### PR TITLE
add content-length for http/1.1

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -73,6 +73,7 @@ static const char webServerMsg[] =
     "HTTP/1.1 200 OK\n"
     "Content-Type: text/html\n"
     "Connection: close\n"
+    "Content-length: 133\n"
     "\n"
     "<html>\n"
     "<head>\n"


### PR DESCRIPTION
http 1.1 clients needs to know the content length to know when to disconnect