### PR TITLE
Add "--enable-distro" build option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,7 +142,6 @@ then
     enable_savecert=yes
     enable_atomicuser=yes
     enable_pkcallbacks=yes
-    enable_sniffer=yes
     enable_aesgcm=yes
     enable_aesccm=yes
     enable_camellia=yes
@@ -164,7 +163,6 @@ then
     enable_eccencrypt=yes
     enable_psk=yes
     enable_idea=yes
-    enable_arc4=yes
     enable_cmac=yes
     enable_webserver=yes
     enable_hc128=yes

--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,73 @@ AS_IF([test "$ax_enable_debug" = "yes"],
       [AM_CFLAGS="$AM_CFLAGS -DNDEBUG"])
 
 
+# Distro build feature subset (Debian, Ubuntu, etc.)
+AC_ARG_ENABLE([distro],
+    [  --enable-distro         Enable wolfSSL distro build (default: disabled)],
+    [ ENABLED_DISTRO=$enableval ],
+    [ ENABLED_DISTRO=no ]
+    )
+if test "$ENABLED_DISTRO" = "yes"
+then
+    enable_shared=yes
+    enable_static=yes
+    enable_dtls=yes
+    enable_openssh=yes
+    enable_opensslextra=yes
+    enable_savesession=yes
+    enable_savecert=yes
+    enable_atomicuser=yes
+    enable_pkcallbacks=yes
+    enable_sniffer=yes
+    enable_aesgcm=yes
+    enable_aesccm=yes
+    enable_camellia=yes
+    enable_ripemd=yes
+    enable_sha512=yes
+    enable_sessioncerts=yes
+    enable_keygen=yes
+    enable_certgen=yes
+    enable_certreq=yes
+    enable_certext=yes
+    enable_sep=yes
+    enable_hkdf=yes
+    enable_dsa=yes
+    enable_ecccustcurves=yes
+    enable_compkey=yes
+    enable_curve25519=yes
+    enable_ed25519=yes
+    enable_fpecc=yes
+    enable_eccencrypt=yes
+    enable_psk=yes
+    enable_idea=yes
+    enable_arc4=yes
+    enable_cmac=yes
+    enable_webserver=yes
+    enable_hc128=yes
+    enable_rabbit=yes
+    enable_ocsp=yes
+    enable_ocspstapling=yes
+    enable_ocspstapling2=yes
+    enable_crl=yes
+    enable_crl_monitor=yes
+    enable_sni=yes
+    enable_maxfragment=yes
+    enable_alpn=yes
+    enable_truncatedhmac=yes
+    enable_supportedcurves=yes
+    enable_session_ticket=yes
+    enable_tlsx=yes
+    enable_pkcs7=yes
+    enable_scep=yes
+    enable_srp=yes
+    enable_certservice=yes
+    enable_jni=yes
+    enable_lighty=yes
+    enable_stunnel=yes
+    enable_pwdbased=yes
+fi
+
+
 # SINGLE THREADED
 AC_ARG_ENABLE([singlethreaded],
     [  --enable-singlethreaded Enable wolfSSL single threaded (default: disabled)],
@@ -2986,6 +3053,7 @@ echo "   * Filesystem:                 $ENABLED_FILESYSTEM"
 echo "   * OpenSSH Build:              $ENABLED_OPENSSH"
 echo "   * OpenSSL Extra API:          $ENABLED_OPENSSLEXTRA"
 echo "   * Max Strength Build:         $ENABLED_MAXSTRENGTH"
+echo "   * Distro Build:               $ENABLED_DISTRO"
 echo "   * fastmath:                   $ENABLED_FASTMATH"
 echo "   * sniffer:                    $ENABLED_SNIFFER"
 echo "   * snifftest:                  $ENABLED_SNIFFTEST"

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -25,14 +25,14 @@ sleep 1
 # client test against our own server - GOOD CERT
 ./examples/server/server -c certs/ocsp/server1-cert.pem -k certs/ocsp/server1-key.pem &
 sleep 1
-./examples/client/client -X -C -A certs/ocsp/root-ca-cert.pem -W 1
+./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 
 # client test against our own server - REVOKED CERT
 ./examples/server/server -c certs/ocsp/server2-cert.pem -k certs/ocsp/server2-key.pem &
 sleep 1
-./examples/client/client -X -C -A certs/ocsp/root-ca-cert.pem -W 1
+./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1
 RESULT=$?
 [ $RESULT -ne 1 ] && echo -e "\n\nClient connection suceeded $RESULT" && exit 1
 

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -16,39 +16,39 @@ sleep 1
 # client test against our own server - GOOD CERTS
 ./examples/server/server -c certs/ocsp/server3-cert.pem -k certs/ocsp/server3-key.pem &
 sleep 1
-./examples/client/client -X -C -A certs/ocsp/root-ca-cert.pem -W 1
+./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 
 ./examples/server/server -c certs/ocsp/server3-cert.pem -k certs/ocsp/server3-key.pem &
 sleep 1
-./examples/client/client -X -C -A certs/ocsp/root-ca-cert.pem -W 2
+./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 
 # client test against our own server - REVOKED SERVER CERT
 ./examples/server/server -c certs/ocsp/server4-cert.pem -k certs/ocsp/server4-key.pem &
 sleep 1
-./examples/client/client -X -C -A certs/ocsp/root-ca-cert.pem -W 1
+./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1
 RESULT=$?
 [ $RESULT -ne 1 ] && echo -e "\n\nClient connection suceeded $RESULT" && exit 1
 
 ./examples/server/server -c certs/ocsp/server4-cert.pem -k certs/ocsp/server4-key.pem &
 sleep 1
-./examples/client/client -X -C -A certs/ocsp/root-ca-cert.pem -W 2
+./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2
 RESULT=$?
 [ $RESULT -ne 1 ] && echo -e "\n\nClient connection suceeded $RESULT" && exit 1
 
 # client test against our own server - REVOKED INTERMEDIATE CERT
 ./examples/server/server -c certs/ocsp/server5-cert.pem -k certs/ocsp/server5-key.pem &
 sleep 1
-./examples/client/client -X -C -A certs/ocsp/root-ca-cert.pem -W 1
+./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed $RESULT" && exit 1
 
 ./examples/server/server -c certs/ocsp/server5-cert.pem -k certs/ocsp/server5-key.pem &
 sleep 1
-./examples/client/client -X -C -A certs/ocsp/root-ca-cert.pem -W 2
+./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 2
 RESULT=$?
 [ $RESULT -ne 1 ] && echo -e "\n\nClient connection suceeded $RESULT" && exit 1
 


### PR DESCRIPTION
Adds build option for distro builds (Debian, Ubuntu, etc.) to make it easier on package maintainers.  Upstream (wolfSSL) can control what options we want enabled/disabled instead of making the maintainers decide.

Also removes "-X" external test option from OCSP stapling tests that do not connect to external servers.