### PR TITLE
Fixes for OCSP and CRL with non-blocking sockets

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -350,7 +350,7 @@ int CheckCertCRL(WOLFSSL_CRL* crl, DecodedCert* cert)
             ret = crl->crlIOCb(crl, (const char*)cert->extCrlInfo,
                                                         cert->extCrlInfoSz);
             if (ret == WOLFSSL_CBIO_ERR_WANT_READ) {
-                ret = WC_PENDING_E;
+                ret = WANT_READ;
             }
             else if (ret >= 0) {
                 /* try again */

--- a/src/crl.c
+++ b/src/crl.c
@@ -349,7 +349,10 @@ int CheckCertCRL(WOLFSSL_CRL* crl, DecodedCert* cert)
         if (crl->crlIOCb) {
             ret = crl->crlIOCb(crl, (const char*)cert->extCrlInfo,
                                                         cert->extCrlInfoSz);
-            if (ret >= 0) {
+            if (ret == WOLFSSL_CBIO_ERR_WANT_READ) {
+                ret = WC_PENDING_E;
+            }
+            else if (ret >= 0) {
                 /* try again */
                 ret = CheckCertCRLList(crl, cert, &foundEntry);
             }

--- a/src/internal.c
+++ b/src/internal.c
@@ -7693,8 +7693,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx, word32 totalSz
                             ret = CheckCertOCSP(ssl->ctx->cm->ocsp, args->dCert,
                                                                           NULL);
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            /* Handle WC_PENDING_E */
-                            if (ret == WC_PENDING_E) {
+                            /* non-blocking socket re-entry requires async */
+                            if (ret == WANT_READ) {
                                 goto exit_ppc;
                             }
                         #endif
@@ -7713,7 +7713,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx, word32 totalSz
                             WOLFSSL_MSG("Doing Non Leaf CRL check");
                             ret = CheckCertCRL(ssl->ctx->cm->crl, args->dCert);
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret == WC_PENDING_E) {
+                            /* non-blocking socket re-entry requires async */
+                            if (ret == WANT_READ) {
                                 goto exit_ppc;
                             }
                         #endif
@@ -7859,7 +7860,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx, word32 totalSz
                         ret = CheckCertOCSP(ssl->ctx->cm->ocsp, args->dCert,
                                                                           NULL);
                     #ifdef WOLFSSL_ASYNC_CRYPT
-                        if (ret == WC_PENDING_E) {
+                        /* non-blocking socket re-entry requires async */
+                        if (ret == WANT_READ) {
                             goto exit_ppc;
                         }
                     #endif
@@ -7879,7 +7881,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx, word32 totalSz
                         WOLFSSL_MSG("Doing Leaf CRL check");
                         ret = CheckCertCRL(ssl->ctx->cm->crl, args->dCert);
                     #ifdef WOLFSSL_ASYNC_CRYPT
-                        if (ret == WC_PENDING_E) {
+                        /* non-blocking socket re-entry requires async */
+                        if (ret == WANT_READ) {
                             goto exit_ppc;
                         }
                     #endif
@@ -8289,8 +8292,7 @@ exit_ppc:
     WOLFSSL_LEAVE("ProcessPeerCerts", ret);
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* Handle WC_PENDING_E */
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_PENDING_E || ret == WANT_READ) {
         /* Mark message as not recevied so it can process again */
         ssl->msgsReceived.got_certificate = 0;
 

--- a/src/io.c
+++ b/src/io.c
@@ -1168,7 +1168,7 @@ int EmbedOcspLookup(void* ctx, const char* url, int urlSz,
                                                             httpBuf, httpBufSz);
 
             ret = wolfIO_TcpConnect(&sfd, domainName, port, io_timeout_sec);
-            if ((ret != 0) || (sfd <= 0)) {
+            if ((ret != 0) || (sfd < 0)) {
                 WOLFSSL_MSG("OCSP Responder connection failed");
             }
             else if (wolfIO_Send(sfd, (char*)httpBuf, httpBufSz, 0) !=
@@ -1267,7 +1267,7 @@ int EmbedCrlLookup(WOLFSSL_CRL* crl, const char* url, int urlSz)
                 httpBuf, httpBufSz);
 
             ret = wolfIO_TcpConnect(&sfd, domainName, port, io_timeout_sec);
-            if ((ret != 0) || (sfd <= 0)) {
+            if ((ret != 0) || (sfd < 0)) {
                 WOLFSSL_MSG("CRL connection failed");
             }
             else if (wolfIO_Send(sfd, (char*)httpBuf, httpBufSz, 0)

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -445,6 +445,9 @@ int CheckOcspRequest(WOLFSSL_OCSP* ocsp, OcspRequest* ocspRequest,
         responseSz = ocsp->cm->ocspIOCb(ocsp->cm->ocspIOCtx, url, urlSz,
                                         request, requestSz, &response);
     }
+    if (responseSz == WOLFSSL_CBIO_ERR_WANT_READ) {
+        ret = WC_PENDING_E;
+    }
 
     XFREE(request, ocsp->cm->heap, DYNAMIC_TYPE_OCSP);
 

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -446,7 +446,7 @@ int CheckOcspRequest(WOLFSSL_OCSP* ocsp, OcspRequest* ocspRequest,
                                         request, requestSz, &response);
     }
     if (responseSz == WOLFSSL_CBIO_ERR_WANT_READ) {
-        ret = WC_PENDING_E;
+        ret = WANT_READ;
     }
 
     XFREE(request, ocsp->cm->heap, DYNAMIC_TYPE_OCSP);


### PR DESCRIPTION
Fix for OCSP and CRL file descriptor check to allow 0.