### PR TITLE
STM32 F2/F4 CubeMX and Std Peripheral Library hardware crypto support

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -201,96 +201,172 @@ void wc_AesAsyncFree(Aes* aes)
 #endif
 
 /* Define AES implementation includes and functions */
-#if defined(STM32F2_CRYPTO)
-     /* STM32F2 hardware AES support for CBC, CTR modes through the STM32F2
-      * Standard Peripheral Library. Documentation located in STM32F2xx
-      * Standard Peripheral Library document (See note in README). */
-    #include "stm32f2xx.h"
-    #include "stm32f2xx_cryp.h"
+#if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+     /* STM32F2/F4 hardware AES support for CBC, CTR modes */
 
+#if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_DIRECT) ||\
+    defined(HAVE_AESGCM)
     static int wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
     {
-    	word32 *enc_key;
-    	CRYP_InitTypeDef AES_CRYP_InitStructure;
-    	CRYP_KeyInitTypeDef AES_CRYP_KeyInitStructure;
+        int ret = 0;
+    #ifdef WOLFSSL_STM32_CUBEMX
+        CRYP_HandleTypeDef hcryp;
 
-    	enc_key = aes->key;
+        /* load key into correct registers */
+        switch(aes->rounds) {
+            case 10: /* 128-bit key */
+                hcryp.Init.KeySize = CRYP_KEYSIZE_128B;
+                break;
+            case 12: /* 192-bit key */
+                hcryp.Init.KeySize = CRYP_KEYSIZE_192B;
+                break;
+            case 14: /* 256-bit key */
+                hcryp.Init.KeySize = CRYP_KEYSIZE_256B;
+                break;
+            default:
+                break;
+        }
 
-    	/* crypto structure initialization */
-    	CRYP_KeyStructInit(&AES_CRYP_KeyInitStructure);
-    	CRYP_StructInit(&AES_CRYP_InitStructure);
+        XMEMSET(&hcryp, 0, sizeof(CRYP_HandleTypeDef));
+        hcryp.Instance = CRYP;
+        hcryp.Init.DataType = CRYP_DATATYPE_8B;
+        hcryp.Init.pKey = (uint8_t*)aes->key;
 
-    	/* reset registers to their default values */
-    	CRYP_DeInit();
+        HAL_CRYP_Init(&hcryp);
 
-    	/* load key into correct registers */
-    	switch(aes->rounds)
-    	{
-    		case 10: /* 128-bit key */
-    			AES_CRYP_InitStructure.CRYP_KeySize = CRYP_KeySize_128b;
-    			AES_CRYP_KeyInitStructure.CRYP_Key2Left  = enc_key[0];
-    			AES_CRYP_KeyInitStructure.CRYP_Key2Right = enc_key[1];
-    			AES_CRYP_KeyInitStructure.CRYP_Key3Left  = enc_key[2];
-    			AES_CRYP_KeyInitStructure.CRYP_Key3Right = enc_key[3];
-    			break;
+        if (HAL_CRYP_AESECB_Encrypt(&hcryp, (uint8_t*)inBlock, AES_BLOCK_SIZE,
+                                                outBlock, STM32_HAL_TIMEOUT) != HAL_OK) {
+            ret = WC_TIMEOUT_E;
+        }
 
-    		case 12: /* 192-bit key */
-    			AES_CRYP_InitStructure.CRYP_KeySize = CRYP_KeySize_192b;
-    			AES_CRYP_KeyInitStructure.CRYP_Key1Left  = enc_key[0];
-    			AES_CRYP_KeyInitStructure.CRYP_Key1Right = enc_key[1];
-    			AES_CRYP_KeyInitStructure.CRYP_Key2Left  = enc_key[2];
-    			AES_CRYP_KeyInitStructure.CRYP_Key2Right = enc_key[3];
-    			AES_CRYP_KeyInitStructure.CRYP_Key3Left  = enc_key[4];
-    			AES_CRYP_KeyInitStructure.CRYP_Key3Right = enc_key[5];
-    			break;
+        HAL_CRYP_DeInit(&hcryp);
+    #else
+        word32 *enc_key;
+        CRYP_InitTypeDef AES_CRYP_InitStructure;
+        CRYP_KeyInitTypeDef AES_CRYP_KeyInitStructure;
 
-    		case 14: /* 256-bit key */
-    			AES_CRYP_InitStructure.CRYP_KeySize = CRYP_KeySize_256b;
-    			AES_CRYP_KeyInitStructure.CRYP_Key0Left  = enc_key[0];
-    			AES_CRYP_KeyInitStructure.CRYP_Key0Right = enc_key[1];
-    			AES_CRYP_KeyInitStructure.CRYP_Key1Left  = enc_key[2];
-    			AES_CRYP_KeyInitStructure.CRYP_Key1Right = enc_key[3];
-    			AES_CRYP_KeyInitStructure.CRYP_Key2Left  = enc_key[4];
-    			AES_CRYP_KeyInitStructure.CRYP_Key2Right = enc_key[5];
-    			AES_CRYP_KeyInitStructure.CRYP_Key3Left  = enc_key[6];
-    			AES_CRYP_KeyInitStructure.CRYP_Key3Right = enc_key[7];
-    			break;
+        enc_key = aes->key;
 
-    		default:
-    			break;
-    	}
-    	CRYP_KeyInit(&AES_CRYP_KeyInitStructure);
+        /* crypto structure initialization */
+        CRYP_KeyStructInit(&AES_CRYP_KeyInitStructure);
+        CRYP_StructInit(&AES_CRYP_InitStructure);
 
-    	/* set direction, mode, and datatype */
-    	AES_CRYP_InitStructure.CRYP_AlgoDir  = CRYP_AlgoDir_Encrypt;
-    	AES_CRYP_InitStructure.CRYP_AlgoMode = CRYP_AlgoMode_AES_ECB;
-    	AES_CRYP_InitStructure.CRYP_DataType = CRYP_DataType_8b;
-    	CRYP_Init(&AES_CRYP_InitStructure);
+        /* reset registers to their default values */
+        CRYP_DeInit();
 
-    	/* enable crypto processor */
-    	CRYP_Cmd(ENABLE);
+        /* load key into correct registers */
+        switch(aes->rounds)
+        {
+            case 10: /* 128-bit key */
+                AES_CRYP_InitStructure.CRYP_KeySize = CRYP_KeySize_128b;
+                AES_CRYP_KeyInitStructure.CRYP_Key2Left  = enc_key[0];
+                AES_CRYP_KeyInitStructure.CRYP_Key2Right = enc_key[1];
+                AES_CRYP_KeyInitStructure.CRYP_Key3Left  = enc_key[2];
+                AES_CRYP_KeyInitStructure.CRYP_Key3Right = enc_key[3];
+                break;
 
-    	/* flush IN/OUT FIFOs */
-    	CRYP_FIFOFlush();
+            case 12: /* 192-bit key */
+                AES_CRYP_InitStructure.CRYP_KeySize = CRYP_KeySize_192b;
+                AES_CRYP_KeyInitStructure.CRYP_Key1Left  = enc_key[0];
+                AES_CRYP_KeyInitStructure.CRYP_Key1Right = enc_key[1];
+                AES_CRYP_KeyInitStructure.CRYP_Key2Left  = enc_key[2];
+                AES_CRYP_KeyInitStructure.CRYP_Key2Right = enc_key[3];
+                AES_CRYP_KeyInitStructure.CRYP_Key3Left  = enc_key[4];
+                AES_CRYP_KeyInitStructure.CRYP_Key3Right = enc_key[5];
+                break;
 
-    	CRYP_DataIn(*(uint32_t*)&inBlock[0]);
-    	CRYP_DataIn(*(uint32_t*)&inBlock[4]);
-    	CRYP_DataIn(*(uint32_t*)&inBlock[8]);
-    	CRYP_DataIn(*(uint32_t*)&inBlock[12]);
+            case 14: /* 256-bit key */
+                AES_CRYP_InitStructure.CRYP_KeySize = CRYP_KeySize_256b;
+                AES_CRYP_KeyInitStructure.CRYP_Key0Left  = enc_key[0];
+                AES_CRYP_KeyInitStructure.CRYP_Key0Right = enc_key[1];
+                AES_CRYP_KeyInitStructure.CRYP_Key1Left  = enc_key[2];
+                AES_CRYP_KeyInitStructure.CRYP_Key1Right = enc_key[3];
+                AES_CRYP_KeyInitStructure.CRYP_Key2Left  = enc_key[4];
+                AES_CRYP_KeyInitStructure.CRYP_Key2Right = enc_key[5];
+                AES_CRYP_KeyInitStructure.CRYP_Key3Left  = enc_key[6];
+                AES_CRYP_KeyInitStructure.CRYP_Key3Right = enc_key[7];
+                break;
 
-    	/* wait until the complete message has been processed */
-    	while(CRYP_GetFlagStatus(CRYP_FLAG_BUSY) != RESET) {}
+            default:
+                break;
+        }
+        CRYP_KeyInit(&AES_CRYP_KeyInitStructure);
 
-    	*(uint32_t*)&outBlock[0]  = CRYP_DataOut();
-    	*(uint32_t*)&outBlock[4]  = CRYP_DataOut();
-    	*(uint32_t*)&outBlock[8]  = CRYP_DataOut();
-    	*(uint32_t*)&outBlock[12] = CRYP_DataOut();
+        /* set direction, mode, and datatype */
+        AES_CRYP_InitStructure.CRYP_AlgoDir  = CRYP_AlgoDir_Encrypt;
+        AES_CRYP_InitStructure.CRYP_AlgoMode = CRYP_AlgoMode_AES_ECB;
+        AES_CRYP_InitStructure.CRYP_DataType = CRYP_DataType_8b;
+        CRYP_Init(&AES_CRYP_InitStructure);
 
-    	/* disable crypto processor */
-    	CRYP_Cmd(DISABLE);
+        /* enable crypto processor */
+        CRYP_Cmd(ENABLE);
 
-        return 0;
+        /* flush IN/OUT FIFOs */
+        CRYP_FIFOFlush();
+
+        CRYP_DataIn(*(uint32_t*)&inBlock[0]);
+        CRYP_DataIn(*(uint32_t*)&inBlock[4]);
+        CRYP_DataIn(*(uint32_t*)&inBlock[8]);
+        CRYP_DataIn(*(uint32_t*)&inBlock[12]);
+
+        /* wait until the complete message has been processed */
+        while(CRYP_GetFlagStatus(CRYP_FLAG_BUSY) != RESET) {}
+
+        *(uint32_t*)&outBlock[0]  = CRYP_DataOut();
+        *(uint32_t*)&outBlock[4]  = CRYP_DataOut();
+        *(uint32_t*)&outBlock[8]  = CRYP_DataOut();
+        *(uint32_t*)&outBlock[12] = CRYP_DataOut();
+
+        /* disable crypto processor */
+        CRYP_Cmd(DISABLE);
+    #endif /* WOLFSSL_STM32_CUBEMX */
+        return ret;
     }
+#endif /* AES_CBC or AES_DIRECT or AESGCM */
+
+#ifdef HAVE_AES_DECRYPT
+    #if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_DIRECT)
+    static int wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
+    {
+        int ret = 0;
+    #ifdef WOLFSSL_STM32_CUBEMX
+        CRYP_HandleTypeDef hcryp;
+
+        /* load key into correct registers */
+        switch(aes->rounds) {
+            case 10: /* 128-bit key */
+                hcryp.Init.KeySize = CRYP_KEYSIZE_128B;
+                break;
+            case 12: /* 192-bit key */
+                hcryp.Init.KeySize = CRYP_KEYSIZE_192B;
+                break;
+            case 14: /* 256-bit key */
+                hcryp.Init.KeySize = CRYP_KEYSIZE_256B;
+                break;
+            default:
+                break;
+        }
+
+        XMEMSET(&hcryp, 0, sizeof(CRYP_HandleTypeDef));
+        hcryp.Instance = CRYP;
+        hcryp.Init.DataType = CRYP_DATATYPE_8B;
+        hcryp.Init.pKey = (uint8_t*)aes->key;
+
+        HAL_CRYP_Init(&hcryp);
+
+        if (HAL_CRYP_AESECB_Decrypt(&hcryp, (uint8_t*)inBlock, AES_BLOCK_SIZE,
+                                                outBlock, STM32_HAL_TIMEOUT) != HAL_OK) {
+            ret = WC_TIMEOUT_E;
+        }
+
+        HAL_CRYP_DeInit(&hcryp);
+    #else
+        #error AES Decrypt not implemented for STM32 StdPeri lib
+    #endif /* WOLFSSL_STM32_CUBEMX */
+        return ret;
+    }
+    #endif /* AES_CBC or AES_DIRECT */
+#endif /* HAVE_AES_DECRYPT */
 
 #elif defined(HAVE_COLDFIRE_SEC)
     /* Freescale Coldfire SEC support for CBC mode.
@@ -1525,9 +1601,10 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 
 
 /* wc_AesSetKey */
-#ifdef STM32F2_CRYPTO
-    int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen, const byte* iv,
-                  int dir)
+#if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+
+int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
+            const byte* iv, int dir)
     {
         word32 *rk = aes->key;
 
@@ -1538,7 +1615,9 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 
         aes->rounds = keylen/4 + 6;
         XMEMCPY(rk, userKey, keylen);
+    #ifndef WOLFSSL_STM32_CUBEMX
         ByteReverseWords(rk, rk, keylen);
+    #endif
 
         return wc_AesSetIV(aes, iv);
     }
@@ -1549,6 +1628,7 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
             return wc_AesSetKey(aes, userKey, keylen, iv, dir);
         }
     #endif
+
 #elif defined(HAVE_COLDFIRE_SEC)
     #if defined (HAVE_THREADX)
         #include "memory_pools.h"
@@ -1574,7 +1654,7 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
     {
         if (AESBuffIn == NULL) {
             #if defined (HAVE_THREADX)
-			    int s1, s2, s3, s4, s5 ;
+                int s1, s2, s3, s4, s5 ;
                 s5 = tx_byte_allocate(&mp_ncached,(void *)&secDesc,
                                       sizeof(SECdescriptorType), TX_NO_WAIT);
                 s1 = tx_byte_allocate(&mp_ncached, (void *)&AESBuffIn,
@@ -1905,7 +1985,7 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
     }
 
     #endif /* WOLFSSL_AES_DIRECT || WOLFSSL_AES_COUNTER */
-#endif /* STM32F2_CRYPTO, wc_AesSetKey block */
+#endif /* wc_AesSetKey block */
 
 
 /* wc_AesSetIV is shared between software and hardware */
@@ -1939,10 +2019,7 @@ int wc_InitAes_h(Aes* aes, void* h)
 
 /* AES-DIRECT */
 #if defined(WOLFSSL_AES_DIRECT)
-    #if defined(STM32F2_CRYPTO) && defined(HAVE_AES_DECRYPT)
-        #error "STM32F2 crypto doesn't yet support AES direct decrypt"
-
-    #elif defined(HAVE_COLDFIRE_SEC)
+    #if defined(HAVE_COLDFIRE_SEC)
         #error "Coldfire SEC doesn't yet support AES direct"
 
     #elif defined(WOLFSSL_PIC32MZ_CRYPT)
@@ -1994,7 +2071,105 @@ int wc_InitAes_h(Aes* aes, void* h)
 
 /* AES-CBC */
 #ifdef HAVE_AES_CBC
-#ifdef STM32F2_CRYPTO
+#if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+
+#ifdef WOLFSSL_STM32_CUBEMX
+    int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+    {
+        int ret = 0;
+        CRYP_HandleTypeDef hcryp;
+
+        /* load key into correct registers */
+        switch(aes->rounds) {
+            case 10: /* 128-bit key */
+                hcryp.Init.KeySize = CRYP_KEYSIZE_128B;
+                break;
+            case 12: /* 192-bit key */
+                hcryp.Init.KeySize = CRYP_KEYSIZE_192B;
+                break;
+            case 14: /* 256-bit key */
+                hcryp.Init.KeySize = CRYP_KEYSIZE_256B;
+                break;
+            default:
+                break;
+        }
+
+        XMEMSET(&hcryp, 0, sizeof(CRYP_HandleTypeDef));
+        hcryp.Instance = CRYP;
+        hcryp.Init.DataType = CRYP_DATATYPE_8B;
+        hcryp.Init.pKey = (uint8_t*)aes->key;
+        hcryp.Init.pInitVect = (uint8_t*)aes->reg;
+
+        HAL_CRYP_Init(&hcryp);
+
+        while (sz > 0) {
+            if (HAL_CRYP_AESCBC_Encrypt(&hcryp, (uint8_t*)in, AES_BLOCK_SIZE,
+                                           out, STM32_HAL_TIMEOUT) != HAL_OK) {
+                ret = WC_TIMEOUT_E;
+                break;
+            }
+
+            /* store iv for next call */
+            XMEMCPY(aes->reg, out + sz - AES_BLOCK_SIZE, AES_BLOCK_SIZE);
+
+            sz  -= AES_BLOCK_SIZE;
+            in  += AES_BLOCK_SIZE;
+            out += AES_BLOCK_SIZE;
+        }
+
+        HAL_CRYP_DeInit(&hcryp);
+
+        return ret;
+    }
+    #ifdef HAVE_AES_DECRYPT
+    int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+    {
+        int ret = 0;
+        CRYP_HandleTypeDef hcryp;
+
+        /* load key into correct registers */
+        switch(aes->rounds) {
+            case 10: /* 128-bit key */
+                hcryp.Init.KeySize = CRYP_KEYSIZE_128B;
+                break;
+            case 12: /* 192-bit key */
+                hcryp.Init.KeySize = CRYP_KEYSIZE_192B;
+                break;
+            case 14: /* 256-bit key */
+                hcryp.Init.KeySize = CRYP_KEYSIZE_256B;
+                break;
+            default:
+                break;
+        }
+
+        XMEMSET(&hcryp, 0, sizeof(CRYP_HandleTypeDef));
+        hcryp.Instance = CRYP;
+        hcryp.Init.DataType = CRYP_DATATYPE_8B;
+        hcryp.Init.pKey = (uint8_t*)aes->key;
+        hcryp.Init.pInitVect = (uint8_t*)aes->reg;
+
+        HAL_CRYP_Init(&hcryp);
+
+        while (sz > 0) {
+            if (HAL_CRYP_AESCBC_Decrypt(&hcryp, (uint8_t*)in, AES_BLOCK_SIZE,
+                                           out, STM32_HAL_TIMEOUT) != HAL_OK) {
+                ret = WC_TIMEOUT_E;
+            }
+
+            /* store iv for next call */
+            XMEMCPY(aes->reg, aes->tmp, AES_BLOCK_SIZE);
+
+            sz -= AES_BLOCK_SIZE;
+            in += AES_BLOCK_SIZE;
+            out += AES_BLOCK_SIZE;
+        }
+
+        HAL_CRYP_DeInit(&hcryp);
+
+        return ret;
+    }
+    #endif /* HAVE_AES_DECRYPT */
+#else
     int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     {
         word32 *enc_key, *iv;
@@ -2222,13 +2397,15 @@ int wc_InitAes_h(Aes* aes, void* h)
         return 0;
     }
     #endif /* HAVE_AES_DECRYPT */
+#endif /* WOLFSSL_STM32_CUBEMX */
+
 #elif defined(HAVE_COLDFIRE_SEC)
     static int wc_AesCbcCrypt(Aes* aes, byte* po, const byte* pi, word32 sz,
                            word32 descHeader)
     {
         #ifdef DEBUG_WOLFSSL
             int i; int stat1, stat2; int ret;
-	    #endif
+        #endif
 
         int size;
         volatile int v;
@@ -2663,13 +2840,47 @@ int wc_InitAes_h(Aes* aes, void* h)
     }
     #endif
 
-#endif /* STM32F2_CRYPTO, AES-CBC block */
+#endif /* AES-CBC block */
 #endif /* HAVE_AES_CBC */
 
 /* AES-CTR */
 #ifdef WOLFSSL_AES_COUNTER
 
-    #ifdef STM32F2_CRYPTO
+    #if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+    #ifdef WOLFSSL_STM32_CUBEMX
+        void wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+        {
+            CRYP_HandleTypeDef hcryp;
+
+            /* load key into correct registers */
+            switch(aes->rounds) {
+                case 10: /* 128-bit key */
+                    hcryp.Init.KeySize = CRYP_KEYSIZE_128B;
+                    break;
+                case 12: /* 192-bit key */
+                    hcryp.Init.KeySize = CRYP_KEYSIZE_192B;
+                    break;
+                case 14: /* 256-bit key */
+                    hcryp.Init.KeySize = CRYP_KEYSIZE_256B;
+                    break;
+                default:
+                    break;
+            }
+
+            XMEMSET(&hcryp, 0, sizeof(CRYP_HandleTypeDef));
+            hcryp.Instance = CRYP;
+            hcryp.Init.DataType = CRYP_DATATYPE_8B;
+            hcryp.Init.pKey = aes->key;
+            hcryp.Init.pInitVect = aes->reg;
+
+            HAL_CRYP_Init(&hcryp);
+
+            HAL_CRYP_AESCTR_Encrypt(&hcryp, in, AES_BLOCK_SIZE, out,
+                                                            STM32_HAL_TIMEOUT);
+
+            HAL_CRYP_DeInit(&hcryp);
+        }
+    #else
         void wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         {
             word32 *enc_key, *iv;
@@ -2772,6 +2983,7 @@ int wc_InitAes_h(Aes* aes, void* h)
             /* disable crypto processor */
             CRYP_Cmd(DISABLE);
         }
+        #endif /* WOLFSSL_STM32_CUBEMX */
 
     #elif defined(WOLFSSL_PIC32MZ_CRYPT)
         void wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
@@ -2911,7 +3123,7 @@ int wc_InitAes_h(Aes* aes, void* h)
             }
         }
 
-    #endif /* STM32F2_CRYPTO, AES-CTR block */
+    #endif /* AES-CTR block */
 
 #endif /* WOLFSSL_AES_COUNTER */
 
@@ -4505,7 +4717,7 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
 
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    
+
 /* Initialize Aes for use with Nitrox device */
 int wc_AesAsyncInit(Aes* aes, int devId)
 {

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -204,8 +204,7 @@ void wc_AesAsyncFree(Aes* aes)
 #if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
      /* STM32F2/F4 hardware AES support for CBC, CTR modes */
 
-#if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_DIRECT) ||\
-    defined(HAVE_AESGCM)
+#if defined(WOLFSSL_AES_DIRECT) || defined(HAVE_AESGCM) || defined(HAVE_AESCCM)
     static int wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
     {
         int ret = 0;
@@ -322,10 +321,10 @@ void wc_AesAsyncFree(Aes* aes)
     #endif /* WOLFSSL_STM32_CUBEMX */
         return ret;
     }
-#endif /* AES_CBC or AES_DIRECT or AESGCM */
+#endif /* WOLFSSL_AES_DIRECT || HAVE_AESGCM || HAVE_AESCCM */
 
 #ifdef HAVE_AES_DECRYPT
-    #if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_DIRECT)
+    #if defined(WOLFSSL_AES_DIRECT) || defined(HAVE_AESGCM)
     static int wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
     {
         int ret = 0;
@@ -365,7 +364,7 @@ void wc_AesAsyncFree(Aes* aes)
     #endif /* WOLFSSL_STM32_CUBEMX */
         return ret;
     }
-    #endif /* AES_CBC or AES_DIRECT */
+    #endif /* WOLFSSL_AES_DIRECT || HAVE_AESGCM */
 #endif /* HAVE_AES_DECRYPT */
 
 #elif defined(HAVE_COLDFIRE_SEC)

--- a/wolfcrypt/src/des3.c
+++ b/wolfcrypt/src/des3.c
@@ -126,23 +126,23 @@ void wc_Des3AsyncFree(Des3* des3)
 #endif
 
 
-#ifdef STM32F2_CRYPTO
+#if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+
     /*
-     * STM32F2 hardware DES/3DES support through the STM32F2 standard
-     * peripheral library. Documentation located in STM32F2xx Standard
-     * Peripheral Library document (See note in README).
+     * STM32F2/F4 hardware DES/3DES support through the standard
+     * peripheral library. (See note in README).
      */
-    #include "stm32f2xx.h"
-	#include "stm32f2xx_cryp.h"
 
     int wc_Des_SetKey(Des* des, const byte* key, const byte* iv, int dir)
     {
         word32 *dkey = des->key;
-        
+
         (void)dir;
 
         XMEMCPY(dkey, key, 8);
+    #ifndef WOLFSSL_STM32_CUBEMX
         ByteReverseWords(dkey, dkey, 8);
+    #endif
 
         wc_Des_SetIV(des, iv);
 
@@ -154,16 +154,18 @@ void wc_Des3AsyncFree(Des3* des3)
         word32 *dkey1 = des->key[0];
         word32 *dkey2 = des->key[1];
         word32 *dkey3 = des->key[2];
-        
+
         (void)dir;
 
         XMEMCPY(dkey1, key, 8);         /* set key 1 */
         XMEMCPY(dkey2, key + 8, 8);     /* set key 2 */
         XMEMCPY(dkey3, key + 16, 8);    /* set key 3 */
 
+    #ifndef WOLFSSL_STM32_CUBEMX
         ByteReverseWords(dkey1, dkey1, 8);
         ByteReverseWords(dkey2, dkey2, 8);
         ByteReverseWords(dkey3, dkey3, 8);
+    #endif
 
         return wc_Des3_SetIV(des, iv);
     }
@@ -171,6 +173,54 @@ void wc_Des3AsyncFree(Des3* des3)
     static void DesCrypt(Des* des, byte* out, const byte* in, word32 sz,
                   int dir, int mode)
     {
+    #ifdef WOLFSSL_STM32_CUBEMX
+        CRYP_HandleTypeDef hcryp;
+
+        XMEMSET(&hcryp, 0, sizeof(CRYP_HandleTypeDef));
+        hcryp.Instance = CRYP;
+        hcryp.Init.KeySize  = CRYP_KEYSIZE_128B;
+        hcryp.Init.DataType = CRYP_DATATYPE_8B;
+        hcryp.Init.pKey = (uint8_t*)des->key;
+        hcryp.Init.pInitVect = (uint8_t*)des->reg;
+
+        HAL_CRYP_Init(&hcryp);
+
+        while (sz > 0)
+        {
+            /* if input and output same will overwrite input iv */
+            XMEMCPY(des->tmp, in + sz - DES_BLOCK_SIZE, DES_BLOCK_SIZE);
+
+            if (mode == DES_CBC) {
+                if (dir == DES_ENCRYPTION) {
+                    HAL_CRYP_DESCBC_Encrypt(&hcryp, (uint8_t*)in,
+                                    DES_BLOCK_SIZE, out, STM32_HAL_TIMEOUT);
+                }
+                else {
+                    HAL_CRYP_DESCBC_Decrypt(&hcryp, (uint8_t*)in,
+                                    DES_BLOCK_SIZE, out, STM32_HAL_TIMEOUT);
+                }
+            }
+            else {
+                if (dir == DES_ENCRYPTION) {
+                    HAL_CRYP_DESECB_Encrypt(&hcryp, (uint8_t*)in,
+                                    DES_BLOCK_SIZE, out, STM32_HAL_TIMEOUT);
+                }
+                else {
+                    HAL_CRYP_DESECB_Decrypt(&hcryp, (uint8_t*)in,
+                                    DES_BLOCK_SIZE, out, STM32_HAL_TIMEOUT);
+                }
+            }
+
+            /* store iv for next call */
+            XMEMCPY(des->reg, des->tmp, DES_BLOCK_SIZE);
+
+            sz  -= DES_BLOCK_SIZE;
+            in  += DES_BLOCK_SIZE;
+            out += DES_BLOCK_SIZE;
+        }
+
+        HAL_CRYP_DeInit(&hcryp);
+    #else
         word32 *dkey, *iv;
         CRYP_InitTypeDef DES_CRYP_InitStructure;
         CRYP_KeyInitTypeDef DES_CRYP_KeyInitStructure;
@@ -244,6 +294,7 @@ void wc_Des3AsyncFree(Des3* des3)
 
         /* disable crypto processor */
         CRYP_Cmd(DISABLE);
+    #endif /* WOLFSSL_STM32_CUBEMX */
     }
 
     int wc_Des_CbcEncrypt(Des* des, byte* out, const byte* in, word32 sz)
@@ -267,6 +318,39 @@ void wc_Des3AsyncFree(Des3* des3)
     static void Des3Crypt(Des3* des, byte* out, const byte* in, word32 sz,
                    int dir)
     {
+    #ifdef WOLFSSL_STM32_CUBEMX
+        CRYP_HandleTypeDef hcryp;
+
+        XMEMSET(&hcryp, 0, sizeof(CRYP_HandleTypeDef));
+        hcryp.Instance = CRYP;
+        hcryp.Init.KeySize  = CRYP_KEYSIZE_128B;
+        hcryp.Init.DataType = CRYP_DATATYPE_8B;
+        hcryp.Init.pKey = (uint8_t*)des->key;
+        hcryp.Init.pInitVect = (uint8_t*)des->reg;
+
+        HAL_CRYP_Init(&hcryp);
+
+        while (sz > 0)
+        {
+            if (dir == DES_ENCRYPTION) {
+                HAL_CRYP_TDESCBC_Encrypt(&hcryp, (byte*)in,
+                                    DES_BLOCK_SIZE, out, STM32_HAL_TIMEOUT);
+            }
+            else {
+                HAL_CRYP_TDESCBC_Decrypt(&hcryp, (byte*)in,
+                                    DES_BLOCK_SIZE, out, STM32_HAL_TIMEOUT);
+            }
+
+            /* store iv for next call */
+            XMEMCPY(des->reg, out + sz - DES_BLOCK_SIZE, DES_BLOCK_SIZE);
+
+            sz  -= DES_BLOCK_SIZE;
+            in  += DES_BLOCK_SIZE;
+            out += DES_BLOCK_SIZE;
+        }
+
+        HAL_CRYP_DeInit(&hcryp);
+    #else
         word32 *dkey1, *dkey2, *dkey3, *iv;
         CRYP_InitTypeDef DES3_CRYP_InitStructure;
         CRYP_KeyInitTypeDef DES3_CRYP_KeyInitStructure;
@@ -338,7 +422,7 @@ void wc_Des3AsyncFree(Des3* des3)
 
         /* disable crypto processor */
         CRYP_Cmd(DISABLE);
-
+    #endif /* WOLFSSL_STM32_CUBEMX */
     }
 
     int wc_Des3_CbcEncrypt(Des3* des, byte* out, const byte* in, word32 sz)
@@ -369,8 +453,8 @@ extern TX_BYTE_POOL mp_ncached;  /* Non Cached memory pool */
 #define DES_BUFFER_SIZE (DES_BLOCK_SIZE * 64)
 static unsigned char *desBuffIn = NULL ;
 static unsigned char *desBuffOut = NULL ;
-static byte *secIV ; 
-static byte *secKey ; 
+static byte *secIV ;
+static byte *secKey ;
 static volatile SECdescriptorType *secDesc ;
 
 static wolfSSL_Mutex Mutex_DesSEC ;
@@ -387,12 +471,12 @@ static wolfSSL_Mutex Mutex_DesSEC ;
 
 extern volatile unsigned char __MBAR[];
 
-static void wc_Des_Cbc(byte* out, const byte* in, word32 sz, 
+static void wc_Des_Cbc(byte* out, const byte* in, word32 sz,
                     byte *key, byte *iv, word32 desc)
 {
     #ifdef DEBUG_WOLFSSL
-    int ret ;  int stat1,stat2 ; 
-	  #endif
+    int ret ;  int stat1,stat2 ;
+    #endif
     int size ;
     volatile int v ;
  
@@ -401,22 +485,22 @@ static void wc_Des_Cbc(byte* out, const byte* in, word32 sz,
     secDesc->length1 = 0x0;
     secDesc->pointer1 = NULL;
     if((desc==SEC_DESC_DES_CBC_ENCRYPT)||(desc==SEC_DESC_DES_CBC_DECRYPT)){
-        secDesc->length2 = DES_IVLEN ;  
+        secDesc->length2 = DES_IVLEN ;
         secDesc->length3 = DES_KEYLEN ;
     } else {
-        secDesc->length2 = DES3_IVLEN ; 
+        secDesc->length2 = DES3_IVLEN ;
         secDesc->length3 = DES3_KEYLEN ;
     }
     secDesc->pointer2 = secIV ;
     secDesc->pointer3 = secKey;
     secDesc->pointer4 = desBuffIn ;
     secDesc->pointer5 = desBuffOut ;
-    secDesc->length6 = 0; 
-    secDesc->pointer6 = NULL; 
+    secDesc->length6 = 0;
+    secDesc->pointer6 = NULL;
     secDesc->length7 = 0x0;
     secDesc->pointer7 = NULL;
-    secDesc->nextDescriptorPtr = NULL ; 
-    
+    secDesc->nextDescriptorPtr = NULL ;
+
     while(sz) {
         XMEMCPY(secIV, iv, secDesc->length2) ;
         if((sz%DES_BUFFER_SIZE) == sz) {
@@ -426,10 +510,10 @@ static void wc_Des_Cbc(byte* out, const byte* in, word32 sz,
             size = DES_BUFFER_SIZE ;
             sz -= DES_BUFFER_SIZE ;
         }
-        
+
         XMEMCPY(desBuffIn, in, size) ;
         XMEMCPY(secKey, key, secDesc->length3) ;
-        
+
         secDesc->header = desc ;
         secDesc->length4 = size;
         secDesc->length5 = size;
@@ -442,16 +526,16 @@ static void wc_Des_Cbc(byte* out, const byte* in, word32 sz,
         while((secDesc->header>> 24) != 0xff) {
             if(v++ > 1000)break ;
         }
-				
+
 #ifdef DEBUG_WOLFSSL
         ret = MCF_SEC_SISRH;
-        stat1 = MCF_SEC_DSR ; 
-        stat2 = MCF_SEC_DISR ; 
+        stat1 = MCF_SEC_DSR ;
+        stat2 = MCF_SEC_DISR ;
         if(ret & 0xe0000000) {
             /* db_printf("Des_Cbc(%x):ISRH=%08x, DSR=%08x, DISR=%08x\n", desc, ret, stat1, stat2) ; */
         }
 #endif
-				
+
         XMEMCPY(out, desBuffOut, size) ;
 
         if((desc==SEC_DESC_DES3_CBC_ENCRYPT)||(desc==SEC_DESC_DES_CBC_ENCRYPT)) {
@@ -459,10 +543,10 @@ static void wc_Des_Cbc(byte* out, const byte* in, word32 sz,
         } else {
             XMEMCPY((void*)iv, (void*)&(in[size-secDesc->length2]), secDesc->length2) ;
         }
-        
-        in  += size ;   
+
+        in  += size ;
         out += size ;
-                
+
     }
     wc_UnLockMutex(&Mutex_DesSEC) ;
     
@@ -484,23 +568,23 @@ int wc_Des_CbcDecrypt(Des* des, byte* out, const byte* in, word32 sz)
 int wc_Des3_CbcEncrypt(Des3* des3, byte* out, const byte* in, word32 sz)
 {
     wc_Des_Cbc(out, in, sz,  (byte *)des3->key,  (byte *)des3->reg, SEC_DESC_DES3_CBC_ENCRYPT) ;
-	  return 0;
+    return 0;
 }
 
 
 int wc_Des3_CbcDecrypt(Des3* des3, byte* out, const byte* in, word32 sz)
 {
     wc_Des_Cbc(out, in, sz,   (byte *)des3->key,  (byte *)des3->reg, SEC_DESC_DES3_CBC_DECRYPT) ;
-	  return 0;
+    return 0;
 }
 
-static void setParity(byte *buf, int len) 
+static void setParity(byte *buf, int len)
 {
     int i, j ;
     byte v ;
     int bits ;
 
-    for(i=0; i<len; i++) 
+    for(i=0; i<len; i++)
     {
         v = buf[i] >> 1 ;
         buf[i] = v << 1 ;
@@ -512,7 +596,7 @@ static void setParity(byte *buf, int len)
         }
         buf[i] |= (1 - (bits&0x1)) ;
     }
-    
+
 }
 
 
@@ -520,54 +604,54 @@ int wc_Des_SetKey(Des* des, const byte* key, const byte* iv, int dir)
 {
     if(desBuffIn == NULL) {
         #if defined (HAVE_THREADX)
-			  int s1, s2, s3, s4, s5 ;
-        s5 = tx_byte_allocate(&mp_ncached,(void *)&secDesc, 
+        int s1, s2, s3, s4, s5 ;
+        s5 = tx_byte_allocate(&mp_ncached,(void *)&secDesc,
                                                      sizeof(SECdescriptorType), TX_NO_WAIT);
         s1 = tx_byte_allocate(&mp_ncached,(void *)&desBuffIn,  DES_BUFFER_SIZE, TX_NO_WAIT);
         s2 = tx_byte_allocate(&mp_ncached,(void *)&desBuffOut, DES_BUFFER_SIZE, TX_NO_WAIT);
         /* Don't know des or des3 to be used. Allocate larger buffers */
         s3 = tx_byte_allocate(&mp_ncached,(void *)&secKey,     DES3_KEYLEN,TX_NO_WAIT);
-        s4 = tx_byte_allocate(&mp_ncached,(void *)&secIV,      DES3_IVLEN,  TX_NO_WAIT);              
+        s4 = tx_byte_allocate(&mp_ncached,(void *)&secIV,      DES3_IVLEN,  TX_NO_WAIT);
         #else
         #warning "Allocate non-Cache buffers"
         #endif
         
         wc_InitMutex(&Mutex_DesSEC) ;
     }
-     
-    XMEMCPY(des->key, key, DES_KEYLEN);  
-    setParity((byte *)des->key, DES_KEYLEN) ;  
-		
+
+    XMEMCPY(des->key, key, DES_KEYLEN);
+    setParity((byte *)des->key, DES_KEYLEN) ;
+
     if (iv) {
         XMEMCPY(des->reg, iv, DES_IVLEN);
     }   else {
         XMEMSET(des->reg, 0x0, DES_IVLEN) ;
     }
-		return 0;
+    return 0;
 }
 
 int wc_Des3_SetKey(Des3* des3, const byte* key, const byte* iv, int dir)
 {
-    
+
     if(desBuffIn == NULL) {
         #if defined (HAVE_THREADX)
-			  int s1, s2, s3, s4, s5 ;
-        s5 = tx_byte_allocate(&mp_ncached,(void *)&secDesc, 
+        int s1, s2, s3, s4, s5 ;
+        s5 = tx_byte_allocate(&mp_ncached,(void *)&secDesc,
                                                      sizeof(SECdescriptorType), TX_NO_WAIT);
         s1 = tx_byte_allocate(&mp_ncached,(void *)&desBuffIn,  DES_BUFFER_SIZE, TX_NO_WAIT);
         s2 = tx_byte_allocate(&mp_ncached,(void *)&desBuffOut, DES_BUFFER_SIZE, TX_NO_WAIT);
         s3 = tx_byte_allocate(&mp_ncached,(void *)&secKey,     DES3_KEYLEN,TX_NO_WAIT);
-        s4 = tx_byte_allocate(&mp_ncached,(void *)&secIV,      DES3_IVLEN,  TX_NO_WAIT);              
+        s4 = tx_byte_allocate(&mp_ncached,(void *)&secIV,      DES3_IVLEN,  TX_NO_WAIT);
         #else
         #warning "Allocate non-Cache buffers"
         #endif
         
         wc_InitMutex(&Mutex_DesSEC) ;
     }
-    
-    XMEMCPY(des3->key[0], key, DES3_KEYLEN); 
-    setParity((byte *)des3->key[0], DES3_KEYLEN) ;  
-		
+
+    XMEMCPY(des3->key[0], key, DES3_KEYLEN);
+    setParity((byte *)des3->key[0], DES3_KEYLEN) ;
+
     if (iv) {
         XMEMCPY(des3->reg, iv, DES3_IVLEN);
     }   else {
@@ -917,23 +1001,23 @@ int  wc_Des3_SetIV(Des3* des, const byte* iv);
         volatile securityAssociation sa __attribute__((aligned (8)));
         volatile bufferDescriptor bd __attribute__((aligned (8)));
         volatile int k ;
-        
+
         /* get uncached address */
 
         in_l = in;
         out_l = out ;
-        sa_p = KVA0_TO_KVA1(&sa) ; 
+        sa_p = KVA0_TO_KVA1(&sa) ;
         bd_p = KVA0_TO_KVA1(&bd) ;
         in_p = KVA0_TO_KVA1(in_l) ;
         out_p= KVA0_TO_KVA1(out_l);
-        
+
         if(PIC32MZ_IF_RAM(in_p))
             XMEMCPY((void *)in_p, (void *)in, sz);
         XMEMSET((void *)out_p, 0, sz);
 
         /* Set up the Security Association */
         XMEMSET((byte *)KVA0_TO_KVA1(&sa), 0, sizeof(sa));
-        sa_p->SA_CTRL.ALGO = algo ; 
+        sa_p->SA_CTRL.ALGO = algo ;
         sa_p->SA_CTRL.LNC = 1;
         sa_p->SA_CTRL.LOADIV = 1;
         sa_p->SA_CTRL.FB = 1;
@@ -951,17 +1035,17 @@ int  wc_Des3_SetIV(Des3* des, const byte* iv);
         bd_p->BD_CTRL.SA_FETCH_EN = 1;
         bd_p->BD_CTRL.LAST_BD = 1;
         bd_p->BD_CTRL.DESC_EN = 1;
-    
+
         bd_p->SA_ADDR = (unsigned int)KVA_TO_PA(&sa) ; /* (unsigned int)sa_p; */
         bd_p->SRCADDR = (unsigned int)KVA_TO_PA(in) ; /* (unsigned int)in_p; */
         bd_p->DSTADDR = (unsigned int)KVA_TO_PA(out); /* (unsigned int)out_p; */
         bd_p->NXTPTR = (unsigned int)KVA_TO_PA(&bd);
         bd_p->MSGLEN = sz ;
-        
+
         /* Fire in the hole! */
         CECON = 1 << 6;
         while (CECON);
-        
+
         /* Run the engine */
         CEBDPADDR = (unsigned int)KVA_TO_PA(&bd) ; /* (unsigned int)bd_p ; */
         CEINTEN = 0x07;
@@ -974,12 +1058,11 @@ int  wc_Des3_SetIV(Des3* des, const byte* iv);
            (cryptoalgo == PIC32_CRYPTOALGO_RCBC)) {
             /* set iv for the next call */
             if(dir == PIC32_ENCRYPTION) {
-	        XMEMCPY((void *)iv, (void*)&(out_p[sz-DES_IVLEN]), DES_IVLEN) ;
-	        } else {
+                XMEMCPY((void *)iv, (void*)&(out_p[sz-DES_IVLEN]), DES_IVLEN) ;
+            } else {
                 ByteReverseWords((word32*)iv, (word32 *)&(in_p[sz-DES_IVLEN]),
                                  DES_IVLEN);
-	        }
-
+            }
         }
 
         ByteReverseWords((word32*)out, (word32 *)KVA0_TO_KVA1(out), sz);
@@ -987,33 +1070,33 @@ int  wc_Des3_SetIV(Des3* des, const byte* iv);
 
     int wc_Des_CbcEncrypt(Des* des, byte* out, const byte* in, word32 sz)
     {
-        DesCrypt(des->key, des->reg, out, in, sz, 
+        DesCrypt(des->key, des->reg, out, in, sz,
                 PIC32_ENCRYPTION, PIC32_ALGO_DES, PIC32_CRYPTOALGO_CBC );
         return 0;
     }
 
     int wc_Des_CbcDecrypt(Des* des, byte* out, const byte* in, word32 sz)
     {
-        DesCrypt(des->key, des->reg, out, in, sz, 
+        DesCrypt(des->key, des->reg, out, in, sz,
                 PIC32_DECRYPTION, PIC32_ALGO_DES, PIC32_CRYPTOALGO_CBC);
         return 0;
     }
 
     int wc_Des3_CbcEncrypt(Des3* des, byte* out, const byte* in, word32 sz)
     {
-        DesCrypt(des->key[0], des->reg, out, in, sz, 
+        DesCrypt(des->key[0], des->reg, out, in, sz,
                 PIC32_ENCRYPTION, PIC32_ALGO_TDES, PIC32_CRYPTOALGO_TCBC);
         return 0;
     }
 
     int wc_Des3_CbcDecrypt(Des3* des, byte* out, const byte* in, word32 sz)
     {
-        DesCrypt(des->key[0], des->reg, out, in, sz, 
+        DesCrypt(des->key[0], des->reg, out, in, sz,
                 PIC32_DECRYPTION, PIC32_ALGO_TDES, PIC32_CRYPTOALGO_TCBC);
         return 0;
     }
-    
-#else /* CTaoCrypt software implementation */
+
+#else /* Begin wolfCrypt software implementation */
 
 /* permuted choice table (key) */
 static const byte pc1[] = {
@@ -1306,7 +1389,7 @@ static int DesSetKey(const byte* key, int dir, word32* out)
                 word32 swap = out[i];
                 out[i] = out[DES_KS_SIZE - 2 - i];
                 out[DES_KS_SIZE - 2 - i] = swap;
-    
+
                 swap = out[i + 1];
                 out[i + 1] = out[DES_KS_SIZE - 1 - i];
                 out[DES_KS_SIZE - 1 - i] = swap;
@@ -1406,8 +1489,8 @@ static void DesProcessBlock(Des* des, const byte* in, byte* out)
         r = ByteReverseWord32(r);
     #endif
     IPERM(&l,&r);
-    
-    DesRawProcessBlock(&l, &r, des->key);   
+
+    DesRawProcessBlock(&l, &r, des->key);
 
     FPERM(&l,&r);
     #ifdef LITTLE_ENDIAN_ORDER
@@ -1430,10 +1513,10 @@ static void Des3ProcessBlock(Des3* des, const byte* in, byte* out)
         r = ByteReverseWord32(r);
     #endif
     IPERM(&l,&r);
-    
-    DesRawProcessBlock(&l, &r, des->key[0]);   
-    DesRawProcessBlock(&r, &l, des->key[1]);   
-    DesRawProcessBlock(&l, &r, des->key[2]);   
+
+    DesRawProcessBlock(&l, &r, des->key[0]);
+    DesRawProcessBlock(&r, &l, des->key[1]);
+    DesRawProcessBlock(&l, &r, des->key[2]);
 
     FPERM(&l,&r);
     #ifdef LITTLE_ENDIAN_ORDER
@@ -1519,7 +1602,7 @@ int wc_Des3_CbcDecrypt(Des3* des, byte* out, const byte* in, word32 sz)
         XMEMCPY(des->reg, des->tmp, DES_BLOCK_SIZE);
 
         out += DES_BLOCK_SIZE;
-        in  += DES_BLOCK_SIZE; 
+        in  += DES_BLOCK_SIZE;
     }
     return 0;
 }
@@ -1535,14 +1618,15 @@ int wc_Des_EcbEncrypt(Des* des, byte* out, const byte* in, word32 sz)
         DesProcessBlock(des, in, out);
 
         out += DES_BLOCK_SIZE;
-        in  += DES_BLOCK_SIZE; 
+        in  += DES_BLOCK_SIZE;
     }
     return 0;
 }
 
 #endif /* WOLFSSL_DES_ECB */
 
-#endif /* STM32F2_CRYPTO */
+#endif /* End wolfCrypt software implementation */
+
 
 void wc_Des_SetIV(Des* des, const byte* iv)
 {

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1436,18 +1436,37 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     return 0;
 }
 
-#elif defined(STM32F2_RNG)
-    #undef RNG
-    #include "stm32f2xx_rng.h"
-    #include "stm32f2xx_rcc.h"
+#elif defined(STM32F2_RNG) || defined(STM32F4_RNG)
     /*
      * wc_Generate a RNG seed using the hardware random number generator
-     * on the STM32F2. Documentation located in STM32F2xx Standard Peripheral
-     * Library document (See note in README).
-     */
+     * on the STM32F2/F4. */
+
+#ifdef WOLFSSL_STM32_CUBEMX
+    int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
+    {
+        RNG_HandleTypeDef hrng;
+        int i;
+        (void)os;
+
+        /* enable RNG clock source */
+        __HAL_RCC_RNG_CLK_ENABLE();
+
+        /* enable RNG peripheral */
+        hrng.Instance = RNG;
+        HAL_RNG_Init(&hrng);
+
+        for (i = 0; i < (int)sz; i++) {
+            /* get value */
+            output[i] = (byte)HAL_RNG_GetRandomNumber(&hrng);
+        }
+
+        return 0;
+    }
+#else
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
         int i;
+        (void)os;
 
         /* enable RNG clock source */
         RCC_AHB2PeriphClockCmd(RCC_AHB2Periph_RNG, ENABLE);
@@ -1455,7 +1474,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         /* enable RNG peripheral */
         RNG_Cmd(ENABLE);
 
-        for (i = 0; i < sz; i++) {
+        for (i = 0; i < (int)sz; i++) {
             /* wait until RNG number is ready */
             while(RNG_GetFlagStatus(RNG_FLAG_DRDY)== RESET) { }
 
@@ -1465,6 +1484,8 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
         return 0;
     }
+#endif /* WOLFSSL_STM32_CUBEMX */
+
 #elif defined(WOLFSSL_LPC43xx) || defined(WOLFSSL_STM32F2xx) || defined(MBED) \
       || defined(WOLFSSL_EMBOS)
 

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -73,18 +73,16 @@
     #define wc_ShaUpdate wc_ShaUpdate_sw
     #define wc_ShaFinal  wc_ShaFinal_sw
 
-#elif defined(STM32F2_HASH)
+#elif defined(STM32F2_HASH) || defined(STM32F4_HASH)
+
     /*
-     * STM32F2 hardware SHA1 support through the STM32F2 standard peripheral
-     * library. Documentation located in STM32F2xx Standard Peripheral Library
-     * document (See note in README).
+     * STM32F2/F4 hardware SHA1 support through the standard peripheral
+     * library. (See note in README).
      */
-    #include "stm32f2xx.h"
-    #include "stm32f2xx_hash.h"
 
     int wc_InitSha(Sha* sha)
     {
-        /* STM32F2 struct notes:
+        /* STM32 struct notes:
          * sha->buffer  = first 4 bytes used to hold partial block if needed
          * sha->buffLen = num bytes currently stored in sha->buffer
          * sha->loLen   = num bytes that have been written to STM32 FIFO

--- a/wolfssl/wolfcrypt/des3.h
+++ b/wolfssl/wolfcrypt/des3.h
@@ -58,7 +58,7 @@ enum {
 #define DES3_KEYLEN 24
 
 
-#ifdef STM32F2_CRYPTO
+#if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
 enum {
     DES_CBC = 0,
     DES_ECB = 1

--- a/wolfssl/wolfcrypt/md5.h
+++ b/wolfssl/wolfcrypt/md5.h
@@ -40,7 +40,7 @@
 
 /* in bytes */
 enum {
-#ifdef STM32F2_HASH
+#if defined(STM32F2_HASH) || defined(STM32F4_HASH)
     MD5_REG_SIZE    =  4,      /* STM32 register size, bytes */
 #endif
     MD5             =  0,      /* hash type unique */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -922,10 +922,48 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #define SIZEOF_LONG_LONG 8
     #define NO_DEV_RANDOM
     #define NO_WOLFSSL_DIR
+    #undef  NO_RABBIT
     #define NO_RABBIT
     #define STM32F2_RNG
     #define STM32F2_CRYPTO
-    #define KEIL_INTRINSICS
+    #ifndef __GNUC__
+        #define KEIL_INTRINSICS
+    #endif
+    #define NO_OLD_RNGNAME
+    #ifdef WOLFSSL_STM32_CUBEMX
+        #include "stm32f2xx_hal.h"
+		#ifndef STM32_HAL_TIMEOUT
+        	#define STM32_HAL_TIMEOUT   0xFF
+		#endif
+    #else
+        #include "stm32f2xx.h"
+        #include "stm32f2xx_cryp.h"
+        #include "stm32f2xx_hash.h"
+    #endif /* WOLFSSL_STM32_CUBEMX */
+#endif
+
+#ifdef WOLFSSL_STM32F4
+    #define SIZEOF_LONG_LONG 8
+    #define NO_DEV_RANDOM
+    #define NO_WOLFSSL_DIR
+    #undef  NO_RABBIT
+    #define NO_RABBIT
+    #define STM32F4_RNG
+    #define STM32F4_CRYPTO
+    #define NO_OLD_RNGNAME
+    #ifndef __GNUC__
+        #define KEIL_INTRINSICS
+    #endif
+    #ifdef WOLFSSL_STM32_CUBEMX
+        #include "stm32f4xx_hal.h"
+		#ifndef STM32_HAL_TIMEOUT
+        	#define STM32_HAL_TIMEOUT   0xFF
+		#endif
+    #else
+        #include "stm32f4xx.h"
+        #include "stm32f4xx_cryp.h"
+        #include "stm32f4xx_hash.h"
+    #endif /* WOLFSSL_STM32_CUBEMX */
 #endif
 
 #ifdef MICRIUM

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -43,7 +43,7 @@
 #ifndef HAVE_FIPS /* avoid redefining structs */
 /* in bytes */
 enum {
-#ifdef STM32F2_HASH
+#if defined(STM32F2_HASH) || defined(STM32F4_HASH)
     SHA_REG_SIZE     =  4,    /* STM32 register size, bytes */
 #endif
     SHA              =  1,    /* hash type unique */


### PR DESCRIPTION
Support for RNG, AES, SHA1, DES3 and MD5. Adds new WOLFSSL_STM32_CUBEMX and WOLFSSL_STM32F4 defines. Tested on STM32F437II.
