### PR TITLE
Fix for building with `BENCH_EMBEDDED`

### DIFF
--- a/IDE/GCC-ARM/Header/user_settings.h
+++ b/IDE/GCC-ARM/Header/user_settings.h
@@ -80,9 +80,13 @@ extern "C" {
     //#define RSA_LOW_MEM
 
     /* Enables blinding mode, to prevent timing attacks */
-    #undef  WC_RSA_BLINDING
-    #define WC_RSA_BLINDING
-
+    #if 1
+        #undef  WC_RSA_BLINDING
+        #define WC_RSA_BLINDING
+    #else
+        #undef  WC_NO_HARDEN
+        #define WC_NO_HARDEN
+    #endif
 #else
     #define NO_RSA
 #endif
@@ -200,6 +204,8 @@ extern "C" {
 /* Sha256 */
 #undef NO_SHA256
 #if 1
+    /* not unrolled - ~2k smaller and ~25% slower */
+    #define USE_SLOW_SHA256
 #else
     #define NO_SHA256
 #endif
@@ -216,7 +222,7 @@ extern "C" {
     #endif
 
     /* over twice as small, but 50% slower */
-    #define USE_SLOW_SHA2
+    #define USE_SLOW_SHA512
 #endif
 
 /* MD5 */

--- a/IDE/GCC-ARM/Makefile.common
+++ b/IDE/GCC-ARM/Makefile.common
@@ -105,4 +105,4 @@ $(BUILD_DIR)/$(BIN).a: $(OBJS_ASM) $(OBJS_C)
 
 clean:
 	rm -f $(BUILD_DIR)/*.elf $(BUILD_DIR)/*.hex $(BUILD_DIR)/*.map
-	rm -f $(BUILD_DIR)/*.o $(BUILD_DIR)/*.sym $(BUILD_DIR)/*.disasm
+	rm -f $(BUILD_DIR)/*.o $(BUILD_DIR)/*.a $(BUILD_DIR)/*.sym $(BUILD_DIR)/*.disasm

--- a/IDE/GCC-ARM/Source/armtarget.c
+++ b/IDE/GCC-ARM/Source/armtarget.c
@@ -19,7 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include "user_settings.h"
+
+#include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/ssl.h>
 #include <wolfssl/wolfcrypt/random.h> /* for CUSTOM_RAND_TYPE */
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -3138,10 +3138,11 @@ static void bench_hmac(int doAsync, int type, int digestSz,
     int    ret = 0, i, count = 0, times, pending = 0;
 #if defined(BENCH_EMBEDDED)
     DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING, MAX_DIGEST_SIZE, HEAP_HINT);
+    (void)digestSz;
 #else
     DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING, digestSz, HEAP_HINT);
 #endif
-    
+
     /* clear for done cleanup */
     XMEMSET(hmac, 0, sizeof(hmac));
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -634,8 +634,11 @@ WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
                            /* what's ref count */
 
 WOLFSSL_API void wolfSSL_X509_free(WOLFSSL_X509*);
+
+#ifdef OPENSSL_EXTRA
 WOLFSSL_API void wolfSSL_OPENSSL_free(void*);
 WOLFSSL_API void *wolfSSL_OPENSSL_malloc(size_t a);
+#endif
 
 WOLFSSL_API int wolfSSL_OCSP_parse_url(char* url, char** host, char** port,
                                      char** path, int* ssl);


### PR DESCRIPTION
Improvements to the GCC-ARM IDE example.