### PR TITLE
use type enum wc_HashType rather than int

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -594,7 +594,7 @@ static int wc_RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
         return BAD_FUNC_ARG;
     }
 
-    tmp = XMALLOC(pkcsBlockLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    tmp = (byte*)XMALLOC(pkcsBlockLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (tmp == NULL) {
         return MEMORY_E;
     }

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -227,7 +227,7 @@ int wc_FreeRsaKey(RsaKey* key)
    out:   mask output after generation
    outSz: size of output buffer
  */
-static int wc_MGF1(int hType, byte* seed, word32 seedSz,
+static int wc_MGF1(enum wc_HashType hType, byte* seed, word32 seedSz,
                                                         byte* out, word32 outSz)
 {
     byte* tmp;
@@ -347,7 +347,7 @@ static int wc_MGF(int type, byte* seed, word32 seedSz,
 
 static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
         word32 pkcsBlockLen, byte padValue, WC_RNG* rng,
-        int hType, int mgf, byte* optLabel, word32 labelLen)
+        enum wc_HashType hType, int mgf, byte* optLabel, word32 labelLen)
 {
     int ret;
     int hLen;
@@ -542,8 +542,8 @@ static int wc_RsaPad(const byte* input, word32 inputLen, byte* pkcsBlock,
 #ifndef WC_NO_RSA_OAEP
 /* helper function to direct which padding is used */
 static int wc_RsaPad_ex(const byte* input, word32 inputLen, byte* pkcsBlock,
-                   word32 pkcsBlockLen, byte padValue, WC_RNG* rng, int padType,
-                   int hType, int mgf, byte* optLabel, word32 labelLen)
+               word32 pkcsBlockLen, byte padValue, WC_RNG* rng, int padType,
+               enum wc_HashType hType, int mgf, byte* optLabel, word32 labelLen)
 {
     int ret;
 
@@ -580,7 +580,8 @@ static int wc_RsaPad_ex(const byte* input, word32 inputLen, byte* pkcsBlock,
 /* UnPad plaintext, set start to *output, return length of plaintext,
  * < 0 on error */
 static int wc_RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
-             byte **output, int hType, int mgf, byte* optLabel, word32 labelLen)
+                            byte **output, enum wc_HashType hType, int mgf,
+                            byte* optLabel, word32 labelLen)
 {
     int hLen;
     int ret;
@@ -703,8 +704,8 @@ static int RsaUnPad(const byte *pkcsBlock, unsigned int pkcsBlockLen,
 #ifndef WC_NO_RSA_OAEP
 /* helper function to direct unpadding */
 static int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen, byte** out,
-                          byte padValue, int padType, int hType, int mgf,
-                          byte* optLabel, word32 labelLen)
+                          byte padValue, int padType, enum wc_HashType hType,
+                          int mgf, byte* optLabel, word32 labelLen)
 {
     int ret;
 
@@ -877,8 +878,8 @@ int wc_RsaPublicEncrypt(const byte* in, word32 inLen, byte* out, word32 outLen,
    label : optional label
    labelSz : size of optional label buffer */
 int wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
-                      word32 outLen, RsaKey* key, WC_RNG* rng,
-                      int type, int hash, int mgf, byte* label, word32 labelSz)
+                    word32 outLen, RsaKey* key, WC_RNG* rng, int type,
+                    enum wc_HashType hash, int mgf, byte* label, word32 labelSz)
 {
     int sz, ret;
 
@@ -942,7 +943,8 @@ int wc_RsaPrivateDecryptInline(byte* in, word32 inLen, byte** out, RsaKey* key)
    label : optional label
    labelSz : size of optional label buffer */
 int wc_RsaPrivateDecryptInline_ex(byte* in, word32 inLen, byte** out,
-         RsaKey* key, int type, int hash, int mgf, byte* label, word32 labelSz)
+                          RsaKey* key, int type, enum wc_HashType hash, int mgf,
+                          byte* label, word32 labelSz)
 {
     int ret;
 
@@ -1024,7 +1026,8 @@ int wc_RsaPrivateDecrypt(const byte* in, word32 inLen, byte* out, word32 outLen,
    label : optional label
    labelSz : size of optional label buffer */
 int wc_RsaPrivateDecrypt_ex(const byte* in, word32 inLen, byte* out, word32 outLen,
-         RsaKey* key, int type, int hash, int mgf, byte* label, word32 labelSz)
+                          RsaKey* key, int type, enum wc_HashType hash, int mgf,
+                          byte* label, word32 labelSz)
 {
     int plainLen;
     byte*  tmp;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -4098,13 +4098,13 @@ int rsa_test(void)
     /* check using pkcsv15 padding with _ex API */
     XMEMSET(plain, 0, sizeof(plain));
     ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
-                  WC_RSA_PKCSV15_PAD, 0, 0, NULL, 0);
+                  WC_RSA_PKCSV15_PAD, WC_HASH_TYPE_NONE, 0, NULL, 0);
     if (ret < 0) {
         free(tmp);
         return -443;
     }
     ret = wc_RsaPrivateDecrypt_ex(out, ret, plain, sizeof(plain), &key,
-                  WC_RSA_PKCSV15_PAD, 0, 0, NULL, 0);
+                  WC_RSA_PKCSV15_PAD, WC_HASH_TYPE_NONE, 0, NULL, 0);
     if (ret < 0) {
         free(tmp);
         return -444;

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -124,14 +124,14 @@ WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
 #define WC_RSA_OAEP_PAD    1
 
 WOLFSSL_API int  wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
-                      word32 outLen, RsaKey* key, WC_RNG* rng,
-                      int type, int hash, int mgf, byte* label, word32 lableSz);
+                   word32 outLen, RsaKey* key, WC_RNG* rng, int type,
+                   enum wc_HashType hash, int mgf, byte* label, word32 lableSz);
 WOLFSSL_API int  wc_RsaPrivateDecrypt_ex(const byte* in, word32 inLen,
-                      byte* out, word32 outLen, RsaKey* key,
-                      int type, int hash, int mgf, byte* label, word32 lableSz);
+                   byte* out, word32 outLen, RsaKey* key, int type,
+                   enum wc_HashType hash, int mgf, byte* label, word32 lableSz);
 WOLFSSL_API int  wc_RsaPrivateDecryptInline_ex(byte* in, word32 inLen,
-                      byte** out, RsaKey* key,
-                      int type, int hash, int mgf, byte* label, word32 lableSz);
+                      byte** out, RsaKey* key, int type, enum wc_HashType hash,
+                      int mgf, byte* label, word32 lableSz);
 #endif /* HAVE_FIPS*/
 WOLFSSL_API int  wc_RsaFlattenPublicKey(RsaKey*, byte*, word32*, byte*,
                                                                        word32*);


### PR DESCRIPTION
Fix ICC compiler warning of passing int to function with parameter type enum wc_HashType.