### PR TITLE
Fixes for scan-build warnings

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16133,6 +16133,7 @@ WOLFSSL_DH* wolfSSL_DH_new(void)
     if (wc_InitDhKey(key) != 0) {
         WOLFSSL_MSG("wolfSSL_DH_new InitDhKey failure");
         XFREE(key, NULL, DYNAMIC_TYPE_DH);
+        XFREE(external, NULL, DYNAMIC_TYPE_DH);
         return NULL;
     }
     external->internal = key;

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -330,11 +330,15 @@ int mp_copy (mp_int * a, mp_int * b)
   }
 
   /* grow dest */
-  if (b->alloc < a->used || b->dp == NULL) {
+  if (b->alloc < a->used) {
      if ((res = mp_grow (b, a->used)) != MP_OKAY) {
         return res;
      }
   }
+
+  /* sanity check on destination */
+  if (b->dp == NULL)
+     return MP_VAL;
 
   /* zero b and copy the parameters over */
   {
@@ -1633,11 +1637,16 @@ int s_mp_sub (mp_int * a, mp_int * b, mp_int * c)
   max_a = a->used;
 
   /* init result */
-  if (c->alloc < max_a || c->dp == NULL) {
+  if (c->alloc < max_a) {
     if ((res = mp_grow (c, max_a)) != MP_OKAY) {
       return res;
     }
   }
+
+  /* sanity check on destination */
+  if (c->dp == NULL)
+     return MP_VAL;
+
   olduse = c->used;
   c->used = max_a;
 

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -330,7 +330,7 @@ int mp_copy (mp_int * a, mp_int * b)
   }
 
   /* grow dest */
-  if (b->alloc < a->used) {
+  if (b->alloc < a->used || b->dp == NULL) {
      if ((res = mp_grow (b, a->used)) != MP_OKAY) {
         return res;
      }
@@ -1633,7 +1633,7 @@ int s_mp_sub (mp_int * a, mp_int * b, mp_int * c)
   max_a = a->used;
 
   /* init result */
-  if (c->alloc < max_a) {
+  if (c->alloc < max_a || c->dp == NULL) {
     if ((res = mp_grow (c, max_a)) != MP_OKAY) {
       return res;
     }

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -336,10 +336,6 @@ int mp_copy (mp_int * a, mp_int * b)
      }
   }
 
-  /* sanity check on destination */
-  if (b->dp == NULL)
-     return MP_VAL;
-
   /* zero b and copy the parameters over */
   {
     mp_digit *tmpa, *tmpb;
@@ -358,7 +354,7 @@ int mp_copy (mp_int * a, mp_int * b)
     }
 
     /* clear high digits */
-    for (; n < b->used; n++) {
+    for (; n < b->used && b->dp; n++) {
       *tmpb++ = 0;
     }
   }
@@ -3776,7 +3772,7 @@ int s_mp_mul_high_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
 
   pa = a->used;
   pb = b->used;
-  for (ix = 0; ix < pa; ix++) {
+  for (ix = 0; ix < pa && a->dp; ix++) {
     /* clear the carry */
     u = 0;
 
@@ -3849,7 +3845,7 @@ int fast_s_mp_mul_high_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
   /* number of output digits to produce */
   pa = a->used + b->used;
   _W = 0;
-  for (ix = digs; ix < pa; ix++) {
+  for (ix = digs; ix < pa && a->dp; ix++) {
       int      tx, ty, iy;
       mp_digit *tmpx, *tmpy;
 

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -78,6 +78,7 @@ int wolfCrypt_Init(void)
             WOLFSSL_MSG(ippGetStatusString(ret));
             WOLFSSL_MSG("Using default fast IPP library");
             ret = 0;
+            (void)ret; /* suppress not read warning */
         }
     #endif
 


### PR DESCRIPTION
Fix possible memory leak in wolfSSL_DH_new on failure. Add null checks in integer.c for destination to make sure “dp” grows when NULL (even though never happens in real-use). Added suppression of wc_port.c warning “Value stored to 'ret' is never read”.