### PR TITLE
fix unused variable warning

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -7869,6 +7869,9 @@ int wc_AesXtsEncrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
     if (blocks > 0) {
         byte tmp[AES_BLOCK_SIZE];
 
+        XMEMSET(tmp, 0, AES_BLOCK_SIZE); /* set to 0's in case of improper AES
+                                          * key setup passed to encrypt direct*/
+
         wc_AesEncryptDirect(tweak, tmp, i);
 
         while (blocks > 0) {
@@ -7959,6 +7962,9 @@ int wc_AesXtsDecrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
         byte carry = 0;
         byte tmp[AES_BLOCK_SIZE];
         byte stl = (sz % AES_BLOCK_SIZE);
+
+        XMEMSET(tmp, 0, AES_BLOCK_SIZE); /* set to 0's in case of improper AES
+                                          * key setup passed to decrypt direct*/
 
         wc_AesEncryptDirect(tweak, tmp, i);
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6916,8 +6916,11 @@ static const CertName certDefaultName = {
 };
 
 #ifdef WOLFSSL_CERT_EXT
+    #if (defined(HAVE_ED25519) && defined(WOLFSSL_TEST_CERT)) || \
+        defined(HAVE_ECC)
     static const char certKeyUsage[] =
         "digitalSignature,nonRepudiation";
+    #endif
     #if defined(WOLFSSL_CERT_REQ) || defined(HAVE_NTRU)
         static const char certKeyUsage2[] =
         "digitalSignature,nonRepudiation,keyEncipherment,keyAgreement";


### PR DESCRIPTION
Warning can be duplicated with "./configure --enable-certext --enable-certgen --disable-ecc CC=clang".