### PR TITLE
Optimize memory usage for ARM Cortex M and similar embedded systems

### DIFF
--- a/wolfcrypt/src/ge_operations.c
+++ b/wolfcrypt/src/ge_operations.c
@@ -758,7 +758,7 @@ static unsigned char negative(signed char b)
 }
 
 
-static void cmov(ge_precomp *t,ge_precomp *u,unsigned char b)
+static void cmov(ge_precomp *t,const ge_precomp *u,unsigned char b)
 {
   fe_cmov(t->yplusx,u->yplusx,b);
   fe_cmov(t->yminusx,u->yminusx,b);
@@ -767,7 +767,7 @@ static void cmov(ge_precomp *t,ge_precomp *u,unsigned char b)
 
 
 /* base[i][j] = (j+1)*256^i*B */
-static ge_precomp base[32][8] = {
+static const ge_precomp base[32][8] = {
 {
  {
   { 25967493,-14356035,29566456,3660896,-12694345,4014787,27544626,-11754271,-6079156,2047605 },
@@ -2222,7 +2222,7 @@ static void slide(signed char *r,const unsigned char *a)
 }
 
 
-static ge_precomp Bi[8] = {
+static const ge_precomp Bi[8] = {
  {
   { 25967493,-14356035,29566456,3660896,-12694345,4014787,27544626,-11754271,-6079156,2047605 },
   { -12545711,934262,-2722910,3049990,-727428,9406986,12720692,5043384,19500929,-15469378 },

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -401,6 +401,24 @@
     #define SINGLE_THREADED         /* Not ported at this time */
 #endif
 
+#ifdef WOLFSSL_NRF5x
+		#define SIZEOF_LONG 4
+		#define SIZEOF_LONG_LONG 8
+		#define NO_ASN_TIME
+		#define NO_DEV_RANDOM
+		#define NO_FILESYSTEM
+		#define NO_MAIN_DRIVER
+		#define NO_WRITEV
+		#define SINGLE_THREADED
+		#define USE_FAST_MATH
+		#define TFM_TIMING_RESISTANT
+		#define ECC_TIMING_RESISTANT
+		#define USE_WOLFSSL_MEMORY
+		#define WOLFSSL_NRF51
+		#define WOLFSSL_USER_IO
+		#define NO_SESSION_CACHE
+#endif
+
 /* Micrium will use Visual Studio for compilation but not the Win32 API */
 #if defined(_WIN32) && !defined(MICRIUM) && !defined(FREERTOS) && \
 	!defined(FREERTOS_TCP) && !defined(EBSNET) && !defined(WOLFSSL_EROAD) && \

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -124,6 +124,9 @@
 /* Uncomment next line if building for VxWorks */
 /* #define WOLFSSL_VXWORKS */
 
+/* Uncomment next line if building for Nordic nRF5x platofrm */
+/* #define WOLFSSL_NRF5x */
+
 /* Uncomment next line to enable deprecated less secure static DH suites */
 /* #define WOLFSSL_STATIC_DH */
 
@@ -412,7 +415,6 @@
 		#define SINGLE_THREADED
 		#define USE_FAST_MATH
 		#define TFM_TIMING_RESISTANT
-		#define ECC_TIMING_RESISTANT
 		#define USE_WOLFSSL_MEMORY
 		#define WOLFSSL_NRF51
 		#define WOLFSSL_USER_IO


### PR DESCRIPTION
Proposed change adds `const` modifier to precomputed `ge_precomp` tables in `ge_operations.c`. 

On embedded systems this forces them to be stored in flash memory instead of RAM. 

Before patch my demo program for Nordic nRF5x platform used almost 50kb of RAM. After the patch memory usage dropped to 18 kb from which 16 kb is heap and stack space statically allocated by init. 

This makes a world of difference on embedded systems where RAM is very limited. For example it allows usage of precomputed curve parameters on nRF51 systems which have only 32kb of RAM. 

The other modification adds minimal configuration profile for Nordic nRF5x system. After defining `WOLFSSL_NRF5x` in the Makefile WolfSSL compiles and runs without issues on nRF51-DK and nRF52-DK reference design boards with SDK12.
