### PR TITLE
clear error node queue after test case and initialize logging buffer

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -15546,6 +15546,9 @@ static void test_wolfSSL_ERR_put_error(void)
     AssertIntEQ(ERR_get_error_line(&file, &line), 0);
     AssertNull(file);
 
+    /* Empty and free up all error nodes */
+    ERR_clear_error();
+
     printf(resultFmt, passed);
     #endif
 }

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -267,6 +267,11 @@ void WOLFSSL_ERROR(int error)
             }
             #if defined(OPENSSL_EXTRA) && !defined(WOLFCRYPT_ONLY)
             }
+            else {
+                XSNPRINTF(buffer, sizeof(buffer),
+                    "wolfSSL error occurred, error = %d", error);
+
+            }
             #endif
 
             wc_UnLockMutex(&debug_mutex);


### PR DESCRIPTION
This PR has two fixes.

1) It updates test_wolfSSL_ERR_put_error to handle its own cleanup when done rather than rely on a wolfSSL_Cleanup() call.

2) Fixes a case where WANT_READ or WANT_WRITE error was logged and the buffer to print out the log message was not initialized. 