### PR TITLE
skip removal of leading zero in GetASNInt() when INTEGER is only a si…

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -729,7 +729,8 @@ static int GetASNInt(const byte* input, word32* inOutIdx, int* len,
         return ret;
 
     if (*len > 0) {
-        if (input[*inOutIdx] == 0x00) {
+        /* remove leading zero, unless there is only one 0x00 byte */
+        if ((input[*inOutIdx] == 0x00) && (*len > 1)) {
             (*inOutIdx)++;
             (*len)--;
 


### PR DESCRIPTION
…ngle zero byte

ASN.1 INTEGER types are unsigned, thus encoded with a leading zero byte if the leading bit of the content is set.  A single zero byte will not have a leading zero byte, and we should not strip it off.

The previous behavior causes issues with OCSP checks on certificates with a serial number of 0.  In this edge case, we stored the cert->serialSz as 0, when it should be of size 1 (with value zero).  The fix in this PR corrects this issue.