### PR TITLE
Added argument for benchmark block size

### DIFF
--- a/wolfcrypt/benchmark/benchmark.h
+++ b/wolfcrypt/benchmark/benchmark.h
@@ -34,6 +34,8 @@ THREAD_RETURN WOLFSSL_THREAD benchmark_test(void* args);
 int benchmark_test(void *args);
 #endif
 
+void benchmark_configure(int block_size);
+
 #ifdef __cplusplus
     }  /* extern "C" */
 #endif


### PR DESCRIPTION
Usage: `./wolfcrypt/benchmark/benchmark 128`. Automatic calculation for showing as bytes, KB or MB. Pulled this out of the STM32 PR #807.