### PR TITLE
fix warnings and errors with FreeBSD PowerPC

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7746,7 +7746,7 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         case WOLFSSL_CSR2_OCSP_MULTI: {
             OcspRequest* request;
             word32 list_length = status_length;
-            byte   index = 0;
+            byte   idx = 0;
 
             #ifdef WOLFSSL_SMALL_STACK
                 CertStatus* status;
@@ -7808,13 +7808,13 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
                     while (ret == 0) {
                         request = (OcspRequest*)TLSX_CSR2_GetRequest(
-                                ssl->extensions, status_type, index++);
+                                ssl->extensions, status_type, idx++);
 
                         if (request == NULL)
                             ret = BAD_CERTIFICATE_STATUS_ERROR;
                         else if (CompareOcspReqResp(request, response) == 0)
                             break;
-                        else if (index == 1) /* server cert must be OK */
+                        else if (idx == 1) /* server cert must be OK */
                             ret = BAD_CERTIFICATE_STATUS_ERROR;
                     }
 

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -110,9 +110,9 @@ void FreeOCSP(WOLFSSL_OCSP* ocsp, int dynamic)
 }
 
 
-static int xstat2err(int stat)
+static int xstat2err(int st)
 {
-    switch (stat) {
+    switch (st) {
         case CERT_GOOD:
             return 0;
         case CERT_REVOKED:

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15388,15 +15388,15 @@ int wolfSSL_ASN1_TIME_print(WOLFSSL_BIO* bio, const WOLFSSL_ASN1_TIME* asnTime)
 
 
 #if defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
-char* wolfSSL_ASN1_TIME_to_string(WOLFSSL_ASN1_TIME* time, char* buf, int len)
+char* wolfSSL_ASN1_TIME_to_string(WOLFSSL_ASN1_TIME* t, char* buf, int len)
 {
     int format;
     int dateLen;
-    byte* date = (byte*)time;
+    byte* date = (byte*)t;
 
     WOLFSSL_ENTER("wolfSSL_ASN1_TIME_to_string");
 
-    if (time == NULL || buf == NULL || len < 5) {
+    if (t == NULL || buf == NULL || len < 5) {
         WOLFSSL_MSG("Bad argument");
         return NULL;
     }
@@ -16324,9 +16324,10 @@ void wolfSSL_DES_set_odd_parity(WOLFSSL_DES_cblock* myDes)
 void wolfSSL_DES_ecb_encrypt(WOLFSSL_DES_cblock* desa,
              WOLFSSL_DES_cblock* desb, WOLFSSL_DES_key_schedule* key, int enc)
 {
+    Des myDes;
+
     WOLFSSL_ENTER("wolfSSL_DES_ecb_encrypt");
 
-    Des myDes;
     if (desa == NULL || key == NULL || desb == NULL ||
         (enc != DES_ENCRYPT && enc != DES_DECRYPT)) {
         WOLFSSL_MSG("Bad argument passed to wolfSSL_DES_ecb_encrypt");
@@ -16338,12 +16339,12 @@ void wolfSSL_DES_ecb_encrypt(WOLFSSL_DES_cblock* desa,
         }
         if (enc){
             if (wc_Des_EcbEncrypt(&myDes, (byte*) desb,
-                                   (const byte*) desa, sizeof(desa)) != 0){
+                                   (const byte*) desa, sizeof(WOLFSSL_DES_cblock)) != 0){
                 WOLFSSL_MSG("wc_Des_EcbEncrpyt return error.");
             }
         } else {
             if (wc_Des_EcbDecrypt(&myDes, (byte*) desb,
-                                   (const byte*) desa, sizeof(desa)) != 0){
+                                   (const byte*) desa, sizeof(WOLFSSL_DES_cblock)) != 0){
                 WOLFSSL_MSG("wc_Des_EcbDecrpyt return error.");
             }
         }

--- a/src/tls.c
+++ b/src/tls.c
@@ -2652,7 +2652,7 @@ int TLSX_CSR2_InitRequests(TLSX* extensions, DecodedCert* cert, byte isPeer,
     return ret;
 }
 
-void* TLSX_CSR2_GetRequest(TLSX* extensions, byte status_type, byte index)
+void* TLSX_CSR2_GetRequest(TLSX* extensions, byte status_type, byte idx)
 {
     TLSX* extension = TLSX_Find(extensions, TLSX_STATUS_REQUEST_V2);
     CertificateStatusRequestItemV2* csr2 = extension ?
@@ -2666,8 +2666,8 @@ void* TLSX_CSR2_GetRequest(TLSX* extensions, byte status_type, byte index)
 
                 case WOLFSSL_CSR2_OCSP_MULTI:
                     /* requests are initialized in the reverse order */
-                    return index < csr2->requests
-                         ? &csr2->request.ocsp[csr2->requests - index - 1]
+                    return idx < csr2->requests
+                         ? &csr2->request.ocsp[csr2->requests - idx - 1]
                          : NULL;
                 break;
             }

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -207,11 +207,11 @@ int wc_ed25519_sign_msg(const byte* in, word32 inlen, byte* out,
    siglen  is the length of sig byte array
    msg     the array of bytes containing the message
    msglen  length of msg array
-   stat    will be 1 on successful verify and 0 on unsuccessful
-   return  0 and stat of 1 on success
+   res     will be 1 on successful verify and 0 on unsuccessful
+   return  0 and res of 1 on success
 */
 int wc_ed25519_verify_msg(byte* sig, word32 siglen, const byte* msg,
-                          word32 msglen, int* stat, ed25519_key* key)
+                          word32 msglen, int* res, ed25519_key* key)
 {
     byte   rcheck[ED25519_KEY_SIZE];
     byte   h[SHA512_DIGEST_SIZE];
@@ -223,11 +223,11 @@ int wc_ed25519_verify_msg(byte* sig, word32 siglen, const byte* msg,
     Sha512 sha;
 
     /* sanity check on arguments */
-    if (sig == NULL || msg == NULL || stat == NULL || key == NULL)
+    if (sig == NULL || msg == NULL || res == NULL || key == NULL)
         return BAD_FUNC_ARG;
 
     /* set verification failed by default */
-    *stat = 0;
+    *res = 0;
 
     /* check on basics needed to verify signature */
     if (siglen < ED25519_SIG_SIZE || (sig[ED25519_SIG_SIZE-1] & 224))
@@ -279,7 +279,7 @@ int wc_ed25519_verify_msg(byte* sig, word32 siglen, const byte* msg,
         return SIG_VERIFY_E;
 
     /* set the verification status */
-    *stat = 1;
+    *res = 1;
 
     return ret;
 }

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -316,7 +316,7 @@ int wc_LoggingCleanup(void)
 #if defined(DEBUG_WOLFSSL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
 /* peek at an error node
  *
- * index : if -1 then the most recent node is looked at, otherwise search
+ * idx : if -1 then the most recent node is looked at, otherwise search
  *         through queue for node at the given index
  * file  : pointer to internal file string
  * reason : pointer to internal error reason
@@ -325,7 +325,7 @@ int wc_LoggingCleanup(void)
  * Returns a negative value in error case, on success returns the nodes error
  * value which is positve (absolute value)
  */
-int wc_PeekErrorNode(int index, const char **file, const char **reason,
+int wc_PeekErrorNode(int idx, const char **file, const char **reason,
         int *line)
 {
     struct wc_error_queue* err;
@@ -335,7 +335,7 @@ int wc_PeekErrorNode(int index, const char **file, const char **reason,
         return BAD_MUTEX_E;
     }
 
-    if (index < 0) {
+    if (idx < 0) {
         err = wc_last_node;
         if (err == NULL) {
             WOLFSSL_MSG("No Errors in queue");
@@ -347,7 +347,7 @@ int wc_PeekErrorNode(int index, const char **file, const char **reason,
         int i;
 
         err = (struct wc_error_queue*)wc_errors;
-        for (i = 0; i < index; i++) {
+        for (i = 0; i < idx; i++) {
             if (err == NULL) {
                 WOLFSSL_MSG("Error node not found. Bad index?");
                 wc_UnLockMutex(&debug_mutex);
@@ -441,10 +441,10 @@ int wc_AddErrorNode(int error, int line, char* buf, char* file)
 }
 
 /* Removes the error node at the specified index.
- * index : if -1 then the most recent node is looked at, otherwise search
+ * idx : if -1 then the most recent node is looked at, otherwise search
  *         through queue for node at the given index
  */
-void wc_RemoveErrorNode(int index)
+void wc_RemoveErrorNode(int idx)
 {
     struct wc_error_queue* current;
 
@@ -453,11 +453,11 @@ void wc_RemoveErrorNode(int index)
         return;
     }
 
-    if (index == -1)
+    if (idx == -1)
         current = wc_last_node;
     else {
         current = (struct wc_error_queue*)wc_errors;
-        for (; current != NULL && index > 0; index--)
+        for (; current != NULL && idx > 0; idx--)
              current = current->next;
     }
     if (current != NULL) {

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1220,7 +1220,7 @@ static int wc_PKCS7_EcdsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
                                 byte* hash, word32 hashSz)
 {
     int ret = 0;
-    int stat = 0;
+    int res = 0;
 #ifdef WOLFSSL_SMALL_STACK
     byte* digest;
     ecc_key* key;
@@ -1267,11 +1267,11 @@ static int wc_PKCS7_EcdsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
         return PUBLIC_KEY_E;
     }
 
-    ret = wc_ecc_verify_hash(sig, sigSz, hash, hashSz, &stat, key);
+    ret = wc_ecc_verify_hash(sig, sigSz, hash, hashSz, &res, key);
 
     wc_ecc_free(key);
 
-    if (ret == 0 && stat != 1) {
+    if (ret == 0 && res != 1) {
         ret = SIG_VERIFY_E;
     }
 
@@ -2807,32 +2807,32 @@ static int wc_PKCS7_DecryptContent(int encryptOID, byte* key, int keySz,
 static int wc_PKCS7_GenerateIV(WC_RNG* rng, byte* iv, word32 ivSz)
 {
     int ret;
-    WC_RNG* random = NULL;
+    WC_RNG* rnd = NULL;
 
     if (iv == NULL || ivSz == 0)
         return BAD_FUNC_ARG;
 
     /* input RNG is optional, init local one if input rng is NULL */
-    if (rng == NULL) {
-        random = (WC_RNG*)XMALLOC(sizeof(WC_RNG), NULL, DYNAMIC_TYPE_RNG);
-        if (random == NULL)
+    if (rnd == NULL) {
+        rnd = (WC_RNG*)XMALLOC(sizeof(WC_RNG), NULL, DYNAMIC_TYPE_RNG);
+        if (rnd == NULL)
             return MEMORY_E;
 
-        ret = wc_InitRng(random);
+        ret = wc_InitRng(rnd);
         if (ret != 0) {
-            XFREE(random, NULL, DYNAMIC_TYPE_RNG);
+            XFREE(rnd, NULL, DYNAMIC_TYPE_RNG);
             return ret;
         }
 
     } else {
-        random = rng;
+        rnd = rng;
     }
 
-    ret = wc_RNG_GenerateBlock(random, iv, ivSz);
+    ret = wc_RNG_GenerateBlock(rnd, iv, ivSz);
 
     if (rng == NULL) {
-        wc_FreeRng(random);
-        XFREE(random, NULL, DYNAMIC_TYPE_RNG);
+        wc_FreeRng(rnd);
+        XFREE(rnd, NULL, DYNAMIC_TYPE_RNG);
     }
 
     return ret;

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -2813,7 +2813,7 @@ static int wc_PKCS7_GenerateIV(WC_RNG* rng, byte* iv, word32 ivSz)
         return BAD_FUNC_ARG;
 
     /* input RNG is optional, init local one if input rng is NULL */
-    if (rnd == NULL) {
+    if (rng == NULL) {
         rnd = (WC_RNG*)XMALLOC(sizeof(WC_RNG), NULL, DYNAMIC_TYPE_RNG);
         if (rnd == NULL)
             return MEMORY_E;

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -611,7 +611,7 @@ static void scryptSalsa(word32* out, word32* in)
         out[i] = in[i] + x[i];
 #else
     for (i = 0; i < 16; i++)
-        out[i] = ByteReverseWord32(in[i] + x[i]);
+        out[i] = ByteReverseWord32(ByteReverseWord32(in[i]) + x[i]);
 #endif
 }
 

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -209,7 +209,7 @@ static int Hash_df(DRBG* drbg, byte* out, word32 outSz, byte type,
                                                   const byte* inA, word32 inASz,
                                                   const byte* inB, word32 inBSz)
 {
-    int ret;
+    int ret = DRBG_FAILURE;
     byte ctr;
     int i;
     int len;


### PR DESCRIPTION
There is one item I'm aware of that is outstanding yet. It could be broken into another pull request or added to this depending.

With "./configure --enable-crl --enable-crl-monitor" the function open fails on line 531 of src/crl.c. When using the flag O_RDONLY in replace of what XEVENT_MODE is set to it gets farther along but fails with ./scripts/resume.test (note ./scripts/resume.test passes without crl and crl-monitor on). The simplest case to see it is with

$ ./examples/server/server
wolfSSL error: unable to load CRL