### PR TITLE
Omit NULL parameter in AlgorithmIdentifier encoding for ECDSA OIDs

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3372,6 +3372,17 @@ static int SetCurve(ecc_key* key, byte* output)
 #endif /* HAVE_ECC && WOLFSSL_CERT_GEN */
 
 
+static INLINE int IsSigAlgoECDSA(int algoOID)
+{
+    /* ECDSA sigAlgo must not have ASN1 NULL parameters */
+    if (algoOID == CTC_SHAwECDSA || algoOID == CTC_SHA256wECDSA ||
+        algoOID == CTC_SHA384wECDSA || algoOID == CTC_SHA512wECDSA) {
+        return 1;
+    }
+
+    return 0;
+}
+
 WOLFSSL_LOCAL word32 SetAlgoID(int algoOID, byte* output, int type, int curveSz)
 {
     word32 tagSz, idSz, seqSz, algoSz = 0;
@@ -3379,7 +3390,8 @@ WOLFSSL_LOCAL word32 SetAlgoID(int algoOID, byte* output, int type, int curveSz)
     byte   ID_Length[MAX_LENGTH_SZ];
     byte   seqArray[MAX_SEQ_SZ + 1];  /* add object_id to end */
 
-    tagSz = (type == oidHashType || type == oidSigType ||
+    tagSz = (type == oidHashType ||
+             (type == oidSigType && !IsSigAlgoECDSA(algoOID)) ||
              (type == oidKeyType && algoOID == RSAk)) ? 2 : 0;
 
     algoName = OidFromId(algoOID, type, &algoSz);


### PR DESCRIPTION
From RFC 5480 (Elliptic Curve Cryptography Subject Public Key Information), **AlgorithmIdentifier** is defined as:

```
      AlgorithmIdentifier  ::=  SEQUENCE  {
        algorithm   OBJECT IDENTIFIER,
        parameters  ANY DEFINED BY algorithm OPTIONAL
      }
```

From [RFC 3279](https://tools.ietf.org/html/rfc3279), Section 2.2 (Signature Algorithms) defines the contents of the AlgorithmIdentifier parameters for various signature algorithm types.

From Section 2.2.3, **ECDSA-SHA1** identifiers **MUST** omit the parameters:

```
When the ecdsa-with-SHA1 algorithm identifier appears as the
   algorithm field in an AlgorithmIdentifier, the encoding MUST omit the
   parameters field.  That is, the AlgorithmIdentifier SHALL be a
   SEQUENCE of one component: the OBJECT IDENTIFIER ecdsa-with-SHA1.
```

[RFC 5758](https://tools.ietf.org/html/rfc5758) expands this to include identifiers for SHA2 hash functions as well:

```
When the ecdsa-with-SHA224, ecdsa-with-SHA256, ecdsa-with-SHA384, or
   ecdsa-with-SHA512 algorithm identifier appears in the algorithm field
   as an AlgorithmIdentifier, the encoding MUST omit the parameters
   field.  That is, the AlgorithmIdentifier SHALL be a SEQUENCE of one
   component, the OID ecdsa-with-SHA224, ecdsa-with-SHA256, ecdsa-with-
   SHA384, or ecdsa-with-SHA512.
```

In *SetAlgoID()* of asn.c, wolfCrypt adds the ASN.1 NULL parameter value in the following condition evaluates to TRUE, or in the case of all oidSigType's:

```
tagSz = (type == oidHashType || type == oidSigType ||
         (type == oidKeyType && algoOID == RSAk)) ? 2 : 0;
```

For correctness as per above RFC's, we should only add the NULL parameter (thus make tagSz == 2) in the case with "type == oidSigType" only when this is NOT an ECDSA-based sig algo type.

**References**
Zendesk Ticket 1933