### PR TITLE
Fixes for QAT with DH and HMAC

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -18191,6 +18191,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         ssl->buffers.sig.buffer, &ssl->buffers.sig.length,
                         args->encSecret, &args->encSz);
 
+                    /* set the max agree result size */
                     ssl->arrays->preMasterSz = ENCRYPT_LEN;
                     break;
                 }
@@ -23336,6 +23337,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             ssl->buffers.serverDH_P.length,
                             ssl->buffers.serverDH_G.buffer,
                             ssl->buffers.serverDH_G.length);
+
+                        /* set the max agree result size */
+                        ssl->arrays->preMasterSz = ENCRYPT_LEN;
                         break;
                     }
                 #endif /* !NO_DH */

--- a/src/internal.c
+++ b/src/internal.c
@@ -2673,7 +2673,7 @@ static INLINE void DecodeSigAlg(const byte* input, byte* hashAlgo, byte* hsType)
 
 #if !defined(NO_DH) || defined(HAVE_ECC)
 
-static enum wc_HashType HashType(int hashAlgo)
+static enum wc_HashType HashAlgoToType(int hashAlgo)
 {
     switch (hashAlgo) {
     #ifdef WOLFSSL_SHA512
@@ -17070,7 +17070,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                         DecodeSigAlg(&input[args->idx], &args->hashAlgo,
                                      &args->sigAlgo);
                         args->idx += 2;
-                        hashType = HashType(args->hashAlgo);
+                        hashType = HashAlgoToType(args->hashAlgo);
                         if (hashType == WC_HASH_TYPE_NONE) {
                             ERROR_OUT(ALGO_ID_E, exit_dske);
                         }
@@ -17343,10 +17343,10 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     #ifdef WC_RSA_PSS
                         case rsa_pss_sa_algo:
                             ret = wc_RsaPSS_CheckPadding(
-                                                     ssl->buffers.digest.buffer,
-                                                     ssl->buffers.digest.length,
-                                                     args->output, args->sigSz,
-                                                     HashType(args->hashAlgo));
+                                             ssl->buffers.digest.buffer,
+                                             ssl->buffers.digest.length,
+                                             args->output, args->sigSz,
+                                             HashAlgoToType(args->hashAlgo));
                             if (ret != 0)
                                 return ret;
                             break;
@@ -18190,6 +18190,8 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                     ret = DhGenKeyPair(ssl, ssl->buffers.serverDH_Key,
                         ssl->buffers.sig.buffer, &ssl->buffers.sig.length,
                         args->encSecret, &args->encSz);
+
+                    ssl->arrays->preMasterSz = ENCRYPT_LEN;
                     break;
                 }
             #endif /* !NO_DH */
@@ -20547,7 +20549,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                          &args->output[args->idx]);
                             args->idx += 2;
 
-                            hashType = HashType(ssl->suites->hashAlgo);
+                            hashType = HashAlgoToType(ssl->suites->hashAlgo);
                             if (hashType == WC_HASH_TYPE_NONE) {
                                 ERROR_OUT(ALGO_ID_E, exit_sske);
                             }
@@ -20790,7 +20792,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                          &args->output[args->idx]);
                             args->idx += 2;
 
-                            hashType = HashType(ssl->suites->hashAlgo);
+                            hashType = HashAlgoToType(ssl->suites->hashAlgo);
                             if (hashType == WC_HASH_TYPE_NONE) {
                                 ERROR_OUT(ALGO_ID_E, exit_sske);
                             }
@@ -22385,10 +22387,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             SetDigest(ssl, args->hashAlgo);
 
                             ret = wc_RsaPSS_CheckPadding(
-                                                     ssl->buffers.digest.buffer,
-                                                     ssl->buffers.digest.length,
-                                                     args->output, args->sigSz,
-                                                     HashType(args->hashAlgo));
+                                             ssl->buffers.digest.buffer,
+                                             ssl->buffers.digest.length,
+                                             args->output, args->sigSz,
+                                             HashAlgoToType(args->hashAlgo));
                             if (ret != 0)
                                 return ret;
                         }

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -711,7 +711,7 @@ static void* benchmarks_do(void* args)
         int rngRet;
 
 #ifndef HAVE_FIPS
-        rngRet = wc_InitRng_ex(&rng, HEAP_HINT, INVALID_DEVID);
+        rngRet = wc_InitRng_ex(&rng, HEAP_HINT, devId);
 #else
         rngRet = wc_InitRng(&rng);
 #endif

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -80,7 +80,7 @@ int wolfCrypt_Init(void)
         ret = wolfAsync_HardwareStart();
         if (ret != 0) {
             WOLFSSL_MSG("Async hardware start failed");
-            return ret;
+            /* don't return failure, allow operation to continue */
         }
     #endif
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -4314,7 +4314,6 @@ int aes192_test(void)
         return -4231;
 #endif
 
-
     ret = wc_AesSetKey(&enc, key, (int) sizeof(key), iv, AES_ENCRYPTION);
     if (ret != 0)
         return -4232;
@@ -4344,6 +4343,12 @@ int aes192_test(void)
 
     if (XMEMCMP(cipher, verify, (int) sizeof(cipher)))
         return -4237;
+
+    wc_AesFree(&enc);
+#ifdef HAVE_AES_DECRYPT
+    wc_AesFree(&dec);
+#endif
+
 #endif /* HAVE_AES_CBC */
 
     return ret;
@@ -4394,7 +4399,6 @@ int aes256_test(void)
         return -4241;
 #endif
 
-
     ret = wc_AesSetKey(&enc, key, (int) sizeof(key), iv, AES_ENCRYPTION);
     if (ret != 0)
         return -4242;
@@ -4424,7 +4428,14 @@ int aes256_test(void)
 
     if (XMEMCMP(cipher, verify, (int) sizeof(cipher)))
         return -4247;
+
+    wc_AesFree(&enc);
+#ifdef HAVE_AES_DECRYPT
+    wc_AesFree(&dec);
+#endif
+
 #endif /* HAVE_AES_CBC */
+
     return 0;
 }
 

--- a/wolfssl/wolfcrypt/hmac.h
+++ b/wolfssl/wolfcrypt/hmac.h
@@ -157,8 +157,7 @@ typedef struct Hmac {
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
-    byte         keyRaw[HMAC_BLOCK_SIZE];
-    word16       keyLen;          /* hmac key length */
+    word16       keyLen;          /* hmac key length (key in ipad) */
     #ifdef HAVE_CAVIUM
         byte*    data;            /* buffered input data for one call */
         word16   dataLen;


### PR DESCRIPTION
* Fix issue with QAT and HMAC operations where key size is larger than block size.
* Fix issue with DhAgree in TLS not setting agreeSz, which caused result to not be returned.
* Renamed the internal.c HashType to HashAlgoToType static function because of name conflict with Cavium.
* Optimize the Hmac struct to remove keyRaw and use ipad, since its not used in async case.
* Enable RNG HW for benchmark.
* Fixed missing AES free in AES 192/256 tests.