### PR TITLE
add dh header to test.h and adjust macro guards

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -23864,29 +23864,6 @@ void* wolfSSL_GetEccSharedSecretCtx(WOLFSSL* ssl)
 }
 #endif /* HAVE_ECC */
 
-#ifndef NO_DH
-
-void wolfSSL_CTX_SetDhAgreeCb(WOLFSSL_CTX* ctx, CallbackDhAgree cb)
-{
-    if (ctx)
-        ctx->DhAgreeCb = cb;
-}
-
-void wolfSSL_SetDhAgreeCtx(WOLFSSL* ssl, void *ctx)
-{
-    if (ssl)
-        ssl->DhAgreeCtx = ctx;
-}
-
-void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
-{
-    if (ssl)
-        return ssl->DhAgreeCtx;
-
-    return NULL;
-}
-#endif /* !NO_DH */
-
 #ifdef HAVE_ED25519
 void  wolfSSL_CTX_SetEd25519SignCb(WOLFSSL_CTX* ctx, CallbackEd25519Sign cb)
 {
@@ -24101,6 +24078,29 @@ void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl)
 
 #endif /* HAVE_PK_CALLBACKS */
 #endif /* NO_CERTS */
+
+#if defined(HAVE_PK_CALLBACKS) && !defined(NO_DH)
+
+void wolfSSL_CTX_SetDhAgreeCb(WOLFSSL_CTX* ctx, CallbackDhAgree cb)
+{
+    if (ctx)
+        ctx->DhAgreeCb = cb;
+}
+
+void wolfSSL_SetDhAgreeCtx(WOLFSSL* ssl, void *ctx)
+{
+    if (ssl)
+        ssl->DhAgreeCtx = ctx;
+}
+
+void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
+{
+    if (ssl)
+        return ssl->DhAgreeCtx;
+
+    return NULL;
+}
+#endif /* HAVE_PK_CALLBACKS && !NO_DH */
 
 
 #ifdef WOLFSSL_HAVE_WOLFSCEP

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -24,6 +24,9 @@
     #ifdef HAVE_ECC
         #include <wolfssl/wolfcrypt/ecc.h>
     #endif /* HAVE_ECC */
+    #ifndef NO_DH
+        #include <wolfssl/wolfcrypt/dh.h>
+    #endif /* !NO_DH */
     #ifdef HAVE_ED25519
         #include <wolfssl/wolfcrypt/ed25519.h>
     #endif /* HAVE_ED25519 */


### PR DESCRIPTION
Fix for the configure option

```
./configure C_EXTRA_FLAGS="-fdebug-types-section -g1" --enable-jobserver=4 --enable-pkcallbacks --disable-asn --disable-ecc --disable-rsa --enable-psk 
```