### PR TITLE
Added code to automatically populate supported ECC curve information

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1340,6 +1340,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     wolfSSL_KeepArrays(ssl);
     #endif
 
+    #if 0 /* all enabled and supported ECC curves will be added automatically */
     #ifdef HAVE_SUPPORTED_CURVES /* add curves to supported curves extension */
         if (wolfSSL_UseSupportedCurve(ssl, WOLFSSL_ECC_SECP256R1)
                 != SSL_SUCCESS) {
@@ -1377,6 +1378,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             wolfSSL_CTX_free(ctx);
             err_sys("unable to set curve secp160r1");
         }
+    #endif
     #endif
 
     #ifdef HAVE_SESSION_TICKET
@@ -1732,6 +1734,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         wolfSSL_set_SessionTicket_cb(sslResume, sessionTicketCB,
                                     (void*)"resumed session");
 #endif
+    #if 0 /* all enabled and supported ECC curves will be added automatically */
     #ifdef HAVE_SUPPORTED_CURVES /* add curves to supported curves extension */
         if (wolfSSL_UseSupportedCurve(sslResume, WOLFSSL_ECC_SECP256R1)
                 != SSL_SUCCESS) {
@@ -1769,6 +1772,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             wolfSSL_CTX_free(ctx);
             err_sys("unable to set curve secp160r1");
         }
+    #endif
     #endif
 
 #ifndef WOLFSSL_CALLBACKS

--- a/src/internal.c
+++ b/src/internal.c
@@ -3487,6 +3487,9 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
 #ifdef HAVE_ALPN
     ssl->alpn_client_list = NULL;
 #endif
+#ifdef HAVE_SUPPORTED_CURVES
+    ssl->options.userCurves = ctx->userCurves;
+#endif
 #endif /* HAVE_TLS_EXTENSIONS */
 
     /* default alert state (none) */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1401,6 +1401,8 @@ int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, word16 name)
             return BAD_FUNC_ARG;
     }
 
+    ssl->options.userCurves = 1;
+
     return TLSX_UseSupportedCurve(&ssl->extensions, name, ssl->heap);
 }
 
@@ -1430,6 +1432,8 @@ int wolfSSL_CTX_UseSupportedCurve(WOLFSSL_CTX* ctx, word16 name)
         default:
             return BAD_FUNC_ARG;
     }
+
+    ctx->userCurves = 1;
 
     return TLSX_UseSupportedCurve(&ctx->extensions, name, ctx->heap);
 }

--- a/src/tls.c
+++ b/src/tls.c
@@ -4493,7 +4493,6 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
 
     /* server will add extension depending on whats parsed from client */
     if (!isServer) {
-
 #ifdef HAVE_QSH
         /* test if user has set a specific scheme already */
         if (!ssl->user_set_QSHSchemes) {
@@ -4564,8 +4563,9 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                 }
             }
         }
-#else
-    #if defined(HAVE_ECC) && defined(HAVE_SUPPORTED_CURVES)
+#endif
+
+#if defined(HAVE_ECC) && defined(HAVE_SUPPORTED_CURVES)
         if (!ssl->options.userCurves && !ssl->ctx->userCurves) {
         #if defined(HAVE_ECC160) || defined(HAVE_ALL_CURVES)
             #ifndef NO_ECC_SECP
@@ -4638,8 +4638,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
             #endif
         #endif
         }
-    #endif /* HAVE_ECC && HAVE_SUPPORTED_CURVES */
-#endif
+#endif /* HAVE_ECC && HAVE_SUPPORTED_CURVES */
     } /* is not server */
 
     (void)public_key;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2034,6 +2034,9 @@ struct WOLFSSL_CTX {
         void*              ticketEncCtx;  /* session encrypt context */
         int                ticketHint;    /* ticket hint in seconds */
     #endif
+    #ifdef HAVE_SUPPORTED_CURVES
+        byte userCurves;                  /* indicates user called wolfSSL_CTX_UseSupportedCurve */
+    #endif
 #endif
 #ifdef ATOMIC_USER
     CallbackMacEncrypt    MacEncryptCb;    /* Atomic User Mac/Encrypt Cb */
@@ -2447,6 +2450,9 @@ typedef struct Options {
 #endif
 #endif
     word16            haveEMS:1;          /* using extended master secret */
+#if defined(HAVE_TLS_EXTENSIONS) && defined(HAVE_SUPPORTED_CURVES)
+    word16            userCurves:1;       /* indicates user called wolfSSL_UseSupportedCurve */
+#endif
 
     /* need full byte values for this section */
     byte            processReply;           /* nonblocking resume */


### PR DESCRIPTION
Unless already provided by user via wolfSSL_CTX_UseSupportedCurve or wolfSSL_UseSupportedCurve.