### PR TITLE
fix c32toa needed with --enable-session-ticket

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -330,7 +330,7 @@ static INLINE void c16toa(word16 u16, byte* c)
 
 #if !defined(NO_OLD_TLS) || defined(HAVE_CHACHA) || defined(HAVE_AESCCM) \
     || defined(HAVE_AESGCM) || defined(WOLFSSL_SESSION_EXPORT) \
-    || defined(WOLFSSL_DTLS)
+    || defined(WOLFSSL_DTLS) || defined(HAVE_SESSION_TICKET)
 /* convert 32 bit integer to opaque */
 static INLINE void c32toa(word32 u32, byte* c)
 {


### PR DESCRIPTION
The function CreateTicket in internal.c requires c32toa when session tickets are enabled. This pull request makes sure that c32toa is compiled in with --enable-session-ticket.

Can be seen with the configure
./configure --enable-tlsx --enable-session-ticket --disable-aesgcm --disable-aesccm --disable-oldtls --disable-chacha
make check

Fixes item 2 from issue #779