### PR TITLE
verify case with unexpected input

### DIFF
--- a/wolfcrypt/src/signature.c
+++ b/wolfcrypt/src/signature.c
@@ -209,7 +209,7 @@ int wc_SignatureVerify(
                 if (plain_len < sig_len) {
                     plain_len = sig_len;
                 }
-                plain_data = (byte*)XMALLOC(hash_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                plain_data = (byte*)XMALLOC(plain_len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 if (plain_data) {
                     /* Perform verification of signature using provided RSA key */
                     ret = wc_RsaSSL_Verify(sig, sig_len, plain_data, plain_len,


### PR DESCRIPTION
Issue brought up by user cxdinter from forums https://www.wolfssl.com/forums/topic849-meet-segmentation-fault-when-using-wcsignatureverify.html

Case where an unexpected plain text size (in this case OID + hash) is larger then hash_len so RSA verify needs more buffer room then just hash_len.