### PR TITLE
TKernel port

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -2681,6 +2681,7 @@ static int SetAuthKeys(OneTimeAuth* authentication, Keys* keys,
         if (authentication)
             authentication->setup = 1;
 #endif
+        (void)authentication;
         (void)heap;
         (void)keys;
         (void)specs;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -94,17 +94,6 @@
 #endif
 
 
-#if defined(WOLFSSL_DTLS) && !defined(WOLFSSL_HAVE_MAX)
-#define WOLFSSL_HAVE_MAX
-
-    static INLINE word32 max(word32 a, word32 b)
-    {
-        return a > b ? a : b;
-    }
-
-#endif /* WOLFSSL_DTLS && !WOLFSSL_HAVE_MAX */
-
-
 #ifndef WOLFSSL_LEANPSK
 char* mystrnstr(const char* s1, const char* s2, unsigned int n)
 {
@@ -12577,7 +12566,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         cert = (DecodedCert*)XMALLOC(sizeof(DecodedCert), NULL,
                                      DYNAMIC_TYPE_TMP_BUFFER);
         if (cert == NULL)
-            return NULL;
+            return MEMORY_E;
     #endif
 
         /* Create a DecodedCert object and copy fields into WOLFSSL_X509 object.
@@ -16540,6 +16529,8 @@ int wolfSSL_BN_mod_exp(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
     }
 
     WOLFSSL_LEAVE("wolfSSL_BN_mod_exp", ret);
+    (void)ret;
+
     return SSL_FAILURE;
 }
 
@@ -21199,6 +21190,7 @@ WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN* chain, int idx)
         #endif
         }
     }
+    (void)ret;
 
     return x509;
 }
@@ -21568,16 +21560,16 @@ void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl)
     }
     #endif /* ifndef NO_CERTS */
 
-#if defined(HAVE_LIGHTY) || defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || defined(OPENSSL_EXTRA)
     #ifndef NO_CERTS
     void wolfSSL_X509_NAME_free(WOLFSSL_X509_NAME *name){
         FreeX509Name(name, NULL);
         WOLFSSL_ENTER("wolfSSL_X509_NAME_free");
     }
     #endif /* NO_CERTS */
-#endif
 
-#if defined(HAVE_LIGHTY) || defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX)
+#if defined(HAVE_LIGHTY)  || defined(WOLFSSL_MYSQL_COMPATIBLE) || \
+    defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
+    defined(HAVE_POCO_LIB)
 
     unsigned char *wolfSSL_SHA1(const unsigned char *d, size_t n, unsigned char *md)
     {
@@ -21772,8 +21764,8 @@ void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl)
         return NULL;
     }
 
-#endif /* HAVE_LIGHTY || WOLFSSL_MYSQL_COMPATIBLE || HAVE_STUNNEL */
-#endif
+#endif /* HAVE_LIGHTY || WOLFSSL_MYSQL_COMPATIBLE || HAVE_STUNNEL || WOLFSSL_NGINX || HAVE_POCO_LIB */
+#endif /* OPENSSL_EXTRA */
 
 
 #ifdef OPENSSL_EXTRA

--- a/src/tls.c
+++ b/src/tls.c
@@ -3564,19 +3564,19 @@ int TLSX_UseSessionTicket(TLSX** extensions, SessionTicket* ticket, void* heap)
     return SSL_SUCCESS;
 }
 
-#define STK_VALIDATE_REQUEST TLSX_SessionTicket_ValidateRequest
-#define STK_GET_SIZE         TLSX_SessionTicket_GetSize
-#define STK_WRITE            TLSX_SessionTicket_Write
-#define STK_PARSE            TLSX_SessionTicket_Parse
-#define STK_FREE(stk, heap)  TLSX_SessionTicket_Free((SessionTicket*)stk,(heap))
+#define WOLF_STK_VALIDATE_REQUEST TLSX_SessionTicket_ValidateRequest
+#define WOLF_STK_GET_SIZE         TLSX_SessionTicket_GetSize
+#define WOLF_STK_WRITE            TLSX_SessionTicket_Write
+#define WOLF_STK_PARSE            TLSX_SessionTicket_Parse
+#define WOLF_STK_FREE(stk, heap)  TLSX_SessionTicket_Free((SessionTicket*)stk,(heap))
 
 #else
 
-#define STK_FREE(a, b)
-#define STK_VALIDATE_REQUEST(a)
-#define STK_GET_SIZE(a, b)      0
-#define STK_WRITE(a, b, c)      0
-#define STK_PARSE(a, b, c, d)   0
+#define WOLF_STK_FREE(a, b)
+#define WOLF_STK_VALIDATE_REQUEST(a)
+#define WOLF_STK_GET_SIZE(a, b)      0
+#define WOLF_STK_WRITE(a, b, c)      0
+#define WOLF_STK_PARSE(a, b, c, d)   0
 
 #endif /* HAVE_SESSION_TICKET */
 
@@ -4229,7 +4229,7 @@ void TLSX_FreeAll(TLSX* list, void* heap)
                 break;
 
             case TLSX_SESSION_TICKET:
-                STK_FREE(extension->data, heap);
+                WOLF_STK_FREE(extension->data, heap);
                 break;
 
             case TLSX_QUANTUM_SAFE_HYBRID:
@@ -4310,7 +4310,7 @@ static word16 TLSX_GetSize(TLSX* list, byte* semaphore, byte isRequest)
                 break;
 
             case TLSX_SESSION_TICKET:
-                length += STK_GET_SIZE((SessionTicket*)extension->data,
+                length += WOLF_STK_GET_SIZE((SessionTicket*)extension->data,
                         isRequest);
                 break;
 
@@ -4393,7 +4393,7 @@ static word16 TLSX_Write(TLSX* list, byte* output, byte* semaphore,
                 break;
 
             case TLSX_SESSION_TICKET:
-                offset += STK_WRITE((SessionTicket*)extension->data,
+                offset += WOLF_STK_WRITE((SessionTicket*)extension->data,
                         output + offset, isRequest);
                 break;
 
@@ -4797,7 +4797,7 @@ word16 TLSX_GetRequestSize(WOLFSSL* ssl)
 
         EC_VALIDATE_REQUEST(ssl, semaphore);
         QSH_VALIDATE_REQUEST(ssl, semaphore);
-        STK_VALIDATE_REQUEST(ssl);
+        WOLF_STK_VALIDATE_REQUEST(ssl);
 
         if (ssl->extensions)
             length += TLSX_GetSize(ssl->extensions, semaphore, 1);
@@ -4832,7 +4832,7 @@ word16 TLSX_WriteRequest(WOLFSSL* ssl, byte* output)
         offset += OPAQUE16_LEN; /* extensions length */
 
         EC_VALIDATE_REQUEST(ssl, semaphore);
-        STK_VALIDATE_REQUEST(ssl);
+        WOLF_STK_VALIDATE_REQUEST(ssl);
         QSH_VALIDATE_REQUEST(ssl, semaphore);
 
         if (ssl->extensions)
@@ -5031,7 +5031,7 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte isRequest,
             case TLSX_SESSION_TICKET:
                 WOLFSSL_MSG("Session Ticket extension received");
 
-                ret = STK_PARSE(ssl, input + offset, size, isRequest);
+                ret = WOLF_STK_PARSE(ssl, input + offset, size, isRequest);
                 break;
 
             case TLSX_QUANTUM_SAFE_HYBRID:

--- a/src/tls.c
+++ b/src/tls.c
@@ -2914,11 +2914,6 @@ int TLSX_ValidateEllipticCurves(WOLFSSL* ssl, byte first, byte second) {
             case WOLFSSL_ECC_SECP160R1:
                 oid = ECC_SECP160R1_OID;
                 octets = 20;
-                /* Default for 160-bits. */
-                if (ssl->eccTempKeySz <= octets && defSz > octets) {
-                    defOid = oid;
-                    defSz = octets;
-                }
                 break;
         #endif /* !NO_ECC_SECP */
         #ifdef HAVE_ECC_SECPR2
@@ -2939,11 +2934,6 @@ int TLSX_ValidateEllipticCurves(WOLFSSL* ssl, byte first, byte second) {
             case WOLFSSL_ECC_SECP192R1:
                 oid = ECC_SECP192R1_OID;
                 octets = 24;
-                /* Default for 192-bits. */
-                if (ssl->eccTempKeySz <= octets && defSz > octets) {
-                    defOid = oid;
-                    defSz = octets;
-                }
                 break;
         #endif /* !NO_ECC_SECP */
         #ifdef HAVE_ECC_KOBLITZ
@@ -2958,11 +2948,6 @@ int TLSX_ValidateEllipticCurves(WOLFSSL* ssl, byte first, byte second) {
             case WOLFSSL_ECC_SECP224R1:
                 oid = ECC_SECP224R1_OID;
                 octets = 28;
-                /* Default for 224-bits. */
-                if (ssl->eccTempKeySz <= octets && defSz > octets) {
-                    defOid = oid;
-                    defSz = octets;
-                }
                 break;
         #endif /* !NO_ECC_SECP */
         #ifdef HAVE_ECC_KOBLITZ
@@ -2972,16 +2957,11 @@ int TLSX_ValidateEllipticCurves(WOLFSSL* ssl, byte first, byte second) {
                 break;
         #endif /* HAVE_ECC_KOBLITZ */
     #endif
-    #if !defined(NO_ECC256)  || defined(HAVE_ALL_CURVES)
+    #if !defined(NO_ECC256) || defined(HAVE_ALL_CURVES)
         #ifndef NO_ECC_SECP
             case WOLFSSL_ECC_SECP256R1:
                 oid = ECC_SECP256R1_OID;
                 octets = 32;
-                /* Default for 256-bits. */
-                if (ssl->eccTempKeySz <= octets && defSz > octets) {
-                    defOid = oid;
-                    defSz = octets;
-                }
                 break;
         #endif /* !NO_ECC_SECP */
         #ifdef HAVE_ECC_KOBLITZ
@@ -3002,11 +2982,6 @@ int TLSX_ValidateEllipticCurves(WOLFSSL* ssl, byte first, byte second) {
             case WOLFSSL_ECC_SECP384R1:
                 oid = ECC_SECP384R1_OID;
                 octets = 48;
-                /* Default for 384-bits. */
-                if (ssl->eccTempKeySz <= octets && defSz > octets) {
-                    defOid = oid;
-                    defSz = octets;
-                }
                 break;
         #endif /* !NO_ECC_SECP */
         #ifdef HAVE_ECC_BRAINPOOL
@@ -3033,6 +3008,12 @@ int TLSX_ValidateEllipticCurves(WOLFSSL* ssl, byte first, byte second) {
         #endif /* !NO_ECC_SECP */
     #endif
             default: continue; /* unsupported curve */
+        }
+
+        /* Set default Oid */
+        if (defOid == 0 && ssl->eccTempKeySz <= octets && defSz > octets) {
+            defOid = oid;
+            defSz = octets;
         }
 
         if (currOid == 0 && ssl->eccTempKeySz == octets)

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -233,8 +233,11 @@ void bench_ntruKeyGen(void);
 void bench_rng(void);
 #endif /* WC_NO_RNG */
 
-double current_time(int);
-
+#ifdef WOLFSSL_CURRTIME_REMAP
+    #define current_time WOLFSSL_CURRTIME_REMAP
+#else
+    double current_time(int);
+#endif
 
 #if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND)
     WOLFSSL_API int wolfSSL_Debugging_ON();
@@ -2592,8 +2595,9 @@ void bench_ed25519KeySign(void)
         return ( ns / CLOCK * 2.0);
     }
 
-#elif defined(WOLFSSL_IAR_ARM_TIME) || defined (WOLFSSL_MDK_ARM) || defined(WOLFSSL_USER_CURRTIME)
-    /* declared above at line 189 */
+#elif defined(WOLFSSL_IAR_ARM_TIME) || defined (WOLFSSL_MDK_ARM) || \
+      defined(WOLFSSL_USER_CURRTIME) || defined(WOLFSSL_CURRTIME_REMAP)
+    /* declared above at line 239 */
     /* extern   double current_time(int reset); */
 
 #elif defined FREERTOS

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8258,7 +8258,7 @@ static int WriteCertReqBody(DerCert* der, byte* buffer)
     /* extensions */
     if (der->extensionsSz) {
         XMEMCPY(buffer + idx, der->extensions, min(der->extensionsSz,
-                                                   sizeof(der->extensions)));
+                                               (int)sizeof(der->extensions)));
         idx += der->extensionsSz;
     }
 

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -216,20 +216,31 @@ STATIC INLINE int ConstantCompare(const byte* a, const byte* b, int length)
     return compareSum;
 }
 
+
 #ifndef WOLFSSL_HAVE_MIN
     #define WOLFSSL_HAVE_MIN
-    #if defined(HAVE_FIPS) && !defined(min)
+    #if defined(HAVE_FIPS) && !defined(min) /* so ifdef check passes */
         #define min min
     #endif
     STATIC INLINE word32 min(word32 a, word32 b)
     {
         return a > b ? b : a;
     }
-#endif /* WOLFSSL_HAVE_MIN */
+#endif /* !WOLFSSL_HAVE_MIN */
+
+#ifndef WOLFSSL_HAVE_MAX
+    #define WOLFSSL_HAVE_MAX
+    #if defined(HAVE_FIPS) && !defined(max) /* so ifdef check passes */
+        #define max max
+    #endif
+    STATIC INLINE word32 max(word32 a, word32 b)
+    {
+        return a > b ? a : b;
+    }
+#endif /* !WOLFSSL_HAVE_MAX */
 
 
 #undef STATIC
-
 
 #endif /* !WOLFSSL_MISC_INCLUDED && !NO_INLINE */
 

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1170,6 +1170,38 @@ static int wc_GenerateRand_IntelRD(OS_Seed* os, byte* output, word32 sz)
         return CUSTOM_RAND_GENERATE_SEED_OS(os, output, sz);
     }
 
+
+#elif defined(CUSTOM_RAND_GENERATE)
+
+   /* Implement your own random generation function
+    * word32 rand_gen(void);
+    * #define CUSTOM_RAND_GENERATE  rand_gen  */
+
+    int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
+    {
+        word32 i = 0;
+
+        (void)os;
+
+        while (i < sz)
+        {
+            /* If not aligned or there is odd/remainder */
+            if( (i + sizeof(CUSTOM_RAND_TYPE)) > sz ||
+                ((wolfssl_word)&output[i] % sizeof(CUSTOM_RAND_TYPE)) != 0
+            ) {
+                /* Single byte at a time */
+                output[i++] = (byte)CUSTOM_RAND_GENERATE();
+            }
+            else {
+                /* Use native 8, 16, 32 or 64 copy instruction */
+                *((CUSTOM_RAND_TYPE*)&output[i]) = CUSTOM_RAND_GENERATE();
+                i += sizeof(CUSTOM_RAND_TYPE);
+            }
+        }
+
+        return 0;
+    }
+
 #elif defined(WOLFSSL_SGX)
 
 int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
@@ -1392,7 +1424,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
                 return RAN_BLOCK_E;
             }
         }
-        
+
     #elif defined(FREESCALE_KSDK_2_0_RNGA)
 
         int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
@@ -1626,40 +1658,9 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         return 0;
     }
 
-#elif defined(CUSTOM_RAND_GENERATE)
-
-   /* Implement your own random generation function
-    * word32 rand_gen(void);
-    * #define CUSTOM_RAND_GENERATE  rand_gen  */
-
-    int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
-    {
-        word32 i = 0;
-
-        (void)os;
-
-        while (i < sz)
-        {
-            /* If not aligned or there is odd/remainder */
-            if( (i + sizeof(CUSTOM_RAND_TYPE)) > sz ||
-                ((wolfssl_word)&output[i] % sizeof(CUSTOM_RAND_TYPE)) != 0
-            ) {
-                /* Single byte at a time */
-                output[i++] = (byte)CUSTOM_RAND_GENERATE();
-            }
-            else {
-                /* Use native 8, 16, 32 or 64 copy instruction */
-                *((CUSTOM_RAND_TYPE*)&output[i]) = CUSTOM_RAND_GENERATE();
-                i += sizeof(CUSTOM_RAND_TYPE);
-            }
-        }
-
-        return 0;
-    }
-
 #elif defined(WOLFSSL_ATMEL)
     #include <wolfssl/wolfcrypt/port/atmel/atmel.h>
-    
+
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
     	int ret = 0;

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -2741,10 +2741,8 @@ int mp_rand_prime(mp_int* N, int len, WC_RNG* rng, void* heap)
     switch(err) {
         case FP_VAL:
             return MP_VAL;
-            break;
         case FP_MEM:
             return MP_MEM;
-            break;
         default:
             break;
     }

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -778,7 +778,7 @@ int wolfSSL_CryptHwMutexUnLock(void) {
 
     int wc_FreeMutex(wolfSSL_Mutex* m)
     {
-        tk_del_sem( m->id );
+        tk_del_sem(m->id);
         return 0;
     }
 
@@ -796,9 +796,12 @@ int wolfSSL_CryptHwMutexUnLock(void) {
 
     /****  uT-Kernel malloc/free ***/
     static ID ID_wolfssl_MPOOL = 0;
-    static T_CMPL wolfssl_MPOOL =
-                 {(void *)NULL,
-    TA_TFIFO , 0,   "wolfSSL_MPOOL"};
+    static T_CMPL wolfssl_MPOOL = {
+        NULL,       /* Extended information */
+        TA_TFIFO,   /* Memory pool attribute */
+        0,          /* Size of whole memory pool (byte) */
+        "wolfSSL"   /* Object name (max 8-char) */
+    };
 
     int uTKernel_init_mpool(unsigned int sz) {
         ER ercd;
@@ -808,7 +811,7 @@ int wolfSSL_CryptHwMutexUnLock(void) {
             ID_wolfssl_MPOOL = ercd;
             return 0;
         } else {
-            return -1;
+            return (int)ercd;
         }
     }
 
@@ -826,7 +829,7 @@ int wolfSSL_CryptHwMutexUnLock(void) {
     void *uTKernel_realloc(void *p, unsigned int sz) {
       ER ercd;
       void *newp;
-      if(p) {
+      if (p) {
           ercd = tk_get_mpl(ID_wolfssl_MPOOL, sz, (VP)&newp, TMO_FEVR);
           if (ercd == E_OK) {
               XMEMCPY(newp, p, sz);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5277,6 +5277,9 @@ byte GetEntropy(ENTROPY_CMD cmd, byte* out)
 #elif defined(WOLFSSL_MKD_SHELL)
     #define CERT_PREFIX ""
     #define CERT_PATH_SEP "/"
+#elif defined(WOLFSSL_uTKERNEL2)
+    #define CERT_PREFIX "/uda/"
+    #define CERT_PATH_SEP "/"
 #else
     #define CERT_PREFIX "./"
     #define CERT_PATH_SEP "/"
@@ -6106,7 +6109,7 @@ int rsa_test(void)
 
     tmp = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (tmp == NULL)
-        return -40;
+        return -38;
 
 #ifdef USE_CERT_BUFFERS_1024
     XMEMCPY(tmp, client_key_der_1024, sizeof_client_key_der_1024);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5324,6 +5324,7 @@ byte GetEntropy(ENTROPY_CMD cmd, byte* out)
     #endif /* HAVE_ECC */
 #endif /* !USE_CERT_BUFFER_* */
 
+#ifndef NO_WRITE_TEMP_FILES
 #ifdef HAVE_ECC
     /* Temporary Cert Files to be used in rsa cert gen test, is RSA enabled */
     #if defined(WOLFSSL_CERT_GEN) && !defined(NO_RSA)
@@ -5360,7 +5361,7 @@ byte GetEntropy(ENTROPY_CMD cmd, byte* out)
         static const char* certReqPemFile = CERT_PREFIX "certreq.pem";
     #endif
 #endif /* !NO_RSA */
-
+#endif /* !NO_WRITE_TEMP_FILES */
 #endif /* !NO_FILESYSTEM */
 
 #ifndef NO_RSA
@@ -6644,7 +6645,7 @@ int rsa_test(void)
         int    pemSz = 0;
         RsaKey derIn;
         RsaKey genKey;
-    #ifndef NO_FILESYSTEM
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         FILE*  keyFile;
         FILE*  pemFile;
     #endif
@@ -6687,7 +6688,7 @@ int rsa_test(void)
             return -302;
         }
 
-    #ifndef NO_FILESYSTEM
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         keyFile = fopen(keyDerFile, "wb");
         if (!keyFile) {
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -6719,7 +6720,7 @@ int rsa_test(void)
             return -304;
         }
 
-    #ifndef NO_FILESYSTEM
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         pemFile = fopen(keyPemFile, "wb");
         if (!pemFile) {
             XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -6775,13 +6776,15 @@ int rsa_test(void)
         Cert        myCert;
         byte*       derCert;
         byte*       pem;
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         FILE*       derFile;
         FILE*       pemFile;
+    #endif
         int         certSz;
         int         pemSz;
-#ifdef WOLFSSL_TEST_CERT
+    #ifdef WOLFSSL_TEST_CERT
         DecodedCert decode;
-#endif
+    #endif
 
         derCert = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
@@ -6868,7 +6871,7 @@ int rsa_test(void)
         FreeDecodedCert(&decode);
     #endif
 
-    #ifndef NO_FILESYSTEM
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         derFile = fopen(certDerFile, "wb");
         if (!derFile) {
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -6897,7 +6900,7 @@ int rsa_test(void)
             return -404;
         }
 
-    #ifndef NO_FILESYSTEM
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         pemFile = fopen(certPemFile, "wb");
         if (!pemFile) {
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -6926,8 +6929,10 @@ int rsa_test(void)
         Cert        myCert;
         byte*       derCert;
         byte*       pem;
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         FILE*       derFile;
         FILE*       pemFile;
+    #endif
         int         certSz;
         int         pemSz;
         size_t      bytes3;
@@ -7102,7 +7107,7 @@ int rsa_test(void)
         FreeDecodedCert(&decode);
     #endif
 
-#ifndef NO_FILESYSTEM
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         derFile = fopen(otherCertDerFile, "wb");
         if (!derFile) {
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -7122,6 +7127,7 @@ int rsa_test(void)
             wc_FreeRng(&rng);
             return -416;
         }
+    #endif
 
         pemSz = wc_DerToPem(derCert, certSz, pem, FOURK_BUF, CERT_TYPE);
         if (pemSz < 0) {
@@ -7133,6 +7139,7 @@ int rsa_test(void)
             return -411;
         }
 
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         pemFile = fopen(otherCertPemFile, "wb");
         if (!pemFile) {
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -7153,7 +7160,7 @@ int rsa_test(void)
             return -415;
         }
         fclose(pemFile);
-#endif /* !NO_FILESYSTEM */
+    #endif
 
         XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -7166,8 +7173,10 @@ int rsa_test(void)
         Cert        myCert;
         byte*       derCert;
         byte*       pem;
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         FILE*       derFile;
         FILE*       pemFile;
+    #endif
         int         certSz;
         int         pemSz;
         size_t      bytes3;
@@ -7348,7 +7357,7 @@ int rsa_test(void)
             return -5408;
         }
 
-#ifdef WOLFSSL_TEST_CERT
+    #ifdef WOLFSSL_TEST_CERT
         InitDecodedCert(&decode, derCert, certSz, 0);
         ret = ParseCert(&decode, CERT_TYPE, NO_VERIFY, 0);
         if (ret != 0) {
@@ -7360,8 +7369,9 @@ int rsa_test(void)
             return -5409;
         }
         FreeDecodedCert(&decode);
-#endif
+    #endif
 
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         derFile = fopen(certEccDerFile, "wb");
         if (!derFile) {
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -7381,6 +7391,7 @@ int rsa_test(void)
             wc_FreeRng(&rng);
             return -5414;
         }
+    #endif
 
         pemSz = wc_DerToPem(derCert, certSz, pem, FOURK_BUF, CERT_TYPE);
         if (pemSz < 0) {
@@ -7392,6 +7403,7 @@ int rsa_test(void)
             return -5411;
         }
 
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         pemFile = fopen(certEccPemFile, "wb");
         if (!pemFile) {
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -7410,8 +7422,9 @@ int rsa_test(void)
             wc_FreeRng(&rng);
             return -5415;
         }
-
         fclose(pemFile);
+    #endif
+
         XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         wc_ecc_free(&caKey);
@@ -7642,7 +7655,7 @@ int rsa_test(void)
         FreeDecodedCert(&decode);
     #endif
 
-    #ifndef NO_FILESYSTEM
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         derFile = fopen("./ntru-cert.der", "wb");
         if (!derFile) {
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -7671,7 +7684,7 @@ int rsa_test(void)
             return -460;
         }
 
-    #ifndef NO_FILESYSTEM
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         pemFile = fopen("./ntru-cert.pem", "wb");
         if (!pemFile) {
             XFREE(derCert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -7720,7 +7733,9 @@ int rsa_test(void)
         byte*       pem;
         int         derSz;
         int         pemSz;
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         FILE*       reqFile;
+    #endif
 
         der = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT,DYNAMIC_TYPE_TMP_BUFFER);
         if (der == NULL) {
@@ -7799,7 +7814,7 @@ int rsa_test(void)
             return -467;
         }
 
-    #ifndef NO_FILESYSTEM
+    #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         reqFile = fopen(certReqDerFile, "wb");
         if (!reqFile) {
             XFREE(pem, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -8062,7 +8077,7 @@ int dsa_test(void)
     int    pemSz = 0;
     DsaKey derIn;
     DsaKey genKey;
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
     FILE*  keyFile;
     FILE*  pemFile;
 #endif
@@ -8101,7 +8116,7 @@ int dsa_test(void)
         return -366;
     }
 
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
     keyFile = fopen(keyDerFile, "wb");
     if (!keyFile) {
         XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -8127,7 +8142,7 @@ int dsa_test(void)
         return -369;
     }
 
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
     pemFile = fopen(keyPemFile, "wb");
     if (!pemFile) {
         XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -9749,7 +9764,7 @@ static int ecc_test_key_gen(WC_RNG* rng, int keySize)
     int   derSz, pemSz;
     byte  der[FOURK_BUF];
     byte  pem[FOURK_BUF];
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
     FILE* keyFile;
     FILE* pemFile;
 #endif
@@ -9771,7 +9786,7 @@ static int ecc_test_key_gen(WC_RNG* rng, int keySize)
         ERROR_OUT(derSz, done);
     }
 
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
     keyFile = fopen(eccCaKeyTempFile, "wb");
     if (!keyFile) {
         ERROR_OUT(-1025, done);
@@ -9788,7 +9803,7 @@ static int ecc_test_key_gen(WC_RNG* rng, int keySize)
         ERROR_OUT(pemSz, done);
     }
 
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
     pemFile = fopen(eccCaKeyPemFile, "wb");
     if (!pemFile) {
         ERROR_OUT(-1028, done);
@@ -9809,7 +9824,7 @@ static int ecc_test_key_gen(WC_RNG* rng, int keySize)
         ERROR_OUT(-5416, done);
     }
 
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
     keyFile = fopen(eccPubKeyDerFile, "wb");
     if (!keyFile) {
         ERROR_OUT(-5417, done);

--- a/wolfssl/io.h
+++ b/wolfssl/io.h
@@ -90,6 +90,14 @@
         #include <netdb.h>
         #include <netinet/in.h>
         #include <io.h>
+    #elif defined(WOLFSSL_PRCONNECT_PRO)
+        #include <prconnect_pro/prconnect_pro.h>
+        #include <sys/types.h>
+        #include <errno.h>
+        #include <unistd.h>
+        #include <fcntl.h>
+        #include <netdb.h>
+        #include <sys/ioctl.h>
     #elif !defined(WOLFSSL_NO_SOCK)
         #include <sys/types.h>
         #include <errno.h>

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -471,9 +471,9 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 
 /* Lighthttp compatibility */
 
-#if defined(HAVE_LIGHTY) || defined(WOLFSSL_MYSQL_COMPATIBLE) \
-                         || defined(HAVE_STUNNEL) \
-                         || defined(WOLFSSL_NGINX)
+#if defined(HAVE_LIGHTY)  || defined(WOLFSSL_MYSQL_COMPATIBLE) || \
+    defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
+    defined(HAVE_POCO_LIB)
 typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 
 #define X509_NAME_free wolfSSL_X509_NAME_free
@@ -501,11 +501,6 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 #define SSL_dup_CA_list wolfSSL_dup_CA_list
 
 #define NID_commonName 0x03 /* matchs ASN_COMMON_NAME in asn.h */
-#endif
-
-#if defined(HAVE_LIGHTY) || defined(WOLFSSL_MYSQL_COMPATIBLE) \
-                         || defined(HAVE_STUNNEL) \
-                         || defined(WOLFSSL_NGINX)
 
 #define OBJ_nid2ln wolfSSL_OBJ_nid2ln
 #define OBJ_txt2nid wolfSSL_OBJ_txt2nid
@@ -513,7 +508,8 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 #define PEM_read_bio_DSAparams wolfSSL_PEM_read_bio_DSAparams
 #define PEM_write_bio_X509 wolfSSL_PEM_write_bio_X509
 
-#endif /* HAVE_STUNNEL || HAVE_LIGHTY || WOLFSSL_MYSQL_COMPATIBLE || WOLFSSL_NGINX */
+#endif /* HAVE_STUNNEL || HAVE_LIGHTY || WOLFSSL_MYSQL_COMPATIBLE || WOLFSSL_NGINX || HAVE_POCO_LIB */
+
 #define SSL_CTX_set_tmp_dh wolfSSL_CTX_set_tmp_dh
 
 #define BIO_new_file        wolfSSL_BIO_new_file

--- a/wolfssl/wolfcrypt/misc.h
+++ b/wolfssl/wolfcrypt/misc.h
@@ -68,11 +68,19 @@ void   ByteReverseWords64(word64*, const word64*, word32);
 #endif /* WORD64_AVAILABLE */
 
 #ifndef WOLFSSL_HAVE_MIN
-    #if defined(HAVE_FIPS) && !defined(min)
+    #if defined(HAVE_FIPS) && !defined(min) /* so ifdef check passes */
         #define min min
     #endif
     WOLFSSL_LOCAL word32 min(word32 a, word32 b);
 #endif
+
+#ifndef WOLFSSL_HAVE_MAX
+    #if defined(HAVE_FIPS) && !defined(max) /* so ifdef check passes */
+        #define max max
+    #endif
+    WOLFSSL_LOCAL word32 max(word32 a, word32 b);
+#endif /* WOLFSSL_HAVE_MAX */
+
 
 #endif /* NO_INLINE */
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -184,6 +184,8 @@
 	    extern void *XMALLOC(size_t n, void* heap, int type);
 	    extern void *XREALLOC(void *p, size_t n, void* heap, int type);
 	    extern void XFREE(void *p, void* heap, int type);
+    #elif defined(XMALLOC_OVERRIDE)
+        /* override the XMALLOC, XFREE and XREALLOC macros */
 	#elif defined(NO_WOLFSSL_MEMORY)
 	    /* just use plain C stdlib stuff if desired */
 	    #include <stdlib.h>
@@ -194,7 +196,7 @@
 	        && !defined(WOLFSSL_SAFERTOS) && !defined(FREESCALE_MQX) \
 	        && !defined(FREESCALE_KSDK_MQX) && !defined(FREESCALE_FREE_RTOS) \
             && !defined(WOLFSSL_LEANPSK) && !defined(FREERTOS) && !defined(FREERTOS_TCP)\
-            && !defined(WOLFSSL_uITRON4) && !defined(WOLFSSL_uTKERNEL2)
+            && !defined(WOLFSSL_uITRON4)
 	    /* default C runtime, can install different routines at runtime via cbs */
 	    #include <wolfssl/wolfcrypt/memory.h>
         #ifdef WOLFSSL_STATIC_MEMORY


### PR DESCRIPTION
Updates for uTKernel port using WOLFSSL_uTKERNEL2:
* Added support for InterNiche prconnect_pro using WOLFSSL_PRCONNECT_PRO.
* Cleanup the min/max functions.
* Added NO_STDIO_FGETS_REMAP to not include the fgets remap for WOLFSSL_uTKERNEL2.
* Fix TFM build warning.
* Added HAVE_POCO_LIB for supporting https://pocoproject.org.
* Added wolfCrypt test temp cert path for WOLFSSL_uTKERNEL2 = /uda/.
* Added NO_WRITE_TEMP_FILES option to prevent writing temp files during wolfCrypt test.
* Added WOLFSSL_CURRTIME_REMAP for benchmark to allow different function name to be used for system which have a conflicting name.
* Add ability to use normal malloc/free with WOLFSSL_uTKERNEL2 using NO_TKERNEL_MEM_POOL.
* Added new XMALLOC_OVERRIDE to allow custom XMALLOC/XFREE/XREALLOC macros.
* Move CUSTOM_RAND_GENERATE up in RNG choices.
* Rename tls.c STK macros due to conflict. 