### PR TITLE
fixes OCSP Stapling v2 tests

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1872,6 +1872,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif
 #ifdef HAVE_CERTIFICATE_STATUS_REQUEST
     if (statusRequest) {
+        if (wolfSSL_CTX_EnableOCSPStapling(ctx) != WOLFSSL_SUCCESS)
+            err_sys("can't enable OCSP Stapling Certificate Manager");
+
         switch (statusRequest) {
             case WOLFSSL_CSR_OCSP:
                 if (wolfSSL_UseOCSPStapling(ssl, WOLFSSL_CSR_OCSP,

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1892,6 +1892,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif
 #ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
     if (statusRequest) {
+        if (wolfSSL_CTX_EnableOCSPStapling(ctx) != WOLFSSL_SUCCESS)
+            err_sys("can't enable OCSP Stapling Certificate Manager");
+
         switch (statusRequest) {
             case WOLFSSL_CSR2_OCSP:
                 if (wolfSSL_UseOCSPStaplingV2(ssl,

--- a/scripts/ocsp-stapling-with-ca-as-responder.test
+++ b/scripts/ocsp-stapling-with-ca-as-responder.test
@@ -2,7 +2,7 @@
 
 # ocsp-stapling.test
 
-trap 'for i in `jobs -p`; do pkill -TERM -P $i; kill $i; done' EXIT
+trap 'for i in `jobs -p`; do pkill -TERM -P $i; done' EXIT
 
 server=login.live.com
 ca=certs/external/baltimore-cybertrust-root.pem

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -2,7 +2,7 @@
 
 # ocsp-stapling.test
 
-trap 'for i in `jobs -p`; do pkill -TERM -P $i; kill $i; done' EXIT
+trap 'for i in `jobs -p`; do pkill -TERM -P $i; done' EXIT
 
 server=login.live.com
 ca=certs/external/baltimore-cybertrust-root.pem

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -2,7 +2,7 @@
 
 # ocsp-stapling.test
 
-trap 'for i in `jobs -p`; do pkill -TERM -P $i; kill $i; done' EXIT
+trap 'for i in `jobs -p`; do pkill -TERM -P $i; done' EXIT
 
 [ ! -x ./examples/client/client ] && echo -e "\n\nClient doesn't exist" && exit 1
 


### PR DESCRIPTION
The OCSP stapling extensions were not being sent by the client example as the OCSP Stapling CM was never enabled.