### PR TITLE
allow PKCS#7 to be compiled with AES disabled

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1344,6 +1344,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
 
     /* wolfCrypt PKCS#7 supports AES-128/192/256-CBC, DES, 3DES for now */
     switch (pkcs7->encryptOID) {
+#ifndef NO_AES
         case AES128CBCb:
             blockKeySz = 16;
             blockSz    = AES_BLOCK_SIZE;
@@ -1358,7 +1359,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
             blockKeySz = 32;
             blockSz    = AES_BLOCK_SIZE;
             break;
-
+#endif
         case DESb:
             blockKeySz = DES_KEYLEN;
             blockSz    = DES_BLOCK_SIZE;
@@ -1801,6 +1802,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
 
     /* wolfCrypt PKCS#7 supports AES-128-CBC, DES, 3DES for now */
     switch(encOID) {
+#ifndef NO_AES
         case AES128CBCb:
             blockKeySz = 16;
             expBlockSz = AES_BLOCK_SIZE;
@@ -1815,7 +1817,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
             blockKeySz = 32;
             expBlockSz = AES_BLOCK_SIZE;
             break;
-
+#endif
         case DESb:
             blockKeySz = DES_KEYLEN;
             expBlockSz = DES_BLOCK_SIZE;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8552,8 +8552,13 @@ int pkcs7enveloped_test(void)
         0x72,0x6c,0x64
     };
 
-    pkcs7EnvelopedVector a, b, c, d;
+    pkcs7EnvelopedVector a;
+#ifndef NO_AES
+    pkcs7EnvelopedVector b, c, d;
     pkcs7EnvelopedVector test_pkcs7env[4];
+#else
+    pkcs7EnvelopedVector test_pkcs7env[1];
+#endif
     int times = sizeof(test_pkcs7env) / sizeof(pkcs7EnvelopedVector), i;
 
     /* read client cert and key in DER format */
@@ -8602,6 +8607,7 @@ int pkcs7enveloped_test(void)
     a.privateKeySz = (word32)privKeySz;
     a.outFileName  = "pkcs7envelopedDataDES3.der";
 
+#ifndef NO_AES
     b.content      = data;
     b.contentSz    = (word32)sizeof(data);
     b.contentOID   = DATA;
@@ -8625,11 +8631,14 @@ int pkcs7enveloped_test(void)
     d.privateKey   = privKey;
     d.privateKeySz = (word32)privKeySz;
     d.outFileName  = "pkcs7envelopedDataAES256CBC.der";
+#endif
 
     test_pkcs7env[0] = a;
+#ifndef NO_AES
     test_pkcs7env[1] = b;
     test_pkcs7env[2] = c;
     test_pkcs7env[3] = d;
+#endif
 
     for (i = 0; i < times; i++) {
         pkcs7.content     = (byte*)test_pkcs7env[i].content;

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -59,7 +59,11 @@ enum Pkcs7_Misc {
     MAX_ENCRYPTED_KEY_SZ  = 512,    /* max enc. key size, RSA <= 4096 */
     MAX_CONTENT_KEY_LEN   = 32,     /* highest current cipher is AES-256-CBC */
     MAX_CONTENT_IV_SIZE   = 16,     /* highest current is AES128 */
+#ifndef NO_AES
     MAX_CONTENT_BLOCK_LEN = AES_BLOCK_SIZE,
+#else
+    MAX_CONTENT_BLOCK_LEN = DES_BLOCK_SIZE,
+#endif
     MAX_RECIP_SZ          = MAX_VERSION_SZ +
                             MAX_SEQ_SZ + ASN_NAME_MAX + MAX_SN_SZ +
                             MAX_SEQ_SZ + MAX_ALGO_SZ + 1 + MAX_ENCRYPTED_KEY_SZ


### PR DESCRIPTION
This PR allows PKCS#7 to be compiled with AES disabled.