### PR TITLE
New `--enable-lowresource` option and SHA256 not unrolled support

### DIFF
--- a/IDE/GCC-ARM/README.md
+++ b/IDE/GCC-ARM/README.md
@@ -60,6 +60,7 @@ These settings are located in `Header/user_settings.h`.
 AES GCM: `GCM_SMALL`, `GCM_WORD32` or `GCM_TABLE`: Tunes performance and flash/memory usage.
 * `CURVED25519_SMALL`: Enables small versions of Ed/Curve (FE/GE math).
 * `USE_SLOW_SHA`: Enables smaller/slower version of SHA.
-* `USE_SLOW_SHA2`: Over twice as small, but 50% slower
+* `USE_SLOW_SHA256`: About 2k smaller and about 25% slower
+* `USE_SLOW_SHA512`: Over twice as small, but 50% slower
 * `USE_CERT_BUFFERS_1024` or `USE_CERT_BUFFERS_2048`: Size of RSA certs / keys to test with. 
 * `BENCH_EMBEDDED`: Define this if using the wolfCrypt test/benchmark and using a low memory target.

--- a/configure.ac
+++ b/configure.ac
@@ -558,9 +558,10 @@ AC_ARG_ENABLE([leanpsk],
 
 if test "$ENABLED_LEANPSK" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LEANPSK -DWOLFSSL_STATIC_PSK -DHAVE_NULL_CIPHER -DSINGLE_THREADED -DNO_AES -DNO_FILESYSTEM -DNO_RABBIT -DNO_RSA -DNO_DSA -DNO_DH -DNO_CERTS -DNO_PWDBASED -DNO_MD4 -DNO_MD5 -DNO_ERROR_STRINGS -DNO_OLD_TLS -DNO_RC4 -DNO_WRITEV -DNO_SESSION_CACHE -DNO_DEV_RANDOM -DWOLFSSL_USER_IO -DNO_SHA -DUSE_SLOW_SHA"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LEANPSK -DWOLFSSL_STATIC_PSK -DHAVE_NULL_CIPHER -DSINGLE_THREADED -DNO_AES -DNO_FILESYSTEM -DNO_RABBIT -DNO_RSA -DNO_DSA -DNO_DH -DNO_CERTS -DNO_PWDBASED -DNO_MD4 -DNO_MD5 -DNO_ERROR_STRINGS -DNO_OLD_TLS -DNO_RC4 -DNO_WRITEV -DNO_DEV_RANDOM -DWOLFSSL_USER_IO -DNO_SHA"
     ENABLED_SLOWMATH="no"
     ENABLED_SINGLETHREADED="yes"
+    enable_lowresource=yes
 fi
 
 AM_CONDITIONAL([BUILD_LEANPSK], [test "x$ENABLED_LEANPSK" = "xyes"])
@@ -575,10 +576,30 @@ AC_ARG_ENABLE([leantls],
 
 if test "$ENABLED_LEANTLS" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LEANTLS -DNO_WRITEV -DHAVE_ECC -DTFM_ECC256 -DECC_USER_CURVES -DNO_WOLFSSL_SERVER -DNO_RABBIT -DNO_RSA -DNO_DSA -DNO_DH -DNO_PWDBASED -DNO_MD5 -DNO_ERROR_STRINGS -DNO_OLD_TLS -DNO_RC4 -DNO_SESSION_CACHE -DNO_SHA -DUSE_SLOW_SHA -DUSE_SLOW_SHA2 -DNO_PSK -DNO_WOLFSSL_MEMORY"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LEANTLS -DNO_WRITEV -DHAVE_ECC -DTFM_ECC256 -DECC_USER_CURVES -DNO_WOLFSSL_SERVER -DNO_RABBIT -DNO_RSA -DNO_DSA -DNO_DH -DNO_PWDBASED -DNO_MD5 -DNO_ERROR_STRINGS -DNO_OLD_TLS -DNO_RC4 -DNO_SHA -DNO_PSK -DNO_WOLFSSL_MEMORY"
+    enable_lowresource=yes
 fi
 
 AM_CONDITIONAL([BUILD_LEANTLS], [test "x$ENABLED_LEANTLS" = "xyes"])
+
+
+# low resource options to reduce flash and memory use
+AC_ARG_ENABLE([lowresource],
+    [AS_HELP_STRING([--enable-lowresource],[Enable low resource options for memory/flash (default: disabled)])],
+    [ ENABLED_LOWRESOURCE=$enableval ],
+    [ ENABLED_LOWRESOURCE=no ]
+    )
+
+if test "$ENABLED_LOWRESOURCE" = "yes"
+then
+    # low memory / flash flags
+    AM_CFLAGS="$AM_CFLAGS -DNO_SESSION_CACHE -DRSA_LOW_MEM -DGCM_SMALL -DCURVE25519_SMALL -DED25519_SMALL"
+
+    # low flash flags
+    AM_CFLAGS="$AM_CFLAGS -DUSE_SLOW_SHA -DUSE_SLOW_SHA256 -DUSE_SLOW_SHA512"
+fi
+
+AM_CONDITIONAL([BUILD_LOWMEM], [test "x$ENABLED_LOWRESOURCE" = "xyes"])
 
 
 # big cache
@@ -713,6 +734,7 @@ AS_IF([ test "x$ENABLED_SNIFFER" = "xyes" ],
 AM_CONDITIONAL([BUILD_SNIFFER],   [ test "x$ENABLED_SNIFFER"   = "xyes" ])
 AM_CONDITIONAL([BUILD_SNIFFTEST], [ test "x$ENABLED_SNIFFTEST" = "xyes" ])
 
+
 # AES-GCM
 AC_ARG_ENABLE([aesgcm],
     [AS_HELP_STRING([--enable-aesgcm],[Enable wolfSSL AES-GCM support (default: enabled)])],
@@ -727,26 +749,26 @@ then
     ENABLED_AESGCM=no
 fi
 
-if test "$ENABLED_AESGCM" = "word32"
+if test "$ENABLED_AESGCM" != "no"
 then
-    AM_CFLAGS="$AM_CFLAGS -DGCM_WORD32"
-    ENABLED_AESGCM=yes
-fi
+    if test "$ENABLED_AESGCM" = "word32"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DGCM_WORD32"
+        ENABLED_AESGCM=yes
+    fi
 
-if test "$ENABLED_AESGCM" = "small"
-then
-    AM_CFLAGS="$AM_CFLAGS -DGCM_SMALL"
-    ENABLED_AESGCM=yes
-fi
+    if test "$ENABLED_AESGCM" = "small" || test "$ENABLED_LOWRESOURCE" = "yes"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DGCM_SMALL"
+        ENABLED_AESGCM=yes
+    fi
 
-if test "$ENABLED_AESGCM" = "table"
-then
-    AM_CFLAGS="$AM_CFLAGS -DGCM_TABLE"
-    ENABLED_AESGCM=yes
-fi
+    if test "$ENABLED_AESGCM" = "table"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DGCM_TABLE"
+        ENABLED_AESGCM=yes
+    fi
 
-if test "$ENABLED_AESGCM" = "yes"
-then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_AESGCM"
 fi
 
@@ -1246,21 +1268,21 @@ then
     ENABLED_CURVE25519="yes"
 fi
 
-if test "$ENABLED_CURVE25519" = "small"
+if test "$ENABLED_CURVE25519" != "no"
 then
-    AM_CFLAGS="$AM_CFLAGS -DCURVE25519_SMALL"
-    ENABLED_CURVE25519_SMALL=yes
-    ENABLED_CURVE25519=yes
-fi
+    if test "$ENABLED_CURVE25519" = "small" || test "$ENABLED_LOWRESOURCE" = "yes"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DCURVE25519_SMALL"
+        ENABLED_CURVE25519_SMALL=yes
+        ENABLED_CURVE25519=yes
+    fi
 
-if test "$ENABLED_CURVE25519" = "no128bit"
-then
-    AM_CFLAGS="$AM_CFLAGS -DNO_CURVED25519_128BIT"
-    ENABLED_CURVE25519=yes
-fi
+    if test "$ENABLED_CURVE25519" = "no128bit"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DNO_CURVED25519_128BIT"
+        ENABLED_CURVE25519=yes
+    fi
 
-if test "$ENABLED_CURVE25519" = "yes"
-then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_CURVE25519"
     ENABLED_FEMATH=yes
 fi
@@ -1282,15 +1304,15 @@ then
     ENABLED_ED25519="yes"
 fi
 
-if test "$ENABLED_ED25519" = "small"
+if test "$ENABLED_ED25519" != "no" && test "$ENABLED_32BIT" = "no"
 then
-    AM_CFLAGS="$AM_CFLAGS -DED25519_SMALL"
-    ENABLED_ED25519_SMALL=yes
-    ENABLED_ED25519=yes
-fi
+    if test "$ENABLED_ED25519" = "small" || test "$ENABLED_LOWRESOURCE" = "yes"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DED25519_SMALL"
+        ENABLED_ED25519_SMALL=yes
+        ENABLED_ED25519=yes
+    fi
 
-if test "$ENABLED_ED25519" = "yes" && test "$ENABLED_32BIT" = "no"
-then
     if test "$ENABLED_SHA512" = "no"
     then
         AC_MSG_ERROR([cannot enable ed25519 without enabling sha512.])

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -684,7 +684,9 @@ static void Usage(void)
 #endif
     printf("-m          Match domain name in cert\n");
     printf("-N          Use Non-blocking sockets\n");
+#ifndef NO_SESSION_CACHE
     printf("-r          Resume session\n");
+#endif
     printf("-w          Wait for bidirectional shutdown\n");
     printf("-M <prot>   Use STARTTLS, using <prot> protocol (smtp)\n");
 #ifdef HAVE_SECURE_RENEGOTIATION

--- a/scripts/resume.test
+++ b/scripts/resume.test
@@ -1,10 +1,11 @@
 #!/bin/sh
 
-#reusme.test
+#resume.test
 
 # need a unique resume port since may run the same time as testsuite
 # use server port zero hack to get one
 resume_string="reused"
+resume_sup_string="Resume session"
 ems_string="Extended\ Master\ Secret"
 resume_port=0
 no_pid=-1
@@ -44,6 +45,18 @@ do_trap() {
 
 do_test() {
     echo -e "\nStarting example server for resume test...\n"
+
+    #make sure we support session resumption (!NO_SESSION_CACHE)
+    # Check the client for the extended master secret disable option. If
+    # present we need to run the test twice.
+    options_check=`./examples/client/client -?`
+    case "$options_check" in
+    *$resume_sup_string*)
+        echo -e "\nResume test supported";;
+    *)
+        echo -e "\nResume test not supported with build"
+        return;;
+    esac
 
     remove_ready_file
     ./examples/server/server -r -R $ready_file -p $resume_port &

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -418,7 +418,7 @@ static INLINE void AddLength(wc_Sha* sha, word32 len)
             t = e; e = d; d = c; c = b; b = a; a = t;
         }
     #else
-        /* nearly 1 K bigger in code size but 25% faster  */
+        /* nearly 1 K bigger in code size but 25% faster */
         /* 4 rounds of 20 operations each. Loop unrolled. */
         R0(a,b,c,d,e, 0); R0(e,a,b,c,d, 1); R0(d,e,a,b,c, 2); R0(c,d,e,a,b, 3);
         R0(b,c,d,e,a, 4); R0(a,b,c,d,e, 5); R0(e,a,b,c,d, 6); R0(d,e,a,b,c, 7);


### PR DESCRIPTION
* Add `USE_SLOW_SHA256` and `USE_SLOW_SHA512` options for reduced code size of SHA. Existing `USE_SLOW_SHA2` applies for SHA512 only.
* Cleanup formatting of the sha256.c and sha512.c code.
* Added new `./configure --lowresource` option, which defines the memory reduction defines.
* Fix for `make check` resume.test scipt with `NO_SESSION_CACHE` defined.