### PR TITLE
comment for adding new wolfCrypt error id strings

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -9366,6 +9366,9 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
     case UNKNOWN_SNI_HOST_NAME_E:
         return "Unrecognized host name Error";
 
+    case UNKNOWN_MAX_FRAG_LEN_E:
+        return "Unrecognized max frag len Error";
+
     case KEYUSE_SIGNATURE_E:
         return "Key Use digitalSignature not set Error";
 

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -142,13 +142,13 @@ enum wolfSSL_ErrorCodes {
     BAD_CERTIFICATE_STATUS_ERROR = -406,   /* Bad certificate status message */
     OCSP_INVALID_STATUS          = -407,   /* Invalid OCSP Status */
 
-    /* add strings to SetErrorString !!!!! */
+    /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* begin negotiation parameter errors */
     UNSUPPORTED_SUITE            = -500,        /* unsupported cipher suite */
     MATCH_SUITE_ERROR            = -501         /* can't match cipher suite */
     /* end negotiation parameter errors only 10 for now */
-    /* add strings to SetErrorString !!!!! */
+    /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* no error stings go down here, add above negotiation errors !!!! */
 };

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -34,7 +34,7 @@
 #endif
 
 
-/* error codes */
+/* error codes, add string for new errors !!! */
 enum {
     MAX_CODE_E         = -100,  /* errors -101 - -299 */
     OPEN_RAN_E         = -101,  /* opening random device error */
@@ -166,6 +166,9 @@ enum {
     BAD_COND_E          = -230,  /* Bad condition variable operation */
 
     MIN_CODE_E          = -300   /* errors -101 - -299 */
+
+    /* add new companion error id strings for any new error codes
+       wolfcrypt/src/error.c !!! */
 };
 
 


### PR DESCRIPTION
Checked list of error values in wolfssl/wolfcrypt/error-crypt.h versus the list of strings in wolfcrypt/src/error.c.

This is just the addition of a comment to help remind about creating an error string for any new error codes added to wolfCrypt.