### PR TITLE
Added new API to show loaded CA signer information

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -166,7 +166,7 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
     /* time passed in number of connects give average */
     int times = benchmark;
     int loops = resumeSession ? 2 : 1;
-    int i = 0;    
+    int i = 0;
 #ifndef NO_SESSION_CACHE
     WOLFSSL_SESSION* benchSession = NULL;
 #endif
@@ -1199,7 +1199,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif
 
 #ifdef USER_CA_CB
-    wolfSSL_CTX_SetCACb(ctx, CaCb);
+    wolfSSL_CTX_SetCACb(ctx, CaDerCallback);
 #endif
 
 #ifdef VERIFY_CALLBACK
@@ -1263,6 +1263,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     if (!usePsk && !useAnon && overrideDateErrors == 1)
         wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, myDateCb);
 #endif /* !defined(NO_CERTS) */
+
+#ifdef WOLFSSL_CERT_SIGNER_INFO
+    wolfSSL_CTX_show_cert_cache(ctx, CaCertSignerCallback);
+#endif
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfAsync_DevOpen(&devId);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3445,8 +3445,8 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
                 signer->next = cm->caTable[row];
                 cm->caTable[row] = signer;   /* takes ownership */
                 wc_UnLockMutex(&cm->caLock);
-                if (cm->caCacheCallback)
-                    cm->caCacheCallback(der->buffer, (int)der->length, type);
+                if (cm->cbCaCache)
+                    cm->cbCaCache(der->buffer, (int)der->length, type);
             }
             else {
                 WOLFSSL_MSG("    CA Mutex Lock failed");
@@ -6622,12 +6622,39 @@ void wolfSSL_SetCertCbCtx(WOLFSSL* ssl, void* ctx)
 
 
 /* store context CA Cache addition callback */
-void wolfSSL_CTX_SetCACb(WOLFSSL_CTX* ctx, CallbackCACache cb)
+void wolfSSL_CTX_SetCACb(WOLFSSL_CTX* ctx, CbCaDer cb)
 {
     if (ctx && ctx->cm)
-        ctx->cm->caCacheCallback = cb;
+        ctx->cm->cbCaCache = cb;
 }
 
+#ifdef WOLFSSL_CERT_SIGNER_INFO
+int wolfSSL_CTX_show_cert_cache(WOLFSSL_CTX* ctx, CbCaCert cb)
+{
+    int ret, i;
+
+    if (ctx == NULL || ctx->cm == NULL || cb == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    for (i=0; i<CA_TABLE_SIZE; i++) {
+        Signer* row = ctx->cm->caTable[i];
+        while (row != NULL) {
+            CertSigner cert;
+
+            ret = wc_SignerExport(row, &cert);
+            if (ret == 0) {
+                if (cb)
+                    cb(&cert);
+            }
+
+            row = row->next;
+        }
+    }
+
+    return SSL_SUCCESS;
+}
+#endif /* WOLFSSL_CERT_SIGNER_INFO */
 
 #if defined(PERSIST_CERT_CACHE)
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -10712,6 +10712,32 @@ int ParseCRL(DecodedCRL* dcrl, const byte* buff, word32 sz, void* cm)
 
 #endif /* HAVE_CRL */
 
+#ifdef WOLFSSL_CERT_SIGNER_INFO
+    int wc_SignerExport(Signer* signer, CertSigner* cert)
+    {
+        if (signer == NULL || cert == NULL)
+            return BAD_FUNC_ARG;
+
+        XMEMSET(cert, 0, sizeof(CertSigner));
+        cert->pubKeySize = signer->pubKeySize;
+        cert->publicKey = signer->publicKey;
+        cert->keyOID = signer->keyOID;
+        cert->keyUsage = signer->keyUsage;
+        cert->pathLength = signer->pathLength;
+        cert->pathLengthSet = signer->pathLengthSet;
+        cert->commonNameLen = signer->nameLen;
+        cert->commonName = signer->name;
+        cert->subjectNameHashLen = sizeof(signer->subjectNameHash);
+        cert->subjectNameHash = signer->subjectNameHash;
+    #ifndef NO_SKID
+        cert->subjectKeyIdHashLen = sizeof(signer->subjectKeyIdHash);
+        cert->subjectKeyIdHash = signer->subjectKeyIdHash;
+    #endif
+
+        return 0;
+    }
+#endif /* WOLFSSL_CERT_SIGNER_INFO */
+
 #undef ERROR_OUT
 
 #endif /* !NO_ASN */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1551,7 +1551,7 @@ struct WOLFSSL_CERT_MANAGER {
 #endif
     char*           ocspOverrideURL;     /* use this responder */
     void*           ocspIOCtx;           /* I/O callback CTX */
-    CallbackCACache caCacheCallback;     /* CA cache addition callback */
+    CbCaDer         cbCaCache;           /* CA cache addition callback */
     CbMissingCRL    cbMissingCRL;        /* notify through cb of missing crl */
     CbOCSPIO        ocspIOCb;            /* I/O callback for OCSP lookup */
     CbOCSPRespFree  ocspRespFreeCb;      /* Frees OCSP Response from IO Cb */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -45,6 +45,10 @@
     #endif
 #endif
 
+#if !defined(NO_ASN) && defined(WOLFSSL_CERT_SIGNER_INFO)
+    #include <wolfssl/wolfcrypt/asn_public.h>
+#endif
+
 #ifdef WOLFSSL_PREFIX
     #include "prefix_ssl.h"
 #endif
@@ -1366,7 +1370,10 @@ WOLFSSL_API int wolfSSL_CertPemToDer(const unsigned char*, int,
     #endif /* WOLFSSL_PEMPUBKEY_TODER_DEFINED */
 #endif /* WOLFSSL_CERT_EXT || WOLFSSL_PUB_PEM_TO_DER*/
 
-typedef void (*CallbackCACache)(unsigned char* der, int sz, int type);
+#ifdef WOLFSSL_CERT_SIGNER_INFO
+    typedef void (*CbCaCert)(const CertSigner* cert);
+#endif
+typedef void (*CbCaDer)(unsigned char* der, int sz, int type);
 typedef void (*CbMissingCRL)(const char* url);
 typedef int  (*CbOCSPIO)(void*, const char*, int,
                                          unsigned char*, int, unsigned char**);
@@ -1518,7 +1525,10 @@ WOLFSSL_API void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl);
 
 
 #ifndef NO_CERTS
-    WOLFSSL_API void wolfSSL_CTX_SetCACb(WOLFSSL_CTX*, CallbackCACache);
+    WOLFSSL_API void wolfSSL_CTX_SetCACb(WOLFSSL_CTX*, CbCaDer);
+    #ifdef WOLFSSL_CERT_SIGNER_INFO
+        WOLFSSL_API int wolfSSL_CTX_show_cert_cache(WOLFSSL_CTX*, CbCaCert);
+    #endif
 
     WOLFSSL_API WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew_ex(void* heap);
     WOLFSSL_API WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew(void);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1289,11 +1289,21 @@ static INLINE void SetDHCtx(WOLFSSL_CTX* ctx)
 
 #ifndef NO_CERTS
 
-static INLINE void CaCb(unsigned char* der, int sz, int type)
+static INLINE void CaDerCallback(unsigned char* der, int sz, int type)
 {
     (void)der;
     printf("Got CA cache add callback, derSz = %d, type = %d\n", sz, type);
 }
+
+#ifdef WOLFSSL_CERT_SIGNER_INFO
+static INLINE void CaCertSignerCallback(const CertSigner* cert)
+{
+    printf("CA Cert Signer Info:\n");
+    printf("\tKey OID: %u\n", cert->keyOID);
+    printf("\tPublic Key Size: %d\n", cert->pubKeySize);
+    printf("\tCommon Name: %s\n", cert->commonName);
+}
+#endif
 
 #endif /* !NO_CERTS */
 

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -608,7 +608,7 @@ extern const char* END_PUB_KEY;
 #endif
 
 /* CA Signers */
-/* if change layout change PERSIST_CERT_CACHE functions too */
+/* If struct changes then PERSIST_CERT_CACHE functions must change too */
 struct Signer {
     word32  pubKeySize;
     word32  keyOID;                  /* key type */
@@ -924,6 +924,9 @@ WOLFSSL_LOCAL void FreeDecodedCRL(DecodedCRL*);
 
 #endif /* HAVE_CRL */
 
+#ifdef WOLFSSL_CERT_SIGNER_INFO
+    WOLFSSL_LOCAL int wc_SignerExport(Signer* signer, CertSigner* cert);
+#endif
 
 #ifdef __cplusplus
     } /* extern "C" */

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -95,6 +95,27 @@ enum Ctc_Misc {
 #endif /* WOLFSSL_CERT_EXT */
 };
 
+#ifdef WOLFSSL_CERT_SIGNER_INFO
+    /* CertSigner information */
+    typedef struct CertSigner {
+        word32  pubKeySize;
+        byte*   publicKey;
+        word32  keyOID;                     /* key type */
+        word16  keyUsage;
+        byte    pathLength;
+        byte    pathLengthSet;
+        int     commonNameLen;
+        char*   commonName;                    /* common name */
+        word32  subjectNameHashLen;
+        byte*   subjectNameHash; /* sha hash of names in certificate */
+    #ifndef NO_SKID
+        word32  subjectKeyIdHashLen;
+        byte*   subjectKeyIdHash;
+    #endif
+    } CertSigner;
+#endif
+
+
 #ifdef WOLFSSL_CERT_GEN
 
 #ifndef HAVE_ECC


### PR DESCRIPTION
Added new "WOLFSSL_CERT_SIGNER_INFO" define to enable ability to show/export CA Signer information using new "wolfSSL_CTX_show_cert_cache()" API.