### PR TITLE
add check for SIZEOF_LONG with sun and LP64

### DIFF
--- a/IDE/MYSQL/CMakeLists_wolfCrypt.txt
+++ b/IDE/MYSQL/CMakeLists_wolfCrypt.txt
@@ -18,10 +18,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
-INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/extra/wolfssl/wolfcrypt
-                    ${CMAKE_SOURCE_DIR}/extra/wolfssl)
+INCLUDE_DIRECTORIES(
+  ${CMAKE_SOURCE_DIR}/include
+  ${CMAKE_SOURCE_DIR}/extra/wolfssl)
 
-INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include)
 ADD_DEFINITIONS(${SSL_DEFINES})
 SET(WOLFCRYPT_SOURCES		src/aes.c src/arc4.c src/asn.c src/blake2b.c
         src/camellia.c src/chacha.c src/coding.c src/compress.c src/des3.c

--- a/IDE/MYSQL/CMakeLists_wolfSSL.txt
+++ b/IDE/MYSQL/CMakeLists_wolfSSL.txt
@@ -21,8 +21,8 @@
 INCLUDE_DIRECTORIES(
  ${CMAKE_SOURCE_DIR}/include
  ${CMAKE_SOURCE_DIR}/extra/wolfssl
- ${CMAKE_SOURCE_DIR}/extra/wolfssl/wolfssl
- ${CMAKE_SOURCE_DIR}/extra/wolfssl/wolfssl/wolfcrypt)
+ ${CMAKE_SOURCE_DIR}/extra/wolfssl/wolfssl)
+
 
 ADD_DEFINITIONS(${SSL_DEFINES})
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -53,7 +53,9 @@
 	#if !defined(_MSC_VER) && !defined(__BCPLUSPLUS__)
 	    #if !defined(SIZEOF_LONG_LONG) && !defined(SIZEOF_LONG)
 	        #if (defined(__alpha__) || defined(__ia64__) || defined(_ARCH_PPC64) \
-	                || defined(__mips64)  || defined(__x86_64__))
+	                || defined(__mips64)  || defined(__x86_64__) || \
+                    ((defined(sun) || defined(__sun)) && \
+                     (defined(LP64) || defined(_LP64))))
 	            /* long should be 64bit */
 	            #define SIZEOF_LONG 8
 	        #elif defined(__i386__) || defined(__CORTEX_M3__)


### PR DESCRIPTION
This tries to set SIZEOF_LONG if not already set when on a Solaris system and finding the macro LP64 defined.

Assuming long is size of 64bits when LP64 is defined on a Solaris system is based from the reference "Solaris 64-bit Developer's Guide" on page 7. http://math-atlas.sourceforge.net/devel/assembly/816-5138.pdf