### PR TITLE
Adjust DTLS retranmission logic

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6750,7 +6750,7 @@ int wolfSSL_dtls_got_timeout(WOLFSSL* ssl)
     int result = SSL_SUCCESS;
 
     if (!ssl->options.handShakeDone &&
-        (DtlsPoolTimeout(ssl) < 0 || DtlsPoolSend(ssl) < 0)) {
+        (DtlsPoolTimeout(ssl) < 0 || DtlsPoolSend(ssl, 0) < 0)) {
 
         result = SSL_FATAL_ERROR;
     }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3073,7 +3073,8 @@ WOLFSSL_LOCAL  int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength);
     WOLFSSL_LOCAL int  DtlsPoolInit(WOLFSSL*);
     WOLFSSL_LOCAL int  DtlsPoolSave(WOLFSSL*, const byte*, int);
     WOLFSSL_LOCAL int  DtlsPoolTimeout(WOLFSSL*);
-    WOLFSSL_LOCAL int  DtlsPoolSend(WOLFSSL*);
+    WOLFSSL_LOCAL int  DtlsPoolSend(WOLFSSL*, byte);
+    WOLFSSL_LOCAL int  VerifyForDtlsPoolSend(WOLFSSL*, byte, word32);
     WOLFSSL_LOCAL void DtlsPoolReset(WOLFSSL*);
     WOLFSSL_LOCAL void DtlsPoolDelete(WOLFSSL*);
 


### PR DESCRIPTION
This patch adjust DTLS retranmission logic
in order to avoid message floods between client
and server
