### PR TITLE
add ARM 64bit type macro

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -88,7 +88,8 @@
 
 	/* These platforms have 64-bit CPU registers.  */
 	#if (defined(__alpha__) || defined(__ia64__) || defined(_ARCH_PPC64) || \
-	     defined(__mips64)  || defined(__x86_64__) || defined(_M_X64))
+	     defined(__mips64)  || defined(__x86_64__) || defined(_M_X64)) || \
+         defined(__aarch64__)
 	    typedef word64 wolfssl_word;
 	#else
 	    typedef word32 wolfssl_word;


### PR DESCRIPTION
Macro found in ARMs manual at the website http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0774a/chr1383660321827.html

Tests if ARM architecture is A64 and adjusts wolfssl_word size.
