### PR TITLE
enable aesgcm and alpn support in TI-RTOS/WolfSSL configuration

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -546,6 +546,9 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #define NO_ERROR_STRINGS
     #define USER_TIME
     #define HAVE_ECC
+    #define HAVE_ALPN
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_AESGCM
 
     #ifdef __IAR_SYSTEMS_ICC__
         #pragma diag_suppress=Pa089


### PR DESCRIPTION
These macros enable the AES GCM cipher suites and application layer
protocol negotiation in the TLS layer. Adding these macros would
allow connecting to websites with higher security requirements and
also support newer web technologies like HTTP/2 but the drawback is
that they add ~2K increase in memory footprint. Applications not
requiring these features can comment the macros and rebuild the
library to get smaller footprint.

Signed-off-by: Vikram Adiga <vikram.adiga@ti.com>