### PR TITLE
updates for TIRTOS build following release 3.10.0

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -3850,7 +3850,7 @@ void FreeHandshakeResources(WOLFSSL* ssl)
     wc_ShaFree(&ssl->hsHashes->hashSha);
 #endif
 #ifndef NO_SHA256
-    wc_Sha256Free(&ssl->hsHashes->hashSha25);
+    wc_Sha256Free(&ssl->hsHashes->hashSha256);
 #endif
 
 #ifdef HAVE_SECURE_RENEGOTIATION

--- a/tirtos/packages/ti/net/wolfssl/package.bld
+++ b/tirtos/packages/ti/net/wolfssl/package.bld
@@ -41,6 +41,7 @@ var wolfSSLObjList = [
     "wolfcrypt/src/sha512.c",
     "wolfcrypt/src/tfm.c",
     "wolfcrypt/src/wc_port.c",
+    "wolfcrtyp/src/wolfmath.c",
 
     "src/internal.c",
     "src/io.c",

--- a/tirtos/packages/ti/net/wolfssl/package.bld
+++ b/tirtos/packages/ti/net/wolfssl/package.bld
@@ -41,7 +41,7 @@ var wolfSSLObjList = [
     "wolfcrypt/src/sha512.c",
     "wolfcrypt/src/tfm.c",
     "wolfcrypt/src/wc_port.c",
-    "wolfcrtyp/src/wolfmath.c",
+    "wolfcrypt/src/wolfmath.c",
 
     "src/internal.c",
     "src/io.c",

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -485,6 +485,7 @@ int wc_UnLockMutex(wolfSSL_Mutex *m)
            if( Error_check( &eb )  )
            {
                Error_raise( &eb, Error_E_generic, "Failed to Create the semaphore.",NULL);
+	       return BAD_MUTEX_E;
            } else return 0;
         }
 


### PR DESCRIPTION
change in wc_port.c solves a compile-time warning: Missing return from non-void function
change in src/internal.c fixes a typo: hashSha25 -> hashSha256
change in package.bld compiles ecc dependencies added in release 3.10.0