### PR TITLE
Autogen tweak for git worktrees

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -13,7 +13,7 @@ if test -d .git; then
 fi
 
 # If this is a source checkout then call autoreconf with error as well
-if test -d .git; then
+if test -e .git; then
   WARNINGS="all,error"
   # touch fips files for non fips distribution
   touch ./ctaocrypt/src/fips.c

--- a/m4/ax_vcs_checkout.m4
+++ b/m4/ax_vcs_checkout.m4
@@ -45,7 +45,10 @@
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#serial 6
+#serial 6.1
+#
+# Added tweak for git. The base repo's .git is a directory. Any worktree's
+# .git is a file. Use -e to check for either dir or file.
 
 AC_DEFUN([AX_VCS_SYSTEM],
     [AC_PREREQ([2.63])dnl
@@ -54,7 +57,7 @@ AC_DEFUN([AX_VCS_SYSTEM],
       AS_IF([test -d ".bzr"],[ac_cv_vcs_system="bazaar"])
       AS_IF([test -d ".svn"],[ac_cv_vcs_system="svn"])
       AS_IF([test -d ".hg"],[ac_cv_vcs_system="mercurial"])
-      AS_IF([test -d ".git"],[ac_cv_vcs_system="git"])
+      AS_IF([test -e ".git"],[ac_cv_vcs_system="git"])
       ])
     AC_DEFINE_UNQUOTED([VCS_SYSTEM],["$ac_cv_vcs_system"],[VCS system])
     ])


### PR DESCRIPTION
Both autogen.sh and m4/ax_vcs_checkout.m4 are using the test option "-d" to see if .git is a directory. This is appropriate for autogen.sh copying the pre-commit and pre-push scripts. When using a git worktree for a branch, autogen.sh does not touch the dummy files it should. .git is a file, not a directory. While appropriate to skip installing the hooks, as they are run from the worktree's parent repo, the dummy files do need to be created. The harden cc flags macro also checks to see if checked out from a repo, and if using a worktree many flags are skipped, hence the change to the m4 file.