### PR TITLE
One last fix of the DTLS version numbers

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -12677,15 +12677,8 @@ static void PickHashSigAlgo(WOLFSSL* ssl,
                  ssl->buffers.outputBuffer.length;
 
         AddHeaders(output, length, client_hello, ssl);
-#ifdef WOLFSSL_DTLS
-        if (ssl->options.dtls) {
-            DtlsRecordLayerHeader* rh = (DtlsRecordLayerHeader*)output;
-            rh->pvMajor = DTLS_MAJOR;
-            rh->pvMinor = DTLS_MINOR;
-        }
-#endif /* WOLFSSL_DTLS */
 
-            /* client hello, first version */
+        /* client hello, first version */
         output[idx++] = ssl->version.major;
         output[idx++] = ssl->version.minor;
         ssl->chVersion = ssl->version;  /* store in case changed */
@@ -18138,14 +18131,14 @@ int DoSessionTicket(WOLFSSL* ssl,
          * Client Hello. */
         ssl->keys.dtls_sequence_number = ssl->keys.dtls_state.curSeq;
         AddHeaders(output, length, hello_verify_request, ssl);
-        {
-            DtlsRecordLayerHeader* rh = (DtlsRecordLayerHeader*)output;
-            rh->pvMajor = DTLS_MAJOR;
-            rh->pvMinor = DTLS_MINOR;
-        }
 
+#ifdef OPENSSL_EXTRA
+        output[idx++] = DTLS_MAJOR;
+        output[idx++] = DTLS_MINOR;
+#else
         output[idx++] = ssl->version.major;
         output[idx++] = ssl->version.minor;
+#endif
 
         output[idx++] = cookieSz;
         if (cookie == NULL || cookieSz == 0)


### PR DESCRIPTION
After reading and rereading the RFC and comparing how to the other SSLs do it, I'm following a strict interpretation of putting the version numbers in the messages, but I'd adding an option to do it like OpenSSL does when using the compatibility mode. GnuTLS uses a completely different interpretation of the RFC.