### PR TITLE
Prevent forcezero from running on freed memory

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -1197,6 +1197,7 @@ static int LoadKeyFile(byte** keyBuf, word32* keyBufSz,
             if (saveBufSz < 0) {
                 saveBufSz = 0;
                 free(saveBuf);
+                saveBuf = NULL;
             }
             else
                 ret = 0;
@@ -1205,8 +1206,10 @@ static int LoadKeyFile(byte** keyBuf, word32* keyBufSz,
         ForceZero(loadBuf, (word32)fileSz);
         free(loadBuf);
 
-        *keyBuf = saveBuf;
-        *keyBufSz = (word32)saveBufSz;
+        if (saveBuf) {
+            *keyBuf = saveBuf;
+            *keyBufSz = (word32)saveBufSz;
+        }
     }
     else {
         *keyBuf = loadBuf;


### PR DESCRIPTION
Cleanup pre-release

The ForceZero call that runs on the freed memory is on line 437 of sniffer.c

This is a suggested fix if we do not wish to treat the conversion from pem to der ```wolfSSL_KeyPemToDer ``` as a hard error.

The other option would be to return an error on line 1200 of sniffer.c

