### PR TITLE
Fixes for CRL handling and possible false failure in `wolfSSL_CTX_load_verify_locations`

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1729,7 +1729,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     }
 
 #ifdef HAVE_CRL
-    if (disableCRL == 0) {
+    if (disableCRL == 0 && !useVerifyCb) {
     #ifdef HAVE_IO_TIMEOUT
         wolfIO_SetTimeout(DEFAULT_TIMEOUT_SEC);
     #endif

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -216,7 +216,7 @@ do
         fi
 
         # check for psk suite and turn on client psk if so
-        psk = ""
+        psk=""
         case $wolfSuite in
         *PSK*)
             psk="-s " ;;

--- a/src/crl.c
+++ b/src/crl.c
@@ -318,7 +318,8 @@ static int CheckCertCRLList(WOLFSSL_CRL* crl, DecodedCert* cert, int *pFoundEntr
         RevokedCert* rc = crle->certs;
 
         while (rc) {
-            if (XMEMCMP(rc->serialNumber, cert->serial, rc->serialSz) == 0) {
+            if (rc->serialSz == cert->serialSz &&
+                   XMEMCMP(rc->serialNumber, cert->serial, rc->serialSz) == 0) {
                 WOLFSSL_MSG("Cert revoked");
                 ret = CRL_CERT_REVOKED;
                 break;

--- a/src/internal.c
+++ b/src/internal.c
@@ -13021,7 +13021,7 @@ int SendCertificateStatus(WOLFSSL* ssl)
 
             #ifdef WOLFSSL_SMALL_STACK
                 cert = (DecodedCert*)XMALLOC(sizeof(DecodedCert), ssl->heap,
-                                             DYNAMIC_TYPE_TMP_DCERT);
+                                             DYNAMIC_TYPE_DCERT);
                 if (cert == NULL)
                     return MEMORY_E;
             #endif

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -197,9 +197,10 @@ int wolfCrypt_Cleanup(void)
 #if !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR)
 
 /* File Handling Helpers */
+/* returns 0 if file found, -1 if no files or negative error */
 int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
 {
-    int ret = 0;
+    int ret = -1; /* default to no files found */
 
     if (name)
         *name = NULL;
@@ -258,9 +259,10 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
     return ret;
 }
 
+/* returns 0 if file found, -1 if no more files */
 int wc_ReadDirNext(ReadDirCtx* ctx, const char* path, char** name)
 {
-    int ret = -1;
+    int ret = -1; /* default to no file found */
 
     if (name)
         *name = NULL;


### PR DESCRIPTION
* Fix for CRL serial number matching to also check length.
* Fix for testing the verify callback override ‘-j’ to not enable CRL since the CA’s are not loaded for this test.
* Fix for `wc_ReadDirFirst` to return non-zero value if no files found.
* Fix for `wolfSSL_CTX_load_verify_locations` to not return failure due to `wc_ReadDirNext` “no more files” -1 response.
* Fix for openssl script test reporting `./scripts/openssl.test: line 219: psk: command not found`.