### PR TITLE
Fixes when using the STM32 with STM32F2_HASH defined.

### DIFF
--- a/wolfcrypt/src/md5.c
+++ b/wolfcrypt/src/md5.c
@@ -64,6 +64,7 @@
      * document (See note in README).
      */
     #include "stm32f2xx.h"
+    #include "stm32f2xx_hash.h"
 
     void wc_InitMd5(Md5* md5)
     {

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -136,7 +136,7 @@ int wc_ShaUpdate(Sha* sha, const byte* data, word32 len)
             /* append partial to existing stored block */
             XMEMCPY((byte*)sha->buffer + sha->buffLen, data, len);
             sha->buffLen += len;
-            return;
+            return 0;
         }
     }
 


### PR DESCRIPTION
Stumbled on this missing return code in wc_ShaUpdate. Fixed missing include and missing return code. Tested build against STM32 headers.