### PR TITLE
Fixes scan-build warning in ecc.c line 2208

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2067,9 +2067,6 @@ static int ecc_mul2add(ecc_point* A, mp_int* kA,
         for (x = 0; x < 16; x++) {
             precomp[x] = wc_ecc_new_point_h(heap);
             if (precomp[x] == NULL) {
-                for (y = 0; y < x; ++y) {
-                    wc_ecc_del_point_h(precomp[y], heap);
-                }
                 err = GEN_MEM_ERR;
                 break;
             }


### PR DESCRIPTION
Fixes scan-build warning "wolfcrypt/src/ecc.c:2208:6: warning: Use of memory after it is freed". This is due to a rebase issue with static memory changes after the new ECC custom curves changes. The precomp[] is init to NULL at top so cleanup can always be done at end (shouldn't be done in middle).