### PR TITLE
Make get_shutdown return correct results with stunnel

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -9952,13 +9952,10 @@ void wolfSSL_set_connect_state(WOLFSSL* ssl)
 int wolfSSL_get_shutdown(const WOLFSSL* ssl)
 {
     WOLFSSL_ENTER("wolfSSL_get_shutdown");
-#ifdef HAVE_STUNNEL
-    return (ssl->options.sentNotify << 1) | (ssl->options.closeNotify);
-#else
-    return (ssl->options.isClosed  ||
-            ssl->options.connReset ||
-            ssl->options.sentNotify);
-#endif
+    /* in OpenSSL, SSL_SENT_SHUTDOWN = 1, when closeNotifySent   *
+     * SSL_RECEIVED_SHUTDOWN = 2, from close notify or fatal err */
+    return ((ssl->options.closeNotify||ssl->options.connReset) << 1)
+            | (ssl->options.sentNotify);
 }
 
 


### PR DESCRIPTION
This report fixes a bug when using stunnel with wolfSSL that caused an infinite loop. Problem was due to returning the get_shutdown string backwards. Also standardizes API to OpenSSL's to include connReset as an indicator of SSL_RECEIVED_SHUTDOWN.

See: https://www.openssl.org/docs/manmaster/ssl/SSL_set_shutdown.html