### PR TITLE
Update support for Freescale KSDK 1.3.0, fix Freescale+FreeRTOS build

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2816,7 +2816,7 @@ ProtocolVersion MakeDTLSv1_2(void)
         return (word32) mqxTime.SECONDS;
     }
 
-#elif defined(FREESCALE_KSDK_BM)
+#elif defined(FREESCALE_KSDK_BM) || defined(FREESCALE_FREE_RTOS)
 
     #include "fsl_pit_driver.h"
 

--- a/src/keys.c
+++ b/src/keys.c
@@ -32,7 +32,7 @@
 #include <wolfssl/internal.h>
 #include <wolfssl/error-ssl.h>
 #if defined(SHOW_SECRETS) || defined(CHACHA_AEAD_TEST)
-    #ifdef FREESCALE_MQX
+    #if defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
         #if MQX_USE_IO_OLD
             #include <fio.h>
         #else

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -117,7 +117,7 @@
     #define XTIME(t1)  mqx_time((t1))
     #define XGMTIME(c, t) mqx_gmtime((c), (t))
     #define XVALIDATE_DATE(d, f, t) ValidateDate((d), (f), (t))
-#elif defined(FREESCALE_KSDK_BM)
+#elif defined(FREESCALE_KSDK_BM) || defined(FREESCALE_FREE_RTOS)
     #include <time.h>
     #define XTIME(t1)  ksdk_time((t1))
     #define XGMTIME(c, t) gmtime((c))
@@ -373,11 +373,7 @@ struct tm* mqx_gmtime(const time_t* clock, struct tm* tmpTime)
 
 #endif /* FREESCALE_MQX */
 
-#ifdef FREESCALE_KSDK_BM
-
-/* setting for PIT timer */
-#define PIT_INSTANCE 0
-#define PIT_CHANNEL  0
+#if defined(FREESCALE_KSDK_BM) || defined(FREESCALE_FREE_RTOS)
 
 #include "fsl_pit_driver.h"
 
@@ -3010,7 +3006,8 @@ int ValidateDate(const byte* date, byte format, int dateType)
     int    diffHH = 0 ; int diffMM = 0 ;
     int    diffSign = 0 ;
 
-#if defined(FREESCALE_MQX) || defined(TIME_OVERRIDES) || defined(NEED_TMP_TIME)
+#if defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX) || \
+    defined(TIME_OVERRIDES) || defined(NEED_TMP_TIME)
     struct tm tmpTimeStorage;
     tmpTime = &tmpTimeStorage;
 #else
@@ -5999,7 +5996,7 @@ static int CopyValidity(byte* output, Cert* cert)
 /* for systems where mktime() doesn't normalize fully */
 static void RebuildTime(time_t* in, struct tm* out)
 {
-    #ifdef FREESCALE_MQX
+    #if defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
         out = localtime_r(in, out);
     #else
         (void)in;
@@ -6025,7 +6022,8 @@ static int SetValidity(byte* output, int daysValid)
     struct tm* tmpTime = NULL;
     struct tm  local;
 
-#if defined(FREESCALE_MQX) || defined(TIME_OVERRIDES) || defined(NEED_TMP_TIME)
+#if defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX) || \
+    defined(TIME_OVERRIDES) || defined(NEED_TMP_TIME)
     /* for use with gmtime_r */
     struct tm tmpTimeStorage;
     tmpTime = &tmpTimeStorage;

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -46,7 +46,7 @@
 #endif
 
 #ifdef SHOW_GEN
-    #ifdef FREESCALE_MQX
+    #if defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
         #if MQX_USE_IO_OLD
             #include <fio.h>
         #else

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -89,7 +89,7 @@ void wolfSSL_Debugging_OFF(void)
 
 #ifdef DEBUG_WOLFSSL
 
-#ifdef FREESCALE_MQX
+#if defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
     #if MQX_USE_IO_OLD
         #include <fio.h>
     #else

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -114,10 +114,6 @@ int  wc_RNG_GenerateByte(WC_RNG* rng, byte* b)
         #ifndef EBSNET
             #include <unistd.h>
         #endif
-    #elif defined(FREESCALE_TRNG)
-        #define TRNG_INSTANCE (0)
-        #include "fsl_device_registers.h"
-        #include "fsl_trng_driver.h"
     #else
         /* include headers that may be needed to get good seed */
     #endif
@@ -1185,6 +1181,15 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         {
             TRNG_DRV_GetRandomData(TRNG_INSTANCE, output, sz);
+            return 0;
+        }
+
+
+    #elif defined(FREESCALE_RNGA)
+
+        int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
+        {
+            RNGA_DRV_GetRandomData(RNGA_INSTANCE, output, sz);
             return 0;
         }
 

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -138,7 +138,8 @@ int UnLockMutex(wolfSSL_Mutex *m)
 
 #else /* MULTI_THREAD */
 
-    #if defined(FREERTOS)  || defined(FREERTOS_TCP)
+    #if defined(FREERTOS)  || defined(FREERTOS_TCP) || \
+        defined(FREESCALE_FREE_RTOS)
 
         int InitMutex(wolfSSL_Mutex* m)
         {
@@ -390,7 +391,7 @@ int UnLockMutex(wolfSSL_Mutex *m)
             return 0;
         }
 
-    #elif defined(FREESCALE_MQX)
+    #elif defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
 
         int InitMutex(wolfSSL_Mutex* m)
         {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -119,7 +119,7 @@
     #include "cavium_ioctl.h"
 #endif
 
-#ifdef FREESCALE_MQX
+#if defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
     #include <mqx.h>
     #include <stdlib.h>
     #if MQX_USE_IO_OLD

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -121,6 +121,8 @@
     /* do nothing */
 #elif defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
     /* do nothing */
+#elif defined(FREESCALE_FREE_RTOS)
+    #include "fsl_os_abstraction.h"
 #elif defined(WOLFSSL_uITRON4)
         /* do nothing */
 #elif defined(WOLFSSL_uTKERNEL2)

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -198,7 +198,7 @@ WOLFSSL_API int wolfCrypt_Init(void);
     #define XFCLOSE                 fs_close
     #define XSEEK_END               0
     #define XBADFILE                NULL
-#elif defined(FREESCALE_MQX)
+#elif defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
     #define XFILE                   MQX_FILE_PTR
     #define XFOPEN                  fopen
     #define XFSEEK                  fseek


### PR DESCRIPTION
This commit fixes support for KSDK 1.3.0 as well as incorporating fixes from Freescale for their Freescale+FreeRTOS build.

**FREESCALE_KSDK_MQX** should be defined when building with KSDK version of MQX.

**FREESCALE_MQX** should be defined when building for "Classic MQX".