### PR TITLE
Fixes bug with creation of the KeyUsage BitString

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1060,7 +1060,8 @@ static word32 SetBitString16Bit(word16 val, byte* output)
 
     idx = SetBitString(len, unusedBits, output);
     output[idx++] = (byte)val;
-    output[idx++] = (byte)(val >> 8);
+    if (len > 1)
+        output[idx++] = (byte)(val >> 8);
 
     return idx;
 }


### PR DESCRIPTION
Fixes bug with creation of the KeyUsage BitString which was always adding the optional second byte reguardless of len, which created invalid ASN if value provided was less than 256. Bug was introduced with ASN refactor in commit fd9e41dd993bf31207868dc63a49c2e8b5a3e102.