### PR TITLE
Change misc.c error to warning when trying to be compiled and inline enabled

### DIFF
--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -46,8 +46,9 @@
 
 /* Check for if compiling misc.c when not needed. */
 #if !defined(WOLFSSL_MISC_INCLUDED) && !defined(NO_INLINE)
-    #error misc.c does not need to be compiled when not defined NO_INLINE
-#endif
+    #warning misc.c does not need to be compiled when using inline (NO_INLINE not defined)
+
+#else
 
 #ifdef INTEL_INTRINSICS
 
@@ -202,5 +203,8 @@ STATIC INLINE int ConstantCompare(const byte* a, const byte* b, int length)
 }
 
 #undef STATIC
+
+
+#endif /* !WOLFSSL_MISC_INCLUDED && !NO_INLINE */
 
 #endif /* WOLF_CRYPT_MISC_C */


### PR DESCRIPTION
Change misc.c error to warning and exclude the misc.c code from being compiled. Most people include all .c files and by default inlining is allowed, which in turn causes an #error in misc.c and it must be excluded. Since we know its already been properly included there is no reason to throw error here. Instead, show warning and exclude code in .c file.