### PR TITLE
ASN Extended Key Usage Support

### DIFF
--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -369,7 +369,10 @@ const char* wc_GetErrorString(int error)
         return "Setting Authority Key Identifier error";
 
     case KEYUSAGE_E:
-        return "Bad Key Usage value error";
+        return "Key Usage value error";
+
+    case EXTKEYUSAGE_E:
+        return "Extended Key Usage value error";
 
     case CERTPOLICIES_E:
         return "Setting Certificate Policies error";

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8921,12 +8921,29 @@ int rsa_test(void)
                                 "keyEncipherment,keyAgreement") != 0) {
             ERROR_OUT(-5683, exit_rsa);
         }
+
+        /* add Extended Key Usage */
+        if (wc_SetExtKeyUsage(&req, "serverAuth,clientAuth,codeSigning,"
+                            "emailProtection,timeStamping,OCSPSigning") != 0) {
+            ERROR_OUT(-5684, exit_rsa);
+        }
     #endif /* WOLFSSL_CERT_EXT */
 
         derSz = wc_MakeCertReq(&req, der, FOURK_BUF, &key, NULL);
         if (derSz < 0) {
-            ERROR_OUT(-5684, exit_rsa);
+            ERROR_OUT(-5685, exit_rsa);
         }
+
+    #ifdef WOLFSSL_CERT_EXT
+        /* Try again with "any" flag set, will override all others */
+        if (wc_SetExtKeyUsage(&req, "any") != 0) {
+            ERROR_OUT(-5686, exit_rsa);
+        }
+        derSz = wc_MakeCertReq(&req, der, FOURK_BUF, &key, NULL);
+        if (derSz < 0) {
+            ERROR_OUT(-5687, exit_rsa);
+        }
+    #endif /* WOLFSSL_CERT_EXT */
 
         ret = 0;
         do {
@@ -8939,35 +8956,35 @@ int rsa_test(void)
             }
         } while (ret == WC_PENDING_E);
         if (ret < 0) {
-            ERROR_OUT(-5685, exit_rsa);
+            ERROR_OUT(-5688, exit_rsa);
         }
         derSz = ret;
 
         pemSz = wc_DerToPem(der, derSz, pem, FOURK_BUF, CERTREQ_TYPE);
         if (pemSz < 0) {
-            ERROR_OUT(-5686, exit_rsa);
+            ERROR_OUT(-5689, exit_rsa);
         }
 
     #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
         reqFile = fopen(certReqDerFile, "wb");
         if (!reqFile) {
-            ERROR_OUT(-5687, exit_rsa);
+            ERROR_OUT(-5690, exit_rsa);
         }
 
         ret = (int)fwrite(der, 1, derSz, reqFile);
         fclose(reqFile);
         if (ret != derSz) {
-            ERROR_OUT(-5688, exit_rsa);
+            ERROR_OUT(-5691, exit_rsa);
         }
 
         reqFile = fopen(certReqPemFile, "wb");
         if (!reqFile) {
-            ERROR_OUT(-5689, exit_rsa);
+            ERROR_OUT(-5692, exit_rsa);
         }
         ret = (int)fwrite(pem, 1, pemSz, reqFile);
         fclose(reqFile);
         if (ret != pemSz) {
-            ERROR_OUT(-5690, exit_rsa);
+            ERROR_OUT(-5693, exit_rsa);
         }
     #endif
 

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -179,6 +179,8 @@ enum Misc_ASN {
 #ifdef WOLFSSL_CERT_EXT
     MAX_KID_SZ			= 45,	   /* Max encoded KID length (SHA-256 case) */
     MAX_KEYUSAGE_SZ     = 18,      /* Max encoded Key Usage length */
+    MAX_EXTKEYUSAGE_SZ  = 12 + (6 * (8 + 2)), /* Max encoded ExtKeyUsage
+                        (SEQ/LEN + OBJID + OCTSTR/LEN + SEQ + (6 * (SEQ + OID))) */
     MAX_OID_SZ          = 32,      /* Max DER length of OID*/
     MAX_OID_STRING_SZ   = 64,      /* Max string length representation of OID*/
     MAX_CERTPOL_NB      = CTC_MAX_CERTPOL_NB,/* Max number of Cert Policy */
@@ -338,7 +340,10 @@ enum ExtKeyUsage_Sum { /* From RFC 5280 */
     EKU_ANY_OID         = 151, /* 2.5.29.37.0, anyExtendedKeyUsage         */
     EKU_SERVER_AUTH_OID = 71,  /* 1.3.6.1.5.5.7.3.1, id-kp-serverAuth      */
     EKU_CLIENT_AUTH_OID = 72,  /* 1.3.6.1.5.5.7.3.2, id-kp-clientAuth      */
-    EKU_OCSP_SIGN_OID   = 79   /* 1.3.6.1.5.5.7.3.9, OCSPSigning           */
+    EKU_CODESIGNING_OID = 73,  /* 1.3.6.1.5.5.7.3.3, id-kp-codeSigning     */
+    EKU_EMAILPROTECT_OID = 74, /* 1.3.6.1.5.5.7.3.4, id-kp-emailProtection */
+    EKU_TIMESTAMP_OID   = 78,  /* 1.3.6.1.5.5.7.3.8, id-kp-timeStamping    */
+    EKU_OCSP_SIGN_OID   = 79   /* 1.3.6.1.5.5.7.3.9, id-kp-OCSPSigning     */
 };
 
 
@@ -356,7 +361,7 @@ enum KeyIdType {
 };
 #endif
 
-/* Key usage extension bits */
+/* Key usage extension bits (based on RFC 5280) */
 #define KEYUSE_DIGITAL_SIG    0x0080
 #define KEYUSE_CONTENT_COMMIT 0x0040
 #define KEYUSE_KEY_ENCIPHER   0x0020
@@ -367,10 +372,14 @@ enum KeyIdType {
 #define KEYUSE_ENCIPHER_ONLY  0x0001
 #define KEYUSE_DECIPHER_ONLY  0x8000
 
-#define EXTKEYUSE_ANY         0x08
-#define EXTKEYUSE_OCSP_SIGN   0x04
-#define EXTKEYUSE_CLIENT_AUTH 0x02
-#define EXTKEYUSE_SERVER_AUTH 0x01
+/* Extended Key Usage bits (internal mapping only) */
+#define EXTKEYUSE_OCSP_SIGN   0x40
+#define EXTKEYUSE_TIMESTAMP   0x20
+#define EXTKEYUSE_EMAILPROT   0x10
+#define EXTKEYUSE_CODESIGN    0x08
+#define EXTKEYUSE_CLIENT_AUTH 0x04
+#define EXTKEYUSE_SERVER_AUTH 0x02
+#define EXTKEYUSE_ANY         0x01
 
 typedef struct DNS_entry   DNS_entry;
 

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -159,6 +159,7 @@ typedef struct Cert {
     byte    akid[CTC_MAX_AKID_SIZE];     /* Authority Key Identifier */
     int     akidSz;                      /* AKID size in bytes */
     word16  keyUsage;                    /* Key Usage */
+    byte    extKeyUsage;                 /* Extended Key Usage */
     char    certPolicies[CTC_MAX_CERTPOL_NB][CTC_MAX_CERTPOL_SZ];
     word16  certPoliciesNb;              /* Number of Cert Policy */
 #endif
@@ -234,6 +235,12 @@ WOLFSSL_API int wc_SetSubjectKeyIdFromNtruPublicKey(Cert *cert, byte *ntruKey,
  * nonRepudiation and contentCommitment are for the same usage.
  */
 WOLFSSL_API int wc_SetKeyUsage(Cert *cert, const char *value);
+
+/* Set ExtendedKeyUsage
+ * Value is a string separated tokens with ','. Accepted tokens are :
+ * any,serverAuth,clientAuth,codeSigning,emailProtection,timeStamping,OCSPSigning
+ */
+WOLFSSL_API int wc_SetExtKeyUsage(Cert *cert, const char *value);
 
 #endif /* WOLFSSL_CERT_EXT */
 

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -190,8 +190,9 @@ enum {
     ASYNC_OP_E          = -245,  /* Async operation error */
 
     ECC_PRIVATEONLY_E   = -246,  /* Invalid use of private only ECC key*/
+    EXTKEYUSAGE_E       = -247,  /* Bad Extended Key Usage value */
 
-    WC_LAST_E           = -246,  /* Update this to indicate last error */
+    WC_LAST_E           = -247,  /* Update this to indicate last error */
     MIN_CODE_E          = -300   /* errors -101 - -299 */
 
     /* add new companion error id strings for any new error codes


### PR DESCRIPTION
ASN1 Extended Key Usage support. Adds new `wc_SetExtKeyUsage()` API. Available only with `--enable-certext` or `WOLFSSL_CERT_EXT`.

WOLFSSL_API int wc_SetExtKeyUsage(Cert *cert, const char *value);

Value is a string separated tokens with ','. Accepted tokens are: `any,serverAuth,clientAuth,codeSigning,emailProtection,timeStamping,OCSPSigning`