### PR TITLE
Changes to remove last warnings from Stunnel

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15449,7 +15449,7 @@ int wolfSSL_SESSION_set_ex_data(WOLFSSL_SESSION* session, int idx, void* data)
 
 
 int wolfSSL_SESSION_get_ex_new_index(long idx, void* data, void* cb1,
-       void* cb2, void* cb3)
+       void* cb2, CRYPTO_free_func* cb3)
 {
     WOLFSSL_ENTER("wolfSSL_SESSION_get_ex_new_index");
     (void)idx;

--- a/wolfssl/openssl/crypto.h
+++ b/wolfssl/openssl/crypto.h
@@ -25,6 +25,9 @@ WOLFSSL_API unsigned long wolfSSLeay(void);
 #define CRYPTO_set_mem_ex_functions      wolfSSL_CRYPTO_set_mem_ex_functions
 #define FIPS_mode                        wolfSSL_FIPS_mode
 #define FIPS_mode_set                    wolfSSL_FIPS_mode_set
+typedef struct CRYPTO_EX_DATA            CRYPTO_EX_DATA;
+typedef void (CRYPTO_free_func)(void*parent, void*ptr, CRYPTO_EX_DATA *ad, int idx,
+        long argl, void* argp);
 #endif /* HAVE_STUNNEL */
 
 #endif /* header */

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -392,8 +392,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define SSL_CTX_sess_set_remove_cb wolfSSL_CTX_sess_set_remove_cb
 
 #define i2d_SSL_SESSION wolfSSL_i2d_SSL_SESSION
-#define d2i_SSL_SESSION(sess, val, length) \
-        wolfSSL_d2i_SSL_SESSION(sess, (const unsigned char **)val, length)
+#define d2i_SSL_SESSION wolfSSL_d2i_SSL_SESSION
 #define SSL_SESSION_set_timeout wolfSSL_SSL_SESSION_set_timeout
 #define SSL_SESSION_get_timeout wolfSSL_SESSION_get_timeout
 #define SSL_SESSION_get_time wolfSSL_SESSION_get_time
@@ -477,7 +476,6 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 #define SSL_SESSION_get_ex_new_index     wolfSSL_SESSION_get_ex_new_index
 #define SSL_SESSION_get_id               wolfSSL_SESSION_get_id
 #define CRYPTO_dynlock_value             WOLFSSL_dynlock_value
-typedef struct CRYPTO_EX_DATA            CRYPTO_EX_DATA;
 typedef WOLFSSL_ASN1_BIT_STRING    ASN1_BIT_STRING;
 
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1553,6 +1553,7 @@ WOLFSSL_API int PEM_write_bio_WOLFSSL_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 *x);
 
 #ifdef HAVE_STUNNEL
 
+#include <wolfssl/openssl/crypto.h>
 
 WOLFSSL_API int wolfSSL_CRYPTO_set_mem_ex_functions(void *(*m) (size_t, const char *, int),
     void *(*r) (void *, size_t, const char *, int), void (*f) (void *));
@@ -1601,7 +1602,8 @@ WOLFSSL_API void* wolfSSL_SESSION_get_ex_data(const WOLFSSL_SESSION*, int);
 
 WOLFSSL_API int   wolfSSL_SESSION_set_ex_data(WOLFSSL_SESSION*, int, void*);
 
-WOLFSSL_API int wolfSSL_SESSION_get_ex_new_index(long,void*,void*,void*,void*);
+WOLFSSL_API int wolfSSL_SESSION_get_ex_new_index(long,void*,void*,void*,
+        CRYPTO_free_func*);
 
 WOLFSSL_API int wolfSSL_X509_NAME_get_sz(WOLFSSL_X509_NAME*);
 


### PR DESCRIPTION
This commit removes the last two extra warnings generated when compiling stunnel with wolfSSL