### PR TITLE
RSA Decrypt Bounds Checking

### DIFF
--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -452,6 +452,9 @@ const char* wc_GetErrorString(int error)
     case BER_INDEF_E:
         return "Unable to decode an indefinite length encoded message";
 
+    case RSA_OUT_OF_RANGE_E:
+        return "Ciphertext to decrypt is out of range";
+
     default:
         return "unknown error number";
 

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -197,10 +197,10 @@ enum {
 
     PSS_SALTLEN_E       = -250,  /* PSS length of salt is to long for hash */
     PRIME_GEN_E         = -251,  /* Failure finding a prime. */
-
     BER_INDEF_E         = -252,  /* Cannot decode indefinite length BER. */
+    RSA_OUT_OF_RANGE_E  = -253,  /* Ciphertext to decrypt out of range. */
 
-    WC_LAST_E           = -252,  /* Update this to indicate last error */
+    WC_LAST_E           = -253,  /* Update this to indicate last error */
     MIN_CODE_E          = -300   /* errors -101 - -299 */
 
     /* add new companion error id strings for any new error codes


### PR DESCRIPTION
1. Added some bounds checking on the ciphertext passed into the RSA decrypt function. NIST SP 800-56B specifies that the ciphertext shouldn't be a number larger than the modulus.
2. Added an API test to check that the direct RSA decrypt function returns an error with a "bad" message.