### PR TITLE
Adds new `WOLFSSL_EXTRA` define to expose useful compatibility API's

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4242,7 +4242,7 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     ssl->buffers.outputBuffer.buffer = ssl->buffers.outputBuffer.staticBuffer;
     ssl->buffers.outputBuffer.bufferSize  = STATIC_BUFFER_LEN;
 
-#if defined(KEEP_PEER_CERT) || defined(GOAHEAD_WS)
+#ifdef KEEP_PEER_CERT
     InitX509(&ssl->peerCert, 0, ssl->heap);
 #endif
 
@@ -4760,7 +4760,7 @@ void SSL_ResourceFree(WOLFSSL* ssl)
           DYNAMIC_TYPE_COOKIE_PWD);
 #endif
 #endif /* WOLFSSL_DTLS */
-#if defined(OPENSSL_EXTRA) || defined(GOAHEAD_WS)
+#ifdef OPENSSL_EXTRA
     if (ssl->biord != ssl->biowr)        /* only free write if different */
         wolfSSL_BIO_free(ssl->biowr);
     wolfSSL_BIO_free(ssl->biord);        /* always free read bio */
@@ -4823,7 +4823,7 @@ void SSL_ResourceFree(WOLFSSL* ssl)
     if (ssl->nxCtx.nxPacket)
         nx_packet_release(ssl->nxCtx.nxPacket);
 #endif
-#if defined(KEEP_PEER_CERT) || defined(GOAHEAD_WS)
+#ifdef KEEP_PEER_CERT
     FreeX509(&ssl->peerCert);
 #endif
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11045,6 +11045,8 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         #endif
     }
 
+#endif
+
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EXTRA)
     void wolfSSL_CTX_set_quiet_shutdown(WOLFSSL_CTX* ctx, int mode)
     {
@@ -11062,7 +11064,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     }
 #endif
 
-
+#ifdef OPENSSL_EXTRA
     void wolfSSL_set_bio(WOLFSSL* ssl, WOLFSSL_BIO* rd, WOLFSSL_BIO* wr)
     {
         WOLFSSL_ENTER("SSL_set_bio");
@@ -11072,7 +11074,9 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         ssl->biord = rd;
         ssl->biowr = wr;
     }
+#endif
 
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EXTRA)
     void wolfSSL_CTX_set_client_CA_list(WOLFSSL_CTX* ctx,
                                        WOLF_STACK_OF(WOLFSSL_X509_NAME)* names)
     {
@@ -11092,7 +11096,9 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
         return s->ca_names;
     }
+#endif
 
+#ifdef OPENSSL_EXTRA
     #if !defined(NO_RSA) && !defined(NO_CERTS)
     WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_load_client_CA_file(const char* fname)
     {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -159,7 +159,7 @@
         #define WOLFSSL_PTHREADS
         #include <pthread.h>
     #endif
-    #if defined(OPENSSL_EXTRA) || defined(GOAHEAD_WS)
+    #ifdef OPENSSL_EXTRA
         #include <unistd.h>      /* for close of BIO */
     #endif
 #endif
@@ -2356,7 +2356,7 @@ struct WOLFSSL_CTX {
     WOLFSSL_X509_STORE x509_store; /* points to ctx->cm */
     byte            readAhead;
     void*           userPRFArg; /* passed to prf callback */
-#endif /* OPENSSL_EXTRA */
+#endif
 #ifdef HAVE_EX_DATA
     void*           ex_data[MAX_EX_DATA];
 #endif
@@ -3322,7 +3322,7 @@ struct WOLFSSL {
 #ifdef HAVE_PK_CALLBACKS
     void*            loggingCtx;         /* logging callback argument */
 #endif
-#endif
+#endif /* OPENSSL_EXTRA */
 #ifndef NO_RSA
     RsaKey*         peerRsaKey;
     byte            peerRsaKeyPresent;


### PR DESCRIPTION
* Added new `WOLFSSL_EXTRA` define for expanded API's without openssl extra.
* Removed old `GOAHEAD_WS`, which had build errors and current project requires full openssl extra compatibility.
* Fix unused arg build warnings for OCSP.

The `WOLFSSL_EXTRA` adds: `wolfSSL_CTX_set_quiet_shutdown`, `wolfSSL_set_quiet_shutdown`, `wolfSSL_set_accept_state` and `wolfSSL_set_connect_state`.