### PR TITLE
fix warnings found building on a PPC

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -804,7 +804,7 @@ static int SetASNInt(int len, byte firstByte, byte* output)
 }
 #endif
 
-#if !defined(NO_DSA) || defined(HAVE_ECC) || (defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA) && !defined(HAVE_USER_RSA))
+#if !defined(NO_DSA) || defined(HAVE_ECC) || defined(WOLFSSL_CERT_GEN) || (defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA) && !defined(HAVE_USER_RSA))
 /* Set the DER/BER encoding of the ASN.1 INTEGER element with an mp_int.
  * The number is assumed to be positive.
  *

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13448,9 +13448,9 @@ int mp_test(void)
     int    ret;
 #if defined(HAVE_ECC) || defined(WOLFSSL_KEY_GEN)
     int    i, j, k;
+    mp_digit d;
 #endif
     mp_int a, b, r1, r2, p;
-    mp_digit d;
 
     ret = mp_init_multi(&a, &b, &r1, &r2, NULL, NULL);
     if (ret != 0)


### PR DESCRIPTION
adding WOLFSSL_CERT_GEN macro check was for
>./configure C_FLAGS="-fdebug-types-section -g1" --enable-certgen
>
>wolfcrypt/src/asn.c: In function 'SetRsaPublicKey':
>wolfcrypt/src/asn.c:6764:5: error: implicit declaration of function 'SetASNIntMP' [-Werror=implicit->function-declaration]
>     nSz = SetASNIntMP(&key->n, MAX_RSA_INT_SZ, n);
>     ^
>wolfcrypt/src/asn.c:6764:5: error: nested extern declaration of 'SetASNIntMP' [-Werror=nested->externs]
>wolfcrypt/src/asn.c: At top level:
>wolfcrypt/src/asn.c:792:12: error: 'SetASNInt' defined but not used [-Werror=unused-function]
> static int SetASNInt(int len, byte firstByte, byte* output)

Moving location of mp_digit d in test.c was for
>./configure C_FLAGS="-fdebug-types-section -g1" --enable-valgrind
>
>
>wolfcrypt/test/test.c: In function ‘mp_test’:
>wolfcrypt/test/test.c:13453:14: error: unused variable ‘d’ [-Werror=unused-variable]
>     mp_digit d;
>              ^