### PR TITLE
help static analysis tools

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1186,7 +1186,7 @@ int wc_RsaPrivateDecrypt(const byte* in, word32 inLen, byte* out, word32 outLen,
         XFREE(tmp, key->heap, DYNAMIC_TYPE_RSA);
         return plainLen;
     }
-    if (plainLen > (int)outLen)
+    if (plainLen > (int)outLen || pad == NULL)
         plainLen = BAD_FUNC_ARG;
     else
         XMEMCPY(out, pad, plainLen);
@@ -1305,7 +1305,7 @@ int wc_RsaSSL_Verify(const byte* in, word32 inLen, byte* out, word32 outLen,
         return plainLen;
     }
 
-    if (plainLen > (int)outLen)
+    if (plainLen > (int)outLen || pad == NULL)
         plainLen = BAD_FUNC_ARG;
     else
         XMEMCPY(out, pad, plainLen);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -3957,6 +3957,7 @@ int memory_test(void)
         return -113; /* should round to 0 since struct + bucket will not fit */
     }
 
+    (void)dist; /* avoid static analysis warning of variable not used */
     return 0;
 }
 #endif /* WOLFSSL_STATIC_MEMORY */


### PR DESCRIPTION
These changes are to help two of the static analyzers used with testing.

The change in rsa.c is to silence a NULL dereference false positive and the addition of (void)dist is to silence an unused variable warning.