### PR TITLE
New ECC and ASN build options for reduce build size options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1032,7 +1032,7 @@ AC_ARG_ENABLE([asn],
 if test "$ENABLED_ASN" = "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_CERTS"
-    if test "$ENABLED_DH" = "no"
+    if test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" == "no"
     then
         # DH needs bigint
         AM_CFLAGS="$AM_CFLAGS -DNO_BIG_INT"
@@ -1056,18 +1056,21 @@ then
     AC_MSG_ERROR([please disable dsa if disabling asn.])
 fi
 
-if test "$ENABLED_ECC" = "yes" && test "$ENABLED_ASN" = "no"
+if test "x$ENABLED_CRYPTONLY" = "xyes"
 then
-    AC_MSG_ERROR([please disable ecc if disabling asn.])
-fi
+    if test "$ENABLED_ECC" = "yes" && test "$ENABLED_ASN" = "no"
+    then
+        AC_MSG_ERROR([please disable ecc if disabling asn.])
+    fi
 
-if test "$ENABLED_PSK" = "no" && test "$ENABLED_ASN" = "no"
-then
-    AC_MSG_ERROR([please enable psk if disabling asn.])
+    if test "$ENABLED_PSK" = "no" && test "$ENABLED_ASN" = "no"
+    then
+        AC_MSG_ERROR([please enable psk if disabling asn.])
+    fi
 fi
 
 # DH needs bigint
-if test "$ENABLED_ASN" = "no" && test "$ENABLED_DH" = "no"
+if test "$ENABLED_ASN" = "no" && test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" = "no"
 then
     ENABLED_FASTMATH=no
     ENABLED_SLOWMATH=no
@@ -2182,7 +2185,7 @@ then
     # turn off fastmth if leanpsk on or asn off (w/o dh)
     if test "$ENABLED_LEANPSK" = "yes" || test "$ENABLED_ASN" = "no"
     then
-        if test "$ENABLED_DH" = "no"
+        if test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" = "no"
         then
             ENABLED_FASTMATH=no
         else

--- a/configure.ac
+++ b/configure.ac
@@ -1034,7 +1034,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_CERTS"
     if test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" == "no"
     then
-        # DH needs bigint
+        # DH and ECC need bigint
         AM_CFLAGS="$AM_CFLAGS -DNO_BIG_INT"
     fi
 else
@@ -1056,20 +1056,7 @@ then
     AC_MSG_ERROR([please disable dsa if disabling asn.])
 fi
 
-if test "x$ENABLED_CRYPTONLY" = "xyes"
-then
-    if test "$ENABLED_ECC" = "yes" && test "$ENABLED_ASN" = "no"
-    then
-        AC_MSG_ERROR([please disable ecc if disabling asn.])
-    fi
-
-    if test "$ENABLED_PSK" = "no" && test "$ENABLED_ASN" = "no"
-    then
-        AC_MSG_ERROR([please enable psk if disabling asn.])
-    fi
-fi
-
-# DH needs bigint
+# DH and ECC need bigint
 if test "$ENABLED_ASN" = "no" && test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" = "no"
 then
     ENABLED_FASTMATH=no
@@ -2164,6 +2151,19 @@ fi
 
 AM_CONDITIONAL([BUILD_CRYPTONLY], [test "x$ENABLED_CRYPTONLY" = "xyes"])
 
+if test "x$ENABLED_CRYPTONLY" = "xno"
+then
+    if test "x$ENABLED_PSK" = "xno" && test "x$ENABLED_ASN" = "xno"
+    then
+        AC_MSG_ERROR([please enable psk if disabling asn.])
+    fi
+
+    if test "x$ENABLED_ECC" = "xyes" && test "x$ENABLED_ASN" = "xno"
+    then
+        AC_MSG_ERROR([please disable ecc if disabling asn.])
+    fi
+fi
+
 
 # set fastmath default
 FASTMATH_DEFAULT=no
@@ -2182,7 +2182,7 @@ AC_ARG_ENABLE([fastmath],
 
 if test "x$ENABLED_FASTMATH" = "xyes"
 then
-    # turn off fastmth if leanpsk on or asn off (w/o dh)
+    # turn off fastmth if leanpsk on or asn off (w/o DH and ECC)
     if test "$ENABLED_LEANPSK" = "yes" || test "$ENABLED_ASN" = "no"
     then
         if test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" = "no"

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1671,7 +1671,9 @@ void bench_eccKeyAgree(void)
     double start, total, each, milliEach;
     int    i, ret;
     byte   shared[32];
+#ifndef NO_ASN
     byte   sig[64+16];  /* der encoding too */
+#endif
     byte   digest[32];
     word32 x = 0;
 
@@ -1712,6 +1714,7 @@ void bench_eccKeyAgree(void)
         digest[i] = (byte)i;
 
 
+#ifndef NO_ASN
     start = current_time(1);
 
     for(i = 0; i < agreeTimes; i++) {
@@ -1739,6 +1742,7 @@ void bench_eccKeyAgree(void)
             return; 
         }
     }
+#endif
 
     total = current_time(0) - start;
     each  = total / agreeTimes;  /* per second  */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -2272,7 +2272,6 @@ static int GetCertHeader(DecodedCert* cert)
 
     return ret;
 }
-#endif /* !NO_ASN_TIME */
 
 #if !defined(NO_RSA)
 /* Store Rsa Key, may save later, Dsa could use in future */
@@ -2297,6 +2296,7 @@ static int StoreRsaKey(DecodedCert* cert)
     return 0;
 }
 #endif
+#endif /* !NO_ASN_TIME */
 
 
 #ifdef HAVE_ECC

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -25,6 +25,13 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
+/*
+ASN Options:
+ * NO_ASN_TIME: Disables time parts of the ASN code for systems without an RTC
+    or wishing to save space.
+ * IGNORE_NAME_CONSTRAINTS: Skip ASN name checks.
+*/
+
 #ifndef NO_ASN
 
 #ifdef HAVE_RTP_SYS
@@ -94,7 +101,7 @@
     #define FALSE 0
 #endif
 
-
+#ifndef NO_ASN_TIME
 #if defined(HAVE_RTP_SYS)
     /* uses parital <time.h> structures */
     #define XTIME(tl)       (0)
@@ -491,6 +498,7 @@ time_t idirect_time(time_t * timer)
 
 #endif /* IDIRECT_DEV_TIME */
 
+#endif /* !NO_ASN_TIME */
 
 WOLFSSL_LOCAL int GetLength(const byte* input, word32* inOutIdx, int* len,
                            word32 maxIdx)
@@ -617,7 +625,7 @@ static int GetShortInt(const byte* input, word32* inOutIdx, int* number)
 }
 #endif /* !NO_PWDBASED */
 
-
+#ifndef NO_ASN_TIME
 /* May not have one, not an error */
 static int GetExplicitVersion(const byte* input, word32* inOutIdx, int* version)
 {
@@ -634,7 +642,7 @@ static int GetExplicitVersion(const byte* input, word32* inOutIdx, int* version)
 
     return 0;
 }
-
+#endif /* !NO_ASN_TIME */
 
 WOLFSSL_LOCAL int GetInt(mp_int* mpi, const byte* input, word32* inOutIdx,
                   word32 maxIdx)
@@ -2212,7 +2220,7 @@ void FreeDecodedCert(DecodedCert* cert)
 #endif /* OPENSSL_EXTRA */
 }
 
-
+#ifndef NO_ASN_TIME
 static int GetCertHeader(DecodedCert* cert)
 {
     int ret = 0, len;
@@ -2264,6 +2272,7 @@ static int GetCertHeader(DecodedCert* cert)
 
     return ret;
 }
+#endif /* !NO_ASN_TIME */
 
 #if !defined(NO_RSA)
 /* Store Rsa Key, may save later, Dsa could use in future */
@@ -2327,7 +2336,7 @@ static int StoreRsaKey(DecodedCert* cert)
 
 #endif /* HAVE_ECC */
 
-
+#ifndef NO_ASN_TIME
 static int GetKey(DecodedCert* cert)
 {
     int length;
@@ -3184,7 +3193,7 @@ static int GetSignature(DecodedCert* cert)
 
     return 0;
 }
-
+#endif /* !NO_ASN_TIME */
 
 static word32 SetDigest(const byte* digest, word32 digSz, byte* output)
 {
@@ -3444,7 +3453,7 @@ int wc_GetCTC_HashOID(int type)
     };
 }
 
-
+#ifndef NO_ASN_TIME
 /* return true (1) or false (0) for Confirmation */
 static int ConfirmSignature(const byte* buf, word32 bufSz,
     const byte* key, word32 keySz, word32 keyOID,
@@ -4494,6 +4503,7 @@ static int DecodeNameConstraints(byte* input, int sz, DecodedCert* cert)
     return 0;
 }
 #endif /* IGNORE_NAME_CONSTRAINTS */
+#endif /* NO_ASN_TIME */
 
 #if defined(WOLFSSL_CERT_EXT) && !defined(WOLFSSL_SEP)
 
@@ -4670,7 +4680,7 @@ static int DecodePolicyOID(char *out, word32 outSz, byte *in, word32 inSz)
     }
 #endif /* WOLFSSL_SEP */
 
-
+#ifndef NO_ASN_TIME
 static int DecodeCertExtensions(DecodedCert* cert)
 /*
  *  Processing the Certificate Extensions. This does not modify the current
@@ -4884,6 +4894,7 @@ int ParseCert(DecodedCert* cert, int type, int verify, void* cm)
 
     return ret;
 }
+#endif /* !NO_ASN_TIME */
 
 
 /* from SSL proper, for locking can't do find here anymore */
@@ -4920,7 +4931,7 @@ Signer* GetCAByName(void* signers, byte* hash)
 
 #endif /* WOLFCRYPT_ONLY */
 
-
+#ifndef NO_ASN_TIME
 int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
 {
     word32 confirmOID;
@@ -5043,7 +5054,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
 
     return 0;
 }
-
+#endif /* !NO_ASN_TIME */
 
 /* Create and init an new signer */
 Signer* MakeSigner(void* heap)

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -57,6 +57,10 @@ ECC Curves:
 
 #ifdef HAVE_ECC
 
+#if (defined(HAVE_ECC_SIGN) || defined(HAVE_ECC_VERIFY)) && defined(NO_ASN)
+    #error ASN must be enabled for ECC sign/verify
+#endif
+
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/openssl/ec.h>
 #include <wolfssl/wolfcrypt/asn.h>

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -27,6 +27,34 @@
 /* in case user set HAVE_ECC there */
 #include <wolfssl/wolfcrypt/settings.h>
 
+/*
+Possible ECC enable options:
+ * HAVE_ECC:            Overall control of ECC                  default: on
+ * HAVE_ECC_ENCRYPT:    ECC encrypt/decrypt w/AES and HKDF      default: off
+ * HAVE_ECC_SIGN:       ECC sign                                default: on
+ * HAVE_ECC_VERIFY:     ECC verify                              default: on
+ * HAVE_ECC_DHE:        ECC build shared secret                 default: on
+ * HAVE_ECC_KEY_IMPORT: ECC Key import                          default: on
+ * HAVE_ECC_KEY_EXPORT: ECC Key export                          default: on
+ * ECC_SHAMIR:          Enables Shamir calc method              default: on
+ * HAVE_COMP_KEY:       Enables compressed key                  default: off
+ * WOLFSSL_VALIDATE_ECC_IMPORT: Validate ECC key on import      default: off
+*/
+
+/*
+ECC Curves:
+ * ECC_USER_CURVES: Allows custom combination of key sizes below
+ * HAVE_ALL_CURVES: Enable all key sizes (on unless ECC_USER_CURVES is defined)
+ * HAVE_ECC112: 112 bit key
+ * HAVE_ECC128: 128 bit key
+ * HAVE_ECC160: 160 bit key
+ * HAVE_ECC192: 192 bit key
+ * HAVE_ECC224: 224 bit key
+ * NO_ECC256: Disables 256 bit key (on by default)
+ * HAVE_ECC384: 384 bit key
+ * HAVE_ECC521: 521 bit key
+*/
+
 #ifdef HAVE_ECC
 
 #include <wolfssl/wolfcrypt/ecc.h>
@@ -1506,13 +1534,13 @@ int wc_ecc_is_valid_idx(int n)
    return 0;
 }
 
-
+#ifdef HAVE_ECC_DHE
 /**
   Create an ECC shared secret between two keys
   private_key      The private ECC key
   public_key       The public key
   out              [out] Destination of the shared secret
-                   Conforms to EC-DH from ANSI X9.63
+                         Conforms to EC-DH from ANSI X9.63
   outlen           [in/out] The max size and resulting size of the shared secret
   return           MP_OKAY if successful
 */
@@ -1533,10 +1561,12 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
       return ECC_BAD_ARG_E;
    }
 
+   /* Verify domain params supplied */
    if (wc_ecc_is_valid_idx(private_key->idx) == 0 ||
        wc_ecc_is_valid_idx(public_key->idx)  == 0)
       return ECC_BAD_ARG_E;
 
+   /* Verify curve name matches */
    if (XSTRNCMP(private_key->dp->name, public_key->dp->name, ECC_MAXNAME) != 0)
       return ECC_BAD_ARG_E;
 
@@ -1576,14 +1606,14 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
 }
 
 /**
- Create an ECC shared secret between two keys
+ Create an ECC shared secret between private key and public point
  private_key      The private ECC key
- point              The point to use (public key)
+ point            The point to use (public key)
  out              [out] Destination of the shared secret
- Conforms to EC-DH from ANSI X9.63
+                        Conforms to EC-DH from ANSI X9.63
  outlen           [in/out] The max size and resulting size of the shared secret
  return           MP_OKAY if successful
- */
+*/
 int wc_ecc_shared_secret_ssh(ecc_key* private_key, ecc_point* point,
                              byte* out, word32 *outlen)
 {
@@ -1600,6 +1630,7 @@ int wc_ecc_shared_secret_ssh(ecc_key* private_key, ecc_point* point,
         return ECC_BAD_ARG_E;
     }
 
+    /* Verify domain params supplied */
     if (wc_ecc_is_valid_idx(private_key->idx) == 0)
         return ECC_BAD_ARG_E;
 
@@ -1637,7 +1668,7 @@ int wc_ecc_shared_secret_ssh(ecc_key* private_key, ecc_point* point,
 
     return err;
 }
-
+#endif /* HAVE_ECC_DHE */
 
 /* return 1 if point is at infinity, 0 if not, < 0 on error */
 int wc_ecc_point_is_at_infinity(ecc_point* p)
@@ -1832,6 +1863,8 @@ int wc_ecc_init(ecc_key* key)
 }
 
 
+#ifdef HAVE_ECC_SIGN
+
 #ifndef NO_ASN
 /**
  Sign a message digest
@@ -1973,7 +2006,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 
    return err;
 }
-
+#endif /* HAVE_ECC_SIGN */
 
 /**
   Free an ECC key from memory
@@ -2227,7 +2260,7 @@ static int ecc_mul2add(ecc_point* A, mp_int* kA,
 #endif /* ECC_SHAMIR */
 
 
-
+#ifdef HAVE_ECC_VERIFY
 #ifndef NO_ASN
 /* verify
  *
@@ -2444,7 +2477,9 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 
    return err;
 }
+#endif /* HAVE_ECC_VERIFY */
 
+#ifdef HAVE_ECC_KEY_IMPORT
 /* import point from der */
 int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
                             ecc_point* point)
@@ -2566,7 +2601,9 @@ int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
 
     return err;
 }
+#endif /* HAVE_ECC_KEY_IMPORT */
 
+#ifdef HAVE_ECC_KEY_EXPORT
 /* export point to der */
 int wc_ecc_export_point_der(const int curve_idx, ecc_point* point, byte* out,
                             word32* outLen)
@@ -2716,7 +2753,7 @@ int wc_ecc_export_x963_ex(ecc_key* key, byte* out, word32* outLen,
 
     return NOT_COMPILED_IN;
 }
-
+#endif /* HAVE_ECC_KEY_EXPORT */
 
 /* is ec point on curve described by dp ? */
 static int ecc_is_point(const ecc_set_type* dp, ecc_point* ecp, mp_int* prime)
@@ -2920,7 +2957,7 @@ int wc_ecc_check_key(ecc_key* key)
     return err;
 }
 
-
+#ifdef HAVE_ECC_KEY_IMPORT
 /* import public ECC key in ANSI X9.63 format */
 int wc_ecc_import_x963(const byte* in, word32 inLen, ecc_key* key)
 {
@@ -3069,8 +3106,9 @@ int wc_ecc_import_x963(const byte* in, word32 inLen, ecc_key* key)
 
    return err;
 }
+#endif /* HAVE_ECC_KEY_IMPORT */
 
-
+#ifdef HAVE_ECC_KEY_EXPORT
 /* export ecc private key only raw, outLen is in/out size
    return MP_OKAY on success */
 int wc_ecc_export_private_only(ecc_key* key, byte* out, word32* outLen)
@@ -3094,8 +3132,9 @@ int wc_ecc_export_private_only(ecc_key* key, byte* out, word32* outLen)
    return mp_to_unsigned_bin(&key->k, out + (numlen -
                                              mp_unsigned_bin_size(&key->k)));
 }
+#endif /* HAVE_ECC_KEY_EXPORT */
 
-
+#ifdef HAVE_ECC_KEY_IMPORT
 /* ecc private key import, public key in ANSI X9.63 format, private raw */
 int wc_ecc_import_private_key(const byte* priv, word32 privSz, const byte* pub,
                            word32 pubSz, ecc_key* key)
@@ -3115,6 +3154,7 @@ int wc_ecc_import_private_key(const byte* priv, word32 privSz, const byte* pub,
 
     return ret;
 }
+#endif /* HAVE_ECC_KEY_IMPORT */
 
 #ifndef NO_ASN
 /**
@@ -3158,6 +3198,7 @@ int wc_ecc_rs_to_sig(const char* r, const char* s, byte* out, word32* outlen)
 }
 #endif /* !NO_ASN */
 
+#ifdef HAVE_ECC_KEY_IMPORT
 /**
    Import raw ECC key
    key       The destination ecc_key structure
@@ -3241,7 +3282,7 @@ int wc_ecc_import_raw(ecc_key* key, const char* qx, const char* qy,
 
     return err;
 }
-
+#endif /* HAVE_ECC_KEY_IMPORT */
 
 /* key size in octets */
 int wc_ecc_size(ecc_key* key)

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1832,6 +1832,7 @@ int wc_ecc_init(ecc_key* key)
 }
 
 
+#ifndef NO_ASN
 /**
  Sign a message digest
  in        The message digest to sign
@@ -1865,6 +1866,7 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
 
     return err;
 }
+#endif /* !NO_ASN */
 
 /**
   Sign a message digest
@@ -2226,6 +2228,7 @@ static int ecc_mul2add(ecc_point* A, mp_int* kA,
 
 
 
+#ifndef NO_ASN
 /* verify
  *
  * w  = s^-1 mod n
@@ -2276,6 +2279,7 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
 
     return err;
 }
+#endif /* !NO_ASN */
 
 /**
    Verify an ECC signature
@@ -3112,6 +3116,7 @@ int wc_ecc_import_private_key(const byte* priv, word32 privSz, const byte* pub,
     return ret;
 }
 
+#ifndef NO_ASN
 /**
    Convert ECC R,S to signature
    r       R component of signature
@@ -3151,6 +3156,7 @@ int wc_ecc_rs_to_sig(const char* r, const char* s, byte* out, word32* outlen)
 
     return err;
 }
+#endif /* !NO_ASN */
 
 /**
    Import raw ECC key

--- a/wolfcrypt/src/signature.c
+++ b/wolfcrypt/src/signature.c
@@ -38,7 +38,7 @@
 #endif
 
 /* If ECC and RSA are disabled then disable signature wrapper */
-#if !defined(HAVE_ECC) && defined(NO_RSA)
+#if (!defined(HAVE_ECC) || (defined(HAVE_ECC) && !defined(NO_ASN))) && defined(NO_RSA)
     #undef NO_SIG_WRAPPER
     #define NO_SIG_WRAPPER
 #endif
@@ -54,7 +54,7 @@ static int wc_SignatureDerEncode(enum wc_HashType hash_type, byte** hash_data,
     if (ret > 0) {
         int oid = ret;
 
-        /* Allocate buffer for hash and encoded ASN header */
+        /* Allocate buffer for hash and max DER encoded */
         word32 digest_len = *hash_len + MAX_DER_DIGEST_SZ;
         byte *digest_buf = (byte*)XMALLOC(digest_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (digest_buf) {
@@ -62,7 +62,7 @@ static int wc_SignatureDerEncode(enum wc_HashType hash_type, byte** hash_data,
             if (ret > 0) {
                 digest_len = ret;
 
-                /* Replace hash with digest (encoded ASN header + hash) */
+                /* Replace hash with digest (DER encoding + hash) */
                 XFREE(*hash_data, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 *hash_data = digest_buf;
                 *hash_len = digest_len;
@@ -194,7 +194,7 @@ int wc_SignatureVerify(
                     break;
                 }
                 /* Otherwise fall-through and perform normal RSA verify against updated
-                 * hash + encoded ASN header */
+                 * DER encoding + hash */
 #endif
 
             case WC_SIGNATURE_TYPE_RSA:
@@ -310,8 +310,8 @@ int wc_SignatureGenerate(
                 if (ret < 0) {
                     break;
                 }
-                /* Otherwise fall-through and perform normal RSA verify against updated
-                 * hash + encoded ASN header */
+                /* Otherwise fall-through and perform normal RSA sign against updated
+                 * DER encoding + hash */
 #endif
 
             case WC_SIGNATURE_TYPE_RSA:

--- a/wolfcrypt/src/signature.c
+++ b/wolfcrypt/src/signature.c
@@ -38,7 +38,8 @@
 #endif
 
 /* If ECC and RSA are disabled then disable signature wrapper */
-#if (!defined(HAVE_ECC) || (defined(HAVE_ECC) && !defined(NO_ASN))) && defined(NO_RSA)
+#if (!defined(HAVE_ECC) || (defined(HAVE_ECC) && !defined(HAVE_ECC_SIGN) \
+    && !defined(HAVE_ECC_VERIFY))) && defined(NO_RSA)
     #undef NO_SIG_WRAPPER
     #define NO_SIG_WRAPPER
 #endif
@@ -169,7 +170,7 @@ int wc_SignatureVerify(
         switch(sig_type) {
             case WC_SIGNATURE_TYPE_ECC:
             {
-#ifdef HAVE_ECC
+#if defined(HAVE_ECC) && defined(HAVE_ECC_VERIFY)
                 int is_valid_sig = 0;
 
                 /* Perform verification of signature using provided ECC key */
@@ -292,7 +293,7 @@ int wc_SignatureGenerate(
         /* Create signature using hash as data */
         switch(sig_type) {
             case WC_SIGNATURE_TYPE_ECC:
-#ifdef HAVE_ECC
+#if defined(HAVE_ECC) && defined(HAVE_ECC_SIGN)
                 /* Create signature using provided ECC key */
                 ret = wc_ecc_sign_hash(hash_data, hash_len, sig, sig_len, rng, (ecc_key*)key);
 #else

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6172,7 +6172,8 @@ int ecc_test(void)
     WC_RNG  rng;
     byte    sharedA[1024];
     byte    sharedB[1024];
-#ifndef NO_ASN
+#if !defined(NO_ASN) || (!defined(NO_SHA) && \
+        ((defined(HAVE_ECC192) && defined(HAVE_ECC224)) || defined(HAVE_ALL_CURVES)))
     byte    sig[1024];
     int     verify;
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6172,8 +6172,8 @@ int ecc_test(void)
     WC_RNG  rng;
     byte    sharedA[1024];
     byte    sharedB[1024];
-#if !defined(NO_ASN) || (!defined(NO_SHA) && \
-        ((defined(HAVE_ECC192) && defined(HAVE_ECC224)) || defined(HAVE_ALL_CURVES)))
+#if !defined(NO_SHA) && \
+        ((defined(HAVE_ECC192) && defined(HAVE_ECC224)) || defined(HAVE_ALL_CURVES))
     byte    sig[1024];
     int     verify;
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6172,11 +6172,14 @@ int ecc_test(void)
     WC_RNG  rng;
     byte    sharedA[1024];
     byte    sharedB[1024];
+#ifndef NO_ASN
     byte    sig[1024];
+    int     verify;
+#endif
     byte    digest[20];
     byte    exportBuf[1024];
     word32  x, y;
-    int     i, verify, ret;
+    int     i, ret;
     ecc_key userA, userB, pubKey;
 
     ret = wc_InitRng(&rng);
@@ -6266,6 +6269,7 @@ int ecc_test(void)
     for (i = 0; i < (int)sizeof(digest); i++)
         digest[i] = (byte)i;
 
+#ifndef NO_ASN
     x = sizeof(sig);
     ret = wc_ecc_sign_hash(digest, sizeof(digest), sig, &x, &rng, &userA);
 
@@ -6280,6 +6284,7 @@ int ecc_test(void)
 
     if (verify != 1)
         return -1016;
+#endif
 
     x = sizeof(exportBuf);
     ret = wc_ecc_export_private_only(&userA, exportBuf, &x);

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -143,24 +143,34 @@ WOLFSSL_API
 int wc_ecc_make_key(WC_RNG* rng, int keysize, ecc_key* key);
 WOLFSSL_API
 int wc_ecc_check_key(ecc_key* key);
+
+#ifdef HAVE_ECC_DHE
 WOLFSSL_API
 int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
                       word32* outlen);
 WOLFSSL_API
 int wc_ecc_shared_secret_ssh(ecc_key* private_key, ecc_point* point,
                              byte* out, word32 *outlen);
+#endif /* HAVE_ECC_DHE */
+
+#ifdef HAVE_ECC_SIGN
 WOLFSSL_API
 int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
                      WC_RNG* rng, ecc_key* key);
 WOLFSSL_API
 int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
                         ecc_key* key, mp_int *r, mp_int *s);
+#endif /* HAVE_ECC_SIGN */
+
+#ifdef HAVE_ECC_VERIFY
 WOLFSSL_API
 int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
                     word32 hashlen, int* stat, ecc_key* key);
 WOLFSSL_API
 int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
                           word32 hashlen, int* stat, ecc_key* key);
+#endif /* HAVE_ECC_VERIFY */
+
 WOLFSSL_API
 int wc_ecc_init(ecc_key* key);
 WOLFSSL_API
@@ -184,12 +194,16 @@ WOLFSSL_API
 int wc_ecc_mulmod(mp_int* k, ecc_point *G, ecc_point *R,
                   mp_int* modulus, int map);
 
+#ifdef HAVE_ECC_KEY_EXPORT
 /* ASN key helpers */
 WOLFSSL_API
 int wc_ecc_export_x963(ecc_key*, byte* out, word32* outLen);
 WOLFSSL_API
 int wc_ecc_export_x963_ex(ecc_key*, byte* out, word32* outLen, int compressed);
     /* extended functionality with compressed option */
+#endif /* HAVE_ECC_KEY_EXPORT */
+
+#ifdef HAVE_ECC_KEY_IMPORT
 WOLFSSL_API
 int wc_ecc_import_x963(const byte* in, word32 inLen, ecc_key* key);
 WOLFSSL_API
@@ -200,16 +214,22 @@ int wc_ecc_rs_to_sig(const char* r, const char* s, byte* out, word32* outlen);
 WOLFSSL_API
 int wc_ecc_import_raw(ecc_key* key, const char* qx, const char* qy,
                    const char* d, const char* curveName);
+#endif /* HAVE_ECC_KEY_IMPORT */
 
+#ifdef HAVE_ECC_KEY_EXPORT
 WOLFSSL_API
 int wc_ecc_export_private_only(ecc_key* key, byte* out, word32* outLen);
 
 WOLFSSL_API
 int wc_ecc_export_point_der(const int curve_idx, ecc_point* point,
                             byte* out, word32* outLen);
+#endif /* HAVE_ECC_KEY_EXPORT */
+
+#ifdef HAVE_ECC_KEY_IMPORT
 WOLFSSL_API
 int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
                             ecc_point* point);
+#endif /* HAVE_ECC_KEY_IMPORT */
 
 /* size helper */
 WOLFSSL_API

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1004,6 +1004,31 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #endif
 #endif
 
+/* ECC Configs */
+#ifdef HAVE_ECC
+    /* By default enable Sign, Verify, DHE, Key Import and Key Export unless explicitly disabled */
+    #ifndef NO_ECC_SIGN
+        #undef HAVE_ECC_SIGN
+        #define HAVE_ECC_SIGN
+    #endif
+    #ifndef NO_ECC_VERIFY
+        #undef HAVE_ECC_VERIFY
+        #define HAVE_ECC_VERIFY
+    #endif
+    #ifndef NO_ECC_DHE
+        #undef HAVE_ECC_DHE
+        #define HAVE_ECC_DHE
+    #endif
+    #ifndef NO_ECC_KEY_IMPORT
+        #undef HAVE_ECC_KEY_IMPORT
+        #define HAVE_ECC_KEY_IMPORT
+    #endif
+    #ifndef NO_ECC_KEY_EXPORT
+        #undef HAVE_ECC_KEY_EXPORT
+        #define HAVE_ECC_KEY_EXPORT
+    #endif
+#endif /* HAVE_ECC */
+
 /* if desktop type system and fastmath increase default max bits */
 #ifdef WOLFSSL_X86_64_BUILD
     #ifdef USE_FAST_MATH

--- a/wolfssl/wolfcrypt/signature.h
+++ b/wolfssl/wolfcrypt/signature.h
@@ -34,7 +34,7 @@ enum wc_SignatureType {
     WC_SIGNATURE_TYPE_NONE = 0,
     WC_SIGNATURE_TYPE_ECC = 1,
     WC_SIGNATURE_TYPE_RSA = 2,
-    WC_SIGNATURE_TYPE_RSA_W_ENC = 3, /* Adds ASN algo header via wc_EncodeSignature */
+    WC_SIGNATURE_TYPE_RSA_W_ENC = 3, /* Adds DER header via wc_EncodeSignature */
 };
 
 WOLFSSL_API int wc_SignatureGetSize(enum wc_SignatureType sig_type,


### PR DESCRIPTION
Fixes so ECC only build works (include.am will enable bigint math for ECC only). Add new ECC build options for Sign, Verify, DHE, Key Import and Key Export. Add new NO_ASN_TIME option to reduce ASN size for ECC only build with sign or verify. Build fixes in signature.c if ECC enabled, but missing ECC sign or verify.