### PR TITLE
test case when not using RSA blinding

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5741,7 +5741,7 @@ static int rsa_sig_test(RsaKey* key, word32 keyLen, int modLen, WC_RNG* rng)
      *     -101 = USER_CRYPTO_ERROR
      */
     if (ret == 0)
-#elif defined(HAVE_FIPS)
+#elif defined(HAVE_FIPS) || !defined(WC_RSA_BLINDING)
     /* FIPS140 implementation doesn't do blinding. */
     if (ret != 0)
 #else


### PR DESCRIPTION
Updated test case to check if not using RSA blinding. Can be seen with "./configure --disable-harden".