### PR TITLE
Fixes for using async with max fragment

### DIFF
--- a/tests/test.conf
+++ b/tests/test.conf
@@ -2199,3 +2199,10 @@
 -v 3
 -d
 
+# server TLSv1.2 with fragment
+-v 3
+
+# client TLSv1.2 with fragment
+-v 3
+-F 1
+


### PR DESCRIPTION
Fixes for using async with `HAVE_MAX_FRAGMENT` or `--enable-maxfragment` which affected TLS 1.2/1.3. Added TLS 1.2 test for using max fragment.