### PR TITLE
add AES content encryption support to PKCS#7 EnvelopedData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,10 @@ certreq.der
 certreq.pem
 pkcs7cert.der
 pkcs7signedData.der
-pkcs7envelopedData.der
+pkcs7envelopedDataDES3.der
+pkcs7envelopedDataAES128CBC.der
+pkcs7envelopedDataAES192CBC.der
+pkcs7envelopedDataAES256CBC.der
 diff
 sslSniffer/sslSnifferTest/tracefile.txt
 tracefile.txt

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,10 @@ CLEANFILES+= cert.der \
              othercert.der \
              othercert.pem \
              pkcs7cert.der \
-             pkcs7envelopedData.der \
+             pkcs7envelopedDataDES3.der \
+             pkcs7envelopedDataAES128CBC.der \
+             pkcs7envelopedDataAES192CBC.der \
+             pkcs7envelopedDataAES256CBC.der \
              pkcs7signedData.der
 
 exampledir = $(docdir)/example

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -784,6 +784,7 @@ static const byte hashSha512hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 3};
 
 /* blkType */
 static const byte blkAes128CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 2};
+static const byte blkAes192CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 22};
 static const byte blkDesCbcOid[]  = {43, 14, 3, 2, 7};
 static const byte blkDes3CbcOid[] = {42, 134, 72, 134, 247, 13, 3, 7};
 
@@ -963,6 +964,10 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                 case AES128CBCb:
                     oid = blkAes128CbcOid;
                     *oidSz = sizeof(blkAes128CbcOid);
+                    break;
+                case AES192CBCb:
+                    oid = blkAes192CbcOid;
+                    *oidSz = sizeof(blkAes192CbcOid);
                     break;
                 case DESb:
                     oid = blkDesCbcOid;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -783,6 +783,7 @@ static const byte hashSha512hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 3};
 #endif /* HAVE_ECC */
 
 /* blkType */
+static const byte blkAes128CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 2};
 static const byte blkDesCbcOid[]  = {43, 14, 3, 2, 7};
 static const byte blkDes3CbcOid[] = {42, 134, 72, 134, 247, 13, 3, 7};
 
@@ -959,6 +960,10 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
 
         case oidBlkType:
             switch (id) {
+                case AES128CBCb:
+                    oid = blkAes128CbcOid;
+                    *oidSz = sizeof(blkAes128CbcOid);
+                    break;
                 case DESb:
                     oid = blkDesCbcOid;
                     *oidSz = sizeof(blkDesCbcOid);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -785,6 +785,7 @@ static const byte hashSha512hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 3};
 /* blkType */
 static const byte blkAes128CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 2};
 static const byte blkAes192CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 22};
+static const byte blkAes256CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 42};
 static const byte blkDesCbcOid[]  = {43, 14, 3, 2, 7};
 static const byte blkDes3CbcOid[] = {42, 134, 72, 134, 247, 13, 3, 7};
 
@@ -968,6 +969,10 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                 case AES192CBCb:
                     oid = blkAes192CbcOid;
                     *oidSz = sizeof(blkAes192CbcOid);
+                    break;
+                case AES256CBCb:
+                    oid = blkAes256CbcOid;
+                    *oidSz = sizeof(blkAes256CbcOid);
                     break;
                 case DESb:
                     oid = blkDesCbcOid;

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1192,7 +1192,8 @@ int wc_PKCS7_EncryptContent(int encryptOID, byte* key, int keySz,
     switch (encryptOID) {
 #ifndef NO_AES
         case AES128CBCb:
-            if (keySz != 16 || ivSz != AES_BLOCK_SIZE)
+        case AES192CBCb:
+            if (ivSz != AES_BLOCK_SIZE)
                 return BAD_FUNC_ARG;
 
             ret = wc_AesSetKey(&aes, key, keySz, iv, AES_ENCRYPTION);
@@ -1211,6 +1212,7 @@ int wc_PKCS7_EncryptContent(int encryptOID, byte* key, int keySz,
                 ret = wc_Des_CbcEncrypt(&des, out, in, inSz);
 
             break;
+
         case DES3b:
             if (keySz != DES3_KEYLEN || ivSz != DES_BLOCK_SIZE)
                 return BAD_FUNC_ARG;
@@ -1249,7 +1251,8 @@ int wc_PKCS7_DecryptContent(int encryptOID, byte* key, int keySz,
     switch (encryptOID) {
 #ifndef NO_AES
         case AES128CBCb:
-            if (keySz != 16 || ivSz != AES_BLOCK_SIZE)
+        case AES192CBCb:
+            if (ivSz != AES_BLOCK_SIZE)
                 return BAD_FUNC_ARG;
 
             ret = wc_AesSetKey(&aes, key, keySz, iv, AES_DECRYPTION);
@@ -1341,6 +1344,11 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     switch (pkcs7->encryptOID) {
         case AES128CBCb:
             blockKeySz = 16;
+            blockSz    = AES_BLOCK_SIZE;
+            break;
+
+        case AES192CBCb:
+            blockKeySz = 24;
             blockSz    = AES_BLOCK_SIZE;
             break;
 
@@ -1788,6 +1796,11 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
     switch(encOID) {
         case AES128CBCb:
             blockKeySz = 16;
+            expBlockSz = AES_BLOCK_SIZE;
+            break;
+
+        case AES192CBCb:
+            blockKeySz = 24;
             expBlockSz = AES_BLOCK_SIZE;
             break;
 

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1193,6 +1193,7 @@ int wc_PKCS7_EncryptContent(int encryptOID, byte* key, int keySz,
 #ifndef NO_AES
         case AES128CBCb:
         case AES192CBCb:
+        case AES256CBCb:
             if (ivSz != AES_BLOCK_SIZE)
                 return BAD_FUNC_ARG;
 
@@ -1252,6 +1253,7 @@ int wc_PKCS7_DecryptContent(int encryptOID, byte* key, int keySz,
 #ifndef NO_AES
         case AES128CBCb:
         case AES192CBCb:
+        case AES256CBCb:
             if (ivSz != AES_BLOCK_SIZE)
                 return BAD_FUNC_ARG;
 
@@ -1340,7 +1342,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     if (output == NULL || outputSz == 0)
         return BAD_FUNC_ARG;
 
-    /* wolfCrypt PKCS#7 supports AES-128-CBC, DES, 3DES for now */
+    /* wolfCrypt PKCS#7 supports AES-128/192/256-CBC, DES, 3DES for now */
     switch (pkcs7->encryptOID) {
         case AES128CBCb:
             blockKeySz = 16;
@@ -1349,6 +1351,11 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
 
         case AES192CBCb:
             blockKeySz = 24;
+            blockSz    = AES_BLOCK_SIZE;
+            break;
+
+        case AES256CBCb:
+            blockKeySz = 32;
             blockSz    = AES_BLOCK_SIZE;
             break;
 
@@ -1801,6 +1808,11 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
 
         case AES192CBCb:
             blockKeySz = 24;
+            expBlockSz = AES_BLOCK_SIZE;
+            break;
+
+        case AES256CBCb:
+            blockKeySz = 32;
             expBlockSz = AES_BLOCK_SIZE;
             break;
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8538,8 +8538,8 @@ int pkcs7enveloped_test(void)
         0x72,0x6c,0x64
     };
 
-    pkcs7EnvelopedVector a, b, c;
-    pkcs7EnvelopedVector test_pkcs7env[3];
+    pkcs7EnvelopedVector a, b, c, d;
+    pkcs7EnvelopedVector test_pkcs7env[4];
     int times = sizeof(test_pkcs7env) / sizeof(pkcs7EnvelopedVector), i;
 
     /* read client cert and key in DER format */
@@ -8604,9 +8604,18 @@ int pkcs7enveloped_test(void)
     c.privateKeySz = (word32)privKeySz;
     c.outFileName  = "pkcs7envelopedDataAES192CBC.der";
 
+    d.content      = data;
+    d.contentSz    = (word32)sizeof(data);
+    d.contentOID   = DATA;
+    d.encryptOID   = AES256CBCb;
+    d.privateKey   = privKey;
+    d.privateKeySz = (word32)privKeySz;
+    d.outFileName  = "pkcs7envelopedDataAES256CBC.der";
+
     test_pkcs7env[0] = a;
     test_pkcs7env[1] = b;
     test_pkcs7env[2] = c;
+    test_pkcs7env[3] = d;
 
     for (i = 0; i < times; i++) {
         pkcs7.content     = (byte*)test_pkcs7env[i].content;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8506,11 +8506,20 @@ int compress_test(void)
 
 #ifdef HAVE_PKCS7
 
+typedef struct {
+    const char* outFileName;
+    const byte* content;
+    word32      contentSz;
+    int         contentOID;
+    int         encryptOID;
+    byte*       privateKey;
+    word32      privateKeySz;
+} pkcs7EnvelopedVector;
+
 int pkcs7enveloped_test(void)
 {
     int ret = 0;
 
-    int cipher = DES3b;
     int envelopedSz, decodedSz;
     PKCS7 pkcs7;
     byte* cert;
@@ -8523,12 +8532,15 @@ int pkcs7enveloped_test(void)
     FILE*  certFile;
     FILE*  keyFile;
     FILE*  pkcs7File;
-    const char* pkcs7OutFile = "pkcs7envelopedData.der";
 
     const byte data[] = { /* Hello World */
         0x48,0x65,0x6c,0x6c,0x6f,0x20,0x57,0x6f,
         0x72,0x6c,0x64
     };
+
+    pkcs7EnvelopedVector a, b;
+    pkcs7EnvelopedVector test_pkcs7env[2];
+    int times = sizeof(test_pkcs7env) / sizeof(pkcs7EnvelopedVector), i;
 
     /* read client cert and key in DER format */
     cert = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -8566,48 +8578,72 @@ int pkcs7enveloped_test(void)
     fclose(keyFile);
 
     wc_PKCS7_InitWithCert(&pkcs7, cert, (word32)certSz);
-    pkcs7.content     = (byte*)data;
-    pkcs7.contentSz   = (word32)sizeof(data);
-    pkcs7.contentOID  = DATA;
-    pkcs7.encryptOID  = cipher;
-    pkcs7.privateKey  = privKey;
-    pkcs7.privateKeySz = (word32)privKeySz;
 
-    /* encode envelopedData */
-    envelopedSz = wc_PKCS7_EncodeEnvelopedData(&pkcs7, enveloped,
-                                            sizeof(enveloped));
-    if (envelopedSz <= 0) {
-        XFREE(cert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(privKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        return -203;
+    /* set up test vectors */
+    a.content      = data;
+    a.contentSz    = (word32)sizeof(data);
+    a.contentOID   = DATA;
+    a.encryptOID   = DES3b;
+    a.privateKey   = privKey;
+    a.privateKeySz = (word32)privKeySz;
+    a.outFileName  = "pkcs7envelopedDataDES3.der";
+
+    b.content      = data;
+    b.contentSz    = (word32)sizeof(data);
+    b.contentOID   = DATA;
+    b.encryptOID   = AES128CBCb;
+    b.privateKey   = privKey;
+    b.privateKeySz = (word32)privKeySz;
+    b.outFileName  = "pkcs7envelopedDataAES128CBC.der";
+
+    test_pkcs7env[0] = a;
+    test_pkcs7env[1] = b;
+
+    for (i = 0; i < times; i++) {
+        pkcs7.content     = (byte*)test_pkcs7env[i].content;
+        pkcs7.contentSz   = test_pkcs7env[i].contentSz;
+        pkcs7.contentOID  = test_pkcs7env[i].contentOID;
+        pkcs7.encryptOID  = test_pkcs7env[i].encryptOID;
+        pkcs7.privateKey  = test_pkcs7env[i].privateKey;
+        pkcs7.privateKeySz = test_pkcs7env[i].privateKeySz;
+
+        /* encode envelopedData */
+        envelopedSz = wc_PKCS7_EncodeEnvelopedData(&pkcs7, enveloped,
+                                                sizeof(enveloped));
+        if (envelopedSz <= 0) {
+            XFREE(cert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(privKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            printf("envelopedSz = %d\n", envelopedSz);
+            return -203;
+        }
+
+        /* decode envelopedData */
+        decodedSz = wc_PKCS7_DecodeEnvelopedData(&pkcs7, enveloped, envelopedSz,
+                                              decoded, sizeof(decoded));
+        if (decodedSz <= 0) {
+            XFREE(cert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(privKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            return -204;
+        }
+
+        /* test decode result */
+        if (XMEMCMP(decoded, data, sizeof(data)) != 0) {
+            XFREE(cert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(privKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            return -205;
+        }
+
+        /* output pkcs7 envelopedData for external testing */
+        pkcs7File = fopen(test_pkcs7env[i].outFileName, "wb");
+        if (!pkcs7File) {
+            XFREE(cert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(privKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            return -206;
+        }
+
+        ret = (int)fwrite(enveloped, envelopedSz, 1, pkcs7File);
+        fclose(pkcs7File);
     }
-
-    /* decode envelopedData */
-    decodedSz = wc_PKCS7_DecodeEnvelopedData(&pkcs7, enveloped, envelopedSz,
-                                          decoded, sizeof(decoded));
-    if (decodedSz <= 0) {
-        XFREE(cert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(privKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        return -204;
-    }
-
-    /* test decode result */
-    if (XMEMCMP(decoded, data, sizeof(data)) != 0) {
-        XFREE(cert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(privKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        return -205;
-    }
-
-    /* output pkcs7 envelopedData for external testing */
-    pkcs7File = fopen(pkcs7OutFile, "wb");
-    if (!pkcs7File) {
-        XFREE(cert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(privKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        return -206;
-    }
-
-    ret = (int)fwrite(enveloped, envelopedSz, 1, pkcs7File);
-    fclose(pkcs7File);
 
     XFREE(cert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(privKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8538,8 +8538,8 @@ int pkcs7enveloped_test(void)
         0x72,0x6c,0x64
     };
 
-    pkcs7EnvelopedVector a, b;
-    pkcs7EnvelopedVector test_pkcs7env[2];
+    pkcs7EnvelopedVector a, b, c;
+    pkcs7EnvelopedVector test_pkcs7env[3];
     int times = sizeof(test_pkcs7env) / sizeof(pkcs7EnvelopedVector), i;
 
     /* read client cert and key in DER format */
@@ -8596,8 +8596,17 @@ int pkcs7enveloped_test(void)
     b.privateKeySz = (word32)privKeySz;
     b.outFileName  = "pkcs7envelopedDataAES128CBC.der";
 
+    c.content      = data;
+    c.contentSz    = (word32)sizeof(data);
+    c.contentOID   = DATA;
+    c.encryptOID   = AES192CBCb;
+    c.privateKey   = privKey;
+    c.privateKeySz = (word32)privKeySz;
+    c.outFileName  = "pkcs7envelopedDataAES192CBC.der";
+
     test_pkcs7env[0] = a;
     test_pkcs7env[1] = b;
+    test_pkcs7env[2] = c;
 
     for (i = 0; i < times; i++) {
         pkcs7.content     = (byte*)test_pkcs7env[i].content;

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -228,6 +228,7 @@ enum Hash_Sum  {
 
 enum Block_Sum {
     AES128CBCb = 414,
+    AES192CBCb = 434,
     DESb       = 69,
     DES3b      = 652
 };

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -229,6 +229,7 @@ enum Hash_Sum  {
 enum Block_Sum {
     AES128CBCb = 414,
     AES192CBCb = 434,
+    AES256CBCb = 454,
     DESb       = 69,
     DES3b      = 652
 };

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -227,8 +227,9 @@ enum Hash_Sum  {
 
 
 enum Block_Sum {
-    DESb  = 69,
-    DES3b = 652
+    AES128CBCb = 414,
+    DESb       = 69,
+    DES3b      = 652
 };
 
 

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -56,9 +56,9 @@ enum PKCS7_TYPES {
 
 enum Pkcs7_Misc {
     PKCS7_NONCE_SZ        = 16,
-    MAX_ENCRYPTED_KEY_SZ  = 512,           /* max enc. key size, RSA <= 4096 */
-    MAX_CONTENT_KEY_LEN   = DES3_KEYLEN,   /* highest current cipher is 3DES */
-    MAX_CONTENT_IV_SIZE   = 16,            /* highest current is AES128 */
+    MAX_ENCRYPTED_KEY_SZ  = 512,    /* max enc. key size, RSA <= 4096 */
+    MAX_CONTENT_KEY_LEN   = 32,     /* highest current cipher is AES-256-CBC */
+    MAX_CONTENT_IV_SIZE   = 16,     /* highest current is AES128 */
     MAX_CONTENT_BLOCK_LEN = AES_BLOCK_SIZE,
     MAX_RECIP_SZ          = MAX_VERSION_SZ +
                             MAX_SEQ_SZ + ASN_NAME_MAX + MAX_SN_SZ +

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -32,6 +32,9 @@
 #endif
 #include <wolfssl/wolfcrypt/asn_public.h>
 #include <wolfssl/wolfcrypt/random.h>
+#ifndef NO_AES
+    #include <wolfssl/wolfcrypt/aes.h>
+#endif
 #ifndef NO_DES3
     #include <wolfssl/wolfcrypt/des3.h>
 #endif
@@ -52,12 +55,14 @@ enum PKCS7_TYPES {
 };
 
 enum Pkcs7_Misc {
-    PKCS7_NONCE_SZ       = 16,
-    MAX_ENCRYPTED_KEY_SZ = 512,           /* max enc. key size, RSA <= 4096 */
-    MAX_CONTENT_KEY_LEN  = DES3_KEYLEN,   /* highest current cipher is 3DES */
-    MAX_RECIP_SZ         = MAX_VERSION_SZ +
-                           MAX_SEQ_SZ + ASN_NAME_MAX + MAX_SN_SZ +
-                           MAX_SEQ_SZ + MAX_ALGO_SZ + 1 + MAX_ENCRYPTED_KEY_SZ
+    PKCS7_NONCE_SZ        = 16,
+    MAX_ENCRYPTED_KEY_SZ  = 512,           /* max enc. key size, RSA <= 4096 */
+    MAX_CONTENT_KEY_LEN   = DES3_KEYLEN,   /* highest current cipher is 3DES */
+    MAX_CONTENT_IV_SIZE   = 16,            /* highest current is AES128 */
+    MAX_CONTENT_BLOCK_LEN = AES_BLOCK_SIZE,
+    MAX_RECIP_SZ          = MAX_VERSION_SZ +
+                            MAX_SEQ_SZ + ASN_NAME_MAX + MAX_SN_SZ +
+                            MAX_SEQ_SZ + MAX_ALGO_SZ + 1 + MAX_ENCRYPTED_KEY_SZ
 };
 
 
@@ -106,6 +111,12 @@ WOLFSSL_LOCAL int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
                                      WC_RNG* rng, byte* contentKeyPlain,
                                      byte* contentKeyEnc, int* keyEncSz,
                                      byte* out, word32 outSz, void* heap);
+WOLFSSL_LOCAL int wc_PKCS7_EncryptContent(int encryptOID, byte* key, int keySz,
+                                     byte* iv, int ivSz, byte* in, int inSz,
+                                     byte* out);
+WOLFSSL_LOCAL int wc_PKCS7_DecryptContent(int encryptOID, byte* key, int keySz,
+                                     byte* iv, int ivSz, byte* in, int inSz,
+                                     byte* out);
 
 WOLFSSL_API int  wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* cert, word32 certSz);
 WOLFSSL_API void wc_PKCS7_Free(PKCS7* pkcs7);


### PR DESCRIPTION
 This PR adds AES-128/192/256-CBC encryption support to the following two PKCS#7 functions:

wc_PKCS7_EncodeEnvelopedData()
wc_PKCS7_DecodeEnvelopedData()

- PKCS#7 padding is used to pad AES input data to a block size length
- Additional tests added to pkcs7enveloped_test() in test.c for AES
- Tested against OpenSSL. OpenSSL can decrypt wolfSSL-generated PKCS#7 EnvelopedData DER file.  wolfSSL can decrypt OpenSSL-generated PKCS#7 EnvelopedData DER file.
- Tested on Ubuntu Linux, OSX, Windows 10 with Visual Studio