### PR TITLE
DTLS Bad MAC Checks

### DIFF
--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -25,10 +25,12 @@
 #endif
 
 #include <cyassl/ctaocrypt/settings.h>
-
 /* let's use cyassl layer AND cyassl openssl layer */
 #include <cyassl/ssl.h>
 #include <cyassl/openssl/ssl.h>
+#ifdef CYASSL_DTLS
+    #include <cyassl/error-ssl.h>
+#endif
 
 #if defined(WOLFSSL_MDK_ARM) || defined(WOLFSSL_KEIL_TCP_NET)
         #include <stdio.h>
@@ -266,6 +268,14 @@ void echoclient_test(void* args)
                 fflush(fout) ;
                 sendSz -= ret;
             }
+#ifdef CYASSL_DTLS
+            else if (wolfSSL_dtls(ssl) && err == DECRYPT_ERROR) {
+                /* This condition is OK. The packet should be dropped
+                 * silently when there is a decrypt or MAC error on
+                 * a DTLS record. */
+                sendSz = 0;
+            }
+#endif
             else {
                 printf("SSL_read msg error %d, %s\n", err,
                     ERR_error_string(err, buffer));

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -47,6 +47,9 @@
 #endif
 #include <cyassl/openssl/ssl.h>
 #include <cyassl/test.h>
+#ifdef CYASSL_DTLS
+    #include <cyassl/error-ssl.h>
+#endif
 
 #include "examples/server/server.h"
 
@@ -292,6 +295,12 @@ static void ServerRead(WOLFSSL* ssl, char* input, int inputLen)
             if (err == WC_PENDING_E) {
                 ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
                 if (ret < 0) break;
+            }
+            else
+        #endif
+        #ifdef CYASSL_DTLS
+            if (wolfSSL_dtls(ssl) && err == DECRYPT_ERROR) {
+                printf("Dropped client's message due to a bad MAC\n");
             }
             else
         #endif


### PR DESCRIPTION
1. Make the decrypt and verify MAC failure cases behave the same with respect to DTLS messages. It should pretend the message never happened.
2. Allow the echoclient to survive the echoserver sending a message with a bad MAC.
3. Allow the server to survive the client sending a message with a bad MAC.