### PR TITLE
Small Fixes for Multicast

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -329,7 +329,8 @@ static INLINE void c16toa(word16 u16, byte* c)
 
 
 #if !defined(NO_OLD_TLS) || defined(HAVE_CHACHA) || defined(HAVE_AESCCM) \
-    || defined(HAVE_AESGCM) || defined(WOLFSSL_SESSION_EXPORT)
+    || defined(HAVE_AESGCM) || defined(WOLFSSL_SESSION_EXPORT) \
+    || defined(WOLFSSL_DTLS)
 /* convert 32 bit integer to opaque */
 static INLINE void c32toa(word32 u32, byte* c)
 {
@@ -4012,7 +4013,7 @@ void FreeSSL(WOLFSSL* ssl, void* heap)
 
 
 #if !defined(NO_OLD_TLS) || defined(HAVE_CHACHA) || defined(HAVE_AESCCM) \
-    || defined(HAVE_AESGCM)
+    || defined(HAVE_AESGCM) || defined(WOLFSSL_DTLS)
 static INLINE void GetSEQIncrement(WOLFSSL* ssl, int verify, word32 seq[2])
 {
     if (verify) {
@@ -4116,6 +4117,7 @@ DtlsMsg* DtlsMsgNew(word32 sz, void* heap)
 {
     DtlsMsg* msg = NULL;
 
+    (void)heap;
     msg = (DtlsMsg*)XMALLOC(sizeof(DtlsMsg), heap, DYNAMIC_TYPE_DTLS_MSG);
 
     if (msg != NULL) {
@@ -4172,6 +4174,7 @@ static DtlsFrag* CreateFragment(word32* begin, word32 end, const byte* data,
     DtlsFrag* newFrag;
     word32 added = end - *begin + 1;
 
+    (void)heap;
     newFrag = (DtlsFrag*)XMALLOC(sizeof(DtlsFrag), heap,
                                  DYNAMIC_TYPE_DTLS_FRAG);
     if (newFrag != NULL) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7654,6 +7654,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
             WOLFSSL_ENTER("DTLSv1_2_client_method_ex");
             if (method)
                 InitSSL_Method(method, MakeDTLSv1_2());
+            (void)heap;
             return method;
         }
     #endif
@@ -8005,6 +8006,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                 InitSSL_Method(method, MakeDTLSv1_2());
                 method->side = WOLFSSL_SERVER_END;
             }
+            (void)heap;
             return method;
         }
     #endif

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -339,7 +339,13 @@ int benchmark_test(void *args)
 
 #if defined(HAVE_LOCAL_RNG)
     {
-        int rngRet = wc_InitRng(&rng);
+        int rngRet;
+
+#ifndef HAVE_FIPS
+        rngRet = wc_InitRng_ex(&rng, HEAP_HINT);
+#else
+        rngRet = wc_InitRng(&rng);
+#endif
         if (rngRet < 0) {
             printf("InitRNG failed\n");
             return rngRet;
@@ -538,7 +544,11 @@ void bench_rng(void)
 #endif
 
 #ifndef HAVE_LOCAL_RNG
+#ifndef HAVE_FIPS
+    ret = wc_InitRng_ex(&rng, HEAP_HINT);
+#else
     ret = wc_InitRng(&rng);
+#endif
     if (ret < 0) {
         printf("InitRNG failed\n");
         return;

--- a/wolfcrypt/src/wolfmath.c
+++ b/wolfcrypt/src/wolfmath.c
@@ -38,6 +38,7 @@
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
 
+#if defined(USE_FAST_MATH) || !defined(NO_BIG_INT)
 
 int get_digit_count(mp_int* a)
 {
@@ -102,3 +103,5 @@ int mp_rand(mp_int* a, int digits, WC_RNG* rng)
 
     return ret;
 }
+
+#endif

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -150,6 +150,11 @@
     #endif
 #endif
 
+#ifndef CHAR_BIT
+    /* Needed for DTLS without big math */
+    #include <limits.h>
+#endif
+
 
 #ifdef HAVE_LIBZ
     #include "zlib.h"


### PR DESCRIPTION
Some small fixes for Lean PSK and DTLS. This will affect the multicast work.
1. Opt-out the wolfmath code if not using big integers.
2. Opt-in a few functions when using lean PSK and DTLS.
3. Add a couple (void)heap to hush the compiler for usused variables in lean PSK.
4. Add include limits.h to internal.h if CHAR_BIT isn't defined. This is mainly for DTLS with lean PSK.