### PR TITLE
prepare for release 3.10.0

### DIFF
--- a/README
+++ b/README
@@ -35,6 +35,43 @@ before calling wolfSSL_new();  Though it's not recommended.
 *** end Notes ***
 
 
+********* wolfSSL (Formerly CyaSSL) Release 3.10.0 (12/21/2016)
+
+Release 3.10.0 of wolfSSL has bug fixes and new features including:
+
+- Added support for SHA224
+- Added scrypt feature
+- Build for Intel SGX use, added in directory IDE/WIN-SGX
+- Fix for ChaCha20-Poly1305 ECDSA certificate type request
+- Enhance PKCS#7 with ECC enveloped data and AES key wrap support
+- Added support for RIOT OS
+- Add support for parsing PKCS#12 files
+- ECC performance increased with custom curves
+- ARMv8 expanded to AArch32 and performance increased
+- Added ANSI-X9.63-KDF support
+- Port to STM32 F2/F4 CubeMX
+- Port to Atmel ATECC508A board
+- Removed fPIE by default when wolfSSL library is compiled
+- Update to Python wrapper, dropping DES and adding wc_RSASetRNG
+- Added support for NXP K82 hardware acceleration
+- Added SCR client and server verify check
+- Added a disable rng option with autoconf
+- Added more tests vectors to test.c with AES-CTR
+- Updated DTLS session export version number
+- Updated DTLS for 64 bit sequence numbers
+- Fix for memory management with TI and WOLFSSL_SMALL_STACK
+- Hardening RSA CRT to be constant time
+- Fix uninitialized warning with IAR compiler
+- Fix for C# wrapper example IO hang on unexpected connection termination
+
+
+This release of wolfSSL fixes a low level security vulnerability. The vulnerability reported was a potential cache attack on RSA operations. If using wolfSSL RSA on a server that other users can have access to monitor the cache, then it is recommended to update wolfSSL. Thanks to Andreas Zankl, Johann Heyszl and Georg Sigl at Fraunhofer AISEC for the report. More information will be available on our site:
+
+https://wolfssl.com/wolfSSL/security/vulnerabilities.php
+
+See INSTALL file for build instructions.
+More info can be found on-line at http://wolfssl.com/wolfSSL/Docs.html
+
 ********* wolfSSL (Formerly CyaSSL) Release 3.9.10 (9/23/2016)
 
 Release 3.9.10 of wolfSSL has bug fixes and new features including:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,43 @@ wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0);
 before calling wolfSSL_new();  Though it's not recommended.
 ```
 
+# wolfSSL (Formerly CyaSSL) Release 3.10.0 (12/21/2016)
+
+## Release 3.10.0 of wolfSSL has bug fixes and new features including:
+
+- Added support for SHA224
+- Added scrypt feature
+- Build for Intel SGX use, added in directory IDE/WIN-SGX
+- Fix for ChaCha20-Poly1305 ECDSA certificate type request
+- Enhance PKCS#7 with ECC enveloped data and AES key wrap support
+- Added support for RIOT OS
+- Add support for parsing PKCS#12 files
+- ECC performance increased with custom curves
+- ARMv8 expanded to AArch32 and performance increased
+- Added ANSI-X9.63-KDF support
+- Port to STM32 F2/F4 CubeMX
+- Port to Atmel ATECC508A board
+- Removed fPIE by default when wolfSSL library is compiled
+- Update to Python wrapper, dropping DES and adding wc_RSASetRNG
+- Added support for NXP K82 hardware acceleration
+- Added SCR client and server verify check
+- Added a disable rng option with autoconf
+- Added more tests vectors to test.c with AES-CTR
+- Updated DTLS session export version number
+- Updated DTLS for 64 bit sequence numbers
+- Fix for memory management with TI and WOLFSSL_SMALL_STACK
+- Hardening RSA CRT to be constant time
+- Fix uninitialized warning with IAR compiler
+- Fix for C# wrapper example IO hang on unexpected connection termination
+
+
+This release of wolfSSL fixes a low level security vulnerability. The vulnerability reported was a potential cache attack on RSA operations. If using wolfSSL RSA on a server that other users can have access to monitor the cache, then it is recommended to update wolfSSL. Thanks to Andreas Zankl, Johann Heyszl and Georg Sigl at Fraunhofer AISEC for the report. More information will be available on our site:
+
+https://wolfssl.com/wolfSSL/security/vulnerabilities.php
+
+See INSTALL file for build instructions.
+More info can be found on-line at http://wolfssl.com/wolfSSL/Docs.html
+
 
 # wolfSSL (Formerly CyaSSL) Release 3.9.10 (9/23/2016)
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #
 #
 
-AC_INIT([wolfssl],[3.9.10],[https://github.com/wolfssl/wolfssl/issues],[wolfssl],[http://www.wolfssl.com])
+AC_INIT([wolfssl],[3.10.0],[https://github.com/wolfssl/wolfssl/issues],[wolfssl],[http://www.wolfssl.com])
 
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -35,7 +35,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h:config.in])dnl Keep filename to 8.3 for MS-DOS.
 
 #shared library versioning
-WOLFSSL_LIBRARY_VERSION=8:0:5
+WOLFSSL_LIBRARY_VERSION=9:0:6
 #                       | | |
 #                +------+ | +---+
 #                |        |     |

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -73,7 +73,7 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_libdir}/libwolfssl.la
 %{_libdir}/libwolfssl.so
 %{_libdir}/libwolfssl.so.3
-%{_libdir}/libwolfssl.so.3.5.0
+%{_libdir}/libwolfssl.so.3.6.0
 
 %files devel
 %defattr(-,root,root,-)

--- a/support/wolfssl.pc
+++ b/support/wolfssl.pc
@@ -5,6 +5,6 @@ includedir=${prefix}/include
 
 Name: wolfssl
 Description: wolfssl C library.
-Version: 3.9.10
+Version: 3.10.0
 Libs: -L${libdir} -lwolfssl
 Cflags: -I${includedir}

--- a/wolfssl/version.h
+++ b/wolfssl/version.h
@@ -28,8 +28,8 @@
 extern "C" {
 #endif
 
-#define LIBWOLFSSL_VERSION_STRING "3.9.10"
-#define LIBWOLFSSL_VERSION_HEX 0x03009010
+#define LIBWOLFSSL_VERSION_STRING "3.10.0"
+#define LIBWOLFSSL_VERSION_HEX 0x03010000
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Updating the README and version number for wolfSSL release 3.10.0.