### PR TITLE
add server side empty renegotiation_info support

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -17827,12 +17827,12 @@ int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     {
         int i;
 
-        if (suites == NULL) {
-            WOLFSSL_MSG("Suites pointer error");
+        if (suites == NULL || suites->suiteSz == 0) {
+            WOLFSSL_MSG("Suites pointer error or suiteSz 0");
             return SUITES_ERROR;
         }
 
-        for (i = 0; i < suites->suiteSz; i += 2) {
+        for (i = 0; i < suites->suiteSz-1; i += SUITE_LEN) {
             if (suites->suites[i]   == first &&
                 suites->suites[i+1] == second )
                 return i;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1694,7 +1694,8 @@ WOLFSSL_LOCAL int    TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length,
    || defined(HAVE_ALPN)                          \
    || defined(HAVE_QSH)                           \
    || defined(HAVE_SESSION_TICKET)                \
-   || defined(HAVE_SECURE_RENEGOTIATION)
+   || defined(HAVE_SECURE_RENEGOTIATION)          \
+   || defined(HAVE_SERVER_RENEGOTIATION_INFO)
 
 #error Using TLS extensions requires HAVE_TLS_EXTENSIONS to be defined.
 
@@ -1823,7 +1824,8 @@ WOLFSSL_LOCAL int TLSX_ValidateEllipticCurves(WOLFSSL* ssl, byte first,
 #endif /* HAVE_SUPPORTED_CURVES */
 
 /** Renegotiation Indication - RFC 5746 */
-#ifdef HAVE_SECURE_RENEGOTIATION
+#if defined(HAVE_SECURE_RENEGOTIATION) \
+ || defined(HAVE_SERVER_RENEGOTIATION_INFO)
 
 enum key_cache_state {
     SCR_CACHE_NULL   = 0,       /* empty / begin state */
@@ -1845,6 +1847,10 @@ typedef struct SecureRenegotiation {
 } SecureRenegotiation;
 
 WOLFSSL_LOCAL int TLSX_UseSecureRenegotiation(TLSX** extensions, void* heap);
+
+#ifdef HAVE_SERVER_RENEGOTIATION_INFO
+WOLFSSL_LOCAL int TLSX_AddEmptyRenegotiationInfo(TLSX** extensions, void* heap);
+#endif
 
 #endif /* HAVE_SECURE_RENEGOTIATION */
 
@@ -2814,7 +2820,8 @@ struct WOLFSSL {
     #ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
         byte status_request_v2;
     #endif
-    #ifdef HAVE_SECURE_RENEGOTIATION
+    #if defined(HAVE_SECURE_RENEGOTIATION) \
+        || defined(HAVE_SERVER_RENEGOTIATION_INFO)
         SecureRenegotiation* secure_renegotiation; /* valid pointer indicates */
     #endif                                         /* user turned on */
     #ifdef HAVE_ALPN


### PR DESCRIPTION
This PR enables a wolfSSL server to send an empty renegotiation_info extension in response to a client probing for secure renegotiation support as per RFC 5746.

When enabled, the server will respond with an empty "renegotiation_info" extension in the ServerHello message when a ClientHello is received that includes either the presence of the TLS_EMPTY_RENEGOTIATION_INFO_SCSV cipher suite, or an empty renegotiation_info TLS extension.

To enable, define **HAVE_SERVER_RENEGOTIATION_INFO** and TLS extensions (HAVE_TLS_EXTENSIONS, or "--enable-tlsx"):

```
$ cd wolfssl
$ ./configure --enable-tlsx CFLAGS="-DHAVE_SERVER_RENEGOTIATION_INFO"
$ make
```