### PR TITLE
Issue #213: AES fails with Freescale (mm)CAU

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -2166,7 +2166,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         {
             XMEMCPY(temp_block, in + offset, AES_BLOCK_SIZE);
 
-            wc_AesEncrypt(aes, in + offset, out + offset);
+            wc_AesDecrypt(aes, in + offset, out + offset);
             
             /* XOR block with IV for CBC */
             for (i = 0; i < AES_BLOCK_SIZE; i++)


### PR DESCRIPTION
An "encrypt" got flipped to a "decrypt." Fixes #213.