### PR TITLE
Fix resumption code around when not available

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -8062,7 +8062,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
             }
 
         #if defined(HAVE_SESSION_TICKET)
-            if (ssl->options.resuming && ssl->ctx->ticketEncCb != NULL) {
+            if (ssl->options.resuming && ssl->session.ticketLen > 0) {
                 WOLFSSL_SESSION* sess = &ssl->session;
                 word32           milli;
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -8062,7 +8062,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
             }
 
         #if defined(HAVE_SESSION_TICKET)
-            if (ssl->options.resuming) {
+            if (ssl->options.resuming && ssl->ctx->ticketEncCb != NULL) {
                 WOLFSSL_SESSION* sess = &ssl->session;
                 word32           milli;
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3570,10 +3570,11 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         return ret;
     }
 
-#ifdef HAVE_STUNNEL
+#if defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
     if ((ret = SNI_Callback(ssl)) != 0)
         return ret;
-#endif /*HAVE_STUNNEL*/
+    ssl->options.side = WOLFSSL_SERVER_END;
+#endif /* HAVE_STUNNELi || WOLFSSL_NGINX || WOLFSSL_HAPROXY */
 
     if (TLSX_Find(ssl->extensions, TLSX_SUPPORTED_VERSIONS) == NULL) {
         if (!ssl->options.downgrade) {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3173,6 +3173,9 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         break;
     }
 
+    if (current == NULL)
+        return 0;
+
     /* Hash the rest of the ClientHello. */
     ret = HashInputRaw(ssl, input + helloSz - bindersLen, bindersLen);
     if (ret != 0)


### PR DESCRIPTION
Can't set a ticket if the encryption callback is NULL.
If no useable pre-shared key is found then we won't do PSK.