### PR TITLE
unintialized warning on chacha keySz

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2010,6 +2010,8 @@ int chacha_test(void)
     XMEMSET(cipher, 0, sizeof(cipher));
     XMEMCPY(cipher + 4, ivs[0], 8);
 
+    keySz = 32; /* explicitly state keySz */
+
     ret |= wc_Chacha_SetKey(&enc, keys[0], keySz);
     ret |= wc_Chacha_SetKey(&dec, keys[0], keySz);
     if (ret != 0)


### PR DESCRIPTION
wolfcrypt/test/test.c - error for possible un-initializated keySz in chacha_test().

Error can be replicated in Linux with: "./configure --disable-fastmath"