### PR TITLE
Fixes from nightly builds for time_t and no AES

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -10613,15 +10613,18 @@ static void test_wolfSSL_ASN1_TIME_adj(void)
 && !defined(USER_TIME) && !defined(TIME_OVERRIDES)
 
     const int year = 365*24*60*60;
-    const int day = 24*60*60;
+    const int day  = 24*60*60;
     const int hour = 60*60;
-    const int min = 60;
-    const byte asn_utc_time = 0x17;
-    const byte asn_gen_time = 0x18;
+    const int min  = 60;
+    const byte asn_utc_time = ASN_UTC_TIME;
+#ifndef TIME_T_NOT_LONG
+    const byte asn_gen_time = ASN_GENERALIZED_TIME;
+#endif
     WOLFSSL_ASN1_TIME *asn_time, *s;
     int offset_day;
     long offset_sec;
     char date_str[20];
+    time_t t;
 
     printf(testingFmt, "wolfSSL_ASN1_TIME_adj()");
 
@@ -10629,7 +10632,7 @@ static void test_wolfSSL_ASN1_TIME_adj(void)
                                     DYNAMIC_TYPE_OPENSSL);
     /* UTC notation test */
     /* 2000/2/15 20:30:00 */
-    time_t t = (time_t)30 * year + 45 * day + 20 * hour + 30 * min + 7 * day;
+    t = (time_t)30 * year + 45 * day + 20 * hour + 30 * min + 7 * day;
     offset_day = 7;
     offset_sec = 45 * min;
     /* offset_sec = -45 * min;*/
@@ -10648,10 +10651,12 @@ static void test_wolfSSL_ASN1_TIME_adj(void)
     XFREE(s,NULL,DYNAMIC_TYPE_OPENSSL);
     XMEMSET(date_str, 0, sizeof(date_str));
 
+    /* Generalized time will overflow time_t if not long */
+#ifndef TIME_T_NOT_LONG
     s = (WOLFSSL_ASN1_TIME*)XMALLOC(sizeof(WOLFSSL_ASN1_TIME), NULL,
                                     DYNAMIC_TYPE_OPENSSL);
     /* GeneralizedTime notation test */
-    /* 2055/03/01 09:00:00 */ 
+    /* 2055/03/01 09:00:00 */
     t = (time_t)85 * year + 59 * day + 9 * hour + 21 * day;
     offset_day = 12;
     offset_sec = 10 * min;
@@ -10662,6 +10667,7 @@ static void test_wolfSSL_ASN1_TIME_adj(void)
 
     XFREE(s,NULL,DYNAMIC_TYPE_OPENSSL);
     XMEMSET(date_str, 0, sizeof(date_str));
+#endif
 
     /* if WOLFSSL_ASN1_TIME struct is not allocated */
     s = NULL;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14189,7 +14189,7 @@ static int pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
         wc_PKCS7_Free(&pkcs7);
     }
 
-#ifndef HAVE_ECC
+#if !defined(HAVE_ECC) || defined(NO_AES)
     (void)eccCert;
     (void)eccCertSz;
     (void)eccPrivKey;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -791,9 +791,11 @@ WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_PKEY_new(void);
 WOLFSSL_API void      wolfSSL_EVP_PKEY_free(WOLFSSL_EVP_PKEY*);
 WOLFSSL_API int       wolfSSL_X509_cmp_current_time(const WOLFSSL_ASN1_TIME*);
 WOLFSSL_API int       wolfSSL_sk_X509_REVOKED_num(WOLFSSL_X509_REVOKED*);
+#ifdef OPENSSL_EXTRA
 WOLFSSL_API void      wolfSSL_X509_STORE_CTX_set_time(WOLFSSL_X509_STORE_CTX*,
                                                       unsigned long flags,
                                                       time_t t);
+#endif
 WOLFSSL_API WOLFSSL_X509_REVOKED* wolfSSL_X509_CRL_get_REVOKED(WOLFSSL_X509_CRL*);
 WOLFSSL_API WOLFSSL_X509_REVOKED* wolfSSL_sk_X509_REVOKED_value(
                                                       WOLFSSL_X509_REVOKED*,int);
@@ -884,7 +886,7 @@ WOLFSSL_API long wolfSSL_set_tlsext_status_ids(WOLFSSL *s, void *arg);
 WOLFSSL_API long wolfSSL_get_tlsext_status_ocsp_resp(WOLFSSL *s, unsigned char **resp);
 WOLFSSL_API long wolfSSL_set_tlsext_status_ocsp_resp(WOLFSSL *s, unsigned char *resp, int len);
 
-WOLFSSL_API void wolfSSL_CONF_modules_unload(int all); 
+WOLFSSL_API void wolfSSL_CONF_modules_unload(int all);
 WOLFSSL_API long wolfSSL_get_tlsext_status_exts(WOLFSSL *s, void *arg);
 WOLFSSL_API long wolfSSL_get_verify_result(const WOLFSSL *ssl);
 

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -397,6 +397,11 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
     /* default */
     /* uses complete <time.h> facility */
     #include <time.h>
+
+    /* PowerPC time_t is int */
+    #ifdef __PPC__
+        #define TIME_T_NOT_LONG
+    #endif
 #endif
 
 


### PR DESCRIPTION
* Fix for new `test_wolfSSL_ASN1_TIME_adj` API unit test to skip generalized time test when on PowerPC (which has time_t as int and will overflow).
* Fix for building with AES disabled and PKCS7 enabled.
* Fix for building without openssl_extra when time_t is not present.