### PR TITLE
add support for Whitewood netRandom

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1646,6 +1646,49 @@ AC_ARG_WITH([ntru],
 AM_CONDITIONAL([BUILD_NTRU], [test "x$ENABLED_NTRU" = "xyes"])
 
 
+# Whitewood netRandom client library
+ENABLED_WNR="no"
+trywnrdir=""
+AC_ARG_WITH([wnr],
+    [AS_HELP_STRING([--with-wnr=PATH],[Path to Whitewood netRandom install (default /usr/local)])],
+    [
+        AC_MSG_CHECKING([for Whitewood netRandom])
+        CPPFLAGS="$CPPFLAGS -DHAVE_WNR"
+        LIBS="$LIBS -lwnr"
+
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <wnr.h>]], [[ wnr_setup(0, 0); ]])], [ wnr_linked=yes ],[ wnr_linked=no ])
+
+        if test "x$wnr_linked" == "xno" ; then
+            if test "x$withval" != "xno" ; then
+                trywnrdir=$withval
+            fi
+            if test "x$withval" == "xyes" ; then
+                trywnrdir="/usr/local"
+            fi
+
+            LDFLAGS="$AM_LDFLAGS $LDFLAGS -L$trywnrdir/lib"
+            CPPFLAGS="$CPPFLAGS -I$trywnrdir/include"
+
+            AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <wnr.h>]], [[ wnr_setup(0, 0); ]])], [ wnr_linked=yes ],[ wnr_linked=no ])
+
+            if test "x$wnr_linked" == "xno" ; then
+                AC_MSG_ERROR([Whitewood netRandom isn't found.
+                If it's already installed, specify its path using --with-wnr=/dir/])
+            fi
+            AC_MSG_RESULT([yes])
+            AM_LDFLAGS="$AM_LDFLAGS -L$trywnrdir/lib"
+        else
+            AC_MSG_RESULT([yes])
+        fi
+
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_WNR"
+        ENABLED_WNR="yes"
+    ]
+)
+
+AM_CONDITIONAL([BUILD_WNR], [test "x$ENABLED_WNR" = "xyes"])
+
+
 # SNI
 AC_ARG_ENABLE([sni],
     [  --enable-sni            Enable SNI (default: disabled)],
@@ -2872,6 +2915,7 @@ echo "   * Persistent cert    cache:   $ENABLED_SAVECERT"
 echo "   * Atomic User Record Layer:   $ENABLED_ATOMICUSER"
 echo "   * Public Key Callbacks:       $ENABLED_PKCALLBACKS"
 echo "   * NTRU:                       $ENABLED_NTRU"
+echo "   * Whitewood netRandom:        $ENABLED_WNR"
 echo "   * Server Name Indication:     $ENABLED_SNI"
 echo "   * ALPN:                       $ENABLED_ALPN"
 echo "   * Maximum Fragment Length:    $ENABLED_MAX_FRAGMENT"

--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -272,6 +272,11 @@ void echoclient_test(void* args)
             err_sys("Cavium OpenNitroxDevice failed");
 #endif /* HAVE_CAVIUM */
 
+#ifdef HAVE_WNR
+        if (wc_InitNetRandom(wnrConfig, NULL, 5000) != 0)
+            err_sys("Whitewood netRandom global config failed");
+#endif
+
         StartTCP();
 
         args.argc = argc;
@@ -291,6 +296,12 @@ void echoclient_test(void* args)
 #ifdef HAVE_CAVIUM
         CspShutdown(CAVIUM_DEV_ID);
 #endif
+
+#ifdef HAVE_WNR
+        if (wc_FreeNetRandom() < 0)
+            err_sys("Failed to free netRandom context");
+#endif /* HAVE_WNR */
+
         return args.return_code;
     }
         

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -411,6 +411,11 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
             err_sys("Cavium OpenNitroxDevice failed");
 #endif /* HAVE_CAVIUM */
 
+#ifdef HAVE_WNR
+        if (wc_InitNetRandom(wnrConfig, NULL, 5000) != 0)
+            err_sys("Whitewood netRandom global config failed");
+#endif
+
         StartTCP();
 
         args.argc = argc;
@@ -427,6 +432,12 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
 #ifdef HAVE_CAVIUM
         CspShutdown(CAVIUM_DEV_ID);
 #endif
+
+#ifdef HAVE_WNR
+        if (wc_FreeNetRandom() < 0)
+            err_sys("Failed to free netRandom context");
+#endif /* HAVE_WNR */
+
         return args.return_code;
     }
 

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -60,6 +60,11 @@ int unit_test(int argc, char** argv)
         err_sys("Cavium OpenNitroxDevice failed");
 #endif /* HAVE_CAVIUM */
 
+#ifdef HAVE_WNR
+    if (wc_InitNetRandom(wnrConfig, NULL, 5000) != 0)
+        err_sys("Whitewood netRandom global config failed");
+#endif /* HAVE_WNR */
+
 #ifndef WOLFSSL_TIRTOS
     ChangeToWolfRoot();
 #endif
@@ -83,6 +88,11 @@ int unit_test(int argc, char** argv)
 #ifdef HAVE_CAVIUM
         CspShutdown(CAVIUM_DEV_ID);
 #endif
+
+#ifdef HAVE_WNR
+    if (wc_FreeNetRandom() < 0)
+        err_sys("Failed to free netRandom context");
+#endif /* HAVE_WNR */
 
     return 0;
 }

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -90,6 +90,13 @@ int testsuite_test(int argc, char** argv)
             err_sys("Cavium OpenNitroxDevice failed");
 #endif /* HAVE_CAVIUM */
 
+#ifdef HAVE_WNR
+        if (wc_InitNetRandom(wnrConfig, NULL, 5000) != 0) {
+            err_sys("Whitewood netRandom global config failed");
+            return -1237;
+        }
+#endif /* HAVE_WNR */
+
     StartTCP();
 
     server_args.argc = argc;
@@ -200,6 +207,12 @@ int testsuite_test(int argc, char** argv)
 #ifdef HAVE_CAVIUM
         CspShutdown(CAVIUM_DEV_ID);
 #endif
+
+#ifdef HAVE_WNR
+    if (wc_FreeNetRandom() < 0)
+        err_sys("Failed to free netRandom context");
+#endif /* HAVE_WNR */
+
     printf("\nAll tests passed!\n");
     return EXIT_SUCCESS;
 }

--- a/wnr-example.conf
+++ b/wnr-example.conf
@@ -1,0 +1,40 @@
+# Example netRandom client library configuration file
+#
+# This uses /dev/urandom for the seed, but could also
+# be set up to use a network entropy source
+
+version = "1.0";
+
+WnrClient:
+{
+  dir:
+  {
+    working = "/var/run/wnrentropy";
+    socket  = "/var/run/wnrentropy";
+  };
+
+  drbg:
+  {
+    type              = "SHA256";
+    security_strength = 256;
+    reseed_interval   = 1;
+  };
+
+  source:
+  {
+    seed = {
+                 type = "FILEPATH";
+                 path = "/dev/urandom";
+           };
+    stream = {
+                 type = "FILEPATH";
+                 path = "/dev/urandom";
+             };
+  };
+
+  buffer:
+  {
+    size = 8192;
+    threshold = 7168;
+  };
+};

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -86,6 +86,10 @@
 #endif
 #include <wolfssl/wolfcrypt/random.h>
 
+#ifdef HAVE_WNR
+    const char* wnrConfigFile = "wnr-example.conf";
+#endif
+
 #if defined(WOLFSSL_MDK_ARM)
     extern FILE * wolfSSL_fopen(const char *fname, const char *mode) ;
     #define fopen wolfSSL_fopen
@@ -282,6 +286,13 @@ int benchmark_test(void *args)
     }
     #endif /* HAVE_CAVIUM */
 
+    #ifdef HAVE_WNR
+    if (wc_InitNetRandom(wnrConfigFile, NULL, 5000) != 0) {
+        printf("Whitewood netRandom config init failed\n");
+        exit(-1);
+    }
+    #endif /* HAVE_WNR */
+
 #if defined(HAVE_LOCAL_RNG)
     {
         int rngRet = wc_InitRng(&rng);
@@ -402,6 +413,13 @@ int benchmark_test(void *args)
 
 #if defined(HAVE_LOCAL_RNG)
     wc_FreeRng(&rng);
+#endif
+
+#ifdef HAVE_WNR
+    if (wc_FreeNetRandom() < 0) {
+        printf("Failed to free netRandom context\n");
+        exit(-1);
+    }
 #endif
 
 #if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -146,6 +146,10 @@
     #include "wolfssl/wolfcrypt/mem_track.h"
 #endif
 
+#ifdef HAVE_WNR
+    const char* wnrConfigFile = "wnr-example.conf";
+#endif
+
 
 typedef struct testVector {
     const char*  input;
@@ -646,6 +650,13 @@ static int OpenNitroxDevice(int dma_mode,int dev_id)
         }
 #endif /* HAVE_CAVIUM */
 
+#ifdef HAVE_WNR
+        if (wc_InitNetRandom(wnrConfigFile, NULL, 5000) != 0) {
+            err_sys("Whitewood netRandom global config failed", -1237);
+            return -1237;
+        }
+#endif
+
         args.argc = argc;
         args.argv = argv;
 
@@ -654,6 +665,11 @@ static int OpenNitroxDevice(int dma_mode,int dev_id)
 #ifdef HAVE_CAVIUM
         CspShutdown(CAVIUM_DEV_ID);
 #endif
+
+#ifdef HAVE_WNR
+        if (wc_FreeNetRandom() < 0)
+            err_sys("Failed to free netRandom context", -1238);
+#endif /* HAVE_WNR */
 
         return args.return_code;
     }

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -257,6 +257,10 @@
 #define cliEccKey  "certs/ecc-client-key.pem"
 #define cliEccCert "certs/client-ecc-cert.pem"
 #define crlPemDir  "certs/crl"
+#ifdef HAVE_WNR
+    /* Whitewood netRandom default config file */
+    #define wnrConfig  "wnr-example.conf"
+#endif
 #else
 #define caCert     "./certs/ca-cert.pem"
 #define eccCert    "./certs/server-ecc.pem"
@@ -271,6 +275,10 @@
 #define cliEccKey  "./certs/ecc-client-key.pem"
 #define cliEccCert "./certs/client-ecc-cert.pem"
 #define crlPemDir  "./certs/crl"
+#ifdef HAVE_WNR
+    /* Whitewood netRandom default config file */
+    #define wnrConfig  "./wnr-example.conf"
+#endif
 #endif
 
 typedef struct tcp_ready {

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -52,6 +52,10 @@
     #include <wolfssl/wolfcrypt/arc4.h>
 #endif /* HAVE_HASHDRBG || NO_RC4 */
 
+#ifdef HAVE_WNR
+    #include <wnr.h>
+#endif
+
 #if defined(USE_WINDOWS_API)
     #if defined(_WIN64)
         typedef unsigned __int64 ProviderHandle;
@@ -128,6 +132,12 @@ int wc_GenerateSeed(OS_Seed* os, byte* seed, word32 sz);
 #endif
 
 #endif /* HAVE_HASH_DRBG || NO_RC4 */
+
+#ifdef HAVE_WNR
+    /* Whitewood netRandom client library */
+    WOLFSSL_API int  wc_InitNetRandom(const char*, wnr_hmac_key, int);
+    WOLFSSL_API int  wc_FreeNetRandom(void);
+#endif /* HAVE_WNR */
 
 
 WOLFSSL_API int  wc_InitRng(WC_RNG*);


### PR DESCRIPTION
This pull request adds support for the Whitewood netRandom client library.  The netRandom library currently only supports Linux variants.  This has been tested on Ubuntu 15.10, x64.

**HAVE_WNR** enables "Whitewood Net Random" support, which can also be enabled through autoconf:

```
--with-wnr=PATH         Path to Whitewood netRandom install (default /usr/local)
```

Functionality is exposed through two new functions in random.h:

```
int wc_InitNetRandom(const char* configFile, wnr_hmac_key hmac_cb, int timeout);
int wc_FreeNetRandom(void)
```

This implementation uses one global netRandom context (wnr_context) for all GenerateSeed calls, protected by a mutex for use in multi-threaded environments.

A sample netRandom config file is included (wnr-example.conf). This is used by default with the examples, unit tests, wolfCrypt test, and benchmark apps.  This configuration simulates Whitewood entropy using /dev/urandom.  The wolfSSL netRandom implementation has also been tested against the Whitewood netRandom instance hosted in AWS, but because there are HMAC keys included in that configuration, it has not been included here.
