### PR TITLE
Enable ECC features for TI devices

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -560,6 +560,7 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #define HAVE_ALPN
     #define HAVE_TLS_EXTENSIONS
     #define HAVE_AESGCM
+    #define HAVE_SUPPORTED_CURVES
 
     #ifdef __IAR_SYSTEMS_ICC__
         #pragma diag_suppress=Pa089

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -561,6 +561,7 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #define HAVE_TLS_EXTENSIONS
     #define HAVE_AESGCM
     #define HAVE_SUPPORTED_CURVES
+    #define ALT_ECC_SIZE
 
     #ifdef __IAR_SYSTEMS_ICC__
         #pragma diag_suppress=Pa089


### PR DESCRIPTION
Add HAVE_SUPPORTED_CURVES and ALT_ECC_SIZE to enable supported curves in TLS handshake and also to reduce the memory usage which is critical for embedded devices