### PR TITLE
testing buffer size with const DH and remove redeclaration of WOLFSSL…

### DIFF
--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -179,7 +179,14 @@ static int GeneratePublic(DhKey* key, const byte* priv, word32 privSz,
 int wc_DhGenerateKeyPair(DhKey* key, WC_RNG* rng, byte* priv, word32* privSz,
                       byte* pub, word32* pubSz)
 {
-    int ret = GeneratePrivate(key, rng, priv, privSz);
+    int ret;
+
+    if (key == NULL || rng == NULL || priv == NULL || privSz == NULL ||
+            pub == NULL || pubSz == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    ret = GeneratePrivate(key, rng, priv, privSz);
 
     return (ret != 0) ? ret : GeneratePublic(key, priv, *privSz, pub, pubSz);
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -7865,9 +7865,15 @@ static int dh_generate_test(WC_RNG *rng)
     DhKey  smallKey;
     byte   p[2] = { 0, 5 };
     byte   g[2] = { 0, 2 };
+#ifdef WOLFSSL_DH_CONST
+    /* the table for constant DH lookup will round to the lowest byte size 21 */
+    byte   priv[21];
+    byte   pub[21];
+#else
     byte   priv[2];
-    word32 privSz = sizeof(priv);
     byte   pub[2];
+#endif
+    word32 privSz = sizeof(priv);
     word32 pubSz = sizeof(pub);
 
     wc_InitDhKey(&smallKey);

--- a/wolfssl/crl.h
+++ b/wolfssl/crl.h
@@ -34,8 +34,6 @@
     extern "C" {
 #endif
 
-typedef struct WOLFSSL_CRL WOLFSSL_CRL;
-
 WOLFSSL_LOCAL int  InitCRL(WOLFSSL_CRL*, WOLFSSL_CERT_MANAGER*);
 WOLFSSL_LOCAL void FreeCRL(WOLFSSL_CRL*, int dynamic);
 


### PR DESCRIPTION
…_CRL

Some compilers will complain about the redeclaration of WOLFSSL_CRL. This pull request removes that and accounts for buffer size needed with WOLFSSL_DH_CONST macro defined when testing.