### PR TITLE
DTLS Pool Change

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6750,7 +6750,7 @@ int wolfSSL_dtls_got_timeout(WOLFSSL* ssl)
     int result = SSL_SUCCESS;
 
     if (!ssl->options.handShakeDone &&
-        (DtlsPoolTimeout(ssl) < 0 || DtlsPoolSend(ssl, 0) < 0)) {
+        (DtlsMsgPoolTimeout(ssl) < 0 || DtlsMsgPoolSend(ssl, 0) < 0)) {
 
         result = SSL_FATAL_ERROR;
     }
@@ -6923,12 +6923,6 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                 ssl->options.dtls   = 1;
                 ssl->options.tls    = 1;
                 ssl->options.tls1_1 = 1;
-
-                if (DtlsPoolInit(ssl) != 0) {
-                    ssl->error = MEMORY_ERROR;
-                    WOLFSSL_ERROR(ssl->error);
-                    return SSL_FATAL_ERROR;
-                }
             }
         #endif
 
@@ -7285,12 +7279,6 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                 ssl->options.dtls   = 1;
                 ssl->options.tls    = 1;
                 ssl->options.tls1_1 = 1;
-
-                if (DtlsPoolInit(ssl) != 0) {
-                    ssl->error = MEMORY_ERROR;
-                    WOLFSSL_ERROR(ssl->error);
-                    return SSL_FATAL_ERROR;
-                }
             }
         #endif
 

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -150,6 +150,7 @@ enum wolfSSL_ErrorCodes {
     INPUT_SIZE_E                 = -412,   /* input size too big error */
     CTX_INIT_MUTEX_E             = -413,   /* initialize ctx mutex error */
     EXT_MASTER_SECRET_NEEDED_E   = -414,   /* need EMS enabled to resume */
+    DTLS_POOL_SZ_E               = -415,   /* exceeded DTLS pool size */
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* begin negotiation parameter errors */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -952,7 +952,7 @@ enum Misc {
     DTLS_RECORD_EXTRA        = 8,  /* diff from normal */
     DTLS_HANDSHAKE_SEQ_SZ    = 2,  /* handshake header sequence number */
     DTLS_HANDSHAKE_FRAG_SZ   = 3,  /* fragment offset and length are 24 bit */
-    DTLS_POOL_SZ             = 5,  /* buffers to hold in the retry pool */
+    DTLS_POOL_SZ             = 255,/* allowed number of list items in TX pool */
     DTLS_EXPORT_PRO          = 165,/* wolfSSL protocol for serialized session */
     DTLS_EXPORT_VERSION      = 2,  /* wolfSSL version for serialized session */
     DTLS_EXPORT_OPT_SZ       = 57, /* amount of bytes used from Options */
@@ -2751,8 +2751,10 @@ struct WOLFSSL {
     int             dtls_timeout_init;  /* starting timeout value */
     int             dtls_timeout_max;   /* maximum timeout value */
     int             dtls_timeout;       /* current timeout value, changes */
+    word32          dtls_tx_msg_list_sz;
+    word32          dtls_rx_msg_list_sz;
     DtlsMsg*        dtls_tx_msg_list;
-    DtlsMsg*        dtls_msg_list;
+    DtlsMsg*        dtls_rx_msg_list;
     void*           IOCB_CookieCtx;     /* gen cookie ctx */
     word32          dtls_expected_rx;
     wc_dtls_export  dtls_export;        /* export function for session */
@@ -3069,7 +3071,7 @@ WOLFSSL_LOCAL  int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength);
     WOLFSSL_LOCAL int  DtlsMsgSet(DtlsMsg*, word32, const byte*, byte,
                                                        word32, word32, void*);
     WOLFSSL_LOCAL DtlsMsg* DtlsMsgFind(DtlsMsg*, word32);
-    WOLFSSL_LOCAL DtlsMsg* DtlsMsgStore(DtlsMsg*, word32, const byte*, word32,
+    WOLFSSL_LOCAL void DtlsMsgStore(WOLFSSL*, word32, const byte*, word32,
                                                 byte, word32, word32, void*);
     WOLFSSL_LOCAL DtlsMsg* DtlsMsgInsert(DtlsMsg*, DtlsMsg*);
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2584,13 +2584,6 @@ typedef struct DtlsRecordLayerHeader {
 } DtlsRecordLayerHeader;
 
 
-typedef struct DtlsPool {
-    buffer          buf[DTLS_POOL_SZ];
-    word16          epoch[DTLS_POOL_SZ];
-    int             used;
-} DtlsPool;
-
-
 typedef struct DtlsFrag {
     word32 begin;
     word32 end;
@@ -2758,7 +2751,7 @@ struct WOLFSSL {
     int             dtls_timeout_init;  /* starting timeout value */
     int             dtls_timeout_max;   /* maximum timeout value */
     int             dtls_timeout;       /* current timeout value, changes */
-    DtlsPool*       dtls_pool;
+    DtlsMsg*        dtls_tx_msg_list;
     DtlsMsg*        dtls_msg_list;
     void*           IOCB_CookieCtx;     /* gen cookie ctx */
     word32          dtls_expected_rx;
@@ -3070,14 +3063,6 @@ WOLFSSL_LOCAL  int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength);
 #endif /* NO_WOLFSSL_SERVER */
 
 #ifdef WOLFSSL_DTLS
-    WOLFSSL_LOCAL int  DtlsPoolInit(WOLFSSL*);
-    WOLFSSL_LOCAL int  DtlsPoolSave(WOLFSSL*, const byte*, int);
-    WOLFSSL_LOCAL int  DtlsPoolTimeout(WOLFSSL*);
-    WOLFSSL_LOCAL int  DtlsPoolSend(WOLFSSL*, byte);
-    WOLFSSL_LOCAL int  VerifyForDtlsPoolSend(WOLFSSL*, byte, word32);
-    WOLFSSL_LOCAL void DtlsPoolReset(WOLFSSL*);
-    WOLFSSL_LOCAL void DtlsPoolDelete(WOLFSSL*);
-
     WOLFSSL_LOCAL DtlsMsg* DtlsMsgNew(word32, void*);
     WOLFSSL_LOCAL void DtlsMsgDelete(DtlsMsg*, void*);
     WOLFSSL_LOCAL void DtlsMsgListDelete(DtlsMsg*, void*);
@@ -3087,6 +3072,12 @@ WOLFSSL_LOCAL  int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength);
     WOLFSSL_LOCAL DtlsMsg* DtlsMsgStore(DtlsMsg*, word32, const byte*, word32,
                                                 byte, word32, word32, void*);
     WOLFSSL_LOCAL DtlsMsg* DtlsMsgInsert(DtlsMsg*, DtlsMsg*);
+
+    WOLFSSL_LOCAL int  DtlsMsgPoolSave(WOLFSSL*, const byte*, word32);
+    WOLFSSL_LOCAL int  DtlsMsgPoolTimeout(WOLFSSL*);
+    WOLFSSL_LOCAL int  VerifyForDtlsMsgPoolSend(WOLFSSL*, byte, word32);
+    WOLFSSL_LOCAL void DtlsMsgPoolReset(WOLFSSL*);
+    WOLFSSL_LOCAL int  DtlsMsgPoolSend(WOLFSSL*, int);
 #endif /* WOLFSSL_DTLS */
 
 #ifndef NO_TLS


### PR DESCRIPTION
1. Remove the statically allocated DTLS message pool, used to store handshake messages to retransmit, with the dynamic MsgList used on the receive side.
2. Moved the checks for the new session ticket message and certificate verify messages to the sanity check function. The handshake sanity check function response for out of order and duplicate messages is handled in DTLS.