### PR TITLE
fix fips-check.sh so it can run from the pre-push hook script

### DIFF
--- a/fips-check.sh
+++ b/fips-check.sh
@@ -88,6 +88,8 @@ linux)
   exit 1
 esac
 
+unset GIT_WORK_TREE
+
 git clone . $TEST_DIR
 [ $? -ne 0 ] && echo "\n\nCouldn't duplicate current working directory.\n\n" && exit 1
 


### PR DESCRIPTION
When git runs a script it sets the environment variable GIT_WORK_TREE. If the script runs git, it sees that GIT_WORK_TREE is set and errors out. I modified the script fips-check.sh to unset GIT_WORK_TREE since the script isn't using it. The script can now clone the current repo into the test directory.