### PR TITLE
DTLS-SCTP fix

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8183,7 +8183,7 @@ static int DoDtlsHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         /* This branch is in order next, and a complete message. */
         ret = DoHandShakeMsgType(ssl, input, inOutIdx, type, size, totalSz);
         if (ret == 0) {
-            if (type != client_hello)
+            if (type != client_hello || !IsDtlsNotSctpMode(ssl))
                 ssl->keys.dtls_expected_peer_handshake_number++;
             if (ssl->dtls_rx_msg_list != NULL) {
                 ret = DtlsMsgDrain(ssl);

--- a/tests/include.am
+++ b/tests/include.am
@@ -23,5 +23,6 @@ EXTRA_DIST += tests/test.conf \
               tests/test-qsh.conf \
               tests/test-psk-no-id.conf \
               tests/test-dtls.conf \
+              tests/test-sctp.conf \
               tests/test-sig.conf
 DISTCLEANFILES+= tests/.libs/unit.test


### PR DESCRIPTION
1. Add the SCTP suite test file to the include.am.
2. Skip the sequence number increment for client_hello messages in DTLS, but do the increment for SCTP.