### PR TITLE
Fixing bug in wc_ecc_sig_size not handling error code

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2705,7 +2705,7 @@ int wc_ecc_size(ecc_key* key)
 int wc_ecc_sig_size(ecc_key* key)
 {
     int sz = wc_ecc_size(key);
-    if (sz < 0)
+    if (sz <= 0)
         return sz;
 
     return sz * 2 + SIG_HEADER_SZ + 4;  /* (4) worst case estimate */


### PR DESCRIPTION
The check here should be <= 0, since wc_ecc_size() returns 0 when key == NULL. Current code won't detect NULL key.