### PR TITLE
RDSEED enhancements

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1084,6 +1084,12 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     if (ctx == NULL)
         err_sys("unable to get ctx");
 
+#ifdef SINGLE_THREADED
+    if (wolfSSL_CTX_new_rng(ctx) != SSL_SUCCESS) {
+        err_sys("Single Threaded new rng at CTX failed");
+    }
+#endif
+
     if (cipherList) {
         if (wolfSSL_CTX_set_cipher_list(ctx, cipherList) != SSL_SUCCESS)
             err_sys("client can't set cipher list 1");

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1029,29 +1029,28 @@ static int wc_InitRng_IntelRD()
     return 1 ;
 }
 
-#define INTELRD_RETRY 10
+#define INTELRD_RETRY 32
 
 #if defined(HAVE_HASHDRBG) || defined(NO_RC4)
 
 /* return 0 on success */
-static INLINE int IntelRDseed32(unsigned int *seed)
+static INLINE int IntelRDseed64(word64* seed)
 {
-    int rdseed;  unsigned char ok ;
+    unsigned char ok;
 
-    __asm__ volatile("rdseed %0; setc %1":"=r"(rdseed), "=qm"(ok));
+    __asm__ volatile("rdseed %0; setc %1":"=r"(*seed), "=qm"(ok));
     if(ok){
-        *seed = rdseed ;
         return 0 ;
     } else
         return 1;
 }
 
 /* return 0 on success */
-static INLINE int IntelRDseed32_r(unsigned int *rnd)
+static INLINE int IntelRDseed64_r(word64* rnd)
 {
-    int i ;
+    int i;
     for(i=0; i<INTELRD_RETRY;i++) {
-       if(IntelRDseed32(rnd) == 0) return 0 ;
+       if(IntelRDseed64(rnd) == 0) return 0 ;
     }
     return 1 ;
 }
@@ -1061,17 +1060,17 @@ static int wc_GenerateSeed_IntelRD(OS_Seed* os, byte* output, word32 sz)
 {
     (void) os ;
     int ret ;
-    unsigned int rndTmp ;
+    word64 rndTmp ;
 
-    for(  ; sz/4 > 0; sz-=4, output+=4) {
-        if(IS_INTEL_RDSEED)ret = IntelRDseed32_r((word32 *)output) ;
+    for(  ; sz/8 > 0; sz-=8, output+=8) {
+        if(IS_INTEL_RDSEED)ret = IntelRDseed64_r((word64*)output);
         else return 1 ;
         if(ret)
              return 1 ;
     }
     if(sz == 0)return 0 ;
 
-    if(IS_INTEL_RDSEED)ret = IntelRDseed32_r(&rndTmp) ;
+    if(IS_INTEL_RDSEED)ret = IntelRDseed64_r(&rndTmp) ;
     else return 1 ;
     if(ret)
          return 1 ;
@@ -1621,8 +1620,21 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
 #if defined(HAVE_INTEL_RDGEN) && (defined(HAVE_HASHDRBG) || defined(NO_RC4))
     wc_InitRng_IntelRD() ; /* set cpuid_flags if not yet */
-    if(IS_INTEL_RDSEED)
-         return wc_GenerateSeed_IntelRD(NULL, output, sz) ;
+    if(IS_INTEL_RDSEED) {
+         ret = wc_GenerateSeed_IntelRD(NULL, output, sz);
+         if (ret == 0) {
+             /* success, we're done */
+             return ret;
+         }
+#ifdef FORCE_FAILURE_RDSEED
+         /* don't fallback to /dev/urandom */
+         return ret;
+#else
+         /* fallback to /dev/urrandom attempt */
+         ret = 0;
+#endif
+    }
+
 #endif
 
     os->fd = open("/dev/urandom",O_RDONLY);

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1630,7 +1630,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
          /* don't fallback to /dev/urandom */
          return ret;
 #else
-         /* fallback to /dev/urrandom attempt */
+         /* fallback to /dev/urandom attempt */
          ret = 0;
 #endif
     }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1902,7 +1902,10 @@ WOLFSSL_LOCAL int TLSX_ValidateQSHScheme(TLSX** extensions, word16 name);
 /* wolfSSL context type */
 struct WOLFSSL_CTX {
     WOLFSSL_METHOD* method;
-    wolfSSL_Mutex   countMutex;    /* reference count mutex */
+#ifdef SINGLE_THREADED
+    WC_RNG*         rng;          /* to be shared with WOLFSSL w/o locking */
+#endif
+    wolfSSL_Mutex   countMutex;   /* reference count mutex */
     int         refCount;         /* reference count */
     int         err;              /* error code in case of mutex not created */
 #ifndef NO_DH
@@ -2396,6 +2399,7 @@ typedef struct Options {
     word16            usingNonblock:1;    /* are we using nonblocking socket */
     word16            saveArrays:1;       /* save array Memory for user get keys
                                            or psk */
+    word16            weOwnRng:1;         /* will be true unless CTX owns */
 #ifdef HAVE_POLY1305
     word16            oldPoly:1;        /* set when to use old rfc way of poly*/
 #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1418,6 +1418,11 @@ WOLFSSL_API void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl);
     WOLFSSL_API int wolfSSL_CTX_EnableOCSPStapling(WOLFSSL_CTX*);
 #endif /* !NO_CERTS */
 
+
+#ifdef SINGLE_THREADED
+    WOLFSSL_API int wolfSSL_CTX_new_rng(WOLFSSL_CTX*);
+#endif
+
 /* end of handshake frees temporary arrays, if user needs for get_keys or
    psk hints, call KeepArrays before handshake and then FreeArrays when done
    if don't want to wait for object free */


### PR DESCRIPTION
1) Increase rdseed retries to 32, still an order of magnitude faster than /dev/urandom
2) Increase rdseed retrieval to 64bits, halving the number of calls
3) Allow fallback to /dev/urandom on retry failure
4) Allow fallback override (that is hard failure) with FORCE_FAILURE_RDSEED
5) In single threaded mode allow WOLFSSL_CTX rng that is shared with WOLFSSL created objects.  New API is:
wolfSSL_CTX_new_rng()