### PR TITLE
remove EccPublicKeyDecode() from WOLFSSL_CERT_EXT guard

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9204,7 +9204,7 @@ int wc_EccPrivateKeyDecode(const byte* input, word32* inOutIdx, ecc_key* key,
     return ret;
 }
 
-#ifdef WOLFSSL_CERT_EXT
+
 int wc_EccPublicKeyDecode(const byte* input, word32* inOutIdx,
                           ecc_key* key, word32 inSz)
 {
@@ -9258,7 +9258,6 @@ int wc_EccPublicKeyDecode(const byte* input, word32* inOutIdx,
 
     return 0;
 }
-#endif
 
 
 #ifdef WOLFSSL_KEY_GEN


### PR DESCRIPTION
This PR removes EccPublicKeyDecode() in asn.c from the WOLFSSL_CERT_EXT guard.

As an external API, wolfCrypt JCE uses this function for key import.  Because this function is simply importing an ECC key, it doesn't seem exclusive to WOLFSSL_CERT_EXT (cert request extensions, which also requires cert gen).

Talking with Jacob, he will also be needing this fix for OpenSSL compatibility layer expansion work.

Ref: https://github.com/wolfSSL/wolfssl/pull/708