### PR TITLE
Fix accidental removal of wc_Sha hashHandle for STM32 w/CubeMX

### DIFF
--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -91,6 +91,9 @@ typedef struct wc_Sha {
     #ifdef WOLFSSL_PIC32MZ_HASH
         hashUpdCache cache; /* cache for updates */
     #endif
+    #if defined(STM32_HASH) && defined(WOLFSSL_STM32_CUBEMX)
+        HASH_HandleTypeDef hashHandle;
+    #endif
     #ifdef WOLFSSL_ASYNC_CRYPT
         WC_ASYNC_DEV asyncDev;
     #endif /* WOLFSSL_ASYNC_CRYPT */


### PR DESCRIPTION
This was removed during merge of 6707be2 on 10/11/17. Thanks `liubing` for the report (#1213).