### PR TITLE
Check build_addr() arguments for NULL

### DIFF
--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -521,6 +521,9 @@ static INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
     (void)useLookup;
     (void)udp;
 
+    if (addr == NULL || peer == NULL)
+        err_sys("invalid arguments to build_addr, addr or peer is NULL");
+
     memset(addr, 0, sizeof(SOCKADDR_IN_T));
 
 #ifndef TEST_IPV6


### PR DESCRIPTION
Check inputs to build_addr() in <wolfssl/test.h> for NULL.  Bug fix from Zendesk ticket 1748.