### PR TITLE
sanity check on ssl pased to wolfSSL_set_fd

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -173,7 +173,9 @@ int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
             if (benchResume)
                 wolfSSL_set_session(ssl, benchSession);
     #endif
-            wolfSSL_set_fd(ssl, sockfd);
+            if (wolfSSL_set_fd(ssl, sockfd) != SSL_SUCCESS) {
+                err_sys("error in setting fd");
+            }
             if (wolfSSL_connect(ssl) != SSL_SUCCESS)
                 err_sys("SSL_connect failed");
 
@@ -213,7 +215,9 @@ int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
     if (ssl == NULL)
         err_sys("unable to get SSL object");
     tcp_connect(&sockfd, host, port, doDTLS, ssl);
-    wolfSSL_set_fd(ssl, sockfd);
+    if (wolfSSL_set_fd(ssl, sockfd) != SSL_SUCCESS) {
+        err_sys("error in setting fd");
+    }
     if (wolfSSL_connect(ssl) == SSL_SUCCESS) {
         /* Perform throughput test */
         char *tx_buffer, *rx_buffer;
@@ -1140,7 +1144,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif
 
     tcp_connect(&sockfd, host, port, doDTLS, ssl);
-    wolfSSL_set_fd(ssl, sockfd);
+    if (wolfSSL_set_fd(ssl, sockfd) != SSL_SUCCESS) {
+        err_sys("error in setting fd");
+    }
 #ifdef HAVE_CRL
     if (disableCRL == 0) {
         if (wolfSSL_EnableCRL(ssl, WOLFSSL_CRL_CHECKALL) != SSL_SUCCESS)
@@ -1292,7 +1298,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif
         }
         tcp_connect(&sockfd, host, port, doDTLS, sslResume);
-        wolfSSL_set_fd(sslResume, sockfd);
+        if (wolfSSL_set_fd(sslResume, sockfd) != SSL_SUCCESS) {
+            err_sys("error in setting fd");
+        }
 #ifdef HAVE_ALPN
         if (alpnList != NULL) {
             printf("ALPN accepted protocols list : %s\n", alpnList);

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -797,7 +797,9 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
                        doDTLS, serverReadyFile ? 1 : 0, doListen);
         doListen = 0; /* Don't listen next time */
 
-        SSL_set_fd(ssl, clientfd);
+        if (SSL_set_fd(ssl, clientfd) != SSL_SUCCESS) {
+            err_sys("error in setting fd");
+        }
 
 #ifdef HAVE_ALPN
         if (alpnList != NULL) {

--- a/input
+++ b/input
@@ -48,7 +48,9 @@ int main(int argc, char** argv)
 
     ssl = SSL_new(ctx);
 
-    SSL_set_fd(ssl, sockfd);
+    if (SSL_set_fd(ssl, sockfd) != SSL_SUCCESS)
+        err_sys("can't set ssl fd");
+
     if (SSL_connect(ssl) != SSL_SUCCESS) err_sys("SSL_connect failed");
 
     while (fgets(send, sizeof(send), fin)) {

--- a/mqx/wolfssl_client/Sources/main.c
+++ b/mqx/wolfssl_client/Sources/main.c
@@ -254,7 +254,9 @@ void client_test(void)
     if ( (ssl = wolfSSL_new(ctx)) == NULL)
         err_sys("wolfSSL_new failed");
 
-    wolfSSL_set_fd(ssl, sockfd);
+    ret = wolfSSL_set_fd(ssl, sockfd);
+    if (ret != SSL_SUCCESS)
+        err_sys("wolfSSL_set_fd failed");
 
     ret = wolfSSL_connect(ssl);
     if (ret != SSL_SUCCESS)

--- a/src/internal.c
+++ b/src/internal.c
@@ -2345,7 +2345,9 @@ void FreeHandshakeResources(WOLFSSL* ssl)
 
 void FreeSSL(WOLFSSL* ssl)
 {
-    FreeSSL_Ctx(ssl->ctx);  /* will decrement and free underyling CTX if 0 */
+    if (ssl->ctx) {
+        FreeSSL_Ctx(ssl->ctx); /* will decrement and free underyling CTX if 0 */
+    }
     SSL_ResourceFree(ssl);
     XFREE(ssl, ssl->heap, DYNAMIC_TYPE_SSL);
 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -255,6 +255,11 @@ int wolfSSL_use_old_poly(WOLFSSL* ssl, int value)
 int wolfSSL_set_fd(WOLFSSL* ssl, int fd)
 {
     WOLFSSL_ENTER("SSL_set_fd");
+
+    if (ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
     ssl->rfd = fd;      /* not used directly to allow IO callbacks */
     ssl->wfd = fd;
 

--- a/swig/wolfssl_adds.c
+++ b/swig/wolfssl_adds.c
@@ -169,7 +169,8 @@ int wolfSSL_swig_connect(WOLFSSL* ssl, const char* server, int port)
     int ret = tcp_connect(&sockfd, server, port);
     if (ret != 0) return ret;
 
-    wolfSSL_set_fd(ssl, sockfd);
+    ret = wolfSSL_set_fd(ssl, sockfd);
+    if (ret != SSL_SUCCESS) return ret;
 
     return wolfSSL_connect(ssl);
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -540,7 +540,10 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
     tcp_accept(&sockfd, &clientfd, (func_args*)args, port, 0, 0, 0, 1);
     CloseSocket(sockfd);
 
-    wolfSSL_set_fd(ssl, clientfd);
+    if (wolfSSL_set_fd(ssl, clientfd) != SSL_SUCCESS) {
+        /*err_sys("SSL_set_fd failed");*/
+        goto done;
+    }
 
 #ifdef NO_PSK
     #if !defined(NO_FILESYSTEM) && !defined(NO_DH)
@@ -649,7 +652,11 @@ static void test_client_nofail(void* args)
 
     ssl = wolfSSL_new(ctx);
     tcp_connect(&sockfd, wolfSSLIP, ((func_args*)args)->signal->port, 0, ssl);
-    wolfSSL_set_fd(ssl, sockfd);
+    if (wolfSSL_set_fd(ssl, sockfd) != SSL_SUCCESS) {
+        /*err_sys("SSL_set_fd failed");*/
+        goto done2;
+    }
+
     if (wolfSSL_connect(ssl) != SSL_SUCCESS)
     {
         int  err = wolfSSL_get_error(ssl, 0);
@@ -739,7 +746,7 @@ static THREAD_RETURN WOLFSSL_THREAD run_wolfssl_server(void* args)
     tcp_accept(&sfd, &cfd, (func_args*)args, port, 0, 0, 0, 1);
     CloseSocket(sfd);
 
-    wolfSSL_set_fd(ssl, cfd);
+    AssertIntEQ(SSL_SUCCESS, wolfSSL_set_fd(ssl, cfd));
 
 #ifdef NO_PSK
     #if !defined(NO_FILESYSTEM) && !defined(NO_DH)
@@ -831,7 +838,7 @@ static void run_wolfssl_client(void* args)
 
     ssl = wolfSSL_new(ctx);
     tcp_connect(&sfd, wolfSSLIP, ((func_args*)args)->signal->port, 0, ssl);
-    wolfSSL_set_fd(ssl, sfd);
+    AssertIntEQ(SSL_SUCCESS, wolfSSL_set_fd(ssl, sfd));
 
     if (callbacks->ssl_ready)
         callbacks->ssl_ready(ssl);


### PR DESCRIPTION
In bombarding one of our example threaded servers came across this segfault. The example should have checked the return value for if NULL before calling the function wolfSSL_set_fd(), but our library should also not crash with a bad argument.