### PR TITLE
Use ntru functions from stable libntruencrypt api

### DIFF
--- a/IDE/MDK5-ARM/Projects/CryptBenchmark/benchmark.c
+++ b/IDE/MDK5-ARM/Projects/CryptBenchmark/benchmark.c
@@ -52,7 +52,7 @@
     #include "cavium_ioctl.h"
 #endif
 #ifdef HAVE_NTRU
-    #include "ntru_crypto.h"
+    #include "libntruencrypt/ntru_crypto.h"
 #endif
 
 #if defined(CYASSL_MDK_ARM)

--- a/IDE/MDK5-ARM/Projects/CryptTest/test.c
+++ b/IDE/MDK5-ARM/Projects/CryptTest/test.c
@@ -101,7 +101,7 @@
 #endif
 
 #ifdef HAVE_NTRU
-    #include "ntru_crypto.h"
+    #include "libntruencrypt/ntru_crypto.h"
 #endif
 #ifdef HAVE_CAVIUM
     #include "cavium_sysdep.h"

--- a/configure.ac
+++ b/configure.ac
@@ -1397,9 +1397,9 @@ AC_ARG_WITH([ntru],
     [
         AC_MSG_CHECKING([for NTRU])
         CPPFLAGS="$CPPFLAGS -DHAVE_NTRU -DHAVE_QSH -DHAVE_TLS_EXTENSIONS"
-        LIBS="$LIBS -lNTRUEncrypt"
+        LIBS="$LIBS -lntruencrypt"
 
-        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <ntru_crypto_drbg.h>]], [[ ntru_crypto_drbg_instantiate(0, 0, 0, 0, 0); ]])], [ ntru_linked=yes ],[ ntru_linked=no ])
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <libntruencrypt/ntru_crypto_drbg.h>]], [[ ntru_crypto_drbg_instantiate(0, 0, 0, 0, 0); ]])], [ ntru_linked=yes ],[ ntru_linked=no ])
 
         if test "x$ntru_linked" == "xno" ; then
             if test "x$withval" != "xno" ; then
@@ -1412,7 +1412,7 @@ AC_ARG_WITH([ntru],
             LDFLAGS="$AM_LDFLAGS -L$tryntrudir/lib"
             CPPFLAGS="$CPPFLAGS -I$tryntrudir/include"
 
-            AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <ntru_crypto_drbg.h>]], [[ ntru_crypto_drbg_instantiate(0, 0, 0, 0, 0); ]])], [ ntru_linked=yes ],[ ntru_linked=no ])
+            AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <libntruencrypt/ntru_crypto_drbg.h>]], [[ ntru_crypto_drbg_instantiate(0, 0, 0, 0, 0); ]])], [ ntru_linked=yes ],[ ntru_linked=no ])
 
             if test "x$ntru_linked" == "xno" ; then
                 AC_MSG_ERROR([NTRU isn't found.

--- a/src/internal.c
+++ b/src/internal.c
@@ -41,7 +41,7 @@
 #endif
 
 #ifdef HAVE_NTRU
-    #include "ntru_crypto.h"
+    #include "libntruencrypt/ntru_crypto.h"
 #endif
 
 #if defined(DEBUG_WOLFSSL) || defined(SHOW_SECRETS) || defined(CHACHA_AEAD_TEST)
@@ -247,7 +247,7 @@ static int QSH_FreeAll(WOLFSSL* ssl)
 static RNG* rng;
 static wolfSSL_Mutex* rngMutex;
 
-static word32 GetEntropy(unsigned char* out, unsigned long long num_bytes)
+static word32 GetEntropy(unsigned char* out, word32 num_bytes)
 {
     int ret = 0;
 
@@ -265,7 +265,7 @@ static word32 GetEntropy(unsigned char* out, unsigned long long num_bytes)
     }
 
     ret |= LockMutex(rngMutex);
-    ret |= wc_RNG_GenerateBlock(rng, out, (word32)num_bytes);
+    ret |= wc_RNG_GenerateBlock(rng, out, num_bytes);
     ret |= UnLockMutex(rngMutex);
 
     if (ret != 0)
@@ -10623,7 +10623,7 @@ static int NtruSecretEncrypt(QSHKey* key, byte* bufIn, word32 inSz,
     }
 
     /* set up ntru drbg */
-    ret = ntru_crypto_external_drbg_instantiate(GetEntropy, &drbg);
+    ret = ntru_crypto_drbg_external_instantiate(GetEntropy, &drbg);
     if (ret != DRBG_OK)
         return NTRU_DRBG_ERROR;
 
@@ -10670,7 +10670,7 @@ static int NtruSecretDecrypt(QSHKey* key, byte* bufIn, word32 inSz,
 
 
     /* set up drbg */
-    ret = ntru_crypto_external_drbg_instantiate(GetEntropy, &drbg);
+    ret = ntru_crypto_drbg_external_instantiate(GetEntropy, &drbg);
     if (ret != DRBG_OK)
         return NTRU_DRBG_ERROR;
 
@@ -10805,7 +10805,7 @@ static word32 QSH_MaxSecret(QSHKey* key)
     }
 
     if (isNtru) {
-        ret = ntru_crypto_external_drbg_instantiate(GetEntropy, &drbg);
+        ret = ntru_crypto_drbg_external_instantiate(GetEntropy, &drbg);
         if (ret != DRBG_OK)
             return NTRU_DRBG_ERROR;
         ret = ntru_crypto_ntru_encrypt(drbg, key->pub.length,
@@ -11251,7 +11251,7 @@ static word32 QSH_KeyExchangeWrite(WOLFSSL* ssl, byte isServer)
                         return NO_PEER_KEY;
                     }
 
-                    rc = ntru_crypto_external_drbg_instantiate(GetEntropy, &drbg);
+                    rc = ntru_crypto_drbg_external_instantiate(GetEntropy, &drbg);
                     if (rc != DRBG_OK) {
                     #ifdef WOLFSSL_SMALL_STACK
                         XFREE(encSecret, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/src/tls.c
+++ b/src/tls.c
@@ -37,7 +37,7 @@
 #endif
 
 #ifdef HAVE_NTRU
-    #include "ntru_crypto.h"
+    #include "libntruencrypt/ntru_crypto.h"
     #include <wolfssl/wolfcrypt/random.h>
 #endif
 #ifdef HAVE_QSH
@@ -2836,7 +2836,7 @@ static word16 TLSX_Write(TLSX* list, byte* output, byte* semaphore,
 
 #ifdef HAVE_NTRU
 
-static word32 GetEntropy(unsigned char* out, unsigned long long num_bytes)
+static word32 GetEntropy(unsigned char* out, word32 num_bytes)
 {
     int ret = 0;
 
@@ -2854,7 +2854,7 @@ static word32 GetEntropy(unsigned char* out, unsigned long long num_bytes)
     }
 
     ret |= LockMutex(rngMutex);
-    ret |= wc_RNG_GenerateBlock(rng, out, (word32)num_bytes);
+    ret |= wc_RNG_GenerateBlock(rng, out, num_bytes);
     ret |= UnLockMutex(rngMutex);
 
     if (ret != 0)
@@ -2947,7 +2947,7 @@ int TLSX_CreateNtruKey(WOLFSSL* ssl, int type)
             WOLFSSL_MSG("Unknown type for creating NTRU key");
             return -1;
     }
-    ret = ntru_crypto_external_drbg_instantiate(GetEntropy, &drbg);
+    ret = ntru_crypto_drbg_external_instantiate(GetEntropy, &drbg);
     if (ret != DRBG_OK) {
         WOLFSSL_MSG("NTRU drbg instantiate failed\n");
         return ret;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -71,7 +71,7 @@
     #include "cavium_ioctl.h"
 #endif
 #ifdef HAVE_NTRU
-    #include "ntru_crypto.h"
+    #include "libntruencrypt/ntru_crypto.h"
 #endif
 
 #if defined(WOLFSSL_MDK_ARM)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -49,7 +49,7 @@
 #endif
 
 #ifdef HAVE_NTRU
-    #include "ntru_crypto.h"
+    #include "libntruencrypt/ntru_crypto.h"
 #endif
 
 #if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -115,7 +115,7 @@
 #endif
 
 #ifdef HAVE_NTRU
-    #include "ntru_crypto.h"
+    #include "libntruencrypt/ntru_crypto.h"
 #endif
 #ifdef HAVE_CAVIUM
     #include "cavium_sysdep.h"


### PR DESCRIPTION
ntru_crypto_external_drbg_instantiate has been renamed
to ntru_crypto_drbg_external_instantiate in the 1.0.0
release of libntruencrypt. Made various other small changes
to build against libntruencrypt.