### PR TITLE
Improvements to TLS v1.3 code

### DIFF
--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -79,6 +79,22 @@ if [ $RESULT -ne 0 ]; then
 fi
 echo ""
 
+# Usual TLS v1.3 server / TLS v1.3 client - fragment.
+echo -e "\n\nTLS v1.3 server with TLS v1.3 client - fragment"
+port=0
+./examples/server/server -v 4 -R $ready_file -p $port &
+server_pid=$!
+create_port
+./examples/client/client -v 4 -F 1 -p $port
+RESULT=$?
+remove_ready_file
+if [ $RESULT -ne 0 ]; then
+    echo -e "\n\nTLS v1.3 and fragments not working"
+    do_cleanup
+    exit 1
+fi
+echo ""
+
 # Use HelloRetryRequest with TLS v1.3 server / TLS v1.3 client.
 echo -e "\n\nTLS v1.3 HelloRetryRequest"
 port=0
@@ -321,6 +337,22 @@ if [ $? -eq 0 ]; then
     fi
     echo ""
 fi
+
+# TLS 1.3 cipher suites server / client.
+echo -e "\n\nTLS v1.3 cipher suite mismatch"
+port=0
+./examples/server/server -v 4 -R $ready_file -p $port -l TLS13-CHACHA20-POLY1305-SHA256 &
+server_pid=$!
+create_port
+./examples/client/client -v 4 -p $port -l TLS13-AES256-GCM-SHA384
+RESULT=$?
+remove_ready_file
+if [ $RESULT -ne 1 ]; then
+    echo -e "\n\nIssue with mismatched TLS v1.3 cipher suites"
+    do_cleanup
+    exit 1
+fi
+echo ""
 
 # TLS 1.3 server / TLS 1.2 client.
 echo -e "\n\nTLS v1.3 server downgrading to TLS v1.2"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4708,12 +4708,14 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
                             ret = RSA_KEY_SIZE_E;
                             WOLFSSL_MSG("Private Key size too small");
                         }
+                        ssl->buffers.keyType = rsa_sa_algo;
                     }
                     else if(ctx) {
                         if (RsaSz < ctx->minRsaKeySz) {
                             ret = RSA_KEY_SIZE_E;
                             WOLFSSL_MSG("Private Key size too small");
                         }
+                        ctx->privateKeyType = rsa_sa_algo;
                     }
                     rsaKey = 1;
                     (void)rsaKey;  /* for no ecc builds */
@@ -4764,9 +4766,11 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
                     eccKey = 1;
                     if (ssl) {
                         ssl->options.haveStaticECC = 1;
+                        ssl->buffers.keyType = ecc_dsa_sa_algo;
                     }
                     else if (ctx) {
                         ctx->haveStaticECC = 1;
+                        ctx->privateKeyType = ecc_dsa_sa_algo;
                     }
 
                     if (ssl && ssl->options.side == WOLFSSL_SERVER_END) {
@@ -4804,6 +4808,7 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
                     WOLFSSL_MSG("ED25519 private key too small");
                     return ECC_KEY_SIZE_E;
                 }
+                ssl->buffers.keyType = ed25519_sa_algo;
             }
             else if (ctx) {
                 if (ED25519_KEY_SIZE < ctx->minEccKeySz) {
@@ -4811,6 +4816,7 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
                     WOLFSSL_MSG("ED25519 private key too small");
                     return ECC_KEY_SIZE_E;
                 }
+                ctx->privateKeyType = ed25519_sa_algo;
             }
 
             wc_ed25519_free(&key);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1502,6 +1502,9 @@ typedef struct Suites {
 } Suites;
 
 
+WOLFSSL_LOCAL void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig,
+                                         int haveRSAsig, int haveAnon,
+                                         int tls1_2);
 WOLFSSL_LOCAL void InitSuites(Suites*, ProtocolVersion, word16, word16, word16, word16,
                               word16, word16, word16, int);
 WOLFSSL_LOCAL int  MatchSuite(WOLFSSL* ssl, Suites* peerSuites);
@@ -2182,6 +2185,7 @@ struct WOLFSSL_CTX {
     int         certChainCnt;
 #endif
     DerBuffer*  privateKey;
+    byte        privateKeyType;
     WOLFSSL_CERT_MANAGER* cm;      /* our cert manager, ctx owns SSL will use */
 #endif
 #ifdef KEEP_OUR_CERT
@@ -2685,6 +2689,7 @@ typedef struct Buffers {
 #ifndef NO_CERTS
     DerBuffer*      certificate;           /* WOLFSSL_CTX owns, unless we own */
     DerBuffer*      key;                   /* WOLFSSL_CTX owns, unless we own */
+    byte            keyType;               /* Type of key: RSA, ECC, Ed25519 */
     DerBuffer*      certChain;             /* WOLFSSL_CTX owns, unless we own */
                  /* chain after self, in DER, with leading size for each cert */
 #ifdef WOLFSSL_TLS13
@@ -3557,6 +3562,9 @@ WOLFSSL_LOCAL void ShrinkInputBuffer(WOLFSSL* ssl, int forcedFree);
 WOLFSSL_LOCAL void ShrinkOutputBuffer(WOLFSSL* ssl);
 
 WOLFSSL_LOCAL int VerifyClientSuite(WOLFSSL* ssl);
+
+WOLFSSL_LOCAL int SetTicket(WOLFSSL*, const byte*, word32);
+
 #ifndef NO_CERTS
     #ifndef NO_RSA
         #ifdef WC_RSA_PSS


### PR DESCRIPTION
Reset list of supported sig algorithms before sending certificate
request on server.
Refactored setting of ticket for both TLS13 and earlier.
Remember the type of key for deciding which sig alg to use with TLS13
CertificateVerify.
RSA PKCS #1.5 not allowed in TLS13 for CertificateVerify.
Remove all remaining DTLS code as spec barely started.
Turn off SHA512 code where decision based on cipher suite hash.
Fix fragment handling to work with encrypted messages.
Test public APIS.