### PR TITLE
updates to FREERTOS settings

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -307,6 +307,10 @@
 
 
 #ifdef FREERTOS
+    #include "FreeRTOS.h"
+    /* FreeRTOS pvPortRealloc() only in AVR32_UC3 port */
+    #define XMALLOC(s, h, type)  pvPortMalloc((s))
+    #define XFREE(p, h, type)    vPortFree((p))
     #ifndef NO_WRITEV
         #define NO_WRITEV
     #endif
@@ -328,7 +332,6 @@
     #endif
 
     #ifndef SINGLE_THREADED
-        #include "FreeRTOS.h"
         #include "semphr.h"
     #endif
 #endif

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -143,6 +143,9 @@
 	#ifdef HAVE_THREAD_LS
 	    #if defined(_MSC_VER)
 	        #define THREAD_LS_T __declspec(thread)
+	    /* Thread local storage only in FreeRTOS v8.2.1 and higher */
+	    #elif defined(FREERTOS)
+	        #define THREAD_LS_T
 	    #else
 	        #define THREAD_LS_T __thread
 	    #endif
@@ -176,7 +179,7 @@
 	    #define XREALLOC(p, n, h, t) realloc((p), (n))
 	#elif !defined(MICRIUM_MALLOC) && !defined(EBSNET) \
 	        && !defined(WOLFSSL_SAFERTOS) && !defined(FREESCALE_MQX) \
-	        && !defined(WOLFSSL_LEANPSK)
+	        && !defined(WOLFSSL_LEANPSK) && !defined(FREERTOS)
 	    /* default C runtime, can install different routines at runtime via cbs */
 	    #include <wolfssl/wolfcrypt/memory.h>
 	    #define XMALLOC(s, h, t)     ((void)h, (void)t, wolfSSL_Malloc((s)))


### PR DESCRIPTION
**settings.h** - map XMALLOC and XFREE to FreeRTOS equivalent memory functions (no realloc compatibility for FreeRTOS), always include FreeRTOS.h when FREERTOS is defined.

**types.h** - do not map XMALLOC, XFREE to wolfSSL_malloc/wolfSSL_free if FREERTOS defined, map THREAD_LS_T as empty mapping when using FreeRTOS since versions prior to 8.2.1 do not support thread local storage.
