### PR TITLE
Interop testing fixes

### DIFF
--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -162,7 +162,7 @@ echo ""
 # TLS 1.3 cipher suites server / client.
 echo -e "\n\nOnly TLS v1.3 cipher suites"
 port=0
-./examples/server/server -v 4 -R $ready_file -p $port -l TLS13-AES128-GCM-SHA256:TLS13-AES256-GCM-SHA384:TLS13-CHACH20-POLY1305-SHA256:TLS13-AES128-CCM-SHA256:TLS13-AES128-CCM-8-SHA256 &
+./examples/server/server -v 4 -R $ready_file -p $port -l TLS13-AES128-GCM-SHA256:TLS13-AES256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256:TLS13-AES128-CCM-SHA256:TLS13-AES128-CCM-8-SHA256 &
 server_pid=$!
 create_port
 ./examples/client/client -v 4 -p $port
@@ -210,7 +210,7 @@ echo ""
 # TLS 1.3 cipher suites server / client.
 echo -e "\n\nOnly TLS v1.3 cipher suite - CHACHA20-POLY1305 SHA-256"
 port=0
-./examples/server/server -v 4 -R $ready_file -p $port -l TLS13-CHACH20-POLY1305-SHA256 &
+./examples/server/server -v 4 -R $ready_file -p $port -l TLS13-CHACHA20-POLY1305-SHA256 &
 server_pid=$!
 create_port
 ./examples/client/client -v 4 -p $port

--- a/src/internal.c
+++ b/src/internal.c
@@ -13621,7 +13621,7 @@ static const char* const cipher_names[] =
 #endif
 
 #ifdef BUILD_TLS_CHACHA20_POLY1305_SHA256
-    "TLS13-CHACH20-POLY1305-SHA256",
+    "TLS13-CHACHA20-POLY1305-SHA256",
 #endif
 
 #ifdef BUILD_TLS_AES_128_CCM_SHA256
@@ -14655,9 +14655,9 @@ int SetCipherList(WOLFSSL_CTX* ctx, Suites* suites, const char* list)
                 }
             #endif /* WOLFSSL_DTLS */
 
-                suites->suites[idx++] = (XSTRSTR(name, "CHACHA")) ? CHACHA_BYTE
+                suites->suites[idx++] = (XSTRSTR(name, "TLS13"))  ? TLS13_BYTE
+                                      : (XSTRSTR(name, "CHACHA")) ? CHACHA_BYTE
                                       : (XSTRSTR(name, "QSH"))    ? QSH_BYTE
-                                      : (XSTRSTR(name, "TLS13"))  ? TLS13_BYTE
                                       : (XSTRSTR(name, "EC"))     ? ECC_BYTE
                                       : (XSTRSTR(name, "CCM"))    ? ECC_BYTE
                                       : 0x00; /* normal */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1005,8 +1005,6 @@ static int CheckBitString(const byte* input, word32* inOutIdx, int* len,
     if (b != 0) {
         if ((byte)(input[idx + length - 1] << (8 - b)) != 0)
             return ASN_PARSE_E;
-        if (((input[idx + length - 1] >> b) & 0x01) != 0x01)
-            return ASN_PARSE_E;
     }
     idx++;
     length--; /* length has been checked for greater than 0 */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2348,7 +2348,7 @@ enum SignatureAlgorithm {
     anonymous_sa_algo = 0,
     rsa_sa_algo       = 1,
     dsa_sa_algo       = 2,
-    ecc_dsa_sa_algo   = 4,
+    ecc_dsa_sa_algo   = 3,
     rsa_pss_sa_algo   = 8
 };
 


### PR DESCRIPTION
Fix TLS13 cipher suite name to CHACHA20
Include SignatureAlgorithm in older versions of TLS when compiling for
TLS v1.3.
BIT STRING unused bits doesn't necessarily indicate last unused bit.
Fix ecc_dsa_sa_algo value.