### PR TITLE
fix curve selection on ecc private only import

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4882,7 +4882,7 @@ int wc_ecc_import_private_key_ex(const byte* priv, word32 privSz,
             return ret;
 
         /* set key size */
-        ret = wc_ecc_set_curve(key, privSz-1, curve_id);
+        ret = wc_ecc_set_curve(key, privSz, curve_id);
     }
 
     if (ret != 0)


### PR DESCRIPTION
This PR fixes an oversight on the ECC private key only import when setting the curve.