### PR TITLE
Public "wc_GetTime" API and "configure --enable-base64encode"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1147,6 +1147,23 @@ fi
 AM_CONDITIONAL([BUILD_CODING], [test "x$ENABLED_CODING" = "xyes"])
 
 
+# Base64 Encode
+BASE64ENCODE_DEFAULT=no
+if test "$host_cpu" = "x86_64"
+then
+BASE64ENCODE_DEFAULT=yes
+fi
+AC_ARG_ENABLE([base64encode],
+    [  --enable-base64encode   Enable Base64 encoding (default: enabled on x86_64)],
+    [ ENABLED_BASE64ENCODE=$enableval ],
+    [ ENABLED_BASE64ENCODE=$BASE64ENCODE_DEFAULT ]
+    )
+if test "$ENABLED_BASE64ENCODE" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_BASE64_ENCODE"
+fi
+
+
 # DES3
 AC_ARG_ENABLE([des3],
     [  --enable-des3           Enable DES3 (default: enabled)],

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3086,6 +3086,22 @@ int ValidateDate(const byte* date, byte format, int dateType)
 }
 #endif /* !NO_TIME_H && USE_WOLF_VALIDDATE */
 
+int wc_GetTime(void* timePtr, word32 timeSize)
+{
+    time_t* ltime = (time_t*)timePtr;
+
+    if (timePtr == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if ((word32)sizeof(time_t) > timeSize) {
+        return BUFFER_E;
+    }
+
+    *ltime = XTIME(0);
+
+    return 0;
+}
 
 static int GetDate(DecodedCert* cert, int dateType)
 {

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -274,6 +274,15 @@ WOLFSSL_API word32 wc_EncodeSignature(byte* out, const byte* digest,
                                       word32 digSz, int hashOID);
 WOLFSSL_API int wc_GetCTC_HashOID(int type);
 
+/* Time */
+/* Returns seconds (Epoch/UTC)
+ * timePtr: is "time_t", which is typically "long"
+ * Example:
+    long lTime;
+    rc = wc_GetTime(&lTime, (word32)sizeof(lTime));
+*/
+WOLFSSL_API int wc_GetTime(void* timePtr, word32 timeSize);
+
 #ifdef __cplusplus
     } /* extern "C" */
 #endif


### PR DESCRIPTION
Added new public "wc_GetTime" API for getting seconds from the asn.c XTIME. Added new "./configure --enable-base64encode" to enable Base64 encoding (now enabled by default for "x86_64").