### PR TITLE
Update MQX Classic, mmCAU Ports

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -32,7 +32,8 @@
 /* Macro to disable benchmark */
 #ifndef NO_CRYPT_BENCHMARK
 
-#ifdef XMALLOC_USER
+#if defined(XMALLOC_USER) || defined(FREESCALE_MQX)
+    /* MQX classic needs for EXIT_FAILURE */
     #include <stdlib.h>  /* we're using malloc / free direct here */
 #endif
 

--- a/wolfcrypt/src/des3.c
+++ b/wolfcrypt/src/des3.c
@@ -750,7 +750,11 @@
      * Documentation located in ColdFire/ColdFire+ CAU and Kinetis mmCAU
      * Software Library User Guide (See note in README).
      */
-    #include "fsl_mmcau.h"
+    #ifdef FREESCALE_MMCAU_CLASSIC
+        #include "cau_api.h"
+    #else
+        #include "fsl_mmcau.h"
+    #endif
 
     const unsigned char parityLookup[128] = {
         1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,
@@ -815,6 +819,13 @@
 
         iv = (byte*)des->reg;
 
+    #ifdef FREESCALE_MMCAU_CLASSIC
+        if ((wolfssl_word)out % WOLFSSL_MMCAU_ALIGNMENT) {
+            WOLFSSL_MSG("Bad cau_des_encrypt alignment");
+            return BAD_ALIGN_E;
+        }
+    #endif
+
         while (len > 0)
         {
             XMEMCPY(temp_block, in + offset, DES_BLOCK_SIZE);
@@ -827,7 +838,11 @@
             if(ret != 0) {
                 return ret;
             }
+        #ifdef FREESCALE_MMCAU_CLASSIC
+            cau_des_encrypt(temp_block, (byte*)des->key, out + offset);
+        #else
             MMCAU_DES_EncryptEcb(temp_block, (byte*)des->key, out + offset);
+        #endif
             wolfSSL_CryptHwMutexUnLock();
 
             len    -= DES_BLOCK_SIZE;
@@ -851,6 +866,13 @@
 
         iv = (byte*)des->reg;
 
+    #ifdef FREESCALE_MMCAU_CLASSIC
+        if ((wolfssl_word)out % WOLFSSL_MMCAU_ALIGNMENT) {
+            WOLFSSL_MSG("Bad cau_des_decrypt alignment");
+            return BAD_ALIGN_E;
+        }
+    #endif
+
         while (len > 0)
         {
             XMEMCPY(temp_block, in + offset, DES_BLOCK_SIZE);
@@ -859,7 +881,12 @@
             if(ret != 0) {
                 return ret;
             }
+
+        #ifdef FREESCALE_MMCAU_CLASSIC
+            cau_des_decrypt(in + offset, (byte*)des->key, out + offset);
+        #else
             MMCAU_DES_DecryptEcb(in + offset, (byte*)des->key, out + offset);
+        #endif
             wolfSSL_CryptHwMutexUnLock();
 
             /* XOR block with IV for CBC */
@@ -888,6 +915,13 @@
 
         iv = (byte*)des->reg;
 
+    #ifdef FREESCALE_MMCAU_CLASSIC
+        if ((wolfssl_word)out % WOLFSSL_MMCAU_ALIGNMENT) {
+            WOLFSSL_MSG("Bad 3ede cau_des_encrypt alignment");
+            return BAD_ALIGN_E;
+        }
+    #endif
+
         while (len > 0)
         {
             XMEMCPY(temp_block, in + offset, DES_BLOCK_SIZE);
@@ -900,9 +934,15 @@
             if(ret != 0) {
                 return ret;
             }
+    #ifdef FREESCALE_MMCAU_CLASSIC
+            cau_des_encrypt(temp_block,   (byte*)des->key[0], out + offset);
+            cau_des_decrypt(out + offset, (byte*)des->key[1], out + offset);
+            cau_des_encrypt(out + offset, (byte*)des->key[2], out + offset);
+    #else
             MMCAU_DES_EncryptEcb(temp_block  , (byte*)des->key[0], out + offset);
             MMCAU_DES_DecryptEcb(out + offset, (byte*)des->key[1], out + offset);
             MMCAU_DES_EncryptEcb(out + offset, (byte*)des->key[2], out + offset);
+    #endif
             wolfSSL_CryptHwMutexUnLock();
 
             len    -= DES_BLOCK_SIZE;
@@ -927,6 +967,13 @@
 
         iv = (byte*)des->reg;
 
+    #ifdef FREESCALE_MMCAU_CLASSIC
+        if ((wolfssl_word)out % WOLFSSL_MMCAU_ALIGNMENT) {
+            WOLFSSL_MSG("Bad 3ede cau_des_decrypt alignment");
+            return BAD_ALIGN_E;
+        }
+    #endif
+
         while (len > 0)
         {
             XMEMCPY(temp_block, in + offset, DES_BLOCK_SIZE);
@@ -935,9 +982,15 @@
             if(ret != 0) {
                 return ret;
             }
+        #ifdef FREESCALE_MMCAU_CLASSIC
+            cau_des_decrypt(in + offset,  (byte*)des->key[2], out + offset);
+            cau_des_encrypt(out + offset, (byte*)des->key[1], out + offset);
+            cau_des_decrypt(out + offset, (byte*)des->key[0], out + offset);
+        #else
             MMCAU_DES_DecryptEcb(in + offset , (byte*)des->key[2], out + offset);
             MMCAU_DES_EncryptEcb(out + offset, (byte*)des->key[1], out + offset);
             MMCAU_DES_DecryptEcb(out + offset, (byte*)des->key[0], out + offset);
+        #endif
             wolfSSL_CryptHwMutexUnLock();
 
             /* XOR block with IV for CBC */

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -149,6 +149,8 @@ static void wolfssl_log(const int logLevel, const char *const logMessage)
 #elif defined(WOLFSSL_UTASKER)
             fnDebugMsg((char*)logMessage);
             fnDebugMsg("\r\n");
+#elif defined(MQX_USE_IO_OLD)
+            fprintf(_mqxio_stderr, "%s\n", logMessage);
 #else
             fprintf(stderr, "%s\n", logMessage);
 #endif

--- a/wolfcrypt/src/md5.c
+++ b/wolfcrypt/src/md5.c
@@ -174,7 +174,11 @@
     {
         int ret = wolfSSL_CryptHwMutexLock();
         if(ret == 0) {
+        #ifdef FREESCALE_MMCAU_CLASSIC_SHA
+            cau_md5_hash_n(data, 1, (unsigned char*)md5->digest);
+        #else
             MMCAU_MD5_HashN(data, 1, (uint32_t*)md5->digest);
+        #endif
             wolfSSL_CryptHwMutexUnLock();
         }
         return ret;

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -886,6 +886,9 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                 case WC_PKCS12_ShroudedKeyBag: /* 668 */
                     {
                         byte* k;
+                #ifdef FREESCALE_MQX
+                        byte* tmp;
+                #endif
                         WOLFSSL_MSG("PKCS12 Shrouded Key Bag found");
                         if (data[idx++] !=
                                      (ASN_CONSTRUCTED | ASN_CONTEXT_SPECIFIC)) {
@@ -911,11 +914,24 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
 
                         if (ret < size) {
                             /* shrink key buffer */
+                        #ifdef FREESCALE_MQX
+                            /* MQX classic has no realloc */
+                            tmp = (byte*)XMALLOC(ret, pkcs12->heap,
+                                                 DYNAMIC_TYPE_PUBLIC_KEY);
+                            if (tmp == NULL) {
+                                XFREE(k, pkcs12->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+                                ERROR_OUT(MEMORY_E, exit_pk12par);
+                            }
+                            XMEMCPY(tmp, k, ret);
+                            XFREE(k, pkcs12->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+                            k = tmp;
+                        #else
                             k = (byte*)XREALLOC(k, ret, pkcs12->heap,
                                                        DYNAMIC_TYPE_PUBLIC_KEY);
                             if (k == NULL) {
                                 ERROR_OUT(MEMORY_E, exit_pk12par);
                             }
+                        #endif
                         }
                         size = ret;
 

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -78,7 +78,7 @@ WOLFSSL_API int wolfSSL_BN_is_prime_ex(const WOLFSSL_BIGNUM*, int,
                                        WOLFSSL_BN_CTX*, WOLFSSL_BN_GENCB*);
 WOLFSSL_API WOLFSSL_BN_ULONG wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM*,
                                                  WOLFSSL_BN_ULONG);
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
     WOLFSSL_API int wolfSSL_BN_print_fp(FILE*, const WOLFSSL_BIGNUM*);
 #endif
 WOLFSSL_API int wolfSSL_BN_rshift(WOLFSSL_BIGNUM*, const WOLFSSL_BIGNUM*, int);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -686,6 +686,7 @@ extern void uITRON4_free(void *p) ;
         #include "mfs.h"
         #if MQX_USE_IO_OLD
             #include "fio.h"
+            #define NO_STDIO_FILESYSTEM
         #else
             #include "nio.h"
         #endif
@@ -694,6 +695,7 @@ extern void uITRON4_free(void *p) ;
         #include "mutex.h"
     #endif
 
+    #define XMALLOC_OVERRIDE
     #define XMALLOC(s, h, t)    (void *)_mem_alloc_system((s))
     #define XFREE(p, h, t)      {void* xp = (p); if ((xp)) _mem_free((xp));}
     /* Note: MQX has no realloc, using fastmath above */
@@ -804,7 +806,8 @@ extern void uITRON4_free(void *p) ;
 
     #ifdef FREESCALE_KSDK_1_3
         #include "fsl_device_registers.h"
-    #else
+    #elif !defined(FREESCALE_MQX)
+        /* Classic MQX does not have fsl_common.h */
         #include "fsl_common.h"
     #endif
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -852,6 +852,14 @@ extern void uITRON4_free(void *p) ;
     #endif
 #endif /* FREESCALE_COMMON */
 
+/* Classic pre-KSDK mmCAU library */
+#ifdef FREESCALE_USE_MMCAU_CLASSIC
+    #define FREESCALE_USE_MMCAU
+    #define FREESCALE_MMCAU_CLASSIC
+    #define FREESCALE_MMCAU_CLASSIC_SHA
+#endif
+
+/* KSDK mmCAU library */
 #ifdef FREESCALE_USE_MMCAU
     /* AES and DES */
     #define FREESCALE_MMCAU
@@ -1279,9 +1287,14 @@ extern void uITRON4_free(void *p) ;
 #endif /* WOLFSSL_SGX */
 
 /* FreeScale MMCAU hardware crypto has 4 byte alignment.
-   However, fsl_mmcau.h gives API with no alignment requirements (4 byte alignment is managed internally by fsl_mmcau.c) */
+   However, KSDK fsl_mmcau.h gives API with no alignment
+   requirements (4 byte alignment is managed internally by fsl_mmcau.c) */
 #ifdef FREESCALE_MMCAU
-    #define WOLFSSL_MMCAU_ALIGNMENT 0
+    #ifdef FREESCALE_MMCAU_CLASSIC
+        #define WOLFSSL_MMCAU_ALIGNMENT 4
+    #else
+        #define WOLFSSL_MMCAU_ALIGNMENT 0
+    #endif
 #endif
 
 /* if using hardware crypto and have alignment requirements, specify the
@@ -1292,7 +1305,7 @@ extern void uITRON4_free(void *p) ;
         #define WOLFSSL_GENERAL_ALIGNMENT 16
     #elif defined(XSTREAM_ALIGN)
         #define WOLFSSL_GENERAL_ALIGNMENT  4
-    #elif defined(FREESCALE_MMCAU)
+    #elif defined(FREESCALE_MMCAU) || defined(FREESCALE_MMCAU_CLASSIC)
         #define WOLFSSL_GENERAL_ALIGNMENT  WOLFSSL_MMCAU_ALIGNMENT
     #else
         #define WOLFSSL_GENERAL_ALIGNMENT  0

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -24,6 +24,7 @@
 #ifndef WOLF_CRYPT_PORT_H
 #define WOLF_CRYPT_PORT_H
 
+#include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/visibility.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR:

1. Updates MQX Classic build (FREESCALE_MQX).  This is for use when MQX is not used with KSDK.  Was updated for MQX 4.2.

2. Restores classic mmCAU library API for users not using the v2.0 mmCAU library API.

3. Includes settings.h in wc_port.h, so that preprocessor defines in <user_settings.h> can be picked up.