### PR TITLE
Fix for scan-build warning for possible use of uninitialized `eccKey`

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -4756,7 +4756,7 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
     byte*    keyData = NULL;
     word32   dataSize;
     word32   keySize;
-    ecc_key* eccKey;
+    ecc_key* eccKey = NULL;
     word16   curveId;
 
     /* TODO: [TLS13] The key sizes should come from wolfcrypt. */


### PR DESCRIPTION
`src/tls.c:4898:20: warning: The left operand of '!=' is a garbage value`.