### PR TITLE
add wc_EccPublicKeyToDer function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ ntru-cert.pem
 ntru-key.raw
 key.der
 key.pem
+ecc-public-key.der
 ecc-key.der
 ecc-key.pem
 certreq.der

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5001,6 +5001,7 @@ int rsa_test(void)
             free(tmp);
             return -5415;
         }
+
         fclose(pemFile);
         free(pem);
         free(derCert);
@@ -6484,6 +6485,25 @@ static int ecc_test_key_gen(WC_RNG* rng, int keySize)
     fclose(pemFile);
     if (ret != pemSz) {
         return -1029;
+    }
+
+    /* test export of public key */
+    derSz = wc_EccPublicKeyToDer(&userA, der, FOURK_BUF, 1);
+    if (derSz <= 0) {
+       return -5516;
+    }
+#ifdef FREESCALE_MQX
+        keyFile = fopen("a:\\certs\\ecc-public-key.der", "wb");
+#else
+        keyFile = fopen("./ecc-public-key.der", "wb");
+#endif
+    if (!keyFile) {
+       return -5417;
+    }
+    ret = (int)fwrite(der, 1, derSz, keyFile);
+    fclose(keyFile);
+    if (ret != derSz) {
+       return -5418;
     }
 
     wc_ecc_free(&userA);

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -195,7 +195,8 @@ enum Misc_ASN {
     EIGHTK_BUF          = 8192,    /* Tmp buffer size           */
     MAX_PUBLIC_KEY_SZ   = MAX_NTRU_ENC_SZ + MAX_ALGO_SZ + MAX_SEQ_SZ * 2,
                                    /* use bigger NTRU size */
-    HEADER_ENCRYPTED_KEY_SIZE = 88 /* Extra header size for encrypted key */
+    HEADER_ENCRYPTED_KEY_SIZE = 88,/* Extra header size for encrypted key */
+    TRAILING_ZERO       = 1        /* Used for size of zero pad */
 };
 
 

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -259,6 +259,10 @@ WOLFSSL_API int wc_SetCertificatePolicies(Cert *cert, const char **input);
     /* public key helper */
     WOLFSSL_API int wc_EccPublicKeyDecode(const byte*, word32*,
                                               ecc_key*, word32);
+    #if (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN))
+        WOLFSSL_API int wc_EccPublicKeyToDer(ecc_key*, byte* output,
+                                               word32 inLen, int with_AlgCurve);
+    #endif
 #endif
 
 /* DER encode signature */


### PR DESCRIPTION
This adds the function to output a ECC public key with algorithm and curve information in DER format.

Line 5997-6001 in asn.c needs double checked for size so that there is adequate buffer space.

With keeping underlying functions requiring either keygen or certgen enabled it kept changes to code lower. Key created by running ./wolcrypt/test/testwolfcrypt can be read with openssl command "openssl ec -in ecc-public-key.der -inform DER -pubin -text"