### PR TITLE
Added `WOLFSSL_IGNORE_FILE_WARN` option

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -20,7 +20,9 @@
  */
 
 #if !defined(WOLFSSL_BIO_INCLUDED)
-    #warning bio.c does not need to be compiled seperatly from ssl.c
+    #ifndef WOLFSSL_IGNORE_FILE_WARN
+        #warning bio.c does not need to be compiled seperatly from ssl.c
+    #endif
 #else
 
 /*** TBD ***/

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -20,7 +20,9 @@
  */
 
 #if !defined(WOLFSSL_EVP_INCLUDED)
-    #warning evp.c does not need to be compiled seperatly from ssl.c
+    #ifndef WOLFSSL_IGNORE_FILE_WARN
+        #warning evp.c does not need to be compiled seperatly from ssl.c
+    #endif
 #else
 
 static unsigned int cipherType(const WOLFSSL_EVP_CIPHER *cipher);

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -46,7 +46,9 @@
 
 /* Check for if compiling misc.c when not needed. */
 #if !defined(WOLFSSL_MISC_INCLUDED) && !defined(NO_INLINE)
-    #warning misc.c does not need to be compiled when using inline (NO_INLINE not defined)
+    #ifndef WOLFSSL_IGNORE_FILE_WARN
+        #warning misc.c does not need to be compiled when using inline (NO_INLINE not defined)
+    #endif
 
 #else
 


### PR DESCRIPTION
Added `WOLFSSL_IGNORE_FILE_WARN` option to ignore warning for `.c` files that do not need to be included.