### PR TITLE
system read returns ssize_t, cast to int

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -695,7 +695,7 @@ static void* DoMonitor(void* arg)
             break;
         }
 
-        length = read(notifyFd, buff, 8192);
+        length = (int) read(notifyFd, buff, 8192);
         if (length < 0) {
             WOLFSSL_MSG("notify read problem, continue");
             continue;


### PR DESCRIPTION
    SYNOPSIS
       #include <unistd.h>

       ssize_t read(int fd, void *buf, size_t count);

caught by: Ubuntu clang version 3.4-1ubuntu3 (tags/RELEASE_34/final) (based on LLVM 3.4)

with configure option: --enable-jni