### PR TITLE
Fix for test script: add ECDH-RSA server for interop tests

### DIFF
--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -4,16 +4,18 @@
 
 # need a unique port since may run the same time as testsuite
 generate_port() {
-    openssl_port=`LC_CTYPE=C tr -cd 0-9 </dev/urandom | head -c 7`
-    openssl_port=$((`LC_CTYPE=C tr -cd 1-9 </dev/urandom | head -c 1`$openssl_port))
-    openssl_port=$(($openssl_port % (65535-49512)))
-    openssl_port=$(($openssl_port + 49512))
+    port=`LC_CTYPE=C tr -cd 0-9 </dev/urandom | head -c 7`
+    port=$((`LC_CTYPE=C tr -cd 1-9 </dev/urandom | head -c 1`$port))
+    port=$(($port % (65535-49512)))
+    port=$(($port + 49512))
 }
 
 
 generate_port
+openssl_port=$port
 no_pid=-1
 server_pid=$no_pid
+ecdh_server_pid=$no_pid
 wolf_suites_tested=0
 wolf_suites_total=0
 counter=0
@@ -47,6 +49,12 @@ do_cleanup() {
         echo "killing server"
         kill -9 $server_pid
     fi
+
+    if  [ $ecdh_server_pid != $no_pid ]
+    then
+        echo "killing ECDH-RSA server"
+        kill -9 $ecdh_server_pid
+    fi
 }
 
 do_trap() {
@@ -77,6 +85,8 @@ then
 fi
 
 
+# get wolfssl ciphers
+wolf_ciphers=`./examples/client/client -e`
 
 found_free_port=0
 while [ "$counter" -lt 20 ]; do
@@ -96,6 +106,7 @@ while [ "$counter" -lt 20 ]; do
         #port already started, try a different port
         counter=$((counter+ 1))
         generate_port
+        openssl_port=$port
     fi
 done
 
@@ -106,8 +117,42 @@ then
     exit 1
 fi
 
-# get wolfssl ciphers
-wolf_ciphers=`./examples/client/client -e`
+# if ECDH-RSA is enabled then start up server for ECDH-RSA suites
+case $wolf_ciphers in
+*ECDH-RSA*)
+    generate_port
+    ecdh_port=$port
+    found_free_port=0
+    counter=0
+    while [ "$counter" -lt 20 ]; do
+        echo -e "\nTrying to start ECDH-RSA openssl server on port $ecdh_port...\n"
+
+        openssl s_server -accept $ecdh_port -cert ./certs/server-ecc-rsa.pem -key ./certs/ecc-key.pem  -quiet -CAfile ./certs/client-ca.pem -www -dhparam ./certs/dh2048.pem -verify 10 -verify_return_error -cipher "ALL:eNULL" &
+        ecdh_server_pid=$!
+        # wait to see if s_server successfully starts before continuing
+        sleep 0.1
+
+        if ps -p $ecdh_server_pid > /dev/null
+        then
+            echo "s_server started successfully on port $ecdh_port"
+            found_free_port=1
+            break
+        else
+            #port already started, try a different port
+            counter=$((counter+ 1))
+            generate_port
+            ecdh_port=$port
+        fi
+    done
+
+    if [ $found_free_port = 0 ]
+    then
+        echo -e "Couldn't find free port for server"
+        do_cleanup
+        exit 1
+    fi
+    ;;
+esac
 
 # server should be ready, let's make sure
 server_ready=0
@@ -217,17 +262,20 @@ do
 
         # check for psk suite and turn on client psk if so
         psk=""
+        port=$openssl_port
         case $wolfSuite in
+        *ECDH-RSA*)
+            port=$ecdh_port ;;
         *PSK*)
             psk="-s " ;;
         esac
 
         if [ $version -lt 4 ]
         then
-            ./examples/client/client -p $openssl_port -g -r -l $wolfSuite -v $version $psk
+            ./examples/client/client -p $port -g -r -l $wolfSuite -v $version $psk
         else
             # do all versions
-            ./examples/client/client -p $openssl_port -g -r -l $wolfSuite $psk
+            ./examples/client/client -p $port -g -r -l $wolfSuite $psk
         fi
 
         client_result=$?
@@ -252,6 +300,10 @@ done
 IFS=$OIFS #restore separator
 
 kill -9 $server_pid
+if  [ $ecdh_server_pid != $no_pid ]
+then
+    kill -9 $ecdh_server_pid
+fi
 
 echo -e "wolfSSL total suites   $wolf_suites_total"
 echo -e "wolfSSL suites tested  $wolf_suites_tested"


### PR DESCRIPTION
With setting the cipher suite ECDH-RSA-AES128-SHA the wolfSSL client sends RSA as a supported sig algo and does not send ECDSA as supported. The OpenSSL server then seems to have trouble using an ECDSA signed certificate such as server-ecc.pem. To avoid this missmatch, in the case that a ECDH-RSA cipher suite is enabled a second OpenSSL server is started that uses the server-ecc-rsa.pem certificate.

The issue this addresses can be seen with 
```
export WOLFSSL_OPENSSL_TEST=1
./configure C_EXTRA_FLAGS=-DWOLFSSL_STATIC_DH
make
./scripts/openssl.test
```
