### PR TITLE
pass heap hint to temporary public ECC key

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3160,8 +3160,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
    if (err == MP_OKAY) {
        int loop_check = 0;
        ecc_key pubkey;
-
-       if (wc_ecc_init(&pubkey) == MP_OKAY) {
+       if (wc_ecc_init_ex(&pubkey, key->heap, INVALID_DEVID) == MP_OKAY) {
            for (;;) {
                if (++loop_check > 64) {
                     err = RNG_FAILURE_E;


### PR DESCRIPTION
This fixes a case in wc_ecc_sign_hash_ex where a temporary ECC key was made without the heap hint. Found by using iprofiler and running the example server with the cipher suite ECDHE-ECDSA-AES128-GCM-SHA256. 