### PR TITLE
Smallstack fixes

### DIFF
--- a/mcapi/crypto.h
+++ b/mcapi/crypto.h
@@ -104,7 +104,7 @@ enum {
 
 /* HMAC */
 typedef struct CRYPT_HMAC_CTX {
-    long long holder[68];   /* big enough to hold internal, but check on init */
+    long long holder[104];   /* big enough to hold internal, but check on init */
 } CRYPT_HMAC_CTX;
 
 int CRYPT_HMAC_SetKey(CRYPT_HMAC_CTX*, int, const unsigned char*, unsigned int);
@@ -164,7 +164,7 @@ enum {
 
 /* AES */
 typedef struct CRYPT_AES_CTX {
-    int holder[76];   /* big enough to hold internal, but check on init */
+    int holder[80];   /* big enough to hold internal, but check on init */
 } CRYPT_AES_CTX;
 
 /* key */

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -797,8 +797,8 @@ int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(tmp, hmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(prk, hmac->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(tmp, myHmac.heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(prk, myHmac.heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return ret;

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1284,7 +1284,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         WOLFSSL_MSG("Failed to create RecipientInfo");
         wc_FreeRng(&rng);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMMIC_TYPE_TMP_BUFFER);
+        XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return recipSz;
     }
@@ -1295,7 +1295,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     wc_FreeRng(&rng);
     if (ret != 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMMIC_TYPE_TMP_BUFFER);
+        XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -1304,7 +1304,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     contentTypeSz = wc_SetContentType(pkcs7->contentOID, contentType);
     if (contentTypeSz == 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMMIC_TYPE_TMP_BUFFER);
+        XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return BAD_FUNC_ARG;
     }
@@ -1316,7 +1316,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     plain = (byte*)XMALLOC(desOutSz, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (plain == NULL) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMMIC_TYPE_TMP_BUFFER);
+        XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return MEMORY_E;
     }
@@ -1331,7 +1331,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     if (encryptedContent == NULL) {
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMMIC_TYPE_TMP_BUFFER);
+        XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return MEMORY_E;
     }
@@ -1348,7 +1348,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMMIC_TYPE_TMP_BUFFER);
+        XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return BAD_FUNC_ARG;
     }
@@ -1366,7 +1366,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
             XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(recip, NULL, DYNAMMIC_TYPE_TMP_BUFFER);
+            XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
             return ret;
         }
@@ -1383,7 +1383,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
             XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(recip, NULL, DYNAMMIC_TYPE_TMP_BUFFER);
+            XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
             return ret;
         }
@@ -1419,7 +1419,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMMIC_TYPE_TMP_BUFFER);
+        XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return BUFFER_E;
     }
@@ -1459,7 +1459,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(recip, NULL, DYNAMMIC_TYPE_TMP_BUFFER);
+    XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return idx;

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1725,7 +1725,7 @@ static int Transform_AVX2(Sha256* sha256)
     RegToDigest(S_0,S_1,S_2,S_3,S_4,S_5,S_6,S_7) ;  
 
     #ifdef WOLFSSL_SMALL_STACK
-        XFREE(W, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(W_K, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     #endif
     
     return 0;


### PR DESCRIPTION
It appears that the SMALL_STACK #ifdef'd code suffered from typos and variable name changes...
The following changes are all required for compilation.
