### PR TITLE
Fix name conflicts in wolfCrypt test with --enable-stacksize

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -452,9 +452,9 @@ static void Usage(void)
                                  CLIENT_DEFAULT_VERSION);
     printf("-V          Prints valid ssl version numbers, SSLv3(0) - TLS1.2(3)\n");
     printf("-l <str>    Cipher suite list (: delimited)\n");
-    printf("-c <file>   Certificate file,           default %s\n", cliCert);
-    printf("-k <file>   Key file,                   default %s\n", cliKey);
-    printf("-A <file>   Certificate Authority file, default %s\n", caCert);
+    printf("-c <file>   Certificate file,           default %s\n", cliCertFile);
+    printf("-k <file>   Key file,                   default %s\n", cliKeyFile);
+    printf("-A <file>   Certificate Authority file, default %s\n", caCertFile);
 #ifndef NO_DH
     printf("-Z <num>    Minimum DH key bits,        default %d\n",
                                  DEFAULT_MIN_DHKEY_BITS);
@@ -594,9 +594,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     char*  alpnList = NULL;
     unsigned char alpn_opt = 0;
     char*  cipherList = NULL;
-    const char* verifyCert = caCert;
-    const char* ourCert    = cliCert;
-    const char* ourKey     = cliKey;
+    const char* verifyCert = caCertFile;
+    const char* ourCert    = cliCertFile;
+    const char* ourKey     = cliKeyFile;
 
     int   doSTARTTLS    = 0;
     char* starttlsProt = NULL;
@@ -638,9 +638,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     ((func_args*)args)->return_code = -1; /* error state */
 
 #ifdef NO_RSA
-    verifyCert = (char*)eccCert;
-    ourCert    = (char*)cliEccCert;
-    ourKey     = (char*)cliEccKey;
+    verifyCert = (char*)eccCertFile;
+    ourCert    = (char*)cliEccCertFile;
+    ourKey     = (char*)cliEccKeyFile;
 #endif
     (void)resumeSz;
     (void)session;
@@ -1240,12 +1240,12 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #ifdef HAVE_ECC
         /* load ecc verify too, echoserver uses it by default w/ ecc */
 #if !defined(NO_FILESYSTEM)
-        if (wolfSSL_CTX_load_verify_locations(ctx, eccCert, 0) != SSL_SUCCESS) {
+        if (wolfSSL_CTX_load_verify_locations(ctx, eccCertFile, 0) != SSL_SUCCESS) {
             wolfSSL_CTX_free(ctx);
             err_sys("can't load ecc ca file, Please run from wolfSSL home dir");
         }
 #else
-        load_buffer(ctx, eccCert, WOLFSSL_CA);
+        load_buffer(ctx, eccCertFile, WOLFSSL_CA);
 #endif  /* !defined(NO_FILESYSTEM) */
 #endif /* HAVE_ECC */
 #if defined(WOLFSSL_TRUST_PEER_CERT) && !defined(NO_FILESYSTEM)

--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -130,16 +130,16 @@ void echoclient_test(void* args)
 
 #ifndef NO_FILESYSTEM
     #ifndef NO_RSA
-    if (SSL_CTX_load_verify_locations(ctx, caCert, 0) != SSL_SUCCESS)
+    if (SSL_CTX_load_verify_locations(ctx, caCertFile, 0) != SSL_SUCCESS)
         err_sys("can't load ca file, Please run from wolfSSL home dir");
     #endif
     #ifdef HAVE_ECC
-        if (SSL_CTX_load_verify_locations(ctx, eccCert, 0) != SSL_SUCCESS)
+        if (SSL_CTX_load_verify_locations(ctx, eccCertFile, 0) != SSL_SUCCESS)
             err_sys("can't load ca file, Please run from wolfSSL home dir");
     #endif
 #elif !defined(NO_CERTS)
     if (!doPSK)
-        load_buffer(ctx, caCert, WOLFSSL_CA);
+        load_buffer(ctx, caCertFile, WOLFSSL_CA);
 #endif
 
 #if defined(CYASSL_SNIFFER)

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -165,23 +165,23 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
     if (doPSK == 0) {
     #if defined(HAVE_NTRU) && defined(WOLFSSL_STATIC_RSA)
         /* ntru */
-        if (CyaSSL_CTX_use_certificate_file(ctx, ntruCert, SSL_FILETYPE_PEM)
+        if (CyaSSL_CTX_use_certificate_file(ctx, ntruCertFile, SSL_FILETYPE_PEM)
                 != SSL_SUCCESS)
             err_sys("can't load ntru cert file, "
                     "Please run from wolfSSL home dir");
 
-        if (CyaSSL_CTX_use_NTRUPrivateKey_file(ctx, ntruKey)
+        if (CyaSSL_CTX_use_NTRUPrivateKey_file(ctx, ntruKeyFile)
                 != SSL_SUCCESS)
             err_sys("can't load ntru key file, "
                     "Please run from wolfSSL home dir");
     #elif defined(HAVE_ECC) && !defined(CYASSL_SNIFFER)
         /* ecc */
-        if (CyaSSL_CTX_use_certificate_file(ctx, eccCert, SSL_FILETYPE_PEM)
+        if (CyaSSL_CTX_use_certificate_file(ctx, eccCertFile, SSL_FILETYPE_PEM)
                 != SSL_SUCCESS)
             err_sys("can't load server cert file, "
                     "Please run from wolfSSL home dir");
 
-        if (CyaSSL_CTX_use_PrivateKey_file(ctx, eccKey, SSL_FILETYPE_PEM)
+        if (CyaSSL_CTX_use_PrivateKey_file(ctx, eccKeyFile, SSL_FILETYPE_PEM)
                 != SSL_SUCCESS)
             err_sys("can't load server key file, "
                     "Please run from wolfSSL home dir");
@@ -189,12 +189,12 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
         /* do nothing, just don't load cert files */
     #else
         /* normal */
-        if (CyaSSL_CTX_use_certificate_file(ctx, svrCert, SSL_FILETYPE_PEM)
+        if (CyaSSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM)
                 != SSL_SUCCESS)
             err_sys("can't load server cert file, "
                     "Please run from wolfSSL home dir");
 
-        if (CyaSSL_CTX_use_PrivateKey_file(ctx, svrKey, SSL_FILETYPE_PEM)
+        if (CyaSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM)
                 != SSL_SUCCESS)
             err_sys("can't load server key file, "
                     "Please run from wolfSSL home dir");
@@ -202,8 +202,8 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
     } /* doPSK */
 #elif !defined(NO_CERTS)
     if (!doPSK) {
-        load_buffer(ctx, svrCert, WOLFSSL_CERT);
-        load_buffer(ctx, svrKey,  WOLFSSL_KEY);
+        load_buffer(ctx, svrCertFile, WOLFSSL_CERT);
+        load_buffer(ctx, svrKeyFile,  WOLFSSL_KEY);
     }
 #endif
 
@@ -277,7 +277,7 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
             wolfSSL_dtls_set_peer(ssl, &client, client_len);
         #endif
         #if !defined(NO_FILESYSTEM) && !defined(NO_DH) && !defined(NO_ASN)
-            CyaSSL_SetTmpDH_file(ssl, dhParam, SSL_FILETYPE_PEM);
+            CyaSSL_SetTmpDH_file(ssl, dhParamFile, SSL_FILETYPE_PEM);
         #elif !defined(NO_DH)
             SetDH(ssl);  /* will repick suites with DHE, higher than PSK */
         #endif

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -213,12 +213,12 @@ static void Usage(void)
     printf("-v <num>    SSL version [0-3], SSLv3(0) - TLS1.2(3)), default %d\n",
                                  SERVER_DEFAULT_VERSION);
     printf("-l <str>    Cipher suite list (: delimited)\n");
-    printf("-c <file>   Certificate file,           default %s\n", svrCert);
-    printf("-k <file>   Key file,                   default %s\n", svrKey);
-    printf("-A <file>   Certificate Authority file, default %s\n", cliCert);
+    printf("-c <file>   Certificate file,           default %s\n", svrCertFile);
+    printf("-k <file>   Key file,                   default %s\n", svrKeyFile);
+    printf("-A <file>   Certificate Authority file, default %s\n", cliCertFile);
     printf("-R <file>   Create Ready file for external monitor default none\n");
 #ifndef NO_DH
-    printf("-D <file>   Diffie-Hellman Params file, default %s\n", dhParam);
+    printf("-D <file>   Diffie-Hellman Params file, default %s\n", dhParamFile);
     printf("-Z <num>    Minimum DH key bits,        default %d\n",
                                  DEFAULT_MIN_DHKEY_BITS);
 #endif
@@ -319,10 +319,10 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     char*  alpnList = NULL;
     unsigned char alpn_opt = 0;
     char*  cipherList = NULL;
-    const char* verifyCert = cliCert;
-    const char* ourCert    = svrCert;
-    const char* ourKey     = svrKey;
-    const char* ourDhParam = dhParam;
+    const char* verifyCert = cliCertFile;
+    const char* ourCert    = svrCertFile;
+    const char* ourKey     = svrKeyFile;
+    const char* ourDhParam = dhParamFile;
     tcp_ready*  readySignal = NULL;
     int    argc = ((func_args*)args)->argc;
     char** argv = ((func_args*)args)->argv;
@@ -363,9 +363,9 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     ((func_args*)args)->return_code = -1; /* error state */
 
 #ifdef NO_RSA
-    verifyCert = (char*)cliEccCert;
-    ourCert    = (char*)eccCert;
-    ourKey     = (char*)eccKey;
+    verifyCert = (char*)cliEccCertFile;
+    ourCert    = (char*)eccCertFile;
+    ourKey     = (char*)eccKeyFile;
 #endif
     (void)pkCallbacks;
     (void)needDH;

--- a/tests/api.c
+++ b/tests/api.c
@@ -208,20 +208,20 @@ static void test_wolfSSL_CTX_use_certificate_file(void)
     AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
 
     /* invalid context */
-    AssertFalse(wolfSSL_CTX_use_certificate_file(NULL, svrCert,
+    AssertFalse(wolfSSL_CTX_use_certificate_file(NULL, svrCertFile,
                                                              SSL_FILETYPE_PEM));
     /* invalid cert file */
     AssertFalse(wolfSSL_CTX_use_certificate_file(ctx, bogusFile,
                                                              SSL_FILETYPE_PEM));
     /* invalid cert type */
-    AssertFalse(wolfSSL_CTX_use_certificate_file(ctx, svrCert, 9999));
+    AssertFalse(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile, 9999));
 
 #ifdef NO_RSA
     /* rsa needed */
-    AssertFalse(wolfSSL_CTX_use_certificate_file(ctx, svrCert,SSL_FILETYPE_PEM));
+    AssertFalse(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,SSL_FILETYPE_PEM));
 #else
     /* success */
-    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCert, SSL_FILETYPE_PEM));
+    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM));
 #endif
 
     wolfSSL_CTX_free(ctx);
@@ -263,21 +263,21 @@ static void test_wolfSSL_CTX_use_PrivateKey_file(void)
     AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
 
     /* invalid context */
-    AssertFalse(wolfSSL_CTX_use_PrivateKey_file(NULL, svrKey,
+    AssertFalse(wolfSSL_CTX_use_PrivateKey_file(NULL, svrKeyFile,
                                                              SSL_FILETYPE_PEM));
     /* invalid key file */
     AssertFalse(wolfSSL_CTX_use_PrivateKey_file(ctx, bogusFile,
                                                              SSL_FILETYPE_PEM));
     /* invalid key type */
-    AssertFalse(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKey, 9999));
+    AssertFalse(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, 9999));
 
     /* success */
 #ifdef NO_RSA
     /* rsa needed */
-    AssertFalse(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKey, SSL_FILETYPE_PEM));
+    AssertFalse(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
 #else
     /* success */
-    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKey, SSL_FILETYPE_PEM));
+    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
 #endif
 
     wolfSSL_CTX_free(ctx);
@@ -299,11 +299,11 @@ static void test_wolfSSL_CTX_trust_peer_cert(void)
                                               SSL_FILETYPE_PEM) != SSL_SUCCESS);
     assert(wolfSSL_CTX_trust_peer_cert(ctx, bogusFile,
                                               SSL_FILETYPE_PEM) != SSL_SUCCESS);
-    assert(wolfSSL_CTX_trust_peer_cert(ctx, cliCert,
+    assert(wolfSSL_CTX_trust_peer_cert(ctx, cliCertFile,
                                              SSL_FILETYPE_ASN1) != SSL_SUCCESS);
 
     /* success */
-    assert(wolfSSL_CTX_trust_peer_cert(ctx, cliCert, SSL_FILETYPE_PEM)
+    assert(wolfSSL_CTX_trust_peer_cert(ctx, cliCertFile, SSL_FILETYPE_PEM)
                                                                 == SSL_SUCCESS);
 
     /* unload cert */
@@ -344,7 +344,7 @@ static void test_wolfSSL_CTX_load_verify_locations(void)
     AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
 
     /* invalid context */
-    AssertFalse(wolfSSL_CTX_load_verify_locations(NULL, caCert, 0));
+    AssertFalse(wolfSSL_CTX_load_verify_locations(NULL, caCertFile, 0));
 
     /* invalid ca file */
     AssertFalse(wolfSSL_CTX_load_verify_locations(ctx, NULL,      0));
@@ -353,11 +353,11 @@ static void test_wolfSSL_CTX_load_verify_locations(void)
 #ifndef WOLFSSL_TIRTOS
     /* invalid path */
     /* not working... investigate! */
-    /* AssertFalse(wolfSSL_CTX_load_verify_locations(ctx, caCert, bogusFile)); */
+    /* AssertFalse(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, bogusFile)); */
 #endif
 
     /* success */
-    AssertTrue(wolfSSL_CTX_load_verify_locations(ctx, caCert, 0));
+    AssertTrue(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, 0));
 
     wolfSSL_CTX_free(ctx);
 #endif
@@ -372,16 +372,16 @@ static void test_wolfSSL_CTX_SetTmpDH_file(void)
 
     /* invalid context */
     AssertIntNE(SSL_SUCCESS, wolfSSL_CTX_SetTmpDH_file(NULL,
-                dhParam, SSL_FILETYPE_PEM));
+                dhParamFile, SSL_FILETYPE_PEM));
 
-    /* invalid dhParam file */
+    /* invalid dhParamFile file */
     AssertIntNE(SSL_SUCCESS, wolfSSL_CTX_SetTmpDH_file(ctx,
                 NULL, SSL_FILETYPE_PEM));
     AssertIntNE(SSL_SUCCESS, wolfSSL_CTX_SetTmpDH_file(ctx,
                 bogusFile, SSL_FILETYPE_PEM));
 
     /* success */
-    AssertIntEQ(SSL_SUCCESS, wolfSSL_CTX_SetTmpDH_file(ctx, dhParam,
+    AssertIntEQ(SSL_SUCCESS, wolfSSL_CTX_SetTmpDH_file(ctx, dhParamFile,
                 SSL_FILETYPE_PEM));
 
     wolfSSL_CTX_free(ctx);
@@ -399,7 +399,7 @@ static void test_wolfSSL_CTX_SetTmpDH_buffer(void)
     AssertIntNE(SSL_SUCCESS, wolfSSL_CTX_SetTmpDH_buffer(NULL, dh_key_der_2048,
                 sizeof_dh_key_der_2048, SSL_FILETYPE_ASN1));
 
-    /* invalid dhParam file */
+    /* invalid dhParamFile file */
     AssertIntNE(SSL_SUCCESS, wolfSSL_CTX_SetTmpDH_buffer(NULL, NULL,
                 0, SSL_FILETYPE_ASN1));
     AssertIntNE(SSL_SUCCESS, wolfSSL_CTX_SetTmpDH_buffer(ctx, dsa_key_der_2048,
@@ -427,8 +427,8 @@ static void test_server_wolfSSL_new(void)
     AssertNotNull(ctx_nocert = wolfSSL_CTX_new(wolfSSLv23_server_method()));
     AssertNotNull(ctx        = wolfSSL_CTX_new(wolfSSLv23_server_method()));
 
-    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCert, SSL_FILETYPE_PEM));
-    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKey, SSL_FILETYPE_PEM));
+    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM));
+    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
 
     /* invalid context */
     AssertNull(ssl = wolfSSL_new(NULL));
@@ -456,7 +456,7 @@ static void test_client_wolfSSL_new(void)
     AssertNotNull(ctx_nocert = wolfSSL_CTX_new(wolfSSLv23_client_method()));
     AssertNotNull(ctx        = wolfSSL_CTX_new(wolfSSLv23_client_method()));
 
-    AssertTrue(wolfSSL_CTX_load_verify_locations(ctx, caCert, 0));
+    AssertTrue(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, 0));
 
     /* invalid context */
     AssertNull(ssl = wolfSSL_new(NULL));
@@ -482,30 +482,30 @@ static void test_wolfSSL_SetTmpDH_file(void)
 
     AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
 #ifndef NO_RSA
-    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCert,
+    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile,
                 SSL_FILETYPE_PEM));
-    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKey,
+    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile,
                 SSL_FILETYPE_PEM));
 #else
-    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, eccCert,
+    AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, eccCertFile,
                 SSL_FILETYPE_PEM));
-    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, eccKey,
+    AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, eccKeyFile,
                 SSL_FILETYPE_PEM));
 #endif
     AssertNotNull(ssl = wolfSSL_new(ctx));
 
     /* invalid ssl */
     AssertIntNE(SSL_SUCCESS, wolfSSL_SetTmpDH_file(NULL,
-                dhParam, SSL_FILETYPE_PEM));
+                dhParamFile, SSL_FILETYPE_PEM));
 
-    /* invalid dhParam file */
+    /* invalid dhParamFile file */
     AssertIntNE(SSL_SUCCESS, wolfSSL_SetTmpDH_file(ssl,
                 NULL, SSL_FILETYPE_PEM));
     AssertIntNE(SSL_SUCCESS, wolfSSL_SetTmpDH_file(ssl,
                 bogusFile, SSL_FILETYPE_PEM));
 
     /* success */
-    AssertIntEQ(SSL_SUCCESS, wolfSSL_SetTmpDH_file(ssl, dhParam,
+    AssertIntEQ(SSL_SUCCESS, wolfSSL_SetTmpDH_file(ssl, dhParamFile,
                 SSL_FILETYPE_PEM));
 
     wolfSSL_free(ssl);
@@ -530,7 +530,7 @@ static void test_wolfSSL_SetTmpDH_buffer(void)
     AssertIntNE(SSL_SUCCESS, wolfSSL_SetTmpDH_buffer(NULL, dh_key_der_2048,
                 sizeof_dh_key_der_2048, SSL_FILETYPE_ASN1));
 
-    /* invalid dhParam file */
+    /* invalid dhParamFile file */
     AssertIntNE(SSL_SUCCESS, wolfSSL_SetTmpDH_buffer(NULL, NULL,
                 0, SSL_FILETYPE_ASN1));
     AssertIntNE(SSL_SUCCESS, wolfSSL_SetTmpDH_buffer(ssl, dsa_key_der_2048,
@@ -672,19 +672,19 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
     wolfSSL_CTX_set_default_passwd_cb(ctx, PasswordCallBack);
 #endif
 
-    if (wolfSSL_CTX_load_verify_locations(ctx, cliCert, 0) != SSL_SUCCESS)
+    if (wolfSSL_CTX_load_verify_locations(ctx, cliCertFile, 0) != SSL_SUCCESS)
     {
         /*err_sys("can't load ca file, Please run from wolfSSL home dir");*/
         goto done;
     }
-    if (wolfSSL_CTX_use_certificate_file(ctx, svrCert, SSL_FILETYPE_PEM)
+    if (wolfSSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM)
             != SSL_SUCCESS)
     {
         /*err_sys("can't load server cert chain file, "
                 "Please run from wolfSSL home dir");*/
         goto done;
     }
-    if (wolfSSL_CTX_use_PrivateKey_file(ctx, svrKey, SSL_FILETYPE_PEM)
+    if (wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM)
             != SSL_SUCCESS)
     {
         /*err_sys("can't load server key file, "
@@ -703,7 +703,7 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
 
 #ifdef NO_PSK
     #if !defined(NO_FILESYSTEM) && !defined(NO_DH)
-        wolfSSL_SetTmpDH_file(ssl, dhParam, SSL_FILETYPE_PEM);
+        wolfSSL_SetTmpDH_file(ssl, dhParamFile, SSL_FILETYPE_PEM);
     #elif !defined(NO_DH)
         SetDH(ssl);  /* will repick suites with DHE, higher priority than PSK */
     #endif
@@ -806,19 +806,19 @@ static void test_client_nofail(void* args)
     wolfSSL_CTX_set_default_passwd_cb(ctx, PasswordCallBack);
 #endif
 
-    if (wolfSSL_CTX_load_verify_locations(ctx, caCert, 0) != SSL_SUCCESS)
+    if (wolfSSL_CTX_load_verify_locations(ctx, caCertFile, 0) != SSL_SUCCESS)
     {
         /* err_sys("can't load ca file, Please run from wolfSSL home dir");*/
         goto done2;
     }
-    if (wolfSSL_CTX_use_certificate_file(ctx, cliCert, SSL_FILETYPE_PEM)
+    if (wolfSSL_CTX_use_certificate_file(ctx, cliCertFile, SSL_FILETYPE_PEM)
             != SSL_SUCCESS)
     {
         /*err_sys("can't load client cert file, "
                 "Please run from wolfSSL home dir");*/
         goto done2;
     }
-    if (wolfSSL_CTX_use_PrivateKey_file(ctx, cliKey, SSL_FILETYPE_PEM)
+    if (wolfSSL_CTX_use_PrivateKey_file(ctx, cliKeyFile, SSL_FILETYPE_PEM)
             != SSL_SUCCESS)
     {
         /*err_sys("can't load client key file, "
@@ -929,13 +929,13 @@ static THREAD_RETURN WOLFSSL_THREAD run_wolfssl_server(void* args)
 #endif
 
 
-    AssertIntEQ(SSL_SUCCESS, wolfSSL_CTX_load_verify_locations(ctx, cliCert, 0));
+    AssertIntEQ(SSL_SUCCESS, wolfSSL_CTX_load_verify_locations(ctx, cliCertFile, 0));
 
     AssertIntEQ(SSL_SUCCESS,
-               wolfSSL_CTX_use_certificate_file(ctx, svrCert, SSL_FILETYPE_PEM));
+               wolfSSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM));
 
     AssertIntEQ(SSL_SUCCESS,
-                 wolfSSL_CTX_use_PrivateKey_file(ctx, svrKey, SSL_FILETYPE_PEM));
+                 wolfSSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
 
     if (callbacks->ctx_ready)
         callbacks->ctx_ready(ctx);
@@ -961,7 +961,7 @@ static THREAD_RETURN WOLFSSL_THREAD run_wolfssl_server(void* args)
 
 #ifdef NO_PSK
     #if !defined(NO_FILESYSTEM) && !defined(NO_DH)
-        wolfSSL_SetTmpDH_file(ssl, dhParam, SSL_FILETYPE_PEM);
+        wolfSSL_SetTmpDH_file(ssl, dhParamFile, SSL_FILETYPE_PEM);
     #elif !defined(NO_DH)
         SetDH(ssl);  /* will repick suites with DHE, higher priority than PSK */
     #endif
@@ -1065,13 +1065,13 @@ static void run_wolfssl_client(void* args)
     wolfSSL_CTX_set_default_passwd_cb(ctx, PasswordCallBack);
 #endif
 
-    AssertIntEQ(SSL_SUCCESS, wolfSSL_CTX_load_verify_locations(ctx, caCert, 0));
+    AssertIntEQ(SSL_SUCCESS, wolfSSL_CTX_load_verify_locations(ctx, caCertFile, 0));
 
     AssertIntEQ(SSL_SUCCESS,
-               wolfSSL_CTX_use_certificate_file(ctx, cliCert, SSL_FILETYPE_PEM));
+               wolfSSL_CTX_use_certificate_file(ctx, cliCertFile, SSL_FILETYPE_PEM));
 
     AssertIntEQ(SSL_SUCCESS,
-                 wolfSSL_CTX_use_PrivateKey_file(ctx, cliKey, SSL_FILETYPE_PEM));
+                 wolfSSL_CTX_use_PrivateKey_file(ctx, cliKeyFile, SSL_FILETYPE_PEM));
 
     if (callbacks->ctx_ready)
         callbacks->ctx_ready(ctx);
@@ -2018,7 +2018,7 @@ static void test_wolfSSL_X509_NAME_get_entry(void)
         int idx;
 
     #ifndef NO_FILESYSTEM
-        x509 = wolfSSL_X509_load_certificate_file(cliCert, SSL_FILETYPE_PEM);
+        x509 = wolfSSL_X509_load_certificate_file(cliCertFile, SSL_FILETYPE_PEM);
         AssertNotNull(x509);
 
         name = X509_get_subject_name(x509);
@@ -2304,8 +2304,8 @@ static void test_wolfSSL_certs(void)
     printf(testingFmt, "wolfSSL_certs()");
 
     AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_server_method()));
-    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCert, SSL_FILETYPE_PEM));
-    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKey, SSL_FILETYPE_PEM));
+    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM));
+    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
     AssertNotNull(ssl = SSL_new(ctx));
 
     AssertIntEQ(wolfSSL_check_private_key(ssl), SSL_SUCCESS);
@@ -2315,7 +2315,7 @@ static void test_wolfSSL_certs(void)
     #endif /* HAVE_PK_CALLBACKS */
 
     /* create and use x509 */
-    x509 = wolfSSL_X509_load_certificate_file(cliCert, SSL_FILETYPE_PEM);
+    x509 = wolfSSL_X509_load_certificate_file(cliCertFile, SSL_FILETYPE_PEM);
     AssertNotNull(x509);
     AssertIntEQ(SSL_use_certificate(ssl, x509), SSL_SUCCESS);
 
@@ -2471,8 +2471,8 @@ static void test_wolfSSL_private_keys(void)
     OpenSSL_add_all_algorithms();
 
     AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_server_method()));
-    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCert, SSL_FILETYPE_PEM));
-    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKey, SSL_FILETYPE_PEM));
+    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM));
+    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
     AssertNotNull(ssl = SSL_new(ctx));
 
     AssertIntEQ(wolfSSL_check_private_key(ssl), SSL_SUCCESS);
@@ -2565,8 +2565,8 @@ static void test_wolfSSL_tmp_dh(void)
     printf(testingFmt, "wolfSSL_tmp_dh()");
 
     AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_server_method()));
-    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCert, SSL_FILETYPE_PEM));
-    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKey, SSL_FILETYPE_PEM));
+    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM));
+    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
     AssertNotNull(ssl = SSL_new(ctx));
 
     f = fopen(file, "rb");
@@ -2729,7 +2729,7 @@ static void test_wolfSSL_X509_STORE_set_flags(void)
     printf(testingFmt, "wolfSSL_ERR_peek_last_error_line()");
     AssertNotNull((store = wolfSSL_X509_STORE_new()));
     AssertNotNull((x509 =
-                wolfSSL_X509_load_certificate_file(svrCert, SSL_FILETYPE_PEM)));
+                wolfSSL_X509_load_certificate_file(svrCertFile, SSL_FILETYPE_PEM)));
     AssertIntEQ(X509_STORE_add_cert(store, x509), SSL_SUCCESS);
 
 #ifdef HAVE_CRL
@@ -2808,8 +2808,8 @@ static void test_wolfSSL_set_options(void)
     printf(testingFmt, "wolfSSL_set_options()");
 
     AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_server_method()));
-    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCert, SSL_FILETYPE_PEM));
-    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKey, SSL_FILETYPE_PEM));
+    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM));
+    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
     AssertNotNull(ssl = SSL_new(ctx));
 
     AssertTrue(SSL_set_options(ssl, SSL_OP_NO_TLSv1) == SSL_OP_NO_TLSv1);
@@ -2845,7 +2845,7 @@ static void test_wolfSSL_PEM_read_bio(void)
 
     printf(testingFmt, "wolfSSL_PEM_read_bio()");
 
-    AssertNotNull(f = fopen(cliCert, "rb"));
+    AssertNotNull(f = fopen(cliCertFile, "rb"));
     bytes = (int)fread(buffer, 1, sizeof(buffer), f);
     fclose(f);
 
@@ -3012,7 +3012,7 @@ static void test_wolfSSL_BIO(void)
         AssertIntEQ((int)BIO_set_mem_eof_return(f_bio1, -1), 0);
         AssertIntEQ((int)BIO_set_mem_eof_return(NULL, -1),   0);
 
-        f1 = XFOPEN(svrCert, "rwb");
+        f1 = XFOPEN(svrCertFile, "rwb");
         AssertIntEQ((int)BIO_set_fp(f_bio1, f1, BIO_CLOSE), SSL_SUCCESS);
         AssertIntEQ(BIO_write_filename(f_bio2, testFile),
                 SSL_SUCCESS);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11025,6 +11025,10 @@ int ecc_test_buffers() {
         return -52;
 #endif
 
+    wc_ecc_free(&cliKey);
+    wc_ecc_free(&servKey);
+    wc_FreeRng(&rng);
+
     return 0;
 }
 #endif /* USE_CERT_BUFFERS_256 */

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -245,37 +245,37 @@
 
 /* all certs relative to wolfSSL home directory now */
 #if defined(WOLFSSL_NO_CURRDIR) || defined(WOLFSSL_MDK_SHELL)
-#define caCert     "certs/ca-cert.pem"
-#define eccCert    "certs/server-ecc.pem"
-#define eccKey     "certs/ecc-key.pem"
-#define svrCert    "certs/server-cert.pem"
-#define svrKey     "certs/server-key.pem"
-#define cliCert    "certs/client-cert.pem"
-#define cliKey     "certs/client-key.pem"
-#define ntruCert   "certs/ntru-cert.pem"
-#define ntruKey    "certs/ntru-key.raw"
-#define dhParam    "certs/dh2048.pem"
-#define cliEccKey  "certs/ecc-client-key.pem"
-#define cliEccCert "certs/client-ecc-cert.pem"
-#define crlPemDir  "certs/crl"
+#define caCertFile     "certs/ca-cert.pem"
+#define eccCertFile    "certs/server-ecc.pem"
+#define eccKeyFile     "certs/ecc-key.pem"
+#define svrCertFile    "certs/server-cert.pem"
+#define svrKeyFile     "certs/server-key.pem"
+#define cliCertFile    "certs/client-cert.pem"
+#define cliKeyFile     "certs/client-key.pem"
+#define ntruCertFile   "certs/ntru-cert.pem"
+#define ntruKeyFile    "certs/ntru-key.raw"
+#define dhParamFile    "certs/dh2048.pem"
+#define cliEccKeyFile  "certs/ecc-client-key.pem"
+#define cliEccCertFile "certs/client-ecc-cert.pem"
+#define crlPemDir      "certs/crl"
 #ifdef HAVE_WNR
     /* Whitewood netRandom default config file */
     #define wnrConfig  "wnr-example.conf"
 #endif
 #else
-#define caCert     "./certs/ca-cert.pem"
-#define eccCert    "./certs/server-ecc.pem"
-#define eccKey     "./certs/ecc-key.pem"
-#define svrCert    "./certs/server-cert.pem"
-#define svrKey     "./certs/server-key.pem"
-#define cliCert    "./certs/client-cert.pem"
-#define cliKey     "./certs/client-key.pem"
-#define ntruCert   "./certs/ntru-cert.pem"
-#define ntruKey    "./certs/ntru-key.raw"
-#define dhParam    "./certs/dh2048.pem"
-#define cliEccKey  "./certs/ecc-client-key.pem"
-#define cliEccCert "./certs/client-ecc-cert.pem"
-#define crlPemDir  "./certs/crl"
+#define caCertFile     "./certs/ca-cert.pem"
+#define eccCertFile    "./certs/server-ecc.pem"
+#define eccKeyFile     "./certs/ecc-key.pem"
+#define svrCertFile    "./certs/server-cert.pem"
+#define svrKeyFile     "./certs/server-key.pem"
+#define cliCertFile    "./certs/client-cert.pem"
+#define cliKeyFile     "./certs/client-key.pem"
+#define ntruCertFile   "./certs/ntru-cert.pem"
+#define ntruKeyFile    "./certs/ntru-key.raw"
+#define dhParamFile    "./certs/dh2048.pem"
+#define cliEccKeyFile  "./certs/ecc-client-key.pem"
+#define cliEccCertFile "./certs/client-ecc-cert.pem"
+#define crlPemDir      "./certs/crl"
 #ifdef HAVE_WNR
     /* Whitewood netRandom default config file */
     #define wnrConfig  "./wnr-example.conf"
@@ -1351,7 +1351,7 @@ static INLINE void CaCb(unsigned char* der, int sz, int type)
             int depth, res;
             FILE* file;
             for(depth = 0; depth <= MAX_WOLF_ROOT_DEPTH; depth++) {
-                file = fopen(ntruKey, "rb");
+                file = fopen(ntruKeyFile, "rb");
                 if (file != NULL) {
                     fclose(file);
                     return depth;


### PR DESCRIPTION
Cleanup name conflicts with test.h cert files (by adding “File” to end). Fix memory leak in ecc_test_buffers function.