### PR TITLE
Stunnel cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1730,7 +1730,7 @@ then
     # For now, requires no fastmath, turn off if on
     if test "x$ENABLED_FASTMATH" = "xyes"
     then
-        ENABLED_FASTMATH = "no"
+        ENABLED_FASTMATH="no"
     fi
 
     # Requires sessioncerts make sure on
@@ -1740,6 +1740,13 @@ then
         AM_CFLAGS="$AM_CFLAGS -DSESSION_CERTS"
     fi
 
+    # Requires crls, make sure on
+    if test "x$ENABLED_CRL" = "xno"
+    then
+        ENABLED_CRL="yes"
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_CRL"
+        AM_CONDITIONAL([BUILD_CRL], [test "x$ENABLED_CRL" = "xyes"])
+    fi
     AM_CFLAGS="$AM_CFLAGS -DHAVE_STUNNEL"
 fi
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7109,8 +7109,14 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
     void wolfSSL_set_shutdown(WOLFSSL* ssl, int opt)
     {
-        (void)ssl;
-        (void)opt;
+        WOLFSSL_ENTER("wolfSSL_set_shutdown");
+        if(ssl==NULL) {
+            WOLFSSL_MSG("Shutdown not set. ssl is null");
+            return;
+        }
+
+        ssl->options.sentNotify =  (opt&SSL_SENT_SHUTDOWN) > 0;
+        ssl->options.closeNotify = (opt&SSL_RECEIVED_SHUTDOWN) > 0;
     }
 
 
@@ -9490,9 +9496,14 @@ void wolfSSL_set_connect_state(WOLFSSL* ssl)
 
 int wolfSSL_get_shutdown(const WOLFSSL* ssl)
 {
+    WOLFSSL_ENTER("wolfSSL_get_shutdown");
+#ifdef HAVE_STUNNEL
+    return (ssl->options.sentNotify << 1) | (ssl->options.closeNotify);
+#else
     return (ssl->options.isClosed  ||
             ssl->options.connReset ||
             ssl->options.sentNotify);
+#endif
 }
 
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10274,7 +10274,7 @@ int wolfSSL_X509_STORE_CTX_init(WOLFSSL_X509_STORE_CTX* ctx,
      WOLFSSL_X509_STORE* store, WOLFSSL_X509* x509, STACK_OF(WOLFSSL_X509)* sk)
 {
     (void)sk;
-    WOLFSSL_ENTER(__func__);
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_init");
     if (ctx != NULL) {
         ctx->store = store;
         ctx->current_cert = x509;
@@ -10461,7 +10461,7 @@ long wolfSSL_ASN1_INTEGER_get(const WOLFSSL_ASN1_INTEGER* i)
 
 void* wolfSSL_X509_STORE_CTX_get_ex_data(WOLFSSL_X509_STORE_CTX* ctx, int idx)
 {
-    WOLFSSL_ENTER(__func__);
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_get_ex_data");
 #if defined(FORTRESS) || defined(HAVE_STUNNEL)
     if (ctx != NULL && idx == 0)
         return ctx->ex_data;
@@ -10475,7 +10475,7 @@ void* wolfSSL_X509_STORE_CTX_get_ex_data(WOLFSSL_X509_STORE_CTX* ctx, int idx)
 
 int wolfSSL_get_ex_data_X509_STORE_CTX_idx(void)
 {
-    WOLFSSL_ENTER(__func__);
+    WOLFSSL_ENTER("wolfSSL_get_ex_data_X509_STORE_CTX_idx");
     return 0;
 }
 
@@ -15106,32 +15106,24 @@ void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl)
         return NULL;
     }
 
-    char WOLFSSL_CTX_use_certificate(WOLFSSL_CTX *ctx, WOLFSSL_X509 *x) {
+    char wolfSSL_CTX_use_certificate(WOLFSSL_CTX *ctx, WOLFSSL_X509 *x) {
         (void)ctx;
         (void)x;
-        WOLFSSL_ENTER("WOLFSSL_CTX_use_certificate");
-        WOLFSSL_STUB("WOLFSSL_CTX_use_certificate");
+        WOLFSSL_ENTER("wolfSSL_CTX_use_certificate");
+        WOLFSSL_STUB("wolfSSL_CTX_use_certificate");
 
         return 0;
     }
 
-    int WOLFSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *pkey) {
+    int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *pkey) {
         (void)ctx;
         (void)pkey;
-        WOLFSSL_ENTER("WOLFSSL_CTX_use_PrivateKey");
-        WOLFSSL_STUB("WOLFSSL_CTX_use_PrivateKey");
+        WOLFSSL_ENTER("wolfSSL_CTX_use_PrivateKey");
+        WOLFSSL_STUB("wolfSSL_CTX_use_PrivateKey");
 
         return 0;
     }
 
-    WOLFSSL_BIO *wolfSSL_BIO_new_file(const char *filename, const char *mode) {
-        (void)filename;
-        (void)mode;
-        WOLFSSL_ENTER("wolfSSL_BIO_new_file");
-        WOLFSSL_STUB("wolfSSL_BIO_new_file");
-
-        return NULL;
-    }
 
     int wolfSSL_BIO_read_filename(WOLFSSL_BIO *b, const char *name) {
         (void)b;
@@ -15142,9 +15134,9 @@ void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl)
         return 0;
     }
 
-    WOLFSSL_BIO_METHOD* WOLFSSL_BIO_s_file(void) {
-        WOLFSSL_ENTER("WOLFSSL_BIO_s_file");
-        WOLFSSL_STUB("WOLFSSL_BIO_s_file");
+    WOLFSSL_BIO_METHOD* wolfSSL_BIO_s_file(void) {
+        WOLFSSL_ENTER("wolfSSL_BIO_s_file");
+        WOLFSSL_STUB("wolfSSL_BIO_s_file");
 
         return NULL;
     }
@@ -15173,16 +15165,6 @@ void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl)
         return 0;
     }
 
-    WOLFSSL_DH *PEM_read_bio_DHparams(WOLFSSL_BIO *bp, WOLFSSL_DH **x, pem_password_cb *cb, void *u) {
-        (void)bp;
-        (void)x;
-        (void)cb;
-        (void)u;
-        WOLFSSL_ENTER("PEM_read_bio_DHparams");
-        WOLFSSL_STUB("PEM_read_bio_DHparams");
-
-        return NULL;
-    }
 
     WOLFSSL_X509 *PEM_read_bio_WOLFSSL_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 **x, pem_password_cb *cb, void *u) {
         (void)bp;
@@ -15195,24 +15177,6 @@ void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl)
         return NULL;
     }
 
-    int PEM_write_bio_WOLFSSL_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 *x) {
-        (void)bp;
-        (void)x;
-        WOLFSSL_ENTER("PEM_write_bio_WOLFSSL_X509");
-        WOLFSSL_STUB("PEM_write_bio_WOLFSSL_X509");
-
-        return 0;
-    }
-
-    long WOLFSSL_CTX_set_tmp_dh(WOLFSSL_CTX *ctx, WOLFSSL_DH *dh) {
-        (void)ctx;
-        (void)dh;
-        WOLFSSL_ENTER("WOLFSSL_CTX_set_tmp_dh");
-        WOLFSSL_STUB("WOLFSSL_CTX_set_tmp_dh");
-
-        return 0;
-    }
-
     void wolfSSL_CTX_set_verify_depth(WOLFSSL_CTX *ctx, int depth) {
         (void)ctx;
         (void)depth;
@@ -15221,44 +15185,44 @@ void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl)
 
     }
 
-    void* WOLFSSL_get_app_data( const WOLFSSL *ssl)
+    void* wolfSSL_get_app_data( const WOLFSSL *ssl)
     {
         /* checkout exdata stuff... */
         (void)ssl;
-        WOLFSSL_ENTER("WOLFSSL_get_app_data");
-        WOLFSSL_STUB("WOLFSSL_get_app_data");
+        WOLFSSL_ENTER("wolfSSL_get_app_data");
+        WOLFSSL_STUB("wolfSSL_get_app_data");
 
         return 0;
     }
 
-    void WOLFSSL_set_app_data(WOLFSSL *ssl, void *arg) {
+    void wolfSSL_set_app_data(WOLFSSL *ssl, void *arg) {
         (void)ssl;
         (void)arg;
-        WOLFSSL_ENTER("WOLFSSL_set_app_data");
-        WOLFSSL_STUB("WOLFSSL_set_app_data");
+        WOLFSSL_ENTER("wolfSSL_set_app_data");
+        WOLFSSL_STUB("wolfSSL_set_app_data");
     }
 
-    WOLFSSL_ASN1_OBJECT * WOLFSSL_X509_NAME_ENTRY_get_object(WOLFSSL_X509_NAME_ENTRY *ne) {
+    WOLFSSL_ASN1_OBJECT * wolfSSL_X509_NAME_ENTRY_get_object(WOLFSSL_X509_NAME_ENTRY *ne) {
         (void)ne;
-        WOLFSSL_ENTER("WOLFSSL_X509_NAME_ENTRY_get_object");
-        WOLFSSL_STUB("WOLFSSL_X509_NAME_ENTRY_get_object");
+        WOLFSSL_ENTER("wolfSSL_X509_NAME_ENTRY_get_object");
+        WOLFSSL_STUB("wolfSSL_X509_NAME_ENTRY_get_object");
 
         return NULL;
     }
 
-    WOLFSSL_X509_NAME_ENTRY *WOLFSSL_X509_NAME_get_entry(WOLFSSL_X509_NAME *name, int loc) {
+    WOLFSSL_X509_NAME_ENTRY *wolfSSL_X509_NAME_get_entry(WOLFSSL_X509_NAME *name, int loc) {
         (void)name;
         (void)loc;
-        WOLFSSL_ENTER("WOLFSSL_X509_NAME_get_entry");
-        WOLFSSL_STUB("WOLFSSL_X509_NAME_get_entry");
+        WOLFSSL_ENTER("wolfSSL_X509_NAME_get_entry");
+        WOLFSSL_STUB("wolfSSL_X509_NAME_get_entry");
 
         return NULL;
     }
 
-    void WOLFSSL_X509_NAME_free(WOLFSSL_X509_NAME *name){
+    void wolfSSL_X509_NAME_free(WOLFSSL_X509_NAME *name){
         FreeX509Name(name);
-        WOLFSSL_ENTER("WOLFSSL_X509_NAME_free");
-        WOLFSSL_STUB("WOLFSSL_X509_NAME_free");
+        WOLFSSL_ENTER("wolfSSL_X509_NAME_free");
+        WOLFSSL_STUB("wolfSSL_X509_NAME_free");
     }
 
     void wolfSSL_sk_X509_NAME_pop_free(STACK_OF(WOLFSSL_X509_NAME)* sk, void f (WOLFSSL_X509_NAME*)){
@@ -15292,7 +15256,7 @@ void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl)
 #ifdef OPENSSL_EXTRA
 void* wolfSSL_CTX_get_ex_data(const WOLFSSL_CTX* ctx, int idx)
 {
-    WOLFSSL_ENTER(__func__);
+    WOLFSSL_ENTER("wolfSSL_CTX_get_ex_data");
     #ifdef HAVE_STUNNEL
     if(ctx != NULL && idx < MAX_EX_DATA) {
         return ctx->ex_data[idx];
@@ -15308,7 +15272,7 @@ void* wolfSSL_CTX_get_ex_data(const WOLFSSL_CTX* ctx, int idx)
 int wolfSSL_CTX_get_ex_new_index(long idx, void* arg, void* a, void* b,
                                 void* c)
 {
-    WOLFSSL_ENTER(__func__);
+    WOLFSSL_ENTER("wolfSSL_CTX_get_ex_new_index");
     (void)idx;
     (void)arg;
     (void)a;
@@ -15320,7 +15284,7 @@ int wolfSSL_CTX_get_ex_new_index(long idx, void* arg, void* a, void* b,
 
 int wolfSSL_CTX_set_ex_data(WOLFSSL_CTX* ctx, int idx, void* data)
 {
-    WOLFSSL_ENTER(__func__);
+    WOLFSSL_ENTER("wolfSSL_CTX_set_ex_data");
     #ifdef HAVE_STUNNEL
     if (ctx != NULL && idx < MAX_EX_DATA)
     {
@@ -15338,7 +15302,7 @@ int wolfSSL_CTX_set_ex_data(WOLFSSL_CTX* ctx, int idx, void* data)
 
 int wolfSSL_set_ex_data(WOLFSSL* ssl, int idx, void* data)
 {
-    WOLFSSL_ENTER(__func__);
+    WOLFSSL_ENTER("wolfSSL_set_ex_data");
 #if defined(FORTRESS) || defined(HAVE_STUNNEL)
     if (ssl != NULL && idx < MAX_EX_DATA)
     {
@@ -15357,7 +15321,7 @@ int wolfSSL_set_ex_data(WOLFSSL* ssl, int idx, void* data)
 int wolfSSL_get_ex_new_index(long idx, void* data, void* cb1, void* cb2,
                          void* cb3)
 {
-    WOLFSSL_ENTER(__func__);
+    WOLFSSL_ENTER("wolfSSL_get_ex_new_index");
     (void)idx;
     (void)data;
     (void)cb1;
@@ -15369,7 +15333,7 @@ int wolfSSL_get_ex_new_index(long idx, void* data, void* cb1, void* cb2,
 
 void* wolfSSL_get_ex_data(const WOLFSSL* ssl, int idx)
 {
-    WOLFSSL_ENTER(__func__);
+    WOLFSSL_ENTER("wolfSSL_get_ex_data");
 #if defined(FORTRESS) || defined(HAVE_STUNNEL)
     if (ssl != NULL && idx < MAX_EX_DATA)
         return ssl->ex_data[idx];
@@ -15382,22 +15346,94 @@ void* wolfSSL_get_ex_data(const WOLFSSL* ssl, int idx)
 #endif /* OPENSSL_EXTRA */
 
 
+#if defined(HAVE_LIGHTY) || defined(HAVE_STUNNEL)
+WOLFSSL_BIO *wolfSSL_BIO_new_file(const char *filename, const char *mode) {
+    (void)filename;
+    (void)mode;
+    WOLFSSL_ENTER("wolfSSL_BIO_new_file");
+    WOLFSSL_STUB("wolfSSL_BIO_new_file");
+
+    return NULL;
+}
+
+
+WOLFSSL_DH *wolfSSL_PEM_read_bio_DHparams(WOLFSSL_BIO *bp, WOLFSSL_DH **x, pem_password_cb *cb, void *u)
+{
+    (void) bp;
+    (void) x;
+    (void) cb;
+    (void) u;
+
+    WOLFSSL_ENTER("wolfSSL_PEM_read_bio_DHparams");
+    WOLFSSL_STUB("wolfSSL_PEM_read_bio_DHparams");
+
+    return NULL;
+}
+
+int PEM_write_bio_WOLFSSL_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 *x) {
+    (void)bp;
+    (void)x;
+    WOLFSSL_ENTER("PEM_write_bio_WOLFSSL_X509");
+    WOLFSSL_STUB("PEM_write_bio_WOLFSSL_X509");
+
+    return 0;
+}
+
+
+#ifndef NO_DH
+/* Intialize ctx->dh with dh's params. Return SSL_SUCCESS on ok */
+long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL_DH* dh)
+{
+    int pSz, gSz;
+    byte *p, *g;
+    int ret=0;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_set_tmp_dh");
+
+    if(!ctx || !dh)
+        return BAD_FUNC_ARG;
+
+    /* Get needed size for p and g */
+    pSz = wolfSSL_BN_bn2bin(dh->p, NULL);
+    gSz = wolfSSL_BN_bn2bin(dh->g, NULL);
+
+    if(pSz <= 0 || gSz <= 0)
+        return SSL_FATAL_ERROR;
+
+    p = XMALLOC(pSz, ctx->heap, DYNAMIC_TYPE_DH);
+    if(!p)
+        return MEMORY_E;
+
+    g = XMALLOC(gSz, ctx->heap, DYNAMIC_TYPE_DH);
+    if(!g) {
+        XFREE(p, ctx->heap, DYNAMIC_TYPE_DH);
+        return MEMORY_E;
+    }
+
+    pSz = wolfSSL_BN_bn2bin(dh->p, p);
+    gSz = wolfSSL_BN_bn2bin(dh->g, g);
+
+    if(pSz >= 0 && gSz >= 0) /* Conversion successful */
+        ret = wolfSSL_CTX_SetTmpDH(ctx, p, pSz, g, gSz);
+
+    XFREE(p, ctx->heap, DYNAMIC_TYPE_DH);
+    XFREE(g, ctx->heap, DYNAMIC_TYPE_DH);
+
+    return pSz > 0 && gSz > 0 ? ret : SSL_FATAL_ERROR;
+}
+#endif /* NO_DH */
+#endif /* HAVE_LIGHTY || HAVE_STUNNEL */
+
 
 /* stunnel compatability functions*/
 #if defined(OPENSSL_EXTRA) && defined(HAVE_STUNNEL)
 int wolfSSL_SESSION_set_ex_data(WOLFSSL_SESSION* session, int idx, void* data)
 {
-    WOLFSSL_ENTER(__func__);
-    #ifdef HAVE_STUNNEL
+    WOLFSSL_ENTER("wolfSSL_SESSION_set_ex_data");
     if(session != NULL && idx < MAX_EX_DATA) {
         session->ex_data[idx] = data;
         return SSL_SUCCESS;
     }
-    #else
-    (void)session;
-    (void)idx;
-    (void)data;
-    #endif
     return SSL_FAILURE;
 }
 
@@ -15405,43 +15441,26 @@ int wolfSSL_SESSION_set_ex_data(WOLFSSL_SESSION* session, int idx, void* data)
 int wolfSSL_SESSION_get_ex_new_index(long idx, void* data, void* cb1,
        void* cb2, void* cb3)
 {
-    WOLFSSL_ENTER(__func__);
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_ex_new_index");
     (void)idx;
     (void)cb1;
     (void)cb2;
     (void)cb3;
-    #ifdef HAVE_STUNNEL
     if(XSTRNCMP(data, "redirect index", 14) == 0) {
         return 0;
     }
     else if(XSTRNCMP(data, "addr index", 10) == 0) {
         return 1;
     }
-    #else
-    (void)data;
-    #endif
     return SSL_FAILURE;
 }
 
 
 void* wolfSSL_SESSION_get_ex_data(const WOLFSSL_SESSION* session, int idx)
 {
-    WOLFSSL_ENTER(__func__);
-    #ifdef HAVE_STUNNEL
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_ex_data");
     if (session != NULL && idx < MAX_EX_DATA)
         return session->ex_data[idx];
-    #else
-    (void)session;
-    (void)idx;
-    #endif 
-    return NULL;
-}
-
-
-WOLFSSL_BIO *wolfSSL_BIO_new_file(const char *filename, const char *mode)
-{
-    (void) filename;
-    (void) mode;
     return NULL;
 }
 
@@ -15489,25 +15508,6 @@ int wolfSSL_FIPS_mode_set(int r)
 }
 
 
-WOLFSSL_DH *wolfSSL_PEM_read_bio_DHparams(WOLFSSL_BIO *bp, WOLFSSL_DH **x, pem_password_cb *cb, void *u)
-{
-    (void) bp;
-    (void) x;
-    (void) cb;
-    (void) u;
-
-    return NULL;
-}
-
-
-int wolfSSL_PEM_write_bio_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 *x)
-{
-    (void) bp;
-    (void) x;
-    return SSL_FAILURE;
-}
-
-
 int wolfSSL_RAND_set_rand_method(const void *meth)
 {
     (void) meth;
@@ -15517,13 +15517,14 @@ int wolfSSL_RAND_set_rand_method(const void *meth)
 
 int wolfSSL_CIPHER_get_bits(const WOLFSSL_CIPHER *c, int *alg_bits)
 {
+    int ret = SSL_FAILURE;
     if(c != NULL && c->ssl != NULL) {
+        ret = 8 * c->ssl->specs.key_size;
         if(alg_bits != NULL) {
-            *alg_bits = 8 * c->ssl->specs.key_size;
+            *alg_bits = ret;
         }
-        return 8 * c->ssl->specs.key_size;
     }
-    return SSL_FAILURE;
+    return ret;
 }
 
 
@@ -15643,47 +15644,13 @@ int wolfSSL_X509_NAME_get_sz(WOLFSSL_X509_NAME* name)
     return name->sz;
 }
 
-#ifndef NO_DH
-/* Intialize ctx->dh with dh's params. Return SSL_SUCCESS on ok */
-long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL_DH* dh)
-{
-    int pSz, gSz;
-    byte *p, *g;
-    int ret=0;
-
-    pSz = wolfSSL_BN_bn2bin(dh->p, NULL);
-    gSz = wolfSSL_BN_bn2bin(dh->g, NULL);
-
-    p = XMALLOC(pSz, ctx->heap, DYNAMIC_TYPE_DH);
-    if(!p)
-        return MEMORY_E;
-
-    g = XMALLOC(gSz, ctx->heap, DYNAMIC_TYPE_DH);
-    if(!g) {
-        XFREE(p, ctx->heap, DYNAMIC_TYPE_DH);
-        return MEMORY_E;
-    }
-
-    pSz = wolfSSL_BN_bn2bin(dh->p, p);
-    gSz = wolfSSL_BN_bn2bin(dh->g, g);
-
-    if(pSz != SSL_FATAL_ERROR && gSz != SSL_FATAL_ERROR)
-        ret = wolfSSL_CTX_SetTmpDH(ctx, p, pSz, g, gSz);
-
-    if(p)
-        XFREE(p, ctx->heap, DYNAMIC_TYPE_DH);
-    if(g)
-        XFREE(g, ctx->heap, DYNAMIC_TYPE_DH);
-
-    return pSz > 0 && gSz > 0 ? SSL_FATAL_ERROR : ret;
-}
-#endif /* NO_DH */
-
 
 const byte* wolfSSL_SESSION_get_id(WOLFSSL_SESSION* sess, unsigned int* idLen)
 {
-    if(!sess)
+    if(!sess || !idLen) {
+        WOLFSSL_MSG("Bad func args. Please provide idLen");
         return NULL;
+    }
     *idLen = sess->sessionIDSz;
     return sess->sessionID;
 }

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -167,7 +167,7 @@ static int CEscape(int escaped, byte e, byte* out, word32* i, word32 max,
         basic = base64Encode[e];
 
     /* check whether to escape. Only escape for EncodeEsc */
-    if (escaped == 1) {
+    if (escaped == ESC_NL_ENC) {
         switch ((char)basic) {
             case '+' :
                 plus     = 1;
@@ -235,9 +235,9 @@ static int DoBase64_Encode(const byte* in, word32 inLen, byte* out,
     word32 outSz = (inLen + 3 - 1) / 3 * 4;
     word32 addSz = (outSz + PEM_LINE_SZ - 1) / PEM_LINE_SZ;  /* new lines */
 
-    if (escaped == 1)
+    if (escaped == ESC_NL_ENC)
         addSz *= 3;   /* instead of just \n, we're doing %0A triplet */
-    else if (escaped == 2)
+    else if (escaped == NO_NL_ENC)
         addSz = 0;    /* encode without \n */
 
     outSz += addSz;
@@ -270,7 +270,7 @@ static int DoBase64_Encode(const byte* in, word32 inLen, byte* out,
         inLen -= 3;
 
         /* Insert newline after PEM_LINE_SZ, unless no \n requested */
-        if (escaped != 2 && (++n % (PEM_LINE_SZ / 4)) == 0 && inLen) {
+        if (escaped != NO_NL_ENC && (++n % (PEM_LINE_SZ / 4)) == 0 && inLen) {
             ret = CEscape(escaped, '\n', out, &i, *outLen, 1);
             if (ret != 0) break;
         }
@@ -302,7 +302,7 @@ static int DoBase64_Encode(const byte* in, word32 inLen, byte* out,
             ret = CEscape(escaped, '=', out, &i, *outLen, 1);
     } 
 
-    if (ret == 0 && escaped != 2) 
+    if (ret == 0 && escaped != NO_NL_ENC) 
         ret = CEscape(escaped, '\n', out, &i, *outLen, 1);
 
     if (i != outSz && escaped != 1 && ret == 0)
@@ -316,19 +316,19 @@ static int DoBase64_Encode(const byte* in, word32 inLen, byte* out,
 /* Base64 Encode, PEM style, with \n line endings */
 int Base64_Encode(const byte* in, word32 inLen, byte* out, word32* outLen)
 {
-    return DoBase64_Encode(in, inLen, out, outLen, 0);
+    return DoBase64_Encode(in, inLen, out, outLen, STD_ENC);
 }
 
 
 /* Base64 Encode, with %0A esacped line endings instead of \n */
 int Base64_EncodeEsc(const byte* in, word32 inLen, byte* out, word32* outLen)
 {
-    return DoBase64_Encode(in, inLen, out, outLen, 1);
+    return DoBase64_Encode(in, inLen, out, outLen, ESC_NL_ENC);
 }
 
 int Base64_Encode_NoNl(const byte* in, word32 inLen, byte* out, word32* outLen)
 {
-    return DoBase64_Encode(in, inLen, out, outLen, 2);
+    return DoBase64_Encode(in, inLen, out, outLen, NO_NL_ENC);
 }
 
 #endif  /* defined(WOLFSSL_BASE64_ENCODE) */

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -408,25 +408,21 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 
 #define SSL_CB_HANDSHAKE_START          0x10
-#define X509_NAME_free WOLFSSL_X509_NAME_free
-#define SSL_CTX_use_certificate WOLFSSL_CTX_use_certificate
-#define SSL_CTX_use_PrivateKey WOLFSSL_CTX_use_PrivateKey
-#define BIO_new_file wolfSSL_BIO_new_file
+#define X509_NAME_free wolfSSL_X509_NAME_free
+#define SSL_CTX_use_certificate wolfSSL_CTX_use_certificate
+#define SSL_CTX_use_PrivateKey wolfSSL_CTX_use_PrivateKey
 #define BIO_read_filename wolfSSL_BIO_read_filename
-#define BIO_s_file WOLFSSL_BIO_s_file
+#define BIO_s_file wolfSSL_BIO_s_file
 #define OBJ_nid2sn wolf_OBJ_nid2sn
 #define OBJ_obj2nid wolf_OBJ_obj2nid
 #define OBJ_sn2nid wolf_OBJ_sn2nid
-#define PEM_read_bio_DHparams PEM_read_bio_DHparams
 #define PEM_read_bio_X509 PEM_read_bio_WOLFSSL_X509
-#define PEM_write_bio_X509 PEM_write_bio_WOLFSSL_X509
-#define SSL_CTX_set_tmp_dh WOLFSSL_CTX_set_tmp_dh
 #define SSL_CTX_set_verify_depth wolfSSL_CTX_set_verify_depth
-#define SSL_get_app_data WOLFSSL_get_app_data
-#define SSL_set_app_data WOLFSSL_set_app_data
+#define SSL_get_app_data wolfSSL_get_app_data
+#define SSL_set_app_data wolfSSL_set_app_data
 #define X509_NAME_entry_count wolfSSL_X509_NAME_entry_count
-#define X509_NAME_ENTRY_get_object WOLFSSL_X509_NAME_ENTRY_get_object
-#define X509_NAME_get_entry WOLFSSL_X509_NAME_get_entry
+#define X509_NAME_ENTRY_get_object wolfSSL_X509_NAME_ENTRY_get_object
+#define X509_NAME_get_entry wolfSSL_X509_NAME_get_entry
 #define sk_X509_NAME_pop_free  wolfSSL_sk_X509_NAME_pop_free
 #define SHA1 wolfSSL_SHA1
 #define X509_check_private_key wolfSSL_X509_check_private_key
@@ -434,6 +430,15 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 
 #endif
 
+#if defined(HAVE_STUNNEL) || defined(HAVE_LIGHTY)
+
+#define PEM_read_bio_DHparams wolfSSL_PEM_read_bio_DHparams
+#define PEM_write_bio_X509 PEM_write_bio_WOLFSSL_X509
+#define SSL_CTX_set_tmp_dh wolfSSL_CTX_set_tmp_dh
+#define BIO_new_file wolfSSL_BIO_new_file
+
+
+#endif /* HAVE_STUNNEL || HAVE_LIGHTY */
 
 #ifdef HAVE_STUNNEL
 #include <wolfssl/openssl/asn1.h>
@@ -449,9 +454,6 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 #define ASN1_STRFLGS_ESC_MSB             4
 #define X509_V_ERR_CERT_REJECTED         28
 
-#define BIO_new_file                     wolfSSL_BIO_new_file
-#define PEM_read_bio_DHparams            wolfSSL_PEM_read_bio_DHparams
-#define PEM_write_bio_X509               wolfSSL_PEM_write_bio_X509
 #define SSL_alert_desc_string_long       wolfSSL_alert_desc_string_long
 #define SSL_alert_type_string_long       wolfSSL_alert_type_string_long
 #define SSL_CIPHER_get_bits              wolfSSL_CIPHER_get_bits
@@ -464,7 +466,6 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 #define SSL_CTX_flush_sessions           wolfSSL_flush_sessions
 #define SSL_CTX_add_session              wolfSSL_CTX_add_session
 #define SSL_get_SSL_CTX                  wolfSSL_get_SSL_CTX
-#define SSL_CTX_set_tmp_dh               wolfSSL_CTX_set_tmp_dh
 #define SSL_version                      wolfSSL_version
 #define SSL_get_state                    wolfSSL_get_state
 #define SSL_state_string_long            wolfSSL_state_string_long

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1513,26 +1513,23 @@ typedef struct WOLFSSL_X509_NAME_ENTRY {
 
 
 #include <wolfssl/openssl/dh.h>
+#include <wolfssl/openssl/asn1.h>
 
-WOLFSSL_API void WOLFSSL_X509_NAME_free(WOLFSSL_X509_NAME *name);
-WOLFSSL_API char WOLFSSL_CTX_use_certificate(WOLFSSL_CTX *ctx, WOLFSSL_X509 *x);
-WOLFSSL_API int WOLFSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *pkey);
-WOLFSSL_API WOLFSSL_BIO* wolfSSL_BIO_new_file(const char *filename, const char *mode);
+WOLFSSL_API void wolfSSL_X509_NAME_free(WOLFSSL_X509_NAME *name);
+WOLFSSL_API char wolfSSL_CTX_use_certificate(WOLFSSL_CTX *ctx, WOLFSSL_X509 *x);
+WOLFSSL_API int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *pkey);
 WOLFSSL_API int wolfSSL_BIO_read_filename(WOLFSSL_BIO *b, const char *name);
-WOLFSSL_API WOLFSSL_BIO_METHOD* WOLFSSL_BIO_s_file(void);
+WOLFSSL_API WOLFSSL_BIO_METHOD* wolfSSL_BIO_s_file(void);
 /* These are to be merged shortly */
 WOLFSSL_API const char *  wolf_OBJ_nid2sn(int n);
 WOLFSSL_API int wolf_OBJ_obj2nid(const WOLFSSL_ASN1_OBJECT *o);
 WOLFSSL_API int wolf_OBJ_sn2nid(const char *sn);
-WOLFSSL_API WOLFSSL_DH *PEM_read_bio_DHparams(WOLFSSL_BIO *bp, WOLFSSL_DH **x, pem_password_cb *cb, void *u);
 WOLFSSL_API WOLFSSL_X509 *PEM_read_bio_WOLFSSL_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 **x, pem_password_cb *cb, void *u);
-WOLFSSL_API int PEM_write_bio_WOLFSSL_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 *x);
-WOLFSSL_API long WOLFSSL_CTX_set_tmp_dh(WOLFSSL_CTX *ctx, WOLFSSL_DH *dh);
 WOLFSSL_API void wolfSSL_CTX_set_verify_depth(WOLFSSL_CTX *ctx,int depth);
-WOLFSSL_API void* WOLFSSL_get_app_data( const WOLFSSL *ssl);
-WOLFSSL_API void WOLFSSL_set_app_data(WOLFSSL *ssl, void *arg);
-WOLFSSL_API WOLFSSL_ASN1_OBJECT * WOLFSSL_X509_NAME_ENTRY_get_object(WOLFSSL_X509_NAME_ENTRY *ne);
-WOLFSSL_API WOLFSSL_X509_NAME_ENTRY *WOLFSSL_X509_NAME_get_entry(WOLFSSL_X509_NAME *name, int loc);
+WOLFSSL_API void* wolfSSL_get_app_data( const WOLFSSL *ssl);
+WOLFSSL_API void wolfSSL_set_app_data(WOLFSSL *ssl, void *arg);
+WOLFSSL_API WOLFSSL_ASN1_OBJECT * wolfSSL_X509_NAME_ENTRY_get_object(WOLFSSL_X509_NAME_ENTRY *ne);
+WOLFSSL_API WOLFSSL_X509_NAME_ENTRY *wolfSSL_X509_NAME_get_entry(WOLFSSL_X509_NAME *name, int loc);
 WOLFSSL_API void wolfSSL_sk_X509_NAME_pop_free(STACK_OF(WOLFSSL_X509_NAME)* sk, void f (WOLFSSL_X509_NAME*));
 WOLFSSL_API unsigned char *wolfSSL_SHA1(const unsigned char *d, size_t n, unsigned char *md);
 WOLFSSL_API int wolfSSL_X509_check_private_key(WOLFSSL_X509*, WOLFSSL_EVP_PKEY*);
@@ -1542,12 +1539,22 @@ WOLFSSL_API STACK_OF(WOLFSSL_X509_NAME) *wolfSSL_dup_CA_list( STACK_OF(WOLFSSL_X
 #endif
 #endif
 
+#if defined(HAVE_STUNNEL) || defined(HAVE_LIGHTY)
+
+WOLFSSL_API WOLFSSL_BIO* wolfSSL_BIO_new_file(const char *filename, const char *mode);
+WOLFSSL_API long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX*, WOLFSSL_DH*);
+WOLFSSL_API WOLFSSL_DH *wolfSSL_PEM_read_bio_DHparams(WOLFSSL_BIO *bp,
+    WOLFSSL_DH **x, pem_password_cb *cb, void *u);
+WOLFSSL_API int PEM_write_bio_WOLFSSL_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 *x);
+
+
+#endif /* HAVE_STUNNEL || HAVE_LIGHTY */
+
 
 #ifdef HAVE_STUNNEL
 
-WOLFSSL_API WOLFSSL_BIO *wolfSSL_BIO_new_file(const char *filename, const char *mode);
 
-WOLFSSL_API int wolfSSL_CRYPTO_set_mem_ex_functions(void *(*m) (size_t, const char *, int), 
+WOLFSSL_API int wolfSSL_CRYPTO_set_mem_ex_functions(void *(*m) (size_t, const char *, int),
     void *(*r) (void *, size_t, const char *, int), void (*f) (void *));
 
 WOLFSSL_API WOLFSSL_DH *wolfSSL_DH_generate_parameters(int prime_len, int generator,
@@ -1560,11 +1567,6 @@ WOLFSSL_API unsigned long wolfSSL_ERR_peek_last_error(void);
 WOLFSSL_API int wolfSSL_FIPS_mode(void);
 
 WOLFSSL_API int wolfSSL_FIPS_mode_set(int r);
-
-WOLFSSL_API WOLFSSL_DH *wolfSSL_PEM_read_bio_DHparams(WOLFSSL_BIO *bp, 
-    WOLFSSL_DH **x, pem_password_cb *cb, void *u);
-
-WOLFSSL_API int wolfSSL_PEM_write_bio_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 *x);
 
 WOLFSSL_API int wolfSSL_RAND_set_rand_method(const void *meth);
 
@@ -1603,7 +1605,6 @@ WOLFSSL_API int wolfSSL_SESSION_get_ex_new_index(long,void*,void*,void*,void*);
 
 WOLFSSL_API int wolfSSL_X509_NAME_get_sz(WOLFSSL_X509_NAME*);
 
-WOLFSSL_API long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX*, WOLFSSL_DH*);
 
 WOLFSSL_API const unsigned char* wolfSSL_SESSION_get_id(WOLFSSL_SESSION*, unsigned int*);
 #endif /* HAVE_STUNNEL */

--- a/wolfssl/wolfcrypt/coding.h
+++ b/wolfssl/wolfcrypt/coding.h
@@ -41,6 +41,12 @@ WOLFSSL_API int Base64_Decode(const byte* in, word32 inLen, byte* out,
 
 
 #ifdef WOLFSSL_BASE64_ENCODE
+    enum Escaped {
+        STD_ENC= 0,
+        ESC_NL_ENC,
+        NO_NL_ENC
+    }; /* Encoding types */
+
     /* encode isn't */
     WOLFSSL_API
     int Base64_Encode(const byte* in, word32 inLen, byte* out,


### PR DESCRIPTION
1st commit cleans up some code used with Stunnel.
It also consolidates openSSL extra functions used by both lighttpd and stunnel into a single section. 
It also replaces the __func__ notation with a more portable string in logging functions.
Finally, it modifies configure.ac so that stunnel has --enable-crls.

The second commit fills in an openSSL extra hole with functionality to help stunnel shut down gracefully. 
