### PR TITLE
fix macro check with SGX settings

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1280,7 +1280,7 @@ extern void uITRON4_free(void *p) ;
         #define WOLFSSL_LOG_PRINTF
         #define WOLFSSL_DH_CONST
     #endif /* _MSC_VER */
-    #ifndef (NO_RSA)
+    #ifndef NO_RSA
         #define WC_RSA_BLINDING
     #endif
     #define SINGLE_THREADED


### PR DESCRIPTION
Fix for error.

>/settings.h:1283:13: error: macro names must be identifiers