### PR TITLE
Enable ASN1_TIME_print when WOLFSSL_MYSQL_COMPATIBLE is defined

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16165,7 +16165,8 @@ WOLFSSL_ASN1_INTEGER* wolfSSL_X509_get_serialNumber(WOLFSSL_X509* x509)
 }
 
 
-#if defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
+#if defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(WOLFSSL_NGINX) || \
+    defined(WOLFSSL_HAPROXY)
 int wolfSSL_ASN1_TIME_print(WOLFSSL_BIO* bio, const WOLFSSL_ASN1_TIME* asnTime)
 {
     char buf[MAX_TIME_STRING_SZ];
@@ -16180,10 +16181,8 @@ int wolfSSL_ASN1_TIME_print(WOLFSSL_BIO* bio, const WOLFSSL_ASN1_TIME* asnTime)
 
     return 0;
 }
-#endif
 
 
-#if defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
 char* wolfSSL_ASN1_TIME_to_string(WOLFSSL_ASN1_TIME* t, char* buf, int len)
 {
     int format;


### PR DESCRIPTION
ASN1_TIME_print (wolfSSL_ASN1_TIME_print) was previously only available when:

- OpenSSL compatibility layer was enabled AND
- Either WOLFSSL_HAPROXY or WOLFSSL_NGINX were defined.

This also enables it when OPENSSL_EXTRA and WOLFSSL_MYSQL_COMPATIBLE are used together.