### PR TITLE
Asynchronous wolfCrypt RSA and TLS client support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ fips_test.c
 fips
 src/async.c
 wolfssl/async.h
+wolfcrypt/src/async.c
+wolfssl/wolfcrypt/async.h
 ctaocrypt/benchmark/benchmark
 ctaocrypt/test/testctaocrypt
 wolfcrypt/benchmark/benchmark

--- a/IDE/WIN/wolfssl-fips.vcxproj
+++ b/IDE/WIN/wolfssl-fips.vcxproj
@@ -300,6 +300,7 @@
     <ClCompile Include="..\..\src\ssl.c" />
     <ClCompile Include="..\..\src\tls.c" />
     <ClCompile Include="..\..\wolfcrypt\src\wc_encrypt.c" />
+    <ClCompile Include="..\..\wolfcrypt\src\wolfevent.c" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\wolfcrypt\src\aes_asm.asm">

--- a/autogen.sh
+++ b/autogen.sh
@@ -20,8 +20,8 @@ if test -d .git; then
   touch ./ctaocrypt/src/fips_test.c
 
   # touch async crypt files
-  touch ./src/async.c
-  touch ./wolfssl/async.h
+  touch ./wolfcrypt/src/async.c
+  touch ./wolfssl/wolfcrypt/async.h
 else
   WARNINGS="all"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -2439,27 +2439,68 @@ AC_ARG_WITH([cavium],
         AC_MSG_CHECKING([for cavium])
         CPPFLAGS="$CPPFLAGS -DHAVE_CAVIUM"
 
-            if test "x$withval" == "xyes" ; then
-                AC_MSG_ERROR([need a PATH for --with-cavium])
-            fi
-            if test "x$withval" != "xno" ; then
-                trycaviumdir=$withval
-            fi
+        if test "x$withval" == "xyes" ; then
+            AC_MSG_ERROR([need a PATH for --with-cavium])
+        fi
+        if test "x$withval" != "xno" ; then
+            trycaviumdir=$withval
+        fi
 
-            LDFLAGS="$AM_LDFLAGS $trycaviumdir/api/cavium_common.o"
-            CPPFLAGS="$CPPFLAGS -I$trycaviumdir/include"
+        LDFLAGS="$AM_LDFLAGS $trycaviumdir/api/cavium_common.o"
+        CPPFLAGS="$CPPFLAGS -I$trycaviumdir/include"
 
-            AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cavium_common.h"]], [[ CspShutdown(CAVIUM_DEV_ID); ]])],[ cavium_linked=yes ],[ cavium_linked=no ])
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cavium_common.h"]], [[ CspShutdown(CAVIUM_DEV_ID); ]])],[ cavium_linked=yes ],[ cavium_linked=no ])
 
-            if test "x$cavium_linked" == "xno" ; then
-                AC_MSG_ERROR([cavium isn't found.
-                If it's already installed, specify its path using --with-cavium=/dir/])
-            fi
-            AC_MSG_RESULT([yes])
-            enable_shared=no
-            enable_static=yes
+        if test "x$cavium_linked" == "xno" ; then
+            AC_MSG_ERROR([cavium isn't found.
+            If it's already installed, specify its path using --with-cavium=/dir/])
+        fi
+        AC_MSG_RESULT([yes])
+        enable_shared=no
+        enable_static=yes
+        ENABLED_CAVIUM=yes
+    ],
+    [ ENABLED_CAVIUM=no ]
+)
+
+# cavium V
+trycaviumdir=""
+AC_ARG_WITH([cavium-v],
+    [  --with-cavium-v=PATH    PATH to Cavium V/software dir ],
+    [
+        AC_MSG_CHECKING([for cavium])
+        CPPFLAGS="$CPPFLAGS -DHAVE_CAVIUM -DHAVE_CAVIUM_V"
+
+        if test "x$withval" == "xyes" ; then
+            AC_MSG_ERROR([need a PATH for --with-cavium])
+        fi
+        if test "x$withval" != "xno" ; then
+            trycaviumdir=$withval
+        fi
+
+        LDFLAGS="$AM_LDFLAGS $trycaviumdir/utils/sample_tests/cavium_common.o $trycaviumdir/utils/sample_tests/cavium_sym_crypto.o $trycaviumdir/utils/sample_tests/cavium_asym_crypto.o"
+        CPPFLAGS="$CPPFLAGS -I$trycaviumdir/include"
+
+        #AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cavium_common.h"]], [[ CspShutdown(0); ]])],[ cavium_linked=yes ],[ cavium_linked=no ])
+
+        if test "x$cavium_linked" == "xno" ; then
+            AC_MSG_ERROR([cavium isn't found.
+            If it's already installed, specify its path using --with-cavium-v=/dir/])
+        fi
+        AC_MSG_RESULT([yes])
+
+        enable_shared=no
+        enable_static=yes
+        ENABLED_CAVIUM=yes
+        ENABLED_CAVIUM_V=yes
+    ],
+    [
+        ENABLED_CAVIUM_=no
+        ENABLED_CAVIUM_V=no
     ]
 )
+
+AM_CONDITIONAL([BUILD_CAVIUM], [test "x$ENABLED_CAVIUM" = "xyes"])
 
 
 # Fast RSA using Intel IPP
@@ -2668,7 +2709,7 @@ AC_ARG_ENABLE([asynccrypt],
 
 if test "$ENABLED_ASYNCCRYPT" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ASYNC_CRYPT"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ASYNC_CRYPT -DHAVE_WOLF_EVENT"
     
     # if Cavium not enabled the use async simulator for testing
     if test "x$ENABLED_CAVIUM" = "xno"
@@ -2678,6 +2719,9 @@ then
 fi
 
 AM_CONDITIONAL([BUILD_ASYNCCRYPT], [test "x$ENABLED_ASYNCCRYPT" = "xyes"])
+
+AM_CONDITIONAL([BUILD_WOLFEVENT], [test "x$ENABLED_ASYNCCRYPT" = "xyes"])
+
 
 
 # Session Export
@@ -3069,6 +3113,7 @@ echo "   * Examples:                   $ENABLED_EXAMPLES"
 echo "   * User Crypto:                $ENABLED_USER_CRYPTO"
 echo "   * Fast RSA:                   $ENABLED_FAST_RSA"
 echo "   * Async Crypto:               $ENABLED_ASYNCCRYPT"
+echo "   * Cavium:                     $ENABLED_CAVIUM"
 echo ""
 echo "---"
 

--- a/cyassl/ctaocrypt/aes.h
+++ b/cyassl/ctaocrypt/aes.h
@@ -56,11 +56,6 @@
     #define AesCcmDecrypt wc_AesCcmDecrypt
 #endif /* HAVE_AESCCM */
 
-#ifdef HAVE_CAVIUM
-    #define AesInitCavium wc_AesInitCavium
-    #define AesFreeCavium wc_AesFreeCavium
-#endif
-
 #endif /* CTAO_CRYPT_AES_H */
 #endif /* NO_AES */
 

--- a/cyassl/ctaocrypt/arc4.h
+++ b/cyassl/ctaocrypt/arc4.h
@@ -26,11 +26,10 @@
 /* for arc4 reverse compatibility */
 #ifndef NO_RC4
 #include <wolfssl/wolfcrypt/arc4.h>
-    #define CYASSL_ARC4_CAVIUM_MAGIC WOLFSSL_ARC4_CAVIUM_MAGIC
     #define Arc4Process wc_Arc4Process
     #define Arc4SetKey wc_Arc4SetKey
-    #define Arc4InitCavium wc_Arc4InitCavium
-    #define Arc4FreeCavium wc_Arc4FreeCavium
+    #define Arc4AsyncInit wc_Arc4AsyncInit
+    #define Arc4AsyncFree wc_Arc4AsyncFree
 #endif
 
 #endif /* CTAO_CRYPT_ARC4_H */

--- a/cyassl/ctaocrypt/des3.h
+++ b/cyassl/ctaocrypt/des3.h
@@ -39,9 +39,9 @@
 #define Des3_CbcEncrypt        wc_Des3_CbcEncrypt
 #define Des3_CbcDecrypt        wc_Des3_CbcDecrypt
 #define Des3_CbcDecryptWithKey wc_Des3_CbcDecryptWithKey
-#ifdef HAVE_CAVIUM
-    #define Des3_InitCavium wc_Des3_InitCavium
-    #define Des3_FreeCavium wc_Des3_FreeCavium
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #define Des3AsyncInit wc_Des3AsyncInit
+    #define Des3AsyncFree wc_Des3AsyncFree
 #endif
 
 #endif /* NO_DES3 */

--- a/cyassl/ctaocrypt/hmac.h
+++ b/cyassl/ctaocrypt/hmac.h
@@ -30,9 +30,9 @@
 #define HmacSetKey wc_HmacSetKey
 #define HmacUpdate wc_HmacUpdate
 #define HmacFinal  wc_HmacFinal
-#ifdef HAVE_CAVIUM
-    #define HmacInitCavium wc_HmacInitCavium
-    #define HmacFreeCavium wc_HmacFreeCavium
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #define HmacAsyncInit wc_HmacAsyncInit
+    #define HmacAsyncFree wc_HmacAsyncFree
 #endif
 #define CyaSSL_GetHmacMaxSize wolfSSL_GetHmacMaxSize
 #ifdef HAVE_HKDF

--- a/cyassl/ctaocrypt/rsa.h
+++ b/cyassl/ctaocrypt/rsa.h
@@ -47,9 +47,9 @@
     #define RsaKeyToDer wc_RsaKeyToDer
 #endif
 
-#ifdef HAVE_CAVIUM
-    #define RsaInitCavium wc_RsaInitCavium
-    #define RsaFreeCavium wc_RsaFreeCavium
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #define RsaAsyncInit wc_RsaAsyncInit
+    #define RsaAsyncFree wc_RsaAsyncFree
 #endif
 
 #endif /* CTAO_CRYPT_RSA_H */

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -55,6 +55,10 @@
 
 #include "examples/server/server.h"
 
+#ifdef WOLFSSL_ASYNC_CRYPT
+    static int devId = INVALID_DEVID;
+#endif
+
 /* Note on using port 0: if the server uses port 0 to bind an ephemeral port
  * number and is using the ready file for scripted testing, the code in
  * test.h will write the actual port number into the ready file for use
@@ -806,6 +810,14 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     }
 #endif /* USE_WINDOWS_API */
 
+#ifdef WOLFSSL_ASYNC_CRYPT
+    ret = wolfAsync_DevOpen(&devId);
+    if (ret != 0) {
+        err_sys("Async device open failed");
+    }
+    wolfSSL_CTX_UseAsync(ctx, devId);
+#endif /* WOLFSSL_ASYNC_CRYPT */
+
     while (1) {
         /* allow resume option */
         if(resumeCount > 1) {
@@ -947,7 +959,7 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
         do {
 #ifdef WOLFSSL_ASYNC_CRYPT
             if (err == WC_PENDING_E) {
-                ret = AsyncCryptPoll(ssl);
+                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
                 if (ret < 0) { break; } else if (ret == 0) { continue; }
             }
 #endif
@@ -1088,6 +1100,10 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     TicketCleanup();
 #endif
 
+#ifdef WOLFSSL_ASYNC_CRYPT
+    wolfAsync_DevClose(&devId);
+#endif
+
     /* There are use cases  when these assignments are not read. To avoid
      * potential confusion those warnings have been handled here.
      */
@@ -1112,11 +1128,6 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
         func_args args;
         tcp_ready ready;
 
-#ifdef HAVE_CAVIUM
-        int ret = OpenNitroxDevice(CAVIUM_DIRECT, CAVIUM_DEV_ID);
-        if (ret != 0)
-            err_sys("Cavium OpenNitroxDevice failed");
-#endif /* HAVE_CAVIUM */
 
         StartTCP();
 
@@ -1138,10 +1149,6 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
 #endif
         CyaSSL_Cleanup();
         FreeTcpReady(&ready);
-
-#ifdef HAVE_CAVIUM
-        CspShutdown(CAVIUM_DEV_ID);
-#endif
 
 #ifdef HAVE_WNR
     if (wc_FreeNetRandom() < 0)

--- a/mcapi/crypto.c
+++ b/mcapi/crypto.c
@@ -223,6 +223,7 @@ int CRYPT_SHA512_Finalize(CRYPT_SHA512_CTX* sha512, unsigned char* digest)
 int CRYPT_HMAC_SetKey(CRYPT_HMAC_CTX* hmac, int type, const unsigned char* key,
                       unsigned int sz)
 {
+    /* compile-time check to verify CRYPT_HMAC_CTX is large enough to hold Hmac */
     typedef char hmac_test[sizeof(CRYPT_HMAC_CTX) >= sizeof(Hmac) ? 1 : -1];
     (void)sizeof(hmac_test);
 

--- a/mcapi/crypto.h
+++ b/mcapi/crypto.h
@@ -104,7 +104,7 @@ enum {
 
 /* HMAC */
 typedef struct CRYPT_HMAC_CTX {
-    long long holder[67];   /* big enough to hold internal, but check on init */
+    long long holder[68];   /* big enough to hold internal, but check on init */
 } CRYPT_HMAC_CTX;
 
 int CRYPT_HMAC_SetKey(CRYPT_HMAC_CTX*, int, const unsigned char*, unsigned int);

--- a/src/include.am
+++ b/src/include.am
@@ -65,6 +65,14 @@ src_libwolfssl_la_SOURCES += \
                wolfcrypt/src/sha256.c \
                wolfcrypt/src/hash.c
 
+if BUILD_WOLFEVENT
+src_libwolfssl_la_SOURCES += wolfcrypt/src/wolfevent.c
+endif
+
+if BUILD_ASYNCCRYPT
+src_libwolfssl_la_SOURCES += wolfcrypt/src/async.c
+endif
+
 if !BUILD_USER_RSA
 if BUILD_RSA
 if BUILD_FAST_RSA
@@ -252,10 +260,6 @@ endif
 
 if BUILD_SNIFFER
 src_libwolfssl_la_SOURCES += src/sniffer.c
-endif
-
-if BUILD_ASYNCCRYPT
-src_libwolfssl_la_SOURCES += src/async.c
 endif
 
 endif # !BUILD_CRYPTONLY

--- a/src/keys.c
+++ b/src/keys.c
@@ -2070,18 +2070,18 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
             dec->arc4 = (Arc4*)XMALLOC(sizeof(Arc4), heap, DYNAMIC_TYPE_CIPHER);
         if (dec && dec->arc4 == NULL)
             return MEMORY_E;
-#ifdef HAVE_CAVIUM
-        if (devId != NO_CAVIUM_DEVICE) {
+#ifdef WOLFSSL_ASYNC_CRYPT
+        if (devId != INVALID_DEVID) {
             if (enc) {
-                if (wc_Arc4InitCavium(enc->arc4, devId) != 0) {
-                    WOLFSSL_MSG("Arc4InitCavium failed in SetKeys");
-                    return CAVIUM_INIT_E;
+                if (wc_Arc4AsyncInit(enc->arc4, devId) != 0) {
+                    WOLFSSL_MSG("Arc4AsyncInit failed in SetKeys");
+                    return ASYNC_INIT_E;
                 }
             }
             if (dec) {
-                if (wc_Arc4InitCavium(dec->arc4, devId) != 0) {
-                    WOLFSSL_MSG("Arc4InitCavium failed in SetKeys");
-                    return CAVIUM_INIT_E;
+                if (wc_Arc4AsyncInit(dec->arc4, devId) != 0) {
+                    WOLFSSL_MSG("Arc4AsyncInit failed in SetKeys");
+                    return ASYNC_INIT_E;
                 }
             }
         }
@@ -2282,18 +2282,18 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
             dec->des3 = (Des3*)XMALLOC(sizeof(Des3), heap, DYNAMIC_TYPE_CIPHER);
         if (dec && dec->des3 == NULL)
             return MEMORY_E;
-#ifdef HAVE_CAVIUM
-        if (devId != NO_CAVIUM_DEVICE) {
+#ifdef WOLFSSL_ASYNC_CRYPT
+        if (devId != INVALID_DEVID) {
             if (enc) {
-                if (wc_Des3_InitCavium(enc->des3, devId) != 0) {
-                    WOLFSSL_MSG("Des3_InitCavium failed in SetKeys");
-                    return CAVIUM_INIT_E;
+                if (wc_Des3AsyncInit(enc->des3, devId) != 0) {
+                    WOLFSSL_MSG("Des3AsyncInit failed in SetKeys");
+                    return ASYNC_INIT_E;
                 }
             }
             if (dec) {
-                if (wc_Des3_InitCavium(dec->des3, devId) != 0) {
-                    WOLFSSL_MSG("Des3_InitCavium failed in SetKeys");
-                    return CAVIUM_INIT_E;
+                if (wc_Des3AsyncInit(dec->des3, devId) != 0) {
+                    WOLFSSL_MSG("Des3AsyncInit failed in SetKeys");
+                    return ASYNC_INIT_E;
                 }
             }
         }
@@ -2346,18 +2346,18 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
             dec->aes = (Aes*)XMALLOC(sizeof(Aes), heap, DYNAMIC_TYPE_CIPHER);
         if (dec && dec->aes == NULL)
             return MEMORY_E;
-#ifdef HAVE_CAVIUM
-        if (devId != NO_CAVIUM_DEVICE) {
+#ifdef WOLFSSL_ASYNC_CRYPT
+        if (devId != INVALID_DEVID) {
             if (enc) {
-                if (wc_AesInitCavium(enc->aes, devId) != 0) {
-                    WOLFSSL_MSG("AesInitCavium failed in SetKeys");
-                    return CAVIUM_INIT_E;
+                if (wc_AesAsyncInit(enc->aes, devId) != 0) {
+                    WOLFSSL_MSG("AesAsyncInit failed in SetKeys");
+                    return ASYNC_INIT_E;
                 }
             }
             if (dec) {
-                if (wc_AesInitCavium(dec->aes, devId) != 0) {
-                    WOLFSSL_MSG("AesInitCavium failed in SetKeys");
-                    return CAVIUM_INIT_E;
+                if (wc_AesAsyncInit(dec->aes, devId) != 0) {
+                    WOLFSSL_MSG("AesAsyncInit failed in SetKeys");
+                    return ASYNC_INIT_E;
                 }
             }
         }
@@ -2675,14 +2675,14 @@ static int SetAuthKeys(OneTimeAuth* authentication, Keys* keys,
  */
 int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
 {
-    int devId = NO_CAVIUM_DEVICE, ret, copy = 0;
+    int devId = INVALID_DEVID, ret, copy = 0;
     Ciphers* wc_encrypt = NULL;
     Ciphers* wc_decrypt = NULL;
     Keys*    keys    = &ssl->keys;
 
     (void)copy;
 
-#ifdef HAVE_CAVIUM
+#ifdef WOLFSSL_ASYNC_CRYPT
     devId = ssl->devId;
 #endif
 

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -54,11 +54,6 @@ int unit_test(int argc, char** argv)
 #if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND)
     wolfSSL_Debugging_ON();
 #endif
-#ifdef HAVE_CAVIUM
-    ret = OpenNitroxDevice(CAVIUM_DIRECT, CAVIUM_DEV_ID);
-    if (ret != 0)
-        err_sys("Cavium OpenNitroxDevice failed");
-#endif /* HAVE_CAVIUM */
 
 #ifdef HAVE_WNR
     if (wc_InitNetRandom(wnrConfig, NULL, 5000) != 0)
@@ -84,10 +79,6 @@ int unit_test(int argc, char** argv)
 #endif
 
     SrpTest();
-
-#ifdef HAVE_CAVIUM
-        CspShutdown(CAVIUM_DEV_ID);
-#endif
 
 #ifdef HAVE_WNR
     if (wc_FreeNetRandom() < 0)

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -84,12 +84,6 @@ int testsuite_test(int argc, char** argv)
     int num = 6;
 #endif
 
-#ifdef HAVE_CAVIUM
-        int ret = OpenNitroxDevice(CAVIUM_DIRECT, CAVIUM_DEV_ID);
-        if (ret != 0)
-            err_sys("Cavium OpenNitroxDevice failed");
-#endif /* HAVE_CAVIUM */
-
 #ifdef HAVE_WNR
         if (wc_InitNetRandom(wnrConfig, NULL, 5000) != 0) {
             err_sys("Whitewood netRandom global config failed");
@@ -202,10 +196,6 @@ int testsuite_test(int argc, char** argv)
 
 #ifdef WOLFSSL_TIRTOS
     fdCloseSession(Task_self());
-#endif
-
-#ifdef HAVE_CAVIUM
-        CspShutdown(CAVIUM_DEV_ID);
 #endif
 
 #ifdef HAVE_WNR

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -692,10 +692,13 @@ static int GetIntRsa(RsaKey* key, mp_int* mpi, const byte* input,
     if (GetLength(input, &i, &length, maxIdx) < 0)
         return ASN_PARSE_E;
 
-    if ( (b = input[i++]) == 0x00)
-        length--;
-    else
-        i--;
+    if (length > 0) {
+        /* remove leading zero */
+        if ( (b = input[i++]) == 0x00)
+            length--;
+        else
+            i--;
+    }
 
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
     if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA) {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -646,7 +646,7 @@ static int GetExplicitVersion(const byte* input, word32* inOutIdx, int* version)
 }
 #endif /* !NO_ASN_TIME */
 
-WOLFSSL_LOCAL int GetInt(mp_int* mpi, const byte* input, word32* inOutIdx,
+int GetInt(mp_int* mpi, const byte* input, word32* inOutIdx,
                   word32 maxIdx)
 {
     word32 i = *inOutIdx;
@@ -675,6 +675,62 @@ WOLFSSL_LOCAL int GetInt(mp_int* mpi, const byte* input, word32* inOutIdx,
     *inOutIdx = i + length;
     return 0;
 }
+
+#if !defined(NO_RSA) && !defined(HAVE_USER_RSA)
+static int GetIntRsa(RsaKey* key, mp_int* mpi, const byte* input,
+                        word32* inOutIdx, word32 maxIdx)
+{
+    word32 i = *inOutIdx;
+    byte   b = input[i++];
+    int    length;
+
+    (void)key;
+
+    if (b != ASN_INTEGER)
+        return ASN_PARSE_E;
+
+    if (GetLength(input, &i, &length, maxIdx) < 0)
+        return ASN_PARSE_E;
+
+    if ( (b = input[i++]) == 0x00)
+        length--;
+    else
+        i--;
+
+#if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
+    if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA) {
+        XMEMSET(mpi, 0, sizeof(mp_int));
+        mpi->used = length;
+    #ifdef USE_FAST_MATH
+        if (length > (FP_SIZE * (int)sizeof(fp_digit))) {
+            return MEMORY_E;
+        }
+        mpi->dpraw = (byte*)mpi->dp;
+    #else
+        mpi->dpraw = (byte*)XMALLOC(length, key->heap, DYNAMIC_TYPE_ASYNC_RSA);
+    #endif
+        if (mpi->dpraw == NULL) {
+            return MEMORY_E;
+        }
+
+        XMEMCPY(mpi->dpraw, input + i, length);
+    }
+    else
+#endif /* WOLFSSL_ASYNC_CRYPT && HAVE_CAVIUM */
+    {
+        if (mp_init(mpi) != MP_OKAY)
+            return MP_INIT_E;
+
+        if (mp_read_unsigned_bin(mpi, (byte*)input + i, length) != 0) {
+            mp_clear(mpi);
+            return ASN_GETINT_E;
+        }
+    }
+
+    *inOutIdx = i + length;
+    return 0;
+}
+#endif /* !NO_RSA && !HAVE_USER_RSA */
 
 
 /* hashType */
@@ -1297,78 +1353,11 @@ WOLFSSL_LOCAL int GetAlgoId(const byte* input, word32* inOutIdx, word32* oid,
 
 #ifndef NO_RSA
 
-
-#ifdef HAVE_CAVIUM
-
-static int GetCaviumInt(byte** buff, word16* buffSz, const byte* input,
-                        word32* inOutIdx, word32 maxIdx, void* heap)
-{
-    word32 i = *inOutIdx;
-    byte   b = input[i++];
-    int    length;
-
-    if (b != ASN_INTEGER)
-        return ASN_PARSE_E;
-
-    if (GetLength(input, &i, &length, maxIdx) < 0)
-        return ASN_PARSE_E;
-
-    if ( (b = input[i++]) == 0x00)
-        length--;
-    else
-        i--;
-
-    *buffSz = (word16)length;
-    *buff   = XMALLOC(*buffSz, heap, DYNAMIC_TYPE_CAVIUM_RSA);
-    if (*buff == NULL)
-        return MEMORY_E;
-
-    XMEMCPY(*buff, input + i, *buffSz);
-
-    *inOutIdx = i + length;
-    return 0;
-}
-
-static int CaviumRsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
-                                     RsaKey* key, word32 inSz)
-{
-    int   version, length;
-    void* h = key->heap;
-
-    if (GetSequence(input, inOutIdx, &length, inSz) < 0)
-        return ASN_PARSE_E;
-
-    if (GetMyVersion(input, inOutIdx, &version) < 0)
-        return ASN_PARSE_E;
-
-    key->type = RSA_PRIVATE;
-
-    if (GetCaviumInt(&key->c_n,  &key->c_nSz,   input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_e,  &key->c_eSz,   input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_d,  &key->c_dSz,   input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_p,  &key->c_pSz,   input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_q,  &key->c_qSz,   input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_dP, &key->c_dP_Sz, input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_dQ, &key->c_dQ_Sz, input, inOutIdx, inSz, h) < 0 ||
-        GetCaviumInt(&key->c_u,  &key->c_uSz,   input, inOutIdx, inSz, h) < 0 )
-            return ASN_RSA_KEY_E;
-
-    return 0;
-}
-
-
-#endif /* HAVE_CAVIUM */
-
 #ifndef HAVE_USER_RSA
 int wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
                         word32 inSz)
 {
-    int    version, length;
-
-#ifdef HAVE_CAVIUM
-    if (key->magic == WOLFSSL_RSA_CAVIUM_MAGIC)
-        return CaviumRsaPrivateKeyDecode(input, inOutIdx, key, inSz);
-#endif
+    int version, length;
 
     if (GetSequence(input, inOutIdx, &length, inSz) < 0)
         return ASN_PARSE_E;
@@ -1378,14 +1367,14 @@ int wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
 
     key->type = RSA_PRIVATE;
 
-    if (GetInt(&key->n,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->e,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->d,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->p,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->q,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->dP, input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->dQ, input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->u,  input, inOutIdx, inSz) < 0 )  return ASN_RSA_KEY_E;
+    if (GetIntRsa(key, &key->n,  input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->e,  input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->d,  input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->p,  input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->q,  input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->dP, input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->dQ, input, inOutIdx, inSz) < 0 ||
+        GetIntRsa(key, &key->u,  input, inOutIdx, inSz) < 0 )  return ASN_RSA_KEY_E;
 
     return 0;
 }
@@ -3674,11 +3663,22 @@ static int ConfirmSignature(const byte* buf, word32 bufSz,
             else {
                 XMEMCPY(plain, sig, sigSz);
 
-                if ((verifySz = wc_RsaSSL_VerifyInline(plain, sigSz, &out,
-                                                                 pubKey)) < 0) {
+                ret = 0;
+                do {
+                #if defined(WOLFSSL_ASYNC_CRYPT)
+                    ret = wc_RsaAsyncWait(ret, pubKey);
+                #endif
+                    if (ret >= 0) {
+                        ret = wc_RsaSSL_VerifyInline(plain, sigSz, &out,
+                                                                    pubKey);
+                    }
+                } while (ret == WC_PENDING_E);
+
+                if (ret < 0) {
                     WOLFSSL_MSG("Rsa SSL verify error");
                 }
                 else {
+                    verifySz = ret;
                     /* make sure we're right justified */
                     encodedSigSz =
                         wc_EncodeSignature(encodedSig, digest, digestSz, typeH);
@@ -7359,7 +7359,15 @@ static int MakeSignature(const byte* buffer, int sz, byte* sig, int sigSz,
     if (rsaKey) {
         /* signature */
         encSigSz = wc_EncodeSignature(encSig, digest, digestSz, typeH);
-        ret = wc_RsaSSL_Sign(encSig, encSigSz, sig, sigSz, rsaKey, rng);
+        ret = 0;
+        do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+            ret = wc_RsaAsyncWait(ret, rsaKey);
+#endif
+            if (ret >= 0) {
+                ret = wc_RsaSSL_Sign(encSig, encSigSz, sig, sigSz, rsaKey, rng);
+            }
+        } while (ret == WC_PENDING_E);
     }
 #endif
 

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -62,6 +62,15 @@ const char* wc_GetErrorString(int error)
     case BAD_MUTEX_E :
         return "Bad mutex, operation failed";
 
+    case WC_TIMEOUT_E:
+        return "Timeout error";
+
+    case WC_PENDING_E:
+        return "wolfCrypt Operation Pending (would block / eagain) error";
+
+    case WC_NOT_PENDING_E:
+        return "wolfCrypt operation not pending error";
+
     case MP_INIT_E :
         return "mp_init error state";
 
@@ -227,8 +236,8 @@ const char* wc_GetErrorString(int error)
     case AES_CCM_AUTH_E:
         return "AES-CCM Authentication check fail";
 
-    case CAVIUM_INIT_E:
-        return "Cavium Init type error";
+    case ASYNC_INIT_E:
+        return "Async Init error";
 
     case COMPRESS_INIT_E:
         return "Compress Init error";
@@ -257,8 +266,8 @@ const char* wc_GetErrorString(int error)
     case ASN_OCSP_CONFIRM_E :
         return "ASN OCSP sig error, confirm failure";
 
-    case BAD_ENC_STATE_E:
-        return "Bad ecc encrypt state operation";
+    case BAD_STATE_E:
+        return "Bad state operation";
 
     case BAD_PADDING_E:
         return "Bad padding, message wrong length";
@@ -376,9 +385,6 @@ const char* wc_GetErrorString(int error)
 
     case HASH_TYPE_E:
         return "Hash type not enabled/available";
-
-    case WC_PENDING_E:
-        return "wolfCrypt Operation Pending (would block / eagain) error";
 
     case WC_KEY_SIZE_E:
         return "Key size error, either too small or large";

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -34,42 +34,54 @@
 #include <wolfssl/wolfcrypt/hash.h>
 
 
-#ifndef NO_ASN
+#if !defined(NO_ASN) || !defined(NO_DH) || defined(HAVE_ECC)
+
+#ifdef NO_ASN
+enum Hash_Sum  {
+    MD2h    = 646,
+    MD5h    = 649,
+    SHAh    =  88,
+    SHA256h = 414,
+    SHA384h = 415,
+    SHA512h = 416
+};
+#endif
+
 int wc_HashGetOID(enum wc_HashType hash_type)
 {
     int oid = HASH_TYPE_E; /* Default to hash type error */
     switch(hash_type)
     {
         case WC_HASH_TYPE_MD2:
-#ifdef WOLFSSL_MD2
+        #ifdef WOLFSSL_MD2
             oid = MD2h;
-#endif
+        #endif
             break;
         case WC_HASH_TYPE_MD5_SHA:
         case WC_HASH_TYPE_MD5:
-#ifndef NO_MD5
+        #ifndef NO_MD5
             oid = MD5h;
-#endif
+        #endif
             break;
         case WC_HASH_TYPE_SHA:
-#ifndef NO_SHA
+        #ifndef NO_SHA
             oid = SHAh;
-#endif
+        #endif
             break;
         case WC_HASH_TYPE_SHA256:
-#ifndef NO_SHA256
+        #ifndef NO_SHA256
             oid = SHA256h;
-#endif
+        #endif
             break;
         case WC_HASH_TYPE_SHA384:
-#if defined(WOLFSSL_SHA512) && defined(WOLFSSL_SHA384)
+        #if defined(WOLFSSL_SHA512) && defined(WOLFSSL_SHA384)
             oid = SHA384h;
-#endif
+        #endif
             break;
         case WC_HASH_TYPE_SHA512:
-#ifdef WOLFSSL_SHA512
+        #ifdef WOLFSSL_SHA512
             oid = SHA512h;
-#endif
+        #endif
             break;
 
         /* Not Supported */

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -50,16 +50,16 @@ int wc_HmacFinal(Hmac* hmac, byte* out)
 }
 
 
-#ifdef HAVE_CAVIUM
-    int  wc_HmacInitCavium(Hmac* hmac, int i)
+#ifdef WOLFSSL_ASYNC_CRYPT
+    int  wc_HmacAsyncInit(Hmac* hmac, int i)
     {
-        return HmacInitCavium(hmac, i);
+        return HmacAsyncInit(hmac, i);
     }
 
 
-    void wc_HmacFreeCavium(Hmac* hmac)
+    void wc_HmacAsyncFree(Hmac* hmac)
     {
-        HmacFreeCavium(hmac);
+        HmacAsyncFree(hmac);
     }
 #endif
 
@@ -105,12 +105,48 @@ int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 
-#ifdef HAVE_CAVIUM
-    static int HmacCaviumFinal(Hmac* hmac, byte* hash);
-    static int HmacCaviumUpdate(Hmac* hmac, const byte* msg, word32 length);
-    static int HmacCaviumSetKey(Hmac* hmac, int type, const byte* key,
-                                word32 length);
-#endif
+int wc_HmacSizeByType(int type)
+{
+    if (!(type == MD5 || type == SHA    || type == SHA256 || type == SHA384
+                      || type == SHA512 || type == BLAKE2B_ID)) {
+        return BAD_FUNC_ARG;
+    }
+
+    switch (type) {
+    #ifndef NO_MD5
+        case MD5:
+            return MD5_DIGEST_SIZE;
+    #endif
+
+    #ifndef NO_SHA
+        case SHA:
+            return SHA_DIGEST_SIZE;
+    #endif
+
+    #ifndef NO_SHA256
+        case SHA256:
+            return SHA256_DIGEST_SIZE;
+    #endif
+
+    #ifdef WOLFSSL_SHA384
+        case SHA384:
+            return SHA384_DIGEST_SIZE;
+    #endif
+
+    #ifdef WOLFSSL_SHA512
+        case SHA512:
+            return SHA512_DIGEST_SIZE;
+    #endif
+
+    #ifdef HAVE_BLAKE2
+        case BLAKE2B_ID:
+            return BLAKE2B_OUTBYTES;
+    #endif
+
+        default:
+            return BAD_FUNC_ARG;
+    }
+}
 
 static int InitHmac(Hmac* hmac, int type)
 {
@@ -175,9 +211,10 @@ int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
     word32 i, hmac_block_size = 0;
     int    ret;
 
-#ifdef HAVE_CAVIUM
-    if (hmac->magic == WOLFSSL_HMAC_CAVIUM_MAGIC)
-        return HmacCaviumSetKey(hmac, type, key, length);
+#if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
+    if (hmac->asyncDev.marker == WOLFSSL_ASYNC_MARKER_HMAC) {
+        return NitroxHmacSetKey(hmac, type, key, length);
+    }
 #endif
 
     ret = InitHmac(hmac, type);
@@ -391,9 +428,10 @@ int wc_HmacUpdate(Hmac* hmac, const byte* msg, word32 length)
 {
     int ret;
 
-#ifdef HAVE_CAVIUM
-    if (hmac->magic == WOLFSSL_HMAC_CAVIUM_MAGIC)
-        return HmacCaviumUpdate(hmac, msg, length);
+#if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
+    if (hmac->asyncDev.marker == WOLFSSL_ASYNC_MARKER_HMAC) {
+        return NitroxHmacUpdate(hmac, msg, length);
+    }
 #endif
 
     if (!hmac->innerHashKeyed) {
@@ -459,9 +497,10 @@ int wc_HmacFinal(Hmac* hmac, byte* hash)
 {
     int ret;
 
-#ifdef HAVE_CAVIUM
-    if (hmac->magic == WOLFSSL_HMAC_CAVIUM_MAGIC)
-        return HmacCaviumFinal(hmac, hash);
+#if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
+    if (hmac->asyncDev.marker == WOLFSSL_ASYNC_MARKER_HMAC) {
+        return NitroxHmacFinal(hmac, hash);
+    }
 #endif
 
     if (!hmac->innerHashKeyed) {
@@ -606,129 +645,57 @@ int wc_HmacFinal(Hmac* hmac, byte* hash)
 }
 
 
-#ifdef HAVE_CAVIUM
+#ifdef WOLFSSL_ASYNC_CRYPT
 
 /* Initialize Hmac for use with Nitrox device */
-int wc_HmacInitCavium(Hmac* hmac, int devId)
+int wc_HmacAsyncInit(Hmac* hmac, int devId)
 {
+    int ret = 0;
+
     if (hmac == NULL)
         return -1;
 
-    if (CspAllocContext(CONTEXT_SSL, &hmac->contextHandle, devId) != 0)
-        return -1;
+    ret = wolfAsync_DevCtxInit(&hmac->asyncDev, WOLFSSL_ASYNC_MARKER_HMAC, devId);
+    if (ret != 0) {
+        return ret;
+    }
 
+#ifdef HAVE_CAVIUM
     hmac->keyLen  = 0;
     hmac->dataLen = 0;
     hmac->type    = 0;
-    hmac->devId   = devId;
-    hmac->magic   = WOLFSSL_HMAC_CAVIUM_MAGIC;
     hmac->data    = NULL;        /* buffered input data */
 
     hmac->innerHashKeyed = 0;
+#endif /* HAVE_CAVIUM */
 
     /* default to NULL heap hint or test value */
 #ifdef WOLFSSL_HEAP_TEST
     hmac->heap = (void)WOLFSSL_HEAP_TEST;
 #else
     hmac->heap = NULL;
-#endif
+#endif /* WOLFSSL_HEAP_TEST */
 
     return 0;
 }
 
 
 /* Free Hmac from use with Nitrox device */
-void wc_HmacFreeCavium(Hmac* hmac)
+void wc_HmacAsyncFree(Hmac* hmac)
 {
     if (hmac == NULL)
         return;
 
-    CspFreeContext(CONTEXT_SSL, hmac->contextHandle, hmac->devId);
-    hmac->magic = 0;
-    XFREE(hmac->data, NULL, DYNAMIC_TYPE_CAVIUM_TMP);
+    wolfAsync_DevCtxFree(&hmac->asyncDev);
+
+#ifdef HAVE_CAVIUM
+    XFREE(hmac->data, hmac->heap, DYNAMIC_TYPE_ASYNC_TMP);
     hmac->data = NULL;
+#endif
 }
 
+#endif /* WOLFSSL_ASYNC_CRYPT */
 
-static int HmacCaviumFinal(Hmac* hmac, byte* hash)
-{
-    word32 requestId;
-
-    if (CspHmac(CAVIUM_BLOCKING, hmac->type, NULL, hmac->keyLen,
-                (byte*)hmac->ipad, hmac->dataLen, hmac->data, hash, &requestId,
-                hmac->devId) != 0) {
-        WOLFSSL_MSG("Cavium Hmac failed");
-        return -1;
-    }
-    hmac->innerHashKeyed = 0;  /* tell update to start over if used again */
-
-    return 0;
-}
-
-
-static int HmacCaviumUpdate(Hmac* hmac, const byte* msg, word32 length)
-{
-    word16 add = (word16)length;
-    word32 total;
-    byte*  tmp;
-
-    if (length > WOLFSSL_MAX_16BIT) {
-        WOLFSSL_MSG("Too big msg for cavium hmac");
-        return -1;
-    }
-
-    if (hmac->innerHashKeyed == 0) {  /* starting new */
-        hmac->dataLen        = 0;
-        hmac->innerHashKeyed = 1;
-    }
-
-    total = add + hmac->dataLen;
-    if (total > WOLFSSL_MAX_16BIT) {
-        WOLFSSL_MSG("Too big msg for cavium hmac");
-        return -1;
-    }
-
-    tmp = XMALLOC(hmac->dataLen + add, hmac->heap ,DYNAMIC_TYPE_CAVIUM_TMP);
-    if (tmp == NULL) {
-        WOLFSSL_MSG("Out of memory for cavium update");
-        return -1;
-    }
-    if (hmac->dataLen)
-        XMEMCPY(tmp, hmac->data,  hmac->dataLen);
-    XMEMCPY(tmp + hmac->dataLen, msg, add);
-
-    hmac->dataLen += add;
-    XFREE(hmac->data, hmac->heap, DYNAMIC_TYPE_CAVIUM_TMP);
-    hmac->data = tmp;
-
-    return 0;
-}
-
-
-static int HmacCaviumSetKey(Hmac* hmac, int type, const byte* key,
-                            word32 length)
-{
-    hmac->macType = (byte)type;
-    if (type == MD5)
-        hmac->type = MD5_TYPE;
-    else if (type == SHA)
-        hmac->type = SHA1_TYPE;
-    else if (type == SHA256)
-        hmac->type = SHA256_TYPE;
-    else  {
-        WOLFSSL_MSG("unsupported cavium hmac type");
-    }
-
-    hmac->innerHashKeyed = 0;  /* should we key Startup flag */
-
-    hmac->keyLen = (word16)length;
-    /* store key in ipad */
-    XMEMCPY(hmac->ipad, key, length);
-
-    return 0;
-}
-
-#endif /* HAVE_CAVIUM */
 
 int wolfSSL_GetHmacMaxSize(void)
 {
@@ -748,49 +715,6 @@ int wolfSSL_GetHmacMaxSize(void)
 #endif /* WOLFSSL_HAVE_MIN */
 
 
-static INLINE int GetHashSizeByType(int type)
-{
-    if (!(type == MD5 || type == SHA    || type == SHA256 || type == SHA384
-                      || type == SHA512 || type == BLAKE2B_ID))
-        return BAD_FUNC_ARG;
-
-    switch (type) {
-        #ifndef NO_MD5
-        case MD5:
-            return MD5_DIGEST_SIZE;
-        #endif
-
-        #ifndef NO_SHA
-        case SHA:
-            return SHA_DIGEST_SIZE;
-        #endif
-
-        #ifndef NO_SHA256
-        case SHA256:
-            return SHA256_DIGEST_SIZE;
-        #endif
-
-        #ifdef WOLFSSL_SHA384
-        case SHA384:
-            return SHA384_DIGEST_SIZE;
-        #endif
-
-        #ifdef WOLFSSL_SHA512
-        case SHA512:
-            return SHA512_DIGEST_SIZE;
-        #endif
-
-        #ifdef HAVE_BLAKE2
-        case BLAKE2B_ID:
-            return BLAKE2B_OUTBYTES;
-        #endif
-
-        default:
-            return BAD_FUNC_ARG;
-    }
-}
-
-
 /* HMAC-KDF with hash type, optional salt and info, return 0 on success */
 int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
                    const byte* salt,  word32 saltSz,
@@ -806,7 +730,7 @@ int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
     byte   prk[MAX_DIGEST_SIZE];
 #endif
     const  byte* localSalt;  /* either points to user input or tmp */
-    int    hashSz = GetHashSizeByType(type);
+    int    hashSz = wc_HmacSizeByType(type);
     word32 outIdx = 0;
     byte   n = 0x1;
     int    ret;
@@ -815,13 +739,13 @@ int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
         return BAD_FUNC_ARG;
 
 #ifdef WOLFSSL_SMALL_STACK
-    tmp = (byte*)XMALLOC(MAX_DIGEST_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    tmp = (byte*)XMALLOC(MAX_DIGEST_SIZE, hmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (tmp == NULL)
         return MEMORY_E;
 
-    prk = (byte*)XMALLOC(MAX_DIGEST_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    prk = (byte*)XMALLOC(MAX_DIGEST_SIZE, hmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (prk == NULL) {
-        XFREE(tmp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(tmp, hmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
         return MEMORY_E;
     }
 #endif
@@ -873,8 +797,8 @@ int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(tmp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(prk, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(tmp, hmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(prk, hmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return ret;

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -46,4 +46,8 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/pic32/pic32mz-hash.c \
               wolfcrypt/src/port/nrf51.c
 
+if BUILD_CAVIUM
+src_libwolfssl_la_SOURCES += wolfcrypt/src/port/cavium/cavium_nitrox.c
 
+EXTRA_DIST += wolfcrypt/src/port/cavium/README.md
+endif

--- a/wolfcrypt/src/port/cavium/README.md
+++ b/wolfcrypt/src/port/cavium/README.md
@@ -1,0 +1,32 @@
+# Cavium Nitrox V Support
+
+## Directory Structure:
+`/`
+    `/CNN55XX-SDK`
+    `/wolfssl`
+
+## Cavium Driver
+
+Tested again `CNN55XX-Driver-Linux-KVM-XEN-PF-SDK-0.2-04.tar`
+From inside `CNN55XX-SDK`:
+1. `make`
+    Note: To resolve warnings in `CNN55XX-SDK/include/vf_defs.h`:
+    a. Changed `vf_config_mode_str` to return `const char*` and modify `vf_mode_str` to be `const char*`.
+    b. In `vf_config_mode_to_num_vfs` above `default:` add `case PF:`.
+
+2. `sudo make load`
+
+## wolfSSL
+
+Currently the AES and DES3 benchmark tests causes the kernel to crash, so they are disabled for now, even though the wolfCrypt tests pass for those.
+
+From inside `wolfssl`:
+1. `./configure --with-cavium-v=../CNN55XX-SDK --enable-asynccrypt --enable-aesni --enable-intelasm --disable-aes --disable-aesgcm --disable-des3`
+2. `make`
+
+## Usage
+
+Note: Must run applications with sudo to access device.
+
+`sudo ./wolfcrypt/benchmark/benchmark`
+`sudo ./wolfcrypt/test/testwolfcrypt`

--- a/wolfcrypt/src/port/cavium/cavium_nitrox.c
+++ b/wolfcrypt/src/port/cavium/cavium_nitrox.c
@@ -1,0 +1,778 @@
+/* cavium-nitrox.c
+ *
+ * Copyright (C) 2006-2016 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL. (formerly known as CyaSSL)
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef HAVE_CAVIUM
+
+#include <wolfssl/wolfcrypt/random.h>
+#include <wolfssl/internal.h>
+#include <wolfssl/error-ssl.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#ifndef NO_RSA
+    #include <wolfssl/wolfcrypt/rsa.h>
+#endif
+#ifndef NO_AES
+    #include <wolfssl/wolfcrypt/aes.h>
+#endif
+
+#include <wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h>
+#include <netinet/in.h> /* For ntohs */
+
+static CspHandle mLastDevHandle = INVALID_DEVID;
+
+int NitroxTranslateResponseCode(int ret)
+{
+    switch (ret) {
+        case EAGAIN:
+        case ERR_REQ_PENDING:
+            ret = WC_PENDING_E;
+            break;
+        case ERR_REQ_TIMEOUT:
+            ret = WC_TIMEOUT_E;
+            break;
+        case 0:
+            /* leave as-is */
+            break;
+        default:
+            printf("NitroxTranslateResponseCode Unknown ret=%x\n", ret);
+            ret = ASYNC_INIT_E;
+    }
+    return ret;
+}
+
+
+CspHandle NitroxGetDeviceHandle(void)
+{
+    return mLastDevHandle;
+}
+    
+CspHandle NitroxOpenDevice(int dma_mode, int dev_id)
+{
+    mLastDevHandle = INVALID_DEVID;
+
+#ifdef HAVE_CAVIUM_V
+    (void)dma_mode;
+
+    if (CspInitialize(dev_id, &mLastDevHandle)) {
+        return -1;
+    }
+
+#else
+    Csp1CoreAssignment core_assign;
+    Uint32             device;
+
+    if (CspInitialize(CAVIUM_DIRECT, CAVIUM_DEV_ID)) {
+        return -1;
+    }
+    if (Csp1GetDevType(&device)) {
+        return -1;
+    }
+    if (device != NPX_DEVICE) {
+        if (ioctl(gpkpdev_hdlr[CAVIUM_DEV_ID], IOCTL_CSP1_GET_CORE_ASSIGNMENT,
+        (Uint32 *)&core_assign)!= 0) {
+            return -1;
+        }
+    }
+    CspShutdown(CAVIUM_DEV_ID);
+
+    mLastDevHandle = CspInitialize(dma_mode, dev_id);
+    if (mLastDevHandle == 0) {
+        mLastDevHandle = dev_id;
+    }
+
+#endif /* HAVE_CAVIUM_V */
+
+    return mLastDevHandle;
+}
+
+
+int NitroxAllocContext(CaviumNitroxDev* nitrox, CspHandle devId,
+    ContextType type)
+{
+    int ret;
+
+    if (nitrox == NULL) {
+        return -1;
+    }
+
+    /* If invalid handle provided, use last open one */
+    if (devId == INVALID_DEVID) {
+        devId = NitroxGetDeviceHandle();
+    }
+
+#ifdef HAVE_CAVIUM_V
+    ret = CspAllocContext(devId, type, &nitrox->contextHandle);
+#else
+    ret = CspAllocContext(type, &nitrox->contextHandle, devId);
+#endif
+    if (ret != 0) {
+        return -1;
+    }
+
+    nitrox->type = type;
+    nitrox->devId = devId;
+
+    return 0;
+}
+
+void NitroxFreeContext(CaviumNitroxDev* nitrox)
+{
+    if (nitrox == NULL) {
+        return;
+    }
+
+#ifdef HAVE_CAVIUM_V
+    CspFreeContext(nitrox->devId, nitrox->type, nitrox->contextHandle);
+#else
+    CspFreeContext(nitrox->type, nitrox->contextHandle, nitrox->devId);
+#endif
+}
+
+void NitroxCloseDevice(CspHandle devId)
+{
+    if (devId >= 0) {
+        CspShutdown(devId);
+    }
+}
+
+#if defined(WOLFSSL_ASYNC_CRYPT)
+
+int NitroxCheckRequest(CspHandle devId, CavReqId reqId)
+{
+    int ret = CspCheckForCompletion(devId, reqId);
+    return NitroxTranslateResponseCode(ret);
+}
+
+int NitroxCheckRequests(CspHandle devId, CspMultiRequestStatusBuffer* req_stat_buf)
+{
+    int ret = CspGetAllResults(req_stat_buf, devId);
+    return NitroxTranslateResponseCode(ret);   
+}
+
+
+#ifndef NO_RSA
+
+int NitroxRsaExptMod(const byte* in, word32 inLen,
+                     byte* exponent, word32 expLen,
+                     byte* modulus, word32 modLen,
+                     byte* out, word32* outLen, RsaKey* key)
+{
+    int ret;
+
+    if (key == NULL || in == NULL || inLen == 0 || exponent == NULL ||
+                                            modulus == NULL || out == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    (void)outLen;
+
+#ifdef HAVE_CAVIUM_V
+    ret = CspMe(key->asyncDev.dev.devId, CAVIUM_REQ_MODE, CAVIUM_SSL_GRP,
+            CAVIUM_DPORT, modLen, expLen, inLen,
+            modulus, exponent, (Uint8*)in, out,
+            &key->asyncDev.dev.reqId);
+    #if 0
+    /* TODO: Try MeCRT */
+    ret = CspMeCRT();
+    #endif
+#else
+    /* Not implemented/supported */
+    ret = NOT_COMPILED_IN;
+#endif
+    ret = NitroxTranslateResponseCode(ret);
+    if (ret != 0) {
+        return ret;
+    }
+
+    return ret;
+}
+
+int NitroxRsaPublicEncrypt(const byte* in, word32 inLen, byte* out,
+                           word32 outLen, RsaKey* key)
+{
+    word32 ret;
+
+    if (key == NULL || in == NULL || out == NULL || outLen < (word32)key->n.used) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef HAVE_CAVIUM_V
+    ret = CspPkcs1v15Enc(key->asyncDev.dev.devId, CAVIUM_REQ_MODE, CAVIUM_SSL_GRP, CAVIUM_DPORT,
+                         BT2, key->n.used, key->e.used,
+                         (word16)inLen, key->n.dpraw, key->e.dpraw, (byte*)in, out,
+                         &key->asyncDev.dev.reqId);
+#else
+    ret = CspPkcs1v15Enc(CAVIUM_REQ_MODE, BT2, key->n.used, key->e.used,
+                         (word16)inLen, key->n.dpraw, key->e.dpraw, (byte*)in, out,
+                         &key->asyncDev.dev.reqId, key->asyncDev.dev.devId);
+#endif
+    ret = NitroxTranslateResponseCode(ret);
+    if (ret != 0) {
+        return ret;
+    }
+
+    return key->n.used;
+}
+
+
+static INLINE void ato16(const byte* c, word16* u16)
+{
+    *u16 = (c[0] << 8) | (c[1]);
+}
+
+int NitroxRsaPrivateDecrypt(const byte* in, word32 inLen, byte* out,
+                            word32 outLen, RsaKey* key)
+{
+    word32 ret;
+    word16 outSz = (word16)outLen;
+
+    if (key == NULL || in == NULL || out == NULL ||
+                                                inLen != (word32)key->n.used) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef HAVE_CAVIUM_V
+    ret = CspPkcs1v15CrtDec(key->asyncDev.dev.devId, CAVIUM_REQ_MODE, CAVIUM_SSL_GRP, CAVIUM_DPORT,
+                            BT2, key->n.used, key->q.dpraw,
+                            key->dQ.dpraw, key->p.dpraw, key->dP.dpraw, key->u.dpraw,
+                            (byte*)in, &outSz, out, &key->asyncDev.dev.reqId);
+#else
+    ret = CspPkcs1v15CrtDec(CAVIUM_REQ_MODE, BT2, key->n.used, key->q.dpraw,
+                            key->dQ.dpraw, key->p.dpraw, key->dP.dpraw, key->u.dpraw,
+                            (byte*)in, &outSz, out, &key->asyncDev.dev.reqId,
+                            key->asyncDev.dev.devId);
+#endif
+    ret = NitroxTranslateResponseCode(ret);
+    if (ret != 0) {
+        return ret;
+    }
+
+    ato16((const byte*)&outSz, &outSz); 
+
+    return outSz;
+}
+
+
+int NitroxRsaSSL_Sign(const byte* in, word32 inLen, byte* out,
+                      word32 outLen, RsaKey* key)
+{
+    word32 ret;
+
+    if (key == NULL || in == NULL || out == NULL || inLen == 0 || outLen <
+                                                         (word32)key->n.used) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef HAVE_CAVIUM_V
+    ret = CspPkcs1v15CrtEnc(key->asyncDev.dev.devId, CAVIUM_REQ_MODE, CAVIUM_SSL_GRP, CAVIUM_DPORT,
+                            BT1, key->n.used, (word16)inLen,
+                            key->q.dpraw, key->dQ.dpraw, key->p.dpraw, key->dP.dpraw, key->u.dpraw,
+                            (byte*)in, out, &key->asyncDev.dev.reqId);
+#else
+    ret = CspPkcs1v15CrtEnc(CAVIUM_REQ_MODE, BT1, key->n.used, (word16)inLen,
+                            key->q.dpraw, key->dQ.dpraw, key->p.dpraw, key->dP.dpraw, key->u.dpraw,
+                            (byte*)in, out, &key->asyncDev.dev.reqId, key->asyncDev.dev.devId);
+#endif
+    ret = NitroxTranslateResponseCode(ret);
+    if (ret != 0) {
+        return ret;
+    }
+
+    return key->n.used;
+}
+
+
+int NitroxRsaSSL_Verify(const byte* in, word32 inLen, byte* out,
+                        word32 outLen, RsaKey* key)
+{
+    word32 ret;
+    word16 outSz = (word16)outLen;
+
+    if (key == NULL || in == NULL || out == NULL || inLen != (word32)key->n.used) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef HAVE_CAVIUM_V
+    ret = CspPkcs1v15Dec(key->asyncDev.dev.devId, CAVIUM_REQ_MODE, CAVIUM_SSL_GRP, CAVIUM_DPORT,
+                         BT1, key->n.used, key->e.used,
+                         key->n.dpraw, key->e.dpraw, (byte*)in, &outSz, out,
+                         &key->asyncDev.dev.reqId);
+#else
+    ret = CspPkcs1v15Dec(CAVIUM_REQ_MODE, BT1, key->n.used, key->e.used,
+                         key->n.dpraw, key->e.dpraw, (byte*)in, &outSz, out,
+                         &key->asyncDev.dev.reqId, key->asyncDev.dev.devId);
+#endif
+    ret = NitroxTranslateResponseCode(ret);
+    if (ret != 0) {
+        return ret;
+    }
+
+    outSz = ntohs(outSz);
+
+    return outSz;
+}
+#endif /* !NO_RSA */
+
+
+#ifndef NO_AES
+int NitroxAesSetKey(Aes* aes, const byte* key, word32 length, const byte* iv)
+{
+    if (aes == NULL)
+        return BAD_FUNC_ARG;
+
+    XMEMCPY(aes->key, key, length);   /* key still holds key, iv still in reg */
+    if (length == 16)
+        aes->type = AES_128_BIT;
+    else if (length == 24)
+        aes->type = AES_192_BIT;
+    else if (length == 32)
+        aes->type = AES_256_BIT;
+
+    return wc_AesSetIV(aes, iv);
+}
+
+#ifdef HAVE_AES_CBC
+int NitroxAesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 length)
+{
+    int ret;
+    wolfssl_word offset = 0;
+
+    while (length > WOLFSSL_MAX_16BIT) {
+        word16 slen = (word16)WOLFSSL_MAX_16BIT;
+    #ifdef HAVE_CAVIUM_V
+        ret = CspEncryptAes(aes->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT, 
+                          CAVIUM_SSL_GRP, CAVIUM_DPORT, aes->asyncDev.dev.contextHandle,
+                          FROM_DPTR, FROM_CTX, AES_CBC, aes->type, (byte*)aes->key,
+                          (byte*)aes->reg, 0, NULL, slen, (byte*)in + offset,
+                          out + offset, &aes->asyncDev.dev.reqId);
+    #else
+        ret = CspEncryptAes(CAVIUM_BLOCKING, aes->asyncDev.dev.contextHandle, CAVIUM_NO_UPDATE,
+                          aes->type, slen, (byte*)in + offset, out + offset,
+                          (byte*)aes->reg, (byte*)aes->key, &aes->asyncDev.dev.reqId,
+                          aes->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        length -= WOLFSSL_MAX_16BIT;
+        offset += WOLFSSL_MAX_16BIT;
+        XMEMCPY(aes->reg, out + offset - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+    }
+    if (length) {
+        word16 slen = (word16)length;
+    #ifdef HAVE_CAVIUM_V
+        ret = CspEncryptAes(aes->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT, 
+                          CAVIUM_SSL_GRP, CAVIUM_DPORT, aes->asyncDev.dev.contextHandle,
+                          FROM_DPTR, FROM_CTX, AES_CBC, aes->type, (byte*)aes->key,
+                          (byte*)aes->reg,  0, NULL, slen, (byte*)in + offset,
+                          out + offset, &aes->asyncDev.dev.reqId);
+    #else
+        ret = CspEncryptAes(CAVIUM_BLOCKING, aes->asyncDev.dev.contextHandle, CAVIUM_NO_UPDATE,
+                          aes->type, slen, (byte*)in + offset, out + offset,
+                          (byte*)aes->reg, (byte*)aes->key, &aes->asyncDev.dev.reqId,
+                          aes->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        XMEMCPY(aes->reg, out + offset+length - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+    }
+    return 0;
+}
+
+#ifdef HAVE_AES_DECRYPT
+int NitroxAesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 length)
+{
+    wolfssl_word offset = 0;
+    int ret;
+
+    while (length > WOLFSSL_MAX_16BIT) {
+        word16 slen = (word16)WOLFSSL_MAX_16BIT;
+        XMEMCPY(aes->tmp, in + offset + slen - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+    #ifdef HAVE_CAVIUM_V
+        ret = CspDecryptAes(aes->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT, 
+                          CAVIUM_SSL_GRP, CAVIUM_DPORT, aes->asyncDev.dev.contextHandle,
+                          FROM_DPTR, FROM_CTX, AES_CBC, aes->type, (byte*)aes->key, (byte*)aes->reg,
+                          0, NULL, slen, (byte*)in + offset, out + offset, &aes->asyncDev.dev.reqId);
+    #else
+        ret = CspDecryptAes(CAVIUM_BLOCKING, aes->asyncDev.dev.contextHandle, CAVIUM_NO_UPDATE,
+                          aes->type, slen, (byte*)in + offset, out + offset,
+                          (byte*)aes->reg, (byte*)aes->key, &aes->asyncDev.dev.reqId,
+                          aes->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        length -= WOLFSSL_MAX_16BIT;
+        offset += WOLFSSL_MAX_16BIT;
+        XMEMCPY(aes->reg, aes->tmp, AES_BLOCK_SIZE);
+    }
+    if (length) {
+        word16 slen = (word16)length;
+        XMEMCPY(aes->tmp, in + offset + slen - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+    #ifdef HAVE_CAVIUM_V
+        ret = CspDecryptAes(aes->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT, 
+                          CAVIUM_SSL_GRP, CAVIUM_DPORT, aes->asyncDev.dev.contextHandle,
+                          FROM_DPTR, FROM_CTX, AES_CBC, aes->type, (byte*)aes->key, (byte*)aes->reg,
+                          0, NULL, slen, (byte*)in + offset, out + offset, &aes->asyncDev.dev.reqId);
+    #else
+        ret = CspDecryptAes(CAVIUM_BLOCKING, aes->asyncDev.dev.contextHandle, CAVIUM_NO_UPDATE,
+                          aes->type, slen, (byte*)in + offset, out + offset,
+                          (byte*)aes->reg, (byte*)aes->key, &aes->asyncDev.dev.reqId,
+                          aes->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        XMEMCPY(aes->reg, aes->tmp, AES_BLOCK_SIZE);
+    }
+    return 0;
+}
+#endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_CBC */
+#endif /* !NO_AES */
+
+
+#if !defined(NO_ARC4) && !defined(HAVE_CAVIUM_V)
+void NitroxArc4SetKey(Arc4* arc4, const byte* key, word32 length)
+{
+    if (CspInitializeRc4(CAVIUM_BLOCKING, arc4->asyncDev.dev.contextHandle, length,
+                         (byte*)key, &arc4->asyncDev.dev.reqId, arc4->devId) != 0) {
+        WOLFSSL_MSG("Bad Cavium Arc4 Init");
+    }
+}
+
+void NitroxArc4Process(Arc4* arc4, byte* out, const byte* in, word32 length)
+{
+    int ret;
+    wolfssl_word offset = 0;
+
+    while (length > WOLFSSL_MAX_16BIT) {
+        word16 slen = (word16)WOLFSSL_MAX_16BIT;
+        ret = CspEncryptRc4(CAVIUM_BLOCKING, arc4->asyncDev.dev.contextHandle,
+            CAVIUM_UPDATE, slen, (byte*)in + offset, out + offset,
+            &arc4->asyncDev.dev.reqId, arc4->devId);
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        length -= WOLFSSL_MAX_16BIT;
+        offset += WOLFSSL_MAX_16BIT;
+    }
+    if (length) {
+        word16 slen = (word16)length;
+        ret = CspEncryptRc4(CAVIUM_BLOCKING, arc4->asyncDev.dev.contextHandle,
+            CAVIUM_UPDATE, slen, (byte*)in + offset, out + offset,
+            &arc4->asyncDev.dev.reqId, arc4->devId);
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+    }
+}
+#endif /* !NO_ARC4 && !HAVE_CAVIUM_V */
+
+
+#ifndef NO_DES3
+int NitroxDes3SetKey(Des3* des3, const byte* key, const byte* iv)
+{
+    if (des3 == NULL)
+        return BAD_FUNC_ARG;
+
+    /* key[0] holds key, iv in reg */
+    XMEMCPY(des3->key[0], key, DES_BLOCK_SIZE*3);
+
+    return wc_Des3_SetIV(des3, iv);
+}
+
+int NitroxDes3CbcEncrypt(Des3* des3, byte* out, const byte* in, word32 length)
+{
+    wolfssl_word offset = 0;
+    int ret;
+
+    while (length > WOLFSSL_MAX_16BIT) {
+        word16 slen = (word16)WOLFSSL_MAX_16BIT;
+    #ifdef HAVE_CAVIUM_V
+        ret = CspEncrypt3Des(des3->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT,
+                            CAVIUM_SSL_GRP, CAVIUM_DPORT, des3->asyncDev.dev.contextHandle,
+                            FROM_DPTR, FROM_CTX, DES3_CBC, (byte*)des3->key[0],
+                            (byte*)des3->reg, slen, (byte*)in + offset,
+                            out + offset, &des3->asyncDev.dev.reqId);
+    #else
+        ret = CspEncrypt3Des(CAVIUM_BLOCKING, des3->asyncDev.dev.contextHandle,
+                            CAVIUM_NO_UPDATE, slen, (byte*)in + offset,
+                            out + offset, (byte*)des3->reg, (byte*)des3->key[0],
+                            &des3->asyncDev.dev.reqId, des3->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        length -= WOLFSSL_MAX_16BIT;
+        offset += WOLFSSL_MAX_16BIT;
+        XMEMCPY(des3->reg, out + offset - DES_BLOCK_SIZE, DES_BLOCK_SIZE);
+    }
+    if (length) {
+        word16 slen = (word16)length;
+    #ifdef HAVE_CAVIUM_V
+        ret = CspEncrypt3Des(des3->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT,
+                            CAVIUM_SSL_GRP, CAVIUM_DPORT, des3->asyncDev.dev.contextHandle,
+                            FROM_DPTR, FROM_CTX, DES3_CBC, (byte*)des3->key[0], (byte*)des3->reg,
+                            slen, (byte*)in + offset, out + offset,
+                            &des3->asyncDev.dev.reqId);
+    #else
+        ret = CspEncrypt3Des(CAVIUM_BLOCKING, des3->asyncDev.dev.contextHandle,
+                            CAVIUM_NO_UPDATE, slen, (byte*)in + offset,
+                            out + offset, (byte*)des3->reg, (byte*)des3->key[0],
+                            &des3->asyncDev.dev.reqId, des3->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        XMEMCPY(des3->reg, out+offset+length - DES_BLOCK_SIZE, DES_BLOCK_SIZE);
+    }
+    return 0;
+}
+
+int NitroxDes3CbcDecrypt(Des3* des3, byte* out, const byte* in, word32 length)
+{
+    wolfssl_word offset = 0;
+    int ret;
+
+    while (length > WOLFSSL_MAX_16BIT) {
+        word16 slen = (word16)WOLFSSL_MAX_16BIT;
+        XMEMCPY(des3->tmp, in + offset + slen - DES_BLOCK_SIZE, DES_BLOCK_SIZE);
+    #ifdef HAVE_CAVIUM_V
+        ret = CspDecrypt3Des(des3->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT,
+                            CAVIUM_SSL_GRP, CAVIUM_DPORT, des3->asyncDev.dev.contextHandle,
+                            FROM_DPTR, FROM_CTX, DES3_CBC, (byte*)des3->key[0], (byte*)des3->reg,
+                            slen, (byte*)in + offset, out + offset,
+                            &des3->asyncDev.dev.reqId);
+    #else
+        ret = CspDecrypt3Des(CAVIUM_BLOCKING, des3->asyncDev.dev.contextHandle,
+                           CAVIUM_NO_UPDATE, slen, (byte*)in + offset, out + offset,
+                           (byte*)des3->reg, (byte*)des3->key[0], &des3->asyncDev.dev.reqId,
+                           des3->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        length -= WOLFSSL_MAX_16BIT;
+        offset += WOLFSSL_MAX_16BIT;
+        XMEMCPY(des3->reg, des3->tmp, DES_BLOCK_SIZE);
+    }
+    if (length) {
+        word16 slen = (word16)length;
+        XMEMCPY(des3->tmp, in + offset + slen - DES_BLOCK_SIZE,DES_BLOCK_SIZE);
+    #ifdef HAVE_CAVIUM_V
+        ret = CspDecrypt3Des(des3->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT,
+                            CAVIUM_SSL_GRP, CAVIUM_DPORT, des3->asyncDev.dev.contextHandle,
+                            FROM_DPTR, FROM_CTX, DES3_CBC, (byte*)des3->key[0], (byte*)des3->reg,
+                            slen, (byte*)in + offset, out + offset,
+                            &des3->asyncDev.dev.reqId);
+    #else
+        ret = CspDecrypt3Des(CAVIUM_BLOCKING, des3->asyncDev.dev.contextHandle,
+                           CAVIUM_NO_UPDATE, slen, (byte*)in + offset, out + offset,
+                           (byte*)des3->reg, (byte*)des3->key[0], &des3->asyncDev.dev.reqId,
+                           des3->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        XMEMCPY(des3->reg, des3->tmp, DES_BLOCK_SIZE);
+    }
+    return 0;
+}
+#endif /* !NO_DES3 */
+
+
+#ifndef NO_HMAC
+int NitroxHmacFinal(Hmac* hmac, byte* hash)
+{
+    int ret = -1;
+
+#ifdef HAVE_CAVIUM_V
+    word16 hashLen = wc_HmacSizeByType(hmac->macType);
+    ret = CspHmac(hmac->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT,
+                  CAVIUM_SSL_GRP, CAVIUM_DPORT, hmac->type, hmac->keyLen,
+                  (byte*)hmac->ipad, hmac->dataLen, hmac->data, hashLen,
+                  hash, &hmac->asyncDev.dev.reqId);
+#else
+    ret = CspHmac(CAVIUM_BLOCKING, hmac->type, NULL, hmac->keyLen,
+                  (byte*)hmac->ipad, hmac->dataLen, hmac->data, hash,
+                  &hmac->asyncDev.dev.reqId, hmac->asyncDev.dev.devId);
+#endif
+    ret = NitroxTranslateResponseCode(ret);
+    if (ret != 0) {
+        return ret;
+    }
+
+    hmac->innerHashKeyed = 0;  /* tell update to start over if used again */
+
+    return 0;
+}
+
+int NitroxHmacUpdate(Hmac* hmac, const byte* msg, word32 length)
+{
+    word16 add = (word16)length;
+    word32 total;
+    byte*  tmp;
+
+    if (length > WOLFSSL_MAX_16BIT) {
+        WOLFSSL_MSG("Too big msg for cavium hmac");
+        return -1;
+    }
+
+    if (hmac->innerHashKeyed == 0) {  /* starting new */
+        hmac->dataLen        = 0;
+        hmac->innerHashKeyed = 1;
+    }
+
+    total = add + hmac->dataLen;
+    if (total > WOLFSSL_MAX_16BIT) {
+        WOLFSSL_MSG("Too big msg for cavium hmac");
+        return -1;
+    }
+
+    tmp = XMALLOC(hmac->dataLen + add, NULL, DYNAMIC_TYPE_ASYNC_TMP);
+    if (tmp == NULL) {
+        WOLFSSL_MSG("Out of memory for cavium update");
+        return -1;
+    }
+    if (hmac->dataLen)
+        XMEMCPY(tmp, hmac->data,  hmac->dataLen);
+    XMEMCPY(tmp + hmac->dataLen, msg, add);
+
+    hmac->dataLen += add;
+    XFREE(hmac->data, NULL, DYNAMIC_TYPE_ASYNC_TMP);
+    hmac->data = tmp;
+
+    return 0;
+}
+
+int NitroxHmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
+{
+    hmac->macType = (byte)type;
+    
+    /* Determine Cavium HashType */
+    switch(type) {
+    #ifndef NO_MD5
+        case MD5:
+            hmac->type = MD5_TYPE;
+            break;
+    #endif
+    #ifndef NO_SHA
+        case SHA:
+            hmac->type = SHA1_TYPE;
+            break;
+    #endif
+    #ifndef NO_SHA256
+        case SHA256:
+        #ifdef HAVE_CAVIUM_V
+            hmac->type = SHA2_SHA256;
+        #else
+            hmac->type = SHA256_TYPE;
+        #endif
+            break;
+    #endif
+    #ifdef HAVE_CAVIUM_V
+        #ifndef WOLFSSL_SHA512
+            case SHA512:
+                hmac->type = SHA2_SHA512;
+                break;
+        #endif
+        #ifndef WOLFSSL_SHA384
+            case SHA384:
+                hmac->type = SHA2_SHA384;
+                break;
+        #endif
+    #endif /* HAVE_CAVIUM_V */
+        default:
+            WOLFSSL_MSG("unsupported cavium hmac type");
+            break;
+    }
+
+    hmac->innerHashKeyed = 0;  /* should we key Startup flag */
+
+    hmac->keyLen = (word16)length;
+    /* store key in ipad */
+    XMEMCPY(hmac->ipad, key, length);
+
+    return 0;
+}
+#endif /* !NO_HMAC */
+
+
+#if !defined(HAVE_HASHDRBG) && !defined(NO_RC4)
+void NitroxRngGenerateBlock(WC_RNG* rng, byte* output, word32 sz)
+{
+    wolfssl_word offset = 0;
+    word32      requestId;
+
+    while (sz > WOLFSSL_MAX_16BIT) {
+        word16 slen = (word16)WOLFSSL_MAX_16BIT;
+    #ifdef HAVE_CAVIUM_V
+        ret = CspTrueRandom(rng->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT, 
+                            CAVIUM_SSL_GRP, CAVIUM_DPORT, slen, output + offset, &requestId);
+    #else
+        ret = CspRandom(CAVIUM_BLOCKING, slen, output + offset, &requestId,
+                        rng->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+        sz     -= WOLFSSL_MAX_16BIT;
+        offset += WOLFSSL_MAX_16BIT;
+    }
+    if (sz) {
+        word16 slen = (word16)sz;
+    #ifdef HAVE_CAVIUM_V
+        ret = CspTrueRandom(rng->asyncDev.dev.devId, CAVIUM_BLOCKING, DMA_DIRECT_DIRECT, 
+                            CAVIUM_SSL_GRP, CAVIUM_DPORT, slen, output + offset, &requestId);
+    #else
+        ret = CspRandom(CAVIUM_BLOCKING, slen, output + offset, &requestId,
+                        rng->asyncDev.dev.devId);
+    #endif
+        ret = NitroxTranslateResponseCode(ret);
+        if (ret != 0) {
+            return ret;
+        }
+    }
+}
+#endif /* !defined(HAVE_HASHDRBG) && !defined(NO_RC4) */
+
+
+#endif /* WOLFSSL_ASYNC_CRYPT */
+
+#endif /* HAVE_CAVIUM */

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -810,7 +810,7 @@ int wc_InitRng(WC_RNG* rng)
 
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM)
     ret = wolfAsync_DevCtxInit(&rng->asyncDev, WOLFSSL_ASYNC_MARKER_RNG, INVALID_DEVID);
-    if (ret != 0) return -2007;
+    if (ret != 0) return ret;
 #endif
 
 #ifdef WOLFSSL_SMALL_STACK

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -193,6 +193,13 @@ int wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId)
     else
 #endif
     {
+    /* For normal math defer the memory allocations */
+    #ifndef USE_FAST_MATH
+        key->n.dp = key->e.dp = 0;  /* public  alloc parts */
+        key->d.dp = key->p.dp  = 0; /* private alloc parts */
+        key->q.dp = key->dP.dp = 0;
+        key->u.dp = key->dQ.dp = 0;
+    #else
         mp_init(&key->n);
         mp_init(&key->e);
         mp_init(&key->d);
@@ -201,6 +208,7 @@ int wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId)
         mp_init(&key->dP);
         mp_init(&key->dQ);
         mp_init(&key->u);
+    #endif /* USE_FAST_MATH */
     }
 
     return ret;

--- a/wolfcrypt/src/wolfevent.c
+++ b/wolfcrypt/src/wolfevent.c
@@ -1,0 +1,274 @@
+/* wolfevent.c
+ *
+ * Copyright (C) 2006-2016 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+
+#ifdef HAVE_WOLF_EVENT
+
+#include <wolfssl/internal.h>
+#include <wolfssl/error-ssl.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#include <wolfssl/wolfcrypt/wolfevent.h>
+
+
+int wolfEvent_Init(WOLF_EVENT* event, WOLF_EVENT_TYPE type, void* context)
+{
+    if (event == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (event->pending) {
+        WOLFSSL_MSG("event already pending!");
+        return BAD_COND_E;
+    }
+
+    XMEMSET(event, 0, sizeof(WOLF_EVENT));
+    event->type = type;
+    event->context = context;
+
+    return 0;
+}
+
+int wolfEvent_Poll(WOLF_EVENT* event, WOLF_EVENT_FLAG flags)
+{
+    int ret = BAD_COND_E;
+
+    /* Check hardware */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if (event->type >= WOLF_EVENT_TYPE_ASYNC_FIRST &&
+        event->type <= WOLF_EVENT_TYPE_ASYNC_LAST)
+    {
+        ret = wolfAsync_EventPoll(event, flags);
+    }
+#endif /* WOLFSSL_ASYNC_CRYPT */
+
+    return ret;
+}
+
+int wolfEventQueue_Init(WOLF_EVENT_QUEUE* queue)
+{
+    int ret = 0;
+
+    if (queue == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    XMEMSET(queue, 0, sizeof(WOLF_EVENT_QUEUE));
+#ifndef SINGLE_THREADED
+    ret = InitMutex(&queue->lock);
+#endif
+    return ret;
+}
+
+
+int wolfEventQueue_Push(WOLF_EVENT_QUEUE* queue, WOLF_EVENT* event)
+{
+    int ret;
+
+    if (queue == NULL || event == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifndef SINGLE_THREADED
+    if ((ret = LockMutex(&queue->lock)) != 0) {
+        return ret;
+    }
+#endif
+
+    /* Setup event */
+    event->next = NULL;
+    event->pending = 1;
+
+    if (queue->tail == NULL)  {
+        queue->head = event;
+    }
+    else {
+        queue->tail->next = event;
+        event->prev = queue->tail;
+    }
+    queue->tail = event;      /* add to the end either way */
+    queue->count++;
+    ret = 0;
+
+#ifndef SINGLE_THREADED
+    UnLockMutex(&queue->lock);
+#endif
+
+    return ret;
+}
+
+int wolfEventQueue_Pop(WOLF_EVENT_QUEUE* queue, WOLF_EVENT** event)
+{
+    int ret = 0;
+
+    if (queue == NULL || event == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifndef SINGLE_THREADED
+    /* In single threaded mode "event_queue.lock" doesn't exist */
+    if ((ret = LockMutex(&queue->lock)) != 0) {
+        return ret;
+    }
+#endif
+
+    /* Pop first item off queue */
+    *event = queue->head;
+    ret = wolfEventQueue_Remove(queue, *event);
+
+#ifndef SINGLE_THREADED
+    UnLockMutex(&queue->lock);
+#endif
+
+    return ret;
+}
+
+/* assumes queue is locked by caller */
+int wolfEventQueue_Remove(WOLF_EVENT_QUEUE* queue, WOLF_EVENT* event)
+{
+    int ret = 0;
+
+    if (queue == NULL || event == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (event == queue->head && event == queue->tail) {
+        queue->head = NULL;
+        queue->tail = NULL;
+    }
+    else if (event == queue->head) {
+        queue->head = event->next;
+        queue->head->prev = NULL;
+    }
+    else if (event == queue->tail) {
+        queue->tail = event->prev;
+        queue->tail->next = NULL;
+    }
+    else {
+        WOLF_EVENT* next = event->next;
+        WOLF_EVENT* prev = event->prev;
+        next->prev = prev;
+        prev->next = next;
+    }
+    queue->count--;
+
+    return ret;
+}
+
+int wolfEventQueue_Poll(WOLF_EVENT_QUEUE* queue, void* context_filter,
+    WOLF_EVENT** events, int maxEvents, WOLF_EVENT_FLAG flags, int* eventCount)
+{
+    WOLF_EVENT* event;
+    int ret = 0, count = 0;
+
+    if (queue == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifndef SINGLE_THREADED
+    /* In single threaded mode "event_queue.lock" doesn't exist */
+    if ((ret = LockMutex(&queue->lock)) != 0) {
+        return ret;
+    }
+#endif
+
+    /* itterate event queue */
+    for (event = queue->head; event != NULL; event = event->next)
+    {
+        /* optional filter based on context */
+        if (context_filter == NULL || event->context == context_filter) {
+
+            /* poll event */
+            ret = wolfEvent_Poll(event, flags);
+            if (ret < 0) break; /* exit for */
+
+            /* If event is done then process */
+            if (event->done) {
+                /* remove from queue */
+                ret = wolfEventQueue_Remove(queue, event);
+                if (ret < 0) break; /* exit for */
+
+                /* return pointer in 'events' arg */
+                if (events) {
+                    events[count] = event; /* return pointer */
+                }
+                count++;
+
+                /* check to make sure our event list isn't full */
+                if (events && count >= maxEvents) {
+                    break; /* exit for */
+                }
+            }
+        }
+    }
+
+#ifndef SINGLE_THREADED
+    UnLockMutex(&queue->lock);
+#endif
+
+    /* return number of properly populated events */
+    if (eventCount) {
+        *eventCount = count;
+    }
+
+    return ret;
+}
+
+int wolfEventQueue_Count(WOLF_EVENT_QUEUE* queue)
+{
+    int ret;
+
+    if (queue == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifndef SINGLE_THREADED
+    /* In single threaded mode "event_queue.lock" doesn't exist */
+    if ((ret = LockMutex(&queue->lock)) != 0) {
+        return ret;
+    }
+#endif
+
+    ret = queue->count;
+
+#ifndef SINGLE_THREADED
+    UnLockMutex(&queue->lock);
+#endif
+
+    return ret;
+}
+
+void wolfEventQueue_Free(WOLF_EVENT_QUEUE* queue)
+{
+    if (queue) {
+    #ifndef SINGLE_THREADED
+        FreeMutex(&queue->lock);
+    #endif
+    }
+}
+
+#endif /* HAVE_WOLF_EVENT */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -107,6 +107,9 @@
 #ifdef HAVE_FIPS
     #include <wolfssl/wolfcrypt/fips_test.h>
 #endif
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
 
 #ifdef _MSC_VER
     /* 4996 warning to use MS extensions e.g., strcpy_s instead of strncpy */
@@ -132,11 +135,6 @@
 
 #ifdef HAVE_NTRU
     #include "libntruencrypt/ntru_crypto.h"
-#endif
-#ifdef HAVE_CAVIUM
-    #include "cavium_sysdep.h"
-    #include "cavium_common.h"
-    #include "cavium_ioctl.h"
 #endif
 
 #if defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
@@ -164,6 +162,9 @@
 #ifdef USE_WOLFSSL_MEMORY
     #include "wolfssl/wolfcrypt/mem_track.h"
 #endif
+
+/* for async devices */
+static int devId = INVALID_DEVID;
 
 #ifdef HAVE_WNR
     const char* wnrConfigFile = "wnr-example.conf";
@@ -251,6 +252,10 @@ int idea_test(void);
 int memory_test(void);
 #endif
 
+#if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND) && !defined(OPENSSL_EXTRA)
+    int  wolfSSL_Debugging_ON(void);
+#endif
+
 /* General big buffer size for many tests. */
 #define FOURK_BUF 4096
 
@@ -295,8 +300,16 @@ int wolfcrypt_test(void* args)
 
     ((func_args*)args)->return_code = -1; /* error state */
 
+#if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND)
+    wolfSSL_Debugging_ON();
+#endif
+
 #if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)
     InitMemoryTracker();
+#endif
+
+#if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND)
+    wolfSSL_Debugging_ON();
 #endif
 
     wolfCrypt_Init();
@@ -315,6 +328,16 @@ int wolfcrypt_test(void* args)
                        -1235);
 #endif /* USE_FAST_MATH */
 #endif /* !NO_BIG_INT */
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    ret = wolfAsync_DevOpen(&devId);
+    if (ret != 0) {
+        err_sys("Async device open failed", -1236);
+        return -1236;
+    }
+#else
+    (void)devId;
+#endif /* WOLFSSL_ASYNC_CRYPT */
 
 #ifndef NO_MD5
     if ( (ret = md5_test()) != 0)
@@ -661,44 +684,11 @@ int wolfcrypt_test(void* args)
 
 #ifndef NO_MAIN_DRIVER
 
-#ifdef HAVE_CAVIUM
-
-static int OpenNitroxDevice(int dma_mode,int dev_id)
-{
-   Csp1CoreAssignment core_assign;
-   Uint32             device;
-
-   if (CspInitialize(CAVIUM_DIRECT,CAVIUM_DEV_ID))
-      return -1;
-   if (Csp1GetDevType(&device))
-      return -1;
-   if (device != NPX_DEVICE) {
-      if (ioctl(gpkpdev_hdlr[CAVIUM_DEV_ID], IOCTL_CSP1_GET_CORE_ASSIGNMENT,
-                (Uint32 *)&core_assign)!= 0)
-         return -1;
-   }
-   CspShutdown(CAVIUM_DEV_ID);
-
-   return CspInitialize(dma_mode, dev_id);
-}
-
-#endif /* HAVE_CAVIUM */
-
     /* so overall tests can pull in test function */
 
     int main(int argc, char** argv)
     {
-
         func_args args;
-
-
-#ifdef HAVE_CAVIUM
-        int ret = OpenNitroxDevice(CAVIUM_DIRECT, CAVIUM_DEV_ID);
-        if (ret != 0) {
-            err_sys("Cavium OpenNitroxDevice failed", -1236);
-            return -1236;
-        }
-#endif /* HAVE_CAVIUM */
 
 #ifdef HAVE_WNR
         if (wc_InitNetRandom(wnrConfigFile, NULL, 5000) != 0) {
@@ -711,10 +701,6 @@ static int OpenNitroxDevice(int dma_mode,int dev_id)
         args.argv = argv;
 
         wolfcrypt_test(&args);
-
-#ifdef HAVE_CAVIUM
-        CspShutdown(CAVIUM_DEV_ID);
-#endif
 
 #ifdef HAVE_WNR
         if (wc_FreeNetRandom() < 0)
@@ -1337,14 +1323,18 @@ int hmac_md5_test(void)
     test_hmac[2] = c;
 
     for (i = 0; i < times; ++i) {
-#if defined(HAVE_FIPS) || defined(HAVE_CAVIUM)
-        if (i == 1)
+    #if defined(HAVE_FIPS) || defined(HAVE_CAVIUM)
+        if (i == 1) {
             continue; /* cavium can't handle short keys, fips not allowed */
-#endif
-#ifdef HAVE_CAVIUM
-        if (wc_HmacInitCavium(&hmac, CAVIUM_DEV_ID) != 0)
+        }
+    #endif
+
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        if (wc_HmacAsyncInit(&hmac, devId) != 0) {
             return -20009;
-#endif
+        }
+    #endif
+
         ret = wc_HmacSetKey(&hmac, MD5, (byte*)keys[i], (word32)XSTRLEN(keys[i]));
         if (ret != 0)
             return -4015;
@@ -1358,9 +1348,10 @@ int hmac_md5_test(void)
 
         if (XMEMCMP(hash, test_hmac[i].output, MD5_DIGEST_SIZE) != 0)
             return -20 - i;
-#ifdef HAVE_CAVIUM
-        wc_HmacFreeCavium(&hmac);
-#endif
+
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        wc_HmacAsyncFree(&hmac);
+    #endif
     }
 
     return 0;
@@ -1418,8 +1409,8 @@ int hmac_sha_test(void)
         if (i == 1)
             continue; /* cavium can't handle short keys, fips not allowed */
 #endif
-#ifdef HAVE_CAVIUM
-        if (wc_HmacInitCavium(&hmac, CAVIUM_DEV_ID) != 0)
+#ifdef WOLFSSL_ASYNC_CRYPT
+        if (wc_HmacAsyncInit(&hmac, devId) != 0)
             return -20010;
 #endif
         ret = wc_HmacSetKey(&hmac, SHA, (byte*)keys[i], (word32)XSTRLEN(keys[i]));
@@ -1435,8 +1426,8 @@ int hmac_sha_test(void)
 
         if (XMEMCMP(hash, test_hmac[i].output, SHA_DIGEST_SIZE) != 0)
             return -20 - i;
-#ifdef HAVE_CAVIUM
-        wc_HmacFreeCavium(&hmac);
+#ifdef WOLFSSL_ASYNC_CRYPT
+        wc_HmacAsyncFree(&hmac);
 #endif
     }
 
@@ -1499,8 +1490,8 @@ int hmac_sha256_test(void)
         if (i == 1)
             continue; /* cavium can't handle short keys, fips not allowed */
 #endif
-#ifdef HAVE_CAVIUM
-        if (wc_HmacInitCavium(&hmac, CAVIUM_DEV_ID) != 0)
+#ifdef WOLFSSL_ASYNC_CRYPT
+        if (wc_HmacAsyncInit(&hmac, devId) != 0)
             return -20011;
 #endif
         ret = wc_HmacSetKey(&hmac, SHA256, (byte*)keys[i],(word32)XSTRLEN(keys[i]));
@@ -1516,8 +1507,8 @@ int hmac_sha256_test(void)
 
         if (XMEMCMP(hash, test_hmac[i].output, SHA256_DIGEST_SIZE) != 0)
             return -20 - i;
-#ifdef HAVE_CAVIUM
-        wc_HmacFreeCavium(&hmac);
+#ifdef WOLFSSL_ASYNC_CRYPT
+        wc_HmacAsyncFree(&hmac);
 #endif
     }
 
@@ -1580,8 +1571,12 @@ int hmac_blake2b_test(void)
         if (i == 1)
             continue; /* cavium can't handle short keys, fips not allowed */
 #endif
-#ifdef HAVE_CAVIUM
-        if (wc_HmacInitCavium(&hmac, CAVIUM_DEV_ID) != 0)
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #ifdef HAVE_CAVIUM_V
+        /* Blake2 not supported on Cavium V, but SHA3 is */
+        return 0;
+    #endif
+        if (wc_HmacAsyncInit(&hmac, devId) != 0)
             return -20011;
 #endif
         ret = wc_HmacSetKey(&hmac, BLAKE2B_ID, (byte*)keys[i],
@@ -1598,8 +1593,8 @@ int hmac_blake2b_test(void)
 
         if (XMEMCMP(hash, test_hmac[i].output, BLAKE2B_256) != 0)
             return -20 - i;
-#ifdef HAVE_CAVIUM
-        wc_HmacFreeCavium(&hmac);
+#ifdef WOLFSSL_ASYNC_CRYPT
+        wc_HmacAsyncFree(&hmac);
 #endif
     }
 
@@ -1816,12 +1811,12 @@ int arc4_test(void)
         if (i == 3)
             keylen = 4;
 
-#ifdef HAVE_CAVIUM
-        if (wc_Arc4InitCavium(&enc, CAVIUM_DEV_ID) != 0)
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        if (wc_Arc4AsyncInit(&enc, devId) != 0)
             return -20001;
-        if (wc_Arc4InitCavium(&dec, CAVIUM_DEV_ID) != 0)
+        if (wc_Arc4AsyncInit(&dec, devId) != 0)
             return -20002;
-#endif
+    #endif
 
         wc_Arc4SetKey(&enc, (byte*)keys[i], keylen);
         wc_Arc4SetKey(&dec, (byte*)keys[i], keylen);
@@ -1836,10 +1831,10 @@ int arc4_test(void)
         if (XMEMCMP(cipher, test_arc4[i].output, test_arc4[i].outLen))
             return -20 - 5 - i;
 
-#ifdef HAVE_CAVIUM
-        wc_Arc4FreeCavium(&enc);
-        wc_Arc4FreeCavium(&dec);
-#endif
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        wc_Arc4AsyncFree(&enc);
+        wc_Arc4AsyncFree(&dec);
+    #endif
     }
 
     return 0;
@@ -2596,17 +2591,23 @@ int des_test(void)
     if (ret != 0)
         return -31;
 
-    wc_Des_CbcEncrypt(&enc, cipher, vector, sizeof(vector));
-    ret = wc_Des_SetKey(&dec, key, iv, DES_DECRYPTION);
+    ret = wc_Des_CbcEncrypt(&enc, cipher, vector, sizeof(vector));
     if (ret != 0)
         return -32;
-    wc_Des_CbcDecrypt(&dec, plain, cipher, sizeof(cipher));
 
-    if (XMEMCMP(plain, vector, sizeof(plain)))
+    ret = wc_Des_SetKey(&dec, key, iv, DES_DECRYPTION);
+    if (ret != 0)
         return -33;
 
-    if (XMEMCMP(cipher, verify, sizeof(cipher)))
+    ret = wc_Des_CbcDecrypt(&dec, plain, cipher, sizeof(cipher));
+    if (ret != 0)
         return -34;
+
+    if (XMEMCMP(plain, vector, sizeof(plain)))
+        return -35;
+
+    if (XMEMCMP(cipher, verify, sizeof(cipher)))
+        return -36;
 
     return 0;
 }
@@ -2652,10 +2653,10 @@ int des3_test(void)
     int ret;
 
 
-#ifdef HAVE_CAVIUM
-    if (wc_Des3_InitCavium(&enc, CAVIUM_DEV_ID) != 0)
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if (wc_Des3AsyncInit(&enc, devId) != 0)
         return -20005;
-    if (wc_Des3_InitCavium(&dec, CAVIUM_DEV_ID) != 0)
+    if (wc_Des3AsyncInit(&dec, devId) != 0)
         return -20006;
 #endif
     ret = wc_Des3_SetKey(&enc, key3, iv3, DES_ENCRYPTION);
@@ -2677,9 +2678,9 @@ int des3_test(void)
     if (XMEMCMP(cipher, verify3, sizeof(cipher)))
         return -36;
 
-#ifdef HAVE_CAVIUM
-    wc_Des3_FreeCavium(&enc);
-    wc_Des3_FreeCavium(&dec);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    wc_Des3AsyncFree(&enc);
+    wc_Des3AsyncFree(&dec);
 #endif
     return 0;
 }
@@ -2714,11 +2715,11 @@ int aes_test(void)
     byte key[] = "0123456789abcdef   ";  /* align */
     byte iv[]  = "1234567890abcdef   ";  /* align */
 
-#ifdef HAVE_CAVIUM
-        if (wc_AesInitCavium(&enc, CAVIUM_DEV_ID) != 0)
-            return -20003;
-        if (wc_AesInitCavium(&dec, CAVIUM_DEV_ID) != 0)
-            return -20004;
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if (wc_AesAsyncInit(&enc, devId) != 0)
+        return -20003;
+    if (wc_AesAsyncInit(&dec, devId) != 0)
+        return -20004;
 #endif
     ret = wc_AesSetKey(&enc, key, AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
     if (ret != 0)
@@ -2829,10 +2830,11 @@ int aes_test(void)
     }
 #endif /* WOLFSSL_AESNI HAVE_AES_DECRYPT */
 
-#ifdef HAVE_CAVIUM
-        wc_AesFreeCavium(&enc);
-        wc_AesFreeCavium(&dec);
-#endif
+#ifdef WOLFSSL_ASYNC_CRYPT
+    wc_AesAsyncFree(&enc);
+    wc_AesAsyncFree(&dec);
+#endif /* WOLFSSL_ASYNC_CRYPT */
+
 #endif /* HAVE_AES_CBC */
 
 #ifdef WOLFSSL_AES_COUNTER
@@ -3745,10 +3747,6 @@ static int random_rng_test(void)
     byte block[32];
     int ret, i;
 
-#ifdef HAVE_CAVIUM
-    ret = wc_InitRngCavium(&rng, CAVIUM_DEV_ID);
-    if (ret != 0) return -2007;
-#endif
     ret = wc_InitRng(&rng);
     if (ret != 0) return -39;
 
@@ -4263,6 +4261,7 @@ int certext_test(void)
 }
 #endif /* WOLFSSL_CERT_EXT && WOLFSSL_TEST_CERT */
 
+
 int rsa_test(void)
 {
     byte*   tmp;
@@ -4309,11 +4308,7 @@ int rsa_test(void)
     fclose(file);
 #endif /* USE_CERT_BUFFERS */
 
-#ifdef HAVE_CAVIUM
-    wc_RsaInitCavium(&key, CAVIUM_DEV_ID);
-#endif
-
-    ret = wc_InitRsaKey(&key, HEAP_HINT);
+    ret = wc_InitRsaKey_ex(&key, HEAP_HINT, devId);
     if (ret != 0) {
         TEST_XFREE(tmp, HEAP_HINT ,DYNAMIC_TYPE_TMP_BUFFER);
         return -39;
@@ -4328,11 +4323,20 @@ int rsa_test(void)
         TEST_XFREE(tmp, HEAP_HINT ,DYNAMIC_TYPE_TMP_BUFFER);
         return -42;
     }
-    ret = wc_RsaPublicEncrypt(in, inLen, out, sizeof(out), &key, &rng);
+
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaPublicEncrypt(in, inLen, out, sizeof(out), &key, &rng);
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT ,DYNAMIC_TYPE_TMP_BUFFER);
         return -43;
     }
+
 #ifdef WC_RSA_BLINDING
     {
         int tmpret = ret;
@@ -4344,26 +4348,54 @@ int rsa_test(void)
         ret = tmpret;
     }
 #endif
-    ret = wc_RsaPrivateDecrypt(out, ret, plain, sizeof(plain), &key);
+
+    idx = ret; /* save off encrypted length */
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaPrivateDecrypt(out, idx, plain, sizeof(plain), &key);
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT ,DYNAMIC_TYPE_TMP_BUFFER);
         return -44;
     }
+
     if (XMEMCMP(plain, in, inLen)) {
         TEST_XFREE(tmp, HEAP_HINT ,DYNAMIC_TYPE_TMP_BUFFER);
         return -45;
     }
-    ret = wc_RsaSSL_Sign(in, inLen, out, sizeof(out), &key, &rng);
+
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaSSL_Sign(in, inLen, out, sizeof(out), &key, &rng);
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT ,DYNAMIC_TYPE_TMP_BUFFER);
         return -46;
     }
+
+    idx = ret;
     XMEMSET(plain, 0, sizeof(plain));
-    ret = wc_RsaSSL_Verify(out, ret, plain, sizeof(plain), &key);
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaSSL_Verify(out, idx, plain, sizeof(plain), &key);
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT ,DYNAMIC_TYPE_TMP_BUFFER);
         return -47;
     }
+
     if (XMEMCMP(plain, in, ret)) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -48;
@@ -4375,18 +4407,36 @@ int rsa_test(void)
         !defined(HAVE_FIPS)
     #ifndef NO_SHA
     XMEMSET(plain, 0, sizeof(plain));
-    ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
+    
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
                        WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA, WC_MGF1SHA1, NULL, 0);
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -143;
     }
-    ret = wc_RsaPrivateDecrypt_ex(out, ret, plain, sizeof(plain), &key,
+
+    idx = ret;
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, sizeof(plain), &key,
                        WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA, WC_MGF1SHA1, NULL, 0);
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -144;
     }
+
     if (XMEMCMP(plain, in, inLen)) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -145;
@@ -4395,18 +4445,35 @@ int rsa_test(void)
 
     #ifndef NO_SHA256
     XMEMSET(plain, 0, sizeof(plain));
-    ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
                   WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, NULL, 0);
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -243;
     }
-    ret = wc_RsaPrivateDecrypt_ex(out, ret, plain, sizeof(plain), &key,
+
+    idx = ret;
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, sizeof(plain), &key,
                   WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, NULL, 0);
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -244;
     }
+
     if (XMEMCMP(plain, in, inLen)) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -245;
@@ -4414,53 +4481,104 @@ int rsa_test(void)
 
     /* check fails if not using the same optional label */
     XMEMSET(plain, 0, sizeof(plain));
-    ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
                   WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, NULL, 0);
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -246;
     }
-    ret = wc_RsaPrivateDecrypt_ex(out, ret, plain, sizeof(plain), &key,
-           WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, in, sizeof(in));
+
+    idx = ret;
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, sizeof(plain), &key,
+               WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, in, sizeof(in));
+        }
+    } while (ret == WC_PENDING_E);
     if (ret > 0) { /* in this case decrypt should fail */
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -247;
     }
+    ret = 0;
 
     /* check using optional label with encrypt/decrypt */
     XMEMSET(plain, 0, sizeof(plain));
-    ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
-           WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, in, sizeof(in));
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
+               WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, in, sizeof(in));
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -248;
     }
-    ret = wc_RsaPrivateDecrypt_ex(out, ret, plain, sizeof(plain), &key,
-           WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, in, sizeof(in));
+
+    idx = ret;
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, sizeof(plain), &key,
+               WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, in, sizeof(in));
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -249;
     }
+
     if (XMEMCMP(plain, in, inLen)) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -250;
     }
 
-        #ifndef NO_SHA
+    #ifndef NO_SHA
         /* check fail using mismatch hash algorithms */
         XMEMSET(plain, 0, sizeof(plain));
-        ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
-                WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA, WC_MGF1SHA1, in, sizeof(in));
+        do {
+    #if defined(WOLFSSL_ASYNC_CRYPT)
+            ret = wc_RsaAsyncWait(ret, &key);
+    #endif
+            if (ret >= 0) {
+                ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
+                    WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA, WC_MGF1SHA1, in, sizeof(in));
+            }
+        } while (ret == WC_PENDING_E);
         if (ret < 0) {
             TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             return -251;
         }
-        ret = wc_RsaPrivateDecrypt_ex(out, ret, plain, sizeof(plain), &key,
-           WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, in, sizeof(in));
+
+        idx = ret;
+        do {
+    #if defined(WOLFSSL_ASYNC_CRYPT)
+            ret = wc_RsaAsyncWait(ret, &key);
+    #endif
+            if (ret >= 0) {
+                ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, sizeof(plain), &key,
+                   WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA256, WC_MGF1SHA256, in, sizeof(in));
+            }
+        } while (ret == WC_PENDING_E);
         if (ret > 0) { /* should fail */
             TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             return -252;
         }
+        ret = 0;
         #endif /* NO_SHA*/
     #endif /* NO_SHA256 */
 
@@ -4471,18 +4589,35 @@ int rsa_test(void)
        BAD_FUNC_ARG is returned when this case is not met */
     if (wc_RsaEncryptSize(&key) > ((int)SHA512_DIGEST_SIZE * 2) + 2) {
         XMEMSET(plain, 0, sizeof(plain));
-        ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
+        do {
+    #if defined(WOLFSSL_ASYNC_CRYPT)
+            ret = wc_RsaAsyncWait(ret, &key);
+    #endif
+            if (ret >= 0) {
+                ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
                   WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA512, WC_MGF1SHA512, NULL, 0);
+            }
+        } while (ret == WC_PENDING_E);
         if (ret < 0) {
             TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             return -343;
         }
-        ret = wc_RsaPrivateDecrypt_ex(out, ret, plain, sizeof(plain), &key,
+
+        idx = ret;
+        do {
+    #if defined(WOLFSSL_ASYNC_CRYPT)
+            ret = wc_RsaAsyncWait(ret, &key);
+    #endif
+            if (ret >= 0) {
+                ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, sizeof(plain), &key,
                   WC_RSA_OAEP_PAD, WC_HASH_TYPE_SHA512, WC_MGF1SHA512, NULL, 0);
+            }
+        } while (ret == WC_PENDING_E);
         if (ret < 0) {
             TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             return -344;
         }
+
         if (XMEMCMP(plain, in, inLen)) {
             TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             return -345;
@@ -4492,18 +4627,35 @@ int rsa_test(void)
 
     /* check using pkcsv15 padding with _ex API */
     XMEMSET(plain, 0, sizeof(plain));
-    ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaPublicEncrypt_ex(in, inLen, out, sizeof(out), &key, &rng,
                   WC_RSA_PKCSV15_PAD, WC_HASH_TYPE_NONE, 0, NULL, 0);
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -443;
     }
-    ret = wc_RsaPrivateDecrypt_ex(out, ret, plain, sizeof(plain), &key,
+
+    idx = ret;
+    do {
+#if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_RsaAsyncWait(ret, &key);
+#endif
+        if (ret >= 0) {
+            ret = wc_RsaPrivateDecrypt_ex(out, idx, plain, sizeof(plain), &key,
                   WC_RSA_PKCSV15_PAD, WC_HASH_TYPE_NONE, 0, NULL, 0);
+        }
+    } while (ret == WC_PENDING_E);
     if (ret < 0) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -444;
     }
+
     if (XMEMCMP(plain, in, inLen)) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -445;
@@ -4540,7 +4692,10 @@ int rsa_test(void)
     InitDecodedCert(&cert, tmp, (word32)bytes, 0);
 
     ret = ParseCert(&cert, CERT_TYPE, NO_VERIFY, 0);
-    if (ret != 0) return -491;
+    if (ret != 0) {
+        free(tmp);
+        return -491;
+    }
 
     FreeDecodedCert(&cert);
 #else
@@ -4568,7 +4723,7 @@ int rsa_test(void)
     fclose(file);
 #endif /* USE_CERT_BUFFERS */
 
-    ret = wc_InitRsaKey(&keypub, 0);
+    ret = wc_InitRsaKey(&keypub, HEAP_HINT);
     if (ret != 0) {
         TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -51;
@@ -5367,7 +5522,7 @@ int rsa_test(void)
         bytes = fread(tmp, 1, FOURK_BUF, caFile);
         fclose(caFile);
 
-        ret = wc_InitRsaKey(&caKey, 0);
+        ret = wc_InitRsaKey(&caKey, HEAP_HINT);
         if (ret != 0) {
             TEST_XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             TEST_XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -5652,9 +5807,7 @@ int rsa_test(void)
 #ifdef WOLFSSL_CERT_EXT
     wc_FreeRsaKey(&keypub);
 #endif
-#ifdef HAVE_CAVIUM
-    wc_RsaFreeCavium(&key);
-#endif
+
     TEST_XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     wc_FreeRng(&rng);
 

--- a/wolfcrypt/user-crypto/include/user_rsa.h
+++ b/wolfcrypt/user-crypto/include/user_rsa.h
@@ -76,6 +76,7 @@ typedef struct RsaKey {
 } RsaKey;
 
 WOLFSSL_API int  wc_InitRsaKey(RsaKey* key, void*);
+WOLFSSL_API int  wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId);
 WOLFSSL_API int  wc_FreeRsaKey(RsaKey* key);
 
 WOLFSSL_API int  wc_RsaPublicEncrypt(const byte* in, word32 inLen, byte* out,

--- a/wolfcrypt/user-crypto/src/rsa.c
+++ b/wolfcrypt/user-crypto/src/rsa.c
@@ -74,7 +74,7 @@ enum {
 };
 
 
-int wc_InitRsaKey(RsaKey* key, void* heap)
+int wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId)
 {
 
     USER_DEBUG(("Entering wc_InitRsaKey\n"));
@@ -87,8 +87,14 @@ int wc_InitRsaKey(RsaKey* key, void* heap)
 
     USER_DEBUG(("\tExit wc_InitRsaKey\n"));
 
+    (void)devId;
     (void)heap;
     return 0;
+}
+
+int wc_InitRsaKey(RsaKey* key, void* heap)
+{
+    return wc_InitRsaKey_ex(key, heap, INVALID_DEVID);
 }
 
 

--- a/wolfssl-ntru.vcproj
+++ b/wolfssl-ntru.vcproj
@@ -322,6 +322,10 @@
 				RelativePath=".\wolfcrypt\src\wc_encrypt.c"
 				>
 			</File>
+			<File
+				RelativePath=".\wolfcrypt\src\wolfevent.c"
+				>
+			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"

--- a/wolfssl.vcproj
+++ b/wolfssl.vcproj
@@ -315,6 +315,10 @@
 				RelativePath=".\wolfcrypt\src\wc_encrypt.c"
 				>
 			</File>
+			<File
+				RelativePath=".\wolfcrypt\src\wolfevent.c"
+				>
+			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"

--- a/wolfssl.vcxproj
+++ b/wolfssl.vcxproj
@@ -317,6 +317,7 @@
     <ClCompile Include="wolfcrypt\src\signature.c" />
     <ClCompile Include="wolfcrypt\src\wc_encrypt.c" />
     <ClCompile Include="wolfcrypt\src\wc_port.c" />
+    <ClCompile Include="wolfcrypt\src\wolfevent.c" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="wolfcrypt\src\aes_asm.asm">

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -142,7 +142,6 @@ enum wolfSSL_ErrorCodes {
     UNKNOWN_ALPN_PROTOCOL_NAME_E = -405,   /* Unrecognized protocol name Error*/
     BAD_CERTIFICATE_STATUS_ERROR = -406,   /* Bad certificate status message */
     OCSP_INVALID_STATUS          = -407,   /* Invalid OCSP Status */
-    ASYNC_NOT_PENDING            = -408,   /* Async operation not pending */
 
     RSA_KEY_SIZE_E               = -409,   /* RSA key too small */
     ECC_KEY_SIZE_E               = -410,   /* ECC key too small */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -31,6 +31,10 @@
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/version.h>
 
+#ifdef HAVE_WOLF_EVENT
+    #include <wolfssl/wolfcrypt/wolfevent.h>
+#endif
+
 #ifndef NO_FILESYSTEM
     #if defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
         #if MQX_USE_IO_OLD
@@ -1416,9 +1420,9 @@ WOLFSSL_API void wolfSSL_KeepArrays(WOLFSSL*);
 WOLFSSL_API void wolfSSL_FreeArrays(WOLFSSL*);
 
 
-/* cavium additions */
-WOLFSSL_API int wolfSSL_UseCavium(WOLFSSL*, int devId);
-WOLFSSL_API int wolfSSL_CTX_UseCavium(WOLFSSL_CTX*, int devId);
+/* async additions */
+WOLFSSL_API int wolfSSL_UseAsync(WOLFSSL*, int devId);
+WOLFSSL_API int wolfSSL_CTX_UseAsync(WOLFSSL_CTX*, int devId);
 
 /* TLS Extensions */
 
@@ -1909,41 +1913,13 @@ WOLFSSL_API int wolfSSL_set_jobject(WOLFSSL* ssl, void* objPtr);
 WOLFSSL_API void* wolfSSL_get_jobject(WOLFSSL* ssl);
 #endif /* WOLFSSL_JNI */
 
-#ifdef HAVE_WOLF_EVENT
-typedef enum WOLF_EVENT_TYPE {
-    WOLF_EVENT_TYPE_NONE,
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        WOLF_EVENT_TYPE_ASYNC_ACCEPT,
-        WOLF_EVENT_TYPE_ASYNC_CONNECT,
-        WOLF_EVENT_TYPE_ASYNC_READ,
-        WOLF_EVENT_TYPE_ASYNC_WRITE,
-        WOLF_EVENT_TYPE_ASYNC_FIRST = WOLF_EVENT_TYPE_ASYNC_ACCEPT,
-        WOLF_EVENT_TYPE_ASYNC_LAST = WOLF_EVENT_TYPE_ASYNC_WRITE,
-    #endif
-} WOLF_EVENT_TYPE;
 
-typedef struct WOLF_EVENT WOLF_EVENT;
-struct WOLF_EVENT {
-    WOLF_EVENT*         next;   /* To support event linked list */
-	WOLFSSL*            ssl;    /* Reference back to SSL object */
-    int                 ret;    /* Async return code */
-    WOLF_EVENT_TYPE     type;
-    unsigned short      pending:1;
-    unsigned short      done:1;
-    /* Future event flags can go here */
-};
+#ifdef WOLFSSL_ASYNC_CRYPT
+WOLFSSL_API int wolfSSL_AsyncPoll(WOLFSSL* ssl, WOLF_EVENT_FLAG flags);
+WOLFSSL_API int wolfSSL_CTX_AsyncPoll(WOLFSSL_CTX* ctx, WOLF_EVENT** events, int maxEvents,
+    WOLF_EVENT_FLAG flags, int* eventCount);
+#endif /* WOLFSSL_ASYNC_CRYPT */
 
-enum WOLF_POLL_FLAGS {
-    WOLF_POLL_FLAG_CHECK_HW = 0x01,
-    WOLF_POLL_FLAG_PEEK = 0x02,
-};
-
-WOLFSSL_API int wolfSSL_CTX_poll(WOLFSSL_CTX* ctx, WOLF_EVENT* events,
-    int maxEvents, unsigned char flags, int* eventCount);
-WOLFSSL_API int wolfSSL_poll(WOLFSSL* ssl, WOLF_EVENT* events,
-    int maxEvents, unsigned char flags, int* eventCount);
-
-#endif /* HAVE_WOLF_EVENT */
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -39,10 +39,6 @@
 #endif
 
 #ifndef HAVE_FIPS /* to avoid redefinition of macros */
-#ifdef HAVE_CAVIUM
-    #include <wolfssl/wolfcrypt/logging.h>
-    #include "cavium_common.h"
-#endif
 
 #ifdef WOLFSSL_AESNI
 
@@ -74,7 +70,10 @@
 #endif
 
 #ifndef HAVE_FIPS /* to avoid redefinition of structures */
-#define WOLFSSL_AES_CAVIUM_MAGIC 0xBEEF0002
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
 
 enum {
     AES_ENC_TYPE   = 1,   /* cipher unique type */
@@ -102,12 +101,12 @@ typedef struct Aes {
 #ifdef WOLFSSL_AESNI
     byte use_aesni;
 #endif /* WOLFSSL_AESNI */
-#ifdef HAVE_CAVIUM
-    AesType type;            /* aes key type */
-    int     devId;           /* nitrox device id */
-    word32  magic;           /* using cavium magic */
-    word64  contextHandle;   /* nitrox context memory handle */
-#endif
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncCryptDev asyncDev;
+    #ifdef HAVE_CAVIUM
+        AesType type;                       /* aes key type */
+    #endif
+#endif /* WOLFSSL_ASYNC_CRYPT */
 #ifdef WOLFSSL_AES_COUNTER
     word32  left;            /* unused bytes left from last call */
 #endif
@@ -183,9 +182,9 @@ WOLFSSL_API int  wc_AesCbcDecrypt(Aes* aes, byte* out,
                                    const byte* authIn, word32 authInSz);
 #endif /* HAVE_AESCCM */
 
-#ifdef HAVE_CAVIUM
-     WOLFSSL_API int  wc_AesInitCavium(Aes*, int);
-     WOLFSSL_API void wc_AesFreeCavium(Aes*);
+#ifdef WOLFSSL_ASYNC_CRYPT
+     WOLFSSL_API int  wc_AesAsyncInit(Aes*, int);
+     WOLFSSL_API void wc_AesAsyncFree(Aes*);
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/arc4.h
+++ b/wolfssl/wolfcrypt/arc4.h
@@ -30,7 +30,9 @@
     extern "C" {
 #endif
 
-#define WOLFSSL_ARC4_CAVIUM_MAGIC 0xBEEF0001
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
 
 enum {
 	ARC4_ENC_TYPE   = 4,    /* cipher unique type */
@@ -42,19 +44,17 @@ typedef struct Arc4 {
     byte x;
     byte y;
     byte state[ARC4_STATE_SIZE];
-#ifdef HAVE_CAVIUM
-    int    devId;           /* nitrox device id */
-    word32 magic;           /* using cavium magic */
-    word64 contextHandle;   /* nitrox context memory handle */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncCryptDev asyncDev;
 #endif
 } Arc4;
 
 WOLFSSL_API void wc_Arc4Process(Arc4*, byte*, const byte*, word32);
 WOLFSSL_API void wc_Arc4SetKey(Arc4*, const byte*, word32);
 
-#ifdef HAVE_CAVIUM
-    WOLFSSL_API int  wc_Arc4InitCavium(Arc4*, int);
-    WOLFSSL_API void wc_Arc4FreeCavium(Arc4*);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    WOLFSSL_API int  wc_Arc4AsyncInit(Arc4*, int);
+    WOLFSSL_API void wc_Arc4AsyncFree(Arc4*);
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/des3.h
+++ b/wolfssl/wolfcrypt/des3.h
@@ -37,7 +37,10 @@
 #endif
 
 #ifndef HAVE_FIPS /* to avoid redefinition of macros */
-#define WOLFSSL_3DES_CAVIUM_MAGIC 0xBEEF0003
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
 
 enum {
     DES_ENC_TYPE    = 2,     /* cipher unique type */
@@ -76,10 +79,8 @@ typedef struct Des3 {
     word32 key[3][DES_KS_SIZE];
     word32 reg[DES_BLOCK_SIZE / sizeof(word32)];      /* for CBC mode */
     word32 tmp[DES_BLOCK_SIZE / sizeof(word32)];      /* same         */
-#ifdef HAVE_CAVIUM
-    int     devId;           /* nitrox device id */
-    word32  magic;           /* using cavium magic */
-    word64  contextHandle;   /* nitrox context memory handle */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncCryptDev asyncDev;
 #endif
 } Des3;
 #endif /* HAVE_FIPS */
@@ -102,9 +103,9 @@ WOLFSSL_API int  wc_Des3_CbcEncrypt(Des3* des, byte* out,
 WOLFSSL_API int  wc_Des3_CbcDecrypt(Des3* des, byte* out,
                                     const byte* in,word32 sz);
 
-#ifdef HAVE_CAVIUM
-    WOLFSSL_API int  wc_Des3_InitCavium(Des3*, int);
-    WOLFSSL_API void wc_Des3_FreeCavium(Des3*);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    WOLFSSL_API int  wc_Des3AsyncInit(Des3*, int);
+    WOLFSSL_API void wc_Des3AsyncFree(Des3*);
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -30,6 +30,10 @@
 #include <wolfssl/wolfcrypt/integer.h>
 #include <wolfssl/wolfcrypt/random.h>
 
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
+
 #ifdef __cplusplus
     extern "C" {
 #endif
@@ -230,6 +234,10 @@ typedef struct {
     ecc_point pubkey;   /* public key */
     mp_int    k;        /* private key */
     void*     heap;     /* heap hint */
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncCryptDev asyncDev;
+#endif
 } ecc_key;
 
 
@@ -275,7 +283,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 WOLFSSL_API
 int wc_ecc_init(ecc_key* key);
 WOLFSSL_API
-int wc_ecc_init_h(ecc_key* key, void* heap);
+int wc_ecc_init_ex(ecc_key* key, void* heap, int devId);
 WOLFSSL_API
 void wc_ecc_free(ecc_key* key);
 WOLFSSL_API
@@ -420,6 +428,12 @@ int wc_ecc_decrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
                 word32 msgSz, byte* out, word32* outSz, ecEncCtx* ctx);
 
 #endif /* HAVE_ECC_ENCRYPT */
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    WOLFSSL_API int wc_ecc_async_handle(ecc_key* key,
+        WOLF_EVENT_QUEUE* queue, WOLF_EVENT* event);
+    WOLFSSL_API int wc_ecc_async_wait(int ret, ecc_key* key);
+#endif
 
 #ifdef __cplusplus
     }    /* extern "C" */

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -44,6 +44,9 @@ enum {
     CRYPTGEN_E         = -104,  /* windows crypt generation error */
     RAN_BLOCK_E        = -105,  /* reading random device would block */
     BAD_MUTEX_E        = -106,  /* Bad mutex operation */
+    WC_TIMEOUT_E       = -107,  /* timeout error */
+    WC_PENDING_E       = -108,  /* wolfCrypt operation pending (would block) */
+    WC_NOT_PENDING_E   = -109,  /* wolfCrypt operation not pending */
 
     MP_INIT_E          = -110,  /* mp_init error state */
     MP_READ_E          = -111,  /* mp_read error state */
@@ -60,7 +63,6 @@ enum {
 
     MEMORY_E           = -125,  /* out of memory error */
     VAR_STATE_CHANGE_E = -126,  /* var state modified by different thread */
-
 
     RSA_WRONG_TYPE_E   = -130,  /* RSA wrong block type for RSA function */
     RSA_BUFFER_E       = -131,  /* RSA buffer error, output too small or
@@ -108,7 +110,7 @@ enum {
     AES_GCM_AUTH_E     = -180,  /* AES-GCM Authentication check failure */
     AES_CCM_AUTH_E     = -181,  /* AES-CCM Authentication check failure */
 
-    CAVIUM_INIT_E      = -182,  /* Cavium Init type error */
+    ASYNC_INIT_E       = -182,  /* Async Init type error */
 
     COMPRESS_INIT_E    = -183,  /* Compress init error */
     COMPRESS_E         = -184,  /* Compress error */
@@ -121,7 +123,7 @@ enum {
     ASN_CRL_NO_SIGNER_E = -190,  /* ASN CRL no signer to confirm failure */
     ASN_OCSP_CONFIRM_E  = -191,  /* ASN OCSP signature confirm failure */
 
-    BAD_ENC_STATE_E     = -192,  /* Bad ecc enc state operation */
+    BAD_STATE_E         = -192,  /* Bad state operation */
     BAD_PADDING_E       = -193,  /* Bad padding, msg not correct length  */
 
     REQ_ATTRIBUTE_E     = -194,  /* setting cert request attributes error */
@@ -169,7 +171,6 @@ enum {
     BAD_COND_E          = -230,  /* Bad condition variable operation */
     SIG_TYPE_E          = -231,  /* Signature Type not enabled/available */
     HASH_TYPE_E         = -232,  /* Hash Type not enabled/available */
-    WC_PENDING_E        = -233,  /* wolfCrypt operation pending (would block) */
 
     WC_KEY_SIZE_E       = -234,  /* Key size error, either too small or large */
     ASN_COUNTRY_SIZE_E  = -235,  /* ASN Cert Gen, invalid country code size */

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -58,7 +58,7 @@ enum wc_HashType {
     #define WC_MAX_DIGEST_SIZE 64 /* default to max size of 64 */
 #endif
 
-#ifndef NO_ASN
+#if !defined(NO_ASN) || !defined(NO_DH) || defined(HAVE_ECC)
 WOLFSSL_API int wc_HashGetOID(enum wc_HashType hash_type);
 #endif
 

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -56,10 +56,15 @@ nobase_include_HEADERS+= \
                          wolfssl/wolfcrypt/memory.h \
                          wolfssl/wolfcrypt/mpi_class.h \
                          wolfssl/wolfcrypt/mpi_superclass.h \
-                         wolfssl/wolfcrypt/mem_track.h
+                         wolfssl/wolfcrypt/mem_track.h \
+                         wolfssl/wolfcrypt/wolfevent.h
 
 noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/pic32/pic32mz-crypt.h \
                          wolfssl/wolfcrypt/port/ti/ti-hash.h \
                          wolfssl/wolfcrypt/port/ti/ti-ccm.h \
                          wolfssl/wolfcrypt/port/nrf51.h
+
+if BUILD_CAVIUM
+noinst_HEADERS+=         wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h
+endif

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -181,6 +181,9 @@ typedef int           mp_err;
 typedef struct  {
     int used, alloc, sign;
     mp_digit *dp;
+#ifdef WOLFSSL_ASYNC_CRYPT
+    byte* dpraw; /* Used for hardware crypto */
+#endif
 } mp_int;
 
 /* callback for mp_prime_random, should fill dst with random bytes and return

--- a/wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h
+++ b/wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h
@@ -1,0 +1,165 @@
+/* cavium-nitrox.h
+ *
+ * Copyright (C) 2006-2016 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL. (formerly known as CyaSSL)
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _CAVIUM_NITROX_H_
+#define _CAVIUM_NITROX_H_
+
+#ifdef HAVE_CAVIUM
+
+#include <wolfssl/wolfcrypt/logging.h>
+
+#ifndef HAVE_CAVIUM_V
+    #include "cavium_sysdep.h"
+#endif
+#include "cavium_common.h"
+#ifndef HAVE_CAVIUM_V
+    #include "cavium_ioctl.h"
+#else
+    #include "cavium_sym_crypto.h"
+    #include "cavium_asym_crypto.h"
+#endif
+#include <errno.h>
+
+#define CAVIUM_SSL_GRP      0
+#define CAVIUM_DPORT        256
+
+/* Compatibility with older Cavium SDK's */
+#ifndef HAVE_CAVIUM_V
+    typedef int CspHandle;
+    typedef word32 CavReqId;
+
+    #define AES_128 AES_128_BIT
+    #define AES_192 AES_192_BIT
+    #define AES_256 AES_256_BIT
+#else
+    #define CAVIUM_DEV_ID       0
+    #define CAVIUM_BLOCKING     BLOCKING
+    #define CAVIUM_NON_BLOCKING NON_BLOCKING
+    #define CAVIUM_DIRECT       DMA_DIRECT_DIRECT
+    typedef Uint64 CavReqId;
+#endif
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #define CAVIUM_REQ_MODE CAVIUM_NON_BLOCKING
+#else
+    #define CAVIUM_REQ_MODE CAVIUM_BLOCKING
+#endif
+
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #define CAVIUM_MAX_PENDING  90
+    #define CAVIUM_MAX_POLL     MAX_TO_POLL
+#endif
+
+
+typedef struct CaviumNitroxDev {
+    CspHandle   devId;                      /* nitrox device id */
+    ContextType type;                       /* Typically CONTEXT_SSL, but also ECC types */
+    Uint64      contextHandle;              /* nitrox context memory handle */
+    CavReqId    reqId;                      /* Current requestId */
+} CaviumNitroxDev;
+
+struct WOLF_EVENT;
+
+
+/* Wrapper API's */
+WOLFSSL_LOCAL int NitroxTranslateResponseCode(int ret);
+WOLFSSL_LOCAL CspHandle NitroxGetDeviceHandle(void);
+WOLFSSL_LOCAL CspHandle NitroxOpenDevice(int dma_mode, int dev_id);
+WOLFSSL_LOCAL int NitroxAllocContext(CaviumNitroxDev* nitrox, CspHandle devId,
+    ContextType type);
+WOLFSSL_LOCAL void NitroxFreeContext(CaviumNitroxDev* nitrox);
+WOLFSSL_LOCAL void NitroxCloseDevice(CspHandle devId);
+
+#if defined(WOLFSSL_ASYNC_CRYPT)
+WOLFSSL_LOCAL int NitroxCheckRequest(CspHandle devId, CavReqId reqId);
+WOLFSSL_LOCAL int NitroxCheckRequests(CspHandle devId,
+    CspMultiRequestStatusBuffer* req_stat_buf);
+#endif /* WOLFSSL_ASYNC_CRYPT */
+
+
+/* Crypto wrappers */
+#ifndef NO_RSA
+    struct RsaKey;
+    WOLFSSL_LOCAL int NitroxRsaExptMod(
+                            const byte* in, word32 inLen,
+                            byte* exponent, word32 expLen,
+                            byte* modulus, word32 modLen,
+                            byte* out, word32* outLen, struct RsaKey* key);
+    WOLFSSL_LOCAL int NitroxRsaPublicEncrypt(const byte* in, word32 inLen,
+                                byte* out, word32 outLen, struct RsaKey* key);
+    WOLFSSL_LOCAL int NitroxRsaPrivateDecrypt(const byte* in, word32 inLen,
+                                byte* out, word32 outLen, struct RsaKey* key);
+    WOLFSSL_LOCAL int NitroxRsaSSL_Sign(const byte* in, word32 inLen,
+                                byte* out, word32 outLen, struct RsaKey* key);
+    WOLFSSL_LOCAL int NitroxRsaSSL_Verify(const byte* in, word32 inLen,
+                                byte* out, word32 outLen, struct RsaKey* key);
+#endif /* !NO_RSA */
+
+#ifndef NO_AES
+    struct Aes;
+    WOLFSSL_LOCAL int NitroxAesSetKey(struct Aes* aes, const byte* key,
+                                                word32 length, const byte* iv);
+    #ifdef HAVE_AES_CBC
+        WOLFSSL_LOCAL int NitroxAesCbcEncrypt(struct Aes* aes, byte* out,
+                                                const byte* in, word32 length);
+    #ifdef HAVE_AES_DECRYPT
+        WOLFSSL_LOCAL int NitroxAesCbcDecrypt(struct Aes* aes, byte* out,
+                                                const byte* in, word32 length);
+    #endif /* HAVE_AES_DECRYPT */
+    #endif /* HAVE_AES_CBC */
+#endif /* !NO_AES */
+
+#ifndef NO_RC4
+    struct Arc4;
+    WOLFSSL_LOCAL void NitroxArc4SetKey(struct Arc4* arc4, const byte* key,
+                                                                word32 length);
+    WOLFSSL_LOCAL void NitroxArc4Process(struct Arc4* arc4, byte* out,
+                                                const byte* in, word32 length);
+#endif /* !NO_RC4 */
+
+#ifndef NO_DES3
+    struct Des3;
+    WOLFSSL_LOCAL int NitroxDes3SetKey(struct Des3* des3, const byte* key,
+                                                               const byte* iv);
+    WOLFSSL_LOCAL int NitroxDes3CbcEncrypt(struct Des3* des3, byte* out,
+                                                const byte* in, word32 length);
+    WOLFSSL_LOCAL int NitroxDes3CbcDecrypt(struct Des3* des3, byte* out,
+                                                const byte* in, word32 length);
+#endif /* !NO_DES3 */
+
+#ifndef NO_HMAC
+    struct Hmac;
+    WOLFSSL_LOCAL int NitroxHmacFinal(struct Hmac* hmac, byte* hash);
+    WOLFSSL_LOCAL int NitroxHmacUpdate(struct Hmac* hmac, const byte* msg,
+                                                                word32 length);
+    WOLFSSL_LOCAL int NitroxHmacSetKey(struct Hmac* hmac, int type,
+                                               const byte* key, word32 length);
+#endif /* NO_HMAC */
+
+#if !defined(HAVE_HASHDRBG) && !defined(NO_RC4)
+    WOLFSSL_API void NitroxRngGenerateBlock(WC_RNG* rng, byte* output, word32 sz);
+#endif
+
+
+#endif /* HAVE_CAVIUM */
+
+#endif /* _CAVIUM_NITROX_H_ */

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -101,7 +101,9 @@ struct WC_RNG {
 
 #else /* (HAVE_HASHDRBG || NO_RC4) && !CUSTOM_RAND_GENERATE_BLOCK */
 
-#define WOLFSSL_RNG_CAVIUM_MAGIC 0xBEEF0004
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
 
 /* secure Random Number Generator */
 
@@ -111,9 +113,8 @@ struct WC_RNG {
 #ifndef NO_RC4
     Arc4    cipher;
 #endif
-#ifdef HAVE_CAVIUM
-    int    devId;           /* nitrox device id */
-    word32 magic;           /* using cavium magic */
+#ifdef WOLFSSL_ASYNC_CRYPT
+    AsyncCryptDev asyncDev;
 #endif
 };
 
@@ -131,13 +132,6 @@ struct WC_RNG {
 WOLFSSL_LOCAL
 int wc_GenerateSeed(OS_Seed* os, byte* seed, word32 sz);
 
-#if defined(HAVE_HASHDRBG) || defined(NO_RC4)
-
-#ifdef HAVE_CAVIUM
-    WOLFSSL_API int  wc_InitRngCavium(WC_RNG*, int);
-#endif
-
-#endif /* HAVE_HASH_DRBG || NO_RC4 */
 
 #ifdef HAVE_WNR
     /* Whitewood netRandom client library */

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -82,8 +82,9 @@ typedef struct RsaKey {
     int   type;                               /* public or private */
     void* heap;                               /* for user memory overrides */
     int   state;
-    byte* tmp;
+    byte*  tmp;                               /* temp buffer for async RSA */
     word32 tmpLen;
+    byte   tmpIsAlloc;
 #ifdef WC_RSA_BLINDING
     WC_RNG* rng;                              /* for PrivateDecrypt blinding */
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1235,9 +1235,10 @@ static char *fgets(char *buff, int sz, FILE *fp)
     /* Make sure wolf events are enabled */
     #undef HAVE_WOLF_EVENT
     #define HAVE_WOLF_EVENT
-#else
-    #ifdef WOLFSSL_ASYNC_CRYPT_TEST
-        #error Must have WOLFSSL_ASYNC_CRYPT enabled with WOLFSSL_ASYNC_CRYPT_TEST
+
+    #if !defined(HAVE_CAVIUM) && !defined(HAVE_INTEL_QA) && \
+        !defined(WOLFSSL_ASYNC_CRYPT_TEST)
+        #error No async hardware defined with WOLFSSL_ASYNC_CRYPT!
     #endif
 #endif /* WOLFSSL_ASYNC_CRYPT */
 

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -289,6 +289,9 @@ typedef struct {
     int      size;
 #endif
     fp_digit dp[FP_SIZE];
+#ifdef WOLFSSL_ASYNC_CRYPT
+    byte *dpraw; /* Used for hardware crypto */
+#endif
 } fp_int;
 
 /* externally define this symbol to ignore the default settings, useful for changing the build from the make process */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -312,8 +312,8 @@
 	    DYNAMIC_TYPE_ECC          = 37,
 	    DYNAMIC_TYPE_TMP_BUFFER   = 38,
 	    DYNAMIC_TYPE_DTLS_MSG     = 39,
-	    DYNAMIC_TYPE_CAVIUM_TMP   = 40,
-	    DYNAMIC_TYPE_CAVIUM_RSA   = 41,
+	    DYNAMIC_TYPE_ASYNC_TMP    = 40,
+	    DYNAMIC_TYPE_ASYNC_RSA    = 41,
 	    DYNAMIC_TYPE_X509         = 42,
 	    DYNAMIC_TYPE_TLSX         = 43,
 	    DYNAMIC_TYPE_OCSP         = 44,
@@ -375,6 +375,9 @@
 	   types need to match at compile time and run time, CheckCtcSettings will
 	   return 1 if a match otherwise 0 */
 	#define CheckCtcSettings() (CTC_SETTINGS == CheckRunTimeSettings())
+
+	/* invalid device id */
+	#define INVALID_DEVID    -2
 
 
 	#ifdef __cplusplus

--- a/wolfssl/wolfcrypt/wolfevent.h
+++ b/wolfssl/wolfcrypt/wolfevent.h
@@ -1,0 +1,103 @@
+/* wolfevent.h
+ *
+ * Copyright (C) 2006-2016 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef _WOLF_EVENT_H_
+#define _WOLF_EVENT_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#ifndef SINGLE_THREADED
+    #include <wolfssl/wolfcrypt/wc_port.h>
+#endif
+
+typedef struct WOLFSSL WOLFSSL;
+typedef struct WOLF_EVENT WOLF_EVENT;
+typedef struct WOLFSSL_CTX WOLFSSL_CTX;
+
+typedef unsigned short WOLF_EVENT_FLAG;
+
+typedef enum WOLF_EVENT_TYPE {
+    WOLF_EVENT_TYPE_NONE,
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        WOLF_EVENT_TYPE_ASYNC_ANY,
+        WOLF_EVENT_TYPE_ASYNC_WOLFSSL,
+        WOLF_EVENT_TYPE_ASYNC_WOLFCRYPT,
+        WOLF_EVENT_TYPE_ASYNC_FIRST = WOLF_EVENT_TYPE_ASYNC_WOLFSSL,
+        WOLF_EVENT_TYPE_ASYNC_LAST = WOLF_EVENT_TYPE_ASYNC_WOLFCRYPT,
+    #endif
+} WOLF_EVENT_TYPE;
+
+struct WOLF_EVENT {
+    /* double linked list */
+    WOLF_EVENT*         next;
+    WOLF_EVENT*         prev;
+
+    void*               context;
+#ifdef HAVE_CAVIUM
+    word64              reqId;
+#endif
+    int                 ret;    /* Async return code */
+    WOLF_EVENT_TYPE     type;
+    WOLF_EVENT_FLAG     pending:1;
+    WOLF_EVENT_FLAG     done:1;
+    /* Future event flags can go here */
+};
+
+enum WOLF_POLL_FLAGS {
+    WOLF_POLL_FLAG_CHECK_HW = 0x01,
+};
+
+typedef struct {
+    WOLF_EVENT*         head;     /* head of queue */
+    WOLF_EVENT*         tail;     /* tail of queue */
+#ifndef SINGLE_THREADED
+    wolfSSL_Mutex       lock;     /* queue lock */
+#endif
+    int                 count;
+} WOLF_EVENT_QUEUE;
+
+
+#ifdef HAVE_WOLF_EVENT
+
+/* Event */
+WOLFSSL_API int wolfEvent_Init(WOLF_EVENT* event, WOLF_EVENT_TYPE type, void* context);
+WOLFSSL_API int wolfEvent_Poll(WOLF_EVENT* event, WOLF_EVENT_FLAG flags);
+
+/* Event Queue */
+WOLFSSL_API int wolfEventQueue_Init(WOLF_EVENT_QUEUE* queue);
+WOLFSSL_API int wolfEventQueue_Push(WOLF_EVENT_QUEUE* queue, WOLF_EVENT* event);
+WOLFSSL_API int wolfEventQueue_Pop(WOLF_EVENT_QUEUE* queue, WOLF_EVENT** event);
+WOLFSSL_API int wolfEventQueue_Remove(WOLF_EVENT_QUEUE* queue, WOLF_EVENT* event);
+WOLFSSL_API int wolfEventQueue_Poll(WOLF_EVENT_QUEUE* queue, void* context_filter,
+    WOLF_EVENT** events, int maxEvents, WOLF_EVENT_FLAG flags, int* eventCount);
+WOLFSSL_API int wolfEventQueue_Count(WOLF_EVENT_QUEUE* queue);
+WOLFSSL_API void wolfEventQueue_Free(WOLF_EVENT_QUEUE* queue);
+
+#endif /* HAVE_WOLF_EVENT */
+
+
+#ifdef __cplusplus
+    }   /* extern "C" */
+#endif
+
+#endif /* _WOLF_EVENT_H_ */


### PR DESCRIPTION
Added asynchronous wolfCrypt RSA, TLS client and Cavium Nitrox V support. Asynchronous wolfSSL client support for "DoServerKeyExchange", "SendClientKeyExchange", "SendCertificateVerify" and "DoCertificateVerify". Fixes for async DTLS. Refactor of the wolf event and async handling for use in wolfCrypt. Refactor of the async device support so its hardware agnostic. Added Cavium Nitrox V support (Nitrox tested using SDK v0.2 CNN55XX-SDK with new configure "--with-cavium-v=/dir" option). Moved Nitrox specific functions to new port file "port/cavium/cavium_nitrox.c". RSA refactor to handle async with states. RSA optimization for using dpraw for private key decode. Use double linked list in wolf event for faster/cleaner code. Use typedef for wolf event flag. Cleanup of the async error codes. wolfCrypt test and benchmark support for async RSA. Asynchronous mode enabled using "./configure --enable-asynccrypt". If no async hardware is defined then the internal async simulator (WOLFSSL_ASYNC_CRYPT_TEST) is used. Note: Using async mode requires async.c/h files from wolfSSL. If interested in using asynchronous mode please send email to info@wolfssl.com.