### PR TITLE
fix sniffer with AES-GCM, add scratch authTag buffer

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -2206,6 +2206,9 @@ static int Decrypt(SSL* ssl, byte* output, const byte* input, word32 sz)
         case wolfssl_aes_gcm:
             if (sz >= (word32)(AESGCM_EXP_IV_SZ + ssl->specs.aead_mac_size))
             {
+                /* scratch buffer, sniffer ignores auth tag*/
+                byte authTag[WOLFSSL_MIN_AUTH_TAG_SZ];
+
                 byte nonce[AESGCM_NONCE_SZ];
                 XMEMCPY(nonce, ssl->keys.aead_dec_imp_IV, AESGCM_IMP_IV_SZ);
                 XMEMCPY(nonce + AESGCM_IMP_IV_SZ, input, AESGCM_EXP_IV_SZ);
@@ -2215,7 +2218,7 @@ static int Decrypt(SSL* ssl, byte* output, const byte* input, word32 sz)
                             input + AESGCM_EXP_IV_SZ,
                             sz - AESGCM_EXP_IV_SZ - ssl->specs.aead_mac_size,
                             nonce, AESGCM_NONCE_SZ,
-                            NULL, 0,
+                            authTag, sizeof(authTag),
                             NULL, 0) < 0) {
                     Trace(BAD_DECRYPT);
                     ret = -1;


### PR DESCRIPTION
Fixes sniffer with AES-GCM suites.  As of c1c7c903, there is now a minimum authTag size.  To meet this requirement, this uses a scratch buffer of that minimum size for the authTag.