### PR TITLE
fix NID name in openssl compatibility

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -122,7 +122,7 @@ const ecc_set_type ecc_sets[] = {
 #ifdef ECC112
 {
         14,
-        NID_secp111r1,
+        NID_secp112r1,
         "SECP112R1",
         "DB7C2ABF62E35E668076BEAD208B",
         "DB7C2ABF62E35E668076BEAD2088",

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -13,7 +13,7 @@ extern "C" {
 /* Map OpenSSL NID value */
 enum {
     POINT_CONVERSION_UNCOMPRESSED = 4,
-    NID_secp111r1 = 0,
+    NID_secp112r1 = 0,
     NID_secp128r1 = 1,
     NID_secp160r1 = 2,
     NID_cert192 = 3,


### PR DESCRIPTION
While testing with the smallest ECC key for putting future restrictions on ECC key sizes, noticed that the variable here is listed as NID_secp111r1 instead of NID_secp112r1. A quick grep of openssl showed no *secp111r1* in the library but they do have NID_secp112r1.