### PR TITLE
Fixes multiple Jenkins warnings/failures

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -142,8 +142,6 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
 
 #ifndef NO_CERTS
 static int BuildCertHashes(WOLFSSL* ssl, Hashes* hashes);
-static void PickHashSigAlgo(WOLFSSL* ssl,
-                                const byte* hashSigAlgo, word32 hashSigAlgoSz);
 #endif
 
 #ifdef HAVE_QSH
@@ -8702,7 +8700,9 @@ int SendCertificateStatus(WOLFSSL* ssl)
         /* case WOLFSSL_CSR_OCSP: */
         case WOLFSSL_CSR2_OCSP: {
             OcspRequest* request = ssl->ctx->certOcspRequest;
-            buffer response = {NULL, 0};
+            buffer response;
+            
+            XMEMSET(&response, 0, sizeof(response));
 
             /* unable to fetch status. skip. */
             if (ssl->ctx->cm == NULL || ssl->ctx->cm->ocspStaplingEnabled == 0)
@@ -8799,7 +8799,7 @@ int SendCertificateStatus(WOLFSSL* ssl)
             buffer responses[1 + MAX_CHAIN_DEPTH];
             int i = 0;
 
-            ForceZero(responses, sizeof(responses));
+            XMEMSET(responses, 0, sizeof(responses));
 
             /* unable to fetch status. skip. */
             if (ssl->ctx->cm == NULL || ssl->ctx->cm->ocspStaplingEnabled == 0)
@@ -10584,7 +10584,7 @@ int SetCipherList(Suites* suites, const char* list)
     return ret;
 }
 
-#ifndef NO_CERTS
+#if !defined(NO_WOLFSSL_SERVER) || !defined(NO_CERTS)
 static void PickHashSigAlgo(WOLFSSL* ssl,
                              const byte* hashSigAlgo, word32 hashSigAlgoSz)
 {
@@ -10620,7 +10620,7 @@ static void PickHashSigAlgo(WOLFSSL* ssl,
         }
     }
 }
-#endif
+#endif /* !defined(NO_WOLFSSL_SERVER) || !defined(NO_CERTS) */
 
 #ifdef WOLFSSL_CALLBACKS
 
@@ -15795,6 +15795,7 @@ int DoSessionTicket(WOLFSSL* ssl,
         return 1;
     }
 
+#ifndef NO_WOLFSSL_SERVER
     static int MatchSuite(WOLFSSL* ssl, Suites* peerSuites)
     {
         word16 i, j;
@@ -15831,7 +15832,7 @@ int DoSessionTicket(WOLFSSL* ssl,
 
         return MATCH_SUITE_ERROR;
     }
-
+#endif
 
 #ifdef OLD_HELLO_ALLOWED
 

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -118,7 +118,7 @@ static int xstat2err(int stat)
 }
 
 
-int CheckCertOCSP(WOLFSSL_OCSP* ocsp, DecodedCert* cert, void* encodedResponse)
+int CheckCertOCSP(WOLFSSL_OCSP* ocsp, DecodedCert* cert, buffer* responseBuffer)
 {
     int ret = OCSP_LOOKUP_FAIL;
 
@@ -141,7 +141,7 @@ int CheckCertOCSP(WOLFSSL_OCSP* ocsp, DecodedCert* cert, void* encodedResponse)
 #endif
 
     if (InitOcspRequest(ocspRequest, cert, ocsp->cm->ocspSendNonce) == 0) {
-        ret = CheckOcspRequest(ocsp, ocspRequest, encodedResponse);
+        ret = CheckOcspRequest(ocsp, ocspRequest, responseBuffer);
 
         FreeOcspRequest(ocspRequest);
     }
@@ -239,14 +239,13 @@ static int GetOcspStatus(WOLFSSL_OCSP* ocsp, OcspRequest* request,
 }
 
 int CheckOcspRequest(WOLFSSL_OCSP* ocsp, OcspRequest* ocspRequest,
-                                                          void* encodedResponse)
+                                                      buffer* responseBuffer)
 {
     OcspEntry*  entry          = NULL;
     CertStatus* status         = NULL;
     byte*       request        = NULL;
     int         requestSz      = 2048;
     byte*       response       = NULL;
-    buffer*     responseBuffer = (buffer*) encodedResponse;
     const char* url            = NULL;
     int         urlSz          = 0;
     int         ret            = -1;

--- a/wolfssl/ocsp.h
+++ b/wolfssl/ocsp.h
@@ -34,14 +34,16 @@
     extern "C" {
 #endif
 
+struct buffer;
 typedef struct WOLFSSL_OCSP WOLFSSL_OCSP;
 
 WOLFSSL_LOCAL int  InitOCSP(WOLFSSL_OCSP*, WOLFSSL_CERT_MANAGER*);
 WOLFSSL_LOCAL void FreeOCSP(WOLFSSL_OCSP*, int dynamic);
 
-WOLFSSL_LOCAL int  CheckCertOCSP(WOLFSSL_OCSP*, DecodedCert*, void*);
+WOLFSSL_LOCAL int  CheckCertOCSP(WOLFSSL_OCSP*, DecodedCert*,
+                                            struct buffer* responseBuffer);
 WOLFSSL_LOCAL int  CheckOcspRequest(WOLFSSL_OCSP* ocsp,
-                                               OcspRequest* ocspRequest, void*);
+                   OcspRequest* ocspRequest, struct buffer* responseBuffer);
 
 #ifdef __cplusplus
     }  /* extern "C" */


### PR DESCRIPTION
First is PickHashSigAlgo is required for client builds or if certs are enabled. Fixed scan-build warning with OCSP not recognized ForceZero as cleaning memory and using possible garbage value. Also cleaned up the OCSP functions to use struct buffer* instead of void* for clarity with a little forward declaration.

This was a result of --disable-rsa being added to the list of configurations to test.