### PR TITLE
add server-keyPkcs8.der to include.am

### DIFF
--- a/certs/include.am
+++ b/certs/include.am
@@ -24,6 +24,7 @@ EXTRA_DIST += \
 	     certs/server-ecc-rsa.pem \
 	     certs/server-keyEnc.pem \
 	     certs/server-key.pem \
+	     certs/server-keyPkcs8.der \
 	     certs/server-keyPkcs8Enc12.pem \
 	     certs/server-keyPkcs8Enc2.pem \
 	     certs/server-keyPkcs8Enc.pem \


### PR DESCRIPTION
The server-keyPkcs8.der file is used in the API test for wc_GetPkcs8TraditionalOffset().  This PR allows "make distcheck" to pass.