### PR TITLE
prepare for version 3.9.6

### DIFF
--- a/README
+++ b/README
@@ -35,6 +35,47 @@ before calling wolfSSL_new();  Though it's not recommended.
 *** end Notes ***
 
 
+ ********* wolfSSL (Formerly CyaSSL) Release 3.9.6 (6/14/2016)
+
+Release 3.9.6 of wolfSSL has bug fixes and new features including:
+
+- Add staticmemory feature
+- Add public wc_GetTime API with base64encode feature
+- Add AES CMAC algorithm
+- Add DTLS sessionexport feature
+- Add python wolfCrypt wrapper
+- Add ECC encrypt/decrypt benchmarks
+- Add dynamic session tickets
+- Add eccshamir option
+- Add Whitewood netRandom support --with-wnr
+- Add embOS port
+- Add minimum key size checks for RSA and ECC
+- Add STARTTLS support to examples
+- Add uTasker port
+- Add asynchronous crypto and wolf event support
+- Add compile check for misc.c with inline
+- Add RNG benchmark
+- Add reduction to stack usage with hash-based RNG
+- Update STM32F2_CRYPTO port with additional algorithms supported
+- Update MDK5 projects
+- Update AES-NI
+- Fix for STM32 with STM32F2_HASH defined
+- Fix for building with MinGw
+- Fix ECC math bugs with ALT_ECC_SIZE and key sizes over 256 bit (1)
+- Fix certificate buffers github issue #422
+- Fix decrypt max size with RSA OAEP
+- Fix DTLS sanity check with DTLS timeout notification
+- Fix free of WOLFSSL_METHOD on failure to create CTX
+- Fix memory leak in failure case with wc_RsaFunction (2)
+
+- No high level security fixes that requires an update though we always
+recommend updating to the latest
+- (1) Code changes for ECC fix can be found at pull requests #411, #416, and #428
+- (2) Builds using RSA with using normal math and not RSA_LOW_MEM should update
+
+See INSTALL file for build instructions.
+More info can be found on-line at //http://wolfssl.com/wolfSSL/Docs.html
+
  ********* wolfSSL (Formerly CyaSSL) Release 3.9.0 (3/18/2016)
 
 Release 3.9.0 of wolfSSL has bug fixes and new features including:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,47 @@ wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0);
 
 before calling wolfSSL_new();  Though it's not recommended.
 ```
+# wolfSSL (Formerly CyaSSL) Release 3.9.6 (6/14/2016)
+
+##Release 3.9.6 of wolfSSL has bug fixes and new features including:
+
+- Add staticmemory feature
+- Add public wc_GetTime API with base64encode feature
+- Add AES CMAC algorithm
+- Add DTLS sessionexport feature
+- Add python wolfCrypt wrapper
+- Add ECC encrypt/decrypt benchmarks
+- Add dynamic session tickets
+- Add eccshamir option
+- Add Whitewood netRandom support --with-wnr
+- Add embOS port
+- Add minimum key size checks for RSA and ECC
+- Add STARTTLS support to examples
+- Add uTasker port
+- Add asynchronous crypto and wolf event support
+- Add compile check for misc.c with inline
+- Add RNG benchmark
+- Add reduction to stack usage with hash-based RNG
+- Update STM32F2_CRYPTO port with additional algorithms supported
+- Update MDK5 projects
+- Update AES-NI
+- Fix for STM32 with STM32F2_HASH defined
+- Fix for building with MinGw
+- Fix ECC math bugs with ALT_ECC_SIZE and key sizes over 256 bit (1)
+- Fix certificate buffers github issue #422
+- Fix decrypt max size with RSA OAEP
+- Fix DTLS sanity check with DTLS timeout notification
+- Fix free of WOLFSSL_METHOD on failure to create CTX
+- Fix memory leak in failure case with wc_RsaFunction (2)
+
+- No high level security fixes that requires an update though we always
+recommend updating to the latest
+- (1) Code changes for ECC fix can be found at pull requests #411, #416, and #428
+- (2) Builds using RSA with using normal math and not RSA_LOW_MEM should update
+
+See INSTALL file for build instructions.
+More info can be found on-line at //http://wolfssl.com/wolfSSL/Docs.html
+
 # wolfSSL (Formerly CyaSSL) Release 3.9.0 (03/18/2016)
 
 ##Release 3.9.0 of wolfSSL has bug fixes and new features including:

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #
 #
 
-AC_INIT([wolfssl],[3.9.1],[https://github.com/wolfssl/wolfssl/issues],[wolfssl],[http://www.wolfssl.com])
+AC_INIT([wolfssl],[3.9.6],[https://github.com/wolfssl/wolfssl/issues],[wolfssl],[http://www.wolfssl.com])
 
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -35,7 +35,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h:config.in])dnl Keep filename to 8.3 for MS-DOS.
 
 #shared library versioning
-WOLFSSL_LIBRARY_VERSION=5:0:2
+WOLFSSL_LIBRARY_VERSION=6:0:3
 #                       | | |
 #                +------+ | +---+
 #                |        |     |

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -69,7 +69,7 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_libdir}/libwolfssl.la
 %{_libdir}/libwolfssl.so
 %{_libdir}/libwolfssl.so.3
-%{_libdir}/libwolfssl.so.3.2.0
+%{_libdir}/libwolfssl.so.3.3.0
 
 %files devel
 %defattr(-,root,root,-)
@@ -169,6 +169,7 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/wolfssl/certs_test.h
 %{_includedir}/wolfssl/crl.h
 %{_includedir}/wolfssl/wolfcrypt/aes.h
+%{_includedir}/wolfssl/wolfcrypt/cmac.h
 %{_includedir}/wolfssl/wolfcrypt/arc4.h
 %{_includedir}/wolfssl/wolfcrypt/asn.h
 %{_includedir}/wolfssl/wolfcrypt/asn_public.h
@@ -221,9 +222,9 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/wolfssl/wolfcrypt/types.h
 %{_includedir}/wolfssl/wolfcrypt/visibility.h
 %{_includedir}/wolfssl/wolfcrypt/wc_encrypt.h
+%{_includedir}/wolfssl/wolfcrypt/mem_track.h
 %{_includedir}/wolfssl/error-ssl.h
 %{_includedir}/wolfssl/ocsp.h
-%{_includedir}/wolfssl/mem_track.h
 %{_includedir}/wolfssl/openssl/asn1.h
 %{_includedir}/wolfssl/openssl/bio.h
 %{_includedir}/wolfssl/openssl/bn.h
@@ -268,6 +269,9 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_libdir}/pkgconfig/wolfssl.pc
 
 %changelog
+* Mon Jun 14 2016 Jacob Barthelmeh <jacob@wolfssl.com>
+- Change location for mem_track.h header
+- Added header for cmac.h
 * Thu Mar 17 2016 Jacob Barthelmeh <jacob@wolfssl.com>
 - Added header for mem_track.h
 * Wed Dec 30 2015 Jacob Barthelmeh <jacob@wolfssl.com>

--- a/support/wolfssl.pc
+++ b/support/wolfssl.pc
@@ -5,6 +5,6 @@ includedir=${prefix}/include
 
 Name: wolfssl
 Description: wolfssl C library.
-Version: 3.9.1
+Version: 3.9.6
 Libs: -L${libdir} -lwolfssl
 Cflags: -I${includedir}

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1241,7 +1241,7 @@ ecc_point* wc_ecc_new_point_h(void* heap)
 
 #ifndef ALT_ECC_SIZE
    if (mp_init_multi(p->x, p->y, p->z, NULL, NULL, NULL) != MP_OKAY) {
-      XFREE(p, 0, DYNAMIC_TYPE_ECC);
+      XFREE(p, heap, DYNAMIC_TYPE_ECC);
       return NULL;
    }
 #else
@@ -1924,7 +1924,7 @@ static int ecc_mul2add(ecc_point* A, mp_int* kA,
   }
   tB = (unsigned char*)XMALLOC(ECC_BUFSIZE, heap, DYNAMIC_TYPE_TMP_BUFFER);
   if (tB == NULL) {
-     XFREE(tA, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+     XFREE(tA, heap, DYNAMIC_TYPE_TMP_BUFFER);
      return GEN_MEM_ERR;
   }
   XMEMSET(tA, 0, ECC_BUFSIZE);

--- a/wolfssl/version.h
+++ b/wolfssl/version.h
@@ -28,8 +28,8 @@
 extern "C" {
 #endif
 
-#define LIBWOLFSSL_VERSION_STRING "3.9.1"
-#define LIBWOLFSSL_VERSION_HEX 0x03009001
+#define LIBWOLFSSL_VERSION_STRING "3.9.6"
+#define LIBWOLFSSL_VERSION_HEX 0x03009006
 
 #ifdef __cplusplus
 }

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -130,7 +130,7 @@ typedef struct Gmac {
 #endif /* HAVE_AESGCM */
 #endif /* HAVE_FIPS */
 
-WOLFSSL_API int  wc_InitAes_h(Aes* aes, void* h);
+WOLFSSL_LOCAL int  wc_InitAes_h(Aes* aes, void* h);
 WOLFSSL_API int  wc_AesSetKey(Aes* aes, const byte* key, word32 len,
                               const byte* iv, int dir);
 WOLFSSL_API int  wc_AesSetIV(Aes* aes, const byte* iv);


### PR DESCRIPTION
Caught two heap hints not used with XFREE in ecc.c
Changed wc_InitAes_h to WOLFSSL_LOCAL this was add with staticmemory feature but does not need to be public facing I think.
Updated rpm/spec.in and tested on a Linux OS