### PR TITLE
fix ecc_check_privkey_gen() parameters with WOLFSSL_VALIDATE_ECC_IMPORT

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3811,22 +3811,27 @@ static int ecc_check_privkey_gen(ecc_key* key, mp_int* a, mp_int* prime)
 static int ecc_check_privkey_gen_helper(ecc_key* key)
 {
     mp_int prime;
+    mp_int a;
     int    err;
 
     if (key == NULL)
         return BAD_FUNC_ARG;
 
-    err = mp_init(&prime);
+    err = mp_init_multi(&prime, &a, NULL, NULL, NULL, NULL);
     if (err != MP_OKAY)
         return err;
 
     err = mp_read_radix(&prime, key->dp->prime, 16);
 
     if (err == MP_OKAY)
-        err = ecc_check_privkey_gen(key, &prime);
+        err = mp_read_radix(&a, key->dp->Af, 16);
+
+    if (err == MP_OKAY)
+        err = ecc_check_privkey_gen(key, &a, &prime);
 
 #ifndef USE_FAST_MATH
     mp_clear(&prime);
+    mp_clear(&a);
 #endif
 
     return err;


### PR DESCRIPTION
ecc_check_privkey_gen() was recently updated to accept 3 parameters.  This PR fixes one instance of ecc_check_privkey_gen() that was not updated to accept the updated parameters, specifically when WOLFSSL_VALIDATE_ECC_IMPORT is defined.

Reference: Zendesk ticket 2375