### PR TITLE
Fix dropped DTLS Hello Verify retransmit

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8061,7 +8061,8 @@ static int DoDtlsHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         /* This branch is in order next, and a complete message. */
         ret = DoHandShakeMsgType(ssl, input, inOutIdx, type, size, totalSz);
         if (ret == 0) {
-            ssl->keys.dtls_expected_peer_handshake_number++;
+            if (type != client_hello)
+                ssl->keys.dtls_expected_peer_handshake_number++;
             if (ssl->dtls_rx_msg_list != NULL) {
                 ret = DtlsMsgDrain(ssl);
             }


### PR DESCRIPTION
Increment the expected handshake number if the call to the handshake message processing function is successful, but not if the handshake message is the client_hello. Process client hello clears that counter and incrementing it breaks the handshake. Fixes issue #612.