### PR TITLE
Fixes for verify callback override

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -575,6 +575,7 @@ static void Usage(void)
     printf("-f          Fewer packets/group messages\n");
     printf("-x          Disable client cert/key loading\n");
     printf("-X          Driven by eXternal test case\n");
+    printf("-j          Use verify callback override\n");
 #ifdef SHOW_SIZES
     printf("-z          Print structure sizes\n");
 #endif
@@ -627,7 +628,7 @@ static void Usage(void)
 #ifdef HAVE_ECC
     printf("-Y          Key Share with ECC named groups only\n");
 #endif
-#endif
+#endif /* WOLFSSL_TLS13 */
 }
 
 THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
@@ -698,6 +699,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     int   doSTARTTLS    = 0;
     char* starttlsProt = NULL;
+    int   useVerifyCb = 0;
 
 #ifdef WOLFSSL_TRUST_PEER_CERT
     const char* trustCert  = NULL;
@@ -767,9 +769,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     StackTrap();
 
 #ifndef WOLFSSL_VXWORKS
-    /* Not used: j, t, Q */
+    /* Not used: t, Q */
     while ((ch = mygetopt(argc, argv, "?"
-            "ab:c:defgh:ik:l:mnop:q:rsuv:wxyz"
+            "ab:c:defgh:ijk:l:mnop:q:rsuv:wxyz"
             "A:B:CDE:F:GHIJKL:M:NO:PRS:TUVW:XYZ:")) != -1) {
         switch (ch) {
             case '?' :
@@ -1069,6 +1071,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 #endif
                 break;
 
+            case 'j' :
+                useVerifyCb = 1;
+                break;
+
             default:
                 Usage();
                 exit(MY_EX_USAGE);
@@ -1335,9 +1341,6 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     wolfSSL_CTX_SetCACb(ctx, CaCb);
 #endif
 
-#ifdef VERIFY_CALLBACK
-    wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, myVerify);
-#endif
 #if !defined(NO_CERTS)
     if (useClientCert){
 #if !defined(NO_FILESYSTEM)
@@ -1360,7 +1363,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif  /* !defined(NO_FILESYSTEM) */
     }
 
-    if (!usePsk && !useAnon) {
+    if (!usePsk && !useAnon && !useVerifyCb) {
 #if !defined(NO_FILESYSTEM)
         if (wolfSSL_CTX_load_verify_locations(ctx, verifyCert,0)
                                                                != SSL_SUCCESS) {
@@ -1391,9 +1394,11 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         }
 #endif /* WOLFSSL_TRUST_PEER_CERT && !NO_FILESYSTEM */
     }
-    if (!usePsk && !useAnon && doPeerCheck == 0)
+    if (useVerifyCb)
+        wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, myVerify);
+    else if (!usePsk && !useAnon && doPeerCheck == 0)
         wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0);
-    if (!usePsk && !useAnon && overrideDateErrors == 1)
+    else if (!usePsk && !useAnon && overrideDateErrors == 1)
         wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, myDateCb);
 #endif /* !defined(NO_CERTS) */
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -2130,6 +2130,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     (void) verifyCert;
     (void) ourCert;
     (void) ourKey;
+    (void) useVerifyCb;
 
 #if !defined(WOLFSSL_TIRTOS)
     return 0;

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -2169,3 +2169,12 @@
 -v 3
 -l NTRU-AES128-SHA
 
+# server TLSv1.2 verify callback override
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# client TLSv1.2 verify callback override
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+-j
+

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1202,8 +1202,6 @@ static INLINE unsigned int my_psk_server_cb(WOLFSSL* ssl, const char* identity,
     #endif /* !NO_FILESYSTEM || (NO_FILESYSTEM && FORCE_BUFFER_TEST) */
 #endif /* !NO_CERTS */
 
-#ifdef VERIFY_CALLBACK
-
 static INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
 {
     (void)preverify;
@@ -1246,8 +1244,6 @@ static INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
     printf("\tAllowing to continue anyway (shouldn't do this, EVER!!!)\n");
     return 1;
 }
-
-#endif /* VERIFY_CALLBACK */
 
 
 static INLINE int myDateCb(int preverify, WOLFSSL_X509_STORE_CTX* store)

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1204,12 +1204,11 @@ static INLINE unsigned int my_psk_server_cb(WOLFSSL* ssl, const char* identity,
 
 static INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
 {
-    (void)preverify;
     char buffer[WOLFSSL_MAX_ERROR_SZ];
-
 #ifdef OPENSSL_EXTRA
     WOLFSSL_X509* peer;
 #endif
+    (void)preverify;
 
     printf("In verification callback, error = %d, %s\n", store->error,
                                  wolfSSL_ERR_error_string(store->error, buffer));


### PR DESCRIPTION
Fix for verify callback override, peerVerifyRet code on success and ensuring DOMAIN_NAME_MISMATCH error gets passed down in ECDSAk case. These were broken in commit 3810571 with async refactor. Added unit test case to verify callback override works. Fixes issue #905 and issue #904. Fix for async build goto label typo.