### PR TITLE
Fix mystrnstr() prototype declaration

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -286,11 +286,12 @@
         #define FREE_ARRAY(VAR_NAME, VAR_ITEMS, HEAP)  /* nothing to free, its stack */
     #endif
 
+    #ifndef WOLFSSL_LEANPSK
+	    char* mystrnstr(const char* s1, const char* s2, unsigned int n);
+    #endif
 
 	#ifndef STRING_USER
 	    #include <string.h>
-	    char* mystrnstr(const char* s1, const char* s2, unsigned int n);
-
 	    #define XMEMCPY(d,s,l)    memcpy((d),(s),(l))
 	    #define XMEMSET(b,c,l)    memset((b),(c),(l))
 	    #define XMEMCMP(s1,s2,n)  memcmp((s1),(s2),(n))


### PR DESCRIPTION
The mystrstr() function is implemented in ./src/ssl.c, where it is only excluded from the build if WOLFSSL_LEANPSK is defined.

In the case where the user had defined STRING_USER, we had the implementation, but the prototype was compiled out - giving the user a warning.

This PR fixes this issue by removing the mystrstr() prototype from STRING_USER and instead protecting it with WOLFSSL_LEANPSK to match the implementation in ./src/ssl.c.