### PR TITLE
fixes ocsp signer lookup in the cert manager.

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9207,7 +9207,10 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
         }
     }
     else {
-        Signer* ca = GetCA(cm, resp->issuerHash);
+        Signer* ca = GetCA(cm, resp->issuerKeyHash);
+
+        if (!ca)
+            ca = GetCA(cm, resp->issuerHash);
 
         if (!ca || !ConfirmSignature(resp->response, resp->responseSz,
                                      ca->publicKey, ca->pubKeySize, ca->keyOID,

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9209,9 +9209,6 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
     else {
         Signer* ca = GetCA(cm, resp->issuerKeyHash);
 
-        if (!ca)
-            ca = GetCA(cm, resp->issuerHash);
-
         if (!ca || !ConfirmSignature(resp->response, resp->responseSz,
                                      ca->publicKey, ca->pubKeySize, ca->keyOID,
                                   resp->sig, resp->sigSz, resp->sigOID, NULL)) {


### PR DESCRIPTION
Looks for CA based on issuerKeyHash instead of issuerHash.

I still kept the issuerHash lookup if the issuerKeyHash lookup fails.