### PR TITLE
exclude wolfSSL_SSL_get0_session when NO_SESSION_CACHE is defined

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -25030,6 +25030,8 @@ int wolfSSL_SSL_in_init(WOLFSSL *s)
     return s->options.acceptState < ACCEPT_THIRD_REPLY_DONE;
 }
 
+#ifndef NO_SESSION_CACHE
+
 WOLFSSL_SESSION *wolfSSL_SSL_get0_session(const WOLFSSL *ssl)
 {
     WOLFSSL_SESSION *session;
@@ -25048,6 +25050,8 @@ WOLFSSL_SESSION *wolfSSL_SSL_get0_session(const WOLFSSL *ssl)
 
     return session;
 }
+
+#endif /* NO_SESSION_CACHE */
 
 int wolfSSL_X509_check_host(X509 *x, const char *chk, size_t chklen,
                     unsigned int flags, char **peername)

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2384,7 +2384,9 @@ WOLFSSL_API WOLFSSL_BIO *wolfSSL_SSL_get_rbio(const WOLFSSL *s);
 WOLFSSL_API WOLFSSL_BIO *wolfSSL_SSL_get_wbio(const WOLFSSL *s);
 WOLFSSL_API int wolfSSL_SSL_do_handshake(WOLFSSL *s);
 WOLFSSL_API int wolfSSL_SSL_in_init(WOLFSSL *a); /* #define in OpenSSL */
-WOLFSSL_API WOLFSSL_SESSION *wolfSSL_SSL_get0_session(const WOLFSSL *s);
+#ifndef NO_SESSION_CACHE
+    WOLFSSL_API WOLFSSL_SESSION *wolfSSL_SSL_get0_session(const WOLFSSL *s);
+#endif
 WOLFSSL_API int wolfSSL_X509_check_host(WOLFSSL_X509 *x, const char *chk,
     size_t chklen, unsigned int flags, char **peername);
 


### PR DESCRIPTION
This PR excludes wolfSSL_SSL_get0_session() from being compiled if NO_SESSION_CACHE is defined.

wolfSSL_SSL_get0_session() calls wolfSSL_get_session() internally.  wolfSSL_get_session() is surrounded by NO_SESSION_CACHE.  Therefore, it makes sense for wolfSSL_SSL_get0_session() to also be compiled out when NO_SESSION_CACHE is defined.