### PR TITLE
Cleanup min(), TRUE, FALSE, ALIGN16 and ALIGN32

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -65,12 +65,6 @@
     #include <sys/filio.h>
 #endif
 
-#ifndef TRUE
-    #define TRUE  1
-#endif
-#ifndef FALSE
-    #define FALSE 0
-#endif
 
 #define ERROR_OUT(err, eLabel) { ret = (err); goto eLabel; }
 
@@ -149,16 +143,6 @@ static int BuildCertHashes(WOLFSSL* ssl, Hashes* hashes);
 #ifdef HAVE_QSH
     int QSH_Init(WOLFSSL* ssl);
 #endif
-
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
 
 
 int IsTLS(const WOLFSSL* ssl)
@@ -5392,7 +5376,7 @@ static int GetDtlsHandShakeHeader(WOLFSSL* ssl, const byte* input,
 
     *type = input[idx++];
     c24to32(input + idx, size);
-    idx += BYTE3_LEN;
+    idx += OPAQUE24_LEN;
 
     ato16(input + idx, &ssl->keys.dtls_peer_handshake_number);
     idx += DTLS_HANDSHAKE_SEQ_SZ;
@@ -6156,7 +6140,7 @@ static int CheckAltNames(DecodedCert* dCert, char* domain)
         altName = dCert->altNames;
 
     while (altName) {
-        WOLFSSL_MSG("    individual AltName check");
+        WOLFSSL_MSG("\tindividual AltName check");
 
         if (MatchDomainName(altName->name,(int)XSTRLEN(altName->name), domain)){
             match = 1;
@@ -6436,7 +6420,7 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         listSz -= certSz + CERT_HEADER_SZ;
 
         totalCerts++;
-        WOLFSSL_MSG("    Put another cert into chain");
+        WOLFSSL_MSG("\tPut another cert into chain");
     }
 
     count = totalCerts;
@@ -9242,7 +9226,7 @@ static int DoAlert(WOLFSSL* ssl, byte* input, word32* inOutIdx, int* type,
 
     WOLFSSL_MSG("Got alert");
     if (*type == close_notify) {
-        WOLFSSL_MSG("    close notify");
+        WOLFSSL_MSG("\tclose notify");
         ssl->options.closeNotify = 1;
     }
     WOLFSSL_ERROR(*type);
@@ -13719,11 +13703,11 @@ static void PickHashSigAlgo(WOLFSSL* ssl,
             WOLFSSL_MSG("server using lower version");
 
             if (!ssl->options.downgrade) {
-                WOLFSSL_MSG("    no downgrade allowed, fatal error");
+                WOLFSSL_MSG("\tno downgrade allowed, fatal error");
                 return VERSION_ERROR;
             }
             if (pv.minor < ssl->options.minDowngrade) {
-                WOLFSSL_MSG("    version below minimum allowed, fatal error");
+                WOLFSSL_MSG("\tversion below minimum allowed, fatal error");
                 return VERSION_ERROR;
             }
 
@@ -13738,19 +13722,19 @@ static void PickHashSigAlgo(WOLFSSL* ssl,
 
             if (pv.minor == SSLv3_MINOR) {
                 /* turn off tls */
-                WOLFSSL_MSG("    downgrading to SSLv3");
+                WOLFSSL_MSG("\tdowngrading to SSLv3");
                 ssl->options.tls    = 0;
                 ssl->options.tls1_1 = 0;
                 ssl->version.minor  = SSLv3_MINOR;
             }
             else if (pv.minor == TLSv1_MINOR) {
                 /* turn off tls 1.1+ */
-                WOLFSSL_MSG("    downgrading to TLSv1");
+                WOLFSSL_MSG("\tdowngrading to TLSv1");
                 ssl->options.tls1_1 = 0;
                 ssl->version.minor  = TLSv1_MINOR;
             }
             else if (pv.minor == TLSv1_1_MINOR) {
-                WOLFSSL_MSG("    downgrading to TLSv1.1");
+                WOLFSSL_MSG("\tdowngrading to TLSv1.1");
                 ssl->version.minor  = TLSv1_1_MINOR;
             }
         }
@@ -18623,24 +18607,24 @@ int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 return VERSION_ERROR;
             }
             if (pv.minor < ssl->options.minDowngrade) {
-                WOLFSSL_MSG("    version below minimum allowed, fatal error");
+                WOLFSSL_MSG("\tversion below minimum allowed, fatal error");
                 return VERSION_ERROR;
             }
             if (pv.minor == SSLv3_MINOR) {
                 /* turn off tls */
-                WOLFSSL_MSG("    downgrading to SSLv3");
+                WOLFSSL_MSG("\tdowngrading to SSLv3");
                 ssl->options.tls    = 0;
                 ssl->options.tls1_1 = 0;
                 ssl->version.minor  = SSLv3_MINOR;
             }
             else if (pv.minor == TLSv1_MINOR) {
-                WOLFSSL_MSG("    downgrading to TLSv1");
+                WOLFSSL_MSG("\tdowngrading to TLSv1");
                 /* turn off tls 1.1+ */
                 ssl->options.tls1_1 = 0;
                 ssl->version.minor  = TLSv1_MINOR;
             }
             else if (pv.minor == TLSv1_1_MINOR) {
-                WOLFSSL_MSG("    downgrading to TLSv1.1");
+                WOLFSSL_MSG("\tdowngrading to TLSv1.1");
                 ssl->version.minor  = TLSv1_1_MINOR;
             }
 #ifndef NO_RSA
@@ -18829,25 +18813,25 @@ int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 return VERSION_ERROR;
             }
             if (pv.minor < ssl->options.minDowngrade) {
-                WOLFSSL_MSG("    version below minimum allowed, fatal error");
+                WOLFSSL_MSG("\tversion below minimum allowed, fatal error");
                 return VERSION_ERROR;
             }
 
             if (pv.minor == SSLv3_MINOR) {
                 /* turn off tls */
-                WOLFSSL_MSG("    downgrading to SSLv3");
+                WOLFSSL_MSG("\tdowngrading to SSLv3");
                 ssl->options.tls    = 0;
                 ssl->options.tls1_1 = 0;
                 ssl->version.minor  = SSLv3_MINOR;
             }
             else if (pv.minor == TLSv1_MINOR) {
                 /* turn off tls 1.1+ */
-                WOLFSSL_MSG("    downgrading to TLSv1");
+                WOLFSSL_MSG("\tdowngrading to TLSv1");
                 ssl->options.tls1_1 = 0;
                 ssl->version.minor  = TLSv1_MINOR;
             }
             else if (pv.minor == TLSv1_1_MINOR) {
-                WOLFSSL_MSG("    downgrading to TLSv1.1");
+                WOLFSSL_MSG("\tdowngrading to TLSv1.1");
                 ssl->version.minor  = TLSv1_1_MINOR;
             }
 #ifndef NO_RSA

--- a/src/io.c
+++ b/src/io.c
@@ -297,32 +297,32 @@ int EmbedReceive(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 
         if (err == SOCKET_EWOULDBLOCK || err == SOCKET_EAGAIN) {
             if (!wolfSSL_dtls(ssl) || wolfSSL_get_using_nonblock(ssl)) {
-                WOLFSSL_MSG("    Would block");
+                WOLFSSL_MSG("\tWould block");
                 return WOLFSSL_CBIO_ERR_WANT_READ;
             }
             else {
-                WOLFSSL_MSG("    Socket timeout");
+                WOLFSSL_MSG("\tSocket timeout");
                 return WOLFSSL_CBIO_ERR_TIMEOUT;
             }
         }
         else if (err == SOCKET_ECONNRESET) {
-            WOLFSSL_MSG("    Connection reset");
+            WOLFSSL_MSG("\tConnection reset");
             return WOLFSSL_CBIO_ERR_CONN_RST;
         }
         else if (err == SOCKET_EINTR) {
-            WOLFSSL_MSG("    Socket interrupted");
+            WOLFSSL_MSG("\tSocket interrupted");
             return WOLFSSL_CBIO_ERR_ISR;
         }
         else if (err == SOCKET_ECONNREFUSED) {
-            WOLFSSL_MSG("    Connection refused");
+            WOLFSSL_MSG("\tConnection refused");
             return WOLFSSL_CBIO_ERR_WANT_READ;
         }
         else if (err == SOCKET_ECONNABORTED) {
-            WOLFSSL_MSG("    Connection aborted");
+            WOLFSSL_MSG("\tConnection aborted");
             return WOLFSSL_CBIO_ERR_CONN_CLOSE;
         }
         else {
-            WOLFSSL_MSG("    General error");
+            WOLFSSL_MSG("\tGeneral error");
             return WOLFSSL_CBIO_ERR_GENERAL;
         }
     }
@@ -353,23 +353,23 @@ int EmbedSend(WOLFSSL* ssl, char *buf, int sz, void *ctx)
         WOLFSSL_MSG("Embed Send error");
 
         if (err == SOCKET_EWOULDBLOCK || err == SOCKET_EAGAIN) {
-            WOLFSSL_MSG("    Would Block");
+            WOLFSSL_MSG("\tWould Block");
             return WOLFSSL_CBIO_ERR_WANT_WRITE;
         }
         else if (err == SOCKET_ECONNRESET) {
-            WOLFSSL_MSG("    Connection reset");
+            WOLFSSL_MSG("\tConnection reset");
             return WOLFSSL_CBIO_ERR_CONN_RST;
         }
         else if (err == SOCKET_EINTR) {
-            WOLFSSL_MSG("    Socket interrupted");
+            WOLFSSL_MSG("\tSocket interrupted");
             return WOLFSSL_CBIO_ERR_ISR;
         }
         else if (err == SOCKET_EPIPE) {
-            WOLFSSL_MSG("    Socket EPIPE");
+            WOLFSSL_MSG("\tSocket EPIPE");
             return WOLFSSL_CBIO_ERR_CONN_CLOSE;
         }
         else {
-            WOLFSSL_MSG("    General error");
+            WOLFSSL_MSG("\tGeneral error");
             return WOLFSSL_CBIO_ERR_GENERAL;
         }
     }
@@ -435,28 +435,28 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 
         if (err == SOCKET_EWOULDBLOCK || err == SOCKET_EAGAIN) {
             if (wolfSSL_get_using_nonblock(ssl)) {
-                WOLFSSL_MSG("    Would block");
+                WOLFSSL_MSG("\tWould block");
                 return WOLFSSL_CBIO_ERR_WANT_READ;
             }
             else {
-                WOLFSSL_MSG("    Socket timeout");
+                WOLFSSL_MSG("\tSocket timeout");
                 return WOLFSSL_CBIO_ERR_TIMEOUT;
             }
         }
         else if (err == SOCKET_ECONNRESET) {
-            WOLFSSL_MSG("    Connection reset");
+            WOLFSSL_MSG("\tConnection reset");
             return WOLFSSL_CBIO_ERR_CONN_RST;
         }
         else if (err == SOCKET_EINTR) {
-            WOLFSSL_MSG("    Socket interrupted");
+            WOLFSSL_MSG("\tSocket interrupted");
             return WOLFSSL_CBIO_ERR_ISR;
         }
         else if (err == SOCKET_ECONNREFUSED) {
-            WOLFSSL_MSG("    Connection refused");
+            WOLFSSL_MSG("\tConnection refused");
             return WOLFSSL_CBIO_ERR_WANT_READ;
         }
         else {
-            WOLFSSL_MSG("    General error");
+            WOLFSSL_MSG("\tGeneral error");
             return WOLFSSL_CBIO_ERR_GENERAL;
         }
     }
@@ -464,7 +464,7 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
         if (dtlsCtx->peer.sz > 0
                 && peerSz != (XSOCKLENT)dtlsCtx->peer.sz
                 && XMEMCMP(&peer, dtlsCtx->peer.sa, peerSz) != 0) {
-            WOLFSSL_MSG("    Ignored packet from invalid peer");
+            WOLFSSL_MSG("\tIgnored packet from invalid peer");
             return WOLFSSL_CBIO_ERR_WANT_READ;
         }
     }
@@ -497,23 +497,23 @@ int EmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
         WOLFSSL_MSG("Embed Send To error");
 
         if (err == SOCKET_EWOULDBLOCK || err == SOCKET_EAGAIN) {
-            WOLFSSL_MSG("    Would Block");
+            WOLFSSL_MSG("\tWould Block");
             return WOLFSSL_CBIO_ERR_WANT_WRITE;
         }
         else if (err == SOCKET_ECONNRESET) {
-            WOLFSSL_MSG("    Connection reset");
+            WOLFSSL_MSG("\tConnection reset");
             return WOLFSSL_CBIO_ERR_CONN_RST;
         }
         else if (err == SOCKET_EINTR) {
-            WOLFSSL_MSG("    Socket interrupted");
+            WOLFSSL_MSG("\tSocket interrupted");
             return WOLFSSL_CBIO_ERR_ISR;
         }
         else if (err == SOCKET_EPIPE) {
-            WOLFSSL_MSG("    Socket EPIPE");
+            WOLFSSL_MSG("\tSocket EPIPE");
             return WOLFSSL_CBIO_ERR_CONN_CLOSE;
         }
         else {
-            WOLFSSL_MSG("    General error");
+            WOLFSSL_MSG("\tGeneral error");
             return WOLFSSL_CBIO_ERR_GENERAL;
         }
     }

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -55,16 +55,6 @@
 #endif
 
 
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-static INLINE word32 min(word32 a, word32 b)
-{
-    return a > b ? b : a;
-}
-
-#endif /* WOLFSSL_HAVE_MIN */
-
 #ifndef WOLFSSL_SNIFFER_TIMEOUT
     #define WOLFSSL_SNIFFER_TIMEOUT 900
     /* Cache unclosed Sessions for 15 minutes since last used */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -105,22 +105,6 @@
     #endif
 #endif /* NO_FILESYSTEM */
 
-#ifndef TRUE
-    #define TRUE  1
-#endif
-#ifndef FALSE
-    #define FALSE 0
-#endif
-
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSSL_HAVE_MIN */
 
 #if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_HAVE_MAX)
 #define WOLFSSL_HAVE_MAX

--- a/src/tls.c
+++ b/src/tls.c
@@ -66,17 +66,6 @@
 #endif
 
 
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
-
-
 #ifdef WOLFSSL_SHA384
     #define P_HASH_MAX_SIZE SHA384_DIGEST_SIZE
 #else

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -96,13 +96,6 @@ ASN Options:
 #endif
 
 
-#ifndef TRUE
-    #define TRUE  1
-#endif
-#ifndef FALSE
-    #define FALSE 0
-#endif
-
 #ifndef NO_ASN_TIME
 #if defined(USER_TIME)
     /* user time, and gmtime compatible functions, there is a gmtime
@@ -6251,18 +6244,6 @@ int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen)
 
 
 #if defined(WOLFSSL_CERT_GEN) && !defined(NO_RSA)
-
-
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
-
 
 /* Initialize and Set Certificate defaults:
    version    = 3 (0x2)

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -40,17 +40,6 @@
 #include <wolfssl/wolfcrypt/cmac.h>
 
 
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
-
-
 static void ShiftAndXorRb(byte* out, byte* in)
 {
     int i, j, xorRb;

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -30,6 +30,15 @@
 
 #include <wolfssl/wolfcrypt/dh.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/logging.h>
+
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+
 
 #if !defined(USER_MATH_LIB) && !defined(WOLFSSL_DH_CONST)
     #include <math.h>
@@ -38,17 +47,6 @@
 #else
     /* user's own math lib */
 #endif
-
-
-#if !defined(WOLFSSL_HAVE_MIN) && !defined(WOLFSSL_DH_CONST)
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
 
 
 void wc_InitDhKey(DhKey* key)
@@ -185,7 +183,7 @@ int wc_DhAgree(DhKey* key, byte* agree, word32* agreeSz, const byte* priv,
 {
     int ret = 0;
 
-    mp_int x; 
+    mp_int x;
     mp_int y;
     mp_int z;
 

--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -35,22 +35,19 @@
 #include <wolfssl/wolfcrypt/sha.h>
 #include <wolfssl/wolfcrypt/dsa.h>
 
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+
 
 enum {
     DSA_HALF_SIZE = 20,   /* r and s size  */
     DSA_SIG_SIZE  = 40    /* signature size */
 };
 
-
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
 
 
 void wc_InitDsaKey(DsaKey* key)

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6982,16 +6982,6 @@ int wc_ecc_set_custom_curve(ecc_key* key, const ecc_set_type* dp)
 
 #ifdef HAVE_X963_KDF
 
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
-
 static INLINE void IncrementX963KdfCounter(byte* inOutCtr)
 {
     int i;

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -30,6 +30,14 @@
 
 #include <wolfssl/wolfcrypt/hmac.h>
 
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+
+
 #ifdef HAVE_FIPS
 /* does init */
 int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 keySz)
@@ -779,17 +787,6 @@ int wolfSSL_GetHmacMaxSize(void)
 }
 
 #ifdef HAVE_HKDF
-
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
-
 
 /* HMAC-KDF with hash type, optional salt and info, return 0 on success */
 int wc_HKDF(int type, const byte* inKey, word32 inKeySz,

--- a/wolfcrypt/src/md4.c
+++ b/wolfcrypt/src/md4.c
@@ -37,17 +37,6 @@
 #endif
 
 
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
-
-
 void wc_InitMd4(Md4* md4)
 {
     md4->digest[0] = 0x67452301L;

--- a/wolfcrypt/src/md5.c
+++ b/wolfcrypt/src/md5.c
@@ -170,16 +170,6 @@
 
 #else /* Begin wolfCrypt software implementation */
 
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
-
 void wc_InitMd5(Md5* md5)
 {
     md5->digest[0] = 0x67452301L;

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -212,6 +212,7 @@ STATIC INLINE int ConstantCompare(const byte* a, const byte* b, int length)
 
 #ifndef WOLFSSL_HAVE_MIN
     #define WOLFSSL_HAVE_MIN
+    #define min min /* for ctaocrypt FIPS */
     STATIC INLINE word32 min(word32 a, word32 b)
     {
         return a > b ? b : a;

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -210,6 +210,15 @@ STATIC INLINE int ConstantCompare(const byte* a, const byte* b, int length)
     return compareSum;
 }
 
+#ifndef WOLFSSL_HAVE_MIN
+    #define WOLFSSL_HAVE_MIN
+    STATIC INLINE word32 min(word32 a, word32 b)
+    {
+        return a > b ? b : a;
+    }
+#endif /* WOLFSSL_HAVE_MIN */
+
+
 #undef STATIC
 
 

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -212,7 +212,9 @@ STATIC INLINE int ConstantCompare(const byte* a, const byte* b, int length)
 
 #ifndef WOLFSSL_HAVE_MIN
     #define WOLFSSL_HAVE_MIN
-    #define min min /* for ctaocrypt FIPS */
+    #if defined(HAVE_FIPS) && !defined(min)
+        #define min min
+    #endif
     STATIC INLINE word32 min(word32 a, word32 b)
     {
         return a > b ? b : a;

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -38,16 +38,6 @@
     #include <wolfcrypt/src/misc.c>
 #endif
 
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
-
 
 /* direction for processing, encoding or decoding */
 typedef enum {

--- a/wolfcrypt/src/port/arm/armv8-sha256.c
+++ b/wolfcrypt/src/port/arm/armv8-sha256.c
@@ -38,27 +38,6 @@
     #include <wolfcrypt/src/misc.c>
 #endif
 
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
-
-#if !defined (ALIGN32)
-    #if defined (__GNUC__)
-        #define ALIGN32 __attribute__ ( (aligned (32)))
-    #elif defined(_MSC_VER)
-        /* disable align warning, we want alignment ! */
-        #pragma warning(disable: 4324)
-        #define ALIGN32 __declspec (align (32))
-    #else
-        #define ALIGN32
-    #endif
-#endif
 
 static const ALIGN32 word32 K[64] = {
     0x428A2F98L, 0x71374491L, 0xB5C0FBCFL, 0xE9B5DBA5L, 0x3956C25BL,

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -59,16 +59,6 @@
     #include <wolfcrypt/src/misc.c>
 #endif
 
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
-
 
 #ifndef NO_SHA
 /* PBKDF1 needs at least SHA available */

--- a/wolfcrypt/src/ripemd.c
+++ b/wolfcrypt/src/ripemd.c
@@ -38,15 +38,6 @@
 #endif
 
 
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
 
 void wc_InitRipeMd(RipeMd* ripemd)
 {

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -30,15 +30,6 @@
 #if !defined(NO_SHA)
 
 #include <wolfssl/wolfcrypt/sha.h>
-#include <wolfssl/wolfcrypt/logging.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-
-#ifdef NO_INLINE
-    #include <wolfssl/wolfcrypt/misc.h>
-#else
-    #define WOLFSSL_MISC_INCLUDED
-    #include <wolfcrypt/src/misc.c>
-#endif
 
 
 /* fips wrapper calls, user can call direct */
@@ -59,6 +50,15 @@
     }
 
 #else /* else build without fips */
+
+#include <wolfssl/wolfcrypt/logging.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
 
 
 /****************************************/
@@ -377,13 +377,6 @@
     }
 #endif /* !USE_CUSTOM_SHA_TRANSFORM */
 
-
-#ifndef WOLFSSL_HAVE_MIN
-    #define WOLFSSL_HAVE_MIN
-    static INLINE word32 min(word32 a, word32 b) {
-        return a > b ? b : a;
-    }
-#endif /* WOLFSSL_HAVE_MIN */
 
 static INLINE void AddLength(Sha* sha, word32 len)
 {

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -289,15 +289,6 @@ static void set_Transform(void) {
     #include "fsl_mmcau.h"
 #endif
 
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
 
 #ifdef FREESCALE_LTC_SHA
 int wc_InitSha256(Sha256* sha256)

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -81,16 +81,6 @@ int wc_Sha384Final(Sha384* sha, byte* out)
 #endif
 
 
-#ifndef WOLFSSL_HAVE_MIN
-#define WOLFSSL_HAVE_MIN
-
-    static INLINE word32 min(word32 a, word32 b)
-    {
-        return a > b ? b : a;
-    }
-
-#endif /* WOLFSSL_HAVE_MIN */
-
 #if defined(USE_INTEL_SPEEDUP)
   #define HAVE_INTEL_AVX1
   #define HAVE_INTEL_AVX2

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -164,12 +164,6 @@
     #pragma warning(disable: 4996)
 #endif
 
-#ifdef NO_AES
-    #if !defined (ALIGN16)
-        #define ALIGN16
-    #endif
-#endif
-
 #ifdef NO_SHA
     #define SHA_DIGEST_SIZE 20
 #endif
@@ -924,7 +918,6 @@ enum Misc {
     LENGTH_SZ      =  2,       /* length field for HMAC, data only */
     VERSION_SZ     =  2,       /* length of proctocol version */
     SEQ_SZ         =  8,       /* 64 bit sequence number  */
-    BYTE3_LEN      =  3,       /* up to 24 bit byte lengths */
     ALERT_SIZE     =  2,       /* level + description     */
     VERIFY_HEADER  =  2,       /* always use 2 bytes      */
     EXT_ID_SZ      =  2,       /* always use 2 bytes      */

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -101,8 +101,8 @@ typedef union {
 
 
 typedef struct WOLFSSL_EVP_MD_CTX {
+    WOLFSSL_Hasher hash;
     unsigned char macType;
-    ALIGN16 WOLFSSL_Hasher hash;
 } WOLFSSL_EVP_MD_CTX;
 
 

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -102,7 +102,7 @@ typedef union {
 
 typedef struct WOLFSSL_EVP_MD_CTX {
     unsigned char macType;
-    WOLFSSL_Hasher hash;
+    ALIGN16 WOLFSSL_Hasher hash;
 } WOLFSSL_EVP_MD_CTX;
 
 

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -68,6 +68,7 @@ void   ByteReverseWords64(word64*, const word64*, word32);
 #endif /* WORD64_AVAILABLE */
 
 #ifndef WOLFSSL_HAVE_MIN
+    #define min min /* for ctaocrypt FIPS */
     WOLFSSL_LOCAL word32 min(word32 a, word32 b);
 #endif
 

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -67,6 +67,10 @@ WOLFSSL_LOCAL
 void   ByteReverseWords64(word64*, const word64*, word32);
 #endif /* WORD64_AVAILABLE */
 
+#ifndef WOLFSSL_HAVE_MIN
+    WOLFSSL_LOCAL word32 min(word32 a, word32 b);
+#endif
+
 #endif /* NO_INLINE */
 
 

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -68,7 +68,9 @@ void   ByteReverseWords64(word64*, const word64*, word32);
 #endif /* WORD64_AVAILABLE */
 
 #ifndef WOLFSSL_HAVE_MIN
-    #define min min /* for ctaocrypt FIPS */
+    #if defined(HAVE_FIPS) && !defined(min)
+        #define min min
+    #endif
     WOLFSSL_LOCAL word32 min(word32 a, word32 b);
 #endif
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -391,22 +391,46 @@
 
     /* AESNI requires alignment and ARMASM gains some performance from it */
     #if defined(WOLFSSL_AESNI) || defined(WOLFSSL_ARMASM)
-    #if !defined (ALIGN16)
-        #if defined (__GNUC__)
-            #define ALIGN16 __attribute__ ( (aligned (16)))
-        #elif defined(_MSC_VER)
-            /* disable align warning, we want alignment ! */
-            #pragma warning(disable: 4324)
-            #define ALIGN16 __declspec (align (16))
-        #else
-            #define ALIGN16
-        #endif
-    #endif
+        #if !defined(ALIGN16)
+            #if defined(__GNUC__)
+                #define ALIGN16 __attribute__ ( (aligned (16)))
+            #elif defined(_MSC_VER)
+                /* disable align warning, we want alignment ! */
+                #pragma warning(disable: 4324)
+                #define ALIGN16 __declspec (align (16))
+            #else
+                #define ALIGN16
+            #endif
+        #endif /* !ALIGN16 */
+
+       #if !defined(ALIGN32)
+            #if defined(__GNUC__)
+                #define ALIGN32 __attribute__ ( (aligned (32)))
+            #elif defined(_MSC_VER)
+                /* disable align warning, we want alignment ! */
+                #pragma warning(disable: 4324)
+                #define ALIGN32 __declspec (align (32))
+            #else
+                #define ALIGN32
+            #endif
+        #endif /* !ALIGN32 */
     #else
         #ifndef ALIGN16
             #define ALIGN16
         #endif
-    #endif /* WOLFSSL_AESNI or WOLFSSL_ARMASM */
+        #ifndef ALIGN32
+            #define ALIGN32
+        #endif
+    #endif /* WOLFSSL_AESNI || WOLFSSL_ARMASM */
+
+
+    #ifndef TRUE
+        #define TRUE  1
+    #endif
+    #ifndef FALSE
+        #define FALSE 0
+    #endif
+
 
     #ifdef WOLFSSL_RIOT_OS
         #define EXIT_TEST(ret) exit(ret)


### PR DESCRIPTION
Replace only use of BYTE3_LEN with OPAQUE24_LEN. Replace “    “ with “\t” (saves bytes and is consistent). Fix align issue with “WOLFSSL_EVP_MD_CTX” hash. Note: Pulling cleanup from async branch.