### PR TITLE
Release

### DIFF
--- a/README
+++ b/README
@@ -34,6 +34,39 @@ before calling wolfSSL_new();  Though it's not recommended.
 
 *** end Notes ***
 
+********* wolfSSL (Formerly CyaSSL) Release 3.10.2 (2/10/2017)
+
+Release 3.10.2 of wolfSSL has bug fixes and new features including:
+
+- Poly1305 Windows macros fix. Thanks to GitHub user Jay Satiro
+- Compatibility layer expanded with multiple functions added
+- Improve fp_copy performance with ALT_ECC_SIZE
+- OCSP updates and improvements
+- Fixes for IAR EWARM 8 compiler warnings
+- Reduce stack usage with ECC_CACHE_CURVE disabled
+- Added ECC export raw for public and private key
+- Fix for NO_ASN_TIME build
+- Supported curves extensions now populated by default
+- Add DTLS build without big integer math
+- Fix for static memory feature with wc_ecc_verify_hash_ex and not SHAMIR
+- Added PSK interoperability testing to script bundled with wolfSSL
+- Fix for Python wrapper random number generation. Compiler optimizations with Python could place the random number in same buffer location each time. Thanks to GitHub user Erik Bray (embray)
+- Fix for tests on unaligned memory with static memory feature
+- Add macro WOLFSSL_NO_OCSP_OPTIONAL_CERTS to skip optional OCSP certificates
+- Sanity checks on NULL arguments added to wolfSSL_set_fd and wolfSSL_DTLS_SetCookieSecret
+- mp_jacobi stack use reduced, thanks to Szabi Tolnai for providing a solution to reduce stack usage
+
+
+This release of wolfSSL fixes 2 low and 1 medium level security vulnerability.
+
+Low level fix of buffer overflow for when loading in a malformed temporary DH file. Thanks to Yueh-Hsun Lin and Peng Li from KNOX Security, Samsung Research America for the report.
+
+Medium level fix for processing of OCSP response. If using OCSP without hard faults enforced and no alternate revocation checks like OCSP stapling then it is recommended to update.
+
+Low level fix for potential cache attack on RSA operations. If using wolfSSL RSA on a server that other users can have access to monitor the cache, then it is recommended to update wolfSSL. Thanks to Andreas Zankl, Johann Heyszl and Georg Sigl at Fraunhofer AISEC for the initial report.
+
+See INSTALL file for build instructions.
+More info can be found on-line at http://wolfssl.com/wolfSSL/Docs.html
 
 ********* wolfSSL (Formerly CyaSSL) Release 3.10.0 (12/21/2016)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,41 @@ wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0);
 before calling wolfSSL_new();  Though it's not recommended.
 ```
 
+# wolfSSL (Formerly CyaSSL) Release 3.10.2 (2/10/2017)
+
+## Release 3.10.2 of wolfSSL has bug fixes and new features including:
+
+- Poly1305 Windows macros fix. Thanks to GitHub user Jay Satiro
+- Compatibility layer expanded with multiple functions added
+- Improve fp_copy performance with ALT_ECC_SIZE
+- OCSP updates and improvements
+- Fixes for IAR EWARM 8 compiler warnings
+- Reduce stack usage with ECC_CACHE_CURVE disabled
+- Added ECC export raw for public and private key
+- Fix for NO_ASN_TIME build
+- Supported curves extensions now populated by default
+- Add DTLS build without big integer math
+- Fix for static memory feature with wc_ecc_verify_hash_ex and not SHAMIR
+- Added PSK interoperability testing to script bundled with wolfSSL
+- Fix for Python wrapper random number generation. Compiler optimizations with Python could place the random number in same buffer location each time. Thanks to GitHub user Erik Bray (embray)
+- Fix for tests on unaligned memory with static memory feature
+- Add macro WOLFSSL_NO_OCSP_OPTIONAL_CERTS to skip optional OCSP certificates
+- Sanity checks on NULL arguments added to wolfSSL_set_fd and wolfSSL_DTLS_SetCookieSecret
+- mp_jacobi stack use reduced, thanks to Szabi Tolnai for providing a solution to reduce stack usage
+
+
+This release of wolfSSL fixes 2 low and 1 medium level security vulnerability.
+
+Low level fix of buffer overflow for when loading in a malformed temporary DH file. Thanks to Yueh-Hsun Lin and Peng Li from KNOX Security, Samsung Research America for the report.
+
+Medium level fix for processing of OCSP response. If using OCSP without hard faults enforced and no alternate revocation checks like OCSP stapling then it is recommended to update.
+
+Low level fix for potential cache attack on RSA operations. If using wolfSSL RSA on a server that other users can have access to monitor the cache, then it is recommended to update wolfSSL. Thanks to Andreas Zankl, Johann Heyszl and Georg Sigl at Fraunhofer AISEC for the initial report.
+
+See INSTALL file for build instructions.
+More info can be found on-line at http://wolfssl.com/wolfSSL/Docs.html
+
+
 # wolfSSL (Formerly CyaSSL) Release 3.10.0 (12/21/2016)
 
 ## Release 3.10.0 of wolfSSL has bug fixes and new features including:

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #
 #
 
-AC_INIT([wolfssl],[3.10.0],[https://github.com/wolfssl/wolfssl/issues],[wolfssl],[http://www.wolfssl.com])
+AC_INIT([wolfssl],[3.10.2],[https://github.com/wolfssl/wolfssl/issues],[wolfssl],[http://www.wolfssl.com])
 
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -35,7 +35,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h:config.in])dnl Keep filename to 8.3 for MS-DOS.
 
 #shared library versioning
-WOLFSSL_LIBRARY_VERSION=9:0:6
+WOLFSSL_LIBRARY_VERSION=10:0:0
 #                       | | |
 #                +------+ | +---+
 #                |        |     |

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -72,8 +72,8 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_docdir}/wolfssl/README.txt
 %{_libdir}/libwolfssl.la
 %{_libdir}/libwolfssl.so
-%{_libdir}/libwolfssl.so.3
-%{_libdir}/libwolfssl.so.3.6.0
+%{_libdir}/libwolfssl.so.10
+%{_libdir}/libwolfssl.so.10.0.0
 
 %files devel
 %defattr(-,root,root,-)
@@ -229,6 +229,7 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/wolfssl/wolfcrypt/visibility.h
 %{_includedir}/wolfssl/wolfcrypt/wc_encrypt.h
 %{_includedir}/wolfssl/wolfcrypt/wolfevent.h
+%{_includedir}/wolfssl/wolfcrypt/wolfmath.h
 %{_includedir}/wolfssl/error-ssl.h
 %{_includedir}/wolfssl/ocsp.h
 %{_includedir}/wolfssl/openssl/aes.h
@@ -276,6 +277,8 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_libdir}/pkgconfig/wolfssl.pc
 
 %changelog
+* Thu Feb 09 2017 Jacob Barthelmeh <jacob@wolfssl.com>
+- Added header for wolfssl/wolfcrypt/wolfmath.h
 * Fri Nov 11 2016 Jacob Barthelmeh <jacob@wolfssl.com>
 - Added header for wolfssl/openssl/aes.h
 * Fri Oct 28 2016 Jacob Barthelmeh <jacob@wolfssl.com>

--- a/src/crl.c
+++ b/src/crl.c
@@ -873,9 +873,19 @@ int LoadCRL(WOLFSSL_CRL* crl, const char* path, int type, int monitor)
             pathBuf[pathLen] = '\0'; /* Null Terminate */
 
             if (type == SSL_FILETYPE_PEM) {
+                /* free old path before setting a new one */
+                if (crl->monitors[0].path) {
+                    XFREE(crl->monitors[0].path, crl->heap,
+                            DYNAMIC_TYPE_CRL_MONITOR);
+                }
                 crl->monitors[0].path = pathBuf;
                 crl->monitors[0].type = SSL_FILETYPE_PEM;
             } else {
+                /* free old path before setting a new one */
+                if (crl->monitors[1].path) {
+                    XFREE(crl->monitors[1].path, crl->heap,
+                            DYNAMIC_TYPE_CRL_MONITOR);
+                }
                 crl->monitors[1].path = pathBuf;
                 crl->monitors[1].type = SSL_FILETYPE_ASN1;
             }

--- a/support/wolfssl.pc
+++ b/support/wolfssl.pc
@@ -5,6 +5,6 @@ includedir=${prefix}/include
 
 Name: wolfssl
 Description: wolfssl C library.
-Version: 3.10.0
+Version: 3.10.2
 Libs: -L${libdir} -lwolfssl
 Cflags: -I${includedir}

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8501,18 +8501,27 @@ int wc_SetAuthKeyIdFromCert(Cert *cert, const byte *der, int derSz)
     ret = ParseCert(decoded, CERT_TYPE, NO_VERIFY, 0);
     if (ret != 0) {
         FreeDecodedCert(decoded);
+        #ifdef WOLFSSL_SMALL_STACK
+            XFREE(decoded, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        #endif
         return ret;
     }
 
     /* Subject Key Id not found !! */
     if (decoded->extSubjKeyIdSet == 0) {
         FreeDecodedCert(decoded);
+        #ifdef WOLFSSL_SMALL_STACK
+            XFREE(decoded, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        #endif
         return ASN_NO_SKID;
     }
 
     /* SKID invalid size */
     if (sizeof(cert->akid) < sizeof(decoded->extSubjKeyId)) {
         FreeDecodedCert(decoded);
+        #ifdef WOLFSSL_SMALL_STACK
+            XFREE(decoded, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        #endif
         return MEMORY_E;
     }
 
@@ -8521,6 +8530,10 @@ int wc_SetAuthKeyIdFromCert(Cert *cert, const byte *der, int derSz)
     cert->akidSz = KEYID_SIZE;
 
     FreeDecodedCert(decoded);
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(decoded, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    #endif
+
     return 0;
 }
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3891,9 +3891,9 @@ int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
 #ifdef HAVE_COMP_KEY
     if (err == MP_OKAY && compressed == 1) {   /* build y */
         mp_int t1, t2;
-        DECLARE_CURVE_SPECS(3)
-
         int did_init = 0;
+
+        DECLARE_CURVE_SPECS(3)
 
         if (mp_init_multi(&t1, &t2, NULL, NULL, NULL, NULL) != MP_OKAY)
             err = MEMORY_E;
@@ -4495,9 +4495,10 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
 
 #ifdef HAVE_COMP_KEY
     if (err == MP_OKAY && compressed == 1) {   /* build y */
-        DECLARE_CURVE_SPECS(3)
         mp_int t1, t2;
         int did_init = 0;
+
+        DECLARE_CURVE_SPECS(3)
 
         if (mp_init_multi(&t1, &t2, NULL, NULL, NULL, NULL) != MP_OKAY)
             err = MEMORY_E;

--- a/wolfssl/version.h
+++ b/wolfssl/version.h
@@ -28,8 +28,8 @@
 extern "C" {
 #endif
 
-#define LIBWOLFSSL_VERSION_STRING "3.10.0"
-#define LIBWOLFSSL_VERSION_HEX 0x03010000
+#define LIBWOLFSSL_VERSION_STRING "3.10.2"
+#define LIBWOLFSSL_VERSION_HEX 0x03010002
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
3 additional commits where added with README and version update.

commit 0cbc640 fixes freeing existing crl monitor path.

commit e307f3e fixes freeing variable decoded when building with small stack and calling functions to set auth key id.

commit 6c55701 is for use of c89 compilers when compiling with compressed ECC keys enabled.