### PR TITLE
remove size_t dependency with default build

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15938,6 +15938,7 @@ WOLFSSL_API int i2t_ASN1_OBJECT(char *buf, int buf_len, WOLFSSL_ASN1_OBJECT *a)
     return -1;
 }
 
+#ifdef WOLFSSL_HAPROXY
 /*** TBD ***/
 WOLFSSL_API size_t SSL_get_finished(const WOLFSSL *s, void *buf, size_t count)
 {
@@ -15957,6 +15958,7 @@ WOLFSSL_API size_t SSL_get_peer_finished(const WOLFSSL *s, void *buf, size_t cou
     WOLFSSL_STUB("SSL_get_peer_finished");
     return SSL_FAILURE;
 }
+#endif /* WOLFSSL_HAPROXY */
 
 /*** TBD ***/
 WOLFSSL_API void SSL_CTX_set_tmp_dh_callback(WOLFSSL_CTX *ctx, WOLFSSL_DH *(*dh) (WOLFSSL *ssl, int is_export, int keylength))

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2357,6 +2357,8 @@ WOLFSSL_API void wolfSSL_get0_next_proto_negotiated(const WOLFSSL *s, const unsi
 #if defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
 WOLFSSL_API const unsigned char *SSL_SESSION_get0_id_context(
         const WOLFSSL_SESSION *sess, unsigned int *sid_ctx_length);
+WOLFSSL_API size_t SSL_get_finished(const WOLFSSL *s, void *buf, size_t count);
+WOLFSSL_API size_t SSL_get_peer_finished(const WOLFSSL *s, void *buf, size_t count);
 #endif
 
 WOLFSSL_API int SSL_SESSION_set1_id(WOLFSSL_SESSION *s, const unsigned char *sid, unsigned int sid_len);
@@ -2368,8 +2370,6 @@ WOLFSSL_API int X509_PUBKEY_get0_param(WOLFSSL_ASN1_OBJECT **ppkalg, const unsig
 WOLFSSL_API int EVP_PKEY_bits(WOLFSSL_EVP_PKEY *pkey);
 WOLFSSL_API int i2d_X509(WOLFSSL_X509 *x, unsigned char **out);
 WOLFSSL_API int i2t_ASN1_OBJECT(char *buf, int buf_len, WOLFSSL_ASN1_OBJECT *a);
-WOLFSSL_API size_t SSL_get_finished(const WOLFSSL *s, void *buf, size_t count);
-WOLFSSL_API size_t SSL_get_peer_finished(const WOLFSSL *s, void *buf, size_t count);
 WOLFSSL_API void SSL_CTX_set_tmp_dh_callback(WOLFSSL_CTX *ctx, WOLFSSL_DH *(*dh) (WOLFSSL *ssl, int is_export, int keylength));
 WOLFSSL_API STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void);
 WOLFSSL_API int X509_STORE_load_locations(WOLFSSL_X509_STORE *ctx, const char *file, const char *dir);


### PR DESCRIPTION
Was using this configure option

>./configure --disable-filesystem --enable-singlethreaded CC="arm-none-eabi-gcc --specs=rdimon.specs" LD=arm-none-eabi-ld AR=arm-none-eabi-ar CXX=arm-none-eabi-c++ CP=arm-none-eabi-cp --host=arm-none-eabi C_EXTRA_FLAGS="-DWOLFSSL_USER_IO -DNO_WRITEV" --enable-static --disable-shared
>
>make src/libwolfssl.la

and seeing

>In file included from src/tls.c:32:0:
>./wolfssl/ssl.h:2328:13: error: unknown type name 'size_t'
> WOLFSSL_API size_t SSL_get_finished(const WOLFSSL *s, void *buf, size_t count);
>             ^
>./wolfssl/ssl.h:2328:66: error: unknown type name 'size_t'
> WOLFSSL_API size_t SSL_get_finished(const WOLFSSL *s, void *buf, size_t count);
>                                                                  ^
>./wolfssl/ssl.h:2329:13: error: unknown type name 'size_t'
> WOLFSSL_API size_t SSL_get_peer_finished(const WOLFSSL *s, void *buf, size_t count);
>             ^
>./wolfssl/ssl.h:2329:71: error: unknown type name 'size_t'
> WOLFSSL_API size_t SSL_get_peer_finished(const WOLFSSL *s, void *buf, size_t count);
>                                                                       ^
>Makefile:3323: recipe for target 'src/src_libwolfssl_la-tls.lo' failed
