### PR TITLE
Remove toolchain level define from OS_TCP section

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -555,7 +555,6 @@ static char *fgets(char *buff, int sz, FILE *fp)
 
 #define NO_WOLFSSL_DIR
 #define NO_WRITEV
-#define WOLFSSL_HAVE_MIN
 #define USE_FAST_MATH
 #define TFM_TIMING_RESISTANT
 #define NO_MAIN_DRIVER


### PR DESCRIPTION
Tested on LPC Xpresso w/ FreeRTOS TCP 
Tested on Makefile project using FreeRTOS TCP

The define for WOLFSSL_HAVE_MIN is incorrect when defined at the OS_TCP level. This should be defined by the user if applicable for the toolchain in use.