### PR TITLE
New ECC curve cache feature to improve performance

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -447,8 +447,12 @@ int benchmark_test(void *args)
     #ifdef HAVE_ECC_ENCRYPT
         bench_eccEncrypt();
     #endif
+
     #if defined(FP_ECC)
         wc_ecc_fp_free();
+    #endif
+    #ifdef ECC_CACHE_CURVE
+        wc_ecc_curve_cache_free();
     #endif
 #endif
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -941,6 +941,10 @@ const ecc_set_type ecc_sets[] = {
     static oid_cache_t ecc_oid_cache[ECC_SET_COUNT];
 #endif
 
+#ifdef HAVE_COMP_KEY
+static int wc_ecc_export_x963_compressed(ecc_key*, byte* out, word32* outLen);
+#endif
+
 #ifdef ECC_CACHE_CURVE
     /* cache (mp_int) of the curve parameters */
     static ecc_curve_spec ecc_curve_spec_cache[ECC_SET_COUNT];
@@ -4310,6 +4314,7 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
     if (err == MP_OKAY && compressed == 1) {   /* build y */
         DECLARE_CURVE_SPECS
         mp_int t1, t2;
+        int did_init = 0;
 
         if (mp_init_multi(&t1, &t2, NULL, NULL, NULL, NULL) != MP_OKAY)
             err = MEMORY_E;
@@ -4356,9 +4361,10 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
 
         if (did_init) {
     #ifndef USE_FAST_MATH
-        mp_clear(&t2);
-        mp_clear(&t1);
+            mp_clear(&t2);
+            mp_clear(&t1);
     #endif
+        }
 
         wc_ecc_curve_free(curve);
     }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4364,6 +4364,9 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
         return ECC_BAD_ARG_E;
     }
 
+    XMEMSET(key, 0, sizeof(ecc_key));
+    key->state = ECC_STATE_NONE;
+
 #ifdef WOLFSSL_ATECC508A
     /* TODO: Implement equiv call to ATECC508A */
     err = BAD_COND_E;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -40,6 +40,7 @@ Possible ECC enable options:
  * ECC_SHAMIR:          Enables Shamir calc method              default: on
  * HAVE_COMP_KEY:       Enables compressed key                  default: off
  * WOLFSSL_VALIDATE_ECC_IMPORT: Validate ECC key on import      default: off
+ * WOLFSSL_VALIDATE_ECC_KEYGEN: Validate ECC key gen            default: off
  * WOLFSSL_CUSTOM_CURVES: Allow non-standard curves.            default: off
  *                        Includes the curve "a" variable in calculation
  * ECC_DUMP_OID:        Enables dump of OID encoding and sum    default: off

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3628,11 +3628,9 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 
        /* compute u1*mG + u2*mQ = mG */
        if (err == MP_OKAY)
-           err = wc_ecc_mulmod(&u1, mG, mG, &curve->Af, &curve->Bf,
-                                                            &curve->prime, 0);
+           err = wc_ecc_mulmod(&u1, mG, mG, &curve->Af, &curve->prime, 0);
        if (err == MP_OKAY)
-           err = wc_ecc_mulmod(&u2, mQ, mQ, &curve->Af, &curve->Bf,
-                                                            &curve->prime, 0);
+           err = wc_ecc_mulmod(&u2, mQ, mQ, &curve->Af, &curve->prime, 0);
 
        /* find the montgomery mp */
        if (err == MP_OKAY)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -668,6 +668,12 @@ int wolfcrypt_test(void* args)
         else
             printf( "ECC buffer test passed!\n");
     #endif
+    #if defined(FP_ECC)
+        wc_ecc_fp_free();
+    #endif
+    #ifdef ECC_CACHE_CURVE
+        wc_ecc_curve_cache_free();
+    #endif
 #endif
 
 #ifdef HAVE_CURVE25519

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -166,30 +166,6 @@ typedef struct ecc_set_type {
     int         cofactor;
 } ecc_set_type;
 
-typedef struct ecc_curve_spec {
-    const ecc_set_type* dp;
-
-    mp_int prime;
-    mp_int Af;
-    mp_int Bf;
-    mp_int order;
-    mp_int Gx;
-    mp_int Gy;
-
-    byte load_mask;
-} ecc_curve_spec;
-
-enum ecc_curve_load_mask {
-    ECC_CURVE_FIELD_NONE    = 0x00,
-    ECC_CURVE_FIELD_PRIME   = 0x01,
-    ECC_CURVE_FIELD_AF      = 0x02,
-    ECC_CURVE_FIELD_BF      = 0x04,
-    ECC_CURVE_FIELD_ORDER   = 0x08,
-    ECC_CURVE_FIELD_GX      = 0x10,
-    ECC_CURVE_FIELD_GY      = 0x20,
-    ECC_CURVE_FIELD_ALL     = 0xFF
-};
-
 
 #ifdef ALT_ECC_SIZE
 
@@ -499,6 +475,10 @@ int wc_ecc_decrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
 WOLFSSL_API int wc_X963_KDF(enum wc_HashType type, const byte* secret,
                 word32 secretSz, const byte* sinfo, word32 sinfoSz,
                 byte* out, word32 outSz);
+#endif
+
+#ifdef ECC_CACHE_CURVE
+WOLFSSL_API void wc_ecc_curve_cache_free(void);
 #endif
 
 #ifdef WOLFSSL_ASYNC_CRYPT

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -48,6 +48,14 @@
 #endif
 
 
+/* Enable curve B parameter if needed */
+#if defined(HAVE_COMP_KEY) || defined(ECC_CACHE_CURVE)
+    #ifndef USE_ECC_B_PARAM /* Allow someone to force enable */
+        #define USE_ECC_B_PARAM
+    #endif
+#endif
+
+
 /* Use this as the key->idx if a custom ecc_set is used for key->dp */
 #define ECC_CUSTOM_IDX    (-1)
 
@@ -278,6 +286,8 @@ int wc_ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key,
     int curve_id);
 WOLFSSL_API
 int wc_ecc_check_key(ecc_key* key);
+WOLFSSL_API
+int wc_ecc_is_point(ecc_point* ecp, mp_int* a, mp_int* b, mp_int* prime);
 
 #ifdef HAVE_ECC_DHE
 WOLFSSL_API


### PR DESCRIPTION
Disabled by default and enabled using ./configure CFALGS="-DECC_CACHE_CURVE" or #define ECC_CACHE_CURVE. Added internal ECC states. Combined wc_ecc_mulmod_ex versions for timing rest / not. Tested with all math, timing, FP variants and NXP LTC and ECC508A hardware. Pulled in from latest async branch. Added new ECC_MAX_SIG_SIZE enum to help with sizing the sign buffer.

Performance Increases with ECC_CACHE_CURVE enabled:
* Key Gen 4.2%
* Key Agree, 4.0%
* Sign 6.8%
* Verify 5.8%