### PR TITLE
Add void to function prototype.

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -253,7 +253,7 @@ void bench_rng(void);
 
 #if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND) && \
         !defined(HAVE_STACK_SIZE)
-    WOLFSSL_API int wolfSSL_Debugging_ON();
+    WOLFSSL_API int wolfSSL_Debugging_ON(void);
     WOLFSSL_API void wolfSSL_Debugging_OFF(void);
 #endif
 


### PR DESCRIPTION
A fix for a warning-turned-error by `-Werror`. I found it after configuring with `./configure --enable-debug CC=clang && make`. It seems to be connected to clang 4.0, which decided that the `-Wstrict-prototypes` flag should not accept prototypes with empty parentheses and demand they be filled with `void`. 