### PR TITLE
compiler warning about myStack use in unique environment

### DIFF
--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1374,7 +1374,7 @@ typedef THREAD_RETURN WOLFSSL_THREAD (*thread_func)(void* args);
 static INLINE void StackSizeCheck(func_args* args, thread_func tf)
 {
     int            ret, i, used;
-    unsigned char* myStack;
+    unsigned char* myStack = NULL;
     int            stackSize = 1024*128;
     pthread_attr_t myAttr;
     pthread_t      threadId;

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1374,7 +1374,7 @@ typedef THREAD_RETURN WOLFSSL_THREAD (*thread_func)(void* args);
 static INLINE void StackSizeCheck(func_args* args, thread_func tf)
 {
     int            ret, i, used;
-    unsigned char* myStack = NULL;
+    unsigned char* myStack;
     int            stackSize = 1024*128;
     pthread_attr_t myAttr;
     pthread_t      threadId;
@@ -1385,13 +1385,10 @@ static INLINE void StackSizeCheck(func_args* args, thread_func tf)
 #endif
 
     ret = posix_memalign((void**)&myStack, sysconf(_SC_PAGESIZE), stackSize);
-    if (ret != 0)
+    if (ret != 0 || myStack == NULL)
         err_sys("posix_memalign failed\n");
 
     XMEMSET(myStack, 0x01, stackSize);
-
-    if (myStack == NULL)
-        err_sys("Failed to initialize myStack");
 
     ret = pthread_attr_init(&myAttr);
     if (ret != 0)

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1374,7 +1374,7 @@ typedef THREAD_RETURN WOLFSSL_THREAD (*thread_func)(void* args);
 static INLINE void StackSizeCheck(func_args* args, thread_func tf)
 {
     int            ret, i, used;
-    unsigned char* myStack;
+    unsigned char* myStack = NULL;
     int            stackSize = 1024*128;
     pthread_attr_t myAttr;
     pthread_t      threadId;
@@ -1388,7 +1388,10 @@ static INLINE void StackSizeCheck(func_args* args, thread_func tf)
     if (ret != 0)
         err_sys("posix_memalign failed\n");
 
-    memset(myStack, 0x01, stackSize);
+    XMEMSET(myStack, 0x01, stackSize);
+
+    if (myStack == NULL)
+        err_sys("Failed to initialize myStack");
 
     ret = pthread_attr_init(&myAttr);
     if (ret != 0)


### PR DESCRIPTION
changed ```memset``` to ```XMEMSET``` for portability and security purposes

produced in the following environment:

gcc version 4.9.3 (Ubuntu 4.9.3-8ubuntu2~14.04)
on a 32-bit Big Endian Platform running Ubuntu 14.04.3 LTS for powerPC

solution: initialize to NULL. Check after setting all memory blocks beyond the pointer to point at 0x01 instead of 0x0. Exit with err_sys if it is still NULL.



