### PR TITLE
64-bit Sequence Number

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -571,22 +571,27 @@ static int ExportKeyState(WOLFSSL* ssl, byte* exp, word32 len, byte ver)
     c32toa(keys->sequence_number_hi, exp + idx);      idx += OPAQUE32_LEN;
     c32toa(keys->sequence_number_lo, exp + idx);      idx += OPAQUE32_LEN;
 
-    c16toa(keys->nextEpoch, exp + idx); idx += OPAQUE16_LEN;
-    c32toa(keys->nextSeq, exp + idx);   idx += OPAQUE32_LEN;
-    c16toa(keys->curEpoch, exp + idx);  idx += OPAQUE16_LEN;
-    c32toa(keys->curSeq, exp + idx);    idx += OPAQUE32_LEN;
-    c32toa(keys->prevSeq, exp + idx);   idx += OPAQUE32_LEN;
+    c16toa(keys->nextEpoch, exp + idx);  idx += OPAQUE16_LEN;
+    c16toa(keys->nextSeq_hi, exp + idx); idx += OPAQUE16_LEN;
+    c32toa(keys->nextSeq_lo, exp + idx); idx += OPAQUE32_LEN;
+    c16toa(keys->curEpoch, exp + idx);   idx += OPAQUE16_LEN;
+    c16toa(keys->curSeq_hi, exp + idx);  idx += OPAQUE16_LEN;
+    c32toa(keys->curSeq_lo, exp + idx);  idx += OPAQUE32_LEN;
+    c16toa(keys->prevSeq_hi, exp + idx); idx += OPAQUE16_LEN;
+    c32toa(keys->prevSeq_lo, exp + idx); idx += OPAQUE32_LEN;
 
     c16toa(keys->dtls_peer_handshake_number, exp + idx); idx += OPAQUE16_LEN;
     c16toa(keys->dtls_expected_peer_handshake_number, exp + idx);
     idx += OPAQUE16_LEN;
 
-    c32toa(keys->dtls_sequence_number, exp + idx);      idx += OPAQUE32_LEN;
-    c32toa(keys->dtls_prev_sequence_number, exp + idx); idx += OPAQUE32_LEN;
-    c16toa(keys->dtls_epoch, exp + idx);                idx += OPAQUE16_LEN;
-    c16toa(keys->dtls_handshake_number, exp + idx);     idx += OPAQUE16_LEN;
-    c32toa(keys->encryptSz, exp + idx);                 idx += OPAQUE32_LEN;
-    c32toa(keys->padSz, exp + idx);                     idx += OPAQUE32_LEN;
+    c16toa(keys->dtls_sequence_number_hi, exp + idx);      idx += OPAQUE16_LEN;
+    c32toa(keys->dtls_sequence_number_lo, exp + idx);      idx += OPAQUE32_LEN;
+    c16toa(keys->dtls_prev_sequence_number_hi, exp + idx); idx += OPAQUE16_LEN;
+    c32toa(keys->dtls_prev_sequence_number_lo, exp + idx); idx += OPAQUE32_LEN;
+    c16toa(keys->dtls_epoch, exp + idx);                   idx += OPAQUE16_LEN;
+    c16toa(keys->dtls_handshake_number, exp + idx);        idx += OPAQUE16_LEN;
+    c32toa(keys->encryptSz, exp + idx);                    idx += OPAQUE32_LEN;
+    c32toa(keys->padSz, exp + idx);                        idx += OPAQUE32_LEN;
     exp[idx++] = keys->encryptionOn;
     exp[idx++] = keys->decryptedCur;
 
@@ -697,22 +702,27 @@ static int ImportKeyState(WOLFSSL* ssl, byte* exp, word32 len, byte ver)
     ato32(exp + idx, &keys->sequence_number_hi);      idx += OPAQUE32_LEN;
     ato32(exp + idx, &keys->sequence_number_lo);      idx += OPAQUE32_LEN;
 
-    ato16(exp + idx, &keys->nextEpoch); idx += OPAQUE16_LEN;
-    ato32(exp + idx, &keys->nextSeq);   idx += OPAQUE32_LEN;
-    ato16(exp + idx, &keys->curEpoch);  idx += OPAQUE16_LEN;
-    ato32(exp + idx, &keys->curSeq);    idx += OPAQUE32_LEN;
-    ato32(exp + idx, &keys->prevSeq);   idx += OPAQUE32_LEN;
+    ato16(exp + idx, &keys->nextEpoch);  idx += OPAQUE16_LEN;
+    ato16(exp + idx, &keys->nextSeq_hi); idx += OPAQUE16_LEN;
+    ato32(exp + idx, &keys->nextSeq_lo); idx += OPAQUE32_LEN;
+    ato16(exp + idx, &keys->curEpoch);   idx += OPAQUE16_LEN;
+    ato16(exp + idx, &keys->curSeq_hi);  idx += OPAQUE16_LEN;
+    ato32(exp + idx, &keys->curSeq_lo);  idx += OPAQUE32_LEN;
+    ato16(exp + idx, &keys->prevSeq_hi); idx += OPAQUE16_LEN;
+    ato32(exp + idx, &keys->prevSeq_lo); idx += OPAQUE32_LEN;
 
     ato16(exp + idx, &keys->dtls_peer_handshake_number); idx += OPAQUE16_LEN;
     ato16(exp + idx, &keys->dtls_expected_peer_handshake_number);
     idx += OPAQUE16_LEN;
 
-    ato32(exp + idx, &keys->dtls_sequence_number);      idx += OPAQUE32_LEN;
-    ato32(exp + idx, &keys->dtls_prev_sequence_number); idx += OPAQUE32_LEN;
-    ato16(exp + idx, &keys->dtls_epoch);                idx += OPAQUE16_LEN;
-    ato16(exp + idx, &keys->dtls_handshake_number);     idx += OPAQUE16_LEN;
-    ato32(exp + idx, &keys->encryptSz);                 idx += OPAQUE32_LEN;
-    ato32(exp + idx, &keys->padSz);                     idx += OPAQUE32_LEN;
+    ato16(exp + idx, &keys->dtls_sequence_number_hi);      idx += OPAQUE16_LEN;
+    ato32(exp + idx, &keys->dtls_sequence_number_lo);      idx += OPAQUE32_LEN;
+    ato16(exp + idx, &keys->dtls_prev_sequence_number_hi); idx += OPAQUE16_LEN;
+    ato32(exp + idx, &keys->dtls_prev_sequence_number_lo); idx += OPAQUE32_LEN;
+    ato16(exp + idx, &keys->dtls_epoch);                   idx += OPAQUE16_LEN;
+    ato16(exp + idx, &keys->dtls_handshake_number);        idx += OPAQUE16_LEN;
+    ato32(exp + idx, &keys->encryptSz);                    idx += OPAQUE32_LEN;
+    ato32(exp + idx, &keys->padSz);                        idx += OPAQUE32_LEN;
     keys->encryptionOn = exp[idx++];
     keys->decryptedCur = exp[idx++];
 
@@ -7776,7 +7786,7 @@ static INLINE int DtlsCheckWindow(WOLFSSL* ssl)
     else {
         return 0;
     }
-/* XXX Handle rollover */
+
     cur_hi = ssl->keys.curSeq_hi;
     cur_lo = ssl->keys.curSeq_lo;
 
@@ -10315,8 +10325,10 @@ int SendCertificate(WOLFSSL* ssl)
                 return sendSz;
         }
         else {
-            if (ssl->options.dtls)
-                DtlsSEQIncrement(ssl, 0);
+            #ifdef WOLFSSL_DTLS
+                if (ssl->options.dtls)
+                    DtlsSEQIncrement(ssl, 0);
+            #endif
         }
 
         #ifdef WOLFSSL_DTLS
@@ -10342,7 +10354,10 @@ int SendCertificate(WOLFSSL* ssl)
     if (ret != WANT_WRITE) {
         /* Clean up the fragment offset. */
         ssl->fragOffset = 0;
-        ssl->keys.dtls_handshake_number++;
+        #ifdef WOLFSSL_DTLS
+            if (ssl->options.dtls)
+                ssl->keys.dtls_handshake_number++;
+        #endif
         if (ssl->options.side == WOLFSSL_SERVER_END)
             ssl->options.serverState = SERVER_CERT_COMPLETE;
     }

--- a/src/internal.c
+++ b/src/internal.c
@@ -3992,7 +3992,7 @@ static INLINE void DtlsSEQIncrement(WOLFSSL* ssl, int verify)
 
 static INLINE void WriteSEQ(WOLFSSL* ssl, int verify, byte* out)
 {
-    word32 seq[2];
+    word32 seq[2] = {0, 0};
 
     if (!ssl->options.dtls) {
         GetSEQIncrement(ssl, verify, seq);

--- a/src/keys.c
+++ b/src/keys.c
@@ -2628,10 +2628,14 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
     }
 #endif
 
-    if (enc)
-        keys->sequence_number      = 0;
-    if (dec)
-        keys->peer_sequence_number = 0;
+    if (enc) {
+        keys->sequence_number_hi      = 0;
+        keys->sequence_number_lo      = 0;
+    }
+    if (dec) {
+        keys->peer_sequence_number_hi = 0;
+        keys->peer_sequence_number_lo = 0;
+    }
     (void)side;
     (void)heap;
     (void)enc;
@@ -2766,7 +2770,8 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
             #endif
         }
         if (wc_decrypt) {
-            ssl->keys.peer_sequence_number = keys->peer_sequence_number;
+            ssl->keys.peer_sequence_number_hi = keys->peer_sequence_number_hi;
+            ssl->keys.peer_sequence_number_lo = keys->peer_sequence_number_lo;
             #ifdef HAVE_AEAD
                 if (ssl->specs.cipher_type == aead) {
                     /* Initialize decrypt implicit IV by decrypt side */

--- a/src/keys.c
+++ b/src/keys.c
@@ -2751,7 +2751,8 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
                     keys->server_write_IV, MAX_WRITE_IV_SZ);
         }
         if (wc_encrypt) {
-            ssl->keys.sequence_number = keys->sequence_number;
+            ssl->keys.sequence_number_hi = keys->sequence_number_hi;
+            ssl->keys.sequence_number_lo = keys->sequence_number_lo;
             #ifdef HAVE_AEAD
                 if (ssl->specs.cipher_type == aead) {
                     /* Initialize the AES-GCM/CCM explicit IV to a zero. */

--- a/src/tls.c
+++ b/src/tls.c
@@ -688,7 +688,7 @@ static INLINE void DtlsGetSEQ(WOLFSSL* ssl, int verify, word32 seq[2])
 
 static INLINE void WriteSEQ(WOLFSSL* ssl, int verify, byte* out)
 {
-    word32 seq[2];
+    word32 seq[2] = {0, 0};
 
     if (!ssl->options.dtls) {
         GetSEQIncrement(ssl, verify, seq);

--- a/src/tls.c
+++ b/src/tls.c
@@ -664,15 +664,15 @@ static INLINE void GetSEQIncrement(WOLFSSL* ssl, int verify, word32 seq[2])
 
 
 #ifdef WOLFSSL_DTLS
-static INLINE void DtlsGetSEQ(WOLFSSL* ssl, int verify, word32 seq[2])
+static INLINE void DtlsGetSEQ(WOLFSSL* ssl, int order, word32 seq[2])
 {
-    if (verify == -1) {
+    if (order == PREV_ORDER) {
         /* Previous epoch case */
         seq[0] = ((ssl->keys.dtls_epoch - 1) << 16) |
                  (ssl->keys.dtls_prev_sequence_number_hi & 0xFFFF);
         seq[1] = ssl->keys.dtls_prev_sequence_number_lo;
     }
-    else if (verify == 1) {
+    else if (order == PEER_ORDER) {
         seq[0] = (ssl->keys.curEpoch << 16) |
                  (ssl->keys.curSeq_hi & 0xFFFF);
         seq[1] = ssl->keys.curSeq_lo; /* explicit from peer */
@@ -686,21 +686,21 @@ static INLINE void DtlsGetSEQ(WOLFSSL* ssl, int verify, word32 seq[2])
 #endif /* WOLFSSL_DTLS */
 
 
-static INLINE void WriteSEQ(WOLFSSL* ssl, int verify, byte* out)
+static INLINE void WriteSEQ(WOLFSSL* ssl, int verifyOrder, byte* out)
 {
     word32 seq[2] = {0, 0};
 
     if (!ssl->options.dtls) {
-        GetSEQIncrement(ssl, verify, seq);
+        GetSEQIncrement(ssl, verifyOrder, seq);
     }
     else {
 #ifdef WOLFSSL_DTLS
-        DtlsGetSEQ(ssl, verify, seq);
+        DtlsGetSEQ(ssl, verifyOrder, seq);
 #endif
     }
 
     c32toa(seq[0], out);
-    c32toa(seq[1], out+4);
+    c32toa(seq[1], out + OPAQUE32_LEN);
 }
 
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1062,7 +1062,11 @@ enum Misc {
     HASH_SIG_SIZE      =   2,  /* default SHA1 RSA */
 
     NO_COPY            =   0,  /* should we copy static buffer for write */
-    COPY               =   1   /* should we copy static buffer for write */
+    COPY               =   1,  /* should we copy static buffer for write */
+
+    PREV_ORDER         = -1,   /* Sequence number is in previous epoch. */
+    PEER_ORDER         = 1,    /* Peer sequence number for verify. */
+    CUR_ORDER          = 0     /* Current sequence number. */
 };
 
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1608,25 +1608,25 @@ typedef struct Keys {
 
 #ifdef WOLFSSL_DTLS
     DtlsSeq window;     /* Sliding window for current epoch    */
-        word16 nextEpoch;   /* Expected epoch in next record       */
-        word16 nextSeq_hi;  /* Expected sequence in next record    */
-        word32 nextSeq_lo;
+    word16 nextEpoch;   /* Expected epoch in next record       */
+    word16 nextSeq_hi;  /* Expected sequence in next record    */
+    word32 nextSeq_lo;
 
-        word16 curEpoch;    /* Received epoch in current record    */
-        word16 curSeq_hi;   /* Received sequence in current record */
-        word32 curSeq_lo;
+    word16 curEpoch;    /* Received epoch in current record    */
+    word16 curSeq_hi;   /* Received sequence in current record */
+    word32 curSeq_lo;
 
-        DtlsSeq prevWindow; /* Sliding window for old epoch        */
-        word16 prevSeq_hi;  /* Next sequence in allowed old epoch  */
-        word32 prevSeq_lo;
+    DtlsSeq prevWindow; /* Sliding window for old epoch        */
+    word16 prevSeq_hi;  /* Next sequence in allowed old epoch  */
+    word32 prevSeq_lo;
 
     word16 dtls_peer_handshake_number;
     word16 dtls_expected_peer_handshake_number;
 
     word16 dtls_epoch;                          /* Current epoch    */
-    word32 dtls_sequence_number_hi;             /* Current epoch */
+    word16 dtls_sequence_number_hi;             /* Current epoch */
     word32 dtls_sequence_number_lo;
-    word32 dtls_prev_sequence_number_hi;        /* Previous epoch */
+    word16 dtls_prev_sequence_number_hi;        /* Previous epoch */
     word32 dtls_prev_sequence_number_lo;
     word16 dtls_handshake_number;               /* Current tx handshake seq */
 #endif

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1613,8 +1613,10 @@ typedef struct Keys {
     byte aead_dec_imp_IV[AEAD_MAX_IMP_SZ];
 #endif
 
-    word32 peer_sequence_number;
-    word32 sequence_number;
+    word32 peer_sequence_number_hi;
+    word32 peer_sequence_number_lo;
+    word32 sequence_number_hi;
+    word32 sequence_number_lo;
 
 #ifdef WOLFSSL_DTLS
     DtlsState dtls_state;                       /* Peer's state */


### PR DESCRIPTION
Updates to use a 64-bit sequence number in every record. And to use 48-bits for DTLS.