### PR TITLE
Extra cleanup in sniffer.c with ForceZero

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -1082,6 +1082,7 @@ static int LoadKeyFile(byte** keyBuf, word32* keyBufSz,
                 ret = 0;
         }
 
+        ForceZero(loadBuf, (word32)fileSz);
         free(loadBuf);
 
         *keyBuf = saveBuf;
@@ -3093,6 +3094,7 @@ doPart:
                          * wants to null terminate plaintext */
                         tmpData = (byte*)realloc(*data, decoded + ret + 1);
                         if (tmpData == NULL) {
+                            ForceZero(*data, decoded);
                             free(*data);
                             *data = NULL;
                             SetError(MEMORY_STR, error, session,

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -3246,9 +3246,22 @@ int ssl_DecodePacket(const byte* packet, int length, byte** data, char* error)
 /* returns 0 on success, -1 on error */
 int ssl_FreeDecodeBuffer(byte** data, char* error)
 {
+    return ssl_FreeZeroDecodeBuffer(data, 0, error);
+}
+
+
+/* Deallocator for the decoded data buffer, zeros out buffer. */
+/* returns 0 on success, -1 on error */
+int ssl_FreeZeroDecodeBuffer(byte** data, int sz, char* error)
+{
     (void)error;
 
+    if (sz < 0) {
+        return -1;
+    }
+
     if (data != NULL) {
+        ForceZero(*data, (word32)sz);
         free(*data);
         *data = NULL;
     }

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -313,8 +313,8 @@ int main(int argc, char** argv)
             }
             if (ret > 0) {
                 data[ret] = 0;
-				printf("SSL App Data(%d:%d):%s\n", packetNumber, ret, data);
-                ssl_FreeDecodeBuffer(&data, err);
+                printf("SSL App Data(%d:%d):%s\n", packetNumber, ret, data);
+                ssl_FreeZeroDecodeBuffer(&data, ret, err);
             }
         }
         else if (saveFile)

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -63,6 +63,10 @@ WOLFSSL_API
 SSL_SNIFFER_API int ssl_FreeDecodeBuffer(unsigned char** data, char* error);
 
 WOLFSSL_API
+SSL_SNIFFER_API int ssl_FreeZeroDecodeBuffer(unsigned char** data, int sz,
+                                             char* error);
+
+WOLFSSL_API
 SSL_SNIFFER_API int ssl_Trace(const char* traceFile, char* error);
 
 WOLFSSL_API


### PR DESCRIPTION
This commit adds two ForceZero calls to sniffer.c in the following locations:

1.  LoadKeyFile() - In the case where the input key is in PEM format, we convert to DER and use that.  We free the PEM key buffer, but it should also be zero'd in memory since that buffer is no longer used by wolfSSL.

2.  ProcessMessage() - Inside "case: application_data", if our call to realloc() fails, we free() the decoded data buffer (data) and set the pointer to NULL.  Since this data buffer holds decrypted data, we're in an error case, and we've already freed this memory, it should be zero'd.

This pull request is associated with Zendesk ticket 1756.