### PR TITLE
Fix for PKCS12 dynamic type names

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15542,7 +15542,7 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                                                heap, DYNAMIC_TYPE_X509);
         if (*ca == NULL) {
             if (pk != NULL) {
-                XFREE(pk, heap, DYNAMIC_TYPE_PKCS);
+                XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
             }
             if (certData != NULL) {
                 XFREE(*cert, heap, DYNAMIC_TYPE_PKCS); *cert = NULL;
@@ -15580,7 +15580,7 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                     wolfSSL_X509_free(x509);
                     wolfSSL_sk_X509_free(*ca); *ca = NULL;
                     if (pk != NULL) {
-                        XFREE(pk, heap, DYNAMIC_TYPE_PKCS);
+                        XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
                     }
                     if (certData != NULL) {
                         XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
@@ -15602,7 +15602,7 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                     wolfSSL_X509_free(x509);
                     wolfSSL_sk_X509_free(*ca); *ca = NULL;
                     if (pk != NULL) {
-                        XFREE(pk, heap, DYNAMIC_TYPE_PKCS);
+                        XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
                     }
                     if (certData != NULL) {
                         XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
@@ -15632,7 +15632,7 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                                                              DYNAMIC_TYPE_X509);
         if (*cert == NULL) {
             if (pk != NULL) {
-                XFREE(pk, heap, DYNAMIC_TYPE_PKCS);
+                XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
             }
             if (ca != NULL) {
                 wolfSSL_sk_X509_free(*ca); *ca = NULL;
@@ -15649,7 +15649,7 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
             WOLFSSL_MSG("Failed to copy decoded cert");
             FreeDecodedCert(&DeCert);
             if (pk != NULL) {
-                XFREE(pk, heap, DYNAMIC_TYPE_PKCS);
+                XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
             }
             if (ca != NULL) {
                 wolfSSL_sk_X509_free(*ca); *ca = NULL;
@@ -15673,7 +15673,7 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
             if (ca != NULL) {
                 wolfSSL_sk_X509_free(*ca); *ca = NULL;
             }
-            XFREE(pk, heap, DYNAMIC_TYPE_PKCS);
+            XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
             return 0;
         }
         #ifndef NO_RSA
@@ -15707,7 +15707,7 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                         wolfSSL_sk_X509_free(*ca); *ca = NULL;
                     }
                     XFREE(*pkey, heap, DYNAMIC_TYPE_PUBLIC_KEY); *pkey = NULL;
-                    XFREE(pk, heap, DYNAMIC_TYPE_PKCS);
+                    XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
                     return 0;
                 }
 
@@ -15718,7 +15718,7 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                         wolfSSL_sk_X509_free(*ca); *ca = NULL;
                     }
                     XFREE(*pkey, heap, DYNAMIC_TYPE_PUBLIC_KEY); *pkey = NULL;
-                    XFREE(pk, heap, DYNAMIC_TYPE_PKCS);
+                    XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
                     WOLFSSL_MSG("Bad PKCS12 key format");
                     return 0;
                 }
@@ -15735,7 +15735,7 @@ int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                 wolfSSL_sk_X509_free(*ca); *ca = NULL;
             }
             XFREE(*pkey, heap, DYNAMIC_TYPE_PUBLIC_KEY); *pkey = NULL;
-            XFREE(pk, heap, DYNAMIC_TYPE_PKCS);
+            XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
             WOLFSSL_MSG("Bad PKCS12 key format");
             return 0;
         }

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -886,9 +886,7 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                 case WC_PKCS12_ShroudedKeyBag: /* 668 */
                     {
                         byte* k;
-                #ifdef FREESCALE_MQX
-                        byte* tmp;
-                #endif
+
                         WOLFSSL_MSG("PKCS12 Shrouded Key Bag found");
                         if (data[idx++] !=
                                      (ASN_CONSTRUCTED | ASN_CONTEXT_SPECIFIC)) {
@@ -914,9 +912,7 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
 
                         if (ret < size) {
                             /* shrink key buffer */
-                        #ifdef FREESCALE_MQX
-                            /* MQX classic has no realloc */
-                            tmp = (byte*)XMALLOC(ret, pkcs12->heap,
+                            byte* tmp = (byte*)XMALLOC(ret, pkcs12->heap,
                                                  DYNAMIC_TYPE_PUBLIC_KEY);
                             if (tmp == NULL) {
                                 XFREE(k, pkcs12->heap, DYNAMIC_TYPE_PUBLIC_KEY);
@@ -925,13 +921,6 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                             XMEMCPY(tmp, k, ret);
                             XFREE(k, pkcs12->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                             k = tmp;
-                        #else
-                            k = (byte*)XREALLOC(k, ret, pkcs12->heap,
-                                                       DYNAMIC_TYPE_PUBLIC_KEY);
-                            if (k == NULL) {
-                                ERROR_OUT(MEMORY_E, exit_pk12par);
-                            }
-                        #endif
                         }
                         size = ret;
 


### PR DESCRIPTION
Fix for PKCS12 dynamic type names (also fix to use manual realloc since its NUMA type and that behaves different).