### PR TITLE
added a new makefile for sgx-fips and scripts to speed up build process

### DIFF
--- a/IDE/LINUX-SGX/build.sh
+++ b/IDE/LINUX-SGX/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+
+CFLAGS="-DDEBUG_WOLFSSL"
+CFLAGS="-DBUILDING_STATIC_LIBRARY"
+export CFLAGS=${CFLAGS}
+
+# NOTE: ONLY build one or the other, do not build both libraries together!
+# Uncomment the make command for either the default Linux SGX or the SGX FIPS
+# Linux solution
+
+# Default
+#make -f sgx_t_static.mk HAVE_WOLFSSL_BENCHMARK=1 HAVE_WOLFSSL_TEST=1
+
+# Uncomment for building with SGX-FIPS
+#make -f sgx_t_fips_static.mk HAVE_WOLFSSL_BENCHMARK=1 HAVE_WOLFSSL_TEST=1 HAVE_FIPS_LINUX_HARNESS=1
+

--- a/IDE/LINUX-SGX/clean.sh
+++ b/IDE/LINUX-SGX/clean.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Just clean both always by default
+
+# Default
+make -f sgx_t_static.mk clean
+
+# Uncomment for SGX-FIPS
+make -f sgx_t_fips_static.mk clean

--- a/IDE/LINUX-SGX/sgx_t_fips_static.mk
+++ b/IDE/LINUX-SGX/sgx_t_fips_static.mk
@@ -1,0 +1,181 @@
+######## Intel(R) SGX SDK Settings ########
+SGX_SDK ?= /opt/intel/sgxsdk
+SGX_MODE ?= SIM
+SGX_ARCH ?= x64
+WOLFSSL_ROOT ?= $(shell readlink -f ../..)
+
+ifeq ($(shell getconf LONG_BIT), 32)
+	SGX_ARCH := x86
+else ifeq ($(findstring -m32, $(CXXFLAGS)), -m32)
+	SGX_ARCH := x86
+endif
+
+ifeq ($(SGX_ARCH), x86)
+	SGX_COMMON_CFLAGS := -m32
+	SGX_LIBRARY_PATH := $(SGX_SDK)/lib
+	SGX_ENCLAVE_SIGNER := $(SGX_SDK)/bin/x86/sgx_sign
+	SGX_EDGER8R := $(SGX_SDK)/bin/x86/sgx_edger8r
+else
+	SGX_COMMON_CFLAGS := -m64
+	SGX_LIBRARY_PATH := $(SGX_SDK)/lib64
+	SGX_ENCLAVE_SIGNER := $(SGX_SDK)/bin/x64/sgx_sign
+	SGX_EDGER8R := $(SGX_SDK)/bin/x64/sgx_edger8r
+endif
+
+ifeq ($(SGX_DEBUG), 1)
+ifeq ($(SGX_PRERELEASE), 1)
+$(error Cannot set SGX_DEBUG and SGX_PRERELEASE at the same time!!)
+endif
+endif
+
+ifeq ($(SGX_DEBUG), 1)
+        SGX_COMMON_CFLAGS += -O0 -g
+else
+        SGX_COMMON_CFLAGS += -O2
+endif
+
+ifneq ($(SGX_MODE), HW)
+	Trts_Library_Name := sgx_trts_sim
+	Service_Library_Name := sgx_tservice_sim
+else
+	Trts_Library_Name := sgx_trts
+	Service_Library_Name := sgx_tservice
+endif
+
+Crypto_Library_Name := sgx_tcrypto
+
+Wolfssl_C_Extra_Flags := -DWOLFSSL_SGX
+Wolfssl_C_Extra_Flags += -DHAVE_FIPS
+Wolfssl_C_Extra_Flags += -DWOLFSSL_KEY_GEN
+Wolfssl_C_Extra_Flags += -DWOLFSSL_SHA512
+Wolfssl_C_Extra_Flags += -DWOLFSSL_SHA384
+Wolfssl_C_Extra_Flags += -DHAVE_THREAD_LS
+Wolfssl_C_Extra_Flags += -DHAVE_HASHDRBG
+Wolfssl_C_Files :=$(WOLFSSL_ROOT)/wolfcrypt/src/aes.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/arc4.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/asn.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/blake2b.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/camellia.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/coding.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/chacha.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/chacha20_poly1305.c\
+					$(WOLFSSL_ROOT)/src/crl.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/des3.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/dh.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/tfm.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/ecc.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/error.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/hash.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/hc128.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/hmac.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/integer.c\
+					$(WOLFSSL_ROOT)/src/internal.c\
+					$(WOLFSSL_ROOT)/src/wolfio.c\
+					$(WOLFSSL_ROOT)/src/keys.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/logging.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/md4.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/md5.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/memory.c\
+					$(WOLFSSL_ROOT)/src/ocsp.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/pkcs7.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/pkcs12.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/poly1305.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/wc_port.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/wolfmath.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/pwdbased.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/rabbit.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/random.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/ripemd.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/rsa.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/dsa.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/sha.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/sha256.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/sha512.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/signature.c\
+					$(WOLFSSL_ROOT)/src/ssl.c\
+					$(WOLFSSL_ROOT)/src/tls.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/wc_encrypt.c\
+					$(WOLFSSL_ROOT)/wolfcrypt/src/wolfevent.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/aes.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/des3.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/fips.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/fips_test.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/hmac.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/misc.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/random.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/rsa.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/sha256.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/sha512.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/sha.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/wolfcrypt_first.c\
+					$(WOLFSSL_ROOT)/ctaocrypt/src/wolfcrypt_last.c\
+
+Wolfssl_Include_Paths := -I$(WOLFSSL_ROOT)/ \
+						 -I$(WOLFSSL_ROOT)/ctaocrypt/ \
+						 -I$(WOLFSSL_ROOT)/wolfcrypt/ \
+						 -I$(SGX_SDK)/include -I$(SGX_SDK)/include/tlibc -I$(SGX_SDK)/include/stlport
+
+ifeq ($(HAVE_WOLFSSL_TEST), 1)
+	Wolfssl_Include_Paths += -I$(WOLFSSL_ROOT)/wolfcrypt/test
+	Wolfssl_C_Files += $(WOLFSSL_ROOT)/wolfcrypt/test/test.c
+endif
+
+ifeq ($(HAVE_WOLFSSL_BENCHMARK), 1)
+	Wolfssl_C_Files += $(WOLFSSL_ROOT)/wolfcrypt/benchmark/benchmark.c
+	Wolfssl_Include_Paths += -I$(WOLFSSL_ROOT)/wolfcrypt/benchmark/
+endif
+
+ifeq ($(HAVE_FIPS_LINUX_HARNESS), 1)
+    Wolfssl_C_Extra_Flags += -DNO_CAVP_AESECB
+    Wolfssl_C_Extra_Flags += -DNO_CAVP_CMAC
+    Wolfssl_C_Extra_Flags += -DNO_CAVP_ECDSA
+    Wolfssl_C_Extra_Flags += -DNO_WOLFCAVP_MAIN_DRIVER
+#    Wolfssl_C_Files += $(WOLFSSL_ROOT)/fips/harness/driver.c
+    Wolfssl_C_Files += $(WOLFSSL_ROOT)/fips/harness/cavp_aes.c
+    Wolfssl_C_Files += $(WOLFSSL_ROOT)/fips/harness/cavp_aesgcm.c
+    Wolfssl_C_Files += $(WOLFSSL_ROOT)/fips/harness/cavp_cmac.c
+    Wolfssl_C_Files += $(WOLFSSL_ROOT)/fips/harness/cavp_common.c
+    Wolfssl_C_Files += $(WOLFSSL_ROOT)/fips/harness/cavp_des3.c
+    Wolfssl_C_Files += $(WOLFSSL_ROOT)/fips/harness/cavp_drbg.c
+    Wolfssl_C_Files += $(WOLFSSL_ROOT)/fips/harness/cavp_hmac.c
+    Wolfssl_C_Files += $(WOLFSSL_ROOT)/fips/harness/cavp_rsa.c
+    Wolfssl_C_Files += $(WOLFSSL_ROOT)/fips/harness/cavp_sha.c
+    Wolfssl_Include_Paths += -I$(WOLFSSL_ROOT)/fips/harness
+endif
+
+Flags_Just_For_C := -Wno-implicit-function-declaration -std=c11
+Common_C_Cpp_Flags := $(SGX_COMMON_CFLAGS) -nostdinc -fvisibility=hidden -fpie -fstack-protector $(Wolfssl_Include_Paths) -fno-builtin-printf -I.
+Wolfssl_C_Flags := $(Flags_Just_For_C) $(Common_C_Cpp_Flags) $(Wolfssl_C_Extra_Flags)
+
+Wolfssl_Link_Flags := $(SGX_COMMON_CFLAGS) -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -L$(SGX_LIBRARY_PATH) \
+	-Wl,--whole-archive -l$(Trts_Library_Name) -Wl,--no-whole-archive \
+	-Wl,--start-group -lsgx_tstdc -lsgx_tstdcxx -l$(Crypto_Library_Name) -l$(Service_Library_Name) -Wl,--end-group \
+	-Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined \
+	-Wl,-pie,-eenclave_entry -Wl,--export-dynamic  \
+	-Wl,--defsym,__ImageBase=0 \
+	-Wl,--version-script=trusted/wolfcrypt.lds
+
+Wolfssl_C_Objects := $(Wolfssl_C_Files:.c=.o)
+
+ifeq ($(SGX_MODE), HW)
+ifneq ($(SGX_DEBUG), 1)
+ifneq ($(SGX_PRERELEASE), 1)
+Build_Mode = HW_RELEASE
+endif
+endif
+endif
+
+override CFLAGS += $(Wolfssl_C_Flags)
+
+.PHONY: all run
+
+all: libwolfssl.fips.sgx.static.lib.a
+
+######## WolfSSL Objects ########
+
+libwolfssl.fips.sgx.static.lib.a: $(Wolfssl_C_Objects)
+	ar rcs libwolfssl.fips.sgx.static.lib.a $(Wolfssl_C_Objects)
+	@echo "LINK =>  $@"
+
+clean:
+	@rm -f ../../wolfcrypt/benchmark/*.o ../../wolfcrypt/test/*.o wolfcrypt.* static_trusted/wolfssl_t.* libwolfssl.fips.sgx.static.lib.a  $(Wolfssl_C_Objects) ../../fips/SGX/Linux-harness/enclave-agent/*.o ../../fips/harness/*.o


### PR DESCRIPTION
First PR post FIPS-SGX effort. This PR adds a new makefile specifically for building the wolfcrypt test, benchmark, and cavp source files in the enclave.

Other related PR's to be pushed in the near future will cover:

FIPS SGX untrusted application for processing the vectors on LINUX

New Visual studio solution for WINDOWS to build the benchmark, test app and cavp sources in an enclave.
FIPS SGX untrusted application for processing the vectors on WINDOWS
