### PR TITLE
Support for Atmel ATECC508A

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2966,15 +2966,29 @@ int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* out,
 }
 
 int EccSharedSecret(WOLFSSL* ssl, ecc_key* priv_key, ecc_key* pub_key,
-    byte* out, word32* outSz)
+        byte* pubKeyDer, word32* pubKeySz, byte* out, word32* outlen,
+        int side, void* ctx)
 {
     int ret;
 
     (void)ssl;
+    (void)pubKeyDer;
+    (void)pubKeySz;
+    (void)side;
+    (void)ctx;
 
     WOLFSSL_ENTER("EccSharedSecret");
 
-    ret = wc_ecc_shared_secret(priv_key, pub_key, out, outSz);
+#ifdef HAVE_PK_CALLBACKS
+    if (ssl->ctx->EccSharedSecretCb) {
+        ret = ssl->ctx->EccSharedSecretCb(ssl, pubKeyDer, pubKeySz,
+            out, outlen, side, ctx);
+    }
+    else
+#endif
+    {
+        ret = wc_ecc_shared_secret(priv_key, pub_key, out, outlen);
+    }
 
     /* Handle async pending response */
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -15437,20 +15451,25 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         ERROR_OUT(NO_PEER_KEY, exit_scke);
                     }
 
-                    /* create private key */
-                    ssl->sigKey = XMALLOC(sizeof(ecc_key),
-                                               ssl->heap, DYNAMIC_TYPE_ECC);
-                    if (ssl->sigKey == NULL) {
-                        ERROR_OUT(MEMORY_E, exit_scke);
-                    }
-                    ssl->sigType = DYNAMIC_TYPE_ECC;
+                #ifdef HAVE_PK_CALLBACKS
+                    if (ssl->ctx->EccSharedSecretCb == NULL)
+                #endif
+                    {
+                        /* create private key */
+                        ssl->sigKey = XMALLOC(sizeof(ecc_key),
+                                                   ssl->heap, DYNAMIC_TYPE_ECC);
+                        if (ssl->sigKey == NULL) {
+                            ERROR_OUT(MEMORY_E, exit_scke);
+                        }
+                        ssl->sigType = DYNAMIC_TYPE_ECC;
 
-                    ret = wc_ecc_init_ex((ecc_key*)ssl->sigKey, ssl->heap,
-                                                                ssl->devId);
-                    if (ret != 0) {
-                        goto exit_scke;
+                        ret = wc_ecc_init_ex((ecc_key*)ssl->sigKey, ssl->heap,
+                                                                    ssl->devId);
+                        if (ret != 0) {
+                            goto exit_scke;
+                        }
+                        ret = EccMakeKey(ssl, (ecc_key*)ssl->sigKey, ssl->peerEccKey);
                     }
-                    ret = EccMakeKey(ssl, (ecc_key*)ssl->sigKey, ssl->peerEccKey);
                     break;
             #endif /* HAVE_ECC && !NO_PSK */
             #ifdef HAVE_NTRU
@@ -15463,41 +15482,46 @@ int SendClientKeyExchange(WOLFSSL* ssl)
             #ifdef HAVE_ECC
                 case ecc_diffie_hellman_kea:
                 {
-                    ecc_key* peerKey;
+                #ifdef HAVE_PK_CALLBACKS
+                    if (ssl->ctx->EccSharedSecretCb == NULL)
+                #endif
+                    {
+                        ecc_key* peerKey;
 
-                    if (ssl->specs.static_ecdh) {
-                        /* TODO: EccDsa is really fixed Ecc change naming */
-                        if (!ssl->peerEccDsaKey || !ssl->peerEccDsaKeyPresent ||
-                                                   !ssl->peerEccDsaKey->dp) {
+                        if (ssl->specs.static_ecdh) {
+                            /* TODO: EccDsa is really fixed Ecc change naming */
+                            if (!ssl->peerEccDsaKey || !ssl->peerEccDsaKeyPresent ||
+                                                       !ssl->peerEccDsaKey->dp) {
+                                ERROR_OUT(NO_PEER_KEY, exit_scke);
+                            }
+                            peerKey = ssl->peerEccDsaKey;
+                        }
+                        else {
+                            if (!ssl->peerEccKey || !ssl->peerEccKeyPresent ||
+                                                    !ssl->peerEccKey->dp) {
+                                ERROR_OUT(NO_PEER_KEY, exit_scke);
+                            }
+                            peerKey = ssl->peerEccKey;
+                        }
+                        if (peerKey == NULL) {
                             ERROR_OUT(NO_PEER_KEY, exit_scke);
                         }
-                        peerKey = ssl->peerEccDsaKey;
-                    }
-                    else {
-                        if (!ssl->peerEccKey || !ssl->peerEccKeyPresent ||
-                                                !ssl->peerEccKey->dp) {
-                            ERROR_OUT(NO_PEER_KEY, exit_scke);
+
+                        /* create private key */
+                        ssl->sigKey = XMALLOC(sizeof(ecc_key),
+                                                   ssl->heap, DYNAMIC_TYPE_ECC);
+                        if (ssl->sigKey == NULL) {
+                            ERROR_OUT(MEMORY_E, exit_scke);
                         }
-                        peerKey = ssl->peerEccKey;
-                    }
-                    if (peerKey == NULL) {
-                        ERROR_OUT(NO_PEER_KEY, exit_scke);
-                    }
+                        ssl->sigType = DYNAMIC_TYPE_ECC;
 
-                    /* create private key */
-                    ssl->sigKey = XMALLOC(sizeof(ecc_key),
-                                               ssl->heap, DYNAMIC_TYPE_ECC);
-                    if (ssl->sigKey == NULL) {
-                        ERROR_OUT(MEMORY_E, exit_scke);
+                        ret = wc_ecc_init_ex((ecc_key*)ssl->sigKey, ssl->heap,
+                                                                    ssl->devId);
+                        if (ret != 0) {
+                            goto exit_scke;
+                        }
+                        ret = EccMakeKey(ssl, (ecc_key*)ssl->sigKey, peerKey);
                     }
-                    ssl->sigType = DYNAMIC_TYPE_ECC;
-
-                    ret = wc_ecc_init_ex((ecc_key*)ssl->sigKey, ssl->heap,
-                                                                ssl->devId);
-                    if (ret != 0) {
-                        goto exit_scke;
-                    }
-                    ret = EccMakeKey(ssl, (ecc_key*)ssl->sigKey, peerKey);
                     break;
                 }
             #endif /* HAVE_ECC */
@@ -15649,21 +15673,20 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                     output += esSz;
                     encSz = esSz + OPAQUE16_LEN;
 
-                    /* Place ECC key in output buffer, leaving room for size */
+                    /* length is used for public key size */
                     *length = MAX_ENCRYPT_SZ;
-                    ret = wc_ecc_export_x963((ecc_key*)ssl->sigKey,
-                                                        output + 1, length);
-                    if (ret != 0) {
-                        ERROR_OUT(ECC_EXPORT_ERROR, exit_scke);
+
+                #ifdef HAVE_PK_CALLBACKS
+                    if (ssl->ctx->EccSharedSecretCb == NULL)
+                #endif
+                    {
+                        /* Place ECC key in buffer, leaving room for size */
+                        ret = wc_ecc_export_x963((ecc_key*)ssl->sigKey,
+                                                output + OPAQUE8_LEN, length);
+                        if (ret != 0) {
+                            ERROR_OUT(ECC_EXPORT_ERROR, exit_scke);
+                        }
                     }
-
-                    *output = (byte)*length; /* place size of key in output buffer */
-                    encSz += *length + 1;
-
-                    /* Create shared ECC key leaving room at the begining
-                       of buffer for size of shared key. Note sizeof
-                       preMasterSecret is ENCRYPT_LEN currently 512 */
-                    *length = sizeof(ssl->arrays->preMasterSecret) - OPAQUE16_LEN;
                     break;
                 }
             #endif /* HAVE_ECC && !NO_PSK */
@@ -15684,18 +15707,17 @@ int SendClientKeyExchange(WOLFSSL* ssl)
             #ifdef HAVE_ECC
                 case ecc_diffie_hellman_kea:
                 {
-                    /* precede export with 1 byte length */
-                    *length = MAX_ENCRYPT_SZ;
-                    ret = wc_ecc_export_x963((ecc_key*)ssl->sigKey,
-                                    encSecret + 1, length);
-                    if (ret != 0) {
-                        ERROR_OUT(ECC_EXPORT_ERROR, exit_scke);
+                #ifdef HAVE_PK_CALLBACKS
+                    if (ssl->ctx->EccSharedSecretCb == NULL)
+                #endif
+                    {
+                        /* Place ECC key in buffer, leaving room for size */
+                        ret = wc_ecc_export_x963((ecc_key*)ssl->sigKey,
+                                            encSecret + OPAQUE8_LEN, &encSz);
+                        if (ret != 0) {
+                            ERROR_OUT(ECC_EXPORT_ERROR, exit_scke);
+                        }
                     }
-
-                    encSecret[0] = (byte)*length;
-                    encSz = *length + 1;
-
-                    *length = sizeof(ssl->arrays->preMasterSecret);
                     break;
                 }
             #endif /* HAVE_ECC */
@@ -15778,10 +15800,22 @@ int SendClientKeyExchange(WOLFSSL* ssl)
             #if defined(HAVE_ECC) && !defined(NO_PSK)
                 case ecdhe_psk_kea:
                 {
-                    ret = EccSharedSecret(ssl, (ecc_key*)ssl->sigKey,
-                        ssl->peerEccKey,
+                    /* Create shared ECC key leaving room at the begining
+                       of buffer for size of shared key. */
+                    ssl->arrays->preMasterSz = ENCRYPT_LEN - OPAQUE16_LEN;
+
+                    ret = EccSharedSecret(ssl,
+                        (ecc_key*)ssl->sigKey, ssl->peerEccKey,
+                        output + OPAQUE8_LEN, length,
                         ssl->arrays->preMasterSecret + OPAQUE16_LEN,
-                        length);
+                        &ssl->arrays->preMasterSz,
+                        WOLFSSL_CLIENT_END,
+                    #ifdef HAVE_PK_CALLBACKS
+                        ssl->EccSharedSecretCtx
+                    #else
+                        NULL
+                    #endif
+                    );
                     break;
                 }
             #endif /* HAVE_ECC && !NO_PSK */
@@ -15815,8 +15849,20 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                     ecc_key* peerKey = (ssl->specs.static_ecdh) ?
                                 ssl->peerEccDsaKey : ssl->peerEccKey;
 
-                    ret = EccSharedSecret(ssl, (ecc_key*)ssl->sigKey, peerKey,
-                             ssl->arrays->preMasterSecret, length);
+                    ssl->arrays->preMasterSz = ENCRYPT_LEN;
+
+                    ret = EccSharedSecret(ssl,
+                        (ecc_key*)ssl->sigKey, peerKey,
+                        encSecret + OPAQUE8_LEN, &encSz,
+                        ssl->arrays->preMasterSecret,
+                        &ssl->arrays->preMasterSz,
+                        WOLFSSL_CLIENT_END,
+                    #ifdef HAVE_PK_CALLBACKS
+                        ssl->EccSharedSecretCtx
+                    #else
+                        NULL
+                    #endif
+                    );
                     break;
                 }
             #endif /* HAVE_ECC */
@@ -15861,6 +15907,11 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                 {
                     byte*  pms = ssl->arrays->preMasterSecret;
 
+                    /* validate args */
+                    if (output == NULL || *length == 0) {
+                        ERROR_OUT(BAD_FUNC_ARG, exit_scke);
+                    }
+
                     c16toa((word16)*length, output);
                     encSz += *length + OPAQUE16_LEN;
                     c16toa((word16)ssl->arrays->preMasterSz, pms);
@@ -15884,10 +15935,19 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                 {
                     byte* pms = ssl->arrays->preMasterSecret;
 
+                    /* validate args */
+                    if (output == NULL || *length > ENCRYPT_LEN) {
+                        ERROR_OUT(BAD_FUNC_ARG, exit_scke);
+                    }
+
+                    /* place size of public key in output buffer */
+                    *output = (byte)*length;
+                    encSz += *length + OPAQUE8_LEN;
+
                     /* Create pre master secret is the concatination of
                        eccSize + eccSharedKey + pskSize + pskKey */
-                    c16toa((word16)*length, pms);
-                    ssl->arrays->preMasterSz += OPAQUE16_LEN + *length;
+                    c16toa((word16)ssl->arrays->preMasterSz, pms);
+                    ssl->arrays->preMasterSz += OPAQUE16_LEN;
                     pms += ssl->arrays->preMasterSz;
 
                     c16toa((word16)ssl->arrays->psk_keySz, pms);
@@ -15910,7 +15970,9 @@ int SendClientKeyExchange(WOLFSSL* ssl)
             #ifdef HAVE_ECC
                 case ecc_diffie_hellman_kea:
                 {
-                    ssl->arrays->preMasterSz = *length;
+                    /* place size of public key in buffer */
+                    *encSecret = (byte)encSz;
+                    encSz += OPAQUE8_LEN;
                     break;
                 }
             #endif /* HAVE_ECC */
@@ -19839,11 +19901,6 @@ int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 #ifdef HAVE_ECC
                     case ecc_diffie_hellman_kea:
                     {
-                        if (!ssl->specs.static_ecdh &&
-                            ssl->eccTempKeyPresent == 0) {
-                            WOLFSSL_MSG("Ecc ephemeral key not made correctly");
-                            ERROR_OUT(ECC_MAKEKEY_ERROR, exit_dcke);
-                        }
                         break;
                     }
                 #endif /* HAVE_ECC */
@@ -19871,11 +19928,6 @@ int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         if (ssl->options.server_psk_cb == NULL) {
                             WOLFSSL_MSG("No server PSK callback set");
                             ERROR_OUT(PSK_KEY_ERROR, exit_dcke);
-                        }
-
-                        if (ssl->eccTempKeyPresent == 0) {
-                            WOLFSSL_MSG("Ecc ephemeral key not made correctly");
-                            ERROR_OUT(ECC_MAKEKEY_ERROR, exit_dcke);
                         }
                         break;
                     }
@@ -20093,42 +20145,47 @@ int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             ERROR_OUT(BUFFER_ERROR, exit_dcke);
                         }
 
-                        if (ssl->peerEccKey == NULL) {
-                            /* alloc/init on demand */
-                            ssl->peerEccKey = (ecc_key*)XMALLOC(sizeof(ecc_key),
-                                                      ssl->heap, DYNAMIC_TYPE_ECC);
+                    #ifdef HAVE_PK_CALLBACKS
+                        if (ssl->ctx->EccSharedSecretCb == NULL)
+                    #endif
+                        {
+                            if (!ssl->specs.static_ecdh &&
+                                ssl->eccTempKeyPresent == 0) {
+                                WOLFSSL_MSG("Ecc ephemeral key not made correctly");
+                                ERROR_OUT(ECC_MAKEKEY_ERROR, exit_dcke);
+                            }
+
                             if (ssl->peerEccKey == NULL) {
-                                WOLFSSL_MSG("PeerEccKey Memory error");
-                                ERROR_OUT(MEMORY_E, exit_dcke);
+                                /* alloc/init on demand */
+                                ssl->peerEccKey = (ecc_key*)XMALLOC(sizeof(ecc_key),
+                                                          ssl->heap, DYNAMIC_TYPE_ECC);
+                                if (ssl->peerEccKey == NULL) {
+                                    WOLFSSL_MSG("PeerEccKey Memory error");
+                                    ERROR_OUT(MEMORY_E, exit_dcke);
+                                }
+                                ret = wc_ecc_init_ex(ssl->peerEccKey, ssl->heap,
+                                                                    ssl->devId);
+                                if (ret != 0) {
+                                    goto exit_dcke;
+                                }
+                            } else if (ssl->peerEccKeyPresent) {  /* don't leak on reuse */
+                                wc_ecc_free(ssl->peerEccKey);
+                                ssl->peerEccKeyPresent = 0;
+                                ret = wc_ecc_init_ex(ssl->peerEccKey, ssl->heap,
+                                                                    ssl->devId);
+                                if (ret != 0) {
+                                    goto exit_dcke;
+                                }
                             }
-                            ret = wc_ecc_init_ex(ssl->peerEccKey, ssl->heap,
-                                                                ssl->devId);
-                            if (ret != 0) {
-                                goto exit_dcke;
+
+                            if (wc_ecc_import_x963_ex(input + idx, length, ssl->peerEccKey,
+                                    private_key->dp->id)) {
+                                ERROR_OUT(ECC_PEERKEY_ERROR, exit_dcke);
                             }
-                        } else if (ssl->peerEccKeyPresent) {  /* don't leak on reuse */
-                            wc_ecc_free(ssl->peerEccKey);
-                            ssl->peerEccKeyPresent = 0;
-                            ret = wc_ecc_init_ex(ssl->peerEccKey, ssl->heap,
-                                                                ssl->devId);
-                            if (ret != 0) {
-                                goto exit_dcke;
-                            }
+
+                            ssl->peerEccKeyPresent = 1;
                         }
 
-                        if (wc_ecc_import_x963_ex(input + idx, length, ssl->peerEccKey,
-                                private_key->dp->id)) {
-                            ERROR_OUT(ECC_PEERKEY_ERROR, exit_dcke);
-                        }
-
-                        idx += length;
-                        ssl->peerEccKeyPresent = 1;
-
-                        ssl->sigLen = sizeof(ssl->arrays->preMasterSecret);
-
-                        if (ret != 0) {
-                            goto exit_dcke;
-                        }
                         break;
                     }
                 #endif /* HAVE_ECC */
@@ -20229,42 +20286,45 @@ int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             ERROR_OUT(BUFFER_ERROR, exit_dcke);
                         }
 
-                        if (ssl->peerEccKey == NULL) {
-                            /* alloc/init on demand */
-                            ssl->peerEccKey = (ecc_key*)XMALLOC(sizeof(ecc_key),
-                                              ssl->heap, DYNAMIC_TYPE_ECC);
+                    #ifdef HAVE_PK_CALLBACKS
+                        if (ssl->ctx->EccSharedSecretCb == NULL)
+                    #endif
+                        {
+                            if (ssl->eccTempKeyPresent == 0) {
+                                WOLFSSL_MSG("Ecc ephemeral key not made correctly");
+                                ERROR_OUT(ECC_MAKEKEY_ERROR, exit_dcke);
+                            }
+
                             if (ssl->peerEccKey == NULL) {
-                                WOLFSSL_MSG("PeerEccKey Memory error");
-                                ERROR_OUT(MEMORY_E, exit_dcke);
+                                /* alloc/init on demand */
+                                ssl->peerEccKey = (ecc_key*)XMALLOC(sizeof(ecc_key),
+                                                  ssl->heap, DYNAMIC_TYPE_ECC);
+                                if (ssl->peerEccKey == NULL) {
+                                    WOLFSSL_MSG("PeerEccKey Memory error");
+                                    ERROR_OUT(MEMORY_E, exit_dcke);
+                                }
+                                ret = wc_ecc_init_ex(ssl->peerEccKey, ssl->heap,
+                                                                    ssl->devId);
+                                if (ret != 0) {
+                                    goto exit_dcke;
+                                }
                             }
-                            ret = wc_ecc_init_ex(ssl->peerEccKey, ssl->heap,
-                                                                ssl->devId);
-                            if (ret != 0) {
-                                goto exit_dcke;
+                            else if (ssl->peerEccKeyPresent) {  /* don't leak on reuse */
+                                wc_ecc_free(ssl->peerEccKey);
+                                ssl->peerEccKeyPresent = 0;
+                                ret = wc_ecc_init_ex(ssl->peerEccKey, ssl->heap,
+                                                                    ssl->devId);
+                                if (ret != 0) {
+                                    goto exit_dcke;
+                                }
                             }
-                        } else if (ssl->peerEccKeyPresent) {  /* don't leak on reuse */
-                            wc_ecc_free(ssl->peerEccKey);
-                            ssl->peerEccKeyPresent = 0;
-                            ret = wc_ecc_init_ex(ssl->peerEccKey, ssl->heap,
-                                                                ssl->devId);
-                            if (ret != 0) {
-                                goto exit_dcke;
+
+                            if (wc_ecc_import_x963_ex(input + idx, length,
+                                     ssl->peerEccKey, ssl->eccTempKey->dp->id)) {
+                                ERROR_OUT(ECC_PEERKEY_ERROR, exit_dcke);
                             }
-                        }
-                        if (wc_ecc_import_x963_ex(input + idx, length,
-                                 ssl->peerEccKey, ssl->eccTempKey->dp->id)) {
-                            ERROR_OUT(ECC_PEERKEY_ERROR, exit_dcke);
-                        }
 
-                        idx += length;
-                        ssl->peerEccKeyPresent = 1;
-
-                        /* Note sizeof preMasterSecret is ENCRYPT_LEN currently 512 */
-                        ssl->sigLen = sizeof(ssl->arrays->preMasterSecret);
-
-                        if (ssl->eccTempKeyPresent == 0) {
-                            WOLFSSL_MSG("Ecc ephemeral key not made correctly");
-                            ERROR_OUT(ECC_MAKEKEY_ERROR, exit_dcke);
+                            ssl->peerEccKeyPresent = 1;
                         }
                         break;
                     }
@@ -20325,9 +20385,21 @@ int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             private_key = (ecc_key*)ssl->sigKey;
                         }
 
+                        ssl->arrays->preMasterSz = ENCRYPT_LEN;
+
                         /* Generate shared secret */
-                        ret = EccSharedSecret(ssl, private_key, ssl->peerEccKey,
-                            ssl->arrays->preMasterSecret, &ssl->sigLen);
+                        ret = EccSharedSecret(ssl,
+                            private_key, ssl->peerEccKey,
+                            input + idx, &length,
+                            ssl->arrays->preMasterSecret,
+                            &ssl->arrays->preMasterSz,
+                            WOLFSSL_SERVER_END,
+                        #ifdef HAVE_PK_CALLBACKS
+                            ssl->EccSharedSecretCtx
+                        #else
+                            NULL
+                        #endif
+                        );
                         break;
                     }
                 #endif /* HAVE_ECC */
@@ -20377,12 +20449,21 @@ int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 #if defined(HAVE_ECC) && !defined(NO_PSK)
                     case ecdhe_psk_kea:
                     {
+                        ssl->sigLen = ENCRYPT_LEN - OPAQUE16_LEN;
+
                         /* Generate shared secret */
                         ret = EccSharedSecret(ssl,
-                            ssl->eccTempKey,
-                            ssl->peerEccKey,
+                            ssl->eccTempKey, ssl->peerEccKey,
+                            input + idx, &length,
                             ssl->arrays->preMasterSecret + OPAQUE16_LEN,
-                            &ssl->sigLen);
+                            &ssl->sigLen,
+                            WOLFSSL_SERVER_END,
+                        #ifdef HAVE_PK_CALLBACKS
+                            ssl->EccSharedSecretCtx
+                        #else
+                            NULL
+                        #endif
+                        );
                         break;
                     }
                 #endif /* HAVE_ECC && !NO_PSK */
@@ -20436,7 +20517,8 @@ int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 #ifdef HAVE_ECC
                     case ecc_diffie_hellman_kea:
                     {
-                        ssl->arrays->preMasterSz = ssl->sigLen;
+                        /* skip past the imported peer key */
+                        idx += length;
                         break;
                     }
                 #endif /* HAVE_ECC */
@@ -20482,6 +20564,9 @@ int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                     case ecdhe_psk_kea:
                     {
                         byte* pms = ssl->arrays->preMasterSecret;
+
+                        /* skip past the imported peer key */
+                        idx += length;
 
                         /* Add preMasterSecret */
                         c16toa((word16)ssl->sigLen, pms);

--- a/src/io.c
+++ b/src/io.c
@@ -80,6 +80,8 @@
     #elif defined(WOLFSSL_VXWORKS)
         #include <sockLib.h>
         #include <errno.h>
+    #elif defined(WOLFSSL_ATMEL)
+        #include "socket/include/socket.h"
     #else
         #include <sys/types.h>
         #include <errno.h>

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -958,6 +958,51 @@ int wolfSSL_SetMinEccKey_Sz(WOLFSSL* ssl, short keySz)
     ssl->options.minEccKeySz = keySz / 8;
     return SSL_SUCCESS;
 }
+
+/* Gets ECC key for shared secret callback testing
+ * Client side: returns peer key
+ * Server side: returns private key
+ */
+int wolfSSL_GetEccKey(WOLFSSL* ssl, struct ecc_key** key)
+{
+    if (ssl == NULL || key == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (ssl->options.side == WOLFSSL_CLIENT_END) {
+        if (ssl->specs.static_ecdh) {
+            if (!ssl->peerEccDsaKey || !ssl->peerEccDsaKeyPresent ||
+                                       !ssl->peerEccDsaKey->dp) {
+                return NO_PEER_KEY;
+            }
+            *key = (struct ecc_key*)ssl->peerEccDsaKey;
+        }
+        else {
+            if (!ssl->peerEccKey || !ssl->peerEccKeyPresent ||
+                                    !ssl->peerEccKey->dp) {
+                return NO_PEER_KEY;
+            }
+            *key = (struct ecc_key*)ssl->peerEccKey;
+        }
+    }
+    else if (ssl->options.side == WOLFSSL_SERVER_END) {
+        if (ssl->specs.static_ecdh) {
+            if (ssl->sigKey == NULL) {
+                return NO_PRIVATE_KEY;
+            }
+            *key = (struct ecc_key*)ssl->sigKey;
+        }
+        else {
+            if (!ssl->eccTempKeyPresent) {
+                return NO_PRIVATE_KEY;
+            }
+            *key = (struct ecc_key*)ssl->eccTempKey;
+        }
+    }
+
+    return 0;
+}
+
 #endif /* !NO_RSA */
 
 #ifndef NO_RSA
@@ -18202,6 +18247,26 @@ void* wolfSSL_GetEccVerifyCtx(WOLFSSL* ssl)
     return NULL;
 }
 
+void wolfSSL_CTX_SetEccSharedSecretCb(WOLFSSL_CTX* ctx, CallbackEccSharedSecret cb)
+{
+    if (ctx)
+        ctx->EccSharedSecretCb = cb;
+}
+
+void  wolfSSL_SetEccSharedSecretCtx(WOLFSSL* ssl, void *ctx)
+{
+    if (ssl)
+        ssl->EccSharedSecretCtx = ctx;
+}
+
+
+void* wolfSSL_GetEccSharedSecretCtx(WOLFSSL* ssl)
+{
+    if (ssl)
+        return ssl->EccSharedSecretCtx;
+
+    return NULL;
+}
 #endif /* HAVE_ECC */
 
 #ifndef NO_RSA

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -959,50 +959,6 @@ int wolfSSL_SetMinEccKey_Sz(WOLFSSL* ssl, short keySz)
     return SSL_SUCCESS;
 }
 
-/* Gets ECC key for shared secret callback testing
- * Client side: returns peer key
- * Server side: returns private key
- */
-int wolfSSL_GetEccKey(WOLFSSL* ssl, struct ecc_key** key)
-{
-    if (ssl == NULL || key == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    if (ssl->options.side == WOLFSSL_CLIENT_END) {
-        if (ssl->specs.static_ecdh) {
-            if (!ssl->peerEccDsaKey || !ssl->peerEccDsaKeyPresent ||
-                                       !ssl->peerEccDsaKey->dp) {
-                return NO_PEER_KEY;
-            }
-            *key = (struct ecc_key*)ssl->peerEccDsaKey;
-        }
-        else {
-            if (!ssl->peerEccKey || !ssl->peerEccKeyPresent ||
-                                    !ssl->peerEccKey->dp) {
-                return NO_PEER_KEY;
-            }
-            *key = (struct ecc_key*)ssl->peerEccKey;
-        }
-    }
-    else if (ssl->options.side == WOLFSSL_SERVER_END) {
-        if (ssl->specs.static_ecdh) {
-            if (ssl->sigKey == NULL) {
-                return NO_PRIVATE_KEY;
-            }
-            *key = (struct ecc_key*)ssl->sigKey;
-        }
-        else {
-            if (!ssl->eccTempKeyPresent) {
-                return NO_PRIVATE_KEY;
-            }
-            *key = (struct ecc_key*)ssl->eccTempKey;
-        }
-    }
-
-    return 0;
-}
-
 #endif /* !NO_RSA */
 
 #ifndef NO_RSA

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -2530,7 +2530,8 @@ void bench_ed25519KeySign(void)
     }
 
 #elif defined(WOLFSSL_IAR_ARM_TIME) || defined (WOLFSSL_MDK_ARM) || defined(WOLFSSL_USER_CURRTIME)
-    extern   double current_time(int reset);
+    /* declared above at line 189 */
+    /* extern   double current_time(int reset); */
 
 #elif defined FREERTOS
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -149,9 +149,15 @@ ASN Options:
 #elif defined(FREESCALE_KSDK_BM) || defined(FREESCALE_FREE_RTOS) || defined(FREESCALE_KSDK_FREERTOS)
     #include <time.h>
     #ifndef XTIME
-    #define XTIME(t1)  0 
+        #define XTIME(t1)   ksdk_time((t1))
     #endif
     #define XGMTIME(c, t)   gmtime((c))
+
+#elif defined(WOLFSSL_ATMEL)
+    #define XTIME(t1)       atmel_get_curr_time_and_date((t1))
+    #define WOLFSSL_GMTIME
+    #define USE_WOLF_TM
+    #define USE_WOLF_TIME_T
 
 #elif defined(IDIRECT_DEV_TIME)
     /*Gets the timestamp from cloak software owned by VT iDirect
@@ -224,6 +230,8 @@ ASN Options:
 #elif defined(TIME_OVERRIDES)
     extern time_t XTIME(time_t * timer);
     extern struct tm* XGMTIME(const time_t* timer, struct tm* tmp);
+#elif defined(WOLFSSL_GMTIME)
+    struct tm* gmtime(const time_t* timer);
 #endif
 
 

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -47,7 +47,9 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/nrf51.c \
               wolfcrypt/src/port/arm/armv8-aes.c \
               wolfcrypt/src/port/arm/armv8-sha256.c \
-              wolfssl/wolfcrypt/port/nxp/ksdk_port.c
+              wolfssl/wolfcrypt/port/nxp/ksdk_port.c \
+              wolfcrypt/src/port/atmel/atmel.c \
+              wolfcrypt/src/port/atmel/README.md
 
 if BUILD_CAVIUM
 src_libwolfssl_la_SOURCES += wolfcrypt/src/port/cavium/cavium_nitrox.c

--- a/wolfcrypt/src/port/atmel/README.md
+++ b/wolfcrypt/src/port/atmel/README.md
@@ -1,0 +1,8 @@
+# Atmel ATECC508A Port
+
+* Adds wolfCrypt support for ECC Hardware acceleration using the ATECC508A 
+	* The new defines added for this port are: `WOLFSSL_ATMEL` and `WOLFSSL_ATECC508A`.
+* Adds new PK callback for Pre Master Secret.
+
+
+For details see our [wolfSSL Atmel ATECC508A](wolfhttps://wolfssl.com/wolfSSL/wolfssl-atmel.html) page.

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -1,0 +1,244 @@
+﻿/* atmel.c
+ *
+ * Copyright (C) 2006-2016 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_ATMEL
+
+#include <wolfssl/wolfcrypt/memory.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/ssl.h>
+#include <wolfssl/internal.h>
+
+#define Aes Aes_Remap
+#define Gmac Gmac_Remap
+#include "asf.h"
+#undef Aes
+#undef Gmac
+
+#include <wolfssl/wolfcrypt/port/atmel/atmel.h>
+
+static bool mAtcaInitDone = 0;
+
+#ifdef WOLFSSL_ATECC508A
+
+/* List of available key slots */
+static int mSlotList[ATECC_MAX_SLOT+1];
+
+/**
+ * \brief Structure to contain certificate information.
+ */
+t_atcert atcert = {
+	.signer_ca_size = 512,
+	.signer_ca = { 0 },
+	.signer_ca_pubkey = { 0 },
+	.end_user_size = 512,
+	.end_user = { 0 },
+	.end_user_pubkey = { 0 }
+};
+
+static int atmel_init_enc_key(void);
+
+#endif /* WOLFSSL_ATECC508A */
+
+
+/**
+ * \brief Generate random number to be used for hash.
+ */
+int atmel_get_random_number(uint32_t count, uint8_t* rand_out)
+{
+	int ret = 0;
+#ifdef WOLFSSL_ATECC508A
+	uint8_t i = 0;
+	uint32_t copy_count = 0;
+	uint8_t rng_buffer[RANDOM_NUM_SIZE];
+
+	if (rand_out == NULL) {
+		return -1;
+	}
+
+	while(i < count) {
+
+		ret = atcatls_random(rng_buffer);
+		if (ret != 0) {
+			WOLFSSL_MSG("Failed to create random number!");
+			return -1;
+		}
+		copy_count = (count - i > RANDOM_NUM_SIZE) ? RANDOM_NUM_SIZE : count - i;
+		XMEMCPY(&rand_out[i], rng_buffer, copy_count);
+		i += copy_count;
+	}
+    atcab_printbin_label((const uint8_t*)"\r\nRandom Number", rand_out, count);
+#else
+    // TODO: Use on-board TRNG
+#endif
+	return ret;
+}
+
+int atmel_get_random_block(unsigned char* output, unsigned int sz)
+{
+	return atmel_get_random_number((uint32_t)sz, (uint8_t*)output);
+}
+
+extern struct rtc_module *_rtc_instance[RTC_INST_NUM];
+long atmel_get_curr_time_and_date(long* tm)
+{
+    (void)tm;
+
+	/* Get current time */
+    //struct rtc_calendar_time rtcTime;
+	//rtc_calendar_get_time(_rtc_instance[0], &rtcTime);
+
+    /* Convert rtc_calendar_time to seconds since UTC */
+    
+    return 0;
+}
+
+
+
+#ifdef WOLFSSL_ATECC508A
+
+/* Function to allocate new slot number */
+int atmel_ecc_alloc(void)
+{
+    int i, slot = -1;
+    for (i=0; i <= ATECC_MAX_SLOT; i++) {
+        /* Find free slot */
+        if (mSlotList[i] == ATECC_INVALID_SLOT) {
+            mSlotList[i] = i;
+            slot = i;
+            break;
+        }
+    }
+    return slot;
+}
+
+
+/* Function to return slot number to avail list */
+void atmel_ecc_free(int slot)
+{
+    if (slot >= 0 && slot <= ATECC_MAX_SLOT) {
+        /* Mark slot of free */
+        mSlotList[slot] = ATECC_INVALID_SLOT;
+    }
+}
+
+
+/**
+ * \brief Give enc key to read pms.
+ */
+static int atmel_set_enc_key(uint8_t* enckey, int16_t keysize)
+{
+    if (enckey == NULL || keysize != ATECC_KEY_SIZE) {
+        return -1;
+    }
+
+    XMEMSET(enckey, 0xFF, keysize); // use default values
+
+    return SSL_SUCCESS;
+}
+
+
+/**
+ * \brief Write enc key before.
+ */
+static int atmel_init_enc_key(void)
+{
+	uint8_t ret = 0;
+	uint8_t read_key[ATECC_KEY_SIZE] = { 0 };
+
+	XMEMSET(read_key, 0xFF, sizeof(read_key));
+	ret = atcab_write_bytes_slot(0x04, 0, read_key, sizeof(read_key));
+	if (ret != ATCA_SUCCESS) {
+		WOLFSSL_MSG("Failed to write key");
+		return -1;
+	}
+
+	ret = atcatlsfn_set_get_enckey(atmel_set_enc_key);
+	if (ret != ATCA_SUCCESS) {
+		WOLFSSL_MSG("Failed to set enckey");
+		return -1;
+	}
+
+	return ret;
+}
+
+static void atmel_show_rev_info(void)
+{
+#if 0
+    uint32_t revision = 0;
+    atcab_info((uint8_t*)&revision);
+    printf("ATECC508A Revision: %x\n", (unsigned int)revision);
+#endif
+}
+
+#endif /* WOLFSSL_ATECC508A */
+
+
+
+void atmel_init(void)
+{
+    if (!mAtcaInitDone) {
+#ifdef WOLFSSL_ATECC508A
+        int i;
+
+        /* Init the free slot list */
+        for (i=0; i<=ATECC_MAX_SLOT; i++) {
+            if (i == 0 || i == 2 || i == 7) {
+                /* ECC Slots (mark avail) */
+                mSlotList[i] = ATECC_INVALID_SLOT;
+            }
+            else {
+                mSlotList[i] = i;
+            }
+        }
+
+        /* Initialize the CryptoAuthLib to communicate with ATECC508A */
+        atcatls_init(&cfg_ateccx08a_i2c_default);
+
+        /* Init the I2C pipe encryption key. */
+        /* Value is generated/stored during pair for the ATECC508A and stored 
+            on micro flash */
+        /* For this example its a fixed value */
+		if (atmel_init_enc_key() != ATCA_SUCCESS) {
+			WOLFSSL_MSG("Failed to initialize transport key");
+		}
+
+        /* show revision information */
+        atmel_show_rev_info();
+
+        /* Configure the ECC508 for use with TLS API funcitons */
+    #if 0
+        atcatls_device_provision();
+    #else
+        atcatls_config_default();
+    #endif
+#endif /* WOLFSSL_ATECC508A */
+
+        mAtcaInitDone = 1;
+    }
+}
+
+#endif /* WOLFSSL_ATMEL */

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1619,6 +1619,23 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         return 0;
     }
 
+#elif defined(WOLFSSL_ATMEL)
+    #include <wolfssl/wolfcrypt/port/atmel/atmel.h>
+    
+    int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
+    {
+    	int ret = 0;
+
+        (void)os;
+    	if (output == NULL) {
+    		return BUFFER_E;
+    	}
+
+    	ret = atmel_get_random_number(sz, output);
+
+    	return ret;
+    }
+
 #elif defined(NO_DEV_RANDOM)
 
 #error "you need to write an os specific wc_GenerateSeed() here"

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -39,6 +39,10 @@
     #include <wolfssl/wolfcrypt/port/nxp/ksdk_port.h>
 #endif
 
+#ifdef WOLFSSL_ATMEL
+    #include <wolfssl/wolfcrypt/port/atmel/atmel.h>
+#endif
+
 #ifdef _MSC_VER
     /* 4996 warning to use MS extensions e.g., strcpy_s instead of strncpy */
     #pragma warning(disable: 4996)
@@ -50,7 +54,7 @@ static volatile int initRefCount = 0;
 /* Used to initialize state for wolfcrypt
    return 0 on success
  */
-int wolfCrypt_Init()
+int wolfCrypt_Init(void)
 {
     int ret = 0;
 
@@ -75,6 +79,10 @@ int wolfCrypt_Init()
 
     #if defined(FREESCALE_LTC_TFM) || defined(FREESCALE_LTC_ECC)
         ksdk_port_init();
+    #endif
+
+    #ifdef WOLFSSL_ATMEL
+        atmel_init();
     #endif
 
     #ifdef WOLFSSL_ARMASM

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2036,6 +2036,7 @@ struct WOLFSSL_CTX {
     #ifdef HAVE_ECC
         CallbackEccSign   EccSignCb;    /* User EccSign   Callback handler */
         CallbackEccVerify EccVerifyCb;  /* User EccVerify Callback handler */
+        CallbackEccSharedSecret EccSharedSecretCb;     /* User EccVerify Callback handler */
     #endif /* HAVE_ECC */
     #ifndef NO_RSA
         CallbackRsaSign   RsaSignCb;    /* User RsaSign   Callback handler */
@@ -2850,6 +2851,7 @@ struct WOLFSSL {
     #ifdef HAVE_ECC
         void* EccSignCtx;     /* Ecc Sign   Callback Context */
         void* EccVerifyCtx;   /* Ecc Verify Callback Context */
+        void* EccSharedSecretCtx; /* Ecc Pms Callback Context */
     #endif /* HAVE_ECC */
     #ifndef NO_RSA
         void* RsaSignCtx;     /* Rsa Sign   Callback Context */
@@ -3044,7 +3046,8 @@ WOLFSSL_LOCAL int VerifyClientSuite(WOLFSSL* ssl);
             const byte* out, word32 outSz, ecc_key* key, byte* keyBuf, word32 keySz,
             void* ctx);
         WOLFSSL_LOCAL int EccSharedSecret(WOLFSSL* ssl, ecc_key* priv_key,
-            ecc_key* pub_key, byte* out, word32* outSz);
+            ecc_key* pub_key, byte* pubKeyDer, word32* pubKeySz, byte* out,
+            word32* outlen, int side, void* ctx);
     #endif /* HAVE_ECC */
 
     #ifdef WOLFSSL_TRUST_PEER_CERT

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1043,6 +1043,8 @@ WOLFSSL_API int wolfSSL_SetMinRsaKey_Sz(WOLFSSL*, short);
 #ifdef HAVE_ECC
 WOLFSSL_API int wolfSSL_CTX_SetMinEccKey_Sz(WOLFSSL_CTX*, short);
 WOLFSSL_API int wolfSSL_SetMinEccKey_Sz(WOLFSSL*, short);
+struct ecc_key;
+WOLFSSL_API int wolfSSL_GetEccKey(WOLFSSL*, struct ecc_key**);
 #endif /* NO_RSA */
 
 WOLFSSL_API int  wolfSSL_SetTmpEC_DHE_Sz(WOLFSSL*, unsigned short);
@@ -1340,6 +1342,14 @@ typedef int (*CallbackEccVerify)(WOLFSSL* ssl,
 WOLFSSL_API void  wolfSSL_CTX_SetEccVerifyCb(WOLFSSL_CTX*, CallbackEccVerify);
 WOLFSSL_API void  wolfSSL_SetEccVerifyCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetEccVerifyCtx(WOLFSSL* ssl);
+
+typedef int (*CallbackEccSharedSecret)(WOLFSSL* ssl,
+        unsigned char* pubKeyDer, unsigned int* pubKeySz,
+        unsigned char* out, unsigned int* outlen,
+        int side, void* ctx); /* side is WOLFSSL_CLIENT_END or WOLFSSL_SERVER_END */
+WOLFSSL_API void  wolfSSL_CTX_SetEccSharedSecretCb(WOLFSSL_CTX*, CallbackEccSharedSecret);
+WOLFSSL_API void  wolfSSL_SetEccSharedSecretCtx(WOLFSSL* ssl, void *ctx);
+WOLFSSL_API void* wolfSSL_GetEccSharedSecretCtx(WOLFSSL* ssl);
 
 typedef int (*CallbackRsaSign)(WOLFSSL* ssl,
        const unsigned char* in, unsigned int inSz,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1043,8 +1043,6 @@ WOLFSSL_API int wolfSSL_SetMinRsaKey_Sz(WOLFSSL*, short);
 #ifdef HAVE_ECC
 WOLFSSL_API int wolfSSL_CTX_SetMinEccKey_Sz(WOLFSSL_CTX*, short);
 WOLFSSL_API int wolfSSL_SetMinEccKey_Sz(WOLFSSL*, short);
-struct ecc_key;
-WOLFSSL_API int wolfSSL_GetEccKey(WOLFSSL*, struct ecc_key**);
 #endif /* NO_RSA */
 
 WOLFSSL_API int  wolfSSL_SetTmpEC_DHE_Sz(WOLFSSL*, unsigned short);
@@ -1344,6 +1342,8 @@ WOLFSSL_API void  wolfSSL_SetEccVerifyCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetEccVerifyCtx(WOLFSSL* ssl);
 
 typedef int (*CallbackEccSharedSecret)(WOLFSSL* ssl,
+        const unsigned char* otherKeyDer, unsigned int otherKeySz,
+        unsigned int otherKeyId,
         unsigned char* pubKeyDer, unsigned int* pubKeySz,
         unsigned char* out, unsigned int* outlen,
         int side, void* ctx); /* side is WOLFSSL_CLIENT_END or WOLFSSL_SERVER_END */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1341,9 +1341,8 @@ WOLFSSL_API void  wolfSSL_CTX_SetEccVerifyCb(WOLFSSL_CTX*, CallbackEccVerify);
 WOLFSSL_API void  wolfSSL_SetEccVerifyCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetEccVerifyCtx(WOLFSSL* ssl);
 
-typedef int (*CallbackEccSharedSecret)(WOLFSSL* ssl,
-        const unsigned char* otherKeyDer, unsigned int otherKeySz,
-        unsigned int otherKeyId,
+struct ecc_key;
+typedef int (*CallbackEccSharedSecret)(WOLFSSL* ssl, struct ecc_key* otherKey,
         unsigned char* pubKeyDer, unsigned int* pubKeySz,
         unsigned char* out, unsigned int* outlen,
         int side, void* ctx); /* side is WOLFSSL_CLIENT_END or WOLFSSL_SERVER_END */

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1711,8 +1711,8 @@ static INLINE int myEccSharedSecret(WOLFSSL* ssl, ecc_key* otherKey,
         int side, void* ctx)
 {
     int      ret;
-    ecc_key* privKey;
-    ecc_key* pubKey;
+    ecc_key* privKey = NULL;
+    ecc_key* pubKey = NULL;
     ecc_key  tmpKey;
 
     (void)ssl;
@@ -1726,10 +1726,12 @@ static INLINE int myEccSharedSecret(WOLFSSL* ssl, ecc_key* otherKey,
     /* for client: create and export public key */
     if (side == WOLFSSL_CLIENT_END) {
         WC_RNG rng;
+
+        privKey = &tmpKey;
+        pubKey = otherKey;
+
         ret = wc_InitRng(&rng);
         if (ret == 0) {
-            privKey = &tmpKey;
-            pubKey = otherKey;
             ret = wc_ecc_make_key_ex(&rng, 0, privKey, otherKey->dp->id);
             if (ret == 0)
                 ret = wc_ecc_export_x963(privKey, pubKeyDer, pubKeySz);
@@ -1741,11 +1743,12 @@ static INLINE int myEccSharedSecret(WOLFSSL* ssl, ecc_key* otherKey,
     else if (side == WOLFSSL_SERVER_END) {
         privKey = otherKey;
         pubKey = &tmpKey;
+
         ret = wc_ecc_import_x963_ex(pubKeyDer, *pubKeySz, pubKey,
             otherKey->dp->id);
     }
     else {
-        ret = -1;
+        ret = BAD_FUNC_ARG;
     }
 
     /* generate shared secret and return it */

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -65,7 +65,8 @@ noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/ti/ti-hash.h \
                          wolfssl/wolfcrypt/port/ti/ti-ccm.h \
                          wolfssl/wolfcrypt/port/nrf51.h \
-                         wolfssl/wolfcrypt/port/nxp/ksdk_port.h
+                         wolfssl/wolfcrypt/port/nxp/ksdk_port.h \
+                         wolfssl/wolfcrypt/port/atmel/atmel.h
 
 if BUILD_CAVIUM
 noinst_HEADERS+=         wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h

--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -1,0 +1,66 @@
+/* atecc508.h
+ *
+ * Copyright (C) 2006-2016 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL. (formerly known as CyaSSL)
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _ATECC508_H_
+#define _ATECC508_H_
+
+#include <stdint.h>
+
+#ifdef WOLFSSL_ATECC508A
+    #undef  SHA_BLOCK_SIZE
+    #define SHA_BLOCK_SIZE  SHA_BLOCK_SIZE_REMAP
+    #include <cryptoauthlib.h>
+    #include <tls/atcatls.h>
+    #include <atcacert/atcacert_client.h>
+    #include <tls/atcatls_cfg.h>
+    #undef SHA_BLOCK_SIZE
+#endif
+
+/* ATECC508A only supports ECC-256 */
+#define ATECC_KEY_SIZE      (32)
+#define ATECC_MAX_SLOT      (0x7) /* Only use 0-7 */
+#define ATECC_INVALID_SLOT  (-1)
+
+struct WOLFSSL;
+struct WOLFSSL_X509_STORE_CTX;
+
+// Cert Structure
+typedef struct t_atcert {
+	uint32_t signer_ca_size;
+	uint8_t signer_ca[512];
+	uint8_t signer_ca_pubkey[64];	
+	uint32_t end_user_size;
+	uint8_t end_user[512];
+	uint8_t end_user_pubkey[64];	
+} t_atcert;
+
+extern t_atcert atcert;
+
+
+/* Amtel port functions */
+void atmel_init(void);
+int atmel_get_random_number(uint32_t count, uint8_t* rand_out);
+long atmel_get_curr_time_and_date(long* tm);
+
+int atmel_ecc_alloc(void);
+void atmel_ecc_free(int slot);
+
+#endif /* _ATECC508_H_ */


### PR DESCRIPTION
Atmel support (WOLFSSL_ATMEL) and port for ATECC508A (WOLFSSL_ATECC508A). Adds wolfCrypt support for ECC Hardware acceleration using the ATECC508A. Adds new PK callback for ECC shared secret. Fixed missing "wc_InitRng_ex" when using "CUSTOM_RAND_GENERATE_BLOCK". Added ATECC508A RNG block function for P-RNG bypass ability. Added internal "wolfSSL_GetEccPrivateKey" function for getting reference to private key for ECC shared secret (used in test.h for testing PK_CALLBACK mode). Added README.md for using the Atmel ATECC508A port.
