### PR TITLE
Fix combination of WOLFSSL_VALIDATE_ECC_KEYGEN and ALT_ECC_SIZE

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -1454,6 +1454,10 @@ int fp_cmp(fp_int *a, fp_int *b)
 /* compare against a single digit */
 int fp_cmp_d(fp_int *a, fp_digit b)
 {
+  /* special case for zero*/
+  if (a->used == 0 && b == 0)
+    return FP_EQ;
+
   /* compare based on sign */
   if ((b && a->used == 0) || a->sign == FP_NEG) {
     return FP_LT;
@@ -2102,13 +2106,19 @@ int mp_sub_d(fp_int *a, fp_digit b, fp_int *c)
 
 
 #ifdef ALT_ECC_SIZE
-void fp_copy(fp_int *a, fp_int* b)
+int fp_copy(fp_int *a, fp_int* b)
 {
     if (a != b) {
+        if (b->size < a->used )
+            return FP_VAL;
+
         b->used = a->used;
         b->sign = a->sign;
+
         XMEMCPY(b->dp, a->dp, a->used * sizeof(fp_digit));
     }
+
+    return FP_OKAY;
 }
 
 void fp_init_copy(fp_int *a, fp_int* b)

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -1056,7 +1056,8 @@ static int _fp_exptmod(fp_int * G, fp_int * X, fp_int * P, fp_int * Y)
   } 
 
   /* init M array */
-  XMEMSET(M, 0, sizeof(M)); 
+  for(x = 0; x < sizeof(M)/sizeof(fp_int); x++)
+    fp_init(&M[x]);
 
   /* now setup montgomery  */
   if ((err = fp_montgomery_setup (P, &mp)) != FP_OKAY) {

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -377,7 +377,7 @@ void fp_set(fp_int *a, fp_digit b);
     #define fp_copy(a, b)  (void)(((a) != (b)) ? ((void)XMEMCPY((b), (a), sizeof(fp_int))) : (void)0)
     #define fp_init_copy(a, b) fp_copy(b, a)
 #else
-    void fp_copy(fp_int *a, fp_int *b);
+    int fp_copy(fp_int *a, fp_int *b);
     void fp_init_copy(fp_int *a, fp_int *b);
 #endif
 


### PR DESCRIPTION
Tests were failing when WOLFSSL_VALIDATE_ECC_KEYGEN was paired with ALT_ECC_SIZE. Fixes fp_cmp_d to properly test against zero when the fp_int has no used bytes but might still have junk sitting around in its buffer.

Also adds a prophylactic guard against buffer overflows in fp_copy if anyone ever tried to copy from an fp_int to an alt_fp_int when used > FP_MAXSIZE_ECC.