### PR TITLE
Asynchronous crypto and wolf event support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ cyassl.sublime*
 fips.c
 fips_test.c
 fips
+src/async.c
+wolfssl/async.h
 ctaocrypt/benchmark/benchmark
 ctaocrypt/test/testctaocrypt
 wolfcrypt/benchmark/benchmark

--- a/autogen.sh
+++ b/autogen.sh
@@ -18,6 +18,10 @@ if test -d .git; then
   # touch fips files for non fips distribution
   touch ./ctaocrypt/src/fips.c
   touch ./ctaocrypt/src/fips_test.c
+
+  # touch async crypt files
+  touch ./src/async.c
+  touch ./wolfssl/async.h
 else
   WARNINGS="all"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -2505,6 +2505,27 @@ fi
 AM_CONDITIONAL([BUILD_MCAPI], [test "x$ENABLED_MCAPI" = "xyes"])
 
 
+# Asynchronous Crypto
+AC_ARG_ENABLE([asynccrypt],
+    [  --enable-asynccrypt    Enable Asynchronous Crypto (default: disabled)],
+    [ ENABLED_ASYNCCRYPT=$enableval ],
+    [ ENABLED_ASYNCCRYPT=no ]
+    )
+
+if test "$ENABLED_ASYNCCRYPT" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ASYNC_CRYPT"
+    
+    # if Cavium not enabled the use async simulator for testing
+    if test "x$ENABLED_CAVIUM" = "xno"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ASYNC_CRYPT_TEST"
+    fi
+fi
+
+AM_CONDITIONAL([BUILD_ASYNCCRYPT], [test "x$ENABLED_ASYNCCRYPT" = "xyes"])
+
+
 # check if PSK was enabled for conditionally running psk.test script
 AM_CONDITIONAL([BUILD_PSK], [test "x$ENABLED_PSK" = "xyes"])
 
@@ -2836,5 +2857,6 @@ echo "   * LIBZ:                       $ENABLED_LIBZ"
 echo "   * Examples:                   $ENABLED_EXAMPLES"
 echo "   * User Crypto:                $ENABLED_USER_CRYPTO"
 echo "   * Fast RSA:                   $ENABLED_FAST_RSA"
+echo "   * Async Crypto:               $ENABLED_ASYNCCRYPT"
 echo ""
 echo "---"

--- a/configure.ac
+++ b/configure.ac
@@ -2860,3 +2860,9 @@ echo "   * Fast RSA:                   $ENABLED_FAST_RSA"
 echo "   * Async Crypto:               $ENABLED_ASYNCCRYPT"
 echo ""
 echo "---"
+
+# Show warnings at bottom so they are noticed
+if test "$ENABLED_ASYNCCRYPT" = "yes"
+then
+    AC_MSG_WARN([Make sure real async files are loaded. Contact wolfSSL for details on using the asynccrypt option.])
+fi

--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -177,7 +177,7 @@ void echoclient_test(void* args)
     do {
 #ifdef WOLFSSL_ASYNC_CRYPT
         if (err == WC_PENDING_E) {
-            ret = AsyncCryptPoll(ctx, ssl);
+            ret = AsyncCryptPoll(ssl);
             if (ret < 0) { break; } else if (ret == 0) { continue; }
         }
 #endif

--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -68,6 +68,7 @@ void echoclient_test(void* args)
     SSL_CTX*    ctx    = 0;
     SSL*        ssl    = 0;
 
+    int ret = 0, err = 0;
     int doDTLS = 0;
     int doPSK = 0;
     int sendSz;
@@ -173,7 +174,25 @@ void echoclient_test(void* args)
     Sleep(100);
 #endif
 
-    if (SSL_connect(ssl) != SSL_SUCCESS) err_sys("SSL_connect failed");
+    do {
+#ifdef WOLFSSL_ASYNC_CRYPT
+        if (err == WC_PENDING_E) {
+            ret = AsyncCryptPoll(ctx, ssl);
+            if (ret < 0) { break; } else if (ret == 0) { continue; }
+        }
+#endif
+        err = 0; /* Reset error */
+        ret = SSL_connect(ssl);
+        if (ret != SSL_SUCCESS) {
+            err = SSL_get_error(ssl, 0);
+        }
+    } while (ret != SSL_SUCCESS && err == WC_PENDING_E);
+
+    if (ret != SSL_SUCCESS) {
+        char buffer[CYASSL_MAX_ERROR_SZ];
+        printf("err = %d, %s\n", err, ERR_error_string(err, buffer));
+        err_sys("SSL_connect failed");
+    }
 
     while (fgets(msg, sizeof(msg), fin) != 0) {
      

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -266,7 +266,7 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
         do {
 #ifdef WOLFSSL_ASYNC_CRYPT
             if (err == WC_PENDING_E) {
-                ret = AsyncCryptPoll(ctx, ssl);
+                ret = AsyncCryptPoll(ssl);
                 if (ret < 0) { break; } else if (ret == 0) { continue; }
             }
 #endif

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -843,7 +843,7 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
         do {
 #ifdef WOLFSSL_ASYNC_CRYPT
             if (err == WC_PENDING_E) {
-                ret = AsyncCryptPoll(ctx, ssl);
+                ret = AsyncCryptPoll(ssl);
                 if (ret < 0) { break; } else if (ret == 0) { continue; }
             }
 #endif

--- a/src/include.am
+++ b/src/include.am
@@ -250,4 +250,8 @@ if BUILD_SNIFFER
 src_libwolfssl_la_SOURCES += src/sniffer.c
 endif
 
+if BUILD_ASYNCCRYPT
+src_libwolfssl_la_SOURCES += src/async.c
+endif
+
 endif # !BUILD_CRYPTONLY

--- a/src/internal.c
+++ b/src/internal.c
@@ -2106,7 +2106,7 @@ int DhAgree(WOLFSSL* ssl,
 {
     int ret;
     DhKey dhKey;
-    
+
 #if defined(WOLFSSL_ASYNC_CRYPT_TEST)
     if (ssl->options.side == WOLFSSL_SERVER_END &&
         ssl->asyncCryptTest.type == ASYNC_TEST_NONE)
@@ -13408,7 +13408,7 @@ static word32 QSH_KeyExchangeWrite(WOLFSSL* ssl, byte isServer)
                     XMEMCPY(es, ssl->arrays->client_identity, esSz);
                     es += esSz;
                     encSz = esSz + OPAQUE16_LEN;
-                    
+
                     ret = DhAgree(ssl,
                         serverP.buffer, serverP.length,
                         serverG.buffer, serverG.length,
@@ -15065,7 +15065,6 @@ int DoSessionTicket(WOLFSSL* ssl,
                 #if !defined(NO_DH) && !defined(NO_RSA)
                     case diffie_hellman_kea:
                     {
-                        int typeH = 0;
                         enum wc_HashType hashType = WC_HASH_TYPE_NONE;
 
                         idx = RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ;
@@ -15173,28 +15172,24 @@ int DoSessionTicket(WOLFSSL* ssl,
                                 case sha512_mac:
                                     #ifdef WOLFSSL_SHA512
                                         hashType = WC_HASH_TYPE_SHA512;
-                                        typeH    = SHA512h;
                                     #endif
                                     break;
 
                                 case sha384_mac:
                                     #ifdef WOLFSSL_SHA384
                                         hashType = WC_HASH_TYPE_SHA384;
-                                        typeH    = SHA384h;
                                     #endif
                                     break;
 
                                 case sha256_mac:
                                     #ifndef NO_SHA256
                                         hashType = WC_HASH_TYPE_SHA256;
-                                        typeH    = SHA256h;
                                     #endif
                                     break;
 
                                 case sha_mac:
                                     #ifndef NO_OLD_TLS
                                         hashType = WC_HASH_TYPE_SHA;
-                                        typeH    = SHAh;
                                     #endif
                                     break;
 
@@ -15256,10 +15251,36 @@ int DoSessionTicket(WOLFSSL* ssl,
                             {
                                 /* For TLS 1.2 re-encode signature */
                                 if (IsAtLeastTLSv1_2(ssl)) {
+                                    int typeH = 0;
                                     byte* encodedSig = (byte*)XMALLOC(MAX_ENCODED_SIG_SZ, NULL,
                                                                       DYNAMIC_TYPE_TMP_BUFFER);
                                     if (encodedSig == NULL) {
                                         ERROR_OUT(MEMORY_E, exit_sske);
+                                    }
+                                    
+                                    switch (ssl->suites->hashAlgo) {
+                                        case sha512_mac:
+                                            #ifdef WOLFSSL_SHA512
+                                                typeH    = SHA512h;
+                                            #endif
+                                            break;
+                                        case sha384_mac:
+                                            #ifdef WOLFSSL_SHA384
+                                                typeH    = SHA384h;
+                                            #endif
+                                            break;
+                                        case sha256_mac:
+                                            #ifndef NO_SHA256
+                                                typeH    = SHA256h;
+                                            #endif
+                                            break;
+                                        case sha_mac:
+                                            #ifndef NO_OLD_TLS
+                                                typeH    = SHAh;
+                                            #endif
+                                            break;
+                                        default:
+                                            break;
                                     }
 
                                     ssl->buffers.sig.length = wc_EncodeSignature(encodedSig,
@@ -17120,7 +17141,7 @@ int DoSessionTicket(WOLFSSL* ssl,
                         if ((idx - begin) + clientPubSz > size) {
                             ERROR_OUT(BUFFER_ERROR, exit_dcke);
                         }
-                        
+
                         ret = DhAgree(ssl,
                             ssl->buffers.serverDH_P.buffer,
                             ssl->buffers.serverDH_P.length,

--- a/src/internal.c
+++ b/src/internal.c
@@ -14796,7 +14796,6 @@ int DoSessionTicket(WOLFSSL* ssl,
                 #ifdef HAVE_ECC
                     case ecc_diffie_hellman_kea:
                     {
-                        int typeH = 0;
                         enum wc_HashType hashType = WC_HASH_TYPE_NONE;
 
                         /* curve type, named curve, length(1) */
@@ -14916,31 +14915,23 @@ int DoSessionTicket(WOLFSSL* ssl,
                                 case sha512_mac:
                                     #ifdef WOLFSSL_SHA512
                                         hashType = WC_HASH_TYPE_SHA512;
-                                        typeH    = SHA512h;
                                     #endif
                                     break;
-
                                 case sha384_mac:
                                     #ifdef WOLFSSL_SHA384
                                         hashType = WC_HASH_TYPE_SHA384;
-                                        typeH    = SHA384h;
                                     #endif
                                     break;
-
                                 case sha256_mac:
                                     #ifndef NO_SHA256
                                         hashType = WC_HASH_TYPE_SHA256;
-                                        typeH    = SHA256h;
                                     #endif
                                     break;
-
                                 case sha_mac:
                                     #ifndef NO_OLD_TLS
                                         hashType = WC_HASH_TYPE_SHA;
-                                        typeH    = SHAh;
                                     #endif
                                     break;
-
                                 default:
                                     WOLFSSL_MSG("Bad hash sig algo");
                                     break;
@@ -14998,17 +14989,43 @@ int DoSessionTicket(WOLFSSL* ssl,
                         ssl->sigLen = sigSz;
 
                         /* Sign hash to create signature */
-                        switch(ssl->specs.sig_algo)
+                        switch (ssl->specs.sig_algo)
                         {
                         #ifndef NO_RSA
                             case rsa_sa_algo:
                             {
                                 /* For TLS 1.2 re-encode signature */
                                 if (IsAtLeastTLSv1_2(ssl)) {
+                                    int typeH = 0;
                                     byte* encodedSig = (byte*)XMALLOC(MAX_ENCODED_SIG_SZ, NULL,
                                                                       DYNAMIC_TYPE_TMP_BUFFER);
                                     if (encodedSig == NULL) {
                                         ERROR_OUT(MEMORY_E, exit_sske);
+                                    }
+                                    
+                                    switch (ssl->suites->hashAlgo) {
+                                        case sha512_mac:
+                                            #ifdef WOLFSSL_SHA512
+                                                typeH    = SHA512h;
+                                            #endif
+                                            break;
+                                        case sha384_mac:
+                                            #ifdef WOLFSSL_SHA384
+                                                typeH    = SHA384h;
+                                            #endif
+                                            break;
+                                        case sha256_mac:
+                                            #ifndef NO_SHA256
+                                                typeH    = SHA256h;
+                                            #endif
+                                            break;
+                                        case sha_mac:
+                                            #ifndef NO_OLD_TLS
+                                                typeH    = SHAh;
+                                            #endif
+                                            break;
+                                        default:
+                                            break;
                                     }
 
                                     ssl->buffers.sig.length = wc_EncodeSignature(encodedSig,
@@ -15174,25 +15191,21 @@ int DoSessionTicket(WOLFSSL* ssl,
                                         hashType = WC_HASH_TYPE_SHA512;
                                     #endif
                                     break;
-
                                 case sha384_mac:
                                     #ifdef WOLFSSL_SHA384
                                         hashType = WC_HASH_TYPE_SHA384;
                                     #endif
                                     break;
-
                                 case sha256_mac:
                                     #ifndef NO_SHA256
                                         hashType = WC_HASH_TYPE_SHA256;
                                     #endif
                                     break;
-
                                 case sha_mac:
                                     #ifndef NO_OLD_TLS
                                         hashType = WC_HASH_TYPE_SHA;
                                     #endif
                                     break;
-
                                 default:
                                     WOLFSSL_MSG("Bad hash sig algo");
                                     break;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -788,7 +788,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
 
     switch (type) {
 
-        case hashType:
+        case oidHashType:
             switch (id) {
                 case MD2h:
                     oid = hashMd2hOid;
@@ -817,7 +817,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
             }
             break;
 
-        case sigType:
+        case oidSigType:
             switch (id) {
                 #ifndef NO_DSA
                 case CTC_SHAwDSA:
@@ -874,7 +874,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
             }
             break;
 
-        case keyType:
+        case oidKeyType:
             switch (id) {
                 #ifndef NO_DSA
                 case DSAk:
@@ -906,7 +906,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
             break;
 
         #ifdef HAVE_ECC
-        case curveType:
+        case oidCurveType:
             switch (id) {
                 #if defined(HAVE_ALL_CURVES) || !defined(NO_ECC256)
                 case ECC_256R1:
@@ -950,7 +950,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
             break;
         #endif /* HAVE_ECC */
 
-        case blkType:
+        case oidBlkType:
             switch (id) {
                 case DESb:
                     oid = blkDesCbcOid;
@@ -964,7 +964,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
             break;
 
         #ifdef HAVE_OCSP
-        case ocspType:
+        case oidOcspType:
             switch (id) {
                 case OCSP_BASIC_OID:
                     oid = ocspBasicOid;
@@ -978,7 +978,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
             break;
         #endif /* HAVE_OCSP */
 
-        case certExtType:
+        case oidCertExtType:
             switch (id) {
                 case BASIC_CA_OID:
                     oid = extBasicCaOid;
@@ -1027,7 +1027,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
             }
             break;
 
-        case certAuthInfoType:
+        case oidCertAuthInfoType:
             switch (id) {
                 case AIA_OCSP_OID:
                     oid = extAuthInfoOcspOid;
@@ -1040,7 +1040,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
             }
             break;
 
-        case certPolicyType:
+        case oidCertPolicyType:
             switch (id) {
                 case CP_ANY_OID:
                     oid = extCertPolicyAnyOid;
@@ -1049,7 +1049,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
             }
             break;
 
-        case certAltNameType:
+        case oidCertAltNameType:
             switch (id) {
                 case HW_NAME_OID:
                     oid = extAltNamesHwNameOid;
@@ -1058,7 +1058,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
             }
             break;
 
-        case certKeyUseType:
+        case oidCertKeyUseType:
             switch (id) {
                 case EKU_ANY_OID:
                     oid = extExtKeyUsageAnyOid;
@@ -1078,7 +1078,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                     break;
             }
 
-        case kdfType:
+        case oidKdfType:
             switch (id) {
                 case PBKDF2_OID:
                     oid = pbkdf2Oid;
@@ -1087,7 +1087,7 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
             }
             break;
 
-        case ignoreType:
+        case oidIgnoreType:
         default:
             break;
     }
@@ -1138,7 +1138,7 @@ WOLFSSL_LOCAL int GetObjectId(const byte* input, word32* inOutIdx, word32* oid,
         const byte* checkOid = NULL;
         word32 checkOidSz;
 
-        if (oidType != ignoreType) {
+        if (oidType != oidIgnoreType) {
             checkOid = OidFromId(*oid, oidType, &checkOidSz);
 
             if (checkOid != NULL &&
@@ -1317,7 +1317,7 @@ int ToTraditional(byte* input, word32 sz)
     if (GetMyVersion(input, &inOutIdx, &version) < 0)
         return ASN_PARSE_E;
 
-    if (GetAlgoId(input, &inOutIdx, &oid, sigType, sz) < 0)
+    if (GetAlgoId(input, &inOutIdx, &oid, oidSigType, sz) < 0)
         return ASN_PARSE_E;
 
     if (input[inOutIdx] == ASN_OBJECT_ID) {
@@ -1594,7 +1594,7 @@ int ToTraditionalEnc(byte* input, word32 sz,const char* password,int passwordSz)
     if (GetSequence(input, &inOutIdx, &length, sz) < 0)
         return ASN_PARSE_E;
 
-    if (GetAlgoId(input, &inOutIdx, &oid, sigType, sz) < 0)
+    if (GetAlgoId(input, &inOutIdx, &oid, oidSigType, sz) < 0)
         return ASN_PARSE_E;
 
     first  = input[inOutIdx - 2];   /* PKCS version always 2nd to last byte */
@@ -1608,7 +1608,7 @@ int ToTraditionalEnc(byte* input, word32 sz,const char* password,int passwordSz)
         if (GetSequence(input, &inOutIdx, &length, sz) < 0)
             return ASN_PARSE_E;
 
-        if (GetAlgoId(input, &inOutIdx, &oid, kdfType, sz) < 0)
+        if (GetAlgoId(input, &inOutIdx, &oid, oidKdfType, sz) < 0)
             return ASN_PARSE_E;
 
         if (oid != PBKDF2_OID)
@@ -1654,7 +1654,7 @@ int ToTraditionalEnc(byte* input, word32 sz,const char* password,int passwordSz)
     if (version == PKCS5v2) {
         /* get encryption algo */
         /* JOHN: New type. Need a little more research. */
-        if (GetAlgoId(input, &inOutIdx, &oid, blkType, sz) < 0) {
+        if (GetAlgoId(input, &inOutIdx, &oid, oidBlkType, sz) < 0) {
 #ifdef WOLFSSL_SMALL_STACK
             XFREE(salt,  NULL, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(cbcIv, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -2352,7 +2352,7 @@ static int GetKey(DecodedCert* cert)
         return ASN_PARSE_E;
 
     if (GetAlgoId(cert->source, &cert->srcIdx,
-                  &cert->keyOID, keyType, cert->maxIdx) < 0)
+                  &cert->keyOID, oidKeyType, cert->maxIdx) < 0)
         return ASN_PARSE_E;
 
     switch (cert->keyOID) {
@@ -2443,7 +2443,7 @@ static int GetKey(DecodedCert* cert)
             byte b;
 
             if (GetObjectId(cert->source, &cert->srcIdx,
-                            &cert->pkCurveOID, curveType, cert->maxIdx) < 0)
+                            &cert->pkCurveOID, oidCurveType, cert->maxIdx) < 0)
                 return ASN_PARSE_E;
 
             if (CheckCurve(cert->pkCurveOID) < 0)
@@ -3146,7 +3146,7 @@ int DecodeToKey(DecodedCert* cert, int verify)
     WOLFSSL_MSG("Got Cert Header");
 
     if ( (ret = GetAlgoId(cert->source, &cert->srcIdx, &cert->signatureOID,
-                          sigType, cert->maxIdx)) < 0)
+                          oidSigType, cert->maxIdx)) < 0)
         return ret;
 
     WOLFSSL_MSG("Got Algo ID");
@@ -3377,8 +3377,8 @@ WOLFSSL_LOCAL word32 SetAlgoID(int algoOID, byte* output, int type, int curveSz)
     byte   ID_Length[MAX_LENGTH_SZ];
     byte   seqArray[MAX_SEQ_SZ + 1];  /* add object_id to end */
 
-    tagSz = (type == hashType || type == sigType ||
-             (type == keyType && algoOID == RSAk)) ? 2 : 0;
+    tagSz = (type == oidHashType || type == oidSigType ||
+             (type == oidKeyType && algoOID == RSAk)) ? 2 : 0;
 
     algoName = OidFromId(algoOID, type, &algoSz);
 
@@ -3414,7 +3414,7 @@ word32 wc_EncodeSignature(byte* out, const byte* digest, word32 digSz,
     word32 encDigSz, algoSz, seqSz;
 
     encDigSz = SetDigest(digest, digSz, digArray);
-    algoSz   = SetAlgoID(hashOID, algoArray, hashType, 0);
+    algoSz   = SetAlgoID(hashOID, algoArray, oidHashType, 0);
     seqSz    = SetSequence(encDigSz + algoSz, seqArray);
 
     XMEMCPY(out, seqArray, seqSz);
@@ -3986,7 +3986,7 @@ static int DecodeAltNames(byte* input, int sz, DecodedCert* cert)
             /* Consume the rest of this sequence. */
             length -= (strLen + idx - lenStartIdx);
 
-            if (GetObjectId(input, &idx, &oid, certAltNameType, sz) < 0) {
+            if (GetObjectId(input, &idx, &oid, oidCertAltNameType, sz) < 0) {
                 WOLFSSL_MSG("\tbad OID");
                 return ASN_PARSE_E;
             }
@@ -4237,7 +4237,7 @@ static int DecodeAuthInfo(byte* input, int sz, DecodedCert* cert)
             return ASN_PARSE_E;
 
         oid = 0;
-        if (GetObjectId(input, &idx, &oid, certAuthInfoType, sz) < 0)
+        if (GetObjectId(input, &idx, &oid, oidCertAuthInfoType, sz) < 0)
             return ASN_PARSE_E;
 
         /* Only supporting URIs right now. */
@@ -4383,7 +4383,7 @@ static int DecodeExtKeyUsage(byte* input, int sz, DecodedCert* cert)
     #endif
 
     while (idx < (word32)sz) {
-        if (GetObjectId(input, &idx, &oid, certKeyUseType, sz) < 0)
+        if (GetObjectId(input, &idx, &oid, oidCertKeyUseType, sz) < 0)
             return ASN_PARSE_E;
 
         switch (oid) {
@@ -4718,7 +4718,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
         }
 
         oid = 0;
-        if (GetObjectId(input, &idx, &oid, certExtType, sz) < 0) {
+        if (GetObjectId(input, &idx, &oid, oidCertExtType, sz) < 0) {
             WOLFSSL_MSG("\tfail: OBJECT ID");
             return ASN_PARSE_E;
         }
@@ -4970,7 +4970,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
     }
 
     if ((ret = GetAlgoId(cert->source, &cert->srcIdx, &confirmOID,
-                         sigType, cert->maxIdx)) < 0)
+                         oidSigType, cert->maxIdx)) < 0)
         return ret;
 
     if ((ret = GetSignature(cert)) < 0)
@@ -5522,7 +5522,7 @@ static int SetRsaPublicKey(byte* output, RsaKey* key,
 #else
         byte algo[MAX_ALGO_SZ];
 #endif
-        algoSz = SetAlgoID(RSAk, algo, keyType, 0);
+        algoSz = SetAlgoID(RSAk, algo, oidKeyType, 0);
         lenSz  = SetLength(seqSz + nSz + eSz + 1, len);
         len[lenSz++] = 0;   /* trailing 0 */
 
@@ -5938,7 +5938,7 @@ static int SetEccPublicKey(byte* output, ecc_key* key, int with_header)
             return MEMORY_E;
         }
 #endif
-        algoSz  = SetAlgoID(ECDSAk, algo, keyType, curveSz);
+        algoSz  = SetAlgoID(ECDSAk, algo, oidKeyType, curveSz);
 
         lenSz   = SetLength(pubSz + 1, len);
         len[lenSz++] = 0;   /* trailing 0 */
@@ -6787,7 +6787,7 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
     der->serialSz  = SetSerial(cert->serial, der->serial);
 
     /* signature algo */
-    der->sigAlgoSz = SetAlgoID(cert->sigType, der->sigAlgo, sigType, 0);
+    der->sigAlgoSz = SetAlgoID(cert->sigType, der->sigAlgo, oidSigType, 0);
     if (der->sigAlgoSz == 0)
         return ALGO_ID_E;
 
@@ -7179,7 +7179,7 @@ static int AddSignature(byte* buffer, int bodySz, const byte* sig, int sigSz,
     int  idx = bodySz, seqSz;
 
     /* algo */
-    idx += SetAlgoID(sigAlgoType, buffer + idx, sigType, 0);
+    idx += SetAlgoID(sigAlgoType, buffer + idx, oidSigType, 0);
     /* bit string */
     buffer[idx++] = ASN_BIT_STRING;
     /* length */
@@ -7986,7 +7986,7 @@ static int SetAltNamesFromCert(Cert* cert, const byte* der, int derSz)
                 decoded->srcIdx = startIdx;
 
                 if (GetAlgoId(decoded->source, &decoded->srcIdx, &oid,
-                              certExtType, decoded->maxIdx) < 0) {
+                              oidCertExtType, decoded->maxIdx) < 0) {
                     ret = ASN_PARSE_E;
                     break;
                 }
@@ -8745,7 +8745,7 @@ static int DecodeSingleResponse(byte* source,
     if (GetSequence(source, &idx, &length, size) < 0)
         return ASN_PARSE_E;
     /* Skip the hash algorithm */
-    if (GetAlgoId(source, &idx, &oid, ignoreType, size) < 0)
+    if (GetAlgoId(source, &idx, &oid, oidIgnoreType, size) < 0)
         return ASN_PARSE_E;
     /* Save reference to the hash of CN */
     if (source[idx++] != ASN_OCTET_STRING)
@@ -8867,7 +8867,7 @@ static int DecodeOcspRespExtensions(byte* source,
         }
 
         oid = 0;
-        if (GetObjectId(source, &idx, &oid, ocspType, sz) < 0) {
+        if (GetObjectId(source, &idx, &oid, oidOcspType, sz) < 0) {
             WOLFSSL_MSG("\tfail: OBJECT ID");
             return ASN_PARSE_E;
         }
@@ -9020,7 +9020,7 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
         return ASN_PARSE_E;
 
     /* Get the signature algorithm */
-    if (GetAlgoId(source, &idx, &resp->sigOID, sigType, size) < 0)
+    if (GetAlgoId(source, &idx, &resp->sigOID, oidSigType, size) < 0)
         return ASN_PARSE_E;
 
     /* Obtain pointer to the start of the signature, and save the size */
@@ -9126,7 +9126,7 @@ int OcspResponseDecode(OcspResponse* resp, void* cm)
         return ASN_PARSE_E;
 
     /* Check ObjectID for the resposeBytes */
-    if (GetObjectId(source, &idx, &oid, ocspType, size) < 0)
+    if (GetObjectId(source, &idx, &oid, oidOcspType, size) < 0)
         return ASN_PARSE_E;
     if (oid != OCSP_BASIC_OID)
         return ASN_PARSE_E;
@@ -9212,9 +9212,9 @@ int EncodeOcspRequest(OcspRequest* req, byte* output, word32 size)
     WOLFSSL_ENTER("EncodeOcspRequest");
 
 #ifdef NO_SHA
-    algoSz = SetAlgoID(SHA256h, algoArray, hashType, 0);
+    algoSz = SetAlgoID(SHA256h, algoArray, oidHashType, 0);
 #else
-    algoSz = SetAlgoID(SHAh, algoArray, hashType, 0);
+    algoSz = SetAlgoID(SHAh, algoArray, oidHashType, 0);
 #endif
 
     issuerSz    = SetDigest(req->issuerHash,    KEYID_SIZE,    issuerArray);
@@ -9604,7 +9604,7 @@ int ParseCRL(DecodedCRL* dcrl, const byte* buff, word32 sz, void* cm)
             return ASN_PARSE_E;
     }
 
-    if (GetAlgoId(buff, &idx, &oid, ignoreType, sz) < 0)
+    if (GetAlgoId(buff, &idx, &oid, oidIgnoreType, sz) < 0)
         return ASN_PARSE_E;
 
     if (GetNameHash(buff, &idx, dcrl->issuerHash, sz) < 0)
@@ -9648,7 +9648,7 @@ int ParseCRL(DecodedCRL* dcrl, const byte* buff, word32 sz, void* cm)
     if (idx != dcrl->sigIndex)
         idx = dcrl->sigIndex;   /* skip extensions */
 
-    if (GetAlgoId(buff, &idx, &dcrl->signatureOID, sigType, sz) < 0)
+    if (GetAlgoId(buff, &idx, &dcrl->signatureOID, oidSigType, sz) < 0)
         return ASN_PARSE_E;
 
     if (GetCRL_Signature(buff, &idx, dcrl, sz) < 0)

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -373,6 +373,9 @@ const char* wc_GetErrorString(int error)
     case HASH_TYPE_E:
         return "Hash type not enabled/available";
 
+    case WC_PENDING_E:
+        return "wolfCrypt Operation Pending (would block / eagain) error";
+
     default:
         return "unknown error number";
 

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -44,6 +44,7 @@ int wc_HashGetOID(enum wc_HashType hash_type)
             oid = MD2h;
 #endif
             break;
+        case WC_HASH_TYPE_MD5_SHA:
         case WC_HASH_TYPE_MD5:
 #ifndef NO_MD5
             oid = MD5h;
@@ -112,6 +113,11 @@ int wc_HashGetDigestSize(enum wc_HashType hash_type)
             dig_size = SHA512_DIGEST_SIZE;
 #endif
             break;
+        case WC_HASH_TYPE_MD5_SHA:
+#if !defined(NO_MD5) && !defined(NO_SHA)
+            dig_size = MD5_DIGEST_SIZE + SHA_DIGEST_SIZE;
+#endif
+            break;
 
         /* Not Supported */
         case WC_HASH_TYPE_MD2:
@@ -168,6 +174,14 @@ int wc_Hash(enum wc_HashType hash_type, const byte* data,
         case WC_HASH_TYPE_SHA512:
 #ifdef WOLFSSL_SHA512
             ret = wc_Sha512Hash(data, data_len, hash);
+#endif
+            break;
+        case WC_HASH_TYPE_MD5_SHA:
+#if !defined(NO_MD5) && !defined(NO_SHA)
+            ret = wc_Md5Hash(data, data_len, hash);
+            if (ret == 0) {
+                ret = wc_ShaHash(data, data_len, &hash[MD5_DIGEST_SIZE]);
+            }
 #endif
             break;
 

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -130,7 +130,7 @@ int wc_GetContentType(const byte* input, word32* inOutIdx, word32* oid,
                    word32 maxIdx)
 {
     WOLFSSL_ENTER("wc_GetContentType");
-    if (GetObjectId(input, inOutIdx, oid, ignoreType, maxIdx) < 0)
+    if (GetObjectId(input, inOutIdx, oid, oidIgnoreType, maxIdx) < 0)
         return ASN_PARSE_E;
 
     return 0;
@@ -396,10 +396,10 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     esd->signerVersionSz = SetMyVersion(1, esd->signerVersion, 0);
     signerInfoSz += esd->signerVersionSz;
     esd->signerDigAlgoIdSz = SetAlgoID(pkcs7->hashOID, esd->signerDigAlgoId,
-                                      hashType, 0);
+                                      oidHashType, 0);
     signerInfoSz += esd->signerDigAlgoIdSz;
     esd->digEncAlgoIdSz = SetAlgoID(pkcs7->encryptOID, esd->digEncAlgoId,
-                                   keyType, 0);
+                                   oidKeyType, 0);
     signerInfoSz += esd->digEncAlgoIdSz;
 
     if (pkcs7->signedAttribsSz != 0) {
@@ -576,7 +576,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
                                                                  esd->certsSet);
 
     esd->singleDigAlgoIdSz = SetAlgoID(pkcs7->hashOID, esd->singleDigAlgoId,
-                                      hashType, 0);
+                                      oidHashType, 0);
     esd->digAlgoIdSetSz = SetSet(esd->singleDigAlgoIdSz, esd->digAlgoIdSet);
 
 
@@ -1033,7 +1033,7 @@ WOLFSSL_LOCAL int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
         return ALGO_ID_E;
     }
 
-    keyEncAlgSz = SetAlgoID(keyEncAlgo, keyAlgArray, keyType, 0);
+    keyEncAlgSz = SetAlgoID(keyEncAlgo, keyAlgArray, oidKeyType, 0);
     if (keyEncAlgSz == 0) {
         FreeDecodedCert(decoded);
 #ifdef WOLFSSL_SMALL_STACK
@@ -1319,7 +1319,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     /* build up our ContentEncryptionAlgorithmIdentifier sequence,
      * adding (ivOctetStringSz + DES_BLOCK_SIZE) for IV OCTET STRING */
     contentEncAlgoSz = SetAlgoID(pkcs7->encryptOID, contentEncAlgo,
-                                 blkType, ivOctetStringSz + DES_BLOCK_SIZE);
+                                 oidBlkType, ivOctetStringSz + DES_BLOCK_SIZE);
 
     if (contentEncAlgoSz == 0) {
         XFREE(encryptedContent, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -1592,7 +1592,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
         XFREE(serialNum, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         
-        if (GetAlgoId(pkiMsg, &idx, &encOID, keyType, pkiMsgSz) < 0) {
+        if (GetAlgoId(pkiMsg, &idx, &encOID, oidKeyType, pkiMsgSz) < 0) {
 #ifdef WOLFSSL_SMALL_STACK
             XFREE(encryptedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
@@ -1653,7 +1653,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
         return ASN_PARSE_E;
     }
 
-    if (GetAlgoId(pkiMsg, &idx, &encOID, blkType, pkiMsgSz) < 0) {
+    if (GetAlgoId(pkiMsg, &idx, &encOID, oidBlkType, pkiMsgSz) < 0) {
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(encryptedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -141,6 +141,7 @@ enum wolfSSL_ErrorCodes {
     UNKNOWN_ALPN_PROTOCOL_NAME_E = -405,   /* Unrecognized protocol name Error*/
     BAD_CERTIFICATE_STATUS_ERROR = -406,   /* Bad certificate status message */
     OCSP_INVALID_STATUS          = -407,   /* Invalid OCSP Status */
+    ASYNC_NOT_PENDING            = -408,   /* Async operation not pending */
 
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1780,6 +1780,39 @@ WOLFSSL_API int wolfSSL_set_jobject(WOLFSSL* ssl, void* objPtr);
 WOLFSSL_API void* wolfSSL_get_jobject(WOLFSSL* ssl);
 #endif /* WOLFSSL_JNI */
 
+#ifdef HAVE_WOLF_EVENT
+typedef enum WOLF_EVENT_TYPE {
+    WOLF_EVENT_TYPE_NONE,
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        WOLF_EVENT_TYPE_ASYNC_ACCEPT,
+        WOLF_EVENT_TYPE_ASYNC_CONNECT,
+        WOLF_EVENT_TYPE_ASYNC_READ,
+        WOLF_EVENT_TYPE_ASYNC_WRITE,
+        WOLF_EVENT_TYPE_ASYNC_FIRST = WOLF_EVENT_TYPE_ASYNC_ACCEPT,
+        WOLF_EVENT_TYPE_ASYNC_LAST = WOLF_EVENT_TYPE_ASYNC_WRITE,
+    #endif
+} WOLF_EVENT_TYPE;
+
+typedef struct WOLF_EVENT WOLF_EVENT;
+struct WOLF_EVENT {
+    WOLF_EVENT*         next;   /* To support event linked list */
+	WOLFSSL*            ssl;    /* Reference back to SSL object */
+    int                 ret;    /* Async return code */
+    WOLF_EVENT_TYPE     type;
+    unsigned short      pending:1;
+    unsigned short      done:1;
+    /* Future event flags can go here */
+};
+
+enum WOLF_POLL_FLAGS {
+    WOLF_POLL_FLAG_CHECK_HW = 0x01,
+};
+
+WOLFSSL_API int wolfssl_CTX_poll_peek(WOLFSSL_CTX* ctx, int* eventCount);
+WOLFSSL_API int wolfSSL_CTX_poll(WOLFSSL_CTX* ctx, WOLF_EVENT* events, int maxEvents,
+                                 unsigned char flags, int* eventCount);
+#endif /* HAVE_WOLF_EVENT */
+
 #ifdef __cplusplus
     }  /* extern "C" */
 #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1806,11 +1806,14 @@ struct WOLF_EVENT {
 
 enum WOLF_POLL_FLAGS {
     WOLF_POLL_FLAG_CHECK_HW = 0x01,
+    WOLF_POLL_FLAG_PEEK = 0x02,
 };
 
-WOLFSSL_API int wolfssl_CTX_poll_peek(WOLFSSL_CTX* ctx, int* eventCount);
-WOLFSSL_API int wolfSSL_CTX_poll(WOLFSSL_CTX* ctx, WOLF_EVENT* events, int maxEvents,
-                                 unsigned char flags, int* eventCount);
+WOLFSSL_API int wolfSSL_CTX_poll(WOLFSSL_CTX* ctx, WOLF_EVENT* events,
+    int maxEvents, unsigned char flags, int* eventCount);
+WOLFSSL_API int wolfSSL_poll(WOLFSSL* ssl, WOLF_EVENT* events,
+    int maxEvents, unsigned char flags, int* eventCount);
+
 #endif /* HAVE_WOLF_EVENT */
 
 #ifdef __cplusplus

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1908,19 +1908,17 @@ static INLINE const char* mymktemp(char *tempfn, int len, int num)
 #endif  /* HAVE_SESSION_TICKET && CHACHA20 && POLY1305 */
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    static INLINE int AsyncCryptPoll(WOLFSSL_CTX* ctx, WOLFSSL* ssl)
+    static INLINE int AsyncCryptPoll(WOLFSSL* ssl)
     {
         int ret, eventCount = 0;
         WOLF_EVENT events[1];
 
         printf("Connect/Accept got WC_PENDING_E\n");
 
-        ret = wolfSSL_CTX_poll(ctx, events, sizeof(events)/sizeof(WOLF_EVENT), WOLF_POLL_FLAG_CHECK_HW, &eventCount);
+        ret = wolfSSL_poll(ssl, events, sizeof(events)/sizeof(WOLF_EVENT),
+            WOLF_POLL_FLAG_CHECK_HW, &eventCount);
         if (ret == 0 && eventCount > 0) {
-            /* Check the SSL context in the event matches ours */
-            if (events[0].ssl == ssl) {
-                ret = 1; /* Success */
-            }
+            ret = 1; /* Success */
         }
 
         return ret;

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1907,4 +1907,24 @@ static INLINE const char* mymktemp(char *tempfn, int len, int num)
 
 #endif  /* HAVE_SESSION_TICKET && CHACHA20 && POLY1305 */
 
+#ifdef WOLFSSL_ASYNC_CRYPT
+    static INLINE int AsyncCryptPoll(WOLFSSL_CTX* ctx, WOLFSSL* ssl)
+    {
+        int ret, eventCount = 0;
+        WOLF_EVENT events[1];
+
+        printf("Connect/Accept got WC_PENDING_E\n");
+
+        ret = wolfSSL_CTX_poll(ctx, events, sizeof(events)/sizeof(WOLF_EVENT), WOLF_POLL_FLAG_CHECK_HW, &eventCount);
+        if (ret == 0 && eventCount > 0) {
+            /* Check the SSL context in the event matches ours */
+            if (events[0].ssl == ssl) {
+                ret = 1; /* Success */
+            }
+        }
+
+        return ret;
+    }
+#endif
+
 #endif /* wolfSSL_TEST_H */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -199,19 +199,19 @@ enum Misc_ASN {
 
 
 enum Oid_Types {
-    hashType         = 0,
-    sigType          = 1,
-    keyType          = 2,
-    curveType        = 3,
-    blkType          = 4,
-    ocspType         = 5,
-    certExtType      = 6,
-    certAuthInfoType = 7,
-    certPolicyType   = 8,
-    certAltNameType  = 9,
-    certKeyUseType   = 10,
-    kdfType          = 11,
-    ignoreType
+    oidHashType         = 0,
+    oidSigType          = 1,
+    oidKeyType          = 2,
+    oidCurveType        = 3,
+    oidBlkType          = 4,
+    oidOcspType         = 5,
+    oidCertExtType      = 6,
+    oidCertAuthInfoType = 7,
+    oidCertPolicyType   = 8,
+    oidCertAltNameType  = 9,
+    oidCertKeyUseType   = 10,
+    oidKdfType          = 11,
+    oidIgnoreType
 };
 
 

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -166,6 +166,7 @@ enum {
     BAD_COND_E          = -230,  /* Bad condition variable operation */
     SIG_TYPE_E          = -231,  /* Signature Type not enabled/available */
     HASH_TYPE_E         = -232,  /* Hash Type not enabled/available */
+    WC_PENDING_E        = -233,  /* wolfCrypt operation pending (would block) */
 
     MIN_CODE_E          = -300   /* errors -101 - -299 */
 

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -38,6 +38,7 @@ enum wc_HashType {
     WC_HASH_TYPE_SHA256 = 5,
     WC_HASH_TYPE_SHA384 = 6,
     WC_HASH_TYPE_SHA512 = 7,
+    WC_HASH_TYPE_MD5_SHA = 8,
 };
 
 /* Find largest possible digest size

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -135,6 +135,9 @@
 /* Uncomment next line if building for ARDUINO */
 /* #define WOLFSSL_ARDUINO */
 
+/* Uncomment next line to enable asynchronous crypto WC_PENDING_E */
+/* #define WOLFSSL_ASYNC_CRYPT */
+
 #include <wolfssl/wolfcrypt/visibility.h>
 
 #ifdef WOLFSSL_USER_SETTINGS
@@ -1146,6 +1149,18 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #undef NO_SHA256
     #undef NO_DH
 #endif
+
+/* Asynchronous Crypto */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    /* Make sure wolf events are enabled */
+    #undef HAVE_WOLF_EVENT
+    #define HAVE_WOLF_EVENT
+#else
+    #ifdef WOLFSSL_ASYNC_CRYPT_TEST
+        #error Must have WOLFSSL_ASYNC_CRYPT enabled with WOLFSSL_ASYNC_CRYPT_TEST
+    #endif
+#endif /* WOLFSSL_ASYNC_CRYPT */
+
 
 /* Place any other flags or defines here */
 


### PR DESCRIPTION
Added "--enable-asynccrypt" option for enabling asynchronous crypto. This includes a refactor of SendServerKeyExchange and DoClientKeyExchange to support WC_PENDING_E on key generation, signing and verification. Currently uses async simulator (WOLFSSL_ASYNC_CRYPT_TEST) if cavium not enabled. All of the examples have been updated to support WC_PENDING_E on accept and connect. A generic WOLF_EVENT infrastructure has been added to support other types of future events and is enabled using "HAVE_WOLF_EVENT". Refactor the ASN OID type (ex: hashType/sigType) to use a more unique name. The real "async.c" and "async.h" files are in a private repo.