### PR TITLE
add ECC helpers to get size and id from curve name

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -3076,6 +3076,59 @@ static void test_wc_GetPkcs8TraditionalOffset(void)
 
 
 /*----------------------------------------------------------------------------*
+ | wolfCrypt ECC
+ *----------------------------------------------------------------------------*/
+
+static void test_wc_ecc_get_curve_size_from_name(void)
+{
+#ifdef HAVE_ECC
+    int ret;
+
+    printf(testingFmt, "wc_ecc_get_curve_size_from_name");
+
+    #if !defined(NO_ECC256) && !defined(NO_ECC_SECP)
+        ret = wc_ecc_get_curve_size_from_name("SECP256R1");
+        AssertIntEQ(ret, 32);
+    #endif
+
+    /* invalid case */
+    ret = wc_ecc_get_curve_size_from_name("BADCURVE");
+    AssertIntEQ(ret, -1);
+
+    /* NULL input */
+    ret = wc_ecc_get_curve_size_from_name(NULL);
+    AssertIntEQ(ret, BAD_FUNC_ARG);
+
+    printf(resultFmt, passed);
+#endif /* HAVE_ECC */
+}
+
+static void test_wc_ecc_get_curve_id_from_name(void)
+{
+#ifdef HAVE_ECC
+    int id;
+
+    printf(testingFmt, "wc_ecc_get_curve_id_from_name");
+
+    #if !defined(NO_ECC256) && !defined(NO_ECC_SECP)
+        id = wc_ecc_get_curve_id_from_name("SECP256R1");
+        AssertIntEQ(id, ECC_SECP256R1);
+    #endif
+
+    /* invalid case */
+    id = wc_ecc_get_curve_id_from_name("BADCURVE");
+    AssertIntEQ(id, -1);
+
+    /* NULL input */
+    id = wc_ecc_get_curve_id_from_name(NULL);
+    AssertIntEQ(id, BAD_FUNC_ARG);
+
+    printf(resultFmt, passed);
+#endif /* HAVE_ECC */
+}
+
+
+/*----------------------------------------------------------------------------*
  | Main
  *----------------------------------------------------------------------------*/
 
@@ -3138,6 +3191,10 @@ void ApiTest(void)
 
     /* wolfCrypt ASN tests */
     test_wc_GetPkcs8TraditionalOffset();
+
+    /* wolfCrypt ECC tests */
+    test_wc_ecc_get_curve_size_from_name();
+    test_wc_ecc_get_curve_id_from_name();
 
     printf(" End API Tests\n");
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2490,6 +2490,34 @@ int wc_ecc_get_curve_size_from_id(int curve_id)
     return ecc_sets[curve_idx].size;
 }
 
+/* Returns the curve index that corresponds to a given curve name in
+ * ecc_sets[] of ecc.c
+ *
+ * name    curve name, from ecc_sets[].name in ecc.c
+ * return  curve index in ecc_sets[] on success, negative on error
+ */
+int wc_ecc_get_curve_idx_from_name(const char* curveName)
+{
+    int curve_idx;
+    word32 len;
+
+    if (curveName == NULL)
+        return BAD_FUNC_ARG;
+
+    len = XSTRLEN(curveName);
+
+    for (curve_idx = 0; ecc_sets[curve_idx].size != 0; curve_idx++) {
+        if (XSTRNCASECMP(ecc_sets[curve_idx].name, curveName, len) == 0) {
+            break;
+        }
+    }
+    if (ecc_sets[curve_idx].size == 0) {
+        WOLFSSL_MSG("ecc_set curve name not found");
+        return ECC_CURVE_INVALID;
+    }
+    return curve_idx;
+}
+
 /* Returns the curve size that corresponds to a given curve name,
  * as listed in ecc_sets[] of ecc.c.
  *
@@ -2498,26 +2526,16 @@ int wc_ecc_get_curve_size_from_id(int curve_id)
  */
 int wc_ecc_get_curve_size_from_name(const char* curveName)
 {
-    int x;
+    int curve_idx;
 
     if (curveName == NULL)
         return BAD_FUNC_ARG;
 
-    /* find curve from name */
-    for (x = 0; ecc_sets[x].size != 0; x++) {
-        if (XSTRNCMP(ecc_sets[x].name, curveName,
-                    XSTRLEN(curveName)) == 0) {
-            break;
-        }
-    }
+    curve_idx = wc_ecc_get_curve_idx_from_name(curveName);
+    if (curve_idx < 0)
+        return curve_idx;
 
-    if (ecc_sets[x].size == 0) {
-        WOLFSSL_MSG("ecc_set curve name not found");
-        return -1;
-    }
-
-    /* will be 0 if not found */
-    return ecc_sets[x].size;
+    return ecc_sets[curve_idx].size;
 }
 
 /* Returns the curve id that corresponds to a given curve name,
@@ -2528,25 +2546,16 @@ int wc_ecc_get_curve_size_from_name(const char* curveName)
  */
 int wc_ecc_get_curve_id_from_name(const char* curveName)
 {
-    int x;
+    int curve_idx;
 
     if (curveName == NULL)
         return BAD_FUNC_ARG;
 
-    /* find curve from name */
-    for (x = 0; ecc_sets[x].size != 0; x++) {
-        if (XSTRNCMP(ecc_sets[x].name, curveName,
-                    XSTRLEN(curveName)) == 0) {
-            break;
-        }
-    }
+    curve_idx = wc_ecc_get_curve_idx_from_name(curveName);
+    if (curve_idx < 0)
+        return curve_idx;
 
-    if (ecc_sets[x].size == 0) {
-        WOLFSSL_MSG("ecc_set curve name not found");
-    }
-
-    /* will be -1 if not found */
-    return ecc_sets[x].id;
+    return ecc_sets[curve_idx].id;
 }
 
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2490,6 +2490,65 @@ int wc_ecc_get_curve_size_from_id(int curve_id)
     return ecc_sets[curve_idx].size;
 }
 
+/* Returns the curve size that corresponds to a given curve name,
+ * as listed in ecc_sets[] of ecc.c.
+ *
+ * name    curve name, from ecc_sets[].name in ecc.c
+ * return  curve size, from ecc_sets[] on success, negative on error
+ */
+int wc_ecc_get_curve_size_from_name(const char* curveName)
+{
+    int x;
+
+    if (curveName == NULL)
+        return BAD_FUNC_ARG;
+
+    /* find curve from name */
+    for (x = 0; ecc_sets[x].size != 0; x++) {
+        if (XSTRNCMP(ecc_sets[x].name, curveName,
+                    XSTRLEN(curveName)) == 0) {
+            break;
+        }
+    }
+
+    if (ecc_sets[x].size == 0) {
+        WOLFSSL_MSG("ecc_set curve name not found");
+        return -1;
+    }
+
+    /* will be 0 if not found */
+    return ecc_sets[x].size;
+}
+
+/* Returns the curve id that corresponds to a given curve name,
+ * as listed in ecc_sets[] of ecc.c.
+ *
+ * name   curve name, from ecc_sets[].name in ecc.c
+ * return curve id, from ecc_sets[] on success, negative on error
+ */
+int wc_ecc_get_curve_id_from_name(const char* curveName)
+{
+    int x;
+
+    if (curveName == NULL)
+        return BAD_FUNC_ARG;
+
+    /* find curve from name */
+    for (x = 0; ecc_sets[x].size != 0; x++) {
+        if (XSTRNCMP(ecc_sets[x].name, curveName,
+                    XSTRLEN(curveName)) == 0) {
+            break;
+        }
+    }
+
+    if (ecc_sets[x].size == 0) {
+        WOLFSSL_MSG("ecc_set curve name not found");
+    }
+
+    /* will be -1 if not found */
+    return ecc_sets[x].id;
+}
+
 
 #ifdef HAVE_ECC_DHE
 /**

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -369,6 +369,9 @@ int wc_ecc_get_curve_id(int curve_idx);
 #define wc_ecc_get_curve_name_from_id wc_ecc_get_name
 WOLFSSL_API
 int wc_ecc_get_curve_size_from_id(int curve_id);
+
+WOLFSSL_API
+int wc_ecc_get_curve_idx_from_name(const char* curveName);
 WOLFSSL_API
 int wc_ecc_get_curve_size_from_name(const char* curveName);
 WOLFSSL_API

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -369,6 +369,10 @@ int wc_ecc_get_curve_id(int curve_idx);
 #define wc_ecc_get_curve_name_from_id wc_ecc_get_name
 WOLFSSL_API
 int wc_ecc_get_curve_size_from_id(int curve_id);
+WOLFSSL_API
+int wc_ecc_get_curve_size_from_name(const char* curveName);
+WOLFSSL_API
+int wc_ecc_get_curve_id_from_name(const char* curveName);
 
 #ifndef WOLFSSL_ATECC508A
 


### PR DESCRIPTION
This PR adds two ECC helper functions:

1) Get ECC curve size from curve name
`int wc_ecc_get_curve_size_from_name(const char* curveName);`

2) Get ECC curve ID from curve name
`int wc_ecc_get_curve_id_from_name(const char* curveName);`

Corresponding unit tests are also added.