### PR TITLE
Fixes several warnings that were seeing building with Visual Studio 2…

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -635,7 +635,7 @@ static int tcp_connect(SOCKET_T* sockfd, const char* ip, word16 port)
     }
     #endif /* HAVE_GETADDRINFO */
 
-    *sockfd = socket(addr.ss_family, SOCK_STREAM, 0);
+    *sockfd = (SOCKET_T)socket(addr.ss_family, SOCK_STREAM, 0);
 
 #ifdef USE_WINDOWS_API
     if (*sockfd == INVALID_SOCKET) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -237,7 +237,7 @@ int wolfSSL_use_old_poly(WOLFSSL* ssl, int value)
     WOLFSSL_ENTER("SSL_use_old_poly");
     WOLFSSL_MSG("Warning SSL connection auto detects old/new and this function"
             "is depriciated");
-    ssl->options.oldPoly = value;
+    ssl->options.oldPoly = (word16)value;
     WOLFSSL_LEAVE("SSL_use_old_poly", 0);
     return 0;
 }

--- a/wolfcrypt/src/chacha20_poly1305.c
+++ b/wolfcrypt/src/chacha20_poly1305.c
@@ -199,7 +199,7 @@ static int calculateAuthTag(
 
         /* -- padding1: pad the AAD to 16 bytes */
 
-        paddingLen = -inAADLen & (CHACHA20_POLY1305_MAC_PADDING_ALIGNMENT - 1);
+        paddingLen = -(int)inAADLen & (CHACHA20_POLY1305_MAC_PADDING_ALIGNMENT - 1);
         if (paddingLen)
         {
             err += wc_Poly1305Update(&poly1305Ctx, padding, paddingLen);
@@ -221,7 +221,7 @@ static int calculateAuthTag(
 
     /* -- padding2: pad the ciphertext to 16 bytes */
 
-    paddingLen = -inCiphertextLen &
+    paddingLen = -(int)inCiphertextLen &
                                   (CHACHA20_POLY1305_MAC_PADDING_ALIGNMENT - 1);
     if (paddingLen)
     {
@@ -264,10 +264,10 @@ static void word32ToLittle64(const word32 inLittle32, byte outLittle64[8])
 {
     XMEMSET(outLittle64, 0, 8);
 
-    outLittle64[0] = (inLittle32 & 0x000000FF);
-    outLittle64[1] = (inLittle32 & 0x0000FF00) >> 8;
-    outLittle64[2] = (inLittle32 & 0x00FF0000) >> 16;
-    outLittle64[3] = (inLittle32 & 0xFF000000) >> 24;
+    outLittle64[0] = (byte)(inLittle32 & 0x000000FF);
+    outLittle64[1] = (byte)((inLittle32 & 0x0000FF00) >> 8);
+    outLittle64[2] = (byte)((inLittle32 & 0x00FF0000) >> 16);
+    outLittle64[3] = (byte)((inLittle32 & 0xFF000000) >> 24);
 }
 
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2142,7 +2142,7 @@ static int ecc_mul2add(ecc_point* A, mp_int* kA,
     bitbufB = tB[0];
 
     /* for every byte of the multiplicands */
-    for (x = -1;; ) {
+    for (x = (unsigned)-1;; ) {
         /* grab a nibble */
         if (++nibble == 4) {
             ++x; if (x == len) break;

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1301,7 +1301,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     XMEMCPY(plain, pkcs7->content, pkcs7->contentSz);
 
     for (i = 0; i < padSz; i++) {
-        plain[pkcs7->contentSz + i] = padSz;
+        plain[pkcs7->contentSz + i] = (byte)padSz;
     }
 
     encryptedContent = (byte*)XMALLOC(desOutSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfcrypt/src/poly1305.c
+++ b/wolfcrypt/src/poly1305.c
@@ -535,7 +535,7 @@ int wc_Poly1305Update(Poly1305* ctx, const byte* m, word32 bytes) {
 			want = bytes;
 		for (i = 0; i < want; i++)
 			ctx->buffer[ctx->leftover + i] = m[i];
-		bytes -= want;
+		bytes -= (word32)want;
 		m += want;
 		ctx->leftover += want;
 		if (ctx->leftover < POLY1305_BLOCK_SIZE)
@@ -549,7 +549,7 @@ int wc_Poly1305Update(Poly1305* ctx, const byte* m, word32 bytes) {
 		size_t want = (bytes & ~(POLY1305_BLOCK_SIZE - 1));
 		poly1305_blocks(ctx, m, want);
 		m += want;
-		bytes -= want;
+		bytes -= (word32)want;
 	}
 
 	/* store leftover */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2202,7 +2202,7 @@ typedef struct Options {
     word16            haveRSA:1;          /* RSA available */
     word16            haveDH:1;           /* server DH parms set by user */
     word16            haveNTRU:1;         /* server NTRU  private key loaded */
-    byte              haveQSH:1;          /* have QSH ability */
+    word16            haveQSH:1;          /* have QSH ability */
     word16            haveECDSAsig:1;     /* server ECDSA signed cert */
     word16            haveStaticECC:1;    /* static server ECC private key */
     word16            havePeerCert:1;     /* do we have peer's cert */


### PR DESCRIPTION
…015. Also noticed issue with "struct Options" in internal.h for the bit flags that was causing split due to type difference (byte vs. word16).