### PR TITLE
Build fixes for various TLS 1.3 disable options

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5219,6 +5219,7 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
             return WOLFSSL_BAD_FILE;
 
         (void)ed25519Key;
+        (void)devId;
     }
     else if (type == CERT_TYPE) {
     #ifdef WOLFSSL_SMALL_STACK

--- a/src/tls.c
+++ b/src/tls.c
@@ -5056,12 +5056,16 @@ static void TLSX_KeyShare_FreeAll(KeyShareEntry* list, void* heap)
     while ((current = list) != NULL) {
         list = current->next;
         if ((current->group & NAMED_DH_MASK) == 0) {
-#ifdef HAVE_CURVE25519
             if (current->group == WOLFSSL_ECC_X25519) {
-            }
-            else
+#ifdef HAVE_CURVE25519
+
 #endif
+            }
+            else {
+#ifdef HAVE_ECC
                 wc_ecc_free((ecc_key*)(current->key));
+#endif
+            }
         }
         XFREE(current->key, heap, DYNAMIC_TYPE_PRIVATE_KEY);
         XFREE(current->ke, heap, DYNAMIC_TYPE_PUBLIC_KEY);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3856,7 +3856,7 @@ static int SendTls13CertificateRequest(WOLFSSL* ssl, byte* reqCtx,
 #endif /* NO_WOLFSSL_SERVER */
 
 #ifndef NO_CERTS
-#if !defined(NO_RSA) || defined(HAVE_ECC)
+#if !defined(NO_RSA) || defined(HAVE_ECC) || defined(HAVE_ED25519)
 /* Encode the signature algorithm into buffer.
  *
  * hashalgo  The hash algorithm.
@@ -3871,13 +3871,14 @@ static INLINE void EncodeSigAlg(byte hashAlgo, byte hsType, byte* output)
             output[0] = hashAlgo;
             output[1] = ecc_dsa_sa_algo;
             break;
-    #ifdef HAVE_ED25519
+#endif
+#ifdef HAVE_ED25519
         /* ED25519: 0x0807 */
         case ed25519_sa_algo:
             output[0] = ED25519_SA_MAJOR;
             output[1] = ED25519_SA_MINOR;
+            (void)hashAlgo;
             break;
-    #endif
 #endif
 #ifndef NO_RSA
         /* PSS signatures: 0x080[4-6] */
@@ -4838,7 +4839,7 @@ static int DoTls13Certificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     return ret;
 }
 
-#if !defined(NO_RSA) || defined(HAVE_ECC)
+#if !defined(NO_RSA) || defined(HAVE_ECC) || defined(HAVE_ED25519)
 
 typedef struct Dcv13Args {
     byte*  output; /* not allocated */
@@ -6163,7 +6164,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         break;
 #endif
 
-#if !defined(NO_RSA) || defined(HAVE_ECC)
+#if !defined(NO_RSA) || defined(HAVE_ECC) || defined(HAVE_ED25519)
     case certificate_verify:
         WOLFSSL_MSG("processing certificate verify");
         ret = DoTls13CertificateVerify(ssl, input, inOutIdx, size);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2540,7 +2540,7 @@ typedef struct Ciphers {
 #endif
 #if defined(BUILD_AES) || defined(BUILD_AESGCM)
     Aes*    aes;
-    #if defined(BUILD_AESGCM) || defined(HAVE_AESCCM)
+    #if defined(BUILD_AESGCM) || defined(HAVE_AESCCM) || defined(WOLFSSL_TLS13)
         byte* additional;
         byte* nonce;
     #endif


### PR DESCRIPTION
Tested with the following:
```
./configure --disable-rsa --disable-ecc --enable-ed25519 --enable-curve25519 -enable-tls13
./configure --disable-rsa --enable-ecc -enable-tls13
./configure --disable-ecc -enable-tls13
```

Came up in forum case with building TLS 1.3 without ECC.