### PR TITLE
account for static memory IO_POOL free when general memory was used

### DIFF
--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -539,7 +539,9 @@ void* wolfSSL_Malloc(size_t size, void* heap, int type)
         }
 
         /* case of using fixed IO buffers */
-        if (mem->flag & WOLFMEM_IO_POOL_FIXED) {
+        if (mem->flag & WOLFMEM_IO_POOL_FIXED &&
+                                             (type == DYNAMIC_TYPE_OUT_BUFFER ||
+                                              type == DYNAMIC_TYPE_IN_BUFFER)) {
             if (type == DYNAMIC_TYPE_OUT_BUFFER) {
                 pt = hint->outBuf;
             }
@@ -547,25 +549,26 @@ void* wolfSSL_Malloc(size_t size, void* heap, int type)
                 pt = hint->inBuf;
             }
         }
-
-        /* check if using IO pool flag */
-        if (mem->flag & WOLFMEM_IO_POOL && pt == NULL &&
+        else {
+            /* check if using IO pool flag */
+            if (mem->flag & WOLFMEM_IO_POOL &&
                                              (type == DYNAMIC_TYPE_OUT_BUFFER ||
                                               type == DYNAMIC_TYPE_IN_BUFFER)) {
-            if (mem->io != NULL) {
-                pt      = mem->io;
-                mem->io = pt->next;
+                if (mem->io != NULL) {
+                    pt      = mem->io;
+                    mem->io = pt->next;
+                }
             }
-        }
 
-        /* general static memory */
-        if (pt == NULL) {
-            for (i = 0; i < WOLFMEM_MAX_BUCKETS; i++) {
-                if ((word32)size < mem->sizeList[i]) {
-                    if (mem->ava[i] != NULL) {
-                        pt = mem->ava[i];
-                        mem->ava[i] = pt->next;
-                        break;
+            /* general static memory */
+            if (pt == NULL) {
+                for (i = 0; i < WOLFMEM_MAX_BUCKETS; i++) {
+                    if ((word32)size < mem->sizeList[i]) {
+                        if (mem->ava[i] != NULL) {
+                            pt = mem->ava[i];
+                            mem->ava[i] = pt->next;
+                            break;
+                        }
                     }
                 }
             }
@@ -672,7 +675,7 @@ void wolfSSL_Free(void *ptr, void* heap, int type)
                 /* fixed IO pools are free'd at the end of SSL lifetime
                    using FreeFixedIO(WOLFSSL_HEAP* heap, wc_Memory** io) */
             }
-            else if (mem->flag & WOLFMEM_IO_POOL &&
+            else if (mem->flag & WOLFMEM_IO_POOL && pt->sz == WOLFMEM_IO_SZ &&
                                              (type == DYNAMIC_TYPE_OUT_BUFFER ||
                                               type == DYNAMIC_TYPE_IN_BUFFER)) {
                 pt->next = mem->io;


### PR DESCRIPTION
Addresses GitHub Issue #751

The root cause of the issue was that there is a chance when using WOLFSSL_IO_POOL instead of using WOLFSSL_IO_FIXED that general memory is used when the IO pool memory runs out. Use of general memory is ok but later when freeing that memory it was not taken into account that the memory had come from the general memory pool and the buffer was placed instead into the IO pool. This was an issue because it could be a smaller buffer size than what is expected in the IO pool.

This fix checks the size of the buffer when freeing it and in the case that the buffer size is the same as an expected IO pool buffer it is returned to the IO pool. There is the possibility that general memory buffers could migrate to the IO pool with this fix if one of the general memory buffer size is the exact same size as WOLFMEM_IO_SZ.

Alternate fixes would be increasing struct size for managing buffers and adding a pool type flag or not allowing general memory use when the IO pool runs out.