### PR TITLE
random port for MinGW with unit tests

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -529,7 +529,6 @@ static void test_wolfSSL_SetTmpDH_buffer(void)
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
-    printf("SUCCESS4\n");
 #endif
 }
 
@@ -637,8 +636,7 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
     ctx = wolfSSL_CTX_new(method);
 
 #if defined(USE_WINDOWS_API)
-    /* Generate random port for testing */
-    port = GetRandomPort();
+    port = ((func_args*)args)->signal->port;
 #elif defined(NO_MAIN_DRIVER) && !defined(WOLFSSL_SNIFFER) && \
      !defined(WOLFSSL_MDK_SHELL) && !defined(WOLFSSL_TIRTOS)
     /* Let tcp_listen assign port */
@@ -885,8 +883,7 @@ static THREAD_RETURN WOLFSSL_THREAD run_wolfssl_server(void* args)
     ((func_args*)args)->return_code = TEST_FAIL;
 
 #if defined(USE_WINDOWS_API)
-    /* Generate random port for testing */
-    port = GetRandomPort();
+    port = ((func_args*)args)->signal->port;
 #elif defined(NO_MAIN_DRIVER) && !defined(WOLFSSL_SNIFFER) && \
      !defined(WOLFSSL_MDK_SHELL) && !defined(WOLFSSL_TIRTOS)
     /* Let tcp_listen assign port */
@@ -1149,6 +1146,11 @@ static void test_wolfSSL_read_write(void)
     StartTCP();
     InitTcpReady(&ready);
 
+#if defined(USE_WINDOWS_API)
+    /* use RNG to get random port if using windows */
+    ready.port = GetRandomPort();
+#endif
+
     server_args.signal = &ready;
     client_args.signal = &ready;
 
@@ -1185,6 +1187,11 @@ static void test_wolfSSL_dtls_export(void)
 #endif
 
     InitTcpReady(&ready);
+
+#if defined(USE_WINDOWS_API)
+    /* use RNG to get random port if using windows */
+    ready.port = GetRandomPort();
+#endif
 
     /* set using dtls */
     XMEMSET(&server_cbf, 0, sizeof(callback_functions));
@@ -1241,6 +1248,12 @@ static void test_wolfSSL_client_server(callback_functions* client_callbacks,
 
     /* RUN Server side */
     InitTcpReady(&ready);
+
+#if defined(USE_WINDOWS_API)
+    /* use RNG to get random port if using windows */
+    ready.port = GetRandomPort();
+#endif
+
     server_args.signal = &ready;
     client_args.signal = &ready;
     start_thread(run_wolfssl_server, &server_args, &serverThread);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -664,6 +664,8 @@ static INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
 
 static INLINE void tcp_socket(SOCKET_T* sockfd, int udp, int sctp)
 {
+    (void)sctp;
+
     if (udp)
         *sockfd = socket(AF_INET_V, SOCK_DGRAM, IPPROTO_UDP);
 #ifdef WOLFSSL_SCTP


### PR DESCRIPTION
This is fixes for the default MinGW build "./configure && make check". Was using Msys to test.

Minor issues I ran into and made note of for a later time where:

First with --enable-distro there is a complaint about _strnicmp in types.h, I believe this should be strnicmp with MinGW but need to test more. Visual Studio was fine with using _strnicmp.

Second issue is --enable-sessionexport --enable-dtls could use work to make it easier to compile. The issues ran into is with inet_pton and inet_ntop which can currently be overridden by mapping the macros XINET_NTOP and XINET_PTON.