### PR TITLE
Add reference count for X509 objects to match OpenSSL

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10205,7 +10205,7 @@ WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl)  /* what's ref count */
 void wolfSSL_X509_free(WOLFSSL_X509* buf)
 {
     WOLFSSL_ENTER("wolfSSL_X509_free");
-    FreeX509(buf);
+    wolfSSL_FreeX509(buf);
 }
 
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8979,10 +8979,17 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     WOLFSSL_X509* wolfSSL_get_peer_certificate(WOLFSSL* ssl)
     {
         WOLFSSL_ENTER("SSL_get_peer_certificate");
-        if (ssl->peerCert.issuer.sz)
-            return &ssl->peerCert;
-        else
-            return 0;
+        WOLFSSL_X509* peerCert;
+
+        if (ssl && ssl->peerCert.issuer.sz) {
+            peerCert = &ssl->peerCert;
+            if (LockMutex(&peerCert->countMutex) == 0 ) {
+                peerCert->refCount++;
+                UnLockMutex(&peerCert->countMutex);
+                return peerCert;
+            }
+        }
+        return 0;
     }
 
 #endif /* KEEP_PEER_CERT */
@@ -9492,8 +9499,12 @@ WOLFSSL_X509* wolfSSL_X509_d2i(WOLFSSL_X509** x509, const byte* in, int len)
             newX509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
                                              DYNAMIC_TYPE_X509);
             if (newX509 != NULL) {
-                InitX509(newX509, 1);
-                if (CopyDecodedToX509(newX509, cert) != 0) {
+                if(!InitX509(newX509, 1)) {
+                    wolfSSL_FreeX509(newX509);
+                    XFREE(newX509, NULL, DYNAMIC_TYPE_X509);
+                    newX509 = NULL;
+                } else if (CopyDecodedToX509(newX509, cert) != 0) {
+                    wolfSSL_FreeX509(newX509);
                     XFREE(newX509, NULL, DYNAMIC_TYPE_X509);
                     newX509 = NULL;
                 }
@@ -9679,8 +9690,12 @@ WOLFSSL_X509* wolfSSL_X509_load_certificate_file(const char* fname, int format)
                 x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
                                                              DYNAMIC_TYPE_X509);
                 if (x509 != NULL) {
-                    InitX509(x509, 1);
-                    if (CopyDecodedToX509(x509, cert) != 0) {
+                    if(!InitX509(x509, 1)) {
+                        wolfSSL_FreeX509(x509);
+                        XFREE(x509, NULL, DYNAMIC_TYPE_X509);
+                        x509 = NULL;
+                } else if (CopyDecodedToX509(x509, cert) != 0) {
+                        wolfSSL_FreeX509(x509);
                         XFREE(x509, NULL, DYNAMIC_TYPE_X509);
                         x509 = NULL;
                     }
@@ -10189,6 +10204,7 @@ WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl)  /* what's ref count */
 
 void wolfSSL_X509_free(WOLFSSL_X509* buf)
 {
+    WOLFSSL_ENTER("wolfSSL_X509_free");
     FreeX509(buf);
 }
 
@@ -15613,9 +15629,12 @@ WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN* chain, int idx)
                     WOLFSSL_MSG("Failed alloc X509");
                 }
                 else {
-                    InitX509(x509, 1);
-
-                    if ((ret = CopyDecodedToX509(x509, cert)) != 0) {
+                    if(!InitX509(x509, 1)) {
+                        wolfSSL_FreeX509(x509);
+                        XFREE(x509, NULL, DYNAMIC_TYPE_X509);
+                        x509 = NULL;
+                    } else if ((ret = CopyDecodedToX509(x509, cert)) != 0) {
+                        wolfSSL_FreeX509(x509);
                         WOLFSSL_MSG("Failed to copy decoded");
                         XFREE(x509, NULL, DYNAMIC_TYPE_X509);
                         x509 = NULL;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2134,6 +2134,8 @@ struct WOLFSSL_X509 {
     int              serialSz;
     byte             serial[EXTERNAL_SERIAL_SIZE];
     char             subjectCN[ASN_NAME_MAX];        /* common name short cut */
+    wolfSSL_Mutex    countMutex;                     /* reference count mutex */
+    int              refCount;                       /* reference count */
 #ifdef WOLFSSL_SEP
     int              deviceTypeSz;
     byte             deviceType[EXTERNAL_SERIAL_SIZE];
@@ -2633,7 +2635,7 @@ WOLFSSL_LOCAL word32  LowResTimer(void);
 
 WOLFSSL_LOCAL void InitX509Name(WOLFSSL_X509_NAME*, int);
 WOLFSSL_LOCAL void FreeX509Name(WOLFSSL_X509_NAME* name);
-WOLFSSL_LOCAL void InitX509(WOLFSSL_X509*, int);
+WOLFSSL_LOCAL int InitX509(WOLFSSL_X509*, int);
 WOLFSSL_LOCAL void FreeX509(WOLFSSL_X509*);
 #ifndef NO_CERTS
     WOLFSSL_LOCAL int  CopyDecodedToX509(WOLFSSL_X509*, DecodedCert*);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -368,7 +368,7 @@ static INLINE void showPeer(WOLFSSL* ssl)
         ShowX509(peer, "peer's cert info:");
     else
         printf("peer has no cert!\n");
-    wolfSSL_X509_free(peer);
+    wolfSSL_FreeX509(peer);
 #endif
     printf("SSL version is %s\n", wolfSSL_get_version(ssl));
 

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -368,6 +368,7 @@ static INLINE void showPeer(WOLFSSL* ssl)
         ShowX509(peer, "peer's cert info:");
     else
         printf("peer has no cert!\n");
+    wolfSSL_X509_free(peer);
 #endif
     printf("SSL version is %s\n", wolfSSL_get_version(ssl));
 


### PR DESCRIPTION
This commit matches wolfSSL's X509 behaviour to OpenSSL for the OpenSSL compatibility layer. (See:  https://www.openssl.org/docs/ssl/SSL_get_peer_certificate.html ) by adding an X509 reference count. The reference count is protected by a mutex, and mimics the count around the CTX and SSL objects.

