### PR TITLE
Fix issue with --disable-harden

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1926,29 +1926,6 @@ done:
 
 #if !defined(FREESCALE_LTC_ECC)
 
-#ifndef WC_NO_CACHE_RESISTANT
-#if defined(TFM_TIMING_RESISTANT) && defined(USE_FAST_MATH) && \
-    !defined(__cplusplus)
-    /* let's use the one we already have */
-    extern const wolfssl_word wc_off_on_addr[2];
-#else
-    static const wolfssl_word wc_off_on_addr[2] =
-    {
-    #if defined(WC_64BIT_CPU)
-        W64LIT(0x0000000000000000),
-        W64LIT(0xffffffffffffffff)
-    #elif defined(WC_16BIT_CPU)
-        0x0000U,
-        0xffffU
-    #else
-        /* 32 bit */
-        0x00000000U,
-        0xffffffffU
-    #endif
-    };
-#endif /* TFM_TIMING_RESISTANT && USE_FAST_MATH */
-#endif /* WC_NO_CACHE_RESISTANT */
-
 /**
    Perform a point multiplication
    k    The scalar to multiply by

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -1045,26 +1045,6 @@ int fp_addmod(fp_int *a, fp_int *b, fp_int *c, fp_int *d)
 
 #ifdef TFM_TIMING_RESISTANT
 
-#ifndef WC_NO_CACHE_RESISTANT
-/* all off / all on pointer addresses for constant calculations */
-/* ecc.c uses same table */
-const wolfssl_word wc_off_on_addr[2] =
-{
-#if defined(WC_64BIT_CPU)
-    W64LIT(0x0000000000000000),
-    W64LIT(0xffffffffffffffff)
-#elif defined(WC_16BIT_CPU)
-    0x0000U,
-    0xffffU
-#else
-    /* 32 bit */
-    0x00000000U,
-    0xffffffffU
-#endif
-};
-
-#endif /* WC_NO_CACHE_RESISTANT */
-
 /* timing resistant montgomery ladder based exptmod
    Based on work by Marc Joye, Sung-Ming Yen, "The Montgomery Powering Ladder",
    Cryptographic Hardware and Embedded Systems, CHES 2002

--- a/wolfcrypt/src/wolfmath.c
+++ b/wolfcrypt/src/wolfmath.c
@@ -52,6 +52,29 @@
 #endif
 
 
+#if !defined(WC_NO_CACHE_RESISTANT) && \
+    ((defined(HAVE_ECC) && defined(ECC_TIMING_RESISTANT)) || \
+     (defined(USE_FAST_MATH) && defined(TFM_TIMING_RESISTANT)))
+
+    /* all off / all on pointer addresses for constant calculations */
+    /* ecc.c uses same table */
+    const wolfssl_word wc_off_on_addr[2] =
+    {
+    #if defined(WC_64BIT_CPU)
+        W64LIT(0x0000000000000000),
+        W64LIT(0xffffffffffffffff)
+    #elif defined(WC_16BIT_CPU)
+        0x0000U,
+        0xffffU
+    #else
+        /* 32 bit */
+        0x00000000U,
+        0xffffffffU
+    #endif
+    };
+#endif
+
+
 int get_digit_count(mp_int* a)
 {
     if (a == NULL)

--- a/wolfssl/wolfcrypt/wolfmath.h
+++ b/wolfssl/wolfcrypt/wolfmath.h
@@ -37,6 +37,14 @@
 #ifndef __WOLFMATH_H__
 #define __WOLFMATH_H__
 
+    /* timing resistance array */
+    #if !defined(WC_NO_CACHE_RESISTANT) && \
+        ((defined(HAVE_ECC) && defined(ECC_TIMING_RESISTANT)) || \
+         (defined(USE_FAST_MATH) && defined(TFM_TIMING_RESISTANT)))
+
+        extern const wolfssl_word wc_off_on_addr[2];
+    #endif
+
     /* common math functions */
     int get_digit_count(mp_int* a);
     mp_digit get_digit(mp_int* a, int n);


### PR DESCRIPTION
Fix issue with --disable-harden build due to `wc_off_on_addr` defined but not used. Cleanup of the `wc_off_on_addr` code to combine duplicate definitions. Fixes issue #908.