### PR TITLE
Fixes for building with NO_AES_DECRYPT

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3571,7 +3571,7 @@ static int wolfssl_decrypt_buffer_key(DerBuffer* der, byte* password,
         ret = wc_Des3_CbcDecryptWithKey(der->buffer, der->buffer, der->length,
                                         key, info->iv);
 #endif /* NO_DES3 */
-#if !defined(NO_AES) && defined(HAVE_AES_CBC)
+#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(HAVE_AES_DECRYPT)
     if (XSTRNCMP(info->name, EVP_AES_128_CBC, EVP_AES_SIZE) == 0)
         ret = wc_AesCbcDecryptWithKey(der->buffer, der->buffer, der->length,
                                       key, AES_128_KEY_SIZE, info->iv);
@@ -3581,7 +3581,7 @@ static int wolfssl_decrypt_buffer_key(DerBuffer* der, byte* password,
     else if (XSTRNCMP(info->name, EVP_AES_256_CBC, EVP_AES_SIZE) == 0)
         ret = wc_AesCbcDecryptWithKey(der->buffer, der->buffer, der->length,
                                       key, AES_256_KEY_SIZE, info->iv);
-#endif /* !NO_AES && HAVE_AES_CBC */
+#endif /* !NO_AES && HAVE_AES_CBC && HAVE_AES_DECRYPT */
 
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -637,6 +637,7 @@ void bench_aes(int show)
     }
 #endif
 
+#ifdef HAVE_AES_DECRYPT
     ret = wc_AesSetKey(&enc, key, 16, iv, AES_DECRYPTION);
     if (ret != 0) {
         printf("AesSetKey failed, ret = %d\n", ret);
@@ -663,6 +664,8 @@ void bench_aes(int show)
         SHOW_INTEL_CYCLES
         printf("\n");
     }
+#endif /* HAVE_AES_DECRYPT */
+
 #ifdef WOLFSSL_ASYNC_CRYPT
     wc_AesAsyncFree(&enc);
 #endif
@@ -1078,7 +1081,7 @@ void bench_chacha(void)
 }
 #endif /* HAVE_CHACHA*/
 
-#if( defined( HAVE_CHACHA ) && defined( HAVE_POLY1305 ) )
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
 void bench_chacha20_poly1305_aead(void)
 {
     double start, total, persec;

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -324,7 +324,7 @@ void wc_AesAsyncFree(Aes* aes)
 #endif /* WOLFSSL_AES_DIRECT || HAVE_AESGCM || HAVE_AESCCM */
 
 #ifdef HAVE_AES_DECRYPT
-    #if defined(WOLFSSL_AES_DIRECT) || defined(HAVE_AESGCM)
+    #if defined(WOLFSSL_AES_DIRECT) || defined(HAVE_AESCCM)
     static int wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
     {
         int ret = 0;
@@ -364,7 +364,7 @@ void wc_AesAsyncFree(Aes* aes)
     #endif /* WOLFSSL_STM32_CUBEMX */
         return ret;
     }
-    #endif /* WOLFSSL_AES_DIRECT || HAVE_AESGCM */
+    #endif /* WOLFSSL_AES_DIRECT || HAVE_AESCCM */
 #endif /* HAVE_AES_DECRYPT */
 
 #elif defined(HAVE_COLDFIRE_SEC)
@@ -720,6 +720,7 @@ static const word32 Te[4][256] = {
 }
 };
 
+#ifdef HAVE_AES_DECRYPT
 static const word32 Td[4][256] = {
 {
     0x51f4a750U, 0x7e416553U, 0x1a17a4c3U, 0x3a275e96U,
@@ -1024,6 +1025,7 @@ static const byte Td4[256] =
     0x17U, 0x2bU, 0x04U, 0x7eU, 0xbaU, 0x77U, 0xd6U, 0x26U,
     0xe1U, 0x69U, 0x14U, 0x63U, 0x55U, 0x21U, 0x0cU, 0x7dU,
 };
+#endif /* HAVE_AES_DECRYPT */
 
 #define GETBYTE(x, y) (word32)((byte)((x) >> (8 * (y))))
 
@@ -1925,6 +1927,8 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
                     Td[3][Te[1][GETBYTE(rk[3], 0)] & 0xff];
             }
         }
+#else
+        (void)dir;
 #endif /* HAVE_AES_DECRYPT */
 
         return wc_AesSetIV(aes, iv);
@@ -4325,7 +4329,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 }
 
 
-#ifdef HAVE_AES_DECRYPT
+#if defined(HAVE_AES_DECRYPT) || defined(HAVE_AESGCM_DECRYPT)
 int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                    const byte* iv, word32 ivSz,
                    const byte* authTag, word32 authTagSz,
@@ -4429,7 +4433,7 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 #endif  /* FREESCALE_LTC_AES_GCM */
 }
 
-#endif /* HAVE_AES_DECRYPT */
+#endif /* HAVE_AES_DECRYPT || HAVE_AESGCM_DECRYPT */
 
 WOLFSSL_API int wc_GmacSetKey(Gmac* gmac, const byte* key, word32 len)
 {

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -32,6 +32,7 @@
 
 
 #if !defined(NO_AES) && defined(HAVE_AES_CBC)
+#ifdef HAVE_AES_DECRYPT
 int wc_AesCbcDecryptWithKey(byte* out, const byte* in, word32 inSz,
                                   const byte* key, word32 keySz, const byte* iv)
 {
@@ -58,6 +59,7 @@ int wc_AesCbcDecryptWithKey(byte* out, const byte* in, word32 inSz,
 
     return ret;
 }
+#endif /* HAVE_AES_DECRYPT */
 
 int wc_AesCbcEncryptWithKey(byte* out, const byte* in, word32 inSz,
                             const byte* key, word32 keySz, const byte* iv)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2868,11 +2868,12 @@ int aes_test(void)
 {
 #if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_COUNTER)
     Aes enc;
-    Aes dec;
-
     byte cipher[AES_BLOCK_SIZE * 4];
+#ifdef HAVE_AES_DECRYPT
+    Aes dec;
     byte plain [AES_BLOCK_SIZE * 4];
 #endif
+#endif /* HAVE_AES_CBC || WOLFSSL_AES_COUNTER */
     int  ret = 0;
 
 #ifdef HAVE_AES_CBC
@@ -2900,9 +2901,11 @@ int aes_test(void)
     ret = wc_AesSetKey(&enc, key, AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
     if (ret != 0)
         return -1001;
+#ifdef HAVE_AES_DECRYPT
     ret = wc_AesSetKey(&dec, key, AES_BLOCK_SIZE, iv, AES_DECRYPTION);
     if (ret != 0)
         return -1002;
+#endif
 
     ret = wc_AesCbcEncrypt(&enc, cipher, msg,   AES_BLOCK_SIZE);
     if (ret != 0)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -669,8 +669,9 @@ typedef byte word24[3];
     #define BUILD_DES3
 #endif
 
-#ifdef NO_AES
+#if defined(NO_AES) || defined(NO_AES_DECRYPT)
     #define AES_BLOCK_SIZE 16
+    #undef  BUILD_AES
 #else
     #undef  BUILD_AES
     #define BUILD_AES


### PR DESCRIPTION
Added new HAVE_AESGCM_DECRYPT to allow AES GCM Decrypt with NO_AES_DECRYPT defined, since GCM uses only encrypt routine. Only allow TLS AES if NO_AES_DECRYPT is not defined.