### PR TITLE
SEP and CERTEXT, QSH debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -672,6 +672,10 @@ AC_ARG_ENABLE([sep],
     )
 if test "$ENABLED_SEP" = "yes"
 then
+    if test "$ENABLED_CERTEXT" = "yes"
+    then
+        AC_MSG_ERROR([cannot enable certext and enable sep.])
+    fi
   AM_CFLAGS="-DWOLFSSL_SEP -DKEEP_PEER_CERT $AM_CFLAGS"
 fi
 
@@ -1800,6 +1804,10 @@ then
     fi
     if test "x$ENABLED_CERTEXT" = "xno"
     then
+        if test "$ENABLED_SEP" = "yes"
+        then
+            AC_MSG_ERROR([cannot enable certext and enable sep.])
+        fi
         ENABLED_CERTEXT="yes"
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_CERT_EXT"
     fi

--- a/src/keys.c
+++ b/src/keys.c
@@ -3058,6 +3058,7 @@ int MakeMasterSecret(WOLFSSL* ssl)
 
         /* show secret SerSi and CliSi */
         #ifdef SHOW_SECRETS
+        {
             word32 j;
             printf("QSH generated secret material\n");
             printf("SerSi        : ");
@@ -3070,6 +3071,7 @@ int MakeMasterSecret(WOLFSSL* ssl)
                 printf("%02x", ssl->QSH_secret->CliSi->buffer[j]);
             }
             printf("\n");
+        }
         #endif
     }
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1088,6 +1088,11 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #undef NO_DH
 #endif
 
+/* Either SEP or CERT_EXT but not both */
+#if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_SEP)
+    #error Can not use both WOLFSSL_CERT_EXT and WOLFSSL_SEP
+#endif
+
 /* Place any other flags or defines here */
 
 


### PR DESCRIPTION
Changes compile behavior to not allow both SEP and CERTEXT enabled at the same time.

Makes debug mode with QSH compile with C89. Placing the variable declaration at the top of scope.