### PR TITLE
Fix build errors with various configs.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2838,7 +2838,7 @@ void FreeX509(WOLFSSL_X509* x509)
 
 #endif /* !NO_DH || HAVE_ECC */
 
-#if !defined(NO_RSA) || defined(HAVE_ECC) || defined(HAVE_ED25519)
+#ifndef NO_CERTS
 /* Encode the signature algorithm into buffer.
  *
  * hashalgo  The hash algorithm.
@@ -2876,7 +2876,10 @@ static INLINE void EncodeSigAlg(byte hashAlgo, byte hsType, byte* output)
 #endif
         /* ED448: 0x0808 */
     }
+    (void)hashAlgo;
+    (void)output;
 }
+
 static void SetDigest(WOLFSSL* ssl, int hashAlgo)
 {
     switch (hashAlgo) {
@@ -2906,7 +2909,7 @@ static void SetDigest(WOLFSSL* ssl, int hashAlgo)
         #endif /* WOLFSSL_SHA512 */
     } /* switch */
 }
-#endif
+#endif /* !NO_CERTS */
 
 #ifndef NO_RSA
 static int TypeHash(int hashAlgo)
@@ -4597,7 +4600,8 @@ int AllocKey(WOLFSSL* ssl, int type, void** pKey)
     return ret;
 }
 
-#if !defined(NO_RSA) || defined(HAVE_ECC) || defined(HAVE_CURVE25519)
+#if !defined(NO_RSA) || defined(HAVE_ECC) || defined(HAVE_ED25519) || \
+    defined(HAVE_CURVE25519)
 static int ReuseKey(WOLFSSL* ssl, int type, void* pKey)
 {
     int ret = 0;
@@ -19521,9 +19525,13 @@ exit_scke:
  */
 int DecodePrivateKey(WOLFSSL *ssl, word16* length)
 {
-    int      ret;
+    int      ret = BAD_FUNC_ARG;
+#if !defined(NO_RSA) || defined(HAVE_ECC) || defined(HAVE_ED25519)
     int      keySz;
     word32   idx;
+#else
+    (void)length;
+#endif
 
     /* make sure private key exists */
     if (ssl->buffers.key == NULL || ssl->buffers.key->buffer == NULL) {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1007,11 +1007,10 @@ static int CheckBitString(const byte* input, word32* inOutIdx, int* len,
     return 0;
 }
 
-#if (!defined(NO_RSA) && (defined(WOLFSSL_CERT_GEN) || \
-                          (defined(WOLFSSL_KEY_GEN) && \
-                           !defined(HAVE_USER_RSA)))) || \
-    (defined(HAVE_ECC) && (defined(WOLFSSL_CERT_GEN) || \
-                           defined(WOLFSSL_KEY_GEN)))
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN)
+
+#if (!defined(NO_RSA) && !defined(HAVE_USER_RSA)) || \
+    defined(HAVE_ECC) || defined(HAVE_ED25519)
 /* Set the DER/BER encoding of the ASN.1 BIT_STRING header.
  *
  * len         Length of data to encode.
@@ -1066,8 +1065,8 @@ static word32 SetBitString16Bit(word16 val, byte* output)
     return idx;
 }
 #endif /* WOLFSSL_CERT_EXT */
-#endif /* !NO_RSA && (WOLFSSL_CERT_GEN || (WOLFSSL_KEY_GEN &&
-                                           !HAVE_USER_RSA)) */
+#endif /* !NO_RSA || HAVE_ECC || HAVE_ED25519 */
+#endif /* WOLFSSL_CERT_GEN || WOLFSSL_KEY_GEN */
 
 
 
@@ -2176,6 +2175,8 @@ int wc_CheckPrivateKey(byte* key, word32 keySz, DecodedCert* der)
     {
         ret = 0;
     }
+
+    (void)keySz;
 
     return ret;
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -920,7 +920,8 @@ int wolfcrypt_test(void* args)
 #endif /* NO_MAIN_DRIVER */
 
 /* helper to save DER, convert to PEM and save PEM */
-#if defined(WOLFSSL_KEY_GEN) || defined(WOLFSSL_CERT_GEN)
+#if !defined(NO_ASN) && (!defined(NO_RSA) || defined(HAVE_ECC)) && \
+    (defined(WOLFSSL_KEY_GEN) || defined(WOLFSSL_CERT_GEN))
 
 #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
 #define SaveDerAndPem(d, dSz, p, pSz, fD, fP, pT, eB) _SaveDerAndPem(d, dSz, p, pSz, fD, fP, pT, eB)


### PR DESCRIPTION
These configurations had build errors.
./configure --enable-keygen --disable-ecc --disable-rsa --disable-ed25519 --enable-psk && make
./configure --enable-keygen --disable-ecc --disable-rsa --enable-ed25519 --enable-psk && make
./configure --enable-keygen --disable-ecc --disable-rsa --enable-psk && make
./configure --enable-keygen --disable-asn --disable-ecc --disable-rsa --enable-psk && make
