### PR TITLE
change priority of cipher suite TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2176,13 +2176,6 @@ void InitSuites(Suites* suites, ProtocolVersion pv, word16 haveRSA,
     }
 #endif
 
-#ifdef BUILD_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
-    if (tls && haveDH && haveRSA) {
-        suites->suites[idx++] = 0;
-        suites->suites[idx++] = TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA;
-    }
-#endif
-
 #ifdef BUILD_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
     if (tls1_2 && haveDH && haveRSA) {
         suites->suites[idx++] = 0;
@@ -2211,6 +2204,13 @@ void InitSuites(Suites* suites, ProtocolVersion pv, word16 haveRSA,
     if (tls && haveDH && haveRSA) {
         suites->suites[idx++] = 0;
         suites->suites[idx++] = TLS_DHE_RSA_WITH_AES_128_CBC_SHA;
+    }
+#endif
+
+#ifdef BUILD_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+    if (tls && haveDH && haveRSA) {
+        suites->suites[idx++] = 0;
+        suites->suites[idx++] = TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA;
     }
 #endif
 


### PR DESCRIPTION
This lowers the default priority of TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA. It was added for MYSQL test "ssl-sha512" where priority of cipher suite was not an issue since the test is explicitly setting the cipher suite. 