### PR TITLE
Add cipher suite ECDHE-ECDSA-AES128-CCM

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -517,13 +517,19 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     WOLFSSL*         sslResume = 0;
     WOLFSSL_SESSION* session = 0;
-    char         resumeMsg[32] = "resuming wolfssl!";
-    int          resumeSz    = (int)strlen(resumeMsg);
 
+#ifndef WOLFSSL_ALT_TEST_STRINGS
     char msg[32] = "hello wolfssl!";   /* GET may make bigger */
+    char resumeMsg[32] = "resuming wolfssl!";
+#else
+    char msg[32] = "hello wolfssl!\n";
+    char resumeMsg[32] = "resuming wolfssl!\n";
+#endif
+
     char reply[80];
     int  input;
     int  msgSz = (int)strlen(msg);
+    int  resumeSz = (int)strlen(resumeMsg);
 
     word16 port   = wolfSSLPort;
     char* host   = (char*)wolfSSLIP;

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -256,7 +256,11 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     SSL_CTX*    ctx    = 0;
     SSL*        ssl    = 0;
 
+#ifndef WOLFSSL_ALT_TEST_STRINGS
     const char msg[] = "I hear you fa shizzle!";
+#else
+    const char msg[] = "I hear you fa shizzle!\n";
+#endif
     char   input[80];
     int    ch;
     int    version = SERVER_DEFAULT_VERSION;

--- a/src/internal.c
+++ b/src/internal.c
@@ -2123,6 +2123,13 @@ void InitSuites(Suites* suites, ProtocolVersion pv, word16 haveRSA,
     }
 #endif
 
+#ifdef BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM
+    if (tls1_2 && haveECC) {
+        suites->suites[idx++] = ECC_BYTE;
+        suites->suites[idx++] = TLS_ECDHE_ECDSA_WITH_AES_128_CCM;
+    }
+#endif
+
 #ifdef BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
     if (tls1_2 && haveECC) {
         suites->suites[idx++] = ECC_BYTE;
@@ -5540,6 +5547,7 @@ static int BuildFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
             break;
 #endif
 
+        case TLS_ECDHE_ECDSA_WITH_AES_128_CCM :
         case TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 :
         case TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8 :
             if (requirement == REQUIRES_ECC)
@@ -11500,6 +11508,10 @@ static const char* const cipher_names[] =
     "AES256-CCM-8",
 #endif
 
+#ifdef BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM
+    "ECDHE-ECDSA-AES128-CCM",
+#endif
+
 #ifdef BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
     "ECDHE-ECDSA-AES128-CCM-8",
 #endif
@@ -11940,6 +11952,10 @@ static int cipher_name_idx[] =
 
 #ifdef BUILD_TLS_RSA_WITH_AES_256_CCM_8
     TLS_RSA_WITH_AES_256_CCM_8,
+#endif
+
+#ifdef BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM
+    TLS_ECDHE_ECDSA_WITH_AES_128_CCM,
 #endif
 
 #ifdef BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8

--- a/src/keys.c
+++ b/src/keys.c
@@ -790,6 +790,24 @@ int SetCipherSpecs(WOLFSSL* ssl)
         break;
 #endif
 
+#ifdef BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM
+    case TLS_ECDHE_ECDSA_WITH_AES_128_CCM :
+        ssl->specs.bulk_cipher_algorithm = wolfssl_aes_ccm;
+        ssl->specs.cipher_type           = aead;
+        ssl->specs.mac_algorithm         = sha256_mac;
+        ssl->specs.kea                   = ecc_diffie_hellman_kea;
+        ssl->specs.sig_algo              = ecc_dsa_sa_algo;
+        ssl->specs.hash_size             = SHA256_DIGEST_SIZE;
+        ssl->specs.pad_size              = PAD_SHA;
+        ssl->specs.static_ecdh           = 0;
+        ssl->specs.key_size              = AES_128_KEY_SIZE;
+        ssl->specs.block_size            = AES_BLOCK_SIZE;
+        ssl->specs.iv_size               = AESGCM_IMP_IV_SZ;
+        ssl->specs.aead_mac_size         = AES_CCM_16_AUTH_SZ;
+
+        break;
+#endif
+
 #ifdef BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
     case TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 :
         ssl->specs.bulk_cipher_algorithm = wolfssl_aes_ccm;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11760,6 +11760,8 @@ const char* wolfSSL_CIPHER_get_name(const WOLFSSL_CIPHER* cipher)
                 return "TLS_DHE_PSK_WITH_AES_256_CCM";
 #endif
 #ifdef HAVE_ECC
+            case TLS_ECDHE_ECDSA_WITH_AES_128_CCM:
+                return "TLS_ECDHE_ECDSA_WITH_AES_128_CCM";
             case TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8:
                 return "TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8";
             case TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8 :

--- a/tests/test-dtls.conf
+++ b/tests/test-dtls.conf
@@ -1046,6 +1046,19 @@
 -v 3
 -l PSK-AES256-GCM-SHA384
 
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-A ./certs/server-ecc.pem
+
 # server DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
 -u
 -v 3

--- a/tests/test-qsh.conf
+++ b/tests/test-qsh.conf
@@ -1823,6 +1823,17 @@
 -v 3
 -l QSH:AES256-CCM-8
 
+# server TLSv1.2 ECDHE-ECDSA-AES128-CCM
+-v 3
+-l QSH:ECDHE-ECDSA-AES128-CCM
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-AES128-CCM
+-v 3
+-l QSH:ECDHE-ECDSA-AES128-CCM
+-A ./certs/server-ecc.pem
+
 # server TLSv1.2 ECDHE-ECDSA-AES128-CCM-8
 -v 3
 -l QSH:ECDHE-ECDSA-AES128-CCM-8

--- a/tests/test-sig.conf
+++ b/tests/test-sig.conf
@@ -185,6 +185,17 @@
 -l ECDHE-ECDSA-AES256-GCM-SHA384
 -A ./certs/ca-cert.pem
 
+# server TLSv1.2 ECDHE-ECDSA-AES128-CCM
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-AES128-CCM
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-A ./certs/ca-cert.pem
+
 # server TLSv1.2 ECDHE-ECDSA-AES128-CCM-8
 -v 3
 -l ECDHE-ECDSA-AES128-CCM-8

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -1812,6 +1812,17 @@
 -v 3
 -l AES256-CCM-8
 
+# server TLSv1.2 ECDHE-ECDSA-AES128-CCM
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-AES128-CCM
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-A ./certs/server-ecc.pem
+
 # server TLSv1.2 ECDHE-ECDSA-AES128-CCM-8
 -v 3
 -l ECDHE-ECDSA-AES128-CCM-8

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -608,6 +608,7 @@ typedef byte word24[3];
         #endif
     #endif
     #if defined(HAVE_AESCCM) && !defined(NO_SHA256)
+        #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM
         #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
         #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8
     #endif
@@ -812,6 +813,7 @@ enum {
      * with non-ECC AES-GCM */
     TLS_RSA_WITH_AES_128_CCM_8         = 0xa0,
     TLS_RSA_WITH_AES_256_CCM_8         = 0xa1,
+    TLS_ECDHE_ECDSA_WITH_AES_128_CCM   = 0xac,
     TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8 = 0xae,
     TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8 = 0xaf,
     TLS_PSK_WITH_AES_128_CCM           = 0xa4,


### PR DESCRIPTION
1. Added the usual cipher suite changes for the new suite.
2. Added a build option, WOLFSSL_ALT_TEST_STRINGS, for testing
   against GnuTLS. It wants to receive strings with newlines.
3. Updated the test configs for the new suite.

Tested against GnuTLS's client and server using the options:

    $ gnutls-cli --priority "NONE:+VERS-TLS-ALL:+AEAD:+ECDHE-ECDSA:+AES-128-CCM:+SIGN-ALL:+COMP-NULL:+CURVE-ALL:+CTYPE-X509" --x509cafile=./certs/server-ecc.pem --no-ca-verification -p 11111 localhost
    $ gnutls-serv --echo --x509keyfile=./certs/ecc-key.pem --x509certfile=./certs/server-ecc.pem --port=11111 -a --priority "NONE:+VERS-TLS-ALL:+AEAD:+ECDHE-ECDSA:+AES-128-CCM:+SIGN-ALL:+COMP-NULL:+CURVE-ALL:+CTYPE-X509"

To talk to GnuTLS, wolfSSL also needed the supported curves option
enabled.