### PR TITLE
Fixes for building CRL with Windows

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -11201,7 +11201,7 @@ int SendCertificateStatus(WOLFSSL* ssl)
             if (responses[0].buffer) {
                 if (ret == 0)
                     ret = BuildCertificateStatus(ssl, status_type,
-                                                              responses, i + 1);
+                                                        responses, (byte)i + 1);
 
                 for (i = 0; i < 1 + MAX_CHAIN_DEPTH; i++)
                     if (responses[i].buffer)
@@ -11713,8 +11713,6 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
     case NOT_CA_ERROR:
         return "Not a CA by basic constraint error";
 
-    case BAD_PATH_ERROR:
-        return "Bad path for opendir error";
 
     case BAD_CERT_MANAGER_ERROR:
         return "Bad Cert Manager error";

--- a/src/tls.c
+++ b/src/tls.c
@@ -2044,7 +2044,7 @@ static word16 TLSX_CSR_Write(CertificateStatusRequest* csr, byte* output,
 
                 /* request extensions */
                 if (csr->request.ocsp.nonceSz)
-                    length = EncodeOcspRequestExtensions(
+                    length = (word16)EncodeOcspRequestExtensions(
                                                  &csr->request.ocsp,
                                                  output + offset + OPAQUE16_LEN,
                                                  OCSP_NONCE_EXT_SZ);
@@ -2397,7 +2397,7 @@ static word16 TLSX_CSR2_Write(CertificateStatusRequestItemV2* csr2,
                     length = 0;
 
                     if (csr2->request.ocsp[0].nonceSz)
-                        length = EncodeOcspRequestExtensions(
+                        length = (word16)EncodeOcspRequestExtensions(
                                                  &csr2->request.ocsp[0],
                                                  output + offset + OPAQUE16_LEN,
                                                  OCSP_NONCE_EXT_SZ);

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -419,6 +419,9 @@ const char* wc_GetErrorString(int error)
     case DH_CHECK_PUB_E:
         return "DH Check Public Key failure";
 
+    case BAD_PATH_ERROR:
+        return "Bad path for opendir error";
+
     default:
         return "unknown error number";
 

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -90,7 +90,7 @@ enum wolfSSL_ErrorCodes {
     ECC_EXPORT_ERROR             = -354,   /* Bad ECC Export Key */
     ECC_SHARED_ERROR             = -355,   /* Bad ECC Shared Secret */
     NOT_CA_ERROR                 = -357,   /* Not a CA cert error */
-    BAD_PATH_ERROR               = -358,   /* Bad path for opendir */
+
     BAD_CERT_MANAGER_ERROR       = -359,   /* Bad Cert Manager */
     OCSP_CERT_REVOKED            = -360,   /* OCSP Certificate revoked */
     CRL_CERT_REVOKED             = -361,   /* CRL Certificate revoked */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1064,7 +1064,6 @@ enum Misc {
 
     MAX_X509_SIZE      = 2048, /* max static x509 buffer size */
     CERT_MIN_SIZE      =  256, /* min PEM cert size with header/footer */
-    MAX_FILENAME_SZ    =  256, /* max file name length */
     FILE_BUFFER_SIZE   = 1024, /* default static file buffer size for input,
                                   will use dynamic buffer if not big enough */
 

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1285,10 +1285,6 @@ static INLINE void CaCb(unsigned char* der, int sz, int type)
 /* Wolf Root Directory Helper */
 /* KEIL-RL File System does not support relative directory */
 #if !defined(WOLFSSL_MDK_ARM) && !defined(WOLFSSL_KEIL_FS) && !defined(WOLFSSL_TIRTOS)
-    #ifndef MAX_PATH
-        #define MAX_PATH 256
-    #endif
-
     /* Maximum depth to search for WolfSSL root */
     #define MAX_WOLF_ROOT_DEPTH 5
 

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -184,6 +184,7 @@ enum {
     WC_CLEANUP_E        = -241,  /* wolfcrypt cleanup failed */
     ECC_CDH_KAT_FIPS_E  = -242,  /* ECC CDH Known Answer Test failure */
     DH_CHECK_PUB_E      = -243,  /* DH Check Pub Key error */
+    BAD_PATH_ERROR      = -244,  /* Bad path for opendir */
 
     MIN_CODE_E          = -300   /* errors -101 - -299 */
 

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -60,6 +60,10 @@ WOLFSSL_API int wolfSSL_SetLoggingCb(wolfSSL_Logging_cb log_function);
 #endif /* defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE) */
 
 #ifdef DEBUG_WOLFSSL
+    #if defined ( WIN32 )
+        #define __func__ __FUNCTION__
+    #endif
+
     /* a is prepended to m and b is appended, creating a log msg a + m + b */
     #define WOLFSSL_LOG_CAT(a, m, b) #a " " m " "  #b
 


### PR DESCRIPTION
Refactor load_verify_buffer and LoadCRL to use new wc_ReadDir* functions. Added new directory/file API's: wc_ReadDirFirst(), wc_ReadDirNext(), wc_ReadDirClose(), wc_ChangeDirBack(), wc_ChangeDir(). Moved MAX_PATH and MAX_FILENAME_SZ to wc_port.h. Moved BAD_PATH_ERROR into error-crypt.h. The wc_ReadDir is only supported when NO_WOLFSSL_DIR and NO_FILESYSTEM are not defined. Add map to __FUNCTION__ macro in Windows with debug enabled (to resolve build error with VS and __func__ missing). Fix cast warning on response from EncodeOcspRequestExtensions.