### PR TITLE
Fixed bug with ASN.1 X509V3 Certificate Policy extension parsing

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4608,7 +4608,7 @@ static int DecodePolicyOID(char *out, word32 outSz, byte *in, word32 inSz)
             WOLFSSL_MSG("\tGet CertPolicy total seq failed");
             return ASN_PARSE_E;
         }
-        
+
         /* Validate total length (2 is the CERT_POLICY_OID+SEQ) */
         if ((total_length + 2) != sz) {
             WOLFSSL_MSG("\tCertPolicy length mismatch");

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4665,7 +4665,11 @@ static int DecodePolicyOID(char *out, word32 outSz, byte *in, word32 inSz)
     #endif
             }
             idx += policy_length;
-        } while((int)idx < total_length && cert->extCertPoliciesNb < MAX_CERTPOL_NB);
+        } while((int)idx < total_length
+    #if defined(WOLFSSL_CERT_EXT)
+            && cert->extCertPoliciesNb < MAX_CERTPOL_NB
+    #endif
+        );
 
         WOLFSSL_LEAVE("DecodeCertPolicy", 0);
         return 0;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4608,6 +4608,12 @@ static int DecodePolicyOID(char *out, word32 outSz, byte *in, word32 inSz)
             WOLFSSL_MSG("\tGet CertPolicy total seq failed");
             return ASN_PARSE_E;
         }
+        
+        /* Validate total length (2 is the CERT_POLICY_OID+SEQ) */
+        if ((total_length + 2) != sz) {
+            WOLFSSL_MSG("\tCertPolicy length mismatch");
+            return ASN_PARSE_E;
+        }
 
         /* Unwrap certificatePolicies */
         do {
@@ -4629,6 +4635,12 @@ static int DecodePolicyOID(char *out, word32 outSz, byte *in, word32 inSz)
             policy_length--;
 
             if (length > 0) {
+                /* Verify length won't overrun buffer */
+                if (length > (sz - (int)idx)) {
+                    WOLFSSL_MSG("\tCertPolicy length exceeds input buffer");
+                    return ASN_PARSE_E;
+                }
+
     #if defined(WOLFSSL_SEP)
                 cert->deviceType = (byte*)XMALLOC(length, cert->heap,
                                                   DYNAMIC_TYPE_X509_EXT);


### PR DESCRIPTION
Bug had to do with parsing when OID contains multiple items such as example 2 below. The wolfssl.com server key now contains a URL in the certificate policy "https://secure.comodo.com/CPS0", which wasn't being parsed over correctly. Also cleanup to use loop instead of duplicate code.

Example 1:
30 12
30 06 06 04 55 1D 20 00
30 08 06 06 67 81 0C 01 02 01

Result:
2.5.29.32.0
2.23.140.1.2.1

Example 2:
30 46
30 3A 06 0B 2B 06 01 04 01 B2 31 01 02 02 07
   30 2B 30 29 06 08 2B 06 01 05 05 07 02 01 16 1D 68 74 74 70 73 3A 2F 2F 73 65 63 75 72 65 2E 63 6F 6D 6F 64 6F 2E 63 6F 6D 2F 43 50 53
30 08 06 06 67 81 0C 01 02 01

Result:
1.3.6.1.4.1.6449.1.2.2.7
2.23.140.1.2.1