### PR TITLE
Limit Country Name size

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -6712,6 +6712,14 @@ static int SetName(byte* output, word32 outputSz, CertName* name)
             int thisLen = strLen;
             int firstSz, secondSz, seqSz, setSz;
 
+            /* Restrict country code size */
+            if (i == 0) {
+                if (strLen >= CTC_COUNTRY_SIZE)
+                    strLen = CTC_COUNTRY_SIZE;
+                else
+                    strLen = 0;
+            }
+
             if (strLen == 0) { /* no user data for this item */
                 names[i].used = 0;
                 continue;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7413,7 +7413,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der,
 
     /* subject name */
     der->subjectSz = SetName(der->subject, sizeof(der->subject), &cert->subject);
-    if (der->subjectSz == 0)
+    if (der->subjectSz <= 0)
         return SUBJECT_E;
 
     /* public key */
@@ -7442,7 +7442,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der,
     /* CA */
     if (cert->isCA) {
         der->caSz = SetCa(der->ca, sizeof(der->ca));
-        if (der->caSz == 0)
+        if (der->caSz <= 0)
             return CA_TRUE_E;
 
         der->extensionsSz += der->caSz;
@@ -7459,7 +7459,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der,
 
         der->skidSz = SetSKID(der->skid, sizeof(der->skid),
                               cert->skid, cert->skidSz);
-        if (der->skidSz == 0)
+        if (der->skidSz <= 0)
             return SKID_E;
 
         der->extensionsSz += der->skidSz;
@@ -7471,7 +7471,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der,
     if (cert->keyUsage != 0){
         der->keyUsageSz = SetKeyUsage(der->keyUsage, sizeof(der->keyUsage),
                                       cert->keyUsage);
-        if (der->keyUsageSz == 0)
+        if (der->keyUsageSz <= 0)
             return KEYUSAGE_E;
 
         der->extensionsSz += der->keyUsageSz;
@@ -7486,7 +7486,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der,
 
         /* put the start of sequence (ID, Size) */
         der->extensionsSz = SetSequence(der->extensionsSz, der->extensions);
-        if (der->extensionsSz == 0)
+        if (der->extensionsSz <= 0)
             return EXTENSIONS_E;
 
         /* put CA */
@@ -7494,7 +7494,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der,
             ret = SetExtensions(der->extensions, sizeof(der->extensions),
                                 &der->extensionsSz,
                                 der->ca, der->caSz);
-            if (ret == 0)
+            if (ret <= 0)
                 return EXTENSIONS_E;
         }
 
@@ -7504,7 +7504,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der,
             ret = SetExtensions(der->extensions, sizeof(der->extensions),
                                 &der->extensionsSz,
                                 der->skid, der->skidSz);
-            if (ret == 0)
+            if (ret <= 0)
                 return EXTENSIONS_E;
         }
 
@@ -7513,7 +7513,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der,
             ret = SetExtensions(der->extensions, sizeof(der->extensions),
                                 &der->extensionsSz,
                                 der->akid, der->akidSz);
-            if (ret == 0)
+            if (ret <= 0)
                 return EXTENSIONS_E;
         }
 
@@ -7522,7 +7522,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der,
             ret = SetExtensions(der->extensions, sizeof(der->extensions),
                                 &der->extensionsSz,
                                 der->keyUsage, der->keyUsageSz);
-            if (ret == 0)
+            if (ret <= 0)
                 return EXTENSIONS_E;
         }
 
@@ -7531,7 +7531,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der,
 
     der->attribSz = SetReqAttrib(der->attrib,
                                  cert->challengePw, der->extensionsSz);
-    if (der->attribSz == 0)
+    if (der->attribSz <= 0)
         return REQ_ATTRIBUTE_E;
 
     der->total = der->versionSz + der->subjectSz + der->publicKeySz +

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -380,6 +380,9 @@ const char* wc_GetErrorString(int error)
     case WC_KEY_SIZE_E:
         return "Key size error, either too small or large";
 
+    case ASN_COUNTRY_SIZE_E:
+        return "Country code size error, either too small or large";
+
     default:
         return "unknown error number";
 

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -77,6 +77,7 @@ enum Ctc_Encoding {
 };
 
 enum Ctc_Misc {
+    CTC_COUNTRY_SIZE  =     2,
     CTC_NAME_SIZE     =    64,
     CTC_DATE_SIZE     =    32,
     CTC_MAX_ALT_SIZE  = 16384,   /* may be huge */

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -170,6 +170,7 @@ enum {
     WC_PENDING_E        = -233,  /* wolfCrypt operation pending (would block) */
 
     WC_KEY_SIZE_E       = -234,  /* Key size error, either too small or large */
+    ASN_COUNTRY_SIZE_E  = -235,  /* ASN Cert Gen, invalid country code size */
 
     MIN_CODE_E          = -300   /* errors -101 - -299 */
 


### PR DESCRIPTION
When generating a certificate, limit the country name size to 2 octets per RFC 5280 Appendix A.1.