### PR TITLE
Add crypto hardware support for ECC sign

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1771,10 +1771,9 @@ int wolfSSL_mcast_read(WOLFSSL* ssl, word16* id, void* data, int sz)
 
 #endif /* WOLFSSL_MULTICAST */
 
-#ifdef WOLFSSL_ASYNC_CRYPT
 
-/* let's use async hardware, WOLFSSL_SUCCESS on ok */
-int wolfSSL_UseAsync(WOLFSSL* ssl, int devId)
+/* helpers to set the device id, WOLFSSL_SUCCESS on ok */
+int wolfSSL_SetDevId(WOLFSSL* ssl, int devId)
 {
     if (ssl == NULL)
         return BAD_FUNC_ARG;
@@ -1783,10 +1782,7 @@ int wolfSSL_UseAsync(WOLFSSL* ssl, int devId)
 
     return WOLFSSL_SUCCESS;
 }
-
-
-/* let's use async hardware, WOLFSSL_SUCCESS on ok */
-int wolfSSL_CTX_UseAsync(WOLFSSL_CTX* ctx, int devId)
+int wolfSSL_CTX_SetDevId(WOLFSSL_CTX* ctx, int devId)
 {
     if (ctx == NULL)
         return BAD_FUNC_ARG;
@@ -1795,8 +1791,6 @@ int wolfSSL_CTX_UseAsync(WOLFSSL_CTX* ctx, int devId)
 
     return WOLFSSL_SUCCESS;
 }
-
-#endif /* WOLFSSL_ASYNC_CRYPT */
 
 /* helpers to get device id and heap */
 int wolfSSL_CTX_GetDevId(WOLFSSL_CTX* ctx, WOLFSSL* ssl)

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1880,8 +1880,10 @@ WOLFSSL_API int wolfSSL_CTX_UseClientSuites(WOLFSSL_CTX* ctx);
 WOLFSSL_API int wolfSSL_UseClientSuites(WOLFSSL* ssl);
 
 /* async additions */
-WOLFSSL_API int wolfSSL_UseAsync(WOLFSSL*, int devId);
-WOLFSSL_API int wolfSSL_CTX_UseAsync(WOLFSSL_CTX*, int devId);
+#define wolfSSL_UseAsync wolfSSL_SetDevId
+#define wolfSSL_CTX_UseAsync wolfSSL_CTX_SetDevId
+WOLFSSL_API int wolfSSL_SetDevId(WOLFSSL*, int devId);
+WOLFSSL_API int wolfSSL_CTX_SetDevId(WOLFSSL_CTX*, int devId);
 
 /* helpers to get device id and heap */
 WOLFSSL_API int   wolfSSL_CTX_GetDevId(WOLFSSL_CTX* ctx, WOLFSSL* ssl);

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -109,7 +109,14 @@ enum {
     ECC_MAXSIZE_GEN = 74,   /* MAX Buffer size required when generating ECC keys*/
     ECC_MAX_PAD_SZ  = 4,    /* ECC maximum padding size */
     ECC_MAX_OID_LEN = 16,
-    ECC_MAX_SIG_SIZE= ((MAX_ECC_BYTES * 2) + ECC_MAX_PAD_SZ + SIG_HEADER_SZ)
+    ECC_MAX_SIG_SIZE= ((MAX_ECC_BYTES * 2) + ECC_MAX_PAD_SZ + SIG_HEADER_SZ),
+
+    /* max crypto hardware size */
+#ifdef WOLFSSL_ATECC508A
+    ECC_MAX_CRYPTO_HW_SIZE = ATECC_KEY_SIZE, /* from port/atmel/atmel.h */
+#elif defined(PLUTON_CRYPTO_ECC)
+    ECC_MAX_CRYPTO_HW_SIZE = 32,
+#endif
 };
 
 /* Curve Types */
@@ -290,6 +297,9 @@ struct ecc_key {
 #ifdef WOLFSSL_ATECC508A
     int  slot;        /* Key Slot Number (-1 unknown) */
     byte pubkey_raw[PUB_KEY_SIZE];
+#endif
+#ifdef PLUTON_CRYPTO_ECC
+    int devId;
 #endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     mp_int* r;          /* sign/verify temps */


### PR DESCRIPTION
The `wc_ecc_init_ex` devId is used to indicate desire to use hardware based key. When `devId = INVAILD_DEVID` the software based ECC will be used.

Added `wolfSSL_CTX_SetDevId` and `wolfSSL_SetDevId` to allow setting `devId`. Use #define macro to map the original async `wolfSSL_CTX_UseAsync` and `wolfSSL_UseAsync` API's to the new ones.