### PR TITLE
openssl.test, switch -Verify to -verify to accomodate ADH cipher suites

### DIFF
--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -82,7 +82,7 @@ found_free_port=0
 while [ "$counter" -lt 20 ]; do
     echo -e "\nTrying to start openssl server on port $openssl_port...\n"
 
-    openssl s_server -accept $openssl_port -cert ./certs/server-cert.pem -key ./certs/server-key.pem  -quiet -CAfile ./certs/client-cert.pem -www  -dhparam ./certs/dh2048.pem -dcert ./certs/server-ecc.pem -dkey ./certs/ecc-key.pem -Verify 10 -verify_return_error -cipher "ALL:eNULL" &
+    openssl s_server -accept $openssl_port -cert ./certs/server-cert.pem -key ./certs/server-key.pem  -quiet -CAfile ./certs/client-cert.pem -www  -dhparam ./certs/dh2048.pem -dcert ./certs/server-ecc.pem -dkey ./certs/ecc-key.pem -verify 10 -verify_return_error -cipher "ALL:eNULL" &
     server_pid=$!
     # wait to see if s_server successfully starts before continuing
     sleep 0.1


### PR DESCRIPTION
The openssl.test failed with ADH (anonymous DH) cipher suites against OpenSSL's s_server because the "-Verify" option was used.

"-Verify" requests a client certificate, and fails if the client cert is not sent.  Since ADH suites don't use certificates for authentication, this failed when "--enable-anon" was used.

Resolution is to switch "-Verify" to "-verify".  The "-verify" still requests a client certificate is sent, but does not fail if one is not returned.