### PR TITLE
fix CertificateRequest cert type for ECDSA ChaCha suites

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10611,7 +10611,8 @@ int SendCertificateRequest(WOLFSSL* ssl)
     /* write to output */
     output[i++] = (byte)typeTotal;  /* # of types */
 #ifdef HAVE_ECC
-    if (ssl->options.cipherSuite0 == ECC_BYTE &&
+    if ((ssl->options.cipherSuite0 == ECC_BYTE ||
+         ssl->options.cipherSuite0 == CHACHA_BYTE) &&
                      ssl->specs.sig_algo == ecc_dsa_sa_algo) {
         output[i++] = ecdsa_sign;
     } else


### PR DESCRIPTION
This PR fixes SendCertificateRequest() to add a cipher suite byte check for CHACHA_BYTE.

This fixes a bug where wolfSSL was incorrectly requesting an RSA certificate when using an ECDSA-CHACHA20 cipher suite.

Reference:
https://www.wolfssl.com/forums/topic896-problem-with-clientcertauth-using-wolfsslserver-using-chachapoly.html