### PR TITLE
use short for RSA min key size and check casts

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -277,7 +277,7 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     int    echoData = 0;
     int    throughput = 0;
     int    minDhKeyBits  = DEFAULT_MIN_DHKEY_BITS;
-    int    minRsaKeyBits = DEFAULT_MIN_RSAKEY_BITS;
+    short  minRsaKeyBits = DEFAULT_MIN_RSAKEY_BITS;
     short  minEccKeyBits = DEFAULT_MIN_ECCKEY_BITS;
     int    doListen = 1;
     int    crlFlags = 0;
@@ -647,7 +647,7 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     }
 #endif
 #ifndef NO_RSA
-    if (wolfSSL_CTX_SetMinRsaKey_Sz(ctx, (word16)minRsaKeyBits) != SSL_SUCCESS){
+    if (wolfSSL_CTX_SetMinRsaKey_Sz(ctx, minRsaKeyBits) != SSL_SUCCESS){
         err_sys("Error setting minimum RSA key size");
     }
 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -510,9 +510,9 @@ int wolfSSL_SetMinEccKey_Sz(WOLFSSL* ssl, short keySz)
 #endif /* !NO_RSA */
 
 #ifndef NO_RSA
-int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX* ctx, word16 keySz)
+int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX* ctx, short keySz)
 {
-    if (ctx == NULL || keySz % 8 != 0) {
+    if (ctx == NULL || keySz < 0 || keySz % 8 != 0) {
         WOLFSSL_MSG("Key size must be divisable by 8 or ctx was null");
         return BAD_FUNC_ARG;
     }
@@ -523,9 +523,9 @@ int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX* ctx, word16 keySz)
 }
 
 
-int wolfSSL_SetMinRsaKey_Sz(WOLFSSL* ssl, word16 keySz)
+int wolfSSL_SetMinRsaKey_Sz(WOLFSSL* ssl, short keySz)
 {
-    if (ssl == NULL || keySz % 8 != 0) {
+    if (ssl == NULL || keySz < 0 || keySz % 8 != 0) {
         WOLFSSL_MSG("Key size must be divisable by 8 or ssl was null");
         return BAD_FUNC_ARG;
     }
@@ -2625,9 +2625,10 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
         switch (cert->keyOID) {
             #ifndef NO_RSA
             case RSAk:
-                if (cert->pubKeySize < cm->minRsaKeySz) {
+                if (cm->minRsaKeySz < 0 ||
+                                   cert->pubKeySize < (word16)cm->minRsaKeySz) {
                     ret = RSA_KEY_SIZE_E;
-                    WOLFSSL_MSG("    CA RSA key is too small");
+                    WOLFSSL_MSG("    CA RSA key size error");
                 }
                 break;
             #endif /* !NO_RSA */
@@ -3655,13 +3656,15 @@ static int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
         #ifndef NO_RSA
             case RSAk:
                 if (ssl && !ssl->options.verifyNone) {
-                    if (cert->pubKeySize < ssl->options.minRsaKeySz) {
+                    if (ssl->options.minRsaKeySz < 0 ||
+                          cert->pubKeySize < (word16)ssl->options.minRsaKeySz) {
                         ret = RSA_KEY_SIZE_E;
                         WOLFSSL_MSG("Certificate RSA key size too small");
                     }
                 }
                 else if (ctx && !ctx->verifyNone) {
-                    if (cert->pubKeySize < ctx->minRsaKeySz) {
+                    if (ctx->minRsaKeySz < 0 ||
+                                  cert->pubKeySize < (word16)ctx->minRsaKeySz) {
                         ret = RSA_KEY_SIZE_E;
                         WOLFSSL_MSG("Certificate RSA key size too small");
                     }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1516,7 +1516,7 @@ struct WOLFSSL_CERT_MANAGER {
     byte            ocspStaplingEnabled; /* is OCSP Stapling on ? */
 
 #ifndef NO_RSA
-    word16          minRsaKeySz;         /* minimum allowed RSA key size */
+    short           minRsaKeySz;         /* minimum allowed RSA key size */
 #endif
 #ifdef HAVE_ECC
     short           minEccKeySz;         /* minimum allowed ECC key size */
@@ -1918,7 +1918,7 @@ struct WOLFSSL_CTX {
     word16      minDhKeySz;       /* minimum DH key size */
 #endif
 #ifndef NO_RSA
-    word16      minRsaKeySz;      /* minimum RSA key size */
+    short       minRsaKeySz;      /* minimum RSA key size */
 #endif
 #ifdef HAVE_ECC
     short       minEccKeySz;      /* minimum ECC key size */
@@ -2388,7 +2388,7 @@ typedef struct Options {
     word16          dhKeySz;            /* actual DH key size */
 #endif
 #ifndef NO_RSA
-    word16          minRsaKeySz;      /* minimum RSA key size */
+    short           minRsaKeySz;      /* minimum RSA key size */
 #endif
 #ifdef HAVE_ECC
     short           minEccKeySz;      /* minimum ECC key size */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -939,8 +939,8 @@ WOLFSSL_API int wolfSSL_GetDhKey_Sz(WOLFSSL*);
 #endif /* NO_DH */
 
 #ifndef NO_RSA
-WOLFSSL_API int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX*, unsigned short);
-WOLFSSL_API int wolfSSL_SetMinRsaKey_Sz(WOLFSSL*, unsigned short);
+WOLFSSL_API int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX*, short);
+WOLFSSL_API int wolfSSL_SetMinRsaKey_Sz(WOLFSSL*, short);
 #endif /* NO_RSA */
 
 #ifdef HAVE_ECC


### PR DESCRIPTION
Use short for RSA min key size and check casts.
This is to update the comparison of RSA key size and min RSA key size so that they are both using a signed type.