### PR TITLE
fix LowResTimer on Microchip ports

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2746,7 +2746,7 @@ ProtocolVersion MakeDTLSv1_2(void)
 
     word32 LowResTimer(void)
     {
-        return (word32) TickGet();
+        return (word32) (TickGet() / TICKS_PER_SECOND);
     }
 
 
@@ -2758,14 +2758,15 @@ ProtocolVersion MakeDTLSv1_2(void)
 
         word32 LowResTimer(void)
         {
-            return (word32) SYS_TMR_TickCountGet();
+            return (word32) (SYS_TMR_TickCountGet() /
+                             SYS_TMR_TickCounterFrequencyGet());
         }
 
     #else
 
         word32 LowResTimer(void)
         {
-            return (word32) SYS_TICK_Get();
+            return (word32) (SYS_TICK_Get() / SYS_TICK_TicksPerSecondGet());
         }
 
     #endif


### PR DESCRIPTION
Microchip ports were using ticks for LowResTimer(), but to return seconds need to be divided by number of ticks per second.

This will fix session cache timeout functionality on Microchip TCP/IPv5, MLA, and Harmony ports.