### PR TITLE
avoid unused variable warnings

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1519,6 +1519,11 @@ void InitSuites(Suites* suites, ProtocolVersion pv, word16 haveRSA,
     }
 #endif
 
+    /* account for  unused variable warnings ifdef WOLFSSL_DTLS  */
+#ifdef WOLFSSL_DTLS
+    (void) dtls;
+    (void) tls;
+#endif
     suites->suiteSz = idx;
 
     InitSuitesHashSigAlgo(suites, haveECDSAsig, haveRSAsig, 0);
@@ -15438,7 +15443,7 @@ int DoSessionTicket(WOLFSSL* ssl,
                 #error "DTLS needs either SHA or SHA-256"
             #endif /* NO_SHA && NO_SHA256 */
 
-            #ifndef NO_SHA
+            #if !defined(NO_SHA) && defined(NO_SHA256)
                 cookieType = SHA;
                 cookieSz = SHA_DIGEST_SIZE;
             #endif /* NO_SHA */

--- a/src/internal.c
+++ b/src/internal.c
@@ -829,12 +829,12 @@ void InitSuites(Suites* suites, ProtocolVersion pv, word16 haveRSA,
     if (pv.major == DTLS_MAJOR) {
         dtls   = 1;
         tls    = 1;
-        tls1_2 = pv.minor <= DTLSv1_2_MINOR;
-    }
-#endif
         /* May be dead assignments dependant upon configuration */
         (void) dtls;
         (void) tls;
+        tls1_2 = pv.minor <= DTLSv1_2_MINOR;
+    }
+#endif
 
 #ifdef HAVE_RENEGOTIATION_INDICATION
     if (side == WOLFSSL_CLIENT_END) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -832,6 +832,9 @@ void InitSuites(Suites* suites, ProtocolVersion pv, word16 haveRSA,
         tls1_2 = pv.minor <= DTLSv1_2_MINOR;
     }
 #endif
+        /* May be dead assignments dependant upon configuration */
+        (void) dtls;
+        (void) tls;
 
 #ifdef HAVE_RENEGOTIATION_INDICATION
     if (side == WOLFSSL_CLIENT_END) {
@@ -1519,11 +1522,6 @@ void InitSuites(Suites* suites, ProtocolVersion pv, word16 haveRSA,
     }
 #endif
 
-    /* account for  unused variable warnings ifdef WOLFSSL_DTLS  */
-#ifdef WOLFSSL_DTLS
-    (void) dtls;
-    (void) tls;
-#endif
     suites->suiteSz = idx;
 
     InitSuitesHashSigAlgo(suites, haveECDSAsig, haveRSAsig, 0);


### PR DESCRIPTION
scan-build detected possible configuration where dtls and tls may not be read if configured with dtls.

Solution for first warning: cast to void pointer after all checks and before leaving the function.
Solution second warning: do not assign value in the case where it will be re-assigned without having been used. 