### PR TITLE
Fixes and cleanup for handling of sig/algo

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -22772,11 +22772,11 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             return BUFFER_ERROR;
 
                         XMEMCPY(clSuites.hashSigAlgo, &input[i],
-                            min(clSuites.hashSigAlgoSz, HELLO_EXT_SIGALGO_MAX));
+                            min(clSuites.hashSigAlgoSz, WOLFSSL_MAX_SIGALGO));
                         i += clSuites.hashSigAlgoSz;
 
-                        if (clSuites.hashSigAlgoSz > HELLO_EXT_SIGALGO_MAX)
-                            clSuites.hashSigAlgoSz = HELLO_EXT_SIGALGO_MAX;
+                        if (clSuites.hashSigAlgoSz > WOLFSSL_MAX_SIGALGO)
+                            clSuites.hashSigAlgoSz = WOLFSSL_MAX_SIGALGO;
                     }
 #ifdef HAVE_EXTENDED_MASTER
                     else if (extId == HELLO_EXT_EXTMS)

--- a/src/internal.c
+++ b/src/internal.c
@@ -22774,8 +22774,11 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             return BUFFER_ERROR;
 
                         clSuites.hashSigAlgoSz = hashSigAlgoSz;
-                        if (clSuites.hashSigAlgoSz > WOLFSSL_MAX_SIGALGO)
+                        if (clSuites.hashSigAlgoSz > WOLFSSL_MAX_SIGALGO) {
+                            WOLFSSL_MSG("ClientHello SigAlgo list exceeds max, "
+                                                                  "truncating");
                             clSuites.hashSigAlgoSz = WOLFSSL_MAX_SIGALGO;
+                        }
 
                         XMEMCPY(clSuites.hashSigAlgo, &input[i],
                                                       clSuites.hashSigAlgoSz);

--- a/src/tls.c
+++ b/src/tls.c
@@ -3771,7 +3771,7 @@ static int TLSX_SessionTicket_Parse(WOLFSSL* ssl, byte* input, word16 length,
     if (!isRequest) {
         if (TLSX_CheckUnsupportedExtension(ssl, TLSX_SESSION_TICKET))
             return TLSX_HandleUnsupportedExtension(ssl);
-        
+
         if (length != 0)
             return BUFFER_ERROR;
 
@@ -4908,8 +4908,10 @@ static int TLSX_SignatureAlgorithms_Parse(WOLFSSL *ssl, byte* input,
 
     /* truncate hashSigAlgo list if too long */
     suites->hashSigAlgoSz = len;
-    if (suites->hashSigAlgoSz > WOLFSSL_MAX_SIGALGO)
+    if (suites->hashSigAlgoSz > WOLFSSL_MAX_SIGALGO) {
+        WOLFSSL_MSG("TLSX SigAlgo list exceeds max, truncating");
         suites->hashSigAlgoSz = WOLFSSL_MAX_SIGALGO;
+    }
     XMEMCPY(suites->hashSigAlgo, input, suites->hashSigAlgoSz);
 
     return TLSX_SignatureAlgorithms_MapPss(ssl, input, len);

--- a/src/tls.c
+++ b/src/tls.c
@@ -4906,8 +4906,11 @@ static int TLSX_SignatureAlgorithms_Parse(WOLFSSL *ssl, byte* input,
     if (length != OPAQUE16_LEN + len)
         return BUFFER_ERROR;
 
-    XMEMCPY(suites->hashSigAlgo, input, len);
+    /* truncate hashSigAlgo list if too long */
     suites->hashSigAlgoSz = len;
+    if (suites->hashSigAlgoSz > WOLFSSL_MAX_SIGALGO)
+        suites->hashSigAlgoSz = WOLFSSL_MAX_SIGALGO;
+    XMEMCPY(suites->hashSigAlgo, input, suites->hashSigAlgoSz);
 
     return TLSX_SignatureAlgorithms_MapPss(ssl, input, len);
 }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1034,7 +1034,6 @@ enum Misc {
     HELLO_EXT_TYPE_SZ     = 2,  /* length of a hello extension type */
     HELLO_EXT_SZ_SZ       = 2,  /* length of a hello extension size */
     HELLO_EXT_SIGALGO_SZ  = 2,  /* length of number of items in sigalgo list */
-    HELLO_EXT_SIGALGO_MAX = 32, /* number of items in the signature algo list */
 
     DTLS_HANDSHAKE_HEADER_SZ = 12, /* normal + seq(2) + offset(3) + length(3) */
     DTLS_RECORD_HEADER_SZ    = 13, /* normal + epoch(2) + seq_num(6) */
@@ -1191,6 +1190,12 @@ enum Misc {
     #define WOLFSSL_MAX_SUITE_SZ 300
     /* 150 suites for now! */
 #endif
+
+/* number of items in the signature algo list */
+#ifndef WOLFSSL_MAX_SIGALGO
+    #define WOLFSSL_MAX_SIGALGO 32
+#endif
+
 
 /* set minimum ECC key size allowed */
 #ifndef WOLFSSL_MIN_ECC_BITS
@@ -1527,7 +1532,7 @@ typedef struct Suites {
     word16 suiteSz;                 /* suite length in bytes        */
     word16 hashSigAlgoSz;           /* SigAlgo extension length in bytes */
     byte   suites[WOLFSSL_MAX_SUITE_SZ];
-    byte   hashSigAlgo[HELLO_EXT_SIGALGO_MAX]; /* sig/algo to offer */
+    byte   hashSigAlgo[WOLFSSL_MAX_SIGALGO]; /* sig/algo to offer */
     byte   setSuites;               /* user set suites from default */
     byte   hashAlgo;                /* selected hash algorithm */
     byte   sigAlgo;                 /* selected sig algorithm */


### PR DESCRIPTION
* Fix to make sure provided sigalgo list doesn't overflow the buffer.
* Added new overridable define `WOLFSSL_MAX_SIGALGO` to allow support for more than then default 16 sig/algo pairs (32-bytes).