### PR TITLE
Added support for static memory with wolfCrypt

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -659,7 +659,7 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
         err_sys("unable to load static memory and create ctx");
 #else
     ctx = SSL_CTX_new(method(NULL));
-#endif
+#endif /* WOLFSSL_STATIC_MEMORY */
     if (ctx == NULL)
         err_sys("unable to get ctx");
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -93,7 +93,9 @@
 #ifdef WOLFSSL_ASYNC_CRYPT
     #include <wolfssl/wolfcrypt/async.h>
 #endif
-static int devId = INVALID_DEVID;
+#if defined(WOLFSSL_ASYNC_CRYPT) || defined(HAVE_ECC)
+    static int devId = INVALID_DEVID;
+#endif
 
 #ifdef HAVE_WNR
     const char* wnrConfigFile = "wnr-example.conf";

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1897,10 +1897,6 @@ WOLFSSL_LOCAL int TLSX_ValidateQSHScheme(TLSX** extensions, word16 name);
 #endif /* HAVE_QSH */
 
 
-#ifdef WOLFSSL_STATIC_MEMORY
-WOLFSSL_LOCAL int wolfSSL_init_memory_heap(WOLFSSL_HEAP* heap);
-#endif
-
 /* wolfSSL context type */
 struct WOLFSSL_CTX {
     WOLFSSL_METHOD* method;

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -33,36 +33,42 @@
     extern "C" {
 #endif
 
-#ifdef WOLFSSL_DEBUG_MEMORY
-    typedef void *(*wolfSSL_Malloc_cb)(size_t size, const char* func, unsigned int line);
-    typedef void (*wolfSSL_Free_cb)(void *ptr, const char* func, unsigned int line);
-    typedef void *(*wolfSSL_Realloc_cb)(void *ptr, size_t size, const char* func, unsigned int line);
-
-    /* Public in case user app wants to use XMALLOC/XFREE */
-    WOLFSSL_API void* wolfSSL_Malloc(size_t size, const char* func, unsigned int line);
-    WOLFSSL_API void  wolfSSL_Free(void *ptr, const char* func, unsigned int line);
-    WOLFSSL_API void* wolfSSL_Realloc(void *ptr, size_t size, const char* func, unsigned int line);
-
-#else
-    #if defined(WOLFSSL_STATIC_MEMORY)
-    typedef void *(*wolfSSL_Malloc_cb)(size_t size, void* heap, int type);
-    typedef void (*wolfSSL_Free_cb)(void *ptr, void* heap, int type);
-    typedef void *(*wolfSSL_Realloc_cb)(void *ptr, size_t size,
-                                                          void* heap, int type);
-    WOLFSSL_API void* wolfSSL_Malloc(size_t size, void* heap, int type);
-    WOLFSSL_API void  wolfSSL_Free(void *ptr, void* heap, int type);
-    WOLFSSL_API void* wolfSSL_Realloc(void *ptr, size_t size,
-                                                          void* heap, int type);
+#ifdef WOLFSSL_STATIC_MEMORY
+    #ifdef WOLFSSL_DEBUG_MEMORY
+        typedef void *(*wolfSSL_Malloc_cb)(size_t size, void* heap, int type, const char* func, unsigned int line);
+        typedef void (*wolfSSL_Free_cb)(void *ptr, void* heap, int type, const char* func, unsigned int line);
+        typedef void *(*wolfSSL_Realloc_cb)(void *ptr, size_t size, void* heap, int type, const char* func, unsigned int line);
+        WOLFSSL_API void* wolfSSL_Malloc(size_t size, void* heap, int type, const char* func, unsigned int line);
+        WOLFSSL_API void  wolfSSL_Free(void *ptr, void* heap, int type, const char* func, unsigned int line);
+        WOLFSSL_API void* wolfSSL_Realloc(void *ptr, size_t size, void* heap, int type, const char* func, unsigned int line);
     #else
-    typedef void *(*wolfSSL_Malloc_cb)(size_t size);
-    typedef void (*wolfSSL_Free_cb)(void *ptr);
-    typedef void *(*wolfSSL_Realloc_cb)(void *ptr, size_t size);
-    /* Public in case user app wants to use XMALLOC/XFREE */
-    WOLFSSL_API void* wolfSSL_Malloc(size_t size);
-    WOLFSSL_API void  wolfSSL_Free(void *ptr);
-    WOLFSSL_API void* wolfSSL_Realloc(void *ptr, size_t size);
-    #endif
-#endif
+        typedef void *(*wolfSSL_Malloc_cb)(size_t size, void* heap, int type);
+        typedef void (*wolfSSL_Free_cb)(void *ptr, void* heap, int type);
+        typedef void *(*wolfSSL_Realloc_cb)(void *ptr, size_t size, void* heap, int type);
+        WOLFSSL_API void* wolfSSL_Malloc(size_t size, void* heap, int type);
+        WOLFSSL_API void  wolfSSL_Free(void *ptr, void* heap, int type);
+        WOLFSSL_API void* wolfSSL_Realloc(void *ptr, size_t size, void* heap, int type);
+    #endif /* WOLFSSL_DEBUG_MEMORY */
+#else
+    #ifdef WOLFSSL_DEBUG_MEMORY
+        typedef void *(*wolfSSL_Malloc_cb)(size_t size, const char* func, unsigned int line);
+        typedef void (*wolfSSL_Free_cb)(void *ptr, const char* func, unsigned int line);
+        typedef void *(*wolfSSL_Realloc_cb)(void *ptr, size_t size, const char* func, unsigned int line);
+
+        /* Public in case user app wants to use XMALLOC/XFREE */
+        WOLFSSL_API void* wolfSSL_Malloc(size_t size, const char* func, unsigned int line);
+        WOLFSSL_API void  wolfSSL_Free(void *ptr, const char* func, unsigned int line);
+        WOLFSSL_API void* wolfSSL_Realloc(void *ptr, size_t size, const char* func, unsigned int line);
+    #else
+        typedef void *(*wolfSSL_Malloc_cb)(size_t size);
+        typedef void (*wolfSSL_Free_cb)(void *ptr);
+        typedef void *(*wolfSSL_Realloc_cb)(void *ptr, size_t size);
+        /* Public in case user app wants to use XMALLOC/XFREE */
+        WOLFSSL_API void* wolfSSL_Malloc(size_t size);
+        WOLFSSL_API void  wolfSSL_Free(void *ptr);
+        WOLFSSL_API void* wolfSSL_Realloc(void *ptr, size_t size);
+    #endif /* WOLFSSL_DEBUG_MEMORY */
+#endif /* WOLFSSL_STATIC_MEMORY */
 
 /* Public set function */
 WOLFSSL_API int wolfSSL_SetAllocators(wolfSSL_Malloc_cb  malloc_function,
@@ -156,7 +162,10 @@ WOLFSSL_API int wolfSSL_SetAllocators(wolfSSL_Malloc_cb  malloc_function,
         byte        haFlag; /* flag used for checking handshake count */
     } WOLFSSL_HEAP_HINT;
 
+    WOLFSSL_API int wc_LoadStaticMemory(WOLFSSL_HEAP_HINT** pHint,
+            unsigned char* buf, unsigned int sz, int flag, int max);
 
+    WOLFSSL_LOCAL int wolfSSL_init_memory_heap(WOLFSSL_HEAP* heap);
     WOLFSSL_LOCAL int wolfSSL_load_static_memory(byte* buffer, word32 sz,
                                                   int flag, WOLFSSL_HEAP* heap);
     WOLFSSL_LOCAL int wolfSSL_GetMemStats(WOLFSSL_HEAP* heap,

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1251,6 +1251,9 @@ static char *fgets(char *buff, int sz, FILE *fp)
 
 /* restriction with static memory */
 #ifdef WOLFSSL_STATIC_MEMORY
+    #if defined(HAVE_IO_POOL) || defined(XMALLOC_USER) || defined(NO_WOLFSSL_MEMORY)
+         #error static memory cannot be used with HAVE_IO_POOL, XMALLOC_USER or NO_WOLFSSL_MEMORY
+    #endif
     #ifndef USE_FAST_MATH
         #error static memory requires fast math please define USE_FAST_MATH
     #endif
@@ -1258,6 +1261,8 @@ static char *fgets(char *buff, int sz, FILE *fp)
         #error static memory does not support small stack please undefine
     #endif
 #endif /* WOLFSSL_STATIC_MEMORY */
+
+
 /* Place any other flags or defines here */
 
 #if defined(WOLFSSL_MYSQL_COMPATIBLE) && defined(_WIN32) \

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -171,24 +171,22 @@
 	/* default to libc stuff */
 	/* XREALLOC is used once in normal math lib, not in fast math lib */
 	/* XFREE on some embeded systems doesn't like free(0) so test  */
-	#if defined(XMALLOC_USER)
+	#if defined(HAVE_IO_POOL)
+		WOLFSSL_API void* XMALLOC(size_t n, void* heap, int type);
+		WOLFSSL_API void* XREALLOC(void *p, size_t n, void* heap, int type);
+		WOLFSSL_API void XFREE(void *p, void* heap, int type);
+	#elif defined(XMALLOC_USER)
 	    /* prototypes for user heap override functions */
 	    #include <stddef.h>  /* for size_t */
 	    extern void *XMALLOC(size_t n, void* heap, int type);
 	    extern void *XREALLOC(void *p, size_t n, void* heap, int type);
 	    extern void XFREE(void *p, void* heap, int type);
-        #ifdef WOLFSSL_STATIC_MEMORY /* don't use wolfSSL static memory either*/
-            #undef WOLFSSL_STATIC_MEMORY
-        #endif
 	#elif defined(NO_WOLFSSL_MEMORY)
 	    /* just use plain C stdlib stuff if desired */
 	    #include <stdlib.h>
 	    #define XMALLOC(s, h, t)     ((void)h, (void)t, malloc((s)))
 	    #define XFREE(p, h, t)       {void* xp = (p); if((xp)) free((xp));}
 	    #define XREALLOC(p, n, h, t) realloc((p), (n))
-        #ifdef WOLFSSL_STATIC_MEMORY /* don't use wolfSSL static memory either*/
-            #undef WOLFSSL_STATIC_MEMORY
-        #endif
 	#elif !defined(MICRIUM_MALLOC) && !defined(EBSNET) \
 	        && !defined(WOLFSSL_SAFERTOS) && !defined(FREESCALE_MQX) \
 	        && !defined(FREESCALE_KSDK_MQX) && !defined(FREESCALE_FREE_RTOS) \
@@ -196,19 +194,27 @@
             && !defined(WOLFSSL_uITRON4) && !defined(WOLFSSL_uTKERNEL2)
 	    /* default C runtime, can install different routines at runtime via cbs */
 	    #include <wolfssl/wolfcrypt/memory.h>
-       #if defined(WOLFSSL_DEBUG_MEMORY) && !defined(WOLFSSL_STATIC_MEMORY)
-           #define XMALLOC(s, h, t)     ((void)h, (void)t, wolfSSL_Malloc((s), __func__, __LINE__))
-           #define XFREE(p, h, t)       {void* xp = (p); if((xp)) wolfSSL_Free((xp), __func__, __LINE__);}
-           #define XREALLOC(p, n, h, t) wolfSSL_Realloc((p), (n), __func__, __LINE__)
-       #elif defined(WOLFSSL_STATIC_MEMORY)
-           #define XMALLOC(s, h, t)     wolfSSL_Malloc((s), (h), (t))
-           #define XFREE(p, h, t)       {void* xp = (p); if((xp)) wolfSSL_Free((xp), (h), (t));}
-           #define XREALLOC(p, n, h, t) wolfSSL_Realloc((p), (n), (h), (t))
-       #else
-           #define XMALLOC(s, h, t)     ((void)h, (void)t, wolfSSL_Malloc((s)))
-           #define XFREE(p, h, t)       {void* xp = (p); if((xp)) wolfSSL_Free((xp));}
-           #define XREALLOC(p, n, h, t) wolfSSL_Realloc((p), (n))
-       #endif
+        #ifdef WOLFSSL_STATIC_MEMORY
+            #ifdef WOLFSSL_DEBUG_MEMORY
+				#define XMALLOC(s, h, t)     wolfSSL_Malloc((s), (h), (t), __func__, __LINE__)
+				#define XFREE(p, h, t)       {void* xp = (p); if((xp)) wolfSSL_Free((xp), (h), (t), __func__, __LINE__);}
+				#define XREALLOC(p, n, h, t) wolfSSL_Realloc((p), (n), (h), (t), __func__, __LINE__)
+            #else
+	            #define XMALLOC(s, h, t)     wolfSSL_Malloc((s), (h), (t))
+				#define XFREE(p, h, t)       {void* xp = (p); if((xp)) wolfSSL_Free((xp), (h), (t));}
+				#define XREALLOC(p, n, h, t) wolfSSL_Realloc((p), (n), (h), (t))
+            #endif /* WOLFSSL_DEBUG_MEMORY */
+        #else
+            #ifdef WOLFSSL_DEBUG_MEMORY
+				#define XMALLOC(s, h, t)     ((void)h, (void)t, wolfSSL_Malloc((s), __func__, __LINE__))
+				#define XFREE(p, h, t)       {void* xp = (p); if((xp)) wolfSSL_Free((xp), __func__, __LINE__);}
+				#define XREALLOC(p, n, h, t) wolfSSL_Realloc((p), (n), __func__, __LINE__)
+            #else
+	            #define XMALLOC(s, h, t)     ((void)h, (void)t, wolfSSL_Malloc((s)))
+	            #define XFREE(p, h, t)       {void* xp = (p); if((xp)) wolfSSL_Free((xp));}
+	            #define XREALLOC(p, n, h, t) wolfSSL_Realloc((p), (n))
+            #endif /* WOLFSSL_DEBUG_MEMORY */
+        #endif /* WOLFSSL_STATIC_MEMORY */
 	#endif
 
 


### PR DESCRIPTION
Adds new "wc_LoadStaticMemory" function and moves "wolfSSL_init_memory_heap" into wolfCrypt layer. Enhanced wolfCrypt test and benchmark to use the wolfCrypt static memory if enabled. Added support for static memory with "WOLFSSL_DEBUG_MEMORY" defined.