### PR TITLE
sanity checks on wolfSSL_dtls_get_peer arguments

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -517,8 +517,13 @@ int wolfSSL_dtls_set_peer(WOLFSSL* ssl, void* peer, unsigned int peerSz)
 int wolfSSL_dtls_get_peer(WOLFSSL* ssl, void* peer, unsigned int* peerSz)
 {
 #ifdef WOLFSSL_DTLS
+    if (ssl == NULL) {
+        return SSL_FAILURE;
+    }
+
     if (peer != NULL && peerSz != NULL
-            && *peerSz >= ssl->buffers.dtlsCtx.peer.sz) {
+            && *peerSz >= ssl->buffers.dtlsCtx.peer.sz
+            && ssl->buffers.dtlsCtx.peer.sa != NULL) {
         *peerSz = ssl->buffers.dtlsCtx.peer.sz;
         XMEMCPY(peer, ssl->buffers.dtlsCtx.peer.sa, *peerSz);
         return SSL_SUCCESS;


### PR DESCRIPTION
Sanity checks on arguments passed in to function wolfSSL_dtls_get_peer. This is added to avoid a potential crash if using the function incorrectly. 