### PR TITLE
Fixes for scan-build warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1040,11 +1040,17 @@ AC_ARG_ENABLE([asn],
 
 if test "$ENABLED_ASN" = "no"
 then
-    AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_CERTS"
-    if test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" == "no"
+    # turn on ASN if OpenSSL extra
+    if test "$ENABLED_OPENSSLEXTRA" = "yes"
     then
-        # DH and ECC need bigint
-        AM_CFLAGS="$AM_CFLAGS -DNO_BIG_INT"
+        ENABLED_ASN=yes
+    else
+        AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_CERTS"
+        if test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" == "no"
+        then
+            # DH and ECC need bigint
+            AM_CFLAGS="$AM_CFLAGS -DNO_BIG_INT"
+        fi
     fi
 else
     # turn off ASN if leanpsk on

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -916,13 +916,15 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             err_sys("client can't set cipher list 1");
     }
 
-#ifdef WOLFSSL_LEANPSK
-    usePsk = 1;
-#endif
+    if (usePsk != 1) {
+    #ifdef WOLFSSL_LEANPSK
+        usePsk = 1;
+    #endif
 
-#if defined(NO_RSA) && !defined(HAVE_ECC)
-    usePsk = 1;
-#endif
+    #if defined(NO_RSA) && !defined(HAVE_ECC)
+        usePsk = 1;
+    #endif
+    }
 
     if (fewerPackets)
         wolfSSL_CTX_set_group_messages(ctx);

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -613,13 +613,15 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
         if (SSL_CTX_set_cipher_list(ctx, cipherList) != SSL_SUCCESS)
             err_sys("server can't set cipher list 1");
 
-#ifdef CYASSL_LEANPSK
-    usePsk = 1;
-#endif
+    if (usePsk != 1) {
+    #ifdef CYASSL_LEANPSK
+        usePsk = 1;
+    #endif
 
-#if defined(NO_RSA) && !defined(HAVE_ECC)
-    usePsk = 1;
-#endif
+    #if defined(NO_RSA) && !defined(HAVE_ECC)
+        usePsk = 1;
+    #endif
+    }
 
     if (fewerPackets)
         CyaSSL_CTX_set_group_messages(ctx);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3543,7 +3543,7 @@ static int ConfirmSignature(const byte* buf, word32 bufSz,
             WOLFSSL_MSG("Verify Signature has unsupported type");
     }
 
-    if (typeH == 0) {
+    if (typeH == 0 || digestSz == 0) {
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(digest, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif


### PR DESCRIPTION
If opensslextra is enabled, make sure ASN is enabled. Fixes scan-build warnings in asn.c, client.c and server.c with PSK enabled and RSA+ECC both disabled.