### PR TITLE
Minor fixes and cleanups for hash digest/block size

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -684,7 +684,7 @@ static int ImportKeyState(WOLFSSL* ssl, byte* exp, word32 len, byte ver)
     idx++; /* no truncated hmac */
 #endif
     sz = exp[idx++];
-    if (sz > MAX_DIGEST_SIZE || sz + idx > len) {
+    if (sz > WC_MAX_DIGEST_SIZE || sz + idx > len) {
         return BUFFER_E;
     }
     XMEMCPY(keys->client_write_MAC_secret, exp + idx, sz); idx += sz;
@@ -11416,7 +11416,7 @@ static INLINE int GetRounds(int pLen, int padLen, int t)
 static int TimingPadVerify(WOLFSSL* ssl, const byte* input, int padLen, int t,
                            int pLen, int content)
 {
-    byte verify[MAX_DIGEST_SIZE];
+    byte verify[WC_MAX_DIGEST_SIZE];
     byte dmy[sizeof(WOLFSSL) >= MAX_PAD_SIZE ? 1 : MAX_PAD_SIZE] = {0};
     byte* dummy = sizeof(dmy) < MAX_PAD_SIZE ? (byte*) ssl : dmy;
     int  ret = 0;
@@ -11679,7 +11679,7 @@ static INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
 #else
     word32 digestSz = ssl->specs.hash_size;
 #endif
-    byte   verify[MAX_DIGEST_SIZE];
+    byte   verify[WC_MAX_DIGEST_SIZE];
 
     if (ssl->specs.cipher_type == block) {
         if (ssl->options.tls1_1)
@@ -12370,7 +12370,7 @@ int SendChangeCipher(WOLFSSL* ssl)
 static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
                  int content, int verify)
 {
-    byte   result[MAX_DIGEST_SIZE];
+    byte   result[WC_MAX_DIGEST_SIZE];
     word32 digestSz = ssl->specs.hash_size;            /* actual sizes */
     word32 padSz    = ssl->specs.pad_size;
     int    ret      = 0;
@@ -12838,11 +12838,11 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
             #ifdef WOLFSSL_SMALL_STACK
                 byte* hmac = NULL;
             #else
-                byte  hmac[MAX_DIGEST_SIZE];
+                byte  hmac[WC_MAX_DIGEST_SIZE];
             #endif
 
             #ifdef WOLFSSL_SMALL_STACK
-                hmac = (byte*)XMALLOC(MAX_DIGEST_SIZE, ssl->heap,
+                hmac = (byte*)XMALLOC(WC_MAX_DIGEST_SIZE, ssl->heap,
                                                        DYNAMIC_TYPE_DIGEST);
                 if (hmac == NULL)
                     ERROR_OUT(MEMORY_E, exit_buildmsg);

--- a/src/keys.c
+++ b/src/keys.c
@@ -2985,14 +2985,14 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
 
         if (clientCopy) {
             XMEMCPY(ssl->keys.client_write_MAC_secret,
-                    keys->client_write_MAC_secret, MAX_DIGEST_SIZE);
+                    keys->client_write_MAC_secret, WC_MAX_DIGEST_SIZE);
             XMEMCPY(ssl->keys.client_write_key,
                     keys->client_write_key, AES_256_KEY_SIZE);
             XMEMCPY(ssl->keys.client_write_IV,
                     keys->client_write_IV, MAX_WRITE_IV_SZ);
         } else {
             XMEMCPY(ssl->keys.server_write_MAC_secret,
-                    keys->server_write_MAC_secret, MAX_DIGEST_SIZE);
+                    keys->server_write_MAC_secret, WC_MAX_DIGEST_SIZE);
             XMEMCPY(ssl->keys.server_write_key,
                     keys->server_write_key, AES_256_KEY_SIZE);
             XMEMCPY(ssl->keys.server_write_IV,

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -9658,7 +9658,7 @@ int wolfSSL_Cleanup(void)
 /* some session IDs aren't random after all, let's make them random */
 static INLINE word32 HashSession(const byte* sessionID, word32 len, int* error)
 {
-    byte digest[MAX_DIGEST_SIZE];
+    byte digest[WC_MAX_DIGEST_SIZE];
 
 #ifndef NO_MD5
     *error =  wc_Md5Hash(sessionID, len, digest);
@@ -27992,7 +27992,7 @@ static int wolfSSL_TicketKeyCb(WOLFSSL* ssl,
                                   int enc, unsigned char* encTicket,
                                   int encTicketLen, int* encLen, void* ctx)
 {
-    byte                    digest[MAX_DIGEST_SIZE];
+    byte                    digest[WC_MAX_DIGEST_SIZE];
     WOLFSSL_EVP_CIPHER_CTX  evpCtx;
     WOLFSSL_HMAC_CTX        hmacCtx;
     unsigned int            mdSz = 0;

--- a/src/tls.c
+++ b/src/tls.c
@@ -6422,7 +6422,7 @@ static int TLSX_PreSharedKey_Parse(WOLFSSL* ssl, byte* input, word16 length,
             /* Length of binder */
             list->binderLen = input[idx++];
             if (list->binderLen < WC_SHA256_DIGEST_SIZE ||
-                    list->binderLen > MAX_DIGEST_SIZE)
+                    list->binderLen > WC_MAX_DIGEST_SIZE)
                 return BUFFER_E;
             if (len < OPAQUE8_LEN + list->binderLen)
                 return BUFFER_E;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -257,7 +257,7 @@ static int DeriveKeyMsg(WOLFSSL* ssl, byte* output, int outputLen,
                         const byte* secret, const byte* label, word32 labelLen,
                         byte* msg, int msgLen, int hashAlgo)
 {
-    byte        hash[MAX_DIGEST_SIZE];
+    byte        hash[WC_MAX_DIGEST_SIZE];
     Digest      digest;
     word32      hashSz = 0;
     const byte* protocol;
@@ -345,7 +345,7 @@ static int DeriveKey(WOLFSSL* ssl, byte* output, int outputLen,
                      int hashAlgo, int includeMsgs)
 {
     int         ret = 0;
-    byte        hash[MAX_DIGEST_SIZE];
+    byte        hash[WC_MAX_DIGEST_SIZE];
     word32      hashSz = 0;
     word32      hashOutSz = 0;
     const byte* protocol;
@@ -2153,7 +2153,7 @@ static int WritePSKBinders(WOLFSSL* ssl, byte* output, word32 idx)
     int           ret;
     TLSX*         ext;
     PreSharedKey* current;
-    byte          binderKey[MAX_DIGEST_SIZE];
+    byte          binderKey[WC_MAX_DIGEST_SIZE];
     word16        len;
 
     ext = TLSX_Find(ssl->extensions, TLSX_PRE_SHARED_KEY);
@@ -2378,7 +2378,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
 static int CreateCookie(WOLFSSL* ssl, byte* hash, byte hashSz)
 {
     int  ret;
-    byte mac[MAX_DIGEST_SIZE];
+    byte mac[WC_MAX_DIGEST_SIZE];
     Hmac cookieHmac;
     byte cookieType;
     byte macSz;
@@ -2448,7 +2448,7 @@ static int RestartHandshakeHash(WOLFSSL* ssl)
 
 #ifdef WOLFSSL_SEND_HRR_COOKIE
     if (ssl->options.sendCookie) {
-        byte   cookie[OPAQUE8_LEN + MAX_DIGEST_SIZE + OPAQUE16_LEN * 2];
+        byte   cookie[OPAQUE8_LEN + WC_MAX_DIGEST_SIZE + OPAQUE16_LEN * 2];
         TLSX*  ext;
         word32 idx = 0;
 
@@ -2898,8 +2898,8 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
     TLSX*         ext;
     word16        bindersLen;
     PreSharedKey* current;
-    byte          binderKey[MAX_DIGEST_SIZE];
-    byte          binder[MAX_DIGEST_SIZE];
+    byte          binderKey[WC_MAX_DIGEST_SIZE];
+    byte          binder[WC_MAX_DIGEST_SIZE];
     word32        binderLen;
     word16        modes;
 #ifdef WOLFSSL_EARLY_DATA
@@ -3131,7 +3131,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
 static int CheckCookie(WOLFSSL* ssl, byte* cookie, byte cookieSz)
 {
     int  ret;
-    byte mac[MAX_DIGEST_SIZE];
+    byte mac[WC_MAX_DIGEST_SIZE];
     Hmac cookieHmac;
     byte cookieType;
     byte macSz;
@@ -3971,7 +3971,7 @@ static const byte clientCertVfyLabel[CERT_VFY_LABEL_SZ] =
 /* Maximum length of the signature data. */
 #define MAX_SIG_DATA_SZ            (SIGNING_DATA_PREFIX_SZ + \
                                     CERT_VFY_LABEL_SZ      + \
-                                    MAX_DIGEST_SIZE)
+                                    WC_MAX_DIGEST_SIZE)
 
 /* Create the signature data for TLS v1.3 certificate verification.
  *
@@ -5166,7 +5166,7 @@ static int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     int    ret;
     word32 finishedSz = 0;
     byte*  secret;
-    byte   mac[MAX_DIGEST_SIZE];
+    byte   mac[WC_MAX_DIGEST_SIZE];
 
     WOLFSSL_ENTER("DoTls13Finished");
 
@@ -5264,7 +5264,7 @@ static int SendTls13Finished(WOLFSSL* ssl)
 
     WOLFSSL_ENTER("SendTls13Finished");
 
-    outputSz = MAX_DIGEST_SIZE + DTLS_HANDSHAKE_HEADER_SZ + MAX_MSG_EXTRA;
+    outputSz = WC_MAX_DIGEST_SIZE + DTLS_HANDSHAKE_HEADER_SZ + MAX_MSG_EXTRA;
     /* Check buffers are big enough and grow if needed. */
     if ((ret = CheckAvailableSize(ssl, outputSz)) != 0)
         return ret;
@@ -5744,7 +5744,7 @@ static int ExpectedResumptionSecret(WOLFSSL* ssl)
 {
     int         ret;
     word32      finishedSz = 0;
-    byte        mac[MAX_DIGEST_SIZE];
+    byte        mac[WC_MAX_DIGEST_SIZE];
     Digest      digest;
     static byte header[] = { 0x14, 0x00, 0x00, 0x00 };
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -11045,11 +11045,11 @@ static int test_wc_DsaExportKeyRaw (void)
 static int test_wc_ed25519_make_key (void)
 {
     int ret = 0;
-        
+
 #if defined(HAVE_ED25519)
     ed25519_key     key;
     WC_RNG          rng;
-        
+
     ret = wc_InitRng(&rng);
     if (ret == 0) {
         ret = wc_ed25519_init(&key);
@@ -15022,7 +15022,7 @@ static void test_wolfSSL_ASN1_TIME_adj(void)
     AssertTrue(asn_time->data[0] == asn_gen_time);
     XSTRNCPY(date_str,(const char*) &asn_time->data+2, 15);
     AssertIntEQ(0, XMEMCMP(date_str, "20550313091000Z", 15));
-    
+
     XFREE(s,NULL,DYNAMIC_TYPE_OPENSSL);
     XMEMSET(date_str, 0, sizeof(date_str));
 #endif /* !TIME_T_NOT_LONG && !NO_64BIT */
@@ -15230,7 +15230,7 @@ static void test_wolfSSL_HMAC(void)
     HMAC_CTX hmac;
     ENGINE* e = NULL;
     const unsigned char key[] = "simple test key";
-    unsigned char hash[MAX_DIGEST_SIZE];
+    unsigned char hash[WC_MAX_DIGEST_SIZE];
     unsigned int len;
 
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -394,7 +394,9 @@ static const bench_alg bench_other_opt[] = {
 #endif
     { NULL, 0}
 };
-#endif
+
+#endif /* !WOLFSSL_BENCHMARK_ALL && !NO_MAIN_DRIVER */
+
 
 #ifdef HAVE_WNR
     const char* wnrConfigFile = "wnr-example.conf";
@@ -1424,6 +1426,12 @@ exit:
 #ifdef WOLFSSL_ASYNC_CRYPT
     wolfAsync_DevClose(&devId);
 #endif
+
+    (void)bench_cipher_algs;
+    (void)bench_digest_algs;
+    (void)bench_mac_algs;
+    (void)bench_asym_algs;
+    (void)bench_other_algs;
 
     return NULL;
 }
@@ -3336,7 +3344,7 @@ static void bench_hmac(int doAsync, int type, int digestSz,
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
 #if defined(BENCH_EMBEDDED)
-    DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING, MAX_DIGEST_SIZE, HEAP_HINT);
+    DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING, WC_MAX_DIGEST_SIZE, HEAP_HINT);
     (void)digestSz;
 #else
     DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING, digestSz, HEAP_HINT);

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -921,7 +921,7 @@ WOLFSSL_API int wolfSSL_EVP_SignFinal(WOLFSSL_EVP_MD_CTX *ctx, unsigned char *si
                   unsigned int *siglen, WOLFSSL_EVP_PKEY *pkey)
 {
     unsigned int mdsize;
-    unsigned char md[MAX_DIGEST_SIZE];
+    unsigned char md[WC_MAX_DIGEST_SIZE];
     int ret;
     if (ctx == NULL) return WOLFSSL_FAILURE;
     WOLFSSL_ENTER("EVP_SignFinal");
@@ -997,7 +997,7 @@ WOLFSSL_API int wolfSSL_EVP_VerifyFinal(WOLFSSL_EVP_MD_CTX *ctx,
         unsigned char*sig, unsigned int siglen, WOLFSSL_EVP_PKEY *pkey)
 {
     int ret;
-    unsigned char md[MAX_DIGEST_SIZE];
+    unsigned char md[WC_MAX_DIGEST_SIZE];
     unsigned int mdsize;
 
     if (ctx == NULL) return WOLFSSL_FAILURE;
@@ -1165,7 +1165,7 @@ int wolfSSL_EVP_DigestSignUpdate(WOLFSSL_EVP_MD_CTX *ctx,
 int wolfSSL_EVP_DigestSignFinal(WOLFSSL_EVP_MD_CTX *ctx,
                                 unsigned char *sig, size_t *siglen)
 {
-    unsigned char digest[MAX_DIGEST_SIZE];
+    unsigned char digest[WC_MAX_DIGEST_SIZE];
     Hmac hmacCopy;
     int hashLen, ret;
 

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -251,7 +251,7 @@ int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_HMAC)
     if (hmac->asyncDev.marker == WOLFSSL_ASYNC_MARKER_HMAC) {
     #if defined(HAVE_CAVIUM)
-        if (length > HMAC_BLOCK_SIZE) {
+        if (length > WC_HMAC_BLOCK_SIZE) {
             return WC_KEY_SIZE_E;
         }
 
@@ -807,7 +807,7 @@ void wc_HmacFree(Hmac* hmac)
 
 int wolfSSL_GetHmacMaxSize(void)
 {
-    return MAX_DIGEST_SIZE;
+    return WC_MAX_DIGEST_SIZE;
 }
 
 #ifdef HAVE_HKDF
@@ -825,7 +825,7 @@ int wolfSSL_GetHmacMaxSize(void)
     int wc_HKDF_Extract(int type, const byte* salt, word32 saltSz,
                         const byte* inKey, word32 inKeySz, byte* out)
     {
-        byte   tmp[MAX_DIGEST_SIZE]; /* localSalt helper */
+        byte   tmp[WC_MAX_DIGEST_SIZE]; /* localSalt helper */
         Hmac   myHmac;
         int    ret;
         const  byte* localSalt;  /* either points to user input or tmp */
@@ -870,7 +870,7 @@ int wolfSSL_GetHmacMaxSize(void)
     int wc_HKDF_Expand(int type, const byte* inKey, word32 inKeySz,
                        const byte* info, word32 infoSz, byte* out, word32 outSz)
     {
-        byte   tmp[MAX_DIGEST_SIZE];
+        byte   tmp[WC_MAX_DIGEST_SIZE];
         Hmac   myHmac;
         int    ret = 0;
         word32 outIdx = 0;
@@ -931,7 +931,7 @@ int wolfSSL_GetHmacMaxSize(void)
                        const byte* info,  word32 infoSz,
                        byte* out,         word32 outSz)
     {
-        byte   prk[MAX_DIGEST_SIZE];
+        byte   prk[WC_MAX_DIGEST_SIZE];
         int    hashSz = wc_HmacSizeByType(type);
         int    ret;
 

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -575,7 +575,7 @@ static int wc_PKCS12_verify(WC_PKCS12* pkcs12, byte* data, word32 dataSz,
 {
     MacData* mac;
     int ret;
-    byte digest[MAX_DIGEST_SIZE];
+    byte digest[WC_MAX_DIGEST_SIZE];
 
     if (pkcs12 == NULL || pkcs12->signData == NULL || data == NULL) {
         return BAD_FUNC_ARG;
@@ -588,13 +588,13 @@ static int wc_PKCS12_verify(WC_PKCS12* pkcs12, byte* data, word32 dataSz,
 #endif
 
     /* check if this builds digest size is too small */
-    if (mac->digestSz > MAX_DIGEST_SIZE) {
+    if (mac->digestSz > WC_MAX_DIGEST_SIZE) {
         WOLFSSL_MSG("PKCS12 max digest size too small");
         return BAD_FUNC_ARG;
     }
 
     if ((ret = wc_PKCS12_create_mac(pkcs12, data, dataSz, psw, pswSz,
-            digest, MAX_DIGEST_SIZE)) < 0) {
+            digest, WC_MAX_DIGEST_SIZE)) < 0) {
         return ret;
     }
 
@@ -1969,7 +1969,7 @@ WC_PKCS12* wc_PKCS12_create(char* pass, word32 passSz, char* name,
     /* create MAC */
     if (macIter > 0) {
         MacData* mac;
-        byte digest[MAX_DIGEST_SIZE]; /* for MAC */
+        byte digest[WC_MAX_DIGEST_SIZE]; /* for MAC */
 
         mac = (MacData*)XMALLOC(sizeof(MacData), heap, DYNAMIC_TYPE_PKCS);
         if (mac == NULL) {
@@ -2019,7 +2019,7 @@ WC_PKCS12* wc_PKCS12_create(char* pass, word32 passSz, char* name,
             return NULL;
         }
         ret = wc_PKCS12_create_mac(pkcs12, safe->data, safe->dataSz,
-                         (const byte*)pass, passSz, digest, MAX_DIGEST_SIZE);
+                         (const byte*)pass, passSz, digest, WC_MAX_DIGEST_SIZE);
         if (ret < 0) {
             wc_PKCS12_free(pkcs12);
             wc_FreeRng(&rng);

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -171,7 +171,7 @@ int wc_PBKDF2(byte* output, const byte* passwd, int pLen, const byte* salt,
 #ifdef WOLFSSL_SMALL_STACK
     byte*  buffer;
 #else
-    byte   buffer[MAX_DIGEST_SIZE];
+    byte   buffer[WC_MAX_DIGEST_SIZE];
 #endif
 
     hLen = GetDigestSize(hashType);
@@ -179,7 +179,7 @@ int wc_PBKDF2(byte* output, const byte* passwd, int pLen, const byte* salt,
         return BAD_FUNC_ARG;
 
 #ifdef WOLFSSL_SMALL_STACK
-    buffer = (byte*)XMALLOC(MAX_DIGEST_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    buffer = (byte*)XMALLOC(WC_MAX_DIGEST_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (buffer == NULL)
         return MEMORY_E;
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2470,7 +2470,7 @@ int hash_test(void)
     int              ret, exp_ret;
     int              i, j;
     byte             data[] = "0123456789abcdef0123456789abcdef012345";
-    byte             out[MAX_DIGEST_SIZE];
+    byte             out[WC_MAX_DIGEST_SIZE];
     enum wc_HashType typesGood[] = { WC_HASH_TYPE_MD5, WC_HASH_TYPE_SHA,
                                      WC_HASH_TYPE_SHA224, WC_HASH_TYPE_SHA256,
                                      WC_HASH_TYPE_SHA384, WC_HASH_TYPE_SHA512 };
@@ -2960,7 +2960,7 @@ int hmac_sha256_test(void)
     if (wc_HmacSizeByType(20) != BAD_FUNC_ARG)
         return -2815;
 #endif
-    if (wolfSSL_GetHmacMaxSize() != MAX_DIGEST_SIZE)
+    if (wolfSSL_GetHmacMaxSize() != WC_MAX_DIGEST_SIZE)
         return -2816;
 
     return 0;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -973,7 +973,7 @@ enum Misc {
     SIZEOF_SENDER   =  4,       /* clnt or srvr           */
     FINISHED_SZ     = 36,       /* WC_MD5_DIGEST_SIZE + WC_SHA_DIGEST_SIZE */
     MAX_RECORD_SIZE = 16384,    /* 2^14, max size by standard */
-    MAX_MSG_EXTRA   = 38 + MAX_DIGEST_SIZE,
+    MAX_MSG_EXTRA   = 38 + WC_MAX_DIGEST_SIZE,
                                 /* max added to msg, mac + pad  from */
                                 /* RECORD_HEADER_SZ + BLOCK_SZ (pad) + Max
                                    digest sz + BLOC_SZ (iv) + pad byte (1) */
@@ -1070,7 +1070,7 @@ enum Misc {
     MAX_LABEL_SZ        = 34,  /* Maximum length of a label */
     MAX_HKDF_LABEL_SZ   = OPAQUE16_LEN +
                           OPAQUE8_LEN + PROTOCOL_LABEL_SZ + MAX_LABEL_SZ +
-                          OPAQUE8_LEN + MAX_DIGEST_SIZE,
+                          OPAQUE8_LEN + WC_MAX_DIGEST_SIZE,
     MAX_REQUEST_SZ      = 256, /* Maximum cert req len (no auth yet */
     SESSION_FLUSH_COUNT = 256, /* Flush session cache unless user turns off */
 
@@ -1762,8 +1762,8 @@ typedef struct WOLFSSL_DTLS_PEERSEQ {
 /* keys and secrets
  * keep as a constant size (no additional ifdefs) for session export */
 typedef struct Keys {
-    byte client_write_MAC_secret[MAX_DIGEST_SIZE];   /* max sizes */
-    byte server_write_MAC_secret[MAX_DIGEST_SIZE];
+    byte client_write_MAC_secret[WC_MAX_DIGEST_SIZE];   /* max sizes */
+    byte server_write_MAC_secret[WC_MAX_DIGEST_SIZE];
     byte client_write_key[AES_256_KEY_SIZE];         /* max sizes */
     byte server_write_key[AES_256_KEY_SIZE];
     byte client_write_IV[MAX_WRITE_IV_SZ];               /* max sizes */
@@ -2166,7 +2166,7 @@ typedef struct PreSharedKey {
     byte                 cipherSuite0;            /* Cipher Suite       */
     byte                 cipherSuite;             /* Cipher Suite       */
     word32               binderLen;               /* Length of HMAC     */
-    byte                 binder[MAX_DIGEST_SIZE]; /* HMAC of hanshake   */
+    byte                 binder[WC_MAX_DIGEST_SIZE]; /* HMAC of hanshake   */
     byte                 hmac;                    /* HMAC algorithm     */
     byte                 resumption:1;            /* Resumption PSK     */
     byte                 chosen:1;                /* Server's choice    */

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1641,7 +1641,7 @@ static INLINE int myDecryptVerifyCb(WOLFSSL* ssl,
     unsigned int padByte = 0;
     Hmac hmac;
     byte myInner[WOLFSSL_TLS_HMAC_INNER_SZ];
-    byte verify[MAX_DIGEST_SIZE];
+    byte verify[WC_MAX_DIGEST_SIZE];
     const char* tlsStr = "TLS";
 
     /* example supports (d)tls aes */

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -37,10 +37,18 @@
 #if defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)
     #include <wolfssl/wolfcrypt/sha512.h>
 #endif
+#ifdef HAVE_BLAKE2
+    #include <wolfssl/wolfcrypt/blake2.h>
+#endif
 
 #ifdef __cplusplus
     extern "C" {
 #endif
+
+#ifndef NO_OLD_WC_NAMES
+    #define MAX_DIGEST_SIZE WC_MAX_DIGEST_SIZE
+#endif
+
 
 /* Hash types */
 enum wc_HashType {
@@ -81,6 +89,8 @@ typedef union {
    Note if this gets up to the size of 80 or over check smallstack build */
 #if defined(WOLFSSL_SHA512)
     #define WC_MAX_DIGEST_SIZE WC_SHA512_DIGEST_SIZE
+#elif defined(HAVE_BLAKE2)
+    #define WC_MAX_DIGEST_SIZE BLAKE2B_OUTBYTES
 #elif defined(WOLFSSL_SHA384)
     #define WC_MAX_DIGEST_SIZE WC_SHA384_DIGEST_SIZE
 #elif !defined(NO_SHA256)

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -45,7 +45,7 @@
     extern "C" {
 #endif
 
-#ifndef NO_OLD_WC_NAMES
+#if !defined(HAVE_FIPS) && !defined(NO_OLD_WC_NAMES)
     #define MAX_DIGEST_SIZE WC_MAX_DIGEST_SIZE
 #endif
 

--- a/wolfssl/wolfcrypt/hmac.h
+++ b/wolfssl/wolfcrypt/hmac.h
@@ -26,27 +26,7 @@
 #ifndef WOLF_CRYPT_HMAC_H
 #define WOLF_CRYPT_HMAC_H
 
-#include <wolfssl/wolfcrypt/types.h>
-
-#ifndef NO_MD5
-    #include <wolfssl/wolfcrypt/md5.h>
-#endif
-
-#ifndef NO_SHA
-    #include <wolfssl/wolfcrypt/sha.h>
-#endif
-
-#if !defined(NO_SHA256) || defined(WOLFSSL_SHA224)
-    #include <wolfssl/wolfcrypt/sha256.h>
-#endif
-
-#ifdef WOLFSSL_SHA512
-    #include <wolfssl/wolfcrypt/sha512.h>
-#endif
-
-#ifdef HAVE_BLAKE2
-    #include <wolfssl/wolfcrypt/blake2.h>
-#endif
+#include <wolfssl/wolfcrypt/hash.h>
 
 #ifdef HAVE_FIPS
 /* for fips */
@@ -61,6 +41,10 @@
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     #include <wolfssl/wolfcrypt/async.h>
+#endif
+
+#ifndef NO_OLD_WC_NAMES
+    #define HMAC_BLOCK_SIZE WC_HMAC_BLOCK_SIZE
 #endif
 
 enum {
@@ -95,26 +79,19 @@ enum {
 
 /* Select the largest available hash for the buffer size. */
 #if defined(WOLFSSL_SHA512)
-    MAX_DIGEST_SIZE = WC_SHA512_DIGEST_SIZE,
-    HMAC_BLOCK_SIZE = WC_SHA512_BLOCK_SIZE,
+    WC_HMAC_BLOCK_SIZE = WC_SHA512_BLOCK_SIZE,
 #elif defined(HAVE_BLAKE2)
-    MAX_DIGEST_SIZE = BLAKE2B_OUTBYTES,
-    HMAC_BLOCK_SIZE = BLAKE2B_BLOCKBYTES,
+    WC_HMAC_BLOCK_SIZE = BLAKE2B_BLOCKBYTES,
 #elif defined(WOLFSSL_SHA384)
-    MAX_DIGEST_SIZE = WC_SHA384_DIGEST_SIZE,
-    HMAC_BLOCK_SIZE = WC_SHA384_BLOCK_SIZE
+    WC_HMAC_BLOCK_SIZE = WC_SHA384_BLOCK_SIZE
 #elif !defined(NO_SHA256)
-    MAX_DIGEST_SIZE = WC_SHA256_DIGEST_SIZE,
-    HMAC_BLOCK_SIZE = WC_SHA256_BLOCK_SIZE
+    WC_HMAC_BLOCK_SIZE = WC_SHA256_BLOCK_SIZE
 #elif defined(WOLFSSL_SHA224)
-    MAX_DIGEST_SIZE = WC_SHA224_DIGEST_SIZE,
-    HMAC_BLOCK_SIZE = WC_SHA224_BLOCK_SIZE
+    WC_HMAC_BLOCK_SIZE = WC_SHA224_BLOCK_SIZE
 #elif !defined(NO_SHA)
-    MAX_DIGEST_SIZE = WC_SHA_DIGEST_SIZE,
-    HMAC_BLOCK_SIZE = WC_SHA_BLOCK_SIZE,
+    WC_HMAC_BLOCK_SIZE = WC_SHA_BLOCK_SIZE,
 #elif !defined(NO_MD5)
-    MAX_DIGEST_SIZE = WC_MD5_DIGEST_SIZE,
-    HMAC_BLOCK_SIZE = WC_MD5_BLOCK_SIZE,
+    WC_HMAC_BLOCK_SIZE = WC_MD5_BLOCK_SIZE,
 #else
     #error "You have to have some kind of hash if you want to use HMAC."
 #endif
@@ -149,9 +126,9 @@ typedef union {
 /* Hmac digest */
 typedef struct Hmac {
     Hash    hash;
-    word32  ipad[HMAC_BLOCK_SIZE  / sizeof(word32)];  /* same block size all*/
-    word32  opad[HMAC_BLOCK_SIZE  / sizeof(word32)];
-    word32  innerHash[MAX_DIGEST_SIZE / sizeof(word32)];
+    word32  ipad[WC_HMAC_BLOCK_SIZE  / sizeof(word32)];  /* same block size all*/
+    word32  opad[WC_HMAC_BLOCK_SIZE  / sizeof(word32)];
+    word32  innerHash[WC_MAX_DIGEST_SIZE / sizeof(word32)];
     void*   heap;                 /* heap hint */
     byte    macType;              /* md5 sha or sha256 */
     byte    innerHashKeyed;       /* keyed flag */


### PR DESCRIPTION
Found these when building the NRF5x example package.

* Fix build warning in benchmark.c with unused variable if features are disabled.
* Cleanup to remove duplicate MAX_DIGEST_SIZE in hmac.h and refactor to use WC_MAX_DIGEST_SIZE.
* Cleanup for HMAC to include hash.h and refactor HMAC_BLOCK_SIZE to WC_HMAC_BLOCK_SIZE.