### PR TITLE
Add return code to CRL missing callback

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -338,8 +338,8 @@ static int CheckCertCRLList(WOLFSSL_CRL* crl, DecodedCert* cert, int *pFoundEntr
 /* Is the cert ok with CRL, return 0 on success */
 int CheckCertCRL(WOLFSSL_CRL* crl, DecodedCert* cert)
 {
-    int        foundEntry = 0;
-    int        ret = 0;
+    int foundEntry = 0;
+    int ret = 0;
 
     WOLFSSL_ENTER("CheckCertCRL");
 
@@ -379,7 +379,10 @@ int CheckCertCRL(WOLFSSL_CRL* crl, DecodedCert* cert)
                 WOLFSSL_MSG("CRL url too long");
             }
 
-            crl->cm->cbMissingCRL(url);
+            /* if non-zero return code then clear CRL_MISSING error */
+            if (crl->cm->cbMissingCRL(url)) {
+                ret = 0;
+            }
         }
     }
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1544,7 +1544,7 @@ WOLFSSL_API int wolfSSL_CertPemToDer(const unsigned char*, int,
 #endif /* WOLFSSL_CERT_EXT || WOLFSSL_PUB_PEM_TO_DER*/
 
 typedef void (*CallbackCACache)(unsigned char* der, int sz, int type);
-typedef void (*CbMissingCRL)(const char* url);
+typedef int  (*CbMissingCRL)(const char* url);
 typedef int  (*CbOCSPIO)(void*, const char*, int,
                                          unsigned char*, int, unsigned char**);
 typedef void (*CbOCSPRespFree)(void*,unsigned char*);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1293,8 +1293,13 @@ static INLINE int CRL_CallBack(const char* url)
 {
     printf("CRL callback url = %s\n", url);
 
-    /* return 0; to continue with CRL_MISSING failure up stack */
-    return 1; /* return non-zero to ignore the CRL missing */
+#if 0
+    if (ignoreCrlMissing) {
+        return 1; /* return non-zero to ignore the CRL missing */
+    }
+#endif
+
+    return 0; /* return zero to continue with CRL_MISSING failure up stack */
 }
 
 #endif

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1289,9 +1289,12 @@ static INLINE int myDateCb(int preverify, WOLFSSL_X509_STORE_CTX* store)
 
 #ifdef HAVE_CRL
 
-static INLINE void CRL_CallBack(const char* url)
+static INLINE int CRL_CallBack(const char* url)
 {
     printf("CRL callback url = %s\n", url);
+
+    /* return 0; to continue with CRL_MISSING failure up stack */
+    return 1; /* return non-zero to ignore the CRL missing */
 }
 
 #endif


### PR DESCRIPTION
This allows for our examples to continue even with a CRL missing failure. Breaks compatability with a void callback function (changing to int). Open to feedback on improvement.

When building with --enable-all (which includes enable-crl) and using the example client which has a CRL URL in the certificate prevents example client from working.