### PR TITLE
add option to build wolfcrypt in build-test script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -148,6 +148,10 @@ ctc:
 	$(MAKE) ctaocrypt/test/testctaocrypt; \
 	$(MAKE) ctaocrypt/benchmark/benchmark; 
 
+wolfc:
+	$(MAKE) wolfcrypt/test/testwolfcrypt; \
+	$(MAKE) wolfcrypt/benchmark/benchmark;
+
 install-exec-local:	install-generic-config
 
 install-generic-config:


### PR DESCRIPTION
Added an option in Makefile.am so that the build-test script can build wolfcrypt with the command "wolfc".