### PR TITLE
Fixed bug where mp_unsigned_bin_size returning 0 could produce a UINT…

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4199,7 +4199,10 @@ static int accel_fp_mul(int idx, mp_int* k, ecc_point *R, mp_int* modulus,
    else {
       /* let's reverse kb so it's little endian */
       x = 0;
-      y = mp_unsigned_bin_size(&tk) - 1;
+      y = mp_unsigned_bin_size(&tk);
+      if (y > 0) {
+          y -= 1;
+      }
       mp_clear(&tk);
 
       while ((unsigned)x < y) {
@@ -4401,7 +4404,10 @@ static int accel_fp_mul2add(int idx1, int idx2,
 
    /* let's reverse kb so it's little endian */
    x = 0;
-   y = mp_unsigned_bin_size(&tka) - 1;
+   y = mp_unsigned_bin_size(&tka);
+   if (y > 0) {
+       y -= 1;
+   }
    mp_clear(&tka);
    while ((unsigned)x < y) {
       z = kb[0][x]; kb[0][x] = kb[0][y]; kb[0][y] = z;
@@ -4423,7 +4429,10 @@ static int accel_fp_mul2add(int idx1, int idx2,
    }
    else {
       x = 0;
-      y = mp_unsigned_bin_size(&tkb) - 1;
+      y = mp_unsigned_bin_size(&tkb);
+      if (y > 0) {
+          y -= 1;
+      }
       mp_clear(&tkb);
       while ((unsigned)x < y) {
          z = kb[1][x]; kb[1][x] = kb[1][y]; kb[1][y] = z;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6262,6 +6262,14 @@ static int ecc_test_raw_vector(const rawEccVector* vector, ecc_key* userA,
 }
 #endif /* HAVE_ECC_VECTOR_TEST */
 
+#undef  ECC_TEST_KEY_SIZE
+#define ECC_TEST_KEY_SIZE       32
+#define ECC_TEST_VERIFY_COUNT   1
+#ifdef FP_ECC
+    #undef  ECC_TEST_VERIFY_COUNT
+    #define ECC_TEST_VERIFY_COUNT   2
+    #define ECC_TEST_VERIFY_ZERO
+#endif
 int ecc_test(void)
 {
     WC_RNG  rng;
@@ -6308,7 +6316,7 @@ int ecc_test(void)
     wc_ecc_init(&userB);
     wc_ecc_init(&pubKey);
 
-    ret = wc_ecc_make_key(&rng, 32, &userA);
+    ret = wc_ecc_make_key(&rng, ECC_TEST_KEY_SIZE, &userA);
     if (ret != 0)
         return -1014;
 
@@ -6316,7 +6324,7 @@ int ecc_test(void)
     if (ret != 0)
         return -1024;
 
-    ret = wc_ecc_make_key(&rng, 32, &userB);
+    ret = wc_ecc_make_key(&rng, ECC_TEST_KEY_SIZE, &userB);
     if (ret != 0)
         return -1002;
 
@@ -6392,8 +6400,13 @@ int ecc_test(void)
 
 #ifdef HAVE_ECC_SIGN
     /* test DSA sign hash */
-    for (i = 0; i < (int)sizeof(digest); i++)
+    for (i = 0; i < (int)sizeof(digest); i++) {
+    #ifdef ECC_TEST_VERIFY_ZERO
+        digest[i] = 0;
+    #else
         digest[i] = (byte)i;
+    #endif
+    }
 
     x = sizeof(sig);
     ret = wc_ecc_sign_hash(digest, sizeof(digest), sig, &x, &rng, &userA);
@@ -6402,12 +6415,14 @@ int ecc_test(void)
         return -1014;
 
 #ifdef HAVE_ECC_VERIFY
-    verify = 0;
-    ret = wc_ecc_verify_hash(sig, x, digest, sizeof(digest), &verify, &userA);
-    if (ret != 0)
-        return -1015;
-    if (verify != 1)
-        return -1016;
+    for (i=0; i<ECC_TEST_VERIFY_COUNT; i++) {
+        verify = 0;
+        ret = wc_ecc_verify_hash(sig, x, digest, sizeof(digest), &verify, &userA);
+        if (ret != 0)
+            return -1015;
+        if (verify != 1)
+            return -1016;
+    }
 #endif /* HAVE_ECC_VERIFY */
 #endif /* HAVE_ECC_SIGN */
 


### PR DESCRIPTION
…_MAX (based on -1) resulting in invalid index to an array. Added test case for this if FP_ECC is defined.