### PR TITLE
scan-build warnings related to enable-psk, disable-asn,rsa,ecc

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1031,19 +1031,12 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         }
 #endif /* WOLFSSL_TRUST_PEER_CERT */
     }
-#else /* !NO_FILESYSTEM && !NO_CERTS */
-    (void) useClientCert;
-    (void) verifyCert;
-    (void) ourCert;
-    (void) ourKey;
 #endif /* !NO_FILESYSTEM && !NO_CERTS */
 #if !defined(NO_CERTS)
     if (!usePsk && !useAnon && doPeerCheck == 0)
         wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0);
     if (!usePsk && !useAnon && overrideDateErrors == 1)
         wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, myDateCb);
-#else
-    (void) overrideDateErrors;
 #endif
 
 #ifdef HAVE_CAVIUM
@@ -1450,6 +1443,15 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     if (trackMemory)
         ShowMemoryTracker();
 #endif /* USE_WOLFSSL_MEMORY */
+
+    /* There are use cases  when these assignments are not read. To avoid
+     * potential confusion those warnings have been handled here.
+     */
+    (void) overrideDateErrors;
+    (void) useClientCert;
+    (void) verifyCert;
+    (void) ourCert;
+    (void) ourKey;
 
 #if !defined(WOLFSSL_TIRTOS)
     return 0;

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -917,11 +917,15 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     }
 
 #ifdef WOLFSSL_LEANPSK
-    usePsk = 1;
+    if (!usePsk) {
+        usePsk = 1;
+    }
 #endif
 
 #if defined(NO_RSA) && !defined(HAVE_ECC)
-    usePsk = 1;
+    if (!usePsk) {
+        usePsk = 1;
+    }
 #endif
 
     if (fewerPackets)
@@ -948,7 +952,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 err_sys("client can't set cipher list 2");
         }
 #endif
-        useClientCert = 0;
+        if (useClientCert) {
+            useClientCert = 0;
+        }
     }
 
     if (useAnon) {
@@ -959,7 +965,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 err_sys("client can't set cipher list 4");
         }
 #endif
-        useClientCert = 0;
+        if (useClientCert) {
+            useClientCert = 0;
+        }
     }
 
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
@@ -1023,12 +1031,19 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         }
 #endif /* WOLFSSL_TRUST_PEER_CERT */
     }
+#else /* !NO_FILESYSTEM && !NO_CERTS */
+    (void) useClientCert;
+    (void) verifyCert;
+    (void) ourCert;
+    (void) ourKey;
 #endif /* !NO_FILESYSTEM && !NO_CERTS */
 #if !defined(NO_CERTS)
     if (!usePsk && !useAnon && doPeerCheck == 0)
         wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0);
     if (!usePsk && !useAnon && overrideDateErrors == 1)
         wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, myDateCb);
+#else
+    (void) overrideDateErrors;
 #endif
 
 #ifdef HAVE_CAVIUM

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -639,8 +639,6 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
             err_sys("can't load server cert file, check file and run from"
                     " wolfSSL home dir");
     }
-#else
-    (void) ourCert;
 #endif
 
 #ifndef NO_DH
@@ -662,9 +660,6 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
             err_sys("can't load server private key file, check file and run "
                 "from wolfSSL home dir");
     }
-#else
-    (void) ourKey;
-    (void) useNtruKey;
 #endif
 
     if (usePsk || usePskPlus) {
@@ -718,9 +713,6 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
         }
         #endif /* WOLFSSL_TRUST_PEER_CERT */
    }
-#else
-    (void) verifyCert;
-    (void) doCliCertCheck;
 #endif
 
 #if defined(CYASSL_SNIFFER)
@@ -844,10 +836,7 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
             #if !defined(NO_FILESYSTEM) && !defined(NO_DH) && !defined(NO_ASN)
                 CyaSSL_SetTmpDH_file(ssl, ourDhParam, SSL_FILETYPE_PEM);
             #elif !defined(NO_DH)
-                (void) ourDhParam;
                 SetDH(ssl);  /* repick suites with DHE, higher priority than PSK */
-            #else
-                (void) ourDhParam;
             #endif
         }
 
@@ -986,6 +975,15 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     TicketCleanup();
 #endif
 
+    /* There are use cases  when these assignments are not read. To avoid
+     * potential confusion those warnings have been handled here.
+     */
+    (void) ourKey;
+    (void) verifyCert;
+    (void) doCliCertCheck;
+    (void) useNtruKey;
+    (void) ourDhParam;
+    (void) ourCert;
 #ifndef CYASSL_TIRTOS
     return 0;
 #endif

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -614,11 +614,15 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
             err_sys("server can't set cipher list 1");
 
 #ifdef CYASSL_LEANPSK
-    usePsk = 1;
+    if (!usePsk) {
+        usePsk = 1;
+    }
 #endif
 
 #if defined(NO_RSA) && !defined(HAVE_ECC)
-    usePsk = 1;
+    if (!usePsk) {
+        usePsk = 1;
+    }
 #endif
 
     if (fewerPackets)
@@ -635,6 +639,8 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
             err_sys("can't load server cert file, check file and run from"
                     " wolfSSL home dir");
     }
+#else
+    (void) ourCert;
 #endif
 
 #ifndef NO_DH
@@ -656,6 +662,9 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
             err_sys("can't load server private key file, check file and run "
                 "from wolfSSL home dir");
     }
+#else
+    (void) ourKey;
+    (void) useNtruKey;
 #endif
 
     if (usePsk || usePskPlus) {
@@ -709,6 +718,9 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
         }
         #endif /* WOLFSSL_TRUST_PEER_CERT */
    }
+#else
+    (void) verifyCert;
+    (void) doCliCertCheck;
 #endif
 
 #if defined(CYASSL_SNIFFER)
@@ -832,7 +844,10 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
             #if !defined(NO_FILESYSTEM) && !defined(NO_DH) && !defined(NO_ASN)
                 CyaSSL_SetTmpDH_file(ssl, ourDhParam, SSL_FILETYPE_PEM);
             #elif !defined(NO_DH)
+                (void) ourDhParam;
                 SetDH(ssl);  /* repick suites with DHE, higher priority than PSK */
+            #else
+                (void) ourDhParam;
             #endif
         }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -8549,6 +8549,10 @@ static int BuildMessage(WOLFSSL* ssl, byte* output, int outSz,
     int ret        = 0;
     int atomicUser = 0;
 
+    if (ssl == NULL || output == NULL || input == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
 #ifdef WOLFSSL_DTLS
     if (ssl->options.dtls) {
         sz       += DTLS_RECORD_EXTRA;


### PR DESCRIPTION
The pull request #376 does not address all of the issues here.

Changes to client.c and server.c account for dead assignments.
Change in src/internal.c prevents a potential segmentation fault if a NULL argument is passed in. 