### PR TITLE
fix wc_EccPrivateKeyDecode when pub exists

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -10004,6 +10004,7 @@ int wc_EccPrivateKeyDecode(const byte* input, word32* inOutIdx, ecc_key* key,
                 if (pubSz < 2*(ECC_MAXSIZE+1)) {
                     XMEMCPY(pub, &input[*inOutIdx], pubSz);
                     *inOutIdx += length;
+                    pubData = pub;
                 }
                 else
                     ret = BUFFER_E;


### PR DESCRIPTION
This PR fixes one oversight of the following commit: https://github.com/wolfSSL/wolfssl/commit/c6ce1fe330529dc4528b663e1ad32b8ed48fa272

wc_EccPrivateKeyDecode() correctly detected and read in the public part of the ECC key, but didn't switch the pubData pointer to match the key location.  This caused a NULL pointer to be passed into wc_ecc_import_private_key_ex() instead.