### PR TITLE
Improvements to logging

### DIFF
--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -123,30 +123,28 @@ static void wolfssl_log(const int logLevel, const char *const logMessage)
     if (log_function)
         log_function(logLevel, logMessage);
     else {
-        if (loggingEnabled) {
 #if defined(WOLFSSL_USER_LOG)
-            WOLFSSL_USER_LOG(logMessage);
+        WOLFSSL_USER_LOG(logMessage);
 #elif defined(WOLFSSL_LOG_PRINTF)
-            printf("%s\n", logMessage);
+        printf("%s\n", logMessage);
 
 #elif defined(THREADX) && !defined(THREADX_NO_DC_PRINTF)
-            dc_log_printf("%s\n", logMessage);
+        dc_log_printf("%s\n", logMessage);
 #elif defined(MICRIUM)
-            BSP_Ser_Printf("%s\r\n", logMessage);
+        BSP_Ser_Printf("%s\r\n", logMessage);
 #elif defined(WOLFSSL_MDK_ARM)
-            fflush(stdout) ;
-            printf("%s\n", logMessage);
-            fflush(stdout) ;
+        fflush(stdout) ;
+        printf("%s\n", logMessage);
+        fflush(stdout) ;
 #elif defined(WOLFSSL_UTASKER)
-            fnDebugMsg((char*)logMessage);
-            fnDebugMsg("\r\n");
+        fnDebugMsg((char*)logMessage);
+        fnDebugMsg("\r\n");
 #elif defined(MQX_USE_IO_OLD)
-            fprintf(_mqxio_stderr, "%s\n", logMessage);
+        fprintf(_mqxio_stderr, "%s\n", logMessage);
 
 #else
-            fprintf(stderr, "%s\n", logMessage);
+        fprintf(stderr, "%s\n", logMessage);
 #endif
-        }
     }
 }
 
@@ -232,8 +230,8 @@ void WOLFSSL_ERROR_LINE(int error, const char* func, unsigned int line,
 void WOLFSSL_ERROR(int error)
 #endif
 {
-#if defined(DEBUG_WOLFSSL) && !defined(WOLFSSL_NGINX)
-    if (loggingEnabled && error != WC_PENDING_E)
+#ifdef WOLFSSL_ASYNC_CRYPT
+    if (error != WC_PENDING_E)
 #endif
     {
         char buffer[WOLFSSL_MAX_ERROR_SZ];
@@ -267,7 +265,8 @@ void WOLFSSL_ERROR(int error)
     #endif
 
     #ifdef DEBUG_WOLFSSL
-        wolfssl_log(ERROR_LOG , buffer);
+        if (loggingEnabled)
+            wolfssl_log(ERROR_LOG , buffer);
     #endif
     }
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -15100,11 +15100,14 @@ int logging_test(void)
     WOLFSSL_BUFFER(NULL, 0);
     WOLFSSL_ERROR(MEMORY_E);
     WOLFSSL_ERROR_MSG(msg);
-    i = log_cnt; /* capture log count */
 
     /* turn off logs */
     wolfSSL_Debugging_OFF();
 
+    /* capture log count */
+    i = log_cnt;
+
+    /* validate no logs are output when disabled */
     WOLFSSL_MSG(msg);
     WOLFSSL_BUFFER(a, sizeof(a));
     WOLFSSL_BUFFER(b, sizeof(b));

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -15068,14 +15068,14 @@ done:
 #endif
 
 #ifdef DEBUG_WOLFSSL
-static int log_cnt = 0;
+static THREAD_LS_T int log_cnt = 0;
 static void my_Logging_cb(const int logLevel, const char *const logMessage)
 {
     (void)logLevel;
     (void)logMessage;
     log_cnt++;
 }
-#endif
+#endif /* DEBUG_WOLFSSL */
 
 int logging_test(void)
 {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -318,16 +318,6 @@ int mutex_test(void);
 int memcb_test(void);
 #endif
 
-#if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND) && \
-        !defined(OPENSSL_EXTRA) && !defined(HAVE_STACK_SIZE)
-#ifdef __cplusplus
-    extern "C" {
-#endif
-    WOLFSSL_API int wolfSSL_Debugging_ON(void);
-#ifdef __cplusplus
-    }  /* extern "C" */
-#endif
-#endif
 
 /* General big buffer size for many tests. */
 #define FOURK_BUF 4096
@@ -855,12 +845,10 @@ int wolfcrypt_test(void* args)
         printf( "mp       test passed!\n");
 #endif
 
-#ifdef HAVE_VALGRIND
     if ( (ret = logging_test()) != 0)
         return err_sys("logging  test failed!\n", ret);
     else
         printf( "logging  test passed!\n");
-#endif
 
     if ( (ret = mutex_test()) != 0)
         return err_sys("mutex    test failed!\n", ret);
@@ -15079,15 +15067,6 @@ done:
 }
 #endif
 
-#ifdef HAVE_VALGRIND
-/* Need a static build to have access to symbols. */
-
-#ifndef WOLFSSL_SSL_H
-/* APIs hiding in ssl.h */
-extern int wolfSSL_Debugging_ON(void);
-extern void wolfSSL_Debugging_OFF(void);
-#endif
-
 #ifdef DEBUG_WOLFSSL
 static int log_cnt = 0;
 static void my_Logging_cb(const int logLevel, const char *const logMessage)
@@ -15104,55 +15083,57 @@ int logging_test(void)
     const char* msg = "Testing, testing. 1, 2, 3, 4 ...";
     byte        a[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
     byte        b[256];
-    size_t      i;
+    int         i;
 
-    for (i = 0; i < sizeof(b); i++)
+    for (i = 0; i < (int)sizeof(b); i++)
         b[i] = i;
 
     if (wolfSSL_Debugging_ON() != 0)
         return -7900;
-    if (wolfSSL_SetLoggingCb(NULL) != BAD_FUNC_ARG)
+
+    if (wolfSSL_SetLoggingCb(my_Logging_cb) != 0)
         return -7901;
 
     WOLFSSL_MSG(msg);
     WOLFSSL_BUFFER(a, sizeof(a));
     WOLFSSL_BUFFER(b, sizeof(b));
     WOLFSSL_BUFFER(NULL, 0);
+    WOLFSSL_ERROR(MEMORY_E);
+    WOLFSSL_ERROR_MSG(msg);
+    i = log_cnt; /* capture log count */
 
+    /* turn off logs */
     wolfSSL_Debugging_OFF();
 
     WOLFSSL_MSG(msg);
+    WOLFSSL_BUFFER(a, sizeof(a));
     WOLFSSL_BUFFER(b, sizeof(b));
+    WOLFSSL_BUFFER(NULL, 0);
+    WOLFSSL_ERROR(MEMORY_E);
+    WOLFSSL_ERROR_MSG(msg);
 
-    if (wolfSSL_SetLoggingCb(my_Logging_cb) != 0)
-        return -7902;
-
-    wolfSSL_Debugging_OFF();
-
-    WOLFSSL_MSG(msg);
-    WOLFSSL_BUFFER(b, sizeof(b));
-
-    if (log_cnt != 0)
-        return -7903;
-    if (wolfSSL_Debugging_ON() != 0)
+    /* check the logs were disabled */
+    if (i != log_cnt)
         return -7904;
 
-    WOLFSSL_MSG(msg);
-    WOLFSSL_BUFFER(b, sizeof(b));
+    /* restore callback and leave logging enabled */
+    wolfSSL_SetLoggingCb(NULL);
+    wolfSSL_Debugging_ON();
 
-    /* One call for each line of output. */
-    if (log_cnt != 17)
-        return -7905;
+    /* suppress unused args */
+    (void)a;
+    (void)b;
+
 #else
     if (wolfSSL_Debugging_ON() != NOT_COMPILED_IN)
         return -7906;
     wolfSSL_Debugging_OFF();
     if (wolfSSL_SetLoggingCb(NULL) != NOT_COMPILED_IN)
         return -7907;
-#endif
+#endif /* DEBUG_WOLFSSL */
     return 0;
 }
-#endif
+
 
 int mutex_test(void)
 {

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -30,6 +30,7 @@
 /* for users not using preprocessor flags*/
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/version.h>
+#include <wolfssl/wolfcrypt/logging.h>
 
 #ifdef HAVE_WOLF_EVENT
     #include <wolfssl/wolfcrypt/wolfevent.h>
@@ -1320,11 +1321,6 @@ WOLFSSL_API int wolfSSL_Cleanup(void);
 WOLFSSL_API const char* wolfSSL_lib_version(void);
 /* which library version do we have in hex */
 WOLFSSL_API unsigned int wolfSSL_lib_version_hex(void);
-
-/* turn logging on, only if compiled in */
-WOLFSSL_API int  wolfSSL_Debugging_ON(void);
-/* turn logging off */
-WOLFSSL_API void wolfSSL_Debugging_OFF(void);
 
 /* do accept or connect depedning on side */
 WOLFSSL_API int wolfSSL_negotiate(WOLFSSL* ssl);


### PR DESCRIPTION
* Added new build option `WOLFSSL_DEBUG_ERRORS_ONLY` to reduce logging/code size when building with `DEBUG_WOLFSSL`.
* Added new `WOLFSSL_ERROR_MSG(const char* msg)` API for logging error messages.
* Added new `WOLFSSL_USER_LOG` to allow custom macro for printing `logMessage`. Example `#define WOLFSSL_USER_LOG(msg) myprintf((msg))`.
* Improvements to the wolfCrypt `logging_test`.
* Moved `wolfSSL_Debugging_ON` and `wolfSSL_Debugging_OFF` to logging.h.
* Exposed the logging API's.
* Allow `wolfSSL_SetLoggingCb` to be called with NULL to restore default logging.