### PR TITLE
NULL plaintext input is supported in FIPS testing

### DIFF
--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -54,7 +54,7 @@
     }
     int wc_HmacUpdate(Hmac* hmac, const byte* in, word32 sz)
     {
-        if (hmac == NULL) {
+        if (hmac == NULL || (in == NULL && sz > 0)) {
             return BAD_FUNC_ARG;
         }
 
@@ -523,7 +523,7 @@ int wc_HmacUpdate(Hmac* hmac, const byte* msg, word32 length)
 {
     int ret = 0;
 
-    if (hmac == NULL) {
+    if (hmac == NULL || (msg == NULL && length > 0)) {
         return BAD_FUNC_ARG;
     }
 

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -54,7 +54,7 @@
     }
     int wc_HmacUpdate(Hmac* hmac, const byte* in, word32 sz)
     {
-        if (hmac == NULL || in == NULL) {
+        if (hmac == NULL) {
             return BAD_FUNC_ARG;
         }
 


### PR DESCRIPTION
input message NULL and of zero length is supported in HMAC UPDATE. This is part of FIPS testing. Check breaks test case in wolfcrypt test.c:

```
12393     /* encrypt msg to B */                                                       
12394     ret = wc_ecc_encrypt(&userA, &userB, msg, sizeof(msg), out, &outSz, NULL);   
12395     if (ret != 0)                                                                
12396         ret = -6903; goto done;
```

