### PR TITLE
Stunnel base commit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1130,21 +1130,6 @@ fi
 AM_CONDITIONAL([BUILD_SHA], [test "x$ENABLED_SHA" = "xyes"])
 
 
-# MD4 
-AC_ARG_ENABLE([md4],
-    [  --enable-md4            Enable MD4 (default: disabled)],
-    [ ENABLED_MD4=$enableval ],
-    [ ENABLED_MD4=no ]
-    )
-
-if test "$ENABLED_MD4" = "no"
-then
-    AM_CFLAGS="$AM_CFLAGS -DNO_MD4"
-fi
-
-AM_CONDITIONAL([BUILD_MD4], [test "x$ENABLED_MD4" = "xyes"])
-
-
 # Web Server Build 
 AC_ARG_ENABLE([webserver],
     [  --enable-webserver      Enable Web Server (default: disabled)],
@@ -1717,6 +1702,65 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_LIGHTY -DHAVE_WOLFSSL_SSL_H=1"
 fi
 
+# stunnel Support
+AC_ARG_ENABLE([stunnel],
+    [  --enable-stunnel         Enable stunnel (default: disabled)],
+    [ ENABLED_STUNNEL=$enableval ],
+    [ ENABLED_STUNNEL=no ]
+    )
+if test "$ENABLED_STUNNEL" = "yes"
+then
+    # Requires opensslextra make sure on
+    if test "x$ENABLED_OPENSSLEXTRA" = "xno"
+    then
+        ENABLED_OPENSSLEXTRA="yes"
+        AM_CFLAGS="-DOPENSSL_EXTRA $AM_CFLAGS"
+    fi
+
+    # Requires coding make sure on
+    if test "x$ENABLED_CODING" = "xno"
+    then
+        ENABLED_CODING="yes"
+    fi
+
+    # For now, requires no fastmath, turn off if on
+    if test "x$ENABLED_FASTMATH" = "xyes"
+    then
+        ENABLED_FASTMATH = "no"
+    fi
+
+    # Requires sessioncerts make sure on
+    if test "x$ENABLED_SESSIONCERTS" = "xno"
+    then
+        ENABLED_SESSIONCERTS="yes"
+        AM_CFLAGS="$AM_CFLAGS -DSESSION_CERTS"
+    fi
+
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_STUNNEL"
+fi
+
+
+# MD4
+AC_ARG_ENABLE([md4],
+    [  --enable-md4            Enable MD4 (default: disabled)],
+    [ ENABLED_MD4=$enableval ],
+    [ ENABLED_MD4=no ]
+    )
+
+
+if test "$ENABLED_MD4" = "no"
+then
+    #turn on MD4 if using stunnel
+    if test "x$ENABLED_STUNNEL" = "xyes"
+    then
+        ENABLED_MD4="yes"
+    else
+        AM_CFLAGS="$AM_CFLAGS -DNO_MD4"
+    fi
+fi
+
+AM_CONDITIONAL([BUILD_MD4], [test "x$ENABLED_MD4" = "xyes"])
+
 
 # PWDBASED has to come after certservice since we want it on w/o explicit on
 # PWDBASED
@@ -1745,7 +1789,11 @@ FASTMATH_DEFAULT=no
 
 if test "$host_cpu" = "x86_64"
 then
-FASTMATH_DEFAULT=yes
+    # fastmath turned off for stunnel by default
+    if test "x$ENABLED_STUNNEL" = "xno"
+    then
+        FASTMATH_DEFAULT=yes
+    fi
 fi
 
 # fastmath
@@ -2218,6 +2266,7 @@ echo "   * CODING:                    $ENABLED_CODING"
 echo "   * MEMORY:                    $ENABLED_MEMORY"
 echo "   * I/O POOL:                  $ENABLED_IOPOOL"
 echo "   * LIGHTY:                    $ENABLED_LIGHTY"
+echo "   * STUNNEL:                   $ENABLED_STUNNEL"
 echo "   * ERROR_STRINGS:             $ENABLED_ERROR_STRINGS"
 echo "   * DTLS:                      $ENABLED_DTLS"
 echo "   * Old TLS Versions:          $ENABLED_OLD_TLS"

--- a/src/internal.c
+++ b/src/internal.c
@@ -4464,7 +4464,7 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 #else
                 store->current_cert = NULL;
 #endif
-#ifdef FORTRESS
+#if defined(HAVE_FORTRESS) || defined(HAVE_STUNNEL)
                 store->ex_data = ssl;
 #endif
                 ok = ssl->verifyCallback(0, store);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -890,7 +890,7 @@ enum Misc {
 
     MAX_WOLFSSL_FILE_SIZE = 1024 * 1024 * 4,  /* 4 mb file size alloc limit */
 
-#ifdef FORTRESS
+#if defined(FORTRESS) || defined (HAVE_STUNNEL)
     MAX_EX_DATA        =   3,  /* allow for three items of ex_data */
 #endif
 
@@ -1612,8 +1612,11 @@ struct WOLFSSL_CTX {
 #endif /* HAVE_ANON */
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
     pem_password_cb passwd_cb;
-    void*            userdata;
+    void*           userdata;
 #endif /* OPENSSL_EXTRA */
+#ifdef HAVE_STUNNEL
+    void*           ex_data[MAX_EX_DATA];
+#endif
 #ifdef HAVE_OCSP
     WOLFSSL_OCSP      ocsp;
 #endif
@@ -1846,6 +1849,9 @@ struct WOLFSSL_SESSION {
 #ifdef HAVE_SESSION_TICKET
     word16       ticketLen;
     byte         ticket[SESSION_TICKET_LEN];
+#endif
+#ifdef HAVE_STUNNEL
+    void*        ex_data[MAX_EX_DATA];
 #endif
 };
 
@@ -2300,7 +2306,7 @@ struct WOLFSSL {
 #ifdef KEEP_PEER_CERT
     WOLFSSL_X509     peerCert;           /* X509 peer cert */
 #endif
-#ifdef FORTRESS
+#if defined(FORTRESS) || defined(HAVE_STUNNEL)
     void*           ex_data[MAX_EX_DATA]; /* external data, for Fortress */
 #endif
 #ifdef HAVE_CAVIUM

--- a/wolfssl/openssl/asn1.h
+++ b/wolfssl/openssl/asn1.h
@@ -1,2 +1,19 @@
 /* asn1.h for openssl */
 
+#ifndef WOLFSSL_ASN1_H_
+#define WOLFSSL_ASN1_H_
+struct WOLFSSL_ASN1_BIT_STRING {
+    int length;
+    int type;
+    char* data;
+    long flags;
+};
+
+struct WOLFSSL_ASN1_STRING {
+    int length;
+    int type;
+    char* data;
+    long flags;
+};
+
+#endif /* WOLFSSL_ASN1_H_ */

--- a/wolfssl/openssl/crypto.h
+++ b/wolfssl/openssl/crypto.h
@@ -21,6 +21,11 @@ WOLFSSL_API unsigned long wolfSSLeay(void);
 #define SSLEAY_VERSION 0x0090600fL
 #define SSLEAY_VERSION_NUMBER SSLEAY_VERSION
 
+#ifdef HAVE_STUNNEL
+#define CRYPTO_set_mem_ex_functions      wolfSSL_CRYPTO_set_mem_ex_functions
+#define FIPS_mode                        wolfSSL_FIPS_mode
+#define FIPS_mode_set                    wolfSSL_FIPS_mode_set
+#endif /* HAVE_STUNNEL */
 
 #endif /* header */
 

--- a/wolfssl/openssl/dh.h
+++ b/wolfssl/openssl/dh.h
@@ -11,7 +11,7 @@
     extern "C" {
 #endif
 
-typedef struct WOLFSSL_DH {
+struct WOLFSSL_DH {
     WOLFSSL_BIGNUM* p;
     WOLFSSL_BIGNUM* g;
     WOLFSSL_BIGNUM* pub_key;      /* openssh deference g^x */
@@ -23,7 +23,7 @@ typedef struct WOLFSSL_DH {
      * lighttpd src code.
      */
      int length;
-} WOLFSSL_DH;
+};
 
 
 WOLFSSL_API WOLFSSL_DH* wolfSSL_DH_new(void);
@@ -48,4 +48,7 @@ typedef WOLFSSL_DH DH;
     }  /* extern "C" */ 
 #endif
 
+#ifdef HAVE_STUNNEL
+#define DH_generate_parameters wolfSSL_DH_generate_parameters
+#endif /* HAVE_STUNNEL */
 #endif /* header */

--- a/wolfssl/openssl/err.h
+++ b/wolfssl/openssl/err.h
@@ -1,2 +1,3 @@
 /* err.h for openssl */
-
+#define ERR_load_crypto_strings          wolfSSL_ERR_load_crypto_strings
+#define ERR_peek_last_error              wolfSSL_ERR_peek_last_error

--- a/wolfssl/openssl/opensslv.h
+++ b/wolfssl/openssl/opensslv.h
@@ -5,7 +5,13 @@
 
 
 /* api version compatibility */
-#define OPENSSL_VERSION_NUMBER 0x0090810fL
+#ifdef HAVE_STUNNEL
+     #define OPENSSL_VERSION_NUMBER 0x0090700fL
+#else
+     #define OPENSSL_VERSION_NUMBER 0x0090810fL
+#endif
+
+#define OPENSSL_VERSION_TEXT             LIBWOLFSSL_VERSION_STRING 
 
 
 #endif /* header */

--- a/wolfssl/openssl/rand.h
+++ b/wolfssl/openssl/rand.h
@@ -1,4 +1,6 @@
 /* rand.h for openSSL */
 
 #include <wolfssl/openssl/ssl.h>
+#include <wolfssl/wolfcrypt/random.h>
 
+#define RAND_set_rand_method     wolfSSL_RAND_set_rand_method

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -289,7 +289,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 
 #define X509_get_serialNumber wolfSSL_X509_get_serialNumber
 
-#define ASN1_TIME_pr wolfSSL_ASN1_TIME_pr
+#define ASN1_TIME_print wolfSSL_ASN1_TIME_print
 
 #define ASN1_INTEGER_cmp wolfSSL_ASN1_INTEGER_cmp
 #define ASN1_INTEGER_get wolfSSL_ASN1_INTEGER_get
@@ -304,7 +304,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define SSL_CTX_set_default_passwd_cb_userdata wolfSSL_CTX_set_default_passwd_cb_userdata
 #define SSL_CTX_set_default_passwd_cb wolfSSL_CTX_set_default_passwd_cb
 
-#define SSL_CTX_set_timeout wolfSSL_CTX_set_timeout
+#define SSL_CTX_set_timeout(ctx, to) wolfSSL_CTX_set_timeout(ctx, (unsigned int) to)
 #define SSL_CTX_set_info_callback wolfSSL_CTX_set_info_callback
 
 #define ERR_peek_error wolfSSL_ERR_peek_error
@@ -392,7 +392,8 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define SSL_CTX_sess_set_remove_cb wolfSSL_CTX_sess_set_remove_cb
 
 #define i2d_SSL_SESSION wolfSSL_i2d_SSL_SESSION
-#define d2i_SSL_SESSION wolfSSL_d2i_SSL_SESSION
+#define d2i_SSL_SESSION(sess, val, length) \
+        wolfSSL_d2i_SSL_SESSION(sess, (const unsigned char **)val, length)
 #define SSL_SESSION_set_timeout wolfSSL_SSL_SESSION_set_timeout
 #define SSL_SESSION_get_timeout wolfSSL_SESSION_get_timeout
 #define SSL_SESSION_get_time wolfSSL_SESSION_get_time
@@ -432,6 +433,52 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 #define SSL_dup_CA_list wolfSSL_dup_CA_list
 
 #endif
+
+
+#ifdef HAVE_STUNNEL
+#include <wolfssl/openssl/asn1.h>
+
+/* defined as: (SSL_ST_ACCEPT|SSL_CB_LOOP), which becomes 0x2001*/
+#define SSL_CB_ACCEPT_LOOP               0x2001 
+#define SSL2_VERSION                     0x0002
+#define SSL3_VERSION                     0x0300
+#define TLS1_VERSION                     0x0301
+#define DTLS1_VERSION                    0xFEFF
+#define SSL23_ST_SR_CLNT_HELLO_A        (0x210|0x2000)
+#define SSL3_ST_SR_CLNT_HELLO_A         (0x110|0x2000)
+#define ASN1_STRFLGS_ESC_MSB             4
+#define X509_V_ERR_CERT_REJECTED         28
+
+#define BIO_new_file                     wolfSSL_BIO_new_file
+#define PEM_read_bio_DHparams            wolfSSL_PEM_read_bio_DHparams
+#define PEM_write_bio_X509               wolfSSL_PEM_write_bio_X509
+#define SSL_alert_desc_string_long       wolfSSL_alert_desc_string_long
+#define SSL_alert_type_string_long       wolfSSL_alert_type_string_long
+#define SSL_CIPHER_get_bits              wolfSSL_CIPHER_get_bits
+#define sk_X509_NAME_num                 wolfSSL_sk_X509_NAME_num
+#define sk_X509_num                      wolfSSL_sk_X509_num
+#define X509_NAME_print_ex               wolfSSL_X509_NAME_print_ex
+#define X509_get0_pubkey_bitstr          wolfSSL_X509_get0_pubkey_bitstr
+#define SSL_CTX_get_options              wolfSSL_CTX_get_options
+
+#define SSL_CTX_flush_sessions           wolfSSL_flush_sessions
+#define SSL_CTX_add_session              wolfSSL_CTX_add_session
+#define SSL_get_SSL_CTX                  wolfSSL_get_SSL_CTX
+#define SSL_CTX_set_tmp_dh               wolfSSL_CTX_set_tmp_dh
+#define SSL_version                      wolfSSL_version
+#define SSL_get_state                    wolfSSL_get_state
+#define SSL_state_string_long            wolfSSL_state_string_long
+#define SSL_get_peer_cert_chain          wolfSSL_get_peer_cert_chain
+#define sk_X509_NAME_value               wolfSSL_sk_X509_NAME_value
+#define sk_X509_value                    wolfSSL_sk_X509_value
+#define SSL_SESSION_get_ex_data          wolfSSL_SESSION_get_ex_data
+#define SSL_SESSION_set_ex_data          wolfSSL_SESSION_set_ex_data
+#define SSL_SESSION_get_ex_new_index     wolfSSL_SESSION_get_ex_new_index
+#define SSL_SESSION_get_id               wolfSSL_SESSION_get_id
+typedef struct CRYPTO_EX_DATA            CRYPTO_EX_DATA;
+typedef WOLFSSL_ASN1_BIT_STRING    ASN1_BIT_STRING;
+
+#endif /* HAVE_STUNNEL */
 
 #ifdef __cplusplus
     } /* extern "C" */

--- a/wolfssl/wolfcrypt/coding.h
+++ b/wolfssl/wolfcrypt/coding.h
@@ -48,6 +48,9 @@ WOLFSSL_API int Base64_Decode(const byte* in, word32 inLen, byte* out,
     WOLFSSL_API
     int Base64_EncodeEsc(const byte* in, word32 inLen, byte* out,
                                   word32* outLen);
+    WOLFSSL_API
+    int Base64_Encode_NoNl(const byte* in, word32 inLen, byte* out,
+                                  word32* outLen);
 #endif
 
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(HAVE_FIPS)


### PR DESCRIPTION
Base pull request for Stunnel compatibility. Includes the build option --enable-stunnel. 

Commit is mostly separated into HAVE_STUNNEL ifdefs at the end of each file--the only pain point is the "ex_data" functions, which were consolidated at the bottom of the file. Git makes it look like these functions were deleted, but they were just moved to the bottom into an ifdef HAVE_OPENSSL.

Configure options for enable-stunnel are:
    --enable-coding
    --enable-sessioncerts
    --enable-opensslextra
    --enable-md4
    --disable-fastmath (this is temporary until a segfault bug can be fixed)