### PR TITLE
fix for --disable-asn when paired with other options

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2679,6 +2679,7 @@ ProtocolVersion MakeDTLSv1_2(void)
 #endif /* USE_WINDOWS_API */
 
 
+#ifndef NO_CERTS
 static int HashOutputRaw(WOLFSSL* ssl, const byte* output, int sz)
 {
 #ifdef HAVE_FUZZER
@@ -2716,6 +2717,7 @@ static int HashOutputRaw(WOLFSSL* ssl, const byte* output, int sz)
 
     return 0;
 }
+#endif /* NO_CERTS */
 
 
 /* add output to md5 and sha handshake hashes, exclude record header */
@@ -2886,6 +2888,7 @@ static void AddHeaders(byte* output, word32 length, byte type, WOLFSSL* ssl)
 }
 
 
+#ifndef NO_CERTS
 static void AddFragHeaders(byte* output, word32 fragSz, word32 fragOffset,
                            word32 length, byte type, WOLFSSL* ssl)
 {
@@ -2903,6 +2906,7 @@ static void AddFragHeaders(byte* output, word32 fragSz, word32 fragOffset,
     AddRecordHeader(output, fragSz + lengthAdj, handshake, ssl);
     AddHandShakeHeader(output + outputAdj, length, fragOffset, fragSz, type, ssl);
 }
+#endif /* NO_CERTS */
 
 
 /* return bytes received, -1 on error */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2279,7 +2279,8 @@ static int wolfssl_decrypt_buffer_key(buffer* der, byte* password,
 #endif
         return SSL_FATAL_ERROR;
     }
-
+#else
+    (void) passwordSz;
 #endif /* NO_MD5 */
 
 #ifndef NO_DES3
@@ -2355,7 +2356,8 @@ static int wolfssl_encrypt_buffer_key(byte* der, word32 derSz, byte* password,
 #endif
         return SSL_FATAL_ERROR;
     }
-
+#else
+    (void) passwordSz;
 #endif /* NO_MD5 */
 
 #ifndef NO_DES3


### PR DESCRIPTION
A significant number of the 119 broken configures reported by "expected_configs" test stemmed from this alone. I have tested each one in turn and this one changes fixes roughly 80% of the configure options that were reported as broken and had "--disable-asn" in them.