### PR TITLE
Release updates for ec_point_formats and ASN1 SetSerialNumber bug

### DIFF
--- a/README
+++ b/README
@@ -35,12 +35,13 @@ before calling wolfSSL_new();  Though it's not recommended.
 *** end Notes ***
 
 
-********* wolfSSL (Formerly CyaSSL) Release 3.12.2 (10/20/2017)
+********* wolfSSL (Formerly CyaSSL) Release 3.12.2 (10/23/2017)
 
 Release 3.12.2 of wolfSSL has bug fixes and new features including:
 
 This release includes many performance improvements with Intel ASM (AVX/AVX2) and AES-NI. New single precision math option to speedup RSA, DH and ECC. Embedded hardware support has been expanded for STM32, PIC32MZ and ATECC508A. AES now supports XTS mode for disk encryption. Certificate improvements for setting serial number, key usage and extended key usage. Refactor of SSL_ and hash types to allow openssl coexistence. Improvements for TLS 1.3. Fixes for OCSP stapling to allow disable and WOLFSSL specific user context for callbacks. Fixes for openssl and MySQL compatibility. Updated Micrium port. Fixes for asynchronous modes.
 
+- Added TLS extension for Supported Point Formats (ec_point_formats)
 - Fix to not send OCSP stapling extensions in client_hello when not enabled
 - Added new API's for disabling OCSP stapling
 - Add check for SIZEOF_LONG with sun and LP64

--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0);
 before calling wolfSSL_new();  Though it's not recommended.
 ```
 
-# wolfSSL (Formerly CyaSSL) Release 3.12.2 (10/20/2017)
+# wolfSSL (Formerly CyaSSL) Release 3.12.2 (10/23/2017)
 
 ## Release 3.12.2 of wolfSSL has bug fixes and new features including:
 
 This release includes many performance improvements with Intel ASM (AVX/AVX2) and AES-NI. New single precision math option to speedup RSA, DH and ECC. Embedded hardware support has been expanded for STM32, PIC32MZ and ATECC508A. AES now supports XTS mode for disk encryption. Certificate improvements for setting serial number, key usage and extended key usage. Refactor of SSL_ and hash types to allow openssl coexistence. Improvements for TLS 1.3. Fixes for OCSP stapling to allow disable and WOLFSSL specific user context for callbacks. Fixes for openssl and MySQL compatibility. Updated Micrium port. Fixes for asynchronous modes.
 
+* Added TLS extension for Supported Point Formats (ec_point_formats)
 * Fix to not send OCSP stapling extensions in client_hello when not enabled
 * Added new API's for disabling OCSP stapling
 * Add check for SIZEOF_LONG with sun and LP64

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -6417,9 +6417,13 @@ WOLFSSL_LOCAL int SetSerialNumber(const byte* sn, word32 snSz, byte* output)
     i += SetLength(snSzInt, &output[i]);
     XMEMCPY(&output[i], sn, snSzInt);
 
+    /* make sure number is positive */
     if (snSzInt > 0) {
-        /* ensure positive (MSB not set) */
+        /* clear MSB bit */
         output[i] &= ~0x80;
+        /* handle zero case... make 1 */
+        if (output[i] == 0)
+            output[i] = 0x01;
     }
 
     /* compute final length */

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -993,7 +993,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
                                     esd->contentInfoSeq);
 
     esd->issuerSnSz = SetSerialNumber(pkcs7->issuerSn, pkcs7->issuerSnSz,
-                                     esd->issuerSn);
+                                     esd->issuerSn, MAX_SN_SZ);
     signerInfoSz += esd->issuerSnSz;
     esd->issuerNameSz = SetSequence(pkcs7->issuerSz, esd->issuerName);
     signerInfoSz += esd->issuerNameSz + pkcs7->issuerSz;
@@ -2576,7 +2576,7 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
 #endif
         return -1;
     }
-    snSz = SetSerialNumber(decoded->serial, decoded->serialSz, serial);
+    snSz = SetSerialNumber(decoded->serial, decoded->serialSz, serial, MAX_SN_SZ);
 
     issuerSerialSeqSz = SetSequence(issuerSeqSz + issuerSz + snSz,
                                     issuerSerialSeq);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -12880,7 +12880,7 @@ static int ed25519_test_cert(void)
 #endif /* HAVE_ED25519_VERIFY */
     int          ret;
     byte*        tmp;
-    int          bytes;
+    size_t       bytes;
     FILE*        file;
 
     tmp = XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -804,7 +804,8 @@ WOLFSSL_LOCAL word32 SetExplicit(byte number, word32 len, byte* output);
 WOLFSSL_LOCAL word32 SetSet(word32 len, byte* output);
 WOLFSSL_LOCAL word32 SetAlgoID(int algoOID,byte* output,int type,int curveSz);
 WOLFSSL_LOCAL int SetMyVersion(word32 version, byte* output, int header);
-WOLFSSL_LOCAL int SetSerialNumber(const byte* sn, word32 snSz, byte* output);
+WOLFSSL_LOCAL int SetSerialNumber(const byte* sn, word32 snSz, byte* output,
+    int maxSnSz);
 WOLFSSL_LOCAL int GetSerialNumber(const byte* input, word32* inOutIdx,
     byte* serial, int* serialSz, word32 maxIdx);
 WOLFSSL_LOCAL int GetNameHash(const byte* source, word32* idx, byte* hash,


### PR DESCRIPTION
Updated release notes for added `ec_point_formats` extension. Fix for setting serial number with random data where the MSB was cleared and resulted in a zero. Fix for build type mismatch error in wolfCrypt test with ed25519 and WOLFSSL_TEST_CERT defined.