### PR TITLE
include MAX_RSA_INT_SZ in wc_RsaKeyToPublicDer(), for 4096-bit keys

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5572,7 +5572,7 @@ static int SetRsaPublicKey(byte* output, RsaKey* key,
     n[0] = ASN_INTEGER;
     nSz  = SetLength(rawLen, n + 1) + 1;  /* int tag */
 
-    if ( (nSz + rawLen) < MAX_RSA_INT_SZ) {
+    if ( (nSz + rawLen) <= MAX_RSA_INT_SZ) {
         if (leadingBit)
             n[nSz] = 0;
 #ifdef HAVE_USER_RSA


### PR DESCRIPTION
From a bug fix submitted on the wolfSSL forums:

https://www.wolfssl.com/forums/post2713.html#p2713