### PR TITLE
K64F RNGA register

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1149,7 +1149,8 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 #elif defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX) || \
       defined(FREESCALE_KSDK_BM) || defined(FREESCALE_FREE_RTOS)
 
-    #if defined(FREESCALE_K70_RNGA) || defined(FREESCALE_RNGA)
+    #if defined(FREESCALE_K70_RNGA) || defined(FREESCALE_RNGA) || \
+        defined(FREESCALE_K64_RNGA)
         /*
          * wc_Generates a RNG seed using the Random Number Generator Accelerator
          * on the Kinetis K70. Documentation located in Chapter 37 of
@@ -1160,7 +1161,11 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
             int i;
 
             /* turn on RNGA module */
-            SIM_SCGC3 |= SIM_SCGC3_RNGA_MASK;
+            #ifdef FREESCALE_K64_RNGA
+                SIM_SCGC6 |= SIM_SCGC6_RNGA_MASK;
+            #else
+                SIM_SCGC3 |= SIM_SCGC3_RNGA_MASK;
+            #endif
 
             /* set SLP bit to 0 - "RNGA is not in sleep mode" */
             RNG_CR &= ~RNG_CR_SLP_MASK;

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -687,6 +687,7 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #elif !defined(FREESCALE_KSDK_BM) && !defined(FREESCALE_FREE_RTOS)
         /* defaulting to K70 RNGA, user should change if different */
         /* #define FREESCALE_K53_RNGB */
+        /* #define FREESCALE_K64_RNGA */
         #define FREESCALE_K70_RNGA
     #endif
 


### PR DESCRIPTION
Verified that `SIM_SCGC6 |= SIM_SCGC6_RNGA_MASK;` is used on FRDM-K64F with simple RNG init.

Waiting on licensing review and requirements before merging.