### PR TITLE
better compatibility with printing errors to a file

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2721,6 +2721,12 @@ void wolfSSL_ERR_print_errors_fp(FILE* fp, int err)
     fprintf(fp, "%s", data);
 }
 
+#if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
+void wolfSSL_ERR_dump_errors_fp(FILE* fp)
+{
+    wc_ERR_print_errors_fp(fp);
+}
+#endif
 #endif
 
 
@@ -8287,6 +8293,10 @@ int wolfSSL_Cleanup(void)
 #if defined(HAVE_ECC) && defined(FP_ECC)
     wc_ecc_fp_free();
 #endif
+
+    if (wolfCrypt_Cleanup() != 0) {
+        WOLFSSL_MSG("Error with wolfCrypt_Cleanup call");
+    }
 
     return ret;
 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8296,6 +8296,7 @@ int wolfSSL_Cleanup(void)
 
     if (wolfCrypt_Cleanup() != 0) {
         WOLFSSL_MSG("Error with wolfCrypt_Cleanup call");
+        ret = WC_CLEANUP_E;
     }
 
     return ret;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20469,13 +20469,15 @@ unsigned long wolfSSL_ERR_peek_last_error_line(const char **file, int *line)
     (void)line;
     (void)file;
 #if defined(DEBUG_WOLFSSL)
-    if (line != NULL) {
-        *line = (int)wc_last_error_line;
+    {
+        int ret;
+
+        if ((ret = wc_PeekErrorNode(-1, file, NULL, line)) < 0) {
+            WOLFSSL_MSG("Issue peeking at error node in queue");
+            return 0;
+        }
+        return (unsigned long)ret;
     }
-    if (file != NULL) {
-        *file = (char*)wc_last_error_file;
-    }
-    return wc_last_error;
 #else
     return (unsigned long)(0 - NOT_COMPILED_IN);
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -2703,7 +2703,6 @@ static void test_wolfSSL_ERR_peek_last_error_line(void)
     ERR_print_errors_fp(stdout);
     printf("Done testing print out\n\n");
     fflush(stdout);
-    wolfSSL_Cleanup();
     #endif /* defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
              !defined(NO_FILESYSTEM) && !defined(DEBUG_WOLFSSL) */
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -2698,6 +2698,12 @@ static void test_wolfSSL_ERR_peek_last_error_line(void)
 #endif
 
     printf(resultFmt, passed);
+
+    printf("\nTesting error print out\n");
+    ERR_print_errors_fp(stdout);
+    printf("Done testing print out\n\n");
+    fflush(stdout);
+    wolfSSL_Cleanup();
     #endif /* defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
              !defined(NO_FILESYSTEM) && !defined(DEBUG_WOLFSSL) */
 }

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -489,6 +489,10 @@ int benchmark_test(void *args)
     }
 #endif
 
+    if (wolfCrypt_Cleanup() != 0) {
+        printf("error with wolfCrypt_Cleanup\n");
+    }
+
 #if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)
     ShowMemoryTracker();
 #endif

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -407,6 +407,9 @@ const char* wc_GetErrorString(int error)
     case BAD_KEYWRAP_IV_E:
         return "Decrypted AES key wrap IV does not match expected";
 
+    case WC_CLEANUP_E:
+        return "wolfcrypt cleanup failed";
+
     default:
         return "unknown error number";
 

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -247,8 +247,8 @@ void WOLFSSL_ERROR(int error)
                 if (error < 0) error = error - (2*error); /*get absolute value*/
                 wc_last_error      = (unsigned long)error;
                 wc_last_error_line = (unsigned long)line;
-                XMEMSET((char*)wc_last_error_file, 0, sizeof(file));
-                if (XSTRLEN(file) < sizeof(file)) {
+                XMEMSET((char*)wc_last_error_file, 0, sizeof(wc_last_error_file));
+                if (XSTRLEN(file) < sizeof(wc_last_error_file)) {
 	                XSTRNCPY((char*)wc_last_error_file, file, XSTRLEN(file));
                 }
                 sprintf(buffer, "wolfSSL error occurred, error = %d line:%d file:%s",
@@ -333,10 +333,26 @@ int wc_AddErrorNode(int error, int line, char* buf, char* file)
         return MEMORY_E;
     }
     else {
+        int sz;
+
         XMEMSET(err, 0, sizeof(struct wc_error_queue));
         err->heap = (void*)wc_error_heap;
-        XMEMCPY(err->error, buf, WOLFSSL_MAX_ERROR_SZ - 1);
-        XMEMCPY(err->file, file, WOLFSSL_MAX_ERROR_SZ - 1);
+        sz = (int)XSTRLEN(buf);
+        if (sz > WOLFSSL_MAX_ERROR_SZ - 1) {
+            sz = WOLFSSL_MAX_ERROR_SZ - 1;
+        }
+        if (sz > 0) {
+            XMEMCPY(err->error, buf, sz);
+        }
+
+        sz = (int)XSTRLEN(file);
+        if (sz > WOLFSSL_MAX_ERROR_SZ - 1) {
+            sz = WOLFSSL_MAX_ERROR_SZ - 1;
+        }
+        if (sz > 0) {
+            XMEMCPY(err->file, file, sz);
+        }
+
         err->value = error;
         err->line  = line;
 

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -97,11 +97,34 @@ int wolfCrypt_Init(void)
             wolfSSL_EVP_init();
     #endif
 
+    #if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
+        if ((ret = wc_LoggingInit()) != 0) {
+            WOLFSSL_MSG("Error creating logging mutex");
+            return ret;
+        }
+    #endif
+
         initRefCount = 1;
     }
 
     return ret;
 }
+
+
+/* return success value is the same as wolfCrypt_Init */
+int wolfCrypt_Cleanup(void)
+{
+    int ret = 0;
+
+    WOLFSSL_ENTER("wolfCrypt_Cleanup");
+
+    #if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
+        ret = wc_LoggingCleanup();
+    #endif
+
+    return ret;
+}
+
 
 wolfSSL_Mutex* wc_InitAndAllocMutex()
 {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -101,6 +101,9 @@
 #ifdef WOLFSSL_ASYNC_CRYPT
     #include <wolfssl/wolfcrypt/async.h>
 #endif
+#if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
+    #include <wolfssl/wolfcrypt/logging.h>
+#endif
 
 #ifdef _MSC_VER
     /* 4996 warning to use MS extensions e.g., strcpy_s instead of strncpy */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -326,6 +326,10 @@ int wolfcrypt_test(void* args)
 
     wolfCrypt_Init();
 
+#if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
+    wc_SetLoggingHeap(HEAP_HINT);
+#endif
+
 #ifdef HAVE_FIPS
     wolfCrypt_SetCb_fips(myFipsCb);
 #endif
@@ -716,6 +720,10 @@ int wolfcrypt_test(void* args)
     else
         printf( "PKCS7encrypted test passed!\n");
 #endif
+
+    if ((ret = wolfCrypt_Cleanup())!= 0) {
+        return err_sys("Error with wolfCrypt_Cleanup!\n", ret);
+    }
 
 #if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)
     ShowMemoryTracker();

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -106,8 +106,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define SSL_get_shared_ciphers(ctx,buf,len) \
                                 strncpy(buf, "Not Implemented, SSLv2 only", len)
 
-/* @TODO */
-#define ERR_print_errors_fp(file) wolfSSL_ERR_print_errors_fp((file))
+#define ERR_print_errors_fp(file) wolfSSL_ERR_dump_errors_fp((file))
 
 /* at the moment only returns ok */
 #define SSL_get_verify_result         wolfSSL_get_verify_result

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -891,6 +891,9 @@ enum {
    since not using thread storage error queue */
 #include <stdio.h>
 WOLFSSL_API void  wolfSSL_ERR_print_errors_fp(FILE*, int err);
+#if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
+WOLFSSL_API void wolfSSL_ERR_dump_errors_fp(FILE* fp);
+#endif
 #endif
 
 enum { /* ssl Constants */

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -180,6 +180,7 @@ enum {
 
     BAD_KEYWRAP_ALG_E   = -239,
     BAD_KEYWRAP_IV_E    = -240,  /* Decrypted AES key wrap IV incorrect */
+    WC_CLEANUP_E        = -241,  /* wolfcrypt cleanup failed */
 
     MIN_CODE_E          = -300   /* errors -101 - -299 */
 

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -46,6 +46,26 @@ typedef void (*wolfSSL_Logging_cb)(const int logLevel,
 
 WOLFSSL_API int wolfSSL_SetLoggingCb(wolfSSL_Logging_cb log_function);
 
+#if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
+    typedef struct wc_error_queue wc_error_queue;
+
+    /* make these variables global and declare them in logging.c */
+    extern volatile char          wc_last_error_file[80];
+    extern volatile unsigned long wc_last_error_line;
+    extern volatile unsigned long wc_last_error;
+    extern volatile void*         wc_error_heap;
+    extern volatile wc_error_queue* wc_errors;
+
+    WOLFSSL_LOCAL int wc_LoggingInit(void);
+    WOLFSSL_LOCAL int wc_LoggingCleanup(void);
+    WOLFSSL_LOCAL int wc_AddErrorNode(int error, int line, char* buf,
+            char* file);
+    WOLFSSL_API   int wc_SetLoggingHeap(void* h);
+    #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
+        WOLFSSL_API   void wc_ERR_print_errors_fp(FILE* fp);
+    #endif
+#endif /* defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE) */
+
 #ifdef DEBUG_WOLFSSL
     /* a is prepended to m and b is appended, creating a log msg a + m + b */
     #define WOLFSSL_LOG_CAT(a, m, b) #a " " m " "  #b
@@ -56,11 +76,6 @@ WOLFSSL_API int wolfSSL_SetLoggingCb(wolfSSL_Logging_cb log_function);
         WOLFSSL_MSG(WOLFSSL_LOG_CAT(wolfSSL Stub, m, not implemented))
 
 #if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
-    /* make these variables global and declare them in logging.c */
-    extern volatile char          wc_last_error_file[80];
-    extern volatile unsigned long wc_last_error_line;
-    extern volatile unsigned long wc_last_error;
-
     void WOLFSSL_ERROR_LINE(int err, const char* func, unsigned int line,
             const char* file, void* ctx);
     #define WOLFSSL_ERROR(x) WOLFSSL_ERROR_LINE((x), __func__, __LINE__, __FILE__,NULL)

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -47,15 +47,6 @@ typedef void (*wolfSSL_Logging_cb)(const int logLevel,
 WOLFSSL_API int wolfSSL_SetLoggingCb(wolfSSL_Logging_cb log_function);
 
 #if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
-    typedef struct wc_error_queue wc_error_queue;
-
-    /* make these variables global and declare them in logging.c */
-    extern volatile char          wc_last_error_file[80];
-    extern volatile unsigned long wc_last_error_line;
-    extern volatile unsigned long wc_last_error;
-    extern volatile void*         wc_error_heap;
-    extern volatile wc_error_queue* wc_errors;
-
     WOLFSSL_LOCAL int wc_LoggingInit(void);
     WOLFSSL_LOCAL int wc_LoggingCleanup(void);
     WOLFSSL_LOCAL int wc_AddErrorNode(int error, int line, char* buf,

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -60,6 +60,8 @@ WOLFSSL_API int wolfSSL_SetLoggingCb(wolfSSL_Logging_cb log_function);
     WOLFSSL_LOCAL int wc_LoggingCleanup(void);
     WOLFSSL_LOCAL int wc_AddErrorNode(int error, int line, char* buf,
             char* file);
+    WOLFSSL_LOCAL int wc_PeekErrorNode(int index, const char **file,
+            const char **reason, int *line);
     WOLFSSL_API   int wc_SetLoggingHeap(void* h);
     #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
         WOLFSSL_API   void wc_ERR_print_errors_fp(FILE* fp);

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -340,7 +340,8 @@
         DYNAMIC_TYPE_PKCS         = 58,
         DYNAMIC_TYPE_MUTEX        = 59,
         DYNAMIC_TYPE_PKCS7        = 60,
-        DYNAMIC_TYPE_ASN1         = 61
+        DYNAMIC_TYPE_ASN1         = 61,
+        DYNAMIC_TYPE_LOG          = 62
 	};
 
 	/* max error buffer string size */

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -186,6 +186,7 @@ WOLFSSL_API int wc_UnLockMutex(wolfSSL_Mutex*);
 
 /* main crypto initialization function */
 WOLFSSL_API int wolfCrypt_Init(void);
+WOLFSSL_API int wolfCrypt_Cleanup(void);
 
 /* filesystem abstraction layer, used by ssl.c */
 #ifndef NO_FILESYSTEM


### PR DESCRIPTION
This creates a queue system to handle logging and keeping track of errors. The queue is only populated when DEBUG_WOLFSSL is defined.

Also added with this pull request is wolfCrypt_Cleanup and a mutex in logging.c for thread safety when accessing the queue.

One point to bring up is if there should be a max queue size? As is the queue can grow to handle any number of error logs.