### PR TITLE
Tls13 updates

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -240,6 +240,63 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int throughput)
     return EXIT_SUCCESS;
 }
 
+static void ServerRead(WOLFSSL* ssl, char* input, int inputLen)
+{
+    int ret, err;
+    char buffer[CYASSL_MAX_ERROR_SZ];
+
+    /* Read data */
+    do {
+        err = 0; /* reset error */
+        ret = SSL_read(ssl, input, inputLen);
+        if (ret < 0) {
+            err = SSL_get_error(ssl, 0);
+
+        #ifdef WOLFSSL_ASYNC_CRYPT
+            if (err == WC_PENDING_E) {
+                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
+                if (ret < 0) break;
+            }
+            else
+        #endif
+            if (err != SSL_ERROR_WANT_READ) {
+                printf("SSL_read input error %d, %s\n", err,
+                                                 ERR_error_string(err, buffer));
+                err_sys("SSL_read failed");
+            }
+        }
+    } while (err == WC_PENDING_E);
+    if (ret > 0) {
+        input[ret] = 0; /* null terminate message */
+        printf("Client message: %s\n", input);
+    }
+}
+
+static void ServerWrite(WOLFSSL* ssl, const char* output, int outputLen)
+{
+    int ret, err;
+    char buffer[CYASSL_MAX_ERROR_SZ];
+
+    do {
+        err = 0; /* reset error */
+        ret = SSL_write(ssl, output, outputLen);
+        if (ret <= 0) {
+            err = SSL_get_error(ssl, 0);
+
+        #ifdef WOLFSSL_ASYNC_CRYPT
+            if (err == WC_PENDING_E) {
+                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
+                if (ret < 0) break;
+            }
+        #endif
+        }
+    } while (err == WC_PENDING_E || err == SSL_ERROR_WANT_WRITE);
+    if (ret != outputLen) {
+        printf("SSL_write msg error %d, %s\n", err,
+                                                 ERR_error_string(err, buffer));
+        err_sys("SSL_write failed");
+    }
+}
 
 static void Usage(void)
 {
@@ -307,6 +364,9 @@ static void Usage(void)
 #ifdef WOLFSSL_TLS13
     printf("-K          Key Exchange for PSK not using (EC)DHE\n");
     printf("-U          Update keys and IVs before sending\n");
+#ifdef WOLFSSL_POST_HANDSHAKE_AUTH
+    printf("-Q          Request certificate from client post-handshake\n");
+#endif
 #endif
 }
 
@@ -393,6 +453,9 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     int noPskDheKe = 0;
 #endif
     int updateKeysIVs = 0;
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
+    int postHandAuth = 0;
+#endif
 
 #ifdef WOLFSSL_STATIC_MEMORY
     #if (defined(HAVE_ECC) && !defined(ALT_ECC_SIZE)) \
@@ -437,10 +500,10 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
 #ifdef WOLFSSL_VXWORKS
     useAnyAddr = 1;
 #else
-    /* Not Used: h, m, t, x, y, z, F, J, M, Q, T, V, W, X, Y */
+    /* Not Used: h, m, t, x, y, z, F, J, M, T, V, W, X, Y */
     while ((ch = mygetopt(argc, argv, "?"
                 "abc:defgijk:l:nop:q:rsuv:w"
-                "A:B:C:D:E:GHIKL:NO:PR:S:UYZ:")) != -1) {
+                "A:B:C:D:E:GHIKL:NO:PQR:S:UYZ:")) != -1) {
         switch (ch) {
             case '?' :
                 Usage();
@@ -652,6 +715,13 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
                 #ifdef WOLFSSL_TLS13
                     updateKeysIVs = 1;
                 #endif
+                break;
+
+            case 'Q' :
+            #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
+                postHandAuth = 1;
+                doCliCertCheck = 0;
+            #endif
                 break;
 
             default:
@@ -1180,39 +1250,42 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
             free(list);
         }
 #endif
+
+#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS)
+    #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
+        if (postHandAuth) {
+            SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER |
+                                    ((usePskPlus)? SSL_VERIFY_FAIL_EXCEPT_PSK :
+                                    SSL_VERIFY_FAIL_IF_NO_PEER_CERT),0);
+            if (SSL_CTX_load_verify_locations(ctx, verifyCert, 0)
+                                                               != SSL_SUCCESS) {
+                err_sys("can't load ca file, Please run from wolfSSL home dir");
+            }
+            #ifdef WOLFSSL_TRUST_PEER_CERT
+            if (trustCert) {
+                if ((ret = wolfSSL_CTX_trust_peer_cert(ctx, trustCert,
+                                            SSL_FILETYPE_PEM)) != SSL_SUCCESS) {
+                    err_sys("can't load trusted peer cert file");
+                }
+            }
+            #endif /* WOLFSSL_TRUST_PEER_CERT */
+       }
+    #endif
+#endif
+
         if (echoData == 0 && throughput == 0) {
             const char* write_msg;
             int write_msg_sz;
 
-            /* Read data */
-            do {
-                err = 0; /* reset error */
-                ret = SSL_read(ssl, input, sizeof(input)-1);
-                if (ret < 0) {
-                    err = SSL_get_error(ssl, 0);
-
-                #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (err == WC_PENDING_E) {
-                        ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-                        if (ret < 0) break;
-                    }
-                    else
-                #endif
-                    if (err != SSL_ERROR_WANT_READ) {
-                        printf("SSL_read input error %d, %s\n", err,
-                                                ERR_error_string(err, buffer));
-                        err_sys("SSL_read failed");
-                    }
-                }
-            } while (err == WC_PENDING_E);
-            if (ret > 0) {
-                input[ret] = 0; /* null terminate message */
-                printf("Client message: %s\n", input);
-            }
+            ServerRead(ssl, input, sizeof(input)-1);
 
 #ifdef WOLFSSL_TLS13
             if (updateKeysIVs)
                 wolfSSL_update_keys(ssl);
+#endif
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
+            if (postHandAuth)
+                wolfSSL_request_certificate(ssl);
 #endif
 
             /* Write data */
@@ -1224,25 +1297,14 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
                 write_msg = webServerMsg;
                 write_msg_sz = sizeof(webServerMsg);
             }
-            do {
-                err = 0; /* reset error */
-                ret = SSL_write(ssl, write_msg, write_msg_sz);
-                if (ret <= 0) {
-                    err = SSL_get_error(ssl, 0);
+            ServerWrite(ssl, write_msg, write_msg_sz);
 
-                #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (err == WC_PENDING_E) {
-                        ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
-                        if (ret < 0) break;
-                    }
-                #endif
-                }
-            } while (err == WC_PENDING_E || err == SSL_ERROR_WANT_WRITE);
-            if (ret != write_msg_sz) {
-                printf("SSL_write msg error %d, %s\n", err,
-                                                ERR_error_string(err, buffer));
-                err_sys("SSL_write failed");
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
+            if (postHandAuth) {
+                ServerWrite(ssl, write_msg, write_msg_sz);
+                ServerRead(ssl, input, sizeof(input)-1);
             }
+#endif
         }
         else {
             ServerEchoData(ssl, clientfd, echoData, throughput);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -846,13 +846,25 @@ int wolfSSL_negotiate(WOLFSSL* ssl)
 
     WOLFSSL_ENTER("wolfSSL_negotiate");
 #ifndef NO_WOLFSSL_SERVER
-    if (ssl->options.side == WOLFSSL_SERVER_END)
-        err = wolfSSL_accept(ssl);
+    if (ssl->options.side == WOLFSSL_SERVER_END) {
+#ifdef WOLFSSL_TLS13
+        if (IsAtLeastTLSv1_3(ssl->version))
+            err = wolfSSL_accept_TLSv13(ssl);
+        else
+#endif
+            err = wolfSSL_accept(ssl);
+    }
 #endif
 
 #ifndef NO_WOLFSSL_CLIENT
-    if (ssl->options.side == WOLFSSL_CLIENT_END)
-        err = wolfSSL_connect(ssl);
+    if (ssl->options.side == WOLFSSL_CLIENT_END) {
+#ifdef WOLFSSL_TLS13
+        if (IsAtLeastTLSv1_3(ssl->version))
+            err = wolfSSL_connect_TLSv13(ssl);
+        else
+#endif
+            err = wolfSSL_connect(ssl);
+    }
 #endif
 
     WOLFSSL_LEAVE("wolfSSL_negotiate", err);

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -253,8 +253,14 @@ void bench_rng(void);
 
 #if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND) && \
         !defined(HAVE_STACK_SIZE)
+#ifdef __cplusplus
+    extern "C" {
+#endif
     WOLFSSL_API int wolfSSL_Debugging_ON(void);
     WOLFSSL_API void wolfSSL_Debugging_OFF(void);
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 #endif
 
 #if !defined(NO_RSA) || !defined(NO_DH) \

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -307,7 +307,13 @@ int memcb_test(void);
 
 #if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND) && \
         !defined(OPENSSL_EXTRA) && !defined(HAVE_STACK_SIZE)
-    int  wolfSSL_Debugging_ON(void);
+#ifdef __cplusplus
+    extern "C" {
+#endif
+    WOLFSSL_API int wolfSSL_Debugging_ON();
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
 #endif
 
 /* General big buffer size for many tests. */

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -164,10 +164,11 @@ enum wolfSSL_ErrorCodes {
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* begin negotiation parameter errors */
-    UNSUPPORTED_SUITE            = -500,        /* unsupported cipher suite */
-    MATCH_SUITE_ERROR            = -501,        /* can't match cipher suite */
-    COMPRESSION_ERROR            = -502,        /* compression mismatch */
-    KEY_SHARE_ERROR              = -503         /* key share mismatch */
+    UNSUPPORTED_SUITE            = -500,   /* unsupported cipher suite */
+    MATCH_SUITE_ERROR            = -501,   /* can't match cipher suite */
+    COMPRESSION_ERROR            = -502,   /* compression mismatch */
+    KEY_SHARE_ERROR              = -503,   /* key share mismatch */
+    POST_HAND_AUTH_ERROR         = -504    /* client won't do post-hand auth */
     /* end negotiation parameter errors only 10 for now */
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -412,6 +412,9 @@ WOLFSSL_API int  wolfSSL_no_ticket_TLSv13(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_CTX_no_dhe_psk(WOLFSSL_CTX* ctx);
 WOLFSSL_API int  wolfSSL_no_dhe_psk(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_update_keys(WOLFSSL* ssl);
+WOLFSSL_API int  wolfSSL_CTX_allow_post_handshake_auth(WOLFSSL_CTX* ctx);
+WOLFSSL_API int  wolfSSL_allow_post_handshake_auth(WOLFSSL* ssl);
+WOLFSSL_API int  wolfSSL_request_certificate(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_accept_TLSv13(WOLFSSL*);
 #endif
 WOLFSSL_API void wolfSSL_CTX_free(WOLFSSL_CTX*);


### PR DESCRIPTION
Improve PSK timeout checks
Add Post-handshake Authentication - not compiled by default.
Fix KeyUpdate to derive keys properly (interop with OpenSSL found issue)
Fix supported curves (not checking ctx extensions)