### PR TITLE
Fix problem with async TLS 1.3 and raw AES encryption key change

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -2049,8 +2049,8 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_AES)
         if (aes->asyncDev.marker == WOLFSSL_ASYNC_MARKER_AES) {
-            aes->asyncKey = userKey;
-            aes->asyncIv = iv;
+            XMEMCPY(aes->asyncKey, userKey, keylen);
+            XMEMCPY(aes->asyncIv, iv, AES_BLOCK_SIZE);
         }
     #endif /* WOLFSSL_ASYNC_CRYPT */
 
@@ -2809,7 +2809,8 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
             return NitroxAesCbcEncrypt(aes, out, in, sz);
         #elif defined(HAVE_INTEL_QA)
             return IntelQaSymAesCbcEncrypt(&aes->asyncDev, out, in, sz,
-                aes->asyncKey, aes->keylen, aes->asyncIv, AES_BLOCK_SIZE);
+                (const byte*)aes->asyncKey, aes->keylen,
+                (const byte*)aes->asyncIv, AES_BLOCK_SIZE);
         #else /* WOLFSSL_ASYNC_CRYPT_TEST */
             WC_ASYNC_TEST* testDev = &aes->asyncDev.test;
             if (testDev->type == ASYNC_TEST_NONE) {
@@ -2894,7 +2895,8 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
             return NitroxAesCbcDecrypt(aes, out, in, sz);
         #elif defined(HAVE_INTEL_QA)
             return IntelQaSymAesCbcDecrypt(&aes->asyncDev, out, in, sz,
-                aes->asyncKey, aes->keylen, aes->asyncIv, AES_BLOCK_SIZE);
+                (const byte*)aes->asyncKey, aes->keylen,
+                (const byte*)aes->asyncIv, AES_BLOCK_SIZE);
         #else /* WOLFSSL_ASYNC_CRYPT_TEST */
             WC_ASYNC_TEST* testDev = &aes->asyncDev.test;
             if (testDev->type == ASYNC_TEST_NONE) {
@@ -4501,7 +4503,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
         /* Not yet supported, contact wolfSSL if interested in using */
     #elif defined(HAVE_INTEL_QA)
         return IntelQaSymAesGcmEncrypt(&aes->asyncDev, out, in, sz,
-            aes->asyncKey, aes->keylen, iv, ivSz,
+            (const byte*)aes->asyncKey, aes->keylen, iv, ivSz,
             authTag, authTagSz, authIn, authInSz);
     #else /* WOLFSSL_ASYNC_CRYPT_TEST */
         WC_ASYNC_TEST* testDev = &aes->asyncDev.test;
@@ -4754,7 +4756,7 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
         /* Not yet supported, contact wolfSSL if interested in using */
     #elif defined(HAVE_INTEL_QA)
         return IntelQaSymAesGcmDecrypt(&aes->asyncDev, out, in, sz,
-            aes->asyncKey, aes->keylen, iv, ivSz,
+            (const byte*)aes->asyncKey, aes->keylen, iv, ivSz,
             authTag, authTagSz, authIn, authInSz);
     #else /* WOLFSSL_ASYNC_CRYPT_TEST */
         WC_ASYNC_TEST* testDev = &aes->asyncDev.test;

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -89,8 +89,8 @@ typedef struct Aes {
     byte use_aesni;
 #endif /* WOLFSSL_AESNI */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    const byte* asyncKey;
-    const byte* asyncIv;
+    word32 asyncKey[AES_MAX_KEY_SIZE/8/sizeof(word32)]; /* raw key */
+    word32 asyncIv[AES_BLOCK_SIZE/sizeof(word32)]; /* raw IV */
     WC_ASYNC_DEV asyncDev;
 #endif /* WOLFSSL_ASYNC_CRYPT */
 #ifdef WOLFSSL_AES_COUNTER


### PR DESCRIPTION
Fix problem with async TLS 1.3 where encryption key is referenced into ssl->keys and changes before it should be used. Solution is to make raw copy of key and IV for async AES.