### PR TITLE
Fixes scan-build warning with "--enable-opensslextra --disable-memory"

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1695,8 +1695,6 @@ void FreeX509(WOLFSSL_X509* x509)
     #endif /* OPENSSL_EXTRA */
     if (x509->altNames)
         FreeAltNames(x509->altNames, NULL);
-    if (x509->dynamicMemory)
-        XFREE(x509, NULL, DYNAMIC_TYPE_X509);
 }
 
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -1923,7 +1923,7 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
     ssl->buffers.outputBuffer.buffer = ssl->buffers.outputBuffer.staticBuffer;
     ssl->buffers.outputBuffer.bufferSize  = STATIC_BUFFER_LEN;
 
-#ifdef KEEP_PEER_CERT
+#if defined(KEEP_PEER_CERT) || defined(GOAHEAD_WS)
     InitX509(&ssl->peerCert, 0);
 #endif
 
@@ -2204,7 +2204,7 @@ void SSL_ResourceFree(WOLFSSL* ssl)
         nx_packet_release(ssl->nxCtx.nxPacket);
 #endif
 #if defined(KEEP_PEER_CERT) || defined(GOAHEAD_WS)
-    FreeX509(&(ssl->peerCert));   /* clang thinks this frees ssl itslef */
+    FreeX509(&ssl->peerCert);
 #endif
 }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -9424,6 +9424,7 @@ static void ExternalFreeX509(WOLFSSL_X509* x509)
     if (x509) {
         if (x509->dynamicMemory) {
             FreeX509(x509);
+            XFREE(x509, NULL, DYNAMIC_TYPE_X509);
         } else {
             WOLFSSL_MSG("free called on non dynamic object, not freeing");
         }


### PR DESCRIPTION
Problem was different #if defines on the InitX509 and FreeX509, which caused the static analyzer to think the "x509->dynamicMemory" was always true.