### PR TITLE
Fixed issue with CRL check and zero pad

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5307,26 +5307,30 @@ WOLFSSL_LOCAL int GetSerialNumber(const byte* input, word32* inOutIdx,
         return ASN_PARSE_E;
     }
 
+    /* serial size check */
     if (*serialSz < 0 || *serialSz > EXTERNAL_SERIAL_SIZE) {
         WOLFSSL_MSG("Serial size bad");
         return ASN_PARSE_E;
     }
 
-    /* serial size check */
+    /* serial size check against max index */
     if ((*inOutIdx + *serialSz) > maxIdx) {
         WOLFSSL_MSG("Bad idx serial");
         return BUFFER_E;
     }
 
-    /* skip padding */
-    if (input[*inOutIdx] == 0x00) {
-        *serialSz -= 1;
-        *inOutIdx += 1;
-    }
+    /* only check padding and return serial if length is greater than 1 */
+    if (*serialSz > 0) {
+        /* skip padding */
+        if (input[*inOutIdx] == 0x00) {
+            *serialSz -= 1;
+            *inOutIdx += 1;
+        }
 
-    /* return serial */
-    XMEMCPY(serial, &input[*inOutIdx], *serialSz);
-    *inOutIdx += *serialSz;
+        /* return serial */
+        XMEMCPY(serial, &input[*inOutIdx], *serialSz);
+        *inOutIdx += *serialSz;
+    }
 
     return result;
 }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5291,6 +5291,10 @@ WOLFSSL_LOCAL int GetSerialNumber(const byte* input, word32* inOutIdx,
     }
 
     /* First byte is ASN type */
+    if ((*inOutIdx+1) > maxIdx) {
+        WOLFSSL_MSG("Bad idx first");
+        return BUFFER_E;
+    }
     b = input[*inOutIdx];
     *inOutIdx += 1;
 
@@ -5303,9 +5307,15 @@ WOLFSSL_LOCAL int GetSerialNumber(const byte* input, word32* inOutIdx,
         return ASN_PARSE_E;
     }
 
-    if (*serialSz > EXTERNAL_SERIAL_SIZE) {
-        WOLFSSL_MSG("Serial Size too big");
+    if (*serialSz < 0 || *serialSz > EXTERNAL_SERIAL_SIZE) {
+        WOLFSSL_MSG("Serial size bad");
         return ASN_PARSE_E;
+    }
+
+    /* serial size check */
+    if ((*inOutIdx + *serialSz) > maxIdx) {
+        WOLFSSL_MSG("Bad idx serial");
+        return BUFFER_E;
     }
 
     /* skip padding */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -670,6 +670,8 @@ WOLFSSL_LOCAL word32 SetSet(word32 len, byte* output);
 WOLFSSL_LOCAL word32 SetAlgoID(int algoOID,byte* output,int type,int curveSz);
 WOLFSSL_LOCAL int SetMyVersion(word32 version, byte* output, int header);
 WOLFSSL_LOCAL int SetSerialNumber(const byte* sn, word32 snSz, byte* output);
+WOLFSSL_LOCAL int GetSerialNumber(const byte* input, word32* inOutIdx,
+    byte* serial, int* serialSz, word32 maxIdx);
 WOLFSSL_LOCAL int GetNameHash(const byte* source, word32* idx, byte* hash,
                              int maxIdx);
 


### PR DESCRIPTION
The GetRevoked function was not trimming pad, while "GetCertHeader" was. Added new ASN "GetSerialNumber" function and implemented it in three places in asn.c, which removes duplicate code and improves performance in "GetCertHeader".