### PR TITLE
Fix for building with IPV6

### DIFF
--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -695,8 +695,9 @@ static INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
 #else
     addr->sin6_family = AF_INET_V;
     addr->sin6_port = XHTONS(port);
-    if (peer == INADDR_ANY)
+    if ((size_t)peer != INADDR_ANY) {
         addr->sin6_addr = in6addr_any;
+    }
     else {
         #ifdef HAVE_GETADDRINFO
             struct addrinfo  hints;

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -695,7 +695,7 @@ static INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
 #else
     addr->sin6_family = AF_INET_V;
     addr->sin6_port = XHTONS(port);
-    if ((size_t)peer != INADDR_ANY) {
+    if ((size_t)peer == INADDR_ANY) {
         addr->sin6_addr = in6addr_any;
     }
     else {


### PR DESCRIPTION
Fix warning with pointer compare to zero for IPV6 `peer == INADDR_ANY` in test.h. Fixes issue #1350.