### PR TITLE
Add CAVP-only Self Test for special build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ fips.c
 fipsv2.c
 fips_test.c
 fips
+selftest.c
 src/async.c
 wolfssl/async.h
 wolfcrypt/src/async.c

--- a/autogen.sh
+++ b/autogen.sh
@@ -21,6 +21,9 @@ if test -e .git; then
   touch ./wolfcrypt/src/fipsv2.c
   touch ./wolfssl/wolfcrypt/fips.h
 
+  # touch CAVP selftest files for non-selftest distribution
+  touch ./wolfcrypt/src/selftest.c
+
   # touch async crypt files
   touch ./wolfcrypt/src/async.c
   touch ./wolfssl/wolfcrypt/async.h

--- a/configure.ac
+++ b/configure.ac
@@ -1990,6 +1990,20 @@ fi
 AM_CONDITIONAL([BUILD_FIPS], [test "x$ENABLED_FIPS" = "xyes"])
 AM_CONDITIONAL([BUILD_FIPS_V2], [test "x$FIPS_VERSION" = "xv2"])
 
+# SELFTEST
+AC_ARG_ENABLE([selftest],
+    [AS_HELP_STRING([--enable-selftest],[Enable selftest, Will NOT work w/o CAVP selftest license (default: disabled)])],
+    [ ENABLED_SELFTEST=$enableval ],
+    [ ENABLED_SELFTEST=no ]
+    )
+
+if test "x$ENABLED_SELFTEST" == "xyes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_SELFTEST"
+fi
+
+AM_CONDITIONAL([BUILD_SELFTEST], [test "x$ENABLED_SELFTEST" = "xyes"])
+
 
 # set sha224 default
 SHA224_DEFAULT=no

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -221,6 +221,7 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/wolfssl/wolfcrypt/random.h
 %{_includedir}/wolfssl/wolfcrypt/ripemd.h
 %{_includedir}/wolfssl/wolfcrypt/rsa.h
+%{_includedir}/wolfssl/wolfcrypt/selftest.h
 %{_includedir}/wolfssl/wolfcrypt/settings.h
 %{_includedir}/wolfssl/wolfcrypt/signature.h
 %{_includedir}/wolfssl/wolfcrypt/sha.h

--- a/src/include.am
+++ b/src/include.am
@@ -68,6 +68,11 @@ src_libwolfssl_la_SOURCES += ctaocrypt/src/fips_test.c
 src_libwolfssl_la_SOURCES += ctaocrypt/src/wolfcrypt_last.c
 endif
 
+# CAVP self test
+if BUILD_SELFTEST
+src_libwolfssl_la_SOURCES += wolfcrypt/src/selftest.c
+endif
+
 src_libwolfssl_la_SOURCES += \
                wolfcrypt/src/hmac.c \
                wolfcrypt/src/hash.c \

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -348,7 +348,7 @@ int Base64_Encode_NoNl(const byte* in, word32 inLen, byte* out, word32* outLen)
 
 
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(HAVE_FIPS) \
-                           || defined(HAVE_ECC_CDH)
+                           || defined(HAVE_ECC_CDH) || defined(HAVE_SELFTEST)
 
 static
 const byte hexDecode[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -107,6 +107,9 @@
 #ifdef HAVE_FIPS
     #include <wolfssl/wolfcrypt/fips_test.h>
 #endif
+#ifdef HAVE_SELFTEST
+    #include <wolfssl/wolfcrypt/selftest.h>
+#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     #include <wolfssl/wolfcrypt/async.h>
 #endif
@@ -431,6 +434,13 @@ int wolfcrypt_test(void* args)
 #else
     (void)devId;
 #endif /* WOLFSSL_ASYNC_CRYPT */
+
+#ifdef HAVE_SELFTEST
+    if ( (ret = wolfCrypt_SelfTest()) != 0)
+        return err_sys("CAVP selftest failed!\n", ret);
+    else
+        printf("CAVP selftest passed!\n");
+#endif
 
     if ( (ret = error_test()) != 0)
         return err_sys("error    test failed!\n", ret);

--- a/wolfssl/wolfcrypt/coding.h
+++ b/wolfssl/wolfcrypt/coding.h
@@ -62,7 +62,7 @@ WOLFSSL_API int Base64_Decode(const byte* in, word32 inLen, byte* out,
 #endif
 
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(HAVE_FIPS) \
-                           || defined(HAVE_ECC_CDH)
+                           || defined(HAVE_ECC_CDH) || defined(HAVE_SELFTEST)
     WOLFSSL_API
     int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen);
     WOLFSSL_API

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -95,3 +95,7 @@ nobase_include_HEADERS+= wolfssl/wolfcrypt/sp.h
 nobase_include_HEADERS+= wolfssl/wolfcrypt/sp_int.h
 endif
 
+if BUILD_SELFTEST
+nobase_include_HEADERS+= wolfssl/wolfcrypt/selftest.h
+endif
+

--- a/wolfssl/wolfcrypt/selftest.h
+++ b/wolfssl/wolfcrypt/selftest.h
@@ -1,0 +1,45 @@
+/* selftest.h
+ *
+ * Copyright (C) 2006-2018 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+
+#ifndef WOLFCRYPT_SELF_TEST_H
+#define WOLFCRYPT_SELF_TEST_H
+
+#include <wolfssl/wolfcrypt/types.h>
+
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#ifdef HAVE_SELFTEST
+    /* wolfCrypt self test, runs CAVP KATs */
+    WOLFSSL_API int wolfCrypt_SelfTest(void);
+#endif
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+
+#endif /* WOLFCRYPT_SELF_TEST_H */
+
+


### PR DESCRIPTION
This adds a new option (**--enable-selftest**) that is used with special CAVP-only builds that require a self test function.  The self test function is not distributed as part of the wolfSSL sources, but the prototype is:

```
#include <wolfssl/wolfcrypt/selftest.h>
int wolfCrypt_SelfTest(void);
```

As selftest.c is not included as part of wolfSSL, fips-check.sh has been modified with a new target that pulls this file in.  This PR depends on the following PR getting merged:

https://github.com/wolfSSL/fips/pull/75

Note that the version of fips-check.sh in this PR uses versioning/tags that are expected to be correct in the future.  In order to manually test this PR and run fips-check.sh, modify the NetBSD section of fips-check.sh to be:

```
NETBSD_FIPS_VERSION=selftest
NETBSD_FIPS_REPO=git@github.com:cconlon/fips.git
NETBSD_CTAO_VERSION=selftest
NETBSD_CTAO_REPO=git@github.com:cconlon/wolfssl.git
```

Then run the following to generate a bundle in the XXX-fips-test directory:

```
$ ./fips-check.sh netbsd-selftest keep
```

