### PR TITLE
Fixed certificate CA path length check for server chains with trusted…

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5849,8 +5849,21 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
                         if (cert->pathLengthSet &&
                             cert->pathLength >= cert->ca->pathLength) {
 
-                            WOLFSSL_MSG("CA signing CA with longer path length");
-                            return ASN_PATHLEN_INV_E;
+                            /* RFC 5246 says: Because certificate validation requires 
+                             * that root keys be distributed independently, the self-signed
+                             * certificate that specifies the root certificate authority MAY be 
+                             * omitted from the chain.
+                             * That means RFC 5246 allows server to send the self-signed
+                             * certificate that specifies the root certificate authority
+                             * in the chain, this case must be handled:
+                             */
+                            if ((cert->pathLength == cert->ca->pathLength) &&
+                                (XMEMCMP(cert->subjectHash, cert->issuerHash, KEYID_SIZE) == 0)) {
+                                WOLFSSL_MSG("Self-signed known root CA detected");
+                            } else {
+                                WOLFSSL_MSG("CA signing CA with longer path length");
+                                return ASN_PATHLEN_INV_E;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
In this commit I think I managed to fix issue #961 (Certificate CA path length check broken for server chains with included trusted self signed CA) in easy way.
The problem:
RFC 5246 says: Because certificate validation requires that root keys be distributed independently, the self-signed certificate that specifies the root certificate authority MAY be omitted from the chain.                             That means RFC 5246 allows server to send the self-signed certificate that specifies the root certificate authority in the chain. But WolfSSL does not expect that server can send root CA in chain.
My fix does not skip certificate check, just handle it like correct CA if it is self-signed and was added to store.
