### PR TITLE
Fix compile time Error with openssl extra and cryptonly

### DIFF
--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -131,7 +131,8 @@ int wolfCrypt_Init(void)
         WOLFSSL_MSG("Using ARM hardware acceleration");
     #endif
 
-    #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
+    #if !defined(WOLFCRYPT_ONLY) && \
+        ( defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) )
         wolfSSL_EVP_init();
     #endif
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -128,7 +128,9 @@
 #endif
 
 #ifdef OPENSSL_EXTRA
+  #ifndef WOLFCRYPT_ONLY
     #include <wolfssl/openssl/evp.h>
+  #endif
     #include <wolfssl/openssl/rand.h>
     #include <wolfssl/openssl/hmac.h>
     #include <wolfssl/openssl/aes.h>
@@ -249,7 +251,9 @@ int  random_test(void);
 #endif /* WC_NO_RNG */
 int  pwdbased_test(void);
 int  ripemd_test(void);
-int  openssl_test(void);   /* test mini api */
+#if defined(OPENSSL_EXTRA) && !defined(WOLFCRYPT_ONLY)
+    int  openssl_test(void);   /* test mini api */
+#endif
 int pbkdf1_test(void);
 int pkcs12_test(void);
 int pbkdf2_test(void);
@@ -751,7 +755,7 @@ int wolfcrypt_test(void* args)
         printf( "PWDBASED test passed!\n");
 #endif
 
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) && !defined(WOLFCRYPT_ONLY)
     if ( (ret = openssl_test()) != 0)
         return err_sys("OPENSSL  test failed!\n", ret);
     else
@@ -8430,7 +8434,7 @@ int srp_test(void)
 
 #endif /* WOLFCRYPT_HAVE_SRP */
 
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) && !defined(WOLFCRYPT_ONLY)
 
 int openssl_test(void)
 {
@@ -9121,12 +9125,11 @@ int openssl_test(void)
 
     }
 #endif /* ifndef NO_AES */
-
     return 0;
 }
 
 
-#endif /* OPENSSL_EXTRA */
+#endif /* OPENSSL_EXTRA && !WOLFCRYPT_ONLY */
 
 
 #ifndef NO_PWDBASED


### PR DESCRIPTION
EVP API's are implemented in <wolf-root>/src/ssl.c The entirety of which is not compiled when WOLFCRYPT_ONLY is defined. Bringing EVP pre-processor checks in line with this logic.