### PR TITLE
Fix buffer overflow in SigAlgs Ext Parsing

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -4906,6 +4906,9 @@ static int TLSX_SignatureAlgorithms_Parse(WOLFSSL *ssl, byte* input,
     if (length != OPAQUE16_LEN + len)
         return BUFFER_ERROR;
 
+    if (len > HELLO_EXT_SIGALGO_MAX)
+        len = HELLO_EXT_SIGALGO_MAX;
+
     XMEMCPY(suites->hashSigAlgo, input, len);
     suites->hashSigAlgoSz = len;
 


### PR DESCRIPTION
Only use the first HELLO_EXT_SIGALGO_MAX (32) bytes of the hash
signature algorithm list. This allows for 16 entries.
Currently TLS v1.3 specifies 13 values with two being legacy algorithms.
A range for private use has been defined.