### PR TITLE
Add support hmacWithSHA2 in pkcs5 format key

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1764,6 +1764,42 @@ static int DecryptKey(const char* password, int passwordSz, byte* salt,
             decryptionType = RC4_TYPE;
             break;
 
+        case PBE_SHA256_DES:
+            typeH = SHA256;
+            derivedLen = 16;           /* may need iv for v1.5 */
+            decryptionType = DES_TYPE;
+            break;
+
+        case PBE_SHA384_DES:
+            typeH = SHA384;
+            derivedLen = 16;           /* may need iv for v1.5 */
+            decryptionType = DES_TYPE;
+            break;
+
+        case PBE_SHA512_DES:
+            typeH = SHA512;
+            derivedLen = 16;           /* may need iv for v1.5 */
+            decryptionType = DES_TYPE;
+            break;
+
+        case PBE_SHA256_DES3:
+            typeH = SHA256;
+            derivedLen = 32;           /* may need iv for v1.5 */
+            decryptionType = DES3_TYPE;
+            break;
+
+        case PBE_SHA384_DES3:
+            typeH = SHA384;
+            derivedLen = 32;           /* may need iv for v1.5 */
+            decryptionType = DES3_TYPE;
+            break;
+
+        case PBE_SHA512_DES3:
+            typeH = SHA512;
+            derivedLen = 32;           /* may need iv for v1.5 */
+            decryptionType = DES3_TYPE;
+            break;
+
         default:
             return ALGO_ID_E;
     }
@@ -1980,6 +2016,40 @@ int ToTraditionalEnc(byte* input, word32 sz,const char* password,int passwordSz)
         if (GetAlgoId(input, &inOutIdx, &oid, oidBlkType, sz) < 0) {
             ERROR_OUT(ASN_PARSE_E, exit_tte);
         }
+        if (input[inOutIdx - 2] == ASN_TAG_NULL &&
+            input[inOutIdx - 1] == 0) {
+            /*NULL object tag, we think it should be hmacWithSHA2*/
+            switch (oid) {
+                case 653: // hmacWithSHA256
+                    id = 1;
+                    break;
+                case 654: // hmacWithSHA384
+                    id = 2;
+                    break;
+                case 655: // hmacWithSHA512
+                    id = 3;
+                    break;
+                default:
+                    ERROR_OUT(ASN_PARSE_E, exit_tte);
+            }
+            if (GetAlgoId(input, &inOutIdx, &oid, sz) < 0) {
+#ifdef WOLFSSL_SMALL_STACK
+            XFREE(salt,  NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(cbcIv, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+                ERROR_OUT(ASN_PARSE_E, exit_tte);
+            }
+            switch (oid) {
+                case 69:
+                    id += 3; // 3 offset for des
+                    break;
+                case 652:
+                    id += 6; // 6 offset for des3
+                    break;
+                default:
+                    ERROR_OUT(ASN_PARSE_E, exit_tte);
+            }
+        } else
 
         if (CheckAlgoV2(oid, &id) < 0) {
             ERROR_OUT(ASN_PARSE_E, exit_tte); /* PKCS v2 algo id error */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -113,6 +113,12 @@ enum PBES {
     PBE_SHA1_DES     = 1,
     PBE_SHA1_DES3    = 2,
     PBE_SHA1_RC4_128 = 3,
+    PBE_SHA256_DES   = 4,
+    PBE_SHA384_DES   = 5,
+    PBE_SHA512_DES   = 6,
+    PBE_SHA256_DES3  = 7,
+    PBE_SHA384_DES3  = 8,
+    PBE_SHA512_DES3  = 9,
     PBES2            = 13       /* algo ID */
 };
 


### PR DESCRIPTION
The cert which the latest openssl created can support hmacwithsha2 serials, but these format certs cannot be decrypted by wolfssl.
And I also have a question, why we don't use oid to check the private key and just sum them up? :)