### PR TITLE
Improved support for PicoTCP on embedded devices

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -83,7 +83,7 @@
         #endif
         #include <fcntl.h>
         #if !(defined(DEVKITPRO) || defined(HAVE_RTP_SYS) || defined(EBSNET)) \
-            || defined(WOLFSSL_PICOTCP)
+            && !(defined(WOLFSSL_PICOTCP))
             #include <sys/socket.h>
             #include <arpa/inet.h>
             #include <netinet/in.h>

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -923,7 +923,7 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL*, void* key, unsigned int len,
         #ifdef __PPU
             #include <sys/types.h>
             #include <sys/socket.h>
-        #elif !defined(WOLFSSL_MDK_ARM) && !defined(WOLFSSL_IAR_ARM)
+        #elif !defined(WOLFSSL_MDK_ARM) && !defined(WOLFSSL_IAR_ARM) && !defined(WOLFSSL_PICOTCP)
             #include <sys/uio.h>
         #endif
         /* allow writev style writing */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -244,10 +244,13 @@
 #endif
 
 #ifdef WOLFSSL_PICOTCP
-    #define errno pico_err
+    #ifndef errno
+        #define errno pico_err
+    #endif
     #include "pico_defines.h"
     #include "pico_stack.h"
     #include "pico_constants.h"
+    #include "pico_protocol.h"
     #define CUSTOM_RAND_GENERATE pico_rand
 #endif
 


### PR DESCRIPTION
PicoTCP is run outside a POSIX operating system scope, so POSIX includes such as 
```
#include <sys/socket.h>
#include <arpa/inet.h>
#include <netinet/in.h>
```
Should not be there.

In some BSP environment though, the errno definition should not be overridden by pico_err.


