### PR TITLE
PKCS#7/CMS expansion

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,18 @@ CLEANFILES+= cert.der \
              othercert.der \
              othercert.pem \
              pkcs7cert.der \
+             pkcs7encryptedDataAES128CBC.der \
+             pkcs7encryptedDataAES192CBC.der \
+             pkcs7encryptedDataAES256CBC_attribs.der \
+             pkcs7encryptedDataAES256CBC.der \
+             pkcs7encryptedDataAES256CBC_multi_attribs.der \
+             pkcs7encryptedDataDES3.der \
+             pkcs7encryptedDataDES.der \
+             pkcs7envelopedDataAES256CBC_ECDH.der \
+             pkcs7envelopedDataAES128CBC_ECDH_SHA1KDF.der \
+             pkcs7envelopedDataAES256CBC_ECDH_SHA256KDF.der \
+             pkcs7envelopedDataAES256CBC_ECDH_SHA512KDF.der \
+             pkcs7envelopedDataAES256CBC_ECDH_SHA512KDF_ukm.der \
              pkcs7envelopedDataDES3.der \
              pkcs7envelopedDataAES128CBC.der \
              pkcs7envelopedDataAES192CBC.der \

--- a/configure.ac
+++ b/configure.ac
@@ -3011,6 +3011,16 @@ if test "x$ENABLED_PKCS7" = "xyes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_PKCS7"
     # Enable prereqs if not already enabled
+    if test "x$ENABLED_AESKEYWRAP" = "xno"
+    then
+        ENABLED_AESKEYWRAP="yes"
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_AES_KEYWRAP -DWOLFSSL_AES_DIRECT"
+    fi
+    if test "x$ENABLED_X963KDF" = "xno"
+    then
+        ENABLED_X963KDF="yes"
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_X963_KDF"
+    fi
     AS_IF([test "x$ENABLED_DES3" = "xno"],
           [ENABLED_DES3=yes])
 fi

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -802,6 +802,19 @@ static const byte blkAes256CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 42};
 static const byte blkDesCbcOid[]  = {43, 14, 3, 2, 7};
 static const byte blkDes3CbcOid[] = {42, 134, 72, 134, 247, 13, 3, 7};
 
+/* keyWrapType */
+static const byte wrapAes128Oid[] = {96, 134, 72, 1, 101, 3, 4, 1, 5};
+static const byte wrapAes192Oid[] = {96, 134, 72, 1, 101, 3, 4, 1, 25};
+static const byte wrapAes256Oid[] = {96, 134, 72, 1, 101, 3, 4, 1, 45};
+
+/* cmsKeyAgreeType */
+static const byte dhSinglePass_stdDH_sha1kdf_Oid[]   =
+                                          {43, 129, 5, 16, 134, 72, 63, 0, 2};
+static const byte dhSinglePass_stdDH_sha224kdf_Oid[] = {43, 129, 4, 1, 11, 0};
+static const byte dhSinglePass_stdDH_sha256kdf_Oid[] = {43, 129, 4, 1, 11, 1};
+static const byte dhSinglePass_stdDH_sha384kdf_Oid[] = {43, 129, 4, 1, 11, 2};
+static const byte dhSinglePass_stdDH_sha512kdf_Oid[] = {43, 129, 4, 1, 11, 3};
+
 /* ocspType */
 #ifdef HAVE_OCSP
     static const byte ocspBasicOid[] = {43, 6, 1, 5, 5, 7, 48, 1, 1};
@@ -1124,12 +1137,55 @@ static const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                     *oidSz = sizeof(extExtKeyUsageOcspSignOid);
                     break;
             }
+            break;
 
         case oidKdfType:
             switch (id) {
                 case PBKDF2_OID:
                     oid = pbkdf2Oid;
                     *oidSz = sizeof(pbkdf2Oid);
+                    break;
+            }
+            break;
+
+        case oidKeyWrapType:
+            switch (id) {
+                case AES128_WRAP:
+                    oid = wrapAes128Oid;
+                    *oidSz = sizeof(wrapAes128Oid);
+                    break;
+                case AES192_WRAP:
+                    oid = wrapAes192Oid;
+                    *oidSz = sizeof(wrapAes192Oid);
+                    break;
+                case AES256_WRAP:
+                    oid = wrapAes256Oid;
+                    *oidSz = sizeof(wrapAes256Oid);
+                    break;
+            }
+            break;
+
+        case oidCmsKeyAgreeType:
+            switch (id) {
+                case dhSinglePass_stdDH_sha1kdf_scheme:
+                    oid = dhSinglePass_stdDH_sha1kdf_Oid;
+                    *oidSz = sizeof(dhSinglePass_stdDH_sha1kdf_Oid);
+                    break;
+                case dhSinglePass_stdDH_sha224kdf_scheme:
+                    oid = dhSinglePass_stdDH_sha224kdf_Oid;
+                    *oidSz = sizeof(dhSinglePass_stdDH_sha224kdf_Oid);
+                    break;
+                case dhSinglePass_stdDH_sha256kdf_scheme:
+                    oid = dhSinglePass_stdDH_sha256kdf_Oid;
+                    *oidSz = sizeof(dhSinglePass_stdDH_sha256kdf_Oid);
+                    break;
+                case dhSinglePass_stdDH_sha384kdf_scheme:
+                    oid = dhSinglePass_stdDH_sha384kdf_Oid;
+                    *oidSz = sizeof(dhSinglePass_stdDH_sha384kdf_Oid);
+                    break;
+                case dhSinglePass_stdDH_sha512kdf_scheme:
+                    oid = dhSinglePass_stdDH_sha512kdf_Oid;
+                    *oidSz = sizeof(dhSinglePass_stdDH_sha512kdf_Oid);
                     break;
             }
             break;

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -2600,19 +2600,23 @@ static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     }
     wc_FreeRsaKey(privKey);
 
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(encryptedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(privKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-#endif
-
     if (keySz <= 0 || outKey == NULL) {
         ForceZero(encryptedKey, MAX_ENCRYPTED_KEY_SZ);
+#ifdef WOLFSSL_SMALL_STACK
+        XFREE(encryptedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(privKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
         return keySz;
     } else {
         *decryptedKeySz = keySz;
         XMEMCPY(decryptedKey, outKey, keySz);
         ForceZero(encryptedKey, MAX_ENCRYPTED_KEY_SZ);
     }
+
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(encryptedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(privKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
 
     return 0;
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9052,6 +9052,15 @@ int compress_test(void)
 
 #ifdef HAVE_PKCS7
 
+/* External Debugging/Testing Note:
+ *
+ * PKCS#7 test functions can output generated PKCS#7/CMS bundles for
+ * additional testing. To dump bundles to files DER encoded files, please
+ * define:
+ *
+ * #define PKCS7_OUTPUT_TEST_BUNDLES
+ */
+
 typedef struct {
     const byte*  content;
     word32       contentSz;
@@ -9080,7 +9089,9 @@ static int pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
     byte   enveloped[2048];
     byte   decoded[2048];
     PKCS7  pkcs7;
+#ifdef PKCS7_OUTPUT_TEST_BUNDLES
     FILE*  pkcs7File;
+#endif
 
     const byte data[] = { /* Hello World */
         0x48,0x65,0x6c,0x6c,0x6f,0x20,0x57,0x6f,
@@ -9179,6 +9190,7 @@ static int pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
         if (XMEMCMP(decoded, data, sizeof(data)) != 0)
             return -212;
 
+#ifdef PKCS7_OUTPUT_TEST_BUNDLES
         /* output pkcs7 envelopedData for external testing */
         pkcs7File = fopen(testVectors[i].outFileName, "wb");
         if (!pkcs7File)
@@ -9186,6 +9198,7 @@ static int pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
 
         ret = (int)fwrite(enveloped, envelopedSz, 1, pkcs7File);
         fclose(pkcs7File);
+#endif /* PKCS7_OUTPUT_TEST_BUNDLES */
 
         wc_PKCS7_Free(&pkcs7);
     }
@@ -9294,10 +9307,10 @@ int pkcs7enveloped_test(void)
     fclose(keyFile);
 #endif /* HAVE_ECC */
 
-    ret = pkcs7enveloped_run_vectors(rsaCert, rsaCertSz,
-                                     rsaPrivKey, rsaPrivKeySz,
-                                     eccCert, eccCertSz,
-                                     eccPrivKey, eccPrivKeySz);
+    ret = pkcs7enveloped_run_vectors(rsaCert, (word32)rsaCertSz,
+                                     rsaPrivKey, (word32)rsaPrivKeySz,
+                                     eccCert, (word32)eccCertSz,
+                                     eccPrivKey, (word32)eccPrivKeySz);
     if (ret != 0) {
         XFREE(rsaCert,    HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         XFREE(rsaPrivKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -9330,12 +9343,15 @@ typedef struct {
 
 int pkcs7encrypted_test(void)
 {
-    int ret, i, testSz;
+    int ret = 0;
+    int i, testSz;
     int encryptedSz, decodedSz, attribIdx;
     PKCS7 pkcs7;
     byte  encrypted[2048];
     byte  decoded[2048];
+#ifdef PKCS7_OUTPUT_TEST_BUNDLES
     FILE* pkcs7File;
+#endif
 
     PKCS7Attrib* expectedAttrib;
     PKCS7DecodedAttrib* decodedAttrib;
@@ -9488,6 +9504,7 @@ int pkcs7encrypted_test(void)
             }
         }
 
+#ifdef PKCS7_OUTPUT_TEST_BUNDLES
         /* output pkcs7 envelopedData for external testing */
         pkcs7File = fopen(testVectors[i].outFileName, "wb");
         if (!pkcs7File)
@@ -9495,6 +9512,7 @@ int pkcs7encrypted_test(void)
 
         ret = (int)fwrite(encrypted, encryptedSz, 1, pkcs7File);
         fclose(pkcs7File);
+#endif
 
         wc_PKCS7_Free(&pkcs7);
     }
@@ -9646,6 +9664,7 @@ int pkcs7signed_test(void)
     else
         outSz = ret;
 
+#ifdef PKCS7_OUTPUT_TEST_BUNDLES
     /* write PKCS#7 to output file for more testing */
     file = fopen("./pkcs7signedData.der", "wb");
     if (!file) {
@@ -9664,6 +9683,7 @@ int pkcs7signed_test(void)
         wc_PKCS7_Free(&msg);
         return -218;
     }
+#endif /* PKCS7_OUTPUT_TEST_BUNDLES */
 
     wc_PKCS7_Free(&msg);
     wc_PKCS7_InitWithCert(&msg, NULL, 0);
@@ -9685,6 +9705,7 @@ int pkcs7signed_test(void)
         return -215;
     }
 
+#ifdef PKCS7_OUTPUT_TEST_BUNDLES
     file = fopen("./pkcs7cert.der", "wb");
     if (!file) {
         XFREE(certDer, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -9695,6 +9716,7 @@ int pkcs7signed_test(void)
     }
     ret = (int)fwrite(msg.singleCert, 1, msg.singleCertSz, file);
     fclose(file);
+#endif /* PKCS7_OUTPUT_TEST_BUNDLES */
 
     XFREE(certDer, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(keyDer, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -213,6 +213,8 @@ enum Oid_Types {
     oidCertAltNameType  = 9,
     oidCertKeyUseType   = 10,
     oidKdfType          = 11,
+    oidKeyWrapType      = 12,
+    oidCmsKeyAgreeType  = 13,
     oidIgnoreType
 };
 
@@ -242,6 +244,22 @@ enum Key_Sum {
     RSAk   = 645,
     NTRUk  = 274,
     ECDSAk = 518
+};
+
+
+enum KeyWrap_Sum {
+    AES128_WRAP = 417,
+    AES192_WRAP = 437,
+    AES256_WRAP = 457
+};
+
+
+enum Key_Agree {
+    dhSinglePass_stdDH_sha1kdf_scheme   = 464,
+    dhSinglePass_stdDH_sha224kdf_scheme = 188,
+    dhSinglePass_stdDH_sha256kdf_scheme = 189,
+    dhSinglePass_stdDH_sha384kdf_scheme = 190,
+    dhSinglePass_stdDH_sha512kdf_scheme = 191,
 };
 
 

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -127,6 +127,13 @@ WOLFSSL_LOCAL int wc_PKCS7_EncryptContent(int encryptOID, byte* key, int keySz,
 WOLFSSL_LOCAL int wc_PKCS7_DecryptContent(int encryptOID, byte* key, int keySz,
                                      byte* iv, int ivSz, byte* in, int inSz,
                                      byte* out);
+WOLFSSL_LOCAL int wc_PKCS7_GenerateIV(WC_RNG* rng, byte* iv, word32 ivSz);
+WOLFSSL_LOCAL int wc_PKCS7_GetPadSize(word32 inputSz, word32 blockSz);
+WOLFSSL_LOCAL int wc_PKCS7_PadData(byte* in, word32 inSz, byte* out, word32 outSz,
+                                     word32 blockSz);
+WOLFSSL_LOCAL int wc_PKCS7_GetOIDBlockSize(int oid);
+WOLFSSL_LOCAL int wc_PKCS7_GetOIDKeySize(int oid);
+
 
 WOLFSSL_API int  wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* cert, word32 certSz);
 WOLFSSL_API void wc_PKCS7_Free(PKCS7* pkcs7);

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -103,6 +103,12 @@ typedef struct PKCS7 {
 
     PKCS7Attrib* signedAttribs;
     word32 signedAttribsSz;
+
+    /* Encrypted-data Content Type */
+    byte* encryptionKey;                /* block cipher encryption key */
+    word32 encryptionKeySz;             /* size of key buffer, bytes */
+    PKCS7Attrib* unprotectedAttribs;    /* optional */
+    word32 unprotectedAttribsSz;
 } PKCS7;
 
 
@@ -124,7 +130,8 @@ WOLFSSL_LOCAL int wc_PKCS7_DecryptContent(int encryptOID, byte* key, int keySz,
 
 WOLFSSL_API int  wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* cert, word32 certSz);
 WOLFSSL_API void wc_PKCS7_Free(PKCS7* pkcs7);
-WOLFSSL_API int  wc_PKCS7_EncodeData(PKCS7* pkcs7, byte* output, word32 outputSz);
+WOLFSSL_API int  wc_PKCS7_EncodeData(PKCS7* pkcs7, byte* output,
+                                       word32 outputSz);
 WOLFSSL_API int  wc_PKCS7_EncodeSignedData(PKCS7* pkcs7,
                                        byte* output, word32 outputSz);
 WOLFSSL_API int  wc_PKCS7_VerifySignedData(PKCS7* pkcs7,
@@ -134,7 +141,11 @@ WOLFSSL_API int  wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7,
 WOLFSSL_API int  wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
                                           word32 pkiMsgSz, byte* output,
                                           word32 outputSz);
-
+WOLFSSL_API int  wc_PKCS7_EncodeEncryptedData(PKCS7* pkcs7,
+                                          byte* output, word32 outputSz);
+WOLFSSL_API int  wc_PKCS7_DecodeEncryptedData(PKCS7* pkcs7, byte* pkiMsg,
+                                          word32 pkiMsgSz, byte* output,
+                                          word32 outputSz);
 #ifdef __cplusplus
     } /* extern "C" */
 #endif

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -78,6 +78,15 @@ typedef struct PKCS7Attrib {
 } PKCS7Attrib;
 
 
+typedef struct PKCS7DecodedAttrib {
+    byte* oid;
+    word32 oidSz;
+    byte* value;
+    word32 valueSz;
+    struct PKCS7DecodedAttrib* next;
+} PKCS7DecodedAttrib;
+
+
 typedef struct PKCS7 {
     byte* content;                /* inner content, not owner             */
     word32 contentSz;             /* content size                         */
@@ -105,10 +114,11 @@ typedef struct PKCS7 {
     word32 signedAttribsSz;
 
     /* Encrypted-data Content Type */
-    byte* encryptionKey;                /* block cipher encryption key */
-    word32 encryptionKeySz;             /* size of key buffer, bytes */
+    byte*        encryptionKey;         /* block cipher encryption key */
+    word32       encryptionKeySz;       /* size of key buffer, bytes */
     PKCS7Attrib* unprotectedAttribs;    /* optional */
-    word32 unprotectedAttribsSz;
+    word32       unprotectedAttribsSz;
+    PKCS7DecodedAttrib* decodedAttrib;  /* linked list of decoded attribs */
 } PKCS7;
 
 
@@ -133,6 +143,11 @@ WOLFSSL_LOCAL int wc_PKCS7_PadData(byte* in, word32 inSz, byte* out, word32 outS
                                      word32 blockSz);
 WOLFSSL_LOCAL int wc_PKCS7_GetOIDBlockSize(int oid);
 WOLFSSL_LOCAL int wc_PKCS7_GetOIDKeySize(int oid);
+WOLFSSL_LOCAL int wc_PKCS7_DecodeUnprotectedAttributes(PKCS7* pkcs7,
+                                     byte* pkiMsg, word32 pkiMsgSz,
+                                     word32* inOutIdx);
+WOLFSSL_LOCAL void wc_PKCS7_FreeDecodedAttrib(PKCS7DecodedAttrib* attrib,
+                                     void* heap);
 
 
 WOLFSSL_API int  wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* cert, word32 certSz);

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -96,6 +96,8 @@ typedef struct PKCS7 {
 
     int hashOID;
     int encryptOID;               /* key encryption algorithm OID         */
+    int keyWrapOID;               /* key wrap algorithm OID               */
+    int keyAgreeOID;              /* key agreement algorithm OID          */
 
     void*  heap;                  /* heap hint for dynamic memory         */
     byte*  singleCert;            /* recipient cert, DER, not owner       */
@@ -105,13 +107,19 @@ typedef struct PKCS7 {
     word32 issuerSz;              /* length of issuer name                */
     byte issuerSn[MAX_SN_SZ];     /* singleCert's serial number           */
     word32 issuerSnSz;            /* length of serial number              */
+
     byte publicKey[512];
     word32 publicKeySz;
+    word32 publicKeyOID;          /* key OID (RSAk, ECDSAk, etc) */
     byte*  privateKey;            /* private key, DER, not owner          */
     word32 privateKeySz;          /* size of private key buffer, bytes    */
 
     PKCS7Attrib* signedAttribs;
     word32 signedAttribsSz;
+
+    /* Enveloped-data optional ukm, not owner */
+    byte*  ukm;
+    word32 ukmSz;
 
     /* Encrypted-data Content Type */
     byte*        encryptionKey;         /* block cipher encryption key */
@@ -120,34 +128,6 @@ typedef struct PKCS7 {
     word32       unprotectedAttribsSz;
     PKCS7DecodedAttrib* decodedAttrib;  /* linked list of decoded attribs */
 } PKCS7;
-
-
-WOLFSSL_LOCAL int wc_PKCS7_SetHeap(PKCS7* pkcs7, void* heap);
-WOLFSSL_LOCAL int wc_SetContentType(int pkcs7TypeOID, byte* output);
-WOLFSSL_LOCAL int wc_GetContentType(const byte* input, word32* inOutIdx,
-                                word32* oid, word32 maxIdx);
-WOLFSSL_LOCAL int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
-                                     int keyEncAlgo, int blockKeySz,
-                                     WC_RNG* rng, byte* contentKeyPlain,
-                                     byte* contentKeyEnc, int* keyEncSz,
-                                     byte* out, word32 outSz, void* heap);
-WOLFSSL_LOCAL int wc_PKCS7_EncryptContent(int encryptOID, byte* key, int keySz,
-                                     byte* iv, int ivSz, byte* in, int inSz,
-                                     byte* out);
-WOLFSSL_LOCAL int wc_PKCS7_DecryptContent(int encryptOID, byte* key, int keySz,
-                                     byte* iv, int ivSz, byte* in, int inSz,
-                                     byte* out);
-WOLFSSL_LOCAL int wc_PKCS7_GenerateIV(WC_RNG* rng, byte* iv, word32 ivSz);
-WOLFSSL_LOCAL int wc_PKCS7_GetPadSize(word32 inputSz, word32 blockSz);
-WOLFSSL_LOCAL int wc_PKCS7_PadData(byte* in, word32 inSz, byte* out, word32 outSz,
-                                     word32 blockSz);
-WOLFSSL_LOCAL int wc_PKCS7_GetOIDBlockSize(int oid);
-WOLFSSL_LOCAL int wc_PKCS7_GetOIDKeySize(int oid);
-WOLFSSL_LOCAL int wc_PKCS7_DecodeUnprotectedAttributes(PKCS7* pkcs7,
-                                     byte* pkiMsg, word32 pkiMsgSz,
-                                     word32* inOutIdx);
-WOLFSSL_LOCAL void wc_PKCS7_FreeDecodedAttrib(PKCS7DecodedAttrib* attrib,
-                                     void* heap);
 
 
 WOLFSSL_API int  wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* cert, word32 certSz);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1448,6 +1448,15 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #endif
 #endif
 
+#ifdef HAVE_PKCS7
+    #ifndef HAVE_AES_KEYWRAP
+        #error PKCS7 requires AES key wrap please define HAVE_AES_KEYWRAP
+    #endif
+    #ifndef HAVE_X963_KDF
+        #error PKCS7 requires X963 KDF please define HAVE_X963_KDF
+    #endif
+#endif
+
 
 /* Place any other flags or defines here */
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -338,7 +338,8 @@
         DYNAMIC_TYPE_DTLS_BUFFER  = 56,
         DYNAMIC_TYPE_SESSION_TICK = 57,
         DYNAMIC_TYPE_PKCS         = 58,
-        DYNAMIC_TYPE_MUTEX        = 59
+        DYNAMIC_TYPE_MUTEX        = 59,
+        DYNAMIC_TYPE_PKCS7        = 60
 	};
 
 	/* max error buffer string size */


### PR DESCRIPTION
This PR expands wolfCrypt's PKCS#7/CMS support including:

- EncryptedData content type (DES, 3DES, AES-128/192/256-CBC)
- EnvelopedData content type (RSA/ECC-DES/3DES/AES)
- Refactor of some PKCS#7 functions to reduce function length
- Addition of PKCS#7 tests for EncryptedData and EnvelopedData

This functionality was interop tested against OpenSSL 1.1.0c from both encode/decode sides.