### PR TITLE
DH - Use q parameter when available, add wc_DhSetKey_ex()

### DIFF
--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -908,6 +908,11 @@ int wc_DhCheckPubKey_ex(DhKey* key, const byte* pub, word32 pubSz,
     if (ret == 0 && prime != NULL) {
         if (mp_read_unsigned_bin(&q, prime, primeSz) != MP_OKAY)
             ret = MP_READ_E;
+
+    } else if (mp_iszero(&key->q) == MP_NO) {
+        /* use q available in DhKey */
+        if (mp_copy(&key->q, &q) != MP_OKAY)
+            ret = MP_INIT_E;
     }
 
     /* pub (y) should not be 0 or 1 */
@@ -926,7 +931,7 @@ int wc_DhCheckPubKey_ex(DhKey* key, const byte* pub, word32 pubSz,
         ret = MP_CMP_E;
     }
 
-    if (ret == 0 && prime != NULL) {
+    if (ret == 0 && (prime != NULL || (mp_iszero(&key->q) == MP_NO) )) {
 
         /* restore key->p into p */
         if (mp_copy(&key->p, &p) != MP_OKAY)

--- a/wolfssl/wolfcrypt/dh.h
+++ b/wolfssl/wolfcrypt/dh.h
@@ -46,7 +46,7 @@ typedef struct DhParams {
 
 /* Diffie-Hellman Key */
 typedef struct DhKey {
-    mp_int p, g;                            /* group parameters  */
+    mp_int p, g, q;                         /* group parameters  */
     void* heap;
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
@@ -84,6 +84,8 @@ WOLFSSL_API int wc_DhKeyDecode(const byte* input, word32* inOutIdx, DhKey* key,
                            word32);
 WOLFSSL_API int wc_DhSetKey(DhKey* key, const byte* p, word32 pSz, const byte* g,
                         word32 gSz);
+WOLFSSL_API int wc_DhSetKey_ex(DhKey* key, const byte* p, word32 pSz,
+                        const byte* g, word32 gSz, const byte* q, word32 qSz);
 WOLFSSL_API int wc_DhParamsLoad(const byte* input, word32 inSz, byte* p,
                             word32* pInOutSz, byte* g, word32* gInOutSz);
 WOLFSSL_API int wc_DhCheckPubKey(DhKey* key, const byte* pub, word32 pubSz);


### PR DESCRIPTION
This PR adds support for the DH "q" parameter, when loaded into a DhKey structure using wc_DhSetKey_ex().  This allows wolfCrypt to be compliant with NIST SP 800-56A key generation and verification.