### PR TITLE
Fixes to address Jenkins issues

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2699,7 +2699,8 @@ static INLINE void DecodeSigAlg(const byte* input, byte* hashAlgo, byte* hsType)
 }
 #endif /* !NO_WOLFSSL_SERVER || !NO_CERTS */
 
-#if !defined(NO_DH) || defined(HAVE_ECC)
+#if !defined(NO_DH) || defined(HAVE_ECC) || \
+    (!defined(NO_RSA) && defined(WC_RSA_PSS))
 
 static enum wc_HashType HashAlgoToType(int hashAlgo)
 {
@@ -2729,8 +2730,10 @@ static enum wc_HashType HashAlgoToType(int hashAlgo)
     return WC_HASH_TYPE_NONE;
 }
 
-#ifndef NO_CERTS
+#endif /* !NO_DH || HAVE_ECC || (!NO_RSA && WC_RSA_PSS) */
 
+
+#ifndef NO_CERTS
 
 void InitX509Name(WOLFSSL_X509_NAME* name, int dynamicFlag)
 {
@@ -2840,10 +2843,8 @@ void FreeX509(WOLFSSL_X509* x509)
     if (x509->altNames)
         FreeAltNames(x509->altNames, x509->heap);
 }
-#endif /* !NO_CERTS */
-#endif /* !NO_DH || HAVE_ECC */
 
-#ifndef NO_CERTS
+
 /* Encode the signature algorithm into buffer.
  *
  * hashalgo  The hash algorithm.

--- a/tests/api.c
+++ b/tests/api.c
@@ -10636,7 +10636,7 @@ static void test_wolfSSL_ASN1_TIME_adj(void)
     const int hour = 60*60;
     const int min  = 60;
     const byte asn_utc_time = ASN_UTC_TIME;
-#ifndef TIME_T_NOT_LONG
+#if !defined(TIME_T_NOT_LONG) && !defined(NO_64BIT)
     const byte asn_gen_time = ASN_GENERALIZED_TIME;
 #endif
     WOLFSSL_ASN1_TIME *asn_time, *s;

--- a/tests/api.c
+++ b/tests/api.c
@@ -10671,7 +10671,7 @@ static void test_wolfSSL_ASN1_TIME_adj(void)
     XMEMSET(date_str, 0, sizeof(date_str));
 
     /* Generalized time will overflow time_t if not long */
-#ifndef TIME_T_NOT_LONG
+#if !defined(TIME_T_NOT_LONG) && !defined(NO_64BIT)
     s = (WOLFSSL_ASN1_TIME*)XMALLOC(sizeof(WOLFSSL_ASN1_TIME), NULL,
                                     DYNAMIC_TYPE_OPENSSL);
     /* GeneralizedTime notation test */
@@ -10686,7 +10686,7 @@ static void test_wolfSSL_ASN1_TIME_adj(void)
 
     XFREE(s,NULL,DYNAMIC_TYPE_OPENSSL);
     XMEMSET(date_str, 0, sizeof(date_str));
-#endif
+#endif /* !TIME_T_NOT_LONG && !NO_64BIT */
 
     /* if WOLFSSL_ASN1_TIME struct is not allocated */
     s = NULL;


### PR DESCRIPTION
* Fix for #ifdef issue causing some X509 functions to be unavailable when DH and ECC are disabled.
* Fix for `HashAlgoToType` not being available if building with DH and ECC disabled and RSA PSS enabled.
* Fix for building with --enable-32bit where test assumes time_t is long.