### PR TITLE
open test file in binary mode

### DIFF
--- a/tests/suites.c
+++ b/tests/suites.c
@@ -361,7 +361,7 @@ static void test_harness(void* vargs)
         fname = args->argv[1];
     }
 
-    file = fopen(fname, "r");
+    file = fopen(fname, "rb");
     if (file == NULL) {
         fprintf(stderr, "unable to open %s\n", fname);
         args->return_code = 1;


### PR DESCRIPTION
This is opens test files in binary mode from wolfssl-root/tests/ . Is to resolve GitHub issue #685.