### PR TITLE
wolfCrypt cleanup in test.c moved and add wolfSSL init to testsuite w…

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -2650,7 +2650,7 @@ static void test_wolfSSL_ERR_peek_last_error_line(void)
 {
     #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
        !defined(NO_FILESYSTEM) && defined(DEBUG_WOLFSSL) && \
-       !defined(NO_OLD_TLS)
+       !defined(NO_OLD_TLS) && defined(HAVE_IO_TESTS_DEPENDENCIES)
     tcp_ready ready;
     func_args client_args;
     func_args server_args;

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -405,11 +405,13 @@ int main(int argc, char** argv)
     server_args.argc = argc;
     server_args.argv = argv;
 
+    wolfSSL_Init();
     ChangeToWolfRoot();
 
     wolfcrypt_test(&server_args);
     if (server_args.return_code != 0) return server_args.return_code;
 
+    wolfSSL_Cleanup();
     printf("\nAll tests passed!\n");
 
     EXIT_TEST(EXIT_SUCCESS);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -327,8 +327,6 @@ int wolfcrypt_test(void* args)
     wolfSSL_Debugging_ON();
 #endif
 
-    wolfCrypt_Init();
-
 #if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
     wc_SetLoggingHeap(HEAP_HINT);
 #endif
@@ -730,10 +728,6 @@ int wolfcrypt_test(void* args)
         printf( "PKCS7encrypted test passed!\n");
 #endif
 
-    if ((ret = wolfCrypt_Cleanup())!= 0) {
-        return err_sys("Error with wolfCrypt_Cleanup!\n", ret);
-    }
-
 #if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)
     ShowMemoryTracker();
 #endif
@@ -762,7 +756,13 @@ int wolfcrypt_test(void* args)
         args.argc = argc;
         args.argv = argv;
 
+        wolfCrypt_Init();
+
         wolfcrypt_test(&args);
+
+        if (wolfCrypt_Cleanup() != 0) {
+            return err_sys("Error with wolfCrypt_Cleanup!\n", -1239);
+        }
 
 #ifdef HAVE_WNR
         if (wc_FreeNetRandom() < 0)


### PR DESCRIPTION
…ith single threaded

This was uncovered running testsuite on a Windows machine. When testsuite calls wolfcrypt_test both wolfCrypt_Init and wolfCrypt_Cleanup would get called by wolfcrypt_test. Also added wolfSSL_Init to testsuite when running with single threaded feature on.