### PR TITLE
fix recursive include in wc_port.h

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -23,7 +23,7 @@
 #ifndef WOLF_CRYPT_PORT_H
 #define WOLF_CRYPT_PORT_H
 
-#include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/visibility.h>
 
 #ifdef __cplusplus
     extern "C" {


### PR DESCRIPTION
Fixes Coverity scan issue for recursive header inclusion of wc_port.h:

wc_port.h -> types.h -> wc_port.h

Switches types.h to visibility.h, for access to WOLFSSL_API.