### PR TITLE
fix disable filesystem errors

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11613,6 +11613,7 @@ char *wolfSSL_BN_bn2hex(const WOLFSSL_BIGNUM *bn)
     return buf;
 }
 
+#ifndef NO_FILESYSTEM
 /* return code compliant with OpenSSL :
  *   1 if success, 0 if error
  */
@@ -11638,6 +11639,7 @@ int wolfSSL_BN_print_fp(FILE *fp, const WOLFSSL_BIGNUM *bn)
 
     return SSL_SUCCESS;
 }
+#endif /* !defined(NO_FILESYSTEM) */
 
 #else /* defined(HAVE_ECC) */
 
@@ -11650,6 +11652,7 @@ char *wolfSSL_BN_bn2hex(const WOLFSSL_BIGNUM *bn)
     return (char*)"";
 }
 
+#ifndef NO_FILESYSTEM
 /* return code compliant with OpenSSL :
  *   1 if success, 0 if error
  */
@@ -11662,6 +11665,8 @@ int wolfSSL_BN_print_fp(FILE *fp, const WOLFSSL_BIGNUM *bn)
 
     return SSL_SUCCESS;
 }
+#endif /* !defined(NO_FILESYSTEM) */
+
 #endif /*(defined(WOLFSSL_KEY_GEN)||defined(HAVE_COMP_KEY))&&defined(HAVE_ECC)*/
 
 WOLFSSL_BIGNUM *wolfSSL_BN_CTX_get(WOLFSSL_BN_CTX *ctx)

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -77,7 +77,9 @@ WOLFSSL_API int wolfSSL_BN_is_prime_ex(const WOLFSSL_BIGNUM*, int,
                                        WOLFSSL_BN_CTX*, WOLFSSL_BN_GENCB*);
 WOLFSSL_API WOLFSSL_BN_ULONG wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM*,
                                                  WOLFSSL_BN_ULONG);
-WOLFSSL_API int wolfSSL_BN_print_fp(FILE*, const WOLFSSL_BIGNUM*);
+#ifndef NO_FILESYSTEM
+    WOLFSSL_API int wolfSSL_BN_print_fp(FILE*, const WOLFSSL_BIGNUM*);
+#endif
 WOLFSSL_API int wolfSSL_BN_rshift(WOLFSSL_BIGNUM*, const WOLFSSL_BIGNUM*, int);
 WOLFSSL_API WOLFSSL_BIGNUM *wolfSSL_BN_CTX_get(WOLFSSL_BN_CTX *ctx);
 WOLFSSL_API void wolfSSL_BN_CTX_start(WOLFSSL_BN_CTX *ctx);


### PR DESCRIPTION
Configuration failures with --disable-filesystem due to wolfSSL_BN_print_fp() in wolfssl/openssl/bn.h including FILE without #ifndef NO_FILESYSTEM defined. Example configurations that will replicate failure(there are at least 21 failures according to Jenkins output):

./configure --disable-aes --disable-aesgcm --disable-filesystem
./configure --disable-dh --disable-filesystem