### PR TITLE
Fixes for building with Emscripten (adds `--disable-asm` option).

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -222,6 +222,33 @@ fi
 AM_CONDITIONAL([BUILD_ALL], [test "x$ENABLED_ALL" = "xyes"])
 
 
+# Support for forcing 32-bit mode
+AC_ARG_ENABLE([32bit],
+    [AS_HELP_STRING([--enable-32bit],[Enables 32-bit support (default: disabled)])],
+    [ ENABLED_32BIT=$enableval ],
+    [ ENABLED_32BIT=no ]
+    )
+
+if test "$ENABLED_32BIT" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DNO_64BIT -DNO_CURVED25519_128BIT -m32"
+    AM_LDFLAGS="$AM_LDFLAGS -m32"
+fi
+
+
+# Support for disabling all ASM
+AC_ARG_ENABLE([asm],
+    [AS_HELP_STRING([--enable-asm],[Enables option for assembly (default: enabled)])],
+    [ ENABLED_ASM=$enableval ],
+    [ ENABLED_ASM=yes ]
+    )
+
+if test "$ENABLED_ASM" = "no"
+then
+    AM_CFLAGS="$AM_CFLAGS -DTFM_NO_ASM -DWOLFSSL_NO_ASM"
+fi
+
+
 # SINGLE THREADED
 AC_ARG_ENABLE([singlethreaded],
     [AS_HELP_STRING([--enable-singlethreaded],[Enable wolfSSL single threaded (default: disabled)])],
@@ -485,7 +512,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_EXT_CACHE"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALWAYS_VERIFY_CB -DOPENSSL_EXTRA"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_DIRECT -DWOLFSSL_DER_LOAD"
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA512 -DWOLFSSL_SHA384 -DWOLFSSL_KEY_GEN"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_KEY_GEN"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_WPAS"
 fi
 
@@ -504,7 +531,7 @@ fi
 
 if test "$ENABLED_FORTRESS" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DFORTRESS -DWOLFSSL_ALWAYS_VERIFY_CB -DOPENSSL_EXTRA -DWOLFSSL_AES_COUNTER -DWOLFSSL_AES_DIRECT -DWOLFSSL_DER_LOAD -DWOLFSSL_SHA512 -DWOLFSSL_SHA384 -DWOLFSSL_KEY_GEN"
+    AM_CFLAGS="$AM_CFLAGS -DFORTRESS -DWOLFSSL_ALWAYS_VERIFY_CB -DOPENSSL_EXTRA -DWOLFSSL_AES_COUNTER -DWOLFSSL_AES_DIRECT -DWOLFSSL_DER_LOAD -DWOLFSSL_KEY_GEN"
 fi
 
 
@@ -764,7 +791,7 @@ AC_ARG_ENABLE([armasm],
     [ ENABLED_ARMASM=$enableval ],
     [ ENABLED_ARMASM=no ]
     )
-if test "$ENABLED_ARMASM" = "yes"
+if test "$ENABLED_ARMASM" = "yes" && test "$ENABLED_ASM" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ARMASM"
     #Check if mcpu and mfpu values already set if not use default
@@ -813,31 +840,34 @@ AC_ARG_ENABLE([intelasm],
     [ ENABLED_INTELASM=no ]
     )
 
-if test "$ENABLED_AESNI" = "small"
+if test "$ENABLED_ASM" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DAES_GCM_AESNI_NO_UNROLL"
-    ENABLED_AESNI=yes
-fi
-
-if test "$ENABLED_AESNI" = "yes" || test "$ENABLED_INTELASM" = "yes"
-then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AESNI"
-    if test "$GCC" = "yes"
+    if test "$ENABLED_AESNI" = "small"
     then
-        # GCC needs these flags, icc doesn't
-        # opt levels greater than 2 may cause problems on systems w/o aesni
-        if test "$CC" != "icc"
-        then
-            AM_CFLAGS="$AM_CFLAGS -maes -msse4 -mpclmul"
-        fi
+        AM_CFLAGS="$AM_CFLAGS -DAES_GCM_AESNI_NO_UNROLL"
+        ENABLED_AESNI=yes
     fi
-    AS_IF([test "x$ENABLED_AESGCM" != "xno"],[AM_CCASFLAGS="$AM_CCASFLAGS -DHAVE_AESGCM"])
-fi
 
-if test "$ENABLED_INTELASM" = "yes"
-then
-    AM_CFLAGS="$AM_CFLAGS -DHAVE_INTEL_RDSEED -DUSE_INTEL_SPEEDUP"
-    ENABLED_AESNI=yes
+    if test "$ENABLED_AESNI" = "yes" || test "$ENABLED_INTELASM" = "yes"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AESNI"
+        if test "$GCC" = "yes"
+        then
+            # GCC needs these flags, icc doesn't
+            # opt levels greater than 2 may cause problems on systems w/o aesni
+            if test "$CC" != "icc"
+            then
+                AM_CFLAGS="$AM_CFLAGS -maes -msse4 -mpclmul"
+            fi
+        fi
+        AS_IF([test "x$ENABLED_AESGCM" != "xno"],[AM_CCASFLAGS="$AM_CCASFLAGS -DHAVE_AESGCM"])
+    fi
+
+    if test "$ENABLED_INTELASM" = "yes"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_INTEL_RDSEED -DUSE_INTEL_SPEEDUP"
+        ENABLED_AESNI=yes
+    fi
 fi
 
 # INTEL RDRAND
@@ -956,27 +986,22 @@ AC_ARG_ENABLE([sha512],
     [ ENABLED_SHA512=$SHA512_DEFAULT ]
     )
 
-# leanpsk and leantls don't need sha512
+# options that don't require sha512
 if test "$ENABLED_LEANPSK" = "yes" || test "$ENABLED_LEANTLS" = "yes"
 then
     ENABLED_SHA512=no
 fi
 
-if test "$ENABLED_OPENSSH" = "yes"
+# options that require sha512
+if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_WPAS" = "yes" || test "$ENABLED_FORTRESS" = "yes"
 then
     ENABLED_SHA512="yes"
 fi
 
-if test "$ENABLED_SHA512" = "yes"
+if test "$ENABLED_SHA512" = "yes" && test "$ENABLED_32BIT" = "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA512 -DWOLFSSL_SHA384"
 fi
-
-if test "$ENABLED_FORTRESS" = "yes"
-then
-    ENABLED_SHA512="yes"
-fi
-
 
 AM_CONDITIONAL([BUILD_SHA512], [test "x$ENABLED_SHA512" = "xyes"])
 
@@ -1264,7 +1289,7 @@ then
     ENABLED_ED25519=yes
 fi
 
-if test "$ENABLED_ED25519" = "yes"
+if test "$ENABLED_ED25519" = "yes" && test "$ENABLED_32BIT" = "no"
 then
     if test "$ENABLED_SHA512" = "no"
     then
@@ -1922,7 +1947,7 @@ then
     ENABLED_SHA3="yes"
 fi
 
-if test "$ENABLED_SHA3" = "yes"
+if test "$ENABLED_SHA3" = "yes" && test "$ENABLED_32BIT" = "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA3"
 fi
@@ -1951,7 +1976,7 @@ then
     ENABLED_POLY1305=no
 fi
 
-if test "$ENABLED_POLY1305" = "yes"
+if test "$ENABLED_POLY1305" = "yes" && test "$ENABLED_32BIT" = "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_POLY1305 -DHAVE_ONE_TIME_AUTH"
 fi
@@ -1969,22 +1994,20 @@ fi
 
 # CHACHA
 AC_ARG_ENABLE([chacha],
-    [AS_HELP_STRING([--enable-chacha],[Enable CHACHA (default: enabled). Use `=noasm` to disable Intel AVX/AVX2 speedups])],
+    [AS_HELP_STRING([--enable-chacha],[Enable CHACHA (default: enabled). Use `=noasm` to disable ASM AVX/AVX2 speedups])],
     [ ENABLED_CHACHA=$enableval ],
     [ ENABLED_CHACHA=$CHACHA_DEFAULT]
     )
-
-if test "$ENABLED_AESNI" = "noasm"
-then
-    AM_CFLAGS="$AM_CFLAGS -DNO_CHACHA_ASM"
-    ENABLED_AESNI=yes
-fi
-
 
 # leanpsk and leantls don't need chacha
 if test "$ENABLED_LEANPSK" = "yes" || test "$ENABLED_LEANTLS" = "yes"
 then
     ENABLED_CHACHA=no
+fi
+
+if test "$ENABLED_CHACHA" = "noasm" || test "$ENABLED_ASM" = "no"
+then
+    AM_CFLAGS="$AM_CFLAGS -DNO_CHACHA_ASM"
 fi
 
 if test "$ENABLED_CHACHA" = "yes"
@@ -3600,7 +3623,6 @@ then
 fi
 
 
-
 # check if PSK was enabled for conditionally running psk.test script
 AM_CONDITIONAL([BUILD_PSK], [test "x$ENABLED_PSK" = "xyes"])
 
@@ -4016,6 +4038,7 @@ echo "   * Old Names:                  $ENABLED_OLDNAMES"
 echo "   * Max Strength Build:         $ENABLED_MAXSTRENGTH"
 echo "   * Distro Build:               $ENABLED_DISTRO"
 echo "   * fastmath:                   $ENABLED_FASTMATH"
+echo "   * Assembly Allowed:           $ENABLED_ASM"
 echo "   * sniffer:                    $ENABLED_SNIFFER"
 echo "   * snifftest:                  $ENABLED_SNIFFTEST"
 echo "   * ARC4:                       $ENABLED_ARC4"

--- a/src/tls.c
+++ b/src/tls.c
@@ -6461,11 +6461,11 @@ static INLINE byte GetHmacLength(int hmac)
         case sha256_mac:
             return WC_SHA256_DIGEST_SIZE;
     #endif
-    #ifndef NO_SHA384
+    #ifdef WOLFSSL_SHA384
         case sha384_mac:
             return WC_SHA384_DIGEST_SIZE;
     #endif
-    #ifndef NO_SHA512
+    #ifdef WOLFSSL_SHA512
         case sha512_mac:
             return WC_SHA512_DIGEST_SIZE;
     #endif

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -1430,7 +1430,7 @@ static INLINE void BuildTls13Nonce(WOLFSSL* ssl, byte* nonce, const byte* iv,
         nonce[i] ^= iv[i];
 }
 
-#ifdef HAVE_CHACHA
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
 /* Encrypt with ChaCha20 and create authenication tag with Poly1305.
  *
  * ssl     The SSL/TLS object.
@@ -1630,7 +1630,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
     return ret;
 }
 
-#ifdef HAVE_CHACHA
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
 /* Decrypt with ChaCha20 and check authenication tag with Poly1305.
  *
  * ssl     The SSL/TLS object.

--- a/wolfcrypt/src/cpuid.c
+++ b/wolfcrypt/src/cpuid.c
@@ -28,8 +28,8 @@
 
 #include <wolfssl/wolfcrypt/cpuid.h>
 
-#if defined(WOLFSSL_X86_64_BUILD) || defined(USE_INTEL_SPEEDUP) || \
-    defined(WOLFSSL_AESNI)
+#if (defined(WOLFSSL_X86_64_BUILD) || defined(USE_INTEL_SPEEDUP) || \
+     defined(WOLFSSL_AESNI)) && !defined(WOLFSSL_NO_ASM)
     /* Each platform needs to query info type 1 from cpuid to see if aesni is
      * supported. Also, let's setup a macro for proper linkage w/o ABI conflicts
      */

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -140,8 +140,8 @@ STATIC INLINE word64 rotrFixed64(word64 x, word64 y)
 STATIC INLINE word64 ByteReverseWord64(word64 value)
 {
 #if defined(WOLFCRYPT_SLOW_WORD64)
-	return (word64)(ByteReverseWord32((word32)value)) << 32 |
-                    ByteReverseWord32((word32)(value>>32));
+	return (word64)((word64)ByteReverseWord32((word32) value)) << 32 |
+                    (word64)ByteReverseWord32((word32)(value   >> 32));
 #else
 	value = ((value & W64LIT(0xFF00FF00FF00FF00)) >> 8) |
             ((value & W64LIT(0x00FF00FF00FF00FF)) << 8);
@@ -192,7 +192,7 @@ STATIC INLINE void xorbuf(void* buf, const void* mask, word32 count)
 STATIC INLINE void ForceZero(const void* mem, word32 len)
 {
     volatile byte* z = (volatile byte*)mem;
-#ifdef WOLFSSL_X86_64_BUILD
+#if defined(WOLFSSL_X86_64_BUILD) && defined(WORD64_AVAILABLE)
     volatile word64* w;
 
     for (w = (volatile word64*)z; len >= sizeof(*w); len -= sizeof(*w))

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -327,7 +327,7 @@ do                                                                      \
     }                                                                   \
 }                                                                       \
 while (0)
-#endif
+#endif /* SHA3_BY_SPEC */
 
 /* The block operation performed on the state.
  *
@@ -376,7 +376,7 @@ static void BlockSha3(word64 *s)
 }
 #else
 #include "sha3_long.i"
-#endif
+#endif /* WOLFSSL_SHA3_SMALL */
 
 /* Convert the array of bytes, in little-endian order, to a 64-bit integer.
  *

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14073,7 +14073,7 @@ static int pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
         0x72,0x6c,0x64
     };
 
-#if !defined(NO_AES) && defined(HAVE_ECC)
+#if !defined(NO_AES) && defined(HAVE_ECC) && defined(WOLFSSL_SHA512)
     byte optionalUkm[] = {
         0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07
     };

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -646,7 +646,7 @@
         #endif
     #endif
 
-    #ifdef HAVE_CHACHA
+    #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
         #ifndef NO_SHA256
             #define BUILD_TLS_CHACHA20_POLY1305_SHA256
         #endif

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -64,6 +64,10 @@
    #define MAX(x,y) ((x)>(y)?(x):(y))
 #endif
 
+#ifdef WOLFSSL_NO_ASM
+   #undef  TFM_NO_ASM
+   #define TFM_NO_ASM
+#endif
 
 #ifndef NO_64BIT
 /* autodetect x86-64 and make sure we are using 64-bit digits with x86-64 asm */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -54,27 +54,27 @@
 	#if !defined(_MSC_VER) && !defined(__BCPLUSPLUS__) && !defined(__EMSCRIPTEN__)
 	    #if !defined(SIZEOF_LONG_LONG) && !defined(SIZEOF_LONG)
 	        #if (defined(__alpha__) || defined(__ia64__) || \
-                   defined(_ARCH_PPC64) || defined(__mips64) || \
-                   defined(__x86_64__) || \
-                   ((defined(sun) || defined(__sun)) && \
-                     (defined(LP64) || defined(_LP64))))
+	            defined(_ARCH_PPC64) || defined(__mips64) || \
+	            defined(__x86_64__) || \
+	            ((defined(sun) || defined(__sun)) && \
+	             (defined(LP64) || defined(_LP64))))
 	            /* long should be 64bit */
 	            #define SIZEOF_LONG 8
-            #elif (defined(__i386__) || defined(__CORTEX_M3__)
-                /* long long should be 64bit */
-                #define SIZEOF_LONG_LONG 8
+	        #elif defined(__i386__) || defined(__CORTEX_M3__)
+	            /* long long should be 64bit */
+	            #define SIZEOF_LONG_LONG 8
 	        #endif
-	    #endif
+ 	    #endif
 	#endif
 
 	#if defined(_MSC_VER) || defined(__BCPLUSPLUS__)
 	    #define WORD64_AVAILABLE
 	    #define W64LIT(x) x##ui64
 	    typedef unsigned __int64 word64;
-    #elif defined(__EMSCRIPTEN__)
-        #define WORD64_AVAILABLE
-        #define W64LIT(x) x##ull
-        typedef unsigned long long word64;
+	#elif defined(__EMSCRIPTEN__)
+	    #define WORD64_AVAILABLE
+	    #define W64LIT(x) x##ull
+	    typedef unsigned long long word64;
 	#elif defined(SIZEOF_LONG) && SIZEOF_LONG == 8
 	    #define WORD64_AVAILABLE
 	    #define W64LIT(x) x##LL


### PR DESCRIPTION
* Added ability to disable all inline asembly using `--disable-asm`.
* Added ability to force 32-bit mode using `--enable-32bit`.
* Added check for `__EMSCRIPTEN__` define in types.h to properly setup 64-bit type.
* Fixes for build combinations without SHA512 and with CHACHA20 (no poly1305).