### PR TITLE
Fix for FIPS build to support new names

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -6391,7 +6391,7 @@ WOLFSSL_LOCAL int SetSerialNumber(const byte* sn, word32 snSz, byte* output)
     int i = 0;
     int snSzInt = (int)snSz;
 
-    if (sn == NULL || output == NULL)
+    if (sn == NULL || output == NULL || snSzInt < 0)
         return BAD_FUNC_ARG;
 
     /* remove leading zeros */
@@ -6405,8 +6405,10 @@ WOLFSSL_LOCAL int SetSerialNumber(const byte* sn, word32 snSz, byte* output)
     i += SetLength(snSzInt, &output[i]);
     XMEMCPY(&output[i], sn, snSzInt);
 
-    /* ensure positive (MSB not set) */
-    output[i] &= ~0x80;
+    if (snSzInt > 0) {
+        /* ensure positive (MSB not set) */
+        output[i] &= ~0x80;
+    }
 
     /* compute final length */
     i += snSzInt;

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -45,9 +45,8 @@
     int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 keySz)
     {
         if (hmac == NULL || (key == NULL && keySz != 0) ||
-           !(type == WC_MD5 || type == WC_SHA || type == WC_SHA224 ||
-                type == WC_SHA256 || type == WC_SHA384 || type == WC_SHA512 ||
-                type == BLAKE2B_ID)) {
+           !(type == WC_MD5 || type == WC_SHA || type == WC_SHA256 ||
+                type == WC_SHA384 || type == WC_SHA512 || type == BLAKE2B_ID)) {
             return BAD_FUNC_ARG;
         }
 

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -28,6 +28,12 @@
 #ifndef NO_SHA
 
 #ifdef HAVE_FIPS
+#define wc_Sha             Sha
+#define WC_SHA             SHA
+#define WC_SHA_BLOCK_SIZE  SHA_BLOCK_SIZE
+#define WC_SHA_DIGEST_SIZE SHA_DIGEST_SIZE
+#define WC_SHA_PAD_SIZE    SHA_PAD_SIZE
+
 /* for fips @wc_fips */
 #include <cyassl/ctaocrypt/sha.h>
 #endif

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -30,6 +30,20 @@
 #ifndef NO_SHA256
 
 #ifdef HAVE_FIPS
+    #define wc_Sha256             Sha256
+    #define WC_SHA256             SHA256
+    #define WC_SHA256_BLOCK_SIZE  SHA256_BLOCK_SIZE
+    #define WC_SHA256_DIGEST_SIZE SHA256_DIGEST_SIZE
+    #define WC_SHA256_PAD_SIZE    SHA256_PAD_SIZE
+
+    #ifdef WOLFSSL_SHA224
+        #define wc_Sha224             Sha224
+        #define WC_SHA224             SHA224
+        #define WC_SHA224_BLOCK_SIZE  SHA224_BLOCK_SIZE
+        #define WC_SHA224_DIGEST_SIZE SHA224_DIGEST_SIZE
+        #define WC_SHA224_PAD_SIZE    SHA224_PAD_SIZE
+    #endif
+
     /* for fips @wc_fips */
     #include <cyassl/ctaocrypt/sha256.h>
 #endif
@@ -114,6 +128,7 @@ WOLFSSL_API void wc_Sha256SizeSet(wc_Sha256*, word32);
 #endif
 
 #ifdef WOLFSSL_SHA224
+#ifndef HAVE_FIPS /* avoid redefinition of structs */
 
 #ifndef NO_OLD_WC_NAMES
     #define Sha224             wc_Sha224
@@ -123,7 +138,6 @@ WOLFSSL_API void wc_Sha256SizeSet(wc_Sha256*, word32);
     #define SHA224_PAD_SIZE    WC_SHA224_PAD_SIZE
 #endif
 
-#ifndef HAVE_FIPS /* avoid redefinition of structs */
 /* in bytes */
 enum {
     WC_SHA224              =   8,   /* hash type unique */

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -29,6 +29,19 @@
 
 /* for fips @wc_fips */
 #ifdef HAVE_FIPS
+    #define wc_Sha512             Sha512
+    #define WC_SHA512             SHA512
+    #define WC_SHA512_BLOCK_SIZE  SHA512_BLOCK_SIZE
+    #define WC_SHA512_DIGEST_SIZE SHA512_DIGEST_SIZE
+    #define WC_SHA512_PAD_SIZE    SHA512_PAD_SIZE
+    #ifdef WOLFSSL_SHA384
+        #define wc_Sha384             Sha384
+        #define WC_SHA384             SHA384
+        #define WC_SHA384_BLOCK_SIZE  SHA384_BLOCK_SIZE
+        #define WC_SHA384_DIGEST_SIZE SHA384_DIGEST_SIZE
+        #define WC_SHA384_PAD_SIZE    SHA384_PAD_SIZE
+    #endif /* WOLFSSL_SHA384 */
+
     #define CYASSL_SHA512
     #if defined(WOLFSSL_SHA384)
         #define CYASSL_SHA384


### PR DESCRIPTION
Support for mapping to new names with old for FIPS build. Fix to revert HMAC SHA224 type check, since SHA224 type isn't in FIPS wolfCrypt.