### PR TITLE
Custom rand optimize

### DIFF
--- a/IDE/ROWLEY-CROSSWORKS-ARM/hw.h
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/hw.h
@@ -10,4 +10,4 @@ uint32_t hw_get_time_sec(void);
 uint32_t hw_get_time_msec(void);
 void hw_uart_printchar(int c);
 void hw_watchdog_disable(void);
-int hw_rand(void);
+uint32_t hw_rand(void);

--- a/IDE/ROWLEY-CROSSWORKS-ARM/kinetis_hw.c
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/kinetis_hw.c
@@ -167,7 +167,7 @@ void hw_uart_printchar(int c)
     UART_PORT->D = (uint8_t)c; /* Send the character */
 }
 
-int hw_rand(void)
+uint32_t hw_rand(void)
 {
     while((RNG->SR & RNG_SR_OREG_LVL(0xF)) == 0) {}; /* Wait until FIFO has a value available */
     return RNG->OR; /* Return next value in FIFO output register */

--- a/IDE/ROWLEY-CROSSWORKS-ARM/user_libc.c
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/user_libc.c
@@ -29,7 +29,7 @@ double current_time(int reset)
     return time;
 }
 
-int custom_rand_generate(void)
+uint32_t custom_rand_generate(void)
 {
     return hw_rand();
 }

--- a/IDE/ROWLEY-CROSSWORKS-ARM/user_settings.h
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/user_settings.h
@@ -18,7 +18,8 @@
 
 /* Custom functions */
 extern int custom_rand_generate(void);
-#define CUSTOM_RAND_GENERATE custom_rand_generate
+#define CUSTOM_RAND_GENERATE  custom_rand_generate
+#define CUSTOM_RAND_TYPE      word32
 #define WOLFSSL_USER_CURRTIME
 
 /* Debugging - Optional */

--- a/IDE/ROWLEY-CROSSWORKS-ARM/wolfssl.hzp
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/wolfssl.hzp
@@ -10,12 +10,14 @@
       project_type="Library" />
     <folder Name="Source Files">
       <configuration Name="Common" filter="c;cpp;cxx;cc;h;s;inc" />
-      <folder
-        Name="wolfcrypt"
-        exclude="*.asm;*.s"
-        filter=""
-        path="../../wolfcrypt"
-        recurse="Yes" />
+      <folder Name="wolfcrypt">
+        <folder Name="benchmark" path="../../wolfcrypt/benchmark" />
+        <folder Name="src" path="../../wolfcrypt/src" />
+        <folder Name="test" path="../../wolfcrypt/test" />
+        <folder Name="user-crypto" path="../../wolfcrypt/user-crypto">
+          <configuration Name="Common" build_exclude_from_build="Yes" />
+        </folder>
+      </folder>
       <folder
         Name="wolfssl"
         exclude="*.asm;*.s"
@@ -24,6 +26,12 @@
         recurse="Yes" />
       <file file_name="user_settings.h" />
       <file file_name="README.md" />
+      <folder
+        Name="source"
+        exclude=""
+        filter=""
+        path="../../src"
+        recurse="No" />
     </folder>
   </project>
   <project Name="test">


### PR DESCRIPTION
Optimizations to improve random number generation performance and provide additional ways to implement custom versions of custom random handlers. Added new "CUSTOM_RAND_TYPE" to define the datatype for the "CUSTOM_RAND_GENERATE" function. Added new "CUSTOM_RAND_GENERATE_SEED" option for anyone who wants to implement their own equivalent "wc_GenerateSeed()" function. Added generic FREESCALE_RNGA and FREESCALE_RNGB options.

Updated the Rowley Crossworks example so it builds due to new user-crypto. Tested and verified new "CUSTOM_RAND_TYPE" using default (8), 16 and 32 bit values on Kinetis K64. Updated example to use 32-bit rand.