### PR TITLE
fix STM32 bug in benchmark.c

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1721,9 +1721,9 @@ void bench_ecc25519KeyAgree(void)
 
     double current_time(int reset)
     {
-        (void) reset;
-
         portTickType tickCount;
+
+        (void) reset;
 
         /* tick count == ms, if configTICK_RATE_HZ is set to 1000 */
         tickCount = xTaskGetTickCount();


### PR DESCRIPTION
Moved portTickType above reset to fix compiler errors when running benchmark app on STM32