### PR TITLE
Added new CUSTOM_RAND_GENERATE_BLOCK option that allows override and …

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -89,6 +89,38 @@ int  wc_RNG_GenerateByte(WC_RNG* rng, byte* b)
 #else /* else build without fips */
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
+/* Allow custom RNG system */
+#ifdef CUSTOM_RAND_GENERATE_BLOCK
+
+int wc_InitRng(WC_RNG* rng)
+{
+    (void)rng;
+    return 0;
+}
+
+int wc_RNG_GenerateBlock(WC_RNG* rng, byte* output, word32 sz)
+{
+    (void)rng;
+    XMEMSET(output, 0, sz);
+    return CUSTOM_RAND_GENERATE_BLOCK(output, sz);
+}
+
+
+int wc_RNG_GenerateByte(WC_RNG* rng, byte* b)
+{
+    return wc_RNG_GenerateBlock(rng, b, 1);
+}
+
+
+int wc_FreeRng(WC_RNG* rng)
+{
+    (void)rng;
+    return 0;
+}
+
+#else
+
+/* Use HASHDRGB with SHA256 */
 #if defined(HAVE_HASHDRBG) || defined(NO_RC4)
 
     #include <wolfssl/wolfcrypt/sha256.h>
@@ -1432,5 +1464,6 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 }
 
 #endif /* USE_WINDOWS_API */
+#endif /* CUSTOM_RAND_GENERATE_BLOCK */
 #endif /* HAVE_FIPS */
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -3559,7 +3559,7 @@ int idea_test(void)
 #endif /* HAVE_IDEA */
 
 
-#if defined(HAVE_HASHDRBG) || defined(NO_RC4)
+#if (defined(HAVE_HASHDRBG) || defined(NO_RC4)) && !defined(CUSTOM_RAND_GENERATE_BLOCK)
 
 int random_test(void)
 {
@@ -3635,7 +3635,7 @@ int random_test(void)
     return 0;
 }
 
-#else /* HAVE_HASHDRBG || NO_RC4 */
+#else /* (HAVE_HASHDRBG || NO_RC4) && !CUSTOM_RAND_GENERATE_BLOCK */
 
 int random_test(void)
 {
@@ -3658,7 +3658,7 @@ int random_test(void)
     return 0;
 }
 
-#endif /* HAVE_HASHDRBG || NO_RC4 */
+#endif /* (HAVE_HASHDRBG || NO_RC4) && !CUSTOM_RAND_GENERATE_BLOCK */
 
 
 #ifdef HAVE_NTRU

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -67,8 +67,8 @@ typedef struct OS_Seed {
     #endif
 } OS_Seed;
 
-#if defined(HAVE_HASHDRBG) || defined(NO_RC4)
 
+#if (defined(HAVE_HASHDRBG) || defined(NO_RC4)) && !defined(CUSTOM_RAND_GENERATE_BLOCK)
 
 #define DRBG_SEED_LEN (440/8)
 
@@ -84,8 +84,8 @@ typedef struct WC_RNG {
 } WC_RNG;
 
 
-#else /* HAVE_HASHDRBG || NO_RC4 */
 
+#else /* (HAVE_HASHDRBG || NO_RC4) && !CUSTOM_RAND_GENERATE_BLOCK */
 
 #define WOLFSSL_RNG_CAVIUM_MAGIC 0xBEEF0004
 
@@ -94,7 +94,9 @@ typedef struct WC_RNG {
 
 typedef struct WC_RNG {
     OS_Seed seed;
+#ifndef NO_RC4
     Arc4    cipher;
+#endif
 #ifdef HAVE_CAVIUM
     int    devId;           /* nitrox device id */
     word32 magic;           /* using cavium magic */
@@ -102,8 +104,8 @@ typedef struct WC_RNG {
 } WC_RNG;
 
 
-#endif /* HAVE_HASH_DRBG || NO_RC4 */
 
+#endif /* (HAVE_HASHDRBG || NO_RC4) && !CUSTOM_RAND_GENERATE_BLOCK */
 #endif /* HAVE_FIPS */
 
 /* NO_OLD_RNGNAME removes RNG struct name to prevent possible type conflicts,

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1019,9 +1019,9 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #define NO_OLD_TLS
 #endif
 
-/* If not forcing to use ARC4 as the DRBG, always enable Hash_DRBG */
+/* If not forcing ARC4 as the DRBG or using custom RNG block gen, enable Hash_DRBG */
 #undef HAVE_HASHDRBG
-#ifndef WOLFSSL_FORCE_RC4_DRBG
+#if !defined(WOLFSSL_FORCE_RC4_DRBG) && !defined(CUSTOM_RAND_GENERATE_BLOCK)
     #define HAVE_HASHDRBG
 #endif
 


### PR DESCRIPTION
…disabling of the HASHDRBG for customers who have a HW RNG they would like to use instead.

Examples:
"./configure --disable-hashdrbg CFLAGS="-DCUSTOM_RAND_GENERATE_BLOCK= custom_rand_generate_block".
OR
/* RNG */
//#define HAVE_HASHDRBG
extern int custom_rand_generate_block(unsigned char* output, unsigned int sz);
#define CUSTOM_RAND_GENERATE_BLOCK  custom_rand_generate_block
#define NO_RC4