### PR TITLE
asm.c time cleanup and io.c include cleanup

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -130,16 +130,6 @@
     #define USE_WOLF_TM
     #define USE_WOLF_TIME_T
 
-    /* forward declaration */
-    extern time_t XTIME(time_t * timer);
-
-    #ifdef STACK_TRAP
-        /* for stack trap tracking, don't call os gmtime on OS X/linux,
-           uses a lot of stack spce */
-        extern time_t time(time_t * timer);
-        #define XTIME(tl)  time((tl))
-    #endif /* STACK_TRAP */
-
 #elif defined(TIME_OVERRIDES)
     /* user would like to override time() and gmtime() functionality */
     #ifndef HAVE_TIME_T_TYPE
@@ -148,10 +138,6 @@
     #ifndef HAVE_TM_TYPE
         #define USE_WOLF_TM
     #endif
-
-    /* forward declarations */
-    extern time_t XTIME(time_t * timer);
-    extern struct tm* XGMTIME(const time_t* timer, struct tm* tmp);
     #define NEED_TMP_TIME
 
 #elif defined(IDIRECT_DEV_TIME)
@@ -189,6 +175,7 @@
     #define XVALIDATE_DATE(d, f, t) ValidateDate((d), (f), (t))
 #endif
 
+/* wolf struct tm and time_t */
 #if defined(USE_WOLF_TM)
     struct tm {
         int  tm_sec;     /* seconds after the minute [0-60] */
@@ -206,6 +193,22 @@
 #endif /* USE_WOLF_TM */
 #if defined(USE_WOLF_TIME_T)
     typedef long time_t;
+#endif
+
+/* forward declarations */
+#if defined(USER_TIME)
+    extern time_t XTIME(time_t * timer);
+
+    #ifdef STACK_TRAP
+        /* for stack trap tracking, don't call os gmtime on OS X/linux,
+           uses a lot of stack spce */
+        extern time_t time(time_t * timer);
+        #define XTIME(tl)  time((tl))
+    #endif /* STACK_TRAP */
+
+#elif defined(TIME_OVERRIDES)
+    extern time_t XTIME(time_t * timer);
+    extern struct tm* XGMTIME(const time_t* timer, struct tm* tmp);
 #endif
 
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -112,6 +112,7 @@
 #elif defined(MICROCHIP_TCPIP_V5) || defined(MICROCHIP_TCPIP)
     #include <time.h>
     #define XTIME(t1)       pic32_time((t1))
+    #define XGMTIME(c, t)   gmtime((c))
 
 #elif defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
     #define XTIME(t1)       mqx_time((t1))
@@ -120,6 +121,7 @@
 #elif defined(FREESCALE_KSDK_BM) || defined(FREESCALE_FREE_RTOS)
     #include <time.h>
     #define XTIME(t1)       ksdk_time((t1))
+    #define XGMTIME(c, t)   gmtime((c))
 
 #elif defined(USER_TIME)
     /* user time, and gmtime compatible functions, there is a gmtime
@@ -145,6 +147,7 @@
     in place of time() from <time.h> */
     #include <time.h>
     #define XTIME(t1)       idirect_time((t1))
+    #define XGMTIME(c, t)   gmtime((c))
 
 #elif defined(_WIN32_WCE)
     #include <windows.h>
@@ -163,11 +166,11 @@
     #define XTIME(tl)       time((tl))
 #endif
 #if !defined(XGMTIME) && !defined(TIME_OVERRIDES)
-    #ifdef HAVE_GMTIME_R
+    #if defined(WOLFSSL_GMTIME) || !defined(HAVE_GMTIME_R)
+        #define XGMTIME(c, t)   gmtime((c))
+    #else
         #define XGMTIME(c, t)   gmtime_r((c), (t))
         #define NEED_TMP_TIME
-    #else
-        #define XGMTIME(c, t)   gmtime((c))
     #endif
 #endif
 #if !defined(XVALIDATE_DATE) && !defined(HAVE_VALIDATE_DATE)
@@ -197,6 +200,7 @@
 
 /* forward declarations */
 #if defined(USER_TIME)
+    struct tm* gmtime(const time_t* timer);
     extern time_t XTIME(time_t * timer);
 
     #ifdef STACK_TRAP


### PR DESCRIPTION
Cleanup of the time macros in asn.c to allow expanded use of wolf "struct tm", "time_t" and "gmtime". Cleanup of the io.c socket includes for clarity. Cleanup trailing spaces in io.c and asn.c.