### PR TITLE
Changes for Nginx

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -644,9 +644,15 @@ static void Usage(void)
     printf("-?          Help, print this usage\n");
     printf("-h <host>   Host to connect to, default %s\n", wolfSSLIP);
     printf("-p <num>    Port to connect on, not 0, default %d\n", wolfSSLPort);
+#ifndef WOLFSSL_TLS13
     printf("-v <num>    SSL version [0-3], SSLv3(0) - TLS1.2(3)), default %d\n",
                                  CLIENT_DEFAULT_VERSION);
     printf("-V          Prints valid ssl version numbers, SSLv3(0) - TLS1.2(3)\n");
+#else
+    printf("-v <num>    SSL version [0-4], SSLv3(0) - TLS1.3(4)), default %d\n",
+                                 CLIENT_DEFAULT_VERSION);
+    printf("-V          Prints valid ssl version numbers, SSLv3(0) - TLS1.3(4)\n");
+#endif
     printf("-l <str>    Cipher suite list (: delimited)\n");
     printf("-c <file>   Certificate file,           default %s\n", cliCertFile);
     printf("-k <file>   Key file,                   default %s\n", cliKeyFile);

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -339,8 +339,13 @@ static void Usage(void)
            " NOTE: All files relative to wolfSSL home dir\n");
     printf("-?          Help, print this usage\n");
     printf("-p <num>    Port to listen on, not 0, default %d\n", yasslPort);
+#ifndef WOLFSSL_TLS13
     printf("-v <num>    SSL version [0-3], SSLv3(0) - TLS1.2(3)), default %d\n",
                                  SERVER_DEFAULT_VERSION);
+#else
+    printf("-v <num>    SSL version [0-4], SSLv3(0) - TLS1.3(4)), default %d\n",
+                                 SERVER_DEFAULT_VERSION);
+#endif
     printf("-l <str>    Cipher suite list (: delimited)\n");
     printf("-c <file>   Certificate file,           default %s\n", svrCertFile);
     printf("-k <file>   Key file,                   default %s\n", svrKeyFile);

--- a/src/keys.c
+++ b/src/keys.c
@@ -2900,6 +2900,7 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
 
     switch (side) {
         case ENCRYPT_SIDE_ONLY:
+#ifdef WOLFSSL_DEBUG_TLS
             WOLFSSL_MSG("Provisioning ENCRYPT key");
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_BUFFER(ssl->keys.client_write_key, AES_256_KEY_SIZE);
@@ -2907,10 +2908,12 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
             else {
                 WOLFSSL_BUFFER(ssl->keys.server_write_key, AES_256_KEY_SIZE);
             }
+#endif
             wc_encrypt = &ssl->encrypt;
             break;
 
         case DECRYPT_SIDE_ONLY:
+#ifdef WOLFSSL_DEBUG_TLS
             WOLFSSL_MSG("Provisioning DECRYPT key");
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_BUFFER(ssl->keys.server_write_key, AES_256_KEY_SIZE);
@@ -2918,10 +2921,12 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
             else {
                 WOLFSSL_BUFFER(ssl->keys.client_write_key, AES_256_KEY_SIZE);
             }
+#endif
             wc_decrypt = &ssl->decrypt;
             break;
 
         case ENCRYPT_AND_DECRYPT_SIDE:
+#ifdef WOLFSSL_DEBUG_TLS
             WOLFSSL_MSG("Provisioning ENCRYPT key");
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 WOLFSSL_BUFFER(ssl->keys.client_write_key, AES_256_KEY_SIZE);
@@ -2936,6 +2941,7 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
             else {
                 WOLFSSL_BUFFER(ssl->keys.client_write_key, AES_256_KEY_SIZE);
             }
+#endif
             wc_encrypt = &ssl->encrypt;
             wc_decrypt = &ssl->decrypt;
             break;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -380,6 +380,11 @@ void wolfSSL_free(WOLFSSL* ssl)
 }
 
 
+int wolfSSL_is_server(WOLFSSL* ssl)
+{
+    return ssl->options.side == WOLFSSL_SERVER_END;
+}
+
 #ifdef HAVE_WRITE_DUP
 
 /*
@@ -1182,6 +1187,7 @@ int wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
 {
     word16 havePSK = 0;
     word16 haveRSA = 1;
+    int    keySz   = 0;
 
     WOLFSSL_ENTER("wolfSSL_SetTmpDH");
     if (ssl == NULL || p == NULL || g == NULL) return BAD_FUNC_ARG;
@@ -1228,10 +1234,13 @@ int wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
     #ifdef NO_RSA
         haveRSA = 0;
     #endif
-    InitSuites(ssl->suites, ssl->version, haveRSA, havePSK, ssl->options.haveDH,
-               ssl->options.haveNTRU, ssl->options.haveECDSAsig,
-               ssl->options.haveECC, ssl->options.haveStaticECC,
-               ssl->options.side);
+    #ifndef NO_CERTS
+        keySz = ssl->buffers.keySz;
+    #endif
+    InitSuites(ssl->suites, ssl->version, keySz, haveRSA, havePSK,
+               ssl->options.haveDH, ssl->options.haveNTRU,
+               ssl->options.haveECDSAsig, ssl->options.haveECC,
+               ssl->options.haveStaticECC, ssl->options.side);
 
     WOLFSSL_LEAVE("wolfSSL_SetTmpDH", 0);
     return SSL_SUCCESS;
@@ -3218,6 +3227,7 @@ int wolfSSL_SetVersion(WOLFSSL* ssl, int version)
 {
     word16 haveRSA = 1;
     word16 havePSK = 0;
+    int    keySz   = 0;
 
     WOLFSSL_ENTER("wolfSSL_SetVersion");
 
@@ -3259,11 +3269,14 @@ int wolfSSL_SetVersion(WOLFSSL* ssl, int version)
     #ifndef NO_PSK
         havePSK = ssl->options.havePSK;
     #endif
+    #ifndef NO_CERTS
+        keySz = ssl->buffers.keySz;
+    #endif
 
-    InitSuites(ssl->suites, ssl->version, haveRSA, havePSK, ssl->options.haveDH,
-                ssl->options.haveNTRU, ssl->options.haveECDSAsig,
-                ssl->options.haveECC, ssl->options.haveStaticECC,
-                ssl->options.side);
+    InitSuites(ssl->suites, ssl->version, keySz, haveRSA, havePSK,
+               ssl->options.haveDH, ssl->options.haveNTRU,
+               ssl->options.haveECDSAsig, ssl->options.haveECC,
+               ssl->options.haveStaticECC, ssl->options.side);
 
     return SSL_SUCCESS;
 }
@@ -4701,21 +4714,27 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
                 #endif
                 } else {
                     /* check that the size of the RSA key is enough */
-                    int RsaSz = wc_RsaEncryptSize((RsaKey*)key);
+                    int rsaSz = wc_RsaEncryptSize((RsaKey*)key);
 
                     if (ssl) {
-                        if (RsaSz < ssl->options.minRsaKeySz) {
+                        if (rsaSz < ssl->options.minRsaKeySz) {
                             ret = RSA_KEY_SIZE_E;
                             WOLFSSL_MSG("Private Key size too small");
                         }
                         ssl->buffers.keyType = rsa_sa_algo;
+                    #ifdef WC_RSA_PSS
+                        ssl->buffers.keySz = rsaSz;
+                    #endif
                     }
                     else if(ctx) {
-                        if (RsaSz < ctx->minRsaKeySz) {
+                        if (rsaSz < ctx->minRsaKeySz) {
                             ret = RSA_KEY_SIZE_E;
                             WOLFSSL_MSG("Private Key size too small");
                         }
                         ctx->privateKeyType = rsa_sa_algo;
+                    #ifdef WC_RSA_PSS
+                        ctx->privateKeySz = rsaSz;
+                    #endif
                     }
                     rsaKey = 1;
                     (void)rsaKey;  /* for no ecc builds */
@@ -5009,8 +5028,8 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
         #endif
 
         /* let's reset suites */
-        InitSuites(ssl->suites, ssl->version, haveRSA, havePSK,
-                   ssl->options.haveDH, ssl->options.haveNTRU,
+        InitSuites(ssl->suites, ssl->version, ssl->buffers.keySz, haveRSA,
+                   havePSK, ssl->options.haveDH, ssl->options.haveNTRU,
                    ssl->options.haveECDSAsig, ssl->options.haveECC,
                    ssl->options.haveStaticECC, ssl->options.side);
     }
@@ -6257,7 +6276,11 @@ long wolfSSL_get_verify_depth(WOLFSSL* ssl)
     if(ssl == NULL) {
         return BAD_FUNC_ARG;
     }
+#ifndef WOLFSSL_NGINX
     return MAX_CHAIN_DEPTH;
+#else
+    return ssl->options.verifyDepth;
+#endif
 }
 
 
@@ -6267,7 +6290,11 @@ long wolfSSL_CTX_get_verify_depth(WOLFSSL_CTX* ctx)
     if(ctx == NULL) {
         return BAD_FUNC_ARG;
     }
+#ifndef WOLFSSL_NGINX
     return MAX_CHAIN_DEPTH;
+#else
+    return ctx->verifyDepth;
+#endif
 }
 
 
@@ -10103,6 +10130,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     void wolfSSL_set_psk_client_callback(WOLFSSL* ssl,wc_psk_client_callback cb)
     {
         byte haveRSA = 1;
+        int  keySz   = 0;
 
         WOLFSSL_ENTER("SSL_set_psk_client_callback");
         ssl->options.havePSK = 1;
@@ -10111,7 +10139,10 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         #ifdef NO_RSA
             haveRSA = 0;
         #endif
-        InitSuites(ssl->suites, ssl->version, haveRSA, TRUE,
+        #ifndef NO_CERTS
+            keySz = ssl->buffers.keySz;
+        #endif
+        InitSuites(ssl->suites, ssl->version, keySz, haveRSA, TRUE,
                    ssl->options.haveDH, ssl->options.haveNTRU,
                    ssl->options.haveECDSAsig, ssl->options.haveECC,
                    ssl->options.haveStaticECC, ssl->options.side);
@@ -10130,6 +10161,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     void wolfSSL_set_psk_server_callback(WOLFSSL* ssl,wc_psk_server_callback cb)
     {
         byte haveRSA = 1;
+        int  keySz   = 0;
 
         WOLFSSL_ENTER("SSL_set_psk_server_callback");
         ssl->options.havePSK = 1;
@@ -10138,7 +10170,10 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         #ifdef NO_RSA
             haveRSA = 0;
         #endif
-        InitSuites(ssl->suites, ssl->version, haveRSA, TRUE,
+        #ifndef NO_CERTS
+            keySz = ssl->buffers.keySz;
+        #endif
+        InitSuites(ssl->suites, ssl->version, keySz, haveRSA, TRUE,
                    ssl->options.haveDH, ssl->options.haveNTRU,
                    ssl->options.haveECDSAsig, ssl->options.haveECC,
                    ssl->options.haveStaticECC, ssl->options.side);
@@ -10686,8 +10721,8 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         #ifndef NO_PSK
             havePSK = ssl->options.havePSK;
         #endif
-        InitSuites(ssl->suites, ssl->version, haveRSA, havePSK,
-                   ssl->options.haveDH, ssl->options.haveNTRU,
+        InitSuites(ssl->suites, ssl->version, ssl->buffers.keySz, haveRSA,
+                   havePSK, ssl->options.haveDH, ssl->options.haveNTRU,
                    ssl->options.haveECDSAsig, ssl->options.haveECC,
                    ssl->options.haveStaticECC, ssl->options.side);
     }
@@ -14328,8 +14363,8 @@ void wolfSSL_set_connect_state(WOLFSSL* ssl)
         #ifndef NO_PSK
             havePSK = ssl->options.havePSK;
         #endif
-        InitSuites(ssl->suites, ssl->version, haveRSA, havePSK,
-                   ssl->options.haveDH, ssl->options.haveNTRU,
+        InitSuites(ssl->suites, ssl->version, ssl->buffers.keySz, haveRSA,
+                   havePSK, ssl->options.haveDH, ssl->options.haveNTRU,
                    ssl->options.haveECDSAsig, ssl->options.haveECC,
                    ssl->options.haveStaticECC, ssl->options.side);
     }
@@ -15929,6 +15964,12 @@ unsigned long wolfSSL_set_options(WOLFSSL* ssl, unsigned long op)
         WOLFSSL_MSG("\tSSL_OP_NO_SSLv2 : wolfSSL does not support SSLv2");
     }
 
+    if ((ssl->options.mask & SSL_OP_NO_TLSv1_3) == SSL_OP_NO_TLSv1_3) {
+        WOLFSSL_MSG("\tSSL_OP_NO_TLSv1_3");
+        if (ssl->version.minor == TLSv1_3_MINOR)
+            ssl->version.minor = TLSv1_2_MINOR;
+    }
+
     if ((ssl->options.mask & SSL_OP_NO_TLSv1_2) == SSL_OP_NO_TLSv1_2) {
         WOLFSSL_MSG("\tSSL_OP_NO_TLSv1_2");
         if (ssl->version.minor == TLSv1_2_MINOR)
@@ -16472,6 +16513,9 @@ long wolfSSL_CTX_add_extra_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
         idx += OPAQUE24_LEN,
         XMEMCPY(chain + idx, der, derSz);
         idx += derSz;
+#ifdef WOLFSSL_TLS13
+        ctx->certChainCnt++;
+#endif
 
         FreeDer(&ctx->certChain);
         ret = AllocDer(&ctx->certChain, idx, CERT_TYPE, ctx->heap);
@@ -22724,19 +22768,25 @@ void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl)
 
 
     void wolfSSL_CTX_set_verify_depth(WOLFSSL_CTX *ctx, int depth) {
+        WOLFSSL_ENTER("wolfSSL_CTX_set_verify_depth");
+#ifndef WOLFSSL_NGINX
         (void)ctx;
         (void)depth;
-        WOLFSSL_ENTER("wolfSSL_CTX_set_verify_depth");
         WOLFSSL_STUB("wolfSSL_CTX_set_verify_depth");
-
+#else
+        ctx->verifyDepth = depth;
+#endif
     }
 
     void wolfSSL_set_verify_depth(WOLFSSL *ssl, int depth) {
+        WOLFSSL_ENTER("wolfSSL_set_verify_depth");
+#ifndef WOLFSSL_NGINX
         (void)ssl;
         (void)depth;
-        WOLFSSL_ENTER("wolfSSL_set_verify_depth");
         WOLFSSL_STUB("wolfSSL_set_verify_depth");
-
+#else
+        ssl->options.verifyDepth = depth;
+#endif
     }
 
     void* wolfSSL_get_app_data( const WOLFSSL *ssl) {
@@ -24957,6 +25007,32 @@ void wolfSSL_get0_next_proto_negotiated(const WOLFSSL *s, const unsigned char **
     WOLFSSL_STUB("wolfSSL_get0_next_proto_negotiated");
 }
 #endif /* HAVE_ALPN */
+
+WOLFSSL_API int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, char* names)
+{
+    int idx, start = 0;
+    int curve;
+
+    ctx->disabledCurves = (word32)-1;
+    for (idx = 1; names[idx-1] != '\0'; idx++) {
+        if (names[idx] != ':' && names[idx] != '\0')
+            continue;
+
+        if (XSTRNCMP(names, "prime256v1", idx - 1 - start) == 0)
+            curve = WOLFSSL_ECC_SECP256R1;
+        else if (XSTRNCMP(names, "secp384r1", idx - 1 - start) == 0)
+            curve = WOLFSSL_ECC_SECP384R1;
+        else if (XSTRNCMP(names, "X25519", idx - 1 - start) == 0)
+            curve = WOLFSSL_ECC_X25519;
+        else
+            return SSL_FAILURE;
+
+        ctx->disabledCurves ^= 1 << curve;
+        start = idx + 1;
+    }
+
+    return SSL_SUCCESS;
+}
 
 #endif /* WOLFSSL_NGINX  / WOLFSSL_HAPROXY */
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -3016,7 +3016,7 @@ int TLSX_ValidateEllipticCurves(WOLFSSL* ssl, byte first, byte second) {
          curve && !(sig && key);
          curve = curve->next) {
 
-    #ifdef WOLFSSL_NGINX
+    #ifdef OPENSSL_EXTRA
         if (ssl->ctx->disabledCurves & (1 << curve->name))
             continue;
     #endif
@@ -5865,7 +5865,7 @@ int TLSX_KeyShare_Establish(WOLFSSL *ssl)
         if (!TLSX_SupportedGroups_Find(ssl, clientKSE->group))
             return BAD_KEY_SHARE_DATA;
 
-    #ifdef WOLFSSL_NGINX
+    #ifdef OPENSSL_EXTRA
         /* Check if server supports group. */
         if (ssl->ctx->disabledCurves & (1 << clientKSE->group))
             continue;

--- a/src/tls.c
+++ b/src/tls.c
@@ -3016,6 +3016,11 @@ int TLSX_ValidateEllipticCurves(WOLFSSL* ssl, byte first, byte second) {
          curve && !(sig && key);
          curve = curve->next) {
 
+    #ifdef WOLFSSL_NGINX
+        if (ssl->ctx->disabledCurves & (1 << curve->name))
+            continue;
+    #endif
+
         /* find supported curve */
         switch (curve->name) {
     #if defined(HAVE_ECC160) || defined(HAVE_ALL_CURVES)
@@ -5860,7 +5865,11 @@ int TLSX_KeyShare_Establish(WOLFSSL *ssl)
         if (!TLSX_SupportedGroups_Find(ssl, clientKSE->group))
             return BAD_KEY_SHARE_DATA;
 
+    #ifdef WOLFSSL_NGINX
         /* Check if server supports group. */
+        if (ssl->ctx->disabledCurves & (1 << clientKSE->group))
+            continue;
+    #endif
         if (TLSX_KeyShare_IsSupported(clientKSE->group))
             break;
     }
@@ -7761,8 +7770,10 @@ word16 TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType)
         length += TLSX_GetSize(ssl->ctx->extensions, semaphore, msgType);
 
 #ifdef HAVE_EXTENDED_MASTER
-    if (msgType == client_hello && ssl->options.haveEMS)
+    if (msgType == client_hello && ssl->options.haveEMS &&
+                                              !IsAtLeastTLSv1_3(ssl->version)) {
         length += HELLO_EXT_SZ;
+    }
 #endif
 
     if (length)
@@ -7836,7 +7847,8 @@ word16 TLSX_WriteRequest(WOLFSSL* ssl, byte* output, byte msgType)
     }
 
 #ifdef HAVE_EXTENDED_MASTER
-    if (msgType == client_hello && ssl->options.haveEMS) {
+    if (msgType == client_hello && ssl->options.haveEMS &&
+                                              !IsAtLeastTLSv1_3(ssl->version)) {
         c16toa(HELLO_EXT_EXTMS, output + offset);
         offset += HELLO_EXT_TYPE_SZ;
         c16toa(0, output + offset);
@@ -8213,9 +8225,6 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte msgType,
             case TLSX_SUPPORTED_VERSIONS:
                 WOLFSSL_MSG("Supported Versions extension received");
 
-                if (!IsAtLeastTLSv1_3(ssl->version))
-                    break;
-
                 if (IsAtLeastTLSv1_3(ssl->version) &&
                         msgType != client_hello) {
                     return EXT_NOT_ALLOWED;
@@ -8433,7 +8442,7 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte msgType,
         (void)heap;
         if (method) {
 #if !defined(NO_SHA256) || defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)
-#ifdef WOLFSSL_TLS13
+#if defined(WOLFSSL_TLS13) && !defined(WOLFSSL_NGINX)
             InitSSL_Method(method, MakeTLSv1_3());
 #else
             InitSSL_Method(method, MakeTLSv1_2());

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3298,12 +3298,8 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     /* Session id - empty in TLS v1.3 */
     sessIdSz = input[i++];
     if (sessIdSz > 0) {
-        ssl->version.major = pv.major;
-        ssl->version.minor = pv.minor;
-        ret = DoClientHello(ssl, input, inOutIdx, helloSz);
-        if (ret != 0)
-            return ret;
-        return HashInput(ssl, input + begin,  helloSz);
+        WOLFSSL_MSG("Client sent session id - not supported");
+        return BUFFER_ERROR;
     }
 
     /* Cipher suites */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1096,6 +1096,7 @@ enum Misc {
 
     ECDHE_SIZE          = 32,  /* ECHDE server size defaults to 256 bit */
     MAX_EXPORT_ECC_SZ   = 256, /* Export ANS X9.62 max future size */
+    MAX_CURVE_NAME_SZ   = 16,  /* Maximum size of curve name string */
 
     NEW_SA_MAJOR        = 8,   /* Most signicant byte used with new sig algos */
     ED25519_SA_MAJOR    = 8,   /* Most significant byte for ED25519 */
@@ -2244,12 +2245,10 @@ struct WOLFSSL_CTX {
 #if defined(HAVE_ECC) || defined(HAVE_ED25519)
     short       minEccKeySz;      /* minimum ECC key size */
 #endif
-#ifdef WOLFSSL_NGINX
-    word32      disabledCurves;   /* curves disabled by user */
-    byte        verifyDepth;      /* maximum verification depth */
-#endif
 #ifdef OPENSSL_EXTRA
-    unsigned long     mask;       /* store SSL_OP_ flags */
+    word32            disabledCurves;   /* curves disabled by user */
+    byte              verifyDepth;      /* maximum verification depth */
+    unsigned long     mask;             /* store SSL_OP_ flags */
 #endif
     CallbackIORecv CBIORecv;
     CallbackIOSend CBIOSend;
@@ -2871,7 +2870,7 @@ typedef struct Options {
 #if defined(HAVE_ECC) || defined(HAVE_ED25519)
     short           minEccKeySz;      /* minimum ECC key size */
 #endif
-#ifdef WOLFSSL_NGINX
+#ifdef OPENSSL_EXTRA
     byte            verifyDepth;      /* maximum verification depth */
 #endif
 #ifdef WOLFSSL_EARLY_DATA

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -760,6 +760,7 @@ typedef WOLFSSL_ASN1_BIT_STRING    ASN1_BIT_STRING;
 #define ERR_LIB_PEM             9
 
 #ifdef HAVE_SESSION_TICKET
+#define SSL_OP_NO_TICKET                  SSL_OP_NO_TICKET
 #define SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB 72
 #endif
 
@@ -796,6 +797,8 @@ typedef WOLFSSL_ASN1_BIT_STRING    ASN1_BIT_STRING;
 #define SSL_CTX_set_next_protos_advertised_cb wolfSSL_CTX_set_next_protos_advertised_cb
 #define SSL_CTX_set_next_proto_select_cb  wolfSSL_CTX_set_next_proto_select_cb
 #define SSL_get0_next_proto_negotiated    wolfSSL_get0_next_proto_negotiated
+#define SSL_is_server                     wolfSSL_is_server
+#define SSL_CTX_set1_curves_list          wolfSSL_CTX_set1_curves_list
 
 #endif
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -383,6 +383,7 @@ WOLFSSL_API int wolfSSL_use_RSAPrivateKey_file(WOLFSSL*, const char*, int);
 
 WOLFSSL_API WOLFSSL_CTX* wolfSSL_CTX_new(WOLFSSL_METHOD*);
 WOLFSSL_API WOLFSSL* wolfSSL_new(WOLFSSL_CTX*);
+WOLFSSL_API int  wolfSSL_is_server(WOLFSSL*);
 WOLFSSL_API WOLFSSL* wolfSSL_write_dup(WOLFSSL*);
 WOLFSSL_API int  wolfSSL_set_fd (WOLFSSL*, int);
 WOLFSSL_API int  wolfSSL_set_write_fd (WOLFSSL*, int);
@@ -839,6 +840,7 @@ enum {
     SSL_OP_NO_TLSv1_1                             = 0x04000000,
     SSL_OP_NO_TLSv1_2                             = 0x08000000,
     SSL_OP_NO_COMPRESSION                         = 0x10000000,
+    SSL_OP_NO_TLSv1_3                             = 0x20000000,
 };
 
 
@@ -1921,7 +1923,6 @@ enum {
     /* Not implemented. */
     WOLFSSL_ECC_X448      = 30,
 
-    /* Not implemented. */
     WOLFSSL_FFDHE_2048    = 256,
     WOLFSSL_FFDHE_3072    = 257,
     WOLFSSL_FFDHE_4096    = 258,
@@ -2396,6 +2397,8 @@ WOLFSSL_API char* wolfSSL_sk_WOLFSSL_STRING_value(
 
 WOLFSSL_API int PEM_write_bio_WOLFSSL_X509(WOLFSSL_BIO *bio,
     WOLFSSL_X509 *cert);
+
+WOLFSSL_API int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, char* names);
 #endif /* WOLFSSL_NGINX */
 
 WOLFSSL_API void wolfSSL_get0_alpn_selected(const WOLFSSL *ssl,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2318,6 +2318,8 @@ WOLFSSL_API int wolfSSL_CTX_AsyncPoll(WOLFSSL_CTX* ctx, WOLF_EVENT** events, int
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
 #ifdef OPENSSL_EXTRA
+WOLFSSL_API int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, char* names);
+
 typedef void (*SSL_Msg_Cb)(int write_p, int version, int content_type,
     const void *buf, size_t len, WOLFSSL *ssl, void *arg);
 
@@ -2398,7 +2400,6 @@ WOLFSSL_API char* wolfSSL_sk_WOLFSSL_STRING_value(
 WOLFSSL_API int PEM_write_bio_WOLFSSL_X509(WOLFSSL_BIO *bio,
     WOLFSSL_X509 *cert);
 
-WOLFSSL_API int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, char* names);
 #endif /* WOLFSSL_NGINX */
 
 WOLFSSL_API void wolfSSL_get0_alpn_selected(const WOLFSSL *ssl,


### PR DESCRIPTION
Support TLS v1.3 clients connecting to Nginx.
Fix for PSS to not advertise hash unless the signature fits the private
key size.
Allow curves to be chosen by user.
Support maximum verification depth (maximum number of untrusted certs in
chain.)
Add support for SSL_is_server() API.
Fix number of certificates in chain when using
wolfSSL_CTX_add_extra_chain_cert().
Allow TLS v1.2 client hello parsing to call TLS v1.3 parsing when
SupportedVersions extension seen.
Minor fixes.