### PR TITLE
fix redefinition of typedef RNG error with FIPS builds

### DIFF
--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -65,6 +65,16 @@
     extern "C" {
 #endif
 
+#ifndef WC_RNG_TYPE_DEFINED /* guard on redeclaration */
+    #ifdef HAVE_FIPS
+        /* use typedef struct from CTaoCrypt */
+        #include <cyassl/ctaocrypt/random.h>
+    #else
+        typedef struct WC_RNG WC_RNG;
+    #endif
+    #define WC_RNG_TYPE_DEFINED
+#endif
+
 typedef struct WOLFSSL          WOLFSSL;
 typedef struct WOLFSSL_SESSION  WOLFSSL_SESSION;
 typedef struct WOLFSSL_METHOD   WOLFSSL_METHOD;
@@ -85,11 +95,6 @@ typedef struct WOLFSSL_SOCKADDR     WOLFSSL_SOCKADDR;
 #ifndef WOLFSSL_RSA_TYPE_DEFINED /* guard on redeclaration */
 typedef struct WOLFSSL_RSA            WOLFSSL_RSA;
 #define WOLFSSL_RSA_TYPE_DEFINED
-#endif
-
-#ifndef WC_RNG_TYPE_DEFINED /* guard on redeclaration */
-    typedef struct WC_RNG WC_RNG;
-    #define WC_RNG_TYPE_DEFINED
 #endif
 
 typedef struct WOLFSSL_DSA            WOLFSSL_DSA;


### PR DESCRIPTION
When compiling wolfSSL FIPS with "--enable-fips", some versions of GCC/clang threw the following warning:

```
$ cd wolfssl-3.9.10-commercial-fips-linux
$ ./configure --enable-fips
$ make
..
..
In file included from ./wolfssl/wolfcrypt/random.h:22:
./cyassl/ctaocrypt/random.h:77:3: warning: redefinition of typedef 'RNG' is a C11 feature [-Wtypedef-redefinition]
} RNG;
  ^
./wolfssl/ssl.h:82:27: note: previous definition is here
    typedef struct WC_RNG WC_RNG;
                          ^
./wolfssl/wolfcrypt/settings.h:147:20: note: expanded from macro 'WC_RNG'
    #define WC_RNG RNG
```

The reason this happens is that settings.h with HAVE_FIPS defines WC_RNG as RNG.  RNG is then declared in both wolfssl/ssl.h and cyassl/ctaocrypt/random.h.

This PR changes wolfssl/ssl.h to use the declaration in <cyassl/ctaocrypt/random.h> when HAVE_FIPS is defined.

Reference: Zendesk 2257
