### PR TITLE
Fix minor build errors and warnings

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4686,7 +4686,7 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     }
 
                 #ifdef WOLFSSL_SMALL_STACK
-                    XFREE(encodedSig, heap, DYNAMIC_TYPE_TMP_BUFFER);
+                    XFREE(encodedSig, sigCtx->heap, DYNAMIC_TYPE_TMP_BUFFER);
                 #endif
                     break;
                 }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1049,19 +1049,19 @@ static word32 SetBitString16Bit(word16 val, byte* output)
 
     if ((val >> 8) != 0) {
         len = 2;
-        lastByte = val >> 8;
+        lastByte = (byte)(val >> 8);
     }
     else {
         len = 1;
-        lastByte = val;
+        lastByte = (byte)val;
     }
 
     while (((lastByte >> unusedBits) & 0x01) == 0x00)
         unusedBits++;
 
     idx = SetBitString(len, unusedBits, output);
-    output[idx++] = val;
-    output[idx++] = val >> 8;
+    output[idx++] = (byte)val;
+    output[idx++] = (byte)(val >> 8);
 
     return idx;
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -12356,13 +12356,13 @@ static int pkcs7_load_certs_keys(byte* rsaCert, word32* rsaCertSz,
 #ifndef NO_RSA
 
 #ifdef USE_CERT_BUFFERS_1024
-    if (*rsaCertSz < sizeof_client_cert_der_1024)
+    if (*rsaCertSz < (word32)sizeof_client_cert_der_1024)
         return -201;
 
     XMEMCPY(rsaCert, client_cert_der_1024, sizeof_client_cert_der_1024);
     *rsaCertSz = sizeof_client_cert_der_1024;
 #elif defined(USE_CERT_BUFFERS_2048)
-    if (*rsaCertSz < sizeof_client_cert_der_2048)
+    if (*rsaCertSz < (word32)sizeof_client_cert_der_2048)
         return -202;
 
     XMEMCPY(rsaCert, client_cert_der_2048, sizeof_client_cert_der_2048);
@@ -12377,13 +12377,13 @@ static int pkcs7_load_certs_keys(byte* rsaCert, word32* rsaCertSz,
 #endif
 
 #ifdef USE_CERT_BUFFERS_1024
-    if (*rsaPrivKeySz < sizeof_client_key_der_1024)
+    if (*rsaPrivKeySz < (word32)sizeof_client_key_der_1024)
         return -204;
 
     XMEMCPY(rsaPrivKey, client_key_der_1024, sizeof_client_key_der_1024);
     *rsaPrivKeySz = sizeof_client_key_der_1024;
 #elif defined(USE_CERT_BUFFERS_2048)
-    if (*rsaPrivKeySz < sizeof_client_key_der_2048)
+    if (*rsaPrivKeySz < (word32)sizeof_client_key_der_2048)
         return -205;
 
     XMEMCPY(rsaPrivKey, client_key_der_2048, sizeof_client_key_der_2048);
@@ -12403,7 +12403,7 @@ static int pkcs7_load_certs_keys(byte* rsaCert, word32* rsaCertSz,
 #ifdef HAVE_ECC
 
 #ifdef USE_CERT_BUFFERS_256
-    if (*eccCertSz < sizeof_cliecc_cert_der_256)
+    if (*eccCertSz < (word32)sizeof_cliecc_cert_der_256)
         return -206;
 
     XMEMCPY(eccCert, cliecc_cert_der_256, sizeof_cliecc_cert_der_256);
@@ -12418,7 +12418,7 @@ static int pkcs7_load_certs_keys(byte* rsaCert, word32* rsaCertSz,
 #endif /* USE_CERT_BUFFERS_256 */
 
 #ifdef USE_CERT_BUFFERS_256
-    if (*eccPrivKeySz < sizeof_ecc_clikey_der_256)
+    if (*eccPrivKeySz < (word32)sizeof_ecc_clikey_der_256)
         return -208;
 
     XMEMCPY(eccPrivKey, ecc_clikey_der_256, sizeof_ecc_clikey_der_256);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -12366,7 +12366,7 @@ static int pkcs7_load_certs_keys(byte* rsaCert, word32* rsaCertSz,
         return -202;
 
     XMEMCPY(rsaCert, client_cert_der_2048, sizeof_client_cert_der_2048);
-    rsaCertSz = sizeof_client_cert_der_2048;
+    *rsaCertSz = sizeof_client_cert_der_2048;
 #else
     certFile = fopen(clientCert, "rb");
     if (!certFile)
@@ -12377,13 +12377,13 @@ static int pkcs7_load_certs_keys(byte* rsaCert, word32* rsaCertSz,
 #endif
 
 #ifdef USE_CERT_BUFFERS_1024
-    if (*rsaKeySz < sizeof_client_key_der_1024)
+    if (*rsaPrivKeySz < sizeof_client_key_der_1024)
         return -204;
 
     XMEMCPY(rsaPrivKey, client_key_der_1024, sizeof_client_key_der_1024);
     *rsaPrivKeySz = sizeof_client_key_der_1024;
 #elif defined(USE_CERT_BUFFERS_2048)
-    if (*rsaKeySz < sizeof_client_key_der_2048)
+    if (*rsaPrivKeySz < sizeof_client_key_der_2048)
         return -205;
 
     XMEMCPY(rsaPrivKey, client_key_der_2048, sizeof_client_key_der_2048);

--- a/wolfssl/io.h
+++ b/wolfssl/io.h
@@ -90,6 +90,9 @@
         #include <netdb.h>
         #include <netinet/in.h>
         #include <io.h>
+        /* <sys/socket.h> defines these, to avoid conflict, do undef */
+        #undef SOCKADDR
+        #undef SOCKADDR_IN
     #elif defined(WOLFSSL_PRCONNECT_PRO)
         #include <prconnect_pro/prconnect_pro.h>
         #include <sys/types.h>


### PR DESCRIPTION
Fix issue with XFREE in asn.c using invalid heap pointer. Fix issue with bad variable names and missing asterisk in test.c `pkcs7_load_certs_keys`.

Fixes for build warnings on Windows. Fix PKCS7 to use const for byte array declaration. Cleanup of the pkcs7 MAX_PKCS7_DIGEST_SZ. Fix for unsigned / signed comparison warning for pkcs7_load_certs_keys in test.c. Fix for cast warning from word16 to byte in asn.c. Fix for build error with io.h refactor for InTime RTOS.