### PR TITLE
wolfcrypt Python: work around minor issue in Random.__del__

### DIFF
--- a/wrapper/python/wolfcrypt/wolfcrypt/random.py
+++ b/wrapper/python/wolfcrypt/wolfcrypt/random.py
@@ -39,7 +39,11 @@ class Random(object):
 
     def __del__(self):
         if self.native_object:
-            _lib.wc_FreeRng(self.native_object)
+            try:
+                _lib.wc_FreeRng(self.native_object)
+            except AttributeError:
+                # Can occur during interpreter shutdown
+                pass
 
 
     def byte(self):


### PR DESCRIPTION
During interpreter shutdown, depending on the order in which things happen, a module can be unloaded before all instances of classes defined in that module are garbage collected.

In particular, this means that any global variables (including imported modules) become `None` by the time the instances `__del__` is called, resulting in
```
AttributeError: 'NoneType' object has no attribute 'wc_FreeRng'
```
being displayed while the process exits.  This can be avoided simply by catching and ignoring the `AttributeError` in this case, since the process is shutting down anyways.

This can be tricky to reproduce--in my own code it was happening deterministically for a while, but now I can't reproduce it.