### PR TITLE
address fortify critical issues

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10527,7 +10527,9 @@ int SendCertificate(WOLFSSL* ssl)
 
             sendSz = BuildMessage(ssl, output, sendSz, input, inputSz,
                                   handshake, 1, 0);
-            XFREE(input, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
+
+            if (inputSz > 0)
+                XFREE(input, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
 
             if (sendSz < 0)
                 return sendSz;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1907,6 +1907,14 @@ int ToTraditionalEnc(byte* input, word32 sz,const char* password,int passwordSz)
             return ASN_PARSE_E;
         }
 
+        if (length > MAX_IV_SIZE) {
+#ifdef WOLFSSL_SMALL_STACK
+            XFREE(salt,  NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(cbcIv, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+            return ASN_PARSE_E;
+        }
+
         XMEMCPY(cbcIv, &input[inOutIdx], length);
         inOutIdx += length;
     }


### PR DESCRIPTION
This PR fixes:

1. An issue in ToTraditionalEnc() where we need to check that the length of an IV we are reading is not larger than the buffer it is going into (MAX_IV_SIZE).

2. Corrects a call to XFREE() in SendCertificate() to only be called when "input" has been allocated (inputSz > 0).