### PR TITLE
Riot os portability and minor design modifications

### DIFF
--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -329,7 +329,7 @@ void wc_ReadDirClose(ReadDirCtx* ctx)
 #endif /* !NO_FILESYSTEM && !NO_WOLFSSL_DIR */
 
 
-wolfSSL_Mutex* wc_InitAndAllocMutex()
+wolfSSL_Mutex* wc_InitAndAllocMutex(void)
 {
     wolfSSL_Mutex* m = (wolfSSL_Mutex*) XMALLOC(sizeof(wolfSSL_Mutex), NULL,
             DYNAMIC_TYPE_MUTEX);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1098,7 +1098,7 @@ int asn_test(void)
 #endif
 
 #ifdef WOLFSSL_MD2
-int md2_test()
+int md2_test(void)
 {
     Md2  md2;
     byte hash[MD2_DIGEST_SIZE];
@@ -13432,7 +13432,7 @@ static int randNum(mp_int* n, int len, WC_RNG* rng, void* heap)
 }
 #endif
 
-int mp_test()
+int mp_test(void)
 {
     WC_RNG rng;
     int    ret;
@@ -13577,7 +13577,7 @@ static void my_Logging_cb(const int logLevel, const char *const logMessage)
 }
 #endif
 
-int logging_test()
+int logging_test(void)
 {
 #ifdef DEBUG_WOLFSSL
     const char* msg = "Testing, testing. 1, 2, 3, 4 ...";

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -908,7 +908,7 @@ int wolfcrypt_test(void* args)
 #endif /* NO_MAIN_DRIVER */
 
 
-int error_test()
+int error_test(void)
 {
     const char* errStr;
     char        out[WOLFSSL_MAX_ERROR_SZ];
@@ -971,7 +971,7 @@ int error_test()
 }
 
 #if !defined(NO_CODING) && defined(WOLFSSL_BASE64_ENCODE)
-int base64_test()
+int base64_test(void)
 {
     int        ret;
     const byte good[] = "A+Gd\0\0\0";
@@ -1068,7 +1068,7 @@ int base64_test()
 #endif
 
 #ifndef NO_ASN
-int asn_test()
+int asn_test(void)
 {
 #ifndef NO_ASN_TIME
     #ifdef WORD64_AVAILABLE
@@ -11234,7 +11234,7 @@ done:
 #endif /* HAVE_ECC_ENCRYPT */
 
 #ifdef USE_CERT_BUFFERS_256
-int ecc_test_buffers() {
+int ecc_test_buffers(void) {
     size_t bytes;
     ecc_key cliKey;
     ecc_key servKey;
@@ -13633,7 +13633,7 @@ int logging_test()
 }
 #endif
 
-int mutex_test()
+int mutex_test(void)
 {
 #ifdef WOLFSSL_PTHREADS
     wolfSSL_Mutex m;
@@ -13685,7 +13685,7 @@ static void *my_Realloc_cb(void *ptr, size_t size)
     return realloc(ptr, size);
 }
 
-int memcb_test()
+int memcb_test(void)
 {
     int ret = 0;
     byte* b = NULL;

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -415,9 +415,8 @@
     #define NO_WRITEV
     #define TFM_NO_ASM
     #define USE_FAST_MATH
-    #define NO_FILE_SYSTEM
+    #define NO_FILESYSTEM
     #define USE_CERT_BUFFERS_2048
-    #define HAVE_ECC
 #endif
 
 #ifdef WOLFSSL_NRF5x


### PR DESCRIPTION
Control availability of feature HAVE_ECC at the application level as opposed to default in the library.

Update some old-style function definitions identified by gcc 5.4.0 on Ubuntu 16.04 LTS Native device in RIOT-OS

Fix typo in NO_FILESYSTEM define
