### PR TITLE
Asynchronous wolfCrypt and Cavium Nitrox V support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ fips_test.c
 fips
 src/async.c
 wolfssl/async.h
+wolfcrypt/src/async.c
+wolfssl/wolfcrypt/async.h
 ctaocrypt/benchmark/benchmark
 ctaocrypt/test/testctaocrypt
 wolfcrypt/benchmark/benchmark

--- a/IDE/WIN/wolfssl-fips.vcxproj
+++ b/IDE/WIN/wolfssl-fips.vcxproj
@@ -300,6 +300,7 @@
     <ClCompile Include="..\..\src\ssl.c" />
     <ClCompile Include="..\..\src\tls.c" />
     <ClCompile Include="..\..\wolfcrypt\src\wc_encrypt.c" />
+    <ClCompile Include="..\..\wolfcrypt\src\wolfevent.c" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\wolfcrypt\src\aes_asm.asm">

--- a/autogen.sh
+++ b/autogen.sh
@@ -20,8 +20,8 @@ if test -d .git; then
   touch ./ctaocrypt/src/fips_test.c
 
   # touch async crypt files
-  touch ./src/async.c
-  touch ./wolfssl/async.h
+  touch ./wolfcrypt/src/async.c
+  touch ./wolfssl/wolfcrypt/async.h
 else
   WARNINGS="all"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -2427,27 +2427,68 @@ AC_ARG_WITH([cavium],
         AC_MSG_CHECKING([for cavium])
         CPPFLAGS="$CPPFLAGS -DHAVE_CAVIUM"
 
-            if test "x$withval" == "xyes" ; then
-                AC_MSG_ERROR([need a PATH for --with-cavium])
-            fi
-            if test "x$withval" != "xno" ; then
-                trycaviumdir=$withval
-            fi
+        if test "x$withval" == "xyes" ; then
+            AC_MSG_ERROR([need a PATH for --with-cavium])
+        fi
+        if test "x$withval" != "xno" ; then
+            trycaviumdir=$withval
+        fi
 
-            LDFLAGS="$AM_LDFLAGS $trycaviumdir/api/cavium_common.o"
-            CPPFLAGS="$CPPFLAGS -I$trycaviumdir/include"
+        LDFLAGS="$AM_LDFLAGS $trycaviumdir/api/cavium_common.o"
+        CPPFLAGS="$CPPFLAGS -I$trycaviumdir/include"
 
-            AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cavium_common.h"]], [[ CspShutdown(CAVIUM_DEV_ID); ]])],[ cavium_linked=yes ],[ cavium_linked=no ])
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cavium_common.h"]], [[ CspShutdown(CAVIUM_DEV_ID); ]])],[ cavium_linked=yes ],[ cavium_linked=no ])
 
-            if test "x$cavium_linked" == "xno" ; then
-                AC_MSG_ERROR([cavium isn't found.
-                If it's already installed, specify its path using --with-cavium=/dir/])
-            fi
-            AC_MSG_RESULT([yes])
-            enable_shared=no
-            enable_static=yes
+        if test "x$cavium_linked" == "xno" ; then
+            AC_MSG_ERROR([cavium isn't found.
+            If it's already installed, specify its path using --with-cavium=/dir/])
+        fi
+        AC_MSG_RESULT([yes])
+        enable_shared=no
+        enable_static=yes
+        ENABLED_CAVIUM=yes
+    ],
+    [ ENABLED_CAVIUM=no ]
+)
+
+# cavium V
+trycaviumdir=""
+AC_ARG_WITH([cavium-v],
+    [  --with-cavium-v=PATH    PATH to Cavium V/software dir ],
+    [
+        AC_MSG_CHECKING([for cavium])
+        CPPFLAGS="$CPPFLAGS -DHAVE_CAVIUM -DHAVE_CAVIUM_V"
+
+        if test "x$withval" == "xyes" ; then
+            AC_MSG_ERROR([need a PATH for --with-cavium])
+        fi
+        if test "x$withval" != "xno" ; then
+            trycaviumdir=$withval
+        fi
+
+        LDFLAGS="$AM_LDFLAGS $trycaviumdir/utils/sample_tests/cavium_common.o $trycaviumdir/utils/sample_tests/cavium_sym_crypto.o $trycaviumdir/utils/sample_tests/cavium_asym_crypto.o"
+        CPPFLAGS="$CPPFLAGS -I$trycaviumdir/include"
+
+        #AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cavium_common.h"]], [[ CspShutdown(0); ]])],[ cavium_linked=yes ],[ cavium_linked=no ])
+
+        if test "x$cavium_linked" == "xno" ; then
+            AC_MSG_ERROR([cavium isn't found.
+            If it's already installed, specify its path using --with-cavium-v=/dir/])
+        fi
+        AC_MSG_RESULT([yes])
+
+        enable_shared=no
+        enable_static=yes
+        ENABLED_CAVIUM=yes
+        ENABLED_CAVIUM_V=yes
+    ],
+    [
+        ENABLED_CAVIUM_=no
+        ENABLED_CAVIUM_V=no
     ]
 )
+
+AM_CONDITIONAL([BUILD_CAVIUM], [test "x$ENABLED_CAVIUM" = "xyes"])
 
 
 # Fast RSA using Intel IPP
@@ -3057,6 +3098,7 @@ echo "   * Examples:                   $ENABLED_EXAMPLES"
 echo "   * User Crypto:                $ENABLED_USER_CRYPTO"
 echo "   * Fast RSA:                   $ENABLED_FAST_RSA"
 echo "   * Async Crypto:               $ENABLED_ASYNCCRYPT"
+echo "   * Cavium:                     $ENABLED_CAVIUM"
 echo ""
 echo "---"
 

--- a/cyassl/ctaocrypt/aes.h
+++ b/cyassl/ctaocrypt/aes.h
@@ -56,11 +56,6 @@
     #define AesCcmDecrypt wc_AesCcmDecrypt
 #endif /* HAVE_AESCCM */
 
-#ifdef HAVE_CAVIUM
-    #define AesInitCavium wc_AesInitCavium
-    #define AesFreeCavium wc_AesFreeCavium
-#endif
-
 #endif /* CTAO_CRYPT_AES_H */
 #endif /* NO_AES */
 

--- a/cyassl/ctaocrypt/arc4.h
+++ b/cyassl/ctaocrypt/arc4.h
@@ -26,11 +26,10 @@
 /* for arc4 reverse compatibility */
 #ifndef NO_RC4
 #include <wolfssl/wolfcrypt/arc4.h>
-    #define CYASSL_ARC4_CAVIUM_MAGIC WOLFSSL_ARC4_CAVIUM_MAGIC
     #define Arc4Process wc_Arc4Process
     #define Arc4SetKey wc_Arc4SetKey
-    #define Arc4InitCavium wc_Arc4InitCavium
-    #define Arc4FreeCavium wc_Arc4FreeCavium
+    #define Arc4AsyncInit wc_Arc4AsyncInit
+    #define Arc4AsyncFree wc_Arc4AsyncFree
 #endif
 
 #endif /* CTAO_CRYPT_ARC4_H */

--- a/cyassl/ctaocrypt/des3.h
+++ b/cyassl/ctaocrypt/des3.h
@@ -39,9 +39,9 @@
 #define Des3_CbcEncrypt        wc_Des3_CbcEncrypt
 #define Des3_CbcDecrypt        wc_Des3_CbcDecrypt
 #define Des3_CbcDecryptWithKey wc_Des3_CbcDecryptWithKey
-#ifdef HAVE_CAVIUM
-    #define Des3_InitCavium wc_Des3_InitCavium
-    #define Des3_FreeCavium wc_Des3_FreeCavium
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #define Des3AsyncInit wc_Des3AsyncInit
+    #define Des3AsyncFree wc_Des3AsyncFree
 #endif
 
 #endif /* NO_DES3 */

--- a/cyassl/ctaocrypt/hmac.h
+++ b/cyassl/ctaocrypt/hmac.h
@@ -30,9 +30,9 @@
 #define HmacSetKey wc_HmacSetKey
 #define HmacUpdate wc_HmacUpdate
 #define HmacFinal  wc_HmacFinal
-#ifdef HAVE_CAVIUM
-    #define HmacInitCavium wc_HmacInitCavium
-    #define HmacFreeCavium wc_HmacFreeCavium
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #define HmacAsyncInit wc_HmacAsyncInit
+    #define HmacAsyncFree wc_HmacAsyncFree
 #endif
 #define CyaSSL_GetHmacMaxSize wolfSSL_GetHmacMaxSize
 #ifdef HAVE_HKDF

--- a/cyassl/ctaocrypt/rsa.h
+++ b/cyassl/ctaocrypt/rsa.h
@@ -47,9 +47,9 @@
     #define RsaKeyToDer wc_RsaKeyToDer
 #endif
 
-#ifdef HAVE_CAVIUM
-    #define RsaInitCavium wc_RsaInitCavium
-    #define RsaFreeCavium wc_RsaFreeCavium
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #define RsaAsyncInit wc_RsaAsyncInit
+    #define RsaAsyncFree wc_RsaAsyncFree
 #endif
 
 #endif /* CTAO_CRYPT_RSA_H */

--- a/src/include.am
+++ b/src/include.am
@@ -63,7 +63,12 @@ src_libwolfssl_la_SOURCES += \
                wolfcrypt/src/hmac.c \
                wolfcrypt/src/random.c \
                wolfcrypt/src/sha256.c \
-               wolfcrypt/src/hash.c
+               wolfcrypt/src/hash.c \
+               wolfcrypt/src/wolfevent.c
+
+if BUILD_ASYNCCRYPT
+src_libwolfssl_la_SOURCES += wolfcrypt/src/async.c
+endif
 
 if !BUILD_USER_RSA
 if BUILD_RSA
@@ -252,10 +257,6 @@ endif
 
 if BUILD_SNIFFER
 src_libwolfssl_la_SOURCES += src/sniffer.c
-endif
-
-if BUILD_ASYNCCRYPT
-src_libwolfssl_la_SOURCES += src/async.c
 endif
 
 endif # !BUILD_CRYPTONLY

--- a/src/keys.c
+++ b/src/keys.c
@@ -2070,18 +2070,18 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
             dec->arc4 = (Arc4*)XMALLOC(sizeof(Arc4), heap, DYNAMIC_TYPE_CIPHER);
         if (dec && dec->arc4 == NULL)
             return MEMORY_E;
-#ifdef HAVE_CAVIUM
-        if (devId != NO_CAVIUM_DEVICE) {
+#ifdef WOLFSSL_ASYNC_CRYPT
+        if (devId != INVALID_DEVID) {
             if (enc) {
-                if (wc_Arc4InitCavium(enc->arc4, devId) != 0) {
-                    WOLFSSL_MSG("Arc4InitCavium failed in SetKeys");
-                    return CAVIUM_INIT_E;
+                if (wc_Arc4AsyncInit(enc->arc4, devId) != 0) {
+                    WOLFSSL_MSG("Arc4AsyncInit failed in SetKeys");
+                    return ASYNC_INIT_E;
                 }
             }
             if (dec) {
-                if (wc_Arc4InitCavium(dec->arc4, devId) != 0) {
-                    WOLFSSL_MSG("Arc4InitCavium failed in SetKeys");
-                    return CAVIUM_INIT_E;
+                if (wc_Arc4AsyncInit(dec->arc4, devId) != 0) {
+                    WOLFSSL_MSG("Arc4AsyncInit failed in SetKeys");
+                    return ASYNC_INIT_E;
                 }
             }
         }
@@ -2282,18 +2282,18 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
             dec->des3 = (Des3*)XMALLOC(sizeof(Des3), heap, DYNAMIC_TYPE_CIPHER);
         if (dec && dec->des3 == NULL)
             return MEMORY_E;
-#ifdef HAVE_CAVIUM
-        if (devId != NO_CAVIUM_DEVICE) {
+#ifdef WOLFSSL_ASYNC_CRYPT
+        if (devId != INVALID_DEVID) {
             if (enc) {
-                if (wc_Des3_InitCavium(enc->des3, devId) != 0) {
-                    WOLFSSL_MSG("Des3_InitCavium failed in SetKeys");
-                    return CAVIUM_INIT_E;
+                if (wc_Des3AsyncInit(enc->des3, devId) != 0) {
+                    WOLFSSL_MSG("Des3AsyncInit failed in SetKeys");
+                    return ASYNC_INIT_E;
                 }
             }
             if (dec) {
-                if (wc_Des3_InitCavium(dec->des3, devId) != 0) {
-                    WOLFSSL_MSG("Des3_InitCavium failed in SetKeys");
-                    return CAVIUM_INIT_E;
+                if (wc_Des3AsyncInit(dec->des3, devId) != 0) {
+                    WOLFSSL_MSG("Des3AsyncInit failed in SetKeys");
+                    return ASYNC_INIT_E;
                 }
             }
         }
@@ -2346,18 +2346,18 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
             dec->aes = (Aes*)XMALLOC(sizeof(Aes), heap, DYNAMIC_TYPE_CIPHER);
         if (dec && dec->aes == NULL)
             return MEMORY_E;
-#ifdef HAVE_CAVIUM
-        if (devId != NO_CAVIUM_DEVICE) {
+#ifdef WOLFSSL_ASYNC_CRYPT
+        if (devId != INVALID_DEVID) {
             if (enc) {
-                if (wc_AesInitCavium(enc->aes, devId) != 0) {
-                    WOLFSSL_MSG("AesInitCavium failed in SetKeys");
-                    return CAVIUM_INIT_E;
+                if (wc_AesAsyncInit(enc->aes, devId) != 0) {
+                    WOLFSSL_MSG("AesAsyncInit failed in SetKeys");
+                    return ASYNC_INIT_E;
                 }
             }
             if (dec) {
-                if (wc_AesInitCavium(dec->aes, devId) != 0) {
-                    WOLFSSL_MSG("AesInitCavium failed in SetKeys");
-                    return CAVIUM_INIT_E;
+                if (wc_AesAsyncInit(dec->aes, devId) != 0) {
+                    WOLFSSL_MSG("AesAsyncInit failed in SetKeys");
+                    return ASYNC_INIT_E;
                 }
             }
         }
@@ -2675,14 +2675,14 @@ static int SetAuthKeys(OneTimeAuth* authentication, Keys* keys,
  */
 int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
 {
-    int devId = NO_CAVIUM_DEVICE, ret, copy = 0;
+    int devId = INVALID_DEVID, ret, copy = 0;
     Ciphers* wc_encrypt = NULL;
     Ciphers* wc_decrypt = NULL;
     Keys*    keys    = &ssl->keys;
 
     (void)copy;
 
-#ifdef HAVE_CAVIUM
+#ifdef WOLFSSL_ASYNC_CRYPT
     devId = ssl->devId;
 #endif
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1084,10 +1084,10 @@ int wolfSSL_read(WOLFSSL* ssl, void* data, int sz)
 }
 
 
-#ifdef HAVE_CAVIUM
+#ifdef WOLFSSL_ASYNC_CRYPT
 
-/* let's use cavium, SSL_SUCCESS on ok */
-int wolfSSL_UseCavium(WOLFSSL* ssl, int devId)
+/* let's use async hardware, SSL_SUCCESS on ok */
+int wolfSSL_UseAsync(WOLFSSL* ssl, int devId)
 {
     if (ssl == NULL)
         return BAD_FUNC_ARG;
@@ -1098,8 +1098,8 @@ int wolfSSL_UseCavium(WOLFSSL* ssl, int devId)
 }
 
 
-/* let's use cavium, SSL_SUCCESS on ok */
-int wolfSSL_CTX_UseCavium(WOLFSSL_CTX* ctx, int devId)
+/* let's use async hardware, SSL_SUCCESS on ok */
+int wolfSSL_CTX_UseAsync(WOLFSSL_CTX* ctx, int devId)
 {
     if (ctx == NULL)
         return BAD_FUNC_ARG;
@@ -1109,8 +1109,7 @@ int wolfSSL_CTX_UseCavium(WOLFSSL_CTX* ctx, int devId)
     return SSL_SUCCESS;
 }
 
-
-#endif /* HAVE_CAVIUM */
+#endif /* WOLFSSL_ASYNC_CRYPT */
 
 #ifdef HAVE_SNI
 
@@ -18976,119 +18975,5 @@ void* wolfSSL_get_jobject(WOLFSSL* ssl)
 }
 
 #endif /* WOLFSSL_JNI */
-
-#ifdef HAVE_WOLF_EVENT
-static int _wolfSSL_CTX_poll(WOLFSSL_CTX* ctx, WOLFSSL* ssl, WOLF_EVENT* events,
-    int maxEvents, unsigned char flags, int* eventCount)
-{
-    WOLF_EVENT* event, *event_prev = NULL;
-    int count = 0, ret = SSL_ERROR_NONE;
-
-    if (ctx == NULL || maxEvents <= 0) {
-        return BAD_FUNC_ARG;
-    }
-
-    /* Events arg can be NULL only if peek */
-    if (events == NULL && !(flags & WOLF_POLL_FLAG_PEEK)) {
-        return BAD_FUNC_ARG;
-    }
-
-#ifndef SINGLE_THREADED
-    /* In single threaded mode "event_queue.lock" doesn't exist */
-    if (LockMutex(&ctx->event_queue.lock) != 0) {
-        return BAD_MUTEX_E;
-    }
-#endif
-
-    /* Itterate event queue */
-    for (event = ctx->event_queue.head; event != NULL; event = event->next)
-    {
-        byte removeEvent = 0;
-
-        /* Optionally filter by ssl object pointer */
-        if (ssl == NULL || (ssl == event->ssl)) {
-            if (flags & WOLF_POLL_FLAG_PEEK) {
-                if (events) {
-                    /* Copy event data to provided buffer */
-                    XMEMCPY(&events[count], event, sizeof(WOLF_EVENT));
-                }
-                count++;
-            }
-            else {
-                /* Check hardware */
-                if (flags & WOLF_POLL_FLAG_CHECK_HW) {
-                #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (event->type >= WOLF_EVENT_TYPE_ASYNC_FIRST &&
-                        event->type <= WOLF_EVENT_TYPE_ASYNC_LAST)
-                    {
-                        ret = wolfSSL_async_poll(event, flags);
-                    }
-                #endif /* WOLFSSL_ASYNC_CRYPT */
-                }
-
-                /* If event is done then return in 'events' argument */
-                if (event->done) {
-                    /* Copy event data to provided buffer */
-                    XMEMCPY(&events[count], event, sizeof(WOLF_EVENT));
-                    count++;
-                    removeEvent = 1;
-                }
-            }
-        }
-
-        if (removeEvent) {
-            /* Remove from queue list */
-            if (event_prev == NULL) {
-                ctx->event_queue.head = event->next;
-                if (ctx->event_queue.head == NULL) {
-                    ctx->event_queue.tail = NULL;
-                }
-            }
-            else {
-                event_prev->next = event->next;
-            }
-        }
-        else {
-            /* Leave in queue, save prev pointer */
-            event_prev = event;
-        }
-
-        /* Check to make sure our event list isn't full */
-        if (events && count >= maxEvents) {
-            break; /* Exit for */
-        }
-
-        /* Check for error */
-        if (ret < 0) {
-            break; /* Exit for */
-        }
-    }
-
-#ifndef SINGLE_THREADED
-    UnLockMutex(&ctx->event_queue.lock);
-#endif
-
-    /* Return number of properly populated events */
-    if (eventCount) {
-        *eventCount = count;
-    }
-
-    return ret;
-}
-
-int wolfSSL_CTX_poll(WOLFSSL_CTX* ctx, WOLF_EVENT* events,
-    int maxEvents, unsigned char flags, int* eventCount)
-{
-    return _wolfSSL_CTX_poll(ctx, NULL, events, maxEvents, flags, eventCount);
-}
-
-int wolfSSL_poll(WOLFSSL* ssl, WOLF_EVENT* events,
-    int maxEvents, unsigned char flags, int* eventCount)
-{
-    return _wolfSSL_CTX_poll(ssl->ctx, ssl, events, maxEvents, flags,
-        eventCount);
-}
-
-#endif /* HAVE_WOLF_EVENT */
 
 #endif /* WOLFCRYPT_ONLY */

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -54,11 +54,6 @@ int unit_test(int argc, char** argv)
 #if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND)
     wolfSSL_Debugging_ON();
 #endif
-#ifdef HAVE_CAVIUM
-    ret = OpenNitroxDevice(CAVIUM_DIRECT, CAVIUM_DEV_ID);
-    if (ret != 0)
-        err_sys("Cavium OpenNitroxDevice failed");
-#endif /* HAVE_CAVIUM */
 
 #ifdef HAVE_WNR
     if (wc_InitNetRandom(wnrConfig, NULL, 5000) != 0)
@@ -84,10 +79,6 @@ int unit_test(int argc, char** argv)
 #endif
 
     SrpTest();
-
-#ifdef HAVE_CAVIUM
-        CspShutdown(CAVIUM_DEV_ID);
-#endif
 
 #ifdef HAVE_WNR
     if (wc_FreeNetRandom() < 0)

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -84,12 +84,6 @@ int testsuite_test(int argc, char** argv)
     int num = 6;
 #endif
 
-#ifdef HAVE_CAVIUM
-        int ret = OpenNitroxDevice(CAVIUM_DIRECT, CAVIUM_DEV_ID);
-        if (ret != 0)
-            err_sys("Cavium OpenNitroxDevice failed");
-#endif /* HAVE_CAVIUM */
-
 #ifdef HAVE_WNR
         if (wc_InitNetRandom(wnrConfig, NULL, 5000) != 0) {
             err_sys("Whitewood netRandom global config failed");
@@ -202,10 +196,6 @@ int testsuite_test(int argc, char** argv)
 
 #ifdef WOLFSSL_TIRTOS
     fdCloseSession(Task_self());
-#endif
-
-#ifdef HAVE_CAVIUM
-        CspShutdown(CAVIUM_DEV_ID);
 #endif
 
 #ifdef HAVE_WNR

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -45,6 +45,7 @@
     #include <stdio.h>
 #endif
 
+#include <wolfssl/internal.h>
 #include <wolfssl/wolfcrypt/random.h>
 #include <wolfssl/wolfcrypt/des3.h>
 #include <wolfssl/wolfcrypt/arc4.h>
@@ -77,15 +78,16 @@
 #endif
 
 #include <wolfssl/wolfcrypt/dh.h>
-#ifdef HAVE_CAVIUM
-    #include "cavium_sysdep.h"
-    #include "cavium_common.h"
-    #include "cavium_ioctl.h"
-#endif
 #ifdef HAVE_NTRU
     #include "libntruencrypt/ntru_crypto.h"
 #endif
 #include <wolfssl/wolfcrypt/random.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+    static int devId = INVALID_DEVID;
+#endif
 
 #ifdef HAVE_WNR
     const char* wnrConfigFile = "wnr-example.conf";
@@ -161,6 +163,9 @@ void bench_ripemd(void);
 void bench_cmac(void);
 
 void bench_rsa(void);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    void bench_rsa_async(void);
+#endif
 void bench_rsaKeyGen(void);
 void bench_dh(void);
 #ifdef HAVE_ECC
@@ -188,33 +193,6 @@ void bench_rng(void);
 
 double current_time(int);
 
-
-#ifdef HAVE_CAVIUM
-
-static int OpenNitroxDevice(int dma_mode,int dev_id)
-{
-   Csp1CoreAssignment core_assign;
-   Uint32             device;
-
-   if (CspInitialize(CAVIUM_DIRECT,CAVIUM_DEV_ID))
-      return -1;
-   if (Csp1GetDevType(&device))
-      return -1;
-   if (device != NPX_DEVICE) {
-      if (ioctl(gpkpdev_hdlr[CAVIUM_DEV_ID], IOCTL_CSP1_GET_CORE_ASSIGNMENT,
-                (Uint32 *)&core_assign)!= 0)
-         return -1;
-   }
-   CspShutdown(CAVIUM_DEV_ID);
-
-   return CspInitialize(dma_mode, dev_id);
-}
-
-#endif
-
-#if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND)
-    WOLFSSL_API int wolfSSL_Debugging_ON();
-#endif
 
 #if !defined(NO_RSA) || !defined(NO_DH) \
                         || defined(WOLFSSL_KEYGEN) || defined(HAVE_ECC) \
@@ -274,29 +252,28 @@ int benchmark_test(void *args)
 
     wolfCrypt_Init();
 
-    #if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND)
-        wolfSSL_Debugging_ON();
-    #endif
+#if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND)
+    wolfSSL_Debugging_ON();
+#endif
 
     (void)plain;
     (void)cipher;
     (void)key;
     (void)iv;
 
-	#ifdef HAVE_CAVIUM
-    int ret = OpenNitroxDevice(CAVIUM_DIRECT, CAVIUM_DEV_ID);
-    if (ret != 0) {
-        printf("Cavium OpenNitroxDevice failed\n");
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if (wolfAsync_DevOpen(&devId) != 0) {
+        printf("Async device open failed\n");
         exit(-1);
     }
-    #endif /* HAVE_CAVIUM */
+#endif /* WOLFSSL_ASYNC_CRYPT */
 
-    #ifdef HAVE_WNR
+#ifdef HAVE_WNR
     if (wc_InitNetRandom(wnrConfigFile, NULL, 5000) != 0) {
         printf("Whitewood netRandom config init failed\n");
         exit(-1);
     }
-    #endif /* HAVE_WNR */
+#endif /* HAVE_WNR */
 
 #if defined(HAVE_LOCAL_RNG)
     {
@@ -384,14 +361,16 @@ int benchmark_test(void *args)
 
 #ifndef NO_RSA
     bench_rsa();
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        bench_rsa_async();
+    #endif
+    #ifdef WOLFSSL_KEY_GEN
+        bench_rsaKeyGen();
+    #endif
 #endif
 
 #ifndef NO_DH
     bench_dh();
-#endif
-
-#if defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)
-    bench_rsaKeyGen();
 #endif
 
 #ifdef HAVE_NTRU
@@ -426,6 +405,10 @@ int benchmark_test(void *args)
     wc_FreeRng(&rng);
 #endif
 
+#ifdef WOLFSSL_ASYNC_CRYPT
+    wolfAsync_DevClose(&devId);
+#endif
+
 #ifdef HAVE_WNR
     if (wc_FreeNetRandom() < 0) {
         printf("Failed to free netRandom context\n");
@@ -452,9 +435,15 @@ static const char blockType[] = "kB";   /* used in printf output */
 #else
 enum BenchmarkBounds {
     numBlocks  = 50,  /* how many megs to test (en/de)cryption */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    ntimes     = 1000,
+    genTimes   = 1000,
+    agreeTimes = 1000
+#else
     ntimes     = 100,
     genTimes   = 100,
     agreeTimes = 100
+#endif
 };
 static const char blockType[] = "megs"; /* used in printf output */
 #endif
@@ -526,9 +515,9 @@ void bench_aes(int show)
     int    i;
     int    ret;
 
-#ifdef HAVE_CAVIUM
-    if (wc_AesInitCavium(&enc, CAVIUM_DEV_ID) != 0) {
-        printf("aes init cavium failed\n");
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if ((ret = wc_AesAsyncInit(&enc, devId)) != 0) {
+        printf("wc_AesAsyncInit failed, ret = %d\n", ret);
         return;
     }
 #endif
@@ -559,10 +548,10 @@ void bench_aes(int show)
         SHOW_INTEL_CYCLES
         printf("\n");
     }
-#ifdef HAVE_CAVIUM
-    wc_AesFreeCavium(&enc);
-    if (wc_AesInitCavium(&enc, CAVIUM_DEV_ID) != 0) {
-        printf("aes init cavium failed\n");
+#ifdef WOLFSSL_ASYNC_CRYPT
+    wc_AesAsyncFree(&enc);
+    if ((ret = wc_AesAsyncInit(&enc, devId)) != 0) {
+        printf("wc_AesAsyncInit failed, ret = %d\n", ret);
         return;
     }
 #endif
@@ -593,8 +582,8 @@ void bench_aes(int show)
         SHOW_INTEL_CYCLES
         printf("\n");
     }
-#ifdef HAVE_CAVIUM
-    wc_AesFreeCavium(&enc);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    wc_AesAsyncFree(&enc);
 #endif
 }
 #endif /* HAVE_AES_CBC */
@@ -805,9 +794,9 @@ void bench_des(void)
     double start, total, persec;
     int    i, ret;
 
-#ifdef HAVE_CAVIUM
-    if (wc_Des3_InitCavium(&enc, CAVIUM_DEV_ID) != 0)
-        printf("des3 init cavium failed\n");
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if (wc_Des3AsyncInit(&enc, devId) != 0)
+        printf("des3 async init failed\n");
 #endif
     ret = wc_Des3_SetKey(&enc, key, iv, DES_ENCRYPTION);
     if (ret != 0) {
@@ -833,8 +822,8 @@ void bench_des(void)
                                               blockType, total, persec);
     SHOW_INTEL_CYCLES
     printf("\n");
-#ifdef HAVE_CAVIUM
-    wc_Des3_FreeCavium(&enc);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    wc_Des3AsyncFree(&enc);
 #endif
 }
 #endif
@@ -882,9 +871,9 @@ void bench_arc4(void)
     double start, total, persec;
     int    i;
 
-#ifdef HAVE_CAVIUM
-    if (wc_Arc4InitCavium(&enc, CAVIUM_DEV_ID) != 0)
-        printf("arc4 init cavium failed\n");
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if (wc_Arc4AsyncInit(&enc, devId) != 0)
+        printf("arc4 async init failed\n");
 #endif
 
     wc_Arc4SetKey(&enc, key, 16);
@@ -906,8 +895,8 @@ void bench_arc4(void)
                                               blockType, total, persec);
     SHOW_INTEL_CYCLES
     printf("\n");
-#ifdef HAVE_CAVIUM
-    wc_Arc4FreeCavium(&enc);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    wc_Arc4AsyncFree(&enc);
 #endif
 }
 #endif
@@ -1395,7 +1384,7 @@ void bench_rsa(void)
     word32 idx = 0;
     const byte* tmp;
 
-    byte      message[] = "Everyone gets Friday off.";
+    const byte message[] = "Everyone gets Friday off.";
     byte      enc[256];  /* for up to 2048 bit */
     const int len = (int)strlen((char*)message);
     double    start, total, each, milliEach;
@@ -1414,55 +1403,253 @@ void bench_rsa(void)
     #error "need a cert buffer size"
 #endif /* USE_CERT_BUFFERS */
 
-
-#ifdef HAVE_CAVIUM
-    if (wc_RsaInitCavium(&rsaKey, CAVIUM_DEV_ID) != 0)
-        printf("RSA init cavium failed\n");
-#endif
-    ret = wc_InitRsaKey(&rsaKey, 0);
-    if (ret < 0) {
-        printf("InitRsaKey failed\n");
+    if ((ret = wc_InitRsaKey(&rsaKey, 0)) < 0) {
+        printf("InitRsaKey failed! %d\n", ret);
         return;
     }
+
+    /* decode the private key */
     ret = wc_RsaPrivateKeyDecode(tmp, &idx, &rsaKey, (word32)bytes);
 
     start = current_time(1);
 
-    for (i = 0; i < ntimes; i++)
-        ret = wc_RsaPublicEncrypt(message,len,enc,sizeof(enc), &rsaKey, &rng);
+    for (i = 0; i < ntimes; i++) {
+        ret = wc_RsaPublicEncrypt(message, len, enc, sizeof(enc),
+                                                        &rsaKey, &rng);
+        if (ret < 0) {
+            break;
+        }
+    } /* for ntimes */
 
     total = current_time(0) - start;
     each  = total / ntimes;   /* per second   */
     milliEach = each * 1000; /* milliseconds */
 
-    printf("RSA %d encryption took %6.3f milliseconds, avg over %d"
+    printf("RSA %d public          %6.3f milliseconds, avg over %d"
            " iterations\n", rsaKeySz, milliEach, ntimes);
 
     if (ret < 0) {
-        printf("Rsa Public Encrypt failed\n");
+        printf("Rsa Public Encrypt failed! %d\n", ret);
         return;
     }
 
+
     start = current_time(1);
+    
+    /* capture resulting encrypt length */
+    idx = ret;
 
     for (i = 0; i < ntimes; i++) {
-         byte  out[256];  /* for up to 2048 bit */
-         wc_RsaPrivateDecrypt(enc, (word32)ret, out, sizeof(out), &rsaKey);
-    }
+        byte  out[256];  /* for up to 2048 bit */
+
+        ret = wc_RsaPrivateDecrypt(enc, idx, out, sizeof(out), &rsaKey);
+        if (ret < 0 && ret != WC_PENDING_E) {
+            break;
+        }
+    } /* for ntimes */
 
     total = current_time(0) - start;
     each  = total / ntimes;   /* per second   */
     milliEach = each * 1000; /* milliseconds */
 
-    printf("RSA %d decryption took %6.3f milliseconds, avg over %d"
+    printf("RSA %d private         %6.3f milliseconds, avg over %d"
            " iterations\n", rsaKeySz, milliEach, ntimes);
 
     wc_FreeRsaKey(&rsaKey);
-#ifdef HAVE_CAVIUM
-    wc_RsaFreeCavium(&rsaKey);
-#endif
 }
-#endif
+
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+void bench_rsa_async(void)
+{
+    int    i;
+    int    ret;
+    size_t bytes;
+    word32 idx = 0;
+    const byte* tmp;
+
+    const byte message[] = "Everyone gets Friday off.";
+    byte      enc[256];  /* for up to 2048 bit */
+    const int len = (int)strlen((char*)message);
+    double    start, total, each, milliEach;
+
+    RsaKey rsaKey[WOLF_ASYNC_MAX_PENDING];
+    int    rsaKeySz = 2048; /* used in printf */
+
+    WOLF_EVENT events[WOLF_ASYNC_MAX_PENDING];
+    WOLF_EVENT_QUEUE eventQueue;
+    int evtNum, asyncDone, asyncPend;
+
+#ifdef USE_CERT_BUFFERS_1024
+    tmp = rsa_key_der_1024;
+    bytes = sizeof_rsa_key_der_1024;
+    rsaKeySz = 1024;
+#elif defined(USE_CERT_BUFFERS_2048)
+    tmp = rsa_key_der_2048;
+    bytes = sizeof_rsa_key_der_2048;
+#else
+    #error "need a cert buffer size"
+#endif /* USE_CERT_BUFFERS */
+
+    /* init event queue */
+    ret = wolfEventQueue_Init(&eventQueue);
+    if (ret != 0) {
+        return;
+    }
+
+    /* clear for done cleanup */
+    XMEMSET(&events, 0, sizeof(events));
+    XMEMSET(&rsaKey, 0, sizeof(rsaKey));
+
+    /* init events and keys */
+    for (i = 0; i < WOLF_ASYNC_MAX_PENDING; i++) {
+        /* setup an async context for each key */
+        if ((ret = wc_RsaAsyncInit(&rsaKey[i], devId)) != 0) {
+            goto done;
+        }
+        if ((ret = wc_InitRsaKey(&rsaKey[i], 0)) < 0) {
+            goto done;
+        }
+        if ((ret = wolfAsync_EventInit(&events[i],
+                WOLF_EVENT_TYPE_ASYNC_WOLFCRYPT, &rsaKey[i].asyncDev)) != 0) {
+            goto done;
+        }
+        events[i].pending = 0; /* Reset pending flag */
+
+        /* decode the private key */
+        idx = 0;
+        if ((ret = wc_RsaPrivateKeyDecode(tmp, &idx, &rsaKey[i],
+                                                        (word32)bytes)) != 0) {
+            printf("wc_RsaPrivateKeyDecode failed! %d\n", ret);
+            goto done;
+        }
+    }
+
+    /* begin public async RSA */
+    start = current_time(1);
+
+    asyncPend = 0;
+    for (i = 0; i < ntimes; ) {
+
+        /* while free pending slots in queue, submit RSA operations */
+        for (evtNum = 0; evtNum < WOLF_ASYNC_MAX_PENDING; evtNum++) {
+            if (events[evtNum].done || (events[evtNum].pending == 0 && 
+                                                    (i + asyncPend) < ntimes))
+            {
+                ret = wc_RsaPublicEncrypt(message, len, enc, sizeof(enc),
+                                                        &rsaKey[evtNum], &rng);
+                if (ret == WC_PENDING_E) {
+                    ret = wc_RsaAsyncHandle(&rsaKey[evtNum], &eventQueue,
+                                                            &events[evtNum]);
+                    if (ret != 0) goto done;
+                    asyncPend++;
+                }
+                else if (ret >= 0) {
+                    /* operation completed */
+                    i++;
+                    asyncPend--;
+                    events[evtNum].done = 0;
+                }
+                else {
+                    printf("wc_RsaPublicEncrypt failed: %d\n", ret);
+                    goto done;
+                }
+            }
+        } /* for evtNum */
+
+        /* poll until there are events done */
+        if (asyncPend > 0) {
+            do {
+                ret = wolfAsync_EventQueue_Poll(&eventQueue, NULL, NULL, 0,
+                                        WOLF_POLL_FLAG_CHECK_HW, &asyncDone);
+                if (ret != 0) goto done;
+            } while (asyncDone == 0);
+        }
+    } /* for ntimes */
+
+    total = current_time(0) - start;
+    each  = total / ntimes;   /* per second   */
+    milliEach = each * 1000; /* milliseconds */
+
+    printf("RSA %d public async    %6.3f milliseconds, avg over %d"
+           " iterations\n", rsaKeySz, milliEach, ntimes);
+
+    if (ret < 0) {
+        goto done;
+    }
+
+
+    /* begin private async RSA */
+    start = current_time(1);
+    
+    /* capture resulting encrypt length */
+    idx = sizeof(enc); /* fixed at 2048 bit */
+
+    asyncPend = 0;
+    for (i = 0; i < ntimes; ) {
+        byte  out[256];  /* for up to 2048 bit */
+
+        /* while free pending slots in queue, submit RSA operations */
+        for (evtNum = 0; evtNum < WOLF_ASYNC_MAX_PENDING; evtNum++) {
+            if (events[evtNum].done || (events[evtNum].pending == 0 && 
+                                                    (i + asyncPend) < ntimes))
+            {
+                ret = wc_RsaPrivateDecrypt(enc, idx, out, sizeof(out),
+                                                            &rsaKey[evtNum]);
+                if (ret == WC_PENDING_E) {
+                    ret = wc_RsaAsyncHandle(&rsaKey[evtNum], &eventQueue,
+                                                            &events[evtNum]);
+                    if (ret != 0) goto done;
+                    asyncPend++;
+                }
+                else if (ret == 0) {
+                    /* operation completed */
+                    i++;
+                    asyncPend--;
+                    events[evtNum].done = 0;
+                }
+                else {
+                    printf("wc_RsaPrivateDecrypt failed: %d\n", ret);
+                    goto done;
+                }
+            }
+        } /* for evtNum */
+
+        /* poll until there are events done */
+        if (asyncPend > 0) {
+            do {
+                ret = wolfAsync_EventQueue_Poll(&eventQueue, NULL, NULL, 0,
+                                        WOLF_POLL_FLAG_CHECK_HW, &asyncDone);
+                if (ret != 0) goto done;
+            } while (asyncDone == 0);
+        }
+    } /* for ntimes */
+
+    total = current_time(0) - start;
+    each  = total / ntimes;   /* per second   */
+    milliEach = each * 1000; /* milliseconds */
+
+    printf("RSA %d private async   %6.3f milliseconds, avg over %d"
+           " iterations\n", rsaKeySz, milliEach, ntimes);
+
+done:
+
+    if (ret < 0) {
+        printf("bench_rsa_async failed: %d\n", ret);
+    }
+
+    /* cleanup */
+    for (i = 0; i < WOLF_ASYNC_MAX_PENDING; i++) {
+        wc_RsaAsyncFree(&rsaKey[i]);
+        wc_FreeRsaKey(&rsaKey[i]);
+    }
+
+    /* free event queue */
+    wolfEventQueue_Free(&eventQueue);
+}
+#endif /* WOLFSSL_ASYNC_CRYPT */
+
+#endif /* !NO_RSA */
 
 
 #ifndef NO_DH

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -646,7 +646,7 @@ static int GetExplicitVersion(const byte* input, word32* inOutIdx, int* version)
 }
 #endif /* !NO_ASN_TIME */
 
-WOLFSSL_LOCAL int GetInt(mp_int* mpi, const byte* input, word32* inOutIdx,
+int GetInt(mp_int* mpi, const byte* input, word32* inOutIdx,
                   word32 maxIdx)
 {
     word32 i = *inOutIdx;
@@ -675,6 +675,62 @@ WOLFSSL_LOCAL int GetInt(mp_int* mpi, const byte* input, word32* inOutIdx,
     *inOutIdx = i + length;
     return 0;
 }
+
+#if !defined(NO_RSA) && !defined(HAVE_USER_RSA)
+static int GetIntRsa(RsaKey* key, mp_int* mpi, const byte* input,
+                        word32* inOutIdx, word32 maxIdx)
+{
+    word32 i = *inOutIdx;
+    byte   b = input[i++];
+    int    length;
+
+    (void)key;
+
+    if (b != ASN_INTEGER)
+        return ASN_PARSE_E;
+
+    if (GetLength(input, &i, &length, maxIdx) < 0)
+        return ASN_PARSE_E;
+
+    if ( (b = input[i++]) == 0x00)
+        length--;
+    else
+        i--;
+
+#if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
+    if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA) {
+        XMEMSET(mpi, 0, sizeof(mp_int));
+        mpi->used = length;
+    #ifdef USE_FAST_MATH
+        if (length > (FP_SIZE * (int)sizeof(fp_digit))) {
+            return MEMORY_E;
+        }
+        mpi->dpraw = (byte*)mpi->dp;
+    #else
+        mpi->dpraw = (byte*)XMALLOC(length, key->heap, DYNAMIC_TYPE_CAVIUM_RSA);
+    #endif
+        if (mpi->dpraw == NULL) {
+            return MEMORY_E;
+        }
+
+        XMEMCPY(mpi->dpraw, input + i, length);
+    }
+    else
+#endif /* WOLFSSL_ASYNC_CRYPT && HAVE_CAVIUM */
+    {
+        if (mp_init(mpi) != MP_OKAY)
+            return MP_INIT_E;
+
+        if (mp_read_unsigned_bin(mpi, (byte*)input + i, length) != 0) {
+            mp_clear(mpi);
+            return ASN_GETINT_E;
+        }
+    }
+
+    *inOutIdx = i + length;
+    return 0;
+}
+#endif /* !NO_RSA && !HAVE_USER_RSA */
 
 
 /* hashType */
@@ -1212,78 +1268,11 @@ WOLFSSL_LOCAL int GetAlgoId(const byte* input, word32* inOutIdx, word32* oid,
 
 #ifndef NO_RSA
 
-
-#ifdef HAVE_CAVIUM
-
-static int GetCaviumInt(byte** buff, word16* buffSz, const byte* input,
-                        word32* inOutIdx, word32 maxIdx, void* heap)
-{
-    word32 i = *inOutIdx;
-    byte   b = input[i++];
-    int    length;
-
-    if (b != ASN_INTEGER)
-        return ASN_PARSE_E;
-
-    if (GetLength(input, &i, &length, maxIdx) < 0)
-        return ASN_PARSE_E;
-
-    if ( (b = input[i++]) == 0x00)
-        length--;
-    else
-        i--;
-
-    *buffSz = (word16)length;
-    *buff   = XMALLOC(*buffSz, heap, DYNAMIC_TYPE_CAVIUM_RSA);
-    if (*buff == NULL)
-        return MEMORY_E;
-
-    XMEMCPY(*buff, input + i, *buffSz);
-
-    *inOutIdx = i + length;
-    return 0;
-}
-
-static int CaviumRsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
-                                     RsaKey* key, word32 inSz)
-{
-    int   version, length;
-    void* h = key->heap;
-
-    if (GetSequence(input, inOutIdx, &length, inSz) < 0)
-        return ASN_PARSE_E;
-
-    if (GetMyVersion(input, inOutIdx, &version) < 0)
-        return ASN_PARSE_E;
-
-    key->type = RSA_PRIVATE;
-
-    if (GetCaviumInt(&key->c_n,  &key->c_nSz,   input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_e,  &key->c_eSz,   input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_d,  &key->c_dSz,   input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_p,  &key->c_pSz,   input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_q,  &key->c_qSz,   input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_dP, &key->c_dP_Sz, input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_dQ, &key->c_dQ_Sz, input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_u,  &key->c_uSz,   input, inOutIdx, inSz, h) < 0 )
-            return ASN_RSA_KEY_E;
-
-    return 0;
-}
-
-
-#endif /* HAVE_CAVIUM */
-
 #ifndef HAVE_USER_RSA
 int wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
                         word32 inSz)
 {
-    int    version, length;
-
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC)
-        return CaviumRsaPrivateKeyDecode(input, inOutIdx, key, inSz);
-#endif
+    int version, length;
 
     if (GetSequence(input, inOutIdx, &length, inSz) < 0)
         return ASN_PARSE_E;
@@ -1293,14 +1282,14 @@ int wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
 
     key->type = RSA_PRIVATE;
 
-    if (GetInt(&key->n,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->e,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->d,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->p,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->q,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->dP, input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->dQ, input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->u,  input, inOutIdx, inSz) < 0 )  return ASN_RSA_KEY_E;
+    if (GetIntRsa(key, &key->n,  input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->e,  input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->d,  input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->p,  input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->q,  input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->dP, input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->dQ, input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->u,  input, inOutIdx, inSz) < 0 )  return ASN_RSA_KEY_E;
 
     return 0;
 }
@@ -3645,11 +3634,22 @@ static int ConfirmSignature(const byte* buf, word32 bufSz,
             else {
                 XMEMCPY(plain, sig, sigSz);
 
-                if ((verifySz = wc_RsaSSL_VerifyInline(plain, sigSz, &out,
-                                                                 pubKey)) < 0) {
+                ret = 0;
+                do {
+                #if defined(WOLFSSL_ASYNC_CRYPT)
+                    ret = wc_RsaAsyncWait(ret, pubKey);
+                #endif
+                    if (ret >= 0) {
+                        ret = wc_RsaSSL_VerifyInline(plain, sigSz, &out,
+                                                                    pubKey);
+                    }
+                } while (ret == WC_PENDING_E);
+
+                if (ret < 0) {
                     WOLFSSL_MSG("Rsa SSL verify error");
                 }
                 else {
+                    verifySz = ret;
                     /* make sure we're right justified */
                     encodedSigSz =
                         wc_EncodeSignature(encodedSig, digest, digestSz, typeH);
@@ -7246,7 +7246,15 @@ static int MakeSignature(const byte* buffer, int sz, byte* sig, int sigSz,
     if (rsaKey) {
         /* signature */
         encSigSz = wc_EncodeSignature(encSig, digest, digestSz, typeH);
-        ret = wc_RsaSSL_Sign(encSig, encSigSz, sig, sigSz, rsaKey, rng);
+        ret = 0;
+        do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+            ret = wc_RsaAsyncWait(ret, rsaKey);
+#endif
+            if (ret >= 0) {
+                ret = wc_RsaSSL_Sign(encSig, encSigSz, sig, sigSz, rsaKey, rng);
+            }
+        } while (ret == WC_PENDING_E);
     }
 #endif
 

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -62,6 +62,15 @@ const char* wc_GetErrorString(int error)
     case BAD_MUTEX_E :
         return "Bad mutex, operation failed";
 
+    case WC_TIMEOUT_E:
+        return "Timeout error";
+
+    case WC_PENDING_E:
+        return "wolfCrypt Operation Pending (would block / eagain) error";
+
+    case WC_NOT_PENDING_E:
+        return "wolfCrypt operation not pending error";
+
     case MP_INIT_E :
         return "mp_init error state";
 
@@ -227,8 +236,8 @@ const char* wc_GetErrorString(int error)
     case AES_CCM_AUTH_E:
         return "AES-CCM Authentication check fail";
 
-    case CAVIUM_INIT_E:
-        return "Cavium Init type error";
+    case ASYNC_INIT_E:
+        return "Async Init error";
 
     case COMPRESS_INIT_E:
         return "Compress Init error";
@@ -257,8 +266,8 @@ const char* wc_GetErrorString(int error)
     case ASN_OCSP_CONFIRM_E :
         return "ASN OCSP sig error, confirm failure";
 
-    case BAD_ENC_STATE_E:
-        return "Bad ecc encrypt state operation";
+    case BAD_STATE_E:
+        return "Bad state operation";
 
     case BAD_PADDING_E:
         return "Bad padding, message wrong length";
@@ -376,9 +385,6 @@ const char* wc_GetErrorString(int error)
 
     case HASH_TYPE_E:
         return "Hash type not enabled/available";
-
-    case WC_PENDING_E:
-        return "wolfCrypt Operation Pending (would block / eagain) error";
 
     case WC_KEY_SIZE_E:
         return "Key size error, either too small or large";

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -50,16 +50,16 @@ int wc_HmacFinal(Hmac* hmac, byte* out)
 }
 
 
-#ifdef HAVE_CAVIUM
-    int  wc_HmacInitCavium(Hmac* hmac, int i)
+#ifdef WOLFSSL_ASYNC_CRYPT
+    int  wc_HmacAsyncInit(Hmac* hmac, int i)
     {
-        return HmacInitCavium(hmac, i);
+        return HmacAsyncInit(hmac, i);
     }
 
 
-    void wc_HmacFreeCavium(Hmac* hmac)
+    void wc_HmacAsyncFree(Hmac* hmac)
     {
-        HmacFreeCavium(hmac);
+        HmacAsyncFree(hmac);
     }
 #endif
 
@@ -105,12 +105,48 @@ int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 
-#ifdef HAVE_CAVIUM
-    static int HmacCaviumFinal(Hmac* hmac, byte* hash);
-    static int HmacCaviumUpdate(Hmac* hmac, const byte* msg, word32 length);
-    static int HmacCaviumSetKey(Hmac* hmac, int type, const byte* key,
-                                word32 length);
-#endif
+int wc_HmacSizeByType(int type)
+{
+    if (!(type == MD5 || type == SHA    || type == SHA256 || type == SHA384
+                      || type == SHA512 || type == BLAKE2B_ID)) {
+        return BAD_FUNC_ARG;
+    }
+
+    switch (type) {
+    #ifndef NO_MD5
+        case MD5:
+            return MD5_DIGEST_SIZE;
+    #endif
+
+    #ifndef NO_SHA
+        case SHA:
+            return SHA_DIGEST_SIZE;
+    #endif
+
+    #ifndef NO_SHA256
+        case SHA256:
+            return SHA256_DIGEST_SIZE;
+    #endif
+
+    #ifdef WOLFSSL_SHA384
+        case SHA384:
+            return SHA384_DIGEST_SIZE;
+    #endif
+
+    #ifdef WOLFSSL_SHA512
+        case SHA512:
+            return SHA512_DIGEST_SIZE;
+    #endif
+
+    #ifdef HAVE_BLAKE2
+        case BLAKE2B_ID:
+            return BLAKE2B_OUTBYTES;
+    #endif
+
+        default:
+            return BAD_FUNC_ARG;
+    }
+}
 
 static int InitHmac(Hmac* hmac, int type)
 {
@@ -175,9 +211,10 @@ int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
     word32 i, hmac_block_size = 0;
     int    ret;
 
-#ifdef HAVE_CAVIUM
-    if (hmac->magic == WOLFSSL_HMAC_CAVIUM_MAGIC)
-        return HmacCaviumSetKey(hmac, type, key, length);
+#if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
+    if (hmac->asyncDev.marker == WOLFSSL_ASYNC_MARKER_HMAC) {
+        return NitroxHmacSetKey(hmac, type, key, length);
+    }
 #endif
 
     ret = InitHmac(hmac, type);
@@ -391,9 +428,10 @@ int wc_HmacUpdate(Hmac* hmac, const byte* msg, word32 length)
 {
     int ret;
 
-#ifdef HAVE_CAVIUM
-    if (hmac->magic == WOLFSSL_HMAC_CAVIUM_MAGIC)
-        return HmacCaviumUpdate(hmac, msg, length);
+#if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
+    if (hmac->asyncDev.marker == WOLFSSL_ASYNC_MARKER_HMAC) {
+        return NitroxHmacUpdate(hmac, msg, length);
+    }
 #endif
 
     if (!hmac->innerHashKeyed) {
@@ -459,9 +497,10 @@ int wc_HmacFinal(Hmac* hmac, byte* hash)
 {
     int ret;
 
-#ifdef HAVE_CAVIUM
-    if (hmac->magic == WOLFSSL_HMAC_CAVIUM_MAGIC)
-        return HmacCaviumFinal(hmac, hash);
+#if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
+    if (hmac->asyncDev.marker == WOLFSSL_ASYNC_MARKER_HMAC) {
+        return NitroxHmacFinal(hmac, hash);
+    }
 #endif
 
     if (!hmac->innerHashKeyed) {
@@ -606,129 +645,57 @@ int wc_HmacFinal(Hmac* hmac, byte* hash)
 }
 
 
-#ifdef HAVE_CAVIUM
+#ifdef WOLFSSL_ASYNC_CRYPT
 
 /* Initialize Hmac for use with Nitrox device */
-int wc_HmacInitCavium(Hmac* hmac, int devId)
+int wc_HmacAsyncInit(Hmac* hmac, int devId)
 {
+    int ret = 0;
+
     if (hmac == NULL)
         return -1;
 
-    if (CspAllocContext(CONTEXT_SSL, &hmac->contextHandle, devId) != 0)
-        return -1;
+    ret = wolfAsync_DevCtxInit(&hmac->asyncDev, WOLFSSL_ASYNC_MARKER_HMAC, devId);
+    if (ret != 0) {
+        return ret;
+    }
 
+#ifdef HAVE_CAVIUM
     hmac->keyLen  = 0;
     hmac->dataLen = 0;
     hmac->type    = 0;
-    hmac->devId   = devId;
-    hmac->magic   = WOLFSSL_HMAC_CAVIUM_MAGIC;
     hmac->data    = NULL;        /* buffered input data */
 
     hmac->innerHashKeyed = 0;
+#endif /* HAVE_CAVIUM */
 
     /* default to NULL heap hint or test value */
 #ifdef WOLFSSL_HEAP_TEST
     hmac->heap = (void)WOLFSSL_HEAP_TEST;
 #else
     hmac->heap = NULL;
-#endif
+#endif /* WOLFSSL_HEAP_TEST */
 
     return 0;
 }
 
 
 /* Free Hmac from use with Nitrox device */
-void wc_HmacFreeCavium(Hmac* hmac)
+void wc_HmacAsyncFree(Hmac* hmac)
 {
     if (hmac == NULL)
         return;
 
-    CspFreeContext(CONTEXT_SSL, hmac->contextHandle, hmac->devId);
-    hmac->magic = 0;
-    XFREE(hmac->data, NULL, DYNAMIC_TYPE_CAVIUM_TMP);
-    hmac->data = NULL;
-}
+    wolfAsync_DevCtxFree(&hmac->asyncDev);
 
-
-static int HmacCaviumFinal(Hmac* hmac, byte* hash)
-{
-    word32 requestId;
-
-    if (CspHmac(CAVIUM_BLOCKING, hmac->type, NULL, hmac->keyLen,
-                (byte*)hmac->ipad, hmac->dataLen, hmac->data, hash, &requestId,
-                hmac->devId) != 0) {
-        WOLFSSL_MSG("Cavium Hmac failed");
-        return -1;
-    }
-    hmac->innerHashKeyed = 0;  /* tell update to start over if used again */
-
-    return 0;
-}
-
-
-static int HmacCaviumUpdate(Hmac* hmac, const byte* msg, word32 length)
-{
-    word16 add = (word16)length;
-    word32 total;
-    byte*  tmp;
-
-    if (length > WOLFSSL_MAX_16BIT) {
-        WOLFSSL_MSG("Too big msg for cavium hmac");
-        return -1;
-    }
-
-    if (hmac->innerHashKeyed == 0) {  /* starting new */
-        hmac->dataLen        = 0;
-        hmac->innerHashKeyed = 1;
-    }
-
-    total = add + hmac->dataLen;
-    if (total > WOLFSSL_MAX_16BIT) {
-        WOLFSSL_MSG("Too big msg for cavium hmac");
-        return -1;
-    }
-
-    tmp = XMALLOC(hmac->dataLen + add, hmac->heap ,DYNAMIC_TYPE_CAVIUM_TMP);
-    if (tmp == NULL) {
-        WOLFSSL_MSG("Out of memory for cavium update");
-        return -1;
-    }
-    if (hmac->dataLen)
-        XMEMCPY(tmp, hmac->data,  hmac->dataLen);
-    XMEMCPY(tmp + hmac->dataLen, msg, add);
-
-    hmac->dataLen += add;
+#ifdef HAVE_CAVIUM
     XFREE(hmac->data, hmac->heap, DYNAMIC_TYPE_CAVIUM_TMP);
-    hmac->data = tmp;
-
-    return 0;
+    hmac->data = NULL;
+#endif
 }
 
+#endif /* WOLFSSL_ASYNC_CRYPT */
 
-static int HmacCaviumSetKey(Hmac* hmac, int type, const byte* key,
-                            word32 length)
-{
-    hmac->macType = (byte)type;
-    if (type == MD5)
-        hmac->type = MD5_TYPE;
-    else if (type == SHA)
-        hmac->type = SHA1_TYPE;
-    else if (type == SHA256)
-        hmac->type = SHA256_TYPE;
-    else  {
-        WOLFSSL_MSG("unsupported cavium hmac type");
-    }
-
-    hmac->innerHashKeyed = 0;  /* should we key Startup flag */
-
-    hmac->keyLen = (word16)length;
-    /* store key in ipad */
-    XMEMCPY(hmac->ipad, key, length);
-
-    return 0;
-}
-
-#endif /* HAVE_CAVIUM */
 
 int wolfSSL_GetHmacMaxSize(void)
 {
@@ -748,49 +715,6 @@ int wolfSSL_GetHmacMaxSize(void)
 #endif /* WOLFSSL_HAVE_MIN */
 
 
-static INLINE int GetHashSizeByType(int type)
-{
-    if (!(type == MD5 || type == SHA    || type == SHA256 || type == SHA384
-                      || type == SHA512 || type == BLAKE2B_ID))
-        return BAD_FUNC_ARG;
-
-    switch (type) {
-        #ifndef NO_MD5
-        case MD5:
-            return MD5_DIGEST_SIZE;
-        #endif
-
-        #ifndef NO_SHA
-        case SHA:
-            return SHA_DIGEST_SIZE;
-        #endif
-
-        #ifndef NO_SHA256
-        case SHA256:
-            return SHA256_DIGEST_SIZE;
-        #endif
-
-        #ifdef WOLFSSL_SHA384
-        case SHA384:
-            return SHA384_DIGEST_SIZE;
-        #endif
-
-        #ifdef WOLFSSL_SHA512
-        case SHA512:
-            return SHA512_DIGEST_SIZE;
-        #endif
-
-        #ifdef HAVE_BLAKE2
-        case BLAKE2B_ID:
-            return BLAKE2B_OUTBYTES;
-        #endif
-
-        default:
-            return BAD_FUNC_ARG;
-    }
-}
-
-
 /* HMAC-KDF with hash type, optional salt and info, return 0 on success */
 int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
                    const byte* salt,  word32 saltSz,
@@ -806,7 +730,7 @@ int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
     byte   prk[MAX_DIGEST_SIZE];
 #endif
     const  byte* localSalt;  /* either points to user input or tmp */
-    int    hashSz = GetHashSizeByType(type);
+    int    hashSz = wc_HmacSizeByType(type);
     word32 outIdx = 0;
     byte   n = 0x1;
     int    ret;
@@ -815,13 +739,13 @@ int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
         return BAD_FUNC_ARG;
 
 #ifdef WOLFSSL_SMALL_STACK
-    tmp = (byte*)XMALLOC(MAX_DIGEST_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    tmp = (byte*)XMALLOC(MAX_DIGEST_SIZE, hmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (tmp == NULL)
         return MEMORY_E;
 
-    prk = (byte*)XMALLOC(MAX_DIGEST_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    prk = (byte*)XMALLOC(MAX_DIGEST_SIZE, hmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (prk == NULL) {
-        XFREE(tmp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(tmp, hmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
         return MEMORY_E;
     }
 #endif
@@ -873,8 +797,8 @@ int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(tmp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(prk, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(tmp, hmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(prk, hmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return ret;

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -46,4 +46,8 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/pic32/pic32mz-hash.c \
               wolfcrypt/src/port/nrf51.c
 
+if BUILD_CAVIUM
+src_libwolfssl_la_SOURCES += wolfcrypt/src/port/cavium/cavium_nitrox.c
 
+EXTRA_DIST += wolfcrypt/src/port/cavium/README.md
+endif

--- a/wolfcrypt/src/port/cavium/README.md
+++ b/wolfcrypt/src/port/cavium/README.md
@@ -1,0 +1,32 @@
+# Cavium Nitrox V Support
+
+## Directory Structure:
+`/`
+    `/CNN55XX-SDK`
+    `/wolfssl`
+
+## Cavium Driver
+
+Tested again `CNN55XX-Driver-Linux-KVM-XEN-PF-SDK-0.2-04.tar`
+From inside `CNN55XX-SDK`:
+1. `make`
+    Note: To resolve warnings in `CNN55XX-SDK/include/vf_defs.h`:
+    a. Changed `vf_config_mode_str` to return `const char*` and modify `vf_mode_str` to be `const char*`.
+    b. In `vf_config_mode_to_num_vfs` above `default:` add `case PF:`.
+
+2. `sudo make load`
+
+## wolfSSL
+
+Currently the AES and DES3 benchmark tests causes the kernel to crash, so they are disabled for now, even though the wolfCrypt tests pass for those.
+
+From inside `wolfssl`:
+1. `./configure --with-cavium-v=../CNN55XX-SDK --enable-asynccrypt --enable-aesni --enable-intelasm --disable-aes --disable-aesgcm --disable-des3`
+2. `make`
+
+## Usage
+
+Note: Must run applications with sudo to access device.
+
+`sudo ./wolfcrypt/benchmark/benchmark`
+`sudo ./wolfcrypt/test/testwolfcrypt`

--- a/wolfcrypt/src/port/cavium/cavium_nitrox.c
+++ b/wolfcrypt/src/port/cavium/cavium_nitrox.c
@@ -1,0 +1,778 @@
+/* cavium-nitrox.c
+ *
+ * Copyright (C) 2006-2016 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL. (formerly known as CyaSSL)
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef HAVE_CAVIUM
+
+#include <wolfssl/wolfcrypt/random.h>
+#include <wolfssl/internal.h>
+#include <wolfssl/error-ssl.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#ifndef NO_RSA
+    #include <wolfssl/wolfcrypt/rsa.h>
+#endif
+#ifndef NO_AES
+    #include <wolfssl/wolfcrypt/aes.h>
+#endif
+
+#include <wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h>
+#include <netinet/in.h> /* For ntohs */
+
+static CspHandle mLastDevHandle = INVALID_DEVID;
+
+int NitroxTranslateResponseCode(int ret)
+{
+    switch (ret) {
+        case EAGAIN:
+        case ERR_REQ_PENDING:
+            ret = WC_PENDING_E;
+            break;
+        case ERR_REQ_TIMEOUT:
+            ret = WC_TIMEOUT_E;
+            break;
+        case 0:
+            /* leave as-is */
+            break;
+        default:
+            printf("NitroxTranslateResponseCode Unknown ret=%x\n", ret);
+            ret = ASYNC_INIT_E;
+    }
+    return ret;
+}
+
+
+CspHandle NitroxGetDeviceHandle(void)
+{
+    return mLastDevHandle;
+}
+    
+CspHandle NitroxOpenDevice(int dma_mode, int dev_id)
+{
+    mLastDevHandle = INVALID_DEVID;
+
+#ifdef HAVE_CAVIUM_V
+    (void)dma_mode;
+
+    if (CspInitialize(dev_id, &mLastDevHandle)) {
+        return -1;
+    }
+
+#else
+    Csp1CoreAssignment core_assign;
+    Uint32             device;
+
+    if (CspInitialize(CAVIUM_DIRECT, CAVIUM_DEV_ID)) {
+        return -1;
+    }
+    if (Csp1GetDevType(&device)) {
+        return -1;
+    }
+    if (device != NPX_DEVICE) {
+        if (ioctl(gpkpdev_hdlr[CAVIUM_DEV_ID], IOCTL_CSP1_GET_CORE_ASSIGNMENT,
+        (Uint32 *)&core_assign)!= 0) {
+            return -1;
+        }
+    }
+    CspShutdown(CAVIUM_DEV_ID);
+
+    mLastDevHandle = CspInitialize(dma_mode, dev_id);
+    if (mLastDevHandle == 0) {
+        mLastDevHandle = dev_id;
+    }
+
+#endif /* HAVE_CAVIUM_V */
+
+    return mLastDevHandle;
+}
+
+
+int NitroxAllocContext(CaviumNitroxDev* nitrox, CspHandle devId,
+    ContextType type)
+{
+    int ret;
+
+    if (nitrox == NULL) {
+        return -1;
+    }
+
+    /* If invalid handle provided, use last open one */
+    if (devId == INVALID_DEVID) {
+        devId = NitroxGetDeviceHandle();
+    }
+
+#ifdef HAVE_CAVIUM_V
+    ret = CspAllocContext(devId, type, &nitrox->contextHandle);
+#else
+    ret = CspAllocContext(type, &nitrox->contextHandle, devId);
+#endif
+    if (ret != 0) {
+        return -1;
+    }
+
+    nitrox->type = type;
+    nitrox->devId = devId;
+
+    return 0;
+}
+
+void NitroxFreeContext(CaviumNitroxDev* nitrox)
+{
+    if (nitrox == NULL) {
+        return;
+    }
+
+#ifdef HAVE_CAVIUM_V
+    CspFreeContext(nitrox->devId, nitrox->type, nitrox->contextHandle);
+#else
+    CspFreeContext(nitrox->type, nitrox->contextHandle, nitrox->devId);
+#endif
+}
+
+void NitroxCloseDevice(CspHandle devId)
+{
+    if (devId >= 0) {
+        CspShutdown(devId);
+    }
+}
+
+#if defined(WOLFSSL_ASYNC_CRYPT)
+
+int NitroxCheckRequest(CspHandle devId, CavReqId reqId)
+{
+    int ret = CspCheckForCompletion(devId, reqId);
+    return NitroxTranslateResponseCode(ret);
+}
+
+int NitroxCheckRequests(CspHandle devId, CspMultiRequestStatusBuffer* req_stat_buf)
+{
+    int ret = CspGetAllResults(req_stat_buf, devId);
+    return NitroxTranslateResponseCode(ret);   
+}
+
+
+#ifndef NO_RSA
+
+int NitroxRsaExptMod(const byte* in, word32 inLen,
+                     byte* exponent, word32 expLen,
+                     byte* modulus, word32 modLen,
+                     byte* out, word32* outLen, RsaKey* key)
+{
+    int ret;
+
+    if (key == NULL || in == NULL || inLen == 0 || exponent == NULL ||
+                                            modulus == NULL || out == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    (void)outLen;
+
+#ifdef HAVE_CAVIUM_V
+    ret = CspMe(key->asyncDev.dev.devId, CAVIUM_REQ_MODE, CAVIUM_SSL_GRP,
+            CAVIUM_DPORT, modLen, expLen, inLen,
+            modulus, exponent, (Uint8*)in, out,
+            &key->asyncDev.dev.reqId);
+    #if 0
+    /* TODO: Try MeCRT */
+    ret = CspMeCRT();
+    #endif
+#else
+    /* Not implemented/supported */
+    ret = NOT_COMPILED_IN;
+#endif
+    ret = NitroxTranslateResponseCode(ret);
+    if (ret != 0) {
+        return ret;
+    }
+
+    return ret;
+}
+
+int NitroxRsaPublicEncrypt(const byte* in, word32 inLen, byte* out,
+                           word32 outLen, RsaKey* key)
+{
+    word32 ret;
+
+    if (key == NULL || in == NULL || out == NULL || outLen < (word32)key->n.used) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef HAVE_CAVIUM_V
+    ret = CspPkcs1v15Enc(key->asyncDev.dev.devId, CAVIUM_REQ_MODE, CAVIUM_SSL_GRP, CAVIUM_DPORT,
+                         BT2, key->n.used, key->e.used,
+                         (word16)inLen, key->n.dpraw, key->e.dpraw, (byte*)in, out,
+                         &key->asyncDev.dev.reqId);
+#else
+    ret = CspPkcs1v15Enc(CAVIUM_REQ_MODE, BT2, key->n.used, key->e.used,
+                         (word16)inLen, key->n.dpraw, key->e.dpraw, (byte*)in, out,
+                         &key->asyncDev.dev.reqId, key->asyncDev.dev.devId);
+#endif
+    ret = NitroxTranslateResponseCode(ret);
+    if (ret != 0) {
+        return ret;
+    }
+
+    return key->n.used;
+}
+
+
+static INLINE void ato16(const byte* c, word16* u16)
+{
+    *u16 = (c[0] << 8) | (c[1]);
+}
+
+int NitroxRsaPrivateDecrypt(const byte* in, word32 inLen, byte* out,
+                            word32 outLen, RsaKey* key)
+{
+    word32 ret;
+    word16 outSz = (word16)outLen;
+
+    if (key == NULL || in == NULL || out == NULL ||
+                                                inLen != (word32)key->n.used) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef HAVE_CAVIUM_V
+    ret = CspPkcs1v15CrtDec(key->asyncDev.dev.devId, CAVIUM_REQ_MODE, CAVIUM_SSL_GRP, CAVIUM_DPORT,
+                            BT2, key->n.used, key->q.dpraw,
+                            key->dQ.dpraw, key->p.dpraw, key->dP.dpraw, key->u.dpraw,
+                            (byte*)in, &outSz, out, &key->asyncDev.dev.reqId);
+#else
+    ret = CspPkcs1v15CrtDec(CAVIUM_REQ_MODE, BT2, key->n.used, key->q.dpraw,
+                            key->dQ.dpraw, key->p.dpraw, key->dP.dpraw, key->u.dpraw,
+                            (byte*)in, &outSz, out, &key->asyncDev.dev.reqId,
+                            key->asyncDev.dev.devId);
+#endif
+    ret = NitroxTranslateResponseCode(ret);
+    if (ret != 0) {
+        return ret;
+    }
+
+    ato16((const byte*)&outSz, &outSz); 
+
+    return outSz;
+}
+
+
+int NitroxRsaSSL_Sign(const byte* in, word32 inLen, byte* out,
+                      word32 outLen, RsaKey* key)
+{
+    word32 ret;
+
+    if (key == NULL || in == NULL || out == NULL || inLen == 0 || outLen <
+                                                         (word32)key->n.used) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef HAVE_CAVIUM_V
+    ret = CspPkcs1v15CrtEnc(key->asyncDev.dev.devId, CAVIUM_REQ_MODE, CAVIUM_SSL_GRP, CAVIUM_DPORT,
+                            BT1, key->n.used, (word16)inLen,
+                            key->q.dpraw, key->dQ.dpraw, key->p.dpraw, key->dP.dpraw, key->u.dpraw,
+                            (byte*)in, out, &key->asyncDev.dev.reqId);
+#else
+    ret = CspPkcs1v15CrtEnc(CAVIUM_REQ_MODE, BT1, key->n.used, (word16)inLen,
+                            key->q.dpraw, key->dQ.dpraw, key->p.dpraw, key->dP.dpraw, key->u.dpraw,
+                            (byte*)in, out, &key->asyncDev.dev.reqId, key->asyncDev.dev.devId);
+#endif
+    ret = NitroxTranslateResponseCode(ret);
+    if (ret != 0) {
+        return ret;
+    }
+
+    return key->n.used;
+}
+
+
+int NitroxRsaSSL_Verify(const byte* in, word32 inLen, byte* out,
+                        word32 outLen, RsaKey* key)
+{
+    word32 ret;
+    word16 outSz = (word16)outLen;
+
+    if (key == NULL || in == NULL || out == NULL || inLen != (word32)key->n.used) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef HAVE_CAVIUM_V
+    ret = CspPkcs1v15Dec(key->asyncDev.dev.devId, CAVIUM_REQ_MODE, CAVIUM_SSL_GRP, CAVIUM_DPORT,
+                         BT1, key->n.used, key->e.used,
+                         key->n.dpraw, key->e.dpraw, (byte*)in, &outSz, out,
+                         &key->asyncDev.dev.reqId);
+#else
+    ret = CspPkcs1v15Dec(CAVIUM_REQ_MODE, BT1, key->n.used, key->e.used,
+                         key->n.dpraw, key->e.dpraw, (byte*)in, &outSz, out,
+                         &key->asyncDev.dev.reqId, key->asyncDev.dev.devId);
+#endif
+    ret = NitroxTranslateResponseCode(ret);
+    if (ret != 0) {
+        return ret;
+    }
+
+    outSz = ntohs(outSz);
+
+    return outSz;
+}
+#endif /* !NO_RSA */
+
+
+#ifndef NO_AES
+int NitroxAesSetKey(Aes* aes, const byte* key, word32 length, const byte* iv)
+{
+    if (aes == NULL)
+        return BAD_FUNC_ARG;
+
+    XMEMCPY(aes->key, key, length);   /* key still holds key, iv still in reg */
+    if (length == 16)
+        aes->type = AES_128_BIT;
+    else if (length == 24)
+        aes->type = AES_192_BIT;
+    else if (length == 32)
+        aes->type = AES_256_BIT;
+
+    return wc_AesSetIV(aes, iv);
+}
+
+#ifdef HAVE_AES_CBC
+int NitroxAesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 length)
+{
+    int ret;
+    wolfssl_word offset = 0;
+
+    while (length > WOLFSSL_MAX_16BIT) {
+        word16 slen = (word16)WOLFSSL_MAX_16BIT;
+    #ifdef HAVE_CAVIUM_V
+        ret = CspEncryptAes(aes->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT, 
+                          CAVIUM_SSL_GRP, CAVIUM_DPORT, aes->asyncDev.dev.contextHandle,
+                          FROM_DPTR, FROM_CTX, AES_CBC, aes->type, (byte*)aes->key,
+                          (byte*)aes->reg, 0, NULL, slen, (byte*)in + offset,
+                          out + offset, &aes->asyncDev.dev.reqId);
+    #else
+        ret = CspEncryptAes(CAVIUM_BLOCKING, aes->asyncDev.dev.contextHandle, CAVIUM_NO_UPDATE,
+                          aes->type, slen, (byte*)in + offset, out + offset,
+                          (byte*)aes->reg, (byte*)aes->key, &aes->asyncDev.dev.reqId,
+                          aes->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        length -= WOLFSSL_MAX_16BIT;
+        offset += WOLFSSL_MAX_16BIT;
+        XMEMCPY(aes->reg, out + offset - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+    }
+    if (length) {
+        word16 slen = (word16)length;
+    #ifdef HAVE_CAVIUM_V
+        ret = CspEncryptAes(aes->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT, 
+                          CAVIUM_SSL_GRP, CAVIUM_DPORT, aes->asyncDev.dev.contextHandle,
+                          FROM_DPTR, FROM_CTX, AES_CBC, aes->type, (byte*)aes->key,
+                          (byte*)aes->reg,  0, NULL, slen, (byte*)in + offset,
+                          out + offset, &aes->asyncDev.dev.reqId);
+    #else
+        ret = CspEncryptAes(CAVIUM_BLOCKING, aes->asyncDev.dev.contextHandle, CAVIUM_NO_UPDATE,
+                          aes->type, slen, (byte*)in + offset, out + offset,
+                          (byte*)aes->reg, (byte*)aes->key, &aes->asyncDev.dev.reqId,
+                          aes->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        XMEMCPY(aes->reg, out + offset+length - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+    }
+    return 0;
+}
+
+#ifdef HAVE_AES_DECRYPT
+int NitroxAesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 length)
+{
+    wolfssl_word offset = 0;
+    int ret;
+
+    while (length > WOLFSSL_MAX_16BIT) {
+        word16 slen = (word16)WOLFSSL_MAX_16BIT;
+        XMEMCPY(aes->tmp, in + offset + slen - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+    #ifdef HAVE_CAVIUM_V
+        ret = CspDecryptAes(aes->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT, 
+                          CAVIUM_SSL_GRP, CAVIUM_DPORT, aes->asyncDev.dev.contextHandle,
+                          FROM_DPTR, FROM_CTX, AES_CBC, aes->type, (byte*)aes->key, (byte*)aes->reg,
+                          0, NULL, slen, (byte*)in + offset, out + offset, &aes->asyncDev.dev.reqId);
+    #else
+        ret = CspDecryptAes(CAVIUM_BLOCKING, aes->asyncDev.dev.contextHandle, CAVIUM_NO_UPDATE,
+                          aes->type, slen, (byte*)in + offset, out + offset,
+                          (byte*)aes->reg, (byte*)aes->key, &aes->asyncDev.dev.reqId,
+                          aes->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        length -= WOLFSSL_MAX_16BIT;
+        offset += WOLFSSL_MAX_16BIT;
+        XMEMCPY(aes->reg, aes->tmp, AES_BLOCK_SIZE);
+    }
+    if (length) {
+        word16 slen = (word16)length;
+        XMEMCPY(aes->tmp, in + offset + slen - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+    #ifdef HAVE_CAVIUM_V
+        ret = CspDecryptAes(aes->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT, 
+                          CAVIUM_SSL_GRP, CAVIUM_DPORT, aes->asyncDev.dev.contextHandle,
+                          FROM_DPTR, FROM_CTX, AES_CBC, aes->type, (byte*)aes->key, (byte*)aes->reg,
+                          0, NULL, slen, (byte*)in + offset, out + offset, &aes->asyncDev.dev.reqId);
+    #else
+        ret = CspDecryptAes(CAVIUM_BLOCKING, aes->asyncDev.dev.contextHandle, CAVIUM_NO_UPDATE,
+                          aes->type, slen, (byte*)in + offset, out + offset,
+                          (byte*)aes->reg, (byte*)aes->key, &aes->asyncDev.dev.reqId,
+                          aes->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        XMEMCPY(aes->reg, aes->tmp, AES_BLOCK_SIZE);
+    }
+    return 0;
+}
+#endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_CBC */
+#endif /* !NO_AES */
+
+
+#if !defined(NO_ARC4) && !defined(HAVE_CAVIUM_V)
+void NitroxArc4SetKey(Arc4* arc4, const byte* key, word32 length)
+{
+    if (CspInitializeRc4(CAVIUM_BLOCKING, arc4->asyncDev.dev.contextHandle, length,
+                         (byte*)key, &arc4->asyncDev.dev.reqId, arc4->devId) != 0) {
+        WOLFSSL_MSG("Bad Cavium Arc4 Init");
+    }
+}
+
+void NitroxArc4Process(Arc4* arc4, byte* out, const byte* in, word32 length)
+{
+    int ret;
+    wolfssl_word offset = 0;
+
+    while (length > WOLFSSL_MAX_16BIT) {
+        word16 slen = (word16)WOLFSSL_MAX_16BIT;
+        ret = CspEncryptRc4(CAVIUM_BLOCKING, arc4->asyncDev.dev.contextHandle,
+            CAVIUM_UPDATE, slen, (byte*)in + offset, out + offset,
+            &arc4->asyncDev.dev.reqId, arc4->devId);
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        length -= WOLFSSL_MAX_16BIT;
+        offset += WOLFSSL_MAX_16BIT;
+    }
+    if (length) {
+        word16 slen = (word16)length;
+        ret = CspEncryptRc4(CAVIUM_BLOCKING, arc4->asyncDev.dev.contextHandle,
+            CAVIUM_UPDATE, slen, (byte*)in + offset, out + offset,
+            &arc4->asyncDev.dev.reqId, arc4->devId);
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+    }
+}
+#endif /* !NO_ARC4 && !HAVE_CAVIUM_V */
+
+
+#ifndef NO_DES3
+int NitroxDes3SetKey(Des3* des3, const byte* key, const byte* iv)
+{
+    if (des3 == NULL)
+        return BAD_FUNC_ARG;
+
+    /* key[0] holds key, iv in reg */
+    XMEMCPY(des3->key[0], key, DES_BLOCK_SIZE*3);
+
+    return wc_Des3_SetIV(des3, iv);
+}
+
+int NitroxDes3CbcEncrypt(Des3* des3, byte* out, const byte* in, word32 length)
+{
+    wolfssl_word offset = 0;
+    int ret;
+
+    while (length > WOLFSSL_MAX_16BIT) {
+        word16 slen = (word16)WOLFSSL_MAX_16BIT;
+    #ifdef HAVE_CAVIUM_V
+        ret = CspEncrypt3Des(des3->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT,
+                            CAVIUM_SSL_GRP, CAVIUM_DPORT, des3->asyncDev.dev.contextHandle,
+                            FROM_DPTR, FROM_CTX, DES3_CBC, (byte*)des3->key[0],
+                            (byte*)des3->reg, slen, (byte*)in + offset,
+                            out + offset, &des3->asyncDev.dev.reqId);
+    #else
+        ret = CspEncrypt3Des(CAVIUM_BLOCKING, des3->asyncDev.dev.contextHandle,
+                            CAVIUM_NO_UPDATE, slen, (byte*)in + offset,
+                            out + offset, (byte*)des3->reg, (byte*)des3->key[0],
+                            &des3->asyncDev.dev.reqId, des3->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        length -= WOLFSSL_MAX_16BIT;
+        offset += WOLFSSL_MAX_16BIT;
+        XMEMCPY(des3->reg, out + offset - DES_BLOCK_SIZE, DES_BLOCK_SIZE);
+    }
+    if (length) {
+        word16 slen = (word16)length;
+    #ifdef HAVE_CAVIUM_V
+        ret = CspEncrypt3Des(des3->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT,
+                            CAVIUM_SSL_GRP, CAVIUM_DPORT, des3->asyncDev.dev.contextHandle,
+                            FROM_DPTR, FROM_CTX, DES3_CBC, (byte*)des3->key[0], (byte*)des3->reg,
+                            slen, (byte*)in + offset, out + offset,
+                            &des3->asyncDev.dev.reqId);
+    #else
+        ret = CspEncrypt3Des(CAVIUM_BLOCKING, des3->asyncDev.dev.contextHandle,
+                            CAVIUM_NO_UPDATE, slen, (byte*)in + offset,
+                            out + offset, (byte*)des3->reg, (byte*)des3->key[0],
+                            &des3->asyncDev.dev.reqId, des3->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        XMEMCPY(des3->reg, out+offset+length - DES_BLOCK_SIZE, DES_BLOCK_SIZE);
+    }
+    return 0;
+}
+
+int NitroxDes3CbcDecrypt(Des3* des3, byte* out, const byte* in, word32 length)
+{
+    wolfssl_word offset = 0;
+    int ret;
+
+    while (length > WOLFSSL_MAX_16BIT) {
+        word16 slen = (word16)WOLFSSL_MAX_16BIT;
+        XMEMCPY(des3->tmp, in + offset + slen - DES_BLOCK_SIZE, DES_BLOCK_SIZE);
+    #ifdef HAVE_CAVIUM_V
+        ret = CspDecrypt3Des(des3->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT,
+                            CAVIUM_SSL_GRP, CAVIUM_DPORT, des3->asyncDev.dev.contextHandle,
+                            FROM_DPTR, FROM_CTX, DES3_CBC, (byte*)des3->key[0], (byte*)des3->reg,
+                            slen, (byte*)in + offset, out + offset,
+                            &des3->asyncDev.dev.reqId);
+    #else
+        ret = CspDecrypt3Des(CAVIUM_BLOCKING, des3->asyncDev.dev.contextHandle,
+                           CAVIUM_NO_UPDATE, slen, (byte*)in + offset, out + offset,
+                           (byte*)des3->reg, (byte*)des3->key[0], &des3->asyncDev.dev.reqId,
+                           des3->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        length -= WOLFSSL_MAX_16BIT;
+        offset += WOLFSSL_MAX_16BIT;
+        XMEMCPY(des3->reg, des3->tmp, DES_BLOCK_SIZE);
+    }
+    if (length) {
+        word16 slen = (word16)length;
+        XMEMCPY(des3->tmp, in + offset + slen - DES_BLOCK_SIZE,DES_BLOCK_SIZE);
+    #ifdef HAVE_CAVIUM_V
+        ret = CspDecrypt3Des(des3->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT,
+                            CAVIUM_SSL_GRP, CAVIUM_DPORT, des3->asyncDev.dev.contextHandle,
+                            FROM_DPTR, FROM_CTX, DES3_CBC, (byte*)des3->key[0], (byte*)des3->reg,
+                            slen, (byte*)in + offset, out + offset,
+                            &des3->asyncDev.dev.reqId);
+    #else
+        ret = CspDecrypt3Des(CAVIUM_BLOCKING, des3->asyncDev.dev.contextHandle,
+                           CAVIUM_NO_UPDATE, slen, (byte*)in + offset, out + offset,
+                           (byte*)des3->reg, (byte*)des3->key[0], &des3->asyncDev.dev.reqId,
+                           des3->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        XMEMCPY(des3->reg, des3->tmp, DES_BLOCK_SIZE);
+    }
+    return 0;
+}
+#endif /* !NO_DES3 */
+
+
+#ifndef NO_HMAC
+int NitroxHmacFinal(Hmac* hmac, byte* hash)
+{
+    int ret = -1;
+
+#ifdef HAVE_CAVIUM_V
+    word16 hashLen = wc_HmacSizeByType(hmac->macType);
+    ret = CspHmac(hmac->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT,
+                  CAVIUM_SSL_GRP, CAVIUM_DPORT, hmac->type, hmac->keyLen,
+                  (byte*)hmac->ipad, hmac->dataLen, hmac->data, hashLen,
+                  hash, &hmac->asyncDev.dev.reqId);
+#else
+    ret = CspHmac(CAVIUM_BLOCKING, hmac->type, NULL, hmac->keyLen,
+                  (byte*)hmac->ipad, hmac->dataLen, hmac->data, hash,
+                  &hmac->asyncDev.dev.reqId, hmac->asyncDev.dev.devId);
+#endif
+    ret = NitroxTranslateResponseCode(ret);
+    if (ret != 0) {
+        return ret;
+    }
+
+    hmac->innerHashKeyed = 0;  /* tell update to start over if used again */
+
+    return 0;
+}
+
+int NitroxHmacUpdate(Hmac* hmac, const byte* msg, word32 length)
+{
+    word16 add = (word16)length;
+    word32 total;
+    byte*  tmp;
+
+    if (length > WOLFSSL_MAX_16BIT) {
+        WOLFSSL_MSG("Too big msg for cavium hmac");
+        return -1;
+    }
+
+    if (hmac->innerHashKeyed == 0) {  /* starting new */
+        hmac->dataLen        = 0;
+        hmac->innerHashKeyed = 1;
+    }
+
+    total = add + hmac->dataLen;
+    if (total > WOLFSSL_MAX_16BIT) {
+        WOLFSSL_MSG("Too big msg for cavium hmac");
+        return -1;
+    }
+
+    tmp = XMALLOC(hmac->dataLen + add, NULL,DYNAMIC_TYPE_CAVIUM_TMP);
+    if (tmp == NULL) {
+        WOLFSSL_MSG("Out of memory for cavium update");
+        return -1;
+    }
+    if (hmac->dataLen)
+        XMEMCPY(tmp, hmac->data,  hmac->dataLen);
+    XMEMCPY(tmp + hmac->dataLen, msg, add);
+
+    hmac->dataLen += add;
+    XFREE(hmac->data, NULL, DYNAMIC_TYPE_CAVIUM_TMP);
+    hmac->data = tmp;
+
+    return 0;
+}
+
+int NitroxHmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
+{
+    hmac->macType = (byte)type;
+    
+    /* Determine Cavium HashType */
+    switch(type) {
+    #ifndef NO_MD5
+        case MD5:
+            hmac->type = MD5_TYPE;
+            break;
+    #endif
+    #ifndef NO_SHA
+        case SHA:
+            hmac->type = SHA1_TYPE;
+            break;
+    #endif
+    #ifndef NO_SHA256
+        case SHA256:
+        #ifdef HAVE_CAVIUM_V
+            hmac->type = SHA2_SHA256;
+        #else
+            hmac->type = SHA256_TYPE;
+        #endif
+            break;
+    #endif
+    #ifdef HAVE_CAVIUM_V
+        #ifndef WOLFSSL_SHA512
+            case SHA512:
+                hmac->type = SHA2_SHA512;
+                break;
+        #endif
+        #ifndef WOLFSSL_SHA384
+            case SHA384:
+                hmac->type = SHA2_SHA384;
+                break;
+        #endif
+    #endif /* HAVE_CAVIUM_V */
+        default:
+            WOLFSSL_MSG("unsupported cavium hmac type");
+            break;
+    }
+
+    hmac->innerHashKeyed = 0;  /* should we key Startup flag */
+
+    hmac->keyLen = (word16)length;
+    /* store key in ipad */
+    XMEMCPY(hmac->ipad, key, length);
+
+    return 0;
+}
+#endif /* !NO_HMAC */
+
+
+#if !defined(HAVE_HASHDRBG) && !defined(NO_RC4)
+void NitroxRngGenerateBlock(WC_RNG* rng, byte* output, word32 sz)
+{
+    wolfssl_word offset = 0;
+    word32      requestId;
+
+    while (sz > WOLFSSL_MAX_16BIT) {
+        word16 slen = (word16)WOLFSSL_MAX_16BIT;
+    #ifdef HAVE_CAVIUM_V
+        ret = CspTrueRandom(rng->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT, 
+                            CAVIUM_SSL_GRP, CAVIUM_DPORT, slen, output + offset, &requestId);
+    #else
+        ret = CspRandom(CAVIUM_BLOCKING, slen, output + offset, &requestId,
+                        rng->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        sz     -= WOLFSSL_MAX_16BIT;
+        offset += WOLFSSL_MAX_16BIT;
+    }
+    if (sz) {
+        word16 slen = (word16)sz;
+    #ifdef HAVE_CAVIUM_V
+        ret = CspTrueRandom(rng->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT, 
+                            CAVIUM_SSL_GRP, CAVIUM_DPORT, slen, output + offset, &requestId);
+    #else
+        ret = CspRandom(CAVIUM_BLOCKING, slen, output + offset, &requestId,
+                        rng->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+    }
+}
+#endif /* !defined(HAVE_HASHDRBG) && !defined(NO_RC4) */
+
+
+#endif /* WOLFSSL_ASYNC_CRYPT */
+
+#endif /* HAVE_CAVIUM */

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -26,9 +26,27 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
+/*
+Possible RSA enable options:
+ * NO_RSA:                  Disables RSA                    default: on (not defined)
+ * RSA_LOW_MEM:             Reduced mem mode, slower        default: off
+ * WOLFSSL_KEY_GEN:         RSA Key Generation supported    default: off
+ * WC_NO_RSA_OAEP:          Disables RSA OAEP padding       default: on (not defined)
+ * RSA_CHECK_KEYTYPE:       RSA check key type              default: off
+*/
+
+/*
+RSA Key Size Configuration:
+ * FP_MAX_BITS:                 With USE_FAST_MATH only         default: 4096
+    If USE_FAST_MATH then use this to override default.
+    Value is key size * 2. Example: RSA 3072 = 6144
+*/
+
+
 #ifndef NO_RSA
 
 #include <wolfssl/wolfcrypt/rsa.h>
+
 
 #ifdef HAVE_FIPS
 int  wc_InitRsaKey(RsaKey* key, void* ptr)
@@ -104,16 +122,16 @@ int wc_RsaFlattenPublicKey(RsaKey* key, byte* a, word32* aSz, byte* b,
 #endif
 
 
-#ifdef HAVE_CAVIUM
-    int  wc_RsaInitCavium(RsaKey* key, int i)
+#ifdef WOLFSSL_ASYNC_CRYPT
+    int  wc_RsaAsyncInit(RsaKey* key, int i)
     {
-        return RsaInitCavium(key, i);
+        return RsaAsyncInit(key, i);
     }
 
 
-    void wc_RsaFreeCavium(RsaKey* key)
+    void wc_RsaAsyncFree(RsaKey* key)
     {
-        RsaFreeCavium(key);
+        RsaAsyncFree(key);
     }
 #endif
 
@@ -123,6 +141,7 @@ int wc_RsaFlattenPublicKey(RsaKey* key, byte* a, word32* aSz, byte* b,
 */
 
 #else /* else build without fips */
+
 #include <wolfssl/wolfcrypt/random.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
@@ -133,53 +152,45 @@ int wc_RsaFlattenPublicKey(RsaKey* key, byte* a, word32* aSz, byte* b,
     #include <wolfcrypt/src/misc.c>
 #endif
 
-#ifdef HAVE_CAVIUM
-    static int  InitCaviumRsaKey(RsaKey* key, void* heap);
-    static int  FreeCaviumRsaKey(RsaKey* key);
-    static int  CaviumRsaPublicEncrypt(const byte* in, word32 inLen, byte* out,
-                                       word32 outLen, RsaKey* key);
-    static int  CaviumRsaPrivateDecrypt(const byte* in, word32 inLen, byte* out,
-                                        word32 outLen, RsaKey* key);
-    static int  CaviumRsaSSL_Sign(const byte* in, word32 inLen, byte* out,
-                                  word32 outLen, RsaKey* key);
-    static int  CaviumRsaSSL_Verify(const byte* in, word32 inLen, byte* out,
-                                    word32 outLen, RsaKey* key);
-#endif
+#define ERROR_OUT(x) { ret = (x); goto done;}
+
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    static int InitAsyncRsaKey(RsaKey* key);
+    static int FreeAsyncRsaKey(RsaKey* key);
+#endif /* WOLFSSL_ASYNC_CRYPT */
 
 enum {
-    RSA_PUBLIC_ENCRYPT  = 0,
-    RSA_PUBLIC_DECRYPT  = 1,
-    RSA_PRIVATE_ENCRYPT = 2,
-    RSA_PRIVATE_DECRYPT = 3,
+    RSA_STATE_NONE = 0,
 
-    RSA_BLOCK_TYPE_1 = 1,
-    RSA_BLOCK_TYPE_2 = 2,
+    RSA_STATE_ENCRYPT_PAD,
+    RSA_STATE_ENCRYPT_EXPTMOD,
+    RSA_STATE_ENCRYPT_RES,
 
-    RSA_MIN_SIZE = 512,
-    RSA_MAX_SIZE = 4096,
-
-    RSA_MIN_PAD_SZ   = 11      /* separator + 0 + pad value + 8 pads */
+    RSA_STATE_DECRYPT_EXPTMOD,
+    RSA_STATE_DECRYPT_UNPAD,
+    RSA_STATE_DECRYPT_RES,
 };
 
 
 int wc_InitRsaKey(RsaKey* key, void* heap)
 {
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC)
-        return InitCaviumRsaKey(key, heap);
+    if (key == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    key->type = RSA_TYPE_UNKNOWN;
+    key->state = RSA_STATE_NONE;
+    key->heap = heap;
+    key->tmp = NULL;
+    key->tmpLen = 0;
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA) {
+        return InitAsyncRsaKey(key);
+    }
 #endif
 
-    key->type = -1;  /* haven't decided yet */
-    key->heap = heap;
-
-/* TomsFastMath doesn't use memory allocation */
-#ifndef USE_FAST_MATH
-    key->n.dp = key->e.dp = 0;  /* public  alloc parts */
-
-    key->d.dp = key->p.dp  = 0;  /* private alloc parts */
-    key->q.dp = key->dP.dp = 0;
-    key->u.dp = key->dQ.dp = 0;
-#else
     mp_init(&key->n);
     mp_init(&key->e);
     mp_init(&key->d);
@@ -188,24 +199,24 @@ int wc_InitRsaKey(RsaKey* key, void* heap)
     mp_init(&key->dP);
     mp_init(&key->dQ);
     mp_init(&key->u);
-#endif
 
     return 0;
 }
-
 
 int wc_FreeRsaKey(RsaKey* key)
 {
     (void)key;
 
-    if (key == NULL)
-        return 0;
+    if (key == NULL) {
+        return BAD_FUNC_ARG;
+    }
 
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC)
-        return FreeCaviumRsaKey(key);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA) {
+        return FreeAsyncRsaKey(key);
+    }
+    else
 #endif
-
     if (key->type == RSA_PRIVATE) {
         mp_forcezero(&key->u);
         mp_forcezero(&key->dQ);
@@ -229,8 +240,8 @@ int wc_FreeRsaKey(RsaKey* key)
    out:   mask output after generation
    outSz: size of output buffer
  */
-static int wc_MGF1(enum wc_HashType hType, byte* seed, word32 seedSz,
-                                            byte* out, word32 outSz, void* heap)
+static int RsaMGF1(enum wc_HashType hType, byte* seed, word32 seedSz,
+                                        byte* out, word32 outSz, void* heap)
 {
     byte* tmp;
     /* needs to be large enough for seed size plus counter(4) */
@@ -291,8 +302,7 @@ static int wc_MGF1(enum wc_HashType hType, byte* seed, word32 seedSz,
             out[idx++] = tmp[i];
         }
         counter++;
-    }
-    while (idx < outSz);
+    } while (idx < outSz);
 
     /* check for if dynamic memory was needed, then free */
     if (tmpF) {
@@ -302,41 +312,37 @@ static int wc_MGF1(enum wc_HashType hType, byte* seed, word32 seedSz,
     return 0;
 }
 
-
 /* helper function to direct which mask generation function is used
    switeched on type input
  */
-static int wc_MGF(int type, byte* seed, word32 seedSz,
-                                            byte* out, word32 outSz, void* heap)
+static int RsaMGF(int type, byte* seed, word32 seedSz, byte* out,
+                                                    word32 outSz, void* heap)
 {
     int ret;
 
     switch(type) {
-        #ifndef NO_SHA
+    #ifndef NO_SHA
         case WC_MGF1SHA1:
-                ret = wc_MGF1(WC_HASH_TYPE_SHA, seed, seedSz, out, outSz, heap);
-                break;
-        #endif
-        #ifndef NO_SHA256
+            ret = RsaMGF1(WC_HASH_TYPE_SHA, seed, seedSz, out, outSz, heap);
+            break;
+    #endif
+    #ifndef NO_SHA256
         case WC_MGF1SHA256:
-                ret = wc_MGF1(WC_HASH_TYPE_SHA256, seed, seedSz,
-                                                              out, outSz, heap);
-                break;
-        #endif
-        #ifdef WOLFSSL_SHA512
-        #ifdef WOLFSSL_SHA384
+            ret = RsaMGF1(WC_HASH_TYPE_SHA256, seed, seedSz, out, outSz, heap);
+            break;
+    #endif
+    #ifdef WOLFSSL_SHA512
+    #ifdef WOLFSSL_SHA384
         case WC_MGF1SHA384:
-                ret = wc_MGF1(WC_HASH_TYPE_SHA384, seed, seedSz,
-                                                              out, outSz, heap);
-                break;
-        #endif
+            ret = RsaMGF1(WC_HASH_TYPE_SHA384, seed, seedSz, out, outSz, heap);
+            break;
+    #endif
         case WC_MGF1SHA512:
-                ret = wc_MGF1(WC_HASH_TYPE_SHA512, seed, seedSz,
-                                                              out, outSz, heap);
-                break;
-        #endif
+            ret = RsaMGF1(WC_HASH_TYPE_SHA512, seed, seedSz, out, outSz, heap);
+            break;
+    #endif
         default:
-            WOLFSSL_MSG("Unknown MGF function: check build options");
+            WOLFSSL_MSG("Unknown MGF type: check build options");
             ret = BAD_FUNC_ARG;
     }
 
@@ -349,12 +355,15 @@ static int wc_MGF(int type, byte* seed, word32 seedSz,
 
     return ret;
 }
+#endif /* !WC_NO_RSA_OAEP */
 
 
-static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
-                          word32 pkcsBlockLen, byte padValue, WC_RNG* rng,
-                          enum wc_HashType hType, int mgf, byte* optLabel,
-                          word32 labelLen, void* heap)
+/* Padding */
+#ifndef WC_NO_RSA_OAEP
+static int RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
+        word32 pkcsBlockLen, byte padValue, WC_RNG* rng,
+        enum wc_HashType hType, int mgf, byte* optLabel, word32 labelLen,
+        void* heap)
 {
     int ret;
     int hLen;
@@ -373,8 +382,7 @@ static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
         byte seed[ WC_MAX_DIGEST_SIZE];
     #endif
 
-    /* can use with no lable but catch if no lable provided while having
-       length > 0 */
+    /* no label is allowed, but catch if no label provided and length > 0 */
     if (optLabel == NULL && labelLen > 0) {
         return BUFFER_E;
     }
@@ -386,13 +394,13 @@ static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     }
 
     #ifdef WOLFSSL_SMALL_STACK
-        lHash = (byte*)XMALLOC(hLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        lHash = (byte*)XMALLOC(hLen, heap, DYNAMIC_TYPE_TMP_BUFFER);
         if (lHash == NULL) {
             return MEMORY_E;
         }
-        seed = (byte*)XMALLOC(hLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        seed = (byte*)XMALLOC(hLen, heap, DYNAMIC_TYPE_TMP_BUFFER);
         if (seed == NULL) {
-            XFREE(lHash, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(lHash, heap, DYNAMIC_TYPE_TMP_BUFFER);
             return MEMORY_E;
         }
     #else
@@ -407,8 +415,8 @@ static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     if ((ret = wc_Hash(hType, optLabel, labelLen, lHash, hLen)) != 0) {
         WOLFSSL_MSG("OAEP hash type possibly not supported or lHash to small");
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(lHash, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-            XFREE(seed,  NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(lHash, heap, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(seed,  heap, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
         return ret;
     }
@@ -424,8 +432,8 @@ static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     if ((word32)(2 * hLen + 2) > pkcsBlockLen) {
         WOLFSSL_MSG("OAEP pad error hash to big for RSA key size");
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(lHash, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-            XFREE(seed,  NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(lHash, heap, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(seed,  heap, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
         return BAD_FUNC_ARG;
     }
@@ -433,8 +441,8 @@ static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     if (inputLen > (pkcsBlockLen - 2 * hLen - 2)) {
         WOLFSSL_MSG("OAEP pad error message too long");
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(lHash, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-            XFREE(seed,  NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(lHash, heap, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(seed,  heap, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
         return BAD_FUNC_ARG;
     }
@@ -444,8 +452,8 @@ static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     psLen = pkcsBlockLen - inputLen - 2 * hLen - 2;
     if (pkcsBlockLen < inputLen) { /*make sure not writing over end of buffer */
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(lHash, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-            XFREE(seed,  NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(lHash, heap, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(seed,  heap, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
         return BUFFER_E;
     }
@@ -462,8 +470,8 @@ static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     /* generate random seed */
     if ((ret = wc_RNG_GenerateBlock(rng, seed, hLen)) != 0) {
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(lHash, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-            XFREE(seed,  NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(lHash, heap, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(seed,  heap, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
         return ret;
     }
@@ -472,19 +480,19 @@ static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     dbMask = (byte*)XMALLOC(pkcsBlockLen - hLen - 1, heap, DYNAMIC_TYPE_RSA);
     if (dbMask == NULL) {
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(lHash, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-            XFREE(seed,  NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(lHash, heap, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(seed,  heap, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
         return MEMORY_E;
     }
     XMEMSET(dbMask, 0, pkcsBlockLen - hLen - 1); /* help static analyzer */
 
-    ret = wc_MGF(mgf, seed, hLen, dbMask, pkcsBlockLen - hLen - 1, heap);
+    ret = RsaMGF(mgf, seed, hLen, dbMask, pkcsBlockLen - hLen - 1, heap);
     if (ret != 0) {
         XFREE(dbMask, heap, DYNAMIC_TYPE_RSA);
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(lHash, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-            XFREE(seed,  NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(lHash, heap, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(seed,  heap, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
         return ret;
     }
@@ -502,11 +510,11 @@ static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     idx = 0;
     pkcsBlock[idx++] = 0x00;
     /* create seedMask inline */
-    if ((ret = wc_MGF(mgf, pkcsBlock + hLen + 1, pkcsBlockLen - hLen - 1,
-                                             pkcsBlock + 1, hLen, heap)) != 0) {
+    if ((ret = RsaMGF(mgf, pkcsBlock + hLen + 1, pkcsBlockLen - hLen - 1,
+                                           pkcsBlock + 1, hLen, heap)) != 0) {
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(lHash, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-            XFREE(seed,  NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(lHash, heap, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(seed,  heap, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
         return ret;
     }
@@ -519,20 +527,21 @@ static int wc_RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
     }
 
     #ifdef WOLFSSL_SMALL_STACK
-        XFREE(lHash, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(seed,  NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(lHash, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(seed,  heap, DYNAMIC_TYPE_TMP_BUFFER);
     #endif
     (void)padValue;
 
     return 0;
 }
-#endif /* WC_NO_RSA_OAEP */
+#endif /* !WC_NO_RSA_OAEP */
 
 
-static int wc_RsaPad(const byte* input, word32 inputLen, byte* pkcsBlock,
-                   word32 pkcsBlockLen, byte padValue, WC_RNG* rng)
+static int RsaPad(const byte* input, word32 inputLen, byte* pkcsBlock,
+                           word32 pkcsBlockLen, byte padValue, WC_RNG* rng)
 {
-    if (inputLen == 0 || pkcsBlockLen == 0) {
+    if (input == NULL || inputLen == 0 || pkcsBlock == NULL ||
+                                                        pkcsBlockLen == 0) {
         return BAD_FUNC_ARG;
     }
 
@@ -542,6 +551,7 @@ static int wc_RsaPad(const byte* input, word32 inputLen, byte* pkcsBlock,
 
     if (padValue == RSA_BLOCK_TYPE_1) {
         if (pkcsBlockLen < inputLen + 2) {
+            WOLFSSL_MSG("RsaPad error, invalid length");
             return RSA_PAD_E;
         }
 
@@ -554,17 +564,20 @@ static int wc_RsaPad(const byte* input, word32 inputLen, byte* pkcsBlock,
         int    ret;
 
         if (pkcsBlockLen < inputLen + 1) {
+            WOLFSSL_MSG("RsaPad error, invalid length");
             return RSA_PAD_E;
         }
 
         padLen = pkcsBlockLen - inputLen - 1;
         ret    = wc_RNG_GenerateBlock(rng, &pkcsBlock[1], padLen);
-        if (ret != 0)
+        if (ret != 0) {
             return ret;
+        }
 
         /* remove zeros */
-        for (i = 1; i < padLen; i++)
+        for (i = 1; i < padLen; i++) {
             if (pkcsBlock[i] == 0) pkcsBlock[i] = 0x01;
+        }
     }
 
     pkcsBlock[pkcsBlockLen-inputLen-1] = 0;     /* separator */
@@ -573,37 +586,35 @@ static int wc_RsaPad(const byte* input, word32 inputLen, byte* pkcsBlock,
     return 0;
 }
 
-
-#ifndef WC_NO_RSA_OAEP
 /* helper function to direct which padding is used */
-static int wc_RsaPad_ex(const byte* input, word32 inputLen, byte* pkcsBlock,
-                        word32 pkcsBlockLen, byte padValue, WC_RNG* rng,
-                        int padType, enum wc_HashType hType, int mgf,
-                        byte* optLabel, word32 labelLen, void* heap)
+int wc_RsaPad_ex(const byte* input, word32 inputLen, byte* pkcsBlock,
+    word32 pkcsBlockLen, byte padValue, WC_RNG* rng, int padType,
+    enum wc_HashType hType, int mgf, byte* optLabel, word32 labelLen,
+    void* heap)
 {
     int ret;
 
     switch (padType)
     {
         case WC_RSA_PKCSV15_PAD:
-            WOLFSSL_MSG("wolfSSL Using RSA PKCSV15 padding");
-            ret = wc_RsaPad(input, inputLen, pkcsBlock, pkcsBlockLen,
-                                                                 padValue, rng);
+            //WOLFSSL_MSG("wolfSSL Using RSA PKCSV15 padding");
+            ret = RsaPad(input, inputLen, pkcsBlock, pkcsBlockLen,
+                                                             padValue, rng);
             break;
 
+    #ifndef WC_NO_RSA_OAEP
         case WC_RSA_OAEP_PAD:
-            WOLFSSL_MSG("wolfSSL Using RSA OAEP padding");
-            ret = wc_RsaPad_OAEP(input, inputLen, pkcsBlock, pkcsBlockLen,
-                           padValue, rng, hType, mgf, optLabel, labelLen, heap);
+            //WOLFSSL_MSG("wolfSSL Using RSA OAEP padding");
+            ret = RsaPad_OAEP(input, inputLen, pkcsBlock, pkcsBlockLen,
+                         padValue, rng, hType, mgf, optLabel, labelLen, heap);
             break;
-
+    #endif
         default:
             WOLFSSL_MSG("Unknown RSA Pad Type");
             ret = RSA_PAD_E;
     }
 
     /* silence warning if not used with padding scheme */
-    (void)padType;
     (void)hType;
     (void)mgf;
     (void)optLabel;
@@ -614,9 +625,11 @@ static int wc_RsaPad_ex(const byte* input, word32 inputLen, byte* pkcsBlock,
 }
 
 
+/* UnPadding */
+#ifndef WC_NO_RSA_OAEP
 /* UnPad plaintext, set start to *output, return length of plaintext,
  * < 0 on error */
-static int wc_RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
+static int RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
                             byte **output, enum wc_HashType hType, int mgf,
                             byte* optLabel, word32 labelLen, void* heap)
 {
@@ -625,6 +638,11 @@ static int wc_RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
     byte h[WC_MAX_DIGEST_SIZE]; /* max digest size */
     byte* tmp;
     word32 idx;
+
+    /* no label is allowed, but catch if no label provided and length > 0 */
+    if (optLabel == NULL && labelLen > 0) {
+        return BUFFER_E;
+    }
 
     hLen = wc_HashGetDigestSize(hType);
     if ((hLen < 0) || (pkcsBlockLen < (2 * (word32)hLen + 2))) {
@@ -638,9 +656,9 @@ static int wc_RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
     XMEMSET(tmp, 0, pkcsBlockLen);
 
     /* find seedMask value */
-    if ((ret = wc_MGF(mgf, (byte*)(pkcsBlock + (hLen + 1)),
-                              pkcsBlockLen - hLen - 1, tmp, hLen, heap)) != 0) {
-        XFREE(tmp, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if ((ret = RsaMGF(mgf, (byte*)(pkcsBlock + (hLen + 1)),
+                            pkcsBlockLen - hLen - 1, tmp, hLen, heap)) != 0) {
+        XFREE(tmp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return ret;
     }
 
@@ -650,9 +668,9 @@ static int wc_RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
     }
 
     /* get dbMask value */
-    if ((ret = wc_MGF(mgf, tmp, hLen, tmp + hLen,
-                                         pkcsBlockLen - hLen - 1, heap)) != 0) {
-        XFREE(tmp, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if ((ret = RsaMGF(mgf, tmp, hLen, tmp + hLen,
+                                       pkcsBlockLen - hLen - 1, heap)) != 0) {
+        XFREE(tmp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return ret;
     }
 
@@ -698,19 +716,20 @@ static int wc_RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
 /* UnPad plaintext, set start to *output, return length of plaintext,
  * < 0 on error */
 static int RsaUnPad(const byte *pkcsBlock, unsigned int pkcsBlockLen,
-                       byte **output, byte padValue)
+                                               byte **output, byte padValue)
 {
-    word32 maxOutputLen = (pkcsBlockLen > 10) ? (pkcsBlockLen - 10) : 0,
-           invalid = 0,
-           i = 1,
-           outputLen;
+    word32 maxOutputLen = (pkcsBlockLen > 10) ? (pkcsBlockLen - 10) : 0;
+    word32 invalid = 0;
+    word32 i = 1;
+    word32 outputLen;
 
-    if (pkcsBlockLen == 0) {
+    if (output == NULL || pkcsBlockLen == 0) {
         return BAD_FUNC_ARG;
     }
 
-    if (pkcsBlock[0] != 0x0) /* skip past zero */
+    if (pkcsBlock[0] != 0x0) { /* skip past zero */
         invalid = 1;
+    }
     pkcsBlock++; pkcsBlockLen--;
 
     /* Require block type padValue */
@@ -741,10 +760,8 @@ static int RsaUnPad(const byte *pkcsBlock, unsigned int pkcsBlockLen,
     return outputLen;
 }
 
-
-#ifndef WC_NO_RSA_OAEP
 /* helper function to direct unpadding */
-static int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen, byte** out,
+int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen, byte** out,
                           byte padValue, int padType, enum wc_HashType hType,
                           int mgf, byte* optLabel, word32 labelLen, void* heap)
 {
@@ -753,23 +770,24 @@ static int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen, byte** out,
     switch (padType)
     {
         case WC_RSA_PKCSV15_PAD:
-            WOLFSSL_MSG("wolfSSL Using RSA PKCSV15 padding");
+            //WOLFSSL_MSG("wolfSSL Using RSA PKCSV15 padding");
             ret = RsaUnPad(pkcsBlock, pkcsBlockLen, out, padValue);
             break;
 
+    #ifndef WC_NO_RSA_OAEP
         case WC_RSA_OAEP_PAD:
-            WOLFSSL_MSG("wolfSSL Using RSA OAEP padding");
-            ret = wc_RsaUnPad_OAEP((byte*)pkcsBlock, pkcsBlockLen, out,
-                                          hType, mgf, optLabel, labelLen, heap);
+            //WOLFSSL_MSG("wolfSSL Using RSA OAEP padding");
+            ret = RsaUnPad_OAEP((byte*)pkcsBlock, pkcsBlockLen, out,
+                                        hType, mgf, optLabel, labelLen, heap);
             break;
+    #endif
 
         default:
-            WOLFSSL_MSG("Unknown RSA Pad Type");
+            WOLFSSL_MSG("Unknown RSA UnPad Type");
             ret = RSA_PAD_E;
     }
 
     /* silence warning if not used with padding scheme */
-    (void)padType;
     (void)hType;
     (void)mgf;
     (void)optLabel;
@@ -778,14 +796,12 @@ static int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen, byte** out,
 
     return ret;
 }
-#endif /* WC_NO_RSA_OAEP */
 
 
-static int wc_RsaFunction(const byte* in, word32 inLen, byte* out,
-                          word32* outLen, int type, RsaKey* key)
+/* RSA Operation */
+static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
+                                      word32* outLen, int type, RsaKey* key)
 {
-    #define ERROR_OUT(x) { ret = (x); goto done;}
-
     mp_int tmp;
     int    ret = 0;
     word32 keyLen, len;
@@ -796,65 +812,73 @@ static int wc_RsaFunction(const byte* in, word32 inLen, byte* out,
     if (mp_read_unsigned_bin(&tmp, (byte*)in, inLen) != MP_OKAY)
         ERROR_OUT(MP_READ_E);
 
-    if (type == RSA_PRIVATE_DECRYPT || type == RSA_PRIVATE_ENCRYPT) {
-        #ifdef RSA_LOW_MEM      /* half as much memory but twice as slow */
-            if (mp_exptmod(&tmp, &key->d, &key->n, &tmp) != MP_OKAY)
-                ERROR_OUT(MP_EXPTMOD_E);
-        #else
-            #define INNER_ERROR_OUT(x) { ret = (x); goto inner_done; }
+    switch(type) {
+    case RSA_PRIVATE_DECRYPT:
+    case RSA_PRIVATE_ENCRYPT:
+    {
+    #ifdef RSA_LOW_MEM      /* half as much memory but twice as slow */
+        if (mp_exptmod(&tmp, &key->d, &key->n, &tmp) != MP_OKAY)
+            ERROR_OUT(MP_EXPTMOD_E);
+    #else
+        #define INNER_ERROR_OUT(x) { ret = (x); goto inner_done; }
 
-            mp_int tmpa, tmpb;
+        mp_int tmpa, tmpb;
 
-            if (mp_init(&tmpa) != MP_OKAY)
-                ERROR_OUT(MP_INIT_E);
+        if (mp_init(&tmpa) != MP_OKAY)
+            ERROR_OUT(MP_INIT_E);
 
-            if (mp_init(&tmpb) != MP_OKAY) {
-                mp_clear(&tmpa);
-                ERROR_OUT(MP_INIT_E);
-            }
-
-            /* tmpa = tmp^dP mod p */
-            if (mp_exptmod(&tmp, &key->dP, &key->p, &tmpa) != MP_OKAY)
-                INNER_ERROR_OUT(MP_EXPTMOD_E);
-
-            /* tmpb = tmp^dQ mod q */
-            if (mp_exptmod(&tmp, &key->dQ, &key->q, &tmpb) != MP_OKAY)
-                INNER_ERROR_OUT(MP_EXPTMOD_E);
-
-            /* tmp = (tmpa - tmpb) * qInv (mod p) */
-            if (mp_sub(&tmpa, &tmpb, &tmp) != MP_OKAY)
-                INNER_ERROR_OUT(MP_SUB_E);
-
-            if (mp_mulmod(&tmp, &key->u, &key->p, &tmp) != MP_OKAY)
-                INNER_ERROR_OUT(MP_MULMOD_E);
-
-            /* tmp = tmpb + q * tmp */
-            if (mp_mul(&tmp, &key->q, &tmp) != MP_OKAY)
-                INNER_ERROR_OUT(MP_MUL_E);
-
-            if (mp_add(&tmp, &tmpb, &tmp) != MP_OKAY)
-                INNER_ERROR_OUT(MP_ADD_E);
-
-        inner_done:
+        if (mp_init(&tmpb) != MP_OKAY) {
             mp_clear(&tmpa);
-            mp_clear(&tmpb);
+            ERROR_OUT(MP_INIT_E);
+        }
 
-            if (ret != 0) {
-                goto done;
-            }
+        /* tmpa = tmp^dP mod p */
+        if (mp_exptmod(&tmp, &key->dP, &key->p, &tmpa) != MP_OKAY)
+            INNER_ERROR_OUT(MP_EXPTMOD_E);
 
-        #endif   /* RSA_LOW_MEM */
+        /* tmpb = tmp^dQ mod q */
+        if (mp_exptmod(&tmp, &key->dQ, &key->q, &tmpb) != MP_OKAY)
+            INNER_ERROR_OUT(MP_EXPTMOD_E);
+
+        /* tmp = (tmpa - tmpb) * qInv (mod p) */
+        if (mp_sub(&tmpa, &tmpb, &tmp) != MP_OKAY)
+            INNER_ERROR_OUT(MP_SUB_E);
+
+        if (mp_mulmod(&tmp, &key->u, &key->p, &tmp) != MP_OKAY)
+            INNER_ERROR_OUT(MP_MULMOD_E);
+
+        /* tmp = tmpb + q * tmp */
+        if (mp_mul(&tmp, &key->q, &tmp) != MP_OKAY)
+            INNER_ERROR_OUT(MP_MUL_E);
+
+        if (mp_add(&tmp, &tmpb, &tmp) != MP_OKAY)
+            INNER_ERROR_OUT(MP_ADD_E);
+
+    inner_done:
+        mp_clear(&tmpa);
+        mp_clear(&tmpb);
+
+        if (ret != 0) {
+            goto done;
+        }
+        #undef INNER_ERROR_OUT
+
+    #endif   /* RSA_LOW_MEM */
+        break;
     }
-    else if (type == RSA_PUBLIC_ENCRYPT || type == RSA_PUBLIC_DECRYPT) {
+    case RSA_PUBLIC_ENCRYPT:
+    case RSA_PUBLIC_DECRYPT:
         if (mp_exptmod(&tmp, &key->e, &key->n, &tmp) != MP_OKAY)
             ERROR_OUT(MP_EXPTMOD_E);
-    }
-    else
+        break;
+    default:
         ERROR_OUT(RSA_WRONG_TYPE_E);
+    }
 
-    keyLen = mp_unsigned_bin_size(&key->n);
-    if (keyLen > *outLen)
+    keyLen = wc_RsaEncryptSize(key);
+    if (keyLen > *outLen) {
         ERROR_OUT(RSA_BUFFER_E);
+    }
 
     len = mp_unsigned_bin_size(&tmp);
 
@@ -872,47 +896,93 @@ static int wc_RsaFunction(const byte* in, word32 inLen, byte* out,
 
 done:
     mp_clear(&tmp);
+    return ret;
+}
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+static int wc_RsaFunctionAsync(const byte* in, word32 inLen, byte* out,
+                                      word32* outLen, int type, RsaKey* key)
+{
+    int ret = 0;
+
+#ifdef WOLFSSL_ASYNC_CRYPT_TEST
+    AsyncCryptTestDev* testDev = &key->asyncDev.dev;
+    if (testDev->type == ASYNC_TEST_NONE) {
+        testDev->type = ASYNC_TEST_RSA_FUNC;
+        testDev->rsaFunc.in = in;
+        testDev->rsaFunc.inSz = inLen;
+        testDev->rsaFunc.out = out;
+        testDev->rsaFunc.outSz = outLen;
+        testDev->rsaFunc.type = type;
+        testDev->rsaFunc.key = key;
+        return WC_PENDING_E;
+    }
+#endif /* WOLFSSL_ASYNC_CRYPT_TEST */
+
+    switch(type) {
+    case RSA_PRIVATE_DECRYPT:
+    case RSA_PRIVATE_ENCRYPT:
+    #ifdef HAVE_CAVIUM
+        ret = NitroxRsaExptMod(in, inLen, key->d.dpraw, key->d.used,
+                               key->n.dpraw, key->n.used, out, outLen, key);
+    #elif defined(HAVE_INTEL_QA)
+        /* TODO: Add support for Intel Quick Assist */
+        ret = -1;
+    #else /* WOLFSSL_ASYNC_CRYPT_TEST */
+        ret = wc_RsaFunctionSync(in, inLen, out, outLen, type, key);
+    #endif
+        break;
+
+    case RSA_PUBLIC_ENCRYPT:
+    case RSA_PUBLIC_DECRYPT:
+    #ifdef HAVE_CAVIUM
+        ret = NitroxRsaExptMod(in, inLen, key->e.dpraw, key->e.used,
+                               key->n.dpraw, key->n.used, out, outLen, key);
+    #elif defined(HAVE_INTEL_QA)
+        /* TODO: Add support for Intel Quick Assist */
+        ret = -1;
+    #else /* WOLFSSL_ASYNC_CRYPT_TEST */
+        ret = wc_RsaFunctionSync(in, inLen, out, outLen, type, key);
+    #endif
+        break;
+
+    default:
+        ret = RSA_WRONG_TYPE_E;
+    }
+
+    return ret;
+}
+#endif /* WOLFSSL_ASYNC_CRYPT */
+
+int wc_RsaFunction(const byte* in, word32 inLen, byte* out,
+                          word32* outLen, int type, RsaKey* key)
+{
+    int ret;
+
+    if (key == NULL || in == NULL || inLen == 0 || out == NULL ||
+            outLen == NULL || *outLen == 0 || type == RSA_TYPE_UNKNOWN) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA) {
+        ret = wc_RsaFunctionAsync(in, inLen, out, outLen, type, key);
+    }
+    else
+#endif
+    {
+        ret = wc_RsaFunctionSync(in, inLen, out, outLen, type, key);
+    }
+
     if (ret == MP_EXPTMOD_E) {
+        /* This can happen due to incorrectly set FP_MAX_BITS or missing XREALLOC */
         WOLFSSL_MSG("RSA_FUNCTION MP_EXPTMOD_E: memory/config problem");
     }
     return ret;
 }
 
 
-int wc_RsaPublicEncrypt(const byte* in, word32 inLen, byte* out, word32 outLen,
-                     RsaKey* key, WC_RNG* rng)
-{
-    int sz, ret;
-
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC)
-        return CaviumRsaPublicEncrypt(in, inLen, out, outLen, key);
-#endif
-
-    sz = mp_unsigned_bin_size(&key->n);
-    if (sz > (int)outLen)
-        return RSA_BUFFER_E;
-
-    if (sz < RSA_MIN_PAD_SZ) {
-        return WC_KEY_SIZE_E;
-    }
-
-    if (inLen > (word32)(sz - RSA_MIN_PAD_SZ))
-        return RSA_BUFFER_E;
-
-    ret = wc_RsaPad(in, inLen, out, sz, RSA_BLOCK_TYPE_2, rng);
-    if (ret != 0)
-        return ret;
-
-    if ((ret = wc_RsaFunction(out, sz, out, &outLen,
-                              RSA_PUBLIC_ENCRYPT, key)) < 0)
-        sz = ret;
-
-    return sz;
-}
-
-
-#ifndef WC_NO_RSA_OAEP
+/* Internal Wrappers */
 /* Gives the option of choosing padding type
    in : input to be encrypted
    inLen: length of input buffer
@@ -920,321 +990,356 @@ int wc_RsaPublicEncrypt(const byte* in, word32 inLen, byte* out, word32 outLen,
    outLen: length of encrypted output buffer
    key   : wolfSSL initialized RSA key struct
    rng   : wolfSSL initialized random number struct
-   type  : type of padding to use ie WC_RSA_OAEP_PAD
+   rsa_type  : type of RSA: RSA_PUBLIC_ENCRYPT, RSA_PUBLIC_DECRYPT, 
+        RSA_PRIVATE_ENCRYPT or RSA_PRIVATE_DECRYPT
+   pad_value: RSA_BLOCK_TYPE_1 or RSA_BLOCK_TYPE_2
+   pad_type  : type of padding: WC_RSA_PKCSV15_PAD or  WC_RSA_OAEP_PAD
    hash  : type of hash algorithm to use found in wolfssl/wolfcrypt/hash.h
    mgf   : type of mask generation function to use
    label : optional label
    labelSz : size of optional label buffer */
-int wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
-                    word32 outLen, RsaKey* key, WC_RNG* rng, int type,
-                    enum wc_HashType hash, int mgf, byte* label, word32 labelSz)
+static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
+                            word32 outLen, RsaKey* key, WC_RNG* rng,
+                            int rsa_type, byte pad_value, int pad_type,
+                            enum wc_HashType hash, int mgf,
+                            byte* label, word32 labelSz)
 {
-    int sz, ret;
+    int ret = BAD_FUNC_ARG, sz;
 
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC)
-        return CaviumRsaPublicEncrypt(in, inLen, out, outLen, key);
-#endif
+    if (in == NULL || inLen == 0 || out == NULL || key == NULL) {
+        return ret;
+    }
 
-    sz = mp_unsigned_bin_size(&key->n);
-    if (sz > (int)outLen)
+    sz = wc_RsaEncryptSize(key);
+    if (sz > (int)outLen) {
         return RSA_BUFFER_E;
+    }
 
     if (sz < RSA_MIN_PAD_SZ) {
         return WC_KEY_SIZE_E;
     }
 
-    if (inLen > (word32)(sz - RSA_MIN_PAD_SZ))
+    if (inLen > (word32)(sz - RSA_MIN_PAD_SZ)) {
         return RSA_BUFFER_E;
+    }
 
-    ret = wc_RsaPad_ex(in, inLen, out, sz, RSA_BLOCK_TYPE_2, rng,
-                                    type, hash, mgf, label, labelSz, key->heap);
-    if (ret != 0)
+    /* Optional key type check (disabled by default) */
+    /* Note: internal tests allow private to be used as public */
+#ifdef RSA_CHECK_KEYTYPE
+    if ((rsa_type == RSA_PUBLIC_ENCRYPT && key->type != RSA_PUBLIC) || 
+        (rsa_type == RSA_PRIVATE_ENCRYPT && key->type != RSA_PRIVATE)) {
+        WOLFSSL_MSG("Wrong RSA Encrypt key type");
+        return RSA_WRONG_TYPE_E;
+    }
+#endif
+
+    switch (key->state) {
+    case RSA_STATE_NONE:
+    case RSA_STATE_ENCRYPT_PAD:
+
+    #if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
+        if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA) {
+            if (rsa_type == RSA_PUBLIC_ENCRYPT && pad_value == RSA_BLOCK_TYPE_2) {
+                key->state = RSA_STATE_ENCRYPT_RES;
+                key->tmpLen = key->n.used;
+                return NitroxRsaPublicEncrypt(in, inLen, out, outLen, key);
+            }
+            else if (rsa_type == RSA_PRIVATE_ENCRYPT && pad_value == RSA_BLOCK_TYPE_1) {
+                key->state = RSA_STATE_ENCRYPT_RES;
+                key->tmpLen = key->n.used;
+                return NitroxRsaSSL_Sign(in, inLen, out, outLen, key);
+            }
+        }
+    #endif
+
+        key->state = RSA_STATE_ENCRYPT_EXPTMOD;
+
+        ret = wc_RsaPad_ex(in, inLen, out, sz, pad_value, rng,
+                               pad_type, hash, mgf, label, labelSz, key->heap);
+        if (ret < 0) {
+            break;
+        }
+        /* fall through */
+    case RSA_STATE_ENCRYPT_EXPTMOD:
+        key->state = RSA_STATE_ENCRYPT_RES;
+
+        key->tmpLen = outLen;
+        ret = wc_RsaFunction(out, sz, out, &key->tmpLen, rsa_type, key);
+        if (ret < 0) {
+            break;
+        }
+        /* fall through */
+    case RSA_STATE_ENCRYPT_RES:
+        key->state = RSA_STATE_NONE;
+        ret = key->tmpLen;
+        break;
+
+    default:
+        ret = BAD_STATE_E;
+    }
+
+    /* if async pending then return and skip done cleanup below */
+    if (ret == WC_PENDING_E) {
         return ret;
+    }
 
-    if ((ret = wc_RsaFunction(out, sz, out, &outLen,
-                              RSA_PUBLIC_ENCRYPT, key)) < 0)
-        sz = ret;
+    key->state = RSA_STATE_NONE;
 
-    return sz;
+    return ret;
+}
+
+/* Gives the option of choosing padding type
+   in : input to be decrypted
+   inLen: length of input buffer
+   out:  decrypted message
+   outLen: length of decrypted message in bytes
+   outPtr: optional inline output pointer (if provided doing inline)
+   key   : wolfSSL initialized RSA key struct
+   rsa_type  : type of RSA: RSA_PUBLIC_ENCRYPT, RSA_PUBLIC_DECRYPT, 
+        RSA_PRIVATE_ENCRYPT or RSA_PRIVATE_DECRYPT
+   pad_value: RSA_BLOCK_TYPE_1 or RSA_BLOCK_TYPE_2
+   pad_type  : type of padding: WC_RSA_PKCSV15_PAD or  WC_RSA_OAEP_PAD
+   hash  : type of hash algorithm to use found in wolfssl/wolfcrypt/hash.h
+   mgf   : type of mask generation function to use
+   label : optional label
+   labelSz : size of optional label buffer */
+static int RsaPrivateDecryptEx(byte* in, word32 inLen, byte* out,
+                            word32 outLen, byte** outPtr, RsaKey* key,
+                            int rsa_type, byte pad_value, int pad_type,
+                            enum wc_HashType hash, int mgf,
+                            byte* label, word32 labelSz)
+{
+    int ret = BAD_FUNC_ARG;
+
+    if (in == NULL || inLen == 0 || out == NULL || key == NULL) {
+        return ret;
+    }
+
+    /* Optional key type check (disabled by default) */
+    /* Note: internal tests allow private to be used as public */
+#ifdef RSA_CHECK_KEYTYPE
+    if ((rsa_type == RSA_PUBLIC_DECRYPT && key->type != RSA_PUBLIC) || 
+        (rsa_type == RSA_PRIVATE_DECRYPT && key->type != RSA_PRIVATE)) {
+        WOLFSSL_MSG("Wrong RSA Decrypt key type");
+        return RSA_WRONG_TYPE_E;
+    }
+#endif
+
+    switch (key->state) {
+    case RSA_STATE_NONE:
+    case RSA_STATE_DECRYPT_EXPTMOD:
+    #if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
+        if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA) {
+            key->tmpLen = 0;
+            if (rsa_type == RSA_PRIVATE_DECRYPT && pad_value == RSA_BLOCK_TYPE_2) {
+                key->state = RSA_STATE_DECRYPT_RES;
+                key->tmp = NULL;
+                ret = NitroxRsaPrivateDecrypt(in, inLen, out, outLen, key);
+                if (ret > 0) {
+                    if (outPtr)
+                        *outPtr = in;
+                }
+                return ret;
+            }
+            else if (rsa_type == RSA_PUBLIC_DECRYPT && pad_value == RSA_BLOCK_TYPE_1) {
+                key->state = RSA_STATE_DECRYPT_RES;
+                key->tmp = NULL;
+                return NitroxRsaSSL_Verify(in, inLen, out, outLen, key);
+            }
+        }
+    #endif
+
+        key->state = RSA_STATE_DECRYPT_UNPAD;
+
+        /* verify the tmp ptr is NULL, otherwise indicates bad state */
+        if (key->tmp != NULL) {
+            ERROR_OUT(BAD_STATE_E);
+        }
+
+        /* if not doing this inline then allocate a buffer for it */
+        key->tmpLen = inLen;
+        if (outPtr == NULL) {
+            key->tmp = (byte*)XMALLOC(inLen, key->heap, DYNAMIC_TYPE_RSA);
+            if (key->tmp == NULL) {
+                ERROR_OUT(MEMORY_E);
+            }
+            XMEMCPY(key->tmp, in, inLen);
+        }
+        else {
+            key->tmp = in;
+        }
+        ret = wc_RsaFunction(key->tmp, inLen, key->tmp, &key->tmpLen,
+                                                                rsa_type, key);
+        if (ret < 0) {
+            break;
+        }
+        /* fall through */
+    case RSA_STATE_DECRYPT_UNPAD:
+    {
+        byte* pad = NULL;
+        key->state = RSA_STATE_DECRYPT_RES;
+        ret = wc_RsaUnPad_ex(key->tmp, key->tmpLen, &pad, pad_value, pad_type,
+                                        hash, mgf, label, labelSz, key->heap);
+        if (ret > 0 && ret <= (int)outLen && pad != NULL) {
+            /* only copy output if not inline */
+            if (outPtr == NULL) {
+                XMEMCPY(out, pad, ret);
+            }
+            else {
+                *outPtr = pad;
+            }
+        }
+        else if (ret >= 0) {
+            ret = RSA_BUFFER_E;
+        }
+        if (ret < 0) {
+            break;
+        }
+        /* fall through */
+    }
+    case RSA_STATE_DECRYPT_RES:
+        key->state = RSA_STATE_NONE;
+    #if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
+        if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA) {
+            ret = key->tmpLen;
+        }
+    #endif
+        break;
+    default:
+        ret = BAD_STATE_E;
+    }
+
+    /* if async pending then return and skip done cleanup below */
+    if (ret == WC_PENDING_E) {
+        return ret;
+    }
+
+done:
+
+    key->state = RSA_STATE_NONE;
+    if (key->tmp) {
+        /* if not inline */
+        if (outPtr == NULL) {
+            ForceZero(key->tmp, key->tmpLen);
+            XFREE(key->tmp, key->heap, DYNAMIC_TYPE_RSA);
+        }
+        key->tmp = NULL;
+        key->tmpLen = 0;
+    }
+
+    return ret;
+}
+
+
+/* Public RSA Functions */
+int wc_RsaPublicEncrypt(const byte* in, word32 inLen, byte* out, word32 outLen,
+                                                     RsaKey* key, WC_RNG* rng)
+{
+    return RsaPublicEncryptEx(in, inLen, out, outLen, key, rng,
+        RSA_PUBLIC_ENCRYPT, RSA_BLOCK_TYPE_2, WC_RSA_PKCSV15_PAD,
+        WC_HASH_TYPE_NONE, WC_MGF1NONE, NULL, 0);
+}
+
+
+#ifndef WC_NO_RSA_OAEP
+int wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
+                    word32 outLen, RsaKey* key, WC_RNG* rng, int type,
+                    enum wc_HashType hash, int mgf, byte* label,
+                    word32 labelSz)
+{
+    return RsaPublicEncryptEx(in, inLen, out, outLen, key, rng,
+        RSA_PUBLIC_ENCRYPT, RSA_BLOCK_TYPE_2, type, hash, mgf, label, labelSz);
 }
 #endif /* WC_NO_RSA_OAEP */
 
 
 int wc_RsaPrivateDecryptInline(byte* in, word32 inLen, byte** out, RsaKey* key)
 {
-    int ret;
-
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC) {
-        ret = CaviumRsaPrivateDecrypt(in, inLen, in, inLen, key);
-        if (ret > 0)
-            *out = in;
-        return ret;
-    }
-#endif
-
-    if ((ret = wc_RsaFunction(in, inLen, in, &inLen, RSA_PRIVATE_DECRYPT, key))
-            < 0) {
-        return ret;
-    }
-
-    return RsaUnPad(in, inLen, out, RSA_BLOCK_TYPE_2);
+    return RsaPrivateDecryptEx(in, inLen, in, inLen, out, key, 
+        RSA_PRIVATE_DECRYPT, RSA_BLOCK_TYPE_2, WC_RSA_PKCSV15_PAD,
+        WC_HASH_TYPE_NONE, WC_MGF1NONE, NULL, 0);
 }
 
 
 #ifndef WC_NO_RSA_OAEP
-/* Gives the option of choosing padding type
-   in : input to be decrypted
-   inLen: length of input buffer
-   out: pointer to place of decrypted message
-   key   : wolfSSL initialized RSA key struct
-   type  : type of padding to use ie WC_RSA_OAEP_PAD
-   hash  : type of hash algorithm to use found in wolfssl/wolfcrypt/hash.h
-   mgf   : type of mask generation function to use
-   label : optional label
-   labelSz : size of optional label buffer */
 int wc_RsaPrivateDecryptInline_ex(byte* in, word32 inLen, byte** out,
-                          RsaKey* key, int type, enum wc_HashType hash, int mgf,
-                          byte* label, word32 labelSz)
+                                  RsaKey* key, int type, enum wc_HashType hash,
+                                  int mgf, byte* label, word32 labelSz)
 {
-    int ret;
-
-    /* sanity check on arguments */
-    if (in == NULL || key == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    /* check if given a label size but not given a label buffer */
-    if (label == NULL && labelSz > 0) {
-        return BAD_FUNC_ARG;
-    }
-
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC) {
-        ret = CaviumRsaPrivateDecrypt(in, inLen, in, inLen, key);
-        if (ret > 0)
-            *out = in;
-        return ret;
-    }
-#endif
-
-    if ((ret = wc_RsaFunction(in, inLen, in, &inLen, RSA_PRIVATE_DECRYPT, key))
-            < 0) {
-        return ret;
-    }
-
-    return wc_RsaUnPad_ex(in, inLen, out, RSA_BLOCK_TYPE_2, type, hash, mgf,
-                                                     label, labelSz, key->heap);
+    return RsaPrivateDecryptEx(in, inLen, in, inLen, out, key, 
+        RSA_PRIVATE_DECRYPT, RSA_BLOCK_TYPE_2, type, hash,
+        mgf, label, labelSz);
 }
 #endif /* WC_NO_RSA_OAEP */
 
 
-int wc_RsaPrivateDecrypt(const byte* in, word32 inLen, byte* out, word32 outLen,
-                     RsaKey* key)
+int wc_RsaPrivateDecrypt(const byte* in, word32 inLen, byte* out,
+                                                 word32 outLen, RsaKey* key)
 {
-    int plainLen;
-    byte*  tmp;
-    byte*  pad = 0;
-
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC)
-        return CaviumRsaPrivateDecrypt(in, inLen, out, outLen, key);
-#endif
-
-    tmp = (byte*)XMALLOC(inLen, key->heap, DYNAMIC_TYPE_RSA);
-    if (tmp == NULL) {
-        return MEMORY_E;
-    }
-
-    XMEMCPY(tmp, in, inLen);
-
-    if ( (plainLen = wc_RsaPrivateDecryptInline(tmp, inLen, &pad, key) ) < 0) {
-        XFREE(tmp, key->heap, DYNAMIC_TYPE_RSA);
-        return plainLen;
-    }
-    if (plainLen > (int)outLen)
-        plainLen = BAD_FUNC_ARG;
-    else
-        XMEMCPY(out, pad, plainLen);
-
-    ForceZero(tmp, inLen);
-    XFREE(tmp, key->heap, DYNAMIC_TYPE_RSA);
-
-    return plainLen;
+    return RsaPrivateDecryptEx((byte*)in, inLen, out, outLen, NULL, key,
+        RSA_PRIVATE_DECRYPT, RSA_BLOCK_TYPE_2, WC_RSA_PKCSV15_PAD,
+        WC_HASH_TYPE_NONE, WC_MGF1NONE, NULL, 0);
 }
 
 
 #ifndef WC_NO_RSA_OAEP
-/* Gives the option of choosing padding type
-   in : input to be decrypted
-   inLen: length of input buffer
-   out:  decrypted message
-   outLen: length of decrypted message in bytes
-   key   : wolfSSL initialized RSA key struct
-   type  : type of padding to use ie WC_RSA_OAEP_PAD
-   hash  : type of hash algorithm to use found in wolfssl/wolfcrypt/hash.h
-   mgf   : type of mask generation function to use
-   label : optional label
-   labelSz : size of optional label buffer */
-int wc_RsaPrivateDecrypt_ex(const byte* in, word32 inLen, byte* out, word32 outLen,
-                          RsaKey* key, int type, enum wc_HashType hash, int mgf,
-                          byte* label, word32 labelSz)
+int wc_RsaPrivateDecrypt_ex(const byte* in, word32 inLen, byte* out,
+                            word32 outLen, RsaKey* key, int type,
+                            enum wc_HashType hash, int mgf, byte* label,
+                            word32 labelSz)
 {
-    int plainLen;
-    byte*  tmp;
-    byte*  pad = 0;
-
-    /* sanity check on arguments */
-    if (out == NULL || in == NULL || key == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    /* check if given a label size but not given a label buffer */
-    if (label == NULL && labelSz > 0) {
-        return BAD_FUNC_ARG;
-    }
-
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC)
-        return CaviumRsaPrivateDecrypt(in, inLen, out, outLen, key);
-#endif
-
-    tmp = (byte*)XMALLOC(inLen, key->heap, DYNAMIC_TYPE_RSA);
-    if (tmp == NULL) {
-        return MEMORY_E;
-    }
-
-    XMEMCPY(tmp, in, inLen);
-
-    if ( (plainLen = wc_RsaPrivateDecryptInline_ex(tmp, inLen, &pad, key,
-                                       type, hash, mgf, label, labelSz) ) < 0) {
-        XFREE(tmp, key->heap, DYNAMIC_TYPE_RSA);
-        return plainLen;
-    }
-    if (plainLen > (int)outLen || pad == NULL)
-        plainLen = BAD_FUNC_ARG;
-    else
-        XMEMCPY(out, pad, plainLen);
-
-    ForceZero(tmp, inLen);
-    XFREE(tmp, key->heap, DYNAMIC_TYPE_RSA);
-
-    return plainLen;
+    return RsaPrivateDecryptEx((byte*)in, inLen, out, outLen, NULL, key,
+        RSA_PRIVATE_DECRYPT, RSA_BLOCK_TYPE_2, type, hash, mgf, label,
+        labelSz);
 }
 #endif /* WC_NO_RSA_OAEP */
 
 
-/* for Rsa Verify */
 int wc_RsaSSL_VerifyInline(byte* in, word32 inLen, byte** out, RsaKey* key)
 {
-    int ret;
-
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC) {
-        ret = CaviumRsaSSL_Verify(in, inLen, in, inLen, key);
-        if (ret > 0)
-            *out = in;
-        return ret;
-    }
-#endif
-
-    if ((ret = wc_RsaFunction(in, inLen, in, &inLen, RSA_PUBLIC_DECRYPT, key))
-            < 0) {
-        return ret;
-    }
-
-    return RsaUnPad(in, inLen, out, RSA_BLOCK_TYPE_1);
+    return RsaPrivateDecryptEx(in, inLen, in, inLen, out, key, 
+        RSA_PUBLIC_DECRYPT, RSA_BLOCK_TYPE_1, WC_RSA_PKCSV15_PAD,
+        WC_HASH_TYPE_NONE, WC_MGF1NONE, NULL, 0);
 }
-
 
 int wc_RsaSSL_Verify(const byte* in, word32 inLen, byte* out, word32 outLen,
-                     RsaKey* key)
+                                                                 RsaKey* key)
 {
-    int plainLen;
-    byte*  tmp;
-    byte*  pad = 0;
-
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC)
-        return CaviumRsaSSL_Verify(in, inLen, out, outLen, key);
-#endif
-
-    tmp = (byte*)XMALLOC(inLen, key->heap, DYNAMIC_TYPE_RSA);
-    if (tmp == NULL) {
-        return MEMORY_E;
-    }
-
-    XMEMCPY(tmp, in, inLen);
-
-    if ( (plainLen = wc_RsaSSL_VerifyInline(tmp, inLen, &pad, key) ) < 0) {
-        XFREE(tmp, key->heap, DYNAMIC_TYPE_RSA);
-        return plainLen;
-    }
-
-    if (plainLen > (int)outLen)
-        plainLen = BAD_FUNC_ARG;
-    else
-        XMEMCPY(out, pad, plainLen);
-
-    ForceZero(tmp, inLen);
-    XFREE(tmp, key->heap, DYNAMIC_TYPE_RSA);
-
-    return plainLen;
+    return RsaPrivateDecryptEx((byte*)in, inLen, out, outLen, NULL, key, 
+        RSA_PUBLIC_DECRYPT, RSA_BLOCK_TYPE_1, WC_RSA_PKCSV15_PAD,
+        WC_HASH_TYPE_NONE, WC_MGF1NONE, NULL, 0);
 }
 
 
-/* for Rsa Sign */
 int wc_RsaSSL_Sign(const byte* in, word32 inLen, byte* out, word32 outLen,
-                      RsaKey* key, WC_RNG* rng)
+                                                   RsaKey* key, WC_RNG* rng)
 {
-    int sz, ret;
-
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC)
-        return CaviumRsaSSL_Sign(in, inLen, out, outLen, key);
-#endif
-
-    sz = mp_unsigned_bin_size(&key->n);
-    if (sz > (int)outLen)
-        return RSA_BUFFER_E;
-
-    if (sz < RSA_MIN_PAD_SZ) {
-        return WC_KEY_SIZE_E;
-    }
-
-    if (inLen > (word32)(sz - RSA_MIN_PAD_SZ))
-        return RSA_BUFFER_E;
-
-    ret = wc_RsaPad(in, inLen, out, sz, RSA_BLOCK_TYPE_1, rng);
-    if (ret != 0)
-        return ret;
-
-    if ((ret = wc_RsaFunction(out, sz, out, &outLen,
-                              RSA_PRIVATE_ENCRYPT,key)) < 0)
-        sz = ret;
-
-    return sz;
+    return RsaPublicEncryptEx(in, inLen, out, outLen, key, rng,
+        RSA_PRIVATE_ENCRYPT, RSA_BLOCK_TYPE_1, WC_RSA_PKCSV15_PAD,
+        WC_HASH_TYPE_NONE, WC_MGF1NONE, NULL, 0);
 }
 
 
 int wc_RsaEncryptSize(RsaKey* key)
 {
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC)
-        return key->c_nSz;
+#if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
+    if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA) {
+        return key->n.used;
+    }
 #endif
     return mp_unsigned_bin_size(&key->n);
 }
 
+
 /* flatten RsaKey structure into individual elements (e, n) */
 int wc_RsaFlattenPublicKey(RsaKey* key, byte* e, word32* eSz, byte* n,
-                           word32* nSz)
+                                                                   word32* nSz)
 {
     int sz, ret;
 
-    if (key == NULL || e == NULL || eSz == NULL || n == NULL || nSz == NULL)
-       return BAD_FUNC_ARG;
+    if (key == NULL || e == NULL || eSz == NULL || n == NULL || nSz == NULL) {
+        return BAD_FUNC_ARG;
+    }
 
     sz = mp_unsigned_bin_size(&key->e);
     if ((word32)sz > *nSz)
@@ -1244,7 +1349,7 @@ int wc_RsaFlattenPublicKey(RsaKey* key, byte* e, word32* eSz, byte* n,
         return ret;
     *eSz = (word32)sz;
 
-    sz = mp_unsigned_bin_size(&key->n);
+    sz = wc_RsaEncryptSize(key);
     if ((word32)sz > *nSz)
         return RSA_BUFFER_E;
     ret = mp_to_unsigned_bin(&key->n, n);
@@ -1361,188 +1466,141 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
 
     return 0;
 }
-
-
 #endif /* WOLFSSL_KEY_GEN */
 
 
-#ifdef HAVE_CAVIUM
-
-#include <wolfssl/wolfcrypt/logging.h>
-#include "cavium_common.h"
-
-/* Initialize RSA for use with Nitrox device */
-int wc_RsaInitCavium(RsaKey* rsa, int devId)
+#ifdef WOLFSSL_ASYNC_CRYPT
+/* Initialize RSA for use with async hardware */
+int wc_RsaAsyncInit(RsaKey* rsa, int devId)
 {
     if (rsa == NULL)
-        return -1;
+        return BAD_FUNC_ARG;
 
-    if (CspAllocContext(CONTEXT_SSL, &rsa->contextHandle, devId) != 0)
-        return -1;
-
-    rsa->devId = devId;
-    rsa->magic = WOLFSSL_RSA_CAVIUM_MAGIC;
-
-    return 0;
+    return wolfAsync_DevCtxInit(&rsa->asyncDev, WOLFSSL_ASYNC_MARKER_RSA, devId);
 }
 
+int wc_RsaAsyncHandle(RsaKey* key, WOLF_EVENT_QUEUE* queue, WOLF_EVENT* event)
+{
+    int ret;
 
-/* Free RSA from use with Nitrox device */
-void wc_RsaFreeCavium(RsaKey* rsa)
+    if (key == NULL || queue == NULL || event == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* make sure this rsa context had "wc_RsaAsyncInit" called on it */
+    if (key->asyncDev.marker != WOLFSSL_ASYNC_MARKER_RSA) {
+        return ASYNC_INIT_E;
+    }
+
+    /* setup the event and push to queue */
+    ret = wolfAsync_EventInit(event, WOLF_EVENT_TYPE_ASYNC_WOLFCRYPT, &key->asyncDev);
+    if (ret == 0) {
+        ret = wolfEventQueue_Push(queue, event);
+    }
+
+    /* check for error (helps with debugging) */
+    if (ret != 0) {
+        WOLFSSL_MSG("wc_RsaAsyncHandle failed");
+    }
+    return ret;
+}
+
+int wc_RsaAsyncWait(int ret, RsaKey* key)
+{
+    if (ret == WC_PENDING_E) {
+        WOLF_EVENT event;
+        XMEMSET(&event, 0, sizeof(event));
+        ret = wolfAsync_EventInit(&event, WOLF_EVENT_TYPE_ASYNC_WOLFCRYPT, &key->asyncDev);
+        if (ret == 0) {
+            ret = wolfAsync_EventWait(&event);
+            if (ret == 0 && event.ret >= 0) {
+                ret = event.ret;
+            }
+        }
+    }
+    return ret;
+}
+
+/* Free RSA from use with async hardware */
+void wc_RsaAsyncFree(RsaKey* rsa)
 {
     if (rsa == NULL)
         return;
 
-    CspFreeContext(CONTEXT_SSL, rsa->contextHandle, rsa->devId);
-    rsa->magic = 0;
+    wolfAsync_DevCtxFree(&rsa->asyncDev);
 }
 
-
-/* Initialize cavium RSA key */
-static int InitCaviumRsaKey(RsaKey* key, void* heap)
+/* Initialize async RSA key */
+static int InitAsyncRsaKey(RsaKey* key)
 {
-    if (key == NULL)
-        return BAD_FUNC_ARG;
-
-    key->heap = heap;
-    key->type = -1;   /* don't know yet */
-
-    key->c_n  = NULL;
-    key->c_e  = NULL;
-    key->c_d  = NULL;
-    key->c_p  = NULL;
-    key->c_q  = NULL;
-    key->c_dP = NULL;
-    key->c_dQ = NULL;
-    key->c_u  = NULL;
-
-    key->c_nSz   = 0;
-    key->c_eSz   = 0;
-    key->c_dSz   = 0;
-    key->c_pSz   = 0;
-    key->c_qSz   = 0;
-    key->c_dP_Sz = 0;
-    key->c_dQ_Sz = 0;
-    key->c_uSz   = 0;
+    XMEMSET(&key->n,  0, sizeof(key->n));
+    XMEMSET(&key->e,  0, sizeof(key->e));
+    XMEMSET(&key->d,  0, sizeof(key->d));
+    XMEMSET(&key->p,  0, sizeof(key->p));
+    XMEMSET(&key->q,  0, sizeof(key->q));
+    XMEMSET(&key->dP, 0, sizeof(key->dP));
+    XMEMSET(&key->dQ, 0, sizeof(key->dQ));
+    XMEMSET(&key->u,  0, sizeof(key->u));
 
     return 0;
 }
 
-
-/* Free cavium RSA key */
-static int FreeCaviumRsaKey(RsaKey* key)
+/* Free async RSA key */
+static int FreeAsyncRsaKey(RsaKey* key)
 {
     if (key == NULL)
         return BAD_FUNC_ARG;
 
-    XFREE(key->c_n,  key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
-    XFREE(key->c_e,  key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
-    XFREE(key->c_d,  key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
-    XFREE(key->c_p,  key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
-    XFREE(key->c_q,  key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
-    XFREE(key->c_dP, key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
-    XFREE(key->c_dQ, key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
-    XFREE(key->c_u,  key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
-
-    return InitCaviumRsaKey(key, key->heap);  /* reset pointers */
-}
-
-
-static int CaviumRsaPublicEncrypt(const byte* in, word32 inLen, byte* out,
-                                   word32 outLen, RsaKey* key)
-{
-    word32 requestId;
-    word32 ret;
-
-    if (key == NULL || in == NULL || out == NULL || outLen < (word32)key->c_nSz)
-        return -1;
-
-    ret = CspPkcs1v15Enc(CAVIUM_BLOCKING, BT2, key->c_nSz, key->c_eSz,
-                         (word16)inLen, key->c_n, key->c_e, (byte*)in, out,
-                         &requestId, key->devId);
-    if (ret != 0) {
-        WOLFSSL_MSG("Cavium Enc BT2 failed");
-        return -1;
+    if (key->type == RSA_PRIVATE) {
+        if (key->d.dpraw) {
+            ForceZero(key->d.dpraw, key->d.used);
+        #ifndef USE_FAST_MATH
+            XFREE(key->d.dpraw,  key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
+        #endif
+        }
+        if (key->p.dpraw) {
+            ForceZero(key->p.dpraw, key->p.used);
+        #ifndef USE_FAST_MATH
+            XFREE(key->p.dpraw,  key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
+        #endif
+        }
+        if (key->q.dpraw) {
+            ForceZero(key->q.dpraw, key->q.used);
+        #ifndef USE_FAST_MATH
+            XFREE(key->q.dpraw,  key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
+        #endif
+        }
+        if (key->dP.dpraw) {
+            ForceZero(key->dP.dpraw, key->dP.used);
+        #ifndef USE_FAST_MATH
+            XFREE(key->dP.dpraw, key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
+        #endif
+        }
+        if (key->dQ.dpraw) {
+            ForceZero(key->dQ.dpraw, key->dQ.used);
+        #ifndef USE_FAST_MATH
+            XFREE(key->dQ.dpraw, key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
+        #endif
+        }
+        if (key->u.dpraw) {
+            ForceZero(key->u.dpraw, key->u.used);
+        #ifndef USE_FAST_MATH
+            XFREE(key->u.dpraw,  key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
+        #endif
+        }
     }
-    return key->c_nSz;
+
+#ifndef USE_FAST_MATH
+    XFREE(key->n.dpraw,  key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
+    XFREE(key->e.dpraw,  key->heap, DYNAMIC_TYPE_CAVIUM_TMP);
+#endif
+
+    return InitAsyncRsaKey(key);  /* reset pointers */
 }
 
+#endif /* WOLFSSL_ASYNC_CRYPT */
 
-static INLINE void ato16(const byte* c, word16* u16)
-{
-    *u16 = (c[0] << 8) | (c[1]);
-}
-
-
-static int CaviumRsaPrivateDecrypt(const byte* in, word32 inLen, byte* out,
-                                    word32 outLen, RsaKey* key)
-{
-    word32 requestId;
-    word32 ret;
-    word16 outSz = (word16)outLen;
-
-    if (key == NULL || in == NULL || out == NULL || inLen != (word32)key->c_nSz)
-        return -1;
-
-    ret = CspPkcs1v15CrtDec(CAVIUM_BLOCKING, BT2, key->c_nSz, key->c_q,
-                            key->c_dQ, key->c_p, key->c_dP, key->c_u,
-                            (byte*)in, &outSz, out, &requestId, key->devId);
-    if (ret != 0) {
-        WOLFSSL_MSG("Cavium CRT Dec BT2 failed");
-        return -1;
-    }
-    ato16((const byte*)&outSz, &outSz); 
-
-    return outSz;
-}
-
-
-static int CaviumRsaSSL_Sign(const byte* in, word32 inLen, byte* out,
-                             word32 outLen, RsaKey* key)
-{
-    word32 requestId;
-    word32 ret;
-
-    if (key == NULL || in == NULL || out == NULL || inLen == 0 || outLen <
-                                                             (word32)key->c_nSz)
-        return -1;
-
-    ret = CspPkcs1v15CrtEnc(CAVIUM_BLOCKING, BT1, key->c_nSz, (word16)inLen,
-                            key->c_q, key->c_dQ, key->c_p, key->c_dP, key->c_u,
-                            (byte*)in, out, &requestId, key->devId);
-    if (ret != 0) {
-        WOLFSSL_MSG("Cavium CRT Enc BT1 failed");
-        return -1;
-    }
-    return key->c_nSz;
-}
-
-
-static int CaviumRsaSSL_Verify(const byte* in, word32 inLen, byte* out,
-                               word32 outLen, RsaKey* key)
-{
-    word32 requestId;
-    word32 ret;
-    word16 outSz = (word16)outLen;
-
-    if (key == NULL || in == NULL || out == NULL || inLen != (word32)key->c_nSz)
-        return -1;
-
-    ret = CspPkcs1v15Dec(CAVIUM_BLOCKING, BT1, key->c_nSz, key->c_eSz,
-                         key->c_n, key->c_e, (byte*)in, &outSz, out,
-                         &requestId, key->devId);
-    if (ret != 0) {
-        WOLFSSL_MSG("Cavium Dec BT1 failed");
-        return -1;
-    }
-    outSz = ntohs(outSz);
-
-    return outSz;
-}
-
-
-#endif /* HAVE_CAVIUM */
+#undef ERROR_OUT
 
 #endif /* HAVE_FIPS */
 #endif /* NO_RSA */
-

--- a/wolfcrypt/src/wolfevent.c
+++ b/wolfcrypt/src/wolfevent.c
@@ -1,0 +1,274 @@
+/* wolfevent.c
+ *
+ * Copyright (C) 2006-2016 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+
+#ifdef HAVE_WOLF_EVENT
+
+#include <wolfssl/internal.h>
+#include <wolfssl/error-ssl.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#include <wolfssl/wolfcrypt/wolfevent.h>
+
+
+int wolfEvent_Init(WOLF_EVENT* event, WOLF_EVENT_TYPE type, void* context)
+{
+    if (event == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (event->pending) {
+        WOLFSSL_MSG("event already pending!");
+        return BAD_COND_E;
+    }
+
+    XMEMSET(event, 0, sizeof(WOLF_EVENT));
+    event->type = type;
+    event->context = context;
+
+    return 0;
+}
+
+int wolfEvent_Poll(WOLF_EVENT* event, WOLF_EVENT_FLAG flags)
+{
+    int ret = BAD_COND_E;
+
+    /* Check hardware */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if (event->type >= WOLF_EVENT_TYPE_ASYNC_FIRST &&
+        event->type <= WOLF_EVENT_TYPE_ASYNC_LAST)
+    {
+        ret = wolfAsync_EventPoll(event, flags);
+    }
+#endif /* WOLFSSL_ASYNC_CRYPT */
+
+    return ret;
+}
+
+int wolfEventQueue_Init(WOLF_EVENT_QUEUE* queue)
+{
+    int ret = 0;
+
+    if (queue == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    XMEMSET(queue, 0, sizeof(WOLF_EVENT_QUEUE));
+#ifndef SINGLE_THREADED
+    ret = InitMutex(&queue->lock);
+#endif
+    return ret;
+}
+
+
+int wolfEventQueue_Push(WOLF_EVENT_QUEUE* queue, WOLF_EVENT* event)
+{
+    int ret;
+
+    if (queue == NULL || event == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifndef SINGLE_THREADED
+    if ((ret = LockMutex(&queue->lock)) != 0) {
+        return ret;
+    }
+#endif
+
+    /* Setup event */
+    event->next = NULL;
+    event->pending = 1;
+
+    if (queue->tail == NULL)  {
+        queue->head = event;
+    }
+    else {
+        queue->tail->next = event;
+        event->prev = queue->tail;
+    }
+    queue->tail = event;      /* add to the end either way */
+    queue->count++;
+    ret = 0;
+
+#ifndef SINGLE_THREADED
+    UnLockMutex(&queue->lock);
+#endif
+
+    return ret;
+}
+
+int wolfEventQueue_Pop(WOLF_EVENT_QUEUE* queue, WOLF_EVENT** event)
+{
+    int ret = 0;
+
+    if (queue == NULL || event == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifndef SINGLE_THREADED
+    /* In single threaded mode "event_queue.lock" doesn't exist */
+    if ((ret = LockMutex(&queue->lock)) != 0) {
+        return ret;
+    }
+#endif
+
+    /* Pop first item off queue */
+    *event = queue->head;
+    ret = wolfEventQueue_Remove(queue, *event);
+
+#ifndef SINGLE_THREADED
+    UnLockMutex(&queue->lock);
+#endif
+
+    return ret;
+}
+
+/* assumes queue is locked by caller */
+int wolfEventQueue_Remove(WOLF_EVENT_QUEUE* queue, WOLF_EVENT* event)
+{
+    int ret = 0;
+
+    if (queue == NULL || event == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (event == queue->head && event == queue->tail) {
+        queue->head = NULL;
+        queue->tail = NULL;
+    }
+    else if (event == queue->head) {
+        queue->head = event->next;
+        queue->head->prev = NULL;
+    }
+    else if (event == queue->tail) {
+        queue->tail = event->prev;
+        queue->tail->next = NULL;
+    }
+    else {
+        WOLF_EVENT* next = event->next;
+        WOLF_EVENT* prev = event->prev;
+        next->prev = prev;
+        prev->next = next;
+    }
+    queue->count--;
+
+    return ret;
+}
+
+int wolfEventQueue_Poll(WOLF_EVENT_QUEUE* queue, void* context_filter,
+    WOLF_EVENT** events, int maxEvents, WOLF_EVENT_FLAG flags, int* eventCount)
+{
+    WOLF_EVENT* event;
+    int ret = 0, count = 0;
+
+    if (queue == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifndef SINGLE_THREADED
+    /* In single threaded mode "event_queue.lock" doesn't exist */
+    if ((ret = LockMutex(&queue->lock)) != 0) {
+        return ret;
+    }
+#endif
+
+    /* itterate event queue */
+    for (event = queue->head; event != NULL; event = event->next)
+    {
+        /* optional filter based on context */
+        if (context_filter == NULL || event->context == context_filter) {
+
+            /* poll event */
+            ret = wolfEvent_Poll(event, flags);
+            if (ret < 0) break; /* exit for */
+
+            /* If event is done then process */
+            if (event->done) {
+                /* remove from queue */
+                ret = wolfEventQueue_Remove(queue, event);
+                if (ret < 0) break; /* exit for */
+
+                /* return pointer in 'events' arg */
+                if (events) {
+                    events[count] = event; /* return pointer */
+                }
+                count++;
+
+                /* check to make sure our event list isn't full */
+                if (events && count >= maxEvents) {
+                    break; /* exit for */
+                }
+            }
+        }
+    }
+
+#ifndef SINGLE_THREADED
+    UnLockMutex(&queue->lock);
+#endif
+
+    /* return number of properly populated events */
+    if (eventCount) {
+        *eventCount = count;
+    }
+
+    return ret;
+}
+
+int wolfEventQueue_Count(WOLF_EVENT_QUEUE* queue)
+{
+    int ret;
+
+    if (queue == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifndef SINGLE_THREADED
+    /* In single threaded mode "event_queue.lock" doesn't exist */
+    if ((ret = LockMutex(&queue->lock)) != 0) {
+        return ret;
+    }
+#endif
+
+    ret = queue->count;
+
+#ifndef SINGLE_THREADED
+    UnLockMutex(&queue->lock);
+#endif
+
+    return ret;
+}
+
+void wolfEventQueue_Free(WOLF_EVENT_QUEUE* queue)
+{
+    if (queue) {
+    #ifndef SINGLE_THREADED
+        FreeMutex(&queue->lock);
+    #endif
+    }
+}
+
+#endif /* HAVE_WOLF_EVENT */

--- a/wolfssl-ntru.vcproj
+++ b/wolfssl-ntru.vcproj
@@ -322,6 +322,10 @@
 				RelativePath=".\wolfcrypt\src\wc_encrypt.c"
 				>
 			</File>
+			<File
+				RelativePath=".\wolfcrypt\src\wolfevent.c"
+				>
+			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"

--- a/wolfssl.vcproj
+++ b/wolfssl.vcproj
@@ -315,6 +315,10 @@
 				RelativePath=".\wolfcrypt\src\wc_encrypt.c"
 				>
 			</File>
+			<File
+				RelativePath=".\wolfcrypt\src\wolfevent.c"
+				>
+			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"

--- a/wolfssl.vcxproj
+++ b/wolfssl.vcxproj
@@ -317,6 +317,7 @@
     <ClCompile Include="wolfcrypt\src\signature.c" />
     <ClCompile Include="wolfcrypt\src\wc_encrypt.c" />
     <ClCompile Include="wolfcrypt\src\wc_port.c" />
+    <ClCompile Include="wolfcrypt\src\wolfevent.c" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="wolfcrypt\src\aes_asm.asm">

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -142,7 +142,6 @@ enum wolfSSL_ErrorCodes {
     UNKNOWN_ALPN_PROTOCOL_NAME_E = -405,   /* Unrecognized protocol name Error*/
     BAD_CERTIFICATE_STATUS_ERROR = -406,   /* Bad certificate status message */
     OCSP_INVALID_STATUS          = -407,   /* Invalid OCSP Status */
-    ASYNC_NOT_PENDING            = -408,   /* Async operation not pending */
 
     RSA_KEY_SIZE_E               = -409,   /* RSA key too small */
     ECC_KEY_SIZE_E               = -410,   /* ECC key too small */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -155,7 +155,7 @@
 #endif
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    #include <wolfssl/async.h>
+    #include <wolfssl/wolfcrypt/async.h>
 #endif
 
 #ifdef _MSC_VER
@@ -1059,8 +1059,6 @@ enum Misc {
 
     HASH_SIG_SIZE      =   2,  /* default SHA1 RSA */
 
-    NO_CAVIUM_DEVICE   =  -2,  /* invalid cavium device id */
-
     NO_COPY            =   0,  /* should we copy static buffer for write */
     COPY               =   1   /* should we copy static buffer for write */
 };
@@ -1899,20 +1897,6 @@ WOLFSSL_LOCAL int TLSX_ValidateQSHScheme(TLSX** extensions, word16 name);
 #endif /* HAVE_QSH */
 
 
-#ifdef HAVE_WOLF_EVENT
-typedef struct {
-    WOLF_EVENT*         head;     /* head of queue */
-    WOLF_EVENT*         tail;     /* tail of queue */
-#ifndef SINGLE_THREADED
-    wolfSSL_Mutex       lock;     /* queue lock */
-#endif
-} WOLF_EVENT_QUEUE;
-
-WOLFSSL_LOCAL int wolfSSL_EventInit(WOLFSSL* ssl, WOLF_EVENT_TYPE type);
-
-WOLFSSL_LOCAL int wolfSSL_CTX_EventPush(WOLFSSL_CTX* ctx, WOLF_EVENT* event);
-#endif /* HAVE_WOLF_EVENT */
-
 #ifdef WOLFSSL_STATIC_MEMORY
 WOLFSSL_LOCAL int wolfSSL_init_memory_heap(WOLFSSL_HEAP* heap);
 #endif
@@ -2001,8 +1985,8 @@ struct WOLFSSL_CTX {
 #ifdef HAVE_OCSP
     WOLFSSL_OCSP      ocsp;
 #endif
-#ifdef HAVE_CAVIUM
-    int              devId;            /* cavium device id to use */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncDevHandle    devId;            /* async device id to use */
 #endif
 #ifdef HAVE_TLS_EXTENSIONS
     TLSX* extensions;                  /* RFC 6066 TLS Extensions data */
@@ -2681,7 +2665,8 @@ struct WOLFSSL {
     void*           hsDoneCtx;         /*  user handshake cb context  */
 #endif
 #ifdef WOLFSSL_ASYNC_CRYPT
-    AsyncCrypt      async;
+    AsyncCryptSSLState  async;
+    AsyncCryptDev       asyncDev;
 #endif
     void*           sigKey;             /* RsaKey or ecc_key allocated from heap */
     word32          sigType;            /* Type of sigKey */
@@ -2780,8 +2765,8 @@ struct WOLFSSL {
 #if defined(FORTRESS) || defined(HAVE_STUNNEL)
     void*           ex_data[MAX_EX_DATA]; /* external data, for Fortress */
 #endif
-#ifdef HAVE_CAVIUM
-    int              devId;            /* cavium device id to use */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncDevHandle  devId;               /* async device id to use */
 #endif
 #ifdef HAVE_ONE_TIME_AUTH
     OneTimeAuth     auth;
@@ -2844,9 +2829,6 @@ struct WOLFSSL {
 #ifdef HAVE_WOLF_EVENT
     WOLF_EVENT event;
 #endif /* HAVE_WOLF_EVENT */
-#ifdef WOLFSSL_ASYNC_CRYPT_TEST
-    AsyncCryptTests asyncCryptTest;
-#endif /* WOLFSSL_ASYNC_CRYPT_TEST */
 };
 
 
@@ -3008,6 +2990,8 @@ WOLFSSL_LOCAL int VerifyClientSuite(WOLFSSL* ssl);
             byte** out, RsaKey* key, const byte* keyBuf, word32 keySz, void* ctx);
         WOLFSSL_LOCAL int RsaDec(WOLFSSL* ssl, byte* in, word32 inSz, byte** out,
             word32* outSz, RsaKey* key, const byte* keyBuf, word32 keySz, void* ctx);
+        WOLFSSL_LOCAL int RsaEnc(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
+            word32* outSz, RsaKey* key, const byte* keyBuf, word32 keySz, void* ctx);
     #endif /* !NO_RSA */
 
     #ifdef HAVE_ECC
@@ -3015,7 +2999,7 @@ WOLFSSL_LOCAL int VerifyClientSuite(WOLFSSL* ssl);
             byte* out, word32* outSz, ecc_key* key, byte* keyBuf, word32 keySz,
             void* ctx);
         WOLFSSL_LOCAL int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz,
-            byte* out, word32 outSz, ecc_key* key, byte* keyBuf, word32 keySz,
+            const byte* out, word32 outSz, ecc_key* key, byte* keyBuf, word32 keySz,
             void* ctx);
         WOLFSSL_LOCAL int EccSharedSecret(WOLFSSL* ssl, ecc_key* priv_key,
             ecc_key* pub_key, byte* out, word32* outSz);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1408,9 +1408,9 @@ WOLFSSL_API void wolfSSL_KeepArrays(WOLFSSL*);
 WOLFSSL_API void wolfSSL_FreeArrays(WOLFSSL*);
 
 
-/* cavium additions */
-WOLFSSL_API int wolfSSL_UseCavium(WOLFSSL*, int devId);
-WOLFSSL_API int wolfSSL_CTX_UseCavium(WOLFSSL_CTX*, int devId);
+/* async additions */
+WOLFSSL_API int wolfSSL_UseAsync(WOLFSSL*, int devId);
+WOLFSSL_API int wolfSSL_CTX_UseAsync(WOLFSSL_CTX*, int devId);
 
 /* TLS Extensions */
 
@@ -1877,41 +1877,6 @@ WOLFSSL_API int wolfSSL_set_jobject(WOLFSSL* ssl, void* objPtr);
 WOLFSSL_API void* wolfSSL_get_jobject(WOLFSSL* ssl);
 #endif /* WOLFSSL_JNI */
 
-#ifdef HAVE_WOLF_EVENT
-typedef enum WOLF_EVENT_TYPE {
-    WOLF_EVENT_TYPE_NONE,
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        WOLF_EVENT_TYPE_ASYNC_ACCEPT,
-        WOLF_EVENT_TYPE_ASYNC_CONNECT,
-        WOLF_EVENT_TYPE_ASYNC_READ,
-        WOLF_EVENT_TYPE_ASYNC_WRITE,
-        WOLF_EVENT_TYPE_ASYNC_FIRST = WOLF_EVENT_TYPE_ASYNC_ACCEPT,
-        WOLF_EVENT_TYPE_ASYNC_LAST = WOLF_EVENT_TYPE_ASYNC_WRITE,
-    #endif
-} WOLF_EVENT_TYPE;
-
-typedef struct WOLF_EVENT WOLF_EVENT;
-struct WOLF_EVENT {
-    WOLF_EVENT*         next;   /* To support event linked list */
-	WOLFSSL*            ssl;    /* Reference back to SSL object */
-    int                 ret;    /* Async return code */
-    WOLF_EVENT_TYPE     type;
-    unsigned short      pending:1;
-    unsigned short      done:1;
-    /* Future event flags can go here */
-};
-
-enum WOLF_POLL_FLAGS {
-    WOLF_POLL_FLAG_CHECK_HW = 0x01,
-    WOLF_POLL_FLAG_PEEK = 0x02,
-};
-
-WOLFSSL_API int wolfSSL_CTX_poll(WOLFSSL_CTX* ctx, WOLF_EVENT* events,
-    int maxEvents, unsigned char flags, int* eventCount);
-WOLFSSL_API int wolfSSL_poll(WOLFSSL* ssl, WOLF_EVENT* events,
-    int maxEvents, unsigned char flags, int* eventCount);
-
-#endif /* HAVE_WOLF_EVENT */
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -107,10 +107,11 @@
     #define SNPRINTF snprintf
 #endif /* USE_WINDOWS_API */
 
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
 #ifdef HAVE_CAVIUM
-    #include "cavium_sysdep.h"
-    #include "cavium_common.h"
-    #include "cavium_ioctl.h"
+    #include <wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h>
 #endif
 
 #ifdef _MSC_VER
@@ -1214,29 +1215,6 @@ static INLINE void CaCb(unsigned char* der, int sz, int type)
 
 #endif /* !NO_CERTS */
 
-#ifdef HAVE_CAVIUM
-
-static INLINE int OpenNitroxDevice(int dma_mode,int dev_id)
-{
-   Csp1CoreAssignment core_assign;
-   Uint32             device;
-
-   if (CspInitialize(CAVIUM_DIRECT,CAVIUM_DEV_ID))
-      return -1;
-   if (Csp1GetDevType(&device))
-      return -1;
-   if (device != NPX_DEVICE) {
-      if (ioctl(gpkpdev_hdlr[CAVIUM_DEV_ID], IOCTL_CSP1_GET_CORE_ASSIGNMENT,
-                (Uint32 *)&core_assign)!= 0)
-         return -1;
-   }
-   CspShutdown(CAVIUM_DEV_ID);
-
-   return CspInitialize(dma_mode, dev_id);
-}
-
-#endif /* HAVE_CAVIUM */
-
 
 /* Wolf Root Directory Helper */
 /* KEIL-RL File System does not support relative directory */
@@ -1962,24 +1940,6 @@ static INLINE const char* mymktemp(char *tempfn, int len, int num)
     }
 
 #endif  /* HAVE_SESSION_TICKET && CHACHA20 && POLY1305 */
-
-#ifdef WOLFSSL_ASYNC_CRYPT
-    static INLINE int AsyncCryptPoll(WOLFSSL* ssl)
-    {
-        int ret, eventCount = 0;
-        WOLF_EVENT events[1];
-
-        printf("Connect/Accept got WC_PENDING_E\n");
-
-        ret = wolfSSL_poll(ssl, events, sizeof(events)/sizeof(WOLF_EVENT),
-            WOLF_POLL_FLAG_CHECK_HW, &eventCount);
-        if (ret == 0 && eventCount > 0) {
-            ret = 1; /* Success */
-        }
-
-        return ret;
-    }
-#endif
 
 static INLINE word16 GetRandomPort(void)
 {

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -39,10 +39,6 @@
 #endif
 
 #ifndef HAVE_FIPS /* to avoid redefinition of macros */
-#ifdef HAVE_CAVIUM
-    #include <wolfssl/wolfcrypt/logging.h>
-    #include "cavium_common.h"
-#endif
 
 #ifdef WOLFSSL_AESNI
 
@@ -74,7 +70,10 @@
 #endif
 
 #ifndef HAVE_FIPS /* to avoid redefinition of structures */
-#define WOLFSSL_AES_CAVIUM_MAGIC 0xBEEF0002
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
 
 enum {
     AES_ENC_TYPE   = 1,   /* cipher unique type */
@@ -102,12 +101,12 @@ typedef struct Aes {
 #ifdef WOLFSSL_AESNI
     byte use_aesni;
 #endif /* WOLFSSL_AESNI */
-#ifdef HAVE_CAVIUM
-    AesType type;            /* aes key type */
-    int     devId;           /* nitrox device id */
-    word32  magic;           /* using cavium magic */
-    word64  contextHandle;   /* nitrox context memory handle */
-#endif
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncCryptDev asyncDev;
+    #ifdef HAVE_CAVIUM
+        AesType type;                       /* aes key type */
+    #endif
+#endif /* WOLFSSL_ASYNC_CRYPT */
 #ifdef WOLFSSL_AES_COUNTER
     word32  left;            /* unused bytes left from last call */
 #endif
@@ -183,9 +182,9 @@ WOLFSSL_API int  wc_AesCbcDecrypt(Aes* aes, byte* out,
                                    const byte* authIn, word32 authInSz);
 #endif /* HAVE_AESCCM */
 
-#ifdef HAVE_CAVIUM
-     WOLFSSL_API int  wc_AesInitCavium(Aes*, int);
-     WOLFSSL_API void wc_AesFreeCavium(Aes*);
+#ifdef WOLFSSL_ASYNC_CRYPT
+     WOLFSSL_API int  wc_AesAsyncInit(Aes*, int);
+     WOLFSSL_API void wc_AesAsyncFree(Aes*);
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/arc4.h
+++ b/wolfssl/wolfcrypt/arc4.h
@@ -30,7 +30,9 @@
     extern "C" {
 #endif
 
-#define WOLFSSL_ARC4_CAVIUM_MAGIC 0xBEEF0001
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
 
 enum {
 	ARC4_ENC_TYPE   = 4,    /* cipher unique type */
@@ -42,19 +44,17 @@ typedef struct Arc4 {
     byte x;
     byte y;
     byte state[ARC4_STATE_SIZE];
-#ifdef HAVE_CAVIUM
-    int    devId;           /* nitrox device id */
-    word32 magic;           /* using cavium magic */
-    word64 contextHandle;   /* nitrox context memory handle */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncCryptDev asyncDev;
 #endif
 } Arc4;
 
 WOLFSSL_API void wc_Arc4Process(Arc4*, byte*, const byte*, word32);
 WOLFSSL_API void wc_Arc4SetKey(Arc4*, const byte*, word32);
 
-#ifdef HAVE_CAVIUM
-    WOLFSSL_API int  wc_Arc4InitCavium(Arc4*, int);
-    WOLFSSL_API void wc_Arc4FreeCavium(Arc4*);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    WOLFSSL_API int  wc_Arc4AsyncInit(Arc4*, int);
+    WOLFSSL_API void wc_Arc4AsyncFree(Arc4*);
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/des3.h
+++ b/wolfssl/wolfcrypt/des3.h
@@ -37,7 +37,10 @@
 #endif
 
 #ifndef HAVE_FIPS /* to avoid redefinition of macros */
-#define WOLFSSL_3DES_CAVIUM_MAGIC 0xBEEF0003
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
 
 enum {
     DES_ENC_TYPE    = 2,     /* cipher unique type */
@@ -76,10 +79,8 @@ typedef struct Des3 {
     word32 key[3][DES_KS_SIZE];
     word32 reg[DES_BLOCK_SIZE / sizeof(word32)];      /* for CBC mode */
     word32 tmp[DES_BLOCK_SIZE / sizeof(word32)];      /* same         */
-#ifdef HAVE_CAVIUM
-    int     devId;           /* nitrox device id */
-    word32  magic;           /* using cavium magic */
-    word64  contextHandle;   /* nitrox context memory handle */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncCryptDev asyncDev;
 #endif
 } Des3;
 #endif /* HAVE_FIPS */
@@ -102,9 +103,9 @@ WOLFSSL_API int  wc_Des3_CbcEncrypt(Des3* des, byte* out,
 WOLFSSL_API int  wc_Des3_CbcDecrypt(Des3* des, byte* out,
                                     const byte* in,word32 sz);
 
-#ifdef HAVE_CAVIUM
-    WOLFSSL_API int  wc_Des3_InitCavium(Des3*, int);
-    WOLFSSL_API void wc_Des3_FreeCavium(Des3*);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    WOLFSSL_API int  wc_Des3AsyncInit(Des3*, int);
+    WOLFSSL_API void wc_Des3AsyncFree(Des3*);
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -30,6 +30,10 @@
 #include <wolfssl/wolfcrypt/integer.h>
 #include <wolfssl/wolfcrypt/random.h>
 
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
+
 #ifdef __cplusplus
     extern "C" {
 #endif
@@ -48,7 +52,7 @@ enum {
 
 
 /* ECC set type defined a NIST GF(p) curve */
-typedef struct {
+typedef struct ecc_set_type {
     int size;             /* The size of the curve in octets */
     int nid;              /* id of this curve */
     const char* name;     /* name of this curve */
@@ -169,6 +173,10 @@ typedef struct {
     ecc_point pubkey;   /* public key */
     mp_int    k;        /* private key */
     void*     heap;     /* heap hint */
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncCryptDev asyncDev;
+#endif
 } ecc_key;
 
 

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -44,6 +44,9 @@ enum {
     CRYPTGEN_E         = -104,  /* windows crypt generation error */
     RAN_BLOCK_E        = -105,  /* reading random device would block */
     BAD_MUTEX_E        = -106,  /* Bad mutex operation */
+    WC_TIMEOUT_E       = -107,  /* timeout error */
+    WC_PENDING_E       = -108,  /* wolfCrypt operation pending (would block) */
+    WC_NOT_PENDING_E   = -109,  /* wolfCrypt operation not pending */
 
     MP_INIT_E          = -110,  /* mp_init error state */
     MP_READ_E          = -111,  /* mp_read error state */
@@ -60,7 +63,6 @@ enum {
 
     MEMORY_E           = -125,  /* out of memory error */
     VAR_STATE_CHANGE_E = -126,  /* var state modified by different thread */
-
 
     RSA_WRONG_TYPE_E   = -130,  /* RSA wrong block type for RSA function */
     RSA_BUFFER_E       = -131,  /* RSA buffer error, output too small or
@@ -108,7 +110,7 @@ enum {
     AES_GCM_AUTH_E     = -180,  /* AES-GCM Authentication check failure */
     AES_CCM_AUTH_E     = -181,  /* AES-CCM Authentication check failure */
 
-    CAVIUM_INIT_E      = -182,  /* Cavium Init type error */
+    ASYNC_INIT_E       = -182,  /* Async Init type error */
 
     COMPRESS_INIT_E    = -183,  /* Compress init error */
     COMPRESS_E         = -184,  /* Compress error */
@@ -121,7 +123,7 @@ enum {
     ASN_CRL_NO_SIGNER_E = -190,  /* ASN CRL no signer to confirm failure */
     ASN_OCSP_CONFIRM_E  = -191,  /* ASN OCSP signature confirm failure */
 
-    BAD_ENC_STATE_E     = -192,  /* Bad ecc enc state operation */
+    BAD_STATE_E         = -192,  /* Bad state operation */
     BAD_PADDING_E       = -193,  /* Bad padding, msg not correct length  */
 
     REQ_ATTRIBUTE_E     = -194,  /* setting cert request attributes error */
@@ -169,7 +171,6 @@ enum {
     BAD_COND_E          = -230,  /* Bad condition variable operation */
     SIG_TYPE_E          = -231,  /* Signature Type not enabled/available */
     HASH_TYPE_E         = -232,  /* Hash Type not enabled/available */
-    WC_PENDING_E        = -233,  /* wolfCrypt operation pending (would block) */
 
     WC_KEY_SIZE_E       = -234,  /* Key size error, either too small or large */
     ASN_COUNTRY_SIZE_E  = -235,  /* ASN Cert Gen, invalid country code size */

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -56,10 +56,15 @@ nobase_include_HEADERS+= \
                          wolfssl/wolfcrypt/memory.h \
                          wolfssl/wolfcrypt/mpi_class.h \
                          wolfssl/wolfcrypt/mpi_superclass.h \
-                         wolfssl/wolfcrypt/mem_track.h
+                         wolfssl/wolfcrypt/mem_track.h \
+                         wolfssl/wolfcrypt/wolfevent.h
 
 noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/pic32/pic32mz-crypt.h \
                          wolfssl/wolfcrypt/port/ti/ti-hash.h \
                          wolfssl/wolfcrypt/port/ti/ti-ccm.h \
                          wolfssl/wolfcrypt/port/nrf51.h
+
+if BUILD_CAVIUM
+noinst_HEADERS+=         wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h
+endif

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -181,6 +181,9 @@ typedef int           mp_err;
 typedef struct  {
     int used, alloc, sign;
     mp_digit *dp;
+#ifdef WOLFSSL_ASYNC_CRYPT
+    byte* dpraw; /* Used for hardware crypto */
+#endif
 } mp_int;
 
 /* callback for mp_prime_random, should fill dst with random bytes and return

--- a/wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h
+++ b/wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h
@@ -1,0 +1,165 @@
+/* cavium-nitrox.h
+ *
+ * Copyright (C) 2006-2016 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL. (formerly known as CyaSSL)
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _CAVIUM_NITROX_H_
+#define _CAVIUM_NITROX_H_
+
+#ifdef HAVE_CAVIUM
+
+#include <wolfssl/wolfcrypt/logging.h>
+
+#ifndef HAVE_CAVIUM_V
+    #include "cavium_sysdep.h"
+#endif
+#include "cavium_common.h"
+#ifndef HAVE_CAVIUM_V
+    #include "cavium_ioctl.h"
+#else
+    #include "cavium_sym_crypto.h"
+    #include "cavium_asym_crypto.h"
+#endif
+#include <errno.h>
+
+#define CAVIUM_SSL_GRP      0
+#define CAVIUM_DPORT        256
+
+/* Compatibility with older Cavium SDK's */
+#ifndef HAVE_CAVIUM_V
+    typedef int CspHandle;
+    typedef word32 CavReqId;
+
+    #define AES_128 AES_128_BIT
+    #define AES_192 AES_192_BIT
+    #define AES_256 AES_256_BIT
+#else
+    #define CAVIUM_DEV_ID       0
+    #define CAVIUM_BLOCKING     BLOCKING
+    #define CAVIUM_NON_BLOCKING NON_BLOCKING
+    #define CAVIUM_DIRECT       DMA_DIRECT_DIRECT
+    typedef Uint64 CavReqId;
+#endif
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #define CAVIUM_REQ_MODE CAVIUM_NON_BLOCKING
+#else
+    #define CAVIUM_REQ_MODE CAVIUM_BLOCKING
+#endif
+
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #define CAVIUM_MAX_PENDING  90
+    #define CAVIUM_MAX_POLL     MAX_TO_POLL
+#endif
+
+
+typedef struct CaviumNitroxDev {
+    CspHandle   devId;                      /* nitrox device id */
+    ContextType type;                       /* Typically CONTEXT_SSL, but also ECC types */
+    Uint64      contextHandle;              /* nitrox context memory handle */
+    CavReqId    reqId;                      /* Current requestId */
+} CaviumNitroxDev;
+
+struct WOLF_EVENT;
+
+
+/* Wrapper API's */
+WOLFSSL_LOCAL int NitroxTranslateResponseCode(int ret);
+WOLFSSL_LOCAL CspHandle NitroxGetDeviceHandle(void);
+WOLFSSL_LOCAL CspHandle NitroxOpenDevice(int dma_mode, int dev_id);
+WOLFSSL_LOCAL int NitroxAllocContext(CaviumNitroxDev* nitrox, CspHandle devId,
+    ContextType type);
+WOLFSSL_LOCAL void NitroxFreeContext(CaviumNitroxDev* nitrox);
+WOLFSSL_LOCAL void NitroxCloseDevice(CspHandle devId);
+
+#if defined(WOLFSSL_ASYNC_CRYPT)
+WOLFSSL_LOCAL int NitroxCheckRequest(CspHandle devId, CavReqId reqId);
+WOLFSSL_LOCAL int NitroxCheckRequests(CspHandle devId,
+    CspMultiRequestStatusBuffer* req_stat_buf);
+#endif /* WOLFSSL_ASYNC_CRYPT */
+
+
+/* Crypto wrappers */
+#ifndef NO_RSA
+    struct RsaKey;
+    WOLFSSL_LOCAL int NitroxRsaExptMod(
+                            const byte* in, word32 inLen,
+                            byte* exponent, word32 expLen,
+                            byte* modulus, word32 modLen,
+                            byte* out, word32* outLen, struct RsaKey* key);
+    WOLFSSL_LOCAL int NitroxRsaPublicEncrypt(const byte* in, word32 inLen,
+                                byte* out, word32 outLen, struct RsaKey* key);
+    WOLFSSL_LOCAL int NitroxRsaPrivateDecrypt(const byte* in, word32 inLen,
+                                byte* out, word32 outLen, struct RsaKey* key);
+    WOLFSSL_LOCAL int NitroxRsaSSL_Sign(const byte* in, word32 inLen,
+                                byte* out, word32 outLen, struct RsaKey* key);
+    WOLFSSL_LOCAL int NitroxRsaSSL_Verify(const byte* in, word32 inLen,
+                                byte* out, word32 outLen, struct RsaKey* key);
+#endif /* !NO_RSA */
+
+#ifndef NO_AES
+    struct Aes;
+    WOLFSSL_LOCAL int NitroxAesSetKey(struct Aes* aes, const byte* key,
+                                                word32 length, const byte* iv);
+    #ifdef HAVE_AES_CBC
+        WOLFSSL_LOCAL int NitroxAesCbcEncrypt(struct Aes* aes, byte* out,
+                                                const byte* in, word32 length);
+    #ifdef HAVE_AES_DECRYPT
+        WOLFSSL_LOCAL int NitroxAesCbcDecrypt(struct Aes* aes, byte* out,
+                                                const byte* in, word32 length);
+    #endif /* HAVE_AES_DECRYPT */
+    #endif /* HAVE_AES_CBC */
+#endif /* !NO_AES */
+
+#ifndef NO_RC4
+    struct Arc4;
+    WOLFSSL_LOCAL void NitroxArc4SetKey(struct Arc4* arc4, const byte* key,
+                                                                word32 length);
+    WOLFSSL_LOCAL void NitroxArc4Process(struct Arc4* arc4, byte* out,
+                                                const byte* in, word32 length);
+#endif /* !NO_RC4 */
+
+#ifndef NO_DES3
+    struct Des3;
+    WOLFSSL_LOCAL int NitroxDes3SetKey(struct Des3* des3, const byte* key,
+                                                               const byte* iv);
+    WOLFSSL_LOCAL int NitroxDes3CbcEncrypt(struct Des3* des3, byte* out,
+                                                const byte* in, word32 length);
+    WOLFSSL_LOCAL int NitroxDes3CbcDecrypt(struct Des3* des3, byte* out,
+                                                const byte* in, word32 length);
+#endif /* !NO_DES3 */
+
+#ifndef NO_HMAC
+    struct Hmac;
+    WOLFSSL_LOCAL int NitroxHmacFinal(struct Hmac* hmac, byte* hash);
+    WOLFSSL_LOCAL int NitroxHmacUpdate(struct Hmac* hmac, const byte* msg,
+                                                                word32 length);
+    WOLFSSL_LOCAL int NitroxHmacSetKey(struct Hmac* hmac, int type,
+                                               const byte* key, word32 length);
+#endif /* NO_HMAC */
+
+#if !defined(HAVE_HASHDRBG) && !defined(NO_RC4)
+    WOLFSSL_API void NitroxRngGenerateBlock(WC_RNG* rng, byte* output, word32 sz);
+#endif
+
+
+#endif /* HAVE_CAVIUM */
+
+#endif /* _CAVIUM_NITROX_H_ */

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -96,19 +96,19 @@ typedef struct WC_RNG {
 
 #else /* (HAVE_HASHDRBG || NO_RC4) && !CUSTOM_RAND_GENERATE_BLOCK */
 
-#define WOLFSSL_RNG_CAVIUM_MAGIC 0xBEEF0004
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
 
 /* secure Random Number Generator */
-
 
 typedef struct WC_RNG {
     OS_Seed seed;
 #ifndef NO_RC4
     Arc4    cipher;
 #endif
-#ifdef HAVE_CAVIUM
-    int    devId;           /* nitrox device id */
-    word32 magic;           /* using cavium magic */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncCryptDev asyncDev;
 #endif
 } WC_RNG;
 
@@ -126,13 +126,6 @@ typedef struct WC_RNG {
 WOLFSSL_LOCAL
 int wc_GenerateSeed(OS_Seed* os, byte* seed, word32 sz);
 
-#if defined(HAVE_HASHDRBG) || defined(NO_RC4)
-
-#ifdef HAVE_CAVIUM
-    WOLFSSL_API int  wc_InitRngCavium(WC_RNG*, int);
-#endif
-
-#endif /* HAVE_HASH_DRBG || NO_RC4 */
 
 #ifdef HAVE_WNR
     /* Whitewood netRandom client library */

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -52,38 +52,49 @@
 
 /* avoid redefinition of structs */
 #if !defined(HAVE_FIPS)
-#define WOLFSSL_RSA_CAVIUM_MAGIC 0xBEEF0006
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
 
 enum {
     RSA_PUBLIC   = 0,
     RSA_PRIVATE  = 1,
-};
 
+    RSA_TYPE_UNKNOWN    = -1,
+    RSA_PUBLIC_ENCRYPT  = 0,
+    RSA_PUBLIC_DECRYPT  = 1,
+    RSA_PRIVATE_ENCRYPT = 2,
+    RSA_PRIVATE_DECRYPT = 3,
+
+    RSA_BLOCK_TYPE_1 = 1,
+    RSA_BLOCK_TYPE_2 = 2,
+
+    RSA_MIN_SIZE = 512,
+    RSA_MAX_SIZE = 4096,
+
+    RSA_MIN_PAD_SZ   = 11      /* separator + 0 + pad value + 8 pads */
+};
 
 /* RSA */
 typedef struct RsaKey {
     mp_int n, e, d, p, q, dP, dQ, u;
-    int   type;                               /* public or private */
-    void* heap;                               /* for user memory overrides */
-#ifdef HAVE_CAVIUM
-    int    devId;           /* nitrox device id */
-    word32 magic;           /* using cavium magic */
-    word64 contextHandle;   /* nitrox context memory handle */
-    byte*  c_n;             /* cavium byte buffers for key parts */
-    byte*  c_e;
-    byte*  c_d;
-    byte*  c_p;
-    byte*  c_q;
-    byte*  c_dP;
-    byte*  c_dQ;
-    byte*  c_u;             /* sizes in bytes */
-    word16 c_nSz, c_eSz, c_dSz, c_pSz, c_qSz, c_dP_Sz, c_dQ_Sz, c_uSz;
-#endif
+    int    type;                               /* public or private */
+    int    state;
+    byte*  tmp;
+    word32 tmpLen;
+    void*  heap;                               /* for user memory overrides */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncCryptDev asyncDev;
+#endif /* WOLFSSL_ASYNC_CRYPT */
 } RsaKey;
 #endif /*HAVE_FIPS */
 
 WOLFSSL_API int  wc_InitRsaKey(RsaKey* key, void*);
 WOLFSSL_API int  wc_FreeRsaKey(RsaKey* key);
+
+WOLFSSL_LOCAL int wc_RsaFunction(const byte* in, word32 inLen, byte* out,
+                                 word32* outLen, int type, RsaKey* key);
 
 WOLFSSL_API int  wc_RsaPublicEncrypt(const byte* in, word32 inLen, byte* out,
                                  word32 outLen, RsaKey* key, WC_RNG* rng);
@@ -115,6 +126,7 @@ WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
  */
 
 /* Mask Generation Function Identifiers */
+#define WC_MGF1NONE   0
 #define WC_MGF1SHA1   26
 #define WC_MGF1SHA256 1
 #define WC_MGF1SHA384 2
@@ -123,6 +135,15 @@ WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
 /* Padding types */
 #define WC_RSA_PKCSV15_PAD 0
 #define WC_RSA_OAEP_PAD    1
+
+WOLFSSL_API int wc_RsaPad_ex(const byte* input, word32 inputLen, byte* pkcsBlock,
+               word32 pkcsBlockLen, byte padValue, WC_RNG* rng, int padType,
+           enum wc_HashType hType, int mgf, byte* optLabel, word32 labelLen,
+           void* heap);
+WOLFSSL_API int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen, byte** out,
+                          byte padValue, int padType, enum wc_HashType hType,
+                          int mgf, byte* optLabel, word32 labelLen, void* heap);
+
 
 WOLFSSL_API int  wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
                    word32 outLen, RsaKey* key, WC_RNG* rng, int type,
@@ -142,11 +163,14 @@ WOLFSSL_API int  wc_RsaFlattenPublicKey(RsaKey*, byte*, word32*, byte*,
     WOLFSSL_API int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng);
 #endif
 
-#ifdef HAVE_CAVIUM
-    WOLFSSL_API int  wc_RsaInitCavium(RsaKey*, int);
-    WOLFSSL_API void wc_RsaFreeCavium(RsaKey*);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    WOLFSSL_API int  wc_RsaAsyncInit(RsaKey*, int);
+    WOLFSSL_API int  wc_RsaAsyncHandle(RsaKey* key, WOLF_EVENT_QUEUE* queue, WOLF_EVENT* event);
+    WOLFSSL_API int  wc_RsaAsyncWait(int ret, RsaKey* key);
+    WOLFSSL_API void wc_RsaAsyncFree(RsaKey*);
 #endif
 #endif /* HAVE_USER_RSA */
+
 #ifdef __cplusplus
     } /* extern "C" */
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1233,6 +1233,11 @@ static char *fgets(char *buff, int sz, FILE *fp)
     /* Make sure wolf events are enabled */
     #undef HAVE_WOLF_EVENT
     #define HAVE_WOLF_EVENT
+
+    #if !defined(HAVE_CAVIUM) && !defined(HAVE_INTEL_QA) && \
+        !defined(WOLFSSL_ASYNC_CRYPT_TEST)
+        #error No async hardware defined with WOLFSSL_ASYNC_CRYPT!
+    #endif
 #else
     #ifdef WOLFSSL_ASYNC_CRYPT_TEST
         #error Must have WOLFSSL_ASYNC_CRYPT enabled with WOLFSSL_ASYNC_CRYPT_TEST

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -289,6 +289,9 @@ typedef struct {
     int      size;
 #endif
     fp_digit dp[FP_SIZE];
+#ifdef WOLFSSL_ASYNC_CRYPT
+    byte *dpraw; /* Used for hardware crypto */
+#endif
 } fp_int;
 
 /* externally define this symbol to ignore the default settings, useful for changing the build from the make process */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -375,6 +375,9 @@
 	   return 1 if a match otherwise 0 */
 	#define CheckCtcSettings() (CTC_SETTINGS == CheckRunTimeSettings())
 
+	/* invalid device id */
+	#define INVALID_DEVID    -2
+
 
 	#ifdef __cplusplus
 	    }   /* extern "C" */

--- a/wolfssl/wolfcrypt/wolfevent.h
+++ b/wolfssl/wolfcrypt/wolfevent.h
@@ -1,0 +1,102 @@
+/* wolfevent.h
+ *
+ * Copyright (C) 2006-2016 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef _WOLF_EVENT_H_
+#define _WOLF_EVENT_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#ifndef SINGLE_THREADED
+    #include <wolfssl/wolfcrypt/wc_port.h>
+#endif
+
+typedef struct WOLFSSL WOLFSSL;
+typedef struct WOLF_EVENT WOLF_EVENT;
+typedef struct WOLFSSL_CTX WOLFSSL_CTX;
+
+typedef unsigned short WOLF_EVENT_FLAG;
+
+typedef enum WOLF_EVENT_TYPE {
+    WOLF_EVENT_TYPE_NONE,
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        WOLF_EVENT_TYPE_ASYNC_WOLFSSL,
+        WOLF_EVENT_TYPE_ASYNC_WOLFCRYPT,
+        WOLF_EVENT_TYPE_ASYNC_FIRST = WOLF_EVENT_TYPE_ASYNC_WOLFSSL,
+        WOLF_EVENT_TYPE_ASYNC_LAST = WOLF_EVENT_TYPE_ASYNC_WOLFCRYPT,
+    #endif
+} WOLF_EVENT_TYPE;
+
+struct WOLF_EVENT {
+    /* double linked list */
+    WOLF_EVENT*         next;
+    WOLF_EVENT*         prev;
+
+    void*               context;
+#ifdef HAVE_CAVIUM
+    word64              reqId;
+#endif
+    int                 ret;    /* Async return code */
+    WOLF_EVENT_TYPE     type;
+    WOLF_EVENT_FLAG     pending:1;
+    WOLF_EVENT_FLAG     done:1;
+    /* Future event flags can go here */
+};
+
+enum WOLF_POLL_FLAGS {
+    WOLF_POLL_FLAG_CHECK_HW = 0x01,
+};
+
+typedef struct {
+    WOLF_EVENT*         head;     /* head of queue */
+    WOLF_EVENT*         tail;     /* tail of queue */
+#ifndef SINGLE_THREADED
+    wolfSSL_Mutex       lock;     /* queue lock */
+#endif
+    int                 count;
+} WOLF_EVENT_QUEUE;
+
+
+#ifdef HAVE_WOLF_EVENT
+
+/* Event */
+WOLFSSL_API int wolfEvent_Init(WOLF_EVENT* event, WOLF_EVENT_TYPE type, void* context);
+WOLFSSL_API int wolfEvent_Poll(WOLF_EVENT* event, WOLF_EVENT_FLAG flags);
+
+/* Event Queue */
+WOLFSSL_API int wolfEventQueue_Init(WOLF_EVENT_QUEUE* queue);
+WOLFSSL_API int wolfEventQueue_Push(WOLF_EVENT_QUEUE* queue, WOLF_EVENT* event);
+WOLFSSL_API int wolfEventQueue_Pop(WOLF_EVENT_QUEUE* queue, WOLF_EVENT** event);
+WOLFSSL_API int wolfEventQueue_Remove(WOLF_EVENT_QUEUE* queue, WOLF_EVENT* event);
+WOLFSSL_API int wolfEventQueue_Poll(WOLF_EVENT_QUEUE* queue, void* context_filter,
+    WOLF_EVENT** events, int maxEvents, WOLF_EVENT_FLAG flags, int* eventCount);
+WOLFSSL_API int wolfEventQueue_Count(WOLF_EVENT_QUEUE* queue);
+WOLFSSL_API void wolfEventQueue_Free(WOLF_EVENT_QUEUE* queue);
+
+#endif /* HAVE_WOLF_EVENT */
+
+
+#ifdef __cplusplus
+    }   /* extern "C" */
+#endif
+
+#endif /* _WOLF_EVENT_H_ */


### PR DESCRIPTION
Tested with Cavium Nitrox V using SDK v0.2 (CNN55XX-SDK) with new configure "--with-cavium-v=/dir" option. Refactor of the wolf event and async handling for use in wolfCrypt. Refactor of the "cavium" functions to use generic "async". Moved Nitrox specific functions to new port files in "port/cavium/cavium_nitrox.c". RSA refactor to handle async with states. RSA optimization for using dpraw for private key decode. Use double linked list in wolf event for faster/cleaner code. Use typedef for wolf event flag. Cleanup of the async error codes. Nitrox support for async with CspGetAllResults to query multiple pending requests ID's at the same time. New NitroxTranslateResponseCode API. wolfCrypt test and benchmark support for async RSA. Asynchronous mode enabled using "./configure --enable-asynccrypt". If no async hardware is defined then the internal async simulator is used. Note: Using async mode requires async.c/.h files from wolfSSL. If interested in using asynchronous mode please send email to info@wolfssl.com.