### PR TITLE
fix link-time error from default autoconf settings with enable bump a…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2111,7 +2111,16 @@ AC_ARG_ENABLE([pwdbased],
 
 if test "$ENABLED_PWDBASED" = "no"
 then
-    if test "$ENABLED_OPENSSLEXTRA" = "yes" || test "$ENABLED_WEBSERVER" = "yes"
+
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+        #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
+        #pwdbased should be enabled
+        #endif
+    ]])], [ pwdbased_enable="yes" ], [ pwdbased_enable="no" ])
+
+    if test "$ENABLED_OPENSSLEXTRA" = "yes" \
+       || test "$ENABLED_WEBSERVER" = "yes" \
+       || test "$pwdbased_enable" = "yes"
     then
         # opensslextra and webserver needs pwdbased
         ENABLED_PWDBASED=yes


### PR DESCRIPTION
…nd disable ecc

Fixes link time error resulting from incomplete autoconf test designed to test if pass word based should be enabled or not. Error occurs when the following conditions are met:

```
(OPENSSL_EXTRA or HAVE_WEBSERVER) is defined
(ENABLED_OPENSSLEXTRA and ENABLED_WEBSERVER) are not defined.
```