### PR TITLE
PKCS7 cleanup: remove dependencies on 3DES and SHA1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3777,8 +3777,6 @@ then
         ENABLED_X963KDF="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_X963_KDF"
     fi
-    AS_IF([test "x$ENABLED_DES3" = "xno"],
-          [ENABLED_DES3=yes])
 fi
 
 if test "x$ENABLED_DES3" = "xno"

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -382,7 +382,7 @@ typedef struct ESD {
     enum wc_HashType hashType;
     byte contentDigest[WC_MAX_DIGEST_SIZE + 2]; /* content only + ASN.1 heading */
     byte contentAttribsDigest[WC_MAX_DIGEST_SIZE];
-    byte encContentDigest[512];
+    byte encContentDigest[MAX_ENCRYPTED_KEY_SZ];
 
     byte outerSeq[MAX_SEQ_SZ];
         byte outerContent[MAX_EXP_SZ];
@@ -3217,7 +3217,7 @@ static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     int keySz;
     word32 encOID;
     word32 keyIdx;
-    byte   issuerHash[WC_SHA_DIGEST_SIZE];
+    byte   issuerHash[KEYID_SIZE];
     byte*  outKey = NULL;
 
 #ifdef WC_RSA_BLINDING
@@ -3245,7 +3245,7 @@ static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
         return ASN_PARSE_E;
 
     /* if we found correct recipient, issuer hashes will match */
-    if (XMEMCMP(issuerHash, pkcs7->issuerHash, WC_SHA_DIGEST_SIZE) == 0) {
+    if (XMEMCMP(issuerHash, pkcs7->issuerHash, KEYID_SIZE) == 0) {
         *recipFound = 1;
     }
 


### PR DESCRIPTION
This PR does some cleanup of the PKCS#7 code, including:

1)  "--enable-pkcs7" no longer enables 3DES by default, and fixes a remaining 3DES dependency in the wolfCrypt test app.

2)  Uses MAX_ENCRYPTED_KEY_SZ instead of constant of 512 in pkcs7.c.

3)  Remove PKCS#7 dependency on SHA1 in both pkcs7.c and wolfCrypt test app.