### PR TITLE
address fortify high issues

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6177,7 +6177,8 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
 {
     int ret = 0;
 
-    if (x509 == NULL || dCert == NULL)
+    if (x509 == NULL || dCert == NULL ||
+        dCert->subjectCNLen < 0)
         return BAD_FUNC_ARG;
 
     x509->version = dCert->version + 1;
@@ -6234,14 +6235,14 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
         else
             x509->deviceTypeSz = 0;
         minSz = min(dCert->hwTypeSz, EXTERNAL_SERIAL_SIZE);
-        if (minSz != 0) {
+        if (minSz > 0) {
             x509->hwTypeSz = minSz;
             XMEMCPY(x509->hwType, dCert->hwType, minSz);
         }
         else
             x509->hwTypeSz = 0;
         minSz = min(dCert->hwSerialNumSz, EXTERNAL_SERIAL_SIZE);
-        if (minSz != 0) {
+        if (minSz > 0) {
             x509->hwSerialNumSz = minSz;
             XMEMCPY(x509->hwSerialNum, dCert->hwSerialNum, minSz);
         }
@@ -6251,14 +6252,14 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
 #endif /* WOLFSSL_SEP */
     {
         int minSz = min(dCert->beforeDateLen, MAX_DATE_SZ);
-        if (minSz != 0) {
+        if (minSz > 0) {
             x509->notBeforeSz = minSz;
             XMEMCPY(x509->notBefore, dCert->beforeDate, minSz);
         }
         else
             x509->notBeforeSz = 0;
         minSz = min(dCert->afterDateLen, MAX_DATE_SZ);
-        if (minSz != 0) {
+        if (minSz > 0) {
             x509->notAfterSz = minSz;
             XMEMCPY(x509->notAfter, dCert->afterDate, minSz);
         }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -410,7 +410,7 @@ time_t XTIME(time_t * timer)
 
 static INLINE word32 btoi(byte b)
 {
-    return b - 0x30;
+    return (word32)(b - 0x30);
 }
 
 

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -91,7 +91,7 @@ int wc_PBKDF1(byte* output, const byte* passwd, int pLen, const byte* salt,
         hLen = (int)MD5_DIGEST_SIZE;
 #endif
 
-    if (kLen > hLen)
+    if ((kLen > hLen) || (kLen < 0))
         return BAD_FUNC_ARG;
 
     if (iterations < 1)


### PR DESCRIPTION
This PR fixes:

1. 4 issues where signed "int" types were used as length arguments to XMEMCPY, but not verified to be positive first.

2.  Possible signed/unsigned type mismatch in btoi() of asn.c.  A cast to (word32) was added.