### PR TITLE
accounts for assumptions with external ocsp stapling test

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -743,6 +743,16 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             done = 1;
         #endif
 
+        /* www.globalsign.com does not respond to ipv6 ocsp requests */
+        #if defined(TEST_IPV6) && defined(HAVE_OCSP)
+            done = 1;
+        #endif
+
+        /* www.globalsign.com has limited supported cipher suites */
+        #if defined(NO_AES) && defined(HAVE_OCSP)
+            done = 1;
+        #endif
+
         #ifndef NO_PSK
             done = 1;
         #endif


### PR DESCRIPTION
I will put it on my to-do list to locate an ipv6 enabled ocsp responder that offers additional ciphers for testing after the next release is out.