### PR TITLE
Add support for `WOLFSSL_NO_MALLOC` with memory callbacks

### DIFF
--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -101,7 +101,11 @@ void* wolfSSL_Malloc(size_t size)
     #endif
     }
     else {
+    #ifndef WOLFSSL_NO_MALLOC
         res = malloc(size);
+    #else
+        WOLFSSL_MSG("No malloc available");
+    #endif
     }
 
     #ifdef WOLFSSL_MALLOC_CHECK
@@ -126,7 +130,11 @@ void wolfSSL_Free(void *ptr)
     #endif
     }
     else {
+    #ifndef WOLFSSL_NO_MALLOC
         free(ptr);
+    #else
+        WOLFSSL_MSG("No free available");
+    #endif
     }
 }
 

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -154,7 +154,11 @@ void* wolfSSL_Realloc(void *ptr, size_t size)
     #endif
     }
     else {
+    #ifndef WOLFSSL_NO_MALLOC
         res = realloc(ptr, size);
+    #else
+        WOLFSSL_MSG("No realloc available");
+    #endif
     }
 
     return res;

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -53,8 +53,8 @@
         /* lwIP needs to be configured to use sockets API in this mode */
         /* LWIP_SOCKET 1 in lwip/opt.h or in build */
         #include "lwip/sockets.h"
-        #include <errno.h>
         #ifndef LWIP_PROVIDE_ERRNO
+            #include <errno.h>
             #define LWIP_PROVIDE_ERRNO 1
         #endif
     #elif defined(FREESCALE_MQX)


### PR DESCRIPTION
Add support using memory callbacks with no malloc / free using `WOLFSSL_NO_MALLOC`.
Fix to only include <errno.h> if `LWIP_PROVIDE_ERRNO` is not defined.