### PR TITLE
Issue #215: Signature module uses old RNG

### DIFF
--- a/wolfcrypt/src/signature.c
+++ b/wolfcrypt/src/signature.c
@@ -175,7 +175,7 @@ int wc_SignatureGenerate(
     enum wc_HashType hash_type, enum wc_SignatureType sig_type,
     const byte* data, word32 data_len,
     byte* sig, word32 *sig_len,
-    const void* key, word32 key_len, RNG* rng)
+    const void* key, word32 key_len, WC_RNG* rng)
 {
     int ret, hash_len;
     byte *hash_data = NULL;

--- a/wolfssl/wolfcrypt/signature.h
+++ b/wolfssl/wolfcrypt/signature.h
@@ -54,7 +54,7 @@ WOLFSSL_API int wc_SignatureGenerate(
     const byte* data, word32 data_len,
     byte* sig, word32 *sig_len,
     const void* key, word32 key_len,
-    RNG* rng);
+    WC_RNG* rng);
 
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
 Use the new WC_RNG construct instead in order to prevent conflicts with board support packages.

Fixes #215.