### PR TITLE
Added support for inline CRL lookup when HAVE_CRL_IO is defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -326,7 +326,7 @@ AC_ARG_ENABLE([ipv6],
 
 if test "$ENABLED_IPV6" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DTEST_IPV6"
+    AM_CFLAGS="$AM_CFLAGS -DTEST_IPV6 -DWOLFSSL_IPV6"
 fi
 
 AM_CONDITIONAL([BUILD_IPV6], [test "x$ENABLED_IPV6" = "xyes"])
@@ -3340,7 +3340,7 @@ echo "#endif /* WOLFSSL_OPTIONS_H */" >> $OPTION_FILE
 echo "" >> $OPTION_FILE
 echo
 
-#backwards compatability for those who have included options or version
+#backwards compatibility for those who have included options or version
 touch cyassl/options.h
 echo "/* cyassl options.h" > cyassl/options.h
 echo " * generated from wolfssl/options.h" >> cyassl/options.h

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -57,6 +57,8 @@
     static int devId = INVALID_DEVID;
 #endif
 
+#define DEFAULT_TIMEOUT_SEC 2
+
 /* Note on using port 0: the client standalone example doesn't utilize the
  * port 0 port sharing; that is used by (1) the server in external control
  * test mode and (2) the testsuite which uses this code and sets up the correct
@@ -277,7 +279,7 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
                     tx_time += current_time(0) - start;
 
                     /* Perform RX */
-                    select_ret = tcp_select(sockfd, 1); /* Timeout=1 second */
+                    select_ret = tcp_select(sockfd, DEFAULT_TIMEOUT_SEC);
                     if (select_ret == TEST_RECV_READY) {
                         start = current_time(1);
                         rx_pos = 0;
@@ -1182,6 +1184,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
 #ifdef HAVE_OCSP
     if (useOcsp) {
+    #ifdef HAVE_IO_TIMEOUT
+        wolfIO_SetTimeout(DEFAULT_TIMEOUT_SEC);
+    #endif
+
         if (ocspUrl != NULL) {
             wolfSSL_CTX_SetOCSP_OverrideURL(ctx, ocspUrl);
             wolfSSL_CTX_EnableOCSP(ctx, WOLFSSL_OCSP_NO_NONCE
@@ -1458,6 +1464,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
 #ifdef HAVE_CRL
     if (disableCRL == 0) {
+    #ifdef HAVE_IO_TIMEOUT
+        wolfIO_SetTimeout(DEFAULT_TIMEOUT_SEC);
+    #endif
+
         if (wolfSSL_EnableCRL(ssl, WOLFSSL_CRL_CHECKALL) != SSL_SUCCESS) {
             wolfSSL_free(ssl);
             wolfSSL_CTX_free(ctx);
@@ -1527,7 +1537,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         }
     }
 #else
-    timeout.tv_sec  = 2;
+    timeout.tv_sec  = DEFAULT_TIMEOUT_SEC;
     timeout.tv_usec = 0;
     NonBlockingSSL_Connect(ssl);  /* will keep retrying on timeout */
 #endif
@@ -1791,7 +1801,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             err_sys("SSL resume failed");
         }
 #else
-        timeout.tv_sec  = 2;
+        timeout.tv_sec  = DEFAULT_TIMEOUT_SEC;
         timeout.tv_usec = 0;
         NonBlockingSSL_Connect(ssl);  /* will keep retrying on timeout */
 #endif
@@ -1848,32 +1858,33 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             #endif
         }
 
-    input = wolfSSL_read(sslResume, reply, sizeof(reply)-1);
+        input = wolfSSL_read(sslResume, reply, sizeof(reply)-1);
 
-    if (input > 0) {
-        reply[input] = 0;
-        printf("Server resume response: %s\n", reply);
+        if (input > 0) {
+            reply[input] = 0;
+            printf("Server resume response: %s\n", reply);
 
-        if (sendGET) {  /* get html */
-            while (1) {
-                input = wolfSSL_read(sslResume, reply, sizeof(reply)-1);
-                if (input > 0) {
-                    reply[input] = 0;
-                    printf("%s\n", reply);
+            if (sendGET) {  /* get html */
+                while (1) {
+                    input = wolfSSL_read(sslResume, reply, sizeof(reply)-1);
+                    if (input > 0) {
+                        reply[input] = 0;
+                        printf("%s\n", reply);
+                    }
+                    else
+                        break;
                 }
-                else
-                    break;
             }
         }
-    } else if (input < 0) {
-        int readErr = wolfSSL_get_error(sslResume, 0);
-        if (readErr != SSL_ERROR_WANT_READ) {
-            printf("wolfSSL_read error %d!\n", readErr);
-            wolfSSL_free(sslResume);
-            wolfSSL_CTX_free(ctx);
-            err_sys("wolfSSL_read failed");
+        else if (input < 0) {
+            int readErr = wolfSSL_get_error(sslResume, 0);
+            if (readErr != SSL_ERROR_WANT_READ) {
+                printf("wolfSSL_read error %d!\n", readErr);
+                wolfSSL_free(sslResume);
+                wolfSSL_CTX_free(ctx);
+                err_sys("wolfSSL_read failed");
+            }
         }
-    }
 
         /* try to send session break */
         wolfSSL_write(sslResume, msg, msgSz);

--- a/src/internal.c
+++ b/src/internal.c
@@ -11853,6 +11853,8 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
     case NOT_CA_ERROR:
         return "Not a CA by basic constraint error";
 
+    case HTTP_TIMEOUT:
+        return "HTTP timeout for OCSP or CRL req";
 
     case BAD_CERT_MANAGER_ERROR:
         return "Bad Cert Manager error";

--- a/src/io.c
+++ b/src/io.c
@@ -36,197 +36,29 @@
 
 #include <wolfssl/internal.h>
 #include <wolfssl/error-ssl.h>
+#include <wolfssl/io.h>
+
+#if defined(HAVE_HTTP_CLIENT)
+    #include <stdlib.h>   /* atoi(), strtol() */
+#endif
+
+/*
+Possible IO enable options:
+ * WOLFSSL_USER_IO:     Disables default Embed* callbacks and     default: off
+                        allows user to define their own using
+                        wolfSSL_SetIORecv and wolfSSL_SetIOSend
+ * USE_WOLFSSL_IO:      Enables the wolfSSL IO functions          default: off
+ * HAVE_HTTP_CLIENT:    Enables HTTP client API's                 default: off
+                                     (unless HAVE_OCSP or HAVE_CRL_IO defined)
+ */
 
 
 /* if user writes own I/O callbacks they can define WOLFSSL_USER_IO to remove
    automatic setting of default I/O functions EmbedSend() and EmbedReceive()
    but they'll still need SetCallback xxx() at end of file
 */
-#ifndef WOLFSSL_USER_IO
 
-#ifdef HAVE_LIBZ
-    #include "zlib.h"
-#endif
-
-#ifndef USE_WINDOWS_API
-    #ifdef WOLFSSL_LWIP
-        /* lwIP needs to be configured to use sockets API in this mode */
-        /* LWIP_SOCKET 1 in lwip/opt.h or in build */
-        #include "lwip/sockets.h"
-        #include <errno.h>
-        #ifndef LWIP_PROVIDE_ERRNO
-            #define LWIP_PROVIDE_ERRNO 1
-        #endif
-    #elif defined(FREESCALE_MQX)
-        #include <posix.h>
-        #include <rtcs.h>
-    #elif defined(FREESCALE_KSDK_MQX)
-        #include <rtcs.h>
-    #elif defined(WOLFSSL_MDK_ARM) || defined(WOLFSSL_KEIL_TCP_NET)
-        #if !defined(WOLFSSL_MDK_ARM)
-            #include "cmsis_os.h"
-            #include "rl_net.h"
-        #else
-            #include <rtl.h>
-        #endif
-        #include "errno.h"
-        #define SOCKET_T int
-    #elif defined(WOLFSSL_TIRTOS)
-        #include <sys/socket.h>
-    #elif defined(FREERTOS_TCP)
-        #include "FreeRTOS_Sockets.h"
-    #elif defined(WOLFSSL_IAR_ARM)
-        /* nothing */
-    #elif defined(WOLFSSL_VXWORKS)
-        #include <sockLib.h>
-        #include <errno.h>
-    #elif defined(WOLFSSL_ATMEL)
-        #include "socket/include/socket.h"
-    #elif defined(INTIME_RTOS)
-        #undef MIN
-        #undef MAX
-        #include <rt.h>
-        #include <sys/types.h>
-        #include <sys/socket.h>
-        #include <netdb.h>
-        #include <netinet/in.h>
-        #include <io.h>
-    #else
-        #include <sys/types.h>
-        #include <errno.h>
-        #ifndef EBSNET
-            #include <unistd.h>
-        #endif
-        #include <fcntl.h>
-
-        #if defined(HAVE_RTP_SYS)
-            #include <socket.h>
-        #elif defined(EBSNET)
-            #include "rtipapi.h"  /* errno */
-            #include "socket.h"
-        #elif !defined(DEVKITPRO) && !defined(WOLFSSL_PICOTCP)
-            #include <sys/socket.h>
-            #include <arpa/inet.h>
-            #include <netinet/in.h>
-            #include <netdb.h>
-            #ifdef __PPU
-                #include <netex/errno.h>
-            #else
-                #include <sys/ioctl.h>
-            #endif
-        #endif
-    #endif
-#endif /* USE_WINDOWS_API */
-
-#ifdef __sun
-    #include <sys/filio.h>
-#endif
-
-#ifdef USE_WINDOWS_API
-    /* no epipe yet */
-    #ifndef WSAEPIPE
-        #define WSAEPIPE       -12345
-    #endif
-    #define SOCKET_EWOULDBLOCK WSAEWOULDBLOCK
-    #define SOCKET_EAGAIN      WSAETIMEDOUT
-    #define SOCKET_ECONNRESET  WSAECONNRESET
-    #define SOCKET_EINTR       WSAEINTR
-    #define SOCKET_EPIPE       WSAEPIPE
-    #define SOCKET_ECONNREFUSED WSAENOTCONN
-    #define SOCKET_ECONNABORTED WSAECONNABORTED
-    #define close(s) closesocket(s)
-#elif defined(__PPU)
-    #define SOCKET_EWOULDBLOCK SYS_NET_EWOULDBLOCK
-    #define SOCKET_EAGAIN      SYS_NET_EAGAIN
-    #define SOCKET_ECONNRESET  SYS_NET_ECONNRESET
-    #define SOCKET_EINTR       SYS_NET_EINTR
-    #define SOCKET_EPIPE       SYS_NET_EPIPE
-    #define SOCKET_ECONNREFUSED SYS_NET_ECONNREFUSED
-    #define SOCKET_ECONNABORTED SYS_NET_ECONNABORTED
-#elif defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
-    #if MQX_USE_IO_OLD
-        /* RTCS old I/O doesn't have an EWOULDBLOCK */
-        #define SOCKET_EWOULDBLOCK  EAGAIN
-        #define SOCKET_EAGAIN       EAGAIN
-        #define SOCKET_ECONNRESET   RTCSERR_TCP_CONN_RESET
-        #define SOCKET_EINTR        EINTR
-        #define SOCKET_EPIPE        EPIPE
-        #define SOCKET_ECONNREFUSED RTCSERR_TCP_CONN_REFUSED
-        #define SOCKET_ECONNABORTED RTCSERR_TCP_CONN_ABORTED
-    #else
-        #define SOCKET_EWOULDBLOCK  NIO_EWOULDBLOCK
-        #define SOCKET_EAGAIN       NIO_EAGAIN
-        #define SOCKET_ECONNRESET   NIO_ECONNRESET
-        #define SOCKET_EINTR        NIO_EINTR
-        #define SOCKET_EPIPE        NIO_EPIPE
-        #define SOCKET_ECONNREFUSED NIO_ECONNREFUSED
-        #define SOCKET_ECONNABORTED NIO_ECONNABORTED
-    #endif
-#elif defined(WOLFSSL_MDK_ARM)|| defined(WOLFSSL_KEIL_TCP_NET)
-    #if !defined(WOLFSSL_MDK_ARM)
-        #define SOCKET_EWOULDBLOCK BSD_ERROR_WOULDBLOCK
-        #define SOCKET_EAGAIN      BSD_ERROR_LOCKED
-        #define SOCKET_ECONNRESET  BSD_ERROR_CLOSED
-        #define SOCKET_EINTR       BSD_ERROR
-        #define SOCKET_EPIPE       BSD_ERROR
-        #define SOCKET_ECONNREFUSED BSD_ERROR
-        #define SOCKET_ECONNABORTED BSD_ERROR
-    #else
-        #define SOCKET_EWOULDBLOCK SCK_EWOULDBLOCK
-        #define SOCKET_EAGAIN      SCK_ELOCKED
-        #define SOCKET_ECONNRESET  SCK_ECLOSED
-        #define SOCKET_EINTR       SCK_ERROR
-        #define SOCKET_EPIPE       SCK_ERROR
-        #define SOCKET_ECONNREFUSED SCK_ERROR
-        #define SOCKET_ECONNABORTED SCK_ERROR
-    #endif
-#elif defined(WOLFSSL_PICOTCP)
-    #define SOCKET_EWOULDBLOCK  PICO_ERR_EAGAIN
-    #define SOCKET_EAGAIN       PICO_ERR_EAGAIN
-    #define SOCKET_ECONNRESET   PICO_ERR_ECONNRESET
-    #define SOCKET_EINTR        PICO_ERR_EINTR
-    #define SOCKET_EPIPE        PICO_ERR_EIO
-    #define SOCKET_ECONNREFUSED PICO_ERR_ECONNREFUSED
-    #define SOCKET_ECONNABORTED PICO_ERR_ESHUTDOWN
-#elif defined(FREERTOS_TCP)
-    #define SOCKET_EWOULDBLOCK FREERTOS_EWOULDBLOCK
-    #define SOCKET_EAGAIN       FREERTOS_EWOULDBLOCK
-    #define SOCKET_ECONNRESET   FREERTOS_SOCKET_ERROR
-    #define SOCKET_EINTR        FREERTOS_SOCKET_ERROR
-    #define SOCKET_EPIPE        FREERTOS_SOCKET_ERROR
-    #define SOCKET_ECONNREFUSED FREERTOS_SOCKET_ERROR
-    #define SOCKET_ECONNABORTED FREERTOS_SOCKET_ERROR
-#else
-    #define SOCKET_EWOULDBLOCK EWOULDBLOCK
-    #define SOCKET_EAGAIN      EAGAIN
-    #define SOCKET_ECONNRESET  ECONNRESET
-    #define SOCKET_EINTR       EINTR
-    #define SOCKET_EPIPE       EPIPE
-    #define SOCKET_ECONNREFUSED ECONNREFUSED
-    #define SOCKET_ECONNABORTED ECONNABORTED
-#endif /* USE_WINDOWS_API */
-
-
-#ifdef DEVKITPRO
-    /* from network.h */
-    int net_send(int, const void*, int, unsigned int);
-    int net_recv(int, void*, int, unsigned int);
-    #define SEND_FUNCTION net_send
-    #define RECV_FUNCTION net_recv
-#elif defined(WOLFSSL_LWIP)
-    #define SEND_FUNCTION lwip_send
-    #define RECV_FUNCTION lwip_recv
-#elif defined(WOLFSSL_PICOTCP)
-    #define SEND_FUNCTION pico_send
-    #define RECV_FUNCTION pico_recv
-#elif defined(FREERTOS_TCP)
-    #define RECV_FUNCTION(a,b,c,d)  FreeRTOS_recv((Socket_t)(a),(void*)(b), (size_t)(c), (BaseType_t)(d))
-    #define SEND_FUNCTION(a,b,c,d)  FreeRTOS_send((Socket_t)(a),(void*)(b), (size_t)(c), (BaseType_t)(d))
-#else
-    #define SEND_FUNCTION send
-    #define RECV_FUNCTION recv
-#endif
-
+#if defined(USE_WOLFSSL_IO) || defined(HAVE_HTTP_CLIENT)
 
 /* Translates return codes returned from
  * send() and recv() if need be.
@@ -266,14 +98,18 @@ static INLINE int LastError(void)
 #endif
 }
 
+#endif /* USE_WOLFSSL_IO || HAVE_HTTP_CLIENT */
+
+
+#ifdef USE_WOLFSSL_IO
+
 /* The receive embedded callback
  *  return : nb bytes read, or error
  */
 int EmbedReceive(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 {
-    int recvd;
-    int err;
     int sd = *(int*)ctx;
+    int recvd;
 
 #ifdef WOLFSSL_DTLS
     {
@@ -296,12 +132,9 @@ int EmbedReceive(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     }
 #endif
 
-    recvd = (int)RECV_FUNCTION(sd, buf, sz, ssl->rflags);
-
-    recvd = TranslateReturnCode(recvd, sd);
-
+    recvd = wolfIO_Recv(sd, buf, sz, ssl->rflags);
     if (recvd < 0) {
-        err = LastError();
+        int err = LastError();
         WOLFSSL_MSG("Embed Receive error");
 
         if (err == SOCKET_EWOULDBLOCK || err == SOCKET_EAGAIN) {
@@ -350,15 +183,10 @@ int EmbedSend(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 {
     int sd = *(int*)ctx;
     int sent;
-    int len = sz;
-    int err;
 
-    sent = (int)SEND_FUNCTION(sd, &buf[sz - len], len, ssl->wflags);
-
-    sent = TranslateReturnCode(sent, sd);
-
+    sent = wolfIO_Send(sd, buf, sz, ssl->wflags);
     if (sent < 0) {
-        err = LastError();
+        int err = LastError();
         WOLFSSL_MSG("Embed Send error");
 
         if (err == SOCKET_EWOULDBLOCK || err == SOCKET_EAGAIN) {
@@ -699,92 +527,166 @@ int EmbedGenerateCookie(WOLFSSL* ssl, byte *buf, int sz, void *ctx)
 #endif /* WOLFSSL_SESSION_EXPORT */
 #endif /* WOLFSSL_DTLS */
 
-#ifdef HAVE_OCSP
-
-#include <stdlib.h>   /* atoi() */
+#endif /* USE_WOLFSSL_IO */
 
 
-static int Word16ToString(char* d, word16 number)
+#if defined(USE_WOLFSSL_IO)
+
+#ifndef DEFAULT_TIMEOUT_SEC
+    #define DEFAULT_TIMEOUT_SEC 0 /* no timeout */
+#endif
+
+#ifdef HAVE_IO_TIMEOUT
+    static int io_timeout_sec = DEFAULT_TIMEOUT_SEC;
+#else
+    #define io_timeout_sec DEFAULT_TIMEOUT_SEC
+#endif
+
+
+void wolfIO_SetTimeout(int to_sec)
+{
+#ifdef HAVE_IO_TIMEOUT
+    io_timeout_sec = to_sec;
+#else
+    (void)to_sec;
+#endif
+}
+
+int wolfIO_SetBlockingMode(SOCKET_T sockfd, int non_blocking)
+{
+    int ret = 0;
+
+#ifdef USE_WINDOWS_API
+    unsigned long blocking = non_blocking;
+    ret = ioctlsocket(sockfd, FIONBIO, &blocking);
+    if (ret == SOCKET_ERROR)
+        ret = -1;
+#else
+    ret = fcntl(sockfd, F_GETFL, 0);
+    if (ret >= 0) {
+        if (non_blocking)
+            ret |= O_NONBLOCK;
+        else
+            ret &= ~O_NONBLOCK;
+        ret = fcntl(sockfd, F_SETFL, ret);
+    }
+#endif
+    if (ret < 0) {
+        WOLFSSL_MSG("wolfIO_SetBlockingMode failed");
+    }
+
+    return ret;
+}
+
+#ifdef _MSC_VER
+    /* 4204: non-constant aggregate initializer (nfds = sockfd + 1) */
+    #pragma warning(disable: 4204)
+#endif
+int wolfIO_Select(SOCKET_T sockfd, int to_sec)
+{
+    fd_set fds;
+    SOCKET_T nfds = sockfd + 1;
+    struct timeval timeout = { (to_sec > 0) ? to_sec : 0, 0};
+    int ret;
+
+    FD_ZERO(&fds);
+    FD_SET(sockfd, &fds);
+
+    ret = select(nfds, &fds, &fds, NULL, &timeout);
+    if (ret == 0) {
+    #ifdef DEBUG_HTTP
+        printf("Timeout: %d\n", ret);
+    #endif
+        return HTTP_TIMEOUT;
+    }
+    else if (ret > 0) {
+        if (FD_ISSET(sockfd, &fds))
+            return 0;
+    }
+    return SOCKET_ERROR_E;
+}
+
+static int wolfIO_Word16ToString(char* d, word16 number)
 {
     int i = 0;
+    word16 order = 10000;
+    word16 digit;
 
-    if (d != NULL) {
-        word16 order = 10000;
-        word16 digit;
+    if (d == NULL)
+        return i;
 
-        if (number == 0) {
-            d[i++] = '0';
+    if (number == 0)
+        d[i++] = '0';
+    else {
+        while (order) {
+            digit = number / order;
+            if (i > 0 || digit != 0)
+                d[i++] = (char)digit + '0';
+            if (digit != 0)
+                number %= digit * order;
+
+            order = (order > 1) ? order / 10 : 0;
         }
-        else {
-            while (order) {
-                digit = number / order;
-                if (i > 0 || digit != 0) {
-                    d[i++] = (char)digit + '0';
-                }
-                if (digit != 0)
-                    number %= digit * order;
-                if (order > 1)
-                    order /= 10;
-                else
-                    order = 0;
-            }
-        }
-        d[i] = 0;
     }
+    d[i] = 0; /* null terminate */
 
     return i;
 }
 
-
-static int tcp_connect(SOCKET_T* sockfd, const char* ip, word16 port)
+int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
 {
+    int ret = 0;
     struct sockaddr_storage addr;
     int sockaddr_len = sizeof(struct sockaddr_in);
     XMEMSET(&addr, 0, sizeof(addr));
 
-    #ifdef HAVE_GETADDRINFO
-    {
-        struct addrinfo hints;
-        struct addrinfo* answer = NULL;
-        char strPort[6];
+#ifdef WOLFIO_DEBUG
+    printf("TCP Connect: %s:%d\n", ip, port);
+#endif
 
-        XMEMSET(&hints, 0, sizeof(hints));
-        hints.ai_family = AF_UNSPEC;
-        hints.ai_socktype = SOCK_STREAM;
-        hints.ai_protocol = IPPROTO_TCP;
+#ifdef HAVE_GETADDRINFO
+{
+    struct addrinfo hints;
+    struct addrinfo* answer = NULL;
+    char strPort[6];
 
-        if (Word16ToString(strPort, port) == 0) {
-            WOLFSSL_MSG("invalid port number for OCSP responder");
-            return -1;
-        }
+    XMEMSET(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
 
-        if (getaddrinfo(ip, strPort, &hints, &answer) < 0 || answer == NULL) {
-            WOLFSSL_MSG("no addr info for OCSP responder");
-            return -1;
-        }
-
-        sockaddr_len = answer->ai_addrlen;
-        XMEMCPY(&addr, answer->ai_addr, sockaddr_len);
-        freeaddrinfo(answer);
-
+    if (wolfIO_Word16ToString(strPort, port) == 0) {
+        WOLFSSL_MSG("invalid port number for responder");
+        return -1;
     }
-    #else /* HAVE_GETADDRINFO */
-    {
-        struct hostent* entry = gethostbyname(ip);
-        struct sockaddr_in *sin = (struct sockaddr_in *)&addr;
 
-        if (entry) {
-            sin->sin_family = AF_INET;
-            sin->sin_port = htons(port);
-            XMEMCPY(&sin->sin_addr.s_addr, entry->h_addr_list[0],
-                                                               entry->h_length);
-        }
-        else {
-            WOLFSSL_MSG("no addr info for OCSP responder");
-            return -1;
-        }
+    if (getaddrinfo(ip, strPort, &hints, &answer) < 0 || answer == NULL) {
+        WOLFSSL_MSG("no addr info for responder");
+        return -1;
     }
-    #endif /* HAVE_GETADDRINFO */
+
+    sockaddr_len = answer->ai_addrlen;
+    XMEMCPY(&addr, answer->ai_addr, sockaddr_len);
+    freeaddrinfo(answer);
+
+}
+#else /* HAVE_GETADDRINFO */
+{
+    struct hostent* entry = gethostbyname(ip);
+    struct sockaddr_in *sin = (struct sockaddr_in *)&addr;
+
+    if (entry) {
+        sin->sin_family = AF_INET;
+        sin->sin_port = htons(port);
+        XMEMCPY(&sin->sin_addr.s_addr, entry->h_addr_list[0],
+                                                           entry->h_length);
+    }
+    else {
+        WOLFSSL_MSG("no addr info for responder");
+        return -1;
+    }
+}
+#endif /* HAVE_GETADDRINFO */
 
     *sockfd = (SOCKET_T)socket(addr.ss_family, SOCK_STREAM, 0);
 
@@ -800,248 +702,420 @@ static int tcp_connect(SOCKET_T* sockfd, const char* ip, word16 port)
      }
 #endif
 
-    if (connect(*sockfd, (struct sockaddr *)&addr, sockaddr_len) != 0) {
-        WOLFSSL_MSG("OCSP responder tcp connect failed");
+#ifdef HAVE_IO_TIMEOUT
+    /* if timeout value provided then set socket non-blocking */
+    if (to_sec > 0) {
+        wolfIO_SetBlockingMode(*sockfd, 1);
+    }
+#else
+    (void)to_sec;
+#endif
+
+    ret = connect(*sockfd, (struct sockaddr *)&addr, sockaddr_len);
+#ifdef HAVE_IO_TIMEOUT
+    if (ret != 0) {
+        if ((errno == EINPROGRESS) && (to_sec > 0)) {
+            /* wait for connect to complete */
+            ret = wolfIO_Select(*sockfd, to_sec);
+
+            /* restore blocking mode */
+            wolfIO_SetBlockingMode(*sockfd, 0);
+        }
+    }
+#endif
+    if (ret != 0) {
+        WOLFSSL_MSG("Responder tcp connect failed");
         return -1;
     }
 
-    return 0;
+    return ret;
 }
 
-
-static int build_http_request(const char* domainName, const char* path,
-                                    int ocspReqSz, byte* buf, int bufSize)
+int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags)
 {
-    word32 domainNameLen, pathLen, ocspReqSzStrLen, completeLen;
-    char ocspReqSzStr[6];
+    int recvd;
 
-    domainNameLen = (word32)XSTRLEN(domainName);
-    pathLen = (word32)XSTRLEN(path);
-    ocspReqSzStrLen = Word16ToString(ocspReqSzStr, (word16)ocspReqSz);
+    recvd = (int)RECV_FUNCTION(sd, buf, sz, rdFlags);
+    recvd = TranslateReturnCode(recvd, sd);
 
-    completeLen = domainNameLen + pathLen + ocspReqSzStrLen + 84;
-    if (completeLen > (word32)bufSize)
-        return 0;
-
-    XSTRNCPY((char*)buf, "POST ", 5);
-    buf += 5;
-    XSTRNCPY((char*)buf, path, pathLen);
-    buf += pathLen;
-    XSTRNCPY((char*)buf, " HTTP/1.1\r\nHost: ", 17);
-    buf += 17;
-    XSTRNCPY((char*)buf, domainName, domainNameLen);
-    buf += domainNameLen;
-    XSTRNCPY((char*)buf, "\r\nContent-Length: ", 18);
-    buf += 18;
-    XSTRNCPY((char*)buf, ocspReqSzStr, ocspReqSzStrLen);
-    buf += ocspReqSzStrLen;
-    XSTRNCPY((char*)buf,
-                      "\r\nContent-Type: application/ocsp-request\r\n\r\n", 44);
-
-    return completeLen;
+    return recvd;
 }
 
+int wolfIO_Send(SOCKET_T sd, char *buf, int sz, int wrFlags)
+{
+    int sent;
+    int len = sz;
 
-static int decode_url(const char* url, int urlSz,
-    char* outName, char* outPath, word16* outPort)
+    sent = (int)SEND_FUNCTION(sd, &buf[sz - len], len, wrFlags);
+    sent = TranslateReturnCode(sent, sd);
+
+    return sent;
+}
+
+#endif /* USE_WOLFSSL_IO */
+
+
+#if defined(HAVE_HTTP_CLIENT)
+
+#ifndef HTTP_SCRATCH_BUFFER_SIZE
+    #define HTTP_SCRATCH_BUFFER_SIZE 512
+#endif
+#ifndef MAX_URL_ITEM_SIZE
+    #define MAX_URL_ITEM_SIZE   80
+#endif
+
+int wolfIO_DecodeUrl(const char* url, int urlSz, char* outName, char* outPath,
+    word16* outPort)
 {
     int result = -1;
 
-    if (outName != NULL && outPath != NULL && outPort != NULL)
-    {
-        if (url == NULL || urlSz == 0)
-        {
+    if (url == NULL || urlSz == 0) {
+        if (outName)
             *outName = 0;
+        if (outPath)
             *outPath = 0;
+        if (outPort)
             *outPort = 0;
+    }
+    else {
+        int i, cur;
+
+        /* need to break the url down into scheme, address, and port */
+        /*     "http://example.com:8080/" */
+        /*     "http://[::1]:443/"        */
+        if (XSTRNCMP(url, "http://", 7) == 0) {
+            cur = 7;
+        } else cur = 0;
+
+        i = 0;
+        if (url[cur] == '[') {
+            cur++;
+            /* copy until ']' */
+            while (url[cur] != 0 && url[cur] != ']' && cur < urlSz) {
+                if (outName)
+                    outName[i] = url[cur];
+                i++; cur++;
+            }
+            cur++; /* skip ']' */
         }
-        else
-        {
-            int i, cur;
-
-            /* need to break the url down into scheme, address, and port */
-            /*     "http://example.com:8080/" */
-            /*     "http://[::1]:443/"        */
-            if (XSTRNCMP(url, "http://", 7) == 0) {
-                cur = 7;
-            } else cur = 0;
-
-            i = 0;
-            if (url[cur] == '[') {
-                cur++;
-                /* copy until ']' */
-                while (url[cur] != 0 && url[cur] != ']' && cur < urlSz) {
-                    outName[i++] = url[cur++];
-                }
-                cur++; /* skip ']' */
+        else {
+            while (url[cur] != 0 && url[cur] != ':' &&
+                                           url[cur] != '/' && cur < urlSz) {
+                if (outName)
+                    outName[i] = url[cur];
+                i++; cur++;
             }
-            else {
-                while (url[cur] != 0 && url[cur] != ':' &&
-                                               url[cur] != '/' && cur < urlSz) {
-                    outName[i++] = url[cur++];
-                }
-            }
+        }
+        if (outName)
             outName[i] = 0;
-            /* Need to pick out the path after the domain name */
+        /* Need to pick out the path after the domain name */
 
-            if (cur < urlSz && url[cur] == ':') {
-                char port[6];
-                int j;
-                word32 bigPort = 0;
-                i = 0;
-                cur++;
-                while (cur < urlSz && url[cur] != 0 && url[cur] != '/' &&
-                        i < 6) {
-                    port[i++] = url[cur++];
-                }
+        if (cur < urlSz && url[cur] == ':') {
+            char port[6];
+            int j;
+            word32 bigPort = 0;
+            i = 0;
+            cur++;
+            while (cur < urlSz && url[cur] != 0 && url[cur] != '/' &&
+                    i < 6) {
+                port[i++] = url[cur++];
+            }
 
-                for (j = 0; j < i; j++) {
-                    if (port[j] < '0' || port[j] > '9') return -1;
-                    bigPort = (bigPort * 10) + (port[j] - '0');
-                }
+            for (j = 0; j < i; j++) {
+                if (port[j] < '0' || port[j] > '9') return -1;
+                bigPort = (bigPort * 10) + (port[j] - '0');
+            }
+            if (outPort)
                 *outPort = (word16)bigPort;
-            }
-            else
-                *outPort = 80;
-
-            if (cur < urlSz && url[cur] == '/') {
-                i = 0;
-                while (cur < urlSz && url[cur] != 0 && i < 80) {
-                    outPath[i++] = url[cur++];
-                }
-                outPath[i] = 0;
-            }
-            else {
-                outPath[0] = '/';
-                outPath[1] = 0;
-            }
-            result = 0;
         }
+        else if (outPort)
+            *outPort = 80;
+
+
+        if (cur < urlSz && url[cur] == '/') {
+            i = 0;
+            while (cur < urlSz && url[cur] != 0 && i < MAX_URL_ITEM_SIZE) {
+                if (outPath)
+                    outPath[i] = url[cur];
+                i++; cur++;
+            }
+            if (outPath)
+                outPath[i] = 0;
+        }
+        else if (outPath) {
+            outPath[0] = '/';
+            outPath[1] = 0;
+        }
+
+        result = 0;
     }
 
     return result;
 }
 
-
-/* return: >0 OCSP Response Size
- *         -1 error */
-static int process_http_response(int sfd, byte** respBuf,
-                                       byte* httpBuf, int httpBufSz, void* heap)
+static int wolfIO_HttpProcessResponseBuf(int sfd, byte **recvBuf, int* recvBufSz,
+    int chunkSz, char* start, int len, int dynType, void* heap)
 {
-    int result;
+    byte* newRecvBuf = NULL;
+    int newRecvSz = *recvBufSz + chunkSz;
+    int pos = 0;
+
+    WOLFSSL_MSG("Processing HTTP response");
+#ifdef WOLFIO_DEBUG
+    printf("HTTP Chunk %d->%d\n", *recvBufSz, chunkSz);
+#endif
+
+    newRecvBuf = (byte*)XMALLOC(newRecvSz, heap, dynType);
+    if (newRecvBuf == NULL) {
+        WOLFSSL_MSG("wolfIO_HttpProcessResponseBuf malloc failed");
+        return MEMORY_E;
+    }
+
+    /* if buffer already exists, then we are growing it */
+    if (*recvBuf) {
+        XMEMCPY(&newRecvBuf[pos], *recvBuf, *recvBufSz);
+        XFREE(*recvBuf, heap, dynType);
+        pos += *recvBufSz;
+        *recvBuf = NULL;
+    }
+
+    /* copy the remainder of the httpBuf into the respBuf */
+    if (len != 0) {
+        XMEMCPY(&newRecvBuf[pos], start, len);
+        pos += len;
+    }
+
+    /* receive the remainder of chunk */
+    while (len < chunkSz) {
+        int rxSz = wolfIO_Recv(sfd, (char*)&newRecvBuf[pos], chunkSz-len, 0);
+        if (rxSz > 0) {
+            len += rxSz;
+            pos += rxSz;
+        }
+        else {
+            WOLFSSL_MSG("wolfIO_HttpProcessResponseBuf recv failed");
+            XFREE(newRecvBuf, heap, dynType);
+            return -1;
+        }
+    }
+
+    *recvBuf = newRecvBuf;
+    *recvBufSz = newRecvSz;
+
+    return 0;
+}
+
+int wolfIO_HttpProcessResponse(int sfd, const char* appStr,
+    byte** respBuf, byte* httpBuf, int httpBufSz, int dynType, void* heap)
+{
+    int result = 0;
     int len = 0;
     char *start, *end;
-    byte *recvBuf = NULL;
-    int recvBufSz = 0;
-    enum phr_state { phr_init, phr_http_start, phr_have_length,
-                     phr_have_type, phr_wait_end, phr_http_end
+    int respBufSz = 0;
+    int isChunked = 0, chunkSz = 0;
+    enum phr_state { phr_init, phr_http_start, phr_have_length, phr_have_type,
+                     phr_wait_end, phr_get_chunk_len, phr_get_chunk_data,
+                     phr_http_end
     } state = phr_init;
 
+    *respBuf = NULL;
     start = end = NULL;
     do {
+        if (state == phr_get_chunk_data) {
+            /* get chunk of data */
+            result = wolfIO_HttpProcessResponseBuf(sfd, respBuf, &respBufSz,
+                chunkSz, start, len, dynType, heap);
+
+            state = (result != 0) ? phr_http_end : phr_get_chunk_len;
+            end = NULL;
+            len = 0;
+        }
+
+        /* read data if no \r\n or first time */
         if (end == NULL) {
-            result = (int)recv(sfd, (char*)httpBuf+len, httpBufSz-len-1, 0);
+            result = wolfIO_Recv(sfd, (char*)httpBuf+len, httpBufSz-len-1, 0);
             if (result > 0) {
                 len += result;
                 start = (char*)httpBuf;
                 start[len] = 0;
             }
             else {
-                WOLFSSL_MSG("process_http_response recv http from peer failed");
+                WOLFSSL_MSG("wolfIO_HttpProcessResponse recv http from peer failed");
                 return -1;
             }
         }
-        end = XSTRSTR(start, "\r\n");
+        end = XSTRSTR(start, "\r\n"); /* locate end */
 
+        /* handle incomplete rx */
         if (end == NULL) {
             if (len != 0)
                 XMEMMOVE(httpBuf, start, len);
             start = end = NULL;
         }
+        /* when start is "\r\n" */
         else if (end == start) {
-            if (state == phr_wait_end) {
-                state = phr_http_end;
-                len -= 2;
-                start += 2;
+            /* if waiting for end or need chunk len */
+            if (state == phr_wait_end || state == phr_get_chunk_len) {
+                state = (isChunked) ? phr_get_chunk_len : phr_http_end;
+                len -= 2; start += 2; /* skip \r\n */
              }
              else {
-                WOLFSSL_MSG("process_http_response header ended early");
+                WOLFSSL_MSG("wolfIO_HttpProcessResponse header ended early");
                 return -1;
              }
         }
         else {
-            *end = 0;
+            *end = 0; /* null terminate */
             len -= (int)(end - start) + 2;
                 /* adjust len to remove the first line including the /r/n */
 
-            if (XSTRNCASECMP(start, "HTTP/1", 6) == 0) {
-                start += 9;
-                if (XSTRNCASECMP(start, "200 OK", 6) != 0 ||
-                                                           state != phr_init) {
-                    WOLFSSL_MSG("process_http_response not OK");
-                    return -1;
-                }
-                state = phr_http_start;
-            }
-            else if (XSTRNCASECMP(start, "Content-Type:", 13) == 0) {
-                start += 13;
-                while (*start == ' ' && *start != '\0') start++;
-                if (XSTRNCASECMP(start, "application/ocsp-response", 25) != 0) {
-                    WOLFSSL_MSG("process_http_response not ocsp-response");
-                    return -1;
-                }
+        #ifdef WOLFIO_DEBUG
+            printf("HTTP Resp: %s\n", start);
+        #endif
 
-                if (state == phr_http_start) state = phr_have_type;
-                else if (state == phr_have_length) state = phr_wait_end;
-                else {
-                    WOLFSSL_MSG("process_http_response type invalid state");
-                    return -1;
-                }
-            }
-            else if (XSTRNCASECMP(start, "Content-Length:", 15) == 0) {
-                start += 15;
-                while (*start == ' ' && *start != '\0') start++;
-                recvBufSz = atoi(start);
+            switch (state) {
+                case phr_init:
+                    if (XSTRNCASECMP(start, "HTTP/1", 6) == 0) {
+                        start += 9;
+                        if (XSTRNCASECMP(start, "200 OK", 6) != 0) {
+                            WOLFSSL_MSG("wolfIO_HttpProcessResponse not OK");
+                            return -1;
+                        }
+                        state = phr_http_start;
+                    }
+                    break;
+                case phr_http_start:
+                case phr_have_length:
+                case phr_have_type:
+                    if (XSTRNCASECMP(start, "Content-Type:", 13) == 0) {
+                        start += 13;
+                        while (*start == ' ' && *start != '\0') start++;
+                        if (XSTRNCASECMP(start, appStr, XSTRLEN(appStr)) != 0) {
+                            WOLFSSL_MSG("wolfIO_HttpProcessResponse appstr mismatch");
+                            return -1;
+                        }
+                        state = (state == phr_http_start) ? phr_have_type : phr_wait_end;
+                    }
+                    else if (XSTRNCASECMP(start, "Content-Length:", 15) == 0) {
+                        start += 15;
+                        while (*start == ' ' && *start != '\0') start++;
+                        chunkSz = atoi(start);
+                        state = (state == phr_http_start) ? phr_have_length : phr_wait_end;
+                    }
+                    else if (XSTRNCASECMP(start, "Transfer-Encoding:", 18) == 0) {
+                        start += 18;
+                        while (*start == ' ' && *start != '\0') start++;
+                        if (XSTRNCASECMP(start, "chunked", 7) == 0) {
+                            isChunked = 1;
+                            state = (state == phr_http_start) ? phr_have_length : phr_wait_end;
+                        }
+                    }
+                    break;
+                case phr_get_chunk_len:
+                    chunkSz = (int)strtol(start, NULL, 16); /* hex format */
+                    state = (chunkSz == 0) ? phr_http_end : phr_get_chunk_data;
+                    break;
+                case phr_get_chunk_data:
+                    /* processing for chunk data done above, since \r\n isn't required */
+                case phr_wait_end:
+                case phr_http_end:
+                    /* do nothing */
+                    break;
+            } /* switch (state) */
 
-                if (state == phr_http_start) state = phr_have_length;
-                else if (state == phr_have_type) state = phr_wait_end;
-                else {
-                    WOLFSSL_MSG("process_http_response length invalid state");
-                    return -1;
-                }
-            }
-
+            /* skip to end plus \r\n */
             start = end + 2;
         }
     } while (state != phr_http_end);
 
-    recvBuf = (byte*)XMALLOC(recvBufSz, heap, DYNAMIC_TYPE_OCSP);
-    if (recvBuf == NULL) {
-        WOLFSSL_MSG("process_http_response couldn't create response buffer");
-        return -1;
+    if (!isChunked) {
+        result = wolfIO_HttpProcessResponseBuf(sfd, respBuf, &respBufSz, chunkSz,
+                                                    start, len, dynType, heap);
     }
 
-    /* copy the remainder of the httpBuf into the respBuf */
-    if (len != 0)
-        XMEMCPY(recvBuf, start, len);
-
-    /* receive the OCSP response data */
-    while (len < recvBufSz) {
-        result = (int)recv(sfd, (char*)recvBuf+len, recvBufSz-len, 0);
-        if (result > 0)
-            len += result;
-        else {
-            WOLFSSL_MSG("process_http_response recv ocsp from peer failed");
-            return -1;
-        }
+    if (result >= 0) {
+        result = respBufSz;
+    }
+    else {
+        WOLFSSL_ERROR(result);
     }
 
-    *respBuf = recvBuf;
-    return recvBufSz;
+    return result;
+}
+
+int wolfIO_HttpBuildRequest(const char* reqType, const char* domainName,
+    const char* path, int pathLen, int reqSz, const char* contentType,
+    byte* buf, int bufSize)
+{
+    word32 reqTypeLen, domainNameLen, reqSzStrLen, contentTypeLen, maxLen;
+    char reqSzStr[6];
+    char* req = (char*)buf;
+
+    reqTypeLen = (word32)XSTRLEN(reqType);
+    domainNameLen = (word32)XSTRLEN(domainName);
+    reqSzStrLen = wolfIO_Word16ToString(reqSzStr, (word16)reqSz);
+    contentTypeLen = (word32)XSTRLEN(contentType);
+
+    /* determine max length */
+    maxLen = reqTypeLen + domainNameLen + pathLen + reqSzStrLen + contentTypeLen + 56;
+    if (maxLen > (word32)bufSize)
+        return 0;
+
+    XSTRNCPY((char*)buf, reqType, reqTypeLen);
+    buf += reqTypeLen;
+    XSTRNCPY((char*)buf, " ", 1);
+    buf += 1;
+    XSTRNCPY((char*)buf, path, pathLen);
+    buf += pathLen;
+    XSTRNCPY((char*)buf, " HTTP/1.1", 9);
+    buf += 9;
+    if (domainNameLen > 0) {
+        XSTRNCPY((char*)buf, "\r\nHost: ", 8);
+        buf += 8;
+        XSTRNCPY((char*)buf, domainName, domainNameLen);
+        buf += domainNameLen;
+    }
+    if (reqSz > 0 && reqSzStrLen > 0) {
+        XSTRNCPY((char*)buf, "\r\nContent-Length: ", 18);
+        buf += 18;
+        XSTRNCPY((char*)buf, reqSzStr, reqSzStrLen);
+        buf += reqSzStrLen;
+    }
+    if (contentTypeLen > 0) {
+        XSTRNCPY((char*)buf, "\r\nContent-Type: ", 16);
+        buf += 16;
+        XSTRNCPY((char*)buf, contentType, contentTypeLen);
+        buf += contentTypeLen;
+    }
+    XSTRNCPY((char*)buf, "\r\n\r\n", 4);
+    buf += 4;
+
+#ifdef WOLFIO_DEBUG
+    printf("HTTP %s: %s", reqType, req);
+#endif
+
+    /* calculate actual length based on original and new pointer */
+    return (int)((char*)buf - req);
 }
 
 
-#define SCRATCH_BUFFER_SIZE 512
+#ifdef HAVE_OCSP
+
+int wolfIO_HttpBuildRequestOcsp(const char* domainName, const char* path,
+                                    int ocspReqSz, byte* buf, int bufSize)
+{
+    return wolfIO_HttpBuildRequest("POST", domainName, path, (int)XSTRLEN(path),
+        ocspReqSz, "application/ocsp-request", buf, bufSize);
+}
+
+/* return: >0 OCSP Response Size
+ *         -1 error */
+int wolfIO_HttpProcessResponseOcsp(int sfd, byte** respBuf,
+                                       byte* httpBuf, int httpBufSz, void* heap)
+{
+    return wolfIO_HttpProcessResponse(sfd, "application/ocsp-response",
+        respBuf, httpBuf, httpBufSz, DYNAMIC_TYPE_OCSP, heap);
+}
 
 /* in default wolfSSL callback ctx is the heap pointer */
 int EmbedOcspLookup(void* ctx, const char* url, int urlSz,
@@ -1054,19 +1128,19 @@ int EmbedOcspLookup(void* ctx, const char* url, int urlSz,
     char*    path;
     char*    domainName;
 #else
-    char     path[80];
-    char     domainName[80];
+    char     path[MAX_URL_ITEM_SIZE];
+    char     domainName[MAX_URL_ITEM_SIZE];
 #endif
 
 #ifdef WOLFSSL_SMALL_STACK
-    path = (char*)XMALLOC(80, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    path = (char*)XMALLOC(MAX_URL_ITEM_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (path == NULL)
-        return -1;
+        return MEMORY_E;
 
-    domainName = (char*)XMALLOC(80, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    domainName = (char*)XMALLOC(MAX_URL_ITEM_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (domainName == NULL) {
         XFREE(path, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        return -1;
+        return MEMORY_E;
     }
 #endif
 
@@ -1076,37 +1150,37 @@ int EmbedOcspLookup(void* ctx, const char* url, int urlSz,
     else if (ocspRespBuf == NULL) {
         WOLFSSL_MSG("Cannot save OCSP response");
     }
-    else if (decode_url(url, urlSz, domainName, path, &port) < 0) {
+    else if (wolfIO_DecodeUrl(url, urlSz, domainName, path, &port) < 0) {
         WOLFSSL_MSG("Unable to decode OCSP URL");
     }
     else {
         /* Note, the library uses the EmbedOcspRespFree() callback to
          * free this buffer. */
-        int   httpBufSz = SCRATCH_BUFFER_SIZE;
-        byte* httpBuf   = (byte*)XMALLOC(httpBufSz, ctx,
-                                                        DYNAMIC_TYPE_OCSP);
+        int   httpBufSz = HTTP_SCRATCH_BUFFER_SIZE;
+        byte* httpBuf   = (byte*)XMALLOC(httpBufSz, ctx, DYNAMIC_TYPE_OCSP);
 
         if (httpBuf == NULL) {
             WOLFSSL_MSG("Unable to create OCSP response buffer");
         }
         else {
-            httpBufSz = build_http_request(domainName, path, ocspReqSz,
+            httpBufSz = wolfIO_HttpBuildRequestOcsp(domainName, path, ocspReqSz,
                                                             httpBuf, httpBufSz);
 
-            if ((tcp_connect(&sfd, domainName, port) != 0) || (sfd <= 0)) {
+            ret = wolfIO_TcpConnect(&sfd, domainName, port, io_timeout_sec);
+            if ((ret != 0) || (sfd <= 0)) {
                 WOLFSSL_MSG("OCSP Responder connection failed");
             }
-            else if ((int)send(sfd, (char*)httpBuf, httpBufSz, 0) !=
+            else if (wolfIO_Send(sfd, (char*)httpBuf, httpBufSz, 0) !=
                                                                     httpBufSz) {
                 WOLFSSL_MSG("OCSP http request failed");
             }
-            else if ((int)send(sfd, (char*)ocspReqBuf, ocspReqSz, 0) !=
+            else if (wolfIO_Send(sfd, (char*)ocspReqBuf, ocspReqSz, 0) !=
                                                                     ocspReqSz) {
                 WOLFSSL_MSG("OCSP ocsp request failed");
             }
             else {
-                ret = process_http_response(sfd, ocspRespBuf, httpBuf,
-                                                      SCRATCH_BUFFER_SIZE, ctx);
+                ret = wolfIO_HttpProcessResponseOcsp(sfd, ocspRespBuf, httpBuf,
+                                                 HTTP_SCRATCH_BUFFER_SIZE, ctx);
             }
 
             close(sfd);
@@ -1122,7 +1196,6 @@ int EmbedOcspLookup(void* ctx, const char* url, int urlSz,
     return ret;
 }
 
-
 /* in default callback ctx is heap hint */
 void EmbedOcspRespFree(void* ctx, byte *resp)
 {
@@ -1131,11 +1204,97 @@ void EmbedOcspRespFree(void* ctx, byte *resp)
 
     (void)ctx;
 }
+#endif /* HAVE_OCSP */
 
 
+#if defined(HAVE_CRL) && defined(HAVE_CRL_IO)
+
+int wolfIO_HttpBuildRequestCrl(const char* url, int urlSz,
+    const char* domainName, byte* buf, int bufSize)
+{
+    return wolfIO_HttpBuildRequest("GET", domainName, url, urlSz, 0, "",
+        buf, bufSize);
+}
+
+int wolfIO_HttpProcessResponseCrl(WOLFSSL_CRL* crl, int sfd, byte* httpBuf,
+    int httpBufSz)
+{
+    int result;
+    byte *respBuf = NULL;
+
+    result = wolfIO_HttpProcessResponse(sfd, "application/pkix-crl",
+        &respBuf, httpBuf, httpBufSz, DYNAMIC_TYPE_CRL, crl->heap);
+    if (result >= 0) {
+        result = BufferLoadCRL(crl, respBuf, result, SSL_FILETYPE_ASN1);
+    }
+    XFREE(respBuf, crl->heap, DYNAMIC_TYPE_CRL);
+
+    return result;
+}
+
+int EmbedCrlLookup(WOLFSSL_CRL* crl, const char* url, int urlSz)
+{
+    SOCKET_T sfd = 0;
+    word16   port;
+    int      ret = -1;
+#ifdef WOLFSSL_SMALL_STACK
+    char*    domainName;
+#else
+    char     domainName[MAX_URL_ITEM_SIZE];
 #endif
 
-#endif /* WOLFSSL_USER_IO */
+#ifdef WOLFSSL_SMALL_STACK
+    domainName = (char*)XMALLOC(MAX_URL_ITEM_SIZE, crl->heap,
+                                                       DYNAMIC_TYPE_TMP_BUFFER);
+    if (domainName == NULL) {
+        XFREE(path, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        return MEMORY_E;
+    }
+#endif
+
+    if (wolfIO_DecodeUrl(url, urlSz, domainName, NULL, &port) < 0) {
+        WOLFSSL_MSG("Unable to decode CRL URL");
+    }
+    else {
+        int   httpBufSz = HTTP_SCRATCH_BUFFER_SIZE;
+        byte* httpBuf   = (byte*)XMALLOC(httpBufSz, crl->heap,
+                                                              DYNAMIC_TYPE_CRL);
+        if (httpBuf == NULL) {
+            WOLFSSL_MSG("Unable to create CRL response buffer");
+        }
+        else {
+            httpBufSz = wolfIO_HttpBuildRequestCrl(url, urlSz, domainName,
+                httpBuf, httpBufSz);
+
+            ret = wolfIO_TcpConnect(&sfd, domainName, port, io_timeout_sec);
+            if ((ret != 0) || (sfd <= 0)) {
+                WOLFSSL_MSG("CRL connection failed");
+            }
+            else if (wolfIO_Send(sfd, (char*)httpBuf, httpBufSz, 0)
+                                                                 != httpBufSz) {
+                WOLFSSL_MSG("CRL http get failed");
+            }
+            else {
+                ret = wolfIO_HttpProcessResponseCrl(crl, sfd, httpBuf,
+                                                      HTTP_SCRATCH_BUFFER_SIZE);
+            }
+
+            close(sfd);
+            XFREE(httpBuf, crl->heap, DYNAMIC_TYPE_CRL);
+        }
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(domainName, crl->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+
+    return ret;
+}
+#endif /* HAVE_CRL && HAVE_CRL_IO */
+
+#endif /* HAVE_HTTP_CLIENT */
+
+
 
 WOLFSSL_API void wolfSSL_SetIORecv(WOLFSSL_CTX *ctx, CallbackIORecv CBIORecv)
 {
@@ -1337,5 +1496,5 @@ void wolfSSL_SetIO_NetX(WOLFSSL* ssl, NX_TCP_SOCKET* nxSocket, ULONG waitOption)
 }
 
 #endif /* HAVE_NETX */
-#endif /* WOLFCRYPT_ONLY */
 
+#endif /* WOLFCRYPT_ONLY */

--- a/src/io.c
+++ b/src/io.c
@@ -219,12 +219,6 @@ int EmbedSend(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 
 #include <wolfssl/wolfcrypt/sha.h>
 
-#ifdef USE_WINDOWS_API
-   #define XSOCKLENT int
-#else
-   #define XSOCKLENT socklen_t
-#endif
-
 #define SENDTO_FUNCTION sendto
 #define RECVFROM_FUNCTION recvfrom
 
@@ -608,7 +602,7 @@ static int wolfIO_Word16ToString(char* d, word16 number)
 
 int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
 {
-#if defined(HAVE_GETADDRINFO) || defined(HAVE_SOCKADDR)
+#ifdef HAVE_SOCKADDR
     int ret = 0;
     SOCKADDR_S addr;
     int sockaddr_len = sizeof(SOCKADDR_IN);
@@ -653,14 +647,12 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
     if (entry) {
         sin->sin_family = AF_INET;
         sin->sin_port = XHTONS(port);
-        XMEMCPY(&sin->sin_addr.s_addr, entry->h_addr_list[0],
-                                                           entry->h_length);
+        XMEMCPY(&sin->sin_addr.s_addr, entry->h_addr_list[0], entry->h_length);
     }
     else {
         WOLFSSL_MSG("no addr info for responder");
         return -1;
     }
-}
 #endif
 
     *sockfd = (SOCKET_T)socket(addr.ss_family, SOCK_STREAM, 0);
@@ -709,7 +701,7 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
     (void)port;
     (void)to_sec;
     return -1;
-#endif /* HAVE_GETADDRINFO || HAVE_SOCKADDR */
+#endif /* HAVE_SOCKADDR */
 }
 
 int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4709,7 +4709,12 @@ int wolfSSL_CertManagerEnableCRL(WOLFSSL_CERT_MANAGER* cm, int options)
                 cm->crl = NULL;
                 return SSL_FAILURE;
             }
+
+        #ifdef HAVE_CRL_IO
+            cm->crl->crlIOCb = EmbedCrlLookup;
+        #endif
         }
+
         cm->crlEnabled = 1;
         if (options & WOLFSSL_CRL_CHECKALL)
             cm->crlCheckAll = 1;
@@ -5377,6 +5382,17 @@ int wolfSSL_CertManagerSetCRL_Cb(WOLFSSL_CERT_MANAGER* cm, CbMissingCRL cb)
     return SSL_SUCCESS;
 }
 
+#ifdef HAVE_CRL_IO
+int wolfSSL_CertManagerSetCRL_IOCb(WOLFSSL_CERT_MANAGER* cm, CbCrlIO cb)
+{
+    if (cm == NULL)
+        return BAD_FUNC_ARG;
+
+    cm->crl->crlIOCb = cb;
+
+    return SSL_SUCCESS;
+}
+#endif
 
 int wolfSSL_CertManagerLoadCRL(WOLFSSL_CERT_MANAGER* cm, const char* path,
                               int type, int monitor)
@@ -5435,6 +5451,16 @@ int wolfSSL_SetCRL_Cb(WOLFSSL* ssl, CbMissingCRL cb)
         return BAD_FUNC_ARG;
 }
 
+#ifdef HAVE_CRL_IO
+int wolfSSL_SetCRL_IOCb(WOLFSSL* ssl, CbCrlIO cb)
+{
+    WOLFSSL_ENTER("wolfSSL_SetCRL_Cb");
+    if (ssl)
+        return wolfSSL_CertManagerSetCRL_IOCb(ssl->ctx->cm, cb);
+    else
+        return BAD_FUNC_ARG;
+}
+#endif
 
 int wolfSSL_CTX_EnableCRL(WOLFSSL_CTX* ctx, int options)
 {
@@ -5475,6 +5501,17 @@ int wolfSSL_CTX_SetCRL_Cb(WOLFSSL_CTX* ctx, CbMissingCRL cb)
     else
         return BAD_FUNC_ARG;
 }
+
+#ifdef HAVE_CRL_IO
+int wolfSSL_CTX_SetCRL_IOCb(WOLFSSL_CTX* ctx, CbCrlIO cb)
+{
+    WOLFSSL_ENTER("wolfSSL_CTX_SetCRL_IOCb");
+    if (ctx)
+        return wolfSSL_CertManagerSetCRL_IOCb(ctx->cm, cb);
+    else
+        return BAD_FUNC_ARG;
+}
+#endif
 
 
 #endif /* HAVE_CRL */

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -152,6 +152,7 @@ enum wolfSSL_ErrorCodes {
     EXT_MASTER_SECRET_NEEDED_E   = -414,   /* need EMS enabled to resume */
     DTLS_POOL_SZ_E               = -415,   /* exceeded DTLS pool size */
     DECODE_E                     = -416,   /* decode handshake message error */
+    HTTP_TIMEOUT                 = -417,   /* HTTP timeout for OCSP or CRL req */
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* begin negotiation parameter errors */

--- a/wolfssl/include.am
+++ b/wolfssl/include.am
@@ -17,7 +17,8 @@ nobase_include_HEADERS+= \
                          wolfssl/test.h \
                          wolfssl/version.h \
                          wolfssl/ocsp.h \
-                         wolfssl/crl.h
+                         wolfssl/crl.h \
+                         wolfssl/io.h
 
 noinst_HEADERS+= \
                          wolfssl/internal.h

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -189,13 +189,6 @@
 #endif
 
 
-#ifdef USE_WINDOWS_API
-    typedef unsigned int SOCKET_T;
-#else
-    typedef int SOCKET_T;
-#endif
-
-
 typedef byte word24[3];
 
 /* Define or comment out the cipher suites you'd like to be compiled in
@@ -1421,11 +1414,6 @@ int  SetCipherList(Suites*, const char* list);
                    unsigned char* exportBuffer, unsigned int sz, void* userCtx);
 #endif
 
-#ifdef HAVE_NETX
-    WOLFSSL_LOCAL int NetX_Receive(WOLFSSL *ssl, char *buf, int sz, void *ctx);
-    WOLFSSL_LOCAL int NetX_Send(WOLFSSL *ssl, char *buf, int sz, void *ctx);
-#endif /* HAVE_NETX */
-
 
 /* wolfSSL Cipher type just points back to SSL */
 struct WOLFSSL_CIPHER {
@@ -1521,6 +1509,9 @@ struct CRL_Monitor {
 struct WOLFSSL_CRL {
     WOLFSSL_CERT_MANAGER* cm;            /* pointer back to cert manager */
     CRL_Entry*            crlList;       /* our CRL list */
+#ifdef HAVE_CRL_IO
+    CbCrlIO               crlIOCb;
+#endif
     wolfSSL_Mutex         crlLock;       /* CRL list lock */
     CRL_Monitor           monitors[2];   /* PEM and DER possible */
 #ifdef HAVE_CRL_MONITOR

--- a/wolfssl/io.h
+++ b/wolfssl/io.h
@@ -1,0 +1,349 @@
+/* io.h
+ *
+ * Copyright (C) 2006-2016 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#ifndef WOLFSSL_IO_H
+#define WOLFSSL_IO_H
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+/* OCSP and CRL_IO require HTTP client */
+#if defined(HAVE_OCSP) || defined(HAVE_CRL_IO)
+    #ifndef HAVE_HTTP_CLIENT
+        #define HAVE_HTTP_CLIENT
+    #endif
+#endif
+
+#if !defined(WOLFSSL_USER_IO)
+    #ifndef USE_WOLFSSL_IO
+        #define USE_WOLFSSL_IO
+    #endif
+#endif
+
+
+#if defined(USE_WOLFSSL_IO) || defined(HAVE_HTTP_CLIENT)
+
+#ifdef HAVE_LIBZ
+    #include "zlib.h"
+#endif
+
+#ifndef USE_WINDOWS_API
+    #ifdef WOLFSSL_LWIP
+        /* lwIP needs to be configured to use sockets API in this mode */
+        /* LWIP_SOCKET 1 in lwip/opt.h or in build */
+        #include "lwip/sockets.h"
+        #include <errno.h>
+        #ifndef LWIP_PROVIDE_ERRNO
+            #define LWIP_PROVIDE_ERRNO 1
+        #endif
+    #elif defined(FREESCALE_MQX)
+        #include <posix.h>
+        #include <rtcs.h>
+    #elif defined(FREESCALE_KSDK_MQX)
+        #include <rtcs.h>
+    #elif defined(WOLFSSL_MDK_ARM) || defined(WOLFSSL_KEIL_TCP_NET)
+        #if !defined(WOLFSSL_MDK_ARM)
+            #include "cmsis_os.h"
+            #include "rl_net.h"
+        #else
+            #include <rtl.h>
+        #endif
+        #include "errno.h"
+        #define SOCKET_T int
+    #elif defined(WOLFSSL_TIRTOS)
+        #include <sys/socket.h>
+    #elif defined(FREERTOS_TCP)
+        #include "FreeRTOS_Sockets.h"
+    #elif defined(WOLFSSL_IAR_ARM)
+        /* nothing */
+    #elif defined(WOLFSSL_VXWORKS)
+        #include <sockLib.h>
+        #include <errno.h>
+    #elif defined(WOLFSSL_ATMEL)
+        #include "socket/include/socket.h"
+    #elif defined(INTIME_RTOS)
+        #undef MIN
+        #undef MAX
+        #include <rt.h>
+        #include <sys/types.h>
+        #include <sys/socket.h>
+        #include <netdb.h>
+        #include <netinet/in.h>
+        #include <io.h>
+    #else
+        #include <sys/types.h>
+        #include <errno.h>
+        #ifndef EBSNET
+            #include <unistd.h>
+        #endif
+        #include <fcntl.h>
+
+        #if defined(HAVE_RTP_SYS)
+            #include <socket.h>
+        #elif defined(EBSNET)
+            #include "rtipapi.h"  /* errno */
+            #include "socket.h"
+        #elif !defined(DEVKITPRO) && !defined(WOLFSSL_PICOTCP)
+            #include <sys/socket.h>
+            #include <arpa/inet.h>
+            #include <netinet/in.h>
+            #include <netdb.h>
+            #ifdef __PPU
+                #include <netex/errno.h>
+            #else
+                #include <sys/ioctl.h>
+            #endif
+        #endif
+    #endif
+#endif /* USE_WINDOWS_API */
+
+#ifdef __sun
+    #include <sys/filio.h>
+#endif
+
+#ifdef USE_WINDOWS_API
+    /* no epipe yet */
+    #ifndef WSAEPIPE
+        #define WSAEPIPE       -12345
+    #endif
+    #define SOCKET_EWOULDBLOCK WSAEWOULDBLOCK
+    #define SOCKET_EAGAIN      WSAETIMEDOUT
+    #define SOCKET_ECONNRESET  WSAECONNRESET
+    #define SOCKET_EINTR       WSAEINTR
+    #define SOCKET_EPIPE       WSAEPIPE
+    #define SOCKET_ECONNREFUSED WSAENOTCONN
+    #define SOCKET_ECONNABORTED WSAECONNABORTED
+    #define close(s) closesocket(s)
+#elif defined(__PPU)
+    #define SOCKET_EWOULDBLOCK SYS_NET_EWOULDBLOCK
+    #define SOCKET_EAGAIN      SYS_NET_EAGAIN
+    #define SOCKET_ECONNRESET  SYS_NET_ECONNRESET
+    #define SOCKET_EINTR       SYS_NET_EINTR
+    #define SOCKET_EPIPE       SYS_NET_EPIPE
+    #define SOCKET_ECONNREFUSED SYS_NET_ECONNREFUSED
+    #define SOCKET_ECONNABORTED SYS_NET_ECONNABORTED
+#elif defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
+    #if MQX_USE_IO_OLD
+        /* RTCS old I/O doesn't have an EWOULDBLOCK */
+        #define SOCKET_EWOULDBLOCK  EAGAIN
+        #define SOCKET_EAGAIN       EAGAIN
+        #define SOCKET_ECONNRESET   RTCSERR_TCP_CONN_RESET
+        #define SOCKET_EINTR        EINTR
+        #define SOCKET_EPIPE        EPIPE
+        #define SOCKET_ECONNREFUSED RTCSERR_TCP_CONN_REFUSED
+        #define SOCKET_ECONNABORTED RTCSERR_TCP_CONN_ABORTED
+    #else
+        #define SOCKET_EWOULDBLOCK  NIO_EWOULDBLOCK
+        #define SOCKET_EAGAIN       NIO_EAGAIN
+        #define SOCKET_ECONNRESET   NIO_ECONNRESET
+        #define SOCKET_EINTR        NIO_EINTR
+        #define SOCKET_EPIPE        NIO_EPIPE
+        #define SOCKET_ECONNREFUSED NIO_ECONNREFUSED
+        #define SOCKET_ECONNABORTED NIO_ECONNABORTED
+    #endif
+#elif defined(WOLFSSL_MDK_ARM)|| defined(WOLFSSL_KEIL_TCP_NET)
+    #if !defined(WOLFSSL_MDK_ARM)
+        #define SOCKET_EWOULDBLOCK BSD_ERROR_WOULDBLOCK
+        #define SOCKET_EAGAIN      BSD_ERROR_LOCKED
+        #define SOCKET_ECONNRESET  BSD_ERROR_CLOSED
+        #define SOCKET_EINTR       BSD_ERROR
+        #define SOCKET_EPIPE       BSD_ERROR
+        #define SOCKET_ECONNREFUSED BSD_ERROR
+        #define SOCKET_ECONNABORTED BSD_ERROR
+    #else
+        #define SOCKET_EWOULDBLOCK SCK_EWOULDBLOCK
+        #define SOCKET_EAGAIN      SCK_ELOCKED
+        #define SOCKET_ECONNRESET  SCK_ECLOSED
+        #define SOCKET_EINTR       SCK_ERROR
+        #define SOCKET_EPIPE       SCK_ERROR
+        #define SOCKET_ECONNREFUSED SCK_ERROR
+        #define SOCKET_ECONNABORTED SCK_ERROR
+    #endif
+#elif defined(WOLFSSL_PICOTCP)
+    #define SOCKET_EWOULDBLOCK  PICO_ERR_EAGAIN
+    #define SOCKET_EAGAIN       PICO_ERR_EAGAIN
+    #define SOCKET_ECONNRESET   PICO_ERR_ECONNRESET
+    #define SOCKET_EINTR        PICO_ERR_EINTR
+    #define SOCKET_EPIPE        PICO_ERR_EIO
+    #define SOCKET_ECONNREFUSED PICO_ERR_ECONNREFUSED
+    #define SOCKET_ECONNABORTED PICO_ERR_ESHUTDOWN
+#elif defined(FREERTOS_TCP)
+    #define SOCKET_EWOULDBLOCK FREERTOS_EWOULDBLOCK
+    #define SOCKET_EAGAIN       FREERTOS_EWOULDBLOCK
+    #define SOCKET_ECONNRESET   FREERTOS_SOCKET_ERROR
+    #define SOCKET_EINTR        FREERTOS_SOCKET_ERROR
+    #define SOCKET_EPIPE        FREERTOS_SOCKET_ERROR
+    #define SOCKET_ECONNREFUSED FREERTOS_SOCKET_ERROR
+    #define SOCKET_ECONNABORTED FREERTOS_SOCKET_ERROR
+#else
+    #define SOCKET_EWOULDBLOCK EWOULDBLOCK
+    #define SOCKET_EAGAIN      EAGAIN
+    #define SOCKET_ECONNRESET  ECONNRESET
+    #define SOCKET_EINTR       EINTR
+    #define SOCKET_EPIPE       EPIPE
+    #define SOCKET_ECONNREFUSED ECONNREFUSED
+    #define SOCKET_ECONNABORTED ECONNABORTED
+#endif /* USE_WINDOWS_API */
+
+
+#ifdef DEVKITPRO
+    /* from network.h */
+    int net_send(int, const void*, int, unsigned int);
+    int net_recv(int, void*, int, unsigned int);
+    #define SEND_FUNCTION net_send
+    #define RECV_FUNCTION net_recv
+#elif defined(WOLFSSL_LWIP)
+    #define SEND_FUNCTION lwip_send
+    #define RECV_FUNCTION lwip_recv
+#elif defined(WOLFSSL_PICOTCP)
+    #define SEND_FUNCTION pico_send
+    #define RECV_FUNCTION pico_recv
+#elif defined(FREERTOS_TCP)
+    #define RECV_FUNCTION(a,b,c,d)  FreeRTOS_recv((Socket_t)(a),(void*)(b), (size_t)(c), (BaseType_t)(d))
+    #define SEND_FUNCTION(a,b,c,d)  FreeRTOS_send((Socket_t)(a),(void*)(b), (size_t)(c), (BaseType_t)(d))
+#else
+    #define SEND_FUNCTION send
+    #define RECV_FUNCTION recv
+#endif
+
+#ifdef USE_WINDOWS_API
+    typedef unsigned int SOCKET_T;
+#else
+    typedef int SOCKET_T;
+#endif
+
+/* IO API's */
+WOLFSSL_API  int wolfIO_SetBlockingMode(SOCKET_T sockfd, int non_blocking);
+WOLFSSL_API void wolfIO_SetTimeout(int to_sec);;
+WOLFSSL_API  int wolfIO_Select(SOCKET_T sockfd, int to_sec);
+WOLFSSL_API  int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip,
+    unsigned short port, int to_sec);
+WOLFSSL_API  int wolfIO_Send(SOCKET_T sd, char *buf, int sz, int wrFlags);
+WOLFSSL_API  int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags);
+
+#endif /* USE_WOLFSSL_IO || HAVE_HTTP_CLIENT */
+
+
+#if defined(USE_WOLFSSL_IO)
+    /* default IO callbacks */
+    WOLFSSL_API int EmbedReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+    WOLFSSL_API int EmbedSend(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+
+    #ifdef WOLFSSL_DTLS
+        WOLFSSL_API int EmbedReceiveFrom(WOLFSSL* ssl, char* buf, int sz, void*);
+        WOLFSSL_API int EmbedSendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+        WOLFSSL_API int EmbedGenerateCookie(WOLFSSL* ssl, unsigned char* buf,
+                                           int sz, void*);
+        #ifdef WOLFSSL_SESSION_EXPORT
+            WOLFSSL_API int EmbedGetPeer(WOLFSSL* ssl, char* ip, int* ipSz,
+                                                unsigned short* port, int* fam);
+            WOLFSSL_API int EmbedSetPeer(WOLFSSL* ssl, char* ip, int ipSz,
+                                                  unsigned short port, int fam);
+        #endif /* WOLFSSL_SESSION_EXPORT */
+    #endif /* WOLFSSL_DTLS */
+#endif /* USE_WOLFSSL_IO */
+
+#ifdef HAVE_OCSP
+    WOLFSSL_API int wolfIO_HttpBuildRequestOcsp(const char* domainName,
+        const char* path, int ocspReqSz, unsigned char* buf, int bufSize);
+    WOLFSSL_API int wolfIO_HttpProcessResponseOcsp(int sfd,
+        unsigned char** respBuf, unsigned char* httpBuf, int httpBufSz,
+        void* heap);
+
+    WOLFSSL_API int EmbedOcspLookup(void*, const char*, int, unsigned char*,
+                                   int, unsigned char**);
+    WOLFSSL_API void EmbedOcspRespFree(void*, unsigned char*);
+#endif
+
+#ifdef HAVE_CRL_IO
+    WOLFSSL_API int wolfIO_HttpBuildRequestCrl(const char* url, int urlSz,
+        const char* domainName, unsigned char* buf, int bufSize);
+    WOLFSSL_API int wolfIO_HttpProcessResponseCrl(WOLFSSL_CRL* crl, int sfd,
+        unsigned char* httpBuf, int httpBufSz);
+
+    WOLFSSL_API int EmbedCrlLookup(WOLFSSL_CRL* crl, const char* url,
+        int urlSz);
+#endif
+
+
+#if defined(HAVE_HTTP_CLIENT)
+    WOLFSSL_API  int wolfIO_DecodeUrl(const char* url, int urlSz, char* outName,
+        char* outPath, unsigned short* outPort);
+
+    WOLFSSL_API  int wolfIO_HttpBuildRequest(const char* reqType,
+        const char* domainName, const char* path, int pathLen, int reqSz,
+        const char* contentType, unsigned char* buf, int bufSize);
+    WOLFSSL_API  int wolfIO_HttpProcessResponse(int sfd, const char* appStr,
+        unsigned char** respBuf, unsigned char* httpBuf, int httpBufSz,
+        int dynType, void* heap);
+#endif /* HAVE_HTTP_CLIENT */
+
+
+/* I/O callbacks */
+typedef int (*CallbackIORecv)(WOLFSSL *ssl, char *buf, int sz, void *ctx);
+typedef int (*CallbackIOSend)(WOLFSSL *ssl, char *buf, int sz, void *ctx);
+WOLFSSL_API void wolfSSL_SetIORecv(WOLFSSL_CTX*, CallbackIORecv);
+WOLFSSL_API void wolfSSL_SetIOSend(WOLFSSL_CTX*, CallbackIOSend);
+
+WOLFSSL_API void wolfSSL_SetIOReadCtx( WOLFSSL* ssl, void *ctx);
+WOLFSSL_API void wolfSSL_SetIOWriteCtx(WOLFSSL* ssl, void *ctx);
+
+WOLFSSL_API void* wolfSSL_GetIOReadCtx( WOLFSSL* ssl);
+WOLFSSL_API void* wolfSSL_GetIOWriteCtx(WOLFSSL* ssl);
+
+WOLFSSL_API void wolfSSL_SetIOReadFlags( WOLFSSL* ssl, int flags);
+WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
+
+
+#ifdef HAVE_NETX
+    WOLFSSL_LOCAL int NetX_Receive(WOLFSSL *ssl, char *buf, int sz, void *ctx);
+    WOLFSSL_LOCAL int NetX_Send(WOLFSSL *ssl, char *buf, int sz, void *ctx);
+
+    WOLFSSL_API void wolfSSL_SetIO_NetX(WOLFSSL* ssl, NX_TCP_SOCKET* nxsocket,
+                                      ULONG waitoption);
+#endif /* HAVE_NETX */
+
+#ifdef WOLFSSL_DTLS
+    typedef int (*CallbackGenCookie)(WOLFSSL* ssl, unsigned char* buf, int sz,
+                                     void* ctx);
+    WOLFSSL_API void  wolfSSL_CTX_SetGenCookie(WOLFSSL_CTX*, CallbackGenCookie);
+    WOLFSSL_API void  wolfSSL_SetCookieCtx(WOLFSSL* ssl, void *ctx);
+    WOLFSSL_API void* wolfSSL_GetCookieCtx(WOLFSSL* ssl);
+
+    #ifdef WOLFSSL_SESSION_EXPORT
+        typedef int (*CallbackGetPeer)(WOLFSSL* ssl, char* ip, int* ipSz,
+                                            unsigned short* port, int* fam);
+        typedef int (*CallbackSetPeer)(WOLFSSL* ssl, char* ip, int ipSz,
+                                              unsigned short port, int fam);
+
+        WOLFSSL_API void wolfSSL_CTX_SetIOGetPeer(WOLFSSL_CTX*, CallbackGetPeer);
+        WOLFSSL_API void wolfSSL_CTX_SetIOSetPeer(WOLFSSL_CTX*, CallbackSetPeer);
+    #endif /* WOLFSSL_SESSION_EXPORT */
+#endif
+
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_IO_H */

--- a/wolfssl/io.h
+++ b/wolfssl/io.h
@@ -90,7 +90,7 @@
         #include <netdb.h>
         #include <netinet/in.h>
         #include <io.h>
-    #else
+    #elif !defined(WOLFSSL_NO_SOCK)
         #include <sys/types.h>
         #include <errno.h>
         #ifndef EBSNET
@@ -224,7 +224,9 @@
 #else
     #define SEND_FUNCTION send
     #define RECV_FUNCTION recv
-    #define HAVE_SOCKADDR
+    #if !defined(HAVE_SOCKADDR) && !defined(WOLFSSL_NO_SOCK)
+        #define HAVE_SOCKADDR
+    #endif
 #endif
 
 #ifdef USE_WINDOWS_API
@@ -233,38 +235,30 @@
     typedef int SOCKET_T;
 #endif
 
-/* Socket Addr Support */
-#ifdef HAVE_SOCKADDR
-    typedef struct sockaddr         SOCKADDR;
-    typedef struct sockaddr_storage SOCKADDR_S;
-    typedef struct sockaddr_in      SOCKADDR_IN;
-    typedef struct sockaddr_in6     SOCKADDR_IN6;
-    typedef struct hostent          HOSTENT;
-#endif /* HAVE_SOCKADDR */
+#ifndef WOLFSSL_NO_SOCK
+    #ifndef XSOCKLENT
+        #ifdef USE_WINDOWS_API
+            #define XSOCKLENT int
+        #else
+            #define XSOCKLENT socklen_t
+        #endif
+    #endif
 
-#ifdef HAVE_GETADDRINFO
-    typedef struct addrinfo         ADDRINFO;
-#endif
+    /* Socket Addr Support */
+    #ifdef HAVE_SOCKADDR
+        typedef struct sockaddr         SOCKADDR;
+        typedef struct sockaddr_storage SOCKADDR_S;
+        typedef struct sockaddr_in      SOCKADDR_IN;
+        #ifdef TEST_IPV6
+            typedef struct sockaddr_in6 SOCKADDR_IN6;
+        #endif
+        typedef struct hostent          HOSTENT;
+    #endif /* HAVE_SOCKADDR */
 
-#ifndef XINET_NTOP
-    #define XINET_NTOP(a,b,c,d) inet_ntop((a),(b),(c),(d))
-#endif
-#ifndef XINET_PTON
-    #define XINET_PTON(a,b,c)   inet_pton((a),(b),(c))
-#endif
-#ifndef XHTONS
-    #define XHTONS(a) htons((a))
-#endif
-#ifndef XNTOHS
-    #define XNTOHS(a) ntohs((a))
-#endif
-
-#ifndef WOLFSSL_IP4
-    #define WOLFSSL_IP4 AF_INET
-#endif
-#ifndef WOLFSSL_IP6
-    #define WOLFSSL_IP6 AF_INET6
-#endif
+    #ifdef HAVE_GETADDRINFO
+        typedef struct addrinfo         ADDRINFO;
+    #endif
+#endif /* WOLFSSL_NO_SOCK */
 
 
 /* IO API's */
@@ -376,6 +370,28 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
         WOLFSSL_API void wolfSSL_CTX_SetIOGetPeer(WOLFSSL_CTX*, CallbackGetPeer);
         WOLFSSL_API void wolfSSL_CTX_SetIOSetPeer(WOLFSSL_CTX*, CallbackSetPeer);
     #endif /* WOLFSSL_SESSION_EXPORT */
+#endif
+
+
+
+#ifndef XINET_NTOP
+    #define XINET_NTOP(a,b,c,d) inet_ntop((a),(b),(c),(d))
+#endif
+#ifndef XINET_PTON
+    #define XINET_PTON(a,b,c)   inet_pton((a),(b),(c))
+#endif
+#ifndef XHTONS
+    #define XHTONS(a) htons((a))
+#endif
+#ifndef XNTOHS
+    #define XNTOHS(a) ntohs((a))
+#endif
+
+#ifndef WOLFSSL_IP4
+    #define WOLFSSL_IP4 AF_INET
+#endif
+#ifndef WOLFSSL_IP6
+    #define WOLFSSL_IP6 AF_INET6
 #endif
 
 

--- a/wolfssl/io.h
+++ b/wolfssl/io.h
@@ -224,6 +224,7 @@
 #else
     #define SEND_FUNCTION send
     #define RECV_FUNCTION recv
+    #define HAVE_SOCKADDR
 #endif
 
 #ifdef USE_WINDOWS_API
@@ -232,10 +233,46 @@
     typedef int SOCKET_T;
 #endif
 
+/* Socket Addr Support */
+#ifdef HAVE_SOCKADDR
+    typedef struct sockaddr         SOCKADDR;
+    typedef struct sockaddr_storage SOCKADDR_S;
+    typedef struct sockaddr_in      SOCKADDR_IN;
+    typedef struct sockaddr_in6     SOCKADDR_IN6;
+    typedef struct hostent          HOSTENT;
+#endif /* HAVE_SOCKADDR */
+
+#ifdef HAVE_GETADDRINFO
+    typedef struct addrinfo         ADDRINFO;
+#endif
+
+#ifndef XINET_NTOP
+    #define XINET_NTOP(a,b,c,d) inet_ntop((a),(b),(c),(d))
+#endif
+#ifndef XINET_PTON
+    #define XINET_PTON(a,b,c)   inet_pton((a),(b),(c))
+#endif
+#ifndef XHTONS
+    #define XHTONS(a) htons((a))
+#endif
+#ifndef XNTOHS
+    #define XNTOHS(a) ntohs((a))
+#endif
+
+#ifndef WOLFSSL_IP4
+    #define WOLFSSL_IP4 AF_INET
+#endif
+#ifndef WOLFSSL_IP6
+    #define WOLFSSL_IP6 AF_INET6
+#endif
+
+
 /* IO API's */
-WOLFSSL_API  int wolfIO_SetBlockingMode(SOCKET_T sockfd, int non_blocking);
-WOLFSSL_API void wolfIO_SetTimeout(int to_sec);;
-WOLFSSL_API  int wolfIO_Select(SOCKET_T sockfd, int to_sec);
+#ifdef HAVE_IO_TIMEOUT
+    WOLFSSL_API  int wolfIO_SetBlockingMode(SOCKET_T sockfd, int non_blocking);
+    WOLFSSL_API void wolfIO_SetTimeout(int to_sec);;
+    WOLFSSL_API  int wolfIO_Select(SOCKET_T sockfd, int to_sec);
+#endif
 WOLFSSL_API  int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip,
     unsigned short port, int to_sec);
 WOLFSSL_API  int wolfIO_Send(SOCKET_T sd, char *buf, int sz, int wrFlags);

--- a/wolfssl/io.h
+++ b/wolfssl/io.h
@@ -249,7 +249,7 @@
         typedef struct sockaddr         SOCKADDR;
         typedef struct sockaddr_storage SOCKADDR_S;
         typedef struct sockaddr_in      SOCKADDR_IN;
-        #ifdef TEST_IPV6
+        #ifdef WOLFSSL_IPV6
             typedef struct sockaddr_in6 SOCKADDR_IN6;
         #endif
         typedef struct hostent          HOSTENT;

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -624,7 +624,7 @@ static INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
     #else
         addr->sin_family = AF_INET_V;
     #endif
-    addr->sin_port = htons(port);
+    addr->sin_port = XHTONS(port);
     if (peer == INADDR_ANY)
         addr->sin_addr.s_addr = INADDR_ANY;
     else {
@@ -633,7 +633,7 @@ static INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
     }
 #else
     addr->sin6_family = AF_INET_V;
-    addr->sin6_port = htons(port);
+    addr->sin6_port = XHTONS(port);
     if (peer == INADDR_ANY)
         addr->sin6_addr = in6addr_any;
     else {
@@ -824,9 +824,9 @@ static INLINE void tcp_listen(SOCKET_T* sockfd, word16* port, int useAnyAddr,
             socklen_t len = sizeof(addr);
             if (getsockname(*sockfd, (struct sockaddr*)&addr, &len) == 0) {
                 #ifndef TEST_IPV6
-                    *port = ntohs(addr.sin_port);
+                    *port = XNTOHS(addr.sin_port);
                 #else
-                    *port = ntohs(addr.sin6_port);
+                    *port = XNTOHS(addr.sin6_port);
                 #endif
             }
         }
@@ -885,9 +885,9 @@ static INLINE void udp_accept(SOCKET_T* sockfd, SOCKET_T* clientfd,
             socklen_t len = sizeof(addr);
             if (getsockname(*sockfd, (struct sockaddr*)&addr, &len) == 0) {
                 #ifndef TEST_IPV6
-                    port = ntohs(addr.sin_port);
+                    port = XNTOHS(addr.sin_port);
                 #else
-                    port = ntohs(addr.sin6_port);
+                    port = XNTOHS(addr.sin6_port);
                 #endif
             }
         }
@@ -2028,7 +2028,7 @@ static INLINE const char* mymktemp(char *tempfn, int len, int num)
         (void)userCtx;
 
         int ret;
-        word16 sLen = htons(inLen);
+        word16 sLen = XHTONS(inLen);
         byte aad[WOLFSSL_TICKET_NAME_SZ + WOLFSSL_TICKET_IV_SZ + 2];
         int  aadSz = WOLFSSL_TICKET_NAME_SZ + WOLFSSL_TICKET_IV_SZ + 2;
         byte* tmp = aad;

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1497,6 +1497,11 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #error old TLS requires MD5 and SHA
 #endif
 
+/* for backwards compatibility */
+#if defined(TEST_IPV6) && !defined(WOLFSSL_IPV6)
+    #define WOLFSSL_IPV6
+#endif
+
 
 /* Place any other flags or defines here */
 


### PR DESCRIPTION
Added support for inline CRL lookup when HAVE_CRL_IO is defined (shares code with OCSP lookup in io.c). Added http chunk transfer encoding support. Added default connection timeout value (DEFAULT_TIMEOUT_SEC) and new wolfIO_SetTimeout() API with HAVE_IO_TIMEOUT. Added generic wolfIO_ API’s for connect, select, non-blocking, read and write. Added new define USE_WOLFSSL_IO to enable access to new wolfIO_* socket wrappers even when WOLFSSL_USER_IO is defined. Moved all API declarations for io.c into new io.h header. Added HAVE_HTTP_CLIENT to expose HTTP API’s. Moved SOCKET_T and SOCKET_ defines into io.h. Added WOLFIO_DEBUG define to display request/responses.