### PR TITLE
removes request->nonceSz check to fully validate response->nonce.

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9955,7 +9955,7 @@ int CompareOcspReqResp(OcspRequest* req, OcspResponse* resp)
 
     /* Nonces are not critical. The responder may not necessarily add
      * the nonce to the response. */
-    if (req->nonceSz && resp->nonceSz != 0) {
+    if (resp->nonceSz != 0) {
         cmp = req->nonceSz - resp->nonceSz;
         if (cmp != 0)
         {


### PR DESCRIPTION
If req->nonceSz is 0, the nonce check will be skipped. In case of an OCSP response replay attack, the response probably would not contain a nonce, but it might contain and we can detect the attack this way.