### PR TITLE
Remove double call to "wolfCrypt_Init()" in test.c

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -291,8 +291,6 @@ int wolfcrypt_test(void* args)
 {
     int ret = 0;
 
-    wolfCrypt_Init();
-
     ((func_args*)args)->return_code = -1; /* error state */
 
 #if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)


### PR DESCRIPTION
Appears to have been added in static memory merge on 6/10. The original call is at line 300.