### PR TITLE
run peek last error line test only when NO_OLD_TLS is not defined

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -2649,7 +2649,8 @@ static void test_wolfSSL_CTX_add_extra_chain_cert(void)
 static void test_wolfSSL_ERR_peek_last_error_line(void)
 {
     #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
-       !defined(NO_FILESYSTEM) && defined(DEBUG_WOLFSSL)
+       !defined(NO_FILESYSTEM) && defined(DEBUG_WOLFSSL) && \
+       !defined(NO_OLD_TLS)
     tcp_ready ready;
     func_args client_args;
     func_args server_args;


### PR DESCRIPTION
Test case depends on being able to have a TLS version mismatch. This requires the test to not be run when the macro NO_OLD_TLS is defined.