### PR TITLE
autoconf checks on some builds that break, macro for no server, and u…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2568,6 +2568,23 @@ AS_IF([test "x$ENABLED_OCSP" = "xyes" && \
        test "x$ENABLED_ECC" = "xno"],
       [AC_MSG_ERROR([please enable rsa or ecc if enabling ocsp.])])
 
+# checks for pkcs7 needed enables
+AS_IF([test "x$ENABLED_PKCS7" = "xyes" && \
+       test "x$ENABLED_RSA" = "xno"],
+      [AC_MSG_ERROR([please enable rsa if enabling pkcs7.])])
+
+AS_IF([test "x$ENABLED_PKCS7" = "xyes" && \
+       test "x$ENABLED_SHA" = "xno"],
+      [AC_MSG_ERROR([please enable sha if enabling pkcs7.])])
+
+AS_IF([test "x$ENABLED_LEANTLS" = "xyes" && \
+       test "x$ENABLED_ECC" = "xno"],
+      [AC_MSG_ERROR([please enable ecc if enabling leantls.])])
+
+AS_IF([test "x$ENABLED_SNIFFER" = "xyes" && \
+       test "x$ENABLED_RSA" = "xno"],
+      [AC_MSG_ERROR([please enable rsa if enabling sniffer.])])
+
 ################################################################################
 # Update CFLAGS based on options                                               #
 ################################################################################

--- a/src/internal.c
+++ b/src/internal.c
@@ -9080,7 +9080,7 @@ int SendCertificateRequest(WOLFSSL* ssl)
         return SendBuffered(ssl);
 }
 
-
+#ifndef NO_WOLFSSL_SERVER
 #if defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
  || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
 static int BuildCertificateStatus(WOLFSSL* ssl, byte type, buffer* status,
@@ -9178,6 +9178,7 @@ static int BuildCertificateStatus(WOLFSSL* ssl, byte type, buffer* status,
     return ret;
 }
 #endif
+#endif /* NO_WOLFSSL_SERVER */
 
 
 int SendCertificateStatus(WOLFSSL* ssl)
@@ -9199,6 +9200,7 @@ int SendCertificateStatus(WOLFSSL* ssl)
 
     switch (status_type) {
 
+    #ifndef NO_WOLFSSL_SERVER
     #if defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
      || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
         /* case WOLFSSL_CSR_OCSP: */
@@ -9490,6 +9492,7 @@ int SendCertificateStatus(WOLFSSL* ssl)
         break;
 
     #endif /* HAVE_CERTIFICATE_STATUS_REQUEST_V2 */
+    #endif /* NO_WOLFSSL_SERVER */
 
         default:
         break;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1879,11 +1879,13 @@ static const char *EVP_AES_256_CBC = "AES-256-CBC";
 #endif
 static const int  EVP_AES_SIZE = 11;
 
+#ifndef NO_DES3
 static const char *EVP_DES_CBC = "DES-CBC";
 static const int  EVP_DES_SIZE = 7;
 
 static const char *EVP_DES_EDE3_CBC = "DES-EDE3-CBC";
 static const int  EVP_DES_EDE3_SIZE = 12;
+#endif
 
 #ifdef HAVE_IDEA
 static const char *EVP_IDEA_CBC = "IDEA-CBC";
@@ -8437,6 +8439,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         if (XSTRNCMP(md, "MD5", 3) != 0) return 0;
 
         /* only support CBC DES and AES for now */
+        #ifndef NO_DES3
         if (XSTRNCMP(type, EVP_DES_CBC, EVP_DES_SIZE) == 0) {
             keyLen = DES_KEY_SIZE;
             ivLen  = DES_IV_SIZE;
@@ -8445,7 +8448,9 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             keyLen = DES3_KEY_SIZE;
             ivLen  = DES_IV_SIZE;
         }
-        else if (XSTRNCMP(type, EVP_AES_128_CBC, EVP_AES_SIZE) == 0) {
+        else
+        #endif /* NO_DES3 */
+        if (XSTRNCMP(type, EVP_AES_128_CBC, EVP_AES_SIZE) == 0) {
             keyLen = AES_128_KEY_SIZE;
             ivLen  = AES_IV_SIZE;
         }
@@ -8797,6 +8802,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     }
 
 
+#ifndef NO_DES3
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_cbc(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_des_cbc");
@@ -8809,7 +8815,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         WOLFSSL_ENTER("wolfSSL_EVP_des_ede3_cbc");
         return EVP_DES_EDE3_CBC;
     }
-
+#endif /* NO_DES3 */
 
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_rc4(void)
     {
@@ -10962,12 +10968,15 @@ char* wolfSSL_CIPHER_description(WOLFSSL_CIPHER* cipher, char* in, int len)
 }
 
 
+#ifndef NO_SESSION_CACHE
+
 WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl)
 {
     /* sessions are stored statically, no need for reference count */
     return wolfSSL_get_session(ssl);
 }
 
+#endif /* NO_SESSION_CACHE */
 
 void wolfSSL_X509_free(WOLFSSL_X509* x509)
 {
@@ -17367,6 +17376,7 @@ int wolfSSL_set_tlsext_host_name(WOLFSSL* ssl, const char* host_name)
 }
 
 
+#ifndef NO_WOLFSSL_SERVER
 const char * wolfSSL_get_servername(WOLFSSL* ssl, byte type)
 {
     void * serverName = NULL;
@@ -17375,6 +17385,7 @@ const char * wolfSSL_get_servername(WOLFSSL* ssl, byte type)
     TLSX_SNI_GetRequest(ssl->extensions, type, &serverName);
     return (const char *)serverName;
 }
+#endif /* NO_WOLFSSL_SERVER */
 #endif /* HAVE_SNI */
 
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -4103,7 +4103,8 @@ int rsa_test(void)
 
     #ifndef WC_NO_RSA_OAEP
     /* OAEP padding testing */
-    #if !defined(HAVE_FAST_RSA) && !defined(HAVE_FIPS)
+    #if !defined(HAVE_FAST_RSA) && !defined(HAVE_USER_RSA) && \
+        !defined(HAVE_FIPS)
     #ifndef NO_SHA
     XMEMSET(plain, 0, sizeof(plain));
     ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -96,6 +96,9 @@ enum Ctc_Misc {
 #ifndef HAVE_ECC
     typedef struct ecc_key ecc_key;
 #endif
+#ifdef NO_RSA
+    typedef struct RsaKey RsaKey;
+#endif
 
 typedef struct CertName {
     char country[CTC_NAME_SIZE];

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1162,6 +1162,12 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #endif
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
+/* leantls checks */
+#ifdef WOLFSSL_LEANTLS
+    #ifndef HAVE_ECC
+        #error leantls build needs ECC
+    #endif
+#endif /* WOLFSSL_LEANTLS*/
 
 /* Place any other flags or defines here */
 


### PR DESCRIPTION
Adds some sanity checks on builds. Completes macros for NO_WOLFSSL_SERVER to match existing function declarations. Removes RSA-OAEP test in the case of using user-crypto build with RSA.