### PR TITLE
Fixing various issues

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -5232,6 +5232,10 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         }
         else {
             WOLFSSL_MSG("Verified CA from chain and already had it");
+            if (anyError == ASN_NO_SIGNER_E){
+                WOLFSSL_MSG("Overriding no signer error from higher CAs in chain");
+                anyError = 0;
+            }
         }
 
 #if defined(HAVE_OCSP) || defined(HAVE_CRL)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5064,6 +5064,9 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
             }
 #endif /* IGNORE_NAME_CONSTRAINTS */
         }
+        else if(GetCA(cm, cert->subjectHash)) {
+            WOLFSSL_MSG("Certificate confirmed as already found in CM cache");
+        }
         else {
             /* no signer */
             WOLFSSL_MSG("No CA signer to verify with");

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -244,7 +244,7 @@
 
 
 #ifndef FP_MAX_BITS
-    #define FP_MAX_BITS           4096
+    #define FP_MAX_BITS           8192
 #endif
 #define FP_MAX_SIZE           (FP_MAX_BITS+(8*DIGIT_BIT))
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -88,7 +88,8 @@
 
 	/* These platforms have 64-bit CPU registers.  */
 	#if (defined(__alpha__) || defined(__ia64__) || defined(_ARCH_PPC64) || \
-	     defined(__mips64)  || defined(__x86_64__) || defined(_M_X64))
+	     defined(__mips64)  || defined(__x86_64__) || defined(_M_X64) || \
+	     defined(__aarch64__) || defined(__arm64__))
 	    typedef word64 wolfssl_word;
 	#else
 	    typedef word32 wolfssl_word;


### PR DESCRIPTION
This patch fixes:
 * broken build on Android ARM64 (armv8) architecture
 * allow using intermediate CA to be loaded as valid one
 * allow explicit checking for intermediate CA in the cert. chain (without need to trust whole root CA)
 * allow using 4096-bit RSA keys