### PR TITLE
Fixes for building AES key wrap and PKCS7 on Windows

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1190,7 +1190,7 @@ int wolfSSL_dtls_export_internal(WOLFSSL* ssl, byte* buf, word32 sz)
 #ifdef WOLFSSL_SESSION_EXPORT_DEBUG
     {
         char debug[256];
-        snprintf(debug, sizeof(debug), "Exporting DTLS session\n"
+        XSNPRINTF(debug, sizeof(debug), "Exporting DTLS session\n"
                    "\tVersion  : %d\n\tProtocol : %02X%01X\n\tLength of: %d\n\n"
                , (int)DTLS_EXPORT_VERSION, buf[0], (buf[1] >> 4), idx - 2);
         WOLFSSL_MSG(debug);
@@ -1234,7 +1234,7 @@ int wolfSSL_dtls_import_internal(WOLFSSL* ssl, byte* buf, word32 sz)
 #ifdef WOLFSSL_SESSION_EXPORT_DEBUG
     {
         char debug[256];
-        snprintf(debug, sizeof(debug), "Importing DTLS session\n"
+        XSNPRINTF(debug, sizeof(debug), "Importing DTLS session\n"
                    "\tVersion  : %d\n\tProtocol : %02X%01X\n\tLength of: %d\n\n"
                , (int)version, buf[0], (buf[1] >> 4), length);
         WOLFSSL_MSG(debug);

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -4963,8 +4963,6 @@ int wc_AesKeyWrap(const byte* key, word32 keySz, const byte* in, word32 inSz,
 int wc_AesKeyUnWrap(const byte* key, word32 keySz, const byte* in, word32 inSz,
                     byte* out, word32 outSz, const byte* iv)
 {
-    (void)iv;
-
     Aes aes;
     byte* r;
     word32 i, n;
@@ -4977,6 +4975,8 @@ int wc_AesKeyUnWrap(const byte* key, word32 keySz, const byte* in, word32 inSz,
     const byte defaultIV[] = {
         0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6
     };
+
+    (void)iv;
 
     if (key == NULL || in == NULL || inSz < 3 ||
         out == NULL || outSz < (inSz - KEYWRAP_BLOCK_SIZE))

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -946,7 +946,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         return ret;
         }
         esd->contentDigest[0] = ASN_OCTET_STRING;
-        esd->contentDigest[1] = hashSz;
+        esd->contentDigest[1] = (byte)hashSz;
         ret = wc_HashFinal(&esd->hash, esd->hashType,
                            &esd->contentDigest[2]);
         if (ret < 0) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -41,6 +41,7 @@
 
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/logging.h>
+#include <wolfssl/wolfcrypt/types.h>
 
 #ifdef WOLFSSL_TEST_CERT
     #include <wolfssl/wolfcrypt/asn.h>
@@ -12687,7 +12688,7 @@ static int pkcs7signed_run_vectors(byte* rsaCert, word32 rsaCertSz,
             wc_ShaFree(&sha);
 
             for (j = 0, k = 2; j < SHA_DIGEST_SIZE; j++, k += 2) {
-                snprintf((char*)&transId[k], 3, "%02x", digest[j]);
+                XSNPRINTF((char*)&transId[k], 3, "%02x", digest[j]);
             }
         }
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -302,13 +302,12 @@
 	        #define XSTRNCASECMP(s1,s2,n) _strnicmp((s1),(s2),(n))
 	    #endif
 
-        #if defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
-	        #ifndef USE_WINDOWS_API
-	            #define XSNPRINTF snprintf
-	        #else
-	            #define XSNPRINTF _snprintf
-	        #endif
-        #endif /* WOLFSSL_MYSQL_COMPATIBLE */
+        /* snprintf is used in asn.c for GetTimeString and PKCS7 test */
+        #ifndef USE_WINDOWS_API
+            #define XSNPRINTF snprintf
+        #else
+            #define XSNPRINTF _snprintf
+        #endif
 
         #if defined(WOLFSSL_CERT_EXT) || defined(HAVE_ALPN)
             /* use only Thread Safe version of strtok */


### PR DESCRIPTION
Cleanup snprintf to use XSNPRINTF and changed so define is always setup.