### PR TITLE
MSVS warning fixes

### DIFF
--- a/examples/client/client.vcxproj
+++ b/examples/client/client.vcxproj
@@ -91,7 +91,6 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/examples/echoclient/echoclient.vcxproj
+++ b/examples/echoclient/echoclient.vcxproj
@@ -91,7 +91,6 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/examples/echoserver/echoserver.vcxproj
+++ b/examples/echoserver/echoserver.vcxproj
@@ -91,7 +91,6 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/examples/server/server.vcxproj
+++ b/examples/server/server.vcxproj
@@ -91,7 +91,6 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/internal.c
+++ b/src/internal.c
@@ -6768,7 +6768,7 @@ int ProcessReply(WOLFSSL* ssl)
 
                     if (ssl->keys.encryptionOn && ssl->options.handShakeDone) {
                         ssl->buffers.inputBuffer.idx += ssl->keys.padSz;
-                        ssl->curSize -= ssl->buffers.inputBuffer.idx;
+                        ssl->curSize -= (word16) ssl->buffers.inputBuffer.idx;
                     }
 
                     if (ssl->curSize != 1) {
@@ -9800,7 +9800,19 @@ static void PickHashSigAlgo(WOLFSSL* ssl,
         word16 length = 0;
         word32 begin  = *inOutIdx;
         int    ret    = 0;
-        #define ERROR_OUT(err, eLabel) do { ret = err; goto eLabel; } while(0)
+
+#if defined( __MSC_VER) && !defined(MSVS1) && !defined(MSVS2)
+    #define MSVS1 __pragma(warning(push)) __pragma(warning(disable:4127))
+    #define MSVS2 } while(0); __praga(warning(pop))
+#else
+    #define MSVS1 }
+    #define MSVS2 while(0);
+#endif
+        /*
+         * MSVS1 and MSVS2 handle constant type warnings in Visual Studio
+         * designed to capture cases such as while(1==1)
+         */
+        #define ERROR_OUT(err, eLabel) do {ret = err; goto eLabel; MSVS1 MSVS2
 
         (void)length; /* shut up compiler warnings */
         (void)begin;
@@ -11067,10 +11079,16 @@ static void PickHashSigAlgo(WOLFSSL* ssl,
                 #endif /*HAVE_PK_CALLBACKS */
 
                 if (IsAtLeastTLSv1_2(ssl)) {
-                    byte* digest;
-                    int   digestSz;
-                    int   typeH;
-                    int   didSet = 0;
+                    /*
+                     * Initialize values to avoid uninitialized compiler
+                     * warnings. Compiler complains because it can not
+                     * guarantee any of the conditionals will succeed in
+                     * assigning a value before wc_EncodeSignature executes.
+                     */
+                    byte* digest    = 0;
+                    int   digestSz  = 0;
+                    int   typeH     = 0;
+                    int   didSet    = 0;
 
                     if (ssl->suites->hashAlgo == sha_mac) {
                         #ifndef NO_SHA
@@ -11426,7 +11444,24 @@ int DoSessionTicket(WOLFSSL* ssl,
     {
         int ret = 0;
         (void)ssl;
-        #define ERROR_OUT(err, eLabel) do { ret = err; goto eLabel; } while(0)
+
+        /*
+         * Macros MSVS1 and MSVS2 are defined above as follows:
+         *
+         *  MSVS1 __pragma(warning(push)) __pragma(warning(disable:4127))
+         *  MSVS2 } while(0); __praga(warning(pop))
+         *  if building in microsoft visual studio
+         *
+         * or
+         *
+         *  MSVS1 }
+         *  MSVS2 while(0);
+         *  for all other cases
+         *
+         * MSVS1 and MSVS2 handle constant type warnings in Visual Studio
+         * designed to capture cases such as while(1==1)
+         */
+        #define ERROR_OUT(err, eLabel) do {ret = err; goto eLabel; MSVS1 MSVS2
 
     #ifndef NO_PSK
         if (ssl->specs.kea == psk_kea)

--- a/sslSniffer/sslSniffer.vcxproj
+++ b/sslSniffer/sslSniffer.vcxproj
@@ -91,7 +91,6 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/testsuite/testsuite.vcxproj
+++ b/testsuite/testsuite.vcxproj
@@ -91,7 +91,6 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/wolfssl.vcproj
+++ b/wolfssl.vcproj
@@ -49,7 +49,7 @@
 				UsePrecompiledHeader="0"
 				WarningLevel="4"
 				DebugInformationFormat="4"
-				DisableSpecificWarnings="4206"
+				DisableSpecificWarnings="4206,4214,4706,4293"
 			/>
 			<Tool
 				Name="VCManagedResourceCompilerTool"

--- a/wolfssl.vcxproj
+++ b/wolfssl.vcxproj
@@ -85,8 +85,8 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>Level4</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <DisableSpecificWarnings>4206;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DebugInformationFormat></DebugInformationFormat>
+      <DisableSpecificWarnings>4206;4214;4706;4293;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -100,7 +100,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <DisableSpecificWarnings>4206;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4206;4214;4706;4293;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
Removed EditAndContinue. Some versions of MSVS will throw a warning if SAFESEH is defined. SAFESEH will get flagged automatically by MSVS in most cases.

type cast word32 to word 16 in internal.c line 6771

I know we don't like using macros in function definitions but to avoid globally disabling a useful warning this is the only way I could accomplish handling the constant in a while loop warning. If we do not want to do it this way the only other solution will be to globally disable warning 4127 like we did with 4214, 4706, and 4293.

Initialized several variables that MSVS compiler did not like being un-initialized. Since all were assigned their values in conditionals the MSVS compiler could not guarantee any of the conditionals would succeed before the variables were used in function wc_EncodeSignature.

