### PR TITLE
DTLS sanity check

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4067,9 +4067,9 @@ static int GetDtlsHandShakeHeader(WOLFSSL* ssl, const byte* input,
 
         if (*type != client_hello && *type != hello_verify_request)
             return VERSION_ERROR;
-        else
-            WOLFSSL_MSG("DTLS Handshake ignoring hello or "
-                        "hello verify version");
+        else {
+            WOLFSSL_MSG("DTLS Handshake ignoring hello or verify version");
+        }
     }
     return 0;
 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6163,8 +6163,6 @@ int wolfSSL_dtls_got_timeout(WOLFSSL* ssl)
 {
     int result = SSL_SUCCESS;
 
-    DtlsMsgListDelete(ssl->dtls_msg_list, ssl->heap);
-    ssl->dtls_msg_list = NULL;
     if (DtlsPoolTimeout(ssl) < 0 || DtlsPoolSend(ssl) < 0) {
         result = SSL_FATAL_ERROR;
     }


### PR DESCRIPTION
* DTLS allows handshake messages to be repeated and arrive out of order. TLS does not. The sanity check for this was inappropriately erring out when client key exchange and change cipher spec are received out of order.
* Fixed a bug where the DTLS got timeout notification function was deleting the peer's received message list.