### PR TITLE
Dtls multi core

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2526,6 +2526,23 @@ fi
 AM_CONDITIONAL([BUILD_ASYNCCRYPT], [test "x$ENABLED_ASYNCCRYPT" = "xyes"])
 
 
+# Session Export
+AC_ARG_ENABLE([sessionexport],
+    [AS_HELP_STRING([--enable-sessionexport],[Enable export and import of sessions (default: disabled)])],
+    [ ENABLED_SESSIONEXPORT=$enableval ],
+    [ ENABLED_SESSIONEXPORT=no ]
+    )
+
+if test "$ENABLED_SESSIONEXPORT" = "yes"
+then
+    if test "$ENABLED_DTLS" = "no"
+    then
+        AC_MSG_ERROR([Only DTLS supported with session export])
+    fi
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SESSION_EXPORT"
+fi
+
+
 # check if PSK was enabled for conditionally running psk.test script
 AM_CONDITIONAL([BUILD_PSK], [test "x$ENABLED_PSK" = "xyes"])
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1403,6 +1403,17 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         strncpy(resumeMsg, "GET /index.html HTTP/1.0\r\n\r\n", resumeSz);
         resumeMsg[resumeSz] = '\0';
     }
+
+/* allow some time for exporting the session */
+#ifdef WOLFSSL_SESSION_EXPORT_DEBUG
+    #ifdef USE_WINDOWS_API
+            Sleep(500);
+    #elif defined(WOLFSSL_TIRTOS)
+            Task_sleep(1);
+    #else
+            sleep(1);
+    #endif
+#endif /* WOLFSSL_SESSION_EXPORT_DEBUG */
     if (wolfSSL_write(ssl, msg, msgSz) != msgSz)
         err_sys("SSL_write failed");
 
@@ -1521,6 +1532,18 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 printf("Getting ALPN protocol name failed\n");
         }
 #endif
+
+    /* allow some time for exporting the session */
+    #ifdef WOLFSSL_SESSION_EXPORT_DEBUG
+        #ifdef USE_WINDOWS_API
+            Sleep(500);
+        #elif defined(WOLFSSL_TIRTOS)
+            Task_sleep(1);
+        #else
+            sleep(1);
+        #endif
+    #endif /* WOLFSSL_SESSION_EXPORT_DEBUG */
+
         if (wolfSSL_write(sslResume, resumeMsg, resumeSz) != resumeSz)
             err_sys("SSL_write failed");
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -787,7 +787,7 @@ int wolfSSL_dtls_import_internal(byte* buf, word32 sz, WOLFSSL* ssl)
     word32 idx    = 0;
     word16 length = 0;
     int version;
-    int ret;
+    int ret, i;
 
     WOLFSSL_ENTER("wolfSSL_dtls_import_internal");
     /* check at least enough room for protocol and length */
@@ -883,6 +883,19 @@ int wolfSSL_dtls_import_internal(byte* buf, word32 sz, WOLFSSL* ssl)
     if (ssl->options.tls == 1 || ssl->options.tls1_1 == 1 ||
             ssl->options.dtls == 1) {
         ssl->hmac = TLS_hmac;
+    }
+
+    /* make sure is a valid suite used */
+    ret = SUITES_ERROR;
+    for (i = 0; i < ssl->suites->suiteSz; i += 2) {
+        if (ssl->suites->suites[i]   == ssl->options.cipherSuite0 &&
+                    ssl->suites->suites[i+1] == ssl->options.cipherSuite) {
+            ret = 0;
+            break;
+        }
+    }
+    if (ret != 0) {
+        return ret;
     }
 
     return idx;

--- a/tests/api.c
+++ b/tests/api.c
@@ -839,15 +839,15 @@ static THREAD_RETURN WOLFSSL_THREAD run_wolfssl_server(void* args)
         }
 
         AssertIntEQ(len, wolfSSL_write(ssl, msg, len));
-#ifdef WOLFSSL_SESSION_EXPORT
+#if defined(WOLFSSL_SESSION_EXPORT) && !defined(HAVE_IO_POOL)
         if (wolfSSL_dtls(ssl)) {
             byte*  import;
             word32 sz;
 
-            wolfSSL_dtls_export(NULL, &sz, ssl);
+            wolfSSL_dtls_export(ssl, NULL, &sz);
             import = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             AssertNotNull(import);
-            idx = wolfSSL_dtls_export(import, &sz, ssl);
+            idx = wolfSSL_dtls_export(ssl, import, &sz);
             AssertIntGE(idx, 0);
             AssertIntGE(wolfSSL_dtls_import(ssl, import, idx), 0);
             XFREE(import, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/tests/api.c
+++ b/tests/api.c
@@ -369,7 +369,9 @@ static void test_server_wolfSSL_new(void)
 
     /* invalid context */
     AssertNull(ssl = wolfSSL_new(NULL));
+#ifndef WOLFSSL_SESSION_EXPORT
     AssertNull(ssl = wolfSSL_new(ctx_nocert));
+#endif
 
     /* success */
     AssertNotNull(ssl = wolfSSL_new(ctx));

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -146,6 +146,8 @@ enum wolfSSL_ErrorCodes {
 
     RSA_KEY_SIZE_E               = -409,   /* RSA key too small */
     ECC_KEY_SIZE_E               = -410,   /* ECC key too small */
+
+    DTLS_EXPORT_VER_E            = -411,   /* export version error */
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* begin negotiation parameter errors */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -952,8 +952,9 @@ enum Misc {
     DTLS_POOL_SZ             = 5,  /* buffers to hold in the retry pool */
     DTLS_EXPORT_PRO          = 165,/* wolfSSL protocol for serialized session */
     DTLS_EXPORT_VERSION      = 1,  /* wolfSSL version for serialized session */
-    DTLS_EXPORT_OPT_SZ       = 57,  /* amount of bytes used from Options */
-    DTLS_EXPORT_KEY_SZ       = 326, /* amount of bytes used from Keys */
+    DTLS_EXPORT_OPT_SZ       = 57, /* amount of bytes used from Options */
+    DTLS_EXPORT_KEY_SZ       = 331,/* max amount of bytes used from Keys */
+    DTLS_EXPORT_MIN_KEY_SZ   = 75, /* min amount of bytes used from Keys */
     DTLS_EXPORT_SPC_SZ       = 16, /* amount of bytes used from CipherSpecs */
     DTLS_EXPORT_LEN          = 2,  /* 2 bytes for length and protocol */
     MAX_EXPORT_BUFFER        = 500, /* max size of buffer for exporting */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1203,8 +1203,6 @@ typedef struct ProtocolVersion {
 } WOLFSSL_PACK ProtocolVersion;
 
 
-WOLFSSL_LOCAL int wolfSSL_dtls_import_internal(byte* buf, word32 sz, WOLFSSL* ssl);
-WOLFSSL_LOCAL int wolfSSL_dtls_export(byte* buf, word32 sz, WOLFSSL* ssl);
 WOLFSSL_LOCAL ProtocolVersion MakeSSLv3(void);
 WOLFSSL_LOCAL ProtocolVersion MakeTLSv1(void);
 WOLFSSL_LOCAL ProtocolVersion MakeTLSv1_1(void);
@@ -1213,6 +1211,14 @@ WOLFSSL_LOCAL ProtocolVersion MakeTLSv1_2(void);
 #ifdef WOLFSSL_DTLS
     WOLFSSL_LOCAL ProtocolVersion MakeDTLSv1(void);
     WOLFSSL_LOCAL ProtocolVersion MakeDTLSv1_2(void);
+
+    #ifdef WOLFSSL_SESSION_EXPORT
+    WOLFSSL_LOCAL int wolfSSL_dtls_import_internal(byte* buf, word32 sz,
+                                                                  WOLFSSL* ssl);
+    WOLFSSL_LOCAL int wolfSSL_dtls_export_internal(byte* buf, word32 sz,
+                                                                  WOLFSSL* ssl);
+    WOLFSSL_LOCAL int wolfSSL_send_session(WOLFSSL* ssl);
+    #endif
 #endif
 
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -954,6 +954,7 @@ enum Misc {
     DTLS_EXPORT_VERSION      = 1,  /* wolfSSL version for serialized session */
     DTLS_EXPORT_OPT_SZ       = 57,  /* amount of bytes used from Options */
     DTLS_EXPORT_KEY_SZ       = 326, /* amount of bytes used from Keys */
+    DTLS_EXPORT_SPC_SZ       = 16, /* amount of bytes used from CipherSpecs */
     DTLS_EXPORT_LEN          = 2,  /* 2 bytes for length and protocol */
     MAX_EXPORT_BUFFER        = 500, /* max size of buffer for exporting */
     FINISHED_LABEL_SZ   = 15,  /* TLS finished label size */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -949,7 +949,11 @@ enum Misc {
     DTLS_HANDSHAKE_SEQ_SZ    = 2,  /* handshake header sequence number */
     DTLS_HANDSHAKE_FRAG_SZ   = 3,  /* fragment offset and length are 24 bit */
     DTLS_POOL_SZ             = 5,  /* buffers to hold in the retry pool */
-
+    DTLS_EXPORT_PRO          = 165,/* wolfSSL protocol for serialized session */
+    DTLS_EXPORT_VERSION      = 1,  /* wolfSSL version for serialized session */
+    DTLS_EXPORT_OPT_SZ       = 57, /* amount of bytes used from Options */
+    DTLS_EXPORT_LEN          = 2,  /* 2 bytes for length and protocol */
+    MAX_EXPORT_BUFFER        = 500, /* max size of buffer for exporting */
     FINISHED_LABEL_SZ   = 15,  /* TLS finished label size */
     TLS_FINISHED_SZ     = 12,  /* TLS has a shorter size  */
     MASTER_LABEL_SZ     = 13,  /* TLS master secret label sz */
@@ -1195,6 +1199,8 @@ typedef struct ProtocolVersion {
 } WOLFSSL_PACK ProtocolVersion;
 
 
+WOLFSSL_LOCAL int wolfSSL_dtls_import_internal(byte* buf, word32 sz, WOLFSSL* ssl);
+WOLFSSL_LOCAL int wolfSSL_dtls_export(byte* buf, word32 sz, WOLFSSL* ssl);
 WOLFSSL_LOCAL ProtocolVersion MakeSSLv3(void);
 WOLFSSL_LOCAL ProtocolVersion MakeTLSv1(void);
 WOLFSSL_LOCAL ProtocolVersion MakeTLSv1_1(void);
@@ -1369,7 +1375,10 @@ int  SetCipherList(Suites*, const char* list);
     typedef unsigned int (*wc_psk_server_callback)(WOLFSSL*, const char*,
                           unsigned char*, unsigned int);
 #endif /* PSK_TYPES_DEFINED */
-
+#ifdef WOLFSSL_DTLS
+    typedef int (*wc_dtls_export)(WOLFSSL* ssl,
+                   unsigned char* exportBuffer, unsigned int sz, void* userCtx);
+#endif
 
 #ifdef HAVE_NETX
     WOLFSSL_LOCAL int NetX_Receive(WOLFSSL *ssl, char *buf, int sz, void *ctx);
@@ -1575,7 +1584,8 @@ typedef struct WOLFSSL_DTLS_CTX {
 
 #define MAX_WRITE_IV_SZ 16 /* max size of client/server write_IV */
 
-/* keys and secrets */
+/* keys and secrets
+ * keep as a constant size (no additional ifdefs) for session export */
 typedef struct Keys {
     byte client_write_MAC_secret[MAX_DIGEST_SIZE];   /* max sizes */
     byte server_write_MAC_secret[MAX_DIGEST_SIZE];
@@ -1583,7 +1593,7 @@ typedef struct Keys {
     byte server_write_key[AES_256_KEY_SIZE];
     byte client_write_IV[MAX_WRITE_IV_SZ];               /* max sizes */
     byte server_write_IV[MAX_WRITE_IV_SZ];
-#ifdef HAVE_AEAD
+#if defined(HAVE_AEAD) || defined(WOLFSSL_SESSION_EXPORT)
     byte aead_exp_IV[AEAD_MAX_EXP_SZ];
     byte aead_enc_imp_IV[AEAD_MAX_IMP_SZ];
     byte aead_dec_imp_IV[AEAD_MAX_IMP_SZ];
@@ -1938,6 +1948,7 @@ struct WOLFSSL_CTX {
     CallbackIOSend CBIOSend;
 #ifdef WOLFSSL_DTLS
     CallbackGenCookie CBIOCookie;       /* gen cookie callback */
+    wc_dtls_export    dtls_export;      /* export function for DTLS session */
 #endif
     VerifyCallback  verifyCallback;     /* cert verification callback */
     word32          timeout;            /* session timeout */
@@ -2033,7 +2044,8 @@ int ProcessOldClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #endif
 #endif
 
-/* All cipher suite related info */
+/* All cipher suite related info
+ * Keep as a constant size (no ifdefs) for session export */
 typedef struct CipherSpecs {
     word16 key_size;
     word16 iv_size;
@@ -2712,6 +2724,7 @@ struct WOLFSSL {
     DtlsMsg*        dtls_msg_list;
     void*           IOCB_CookieCtx;     /* gen cookie ctx */
     word32          dtls_expected_rx;
+    wc_dtls_export  dtls_export;        /* export function for session */
 #endif
 #ifdef WOLFSSL_CALLBACKS
     HandShakeInfo   handShakeInfo;      /* info saved during handshake */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -926,6 +926,7 @@ enum Misc {
     OPAQUE16_LEN =  2,         /* 2 bytes                 */
     OPAQUE24_LEN =  3,         /* 3 bytes                 */
     OPAQUE32_LEN =  4,         /* 4 bytes                 */
+    OPAQUE64_LEN =  8,         /* 8 bytes                 */
     COMP_LEN     =  1,         /* compression length      */
     CURVE_LEN    =  2,         /* ecc named curve length  */
     SERVER_ID_LEN = 20,        /* server session id length  */
@@ -951,7 +952,8 @@ enum Misc {
     DTLS_POOL_SZ             = 5,  /* buffers to hold in the retry pool */
     DTLS_EXPORT_PRO          = 165,/* wolfSSL protocol for serialized session */
     DTLS_EXPORT_VERSION      = 1,  /* wolfSSL version for serialized session */
-    DTLS_EXPORT_OPT_SZ       = 57, /* amount of bytes used from Options */
+    DTLS_EXPORT_OPT_SZ       = 57,  /* amount of bytes used from Options */
+    DTLS_EXPORT_KEY_SZ       = 326, /* amount of bytes used from Keys */
     DTLS_EXPORT_LEN          = 2,  /* 2 bytes for length and protocol */
     MAX_EXPORT_BUFFER        = 500, /* max size of buffer for exporting */
     FINISHED_LABEL_SZ   = 15,  /* TLS finished label size */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1213,10 +1213,10 @@ WOLFSSL_LOCAL ProtocolVersion MakeTLSv1_2(void);
     WOLFSSL_LOCAL ProtocolVersion MakeDTLSv1_2(void);
 
     #ifdef WOLFSSL_SESSION_EXPORT
-    WOLFSSL_LOCAL int wolfSSL_dtls_import_internal(byte* buf, word32 sz,
-                                                                  WOLFSSL* ssl);
-    WOLFSSL_LOCAL int wolfSSL_dtls_export_internal(byte* buf, word32 sz,
-                                                                  WOLFSSL* ssl);
+    WOLFSSL_LOCAL int wolfSSL_dtls_import_internal(WOLFSSL* ssl, byte* buf,
+                                                                     word32 sz);
+    WOLFSSL_LOCAL int wolfSSL_dtls_export_internal(WOLFSSL* ssl, byte* buf,
+                                                                     word32 sz);
     WOLFSSL_LOCAL int wolfSSL_send_session(WOLFSSL* ssl);
     #endif
 #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -229,10 +229,13 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_2_client_method(void);
 #ifdef WOLFSSL_DTLS
 typedef int (*wc_dtls_export)(WOLFSSL* ssl,
                    unsigned char* exportBuffer, unsigned int sz, void* userCtx);
-WOLFSSL_API int wolfSSL_dtls_import(WOLFSSL* ssl, unsigned char* buf, unsigned int sz);
-WOLFSSL_API int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx, wc_dtls_export func);
+WOLFSSL_API int wolfSSL_dtls_import(WOLFSSL* ssl, unsigned char* buf,
+                                                               unsigned int sz);
+WOLFSSL_API int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx,
+                                                           wc_dtls_export func);
 WOLFSSL_API int wolfSSL_dtls_set_export(WOLFSSL* ssl, wc_dtls_export func);
-WOLFSSL_LOCAL int wolfSSL_send_session(WOLFSSL* ssl);
+WOLFSSL_API int wolfSSL_dtls_export(unsigned char* buf, unsigned int* sz,
+                                                                  WOLFSSL* ssl);
 #endif /* WOLFSSL_DTLS */
 #endif /* WOLFSSL_SESSION_EXPORT */
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -225,6 +225,17 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_2_client_method(void);
     WOLFSSL_API int wolfSSL_use_old_poly(WOLFSSL*, int);
 #endif
 
+#ifdef WOLFSSL_SESSION_EXPORT
+#ifdef WOLFSSL_DTLS
+typedef int (*wc_dtls_export)(WOLFSSL* ssl,
+                   unsigned char* exportBuffer, unsigned int sz, void* userCtx);
+WOLFSSL_API int wolfSSL_dtls_import(WOLFSSL* ssl, unsigned char* buf, unsigned int sz);
+WOLFSSL_API int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx, wc_dtls_export func);
+WOLFSSL_API int wolfSSL_dtls_set_export(WOLFSSL* ssl, wc_dtls_export func);
+WOLFSSL_LOCAL int wolfSSL_send_session(WOLFSSL* ssl);
+#endif /* WOLFSSL_DTLS */
+#endif /* WOLFSSL_SESSION_EXPORT */
+
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS)
 
 WOLFSSL_API int wolfSSL_CTX_use_certificate_file(WOLFSSL_CTX*, const char*, int);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -234,8 +234,8 @@ WOLFSSL_API int wolfSSL_dtls_import(WOLFSSL* ssl, unsigned char* buf,
 WOLFSSL_API int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx,
                                                            wc_dtls_export func);
 WOLFSSL_API int wolfSSL_dtls_set_export(WOLFSSL* ssl, wc_dtls_export func);
-WOLFSSL_API int wolfSSL_dtls_export(unsigned char* buf, unsigned int* sz,
-                                                                  WOLFSSL* ssl);
+WOLFSSL_API int wolfSSL_dtls_export(WOLFSSL* ssl, unsigned char* buf,
+                                                              unsigned int* sz);
 #endif /* WOLFSSL_DTLS */
 #endif /* WOLFSSL_SESSION_EXPORT */
 


### PR DESCRIPTION
Adds the option to use --enable-sessionexport with DTLS and send a session after completing change cipher spec in handshake. 