### PR TITLE
Fix GCC Compiler warning, fix stunnel naming conflict

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -14279,7 +14279,7 @@ int DoSessionTicket(WOLFSSL* ssl,
 #ifdef WOLFSSL_DTLS
         Hmac            cookieHmac;
         byte            peerCookie[MAX_COOKIE_LEN];
-        byte            peerCookieSz;
+        byte            peerCookieSz = 0;
         byte            cookieType;
         byte            cookieSz;
 #endif /* WOLFSSL_DTLS */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6945,7 +6945,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 #ifndef NO_PSK
 
     void wolfSSL_CTX_set_psk_client_callback(WOLFSSL_CTX* ctx,
-                                         psk_client_callback cb)
+                                         wc_psk_client_callback cb)
     {
         WOLFSSL_ENTER("SSL_CTX_set_psk_client_callback");
         ctx->havePSK = 1;
@@ -6953,7 +6953,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     }
 
 
-    void wolfSSL_set_psk_client_callback(WOLFSSL* ssl, psk_client_callback cb)
+    void wolfSSL_set_psk_client_callback(WOLFSSL* ssl,wc_psk_client_callback cb)
     {
         byte haveRSA = 1;
 
@@ -6972,7 +6972,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
 
     void wolfSSL_CTX_set_psk_server_callback(WOLFSSL_CTX* ctx,
-                                         psk_server_callback cb)
+                                         wc_psk_server_callback cb)
     {
         WOLFSSL_ENTER("SSL_CTX_set_psk_server_callback");
         ctx->havePSK = 1;
@@ -6980,7 +6980,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     }
 
 
-    void wolfSSL_set_psk_server_callback(WOLFSSL* ssl, psk_server_callback cb)
+    void wolfSSL_set_psk_server_callback(WOLFSSL* ssl,wc_psk_server_callback cb)
     {
         byte haveRSA = 1;
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1209,9 +1209,9 @@ WOLFSSL_LOCAL
 int  SetCipherList(Suites*, const char* list);
 
 #ifndef PSK_TYPES_DEFINED
-    typedef unsigned int (*psk_client_callback)(WOLFSSL*, const char*, char*,
+    typedef unsigned int (*wc_psk_client_callback)(WOLFSSL*, const char*, char*,
                           unsigned int, unsigned char*, unsigned int);
-    typedef unsigned int (*psk_server_callback)(WOLFSSL*, const char*,
+    typedef unsigned int (*wc_psk_server_callback)(WOLFSSL*, const char*,
                           unsigned char*, unsigned int);
 #endif /* PSK_TYPES_DEFINED */
 
@@ -1666,8 +1666,8 @@ struct WOLFSSL_CTX {
 #endif
 #ifndef NO_PSK
     byte        havePSK;                /* psk key set by user */
-    psk_client_callback client_psk_cb;  /* client callback */
-    psk_server_callback server_psk_cb;  /* server callback */
+    wc_psk_client_callback client_psk_cb;  /* client callback */
+    wc_psk_server_callback server_psk_cb;  /* server callback */
     char        server_hint[MAX_PSK_ID_LEN];
 #endif /* NO_PSK */
 #ifdef HAVE_ANON
@@ -2009,8 +2009,8 @@ typedef struct Buffers {
 
 typedef struct Options {
 #ifndef NO_PSK
-    psk_client_callback client_psk_cb;
-    psk_server_callback server_psk_cb;
+    wc_psk_client_callback client_psk_cb;
+    wc_psk_server_callback server_psk_cb;
     word16            havePSK:1;            /* psk key set by user */
 #endif /* NO_PSK */
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -723,11 +723,12 @@ enum { /* ssl Constants */
 
 
 #ifndef NO_PSK
-    typedef unsigned int (*psk_client_callback)(WOLFSSL*, const char*, char*,
+    typedef unsigned int (*wc_psk_client_callback)(WOLFSSL*, const char*, char*,
                                     unsigned int, unsigned char*, unsigned int);
     WOLFSSL_API void wolfSSL_CTX_set_psk_client_callback(WOLFSSL_CTX*,
-                                                    psk_client_callback);
-    WOLFSSL_API void wolfSSL_set_psk_client_callback(WOLFSSL*,psk_client_callback);
+                                                    wc_psk_client_callback);
+    WOLFSSL_API void wolfSSL_set_psk_client_callback(WOLFSSL*,
+                                                    wc_psk_client_callback);
 
     WOLFSSL_API const char* wolfSSL_get_psk_identity_hint(const WOLFSSL*);
     WOLFSSL_API const char* wolfSSL_get_psk_identity(const WOLFSSL*);
@@ -735,11 +736,12 @@ enum { /* ssl Constants */
     WOLFSSL_API int wolfSSL_CTX_use_psk_identity_hint(WOLFSSL_CTX*, const char*);
     WOLFSSL_API int wolfSSL_use_psk_identity_hint(WOLFSSL*, const char*);
 
-    typedef unsigned int (*psk_server_callback)(WOLFSSL*, const char*,
+    typedef unsigned int (*wc_psk_server_callback)(WOLFSSL*, const char*,
                           unsigned char*, unsigned int);
     WOLFSSL_API void wolfSSL_CTX_set_psk_server_callback(WOLFSSL_CTX*,
-                                                    psk_server_callback);
-    WOLFSSL_API void wolfSSL_set_psk_server_callback(WOLFSSL*,psk_server_callback);
+                                                    wc_psk_server_callback);
+    WOLFSSL_API void wolfSSL_set_psk_server_callback(WOLFSSL*,
+                                                    wc_psk_server_callback);
 
     #define PSK_TYPES_DEFINED
 #endif /* NO_PSK */


### PR DESCRIPTION
Compiler warning from commit b62e5d5
Stunnel naming conflict with psk_client_callback typedef