### PR TITLE
Add "user specific" debugging APIs.

### DIFF
--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -208,3 +208,32 @@ void WOLFSSL_ERROR(int error)
 }
 
 #endif  /* DEBUG_WOLFSSL */
+
+#ifdef USER_DEBUG_WOLFSSL
+void USER_WOLFSSL_MSG(const char* msg)
+{
+#ifdef THREADX
+            dc_log_printf("%s\n", msg);
+#elif defined(MICRIUM)
+        #if (NET_SECURE_MGR_CFG_EN == DEF_ENABLED)
+            NetSecure_TraceOut((CPU_CHAR *)msg);
+        #endif
+#elif defined(WOLFSSL_MDK_ARM)
+            fflush(stdout) ;
+            printf("%s\n", msg);
+            fflush(stdout) ;
+#elif defined(WOLFSSL_LOG_PRINTF)
+            printf("%s\n", msg);
+#else
+            fprintf(stderr, "%s\n", msg);
+#endif
+}
+
+void USER_WOLFSSL_ERROR(int error)
+{
+    char buffer[80];
+    sprintf(buffer, "wolfSSL error occurred, error = %d", error);
+    USER_WOLFSSL_MSG(buffer);
+}
+
+#endif /* USER_DEBUG_WOLFSSL */

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -71,6 +71,11 @@ WOLFSSL_API int wolfSSL_SetLoggingCb(wolfSSL_Logging_cb log_function);
 
 #endif /* DEBUG_WOLFSSL  */
 
+#ifdef USER_DEBUG_WOLFSSL
+    void USER_WOLFSSL_ERROR(int);
+    void USER_WOLFSSL_MSG(const char* msg);
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The APIs from DEBUG_WOLFSSL work great, but can take up a lot of space when enabled.  On platforms with limited resources, it may not be possible to enable DEBUG_WOLFSSL and have the image still fit.

USER_DEBUG_WOLFSSL is intended to only be used when a specific issue is being debugged.  It can replace the few important WOLFSSL_MSG or WOLFSSL_ERROR calls in the code path desired or can be used to add a few more debug statements where the developer needs it without getting the whole DEBUG_WOLFSSL output.
