### PR TITLE
Static Memory Fixes

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -682,6 +682,9 @@ int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx, wolfSSL_method_func method
     }
 
     if (*ctx == NULL) {
+        if (sizeof(WOLFSSL_HEAP) + sizeof(WOLFSSL_HEAP_HINT) > sz - idx) {
+            return BUFFER_E; /* not enough memory for structures */
+        }
         heap = (WOLFSSL_HEAP*)buf;
         idx += sizeof(WOLFSSL_HEAP);
         if (wolfSSL_init_memory_heap(heap) != SSL_SUCCESS) {
@@ -693,6 +696,9 @@ int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx, wolfSSL_method_func method
         hint->memory = heap;
     }
     else if ((*ctx)->heap == NULL) {
+        if (sizeof(WOLFSSL_HEAP) + sizeof(WOLFSSL_HEAP_HINT) > sz - idx) {
+            return BUFFER_E; /* not enough memory for structures */
+        }
         heap = (WOLFSSL_HEAP*)buf;
         idx += sizeof(WOLFSSL_HEAP);
         if (wolfSSL_init_memory_heap(heap) != SSL_SUCCESS) {

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -137,6 +137,7 @@ WOLFSSL_API int wolfSSL_SetAllocators(wolfSSL_Malloc_cb  malloc_function,
         WOLFSSL_MEM_CONN_STATS* stats;  /* hold individual connection stats */
         wc_Memory*  outBuf; /* set if using fixed io buffers */
         wc_Memory*  inBuf;
+        byte        haFlag; /* flag used for checking handshake count */
     } WOLFSSL_HEAP_HINT;
 
 


### PR DESCRIPTION
This is to address two issues. One bug report of the current handshake counter not getting decremented and one potential race condition with comparing and incrementing the counter.

haFlag was added for keeping track of if FreeHandshakeResources was called. There is a case where it could not be called, for example create SSL structure, do not perform any more operations with SSL structure, free SSL structure.