### PR TITLE
PKCS7: fix optional UserKeyingMaterial encoding

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1326,6 +1326,7 @@ static int wc_PKCS7_KariGenerateSharedInfo(WC_PKCS7_KARI* kari, int keyWrapOID)
     int keyInfoSz = 0;
     int suppPubInfoSeqSz = 0;
     int entityUInfoOctetSz = 0;
+    int entityUInfoExplicitSz = 0;
     int kekOctetSz = 0;
     int sharedInfoSz = 0;
 
@@ -1335,6 +1336,7 @@ static int wc_PKCS7_KariGenerateSharedInfo(WC_PKCS7_KARI* kari, int keyWrapOID)
     byte keyInfo[MAX_ALGO_SZ];
     byte suppPubInfoSeq[MAX_SEQ_SZ];
     byte entityUInfoOctet[MAX_OCTET_STR_SZ];
+    byte entityUInfoExplicitSeq[MAX_SEQ_SZ];
     byte kekOctet[MAX_OCTET_STR_SZ];
 
     if (kari == NULL)
@@ -1357,6 +1359,11 @@ static int wc_PKCS7_KariGenerateSharedInfo(WC_PKCS7_KARI* kari, int keyWrapOID)
     if (kari->ukmSz > 0) {
         entityUInfoOctetSz = SetOctetString(kari->ukmSz, entityUInfoOctet);
         sharedInfoSz += (entityUInfoOctetSz + kari->ukmSz);
+
+        entityUInfoExplicitSz = SetExplicit(0, entityUInfoOctetSz +
+                                            kari->ukmSz,
+                                            entityUInfoExplicitSeq);
+        sharedInfoSz += entityUInfoExplicitSz;
     }
 
     /* keyInfo */
@@ -1379,6 +1386,9 @@ static int wc_PKCS7_KariGenerateSharedInfo(WC_PKCS7_KARI* kari, int keyWrapOID)
     XMEMCPY(kari->sharedInfo + idx, keyInfo, keyInfoSz);
     idx += keyInfoSz;
     if (kari->ukmSz > 0) {
+        XMEMCPY(kari->sharedInfo + idx, entityUInfoExplicitSeq,
+                entityUInfoExplicitSz);
+        idx += entityUInfoExplicitSz;
         XMEMCPY(kari->sharedInfo + idx, entityUInfoOctet, entityUInfoOctetSz);
         idx += entityUInfoOctetSz;
         XMEMCPY(kari->sharedInfo + idx, kari->ukm, kari->ukmSz);


### PR DESCRIPTION
This PR fixes the encoding of an optional UserKeyingMaterial element in PKCS#7.

Prior to this fix, wolfSSL worked against itself with bundles that were generated using the optional UKM, but failed against OpenSSL.

To verify that wolfSSL now correctly generates PKCS#7/CMS bundles with the optional ukm:

```
$ cd wolfssl
$ ./configure --enable-pkcs7 CFLAGS="-DPKCS7_OUTPUT_TEST_BUNDLES"
$ make
$ make check

$ openssl cms -decrypt -inform DER -in pkcs7envelopedDataAES256CBC_ECDH_SHA512KDF_ukm.der -recip ./certs/client-ecc-cert.pem -inkey ./certs/ecc-client-key.pem
```

This PR is related to Zendesk ticket 2662.