### PR TITLE
help out clang static analyzer

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -454,6 +454,7 @@ static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
         #endif
         return MEMORY_E;
     }
+    XMEMSET(dbMask, 0, pkcsBlockLen - hLen - 1); /* help static analyzer */
 
     ret = wc_MGF(mgf, seed, hLen, dbMask, pkcsBlockLen - hLen - 1);
     if (ret != 0) {


### PR DESCRIPTION
Clang Static Analyzer warning with --disable-memory (use malloc instead of wolfSSL function)

Three main conditions for array to contain garbage.
1) was never set
2) is set to garbage
3) is reading outside of array

Demonstrating it is not garbage
1) * in function wc_MGF1 outSz is equal to pkcsBlockLen - hLen - 1 which is the size of array malloced
    * out byte pointer is the starting index of buffer dbMask
    * idx is used for the index of out buffer being set
    * in function wc_MGF1 a do while loop continues till idx >= outSz and idx is only incremented each time out buffer is set to an index of tmp

2) * each index of dbMask gets set to a value from tmp array in function wc_MGF1
    * tmp contains the digest from wc_Hash which is of length hLen
    * a for loop increments the index used to get memory from tmp for 0 to hLen and stores it in dbMask then counter is increased and new digest is retrieved

3) * dbMask index of i is accessed during static analyzer warning
    * in while loop i starts at 0 and has conditional to be less than pkcsBlockLen - hLen -1 which is size of malloced buffer
   * i will never be less than 0 and never larger than buffer size at point of warning

In conclusion each value for the array of dbMask is set to a non garbage value. The only instance of not being set is when an error is hit, and if that is the case than an error code would be returned for function wc_MGF before reaching the point in code that the warning is at. To help out the static analyzer an XMEMSET to 0 for the size of the buffer dbMask is used.