### PR TITLE
Fixes build error with NO_FILESYSTEM and !NO_CERTS

### DIFF
--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -132,7 +132,7 @@ void echoclient_test(void* args)
     #endif
 #elif !defined(NO_CERTS)
     if (!doPSK)
-        load_buffer(ctx, caCert, CYASSL_CA);
+        load_buffer(ctx, caCert, WOLFSSL_CA);
 #endif
 
 #if defined(CYASSL_SNIFFER)

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -191,8 +191,8 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
     } /* doPSK */
 #elif !defined(NO_CERTS)
     if (!doPSK) {
-        load_buffer(ctx, svrCert, CYASSL_CERT);
-        load_buffer(ctx, svrKey,  CYASSL_KEY);
+        load_buffer(ctx, svrCert, WOLFSSL_CERT);
+        load_buffer(ctx, svrKey,  WOLFSSL_KEY);
     }
 #endif
 


### PR DESCRIPTION
Where the wolfssl/test.h load_buffer() function is passing non-existent enum value. Was renamed from CYASSL_ to WOLFSSL_ at some point previously.