### PR TITLE
Fixes for STM32 hardware acceleration

### DIFF
--- a/IDE/MDK-ARM/STM32F2xx_StdPeriph_Lib/time-STM32F2xx.c
+++ b/IDE/MDK-ARM/STM32F2xx_StdPeriph_Lib/time-STM32F2xx.c
@@ -1,4 +1,4 @@
-/* main.c
+/* time-STM32F2xx.c
  *
  * Copyright (C) 2006-2016 wolfSSL Inc.
  *
@@ -19,16 +19,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
- 
+
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
 
 #include "time.h"
 
-#define PERIPH_BASE           ((uint32_t)0x40000000) 
+#define PERIPH_BASE           ((uint32_t)0x40000000)
 /*-----------------------------------------------------------------------------
- *        initialize RTC 
+ *        initialize RTC
  *----------------------------------------------------------------------------*/
 #include "stm32f2xx.h"
 
@@ -46,15 +46,15 @@
 #define CR_OFFSET            (PWR_OFFSET + 0x00)
 #define DBP_BitNumber        0x08
 #define CR_DBP_BB     (PERIPH_BB_BASE + (CR_OFFSET * 32) + (DBP_BitNumber * 4))
-#define RTC_INIT_MASK        ((uint32_t)0xFFFFFFFF)  
+#define RTC_INIT_MASK        ((uint32_t)0xFFFFFFFF)
 #define INITMODE_TIMEOUT     ((uint32_t) 0x00010000)
 
-static void init_RTC() 
+static void init_RTC()
 {
     __IO uint32_t initcounter =  0x00 ;
-    uint32_t initstatus = 0x00;    /* Enable the PWR clock : RCC_APB1Periph_PWR  */       
+    uint32_t initstatus = 0x00;    /* Enable the PWR clock : RCC_APB1Periph_PWR  */
     ((uint32_t *)RCC)[0x10] |= ((uint32_t)0x10000000) ;
-    
+
     /* Allow access to RTC */
     *(__IO uint32_t *) CR_DBP_BB = ENABLE ;
       /* RCC_LSEConfig(RCC_LSE_ON) */
@@ -62,7 +62,7 @@ static void init_RTC()
     /* Reset LSEBYP bit */
     *(__IO uint8_t *) (RCC_BASE + 0x70) =  ((uint8_t)0x00);
     *(__IO uint8_t *) (RCC_BASE + 0x70) =  ((uint8_t)0x01);
-    /* Wait till LSE is ready */  
+    /* Wait till LSE is ready */
         while((RCC->BDCR << 0x2) == 0x0) { }
       /* Select the RTC clock source: RCC_RTCCLKSource_LSE */
     ((RCC_TypeDef *)RCC)->BDCR |= (uint32_t)0x00000100;
@@ -70,13 +70,13 @@ static void init_RTC()
     /* Enable the RTC Clock */
     *(__IO uint32_t *)  (PERIPH_BB_BASE + (((RCC_BASE - PERIPH_BASE)+ 0x70) * 32) + (0x0F* 4)) = (uint32_t)ENABLE;
 
-    *(__IO uint32_t *) CR_DBP_BB = (uint32_t)ENABLE; 
+    *(__IO uint32_t *) CR_DBP_BB = (uint32_t)ENABLE;
     RTC->ISR = (uint32_t) RTC_INIT_MASK;
     do {
       initstatus = RTC->ISR & RTC_ISR_INITF;
-      initcounter++;  
+      initcounter++;
     } while((initcounter != INITMODE_TIMEOUT) && (initstatus == 0x00));
-    
+
     /* Disable the write protection for RTC registers */
     RTC->WPR = 0xCA;
     RTC->WPR = 0x53;
@@ -86,14 +86,14 @@ static void init_RTC()
     RTC->CR |=   ((uint32_t)0x00000000) ;   /* RTC_HourFormat_24 */
 
     /* Configure the RTC PRER */
-    RTC->PRER = 0x7f ; 
+    RTC->PRER = 0x7f ;
     RTC->PRER |= (uint32_t)(0xff << 16);
 
     /* Exit Initialization mode */
-    RTC->ISR &= (uint32_t)~RTC_ISR_INIT; 
+    RTC->ISR &= (uint32_t)~RTC_ISR_INIT;
 
     /* Enable the write protection for RTC registers */
-    RTC->WPR = 0xFF; 
+    RTC->WPR = 0xFF;
 }
 
 /*-----------------------------------------------------------------------------
@@ -108,16 +108,16 @@ static void init_TIM()
     ((uint32_t *)RCC)[0x10] |= RCC_APB1Periph_TIM2 ;
 
     tmpcr1 = TIM2->CR1 ;
-    tmpcr1 &=   (uint16_t) (~(((uint16_t)0x0010) | ((uint16_t)0x0060) )); 
+    tmpcr1 &=   (uint16_t) (~(((uint16_t)0x0010) | ((uint16_t)0x0060) ));
                                      /* CR1 &= ~(TIM_CR1_DIR | TIM_CR1_CMS) */
     tmpcr1 |= (uint16_t)0x0000  ;    /* CR1 |= TIM_CounterMode_Up */
     TIM2->CR1=  tmpcr1 ;
 
     TIM2->ARR = 0xffffffff ;         /* ARR= TIM_Period */
     TIM2->PSC = 60 ;                 /* PSC = TIM_Prescaler */
-    TIM2->EGR = ((uint16_t)0x0001) ; /* EGR = TIM_PSCReloadMode_Immediate */      
+    TIM2->EGR = ((uint16_t)0x0001) ; /* EGR = TIM_PSCReloadMode_Immediate */
 
-    *(uint16_t *)(PERIPH_BASE+0x0) |=((uint16_t)0x0001) ; 
+    *(uint16_t *)(PERIPH_BASE+0x0) |=((uint16_t)0x0001) ;
                                      /* TIM_Cmd(TIM2, ENABLE) ; */
 }
 
@@ -129,10 +129,10 @@ void init_time(void) {
 static void GetTime(uint8_t *h, uint8_t *m, uint8_t *s)
 {
     uint32_t tmpreg = 0;
-    tmpreg = (uint32_t)(RTC->TR & RTC_TR_RESERVED_MASK); 
+    tmpreg = (uint32_t)(RTC->TR & RTC_TR_RESERVED_MASK);
     *h = (uint8_t)Bcd2ToByte((uint8_t)((tmpreg & (RTC_TR_HT | RTC_TR_HU)) >> 16));
     *m = (uint8_t)Bcd2ToByte((uint8_t)((tmpreg & (RTC_TR_MNT | RTC_TR_MNU)) >>8));
-    *s = (uint8_t)Bcd2ToByte((tmpreg & (RTC_TR_ST | RTC_TR_SU))); 
+    *s = (uint8_t)Bcd2ToByte((tmpreg & (RTC_TR_ST | RTC_TR_SU)));
 }
 
 static uint32_t ByteToBcd2(uint8_t Value)
@@ -151,29 +151,29 @@ static void SetTime(uint8_t h, uint8_t m, uint8_t s)
      uint32_t synchrostatus = 0x00;
      __IO uint32_t initcounter = 0;
      uint32_t initstatus = 0x00;
-     uint32_t tmpreg ;  
+     uint32_t tmpreg ;
 
      tmpreg = ((ByteToBcd2(h) << 16) | (ByteToBcd2(m) << 8) |  ByteToBcd2(s)) ;
      /* Disable the write protection for RTC registers */
      RTC->WPR = 0xCA;
      RTC->WPR = 0x53;
-     RTC->ISR &= (uint32_t)~RTC_ISR_INIT; 
+     RTC->ISR &= (uint32_t)~RTC_ISR_INIT;
 
      RTC->ISR = (uint32_t)RTC_INIT_MASK;
 
      /* Wait till RTC is in INIT state and if Time out is reached exit */
      do {
          initstatus = RTC->ISR & RTC_ISR_INITF;
-         initcounter++;  
+         initcounter++;
      } while((initcounter != INITMODE_TIMEOUT) && (initstatus == 0x00));
-    
+
      RTC->TR = (uint32_t)(tmpreg & RTC_TR_RESERVED_MASK);
-    
+
      RTC->ISR &= (uint32_t)RTC_RSF_MASK;
      /* Wait the registers to be synchronised */
      do {
          synchrostatus = RTC->ISR & RTC_ISR_RSF;
-         synchrocounter++;  
+         synchrocounter++;
      } while((synchrocounter != SYNCHRO_TIMEOUT) && (synchrostatus == 0x00));
 
      RTC->WPR = 0xFF;
@@ -182,7 +182,7 @@ static void SetTime(uint8_t h, uint8_t m, uint8_t s)
 static void GetDate(uint8_t *y, uint8_t *m, uint8_t *d)
 {
     uint32_t tmpreg = 0;
-    tmpreg = (uint32_t)(RTC->DR & RTC_TR_RESERVED_MASK); 
+    tmpreg = (uint32_t)(RTC->DR & RTC_TR_RESERVED_MASK);
     *y = (uint8_t)Bcd2ToByte((uint8_t)((tmpreg & (RTC_DR_YT|RTC_DR_YU)) >>16));
     *m = (uint8_t)Bcd2ToByte((uint8_t)((tmpreg & (RTC_DR_MT|RTC_DR_MU)) >> 8));
     *d = (uint8_t)Bcd2ToByte((uint8_t)(tmpreg & (RTC_DR_DT |RTC_DR_DU)));
@@ -194,20 +194,20 @@ static void SetDate(uint8_t y, uint8_t m, uint8_t d)
      uint32_t synchrostatus = 0x00;
      __IO uint32_t initcounter = 0;
      uint32_t initstatus = 0x00;
-     uint32_t tmpreg = 0 ;  
-    
+     uint32_t tmpreg = 0 ;
+
     tmpreg = ((ByteToBcd2(y) << 16) | (ByteToBcd2(m) << 8) |  ByteToBcd2(d)) ;
     /* Disable the write protection for RTC registers */
     RTC->WPR = 0xCA;
     RTC->WPR = 0x53;
-    RTC->ISR &= (uint32_t)~RTC_ISR_INIT; 
+    RTC->ISR &= (uint32_t)~RTC_ISR_INIT;
 
     RTC->ISR = (uint32_t)RTC_INIT_MASK;
 
     /* Wait till RTC is in INIT state and if Time out is reached exit */
     do {
         initstatus = RTC->ISR & RTC_ISR_INITF;
-        initcounter++;  
+        initcounter++;
     } while((initcounter != INITMODE_TIMEOUT) && (initstatus == 0x00));
 
     RTC->DR = (uint32_t)(tmpreg & RTC_TR_RESERVED_MASK);
@@ -216,7 +216,7 @@ static void SetDate(uint8_t y, uint8_t m, uint8_t d)
     /* Wait the registers to be synchronised */
     do {
         synchrostatus = RTC->ISR & RTC_ISR_RSF;
-        synchrocounter++;  
+        synchrocounter++;
     } while((synchrocounter != SYNCHRO_TIMEOUT) && (synchrostatus == 0x00));
 
     RTC->WPR = 0xFF;
@@ -226,11 +226,11 @@ static void SetDate(uint8_t y, uint8_t m, uint8_t d)
 #include <stdio.h>
 void CYASSL_MSG(const char *msg) ;
 
-struct tm *Cyassl_MDK_gmtime(const time_t *c) 
-{ 
+struct tm *Cyassl_MDK_gmtime(const time_t *c)
+{
     uint8_t h, m, s ;
     uint8_t y, mo, d ;
-    static struct tm date ; 
+    static struct tm date ;
 
     GetTime(&h, &m, &s) ;
     GetDate(&y, &mo, &d) ;
@@ -242,20 +242,20 @@ struct tm *Cyassl_MDK_gmtime(const time_t *c)
     date.tm_min = m ;
     date.tm_sec = s ;
 
-    #if defined(DEBUG_CYASSL) 
+    #if defined(DEBUG_CYASSL)
     {
         char msg[100] ;
-        sprintf(msg, 
+        sprintf(msg,
         "Debug::Cyassl_KEIL_gmtime(DATE=/%2d/%02d/%04d TIME=%02d:%02d:%02d)\n",
-                d,  mo,  y+2000, h,  m,  s) ; 
-        CYASSL_MSG(msg) ;   
+                d,  mo,  y+2000, h,  m,  s) ;
+        CYASSL_MSG(msg) ;
     }
     #endif
-    
+
     return(&date) ;
 }
 
-double current_time() 
+double current_time()
 {
       return ((double)TIM2->CNT/1000000.0) ;
 }
@@ -266,35 +266,35 @@ typedef struct func_args {
     int    return_code;
 } func_args;
 
-void time_main(void *args) 
+void time_main(void *args)
 {
     char * datetime ;
     uint8_t h, m, s ;
     uint8_t y, mo, d ;
-    
+
     if( args == NULL || ((func_args *)args)->argc == 1) {
         GetTime(&h, &m, &s) ;
         GetDate(&y, &mo, &d) ;
-        printf("Date: %d/%d/%d, Time: %02d:%02d:%02d\n", 
-             mo, d, y+2000, h, m, s) ;              
-    } else if(((func_args *)args)->argc == 3 && 
-              ((func_args *)args)->argv[1][0] == '-' && 
+        printf("Date: %d/%d/%d, Time: %02d:%02d:%02d\n",
+             mo, d, y+2000, h, m, s) ;
+    } else if(((func_args *)args)->argc == 3 &&
+              ((func_args *)args)->argv[1][0] == '-' &&
               ((func_args *)args)->argv[1][1] == 'd' ) {
         datetime = ((func_args *)args)->argv[2];
         sscanf(datetime, "%d/%d/%d", (int *)&mo, (int *)&d, (int *) &y) ;
-        SetDate(y-2000, mo, d) ;        
-    } else if(((func_args *)args)->argc == 3 && 
-              ((func_args *)args)->argv[1][0] == '-' && 
+        SetDate(y-2000, mo, d) ;
+    } else if(((func_args *)args)->argc == 3 &&
+              ((func_args *)args)->argv[1][0] == '-' &&
               ((func_args *)args)->argv[1][1] == 't' ) {
         datetime = ((func_args *)args)->argv[2];
-        sscanf(datetime, "%d:%d:%d",            
+        sscanf(datetime, "%d:%d:%d",
             (int *)&h, (int *)&m, (int *)&s) ;
         SetTime(h, m, s) ;
-    } else printf("Invalid argument\n") ; 
+    } else printf("Invalid argument\n") ;
 }
 
 
 /*******************************************************************
-      time()                                                                      
+      time()
 ********************************************************************/
 time_t time(time_t * t) { return 0 ; }

--- a/IDE/OPENSTM32/Inc/user_settings.h
+++ b/IDE/OPENSTM32/Inc/user_settings.h
@@ -25,6 +25,11 @@ extern "C" {
 #undef  WOLFSSL_STM32_CUBEMX
 #define WOLFSSL_STM32_CUBEMX
 
+/* Optionally Disable Hardware Hashing Support */
+//#define NO_STM32_HASH
+//#define NO_STM32_RNG
+//#define NO_STM32_CRYPTO
+
 #undef  FREERTOS
 //#define FREERTOS
 
@@ -121,9 +126,9 @@ extern "C" {
     #undef  RSA_LOW_MEM
     //#define RSA_LOW_MEM
 
-	/* Enables blinding mode, to prevent timing attacks */
-	#undef  WC_RSA_BLINDING
-	#define WC_RSA_BLINDING
+    /* Enables blinding mode, to prevent timing attacks */
+    #undef  WC_RSA_BLINDING
+    #define WC_RSA_BLINDING
 
 #else
     #define NO_RSA
@@ -192,6 +197,9 @@ extern "C" {
 /* Sha256 */
 #undef NO_SHA256
 #if 1
+    #if 1
+        #define WOLFSSL_SHA224
+    #endif
 #else
     #define NO_SHA256
 #endif
@@ -214,7 +222,7 @@ extern "C" {
 /* MD5 */
 #undef  NO_MD5
 #if 1
-	/* enabled */
+    /* enabled */
 #else
     #define NO_MD5
 #endif
@@ -282,22 +290,22 @@ extern "C" {
 #define NO_OLD_RNGNAME
 
 /* Choose RNG method */
-#if 0
 #if 1
     /* Use built-in P-RNG (SHA256 based) with HW RNG */
     /* P-RNG + HW RNG (P-RNG is ~8K) */
     #undef  HAVE_HASHDRBG
     #define HAVE_HASHDRBG
 
-    extern unsigned int custom_rand_generate(void);
-    #undef  CUSTOM_RAND_GENERATE
-    #define CUSTOM_RAND_GENERATE  custom_rand_generate
+    #if 0
+        extern unsigned int custom_rand_generate(void);
+        #undef  CUSTOM_RAND_GENERATE
+        #define CUSTOM_RAND_GENERATE  custom_rand_generate
+    #endif
 #else
     /* Bypass P-RNG and use only HW RNG */
     extern int custom_rand_generate_block(unsigned char* output, unsigned int sz);
     #undef  CUSTOM_RAND_GENERATE_BLOCK
     #define CUSTOM_RAND_GENERATE_BLOCK  custom_rand_generate_block
-#endif
 #endif
 
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -256,7 +256,7 @@
 
 
 /* Define AES implementation includes and functions */
-#if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+#if defined(STM32_CRYPTO)
      /* STM32F2/F4 hardware AES support for CBC, CTR modes */
 
     /* CRYPT_AES_GCM starts the IV with 2 */
@@ -1782,7 +1782,7 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 
 
 /* wc_AesSetKey */
-#if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+#if defined(STM32_CRYPTO)
 
     int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
             const byte* iv, int dir)
@@ -2253,7 +2253,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 
 /* AES-CBC */
 #ifdef HAVE_AES_CBC
-#if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+#if defined(STM32_CRYPTO)
 
 #ifdef WOLFSSL_STM32_CUBEMX
     int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
@@ -3000,8 +3000,8 @@ int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 #endif
 
 /* AES-CTR */
-#if defined(WOLFSSL_AES_COUNTER) || (defined(HAVE_AESGCM_DECRYPT) && defined(STM32F4_CRYPTO))
-    #if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+#if defined(WOLFSSL_AES_COUNTER) || (defined(HAVE_AESGCM_DECRYPT) && defined(STM32_CRYPTO))
+    #ifdef STM32_CRYPTO
     #ifdef WOLFSSL_STM32_CUBEMX
         int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         {
@@ -6933,7 +6933,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     byte initialCounter[AES_BLOCK_SIZE];
     byte *ctr;
     byte scratch[AES_BLOCK_SIZE];
-#if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+#if defined(STM32_CRYPTO) && (defined(WOLFSSL_STM32F4) || defined(WOLFSSL_STM32F7))
     #ifdef WOLFSSL_STM32_CUBEMX
         CRYP_HandleTypeDef hcryp;
     #else
@@ -6943,7 +6943,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     byte* authInPadded = NULL;
     byte tag[AES_BLOCK_SIZE];
     int authPadSz;
-#endif /* STM32F2_CRYPTO || STM32F4_CRYPTO */
+#endif /* STM32_CRYPTO */
 #endif /* FREESCALE_LTC_AES_GCM */
 
     /* argument checks */
@@ -6969,7 +6969,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 
 #else
 
-#if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+#if defined(WOLFSSL_STM32F4) || defined(WOLFSSL_STM32F7)
 
     /* additional argument checks - STM32 HW only supports 12 byte IV */
     if (ivSz != NONCE_SZ) {
@@ -7173,7 +7173,7 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     word32 keySize;
 #ifdef FREESCALE_LTC_AES_GCM
     status_t status;
-#elif defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+#elif defined(STM32_CRYPTO) && (defined(WOLFSSL_STM32F4) || defined(WOLFSSL_STM32F7))
     #ifdef WOLFSSL_STM32_CUBEMX
         CRYP_HandleTypeDef hcryp;
     #else
@@ -7216,7 +7216,7 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 
     ret = (status == kStatus_Success) ? 0 : AES_GCM_AUTH_E;
 
-#elif defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+#elif defined(STM32_CRYPTO) && (defined(WOLFSSL_STM32F4) || defined(WOLFSSL_STM32F7))
 
     /* additional argument checks - STM32 HW only supports 12 byte IV */
     if (ivSz != NONCE_SZ) {

--- a/wolfcrypt/src/des3.c
+++ b/wolfcrypt/src/des3.c
@@ -124,7 +124,7 @@
 
 
 /* Hardware Acceleration */
-#if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+#if defined(STM32_CRYPTO)
 
     /*
      * STM32F2/F4 hardware DES/3DES support through the standard

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1447,12 +1447,19 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         /* enable RNG clock source */
         RCC_AHB2PeriphClockCmd(RCC_AHB2Periph_RNG, ENABLE);
 
+        /* reset RNG */
+        RNG_DeInit();
+
         /* enable RNG peripheral */
         RNG_Cmd(ENABLE);
 
+        /* verify no errors with RNG_CLK or Seed */
+        if (RNG_GetFlagStatus(RNG_FLAG_SECS | RNG_FLAG_CECS) != RESET)
+        	return RNG_FAILURE_E;
+
         for (i = 0; i < (int)sz; i++) {
             /* wait until RNG number is ready */
-            while(RNG_GetFlagStatus(RNG_FLAG_DRDY)== RESET) { }
+            while (RNG_GetFlagStatus(RNG_FLAG_DRDY) == RESET) { }
 
             /* get value */
             output[i] = RNG_GetRandomNumber();

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1232,7 +1232,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
             word32 *rnd32 = (word32 *)rnd;
             word32 size = sz;
             byte* op = output;
-            
+
 #if ((__PIC32_FEATURE_SET0 == 'E') && (__PIC32_FEATURE_SET1 == 'C'))
             RNGNUMGEN1 = _CP0_GET_COUNT();
             RNGPOLY1 = _CP0_GET_COUNT();
@@ -1412,10 +1412,10 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         #define USE_TEST_GENSEED
     #endif /* FREESCALE_K70_RNGA */
 
-#elif defined(STM32F2_RNG) || defined(STM32F4_RNG)
+#elif defined(STM32_RNG)
     /*
      * wc_Generate a RNG seed using the hardware random number generator
-     * on the STM32F2/F4. */
+     * on the STM32F2/F4/F7. */
 
     #ifdef WOLFSSL_STM32_CUBEMX
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -100,7 +100,9 @@
 #endif
 
 
-#ifndef WOLFSSL_PIC32MZ_HASH
+static INLINE void AddLength(Sha256* sha256, word32 len);
+
+#if !defined(WOLFSSL_PIC32MZ_HASH) && !defined(STM32_HASH)
 static int InitSha256(Sha256* sha256)
 {
     int ret = 0;
@@ -330,6 +332,159 @@ static int InitSha256(Sha256* sha256)
 #elif defined(WOLFSSL_PIC32MZ_HASH)
     #include <wolfssl/wolfcrypt/port/pic32/pic32mz-crypt.h>
 
+#elif defined(STM32_HASH)
+
+    /*
+     * STM32F2/F4/F7 hardware SHA256 support through the HASH_* API's from the
+     * Standard Peripheral Library or CubeMX (See note in README).
+     */
+
+    /* STM32 register size, bytes */
+    #ifdef WOLFSSL_STM32_CUBEMX
+        #define SHA256_REG_SIZE  SHA256_BLOCK_SIZE
+    #else
+        #define SHA256_REG_SIZE  4
+        /* STM32 struct notes:
+         * sha256->buffer  = first 4 bytes used to hold partial block if needed
+         * sha256->buffLen = num bytes currently stored in sha256->buffer
+         * sha256->loLen   = num bytes that have been written to STM32 FIFO
+         */
+    #endif
+    #define SHA256_HW_TIMEOUT 0xFF
+
+    int wc_InitSha256_ex(Sha256* sha256, void* heap, int devId)
+    {
+        if (sha256 == NULL)
+            return BAD_FUNC_ARG;
+
+        sha256->heap = heap;
+        XMEMSET(sha256->buffer, 0, sizeof(sha256->buffer));
+        sha256->buffLen = 0;
+        sha256->loLen = 0;
+        sha256->hiLen = 0;
+
+        /* initialize HASH peripheral */
+    #ifdef WOLFSSL_STM32_CUBEMX
+        HAL_HASH_DeInit(&sha256->hashHandle);
+        sha256->hashHandle.Init.DataType = HASH_DATATYPE_8B;
+        if (HAL_HASH_Init(&sha256->hashHandle) != HAL_OK) {
+            return ASYNC_INIT_E;
+        }
+        /* reset the hash control register */
+        /* required because Cube MX is not clearing algo bits */
+        HASH->CR &= ~HASH_CR_ALGO;
+    #else
+        HASH_DeInit();
+
+        /* reset the hash control register */
+        HASH->CR &= ~ (HASH_CR_ALGO | HASH_CR_DATATYPE | HASH_CR_MODE);
+
+        /* configure algo used, algo mode, datatype */
+        HASH->CR |= (HASH_AlgoSelection_SHA256 | HASH_AlgoMode_HASH
+                   | HASH_DataType_8b);
+
+        /* reset HASH processor */
+        HASH->CR |= HASH_CR_INIT;
+    #endif
+
+        return 0;
+    }
+
+    int wc_Sha256Update(Sha256* sha256, const byte* data, word32 len)
+    {
+        int ret = 0;
+        byte* local;
+
+        if (sha256 == NULL || (data == NULL && len > 0)) {
+            return BAD_FUNC_ARG;
+        }
+
+        /* do block size increments */
+        local = (byte*)sha256->buffer;
+
+        /* check that internal buffLen is valid */
+        if (sha256->buffLen >= SHA256_REG_SIZE)
+            return BUFFER_E;
+
+        while (len) {
+            word32 add = min(len, SHA256_REG_SIZE - sha256->buffLen);
+            XMEMCPY(&local[sha256->buffLen], data, add);
+
+            sha256->buffLen += add;
+            data            += add;
+            len             -= add;
+
+            if (sha256->buffLen == SHA256_REG_SIZE) {
+            #ifdef WOLFSSL_STM32_CUBEMX
+                if (HAL_HASHEx_SHA256_Accumulate(
+                        &sha256->hashHandle, local, SHA256_REG_SIZE) != HAL_OK) {
+                    ret = ASYNC_OP_E;
+                }
+            #else
+                HASH_DataIn(*(uint32_t*)local);
+            #endif
+
+                AddLength(sha256, SHA256_REG_SIZE);
+                sha256->buffLen = 0;
+            }
+        }
+        return ret;
+    }
+
+    int wc_Sha256Final(Sha256* sha256, byte* hash)
+    {
+        int ret = 0;
+
+        if (sha256 == NULL || hash == NULL)
+            return BAD_FUNC_ARG;
+
+    #ifdef WOLFSSL_STM32_CUBEMX
+        if (HAL_HASHEx_SHA256_Start(&sha256->hashHandle,
+                (byte*)sha256->buffer, sha256->buffLen,
+                (byte*)sha256->digest, SHA256_HW_TIMEOUT) != HAL_OK) {
+            ret = ASYNC_OP_E;
+        }
+    #else
+        __IO uint16_t nbvalidbitsdata = 0;
+
+        /* finish reading any trailing bytes into FIFO */
+        if (sha256->buffLen > 0) {
+            HASH_DataIn(*(uint32_t*)sha256->buffer);
+            AddLength(sha256, sha256->buffLen);
+        }
+
+        /* calculate number of valid bits in last word of input data */
+        nbvalidbitsdata = 8 * (sha256->loLen % SHA256_REG_SIZE);
+
+        /* configure number of valid bits in last word of the data */
+        HASH_SetLastWordValidBitsNbr(nbvalidbitsdata);
+
+        /* start HASH processor */
+        HASH_StartDigest();
+
+        /* wait until Busy flag == RESET */
+        while (HASH_GetFlagStatus(HASH_FLAG_BUSY) != RESET) {}
+
+        /* read message digest */
+        sha256->digest[0] = HASH->HR[0];
+        sha256->digest[1] = HASH->HR[1];
+        sha256->digest[2] = HASH->HR[2];
+        sha256->digest[3] = HASH->HR[3];
+        sha256->digest[4] = HASH->HR[4];
+        sha256->digest[5] = HASH_DIGEST->HR[5];
+        sha256->digest[6] = HASH_DIGEST->HR[6];
+        sha256->digest[7] = HASH_DIGEST->HR[7];
+
+        ByteReverseWords(sha256->digest, sha256->digest, SHA256_DIGEST_SIZE);
+    #endif /* WOLFSSL_STM32_CUBEMX */
+
+        XMEMCPY(hash, sha256->digest, SHA256_DIGEST_SIZE);
+
+        (void)wc_InitSha256_ex(sha256, sha256->heap, INVALID_DEVID);
+
+        return ret;
+    }
+
 #else
     #define NEED_SOFT_SHA256
 
@@ -450,14 +605,17 @@ static int InitSha256(Sha256* sha256)
 /* End wc_ software implementation */
 
 
-#ifdef XTRANSFORM
+#if defined(XTRANSFORM) || defined(STM32_HASH)
+static INLINE void AddLength(Sha256* sha256, word32 len)
+{
+    word32 tmp = sha256->loLen;
+    if ( (sha256->loLen += len) < tmp)
+        sha256->hiLen++;                       /* carry low to high */
+}
+#endif
 
-    static INLINE void AddLength(Sha256* sha256, word32 len)
-    {
-        word32 tmp = sha256->loLen;
-        if ( (sha256->loLen += len) < tmp)
-            sha256->hiLen++;                       /* carry low to high */
-    }
+
+#ifdef XTRANSFORM
 
     static INLINE int Sha256Update(Sha256* sha256, const byte* data, word32 len)
     {
@@ -1771,6 +1929,152 @@ static int Transform_AVX2(Sha256* sha256)
 
 
 #ifdef WOLFSSL_SHA224
+
+#ifdef STM32_HASH
+
+    #define Sha256Update Sha224Update
+    #define Sha256Final  Sha224Final
+
+    /*
+     * STM32F2/F4/F7 hardware SHA224 support through the HASH_* API's from the
+     * Standard Peripheral Library or CubeMX (See note in README).
+     */
+
+    /* STM32 register size, bytes */
+    #ifdef WOLFSSL_STM32_CUBEMX
+        #define SHA224_REG_SIZE  SHA224_BLOCK_SIZE
+    #else
+        #define SHA224_REG_SIZE  4
+        /* STM32 struct notes:
+         * sha224->buffer  = first 4 bytes used to hold partial block if needed
+         * sha224->buffLen = num bytes currently stored in sha256->buffer
+         * sha224->loLen   = num bytes that have been written to STM32 FIFO
+         */
+    #endif
+    #define SHA224_HW_TIMEOUT 0xFF
+
+    static int InitSha224(Sha224* sha224)
+    {
+        if (sha224 == NULL)
+            return BAD_FUNC_ARG;
+
+        XMEMSET(sha224->buffer, 0, sizeof(sha224->buffer));
+        sha224->buffLen = 0;
+        sha224->loLen = 0;
+        sha224->hiLen = 0;
+
+        /* initialize HASH peripheral */
+    #ifdef WOLFSSL_STM32_CUBEMX
+        HAL_HASH_DeInit(&sha224->hashHandle);
+        sha224->hashHandle.Init.DataType = HASH_DATATYPE_8B;
+        if (HAL_HASH_Init(&sha224->hashHandle) != HAL_OK) {
+            return ASYNC_INIT_E;
+        }
+        /* required because Cube MX is not clearing algo bits */
+        HASH->CR &= ~HASH_CR_ALGO;
+    #else
+        HASH_DeInit();
+
+        /* reset the hash control register */
+        /* required because Cube MX is not clearing algo bits */
+        HASH->CR &= ~ (HASH_CR_ALGO | HASH_CR_DATATYPE | HASH_CR_MODE);
+
+        /* configure algo used, algo mode, datatype */
+        HASH->CR |= (HASH_AlgoSelection_SHA224 | HASH_AlgoMode_HASH
+                   | HASH_DataType_8b);
+
+        /* reset HASH processor */
+        HASH->CR |= HASH_CR_INIT;
+    #endif
+
+        return 0;
+    }
+
+    static int Sha224Update(Sha256* sha224, const byte* data, word32 len)
+    {
+        int ret = 0;
+        byte* local;
+
+        /* do block size increments */
+        local = (byte*)sha224->buffer;
+
+        /* check that internal buffLen is valid */
+        if (sha224->buffLen >= SHA224_REG_SIZE)
+            return BUFFER_E;
+
+        while (len) {
+            word32 add = min(len, SHA224_REG_SIZE - sha224->buffLen);
+            XMEMCPY(&local[sha224->buffLen], data, add);
+
+            sha224->buffLen += add;
+            data         += add;
+            len          -= add;
+
+            if (sha224->buffLen == SHA224_REG_SIZE) {
+            #ifdef WOLFSSL_STM32_CUBEMX
+                if (HAL_HASHEx_SHA224_Accumulate(
+                        &sha224->hashHandle, local, SHA224_REG_SIZE) != HAL_OK) {
+                    ret = ASYNC_OP_E;
+                }
+            #else
+                HASH_DataIn(*(uint32_t*)local);
+            #endif
+
+                AddLength(sha224, SHA224_REG_SIZE);
+                sha224->buffLen = 0;
+            }
+        }
+        return ret;
+    }
+
+    static int Sha224Final(Sha256* sha224)
+    {
+        int ret = 0;
+
+    #ifdef WOLFSSL_STM32_CUBEMX
+        if (HAL_HASHEx_SHA224_Start(&sha224->hashHandle,
+                (byte*)sha224->buffer, sha224->buffLen,
+                (byte*)sha224->digest, SHA224_HW_TIMEOUT) != HAL_OK) {
+            ret = ASYNC_OP_E;
+        }
+    #else
+        __IO uint16_t nbvalidbitsdata = 0;
+
+        /* finish reading any trailing bytes into FIFO */
+        if (sha224->buffLen > 0) {
+            HASH_DataIn(*(uint32_t*)sha224->buffer);
+            AddLength(sha224, sha224->buffLen);
+        }
+
+        /* calculate number of valid bits in last word of input data */
+        nbvalidbitsdata = 8 * (sha224->loLen % SHA224_REG_SIZE);
+
+        /* configure number of valid bits in last word of the data */
+        HASH_SetLastWordValidBitsNbr(nbvalidbitsdata);
+
+        /* start HASH processor */
+        HASH_StartDigest();
+
+        /* wait until Busy flag == RESET */
+        while (HASH_GetFlagStatus(HASH_FLAG_BUSY) != RESET) {}
+
+        /* read message digest */
+        sha224->digest[0] = HASH->HR[0];
+        sha224->digest[1] = HASH->HR[1];
+        sha224->digest[2] = HASH->HR[2];
+        sha224->digest[3] = HASH->HR[3];
+        sha224->digest[4] = HASH->HR[4];
+        sha224->digest[5] = HASH_DIGEST->HR[5];
+        sha224->digest[6] = HASH_DIGEST->HR[6];
+
+        ByteReverseWords(sha224->digest, sha224->digest, SHA224_DIGEST_SIZE);
+    #endif /* WOLFSSL_STM32_CUBEMX */
+
+        return ret;
+    }
+
+#else
+
     static int InitSha224(Sha224* sha224)
     {
 
@@ -1800,6 +2104,8 @@ static int Transform_AVX2(Sha256* sha256)
 
         return ret;
     }
+
+#endif /* STM32_HASH */
 
     int wc_InitSha224_ex(Sha224* sha224, void* heap, int devId)
     {
@@ -1845,7 +2151,7 @@ static int Transform_AVX2(Sha256* sha256)
         }
     #endif /* WOLFSSL_ASYNC_CRYPT */
 
-        ret = Sha256Update((Sha256 *)sha224, data, len);
+        ret = Sha256Update((Sha256*)sha224, data, len);
 
         return ret;
     }
@@ -1871,7 +2177,7 @@ static int Transform_AVX2(Sha256* sha256)
         if (ret != 0)
             return ret;
 
-    #if defined(LITTLE_ENDIAN_ORDER)
+    #if defined(LITTLE_ENDIAN_ORDER) && !defined(STM32_HASH)
         ByteReverseWords(sha224->digest, sha224->digest, SHA224_DIGEST_SIZE);
     #endif
         XMEMCPY(hash, sha224->digest, SHA224_DIGEST_SIZE);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5031,8 +5031,7 @@ int aes_test(void)
             return -4216;
 
     /* test not supported on STM32 crypto HW or PIC32MZ HW */
-#if !defined(STM32F2_CRYPTO) && !defined(STM32F4_CRYPTO) && \
-    !defined(WOLFSSL_PIC32MZ_CRYPT)
+#if !defined(STM32_CRYPTO) && !defined(WOLFSSL_PIC32MZ_CRYPT)
         /* and an additional 9 bytes to reuse tmp left buffer */
         ret = wc_AesCtrEncrypt(&enc, cipher, ctrPlain, sizeof(oddCipher));
         if (ret != 0) {
@@ -5405,8 +5404,7 @@ int aesgcm_test(void)
 
     /* FIPS, QAT and STM32F2/4 HW Crypto only support 12-byte IV */
 #if !defined(HAVE_FIPS) && !defined(HAVE_INTEL_QA) && \
-        !defined(STM32F2_CRYPTO) && !defined(STM32F4_CRYPTO) && \
-        !defined(WOLFSSL_PIC32MZ_CRYPT) && \
+        !defined(STM32_CRYPTO) && !defined(WOLFSSL_PIC32MZ_CRYPT) && \
         !defined(WOLFSSL_XILINX_CRYPT)
 
     #define ENABLE_NON_12BYTE_IV_TEST
@@ -5454,7 +5452,7 @@ int aesgcm_test(void)
     byte resultP[sizeof(p)];
     byte resultC[sizeof(p)];
     int  result;
-#if !defined(HAVE_FIPS) && !defined(STM32F2_CRYPTO) && !defined(STM32F4_CRYPTO)
+#if !defined(HAVE_FIPS) && !defined(STM32_CRYPTO)
     int  ivlen;
 #endif
     int  alen, plen;
@@ -5535,7 +5533,7 @@ int aesgcm_test(void)
         return -4309;
 #endif /* BENCH_AESGCM_LARGE */
 
-#if !defined(HAVE_FIPS) && !defined(STM32F2_CRYPTO) && !defined(STM32F4_CRYPTO)
+#if !defined(HAVE_FIPS) && !defined(STM32_CRYPTO)
     /* Variable IV length test */
     for (ivlen=0; ivlen<(int)sizeof(k1); ivlen++) {
          /* AES-GCM encrypt and decrypt both use AES encrypt internally */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5030,8 +5030,6 @@ int aes_test(void)
         if (XMEMCMP(cipher, ctr128Cipher, sizeof(oddCipher)))
             return -4216;
 
-    /* test not supported on STM32 crypto HW or PIC32MZ HW */
-#if !defined(STM32_CRYPTO) && !defined(WOLFSSL_PIC32MZ_CRYPT)
         /* and an additional 9 bytes to reuse tmp left buffer */
         ret = wc_AesCtrEncrypt(&enc, cipher, ctrPlain, sizeof(oddCipher));
         if (ret != 0) {
@@ -5047,7 +5045,6 @@ int aes_test(void)
 
         if (XMEMCMP(cipher, oddCipher, sizeof(oddCipher)))
             return -4218;
-#endif
 
         /* 192 bit key */
         wc_AesSetKeyDirect(&enc, ctr192Key, sizeof(ctr192Key),

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -100,10 +100,6 @@ typedef struct Aes {
 #ifdef WOLFSSL_AES_COUNTER
     word32  left;            /* unused bytes left from last call */
 #endif
-#ifdef WOLFSSL_PIC32MZ_CRYPT
-    word32 key_ce[AES_BLOCK_SIZE*2/sizeof(word32)];
-    word32 iv_ce [AES_BLOCK_SIZE  /sizeof(word32)];
-#endif
 #ifdef WOLFSSL_XILINX_CRYPT
     XSecure_Aes xilAes;
     XCsuDma     dma;

--- a/wolfssl/wolfcrypt/des3.h
+++ b/wolfssl/wolfcrypt/des3.h
@@ -58,7 +58,7 @@ enum {
 #define DES3_KEYLEN 24
 
 
-#if defined(STM32F2_CRYPTO) || defined(STM32F4_CRYPTO)
+#if defined(STM32_CRYPTO)
 enum {
     DES_CBC = 0,
     DES_ECB = 1

--- a/wolfssl/wolfcrypt/md5.h
+++ b/wolfssl/wolfcrypt/md5.h
@@ -40,9 +40,6 @@
 
 /* in bytes */
 enum {
-#if defined(STM32F2_HASH) || defined(STM32F4_HASH)
-    MD5_REG_SIZE    =  4,      /* STM32 register size, bytes */
-#endif
     MD5             =  0,      /* hash type unique */
     MD5_BLOCK_SIZE  = 64,
     MD5_DIGEST_SIZE = 16,
@@ -74,6 +71,9 @@ typedef struct Md5 {
     void*   heap;
 #ifdef WOLFSSL_PIC32MZ_HASH
     hashUpdCache cache; /* cache for updates */
+#endif
+#if defined(STM32_HASH) && defined(WOLFSSL_STM32_CUBEMX)
+    HASH_HandleTypeDef hashHandle;
 #endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -91,6 +91,12 @@
 /* Uncomment next line if using STM32F2 */
 /* #define WOLFSSL_STM32F2 */
 
+/* Uncomment next line if using STM32F4 */
+/* #define WOLFSSL_STM32F4 */
+
+/* Uncomment next line if using STM32F7 */
+/* #define WOLFSSL_STM32F7 */
+
 /* Uncomment next line if using QL SEP settings */
 /* #define WOLFSSL_QL */
 
@@ -960,33 +966,9 @@ extern void uITRON4_free(void *p) ;
     #define GCM_TABLE
 #endif
 
-#ifdef WOLFSSL_STM32F2
-    #define SIZEOF_LONG_LONG 8
-    #define NO_DEV_RANDOM
-    #define NO_WOLFSSL_DIR
-    #undef  NO_RABBIT
-    #define NO_RABBIT
-    #undef  NO_64BIT
-    #define NO_64BIT
-    #define STM32F2_RNG
-    #define STM32F2_CRYPTO
-    #if !defined(__GNUC__) && !defined(__ICCARM__)
-        #define KEIL_INTRINSICS
-    #endif
-    #define NO_OLD_RNGNAME
-    #ifdef WOLFSSL_STM32_CUBEMX
-        #include "stm32f2xx_hal.h"
-        #ifndef STM32_HAL_TIMEOUT
-            #define STM32_HAL_TIMEOUT   0xFF
-        #endif
-    #else
-        #include "stm32f2xx.h"
-        #include "stm32f2xx_cryp.h"
-        #include "stm32f2xx_hash.h"
-    #endif /* WOLFSSL_STM32_CUBEMX */
-#endif
+#if defined(WOLFSSL_STM32F2) || defined(WOLFSSL_STM32F4) || \
+    defined(WOLFSSL_STM32F7)
 
-#ifdef WOLFSSL_STM32F4
     #define SIZEOF_LONG_LONG 8
     #define NO_DEV_RANDOM
     #define NO_WOLFSSL_DIR
@@ -994,23 +976,56 @@ extern void uITRON4_free(void *p) ;
     #define NO_RABBIT
     #undef  NO_64BIT
     #define NO_64BIT
-    #define STM32F4_RNG
-    #define STM32F4_CRYPTO
-    #define NO_OLD_RNGNAME
+    #ifndef NO_STM32_RNG
+        #undef  STM32_RNG
+        #define STM32_RNG
+    #endif
+    #ifndef NO_STM32_CRYPTO
+        #undef  STM32_CRYPTO
+        #define STM32_CRYPTO
+    #endif
+    #ifndef NO_STM32_HASH
+        #undef  STM32_HASH
+        #define STM32_HASH
+    #endif
     #if !defined(__GNUC__) && !defined(__ICCARM__)
         #define KEIL_INTRINSICS
     #endif
+    #define NO_OLD_RNGNAME
     #ifdef WOLFSSL_STM32_CUBEMX
-        #include "stm32f4xx_hal.h"
+        #if defined(WOLFSSL_STM32F2)
+            #include "stm32f2xx_hal.h"
+        #elif defined(WOLFSSL_STM32F4)
+            #include "stm32f4xx_hal.h"
+        #elif defined(WOLFSSL_STM32F7)
+            #include "stm32f7xx_hal.h"
+        #endif
+
         #ifndef STM32_HAL_TIMEOUT
             #define STM32_HAL_TIMEOUT   0xFF
         #endif
     #else
-        #include "stm32f4xx.h"
-        #include "stm32f4xx_cryp.h"
-        #include "stm32f4xx_hash.h"
+        #if defined(WOLFSSL_STM32F2)
+            #include "stm32f2xx.h"
+            #ifdef STM32_CRYPTO
+                #include "stm32f2xx_cryp.h"
+            #endif
+            #ifdef STM32_HASH
+                #include "stm32f2xx_hash.h"
+            #endif
+        #elif defined(WOLFSSL_STM32F4)
+            #include "stm32f4xx.h"
+            #ifdef STM32_CRYPTO
+                #include "stm32f4xx_cryp.h"
+            #endif
+            #ifdef STM32_HASH
+                #include "stm32f4xx_hash.h"
+            #endif
+        #elif defined(WOLFSSL_STM32F7)
+            #include "stm32f7xx.h"
+        #endif
     #endif /* WOLFSSL_STM32_CUBEMX */
-#endif
+#endif /* WOLFSSL_STM32F2 || WOLFSSL_STM32F4 || WOLFSSL_STM32F7 */
 
 #ifdef MICRIUM
     #include <stdlib.h>

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -51,9 +51,6 @@
 
 /* in bytes */
 enum {
-#if defined(STM32F2_HASH) || defined(STM32F4_HASH)
-    SHA_REG_SIZE     =  4,    /* STM32 register size, bytes */
-#endif
     SHA              =  1,    /* hash type unique */
     SHA_BLOCK_SIZE   = 64,
     SHA_DIGEST_SIZE  = 20,
@@ -64,25 +61,28 @@ enum {
 #ifndef WOLFSSL_TI_HASH
 /* Sha digest */
 typedef struct Sha {
-    #ifdef FREESCALE_LTC_SHA
-        ltc_hash_ctx_t ctx;
-    #else
-        word32  buffLen;   /* in bytes          */
-        word32  loLen;     /* length in bytes   */
-        word32  hiLen;     /* length in bytes   */
-        word32  buffer[SHA_BLOCK_SIZE  / sizeof(word32)];
-    #ifdef WOLFSSL_PIC32MZ_HASH
-        word32  digest[PIC32_DIGEST_SIZE / sizeof(word32)];
-    #else
-        word32  digest[SHA_DIGEST_SIZE / sizeof(word32)];
-    #endif
-        void*   heap;
-    #ifdef WOLFSSL_PIC32MZ_HASH
-        hashUpdCache cache; /* cache for updates */
-    #endif
-    #ifdef WOLFSSL_ASYNC_CRYPT
-        WC_ASYNC_DEV asyncDev;
-    #endif /* WOLFSSL_ASYNC_CRYPT */
+#ifdef FREESCALE_LTC_SHA
+    ltc_hash_ctx_t ctx;
+#else
+    word32  buffLen;   /* in bytes          */
+    word32  loLen;     /* length in bytes   */
+    word32  hiLen;     /* length in bytes   */
+    word32  buffer[SHA_BLOCK_SIZE  / sizeof(word32)];
+#ifdef WOLFSSL_PIC32MZ_HASH
+    word32  digest[PIC32_DIGEST_SIZE / sizeof(word32)];
+#else
+    word32  digest[SHA_DIGEST_SIZE / sizeof(word32)];
+#endif
+    void*   heap;
+#ifdef WOLFSSL_PIC32MZ_HASH
+    hashUpdCache cache; /* cache for updates */
+#endif
+#if defined(STM32_HASH) && defined(WOLFSSL_STM32_CUBEMX)
+    HASH_HandleTypeDef hashHandle;
+#endif
+#ifdef WOLFSSL_ASYNC_CRYPT
+    WC_ASYNC_DEV asyncDev;
+#endif /* WOLFSSL_ASYNC_CRYPT */
 #endif /* FREESCALE_LTC_SHA */
 } Sha;
 

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -77,6 +77,9 @@ typedef struct Sha256 {
 #ifdef WOLFSSL_PIC32MZ_HASH
     hashUpdCache cache; /* cache for updates */
 #endif
+#if defined(STM32_HASH) && defined(WOLFSSL_STM32_CUBEMX)
+    HASH_HandleTypeDef hashHandle;
+#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
 #endif /* WOLFSSL_ASYNC_CRYPT */


### PR DESCRIPTION
Adds CubeMX HAL hashing support for MD5, SHA1, SHA224 and SHA256.
Adds support for STM32F7 (`WOLFSSL_STM32F7`).
Fixes issue with AES-GCM and STM32F2.
Cleanup of the STM32 macros (adds `NO_STM32_HASH`, `NO_STM32_CRYPTO` and `NO_STM32_RNG` to optionally disable hardware acceleration).

Tested on STM32F777 with CubeMX Hal and STM32F437II with StdPerih_Lib.