### PR TITLE
Use gcc byte swapping builtins

### DIFF
--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -85,6 +85,8 @@ STATIC INLINE word32 ByteReverseWord32(word32 value)
     return (word32)__lwbrx(&value,0);
 #elif defined(KEIL_INTRINSICS)
     return (word32)__rev(value);
+#elif defined(GCC_BUILTINS)
+    return __builtin_bswap32(value);
 #elif defined(FAST_ROTATE)
     /* 5 instructions with rotate instruction, 9 without */
     return (rotrFixed(value, 8U) & 0xff00ff00) |
@@ -125,7 +127,9 @@ STATIC INLINE word64 rotrFixed64(word64 x, word64 y)
 
 STATIC INLINE word64 ByteReverseWord64(word64 value)
 {
-#ifdef WOLFCRYPT_SLOW_WORD64
+#if defined(GCC_BUILTINS)
+	return __builtin_bswap64(value);
+#elif defined(WOLFCRYPT_SLOW_WORD64)
 	return (word64)(ByteReverseWord32((word32)value)) << 32 | 
                     ByteReverseWord32((word32)(value>>32));
 #else

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -136,10 +136,15 @@
 	#elif defined(__MWERKS__) && TARGET_CPU_PPC
 	    #define PPC_INTRINSICS
 	    #define FAST_ROTATE
-	#elif defined(__GNUC__) && defined(__i386__)
+	#elif defined(__GNUC__)
+	    #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)
+	        #define GCC_BUILTINS
+	    #endif
+	    #if defined(__i386__)
 	        /* GCC does peephole optimizations which should result in using rotate
 	           instructions  */
-	    #define FAST_ROTATE
+	        #define FAST_ROTATE
+	    #endif
 	#endif
 
 


### PR DESCRIPTION
With this commit gcc's byte swapping builtins are used if available. On x86 this will emit a `bswap` instruction and on ARMv6 and later a `rev` instruction. Note that gcc already optimized the function to a `bswap` on x86, but on ARMv6 it generated multiple instructions instead of one.