### PR TITLE
fix mixed declarations by moving them to their block start

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -14069,14 +14069,17 @@ int DoSessionTicket(WOLFSSL* ssl,
         #endif
             if (TLSX_SupportExtensions(ssl)) {
                 int ret = 0;
-                /* auto populate extensions supported unless user defined */
-                if ((ret = TLSX_PopulateExtensions(ssl, 1)) != 0)
-                    return ret;
 #else
             if (IsAtLeastTLSv1_2(ssl)) {
 #endif
                 /* Process the hello extension. Skip unsupported. */
                 word16 totalExtSz;
+
+#ifdef HAVE_TLS_EXTENSIONS
+                /* auto populate extensions supported unless user defined */
+                if ((ret = TLSX_PopulateExtensions(ssl, 1)) != 0)
+                    return ret;
+#endif
 
                 if ((i - begin) + OPAQUE16_LEN > helloSz)
                     return BUFFER_ERROR;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1492,11 +1492,13 @@ int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen)
         sizes[i] = SetLength(rawLen, tmps[i] + 1) + 1 + lbit; /* tag & lbit */
 
         if (sizes[i] <= MAX_SEQ_SZ) {
+            int err;
+
             /* leading zero */
             if (lbit)
                 tmps[i][sizes[i]-1] = 0x00;
 
-            int err = mp_to_unsigned_bin(keyInt, tmps[i] + sizes[i]);
+            err = mp_to_unsigned_bin(keyInt, tmps[i] + sizes[i]);
             if (err == MP_OKAY) {
                 sizes[i] += (rawLen-lbit); /* lbit included in rawLen */
                 intTotalLen += sizes[i];


### PR DESCRIPTION
In Visual Studio <= 2012 C99 mixed declarations aren't supported.