### PR TITLE
Ecc_encrypt + hkdf requires aes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1000,6 +1000,10 @@ AC_ARG_ENABLE([aes],
 if test "$ENABLED_AES" = "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DNO_AES"
+    if test "$ENABLED_ECC_ENCRYPT" = "yes"
+    then
+        AC_MSG_ERROR([cannot enable eccencrypt and hkdf without aes.])
+    fi
     if test "$ENABLED_AESGCM" = "yes"
     then
         AC_MSG_ERROR([AESGCM requires AES.])


### PR DESCRIPTION
Offending configuration reported by jenkins:

./configure --disable-aes --disable-aesgcm --enable-eccencrypt --enable-ecc --enable-hkdf