### PR TITLE
RSA Key Generation Test Fix

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2456,7 +2456,12 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
             if (err == MP_OKAY)
                 err = wc_CheckProbablePrime_ex(&p, NULL, &tmp3, size, &isPrime);
 
+#ifdef WOLFSSL_FIPS
             i++;
+#else
+            /* Keep the old retry behavior in non-FIPS build. */
+            (void)i;
+#endif
         } while (err == MP_OKAY && !isPrime && i < failCount);
     }
 
@@ -2487,7 +2492,12 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
             if (err == MP_OKAY)
                 err = wc_CheckProbablePrime_ex(&p, &q, &tmp3, size, &isPrime);
 
+#ifdef WOLFSSL_FIPS
             i++;
+#else
+            /* Keep the old retry behavior in non-FIPS build. */
+            (void)i;
+#endif
         } while (err == MP_OKAY && !isPrime && i < failCount);
     }
 


### PR DESCRIPTION
A recent change to the RSA key generation process is capping the number of attempts of finding a probable prime to a multiple of the prime's size. This means it might fail once in a while. (It could also fail for a couple other reasons but this is the most likely.) The API is changed to retry key generation until it succeeds.