### PR TITLE
Disallow upgrading to TLS v1.3

### DIFF
--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -379,7 +379,7 @@ create_port
 ./examples/client/client -v 4 -p $port
 RESULT=$?
 remove_ready_file
-if [ $RESULT -ne 0 ]; then
+if [ $RESULT -eq 0 ]; then
     echo -e "\n\nIssue with TLS v1.3 client upgrading server to TLS v1.3"
     do_cleanup
     exit 1

--- a/src/internal.c
+++ b/src/internal.c
@@ -22776,13 +22776,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     #ifdef WOLFSSL_TLS13
                 if (TLSX_Find(ssl->extensions,
                                              TLSX_SUPPORTED_VERSIONS) != NULL) {
-                    TLSX_FreeAll(ssl->extensions, ssl->heap);
-                    ssl->extensions = NULL;
-                    ssl->version.minor = TLSv1_3_MINOR;
-                    *inOutIdx = begin;
-                    if ((ret = InitHandshakeHashes(ssl)) != 0)
-                        return ret;
-                    return DoTls13ClientHello(ssl, input, inOutIdx, helloSz);
+                    WOLFSSL_MSG(
+                            "Client attempting to connect with higher version");
+                    return VERSION_ERROR;
                 }
     #endif
 #if defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)


### PR DESCRIPTION
Change SupportedVersions extension to only include TLS v1.3 if downgrade
is disabled.

Fix parsing of SupportedVersions extension
Don't upgrade
Only downgrade in SupportedVersions extension if option enabled