### PR TITLE
fix header recursion with wc_port.h and types.h

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -23,8 +23,6 @@
 #ifndef WOLF_CRYPT_PORT_H
 #define WOLF_CRYPT_PORT_H
 
-#include <wolfssl/wolfcrypt/types.h>
-
 #ifdef __cplusplus
     extern "C" {
 #endif


### PR DESCRIPTION
Fixes header recursion issue from Coverity Scan.  Tested this on OSX and Linux with normal and CyaSSL / CTaoCrypt compatibility layer.