### PR TITLE
Static analysis tests

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3089,9 +3089,6 @@ void InitDecodedCert(DecodedCert* cert, byte* source, word32 inSz, void* heap)
         cert->source          = source;  /* don't own */
         cert->maxIdx          = inSz;    /* can't go over this index */
         cert->heap            = heap;
-        XMEMSET(cert->serial, 0, EXTERNAL_SERIAL_SIZE);
-        XMEMSET(cert->extSubjKeyId, 0, KEYID_SIZE);
-        XMEMSET(cert->extAuthKeyId, 0, KEYID_SIZE);
     #ifdef WOLFSSL_CERT_GEN
         cert->subjectSNEnc    = CTC_UTF8;
         cert->subjectCEnc     = CTC_PRINTABLE;
@@ -3100,13 +3097,6 @@ void InitDecodedCert(DecodedCert* cert, byte* source, word32 inSz, void* heap)
         cert->subjectOEnc     = CTC_UTF8;
         cert->subjectOUEnc    = CTC_UTF8;
     #endif /* WOLFSSL_CERT_GEN */
-    #ifdef OPENSSL_EXTRA
-        XMEMSET(&cert->issuerName, 0, sizeof(DecodedName));
-        XMEMSET(&cert->subjectName, 0, sizeof(DecodedName));
-    #endif /* OPENSSL_EXTRA */
-    #ifdef WOLFSSL_CERT_EXT
-        XMEMSET(cert->extCertPolicies, 0, MAX_CERTPOL_NB*MAX_CERTPOL_SZ);
-    #endif
 
         InitSignatureCtx(&cert->sigCtx, heap, INVALID_DEVID);
     }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3080,127 +3080,36 @@ int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen)
 
 void InitDecodedCert(DecodedCert* cert, byte* source, word32 inSz, void* heap)
 {
-    cert->publicKey       = 0;
-    cert->pubKeySize      = 0;
-    cert->pubKeyStored    = 0;
-    cert->keyOID          = 0;
-    cert->version         = 0;
-    cert->signature       = 0;
-    cert->subjectCN       = 0;
-    cert->subjectCNLen    = 0;
-    cert->subjectCNEnc    = CTC_UTF8;
-    cert->subjectCNStored = 0;
-    cert->weOwnAltNames   = 0;
-    cert->altNames        = NULL;
-#ifndef IGNORE_NAME_CONSTRAINTS
-    cert->altEmailNames   = NULL;
-    cert->permittedNames  = NULL;
-    cert->excludedNames   = NULL;
-#endif /* IGNORE_NAME_CONSTRAINTS */
-    cert->issuer[0]       = '\0';
-    cert->subject[0]      = '\0';
-    cert->source          = source;  /* don't own */
-    cert->srcIdx          = 0;
-    cert->maxIdx          = inSz;    /* can't go over this index */
-    cert->heap            = heap;
-    XMEMSET(cert->serial, 0, EXTERNAL_SERIAL_SIZE);
-    cert->serialSz        = 0;
-    cert->extensions      = 0;
-    cert->extensionsSz    = 0;
-    cert->extensionsIdx   = 0;
-    cert->extAuthInfo     = NULL;
-    cert->extAuthInfoSz   = 0;
-    cert->extCrlInfo      = NULL;
-    cert->extCrlInfoSz    = 0;
-    XMEMSET(cert->extSubjKeyId, 0, KEYID_SIZE);
-    cert->extSubjKeyIdSet = 0;
-    XMEMSET(cert->extAuthKeyId, 0, KEYID_SIZE);
-    cert->extAuthKeyIdSet = 0;
-    cert->extKeyUsageSet  = 0;
-    cert->extKeyUsage     = 0;
-    cert->extExtKeyUsageSet = 0;
-    cert->extExtKeyUsage    = 0;
-    cert->isCA            = 0;
-    cert->pathLengthSet   = 0;
-    cert->pathLength      = 0;
-#ifdef HAVE_PKCS7
-    cert->issuerRaw       = NULL;
-    cert->issuerRawLen    = 0;
-#endif
-#ifdef WOLFSSL_CERT_GEN
-    cert->subjectSN       = 0;
-    cert->subjectSNLen    = 0;
-    cert->subjectSNEnc    = CTC_UTF8;
-    cert->subjectC        = 0;
-    cert->subjectCLen     = 0;
-    cert->subjectCEnc     = CTC_PRINTABLE;
-    cert->subjectL        = 0;
-    cert->subjectLLen     = 0;
-    cert->subjectLEnc     = CTC_UTF8;
-    cert->subjectST       = 0;
-    cert->subjectSTLen    = 0;
-    cert->subjectSTEnc    = CTC_UTF8;
-    cert->subjectO        = 0;
-    cert->subjectOLen     = 0;
-    cert->subjectOEnc     = CTC_UTF8;
-    cert->subjectOU       = 0;
-    cert->subjectOULen    = 0;
-    cert->subjectOUEnc    = CTC_UTF8;
-    cert->subjectEmail    = 0;
-    cert->subjectEmailLen = 0;
-#endif /* WOLFSSL_CERT_GEN */
-    cert->beforeDate      = NULL;
-    cert->beforeDateLen   = 0;
-    cert->afterDate       = NULL;
-    cert->afterDateLen    = 0;
-#ifdef OPENSSL_EXTRA
-    XMEMSET(&cert->issuerName, 0, sizeof(DecodedName));
-    XMEMSET(&cert->subjectName, 0, sizeof(DecodedName));
-    cert->extCRLdistSet = 0;
-    cert->extCRLdistCrit = 0;
-    cert->extAuthInfoSet = 0;
-    cert->extAuthInfoCrit = 0;
-    cert->extBasicConstSet = 0;
-    cert->extBasicConstCrit = 0;
-    cert->extSubjAltNameSet = 0;
-    cert->extSubjAltNameCrit = 0;
-    cert->extAuthKeyIdCrit = 0;
-    cert->extSubjKeyIdCrit = 0;
-    cert->extKeyUsageCrit = 0;
-    cert->extExtKeyUsageCrit = 0;
-    cert->extExtKeyUsageSrc = NULL;
-    cert->extExtKeyUsageSz = 0;
-    cert->extExtKeyUsageCount = 0;
-    cert->extAuthKeyIdSrc = NULL;
-    cert->extAuthKeyIdSz = 0;
-    cert->extSubjKeyIdSrc = NULL;
-    cert->extSubjKeyIdSz = 0;
-#endif /* OPENSSL_EXTRA */
-#if defined(OPENSSL_EXTRA) || !defined(IGNORE_NAME_CONSTRAINTS)
-    cert->extNameConstraintSet = 0;
-#endif /* OPENSSL_EXTRA || !IGNORE_NAME_CONSTRAINTS */
-#ifdef HAVE_ECC
-    cert->pkCurveOID = 0;
-#endif /* HAVE_ECC */
-#ifdef WOLFSSL_SEP
-    cert->deviceTypeSz = 0;
-    cert->deviceType = NULL;
-    cert->hwTypeSz = 0;
-    cert->hwType = NULL;
-    cert->hwSerialNumSz = 0;
-    cert->hwSerialNum = NULL;
-    #ifdef OPENSSL_EXTRA
-        cert->extCertPolicySet = 0;
-        cert->extCertPolicyCrit = 0;
-    #endif /* OPENSSL_EXTRA */
-#endif /* WOLFSSL_SEP */
-#ifdef WOLFSSL_CERT_EXT
-    XMEMSET(cert->extCertPolicies, 0, MAX_CERTPOL_NB*MAX_CERTPOL_SZ);
-    cert->extCertPoliciesNb = 0;
-#endif
+    if (cert != NULL) {
+        XMEMSET(cert, 0, sizeof(DecodedCert));
 
-    cert->ca = NULL;
-    InitSignatureCtx(&cert->sigCtx, heap, INVALID_DEVID);
+        cert->subjectCNEnc    = CTC_UTF8;
+        cert->issuer[0]       = '\0';
+        cert->subject[0]      = '\0';
+        cert->source          = source;  /* don't own */
+        cert->maxIdx          = inSz;    /* can't go over this index */
+        cert->heap            = heap;
+        XMEMSET(cert->serial, 0, EXTERNAL_SERIAL_SIZE);
+        XMEMSET(cert->extSubjKeyId, 0, KEYID_SIZE);
+        XMEMSET(cert->extAuthKeyId, 0, KEYID_SIZE);
+    #ifdef WOLFSSL_CERT_GEN
+        cert->subjectSNEnc    = CTC_UTF8;
+        cert->subjectCEnc     = CTC_PRINTABLE;
+        cert->subjectLEnc     = CTC_UTF8;
+        cert->subjectSTEnc    = CTC_UTF8;
+        cert->subjectOEnc     = CTC_UTF8;
+        cert->subjectOUEnc    = CTC_UTF8;
+    #endif /* WOLFSSL_CERT_GEN */
+    #ifdef OPENSSL_EXTRA
+        XMEMSET(&cert->issuerName, 0, sizeof(DecodedName));
+        XMEMSET(&cert->subjectName, 0, sizeof(DecodedName));
+    #endif /* OPENSSL_EXTRA */
+    #ifdef WOLFSSL_CERT_EXT
+        XMEMSET(cert->extCertPolicies, 0, MAX_CERTPOL_NB*MAX_CERTPOL_SZ);
+    #endif
+
+        InitSignatureCtx(&cert->sigCtx, heap, INVALID_DEVID);
+    }
 }
 
 

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -3847,6 +3847,10 @@ int fast_s_mp_mul_high_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
 #endif
   mp_word  _W;
 
+  if (a->dp == NULL) { /* JRB, avoid reading uninitialized values */
+      return MP_VAL;
+  }
+
   /* grow the destination as required */
   pa = a->used + b->used;
   if (c->alloc < pa) {
@@ -3867,7 +3871,7 @@ int fast_s_mp_mul_high_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
   /* number of output digits to produce */
   pa = a->used + b->used;
   _W = 0;
-  for (ix = digs; ix < pa && a->dp; ix++) {
+  for (ix = digs; ix < pa; ix++) { /* JRB, have a->dp check at top of function*/
       int      tx, ty, iy;
       mp_digit *tmpx, *tmpy;
 

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -3177,7 +3177,7 @@ int fast_s_mp_mul_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
   {
     mp_digit *tmpc;
     tmpc = c->dp;
-    for (ix = 0; ix < pa+1; ix++) {
+    for (ix = 0; ix < pa; ix++) { /* JRB, +1 could read uninitialized data */
       /* now extract the previous digit [below the carry] */
       *tmpc++ = W[ix];
     }


### PR DESCRIPTION
This pull request addresses 3 reports.

1) Read of uninitialized  value in function fast_s_mp_mul_digs.

2) Read of uninitialized value in function fast_s_mp_mul_high_digs if a->dp is null.
This needs closely reviewed because it adds an additional return value. Before if there was a case where a->dp was null then uninitialized values would be read in the second for loop but still MP_OKAY was returned.

3) InitDecodedCert function missing initialization of a couple of the elements in the DecodedCert structure.