### PR TITLE
Add method to get WOLFSSL_CTX certificate manager

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2957,6 +2957,13 @@ void FreeDer(DerBuffer** pDer)
     }
 }
 
+WOLFSSL_CERT_MANAGER* wolfSSL_CTX_GetCertManager(WOLFSSL_CTX* ctx)
+{
+    WOLFSSL_CERT_MANAGER* cm = NULL;
+    if (ctx)
+        cm = ctx->cm;
+    return cm;
+}
 
 WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew_ex(void* heap)
 {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7557,7 +7557,7 @@ int wolfSSL_CTX_get_cert_cache_memsize(WOLFSSL_CTX* ctx)
     return CM_GetCertCacheMemSize(ctx->cm);
 }
 
-#endif /* PERSISTE_CERT_CACHE */
+#endif /* PERSIST_CERT_CACHE */
 #endif /* !NO_CERTS */
 
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1410,7 +1410,7 @@ WOLFSSL_API WC_RNG* wolfSSL_GetRNG(WOLFSSL*);
 WOLFSSL_API int wolfSSL_CTX_SetMinVersion(WOLFSSL_CTX* ctx, int version);
 WOLFSSL_API int wolfSSL_SetMinVersion(WOLFSSL* ssl, int version);
 WOLFSSL_API int wolfSSL_GetObjectSize(void);  /* object size based on build */
-WOLFSSL_API int wolfSSL_CTX_GetObjectSize(void); 
+WOLFSSL_API int wolfSSL_CTX_GetObjectSize(void);
 WOLFSSL_API int wolfSSL_METHOD_GetObjectSize(void);
 WOLFSSL_API int wolfSSL_GetOutputSize(WOLFSSL*, int);
 WOLFSSL_API int wolfSSL_GetMaxOutputSize(WOLFSSL*);
@@ -1640,6 +1640,8 @@ WOLFSSL_API void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl);
 
 #ifndef NO_CERTS
     WOLFSSL_API void wolfSSL_CTX_SetCACb(WOLFSSL_CTX*, CallbackCACache);
+
+    WOLFSSL_API WOLFSSL_CERT_MANAGER* wolfSSL_CTX_GetCertManager(WOLFSSL_CTX*);
 
     WOLFSSL_API WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew_ex(void* heap);
     WOLFSSL_API WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew(void);


### PR DESCRIPTION
* Added new API `wolfSSL_CTX_GetCertManager` for getting the WOLFSSL_CTX certificate manager.
* Add unit tests for `wolfSSL_CTX_GetCertManager`, `wolfSSL_CTX_UnloadCAs`, `wolfSSL_CertManagerUnloadCAs` and `wolfSSL_CTX_get_cert_cache_memsize`.
* Fixed comment typo `PERSISTE_CERT_CACHE`.