### PR TITLE
check err after set

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4192,7 +4192,8 @@ static int accel_fp_mul(int idx, mp_int* k, ecc_point *R, mp_int* modulus,
    }
 
    if (err == MP_OKAY) {
-      z = 0;
+      z = 0;    /* mp_to_unsigned_bin != MP_OKAY z will be declared/not set */
+      (void) z; /* Acknowledge the unused assignment */
       ForceZero(kb, KB_SIZE);
       /* map R back from projective space */
       if (map) {
@@ -4447,6 +4448,9 @@ static int accel_fp_mul2add(int idx1, int idx2,
    XFREE(kb[0], NULL, DYNAMIC_TYPE_TMP_BUFFER);
    XFREE(kb[1], NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
+
+    if (err != MP_OKAY)
+        return err;
 
 #undef KB_SIZE
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4449,7 +4449,7 @@ static int accel_fp_mul2add(int idx1, int idx2,
    XFREE(kb[1], NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
-    #undef KB_SIZE
+#undef KB_SIZE
 
     if (err != MP_OKAY)
         return err;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4449,10 +4449,10 @@ static int accel_fp_mul2add(int idx1, int idx2,
    XFREE(kb[1], NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
+    #undef KB_SIZE
+
     if (err != MP_OKAY)
         return err;
-
-#undef KB_SIZE
 
    return ecc_map(R, modulus, mp);
 }


### PR DESCRIPTION
Acknowledge an unused assignment in the case z is set to 0 to avoid a declared/unused variable warning.

err was being set in accel_fp_mul2add but not checked after breaking out. Added a check for the case there is an error.