### PR TITLE
add helper functions for choosing static buffer size

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -632,6 +632,18 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
         err_sys("unable to get method");
 
 #ifdef WOLFSSL_STATIC_MEMORY
+    #ifdef DEBUG_WOLFSSL
+    /* print off helper buffer sizes for use with static memory
+     * printing to stderr incase of debug mode turned on */
+    fprintf(stderr, "static memory management size = %d\n",
+            wolfSSL_MemoryPaddingSz());
+    fprintf(stderr, "calculated optimum general buffer size = %d\n",
+            wolfSSL_StaticBufferSz(memory, sizeof(memory), 0));
+    fprintf(stderr, "calculated optimum IO buffer size      = %d\n",
+            wolfSSL_StaticBufferSz(memoryIO, sizeof(memoryIO),
+                                                  WOLFMEM_IO_POOL_FIXED));
+    #endif /* DEBUG_WOLFSSL */
+
     if (wolfSSL_CTX_load_static_memory(&ctx, method, memory, sizeof(memory),0,1)
             != SSL_SUCCESS)
         err_sys("unable to load static memory and create ctx");

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -643,16 +643,8 @@ int wolfSSL_GetObjectSize(void)
 
 int wolfSSL_init_memory_heap(WOLFSSL_HEAP* heap)
 {
-    /* default size of chunks of memory to seperate into
-     * having session certs enabled makes a 21k SSL struct */
-#ifndef SESSION_CERTS
-    word32 wc_defaultMemSz[WOLFMEM_DEF_BUCKETS] =
-                           { 64, 128, 256, 512, 1024, 2432, 3456, 4544, 16128 };
-#else
-    word32 wc_defaultMemSz[WOLFMEM_DEF_BUCKETS] =
-                           { 64, 128, 256, 512, 1024, 2432, 3456, 4544, 21056 };
-#endif
-    word32 wc_defaultDist[WOLFMEM_DEF_BUCKETS] = { 8, 4, 4, 12, 4, 5, 2, 1, 1 };
+    word32 wc_MemSz[WOLFMEM_DEF_BUCKETS] = { WOLFMEM_BUCKETS };
+    word32 wc_Dist[WOLFMEM_DEF_BUCKETS]  = { WOLFMEM_DIST };
 
     if (heap == NULL) {
         return BAD_FUNC_ARG;
@@ -660,11 +652,8 @@ int wolfSSL_init_memory_heap(WOLFSSL_HEAP* heap)
 
     XMEMSET(heap, 0, sizeof(WOLFSSL_HEAP));
 
-    /* default pool sizes and distribution, else leave a 0's for now */
-    #if WOLFMEM_DEF_BUCKETS == WOLFMEM_MAX_BUCKETS
-        XMEMCPY(heap->sizeList, wc_defaultMemSz, sizeof(wc_defaultMemSz));
-        XMEMCPY(heap->distList, wc_defaultDist, sizeof(wc_defaultMemSz));
-    #endif
+    XMEMCPY(heap->sizeList, wc_MemSz, sizeof(wc_MemSz));
+    XMEMCPY(heap->distList, wc_Dist,  sizeof(wc_Dist));
 
     if (InitMutex(&(heap->memory_mutex)) != 0) {
         WOLFSSL_MSG("Error creating heap memory mutex");

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -71,10 +71,26 @@ WOLFSSL_API int wolfSSL_SetAllocators(wolfSSL_Malloc_cb  malloc_function,
 
 #ifdef WOLFSSL_STATIC_MEMORY
     #define WOLFSSL_STATIC_TIMEOUT 1
-    #define WOLFSSL_STATIC_ALIGN 16
-    #define WOLFMEM_MAX_BUCKETS  9
+    #ifndef WOLFSSL_STATIC_ALIGN
+        #define WOLFSSL_STATIC_ALIGN 16
+    #endif
+    #ifndef WOLFMEM_MAX_BUCKETS
+        #define WOLFMEM_MAX_BUCKETS  9
+    #endif
     #define WOLFMEM_DEF_BUCKETS  9     /* number of default memory blocks */
     #define WOLFMEM_IO_SZ        16992 /* 16 byte aligned */
+    #ifndef WOLFMEM_BUCKETS
+        /* default size of chunks of memory to seperate into
+         * having session certs enabled makes a 21k SSL struct */
+        #ifndef SESSION_CERTS
+            #define WOLFMEM_BUCKETS 64,128,256,512,1024,2432,3456,4544,16128
+        #else
+            #define WOLFMEM_BUCKETS 64,128,256,512,1024,2432,3456,4544,21056
+        #endif
+    #endif
+    #ifndef WOLFMEM_DIST
+        #define WOLFMEM_DIST    8,4,4,12,4,5,2,1,1
+    #endif
 
     /* flags for loading static memory (one hot bit) */
     #define WOLFMEM_GENERAL       0x01
@@ -147,6 +163,9 @@ WOLFSSL_API int wolfSSL_SetAllocators(wolfSSL_Malloc_cb  malloc_function,
                                                       WOLFSSL_MEM_STATS* stats);
     WOLFSSL_LOCAL int SetFixedIO(WOLFSSL_HEAP* heap, wc_Memory** io);
     WOLFSSL_LOCAL int FreeFixedIO(WOLFSSL_HEAP* heap, wc_Memory** io);
+
+    WOLFSSL_API int wolfSSL_StaticBufferSz(byte* buffer, word32 sz, int flag);
+    WOLFSSL_API int wolfSSL_MemoryPaddingSz(void);
 #endif /* WOLFSSL_STATIC_MEMORY */
 
 #ifdef __cplusplus


### PR DESCRIPTION
This gives helper functions for determining the optimum buffer size to use depending on static memory buckets and distribution. Using the returned value from wolfSSL_StaticBufferSz to adjust a users buffer size will allow for the most efficient use of memory.