### PR TITLE
CA Certificate Path Length Checking

### DIFF
--- a/SCRIPTS-LIST
+++ b/SCRIPTS-LIST
@@ -24,6 +24,8 @@ certs/
   ocspd0.sh - ocsp responder for root-ca-cert.pem
   ocspd1.sh - ocsp responder for intermediate1-ca-cert.pem
   ocspd2.sh - ocsp responder for intermediate2-ca-cert.pem
+ test-pathlen/
+  assemble-chains.sh - composes the cert chain files out of the certs
 
 scripts/
  external.test - example client test against our website, part of tests

--- a/certs/include.am
+++ b/certs/include.am
@@ -47,3 +47,4 @@ dist_doc_DATA+= certs/taoCert.txt
 
 EXTRA_DIST+= certs/ntru-key.raw
 
+include certs/test-pathlen/include.am

--- a/certs/test-pathlen/assemble-chains.sh
+++ b/certs/test-pathlen/assemble-chains.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# assemble-chains.sh
+# Assemble all the certificate CA path test cert chains.
+
+# Success: PathLen of 0
+## server-0-ca.pem: signed by ca-cert.pem
+## server-0-cert.pem: signed by server-0-ca.pem 
+cat server-0-cert.pem server-0-ca.pem > server-0-chain.pem
+
+# Success: PathLen of 1
+## server-1-ca.pem: signed by ca-cert.pem
+## server-1-0-ca.pem: signed by server-1-ca.pem
+## server-1-0-cert.pem: signed by server-1-0-ca.pem
+cat server-1-0-cert.pem server-1-0-ca.pem server-1-ca.pem > server-1-0-chain.pem
+## server-1-cert.pem: signed by server-1-ca.pem
+cat server-1-cert.pem server-1-ca.pem > server-1-chain.pem
+
+# Success: PathLen of 127
+## server-127-ca.pem: signed by ca-cert.pem
+## server-127-cert.pem: signed by server-127-cert.pem
+cat server-127-cert.pem server-127-ca.pem > server-127-chain.pem
+
+# Failure: PathLen of 128
+## server-128-ca.pem: signed by ca-cert.pem
+## server-128-cert.pem: signed by server-128-ca.pem
+cat server-128-cert.pem server-128-ca.pem > server-128-chain.pem
+
+# Failure: PathLen of 0, signing PathLen of 1
+## server-0-1-ca.pem: signed by server-0-ca.pem
+## server-0-1-cert.pem: signed by server-0-1-ca.pem
+cat server-0-1-cert.pem server-0-1-ca.pem server-0-ca.pem > server-0-1-chain.pem

--- a/certs/test-pathlen/include.am
+++ b/certs/test-pathlen/include.am
@@ -1,0 +1,23 @@
+# vim:ft=automake
+# All paths should be given relative to the root
+#
+
+EXTRA_DIST += \
+            certs/test-pathlen/server-0-1-ca.pem \
+            certs/test-pathlen/server-0-1-cert.pem \
+            certs/test-pathlen/server-0-1-chain.pem \
+            certs/test-pathlen/server-0-ca.pem \
+            certs/test-pathlen/server-0-cert.pem \
+            certs/test-pathlen/server-0-chain.pem \
+            certs/test-pathlen/server-1-0-ca.pem \
+            certs/test-pathlen/server-1-0-cert.pem \
+            certs/test-pathlen/server-1-0-chain.pem \
+            certs/test-pathlen/server-1-ca.pem \
+            certs/test-pathlen/server-1-cert.pem \
+            certs/test-pathlen/server-1-chain.pem \
+            certs/test-pathlen/server-127-ca.pem \
+            certs/test-pathlen/server-127-cert.pem \
+            certs/test-pathlen/server-127-chain.pem \
+            certs/test-pathlen/server-128-ca.pem \
+            certs/test-pathlen/server-128-cert.pem \
+            certs/test-pathlen/server-128-chain.pem

--- a/certs/test-pathlen/server-0-1-ca.pem
+++ b/certs/test-pathlen/server-0-1-ca.pem
@@ -1,0 +1,89 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 110 (0x6e)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:22:35 2016 GMT
+            Not After : Jun 17 00:22:35 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0-1 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:64
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:1
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         22:dd:95:9c:dc:e6:7f:ad:df:55:68:c8:21:f8:84:12:fd:13:
+         22:80:2b:ba:1f:da:9d:d2:55:00:a1:22:fc:50:44:6d:0f:ac:
+         8a:61:2c:32:c5:63:e1:26:37:10:7c:5e:05:f1:90:0f:21:57:
+         b4:61:e0:40:0b:4f:1b:bf:8b:d8:fd:28:d6:55:73:bd:a9:5c:
+         5e:61:89:4f:e1:07:b6:5a:78:c5:0c:65:7a:38:11:e7:86:46:
+         2a:0c:a5:70:71:aa:16:9c:79:d6:c2:18:4c:b8:fb:86:1a:78:
+         70:e5:0a:27:48:2a:d4:14:d7:3f:31:76:33:a0:4b:f9:f8:34:
+         2e:c9:06:e4:e2:a0:0c:02:1e:c4:a0:d3:2b:ce:77:0e:b8:31:
+         d5:02:66:b1:62:10:5b:63:e2:7f:aa:23:0a:63:d9:33:76:2d:
+         88:9b:0f:6a:a2:ab:e8:b7:a4:83:7c:8e:1d:8c:45:d7:90:78:
+         5c:3d:41:85:ac:79:ce:6c:fc:36:6b:20:fa:0c:19:a1:2b:91:
+         d0:5f:fd:72:86:cb:17:22:02:70:76:ed:61:78:1c:ce:d0:e3:
+         17:9c:4d:58:9e:30:d5:c7:33:5b:44:0d:16:5c:ca:a4:67:13:
+         3a:18:f8:94:ac:5e:17:a5:c2:2c:11:89:7b:7a:fd:f5:9a:e3:
+         19:93:c0:60
+-----BEGIN CERTIFICATE-----
+MIIEtjCCA56gAwIBAgIBbjANBgkqhkiG9w0BAQUFADCBmDELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1Nl
+cnZlciAwIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMB4XDTE2
+MDkyMDAwMjIzNVoXDTE5MDYxNzAwMjIzNVowgZoxCzAJBgNVBAYTAlVTMRMwEQYD
+VQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxlMRUwEwYDVQQKDAx3b2xm
+U1NMIEluYy4xFDASBgNVBAsMC0VuZ2luZWVyaW5nMRYwFAYDVQQDDA1TZXJ2ZXIg
+MC0xIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwJUI4VdB8nFtt9JFQScBZcZFrvK8JDC4
+lc4vTtb2HIi8fJ/7qGd//lycUXX3isoH5zUvj+G9e8AvfKtkqBf8yl17uuAh5XIu
+by6G2JVz2qwbU7lfP9cZDSVP4WNjUYsLZD+tQ7ilHFw0s64AoGPF9n8LWWh4c6aM
+GKkCba/DGQEuuBDjxsxAtGmjRjNph27Euxem8+jdrXO8ey8htf1mUQy9VLPhbV8c
+vCNz0QkDiRTSELlkwyrQoZZKvOHUGlvHoMDBY3gPRDcwMpaAMiOVoXe6E9KXc+Jd
+JclqDcM5YKS0sGlCQgnp2Ai8MyCzWCKnquvE4eZhg8XSlt/Z0E+t1wIDAQABo4IB
+BTCCAQEwHQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHBBgNVHSMEgbkw
+gbaAFLMRMsmSmITiyfjQO24DQsofDo48oYGapIGXMIGUMQswCQYDVQQGEwJVUzEQ
+MA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3
+dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3Ns
+LmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIBZDAPBgNVHRME
+CDAGAQH/AgEBMAsGA1UdDwQEAwIBBjANBgkqhkiG9w0BAQUFAAOCAQEAIt2VnNzm
+f63fVWjIIfiEEv0TIoAruh/andJVAKEi/FBEbQ+simEsMsVj4SY3EHxeBfGQDyFX
+tGHgQAtPG7+L2P0o1lVzvalcXmGJT+EHtlp4xQxlejgR54ZGKgylcHGqFpx51sIY
+TLj7hhp4cOUKJ0gq1BTXPzF2M6BL+fg0LskG5OKgDAIexKDTK853Drgx1QJmsWIQ
+W2Pif6ojCmPZM3YtiJsPaqKr6Lekg3yOHYxF15B4XD1Bhax5zmz8Nmsg+gwZoSuR
+0F/9cobLFyICcHbtYXgcztDjF5xNWJ4w1cczW0QNFlzKpGcTOhj4lKxeF6XCLBGJ
+e3r99ZrjGZPAYA==
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-0-1-cert.pem
+++ b/certs/test-pathlen/server-0-1-cert.pem
@@ -1,0 +1,86 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 111 (0x6f)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0-1 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:24:02 2016 GMT
+            Not After : Jun 17 00:24:02 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0-1/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Washington/L=Seattle/O=wolfSSL Inc./OU=Engineering/CN=Server 0 CA/emailAddress=info@wolfssl.com
+                serial:6E
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+    Signature Algorithm: sha1WithRSAEncryption
+         80:ab:40:d2:72:bd:c9:24:e2:b7:cf:b0:f0:39:3d:36:88:9e:
+         5c:c9:cd:92:64:fe:8a:09:48:fb:42:38:ae:a9:f3:69:61:f0:
+         58:38:9c:0b:99:d3:d1:67:7a:cf:21:e1:8e:97:2c:98:14:c1:
+         a9:62:64:70:d6:bf:5b:ff:85:3d:47:c3:81:84:c4:c5:3d:d3:
+         41:35:62:e1:25:fc:78:fd:9e:04:44:bf:62:f5:52:a0:38:57:
+         a1:45:30:38:35:c2:e5:d2:b6:52:8f:c4:3f:c4:d5:f5:22:25:
+         25:70:c3:b2:4d:9e:29:10:a7:13:84:1a:fc:44:a9:df:35:62:
+         f9:39:e2:9a:13:2d:84:7e:02:11:b6:f3:95:2c:93:c8:45:26:
+         2f:d8:c9:23:b5:fa:f1:aa:da:c7:6f:a8:e4:52:4e:f3:94:60:
+         dc:3e:b3:db:5e:4b:92:a9:55:c1:0e:28:8d:6a:fd:98:65:da:
+         05:0f:25:ae:7f:20:50:60:43:59:a2:f5:1a:e2:a4:e1:92:ae:
+         f6:cb:19:39:60:fe:96:a8:f3:40:e4:93:9c:a6:b4:18:12:3d:
+         d1:78:e3:b0:07:72:fc:9a:75:9f:25:17:f3:00:2c:bc:04:fe:
+         1a:23:ad:e4:2d:55:a4:d3:0d:3d:60:e5:9f:cf:47:f0:c3:02:
+         68:b1:07:72
+-----BEGIN CERTIFICATE-----
+MIIEpDCCA4ygAwIBAgIBbzANBgkqhkiG9w0BAQUFADCBmjELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFjAUBgNVBAMMDVNl
+cnZlciAwLTEgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcN
+MTYwOTIwMDAyNDAyWhcNMTkwNjE3MDAyNDAyWjCBlzELMAkGA1UEBhMCVVMxEzAR
+BgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdv
+bGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxEzARBgNVBAMMClNlcnZl
+ciAwLTExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiV
+zi9O1vYciLx8n/uoZ3/+XJxRdfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5v
+LobYlXParBtTuV8/1xkNJU/hY2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowY
+qQJtr8MZAS64EOPGzEC0aaNGM2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8
+I3PRCQOJFNIQuWTDKtChlkq84dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0l
+yWoNwzlgpLSwaUJCCenYCLwzILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjgfUw
+gfIwHQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHFBgNVHSMEgb0wgbqA
+FLMRMsmSmITiyfjQO24DQsofDo48oYGepIGbMIGYMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTEVMBMGA1UECgwMd29s
+ZlNTTCBJbmMuMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEUMBIGA1UEAwwLU2VydmVy
+IDAgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb22CAW4wCQYDVR0T
+BAIwADANBgkqhkiG9w0BAQUFAAOCAQEAgKtA0nK9ySTit8+w8Dk9NoieXMnNkmT+
+iglI+0I4rqnzaWHwWDicC5nT0Wd6zyHhjpcsmBTBqWJkcNa/W/+FPUfDgYTExT3T
+QTVi4SX8eP2eBES/YvVSoDhXoUUwODXC5dK2Uo/EP8TV9SIlJXDDsk2eKRCnE4Qa
+/ESp3zVi+TnimhMthH4CEbbzlSyTyEUmL9jJI7X68arax2+o5FJO85Rg3D6z215L
+kqlVwQ4ojWr9mGXaBQ8lrn8gUGBDWaL1GuKk4ZKu9ssZOWD+lqjzQOSTnKa0GBI9
+0XjjsAdy/Jp1nyUX8wAsvAT+GiOt5C1VpNMNPWDln89H8MMCaLEHcg==
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-0-1-chain.pem
+++ b/certs/test-pathlen/server-0-1-chain.pem
@@ -1,0 +1,264 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 111 (0x6f)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0-1 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:24:02 2016 GMT
+            Not After : Jun 17 00:24:02 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0-1/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Washington/L=Seattle/O=wolfSSL Inc./OU=Engineering/CN=Server 0 CA/emailAddress=info@wolfssl.com
+                serial:6E
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+    Signature Algorithm: sha1WithRSAEncryption
+         80:ab:40:d2:72:bd:c9:24:e2:b7:cf:b0:f0:39:3d:36:88:9e:
+         5c:c9:cd:92:64:fe:8a:09:48:fb:42:38:ae:a9:f3:69:61:f0:
+         58:38:9c:0b:99:d3:d1:67:7a:cf:21:e1:8e:97:2c:98:14:c1:
+         a9:62:64:70:d6:bf:5b:ff:85:3d:47:c3:81:84:c4:c5:3d:d3:
+         41:35:62:e1:25:fc:78:fd:9e:04:44:bf:62:f5:52:a0:38:57:
+         a1:45:30:38:35:c2:e5:d2:b6:52:8f:c4:3f:c4:d5:f5:22:25:
+         25:70:c3:b2:4d:9e:29:10:a7:13:84:1a:fc:44:a9:df:35:62:
+         f9:39:e2:9a:13:2d:84:7e:02:11:b6:f3:95:2c:93:c8:45:26:
+         2f:d8:c9:23:b5:fa:f1:aa:da:c7:6f:a8:e4:52:4e:f3:94:60:
+         dc:3e:b3:db:5e:4b:92:a9:55:c1:0e:28:8d:6a:fd:98:65:da:
+         05:0f:25:ae:7f:20:50:60:43:59:a2:f5:1a:e2:a4:e1:92:ae:
+         f6:cb:19:39:60:fe:96:a8:f3:40:e4:93:9c:a6:b4:18:12:3d:
+         d1:78:e3:b0:07:72:fc:9a:75:9f:25:17:f3:00:2c:bc:04:fe:
+         1a:23:ad:e4:2d:55:a4:d3:0d:3d:60:e5:9f:cf:47:f0:c3:02:
+         68:b1:07:72
+-----BEGIN CERTIFICATE-----
+MIIEpDCCA4ygAwIBAgIBbzANBgkqhkiG9w0BAQUFADCBmjELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFjAUBgNVBAMMDVNl
+cnZlciAwLTEgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcN
+MTYwOTIwMDAyNDAyWhcNMTkwNjE3MDAyNDAyWjCBlzELMAkGA1UEBhMCVVMxEzAR
+BgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdv
+bGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxEzARBgNVBAMMClNlcnZl
+ciAwLTExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiV
+zi9O1vYciLx8n/uoZ3/+XJxRdfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5v
+LobYlXParBtTuV8/1xkNJU/hY2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowY
+qQJtr8MZAS64EOPGzEC0aaNGM2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8
+I3PRCQOJFNIQuWTDKtChlkq84dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0l
+yWoNwzlgpLSwaUJCCenYCLwzILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjgfUw
+gfIwHQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHFBgNVHSMEgb0wgbqA
+FLMRMsmSmITiyfjQO24DQsofDo48oYGepIGbMIGYMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTEVMBMGA1UECgwMd29s
+ZlNTTCBJbmMuMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEUMBIGA1UEAwwLU2VydmVy
+IDAgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb22CAW4wCQYDVR0T
+BAIwADANBgkqhkiG9w0BAQUFAAOCAQEAgKtA0nK9ySTit8+w8Dk9NoieXMnNkmT+
+iglI+0I4rqnzaWHwWDicC5nT0Wd6zyHhjpcsmBTBqWJkcNa/W/+FPUfDgYTExT3T
+QTVi4SX8eP2eBES/YvVSoDhXoUUwODXC5dK2Uo/EP8TV9SIlJXDDsk2eKRCnE4Qa
+/ESp3zVi+TnimhMthH4CEbbzlSyTyEUmL9jJI7X68arax2+o5FJO85Rg3D6z215L
+kqlVwQ4ojWr9mGXaBQ8lrn8gUGBDWaL1GuKk4ZKu9ssZOWD+lqjzQOSTnKa0GBI9
+0XjjsAdy/Jp1nyUX8wAsvAT+GiOt5C1VpNMNPWDln89H8MMCaLEHcg==
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 110 (0x6e)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:22:35 2016 GMT
+            Not After : Jun 17 00:22:35 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0-1 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:64
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:1
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         22:dd:95:9c:dc:e6:7f:ad:df:55:68:c8:21:f8:84:12:fd:13:
+         22:80:2b:ba:1f:da:9d:d2:55:00:a1:22:fc:50:44:6d:0f:ac:
+         8a:61:2c:32:c5:63:e1:26:37:10:7c:5e:05:f1:90:0f:21:57:
+         b4:61:e0:40:0b:4f:1b:bf:8b:d8:fd:28:d6:55:73:bd:a9:5c:
+         5e:61:89:4f:e1:07:b6:5a:78:c5:0c:65:7a:38:11:e7:86:46:
+         2a:0c:a5:70:71:aa:16:9c:79:d6:c2:18:4c:b8:fb:86:1a:78:
+         70:e5:0a:27:48:2a:d4:14:d7:3f:31:76:33:a0:4b:f9:f8:34:
+         2e:c9:06:e4:e2:a0:0c:02:1e:c4:a0:d3:2b:ce:77:0e:b8:31:
+         d5:02:66:b1:62:10:5b:63:e2:7f:aa:23:0a:63:d9:33:76:2d:
+         88:9b:0f:6a:a2:ab:e8:b7:a4:83:7c:8e:1d:8c:45:d7:90:78:
+         5c:3d:41:85:ac:79:ce:6c:fc:36:6b:20:fa:0c:19:a1:2b:91:
+         d0:5f:fd:72:86:cb:17:22:02:70:76:ed:61:78:1c:ce:d0:e3:
+         17:9c:4d:58:9e:30:d5:c7:33:5b:44:0d:16:5c:ca:a4:67:13:
+         3a:18:f8:94:ac:5e:17:a5:c2:2c:11:89:7b:7a:fd:f5:9a:e3:
+         19:93:c0:60
+-----BEGIN CERTIFICATE-----
+MIIEtjCCA56gAwIBAgIBbjANBgkqhkiG9w0BAQUFADCBmDELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1Nl
+cnZlciAwIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMB4XDTE2
+MDkyMDAwMjIzNVoXDTE5MDYxNzAwMjIzNVowgZoxCzAJBgNVBAYTAlVTMRMwEQYD
+VQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxlMRUwEwYDVQQKDAx3b2xm
+U1NMIEluYy4xFDASBgNVBAsMC0VuZ2luZWVyaW5nMRYwFAYDVQQDDA1TZXJ2ZXIg
+MC0xIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwJUI4VdB8nFtt9JFQScBZcZFrvK8JDC4
+lc4vTtb2HIi8fJ/7qGd//lycUXX3isoH5zUvj+G9e8AvfKtkqBf8yl17uuAh5XIu
+by6G2JVz2qwbU7lfP9cZDSVP4WNjUYsLZD+tQ7ilHFw0s64AoGPF9n8LWWh4c6aM
+GKkCba/DGQEuuBDjxsxAtGmjRjNph27Euxem8+jdrXO8ey8htf1mUQy9VLPhbV8c
+vCNz0QkDiRTSELlkwyrQoZZKvOHUGlvHoMDBY3gPRDcwMpaAMiOVoXe6E9KXc+Jd
+JclqDcM5YKS0sGlCQgnp2Ai8MyCzWCKnquvE4eZhg8XSlt/Z0E+t1wIDAQABo4IB
+BTCCAQEwHQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHBBgNVHSMEgbkw
+gbaAFLMRMsmSmITiyfjQO24DQsofDo48oYGapIGXMIGUMQswCQYDVQQGEwJVUzEQ
+MA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3
+dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3Ns
+LmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIBZDAPBgNVHRME
+CDAGAQH/AgEBMAsGA1UdDwQEAwIBBjANBgkqhkiG9w0BAQUFAAOCAQEAIt2VnNzm
+f63fVWjIIfiEEv0TIoAruh/andJVAKEi/FBEbQ+simEsMsVj4SY3EHxeBfGQDyFX
+tGHgQAtPG7+L2P0o1lVzvalcXmGJT+EHtlp4xQxlejgR54ZGKgylcHGqFpx51sIY
+TLj7hhp4cOUKJ0gq1BTXPzF2M6BL+fg0LskG5OKgDAIexKDTK853Drgx1QJmsWIQ
+W2Pif6ojCmPZM3YtiJsPaqKr6Lekg3yOHYxF15B4XD1Bhax5zmz8Nmsg+gwZoSuR
+0F/9cobLFyICcHbtYXgcztDjF5xNWJ4w1cczW0QNFlzKpGcTOhj4lKxeF6XCLBGJ
+e3r99ZrjGZPAYA==
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 100 (0x64)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 19 23:03:51 2016 GMT
+            Not After : Jun 16 23:03:51 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:B7:B6:90:33:66:1B:6B:23
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         a4:3b:22:20:6f:07:33:d0:ae:6d:13:fd:4f:48:dc:03:c6:9c:
+         e0:34:73:fa:e8:2f:aa:bd:15:1c:87:fe:6f:e4:c6:8e:36:b8:
+         b6:bb:53:c1:ea:e4:5c:d9:de:44:d5:05:89:88:79:d9:87:c9:
+         05:78:57:bf:c0:25:1f:18:b6:f6:02:50:c8:b1:d1:0d:64:b0:
+         da:7e:68:e0:fa:64:68:51:1a:05:7f:7d:33:c5:27:71:0f:f6:
+         d7:72:19:7c:9f:57:34:5f:45:7a:b5:48:2e:d1:83:36:85:90:
+         0c:c8:c1:be:3f:c3:7a:a3:ad:9b:3a:ce:a7:b4:50:1b:76:2e:
+         8a:a4:a4:61:96:75:b4:a7:63:6e:7c:43:2f:98:18:39:92:57:
+         87:54:76:37:73:53:37:cb:f1:95:34:11:9d:f4:94:e7:19:4a:
+         9d:5f:91:cc:ff:b4:ed:39:53:82:42:86:2e:24:13:41:a4:4a:
+         6c:d1:d9:00:ac:76:2c:59:9e:c4:28:33:b5:01:bf:74:63:01:
+         23:8a:a8:78:e4:b7:e0:8b:ab:ec:b0:43:d8:0b:b8:ff:9e:62:
+         0a:5d:e4:7c:73:f9:b4:d7:dd:6a:13:a5:28:05:90:f1:26:c1:
+         4d:2b:db:a2:c6:f5:aa:13:19:a5:28:27:f8:c7:94:e8:ef:21:
+         85:5b:32:02
+-----BEGIN CERTIFICATE-----
+MIIEuDCCA6CgAwIBAgIBZDANBgkqhkiG9w0BAQUFADCBlDELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
+d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTYwOTE5
+MjMwMzUxWhcNMTkwNjE2MjMwMzUxWjCBmDELMAkGA1UEBhMCVVMxEzARBgNVBAgM
+Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdvbGZTU0wg
+SW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1NlcnZlciAwIENB
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEAwJUI4VdB8nFtt9JFQScBZcZFrvK8JDC4lc4vTtb2
+HIi8fJ/7qGd//lycUXX3isoH5zUvj+G9e8AvfKtkqBf8yl17uuAh5XIuby6G2JVz
+2qwbU7lfP9cZDSVP4WNjUYsLZD+tQ7ilHFw0s64AoGPF9n8LWWh4c6aMGKkCba/D
+GQEuuBDjxsxAtGmjRjNph27Euxem8+jdrXO8ey8htf1mUQy9VLPhbV8cvCNz0QkD
+iRTSELlkwyrQoZZKvOHUGlvHoMDBY3gPRDcwMpaAMiOVoXe6E9KXc+JdJclqDcM5
+YKS0sGlCQgnp2Ai8MyCzWCKnquvE4eZhg8XSlt/Z0E+t1wIDAQABo4IBDTCCAQkw
+HQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHJBgNVHSMEgcEwgb6AFCeO
+ZxF0wyYdP+0zY7Ok2B0w5ejVoYGapIGXMIGUMQswCQYDVQQGEwJVUzEQMA4GA1UE
+CAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3dG9vdGgx
+EzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEf
+MB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIJALe2kDNmG2sjMA8GA1Ud
+EwQIMAYBAf8CAQAwCwYDVR0PBAQDAgEGMA0GCSqGSIb3DQEBBQUAA4IBAQCkOyIg
+bwcz0K5tE/1PSNwDxpzgNHP66C+qvRUch/5v5MaONri2u1PB6uRc2d5E1QWJiHnZ
+h8kFeFe/wCUfGLb2AlDIsdENZLDafmjg+mRoURoFf30zxSdxD/bXchl8n1c0X0V6
+tUgu0YM2hZAMyMG+P8N6o62bOs6ntFAbdi6KpKRhlnW0p2NufEMvmBg5kleHVHY3
+c1M3y/GVNBGd9JTnGUqdX5HM/7TtOVOCQoYuJBNBpEps0dkArHYsWZ7EKDO1Ab90
+YwEjiqh45Lfgi6vssEPYC7j/nmIKXeR8c/m0191qE6UoBZDxJsFNK9uixvWqExml
+KCf4x5To7yGFWzIC
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-0-ca.pem
+++ b/certs/test-pathlen/server-0-ca.pem
@@ -1,0 +1,89 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 100 (0x64)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 19 23:03:51 2016 GMT
+            Not After : Jun 16 23:03:51 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:B7:B6:90:33:66:1B:6B:23
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         a4:3b:22:20:6f:07:33:d0:ae:6d:13:fd:4f:48:dc:03:c6:9c:
+         e0:34:73:fa:e8:2f:aa:bd:15:1c:87:fe:6f:e4:c6:8e:36:b8:
+         b6:bb:53:c1:ea:e4:5c:d9:de:44:d5:05:89:88:79:d9:87:c9:
+         05:78:57:bf:c0:25:1f:18:b6:f6:02:50:c8:b1:d1:0d:64:b0:
+         da:7e:68:e0:fa:64:68:51:1a:05:7f:7d:33:c5:27:71:0f:f6:
+         d7:72:19:7c:9f:57:34:5f:45:7a:b5:48:2e:d1:83:36:85:90:
+         0c:c8:c1:be:3f:c3:7a:a3:ad:9b:3a:ce:a7:b4:50:1b:76:2e:
+         8a:a4:a4:61:96:75:b4:a7:63:6e:7c:43:2f:98:18:39:92:57:
+         87:54:76:37:73:53:37:cb:f1:95:34:11:9d:f4:94:e7:19:4a:
+         9d:5f:91:cc:ff:b4:ed:39:53:82:42:86:2e:24:13:41:a4:4a:
+         6c:d1:d9:00:ac:76:2c:59:9e:c4:28:33:b5:01:bf:74:63:01:
+         23:8a:a8:78:e4:b7:e0:8b:ab:ec:b0:43:d8:0b:b8:ff:9e:62:
+         0a:5d:e4:7c:73:f9:b4:d7:dd:6a:13:a5:28:05:90:f1:26:c1:
+         4d:2b:db:a2:c6:f5:aa:13:19:a5:28:27:f8:c7:94:e8:ef:21:
+         85:5b:32:02
+-----BEGIN CERTIFICATE-----
+MIIEuDCCA6CgAwIBAgIBZDANBgkqhkiG9w0BAQUFADCBlDELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
+d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTYwOTE5
+MjMwMzUxWhcNMTkwNjE2MjMwMzUxWjCBmDELMAkGA1UEBhMCVVMxEzARBgNVBAgM
+Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdvbGZTU0wg
+SW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1NlcnZlciAwIENB
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEAwJUI4VdB8nFtt9JFQScBZcZFrvK8JDC4lc4vTtb2
+HIi8fJ/7qGd//lycUXX3isoH5zUvj+G9e8AvfKtkqBf8yl17uuAh5XIuby6G2JVz
+2qwbU7lfP9cZDSVP4WNjUYsLZD+tQ7ilHFw0s64AoGPF9n8LWWh4c6aMGKkCba/D
+GQEuuBDjxsxAtGmjRjNph27Euxem8+jdrXO8ey8htf1mUQy9VLPhbV8cvCNz0QkD
+iRTSELlkwyrQoZZKvOHUGlvHoMDBY3gPRDcwMpaAMiOVoXe6E9KXc+JdJclqDcM5
+YKS0sGlCQgnp2Ai8MyCzWCKnquvE4eZhg8XSlt/Z0E+t1wIDAQABo4IBDTCCAQkw
+HQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHJBgNVHSMEgcEwgb6AFCeO
+ZxF0wyYdP+0zY7Ok2B0w5ejVoYGapIGXMIGUMQswCQYDVQQGEwJVUzEQMA4GA1UE
+CAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3dG9vdGgx
+EzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEf
+MB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIJALe2kDNmG2sjMA8GA1Ud
+EwQIMAYBAf8CAQAwCwYDVR0PBAQDAgEGMA0GCSqGSIb3DQEBBQUAA4IBAQCkOyIg
+bwcz0K5tE/1PSNwDxpzgNHP66C+qvRUch/5v5MaONri2u1PB6uRc2d5E1QWJiHnZ
+h8kFeFe/wCUfGLb2AlDIsdENZLDafmjg+mRoURoFf30zxSdxD/bXchl8n1c0X0V6
+tUgu0YM2hZAMyMG+P8N6o62bOs6ntFAbdi6KpKRhlnW0p2NufEMvmBg5kleHVHY3
+c1M3y/GVNBGd9JTnGUqdX5HM/7TtOVOCQoYuJBNBpEps0dkArHYsWZ7EKDO1Ab90
+YwEjiqh45Lfgi6vssEPYC7j/nmIKXeR8c/m0191qE6UoBZDxJsFNK9uixvWqExml
+KCf4x5To7yGFWzIC
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-0-cert.pem
+++ b/certs/test-pathlen/server-0-cert.pem
@@ -1,0 +1,86 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 101 (0x65)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:03:21 2016 GMT
+            Not After : Jun 17 00:03:21 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:64
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+    Signature Algorithm: sha1WithRSAEncryption
+         09:2d:8f:57:0a:4c:f7:b1:30:48:1c:eb:00:c3:06:8c:d6:49:
+         dd:45:92:25:5c:29:1a:86:90:74:28:46:18:65:8f:fb:13:c4:
+         a7:85:3d:93:42:37:a1:44:aa:17:f6:b3:99:68:05:99:02:e5:
+         ac:cd:5e:3d:fc:fe:1f:a8:b2:2c:b4:2b:9c:a2:0b:94:f0:7b:
+         ef:5c:e9:ae:e5:fa:72:b9:a4:d5:b5:09:54:01:02:6a:da:09:
+         0c:72:4b:14:bd:1d:64:b7:70:80:be:cd:33:86:5e:1f:a0:49:
+         54:9d:af:eb:5c:dc:d5:15:97:7b:5f:8f:b3:6f:54:ce:16:f7:
+         d4:be:0b:40:f0:5b:31:54:04:49:37:d2:9d:c8:9a:05:1a:6e:
+         27:db:37:60:de:32:a7:d9:33:da:4b:a8:9e:08:0a:13:c4:ec:
+         75:e9:17:39:da:14:21:f5:c4:2b:9c:b6:31:ad:61:df:ed:52:
+         d2:d6:1f:d9:e0:f9:bb:29:15:9f:40:f5:e2:41:43:90:46:24:
+         e2:34:55:57:44:7b:46:c5:87:84:80:46:02:a5:db:7d:bc:0d:
+         69:ce:aa:9e:3e:e3:7a:bf:69:61:88:f7:a1:6e:01:0b:f4:59:
+         c2:42:d4:e0:32:d4:13:16:8a:39:fe:0b:9d:31:26:47:92:8c:
+         8f:1e:a4:4e
+-----BEGIN CERTIFICATE-----
+MIIEnDCCA4SgAwIBAgIBZTANBgkqhkiG9w0BAQUFADCBmDELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1Nl
+cnZlciAwIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMB4XDTE2
+MDkyMDAwMDMyMVoXDTE5MDYxNzAwMDMyMVowgZUxCzAJBgNVBAYTAlVTMRMwEQYD
+VQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxlMRUwEwYDVQQKDAx3b2xm
+U1NMIEluYy4xFDASBgNVBAsMC0VuZ2luZWVyaW5nMREwDwYDVQQDDAhTZXJ2ZXIg
+MDEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAMCVCOFXQfJxbbfSRUEnAWXGRa7yvCQwuJXOL07W
+9hyIvHyf+6hnf/5cnFF194rKB+c1L4/hvXvAL3yrZKgX/Mpde7rgIeVyLm8uhtiV
+c9qsG1O5Xz/XGQ0lT+FjY1GLC2Q/rUO4pRxcNLOuAKBjxfZ/C1loeHOmjBipAm2v
+wxkBLrgQ48bMQLRpo0YzaYduxLsXpvPo3a1zvHsvIbX9ZlEMvVSz4W1fHLwjc9EJ
+A4kU0hC5ZMMq0KGWSrzh1Bpbx6DAwWN4D0Q3MDKWgDIjlaF3uhPSl3PiXSXJag3D
+OWCktLBpQkIJ6dgIvDMgs1gip6rrxOHmYYPF0pbf2dBPrdcCAwEAAaOB8TCB7jAd
+BgNVHQ4EFgQUsxEyyZKYhOLJ+NA7bgNCyh8OjjwwgcEGA1UdIwSBuTCBtoAUsxEy
+yZKYhOLJ+NA7bgNCyh8OjjyhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYDVQQI
+DAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290aDET
+MBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8w
+HQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggFkMAkGA1UdEwQCMAAwDQYJ
+KoZIhvcNAQEFBQADggEBAAktj1cKTPexMEgc6wDDBozWSd1FkiVcKRqGkHQoRhhl
+j/sTxKeFPZNCN6FEqhf2s5loBZkC5azNXj38/h+osiy0K5yiC5Twe+9c6a7l+nK5
+pNW1CVQBAmraCQxySxS9HWS3cIC+zTOGXh+gSVSdr+tc3NUVl3tfj7NvVM4W99S+
+C0DwWzFUBEk30p3ImgUabifbN2DeMqfZM9pLqJ4IChPE7HXpFznaFCH1xCuctjGt
+Yd/tUtLWH9ng+bspFZ9A9eJBQ5BGJOI0VVdEe0bFh4SARgKl2328DWnOqp4+43q/
+aWGI96FuAQv0WcJC1OAy1BMWijn+C50xJkeSjI8epE4=
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-0-chain.pem
+++ b/certs/test-pathlen/server-0-chain.pem
@@ -1,0 +1,175 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 101 (0x65)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:03:21 2016 GMT
+            Not After : Jun 17 00:03:21 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:64
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+    Signature Algorithm: sha1WithRSAEncryption
+         09:2d:8f:57:0a:4c:f7:b1:30:48:1c:eb:00:c3:06:8c:d6:49:
+         dd:45:92:25:5c:29:1a:86:90:74:28:46:18:65:8f:fb:13:c4:
+         a7:85:3d:93:42:37:a1:44:aa:17:f6:b3:99:68:05:99:02:e5:
+         ac:cd:5e:3d:fc:fe:1f:a8:b2:2c:b4:2b:9c:a2:0b:94:f0:7b:
+         ef:5c:e9:ae:e5:fa:72:b9:a4:d5:b5:09:54:01:02:6a:da:09:
+         0c:72:4b:14:bd:1d:64:b7:70:80:be:cd:33:86:5e:1f:a0:49:
+         54:9d:af:eb:5c:dc:d5:15:97:7b:5f:8f:b3:6f:54:ce:16:f7:
+         d4:be:0b:40:f0:5b:31:54:04:49:37:d2:9d:c8:9a:05:1a:6e:
+         27:db:37:60:de:32:a7:d9:33:da:4b:a8:9e:08:0a:13:c4:ec:
+         75:e9:17:39:da:14:21:f5:c4:2b:9c:b6:31:ad:61:df:ed:52:
+         d2:d6:1f:d9:e0:f9:bb:29:15:9f:40:f5:e2:41:43:90:46:24:
+         e2:34:55:57:44:7b:46:c5:87:84:80:46:02:a5:db:7d:bc:0d:
+         69:ce:aa:9e:3e:e3:7a:bf:69:61:88:f7:a1:6e:01:0b:f4:59:
+         c2:42:d4:e0:32:d4:13:16:8a:39:fe:0b:9d:31:26:47:92:8c:
+         8f:1e:a4:4e
+-----BEGIN CERTIFICATE-----
+MIIEnDCCA4SgAwIBAgIBZTANBgkqhkiG9w0BAQUFADCBmDELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1Nl
+cnZlciAwIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMB4XDTE2
+MDkyMDAwMDMyMVoXDTE5MDYxNzAwMDMyMVowgZUxCzAJBgNVBAYTAlVTMRMwEQYD
+VQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxlMRUwEwYDVQQKDAx3b2xm
+U1NMIEluYy4xFDASBgNVBAsMC0VuZ2luZWVyaW5nMREwDwYDVQQDDAhTZXJ2ZXIg
+MDEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAMCVCOFXQfJxbbfSRUEnAWXGRa7yvCQwuJXOL07W
+9hyIvHyf+6hnf/5cnFF194rKB+c1L4/hvXvAL3yrZKgX/Mpde7rgIeVyLm8uhtiV
+c9qsG1O5Xz/XGQ0lT+FjY1GLC2Q/rUO4pRxcNLOuAKBjxfZ/C1loeHOmjBipAm2v
+wxkBLrgQ48bMQLRpo0YzaYduxLsXpvPo3a1zvHsvIbX9ZlEMvVSz4W1fHLwjc9EJ
+A4kU0hC5ZMMq0KGWSrzh1Bpbx6DAwWN4D0Q3MDKWgDIjlaF3uhPSl3PiXSXJag3D
+OWCktLBpQkIJ6dgIvDMgs1gip6rrxOHmYYPF0pbf2dBPrdcCAwEAAaOB8TCB7jAd
+BgNVHQ4EFgQUsxEyyZKYhOLJ+NA7bgNCyh8OjjwwgcEGA1UdIwSBuTCBtoAUsxEy
+yZKYhOLJ+NA7bgNCyh8OjjyhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYDVQQI
+DAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290aDET
+MBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8w
+HQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggFkMAkGA1UdEwQCMAAwDQYJ
+KoZIhvcNAQEFBQADggEBAAktj1cKTPexMEgc6wDDBozWSd1FkiVcKRqGkHQoRhhl
+j/sTxKeFPZNCN6FEqhf2s5loBZkC5azNXj38/h+osiy0K5yiC5Twe+9c6a7l+nK5
+pNW1CVQBAmraCQxySxS9HWS3cIC+zTOGXh+gSVSdr+tc3NUVl3tfj7NvVM4W99S+
+C0DwWzFUBEk30p3ImgUabifbN2DeMqfZM9pLqJ4IChPE7HXpFznaFCH1xCuctjGt
+Yd/tUtLWH9ng+bspFZ9A9eJBQ5BGJOI0VVdEe0bFh4SARgKl2328DWnOqp4+43q/
+aWGI96FuAQv0WcJC1OAy1BMWijn+C50xJkeSjI8epE4=
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 100 (0x64)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 19 23:03:51 2016 GMT
+            Not After : Jun 16 23:03:51 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 0 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:B7:B6:90:33:66:1B:6B:23
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         a4:3b:22:20:6f:07:33:d0:ae:6d:13:fd:4f:48:dc:03:c6:9c:
+         e0:34:73:fa:e8:2f:aa:bd:15:1c:87:fe:6f:e4:c6:8e:36:b8:
+         b6:bb:53:c1:ea:e4:5c:d9:de:44:d5:05:89:88:79:d9:87:c9:
+         05:78:57:bf:c0:25:1f:18:b6:f6:02:50:c8:b1:d1:0d:64:b0:
+         da:7e:68:e0:fa:64:68:51:1a:05:7f:7d:33:c5:27:71:0f:f6:
+         d7:72:19:7c:9f:57:34:5f:45:7a:b5:48:2e:d1:83:36:85:90:
+         0c:c8:c1:be:3f:c3:7a:a3:ad:9b:3a:ce:a7:b4:50:1b:76:2e:
+         8a:a4:a4:61:96:75:b4:a7:63:6e:7c:43:2f:98:18:39:92:57:
+         87:54:76:37:73:53:37:cb:f1:95:34:11:9d:f4:94:e7:19:4a:
+         9d:5f:91:cc:ff:b4:ed:39:53:82:42:86:2e:24:13:41:a4:4a:
+         6c:d1:d9:00:ac:76:2c:59:9e:c4:28:33:b5:01:bf:74:63:01:
+         23:8a:a8:78:e4:b7:e0:8b:ab:ec:b0:43:d8:0b:b8:ff:9e:62:
+         0a:5d:e4:7c:73:f9:b4:d7:dd:6a:13:a5:28:05:90:f1:26:c1:
+         4d:2b:db:a2:c6:f5:aa:13:19:a5:28:27:f8:c7:94:e8:ef:21:
+         85:5b:32:02
+-----BEGIN CERTIFICATE-----
+MIIEuDCCA6CgAwIBAgIBZDANBgkqhkiG9w0BAQUFADCBlDELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
+d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTYwOTE5
+MjMwMzUxWhcNMTkwNjE2MjMwMzUxWjCBmDELMAkGA1UEBhMCVVMxEzARBgNVBAgM
+Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdvbGZTU0wg
+SW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1NlcnZlciAwIENB
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEAwJUI4VdB8nFtt9JFQScBZcZFrvK8JDC4lc4vTtb2
+HIi8fJ/7qGd//lycUXX3isoH5zUvj+G9e8AvfKtkqBf8yl17uuAh5XIuby6G2JVz
+2qwbU7lfP9cZDSVP4WNjUYsLZD+tQ7ilHFw0s64AoGPF9n8LWWh4c6aMGKkCba/D
+GQEuuBDjxsxAtGmjRjNph27Euxem8+jdrXO8ey8htf1mUQy9VLPhbV8cvCNz0QkD
+iRTSELlkwyrQoZZKvOHUGlvHoMDBY3gPRDcwMpaAMiOVoXe6E9KXc+JdJclqDcM5
+YKS0sGlCQgnp2Ai8MyCzWCKnquvE4eZhg8XSlt/Z0E+t1wIDAQABo4IBDTCCAQkw
+HQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHJBgNVHSMEgcEwgb6AFCeO
+ZxF0wyYdP+0zY7Ok2B0w5ejVoYGapIGXMIGUMQswCQYDVQQGEwJVUzEQMA4GA1UE
+CAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3dG9vdGgx
+EzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEf
+MB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIJALe2kDNmG2sjMA8GA1Ud
+EwQIMAYBAf8CAQAwCwYDVR0PBAQDAgEGMA0GCSqGSIb3DQEBBQUAA4IBAQCkOyIg
+bwcz0K5tE/1PSNwDxpzgNHP66C+qvRUch/5v5MaONri2u1PB6uRc2d5E1QWJiHnZ
+h8kFeFe/wCUfGLb2AlDIsdENZLDafmjg+mRoURoFf30zxSdxD/bXchl8n1c0X0V6
+tUgu0YM2hZAMyMG+P8N6o62bOs6ntFAbdi6KpKRhlnW0p2NufEMvmBg5kleHVHY3
+c1M3y/GVNBGd9JTnGUqdX5HM/7TtOVOCQoYuJBNBpEps0dkArHYsWZ7EKDO1Ab90
+YwEjiqh45Lfgi6vssEPYC7j/nmIKXeR8c/m0191qE6UoBZDxJsFNK9uixvWqExml
+KCf4x5To7yGFWzIC
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-1-0-ca.pem
+++ b/certs/test-pathlen/server-1-0-ca.pem
@@ -1,0 +1,89 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 103 (0x67)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 21:23:18 2016 GMT
+            Not After : Jun 16 21:23:18 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1-0 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:66
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         37:78:ec:5f:82:05:c6:19:f6:3a:be:82:5f:1e:d3:69:26:20:
+         92:f2:24:e8:6d:5f:44:70:ca:bd:53:24:ab:1f:58:6b:24:08:
+         d0:3a:a6:46:d3:1d:63:7c:22:8b:4a:e2:69:9e:de:03:08:91:
+         b5:37:bb:55:fe:91:fc:b4:2f:ce:9f:58:f7:80:6c:77:ed:82:
+         6d:93:f0:30:9b:42:21:dc:98:64:87:df:f5:2f:f6:90:d9:af:
+         7b:e0:98:68:07:3a:bd:70:60:e6:c8:4b:a2:c7:aa:9d:3b:cf:
+         79:07:44:57:86:cc:e2:3a:7d:b1:ee:c7:61:48:8c:0e:b0:8d:
+         0c:f6:c2:3e:e2:68:2d:50:a7:ac:5b:86:6e:f5:d1:5e:24:dd:
+         b7:c4:23:c0:90:82:e1:4f:bb:a7:6f:94:d3:9b:a3:28:30:12:
+         8b:57:18:79:91:92:44:97:ff:08:75:49:74:3b:a8:91:ca:30:
+         e0:d0:5b:90:b7:26:14:69:b8:fe:72:fa:cd:8a:da:75:28:6d:
+         e2:e4:82:83:83:01:e4:60:c8:67:5b:ef:04:a9:29:2a:6d:64:
+         1a:fc:fd:52:57:57:56:b3:bb:06:0e:e5:5f:22:d1:88:6b:12:
+         aa:f1:d5:91:09:c9:5c:1c:55:18:e6:34:fa:cd:d7:aa:bf:04:
+         fa:58:7d:cf
+-----BEGIN CERTIFICATE-----
+MIIEtjCCA56gAwIBAgIBZzANBgkqhkiG9w0BAQUFADCBmDELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1Nl
+cnZlciAxIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMB4XDTE2
+MDkyMDIxMjMxOFoXDTE5MDYxNjIxMjMxOFowgZoxCzAJBgNVBAYTAlVTMRMwEQYD
+VQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxlMRUwEwYDVQQKDAx3b2xm
+U1NMIEluYy4xFDASBgNVBAsMC0VuZ2luZWVyaW5nMRYwFAYDVQQDDA1TZXJ2ZXIg
+MS0wIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwJUI4VdB8nFtt9JFQScBZcZFrvK8JDC4
+lc4vTtb2HIi8fJ/7qGd//lycUXX3isoH5zUvj+G9e8AvfKtkqBf8yl17uuAh5XIu
+by6G2JVz2qwbU7lfP9cZDSVP4WNjUYsLZD+tQ7ilHFw0s64AoGPF9n8LWWh4c6aM
+GKkCba/DGQEuuBDjxsxAtGmjRjNph27Euxem8+jdrXO8ey8htf1mUQy9VLPhbV8c
+vCNz0QkDiRTSELlkwyrQoZZKvOHUGlvHoMDBY3gPRDcwMpaAMiOVoXe6E9KXc+Jd
+JclqDcM5YKS0sGlCQgnp2Ai8MyCzWCKnquvE4eZhg8XSlt/Z0E+t1wIDAQABo4IB
+BTCCAQEwHQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHBBgNVHSMEgbkw
+gbaAFLMRMsmSmITiyfjQO24DQsofDo48oYGapIGXMIGUMQswCQYDVQQGEwJVUzEQ
+MA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3
+dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3Ns
+LmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIBZjAPBgNVHRME
+CDAGAQH/AgEAMAsGA1UdDwQEAwIBBjANBgkqhkiG9w0BAQUFAAOCAQEAN3jsX4IF
+xhn2Or6CXx7TaSYgkvIk6G1fRHDKvVMkqx9YayQI0DqmRtMdY3wii0riaZ7eAwiR
+tTe7Vf6R/LQvzp9Y94Bsd+2CbZPwMJtCIdyYZIff9S/2kNmve+CYaAc6vXBg5shL
+oseqnTvPeQdEV4bM4jp9se7HYUiMDrCNDPbCPuJoLVCnrFuGbvXRXiTdt8QjwJCC
+4U+7p2+U05ujKDASi1cYeZGSRJf/CHVJdDuokcow4NBbkLcmFGm4/nL6zYradSht
+4uSCg4MB5GDIZ1vvBKkpKm1kGvz9UldXVrO7Bg7lXyLRiGsSqvHVkQnJXBxVGOY0
++s3Xqr8E+lh9zw==
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-1-0-cert.pem
+++ b/certs/test-pathlen/server-1-0-cert.pem
@@ -1,0 +1,86 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 104 (0x68)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1-0 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:07:57 2016 GMT
+            Not After : Jun 17 00:07:57 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1-0/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Washington/L=Seattle/O=wolfSSL Inc./OU=Engineering/CN=Server 1 CA/emailAddress=info@wolfssl.com
+                serial:67
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+    Signature Algorithm: sha1WithRSAEncryption
+         6d:98:b9:e7:03:b3:0e:36:15:f5:6f:6c:60:59:9d:60:95:cb:
+         8c:31:f6:b7:7d:27:6a:37:99:79:cb:06:89:4a:87:c8:a6:d7:
+         86:46:5c:f3:02:f9:37:98:3a:d2:59:3a:37:59:7e:46:58:ee:
+         18:b2:77:a9:85:39:45:e1:05:d4:a7:bc:1e:cc:4a:a3:be:1e:
+         7e:58:15:79:c4:25:8f:1d:3f:f4:e2:5d:3c:c1:a5:45:f3:e0:
+         fd:97:96:49:78:c7:c7:e2:e9:78:97:91:9c:44:a3:f9:b4:cc:
+         14:61:b4:03:55:ef:d2:33:3b:8d:8e:01:e1:a1:27:a4:1e:66:
+         06:13:0b:e0:5b:6b:69:8a:8a:c8:c5:a9:a3:8f:6e:dd:25:03:
+         5f:3f:65:21:8e:d5:b2:dc:0e:e1:b6:d2:fd:9c:d8:99:33:f6:
+         4b:8c:71:2b:9e:0a:3a:40:a5:28:ef:d8:65:fb:08:2f:f4:e9:
+         2b:d6:7c:9c:09:1c:6e:aa:f0:7f:67:13:dc:a3:e6:fa:5c:49:
+         04:ba:55:d4:3e:4d:17:3d:e9:13:bf:b1:95:e8:71:41:47:4a:
+         73:52:97:85:71:ac:a1:b7:32:82:64:77:c2:53:5c:f0:35:81:
+         34:10:77:09:69:04:73:05:39:b6:62:2e:fd:37:a4:20:3e:40:
+         98:a5:e5:dc
+-----BEGIN CERTIFICATE-----
+MIIEpDCCA4ygAwIBAgIBaDANBgkqhkiG9w0BAQUFADCBmjELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFjAUBgNVBAMMDVNl
+cnZlciAxLTAgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcN
+MTYwOTIwMDAwNzU3WhcNMTkwNjE3MDAwNzU3WjCBlzELMAkGA1UEBhMCVVMxEzAR
+BgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdv
+bGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxEzARBgNVBAMMClNlcnZl
+ciAxLTAxHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiV
+zi9O1vYciLx8n/uoZ3/+XJxRdfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5v
+LobYlXParBtTuV8/1xkNJU/hY2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowY
+qQJtr8MZAS64EOPGzEC0aaNGM2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8
+I3PRCQOJFNIQuWTDKtChlkq84dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0l
+yWoNwzlgpLSwaUJCCenYCLwzILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjgfUw
+gfIwHQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHFBgNVHSMEgb0wgbqA
+FLMRMsmSmITiyfjQO24DQsofDo48oYGepIGbMIGYMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTEVMBMGA1UECgwMd29s
+ZlNTTCBJbmMuMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEUMBIGA1UEAwwLU2VydmVy
+IDEgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb22CAWcwCQYDVR0T
+BAIwADANBgkqhkiG9w0BAQUFAAOCAQEAbZi55wOzDjYV9W9sYFmdYJXLjDH2t30n
+ajeZecsGiUqHyKbXhkZc8wL5N5g60lk6N1l+RljuGLJ3qYU5ReEF1Ke8HsxKo74e
+flgVecQljx0/9OJdPMGlRfPg/ZeWSXjHx+LpeJeRnESj+bTMFGG0A1Xv0jM7jY4B
+4aEnpB5mBhML4FtraYqKyMWpo49u3SUDXz9lIY7VstwO4bbS/ZzYmTP2S4xxK54K
+OkClKO/YZfsIL/TpK9Z8nAkcbqrwf2cT3KPm+lxJBLpV1D5NFz3pE7+xlehxQUdK
+c1KXhXGsobcygmR3wlNc8DWBNBB3CWkEcwU5tmIu/TekID5AmKXl3A==
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-1-0-chain.pem
+++ b/certs/test-pathlen/server-1-0-chain.pem
@@ -1,0 +1,264 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 104 (0x68)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1-0 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:07:57 2016 GMT
+            Not After : Jun 17 00:07:57 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1-0/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Washington/L=Seattle/O=wolfSSL Inc./OU=Engineering/CN=Server 1 CA/emailAddress=info@wolfssl.com
+                serial:67
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+    Signature Algorithm: sha1WithRSAEncryption
+         6d:98:b9:e7:03:b3:0e:36:15:f5:6f:6c:60:59:9d:60:95:cb:
+         8c:31:f6:b7:7d:27:6a:37:99:79:cb:06:89:4a:87:c8:a6:d7:
+         86:46:5c:f3:02:f9:37:98:3a:d2:59:3a:37:59:7e:46:58:ee:
+         18:b2:77:a9:85:39:45:e1:05:d4:a7:bc:1e:cc:4a:a3:be:1e:
+         7e:58:15:79:c4:25:8f:1d:3f:f4:e2:5d:3c:c1:a5:45:f3:e0:
+         fd:97:96:49:78:c7:c7:e2:e9:78:97:91:9c:44:a3:f9:b4:cc:
+         14:61:b4:03:55:ef:d2:33:3b:8d:8e:01:e1:a1:27:a4:1e:66:
+         06:13:0b:e0:5b:6b:69:8a:8a:c8:c5:a9:a3:8f:6e:dd:25:03:
+         5f:3f:65:21:8e:d5:b2:dc:0e:e1:b6:d2:fd:9c:d8:99:33:f6:
+         4b:8c:71:2b:9e:0a:3a:40:a5:28:ef:d8:65:fb:08:2f:f4:e9:
+         2b:d6:7c:9c:09:1c:6e:aa:f0:7f:67:13:dc:a3:e6:fa:5c:49:
+         04:ba:55:d4:3e:4d:17:3d:e9:13:bf:b1:95:e8:71:41:47:4a:
+         73:52:97:85:71:ac:a1:b7:32:82:64:77:c2:53:5c:f0:35:81:
+         34:10:77:09:69:04:73:05:39:b6:62:2e:fd:37:a4:20:3e:40:
+         98:a5:e5:dc
+-----BEGIN CERTIFICATE-----
+MIIEpDCCA4ygAwIBAgIBaDANBgkqhkiG9w0BAQUFADCBmjELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFjAUBgNVBAMMDVNl
+cnZlciAxLTAgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcN
+MTYwOTIwMDAwNzU3WhcNMTkwNjE3MDAwNzU3WjCBlzELMAkGA1UEBhMCVVMxEzAR
+BgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdv
+bGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxEzARBgNVBAMMClNlcnZl
+ciAxLTAxHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiV
+zi9O1vYciLx8n/uoZ3/+XJxRdfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5v
+LobYlXParBtTuV8/1xkNJU/hY2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowY
+qQJtr8MZAS64EOPGzEC0aaNGM2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8
+I3PRCQOJFNIQuWTDKtChlkq84dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0l
+yWoNwzlgpLSwaUJCCenYCLwzILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjgfUw
+gfIwHQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHFBgNVHSMEgb0wgbqA
+FLMRMsmSmITiyfjQO24DQsofDo48oYGepIGbMIGYMQswCQYDVQQGEwJVUzETMBEG
+A1UECAwKV2FzaGluZ3RvbjEQMA4GA1UEBwwHU2VhdHRsZTEVMBMGA1UECgwMd29s
+ZlNTTCBJbmMuMRQwEgYDVQQLDAtFbmdpbmVlcmluZzEUMBIGA1UEAwwLU2VydmVy
+IDEgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb22CAWcwCQYDVR0T
+BAIwADANBgkqhkiG9w0BAQUFAAOCAQEAbZi55wOzDjYV9W9sYFmdYJXLjDH2t30n
+ajeZecsGiUqHyKbXhkZc8wL5N5g60lk6N1l+RljuGLJ3qYU5ReEF1Ke8HsxKo74e
+flgVecQljx0/9OJdPMGlRfPg/ZeWSXjHx+LpeJeRnESj+bTMFGG0A1Xv0jM7jY4B
+4aEnpB5mBhML4FtraYqKyMWpo49u3SUDXz9lIY7VstwO4bbS/ZzYmTP2S4xxK54K
+OkClKO/YZfsIL/TpK9Z8nAkcbqrwf2cT3KPm+lxJBLpV1D5NFz3pE7+xlehxQUdK
+c1KXhXGsobcygmR3wlNc8DWBNBB3CWkEcwU5tmIu/TekID5AmKXl3A==
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 103 (0x67)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 21:23:18 2016 GMT
+            Not After : Jun 16 21:23:18 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1-0 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:66
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         37:78:ec:5f:82:05:c6:19:f6:3a:be:82:5f:1e:d3:69:26:20:
+         92:f2:24:e8:6d:5f:44:70:ca:bd:53:24:ab:1f:58:6b:24:08:
+         d0:3a:a6:46:d3:1d:63:7c:22:8b:4a:e2:69:9e:de:03:08:91:
+         b5:37:bb:55:fe:91:fc:b4:2f:ce:9f:58:f7:80:6c:77:ed:82:
+         6d:93:f0:30:9b:42:21:dc:98:64:87:df:f5:2f:f6:90:d9:af:
+         7b:e0:98:68:07:3a:bd:70:60:e6:c8:4b:a2:c7:aa:9d:3b:cf:
+         79:07:44:57:86:cc:e2:3a:7d:b1:ee:c7:61:48:8c:0e:b0:8d:
+         0c:f6:c2:3e:e2:68:2d:50:a7:ac:5b:86:6e:f5:d1:5e:24:dd:
+         b7:c4:23:c0:90:82:e1:4f:bb:a7:6f:94:d3:9b:a3:28:30:12:
+         8b:57:18:79:91:92:44:97:ff:08:75:49:74:3b:a8:91:ca:30:
+         e0:d0:5b:90:b7:26:14:69:b8:fe:72:fa:cd:8a:da:75:28:6d:
+         e2:e4:82:83:83:01:e4:60:c8:67:5b:ef:04:a9:29:2a:6d:64:
+         1a:fc:fd:52:57:57:56:b3:bb:06:0e:e5:5f:22:d1:88:6b:12:
+         aa:f1:d5:91:09:c9:5c:1c:55:18:e6:34:fa:cd:d7:aa:bf:04:
+         fa:58:7d:cf
+-----BEGIN CERTIFICATE-----
+MIIEtjCCA56gAwIBAgIBZzANBgkqhkiG9w0BAQUFADCBmDELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1Nl
+cnZlciAxIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMB4XDTE2
+MDkyMDIxMjMxOFoXDTE5MDYxNjIxMjMxOFowgZoxCzAJBgNVBAYTAlVTMRMwEQYD
+VQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxlMRUwEwYDVQQKDAx3b2xm
+U1NMIEluYy4xFDASBgNVBAsMC0VuZ2luZWVyaW5nMRYwFAYDVQQDDA1TZXJ2ZXIg
+MS0wIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwJUI4VdB8nFtt9JFQScBZcZFrvK8JDC4
+lc4vTtb2HIi8fJ/7qGd//lycUXX3isoH5zUvj+G9e8AvfKtkqBf8yl17uuAh5XIu
+by6G2JVz2qwbU7lfP9cZDSVP4WNjUYsLZD+tQ7ilHFw0s64AoGPF9n8LWWh4c6aM
+GKkCba/DGQEuuBDjxsxAtGmjRjNph27Euxem8+jdrXO8ey8htf1mUQy9VLPhbV8c
+vCNz0QkDiRTSELlkwyrQoZZKvOHUGlvHoMDBY3gPRDcwMpaAMiOVoXe6E9KXc+Jd
+JclqDcM5YKS0sGlCQgnp2Ai8MyCzWCKnquvE4eZhg8XSlt/Z0E+t1wIDAQABo4IB
+BTCCAQEwHQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHBBgNVHSMEgbkw
+gbaAFLMRMsmSmITiyfjQO24DQsofDo48oYGapIGXMIGUMQswCQYDVQQGEwJVUzEQ
+MA4GA1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3
+dG9vdGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3Ns
+LmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIBZjAPBgNVHRME
+CDAGAQH/AgEAMAsGA1UdDwQEAwIBBjANBgkqhkiG9w0BAQUFAAOCAQEAN3jsX4IF
+xhn2Or6CXx7TaSYgkvIk6G1fRHDKvVMkqx9YayQI0DqmRtMdY3wii0riaZ7eAwiR
+tTe7Vf6R/LQvzp9Y94Bsd+2CbZPwMJtCIdyYZIff9S/2kNmve+CYaAc6vXBg5shL
+oseqnTvPeQdEV4bM4jp9se7HYUiMDrCNDPbCPuJoLVCnrFuGbvXRXiTdt8QjwJCC
+4U+7p2+U05ujKDASi1cYeZGSRJf/CHVJdDuokcow4NBbkLcmFGm4/nL6zYradSht
+4uSCg4MB5GDIZ1vvBKkpKm1kGvz9UldXVrO7Bg7lXyLRiGsSqvHVkQnJXBxVGOY0
++s3Xqr8E+lh9zw==
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 102 (0x66)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 19 23:16:34 2016 GMT
+            Not After : Jun 16 23:16:34 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:B7:B6:90:33:66:1B:6B:23
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:1
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         83:fd:d4:aa:5d:ba:bd:55:4a:76:80:0b:7b:fb:ac:61:46:e5:
+         e7:0d:2c:2b:85:d3:6a:af:40:4c:f1:51:2b:7d:8b:52:ce:77:
+         4e:73:39:b2:77:79:95:a6:49:b9:8c:c3:99:8d:d5:71:f4:33:
+         ca:dc:5a:81:7a:b3:ec:1e:97:ee:c8:b8:c7:ec:7e:91:74:5c:
+         0a:78:e3:db:a4:6f:90:69:4c:4a:a8:4c:cd:96:f3:8e:94:31:
+         86:48:b4:77:0a:c6:ee:8d:43:c9:2e:11:86:4c:0d:67:e0:8b:
+         4c:d2:84:9d:18:88:ef:93:34:bb:69:93:c0:96:a0:d1:4f:b7:
+         7e:a8:05:99:09:8e:39:66:13:8d:91:fe:05:12:c7:99:6a:2f:
+         38:5e:58:2f:5d:0c:54:14:6b:c9:8a:dc:c2:21:ce:44:38:09:
+         f3:13:96:23:12:a6:fc:24:a1:bc:8c:7e:65:9c:1f:e3:f9:58:
+         a4:42:b7:20:97:29:c6:f2:b7:61:d2:67:25:ba:bb:c0:79:00:
+         69:e1:30:6d:46:1d:ee:6e:44:ee:7d:9a:35:ef:bb:41:b4:ac:
+         e0:78:9e:ef:c5:e4:19:09:05:22:0d:06:b3:16:52:df:90:fc:
+         d5:fb:6f:52:bd:44:55:13:4b:86:81:0b:a9:75:74:64:33:32:
+         8f:98:a8:50
+-----BEGIN CERTIFICATE-----
+MIIEuDCCA6CgAwIBAgIBZjANBgkqhkiG9w0BAQUFADCBlDELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
+d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTYwOTE5
+MjMxNjM0WhcNMTkwNjE2MjMxNjM0WjCBmDELMAkGA1UEBhMCVVMxEzARBgNVBAgM
+Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdvbGZTU0wg
+SW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1NlcnZlciAxIENB
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEAwJUI4VdB8nFtt9JFQScBZcZFrvK8JDC4lc4vTtb2
+HIi8fJ/7qGd//lycUXX3isoH5zUvj+G9e8AvfKtkqBf8yl17uuAh5XIuby6G2JVz
+2qwbU7lfP9cZDSVP4WNjUYsLZD+tQ7ilHFw0s64AoGPF9n8LWWh4c6aMGKkCba/D
+GQEuuBDjxsxAtGmjRjNph27Euxem8+jdrXO8ey8htf1mUQy9VLPhbV8cvCNz0QkD
+iRTSELlkwyrQoZZKvOHUGlvHoMDBY3gPRDcwMpaAMiOVoXe6E9KXc+JdJclqDcM5
+YKS0sGlCQgnp2Ai8MyCzWCKnquvE4eZhg8XSlt/Z0E+t1wIDAQABo4IBDTCCAQkw
+HQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHJBgNVHSMEgcEwgb6AFCeO
+ZxF0wyYdP+0zY7Ok2B0w5ejVoYGapIGXMIGUMQswCQYDVQQGEwJVUzEQMA4GA1UE
+CAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3dG9vdGgx
+EzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEf
+MB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIJALe2kDNmG2sjMA8GA1Ud
+EwQIMAYBAf8CAQEwCwYDVR0PBAQDAgEGMA0GCSqGSIb3DQEBBQUAA4IBAQCD/dSq
+Xbq9VUp2gAt7+6xhRuXnDSwrhdNqr0BM8VErfYtSzndOczmyd3mVpkm5jMOZjdVx
+9DPK3FqBerPsHpfuyLjH7H6RdFwKeOPbpG+QaUxKqEzNlvOOlDGGSLR3CsbujUPJ
+LhGGTA1n4ItM0oSdGIjvkzS7aZPAlqDRT7d+qAWZCY45ZhONkf4FEseZai84Xlgv
+XQxUFGvJitzCIc5EOAnzE5YjEqb8JKG8jH5lnB/j+VikQrcglynG8rdh0mclurvA
+eQBp4TBtRh3ubkTufZo177tBtKzgeJ7vxeQZCQUiDQazFlLfkPzV+29SvURVE0uG
+gQupdXRkMzKPmKhQ
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-1-ca.pem
+++ b/certs/test-pathlen/server-1-ca.pem
@@ -1,0 +1,89 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 102 (0x66)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 19 23:16:34 2016 GMT
+            Not After : Jun 16 23:16:34 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:B7:B6:90:33:66:1B:6B:23
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:1
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         83:fd:d4:aa:5d:ba:bd:55:4a:76:80:0b:7b:fb:ac:61:46:e5:
+         e7:0d:2c:2b:85:d3:6a:af:40:4c:f1:51:2b:7d:8b:52:ce:77:
+         4e:73:39:b2:77:79:95:a6:49:b9:8c:c3:99:8d:d5:71:f4:33:
+         ca:dc:5a:81:7a:b3:ec:1e:97:ee:c8:b8:c7:ec:7e:91:74:5c:
+         0a:78:e3:db:a4:6f:90:69:4c:4a:a8:4c:cd:96:f3:8e:94:31:
+         86:48:b4:77:0a:c6:ee:8d:43:c9:2e:11:86:4c:0d:67:e0:8b:
+         4c:d2:84:9d:18:88:ef:93:34:bb:69:93:c0:96:a0:d1:4f:b7:
+         7e:a8:05:99:09:8e:39:66:13:8d:91:fe:05:12:c7:99:6a:2f:
+         38:5e:58:2f:5d:0c:54:14:6b:c9:8a:dc:c2:21:ce:44:38:09:
+         f3:13:96:23:12:a6:fc:24:a1:bc:8c:7e:65:9c:1f:e3:f9:58:
+         a4:42:b7:20:97:29:c6:f2:b7:61:d2:67:25:ba:bb:c0:79:00:
+         69:e1:30:6d:46:1d:ee:6e:44:ee:7d:9a:35:ef:bb:41:b4:ac:
+         e0:78:9e:ef:c5:e4:19:09:05:22:0d:06:b3:16:52:df:90:fc:
+         d5:fb:6f:52:bd:44:55:13:4b:86:81:0b:a9:75:74:64:33:32:
+         8f:98:a8:50
+-----BEGIN CERTIFICATE-----
+MIIEuDCCA6CgAwIBAgIBZjANBgkqhkiG9w0BAQUFADCBlDELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
+d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTYwOTE5
+MjMxNjM0WhcNMTkwNjE2MjMxNjM0WjCBmDELMAkGA1UEBhMCVVMxEzARBgNVBAgM
+Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdvbGZTU0wg
+SW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1NlcnZlciAxIENB
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEAwJUI4VdB8nFtt9JFQScBZcZFrvK8JDC4lc4vTtb2
+HIi8fJ/7qGd//lycUXX3isoH5zUvj+G9e8AvfKtkqBf8yl17uuAh5XIuby6G2JVz
+2qwbU7lfP9cZDSVP4WNjUYsLZD+tQ7ilHFw0s64AoGPF9n8LWWh4c6aMGKkCba/D
+GQEuuBDjxsxAtGmjRjNph27Euxem8+jdrXO8ey8htf1mUQy9VLPhbV8cvCNz0QkD
+iRTSELlkwyrQoZZKvOHUGlvHoMDBY3gPRDcwMpaAMiOVoXe6E9KXc+JdJclqDcM5
+YKS0sGlCQgnp2Ai8MyCzWCKnquvE4eZhg8XSlt/Z0E+t1wIDAQABo4IBDTCCAQkw
+HQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHJBgNVHSMEgcEwgb6AFCeO
+ZxF0wyYdP+0zY7Ok2B0w5ejVoYGapIGXMIGUMQswCQYDVQQGEwJVUzEQMA4GA1UE
+CAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3dG9vdGgx
+EzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEf
+MB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIJALe2kDNmG2sjMA8GA1Ud
+EwQIMAYBAf8CAQEwCwYDVR0PBAQDAgEGMA0GCSqGSIb3DQEBBQUAA4IBAQCD/dSq
+Xbq9VUp2gAt7+6xhRuXnDSwrhdNqr0BM8VErfYtSzndOczmyd3mVpkm5jMOZjdVx
+9DPK3FqBerPsHpfuyLjH7H6RdFwKeOPbpG+QaUxKqEzNlvOOlDGGSLR3CsbujUPJ
+LhGGTA1n4ItM0oSdGIjvkzS7aZPAlqDRT7d+qAWZCY45ZhONkf4FEseZai84Xlgv
+XQxUFGvJitzCIc5EOAnzE5YjEqb8JKG8jH5lnB/j+VikQrcglynG8rdh0mclurvA
+eQBp4TBtRh3ubkTufZo177tBtKzgeJ7vxeQZCQUiDQazFlLfkPzV+29SvURVE0uG
+gQupdXRkMzKPmKhQ
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-1-cert.pem
+++ b/certs/test-pathlen/server-1-cert.pem
@@ -1,0 +1,86 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 105 (0x69)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:06:27 2016 GMT
+            Not After : Jun 17 00:06:27 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:66
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+    Signature Algorithm: sha1WithRSAEncryption
+         13:f9:04:1c:01:40:c5:1c:e9:51:fc:95:da:cb:d1:44:9f:25:
+         63:e8:85:f7:85:78:f1:ac:01:2d:25:34:16:96:62:a8:5a:fd:
+         41:a2:2a:60:b1:c3:97:92:59:0d:ba:2c:74:ae:a5:ff:ae:3d:
+         22:99:1e:ca:f9:89:4e:7c:c1:65:00:0e:84:61:3f:2d:5f:47:
+         7f:a9:90:bf:fa:83:64:55:2c:0c:ec:34:92:59:07:b0:86:9d:
+         66:a4:d4:16:82:e1:a8:ab:d1:12:00:b2:a4:af:c7:69:c4:54:
+         0b:bb:4f:64:9b:77:94:ed:5d:aa:42:70:4e:7c:5f:ae:46:91:
+         17:95:0b:27:b3:fd:28:87:34:8c:a8:4e:7d:07:9e:c1:d4:fd:
+         6b:e5:c5:a9:ca:c3:24:35:26:b5:7e:aa:11:78:f4:fa:c7:66:
+         59:cd:58:8f:13:7a:cf:00:8d:ba:75:8d:0d:ed:ca:ef:70:93:
+         d7:8c:d9:a4:c0:4b:b1:00:b3:da:5f:71:a6:6a:4d:3b:40:36:
+         76:12:75:45:50:a1:32:ca:14:76:9d:d8:3d:92:7e:80:e1:d0:
+         24:c3:a1:56:77:06:a6:d8:d3:f3:18:c1:69:d4:e3:4d:95:2b:
+         05:00:1b:e5:2a:a8:ca:69:01:7e:c4:c8:e5:e5:09:b5:3b:65:
+         73:5f:ba:46
+-----BEGIN CERTIFICATE-----
+MIIEnDCCA4SgAwIBAgIBaTANBgkqhkiG9w0BAQUFADCBmDELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1Nl
+cnZlciAxIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMB4XDTE2
+MDkyMDAwMDYyN1oXDTE5MDYxNzAwMDYyN1owgZUxCzAJBgNVBAYTAlVTMRMwEQYD
+VQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxlMRUwEwYDVQQKDAx3b2xm
+U1NMIEluYy4xFDASBgNVBAsMC0VuZ2luZWVyaW5nMREwDwYDVQQDDAhTZXJ2ZXIg
+MTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAMCVCOFXQfJxbbfSRUEnAWXGRa7yvCQwuJXOL07W
+9hyIvHyf+6hnf/5cnFF194rKB+c1L4/hvXvAL3yrZKgX/Mpde7rgIeVyLm8uhtiV
+c9qsG1O5Xz/XGQ0lT+FjY1GLC2Q/rUO4pRxcNLOuAKBjxfZ/C1loeHOmjBipAm2v
+wxkBLrgQ48bMQLRpo0YzaYduxLsXpvPo3a1zvHsvIbX9ZlEMvVSz4W1fHLwjc9EJ
+A4kU0hC5ZMMq0KGWSrzh1Bpbx6DAwWN4D0Q3MDKWgDIjlaF3uhPSl3PiXSXJag3D
+OWCktLBpQkIJ6dgIvDMgs1gip6rrxOHmYYPF0pbf2dBPrdcCAwEAAaOB8TCB7jAd
+BgNVHQ4EFgQUsxEyyZKYhOLJ+NA7bgNCyh8OjjwwgcEGA1UdIwSBuTCBtoAUsxEy
+yZKYhOLJ+NA7bgNCyh8OjjyhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYDVQQI
+DAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290aDET
+MBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8w
+HQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggFmMAkGA1UdEwQCMAAwDQYJ
+KoZIhvcNAQEFBQADggEBABP5BBwBQMUc6VH8ldrL0USfJWPohfeFePGsAS0lNBaW
+Yqha/UGiKmCxw5eSWQ26LHSupf+uPSKZHsr5iU58wWUADoRhPy1fR3+pkL/6g2RV
+LAzsNJJZB7CGnWak1BaC4air0RIAsqSvx2nEVAu7T2Sbd5TtXapCcE58X65GkReV
+Cyez/SiHNIyoTn0HnsHU/WvlxanKwyQ1JrV+qhF49PrHZlnNWI8Tes8Ajbp1jQ3t
+yu9wk9eM2aTAS7EAs9pfcaZqTTtANnYSdUVQoTLKFHad2D2SfoDh0CTDoVZ3BqbY
+0/MYwWnU402VKwUAG+UqqMppAX7EyOXlCbU7ZXNfukY=
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-1-chain.pem
+++ b/certs/test-pathlen/server-1-chain.pem
@@ -1,0 +1,175 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 105 (0x69)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:06:27 2016 GMT
+            Not After : Jun 17 00:06:27 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:66
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+    Signature Algorithm: sha1WithRSAEncryption
+         13:f9:04:1c:01:40:c5:1c:e9:51:fc:95:da:cb:d1:44:9f:25:
+         63:e8:85:f7:85:78:f1:ac:01:2d:25:34:16:96:62:a8:5a:fd:
+         41:a2:2a:60:b1:c3:97:92:59:0d:ba:2c:74:ae:a5:ff:ae:3d:
+         22:99:1e:ca:f9:89:4e:7c:c1:65:00:0e:84:61:3f:2d:5f:47:
+         7f:a9:90:bf:fa:83:64:55:2c:0c:ec:34:92:59:07:b0:86:9d:
+         66:a4:d4:16:82:e1:a8:ab:d1:12:00:b2:a4:af:c7:69:c4:54:
+         0b:bb:4f:64:9b:77:94:ed:5d:aa:42:70:4e:7c:5f:ae:46:91:
+         17:95:0b:27:b3:fd:28:87:34:8c:a8:4e:7d:07:9e:c1:d4:fd:
+         6b:e5:c5:a9:ca:c3:24:35:26:b5:7e:aa:11:78:f4:fa:c7:66:
+         59:cd:58:8f:13:7a:cf:00:8d:ba:75:8d:0d:ed:ca:ef:70:93:
+         d7:8c:d9:a4:c0:4b:b1:00:b3:da:5f:71:a6:6a:4d:3b:40:36:
+         76:12:75:45:50:a1:32:ca:14:76:9d:d8:3d:92:7e:80:e1:d0:
+         24:c3:a1:56:77:06:a6:d8:d3:f3:18:c1:69:d4:e3:4d:95:2b:
+         05:00:1b:e5:2a:a8:ca:69:01:7e:c4:c8:e5:e5:09:b5:3b:65:
+         73:5f:ba:46
+-----BEGIN CERTIFICATE-----
+MIIEnDCCA4SgAwIBAgIBaTANBgkqhkiG9w0BAQUFADCBmDELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1Nl
+cnZlciAxIENBMR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMB4XDTE2
+MDkyMDAwMDYyN1oXDTE5MDYxNzAwMDYyN1owgZUxCzAJBgNVBAYTAlVTMRMwEQYD
+VQQIDApXYXNoaW5ndG9uMRAwDgYDVQQHDAdTZWF0dGxlMRUwEwYDVQQKDAx3b2xm
+U1NMIEluYy4xFDASBgNVBAsMC0VuZ2luZWVyaW5nMREwDwYDVQQDDAhTZXJ2ZXIg
+MTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbTCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAMCVCOFXQfJxbbfSRUEnAWXGRa7yvCQwuJXOL07W
+9hyIvHyf+6hnf/5cnFF194rKB+c1L4/hvXvAL3yrZKgX/Mpde7rgIeVyLm8uhtiV
+c9qsG1O5Xz/XGQ0lT+FjY1GLC2Q/rUO4pRxcNLOuAKBjxfZ/C1loeHOmjBipAm2v
+wxkBLrgQ48bMQLRpo0YzaYduxLsXpvPo3a1zvHsvIbX9ZlEMvVSz4W1fHLwjc9EJ
+A4kU0hC5ZMMq0KGWSrzh1Bpbx6DAwWN4D0Q3MDKWgDIjlaF3uhPSl3PiXSXJag3D
+OWCktLBpQkIJ6dgIvDMgs1gip6rrxOHmYYPF0pbf2dBPrdcCAwEAAaOB8TCB7jAd
+BgNVHQ4EFgQUsxEyyZKYhOLJ+NA7bgNCyh8OjjwwgcEGA1UdIwSBuTCBtoAUsxEy
+yZKYhOLJ+NA7bgNCyh8OjjyhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYDVQQI
+DAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290aDET
+MBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29tMR8w
+HQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggFmMAkGA1UdEwQCMAAwDQYJ
+KoZIhvcNAQEFBQADggEBABP5BBwBQMUc6VH8ldrL0USfJWPohfeFePGsAS0lNBaW
+Yqha/UGiKmCxw5eSWQ26LHSupf+uPSKZHsr5iU58wWUADoRhPy1fR3+pkL/6g2RV
+LAzsNJJZB7CGnWak1BaC4air0RIAsqSvx2nEVAu7T2Sbd5TtXapCcE58X65GkReV
+Cyez/SiHNIyoTn0HnsHU/WvlxanKwyQ1JrV+qhF49PrHZlnNWI8Tes8Ajbp1jQ3t
+yu9wk9eM2aTAS7EAs9pfcaZqTTtANnYSdUVQoTLKFHad2D2SfoDh0CTDoVZ3BqbY
+0/MYwWnU402VKwUAG+UqqMppAX7EyOXlCbU7ZXNfukY=
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 102 (0x66)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 19 23:16:34 2016 GMT
+            Not After : Jun 16 23:16:34 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 1 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:B7:B6:90:33:66:1B:6B:23
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:1
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         83:fd:d4:aa:5d:ba:bd:55:4a:76:80:0b:7b:fb:ac:61:46:e5:
+         e7:0d:2c:2b:85:d3:6a:af:40:4c:f1:51:2b:7d:8b:52:ce:77:
+         4e:73:39:b2:77:79:95:a6:49:b9:8c:c3:99:8d:d5:71:f4:33:
+         ca:dc:5a:81:7a:b3:ec:1e:97:ee:c8:b8:c7:ec:7e:91:74:5c:
+         0a:78:e3:db:a4:6f:90:69:4c:4a:a8:4c:cd:96:f3:8e:94:31:
+         86:48:b4:77:0a:c6:ee:8d:43:c9:2e:11:86:4c:0d:67:e0:8b:
+         4c:d2:84:9d:18:88:ef:93:34:bb:69:93:c0:96:a0:d1:4f:b7:
+         7e:a8:05:99:09:8e:39:66:13:8d:91:fe:05:12:c7:99:6a:2f:
+         38:5e:58:2f:5d:0c:54:14:6b:c9:8a:dc:c2:21:ce:44:38:09:
+         f3:13:96:23:12:a6:fc:24:a1:bc:8c:7e:65:9c:1f:e3:f9:58:
+         a4:42:b7:20:97:29:c6:f2:b7:61:d2:67:25:ba:bb:c0:79:00:
+         69:e1:30:6d:46:1d:ee:6e:44:ee:7d:9a:35:ef:bb:41:b4:ac:
+         e0:78:9e:ef:c5:e4:19:09:05:22:0d:06:b3:16:52:df:90:fc:
+         d5:fb:6f:52:bd:44:55:13:4b:86:81:0b:a9:75:74:64:33:32:
+         8f:98:a8:50
+-----BEGIN CERTIFICATE-----
+MIIEuDCCA6CgAwIBAgIBZjANBgkqhkiG9w0BAQUFADCBlDELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
+d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTYwOTE5
+MjMxNjM0WhcNMTkwNjE2MjMxNjM0WjCBmDELMAkGA1UEBhMCVVMxEzARBgNVBAgM
+Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdvbGZTU0wg
+SW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFDASBgNVBAMMC1NlcnZlciAxIENB
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tMIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEAwJUI4VdB8nFtt9JFQScBZcZFrvK8JDC4lc4vTtb2
+HIi8fJ/7qGd//lycUXX3isoH5zUvj+G9e8AvfKtkqBf8yl17uuAh5XIuby6G2JVz
+2qwbU7lfP9cZDSVP4WNjUYsLZD+tQ7ilHFw0s64AoGPF9n8LWWh4c6aMGKkCba/D
+GQEuuBDjxsxAtGmjRjNph27Euxem8+jdrXO8ey8htf1mUQy9VLPhbV8cvCNz0QkD
+iRTSELlkwyrQoZZKvOHUGlvHoMDBY3gPRDcwMpaAMiOVoXe6E9KXc+JdJclqDcM5
+YKS0sGlCQgnp2Ai8MyCzWCKnquvE4eZhg8XSlt/Z0E+t1wIDAQABo4IBDTCCAQkw
+HQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHJBgNVHSMEgcEwgb6AFCeO
+ZxF0wyYdP+0zY7Ok2B0w5ejVoYGapIGXMIGUMQswCQYDVQQGEwJVUzEQMA4GA1UE
+CAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3dG9vdGgx
+EzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEf
+MB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIJALe2kDNmG2sjMA8GA1Ud
+EwQIMAYBAf8CAQEwCwYDVR0PBAQDAgEGMA0GCSqGSIb3DQEBBQUAA4IBAQCD/dSq
+Xbq9VUp2gAt7+6xhRuXnDSwrhdNqr0BM8VErfYtSzndOczmyd3mVpkm5jMOZjdVx
+9DPK3FqBerPsHpfuyLjH7H6RdFwKeOPbpG+QaUxKqEzNlvOOlDGGSLR3CsbujUPJ
+LhGGTA1n4ItM0oSdGIjvkzS7aZPAlqDRT7d+qAWZCY45ZhONkf4FEseZai84Xlgv
+XQxUFGvJitzCIc5EOAnzE5YjEqb8JKG8jH5lnB/j+VikQrcglynG8rdh0mclurvA
+eQBp4TBtRh3ubkTufZo177tBtKzgeJ7vxeQZCQUiDQazFlLfkPzV+29SvURVE0uG
+gQupdXRkMzKPmKhQ
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-127-ca.pem
+++ b/certs/test-pathlen/server-127-ca.pem
@@ -1,0 +1,89 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 106 (0x6a)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 19 23:24:16 2016 GMT
+            Not After : Jun 16 23:24:16 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 127 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:B7:B6:90:33:66:1B:6B:23
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:127
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         34:c3:f2:9a:80:df:5c:8a:b4:c1:08:f5:c6:72:a2:74:90:1d:
+         e9:f9:7a:e7:6e:3b:df:be:01:28:6b:10:ee:5f:9d:8d:5b:7a:
+         fc:40:12:7f:b6:bb:ac:d9:07:73:78:d0:4f:53:5d:f8:c3:50:
+         ba:f7:76:a2:e5:12:fa:8f:01:24:a2:b7:8a:e4:6c:0b:62:51:
+         37:39:4a:90:eb:11:16:26:58:44:ed:3f:41:57:8e:32:7a:e4:
+         85:a7:ce:44:d2:46:28:9e:29:34:9b:16:a5:17:ef:56:11:0a:
+         60:b8:88:7c:3e:ed:ec:5e:57:5f:b1:b9:b7:55:38:a0:ea:04:
+         58:22:04:7e:30:f3:40:33:a1:cd:3f:24:72:7b:a4:b4:2d:b5:
+         96:b3:80:7a:48:85:83:3c:6e:55:43:7c:13:d3:5e:f8:70:32:
+         da:5a:78:db:d0:54:54:9c:e9:38:05:da:7c:ac:bb:ec:79:cf:
+         3e:56:32:ce:29:31:70:07:9a:c7:b4:00:02:33:af:1b:ce:7c:
+         16:ff:8b:c0:8b:80:1e:0d:c7:d4:07:95:49:d4:9a:ed:55:b6:
+         1f:bd:e7:77:b9:fa:af:29:6a:49:79:02:3c:b9:ea:6c:68:c3:
+         ef:ca:40:27:d0:15:d0:da:31:9c:2f:3d:a5:66:e3:f8:a4:98:
+         d5:00:5f:b2
+-----BEGIN CERTIFICATE-----
+MIIEujCCA6KgAwIBAgIBajANBgkqhkiG9w0BAQUFADCBlDELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
+d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTYwOTE5
+MjMyNDE2WhcNMTkwNjE2MjMyNDE2WjCBmjELMAkGA1UEBhMCVVMxEzARBgNVBAgM
+Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdvbGZTU0wg
+SW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFjAUBgNVBAMMDVNlcnZlciAxMjcg
+Q0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0GCSqGSIb3
+DQEBAQUAA4IBDwAwggEKAoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiVzi9O
+1vYciLx8n/uoZ3/+XJxRdfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5vLobY
+lXParBtTuV8/1xkNJU/hY2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowYqQJt
+r8MZAS64EOPGzEC0aaNGM2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8I3PR
+CQOJFNIQuWTDKtChlkq84dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0lyWoN
+wzlgpLSwaUJCCenYCLwzILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjggENMIIB
+CTAdBgNVHQ4EFgQUsxEyyZKYhOLJ+NA7bgNCyh8OjjwwgckGA1UdIwSBwTCBvoAU
+J45nEXTDJh0/7TNjs6TYHTDl6NWhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYD
+VQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290
+aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29t
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggkAt7aQM2YbayMwDwYD
+VR0TBAgwBgEB/wIBfzALBgNVHQ8EBAMCAQYwDQYJKoZIhvcNAQEFBQADggEBADTD
+8pqA31yKtMEI9cZyonSQHen5euduO9++AShrEO5fnY1bevxAEn+2u6zZB3N40E9T
+XfjDULr3dqLlEvqPASSit4rkbAtiUTc5SpDrERYmWETtP0FXjjJ65IWnzkTSRiie
+KTSbFqUX71YRCmC4iHw+7exeV1+xubdVOKDqBFgiBH4w80Azoc0/JHJ7pLQttZaz
+gHpIhYM8blVDfBPTXvhwMtpaeNvQVFSc6TgF2nysu+x5zz5WMs4pMXAHmse0AAIz
+rxvOfBb/i8CLgB4Nx9QHlUnUmu1Vth+953e5+q8pakl5Ajy56mxow+/KQCfQFdDa
+MZwvPaVm4/ikmNUAX7I=
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-127-cert.pem
+++ b/certs/test-pathlen/server-127-cert.pem
@@ -1,0 +1,86 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 107 (0x6b)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 127 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:09:11 2016 GMT
+            Not After : Jun 17 00:09:11 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 127/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:6A
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+    Signature Algorithm: sha1WithRSAEncryption
+         65:05:63:43:5f:91:a4:54:31:3e:e8:55:ac:7b:b2:57:c2:f2:
+         2e:3d:f2:53:cf:13:b5:35:7c:b6:f9:a7:86:e2:41:aa:14:6a:
+         65:69:17:fb:02:39:7c:31:78:80:9a:0d:27:10:9a:7c:2c:17:
+         30:03:32:6a:3f:06:fa:19:02:83:91:71:4d:50:e0:55:17:ed:
+         ec:62:3b:29:51:2e:c9:9a:75:3b:91:f9:bc:d0:2d:4f:ff:30:
+         d8:1d:b6:7e:8e:39:70:a1:c9:d1:f7:a3:81:a5:7c:5d:e4:e0:
+         cf:43:60:a1:c0:b8:e7:16:ed:43:6d:b2:09:cd:bc:51:57:f0:
+         73:a2:cb:03:b6:c7:56:97:96:c6:8c:93:aa:44:3d:62:0c:b5:
+         ca:b8:65:1b:98:8f:ad:98:9e:9b:2e:83:0d:e6:d0:76:d8:c5:
+         5c:4a:9e:40:88:65:c0:0e:bc:5c:87:dd:c1:e0:51:b7:8b:d5:
+         73:da:8d:83:0d:16:60:a3:ff:f4:7c:4a:85:bb:a1:81:f5:9e:
+         5d:f8:e7:d6:9d:6a:5b:9d:2b:f8:3d:02:16:ff:b9:6a:60:c9:
+         64:40:5d:9c:37:a4:b8:ee:82:52:5c:db:07:5f:04:98:4a:f2:
+         ec:6c:86:50:9c:a0:99:5b:24:9a:d9:7d:1f:5d:f3:7e:47:59:
+         10:48:f5:2a
+-----BEGIN CERTIFICATE-----
+MIIEoDCCA4igAwIBAgIBazANBgkqhkiG9w0BAQUFADCBmjELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFjAUBgNVBAMMDVNl
+cnZlciAxMjcgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcN
+MTYwOTIwMDAwOTExWhcNMTkwNjE3MDAwOTExWjCBlzELMAkGA1UEBhMCVVMxEzAR
+BgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdv
+bGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxEzARBgNVBAMMClNlcnZl
+ciAxMjcxHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiV
+zi9O1vYciLx8n/uoZ3/+XJxRdfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5v
+LobYlXParBtTuV8/1xkNJU/hY2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowY
+qQJtr8MZAS64EOPGzEC0aaNGM2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8
+I3PRCQOJFNIQuWTDKtChlkq84dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0l
+yWoNwzlgpLSwaUJCCenYCLwzILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjgfEw
+ge4wHQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHBBgNVHSMEgbkwgbaA
+FLMRMsmSmITiyfjQO24DQsofDo48oYGapIGXMIGUMQswCQYDVQQGEwJVUzEQMA4G
+A1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3dG9v
+dGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNv
+bTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIBajAJBgNVHRMEAjAA
+MA0GCSqGSIb3DQEBBQUAA4IBAQBlBWNDX5GkVDE+6FWse7JXwvIuPfJTzxO1NXy2
++aeG4kGqFGplaRf7Ajl8MXiAmg0nEJp8LBcwAzJqPwb6GQKDkXFNUOBVF+3sYjsp
+US7JmnU7kfm80C1P/zDYHbZ+jjlwocnR96OBpXxd5ODPQ2ChwLjnFu1DbbIJzbxR
+V/BzossDtsdWl5bGjJOqRD1iDLXKuGUbmI+tmJ6bLoMN5tB22MVcSp5AiGXADrxc
+h93B4FG3i9Vz2o2DDRZgo//0fEqFu6GB9Z5d+OfWnWpbnSv4PQIW/7lqYMlkQF2c
+N6S47oJSXNsHXwSYSvLsbIZQnKCZWySa2X0fXfN+R1kQSPUq
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-127-chain.pem
+++ b/certs/test-pathlen/server-127-chain.pem
@@ -1,0 +1,175 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 107 (0x6b)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 127 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:09:11 2016 GMT
+            Not After : Jun 17 00:09:11 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 127/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:6A
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+    Signature Algorithm: sha1WithRSAEncryption
+         65:05:63:43:5f:91:a4:54:31:3e:e8:55:ac:7b:b2:57:c2:f2:
+         2e:3d:f2:53:cf:13:b5:35:7c:b6:f9:a7:86:e2:41:aa:14:6a:
+         65:69:17:fb:02:39:7c:31:78:80:9a:0d:27:10:9a:7c:2c:17:
+         30:03:32:6a:3f:06:fa:19:02:83:91:71:4d:50:e0:55:17:ed:
+         ec:62:3b:29:51:2e:c9:9a:75:3b:91:f9:bc:d0:2d:4f:ff:30:
+         d8:1d:b6:7e:8e:39:70:a1:c9:d1:f7:a3:81:a5:7c:5d:e4:e0:
+         cf:43:60:a1:c0:b8:e7:16:ed:43:6d:b2:09:cd:bc:51:57:f0:
+         73:a2:cb:03:b6:c7:56:97:96:c6:8c:93:aa:44:3d:62:0c:b5:
+         ca:b8:65:1b:98:8f:ad:98:9e:9b:2e:83:0d:e6:d0:76:d8:c5:
+         5c:4a:9e:40:88:65:c0:0e:bc:5c:87:dd:c1:e0:51:b7:8b:d5:
+         73:da:8d:83:0d:16:60:a3:ff:f4:7c:4a:85:bb:a1:81:f5:9e:
+         5d:f8:e7:d6:9d:6a:5b:9d:2b:f8:3d:02:16:ff:b9:6a:60:c9:
+         64:40:5d:9c:37:a4:b8:ee:82:52:5c:db:07:5f:04:98:4a:f2:
+         ec:6c:86:50:9c:a0:99:5b:24:9a:d9:7d:1f:5d:f3:7e:47:59:
+         10:48:f5:2a
+-----BEGIN CERTIFICATE-----
+MIIEoDCCA4igAwIBAgIBazANBgkqhkiG9w0BAQUFADCBmjELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFjAUBgNVBAMMDVNl
+cnZlciAxMjcgQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcN
+MTYwOTIwMDAwOTExWhcNMTkwNjE3MDAwOTExWjCBlzELMAkGA1UEBhMCVVMxEzAR
+BgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdv
+bGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxEzARBgNVBAMMClNlcnZl
+ciAxMjcxHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiV
+zi9O1vYciLx8n/uoZ3/+XJxRdfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5v
+LobYlXParBtTuV8/1xkNJU/hY2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowY
+qQJtr8MZAS64EOPGzEC0aaNGM2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8
+I3PRCQOJFNIQuWTDKtChlkq84dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0l
+yWoNwzlgpLSwaUJCCenYCLwzILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjgfEw
+ge4wHQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHBBgNVHSMEgbkwgbaA
+FLMRMsmSmITiyfjQO24DQsofDo48oYGapIGXMIGUMQswCQYDVQQGEwJVUzEQMA4G
+A1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3dG9v
+dGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNv
+bTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIBajAJBgNVHRMEAjAA
+MA0GCSqGSIb3DQEBBQUAA4IBAQBlBWNDX5GkVDE+6FWse7JXwvIuPfJTzxO1NXy2
++aeG4kGqFGplaRf7Ajl8MXiAmg0nEJp8LBcwAzJqPwb6GQKDkXFNUOBVF+3sYjsp
+US7JmnU7kfm80C1P/zDYHbZ+jjlwocnR96OBpXxd5ODPQ2ChwLjnFu1DbbIJzbxR
+V/BzossDtsdWl5bGjJOqRD1iDLXKuGUbmI+tmJ6bLoMN5tB22MVcSp5AiGXADrxc
+h93B4FG3i9Vz2o2DDRZgo//0fEqFu6GB9Z5d+OfWnWpbnSv4PQIW/7lqYMlkQF2c
+N6S47oJSXNsHXwSYSvLsbIZQnKCZWySa2X0fXfN+R1kQSPUq
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 106 (0x6a)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 19 23:24:16 2016 GMT
+            Not After : Jun 16 23:24:16 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 127 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:B7:B6:90:33:66:1B:6B:23
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:127
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         34:c3:f2:9a:80:df:5c:8a:b4:c1:08:f5:c6:72:a2:74:90:1d:
+         e9:f9:7a:e7:6e:3b:df:be:01:28:6b:10:ee:5f:9d:8d:5b:7a:
+         fc:40:12:7f:b6:bb:ac:d9:07:73:78:d0:4f:53:5d:f8:c3:50:
+         ba:f7:76:a2:e5:12:fa:8f:01:24:a2:b7:8a:e4:6c:0b:62:51:
+         37:39:4a:90:eb:11:16:26:58:44:ed:3f:41:57:8e:32:7a:e4:
+         85:a7:ce:44:d2:46:28:9e:29:34:9b:16:a5:17:ef:56:11:0a:
+         60:b8:88:7c:3e:ed:ec:5e:57:5f:b1:b9:b7:55:38:a0:ea:04:
+         58:22:04:7e:30:f3:40:33:a1:cd:3f:24:72:7b:a4:b4:2d:b5:
+         96:b3:80:7a:48:85:83:3c:6e:55:43:7c:13:d3:5e:f8:70:32:
+         da:5a:78:db:d0:54:54:9c:e9:38:05:da:7c:ac:bb:ec:79:cf:
+         3e:56:32:ce:29:31:70:07:9a:c7:b4:00:02:33:af:1b:ce:7c:
+         16:ff:8b:c0:8b:80:1e:0d:c7:d4:07:95:49:d4:9a:ed:55:b6:
+         1f:bd:e7:77:b9:fa:af:29:6a:49:79:02:3c:b9:ea:6c:68:c3:
+         ef:ca:40:27:d0:15:d0:da:31:9c:2f:3d:a5:66:e3:f8:a4:98:
+         d5:00:5f:b2
+-----BEGIN CERTIFICATE-----
+MIIEujCCA6KgAwIBAgIBajANBgkqhkiG9w0BAQUFADCBlDELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
+d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTYwOTE5
+MjMyNDE2WhcNMTkwNjE2MjMyNDE2WjCBmjELMAkGA1UEBhMCVVMxEzARBgNVBAgM
+Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdvbGZTU0wg
+SW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFjAUBgNVBAMMDVNlcnZlciAxMjcg
+Q0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0GCSqGSIb3
+DQEBAQUAA4IBDwAwggEKAoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiVzi9O
+1vYciLx8n/uoZ3/+XJxRdfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5vLobY
+lXParBtTuV8/1xkNJU/hY2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowYqQJt
+r8MZAS64EOPGzEC0aaNGM2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8I3PR
+CQOJFNIQuWTDKtChlkq84dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0lyWoN
+wzlgpLSwaUJCCenYCLwzILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjggENMIIB
+CTAdBgNVHQ4EFgQUsxEyyZKYhOLJ+NA7bgNCyh8OjjwwgckGA1UdIwSBwTCBvoAU
+J45nEXTDJh0/7TNjs6TYHTDl6NWhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYD
+VQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290
+aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29t
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggkAt7aQM2YbayMwDwYD
+VR0TBAgwBgEB/wIBfzALBgNVHQ8EBAMCAQYwDQYJKoZIhvcNAQEFBQADggEBADTD
+8pqA31yKtMEI9cZyonSQHen5euduO9++AShrEO5fnY1bevxAEn+2u6zZB3N40E9T
+XfjDULr3dqLlEvqPASSit4rkbAtiUTc5SpDrERYmWETtP0FXjjJ65IWnzkTSRiie
+KTSbFqUX71YRCmC4iHw+7exeV1+xubdVOKDqBFgiBH4w80Azoc0/JHJ7pLQttZaz
+gHpIhYM8blVDfBPTXvhwMtpaeNvQVFSc6TgF2nysu+x5zz5WMs4pMXAHmse0AAIz
+rxvOfBb/i8CLgB4Nx9QHlUnUmu1Vth+953e5+q8pakl5Ajy56mxow+/KQCfQFdDa
+MZwvPaVm4/ikmNUAX7I=
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-128-ca.pem
+++ b/certs/test-pathlen/server-128-ca.pem
@@ -1,0 +1,89 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 108 (0x6c)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 19 23:25:55 2016 GMT
+            Not After : Jun 16 23:25:55 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 128 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:B7:B6:90:33:66:1B:6B:23
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:128
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         2c:4e:94:b0:f6:75:cc:c4:9e:b5:68:56:f6:af:57:00:aa:74:
+         99:59:6e:a8:de:d1:31:79:8a:b2:0c:42:d1:84:42:e4:89:7a:
+         65:d1:cb:3f:fe:10:0c:ab:3a:89:a2:34:67:2d:43:cd:c1:09:
+         80:b5:79:8c:0c:d8:2e:aa:c9:4c:89:59:0b:4a:1f:cd:f3:7c:
+         c1:7b:9e:26:7e:ea:c6:cd:de:b5:74:10:54:ee:0f:8f:85:5e:
+         1a:9d:61:59:80:ac:f1:b8:be:a3:7e:57:41:62:6f:c4:30:18:
+         92:cb:75:a2:fa:97:b7:90:db:ab:4f:b3:0d:05:cc:a9:e6:b8:
+         b2:57:2d:b8:b6:85:bf:98:7d:43:d1:82:11:3e:ca:8d:2f:b0:
+         5f:0d:d2:29:70:30:02:08:3a:38:bc:c9:e9:6c:59:7f:17:7b:
+         97:9a:96:9a:f4:bf:6e:e3:44:70:ac:95:f8:5a:08:74:b4:5f:
+         35:17:5e:da:77:3b:49:22:1f:9e:1d:1f:da:30:3f:69:6a:61:
+         57:8b:59:b0:4b:50:c2:22:bd:6b:79:b3:a4:7b:11:00:34:cf:
+         a9:fc:ad:99:a0:33:5c:1e:45:ab:d8:a7:71:11:c6:3a:f4:cb:
+         b5:67:85:0d:34:46:fa:f0:76:4b:51:12:6b:3a:fd:25:30:f6:
+         65:5a:61:ef
+-----BEGIN CERTIFICATE-----
+MIIEuzCCA6OgAwIBAgIBbDANBgkqhkiG9w0BAQUFADCBlDELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
+d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTYwOTE5
+MjMyNTU1WhcNMTkwNjE2MjMyNTU1WjCBmjELMAkGA1UEBhMCVVMxEzARBgNVBAgM
+Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdvbGZTU0wg
+SW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFjAUBgNVBAMMDVNlcnZlciAxMjgg
+Q0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0GCSqGSIb3
+DQEBAQUAA4IBDwAwggEKAoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiVzi9O
+1vYciLx8n/uoZ3/+XJxRdfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5vLobY
+lXParBtTuV8/1xkNJU/hY2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowYqQJt
+r8MZAS64EOPGzEC0aaNGM2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8I3PR
+CQOJFNIQuWTDKtChlkq84dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0lyWoN
+wzlgpLSwaUJCCenYCLwzILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjggEOMIIB
+CjAdBgNVHQ4EFgQUsxEyyZKYhOLJ+NA7bgNCyh8OjjwwgckGA1UdIwSBwTCBvoAU
+J45nEXTDJh0/7TNjs6TYHTDl6NWhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYD
+VQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290
+aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29t
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggkAt7aQM2YbayMwEAYD
+VR0TBAkwBwEB/wICAIAwCwYDVR0PBAQDAgEGMA0GCSqGSIb3DQEBBQUAA4IBAQAs
+TpSw9nXMxJ61aFb2r1cAqnSZWW6o3tExeYqyDELRhELkiXpl0cs//hAMqzqJojRn
+LUPNwQmAtXmMDNguqslMiVkLSh/N83zBe54mfurGzd61dBBU7g+PhV4anWFZgKzx
+uL6jfldBYm/EMBiSy3Wi+pe3kNurT7MNBcyp5riyVy24toW/mH1D0YIRPsqNL7Bf
+DdIpcDACCDo4vMnpbFl/F3uXmpaa9L9u40RwrJX4Wgh0tF81F17adztJIh+eHR/a
+MD9pamFXi1mwS1DCIr1rebOkexEANM+p/K2ZoDNcHkWr2KdxEcY69Mu1Z4UNNEb6
+8HZLURJrOv0lMPZlWmHv
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-128-cert.pem
+++ b/certs/test-pathlen/server-128-cert.pem
@@ -1,0 +1,86 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 109 (0x6d)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 128 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:10:39 2016 GMT
+            Not After : Jun 17 00:10:39 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 128/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:6C
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+    Signature Algorithm: sha1WithRSAEncryption
+         b5:8d:6e:c1:2f:26:fb:25:f5:48:99:97:42:b0:20:22:73:3a:
+         37:96:f4:f5:33:ae:10:10:51:2c:8b:30:2e:de:27:0d:f5:68:
+         b8:fd:4c:28:59:5a:ec:e5:31:7e:83:97:37:96:26:09:88:d1:
+         19:46:48:74:59:d1:4e:4a:f6:bf:f5:ea:1b:3b:99:d4:aa:7c:
+         46:60:f5:38:43:a2:2b:a7:d9:b5:30:cb:a5:2b:5a:de:68:a5:
+         9f:8c:3b:d6:6e:b2:0a:6f:3f:df:88:fe:70:83:d2:21:58:c0:
+         53:89:da:a0:33:9d:1d:f7:a1:88:d3:18:ac:9c:2a:18:45:68:
+         37:af:46:85:1a:1c:4c:bf:8c:b0:1a:c6:3e:3e:98:2e:9e:26:
+         6d:1c:8a:db:15:d2:5e:28:48:cc:07:9d:1d:e1:7d:89:b5:7a:
+         13:b1:5a:b3:03:3f:77:c4:21:7b:d2:2a:96:24:3c:d9:65:76:
+         42:e5:cb:20:30:d3:17:bc:f9:8d:dd:e4:63:ae:2a:13:0f:3c:
+         df:c5:86:dd:d4:db:79:50:6f:88:b8:58:bd:6f:09:2b:c5:21:
+         bd:1e:a0:9c:e8:97:6b:cb:c8:9a:8e:09:ac:8e:5a:72:ed:d7:
+         b0:d0:7f:85:b0:91:73:e4:2b:28:e1:a1:6d:3f:2a:8f:ea:d1:
+         df:57:64:25
+-----BEGIN CERTIFICATE-----
+MIIEoDCCA4igAwIBAgIBbTANBgkqhkiG9w0BAQUFADCBmjELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFjAUBgNVBAMMDVNl
+cnZlciAxMjggQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcN
+MTYwOTIwMDAxMDM5WhcNMTkwNjE3MDAxMDM5WjCBlzELMAkGA1UEBhMCVVMxEzAR
+BgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdv
+bGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxEzARBgNVBAMMClNlcnZl
+ciAxMjgxHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiV
+zi9O1vYciLx8n/uoZ3/+XJxRdfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5v
+LobYlXParBtTuV8/1xkNJU/hY2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowY
+qQJtr8MZAS64EOPGzEC0aaNGM2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8
+I3PRCQOJFNIQuWTDKtChlkq84dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0l
+yWoNwzlgpLSwaUJCCenYCLwzILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjgfEw
+ge4wHQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHBBgNVHSMEgbkwgbaA
+FLMRMsmSmITiyfjQO24DQsofDo48oYGapIGXMIGUMQswCQYDVQQGEwJVUzEQMA4G
+A1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3dG9v
+dGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNv
+bTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIBbDAJBgNVHRMEAjAA
+MA0GCSqGSIb3DQEBBQUAA4IBAQC1jW7BLyb7JfVImZdCsCAiczo3lvT1M64QEFEs
+izAu3icN9Wi4/UwoWVrs5TF+g5c3liYJiNEZRkh0WdFOSva/9eobO5nUqnxGYPU4
+Q6Irp9m1MMulK1reaKWfjDvWbrIKbz/fiP5wg9IhWMBTidqgM50d96GI0xisnCoY
+RWg3r0aFGhxMv4ywGsY+PpguniZtHIrbFdJeKEjMB50d4X2JtXoTsVqzAz93xCF7
+0iqWJDzZZXZC5csgMNMXvPmN3eRjrioTDzzfxYbd1Nt5UG+IuFi9bwkrxSG9HqCc
+6Jdry8iajgmsjlpy7dew0H+FsJFz5Cso4aFtPyqP6tHfV2Ql
+-----END CERTIFICATE-----

--- a/certs/test-pathlen/server-128-chain.pem
+++ b/certs/test-pathlen/server-128-chain.pem
@@ -1,0 +1,175 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 109 (0x6d)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 128 CA/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 20 00:10:39 2016 GMT
+            Not After : Jun 17 00:10:39 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 128/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:6C
+
+            X509v3 Basic Constraints: 
+                CA:FALSE
+    Signature Algorithm: sha1WithRSAEncryption
+         b5:8d:6e:c1:2f:26:fb:25:f5:48:99:97:42:b0:20:22:73:3a:
+         37:96:f4:f5:33:ae:10:10:51:2c:8b:30:2e:de:27:0d:f5:68:
+         b8:fd:4c:28:59:5a:ec:e5:31:7e:83:97:37:96:26:09:88:d1:
+         19:46:48:74:59:d1:4e:4a:f6:bf:f5:ea:1b:3b:99:d4:aa:7c:
+         46:60:f5:38:43:a2:2b:a7:d9:b5:30:cb:a5:2b:5a:de:68:a5:
+         9f:8c:3b:d6:6e:b2:0a:6f:3f:df:88:fe:70:83:d2:21:58:c0:
+         53:89:da:a0:33:9d:1d:f7:a1:88:d3:18:ac:9c:2a:18:45:68:
+         37:af:46:85:1a:1c:4c:bf:8c:b0:1a:c6:3e:3e:98:2e:9e:26:
+         6d:1c:8a:db:15:d2:5e:28:48:cc:07:9d:1d:e1:7d:89:b5:7a:
+         13:b1:5a:b3:03:3f:77:c4:21:7b:d2:2a:96:24:3c:d9:65:76:
+         42:e5:cb:20:30:d3:17:bc:f9:8d:dd:e4:63:ae:2a:13:0f:3c:
+         df:c5:86:dd:d4:db:79:50:6f:88:b8:58:bd:6f:09:2b:c5:21:
+         bd:1e:a0:9c:e8:97:6b:cb:c8:9a:8e:09:ac:8e:5a:72:ed:d7:
+         b0:d0:7f:85:b0:91:73:e4:2b:28:e1:a1:6d:3f:2a:8f:ea:d1:
+         df:57:64:25
+-----BEGIN CERTIFICATE-----
+MIIEoDCCA4igAwIBAgIBbTANBgkqhkiG9w0BAQUFADCBmjELMAkGA1UEBhMCVVMx
+EzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoM
+DHdvbGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFjAUBgNVBAMMDVNl
+cnZlciAxMjggQ0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcN
+MTYwOTIwMDAxMDM5WhcNMTkwNjE3MDAxMDM5WjCBlzELMAkGA1UEBhMCVVMxEzAR
+BgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdv
+bGZTU0wgSW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxEzARBgNVBAMMClNlcnZl
+ciAxMjgxHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiV
+zi9O1vYciLx8n/uoZ3/+XJxRdfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5v
+LobYlXParBtTuV8/1xkNJU/hY2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowY
+qQJtr8MZAS64EOPGzEC0aaNGM2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8
+I3PRCQOJFNIQuWTDKtChlkq84dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0l
+yWoNwzlgpLSwaUJCCenYCLwzILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjgfEw
+ge4wHQYDVR0OBBYEFLMRMsmSmITiyfjQO24DQsofDo48MIHBBgNVHSMEgbkwgbaA
+FLMRMsmSmITiyfjQO24DQsofDo48oYGapIGXMIGUMQswCQYDVQQGEwJVUzEQMA4G
+A1UECAwHTW9udGFuYTEQMA4GA1UEBwwHQm96ZW1hbjERMA8GA1UECgwIU2F3dG9v
+dGgxEzARBgNVBAsMCkNvbnN1bHRpbmcxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNv
+bTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIBbDAJBgNVHRMEAjAA
+MA0GCSqGSIb3DQEBBQUAA4IBAQC1jW7BLyb7JfVImZdCsCAiczo3lvT1M64QEFEs
+izAu3icN9Wi4/UwoWVrs5TF+g5c3liYJiNEZRkh0WdFOSva/9eobO5nUqnxGYPU4
+Q6Irp9m1MMulK1reaKWfjDvWbrIKbz/fiP5wg9IhWMBTidqgM50d96GI0xisnCoY
+RWg3r0aFGhxMv4ywGsY+PpguniZtHIrbFdJeKEjMB50d4X2JtXoTsVqzAz93xCF7
+0iqWJDzZZXZC5csgMNMXvPmN3eRjrioTDzzfxYbd1Nt5UG+IuFi9bwkrxSG9HqCc
+6Jdry8iajgmsjlpy7dew0H+FsJFz5Cso4aFtPyqP6tHfV2Ql
+-----END CERTIFICATE-----
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 108 (0x6c)
+    Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=US, ST=Montana, L=Bozeman, O=Sawtooth, OU=Consulting, CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+        Validity
+            Not Before: Sep 19 23:25:55 2016 GMT
+            Not After : Jun 16 23:25:55 2019 GMT
+        Subject: C=US, ST=Washington, L=Seattle, O=wolfSSL Inc., OU=Engineering, CN=Server 128 CA/emailAddress=info@wolfssl.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:95:08:e1:57:41:f2:71:6d:b7:d2:45:41:27:
+                    01:65:c6:45:ae:f2:bc:24:30:b8:95:ce:2f:4e:d6:
+                    f6:1c:88:bc:7c:9f:fb:a8:67:7f:fe:5c:9c:51:75:
+                    f7:8a:ca:07:e7:35:2f:8f:e1:bd:7b:c0:2f:7c:ab:
+                    64:a8:17:fc:ca:5d:7b:ba:e0:21:e5:72:2e:6f:2e:
+                    86:d8:95:73:da:ac:1b:53:b9:5f:3f:d7:19:0d:25:
+                    4f:e1:63:63:51:8b:0b:64:3f:ad:43:b8:a5:1c:5c:
+                    34:b3:ae:00:a0:63:c5:f6:7f:0b:59:68:78:73:a6:
+                    8c:18:a9:02:6d:af:c3:19:01:2e:b8:10:e3:c6:cc:
+                    40:b4:69:a3:46:33:69:87:6e:c4:bb:17:a6:f3:e8:
+                    dd:ad:73:bc:7b:2f:21:b5:fd:66:51:0c:bd:54:b3:
+                    e1:6d:5f:1c:bc:23:73:d1:09:03:89:14:d2:10:b9:
+                    64:c3:2a:d0:a1:96:4a:bc:e1:d4:1a:5b:c7:a0:c0:
+                    c1:63:78:0f:44:37:30:32:96:80:32:23:95:a1:77:
+                    ba:13:d2:97:73:e2:5d:25:c9:6a:0d:c3:39:60:a4:
+                    b4:b0:69:42:42:09:e9:d8:08:bc:33:20:b3:58:22:
+                    a7:aa:eb:c4:e1:e6:61:83:c5:d2:96:df:d9:d0:4f:
+                    ad:d7
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                B3:11:32:C9:92:98:84:E2:C9:F8:D0:3B:6E:03:42:CA:1F:0E:8E:3C
+            X509v3 Authority Key Identifier: 
+                keyid:27:8E:67:11:74:C3:26:1D:3F:ED:33:63:B3:A4:D8:1D:30:E5:E8:D5
+                DirName:/C=US/ST=Montana/L=Bozeman/O=Sawtooth/OU=Consulting/CN=www.wolfssl.com/emailAddress=info@wolfssl.com
+                serial:B7:B6:90:33:66:1B:6B:23
+
+            X509v3 Basic Constraints: 
+                CA:TRUE, pathlen:128
+            X509v3 Key Usage: 
+                Certificate Sign, CRL Sign
+    Signature Algorithm: sha1WithRSAEncryption
+         2c:4e:94:b0:f6:75:cc:c4:9e:b5:68:56:f6:af:57:00:aa:74:
+         99:59:6e:a8:de:d1:31:79:8a:b2:0c:42:d1:84:42:e4:89:7a:
+         65:d1:cb:3f:fe:10:0c:ab:3a:89:a2:34:67:2d:43:cd:c1:09:
+         80:b5:79:8c:0c:d8:2e:aa:c9:4c:89:59:0b:4a:1f:cd:f3:7c:
+         c1:7b:9e:26:7e:ea:c6:cd:de:b5:74:10:54:ee:0f:8f:85:5e:
+         1a:9d:61:59:80:ac:f1:b8:be:a3:7e:57:41:62:6f:c4:30:18:
+         92:cb:75:a2:fa:97:b7:90:db:ab:4f:b3:0d:05:cc:a9:e6:b8:
+         b2:57:2d:b8:b6:85:bf:98:7d:43:d1:82:11:3e:ca:8d:2f:b0:
+         5f:0d:d2:29:70:30:02:08:3a:38:bc:c9:e9:6c:59:7f:17:7b:
+         97:9a:96:9a:f4:bf:6e:e3:44:70:ac:95:f8:5a:08:74:b4:5f:
+         35:17:5e:da:77:3b:49:22:1f:9e:1d:1f:da:30:3f:69:6a:61:
+         57:8b:59:b0:4b:50:c2:22:bd:6b:79:b3:a4:7b:11:00:34:cf:
+         a9:fc:ad:99:a0:33:5c:1e:45:ab:d8:a7:71:11:c6:3a:f4:cb:
+         b5:67:85:0d:34:46:fa:f0:76:4b:51:12:6b:3a:fd:25:30:f6:
+         65:5a:61:ef
+-----BEGIN CERTIFICATE-----
+MIIEuzCCA6OgAwIBAgIBbDANBgkqhkiG9w0BAQUFADCBlDELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNh
+d3Rvb3RoMRMwEQYDVQQLDApDb25zdWx0aW5nMRgwFgYDVQQDDA93d3cud29sZnNz
+bC5jb20xHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wHhcNMTYwOTE5
+MjMyNTU1WhcNMTkwNjE2MjMyNTU1WjCBmjELMAkGA1UEBhMCVVMxEzARBgNVBAgM
+Cldhc2hpbmd0b24xEDAOBgNVBAcMB1NlYXR0bGUxFTATBgNVBAoMDHdvbGZTU0wg
+SW5jLjEUMBIGA1UECwwLRW5naW5lZXJpbmcxFjAUBgNVBAMMDVNlcnZlciAxMjgg
+Q0ExHzAdBgkqhkiG9w0BCQEWEGluZm9Ad29sZnNzbC5jb20wggEiMA0GCSqGSIb3
+DQEBAQUAA4IBDwAwggEKAoIBAQDAlQjhV0HycW230kVBJwFlxkWu8rwkMLiVzi9O
+1vYciLx8n/uoZ3/+XJxRdfeKygfnNS+P4b17wC98q2SoF/zKXXu64CHlci5vLobY
+lXParBtTuV8/1xkNJU/hY2NRiwtkP61DuKUcXDSzrgCgY8X2fwtZaHhzpowYqQJt
+r8MZAS64EOPGzEC0aaNGM2mHbsS7F6bz6N2tc7x7LyG1/WZRDL1Us+FtXxy8I3PR
+CQOJFNIQuWTDKtChlkq84dQaW8egwMFjeA9ENzAyloAyI5Whd7oT0pdz4l0lyWoN
+wzlgpLSwaUJCCenYCLwzILNYIqeq68Th5mGDxdKW39nQT63XAgMBAAGjggEOMIIB
+CjAdBgNVHQ4EFgQUsxEyyZKYhOLJ+NA7bgNCyh8OjjwwgckGA1UdIwSBwTCBvoAU
+J45nEXTDJh0/7TNjs6TYHTDl6NWhgZqkgZcwgZQxCzAJBgNVBAYTAlVTMRAwDgYD
+VQQIDAdNb250YW5hMRAwDgYDVQQHDAdCb3plbWFuMREwDwYDVQQKDAhTYXd0b290
+aDETMBEGA1UECwwKQ29uc3VsdGluZzEYMBYGA1UEAwwPd3d3LndvbGZzc2wuY29t
+MR8wHQYJKoZIhvcNAQkBFhBpbmZvQHdvbGZzc2wuY29tggkAt7aQM2YbayMwEAYD
+VR0TBAkwBwEB/wICAIAwCwYDVR0PBAQDAgEGMA0GCSqGSIb3DQEBBQUAA4IBAQAs
+TpSw9nXMxJ61aFb2r1cAqnSZWW6o3tExeYqyDELRhELkiXpl0cs//hAMqzqJojRn
+LUPNwQmAtXmMDNguqslMiVkLSh/N83zBe54mfurGzd61dBBU7g+PhV4anWFZgKzx
+uL6jfldBYm/EMBiSy3Wi+pe3kNurT7MNBcyp5riyVy24toW/mH1D0YIRPsqNL7Bf
+DdIpcDACCDo4vMnpbFl/F3uXmpaa9L9u40RwrJX4Wgh0tF81F17adztJIh+eHR/a
+MD9pamFXi1mwS1DCIr1rebOkexEANM+p/K2ZoDNcHkWr2KdxEcY69Mu1Z4UNNEb6
+8HZLURJrOv0lMPZlWmHv
+-----END CERTIFICATE-----

--- a/src/internal.c
+++ b/src/internal.c
@@ -6099,7 +6099,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
 
     x509->basicConstSet = dCert->extBasicConstSet;
     x509->basicConstCrit = dCert->extBasicConstCrit;
-    x509->basicConstPlSet = dCert->extBasicConstPlSet;
+    x509->basicConstPlSet = dCert->pathLengthSet;
     x509->subjAltNameSet = dCert->extSubjAltNameSet;
     x509->subjAltNameCrit = dCert->extSubjAltNameCrit;
     x509->authKeyIdSet = dCert->extAuthKeyIdSet;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3155,6 +3155,8 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
             signer->pubKeySize     = cert->pubKeySize;
             signer->nameLen        = cert->subjectCNLen;
             signer->name           = cert->subjectCN;
+            signer->pathLength     = cert->pathLength;
+            signer->pathLengthSet  = cert->pathLengthSet;
         #ifndef IGNORE_NAME_CONSTRAINTS
             signer->permittedNames = cert->permittedNames;
             signer->excludedNames  = cert->excludedNames;

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -395,6 +395,12 @@ const char* wc_GetErrorString(int error)
     case MISSING_RNG_E:
         return "RNG required but not provided";
 
+    case ASN_PATHLEN_SIZE_E:
+        return "ASN CA path length value too large error";
+
+    case ASN_PATHLEN_INV_E:
+        return "ASN CA path length larger than signer error";
+
     default:
         return "unknown error number";
 

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -444,6 +444,8 @@ struct DecodedCert {
     byte    extNameConstraintSet;
 #endif /* IGNORE_NAME_CONSTRAINTS */
     byte    isCA;                    /* CA basic constraint true         */
+    byte    pathLengthSet;           /* CA basic const path length set   */
+    byte    pathLength;              /* CA basic constraint path length  */
     byte    weOwnAltNames;           /* altNames haven't been given to copy */
     byte    extKeyUsageSet;
     word16  extKeyUsage;             /* Key usage bitfield               */
@@ -452,8 +454,6 @@ struct DecodedCert {
 #ifdef OPENSSL_EXTRA
     byte    extBasicConstSet;
     byte    extBasicConstCrit;
-    byte    extBasicConstPlSet;
-    word32  pathLength;              /* CA basic constraint path length, opt */
     byte    extSubjAltNameSet;
     byte    extSubjAltNameCrit;
     byte    extAuthKeyIdCrit;
@@ -564,6 +564,8 @@ struct Signer {
     word32  pubKeySize;
     word32  keyOID;                  /* key type */
     word16  keyUsage;
+    byte    pathLength;
+    byte    pathLengthSet;
     byte*   publicKey;
     int     nameLen;
     char*   name;                    /* common name */

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -175,6 +175,8 @@ enum {
     WC_KEY_SIZE_E       = -234,  /* Key size error, either too small or large */
     ASN_COUNTRY_SIZE_E  = -235,  /* ASN Cert Gen, invalid country code size */
     MISSING_RNG_E       = -236,  /* RNG required but not provided */
+    ASN_PATHLEN_SIZE_E  = -237,  /* ASN CA path length too large error */
+    ASN_PATHLEN_INV_E   = -238,  /* ASN CA path length inversion error */
 
     MIN_CODE_E          = -300   /* errors -101 - -299 */
 


### PR DESCRIPTION
1. Check the path length between an intermediate CA cert and its
   signer's path length.
2. Always decode the path length if present and store it in the decoded
   certificate.
3. Save the path length into the signer list.
4. Path length capped at 127.
5. Added some test certs for checking CA path lengths.