### PR TITLE
Fixes for building the library with a C++ compiler with TLSX enabled

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1878,7 +1878,8 @@ int wc_ecc_mulmod(mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
 
 
 #ifndef WC_NO_CACHE_RESISTANT
-#if defined(TFM_TIMING_RESISTANT) && defined(USE_FAST_MATH)
+#if defined(TFM_TIMING_RESISTANT) && defined(USE_FAST_MATH) && \
+    !defined(__cplusplus)
     /* let's use the one we already have */
     extern const wolfssl_word wc_off_on_addr[2];
 #else


### PR DESCRIPTION
1. Add many typecasts for malloc() data to proper pointer type.
2. Add many typecasts for constants in tertiary operators.
3. ECC to use local copy of wc_off_on_addr instead of extern copy.

To recreate, with gcc:

    $ ./configure --enable-tlsx CC=g++ && make

Note, clang++ on the Mac has its own issues, like not wanting to compile C code. Fix 3 didn't happen until link time.