### PR TITLE
Add session resume, client auth, version to openssl.test

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -127,6 +127,15 @@ static void ShowCiphers(void)
         printf("%s\n", ciphers);
 }
 
+/* Shows which versions are valid */
+static void ShowVersions(void)
+{
+#ifdef WOLFSSL_ALLOW_SSLV3
+    printf("0:");
+#endif
+    printf("1:2:3\n");
+}
+
 int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
     int doDTLS, int benchmark, int resumeSession)
 {
@@ -300,6 +309,7 @@ static void Usage(void)
     printf("-p <num>    Port to connect on, not 0, default %d\n", wolfSSLPort);
     printf("-v <num>    SSL version [0-3], SSLv3(0) - TLS1.2(3)), default %d\n",
                                  CLIENT_DEFAULT_VERSION);
+    printf("-V          Prints valid ssl version numbers, SSLv3(0) - TLS1.2(3)\n");
     printf("-l <str>    Cipher suite list (: delimited)\n");
     printf("-c <file>   Certificate file,           default %s\n", cliCert);
     printf("-k <file>   Key file,                   default %s\n", cliKey);
@@ -372,8 +382,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     WOLFSSL*         sslResume = 0;
     WOLFSSL_SESSION* session = 0;
-    char         resumeMsg[] = "resuming wolfssl!";
-    int          resumeSz    = sizeof(resumeMsg);
+    char         resumeMsg[32] = "resuming wolfssl!";
+    int          resumeSz    = (int)strlen(resumeMsg);
 
     char msg[32] = "hello wolfssl!";   /* GET may make bigger */
     char reply[80];
@@ -466,7 +476,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
 #ifndef WOLFSSL_VXWORKS
     while ((ch = mygetopt(argc, argv,
-                          "?gdeDusmNrwRitfxXUPCh:p:v:l:A:c:k:Z:b:zS:L:ToO:aB:"))
+                          "?gdeDusmNrwRitfxXUPCh:p:Vv:l:A:c:k:Z:b:zS:L:ToO:aB:"))
                                                                         != -1) {
         switch (ch) {
             case '?' :
@@ -557,6 +567,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                     exit(MY_EX_USAGE);
                 }
                 break;
+
+            case 'V' :
+                ShowVersions();
+                exit(EXIT_SUCCESS);
 
             case 'l' :
                 cipherList = myoptarg;
@@ -1076,6 +1090,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         msgSz = 28;
         strncpy(msg, "GET /index.html HTTP/1.0\r\n\r\n", msgSz);
         msg[msgSz] = '\0';
+
+        resumeSz = msgSz;
+        strncpy(resumeMsg, "GET /index.html HTTP/1.0\r\n\r\n", resumeSz);
+        resumeMsg[resumeSz] = '\0';
     }
     if (wolfSSL_write(ssl, msg, msgSz) != msgSz)
         err_sys("SSL_write failed");
@@ -1156,7 +1174,6 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                                     (void*)"resumed session");
 #endif
 
-        showPeer(sslResume);
 #ifndef WOLFSSL_CALLBACKS
         if (nonBlocking) {
             wolfSSL_set_using_nonblock(sslResume, 1);
@@ -1170,6 +1187,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         timeout.tv_usec = 0;
         NonBlockingSSL_Connect(ssl);  /* will keep retrying on timeout */
 #endif
+        showPeer(sslResume);
 
         if (wolfSSL_session_reused(sslResume))
             printf("reused session id\n");
@@ -1208,11 +1226,28 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             #endif
         }
 
-        input = wolfSSL_read(sslResume, reply, sizeof(reply)-1);
-        if (input > 0) {
-            reply[input] = 0;
-            printf("Server resume response: %s\n", reply);
+    input = wolfSSL_read(sslResume, reply, sizeof(reply)-1);
+
+    if (input > 0) {
+        reply[input] = 0;
+        printf("Server resume response: %s\n", reply);
+
+        if (sendGET) {  /* get html */
+            while (1) {
+                input = wolfSSL_read(sslResume, reply, sizeof(reply)-1);
+                if (input > 0) {
+                    reply[input] = 0;
+                    printf("%s\n", reply);
+                }
+                else
+                    break;
+            }
         }
+    } else if (input < 0) {
+        int readErr = wolfSSL_get_error(ssl, 0);
+        if (readErr != SSL_ERROR_WANT_READ)
+            err_sys("wolfSSL_read failed");
+    }
 
         /* try to send session break */
         wolfSSL_write(sslResume, msg, msgSz);

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #openssl.test
 
@@ -41,7 +41,7 @@ command -v openssl >/dev/null 2>&1 || { echo >&2 "Requires openssl command, but 
 
 echo -e "\nTesting for _build directory as part of distcheck, different paths"
 currentDir=`pwd`
-if [[ $currentDir == *"_build" ]]
+if [ $currentDir = *"_build" ]
 then
     echo -e "_build directory detected, moving a directory back"
     cd ..
@@ -49,17 +49,13 @@ fi
 
 echo -e "\nStarting openssl server...\n"
 
-openssl s_server -accept $openssl_port -cert ./certs/server-cert.pem -key ./certs/server-key.pem  -quiet -www  -dhparam ./certs/dh2048.pem -dcert ./certs/server-ecc.pem -dkey ./certs/ecc-key.pem &
+openssl s_server -accept $openssl_port -cert ./certs/server-cert.pem -key ./certs/server-key.pem  -quiet -CAfile ./certs/client-cert.pem -www  -dhparam ./certs/dh2048.pem -dcert ./certs/server-ecc.pem -dkey ./certs/ecc-key.pem -Verify 10 -verify_return_error &
 server_pid=$!
 
 
-# get openssl ciphers
-open_ciphers=`openssl ciphers`
-IFS=':'  read -ra opensslArray <<< "$open_ciphers"
 
 # get wolfssl ciphers
 wolf_ciphers=`./examples/client/client -e`
-IFS=':'  read -ra wolfsslArray <<< "$wolf_ciphers"
 
 # server should be ready, let's make sure
 server_ready=0
@@ -67,7 +63,7 @@ while [ "$counter" -lt 20 ]; do
     echo -e "waiting for openssl s_server ready..."
     nc -z localhost $openssl_port
     nc_result=$?
-    if [ $nc_result == 0 ]
+    if [ $nc_result = 0 ]
     then
         echo -e "openssl s_server ready!"
         server_ready=1
@@ -78,45 +74,86 @@ while [ "$counter" -lt 20 ]; do
 done
 
 
-if [ $server_ready == 0 ]
+if [ $server_ready = 0 ]
 then
     echo -e "Couldn't verify openssl server is running, timeout error"
     do_cleanup
     exit -1
 fi
 
-for wolfSuite in "${wolfsslArray[@]}"; do
+OIFS=$IFS # store old seperator to reset
+IFS=$'\:' # set delimiter
+set -f # no globbing
 
-    echo -e "trying wolfSSL cipher suite $wolfSuite"
-    matchSuite=0
-    wolf_suites_total=$((wolf_suites_total + 1))
+wolf_versions=`./examples/client/client -V`
+wolf_versions="$wolf_versions:4" #:4 will test without -v flag
 
-    for openSuite in "${opensslArray[@]}"; do
-        if [ $openSuite == $wolfSuite ]
-        then
+wolf_temp_suites_total=0
+wolf_temp_suites_tested=0
+
+for version in $wolf_versions;
+do
+    echo -e "version = $version"
+    # get openssl ciphers depending on version
+    case $version in "0")
+        openssl_ciphers=`openssl ciphers "SSLv3"`
+        ;;
+    "1")
+        openssl_ciphers=`openssl ciphers "TLSv1"`
+        ;;
+    "2")
+        openssl_ciphers=`openssl ciphers "TLSv1.1"`
+        ;;
+    "3")
+        openssl_ciphers=`openssl ciphers "TLSv1.2"`
+        ;;
+    "4") #test all suites
+        openssl_ciphers=`openssl ciphers "ALL"`
+        ;;
+    esac
+
+    for wolfSuite in $wolf_ciphers; do
+        echo -e "trying wolfSSL cipher suite $wolfSuite"
+        wolf_temp_suites_total=$((wolf_temp_suites_total + 1))
+        matchSuite=0;
+
+        case ":$openssl_ciphers:" in *":$wolfSuite:"*) # add extra : for edge cases
             echo -e "Matched to OpenSSL suite support"
-            matchSuite=1
+            matchSuite=1;;
+        esac
+
+        if [ $matchSuite = 0 ]
+        then
+            echo -e "Couldn't match suite, continuing..."
+            continue
         fi
+
+        if [ $version -lt 4 ]
+        then
+            ./examples/client/client -p $openssl_port -g -r -l $wolfSuite -v $version
+        else
+            # do all versions
+            ./examples/client/client -p $openssl_port -g -r -l $wolfSuite
+        fi
+
+        client_result=$?
+
+        if [ $client_result != 0 ]
+        then
+            echo -e "client failed! Suite = $wolfSuite version = $version"
+            do_cleanup
+            exit 1
+        fi
+        wolf_temp_suites_tested=$((wolf_temp_suites_tested+1))
+
     done
-
-    if [ $matchSuite == 0 ]
-    then
-        echo -e "Couldn't match suite, continuing..."
-        continue
-    fi
-
-    ./examples/client/client -p $openssl_port -g -l $wolfSuite
-    client_result=$?
-
-    if [ $client_result != 0 ]
-    then
-        echo -e "client failed!"
-        do_cleanup
-        exit 1
-    fi
-    wolf_suites_tested=$((wolf_suites_tested+1))
-
+    wolf_suites_tested=$((wolf_temp_suites_tested+wolf_suites_tested))
+    wolf_suites_total=$((wolf_temp_suites_total+wolf_suites_total))
+    echo -e "wolfSSL suites tested with version:$version  $wolf_temp_suites_tested"
+    wolf_temp_suites_total=0
+    wolf_temp_suites_tested=0
 done
+IFS=$OIFS #restore separator
 
 kill -9 $server_pid
 


### PR DESCRIPTION
This commit adds remaining functionality for openssl.test as described above.

It also removes bashisms so script is at posix sh standard.