### PR TITLE
Add in stub functions for opensslv1.0.1 w/ stunnel and lighttpd

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16406,6 +16406,23 @@ void* wolfSSL_get_ex_data(const WOLFSSL* ssl, int idx)
 
 
 #if defined(HAVE_LIGHTY) || defined(HAVE_STUNNEL)
+char * wolf_OBJ_nid2ln(int n) {
+    (void)n;
+    WOLFSSL_ENTER("wolf_OBJ_nid2ln");
+    WOLFSSL_STUB("wolf_OBJ_nid2ln");
+
+    return NULL;
+}
+
+int wolf_OBJ_txt2nid(const char* s) {
+    (void)s;
+    WOLFSSL_ENTER("wolf_OBJ_txt2nid");
+    WOLFSSL_STUB("wolf_OBJ_txt2nid");
+
+    return 0;
+}
+
+
 WOLFSSL_BIO *wolfSSL_BIO_new_file(const char *filename, const char *mode) {
     (void)filename;
     (void)mode;
@@ -16486,6 +16503,13 @@ long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL_DH* dh)
 
 /* stunnel compatability functions*/
 #if defined(OPENSSL_EXTRA) && defined(HAVE_STUNNEL)
+void WOLFSSL_ERR_remove_thread_state(void* pid)
+{
+    (void) pid;
+    return;
+}
+
+
 int wolfSSL_SESSION_set_ex_data(WOLFSSL_SESSION* session, int idx, void* data)
 {
     WOLFSSL_ENTER("wolfSSL_SESSION_set_ex_data");
@@ -16549,6 +16573,19 @@ WOLFSSL_DH *wolfSSL_DH_generate_parameters(int prime_len, int generator,
     WOLFSSL_STUB("wolfSSL_DH_generate_parameters");
 
     return NULL;
+}
+
+int wolfSSL_DH_generate_parameters_ex(WOLFSSL_DH* dh, int prime_len, int generator,
+                           void (*callback) (int, int, void *))
+{
+    (void)prime_len;
+    (void)generator;
+    (void)callback;
+    (void)dh;
+    WOLFSSL_ENTER("wolfSSL_DH_generate_parameters_ex");
+    WOLFSSL_STUB("wolfSSL_DH_generate_parameters_ex");
+
+    return -1;
 }
 
 
@@ -16849,6 +16886,52 @@ void wolfSSL_CTX_set_servername_arg(WOLFSSL_CTX* ctx, void* arg)
     if (ctx)
         ctx->sniRecvCbArg = arg;
 }
+
+
+long wolfSSL_CTX_clear_options(WOLFSSL_CTX* ctx, long opt)
+{
+    WOLFSSL_ENTER("SSL_CTX_clear_options");
+    WOLFSSL_STUB("SSL_CTX_clear_options");
+    (void)ctx;
+    (void)opt;
+    return opt;
+}
+
+void wolfSSL_THREADID_set_callback(void(*threadid_func)(void*))
+{
+    WOLFSSL_ENTER("wolfSSL_THREADID_set_callback");
+    WOLFSSL_STUB("wolfSSL_THREADID_set_callback");
+    (void)threadid_func;
+    return;
+}
+
+void wolfSSL_THREADID_set_numeric(void* id, unsigned long val)
+{
+    WOLFSSL_ENTER("wolfSSL_THREADID_set_numeric");
+    WOLFSSL_STUB("wolfSSL_THREADID_set_numeric");
+    (void)id;
+    (void)val;
+    return;
+}
+
+
+WOLFSSL_X509* wolfSSL_X509_STORE_get1_certs(WOLFSSL_X509_STORE_CTX* ctx,
+                                                WOLFSSL_X509_NAME* name)
+{
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_get1_certs");
+    WOLFSSL_STUB("wolfSSL_X509_STORE_get1_certs");
+    (void)ctx;
+    (void)name;
+    return NULL;
+}
+
+void wolfSSL_sk_X509_pop_free(STACK_OF(WOLFSSL_X509)* sk, void f (WOLFSSL_X509*)){
+    (void) sk;
+    (void) f;
+    WOLFSSL_ENTER("wolfSSL_sk_X509_pop_free");
+    WOLFSSL_STUB("wolfSSL_sk_X509_pop_free");
+}
+
 #endif /* OPENSSL_EXTRA and HAVE_STUNNEL */
 
 #if defined(OPENSSL_EXTRA) && defined(HAVE_CURVE25519)

--- a/wolfssl/openssl/crypto.h
+++ b/wolfssl/openssl/crypto.h
@@ -14,6 +14,8 @@
 WOLFSSL_API const char*   wolfSSLeay_version(int type);
 WOLFSSL_API unsigned long wolfSSLeay(void);
 
+#define CRYPTO_THREADID void
+
 #define SSLeay_version wolfSSLeay_version
 #define SSLeay wolfSSLeay
 
@@ -28,6 +30,8 @@ WOLFSSL_API unsigned long wolfSSLeay(void);
 typedef struct CRYPTO_EX_DATA            CRYPTO_EX_DATA;
 typedef void (CRYPTO_free_func)(void*parent, void*ptr, CRYPTO_EX_DATA *ad, int idx,
         long argl, void* argp);
+#define CRYPTO_THREADID_set_callback wolfSSL_THREADID_set_callback
+#define CRYPTO_THREADID_set_numeric wolfSSL_THREADID_set_numeric
 #endif /* HAVE_STUNNEL */
 
 #endif /* header */

--- a/wolfssl/openssl/dh.h
+++ b/wolfssl/openssl/dh.h
@@ -49,6 +49,7 @@ typedef WOLFSSL_DH DH;
 #endif
 
 #ifdef HAVE_STUNNEL
-#define DH_generate_parameters wolfSSL_DH_generate_parameters
+#define DH_generate_parameters    wolfSSL_DH_generate_parameters
+#define DH_generate_parameters_ex wolfSSL_DH_generate_parameters_ex
 #endif /* HAVE_STUNNEL */
 #endif /* header */

--- a/wolfssl/openssl/opensslv.h
+++ b/wolfssl/openssl/opensslv.h
@@ -8,7 +8,7 @@
 #if defined(HAVE_STUNNEL) || defined(HAVE_LIGHTY)
      /* version number can be increased for Lighty after compatibility for ECDH
         is added */
-     #define OPENSSL_VERSION_NUMBER 0x0090700fL
+     #define OPENSSL_VERSION_NUMBER 0x10001000L
 #else
      #define OPENSSL_VERSION_NUMBER 0x0090810fL
 #endif

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -431,6 +431,8 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 
 #if defined(HAVE_STUNNEL) || defined(HAVE_LIGHTY)
 
+#define OBJ_nid2ln wolf_OBJ_nid2ln
+#define OBJ_txt2nid wolf_OBJ_txt2nid
 #define PEM_read_bio_DHparams wolfSSL_PEM_read_bio_DHparams
 #define PEM_write_bio_X509 PEM_write_bio_WOLFSSL_X509
 #define SSL_CTX_set_tmp_dh wolfSSL_CTX_set_tmp_dh
@@ -477,6 +479,8 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 #define SSL_SESSION_get_id               wolfSSL_SESSION_get_id
 #define CRYPTO_dynlock_value             WOLFSSL_dynlock_value
 typedef WOLFSSL_ASN1_BIT_STRING    ASN1_BIT_STRING;
+#define X509_STORE_get1_certs            wolfSSL_X509_STORE_get1_certs
+#define sk_X509_pop_free                 wolfSSL_sk_X509_pop_free
 
 #define SSL_TLSEXT_ERR_OK                    0
 #define SSL_TLSEXT_ERR_ALERT_FATAL           alert_fatal
@@ -492,6 +496,8 @@ typedef WOLFSSL_ASN1_BIT_STRING    ASN1_BIT_STRING;
 
 #define PSK_MAX_PSK_LEN                      256
 #define PSK_MAX_IDENTITY_LEN                 128
+#define ERR_remove_thread_state WOLFSSL_ERR_remove_thread_state
+#define SSL_CTX_clear_options wolfSSL_CTX_clear_options
 
 
 #endif /* HAVE_STUNNEL */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1620,6 +1620,8 @@ WOLFSSL_API STACK_OF(WOLFSSL_X509_NAME) *wolfSSL_dup_CA_list( STACK_OF(WOLFSSL_X
 
 #if defined(HAVE_STUNNEL) || defined(HAVE_LIGHTY)
 
+WOLFSSL_API char * wolf_OBJ_nid2ln(int n);
+WOLFSSL_API int wolf_OBJ_txt2nid(const char *sn);
 WOLFSSL_API WOLFSSL_BIO* wolfSSL_BIO_new_file(const char *filename, const char *mode);
 WOLFSSL_API long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX*, WOLFSSL_DH*);
 WOLFSSL_API WOLFSSL_DH *wolfSSL_PEM_read_bio_DHparams(WOLFSSL_BIO *bp,
@@ -1642,6 +1644,9 @@ WOLFSSL_API int wolfSSL_CRYPTO_set_mem_ex_functions(void *(*m) (size_t, const ch
 
 WOLFSSL_API WOLFSSL_DH *wolfSSL_DH_generate_parameters(int prime_len, int generator,
     void (*callback) (int, int, void *), void *cb_arg);
+
+WOLFSSL_API int wolfSSL_DH_generate_parameters_ex(WOLFSSL_DH*, int, int,
+                           void (*callback) (int, int, void *));
 
 WOLFSSL_API void wolfSSL_ERR_load_crypto_strings(void);
 
@@ -1708,6 +1713,19 @@ WOLFSSL_API void wolfSSL_CTX_set_servername_callback(WOLFSSL_CTX *,
         CallbackSniRecv);
 
 WOLFSSL_API void wolfSSL_CTX_set_servername_arg(WOLFSSL_CTX *, void*);
+
+WOLFSSL_API void WOLFSSL_ERR_remove_thread_state(void*);
+
+WOLFSSL_API long wolfSSL_CTX_clear_options(WOLFSSL_CTX*, long);
+
+WOLFSSL_API void wolfSSL_THREADID_set_callback(void (*threadid_func)(void*));
+
+WOLFSSL_API void wolfSSL_THREADID_set_numeric(void* id, unsigned long val);
+
+WOLFSSL_API WOLFSSL_X509* wolfSSL_X509_STORE_get1_certs(WOLFSSL_X509_STORE_CTX*,
+                                                        WOLFSSL_X509_NAME*);
+
+WOLFSSL_API void wolfSSL_sk_X509_pop_free(STACK_OF(WOLFSSL_X509)* sk, void f (WOLFSSL_X509*));
 #endif /* HAVE_STUNNEL */
 
 #ifdef WOLFSSL_JNI


### PR DESCRIPTION
This commit adds the necessary stub functions for opensslv1.0.1 support with lighttpd and stunnel, and increases the openssl supported version for these two builds.