### PR TITLE
Avoid unused variable warnings with dead store in AES_GCM_decrypt

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -3145,6 +3145,12 @@ static int AES_GCM_decrypt(const unsigned char *in,
         tmp4 = _mm_shuffle_epi8(tmp4, BSWAP_MASK);
     }
 
+    /* Acknowledge the dead store and continue */
+    (void) tmp1;
+    (void) tmp2;
+    (void) tmp3;
+    (void) tmp4;
+
     for (k = i*4; k < nbytes/16; k++) {
         tmp1 = _mm_shuffle_epi8(ctr1, BSWAP_EPI64);
         ctr1 = _mm_add_epi32(ctr1, ONE);


### PR DESCRIPTION
Assigning to John for review beause of commit: https://github.com/wolfSSL/wolfssl/commit/f8aeac608c2a53e5476b16d11fe937dad6cd1ea8