### PR TITLE
Fail on redundant handshake message data

### DIFF
--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -151,6 +151,7 @@ enum wolfSSL_ErrorCodes {
     CTX_INIT_MUTEX_E             = -413,   /* initialize ctx mutex error */
     EXT_MASTER_SECRET_NEEDED_E   = -414,   /* need EMS enabled to resume */
     DTLS_POOL_SZ_E               = -415,   /* exceeded DTLS pool size */
+    DECODE_E                     = -416,   /* decode handshake message error */
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* begin negotiation parameter errors */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -200,6 +200,7 @@ enum AlertDescription {
     certificate_expired             =  45,
     certificate_unknown             =  46,
     illegal_parameter               =  47,
+    decode_error                    =  50,
     decrypt_error                   =  51,
     #ifdef WOLFSSL_MYSQL_COMPATIBLE
     /* catch name conflict for enum protocol with MYSQL build */


### PR DESCRIPTION
Skip data at the end of handshake messages that is included in the size but isn't message data.