### PR TITLE
Fix for failing OID check with "ocspstapling2" enabled

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -653,6 +653,10 @@ WOLFSSL_LOCAL int GetInt(mp_int* mpi, const byte* input, word32* inOutIdx,
     WOLFSSL_LOCAL int EncodeObjectId(const word16* in, word32 inSz,
         byte* out, word32* outSz);
 #endif
+#ifdef HAVE_OID_DECODING
+    WOLFSSL_LOCAL int DecodeObjectId(const byte* in, word32 inSz,
+        word16* out, word32* outSz);
+#endif
 WOLFSSL_LOCAL int GetObjectId(const byte* input, word32* inOutIdx, word32* oid,
                               word32 oidType, word32 maxIdx);
 WOLFSSL_LOCAL int GetAlgoId(const byte* input, word32* inOutIdx, word32* oid,


### PR DESCRIPTION
Fix for failing OID check with "ocspstapling2" enabled. Found OID type in "ToTraditional" that should be keyType, not sigType. Added optional OID decode function and optional OID info dump in "GetObjectId" (both off by default).