### PR TITLE
PKCS12 : visibility of structs and guards

### DIFF
--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -55,10 +55,9 @@ enum {
     WC_PKCS12_ENCRYPTED_DATA = 656,
 };
 
-typedef struct ContentInfo ContentInfo;
 typedef struct ContentInfo {
     byte* data;
-    ContentInfo* next;
+    struct ContentInfo* next;
     word32 encC;  /* encryptedContent */
     word32 dataSz;
     int type; /* DATA / encrypted / envelpoed */
@@ -84,12 +83,12 @@ typedef struct MacData {
 } MacData;
 
 
-typedef struct WC_PKCS12 {
+struct WC_PKCS12 {
     void* heap;
     AuthenticatedSafe* safe;
     MacData* signData;
     word32 oid; /* DATA / Enveloped DATA ... */
-} WC_PKCS12;
+};
 
 
 /* for friendlyName, localKeyId .... */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2486,7 +2486,7 @@ typedef struct Arrays {
 #define MAX_DATE_SZ 32
 #endif
 
-typedef struct WOLFSSL_STACK {
+struct WOLFSSL_STACK {
     unsigned long num; /* number of nodes in stack
                         * (saftey measure for freeing and shortcut for count) */
     union {
@@ -2494,7 +2494,7 @@ typedef struct WOLFSSL_STACK {
         WOLFSSL_BIO*  bio;
     } data;
     WOLFSSL_STACK* next;
-} WOLFSSL_STACK;
+};
 
 
 struct WOLFSSL_X509_NAME {

--- a/wolfssl/wolfcrypt/pkcs12.h
+++ b/wolfssl/wolfcrypt/pkcs12.h
@@ -29,12 +29,14 @@
     extern "C" {
 #endif
 
-typedef struct WC_PKCS12 WC_PKCS12;
-typedef struct WC_DerCertList WC_DerCertList;
+#ifndef WOLFSSL_TYPES_DEFINED /* do not redeclare from ssl.h */
+    typedef struct WC_PKCS12 WC_PKCS12;
+#endif
+
 typedef struct WC_DerCertList { /* dereferenced in ssl.c */
     byte* buffer;
     word32 bufferSz;
-    WC_DerCertList* next;
+    struct WC_DerCertList* next;
 } WC_DerCertList;
 
 


### PR DESCRIPTION
Older versions of clang (specifically 6.0) gives warning about redeclaration.
Thanks Chris for bringing this up.