### PR TITLE
OCSP Fixes

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -1015,7 +1015,7 @@ static int process_http_response(int sfd, byte** respBuf,
         XMEMCPY(recvBuf, start, len);
 
     /* receive the OCSP response data */
-    do {
+    while (len < recvBufSz) {
         result = (int)recv(sfd, (char*)recvBuf+len, recvBufSz-len, 0);
         if (result > 0)
             len += result;
@@ -1023,7 +1023,7 @@ static int process_http_response(int sfd, byte** respBuf,
             WOLFSSL_MSG("process_http_response recv ocsp from peer failed");
             return -1;
         }
-    } while (len != recvBufSz);
+    }
 
     *respBuf = recvBuf;
     return recvBufSz;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4570,7 +4570,7 @@ int wolfSSL_CertManagerCheckOCSP(WOLFSSL_CERT_MANAGER* cm, byte* der, int sz)
 
     InitDecodedCert(cert, der, sz, NULL);
 
-    if ((ret = ParseCertRelative(cert, CERT_TYPE, NO_VERIFY, cm)) != 0) {
+    if ((ret = ParseCertRelative(cert, CERT_TYPE, VERIFY_OCSP, cm)) != 0) {
         WOLFSSL_MSG("ParseCert failed");
     }
     else if ((ret = CheckCertOCSP(cm->ocsp, cert, NULL)) != 0) {
@@ -5046,7 +5046,7 @@ int wolfSSL_CertManagerCheckCRL(WOLFSSL_CERT_MANAGER* cm, byte* der, int sz)
 
     InitDecodedCert(cert, der, sz, NULL);
 
-    if ((ret = ParseCertRelative(cert, CERT_TYPE, NO_VERIFY, cm)) != 0) {
+    if ((ret = ParseCertRelative(cert, CERT_TYPE, VERIFY_CRL, cm)) != 0) {
         WOLFSSL_MSG("ParseCert failed");
     }
     else if ((ret = CheckCertCRL(cm->crl, cert)) != 0) {

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -312,8 +312,10 @@ enum ExtKeyUsage_Sum { /* From RFC 5280 */
 
 
 enum VerifyType {
-    NO_VERIFY = 0,
-    VERIFY    = 1
+    NO_VERIFY   = 0,
+    VERIFY      = 1,
+    VERIFY_CRL  = 2,
+    VERIFY_OCSP = 3
 };
 
 #ifdef WOLFSSL_CERT_EXT


### PR DESCRIPTION
1. When using Cert Manager OCSP lookup, the issuer key hash wasn't being set correctly. This could lead to unknown responses from lookup.
2. Default OCSP lookup callback could get blocked waiting for server to close socket.