### PR TITLE
Remove unimplemented function prototypes

### DIFF
--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -217,12 +217,6 @@ WOLFSSL_API int wc_SetSubjectKeyIdFromNtruPublicKey(Cert *cert, byte *ntruKey,
  */
 WOLFSSL_API int wc_SetKeyUsage(Cert *cert, const char *value);
 
-/* encode Certificate Policies, return total bytes written
- * each input value must be ITU-T X.690 formatted : a.b.c...
- * input must be an array of values with a NULL terminated for the latest
- * RFC5280 : non-critical */
-WOLFSSL_API int wc_SetCertificatePolicies(Cert *cert, const char **input);
-
 #endif /* WOLFSSL_CERT_EXT */
 
     #ifdef HAVE_NTRU

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -106,18 +106,11 @@ WOLFSSL_API int wc_Sha256Hash(const byte*, word32, byte*);
 #ifdef WOLFSSL_SHA512
 #include <wolfssl/wolfcrypt/sha512.h>
 WOLFSSL_API int wc_Sha512Hash(const byte*, word32, byte*);
-#if defined(WOLFSSL_TI_HASH)
-    WOLFSSL_API void wc_Sha512Free(Sha512*);
-#else
-    #define wc_Sha512Free(d)
-#endif
+#define wc_Sha512Free(d)
+
     #if defined(WOLFSSL_SHA384)
         WOLFSSL_API int wc_Sha384Hash(const byte*, word32, byte*);
-        #if defined(WOLFSSL_TI_HASH)
-            WOLFSSL_API void wc_Sha384Free(Sha384*);
-        #else
-            #define wc_Sha384Free(d)
-        #endif
+        #define wc_Sha384Free(d)
     #endif /* defined(WOLFSSL_SHA384) */
 #endif /* WOLFSSL_SHA512 */
 


### PR DESCRIPTION
These function prototypes did not have a corresponding implementation.  Identified by Michael when doing a refresh/update on the wolfCrypt API docs.

wc_SetCertificatePolicies() is now static in asn.c.  Removal of the prototype in asn_public.h was overlooked at the time (commit d2ea6f7e).

ti-hash.c did not implement wc_Sha384Free() or wc_Sha512Free() because the hardware crypto did not support SHA-384/512, but function prototypes got added for them initially (commit 82aaff9e).