### PR TITLE
Option for no PSK Id Hint and test cases

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -158,6 +158,9 @@ static void Usage(void)
 #ifdef HAVE_ANON
     printf("-a          Anonymous server\n");
 #endif
+#ifndef NO_PSK
+    printf("-I          Do not send PSK identity hint\n");
+#endif
 }
 
 THREAD_RETURN CYASSL_THREAD server_test(void* args)
@@ -199,6 +202,10 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     int    argc = ((func_args*)args)->argc;
     char** argv = ((func_args*)args)->argv;
 
+#ifndef NO_PSK
+    int doNotSendPskIdentityHint = 1;
+#endif
+
 #ifdef HAVE_SNI
     char*  sniHostName = NULL;
 #endif
@@ -230,7 +237,7 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     fdOpenSession(Task_self());
 #endif
 
-    while ((ch = mygetopt(argc, argv, "?dbstnNufrRawPp:v:l:A:c:k:Z:S:oO:D:"))
+    while ((ch = mygetopt(argc, argv, "?dbstnNufrRawPIp:v:l:A:c:k:Z:S:oO:D:"))
                          != -1) {
         switch (ch) {
             case '?' :
@@ -361,6 +368,11 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
             case 'a' :
                 #ifdef HAVE_ANON
                     useAnon = 1;
+                #endif
+                break;
+            case 'I':
+                #ifndef NO_PSK
+                    doNotSendPskIdentityHint = 0;
                 #endif
                 break;
 
@@ -500,7 +512,10 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     if (usePsk) {
 #ifndef NO_PSK
         SSL_CTX_set_psk_server_callback(ctx, my_psk_server_cb);
-        SSL_CTX_use_psk_identity_hint(ctx, "cyassl server");
+
+        if (doNotSendPskIdentityHint == 1)
+            SSL_CTX_use_psk_identity_hint(ctx, "cyassl server");
+
         if (cipherList == NULL) {
             const char *defaultCipherList;
             #if defined(HAVE_AESGCM) && !defined(NO_DH)

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -476,6 +476,17 @@ int SuiteTest(void)
     }
 #endif
 
+#ifndef NO_PSK
+    /* add psk extra suites */
+    strcpy(argv0[1], "tests/test-psk-no-id.conf");
+    printf("starting psk no identity extra cipher suite tests\n");
+    test_harness(&args);
+    if (args.return_code != 0) {
+        printf("error from script %d\n", args.return_code);
+        exit(EXIT_FAILURE);
+    }
+#endif
+
     printf(" End Cipher Suite Tests\n");
 
     wolfSSL_CTX_free(cipherSuiteCtx);

--- a/tests/test-psk-no-id.conf
+++ b/tests/test-psk-no-id.conf
@@ -1,0 +1,169 @@
+#################################
+# ^ Make sure to leave a blank line here. As suites.c parses this file
+# and determines if it's executing a test or not based on every other blank
+# line.
+#
+# Begin No PSK Identity Hint
+#################################
+# No Hint server TLSv1 PSK-AES128
+-s
+-I
+-v 1
+-l PSK-AES128-CBC-SHA
+
+# No Hint client TLSv1 PSK-AES128
+-s
+-v 1
+-l PSK-AES128-CBC-SHA
+
+# No Hint server TLSv1 PSK-AES256
+-s
+-I
+-v 1
+-l PSK-AES256-CBC-SHA
+
+# No Hint client TLSv1 PSK-AES256
+-s
+-v 1
+-l PSK-AES256-CBC-SHA
+
+# No Hint server TLSv1.1 PSK-AES128
+-s
+-I
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# No Hint client TLSv1.1 PSK-AES128
+-s
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# No Hint server TLSv1.1 PSK-AES256
+-s
+-I
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# No Hint client TLSv1.1 PSK-AES256
+-s
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# No Hint server TLSv1.2 PSK-AES128
+-s
+-I
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# No Hint client TLSv1.2 PSK-AES128
+-s
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# No Hint server TLSv1.2 PSK-AES256
+-s
+-I
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# No Hint client TLSv1.2 PSK-AES256
+-s
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# No Hint server TLSv1.0 PSK-AES128-SHA256
+-s
+-I
+-v 1
+-l PSK-AES128-CBC-SHA256
+
+# No Hint client TLSv1.0 PSK-AES128-SHA256
+-s
+-v 1
+-l PSK-AES128-CBC-SHA256
+
+# No Hint server TLSv1.1 PSK-AES128-SHA256
+-s
+-I
+-v 2
+-l PSK-AES128-CBC-SHA256
+
+# No Hint client TLSv1.1 PSK-AES128-SHA256
+-s
+-v 2
+-l PSK-AES128-CBC-SHA256
+
+# No Hint server TLSv1.2 PSK-AES128-SHA256
+-s
+-I
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# No Hint client TLSv1.2 PSK-AES128-SHA256
+-s
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# No Hint server TLSv1.0 PSK-AES256-SHA384
+-s
+-I
+-v 1
+-l PSK-AES256-CBC-SHA384
+
+# No Hint client TLSv1.0 PSK-AES256-SHA384
+-s
+-v 1
+-l PSK-AES256-CBC-SHA384
+
+# No Hint server TLSv1.1 PSK-AES256-SHA384
+-s
+-I
+-v 2
+-l PSK-AES256-CBC-SHA384
+
+# No Hint client TLSv1.1 PSK-AES256-SHA384
+-s
+-v 2
+-l PSK-AES256-CBC-SHA384
+
+# No Hint server TLSv1.2 PSK-AES256-SHA384
+-s
+-I
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# No Hint client TLSv1.2 PSK-AES256-SHA384
+-s
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# server TLSv1.2 PSK-AES128-GCM-SHA256
+-s
+-I
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# client TLSv1.2 PSK-AES128-GCM-SHA256
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# server TLSv1.2 PSK-AES256-GCM-SHA384
+-s
+-I
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# client TLSv1.2 PSK-AES256-GCM-SHA384
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+#######################
+# ^ End no PSK Identity Hint
+#######################
+#################################
+# Handshake message structure is different for
+# Diffie Helman Ephemeral do not test those.
+#################################
+


### PR DESCRIPTION
1. Put white spaces back in.

2. reversed false and true signals and called variable "doNotSendPskIdentityHint"

3. Changed variable back to local. Thank you for pointing that out.