### PR TITLE
Reduce heap usage with fast math when not using ALT_ECC_SIZE

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -988,10 +988,13 @@ int fp_mulmod(fp_int *a, fp_int *b, fp_int *c, fp_int *d)
 
   fp_init(&t);
   fp_mul(a, b, &t);
+#if defined(ALT_ECC_SIZE) || defined(WOLFSSL_ASYNC_CRYPT)
   if (d->size < FP_SIZE) {
     err = fp_mod(&t, c, &t);
     fp_copy(&t, d);
-  } else {
+  } else
+#endif
+  {
     err = fp_mod(&t, c, d);
   }
 
@@ -1006,10 +1009,13 @@ int fp_submod(fp_int *a, fp_int *b, fp_int *c, fp_int *d)
 
   fp_init(&t);
   fp_sub(a, b, &t);
+#if defined(ALT_ECC_SIZE) || defined(WOLFSSL_ASYNC_CRYPT)
   if (d->size < FP_SIZE) {
     err = fp_mod(&t, c, &t);
     fp_copy(&t, d);
-  } else {
+  } else
+#endif
+  {
     err = fp_mod(&t, c, d);
   }
 
@@ -1024,10 +1030,13 @@ int fp_addmod(fp_int *a, fp_int *b, fp_int *c, fp_int *d)
 
   fp_init(&t);
   fp_add(a, b, &t);
+#if defined(ALT_ECC_SIZE) || defined(WOLFSSL_ASYNC_CRYPT)
   if (d->size < FP_SIZE) {
     err = fp_mod(&t, c, &t);
     fp_copy(&t, d);
-  } else {
+  } else
+#endif
+  {
     err = fp_mod(&t, c, d);
   }
 
@@ -2185,10 +2194,13 @@ void fp_sub_d(fp_int *a, fp_digit b, fp_int *c)
    fp_int tmp;
    fp_init(&tmp);
    fp_set(&tmp, b);
+#if defined(ALT_ECC_SIZE) || defined(WOLFSSL_ASYNC_CRYPT)
    if (c->size < FP_SIZE) {
      fp_sub(a, &tmp, &tmp);
      fp_copy(&tmp, c);
-   } else {
+   } else
+#endif
+   {
      fp_sub(a, &tmp, c);
    }
 }
@@ -2206,22 +2218,32 @@ int mp_init (mp_int * a)
 
 void fp_init(fp_int *a)
 {
+#if defined(ALT_ECC_SIZE) || defined(WOLFSSL_ASYNC_CRYPT)
     a->size = FP_SIZE;
+#endif
     fp_zero(a);
 }
 
 void fp_zero(fp_int *a)
 {
+    int size = FP_SIZE;
     a->used = 0;
     a->sign = FP_ZPOS;
-    XMEMSET(a->dp, 0, a->size * sizeof(fp_digit));
+#if defined(ALT_ECC_SIZE) || defined(WOLFSSL_ASYNC_CRYPT)
+    size = a->size;
+#endif
+    XMEMSET(a->dp, 0, size * sizeof(fp_digit));
 }
 
 void fp_clear(fp_int *a)
 {
+    int size = FP_SIZE;
     a->used = 0;
     a->sign = FP_ZPOS;
-    ForceZero(a->dp, a->size * sizeof(fp_digit));
+#if defined(ALT_ECC_SIZE) || defined(WOLFSSL_ASYNC_CRYPT)
+    size = a->size;
+#endif
+    ForceZero(a->dp, size * sizeof(fp_digit));
 }
 
 
@@ -2403,7 +2425,7 @@ void fp_copy(fp_int *a, fp_int *b)
 {
     /* if source and destination are different */
     if (a != b) {
-#ifdef ALT_ECC_SIZE
+#if defined(ALT_ECC_SIZE) || defined(WOLFSSL_ASYNC_CRYPT)
         /* verify a will fit in b */
         if (b->size >= a->used) {
             int x, oldused;
@@ -2502,11 +2524,14 @@ int fp_sqrmod(fp_int *a, fp_int *b, fp_int *c)
   fp_init(&t);
   fp_sqr(a, &t);
 
+#if defined(ALT_ECC_SIZE) || defined(WOLFSSL_ASYNC_CRYPT)
   if (c->size < FP_SIZE) {
     err = fp_mod(&t, b, &t);
     fp_copy(&t, c);
   }
-  else {
+  else
+#endif
+  {
     err = fp_mod(&t, b, c);
   }
 
@@ -3246,9 +3271,14 @@ int mp_toradix (mp_int *a, char *str, int radix)
 void mp_dump(const char* desc, mp_int* a, byte verbose)
 {
   char buffer[FP_SIZE * sizeof(fp_digit) * 2];
+  int size = FP_SIZE;
+
+#if defined(ALT_ECC_SIZE) || defined(WOLFSSL_ASYNC_CRYPT)
+  size = a->size;
+#endif
 
   printf("%s: ptr=%p, used=%d, sign=%d, size=%d, fpd=%d\n",
-    desc, a, a->used, a->sign, a->size, (int)sizeof(fp_digit));
+    desc, a, a->used, a->sign, size, (int)sizeof(fp_digit));
 
   mp_toradix(a, buffer, 16);
   printf("  %s\n  ", buffer);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6197,7 +6197,7 @@ int rsa_test(void)
     }
     do {
 #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_RsaAsyncWait(ret, key);
+        ret = wc_RsaAsyncWait(ret, &key);
 #endif
         if (ret >= 0) {
             ret = wc_RsaPrivateDecryptInline(out, idx, &res, &key);
@@ -6332,7 +6332,7 @@ int rsa_test(void)
 
     do {
 #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_RsaAsyncWait(ret, key);
+        ret = wc_RsaAsyncWait(ret, &key);
 #endif
         if (ret >= 0) {
             ret = wc_RsaPrivateDecryptInline_ex(out, idx, &res, &key,

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1493,7 +1493,8 @@ static char *fgets(char *buff, int sz, FILE *fp)
     #endif
 #endif
 
-#if !defined(NO_OLD_TLS) && (defined(NO_SHA) || defined(NO_MD5))
+#if !defined(WOLFCRYPT_ONLY) && !defined(NO_OLD_TLS) && \
+        (defined(NO_SHA) || defined(NO_MD5))
     #error old TLS requires MD5 and SHA
 #endif
 

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -286,7 +286,9 @@
 typedef struct fp_int {
     int      used;
     int      sign;
+#if defined(ALT_ECC_SIZE) || defined(WOLFSSL_ASYNC_CRYPT)
     int      size;
+#endif
     fp_digit dp[FP_SIZE];
 #ifdef WOLFSSL_ASYNC_CRYPT
     byte *dpraw; /* Used for hardware crypto */


### PR DESCRIPTION
Reduce TFM fp_int size by only adding the “int size” if ALT_ECC_SIZE or WOLFSSL_ASYNC_CRYPT is defined. Fix couple of async build errors in wolfCrypt test.