### PR TITLE
Fix leading zero in wc_BuildEccKeyDer

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9681,8 +9681,9 @@ static int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 inLen,
             pubidx += SetLength(pubSz + ASN_ECC_CONTEXT_SZ + 2, pub+pubidx);
         else /* leading zero */
             pubidx += SetLength(pubSz + ASN_ECC_CONTEXT_SZ + 1, pub+pubidx);
+
+        /* SetBitString adds leading zero */
         pubidx += SetBitString(pubSz, 0, pub + pubidx);
-        pub[pubidx++] = (byte)0; /* leading zero */
         ret = wc_ecc_export_x963(key, pub + pubidx, &pubSz);
         if (ret != 0) {
             XFREE(prv, key->heap, DYNAMIC_TYPE_TMP_BUFFER);


### PR DESCRIPTION
This PR fixes wc_BuildEccKeyDer() after recent ASN rework.

Previously, this function was manually adding the leading zero to the public ECC key ASN BIT STRING.  After the ASN rework, SetBitString() was added which also adds the leading zero when "0" is passed as the 2nd argument.  This caused there to be two leading zeros added.

To see that this caused wc_EccKeyToDer() to incorrectly generate the DER blob, run the following prior to this fix to see OpenSSL fail to read the generated key:

```
$ cd wolfssl
$ ./configure --enable-keygen
$ make test
$ openssl ec -inform DER -in ecc-key.der
```