### PR TITLE
build: Fix Visual Studio builds for TLS 1.3

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1520,12 +1520,14 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     #ifdef WOLFSSL_TLS13
     if (!helloRetry) {
         if (onlyKeyShare == 0 || onlyKeyShare == 2) {
+        #ifdef HAVE_CURVE25519
             if (useX25519) {
                 if (wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_X25519)
                         != SSL_SUCCESS) {
                     err_sys("unable to use curve secp256r1");
                 }
             }
+        #endif
             if (wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_SECP256R1)
                     != SSL_SUCCESS) {
                 err_sys("unable to use curve secp256r1");
@@ -1951,11 +1953,13 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif
 
     #ifdef WOLFSSL_TLS13
+    #ifdef HAVE_CURVE25519
         if (useX25519) {
             if (wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_X25519) != SSL_SUCCESS) {
                 err_sys("unable to use curve secp256r1");
             }
         }
+    #endif
         if (wolfSSL_UseKeyShare(sslResume,
                                 WOLFSSL_ECC_SECP256R1) != SSL_SUCCESS) {
             err_sys("unable to use curve secp256r1");

--- a/src/tls.c
+++ b/src/tls.c
@@ -1591,6 +1591,7 @@ static int TLSX_SNI_Parse(WOLFSSL* ssl, byte* input, word16 length,
         switch(type) {
             case WOLFSSL_SNI_HOST_NAME: {
                 int matchStat;
+                byte matched;
 #ifdef WOLFSSL_TLS13
                 /* Don't process the second ClientHello SNI extension if there
                  * was problems with the first.
@@ -1598,10 +1599,11 @@ static int TLSX_SNI_Parse(WOLFSSL* ssl, byte* input, word16 length,
                 if (sni->status != 0)
                     break;
 #endif
-                byte matched = cacheOnly ||
-                            ((XSTRLEN(sni->data.host_name) == size)
-                            && (XSTRNCMP(sni->data.host_name,
-                                       (const char*)input + offset, size) == 0));
+                matched = (cacheOnly ||
+                           ((XSTRLEN(sni->data.host_name) == size) &&
+                            (XSTRNCMP(sni->data.host_name,
+                                      (const char*)input + offset,
+                                      size) == 0)));
 
                 if (matched || sni->options & WOLFSSL_SNI_ANSWER_ON_MISMATCH) {
                     int r = TLSX_UseSNI(&ssl->extensions,
@@ -4290,10 +4292,10 @@ int TLSX_UseQSHScheme(TLSX** extensions, word16 name, byte* pKey, word16 pkeySz,
  */
 static word16 TLSX_SupportedVersions_GetSize(void* data)
 {
-    (void)data;
-
     /* TLS v1.2 and TLS v1.3  */
     int cnt = 2;
+
+    (void)data;
 
 #ifndef NO_OLD_TLS
     /* TLS v1 and TLS v1.1  */

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4755,8 +4755,9 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             byte type, word32 size, word32 totalSz)
 {
     int ret = 0;
-    (void)totalSz;
     word32 inIdx = *inOutIdx;
+
+    (void)totalSz;
 
     WOLFSSL_ENTER("DoTls13HandShakeMsgType");
 

--- a/wolfssl.vcproj
+++ b/wolfssl.vcproj
@@ -172,15 +172,15 @@
 				>
 			</File>
 			<File
-				RelativePath=".\wolfcrypt\src\coding.c"
-				>
-			</File>
-			<File
 				RelativePath=".\wolfcrypt\src\chacha.c"
 				>
 			</File>
 			<File
 				RelativePath=".\wolfcrypt\src\chacha20_poly1305.c"
+				>
+			</File>
+			<File
+				RelativePath=".\wolfcrypt\src\coding.c"
 				>
 			</File>
 			<File
@@ -256,23 +256,15 @@
 				>
 			</File>
 			<File
-				RelativePath=".\wolfcrypt\src\pkcs7.c"
-				>
-			</File>
-			<File
 				RelativePath=".\wolfcrypt\src\pkcs12.c"
 				>
 			</File>
 			<File
+				RelativePath=".\wolfcrypt\src\pkcs7.c"
+				>
+			</File>
+			<File
 				RelativePath=".\wolfcrypt\src\poly1305.c"
-				>
-			</File>
-			<File
-				RelativePath=".\wolfcrypt\src\wc_port.c"
-				>
-			</File>
-			<File
-				RelativePath=".\wolfcrypt\src\wolfmath.c"
 				>
 			</File>
 			<File
@@ -320,11 +312,23 @@
 				>
 			</File>
 			<File
+				RelativePath=".\src\tls13.c"
+				>
+			</File>
+			<File
 				RelativePath=".\wolfcrypt\src\wc_encrypt.c"
 				>
 			</File>
 			<File
+				RelativePath=".\wolfcrypt\src\wc_port.c"
+				>
+			</File>
+			<File
 				RelativePath=".\wolfcrypt\src\wolfevent.c"
+				>
+			</File>
+			<File
+				RelativePath=".\wolfcrypt\src\wolfmath.c"
 				>
 			</File>
 		</Filter>

--- a/wolfssl.vcxproj
+++ b/wolfssl.vcxproj
@@ -283,6 +283,7 @@
     <ClCompile Include="src\ocsp.c" />
     <ClCompile Include="src\ssl.c" />
     <ClCompile Include="src\tls.c" />
+    <ClCompile Include="src\tls13.c" />
     <ClCompile Include="wolfcrypt\src\aes.c" />
     <ClCompile Include="wolfcrypt\src\arc4.c" />
     <ClCompile Include="wolfcrypt\src\asn.c" />


### PR DESCRIPTION
- Include tls13.c in Visual Studio project files.

- Clean up mixed declarations.

- Put guards around the CURVE25519 code in client example.

--

Disclaimer: Though this makes Visual Studio and mingw builds possible (only client example fix needed for mingw) from master with TLS 1.3 enabled, and all tests pass respectively, I have not actually tried anything real world with this.

Note these changes only make it _possible_ to build with TLS 1.3 support, they do not enable it by default. In VS the equivalent of `--enable-tls13` seems to be:
~~~c
#define WC_RSA_PSS
#define WOLFSSL_TLS13
#define HAVE_TLS_EXTENSIONS
#define HAVE_FFDHE_2048
#define HAVE_HKDF
~~~
