### PR TITLE
DTLS Retransmit Fix

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4752,8 +4752,7 @@ retry:
             case WOLFSSL_CBIO_ERR_TIMEOUT:
                 if (ssl->options.dtls) {
 #ifdef WOLFSSL_DTLS
-                    if ((!ssl->options.handShakeDone ||
-                               ssl->options.dtlsHsRetain) &&
+                    if (!ssl->options.handShakeDone &&
                         DtlsPoolTimeout(ssl) == 0 &&
                         DtlsPoolSend(ssl) == 0) {
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6617,7 +6617,9 @@ int wolfSSL_dtls_got_timeout(WOLFSSL* ssl)
 {
     int result = SSL_SUCCESS;
 
-    if (DtlsPoolTimeout(ssl) < 0 || DtlsPoolSend(ssl) < 0) {
+    if (!ssl->options.handShakeDone &&
+        (DtlsPoolTimeout(ssl) < 0 || DtlsPoolSend(ssl) < 0)) {
+
         result = SSL_FATAL_ERROR;
     }
     return result;


### PR DESCRIPTION
Fix where the last flight was getting retransmit on timeout notification. This causes problems with other SSLs, and was incorrect behavior.