### PR TITLE
fix invalid check on unsigned type

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -18725,12 +18725,16 @@ int wolfSSL_RSA_sign(int type, const unsigned char* m,
             WOLFSSL_MSG("Bad Encode Signature");
         }
         else {
-            *sigLen = wc_RsaSSL_Sign(encodedSig, signSz, sigRet, outLen,
+            ret = wc_RsaSSL_Sign(encodedSig, signSz, sigRet, outLen,
                                   (RsaKey*)rsa->internal, rng);
-            if (*sigLen <= 0)
+            if (ret <= 0) {
                 WOLFSSL_MSG("Bad Rsa Sign");
-            else
+                ret = 0;
+            }
+            else {
                 ret = SSL_SUCCESS;
+                *sigLen = ret;
+            }
         }
 
     }


### PR DESCRIPTION
The parameter sigLen is an unsigned type and wc_RsaSSL_Sign can return a negative value when encountering an error. This updates wolfSSL_RSA_sign to correctly check the return value of wc_RsaSSL_Sign.