### PR TITLE
update to MYSQL compatibility

### DIFF
--- a/IDE/MYSQL/CMakeLists_wolfCrypt.txt
+++ b/IDE/MYSQL/CMakeLists_wolfCrypt.txt
@@ -27,7 +27,7 @@ SET(WOLFCRYPT_SOURCES		src/aes.c src/arc4.c src/asn.c src/blake2b.c
         src/camellia.c src/chacha.c src/coding.c src/compress.c src/des3.c
         src/dh.c src/dsa.c src/ecc.c src/error.c src/hc128.c src/hmac.c
         src/integer.c src/logging.c src/md2.c src/md4.c src/md5.c src/memory.c
-        src/misc.c src/pkcs7.c src/poly1305.c src/pwdbased.c src/rabbit.c
+        src/pkcs7.c src/poly1305.c src/pwdbased.c src/rabbit.c
         src/random.c src/ripemd.c src/rsa.c src/sha.c src/sha256.c src/sha512.c
         src/tfm.c src/wc_port.c src/wc_encrypt.c src/hash.c
         ../wolfssl/wolfcrypt/aes.h ../wolfssl/wolfcrypt/arc4.h ../wolfssl/wolfcrypt/asn.h ../wolfssl/wolfcrypt/blake2.h
@@ -39,6 +39,7 @@ SET(WOLFCRYPT_SOURCES		src/aes.c src/arc4.c src/asn.c src/blake2b.c
         ../wolfssl/wolfcrypt/tfm.h ../wolfssl/wolfcrypt/wc_port.h ../wolfssl/wolfcrypt/wc_encrypt.h
         ../wolfssl/wolfcrypt/hash.h
    )
+# misc.c is not compiled in since using INLINE
 
 ADD_CONVENIENCE_LIBRARY(wolfcrypt ${WOLFCRYPT_SOURCES})
 RESTRICT_SYMBOL_EXPORTS(wolfcrypt)

--- a/src/internal.c
+++ b/src/internal.c
@@ -1300,6 +1300,13 @@ void InitSuites(Suites* suites, ProtocolVersion pv, word16 haveRSA,
     }
 #endif
 
+#ifdef BUILD_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+    if (tls && haveDH && haveRSA) {
+        suites->suites[idx++] = 0;
+        suites->suites[idx++] = TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA;
+    }
+#endif
+
 #ifdef BUILD_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
     if (tls1_2 && haveDH && haveRSA) {
         suites->suites[idx++] = 0;
@@ -4724,6 +4731,15 @@ static int BuildFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
         case TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA :
         case TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256 :
         case TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256 :
+            if (requirement == REQUIRES_RSA)
+                return 1;
+            if (requirement == REQUIRES_RSA_SIG)
+                return 1;
+            if (requirement == REQUIRES_DHE)
+                return 1;
+            break;
+
+        case TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA:
             if (requirement == REQUIRES_RSA)
                 return 1;
             if (requirement == REQUIRES_RSA_SIG)
@@ -10667,6 +10683,10 @@ static const char* const cipher_names[] =
 #ifdef BUILD_TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256
     "DHE-PSK-CHACHA20-POLY1305",
 #endif
+
+#ifdef BUILD_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+    "EDH-RSA-DES-CBC3-SHA",
+#endif
 };
 
 
@@ -11104,6 +11124,10 @@ static int cipher_name_idx[] =
 
 #ifdef BUILD_TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256
     TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256,
+#endif
+
+#ifdef BUILD_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+    TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA,
 #endif
 };
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -643,7 +643,7 @@ void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
 #ifndef NO_CERTS
     FreeDer(&ctx->privateKey);
     FreeDer(&ctx->certificate);
-    #ifdef OPENSSL_EXTRA
+    #ifdef KEEP_OUR_CERT
         FreeX509(ctx->ourCert);
         if (ctx->ourCert) {
             XFREE(ctx->ourCert, ctx->heap, DYNAMIC_TYPE_X509);

--- a/src/internal.c
+++ b/src/internal.c
@@ -2592,6 +2592,7 @@ void SSL_ResourceFree(WOLFSSL* ssl)
     }
 #endif
 #ifndef NO_CERTS
+    ssl->keepCert = 0; /* make sure certificate is free'd */
     wolfSSL_UnloadCertsKeys(ssl);
 #endif
 #ifndef NO_RSA

--- a/src/internal.c
+++ b/src/internal.c
@@ -644,6 +644,7 @@ void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
     FreeDer(&ctx->privateKey);
     FreeDer(&ctx->certificate);
     #ifdef OPENSSL_EXTRA
+        FreeX509(ctx->ourCert);
         if (ctx->ourCert) {
             XFREE(ctx->ourCert, ctx->heap, DYNAMIC_TYPE_X509);
         }
@@ -11170,10 +11171,17 @@ const char* wolfSSL_get_cipher_name_internal(WOLFSSL* ssl)
             if (cipher_name_idx[i] == ssl->options.cipherSuite) {
                 const char* nameFound = cipher_names[i];
 
+                /* extra sanity check on returned cipher name */
+                if (nameFound == NULL) {
+                    continue;
+                }
+
                 /* if first is null then not any */
-                if (first == NULL && !XSTRSTR(nameFound, "CHACHA") &&
+                if (first == NULL) {
+                    if (!XSTRSTR(nameFound, "CHACHA") &&
                      !XSTRSTR(nameFound, "EC") && !XSTRSTR(nameFound, "CCM")) {
-                    return cipher_names[i];
+                        return cipher_names[i];
+                    }
                 }
                 else if (XSTRSTR(nameFound, first)) {
                     return cipher_names[i];

--- a/src/internal.c
+++ b/src/internal.c
@@ -1706,6 +1706,7 @@ void InitX509Name(WOLFSSL_X509_NAME* name, int dynamicFlag)
 #ifdef OPENSSL_EXTRA
         XMEMSET(&name->fullName, 0, sizeof(DecodedName));
         XMEMSET(&name->cnEntry,  0, sizeof(WOLFSSL_X509_NAME_ENTRY));
+        name->cnEntry.value = &(name->cnEntry.data); /* point to internal data*/
         name->x509 = NULL;
 #endif /* OPENSSL_EXTRA */
     }

--- a/src/keys.c
+++ b/src/keys.c
@@ -1551,6 +1551,23 @@ int SetCipherSpecs(WOLFSSL* ssl)
         break;
 #endif
 
+#ifdef BUILD_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+    case TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA :
+        ssl->specs.bulk_cipher_algorithm = wolfssl_triple_des;
+        ssl->specs.cipher_type           = block;
+        ssl->specs.mac_algorithm         = sha_mac;
+        ssl->specs.kea                   = diffie_hellman_kea;
+        ssl->specs.sig_algo              = rsa_sa_algo;
+        ssl->specs.hash_size             = SHA_DIGEST_SIZE;
+        ssl->specs.pad_size              = PAD_SHA;
+        ssl->specs.static_ecdh           = 0;
+        ssl->specs.key_size              = DES3_KEY_SIZE;
+        ssl->specs.block_size            = DES_BLOCK_SIZE;
+        ssl->specs.iv_size               = DES_IV_SIZE;
+
+        break;
+#endif
+
 #ifdef BUILD_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
     case TLS_DHE_RSA_WITH_AES_256_CBC_SHA256 :
         ssl->specs.bulk_cipher_algorithm = wolfssl_aes;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10312,7 +10312,7 @@ static void ExternalFreeX509(WOLFSSL_X509* x509)
                                                     WOLFSSL_X509_NAME_ENTRY* in)
     {
         WOLFSSL_ENTER("wolfSSL_X509_NAME_ENTRY_get_data");
-        return &in->value;
+        return in->value;
     }
 
 
@@ -17226,9 +17226,9 @@ void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl)
         /* common name index case */
         if (loc == name->fullName.cnIdx) {
             /* get CN shortcut from x509 since it has null terminator */
-            name->cnEntry.value.data   = name->x509->subjectCN;
-            name->cnEntry.value.length = name->fullName.cnLen;
-            name->cnEntry.value.type   = ASN_COMMON_NAME;
+            name->cnEntry.data.data   = name->x509->subjectCN;
+            name->cnEntry.data.length = name->fullName.cnLen;
+            name->cnEntry.data.type   = ASN_COMMON_NAME;
             name->cnEntry.set  = 1;
             return &(name->cnEntry);
         }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3470,6 +3470,7 @@ static int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
             if (ssl->buffers.weOwnCert) {
                 FreeDer(&ssl->buffers.certificate);
                 #ifdef OPENSSL_EXTRA
+                    FreeX509(ssl->ourCert);
                     if (ssl->ourCert) {
                         XFREE(ssl->ourCert, ssl->heap, DYNAMIC_TYPE_X509);
                     }
@@ -3486,6 +3487,7 @@ static int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
         else if (ctx) {
             FreeDer(&ctx->certificate); /* Make sure previous is free'd */
             #ifdef OPENSSL_EXTRA
+                FreeX509(ctx->ourCert);
                 if (ctx->ourCert) {
                     XFREE(ctx->ourCert, ctx->heap, DYNAMIC_TYPE_X509);
                 }
@@ -8042,6 +8044,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             WOLFSSL_MSG("Unloading cert");
             FreeDer(&ssl->buffers.certificate);
             #ifdef OPENSSL_EXTRA
+                FreeX509(ssl->ourCert);
                 if (ssl->ourCert) {
                     XFREE(ssl->ourCert, ssl->heap, DYNAMIC_TYPE_X509);
                 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11272,6 +11272,12 @@ const char* wolfSSL_get_cipher(WOLFSSL* ssl)
     return wolfSSL_CIPHER_get_name(wolfSSL_get_current_cipher(ssl));
 }
 
+/* gets cipher name in the format DHE-RSA-... rather then TLS_DHE... */
+const char* wolfSSL_get_cipher_name(WOLFSSL* ssl)
+{
+    /* get access to cipher_name_idx in internal.c */
+    return wolfSSL_get_cipher_name_internal(ssl);
+}
 #ifdef OPENSSL_EXTRA
 
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -1703,6 +1703,7 @@ static void test_wolfSSL_X509_NAME_get_entry(void)
         subCN = (char*)ASN1_STRING_data(asn);
         AssertNotNull(subCN);
 
+        wolfSSL_FreeX509(x509);
     #endif
 
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -39,6 +39,10 @@
 #include <wolfssl/test.h>
 #include <tests/unit.h>
 
+#ifdef OPENSSL_EXTRA
+    #include <wolfssl/openssl/ssl.h>
+#endif
+
 /* enable testing buffer load functions */
 #ifndef USE_CERT_BUFFERS_2048
     #define USE_CERT_BUFFERS_2048
@@ -1663,6 +1667,53 @@ static void test_wolfSSL_UseALPN(void)
 }
 
 /*----------------------------------------------------------------------------*
+ | X509 Tests
+ *----------------------------------------------------------------------------*/
+static void test_wolfSSL_X509_NAME_get_entry(void)
+{
+#ifndef NO_CERTS
+#if defined(OPENSSL_EXTRA) && (defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)) \
+    && (defined(HAVE_LIGHTY) || defined(WOLFSSL_MYSQL_COMPATIBLE))
+    printf(testingFmt, "wolfSSL_X509_NAME_get_entry()");
+
+    {
+        /* use openssl like name to test mapping */
+        X509_NAME_ENTRY* ne = NULL;
+        X509_NAME* name = NULL;
+        char* subCN = NULL;
+        X509* x509;
+        ASN1_STRING* asn;
+        int idx;
+
+    #ifndef NO_FILESYSTEM
+        x509 = wolfSSL_X509_load_certificate_file(cliCert, SSL_FILETYPE_PEM);
+        AssertNotNull(x509);
+
+        name = X509_get_subject_name(x509);
+
+        idx = X509_NAME_get_index_by_NID(name, NID_commonName, -1);
+        AssertIntGE(idx, 0);
+
+        ne = X509_NAME_get_entry(name, idx);
+        AssertNotNull(ne);
+
+        asn = X509_NAME_ENTRY_get_data(ne);
+        AssertNotNull(asn);
+
+        subCN = (char*)ASN1_STRING_data(asn);
+        AssertNotNull(subCN);
+
+    #endif
+
+    }
+
+    printf(resultFmt, passed);
+#endif /* OPENSSL_EXTRA */
+#endif /* !NO_CERTS */
+}
+
+
+/*----------------------------------------------------------------------------*
  | Main
  *----------------------------------------------------------------------------*/
 
@@ -1691,6 +1742,9 @@ void ApiTest(void)
     test_wolfSSL_UseTruncatedHMAC();
     test_wolfSSL_UseSupportedCurve();
     test_wolfSSL_UseALPN();
+
+    /* X509 tests */
+    test_wolfSSL_X509_NAME_get_entry();
 
     test_wolfSSL_Cleanup();
     printf(" End API Tests\n");

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -1126,6 +1126,22 @@
 -v 2
 -l DHE-RSA-AES256-SHA256
 
+# server TLSv1.1 DHE 3DES
+-v 2
+-l EDH-RSA-DES-CBC3-SHA
+
+# client TLSv1.1 DHE 3DES
+-v 2
+-l EDH-RSA-DES-CBC3-SHA
+
+# server TLSv1.2 DHE 3DES
+-v 3
+-l EDH-RSA-DES-CBC3-SHA
+
+# client TLSv1.2 DHE 3DES
+-v 3
+-l EDH-RSA-DES-CBC3-SHA
+
 # server TLSv1.2 DHE AES128
 -v 3
 -l DHE-RSA-AES128-SHA

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3013,8 +3013,8 @@ int ExtractDate(const unsigned char* date, unsigned char format,
             certTime->tm_year = 2000;
     }
     else  { /* format == GENERALIZED_TIME */
-        certTime->tm_year += btoi(date[*idx++]) * 1000;
-        certTime->tm_year += btoi(date[*idx++]) * 100;
+        certTime->tm_year += btoi(date[*idx]) * 1000; *idx = *idx + 1;
+        certTime->tm_year += btoi(date[*idx]) * 100;  *idx = *idx + 1;
     }
 
     /* adjust tm_year, tm_mon */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3064,6 +3064,7 @@ WOLFSSL_LOCAL void c32to24(word32 in, word24 out);
 
 WOLFSSL_LOCAL const char* const* GetCipherNames(void);
 WOLFSSL_LOCAL int GetCipherNamesSize(void);
+WOLFSSL_LOCAL const char* wolfSSL_get_cipher_name_internal(WOLFSSL* ssl);
 
 
 enum encrypt_side {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1903,7 +1903,7 @@ struct WOLFSSL_CTX {
     DerBuffer*  privateKey;
     WOLFSSL_CERT_MANAGER* cm;      /* our cert manager, ctx owns SSL will use */
 #endif
-#ifdef OPENSSL_EXTRA
+#ifdef KEEP_OUR_CERT
     WOLFSSL_X509*    ourCert;     /* keep alive a X509 struct of cert */
 #endif
     Suites*     suites;           /* make dynamic, user may not need/set */
@@ -2726,7 +2726,7 @@ struct WOLFSSL {
 #ifdef KEEP_PEER_CERT
     WOLFSSL_X509     peerCert;           /* X509 peer cert */
 #endif
-#ifdef OPENSSL_EXTRA
+#ifdef KEEP_OUR_CERT
     WOLFSSL_X509*    ourCert;            /* keep alive a X509 struct of cert.
                                             points to ctx if not owned (owned
                                             flag found in buffers.weOwnCert) */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -398,6 +398,9 @@ typedef byte word24[3];
         #if !defined(NO_SHA)
             #define BUILD_TLS_DHE_RSA_WITH_AES_128_CBC_SHA
             #define BUILD_TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+            #if !defined(NO_DES3)
+                #define BUILD_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+            #endif
         #endif
         #if !defined(NO_SHA256)
             #define BUILD_TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
@@ -703,6 +706,7 @@ typedef byte word24[3];
 
 /* actual cipher values, 2nd byte */
 enum {
+    TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA = 0x16,
     TLS_DHE_RSA_WITH_AES_256_CBC_SHA  = 0x39,
     TLS_DHE_RSA_WITH_AES_128_CBC_SHA  = 0x33,
     TLS_DH_anon_WITH_AES_128_CBC_SHA  = 0x34,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -45,9 +45,6 @@
 #endif
 #ifndef NO_ASN
     #include <wolfssl/wolfcrypt/asn.h>
-    #ifdef OPENSSL_EXTRA
-    #include <wolfssl/openssl/asn1.h> /* for asn1 string and bit struct */
-    #endif
 #endif
 #ifndef NO_MD5
     #include <wolfssl/wolfcrypt/md5.h>
@@ -2441,16 +2438,6 @@ typedef struct Arrays {
 #ifndef MAX_DATE_SZ
 #define MAX_DATE_SZ 32
 #endif
-
-#ifdef OPENSSL_EXTRA
-struct WOLFSSL_X509_NAME_ENTRY {
-    WOLFSSL_ASN1_OBJECT* object; /* not defined yet */
-    WOLFSSL_ASN1_STRING value;
-    int set;
-    int size;
-};
-#endif /* OPENSSL_EXTRA */
-
 
 struct WOLFSSL_X509_NAME {
     char  *name;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2731,6 +2731,7 @@ struct WOLFSSL {
                                             points to ctx if not owned (owned
                                             flag found in buffers.weOwnCert) */
 #endif
+    byte             keepCert;           /* keep certificate after handshake */
 #if defined(FORTRESS) || defined(HAVE_STUNNEL)
     void*           ex_data[MAX_EX_DATA]; /* external data, for Fortress */
 #endif

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -873,7 +873,11 @@ enum Misc {
     ZLIB_COMPRESSION = 221,     /* wolfSSL zlib compression */
     HELLO_EXT_SIG_ALGO = 13,    /* ID for the sig_algo hello extension */
     SECRET_LEN      = 48,       /* pre RSA and all master */
+#if defined(WOLFSSL_MYSQL_COMPATIBLE)
+    ENCRYPT_LEN     = 1024,     /* allow larger static buffer with mysql */
+#else
     ENCRYPT_LEN     = 512,      /* allow 4096 bit static buffer */
+#endif
     SIZEOF_SENDER   =  4,       /* clnt or srvr           */
     FINISHED_SZ     = 36,       /* MD5_DIGEST_SIZE + SHA_DIGEST_SIZE */
     MAX_RECORD_SIZE = 16384,    /* 2^14, max size by standard */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -45,6 +45,9 @@
 #endif
 #ifndef NO_ASN
     #include <wolfssl/wolfcrypt/asn.h>
+    #ifdef OPENSSL_EXTRA
+    #include <wolfssl/openssl/asn1.h> /* for asn1 string and bit struct */
+    #endif
 #endif
 #ifndef NO_MD5
     #include <wolfssl/wolfcrypt/md5.h>
@@ -1899,6 +1902,9 @@ struct WOLFSSL_CTX {
     DerBuffer*  privateKey;
     WOLFSSL_CERT_MANAGER* cm;      /* our cert manager, ctx owns SSL will use */
 #endif
+#ifdef OPENSSL_EXTRA
+    WOLFSSL_X509*    ourCert;     /* keep alive a X509 struct of cert */
+#endif
     Suites*     suites;           /* make dynamic, user may not need/set */
     void*       heap;             /* for user memory overrides */
     byte        verifyPeer;
@@ -2432,6 +2438,16 @@ typedef struct Arrays {
 #define MAX_DATE_SZ 32
 #endif
 
+#ifdef OPENSSL_EXTRA
+struct WOLFSSL_X509_NAME_ENTRY {
+    WOLFSSL_ASN1_OBJECT* object; /* not defined yet */
+    WOLFSSL_ASN1_STRING value;
+    int set;
+    int size;
+};
+#endif /* OPENSSL_EXTRA */
+
+
 struct WOLFSSL_X509_NAME {
     char  *name;
     char  staticName[ASN_NAME_MAX];
@@ -2439,6 +2455,8 @@ struct WOLFSSL_X509_NAME {
     int   sz;
 #if defined(OPENSSL_EXTRA) && !defined(NO_ASN)
     DecodedName fullName;
+    WOLFSSL_X509_NAME_ENTRY cnEntry;
+    WOLFSSL_X509*           x509;   /* x509 that struct belongs to */
 #endif /* OPENSSL_EXTRA */
 };
 
@@ -2716,6 +2734,11 @@ struct WOLFSSL {
 #endif
 #ifdef KEEP_PEER_CERT
     WOLFSSL_X509     peerCert;           /* X509 peer cert */
+#endif
+#ifdef OPENSSL_EXTRA
+    WOLFSSL_X509*    ourCert;            /* keep alive a X509 struct of cert.
+                                            points to ctx if not owned (owned
+                                            flag found in buffers.weOwnCert) */
 #endif
 #if defined(FORTRESS) || defined(HAVE_STUNNEL)
     void*           ex_data[MAX_EX_DATA]; /* external data, for Fortress */

--- a/wolfssl/openssl/des.h
+++ b/wolfssl/openssl/des.h
@@ -61,6 +61,12 @@ WOLFSSL_API void wolfSSL_DES_cbc_encrypt(const unsigned char* input,
                      unsigned char* output, long length,
                      WOLFSSL_DES_key_schedule* schedule, WOLFSSL_DES_cblock* ivec,
                      int enc);
+WOLFSSL_API void wolfSSL_DES_ede3_cbc_encrypt(const unsigned char* input,
+                                      unsigned char* output, long sz,
+                                      WOLFSSL_DES_key_schedule* ks1,
+                                      WOLFSSL_DES_key_schedule* ks2,
+                                      WOLFSSL_DES_key_schedule* ks3,
+                                      WOLFSSL_DES_cblock* ivec, int enc);
 WOLFSSL_API void wolfSSL_DES_ncbc_encrypt(const unsigned char* input,
                       unsigned char* output, long length,
                       WOLFSSL_DES_key_schedule* schedule,
@@ -76,27 +82,12 @@ typedef WOLFSSL_const_DES_cblock const_DES_cblock;
 typedef WOLFSSL_DES_key_schedule DES_key_schedule;
 
 #define DES_set_key_unchecked wolfSSL_DES_set_key_unchecked
-#define DES_key_sched wolfSSL_DES_key_sched
-#define DES_cbc_encrypt wolfSSL_DES_cbc_encrypt
-#define DES_ncbc_encrypt wolfSSL_DES_ncbc_encrypt
-#define DES_set_odd_parity wolfSSL_DES_set_odd_parity
-#define DES_ecb_encrypt wolfSSL_DES_ecb_encrypt
-#define DES_ede3_cbc_encrypt(input, output, sz, ks1, ks2, ks3, ivec, enc) \
-do {                                                         \
-    Des3 des;                                                \
-    byte key[24];/* EDE uses 24 size key */                  \
-    memcpy(key, (ks1), DES_BLOCK_SIZE);                      \
-    memcpy(&key[DES_BLOCK_SIZE], (ks2), DES_BLOCK_SIZE);     \
-    memcpy(&key[DES_BLOCK_SIZE * 2], (ks3), DES_BLOCK_SIZE); \
-    if (enc) {                                               \
-        wc_Des3_SetKey(&des, key, (const byte*)(ivec), DES_ENCRYPTION);    \
-        wc_Des3_CbcEncrypt(&des, (output), (input), (sz));    \
-    }                                                         \
-    else {                                                    \
-        wc_Des3_SetKey(&des, key, (const byte*)(ivec), DES_ENCRYPTION);    \
-        wc_Des3_CbcDecrypt(&des, (output), (input), (sz));    \
-    }                                                         \
-} while(0)
+#define DES_key_sched         wolfSSL_DES_key_sched
+#define DES_cbc_encrypt       wolfSSL_DES_cbc_encrypt
+#define DES_ncbc_encrypt      wolfSSL_DES_ncbc_encrypt
+#define DES_set_odd_parity    wolfSSL_DES_set_odd_parity
+#define DES_ecb_encrypt       wolfSSL_DES_ecb_encrypt
+#define DES_ede3_cbc_encrypt  wolfSSL_DES_ede3_cbc_encrypt
 
 #ifdef __cplusplus
     } /* extern "C" */

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -185,12 +185,14 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define SSL_SESSION_free wolfSSL_SESSION_free
 #define SSL_is_init_finished wolfSSL_is_init_finished
 
-#define SSL_get_version wolfSSL_get_version
+#define SSL_get_version        wolfSSL_get_version
 #define SSL_get_current_cipher wolfSSL_get_current_cipher
-#define SSL_get_cipher wolfSSL_get_cipher
+
+/* use wolfSSL_get_cipher_name for its return format */
+#define SSL_get_cipher         wolfSSL_get_cipher_name
 #define SSL_CIPHER_description wolfSSL_CIPHER_description
-#define SSL_CIPHER_get_name wolfSSL_CIPHER_get_name
-#define SSL_get1_session wolfSSL_get1_session
+#define SSL_CIPHER_get_name    wolfSSL_CIPHER_get_name
+#define SSL_get1_session       wolfSSL_get1_session
 
 #define SSL_get_keyblock_size wolfSSL_get_keyblock_size
 #define SSL_get_keys          wolfSSL_get_keys

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -104,7 +104,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define SSL_get_verify_depth          wolfSSL_get_verify_depth
 #define SSL_CTX_get_verify_mode       wolfSSL_CTX_get_verify_mode
 #define SSL_CTX_get_verify_depth      wolfSSL_CTX_get_verify_depth
-#define SSL_get_certificate(ctx)      0 /* used to pass to get_privatekey */
+#define SSL_get_certificate           wolfSSL_get_certificate
 
 #define SSLv3_server_method wolfSSLv3_server_method
 #define SSLv3_client_method wolfSSLv3_client_method
@@ -409,7 +409,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 
 /* Lighthttp compatibility */
 
-#ifdef HAVE_LIGHTY                       
+#if defined(HAVE_LIGHTY) || defined(WOLFSSL_MYSQL_COMPATIBLE)
 typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 
 #define SSL_CB_HANDSHAKE_START          0x10
@@ -428,14 +428,20 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 #define X509_NAME_entry_count wolfSSL_X509_NAME_entry_count
 #define X509_NAME_ENTRY_get_object wolfSSL_X509_NAME_ENTRY_get_object
 #define X509_NAME_get_entry wolfSSL_X509_NAME_get_entry
+#define ASN1_STRING_data wolfSSL_ASN1_STRING_data
+#define ASN1_STRING_length wolfSSL_ASN1_STRING_length
+#define X509_NAME_get_index_by_NID wolfSSL_X509_NAME_get_index_by_NID
+#define X509_NAME_ENTRY_get_data wolfSSL_X509_NAME_ENTRY_get_data
 #define sk_X509_NAME_pop_free  wolfSSL_sk_X509_NAME_pop_free
 #define SHA1 wolfSSL_SHA1
 #define X509_check_private_key wolfSSL_X509_check_private_key
 #define SSL_dup_CA_list wolfSSL_dup_CA_list
 
+#define NID_commonName 0x03 /* matchs ASN_COMMON_NAME in asn.h */
 #endif
 
-#if defined(HAVE_STUNNEL) || defined(HAVE_LIGHTY)
+#if defined(HAVE_STUNNEL) || defined(HAVE_LIGHTY) \
+    || defined(WOLFSSL_MYSQL_COMPATIBLE)
 
 #define OBJ_nid2ln wolf_OBJ_nid2ln
 #define OBJ_txt2nid wolf_OBJ_txt2nid
@@ -445,7 +451,7 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 #define BIO_new_file wolfSSL_BIO_new_file
 
 
-#endif /* HAVE_STUNNEL || HAVE_LIGHTY */
+#endif /* HAVE_STUNNEL || HAVE_LIGHTY || WOLFSSL_MYSQL_COMPATIBLE */
 
 #ifdef HAVE_STUNNEL
 #include <wolfssl/openssl/asn1.h>

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1650,6 +1650,16 @@ WOLFSSL_API char* wolfSSL_ASN1_TIME_to_string(WOLFSSL_ASN1_TIME* time,
 #endif /* WOLFSSL_MYSQL_COMPATIBLE */
 
 #ifdef OPENSSL_EXTRA /*lighttp compatibility */
+
+#include <wolfssl/openssl/asn1.h>
+struct WOLFSSL_X509_NAME_ENTRY {
+    WOLFSSL_ASN1_OBJECT* object; /* not defined yet */
+    WOLFSSL_ASN1_STRING  data;
+    WOLFSSL_ASN1_STRING* value;  /* points to data, for lighttpd port */
+    int set;
+    int size;
+};
+
 #if defined(HAVE_LIGHTY) || defined(WOLFSSL_MYSQL_COMPATIBLE)
 WOLFSSL_API void wolfSSL_X509_NAME_free(WOLFSSL_X509_NAME *name);
 WOLFSSL_API char wolfSSL_CTX_use_certificate(WOLFSSL_CTX *ctx, WOLFSSL_X509 *x);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1649,14 +1649,6 @@ WOLFSSL_API char* wolfSSL_ASN1_TIME_to_string(WOLFSSL_ASN1_TIME* time,
 #endif /* WOLFSSL_MYSQL_COMPATIBLE */
 
 #ifdef OPENSSL_EXTRA /*lighttp compatibility */
-
-typedef struct WOLFSSL_X509_NAME_ENTRY {
-    WOLFSSL_ASN1_OBJECT* object;
-    WOLFSSL_ASN1_STRING* value;
-    int set;
-    int size;
-} WOLFSSL_X509_NAME_ENTRY;
-
 #if defined(HAVE_LIGHTY) || defined(WOLFSSL_MYSQL_COMPATIBLE)
 WOLFSSL_API void wolfSSL_X509_NAME_free(WOLFSSL_X509_NAME *name);
 WOLFSSL_API char wolfSSL_CTX_use_certificate(WOLFSSL_CTX *ctx, WOLFSSL_X509 *x);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1012,7 +1012,7 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL*, void* key, unsigned int len,
                                                const unsigned char*, long);
     WOLFSSL_API int wolfSSL_UnloadCertsKeys(WOLFSSL*);
 
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) && defined(KEEP_OUR_CERT)
         WOLFSSL_API WOLFSSL_X509* wolfSSL_get_certificate(WOLFSSL* ssl);
     #endif
 #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1643,6 +1643,10 @@ WOLFSSL_API int wolfSSL_accept_ex(WOLFSSL*, HandShakeCallBack, TimeoutCallBack,
     WOLFSSL_API void wolfSSL_cert_service(void);
 #endif
 
+#if defined(WOLFSSL_MYSQL_COMPATIBLE)
+WOLFSSL_API char* wolfSSL_ASN1_TIME_to_string(WOLFSSL_ASN1_TIME* time,
+                                                            char* buf, int len);
+#endif /* WOLFSSL_MYSQL_COMPATIBLE */
 
 #ifdef OPENSSL_EXTRA /*lighttp compatibility */
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -267,6 +267,7 @@ WOLFSSL_API WOLFSSL* wolfSSL_new(WOLFSSL_CTX*);
 WOLFSSL_API int  wolfSSL_set_fd (WOLFSSL*, int);
 WOLFSSL_API char* wolfSSL_get_cipher_list(int priority);
 WOLFSSL_API int  wolfSSL_get_ciphers(char*, int);
+WOLFSSL_API const char* wolfSSL_get_cipher_name(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_get_fd(const WOLFSSL*);
 WOLFSSL_API void wolfSSL_set_using_nonblock(WOLFSSL*, int);
 WOLFSSL_API int  wolfSSL_get_using_nonblock(WOLFSSL*);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -70,6 +70,7 @@ typedef struct WOLFSSL_CTX      WOLFSSL_CTX;
 
 typedef struct WOLFSSL_X509       WOLFSSL_X509;
 typedef struct WOLFSSL_X509_NAME  WOLFSSL_X509_NAME;
+typedef struct WOLFSSL_X509_NAME_ENTRY  WOLFSSL_X509_NAME_ENTRY;
 typedef struct WOLFSSL_X509_CHAIN WOLFSSL_X509_CHAIN;
 
 typedef struct WOLFSSL_CERT_MANAGER WOLFSSL_CERT_MANAGER;
@@ -474,6 +475,11 @@ WOLFSSL_API unsigned char* wolfSSL_X509_get_subjectKeyID(
 WOLFSSL_API int wolfSSL_X509_NAME_entry_count(WOLFSSL_X509_NAME*);
 WOLFSSL_API int wolfSSL_X509_NAME_get_text_by_NID(
                                             WOLFSSL_X509_NAME*, int, char*, int);
+WOLFSSL_API int wolfSSL_X509_NAME_get_index_by_NID(
+                                           WOLFSSL_X509_NAME*, int, int);
+WOLFSSL_API WOLFSSL_ASN1_STRING* wolfSSL_X509_NAME_ENTRY_get_data(WOLFSSL_X509_NAME_ENTRY*);
+WOLFSSL_API char* wolfSSL_ASN1_STRING_data(WOLFSSL_ASN1_STRING*);
+WOLFSSL_API int wolfSSL_ASN1_STRING_length(WOLFSSL_ASN1_STRING*);
 WOLFSSL_API int         wolfSSL_X509_verify_cert(WOLFSSL_X509_STORE_CTX*);
 WOLFSSL_API const char* wolfSSL_X509_verify_cert_error_string(long);
 WOLFSSL_API int wolfSSL_X509_get_signature_type(WOLFSSL_X509*);
@@ -1004,6 +1010,10 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL*, void* key, unsigned int len,
     WOLFSSL_API int wolfSSL_use_certificate_chain_buffer(WOLFSSL*,
                                                const unsigned char*, long);
     WOLFSSL_API int wolfSSL_UnloadCertsKeys(WOLFSSL*);
+
+    #ifdef OPENSSL_EXTRA
+        WOLFSSL_API WOLFSSL_X509* wolfSSL_get_certificate(WOLFSSL* ssl);
+    #endif
 #endif
 
 WOLFSSL_API int wolfSSL_CTX_set_group_messages(WOLFSSL_CTX*);
@@ -1635,7 +1645,6 @@ WOLFSSL_API int wolfSSL_accept_ex(WOLFSSL*, HandShakeCallBack, TimeoutCallBack,
 
 
 #ifdef OPENSSL_EXTRA /*lighttp compatibility */
-#ifdef HAVE_LIGHTY
 
 typedef struct WOLFSSL_X509_NAME_ENTRY {
     WOLFSSL_ASN1_OBJECT* object;
@@ -1644,10 +1653,7 @@ typedef struct WOLFSSL_X509_NAME_ENTRY {
     int size;
 } WOLFSSL_X509_NAME_ENTRY;
 
-
-#include <wolfssl/openssl/dh.h>
-#include <wolfssl/openssl/asn1.h>
-
+#if defined(HAVE_LIGHTY) || defined(WOLFSSL_MYSQL_COMPATIBLE)
 WOLFSSL_API void wolfSSL_X509_NAME_free(WOLFSSL_X509_NAME *name);
 WOLFSSL_API char wolfSSL_CTX_use_certificate(WOLFSSL_CTX *ctx, WOLFSSL_X509 *x);
 WOLFSSL_API int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *pkey);
@@ -1672,7 +1678,8 @@ WOLFSSL_API STACK_OF(WOLFSSL_X509_NAME) *wolfSSL_dup_CA_list( STACK_OF(WOLFSSL_X
 #endif
 #endif
 
-#if defined(HAVE_STUNNEL) || defined(HAVE_LIGHTY)
+#if defined(HAVE_STUNNEL) || defined(HAVE_LIGHTY) \
+                          || defined(WOLFSSL_MYSQL_COMPATIBLE)
 
 WOLFSSL_API char * wolf_OBJ_nid2ln(int n);
 WOLFSSL_API int wolf_OBJ_txt2nid(const char *sn);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -495,7 +495,7 @@ static INLINE void showPeer(WOLFSSL* ssl)
         printf("peer has no cert!\n");
     wolfSSL_FreeX509(peer);
 #endif
-#if defined(SHOW_CERTS) && defined(OPENSSL_EXTRA)
+#if defined(SHOW_CERTS) && defined(OPENSSL_EXTRA) && defined(KEEP_OUR_CERT)
     ShowX509(wolfSSL_get_certificate(ssl), "our cert info:");
 #endif /* SHOW_CERTS */
     printf("SSL version is %s\n", wolfSSL_get_version(ssl));

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -441,13 +441,21 @@ static INLINE int PasswordCallBack(char* passwd, int sz, int rw, void* userdata)
 static INLINE void ShowX509(WOLFSSL_X509* x509, const char* hdr)
 {
     char* altName;
-    char* issuer  = wolfSSL_X509_NAME_oneline(
-                                       wolfSSL_X509_get_issuer_name(x509), 0, 0);
-    char* subject = wolfSSL_X509_NAME_oneline(
-                                      wolfSSL_X509_get_subject_name(x509), 0, 0);
+    char* issuer;
+    char* subject;
     byte  serial[32];
     int   ret;
     int   sz = sizeof(serial);
+
+    if (x509 == NULL) {
+        printf("%s No Cert\n", hdr);
+        return;
+    }
+
+    issuer  = wolfSSL_X509_NAME_oneline(
+                                      wolfSSL_X509_get_issuer_name(x509), 0, 0);
+    subject = wolfSSL_X509_NAME_oneline(
+                                     wolfSSL_X509_get_subject_name(x509), 0, 0);
 
     printf("%s\n issuer : %s\n subject: %s\n", hdr, issuer, subject);
 
@@ -487,6 +495,9 @@ static INLINE void showPeer(WOLFSSL* ssl)
         printf("peer has no cert!\n");
     wolfSSL_FreeX509(peer);
 #endif
+#if defined(SHOW_CERTS) && defined(OPENSSL_EXTRA)
+    ShowX509(wolfSSL_get_certificate(ssl), "our cert info:");
+#endif /* SHOW_CERTS */
     printf("SSL version is %s\n", wolfSSL_get_version(ssl));
 
     cipher = wolfSSL_get_current_cipher(ssl);

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -610,6 +610,8 @@ WOLFSSL_LOCAL void    FreeTrustedPeerTable(TrustedPeerCert**, int, void*);
 WOLFSSL_LOCAL int ToTraditional(byte* buffer, word32 length);
 WOLFSSL_LOCAL int ToTraditionalEnc(byte* buffer, word32 length,const char*,int);
 
+WOLFSSL_LOCAL int ExtractDate(const unsigned char* date, unsigned char format,
+                                                 struct tm* certTime, int* idx);
 WOLFSSL_LOCAL int ValidateDate(const byte* date, byte format, int dateType);
 
 /* ASN.1 helper functions */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -59,7 +59,6 @@
     extern "C" {
 #endif
 
-
 enum {
     ISSUER  = 0,
     SUBJECT = 1,
@@ -610,8 +609,10 @@ WOLFSSL_LOCAL void    FreeTrustedPeerTable(TrustedPeerCert**, int, void*);
 WOLFSSL_LOCAL int ToTraditional(byte* buffer, word32 length);
 WOLFSSL_LOCAL int ToTraditionalEnc(byte* buffer, word32 length,const char*,int);
 
+typedef struct tm wolfssl_tm;
+
 WOLFSSL_LOCAL int ExtractDate(const unsigned char* date, unsigned char format,
-                                                 struct tm* certTime, int* idx);
+                                                 wolfssl_tm* certTime, int* idx);
 WOLFSSL_LOCAL int ValidateDate(const byte* date, byte format, int dateType);
 
 /* ASN.1 helper functions */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -217,6 +217,14 @@
 	        #define XSTRNCASECMP(s1,s2,n) _strnicmp((s1),(s2),(n))
 	    #endif
 
+        #if defined(WOLFSSL_MYSQL_COMPATIBLE)
+	        #ifndef USE_WINDOWS_API
+	            #define XSNPRINTF snprintf
+	        #else
+	            #define XSNPRINTF _snprintf
+	        #endif
+        #endif /* WOLFSSL_MYSQL_COMPATIBLE */
+
         #if defined(WOLFSSL_CERT_EXT) || defined(HAVE_ALPN)
             /* use only Thread Safe version of strtok */
             #ifndef USE_WINDOWS_API


### PR DESCRIPTION
Adds the functions 

>X509_NAME_get_index_by_NID
>X509_NAME_ENTRY_get_data
>ASN1_STRING_data
>ASN1_STRING_length

Implements the previous function stubs

>wolfSSL_X509_NAME_get_entry
>wolfSSL_DES_set_key_unchecked

There is one more function that needs addressed

>wolfSSL_ASN1_TIME_to_string

While tying this function into asn.c code and completing it I want to let the tests run on current code.