### PR TITLE
Fixes for wolfCrypt test/benchmark with static memory

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -166,7 +166,7 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
     /* time passed in number of connects give average */
     int times = benchmark;
     int loops = resumeSession ? 2 : 1;
-    int i = 0;    
+    int i = 0;
 #ifndef NO_SESSION_CACHE
     WOLFSSL_SESSION* benchSession = NULL;
 #endif

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -210,7 +210,7 @@ int testsuite_test(int argc, char** argv)
 #endif /* HAVE_WNR */
 
     printf("\nAll tests passed!\n");
-    EXIT_TEST(EXIT_SUCCESS);
+    return EXIT_SUCCESS;
 }
 
 void simple_test(func_args* args)

--- a/wolfcrypt/benchmark/benchmark.h
+++ b/wolfcrypt/benchmark/benchmark.h
@@ -28,7 +28,11 @@
     extern "C" {
 #endif
 
-int benchmark_test(void* args);
+#ifdef HAVE_STACK_SIZE
+THREAD_RETURN WOLFSSL_THREAD benchmark_test(void* args);
+#else
+int benchmark_test(void *args);
+#endif
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolfcrypt/src/wolfmath.c
+++ b/wolfcrypt/src/wolfmath.c
@@ -61,6 +61,7 @@ int get_rand_digit(WC_RNG* rng, mp_digit* d)
     return wc_RNG_GenerateBlock(rng, (byte*)d, sizeof(mp_digit));
 }
 
+#ifdef WC_RSA_BLINDING
 int mp_rand(mp_int* a, int digits, WC_RNG* rng)
 {
     int ret;
@@ -103,5 +104,6 @@ int mp_rand(mp_int* a, int digits, WC_RNG* rng)
 
     return ret;
 }
+#endif /* WC_RSA_BLINDING */
 
-#endif
+#endif /* USE_FAST_MATH || !NO_BIG_INT */

--- a/wolfcrypt/test/test.h
+++ b/wolfcrypt/test/test.h
@@ -28,7 +28,11 @@
     extern "C" {
 #endif
 
+#ifdef HAVE_STACK_SIZE
+THREAD_RETURN WOLFSSL_THREAD wolfcrypt_test(void* args);
+#else
 int wolfcrypt_test(void* args);
+#endif
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1386,7 +1386,7 @@ static INLINE int StackSizeCheck(func_args* args, thread_func tf)
     used = stackSize - i;
     printf("stack used = %d\n", used);
 
-    return (int)status;
+    return (int)((size_t)status);
 }
 
 

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1339,9 +1339,10 @@ static INLINE void CaCb(unsigned char* der, int sz, int type)
 typedef THREAD_RETURN WOLFSSL_THREAD (*thread_func)(void* args);
 
 
-static INLINE void StackSizeCheck(func_args* args, thread_func tf)
+static INLINE int StackSizeCheck(func_args* args, thread_func tf)
 {
     int            ret, i, used;
+    void*          status;
     unsigned char* myStack = NULL;
     int            stackSize = 1024*128;
     pthread_attr_t myAttr;
@@ -1372,7 +1373,7 @@ static INLINE void StackSizeCheck(func_args* args, thread_func tf)
         exit(EXIT_FAILURE);
     }
 
-    ret = pthread_join(threadId, NULL);
+    ret = pthread_join(threadId, &status);
     if (ret != 0)
         err_sys("pthread_join failed");
 
@@ -1384,6 +1385,8 @@ static INLINE void StackSizeCheck(func_args* args, thread_func tf)
 
     used = stackSize - i;
     printf("stack used = %d\n", used);
+
+    return (int)status;
 }
 
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -440,6 +440,8 @@
 
     #ifdef WOLFSSL_RIOT_OS
         #define EXIT_TEST(ret) exit(ret)
+    #elif defined(HAVE_STACK_SIZE)
+        #define EXIT_TEST(ret) return (void*)((long)(ret))
     #else
         #define EXIT_TEST(ret) return ret
     #endif

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -441,7 +441,7 @@
     #ifdef WOLFSSL_RIOT_OS
         #define EXIT_TEST(ret) exit(ret)
     #elif defined(HAVE_STACK_SIZE)
-        #define EXIT_TEST(ret) return (void*)((long)(ret))
+        #define EXIT_TEST(ret) return (void*)((size_t)(ret))
     #else
         #define EXIT_TEST(ret) return ret
     #endif


### PR DESCRIPTION
* Moved the static memory into global and out of stack (when using WOLFSSL_STATIC_MEMORY).
* Added HAVE_STACK_SIZE support.
* Fix RNG to use wc_InitRng_ex (for non FIPS builds).