### PR TITLE
RNG : option to not use RNG

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -221,6 +221,19 @@ then
 fi
 
 
+AC_ARG_ENABLE([norng],
+    [  --enable-norng       Enable Test Cert (default: disabled)],
+    [ ENABLED_NORNG=$enableval ],
+    [ ENABLED_NORNG=no ]
+    )
+
+if test "$ENABLED_NORNG" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWC_NO_RNG"
+fi
+AM_CONDITIONAL([BUILD_RNG], [test "x$ENABLED_NORNG" = "xno"])
+
+
 # DTLS-SCTP
 AC_ARG_ENABLE([sctp],
     [AS_HELP_STRING([--enable-sctp],[Enable wolfSSL DTLS-SCTP support (default: disabled)])],

--- a/configure.ac
+++ b/configure.ac
@@ -221,17 +221,17 @@ then
 fi
 
 
-AC_ARG_ENABLE([norng],
-    [  --enable-norng       Enable Test Cert (default: disabled)],
-    [ ENABLED_NORNG=$enableval ],
-    [ ENABLED_NORNG=no ]
+AC_ARG_ENABLE([rng],
+    [AS_HELP_STRING([  --enable-rng       Enable compiling and using RNG (default: enabled)])],
+    [ ENABLED_RNG=$enableval ],
+    [ ENABLED_RNG=yes ]
     )
 
-if test "$ENABLED_NORNG" = "yes"
+if test "$ENABLED_RNG" = "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DWC_NO_RNG"
 fi
-AM_CONDITIONAL([BUILD_RNG], [test "x$ENABLED_NORNG" = "xno"])
+AM_CONDITIONAL([BUILD_RNG], [test "x$ENABLED_RNG" = "xyes"])
 
 
 # DTLS-SCTP

--- a/src/include.am
+++ b/src/include.am
@@ -61,8 +61,11 @@ endif
 
 src_libwolfssl_la_SOURCES += \
                wolfcrypt/src/hmac.c \
-               wolfcrypt/src/random.c \
                wolfcrypt/src/hash.c
+
+if BUILD_RNG
+src_libwolfssl_la_SOURCES += wolfcrypt/src/random.c
+endif
 
 if BUILD_ARMASM
 src_libwolfssl_la_SOURCES += wolfcrypt/src/port/arm/armv8-sha256.c

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -224,7 +224,9 @@ void bench_ed25519KeySign(void);
 void bench_ntru(void);
 void bench_ntruKeyGen(void);
 #endif
+#ifndef WC_NO_RNG
 void bench_rng(void);
+#endif /* WC_NO_RNG */
 
 double current_time(int);
 
@@ -340,7 +342,9 @@ int benchmark_test(void *args)
     }
 #endif
 
+#ifndef WC_NO_RNG
     bench_rng();
+#endif /* WC_NO_RNG */
 #ifndef NO_AES
 #ifdef HAVE_AES_CBC
     bench_aes(0);
@@ -503,6 +507,7 @@ enum BenchmarkBounds {
 static const char blockType[] = "megs"; /* used in printf output */
 #endif
 
+#ifndef WC_NO_RNG
 void bench_rng(void)
 {
     int    ret, i;
@@ -558,6 +563,7 @@ void bench_rng(void)
     wc_FreeRng(&rng);
 #endif
 }
+#endif /* WC_NO_RNG */
 
 
 #ifndef NO_AES

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3781,6 +3781,7 @@ static int ConfirmSignature(const byte* buf, word32 bufSz,
             WOLFSSL_MSG("Verify Key type unknown");
     }
 
+    (void)digestSz;
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(digest, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -82,6 +82,7 @@ int  wc_RNG_GenerateByte(WC_RNG* rng, byte* b)
     }
 #endif /* HAVE_HASHDRBG || NO_RC4 */
 #else /* else build without fips */
+#ifndef WC_NO_RNG /* if not FIPS and RNG is disabled then do not compile */
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 /* Allow custom RNG system */
@@ -1671,5 +1672,6 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
 #endif /* USE_WINDOWS_API */
 #endif /* CUSTOM_RAND_GENERATE_BLOCK */
+#endif /* WC_NO_RNG */
 #endif /* HAVE_FIPS */
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -51,7 +51,13 @@
 #include <wolfssl/wolfcrypt/sha256.h>
 #include <wolfssl/wolfcrypt/sha512.h>
 #include <wolfssl/wolfcrypt/arc4.h>
-#include <wolfssl/wolfcrypt/random.h>
+
+#if defined(WC_NO_RNG) && defined(USE_FAST_MATH)
+    #include <wolfssl/wolfcrypt/tfm.h>
+#else
+    #include <wolfssl/wolfcrypt/random.h>
+#endif
+
 #include <wolfssl/wolfcrypt/coding.h>
 #include <wolfssl/wolfcrypt/rsa.h>
 #include <wolfssl/wolfcrypt/des3.h>
@@ -195,7 +201,9 @@ int  rsa_test(void);
 int  dh_test(void);
 int  dsa_test(void);
 int  srp_test(void);
+#ifndef WC_NO_RNG
 int  random_test(void);
+#endif /* WC_NO_RNG */
 int  pwdbased_test(void);
 int  ripemd_test(void);
 int  openssl_test(void);   /* test mini api */
@@ -548,10 +556,12 @@ int wolfcrypt_test(void* args)
         printf( "IDEA     test passed!\n");
 #endif
 
+#ifndef WC_NO_RNG
     if ( (ret = random_test()) != 0)
         return err_sys("RANDOM   test failed!\n", ret);
     else
         printf( "RANDOM   test passed!\n");
+#endif /* WC_NO_RNG */
 
 #ifdef WOLFSSL_STATIC_MEMORY
     if ( (ret = memory_test()) != 0)
@@ -3747,6 +3757,7 @@ int idea_test(void)
         }
     }
 
+#ifndef WC_NO_RNG
     /* random test for CBC */
     {
         WC_RNG rng;
@@ -3814,12 +3825,14 @@ int idea_test(void)
 
         wc_FreeRng(&rng);
     }
+#endif /* WC_NO_RNG */
 
     return 0;
 }
 #endif /* HAVE_IDEA */
 
 
+#ifndef WC_NO_RNG
 static int random_rng_test(void)
 {
     WC_RNG rng;
@@ -3947,6 +3960,7 @@ int random_test(void)
 }
 
 #endif /* (HAVE_HASHDRBG || NO_RC4) && !CUSTOM_RAND_GENERATE_BLOCK */
+#endif /* WC_NO_RNG */
 
 
 #ifdef WOLFSSL_STATIC_MEMORY


### PR DESCRIPTION
This allows a user to build crypto operations with the option of not building in an RNG if not needed. Some example configure commands are as follows.

$ ./configure --enable-norng --enable-cryptonly --disable-rsa --disable-dh --disable-ecc --disable-fastmath

$ ./configure --enable-norng --enable-cryptonly --disable-rsa --disable-dh --disable-ecc

Not many checks (any) are done on the configuration of wolfSSL. If building in crypto that makes a call to any RNG functions the build will fail with errors.