### PR TITLE
tenAsys INtime RTOS port fixes from customer peer review

### DIFF
--- a/IDE/INTIME-RTOS/README.md
+++ b/IDE/INTIME-RTOS/README.md
@@ -148,7 +148,7 @@ Client connected successfully
 Using Non-Blocking I/O: 0
 Message for server:     Client:
 
-Recieved:       I hear ya fa shizzle!
+Received:       I hear ya fa shizzle!
 
 The client has closed the connection.
 ```

--- a/IDE/INTIME-RTOS/user_settings.h
+++ b/IDE/INTIME-RTOS/user_settings.h
@@ -13,9 +13,6 @@ extern "C" {
 #undef  INTIME_RTOS
 #define INTIME_RTOS
 
-#undef  INTIME_RTOS_MUTEX_MAX
-#define INTIME_RTOS_MUTEX_MAX       10
-
 #undef  WOLF_EXAMPLES_STACK
 #define WOLF_EXAMPLES_STACK         65536
 

--- a/IDE/INTIME-RTOS/wolfExamples.c
+++ b/IDE/INTIME-RTOS/wolfExamples.c
@@ -122,7 +122,7 @@ int wolfExample_TLSClient(const char* ip, int port)
             printf("Read error. Error: %d\n", ret);
             goto exit;
         }
-        printf("Recieved: \t%s\n", rcvBuff);
+        printf("Received: \t%s\n", rcvBuff);
     }
 
 exit:

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -2283,6 +2283,8 @@ void fp_free(fp_int* a)
 /* clear one (frees)  */
 void mp_clear (mp_int * a)
 {
+    if (a == NULL)
+        return;
     fp_clear(a);
 }
 

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1012,9 +1012,6 @@ int wolfSSL_CryptHwMutexUnLock(void) {
     }
 
 #elif defined(INTIME_RTOS)
-    #ifndef INTIME_RTOS_MUTEX_MAX
-        #define INTIME_RTOS_MUTEX_MAX 10
-    #endif
 
     int wc_InitMutex(wolfSSL_Mutex* m)
     {
@@ -1025,7 +1022,7 @@ int wolfSSL_CryptHwMutexUnLock(void) {
 
         *m = CreateRtSemaphore(
             1,                      /* initial unit count */
-            INTIME_RTOS_MUTEX_MAX,  /* maximum unit count */
+            1,                      /* maximum unit count */
             PRIORITY_QUEUING        /* creation flags: FIFO_QUEUING or PRIORITY_QUEUING */
         );
         if (*m == BAD_RTHANDLE) {


### PR DESCRIPTION
Fix mutex to use single count for semaphore so behavior is like mutex. Fix typo with “received”. Fix for mp_clear with fast math to do null check on arg (noticed null with ecc make key benchmark with wc_ecc_free).