### PR TITLE
only check server's cert key encipher on client for RSA key exchange

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6489,6 +6489,7 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 #ifndef IGNORE_KEY_EXTENSIONS
         if (dCert->extKeyUsageSet) {
             if ((ssl->specs.kea == rsa_kea) &&
+                (ssl->options.side == WOLFSSL_CLIENT_END) &&
                 (dCert->extKeyUsage & KEYUSE_KEY_ENCIPHER) == 0) {
                 ret = KEYUSE_ENCIPHER_E;
             }


### PR DESCRIPTION
To send client key exchange for RSA, the client needs a server key that has key encipherment set. If The server doesn't encrypt keys, with the client's key so it can ignore that bit.