### PR TITLE
Fix build issue with ASN enabled and no HMAC

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6842,6 +6842,8 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     int     ret;
     ecc_key userA, userB, pubKey;
 
+    (void)testVerifyCount;
+
     wc_ecc_init(&userA);
     wc_ecc_init(&userB);
     wc_ecc_init(&pubKey);


### PR DESCRIPTION
Fix build issue with ASN enabled and no HMAC (missing MAX_DIGEST_SIZE). Switch to using WC_MAX_DIGEST_SIZE from hash.h, which is always available. Fixed build error with unused "testVerifyCount" if "NO_ECC_SIGN" or "NO_ECC_VERIFY". Added small stack option for digest in MakeSignature.