### PR TITLE
Fixed bug with "ChangeToWolfRoot" that was incorrectly seeking previo…

### DIFF
--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1212,27 +1212,23 @@ static INLINE int OpenNitroxDevice(int dma_mode,int dev_id)
     static INLINE int ChangeToWolfRoot(void)
     {
         #if !defined(NO_FILESYSTEM) 
-            int depth;
+            int depth, res;
             XFILE file;
-            char path[MAX_PATH];
-            XMEMSET(path, 0, MAX_PATH);
-
             for(depth = 0; depth <= MAX_WOLF_ROOT_DEPTH; depth++) {
                 file = XFOPEN(ntruKey, "rb");
                 if (file != XBADFILE) {
                     XFCLOSE(file);
                     return depth;
                 }
-                #ifdef USE_WINDOWS_API
-                    XSTRNCAT(path, "..\\", MAX_PATH - XSTRLEN(path));
-                    SetCurrentDirectoryA(path);
-                #else
-                    XSTRNCAT(path, "../", MAX_PATH - XSTRLEN(path));
-                    if (chdir(path) < 0) {
-                        printf("chdir to %s failed\n", path);
-                        break;
-                    }
-                #endif
+            #ifdef USE_WINDOWS_API
+                res = SetCurrentDirectoryA("..\\");
+            #else
+                res = chdir("../");
+            #endif
+                if (res < 0) {
+                    printf("chdir to ../ failed!\n");
+                    break;
+                }
             }
         
             err_sys("wolf root not found");


### PR DESCRIPTION
…us directories where depth 2 was using ..\..\ and skipping one. This bug applied to both Win and Lin*. For example running ./server from inside examples/server would not find the wolf root.