### PR TITLE
fprintf to stderr is not ideal for debugging

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17145,7 +17145,9 @@ int wolfSSL_ED25519_verify(const unsigned char *msg, unsigned int msgSz,
     if ((ret = wc_ed25519_verify_msg((byte*)sig, sigSz, msg, msgSz,
                                      &check, &key)) != MP_OKAY) {
         WOLFSSL_MSG("wc_ed25519_verify_msg failed");
-        fprintf(stderr, "err code = %d, sigSz=%d, msgSz=%d\n", ret, sigSz, msgSz);
+        /* Disable until a better solution then fprintf to stderr */
+        /* fprintf(stderr, "err code = %d, sigSz=%d, msgSz=%d\n", ret,
+                                                              sigSz, msgSz); */
     }
     else if (!check)
         WOLFSSL_MSG("wc_ed25519_verify_msg failed (signature invalid)");


### PR DESCRIPTION
"fprintf  to stderr" ouputs information directly to the console and is not an ideal way to handle debugging in a distribution. I will begin seeking a solution to all the formatted fprintf strings currently in src/ssl.c however as a temporary solution I would like to disable just this one for openssh testing.

openSSH runs tests to ensure that this method fails as expected. Whenever running unit tests with wolfssl users will see several hundred lines print out with this error which misleadingly suggests there is something failing when in fact the test:

ASSERT_INT_NE(sshkey_verify(bad, sig, len, d, l, 0), 0);

is supposed to correctly return a non-zero value and we do not want to see this line printed for each failure test.