### PR TITLE
Fix issue with ASN encoding SetName function header length

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7700,7 +7700,6 @@ int SetName(byte* output, word32 outputSz, CertName* name)
                 firstSz  = SetObjectId(JOINT_LEN + 1, firstLen);
             }
             thisLen += firstSz;
-            thisLen++;                                /* object id */
 
             seqSz = SetSequence(thisLen, sequence);
             thisLen += seqSz;


### PR DESCRIPTION
Fix issue with ASN encoding, where the SetName function was incorrectly adding extra byte for object id tag. Refactor changed lines 7694 and 7700 to use SetObjectId which handles length (was using SetLength prior to refactor). Issue was noticed via compatibility testing using generated cert against openssl asn1parse.