### PR TITLE
Normal math speed-up to not allocate on mp_int and defer until mp_grow

### DIFF
--- a/IDE/ROWLEY-CROSSWORKS-ARM/user_settings.h
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/user_settings.h
@@ -216,6 +216,8 @@ extern "C" {
             #define FREESCALE_USE_LTC
             #define LTC_MAX_ECC_BITS    (512)
             #define LTC_MAX_INT_BYTES   (256)
+
+            //#define FREESCALE_LTC_TFM_RSA_4096_ENABLE
         #endif
     #endif
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -3114,12 +3114,14 @@ int DhGenKeyPair(WOLFSSL* ssl,
     int ret;
     DhKey dhKey;
 
-    wc_InitDhKey(&dhKey);
-    ret = wc_DhSetKey(&dhKey, p, pSz, g, gSz);
+    ret = wc_InitDhKey(&dhKey);
     if (ret == 0) {
-        ret = wc_DhGenerateKeyPair(&dhKey, ssl->rng, priv, privSz, pub, pubSz);
+        ret = wc_DhSetKey(&dhKey, p, pSz, g, gSz);
+        if (ret == 0) {
+            ret = wc_DhGenerateKeyPair(&dhKey, ssl->rng, priv, privSz, pub, pubSz);
+        }
+        wc_FreeDhKey(&dhKey);
     }
-    wc_FreeDhKey(&dhKey);
 
     return ret;
 }
@@ -3135,16 +3137,18 @@ int DhAgree(WOLFSSL* ssl,
     int ret;
     DhKey dhKey;
 
-    wc_InitDhKey(&dhKey);
-    ret = wc_DhSetKey(&dhKey, p, pSz, g, gSz);
-    if (ret == 0 && pub) {
-        /* for DH, encSecret is Yc, agree is pre-master */
-        ret = wc_DhGenerateKeyPair(&dhKey, ssl->rng, priv, privSz, pub, pubSz);
-    }
+    ret = wc_InitDhKey(&dhKey);
     if (ret == 0) {
-        ret = wc_DhAgree(&dhKey, agree, agreeSz, priv, *privSz, otherPub, otherPubSz);
+        ret = wc_DhSetKey(&dhKey, p, pSz, g, gSz);
+        if (ret == 0 && pub) {
+            /* for DH, encSecret is Yc, agree is pre-master */
+            ret = wc_DhGenerateKeyPair(&dhKey, ssl->rng, priv, privSz, pub, pubSz);
+        }
+        if (ret == 0) {
+            ret = wc_DhAgree(&dhKey, agree, agreeSz, priv, *privSz, otherPub, otherPubSz);
+        }
+        wc_FreeDhKey(&dhKey);
     }
-    wc_FreeDhKey(&dhKey);
 
     return ret;
 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16130,7 +16130,11 @@ WOLFSSL_DH* wolfSSL_DH_new(void)
     }
 
     InitwolfSSL_DH(external);
-    wc_InitDhKey(key);
+    if (wc_InitDhKey(key) != 0) {
+        WOLFSSL_MSG("wolfSSL_DH_new InitDhKey failure");
+        XFREE(key, NULL, DYNAMIC_TYPE_DH);
+        return NULL;
+    }
     external->internal = key;
 
     return external;
@@ -16425,7 +16429,11 @@ WOLFSSL_DSA* wolfSSL_DSA_new(void)
     }
 
     InitwolfSSL_DSA(external);
-    InitDsaKey(key);
+    if (wc_InitDsaKey(key) != 0) {
+        WOLFSSL_MSG("wolfSSL_DSA_new InitDsaKey failure");
+        XFREE(key, NULL, DYNAMIC_TYPE_DSA);
+        return NULL;
+    }
     external->internal = key;
 
     return external;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8311,8 +8311,13 @@ int wolfSSL_Cleanup(void)
     if (wc_FreeMutex(&count_mutex) != 0)
         ret = BAD_MUTEX_E;
 
-#if defined(HAVE_ECC) && defined(FP_ECC)
-    wc_ecc_fp_free();
+#ifdef HAVE_ECC
+    #ifdef FP_ECC
+        wc_ecc_fp_free();
+    #endif
+    #ifdef ECC_CACHE_CURVE
+        wc_ecc_curve_cache_free();
+    #endif
 #endif
 
     if (wolfCrypt_Cleanup() != 0) {

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -51,6 +51,10 @@ int unit_test(int argc, char** argv)
     (void)argv;
     printf("starting unit tests...\n");
 
+#if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)
+    InitMemoryTracker();
+#endif
+
 #if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND)
     wolfSSL_Debugging_ON();
 #endif
@@ -84,6 +88,10 @@ int unit_test(int argc, char** argv)
     if (wc_FreeNetRandom() < 0)
         err_sys("Failed to free netRandom context");
 #endif /* HAVE_WNR */
+
+#if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)
+    ShowMemoryTracker();
+#endif
 
     return 0;
 }

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1891,7 +1891,11 @@ void bench_dh(void)
 #endif /* USE_CERT_BUFFERS */
 
 
-    wc_InitDhKey(&dhKey);
+    if (wc_InitDhKey(&dhKey) != 0) {
+        printf("InitDhKey failed!\n");
+        return;
+    }
+
 #ifdef NO_ASN
     bytes = wc_DhSetKey(&dhKey, dh_p, sizeof(dh_p), dh_g, sizeof(dh_g));
 #else

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -49,12 +49,17 @@
 #endif
 
 
-void wc_InitDhKey(DhKey* key)
+int wc_InitDhKey(DhKey* key)
 {
-    if (key) {
-        mp_init(&key->p);
-        mp_init(&key->g);
-    }
+    int ret = 0;
+
+    if (key == NULL)
+        return BAD_FUNC_ARG;
+
+    if (mp_init_multi(&key->p, &key->g, NULL, NULL, NULL, NULL) != MP_OKAY)
+        ret = MEMORY_E;
+
+    return ret;
 }
 
 

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -51,20 +51,21 @@
 
 void wc_InitDhKey(DhKey* key)
 {
-    (void)key;
-/* TomsFastMath doesn't use memory allocation */
-#ifndef USE_FAST_MATH
-    key->p.dp = NULL;
-    key->g.dp = NULL;
-#endif
+    if (key) {
+        mp_init(&key->p);
+        mp_init(&key->g);
+    }
 }
 
 
 void wc_FreeDhKey(DhKey* key)
 {
-    (void)key;
-    mp_clear(&key->p);
-    mp_clear(&key->g);
+    if (key) {
+    #ifndef USE_FAST_MATH
+        mp_clear(&key->p);
+        mp_clear(&key->g);
+    #endif
+    }
 }
 
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2323,12 +2323,6 @@ ecc_point* wc_ecc_new_point_h(void* heap)
    }
    XMEMSET(p, 0, sizeof(ecc_point));
 
-#ifndef USE_FAST_MATH
-   p->x->dp = NULL;
-   p->y->dp = NULL;
-   p->z->dp = NULL;
-#endif
-
 #ifndef ALT_ECC_SIZE
    if (mp_init_multi(p->x, p->y, p->z, NULL, NULL, NULL) != MP_OKAY) {
       XFREE(p, heap, DYNAMIC_TYPE_ECC);
@@ -3018,17 +3012,20 @@ int wc_ecc_init_ex(ecc_key* key, void* heap, int devId)
     }
 #else
 #ifdef ALT_ECC_SIZE
-    if (mp_init(&key->k) != MP_OKAY) {
-        return MEMORY_E;
-    }
-
     key->pubkey.x = (mp_int*)&key->pubkey.xyz[0];
     key->pubkey.y = (mp_int*)&key->pubkey.xyz[1];
     key->pubkey.z = (mp_int*)&key->pubkey.xyz[2];
     alt_fp_init(key->pubkey.x);
     alt_fp_init(key->pubkey.y);
     alt_fp_init(key->pubkey.z);
+    ret = mp_init(&key->k);
+#else
+    ret = mp_init_multi(&key->k, key->pubkey.x, key->pubkey.y, key->pubkey.z,
+                                                                    NULL, NULL);
 #endif /* ALT_ECC_SIZE */
+    if (ret != MP_OKAY) {
+        return MEMORY_E;
+    }
 #endif /* WOLFSSL_ATECC508A */
 
 #ifdef WOLFSSL_HEAP_TEST

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -317,7 +317,7 @@ int mp_copy (mp_int * a, mp_int * b)
   }
 
   /* grow dest */
-  if (b->alloc < a->used || a->used == 0) {
+  if (b->alloc < a->used) {
      if ((res = mp_grow (b, a->used)) != MP_OKAY) {
         return res;
      }
@@ -360,7 +360,7 @@ int mp_grow (mp_int * a, int size)
   mp_digit *tmp;
 
   /* if the alloc size is smaller alloc more ram */
-  if (a->alloc < size || size == 0) {
+  if (a->alloc < size) {
     /* ensure there are always at least MP_PREC digits extra on top */
     size += (MP_PREC * 2) - (size % MP_PREC);
 
@@ -1283,8 +1283,12 @@ int mp_cmp (mp_int * a, mp_int * b)
 /* compare a digit */
 int mp_cmp_d(mp_int * a, mp_digit b)
 {
+  /* special case for zero*/
+  if (a->used == 0 && b == 0)
+    return MP_EQ;
+
   /* compare based on sign */
-  if (a->sign == MP_NEG) {
+  if ((b && a->used == 0) || a->sign == MP_NEG) {
     return MP_LT;
   }
 

--- a/wolfcrypt/src/port/nxp/ksdk_port.c
+++ b/wolfcrypt/src/port/nxp/ksdk_port.c
@@ -23,7 +23,6 @@
     #include <config.h>
 #endif
 
-/* in case user set USE_FAST_MATH there */
 #include <wolfssl/wolfcrypt/settings.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
@@ -33,8 +32,7 @@
 #endif
 
 /* If FREESCALE_LTC_TFM or FREESCALE_LTC_ECC */
-#if (defined(USE_FAST_MATH) && defined(FREESCALE_LTC_TFM)) ||\
-    defined(FREESCALE_LTC_ECC)
+#if defined(FREESCALE_LTC_TFM) || defined(FREESCALE_LTC_ECC)
 
 #include <wolfssl/wolfcrypt/port/nxp/ksdk_port.h>
 #include <wolfssl/wolfcrypt/random.h>
@@ -42,12 +40,12 @@
 #include <wolfssl/wolfcrypt/logging.h>
 #include <stdint.h>
 
-#define ERROR_OUT(err) { ret = (err); goto done; }
+#define ERROR_OUT(res) { ret = (res); goto done; }
 
 
 int ksdk_port_init(void)
 {
-#if defined(USE_FAST_MATH) && defined(FREESCALE_LTC_TFM)
+#if defined(FREESCALE_LTC_TFM)
     LTC_Init(LTC0);
 #endif
 
@@ -56,8 +54,7 @@ int ksdk_port_init(void)
 
 
 /* LTC TFM */
-#if defined(USE_FAST_MATH) && defined(FREESCALE_LTC_TFM)
-#include <wolfssl/wolfcrypt/tfm.h>
+#if defined(FREESCALE_LTC_TFM)
 
 /* Reverse array in memory (in place) */
 static void ltc_reverse_array(uint8_t *src, size_t src_len)
@@ -73,39 +70,52 @@ static void ltc_reverse_array(uint8_t *src, size_t src_len)
     }
 }
 
-/* same as fp_to_unsigned_bin() with fp_reverse() skipped */
-static void fp_to_unsigned_lsb_bin(fp_int *a, unsigned char *b)
+/* same as mp_to_unsigned_bin() with mp_reverse() skipped */
+static int mp_to_unsigned_lsb_bin(mp_int *a, unsigned char *b)
 {
-    fp_int t;
+    int res;
+    mp_int t;
 
-    fp_init_copy(&t, a);
+    res = mp_init_copy(&t, a);
+    if (res == MP_OKAY) {
+        res = mp_to_unsigned_bin_at_pos(0, &t, b);
+        if (res >= 0)
+            res = 0;
+    #ifndef USE_FAST_MATH
+        mp_clear(&t);
+    #endif
+    }
 
-    (void)fp_to_unsigned_bin_at_pos(0, &t, b);
+    return res;
 }
 
-static void ltc_get_lsb_bin_from_mp_int(uint8_t *dst, mp_int *A, uint16_t *psz)
+static int ltc_get_lsb_bin_from_mp_int(uint8_t *dst, mp_int *A, uint16_t *psz)
 {
+    int res;
     uint16_t sz;
 
     sz = mp_unsigned_bin_size(A);
-    fp_to_unsigned_lsb_bin(A, dst); /* result is lsbyte at lowest addr as required by LTC */
+    res = mp_to_unsigned_lsb_bin(A, dst); /* result is lsbyte at lowest addr as required by LTC */
     *psz = sz;
+
+    return res;
 }
 
 /* these function are used by wolfSSL upper layers (like RSA) */
 
 /* c = a * b */
-void fp_mul(fp_int *A, fp_int *B, fp_int *C)
+int mp_mul(mp_int *A, mp_int *B, mp_int *C)
 {
+    int res = MP_OKAY;
     int szA, szB;
-    szA = fp_unsigned_bin_size(A);
-    szB = fp_unsigned_bin_size(B);
+    szA = mp_unsigned_bin_size(A);
+    szB = mp_unsigned_bin_size(B);
 
     /* if unsigned mul can fit into LTC PKHA let's use it, otherwise call software mul */
     if ((szA <= LTC_MAX_INT_BYTES / 2) && (szB <= LTC_MAX_INT_BYTES / 2)) {
         int neg;
 
-        neg = (A->sign == B->sign) ? FP_ZPOS : FP_NEG;
+        neg = (A->sign == B->sign) ? MP_ZPOS : MP_NEG;
 
         /* unsigned multiply */
         uint8_t *ptrA = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, 0, DYNAMIC_TYPE_BIGINT);
@@ -115,16 +125,19 @@ void fp_mul(fp_int *A, fp_int *B, fp_int *C)
         if (ptrA && ptrB && ptrC) {
             uint16_t sizeA, sizeB;
 
-            ltc_get_lsb_bin_from_mp_int(ptrA, A, &sizeA);
-            ltc_get_lsb_bin_from_mp_int(ptrB, B, &sizeB);
-            XMEMSET(ptrC, 0xFF, LTC_MAX_INT_BYTES);
+            res = ltc_get_lsb_bin_from_mp_int(ptrA, A, &sizeA);
+            if (res == MP_OKAY)
+                res = ltc_get_lsb_bin_from_mp_int(ptrB, B, &sizeB);
+            if (res == MP_OKAY) {
+                XMEMSET(ptrC, 0xFF, LTC_MAX_INT_BYTES);
 
-            LTC_PKHA_ModMul(LTC_BASE, ptrA, sizeA, ptrB, sizeB, ptrC, LTC_MAX_INT_BYTES, ptrB, &sizeB,
-                            kLTC_PKHA_IntegerArith, kLTC_PKHA_NormalValue, kLTC_PKHA_NormalValue,
-                            kLTC_PKHA_TimingEqualized);
+                LTC_PKHA_ModMul(LTC_BASE, ptrA, sizeA, ptrB, sizeB, ptrC, LTC_MAX_INT_BYTES, ptrB, &sizeB,
+                                kLTC_PKHA_IntegerArith, kLTC_PKHA_NormalValue, kLTC_PKHA_NormalValue,
+                                kLTC_PKHA_TimingEqualized);
 
-            ltc_reverse_array(ptrB, sizeB);
-            mp_read_unsigned_bin(C, ptrB, sizeB);
+                ltc_reverse_array(ptrB, sizeB);
+                res = mp_read_unsigned_bin(C, ptrB, sizeB);
+            }
         }
 
         /* fix sign */
@@ -138,52 +151,53 @@ void fp_mul(fp_int *A, fp_int *B, fp_int *C)
         if (ptrC) {
             XFREE(ptrC, NULL, DYNAMIC_TYPE_BIGINT);
         }
-        return;
     }
     else {
-        wolfcrypt_fp_mul(A, B, C);
+        res = wolfcrypt_mp_mul(A, B, C);
     }
+    return res;
 }
 
 /* c = a mod b, 0 <= c < b  */
-int fp_mod(fp_int *a, fp_int *b, fp_int *c)
+int mp_mod(mp_int *a, mp_int *b, mp_int *c)
 {
+    int res = MP_OKAY;
 #if defined(FREESCALE_LTC_TFM_RSA_4096_ENABLE)
     int szA, szB;
-    szA = fp_unsigned_bin_size(a);
-    szB = fp_unsigned_bin_size(b);
+    szA = mp_unsigned_bin_size(a);
+    szB = mp_unsigned_bin_size(b);
     if ((szA <= LTC_MAX_INT_BYTES) && (szB <= LTC_MAX_INT_BYTES))
     {
 #endif /* FREESCALE_LTC_TFM_RSA_4096_ENABLE */
-        int res = FP_OKAY;
         int neg;
-
         uint8_t *ptrA = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, 0, DYNAMIC_TYPE_BIGINT);
         uint8_t *ptrB = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, 0, DYNAMIC_TYPE_BIGINT);
         uint8_t *ptrC = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, 0, DYNAMIC_TYPE_BIGINT);
 
         /* get sign for the result */
-        neg = (a->sign == b->sign) ? FP_ZPOS : FP_NEG;
+        neg = (a->sign == b->sign) ? MP_ZPOS : MP_NEG;
 
         /* get remainder of unsigned a divided by unsigned b */
         if (ptrA && ptrB && ptrC) {
             uint16_t sizeA, sizeB, sizeC;
 
-            ltc_get_lsb_bin_from_mp_int(ptrA, a, &sizeA);
-            ltc_get_lsb_bin_from_mp_int(ptrB, b, &sizeB);
-
-            if (kStatus_Success ==
-                LTC_PKHA_ModRed(LTC_BASE, ptrA, sizeA, ptrB, sizeB, ptrC, &sizeC, kLTC_PKHA_IntegerArith))
-            {
-                ltc_reverse_array(ptrC, sizeC);
-                mp_read_unsigned_bin(c, ptrC, sizeC);
-            }
-            else {
-                res = FP_VAL;
+            res = ltc_get_lsb_bin_from_mp_int(ptrA, a, &sizeA);
+            if (res == MP_OKAY)
+                res = ltc_get_lsb_bin_from_mp_int(ptrB, b, &sizeB);
+            if (res == MP_OKAY) {
+                if (kStatus_Success ==
+                    LTC_PKHA_ModRed(LTC_BASE, ptrA, sizeA, ptrB, sizeB, ptrC, &sizeC, kLTC_PKHA_IntegerArith))
+                {
+                    ltc_reverse_array(ptrC, sizeC);
+                    res = mp_read_unsigned_bin(c, ptrC, sizeC);
+                }
+                else {
+                    res = MP_VAL;
+                }
             }
         }
         else {
-            res = FP_MEM;
+            res = MP_MEM;
         }
 
         /* fix sign */
@@ -198,26 +212,25 @@ int fp_mod(fp_int *a, fp_int *b, fp_int *c)
         if (ptrC) {
             XFREE(ptrC, NULL, DYNAMIC_TYPE_BIGINT);
         }
-        return res;
 #if defined(FREESCALE_LTC_TFM_RSA_4096_ENABLE)
     }
     else {
-        return wolfcrypt_fp_mod(a, b, c);
+        res = wolfcrypt_mp_mod(a, b, c);
     }
 #endif /* FREESCALE_LTC_TFM_RSA_4096_ENABLE */
+    return res;
 }
 
 /* c = 1/a (mod b) for odd b only */
-int fp_invmod(fp_int *a, fp_int *b, fp_int *c)
+int mp_invmod(mp_int *a, mp_int *b, mp_int *c)
 {
+    int res = MP_OKAY;
 #if defined(FREESCALE_LTC_TFM_RSA_4096_ENABLE)
     int szA, szB;
-    szA = fp_unsigned_bin_size(a);
-    szB = fp_unsigned_bin_size(b);
+    szA = mp_unsigned_bin_size(a);
+    szB = mp_unsigned_bin_size(b);
     if ((szA <= LTC_MAX_INT_BYTES) && (szB <= LTC_MAX_INT_BYTES)) {
 #endif
-        int res = FP_OKAY;
-
         uint8_t *ptrA = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, 0, DYNAMIC_TYPE_BIGINT);
         uint8_t *ptrB = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, 0, DYNAMIC_TYPE_BIGINT);
         uint8_t *ptrC = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, 0, DYNAMIC_TYPE_BIGINT);
@@ -225,21 +238,23 @@ int fp_invmod(fp_int *a, fp_int *b, fp_int *c)
         if (ptrA && ptrB && ptrC) {
             uint16_t sizeA, sizeB, sizeC;
 
-            ltc_get_lsb_bin_from_mp_int(ptrA, a, &sizeA);
-            ltc_get_lsb_bin_from_mp_int(ptrB, b, &sizeB);
-
-            if (kStatus_Success ==
-                LTC_PKHA_ModInv(LTC_BASE, ptrA, sizeA, ptrB, sizeB, ptrC, &sizeC, kLTC_PKHA_IntegerArith))
-            {
-                ltc_reverse_array(ptrC, sizeC);
-                mp_read_unsigned_bin(c, ptrC, sizeC);
-            }
-            else {
-                res = FP_VAL;
+            res = ltc_get_lsb_bin_from_mp_int(ptrA, a, &sizeA);
+            if (res == MP_OKAY)
+                res = ltc_get_lsb_bin_from_mp_int(ptrB, b, &sizeB);
+            if (res == MP_OKAY) {
+                if (kStatus_Success ==
+                    LTC_PKHA_ModInv(LTC_BASE, ptrA, sizeA, ptrB, sizeB, ptrC, &sizeC, kLTC_PKHA_IntegerArith))
+                {
+                    ltc_reverse_array(ptrC, sizeC);
+                    res = mp_read_unsigned_bin(c, ptrC, sizeC);
+                }
+                else {
+                    res = MP_VAL;
+                }
             }
         }
         else {
-            res = FP_MEM;
+            res = MP_MEM;
         }
 
         c->sign = a->sign;
@@ -252,85 +267,91 @@ int fp_invmod(fp_int *a, fp_int *b, fp_int *c)
         if (ptrC) {
             XFREE(ptrC, NULL, DYNAMIC_TYPE_BIGINT);
         }
-        return res;
 #if defined(FREESCALE_LTC_TFM_RSA_4096_ENABLE)
     }
     else {
-        return wolfcrypt_fp_invmod(a, b, c);
+        res = wolfcrypt_mp_invmod(a, b, c);
     }
 #endif /* FREESCALE_LTC_TFM_RSA_4096_ENABLE */
+    return res;
 }
 
 /* d = a * b (mod c) */
-int fp_mulmod(fp_int *a, fp_int *b, fp_int *c, fp_int *d)
+int mp_mulmod(mp_int *a, mp_int *b, mp_int *c, mp_int *d)
 {
+    int res = MP_OKAY;
 #if defined(FREESCALE_LTC_TFM_RSA_4096_ENABLE)
     int szA, szB, szC;
-    szA = fp_unsigned_bin_size(a);
-    szB = fp_unsigned_bin_size(b);
-    szC = fp_unsigned_bin_size(c);
+    szA = mp_unsigned_bin_size(a);
+    szB = mp_unsigned_bin_size(b);
+    szC = mp_unsigned_bin_size(c);
     if ((szA <= LTC_MAX_INT_BYTES) && (szB <= LTC_MAX_INT_BYTES) && (szC <= LTC_MAX_INT_BYTES)) {
 #endif /* FREESCALE_LTC_TFM_RSA_4096_ENABLE */
-        int res = FP_OKAY;
-        fp_int t;
+        mp_int t;
 
         uint8_t *ptrA = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, NULL, DYNAMIC_TYPE_BIGINT);
         uint8_t *ptrB = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, NULL, DYNAMIC_TYPE_BIGINT);
         uint8_t *ptrC = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, NULL, DYNAMIC_TYPE_BIGINT);
         uint8_t *ptrD = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, NULL, DYNAMIC_TYPE_BIGINT);
 
-        /* if A or B is negative, substracta abs(A) or abs(B) from modulus to get positive integer representation of the
+        /* if A or B is negative, subtract abs(A) or abs(B) from modulus to get positive integer representation of the
          * same number */
-        fp_init(&t);
+        res = mp_init(&t);
         if (a->sign) {
-            fp_add(a, c, &t);
-            fp_copy(&t, a);
+            if (res == MP_OKAY)
+                res = mp_add(a, c, &t);
+            if (res == MP_OKAY)
+                res = mp_copy(&t, a);
         }
         if (b->sign) {
-            fp_add(b, c, &t);
-            fp_copy(&t, b);
+            if (res == MP_OKAY)
+                res = mp_add(b, c, &t);
+            if (res == MP_OKAY)
+                res = mp_copy(&t, b);
         }
 
-        if (ptrA && ptrB && ptrC && ptrD) {
+        if (res == MP_OKAY && ptrA && ptrB && ptrC && ptrD) {
             uint16_t sizeA, sizeB, sizeC, sizeD;
 
-            ltc_get_lsb_bin_from_mp_int(ptrA, a, &sizeA);
-            ltc_get_lsb_bin_from_mp_int(ptrB, b, &sizeB);
-            ltc_get_lsb_bin_from_mp_int(ptrC, c, &sizeC);
+            res = ltc_get_lsb_bin_from_mp_int(ptrA, a, &sizeA);
+            if (res == MP_OKAY)
+                res = ltc_get_lsb_bin_from_mp_int(ptrB, b, &sizeB);
+            if (res == MP_OKAY)
+                res = ltc_get_lsb_bin_from_mp_int(ptrC, c, &sizeC);
 
             /* (A*B)mod C = ((A mod C) * (B mod C)) mod C  */
-            if (LTC_PKHA_CompareBigNum(ptrA, sizeA, ptrC, sizeC) >= 0) {
+            if (res == MP_OKAY && LTC_PKHA_CompareBigNum(ptrA, sizeA, ptrC, sizeC) >= 0) {
                 if (kStatus_Success !=
                     LTC_PKHA_ModRed(LTC_BASE, ptrA, sizeA, ptrC, sizeC, ptrA, &sizeA, kLTC_PKHA_IntegerArith))
                 {
-                    res = FP_VAL;
+                    res = MP_VAL;
                 }
             }
-            if ((FP_OKAY == res) && (LTC_PKHA_CompareBigNum(ptrB, sizeB, ptrC, sizeC) >= 0))
+            if (res == MP_OKAY && (LTC_PKHA_CompareBigNum(ptrB, sizeB, ptrC, sizeC) >= 0))
             {
                 if (kStatus_Success !=
                     LTC_PKHA_ModRed(LTC_BASE, ptrB, sizeB, ptrC, sizeC, ptrB, &sizeB, kLTC_PKHA_IntegerArith))
                 {
-                    res = FP_VAL;
+                    res = MP_VAL;
                 }
             }
 
-            if (FP_OKAY == res) {
+            if (res == MP_OKAY) {
                 if (kStatus_Success != LTC_PKHA_ModMul(LTC_BASE, ptrA, sizeA, ptrB, sizeB, ptrC, sizeC, ptrD, &sizeD,
                                                        kLTC_PKHA_IntegerArith, kLTC_PKHA_NormalValue,
                                                        kLTC_PKHA_NormalValue, kLTC_PKHA_TimingEqualized))
                 {
-                    res = FP_VAL;
+                    res = MP_VAL;
                 }
             }
 
-            if (FP_OKAY == res) {
+            if (res == MP_OKAY) {
                 ltc_reverse_array(ptrD, sizeD);
-                mp_read_unsigned_bin(d, ptrD, sizeD);
+                res = mp_read_unsigned_bin(d, ptrD, sizeD);
             }
         }
         else {
-            res = FP_MEM;
+            res = MP_MEM;
         }
 
         if (ptrA) {
@@ -345,41 +366,45 @@ int fp_mulmod(fp_int *a, fp_int *b, fp_int *c, fp_int *d)
         if (ptrD) {
             XFREE(ptrD, NULL, DYNAMIC_TYPE_BIGINT);
         }
-        return res;
+    #ifndef USE_FAST_MATH
+        mp_clear(&t);
+    #endif
 #if defined(FREESCALE_LTC_TFM_RSA_4096_ENABLE)
     }
     else {
-        return wolfcrypt_fp_mulmod(a, b, c, d);
+        res = wolfcrypt_mp_mulmod(a, b, c, d);
     }
 #endif /* FREESCALE_LTC_TFM_RSA_4096_ENABLE */
+    return res;
 }
 
 /* Y = G^X mod P */
-int _fp_exptmod(fp_int *G, fp_int *X, fp_int *P, fp_int *Y)
+int mp_exptmod(mp_int *G, mp_int *X, mp_int *P, mp_int *Y)
 {
+    int res = MP_OKAY;
 #if defined(FREESCALE_LTC_TFM_RSA_4096_ENABLE)
     int szA, szB, szC;
-    fp_int tmp;
-    int err;
+    mp_int tmp;
 
     /* if G cannot fit into LTC_PKHA, reduce it */
-    szA = fp_unsigned_bin_size(G);
+    szA = mp_unsigned_bin_size(G);
     if (szA > LTC_MAX_INT_BYTES) {
-        fp_init(&tmp);
-        if ((err = fp_mod(G, P, &tmp)) != FP_OKAY) {
-            return err;
+        res = mp_init(&tmp);
+        if (res != MP_OKAY)
+            return res;
+        if ((res = mp_mod(G, P, &tmp)) != MP_OKAY) {
+            return res;
         }
         G = &tmp;
-        szA = fp_unsigned_bin_size(G);
+        szA = mp_unsigned_bin_size(G);
     }
 
-    szB = fp_unsigned_bin_size(X);
-    szC = fp_unsigned_bin_size(P);
+    szB = mp_unsigned_bin_size(X);
+    szC = mp_unsigned_bin_size(P);
 
     if ((szA <= LTC_MAX_INT_BYTES) && (szB <= LTC_MAX_INT_BYTES) && (szC <= LTC_MAX_INT_BYTES)) {
 #endif /* FREESCALE_LTC_TFM_RSA_4096_ENABLE */
-        int res = FP_OKAY;
-        fp_int t;
+        mp_int t;
 
         uint16_t sizeG, sizeX, sizeP;
         uint8_t *ptrG = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, 0, DYNAMIC_TYPE_BIGINT);
@@ -387,16 +412,20 @@ int _fp_exptmod(fp_int *G, fp_int *X, fp_int *P, fp_int *Y)
         uint8_t *ptrP = (uint8_t *)XMALLOC(LTC_MAX_INT_BYTES, 0, DYNAMIC_TYPE_BIGINT);
 
         /* if G is negative, add modulus to convert to positive number for LTC */
-        fp_init(&t);
+        res = mp_init(&t);
         if (G->sign) {
-            fp_add(G, P, &t);
-            fp_copy(&t, G);
+            if (res == MP_OKAY)
+                res = mp_add(G, P, &t);
+            if (res == MP_OKAY)
+                res = mp_copy(&t, G);
         }
 
-        if (ptrG && ptrX && ptrP) {
-            ltc_get_lsb_bin_from_mp_int(ptrG, G, &sizeG);
-            ltc_get_lsb_bin_from_mp_int(ptrX, X, &sizeX);
-            ltc_get_lsb_bin_from_mp_int(ptrP, P, &sizeP);
+        if (res == MP_OKAY && ptrG && ptrX && ptrP) {
+            res = ltc_get_lsb_bin_from_mp_int(ptrG, G, &sizeG);
+            if (res == MP_OKAY)
+                res = ltc_get_lsb_bin_from_mp_int(ptrX, X, &sizeX);
+            if (res == MP_OKAY)
+                res = ltc_get_lsb_bin_from_mp_int(ptrP, P, &sizeP);
 
             /* if number if greater that modulo, we must first reduce due to LTC requirement on modular exponentiaton */
             /* it needs number less than modulus.  */
@@ -405,29 +434,29 @@ int _fp_exptmod(fp_int *G, fp_int *X, fp_int *P, fp_int *Y)
                and then the modular exponentiation.
              */
             /* if G >= P then */
-            if (LTC_PKHA_CompareBigNum(ptrG, sizeG, ptrP, sizeP) >= 0) {
+            if (res == MP_OKAY && LTC_PKHA_CompareBigNum(ptrG, sizeG, ptrP, sizeP) >= 0) {
                 res = (int)LTC_PKHA_ModRed(LTC_BASE, ptrG, sizeG, ptrP, sizeP, ptrG, &sizeG, kLTC_PKHA_IntegerArith);
 
                 if (res != kStatus_Success) {
-                    res = FP_VAL;
+                    res = MP_VAL;
                 }
             }
 
-            if (FP_OKAY == res) {
+            if (res == MP_OKAY) {
                 res = (int)LTC_PKHA_ModExp(LTC_BASE, ptrG, sizeG, ptrP, sizeP, ptrX, sizeX, ptrP, &sizeP,
                                            kLTC_PKHA_IntegerArith, kLTC_PKHA_NormalValue, kLTC_PKHA_TimingEqualized);
 
                 if (res != kStatus_Success) {
-                    res = FP_VAL;
+                    res = MP_VAL;
                 }
                 else {
                     ltc_reverse_array(ptrP, sizeP);
-                    mp_read_unsigned_bin(Y, ptrP, sizeP);
+                    res = mp_read_unsigned_bin(Y, ptrP, sizeP);
                 }
             }
         }
         else {
-            res = FP_MEM;
+            res = MP_MEM;
         }
 
         if (ptrG) {
@@ -439,16 +468,24 @@ int _fp_exptmod(fp_int *G, fp_int *X, fp_int *P, fp_int *Y)
         if (ptrP) {
             XFREE(ptrP, NULL, DYNAMIC_TYPE_BIGINT);
         }
-        return res;
+    #ifndef USE_FAST_MATH
+        mp_clear(&t);
+    #endif
 #if defined(FREESCALE_LTC_TFM_RSA_4096_ENABLE)
     }
     else {
-        return _wolfcrypt_fp_exptmod(G, X, P, Y);
+        res = wolfcrypt_mp_exptmod(G, X, P, Y);
     }
+
+#ifndef USE_FAST_MATH
+    if (szA > LTC_MAX_INT_BYTES)
+        mp_clear(&tmp);
+#endif
 #endif /* FREESCALE_LTC_TFM_RSA_4096_ENABLE */
+    return res;
 }
 
-#endif /* USE_FAST_MATH && FREESCALE_LTC_TFM */
+#endif /* FREESCALE_LTC_TFM */
 
 
 /* ECC */
@@ -457,11 +494,12 @@ int _fp_exptmod(fp_int *G, fp_int *X, fp_int *P, fp_int *Y)
 /* convert from mp_int to LTC integer, as array of bytes of size sz.
  * if mp_int has less bytes than sz, add zero bytes at most significant byte positions.
  * This is when for example modulus is 32 bytes (P-256 curve)
- * and mp_int has only 31 bytes, we add leading zeroes
+ * and mp_int has only 31 bytes, we add leading zeros
  * so that result array has 32 bytes, same as modulus (sz).
  */
-static void ltc_get_from_mp_int(uint8_t *dst, mp_int *a, int sz)
+static int ltc_get_from_mp_int(uint8_t *dst, mp_int *a, int sz)
 {
+    int res;
     int szbin;
     int offset;
 
@@ -480,10 +518,14 @@ static void ltc_get_from_mp_int(uint8_t *dst, mp_int *a, int sz)
         XMEMSET(dst, 0, offset);
 
     /* convert mp_int to array of bytes */
-    mp_to_unsigned_bin(a, dst + offset);
+    res = mp_to_unsigned_bin(a, dst + offset);
 
-    /* reverse array for LTC direct use */
-    ltc_reverse_array(dst, sz);
+    if (res == MP_OKAY) {
+        /* reverse array for LTC direct use */
+        ltc_reverse_array(dst, sz);
+    }
+
+    return res;
 }
 
 /* ECC specs in lsbyte at lowest address format for direct use by LTC PKHA driver functions */
@@ -636,6 +678,7 @@ int wc_ecc_mulmod_ex(mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
     int szkbin;
     bool point_of_infinity;
     status_t status;
+    int res;
 
     (void)a;
 
@@ -655,9 +698,14 @@ int wc_ecc_mulmod_ex(mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
     szModulus = mp_unsigned_bin_size(modulus);
     szkbin = mp_unsigned_bin_size(k);
 
-    ltc_get_from_mp_int(kbin, k, szkbin);
-    ltc_get_from_mp_int(Gxbin, G->x, szModulus);
-    ltc_get_from_mp_int(Gybin, G->y, szModulus);
+    res = ltc_get_from_mp_int(kbin, k, szkbin);
+    if (res == MP_OKAY)
+        res = ltc_get_from_mp_int(Gxbin, G->x, szModulus);
+    if (res == MP_OKAY)
+        res = ltc_get_from_mp_int(Gybin, G->y, szModulus);
+
+    if (res != MP_OKAY)
+        return res;
 
     size = szModulus;
     /* find LTC friendly parameters for the selected curve */
@@ -671,25 +719,28 @@ int wc_ecc_mulmod_ex(mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
     status = LTC_PKHA_ECC_PointMul(LTC_BASE, &B, kbin, szkbin, modbin, r2modn, aCurveParam, bCurveParam, size,
                                    kLTC_PKHA_TimingEqualized, kLTC_PKHA_IntegerArith, &B, &point_of_infinity);
     if (status != kStatus_Success) {
-        return FP_VAL;
+        return MP_VAL;
     }
 
     ltc_reverse_array(Gxbin, size);
     ltc_reverse_array(Gybin, size);
-    mp_read_unsigned_bin(R->x, Gxbin, size);
-    mp_read_unsigned_bin(R->y, Gybin, size);
-    /* if k is negative, we compute the multiplication with abs(-k)
-     * with result (x, y) and modify the result to (x, -y)
-     */
-    R->y->sign = k->sign;
-    mp_set(R->z, 1);
+    res = mp_read_unsigned_bin(R->x, Gxbin, size);
+    if (res == MP_OKAY) {
+        res = mp_read_unsigned_bin(R->y, Gybin, size);
+        /* if k is negative, we compute the multiplication with abs(-k)
+         * with result (x, y) and modify the result to (x, -y)
+         */
+        R->y->sign = k->sign;
+    }
+    if (res == MP_OKAY)
+        res = mp_set(R->z, 1);
 
-    return MP_OKAY;
+    return res;
 }
 
 int wc_ecc_point_add(ecc_point *mG, ecc_point *mQ, ecc_point *mR, mp_int *m)
 {
-    int err;
+    int res;
     ltc_pkha_ecc_point_t A, B;
     int size;
     status_t status;
@@ -704,15 +755,22 @@ int wc_ecc_point_add(ecc_point *mG, ecc_point *mQ, ecc_point *mR, mp_int *m)
     const uint8_t *r2modn;
 
     size = mp_unsigned_bin_size(m);
+
     /* find LTC friendly parameters for the selected curve */
-    if (0 != ltc_get_ecc_specs(&modbin, &r2modn, &aCurveParam, &bCurveParam, size)) {
-        err = ECC_BAD_ARG_E;
+    if (ltc_get_ecc_specs(&modbin, &r2modn, &aCurveParam, &bCurveParam, size) != 0) {
+        res = ECC_BAD_ARG_E;
     }
     else {
-        ltc_get_from_mp_int(Gxbin, mG->x, size);
-        ltc_get_from_mp_int(Gybin, mG->y, size);
-        ltc_get_from_mp_int(Qxbin, mQ->x, size);
-        ltc_get_from_mp_int(Qybin, mQ->y, size);
+        res = ltc_get_from_mp_int(Gxbin, mG->x, size);
+        if (res == MP_OKAY)
+            res = ltc_get_from_mp_int(Gybin, mG->y, size);
+        if (res == MP_OKAY)
+            res = ltc_get_from_mp_int(Qxbin, mQ->x, size);
+        if (res == MP_OKAY)
+            res = ltc_get_from_mp_int(Qybin, mQ->y, size);
+
+        if (res != MP_OKAY)
+            return res;
 
         A.X = Gxbin;
         A.Y = Gybin;
@@ -723,18 +781,19 @@ int wc_ecc_point_add(ecc_point *mG, ecc_point *mQ, ecc_point *mR, mp_int *m)
         status = LTC_PKHA_ECC_PointAdd(LTC_BASE, &A, &B, modbin, r2modn, aCurveParam, bCurveParam, size,
                                        kLTC_PKHA_IntegerArith, &A);
         if (status != kStatus_Success) {
-            err = FP_VAL;
+            res = MP_VAL;
         }
         else {
             ltc_reverse_array(Gxbin, size);
             ltc_reverse_array(Gybin, size);
-            mp_read_unsigned_bin(mR->x, Gxbin, size);
-            mp_read_unsigned_bin(mR->y, Gybin, size);
-            mp_set(mR->z, 1);
-            err = MP_OKAY;
+            res = mp_read_unsigned_bin(mR->x, Gxbin, size);
+            if (res == MP_OKAY)
+                res = mp_read_unsigned_bin(mR->y, Gybin, size);
+            if (res == MP_OKAY)
+                res = mp_set(mR->z, 1);
         }
     }
-    return err;
+    return res;
 }
 
 #if defined(HAVE_ED25519) || defined(HAVE_CURVE25519)
@@ -852,7 +911,7 @@ status_t LTC_PKHA_Prime25519SquareRootMod(const uint8_t *A, size_t sizeA,
      *
      * X mod 2 get from LSB bit0
      */
-    if ((status == kStatus_Success) && 
+    if ((status == kStatus_Success) &&
         ((bool)sign != (bool)(res[0] & 0x01u)))
     {
         status = LTC_PKHA_ModSub1(LTC_BASE, modbin, sizeof(modbin), res,
@@ -1036,7 +1095,7 @@ int wc_curve25519(ECPoint *q, byte *n, const ECPoint *p, fsl_ltc_ecc_coordinate_
     ltcPoint.X = &pIn.point[0];
     ltcPoint.Y = &pIn.pointY[0];
 
-    /* if input point P is on Curve25519 Montgomery curve, transform 
+    /* if input point P is on Curve25519 Montgomery curve, transform
         it to Weierstrass equivalent */
     if (type == kLTC_Curve25519) {
         LTC_PKHA_Curve25519ToWeierstrass(&ltcPoint, &ltcPoint);
@@ -1197,7 +1256,7 @@ status_t LTC_PKHA_Ed25519ToWeierstrass(const ltc_pkha_ecc_point_t *ltcPointIn,
     Mx = (1 + Ey) * ModularArithmetic.invert(1 - Ey, prime) % prime
     My = (1 + Ey) * ModularArithmetic.invert((1 - Ey)*Ex, prime) % prime */
 
-    /* Gx = ((Mx * ModularArithmetic.invert(B, prime)) + 
+    /* Gx = ((Mx * ModularArithmetic.invert(B, prime)) +
         (A * ModularArithmetic.invert(3*B, prime))) % prime
     Gy = (My * ModularArithmetic.invert(B, prime)) % prime */
 
@@ -1497,7 +1556,7 @@ status_t LTC_PKHA_sc_muladd(uint8_t *s, const uint8_t *a,
     uint8_t tempB[32] = {0};
     status_t status;
 
-    /* Assume only b can be larger than modulus. It is called durind 
+    /* Assume only b can be larger than modulus. It is called durind
      * wc_ed25519_sign_msg() where hram (=a) and nonce(=c)
      * have been reduced by LTC_PKHA_sc_reduce()
      * Thus reducing b only.
@@ -1622,4 +1681,4 @@ status_t LTC_PKHA_Ed25519_Compress(const ltc_pkha_ecc_point_t *ltcPointIn,
 
 #undef ERROR_OUT
 
-#endif /* (USE_FAST_MATH && FREESCALE_LTC_TFM) || FREESCALE_LTC_ECC */
+#endif /* FREESCALE_LTC_TFM || FREESCALE_LTC_ECC */

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -258,14 +258,19 @@ int wc_FreeRsaKey(RsaKey* key)
             mp_forcezero(&key->p);
             mp_forcezero(&key->d);
         }
+    #ifndef USE_FAST_MATH
+        /* private part */
         mp_clear(&key->u);
         mp_clear(&key->dQ);
         mp_clear(&key->dP);
         mp_clear(&key->q);
         mp_clear(&key->p);
         mp_clear(&key->d);
+
+        /* public part */
         mp_clear(&key->e);
         mp_clear(&key->n);
+    #endif
     }
 
     return ret;

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -214,13 +214,6 @@ int wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId)
     else
 #endif
     {
-    /* For normal math defer the memory allocations */
-    #ifndef USE_FAST_MATH
-        key->n.dp = key->e.dp = 0;  /* public  alloc parts */
-        key->d.dp = key->p.dp  = 0; /* private alloc parts */
-        key->q.dp = key->dP.dp = 0;
-        key->u.dp = key->dQ.dp = 0;
-    #else
         mp_init(&key->n);
         mp_init(&key->e);
         mp_init(&key->d);
@@ -229,7 +222,6 @@ int wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId)
         mp_init(&key->dP);
         mp_init(&key->dQ);
         mp_init(&key->u);
-    #endif /* USE_FAST_MATH */
     }
 
     return ret;
@@ -266,6 +258,12 @@ int wc_FreeRsaKey(RsaKey* key)
             mp_forcezero(&key->p);
             mp_forcezero(&key->d);
         }
+        mp_clear(&key->u);
+        mp_clear(&key->dQ);
+        mp_clear(&key->dP);
+        mp_clear(&key->q);
+        mp_clear(&key->p);
+        mp_clear(&key->d);
         mp_clear(&key->e);
         mp_clear(&key->n);
     }
@@ -907,7 +905,7 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
          */
         #define RET_ERR(ret, r, e) \
             ((ret) | (COND_N((ret) == 0, COND_N((r) != MP_OKAY, (e)))))
-    
+
         { /* tmpa/b scope */
         mp_int tmpa, tmpb;
         int r;

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -198,11 +198,7 @@ void s_fp_sub(fp_int *a, fp_int *b, fp_int *c)
 }
 
 /* c = a * b */
-#if defined(FREESCALE_LTC_TFM)
-void wolfcrypt_fp_mul(fp_int *A, fp_int *B, fp_int *C)
-#else
 void fp_mul(fp_int *A, fp_int *B, fp_int *C)
-#endif
 {
     int   y, yy, oldused;
 
@@ -742,11 +738,7 @@ void fp_div_2d(fp_int *a, int b, fp_int *c, fp_int *d)
 }
 
 /* c = a mod b, 0 <= c < b  */
-#if defined(FREESCALE_LTC_TFM)
-int wolfcrypt_fp_mod(fp_int *a, fp_int *b, fp_int *c)
-#else
 int fp_mod(fp_int *a, fp_int *b, fp_int *c)
-#endif
 {
    fp_int t;
    int    err;
@@ -897,11 +889,7 @@ top:
 }
 
 /* c = 1/a (mod b) for odd b only */
-#if defined(FREESCALE_LTC_TFM)
-int wolfcrypt_fp_invmod(fp_int *a, fp_int *b, fp_int *c)
-#else
 int fp_invmod(fp_int *a, fp_int *b, fp_int *c)
-#endif
 {
   fp_int  x, y, u, v, B, D;
   int     neg;
@@ -993,11 +981,7 @@ top:
 }
 
 /* d = a * b (mod c) */
-#if defined(FREESCALE_LTC_TFM)
-int wolfcrypt_fp_mulmod(fp_int *a, fp_int *b, fp_int *c, fp_int *d)
-#else
 int fp_mulmod(fp_int *a, fp_int *b, fp_int *c, fp_int *d)
-#endif
 {
   int err;
   fp_int t;
@@ -1076,11 +1060,7 @@ const wolfssl_word wc_off_on_addr[2] =
    Based on work by Marc Joye, Sung-Ming Yen, "The Montgomery Powering Ladder",
    Cryptographic Hardware and Embedded Systems, CHES 2002
 */
-#if defined(FREESCALE_LTC_TFM)
-int _wolfcrypt_fp_exptmod(fp_int * G, fp_int * X, fp_int * P, fp_int * Y)
-#else
 static int _fp_exptmod(fp_int * G, fp_int * X, fp_int * P, fp_int * Y)
-#endif
 {
 #ifdef WC_NO_CACHE_RESISTANT
   fp_int   R[2];
@@ -2248,7 +2228,11 @@ int mp_sub (mp_int * a, mp_int * b, mp_int * c)
 }
 
 /* high level multiplication (handles sign) */
+#if defined(FREESCALE_LTC_TFM)
+int wolfcrypt_mp_mul(mp_int * a, mp_int * b, mp_int * c)
+#else
 int mp_mul (mp_int * a, mp_int * b, mp_int * c)
+#endif
 {
   fp_mul(a, b, c);
   return MP_OKAY;
@@ -2261,7 +2245,11 @@ int mp_mul_d (mp_int * a, mp_digit b, mp_int * c)
 }
 
 /* d = a * b (mod c) */
+#if defined(FREESCALE_LTC_TFM)
+int wolfcrypt_mp_mulmod (mp_int * a, mp_int * b, mp_int * c, mp_int * d)
+#else
 int mp_mulmod (mp_int * a, mp_int * b, mp_int * c, mp_int * d)
+#endif
 {
   return fp_mulmod(a, b, c, d);
 }
@@ -2279,13 +2267,21 @@ int mp_addmod(mp_int *a, mp_int *b, mp_int *c, mp_int *d)
 }
 
 /* c = a mod b, 0 <= c < b */
+#if defined(FREESCALE_LTC_TFM)
+int wolfcrypt_mp_mod (mp_int * a, mp_int * b, mp_int * c)
+#else
 int mp_mod (mp_int * a, mp_int * b, mp_int * c)
+#endif
 {
   return fp_mod (a, b, c);
 }
 
 /* hac 14.61, pp608 */
+#if defined(FREESCALE_LTC_TFM)
+int wolfcrypt_mp_invmod (mp_int * a, mp_int * b, mp_int * c)
+#else
 int mp_invmod (mp_int * a, mp_int * b, mp_int * c)
+#endif
 {
   return fp_invmod(a, b, c);
 }
@@ -2295,7 +2291,11 @@ int mp_invmod (mp_int * a, mp_int * b, mp_int * c)
  * embedded in the normal function but that wasted alot of stack space
  * for nothing (since 99% of the time the Montgomery code would be called)
  */
+#if defined(FREESCALE_LTC_TFM)
+int wolfcrypt_mp_exptmod (mp_int * G, mp_int * X, mp_int * P, mp_int * Y)
+#else
 int mp_exptmod (mp_int * G, mp_int * X, mp_int * P, mp_int * Y)
+#endif
 {
   return fp_exptmod(G, X, P, Y);
 }
@@ -2316,6 +2316,11 @@ int mp_cmp_d(mp_int * a, mp_digit b)
 int mp_unsigned_bin_size (mp_int * a)
 {
   return fp_unsigned_bin_size(a);
+}
+
+int mp_to_unsigned_bin_at_pos(int x, fp_int *t, unsigned char *b)
+{
+    return fp_to_unsigned_bin_at_pos(x, t, b);
 }
 
 /* store in unsigned [big endian] format */

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3078,9 +3078,10 @@ int mp_cnt_lsb(fp_int* a)
 
 #if defined(HAVE_ECC) || !defined(NO_RSA) || !defined(NO_DSA)
 /* fast math conversion */
-void mp_set(fp_int *a, fp_digit b)
+int mp_set(fp_int *a, fp_digit b)
 {
     fp_set(a,b);
+    return MP_OKAY;
 }
 #endif
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5155,13 +5155,13 @@ int rsa_test(void)
     } while (ret == WC_PENDING_E);
     if (ret < 0) {
         XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	wc_FreeRng(&rng);
+    	wc_FreeRng(&rng);
         return -444;
     }
 
     if (XMEMCMP(plain, in, inLen)) {
         XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	wc_FreeRng(&rng);
+	    wc_FreeRng(&rng);
         return -445;
     }
     #endif /* !HAVE_FAST_RSA && !HAVE_FIPS */
@@ -5181,7 +5181,7 @@ int rsa_test(void)
     file2 = fopen(clientCert, "rb");
     if (!file2) {
         XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	wc_FreeRng(&rng);
+    	wc_FreeRng(&rng);
         return -49;
     }
 
@@ -5200,7 +5200,7 @@ int rsa_test(void)
     if (ret != 0) {
         FreeDecodedCert(&cert);
         XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	wc_FreeRng(&rng);
+    	wc_FreeRng(&rng);
         return -491;
     }
 
@@ -5223,7 +5223,7 @@ int rsa_test(void)
         err_sys("can't open ./certs/client-keyPub.der, "
                 "Please run from wolfSSL home dir", -40);
         XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	wc_FreeRng(&rng);
+    	wc_FreeRng(&rng);
         return -50;
     }
 
@@ -5234,7 +5234,7 @@ int rsa_test(void)
     ret = wc_InitRsaKey(&keypub, HEAP_HINT);
     if (ret != 0) {
         XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	wc_FreeRng(&rng);
+    	wc_FreeRng(&rng);
         return -51;
     }
     idx = 0;
@@ -5243,7 +5243,7 @@ int rsa_test(void)
     if (ret != 0) {
         XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         wc_FreeRsaKey(&keypub);
-	wc_FreeRng(&rng);
+    	wc_FreeRng(&rng);
         return -52;
     }
 #endif /* WOLFSSL_CERT_EXT */
@@ -5262,13 +5262,13 @@ int rsa_test(void)
         ret = wc_InitRsaKey(&genKey, HEAP_HINT);
         if (ret != 0) {
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -300;
         }
         ret = wc_MakeRsaKey(&genKey, 1024, 65537, &rng);
         if (ret != 0) {
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -301;
         }
 
@@ -5276,7 +5276,7 @@ int rsa_test(void)
         if (der == NULL) {
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&genKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -307;
         }
         pem = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -5284,7 +5284,7 @@ int rsa_test(void)
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&genKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -308;
         }
 
@@ -5293,7 +5293,7 @@ int rsa_test(void)
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -302;
         }
 
@@ -5307,7 +5307,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&genKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -303;
         }
         ret = (int)fwrite(der, 1, derSz, keyFile);
@@ -5317,7 +5317,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&genKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -313;
         }
 
@@ -5327,7 +5327,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&genKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -304;
         }
 
@@ -5341,7 +5341,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&genKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -305;
         }
         ret = (int)fwrite(pem, 1, pemSz, pemFile);
@@ -5351,7 +5351,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&genKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -314;
         }
 
@@ -5361,7 +5361,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&genKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -3060;
         }
         idx = 0;
@@ -5372,7 +5372,7 @@ int rsa_test(void)
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&derIn);
             wc_FreeRsaKey(&genKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -306;
         }
 
@@ -5401,14 +5401,14 @@ int rsa_test(void)
                                                        DYNAMIC_TYPE_TMP_BUFFER);
         if (derCert == NULL) {
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -309;
         }
         pem = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,DYNAMIC_TYPE_TMP_BUFFER);
         if (pem == NULL) {
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -310;
         }
 
@@ -5437,7 +5437,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -398;
         }
 
@@ -5446,7 +5446,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -399;
         }
 
@@ -5455,7 +5455,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -400;
         }
 #endif /* WOLFSSL_CERT_EXT */
@@ -5465,7 +5465,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -401;
         }
 
@@ -5476,7 +5476,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -402;
         }
         FreeDecodedCert(&decode);
@@ -5491,7 +5491,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -403;
         }
         ret = (int)fwrite(derCert, 1, certSz, derFile);
@@ -5500,7 +5500,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -414;
         }
 
@@ -5509,7 +5509,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -404;
         }
 
@@ -5522,7 +5522,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -405;
         }
         ret = (int)fwrite(pem, 1, pemSz, pemFile);
@@ -5531,7 +5531,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -406;
         }
         XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -5558,14 +5558,14 @@ int rsa_test(void)
                                                        DYNAMIC_TYPE_TMP_BUFFER);
         if (derCert == NULL) {
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -311;
         }
         pem = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,DYNAMIC_TYPE_TMP_BUFFER);
         if (pem == NULL) {
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -312;
         }
 
@@ -5575,7 +5575,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -412;
         }
 
@@ -5587,7 +5587,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -411;
         }
         ret = wc_RsaPrivateKeyDecode(tmp, &idx3, &caKey, (word32)bytes3);
@@ -5596,7 +5596,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&caKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -413;
         }
 
@@ -5625,7 +5625,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -398;
         }
 
@@ -5634,7 +5634,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -399;
         }
 
@@ -5643,7 +5643,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -400;
         }
 #endif /* WOLFSSL_CERT_EXT */
@@ -5654,7 +5654,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&caKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -405;
         }
 
@@ -5664,7 +5664,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&caKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -407;
         }
 
@@ -5675,7 +5675,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&caKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -408;
         }
 
@@ -5687,7 +5687,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&caKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -409;
         }
         FreeDecodedCert(&decode);
@@ -5703,7 +5703,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&caKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -410;
         }
         ret = (int)fwrite(derCert, 1, certSz, derFile);
@@ -5713,7 +5713,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&caKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -416;
         }
 
@@ -5723,7 +5723,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&caKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -411;
         }
 
@@ -5737,7 +5737,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&caKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -412;
         }
         ret = (int)fwrite(pem, 1, pemSz, pemFile);
@@ -5747,7 +5747,7 @@ int rsa_test(void)
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             fclose(pemFile);
             wc_FreeRsaKey(&caKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -415;
         }
         fclose(pemFile);
@@ -5780,14 +5780,14 @@ int rsa_test(void)
                                                        DYNAMIC_TYPE_TMP_BUFFER);
         if (derCert == NULL) {
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5311;
         }
         pem = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,DYNAMIC_TYPE_TMP_BUFFER);
         if (pem == NULL) {
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5312;
         }
 
@@ -5797,7 +5797,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5412;
         }
 
@@ -5810,7 +5810,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5413;
         }
 
@@ -5839,7 +5839,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5500;
         }
 
@@ -5851,7 +5851,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5501;
         }
 
@@ -5862,7 +5862,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_ecc_free(&caKeyPub);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5502;
         }
 
@@ -5872,7 +5872,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_ecc_free(&caKeyPub);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5503;
         }
 
@@ -5882,7 +5882,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_ecc_free(&caKeyPub);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5504;
         }
         wc_ecc_free(&caKeyPub);
@@ -5892,7 +5892,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5505;
         }
 #endif /* WOLFSSL_CERT_EXT */
@@ -5903,7 +5903,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_ecc_free(&caKey);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5405;
         }
 
@@ -5913,7 +5913,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_ecc_free(&caKey);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5407;
         }
 
@@ -5924,7 +5924,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_ecc_free(&caKey);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5408;
         }
 
@@ -5936,7 +5936,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_ecc_free(&caKey);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5409;
         }
         FreeDecodedCert(&decode);
@@ -5952,7 +5952,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_ecc_free(&caKey);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5410;
         }
         ret = (int)fwrite(derCert, 1, certSz, derFile);
@@ -5962,7 +5962,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_ecc_free(&caKey);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5414;
         }
 
@@ -5972,7 +5972,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_ecc_free(&caKey);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5411;
         }
 
@@ -5986,7 +5986,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_ecc_free(&caKey);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5412;
         }
         ret = (int)fwrite(pem, 1, pemSz, pemFile);
@@ -5995,7 +5995,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_ecc_free(&caKey);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -5415;
         }
 
@@ -6025,14 +6025,14 @@ int rsa_test(void)
                                                        DYNAMIC_TYPE_TMP_BUFFER);
         if (derCert == NULL) {
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -311;
         }
         pem = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,DYNAMIC_TYPE_TMP_BUFFER);
         if (pem == NULL) {
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -312;
         }
 
@@ -6050,7 +6050,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -448;
         }
 
@@ -6061,7 +6061,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -449;
         }
 
@@ -6072,7 +6072,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -450;
         }
 
@@ -6082,7 +6082,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -451;
         }
 
@@ -6092,7 +6092,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -452;
         }
 
@@ -6104,7 +6104,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -453;
         }
         ret = wc_RsaPrivateKeyDecode(tmp, &idx3, &caKey, (word32)bytes);
@@ -6112,7 +6112,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -454;
         }
 
@@ -6135,7 +6135,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -496;
         }
 
@@ -6144,7 +6144,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -495;
         }
 
@@ -6154,7 +6154,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -494;
         }
 #endif /* WOLFSSL_CERT_EXT */
@@ -6165,7 +6165,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&caKey);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -455;
         }
 
@@ -6176,7 +6176,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_FreeRsaKey(&caKey);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -456;
         }
 
@@ -6187,7 +6187,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -457;
         }
 
@@ -6199,7 +6199,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -458;
         }
         FreeDecodedCert(&decode);
@@ -6209,7 +6209,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -459;
         }
         ret = (int)fwrite(derCert, 1, certSz, derFile);
@@ -6218,7 +6218,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -473;
         }
 
@@ -6227,7 +6227,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -460;
         }
 
@@ -6236,7 +6236,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -461;
         }
         ret = (int)fwrite(pem, 1, pemSz, pemFile);
@@ -6245,7 +6245,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -474;
         }
 
@@ -6254,7 +6254,7 @@ int rsa_test(void)
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -462;
         }
         ret = (int)fwrite(private_key, 1, private_key_len, ntruPrivFile);
@@ -6263,7 +6263,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -475;
         }
         XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -6282,14 +6282,14 @@ int rsa_test(void)
         der = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,DYNAMIC_TYPE_TMP_BUFFER);
         if (der == NULL) {
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -463;
         }
         pem = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,DYNAMIC_TYPE_TMP_BUFFER);
         if (pem == NULL) {
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -464;
         }
 
@@ -6313,7 +6313,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -496;
         }
 
@@ -6323,7 +6323,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -494;
         }
 #endif /* WOLFSSL_CERT_EXT */
@@ -6333,7 +6333,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -465;
         }
 
@@ -6343,7 +6343,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -466;
         }
 
@@ -6352,7 +6352,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -467;
         }
 
@@ -6365,7 +6365,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -468;
         }
 
@@ -6375,7 +6375,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -471;
         }
 
@@ -6388,7 +6388,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -469;
         }
         ret = (int)fwrite(pem, 1, pemSz, reqFile);
@@ -6397,7 +6397,7 @@ int rsa_test(void)
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-	    wc_FreeRng(&rng);
+    	    wc_FreeRng(&rng);
             return -470;
         }
 
@@ -6473,8 +6473,13 @@ int dh_test(void)
     (void)tmp;
     (void)bytes;
 
-    wc_InitDhKey(&key);
-    wc_InitDhKey(&key2);
+    ret = wc_InitDhKey(&key);
+    if (ret != 0)
+        return -57;
+    ret = wc_InitDhKey(&key2);
+    if (ret != 0)
+        return -57;
+
 #ifdef NO_ASN
     ret = wc_DhSetKey(&key, dh_p, sizeof(dh_p), dh_g, sizeof(dh_g));
     if (ret != 0)
@@ -6566,7 +6571,9 @@ int dsa_test(void)
     wc_ShaUpdate(&sha, tmp, bytes);
     wc_ShaFinal(&sha, hash);
 
-    wc_InitDsaKey(&key);
+    ret = wc_InitDsaKey(&key);
+    if (ret != 0) return -66;
+
     ret = wc_DsaPrivateKeyDecode(tmp, &idx, &key, bytes);
     if (ret != 0) return -61;
 
@@ -6593,12 +6600,20 @@ int dsa_test(void)
     FILE*  keyFile;
     FILE*  pemFile;
 
-    wc_InitDsaKey(&genKey);
+    ret = wc_InitDsaKey(&genKey);
+    if (ret != 0) return -361;
+
     ret = wc_MakeDsaParameters(&rng, 1024, &genKey);
-    if (ret != 0) return -362;
+    if (ret != 0) {
+        wc_FreeDsaKey(&genKey);
+        return -362;
+    }
 
     ret = wc_MakeDsaKey(&rng, &genKey);
-    if (ret != 0) return -363;
+    if (ret != 0) {
+        wc_FreeDsaKey(&genKey);
+        return -363;
+    }
 
     der = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (der == NULL) {
@@ -6667,7 +6682,14 @@ int dsa_test(void)
         return -371;
     }
 
-    wc_InitDsaKey(&derIn);
+    ret = wc_InitDsaKey(&derIn);
+    if (ret != 0) {
+        XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        wc_FreeDsaKey(&genKey);
+        return -374;
+    }
+
     idx = 0;
     ret = wc_DsaPrivateKeyDecode(der, &idx, &derIn, derSz);
     if (ret != 0) {

--- a/wolfssl/wolfcrypt/dh.h
+++ b/wolfssl/wolfcrypt/dh.h
@@ -41,7 +41,7 @@ typedef struct DhKey {
 } DhKey;
 
 
-WOLFSSL_API void wc_InitDhKey(DhKey* key);
+WOLFSSL_API int wc_InitDhKey(DhKey* key);
 WOLFSSL_API void wc_FreeDhKey(DhKey* key);
 
 WOLFSSL_API int wc_DhGenerateKeyPair(DhKey* key, WC_RNG* rng, byte* priv,

--- a/wolfssl/wolfcrypt/dsa.h
+++ b/wolfssl/wolfcrypt/dsa.h
@@ -56,8 +56,8 @@ typedef struct DsaKey {
     void* heap;                               /* memory hint */
 } DsaKey;
 
-WOLFSSL_API void wc_InitDsaKey(DsaKey* key);
-WOLFSSL_API int  wc_InitDsaKey_h(DsaKey* key, void* h);
+WOLFSSL_API int wc_InitDsaKey(DsaKey* key);
+WOLFSSL_API int wc_InitDsaKey_h(DsaKey* key, void* h);
 WOLFSSL_API void wc_FreeDsaKey(DsaKey* key);
 WOLFSSL_API int wc_DsaSign(const byte* digest, byte* out,
                            DsaKey* key, WC_RNG* rng);

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -239,6 +239,7 @@ void mp_clear (mp_int * a);
 void mp_forcezero(mp_int * a);
 int  mp_unsigned_bin_size(mp_int * a);
 int  mp_read_unsigned_bin (mp_int * a, const unsigned char *b, int c);
+int  mp_to_unsigned_bin_at_pos(int x, mp_int *t, unsigned char *b);
 int  mp_to_unsigned_bin (mp_int * a, unsigned char *b);
 int  mp_exptmod (mp_int * G, mp_int * X, mp_int * P, mp_int * Y);
 /* end functions needed by Rsa */

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -37,7 +37,7 @@
     #include <wolfssl/wolfcrypt/tfm.h>
 #else
 
-#include <wolfssl/wolfcrypt/random.h> 
+#include <wolfssl/wolfcrypt/random.h>
 
 #ifndef CHAR_BIT
     #include <limits.h>
@@ -96,7 +96,7 @@ extern "C" {
 #elif defined(MP_16BIT) || defined(NO_64BIT)
    typedef unsigned short     mp_digit;
    typedef unsigned int       mp_word;
-   #define DIGIT_BIT          12 
+   #define DIGIT_BIT          12
 #elif defined(MP_64BIT)
    /* for GCC only on supported platforms */
    typedef unsigned long long mp_digit;  /* 64 bit type, 128 uses mode(TI) */
@@ -265,7 +265,7 @@ int  mp_invmod_slow (mp_int * a, mp_int * b, mp_int * c);
 int  mp_cmp_mag (mp_int * a, mp_int * b);
 int  mp_cmp (mp_int * a, mp_int * b);
 int  mp_cmp_d(mp_int * a, mp_digit b);
-void mp_set (mp_int * a, mp_digit b);
+int  mp_set (mp_int * a, mp_digit b);
 int  mp_is_bit_set (mp_int * a, mp_digit b);
 int  mp_mod (mp_int * a, mp_int * b, mp_int * c);
 int  mp_div(mp_int * a, mp_int * b, mp_int * c, mp_int * d);

--- a/wolfssl/wolfcrypt/port/nxp/ksdk_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/ksdk_port.h
@@ -23,7 +23,11 @@
 #define _KSDK_PORT_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/tfm.h>
+#ifdef USE_FAST_MATH
+    #include <wolfssl/wolfcrypt/tfm.h>
+#else
+    #include <wolfssl/wolfcrypt/integer.h>
+#endif
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/curve25519.h>
 #include <wolfssl/wolfcrypt/ed25519.h>
@@ -34,13 +38,12 @@ int ksdk_port_init(void);
 
 /* software algorithm, by wolfcrypt */
 #if defined(FREESCALE_LTC_TFM)
-	void wolfcrypt_fp_mul(fp_int *A, fp_int *B, fp_int *C);
-	int wolfcrypt_fp_mod(fp_int *a, fp_int *b, fp_int *c);
-	int wolfcrypt_fp_mulmod(fp_int *a, fp_int *b, fp_int *c, fp_int *d);
-	int wolfcrypt_fp_mod(fp_int *a, fp_int *b, fp_int *c);
-	int wolfcrypt_fp_invmod(fp_int *a, fp_int *b, fp_int *c);
-	int _wolfcrypt_fp_exptmod(fp_int *G, fp_int *X, fp_int *P, fp_int *Y);
-	int _fp_exptmod(fp_int *G, fp_int *X, fp_int *P, fp_int *Y);
+	int wolfcrypt_mp_mul(mp_int *A, mp_int *B, mp_int *C);
+	int wolfcrypt_mp_mod(mp_int *a, mp_int *b, mp_int *c);
+	int wolfcrypt_mp_mulmod(mp_int *a, mp_int *b, mp_int *c, mp_int *d);
+	int wolfcrypt_mp_mod(mp_int *a, mp_int *b, mp_int *c);
+	int wolfcrypt_mp_invmod(mp_int *a, mp_int *b, mp_int *c);
+	int wolfcrypt_mp_exptmod(mp_int *G, mp_int *X, mp_int *P, mp_int *Y);
 #endif /* FREESCALE_LTC_TFM */
 
 #if defined(FREESCALE_LTC_ECC)

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -914,8 +914,9 @@ static char *fgets(char *buff, int sz, FILE *fp)
 #endif /* FREESCALE_USE_LTC */
 
 #ifdef FREESCALE_LTC_TFM_RSA_4096_ENABLE
-    #undef  USE_CERT_BUFFERS_2048
+    #undef  USE_CERT_BUFFERS_4096
     #define USE_CERT_BUFFERS_4096
+    #undef  FP_MAX_BITS
     #define FP_MAX_BITS (8192)
 
     #undef  NO_DH

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -606,6 +606,8 @@ typedef fp_int mp_int;
 #define MP_OKAY FP_OKAY /* ok result    */
 #define MP_NO   FP_NO   /* yes/no result */
 #define MP_YES  FP_YES  /* yes/no result */
+#define MP_ZPOS FP_ZPOS
+#define MP_NEG  FP_NEG
 
 /* Prototypes */
 #define mp_zero(a)  fp_zero(a)

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -639,6 +639,7 @@ int  mp_cmp_d(mp_int *a, mp_digit b);
 
 int  mp_unsigned_bin_size(mp_int * a);
 int  mp_read_unsigned_bin (mp_int * a, const unsigned char *b, int c);
+int  mp_to_unsigned_bin_at_pos(int x, mp_int *t, unsigned char *b);
 int  mp_to_unsigned_bin (mp_int * a, unsigned char *b);
 
 int  mp_sub_d(fp_int *a, fp_digit b, fp_int *c);

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -671,7 +671,7 @@ int mp_radix_size (mp_int * a, int radix, int *size);
 #endif
 
 #if defined(HAVE_ECC) || !defined(NO_RSA) || !defined(NO_DSA)
-    void mp_set(fp_int *a, fp_digit b);
+    int mp_set(fp_int *a, fp_digit b);
 #endif
 
 #if defined(HAVE_ECC) || defined(WOLFSSL_KEY_GEN)


### PR DESCRIPTION
Added memory tracker support to ./tests/unit.test. Fix memory leak with curve cache enabled, by adding to wolfSSL_Cleanup.

./configure --disable-fastmath && make
./wolfcrypt/benchmark/benchmark

Benchmarks (% improvement):
RSA 2048 public:  35.7%
RSA 2048 private: 25%
DH  2048 key generation: nil
DH  2048 key agreement: 10.5%
ECC  256 key generation: 10.6%
EC-DHE   key agreement: 7.2%
EC-DSA   sign   time: 19.8%
EC-DSA   verify time: 21%

Memory Allocation Stats:
./configure --disable-fastmath CFLAGS="-DWOLFSSL_TRACK_MEMORY" && make
./wolfcrypt/test/testwolfcrypt
Before:
total   Allocs =   3023114
total   Bytes  = 12093762338
peak    Bytes  =     22296
current Bytes  =         0

After:
total   Allocs =   2230877
total   Bytes  = 12084379170
peak    Bytes  =     22288
current Bytes  =         0

total alloc reduction of 26%
total byte reduction of < 1%
peak reduction of 8 bytes