### PR TITLE
fix for logging file names

### DIFF
--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -207,7 +207,7 @@ void WOLFSSL_BUFFER(const byte* buffer, word32 length)
 void WOLFSSL_ENTER(const char* msg)
 {
     if (loggingEnabled) {
-        char buffer[80];
+        char buffer[WOLFSSL_MAX_ERROR_SZ];
         XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Entering %s", msg);
         wolfssl_log(ENTER_LOG , buffer);
     }
@@ -217,7 +217,7 @@ void WOLFSSL_ENTER(const char* msg)
 void WOLFSSL_LEAVE(const char* msg, int ret)
 {
     if (loggingEnabled) {
-        char buffer[80];
+        char buffer[WOLFSSL_MAX_ERROR_SZ];
         XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Leaving %s, return %d",
                 msg, ret);
         wolfssl_log(LEAVE_LOG , buffer);
@@ -242,7 +242,7 @@ void WOLFSSL_ERROR(int error)
     if (loggingEnabled && error != WC_PENDING_E)
     #endif
     {
-        char buffer[80];
+        char buffer[WOLFSSL_MAX_ERROR_SZ];
         #if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
             (void)usrCtx; /* a user ctx for future flexibility */
             (void)func;

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -208,7 +208,7 @@ void WOLFSSL_ENTER(const char* msg)
 {
     if (loggingEnabled) {
         char buffer[80];
-        sprintf(buffer, "wolfSSL Entering %s", msg);
+        XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Entering %s", msg);
         wolfssl_log(ENTER_LOG , buffer);
     }
 }
@@ -218,7 +218,8 @@ void WOLFSSL_LEAVE(const char* msg, int ret)
 {
     if (loggingEnabled) {
         char buffer[80];
-        sprintf(buffer, "wolfSSL Leaving %s, return %d", msg, ret);
+        XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Leaving %s, return %d",
+                msg, ret);
         wolfssl_log(LEAVE_LOG , buffer);
     }
 }
@@ -248,11 +249,13 @@ void WOLFSSL_ERROR(int error)
 
             if (wc_LockMutex(&debug_mutex) != 0) {
                 WOLFSSL_MSG("Lock debug mutex failed");
-                sprintf(buffer, "wolfSSL error occurred, error = %d", error);
+                XSNPRINTF(buffer, sizeof(buffer),
+                        "wolfSSL error occurred, error = %d", error);
             }
             else {
                 if (error < 0) error = error - (2*error); /*get absolute value*/
-                sprintf(buffer, "wolfSSL error occurred, error = %d line:%d file:%s",
+                XSNPRINTF(buffer, sizeof(buffer),
+                        "wolfSSL error occurred, error = %d line:%d file:%s",
                     error, line, file);
                 if (wc_AddErrorNode(error, line, buffer, (char*)file) != 0) {
                     WOLFSSL_MSG("Error creating logging node");
@@ -263,7 +266,8 @@ void WOLFSSL_ERROR(int error)
                 wc_UnLockMutex(&debug_mutex);
             }
         #else
-            sprintf(buffer, "wolfSSL error occurred, error = %d", error);
+            XSNPRINTF(buffer, sizeof(buffer),
+                    "wolfSSL error occurred, error = %d", error);
         #endif
         #ifdef DEBUG_WOLFSSL
         wolfssl_log(ERROR_LOG , buffer);

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -324,7 +324,8 @@
 	        #define XSTRNCASECMP(s1,s2,n) strncasecmp((s1),(s2),(n))
 	    #endif
 
-        /* snprintf is used in asn.c for GetTimeString and PKCS7 test */
+        /* snprintf is used in asn.c for GetTimeString, PKCS7 test, and when
+           debugging is turned on */
         #ifndef USE_WINDOWS_API
             #define XSNPRINTF snprintf
         #else

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -453,9 +453,7 @@
 
 	/* max error buffer string size */
     #ifndef WOLFSSL_MAX_ERROR_SZ
-	enum {
-	    WOLFSSL_MAX_ERROR_SZ = 80
-	};
+	    #define WOLFSSL_MAX_ERROR_SZ 80
     #endif
 
 	/* stack protection */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -452,9 +452,11 @@
 	};
 
 	/* max error buffer string size */
+    #ifndef WOLFSSL_MAX_ERROR_SZ
 	enum {
 	    WOLFSSL_MAX_ERROR_SZ = 80
 	};
+    #endif
 
 	/* stack protection */
 	enum {


### PR DESCRIPTION
Uses XSNPRINTF to limit the message size copied into an error buffer. When using --enable-opensslextra, this cuts of the file name when the path is too long.