### PR TITLE
Add support for libsignal-protocol-c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -424,6 +424,12 @@ AC_ARG_ENABLE([haproxy],
     [ ENABLED_HAPROXY=no ]
     )
 
+# signal compatibility build
+AC_ARG_ENABLE([signal],
+    [AS_HELP_STRING([--enable-signal],[Enable signal (default: disabled)])],
+    [ ENABLED_SIGNAL=$enableval ],
+    [ ENABLED_SIGNAL=no ]
+    )
 
 # OpenSSL Coexist 
 AC_ARG_ENABLE([opensslcoexist],
@@ -446,7 +452,7 @@ AC_ARG_ENABLE([opensslextra],
     [ ENABLED_OPENSSLEXTRA=$enableval ],
     [ ENABLED_OPENSSLEXTRA=no ]
     )
-if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_NGINX" = "yes"
+if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_NGINX" = "yes" || test "$ENABLED_SIGNAL" = "yes"
 then
     ENABLED_OPENSSLEXTRA="yes"
 fi
@@ -1199,7 +1205,7 @@ then
     ENABLED_ECC=no
 fi
 
-if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_NGINX" = "yes"
+if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_NGINX" = "yes" || test "$ENABLED_SIGNAL" = "yes"
 then
     ENABLED_ECC="yes"
 fi
@@ -2531,7 +2537,7 @@ AC_ARG_ENABLE([tlsx],
     [ ENABLED_TLSX=no ]
     )
 
-if test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_HAPROXY" = "xyes"
+if test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_HAPROXY" = "xyes" || test "x$ENABLED_SIGNAL" = "xyes"
 then
     ENABLED_TLSX=yes
 fi
@@ -2814,6 +2820,17 @@ fi
 if test "$ENABLED_HAPROXY" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HAPROXY"
+    # Requires opensslextra make sure on
+    if test "x$ENABLED_OPENSSLEXTRA" = "xno" && test "x$ENABLED_OPENSSLCOEXIST" = "xno"
+    then
+        ENABLED_OPENSSLEXTRA="yes"
+        AM_CFLAGS="-DOPENSSL_EXTRA $AM_CFLAGS"
+    fi
+fi
+
+if test "$ENABLED_SIGNAL" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SIGNAL"
     # Requires opensslextra make sure on
     if test "x$ENABLED_OPENSSLEXTRA" = "xno" && test "x$ENABLED_OPENSSLCOEXIST" = "xno"
     then
@@ -4138,6 +4155,7 @@ echo "   * LIGHTY:                     $ENABLED_LIGHTY"
 echo "   * HAPROXY:                    $ENABLED_HAPROXY"
 echo "   * STUNNEL:                    $ENABLED_STUNNEL"
 echo "   * NGINX:                      $ENABLED_NGINX"
+echo "   * SIGNAL:                     $ENABLED_SIGNAL"
 echo "   * ERROR_STRINGS:              $ENABLED_ERROR_STRINGS"
 echo "   * DTLS:                       $ENABLED_DTLS"
 echo "   * SCTP:                       $ENABLED_SCTP"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12789,6 +12789,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_cbc(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_128_cbc");
+        if (EVP_AES_128_CBC == NULL)
+            wolfSSL_EVP_init();
         return EVP_AES_128_CBC;
     }
 
@@ -12796,6 +12798,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_cbc(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_192_cbc");
+        if (EVP_AES_192_CBC == NULL)
+            wolfSSL_EVP_init();
         return EVP_AES_192_CBC;
     }
 
@@ -12803,6 +12807,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_cbc(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_256_cbc");
+        if (EVP_AES_256_CBC == NULL)
+            wolfSSL_EVP_init();
         return EVP_AES_256_CBC;
     }
 
@@ -12810,6 +12816,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_ctr(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_128_ctr");
+        if (EVP_AES_128_CTR == NULL)
+            wolfSSL_EVP_init();
         return EVP_AES_128_CTR;
     }
 
@@ -12817,6 +12825,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_ctr(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_192_ctr");
+        if (EVP_AES_192_CTR == NULL)
+            wolfSSL_EVP_init();
         return EVP_AES_192_CTR;
     }
 
@@ -12824,12 +12834,16 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_ctr(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_256_ctr");
+        if (EVP_AES_256_CTR == NULL)
+            wolfSSL_EVP_init();
         return EVP_AES_256_CTR;
     }
 
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_ecb(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_128_ecb");
+        if (EVP_AES_128_ECB == NULL)
+            wolfSSL_EVP_init();
         return EVP_AES_128_ECB;
     }
 
@@ -12837,6 +12851,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_ecb(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_192_ecb");
+        if (EVP_AES_192_ECB == NULL)
+            wolfSSL_EVP_init();
         return EVP_AES_192_ECB;
     }
 
@@ -12844,6 +12860,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_ecb(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_256_ecb");
+        if (EVP_AES_256_ECB == NULL)
+            wolfSSL_EVP_init();
         return EVP_AES_256_ECB;
     }
     #endif /* NO_AES */
@@ -12852,24 +12870,32 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_cbc(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_des_cbc");
+        if (EVP_DES_CBC == NULL)
+            wolfSSL_EVP_init();
         return EVP_DES_CBC;
     }
 #ifdef WOLFSSL_DES_ECB
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_ecb(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_des_ecb");
+        if (EVP_DES_ECB == NULL)
+            wolfSSL_EVP_init();
         return EVP_DES_ECB;
     }
 #endif
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_ede3_cbc(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_des_ede3_cbc");
+        if (EVP_DES_EDE3_CBC == NULL)
+            wolfSSL_EVP_init();
         return EVP_DES_EDE3_CBC;
     }
 #ifdef WOLFSSL_DES_ECB
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_ede3_ecb(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_des_ede3_ecb");
+        if (EVP_DES_EDE3_ECB == NULL)
+            wolfSSL_EVP_init();
         return EVP_DES_EDE3_ECB;
     }
 #endif
@@ -12886,6 +12912,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_idea_cbc(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_idea_cbc");
+        if (EVP_IDEA_CBC == NULL)
+            wolfSSL_EVP_init();
         return EVP_IDEA_CBC;
     }
 #endif
@@ -12957,7 +12985,6 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         ctx->flags   = 0;
 
 #ifndef NO_AES
-        /* printf("cipherType=%d\n", ctx->cipherType); */
         if (ctx->cipherType == AES_128_CBC_TYPE ||
             (type && XSTRNCMP(type, EVP_AES_128_CBC, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_128_CBC");
@@ -13012,14 +13039,19 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             if (key) {
                 ret = wc_AesSetKey(&ctx->cipher.aes, key, ctx->keyLen, iv,
                                 ctx->enc ? AES_ENCRYPTION : AES_DECRYPTION);
-                if (ret != 0)
+                if (ret != 0){
+                    WOLFSSL_MSG("wc_AesSetKey() failed");
                     return ret;
+                }
             }
             if (iv && key == NULL) {
                 ret = wc_AesSetIV(&ctx->cipher.aes, iv);
-                if (ret != 0)
+                if (ret != 0){
+                    WOLFSSL_MSG("wc_AesSetIV() failed");
                     return ret;
+                }
             }
+            WOLFSSL_MSG("wolfSSL_EVP_CipherInit() done");
         }
 #ifdef WOLFSSL_AES_COUNTER
         else if (ctx->cipherType == AES_128_CTR_TYPE ||
@@ -20796,6 +20828,162 @@ int wolfSSL_RSA_GenAdd(WOLFSSL_RSA* rsa)
 }
 #endif /* NO_RSA */
 
+#ifdef WOLFSSL_SIGNAL
+int wolfSSL_HMAC_CTX_init(HMAC_CTX* ctx)
+{
+    WOLFSSL_MSG("wolfSSL_HMAC_CTX_init");
+    (void) ctx;
+
+    return SSL_SUCCESS;
+}
+
+
+int wolfSSL_HMAC_Init(WOLFSSL_HMAC_CTX* ctx, const void* key, int keylen,
+                  const EVP_MD* type)
+{
+    int hmac_error = 0;
+
+    WOLFSSL_MSG("wolfSSL_HMAC_Init");
+
+    if (ctx == NULL) {
+        WOLFSSL_MSG("no ctx on init");
+        return SSL_FAILURE;
+    }
+
+    if (type) {
+        WOLFSSL_MSG("init has type");
+
+        if (XSTRNCMP(type, "MD5", 3) == 0) {
+            WOLFSSL_MSG("md5 hmac");
+            ctx->type = MD5;
+        }
+        else if (XSTRNCMP(type, "SHA256", 6) == 0) {
+            WOLFSSL_MSG("sha256 hmac");
+            ctx->type = SHA256;
+        }
+
+        /* has to be last since would pick or 256, 384, or 512 too */
+        else if (XSTRNCMP(type, "SHA", 3) == 0) {
+            WOLFSSL_MSG("sha hmac");
+            ctx->type = SHA;
+        }
+        else {
+            WOLFSSL_MSG("bad init type");
+            return SSL_FAILURE;
+        }
+    }
+
+    if (key && keylen) {
+        WOLFSSL_MSG("keying hmac");
+
+        if (wc_HmacInit(&ctx->hmac, NULL, INVALID_DEVID) == 0) {
+            hmac_error = wc_HmacSetKey(&ctx->hmac, ctx->type, (const byte*)key,
+                                       (word32)keylen);
+            if (hmac_error < 0){
+                wc_HmacFree(&ctx->hmac);
+                return SSL_FAILURE;
+            }
+        }
+    } else {
+        WOLFSSL_MSG("no key or keylen");
+        return SSL_FAILURE;
+    }
+
+    return SSL_SUCCESS;
+}
+
+
+int wolfSSL_HMAC_Init_ex(WOLFSSL_HMAC_CTX* ctx, const void* key, int len,
+                         const EVP_MD* md, void* impl)
+{
+    (void)impl;
+    return wolfSSL_HMAC_Init(ctx, key, len, md);
+}
+
+
+int wolfSSL_HMAC_Update(WOLFSSL_HMAC_CTX* ctx, const unsigned char* data,
+                    int len)
+{
+    int hmac_error = 0;
+
+    WOLFSSL_MSG("wolfSSL_HMAC_Update");
+
+    if (ctx == NULL || data == NULL) {
+        WOLFSSL_MSG("no ctx or data");
+        return SSL_FAILURE;
+    }
+    WOLFSSL_MSG("updating hmac");
+    hmac_error = wc_HmacUpdate(&ctx->hmac, data, (word32)len);
+    if (hmac_error < 0){
+        WOLFSSL_MSG("hmac update error");
+        return SSL_FAILURE;
+    }
+
+    return SSL_SUCCESS;
+}
+
+
+int wolfSSL_HMAC_Final(WOLFSSL_HMAC_CTX* ctx, unsigned char* hash,
+                   unsigned int* len)
+{
+    int hmac_error;
+
+    WOLFSSL_MSG("wolfSSL_HMAC_Final");
+
+    if (ctx == NULL || hash == NULL || len == NULL) {
+        WOLFSSL_MSG("invalid parameter");
+        return SSL_FAILURE;
+    }
+
+    WOLFSSL_MSG("final hmac");
+    hmac_error = wc_HmacFinal(&ctx->hmac, hash);
+    if (hmac_error < 0){
+        WOLFSSL_MSG("final hmac error");
+        return SSL_FAILURE;
+    }
+
+    if (len) {
+        WOLFSSL_MSG("setting output len");
+        switch (ctx->type) {
+        case MD5:
+            *len = MD5_DIGEST_SIZE;
+            break;
+
+        case SHA:
+            *len = SHA_DIGEST_SIZE;
+            break;
+
+        case SHA256:
+            *len = SHA256_DIGEST_SIZE;
+            break;
+
+        default:
+            WOLFSSL_MSG("bad hmac type");
+            return SSL_FAILURE;
+        }
+    }
+    return SSL_SUCCESS;
+}
+
+
+int wolfSSL_HMAC_cleanup(WOLFSSL_HMAC_CTX* ctx)
+{
+    WOLFSSL_MSG("wolfSSL_HMAC_cleanup");
+
+    if (ctx)
+        wc_HmacFree(&ctx->hmac);
+
+    return SSL_SUCCESS;
+}
+
+#else /* WOLFSSL_SIGNAL */
+
+void wolfSSL_HMAC_CTX_init(HMAC_CTX* ctx)
+{
+    WOLFSSL_MSG("wolfSSL_HMAC_CTX_init");
+    (void) ctx;
+}
+
 
 void wolfSSL_HMAC_Init(WOLFSSL_HMAC_CTX* ctx, const void* key, int keylen,
                   const EVP_MD* type)
@@ -20840,12 +21028,12 @@ void wolfSSL_HMAC_Init(WOLFSSL_HMAC_CTX* ctx, const void* key, int keylen,
     }
 }
 
-int wolfSSL_HMAC_Init_ex(WOLFSSL_HMAC_CTX* ctx, const void* key, int len,
+
+void wolfSSL_HMAC_Init_ex(WOLFSSL_HMAC_CTX* ctx, const void* key, int len,
                          const EVP_MD* md, void* impl)
 {
     (void)impl;
     wolfSSL_HMAC_Init(ctx, key, len, md);
-    return 1;
 }
 
 
@@ -20903,6 +21091,7 @@ void wolfSSL_HMAC_cleanup(WOLFSSL_HMAC_CTX* ctx)
         wc_HmacFree(&ctx->hmac);
 }
 
+#endif /* WOLFSSL_SIGNAL */
 
 const WOLFSSL_EVP_MD* wolfSSL_EVP_get_digestbynid(int id)
 {

--- a/tests/api.c
+++ b/tests/api.c
@@ -7072,7 +7072,6 @@ static int test_wc_CamelliaSetKey (void)
         }
     } /* END bad args. */
 
-    printf(resultFmt, ret == 0 ? passed : failed);
 
 #endif
     return ret;
@@ -10683,7 +10682,7 @@ static void test_wolfSSL_ASN1_TIME_adj(void)
     AssertTrue(asn_time->data[0] == asn_gen_time);
     XSTRNCPY(date_str,(const char*) &asn_time->data+2, 15);
     AssertIntEQ(0, XMEMCMP(date_str, "20550313091000Z", 15));
-
+    
     XFREE(s,NULL,DYNAMIC_TYPE_OPENSSL);
     XMEMSET(date_str, 0, sizeof(date_str));
 #endif /* !TIME_T_NOT_LONG && !NO_64BIT */

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -278,20 +278,41 @@ WOLFSSL_API int  wolfSSL_EVP_CipherInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
                                     WOLFSSL_ENGINE *impl,
                                     unsigned char* key, unsigned char* iv,
                                     int enc);
+#ifdef WOLFSSL_SIGNAL
 WOLFSSL_API int  wolfSSL_EVP_EncryptInit(WOLFSSL_EVP_CIPHER_CTX* ctx,
                                     const WOLFSSL_EVP_CIPHER* type,
-                                    unsigned char* key, unsigned char* iv);
+                                    const unsigned char* key,
+                                    const unsigned char* iv);
 WOLFSSL_API int  wolfSSL_EVP_EncryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
                                     const WOLFSSL_EVP_CIPHER* type,
                                     WOLFSSL_ENGINE *impl,
-                                    unsigned char* key, unsigned char* iv);
+                                    const unsigned char* key,
+                                    const unsigned char* iv);
 WOLFSSL_API int  wolfSSL_EVP_DecryptInit(WOLFSSL_EVP_CIPHER_CTX* ctx,
                                     const WOLFSSL_EVP_CIPHER* type,
-                                    unsigned char* key, unsigned char* iv);
+                                    const unsigned char* key,
+                                    const unsigned char* iv);
 WOLFSSL_API int  wolfSSL_EVP_DecryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
                                     const WOLFSSL_EVP_CIPHER* type,
                                     WOLFSSL_ENGINE *impl,
-                                    unsigned char* key, unsigned char* iv);
+                                    const unsigned char* key,
+                                    const unsigned char* iv);
+#else
+WOLFSSL_API int  wolfSSL_EVP_EncryptInit(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                         const WOLFSSL_EVP_CIPHER* type,
+                                         unsigned char* key, unsigned char* iv);
+WOLFSSL_API int  wolfSSL_EVP_EncryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                            const WOLFSSL_EVP_CIPHER* type,
+                                            WOLFSSL_ENGINE *impl,
+                                            unsigned char* key, unsigned char* iv);
+WOLFSSL_API int  wolfSSL_EVP_DecryptInit(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                            const WOLFSSL_EVP_CIPHER* type,
+                                            unsigned char* key, unsigned char* iv);
+WOLFSSL_API int  wolfSSL_EVP_DecryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                            const WOLFSSL_EVP_CIPHER* type,
+                                            WOLFSSL_ENGINE *impl,
+                                            unsigned char* key, unsigned char* iv);
+#endif  /* WOLFSSL_SIGNAL */
 WOLFSSL_API int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
                                    unsigned char *out, int *outl,
                                    const unsigned char *in, int inl);

--- a/wolfssl/openssl/hmac.h
+++ b/wolfssl/openssl/hmac.h
@@ -36,6 +36,7 @@
 #endif
 
 #include <wolfssl/openssl/evp.h>
+#include <wolfssl/openssl/opensslv.h>
 #include <wolfssl/wolfcrypt/hmac.h>
 
 #ifdef __cplusplus
@@ -54,27 +55,40 @@ typedef struct WOLFSSL_HMAC_CTX {
     int  type;
 } WOLFSSL_HMAC_CTX;
 
-
-WOLFSSL_API void wolfSSL_HMAC_Init(WOLFSSL_HMAC_CTX* ctx, const void* key,
+#ifdef WOLFSSL_SIGNAL
+WOLFSSL_API int wolfSSL_HMAC_CTX_init(WOLFSSL_HMAC_CTX* ctx);
+WOLFSSL_API int wolfSSL_HMAC_Init(WOLFSSL_HMAC_CTX* ctx, const void* key,
                                  int keylen, const EVP_MD* type);
 WOLFSSL_API int wolfSSL_HMAC_Init_ex(WOLFSSL_HMAC_CTX* ctx, const void* key,
                                      int len, const EVP_MD* md, void* impl);
-WOLFSSL_API void wolfSSL_HMAC_Update(WOLFSSL_HMAC_CTX* ctx,
+WOLFSSL_API int wolfSSL_HMAC_Update(WOLFSSL_HMAC_CTX* ctx,
                                    const unsigned char* data, int len);
-WOLFSSL_API void wolfSSL_HMAC_Final(WOLFSSL_HMAC_CTX* ctx, unsigned char* hash,
+WOLFSSL_API int wolfSSL_HMAC_Final(WOLFSSL_HMAC_CTX* ctx, unsigned char* hash,
                                   unsigned int* len);
+WOLFSSL_API int wolfSSL_HMAC_cleanup(WOLFSSL_HMAC_CTX* ctx);
+#else
+WOLFSSL_API void wolfSSL_HMAC_CTX_init(WOLFSSL_HMAC_CTX* ctx);
+WOLFSSL_API void wolfSSL_HMAC_Init(WOLFSSL_HMAC_CTX* ctx, const void* key,
+                                           int keylen, const EVP_MD* type);
+WOLFSSL_API void wolfSSL_HMAC_Init_ex(WOLFSSL_HMAC_CTX* ctx, const void* key,
+                                              int len, const EVP_MD* md, void* impl);
+WOLFSSL_API void wolfSSL_HMAC_Update(WOLFSSL_HMAC_CTX* ctx,
+                                             const unsigned char* data, int len);
+WOLFSSL_API void wolfSSL_HMAC_Final(WOLFSSL_HMAC_CTX* ctx, unsigned char* hash,
+                                            unsigned int* len);
 WOLFSSL_API void wolfSSL_HMAC_cleanup(WOLFSSL_HMAC_CTX* ctx);
-
+#endif
 
 typedef struct WOLFSSL_HMAC_CTX HMAC_CTX;
 
 #define HMAC(a,b,c,d,e,f,g) wolfSSL_HMAC((a),(b),(c),(d),(e),(f),(g))
 
-#define HMAC_Init    wolfSSL_HMAC_Init
-#define HMAC_Init_ex wolfSSL_HMAC_Init_ex
-#define HMAC_Update  wolfSSL_HMAC_Update
-#define HMAC_Final   wolfSSL_HMAC_Final
-#define HMAC_cleanup wolfSSL_HMAC_cleanup
+#define HMAC_CTX_init    wolfSSL_HMAC_CTX_init
+#define HMAC_Init        wolfSSL_HMAC_Init
+#define HMAC_Init_ex     wolfSSL_HMAC_Init_ex
+#define HMAC_Update      wolfSSL_HMAC_Update
+#define HMAC_Final       wolfSSL_HMAC_Final
+#define HMAC_cleanup     wolfSSL_HMAC_cleanup
 
 
 #ifdef __cplusplus

--- a/wolfssl/openssl/opensslv.h
+++ b/wolfssl/openssl/opensslv.h
@@ -5,7 +5,7 @@
 
 
 /* api version compatibility */
-#if defined(HAVE_STUNNEL) || defined(HAVE_LIGHTY) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
+#if defined(HAVE_STUNNEL) || defined(HAVE_LIGHTY) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_SIGNAL)
      /* version number can be increased for Lighty after compatibility for ECDH
         is added */
      #define OPENSSL_VERSION_NUMBER 0x10001000L
@@ -17,4 +17,3 @@
 
 
 #endif /* header */
-


### PR DESCRIPTION
I add support for libsignal-protocol-c and enable to compile with libsignal-protocol-c test programs.

1. Add wolfSSL_EVP_init() call in wolfSSL_EVP_aes encryption functions to initialize EVP.
2. Because OpenSSL changed prototype declaration of HMAC functions and EVP functions between v0.9 and v1.0 , I added ENABLE_SIGNAL define and switch those declarations.
3. I added --enable-signal option in configure command.
