### PR TITLE
free ctx in case of InitMutex fail

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1376,7 +1376,7 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
 
     if (InitMutex(&ctx->countMutex) < 0) {
         WOLFSSL_MSG("Mutex error on CTX init");
-        ctx->err = (int)CTX_INIT_MUTEX_E;
+        ctx->err = CTX_INIT_MUTEX_E;
         return BAD_MUTEX_E;
     }
 
@@ -1541,7 +1541,7 @@ void FreeSSL_Ctx(WOLFSSL_CTX* ctx)
 
         /* check error state, if mutex error code then mutex init failed but
          * CTX was still malloc'd */
-        if (ctx->err == (int)CTX_INIT_MUTEX_E) {
+        if (ctx->err == CTX_INIT_MUTEX_E) {
             SSL_CtxResourceFree(ctx);
             XFREE(ctx, ctx->heap, DYNAMIC_TYPE_CTX);
         }

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -149,6 +149,7 @@ enum wolfSSL_ErrorCodes {
 
     DTLS_EXPORT_VER_E            = -411,   /* export version error */
     INPUT_SIZE_E                 = -412,   /* input size too big error */
+    CTX_INIT_MUTEX_E             = -413,   /* initialize ctx mutex error */
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* begin negotiation parameter errors */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1922,6 +1922,7 @@ struct WOLFSSL_CTX {
     WOLFSSL_METHOD* method;
     wolfSSL_Mutex   countMutex;    /* reference count mutex */
     int         refCount;         /* reference count */
+    int         err;              /* error code in case of mutex not created */
 #ifndef NO_DH
     buffer      serverDH_P;
     buffer      serverDH_G;


### PR DESCRIPTION
In the case that CTX count mutex can not be initialized still free malloc of CTX.