### PR TITLE
Github Issue #130 (XMALLOC_USER, NO_WOLFSSL_MEMORY) with FREERTOS

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -381,9 +381,13 @@ static char *fgets(char *buff, int sz, FILE *fp)
 
 #ifdef FREERTOS
     #include "FreeRTOS.h"
+
     /* FreeRTOS pvPortRealloc() only in AVR32_UC3 port */
-    #define XMALLOC(s, h, type)  pvPortMalloc((s))
-    #define XFREE(p, h, type)    vPortFree((p))
+    #if !defined(XMALLOC_USER) && !defined(NO_WOLFSSL_MEMORY)
+        #define XMALLOC(s, h, type)  pvPortMalloc((s))
+        #define XFREE(p, h, type)    vPortFree((p))
+    #endif
+
     #ifndef NO_WRITEV
         #define NO_WRITEV
     #endif


### PR DESCRIPTION
Tested in uVision project wolfSSL_STM32\Project\wolfcrypt_test\MDK-ARM\Project.uvproj on Windows 10 using the evaluation version of uVision.

Was able to test compilation. Compiled successfully.
Linking failed as linker can only do 32K in evaluation and project was 66K
Unable to test execution.