### PR TITLE
fix C++ compiler warnings for distro build

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7088,7 +7088,8 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             do {
                 #ifdef HAVE_CERTIFICATE_STATUS_REQUEST
                     if (ssl->status_request) {
-                        request = TLSX_CSR_GetRequest(ssl->extensions);
+                        request = (OcspRequest*)TLSX_CSR_GetRequest(
+                                                               ssl->extensions);
                         ssl->status_request = 0;
                         break;
                     }
@@ -7096,8 +7097,8 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
                 #ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
                     if (ssl->status_request_v2) {
-                        request = TLSX_CSR2_GetRequest(ssl->extensions,
-                                                                status_type, 0);
+                        request = (OcspRequest*)TLSX_CSR2_GetRequest(
+                                               ssl->extensions, status_type, 0);
                         ssl->status_request_v2 = 0;
                         break;
                     }
@@ -7211,8 +7212,8 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         ret = BAD_CERTIFICATE_STATUS_ERROR;
 
                     while (ret == 0) {
-                        request = TLSX_CSR2_GetRequest(ssl->extensions,
-                                                          status_type, index++);
+                        request = (OcspRequest*)TLSX_CSR2_GetRequest(
+                                ssl->extensions, status_type, index++);
 
                         if (request == NULL)
                             ret = BAD_CERTIFICATE_STATUS_ERROR;
@@ -18810,7 +18811,7 @@ int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                 ssl->buffers.dtlsCookieSecret.length);
             if (ret != 0) return ret;
             ret = wc_HmacUpdate(&cookieHmac,
-                                ssl->buffers.dtlsCtx.peer.sa,
+                                (const byte*)ssl->buffers.dtlsCtx.peer.sa,
                                 ssl->buffers.dtlsCtx.peer.sz);
             if (ret != 0) return ret;
             ret = wc_HmacUpdate(&cookieHmac, input + i, OPAQUE16_LEN);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1790,7 +1790,7 @@ WOLFSSL_API int wolfSSL_set_SessionTicket(WOLFSSL* ssl, byte* buf, word32 bufSz)
                 if(ssl->session.isDynamic)
                     XFREE(ssl->session.ticket, ssl->heap,
                             DYNAMIC_TYPE_SESSION_TICK);
-                ssl->session.ticket = XMALLOC(bufSz, ssl->heap,
+                ssl->session.ticket = (byte*)XMALLOC(bufSz, ssl->heap,
                         DYNAMIC_TYPE_SESSION_TICK);
                 if(!ssl->session.ticket) {
                     ssl->session.ticket = ssl->session.staticTicket;
@@ -7898,7 +7898,8 @@ static int GetDeepCopySession(WOLFSSL* ssl, WOLFSSL_SESSION* copyFrom)
     /* If doing dynamic copy, need to alloc outside lock, then inside a lock
      * confirm the size still matches and memcpy */
     if (doDynamicCopy) {
-        tmpBuff = XMALLOC(ticketLen, ssl->heap, DYNAMIC_TYPE_SESSION_TICK);
+        tmpBuff = (byte*)XMALLOC(ticketLen, ssl->heap,
+                                                     DYNAMIC_TYPE_SESSION_TICK);
         if (!tmpBuff)
             return MEMORY_ERROR;
 
@@ -7914,7 +7915,7 @@ static int GetDeepCopySession(WOLFSSL* ssl, WOLFSSL_SESSION* copyFrom)
         }
 
         if (ret == SSL_SUCCESS) {
-            copyInto->ticket = tmpBuff;
+            copyInto->ticket = (byte*)tmpBuff;
             copyInto->isDynamic = 1;
             XMEMCPY(copyInto->ticket, copyFrom->ticket, ticketLen);
         }
@@ -7999,7 +8000,7 @@ int AddSession(WOLFSSL* ssl)
     ticLen = ssl->session.ticketLen;
     /* Alloc Memory here so if Malloc fails can exit outside of lock */
     if(ticLen > SESSION_TICKET_LEN) {
-        tmpBuff = XMALLOC(ticLen, ssl->heap,
+        tmpBuff = (byte*)XMALLOC(ticLen, ssl->heap,
                 DYNAMIC_TYPE_SESSION_TICK);
         if(!tmpBuff)
             return MEMORY_E;

--- a/src/tls.c
+++ b/src/tls.c
@@ -2084,13 +2084,14 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, byte* input, word16 length,
     if (!isRequest) {
 #ifndef NO_WOLFSSL_CLIENT
         TLSX* extension = TLSX_Find(ssl->extensions, TLSX_STATUS_REQUEST);
-        CertificateStatusRequest* csr = extension ? extension->data : NULL;
+        CertificateStatusRequest* csr = extension ?
+                              (CertificateStatusRequest*)extension->data : NULL;
 
         if (!csr) {
             /* look at context level */
 
             extension = TLSX_Find(ssl->ctx->extensions, TLSX_STATUS_REQUEST);
-            csr = extension ? extension->data : NULL;
+            csr = extension ? (CertificateStatusRequest*)extension->data : NULL;
 
             if (!csr)
                 return BUFFER_ERROR; /* unexpected extension */
@@ -2106,7 +2107,7 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, byte* input, word16 length,
                     /* propagate nonce */
                     if (csr->request.ocsp.nonceSz) {
                         OcspRequest* request =
-                                           TLSX_CSR_GetRequest(ssl->extensions);
+                             (OcspRequest*)TLSX_CSR_GetRequest(ssl->extensions);
 
                         if (request) {
                             XMEMCPY(request->nonce, csr->request.ocsp.nonce,
@@ -2185,7 +2186,8 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, byte* input, word16 length,
 int TLSX_CSR_InitRequest(TLSX* extensions, DecodedCert* cert, void* heap)
 {
     TLSX* extension = TLSX_Find(extensions, TLSX_STATUS_REQUEST);
-    CertificateStatusRequest* csr = extension ? extension->data : NULL;
+    CertificateStatusRequest* csr = extension ?
+        (CertificateStatusRequest*)extension->data : NULL;
     int ret = 0;
 
     if (csr) {
@@ -2215,7 +2217,8 @@ int TLSX_CSR_InitRequest(TLSX* extensions, DecodedCert* cert, void* heap)
 void* TLSX_CSR_GetRequest(TLSX* extensions)
 {
     TLSX* extension = TLSX_Find(extensions, TLSX_STATUS_REQUEST);
-    CertificateStatusRequest* csr = extension ? extension->data : NULL;
+    CertificateStatusRequest* csr = extension ?
+                              (CertificateStatusRequest*)extension->data : NULL;
 
     if (csr) {
         switch (csr->status_type) {
@@ -2231,7 +2234,8 @@ void* TLSX_CSR_GetRequest(TLSX* extensions)
 int TLSX_CSR_ForceRequest(WOLFSSL* ssl)
 {
     TLSX* extension = TLSX_Find(ssl->extensions, TLSX_STATUS_REQUEST);
-    CertificateStatusRequest* csr = extension ? extension->data : NULL;
+    CertificateStatusRequest* csr = extension ?
+                              (CertificateStatusRequest*)extension->data : NULL;
 
     if (csr) {
         switch (csr->status_type) {
@@ -2433,14 +2437,15 @@ static int TLSX_CSR2_Parse(WOLFSSL* ssl, byte* input, word16 length,
     if (!isRequest) {
 #ifndef NO_WOLFSSL_CLIENT
         TLSX* extension = TLSX_Find(ssl->extensions, TLSX_STATUS_REQUEST_V2);
-        CertificateStatusRequestItemV2* csr2 = extension ? extension->data
-                                                         : NULL;
+        CertificateStatusRequestItemV2* csr2 = extension ?
+                        (CertificateStatusRequestItemV2*)extension->data : NULL;
 
         if (!csr2) {
             /* look at context level */
 
             extension = TLSX_Find(ssl->ctx->extensions, TLSX_STATUS_REQUEST_V2);
-            csr2 = extension ? extension->data : NULL;
+            csr2 = extension ?
+                        (CertificateStatusRequestItemV2*)extension->data : NULL;
 
             if (!csr2)
                 return BUFFER_ERROR; /* unexpected extension */
@@ -2459,7 +2464,7 @@ static int TLSX_CSR2_Parse(WOLFSSL* ssl, byte* input, word16 length,
                         /* propagate nonce */
                         if (csr2->request.ocsp[0].nonceSz) {
                             OcspRequest* request =
-                                        TLSX_CSR2_GetRequest(ssl->extensions,
+                             (OcspRequest*)TLSX_CSR2_GetRequest(ssl->extensions,
                                                           csr2->status_type, 0);
 
                             if (request) {
@@ -2567,7 +2572,8 @@ int TLSX_CSR2_InitRequests(TLSX* extensions, DecodedCert* cert, byte isPeer,
                                                                      void* heap)
 {
     TLSX* extension = TLSX_Find(extensions, TLSX_STATUS_REQUEST_V2);
-    CertificateStatusRequestItemV2* csr2 = extension ? extension->data : NULL;
+    CertificateStatusRequestItemV2* csr2 = extension ?
+        (CertificateStatusRequestItemV2*)extension->data : NULL;
     int ret = 0;
 
     for (; csr2; csr2 = csr2->next) {
@@ -2602,13 +2608,15 @@ int TLSX_CSR2_InitRequests(TLSX* extensions, DecodedCert* cert, byte isPeer,
         }
     }
 
+    (void)cert;
     return ret;
 }
 
 void* TLSX_CSR2_GetRequest(TLSX* extensions, byte status_type, byte index)
 {
     TLSX* extension = TLSX_Find(extensions, TLSX_STATUS_REQUEST_V2);
-    CertificateStatusRequestItemV2* csr2 = extension ? extension->data : NULL;
+    CertificateStatusRequestItemV2* csr2 = extension ?
+                        (CertificateStatusRequestItemV2*)extension->data : NULL;
 
     for (; csr2; csr2 = csr2->next) {
         if (csr2->status_type == status_type) {
@@ -2632,7 +2640,8 @@ void* TLSX_CSR2_GetRequest(TLSX* extensions, byte status_type, byte index)
 int TLSX_CSR2_ForceRequest(WOLFSSL* ssl)
 {
     TLSX* extension = TLSX_Find(ssl->extensions, TLSX_STATUS_REQUEST_V2);
-    CertificateStatusRequestItemV2* csr2 = extension ? extension->data : NULL;
+    CertificateStatusRequestItemV2* csr2 = extension ?
+                        (CertificateStatusRequestItemV2*)extension->data : NULL;
 
     /* forces only the first one */
     if (csr2) {
@@ -3292,7 +3301,8 @@ int TLSX_AddEmptyRenegotiationInfo(TLSX** extensions, void* heap)
 static void TLSX_SessionTicket_ValidateRequest(WOLFSSL* ssl)
 {
     TLSX*          extension = TLSX_Find(ssl->extensions, TLSX_SESSION_TICKET);
-    SessionTicket* ticket    = extension ? extension->data : NULL;
+    SessionTicket* ticket    = extension ?
+                                         (SessionTicket*)extension->data : NULL;
 
     if (ticket) {
         /* TODO validate ticket timeout here! */
@@ -4086,11 +4096,12 @@ void TLSX_FreeAll(TLSX* list, void* heap)
                 break;
 
             case TLSX_STATUS_REQUEST:
-                CSR_FREE_ALL(extension->data, heap);
+                CSR_FREE_ALL((CertificateStatusRequest*)extension->data, heap);
                 break;
 
             case TLSX_STATUS_REQUEST_V2:
-                CSR2_FREE_ALL(extension->data, heap);
+                CSR2_FREE_ALL((CertificateStatusRequestItemV2*)extension->data,
+                        heap);
                 break;
 
             case TLSX_RENEGOTIATION_INFO:
@@ -4163,19 +4174,24 @@ static word16 TLSX_GetSize(TLSX* list, byte* semaphore, byte isRequest)
                 break;
 
             case TLSX_STATUS_REQUEST:
-                length += CSR_GET_SIZE(extension->data, isRequest);
+                length += CSR_GET_SIZE(
+                         (CertificateStatusRequest*)extension->data, isRequest);
                 break;
 
             case TLSX_STATUS_REQUEST_V2:
-                length += CSR2_GET_SIZE(extension->data, isRequest);
+                length += CSR2_GET_SIZE(
+                        (CertificateStatusRequestItemV2*)extension->data,
+                        isRequest);
                 break;
 
             case TLSX_RENEGOTIATION_INFO:
-                length += SCR_GET_SIZE(extension->data, isRequest);
+                length += SCR_GET_SIZE((SecureRenegotiation*)extension->data,
+                        isRequest);
                 break;
 
             case TLSX_SESSION_TICKET:
-                length += STK_GET_SIZE(extension->data, isRequest);
+                length += STK_GET_SIZE((SessionTicket*)extension->data,
+                        isRequest);
                 break;
 
             case TLSX_QUANTUM_SAFE_HYBRID:
@@ -4241,23 +4257,24 @@ static word16 TLSX_Write(TLSX* list, byte* output, byte* semaphore,
                 break;
 
             case TLSX_STATUS_REQUEST:
-                offset += CSR_WRITE(extension->data, output + offset,
-                                                                     isRequest);
+                offset += CSR_WRITE((CertificateStatusRequest*)extension->data,
+                        output + offset, isRequest);
                 break;
 
             case TLSX_STATUS_REQUEST_V2:
-                offset += CSR2_WRITE(extension->data, output + offset,
-                                                                     isRequest);
+                offset += CSR2_WRITE(
+                        (CertificateStatusRequestItemV2*)extension->data,
+                        output + offset, isRequest);
                 break;
 
             case TLSX_RENEGOTIATION_INFO:
-                offset += SCR_WRITE(extension->data, output + offset,
-                                                                     isRequest);
+                offset += SCR_WRITE((SecureRenegotiation*)extension->data,
+                        output + offset, isRequest);
                 break;
 
             case TLSX_SESSION_TICKET:
-                offset += STK_WRITE(extension->data, output + offset,
-                                                                     isRequest);
+                offset += STK_WRITE((SessionTicket*)extension->data,
+                        output + offset, isRequest);
                 break;
 
             case TLSX_QUANTUM_SAFE_HYBRID:

--- a/tests/srp.c
+++ b/tests/srp.c
@@ -117,8 +117,8 @@ static void test_SrpInit(void)
 
     /* invalid params */
     AssertIntEQ(BAD_FUNC_ARG, wc_SrpInit(NULL, SRP_TYPE_SHA, SRP_CLIENT_SIDE));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpInit(&srp, 255,          SRP_CLIENT_SIDE));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpInit(&srp, SRP_TYPE_SHA, 255            ));
+    AssertIntEQ(BAD_FUNC_ARG, wc_SrpInit(&srp, (SrpType)255, SRP_CLIENT_SIDE));
+    AssertIntEQ(BAD_FUNC_ARG, wc_SrpInit(&srp, SRP_TYPE_SHA, (SrpSide)255));
 
     /* success */
     AssertIntEQ(0, wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_CLIENT_SIDE));
@@ -240,8 +240,8 @@ static void test_SrpSetPassword(void)
 static void test_SrpGetPublic(void)
 {
     Srp srp;
-    byte public[64];
-    word32 publicSz = 0;
+    byte pub[64];
+    word32 pubSz = 0;
 
     AssertIntEQ(0, wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_CLIENT_SIDE));
     AssertIntEQ(0, wc_SrpSetUsername(&srp, username, usernameSz));
@@ -250,23 +250,23 @@ static void test_SrpGetPublic(void)
                                          salt, sizeof(salt)));
 
     /* invalid call order */
-    AssertIntEQ(SRP_CALL_ORDER_E, wc_SrpGetPublic(&srp, public, &publicSz));
+    AssertIntEQ(SRP_CALL_ORDER_E, wc_SrpGetPublic(&srp, pub, &pubSz));
 
     /* fix call order */
     AssertIntEQ(0, wc_SrpSetPassword(&srp, password, passwordSz));
 
     /* invalid params */
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetPublic(NULL, public, &publicSz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetPublic(&srp, NULL,   &publicSz));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetPublic(&srp, public, NULL));
-    AssertIntEQ(BUFFER_E,     wc_SrpGetPublic(&srp, public, &publicSz));
+    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetPublic(NULL, pub, &pubSz));
+    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetPublic(&srp, NULL,   &pubSz));
+    AssertIntEQ(BAD_FUNC_ARG, wc_SrpGetPublic(&srp, pub, NULL));
+    AssertIntEQ(BUFFER_E,     wc_SrpGetPublic(&srp, pub, &pubSz));
 
     /* success */
-    publicSz = sizeof(public);
+    pubSz = sizeof(pub);
     AssertIntEQ(0, wc_SrpSetPrivate(&srp, a, sizeof(a)));
-    AssertIntEQ(0, wc_SrpGetPublic(&srp, public, &publicSz));
-    AssertIntEQ(publicSz, sizeof(A));
-    AssertIntEQ(0, XMEMCMP(public, A, publicSz));
+    AssertIntEQ(0, wc_SrpGetPublic(&srp, pub, &pubSz));
+    AssertIntEQ(pubSz, sizeof(A));
+    AssertIntEQ(0, XMEMCMP(pub, A, pubSz));
 
     wc_SrpTerm(&srp);
 
@@ -277,16 +277,16 @@ static void test_SrpGetPublic(void)
                                          salt, sizeof(salt)));
 
     /* invalid call order */
-    AssertIntEQ(SRP_CALL_ORDER_E, wc_SrpGetPublic(&srp, public, &publicSz));
+    AssertIntEQ(SRP_CALL_ORDER_E, wc_SrpGetPublic(&srp, pub, &pubSz));
 
     /* fix call order */
     AssertIntEQ(0, wc_SrpSetVerifier(&srp, verifier, sizeof(verifier)));
 
     /* success */
     AssertIntEQ(0, wc_SrpSetPrivate(&srp, b, sizeof(b)));
-    AssertIntEQ(0, wc_SrpGetPublic(&srp, public, &publicSz));
-    AssertIntEQ(publicSz, sizeof(B));
-    AssertIntEQ(0, XMEMCMP(public, B, publicSz));
+    AssertIntEQ(0, wc_SrpGetPublic(&srp, pub, &pubSz));
+    AssertIntEQ(pubSz, sizeof(B));
+    AssertIntEQ(0, XMEMCMP(pub, B, pubSz));
 
     wc_SrpTerm(&srp);
 }

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1415,7 +1415,8 @@ static int wc_PKCS7_KariGenerateKEK(WC_PKCS7_KARI* kari,
                                     int keyWrapOID, int keyEncOID)
 {
     int ret;
-    int kSz, kdfType;
+    int kSz;
+    enum wc_HashType kdfType;
     byte*  secret;
     word32 secretSz;
 
@@ -2123,7 +2124,7 @@ static int wc_PKCS7_GenerateIV(WC_RNG* rng, byte* iv, word32 ivSz)
 
     /* input RNG is optional, init local one if input rng is NULL */
     if (rng == NULL) {
-        random = XMALLOC(sizeof(WC_RNG), NULL, DYNAMIC_TYPE_RNG);
+        random = (WC_RNG*)XMALLOC(sizeof(WC_RNG), NULL, DYNAMIC_TYPE_RNG);
         if (random == NULL)
             return MEMORY_E;
 

--- a/wolfcrypt/src/srp.c
+++ b/wolfcrypt/src/srp.c
@@ -454,12 +454,12 @@ int wc_SrpSetVerifier(Srp* srp, const byte* verifier, word32 size)
     return mp_read_unsigned_bin(&srp->auth, verifier, size);
 }
 
-int wc_SrpSetPrivate(Srp* srp, const byte* private, word32 size)
+int wc_SrpSetPrivate(Srp* srp, const byte* priv, word32 size)
 {
     mp_int p;
     int r;
 
-    if (!srp || !private || !size)
+    if (!srp || !priv || !size)
         return BAD_FUNC_ARG;
 
     if (mp_iszero(&srp->auth) == MP_YES)
@@ -468,7 +468,7 @@ int wc_SrpSetPrivate(Srp* srp, const byte* private, word32 size)
     r = mp_init(&p);
     if (r != MP_OKAY)
         return MP_INIT_E;
-    if (!r) r = mp_read_unsigned_bin(&p, private, size);
+    if (!r) r = mp_read_unsigned_bin(&p, priv, size);
     if (!r) r = mp_mod(&p, &srp->N, &srp->priv);
     if (!r) r = mp_iszero(&srp->priv) == MP_YES ? SRP_BAD_KEY_E : 0;
 


### PR DESCRIPTION
This fixes some warnings and errors when using non default build features with a C++ compiler. The configure used for the warnings and errors caught in this pull request was "./configure --enable-distro --enable-secure-renegotiation CC=g++-6".

Made the behavior on cache_status++ with secure renegotiation to stay at complete state when reached rather than wrap around.