### PR TITLE
Fix for "wc_ecc_make_key_ex" if call to rng fails

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2505,23 +2505,27 @@ int wc_ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key, int curve_id)
 
     /* make up random string */
     err = wc_RNG_GenerateBlock(rng, buf, keysize);
+    if (err != 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    #endif
+        return err;
+    }
 
     /* setup the key variables */
-    if (err == 0) {
-        err = mp_init_multi(&key->k, &prime, &order, &a, NULL, NULL);
-        if (err == MP_OKAY) {
-        #ifndef ALT_ECC_SIZE
-            err = mp_init_multi(key->pubkey.x, key->pubkey.y, key->pubkey.z,
-                                                            NULL, NULL, NULL);
-        #else
-            key->pubkey.x = (mp_int*)&key->pubkey.xyz[0];
-            key->pubkey.y = (mp_int*)&key->pubkey.xyz[1];
-            key->pubkey.z = (mp_int*)&key->pubkey.xyz[2];
-            alt_fp_init(key->pubkey.x);
-            alt_fp_init(key->pubkey.y);
-            alt_fp_init(key->pubkey.z);
-        #endif
-        }
+    err = mp_init_multi(&key->k, &prime, &order, &a, NULL, NULL);
+    if (err == MP_OKAY) {
+    #ifndef ALT_ECC_SIZE
+        err = mp_init_multi(key->pubkey.x, key->pubkey.y, key->pubkey.z,
+                                                        NULL, NULL, NULL);
+    #else
+        key->pubkey.x = (mp_int*)&key->pubkey.xyz[0];
+        key->pubkey.y = (mp_int*)&key->pubkey.xyz[1];
+        key->pubkey.z = (mp_int*)&key->pubkey.xyz[2];
+        alt_fp_init(key->pubkey.x);
+        alt_fp_init(key->pubkey.y);
+        alt_fp_init(key->pubkey.z);
+    #endif
     }
 
     if (err == MP_OKAY) {

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -100,6 +100,13 @@ int mp_init_multi(mp_int* a, mp_int* b, mp_int* c, mp_int* d, mp_int* e,
 {
     int res = MP_OKAY;
 
+    if (a) XMEMSET(a, 0, sizeof(mp_int));
+    if (b) XMEMSET(b, 0, sizeof(mp_int));
+    if (c) XMEMSET(c, 0, sizeof(mp_int));
+    if (d) XMEMSET(d, 0, sizeof(mp_int));
+    if (e) XMEMSET(e, 0, sizeof(mp_int));
+    if (f) XMEMSET(f, 0, sizeof(mp_int));
+
     if (a && ((res = mp_init(a)) != MP_OKAY))
         return res;
 
@@ -454,7 +461,7 @@ void mp_zero (mp_int * a)
 {
   int       n;
   mp_digit *tmp;
-  
+
   if (a == NULL)
       return;
 
@@ -4418,7 +4425,7 @@ int mp_rand_prime(mp_int* N, int len, WC_RNG* rng, void* heap)
 
     XMEMSET(buf, 0, len);
     XFREE(buf, heap, DYNAMIC_TYPE_RSA);
-    
+
     return MP_OKAY;
 }
 


### PR DESCRIPTION
 Issue only applies to !USE_FAST_MATH case on failure response from call to "wc_RNG_GenerateBlock". Came up in forum post: https://www.wolfssl.com/forums/topic884-meet-segmentation-fault-when-using-wceccmakekeyex.html