### PR TITLE
DTLS Handshake Update

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7689,6 +7689,12 @@ int ProcessReply(WOLFSSL* ssl)
 
                 case application_data:
                     WOLFSSL_MSG("got app DATA");
+                    #ifdef WOLFSSL_DTLS
+                        if (ssl->options.dtls && ssl->options.dtlsHsRetain) {
+                            FreeHandshakeResources(ssl);
+                            ssl->options.dtlsHsRetain = 0;
+                        }
+                    #endif
                     if ((ret = DoApplicationData(ssl,
                                                 ssl->buffers.inputBuffer.buffer,
                                                &ssl->buffers.inputBuffer.idx))
@@ -7819,7 +7825,7 @@ int SendChangeCipher(WOLFSSL* ssl)
 
     if (ssl->options.groupMessages)
         return 0;
-    #ifdef WOLFSSL_DTLS
+    #if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_DEBUG_DTLS)
     else if (ssl->options.dtls) {
         /* If using DTLS, force the ChangeCipherSpec message to be in the
          * same datagram as the finished message. */

--- a/src/io.c
+++ b/src/io.c
@@ -404,7 +404,10 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 
     WOLFSSL_ENTER("EmbedReceiveFrom()");
 
-    if (!wolfSSL_get_using_nonblock(ssl) && dtls_timeout != 0) {
+    if (ssl->options.handShakeDone)
+        dtls_timeout = 0;
+
+    if (!wolfSSL_get_using_nonblock(ssl)) {
         #ifdef USE_WINDOWS_API
             DWORD timeout = dtls_timeout * 1000;
         #else

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5985,7 +5985,16 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                 }
             }
 #endif /* NO_HANDSHAKE_DONE_CB */
-            FreeHandshakeResources(ssl);
+
+            if (!ssl->options.dtls) {
+                FreeHandshakeResources(ssl);
+            }
+#ifdef WOLFSSL_DTLS
+            else {
+                ssl->options.dtlsHsRetain = 1;
+            }
+#endif /* WOLFSSL_DTLS */
+
             WOLFSSL_LEAVE("SSL_connect()", SSL_SUCCESS);
             return SSL_SUCCESS;
 
@@ -6259,7 +6268,16 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                 }
             }
 #endif /* NO_HANDSHAKE_DONE_CB */
-            FreeHandshakeResources(ssl);
+
+            if (!ssl->options.dtls) {
+                FreeHandshakeResources(ssl);
+            }
+#ifdef WOLFSSL_DTLS
+            else {
+                ssl->options.dtlsHsRetain = 1;
+            }
+#endif /* WOLFSSL_DTLS */
+
             WOLFSSL_LEAVE("SSL_accept()", SSL_SUCCESS);
             return SSL_SUCCESS;
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2255,6 +2255,9 @@ typedef struct Options {
     word16            createTicket:1;     /* Server to create new Ticket */
     word16            useTicket:1;        /* Use Ticket not session cache */
 #endif
+#ifdef WOLFSSL_DTLS
+    word16            dtlsHsRetain:1;     /* DTLS retaining HS data */
+#endif
 
     /* need full byte values for this section */
     byte            processReply;           /* nonblocking resume */


### PR DESCRIPTION
An endpoint retains the handshake resources after the handshake is done until the peer's first application data message is received where it is freed. The receive-from IO callback also needs to stop timing out once the handshake completes.