### PR TITLE
static analysis : Fix warnings with wc_AesCcmSetKey

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -2473,6 +2473,8 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
     #endif
 
     if (specs->bulk_cipher_algorithm == wolfssl_aes_ccm) {
+        int CcmRet;
+
         if (enc && enc->aes == NULL)
             enc->aes = (Aes*)XMALLOC(sizeof(Aes), heap, DYNAMIC_TYPE_CIPHER);
         if (enc && enc->aes == NULL)
@@ -2484,24 +2486,40 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
 
         if (side == WOLFSSL_CLIENT_END) {
             if (enc) {
-                wc_AesCcmSetKey(enc->aes, keys->client_write_key, specs->key_size);
+                CcmRet = wc_AesCcmSetKey(enc->aes, keys->client_write_key,
+                                         specs->key_size);
+                if (CcmRet != 0) {
+                    return CcmRet;
+                }
                 XMEMCPY(keys->aead_enc_imp_IV, keys->client_write_IV,
                         AESGCM_IMP_IV_SZ);
             }
             if (dec) {
-                wc_AesCcmSetKey(dec->aes, keys->server_write_key, specs->key_size);
+                CcmRet = wc_AesCcmSetKey(dec->aes, keys->server_write_key,
+                                         specs->key_size);
+                if (CcmRet != 0) {
+                    return CcmRet;
+                }
                 XMEMCPY(keys->aead_dec_imp_IV, keys->server_write_IV,
                         AESGCM_IMP_IV_SZ);
             }
         }
         else {
             if (enc) {
-                wc_AesCcmSetKey(enc->aes, keys->server_write_key, specs->key_size);
+                CcmRet = wc_AesCcmSetKey(enc->aes, keys->server_write_key,
+                                         specs->key_size);
+                if (CcmRet != 0) {
+                    return CcmRet;
+                }
                 XMEMCPY(keys->aead_enc_imp_IV, keys->server_write_IV,
                         AESGCM_IMP_IV_SZ);
             }
             if (dec) {
-                wc_AesCcmSetKey(dec->aes, keys->client_write_key, specs->key_size);
+                CcmRet = wc_AesCcmSetKey(dec->aes, keys->client_write_key,
+                                         specs->key_size);
+                if (CcmRet != 0) {
+                    return CcmRet;
+                }
                 XMEMCPY(keys->aead_dec_imp_IV, keys->client_write_IV,
                         AESGCM_IMP_IV_SZ);
             }

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -742,8 +742,12 @@ void bench_aesccm(void)
     Aes    enc;
     double start, total, persec;
     int    i;
+    int    ret;
 
-    wc_AesCcmSetKey(&enc, key, 16);
+    if ((ret = wc_AesCcmSetKey(&enc, key, 16)) != 0) {
+        printf("wc_AesCcmSetKey failed, ret = %d\n", ret);
+        return;
+    }
     start = current_time(1);
     BEGIN_INTEL_CYCLES
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -131,9 +131,10 @@ int wc_GmacUpdate(Gmac* gmac, const byte* iv, word32 ivSz,
 
 #endif /* HAVE_AESGCM */
 #ifdef HAVE_AESCCM
-void wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz)
+int wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz)
 {
     AesCcmSetKey(aes, key, keySz);
+    return 0;
 }
 
 
@@ -4029,15 +4030,15 @@ WOLFSSL_API int wc_GmacUpdate(Gmac* gmac, const byte* iv, word32 ivSz,
 
 #endif
 
-void wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz)
+int wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz)
 {
     byte nonce[AES_BLOCK_SIZE];
 
     if (!((keySz == 16) || (keySz == 24) || (keySz == 32)))
-        return;
+        return BAD_FUNC_ARG;
 
     XMEMSET(nonce, 0, sizeof(nonce));
-    wc_AesSetKey(aes, key, keySz, nonce, AES_ENCRYPTION);
+    return wc_AesSetKey(aes, key, keySz, nonce, AES_ENCRYPTION);
 }
 
 

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -4285,15 +4285,15 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 /* Software version of AES-CCM from wolfcrypt/src/aes.c
  * Gets some speed up from hardware acceleration of wc_AesEncrypt */
 
-void wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz)
+int wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz)
 {
     byte nonce[AES_BLOCK_SIZE];
 
     if (!((keySz == 16) || (keySz == 24) || (keySz == 32)))
-        return;
+        return BAD_FUNC_ARG;
 
     XMEMSET(nonce, 0, sizeof(nonce));
-    wc_AesSetKey(aes, key, keySz, nonce, AES_ENCRYPTION);
+    return wc_AesSetKey(aes, key, keySz, nonce, AES_ENCRYPTION);
 }
 
 

--- a/wolfcrypt/src/port/ti/ti-aes.c
+++ b/wolfcrypt/src/port/ti/ti-aes.c
@@ -518,9 +518,9 @@ WOLFSSL_API int wc_GmacUpdate(Gmac* gmac, const byte* iv, word32 ivSz,
 #endif /* HAVE_AESGCM */
 
 #ifdef HAVE_AESCCM
-WOLFSSL_API void wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz)
+WOLFSSL_API int wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz)
 {
-    AesAuthSetKey(aes, key, keySz) ;
+    return AesAuthSetKey(aes, key, keySz) ;
 }
 
 WOLFSSL_API int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -3349,7 +3349,10 @@ int aesccm_test(void)
     XMEMSET(c2, 0, sizeof(c2));
     XMEMSET(p2, 0, sizeof(p2));
 
-    wc_AesCcmSetKey(&enc, k, sizeof(k));
+    result = wc_AesCcmSetKey(&enc, k, sizeof(k));
+    if (result != 0)
+        return -105;
+
     /* AES-CCM encrypt and decrypt both use AES encrypt internally */
     result = wc_AesCcmEncrypt(&enc, c2, p, sizeof(c2), iv, sizeof(iv),
                                                  t2, sizeof(t2), a, sizeof(a));

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -154,7 +154,7 @@ WOLFSSL_API int  wc_AesCbcDecrypt(Aes* aes, byte* out,
                                byte* authTag, word32 authTagSz);
 #endif /* HAVE_AESGCM */
 #ifdef HAVE_AESCCM
- WOLFSSL_API void wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz);
+ WOLFSSL_API int  wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz);
  WOLFSSL_API int  wc_AesCcmEncrypt(Aes* aes, byte* out,
                                    const byte* in, word32 inSz,
                                    const byte* nonce, word32 nonceSz,


### PR DESCRIPTION
Change wc_AesCcmSetKey to have a return value and check the return value throughout the library.