### PR TITLE
add STARTTLS support to example client

### DIFF
--- a/examples/client/client.h
+++ b/examples/client/client.h
@@ -35,6 +35,12 @@ int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
 int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
 	int doDTLS, int throughput);
 
+/* Initiates the STARTTLS command sequence over TCP */
+int StartTLS_Init(SOCKET_T* sockfd);
+
+/* Closes down the SMTP connection */
+int SMTP_Shutdown(WOLFSSL* ssl, int wc_shutdown);
+
 
 #endif /* WOLFSSL_CLIENT_H */
 


### PR DESCRIPTION
This pull request adds an option to the example client to use STARTTLS commands over TCP/IP before beginning the SSL/TLS handshake.

```
-M <prot>   Use STARTTLS, using <prot> protocol (smtp)
```

The example client currently only supports STARTTLS for SMTP, but the command line option takes an argument for easier expansion of other protocols in the future.

Example:

```
$ ./examples/client/client -h smtp.office365.com -p 587 -d -M smtp
220 BLUPR14CA0002.outlook.office365.com Microsoft ESMTP MAIL Service ready at Fri, 22 Apr 2016 19:52:39 +0000

250-BLUPR14CA0002.outlook.office365.com Hello [72.175.105.82]
250-SIZE 157286400
250-PIPELINING
250-DSN
250-ENHANCEDSTATUSCODES
250-STARTTLS
250-8BITMIME
250-BINARYMIME
250 CHUNKING

220 2.0.0 SMTP server ready

SSL version is TLSv1.2
SSL cipher suite is TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384

wolfSSL client shutting down SMTP connection
221 2.0.0 Service closing transmission channel
```