### PR TITLE
Fixes for compiler warnings with IAR EWARM 8

### DIFF
--- a/IDE/IAR-EWARM/Projects/user_settings.h
+++ b/IDE/IAR-EWARM/Projects/user_settings.h
@@ -8,6 +8,7 @@
 #define NO_DEV_RANDOM
 #define USE_CERT_BUFFERS_2048
 #define WOLFSSL_USER_CURRTIME
+#define SIZEOF_LONG_LONG 8
 
 #define CUSTOM_RAND_GENERATE custom_rand_generate
 /*  warning "write a real random seed!!!!, just for testing now"   */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -18046,8 +18046,9 @@ WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN* chain, int idx)
             InitDecodedCert(cert, chain->certs[idx].buffer,
                                   chain->certs[idx].length, NULL);
 
-            if ((ret = ParseCertRelative(cert, CERT_TYPE, 0, NULL)) != 0)
+            if ((ret = ParseCertRelative(cert, CERT_TYPE, 0, NULL)) != 0) {
                 WOLFSSL_MSG("Failed to parse cert");
+            }
             else {
                 x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
                                                              DYNAMIC_TYPE_X509);
@@ -18677,7 +18678,7 @@ int PEM_write_bio_WOLFSSL_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 *x) {
 }
 
 
-#ifndef NO_DH
+#if defined(OPENSSL_EXTRA) && !defined(NO_DH)
 /* Intialize ctx->dh with dh's params. Return SSL_SUCCESS on ok */
 long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL_DH* dh)
 {
@@ -18718,7 +18719,7 @@ long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL_DH* dh)
 
     return pSz > 0 && gSz > 0 ? ret : SSL_FATAL_ERROR;
 }
-#endif /* NO_DH */
+#endif /* OPENSSL_EXTRA && !NO_DH */
 #endif /* HAVE_LIGHTY || HAVE_STUNNEL || WOLFSSL_MYSQL_COMPATIBLE */
 
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -4464,12 +4464,12 @@ static void roll_auth(Aes* aes, const byte* in, word32 inSz, byte* out)
     word32 remainder;
 
     /* encode the length in */
-    if (inSz <= 0xFEFF) { /* 16-bit */
+    if (inSz <= 0xFEFF) {
         authLenSz = 2;
         out[0] ^= ((inSz & 0xFF00) >> 8);
         out[1] ^=  (inSz & 0x00FF);
     }
-    else if (inSz <= 0xFFFFFF) { /* 24-bit */
+    else if (inSz <= 0xFFFFFFFF) {
         authLenSz = 6;
         out[0] ^= 0xFF; out[1] ^= 0xFE;
         out[2] ^= ((inSz & 0xFF000000) >> 24);

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -4464,12 +4464,12 @@ static void roll_auth(Aes* aes, const byte* in, word32 inSz, byte* out)
     word32 remainder;
 
     /* encode the length in */
-    if (inSz <= 0xFEFF) {
+    if (inSz <= 0xFEFF) { /* 16-bit */
         authLenSz = 2;
         out[0] ^= ((inSz & 0xFF00) >> 8);
         out[1] ^=  (inSz & 0x00FF);
     }
-    else if (inSz <= 0xFFFFFFFF) {
+    else if (inSz <= 0xFFFFFF) { /* 24-bit */
         authLenSz = 6;
         out[0] ^= 0xFF; out[1] ^= 0xFE;
         out[2] ^= ((inSz & 0xFF000000) >> 24);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3873,9 +3873,9 @@ int wc_ecc_export_x963_ex(ecc_key* key, byte* out, word32* outLen,
 #ifdef HAVE_COMP_KEY
     else
         return wc_ecc_export_x963_compressed(key, out, outLen);
-#endif
-
+#else
     return NOT_COMPILED_IN;
+#endif
 }
 #endif /* HAVE_ECC_KEY_EXPORT */
 
@@ -5239,7 +5239,8 @@ static int add_entry(int idx, ecc_point *g)
 static int build_lut(int idx, mp_int* a, mp_int* modulus, mp_digit mp,
     mp_int* mu)
 {
-   unsigned x, y, err, bitlen, lut_gap;
+   int err;
+   unsigned x, y, bitlen, lut_gap;
    mp_int tmp;
 
    if (mp_init(&tmp) != MP_OKAY)
@@ -5385,8 +5386,8 @@ static int accel_fp_mul(int idx, mp_int* k, ecc_point *R, mp_int* a,
 #else
    unsigned char kb[KB_SIZE];
 #endif
-   int      x;
-   unsigned y, z = 0, err, bitlen, bitpos, lut_gap, first;
+   int      x, err;
+   unsigned y, z = 0, bitlen, bitpos, lut_gap, first;
    mp_int   tk, order;
 
    if (mp_init_multi(&tk, &order, NULL, NULL, NULL, NULL) != MP_OKAY)
@@ -5534,8 +5535,8 @@ static int accel_fp_mul2add(int idx1, int idx2,
 #else
    unsigned char kb[2][KB_SIZE];
 #endif
-   int      x;
-   unsigned y, z, err, bitlen, bitpos, lut_gap, first, zA, zB;
+   int      x, err;
+   unsigned y, z, bitlen, bitpos, lut_gap, first, zA, zB;
    mp_int tka, tkb, order;
 
    if (mp_init_multi(&tka, &tkb, &order, NULL, NULL, NULL) != MP_OKAY)

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -815,13 +815,13 @@ int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
         return BAD_FUNC_ARG;
 
 #ifdef WOLFSSL_SMALL_STACK
-    tmp = (byte*)XMALLOC(MAX_DIGEST_SIZE, myHmac.heap, DYNAMIC_TYPE_TMP_BUFFER);
+    tmp = (byte*)XMALLOC(MAX_DIGEST_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (tmp == NULL)
         return MEMORY_E;
 
-    prk = (byte*)XMALLOC(MAX_DIGEST_SIZE, myHmac.heap, DYNAMIC_TYPE_TMP_BUFFER);
+    prk = (byte*)XMALLOC(MAX_DIGEST_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (prk == NULL) {
-        XFREE(tmp, myHmac.heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(tmp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return MEMORY_E;
     }
 #endif
@@ -873,8 +873,8 @@ int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(tmp, myHmac.heap, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(prk, myHmac.heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(tmp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(prk, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return ret;

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -50,6 +50,12 @@
 
 #else
 
+
+#if defined(__ICCARM__)
+    #include <intrinsics.h>
+#endif
+
+
 #ifdef INTEL_INTRINSICS
 
     #include <stdlib.h>      /* get intrinsic definitions */

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1415,7 +1415,8 @@ static int wc_PKCS7_KariGenerateKEK(WC_PKCS7_KARI* kari,
                                     int keyWrapOID, int keyEncOID)
 {
     int ret;
-    int kSz, kdfType;
+    int kSz;
+    enum wc_HashType kdfType;
     byte*  secret;
     word32 secretSz;
 
@@ -3571,9 +3572,9 @@ static int wc_PKCS7_DecodeUnprotectedAttributes(PKCS7* pkcs7, byte* pkiMsg,
 
         /* save attribute value bytes and size */
         if (GetSet(pkiMsg, &idx, &length, pkiMsgSz) < 0) {
-            return ASN_PARSE_E;
             XFREE(attrib->oid, pkcs7->heap, DYNAMIC_TYPE_PKCS);
             XFREE(attrib, pkcs7->heap, DYNAMIC_TYPE_PKCS);
+            return ASN_PARSE_E;
         }
 
         if ((pkiMsgSz - idx) < (word32)length) {


### PR DESCRIPTION
* Fix “wc_PKCS7_DecodeUnprotectedAttributes” return prior to free in GetSet error case.
* Fix “wc_PKCS7_KariGenerateKEK” type mismatch for kdfType.
* Fix aes.c roll_auth use of inSz over 24-bit.
* Fix ecc “build_lut”, “accel_fp_mul” and “accel_fp_mul2add” use of err as unsigned.
* Fix “wc_HKDF” use of un-initialized “myHmac” for heap.
* Fix undefined reference to __REV for IAR due to missing intrinsics.h.
* Fix build error for “wolfSSL_CTX_set_tmp_dh” if OPENSSL_EXTRA not defined and “HAVE_LIGHTY || HAVE_STUNNEL || WOLFSSL_MYSQL_COMPATIBLE”.
* Cleanup of “wolfSSL_get_chain_X509” brace..
* Cleanup SSL_CtxResourceFree use of `i` and define comments.
* Added “SIZEOF_LONG_LONG” to IAR-EWARM user_settings.h to support word64 (required for SHA512, etc).