### PR TITLE
Fix for parsing permitted name constraint for subject directory name

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -87,7 +87,7 @@ enum ASN_Tags {
     ASN_LONG_LENGTH       = 0x80
 };
 
-enum  ASN_Flags{
+enum ASN_Flags {
     ASN_CONSTRUCTED       = 0x20,
     ASN_CONTEXT_SPECIFIC  = 0x80
 };


### PR DESCRIPTION
Cleanup to use switch in ConfirmNameConstraints.