### PR TITLE
Fix to reduce ECC memory usage when async crypt is not enabled

### DIFF
--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -274,10 +274,9 @@ typedef struct ecc_key {
     ecc_point pubkey;   /* public key */
     mp_int    k;        /* private key */
 #endif
+#ifdef WOLFSSL_ASYNC_CRYPT
     mp_int*   r;        /* sign/verify temps */
     mp_int*   s;
-
-#ifdef WOLFSSL_ASYNC_CRYPT
     AsyncCryptDev asyncDev;
 #endif
 } ecc_key;


### PR DESCRIPTION
 Fix uses local for r and s instead of key->r and key->s. Reduces peak heap use by 216 bytes for ECC sign. The curve cache changes are responsible for the remaining additional stack use. Working on another fix for that.