### PR TITLE
Disable TLS v1.0 by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1413,6 +1413,19 @@ else
 fi
 
 
+# TLSv1.0
+AC_ARG_ENABLE([tlsv10],
+    [AS_HELP_STRING([--enable-tlsv10],[Enable old TLS versions 1.0 (default: disabled)])],
+    [ ENABLED_TLSV10=$enableval ],
+    [ ENABLED_TLSV10=no ]
+    )
+
+if test "$ENABLED_TLSV10" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALLOW_TLSV10"
+fi
+
+
 # SSLv3
 AC_ARG_ENABLE([sslv3],
     [AS_HELP_STRING([--enable-sslv3],[Enable SSL version 3.0 (default: disabled)])],
@@ -4123,6 +4136,7 @@ echo "   * SCTP:                       $ENABLED_SCTP"
 echo "   * Multicast:                  $ENABLED_MCAST"
 echo "   * Old TLS Versions:           $ENABLED_OLD_TLS"
 echo "   * SSL version 3.0:            $ENABLED_SSLV3"
+echo "   * TLS v1.0:                   $ENABLED_TLSV10"
 echo "   * TLS v1.3:                   $ENABLED_TLS13"
 echo "   * TLS v1.3 Draft 18:          $ENABLED_TLS13_DRAFT18"
 echo "   * Post-handshake Auth:        $ENABLED_TLS13_POST_AUTH"

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -170,12 +170,19 @@ static void ShowCiphers(void)
 static void ShowVersions(void)
 {
 #ifndef NO_OLD_TLS
-#ifdef WOLFSSL_ALLOW_SSLV3
-    printf("0:");
-#endif /* WOLFSSL_ALLOW_SSLV3 */
-    printf("1:2:");
+    #ifdef WOLFSSL_ALLOW_SSLV3
+        printf("0:");
+    #endif
+    #ifdef WOLFSSL_ALLOW_TLSV10
+        printf("1:");
+    #endif
+    printf("2:");
 #endif /* NO_OLD_TLS */
-    printf("3\n");
+    printf("3:");
+#ifdef WOLFSSL_TLS13
+    printf("4:");
+#endif
+    printf("\n");
 }
 
 /* Measures average time to create, connect and disconnect a connection (TPS).
@@ -1394,27 +1401,29 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     #endif
 
     #ifndef NO_TLS
+        #ifdef WOLFSSL_ALLOW_TLSV10
         case 1:
             method = wolfTLSv1_client_method_ex;
             break;
+        #endif
 
         case 2:
             method = wolfTLSv1_1_client_method_ex;
             break;
-    #endif /* NO_TLS */
-
-#endif  /* NO_OLD_TLS */
+    #endif /* !NO_TLS */
+#endif /* !NO_OLD_TLS */
 
 #ifndef NO_TLS
         case 3:
             method = wolfTLSv1_2_client_method_ex;
             break;
+
     #ifdef WOLFSSL_TLS13
         case 4:
             method = wolfTLSv1_3_client_method_ex;
             break;
     #endif
-#endif
+#endif /* NO_TLS */
 
 #ifdef WOLFSSL_DTLS
         #ifndef NO_OLD_TLS

--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -124,7 +124,7 @@ void echoclient_test(void* args)
 
 #if defined(CYASSL_DTLS)
     method  = DTLSv1_2_client_method();
-#elif  !defined(NO_TLS)
+#elif !defined(NO_TLS)
     method = CyaSSLv23_client_method();
 #elif defined(WOLFSSL_ALLOW_SSLV3)
     method = SSLv3_client_method();

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -143,7 +143,7 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
 
 #if defined(CYASSL_DTLS)
     method  = CyaDTLSv1_2_server_method();
-#elif  !defined(NO_TLS)
+#elif !defined(NO_TLS)
     method = CyaSSLv23_server_method();
 #elif defined(WOLFSSL_ALLOW_SSLV3)
     method = CyaSSLv3_server_method();

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -877,29 +877,29 @@ THREAD_RETURN CYASSL_THREAD server_test(void* args)
     #endif
 
     #ifndef NO_TLS
+        #ifdef WOLFSSL_ALLOW_TLSV10
         case 1:
             method = wolfTLSv1_server_method_ex;
             break;
-
+        #endif
 
         case 2:
             method = wolfTLSv1_1_server_method_ex;
             break;
-
-        #endif
-#endif
+    #endif /* !NO_TLS */
+#endif /* !NO_OLD_TLS */
 
 #ifndef NO_TLS
         case 3:
             method = wolfTLSv1_2_server_method_ex;
             break;
-#endif
 
-#ifdef WOLFSSL_TLS13
+    #ifdef WOLFSSL_TLS13
         case 4:
             method = wolfTLSv1_3_server_method_ex;
             break;
-#endif
+    #endif
+#endif /* NO_TLS */
 
 #ifdef CYASSL_DTLS
     #ifndef NO_OLD_TLS

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -1288,7 +1288,7 @@ static int SetNamedPrivateKey(const char* name, const char* address, int port,
         sniffer->server = serverIp;
         sniffer->port = port;
 
-        sniffer->ctx = SSL_CTX_new(TLSv1_client_method());
+        sniffer->ctx = SSL_CTX_new(TLSv1_2_client_method());
         if (!sniffer->ctx) {
             SetError(MEMORY_STR, error, NULL, 0);
 #ifdef HAVE_SNI

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3637,9 +3637,11 @@ int wolfSSL_SetVersion(WOLFSSL* ssl, int version)
 
 #ifndef NO_TLS
     #ifndef NO_OLD_TLS
+        #ifdef WOLFSSL_ALLOW_TLSV10
         case WOLFSSL_TLSV1:
             ssl->version = MakeTLSv1();
             break;
+        #endif
 
         case WOLFSSL_TLSV1_1:
             ssl->version = MakeTLSv1_1();

--- a/src/tls.c
+++ b/src/tls.c
@@ -428,6 +428,7 @@ int BuildTlsFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
 
 #ifndef NO_OLD_TLS
 
+#ifdef WOLFSSL_ALLOW_TLSV10
 ProtocolVersion MakeTLSv1(void)
 {
     ProtocolVersion pv;
@@ -436,6 +437,7 @@ ProtocolVersion MakeTLSv1(void)
 
     return pv;
 }
+#endif /* WOLFSSL_ALLOW_TLSV10 */
 
 
 ProtocolVersion MakeTLSv1_1(void)
@@ -447,7 +449,7 @@ ProtocolVersion MakeTLSv1_1(void)
     return pv;
 }
 
-#endif
+#endif /* !NO_OLD_TLS */
 
 
 ProtocolVersion MakeTLSv1_2(void)
@@ -8622,16 +8624,10 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte msgType,
 #ifndef NO_WOLFSSL_CLIENT
 
 #ifndef NO_OLD_TLS
-
+    #ifdef WOLFSSL_ALLOW_TLSV10
     WOLFSSL_METHOD* wolfTLSv1_client_method(void)
     {
         return wolfTLSv1_client_method_ex(NULL);
-    }
-
-
-    WOLFSSL_METHOD* wolfTLSv1_1_client_method(void)
-    {
-        return wolfTLSv1_1_client_method_ex(NULL);
     }
 
     WOLFSSL_METHOD* wolfTLSv1_client_method_ex(void* heap)
@@ -8643,7 +8639,12 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte msgType,
             InitSSL_Method(method, MakeTLSv1());
         return method;
     }
+    #endif /* WOLFSSL_ALLOW_TLSV10 */
 
+    WOLFSSL_METHOD* wolfTLSv1_1_client_method(void)
+    {
+        return wolfTLSv1_1_client_method_ex(NULL);
+    }
 
     WOLFSSL_METHOD* wolfTLSv1_1_client_method_ex(void* heap)
     {
@@ -8740,16 +8741,10 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte msgType,
 #ifndef NO_WOLFSSL_SERVER
 
 #ifndef NO_OLD_TLS
-
+    #ifdef WOLFSSL_ALLOW_TLSV10
     WOLFSSL_METHOD* wolfTLSv1_server_method(void)
     {
         return wolfTLSv1_server_method_ex(NULL);
-    }
-
-
-    WOLFSSL_METHOD* wolfTLSv1_1_server_method(void)
-    {
-        return wolfTLSv1_1_server_method_ex(NULL);
     }
 
     WOLFSSL_METHOD* wolfTLSv1_server_method_ex(void* heap)
@@ -8763,7 +8758,12 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte msgType,
         }
         return method;
     }
+    #endif /* WOLFSSL_ALLOW_TLSV10 */
 
+    WOLFSSL_METHOD* wolfTLSv1_1_server_method(void)
+    {
+        return wolfTLSv1_1_server_method_ex(NULL);
+    }
 
     WOLFSSL_METHOD* wolfTLSv1_1_server_method_ex(void* heap)
     {

--- a/tests/api.c
+++ b/tests/api.c
@@ -271,8 +271,10 @@ static void test_wolfSSL_Method_Allocators(void)
         TEST_VALID_METHOD_ALLOCATOR(wolfSSLv3_server_method);
         TEST_VALID_METHOD_ALLOCATOR(wolfSSLv3_client_method);
     #endif
-    TEST_VALID_METHOD_ALLOCATOR(wolfTLSv1_server_method);
-    TEST_VALID_METHOD_ALLOCATOR(wolfTLSv1_client_method);
+    #ifdef WOLFSL_ALLOW_TLSV10
+        TEST_VALID_METHOD_ALLOCATOR(wolfTLSv1_server_method);
+        TEST_VALID_METHOD_ALLOCATOR(wolfTLSv1_client_method);
+    #endif
     TEST_VALID_METHOD_ALLOCATOR(wolfTLSv1_1_server_method);
     TEST_VALID_METHOD_ALLOCATOR(wolfTLSv1_1_client_method);
 #endif


### PR DESCRIPTION
. Added new `--enable-tlsv10` option to force enable (only works if --enable-oldtls is set, which is on by default).