### PR TITLE
fix ld exit status error on Big Endian Systems with enable bump

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2110,6 +2110,18 @@ AC_ARG_ENABLE([pwdbased],
 
 if test "$ENABLED_PWDBASED" = "no"
 then
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #ifdef OPENSSL_EXTRA
+    # macro not defined
+    #endif
+    ]])], [ ENABLED_OPENSSLEXTRA="yes" ], [ ENABLED_OPENSSLEXTRA="no" ])
+
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+    #ifdef HAVE_WEBSERVER
+    # macro not defined
+    #endif
+    ]])], [ ENABLED_WEBSERVER="yes" ], [ ENABLED_WEBSERVER="no" ])
+
     if test "$ENABLED_OPENSSLEXTRA" = "yes" || test "$ENABLED_WEBSERVER" = "yes"
     then
         # opensslextra and webserver needs pwdbased


### PR DESCRIPTION
pwdbased was not being defined with bump as bump was not defining "ENABLED_OPENSSLEXTRA" but was adding flag -DOPENSSL_EXTRA to AM_FLAGS. This is my solution to the problem.

I decided to test for each explicitly so as not to leave potential traps for future development. IE my first solution was:

```
    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
    #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
    # macro not defined
    #endif
    ]])], [ ENABLED_OPENSSLEXTRA="yes" ], [ ENABLED_OPENSSLEXTRA="no" ])
```

The problem with that after discussing with Jacob would be that if someone enabled webserver and at some point in the future we have a different check lower in the file for OPENSSLEXTRA but not WEBSERVER. We have just defined the wrong thing. Thus two individual checks rather than just the one.