### PR TITLE
Always execute wc_InitRsaKey if we are always going to execute wc_Fre…

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3586,13 +3586,11 @@ static int ConfirmSignature(const byte* buf, word32 bufSz,
                 break; /* not confirmed */
             }
 #endif
-
-            if (sigSz > MAX_ENCODED_SIG_SZ) {
-                WOLFSSL_MSG("Verify Signature is too big");
-            }
-
             if (wc_InitRsaKey(pubKey, heap) != 0) {
                 WOLFSSL_MSG("InitRsaKey failed");
+            }
+            else if (sigSz > MAX_ENCODED_SIG_SZ) {
+                WOLFSSL_MSG("Verify Signature is too big");
             }
             else if (wc_RsaPublicKeyDecode(key, &idx, pubKey, keySz) < 0) {
                 WOLFSSL_MSG("ASN Key decode error RSA");

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3590,7 +3590,8 @@ static int ConfirmSignature(const byte* buf, word32 bufSz,
             if (sigSz > MAX_ENCODED_SIG_SZ) {
                 WOLFSSL_MSG("Verify Signature is too big");
             }
-            else if (wc_InitRsaKey(pubKey, heap) != 0) {
+
+            if (wc_InitRsaKey(pubKey, heap) != 0) {
                 WOLFSSL_MSG("InitRsaKey failed");
             }
             else if (wc_RsaPublicKeyDecode(key, &idx, pubKey, keySz) < 0) {


### PR DESCRIPTION
…eRsaKey

As discussed yesterday, removed from if..else if and cause initRsaKey to always be executed.