### PR TITLE
fix for unused variables

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -2800,6 +2800,10 @@ static void test_wolfSSL_PKCS12(void)
     sk_X509_free(ca);
 #endif /* HAVE_ECC */
 
+    (void)x509;
+    (void)subject;
+    (void)order;
+
     printf(resultFmt, passed);
 #endif /* OPENSSL_EXTRA */
 }


### PR DESCRIPTION
Configure to reproduce the issue is ```./configure --disable-ecc --enable-des3 --enable-opensslextra```