### PR TITLE
Some memory optimizations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -511,9 +511,14 @@ fi
 
 if test "$ENABLED_OPENSSLEXTRA" = "yes" && test "$ENABLED_SMALL" = "yes"
 then
-    AC_MSG_ERROR([cannot enable small and opensslextra, only one or the other.])
+   AC_MSG_ERROR([cannot enable small and opensslextra, only one or the other.])
 fi
 
+if test "$ENABLED_OPENSSLEXTRA" = "x509small"
+then
+  AC_MSG_NOTICE([Enabling only a subset of X509 opensslextra])
+  AM_CFLAGS="-DOPENSSL_EXTRA_X509_SMALL"
+fi
 
 # High Strength Build
 AC_ARG_ENABLE([maxstrength],

--- a/src/internal.c
+++ b/src/internal.c
@@ -2750,7 +2750,7 @@ void InitX509Name(WOLFSSL_X509_NAME* name, int dynamicFlag)
     if (name != NULL) {
         name->name        = name->staticName;
         name->dynamicName = 0;
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         XMEMSET(&name->fullName, 0, sizeof(DecodedName));
         XMEMSET(&name->cnEntry,  0, sizeof(WOLFSSL_X509_NAME_ENTRY));
         XMEMSET(&name->extra,    0, sizeof(name->extra));
@@ -2767,7 +2767,7 @@ void FreeX509Name(WOLFSSL_X509_NAME* name, void* heap)
     if (name != NULL) {
         if (name->dynamicName)
             XFREE(name->name, heap, DYNAMIC_TYPE_SUBJECT_CN);
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         {
             int i;
             if (name->fullName.fullName != NULL) {
@@ -2781,7 +2781,7 @@ void FreeX509Name(WOLFSSL_X509_NAME* name, void* heap)
                 }
             }
         }
-#endif /* OPENSSL_EXTRA */
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
     }
     (void)heap;
 }
@@ -2800,40 +2800,7 @@ void InitX509(WOLFSSL_X509* x509, int dynamicFlag, void* heap)
     x509->heap = heap;
     InitX509Name(&x509->issuer, 0);
     InitX509Name(&x509->subject, 0);
-    x509->version        = 0;
-    x509->pubKey.buffer  = NULL;
-    x509->sig.buffer     = NULL;
-    x509->derCert        = NULL;
-    x509->altNames       = NULL;
-    x509->altNamesNext   = NULL;
     x509->dynamicMemory  = (byte)dynamicFlag;
-    x509->isCa           = 0;
-#ifdef HAVE_ECC
-    x509->pkCurveOID = 0;
-#endif /* HAVE_ECC */
-#ifdef OPENSSL_EXTRA
-    x509->pathLength     = 0;
-    x509->basicConstSet  = 0;
-    x509->basicConstCrit = 0;
-    x509->basicConstPlSet = 0;
-    x509->subjAltNameSet = 0;
-    x509->subjAltNameCrit = 0;
-    x509->authKeyIdSet   = 0;
-    x509->authKeyIdCrit  = 0;
-    x509->authKeyId      = NULL;
-    x509->authKeyIdSz    = 0;
-    x509->subjKeyIdSet   = 0;
-    x509->subjKeyIdCrit  = 0;
-    x509->subjKeyId      = NULL;
-    x509->subjKeyIdSz    = 0;
-    x509->keyUsageSet    = 0;
-    x509->keyUsageCrit   = 0;
-    x509->keyUsage       = 0;
-    #ifdef WOLFSSL_SEP
-        x509->certPolicySet  = 0;
-        x509->certPolicyCrit = 0;
-    #endif /* WOLFSSL_SEP */
-#endif /* OPENSSL_EXTRA */
 }
 
 
@@ -2849,7 +2816,7 @@ void FreeX509(WOLFSSL_X509* x509)
         XFREE(x509->pubKey.buffer, x509->heap, DYNAMIC_TYPE_PUBLIC_KEY);
     FreeDer(&x509->derCert);
     XFREE(x509->sig.buffer, x509->heap, DYNAMIC_TYPE_SIGNATURE);
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         XFREE(x509->authKeyId, x509->heap, DYNAMIC_TYPE_X509_EXT);
         XFREE(x509->subjKeyId, x509->heap, DYNAMIC_TYPE_X509_EXT);
         if (x509->authInfo != NULL) {
@@ -2858,7 +2825,7 @@ void FreeX509(WOLFSSL_X509* x509)
         if (x509->extKeyUsageSrc != NULL) {
             XFREE(x509->extKeyUsageSrc, x509->heap, DYNAMIC_TYPE_X509_EXT);
         }
-    #endif /* OPENSSL_EXTRA */
+    #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
     if (x509->altNames)
         FreeAltNames(x509->altNames, x509->heap);
 }
@@ -7509,7 +7476,8 @@ static void AddSessionCertToChain(WOLFSSL_X509_CHAIN* chain,
 }
 #endif
 
-#if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
+#if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS) || \
+    defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 /* Copy parts X509 needs from Decoded cert, 0 on success */
 int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
 {
@@ -7524,7 +7492,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
     XSTRNCPY(x509->issuer.name, dCert->issuer, ASN_NAME_MAX);
     x509->issuer.name[ASN_NAME_MAX - 1] = '\0';
     x509->issuer.sz = (int)XSTRLEN(x509->issuer.name) + 1;
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     if (dCert->issuerName.fullName != NULL) {
         XMEMCPY(&x509->issuer.fullName,
                                        &dCert->issuerName, sizeof(DecodedName));
@@ -7536,12 +7504,12 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
                      dCert->issuerName.fullName, dCert->issuerName.fullNameLen);
     }
     x509->issuer.x509 = x509;
-#endif /* OPENSSL_EXTRA */
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
     XSTRNCPY(x509->subject.name, dCert->subject, ASN_NAME_MAX);
     x509->subject.name[ASN_NAME_MAX - 1] = '\0';
     x509->subject.sz = (int)XSTRLEN(x509->subject.name) + 1;
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     if (dCert->subjectName.fullName != NULL) {
         XMEMCPY(&x509->subject.fullName,
                                       &dCert->subjectName, sizeof(DecodedName));
@@ -7552,7 +7520,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
                    dCert->subjectName.fullName, dCert->subjectName.fullNameLen);
     }
     x509->subject.x509 = x509;
-#endif /* OPENSSL_EXTRA */
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 #ifdef WOLFSSL_NGINX
     XMEMCPY(x509->subject.raw, dCert->subjectRaw, dCert->subjectRawLen);
     x509->subject.rawLen = dCert->subjectRawLen;
@@ -7647,7 +7615,8 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
     dCert->weOwnAltNames = 0;
     x509->altNamesNext   = x509->altNames;  /* index hint */
 
-#if defined(OPENSSL_EXTRA) && !defined(IGNORE_NAME_CONSTRAINTS)
+#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
+    !defined(IGNORE_NAME_CONSTRAINTS)
     /* add copies of alternate emails from dCert to X509 */
     if (dCert->altEmailNames != NULL) {
         DNS_entry* cur = dCert->altEmailNames;
@@ -7682,10 +7651,10 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
             cur = cur->next;
         }
     }
-#endif
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
     x509->isCa = dCert->isCA;
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     x509->pathLength = dCert->pathLength;
     x509->keyUsage = dCert->extKeyUsage;
 
@@ -7766,7 +7735,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
             x509->certPoliciesNb = dCert->extCertPoliciesNb;
         }
     #endif /* WOLFSSL_CERT_EXT */
-#endif /* OPENSSL_EXTRA */
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 #ifdef HAVE_ECC
     x509->pkCurveOID = dCert->pkCurveOID;
 #endif /* HAVE_ECC */
@@ -7800,7 +7769,7 @@ typedef struct ProcPeerCertArgs {
 #ifdef WOLFSSL_TRUST_PEER_CERT
     byte haveTrustPeer; /* was cert verified by loaded trusted peer cert */
 #endif
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     char   untrustedDepth;
 #endif
 } ProcPeerCertArgs;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15039,8 +15039,8 @@ static void ExternalFreeX509(WOLFSSL_X509* x509)
     }
 }
 
-
-void wolfSSL_FreeX509(WOLFSSL_X509* x509)
+/* Frees an external WOLFSSL_X509 structure */
+void wolfSSL_X509_free(WOLFSSL_X509* x509)
 {
     WOLFSSL_ENTER("wolfSSL_FreeX509");
     ExternalFreeX509(x509);
@@ -16199,14 +16199,6 @@ const char* wolfSSL_get_curve_name(WOLFSSL* ssl)
 #endif
 
 #if !defined(NO_CERTS)
-/* Frees an external WOLFSSL_X509 structure */
-void wolfSSL_X509_free(WOLFSSL_X509* x509)
-{
-    WOLFSSL_ENTER("wolfSSL_X509_free");
-    ExternalFreeX509(x509);
-}
-
-
 /* returns a pointer to a new WOLFSSL_X509 structure on success and NULL on
  * fail
  */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -13405,12 +13405,14 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
 #endif
 #endif /* NO_DES3 */
 
+#ifndef NO_RC4
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_rc4(void)
     {
         static const char* type = "ARC4";
         WOLFSSL_ENTER("wolfSSL_EVP_rc4");
         return type;
     }
+#endif
 
 #ifdef HAVE_IDEA
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_idea_cbc(void)
@@ -14339,12 +14341,19 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             return NULL;  /* no static buffer support */
         }
 
+#ifndef NO_MD5
         if (XSTRNCMP(evp_md, "MD5", 3) == 0)
             type = WC_MD5;
-        else if (XSTRNCMP(evp_md, "SHA", 3) == 0)
+        else
+#endif
+#ifndef NO_SHA
+            if (XSTRNCMP(evp_md, "SHA", 3) == 0)
             type = WC_SHA;
         else
+#endif
+        {
             return NULL;
+        }
 
     #ifdef WOLFSSL_SMALL_STACK
         hmac = (Hmac*)XMALLOC(sizeof(Hmac), heap, DYNAMIC_TYPE_HMAC);
@@ -14370,6 +14379,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         XFREE(hmac, heap, DYNAMIC_TYPE_HMAC);
     #endif
 
+        (void)evp_md;
         return ret;
     }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3193,17 +3193,35 @@ static struct cipher{
 } cipher_tbl[] = {
 
 #ifndef NO_AES
+    #ifdef WOLFSSL_AES_128
     {AES_128_CBC_TYPE, "AES-128-CBC"},
+    #endif
+    #ifdef WOLFSSL_AES_192
     {AES_192_CBC_TYPE, "AES-192-CBC"},
+    #endif
+    #ifdef WOLFSSL_AES_256
     {AES_256_CBC_TYPE, "AES-256-CBC"},
+    #endif
 #if defined(OPENSSL_EXTRA)
+    #ifdef WOLFSSL_AES_128
         {AES_128_CTR_TYPE, "AES-128-CTR"},
+    #endif
+    #ifdef WOLFSSL_AES_192
         {AES_192_CTR_TYPE, "AES-192-CTR"},
+    #endif
+    #ifdef WOLFSSL_AES_256
         {AES_256_CTR_TYPE, "AES-256-CTR"},
+    #endif
 
+    #ifdef WOLFSSL_AES_128
         {AES_128_ECB_TYPE, "AES-128-ECB"},
+    #endif
+    #ifdef WOLFSSL_AES_192
         {AES_192_ECB_TYPE, "AES-192-ECB"},
+    #endif
+    #ifdef WOLFSSL_AES_256
         {AES_256_ECB_TYPE, "AES-256-ECB"},
+    #endif
 #endif
 
 #endif
@@ -3234,6 +3252,7 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbyname(const char *name)
         const char *alias;
     } alias_tbl[] =
     {
+#ifndef NO_DES3
         {"DES-CBC", "DES"},
         {"DES-CBC", "des"},
         {"DES-ECB", "DES-ECB"},
@@ -3243,21 +3262,42 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbyname(const char *name)
         {"DES-EDE3-ECB", "DES-EDE3"},
         {"DES-EDE3-ECB", "des-ede3"},
         {"DES-EDE3-ECB", "des-ede3-ecb"},
+#endif
+#ifdef HAVE_IDEA
         {"IDEA-CBC", "IDEA"},
         {"IDEA-CBC", "idea"},
-        {"AES-128-CBC", "AES128-ECB"},
-        {"AES-128-CBC", "aes128-ecb"},
-        {"AES-192-CBC", "AES192-ECB"},
-        {"AES-192-CBC", "aes192-ecb"},
-        {"AES-256-CBC", "AES256-ECB"},
-        {"AES-256-CBC", "aes256-ecb"},
+#endif
+#ifndef NO_AES
+    #ifdef HAVE_AES_CBC
+        #ifdef WOLFSSL_AES_128
+        {"AES-128-CBC", "AES128-CBC"},
+        {"AES-128-CBC", "aes128-cbc"},
+        #endif
+        #ifdef WOLFSSL_AES_192
+        {"AES-192-CBC", "AES192-CBC"},
+        {"AES-192-CBC", "aes192-cbc"},
+        #endif
+        #ifdef WOLFSSL_AES_256
+        {"AES-256-CBC", "AES256-CBC"},
+        {"AES-256-CBC", "aes256-cbc"},
+        #endif
+    #endif
+    #ifdef WOLFSSL_AES_128
         {"AES-128-ECB", "AES128-ECB"},
         {"AES-128-ECB", "aes128-ecb"},
+    #endif
+    #ifdef WOLFSSL_AES_192
         {"AES-192-ECB", "AES192-ECB"},
         {"AES-192-ECB", "aes192-ecb"},
+    #endif
+    #ifdef WOLFSSL_AES_256
         {"AES-256-ECB", "AES256-ECB"},
         {"AES-256-EBC", "aes256-ecb"},
+    #endif
+#endif
+#ifndef NO_RC4
         {"ARC4", "RC4"},
+#endif
         { NULL, NULL}
     };
 
@@ -3295,24 +3335,44 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbynid(int id)
 
 #if defined(OPENSSL_EXTRA)
 #ifndef NO_AES
+    #ifdef HAVE_AES_CBC
+        #ifdef WOLFSSL_AES_128
         case NID_aes_128_cbc:
             return wolfSSL_EVP_aes_128_cbc();
+        #endif
+        #ifdef WOLFSSL_AES_192
         case NID_aes_192_cbc:
             return wolfSSL_EVP_aes_192_cbc();
+        #endif
+        #ifdef WOLFSSL_AES_256
         case NID_aes_256_cbc:
             return wolfSSL_EVP_aes_256_cbc();
+        #endif
+    #endif
+        #ifdef WOLFSSL_AES_128
         case NID_aes_128_ctr:
             return wolfSSL_EVP_aes_128_ctr();
+        #endif
+        #ifdef WOLFSSL_AES_192
         case NID_aes_192_ctr:
             return wolfSSL_EVP_aes_192_ctr();
+        #endif
+        #ifdef WOLFSSL_AES_256
         case NID_aes_256_ctr:
             return wolfSSL_EVP_aes_256_ctr();
+        #endif
+        #ifdef WOLFSSL_AES_128
         case NID_aes_128_ecb:
             return wolfSSL_EVP_aes_128_ecb();
+        #endif
+        #ifdef WOLFSSL_AES_192
         case NID_aes_192_ecb:
             return wolfSSL_EVP_aes_192_ecb();
+        #endif
+        #ifdef WOLFSSL_AES_256
         case NID_aes_256_ecb:
             return wolfSSL_EVP_aes_256_ecb();
+        #endif
 #endif
 
 #ifndef NO_DES3
@@ -3344,17 +3404,37 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbynid(int id)
 }
 
 #ifndef NO_AES
-static char *EVP_AES_128_CBC;
-static char *EVP_AES_192_CBC;
-static char *EVP_AES_256_CBC;
+    #ifdef HAVE_AES_CBC
+    #ifdef WOLFSSL_AES_128
+        static char *EVP_AES_128_CBC;
+    #endif
+    #ifdef WOLFSSL_AES_192
+        static char *EVP_AES_192_CBC;
+    #endif
+    #ifdef WOLFSSL_AES_256
+        static char *EVP_AES_256_CBC;
+    #endif
+    #endif /* HAVE_AES_CBC */
 #if defined(OPENSSL_EXTRA)
+    #ifdef WOLFSSL_AES_128
     static char *EVP_AES_128_CTR;
+    #endif
+    #ifdef WOLFSSL_AES_192
     static char *EVP_AES_192_CTR;
+    #endif
+    #ifdef WOLFSSL_AES_256
     static char *EVP_AES_256_CTR;
+    #endif
 
+    #ifdef WOLFSSL_AES_128
     static char *EVP_AES_128_ECB;
+    #endif
+    #ifdef WOLFSSL_AES_192
     static char *EVP_AES_192_ECB;
+    #endif
+    #ifdef WOLFSSL_AES_256
     static char *EVP_AES_256_ECB;
+    #endif
 #endif
 static const int  EVP_AES_SIZE = 11;
 #endif
@@ -3379,18 +3459,38 @@ static const int  EVP_IDEA_SIZE = 8;
 void wolfSSL_EVP_init(void)
 {
 #ifndef NO_AES
-    EVP_AES_128_CBC = (char *)EVP_get_cipherbyname("AES-128-CBC");
-    EVP_AES_192_CBC = (char *)EVP_get_cipherbyname("AES-192-CBC");
-    EVP_AES_256_CBC = (char *)EVP_get_cipherbyname("AES-256-CBC");
+    #ifdef HAVE_AES_CBC
+        #ifdef WOLFSSL_AES_128
+        EVP_AES_128_CBC = (char *)EVP_get_cipherbyname("AES-128-CBC");
+        #endif
+        #ifdef WOLFSSL_AES_192
+        EVP_AES_192_CBC = (char *)EVP_get_cipherbyname("AES-192-CBC");
+        #endif
+        #ifdef WOLFSSL_AES_256
+        EVP_AES_256_CBC = (char *)EVP_get_cipherbyname("AES-256-CBC");
+        #endif
+    #endif /* HAVE_AES_CBC */
 
 #if defined(OPENSSL_EXTRA)
+        #ifdef WOLFSSL_AES_128
         EVP_AES_128_CTR = (char *)EVP_get_cipherbyname("AES-128-CTR");
+        #endif
+        #ifdef WOLFSSL_AES_192
         EVP_AES_192_CTR = (char *)EVP_get_cipherbyname("AES-192-CTR");
+        #endif
+        #ifdef WOLFSSL_AES_256
         EVP_AES_256_CTR = (char *)EVP_get_cipherbyname("AES-256-CTR");
+        #endif
 
+        #ifdef WOLFSSL_AES_128
         EVP_AES_128_ECB = (char *)EVP_get_cipherbyname("AES-128-ECB");
+        #endif
+        #ifdef WOLFSSL_AES_192
         EVP_AES_192_ECB = (char *)EVP_get_cipherbyname("AES-192-ECB");
+        #endif
+        #ifdef WOLFSSL_AES_256
         EVP_AES_256_ECB = (char *)EVP_get_cipherbyname("AES-256-ECB");
+        #endif
 #endif
 #endif
 
@@ -4491,7 +4591,6 @@ static int wolfssl_encrypt_buffer_key(byte* der, word32 derSz, byte* password,
 #endif /* NO_MD5 */
 
     if (ret > 0) {
-        ret = WOLFSSL_BAD_FILE; /* Reset error return */
 #ifndef NO_DES3
         if (XSTRNCMP(info->name, EVP_DES_CBC, EVP_DES_SIZE) == 0)
             ret = wc_Des_CbcEncryptWithKey(der, der, derSz, key, info->iv);
@@ -4499,16 +4598,28 @@ static int wolfssl_encrypt_buffer_key(byte* der, word32 derSz, byte* password,
             ret = wc_Des3_CbcEncryptWithKey(der, der, derSz, key, info->iv);
 #endif /* NO_DES3 */
 #ifndef NO_AES
+    #ifdef WOLFSSL_AES_128
         if (XSTRNCMP(info->name, EVP_AES_128_CBC, EVP_AES_SIZE) == 0)
             ret = wc_AesCbcEncryptWithKey(der, der, derSz,
                                           key, AES_128_KEY_SIZE, info->iv);
-        else if (XSTRNCMP(info->name, EVP_AES_192_CBC, EVP_AES_SIZE) == 0)
+        else
+    #endif
+    #ifdef WOLFSSL_AES_192
+        if (XSTRNCMP(info->name, EVP_AES_192_CBC, EVP_AES_SIZE) == 0)
             ret = wc_AesCbcEncryptWithKey(der, der, derSz,
                                           key, AES_192_KEY_SIZE, info->iv);
-        else if (XSTRNCMP(info->name, EVP_AES_256_CBC, EVP_AES_SIZE) == 0)
+        else
+    #endif
+    #ifdef WOLFSSL_AES_192
+        if (XSTRNCMP(info->name, EVP_AES_256_CBC, EVP_AES_SIZE) == 0)
             ret = wc_AesCbcEncryptWithKey(der, der, derSz,
                                           key, AES_256_KEY_SIZE, info->iv);
+        else
+    #endif
 #endif /* NO_AES */
+        {
+            ret = WOLFSSL_BAD_FILE; /* Reset error return */
+        }
     }
 
 #ifdef WOLFSSL_SMALL_STACK
@@ -7617,16 +7728,25 @@ static int wolfSSL_EVP_Digest(unsigned char* in, int inSz, unsigned char* out,
 
     if (XSTRNCMP("SHA", evp, 3) == 0) {
         if (XSTRLEN(evp) > 3) {
+            #ifndef NO_SHA256
             if (XSTRNCMP("SHA256", evp, 6) == 0) {
                 hash = WC_HASH_TYPE_SHA256;
             }
-            else if (XSTRNCMP("SHA384", evp, 6) == 0) {
+            else
+            #endif
+            #ifdef WOLFSSL_SHA384
+            if (XSTRNCMP("SHA384", evp, 6) == 0) {
                 hash = WC_HASH_TYPE_SHA384;
             }
-            else if (XSTRNCMP("SHA512", evp, 6) == 0) {
+            else 
+            #endif
+            #ifdef WOLFSSL_SHA512
+            if (XSTRNCMP("SHA512", evp, 6) == 0) {
                 hash = WC_HASH_TYPE_SHA512;
             }
-            else {
+            else
+            #endif
+            {
                 WOLFSSL_MSG("Unknown SHA hash");
             }
         }
@@ -7634,15 +7754,21 @@ static int wolfSSL_EVP_Digest(unsigned char* in, int inSz, unsigned char* out,
             hash = WC_HASH_TYPE_SHA;
         }
     }
+#ifdef WOLFSSL_MD2
     else if (XSTRNCMP("MD2", evp, 3) == 0) {
         hash = WC_HASH_TYPE_MD2;
     }
+#endif
+#ifndef NO_MD4
     else if (XSTRNCMP("MD4", evp, 3) == 0) {
         hash = WC_HASH_TYPE_MD4;
     }
+#endif
+#ifndef NO_MD5
     else if (XSTRNCMP("MD5", evp, 3) == 0) {
         hash = WC_HASH_TYPE_MD5;
     }
+#endif
 
     hashSz = wc_HashGetDigestSize(hash);
     if (hashSz < 0) {
@@ -12426,19 +12552,29 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         else
         #endif /* NO_DES3 */
         #ifndef NO_AES
-        if (XSTRNCMP(type, EVP_AES_128_CBC, EVP_AES_SIZE) == 0) {
-            keyLen = AES_128_KEY_SIZE;
-            ivLen  = AES_IV_SIZE;
-        }
-        else if (XSTRNCMP(type, EVP_AES_192_CBC, EVP_AES_SIZE) == 0) {
-            keyLen = AES_192_KEY_SIZE;
-            ivLen  = AES_IV_SIZE;
-        }
-        else if (XSTRNCMP(type, EVP_AES_256_CBC, EVP_AES_SIZE) == 0) {
-            keyLen = AES_256_KEY_SIZE;
-            ivLen  = AES_IV_SIZE;
-        }
-        else
+            #ifdef HAVE_AES_CBC
+                #ifdef WOLFSSL_AES_128
+                if (XSTRNCMP(type, EVP_AES_128_CBC, EVP_AES_SIZE) == 0) {
+                    keyLen = AES_128_KEY_SIZE;
+                    ivLen  = AES_IV_SIZE;
+                }
+                else
+                #endif
+                #ifdef WOLFSSL_AES_192
+                if (XSTRNCMP(type, EVP_AES_192_CBC, EVP_AES_SIZE) == 0) {
+                    keyLen = AES_192_KEY_SIZE;
+                    ivLen  = AES_IV_SIZE;
+                }
+                else
+                #endif
+                #ifdef WOLFSSL_AES_192
+                if (XSTRNCMP(type, EVP_AES_256_CBC, EVP_AES_SIZE) == 0) {
+                    keyLen = AES_256_KEY_SIZE;
+                    ivLen  = AES_IV_SIZE;
+                }
+                else
+                #endif
+            #endif /* HAVE_AES_CBC */
         #endif /* NO_AES */
         {
         #ifdef WOLFSSL_SMALL_STACK
@@ -13134,6 +13270,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
 
     #ifndef NO_AES
 
+    #ifdef HAVE_AES_CBC
+    #ifdef WOLFSSL_AES_128
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_cbc(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_128_cbc");
@@ -13141,8 +13279,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             wolfSSL_EVP_init();
         return EVP_AES_128_CBC;
     }
+    #endif /* WOLFSSL_AES_128 */
 
 
+    #ifdef WOLFSSL_AES_192
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_cbc(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_192_cbc");
@@ -13150,8 +13290,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             wolfSSL_EVP_init();
         return EVP_AES_192_CBC;
     }
+    #endif /* WOLFSSL_AES_192 */
 
 
+    #ifdef WOLFSSL_AES_256
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_cbc(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_256_cbc");
@@ -13159,8 +13301,11 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             wolfSSL_EVP_init();
         return EVP_AES_256_CBC;
     }
+    #endif /* WOLFSSL_AES_256 */
+    #endif /* HAVE_AES_CBC */
 
 
+    #ifdef WOLFSSL_AES_128
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_ctr(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_128_ctr");
@@ -13168,8 +13313,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             wolfSSL_EVP_init();
         return EVP_AES_128_CTR;
     }
+    #endif /* WOLFSSL_AES_2128 */
 
 
+    #ifdef WOLFSSL_AES_192
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_ctr(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_192_ctr");
@@ -13177,8 +13324,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             wolfSSL_EVP_init();
         return EVP_AES_192_CTR;
     }
+    #endif /* WOLFSSL_AES_192 */
 
 
+    #ifdef WOLFSSL_AES_256
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_ctr(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_256_ctr");
@@ -13186,7 +13335,9 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             wolfSSL_EVP_init();
         return EVP_AES_256_CTR;
     }
+    #endif /* WOLFSSL_AES_256 */
 
+    #ifdef WOLFSSL_AES_128
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_ecb(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_128_ecb");
@@ -13194,8 +13345,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             wolfSSL_EVP_init();
         return EVP_AES_128_ECB;
     }
+    #endif /* WOLFSSL_AES_128 */
 
 
+    #ifdef WOLFSSL_AES_192
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_ecb(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_192_ecb");
@@ -13203,8 +13356,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             wolfSSL_EVP_init();
         return EVP_AES_192_ECB;
     }
+    #endif /* WOLFSSL_AES_192*/
 
 
+    #ifdef WOLFSSL_AES_256
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_ecb(void)
     {
         WOLFSSL_ENTER("wolfSSL_EVP_aes_256_ecb");
@@ -13212,6 +13367,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             wolfSSL_EVP_init();
         return EVP_AES_256_ECB;
     }
+    #endif /* WOLFSSL_AES_256 */
     #endif /* NO_AES */
 
 #ifndef NO_DES3
@@ -13335,6 +13491,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         }
         ret = 0;
 #ifndef NO_AES
+    #ifdef HAVE_AES_CBC
+        #ifdef WOLFSSL_AES_128
         if (ctx->cipherType == AES_128_CBC_TYPE ||
             (type && XSTRNCMP(type, EVP_AES_128_CBC, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_128_CBC");
@@ -13358,7 +13516,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             }
             ret = 0;
         }
-        else if (ctx->cipherType == AES_192_CBC_TYPE ||
+        else
+        #endif /* WOLFSSL_AES_128 */
+        #ifdef WOLFSSL_AES_192
+        if (ctx->cipherType == AES_192_CBC_TYPE ||
                  (type && XSTRNCMP(type, EVP_AES_192_CBC, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_192_CBC");
             ctx->cipherType = AES_192_CBC_TYPE;
@@ -13381,7 +13542,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             }
             ret = 0;
         }
-        else if (ctx->cipherType == AES_256_CBC_TYPE ||
+        else
+        #endif /* WOLFSSL_AES_192 */
+        #ifdef WOLFSSL_AES_256
+        if (ctx->cipherType == AES_256_CBC_TYPE ||
                  (type && XSTRNCMP(type, EVP_AES_256_CBC, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_256_CBC");
             ctx->cipherType = AES_256_CBC_TYPE;
@@ -13408,7 +13572,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             }
             ret = 0;
         }
+        #endif /* WOLFSSL_AES_256 */
+    #endif /* HAVE_AES_CBC */
 #ifdef WOLFSSL_AES_COUNTER
+        #ifdef WOLFSSL_AES_128
         else if (ctx->cipherType == AES_128_CTR_TYPE ||
                  (type && XSTRNCMP(type, EVP_AES_128_CTR, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_128_CTR");
@@ -13432,7 +13599,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             }
             ret = 0;
         }
-        else if (ctx->cipherType == AES_192_CTR_TYPE ||
+        else
+        #endif /* WOLFSSL_AES_128 */
+        #ifdef WOLFSSL_AES_192
+        if (ctx->cipherType == AES_192_CTR_TYPE ||
                  (type && XSTRNCMP(type, EVP_AES_192_CTR, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_192_CTR");
             ctx->cipherType = AES_192_CTR_TYPE;
@@ -13455,7 +13625,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             }
             ret = 0;
         }
-        else if (ctx->cipherType == AES_256_CTR_TYPE ||
+        else
+        #endif /* WOLFSSL_AES_192 */
+        #ifdef WOLFSSL_AES_256
+        if (ctx->cipherType == AES_256_CTR_TYPE ||
                  (type && XSTRNCMP(type, EVP_AES_256_CTR, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_256_CTR");
             ctx->cipherType = AES_256_CTR_TYPE;
@@ -13478,7 +13651,9 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             }
             ret = 0;
         }
+        #endif /* WOLFSSL_AES_256 */
 #endif /* WOLFSSL_AES_CTR */
+        #ifdef WOLFSSL_AES_128
         else if (ctx->cipherType == AES_128_ECB_TYPE ||
             (type && XSTRNCMP(type, EVP_AES_128_ECB, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_128_ECB");
@@ -13497,7 +13672,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                 return ret;
             ret = 0;
         }
-        else if (ctx->cipherType == AES_192_ECB_TYPE ||
+        else
+        #endif /* WOLFSSL_AES_128 */
+        #ifdef WOLFSSL_AES_192
+        if (ctx->cipherType == AES_192_ECB_TYPE ||
                  (type && XSTRNCMP(type, EVP_AES_192_ECB, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_192_ECB");
             ctx->cipherType = AES_192_ECB_TYPE;
@@ -13515,7 +13693,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                 return ret;
             ret = 0;
         }
-        else if (ctx->cipherType == AES_256_ECB_TYPE ||
+        else
+        #endif /* WOLFSSL_AES_192 */
+        #ifdef WOLFSSL_AES_256
+        if (ctx->cipherType == AES_256_ECB_TYPE ||
                  (type && XSTRNCMP(type, EVP_AES_256_ECB, EVP_AES_SIZE) == 0)) {
             WOLFSSL_MSG("EVP_AES_256_ECB");
             ctx->cipherType = AES_256_ECB_TYPE;
@@ -13533,6 +13714,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                 return ret;
             ret = 0;
         }
+        #endif /* WOLFSSL_AES_256 */
 #endif /* NO_AES */
 
 #ifndef NO_DES3
@@ -28956,36 +29138,45 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
                 type = oidSigType;
                 break;
 
+        #ifndef NO_MD5
             case CTC_MD5wRSA:
                 sName = "md5WithRSA";
                 type = oidSigType;
                 break;
+        #endif
 
             case CTC_SHAwRSA:
                 sName = "shaWithRSA";
                 type = oidSigType;
                 break;
 
+        #ifdef WOLFSSL_SHA224
             case CTC_SHA224wRSA:
                 sName = "sha224WithRSA";
                 type = oidSigType;
                 break;
+        #endif
 
+        #ifndef NO_SHA256
             case CTC_SHA256wRSA:
                 sName = "sha256WithRSA";
                 type = oidSigType;
                 break;
+        #endif
 
+        #ifdef WOLFSSL_SHA384
             case CTC_SHA384wRSA:
                 sName = "sha384WithRSA";
                 type = oidSigType;
                 break;
+        #endif
 
+        #ifdef WOLFSSL_SHA512
             case CTC_SHA512wRSA:
                 sName = "sha512WithRSA";
                 type = oidSigType;
                 break;
-
+        #endif
         #endif /* NO_RSA */
         #ifdef HAVE_ECC
             case CTC_SHAwECDSA:

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2643,7 +2643,7 @@ int wolfSSL_want_write(WOLFSSL* ssl)
 
 char* wolfSSL_ERR_error_string(unsigned long errNumber, char* data)
 {
-    static const char* msg = "Please supply a buffer for error string";
+    static const char* const msg = "Please supply a buffer for error string";
 
     WOLFSSL_ENTER("ERR_error_string");
     if (data) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4897,8 +4897,7 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
         return 0;
     }
 
-#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
-        defined(HAVE_WEBSERVER)) && !defined(NO_PWDBASED)
+#if (defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)) && !defined(NO_PWDBASED)
     if (encrypted_key || header == BEGIN_ENC_PRIV_KEY) {
         int   passwordSz;
     #ifdef WOLFSSL_SMALL_STACK
@@ -4942,8 +4941,7 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
             }
         }
     }
-#endif  /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL || HAVE_WEBSERVER ||
-           NO_PWDBASED */
+#endif  /* OPENSSL_EXTRA || HAVE_WEBSERVER || NO_PWDBASED */
 
     return 0;
 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -29428,31 +29428,37 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
                 break;
 
                 /* oidCmsKeyAgreeType */
+        #ifndef NO_SHA
             case dhSinglePass_stdDH_sha1kdf_scheme:
                 sName = "DH-SHA kdf";
                 type = oidCmsKeyAgreeType;
                 break;
-
+        #endif
+        #ifdef WOLFSSL_SHA224
             case dhSinglePass_stdDH_sha224kdf_scheme:
                 sName = "DH-SHA224 kdf";
                 type = oidCmsKeyAgreeType;
                 break;
-
+        #endif
+        #ifndef NO_SHA256
             case dhSinglePass_stdDH_sha256kdf_scheme:
                 sName = "DH-SHA256 kdf";
                 type = oidCmsKeyAgreeType;
                 break;
 
+        #endif
+        #ifdef WOLFSSL_SHA384
             case dhSinglePass_stdDH_sha384kdf_scheme:
                 sName = "DH-SHA384 kdf";
                 type = oidCmsKeyAgreeType;
                 break;
-
+        #endif
+        #ifdef WOLFSSL_SHA512
             case dhSinglePass_stdDH_sha512kdf_scheme:
                 sName = "DH-SHA512 kdf";
                 type = oidCmsKeyAgreeType;
                 break;
-
+        #endif
             default:
                 WOLFSSL_MSG("NID not in table");
                 return NULL;
@@ -29960,16 +29966,26 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
             /* oidCmsKeyAgreeType */
             case oidCmsKeyAgreeType:
                 switch (oid) {
+                    #ifndef NO_SHA
                     case dhSinglePass_stdDH_sha1kdf_scheme:
                         return dhSinglePass_stdDH_sha1kdf_scheme;
+                    #endif
+                    #ifdef WOLFSSL_SHA224
                     case dhSinglePass_stdDH_sha224kdf_scheme:
                         return dhSinglePass_stdDH_sha224kdf_scheme;
+                    #endif
+                    #ifndef NO_SHA256
                     case dhSinglePass_stdDH_sha256kdf_scheme:
                         return dhSinglePass_stdDH_sha256kdf_scheme;
+                    #endif
+                    #ifdef WOLFSSL_SHA384
                     case dhSinglePass_stdDH_sha384kdf_scheme:
                         return dhSinglePass_stdDH_sha384kdf_scheme;
+                    #endif
+                    #ifdef WOLFSSL_SHA512
                     case dhSinglePass_stdDH_sha512kdf_scheme:
                         return dhSinglePass_stdDH_sha512kdf_scheme;
+                    #endif
                 }
                 break;
 

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -102,6 +102,7 @@ static INLINE int wolfSSL_LastError(void)
 #endif /* USE_WOLFSSL_IO || HAVE_HTTP_CLIENT */
 
 
+#ifdef OPENSSL_EXTRA
 /* Use the WOLFSSL read BIO for receiving data. This is set by the fucntion wolfSSL_set_bio and can also be set by wolfSSL_SetIORecv.
  *
  * ssl  WOLFSSL struct passed in that has this function set as the receive callback.
@@ -116,7 +117,7 @@ int BioReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx)
     int recvd = WOLFSSL_CBIO_ERR_GENERAL;
 
     WOLFSSL_ENTER("BioReceive");
-#ifdef OPENSSL_EXTRA
+
     if (ssl->biord == NULL) {
         WOLFSSL_MSG("WOLFSSL biord not set");
         return WOLFSSL_CBIO_ERR_GENERAL;
@@ -137,12 +138,7 @@ int BioReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx)
             WOLFSSL_MSG("This BIO type is unknown / unsupported");
             return WOLFSSL_CBIO_ERR_GENERAL;
     }
-#else
-    (void)ssl;
-    (void)buf;
-    (void)sz;
-    WOLFSSL_MSG("OPENSSL_EXTRA not compiled in");
-#endif
+
     (void)ctx;
     return recvd;
 }
@@ -161,7 +157,6 @@ int BioSend(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 {
     int sent = WOLFSSL_CBIO_ERR_GENERAL;
 
-#ifdef OPENSSL_EXTRA
     if (ssl->biowr == NULL) {
         WOLFSSL_MSG("WOLFSSL biowr not set\n");
         return WOLFSSL_CBIO_ERR_GENERAL;
@@ -179,16 +174,11 @@ int BioSend(WOLFSSL* ssl, char *buf, int sz, void *ctx)
             WOLFSSL_MSG("This BIO type is unknown / unsupported");
             return WOLFSSL_CBIO_ERR_GENERAL;
     }
-#else
-    (void)ssl;
-    (void)buf;
-    (void)sz;
-    WOLFSSL_MSG("OPENSSL_EXTRA not compiled in");
-#endif
     (void)ctx;
 
     return sent;
 }
+#endif
 
 
 #ifdef USE_WOLFSSL_IO

--- a/tests/api.c
+++ b/tests/api.c
@@ -247,9 +247,15 @@
     #include <wolfssl/wolfcrypt/ed25519.h>
 #endif
 
+#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
+    #include <wolfssl/openssl/ssl.h>
+    #ifndef NO_ASN
+    /* for ASN_COMMON_NAME DN_tags enum */
+    #include <wolfssl/wolfcrypt/asn.h>
+    #endif
+#endif
 #ifdef OPENSSL_EXTRA
     #include <wolfssl/openssl/asn1.h>
-    #include <wolfssl/openssl/ssl.h>
     #include <wolfssl/openssl/crypto.h>
     #include <wolfssl/openssl/pkcs12.h>
     #include <wolfssl/openssl/evp.h>
@@ -264,10 +270,6 @@
     #include <wolfssl/openssl/objects.h>
 #ifndef NO_DES3
     #include <wolfssl/openssl/des.h>
-#endif
-#ifndef NO_ASN
-    /* for ASN_COMMON_NAME DN_tags enum */
-    #include <wolfssl/wolfcrypt/asn.h>
 #endif
 #endif /* OPENSSL_EXTRA */
 
@@ -14659,8 +14661,8 @@ static void test_wolfSSL_CTX_add_client_CA(void)
 
 static void test_wolfSSL_X509_NID(void)
 {
-    #if defined(OPENSSL_EXTRA) && !defined(NO_RSA)\
-    && defined(USE_CERT_BUFFERS_2048) && !defined(NO_ASN)
+    #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
+    !defined(NO_RSA) && defined(USE_CERT_BUFFERS_2048) && !defined(NO_ASN)
     int   sigType;
     int   nameSz;
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -957,15 +957,79 @@ static void test_wolfSSL_EC(void)
 static void test_wolfSSL_EVP_get_cipherbynid(void)
 {
 #ifndef NO_AES
-      AssertNotNull(strcmp("EVP_AES_128_CBC", wolfSSL_EVP_get_cipherbynid(419)));
-      AssertNotNull(strcmp("EVP_AES_192_CBC", wolfSSL_EVP_get_cipherbynid(423)));
-      AssertNotNull(strcmp("EVP_AES_256_CBC", wolfSSL_EVP_get_cipherbynid(427)));
-      AssertNotNull(strcmp("EVP_AES_128_CTR", wolfSSL_EVP_get_cipherbynid(904)));
-      AssertNotNull(strcmp("EVP_AES_192_CTR", wolfSSL_EVP_get_cipherbynid(905)));
-      AssertNotNull(strcmp("EVP_AES_256_CTR", wolfSSL_EVP_get_cipherbynid(906)));
-      AssertNotNull(strcmp("EVP_AES_128_ECB", wolfSSL_EVP_get_cipherbynid(418)));
-      AssertNotNull(strcmp("EVP_AES_192_ECB", wolfSSL_EVP_get_cipherbynid(422)));
-      AssertNotNull(strcmp("EVP_AES_256_ECB", wolfSSL_EVP_get_cipherbynid(426)));
+    const WOLFSSL_EVP_CIPHER* c;
+
+    c = wolfSSL_EVP_get_cipherbynid(419);
+    #if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
+        AssertNotNull(c);
+        AssertNotNull(strcmp("EVP_AES_128_CBC", c));
+    #else
+        AssertNull(c);
+    #endif
+
+    c = wolfSSL_EVP_get_cipherbynid(423);
+    #if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_192)
+        AssertNotNull(c);
+        AssertNotNull(strcmp("EVP_AES_192_CBC", c));
+    #else
+        AssertNull(c);
+    #endif
+
+    c = wolfSSL_EVP_get_cipherbynid(427);
+    #if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_256)
+        AssertNotNull(c);
+        AssertNotNull(strcmp("EVP_AES_256_CBC", c));
+    #else
+        AssertNull(c);
+    #endif
+
+    c = wolfSSL_EVP_get_cipherbynid(904);
+    #if defined(WOLFSSL_AES_COUNTER) && defined(WOLFSSL_AES_128)
+        AssertNotNull(c);
+        AssertNotNull(strcmp("EVP_AES_128_CTR", c));
+    #else
+        AssertNull(c);
+    #endif
+
+    c = wolfSSL_EVP_get_cipherbynid(905);
+    #if defined(WOLFSSL_AES_COUNTER) && defined(WOLFSSL_AES_192)
+        AssertNotNull(c);
+        AssertNotNull(strcmp("EVP_AES_192_CTR", c));
+    #else
+        AssertNull(c);
+    #endif
+
+    c = wolfSSL_EVP_get_cipherbynid(906);
+    #if defined(WOLFSSL_AES_COUNTER) && defined(WOLFSSL_AES_256)
+        AssertNotNull(c);
+        AssertNotNull(strcmp("EVP_AES_256_CTR", c));
+    #else
+        AssertNull(c);
+    #endif
+
+    c = wolfSSL_EVP_get_cipherbynid(418);
+    #if defined(HAVE_AES_ECB) && defined(WOLFSSL_AES_128)
+        AssertNotNull(c);
+        AssertNotNull(strcmp("EVP_AES_128_ECB", c));
+    #else
+        AssertNull(c);
+    #endif
+
+    c = wolfSSL_EVP_get_cipherbynid(422);
+    #if defined(HAVE_AES_ECB) && defined(WOLFSSL_AES_192)
+        AssertNotNull(c);
+        AssertNotNull(strcmp("EVP_AES_192_ECB", c));
+    #else
+        AssertNull(c);
+    #endif
+
+    c = wolfSSL_EVP_get_cipherbynid(426);
+    #if defined(HAVE_AES_ECB) && defined(WOLFSSL_AES_256)
+        AssertNotNull(c);
+        AssertNotNull(strcmp("EVP_AES_256_ECB", c));
+    #else
+        AssertNull(c);
+    #endif
 #endif
 
 #ifndef NO_DES3
@@ -6813,13 +6877,18 @@ static int test_wc_InitCmac (void)
 
     printf(testingFmt, "wc_InitCmac()");
 
+#ifdef WOLFSSL_AES_128
     ret = wc_InitCmac(&cmac1, key1, key1Sz, type, NULL);
-    if (ret == 0) {
+#endif
+#ifdef WOLFSSL_AES_192
+    if (ret == 0)
         ret = wc_InitCmac(&cmac2, key2, key2Sz, type, NULL);
-    }
-    if (ret == 0) {
+#endif
+#ifdef WOLFSSL_AES_256
+    if (ret == 0)
         ret = wc_InitCmac(&cmac3, key3, key3Sz, type, NULL);
-    }
+#endif
+
     /* Test bad args. */
     if (ret == 0) {
         ret = wc_InitCmac(NULL, key3, key3Sz, type, NULL);
@@ -6839,6 +6908,13 @@ static int test_wc_InitCmac (void)
         }
     }
 
+    (void)key1;
+    (void)key1Sz;
+    (void)key2;
+    (void)key2Sz;
+    (void)cmac1;
+    (void)cmac2;
+
     printf(resultFmt, ret == 0 ? passed : failed);
 
 #endif
@@ -6854,7 +6930,7 @@ static int test_wc_CmacUpdate (void)
 {
     int         ret = 0;
 
-#if defined(WOLFSSL_CMAC) && !defined(NO_AES)
+#if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_128)
     Cmac        cmac;
     byte        key[] =
     {
@@ -6908,7 +6984,7 @@ static int test_wc_CmacFinal (void)
 {
     int         ret = 0;
 
-#if defined(WOLFSSL_CMAC) && !defined(NO_AES)
+#if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_128)
     Cmac        cmac;
     byte        key[] =
     {
@@ -6984,7 +7060,7 @@ static int test_wc_CmacFinal (void)
 static int test_wc_AesCmacGenerate (void)
 {
     int         ret = 0;
-#if defined(WOLFSSL_CMAC) && !defined(NO_AES)
+#if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_128)
     Cmac        cmac;
     byte        key[] =
     {
@@ -7662,7 +7738,7 @@ static int test_wc_ChaCha20Poly1305_aead (void)
 static int test_wc_AesSetIV (void)
 {
     int     ret = 0;
-#ifndef NO_AES
+#if !defined(NO_AES) && defined(WOLFSSL_AES_128)
     Aes     aes;
     byte    key16[] =
     {
@@ -7716,12 +7792,15 @@ static int test_wc_AesSetKey (void)
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
         0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
     };
+#ifdef WOLFSSL_AES_192
     byte    key24[] =
     {
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
         0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37
     };
+#endif
+#ifdef WOLFSSL_AES_256
     byte    key32[] =
     {
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
@@ -7729,6 +7808,7 @@ static int test_wc_AesSetKey (void)
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
         0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
     };
+#endif
     byte    badKey16[] =
     {
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
@@ -7742,16 +7822,23 @@ static int test_wc_AesSetKey (void)
     if (ret != 0)
         return ret;
 
+#ifdef WOLFSSL_AES_128
     ret = wc_AesSetKey(&aes, key16, (word32) sizeof(key16) / sizeof(byte),
                                                         iv, AES_ENCRYPTION);
+#endif
+#ifdef WOLFSSL_AES_192
     if (ret == 0) {
         ret = wc_AesSetKey (&aes, key24, (word32) sizeof(key24) / sizeof(byte),
                                                            iv, AES_ENCRYPTION);
     }
+#endif
+#ifdef WOLFSSL_AES_256
     if (ret == 0) {
         ret = wc_AesSetKey (&aes, key32, (word32) sizeof(key32) / sizeof(byte),
                                                            iv, AES_ENCRYPTION);
     }
+#endif
+
     /* Pass in bad args. */
     if (ret == 0) {
         ret = wc_AesSetKey (NULL, key16, (word32) sizeof(key16) / sizeof(byte),
@@ -7785,7 +7872,8 @@ static int test_wc_AesSetKey (void)
 static int test_wc_AesCbcEncryptDecrypt (void)
 {
     int     ret = 0;
-#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(HAVE_AES_DECRYPT)
+#if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(HAVE_AES_DECRYPT)&& \
+    defined(WOLFSSL_AES_256)
     Aes     aes;
     byte    key32[] =
     {
@@ -7931,7 +8019,7 @@ static int test_wc_AesCbcEncryptDecrypt (void)
 static int test_wc_AesCtrEncryptDecrypt (void)
 {
     int     ret = 0;
-#if !defined(NO_AES) && defined(WOLFSSL_AES_COUNTER)
+#if !defined(NO_AES) && defined(WOLFSSL_AES_COUNTER) && defined(WOLFSSL_AES_256)
     Aes     aesEnc, aesDec;
     byte    key32[] =
     {
@@ -8018,17 +8106,22 @@ static int test_wc_AesGcmSetKey (void)
 #if  !defined(NO_AES) && defined(HAVE_AESGCM)
 
     Aes     aes;
+#ifdef WOLFSSL_AES_128
     byte    key16[] =
     {
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
         0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
     };
+#endif
+#ifdef WOLFSSL_AES_192
     byte    key24[] =
     {
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
         0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37
     };
+#endif
+#ifdef WOLFSSL_AES_256
     byte    key32[] =
     {
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
@@ -8036,6 +8129,7 @@ static int test_wc_AesGcmSetKey (void)
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
         0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
     };
+#endif
     byte    badKey16[] =
     {
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
@@ -8061,13 +8155,19 @@ static int test_wc_AesGcmSetKey (void)
     if (ret != 0)
         return ret;
 
+#ifdef WOLFSSL_AES_128
     ret = wc_AesGcmSetKey(&aes, key16, sizeof(key16)/sizeof(byte));
+#endif
+#ifdef WOLFSSL_AES_192
     if (ret == 0) {
         ret = wc_AesGcmSetKey(&aes, key24, sizeof(key24)/sizeof(byte));
     }
+#endif
+#ifdef WOLFSSL_AES_256
     if (ret == 0) {
         ret = wc_AesGcmSetKey(&aes, key32, sizeof(key32)/sizeof(byte));
     }
+#endif
 
     /* Pass in bad args. */
     if (ret == 0) {
@@ -8099,7 +8199,7 @@ static int test_wc_AesGcmSetKey (void)
 static int test_wc_AesGcmEncryptDecrypt (void)
 {
     int     ret = 0;
-#if !defined(NO_AES) && defined(HAVE_AESGCM)
+#if !defined(NO_AES) && defined(HAVE_AESGCM) && defined(WOLFSSL_AES_256)
 
     Aes     aes;
     byte    key32[] =
@@ -8250,12 +8350,15 @@ static int test_wc_GmacSetKey (void)
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
         0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
     };
+#ifdef WOLFSSL_AES_192
     byte    key24[] =
     {
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
         0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37
     };
+#endif
+#ifdef WOLFSSL_AES_256
     byte    key32[] =
     {
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
@@ -8263,6 +8366,7 @@ static int test_wc_GmacSetKey (void)
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
         0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
     };
+#endif
     byte    badKey16[] =
     {
         0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
@@ -8288,13 +8392,19 @@ static int test_wc_GmacSetKey (void)
     if (ret != 0)
         return ret;
 
+#ifdef WOLFSSL_AES_128
     ret = wc_GmacSetKey(&gmac, key16, sizeof(key16)/sizeof(byte));
+#endif
+#ifdef WOLFSSL_AES_192
     if (ret == 0) {
         ret = wc_GmacSetKey(&gmac, key24, sizeof(key24)/sizeof(byte));
     }
+#endif
+#ifdef WOLFSSL_AES_256
     if (ret == 0) {
         ret = wc_GmacSetKey(&gmac, key32, sizeof(key32)/sizeof(byte));
     }
+#endif
 
     /* Pass in bad args. */
     if (ret == 0) {
@@ -8335,17 +8445,22 @@ static int test_wc_GmacUpdate (void)
     int     ret = 0;
 #if !defined(NO_AES) && defined(HAVE_AESGCM)
     Gmac    gmac;
+#ifdef WOLFSSL_AES_128
     const byte key16[] =
     {
         0x89, 0xc9, 0x49, 0xe9, 0xc8, 0x04, 0xaf, 0x01,
         0x4d, 0x56, 0x04, 0xb3, 0x94, 0x59, 0xf2, 0xc8
     };
+#endif
+#ifdef WOLFSSL_AES_192
     byte    key24[] =
     {
         0x41, 0xc5, 0xda, 0x86, 0x67, 0xef, 0x72, 0x52,
         0x20, 0xff, 0xe3, 0x9a, 0xe0, 0xac, 0x59, 0x0a,
         0xc9, 0xfc, 0xa7, 0x29, 0xab, 0x60, 0xad, 0xa0
     };
+#endif
+#ifdef WOLFSSL_AES_256
    byte    key32[] =
     {
         0x78, 0xdc, 0x4e, 0x0a, 0xaf, 0x52, 0xd9, 0x35,
@@ -8353,46 +8468,59 @@ static int test_wc_GmacUpdate (void)
         0xca, 0x1f, 0xd4, 0x75, 0xf5, 0xda, 0x86, 0xa4,
         0x9c, 0x8d, 0xd7, 0x3d, 0x68, 0xc8, 0xe2, 0x23
     };
+#endif
+#ifdef WOLFSSL_AES_128
     const byte authIn[] =
     {
         0x82, 0xad, 0xcd, 0x63, 0x8d, 0x3f, 0xa9, 0xd9,
         0xf3, 0xe8, 0x41, 0x00, 0xd6, 0x1e, 0x07, 0x77
     };
+#endif
+#ifdef WOLFSSL_AES_192
     const byte authIn2[] =
     {
        0x8b, 0x5c, 0x12, 0x4b, 0xef, 0x6e, 0x2f, 0x0f,
        0xe4, 0xd8, 0xc9, 0x5c, 0xd5, 0xfa, 0x4c, 0xf1
     };
+#endif
     const byte authIn3[] =
     {
         0xb9, 0x6b, 0xaa, 0x8c, 0x1c, 0x75, 0xa6, 0x71,
         0xbf, 0xb2, 0xd0, 0x8d, 0x06, 0xbe, 0x5f, 0x36
     };
+#ifdef WOLFSSL_AES_128
     const byte tag1[] = /* Known. */
     {
         0x88, 0xdb, 0x9d, 0x62, 0x17, 0x2e, 0xd0, 0x43,
         0xaa, 0x10, 0xf1, 0x6d, 0x22, 0x7d, 0xc4, 0x1b
     };
+#endif
+#ifdef WOLFSSL_AES_192
     const byte tag2[] = /* Known */
     {
         0x20, 0x4b, 0xdb, 0x1b, 0xd6, 0x21, 0x54, 0xbf,
         0x08, 0x92, 0x2a, 0xaa, 0x54, 0xee, 0xd7, 0x05
     };
+#endif
     const byte tag3[] = /* Known */
     {
         0x3e, 0x5d, 0x48, 0x6a, 0xa2, 0xe3, 0x0b, 0x22,
         0xe0, 0x40, 0xb8, 0x57, 0x23, 0xa0, 0x6e, 0x76
     };
+#ifdef WOLFSSL_AES_128
     const byte iv[] =
     {
         0xd1, 0xb1, 0x04, 0xc8, 0x15, 0xbf, 0x1e, 0x94,
         0xe2, 0x8c, 0x8f, 0x16
     };
+#endif
+#ifdef WOLFSSL_AES_192
     const byte iv2[] =
     {
         0x05, 0xad, 0x13, 0xa5, 0xe2, 0xc2, 0xab, 0x66,
         0x7e, 0x1a, 0x6f, 0xbc
     };
+#endif
     const byte iv3[] =
     {
         0xd7, 0x9c, 0xf2, 0x2d, 0x50, 0x4c, 0xc7, 0x93,
@@ -8413,6 +8541,7 @@ static int test_wc_GmacUpdate (void)
     if (ret != 0)
         return ret;
 
+#ifdef WOLFSSL_AES_128
     ret = wc_GmacSetKey(&gmac, key16, sizeof(key16));
     if (ret == 0) {
         ret = wc_GmacUpdate(&gmac, iv, sizeof(iv), authIn, sizeof(authIn),
@@ -8420,29 +8549,36 @@ static int test_wc_GmacUpdate (void)
         if (ret == 0) {
             ret = XMEMCMP(tag1, tagOut, sizeof(tag1));
         }
-        if (ret == 0) {
-            XMEMSET(&gmac, 0, sizeof(Gmac));
-            ret = wc_GmacSetKey(&gmac, key24, sizeof(key24)/sizeof(byte));
-        }
-        if (ret == 0) {
-            ret = wc_GmacUpdate(&gmac, iv2, sizeof(iv2), authIn2,
-                                sizeof(authIn2), tagOut2, sizeof(tag2));
-        }
-        if (ret == 0) {
-            ret = XMEMCMP(tagOut2, tag2, sizeof(tag2));
-        }
-        if (ret == 0) {
-            XMEMSET(&gmac, 0, sizeof(Gmac));
-            ret = wc_GmacSetKey(&gmac, key32, sizeof(key32)/sizeof(byte));
-        }
-        if (ret == 0) {
-            ret = wc_GmacUpdate(&gmac, iv3, sizeof(iv3), authIn3,
-                                sizeof(authIn3), tagOut3, sizeof(tag3));
-        }
-        if (ret == 0) {
-            ret = XMEMCMP(tag3, tagOut3, sizeof(tag3));
-        }
     }
+#endif
+
+#ifdef WOLFSSL_AES_192
+    if (ret == 0) {
+        XMEMSET(&gmac, 0, sizeof(Gmac));
+        ret = wc_GmacSetKey(&gmac, key24, sizeof(key24)/sizeof(byte));
+    }
+    if (ret == 0) {
+        ret = wc_GmacUpdate(&gmac, iv2, sizeof(iv2), authIn2,
+                            sizeof(authIn2), tagOut2, sizeof(tag2));
+    }
+    if (ret == 0) {
+        ret = XMEMCMP(tagOut2, tag2, sizeof(tag2));
+    }
+#endif
+
+#ifdef WOLFSSL_AES_256
+    if (ret == 0) {
+        XMEMSET(&gmac, 0, sizeof(Gmac));
+        ret = wc_GmacSetKey(&gmac, key32, sizeof(key32)/sizeof(byte));
+    }
+    if (ret == 0) {
+        ret = wc_GmacUpdate(&gmac, iv3, sizeof(iv3), authIn3,
+                            sizeof(authIn3), tagOut3, sizeof(tag3));
+    }
+    if (ret == 0) {
+        ret = XMEMCMP(tag3, tagOut3, sizeof(tag3));
+    }
+#endif
 
     /*Pass bad args. */
     if (ret == 0) {
@@ -10141,13 +10277,19 @@ static int test_wc_AesCcmSetKey (void)
     if (ret != 0)
         return ret;
 
+#ifdef WOLFSSL_AES_128
     ret = wc_AesCcmSetKey(&aes, key16, sizeof(key16));
+#endif
+#ifdef WOLFSSL_AES_192
     if (ret == 0) {
         ret = wc_AesCcmSetKey(&aes, key24, sizeof(key24));
-        if (ret == 0) {
-            ret = wc_AesCcmSetKey(&aes, key32, sizeof(key32));
-        }
     }
+#endif
+#ifdef WOLFSSL_AES_256
+    if (ret == 0) {
+        ret = wc_AesCcmSetKey(&aes, key32, sizeof(key32));
+    }
+#endif
 
     /* Test bad args. */
     if (ret == 0) {
@@ -10180,7 +10322,7 @@ static int test_wc_AesCcmSetKey (void)
 static int test_wc_AesCcmEncryptDecrypt (void)
 {
     int ret = 0;
-#ifdef HAVE_AESCCM
+#if defined(HAVE_AESCCM) && defined(WOLFSSL_AES_128)
     Aes aes;
     const byte  key16[] =
     {
@@ -12883,7 +13025,7 @@ static int test_wc_ecc_encryptDecrypt (void)
 {
     int         ret = 0;
 
-#if defined(HAVE_ECC) && defined(HAVE_ECC_ENCRYPT)
+#if defined(HAVE_ECC) && defined(HAVE_ECC_ENCRYPT) && defined(WOLFSSL_AES_128)
     ecc_key     srvKey, cliKey;
     WC_RNG      rng;
     const char* msg   = "EccBlock Size 16";
@@ -17007,8 +17149,14 @@ static int my_DhCallback(WOLFSSL* ssl, struct DhKey* key,
 
 static void test_dh_ctx_setup(WOLFSSL_CTX* ctx) {
     wolfSSL_CTX_SetDhAgreeCb(ctx, my_DhCallback);
+#ifdef WOLFSSL_AES_128
     AssertIntEQ(wolfSSL_CTX_set_cipher_list(ctx, "DHE-RSA-AES128-SHA256"),
             WOLFSSL_SUCCESS);
+#endif
+#ifdef WOLFSSL_AES_256
+    AssertIntEQ(wolfSSL_CTX_set_cipher_list(ctx, "DHE-RSA-AES256-SHA256"),
+            WOLFSSL_SUCCESS);
+#endif
 }
 
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1703,12 +1703,18 @@ exit:
 
 void bench_aescbc(int doAsync)
 {
+#ifdef WOLFSSL_AES_128
     bench_aescbc_internal(doAsync, bench_key, 16, bench_iv,
                  "AES-128-CBC-enc", "AES-128-CBC-dec");
+#endif
+#ifdef WOLFSSL_AES_192
     bench_aescbc_internal(doAsync, bench_key, 24, bench_iv,
                  "AES-192-CBC-enc", "AES-192-CBC-dec");
+#endif
+#ifdef WOLFSSL_AES_256
     bench_aescbc_internal(doAsync, bench_key, 32, bench_iv,
                  "AES-256-CBC-enc", "AES-256-CBC-dec");
+#endif
 }
 
 #endif /* HAVE_AES_CBC */
@@ -1815,12 +1821,18 @@ exit:
 
 void bench_aesgcm(int doAsync)
 {
+#ifdef WOLFSSL_AES_128
     bench_aesgcm_internal(doAsync, bench_key, 16, bench_iv, 12,
                           "AES-128-GCM-enc", "AES-128-GCM-dec");
+#endif
+#ifdef WOLFSSL_AES_192
     bench_aesgcm_internal(doAsync, bench_key, 24, bench_iv, 12,
                           "AES-192-GCM-enc", "AES-192-GCM-dec");
+#endif
+#ifdef WOLFSSL_AES_256
     bench_aesgcm_internal(doAsync, bench_key, 32, bench_iv, 12,
                           "AES-256-GCM-enc", "AES-256-GCM-dec");
+#endif
 }
 #endif /* HAVE_AESGCM */
 
@@ -1917,12 +1929,18 @@ exit:
 
 void bench_aesecb(int doAsync)
 {
+#ifdef WOLFSSL_AES_128
     bench_aesecb_internal(doAsync, bench_key, 16,
                  "AES-128-ECB-enc", "AES-128-ECB-dec");
+#endif
+#ifdef WOLFSSL_AES_192
     bench_aesecb_internal(doAsync, bench_key, 24,
                  "AES-192-ECB-enc", "AES-192-ECB-dec");
+#endif
+#ifdef WOLFSSL_AES_256
     bench_aesecb_internal(doAsync, bench_key, 32,
                  "AES-256-ECB-enc", "AES-256-ECB-dec");
+#endif
 }
 #endif /* WOLFSSL_AES_DIRECT */
 
@@ -1956,9 +1974,15 @@ static void bench_aescfb_internal(const byte* key, word32 keySz, const byte* iv,
 
 void bench_aescfb(void)
 {
+#ifdef WOLFSSL_AES_128
     bench_aescfb_internal(bench_key, 16, bench_iv, "AES-128-CFB");
+#endif
+#ifdef WOLFSSL_AES_192
     bench_aescfb_internal(bench_key, 24, bench_iv, "AES-192-CFB");
+#endif
+#ifdef WOLFSSL_AES_256
     bench_aescfb_internal(bench_key, 32, bench_iv, "AES-256-CFB");
+#endif
 }
 #endif /* WOLFSSL_AES_CFB */
 
@@ -2053,9 +2077,15 @@ static void bench_aesctr_internal(const byte* key, word32 keySz, const byte* iv,
 
 void bench_aesctr(void)
 {
+#ifdef WOLFSSL_AES_128
     bench_aesctr_internal(bench_key, 16, bench_iv, "AES-128-CTR");
+#endif
+#ifdef WOLFSSL_AES_192
     bench_aesctr_internal(bench_key, 24, bench_iv, "AES-192-CTR");
+#endif
+#ifdef WOLFSSL_AES_256
     bench_aesctr_internal(bench_key, 32, bench_iv, "AES-256-CTR");
+#endif
 }
 #endif /* WOLFSSL_AES_COUNTER */
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1694,6 +1694,7 @@ exit_aes_dec:
 
 #endif /* HAVE_AES_DECRYPT */
 
+    (void)decLabel;
 exit:
 
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
@@ -1781,6 +1782,7 @@ static void bench_aesgcm_internal(int doAsync, const byte* key, word32 keySz,
 exit_aes_gcm:
     bench_stats_sym_finish(encLabel, doAsync, count, bench_size, start, ret);
 
+#ifdef HAVE_AES_DECRYPT
     /* GCM uses same routine in backend for both encrypt and decrypt */
     bench_stats_start(&count, &start);
     do {
@@ -1804,6 +1806,9 @@ exit_aes_gcm:
     } while (bench_stats_sym_check(start));
 exit_aes_gcm_dec:
     bench_stats_sym_finish(decLabel, doAsync, count, bench_size, start, ret);
+#endif /* HAVE_AES_DECRYPT */
+
+    (void)decLabel;
 
 exit:
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -2031,7 +2031,8 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 #ifdef NEED_AES_TABLES
 
         switch (keylen) {
-    #if defined(AES_MAX_KEY_SIZE) && AES_MAX_KEY_SIZE >= 128
+    #if defined(AES_MAX_KEY_SIZE) && AES_MAX_KEY_SIZE >= 128 && \
+            defined(WOLFSSL_AES_128)
         case 16:
             while (1)
             {
@@ -2052,7 +2053,8 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
             break;
     #endif /* 128 */
 
-    #if defined(AES_MAX_KEY_SIZE) && AES_MAX_KEY_SIZE >= 192
+    #if defined(AES_MAX_KEY_SIZE) && AES_MAX_KEY_SIZE >= 192 && \
+            defined(WOLFSSL_AES_192)
         case 24:
             /* for (;;) here triggers a bug in VC60 SP4 w/ Pro Pack */
             while (1)
@@ -2076,7 +2078,8 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
             break;
     #endif /* 192 */
 
-    #if defined(AES_MAX_KEY_SIZE) && AES_MAX_KEY_SIZE >= 256
+    #if defined(AES_MAX_KEY_SIZE) && AES_MAX_KEY_SIZE >= 256 && \
+            defined(WOLFSSL_AES_256)
         case 32:
             while (1)
             {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7075,30 +7075,30 @@ WOLFSSL_LOCAL int GetSerialNumber(const byte* input, word32* inOutIdx,
 
 
 
-const char* BEGIN_CERT         = "-----BEGIN CERTIFICATE-----";
-const char* END_CERT           = "-----END CERTIFICATE-----";
-const char* BEGIN_CERT_REQ     = "-----BEGIN CERTIFICATE REQUEST-----";
-const char* END_CERT_REQ       = "-----END CERTIFICATE REQUEST-----";
-const char* BEGIN_DH_PARAM     = "-----BEGIN DH PARAMETERS-----";
-const char* END_DH_PARAM       = "-----END DH PARAMETERS-----";
-const char* BEGIN_DSA_PARAM    = "-----BEGIN DSA PARAMETERS-----";
-const char* END_DSA_PARAM      = "-----END DSA PARAMETERS-----";
-const char* BEGIN_X509_CRL     = "-----BEGIN X509 CRL-----";
-const char* END_X509_CRL       = "-----END X509 CRL-----";
-const char* BEGIN_RSA_PRIV     = "-----BEGIN RSA PRIVATE KEY-----";
-const char* END_RSA_PRIV       = "-----END RSA PRIVATE KEY-----";
-const char* BEGIN_PRIV_KEY     = "-----BEGIN PRIVATE KEY-----";
-const char* END_PRIV_KEY       = "-----END PRIVATE KEY-----";
-const char* BEGIN_ENC_PRIV_KEY = "-----BEGIN ENCRYPTED PRIVATE KEY-----";
-const char* END_ENC_PRIV_KEY   = "-----END ENCRYPTED PRIVATE KEY-----";
-const char* BEGIN_EC_PRIV      = "-----BEGIN EC PRIVATE KEY-----";
-const char* END_EC_PRIV        = "-----END EC PRIVATE KEY-----";
-const char* BEGIN_DSA_PRIV     = "-----BEGIN DSA PRIVATE KEY-----";
-const char* END_DSA_PRIV       = "-----END DSA PRIVATE KEY-----";
-const char* BEGIN_PUB_KEY      = "-----BEGIN PUBLIC KEY-----";
-const char* END_PUB_KEY        = "-----END PUBLIC KEY-----";
-const char* BEGIN_EDDSA_PRIV   = "-----BEGIN EDDSA PRIVATE KEY-----";
-const char* END_EDDSA_PRIV     = "-----END EDDSA PRIVATE KEY-----";
+const char* const BEGIN_CERT         = "-----BEGIN CERTIFICATE-----";
+const char* const END_CERT           = "-----END CERTIFICATE-----";
+const char* const BEGIN_CERT_REQ     = "-----BEGIN CERTIFICATE REQUEST-----";
+const char* const END_CERT_REQ       = "-----END CERTIFICATE REQUEST-----";
+const char* const BEGIN_DH_PARAM     = "-----BEGIN DH PARAMETERS-----";
+const char* const END_DH_PARAM       = "-----END DH PARAMETERS-----";
+const char* const BEGIN_DSA_PARAM    = "-----BEGIN DSA PARAMETERS-----";
+const char* const END_DSA_PARAM      = "-----END DSA PARAMETERS-----";
+const char* const BEGIN_X509_CRL     = "-----BEGIN X509 CRL-----";
+const char* const END_X509_CRL       = "-----END X509 CRL-----";
+const char* const BEGIN_RSA_PRIV     = "-----BEGIN RSA PRIVATE KEY-----";
+const char* const END_RSA_PRIV       = "-----END RSA PRIVATE KEY-----";
+const char* const BEGIN_PRIV_KEY     = "-----BEGIN PRIVATE KEY-----";
+const char* const END_PRIV_KEY       = "-----END PRIVATE KEY-----";
+const char* const BEGIN_ENC_PRIV_KEY = "-----BEGIN ENCRYPTED PRIVATE KEY-----";
+const char* const END_ENC_PRIV_KEY   = "-----END ENCRYPTED PRIVATE KEY-----";
+const char* const BEGIN_EC_PRIV      = "-----BEGIN EC PRIVATE KEY-----";
+const char* const END_EC_PRIV        = "-----END EC PRIVATE KEY-----";
+const char* const BEGIN_DSA_PRIV     = "-----BEGIN DSA PRIVATE KEY-----";
+const char* const END_DSA_PRIV       = "-----END DSA PRIVATE KEY-----";
+const char* const BEGIN_PUB_KEY      = "-----BEGIN PUBLIC KEY-----";
+const char* const END_PUB_KEY        = "-----END PUBLIC KEY-----";
+const char* const BEGIN_EDDSA_PRIV   = "-----BEGIN EDDSA PRIVATE KEY-----";
+const char* const END_EDDSA_PRIV     = "-----END EDDSA PRIVATE KEY-----";
 
 #if defined(WOLFSSL_KEY_GEN) || defined(WOLFSSL_CERT_GEN) || defined(OPENSSL_EXTRA)
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -783,39 +783,87 @@ static word32 SetBitString16Bit(word16 val, byte* output)
 
 
 /* hashType */
-static const byte hashMd2hOid[] = {42, 134, 72, 134, 247, 13, 2, 2};
-static const byte hashMd5hOid[] = {42, 134, 72, 134, 247, 13, 2, 5};
-static const byte hashSha1hOid[] = {43, 14, 3, 2, 26};
-static const byte hashSha224hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 4};
-static const byte hashSha256hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 1};
-static const byte hashSha384hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 2};
-static const byte hashSha512hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 3};
+#ifdef WOLFSSL_MD2
+    static const byte hashMd2hOid[] = {42, 134, 72, 134, 247, 13, 2, 2};
+#endif
+#ifndef NO_MD5
+    static const byte hashMd5hOid[] = {42, 134, 72, 134, 247, 13, 2, 5};
+#endif
+#ifndef NO_SHA
+    static const byte hashSha1hOid[] = {43, 14, 3, 2, 26};
+#endif
+#ifdef WOLFSSL_SHA224
+    static const byte hashSha224hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 4};
+#endif
+#ifndef NO_SHA256
+    static const byte hashSha256hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 1};
+#endif
+#ifdef WOLFSSL_SHA384
+    static const byte hashSha384hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 2};
+#endif
+#ifdef WOLFSSL_SHA512
+    static const byte hashSha512hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 3};
+#endif
 
 /* hmacType */
-static const byte hmacSha224Oid[] = {42, 134, 72, 134, 247, 13, 2, 8};
-static const byte hmacSha256Oid[] = {42, 134, 72, 134, 247, 13, 2, 9};
-static const byte hmacSha384Oid[] = {42, 134, 72, 134, 247, 13, 2, 10};
-static const byte hmacSha512Oid[] = {42, 134, 72, 134, 247, 13, 2, 11};
+#ifndef NO_HMAC
+    #ifdef WOLFSSL_SHA224
+    static const byte hmacSha224Oid[] = {42, 134, 72, 134, 247, 13, 2, 8};
+    #endif
+    #ifndef NO_SHA256
+    static const byte hmacSha256Oid[] = {42, 134, 72, 134, 247, 13, 2, 9};
+    #endif
+    #ifdef WOLFSSL_SHA384
+    static const byte hmacSha384Oid[] = {42, 134, 72, 134, 247, 13, 2, 10};
+    #endif
+    #ifdef WOLFSSL_SHA512
+    static const byte hmacSha512Oid[] = {42, 134, 72, 134, 247, 13, 2, 11};
+    #endif
+#endif
 
 /* sigType */
-#ifndef NO_DSA
+#if !defined(NO_DSA) && !defined(NO_SHA)
     static const byte sigSha1wDsaOid[] = {42, 134, 72, 206, 56, 4, 3};
 #endif /* NO_DSA */
 #ifndef NO_RSA
+    #ifdef WOLFSSL_MD2
     static const byte sigMd2wRsaOid[] = {42, 134, 72, 134, 247, 13, 1, 1, 2};
+    #endif
+    #ifndef NO_MD5
     static const byte sigMd5wRsaOid[] = {42, 134, 72, 134, 247, 13, 1, 1, 4};
+    #endif
+    #ifndef NO_SHA
     static const byte sigSha1wRsaOid[] = {42, 134, 72, 134, 247, 13, 1, 1, 5};
+    #endif
+    #ifdef WOLFSSL_SHA224
     static const byte sigSha224wRsaOid[] = {42, 134, 72, 134, 247, 13, 1, 1,14};
+    #endif
+    #ifndef NO_SHA256
     static const byte sigSha256wRsaOid[] = {42, 134, 72, 134, 247, 13, 1, 1,11};
+    #endif
+    #ifdef WOLFSSL_SHA384
     static const byte sigSha384wRsaOid[] = {42, 134, 72, 134, 247, 13, 1, 1,12};
+    #endif
+    #ifdef WOLFSSL_SHA512
     static const byte sigSha512wRsaOid[] = {42, 134, 72, 134, 247, 13, 1, 1,13};
+    #endif
 #endif /* NO_RSA */
 #ifdef HAVE_ECC
+    #ifndef NO_SHA
     static const byte sigSha1wEcdsaOid[] = {42, 134, 72, 206, 61, 4, 1};
+    #endif
+    #ifdef WOLFSSL_SHA224
     static const byte sigSha224wEcdsaOid[] = {42, 134, 72, 206, 61, 4, 3, 1};
+    #endif
+    #ifndef NO_SHA256
     static const byte sigSha256wEcdsaOid[] = {42, 134, 72, 206, 61, 4, 3, 2};
+    #endif
+    #ifdef WOLFSSL_SHA384
     static const byte sigSha384wEcdsaOid[] = {42, 134, 72, 206, 61, 4, 3, 3};
+    #endif
+    #ifdef WOLFSSL_SHA512
     static const byte sigSha512wEcdsaOid[] = {42, 134, 72, 206, 61, 4, 3, 4};
+    #endif
 #endif /* HAVE_ECC */
 #ifdef HAVE_ED25519
     static const byte sigEd25519Oid[] = {43, 101, 112};
@@ -905,11 +953,17 @@ static const byte extExtKeyUsageOcspSignOid[]     = {43, 6, 1, 5, 5, 7, 3, 9};
 static const byte pbkdf2Oid[] = {42, 134, 72, 134, 247, 13, 1, 5, 12};
 
 /* PKCS5 */
+#if !defined(NO_DES3) && !defined(NO_SHA)
 static const byte pbeSha1Des[] = {42, 134, 72, 134, 247, 13, 1, 5, 10};
+#endif
 
 /* PKCS12 */
+#if !defined(NO_RC4) && !defined(NO_SHA)
 static const byte pbeSha1RC4128[] = {42, 134, 72, 134, 247, 13, 1, 12, 1, 1};
+#endif
+#if !defined(NO_DES3) && !defined(NO_SHA)
 static const byte pbeSha1Des3[] = {42, 134, 72, 134, 247, 13, 1, 12, 1, 3};
+#endif
 
 
 /* returns a pointer to the OID string on success and NULL on fail */
@@ -923,96 +977,134 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
 
         case oidHashType:
             switch (id) {
+            #ifdef WOLFSSL_MD2
                 case MD2h:
                     oid = hashMd2hOid;
                     *oidSz = sizeof(hashMd2hOid);
                     break;
+            #endif
+            #ifndef NO_MD5
                 case MD5h:
                     oid = hashMd5hOid;
                     *oidSz = sizeof(hashMd5hOid);
                     break;
+            #endif
+            #ifndef NO_SHA
                 case SHAh:
                     oid = hashSha1hOid;
                     *oidSz = sizeof(hashSha1hOid);
                     break;
+            #endif
+            #ifdef WOLFSSL_SHA224
                 case SHA224h:
                     oid = hashSha224hOid;
                     *oidSz = sizeof(hashSha224hOid);
                     break;
+            #endif
+            #ifndef NO_SHA256
                 case SHA256h:
                     oid = hashSha256hOid;
                     *oidSz = sizeof(hashSha256hOid);
                     break;
+            #endif
+            #ifdef WOLFSSL_SHA384
                 case SHA384h:
                     oid = hashSha384hOid;
                     *oidSz = sizeof(hashSha384hOid);
                     break;
+            #endif
+            #ifdef WOLFSSL_SHA512
                 case SHA512h:
                     oid = hashSha512hOid;
                     *oidSz = sizeof(hashSha512hOid);
                     break;
+            #endif
             }
             break;
 
         case oidSigType:
             switch (id) {
-                #ifndef NO_DSA
+                #if !defined(NO_DSA) && !defined(NO_SHA)
                 case CTC_SHAwDSA:
                     oid = sigSha1wDsaOid;
                     *oidSz = sizeof(sigSha1wDsaOid);
                     break;
                 #endif /* NO_DSA */
                 #ifndef NO_RSA
+                #ifdef WOLFSSL_MD2
                 case CTC_MD2wRSA:
                     oid = sigMd2wRsaOid;
                     *oidSz = sizeof(sigMd2wRsaOid);
                     break;
+                #endif
+                #ifndef NO_MD5
                 case CTC_MD5wRSA:
                     oid = sigMd5wRsaOid;
                     *oidSz = sizeof(sigMd5wRsaOid);
                     break;
+                #endif
+                #ifndef NO_SHA
                 case CTC_SHAwRSA:
                     oid = sigSha1wRsaOid;
                     *oidSz = sizeof(sigSha1wRsaOid);
                     break;
+                #endif
+                #ifdef WOLFSSL_SHA224
                 case CTC_SHA224wRSA:
                     oid = sigSha224wRsaOid;
                     *oidSz = sizeof(sigSha224wRsaOid);
                     break;
+                #endif
+                #ifndef NO_SHA256
                 case CTC_SHA256wRSA:
                     oid = sigSha256wRsaOid;
                     *oidSz = sizeof(sigSha256wRsaOid);
                     break;
+                #endif
+                #ifdef WOLFSSL_SHA384
                 case CTC_SHA384wRSA:
                     oid = sigSha384wRsaOid;
                     *oidSz = sizeof(sigSha384wRsaOid);
                     break;
+                #endif
+                #ifdef WOLFSSL_SHA512
                 case CTC_SHA512wRSA:
                     oid = sigSha512wRsaOid;
                     *oidSz = sizeof(sigSha512wRsaOid);
                     break;
+                #endif /* WOLFSSL_SHA512 */
                 #endif /* NO_RSA */
                 #ifdef HAVE_ECC
+                #ifndef NO_SHA
                 case CTC_SHAwECDSA:
                     oid = sigSha1wEcdsaOid;
                     *oidSz = sizeof(sigSha1wEcdsaOid);
                     break;
+                #endif
+                #ifdef WOLFSSL_SHA224
                 case CTC_SHA224wECDSA:
                     oid = sigSha224wEcdsaOid;
                     *oidSz = sizeof(sigSha224wEcdsaOid);
                     break;
+                #endif
+                #ifndef NO_SHA256
                 case CTC_SHA256wECDSA:
                     oid = sigSha256wEcdsaOid;
                     *oidSz = sizeof(sigSha256wEcdsaOid);
                     break;
+                #endif
+                #ifdef WOLFSSL_SHA384
                 case CTC_SHA384wECDSA:
                     oid = sigSha384wEcdsaOid;
                     *oidSz = sizeof(sigSha384wEcdsaOid);
                     break;
+                #endif
+                #ifdef WOLFSSL_SHA512
                 case CTC_SHA512wECDSA:
                     oid = sigSha512wEcdsaOid;
                     *oidSz = sizeof(sigSha512wEcdsaOid);
                     break;
+                #endif
                 #endif /* HAVE_ECC */
                 #ifdef HAVE_ED25519
                 case CTC_ED25519:
@@ -1072,18 +1164,27 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
 
         case oidBlkType:
             switch (id) {
+    #ifdef HAVE_AES_CBC
+        #ifdef WOLFSSL_AES_128
                 case AES128CBCb:
                     oid = blkAes128CbcOid;
                     *oidSz = sizeof(blkAes128CbcOid);
                     break;
+        #endif
+        #ifdef WOLFSSL_AES_192
                 case AES192CBCb:
                     oid = blkAes192CbcOid;
                     *oidSz = sizeof(blkAes192CbcOid);
                     break;
+        #endif
+        #ifdef WOLFSSL_AES_256
                 case AES256CBCb:
                     oid = blkAes256CbcOid;
                     *oidSz = sizeof(blkAes256CbcOid);
                     break;
+        #endif
+    #endif /* HAVE_AES_CBC */
+    #ifndef NO_DES3
                 case DESb:
                     oid = blkDesCbcOid;
                     *oidSz = sizeof(blkDesCbcOid);
@@ -1092,6 +1193,7 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                     oid = blkDes3CbcOid;
                     *oidSz = sizeof(blkDes3CbcOid);
                     break;
+    #endif /* !NO_DES3 */
             }
             break;
 
@@ -1234,20 +1336,25 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
 
         case oidPBEType:
             switch (id) {
+        #if !defined(NO_SHA) && !defined(NO_RC4)
                 case PBE_SHA1_RC4_128:
                     oid = pbeSha1RC4128;
                     *oidSz = sizeof(pbeSha1RC4128);
                     break;
-
+        #endif
+        #if !defined(NO_SHA) && !defined(NO_DES3)
                 case PBE_SHA1_DES:
                     oid = pbeSha1Des;
                     *oidSz = sizeof(pbeSha1Des);
                     break;
 
+        #endif
+        #if !defined(NO_SHA) && !defined(NO_DES3)
                 case PBE_SHA1_DES3:
                     oid = pbeSha1Des3;
                     *oidSz = sizeof(pbeSha1Des3);
                     break;
+        #endif
             }
             break;
 
@@ -1293,26 +1400,36 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
             }
             break;
 
+#ifndef NO_HMAC
         case oidHmacType:
             switch (id) {
+        #ifdef WOLFSSL_SHA224
                 case HMAC_SHA224_OID:
                     oid = hmacSha224Oid;
                     *oidSz = sizeof(hmacSha224Oid);
                     break;
+        #endif
+        #ifndef NO_SHA256
                 case HMAC_SHA256_OID:
                     oid = hmacSha256Oid;
                     *oidSz = sizeof(hmacSha256Oid);
                     break;
+        #endif
+        #ifdef WOLFSSL_SHA284
                 case HMAC_SHA384_OID:
                     oid = hmacSha384Oid;
                     *oidSz = sizeof(hmacSha384Oid);
                     break;
+        #endif
+        #ifdef WOLFSSL_SHA512
                 case HMAC_SHA512_OID:
                     oid = hmacSha512Oid;
                     *oidSz = sizeof(hmacSha512Oid);
                     break;
+        #endif
             }
             break;
+#endif /* !NO_HMAC */
 
         case oidIgnoreType:
         default:

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3591,7 +3591,7 @@ void FreeDecodedCert(DecodedCert* cert)
     XFREE(cert->hwType, cert->heap, DYNAMIC_TYPE_X509_EXT);
     XFREE(cert->hwSerialNum, cert->heap, DYNAMIC_TYPE_X509_EXT);
 #endif /* WOLFSSL_SEP */
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     if (cert->issuerName.fullName != NULL)
         XFREE(cert->issuerName.fullName, cert->heap, DYNAMIC_TYPE_X509);
     if (cert->subjectName.fullName != NULL)
@@ -3829,7 +3829,7 @@ static int GetName(DecodedCert* cert, int nameType)
     char*  full;
     byte*  hash;
     word32 idx;
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         DecodedName* dName =
                   (nameType == ISSUER) ? &cert->issuerName : &cert->subjectName;
         int dcnum = 0;
@@ -3941,7 +3941,7 @@ static int GetName(DecodedCert* cert, int nameType)
                     idx += 4;
                     copy = TRUE;
                 }
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     dName->cnIdx = cert->srcIdx;
                     dName->cnLen = strLen;
                 #endif /* OPENSSL_EXTRA */
@@ -3959,7 +3959,7 @@ static int GetName(DecodedCert* cert, int nameType)
                         cert->subjectSNEnc = b;
                     }
                 #endif /* WOLFSSL_CERT_GEN */
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     dName->snIdx = cert->srcIdx;
                     dName->snLen = strLen;
                 #endif /* OPENSSL_EXTRA */
@@ -3977,7 +3977,7 @@ static int GetName(DecodedCert* cert, int nameType)
                         cert->subjectCEnc = b;
                     }
                 #endif /* WOLFSSL_CERT_GEN */
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     dName->cIdx = cert->srcIdx;
                     dName->cLen = strLen;
                 #endif /* OPENSSL_EXTRA */
@@ -3995,7 +3995,7 @@ static int GetName(DecodedCert* cert, int nameType)
                         cert->subjectLEnc = b;
                     }
                 #endif /* WOLFSSL_CERT_GEN */
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     dName->lIdx = cert->srcIdx;
                     dName->lLen = strLen;
                 #endif /* OPENSSL_EXTRA */
@@ -4013,7 +4013,7 @@ static int GetName(DecodedCert* cert, int nameType)
                         cert->subjectSTEnc = b;
                     }
                 #endif /* WOLFSSL_CERT_GEN */
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     dName->stIdx = cert->srcIdx;
                     dName->stLen = strLen;
                 #endif /* OPENSSL_EXTRA */
@@ -4031,7 +4031,7 @@ static int GetName(DecodedCert* cert, int nameType)
                         cert->subjectOEnc = b;
                     }
                 #endif /* WOLFSSL_CERT_GEN */
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     dName->oIdx = cert->srcIdx;
                     dName->oLen = strLen;
                 #endif /* OPENSSL_EXTRA */
@@ -4049,7 +4049,7 @@ static int GetName(DecodedCert* cert, int nameType)
                         cert->subjectOUEnc = b;
                     }
                 #endif /* WOLFSSL_CERT_GEN */
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     dName->ouIdx = cert->srcIdx;
                     dName->ouLen = strLen;
                 #endif /* OPENSSL_EXTRA */
@@ -4060,7 +4060,7 @@ static int GetName(DecodedCert* cert, int nameType)
                    idx += 14;
                    copy = TRUE;
                 }
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     dName->snIdx = cert->srcIdx;
                     dName->snLen = strLen;
                 #endif /* OPENSSL_EXTRA */
@@ -4114,7 +4114,7 @@ static int GetName(DecodedCert* cert, int nameType)
                         cert->subjectEmailLen = adv;
                     }
                 #endif /* WOLFSSL_CERT_GEN */
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     dName->emailIdx = cert->srcIdx;
                     dName->emailLen = adv;
                 #endif /* OPENSSL_EXTRA */
@@ -4160,7 +4160,8 @@ static int GetName(DecodedCert* cert, int nameType)
                         case ASN_USER_ID:
                             XMEMCPY(&full[idx], "/UID=", 5);
                             idx += 5;
-                        #ifdef OPENSSL_EXTRA
+                        #if defined(OPENSSL_EXTRA) || \
+                            defined(OPENSSL_EXTRA_X509_SMALL)
                             dName->uidIdx = cert->srcIdx;
                             dName->uidLen = adv;
                         #endif /* OPENSSL_EXTRA */
@@ -4169,7 +4170,8 @@ static int GetName(DecodedCert* cert, int nameType)
                         case ASN_DOMAIN_COMPONENT:
                             XMEMCPY(&full[idx], "/DC=", 4);
                             idx += 4;
-                        #ifdef OPENSSL_EXTRA
+                        #if defined(OPENSSL_EXTRA) || \
+                            defined(OPENSSL_EXTRA_X509_SMALL)
                             dName->dcIdx[dcnum] = cert->srcIdx;
                             dName->dcLen[dcnum] = adv;
                             dName->dcNum = dcnum + 1;
@@ -4191,7 +4193,7 @@ static int GetName(DecodedCert* cert, int nameType)
     }
     full[idx++] = 0;
 
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     {
         int totalLen = 0;
         int i = 0;
@@ -5925,7 +5927,7 @@ static int DecodeAuthKeyId(byte* input, int sz, DecodedCert* cert)
         return ASN_PARSE_E;
     }
 
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     cert->extAuthKeyIdSrc = &input[idx];
     cert->extAuthKeyIdSz = length;
 #endif /* OPENSSL_EXTRA */
@@ -5959,7 +5961,7 @@ static int DecodeSubjKeyId(byte* input, int sz, DecodedCert* cert)
     if (ret < 0)
         return ret;
 
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         cert->extSubjKeyIdSrc = &input[idx];
         cert->extSubjKeyIdSz = length;
     #endif /* OPENSSL_EXTRA */
@@ -6010,7 +6012,7 @@ static int DecodeExtKeyUsage(byte* input, int sz, DecodedCert* cert)
         return ASN_PARSE_E;
     }
 
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     cert->extExtKeyUsageSrc = input + idx;
     cert->extExtKeyUsageSz = length;
 #endif
@@ -6043,7 +6045,7 @@ static int DecodeExtKeyUsage(byte* input, int sz, DecodedCert* cert)
                 break;
         }
 
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         cert->extExtKeyUsageCount++;
     #endif
     }
@@ -6427,7 +6429,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
         switch (oid) {
             case BASIC_CA_OID:
                 VERIFY_AND_SET_OID(cert->extBasicConstSet);
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     cert->extBasicConstCrit = critical;
                 #endif
                 if (DecodeBasicCaConstraint(&input[idx], length, cert) < 0)
@@ -6436,7 +6438,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
 
             case CRL_DIST_OID:
                 VERIFY_AND_SET_OID(cert->extCRLdistSet);
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     cert->extCRLdistCrit = critical;
                 #endif
                 if (DecodeCrlDist(&input[idx], length, cert) < 0)
@@ -6445,7 +6447,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
 
             case AUTH_INFO_OID:
                 VERIFY_AND_SET_OID(cert->extAuthInfoSet);
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     cert->extAuthInfoCrit = critical;
                 #endif
                 if (DecodeAuthInfo(&input[idx], length, cert) < 0)
@@ -6454,7 +6456,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
 
             case ALT_NAMES_OID:
                 VERIFY_AND_SET_OID(cert->extSubjAltNameSet);
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     cert->extSubjAltNameCrit = critical;
                 #endif
                 ret = DecodeAltNames(&input[idx], length, cert);
@@ -6464,7 +6466,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
 
             case AUTH_KEY_OID:
                 VERIFY_AND_SET_OID(cert->extAuthKeyIdSet);
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     cert->extAuthKeyIdCrit = critical;
                 #endif
                 if (DecodeAuthKeyId(&input[idx], length, cert) < 0)
@@ -6473,7 +6475,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
 
             case SUBJ_KEY_OID:
                 VERIFY_AND_SET_OID(cert->extSubjKeyIdSet);
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     cert->extSubjKeyIdCrit = critical;
                 #endif
                 #ifndef WOLFSSL_ALLOW_CRIT_SKID
@@ -6495,7 +6497,8 @@ static int DecodeCertExtensions(DecodedCert* cert)
             case CERT_POLICY_OID:
                 #ifdef WOLFSSL_SEP
                     VERIFY_AND_SET_OID(cert->extCertPolicySet);
-                    #ifdef OPENSSL_EXTRA
+                    #if defined(OPENSSL_EXTRA) || \
+                        defined(OPENSSL_EXTRA_X509_SMALL)
                         cert->extCertPolicyCrit = critical;
                     #endif
                 #endif
@@ -6510,7 +6513,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
 
             case KEY_USAGE_OID:
                 VERIFY_AND_SET_OID(cert->extKeyUsageSet);
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     cert->extKeyUsageCrit = critical;
                 #endif
                 if (DecodeKeyUsage(&input[idx], length, cert) < 0)
@@ -6519,7 +6522,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
 
             case EXT_KEY_USAGE_OID:
                 VERIFY_AND_SET_OID(cert->extExtKeyUsageSet);
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     cert->extExtKeyUsageCrit = critical;
                 #endif
                 if (DecodeExtKeyUsage(&input[idx], length, cert) < 0)
@@ -6538,7 +6541,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
                 }
             #endif
                 VERIFY_AND_SET_OID(cert->extNameConstraintSet);
-                #ifdef OPENSSL_EXTRA
+                #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     cert->extNameConstraintCrit = critical;
                 #endif
                 if (DecodeNameConstraints(&input[idx], length, cert) < 0)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -939,17 +939,34 @@ static word32 SetBitString16Bit(word16 val, byte* output)
     /* See "ecc_sets" table in ecc.c */
 #endif /* HAVE_ECC */
 
+#ifdef HAVE_AES_CBC
 /* blkType */
-static const byte blkAes128CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 2};
-static const byte blkAes192CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 22};
-static const byte blkAes256CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 42};
-static const byte blkDesCbcOid[]  = {43, 14, 3, 2, 7};
-static const byte blkDes3CbcOid[] = {42, 134, 72, 134, 247, 13, 3, 7};
+    #ifdef WOLFSSL_AES_128
+    static const byte blkAes128CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 2};
+    #endif
+    #ifdef WOLFSSL_AES_192
+    static const byte blkAes192CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 22};
+    #endif
+    #ifdef WOLFSSL_AES_256
+    static const byte blkAes256CbcOid[] = {96, 134, 72, 1, 101, 3, 4, 1, 42};
+    #endif
+#endif /* HAVE_AES_CBC */
+
+#ifndef NO_DES3
+    static const byte blkDesCbcOid[]  = {43, 14, 3, 2, 7};
+    static const byte blkDes3CbcOid[] = {42, 134, 72, 134, 247, 13, 3, 7};
+#endif
 
 /* keyWrapType */
-static const byte wrapAes128Oid[] = {96, 134, 72, 1, 101, 3, 4, 1, 5};
-static const byte wrapAes192Oid[] = {96, 134, 72, 1, 101, 3, 4, 1, 25};
-static const byte wrapAes256Oid[] = {96, 134, 72, 1, 101, 3, 4, 1, 45};
+#ifdef WOLFSSL_AES_128
+    static const byte wrapAes128Oid[] = {96, 134, 72, 1, 101, 3, 4, 1, 5};
+#endif
+#ifdef WOLFSSL_AES_192
+    static const byte wrapAes192Oid[] = {96, 134, 72, 1, 101, 3, 4, 1, 25};
+#endif
+#ifdef WOLFSSL_AES_256
+    static const byte wrapAes256Oid[] = {96, 134, 72, 1, 101, 3, 4, 1, 45};
+#endif
 
 /* cmsKeyAgreeType */
 #ifndef NO_SHA
@@ -1489,7 +1506,7 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                     *oidSz = sizeof(hmacSha256Oid);
                     break;
         #endif
-        #ifdef WOLFSSL_SHA284
+        #ifdef WOLFSSL_SHA384
                 case HMAC_SHA384_OID:
                     oid = hmacSha384Oid;
                     *oidSz = sizeof(hmacSha384Oid);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -952,12 +952,22 @@ static const byte wrapAes192Oid[] = {96, 134, 72, 1, 101, 3, 4, 1, 25};
 static const byte wrapAes256Oid[] = {96, 134, 72, 1, 101, 3, 4, 1, 45};
 
 /* cmsKeyAgreeType */
-static const byte dhSinglePass_stdDH_sha1kdf_Oid[]   =
+#ifndef NO_SHA
+    static const byte dhSinglePass_stdDH_sha1kdf_Oid[]   =
                                           {43, 129, 5, 16, 134, 72, 63, 0, 2};
-static const byte dhSinglePass_stdDH_sha224kdf_Oid[] = {43, 129, 4, 1, 11, 0};
-static const byte dhSinglePass_stdDH_sha256kdf_Oid[] = {43, 129, 4, 1, 11, 1};
-static const byte dhSinglePass_stdDH_sha384kdf_Oid[] = {43, 129, 4, 1, 11, 2};
-static const byte dhSinglePass_stdDH_sha512kdf_Oid[] = {43, 129, 4, 1, 11, 3};
+#endif
+#ifdef WOLFSSL_SHA224
+    static const byte dhSinglePass_stdDH_sha224kdf_Oid[] = {43, 129, 4, 1, 11, 0};
+#endif
+#ifndef NO_SHA256
+    static const byte dhSinglePass_stdDH_sha256kdf_Oid[] = {43, 129, 4, 1, 11, 1};
+#endif
+#ifdef WOLFSSL_SHA384
+    static const byte dhSinglePass_stdDH_sha384kdf_Oid[] = {43, 129, 4, 1, 11, 2};
+#endif
+#ifdef WOLFSSL_SHA512
+    static const byte dhSinglePass_stdDH_sha512kdf_Oid[] = {43, 129, 4, 1, 11, 3};
+#endif
 
 /* ocspType */
 #ifdef HAVE_OCSP
@@ -1408,43 +1418,59 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
 
         case oidKeyWrapType:
             switch (id) {
+            #ifdef WOLFSSL_AES_128
                 case AES128_WRAP:
                     oid = wrapAes128Oid;
                     *oidSz = sizeof(wrapAes128Oid);
                     break;
+            #endif
+            #ifdef WOLFSSL_AES_192
                 case AES192_WRAP:
                     oid = wrapAes192Oid;
                     *oidSz = sizeof(wrapAes192Oid);
                     break;
+            #endif
+            #ifdef WOLFSSL_AES_256
                 case AES256_WRAP:
                     oid = wrapAes256Oid;
                     *oidSz = sizeof(wrapAes256Oid);
                     break;
+            #endif
             }
             break;
 
         case oidCmsKeyAgreeType:
             switch (id) {
+            #ifndef NO_SHA
                 case dhSinglePass_stdDH_sha1kdf_scheme:
                     oid = dhSinglePass_stdDH_sha1kdf_Oid;
                     *oidSz = sizeof(dhSinglePass_stdDH_sha1kdf_Oid);
                     break;
+            #endif
+            #ifdef WOLFSSL_SHA224
                 case dhSinglePass_stdDH_sha224kdf_scheme:
                     oid = dhSinglePass_stdDH_sha224kdf_Oid;
                     *oidSz = sizeof(dhSinglePass_stdDH_sha224kdf_Oid);
                     break;
+            #endif
+            #ifndef NO_SHA256
                 case dhSinglePass_stdDH_sha256kdf_scheme:
                     oid = dhSinglePass_stdDH_sha256kdf_Oid;
                     *oidSz = sizeof(dhSinglePass_stdDH_sha256kdf_Oid);
                     break;
+            #endif
+            #ifdef WOLFSSL_SHA384
                 case dhSinglePass_stdDH_sha384kdf_scheme:
                     oid = dhSinglePass_stdDH_sha384kdf_Oid;
                     *oidSz = sizeof(dhSinglePass_stdDH_sha384kdf_Oid);
                     break;
+            #endif
+            #ifdef WOLFSSL_SHA512
                 case dhSinglePass_stdDH_sha512kdf_scheme:
                     oid = dhSinglePass_stdDH_sha512kdf_Oid;
                     *oidSz = sizeof(dhSinglePass_stdDH_sha512kdf_Oid);
                     break;
+            #endif
             }
             break;
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7077,12 +7077,18 @@ WOLFSSL_LOCAL int GetSerialNumber(const byte* input, word32* inOutIdx,
 
 const char* const BEGIN_CERT         = "-----BEGIN CERTIFICATE-----";
 const char* const END_CERT           = "-----END CERTIFICATE-----";
-const char* const BEGIN_CERT_REQ     = "-----BEGIN CERTIFICATE REQUEST-----";
-const char* const END_CERT_REQ       = "-----END CERTIFICATE REQUEST-----";
-const char* const BEGIN_DH_PARAM     = "-----BEGIN DH PARAMETERS-----";
-const char* const END_DH_PARAM       = "-----END DH PARAMETERS-----";
-const char* const BEGIN_DSA_PARAM    = "-----BEGIN DSA PARAMETERS-----";
-const char* const END_DSA_PARAM      = "-----END DSA PARAMETERS-----";
+#ifdef WOLFSSL_CERT_REQ
+    const char* const BEGIN_CERT_REQ     = "-----BEGIN CERTIFICATE REQUEST-----";
+    const char* const END_CERT_REQ       = "-----END CERTIFICATE REQUEST-----";
+#endif
+#ifndef NO_DH
+    const char* const BEGIN_DH_PARAM     = "-----BEGIN DH PARAMETERS-----";
+    const char* const END_DH_PARAM       = "-----END DH PARAMETERS-----";
+#endif
+#ifndef NO_DSA
+    const char* const BEGIN_DSA_PARAM    = "-----BEGIN DSA PARAMETERS-----";
+    const char* const END_DSA_PARAM      = "-----END DSA PARAMETERS-----";
+#endif
 const char* const BEGIN_X509_CRL     = "-----BEGIN X509 CRL-----";
 const char* const END_X509_CRL       = "-----END X509 CRL-----";
 const char* const BEGIN_RSA_PRIV     = "-----BEGIN RSA PRIVATE KEY-----";
@@ -7091,14 +7097,18 @@ const char* const BEGIN_PRIV_KEY     = "-----BEGIN PRIVATE KEY-----";
 const char* const END_PRIV_KEY       = "-----END PRIVATE KEY-----";
 const char* const BEGIN_ENC_PRIV_KEY = "-----BEGIN ENCRYPTED PRIVATE KEY-----";
 const char* const END_ENC_PRIV_KEY   = "-----END ENCRYPTED PRIVATE KEY-----";
-const char* const BEGIN_EC_PRIV      = "-----BEGIN EC PRIVATE KEY-----";
-const char* const END_EC_PRIV        = "-----END EC PRIVATE KEY-----";
+#ifdef HAVE_ECC
+    const char* const BEGIN_EC_PRIV      = "-----BEGIN EC PRIVATE KEY-----";
+    const char* const END_EC_PRIV        = "-----END EC PRIVATE KEY-----";
+#endif
 const char* const BEGIN_DSA_PRIV     = "-----BEGIN DSA PRIVATE KEY-----";
 const char* const END_DSA_PRIV       = "-----END DSA PRIVATE KEY-----";
 const char* const BEGIN_PUB_KEY      = "-----BEGIN PUBLIC KEY-----";
 const char* const END_PUB_KEY        = "-----END PUBLIC KEY-----";
-const char* const BEGIN_EDDSA_PRIV   = "-----BEGIN EDDSA PRIVATE KEY-----";
-const char* const END_EDDSA_PRIV     = "-----END EDDSA PRIVATE KEY-----";
+#ifdef HAVE_ED25519
+    const char* const BEGIN_EDDSA_PRIV   = "-----BEGIN EDDSA PRIVATE KEY-----";
+    const char* const END_EDDSA_PRIV     = "-----END EDDSA PRIVATE KEY-----";
+#endif
 
 #if defined(WOLFSSL_KEY_GEN) || defined(WOLFSSL_CERT_GEN) || defined(OPENSSL_EXTRA)
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -395,24 +395,48 @@ static int GetInteger7Bit(const byte* input, word32* inOutIdx, word32 maxIdx)
 }
 
 
-#ifndef NO_DSA
+#if !defined(NO_DSA) && !defined(NO_SHA)
 static char sigSha1wDsaName[] = "SHAwDSA";
 #endif /* NO_DSA */
 #ifndef NO_RSA
-static char sigMd2wRsaName[] = "MD2wRSA";
-static char sigMd5wRsaName[] = "MD5wRSA";
-static char sigSha1wRsaName[] = "SHAwRSA";
-static char sigSha224wRsaName[] = "SHA224wRSA";
-static char sigSha256wRsaName[] = "SHA256wRSA";
-static char sigSha384wRsaName[] = "SHA384wRSA";
-static char sigSha512wRsaName[] = "SHA512wRSA";
+#ifdef WOLFSSL_MD2
+    static char sigMd2wRsaName[] = "MD2wRSA";
+#endif
+#ifndef NO_MD5
+    static char sigMd5wRsaName[] = "MD5wRSA";
+#endif
+#ifndef NO_SHA
+    static char sigSha1wRsaName[] = "SHAwRSA";
+#endif
+#ifdef WOLFSSL_SHA224
+    static char sigSha224wRsaName[] = "SHA224wRSA";
+#endif
+#ifndef NO_SHA256
+    static char sigSha256wRsaName[] = "SHA256wRSA";
+#endif
+#ifdef WOLFSSL_SHA384
+    static char sigSha384wRsaName[] = "SHA384wRSA";
+#endif
+#ifdef WOLFSSL_SHA512
+    static char sigSha512wRsaName[] = "SHA512wRSA";
+#endif
 #endif /* NO_RSA */
 #ifdef HAVE_ECC
-static char sigSha1wEcdsaName[] = "SHAwECDSA";
-static char sigSha224wEcdsaName[] = "SHA224wECDSA";
-static char sigSha256wEcdsaName[] = "SHA256wECDSA";
-static char sigSha384wEcdsaName[] = "SHA384wECDSA";
-static char sigSha512wEcdsaName[] = "SHA512wECDSA";
+#ifndef NO_SHA
+    static char sigSha1wEcdsaName[] = "SHAwECDSA";
+#endif
+#ifdef WOLFSSL_SHA224
+    static char sigSha224wEcdsaName[] = "SHA224wECDSA";
+#endif
+#ifndef NO_SHA256
+    static char sigSha256wEcdsaName[] = "SHA256wECDSA";
+#endif
+#ifdef WOLFSSL_SHA384
+    static char sigSha384wEcdsaName[] = "SHA384wECDSA";
+#endif
+#ifdef WOLFSSL_SHA512
+    static char sigSha512wEcdsaName[] = "SHA512wECDSA";
+#endif
 #endif /* HAVE_ECC */
 static char sigUnknownName[] = "Unknown";
 
@@ -423,38 +447,62 @@ static char sigUnknownName[] = "Unknown";
  */
 char* GetSigName(int oid) {
     switch (oid) {
-        #ifndef NO_DSA
+    #if !defined(NO_DSA) && !defined(NO_SHA)
         case CTC_SHAwDSA:
             return sigSha1wDsaName;
-        #endif /* NO_DSA */
-        #ifndef NO_RSA
+    #endif /* NO_DSA && NO_SHA */
+    #ifndef NO_RSA
+        #ifdef WOLFSSL_MD2
         case CTC_MD2wRSA:
             return sigMd2wRsaName;
+        #endif
+        #ifndef NO_MD5
         case CTC_MD5wRSA:
             return sigMd5wRsaName;
+        #endif
+        #ifndef NO_SHA
         case CTC_SHAwRSA:
             return sigSha1wRsaName;
+        #endif
+        #ifdef WOLFSSL_SHA224
         case CTC_SHA224wRSA:
             return sigSha224wRsaName;
+        #endif
+        #ifndef NO_SHA256
         case CTC_SHA256wRSA:
             return sigSha256wRsaName;
+        #endif
+        #ifdef WOLFSSL_SHA384
         case CTC_SHA384wRSA:
             return sigSha384wRsaName;
+        #endif
+        #ifdef WOLFSSL_SHA512
         case CTC_SHA512wRSA:
             return sigSha512wRsaName;
-        #endif /* NO_RSA */
-        #ifdef HAVE_ECC
+        #endif
+    #endif /* NO_RSA */
+    #ifdef HAVE_ECC
+        #ifndef NO_SHA
         case CTC_SHAwECDSA:
             return sigSha1wEcdsaName;
+        #endif
+        #ifdef WOLFSSL_SHA224
         case CTC_SHA224wECDSA:
             return sigSha224wEcdsaName;
+        #endif
+        #ifndef NO_SHA256
         case CTC_SHA256wECDSA:
             return sigSha256wEcdsaName;
+        #endif
+        #ifdef WOLFSSL_SHA384
         case CTC_SHA384wECDSA:
             return sigSha384wEcdsaName;
+        #endif
+        #ifdef WOLFSSL_SHA512
         case CTC_SHA512wECDSA:
             return sigSha512wEcdsaName;
-        #endif /* HAVE_ECC */
+        #endif
+    #endif /* HAVE_ECC */
         default:
             return sigUnknownName;
     }

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -493,28 +493,46 @@ static unsigned int cipherType(const WOLFSSL_EVP_CIPHER *cipher)
   #endif
 
   #if !defined(NO_AES) && defined(HAVE_AES_CBC)
+      #ifdef WOLFSSL_AES_128
       else if (XSTRNCMP(cipher, EVP_AES_128_CBC, EVP_AES_SIZE) == 0)
           return AES_128_CBC_TYPE;
+      #endif
+      #ifdef WOLFSSL_AES_192
       else if (XSTRNCMP(cipher, EVP_AES_192_CBC, EVP_AES_SIZE) == 0)
           return AES_192_CBC_TYPE;
+      #endif
+      #ifdef WOLFSSL_AES_256
       else if (XSTRNCMP(cipher, EVP_AES_256_CBC, EVP_AES_SIZE) == 0)
           return AES_256_CBC_TYPE;
+      #endif
   #endif /* !NO_AES && HAVE_AES_CBC */
   #if !defined(NO_AES) && defined(WOLFSSL_AES_COUNTER)
+      #ifdef WOLFSSL_AES_128
       else if (XSTRNCMP(cipher, EVP_AES_128_CTR, EVP_AES_SIZE) == 0)
           return AES_128_CTR_TYPE;
+      #endif
+      #ifdef WOLFSSL_AES_192
       else if (XSTRNCMP(cipher, EVP_AES_192_CTR, EVP_AES_SIZE) == 0)
           return AES_192_CTR_TYPE;
+      #endif
+      #ifdef WOLFSSL_AES_256
       else if (XSTRNCMP(cipher, EVP_AES_256_CTR, EVP_AES_SIZE) == 0)
           return AES_256_CTR_TYPE;
+      #endif
   #endif /* !NO_AES && HAVE_AES_CBC */
   #if !defined(NO_AES) && defined(HAVE_AES_ECB)
+      #ifdef WOLFSSL_AES_128
       else if (XSTRNCMP(cipher, EVP_AES_128_ECB, EVP_AES_SIZE) == 0)
           return AES_128_ECB_TYPE;
+      #endif
+      #ifdef WOLFSSL_AES_192
       else if (XSTRNCMP(cipher, EVP_AES_192_ECB, EVP_AES_SIZE) == 0)
           return AES_192_ECB_TYPE;
+      #endif
+      #ifdef WOLFSSL_AES_256
       else if (XSTRNCMP(cipher, EVP_AES_256_ECB, EVP_AES_SIZE) == 0)
           return AES_256_ECB_TYPE;
+      #endif
   #endif /* !NO_AES && HAVE_AES_CBC */
       else return 0;
 }

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -181,7 +181,8 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
 
     switch(keylen)
     {
-#if defined(AES_MAX_KEY_SIZE) && AES_MAX_KEY_SIZE >= 128
+#if defined(AES_MAX_KEY_SIZE) && AES_MAX_KEY_SIZE >= 128 && \
+        defined(WOLFSSL_AES_128)
     case 16:
         while (1)
         {
@@ -199,7 +200,8 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
         break;
 #endif /* 128 */
 
-#if defined(AES_MAX_KEY_SIZE) && AES_MAX_KEY_SIZE >= 192
+#if defined(AES_MAX_KEY_SIZE) && AES_MAX_KEY_SIZE >= 192 && \
+        defined(WOLFSSL_AES_192)
     case 24:
         /* for (;;) here triggers a bug in VC60 SP4 w/ Pro Pack */
         while (1)
@@ -220,7 +222,8 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
         break;
 #endif /* 192 */
 
-#if defined(AES_MAX_KEY_SIZE) && AES_MAX_KEY_SIZE >= 256
+#if defined(AES_MAX_KEY_SIZE) && AES_MAX_KEY_SIZE >= 256 && \
+        defined(WOLFSSL_AES_256)
     case 32:
         while (1)
         {
@@ -492,6 +495,7 @@ void wc_AesFree(Aes* aes)
             note: grouping AESE & AESMC together as pairs reduces latency
             */
             switch(aes->rounds) {
+#ifdef WOLFSSL_AES_128
             case 10: /* AES 128 BLOCK */
                 __asm__ __volatile__ (
                 "MOV w11, %w[blocks] \n"
@@ -542,7 +546,8 @@ void wc_AesFree(Aes* aes)
                 "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13"
                 );
                 break;
-
+#endif /* WOLFSSL_AES_128 */
+#ifdef WOLFSSL_AES_192
             case 12: /* AES 192 BLOCK */
                 __asm__ __volatile__ (
                 "MOV w11, %w[blocks] \n"
@@ -599,7 +604,8 @@ void wc_AesFree(Aes* aes)
                 "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14"
                 );
                 break;
-
+#endif /* WOLFSSL_AES_192*/
+#ifdef WOLFSSL_AES_256
             case 14: /* AES 256 BLOCK */
                 __asm__ __volatile__ (
                 "MOV w11, %w[blocks] \n"
@@ -662,7 +668,7 @@ void wc_AesFree(Aes* aes)
                 "v16"
                 );
                 break;
-
+#endif /* WOLFSSL_AES_256 */
             default:
                 WOLFSSL_MSG("Bad AES-CBC round value");
                 return BAD_FUNC_ARG;
@@ -688,6 +694,7 @@ void wc_AesFree(Aes* aes)
             word32* reg = aes->reg;
 
             switch(aes->rounds) {
+#ifdef WOLFSSL_AES_128
             case 10: /* AES 128 BLOCK */
                 __asm__ __volatile__ (
                 "MOV w11, %w[blocks] \n"
@@ -739,7 +746,8 @@ void wc_AesFree(Aes* aes)
                 "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13"
                 );
                 break;
-
+#endif /* WOLFSSL_AES_128 */
+#ifdef WOLFSSL_AES_192
             case 12: /* AES 192 BLOCK */
                 __asm__ __volatile__ (
                 "MOV w11, %w[blocks] \n"
@@ -797,7 +805,8 @@ void wc_AesFree(Aes* aes)
                 "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15"
                 );
                 break;
-
+#endif /* WOLFSSL_AES_192 */
+#ifdef WOLFSSL_AES_256
             case 14: /* AES 256 BLOCK */
                 __asm__ __volatile__ (
                 "MOV w11, %w[blocks] \n"
@@ -860,7 +869,7 @@ void wc_AesFree(Aes* aes)
                 "v16", "v17"
                 );
                 break;
-
+#endif /* WOLFSSL_AES_256 */
             default:
                 WOLFSSL_MSG("Bad AES-CBC round value");
                 return BAD_FUNC_ARG;
@@ -914,6 +923,7 @@ void wc_AesFree(Aes* aes)
                 byte*  keyPt  = (byte*)aes->key;
                 sz           -= numBlocks * AES_BLOCK_SIZE;
                 switch(aes->rounds) {
+#ifdef WOLFSSL_AES_128
                 case 10: /* AES 128 BLOCK */
                     __asm__ __volatile__ (
                     "MOV w11, %w[blocks] \n"
@@ -1053,7 +1063,8 @@ void wc_AesFree(Aes* aes)
                     "v6", "v7", "v8", "v9", "v10","v11","v12","v13","v14","v15"
                     );
                     break;
-
+#endif /* WOLFSSL_AES_128 */
+#ifdef WOLFSSL_AES_192
                 case 12: /* AES 192 BLOCK */
                     __asm__ __volatile__ (
                     "MOV w11, %w[blocks]              \n"
@@ -1209,7 +1220,8 @@ void wc_AesFree(Aes* aes)
                     "v16", "v17"
                     );
                     break;
-
+#endif /* WOLFSSL_AES_192 */
+#ifdef WOLFSSL_AES_256
                 case 14: /* AES 256 BLOCK */
                     __asm__ __volatile__ (
                     "MOV w11, %w[blocks] \n"
@@ -1378,7 +1390,7 @@ void wc_AesFree(Aes* aes)
                     "v16", "v17", "v18", "v19"
                     );
                     break;
-
+#endif /* WOLFSSL_AES_256 */
                 default:
                     WOLFSSL_MSG("Bad AES-CTR round value");
                     return BAD_FUNC_ARG;
@@ -1517,6 +1529,7 @@ void GHASH(Aes* aes, const byte* a, word32 aSz,
 }
 
 
+#ifdef WOLFSSL_AES_128
 /* internal function : see wc_AesGcmEncrypt */
 static int Aes128GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                    const byte* iv, word32 ivSz,
@@ -1832,8 +1845,9 @@ static int Aes128GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     }
     return 0;
 }
+#endif /* WOLFSSL_AES_128 */
 
-
+#ifdef WOLFSSL_AES_192
 /* internal function : see wc_AesGcmEncrypt */
 static int Aes192GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                    const byte* iv, word32 ivSz,
@@ -2164,8 +2178,9 @@ static int Aes192GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 
     return 0;
 }
+#endif /* WOLFSSL_AES_192 */
 
-
+#ifdef WOLFSSL_AES_256
 /* internal function : see wc_AesGcmEncrypt */
 static int Aes256GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                    const byte* iv, word32 ivSz,
@@ -2508,6 +2523,7 @@ static int Aes256GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 
     return 0;
 }
+#endif /* WOLFSSL_AES_256 */
 
 
 /* aarch64 with PMULL and PMULL2
@@ -2552,18 +2568,21 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     switch (aes->rounds) {
+#ifdef WOLFSSL_AES_128
         case 10:
             return Aes128GcmEncrypt(aes, out, in, sz, iv, ivSz,
                                     authTag, authTagSz, authIn, authInSz);
-
+#endif
+#ifdef WOLFSSL_AES_192
         case 12:
             return Aes192GcmEncrypt(aes, out, in, sz, iv, ivSz,
                                     authTag, authTagSz, authIn, authInSz);
-
+#endif
+#ifdef WOLFSSL_AES_256
         case 14:
             return Aes256GcmEncrypt(aes, out, in, sz, iv, ivSz,
                                     authTag, authTagSz, authIn, authInSz);
-
+#endif
         default:
             WOLFSSL_MSG("AES-GCM invalid round number");
             return BAD_FUNC_ARG;
@@ -2644,6 +2663,7 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
          * an issue with call to encrypt/decrypt leftovers */
         byte*  keyPt  = (byte*)aes->key;
         switch(aes->rounds) {
+#ifdef WOLFSSL_AES_128
         case 10: /* AES 128 BLOCK */
             __asm__ __volatile__ (
             "MOV w11, %w[blocks] \n"
@@ -2707,7 +2727,8 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
             "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14"
             );
             break;
-
+#endif
+#ifdef WOLFSSL_AES_192
         case 12: /* AES 192 BLOCK */
             __asm__ __volatile__ (
             "MOV w11, %w[blocks] \n"
@@ -2777,6 +2798,8 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
             "v16"
             );
             break;
+#endif /* WOLFSSL_AES_192 */
+#ifdef WOLFSSL_AES_256
         case 14: /* AES 256 BLOCK */
             __asm__ __volatile__ (
             "MOV w11, %w[blocks] \n"
@@ -2850,7 +2873,7 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
             "v16", "v17", "v18", "v19"
             );
             break;
-
+#endif /* WOLFSSL_AES_256 */
         default:
             WOLFSSL_MSG("Bad AES-GCM round value");
             return BAD_FUNC_ARG;
@@ -3057,6 +3080,7 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
             note: grouping AESE & AESMC together as pairs reduces latency
             */
             switch(aes->rounds) {
+#ifdef WOLFSSL_AES_128
             case 10: /* AES 128 BLOCK */
                 __asm__ __volatile__ (
                 "MOV r11, %[blocks] \n"
@@ -3116,7 +3140,8 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                 "q6", "q7", "q8", "q9", "q10", "q11", "q12"
                 );
                 break;
-
+#endif /* WOLFSSL_AES_128 */
+#ifdef WOLFSSL_AES_192
             case 12: /* AES 192 BLOCK */
                 __asm__ __volatile__ (
                 "MOV r11, %[blocks] \n"
@@ -3182,7 +3207,8 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                 "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14"
                 );
                 break;
-
+#endif /* WOLFSSL_AES_192 */
+#ifdef WOLFSSL_AES_256
             case 14: /* AES 256 BLOCK */
                 __asm__ __volatile__ (
                 "MOV r11, %[blocks] \n"
@@ -3255,7 +3281,7 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                 "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
                 );
                 break;
-
+#endif /* WOLFSSL_AES_256 */
             default:
                 WOLFSSL_MSG("Bad AES-CBC round value");
                 return BAD_FUNC_ARG;
@@ -3280,6 +3306,7 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
             word32* keyPt = aes->key;
             word32* regPt = aes->reg;
             switch(aes->rounds) {
+#ifdef WOLFSSL_AES_128
             case 10: /* AES 128 BLOCK */
                 __asm__ __volatile__ (
                 "MOV r11, %[blocks] \n"
@@ -3341,7 +3368,8 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                 "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13"
                 );
                 break;
-
+#endif /* WOLFSSL_AES_128 */
+#ifdef WOLFSSL_AES_192
             case 12: /* AES 192 BLOCK */
                 __asm__ __volatile__ (
                 "MOV r11, %[blocks] \n"
@@ -3409,7 +3437,8 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                 "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
                 );
                 break;
-
+#endif /* WOLFSSL_AES_192 */
+#ifdef WOLFSSL_AES_256
             case 14: /* AES 256 BLOCK */
                 __asm__ __volatile__ (
                 "MOV r11, %[blocks] \n"
@@ -3484,7 +3513,7 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                 "q6", "q7", "q8", "q9", "q10", "q11", "q12", "q13", "q14", "q15"
                 );
                 break;
-
+#endif /* WOLFSSL_AES_256 */
             default:
                 WOLFSSL_MSG("Bad AES-CBC round value");
                 return BAD_FUNC_ARG;
@@ -3539,6 +3568,7 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                 word32*  regPt  = aes->reg;
                 sz           -= numBlocks * AES_BLOCK_SIZE;
                 switch(aes->rounds) {
+#ifdef WOLFSSL_AES_128
                 case 10: /* AES 128 BLOCK */
                     __asm__ __volatile__ (
                     "MOV r11, %[blocks] \n"
@@ -3674,7 +3704,8 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                     "q6", "q7", "q8", "q9", "q10","q11","q12","q13","q14", "q15"
                     );
                     break;
-
+#endif /* WOLFSSL_AES_128 */
+#ifdef WOLFSSL_AES_192
                 case 12: /* AES 192 BLOCK */
                     __asm__ __volatile__ (
                     "MOV r11, %[blocks] \n"
@@ -3833,7 +3864,8 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                     "q6", "q7", "q8", "q9", "q10","q11","q12","q13","q14"
                     );
                     break;
-
+#endif /* WOLFSSL_AES_192 */
+#ifdef WOLFSSL_AES_256
                 case 14: /* AES 256 BLOCK */
                     __asm__ __volatile__ (
                     "MOV r11, %[blocks] \n"
@@ -4009,7 +4041,7 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                     "q6", "q7", "q8", "q9", "q10","q11","q12","q13","q14"
                     );
                     break;
-
+#endif /* WOLFSSL_AES_256 */
                 default:
                     WOLFSSL_MSG("Bad AES-CTR round qalue");
                     return BAD_FUNC_ARG;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5312,22 +5312,26 @@ static int aes_cbc_test(void)
     ret = wc_AesCbcEncryptWithKey(cipher, msg, AES_BLOCK_SIZE, key, 17, NULL);
     if (ret != BAD_FUNC_ARG)
         return -4100;
+#ifdef HAVE_AES_DECRYPT
     ret = wc_AesCbcDecryptWithKey(plain, cipher, AES_BLOCK_SIZE, key, 17, NULL);
     if (ret != BAD_FUNC_ARG)
         return -4101;
+#endif
 
     ret = wc_AesCbcEncryptWithKey(cipher, msg, AES_BLOCK_SIZE, key,
                                   AES_BLOCK_SIZE, iv);
     if (ret != 0)
         return -4102;
+#ifdef HAVE_AES_DECRYPT
     ret = wc_AesCbcDecryptWithKey(plain, cipher, AES_BLOCK_SIZE, key,
                                   AES_BLOCK_SIZE, iv);
     if (ret != 0)
         return -4103;
-
     if (XMEMCMP(plain, msg, AES_BLOCK_SIZE) != 0)
         return -4104;
+#endif /* HAVE_AES_DECRYPT */
 
+    (void)plain;
     return 0;
 }
 #endif
@@ -5781,9 +5785,9 @@ int aes_test(void)
     wc_AesFree(&enc);
 #ifdef HAVE_AES_DECRYPT
     wc_AesFree(&dec);
+    (void)plain;
 #endif
 
-    (void)plain;
     (void)cipher;
 
     return ret;
@@ -6162,6 +6166,7 @@ int aesgcm_test(void)
     if (XMEMCMP(t1, resultT, sizeof(resultT)))
         return -4304;
 
+#ifdef HAVE_AES_DECRYPT
     result = wc_AesGcmDecrypt(&enc, resultP, resultC, sizeof(resultC),
                       iv1, sizeof(iv1), resultT, sizeof(resultT), a, sizeof(a));
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -6171,6 +6176,7 @@ int aesgcm_test(void)
         return -4305;
     if (XMEMCMP(p, resultP, sizeof(resultP)))
         return -4306;
+#endif /* HAVE_AES_DECRYPT */
 
     /* Large buffer test */
 #ifdef BENCH_AESGCM_LARGE
@@ -6188,6 +6194,7 @@ int aesgcm_test(void)
     if (result != 0)
         return -4307;
 
+#ifdef HAVE_AES_DECRYPT
     result = wc_AesGcmDecrypt(&enc, large_outdec, large_output,
                               BENCH_AESGCM_LARGE, iv1, sizeof(iv1), resultT,
                               sizeof(resultT), a, sizeof(a));
@@ -6198,6 +6205,7 @@ int aesgcm_test(void)
         return -4308;
     if (XMEMCMP(large_input, large_outdec, BENCH_AESGCM_LARGE))
         return -4309;
+#endif /* HAVE_AES_DECRYPT */
 #endif /* BENCH_AESGCM_LARGE */
 #ifdef ENABLE_NON_12BYTE_IV_TEST
     /* Variable IV length test */
@@ -6210,6 +6218,7 @@ int aesgcm_test(void)
 #endif
         if (result != 0)
             return -4310;
+#ifdef HAVE_AES_DECRYPT
         result = wc_AesGcmDecrypt(&enc, resultP, resultC, sizeof(resultC), k1,
                          (word32)ivlen, resultT, sizeof(resultT), a, sizeof(a));
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -6217,6 +6226,7 @@ int aesgcm_test(void)
 #endif
         if (result != 0)
             return -4311;
+#endif /* HAVE_AES_DECRYPT */
     }
 #endif
 
@@ -6230,6 +6240,7 @@ int aesgcm_test(void)
 #endif
         if (result != 0)
             return -4312;
+#ifdef HAVE_AES_DECRYPT
         result = wc_AesGcmDecrypt(&enc, resultP, resultC, sizeof(resultC), iv1,
                         sizeof(iv1), resultT, sizeof(resultT), p, (word32)alen);
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -6237,6 +6248,7 @@ int aesgcm_test(void)
 #endif
         if (result != 0)
             return -4313;
+#endif /* HAVE_AES_DECRYPT */
     }
 
 #ifdef BENCH_AESGCM_LARGE
@@ -6252,6 +6264,7 @@ int aesgcm_test(void)
         if (result != 0)
             return -4314;
 
+#ifdef HAVE_AES_DECRYPT
         result = wc_AesGcmDecrypt(&enc, large_outdec, large_output,
                                   plen, iv1, sizeof(iv1), resultT,
                                   sizeof(resultT), a, sizeof(a));
@@ -6260,6 +6273,7 @@ int aesgcm_test(void)
 #endif
         if (result != 0)
             return -4315;
+#endif /* HAVE_AES_DECRYPT */
     }
 #else
     /* Variable plain text length test */
@@ -6272,6 +6286,7 @@ int aesgcm_test(void)
 #endif
         if (result != 0)
             return -4314;
+#ifdef HAVE_AES_DECRYPT
         result = wc_AesGcmDecrypt(&enc, resultP, resultC, (word32)plen, iv1,
                            sizeof(iv1), resultT, sizeof(resultT), a, sizeof(a));
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -6279,6 +6294,7 @@ int aesgcm_test(void)
 #endif
         if (result != 0)
             return -4315;
+#endif /* HAVE_AES_DECRYPT */
     }
 #endif /* BENCH_AESGCM_LARGE */
 #endif /* WOLFSSL_AES_256 */
@@ -6304,6 +6320,7 @@ int aesgcm_test(void)
     if (XMEMCMP(t2, resultT, sizeof(resultT)))
         return -4318;
 
+#ifdef HAVE_AES_DECRYPT
     result = wc_AesGcmDecrypt(&enc, resultP, resultC, sizeof(resultC),
                       iv2, sizeof(iv2), resultT, sizeof(resultT), a, sizeof(a));
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -6313,6 +6330,7 @@ int aesgcm_test(void)
         return -4319;
     if (XMEMCMP(p, resultP, sizeof(resultP)))
         return -4320;
+#endif /* HAVE_AES_DECRYPT */
 
     XMEMSET(resultT, 0, sizeof(resultT));
     XMEMSET(resultC, 0, sizeof(resultC));
@@ -6333,6 +6351,7 @@ int aesgcm_test(void)
     if (XMEMCMP(t3, resultT, sizeof(t3)))
         return -8211;
 
+#ifdef HAVE_AES_DECRYPT
     result = wc_AesGcmDecrypt(&enc, resultP, resultC, sizeof(c3),
                       iv3, sizeof(iv3), resultT, sizeof(t3), a3, sizeof(a3));
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -6342,6 +6361,7 @@ int aesgcm_test(void)
         return -8212;
     if (XMEMCMP(p3, resultP, sizeof(p3)))
         return -8213;
+#endif /* HAVE_AES_DECRYPT */
 #endif /* WOLFSSL_AES_128 */
 #endif /* ENABLE_NON_12BYTE_IV_TEST */
 
@@ -6364,6 +6384,7 @@ int aesgcm_test(void)
     if (XMEMCMP(t1, resultT + 1, sizeof(resultT) - 1))
         return -4323;
 
+#ifdef HAVE_AES_DECRYPT
     result = wc_AesGcmDecrypt(&enc, resultP, resultC, sizeof(resultC),
               iv1, sizeof(iv1), resultT + 1, sizeof(resultT) - 1, a, sizeof(a));
 #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -6373,6 +6394,7 @@ int aesgcm_test(void)
         return -4324;
     if (XMEMCMP(p, resultP, sizeof(resultP)))
         return -4325;
+#endif /* HAVE_AES_DECRYPT */
 #endif /* WOLFSSL_AES_256 */
     wc_AesFree(&enc);
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -16464,13 +16464,13 @@ int pkcs7encrypted_test(void)
 
     PKCS7Attrib attribs[] =
     {
-        { genAttrOid, sizeof(genAttrOid), genAttr, sizeof(genAttr) }
+        { genAttrOid, genAttr, sizeof(genAttrOid), sizeof(genAttr) }
     };
 
     PKCS7Attrib multiAttribs[] =
     {
-        { genAttrOid, sizeof(genAttrOid), genAttr, sizeof(genAttr) },
-        { genAttrOid2, sizeof(genAttrOid2), genAttr2, sizeof(genAttr2) }
+        { genAttrOid, genAttr, sizeof(genAttrOid), sizeof(genAttr) },
+        { genAttrOid2, genAttr2, sizeof(genAttrOid2), sizeof(genAttr2) }
     };
 #endif /* NO_AES */
 
@@ -16638,12 +16638,12 @@ static int pkcs7signed_run_vectors(byte* rsaCert, word32 rsaCertSz,
 
     PKCS7Attrib attribs[] =
     {
-        { transIdOid, sizeof(transIdOid),
-                     transId, sizeof(transId) - 1 }, /* take off the null */
-        { messageTypeOid, sizeof(messageTypeOid),
-                     messageType, sizeof(messageType) },
-        { senderNonceOid, sizeof(senderNonceOid),
-                     senderNonce, sizeof(senderNonce) }
+        { transIdOid, transId, sizeof(transIdOid),
+                               sizeof(transId) - 1 }, /* take off the null */
+        { messageTypeOid, messageType, sizeof(messageTypeOid),
+                                       sizeof(messageType) },
+        { senderNonceOid, senderNonce, sizeof(senderNonceOid),
+                                       sizeof(senderNonce) }
     };
 
     const pkcs7SignedVector testVectors[] =

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -671,16 +671,19 @@ int wolfcrypt_test(void* args)
     else
         printf( "AES      test passed!\n");
 
+#ifdef WOLFSSL_AES_192
     if ( (ret = aes192_test()) != 0)
         return err_sys("AES192   test failed!\n", ret);
     else
         printf( "AES192   test passed!\n");
+#endif
 
+#ifdef WOLFSSL_AES_256
     if ( (ret = aes256_test()) != 0)
         return err_sys("AES256   test failed!\n", ret);
     else
         printf( "AES256   test passed!\n");
-
+#endif
 #ifdef HAVE_AESGCM
     if ( (ret = aesgcm_test()) != 0)
         return err_sys("AES-GCM  test failed!\n", ret);
@@ -5721,6 +5724,7 @@ int aes_test(void)
     return ret;
 }
 
+#ifdef WOLFSSL_AES_192
 int aes192_test(void)
 {
 #ifdef HAVE_AES_CBC
@@ -5811,7 +5815,9 @@ int aes192_test(void)
 
     return ret;
 }
+#endif /* WOLFSSL_AES_192 */
 
+#ifdef WOLFSSL_AES_256
 int aes256_test(void)
 {
 #ifdef HAVE_AES_CBC
@@ -5896,6 +5902,7 @@ int aes256_test(void)
 
     return ret;
 }
+#endif /* WOLFSSL_AES_256 */
 
 
 #ifdef HAVE_AESGCM

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -602,7 +602,7 @@ int wolfcrypt_test(void* args)
         printf( "X963-KDF    test passed!\n");
 #endif
 
-#ifdef HAVE_AESGCM
+#if defined(HAVE_AESGCM) && defined(WOLFSSL_AES_128)
     if ( (ret = gmac_test()) != 0)
         return err_sys("GMAC     test failed!\n", ret);
     else
@@ -691,7 +691,7 @@ int wolfcrypt_test(void* args)
         printf( "AES-GCM  test passed!\n");
 #endif
 
-#ifdef HAVE_AESCCM
+#if defined(HAVE_AESCCM) && defined(WOLFSSL_AES_128)
     if ( (ret = aesccm_test()) != 0)
         return err_sys("AES-CCM  test failed!\n", ret);
     else
@@ -801,7 +801,7 @@ int wolfcrypt_test(void* args)
         return err_sys("ECC      test failed!\n", ret);
     else
         printf( "ECC      test passed!\n");
-    #ifdef HAVE_ECC_ENCRYPT
+    #if defined(HAVE_ECC_ENCRYPT) && defined(WOLFSSL_AES_128)
         if ( (ret = ecc_encrypt_test()) != 0)
             return err_sys("ECC Enc  test failed!\n", ret);
         else
@@ -4443,6 +4443,7 @@ int des3_test(void)
             0x08,0x09,0x0a,0x0b,0x0c,0x0d,0x0e,0x0f
         };
 
+#ifdef WOLFSSL_AES_128
         const byte key1[] =
         {
             0x2b,0x7e,0x15,0x16,0x28,0xae,0xd2,0xa6,
@@ -4468,7 +4469,9 @@ int des3_test(void)
             0x30,0xc8,0x1c,0x46,0xa3,0x5c,0xe4,0x11,
             0xe5,0xfb,0xc1,0x19,0x1a,0x0a,0x52,0xef
         };
+#endif /* WOLFSSL_AES_128 */
 
+#ifdef WOLFSSL_AES_192
         /* 192 size key test */
         const byte key2[] =
         {
@@ -4500,7 +4503,9 @@ int des3_test(void)
             0xf6,0x9f,0x24,0x45,0xdf,0x4f,0x9b,0x17,
             0xad,0x2b,0x41,0x7b,0xe6,0x6c,0x37,0x10
         };
+#endif /* WOLFSSL_AES_192 */
 
+#ifdef WOLFSSL_AES_256
         /* 256 size key simple test */
         const byte key3[] =
         {
@@ -4533,8 +4538,9 @@ int des3_test(void)
             0xf6,0x9f,0x24,0x45,0xdf,0x4f,0x9b,0x17,
             0xad,0x2b,0x41,0x7b,0xe6,0x6c,0x37,0x10
         };
+#endif /* WOLFSSL_AES_256 */
 
-
+#ifdef WOLFSSL_AES_128
         /* 128 key tests */
         ret = wc_AesSetKey(&enc, key1, AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
         if (ret != 0)
@@ -4572,7 +4578,9 @@ int des3_test(void)
         if (XMEMCMP(plain, msg1, AES_BLOCK_SIZE * 3))
             return -1110;
     #endif /* HAVE_AES_DECRYPT */
+#endif /* WOLFSSL_AES_128 */
 
+#ifdef WOLFSSL_AES_192
         /* 192 key size test */
         ret = wc_AesSetKey(&enc, key2, sizeof(key2), iv, AES_ENCRYPTION);
         if (ret != 0)
@@ -4600,8 +4608,9 @@ int des3_test(void)
         if (XMEMCMP(plain, msg2, AES_BLOCK_SIZE * 4))
             return -1116;
     #endif /* HAVE_AES_DECRYPT */
+#endif /* WOLFSSL_AES_192 */
 
-
+#ifdef WOLFSSL_AES_256
         /* 256 key size test */
         ret = wc_AesSetKey(&enc, key3, sizeof(key3), iv, AES_ENCRYPTION);
         if (ret != 0)
@@ -4664,6 +4673,7 @@ int des3_test(void)
         if (XMEMCMP(plain, msg3, AES_BLOCK_SIZE * 4))
             return -1131;
     #endif /* HAVE_AES_DECRYPT */
+#endif /* WOLFSSL_AES_256 */
 
         return ret;
     }
@@ -4714,7 +4724,11 @@ static int aes_key_size_test(void)
 #endif
     /* NULL IV indicates to use all zeros IV. */
     ret = wc_AesSetKey(&aes, key16, sizeof(key16), NULL, AES_ENCRYPTION);
+#ifdef WOLFSSL_AES_128
     if (ret != 0)
+#else
+    if (ret != BAD_FUNC_ARG)
+#endif
         return -4006;
     ret = wc_AesSetKey(&aes, key32, sizeof(key32) - 1, iv, AES_ENCRYPTION);
     if (ret != BAD_FUNC_ARG)
@@ -4728,27 +4742,39 @@ static int aes_key_size_test(void)
 #endif
 
     ret = wc_AesSetKey(&aes, key16, sizeof(key16), iv, AES_ENCRYPTION);
+#ifdef WOLFSSL_AES_128
     if (ret != 0)
+#else
+    if (ret != BAD_FUNC_ARG)
+#endif
         return -4009;
-#ifndef HAVE_FIPS
+#if !defined(HAVE_FIPS) && defined(WOLFSSL_AES_128)
     ret = wc_AesGetKeySize(&aes, &keySize);
     if (ret != 0 || keySize != sizeof(key16))
         return -4010;
 #endif
 
     ret = wc_AesSetKey(&aes, key24, sizeof(key24), iv, AES_ENCRYPTION);
+#ifdef WOLFSSL_AES_192
     if (ret != 0)
+#else
+    if (ret != BAD_FUNC_ARG)
+#endif
         return -4011;
-#ifndef HAVE_FIPS
+#if !defined(HAVE_FIPS) && defined(WOLFSSL_AES_192)
     ret = wc_AesGetKeySize(&aes, &keySize);
     if (ret != 0 || keySize != sizeof(key24))
         return -4012;
 #endif
 
     ret = wc_AesSetKey(&aes, key32, sizeof(key32), iv, AES_ENCRYPTION);
+#ifdef WOLFSSL_AES_256
     if (ret != 0)
+#else
+    if (ret != BAD_FUNC_ARG)
+#endif
         return -4013;
-#ifndef HAVE_FIPS
+#if !defined(HAVE_FIPS) && defined(WOLFSSL_AES_256)
     ret = wc_AesGetKeySize(&aes, &keySize);
     if (ret != 0 || keySize != sizeof(key32))
         return -4014;
@@ -4759,6 +4785,7 @@ static int aes_key_size_test(void)
 
 #if defined(WOLFSSL_AES_XTS)
 /* test vectors from http://csrc.nist.gov/groups/STM/cavp/block-cipher-modes.html */
+#ifdef WOLFSSL_AES_128
 static int aes_xts_128_test(void)
 {
     XtsAes aes;
@@ -4911,8 +4938,10 @@ static int aes_xts_128_test(void)
 
     return ret;
 }
+#endif /* WOLFSSL_AES_128 */
 
 
+#ifdef WOLFSSL_AES_256
 static int aes_xts_256_test(void)
 {
     XtsAes aes;
@@ -5069,8 +5098,10 @@ static int aes_xts_256_test(void)
 
     return ret;
 }
+#endif /* WOLFSSL_AES_256 */
 
 
+#if defined(WOLFSSL_AES_128) && defined(WOLFSSL_AES_256)
 /* both 128 and 256 bit key test */
 static int aes_xts_sector_test(void)
 {
@@ -5183,8 +5214,10 @@ static int aes_xts_sector_test(void)
 
     return ret;
 }
+#endif /* WOLFSSL_AES_128 && WOLFSSL_AES_256 */
 
 
+#ifdef WOLFSSL_AES_128
 /* testing of bad arguments */
 static int aes_xts_args_test(void)
 {
@@ -5258,9 +5291,10 @@ static int aes_xts_args_test(void)
 
     return 0;
 }
+#endif /* WOLFSSL_AES_128 */
 #endif /* WOLFSSL_AES_XTS */
 
-#if defined(HAVE_AES_CBC)
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
 static int aes_cbc_test(void)
 {
     byte cipher[AES_BLOCK_SIZE];
@@ -5311,6 +5345,7 @@ int aes_test(void)
     int  ret = 0;
 
 #ifdef HAVE_AES_CBC
+#ifdef WOLFSSL_AES_128
     const byte msg[] = { /* "Now is the time for all " w/o trailing 0 */
         0x6e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
         0x68,0x65,0x20,0x74,0x69,0x6d,0x65,0x20,
@@ -5361,6 +5396,7 @@ int aes_test(void)
 #endif /* HAVE_AES_DECRYPT */
     if (XMEMCMP(cipher, verify, AES_BLOCK_SIZE))
         return -4207;
+#endif /* WOLFSSL_AES_128 */
 
 #if defined(WOLFSSL_AESNI) && defined(HAVE_AES_DECRYPT)
     {
@@ -5482,6 +5518,7 @@ int aes_test(void)
             0xad,0x2b,0x41,0x7b,0xe6,0x6c,0x37,0x10
         };
 
+#ifdef WOLFSSL_AES_128
         const byte oddCipher[] =
         {
             0xb9,0xd7,0xcb,0x08,0xb0,0xe1,0x7b,0xa0,
@@ -5505,7 +5542,9 @@ int aes_test(void)
             0x1e,0x03,0x1d,0xda,0x2f,0xbe,0x03,0xd1,
             0x79,0x21,0x70,0xa0,0xf3,0x00,0x9c,0xee
         };
+#endif /* WOLFSSL_AES_128 */
 
+#ifdef WOLFSSL_AES_192
         const byte ctr192Key[] =
         {
             0x8e,0x73,0xb0,0xf7,0xda,0x0e,0x64,0x52,
@@ -5524,7 +5563,8 @@ int aes_test(void)
             0x4f,0x78,0xa7,0xf6,0xd2,0x98,0x09,0x58,
             0x5a,0x97,0xda,0xec,0x58,0xc6,0xb0,0x50
         };
-
+#endif
+#ifdef WOLFSSL_AES_256
         const byte ctr256Key[] =
         {
             0x60,0x3d,0xeb,0x10,0x15,0xca,0x71,0xbe,
@@ -5544,7 +5584,9 @@ int aes_test(void)
             0xdf,0xc9,0xc5,0x8d,0xb6,0x7a,0xad,0xa6,
             0x13,0xc2,0xdd,0x08,0x45,0x79,0x41,0xa6
         };
+#endif
 
+#ifdef WOLFSSL_AES_128
         wc_AesSetKeyDirect(&enc, ctr128Key, sizeof(ctr128Key),
                            ctrIv, AES_ENCRYPTION);
         /* Ctr only uses encrypt, even on key setup */
@@ -5602,7 +5644,9 @@ int aes_test(void)
 
         if (XMEMCMP(cipher, oddCipher, sizeof(oddCipher)))
             return -4218;
+#endif /* WOLFSSL_AES_128 */
 
+#ifdef WOLFSSL_AES_192
         /* 192 bit key */
         wc_AesSetKeyDirect(&enc, ctr192Key, sizeof(ctr192Key),
                            ctrIv, AES_ENCRYPTION);
@@ -5625,7 +5669,9 @@ int aes_test(void)
         }
         if (XMEMCMP(ctr192Cipher, cipher, sizeof(ctr192Cipher)))
             return -4220;
+#endif /* WOLFSSL_AES_192 */
 
+#ifdef WOLFSSL_AES_256
         /* 256 bit key */
         wc_AesSetKeyDirect(&enc, ctr256Key, sizeof(ctr256Key),
                            ctrIv, AES_ENCRYPTION);
@@ -5648,10 +5694,11 @@ int aes_test(void)
         }
         if (XMEMCMP(ctr256Cipher, cipher, sizeof(ctr256Cipher)))
             return -4222;
+#endif /* WOLFSSL_AES_256 */
     }
 #endif /* WOLFSSL_AES_COUNTER */
 
-#ifdef WOLFSSL_AES_DIRECT
+#if defined(WOLFSSL_AES_DIRECT) && defined(WOLFSSL_AES_256)
     {
         const byte niPlain[] =
         {
@@ -5689,32 +5736,47 @@ int aes_test(void)
         if (XMEMCMP(plain, niPlain, AES_BLOCK_SIZE) != 0)
             return -4226;
     }
-#endif /* WOLFSSL_AES_DIRECT */
+#endif /* WOLFSSL_AES_DIRECT && WOLFSSL_AES_256 */
 
     ret = aes_key_size_test();
     if (ret != 0)
         return ret;
 
-#if defined(HAVE_AES_CBC)
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
     ret = aes_cbc_test();
     if (ret != 0)
         return ret;
 #endif
 
 #if defined(WOLFSSL_AES_XTS)
+    #ifdef WOLFSSL_AES_128
     ret = aes_xts_128_test();
     if (ret != 0)
         return ret;
+    #endif
+    #ifdef WOLFSSL_AES_256
     ret = aes_xts_256_test();
     if (ret != 0)
         return ret;
+    #endif
+    #if defined(WOLFSSL_AES_128) && defined(WOLFSSL_AES_256)
     ret = aes_xts_sector_test();
     if (ret != 0)
         return ret;
+    #endif
+    #ifdef WOLFSSL_AES_128
     ret = aes_xts_args_test();
     if (ret != 0)
         return ret;
+    #endif
 #endif
+
+#if defined(WOLFSSL_AES_CFB)
+    ret = aescfb_test();
+    if (ret != 0)
+        return ret;
+#endif
+
 
     wc_AesFree(&enc);
 #ifdef HAVE_AES_DECRYPT
@@ -5806,12 +5868,6 @@ int aes192_test(void)
 #endif
 
 #endif /* HAVE_AES_CBC */
-
-#if defined(WOLFSSL_AES_CFB)
-    ret = aescfb_test();
-    if (ret != 0)
-        return ret;
-#endif
 
     return ret;
 }
@@ -5934,6 +5990,7 @@ int aesgcm_test(void)
         0xab, 0xad, 0xda, 0xd2
     };
 
+#ifdef WOLFSSL_AES_256
     const byte k1[] =
     {
         0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
@@ -5959,6 +6016,7 @@ int aesgcm_test(void)
         0xc5, 0xf6, 0x1e, 0x63, 0x93, 0xba, 0x7a, 0x0a,
         0xbc, 0xc9, 0xf6, 0x62
     };
+#endif /* WOLFSSL_AES_256 */
 
     const byte t1[] =
     {
@@ -5972,7 +6030,7 @@ int aesgcm_test(void)
         !defined(WOLFSSL_XILINX_CRYPT)
 
     #define ENABLE_NON_12BYTE_IV_TEST
-
+#ifdef WOLFSSL_AES_192
     /* Test Case 12, uses same plaintext and AAD data. */
     const byte k2[] =
     {
@@ -6010,7 +6068,8 @@ int aesgcm_test(void)
         0xdc, 0xf5, 0x66, 0xff, 0x29, 0x1c, 0x25, 0xbb,
         0xb8, 0x56, 0x8f, 0xc3, 0xd3, 0x76, 0xa6, 0xd9
     };
-
+#endif /* WOLFSSL_AES_192 */
+#ifdef WOLFSSL_AES_128
     /* The following is an interesting test case from the example
      * FIPS test vectors for AES-GCM. IVlen = 1 byte */
     const byte p3[] =
@@ -6047,16 +6106,19 @@ int aesgcm_test(void)
         0x06, 0x90, 0xed, 0x01, 0x34, 0xdd, 0xc6, 0x95,
         0x31, 0x2e, 0x2a, 0xf9, 0x57, 0x7a, 0x1e, 0xa6
     };
+#endif /* WOLFSSL_AES_128 */
+#ifdef WOLFSSL_AES_256
+    int ivlen;
+#endif
 #endif
 
     byte resultT[sizeof(t1)];
     byte resultP[sizeof(p)];
     byte resultC[sizeof(p)];
     int  result;
-#if !defined(HAVE_FIPS) && !defined(STM32_CRYPTO)
-    int  ivlen;
-#endif
+#ifdef WOLFSSL_AES_256
     int  alen, plen;
+#endif
 
 #if !defined(BENCH_EMBEDDED)
     #ifndef BENCH_AESGCM_LARGE
@@ -6079,6 +6141,7 @@ int aesgcm_test(void)
         return -4300;
     }
 
+#ifdef WOLFSSL_AES_256
     result = wc_AesGcmSetKey(&enc, k1, sizeof(k1));
     if (result != 0)
         return -4301;
@@ -6133,7 +6196,6 @@ int aesgcm_test(void)
     if (XMEMCMP(large_input, large_outdec, BENCH_AESGCM_LARGE))
         return -4309;
 #endif /* BENCH_AESGCM_LARGE */
-
 #ifdef ENABLE_NON_12BYTE_IV_TEST
     /* Variable IV length test */
     for (ivlen=0; ivlen<(int)sizeof(k1); ivlen++) {
@@ -6216,6 +6278,7 @@ int aesgcm_test(void)
             return -4315;
     }
 #endif /* BENCH_AESGCM_LARGE */
+#endif /* WOLFSSL_AES_256 */
 
     /* test with IV != 12 bytes */
 #ifdef ENABLE_NON_12BYTE_IV_TEST
@@ -6223,6 +6286,7 @@ int aesgcm_test(void)
     XMEMSET(resultC, 0, sizeof(resultC));
     XMEMSET(resultP, 0, sizeof(resultP));
 
+#ifdef WOLFSSL_AES_192
     wc_AesGcmSetKey(&enc, k2, sizeof(k2));
     /* AES-GCM encrypt and decrypt both use AES encrypt internally */
     result = wc_AesGcmEncrypt(&enc, resultC, p, sizeof(p), iv2, sizeof(iv2),
@@ -6250,7 +6314,8 @@ int aesgcm_test(void)
     XMEMSET(resultT, 0, sizeof(resultT));
     XMEMSET(resultC, 0, sizeof(resultC));
     XMEMSET(resultP, 0, sizeof(resultP));
-
+#endif /* WOLFSSL_AES_192 */
+#ifdef WOLFSSL_AES_128
     wc_AesGcmSetKey(&enc, k3, sizeof(k3));
     /* AES-GCM encrypt and decrypt both use AES encrypt internally */
     result = wc_AesGcmEncrypt(&enc, resultC, p3, sizeof(p3), iv3, sizeof(iv3),
@@ -6274,6 +6339,7 @@ int aesgcm_test(void)
         return -8212;
     if (XMEMCMP(p3, resultP, sizeof(p3)))
         return -8213;
+#endif /* WOLFSSL_AES_128 */
 #endif /* ENABLE_NON_12BYTE_IV_TEST */
 
     XMEMSET(resultT, 0, sizeof(resultT));
@@ -6308,6 +6374,7 @@ int aesgcm_test(void)
     return 0;
 }
 
+#ifdef WOLFSSL_AES_128
 int gmac_test(void)
 {
     Gmac gmac;
@@ -6371,9 +6438,10 @@ int gmac_test(void)
 
     return 0;
 }
+#endif /* WOLFSSL_AES_128 */
 #endif /* HAVE_AESGCM */
 
-#ifdef HAVE_AESCCM
+#if defined(HAVE_AESCCM) && defined(WOLFSSL_AES_128)
 int aesccm_test(void)
 {
     Aes enc;
@@ -6464,7 +6532,7 @@ int aesccm_test(void)
 
     return 0;
 }
-#endif /* HAVE_AESCCM */
+#endif /* HAVE_AESCCM WOLFSSL_AES_128 */
 
 
 #ifdef HAVE_AES_KEYWRAP
@@ -6487,6 +6555,7 @@ int aeskeywrap_test(void)
 
     /* test vectors from RFC 3394 (kek, data, verify) */
 
+#ifdef WOLFSSL_AES_128
     /* Wrap 128 bits of Key Data with a 128-bit KEK */
     const byte k1[] = {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -6503,7 +6572,9 @@ int aeskeywrap_test(void)
         0xAE, 0xF3, 0x4B, 0xD8, 0xFB, 0x5A, 0x7B, 0x82,
         0x9D, 0x3E, 0x86, 0x23, 0x71, 0xD2, 0xCF, 0xE5
     };
+#endif /* WOLFSSL_AES_128 */
 
+#ifdef WOLFSSL_AES_192
     /* Wrap 128 bits of Key Data with a 192-bit KEK */
     const byte k2[] = {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -6521,7 +6592,9 @@ int aeskeywrap_test(void)
         0xF9, 0x2B, 0x5B, 0x97, 0xC0, 0x50, 0xAE, 0xD2,
         0x46, 0x8A, 0xB8, 0xA1, 0x7A, 0xD8, 0x4E, 0x5D
     };
+#endif
 
+#ifdef WOLFSSL_AES_256
     /* Wrap 128 bits of Key Data with a 256-bit KEK */
     const byte k3[] = {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -6540,7 +6613,9 @@ int aeskeywrap_test(void)
         0x63, 0xE9, 0x77, 0x79, 0x05, 0x81, 0x8A, 0x2A,
         0x93, 0xC8, 0x19, 0x1E, 0x7D, 0x6E, 0x8A, 0xE7
     };
+#endif
 
+#ifdef WOLFSSL_AES_192
     /* Wrap 192 bits of Key Data with a 192-bit KEK */
     const byte k4[] = {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -6560,7 +6635,9 @@ int aeskeywrap_test(void)
         0xE1, 0xC6, 0xC7, 0xDD, 0xEE, 0x72, 0x5A, 0x93,
         0x6B, 0xA8, 0x14, 0x91, 0x5C, 0x67, 0x62, 0xD2
     };
+#endif
 
+#ifdef WOLFSSL_AES_256
     /* Wrap 192 bits of Key Data with a 256-bit KEK */
     const byte k5[] = {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -6604,18 +6681,29 @@ int aeskeywrap_test(void)
         0xCB, 0xC7, 0xF0, 0xE7, 0x1A, 0x99, 0xF4, 0x3B,
         0xFB, 0x98, 0x8B, 0x9B, 0x7A, 0x02, 0xDD, 0x21
     };
+#endif /* WOLFSSL_AES_256 */
 
     byte output[MAX_KEYWRAP_TEST_OUTLEN];
     byte plain [MAX_KEYWRAP_TEST_PLAINLEN];
 
     const keywrapVector test_wrap[] =
     {
+    #ifdef WOLFSSL_AES_128
         {k1, d1, v1, sizeof(k1), sizeof(d1), sizeof(v1)},
+    #endif
+    #ifdef WOLFSSL_AES_192
         {k2, d2, v2, sizeof(k2), sizeof(d2), sizeof(v2)},
+    #endif
+    #ifdef WOLFSSL_AES_256
         {k3, d3, v3, sizeof(k3), sizeof(d3), sizeof(v3)},
+    #endif
+    #ifdef WOLFSSL_AES_192
         {k4, d4, v4, sizeof(k4), sizeof(d4), sizeof(v4)},
+    #endif
+    #ifdef WOLFSSL_AES_256
         {k5, d5, v5, sizeof(k5), sizeof(d5), sizeof(v5)},
         {k6, d6, v6, sizeof(k6), sizeof(d6), sizeof(v6)}
+    #endif
     };
     testSz = sizeof(test_wrap) / sizeof(keywrapVector);
 
@@ -10332,6 +10420,7 @@ int srp_test(void)
 static int openssl_aes_test(void)
 {
 #ifdef HAVE_AES_CBC
+#ifdef WOLFSSL_AES_128
     {
         /* EVP_CipherUpdate test */
         const byte cbcPlain[] =
@@ -10463,10 +10552,11 @@ static int openssl_aes_test(void)
 
 
     }  /* end evp_cipher test: EVP_aes_128_cbc*/
+#endif /* WOLFSSL_AES_128 */
 #endif /* HAVE_AES_CBC */
 
-#ifdef HAVE_AES_ECB
-    {  /* evp_cipher test: EVP_aes_128_ecb*/
+#if defined(HAVE_AES_ECB) && defined(WOLFSSL_AES_256)
+    {  /* evp_cipher test: EVP_aes_256_ecb*/
         EVP_CIPHER_CTX ctx;
         const byte msg[] =
         {
@@ -10513,9 +10603,9 @@ static int openssl_aes_test(void)
             return -186;
 
     }  /* end evp_cipher test */
-#endif /* HAVE_AES_ECB */
+#endif /* HAVE_AES_ECB && WOLFSSL_AES_256 */
 
-#ifdef WOLFSSL_AES_DIRECT
+#if defined(WOLFSSL_AES_DIRECT) && defined(WOLFSSL_AES_256)
     /* enable HAVE_AES_DECRYPT for AES_encrypt/decrypt */
     {
         /* Test: AES_encrypt/decrypt/set Key */
@@ -10561,11 +10651,15 @@ static int openssl_aes_test(void)
         if (XMEMCMP(cipher, verify, AES_BLOCK_SIZE))
             return -188;
     }
-#endif /* WOLFSSL_AES_DIRECT */
+#endif /* WOLFSSL_AES_DIRECT && WOLFSSL_AES_256 */
 
 /* EVP_Cipher with EVP_aes_xxx_ctr() */
 #ifdef WOLFSSL_AES_COUNTER
     {
+        byte plainBuff [64];
+        byte cipherBuff[64];
+
+#ifdef WOLFSSL_AES_128
         const byte ctrKey[] =
         {
             0x2b,0x7e,0x15,0x16,0x28,0xae,0xd2,0xa6,
@@ -10603,18 +10697,16 @@ static int openssl_aes_test(void)
             0x79,0x21,0x70,0xa0,0xf3,0x00,0x9c,0xee
         };
 
-        byte plainBuff [64];
-        byte cipherBuff[64];
-
         const byte oddCipher[] =
         {
             0xb9,0xd7,0xcb,0x08,0xb0,0xe1,0x7b,0xa0,
             0xc2
         };
-
+#endif
 
         /* test vector from "Recommendation for Block Cipher Modes of Operation"
          * NIST Special Publication 800-38A */
+#ifdef WOLFSSL_AES_192
         const byte ctr192Key[] =
         {
             0x8e,0x73,0xb0,0xf7,0xda,0x0e,0x64,0x52,
@@ -10640,7 +10732,9 @@ static int openssl_aes_test(void)
             0x1a,0xbc,0x93,0x24,0x17,0x52,0x1c,0xa2,
             0x4f,0x2b,0x04,0x59,0xfe,0x7e,0x6e,0x0b
         };
+#endif /* WOLFSSL_AES_192 */
 
+#ifdef WOLFSSL_AES_256
         /* test vector from "Recommendation for Block Cipher Modes of Operation"
          * NIST Special Publication 800-38A */
         const byte ctr256Key[] =
@@ -10669,9 +10763,11 @@ static int openssl_aes_test(void)
             0x60,0x1e,0xc3,0x13,0x77,0x57,0x89,0xa5,
             0xb7,0xa7,0xf5,0x04,0xbb,0xf3,0xd2,0x28
         };
+#endif /* WOLFSSL_AES_256 */
 
         EVP_CIPHER_CTX en;
         EVP_CIPHER_CTX de;
+#ifdef WOLFSSL_AES_128
         EVP_CIPHER_CTX *p_en;
         EVP_CIPHER_CTX *p_de;
 
@@ -10754,7 +10850,9 @@ static int openssl_aes_test(void)
             return -3314;
         if (XMEMCMP(cipherBuff, oddCipher, 9))
             return -3315;
+#endif /* WOLFSSL_AES_128 */
 
+#ifdef WOLFSSL_AES_192
         EVP_CIPHER_CTX_init(&en);
         if (EVP_CipherInit(&en, EVP_aes_192_ctr(),
                 (unsigned char*)ctr192Key, (unsigned char*)ctr192Iv, 0) == 0)
@@ -10776,7 +10874,9 @@ static int openssl_aes_test(void)
             return -3320;
         if (XMEMCMP(ctr192Cipher, cipherBuff, sizeof(ctr192Cipher)))
             return -3321;
+#endif /* WOLFSSL_AES_192 */
 
+#ifdef WOLFSSL_AES_256
         EVP_CIPHER_CTX_init(&en);
         if (EVP_CipherInit(&en, EVP_aes_256_ctr(),
             (unsigned char*)ctr256Key, (unsigned char*)ctr256Iv, 0) == 0)
@@ -10798,10 +10898,11 @@ static int openssl_aes_test(void)
             return -3326;
         if (XMEMCMP(ctr256Cipher, cipherBuff, sizeof(ctr256Cipher)))
             return -3327;
+#endif /* WOLFSSL_AES_256 */
     }
 #endif /* HAVE_AES_COUNTER */
 
-#ifdef WOLFSSL_AES_CFB
+#if defined(WOLFSSL_AES_CFB) && defined(WOLFSSL_AES_128)
     {
         AES_KEY enc;
         AES_KEY dec;
@@ -10860,7 +10961,7 @@ static int openssl_aes_test(void)
         if (num != 0)
             return -3331;
     }
-#endif /* WOLFSSL_AES_CFB */
+#endif /* WOLFSSL_AES_CFB && WOLFSSL_AES_128 */
     return 0;
 }
 #endif /* !defined(NO_AES) && !defined(WOLFCRYPT_ONLY) */
@@ -11087,6 +11188,7 @@ int openssl_test(void)
         if (openssl_aes_test() != 0)
             return -3429;
 
+#ifdef WOLFSSL_AES_128
     {  /* evp_cipher test: EVP_aes_128_cbc */
         EVP_CIPHER_CTX ctx;
         int idx, cipherSz, plainSz;
@@ -11167,9 +11269,10 @@ int openssl_test(void)
             return -8112;
 
     }  /* end evp_cipher test: EVP_aes_128_cbc*/
+#endif /* WOLFSSL_AES_128 */
 
-#ifdef HAVE_AES_ECB
-    {  /* evp_cipher test: EVP_aes_128_ecb*/
+#if defined(HAVE_AES_ECB) && defined(WOLFSSL_AES_256)
+    {  /* evp_cipher test: EVP_aes_256_ecb*/
         EVP_CIPHER_CTX ctx;
         const byte msg[] =
         {
@@ -11218,12 +11321,12 @@ int openssl_test(void)
             return -5923;
 
     }  /* end evp_cipher test */
-#endif
+#endif /* HAVE_AES_ECB && WOLFSSL_AES_128 */
 
 #define OPENSSL_TEST_ERROR (-10000)
 
 
-#ifdef WOLFSSL_AES_DIRECT
+#if defined(WOLFSSL_AES_DIRECT) && defined(WOLFSSL_AES_256)
   /* enable HAVE_AES_DECRYPT for AES_encrypt/decrypt */
 {
 
@@ -11274,11 +11377,15 @@ int openssl_test(void)
       return OPENSSL_TEST_ERROR-61;
 }
 
-#endif
+#endif /* WOLFSSL_AES_DIRECT && WOLFSSL_AES_256 */
 
 /* EVP_Cipher with EVP_aes_xxx_ctr() */
 #ifdef WOLFSSL_AES_COUNTER
 {
+    byte plainBuff [64];
+    byte cipherBuff[64];
+
+#ifdef WOLFSSL_AES_128
     const byte ctrKey[] =
     {
         0x2b,0x7e,0x15,0x16,0x28,0xae,0xd2,0xa6,
@@ -11290,7 +11397,6 @@ int openssl_test(void)
         0xf0,0xf1,0xf2,0xf3,0xf4,0xf5,0xf6,0xf7,
         0xf8,0xf9,0xfa,0xfb,0xfc,0xfd,0xfe,0xff
     };
-
 
     const byte ctrPlain[] =
     {
@@ -11316,16 +11422,14 @@ int openssl_test(void)
         0x79,0x21,0x70,0xa0,0xf3,0x00,0x9c,0xee
     };
 
-    byte plainBuff [64];
-    byte cipherBuff[64];
-
     const byte oddCipher[] =
     {
         0xb9,0xd7,0xcb,0x08,0xb0,0xe1,0x7b,0xa0,
         0xc2
     };
+#endif /* WOLFSSL_AES_128 */
 
-
+#ifdef WOLFSSL_AES_192
     /* test vector from "Recommendation for Block Cipher Modes of Operation"
      * NIST Special Publication 800-38A */
     const byte ctr192Key[] =
@@ -11353,7 +11457,9 @@ int openssl_test(void)
         0x1a,0xbc,0x93,0x24,0x17,0x52,0x1c,0xa2,
         0x4f,0x2b,0x04,0x59,0xfe,0x7e,0x6e,0x0b
     };
+#endif /* WOLFSSL_AES_192 */
 
+#ifdef WOLFSSL_AES_256
     /* test vector from "Recommendation for Block Cipher Modes of Operation"
      * NIST Special Publication 800-38A */
     const byte ctr256Key[] =
@@ -11382,9 +11488,11 @@ int openssl_test(void)
         0x60,0x1e,0xc3,0x13,0x77,0x57,0x89,0xa5,
         0xb7,0xa7,0xf5,0x04,0xbb,0xf3,0xd2,0x28
     };
+#endif /* WOLFSSL_AES_256 */
 
     EVP_CIPHER_CTX en;
     EVP_CIPHER_CTX de;
+#ifdef WOLFSSL_AES_128
     EVP_CIPHER_CTX *p_en;
     EVP_CIPHER_CTX *p_de;
 
@@ -11465,7 +11573,9 @@ int openssl_test(void)
         return -5946;
     if (XMEMCMP(cipherBuff, oddCipher, 9))
         return -5947;
+#endif /* WOLFSSL_AES_128 */
 
+#ifdef WOLFSSL_AES_192
     EVP_CIPHER_CTX_init(&en);
     if (EVP_CipherInit(&en, EVP_aes_192_ctr(),
             (unsigned char*)ctr192Key, (unsigned char*)ctr192Iv, 0) == 0)
@@ -11487,7 +11597,9 @@ int openssl_test(void)
         return -5952;
     if (XMEMCMP(ctr192Cipher, cipherBuff, sizeof(ctr192Cipher)))
         return -5953;
+#endif /* WOLFSSL_AES_192 */
 
+#ifdef WOLFSSL_AES_256
     EVP_CIPHER_CTX_init(&en);
     if (EVP_CipherInit(&en, EVP_aes_256_ctr(),
         (unsigned char*)ctr256Key, (unsigned char*)ctr256Iv, 0) == 0)
@@ -11509,9 +11621,11 @@ int openssl_test(void)
         return -5958;
     if (XMEMCMP(ctr256Cipher, cipherBuff, sizeof(ctr256Cipher)))
         return -5959;
+#endif /* WOLFSSL_AES_256 */
 }
 #endif /* HAVE_AES_COUNTER */
 
+#ifdef WOLFSSL_AES_128
 {
       /* EVP_CipherUpdate test */
 
@@ -11662,6 +11776,7 @@ int openssl_test(void)
             return -3448;
 
     }
+#endif /* WOLFSSL_AES_128 */
 #endif /* ifndef NO_AES */
     return 0;
 }
@@ -14598,7 +14713,7 @@ done:
     return ret;
 }
 
-#ifdef HAVE_ECC_ENCRYPT
+#if defined(HAVE_ECC_ENCRYPT) && defined(WOLFSSL_AES_128)
 
 int ecc_encrypt_test(void)
 {
@@ -15683,17 +15798,24 @@ typedef struct CMAC_Test_Case {
 
 int cmac_test(void)
 {
+#ifdef WOLFSSL_AES_128
     const byte k128[] =
     {
         0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
         0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c
     };
+    #define KLEN_128 (sizeof(k128))
+#endif
+#ifdef WOLFSSL_AES_192
     const byte k192[] =
     {
         0x8e, 0x73, 0xb0, 0xf7, 0xda, 0x0e, 0x64, 0x52,
         0xc8, 0x10, 0xf3, 0x2b, 0x80, 0x90, 0x79, 0xe5,
         0x62, 0xf8, 0xea, 0xd2, 0x52, 0x2c, 0x6b, 0x7b
     };
+    #define KLEN_192 (sizeof(k192))
+#endif
+#ifdef WOLFSSL_AES_256
     const byte k256[] =
     {
         0x60, 0x3d, 0xeb, 0x10, 0x15, 0xca, 0x71, 0xbe,
@@ -15701,9 +15823,8 @@ int cmac_test(void)
         0x1f, 0x35, 0x2c, 0x07, 0x3b, 0x61, 0x08, 0xd7,
         0x2d, 0x98, 0x10, 0xa3, 0x09, 0x14, 0xdf, 0xf4
     };
-    #define KLEN_128 (sizeof(k128))
-    #define KLEN_192 (sizeof(k192))
     #define KLEN_256 (sizeof(k256))
+#endif
 
     const byte m[] =
     {
@@ -15722,6 +15843,7 @@ int cmac_test(void)
     #define MLEN_319 (MLEN_320 - 1)
     #define MLEN_512 (512/8)
 
+#ifdef WOLFSSL_AES_128
     const byte t128_0[] =
     {
         0xbb, 0x1d, 0x69, 0x29, 0xe9, 0x59, 0x37, 0x28,
@@ -15747,7 +15869,8 @@ int cmac_test(void)
         0x51, 0xf0, 0xbe, 0xbf, 0x7e, 0x3b, 0x9d, 0x92,
         0xfc, 0x49, 0x74, 0x17, 0x79, 0x36, 0x3c, 0xfe
     };
-
+#endif
+#ifdef WOLFSSL_AES_192
     const byte t192_0[] =
     {
         0xd1, 0x7d, 0xdf, 0x46, 0xad, 0xaa, 0xcd, 0xe5,
@@ -15768,7 +15891,8 @@ int cmac_test(void)
         0xa1, 0xd5, 0xdf, 0x0e, 0xed, 0x79, 0x0f, 0x79,
         0x4d, 0x77, 0x58, 0x96, 0x59, 0xf3, 0x9a, 0x11
     };
-
+#endif
+#ifdef WOLFSSL_AES_256
     const byte t256_0[] =
     {
         0x02, 0x89, 0x62, 0xf6, 0x1b, 0x7b, 0xf8, 0x9e,
@@ -15789,23 +15913,31 @@ int cmac_test(void)
         0xe1, 0x99, 0x21, 0x90, 0x54, 0x9f, 0x6e, 0xd5,
         0x69, 0x6a, 0x2c, 0x05, 0x6c, 0x31, 0x54, 0x10
     };
-
+#endif
     const CMAC_Test_Case testCases[] =
     {
+#ifdef WOLFSSL_AES_128
         {WC_CMAC_AES, 0, m, MLEN_0, k128, KLEN_128, t128_0, AES_BLOCK_SIZE},
         {WC_CMAC_AES, 0, m, MLEN_128, k128, KLEN_128, t128_128, AES_BLOCK_SIZE},
         {WC_CMAC_AES, 0, m, MLEN_320, k128, KLEN_128, t128_320, AES_BLOCK_SIZE},
         {WC_CMAC_AES, 0, m, MLEN_512, k128, KLEN_128, t128_512, AES_BLOCK_SIZE},
         {WC_CMAC_AES, 5, m, MLEN_512, k128, KLEN_128, t128_512, AES_BLOCK_SIZE},
+#endif
+#ifdef WOLFSSL_AES_192
         {WC_CMAC_AES, 0, m, MLEN_0, k192, KLEN_192, t192_0, AES_BLOCK_SIZE},
         {WC_CMAC_AES, 0, m, MLEN_128, k192, KLEN_192, t192_128, AES_BLOCK_SIZE},
         {WC_CMAC_AES, 0, m, MLEN_320, k192, KLEN_192, t192_320, AES_BLOCK_SIZE},
         {WC_CMAC_AES, 0, m, MLEN_512, k192, KLEN_192, t192_512, AES_BLOCK_SIZE},
+#endif
+#ifdef WOLFSSL_AES_256
         {WC_CMAC_AES, 0, m, MLEN_0, k256, KLEN_256, t256_0, AES_BLOCK_SIZE},
         {WC_CMAC_AES, 0, m, MLEN_128, k256, KLEN_256, t256_128, AES_BLOCK_SIZE},
         {WC_CMAC_AES, 0, m, MLEN_320, k256, KLEN_256, t256_320, AES_BLOCK_SIZE},
         {WC_CMAC_AES, 0, m, MLEN_512, k256, KLEN_256, t256_512, AES_BLOCK_SIZE},
+#endif
+#ifdef WOLFSSL_AES_128
         {WC_CMAC_AES, 0, m, MLEN_319, k128, KLEN_128, t128_319, AES_BLOCK_SIZE}
+#endif
     };
 
     Cmac cmac;
@@ -16162,7 +16294,8 @@ static int pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
         0x72,0x6c,0x64
     };
 
-#if !defined(NO_AES) && defined(HAVE_ECC) && defined(WOLFSSL_SHA512)
+#if !defined(NO_AES) && defined(WOLFSSL_AES_256) && defined(HAVE_ECC) && \
+    defined(WOLFSSL_SHA512)
     byte optionalUkm[] = {
         0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07
     };
@@ -16178,35 +16311,39 @@ static int pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
     #endif
 
     #ifndef NO_AES
+        #ifdef WOLFSSL_AES_128
         {data, (word32)sizeof(data), DATA, AES128CBCb, 0, 0, rsaCert, rsaCertSz,
          rsaPrivKey, rsaPrivKeySz, NULL, 0, "pkcs7envelopedDataAES128CBC.der"},
-
+        #endif
+        #ifdef WOLFSSL_AES_192
         {data, (word32)sizeof(data), DATA, AES192CBCb, 0, 0, rsaCert, rsaCertSz,
          rsaPrivKey, rsaPrivKeySz, NULL, 0, "pkcs7envelopedDataAES192CBC.der"},
-
+        #endif
+        #ifdef WOLFSSL_AES_256
         {data, (word32)sizeof(data), DATA, AES256CBCb, 0, 0, rsaCert, rsaCertSz,
          rsaPrivKey, rsaPrivKeySz, NULL, 0, "pkcs7envelopedDataAES256CBC.der"},
+        #endif
     #endif /* NO_AES */
 #endif
 
         /* key agreement key encryption technique*/
 #ifdef HAVE_ECC
     #ifndef NO_AES
-        #ifndef NO_SHA
+        #if !defined(NO_SHA) && defined(WOLFSSL_AES_128)
         {data, (word32)sizeof(data), DATA, AES128CBCb, AES128_WRAP,
          dhSinglePass_stdDH_sha1kdf_scheme, eccCert, eccCertSz, eccPrivKey,
          eccPrivKeySz, NULL, 0,
          "pkcs7envelopedDataAES128CBC_ECDH_SHA1KDF.der"},
         #endif
 
-        #ifndef NO_SHA256
+        #if !defined(NO_SHA256) && defined(WOLFSSL_AES_256)
         {data, (word32)sizeof(data), DATA, AES256CBCb, AES256_WRAP,
          dhSinglePass_stdDH_sha256kdf_scheme, eccCert, eccCertSz, eccPrivKey,
          eccPrivKeySz, NULL, 0,
          "pkcs7envelopedDataAES256CBC_ECDH_SHA256KDF.der"},
-        #endif /* NO_SHA256 */
+        #endif /* NO_SHA256 && WOLFSSL_AES_256 */
 
-        #ifdef WOLFSSL_SHA512
+        #if defined(WOLFSSL_SHA512) && defined(WOLFSSL_AES_256)
         {data, (word32)sizeof(data), DATA, AES256CBCb, AES256_WRAP,
          dhSinglePass_stdDH_sha512kdf_scheme, eccCert, eccCertSz, eccPrivKey,
          eccPrivKeySz, NULL, 0,
@@ -16217,7 +16354,7 @@ static int pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
          dhSinglePass_stdDH_sha512kdf_scheme, eccCert, eccCertSz, eccPrivKey,
          eccPrivKeySz, optionalUkm, sizeof(optionalUkm),
          "pkcs7envelopedDataAES256CBC_ECDH_SHA512KDF_ukm.der"},
-        #endif /* WOLFSSL_SHA512 */
+        #endif /* WOLFSSL_SHA512 && WOLFSSL_AES_256 */
     #endif /* NO_AES */
 #endif
     };
@@ -16432,22 +16569,29 @@ int pkcs7encrypted_test(void)
 #endif
 
 #ifndef NO_AES
+#ifdef WOLFSSL_AES_128
     byte aes128Key[] = {
         0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
         0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08
     };
+#endif
+#ifdef WOLFSSL_AES_192
     byte aes192Key[] = {
         0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
         0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
         0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08
     };
+#endif
+#ifdef WOLFSSL_AES_256
     byte aes256Key[] = {
         0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
         0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
         0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,
         0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08
     };
+#endif
 
+#ifdef WOLFSSL_AES_256
     /* Attribute example from RFC 4134, Section 7.2
      * OID = 1.2.5555
      * OCTET STRING = 'This is a test General ASN Attribute, number 1.' */
@@ -16471,14 +16615,15 @@ int pkcs7encrypted_test(void)
 
     PKCS7Attrib attribs[] =
     {
-        { genAttrOid, genAttr, sizeof(genAttrOid), sizeof(genAttr) }
+        { genAttrOid, sizeof(genAttrOid), genAttr, sizeof(genAttr) }
     };
 
     PKCS7Attrib multiAttribs[] =
     {
-        { genAttrOid, genAttr, sizeof(genAttrOid), sizeof(genAttr) },
-        { genAttrOid2, genAttr2, sizeof(genAttrOid2), sizeof(genAttr2) }
+        { genAttrOid, sizeof(genAttrOid), genAttr, sizeof(genAttr) },
+        { genAttrOid2, sizeof(genAttrOid2), genAttr2, sizeof(genAttr2) }
     };
+#endif
 #endif /* NO_AES */
 
     const pkcs7EncryptedVector testVectors[] =
@@ -16492,12 +16637,15 @@ int pkcs7encrypted_test(void)
 #endif /* NO_DES3 */
 
 #ifndef NO_AES
+    #ifdef WOLFSSL_AES_128
         {data, (word32)sizeof(data), DATA, AES128CBCb, aes128Key,
          sizeof(aes128Key), NULL, 0, "pkcs7encryptedDataAES128CBC.der"},
-
+    #endif
+    #ifdef WOLFSSL_AES_192
         {data, (word32)sizeof(data), DATA, AES192CBCb, aes192Key,
          sizeof(aes192Key), NULL, 0, "pkcs7encryptedDataAES192CBC.der"},
-
+    #endif
+    #ifdef WOLFSSL_AES_256
         {data, (word32)sizeof(data), DATA, AES256CBCb, aes256Key,
          sizeof(aes256Key), NULL, 0, "pkcs7encryptedDataAES256CBC.der"},
 
@@ -16511,6 +16659,7 @@ int pkcs7encrypted_test(void)
          sizeof(aes256Key), multiAttribs,
          (sizeof(multiAttribs)/sizeof(PKCS7Attrib)),
          "pkcs7encryptedDataAES256CBC_multi_attribs.der"},
+    #endif
 #endif /* NO_AES */
     };
 
@@ -16645,11 +16794,11 @@ static int pkcs7signed_run_vectors(byte* rsaCert, word32 rsaCertSz,
 
     PKCS7Attrib attribs[] =
     {
-        { transIdOid, transId, sizeof(transIdOid),
+        { transIdOid, sizeof(transIdOid), transId,
                                sizeof(transId) - 1 }, /* take off the null */
-        { messageTypeOid, messageType, sizeof(messageTypeOid),
+        { messageTypeOid, sizeof(messageTypeOid), messageType,
                                        sizeof(messageType) },
-        { senderNonceOid, senderNonce, sizeof(senderNonceOid),
+        { senderNonceOid, sizeof(senderNonceOid), senderNonce,
                                        sizeof(senderNonce) }
     };
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5783,6 +5783,9 @@ int aes_test(void)
     wc_AesFree(&dec);
 #endif
 
+    (void)plain;
+    (void)cipher;
+
     return ret;
 }
 
@@ -6342,6 +6345,7 @@ int aesgcm_test(void)
 #endif /* WOLFSSL_AES_128 */
 #endif /* ENABLE_NON_12BYTE_IV_TEST */
 
+#ifdef WOLFSSL_AES_256
     XMEMSET(resultT, 0, sizeof(resultT));
     XMEMSET(resultC, 0, sizeof(resultC));
     XMEMSET(resultP, 0, sizeof(resultP));
@@ -6369,6 +6373,7 @@ int aesgcm_test(void)
         return -4324;
     if (XMEMCMP(p, resultP, sizeof(resultP)))
         return -4325;
+#endif /* WOLFSSL_AES_256 */
     wc_AesFree(&enc);
 
     return 0;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3047,7 +3047,8 @@ struct WOLFSSL_X509_NAME {
     int   dynamicName;
     int   sz;
     char  staticName[ASN_NAME_MAX];
-#if defined(OPENSSL_EXTRA) && !defined(NO_ASN)
+#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
+    !defined(NO_ASN)
     DecodedName fullName;
     WOLFSSL_X509_NAME_ENTRY cnEntry;
     WOLFSSL_X509_NAME_ENTRY extra[MAX_NAME_ENTRIES]; /* extra entries added */
@@ -3077,7 +3078,7 @@ struct WOLFSSL_X509 {
     byte             hwType[EXTERNAL_SERIAL_SIZE];
     int              hwSerialNumSz;
     byte             hwSerialNum[EXTERNAL_SERIAL_SIZE];
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         byte             certPolicySet;
         byte             certPolicyCrit;
     #endif /* OPENSSL_EXTRA */
@@ -3105,7 +3106,7 @@ struct WOLFSSL_X509 {
     char             certPolicies[MAX_CERTPOL_NB][MAX_CERTPOL_SZ];
     int              certPoliciesNb;
 #endif /* WOLFSSL_CERT_EXT */
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 #ifdef HAVE_EX_DATA
     void*            ex_data[MAX_EX_DATA];
 #endif
@@ -3140,7 +3141,7 @@ struct WOLFSSL_X509 {
     byte             subjAltNameCrit:1;
     byte             authKeyIdSet:1;
     byte             authKeyIdCrit:1;
-#endif /* OPENSSL_EXTRA */
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
     byte             serial[EXTERNAL_SERIAL_SIZE];
     char             subjectCN[ASN_NAME_MAX];        /* common name short cut */
 #ifdef WOLFSSL_CERT_REQ

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -277,32 +277,54 @@
     #if !defined(NO_RSA) && !defined(NO_AES) && !defined(NO_TLS)
         #if !defined(NO_SHA)
             #if defined(WOLFSSL_STATIC_RSA)
-                #define BUILD_TLS_RSA_WITH_AES_128_CBC_SHA
-                #define BUILD_TLS_RSA_WITH_AES_256_CBC_SHA
+                #ifdef WOLFSSL_AES_128
+                    #define BUILD_TLS_RSA_WITH_AES_128_CBC_SHA
+                #endif
+                #ifdef WOLFSSL_AES_256
+                    #define BUILD_TLS_RSA_WITH_AES_256_CBC_SHA
+                #endif
             #endif
             #if defined(HAVE_NTRU) && defined(WOLFSSL_STATIC_RSA)
+                #ifdef WOLFSSL_AES_128
                     #define BUILD_TLS_NTRU_RSA_WITH_AES_128_CBC_SHA
+                #endif
+                #ifdef WOLFSSL_AES_256
                     #define BUILD_TLS_NTRU_RSA_WITH_AES_256_CBC_SHA
+                #endif
             #endif
         #endif
         #if defined(WOLFSSL_STATIC_RSA)
             #if !defined (NO_SHA256)
-                #define BUILD_TLS_RSA_WITH_AES_128_CBC_SHA256
-                #define BUILD_TLS_RSA_WITH_AES_256_CBC_SHA256
+                #ifdef WOLFSSL_AES_128
+                    #define BUILD_TLS_RSA_WITH_AES_128_CBC_SHA256
+                #endif
+                #ifdef WOLFSSL_AES_256
+                    #define BUILD_TLS_RSA_WITH_AES_256_CBC_SHA256
+                #endif
             #endif
             #if defined (HAVE_AESGCM)
-                #define BUILD_TLS_RSA_WITH_AES_128_GCM_SHA256
-                #if defined (WOLFSSL_SHA384)
+                #ifdef WOLFSSL_AES_128
+                    #define BUILD_TLS_RSA_WITH_AES_128_GCM_SHA256
+                #endif
+                #if defined (WOLFSSL_SHA384) && defined(WOLFSSL_AES_256)
                     #define BUILD_TLS_RSA_WITH_AES_256_GCM_SHA384
                 #endif
             #endif
             #if defined (HAVE_AESCCM)
-                #define BUILD_TLS_RSA_WITH_AES_128_CCM_8
-                #define BUILD_TLS_RSA_WITH_AES_256_CCM_8
+                #ifdef WOLFSSL_AES_128
+                    #define BUILD_TLS_RSA_WITH_AES_128_CCM_8
+                #endif
+                #ifdef WOLFSSL_AES_256
+                    #define BUILD_TLS_RSA_WITH_AES_256_CCM_8
+                #endif
             #endif
             #if defined(HAVE_BLAKE2)
-                #define BUILD_TLS_RSA_WITH_AES_128_CBC_B2B256
-                #define BUILD_TLS_RSA_WITH_AES_256_CBC_B2B256
+                #ifdef WOLFSSL_AES_128
+                    #define BUILD_TLS_RSA_WITH_AES_128_CBC_B2B256
+                #endif
+                #ifdef WOLFSSL_AES_256
+                    #define BUILD_TLS_RSA_WITH_AES_256_CBC_B2B256
+                #endif
             #endif
         #endif
     #endif
@@ -335,22 +357,32 @@
 #if defined(WOLFSSL_STATIC_PSK)
     #if !defined(NO_PSK) && !defined(NO_AES) && !defined(NO_TLS)
         #if !defined(NO_SHA)
-            #define BUILD_TLS_PSK_WITH_AES_128_CBC_SHA
-            #define BUILD_TLS_PSK_WITH_AES_256_CBC_SHA
+            #ifdef WOLFSSL_AES_128
+                #define BUILD_TLS_PSK_WITH_AES_128_CBC_SHA
+            #endif
+            #ifdef WOLFSSL_AES_256
+                #define BUILD_TLS_PSK_WITH_AES_256_CBC_SHA
+            #endif
         #endif
         #ifndef NO_SHA256
+            #ifdef WOLFSSL_AES_128
             #define BUILD_TLS_PSK_WITH_AES_128_CBC_SHA256
             #ifdef HAVE_AESGCM
                 #define BUILD_TLS_PSK_WITH_AES_128_GCM_SHA256
             #endif
+            #endif /* WOLFSSL_AES_128 */
             #ifdef HAVE_AESCCM
-                #define BUILD_TLS_PSK_WITH_AES_128_CCM_8
-                #define BUILD_TLS_PSK_WITH_AES_256_CCM_8
-                #define BUILD_TLS_PSK_WITH_AES_128_CCM
-                #define BUILD_TLS_PSK_WITH_AES_256_CCM
+                #ifdef WOLFSSL_AES_128
+                    #define BUILD_TLS_PSK_WITH_AES_128_CCM_8
+                    #define BUILD_TLS_PSK_WITH_AES_128_CCM
+                #endif
+                #ifdef WOLFSSL_AES_256
+                    #define BUILD_TLS_PSK_WITH_AES_256_CCM_8
+                    #define BUILD_TLS_PSK_WITH_AES_256_CCM
+                #endif
             #endif
         #endif
-        #ifdef WOLFSSL_SHA384
+        #if defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256)
             #define BUILD_TLS_PSK_WITH_AES_256_CBC_SHA384
             #ifdef HAVE_AESGCM
                 #define BUILD_TLS_PSK_WITH_AES_256_GCM_SHA384
@@ -407,26 +439,34 @@
         !defined(NO_RSA)
 
         #if !defined(NO_SHA)
-            #define BUILD_TLS_DHE_RSA_WITH_AES_128_CBC_SHA
-            #define BUILD_TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+            #ifdef WOLFSSL_AES_128
+                #define BUILD_TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+            #endif
+            #ifdef WOLFSSL_AES_256
+                #define BUILD_TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+            #endif
             #if !defined(NO_DES3)
                 #define BUILD_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
             #endif
         #endif
-        #if !defined(NO_SHA256)
-            #define BUILD_TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
-            #define BUILD_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
+        #if !defined(NO_SHA256) && defined(HAVE_AES_CBC)
+            #ifdef WOLFSSL_AES_128
+                #define BUILD_TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+            #endif
+            #ifdef WOLFSSL_AES_256
+                #define BUILD_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
+            #endif
         #endif
     #endif
 
     #if defined(HAVE_ANON) && !defined(NO_TLS) && !defined(NO_DH) && \
-        !defined(NO_AES) && !defined(NO_SHA)
+        !defined(NO_AES) && !defined(NO_SHA) && defined(WOLFSSL_AES_128)
         #define BUILD_TLS_DH_anon_WITH_AES_128_CBC_SHA
     #endif
 
     #if !defined(NO_DH) && !defined(NO_PSK) && !defined(NO_TLS)
         #ifndef NO_SHA256
-            #ifndef NO_AES
+            #if !defined(NO_AES) && defined(WOLFSSL_AES_128)
                 #define BUILD_TLS_DHE_PSK_WITH_AES_128_CBC_SHA256
             #endif
             #ifdef HAVE_NULL_CIPHER
@@ -434,7 +474,7 @@
             #endif
         #endif
         #ifdef WOLFSSL_SHA384
-            #ifndef NO_AES
+            #if !defined(NO_AES) && defined(WOLFSSL_AES_256)
                 #define BUILD_TLS_DHE_PSK_WITH_AES_256_CBC_SHA384
             #endif
             #ifdef HAVE_NULL_CIPHER
@@ -447,23 +487,39 @@
         #if !defined(NO_AES)
             #if !defined(NO_SHA)
                 #if !defined(NO_RSA)
-                    #define BUILD_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
-                    #define BUILD_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+                    #ifdef WOLFSSL_AES_128
+                        #define BUILD_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+                    #endif
+                    #ifdef WOLFSSL_AES_256
+                        #define BUILD_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+                    #endif
                     #if defined(WOLFSSL_STATIC_DH)
-                        #define BUILD_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
-                        #define BUILD_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+                        #ifdef WOLFSSL_AES_128
+                            #define BUILD_TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+                        #endif
+                        #ifdef WOLFSSL_AES_256
+                            #define BUILD_TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+                        #endif
                     #endif
                 #endif
 
-                #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
-                #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+                #ifdef WOLFSSL_AES_128
+                    #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+                #endif
+                #ifdef WOLFSSL_AES_256
+                    #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+                #endif
 
                 #if defined(WOLFSSL_STATIC_DH)
-                    #define BUILD_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
-                    #define BUILD_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
+                    #ifdef WOLFSSL_AES_128
+                        #define BUILD_TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+                    #endif
+                    #ifdef WOLFSSL_AES_256
+                        #define BUILD_TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
+                    #endif
                 #endif
             #endif /* NO_SHA */
-            #ifndef NO_SHA256
+            #if !defined(NO_SHA256) && defined(WOLFSSL_AES_128)
                 #if !defined(NO_RSA)
                     #define BUILD_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
                     #if defined(WOLFSSL_STATIC_DH)
@@ -476,7 +532,7 @@
                 #endif
             #endif
 
-            #ifdef WOLFSSL_SHA384
+            #if defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256)
                 #if !defined(NO_RSA)
                     #define BUILD_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
                     #if defined(WOLFSSL_STATIC_DH)
@@ -492,21 +548,25 @@
             #if defined (HAVE_AESGCM)
                 #if !defined(NO_RSA)
                     #if defined(WOLFSSL_STATIC_DH)
-                        #define BUILD_TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+                        #ifdef WOLFSSL_AES_128
+                            #define BUILD_TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+                        #endif
                     #endif
                     #if defined(WOLFSSL_SHA384)
                         #if defined(WOLFSSL_STATIC_DH)
-                            #define BUILD_TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
+                            #ifdef WOLFSSL_AES_256
+                                #define BUILD_TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
+                            #endif
                         #endif
                     #endif
                 #endif
 
-                #if defined(WOLFSSL_STATIC_DH)
+                #if defined(WOLFSSL_STATIC_DH) && defined(WOLFSSL_AES_128)
                     #define BUILD_TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
                 #endif
 
                 #if defined(WOLFSSL_SHA384)
-                    #if defined(WOLFSSL_STATIC_DH)
+                    #if defined(WOLFSSL_STATIC_DH) && defined(WOLFSSL_AES_256)
                         #define BUILD_TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384
                     #endif
                 #endif
@@ -550,7 +610,8 @@
                 #define BUILD_TLS_ECDHE_PSK_WITH_NULL_SHA256
             #endif
         #endif
-        #if !defined(NO_PSK) && !defined(NO_SHA256) && !defined(NO_AES)
+        #if !defined(NO_PSK) && !defined(NO_SHA256) && !defined(NO_AES) && \
+            defined(WOLFSSL_AES_128)
             #define BUILD_TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256
         #endif
     #endif
@@ -582,39 +643,44 @@
 #if !defined(NO_DH) && !defined(NO_AES) && !defined(NO_TLS) && \
     !defined(NO_RSA) && defined(HAVE_AESGCM)
 
-    #ifndef NO_SHA256
+    #if !defined(NO_SHA256) && defined(WOLFSSL_AES_128)
         #define BUILD_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
     #endif
 
-    #ifdef WOLFSSL_SHA384
+    #if defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256)
         #define BUILD_TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
     #endif
 #endif
 
 #if !defined(NO_DH) && !defined(NO_PSK) && !defined(NO_TLS)
     #ifndef NO_SHA256
-        #ifdef HAVE_AESGCM
+        #if defined(HAVE_AESGCM) && defined(WOLFSSL_AES_128)
             #define BUILD_TLS_DHE_PSK_WITH_AES_128_GCM_SHA256
         #endif
         #ifdef HAVE_AESCCM
-            #define BUILD_TLS_DHE_PSK_WITH_AES_128_CCM
-            #define BUILD_TLS_DHE_PSK_WITH_AES_256_CCM
+            #ifdef WOLFSSL_AES_128
+                #define BUILD_TLS_DHE_PSK_WITH_AES_128_CCM
+            #endif
+            #ifdef WOLFSSL_AES_256
+                #define BUILD_TLS_DHE_PSK_WITH_AES_256_CCM
+            #endif
         #endif
     #endif
-    #if defined(WOLFSSL_SHA384) && defined(HAVE_AESGCM)
+    #if defined(WOLFSSL_SHA384) && defined(HAVE_AESGCM) && \
+        defined(WOLFSSL_AES_256)
         #define BUILD_TLS_DHE_PSK_WITH_AES_256_GCM_SHA384
     #endif
 #endif
 
 #if defined(HAVE_ECC) && !defined(NO_TLS) && !defined(NO_AES)
     #ifdef HAVE_AESGCM
-        #ifndef NO_SHA256
+        #if !defined(NO_SHA256) && defined(WOLFSSL_AES_128)
             #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
             #ifndef NO_RSA
                 #define BUILD_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
             #endif
         #endif
-        #ifdef WOLFSSL_SHA384
+        #if defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256)
             #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
             #ifndef NO_RSA
                 #define BUILD_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -622,9 +688,13 @@
         #endif
     #endif
     #if defined(HAVE_AESCCM) && !defined(NO_SHA256)
-        #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM
-        #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
-        #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8
+        #ifdef WOLFSSL_AES_128
+            #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM
+            #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
+        #endif
+        #ifdef WOLFSSL_AES_256
+            #define BUILD_TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8
+        #endif
     #endif
 #endif
 
@@ -642,10 +712,10 @@
 
 #if defined(WOLFSSL_TLS13)
     #ifdef HAVE_AESGCM
-        #ifndef NO_SHA256
+        #if !defined(NO_SHA256) && defined(WOLFSSL_AES_128)
             #define BUILD_TLS_AES_128_GCM_SHA256
         #endif
-        #ifdef WOLFSSL_SHA384
+        #if defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256)
             #define BUILD_TLS_AES_256_GCM_SHA384
         #endif
     #endif
@@ -657,7 +727,7 @@
     #endif
 
     #ifdef HAVE_AESCCM
-        #ifndef NO_SHA256
+        #if !defined(NO_SHA256) && defined(WOLFSSL_AES_128)
             #define BUILD_TLS_AES_128_CCM_SHA256
             #define BUILD_TLS_AES_128_CCM_8_SHA256
         #endif

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3044,9 +3044,9 @@ struct WOLFSSL_STACK {
 
 struct WOLFSSL_X509_NAME {
     char  *name;
-    char  staticName[ASN_NAME_MAX];
     int   dynamicName;
     int   sz;
+    char  staticName[ASN_NAME_MAX];
 #if defined(OPENSSL_EXTRA) && !defined(NO_ASN)
     DecodedName fullName;
     WOLFSSL_X509_NAME_ENTRY cnEntry;
@@ -3069,18 +3069,11 @@ struct WOLFSSL_X509_NAME {
 
 struct WOLFSSL_X509 {
     int              version;
-    WOLFSSL_X509_NAME issuer;
-    WOLFSSL_X509_NAME subject;
     int              serialSz;
-    byte             serial[EXTERNAL_SERIAL_SIZE];
-    char             subjectCN[ASN_NAME_MAX];        /* common name short cut */
-#ifdef WOLFSSL_CERT_REQ
-    char             challengePw[CTC_NAME_SIZE]; /* for REQ certs */
-#endif
 #ifdef WOLFSSL_SEP
     int              deviceTypeSz;
-    byte             deviceType[EXTERNAL_SERIAL_SIZE];
     int              hwTypeSz;
+    byte             deviceType[EXTERNAL_SERIAL_SIZE];
     byte             hwType[EXTERNAL_SERIAL_SIZE];
     int              hwSerialNumSz;
     byte             hwSerialNum[EXTERNAL_SERIAL_SIZE];
@@ -3090,24 +3083,24 @@ struct WOLFSSL_X509 {
     #endif /* OPENSSL_EXTRA */
 #endif
     int              notBeforeSz;
-    byte             notBefore[MAX_DATE_SZ];
     int              notAfterSz;
+    byte             notBefore[MAX_DATE_SZ];
     byte             notAfter[MAX_DATE_SZ];
-    int              sigOID;
     buffer           sig;
-    int              pubKeyOID;
+    int              sigOID;
+    DNS_entry*       altNames;                       /* alt names list */
     buffer           pubKey;
+    int              pubKeyOID;
+    DNS_entry*       altNamesNext;                   /* hint for retrieval */
     #ifdef HAVE_ECC
         word32       pkCurveOID;
     #endif /* HAVE_ECC */
     #ifndef NO_CERTS
         DerBuffer*   derCert;                        /* may need  */
     #endif
-    DNS_entry*       altNames;                       /* alt names list */
-    DNS_entry*       altNamesNext;                   /* hint for retrieval */
     void*            heap;                           /* heap hint */
     byte             dynamicMemory;                  /* dynamic memory flag */
-    byte             isCa;
+    byte             isCa:1;
 #ifdef WOLFSSL_CERT_EXT
     char             certPolicies[MAX_CERTPOL_NB][MAX_CERTPOL_SZ];
     int              certPoliciesNb;
@@ -3116,36 +3109,45 @@ struct WOLFSSL_X509 {
 #ifdef HAVE_EX_DATA
     void*            ex_data[MAX_EX_DATA];
 #endif
+    byte*            authKeyId;
+    byte*            subjKeyId;
+    byte*            extKeyUsageSrc;
+    byte*            CRLInfo;
+    byte*            authInfo;
     word32           pathLength;
     word16           keyUsage;
-    byte             CRLdistSet;
-    byte             CRLdistCrit;
-    byte*            CRLInfo;
     int              CRLInfoSz;
-    byte             authInfoSet;
-    byte             authInfoCrit;
-    byte*            authInfo;
     int              authInfoSz;
-    byte             basicConstSet;
-    byte             basicConstCrit;
-    byte             basicConstPlSet;
-    byte             subjAltNameSet;
-    byte             subjAltNameCrit;
-    byte             authKeyIdSet;
-    byte             authKeyIdCrit;
-    byte*            authKeyId;
     word32           authKeyIdSz;
-    byte             subjKeyIdSet;
-    byte             subjKeyIdCrit;
-    byte*            subjKeyId;
     word32           subjKeyIdSz;
-    byte             keyUsageSet;
-    byte             keyUsageCrit;
-    byte             extKeyUsageCrit;
-    byte*            extKeyUsageSrc;
     word32           extKeyUsageSz;
     word32           extKeyUsageCount;
+
+    byte             CRLdistSet:1;
+    byte             CRLdistCrit:1;
+    byte             authInfoSet:1;
+    byte             authInfoCrit:1;
+    byte             keyUsageSet:1;
+    byte             keyUsageCrit:1;
+    byte             extKeyUsageCrit:1;
+    byte             subjKeyIdSet:1;
+
+    byte             subjKeyIdCrit:1;
+    byte             basicConstSet:1;
+    byte             basicConstCrit:1;
+    byte             basicConstPlSet:1;
+    byte             subjAltNameSet:1;
+    byte             subjAltNameCrit:1;
+    byte             authKeyIdSet:1;
+    byte             authKeyIdCrit:1;
 #endif /* OPENSSL_EXTRA */
+    byte             serial[EXTERNAL_SERIAL_SIZE];
+    char             subjectCN[ASN_NAME_MAX];        /* common name short cut */
+#ifdef WOLFSSL_CERT_REQ
+    char             challengePw[CTC_NAME_SIZE]; /* for REQ certs */
+#endif
+    WOLFSSL_X509_NAME issuer;
+    WOLFSSL_X509_NAME subject;
 };
 
 

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -165,7 +165,9 @@ enum {
     EVP_PKEY_RSA      = 16,
     EVP_PKEY_DSA      = 17,
     EVP_PKEY_EC       = 18,
+#ifdef HAVE_IDEA
     IDEA_CBC_TYPE     = 19,
+#endif
     NID_sha1          = 64,
     NID_sha224        = 65,
     NID_md2           = 77,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -733,7 +733,6 @@ WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
                            /* what's ref count */
 
 WOLFSSL_API WOLFSSL_X509* wolfSSL_X509_new(void);
-WOLFSSL_API void wolfSSL_X509_free(WOLFSSL_X509*);
 
 #ifdef OPENSSL_EXTRA
 WOLFSSL_API void wolfSSL_OPENSSL_free(void*);
@@ -1470,7 +1469,8 @@ WOLFSSL_API unsigned char* wolfSSL_get_chain_cert(WOLFSSL_X509_CHAIN*, int idx);
 /* index cert in X509 */
 WOLFSSL_API WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN*, int idx);
 /* free X509 */
-WOLFSSL_API void wolfSSL_FreeX509(WOLFSSL_X509*);
+#define wolfSSL_FreeX509(x509) wolfSSL_X509_free((x509))
+WOLFSSL_API void wolfSSL_X509_free(WOLFSSL_X509*);
 /* get index cert in PEM */
 WOLFSSL_API int  wolfSSL_get_chain_cert_pem(WOLFSSL_X509_CHAIN*, int idx,
                                 unsigned char* buf, int inLen, int* outLen);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -84,7 +84,7 @@
         #define NO_OLD_WC_NAMES
     #endif
 
-#elif defined(OPENSSL_EXTRA)
+#elif (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
     #include <wolfssl/openssl/bn.h>
     #include <wolfssl/openssl/hmac.h>
 
@@ -223,7 +223,7 @@ struct WOLFSSL_EVP_PKEY {
     union {
         char* ptr; /* der format of key / or raw for NTRU */
     } pkey;
-    #ifdef OPENSSL_EXTRA
+    #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
     #ifndef NO_RSA
         WOLFSSL_RSA* rsa;
         byte      ownRsa; /* if struct owns RSA and should free it */
@@ -233,7 +233,7 @@ struct WOLFSSL_EVP_PKEY {
         byte      ownEcc; /* if struct owns ECC and should free it */
     #endif
     WC_RNG rng;
-    #endif
+    #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
     #ifdef HAVE_ECC
         int pkey_curve;
     #endif
@@ -2416,6 +2416,21 @@ WOLFSSL_API int wolfSSL_accept_ex(WOLFSSL*, HandShakeCallBack, TimeoutCallBack,
     WOLFSSL_API void wolfSSL_cert_service(void);
 #endif
 
+#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
+/* Smaller subset of X509 compatibility functions. Avoid increasing the size of
+ * this subset and its memory usage */
+
+#include <wolfssl/openssl/asn1.h>
+struct WOLFSSL_X509_NAME_ENTRY {
+    WOLFSSL_ASN1_OBJECT* object; /* not defined yet */
+    WOLFSSL_ASN1_STRING  data;
+    WOLFSSL_ASN1_STRING* value;  /* points to data, for lighttpd port */
+    int nid; /* i.e. ASN_COMMON_NAME */
+    int set;
+    int size;
+};
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
 #ifdef OPENSSL_EXTRA
 
 enum {
@@ -2521,16 +2536,6 @@ struct WOLFSSL_ASN1_BIT_STRING {
     long flags;
 };
 
-
-#include <wolfssl/openssl/asn1.h>
-struct WOLFSSL_X509_NAME_ENTRY {
-    WOLFSSL_ASN1_OBJECT* object; /* not defined yet */
-    WOLFSSL_ASN1_STRING  data;
-    WOLFSSL_ASN1_STRING* value;  /* points to data, for lighttpd port */
-    int nid; /* i.e. ASN_COMMON_NAME */
-    int set;
-    int size;
-};
 
 #if defined(HAVE_LIGHTY) || defined(WOLFSSL_MYSQL_COMPATIBLE) \
                          || defined(HAVE_STUNNEL) \

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1775,7 +1775,9 @@ enum BulkCipherAlgorithm {
     wolfssl_des,
     wolfssl_triple_des,             /* leading 3 (3des) not valid identifier */
     wolfssl_des40,
+#ifdef HAVE_IDEA
     wolfssl_idea,
+#endif
     wolfssl_aes,
     wolfssl_aes_gcm,
     wolfssl_aes_ccm,

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -679,30 +679,30 @@ struct DecodedCert {
 };
 
 
-extern const char* BEGIN_CERT;
-extern const char* END_CERT;
-extern const char* BEGIN_CERT_REQ;
-extern const char* END_CERT_REQ;
-extern const char* BEGIN_DSA_PARAM;
-extern const char* END_DSA_PARAM;
-extern const char* BEGIN_DH_PARAM;
-extern const char* END_DH_PARAM;
-extern const char* BEGIN_X509_CRL;
-extern const char* END_X509_CRL;
-extern const char* BEGIN_RSA_PRIV;
-extern const char* END_RSA_PRIV;
-extern const char* BEGIN_PRIV_KEY;
-extern const char* END_PRIV_KEY;
-extern const char* BEGIN_ENC_PRIV_KEY;
-extern const char* END_ENC_PRIV_KEY;
-extern const char* BEGIN_EC_PRIV;
-extern const char* END_EC_PRIV;
-extern const char* BEGIN_DSA_PRIV;
-extern const char* END_DSA_PRIV;
-extern const char* BEGIN_PUB_KEY;
-extern const char* END_PUB_KEY;
-extern const char* BEGIN_EDDSA_PRIV;
-extern const char* END_EDDSA_PRIV;
+extern const char* const BEGIN_CERT;
+extern const char* const END_CERT;
+extern const char* const BEGIN_CERT_REQ;
+extern const char* const END_CERT_REQ;
+extern const char* const BEGIN_DSA_PARAM;
+extern const char* const END_DSA_PARAM;
+extern const char* const BEGIN_DH_PARAM;
+extern const char* const END_DH_PARAM;
+extern const char* const BEGIN_X509_CRL;
+extern const char* const END_X509_CRL;
+extern const char* const BEGIN_RSA_PRIV;
+extern const char* const END_RSA_PRIV;
+extern const char* const BEGIN_PRIV_KEY;
+extern const char* const END_PRIV_KEY;
+extern const char* const BEGIN_ENC_PRIV_KEY;
+extern const char* const END_ENC_PRIV_KEY;
+extern const char* const BEGIN_EC_PRIV;
+extern const char* const END_EC_PRIV;
+extern const char* const BEGIN_DSA_PRIV;
+extern const char* const END_DSA_PRIV;
+extern const char* const BEGIN_PUB_KEY;
+extern const char* const END_PUB_KEY;
+extern const char* const BEGIN_EDDSA_PRIV;
+extern const char* const END_EDDSA_PRIV;
 
 #ifdef NO_SHA
     #define SIGNER_DIGEST_SIZE WC_SHA256_DIGEST_SIZE

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -571,7 +571,7 @@ struct DecodedCert {
     word16  extKeyUsage;             /* Key usage bitfield               */
     byte    extExtKeyUsage;          /* Extended Key usage bitfield      */
 
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     byte*   extExtKeyUsageSrc;
     word32  extExtKeyUsageSz;
     word32  extExtKeyUsageCount;
@@ -619,7 +619,7 @@ struct DecodedCert {
     char*   subjectEmail;
     int     subjectEmailLen;
 #endif /* WOLFSSL_CERT_GEN */
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     DecodedName issuerName;
     DecodedName subjectName;
 #endif /* OPENSSL_EXTRA */
@@ -659,7 +659,7 @@ struct DecodedCert {
 #ifdef WOLFSSL_SEP
     byte extCertPolicySet : 1;
 #endif
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     byte extCRLdistCrit : 1;
     byte extAuthInfoCrit : 1;
     byte extBasicConstCrit : 1;
@@ -758,7 +758,8 @@ struct TrustedPeerCert {
 
 
 /* for testing or custom openssl wrappers */
-#if defined(WOLFSSL_TEST_CERT) || defined(OPENSSL_EXTRA)
+#if defined(WOLFSSL_TEST_CERT) || defined(OPENSSL_EXTRA) || \
+    defined(OPENSSL_EXTRA_X509_SMALL)
     #define WOLFSSL_ASN_API WOLFSSL_API
 #else
     #define WOLFSSL_ASN_API WOLFSSL_LOCAL

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -93,10 +93,6 @@ typedef struct PKCS7DecodedAttrib {
 
 
 typedef struct PKCS7 {
-    byte issuerHash[KEYID_SIZE];  /* hash of all alt Names                */
-    byte issuerSn[MAX_SN_SZ];     /* singleCert's serial number           */
-    byte publicKey[MAX_RSA_INT_SZ + MAX_RSA_E_SZ ];/*MAX RSA key size (m + e)*/
-    word32 certSz[MAX_PKCS7_CERTS];
     WC_RNG* rng;
     PKCS7Attrib* signedAttribs;
     byte* content;                /* inner content, not owner             */
@@ -131,6 +127,10 @@ typedef struct PKCS7 {
     int encryptOID;               /* key encryption algorithm OID         */
     int keyWrapOID;               /* key wrap algorithm OID               */
     int keyAgreeOID;              /* key agreement algorithm OID          */
+    byte issuerHash[KEYID_SIZE];  /* hash of all alt Names                */
+    byte issuerSn[MAX_SN_SZ];     /* singleCert's serial number           */
+    byte publicKey[MAX_RSA_INT_SZ + MAX_RSA_E_SZ ];/*MAX RSA key size (m + e)*/
+    word32 certSz[MAX_PKCS7_CERTS];
 } PKCS7;
 
 

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -77,8 +77,8 @@ enum Pkcs7_Misc {
 
 typedef struct PKCS7Attrib {
     byte* oid;
-    byte* value;
     word32 oidSz;
+    byte* value;
     word32 valueSz;
 } PKCS7Attrib;
 
@@ -86,8 +86,8 @@ typedef struct PKCS7Attrib {
 typedef struct PKCS7DecodedAttrib {
     struct PKCS7DecodedAttrib* next;
     byte* oid;
-    byte* value;
     word32 oidSz;
+    byte* value;
     word32 valueSz;
 } PKCS7DecodedAttrib;
 

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -77,63 +77,60 @@ enum Pkcs7_Misc {
 
 typedef struct PKCS7Attrib {
     byte* oid;
-    word32 oidSz;
     byte* value;
+    word32 oidSz;
     word32 valueSz;
 } PKCS7Attrib;
 
 
 typedef struct PKCS7DecodedAttrib {
-    byte* oid;
-    word32 oidSz;
-    byte* value;
-    word32 valueSz;
     struct PKCS7DecodedAttrib* next;
+    byte* oid;
+    byte* value;
+    word32 oidSz;
+    word32 valueSz;
 } PKCS7DecodedAttrib;
 
 
 typedef struct PKCS7 {
-    byte* content;                /* inner content, not owner             */
-    word32 contentSz;             /* content size                         */
-    int contentOID;               /* PKCS#7 content type OID sum          */
-
+    byte issuerHash[KEYID_SIZE];  /* hash of all alt Names                */
+    byte issuerSn[MAX_SN_SZ];     /* singleCert's serial number           */
+    byte publicKey[MAX_RSA_INT_SZ + MAX_RSA_E_SZ ];/*MAX RSA key size (m + e)*/
+    word32 certSz[MAX_PKCS7_CERTS];
     WC_RNG* rng;
-
-    int hashOID;
-    int encryptOID;               /* key encryption algorithm OID         */
-    int keyWrapOID;               /* key wrap algorithm OID               */
-    int keyAgreeOID;              /* key agreement algorithm OID          */
-
+    PKCS7Attrib* signedAttribs;
+    byte* content;                /* inner content, not owner             */
+    byte*  singleCert;            /* recipient cert, DER, not owner       */
+    byte*  issuer;                /* issuer name of singleCert            */
+    byte*  privateKey;            /* private key, DER, not owner          */
     void*  heap;                  /* heap hint for dynamic memory         */
     byte*  cert[MAX_PKCS7_CERTS];
-    word32 certSz[MAX_PKCS7_CERTS];
-    byte*  singleCert;            /* recipient cert, DER, not owner       */
-    word32 singleCertSz;          /* size of recipient cert buffer, bytes */
-    byte issuerHash[KEYID_SIZE];  /* hash of all alt Names                */
-    byte*  issuer;                /* issuer name of singleCert            */
-    word32 issuerSz;              /* length of issuer name                */
-    byte issuerSn[MAX_SN_SZ];     /* singleCert's serial number           */
-    word32 issuerSnSz;            /* length of serial number              */
 
-    byte publicKey[MAX_RSA_INT_SZ + MAX_RSA_E_SZ ];/*MAX RSA key size (m + e)*/
-    word32 publicKeySz;
-    word32 publicKeyOID;          /* key OID (RSAk, ECDSAk, etc) */
-    byte*  privateKey;            /* private key, DER, not owner          */
-    word32 privateKeySz;          /* size of private key buffer, bytes    */
-
-    PKCS7Attrib* signedAttribs;
-    word32 signedAttribsSz;
+    /* Encrypted-data Content Type */
+    byte*        encryptionKey;         /* block cipher encryption key */
+    PKCS7Attrib* unprotectedAttribs;    /* optional */
+    PKCS7DecodedAttrib* decodedAttrib;  /* linked list of decoded attribs */
 
     /* Enveloped-data optional ukm, not owner */
     byte*  ukm;
     word32 ukmSz;
 
-    /* Encrypted-data Content Type */
-    byte*        encryptionKey;         /* block cipher encryption key */
-    word32       encryptionKeySz;       /* size of key buffer, bytes */
-    PKCS7Attrib* unprotectedAttribs;    /* optional */
-    word32       unprotectedAttribsSz;
-    PKCS7DecodedAttrib* decodedAttrib;  /* linked list of decoded attribs */
+    word32 encryptionKeySz;       /* size of key buffer, bytes */
+    word32 unprotectedAttribsSz;
+    word32 contentSz;             /* content size                         */
+    word32 singleCertSz;          /* size of recipient cert buffer, bytes */
+    word32 issuerSz;              /* length of issuer name                */
+    word32 issuerSnSz;            /* length of serial number              */
+
+    word32 publicKeySz;
+    word32 publicKeyOID;          /* key OID (RSAk, ECDSAk, etc) */
+    word32 privateKeySz;          /* size of private key buffer, bytes    */
+    word32 signedAttribsSz;
+    int contentOID;               /* PKCS#7 content type OID sum          */
+    int hashOID;
+    int encryptOID;               /* key encryption algorithm OID         */
+    int keyWrapOID;               /* key wrap algorithm OID               */
+    int keyAgreeOID;              /* key agreement algorithm OID          */
 } PKCS7;
 
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1399,6 +1399,20 @@ extern void uITRON4_free(void *p) ;
         #undef  AES_MAX_KEY_SIZE
         #define AES_MAX_KEY_SIZE    256
     #endif
+
+    #ifndef NO_AES_128
+        #undef  WOLFSSL_AES_128
+        #define WOLFSSL_AES_128
+    #endif
+    #if !defined(NO_AES_192) && AES_MAX_KEY_SIZE >= 192
+        #undef  WOLFSSL_AES_192
+        #define WOLFSSL_AES_192
+    #endif
+    #if !defined(NO_AES_256) && AES_MAX_KEY_SIZE >= 256
+        #undef  WOLFSSL_AES_256
+        #define WOLFSSL_AES_256
+    #endif
+
     #ifndef NO_AES_DECRYPT
         #undef  HAVE_AES_DECRYPT
         #define HAVE_AES_DECRYPT

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1630,6 +1630,16 @@ extern void uITRON4_free(void *p) ;
     #endif
 #endif
 
+/* switch for compatibility layer functionality. Has subparts i.e. BIO/X509
+ * When opensslextra is enabled all subparts should be turned on. */
+#ifdef OPENSSL_EXTRA
+    #undef  OPENSSL_EXTRA_X509_SMALL
+    #define OPENSSL_EXTRA_X509_SMALL
+
+    #undef  OPENSSL_EXTRA_PKEY
+    #define OPENSSL_EXTRA_PKEY
+#endif /* OPENSSL_EXTRA */
+    
 #ifdef __cplusplus
     }   /* extern "C" */
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1412,6 +1412,9 @@ extern void uITRON4_free(void *p) ;
         #undef  WOLFSSL_AES_256
         #define WOLFSSL_AES_256
     #endif
+    #if !defined(WOLFSSL_AES_128) && defined(HAVE_ECC_ENCRYPT)
+        #warning HAVE_ECC_ENCRYPT uses AES 128 bit keys
+     #endif
 
     #ifndef NO_AES_DECRYPT
         #undef  HAVE_AES_DECRYPT
@@ -1635,9 +1638,6 @@ extern void uITRON4_free(void *p) ;
 #ifdef OPENSSL_EXTRA
     #undef  OPENSSL_EXTRA_X509_SMALL
     #define OPENSSL_EXTRA_X509_SMALL
-
-    #undef  OPENSSL_EXTRA_PKEY
-    #define OPENSSL_EXTRA_PKEY
 #endif /* OPENSSL_EXTRA */
     
 #ifdef __cplusplus


### PR DESCRIPTION
- Adds --enable-opensslextra=x509small to build a subset of OpenSSL compatibility functions. (the used functions in ssl.c where re-arranged to group most of them together)
- Adds macros for turning off specific AES key sizes (NO_AES_128, NO_AES_192, NO_AES_256)
- Many locations where macro guards are added
