### PR TITLE
Fix memory leak with InitSSL having duplicate RNG creation code

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -3692,34 +3692,6 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     if (ret != 0)
         return ret;
 
-#ifdef SINGLE_THREADED
-    ssl->rng = ctx->rng;   /* CTX may have one, if so use it */
-#endif
-
-    if (ssl->rng == NULL) {
-        /* RNG */
-        ssl->rng = (WC_RNG*)XMALLOC(sizeof(WC_RNG), ssl->heap,DYNAMIC_TYPE_RNG);
-        if (ssl->rng == NULL) {
-            WOLFSSL_MSG("RNG Memory error");
-            return MEMORY_E;
-        }
-        XMEMSET(ssl->rng, 0, sizeof(WC_RNG));
-        ssl->options.weOwnRng = 1;
-
-        /* FIPS RNG API does not accept a heap hint */
-#ifndef HAVE_FIPS
-        if ( (ret = wc_InitRng_ex(ssl->rng, ssl->heap, ssl->devId)) != 0) {
-            WOLFSSL_MSG("RNG Init error");
-            return ret;
-        }
-#else
-        if ( (ret = wc_InitRng(ssl->rng)) != 0) {
-            WOLFSSL_MSG("RNG Init error");
-            return ret;
-        }
-#endif
-    }
-
 #if defined(WOLFSSL_DTLS) && !defined(NO_WOLFSSL_SERVER)
     if (ssl->options.dtls && ssl->options.side == WOLFSSL_SERVER_END) {
         ret = wolfSSL_DTLS_SetCookieSecret(ssl, NULL, 0);

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1457,9 +1457,8 @@ static int wc_PKCS7_SignedDataVerifySignature(PKCS7* pkcs7, byte* sig,
                                               word32 signedAttribSz)
 {
     int ret = 0;
-    word32 plainDigestSz, pkcs7DigestSz;
-
-    byte* plainDigest; /* offset into pkcs7Digest */
+    word32 plainDigestSz = 0, pkcs7DigestSz;
+    byte* plainDigest = NULL; /* offset into pkcs7Digest */
 #ifdef WOLFSSL_SMALL_STACK
     byte* pkcs7Digest;
 #else


### PR DESCRIPTION
Fix async merge error which duplicated the wolfSSL_new RNG creation and caused a memory leak. Fix for build error with plainDigestSz not being initialized.