### PR TITLE
DTLS update per RFC 6347 Section 4.2.3

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10074,13 +10074,7 @@ int ProcessReply(WOLFSSL* ssl)
             /* more messages per record */
             else if ((ssl->buffers.inputBuffer.idx - startIdx) < ssl->curSize) {
                 WOLFSSL_MSG("More messages in record");
-                #ifdef WOLFSSL_DTLS
-                    /* read-ahead but dtls doesn't bundle messages per record */
-                    if (ssl->options.dtls) {
-                        ssl->options.processReply = doProcessInit;
-                        continue;
-                    }
-                #endif
+
                 ssl->options.processReply = runProcessingOneMessage;
 
                 if (IsEncryptionOn(ssl, 0)) {


### PR DESCRIPTION
Thanks to Eric Samsel over at Welch Allyn for this report. There is an interop bug in wolfSSL where wolfSSL can not be used with newer versions of Microsoft DTLS implementations which package flights into a single record when there is room and messages are all part of the same flight.

RFC 6347 Section 4.2.3 States: 

    Note that as with TLS, multiple handshake messages may be placed in
    the same DTLS record, provided that there is room and that they are
    part of the same flight.  Thus, there are two acceptable ways to pack
    two DTLS messages into the same datagram: in the same record or in
    separate records.

