### PR TITLE
Add option for `ecc_mul2add` to be made as exposed API

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -984,10 +984,6 @@ static int wc_ecc_export_x963_compressed(ecc_key*, byte* out, word32* outLen);
 #ifndef WOLFSSL_SP_MATH
 static int ecc_check_pubkey_order(ecc_key* key, ecc_point* pubkey, mp_int* a,
         mp_int* prime, mp_int* order);
-#ifdef ECC_SHAMIR
-static int ecc_mul2add(ecc_point* A, mp_int* kA, ecc_point* B, mp_int* kB,
-                       ecc_point* C, mp_int* a, mp_int* modulus, void* heap);
-#endif
 #endif
 
 int mp_jacobi(mp_int* a, mp_int* n, int* c);
@@ -3921,7 +3917,7 @@ static int normal_ecc_mul2add(ecc_point* A, mp_int* kA,
                              ecc_point* C, mp_int* a, mp_int* modulus,
                              void* heap)
 #else
-static int ecc_mul2add(ecc_point* A, mp_int* kA,
+int ecc_mul2add(ecc_point* A, mp_int* kA,
                     ecc_point* B, mp_int* kB,
                     ecc_point* C, mp_int* a, mp_int* modulus,
                     void* heap)

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -335,6 +335,10 @@ const char* wc_ecc_get_name(int curve_id);
     #define ECC_API    WOLFSSL_LOCAL
 #endif
 
+ECC_API int ecc_mul2add(ecc_point* A, mp_int* kA,
+                ecc_point* B, mp_int* kB,
+                ecc_point* C, mp_int* a, mp_int* modulus, void* heap);
+
 ECC_API int ecc_map(ecc_point*, mp_int*, mp_digit);
 ECC_API int ecc_projective_add_point(ecc_point* P, ecc_point* Q, ecc_point* R,
                                      mp_int* a, mp_int* modulus, mp_digit mp);


### PR DESCRIPTION
Added `ecc_mul2add` to ecc.h header and is exposed as an API if `WOLFSSL_PUBLIC_ECC_ADD_DBL` is defined.