### PR TITLE
allow re-using WOLFSSL structure after calling shutdown

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -5094,6 +5094,10 @@ int HashInput(WOLFSSL* ssl, const byte* input, int sz)
     }
 #endif
 
+    if (ssl->hsHashes == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
 #ifndef NO_OLD_TLS
 #ifndef NO_SHA
     wc_ShaUpdate(&ssl->hsHashes->hashSha, adj, sz);


### PR DESCRIPTION
There is a case with the compatibility layer where a WOLFSSL structure can be used for another connection after wolfSSL_shutdown is called and before wolfSSL_free or a second wolfSSL_new is called.

>wolfSSL_new
>wolfSSL_accept
>wolfSSL_read/wolfSSL_write
>wolfSSL_shutdown
>wolfSSL_accept
>wolfSSL_read/wolfSSL_write
>wolfSSL_shutdown
>wolfSSL_free