### PR TITLE
Make WOLFSSL_METHODs static structs to eliminate heap storage

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -443,14 +443,6 @@ static INLINE void ato32(const byte* c, word32* u32)
 #endif /* HAVE_LIBZ */
 
 
-void InitSSL_Method(WOLFSSL_METHOD* method, ProtocolVersion pv)
-{
-    method->version    = pv;
-    method->side       = WOLFSSL_CLIENT_END;
-    method->downgrade  = 0;
-}
-
-
 /* Initialze SSL context, return 0 on success */
 int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method)
 {
@@ -526,7 +518,6 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method)
 /* In case contexts are held in array and don't want to free actual ctx */
 void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
 {
-    XFREE(ctx->method, ctx->heap, DYNAMIC_TYPE_METHOD);
     if (ctx->suites)
         XFREE(ctx->suites, ctx->heap, DYNAMIC_TYPE_SUITES);
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5556,12 +5556,12 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     WOLFSSL_METHOD* wolfSSLv3_client_method(void)
     {
         static WOLFSSL_METHOD method = {
-            .version = {
-                .major = SSLv3_MAJOR,
-                .minor = SSLv3_MINOR
+            {
+                SSLv3_MAJOR,
+                SSLv3_MINOR
             },
-            .side = WOLFSSL_CLIENT_END,
-            .downgrade = 0
+            WOLFSSL_CLIENT_END,
+            0
         };
         WOLFSSL_ENTER("SSLv3_client_method");
 
@@ -5575,12 +5575,12 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         WOLFSSL_METHOD* wolfDTLSv1_client_method(void)
         {
             static WOLFSSL_METHOD method = {
-                .version = {
-                    .major = DTLS_MAJOR,
-                    .minor = DTLS_MINOR
+                {
+                    DTLS_MAJOR,
+                    DTLS_MINOR
                 },
-                .side = WOLFSSL_CLIENT_END,
-                .downgrade = 0
+                WOLFSSL_CLIENT_END,
+                0
             };
             WOLFSSL_ENTER("DTLSv1_client_method");
 
@@ -5591,12 +5591,12 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         WOLFSSL_METHOD* wolfDTLSv1_2_client_method(void)
         {
              static WOLFSSL_METHOD method = {
-                .version = {
-                    .major = DTLS_MAJOR,
-                    .minor = DTLSv1_2_MINOR
+                {
+                    DTLS_MAJOR,
+                    DTLSv1_2_MINOR
                 },
-                .side = WOLFSSL_CLIENT_END,
-                .downgrade = 0
+                WOLFSSL_CLIENT_END,
+                0
             };
             WOLFSSL_ENTER("DTLSv1_2_client_method");
 
@@ -5858,12 +5858,12 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     WOLFSSL_METHOD* wolfSSLv3_server_method(void)
     {
         static WOLFSSL_METHOD method = {
-            .version = {
-                .major = SSLv3_MAJOR,
-                .minor = SSLv3_MINOR
+            {
+                SSLv3_MAJOR,
+                SSLv3_MINOR
             },
-            .side = WOLFSSL_SERVER_END,
-            .downgrade = 0
+            WOLFSSL_SERVER_END,
+            0
         };
 
         WOLFSSL_ENTER("SSLv3_server_method");
@@ -5878,12 +5878,12 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         WOLFSSL_METHOD* wolfDTLSv1_server_method(void)
         {
             static WOLFSSL_METHOD method = {
-                .version = {
-                    .major = DTLS_MAJOR,
-                    .minor = DTLS_MINOR
+                {
+                    DTLS_MAJOR,
+                    DTLS_MINOR
                 },
-                .side = WOLFSSL_SERVER_END,
-                .downgrade = 0
+                WOLFSSL_SERVER_END,
+                0
             };
 
             WOLFSSL_ENTER("DTLSv1_server_method");
@@ -5894,12 +5894,12 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         WOLFSSL_METHOD* wolfDTLSv1_2_server_method(void)
         {
             static WOLFSSL_METHOD method = {
-                .version = {
-                    .major = DTLS_MAJOR,
-                    .minor = DTLSv1_2_MINOR
+                {
+                    DTLS_MAJOR,
+                    DTLSv1_2_MINOR
                 },
-                .side = WOLFSSL_SERVER_END,
-                .downgrade = 0
+                WOLFSSL_SERVER_END,
+                0
             };
 
             WOLFSSL_ENTER("DTLSv1_2_server_method");

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -174,8 +174,7 @@ WOLFSSL_CTX* wolfSSL_CTX_new(WOLFSSL_METHOD* method)
         }
     }
     else {
-        WOLFSSL_MSG("Alloc CTX failed, method freed");
-        XFREE(method, NULL, DYNAMIC_TYPE_METHOD);
+        WOLFSSL_MSG("Alloc CTX failed");
     }
 
     WOLFSSL_LEAVE("WOLFSSL_CTX_new", 0);
@@ -5556,13 +5555,17 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     #if defined(WOLFSSL_ALLOW_SSLV3) && !defined(NO_OLD_TLS)
     WOLFSSL_METHOD* wolfSSLv3_client_method(void)
     {
-        WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD),
-                                                        0, DYNAMIC_TYPE_METHOD);
+        static WOLFSSL_METHOD method = {
+            .version = {
+                .major = SSLv3_MAJOR,
+                .minor = SSLv3_MINOR
+            },
+            .side = WOLFSSL_CLIENT_END,
+            .downgrade = 0
+        };
         WOLFSSL_ENTER("SSLv3_client_method");
-        if (method)
-            InitSSL_Method(method, MakeSSLv3());
-        return method;
+
+        return &method;
     }
     #endif
 
@@ -5571,25 +5574,33 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         #ifndef NO_OLD_TLS
         WOLFSSL_METHOD* wolfDTLSv1_client_method(void)
         {
-            WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD),
-                                                        0, DYNAMIC_TYPE_METHOD);
+            static WOLFSSL_METHOD method = {
+                .version = {
+                    .major = DTLS_MAJOR,
+                    .minor = DTLS_MINOR
+                },
+                .side = WOLFSSL_CLIENT_END,
+                .downgrade = 0
+            };
             WOLFSSL_ENTER("DTLSv1_client_method");
-            if (method)
-                InitSSL_Method(method, MakeDTLSv1());
-            return method;
+
+            return &method;
         }
         #endif  /* NO_OLD_TLS */
 
         WOLFSSL_METHOD* wolfDTLSv1_2_client_method(void)
         {
-            WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD),
-                                                        0, DYNAMIC_TYPE_METHOD);
+             static WOLFSSL_METHOD method = {
+                .version = {
+                    .major = DTLS_MAJOR,
+                    .minor = DTLSv1_2_MINOR
+                },
+                .side = WOLFSSL_CLIENT_END,
+                .downgrade = 0
+            };
             WOLFSSL_ENTER("DTLSv1_2_client_method");
-            if (method)
-                InitSSL_Method(method, MakeDTLSv1_2());
-            return method;
+
+            return &method;
         }
     #endif
 
@@ -5846,15 +5857,17 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     #if defined(WOLFSSL_ALLOW_SSLV3) && !defined(NO_OLD_TLS)
     WOLFSSL_METHOD* wolfSSLv3_server_method(void)
     {
-        WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD),
-                                                        0, DYNAMIC_TYPE_METHOD);
+        static WOLFSSL_METHOD method = {
+            .version = {
+                .major = SSLv3_MAJOR,
+                .minor = SSLv3_MINOR
+            },
+            .side = WOLFSSL_SERVER_END,
+            .downgrade = 0
+        };
+
         WOLFSSL_ENTER("SSLv3_server_method");
-        if (method) {
-            InitSSL_Method(method, MakeSSLv3());
-            method->side = WOLFSSL_SERVER_END;
-        }
-        return method;
+        return &method;
     }
     #endif
 
@@ -5864,29 +5877,33 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         #ifndef NO_OLD_TLS
         WOLFSSL_METHOD* wolfDTLSv1_server_method(void)
         {
-            WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD),
-                                                        0, DYNAMIC_TYPE_METHOD);
+            static WOLFSSL_METHOD method = {
+                .version = {
+                    .major = DTLS_MAJOR,
+                    .minor = DTLS_MINOR
+                },
+                .side = WOLFSSL_SERVER_END,
+                .downgrade = 0
+            };
+
             WOLFSSL_ENTER("DTLSv1_server_method");
-            if (method) {
-                InitSSL_Method(method, MakeDTLSv1());
-                method->side = WOLFSSL_SERVER_END;
-            }
-            return method;
+            return &method;
         }
         #endif /* NO_OLD_TLS */
 
         WOLFSSL_METHOD* wolfDTLSv1_2_server_method(void)
         {
-            WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD),
-                                                        0, DYNAMIC_TYPE_METHOD);
+            static WOLFSSL_METHOD method = {
+                .version = {
+                    .major = DTLS_MAJOR,
+                    .minor = DTLSv1_2_MINOR
+                },
+                .side = WOLFSSL_SERVER_END,
+                .downgrade = 0
+            };
+
             WOLFSSL_ENTER("DTLSv1_2_server_method");
-            if (method) {
-                InitSSL_Method(method, MakeDTLSv1_2());
-                method->side = WOLFSSL_SERVER_END;
-            }
-            return method;
+            return &method;
         }
     #endif
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -3379,23 +3379,31 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
 
     WOLFSSL_METHOD* wolfTLSv1_client_method(void)
     {
-        WOLFSSL_METHOD* method =
-                             (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD), 0,
-                                                      DYNAMIC_TYPE_METHOD);
-        if (method)
-            InitSSL_Method(method, MakeTLSv1());
-        return method;
+        static WOLFSSL_METHOD method = {
+            .version = {
+               .major = SSLv3_MAJOR,
+               .minor = TLSv1_MINOR
+            },
+            .side = WOLFSSL_CLIENT_END,
+            .downgrade = 0
+        };
+
+        return &method;
     }
 
 
     WOLFSSL_METHOD* wolfTLSv1_1_client_method(void)
     {
-        WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD), 0,
-                                                       DYNAMIC_TYPE_METHOD);
-        if (method)
-            InitSSL_Method(method, MakeTLSv1_1());
-        return method;
+        static WOLFSSL_METHOD method = {
+            .version = {
+                .major = SSLv3_MAJOR,
+                .minor = TLSv1_1_MINOR
+            },
+            .side = WOLFSSL_CLIENT_END,
+            .downgrade = 0
+        };
+
+        return &method;
     }
 
 #endif /* !NO_OLD_TLS */
@@ -3404,12 +3412,16 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
 
     WOLFSSL_METHOD* wolfTLSv1_2_client_method(void)
     {
-        WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD), 0,
-                                                       DYNAMIC_TYPE_METHOD);
-        if (method)
-            InitSSL_Method(method, MakeTLSv1_2());
-        return method;
+         static WOLFSSL_METHOD method = {
+            .version = {
+                .major = SSLv3_MAJOR,
+                .minor = TLSv1_2_MINOR
+            },
+            .side = WOLFSSL_CLIENT_END,
+            .downgrade = 0
+        };
+
+        return &method;
     }
 
 #endif
@@ -3417,20 +3429,24 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
 
     WOLFSSL_METHOD* wolfSSLv23_client_method(void)
     {
-        WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD), 0,
-                                                       DYNAMIC_TYPE_METHOD);
-        if (method) {
+          static WOLFSSL_METHOD method = {
+            .version = {
+                .major = SSLv3_MAJOR,
 #ifndef NO_SHA256         /* 1.2 requires SHA256 */
-            InitSSL_Method(method, MakeTLSv1_2());
+                .minor = TLSv1_2_MINOR
 #else
-            InitSSL_Method(method, MakeTLSv1_1());
+                .minor = TLSv1_1_MINOR
 #endif
+            },
+            .side = WOLFSSL_CLIENT_END,
 #ifndef NO_OLD_TLS
-            method->downgrade = 1;
+            .downgrade = 1
+#else
+            .downgrade = 0
 #endif
-        }
-        return method;
+        };
+
+        return &method;
     }
 
 
@@ -3444,27 +3460,31 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
 
     WOLFSSL_METHOD* wolfTLSv1_server_method(void)
     {
-        WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD), 0,
-                                                       DYNAMIC_TYPE_METHOD);
-        if (method) {
-            InitSSL_Method(method, MakeTLSv1());
-            method->side = WOLFSSL_SERVER_END;
-        }
-        return method;
+        static WOLFSSL_METHOD method = {
+            .version = {
+                .major = SSLv3_MAJOR,
+                .minor = TLSv1_MINOR
+            },
+            .side = WOLFSSL_SERVER_END,
+            .downgrade = 0
+        };
+
+        return &method;
     }
 
 
     WOLFSSL_METHOD* wolfTLSv1_1_server_method(void)
     {
-        WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD), 0,
-                                                       DYNAMIC_TYPE_METHOD);
-        if (method) {
-            InitSSL_Method(method, MakeTLSv1_1());
-            method->side = WOLFSSL_SERVER_END;
-        }
-        return method;
+         static WOLFSSL_METHOD method = {
+            .version = {
+                .major = SSLv3_MAJOR,
+                .minor = TLSv1_1_MINOR
+            },
+            .side = WOLFSSL_SERVER_END,
+            .downgrade = 0
+        };
+
+        return &method;
     }
 
 #endif /* !NO_OLD_TLS */
@@ -3473,14 +3493,15 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
 
     WOLFSSL_METHOD* wolfTLSv1_2_server_method(void)
     {
-        WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD), 0,
-                                                       DYNAMIC_TYPE_METHOD);
-        if (method) {
-            InitSSL_Method(method, MakeTLSv1_2());
-            method->side = WOLFSSL_SERVER_END;
-        }
-        return method;
+        static WOLFSSL_METHOD method = {
+            .version = {
+               .major = SSLv3_MAJOR,
+               .minor = TLSv1_2_MINOR
+            },
+            .side = WOLFSSL_SERVER_END,
+            .downgrade = 0
+        };
+        return &method;
     }
 
 #endif
@@ -3488,21 +3509,24 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
 
     WOLFSSL_METHOD* wolfSSLv23_server_method(void)
     {
-        WOLFSSL_METHOD* method =
-                              (WOLFSSL_METHOD*) XMALLOC(sizeof(WOLFSSL_METHOD), 0,
-                                                       DYNAMIC_TYPE_METHOD);
-        if (method) {
+        static WOLFSSL_METHOD method = {
+            .version = {
+               .major = SSLv3_MAJOR,
 #ifndef NO_SHA256         /* 1.2 requires SHA256 */
-            InitSSL_Method(method, MakeTLSv1_2());
+               .minor = TLSv1_2_MINOR
 #else
-            InitSSL_Method(method, MakeTLSv1_1());
+               .minor = TLSv1_1_MINOR
 #endif
-            method->side      = WOLFSSL_SERVER_END;
+            },
+            .side = WOLFSSL_SERVER_END,
 #ifndef NO_OLD_TLS
-            method->downgrade = 1;
+            .downgrade = 1
+#else
+            .downgrade = 0
 #endif /* !NO_OLD_TLS */
-        }
-        return method;
+        };
+
+        return &method;
     }
 
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -3380,12 +3380,12 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
     WOLFSSL_METHOD* wolfTLSv1_client_method(void)
     {
         static WOLFSSL_METHOD method = {
-            .version = {
-               .major = SSLv3_MAJOR,
-               .minor = TLSv1_MINOR
+            {
+               SSLv3_MAJOR,
+               TLSv1_MINOR
             },
-            .side = WOLFSSL_CLIENT_END,
-            .downgrade = 0
+            WOLFSSL_CLIENT_END,
+            0
         };
 
         return &method;
@@ -3395,12 +3395,12 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
     WOLFSSL_METHOD* wolfTLSv1_1_client_method(void)
     {
         static WOLFSSL_METHOD method = {
-            .version = {
-                .major = SSLv3_MAJOR,
-                .minor = TLSv1_1_MINOR
+            {
+                SSLv3_MAJOR,
+                TLSv1_1_MINOR
             },
-            .side = WOLFSSL_CLIENT_END,
-            .downgrade = 0
+            WOLFSSL_CLIENT_END,
+            0
         };
 
         return &method;
@@ -3413,12 +3413,12 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
     WOLFSSL_METHOD* wolfTLSv1_2_client_method(void)
     {
          static WOLFSSL_METHOD method = {
-            .version = {
-                .major = SSLv3_MAJOR,
-                .minor = TLSv1_2_MINOR
+            {
+                SSLv3_MAJOR,
+                TLSv1_2_MINOR
             },
-            .side = WOLFSSL_CLIENT_END,
-            .downgrade = 0
+            WOLFSSL_CLIENT_END,
+            0
         };
 
         return &method;
@@ -3430,19 +3430,19 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
     WOLFSSL_METHOD* wolfSSLv23_client_method(void)
     {
           static WOLFSSL_METHOD method = {
-            .version = {
-                .major = SSLv3_MAJOR,
+            {
+                SSLv3_MAJOR,
 #ifndef NO_SHA256         /* 1.2 requires SHA256 */
-                .minor = TLSv1_2_MINOR
+                TLSv1_2_MINOR
 #else
-                .minor = TLSv1_1_MINOR
+                TLSv1_1_MINOR
 #endif
             },
-            .side = WOLFSSL_CLIENT_END,
+            WOLFSSL_CLIENT_END,
 #ifndef NO_OLD_TLS
-            .downgrade = 1
+            1
 #else
-            .downgrade = 0
+            0
 #endif
         };
 
@@ -3461,12 +3461,12 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
     WOLFSSL_METHOD* wolfTLSv1_server_method(void)
     {
         static WOLFSSL_METHOD method = {
-            .version = {
-                .major = SSLv3_MAJOR,
-                .minor = TLSv1_MINOR
+            {
+                SSLv3_MAJOR,
+                TLSv1_MINOR
             },
-            .side = WOLFSSL_SERVER_END,
-            .downgrade = 0
+            WOLFSSL_SERVER_END,
+            0
         };
 
         return &method;
@@ -3477,11 +3477,11 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
     {
          static WOLFSSL_METHOD method = {
             .version = {
-                .major = SSLv3_MAJOR,
-                .minor = TLSv1_1_MINOR
+                SSLv3_MAJOR,
+                TLSv1_1_MINOR
             },
-            .side = WOLFSSL_SERVER_END,
-            .downgrade = 0
+            WOLFSSL_SERVER_END,
+            0
         };
 
         return &method;
@@ -3494,12 +3494,12 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
     WOLFSSL_METHOD* wolfTLSv1_2_server_method(void)
     {
         static WOLFSSL_METHOD method = {
-            .version = {
-               .major = SSLv3_MAJOR,
-               .minor = TLSv1_2_MINOR
+            {
+               SSLv3_MAJOR,
+               TLSv1_2_MINOR
             },
-            .side = WOLFSSL_SERVER_END,
-            .downgrade = 0
+            WOLFSSL_SERVER_END,
+            0
         };
         return &method;
     }
@@ -3510,19 +3510,19 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
     WOLFSSL_METHOD* wolfSSLv23_server_method(void)
     {
         static WOLFSSL_METHOD method = {
-            .version = {
-               .major = SSLv3_MAJOR,
+            {
+               SSLv3_MAJOR,
 #ifndef NO_SHA256         /* 1.2 requires SHA256 */
-               .minor = TLSv1_2_MINOR
+               TLSv1_2_MINOR
 #else
-               .minor = TLSv1_1_MINOR
+               TLSv1_1_MINOR
 #endif
             },
-            .side = WOLFSSL_SERVER_END,
+            WOLFSSL_SERVER_END,
 #ifndef NO_OLD_TLS
-            .downgrade = 1
+            1
 #else
-            .downgrade = 0
+            0
 #endif /* !NO_OLD_TLS */
         };
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -91,7 +91,6 @@ static void test_wolfSSL_Method_Allocators(void)
         do {                                            \
             WOLFSSL_METHOD *method;                      \
             condition(method = allocator());            \
-            XFREE(method, 0, DYNAMIC_TYPE_METHOD);      \
         } while(0)
 
     #define TEST_VALID_METHOD_ALLOCATOR(a) \

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1125,9 +1125,6 @@ struct WOLFSSL_METHOD {
 };
 
 
-/* defautls to client */
-WOLFSSL_LOCAL void InitSSL_Method(WOLFSSL_METHOD*, ProtocolVersion);
-
 /* for sniffer */
 WOLFSSL_LOCAL int DoFinished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             word32 size, word32 totalSz, int sniff);


### PR DESCRIPTION
This commit is part of a request for integration with stunnel. It allows a closer matching between the wolfSSL and OpenSSL APIs. By making the WOLFSSL_METHOD objects static, there is no need to free/malloc them, and therefore no new frees are needed to integrate into OpenSSL applications, where the _METHOD structs are already static, const structs that don't require frees. 

This will also allow use of a single WOLFSSL_METHOD across multiple SSL_CTXs, the specific problem seen with stunnel.
