### PR TITLE
Fixes for using custom curves with `wc_ecc_set_custom_curve`

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1233,7 +1233,7 @@ const char* wc_ecc_get_name(int curve_id)
 
 int wc_ecc_set_curve(ecc_key* key, int keysize, int curve_id)
 {
-    if (keysize <= 0 && curve_id <= 0) {
+    if (keysize <= 0 && curve_id < 0) {
         return BAD_FUNC_ARG;
     }
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -929,6 +929,15 @@ const ecc_set_type ecc_sets[] = {
     },
     #endif /* !NO_ECC_SECP */
 #endif /* ECC521 */
+#if defined(WOLFSSL_CUSTOM_CURVES) && defined(ECC_CACHE_CURVE)
+    /* place holder for custom curve index for cache */
+    {
+        1, /* non-zero */
+        ECC_CURVE_CUSTOM,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, 0, 0, 0
+    },
+#endif
 {
    0, -1,
    NULL, NULL, NULL, NULL, NULL, NULL, NULL,
@@ -2506,7 +2515,8 @@ int wc_ecc_get_curve_idx_from_name(const char* curveName)
     len = (word32)XSTRLEN(curveName);
 
     for (curve_idx = 0; ecc_sets[curve_idx].size != 0; curve_idx++) {
-        if (XSTRNCASECMP(ecc_sets[curve_idx].name, curveName, len) == 0) {
+        if (ecc_sets[curve_idx].name &&
+                XSTRNCASECMP(ecc_sets[curve_idx].name, curveName, len) == 0) {
             break;
         }
     }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3538,6 +3538,13 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 
        /* don't use async for key, since we don't support async return here */
        if (wc_ecc_init_ex(&pubkey, key->heap, INVALID_DEVID) == MP_OKAY) {
+       #ifdef WOLFSSL_CUSTOM_CURVES
+           /* if custom curve, apply params to pubkey */
+           if (key->idx == ECC_CUSTOM_IDX) {
+               wc_ecc_set_custom_curve(&pubkey, key->dp);
+           }
+       #endif
+
            for (;;) {
                if (++loop_check > 64) {
                     err = RNG_FAILURE_E;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -43,11 +43,7 @@
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/types.h>
 
-#ifdef WOLFSSL_TEST_CERT
-    #include <wolfssl/wolfcrypt/asn.h>
-#else
-    #include <wolfssl/wolfcrypt/asn_public.h>
-#endif
+#include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/md2.h>
 #include <wolfssl/wolfcrypt/md5.h>
 #include <wolfssl/wolfcrypt/md4.h>
@@ -10109,7 +10105,7 @@ done:
 #endif /* WOLFSSL_KEY_GEN */
 
 static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
-    int curve_id)
+    int curve_id, const ecc_set_type* dp)
 {
     DECLARE_VAR(sharedA, byte, ECC_SHARED_SIZE, HEAP_HINT);
     DECLARE_VAR(sharedB, byte, ECC_SHARED_SIZE, HEAP_HINT);
@@ -10129,6 +10125,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     ecc_key userA, userB, pubKey;
 
     (void)testVerifyCount;
+    (void)dp;
 
     XMEMSET(&userA, 0, sizeof(ecc_key));
     XMEMSET(&userB, 0, sizeof(ecc_key));
@@ -10143,6 +10140,14 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     ret = wc_ecc_init_ex(&pubKey, HEAP_HINT, devId);
     if (ret != 0)
         goto done;
+
+#ifdef WOLFSSL_CUSTOM_CURVES
+    if (dp) {
+        wc_ecc_set_custom_curve(&userA, dp);
+        wc_ecc_set_custom_curve(&userB, dp);
+        wc_ecc_set_custom_curve(&pubKey, dp);
+    }
+#endif
 
     ret = wc_ecc_make_key_ex(rng, keySize, &userA, curve_id);
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -10386,7 +10391,7 @@ static int ecc_test_curve(WC_RNG* rng, int keySize)
 {
     int ret;
 
-    ret = ecc_test_curve_size(rng, keySize, ECC_TEST_VERIFY_COUNT, ECC_CURVE_DEF);
+    ret = ecc_test_curve_size(rng, keySize, ECC_TEST_VERIFY_COUNT, ECC_CURVE_DEF, NULL);
     if (ret < 0) {
         if (ret == ECC_CURVE_OID_E) {
             /* ignore error for curves not found */
@@ -10983,6 +10988,59 @@ done:
 }
 #endif /* WOLFSSL_CERT_EXT */
 
+#ifdef WOLFSSL_CUSTOM_CURVES
+static int ecc_test_custom_curves(WC_RNG* rng)
+{
+    int ret;
+
+    /* test use of custom curve - using BRAINPOOLP256R1 for test */
+    const ecc_oid_t ecc_oid_brainpoolp256r1[] = {
+        0x2B,0x24,0x03,0x03,0x02,0x08,0x01,0x01,0x07
+    };
+    const ecc_set_type ecc_dp_brainpool256r1 = {
+        32,                                                                 /* size/bytes */
+        ECC_BRAINPOOLP256R1,                                                /* ID         */
+        "BRAINPOOLP256R1",                                                  /* curve name */
+        "A9FB57DBA1EEA9BC3E660A909D838D726E3BF623D52620282013481D1F6E5377", /* prime      */
+        "7D5A0975FC2C3057EEF67530417AFFE7FB8055C126DC5C6CE94A4B44F330B5D9", /* A          */
+        "26DC5C6CE94A4B44F330B5D9BBD77CBF958416295CF7E1CE6BCCDC18FF8C07B6", /* B          */
+        "A9FB57DBA1EEA9BC3E660A909D838D718C397AA3B561A6F7901E0E82974856A7", /* order      */
+        "8BD2AEB9CB7E57CB2C4B482FFC81B7AFB9DE27E1E3BD23C23A4453BD9ACE3262", /* Gx         */
+        "547EF835C3DAC4FD97F8461A14611DC9C27745132DED8E545C1D54C72F046997", /* Gy         */
+        ecc_oid_brainpoolp256r1,                                            /* oid/oidSz  */
+        sizeof(ecc_oid_brainpoolp256r1) / sizeof(ecc_oid_t),
+        ECC_BRAINPOOLP256R1_OID,                                            /* oid sum    */
+        1,                                                                  /* cofactor   */
+    };
+
+    ret = ecc_test_curve_size(rng, 0, ECC_TEST_VERIFY_COUNT, ECC_CURVE_DEF,
+        &ecc_dp_brainpool256r1);
+    if (ret != 0) {
+        printf("ECC test for custom curve failed! %d\n", ret);
+        return ret;
+    }
+
+    #if defined(HAVE_ECC_BRAINPOOL) || defined(HAVE_ECC_KOBLITZ)
+    {
+        int curve_id;
+        #ifdef HAVE_ECC_BRAINPOOL
+            curve_id = ECC_BRAINPOOLP256R1;
+        #else
+            curve_id = ECC_SECP256K1;
+        #endif
+        /* Test and demonstrate use of non-SECP curve */
+        ret = ecc_test_curve_size(rng, 0, ECC_TEST_VERIFY_COUNT, curve_id, NULL);
+        if (ret < 0) {
+            printf("ECC test for curve_id %d failed! %d\n", curve_id, ret);
+            return ret;
+        }
+    }
+    #endif
+
+    return ret;
+}
+#endif /* WOLFSSL_CUSTOM_CURVES */
+
 int ecc_test(void)
 {
     int ret;
@@ -11081,22 +11139,10 @@ int ecc_test(void)
 #endif /* HAVE_ECC521 */
 
 #if defined(WOLFSSL_CUSTOM_CURVES)
-    #if defined(HAVE_ECC_BRAINPOOL) || defined(HAVE_ECC_KOBLITZ)
-    {
-        int curve_id;
-        #ifdef HAVE_ECC_BRAINPOOL
-            curve_id = ECC_BRAINPOOLP256R1;
-        #else
-            curve_id = ECC_SECP256K1;
-        #endif
-        /* Test and demonstrate use of non-SECP curve */
-        ret = ecc_test_curve_size(&rng, 0, ECC_TEST_VERIFY_COUNT, curve_id);
-        if (ret < 0) {
-            printf("ecc_test_curve_size: type %d: failed!: %d\n", curve_id, ret);
-            goto done;
-        }
+    ret = ecc_test_custom_curves(&rng);
+    if (ret != 0) {
+        goto done;
     }
-    #endif
 #endif
 
 #ifdef HAVE_ECC_CDH

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -158,6 +158,10 @@ typedef enum ecc_curve_id {
 #ifdef HAVE_X448
     ECC_X448,
 #endif
+
+#ifdef WOLFSSL_CUSTOM_CURVES
+    ECC_CURVE_CUSTOM,
+#endif
 } ecc_curve_id;
 
 #ifdef HAVE_OID_ENCODING


### PR DESCRIPTION
Fixes for using `WOLFSSL_CUSTOM_CURVES` and `wc_ecc_set_custom_curve`. Fixes resolves issue with `->dp` and `->idx` getting reset which caused curve parameters to not be set correctly. Proper sequence for using custom curves is ‘wc_ecc_init`, `wc_ecc_set_custom_curve` then `wc_ecc_make_key_ex(…, ECC_CUSTOM_IDX)’ or `wc_ecc_import_x963_ex(…, ECC_CUSTOM_IDX)`. Test case and example to follow shortly.