### PR TITLE
static analysis check of null dereference and memory management

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -9504,7 +9504,9 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     void wolfSSL_CTX_set_default_passwd_cb(WOLFSSL_CTX* ctx, pem_password_cb cb)
     {
         WOLFSSL_ENTER("SSL_CTX_set_default_passwd_cb");
-        ctx->passwd_cb = cb;
+        if (ctx != NULL) {
+            ctx->passwd_cb = cb;
+        }
     }
 
     int wolfSSL_num_locks(void)

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -166,8 +166,9 @@ int main(int argc, char** argv)
 
 	    printf("Enter the interface number (1-%d): ", i);
 	    ret = scanf("%d", &inum);
-        if (ret != 1)
+        if (ret != 1) {
             printf("scanf port failed\n");
+        }
 
 	    if (inum < 1 || inum > i)
 		    err_sys("Interface number out of range");

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1457,6 +1457,7 @@ static int wc_PKCS7_KariGenerateKEK(WC_PKCS7_KARI* kari,
 
     } else {
         /* bad direction */
+        XFREE(secret, kari->heap, DYNAMIC_TYPE_PKCS7);
         return BAD_FUNC_ARG;
     }
 
@@ -2127,8 +2128,10 @@ static int wc_PKCS7_GenerateIV(WC_RNG* rng, byte* iv, word32 ivSz)
             return MEMORY_E;
 
         ret = wc_InitRng(random);
-        if (ret != 0)
+        if (ret != 0) {
+            XFREE(random, NULL, DYNAMIC_TYPE_RNG);
             return ret;
+        }
 
     } else {
         random = rng;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6675,6 +6675,9 @@ int openssl_test(void)
     {
         byte* p;
         p = (byte*)CRYPTO_malloc(10, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        if (p == NULL) {
+            return -70;
+        }
         XMEMSET(p, 0, 10);
         CRYPTO_free(p, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     }


### PR DESCRIPTION
This is valid cases from running static analysis checks with the configure option "./configure --enable-distro --enable-scrypt" and a fix for a warning from gcc-6 while building the sniffer feature.