### PR TITLE
Get the hash of the handshake messages rather than finalize.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10023,13 +10023,6 @@ static void BuildSHA_CertVerify(WOLFSSL* ssl, byte* digest)
 static int BuildCertHashes(WOLFSSL* ssl, Hashes* hashes)
 {
     int ret = 0;
-    /* store current states, building requires get_digest which resets state */
-    #ifdef WOLFSSL_SHA384
-        Sha384 sha384 = ssl->hsHashes->hashSha384;
-    #endif
-    #ifdef WOLFSSL_SHA512
-        Sha512 sha512 = ssl->hsHashes->hashSha512;
-    #endif
 
     (void)hashes;
 
@@ -10064,17 +10057,7 @@ static int BuildCertHashes(WOLFSSL* ssl, Hashes* hashes)
         BuildMD5_CertVerify(ssl, hashes->md5);
         BuildSHA_CertVerify(ssl, hashes->sha);
     }
-
-    /* restore */
 #endif
-    if (IsAtLeastTLSv1_2(ssl)) {
-        #ifdef WOLFSSL_SHA384
-            ssl->hsHashes->hashSha384 = sha384;
-        #endif
-        #ifdef WOLFSSL_SHA512
-            ssl->hsHashes->hashSha512 = sha512;
-        #endif
-    }
 
     return ret;
 }

--- a/src/internal.c
+++ b/src/internal.c
@@ -10040,17 +10040,20 @@ static int BuildCertHashes(WOLFSSL* ssl, Hashes* hashes)
 #endif
         if (IsAtLeastTLSv1_2(ssl)) {
             #ifndef NO_SHA256
-                ret = wc_Sha256GetHash(&ssl->hsHashes->hashSha256,hashes->sha256);
+                ret = wc_Sha256GetHash(&ssl->hsHashes->hashSha256,
+                                       hashes->sha256);
                 if (ret != 0)
                     return ret;
             #endif
             #ifdef WOLFSSL_SHA384
-                ret = wc_Sha384Final(&ssl->hsHashes->hashSha384,hashes->sha384);
+                ret = wc_Sha384GetHash(&ssl->hsHashes->hashSha384,
+                                       hashes->sha384);
                 if (ret != 0)
                     return ret;
             #endif
             #ifdef WOLFSSL_SHA512
-                ret = wc_Sha512Final(&ssl->hsHashes->hashSha512,hashes->sha512);
+                ret = wc_Sha512GetHash(&ssl->hsHashes->hashSha512,
+                                       hashes->sha512);
                 if (ret != 0)
                     return ret;
             #endif


### PR DESCRIPTION
Inconsistency between SHA256 and SHA384/SHA512 when getting hash.
More handshake messages can be added after this operation.