### PR TITLE
leave off SHA1-RSA/ECDSA signature algorithms when NO_OLD_TLS is defined

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1704,7 +1704,7 @@ static void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig,
             suites->hashSigAlgo[idx++] = sha256_mac;
             suites->hashSigAlgo[idx++] = ecc_dsa_sa_algo;
         #endif
-        #ifndef NO_SHA
+        #if !defined(NO_SHA) && !defined(NO_OLD_TLS)
             suites->hashSigAlgo[idx++] = sha_mac;
             suites->hashSigAlgo[idx++] = ecc_dsa_sa_algo;
         #endif
@@ -1723,7 +1723,7 @@ static void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig,
             suites->hashSigAlgo[idx++] = sha256_mac;
             suites->hashSigAlgo[idx++] = rsa_sa_algo;
         #endif
-        #ifndef NO_SHA
+        #if !defined(NO_SHA) && !defined(NO_OLD_TLS)
             suites->hashSigAlgo[idx++] = sha_mac;
             suites->hashSigAlgo[idx++] = rsa_sa_algo;
         #endif


### PR DESCRIPTION
When using NO_OLD_TLS, SHA1 handling code is excluded from DoServerKeyExchange(), but wolfSSL still broadcasts support for it in the TLS Signature Algorithms Extension.

This pull request disables sending of the SHA1-RSA and SHA1-ECDSA signature algorithms in a ClientHello when NO_OLD_TLS is defined.

Based on patch contribution from Zendesk Ticket 2101.  Contributor agreement status confirmed for this case.

Error case prior to this pull request can be reproduced by trying to connect to "bing.com:443".  This server seems to pick the lowest security level signature algorithm, thus chooses SHA1:

```
$ cd wolfssl
$ ./configure --disable-oldtls
$ ./examples/client/client -h bing.com -p 443 -d -g
err = -133, Setting Cert AlgoID error
wolfSSL error: wolfSSL_connect failed
```