### PR TITLE
Fixes for building with custom options

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -177,10 +177,8 @@
     #include <wolfssl/certs_test.h>
 #endif
 
-
 #ifdef HAVE_BLAKE2
     #include <wolfssl/wolfcrypt/blake2.h>
-    void bench_blake2(void);
 #endif
 
 #ifdef _MSC_VER
@@ -189,62 +187,6 @@
 #endif
 
 #include "wolfcrypt/benchmark/benchmark.h"
-
-void bench_des(int);
-void bench_idea(void);
-void bench_arc4(int);
-void bench_hc128(void);
-void bench_rabbit(void);
-void bench_chacha(void);
-void bench_chacha20_poly1305_aead(void);
-void bench_aescbc(int);
-void bench_aesgcm(int);
-void bench_aesccm(void);
-void bench_aesctr(void);
-void bench_poly1305(void);
-void bench_camellia(void);
-
-void bench_md5(int);
-void bench_sha(int);
-void bench_sha224(int);
-void bench_sha256(int);
-void bench_sha384(int);
-void bench_sha512(int);
-void bench_sha3_224(int);
-void bench_sha3_256(int);
-void bench_sha3_384(int);
-void bench_sha3_512(int);
-int  bench_ripemd(void);
-void bench_cmac(void);
-void bench_scrypt(void);
-
-void bench_rsaKeyGen(int);
-void bench_rsa(int);
-void bench_dh(int);
-#ifdef HAVE_ECC
-void bench_eccMakeKey(int);
-void bench_ecc(int);
-    #ifdef HAVE_ECC_ENCRYPT
-    void bench_eccEncrypt(void);
-    #endif
-#endif
-#ifdef HAVE_CURVE25519
-    void bench_curve25519KeyGen(void);
-    #ifdef HAVE_CURVE25519_SHARED_SECRET
-        void bench_curve25519KeyAgree(void);
-    #endif /* HAVE_CURVE25519_SHARED_SECRET */
-#endif /* HAVE_CURVE25519 */
-#ifdef HAVE_ED25519
-void bench_ed25519KeyGen(void);
-void bench_ed25519KeySign(void);
-#endif
-#ifdef HAVE_NTRU
-void bench_ntru(void);
-void bench_ntruKeyGen(void);
-#endif
-#ifndef WC_NO_RNG
-void bench_rng(void);
-#endif /* WC_NO_RNG */
 
 #ifdef WOLFSSL_CURRTIME_REMAP
     #define current_time WOLFSSL_CURRTIME_REMAP
@@ -954,13 +896,7 @@ static void* benchmarks_do(void* args)
     return NULL;
 }
 
-
-/* so embedded projects can pull in tests on their own */
-#ifdef HAVE_STACK_SIZE
-THREAD_RETURN WOLFSSL_THREAD benchmark_test(void* args)
-#else
-int benchmark_test(void *args)
-#endif
+int benchmark_init(void)
 {
     int ret = 0;
     int block_size;
@@ -970,11 +906,8 @@ int benchmark_test(void *args)
                                                             WOLFMEM_GENERAL, 1);
     if (ret != 0) {
         printf("unable to load static memory %d\n", ret);
-        EXIT_TEST(EXIT_FAILURE);
     }
 #endif /* WOLFSSL_STATIC_MEMORY */
-
-    (void)args;
 
     wolfCrypt_Init();
 
@@ -991,7 +924,6 @@ int benchmark_test(void *args)
     ret = wc_InitNetRandom(wnrConfigFile, NULL, 5000);
     if (ret != 0) {
         printf("Whitewood netRandom config init failed %d\n", ret);
-        EXIT_TEST(EXIT_FAILURE);
     }
 #endif /* HAVE_WNR */
 
@@ -1005,7 +937,7 @@ int benchmark_test(void *args)
     bench_cipher = (byte*)XMALLOC(block_size, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
     if (bench_plain == NULL || bench_cipher == NULL) {
         printf("Benchmark block buffer alloc failed!\n");
-        EXIT_TEST(EXIT_FAILURE);
+        ret = EXIT_FAILURE;
     }
     XMEMSET(bench_plain, 0, block_size);
     XMEMSET(bench_cipher, 0, block_size);
@@ -1015,7 +947,7 @@ int benchmark_test(void *args)
     bench_iv = (byte*)XMALLOC(sizeof(bench_iv_buf), HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
     if (bench_key == NULL || bench_iv == NULL) {
         printf("Benchmark cipher buffer alloc failed!\n");
-        EXIT_TEST(EXIT_FAILURE);
+        ret = EXIT_FAILURE;
     }
     XMEMCPY(bench_key, bench_key_buf, sizeof(bench_key_buf));
     XMEMCPY(bench_iv, bench_iv_buf, sizeof(bench_iv_buf));
@@ -1023,6 +955,50 @@ int benchmark_test(void *args)
     (void)bench_key;
     (void)bench_iv;
 
+    return ret;
+}
+
+int benchmark_free(void)
+{
+    int ret;
+
+    XFREE(bench_plain, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
+    XFREE(bench_cipher, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    XFREE(bench_key, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
+    XFREE(bench_iv, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
+#endif
+
+#ifdef HAVE_WNR
+    ret = wc_FreeNetRandom();
+    if (ret < 0) {
+        printf("Failed to free netRandom context %d\n", ret);
+    }
+#endif
+
+    bench_stats_free();
+
+    if ((ret = wolfCrypt_Cleanup()) != 0) {
+        printf("error %d with wolfCrypt_Cleanup\n", ret);
+    }
+
+    return ret;
+}
+
+/* so embedded projects can pull in tests on their own */
+#ifdef HAVE_STACK_SIZE
+THREAD_RETURN WOLFSSL_THREAD benchmark_test(void* args)
+#else
+int benchmark_test(void *args)
+#endif
+{
+    int ret;
+
+    (void)args;
+
+    ret = benchmark_init();
+    if (ret != 0)
+        EXIT_TEST(ret);
 
 #if defined(WOLFSSL_ASYNC_CRYPT) && !defined(WC_NO_ASYNC_THREADING)
 {
@@ -1060,26 +1036,7 @@ int benchmark_test(void *args)
     benchmarks_do(NULL);
 #endif
 
-    XFREE(bench_plain, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
-    XFREE(bench_cipher, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
-#ifdef WOLFSSL_ASYNC_CRYPT
-    XFREE(bench_key, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
-    XFREE(bench_iv, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
-#endif
-
-#ifdef HAVE_WNR
-    ret = wc_FreeNetRandom();
-    if (ret < 0) {
-        printf("Failed to free netRandom context %d\n", ret);
-        EXIT_TEST(EXIT_FAILURE);
-    }
-#endif
-
-    bench_stats_free();
-
-    if (wolfCrypt_Cleanup() != 0) {
-        printf("error with wolfCrypt_Cleanup\n");
-    }
+    ret = benchmark_free();
 
     EXIT_TEST(ret);
 }
@@ -2136,7 +2093,7 @@ void bench_sha3_224(int doAsync)
     Sha3   hash[BENCH_MAX_PENDING];
     double start;
     int    ret, i, count = 0, times;
-    DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING, SHA224_DIGEST_SIZE, HEAP_HINT);
+    DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING, SHA3_224_DIGEST_SIZE, HEAP_HINT);
 
     bench_async_begin();
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -909,7 +909,10 @@ int benchmark_init(void)
     }
 #endif /* WOLFSSL_STATIC_MEMORY */
 
-    wolfCrypt_Init();
+    if ((ret = wolfCrypt_Init()) != 0) {
+        printf("wolfCrypt_Init failed %d\n", ret);
+        return EXIT_FAILURE;
+    }
 
     bench_stats_init();
 
@@ -936,8 +939,11 @@ int benchmark_init(void)
     bench_plain = (byte*)XMALLOC(block_size, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
     bench_cipher = (byte*)XMALLOC(block_size, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
     if (bench_plain == NULL || bench_cipher == NULL) {
+        XFREE(bench_plain, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
+        XFREE(bench_cipher, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
+
         printf("Benchmark block buffer alloc failed!\n");
-        ret = EXIT_FAILURE;
+        return EXIT_FAILURE;
     }
     XMEMSET(bench_plain, 0, block_size);
     XMEMSET(bench_cipher, 0, block_size);
@@ -946,8 +952,11 @@ int benchmark_init(void)
     bench_key = (byte*)XMALLOC(sizeof(bench_key_buf), HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
     bench_iv = (byte*)XMALLOC(sizeof(bench_iv_buf), HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
     if (bench_key == NULL || bench_iv == NULL) {
+        XFREE(bench_key, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
+        XFREE(bench_iv, HEAP_HINT, DYNAMIC_TYPE_WOLF_BIGINT);
+
         printf("Benchmark cipher buffer alloc failed!\n");
-        ret = EXIT_FAILURE;
+        return EXIT_FAILURE;
     }
     XMEMCPY(bench_key, bench_key_buf, sizeof(bench_key_buf));
     XMEMCPY(bench_iv, bench_iv_buf, sizeof(bench_iv_buf));

--- a/wolfcrypt/benchmark/benchmark.h
+++ b/wolfcrypt/benchmark/benchmark.h
@@ -28,14 +28,60 @@
     extern "C" {
 #endif
 
+/* run all benchmark entry */
 #ifdef HAVE_STACK_SIZE
 THREAD_RETURN WOLFSSL_THREAD benchmark_test(void* args);
 #else
 int benchmark_test(void *args);
 #endif
 
+/* individual benchmarks */
+int  benchmark_init(void);
+int  benchmark_free(void);
 void benchmark_configure(int block_size);
 
+void bench_des(int);
+void bench_idea(void);
+void bench_arc4(int);
+void bench_hc128(void);
+void bench_rabbit(void);
+void bench_chacha(void);
+void bench_chacha20_poly1305_aead(void);
+void bench_aescbc(int);
+void bench_aesgcm(int);
+void bench_aesccm(void);
+void bench_aesctr(void);
+void bench_poly1305(void);
+void bench_camellia(void);
+void bench_md5(int);
+void bench_sha(int);
+void bench_sha224(int);
+void bench_sha256(int);
+void bench_sha384(int);
+void bench_sha512(int);
+void bench_sha3_224(int);
+void bench_sha3_256(int);
+void bench_sha3_384(int);
+void bench_sha3_512(int);
+int  bench_ripemd(void);
+void bench_cmac(void);
+void bench_scrypt(void);
+void bench_rsaKeyGen(int);
+void bench_rsa(int);
+void bench_dh(int);
+void bench_eccMakeKey(int);
+void bench_ecc(int);
+void bench_eccEncrypt(void);
+void bench_curve25519KeyGen(void);
+void bench_curve25519KeyAgree(void);
+void bench_ed25519KeyGen(void);
+void bench_ed25519KeySign(void);
+void bench_ntru(void);
+void bench_ntruKeyGen(void);
+void bench_rng(void);
+void bench_blake2(void);
+
+		
 #ifdef __cplusplus
     }  /* extern "C" */
 #endif

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1806,8 +1806,6 @@ int GetObjectId(const byte* input, word32* inOutIdx, word32* oid,
     return ret;
 }
 
-
-#if defined(HAVE_ECC) || (!defined(NO_RSA) && !defined(HAVE_USER_RSA) && (defined(OPENSSL_EXTRA) || defined(RSA_DECODE_EXTRA)))
 static int SkipObjectId(const byte* input, word32* inOutIdx, word32 maxIdx)
 {
     word32 idx = *inOutIdx;
@@ -1823,7 +1821,6 @@ static int SkipObjectId(const byte* input, word32* inOutIdx, word32 maxIdx)
 
     return 0;
 }
-#endif
 
 WOLFSSL_LOCAL int GetAlgoId(const byte* input, word32* inOutIdx, word32* oid,
                      word32 oidType, word32 maxIdx)

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -544,6 +544,9 @@ int wc_InitRng_ex(WC_RNG* rng, void* heap, int devId)
         return 0;
 #endif
 
+#ifdef CUSTOM_RAND_GENERATE_BLOCK
+	ret = 0; /* success */
+#else
 #ifdef HAVE_HASHDRBG
     if (wc_RNG_HealthTestLocal(0) == 0) {
         DECLARE_VAR(entropy, byte, ENTROPY_NONCE_SZ, rng->heap);
@@ -587,6 +590,7 @@ int wc_InitRng_ex(WC_RNG* rng, void* heap, int devId)
         rng->status = DRBG_FAILED;
     }
 #endif /* HAVE_HASHDRBG */
+#endif /* CUSTOM_RAND_GENERATE_BLOCK */
 
     return ret;
 }
@@ -625,8 +629,8 @@ int wc_RNG_GenerateBlock(WC_RNG* rng, byte* output, word32 sz)
 
 #ifdef CUSTOM_RAND_GENERATE_BLOCK
     XMEMSET(output, 0, sz);
-    return CUSTOM_RAND_GENERATE_BLOCK(output, sz);
-#endif
+    ret = CUSTOM_RAND_GENERATE_BLOCK(output, sz);
+#else
 
 #ifdef HAVE_HASHDRBG
     if (sz > RNG_MAX_BLOCK_LEN)
@@ -674,6 +678,7 @@ int wc_RNG_GenerateBlock(WC_RNG* rng, byte* output, word32 sz)
     ret = RNG_FAILURE_E;
 
 #endif /* HAVE_HASHDRBG */
+#endif /* CUSTOM_RAND_GENERATE_BLOCK */
 
     return ret;
 }

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -55,6 +55,7 @@
 #endif
 
 #if defined(USE_WOLFSSL_MEMORY) && defined(WOLFSSL_TRACK_MEMORY)
+    #include <wolfssl/wolfcrypt/memory.h>
     #include <wolfssl/wolfcrypt/mem_track.h>
 #endif
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6617,11 +6617,11 @@ int rsa_test(void)
 
 #ifdef USE_CERT_BUFFERS_1024
     bytes = sizeof_client_key_der_1024;
-	if (bytes < sizeof_client_cert_der_1024)
+	if (bytes < (size_t)sizeof_client_cert_der_1024)
 		bytes = sizeof_client_cert_der_1024;
 #elif defined(USE_CERT_BUFFERS_2048)
     bytes = sizeof_client_key_der_2048;
-	if (bytes < sizeof_client_cert_der_2048)
+	if (bytes < (size_t)sizeof_client_cert_der_2048)
 		bytes = sizeof_client_cert_der_2048;
 #else
 	bytes = FOURK_BUF;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -32,8 +32,8 @@
 
 #ifndef NO_CRYPT_TEST
 
+#include <wolfssl/wolfcrypt/memory.h>
 #ifdef WOLFSSL_STATIC_MEMORY
-    #include <wolfssl/wolfcrypt/memory.h>
     static WOLFSSL_HEAP_HINT* HEAP_HINT;
 #else
     #define HEAP_HINT NULL
@@ -310,7 +310,7 @@ int memcb_test(void);
 #ifdef __cplusplus
     extern "C" {
 #endif
-    WOLFSSL_API int wolfSSL_Debugging_ON();
+    WOLFSSL_API int wolfSSL_Debugging_ON(void);
 #ifdef __cplusplus
     }  /* extern "C" */
 #endif
@@ -402,7 +402,8 @@ int wolfcrypt_test(void* args)
     if (CheckCtcSettings() != 1)
         return err_sys("Build vs runtime math mismatch\n", -1000);
 
-#ifdef USE_FAST_MATH
+#if defined(USE_FAST_MATH) && \
+	(!defined(NO_RSA) || !defined(NO_DH) || defined(HAVE_ECC))
     if (CheckFastMathSettings() != 1)
         return err_sys("Build vs runtime fastmath FP_MAX_BITS mismatch\n",
                        -1001);
@@ -2029,8 +2030,8 @@ int hash_test(void)
     byte             data[] = "0123456789abcdef0123456789abcdef012345";
     byte             out[MAX_DIGEST_SIZE];
     enum wc_HashType typesGood[] = { WC_HASH_TYPE_MD5, WC_HASH_TYPE_SHA,
-                                     WC_HASH_TYPE_SHA224, WC_HASH_TYPE_SHA384,
-                                     WC_HASH_TYPE_SHA512, WC_HASH_TYPE_SHA256 };
+                                     WC_HASH_TYPE_SHA224, WC_HASH_TYPE_SHA256,
+                                     WC_HASH_TYPE_SHA384, WC_HASH_TYPE_SHA512 };
     enum wc_HashType typesNoImpl[] = {
 #ifdef NO_MD5
                                         WC_HASH_TYPE_MD5,
@@ -6160,6 +6161,7 @@ static int rsa_flatten_test(RsaKey* key)
     return 0;
 }
 
+#ifndef NO_SIG_WRAPPER
 static int rsa_sig_test(RsaKey* key, word32 keyLen, int modLen, WC_RNG* rng)
 {
     int ret;
@@ -6294,6 +6296,7 @@ static int rsa_sig_test(RsaKey* key, word32 keyLen, int modLen, WC_RNG* rng)
 
     return 0;
 }
+#endif /* !NO_SIG_WRAPPER */
 
 #ifndef HAVE_USER_RSA
 static int rsa_decode_test(void)
@@ -6349,7 +6352,7 @@ static int rsa_decode_test(void)
         goto done;
     }
     /* TODO: probably should fail when length is -1! */
-    ret = wc_RsaPublicKeyDecodeRaw(n, -1, e, sizeof(e), &keyPub);
+    ret = wc_RsaPublicKeyDecodeRaw(n, (word32)-1, e, sizeof(e), &keyPub);
     if (ret != 0) {
         ret = -5404;
         goto done;
@@ -6358,7 +6361,7 @@ static int rsa_decode_test(void)
     ret = wc_InitRsaKey(&keyPub, NULL);
     if (ret != 0)
         return -5405;
-    ret = wc_RsaPublicKeyDecodeRaw(n, sizeof(n), e, -1, &keyPub);
+    ret = wc_RsaPublicKeyDecodeRaw(n, sizeof(n), e, (word32)-1, &keyPub);
     if (ret != 0) {
         ret = -5406;
         goto done;
@@ -6612,7 +6615,19 @@ int rsa_test(void)
         return ret;
 #endif
 
-    tmp = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+#ifdef USE_CERT_BUFFERS_1024
+    bytes = sizeof_client_key_der_1024;
+	if (bytes < sizeof_client_cert_der_1024)
+		bytes = sizeof_client_cert_der_1024;
+#elif defined(USE_CERT_BUFFERS_2048)
+    bytes = sizeof_client_key_der_2048;
+	if (bytes < sizeof_client_cert_der_2048)
+		bytes = sizeof_client_cert_der_2048;
+#else
+	bytes = FOURK_BUF;
+#endif
+
+    tmp = (byte*)XMALLOC(bytes, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (tmp == NULL
     #ifdef WOLFSSL_ASYNC_CRYPT
         || out == NULL || plain == NULL
@@ -6623,10 +6638,8 @@ int rsa_test(void)
 
 #ifdef USE_CERT_BUFFERS_1024
     XMEMCPY(tmp, client_key_der_1024, sizeof_client_key_der_1024);
-    bytes = sizeof_client_key_der_1024;
 #elif defined(USE_CERT_BUFFERS_2048)
     XMEMCPY(tmp, client_key_der_2048, sizeof_client_key_der_2048);
-    bytes = sizeof_client_key_der_2048;
 #elif !defined(NO_FILESYSTEM)
     file = fopen(clientKey, "rb");
     if (!file) {
@@ -6660,9 +6673,11 @@ int rsa_test(void)
         ERROR_OUT(-5505, exit_rsa);
     }
 
+#ifndef NO_SIG_WRAPPER
     ret = rsa_sig_test(&key, sizeof(RsaKey), wc_RsaEncryptSize(&key), &rng);
     if (ret != 0)
         goto exit_rsa;
+#endif
 
     do {
 #if defined(WOLFSSL_ASYNC_CRYPT)

--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -90,9 +90,15 @@
     /* if defined to not using inline then declare function prototypes */
     #ifdef NO_INLINE
         #define STATIC
-        WOLFSSL_LOCAL void* TrackMalloc(size_t sz);
-        WOLFSSL_LOCAL void TrackFree(void* ptr);
-        WOLFSSL_LOCAL void* TrackRealloc(void* ptr, size_t sz);
+		#ifdef WOLFSSL_DEBUG_MEMORY
+			WOLFSSL_LOCAL void* TrackMalloc(size_t sz, const char* func, unsigned int line);
+			WOLFSSL_LOCAL void TrackFree(void* ptr, const char* func, unsigned int line);
+			WOLFSSL_LOCAL void* TrackRealloc(void* ptr, size_t sz, const char* func, unsigned int line);
+		#else
+			WOLFSSL_LOCAL void* TrackMalloc(size_t sz);
+			WOLFSSL_LOCAL void TrackFree(void* ptr);
+			WOLFSSL_LOCAL void* TrackRealloc(void* ptr, size_t sz);
+		#endif
         WOLFSSL_LOCAL int InitMemoryTracker(void);
         WOLFSSL_LOCAL void ShowMemoryTracker(void);
     #else


### PR DESCRIPTION
* Fix for SHA3 benchmark digest size for 224.
* Fix for hash test order of SHA256 wrong.
* Fix for building track and debug memory together.
* Fix for asn `SkipObjectId` missing, when RSA and ECC disabled. 
* Fix warning with RNG with `CUSTOM_RAND_GENERATE_BLOCK` code not reachable.
* Enhancement to allow individual bench calls with bench init/free.
* Enhanced RSA test to allocate actual size buffer when used with ` USE_CERT_BUFFERS_1024` or ` USE_CERT_BUFFERS_2048` to reduce heap allocation.