### PR TITLE
Improvements to wolfSSL get/set version

### DIFF
--- a/cyassl/ssl.h
+++ b/cyassl/ssl.h
@@ -445,7 +445,6 @@
 #define CyaSSL_CTX_use_PrivateKey_file      wolfSSL_CTX_use_PrivateKey_file
 #define CyaSSL_CTX_use_certificate_file     wolfSSL_CTX_use_certificate_file
 #define CyaSSL_CTX_use_PrivateKey_buffer    wolfSSL_CTX_use_PrivateKey_buffer
-#define CyaSSL_CTX_use_PrivateKey_buffer    wolfSSL_CTX_use_PrivateKey_buffer
 #define CyaSSL_CTX_use_certificate_buffer   wolfSSL_CTX_use_certificate_buffer
 #define CyaSSL_CTX_use_NTRUPrivateKey_file  wolfSSL_CTX_use_NTRUPrivateKey_file
 #define CyaSSL_use_certificate_chain_buffer wolfSSL_use_certificate_chain_buffer

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3615,6 +3615,32 @@ int wolfSSL_SetMinVersion(WOLFSSL* ssl, int version)
 }
 
 
+/* Function to get version as WOLFSSL_ enum value for wolfSSL_SetVersion */
+int wolfSSL_GetVersion(WOLFSSL* ssl)
+{
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
+
+    if (ssl->version.major == SSLv3_MAJOR) {
+        switch (ssl->version.minor) {
+            case SSLv3_MINOR :
+                return WOLFSSL_SSLV3;
+            case TLSv1_MINOR :
+                return WOLFSSL_TLSV1;
+            case TLSv1_1_MINOR :
+                return WOLFSSL_TLSV1_1;
+            case TLSv1_2_MINOR :
+                return WOLFSSL_TLSV1_2;
+            case TLSv1_3_MINOR :
+                return WOLFSSL_TLSV1_3;
+            default:
+                break;
+        }
+    }
+
+    return VERSION_ERROR;
+}
+
 int wolfSSL_SetVersion(WOLFSSL* ssl, int version)
 {
     word16 haveRSA = 1;
@@ -3648,6 +3674,12 @@ int wolfSSL_SetVersion(WOLFSSL* ssl, int version)
         case WOLFSSL_TLSV1_2:
             ssl->version = MakeTLSv1_2();
             break;
+#endif
+#ifdef WOLFSSL_TLS13
+        case WOLFSSL_TLSV1_3:
+            ssl->version = MakeTLSv1_3();
+            break;
+
 #endif
 
         default:

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1535,6 +1535,7 @@ enum {
     WOLFSSL_TLSV1    = 1,
     WOLFSSL_TLSV1_1  = 2,
     WOLFSSL_TLSV1_2  = 3,
+    WOLFSSL_TLSV1_3  = 4,
     WOLFSSL_USER_CA  = 1,          /* user added as trusted */
     WOLFSSL_CHAIN_CA = 2           /* added to cache from trusted chain */
 };
@@ -1548,6 +1549,7 @@ WOLFSSL_API int wolfSSL_CTX_GetObjectSize(void);
 WOLFSSL_API int wolfSSL_METHOD_GetObjectSize(void);
 WOLFSSL_API int wolfSSL_GetOutputSize(WOLFSSL*, int);
 WOLFSSL_API int wolfSSL_GetMaxOutputSize(WOLFSSL*);
+WOLFSSL_API int wolfSSL_GetVersion(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_SetVersion(WOLFSSL* ssl, int version);
 WOLFSSL_API int wolfSSL_KeyPemToDer(const unsigned char*, int,
                                     unsigned char*, int, const char*);


### PR DESCRIPTION
* Added new API `wolfSSL_GetVersion` to get version as wolfSSL value which can be passed into `wolfSSL_SetVersion`.
* Fixed duplicate `CyaSSL_CTX_use_PrivateKey_buffer` define.
* Added TLS1.3 to `wolfSSL_SetVersion`.