### PR TITLE
fix wc_PKCS7_EncodeSignedData with no signed attributes

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -503,8 +503,12 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
             }
             wc_ShaUpdate(&esd->sha, attribSet, attribSetSz);
             wc_ShaUpdate(&esd->sha, flatSignedAttribs, flatSignedAttribsSz);
+            wc_ShaFinal(&esd->sha, esd->contentAttribsDigest);
+        } else {
+            /* when no attrs, digest is contentDigest without tag and length */
+            XMEMCPY(esd->contentAttribsDigest, esd->contentDigest + 2,
+                    SHA_DIGEST_SIZE);
         }
-        wc_ShaFinal(&esd->sha, esd->contentAttribsDigest);
 
         digestStrSz = SetOctetString(SHA_DIGEST_SIZE, digestStr);
         digestInfoSeqSz = SetSequence(esd->signerDigAlgoIdSz +


### PR DESCRIPTION
This PR fixes a bug in wc_PKCS7_EncodeSignedData() for cases with empty or no signed attributes.  The message digest in these cases was being incorrectly calculated.

As per RFC 5652, Section 5.4 (Message Digest Calculation Process):

```
5.4.  Message Digest Calculation Process
...
   Specifically, the initial input is the
   encapContentInfo eContent OCTET STRING to which the signing process
   is applied.  Only the octets comprising the value of the eContent
   OCTET STRING are input to the message digest algorithm, not the tag
   or the length octets.
...
   The result of the message digest calculation process depends on
   whether the signedAttrs field is present.  When the field is absent,
   the result is just the message digest of the content as described
   above.
```

This PR is associated with Zendesk ticket 2434.