### PR TITLE
Update HASH_DRBG Reseed mechanism and add test case

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -10533,6 +10533,30 @@ static int test_tls13_apis(void)
 
 #endif
 
+#ifdef HAVE_HASHDRBG
+
+static int test_wc_RNG_GenerateBlock()
+{
+    int i, ret;
+    WC_RNG rng;
+    byte key[32];
+
+    ret = wc_InitRng(&rng);
+
+    if (ret == 0) {
+        for(i = 0; i < WC_RESEED_INTERVAL + 10; i++) {
+            ret = wc_RNG_GenerateBlock(&rng, key, sizeof(key));
+            if (ret != 0) {
+                break;
+            }
+        }
+    }
+
+    wc_FreeRng(&rng);
+
+    return ret;
+}
+#endif
 
 /*----------------------------------------------------------------------------*
  | Main
@@ -10716,6 +10740,11 @@ void ApiTest(void)
     AssertIntEQ(test_wc_DsaPublicPrivateKeyDecode(), 0);
     AssertIntEQ(test_wc_MakeDsaKey(), 0);
     AssertIntEQ(test_wc_DsaKeyToDer(), 0);
+
+#ifdef HAVE_HASHDRBG
+    AssertIntEQ(WC_RESEED_INTERVAL, 1000000);
+    AssertIntEQ(test_wc_RNG_GenerateBlock(), 0);
+#endif
     printf(" End API Tests\n");
 
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -10742,7 +10742,6 @@ void ApiTest(void)
     AssertIntEQ(test_wc_DsaKeyToDer(), 0);
 
 #ifdef HAVE_HASHDRBG
-    AssertIntEQ(WC_RESEED_INTERVAL, 1000000);
     AssertIntEQ(test_wc_RNG_GenerateBlock(), 0);
 #endif
     printf(" End API Tests\n");

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -408,13 +408,17 @@ static INLINE void array_add(byte* d, word32 dLen, const byte* s, word32 sLen)
 /* Returns: DRBG_SUCCESS, DRBG_NEED_RESEED, or DRBG_FAILURE */
 static int Hash_DRBG_Generate(DRBG* drbg, byte* out, word32 outSz)
 {
-    int ret = DRBG_NEED_RESEED;
+    int ret;
     Sha256 sha;
-    DECLARE_VAR(digest, byte, SHA256_DIGEST_SIZE, drbg->heap);
+    byte type;
+    word32 reseedCtr;
 
-    if (drbg->reseedCtr != RESEED_INTERVAL) {
-        byte type = drbgGenerateH;
-        word32 reseedCtr = drbg->reseedCtr;
+    if (drbg->reseedCtr == RESEED_INTERVAL) {
+        return DRBG_NEED_RESEED;
+    } else {
+        DECLARE_VAR(digest, byte, SHA256_DIGEST_SIZE, drbg->heap);
+        type = drbgGenerateH;
+        reseedCtr = drbg->reseedCtr;
 
         ret = Hash_gen(drbg, out, outSz, drbg->V);
         if (ret == DRBG_SUCCESS) {
@@ -444,13 +448,9 @@ static int Hash_DRBG_Generate(DRBG* drbg, byte* out, word32 outSz)
             }
             drbg->reseedCtr++;
         }
+        ForceZero(digest, SHA256_DIGEST_SIZE);
+        FREE_VAR(digest, drbg->heap);
     }
-    ForceZero(digest, SHA256_DIGEST_SIZE);
-
-    FREE_VAR(digest, drbg->heap);
-
-    if (ret == DRBG_NEED_RESEED)
-        return ret;
 
     return (ret == 0) ? DRBG_SUCCESS : DRBG_FAILURE;
 }

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -154,7 +154,7 @@ int wc_RNG_GenerateByte(WC_RNG* rng, byte* b)
 
 #define OUTPUT_BLOCK_LEN  (SHA256_DIGEST_SIZE)
 #define MAX_REQUEST_LEN   (0x10000)
-#define RESEED_INTERVAL   (1000000)
+#define RESEED_INTERVAL   WC_RESEED_INTERVAL
 #define SECURITY_STRENGTH (256)
 #define ENTROPY_SZ        (SECURITY_STRENGTH/8)
 #define NONCE_SZ          (ENTROPY_SZ/2)
@@ -448,6 +448,9 @@ static int Hash_DRBG_Generate(DRBG* drbg, byte* out, word32 outSz)
     ForceZero(digest, SHA256_DIGEST_SIZE);
 
     FREE_VAR(digest, drbg->heap);
+
+    if (ret == DRBG_NEED_RESEED)
+        return ret;
 
     return (ret == 0) ? DRBG_SUCCESS : DRBG_FAILURE;
 }

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -60,7 +60,9 @@
 #if !defined(WC_NO_HASHDRBG) || !defined(CUSTOM_RAND_GENERATE_BLOCK)
     #undef  HAVE_HASHDRBG
     #define HAVE_HASHDRBG
-    #define WC_RESEED_INTERVAL (1000000)
+    #ifndef WC_RESEED_INTERVAL
+        #define WC_RESEED_INTERVAL (1000000)
+    #endif
 #endif
 
 

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -60,6 +60,7 @@
 #if !defined(WC_NO_HASHDRBG) || !defined(CUSTOM_RAND_GENERATE_BLOCK)
     #undef  HAVE_HASHDRBG
     #define HAVE_HASHDRBG
+    #define WC_RESEED_INTERVAL (1000000)
 #endif
 
 


### PR DESCRIPTION
Added WC_RESEED_INTERVAL to random.h for access to reseed interval outside random.c

Left defines for internal RESEED_INTERVAL in place and defined it to be WC_RESEED_INTERVAL

Added check for DRBG_NEED_RESEED in Hash_DRBG_Generate to return this condition in order for the sanity check in wc_RNG_GenerateBlock to detect DRBG_NEED_RESEED.

Sanity check that was not firing as expected is located here:
https://github.com/wolfSSL/wolfssl/pull/1150/files#diff-9459cb9c326c9d6ba53b85057b28ad7aR646