### PR TITLE
Fix for processing HTTP responses to accept a list of application strings

### DIFF
--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -345,7 +345,7 @@ WOLFSSL_API  int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags);
     WOLFSSL_API  int wolfIO_HttpBuildRequest(const char* reqType,
         const char* domainName, const char* path, int pathLen, int reqSz,
         const char* contentType, unsigned char* buf, int bufSize);
-    WOLFSSL_API  int wolfIO_HttpProcessResponse(int sfd, const char* appStr,
+    WOLFSSL_API  int wolfIO_HttpProcessResponse(int sfd, const char** appStrList,
         unsigned char** respBuf, unsigned char* httpBuf, int httpBufSz,
         int dynType, void* heap);
 #endif /* HAVE_HTTP_CLIENT */


### PR DESCRIPTION
Fix for processing HTTP responses to accept a list of application strings. Specifically for CRL which has both "application/pkix-crl" and "application/x-pkcs7-crl". Both CRL formats are the same and both parse correctly. Applies to `--enable-crl` with `HAVE_CRL_IO` only.