### PR TITLE
Port for Nordic nRF51 RNG, RTC and AES. Added RNG test for wc_RNG_Gen…

### DIFF
--- a/README
+++ b/README
@@ -162,8 +162,8 @@ Release 3.6.0 of wolfSSL has bug fixes and new features including:
 - ECC make key crash fix on RNG failure, ECC users must update.
 - Improvements to usage of time code.
 - Improvements to VS solution files.
-- GNU Binutils 2.24 ld has problems with some debug builds, to fix an ld error
-  add -fdebug-types-section to C_EXTRA_FLAGS
+- GNU Binutils 2.24 (and late 2.23) ld has problems with some debug builds,
+  to fix an ld error add C_EXTRA_FLAGS="-fdebug-types-section -g1".
 
 - No high level security fixes that requires an update though we always
   recommend updating to the latest (except note 14, ecc RNG failure)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2785,7 +2785,7 @@ static int wolfssl_decrypt_buffer_key(DerBuffer* der, byte* password,
         ret = wc_Des3_CbcDecryptWithKey(der->buffer, der->buffer, der->length,
                                         key, info->iv);
 #endif /* NO_DES3 */
-#ifndef NO_AES
+#if !defined(NO_AES) && defined(HAVE_AES_CBC)
     if (XSTRNCMP(info->name, EVP_AES_128_CBC, EVP_AES_SIZE) == 0)
         ret = wc_AesCbcDecryptWithKey(der->buffer, der->buffer, der->length,
                                       key, AES_128_KEY_SIZE, info->iv);
@@ -2795,7 +2795,7 @@ static int wolfssl_decrypt_buffer_key(DerBuffer* der, byte* password,
     else if (XSTRNCMP(info->name, EVP_AES_256_CBC, EVP_AES_SIZE) == 0)
         ret = wc_AesCbcDecryptWithKey(der->buffer, der->buffer, der->length,
                                       key, AES_256_KEY_SIZE, info->iv);
-#endif /* NO_AES */
+#endif /* !NO_AES && HAVE_AES_CBC */
 
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -9123,6 +9123,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         switch (ctx->cipherType) {
 
 #ifndef NO_AES
+#ifdef HAVE_AES_CBC
             case AES_128_CBC_TYPE :
             case AES_192_CBC_TYPE :
             case AES_256_CBC_TYPE :
@@ -9132,7 +9133,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
                 else
                     ret = wc_AesCbcDecrypt(&ctx->cipher.aes, dst, src, len);
                 break;
-
+#endif /* HAVE_AES_CBC */
 #ifdef WOLFSSL_AES_COUNTER
             case AES_128_CTR_TYPE :
             case AES_192_CTR_TYPE :
@@ -9140,7 +9141,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
                     WOLFSSL_MSG("AES CTR");
                     wc_AesCtrEncrypt(&ctx->cipher.aes, dst, src, len);
                 break;
-#endif
+#endif /* WOLFSSL_AES_COUNTER */
 #endif /* NO_AES */
 
 #ifndef NO_DES3

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -256,7 +256,7 @@ int benchmark_test(void *args)
     (void)args;
 #endif
 
-#ifdef USE_WOLFSSL_MEMORY
+#if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)
     InitMemoryTracker();
 #endif
 
@@ -290,20 +290,21 @@ int benchmark_test(void *args)
 #endif
 
 #ifndef NO_AES
+#ifdef HAVE_AES_CBC
     bench_aes(0);
     bench_aes(1);
 #endif
 #ifdef HAVE_AESGCM
     bench_aesgcm();
 #endif
-
 #ifdef WOLFSSL_AES_COUNTER
     bench_aesctr();
 #endif
-
 #ifdef HAVE_AESCCM
     bench_aesccm();
 #endif
+#endif /* !NO_AES */
+
 #ifdef HAVE_CAMELLIA
     bench_camellia();
 #endif
@@ -399,7 +400,7 @@ int benchmark_test(void *args)
     wc_FreeRng(&rng);
 #endif
 
-#ifdef USE_WOLFSSL_MEMORY
+#if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)
     ShowMemoryTracker();
 #endif
 
@@ -428,6 +429,7 @@ static const char blockType[] = "megs"; /* used in printf output */
 
 #ifndef NO_AES
 
+#ifdef HAVE_AES_CBC
 void bench_aes(int show)
 {
     Aes    enc;
@@ -472,8 +474,7 @@ void bench_aes(int show)
     wc_AesFreeCavium(&enc);
 #endif
 }
-#endif
-
+#endif /* HAVE_AES_CBC */
 
 #if defined(HAVE_AESGCM) || defined(HAVE_AESCCM)
     static byte additional[13];
@@ -533,7 +534,8 @@ void bench_aesgcm(void)
     printf("\n");
 #endif
 }
-#endif
+#endif /* HAVE_AESGCM */
+
 
 #ifdef WOLFSSL_AES_COUNTER
 void bench_aesctr(void)
@@ -563,8 +565,7 @@ void bench_aesctr(void)
     SHOW_INTEL_CYCLES
     printf("\n");
 }
-#endif
-
+#endif /* WOLFSSL_AES_COUNTER */
 
 
 #ifdef HAVE_AESCCM
@@ -596,7 +597,8 @@ void bench_aesccm(void)
     SHOW_INTEL_CYCLES
     printf("\n");
 }
-#endif
+#endif /* HAVE_AESCCM */
+#endif /* !NO_AES */
 
 
 #ifdef HAVE_POLY1305

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -118,7 +118,7 @@
 #ifdef HAVE_BLAKE2
     #include <wolfssl/wolfcrypt/blake2.h>
     void bench_blake2(void);
-#endif 
+#endif
 
 #ifdef _MSC_VER
     /* 4996 warning to use MS extensions e.g., strcpy_s instead of strncpy */
@@ -126,6 +126,10 @@
 #endif
 
 #include "wolfcrypt/benchmark/benchmark.h"
+
+#ifdef USE_WOLFSSL_MEMORY
+    #include "wolfssl/mem_track.h"
+#endif
 
 void bench_des(void);
 void bench_idea(void);
@@ -156,9 +160,11 @@ void bench_eccKeyGen(void);
 void bench_eccKeyAgree(void);
 #endif
 #ifdef HAVE_CURVE25519
-void bench_curve25519KeyGen(void);
-void bench_curve25519KeyAgree(void);
-#endif
+    void bench_curve25519KeyGen(void);
+    #ifdef HAVE_CURVE25519_SHARED_SECRET
+        void bench_curve25519KeyAgree(void);
+    #endif /* HAVE_CURVE25519_SHARED_SECRET */
+#endif /* HAVE_CURVE25519 */
 #ifdef HAVE_ED25519
 void bench_ed25519KeyGen(void);
 void bench_ed25519KeySign(void);
@@ -245,9 +251,13 @@ int main(int argc, char** argv)
     (void)argc;
     (void)argv;
 #else
-int benchmark_test(void *args) 
+int benchmark_test(void *args)
 {
     (void)args;
+#endif
+
+#ifdef USE_WOLFSSL_MEMORY
+    InitMemoryTracker();
 #endif
 
     wolfCrypt_Init();
@@ -318,7 +328,7 @@ int benchmark_test(void *args)
 #ifdef HAVE_IDEA
     bench_idea();
 #endif
-    
+
     printf("\n");
 
 #ifndef NO_MD5
@@ -375,7 +385,9 @@ int benchmark_test(void *args)
 
 #ifdef HAVE_CURVE25519
     bench_curve25519KeyGen();
-    bench_curve25519KeyAgree();
+    #ifdef HAVE_CURVE25519_SHARED_SECRET
+        bench_curve25519KeyAgree();
+    #endif
 #endif
 
 #ifdef HAVE_ED25519
@@ -385,6 +397,10 @@ int benchmark_test(void *args)
 
 #if defined(HAVE_LOCAL_RNG)
     wc_FreeRng(&rng);
+#endif
+
+#ifdef USE_WOLFSSL_MEMORY
+    ShowMemoryTracker();
 #endif
 
     return 0;
@@ -740,7 +756,7 @@ void bench_arc4(void)
     Arc4   enc;
     double start, total, persec;
     int    i;
-    
+
 #ifdef HAVE_CAVIUM
     if (wc_Arc4InitCavium(&enc, CAVIUM_DEV_ID) != 0)
         printf("arc4 init cavium failed\n");
@@ -778,7 +794,7 @@ void bench_hc128(void)
     HC128  enc;
     double start, total, persec;
     int    i;
-    
+
     wc_Hc128_SetKey(&enc, key, iv);
     start = current_time(1);
     BEGIN_INTEL_CYCLES
@@ -808,7 +824,7 @@ void bench_rabbit(void)
     Rabbit  enc;
     double start, total, persec;
     int    i;
-    
+
     wc_RabbitSetKey(&enc, key, iv);
     start = current_time(1);
     BEGIN_INTEL_CYCLES
@@ -912,7 +928,7 @@ void bench_md5(void)
 
     for(i = 0; i < numBlocks; i++)
         wc_Md5Update(&hash, plain, sizeof(plain));
-   
+
     wc_Md5Final(&hash, digest);
 
     END_INTEL_CYCLES
@@ -938,7 +954,7 @@ void bench_sha(void)
     byte   digest[SHA_DIGEST_SIZE];
     double start, total, persec;
     int    i, ret;
-        
+
     ret = wc_InitSha(&hash);
     if (ret != 0) {
         printf("InitSha failed, ret = %d\n", ret);
@@ -946,10 +962,10 @@ void bench_sha(void)
     }
     start = current_time(1);
     BEGIN_INTEL_CYCLES
-    
+
     for(i = 0; i < numBlocks; i++)
         wc_ShaUpdate(&hash, plain, sizeof(plain));
-   
+
     wc_ShaFinal(&hash, digest);
 
     END_INTEL_CYCLES
@@ -1065,7 +1081,7 @@ void bench_sha512(void)
     byte   digest[SHA512_DIGEST_SIZE];
     double start, total, persec;
     int    i, ret;
-        
+
     ret = wc_InitSha512(&hash);
     if (ret != 0) {
         printf("InitSha512 failed, ret = %d\n", ret);
@@ -1073,7 +1089,7 @@ void bench_sha512(void)
     }
     start = current_time(1);
     BEGIN_INTEL_CYCLES
-    
+
     for(i = 0; i < numBlocks; i++) {
         ret = wc_Sha512Update(&hash, plain, sizeof(plain));
         if (ret != 0) {
@@ -1110,14 +1126,14 @@ void bench_ripemd(void)
     byte   digest[RIPEMD_DIGEST_SIZE];
     double start, total, persec;
     int    i;
-        
+
     wc_InitRipeMd(&hash);
     start = current_time(1);
     BEGIN_INTEL_CYCLES
-    
+
     for(i = 0; i < numBlocks; i++)
         wc_RipeMdUpdate(&hash, plain, sizeof(plain));
-   
+
     wc_RipeMdFinal(&hash, digest);
 
     END_INTEL_CYCLES
@@ -1143,7 +1159,7 @@ void bench_blake2(void)
     byte    digest[64];
     double  start, total, persec;
     int     i, ret;
-       
+
     ret = wc_InitBlake2b(&b2b, 64);
     if (ret != 0) {
         printf("InitBlake2b failed, ret = %d\n", ret);
@@ -1151,7 +1167,7 @@ void bench_blake2(void)
     }
     start = current_time(1);
     BEGIN_INTEL_CYCLES
-    
+
     for(i = 0; i < numBlocks; i++) {
         ret = wc_Blake2bUpdate(&b2b, plain, sizeof(plain));
         if (ret != 0) {
@@ -1159,7 +1175,7 @@ void bench_blake2(void)
             return;
         }
     }
-   
+
     ret = wc_Blake2bFinal(&b2b, digest, 64);
     if (ret != 0) {
         printf("Blake2bFinal failed, ret = %d\n", ret);
@@ -1327,7 +1343,7 @@ void bench_dh(void)
     #error "need to define a cert buffer size"
 #endif /* USE_CERT_BUFFERS */
 
-		
+
     wc_InitDhKey(&dhKey);
 #ifdef NO_ASN
     bytes = wc_DhSetKey(&dhKey, dh_p, sizeof(dh_p), dh_g, sizeof(dh_g));
@@ -1374,12 +1390,12 @@ void bench_rsaKeyGen(void)
     RsaKey genKey;
     double start, total, each, milliEach;
     int    i;
-  
-    /* 1024 bit */ 
+
+    /* 1024 bit */
     start = current_time(1);
 
     for(i = 0; i < genTimes; i++) {
-        wc_InitRsaKey(&genKey, 0); 
+        wc_InitRsaKey(&genKey, 0);
         wc_MakeRsaKey(&genKey, 1024, 65537, &rng);
         wc_FreeRsaKey(&genKey);
     }
@@ -1395,7 +1411,7 @@ void bench_rsaKeyGen(void)
     start = current_time(1);
 
     for(i = 0; i < genTimes; i++) {
-        wc_InitRsaKey(&genKey, 0); 
+        wc_InitRsaKey(&genKey, 0);
         wc_MakeRsaKey(&genKey, 2048, 65537, &rng);
         wc_FreeRsaKey(&genKey);
     }
@@ -1647,8 +1663,8 @@ void bench_eccKeyGen(void)
     ecc_key genKey;
     double start, total, each, milliEach;
     int    i;
-  
-    /* 256 bit */ 
+
+    /* 256 bit */
     start = current_time(1);
 
     for(i = 0; i < genTimes; i++) {
@@ -1672,7 +1688,7 @@ void bench_eccKeyAgree(void)
     double start, total, each, milliEach;
     int    i, ret;
     byte   shared[32];
-#ifndef NO_ASN
+#if !defined(NO_ASN) && !defined(NO_ECC_SIGN)
     byte   sig[64+16];  /* der encoding too */
 #endif
     byte   digest[32];
@@ -1715,7 +1731,7 @@ void bench_eccKeyAgree(void)
         digest[i] = (byte)i;
 
 
-#ifndef NO_ASN
+#if !defined(NO_ASN) && !defined(NO_ECC_SIGN)
     start = current_time(1);
 
     for(i = 0; i < agreeTimes; i++) {
@@ -1723,7 +1739,7 @@ void bench_eccKeyAgree(void)
         ret = wc_ecc_sign_hash(digest, sizeof(digest), sig, &x, &rng, &genKey);
         if (ret != 0) {
             printf("ecc_sign_hash failed\n");
-            return; 
+            return;
         }
     }
 
@@ -1740,7 +1756,7 @@ void bench_eccKeyAgree(void)
         ret = wc_ecc_verify_hash(sig, x, digest, sizeof(digest), &verify, &genKey);
         if (ret != 0) {
             printf("ecc_verify_hash failed\n");
-            return; 
+            return;
         }
     }
 #endif
@@ -1779,7 +1795,7 @@ void bench_curve25519KeyGen(void)
            " iterations\n", milliEach, genTimes);
 }
 
-
+#ifdef HAVE_CURVE25519_SHARED_SECRET
 void bench_curve25519KeyAgree(void)
 {
     curve25519_key genKey, genKey2;
@@ -1823,6 +1839,7 @@ void bench_curve25519KeyAgree(void)
     wc_curve25519_free(&genKey2);
     wc_curve25519_free(&genKey);
 }
+#endif /* HAVE_CURVE25519_SHARED_SECRET */
 #endif /* HAVE_CURVE25519 */
 
 #ifdef HAVE_ED25519
@@ -1852,12 +1869,15 @@ void bench_ed25519KeyGen(void)
 
 void bench_ed25519KeySign(void)
 {
+    int    ret;
     ed25519_key genKey;
+#ifdef HAVE_ED25519_SIGN
     double start, total, each, milliEach;
-    int    i, ret;
+    int    i;
     byte   sig[ED25519_SIG_SIZE];
     byte   msg[512];
     word32 x = 0;
+#endif
 
     wc_ed25519_init(&genKey);
 
@@ -1866,10 +1886,11 @@ void bench_ed25519KeySign(void)
         printf("ed25519_make_key failed\n");
         return;
     }
+
+#ifdef HAVE_ED25519_SIGN
     /* make dummy msg */
     for (i = 0; i < (int)sizeof(msg); i++)
         msg[i] = (byte)i;
-
 
     start = current_time(1);
 
@@ -1888,6 +1909,7 @@ void bench_ed25519KeySign(void)
     printf("ED25519  sign   time     %6.3f milliseconds, avg over %d"
            " iterations\n", milliEach, agreeTimes);
 
+#ifdef HAVE_ED25519_VERIFY
     start = current_time(1);
 
     for(i = 0; i < agreeTimes; i++) {
@@ -1905,6 +1927,8 @@ void bench_ed25519KeySign(void)
     milliEach = each * 1000;     /* milliseconds */
     printf("ED25519  verify time     %6.3f milliseconds, avg over %d"
            " iterations\n", milliEach, agreeTimes);
+#endif /* HAVE_ED25519_VERIFY */
+#endif /* HAVE_ED25519_SIGN */
 
     wc_ed25519_free(&genKey);
 }
@@ -1920,7 +1944,7 @@ void bench_ed25519KeySign(void)
     {
         static int init = 0;
         static LARGE_INTEGER freq;
-    
+
         LARGE_INTEGER count;
 
         (void)reset;
@@ -1960,7 +1984,7 @@ void bench_ed25519KeySign(void)
 
 #elif defined(WOLFSSL_IAR_ARM_TIME) || defined (WOLFSSL_MDK_ARM) || defined(WOLFSSL_USER_CURRTIME)
     extern   double current_time(int reset);
-    
+
 #elif defined FREERTOS
 
     double current_time(int reset)

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -267,10 +267,7 @@ void wc_AesFreeCavium(Aes* aes)
         return nrf51_aes_encrypt(inBlock, (byte*)aes->key, aes->rounds, outBlock);
     }
     #ifdef HAVE_AES_DECRYPT
-    static int wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
-    {
-        return nrf51_aes_decrypt(inBlock, (byte*)aes->key, aes->rounds, outBlock);
-    }
+        #error nRF51 AES Hardware does not support decrypt
     #endif /* HAVE_AES_DECRYPT */
 
 #else

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -43,6 +43,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 }
 
 
+#ifdef HAVE_AES_CBC
 int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     return AesCbcEncrypt_fips(aes, out, in, sz);
@@ -54,6 +55,7 @@ int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     return AesCbcDecrypt_fips(aes, out, in, sz);
 }
 #endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_CBC */
 
 /* AES-CTR */
 #ifdef WOLFSSL_AES_COUNTER
@@ -252,12 +254,14 @@ void wc_AesFreeCavium(Aes* aes)
 
     static int  wc_AesCaviumSetKey(Aes* aes, const byte* key, word32 length,
                                 const byte* iv);
+    #ifdef HAVE_AES_CBC
     static int  wc_AesCaviumCbcEncrypt(Aes* aes, byte* out, const byte* in,
                                     word32 length);
     #ifdef HAVE_AES_DECRYPT
     static int  wc_AesCaviumCbcDecrypt(Aes* aes, byte* out, const byte* in,
                                     word32 length);
     #endif /* HAVE_AES_DECRYPT */
+    #endif /* HAVE_AES_CBC */
 #elif defined(WOLFSSL_NRF51_AES)
     /* Use built-in AES hardware - AES 128 ECB Encrypt Only */
     #include "wolfssl/wolfcrypt/port/nrf51.h"
@@ -271,6 +275,7 @@ void wc_AesFreeCavium(Aes* aes)
     #endif /* HAVE_AES_DECRYPT */
 
 #else
+
     /* using wolfCrypt software AES implementation */
     #define NEED_AES_TABLES
 #endif
@@ -996,6 +1001,7 @@ static int haveAESNI  = 0;
 
 /* tell C compiler these are asm functions in case any mix up of ABI underscore
    prefix between clang/gcc/llvm etc */
+#ifdef HAVE_AES_CBC
 void AES_CBC_encrypt(const unsigned char* in, unsigned char* out,
                      unsigned char* ivec, unsigned long length,
                      const unsigned char* KS, int nr)
@@ -1006,8 +1012,9 @@ void AES_CBC_decrypt(const unsigned char* in, unsigned char* out,
                      unsigned char* ivec, unsigned long length,
                      const unsigned char* KS, int nr)
                      XASM_LINK("AES_CBC_decrypt");
-#endif
-
+#endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_CBC */
+                     
 void AES_ECB_encrypt(const unsigned char* in, unsigned char* out,
                      unsigned long length, const unsigned char* KS, int nr)
                      XASM_LINK("AES_ECB_encrypt");
@@ -1098,6 +1105,8 @@ static int AES_set_decrypt_key(const unsigned char* userKey, const int bits,
 #endif /* HAVE_AES_DECRYPT */
 #endif /* WOLFSSL_AESNI */
 
+#if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_DIRECT) ||\
+    defined(HAVE_AESGCM)
 
 static void wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 {
@@ -1277,8 +1286,10 @@ static void wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
     XMEMCPY(outBlock + 2 * sizeof(s0), &s2, sizeof(s2));
     XMEMCPY(outBlock + 3 * sizeof(s0), &s3, sizeof(s3));
 }
+#endif /* HAVE_AES_CBC || WOLFSSL_AES_DIRECT || HAVE_AESGCM */
 
 #ifdef HAVE_AES_DECRYPT
+#if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_DIRECT)
 static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 {
     word32 s0, s1, s2, s3;
@@ -1438,6 +1449,8 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
     XMEMCPY(outBlock + 3 * sizeof(s0), &s3, sizeof(s3));
 }
 #endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_CBC || WOLFSSL_AES_DIRECT */
+
 #endif /* NEED_AES_TABLES */
 
 
@@ -1842,6 +1855,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 
 
 /* AES-CBC */
+#ifdef HAVE_AES_CBC
 #ifdef STM32F2_CRYPTO
     int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     {
@@ -2470,6 +2484,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
     #endif
 
 #endif /* STM32F2_CRYPTO, AES-CBC block */
+#endif /* HAVE_AES_CBC */
 
 /* AES-CTR */
 #ifdef WOLFSSL_AES_COUNTER
@@ -4246,7 +4261,7 @@ static int wc_AesCaviumSetKey(Aes* aes, const byte* key, word32 length,
     return wc_AesSetIV(aes, iv);
 }
 
-
+#ifdef HAVE_AES_CBC
 static int wc_AesCaviumCbcEncrypt(Aes* aes, byte* out, const byte* in,
                                word32 length)
 {
@@ -4316,6 +4331,7 @@ static int wc_AesCaviumCbcDecrypt(Aes* aes, byte* out, const byte* in,
     return 0;
 }
 #endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_CBC */
 
 #endif /* HAVE_CAVIUM */
 

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -39,10 +39,10 @@
 #endif
 
 const curve25519_set_type curve25519_sets[] = {
-{
+    {
         32,
         "CURVE25519",
-}
+    }
 };
 
 
@@ -78,6 +78,8 @@ int wc_curve25519_make_key(WC_RNG* rng, int keysize, curve25519_key* key)
 
     return ret;
 }
+
+#ifdef HAVE_CURVE25519_SHARED_SECRET
 
 int wc_curve25519_shared_secret(curve25519_key* private_key,
                                 curve25519_key* public_key,
@@ -125,6 +127,10 @@ int wc_curve25519_shared_secret_ex(curve25519_key* private_key,
     return ret;
 }
 
+#endif /* HAVE_CURVE25519_SHARED_SECRET */
+
+#ifdef HAVE_CURVE25519_KEY_EXPORT
+
 /* export curve25519 public key (Big endian)
  * return 0 on success */
 int wc_curve25519_export_public(curve25519_key* key, byte* out, word32* outLen)
@@ -165,6 +171,10 @@ int wc_curve25519_export_public_ex(curve25519_key* key, byte* out,
     return 0;
 }
 
+#endif /* HAVE_CURVE25519_KEY_EXPORT */
+
+#ifdef HAVE_CURVE25519_KEY_IMPORT
+
 /* import curve25519 public key (Big endian)
  *  return 0 on success */
 int wc_curve25519_import_public(const byte* in, word32 inLen,
@@ -204,6 +214,10 @@ int wc_curve25519_import_public_ex(const byte* in, word32 inLen,
     return 0;
 }
 
+#endif /* HAVE_CURVE25519_KEY_IMPORT */
+
+
+#ifdef HAVE_CURVE25519_KEY_EXPORT
 
 /* export curve25519 private key only raw (Big endian)
  * outLen is in/out size
@@ -276,6 +290,9 @@ int wc_curve25519_export_key_raw_ex(curve25519_key* key,
     return wc_curve25519_export_public_ex(key, pub, pubSz, endian);
 }
 
+#endif /* HAVE_CURVE25519_KEY_EXPORT */
+
+#ifdef HAVE_CURVE25519_KEY_IMPORT
 
 /* curve25519 private key import (Big endian)
  * Public key to match private key needs to be imported too
@@ -347,6 +364,9 @@ int wc_curve25519_import_private_ex(const byte* priv, word32 privSz,
 
     return 0;
 }
+
+#endif /* HAVE_CURVE25519_KEY_IMPORT */
+
 
 int wc_curve25519_init(curve25519_key* key)
 {

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5281,6 +5281,7 @@ int wc_ecc_decrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
 
     if (ret == 0) {
        switch (ctx->encAlgo) {
+    #ifdef HAVE_AES_CBC
            case ecAES_128_CBC:
                {
                    Aes aes;
@@ -5291,7 +5292,7 @@ int wc_ecc_decrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
                    ret = wc_AesCbcDecrypt(&aes, out, msg, msgSz-digestSz);
                }
                break;
-
+    #endif
            default:
                ret = BAD_FUNC_ARG;
                break;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -65,6 +65,7 @@ ECC Curves:
 #include <wolfssl/openssl/ec.h>
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/logging.h>
 
 #ifdef HAVE_ECC_ENCRYPT
     #include <wolfssl/wolfcrypt/hmac.h>
@@ -3017,7 +3018,8 @@ int wc_ecc_import_x963(const byte* in, word32 inLen, ecc_key* key)
          }
       }
       if (ecc_sets[x].size == 0) {
-         err = ASN_PARSE_E;
+          WOLFSSL_MSG("ecc_set size not found");
+          err = ASN_PARSE_E;
       } else {
           /* set the idx */
           key->idx  = x;
@@ -3257,6 +3259,7 @@ int wc_ecc_import_raw(ecc_key* key, const char* qx, const char* qy,
             }
         }
         if (ecc_sets[x].size == 0) {
+            WOLFSSL_MSG("ecc_set curve name not found");
             err = ASN_PARSE_E;
         } else {
             /* set the curve */

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -79,6 +79,7 @@ int wc_ed25519_make_key(WC_RNG* rng, int keySz, ed25519_key* key)
 }
 
 
+#ifdef HAVE_ED25519_SIGN
 /*
     in     contains the message to sign
     inlen  is the length of the message to sign
@@ -164,6 +165,9 @@ int wc_ed25519_sign_msg(const byte* in, word32 inlen, byte* out,
     return ret;
 }
 
+#endif /* HAVE_ED25519_SIGN */
+
+#ifdef HAVE_ED25519_VERIFY
 
 /*
    sig     is array of bytes containing the signature
@@ -238,6 +242,8 @@ int wc_ed25519_verify_msg(byte* sig, word32 siglen, const byte* msg,
     return ret;
 }
 
+#endif /* HAVE_ED25519_VERIFY */
+
 
 /* initialize information and memory for key */
 int wc_ed25519_init(ed25519_key* key)
@@ -261,6 +267,8 @@ void wc_ed25519_free(ed25519_key* key)
 }
 
 
+#ifdef HAVE_ED25519_KEY_EXPORT
+
 /*
     outLen should contain the size of out buffer when input. outLen is than set
     to the final output length.
@@ -283,7 +291,10 @@ int wc_ed25519_export_public(ed25519_key* key, byte* out, word32* outLen)
     return 0;
 }
 
+#endif /* HAVE_ED25519_KEY_EXPORT */
 
+
+#ifdef HAVE_ED25519_KEY_IMPORT
 /*
     Imports a compressed/uncompressed public key.
     in    the byte array containing the public key
@@ -357,6 +368,10 @@ int wc_ed25519_import_private_key(const byte* priv, word32 privSz,
     return ret;
 }
 
+#endif /* HAVE_ED25519_KEY_IMPORT */
+
+
+#ifdef HAVE_ED25519_KEY_EXPORT
 
 /*
  export private key only (secret part so 32 bytes)
@@ -423,6 +438,9 @@ int wc_ed25519_export_key(ed25519_key* key,
 
     return ret;
 }
+
+#endif /* HAVE_ED25519_KEY_EXPORT */
+
 
 /* returns the private key size (secret only) in bytes */
 int wc_ed25519_size(ed25519_key* key)

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -43,6 +43,7 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/ti/ti-des3.c \
               wolfcrypt/src/port/ti/ti-hash.c \
               wolfcrypt/src/port/ti/ti-ccm.c \
-              wolfcrypt/src/port/pic32/pic32mz-hash.c
+              wolfcrypt/src/port/pic32/pic32mz-hash.c \
+              wolfcrypt/src/port/nrf51.c
 
 

--- a/wolfcrypt/src/port/nrf51.c
+++ b/wolfcrypt/src/port/nrf51.c
@@ -1,0 +1,215 @@
+/* nrf51.c
+ *
+ * Copyright (C) 2006-2015 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL. (formerly known as CyaSSL)
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_NRF51
+
+#include "bsp.h"
+#include "nrf_delay.h"
+#include "app_uart.h"
+#include "app_error.h"
+#include "nrf_drv_rng.h"
+#include "nrf_drv_rtc.h"
+#include "nrf_drv_clock.h"
+#include "nrf_ecb.h"
+
+#ifdef SOFTDEVICE_PRESENT
+    #include "softdevice_handler.h"
+    #include "nrf_soc.h"
+#endif /* SOFTDEVICE_PRESENT */
+
+/* RTC */
+#ifndef NO_CRYPT_BENCHMARK
+static byte mRtcInitDone = 0;
+static int mRtcSec = 0;
+const nrf_drv_rtc_t rtc = NRF_DRV_RTC_INSTANCE(0); /**< Declaring an instance of nrf_drv_rtc for RTC0. */
+#endif /* !NO_CRYPT_BENCHMARK */
+
+/* AES */
+#if !defined(NO_AES) && !defined(SOFTDEVICE_PRESENT)
+    static byte mAesInitDone = 0;
+#endif
+
+/** @brief Function for getting vector of random numbers.
+ *
+ * @param[out] p_buff   Pointer to unit8_t buffer for storing the bytes.
+ * @param[in]  length   Number of bytes to take from pool and place in p_buff.
+ *
+ * @retval     0 = Success, else error
+ */
+int nrf51_random_generate(byte* output, word32 size)
+{
+    int remaining = size, length, pos = 0;
+    uint8_t available;
+    uint32_t err_code;
+
+    /* Make sure RNG is running */
+    err_code = nrf_drv_rng_init(NULL);
+    if (NRF_SUCCESS != NRF_SUCCESS && err_code != NRF_ERROR_INVALID_STATE) {
+        return -1;
+    }
+
+    while (remaining > 0) {
+        err_code = nrf_drv_rng_bytes_available(&available);
+        if (err_code == NRF_SUCCESS) {
+            length = (remaining < available) ? remaining : available;
+            if (length > 0) {
+                err_code = nrf_drv_rng_rand(&output[pos], length);
+                remaining -= length;
+                pos += length;
+            }
+        }
+
+        if (err_code != NRF_SUCCESS) {
+            break;
+        }
+    }
+
+    return (err_code == NRF_SUCCESS) ? 0 : -1;
+}
+
+#if !defined(NO_AES) && defined(WOLFSSL_NRF51_AES)
+
+#ifdef SOFTDEVICE_PRESENT
+static const byte* nRF51AesKey = NULL;
+#endif
+int nrf51_aes_set_key(const byte* key)
+{
+#ifdef SOFTDEVICE_PRESENT
+    nRF51AesKey = key;
+#else
+    if (!mAesInitDone) {
+        nrf_ecb_init();
+        mAesInitDone = 1;
+    }
+    nrf_ecb_set_key(key);
+#endif
+    return 0;
+}
+
+
+int nrf51_aes_encrypt(const byte* in, const byte* key, word32 rounds, byte* out)
+{
+    uint32_t err_code = 0;
+#ifdef SOFTDEVICE_PRESENT
+    nrf_ecb_hal_data_t ecb_hal_data;
+#endif
+
+    /* Set key */
+    nrf51_aes_set_key(key);
+
+#ifdef SOFTDEVICE_PRESENT
+    /* Define ECB record */
+    XMEMCPY(ecb_hal_data.key, nRF51AesKey, SOC_ECB_KEY_LENGTH);
+    XMEMCPY(ecb_hal_data.cleartext, in, SOC_ECB_CLEARTEXT_LENGTH);
+    XMEMSET(ecb_hal_data.ciphertext, 0, SOC_ECB_CIPHERTEXT_LENGTH);
+
+    /* Perform block encrypt */
+    err_code = sd_ecb_block_encrypt(&ecb_hal_data);
+    if (err_code != NRF_SUCCESS) {
+        return -1;
+    }
+
+    /* Grab result */
+    XMEMCPY(out, ecb_hal_data.ciphertext, SOC_ECB_CIPHERTEXT_LENGTH);
+#else
+    err_code = nrf_ecb_crypt(out, in);
+    err_code = err_code ? 0 : -1;
+#endif
+
+    return err_code;
+}
+
+#endif /* !NO_AES && WOLFSSL_NRF51_AES */
+
+
+#ifndef NO_CRYPT_BENCHMARK
+static void rtc_handler(nrf_drv_rtc_int_type_t int_type)
+{
+    if (int_type == NRF_DRV_RTC_INT_COMPARE0)
+    {
+        mRtcSec++;
+        nrf_drv_rtc_counter_clear(&rtc);
+        nrf_drv_rtc_int_enable(&rtc, RTC_CHANNEL_INT_MASK(0));
+
+#ifdef BSP_LED_0
+        nrf_gpio_pin_toggle(BSP_LED_0);
+#endif
+    }
+}
+
+static void rtc_config(void)
+{
+    uint32_t err_code;
+
+    // Start the internal LFCLK XTAL oscillator
+    err_code = nrf_drv_clock_init(NULL);
+    APP_ERROR_CHECK(err_code);
+
+    nrf_drv_clock_lfclk_request();
+
+    // Initialize RTC instance
+    err_code = nrf_drv_rtc_init(&rtc, NULL, rtc_handler);
+    APP_ERROR_CHECK(err_code);
+
+    // Enable tick event
+    nrf_drv_rtc_tick_enable(&rtc, false);
+
+    // Set compare channel to trigger interrupt after 1 seconds
+    err_code = nrf_drv_rtc_cc_set(&rtc, 0, RTC0_CONFIG_FREQUENCY, true);
+    APP_ERROR_CHECK(err_code);
+
+    // Power on RTC instance
+    nrf_drv_rtc_enable(&rtc);
+}
+
+static int rtc_get_ms(void)
+{
+    /* Prescaler is 12-bit for COUNTER: frequency = (32768/(PRESCALER+1)) */
+    int frequency = (32768 / (rtc_prescaler_get(rtc.p_reg) + 1));
+    int counter = nrf_drv_rtc_counter_get(&rtc);
+
+    /* Convert with rounding frequency to milliseconds */
+    return ((counter * 1000) + (frequency / 2) ) / frequency;
+}
+
+double current_time(int reset)
+{
+    double time;
+
+    if (!mRtcInitDone) {
+        rtc_config();
+        mRtcInitDone = 1;
+    }
+
+    time = mRtcSec;
+    time += (double)rtc_get_ms() / 1000;
+
+    return time;
+}
+#endif /* !NO_CRYPT_BENCHMARK */
+
+#endif /* WOLFSSL_NRF51 */

--- a/wolfcrypt/src/port/nrf51.c
+++ b/wolfcrypt/src/port/nrf51.c
@@ -68,7 +68,7 @@ int nrf51_random_generate(byte* output, word32 size)
 
     /* Make sure RNG is running */
     err_code = nrf_drv_rng_init(NULL);
-    if (NRF_SUCCESS != NRF_SUCCESS && err_code != NRF_ERROR_INVALID_STATE) {
+    if (err_code != NRF_SUCCESS && err_code != NRF_ERROR_INVALID_STATE) {
         return -1;
     }
 
@@ -113,13 +113,17 @@ int nrf51_aes_set_key(const byte* key)
 
 int nrf51_aes_encrypt(const byte* in, const byte* key, word32 rounds, byte* out)
 {
+    int ret;
     uint32_t err_code = 0;
 #ifdef SOFTDEVICE_PRESENT
     nrf_ecb_hal_data_t ecb_hal_data;
 #endif
 
     /* Set key */
-    nrf51_aes_set_key(key);
+    ret = nrf51_aes_set_key(key);
+    if (ret != 0) {
+        return ret;
+    }
 
 #ifdef SOFTDEVICE_PRESENT
     /* Define ECB record */

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1379,7 +1379,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
         /* Make sure RNG is running */
         err_code = nrf_drv_rng_init(NULL);
-        if (NRF_SUCCESS != NRF_SUCCESS && err_code != NRF_ERROR_INVALID_STATE) {
+        if (err_code != NRF_SUCCESS && err_code != NRF_ERROR_INVALID_STATE) {
             return -1;
         }
 

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1366,6 +1366,42 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         return 0;
     }
 
+#elif defined(WOLFSSL_NRF51)
+    #include "app_error.h"
+    #include "nrf_drv_rng.h"
+    int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
+    {
+        int remaining = sz, length, pos = 0;
+        uint8_t available;
+        uint32_t err_code;
+
+        (void)os;
+
+        /* Make sure RNG is running */
+        err_code = nrf_drv_rng_init(NULL);
+        if (NRF_SUCCESS != NRF_SUCCESS && err_code != NRF_ERROR_INVALID_STATE) {
+            return -1;
+        }
+
+        while (remaining > 0) {
+            err_code = nrf_drv_rng_bytes_available(&available);
+            if (err_code == NRF_SUCCESS) {
+                length = (remaining < available) ? remaining : available;
+                if (length > 0) {
+                    err_code = nrf_drv_rng_rand(&output[pos], length);
+                    remaining -= length;
+                    pos += length;
+                }
+            }
+
+            if (err_code != NRF_SUCCESS) {
+                break;
+            }
+        }
+
+        return (err_code == NRF_SUCCESS) ? 0 : -1;
+    }
+
 #elif defined(CUSTOM_RAND_GENERATE)
 
    /* Implement your own random generation function

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -30,7 +30,7 @@
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 
-#ifndef NO_AES
+#if !defined(NO_AES) && defined(HAVE_AES_CBC)
 int wc_AesCbcDecryptWithKey(byte* out, const byte* in, word32 inSz,
                                   const byte* key, word32 keySz, const byte* iv)
 {
@@ -84,7 +84,7 @@ int wc_AesCbcEncryptWithKey(byte* out, const byte* in, word32 inSz,
 
     return ret;
 }
-#endif /* !NO_AES */
+#endif /* !NO_AES && HAVE_AES_CBC */
 
 
 #ifndef NO_DES3

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -3607,6 +3607,7 @@ static int random_rng_test(void)
         ret = -38;
         goto exit;
     }
+    ret = 0;
 
 exit:
     /* Make sure and free RNG */
@@ -6443,7 +6444,7 @@ int ecc_test(void)
         ecc192.S  = "02ba6465a234903744ab02bc8521405b73cf5fc00e1a9f41";
         ecc192.curveName = "ECC-192";
         ret = ecc_test_raw_vector(&ecc192, &userA, sig, sizeof(sig));
-        if (ret != 0) {
+        if (ret < 0) {
             return ret;
         }
     }
@@ -6475,7 +6476,7 @@ int ecc_test(void)
         ecc224.S  = "24fc7ed7f1352ca3872aa0916191289e2e04d454935d50fe6af3ad5b";
         ecc224.curveName = "ECC-224";
         ret = ecc_test_raw_vector(&ecc224, &userA, sig, sizeof(sig));
-        if (ret != 0) {
+        if (ret < 0) {
             return ret;
         }
     }
@@ -6507,7 +6508,7 @@ int ecc_test(void)
         ecc256.S  = "a2248b62c03db35a7cd63e8a120a3521a89d3d2f61ff99035a2148ae32e3a248";
         ecc256.curveName = "nistp256";
         ret = ecc_test_raw_vector(&ecc256, &userA, sig, sizeof(sig));
-        if (ret != 0) {
+        if (ret < 0) {
             return ret;
         }
     }
@@ -6539,7 +6540,7 @@ int ecc_test(void)
         ecc384.S  = "491af1d0cccd56ddd520b233775d0bc6b40a6255cc55207d8e9356741f23c96c14714221078dbd5c17f4fdd89b32a907";
         ecc384.curveName = "nistp384";
         ret = ecc_test_raw_vector(&ecc384, &userA, sig, sizeof(sig));
-        if (ret != 0) {
+        if (ret < 0) {
             return ret;
         }
     }
@@ -6571,7 +6572,7 @@ int ecc_test(void)
         ecc521.S  = "019cd2c5c3f9870ecdeb9b323abdf3a98cd5e231d85c6ddc5b71ab190739f7f226e6b134ba1d5889ddeb2751dabd97911dff90c34684cdbe7bb669b6c3d22f2480c";
         ecc521.curveName = "nistp521";
         ret = ecc_test_raw_vector(&ecc521, &userA, sig, sizeof(sig));
-        if (ret != 0) {
+        if (ret < 0) {
             return ret;
         }
     }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6369,7 +6369,7 @@ int ecc_test(void)
         return -1010;
     wc_ecc_free(&pubKey);
     wc_ecc_init(&pubKey);
-#if HAVE_ECC_KEY_IMPORT
+#ifdef HAVE_ECC_KEY_IMPORT
     ret = wc_ecc_import_x963(exportBuf, x, &pubKey);
     if (ret != 0)
         return -1011;
@@ -6443,6 +6443,9 @@ int ecc_test(void)
         ecc192.S  = "02ba6465a234903744ab02bc8521405b73cf5fc00e1a9f41";
         ecc192.curveName = "ECC-192";
         ret = ecc_test_raw_vector(&ecc192, &userA, sig, sizeof(sig));
+        if (ret != 0) {
+            return ret;
+        }
     }
 #endif /* HAVE_ECC192 */
 #if defined(HAVE_ECC224) || defined(HAVE_ALL_CURVES)
@@ -6472,6 +6475,9 @@ int ecc_test(void)
         ecc224.S  = "24fc7ed7f1352ca3872aa0916191289e2e04d454935d50fe6af3ad5b";
         ecc224.curveName = "ECC-224";
         ret = ecc_test_raw_vector(&ecc224, &userA, sig, sizeof(sig));
+        if (ret != 0) {
+            return ret;
+        }
     }
 #endif /* HAVE_ECC192 */
 #if !defined(NO_ECC256) || defined(HAVE_ALL_CURVES)
@@ -6501,6 +6507,9 @@ int ecc_test(void)
         ecc256.S  = "a2248b62c03db35a7cd63e8a120a3521a89d3d2f61ff99035a2148ae32e3a248";
         ecc256.curveName = "nistp256";
         ret = ecc_test_raw_vector(&ecc256, &userA, sig, sizeof(sig));
+        if (ret != 0) {
+            return ret;
+        }
     }
 #endif /* !NO_ECC256 */
 #if defined(HAVE_ECC384) || defined(HAVE_ALL_CURVES)
@@ -6530,6 +6539,9 @@ int ecc_test(void)
         ecc384.S  = "491af1d0cccd56ddd520b233775d0bc6b40a6255cc55207d8e9356741f23c96c14714221078dbd5c17f4fdd89b32a907";
         ecc384.curveName = "nistp384";
         ret = ecc_test_raw_vector(&ecc384, &userA, sig, sizeof(sig));
+        if (ret != 0) {
+            return ret;
+        }
     }
 #endif /* HAVE_ECC384 */
 #if defined(HAVE_ECC521) || defined(HAVE_ALL_CURVES)
@@ -6559,11 +6571,11 @@ int ecc_test(void)
         ecc521.S  = "019cd2c5c3f9870ecdeb9b323abdf3a98cd5e231d85c6ddc5b71ab190739f7f226e6b134ba1d5889ddeb2751dabd97911dff90c34684cdbe7bb669b6c3d22f2480c";
         ecc521.curveName = "nistp521";
         ret = ecc_test_raw_vector(&ecc521, &userA, sig, sizeof(sig));
+        if (ret != 0) {
+            return ret;
+        }
     }
 #endif /* HAVE_ECC521 */
-    if (ret != 0) {
-        return ret;
-    }
 #endif /* HAVE_ECC_VECTOR_TEST */
 
 #ifdef WOLFSSL_KEY_GEN

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -262,7 +262,7 @@ int wolfcrypt_test(void* args)
 
     ((func_args*)args)->return_code = -1; /* error state */
 
-#ifdef USE_WOLFSSL_MEMORY
+#if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)
     InitMemoryTracker();
 #endif
 
@@ -594,7 +594,7 @@ int wolfcrypt_test(void* args)
         printf( "PKCS7signed    test passed!\n");
 #endif
 
-#ifdef USE_WOLFSSL_MEMORY
+#if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)
     ShowMemoryTracker();
 #endif
 
@@ -2616,11 +2616,13 @@ int des3_test(void)
 #ifndef NO_AES
 int aes_test(void)
 {
+#if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_COUNTER)
     Aes enc;
     Aes dec;
 
     byte cipher[AES_BLOCK_SIZE * 4];
     byte plain [AES_BLOCK_SIZE * 4];
+#endif
     int  ret = 0;
 
 #ifdef HAVE_AES_CBC

--- a/wolfssl/include.am
+++ b/wolfssl/include.am
@@ -18,7 +18,8 @@ nobase_include_HEADERS+= \
                          wolfssl/version.h \
                          wolfssl/options.h \
                          wolfssl/ocsp.h \
-                         wolfssl/crl.h
+                         wolfssl/crl.h \
+                         wolfssl/mem_track.h
 
 noinst_HEADERS+= \
                          wolfssl/internal.h

--- a/wolfssl/mem_track.h
+++ b/wolfssl/mem_track.h
@@ -123,7 +123,7 @@
         int ret = 0;
         ret = wolfSSL_SetAllocators(TrackMalloc, TrackFree, TrackRealloc);
         if (ret != 0) {
-            WOLFSSL_MSG("wolfSSL SetAllocators failed for track memory");
+            printf("wolfSSL SetAllocators failed for track memory\n");
             return ret;
         }
 

--- a/wolfssl/mem_track.h
+++ b/wolfssl/mem_track.h
@@ -120,9 +120,8 @@
 
     static INLINE int InitMemoryTracker(void)
     {
-        int ret = 0;
-        ret = wolfSSL_SetAllocators(TrackMalloc, TrackFree, TrackRealloc);
-        if (ret != 0) {
+        int ret = wolfSSL_SetAllocators(TrackMalloc, TrackFree, TrackRealloc);
+        if (ret < 0) {
             printf("wolfSSL SetAllocators failed for track memory\n");
             return ret;
         }

--- a/wolfssl/mem_track.h
+++ b/wolfssl/mem_track.h
@@ -1,0 +1,157 @@
+/* mem_track.h
+ *
+ * Copyright (C) 2006-2015 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL. (formerly known as CyaSSL)
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+
+#ifndef WOLFSSL_MEM_TRACK_H
+#define WOLFSSL_MEM_TRACK_H
+
+#ifdef USE_WOLFSSL_MEMORY
+
+    #include "wolfssl/wolfcrypt/logging.h"
+
+    typedef struct memoryStats {
+        size_t totalAllocs;     /* number of allocations */
+        size_t totalBytes;      /* total number of bytes allocated */
+        size_t peakBytes;       /* concurrent max bytes */
+        size_t currentBytes;    /* total current bytes in use */
+    } memoryStats;
+
+    typedef struct memHint {
+        size_t thisSize;      /* size of this memory */
+        void*  thisMemory;    /* actual memory for user */
+    } memHint;
+
+    typedef struct memoryTrack {
+        union {
+            memHint hint;
+            byte    alignit[16];   /* make sure we have strong alignment */
+        } u;
+    } memoryTrack;
+
+    #if defined(WOLFSSL_TRACK_MEMORY)
+        #define DO_MEM_STATS
+        static memoryStats ourMemStats;
+    #endif
+
+    static INLINE void* TrackMalloc(size_t sz)
+    {
+        memoryTrack* mt;
+
+        if (sz == 0)
+            return NULL;
+
+        mt = (memoryTrack*)malloc(sizeof(memoryTrack) + sz);
+        if (mt == NULL)
+            return NULL;
+
+        mt->u.hint.thisSize   = sz;
+        mt->u.hint.thisMemory = (byte*)mt + sizeof(memoryTrack);
+
+#ifdef DO_MEM_STATS
+        ourMemStats.totalAllocs++;
+        ourMemStats.totalBytes   += sz;
+        ourMemStats.currentBytes += sz;
+        if (ourMemStats.currentBytes > ourMemStats.peakBytes)
+            ourMemStats.peakBytes = ourMemStats.currentBytes;
+#endif
+
+        return mt->u.hint.thisMemory;
+    }
+
+
+    static INLINE void TrackFree(void* ptr)
+    {
+        memoryTrack* mt;
+
+        if (ptr == NULL) {
+            return;
+        }
+
+        mt = (memoryTrack*)ptr;
+        --mt;   /* same as minus sizeof(memoryTrack), removes header */
+
+#ifdef DO_MEM_STATS
+        ourMemStats.currentBytes -= mt->u.hint.thisSize;
+#endif
+
+        free(mt);
+    }
+
+
+    static INLINE void* TrackRealloc(void* ptr, size_t sz)
+    {
+        void* ret = TrackMalloc(sz);
+
+        if (ptr) {
+            /* if realloc is bigger, don't overread old ptr */
+            memoryTrack* mt = (memoryTrack*)ptr;
+            --mt;  /* same as minus sizeof(memoryTrack), removes header */
+
+            if (mt->u.hint.thisSize < sz)
+                sz = mt->u.hint.thisSize;
+        }
+
+        if (ret && ptr)
+            memcpy(ret, ptr, sz);
+
+        if (ret)
+            TrackFree(ptr);
+
+        return ret;
+    }
+
+    static INLINE int InitMemoryTracker(void)
+    {
+        int ret = 0;
+        ret = wolfSSL_SetAllocators(TrackMalloc, TrackFree, TrackRealloc);
+        if (ret != 0) {
+            WOLFSSL_MSG("wolfSSL SetAllocators failed for track memory");
+            return ret;
+        }
+
+    #ifdef DO_MEM_STATS
+        ourMemStats.totalAllocs  = 0;
+        ourMemStats.totalBytes   = 0;
+        ourMemStats.peakBytes    = 0;
+        ourMemStats.currentBytes = 0;
+    #endif
+        
+        return ret;
+    }
+
+    static INLINE void ShowMemoryTracker(void)
+    {
+    #ifdef DO_MEM_STATS
+        printf("total   Allocs = %9lu\n",
+                                       (unsigned long)ourMemStats.totalAllocs);
+        printf("total   Bytes  = %9lu\n",
+                                       (unsigned long)ourMemStats.totalBytes);
+        printf("peak    Bytes  = %9lu\n",
+                                       (unsigned long)ourMemStats.peakBytes);
+        printf("current Bytes  = %9lu\n",
+                                       (unsigned long)ourMemStats.currentBytes);
+    #endif
+    }
+
+#endif /* USE_WOLFSSL_MEMORY */
+
+#endif /* WOLFSSL_MEM_TRACK_H */
+    

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -10,6 +10,7 @@
 #include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/random.h>
+#include <wolfssl/mem_track.h>
 
 #ifdef ATOMIC_USER
     #include <wolfssl/wolfcrypt/aes.h>
@@ -1245,129 +1246,6 @@ static INLINE int OpenNitroxDevice(int dma_mode,int dev_id)
         #endif
     }
 #endif /* !defined(WOLFSSL_MDK_ARM) && !defined(WOLFSSL_KEIL_FS) && !defined(WOLFSSL_TIRTOS) */
-
-
-#ifdef USE_WOLFSSL_MEMORY
-
-    typedef struct memoryStats {
-        size_t totalAllocs;     /* number of allocations */
-        size_t totalBytes;      /* total number of bytes allocated */
-        size_t peakBytes;       /* concurrent max bytes */
-        size_t currentBytes;    /* total current bytes in use */
-    } memoryStats;
-
-    typedef struct memHint {
-        size_t thisSize;      /* size of this memory */
-        void*  thisMemory;    /* actual memory for user */
-    } memHint;
-
-    typedef struct memoryTrack {
-        union {
-            memHint hint;
-            byte    alignit[16];   /* make sure we have strong alignment */
-        } u;
-    } memoryTrack;
-
-    #if defined(WOLFSSL_TRACK_MEMORY)
-        #define DO_MEM_STATS
-        static memoryStats ourMemStats;
-    #endif
-
-    static INLINE void* TrackMalloc(size_t sz)
-    {
-        memoryTrack* mt;
-
-        if (sz == 0)
-            return NULL;
-
-        mt = (memoryTrack*)malloc(sizeof(memoryTrack) + sz);
-        if (mt == NULL)
-            return NULL;
-
-        mt->u.hint.thisSize   = sz;
-        mt->u.hint.thisMemory = (byte*)mt + sizeof(memoryTrack);
-
-#ifdef DO_MEM_STATS
-        ourMemStats.totalAllocs++;
-        ourMemStats.totalBytes   += sz;
-        ourMemStats.currentBytes += sz;
-        if (ourMemStats.currentBytes > ourMemStats.peakBytes)
-            ourMemStats.peakBytes = ourMemStats.currentBytes;
-#endif
-
-        return mt->u.hint.thisMemory;
-    }
-
-
-    static INLINE void TrackFree(void* ptr)
-    {
-        memoryTrack* mt;
-
-        if (ptr == NULL)
-            return;
-
-        mt = (memoryTrack*)ptr;
-        --mt;   /* same as minus sizeof(memoryTrack), removes header */
-
-#ifdef DO_MEM_STATS
-        ourMemStats.currentBytes -= mt->u.hint.thisSize;
-#endif
-
-        free(mt);
-    }
-
-
-    static INLINE void* TrackRealloc(void* ptr, size_t sz)
-    {
-        void* ret = TrackMalloc(sz);
-
-        if (ptr) {
-            /* if realloc is bigger, don't overread old ptr */
-            memoryTrack* mt = (memoryTrack*)ptr;
-            --mt;  /* same as minus sizeof(memoryTrack), removes header */
-
-            if (mt->u.hint.thisSize < sz)
-                sz = mt->u.hint.thisSize;
-        }
-
-        if (ret && ptr)
-            memcpy(ret, ptr, sz);
-
-        if (ret)
-            TrackFree(ptr);
-
-        return ret;
-    }
-
-    static INLINE void InitMemoryTracker(void)
-    {
-        if (wolfSSL_SetAllocators(TrackMalloc, TrackFree, TrackRealloc) != 0)
-            err_sys("wolfSSL SetAllocators failed for track memory");
-
-    #ifdef DO_MEM_STATS
-        ourMemStats.totalAllocs  = 0;
-        ourMemStats.totalBytes   = 0;
-        ourMemStats.peakBytes    = 0;
-        ourMemStats.currentBytes = 0;
-    #endif
-    }
-
-    static INLINE void ShowMemoryTracker(void)
-    {
-    #ifdef DO_MEM_STATS
-        printf("total   Allocs = %9lu\n",
-                                       (unsigned long)ourMemStats.totalAllocs);
-        printf("total   Bytes  = %9lu\n",
-                                       (unsigned long)ourMemStats.totalBytes);
-        printf("peak    Bytes  = %9lu\n",
-                                       (unsigned long)ourMemStats.peakBytes);
-        printf("current Bytes  = %9lu\n",
-                                       (unsigned long)ourMemStats.currentBytes);
-    #endif
-    }
-
-#endif /* USE_WOLFSSL_MEMORY */
-
 
 #ifdef HAVE_STACK_SIZE
 

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -59,4 +59,5 @@ nobase_include_HEADERS+= \
 noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/pic32/pic32mz-crypt.h \
                          wolfssl/wolfcrypt/port/ti/ti-hash.h \
-                         wolfssl/wolfcrypt/port/ti/ti-ccm.h
+                         wolfssl/wolfcrypt/port/ti/ti-ccm.h \
+                         wolfssl/wolfcrypt/port/nrf51.h

--- a/wolfssl/wolfcrypt/port/nrf51.h
+++ b/wolfssl/wolfcrypt/port/nrf51.h
@@ -1,0 +1,43 @@
+/* nrf51.h
+ *
+ * Copyright (C) 2006-2015 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL. (formerly known as CyaSSL)
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef WOLFSSL_NRF51_PORT_H
+#define WOLFSSL_NRF51_PORT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wolfssl/wolfcrypt/types.h>
+
+/* Public Functions */
+int nrf51_random_generate(byte* output, word32 sz);
+
+int nrf51_aes_set_key(const byte* key);
+int nrf51_aes_encrypt(const byte* in, const byte* key, word32 rounds, byte* out);
+
+double current_time(int reset);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WOLFSSL_NRF51_PORT_H */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1029,6 +1029,61 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #endif
 #endif /* HAVE_ECC */
 
+/* Curve255519 Configs */
+#ifdef HAVE_CURVE25519
+    /* By default enable shared secret, key export and import */
+    #ifndef NO_CURVE25519_SHARED_SECRET
+        #undef HAVE_CURVE25519_SHARED_SECRET
+        #define HAVE_CURVE25519_SHARED_SECRET
+    #endif
+    #ifndef NO_CURVE25519_KEY_EXPORT
+        #undef HAVE_CURVE25519_KEY_EXPORT
+        #define HAVE_CURVE25519_KEY_EXPORT
+    #endif
+    #ifndef NO_CURVE25519_KEY_IMPORT
+        #undef HAVE_CURVE25519_KEY_IMPORT
+        #define HAVE_CURVE25519_KEY_IMPORT
+    #endif
+#endif /* HAVE_CURVE25519 */
+
+/* Ed255519 Configs */
+#ifdef HAVE_ED25519
+    /* By default enable sign, verify, key export and import */
+    #ifndef NO_ED25519_SIGN
+        #undef HAVE_ED25519_SIGN
+        #define HAVE_ED25519_SIGN
+    #endif
+    #ifndef NO_ED25519_VERIFY
+        #undef HAVE_ED25519_VERIFY
+        #define HAVE_ED25519_VERIFY
+    #endif
+    #ifndef NO_ED25519_KEY_EXPORT
+        #undef HAVE_ED25519_KEY_EXPORT
+        #define HAVE_ED25519_KEY_EXPORT
+    #endif
+    #ifndef NO_ED25519_KEY_IMPORT
+        #undef HAVE_ED25519_KEY_IMPORT
+        #define HAVE_ED25519_KEY_IMPORT
+    #endif
+#endif /* HAVE_ED25519 */
+
+/* AES Config */
+#ifndef NO_AES
+    /* By default enable all AES key sizes, decryption and CBC */
+    #ifndef AES_MAX_KEY_SIZE
+        #undef  AES_MAX_KEY_SIZE
+        #define AES_MAX_KEY_SIZE    256
+    #endif
+    #ifndef NO_AES_DECRYPT
+        #undef HAVE_AES_DECRYPT
+        #define HAVE_AES_DECRYPT
+    #endif
+    #ifndef NO_AES_CBC
+        #undef  HAVE_AES_CBC
+        #define HAVE_AES_CBC
+    #endif
+#endif
+
 /* if desktop type system and fastmath increase default max bits */
 #ifdef WOLFSSL_X86_64_BUILD
     #ifdef USE_FAST_MATH

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1075,12 +1075,16 @@ static char *fgets(char *buff, int sz, FILE *fp)
         #define AES_MAX_KEY_SIZE    256
     #endif
     #ifndef NO_AES_DECRYPT
-        #undef HAVE_AES_DECRYPT
+        #undef  HAVE_AES_DECRYPT
         #define HAVE_AES_DECRYPT
     #endif
     #ifndef NO_AES_CBC
         #undef  HAVE_AES_CBC
         #define HAVE_AES_CBC
+    #else
+        #ifndef WOLFCRYPT_ONLY
+            #error "AES CBC is required for TLS and can only be disabled for WOLFCRYPT_ONLY builds"
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
…erateBlock 0's check even if HAVE_HASHDRBG is enabled. Added NIST test vectors for ECC P-256, P-384 and P-521. Added helpful debug message in ECC import if issue finding ecc_sets[] for curve. Moved memory tracker into separate file and added support for it to wolfcrypt test and benchmark. Added Ed255519/Curve25519 options for granular control of sign, verify, shared secret, import and export. Added AES options for max key size (AES_MAX_KEY_SIZE), no decrypt (NO_AES_DECRYPT) and no CBC (NO_AES_CBC).