### PR TITLE
Added missing wolfCrypt_Init() to wolfCrypt test application

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -271,6 +271,8 @@ int wolfcrypt_test(void* args)
     InitMemoryTracker();
 #endif
 
+    wolfCrypt_Init();
+
 #ifdef HAVE_FIPS
     wolfCrypt_SetCb_fips(myFipsCb);
 #endif


### PR DESCRIPTION
Noticed that wolfcrypt/test/testwolfcrypt application was not calling wolfCrypt_Init(). Verified all other test/example applications either call wolfSSL_Init() or wolfCrypt_Init().