### PR TITLE
Fix for scan-build issues with possible use of null’s

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -538,7 +538,6 @@ static void Usage(void)
 #endif
     printf("-B <num>    Benchmark throughput using <num> bytes and print stats\n");
     printf("-s          Use pre Shared keys\n");
-    printf("-t          Track wolfSSL memory use\n");
     printf("-d          Disable peer checks\n");
     printf("-D          Override Date Errors example\n");
     printf("-e          List Every cipher suite available, \n");

--- a/src/internal.c
+++ b/src/internal.c
@@ -6809,6 +6809,7 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             if (args->certs == NULL) {
                 ERROR_OUT(MEMORY_E, exit_dc);
             }
+            XMEMSET(args->certs, 0, sizeof(buffer) * MAX_CHAIN_DEPTH);
 
             if ((args->idx - args->begin) + OPAQUE24_LEN > size) {
                 ERROR_OUT(BUFFER_ERROR, exit_dc);

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -60,7 +60,7 @@ WOLFSSL_API WOLFSSL_EVP_CIPHER_CTX *wolfSSL_EVP_CIPHER_CTX_new(void)
 	WOLFSSL_EVP_CIPHER_CTX *ctx = (WOLFSSL_EVP_CIPHER_CTX*)XMALLOC(sizeof *ctx,
                                                  NULL, DYNAMIC_TYPE_TMP_BUFFER);
 	if (ctx){
-      WOLFSSL_ENTER("wolfSSL_EVP_CIPHER_CTX_new");  
+      WOLFSSL_ENTER("wolfSSL_EVP_CIPHER_CTX_new");
 		  wolfSSL_EVP_CIPHER_CTX_init(ctx);
   }
 	return ctx;
@@ -327,7 +327,7 @@ WOLFSSL_API int  wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
                                    unsigned char *out, int *outl)
 {
     int fl ;
-    if (ctx == NULL) return BAD_FUNC_ARG;
+    if (ctx == NULL || out == NULL) return BAD_FUNC_ARG;
     WOLFSSL_ENTER("wolfSSL_EVP_CipherFinal");
     if (ctx->flags & WOLFSSL_EVP_CIPH_NO_PADDING) {
         *outl = 0;


### PR DESCRIPTION
In wolfSSL_EVP_CipherFinal out arg and DoCertificate args->certs.
Removed obsolete client example help arg “-t”.