### PR TITLE
update Windows FIPS build

### DIFF
--- a/IDE/WIN/wolfssl-fips.vcxproj
+++ b/IDE/WIN/wolfssl-fips.vcxproj
@@ -301,6 +301,7 @@
     <ClCompile Include="..\..\src\tls.c" />
     <ClCompile Include="..\..\wolfcrypt\src\wc_encrypt.c" />
     <ClCompile Include="..\..\wolfcrypt\src\wolfevent.c" />
+    <ClCompile Include="..\..\wolfcrypt\src\pkcs12.c" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\wolfcrypt\src\aes_asm.asm">


### PR DESCRIPTION
Update to the window-fips solution. This was in windows-fips 3.10.0 bundles to allow the default windows-fips build.