### PR TITLE
Make LowResTimer() use XTIME if USER_TIME is defined

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -5431,7 +5431,7 @@ ProtocolVersion MakeDTLSv1_2(void)
     }
 #endif
 
-#elif defined(TIME_OVERRIDES)
+#elif defined(TIME_OVERRIDES) || defined(USER_TIME)
 
     /* use same asn time overrides unless user wants tick override above */
 


### PR DESCRIPTION
In `internal.c`, LowResTimer() is like below if USER_TIME is enable.
```c
/* Posix style time */
#include <time.h>

word32 LowResTimer(void)
{
    return (word32)time(0);
}
```
However, `time.h` is probably unavailable when developers want to define USER_TIME and XTIME. In addition, the below is TIME_OVERRIDES version of LowResTimer().
```c
#ifndef HAVE_TIME_T_TYPE
    typedef long time_t;
#endif
extern time_t XTIME(time_t * timer);

word32 LowResTimer(void)
{
    return (word32) XTIME(0);
}
```
This definition should be also used if USER_TIME is enable.
