### PR TITLE
Fixes for TLS 1.3 without ECC or RSA

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2639,7 +2639,12 @@ then
     if test "x$ENABLED_TLSX" = "xno"
     then
         ENABLED_TLSX="yes"
-        AM_CFLAGS="$AM_CFLAGS -DHAVE_TLS_EXTENSIONS -DHAVE_SNI -DHAVE_MAX_FRAGMENT -DHAVE_TRUNCATED_HMAC -DHAVE_SUPPORTED_CURVES"
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_TLS_EXTENSIONS -DHAVE_SNI -DHAVE_MAX_FRAGMENT -DHAVE_TRUNCATED_HMAC"
+
+        # Check the ECC supported curves prereq
+        AS_IF([test "x$ENABLED_ECC" = "xyes"],
+              [ENABLED_SUPPORTED_CURVES=yes
+               AM_CFLAGS="$AM_CFLAGS -DHAVE_SUPPORTED_CURVES"])
     fi
 
     # Requires ecc make sure on

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -197,7 +197,7 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
             else if (useX25519) {
                 if (wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_X25519)
                         != SSL_SUCCESS) {
-                    err_sys("unable to use curve secp256r1");
+                    err_sys("unable to use curve x25519");
                 }
             }
         #endif
@@ -281,7 +281,7 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
             if (useX25519) {
                 if (wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_X25519)
                         != SSL_SUCCESS) {
-                    err_sys("unable to use curve secp256r1");
+                    err_sys("unable to use curve x25519");
                 }
             }
         #endif
@@ -1551,10 +1551,11 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             if (useX25519) {
                 if (wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_X25519)
                         != SSL_SUCCESS) {
-                    err_sys("unable to use curve secp256r1");
+                    err_sys("unable to use curve x25519");
                 }
             }
         #endif
+        #ifdef HAVE_ECC
             if (wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_SECP256R1)
                     != SSL_SUCCESS) {
                 err_sys("unable to use curve secp256r1");
@@ -1563,6 +1564,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                     != SSL_SUCCESS) {
                 err_sys("unable to use curve secp384r1");
             }
+        #endif
         }
         if (onlyKeyShare == 0 || onlyKeyShare == 1) {
         #ifdef HAVE_FFDHE_2048
@@ -1983,10 +1985,11 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     #ifdef HAVE_CURVE25519
         if (useX25519) {
             if (wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_X25519) != SSL_SUCCESS) {
-                err_sys("unable to use curve secp256r1");
+                err_sys("unable to use curve x25519");
             }
         }
     #endif
+    #ifdef HAVE_ECC
         if (wolfSSL_UseKeyShare(sslResume,
                                 WOLFSSL_ECC_SECP256R1) != SSL_SUCCESS) {
             err_sys("unable to use curve secp256r1");
@@ -1995,6 +1998,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                                 WOLFSSL_ECC_SECP384R1) != SSL_SUCCESS) {
             err_sys("unable to use curve secp384r1");
         }
+    #endif
     #ifdef HAVE_FFDHE_2048
         if (wolfSSL_UseKeyShare(sslResume, WOLFSSL_FFDHE_2048) != SSL_SUCCESS) {
             err_sys("unable to use DH 2048-bit parameters");

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3588,6 +3588,7 @@ static int CreateRSAEncodedSig(byte* sig, byte* sigData, int sigDataSz,
         return wc_EncodeSignature(sig, hash, hashSz, hashOid);
     }
 }
+#endif /* !NO_RSA */
 
 #ifdef HAVE_ECC
 /* Encode the ECC signature.
@@ -3648,9 +3649,9 @@ static int CreateECCEncodedSig(byte* sigData, int sigDataSz, int hashAlgo)
 
     return hashSz;
 }
-#endif
+#endif /* HAVE_ECC */
 
-
+#ifndef NO_RSA
 /* Check that the decrypted signature matches the encoded signature
  * based on the digest of the signature data.
  *
@@ -4467,15 +4468,19 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                 WOLFSSL_MSG("Oops, peer sent ED25519 key but not in verify");
             }
         #endif
+        #ifdef HAVE_ECC
             if (args->sigAlgo == ecc_dsa_sa_algo &&
                                                    !ssl->peerEccDsaKeyPresent) {
                 WOLFSSL_MSG("Oops, peer sent ECC key but not in verify");
             }
+        #endif
+        #ifndef NO_RSA
             if ((args->sigAlgo == rsa_sa_algo ||
                  args->sigAlgo == rsa_pss_sa_algo) &&
                          (ssl->peerRsaKey == NULL || !ssl->peerRsaKeyPresent)) {
                 WOLFSSL_MSG("Oops, peer sent RSA key but not in verify");
             }
+        #endif
 
             sig->buffer = (byte*)XMALLOC(args->sz, ssl->heap,
                                          DYNAMIC_TYPE_TMP_BUFFER);


### PR DESCRIPTION
Fix for building without ECC where HAVE_SUPPORTED_CURVES was getting defined because of ENABLED_TLSX.