### PR TITLE
avoid dereference of null pointer if args is null

### DIFF
--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -846,7 +846,6 @@ static INLINE void tcp_accept(SOCKET_T* sockfd, SOCKET_T* clientfd,
 
     #if defined(_POSIX_THREADS) && defined(NO_MAIN_DRIVER) && !defined(__MINGW32__)
         /* signal ready to tcp_accept */
-        {
         if (args)
             ready = args->signal;
         if (ready) {
@@ -855,7 +854,6 @@ static INLINE void tcp_accept(SOCKET_T* sockfd, SOCKET_T* clientfd,
             ready->port = port;
             pthread_cond_signal(&ready->cond);
             pthread_mutex_unlock(&ready->mutex);
-        }
         }
     #elif defined (WOLFSSL_TIRTOS)
         /* Need mutex? */

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -870,7 +870,8 @@ static INLINE void tcp_accept(SOCKET_T* sockfd, SOCKET_T* clientfd,
         if (ready_file) {
         #ifndef NO_FILESYSTEM
             FILE* srf = NULL;
-            ready = args ? args->signal : NULL;
+            if (args)
+                ready = args->signal;
 
             if (ready) {
                 srf = fopen(ready->srfName, "w");

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -836,6 +836,8 @@ static INLINE void tcp_accept(SOCKET_T* sockfd, SOCKET_T* clientfd,
     socklen_t client_len = sizeof(client);
     tcp_ready* ready = NULL;
 
+    (void) ready; /* Account for case when "ready" is not used */
+
     if (udp) {
         udp_accept(sockfd, clientfd, useAnyAddr, port, args);
         return;


### PR DESCRIPTION
```
847 #if defined(_POSIX_THREADS) && defined(NO_MAIN_DRIVER) && !defined(__MINGW32__)
849     ready = args->signal        // dereferences 'args' without a null check (could seg fault)
...
859 #elif defined (WOLFSSL_TIRTOS)
860     ready = args->signal       //  dereferences 'args' without a null check (could seg fault)
...
866 #ifndef NO_FILESYSTEM
868     ready = args ? args->signal : NULL;  // null check on args before dereference (good)
```    