### PR TITLE
Fix no ECC builds with TLS13 code.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -285,11 +285,7 @@ fi
 
 if test "$ENABLED_TLS13" = "yes"
 then
-    AM_CFLAGS="-DWOLFSSL_TLS13 -DHAVE_TLS_EXTENSIONS $AM_CFLAGS"
-    if test "$ENABLED_DH" = "yes"
-    then
-        AM_CFLAGS="-DHAVE_FFDHE_2048 $AM_CFLAGS"
-    fi
+    AM_CFLAGS="-DWOLFSSL_TLS13 -DHAVE_TLS_EXTENSIONS -DHAVE_SUPPORTED_CURVES $AM_CFLAGS"
 fi
 
 # check if TLS v1.3 was enabled for conditionally running tls13.test script
@@ -1510,6 +1506,11 @@ else
         AM_CFLAGS="$AM_CFLAGS -DNO_DH"
         ENABLED_DH=no
     fi
+fi
+
+if test "$ENABLED_TLS13" = "yes" && test "$ENABLED_DH" = "yes"
+then
+    AM_CFLAGS="-DHAVE_FFDHE_2048 $AM_CFLAGS"
 fi
 
 AM_CONDITIONAL([BUILD_DH], [test "x$ENABLED_DH" = "xyes"])

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -175,21 +175,24 @@ if [ $RESULT -ne 0 ]; then
 fi
 echo ""
 
-# Usual TLS v1.3 server / TLS v1.3 client and ECC certificates.
-echo -e "\n\nTLS v1.3 server with TLS v1.3 client - ECC certificates"
-port=0
-./examples/server/server -v 4 -A certs/client-ecc-cert.pem -c certs/server-ecc.pem -k certs/ecc-key.pem -R $ready_file -p $port &
-server_pid=$!
-create_port
-./examples/client/client -v 4 -A certs/ca-ecc-cert.pem -c certs/client-ecc-cert.pem -k certs/ecc-client-key.pem -p $port
-RESULT=$?
-remove_ready_file
-if [ $RESULT -ne 0 ]; then
-    echo -e "\n\nTLS v1.3 ECC certificates not working"
-    do_cleanup
-    exit 1
+./examples/client/client -v 4 -e 2>&1 | grep -- '-ECC'
+if [ $? -eq 0 ]; then
+    # Usual TLS v1.3 server / TLS v1.3 client and ECC certificates.
+    echo -e "\n\nTLS v1.3 server with TLS v1.3 client - ECC certificates"
+    port=0
+    ./examples/server/server -v 4 -A certs/client-ecc-cert.pem -c certs/server-ecc.pem -k certs/ecc-key.pem -R $ready_file -p $port &
+    server_pid=$!
+    create_port
+    ./examples/client/client -v 4 -A certs/ca-ecc-cert.pem -c certs/client-ecc-cert.pem -k certs/ecc-client-key.pem -p $port
+    RESULT=$?
+    remove_ready_file
+    if [ $RESULT -ne 0 ]; then
+        echo -e "\n\nTLS v1.3 ECC certificates not working"
+        do_cleanup
+        exit 1
+    fi
+    echo ""
 fi
-echo ""
 
 # Usual TLS v1.3 server / TLS v1.3 client and no client certificate.
 echo -e "\n\nTLS v1.3 server with TLS v1.3 client - no client cretificate"

--- a/src/internal.c
+++ b/src/internal.c
@@ -22014,7 +22014,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
         }
 
-#ifdef HAVE_SUPPORTED_CURVES
+#if defined(HAVE_SUPPORTED_CURVES) && defined(HAVE_ECC)
         if (!TLSX_ValidateSupportedCurves(ssl, first, second)) {
             WOLFSSL_MSG("Don't have matching curves");
                 return 0;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3325,7 +3325,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ssl->version.minor = pv.minor;
     }
 
-#ifdef WOLFSSL_SEND_HRR_COOKIE
+#if !defined(WOLFSSL_TLS13_DRAFT_18) && defined(WOLFSSL_SEND_HRR_COOKIE)
     if (ssl->options.sendCookie &&
                        ssl->options.serverState == SERVER_HELLO_RETRY_REQUEST) {
         TLSX* ext;

--- a/tests/api.c
+++ b/tests/api.c
@@ -10721,6 +10721,7 @@ static int test_tls13_apis(void)
                 WOLFSSL_SUCCESS);
 #endif
 
+#ifdef HAVE_ECC
     AssertIntEQ(wolfSSL_UseKeyShare(NULL, WOLFSSL_ECC_SECP256R1), BAD_FUNC_ARG);
     AssertIntEQ(wolfSSL_UseKeyShare(serverSsl, WOLFSSL_ECC_SECP256R1),
                 SIDE_ERROR);
@@ -10728,6 +10729,15 @@ static int test_tls13_apis(void)
                 WOLFSSL_SUCCESS);
     AssertIntEQ(wolfSSL_UseKeyShare(clientSsl, WOLFSSL_ECC_SECP256R1),
                 WOLFSSL_SUCCESS);
+#else
+    AssertIntEQ(wolfSSL_UseKeyShare(NULL, WOLFSSL_ECC_SECP256R1), BAD_FUNC_ARG);
+    AssertIntEQ(wolfSSL_UseKeyShare(serverSsl, WOLFSSL_ECC_SECP256R1),
+                SIDE_ERROR);
+    AssertIntEQ(wolfSSL_UseKeyShare(clientTls12Ssl, WOLFSSL_ECC_SECP256R1),
+                NOT_COMPILED_IN);
+    AssertIntEQ(wolfSSL_UseKeyShare(clientSsl, WOLFSSL_ECC_SECP256R1),
+                NOT_COMPILED_IN);
+#endif
 
     AssertIntEQ(wolfSSL_NoKeyShares(NULL), BAD_FUNC_ARG);
     AssertIntEQ(wolfSSL_NoKeyShares(serverSsl), SIDE_ERROR);

--- a/tests/include.am
+++ b/tests/include.am
@@ -21,6 +21,7 @@ endif
 EXTRA_DIST += tests/unit.h
 EXTRA_DIST += tests/test.conf \
               tests/test-tls13.conf \
+              tests/test-tls13-ecc.conf \
               tests/test-qsh.conf \
               tests/test-psk-no-id.conf \
               tests/test-dtls.conf \

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -577,6 +577,16 @@ int SuiteTest(void)
         printf("error from script %d\n", args.return_code);
         exit(EXIT_FAILURE);
     }
+    #ifdef HAVE_ECC
+    /* add TLSv13 ECC extra suites */
+    strcpy(argv0[1], "tests/test-tls13-ecc.conf");
+    printf("starting TLSv13 ECC extra cipher suite tests\n");
+    test_harness(&args);
+    if (args.return_code != 0) {
+        printf("error from script %d\n", args.return_code);
+        exit(EXIT_FAILURE);
+    }
+    #endif
 #endif
 #if defined(HAVE_CURVE25519) && defined(HAVE_ED25519)
     /* add ED25519 certificate cipher suite tests */

--- a/tests/test-tls13-ecc.conf
+++ b/tests/test-tls13-ecc.conf
@@ -1,74 +1,67 @@
 # server TLSv1.3 TLS13-CHACH20-POLY1305-SHA256
 -v 4
 -l TLS13-CHACH20-POLY1305-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
 
 # client TLSv1.3 TLS13-CHACH20-POLY1305-SHA256
 -v 4
 -l TLS13-CHACH20-POLY1305-SHA256
+-A ./certs/ca-ecc-cert.pem
 
 # server TLSv1.3 TLS13-AES128-GCM-SHA256
 -v 4
 -l TLS13-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
 
 # client TLSv1.3 TLS13-AES128-GCM-SHA256
 -v 4
 -l TLS13-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
 
 # server TLSv1.3 TLS13-AES256-GCM-SHA384
 -v 4
 -l TLS13-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
 
 # client TLSv1.3 TLS13-AES256-GCM-SHA384
 -v 4
 -l TLS13-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
 
 # server TLSv1.3 TLS13-AES128-CCM-SHA256
 -v 4
 -l TLS13-AES128-CCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
 
 # client TLSv1.3 TLS13-AES128-CCM-SHA256
 -v 4
 -l TLS13-AES128-CCM-SHA256
+-A ./certs/ca-ecc-cert.pem
 
 # server TLSv1.3 TLS13-AES128-CCM-8-SHA256
 -v 4
 -l TLS13-AES128-CCM-8-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
 
 # client TLSv1.3 TLS13-AES128-CCM-8-SHA256
 -v 4
 -l TLS13-AES128-CCM-8-SHA256
+-A ./certs/ca-ecc-cert.pem
 
-# server TLSv1.3 accepting EarlyData
+# server TLSv1.3 TLS13-AES128-GCM-SHA256
 -v 4
 -l TLS13-AES128-GCM-SHA256
--r
--0
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
 
-# client TLSv1.3 sending EarlyData
+# client TLSv1.3 TLS13-AES128-GCM-SHA256
 -v 4
 -l TLS13-AES128-GCM-SHA256
--r
--0
-
-# server TLSv1.3 not accepting EarlyData
--v 4
--l TLS13-AES128-GCM-SHA256
--r
-
-# client TLSv1.3 sending EarlyData
--v 4
--l TLS13-AES128-GCM-SHA256
--r
--0
-
-# server TLSv1.3 accepting EarlyData
--v 4
--l TLS13-AES128-GCM-SHA256
--r
--0
-
-# client TLSv1.3 not sending EarlyData
--v 4
--l TLS13-AES128-GCM-SHA256
--r
+-A ./certs/ca-ecc-cert.pem
+-t
 


### PR DESCRIPTION
Fix tests so that having ECC disabled works as well.
Fix define protection for Draft 18 and HRR Cookie.