### PR TITLE
add the Windows object ordering tags to wolfCrypt first and last sources

### DIFF
--- a/ctaocrypt/src/wolfcrypt_first.c
+++ b/ctaocrypt/src/wolfcrypt_first.c
@@ -30,6 +30,12 @@
 
 #ifdef HAVE_FIPS
 
+#ifdef USE_WINDOWS_API
+    #pragma code_seg(".fipsA$a")
+    #pragma const_seg(".fipsB$a")
+#endif
+
+
 /* read only start address */
 const unsigned int wolfCrypt_FIPS_ro_start[] =
 { 0x1a2b3c4d, 0x00000001 };

--- a/ctaocrypt/src/wolfcrypt_last.c
+++ b/ctaocrypt/src/wolfcrypt_last.c
@@ -30,6 +30,12 @@
 
 #ifdef HAVE_FIPS
 
+#ifdef USE_WINDOWS_API
+    #pragma code_seg(".fipsA$l")
+    #pragma const_seg(".fipsB$l")
+#endif
+
+
 /* last function of text/code segment */
 int wolfCrypt_FIPS_last(void);
 int wolfCrypt_FIPS_last(void)


### PR DESCRIPTION
These pragmas are used to force the ordering of objects in the linked executable. These were missing.