### PR TITLE
Fix windows example echoserver

### DIFF
--- a/README
+++ b/README
@@ -72,6 +72,7 @@ Release 3.9.6 of wolfSSL has bug fixes and new features including:
 recommend updating to the latest
 - (1) Code changes for ECC fix can be found at pull requests #411, #416, and #428
 - (2) Builds using RSA with using normal math and not RSA_LOW_MEM should update
+- Tag 3.9.6w is for a Windows example echoserver fix
 
 See INSTALL file for build instructions.
 More info can be found on-line at //http://wolfssl.com/wolfSSL/Docs.html

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -114,11 +114,9 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
     doPSK = 1;
 #endif
 
-#if defined(USE_WINDOWS_API)
-    /* Generate random port for testing */
-    port = GetRandomPort();
-#elif defined(NO_MAIN_DRIVER) && !defined(CYASSL_SNIFFER) && \
-     !defined(WOLFSSL_MDK_SHELL) && !defined(CYASSL_TIRTOS)
+#if defined(NO_MAIN_DRIVER) && !defined(CYASSL_SNIFFER) && \
+     !defined(WOLFSSL_MDK_SHELL) && !defined(CYASSL_TIRTOS) && \
+     !defined(USE_WINDOWS_API)
     /* Let tcp_listen assign port */
     port = 0;
 #else


### PR DESCRIPTION
Fixes issue where echoserver.c had been using GetRandomPort(), but wasn't tied in correctly.  This caused the testsuite to fail on Windows builds with a "tcp connect error".

This commit backs out the GetRandomPort() change and uses wolfSSLPort in echoserver.c / echoserver_test().