### PR TITLE
Fix potential buffer over-read in PemToDer()

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4156,23 +4156,39 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
         char*  line        = XSTRNSTR(headerEnd, encHeader, min(headerEndSz,
                                                                 PEM_LINE_LEN));
         if (line != NULL) {
-            char*  newline;
+            word32 lineSz;
             char*  finish;
             word32 finishSz;
+            char*  start;
             word32 startSz;
-            word32 lineSz   = (word32)(bufferEnd - line);
-            char*  start    = XSTRNSTR(line, "DES", min(lineSz, PEM_LINE_LEN));
+            char*  newline;
 
-            if (start == NULL)
+            if (line >= bufferEnd) {
+                return SSL_BAD_FILE;
+            }
+
+            lineSz = (word32)(bufferEnd - line);
+            start = XSTRNSTR(line, "DES", min(lineSz, PEM_LINE_LEN));
+
+            if (start == NULL) {
                 start = XSTRNSTR(line, "AES", min(lineSz, PEM_LINE_LEN));
+            }
 
             if (start == NULL) return SSL_BAD_FILE;
             if (info == NULL)  return SSL_BAD_FILE;
 
+            if (start >= bufferEnd) {
+                return SSL_BAD_FILE;
+            }
+
             startSz = (word32)(bufferEnd - start);
-            finish = XSTRNSTR(start, ",", min((word32)startSz, PEM_LINE_LEN));
+            finish = XSTRNSTR(start, ",", min(startSz, PEM_LINE_LEN));
 
             if ((start != NULL) && (finish != NULL) && (start < finish)) {
+                if (finish >= bufferEnd) {
+                    return SSL_BAD_FILE;
+                }
+
                 finishSz = (word32)(bufferEnd - finish);
                 newline = XSTRNSTR(finish, "\r", min(finishSz, PEM_LINE_LEN));
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4152,32 +4152,29 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
     {
         /* remove encrypted header if there */
         char   encHeader[] = "Proc-Type";
-        word32 headerEndSz = min((word32)((size_t)(bufferEnd - headerEnd)),
-                                 PEM_LINE_LEN);
-        char*  line        = XSTRNSTR(headerEnd, encHeader, headerEndSz);
+        word32 headerEndSz = (word32)(bufferEnd - headerEnd);
+        char*  line        = XSTRNSTR(headerEnd, encHeader, min(headerEndSz,
+                                                                PEM_LINE_LEN));
         if (line != NULL) {
-            word32 lineSz   = min((word32)((size_t)(bufferEnd - line)),
-                                  PEM_LINE_LEN);
             char*  newline;
             char*  finish;
             word32 finishSz;
-            char*  start    = XSTRNSTR(line, "DES", lineSz);
             word32 startSz;
+            word32 lineSz   = (word32)(bufferEnd - line);
+            char*  start    = XSTRNSTR(line, "DES", min(lineSz, PEM_LINE_LEN));
 
             if (start == NULL)
-                start = XSTRNSTR(line, "AES", lineSz);
+                start = XSTRNSTR(line, "AES", min(lineSz, PEM_LINE_LEN));
 
             if (start == NULL) return SSL_BAD_FILE;
             if (info == NULL)  return SSL_BAD_FILE;
 
-            startSz = min((word32)((size_t)(bufferEnd - line)),
-                          PEM_LINE_LEN);
-            finish = XSTRNSTR(start, ",", startSz);
+            startSz = (word32)(bufferEnd - start);
+            finish = XSTRNSTR(start, ",", min((word32)startSz, PEM_LINE_LEN));
 
             if ((start != NULL) && (finish != NULL) && (start < finish)) {
-                finishSz = min((word32)((size_t)(bufferEnd - finish)),
-                               PEM_LINE_LEN);
-                newline = XSTRNSTR(finish, "\r", finishSz);
+                finishSz = (word32)(bufferEnd - finish);
+                newline = XSTRNSTR(finish, "\r", min(finishSz, PEM_LINE_LEN));
 
                 if (XMEMCPY(info->name, start, finish - start) == NULL)
                     return SSL_FATAL_ERROR;
@@ -4186,7 +4183,8 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
                     return SSL_FATAL_ERROR;
 
                 if (newline == NULL)
-                    newline = XSTRNSTR(finish, "\n", finishSz);
+                    newline = XSTRNSTR(finish, "\n", min(finishSz,
+                                                         PEM_LINE_LEN));
                 if ((newline != NULL) && (newline > finish)) {
                     info->ivSz = (word32)(newline - (finish + 1));
                     info->set = 1;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4151,28 +4151,32 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
     {
         /* remove encrypted header if there */
-        char encHeader[] = "Proc-Type";
-        unsigned int headerEndSz = min(PEM_LINE_LEN, bufferEnd - headerEnd);
-        char* line = XSTRNSTR(headerEnd, encHeader, headerEndSz);
-        unsigned int lineSz = min(PEM_LINE_LEN, bufferEnd - line);
-        if (line) {
-            char* newline;
-            char* finish;
-            char* start  = XSTRNSTR(line, "DES", lineSz);
-            unsigned int finishSz;
-            unsigned int startSz;
+        char   encHeader[] = "Proc-Type";
+        word32 headerEndSz = min((word32)((size_t)(bufferEnd - headerEnd)),
+                                 PEM_LINE_LEN);
+        char*  line        = XSTRNSTR(headerEnd, encHeader, headerEndSz);
+        if (line != NULL) {
+            word32 lineSz   = min((word32)((size_t)(bufferEnd - line)),
+                                  PEM_LINE_LEN);
+            char*  newline;
+            char*  finish;
+            word32 finishSz;
+            char*  start    = XSTRNSTR(line, "DES", lineSz);
+            word32 startSz;
 
-            if (!start)
+            if (start == NULL)
                 start = XSTRNSTR(line, "AES", lineSz);
 
-            if (!start) return SSL_BAD_FILE;
-            if (!info)  return SSL_BAD_FILE;
+            if (start == NULL) return SSL_BAD_FILE;
+            if (info == NULL)  return SSL_BAD_FILE;
 
-            startSz = min(PEM_LINE_LEN, bufferEnd - start);
+            startSz = min((word32)((size_t)(bufferEnd - line)),
+                          PEM_LINE_LEN);
             finish = XSTRNSTR(start, ",", startSz);
 
-            if (start && finish && (start < finish)) {
-                finishSz = min(PEM_LINE_LEN, bufferEnd - finish);
+            if ((start != NULL) && (finish != NULL) && (start < finish)) {
+                finishSz = min((word32)((size_t)(bufferEnd - finish)),
+                               PEM_LINE_LEN);
                 newline = XSTRNSTR(finish, "\r", finishSz);
 
                 if (XMEMCPY(info->name, start, finish - start) == NULL)
@@ -4181,8 +4185,9 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
                 if (XMEMCPY(info->iv, finish + 1, sizeof(info->iv)) == NULL)
                     return SSL_FATAL_ERROR;
 
-                if (!newline) newline = XSTRNSTR(finish, "\n", finishSz);
-                if (newline && (newline > finish)) {
+                if (newline == NULL)
+                    newline = XSTRNSTR(finish, "\n", finishSz);
+                if ((newline != NULL) && (newline > finish)) {
                     info->ivSz = (word32)(newline - (finish + 1));
                     info->set = 1;
                 }


### PR DESCRIPTION
When configured with `--enable-opensslextra` or `--enable-webserver`, a malformed certificate passed to `PemToDer()` can cause a buffer over-read. Alex noticed this while fuzz testing `wolfSSL_CertPemToDer()`, and between the two of us we tracked down this bug. My solution was to add 4 new variables to make sure `XSTRNSTR()` would not overflow the buffer. After this change, fuzzing `wolfSSL_CertPemToDer()` for a time yielded no errors.