### PR TITLE
add proper definitions for wolfSSL_CTX_SetMinDhKey_Sz

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -592,7 +592,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     if (fewerPackets)
         wolfSSL_CTX_set_group_messages(ctx);
 
-#ifndef NO_DH
+#if !defined(NO_DH) && !defined(NO_CERTS) && !defined(NO_FILESYSTEM)
     wolfSSL_CTX_SetMinDhKey_Sz(ctx, (word16)minDhKeyBits);
 #endif
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -474,10 +474,10 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
             err_sys("can't load server cert file, check file and run from"
                     " wolfSSL home dir");
     }
-#endif
 
-#ifndef NO_DH
-    wolfSSL_CTX_SetMinDhKey_Sz(ctx, (word16)minDhKeyBits);
+    #ifndef NO_DH
+        wolfSSL_CTX_SetMinDhKey_Sz(ctx, (word16)minDhKeyBits);
+    #endif
 #endif
 
 #ifdef HAVE_NTRU


### PR DESCRIPTION
Configuration failures due to improper ifdefs surrounding wolfSSL_CTX_SetMinDhKey_Sz() - not finding function definition in src/ssl.c due to it being wrapped in !defined(NO_CERTS) in ssl.c and not in client.c/server.c. Caught additional !defined(NO_FILESYSTEM) as well. 

Example configurations to replicate error:

--enable-psk --disable-asn --disable-ecc --disable-rsa
 