### PR TITLE
ThreadX/NetX warning and optional dc_log_printf exclusion

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -1402,6 +1402,8 @@ int NetX_Receive(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     ULONG copied = 0;
     UINT  status;
 
+    (void)ssl;
+
     if (nxCtx == NULL || nxCtx->nxSocket == NULL) {
         WOLFSSL_MSG("NetX Recv NULL parameters");
         return WOLFSSL_CBIO_ERR_GENERAL;
@@ -1454,6 +1456,8 @@ int NetX_Send(WOLFSSL* ssl, char *buf, int sz, void *ctx)
     NX_PACKET*      packet;
     NX_PACKET_POOL* pool;   /* shorthand */
     UINT            status;
+
+    (void)ssl;
 
     if (nxCtx == NULL || nxCtx->nxSocket == NULL) {
         WOLFSSL_MSG("NetX Send NULL parameters");

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -121,7 +121,7 @@ void wolfSSL_Debugging_OFF(void)
     #include <stdio.h>   /* for default printf stuff */
 #endif
 
-#ifdef THREADX
+#if defined(THREADX) && !defined(THREADX_NO_DC_PRINTF)
     int dc_log_printf(char*, ...);
 #endif
 
@@ -131,7 +131,7 @@ static void wolfssl_log(const int logLevel, const char *const logMessage)
         log_function(logLevel, logMessage);
     else {
         if (loggingEnabled) {
-#ifdef THREADX
+#if defined(THREADX) && !defined(THREADX_NO_DC_PRINTF)
             dc_log_printf("%s\n", logMessage);
 #elif defined(MICRIUM)
         #if (NET_SECURE_MGR_CFG_EN == DEF_ENABLED)


### PR DESCRIPTION
This PR fixes:

1) Minor warning in NetX I/O callbacks where WOLFSSL* is not used.

2) Some ThreadX users do not have dc_log_printf() available. Provides a way to disable compilation of this in logging.c when THREADX_NO_DC_PRINTF is defined.