### PR TITLE
Add the peer cert buffer and count to X509_STORE_CTX for verify callback

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6861,6 +6861,7 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         return MEMORY_E;
     }
 #endif
+    XMEMSET(store, 0, sizeof(WOLFSSL_X509_STORE_CTX));
 
     if (anyError != 0 && ret == 0)
         ret = anyError;
@@ -6879,6 +6880,8 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 store->discardSessionCerts = 0;
                 store->domain = domain;
                 store->userCtx = ssl->verifyCbCtx;
+                store->certs = certs;
+                store->totalCerts = totalCerts;
 #ifdef KEEP_PEER_CERT
                 store->current_cert = &ssl->peerCert;
 #else
@@ -6916,6 +6919,8 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             store->discardSessionCerts = 0;
             store->domain = domain;
             store->userCtx = ssl->verifyCbCtx;
+            store->certs = certs;
+            store->totalCerts = totalCerts;
 #ifdef KEEP_PEER_CERT
             store->current_cert = &ssl->peerCert;
 #endif

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1280,11 +1280,8 @@ WOLFSSL_LOCAL int DoFinished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 WOLFSSL_LOCAL int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx);
 
 
-/* wolfSSL buffer type */
-typedef struct buffer {
-    byte*  buffer;
-    word32 length;
-} buffer;
+/* wolfSSL buffer type - internal uses "buffer" type */
+typedef WOLFSSL_BUFFER_INFO buffer;
 
 #ifndef NO_CERTS
     /* wolfSSL DER buffer */

--- a/wolfssl/ocsp.h
+++ b/wolfssl/ocsp.h
@@ -35,16 +35,15 @@
     extern "C" {
 #endif
 
-struct buffer;
 typedef struct WOLFSSL_OCSP WOLFSSL_OCSP;
 
 WOLFSSL_LOCAL int  InitOCSP(WOLFSSL_OCSP*, WOLFSSL_CERT_MANAGER*);
 WOLFSSL_LOCAL void FreeOCSP(WOLFSSL_OCSP*, int dynamic);
 
 WOLFSSL_LOCAL int  CheckCertOCSP(WOLFSSL_OCSP*, DecodedCert*,
-                                            struct buffer* responseBuffer);
+                                            WOLFSSL_BUFFER_INFO* responseBuffer);
 WOLFSSL_LOCAL int  CheckOcspRequest(WOLFSSL_OCSP* ocsp,
-                   OcspRequest* ocspRequest, struct buffer* responseBuffer);
+                   OcspRequest* ocspRequest, WOLFSSL_BUFFER_INFO* responseBuffer);
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -175,6 +175,8 @@ typedef struct WOLFSSL_X509_STORE_CTX {
     int   error;                 /* current error */
     int   error_depth;           /* cert depth for this error */
     int   discardSessionCerts;   /* so verify callback can flag for discard */
+    int   totalCerts;            /* number of peer cert buffers */
+    struct buffer* certs;        /* peer certs */
 } WOLFSSL_X509_STORE_CTX;
 
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -166,6 +166,11 @@ typedef struct WOLFSSL_X509_OBJECT {
     } data;
 } WOLFSSL_X509_OBJECT;
 
+typedef struct WOLFSSL_BUFFER_INFO {
+    unsigned char* buffer;
+    unsigned int length;
+} WOLFSSL_BUFFER_INFO;
+
 typedef struct WOLFSSL_X509_STORE_CTX {
     WOLFSSL_X509_STORE* store;    /* Store full of a CA cert chain */
     WOLFSSL_X509* current_cert;   /* stunnel dereference */
@@ -176,7 +181,7 @@ typedef struct WOLFSSL_X509_STORE_CTX {
     int   error_depth;           /* cert depth for this error */
     int   discardSessionCerts;   /* so verify callback can flag for discard */
     int   totalCerts;            /* number of peer cert buffers */
-    struct buffer* certs;        /* peer certs */
+    WOLFSSL_BUFFER_INFO* certs;  /* peer certs */
 } WOLFSSL_X509_STORE_CTX;
 
 

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -371,7 +371,7 @@ static INLINE WC_NORETURN void err_sys(const char* msg)
      * msg pointer can be null even when hardcoded and then it won't exit,
      * making null pointer checks above the err_sys() call useless.
      * We could just always exit() but some compilers will complain about no
-     * possible return, with gcc we know the attribute to handle that with 
+     * possible return, with gcc we know the attribute to handle that with
      * WC_NORETURN. */
     if (msg)
 #endif
@@ -1143,17 +1143,20 @@ static INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
                                        wolfSSL_X509_get_issuer_name(peer), 0, 0);
         char* subject = wolfSSL_X509_NAME_oneline(
                                       wolfSSL_X509_get_subject_name(peer), 0, 0);
-        printf("peer's cert info:\n issuer : %s\n subject: %s\n", issuer,
+        printf("\tPeer's cert info:\n issuer : %s\n subject: %s\n", issuer,
                                                                   subject);
         XFREE(subject, 0, DYNAMIC_TYPE_OPENSSL);
         XFREE(issuer,  0, DYNAMIC_TYPE_OPENSSL);
     }
     else
-        printf("peer has no cert!\n");
+        printf("\tPeer has no cert!\n");
+#else
+    printf("\tPeer certs: %d\n", store->totalCerts);
 #endif
-    printf("Subject's domain name is %s\n", store->domain);
 
-    printf("Allowing to continue anyway (shouldn't do this, EVER!!!)\n");
+    printf("\tSubject's domain name is %s\n", store->domain);
+
+    printf("\tAllowing to continue anyway (shouldn't do this, EVER!!!)\n");
     return 1;
 }
 
@@ -1267,7 +1270,7 @@ static INLINE void CaCb(unsigned char* der, int sz, int type)
 
     static INLINE int ChangeToWolfRoot(void)
     {
-        #if !defined(NO_FILESYSTEM) 
+        #if !defined(NO_FILESYSTEM)
             int depth, res;
             XFILE file;
             for(depth = 0; depth <= MAX_WOLF_ROOT_DEPTH; depth++) {
@@ -1286,7 +1289,7 @@ static INLINE void CaCb(unsigned char* der, int sz, int type)
                     break;
                 }
             }
-        
+
             err_sys("wolf root not found");
             return -1;
         #else

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1152,6 +1152,14 @@ static INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
         printf("\tPeer has no cert!\n");
 #else
     printf("\tPeer certs: %d\n", store->totalCerts);
+    #ifdef VERIFY_CALLBACK_SHOW_PEER_CERTS
+    {   int i;
+        for (i=0; i<store->totalCerts; i++) {
+            WOLFSSL_BUFFER_INFO* cert = &store->certs[i];
+            printf("\t\tCert %d: Ptr %p, Len %u\n", i, cert->buffer, cert->length);
+        }
+    }
+    #endif
 #endif
 
     printf("\tSubject's domain name is %s\n", store->domain);


### PR DESCRIPTION
Add the peer cert buffer and count to the X509_STORE_CTX used for the verify callback. Fixes #627.