### PR TITLE
fix visual studio code analysis warnings

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -16044,7 +16044,7 @@ int DoSessionTicket(WOLFSSL* ssl,
         byte            peerCookie[MAX_COOKIE_LEN];
         byte            peerCookieSz = 0;
         byte            cookieType;
-        byte            cookieSz;
+        byte            cookieSz = 0;
 #endif /* WOLFSSL_DTLS */
 
 #ifdef WOLFSSL_CALLBACKS

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2120,6 +2120,10 @@ int wolfSSL_set_group_messages(WOLFSSL* ssl)
 /* make minVersion the internal equivalent SSL version */
 static int SetMinVersionHelper(byte* minVersion, int version)
 {
+#ifdef NO_TLS
+    (void)minVersion;
+#endif
+
     switch (version) {
 #if defined(WOLFSSL_ALLOW_SSLV3) && !defined(NO_OLD_TLS)
         case WOLFSSL_SSLV3:

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -365,6 +365,9 @@ int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
     word32 inIdx  = 0;
     word32 outIdx = 0;
 
+    if (in == NULL || out == NULL || outLen == NULL)
+        return BAD_FUNC_ARG;
+
     if (inLen == 1 && *outLen && in) {
         byte b = in[inIdx++] - 0x30;  /* 0 starts at 0x30 */
 
@@ -376,7 +379,7 @@ int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
 
         if (b == BAD)
             return ASN_INPUT_E;
-        
+
         out[outIdx++] = b;
 
         *outLen = outIdx;
@@ -404,7 +407,7 @@ int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
 
         if (b == BAD || b2 == BAD)
             return ASN_INPUT_E;
-        
+
         out[outIdx++] = (byte)((b << 4) | b2);
         inLen -= 2;
     }
@@ -418,6 +421,9 @@ int Base16_Encode(const byte* in, word32 inLen, byte* out, word32* outLen)
     word32 outIdx = 0;
     word32 i;
     byte   hb, lb;
+
+    if (in == NULL || out == NULL || outLen == NULL)
+        return BAD_FUNC_ARG;
 
     if (*outLen < (2 * inLen + 1))
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -361,15 +361,17 @@ static int Hash_gen(DRBG* drbg, byte* out, word32 outSz, const byte* V)
             drbg->lastBlock = checkBlock;
         }
 
-        if (outSz >= OUTPUT_BLOCK_LEN) {
-            XMEMCPY(out, digest, OUTPUT_BLOCK_LEN);
-            outSz -= OUTPUT_BLOCK_LEN;
-            out += OUTPUT_BLOCK_LEN;
-            array_add_one(data, DRBG_SEED_LEN);
-        }
-        else if (out != NULL && outSz != 0) {
-            XMEMCPY(out, digest, outSz);
-            outSz = 0;
+        if (out != NULL) {
+            if (outSz >= OUTPUT_BLOCK_LEN) {
+                XMEMCPY(out, digest, OUTPUT_BLOCK_LEN);
+                outSz -= OUTPUT_BLOCK_LEN;
+                out += OUTPUT_BLOCK_LEN;
+                array_add_one(data, DRBG_SEED_LEN);
+            }
+            else if (out != NULL && outSz != 0) {
+                XMEMCPY(out, digest, outSz);
+                outSz = 0;
+            }
         }
     }
     ForceZero(data, sizeof(data));


### PR DESCRIPTION
This pull request fixes warnings from the Visual Studio Code Analysis tool, run on Windows 7 with Visual Studio Express 2012.

Reference: Zendesk 1939