### PR TITLE
fix index to check for sperator value

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -657,8 +657,8 @@ static int wc_RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
     /* done with use of tmp buffer */
     XFREE(tmp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
-    /* advance idx to index of PS and msg separator */
-    idx = hLen + 2 + hLen;
+    /* advance idx to index of PS and msg separator, account for PS size of 0*/
+    idx = hLen + 1 + hLen;
     while (idx < pkcsBlockLen && pkcsBlock[idx] == 0) {idx++;}
 
     /* create hash of label for comparision with hash sent */


### PR DESCRIPTION
hlen + 2 + hlen advances the index pointer to the second value of PS. This will never be more than the buffer since it is required that the msg size be at least size 1 but leads to an edge case of not being able to decrypt the message when PS is size of 0. The returned value with the bug is -192 BAD_PADDING_E since the separator value is not found.

Decrypted OAEP message has the form of 
0x00 | seed (size of hlen) | lhash (size of hlen) | PS | 0x01 | msg
Where PS is 0 byte padding up to the separator byte 0x01.

Thanks to LordCapybara for posting this on our forums. 
https://www.wolfssl.com/forums/topic798-rsa-in-oaep-mode.html
