### PR TITLE
forcing sensitive memory to be all zeros when done with it

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7454,6 +7454,9 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
         if (ssl->buffers.weOwnKey) {
             WOLFSSL_MSG("Unloading key");
+            if (ssl->buffers.key.buffer) {
+                ForceZero(ssl->buffers.key.buffer, ssl->buffers.key.length);
+            }
             XFREE(ssl->buffers.key.buffer, ssl->heap, DYNAMIC_TYPE_KEY);
             ssl->buffers.weOwnKey = 0;
             ssl->buffers.key.length = 0;

--- a/tests/api.c
+++ b/tests/api.c
@@ -354,10 +354,17 @@ static void test_wolfSSL_SetTmpDH_file(void)
     WOLFSSL *ssl;
 
     AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
+#ifndef NO_RSA
     AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCert,
                 SSL_FILETYPE_PEM));
     AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKey,
                 SSL_FILETYPE_PEM));
+#else
+    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, eccCert,
+                SSL_FILETYPE_PEM));
+    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, eccKey,
+                SSL_FILETYPE_PEM));
+#endif
     AssertNotNull(ssl = wolfSSL_new(ctx));
 
     /* invalid ssl */

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -196,6 +196,9 @@ int wc_FreeRsaKey(RsaKey* key)
 {
     (void)key;
 
+    if (key == NULL)
+        return 0;
+
 #ifdef HAVE_CAVIUM
     if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC)
         return FreeCaviumRsaKey(key);
@@ -213,6 +216,17 @@ int wc_FreeRsaKey(RsaKey* key)
     }
     mp_clear(&key->e);
     mp_clear(&key->n);
+#else
+    /* still clear private key memory information when free'd */
+    if (key->type == RSA_PRIVATE) {
+        mp_clear(&key->u);
+        mp_clear(&key->dQ);
+        mp_clear(&key->u);
+        mp_clear(&key->dP);
+        mp_clear(&key->q);
+        mp_clear(&key->p);
+        mp_clear(&key->d);
+    }
 #endif
 
     return 0;

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -36,6 +36,11 @@
 
 /* in case user set USE_FAST_MATH there */
 #include <wolfssl/wolfcrypt/settings.h>
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #include <wolfcrypt/src/misc.c>
+#endif
 
 #ifdef USE_FAST_MATH
 
@@ -2031,7 +2036,7 @@ void fp_zero(fp_int *a)
 {
     a->used = 0;
     a->sign = FP_ZPOS;
-    XMEMSET(a->dp, 0, a->size * sizeof(fp_digit));
+    ForceZero(a->dp, a->size * sizeof(fp_digit));
 }
 #endif
 

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -40,7 +40,7 @@
     #include <limits.h>
 #endif
 
-#include <wolfssl/wolfcrypt/random.h> 
+#include <wolfssl/wolfcrypt/random.h>
 
 #ifdef __cplusplus
     extern "C" {
@@ -369,7 +369,7 @@ typedef struct {
     void fp_init(fp_int *a);
     void fp_zero(fp_int *a);
 #else
-    #define fp_init(a)  (void)XMEMSET((a), 0, sizeof(fp_int))
+    #define fp_init(a)  (void)ForceZero((a), sizeof(fp_int))
     #define fp_zero(a)  fp_init(a)
 #endif
 


### PR DESCRIPTION
Force zero on private or potentially sensitive buffers after session is done.