### PR TITLE
when dropping a DTLS message, drop the whole datagram

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8039,7 +8039,8 @@ int ProcessReply(WOLFSSL* ssl)
             if (ssl->options.dtls && ret == SEQUENCE_ERROR) {
                 WOLFSSL_MSG("Silently dropping out of order DTLS message");
                 ssl->options.processReply = doProcessInit;
-                ssl->buffers.inputBuffer.idx += ssl->curSize;
+                ssl->buffers.inputBuffer.length = 0;
+                ssl->buffers.inputBuffer.idx = 0;
 
                 ret = DtlsPoolSend(ssl);
                 if (ret != 0)

--- a/src/internal.c
+++ b/src/internal.c
@@ -6542,6 +6542,9 @@ static INLINE int DtlsCheckWindow(DtlsState* state)
     else if ((cur < next) && (window & ((DtlsSeq)1 << (next - cur - 1)))) {
         return 0;
     }
+    else if (cur > next + DTLS_SEQ_BITS) {
+        return 0;
+    }
 
     return 1;
 }


### PR DESCRIPTION
Fixes an issue found with extended fuzz testing.