### PR TITLE
Updates for Wind River WORKBENCH/ VxWorks Compatibility

### DIFF
--- a/IDE/WORKBENCH/README.md
+++ b/IDE/WORKBENCH/README.md
@@ -2,40 +2,20 @@
 ####1 Necessary Files if Using VxWorks Simulator
 The following files are required to replicate this build:
 * vxsim\_linux\_1\_0\_2\_2 (directory)
-* Includes
-    * compilers/gnu-4.8.1.5/include/c++/4.8
-    * compilers/gnu-4.8.1.5/include/c++/4.8/i586-wrs-vxworks
-    * compilers/gnu-4.8.1.5/lib/gcc/i586-wrs-vxworks/4.8.1/include
-    * compilers/gnu-4.8.1.5/lib/gcc/i586-wrs-vxworks/4.8.1/include-fixed
-    * vsb\_vxsim\_linux/share/h
-    * vsb\_vxsim\_linux/krnl/h/system
-    * vsb\_vxsim\_linux/krnl/h/public
-    * vsb\_vxsim\_linux/krnl/configlette
-    * vsb\_vxsim\_linux/h
-* usrAppInit.c (should be created when with new VxWorks image)
-    * Include this at the top:
-        #include <wolfssl/wolfcrypt/settings.h>
-        #include <wolfcrypt/test/test.h>
-        #include <wolfssl/ssl.h> /* name change portability layer */
-        #include <wolfssl/test.h>
-        extern int benchmark_test(void* args);
-        extern THREAD\_RETURN WOLFSSL\_THREAD client\_test(void* args);
-        extern THREAD\_RETURN WOLFSSL\_THREAD server\_test(void* args);
-    * Inside main function UsrAppInit (void):
-        func\_args args = { 0 };
-        tcp\_ready ready;
-        InitTcpReady(&ready);
-        args.signal = &ready;
-        benchmark\_test(NULL);
-        wolfcrypt\_test(NULL);
-        /* client\_test(NULL); */
-        /*server\_test(&args);*/
-* usrRtpAppInit.c (should be created when with new VxWorks image)
-    Leave unchanged
-* This project was tested with a pre-built image in the VxWorks distribution
-called vsb\_vxsim\_linux.
+* compilers/gnu-4.8.1.5/include/c++/4.8
+* compilers/gnu-4.8.1.5/include/c++/4.8/i586-wrs-vxworks
+* compilers/gnu-4.8.1.5/lib/gcc/i586-wrs-vxworks/4.8.1/include
+* compilers/gnu-4.8.1.5/lib/gcc/i586-wrs-vxworks/4.8.1/include-fixed
+* vsb\_vxsim\_linux/share/h
+* vsb\_vxsim\_linux/krnl/h/system
+* vsb\_vxsim\_linux/krnl/h/public
+* vsb\_vxsim\_linux/krnl/configlette
+* vsb\_vxsim\_linux/h
 
-####2 Steps
+Note: This project was tested with a pre-built image in the VxWorks distribution
+called vip\_vxsim\_linux\_gnu.
+
+####2 Steps to Add wolfSSL to Workbench Project
 1. Start by creating a new VxWorks image in Workbench by going to File > New >
 Project and then selecting VxWorks Image Project.
 

--- a/IDE/WORKBENCH/README.md
+++ b/IDE/WORKBENCH/README.md
@@ -43,7 +43,7 @@ Highlight EXTRA\_DEFINE. Click Edit and add the following to this line:
     
 6. If using a filesystem and running the wolfCrypt test and benchmark applications, copy the certs folder in \<path\_to\_wolfssl\>/wolfssl to the Wind River Workbench workspace folder. This is where the simulator looks for the filesystem. 
 
-7. If NO\_DEV\_RANDOM is defined in \<path\to\_wolfssl\>wolfssl/wolfcrypt/settings.h inside the
+7. If NO\_DEV\_RANDOM is defined in \<path\_to\_wolfssl\>wolfssl/wolfcrypt/settings.h inside the
 \#ifdef WOLFSSL\_VXWORKS block, a new GenerateSeed() function will need to be defined
 in wolfcrypt/src/random.c.
 
@@ -75,34 +75,45 @@ by adding the following to the usrAppInit() function:
         wolfcrypt_test(&args);
         wolfcrypt_benchmark(&args);
 
-3. Start the simulator and check that all wolfCrypt tests pass.
+3. Start the simulator by clicking the "Connect 'VxWorks Simulator'" button to the right of the "VxWorks Simulator" dropdown. Verify in the terminal at the bottom that all wolfCrypt tests pass.
 
 #####3.2 Example Client
-The wolfSSL example client.c file can be found in wolfssl/examples/client.
+The wolfSSL example client.c file can be found in \<path\_to\_wolfssl\>/wolfssl/examples/client.
 
-1. In usrAppInit.c, inlucde the func\_args as described in the Test Application
+1. Add the following include to usrAppInit.c:
+
+        #include </examples/client/client.h> 
+
+2. In usrAppInit.c, include the func\_args as described in the Test Application
 section, and add a call to the client function:
 
         client_test(&args);
-
-2. Add the /examples/client/client.h header file to the includes at the top of usrAppInit.c.
-
-3. The wolfSSLIP will need to be changed to the IP address to connect to. If using the VxWorks Simulator, localhost will not work. NAT should be selected in the Simulator Connection Advanced setup. To do this, click the dropdown button next to VxWorks Simulator at the top of Workbench and select Open Connection Details. Make sure the correct image file is selected for you project: <Project\_Dir>/default/VxWorks. Then click Advanced and select NAT as the Network Config. Click OK and Apply.
-
-4. If using the example server from within the wolfSSL directory on the host
-machine to connect the client to, configure and make wolfSSL and then run:
-
-        ./examples/server/server -d -b
     
-    The -d option disables peer checks, -b allows for binding to any interface.
+3. The char* host in examples/client/client.c will need to be changed to the IP address to connect to. For example:
 
-5. Start the example client in Workbench.
+    char* host = "192.168.15.1";
+    
+    If using the VxWorks Simulator, localhost will not work. NAT should be selected in the Simulator Connection Advanced setup. To do this, click the dropdown button next to VxWorks Simulator at the top of Workbench and select Open Connection Details. Make sure the correct image file is selected for you project: <Project\_Dir>/default/VxWorks. Then click Advanced and select NAT as the Network Config. Click OK and Apply.
+
+4. There is an example server in \<path\_to\_wolfssl\> that can be used for testing the client. wolfSSL will first need to be built. Follow the instructions [here](https://www.wolfssl.com/wolfSSL/Docs-wolfssl-manual-2-building-wolfssl.html) to do so. See the [wolfSSL manual]( https://wolfssl.com/wolfSSL/Docs-wolfssl-manual-3-getting-started.html) for instructions on setting up the example server. From within \<path\_to\_wolfssl\>/wolfssl, the following command can be used to run the server on the host machine:
+
+    ./examples/server/server -d -b
+
+5. Start the example client in Workbench by following step 3 in section 3.1. 
+
+6. The following output should be expected in the simulator terminal:
+
+    SSL version is TLSv1.2
+    SSL cipher suite is TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    Server response: I hear you fa shizzle!
 
 #####3.3 Example Server
 The example server requires more configuration than the client if using the
 VxWorks simulator.
 
-1. Add the server.h header file to the includes at the top of usrAppInit.c.
+1. Add the following include to usrAppInit.c:
+
+        #include </examples/server/server.h> 
 
 2. In usrAppInit.c, add:
     
@@ -117,7 +128,7 @@ VxWorks simulator.
     dropdown. Choose the corresponding kernel image, typically called
     project/default/VxWorks. Select simnetd from the dropdown and enter
     192.168.200.1 as the IP address. To connect to the server running on the VxWorks Simulator, enter these commands
-    into the host terminal any directory (for Ubuntu 14.04):
+    into the host terminal from any directory (for Ubuntu 14.04):
 
         sudo openvpn --mktun --dev tap0
     
@@ -125,11 +136,17 @@ VxWorks simulator.
 
         sudo vxworks-7/host/x86-linux2/bin/vxsimnetd
     
-    This will start the vxsimnetd application. Leave it open. The IP address to
-    connect to the server is the same as above.
+    This will start the vxsimnetd application. Leave it running in the background. 
 
-4. Start the client on the host machine:
+4. There is an example client in \<path\_to\_wolfssl\>/wolfssl/examples. Again, wolfSSL will first need to be built. Follow the instructions [here](https://www.wolfssl.com/wolfSSL/Docs-wolfssl-manual-2-building-wolfssl.html) to do so. See the [wolfSSL manual]( https://wolfssl.com/wolfSSL/Docs-wolfssl-manual-3-getting-started.html) for instructions on how to set up the client. From within \<path\_to\_wolfssl\>/wolfssl, the following command can be used to run the client on the host machine:
 
-        ./examples/client/client -d
+        ./examples/client/client -h 192.168.200.1 -d
     
     The -d option disables peer checks.
+    
+5. The following output should be expected in the simulator terminal:
+
+    SSL version is TLSv1.2
+    SSL cipher suite is TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    Client message: hello wolfssl!
+

--- a/IDE/WORKBENCH/README.md
+++ b/IDE/WORKBENCH/README.md
@@ -23,8 +23,8 @@ Project and then selecting VxWorks Image Project.
 to the wolfSSL library here. Uncheck everything except the examples, src and 
 wolfcrypt directories. Uncheck the following:
 
-        wolfcrypt/src/aes\_asm.asm
-        wolfcrypt/src/aes\_asm.s
+        wolfcrypt/src/aes_asm.asm
+        wolfcrypt/src/aes_asm.s
         examples/echoclient/
         examples/echoserver/
         wolcrypt/user-crypto

--- a/IDE/WORKBENCH/README.md
+++ b/IDE/WORKBENCH/README.md
@@ -19,7 +19,7 @@ called vip\_vxsim\_linux\_gnu.
 1. Start by creating a new VxWorks image in Workbench by going to File > New >
 Project and then selecting VxWorks Image Project.
 
-2. Right click on the project and go to Import > Filesystem. Choose the path
+2. Right click on the project and go to Import > General > Filesystem. Choose the path
 to the wolfSSL library here. Uncheck everything except the examples, src and 
 wolfcrypt directories.
 In the wolfcrypt/src folder, uncheck aes\_asm.asm and aes\_asm.s.

--- a/IDE/WORKBENCH/README.md
+++ b/IDE/WORKBENCH/README.md
@@ -31,7 +31,7 @@ In the wolfcrypt/src folder, uncheck aes\_asm.asm and aes\_asm.s.
     
     Click ok.
 
-4. In wolfssl/wolfssl/wolfcrypt/settings.h, uncomment #define WOLFSSL_VXWORKS
+4. In \<path\_to\_wolfssl\>/wolfssl/wolfcrypt/settings.h, uncomment #define WOLFSSL_VXWORKS
 
 5. If not using a filesystem, right click on project, go to Properties > 
 Build Properties > Variables.
@@ -39,11 +39,12 @@ Highlight EXTRA\_DEFINE. Click Edit and add the following to this line:
     
         -DUSE_CERT_BUFFERS_2048 -DNO_FILESYSTEM
 
-6. If using a filesystem, copy the certs folder in wolfssl to the Wind River
-Workbench workspace folder. This is where the simulator looks for the filesystem. 
+    USE\_CERT\_BUFFERS is only necessary for the wolfCrypt test and benchmark applications.
+    
+6. If using a filesystem and running the wolfCrypt test and benchmark applications, copy the certs folder in \<path\_to\_wolfssl\>/wolfssl to the Wind River Workbench workspace folder. This is where the simulator looks for the filesystem. 
 
-7. If NO\_\_DEV\_RANDOM remains defined in wolfssl/wolfcrypt/settings.h under
-\#ifdef WOLFSSL\_VXWORKS, a new GenerateSeed() function will need to be defined
+7. If NO\_DEV\_RANDOM is defined in wolfssl/wolfcrypt/settings.h inside the
+\#ifdef WOLFSSL\_VXWORKS block, a new GenerateSeed() function will need to be defined
 in wolfcrypt/src/random.c.
 
 ####3 Testing wolfSSL with VxWorks:
@@ -55,6 +56,7 @@ the cryptographic algorithms in milliseconds.
 1. Include these header files in usrAppInit.c:
        
         #include <wolfcrypt/test/test.h>
+        #include <wolfcrypt/benchmark/benchmark.h>
         #include <wolfssl/ssl.h>
         #include <wolfssl/wolfcrypt/settings.h>
         #include <wolfssl/test.h>

--- a/IDE/WORKBENCH/README.md
+++ b/IDE/WORKBENCH/README.md
@@ -75,7 +75,7 @@ by adding the following to the usrAppInit() function:
         wolfcrypt_test(&args);
         wolfcrypt_benchmark(&args);
 
-3. Start the simulator by clicking the "Connect 'VxWorks Simulator'" button to the right of the "VxWorks Simulator" dropdown. Verify in the terminal at the bottom that all wolfCrypt tests pass.
+3. Start the simulator by clicking the "Connect 'VxWorks Simulator'" button to the right of the "VxWorks Simulator" dropdown. Verify in the simulator terminal that all wolfCrypt tests pass.
 
 #####3.2 Example Client
 The wolfSSL example client.c file can be found in \<path\_to\_wolfssl\>/wolfssl/examples/client.
@@ -91,21 +91,21 @@ section, and add a call to the client function:
     
 3. The char* host in examples/client/client.c will need to be changed to the IP address to connect to. For example:
 
-    char* host = "192.168.15.1";
+        char* host = "192.168.15.1";
     
     If using the VxWorks Simulator, localhost will not work. NAT should be selected in the Simulator Connection Advanced setup. To do this, click the dropdown button next to VxWorks Simulator at the top of Workbench and select Open Connection Details. Make sure the correct image file is selected for you project: <Project\_Dir>/default/VxWorks. Then click Advanced and select NAT as the Network Config. Click OK and Apply.
 
 4. There is an example server in \<path\_to\_wolfssl\> that can be used for testing the client. wolfSSL will first need to be built. Follow the instructions [here](https://www.wolfssl.com/wolfSSL/Docs-wolfssl-manual-2-building-wolfssl.html) to do so. See the [wolfSSL manual]( https://wolfssl.com/wolfSSL/Docs-wolfssl-manual-3-getting-started.html) for instructions on setting up the example server. From within \<path\_to\_wolfssl\>/wolfssl, the following command can be used to run the server on the host machine:
 
-    ./examples/server/server -d -b
+        ./examples/server/server -d -b
 
 5. Start the example client in Workbench by following step 3 in section 3.1. 
 
 6. The following output should be expected in the simulator terminal:
 
-    SSL version is TLSv1.2
-    SSL cipher suite is TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-    Server response: I hear you fa shizzle!
+        SSL version is TLSv1.2
+        SSL cipher suite is TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        Server response: I hear you fa shizzle!
 
 #####3.3 Example Server
 The example server requires more configuration than the client if using the
@@ -146,7 +146,7 @@ VxWorks simulator.
     
 5. The following output should be expected in the simulator terminal:
 
-    SSL version is TLSv1.2
-    SSL cipher suite is TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-    Client message: hello wolfssl!
+        SSL version is TLSv1.2
+        SSL cipher suite is TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        Client message: hello wolfssl!
 

--- a/IDE/WORKBENCH/README.md
+++ b/IDE/WORKBENCH/README.md
@@ -54,7 +54,7 @@ Choose Browse and select the wolfssl directory. Click ok.
 Build Properties > Variables.
 Highlight EXTRA\_DEFINE. Click Edit and add the following to this line:
     
-    -DUSE_CERT_BUFFERS_2048 -DNO_FILESYSTEM
+        -DUSE_CERT_BUFFERS_2048 -DNO_FILESYSTEM
 
 6. If using a filesystem, copy the certs folder in wolfssl to the Wind River
 Workbench workspace folder. This is where the simulator looks for the filesystem. 

--- a/IDE/WORKBENCH/README.md
+++ b/IDE/WORKBENCH/README.md
@@ -24,9 +24,12 @@ to the wolfSSL library here. Uncheck everything except the examples, src and
 wolfcrypt directories.
 In the wolfcrypt/src folder, uncheck aes\_asm.asm and aes\_asm.s.
 
-3. Include the path to the wolfSSL header files, wolfssl/wolfssl:
-To do this, right click the project and go to Properties > Build Properties > Paths.
-Choose Browse and select the wolfssl directory. Click ok.
+3. To include the path to the wolfSSL header files, right click on the project and go to Properties > Build Properties > Paths.
+    Choose Browse and select:
+
+        <path_to_wolfssl>/wolfssl
+    
+    Click ok.
 
 4. In wolfssl/wolfssl/wolfcrypt/settings.h, uncomment #define WOLFSSL_VXWORKS
 

--- a/IDE/WORKBENCH/README.md
+++ b/IDE/WORKBENCH/README.md
@@ -53,7 +53,8 @@ Choose Browse and select the wolfssl directory. Click ok.
 5. If not using a filesystem, right click on project, go to Properties > 
 Build Properties > Variables.
 Highlight EXTRA\_DEFINE. Click Edit and add the following to this line:
-    -DUSE\_CERT\_BUFFERS\_2048 -DNO\_FILESYSTEM
+    
+    -DUSE_CERT_BUFFERS_2048 -DNO_FILESYSTEM
 
 6. If using a filesystem, copy the certs folder in wolfssl to the Wind River
 Workbench workspace folder. This is where the simulator looks for the filesystem. 
@@ -69,6 +70,7 @@ and output the status for each as a success or failure. The benchmark applicatio
 the cryptographic algorithms in milliseconds.
 
 1. Include these header files in usrAppInit.c:
+       
         #include <wolfcrypt/test/test.h>
         #include <wolfssl/ssl.h>
         #include <wolfssl/wolfcrypt/settings.h>
@@ -85,8 +87,8 @@ by adding the following to the usrAppInit() function:
 
         func_args args;
 
-    wolfcrypt_test(&args);
-    wolfcrypt_benchmark(&args);
+        wolfcrypt_test(&args);
+        wolfcrypt_benchmark(&args);
 
 3. Start the simulator and check that all wolfCrypt tests pass.
 
@@ -95,7 +97,8 @@ The wolfSSL example client.c file can be found in wolfssl/examples/client.
 
 1. In usrAppInit.c, inlucde the func\_args as described in the Test Application
 section, and add a call to the client function:
-    client_test(&args);
+
+        client_test(&args);
 
 2. Add the /examples/client/client.h header file to the includes at the top of usrAppInit.c.
 
@@ -103,8 +106,10 @@ section, and add a call to the client function:
 
 4. If using the example server from within the wolfSSL directory on the host
 machine to connect the client to, configure and make wolfSSL and then run:
-    ./examples/server/server -d -b
-The -d option disables peer checks, -b allows for binding to any interface.
+
+        ./examples/server/server -d -b
+    
+    The -d option disables peer checks, -b allows for binding to any interface.
 
 5. Start the example client in Workbench.
 
@@ -123,19 +128,23 @@ VxWorks simulator.
         server_test(&args);
 
 3. Start the server and complete the following:
-Go to "Open Connection Details" under VxWorks Simulator which is in the connections
-dropdown. Choose the corresponding kernel image, typically called
-project/default/VxWorks. Select simnetd from the dropdown and enter
-192.168.200.1 as the IP address.
+    Go to "Open Connection Details" under VxWorks Simulator which is in the connections
+    dropdown. Choose the corresponding kernel image, typically called
+    project/default/VxWorks. Select simnetd from the dropdown and enter
+    192.168.200.1 as the IP address. To connect to the server running on the VxWorks Simulator, enter these commands
+    into the host terminal any directory (for Ubuntu 14.04):
 
-To connect to the server running on the VxWorks Simulator, enter these commands
-into the host terminal any directory (for Ubuntu 14.04):
-    sudo openvpn --mktun --dev tap0
-In Wind River directory:
-    sudo vxworks-7/host/x86-linux2/bin/vxsimnetd
-This will start the vxsimnetd application. Leave it open. The IP address to
-connect to the server is the same as above.
+        sudo openvpn --mktun --dev tap0
+    
+    In Wind River directory:
+
+        sudo vxworks-7/host/x86-linux2/bin/vxsimnetd
+    
+    This will start the vxsimnetd application. Leave it open. The IP address to
+    connect to the server is the same as above.
 
 4. Start the client on the host machine:
-    ./examples/client/client -d
-The -d option disables peer checks.
+
+        ./examples/client/client -d
+    
+    The -d option disables peer checks.

--- a/IDE/WORKBENCH/README.md
+++ b/IDE/WORKBENCH/README.md
@@ -21,13 +21,20 @@ Project and then selecting VxWorks Image Project.
 
 2. Right click on the project and go to Import > General > Filesystem. Choose the path
 to the wolfSSL library here. Uncheck everything except the examples, src and 
-wolfcrypt directories.
-In the wolfcrypt/src folder, uncheck aes\_asm.asm and aes\_asm.s.
+wolfcrypt directories. Uncheck the following:
+
+        wolfcrypt/src/aes\_asm.asm
+        wolfcrypt/src/aes\_asm.s
+        examples/echoclient/
+        examples/echoserver/
+        wolcrypt/user-crypto
+    
+    Leave "Create top level folder" unchecked. Click Finish. 
 
 3. To include the path to the wolfSSL header files, right click on the project and go to Properties > Build Properties > Paths.
     Choose Browse and select:
 
-        <path_to_wolfssl>/wolfssl
+        <path_to_wolfssl>/
     
     Click ok.
 
@@ -40,10 +47,14 @@ Highlight EXTRA\_DEFINE. Click Edit and add the following to this line:
         -DUSE_CERT_BUFFERS_2048 -DNO_FILESYSTEM
 
     USE\_CERT\_BUFFERS is only necessary for the wolfCrypt test and benchmark applications.
-    
-6. If using a filesystem and running the wolfCrypt test and benchmark applications, copy the certs folder in \<path\_to\_wolfssl\>/wolfssl to the Wind River Workbench workspace folder. This is where the simulator looks for the filesystem. 
+        
+6. If using the VxWorks simulator add the following to EXTRA\_DEFINE:
 
-7. If NO\_DEV\_RANDOM is defined in \<path\_to\_wolfssl\>wolfssl/wolfcrypt/settings.h inside the
+        -DVXWORKS_SIM /* only if using the VxWorks simulator */
+
+7. If using a filesystem and running the wolfCrypt test and benchmark applications, copy the certs folder in \<path\_to\_wolfssl\>/wolfssl to the Wind River Workbench workspace folder. This is where the simulator looks for the filesystem. 
+
+8. If NO\_DEV\_RANDOM is defined in \<path\_to\_wolfssl\>wolfssl/wolfcrypt/settings.h inside the
 \#ifdef WOLFSSL\_VXWORKS block, a new GenerateSeed() function will need to be defined
 in wolfcrypt/src/random.c.
 
@@ -53,36 +64,40 @@ The wolfCrypt test application will test each of the cryptographic algorithms
 and output the status for each as a success or failure. The benchmark application will output the runtime of
 the cryptographic algorithms in milliseconds.
 
-1. Include these header files in usrAppInit.c:
+1. Include the following at the top of usrAppInit.c:
        
         #include <wolfcrypt/test/test.h>
-        #include <wolfcrypt/benchmark/benchmark.h>
         #include <wolfssl/ssl.h>
         #include <wolfssl/wolfcrypt/settings.h>
         #include <wolfssl/test.h>
+        extern int benchmark_test(void* args);
 
 2. In usrAppInit.c, make a call to the wolfCrypt test and benchmark applications 
 by adding the following to the usrAppInit() function:
 
         typedef struct func_args {
-            int    argc;
-            char** argv;
-            int    return_code;
-        } func_args;
+	        int    argc;
+	        char** argv;
+	        int    return_code;
+	        tcp_ready* signal;
+	        callback_functions *callbacks;
+	    } func_args;
+	
+	    func_args args;
 
-        func_args args;
+	    wolfcrypt_test(&args);
+	    benchmark_test(&args);
 
-        wolfcrypt_test(&args);
-        wolfcrypt_benchmark(&args);
+3. Right click on the project and select "Build Project".
 
-3. Start the simulator by clicking the "Connect 'VxWorks Simulator'" button to the right of the "VxWorks Simulator" dropdown. Verify in the simulator terminal that all wolfCrypt tests pass.
+4. To run the VxWorks simulator, click the dropdown list next to "VxWorks Simulator" at the top of Workbench and go to "Open Connection Details". Add the correct Kernel Image file. This will be located in ```workspace/<project\_name>/default/vxWorks```. Click Apply. Start the simulator by clicking the green, "Connect 'VxWorks Simulator'" button to the right of the "VxWorks Simulator" dropdown list. Verify in the simulator terminal that all wolfCrypt tests pass.
 
 #####3.2 Example Client
 The wolfSSL example client.c file can be found in \<path\_to\_wolfssl\>/wolfssl/examples/client.
 
 1. Add the following include to usrAppInit.c:
 
-        #include </examples/client/client.h> 
+        #include <examples/client/client.h> 
 
 2. In usrAppInit.c, include the func\_args as described in the Test Application
 section, and add a call to the client function:
@@ -93,15 +108,17 @@ section, and add a call to the client function:
 
         char* host = "192.168.15.1";
     
-    If using the VxWorks Simulator, localhost will not work. NAT should be selected in the Simulator Connection Advanced setup. To do this, click the dropdown button next to VxWorks Simulator at the top of Workbench and select Open Connection Details. Make sure the correct image file is selected for you project: <Project\_Dir>/default/VxWorks. Then click Advanced and select NAT as the Network Config. Click OK and Apply.
+4. Right click on the project and select "Build Project".
 
-4. There is an example server in \<path\_to\_wolfssl\> that can be used for testing the client. wolfSSL will first need to be built. Follow the instructions [here](https://www.wolfssl.com/wolfSSL/Docs-wolfssl-manual-2-building-wolfssl.html) to do so. See the [wolfSSL manual]( https://wolfssl.com/wolfSSL/Docs-wolfssl-manual-3-getting-started.html) for instructions on setting up the example server. From within \<path\_to\_wolfssl\>/wolfssl, the following command can be used to run the server on the host machine:
+5. If using the VxWorks Simulator, localhost will not work. NAT should be selected in the Simulator Connection Advanced setup. To do this, click the dropdown button next to VxWorks Simulator at the top of Workbench and select "Open Connection Details". Make sure the correct kernel image file is selected for you project as stated in section 3.1 step 4. Then click Advanced and select NAT as the Network Config. Click OK and Apply.
+
+6. There is an example server in \<path\_to\_wolfssl\> that can be used for testing the client. wolfSSL will first need to be built. Follow the instructions [here](https://www.wolfssl.com/wolfSSL/Docs-wolfssl-manual-2-building-wolfssl.html) to do so. See the [wolfSSL manual]( https://wolfssl.com/wolfSSL/Docs-wolfssl-manual-3-getting-started.html) for instructions on setting up the example server. From within \<path\_to\_wolfssl\>/wolfssl, the following command can be used to run the server on the host machine:
 
         ./examples/server/server -d -b
 
-5. Start the example client in Workbench by following step 3 in section 3.1. 
+7. Start the example client in Workbench by following step 3 in section 3.1. 
 
-6. The following output should be expected in the simulator terminal:
+8. The following output should be expected in the simulator terminal:
 
         SSL version is TLSv1.2
         SSL cipher suite is TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -109,42 +126,48 @@ section, and add a call to the client function:
 
 #####3.3 Example Server
 The example server requires more configuration than the client if using the
-VxWorks simulator.
+VxWorks simulator. 
+
+Note: The wolfSSL example server and client cannot run at the same time on the VxWorks simulator. Either remove or comment out the ```client_test(&args);``` line. 
 
 1. Add the following include to usrAppInit.c:
 
         #include </examples/server/server.h> 
 
-2. In usrAppInit.c, add:
+2. In usrAppInit.c, after the ```func_args args;``` call, add:
     
-        func_args args = { 0 };
-        tcp_ready ready;
-        InitTcpReady(&ready);
-        args.signal = &ready;
+        tcp_ready ready; 
+	    ready.ready = 0;
+	    ready.port = 0;
+	    args.signal = &ready;
+
         server_test(&args);
 
-3. Start the server and complete the following:
+3. Right click on the project and select "Build Project". 
+
+4. Start the server and complete the following:
     Go to "Open Connection Details" under VxWorks Simulator which is in the connections
-    dropdown. Choose the corresponding kernel image, typically called
-    project/default/VxWorks. Select simnetd from the dropdown and enter
+    dropdown. Follow step 4 of section 3.1 to select the correct kernel image for the simulator. In "Open Connection Details" of the simulator, go to "Advanced...". Select simnetd from the Network Config dropdown and enter
     192.168.200.1 as the IP address. To connect to the server running on the VxWorks Simulator, enter these commands
-    into the host terminal from any directory (for Ubuntu 14.04):
+    into the host machine's terminal from any directory (for Ubuntu 14.04):
 
         sudo openvpn --mktun --dev tap0
     
-    In Wind River directory:
+    Note: openvpn may need to be installed first.
+    
+    In Wind River directory on the host machine:
 
         sudo vxworks-7/host/x86-linux2/bin/vxsimnetd
     
     This will start the vxsimnetd application. Leave it running in the background. 
 
-4. There is an example client in \<path\_to\_wolfssl\>/wolfssl/examples. Again, wolfSSL will first need to be built. Follow the instructions [here](https://www.wolfssl.com/wolfSSL/Docs-wolfssl-manual-2-building-wolfssl.html) to do so. See the [wolfSSL manual]( https://wolfssl.com/wolfSSL/Docs-wolfssl-manual-3-getting-started.html) for instructions on how to set up the client. From within \<path\_to\_wolfssl\>/wolfssl, the following command can be used to run the client on the host machine:
+5. There is an example client in \<path\_to\_wolfssl\>/wolfssl/examples. Again, wolfSSL will first need to be built. Follow the instructions [here](https://www.wolfssl.com/wolfSSL/Docs-wolfssl-manual-2-building-wolfssl.html) to do so. See the [wolfSSL manual]( https://wolfssl.com/wolfSSL/Docs-wolfssl-manual-3-getting-started.html) for instructions on how to set up the client. From within \<path\_to\_wolfssl\>/wolfssl, the following command can be used to run the client on the host machine:
 
         ./examples/client/client -h 192.168.200.1 -d
     
     The -d option disables peer checks.
     
-5. The following output should be expected in the simulator terminal:
+6. The following output should be expected in the simulator terminal:
 
         SSL version is TLSv1.2
         SSL cipher suite is TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384

--- a/IDE/WORKBENCH/README.md
+++ b/IDE/WORKBENCH/README.md
@@ -1,5 +1,5 @@
 ## Wind River Workbench using VxWorks with wolfSSL
-####1 Necessary Files
+####1 Necessary Files if Using VxWorks Simulator
 The following files are required to replicate this build:
 * vxsim\_linux\_1\_0\_2\_2 (directory)
 * Includes

--- a/IDE/WORKBENCH/README.md
+++ b/IDE/WORKBENCH/README.md
@@ -43,7 +43,7 @@ Highlight EXTRA\_DEFINE. Click Edit and add the following to this line:
     
 6. If using a filesystem and running the wolfCrypt test and benchmark applications, copy the certs folder in \<path\_to\_wolfssl\>/wolfssl to the Wind River Workbench workspace folder. This is where the simulator looks for the filesystem. 
 
-7. If NO\_DEV\_RANDOM is defined in wolfssl/wolfcrypt/settings.h inside the
+7. If NO\_DEV\_RANDOM is defined in \<path\to\_wolfssl\>wolfssl/wolfcrypt/settings.h inside the
 \#ifdef WOLFSSL\_VXWORKS block, a new GenerateSeed() function will need to be defined
 in wolfcrypt/src/random.c.
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -314,7 +314,9 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     fdOpenSession(Task_self());
 #endif
 
-#ifndef WOLFSSL_VXWORKS
+#ifdef WOLFSSL_VXWORKS
+    useAnyAddr = 1;
+#else
     while ((ch = mygetopt(argc, argv, "?dbstnNufrRawPIp:v:l:A:c:k:Z:S:oO:D:L:ieB:"))
                          != -1) {
         switch (ch) {

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -503,7 +503,7 @@ static INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
         #elif defined(WOLFSSL_TIRTOS)
             struct hostent* entry = DNSGetHostByName(peer);
         #elif defined(WOLFSSL_VXWORKS)
-            struct hostent* entry = (struct hostent*)hostGetByName(peer);
+            struct hostent* entry = (struct hostent*)hostGetByName((char*)peer);
         #else
             struct hostent* entry = gethostbyname(peer);
         #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -305,6 +305,10 @@
 
 
 #ifdef WOLFSSL_VXWORKS
+    /* VxWorks simulator incorrectly detects building for i386 */
+    #ifdef VXWORKS_SIM
+        #define TFM_NO_ASM
+    #endif
     #define WOLFSSL_HAVE_MIN
     #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT


### PR DESCRIPTION
Files edited:

* ```IDE/WORKBENCH/README```: update after testing with Chris
* ```wolfssl/wolfcrypt/settings.h```: add define for i386 detection issue in VxWorks
* ```wolfssl/test.h```: Remove const warning
* ```examples/server/server.c```: allow VxWorks server to connect to any address (required for using simulator)