### PR TITLE
Fixes and improvements for `EC_POINT_mul`

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -18459,6 +18459,11 @@ WOLFSSL_BIGNUM* wolfSSL_BN_copy(WOLFSSL_BIGNUM* r, const WOLFSSL_BIGNUM* bn)
 {
     WOLFSSL_MSG("wolfSSL_BN_copy");
 
+    if (r == NULL || bn == NULL) {
+        WOLFSSL_MSG("r or bn NULL error");
+        return NULL;
+    }
+
     if (mp_copy((mp_int*)bn->internal, (mp_int*)r->internal) != MP_OKAY) {
         WOLFSSL_MSG("mp_copy error");
         return NULL;
@@ -18475,6 +18480,11 @@ WOLFSSL_BIGNUM* wolfSSL_BN_copy(WOLFSSL_BIGNUM* r, const WOLFSSL_BIGNUM* bn)
 int wolfSSL_BN_set_word(WOLFSSL_BIGNUM* bn, WOLFSSL_BN_ULONG w)
 {
     WOLFSSL_MSG("wolfSSL_BN_set_word");
+
+    if (bn == NULL) {
+        WOLFSSL_MSG("bn NULL error");
+        return WOLFSSL_FAILURE;
+    }
 
     if (mp_set_int((mp_int*)bn->internal, w) != MP_OKAY) {
         WOLFSSL_MSG("mp_init_set_int error");
@@ -21590,35 +21600,40 @@ int wolfSSL_EC_KEY_set_public_key(WOLFSSL_EC_KEY *key,
         return WOLFSSL_FAILURE;
     }
 
-#if defined(DEBUG_WOLFSSL) && !defined(NO_FILESYSTEM)
-    wolfssl_EC_POINT_dump("pub", pub);
-    wolfssl_EC_POINT_dump("key->pub_key", key->pub_key);
-#endif
+    wolfSSL_EC_POINT_dump("pub", pub);
+    wolfSSL_EC_POINT_dump("key->pub_key", key->pub_key);
+
     return WOLFSSL_SUCCESS;
 }
 /* End EC_KEY */
 
-#if defined(DEBUG_WOLFSSL) && !defined(NO_FILESYSTEM)
-void wolfssl_EC_POINT_dump(const char *msg, const WOLFSSL_EC_POINT *p)
+void wolfSSL_EC_POINT_dump(const char *msg, const WOLFSSL_EC_POINT *p)
 {
+#if defined(DEBUG_WOLFSSL)
     char *num;
 
-    WOLFSSL_ENTER("wolfssl_EC_POINT_dump");
+    WOLFSSL_ENTER("wolfSSL_EC_POINT_dump");
 
     if (p == NULL) {
-        fprintf(stderr, "%s = NULL", msg);
+        printf("%s = NULL", msg);
         return;
     }
 
-    fprintf(stderr, "%s:\n\tinSet=%d, exSet=%d\n", msg, p->inSet, p->exSet);
+    printf("%s:\n\tinSet=%d, exSet=%d\n", msg, p->inSet, p->exSet);
     num = wolfSSL_BN_bn2hex(p->X);
-    fprintf(stderr, "\tX = %s\n", num);
+    printf("\tX = %s\n", num);
     XFREE(num, NULL, DYNAMIC_TYPE_ECC);
     num = wolfSSL_BN_bn2hex(p->Y);
-    fprintf(stderr, "\tY = %s\n", num);
+    printf("\tY = %s\n", num);
     XFREE(num, NULL, DYNAMIC_TYPE_ECC);
-}
+    num = wolfSSL_BN_bn2hex(p->Z);
+    printf("\tZ = %s\n", num);
+    XFREE(num, NULL, DYNAMIC_TYPE_ECC);
+#else
+    (void)msg;
+    (void)p;
 #endif
+}
 
 /* Start EC_GROUP */
 
@@ -21812,11 +21827,10 @@ int wolfSSL_ECPoint_i2d(const WOLFSSL_EC_GROUP *group,
         }
     }
 
-#if defined(DEBUG_WOLFSSL) && !defined(NO_FILESYSTEM)
     if (out != NULL) {
-        wolfssl_EC_POINT_dump("i2d p", p);
+        wolfSSL_EC_POINT_dump("i2d p", p);
     }
-#endif
+
     err = wc_ecc_export_point_der(group->curve_idx, (ecc_point*)p->internal,
                                   out, len);
     if (err != MP_OKAY && !(out == NULL && err == LENGTH_ONLY_E)) {
@@ -21855,9 +21869,8 @@ int wolfSSL_ECPoint_d2i(unsigned char *in, unsigned int len,
         }
     }
 
-#if defined(DEBUG_WOLFSSL) && !defined(NO_FILESYSTEM)
-    wolfssl_EC_POINT_dump("d2i p", p);
-#endif
+    wolfSSL_EC_POINT_dump("d2i p", p);
+
     return WOLFSSL_SUCCESS;
 }
 
@@ -21960,20 +21973,22 @@ int wolfSSL_EC_POINT_mul(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *r,
     }
 
     ret = mp_read_radix(&prime, ecc_sets[group->curve_idx].prime, 16);
-    if (ret == MP_OKAY)
+    if (ret == MP_OKAY) {
         ret = mp_read_radix(&a, ecc_sets[group->curve_idx].Af, 16);
+    }
 
     /* r = q * m % prime */
-    if (ret == MP_OKAY)
+    if (ret == MP_OKAY) {
         ret = wc_ecc_mulmod((mp_int*)m->internal, (ecc_point*)q->internal,
                       (ecc_point*)r->internal, &a, &prime, 1);
+    }
 
     mp_clear(&a);
     mp_clear(&prime);
 
     if (ret == MP_OKAY) {
         /* set the external value for the computed point */
-        ret = SetECPointInternal(r);
+        ret = SetECPointExternal(r);
         if (ret != WOLFSSL_SUCCESS) {
             WOLFSSL_MSG("SetECPointInternal r failed");
         }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -22040,9 +22040,8 @@ void wolfSSL_EC_POINT_free(WOLFSSL_EC_POINT *p)
     WOLFSSL_ENTER("wolfSSL_EC_POINT_free");
 
     if (p != NULL) {
-        if (p->internal == NULL) {
+        if (p->internal != NULL) {
             wc_ecc_del_point((ecc_point*)p->internal);
-            XFREE(p->internal, NULL, DYNAMIC_TYPE_ECC);
             p->internal = NULL;
         }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -145,6 +145,7 @@
     #include <wolfssl/openssl/dh.h>
     #include <wolfssl/openssl/bn.h>
     #include <wolfssl/openssl/pem.h>
+    #include <wolfssl/openssl/ec.h>
 #ifndef NO_DES3
     #include <wolfssl/openssl/des.h>
 #endif
@@ -733,13 +734,80 @@ static int test_wolfSSL_SetMinVersion(void)
 
 } /* END test_wolfSSL_SetMinVersion */
 
+
+/*----------------------------------------------------------------------------*
+ | EC
+ *----------------------------------------------------------------------------*/
+
+/* Test function for EC_POINT_new, EC_POINT_mul, EC_POINT_free,
+    EC_GROUP_new_by_curve_name
+ */
+
+# if defined(OPENSSL_EXTRA)
+static void test_wolfSSL_EC(void)
+{
+#ifdef HAVE_ECC
+    BN_CTX *ctx;
+    EC_GROUP *group;
+    EC_POINT *Gxy, *new_point;
+    BIGNUM *k = NULL, *Gx = NULL, *Gy = NULL, *Gz = NULL;
+    BIGNUM *X, *Y;
+
+    const char* kTest = "F4F8338AFCC562C5C3F3E1E46A7EFECD17AF381913FF7A96314EA47055EA0FD0";
+    /* NISTP256R1 Gx/Gy */
+    const char* kGx   = "6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296";
+    const char* kGy   = "4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5";
+
+    AssertNotNull(ctx = BN_CTX_new());
+    AssertNotNull(group = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1));
+    AssertNotNull(Gxy = EC_POINT_new(group));
+    AssertNotNull(new_point = EC_POINT_new(group));
+    AssertNotNull(X = BN_new());
+    AssertNotNull(Y = BN_new());
+
+    /* load test values */
+    AssertIntEQ(BN_hex2bn(&k,  kTest), WOLFSSL_SUCCESS);
+    AssertIntEQ(BN_hex2bn(&Gx, kGx),   WOLFSSL_SUCCESS);
+    AssertIntEQ(BN_hex2bn(&Gy, kGy),   WOLFSSL_SUCCESS);
+    AssertIntEQ(BN_hex2bn(&Gz, "1"),   WOLFSSL_SUCCESS);
+
+    /* populate coordinates for input point */
+    Gxy->X = Gx;
+    Gxy->Y = Gy;
+    Gxy->Z = Gz;
+    Gxy->inSet = 0;
+
+    /* perform point multiplication */
+    AssertIntEQ(EC_POINT_mul(group, new_point, NULL, Gxy, k, ctx), WOLFSSL_SUCCESS);
+
+    /* check if point X coordinate is zero */
+    AssertIntEQ(BN_is_zero(new_point->X), WOLFSSL_FAILURE);
+
+    /* extract the coordinates from point */
+    AssertIntEQ(EC_POINT_get_affine_coordinates_GFp(group, new_point, X, Y, ctx), WOLFSSL_SUCCESS);
+
+    /* check if point X coordinate is zero */
+    AssertIntEQ(BN_is_zero(X), WOLFSSL_FAILURE);
+
+    /* cleanup */
+    BN_free(X);
+    BN_free(Y);
+    BN_free(k);
+    EC_POINT_free(new_point);
+    EC_POINT_free(Gxy);
+    EC_GROUP_free(group);
+    BN_CTX_free(ctx);
+#endif /* HAVE_ECC */
+}
+#endif
+
+
+#include <wolfssl/openssl/pem.h>
 /*----------------------------------------------------------------------------*
  | EVP
  *----------------------------------------------------------------------------*/
 
 /* Test function for wolfSSL_EVP_get_cipherbynid.
- *
- * POST: return 1 on success.
  */
 
 # if defined(OPENSSL_EXTRA)
@@ -11074,6 +11142,7 @@ void ApiTest(void)
 #ifdef OPENSSL_EXTRA
     /*wolfSSS_EVP_get_cipherbynid test*/
     test_wolfSSL_EVP_get_cipherbynid();
+    test_wolfSSL_EC();
 #endif
 
 #ifdef HAVE_HASHDRBG

--- a/tests/api.c
+++ b/tests/api.c
@@ -775,7 +775,6 @@ static void test_wolfSSL_EC(void)
     Gxy->X = Gx;
     Gxy->Y = Gy;
     Gxy->Z = Gz;
-    Gxy->inSet = 0;
 
     /* perform point multiplication */
     AssertIntEQ(EC_POINT_mul(group, new_point, NULL, Gxy, k, ctx), WOLFSSL_SUCCESS);
@@ -9759,9 +9758,9 @@ static void test_wolfSSL_EVP_PKEY_new_mac_key(void)
 #ifdef OPENSSL_EXTRA
     static const unsigned char pw[] = "password";
     static const int pwSz = sizeof(pw) - 1;
-    size_t checkPwSz;
-    const unsigned char* checkPw;
-    WOLFSSL_EVP_PKEY* key;
+    size_t checkPwSz = 0;
+    const unsigned char* checkPw = NULL;
+    WOLFSSL_EVP_PKEY* key = NULL;
 
     printf(testingFmt, "wolfSSL_EVP_PKEY_new_mac_key()");
 
@@ -9780,15 +9779,15 @@ static void test_wolfSSL_EVP_PKEY_new_mac_key(void)
 
     AssertNotNull(key = wolfSSL_EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, pw, 0));
     AssertIntEQ(key->pkey_sz, 0);
-    AssertNotNull(key->pkey.ptr);
-    AssertNotNull(checkPw = wolfSSL_EVP_PKEY_get0_hmac(key, &checkPwSz));
+    checkPw = wolfSSL_EVP_PKEY_get0_hmac(key, &checkPwSz);
+    (void)checkPw;
     AssertIntEQ((int)checkPwSz, 0);
     wolfSSL_EVP_PKEY_free(key);
 
     AssertNotNull(key = wolfSSL_EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, NULL, 0));
     AssertIntEQ(key->pkey_sz, 0);
-    AssertNotNull(key->pkey.ptr);
-    AssertNotNull(checkPw = wolfSSL_EVP_PKEY_get0_hmac(key, &checkPwSz));
+    checkPw = wolfSSL_EVP_PKEY_get0_hmac(key, &checkPwSz);
+    (void)checkPw;
     AssertIntEQ((int)checkPwSz, 0);
     wolfSSL_EVP_PKEY_free(key);
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -569,7 +569,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_mac_key(int type, ENGINE* e,
     pkey = wolfSSL_PKEY_new();
     if (pkey != NULL) {
         pkey->pkey.ptr = (char*)XMALLOC(keylen, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
-        if (pkey->pkey.ptr == NULL) {
+        if (pkey->pkey.ptr == NULL && keylen > 0) {
             wolfSSL_EVP_PKEY_free(pkey);
             pkey = NULL;
         }

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -130,10 +130,6 @@ int wolfSSL_EC_GROUP_get_order(const WOLFSSL_EC_GROUP *group,
                                WOLFSSL_BIGNUM *order, WOLFSSL_BN_CTX *ctx);
 WOLFSSL_API
 void wolfSSL_EC_GROUP_free(WOLFSSL_EC_GROUP *group);
-#if defined(DEBUG_WOLFSSL) && !defined(NO_FILESYSTEM)
-WOLFSSL_API
-void wolfssl_EC_POINT_dump(const char *msg, const WOLFSSL_EC_POINT *p);
-#endif
 WOLFSSL_API
 WOLFSSL_EC_POINT *wolfSSL_EC_POINT_new(const WOLFSSL_EC_GROUP *group);
 WOLFSSL_API
@@ -187,6 +183,8 @@ int wolfSSL_EC_POINT_is_at_infinity(const WOLFSSL_EC_GROUP *group,
 #define EC_POINT_cmp wolfSSL_EC_POINT_cmp
 #define EC_POINT_free wolfSSL_EC_POINT_free
 #define EC_POINT_is_at_infinity wolfSSL_EC_POINT_is_at_infinity
+
+#define EC_POINT_dump wolfSSL_EC_POINT_dump
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2606,6 +2606,8 @@ WOLFSSL_API int wolfSSL_sk_SSL_CIPHER_num(const void * p);
 WOLFSSL_API int wolfSSL_sk_SSL_COMP_zero(WOLFSSL_STACK* st);
 WOLFSSL_API WOLFSSL_CIPHER* wolfSSL_sk_SSL_CIPHER_value(void *ciphers, int idx);
 WOLFSSL_API void ERR_load_SSL_strings(void);
+WOLFSSL_API void wolfSSL_EC_POINT_dump(const char *msg, const WOLFSSL_EC_POINT *p);
+
 #endif /* OPENSSL_EXTRA */
 
 #ifdef __cplusplus


### PR DESCRIPTION
* Fix for `EC_POINT_mul` population of result.
* Fix for `EC_POINT_free` not freeing internal.
* Add NULL arg checks for a few compatability functions.
* Added unit tests for compatability layer API's `EC_POINT_` and `EC_GROUP_` in `test_wolfSSL_EC`.
* Cleanup of the `EC_POINT_dump`.