### PR TITLE
Public key PEM to DER fixes

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4249,6 +4249,7 @@ int wolfSSL_PemCertToDer(const char* fileName, unsigned char* derBuf, int derSz)
 #endif /* WOLFSSL_CERT_GEN */
 
 #ifdef WOLFSSL_CERT_EXT
+#ifndef NO_FILESYSTEM
 /* load pem public key from file into der buffer, return der size or error */
 int wolfSSL_PemPubKeyToDer(const char* fileName,
                            unsigned char* derBuf, int derSz)
@@ -4313,6 +4314,7 @@ int wolfSSL_PemPubKeyToDer(const char* fileName,
 
     return ret;
 }
+#endif /* NO_FILESYSTEM */
 
 /* Return bytes written to buff or < 0 for error */
 int wolfSSL_PubKeyPemToDer(const unsigned char* pem, int pemSz,

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9641,7 +9641,7 @@ int ParseCRL(DecodedCRL* dcrl, const byte* buff, word32 sz, void* cm)
 }
 
 #endif /* HAVE_CRL */
-#endif
+#endif /* !NO_ASN */
 
 #ifdef WOLFSSL_SEP
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1086,15 +1086,17 @@ WOLFSSL_API int wolfSSL_KeyPemToDer(const unsigned char*, int,
                                     unsigned char*, int, const char*);
 WOLFSSL_API int wolfSSL_CertPemToDer(const unsigned char*, int,
                                      unsigned char*, int, int);
-#ifdef WOLFSSL_CERT_EXT
+#if defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER)
     #ifndef WOLFSSL_PEMPUBKEY_TODER_DEFINED
-        WOLFSSL_API int wolfSSL_PemPubKeyToDer(const char* fileName,
-                                               unsigned char* derBuf, int derSz);
+        #ifndef NO_FILESYSTEM
+            WOLFSSL_API int wolfSSL_PemPubKeyToDer(const char* fileName,
+                                                   unsigned char* derBuf, int derSz);
+        #endif
         WOLFSSL_API int wolfSSL_PubKeyPemToDer(const unsigned char*, int,
                                                unsigned char*, int);
-    #define WOLFSSL_PEMPUBKEY_TODER_DEFINED
-    #endif
-#endif /* WOLFSSL_CERT_EXT */
+        #define WOLFSSL_PEMPUBKEY_TODER_DEFINED
+    #endif /* WOLFSSL_PEMPUBKEY_TODER_DEFINED */
+#endif /* WOLFSSL_CERT_EXT || WOLFSSL_PUB_PEM_TO_DER*/
 
 typedef void (*CallbackCACache)(unsigned char* der, int sz, int type);
 typedef void (*CbMissingCRL)(const char* url);

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -74,13 +74,6 @@ enum Ctc_Encoding {
     CTC_PRINTABLE  = 0x13  /* printable */
 };
 
-
-#ifdef WOLFSSL_CERT_GEN
-
-#ifndef HAVE_ECC
-    typedef struct ecc_key ecc_key;
-#endif
-
 enum Ctc_Misc {
     CTC_NAME_SIZE     =    64,
     CTC_DATE_SIZE     =    32,
@@ -89,12 +82,18 @@ enum Ctc_Misc {
 #ifdef WOLFSSL_CERT_EXT
     /* AKID could contains: hash + (Option) AuthCertIssuer,AuthCertSerialNum
      * We support only hash */
-    CTC_MAX_SKID_SIZE = SHA256_DIGEST_SIZE,
-    CTC_MAX_AKID_SIZE = SHA256_DIGEST_SIZE,
+    CTC_MAX_SKID_SIZE = 32, /* SHA256_DIGEST_SIZE */
+    CTC_MAX_AKID_SIZE = 32, /* SHA256_DIGEST_SIZE */
     CTC_MAX_CERTPOL_SZ = 64,
     CTC_MAX_CERTPOL_NB = 2 /* Max number of Certificate Policy */
 #endif /* WOLFSSL_CERT_EXT */
 };
+
+#ifdef WOLFSSL_CERT_GEN
+
+#ifndef HAVE_ECC
+    typedef struct ecc_key ecc_key;
+#endif
 
 typedef struct CertName {
     char country[CTC_NAME_SIZE];
@@ -217,18 +216,6 @@ WOLFSSL_API int wc_SetKeyUsage(Cert *cert, const char *value);
  * RFC5280 : non-critical */
 WOLFSSL_API int wc_SetCertificatePolicies(Cert *cert, const char **input);
 
-#ifndef WOLFSSL_PEMPUBKEY_TODER_DEFINED
-    #ifndef NO_FILESYSTEM
-    /* forward from wolfssl */
-    WOLFSSL_API int wolfSSL_PemPubKeyToDer(const char* fileName,
-                                           unsigned char* derBuf, int derSz);
-    #endif
-
-    /* forward from wolfssl */
-    WOLFSSL_API int wolfSSL_PubKeyPemToDer(const unsigned char*, int,
-                                           unsigned char*, int);
-    #define WOLFSSL_PEMPUBKEY_TODER_DEFINED
-#endif /* WOLFSSL_PEMPUBKEY_TODER_DEFINED */
 #endif /* WOLFSSL_CERT_EXT */
 
     #ifdef HAVE_NTRU
@@ -239,6 +226,20 @@ WOLFSSL_API int wc_SetCertificatePolicies(Cert *cert, const char **input);
 
 #endif /* WOLFSSL_CERT_GEN */
 
+#if defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER)
+    #ifndef WOLFSSL_PEMPUBKEY_TODER_DEFINED
+        #ifndef NO_FILESYSTEM
+        /* forward from wolfssl */
+        WOLFSSL_API int wolfSSL_PemPubKeyToDer(const char* fileName,
+                                               unsigned char* derBuf, int derSz);
+        #endif
+
+        /* forward from wolfssl */
+        WOLFSSL_API int wolfSSL_PubKeyPemToDer(const unsigned char*, int,
+                                               unsigned char*, int);
+        #define WOLFSSL_PEMPUBKEY_TODER_DEFINED
+    #endif /* WOLFSSL_PEMPUBKEY_TODER_DEFINED */
+#endif /* WOLFSSL_CERT_EXT || WOLFSSL_PUB_PEM_TO_DER */
 
 #if defined(WOLFSSL_KEY_GEN) || defined(WOLFSSL_CERT_GEN) || !defined(NO_DSA)
     WOLFSSL_API int wc_DerToPem(const byte* der, word32 derSz, byte* output,

--- a/wolfssl/wolfcrypt/coding.h
+++ b/wolfssl/wolfcrypt/coding.h
@@ -33,7 +33,8 @@
 WOLFSSL_API int Base64_Decode(const byte* in, word32 inLen, byte* out,
                                word32* outLen);
 
-#if defined(OPENSSL_EXTRA) || defined(SESSION_CERTS) || defined(WOLFSSL_KEY_GEN)                         || defined(WOLFSSL_CERT_GEN) || defined(HAVE_WEBSERVER)                         || !defined(NO_DSA)
+#if defined(OPENSSL_EXTRA) || defined(SESSION_CERTS) || defined(WOLFSSL_KEY_GEN) \
+   || defined(WOLFSSL_CERT_GEN) || defined(HAVE_WEBSERVER) || !defined(NO_DSA)
     #ifndef WOLFSSL_BASE64_ENCODE
         #define WOLFSSL_BASE64_ENCODE
     #endif


### PR DESCRIPTION
Fix so WOLFSSL_CERT_EXT can be defined without WOLFSSL_CERT_GEN.
Added new "WOLFSSL_PUB_PEM_TO_DER" to allow the public key PEM to DER functions to be available without CERT_GEN or CERT_EXT.
Fix to add NO_FILESYSTEM check around wolfSSL_PemPubKeyToDer in ssl.h.
Cleanup in coding.h for the #if check.