### PR TITLE
Fix cases that were not detected in Jenkins

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17053,6 +17053,10 @@ int wolfSSL_EC25519_generate_key(unsigned char *priv, unsigned int *privSz,
 {
 #ifndef WOLFSSL_KEY_GEN
     WOLFSSL_MSG("No Key Gen built in");
+    (void) priv;
+    (void) privSz;
+    (void) pub;
+    (void) pubSz;
     return SSL_FAILURE;
 #else /* WOLFSSL_KEY_GEN */
     int ret = SSL_FAILURE;
@@ -17127,6 +17131,12 @@ int wolfSSL_EC25519_shared_key(unsigned char *shared, unsigned int *sharedSz,
 {
 #ifndef WOLFSSL_KEY_GEN
     WOLFSSL_MSG("No Key Gen built in");
+    (void) shared;
+    (void) sharedSz;
+    (void) priv;
+    (void) privSz;
+    (void) pub;
+    (void) pubSz;
     return SSL_FAILURE;
 #else /* WOLFSSL_KEY_GEN */
     int ret = SSL_FAILURE;


### PR DESCRIPTION
Related to: https://github.com/wolfSSL/wolfssl/commit/6a56a53545eec545092830641d3129be6c2035b5

added the following configure options to jenkins and implemented the same fixes for both cases as done previously for opensslx and ed25519:
--enable-opensslextra --enable-curve25519
--enable-opensslextra --enable-curve25519=small