### PR TITLE
Update Micrium uC/OS-III Port

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -1556,4 +1556,221 @@ void wolfSSL_SetIO_NetX(WOLFSSL* ssl, NX_TCP_SOCKET* nxSocket, ULONG waitOption)
 
 #endif /* HAVE_NETX */
 
+
+#ifdef MICRIUM
+
+/* Micrium uTCP/IP port, using the NetSock API
+ * TCP and UDP are currently supported with the callbacks below.
+ *
+ * WOLFSSL_SESSION_EXPORT is not yet supported, would need EmbedGetPeer()
+ * and EmbedSetPeer() callbacks implemented.
+ *
+ * HAVE_CRL is not yet supported, would need an EmbedCrlLookup()
+ * callback implemented.
+ *
+ * HAVE_OCSP is not yet supported, would need an EmbedOCSPLookup()
+ * callback implemented.
+ */
+
+/* The Micrium uTCP/IP send callback
+ * return : bytes sent, or error
+ */
+int MicriumSend(WOLFSSL* ssl, char* buf, int sz, void* ctx)
+{
+    NET_SOCK_ID sd = *(int*)ctx;
+    NET_SOCK_RTN_CODE ret;
+    NET_ERR err;
+
+    ret = NetSock_TxData(sd, buf, sz, ssl->wflags, &err);
+    if (ret < 0) {
+        WOLFSSL_MSG("Embed Send error");
+
+        if (err == NET_ERR_TX) {
+            WOLFSSL_MSG("\tWould block");
+            return WOLFSSL_CBIO_ERR_WANT_WRITE;
+
+        } else {
+            WOLFSSL_MSG("\tGeneral error");
+            return WOLFSSL_CBIO_ERR_GENERAL;
+        }
+    }
+
+    return ret;
+}
+
+/* The Micrium uTCP/IP receive callback
+ *  return : nb bytes read, or error
+ */
+int MicriumReceive(WOLFSSL *ssl, char *buf, int sz, void *ctx)
+{
+    NET_SOCK_ID sd = *(int*)ctx;
+    NET_SOCK_RTN_CODE ret;
+    NET_ERR err;
+
+#ifdef WOLFSSL_DTLS
+    {
+        int dtls_timeout = wolfSSL_dtls_get_current_timeout(ssl);
+        if (wolfSSL_dtls(ssl)
+                     && !wolfSSL_get_using_nonblock(ssl)
+                     && dtls_timeout != 0) {
+            /* needs timeout in milliseconds */
+            NetSock_CfgTimeoutRxQ_Set(sd, dtls_timeout * 1000, &err);
+            if (err != NET_SOCK_ERR_NONE) {
+                WOLFSSL_MSG("NetSock_CfgTimeoutRxQ_Set failed");
+            }
+        }
+    }
+#endif
+
+    ret = NetSock_RxData(sd, buf, sz, ssl->rflags, &err);
+    if (ret < 0) {
+        WOLFSSL_MSG("Embed Receive error");
+
+        if (err == NET_ERR_RX || err == NET_SOCK_ERR_RX_Q_EMPTY ||
+            err == NET_ERR_FAULT_LOCK_ACQUIRE) {
+            if (!wolfSSL_dtls(ssl) || wolfSSL_get_using_nonblock(ssl)) {
+                WOLFSSL_MSG("\tWould block");
+                return WOLFSSL_CBIO_ERR_WANT_READ;
+            }
+            else {
+                WOLFSSL_MSG("\tSocket timeout");
+                return WOLFSSL_CBIO_ERR_TIMEOUT;
+            }
+
+        } else if (err == NET_SOCK_ERR_CLOSED) {
+            WOLFSSL_MSG("Embed receive connection closed");
+            return WOLFSSL_CBIO_ERR_CONN_CLOSE;
+
+        } else {
+            WOLFSSL_MSG("\tGeneral error");
+            return WOLFSSL_CBIO_ERR_GENERAL;
+        }
+    }
+
+    return ret;
+}
+
+/* The Micrium uTCP/IP receivefrom callback
+ *  return : nb bytes read, or error
+ */
+int MicriumReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
+{
+    WOLFSSL_DTLS_CTX* dtlsCtx = (WOLFSSL_DTLS_CTX*)ctx;
+    NET_SOCK_ID       sd = dtlsCtx->rfd;
+    NET_SOCK_ADDR     peer;
+    NET_SOCK_ADDR_LEN peerSz = sizeof(peer);
+    NET_SOCK_RTN_CODE ret;
+    NET_ERR err;
+    int dtls_timeout = wolfSSL_dtls_get_current_timeout(ssl);
+
+    WOLFSSL_ENTER("MicriumReceiveFrom()");
+
+    if (ssl->options.handShakeDone)
+        dtls_timeout = 0;
+
+    if (!wolfSSL_get_using_nonblock(ssl)) {
+        /* needs timeout in milliseconds */
+        NetSock_CfgTimeoutRxQ_Set(sd, dtls_timeout * 1000, &err);
+        if (err != NET_SOCK_ERR_NONE) {
+            WOLFSSL_MSG("NetSock_CfgTimeoutRxQ_Set failed");
+        }
+    }
+
+    ret = NetSock_RxDataFrom(sd, buf, sz, ssl->rflags, &peer, &peerSz,
+                             0, 0, 0, &err);
+    if (ret < 0) {
+        WOLFSSL_MSG("Embed Receive From error");
+
+        if (err == NET_ERR_RX || err == NET_SOCK_ERR_RX_Q_EMPTY ||
+            err == NET_ERR_FAULT_LOCK_ACQUIRE) {
+            if (wolfSSL_get_using_nonblock(ssl)) {
+                WOLFSSL_MSG("\tWould block");
+                return WOLFSSL_CBIO_ERR_WANT_READ;
+            }
+            else {
+                WOLFSSL_MSG("\tSocket timeout");
+                return WOLFSSL_CBIO_ERR_TIMEOUT;
+            }
+        } else {
+            WOLFSSL_MSG("\tGeneral error");
+            return WOLFSSL_CBIO_ERR_GENERAL;
+        }
+    }
+    else {
+        if (dtlsCtx->peer.sz > 0
+                && peerSz != (NET_SOCK_ADDR_LEN)dtlsCtx->peer.sz
+                && XMEMCMP(&peer, dtlsCtx->peer.sa, peerSz) != 0) {
+            WOLFSSL_MSG("\tIgnored packet from invalid peer");
+            return WOLFSSL_CBIO_ERR_WANT_READ;
+        }
+    }
+
+    return ret;
+}
+
+/* The Micrium uTCP/IP sendto callback
+ *  return : nb bytes sent, or error
+ */
+int MicriumSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
+{
+    WOLFSSL_DTLS_CTX* dtlsCtx = (WOLFSSL_DTLS_CTX*)ctx;
+    NET_SOCK_ID sd = dtlsCtx->wfd;
+    NET_SOCK_RTN_CODE ret;
+    int len = sz;
+    NET_ERR err;
+
+    WOLFSSL_ENTER("MicriumSendTo()");
+
+    ret = NetSock_TxDataTo(sd, &buf[sz - len], len, ssl->wflags,
+                           (NET_SOCK_ADDR*)dtlsCtx->peer.sa,
+                           (NET_SOCK_ADDR_LEN)dtlsCtx->peer.sz,
+                           &err);
+    if (err < 0) {
+        WOLFSSL_MSG("Embed Send To error");
+
+        if (err == NET_ERR_TX) {
+            WOLFSSL_MSG("\tWould block");
+            return WOLFSSL_CBIO_ERR_WANT_WRITE;
+
+        } else {
+            WOLFSSL_MSG("\tGeneral error");
+            return WOLFSSL_CBIO_ERR_GENERAL;
+        }
+    }
+
+    return ret;
+}
+
+/* Micrium DTLS Generate Cookie callback
+ *  return : number of bytes copied into buf, or error
+ */
+int MicriumGenerateCookie(WOLFSSL* ssl, byte *buf, int sz, void *ctx)
+{
+    NET_SOCK_ADDR peer;
+    NET_SOCK_ADDR_LEN peerSz = sizeof(peer);
+    byte digest[SHA_DIGEST_SIZE];
+    int  ret = 0;
+
+    (void)ctx;
+
+    XMEMSET(&peer, 0, sizeof(peer));
+    if (wolfSSL_dtls_get_peer(ssl, (void*)&peer,
+                              (unsigned int*)&peerSz) != SSL_SUCCESS) {
+        WOLFSSL_MSG("getpeername failed in MicriumGenerateCookie");
+        return GEN_COOKIE_E;
+    }
+
+    ret = wc_ShaHash((byte*)&peer, peerSz, digest);
+    if (ret != 0)
+        return ret;
+
+    if (sz > SHA_DIGEST_SIZE)
+        sz = SHA_DIGEST_SIZE;
+    XMEMCPY(buf, digest, sz);
+
+    return sz;
+}
+
+#endif /* MICRIUM */
+
 #endif /* WOLFCRYPT_ONLY */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5971,7 +5971,9 @@ int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX* ctx, const char* file,
                                      const char* path)
 {
     int ret = SSL_SUCCESS;
+#ifndef NO_WOLFSSL_DIR
     int fileRet;
+#endif
 
     WOLFSSL_ENTER("wolfSSL_CTX_load_verify_locations");
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -1178,12 +1178,12 @@ end:
      */
     word32 TimeNowInMilliseconds(void)
     {
-        NET_SECURE_OS_TICK  clk = 0;
+        OS_TICK ticks = 0;
+        OS_ERR  err;
 
-        #if (NET_SECURE_MGR_CFG_EN == DEF_ENABLED)
-            clk = NetSecure_OS_TimeGet();
-        #endif
-        return (word32)clk * 1000;
+        ticks = OSTimeGet(&err);
+
+        return (word32) (ticks / OSCfg_TickRate_Hz) * 1000;
     }
 #elif defined(MICROCHIP_TCPIP_V5)
     /* The time in milliseconds.

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -120,6 +120,8 @@ void wolfSSL_Debugging_OFF(void)
 #elif defined(WOLFSSL_SGX)
     /* Declare sprintf for ocall */
     int sprintf(char* buf, const char *fmt, ...);
+#elif defined(MICRIUM)
+    #include <bsp_ser.h>
 #else
     #include <stdio.h>   /* for default printf stuff */
 #endif
@@ -137,9 +139,7 @@ static void wolfssl_log(const int logLevel, const char *const logMessage)
 #if defined(THREADX) && !defined(THREADX_NO_DC_PRINTF)
             dc_log_printf("%s\n", logMessage);
 #elif defined(MICRIUM)
-        #if (NET_SECURE_MGR_CFG_EN == DEF_ENABLED)
-            NetSecure_TraceOut((CPU_CHAR *)logMessage);
-        #endif
+            BSP_Ser_Printf("%s\r\n", logMessage);
 #elif defined(WOLFSSL_MDK_ARM)
             fflush(stdout) ;
             printf("%s\n", logMessage);

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -125,6 +125,7 @@ int wc_RNG_GenerateByte(WC_RNG* rng, byte* b)
 #elif defined(WOLFSSL_IAR_ARM)
 #elif defined(WOLFSSL_ROWLEY_ARM)
 #elif defined(WOLFSSL_EMBOS)
+#elif defined(MICRIUM)
 #else
     /* include headers that may be needed to get good seed */
     #include <fcntl.h>
@@ -1209,16 +1210,6 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     return 0;
 }
 
-
-#elif defined(MICRIUM)
-
-int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
-{
-    #if (NET_SECURE_MGR_CFG_EN == DEF_ENABLED)
-        NetSecure_InitSeed(output, sz);
-    #endif
-    return 0;
-}
 
 #elif defined(MICROCHIP_PIC32)
 

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -590,20 +590,24 @@ int wolfSSL_CryptHwMutexUnLock(void) {
 
     int wc_InitMutex(wolfSSL_Mutex* m)
     {
-        #if (NET_SECURE_MGR_CFG_EN == DEF_ENABLED)
-            if (NetSecure_OS_MutexCreate(m) == 0)
-                return 0;
-            else
-                return BAD_MUTEX_E;
-        #else
+        OS_ERR err;
+
+        OSMutexCreate(m, "wolfSSL Mutex", &err);
+
+        if (err == OS_ERR_NONE)
             return 0;
-        #endif
+        else
+            return BAD_MUTEX_E;
     }
 
     int wc_FreeMutex(wolfSSL_Mutex* m)
     {
-        #if (NET_SECURE_MGR_CFG_EN == DEF_ENABLED)
-            if (NetSecure_OS_wc_FreeMutex(m) == 0)
+        #if (OS_CFG_MUTEX_DEL_EN == DEF_ENABLED)
+            OS_ERR err;
+
+            OSMutexDel(m, OS_OPT_DEL_ALWAYS, &err);
+
+            if (err == OS_ERR_NONE)
                 return 0;
             else
                 return BAD_MUTEX_E;
@@ -614,27 +618,26 @@ int wolfSSL_CryptHwMutexUnLock(void) {
 
     int wc_LockMutex(wolfSSL_Mutex* m)
     {
-        #if (NET_SECURE_MGR_CFG_EN == DEF_ENABLED)
-            if (NetSecure_OS_wc_LockMutex(m) == 0)
-                return 0;
-            else
-                return BAD_MUTEX_E;
-        #else
+        OS_ERR err;
+
+        OSMutexPend(m, 0, OS_OPT_PEND_BLOCKING, NULL, &err);
+
+        if (err == OS_ERR_NONE)
             return 0;
-        #endif
+        else
+            return BAD_MUTEX_E;
     }
 
     int wc_UnLockMutex(wolfSSL_Mutex* m)
     {
-        #if (NET_SECURE_MGR_CFG_EN == DEF_ENABLED)
-            if (NetSecure_OS_wc_UnLockMutex(m) == 0)
-                return 0;
-            else
-                return BAD_MUTEX_E;
-        #else
-            return 0;
-        #endif
+        OS_ERR err;
 
+        OSMutexPost(m, OS_OPT_POST_NONE, &err);
+
+        if (err == OS_ERR_NONE)
+            return 0;
+        else
+            return BAD_MUTEX_E;
     }
 
 #elif defined(EBSNET)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -185,6 +185,14 @@
         #define printf dc_log_printf
 #endif
 
+
+#ifdef MICRIUM
+    #include <bsp_ser.h>
+    void BSP_Ser_Printf (CPU_CHAR* format, ...);
+    #undef printf
+    #define printf BSP_Ser_Printf
+#endif
+
 #include "wolfcrypt/test/test.h"
 
 
@@ -7370,21 +7378,21 @@ int rsa_test(void)
             ERROR_OUT(-5572, exit_rsa);
         }
 
-        strncpy(myCert.subject.country, "US", CTC_NAME_SIZE);
-        strncpy(myCert.subject.state, "OR", CTC_NAME_SIZE);
-        strncpy(myCert.subject.locality, "Portland", CTC_NAME_SIZE);
-        strncpy(myCert.subject.org, "yaSSL", CTC_NAME_SIZE);
-        strncpy(myCert.subject.unit, "Development", CTC_NAME_SIZE);
-        strncpy(myCert.subject.commonName, "www.yassl.com", CTC_NAME_SIZE);
-        strncpy(myCert.subject.email, "info@yassl.com", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.country, "US", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.state, "OR", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.locality, "Portland", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.org, "yaSSL", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.unit, "Development", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.commonName, "www.yassl.com", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.email, "info@yassl.com", CTC_NAME_SIZE);
         myCert.isCA    = 1;
         myCert.sigType = CTC_SHA256wRSA;
 
     #ifdef WOLFSSL_CERT_EXT
         /* add Policies */
-        strncpy(myCert.certPolicies[0], "2.16.840.1.101.3.4.1.42",
+        XSTRNCPY(myCert.certPolicies[0], "2.16.840.1.101.3.4.1.42",
                 CTC_MAX_CERTPOL_SZ);
-        strncpy(myCert.certPolicies[1], "1.2.840.113549.1.9.16.6.5",
+        XSTRNCPY(myCert.certPolicies[1], "1.2.840.113549.1.9.16.6.5",
                 CTC_MAX_CERTPOL_SZ);
         myCert.certPoliciesNb = 2;
 
@@ -7522,17 +7530,17 @@ int rsa_test(void)
         myCert.sigType = CTC_SHA256wRSA;
     #endif
 
-        strncpy(myCert.subject.country, "US", CTC_NAME_SIZE);
-        strncpy(myCert.subject.state, "OR", CTC_NAME_SIZE);
-        strncpy(myCert.subject.locality, "Portland", CTC_NAME_SIZE);
-        strncpy(myCert.subject.org, "yaSSL", CTC_NAME_SIZE);
-        strncpy(myCert.subject.unit, "Development", CTC_NAME_SIZE);
-        strncpy(myCert.subject.commonName, "www.yassl.com", CTC_NAME_SIZE);
-        strncpy(myCert.subject.email, "info@yassl.com", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.country, "US", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.state, "OR", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.locality, "Portland", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.org, "yaSSL", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.unit, "Development", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.commonName, "www.yassl.com", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.email, "info@yassl.com", CTC_NAME_SIZE);
 
     #ifdef WOLFSSL_CERT_EXT
         /* add Policies */
-        strncpy(myCert.certPolicies[0], "2.16.840.1.101.3.4.1.42",
+        XSTRNCPY(myCert.certPolicies[0], "2.16.840.1.101.3.4.1.42",
                 CTC_MAX_CERTPOL_SZ);
         myCert.certPoliciesNb =1;
 
@@ -7695,19 +7703,19 @@ int rsa_test(void)
         }
         myCert.sigType = CTC_SHA256wECDSA;
 
-        strncpy(myCert.subject.country, "US", CTC_NAME_SIZE);
-        strncpy(myCert.subject.state, "OR", CTC_NAME_SIZE);
-        strncpy(myCert.subject.locality, "Portland", CTC_NAME_SIZE);
-        strncpy(myCert.subject.org, "wolfSSL", CTC_NAME_SIZE);
-        strncpy(myCert.subject.unit, "Development", CTC_NAME_SIZE);
-        strncpy(myCert.subject.commonName, "www.wolfssl.com", CTC_NAME_SIZE);
-        strncpy(myCert.subject.email, "info@wolfssl.com", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.country, "US", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.state, "OR", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.locality, "Portland", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.org, "wolfSSL", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.unit, "Development", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.commonName, "www.wolfssl.com", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.email, "info@wolfssl.com", CTC_NAME_SIZE);
 
 #ifdef WOLFSSL_CERT_EXT
         /* add Policies */
-        strncpy(myCert.certPolicies[0], "2.4.589440.587.101.2.1.9632587.1",
+        XSTRNCPY(myCert.certPolicies[0], "2.4.589440.587.101.2.1.9632587.1",
                 CTC_MAX_CERTPOL_SZ);
-        strncpy(myCert.certPolicies[1], "1.2.13025.489.1.113549",
+        XSTRNCPY(myCert.certPolicies[1], "1.2.13025.489.1.113549",
                 CTC_MAX_CERTPOL_SZ);
         myCert.certPoliciesNb = 2;
 
@@ -7916,13 +7924,13 @@ int rsa_test(void)
             ERROR_OUT(-5573, exit_rsa);
         }
 
-        strncpy(myCert.subject.country, "US", CTC_NAME_SIZE);
-        strncpy(myCert.subject.state, "OR", CTC_NAME_SIZE);
-        strncpy(myCert.subject.locality, "Portland", CTC_NAME_SIZE);
-        strncpy(myCert.subject.org, "yaSSL", CTC_NAME_SIZE);
-        strncpy(myCert.subject.unit, "Development", CTC_NAME_SIZE);
-        strncpy(myCert.subject.commonName, "www.yassl.com", CTC_NAME_SIZE);
-        strncpy(myCert.subject.email, "info@yassl.com", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.country, "US", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.state, "OR", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.locality, "Portland", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.org, "yaSSL", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.unit, "Development", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.commonName, "www.yassl.com", CTC_NAME_SIZE);
+        XSTRNCPY(myCert.subject.email, "info@yassl.com", CTC_NAME_SIZE);
         myCert.daysValid = 1000;
 
     #ifdef WOLFSSL_CERT_EXT
@@ -8067,14 +8075,14 @@ int rsa_test(void)
 
         req.version = 0;
         req.isCA    = 1;
-        strncpy(req.challengePw, "yassl123", CTC_NAME_SIZE);
-        strncpy(req.subject.country, "US", CTC_NAME_SIZE);
-        strncpy(req.subject.state, "OR", CTC_NAME_SIZE);
-        strncpy(req.subject.locality, "Portland", CTC_NAME_SIZE);
-        strncpy(req.subject.org, "yaSSL", CTC_NAME_SIZE);
-        strncpy(req.subject.unit, "Development", CTC_NAME_SIZE);
-        strncpy(req.subject.commonName, "www.yassl.com", CTC_NAME_SIZE);
-        strncpy(req.subject.email, "info@yassl.com", CTC_NAME_SIZE);
+        XSTRNCPY(req.challengePw, "yassl123", CTC_NAME_SIZE);
+        XSTRNCPY(req.subject.country, "US", CTC_NAME_SIZE);
+        XSTRNCPY(req.subject.state, "OR", CTC_NAME_SIZE);
+        XSTRNCPY(req.subject.locality, "Portland", CTC_NAME_SIZE);
+        XSTRNCPY(req.subject.org, "yaSSL", CTC_NAME_SIZE);
+        XSTRNCPY(req.subject.unit, "Development", CTC_NAME_SIZE);
+        XSTRNCPY(req.subject.commonName, "www.yassl.com", CTC_NAME_SIZE);
+        XSTRNCPY(req.subject.email, "info@yassl.com", CTC_NAME_SIZE);
         req.sigType = CTC_SHA256wRSA;
 
     #ifdef WOLFSSL_CERT_EXT

--- a/wolfssl/io.h
+++ b/wolfssl/io.h
@@ -35,7 +35,8 @@
 #endif
 
 #if !defined(WOLFSSL_USER_IO)
-    #ifndef USE_WOLFSSL_IO
+    /* Micrium uses NetSock I/O callbacks in io.c */
+    #if !defined(USE_WOLFSSL_IO) && !defined(MICRIUM)
         #define USE_WOLFSSL_IO
     #endif
 #endif
@@ -373,6 +374,15 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
     WOLFSSL_API void wolfSSL_SetIO_NetX(WOLFSSL* ssl, NX_TCP_SOCKET* nxsocket,
                                       ULONG waitoption);
 #endif /* HAVE_NETX */
+
+#ifdef MICRIUM
+    WOLFSSL_LOCAL int MicriumSend(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+    WOLFSSL_LOCAL int MicriumReceive(WOLFSSL* ssl, char* buf, int sz,
+                                     void* ctx);
+    WOLFSSL_LOCAL int MicriumReceiveFrom(WOLFSSL* ssl, char* buf, int sz,
+                                         void* ctx);
+    WOLFSSL_LOCAL int MicriumSendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+#endif /* MICRIUM */
 
 #ifdef WOLFSSL_DTLS
     typedef int (*CallbackGenCookie)(WOLFSSL* ssl, unsigned char* buf, int sz,

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -37,7 +37,7 @@
 /* Uncomment next line if using ThreadX */
 /* #define THREADX */
 
-/* Uncomment next line if using Micrium ucOS */
+/* Uncomment next line if using Micrium uC/OS-III */
 /* #define MICRIUM */
 
 /* Uncomment next line if using Mbed */
@@ -1013,28 +1013,47 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 #ifdef MICRIUM
+    #include <stdlib.h>
+    #include <os.h>
+    #include <net_cfg.h>
+    #include <net_sock.h>
+    #include <net_err.h>
+    #include <lib_mem.h>
+    #include <lib_math.h>
 
-    #include "stdlib.h"
-    #include "net_cfg.h"
-    #include "ssl_cfg.h"
-    #include "net_secure_os.h"
+    #define USE_FAST_MATH
+    #define TFM_TIMING_RESISTANT
+    #define ECC_TIMING_RESISTANT
+    #define WC_RSA_BLINDING
+    #define HAVE_HASHDRBG
+
+    #define HAVE_ECC
+    #define ALT_ECC_SIZE
+    #define TFM_ECC192
+    #define TFM_ECC224
+    #define TFM_ECC256
+    #define TFM_ECC384
+    #define TFM_ECC521
+
+    #define NO_RC4
+    #define HAVE_TLS_EXTENSIONS
+    #define HAVE_SUPPORTED_CURVES
+    #define HAVE_EXTENDED_MASTER
+
+    #define NO_WOLFSSL_DIR
+    #define NO_WRITEV
+
+    #ifndef CUSTOM_RAND_GENERATE
+        #define CUSTOM_RAND_TYPE     RAND_NBR
+        #define CUSTOM_RAND_GENERATE Math_Rand
+    #endif
 
     #define WOLFSSL_TYPES
-
     typedef CPU_INT08U byte;
     typedef CPU_INT16U word16;
     typedef CPU_INT32U word32;
 
-    #if (NET_SECURE_MGR_CFG_WORD_SIZE == CPU_WORD_SIZE_32)
-        #define SIZEOF_LONG        4
-        #undef  SIZEOF_LONG_LONG
-    #else
-        #undef  SIZEOF_LONG
-        #define SIZEOF_LONG_LONG   8
-    #endif
-
     #define STRING_USER
-
     #define XSTRLEN(pstr) ((CPU_SIZE_T)Str_Len((CPU_CHAR *)(pstr)))
     #define XSTRNCPY(pstr_dest, pstr_src, len_max) \
                     ((CPU_CHAR *)Str_Copy_N((CPU_CHAR *)(pstr_dest), \
@@ -1042,9 +1061,18 @@ extern void uITRON4_free(void *p) ;
     #define XSTRNCMP(pstr_1, pstr_2, len_max) \
                     ((CPU_INT16S)Str_Cmp_N((CPU_CHAR *)(pstr_1), \
                      (CPU_CHAR *)(pstr_2), (CPU_SIZE_T)(len_max)))
+    #define XSTRNCASECMP(pstr_1, pstr_2, len_max) \
+                    ((CPU_INT16S)Str_CmpIgnoreCase_N((CPU_CHAR *)(pstr_1), \
+                     (CPU_CHAR *)(pstr_2), (CPU_SIZE_T)(len_max)))
     #define XSTRSTR(pstr, pstr_srch) \
                     ((CPU_CHAR *)Str_Str((CPU_CHAR *)(pstr), \
                      (CPU_CHAR *)(pstr_srch)))
+    #define XSTRNSTR(pstr, pstr_srch, len_max) \
+                    ((CPU_CHAR *)Str_Str_N((CPU_CHAR *)(pstr), \
+                     (CPU_CHAR *)(pstr_srch),(CPU_SIZE_T)(len_max)))
+    #define XSTRNCAT(pstr_dest, pstr_cat, len_max) \
+                    ((CPU_CHAR *)Str_Cat_N((CPU_CHAR *)(pstr_dest), \
+                     (const CPU_CHAR *)(pstr_cat),(CPU_SIZE_T)(len_max)))
     #define XMEMSET(pmem, data_val, size) \
                     ((void)Mem_Set((void *)(pmem), (CPU_INT08U) (data_val), \
                     (CPU_SIZE_T)(size)))
@@ -1055,85 +1083,8 @@ extern void uITRON4_free(void *p) ;
                      (CPU_SIZE_T)(size))) ? DEF_NO : DEF_YES)
     #define XMEMMOVE XMEMCPY
 
-#if (NET_SECURE_MGR_CFG_EN == DEF_ENABLED)
-    #define MICRIUM_MALLOC
-    #define XMALLOC(s, h, type) ((void *)NetSecure_BlkGet((CPU_INT08U)(type), \
-                                 (CPU_SIZE_T)(s), (void *)0))
-    #define XFREE(p, h, type)   (NetSecure_BlkFree((CPU_INT08U)(type), \
-                                 (p), (void *)0))
-    #define XREALLOC(p, n, h, t) realloc((p), (n))
-#endif
-
-    #if (NET_SECURE_MGR_CFG_FS_EN == DEF_ENABLED)
-        #undef  NO_FILESYSTEM
-    #else
-        #define NO_FILESYSTEM
-    #endif
-
-    #if (SSL_CFG_TRACE_LEVEL == WOLFSSL_TRACE_LEVEL_DBG)
-        #define DEBUG_WOLFSSL
-    #else
-        #undef  DEBUG_WOLFSSL
-    #endif
-
-    #if (SSL_CFG_OPENSSL_EN == DEF_ENABLED)
-        #define OPENSSL_EXTRA
-    #else
-        #undef  OPENSSL_EXTRA
-    #endif
-
-    #if (SSL_CFG_MULTI_THREAD_EN == DEF_ENABLED)
-        #undef  SINGLE_THREADED
-    #else
+    #if (OS_CFG_MUTEX_EN == DEF_DISABLED)
         #define SINGLE_THREADED
-    #endif
-
-    #if (SSL_CFG_DH_EN == DEF_ENABLED)
-        #undef  NO_DH
-    #else
-        #define NO_DH
-    #endif
-
-    #if (SSL_CFG_DSA_EN == DEF_ENABLED)
-        #undef  NO_DSA
-    #else
-        #define NO_DSA
-    #endif
-
-    #if (SSL_CFG_PSK_EN == DEF_ENABLED)
-        #undef  NO_PSK
-    #else
-        #define NO_PSK
-    #endif
-
-    #if (SSL_CFG_3DES_EN == DEF_ENABLED)
-        #undef  NO_DES
-    #else
-        #define NO_DES
-    #endif
-
-    #if (SSL_CFG_AES_EN == DEF_ENABLED)
-        #undef  NO_AES
-    #else
-        #define NO_AES
-    #endif
-
-    #if (SSL_CFG_RC4_EN == DEF_ENABLED)
-        #undef  NO_RC4
-    #else
-        #define NO_RC4
-    #endif
-
-    #if (SSL_CFG_RABBIT_EN == DEF_ENABLED)
-        #undef  NO_RABBIT
-    #else
-        #define NO_RABBIT
-    #endif
-
-    #if (SSL_CFG_HC128_EN == DEF_ENABLED)
-        #undef  NO_HC128
-    #else
-        #define NO_HC128
     #endif
 
     #if (CPU_CFG_ENDIAN_TYPE == CPU_ENDIAN_TYPE_BIG)
@@ -1142,69 +1093,6 @@ extern void uITRON4_free(void *p) ;
         #undef  BIG_ENDIAN_ORDER
         #define LITTLE_ENDIAN_ORDER
     #endif
-
-    #if (SSL_CFG_MD4_EN == DEF_ENABLED)
-        #undef  NO_MD4
-    #else
-        #define NO_MD4
-    #endif
-
-    #if (SSL_CFG_WRITEV_EN == DEF_ENABLED)
-        #undef  NO_WRITEV
-    #else
-        #define NO_WRITEV
-    #endif
-
-    #if (SSL_CFG_USER_RNG_SEED_EN == DEF_ENABLED)
-        #define NO_DEV_RANDOM
-    #else
-        #undef  NO_DEV_RANDOM
-    #endif
-
-    #if (SSL_CFG_USER_IO_EN == DEF_ENABLED)
-        #define WOLFSSL_USER_IO
-    #else
-        #undef  WOLFSSL_USER_IO
-    #endif
-
-    #if (SSL_CFG_DYNAMIC_BUFFERS_EN == DEF_ENABLED)
-        #undef  LARGE_STATIC_BUFFERS
-        #undef  STATIC_CHUNKS_ONLY
-    #else
-        #define LARGE_STATIC_BUFFERS
-        #define STATIC_CHUNKS_ONLY
-    #endif
-
-    #if (SSL_CFG_DER_LOAD_EN == DEF_ENABLED)
-        #define  WOLFSSL_DER_LOAD
-    #else
-        #undef   WOLFSSL_DER_LOAD
-    #endif
-
-    #if (SSL_CFG_DTLS_EN == DEF_ENABLED)
-        #define  WOLFSSL_DTLS
-    #else
-        #undef   WOLFSSL_DTLS
-    #endif
-
-    #if (SSL_CFG_CALLBACKS_EN == DEF_ENABLED)
-         #define WOLFSSL_CALLBACKS
-    #else
-         #undef  WOLFSSL_CALLBACKS
-    #endif
-
-    #if (SSL_CFG_FAST_MATH_EN == DEF_ENABLED)
-         #define USE_FAST_MATH
-    #else
-         #undef  USE_FAST_MATH
-    #endif
-
-    #if (SSL_CFG_TFM_TIMING_RESISTANT_EN == DEF_ENABLED)
-         #define TFM_TIMING_RESISTANT
-    #else
-         #undef  TFM_TIMING_RESISTANT
-    #endif
-
 #endif /* MICRIUM */
 
 

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -242,7 +242,7 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XBADFILE                NULL
     #define XFGETS                  fgets
 #elif defined(MICRIUM)
-    #include <fs.h>
+    #include <fs_api.h>
     #define XFILE      FS_FILE*
     #define XFOPEN     fs_fopen
     #define XFSEEK     fs_fseek


### PR DESCRIPTION
This PR updates our port to Micrium uC/OS-III.

This was tested against the following software versions:

| Software Package | Version |
| --- | --- |
| uC/OS-III | 3.04.05 |
| uC/TCP-IP | 3.03.00 |
| uC/CPU | 1.31.02 |
| uC/LIB | 1.38.01 |
| uC/CLK | 3.09.03 |
| uC/FS | 4.07.00 |
| uC/DNSc | 2.00.01 |
| uC/SNTPc | 2.00.00 |
| IAR EWARM | 8.11.2.13606 |

For I/O, this uses the uC/OS-III NetSock API, and includes I/O callbacks in ./src/io.c for TCP (MicriumSend(), MicriumReceive()), and UDP (MicriumSentTo(), MicriumReceiveFrom()).

This was tested using the Freescale/NXP TWR-K70F120M board (Kinetis K70), including:
- wolfCrypt tests pass
- Acting as a TLS client to google.com
- Acting as a TLS client to wolfSSL example server on OS X
- Acting as a TLS server for the wolfSSL example client on OS X
- Acting as a DTLS client to wolfSSL example server on OS X
- Acting as a DTLS server to wolfSSL example client on OS X

**Notes:**

WOLFSSL_SESSION_EXPORT is not yet supported, would need EmbedGetPeer() and EmbedSetPeer() callbacks implemented.

HAVE_CRL is not yet supported, would need EmbedCrlLookup() callback implemented.

HAVE_OCSP is not yet supported, would need EmbedOCSPLookup() callback implemented.
