### PR TITLE
Fix decryption error when EVP_CipherInit is called mulitple times.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -13310,20 +13310,23 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             return 0;   /* failure */
         }
 
-        if (type == NULL && ctx->cipherType == 0xff) {
+        if (type == NULL && ctx->cipherType == WOLFSSL_EVP_CIPH_TYPE_INIT) {
             WOLFSSL_MSG("no type set");
             return 0;   /* failure */
         }
-        ctx->bufUsed = 0;
-        ctx->lastUsed = 0;
-        ctx->flags   = 0;
+        if (ctx->cipherType == WOLFSSL_EVP_CIPH_TYPE_INIT){
+            ctx->bufUsed = 0;
+            ctx->lastUsed = 0;
+            ctx->flags   = 0;
+        }
         ret = 0;
 #ifndef NO_AES
         if (ctx->cipherType == AES_128_CBC_TYPE ||
             (type && XSTRNCMP(type, EVP_AES_128_CBC, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_128_CBC");
             ctx->cipherType = AES_128_CBC_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_CBC_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_CBC_MODE;
             ctx->keyLen     = 16;
             ctx->block_size = AES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
@@ -13345,7 +13348,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                  (type && XSTRNCMP(type, EVP_AES_192_CBC, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_192_CBC");
             ctx->cipherType = AES_192_CBC_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_CBC_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_CBC_MODE;
             ctx->keyLen     = 24;
             ctx->block_size = AES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
@@ -13367,7 +13371,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                  (type && XSTRNCMP(type, EVP_AES_256_CBC, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_256_CBC");
             ctx->cipherType = AES_256_CBC_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_CBC_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_CBC_MODE;
             ctx->keyLen     = 32;
             ctx->block_size = AES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
@@ -13393,8 +13398,9 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         else if (ctx->cipherType == AES_128_CTR_TYPE ||
                  (type && XSTRNCMP(type, EVP_AES_128_CTR, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_128_CTR");
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
             ctx->cipherType = AES_128_CTR_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_CTR_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_CTR_MODE;
             ctx->keyLen     = 16;
             ctx->block_size = AES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
@@ -13416,7 +13422,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                  (type && XSTRNCMP(type, EVP_AES_192_CTR, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_192_CTR");
             ctx->cipherType = AES_192_CTR_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_CTR_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_CTR_MODE;
             ctx->keyLen     = 24;
             ctx->block_size = AES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
@@ -13438,7 +13445,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                  (type && XSTRNCMP(type, EVP_AES_256_CTR, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_256_CTR");
             ctx->cipherType = AES_256_CTR_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_CTR_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_CTR_MODE;
             ctx->keyLen     = 32;
             ctx->block_size = AES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
@@ -13461,7 +13469,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             (type && XSTRNCMP(type, EVP_AES_128_ECB, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_128_ECB");
             ctx->cipherType = AES_128_ECB_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_ECB_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_ECB_MODE;
             ctx->keyLen     = 16;
             ctx->block_size = AES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
@@ -13478,7 +13487,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                  (type && XSTRNCMP(type, EVP_AES_192_ECB, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_192_ECB");
             ctx->cipherType = AES_192_ECB_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_ECB_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_ECB_MODE;
             ctx->keyLen     = 24;
             ctx->block_size = AES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
@@ -13495,7 +13505,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                  (type && XSTRNCMP(type, EVP_AES_256_ECB, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_256_ECB");
             ctx->cipherType = AES_256_ECB_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_ECB_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_ECB_MODE;
             ctx->keyLen     = 32;
             ctx->block_size = AES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
@@ -13515,7 +13526,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                  (type && XSTRNCMP(type, EVP_DES_CBC, EVP_DES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_DES_CBC");
             ctx->cipherType = DES_CBC_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_CBC_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_CBC_MODE;
             ctx->keyLen     = 8;
             ctx->block_size = DES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
@@ -13536,12 +13548,14 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                  (type && XSTRNCMP(type, EVP_DES_ECB, EVP_DES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_DES_ECB");
             ctx->cipherType = DES_ECB_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_ECB_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_ECB_MODE;
             ctx->keyLen     = 8;
             ctx->block_size = DES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
+                WOLFSSL_MSG("Des_SetKey");
                 ret = wc_Des_SetKey(&ctx->cipher.des, key, NULL,
                           ctx->enc ? DES_ENCRYPTION : DES_DECRYPTION);
                 if (ret != 0)
@@ -13555,7 +13569,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                   XSTRNCMP(type, EVP_DES_EDE3_CBC, EVP_DES_EDE3_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_DES_EDE3_CBC");
             ctx->cipherType = DES_EDE3_CBC_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_CBC_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_CBC_MODE;
             ctx->keyLen     = 24;
             ctx->block_size = DES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
@@ -13579,7 +13594,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                   XSTRNCMP(type, EVP_DES_EDE3_ECB, EVP_DES_EDE3_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_DES_EDE3_ECB");
             ctx->cipherType = DES_EDE3_ECB_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_ECB_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_ECB_MODE;
             ctx->keyLen     = 24;
             ctx->block_size = DES_BLOCK_SIZE;
             if (enc == 0 || enc == 1)
@@ -13598,7 +13614,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                                      XSTRNCMP(type, "ARC4", 4) == 0)) {
             WOLFSSL_MSG("ARC4");
             ctx->cipherType = ARC4_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_STREAM_CIPHER;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_STREAM_CIPHER;
             ctx->block_size = 1;
             if (ctx->keyLen == 0)  /* user may have already set */
                 ctx->keyLen = 16;  /* default to 128 */
@@ -13612,7 +13629,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                  (type && XSTRNCMP(type, EVP_IDEA_CBC, EVP_IDEA_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_IDEA_CBC");
             ctx->cipherType = IDEA_CBC_TYPE;
-            ctx->flags      = WOLFSSL_EVP_CIPH_CBC_MODE;
+            ctx->flags     &= ~WOLFSSL_EVP_CIPH_MODE;
+            ctx->flags     |= WOLFSSL_EVP_CIPH_CBC_MODE;
             ctx->keyLen     = IDEA_KEY_SIZE;
             ctx->block_size = 8;
             if (enc == 0 || enc == 1)

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -415,6 +415,7 @@ WOLFSSL_API int wolfSSL_PKCS5_PBKDF2_HMAC_SHA1(const char * pass, int passlen,
 #define WOLFSSL_EVP_CIPH_GCM_MODE           0x6
 #define WOLFSSL_EVP_CIPH_CCM_MODE           0x7
 #define WOLFSSL_EVP_CIPH_NO_PADDING       0x100
+#define WOLFSSL_EVP_CIPH_TYPE_INIT         0xff
 
 /* end OpenSSH compat */
 


### PR DESCRIPTION
If EVP_CipherInit() is called multiple time, function reset flags in EVP_CIPHER_CTX structure.
OpenSSL allows to call it multiple time, So wolfSSL also have to follow it.
This code below cause error but OpenSSL does not.
...
EVP_CIPHER_CTX_init(&dec);
ret = EVP_CipherInit(&enc, cipher, NULL, NULL,DECRYPT);
ret = EVP_CIPHER_CTX_set_padding(&dec, pad);
....
ret = EVP_CipherInit(&dec,NULL, key, iv, DECRYPT); <- overwrite flag information
...
(Got error when decoding)