### PR TITLE
add missing certs and keys to certs/include.am

### DIFF
--- a/certs/include.am
+++ b/certs/include.am
@@ -9,9 +9,11 @@ EXTRA_DIST += \
 	     certs/client-keyEnc.pem \
 	     certs/client-key.pem \
 	     certs/ecc-key.pem \
+	     certs/ecc-keyPkcs8Enc.pem \
 	     certs/ecc-key-comp.pem \
 	     certs/ecc-keyPkcs8.pem \
 	     certs/ecc-client-key.pem \
+	     certs/ecc-client-keyPub.pem \
 	     certs/client-ecc-cert.pem \
 	     certs/client-ca.pem \
 	     certs/ntru-cert.pem \
@@ -35,14 +37,20 @@ EXTRA_DIST += \
 	     certs/ca-cert.der \
 	     certs/client-cert.der \
 	     certs/client-key.der \
+	     certs/client-ecc-cert.der \
 	     certs/client-keyPub.der \
 	     certs/dh2048.der \
 	     certs/rsa2048.der \
 	     certs/dsa2048.der \
+	     certs/ecc-client-key.der \
+	     certs/ecc-client-keyPub.der \
 	     certs/ecc-key.der \
 	     certs/ecc-keyPub.der \
 	     certs/server-key.der \
 	     certs/server-cert.der \
+	     certs/server-ecc-comp.der \
+	     certs/server-ecc.der \
+	     certs/server-ecc-rsa.der \
          certs/server-cert-chain.der
 
 dist_doc_DATA+= certs/taoCert.txt


### PR DESCRIPTION
There were a few certs/keys that were missing from certs/include.am and not getting included in our distribution.  This PR fixes this issue.