### PR TITLE
Fix wc_SetKeyUsage() value error.

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9082,7 +9082,9 @@ int wc_SetKeyUsage(Cert *cert, const char *value)
     XSTRNCPY(str, value, XSTRLEN(value));
 
     /* parse value, and set corresponding Key Usage value */
-    token = XSTRTOK(str, ",", &ptr);
+    if ((token = XSTRTOK(str, ",", &ptr)) == NULL) {
+        return KEYUSAGE_E;
+    }
     while (token != NULL)
     {
         len = (word32)XSTRLEN(token);


### PR DESCRIPTION
This PR fixes an issue with passing an empty string into wc_SetKeyUsage as the second argument. What happens is that the token is null and the function returns zero. This fix checks that the token is not NULL once all the input has been tokenized. You can reproduce this error by passing "" in as the value of the second argument.