### PR TITLE
Added VerifyRsaSign PK callback

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -3108,6 +3108,9 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
     int   ret;
 
     (void)ssl;
+    (void)keyBuf;
+    (void)keySz;
+    (void)ctx;
     (void)sigAlgo;
     (void)hashAlgo;
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -3139,7 +3139,7 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
             return ret;
     #ifdef HAVE_PK_CALLBACKS
         if (ssl->ctx->RsaPssVerifyCb) {
-            ret = ssl->ctx->RsaPssVerifyCb(ssl, verifySig, sigSz, &out,
+            ret = ssl->ctx->RsaPssVerifySignCb(ssl, verifySig, sigSz, &out,
                                            TypeHash(hashAlgo), mgf,
                                            keyBuf, keySz, ctx);
         }
@@ -3161,7 +3161,7 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
     {
     #ifdef HAVE_PK_CALLBACKS
         if (ssl->ctx->RsaVerifyCb) {
-            ret = ssl->ctx->RsaVerifyCb(ssl, verifySig, sigSz, &out,
+            ret = ssl->ctx->RsaVerifySignCb(ssl, verifySig, sigSz, &out,
                 keyBuf, keySz, ctx);
         }
         else

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7787,7 +7787,7 @@ static int wolfSSL_EVP_Digest(unsigned char* in, int inSz, unsigned char* out,
             if (XSTRNCMP("SHA384", evp, 6) == 0) {
                 hash = WC_HASH_TYPE_SHA384;
             }
-            else 
+            else
             #endif
             #ifdef WOLFSSL_SHA512
             if (XSTRNCMP("SHA512", evp, 6) == 0) {
@@ -15174,7 +15174,7 @@ WOLFSSL_X509* wolfSSL_X509_d2i(WOLFSSL_X509** x509, const byte* in, int len)
     return newX509;
 }
 
-#endif /* KEEP_PEER_CERT || SESSION_CERTS || OPENSSL_EXTRA || 
+#endif /* KEEP_PEER_CERT || SESSION_CERTS || OPENSSL_EXTRA ||
           OPENSSL_EXTRA_X509_SMALL */
 
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
@@ -28685,6 +28685,12 @@ void  wolfSSL_CTX_SetRsaVerifyCb(WOLFSSL_CTX* ctx, CallbackRsaVerify cb)
         ctx->RsaVerifyCb = cb;
 }
 
+void  wolfSSL_CTX_SetRsaVerifySignCb(WOLFSSL_CTX* ctx, CallbackRsaVerify cb)
+{
+    if (ctx)
+        ctx->RsaVerifySignCb = cb;
+}
+
 
 void  wolfSSL_SetRsaVerifyCtx(WOLFSSL* ssl, void *ctx)
 {
@@ -28729,6 +28735,12 @@ void  wolfSSL_CTX_SetRsaPssVerifyCb(WOLFSSL_CTX* ctx, CallbackRsaPssVerify cb)
 {
     if (ctx)
         ctx->RsaPssVerifyCb = cb;
+}
+
+void  wolfSSL_CTX_SetRsaPssVerifySignCb(WOLFSSL_CTX* ctx, CallbackRsaPssVerify cb)
+{
+    if (ctx)
+        ctx->RsaPssVerifySignCb = cb;
 }
 
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28685,10 +28685,10 @@ void  wolfSSL_CTX_SetRsaVerifyCb(WOLFSSL_CTX* ctx, CallbackRsaVerify cb)
         ctx->RsaVerifyCb = cb;
 }
 
-void  wolfSSL_CTX_SetRsaVerifySignCb(WOLFSSL_CTX* ctx, CallbackRsaVerify cb)
+void  wolfSSL_CTX_SetRsaSignCheckCb(WOLFSSL_CTX* ctx, CallbackRsaVerify cb)
 {
     if (ctx)
-        ctx->RsaVerifySignCb = cb;
+        ctx->RsaSignCheckCb = cb;
 }
 
 
@@ -28737,10 +28737,10 @@ void  wolfSSL_CTX_SetRsaPssVerifyCb(WOLFSSL_CTX* ctx, CallbackRsaPssVerify cb)
         ctx->RsaPssVerifyCb = cb;
 }
 
-void  wolfSSL_CTX_SetRsaPssVerifySignCb(WOLFSSL_CTX* ctx, CallbackRsaPssVerify cb)
+void  wolfSSL_CTX_SetRsaPssSignCheckCb(WOLFSSL_CTX* ctx, CallbackRsaPssVerify cb)
 {
     if (ctx)
-        ctx->RsaPssVerifySignCb = cb;
+        ctx->RsaPssSignCheckCb = cb;
 }
 
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5000,7 +5000,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                     ssl->suites->hashAlgo, (RsaKey*)ssl->hsKey,
                     ssl->buffers.key->buffer, ssl->buffers.key->length,
                 #ifdef HAVE_PK_CALLBACKS
-                    ssl->RsaVerifyCtx
+                    ssl->RsaSignCtx
                 #else
                     NULL
                 #endif

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4997,7 +4997,14 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 /* check for signature faults */
                 ret = VerifyRsaSign(ssl, args->verifySig, args->sigLen,
                     sig->buffer, sig->length, args->sigAlgo,
-                    ssl->suites->hashAlgo, (RsaKey*)ssl->hsKey);
+                    ssl->suites->hashAlgo, (RsaKey*)ssl->hsKey,
+                    ssl->buffers.key->buffer, ssl->buffers.key->length,
+                #ifdef HAVE_PK_CALLBACKS
+                    ssl->RsaVerifyCtx
+                #else
+                    NULL
+                #endif
+                );
             }
         #endif /* !NO_RSA */
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2507,11 +2507,13 @@ struct WOLFSSL_CTX {
         CallbackDhAgree DhAgreeCb;      /* User DH Agree Callback handler */
     #endif
     #ifndef NO_RSA
-        CallbackRsaSign   RsaSignCb;    /* User RsaSign   Callback handler */
-        CallbackRsaVerify RsaVerifyCb;  /* User RsaVerify Callback handler */
+        CallbackRsaSign   RsaSignCb;       /* User RsaSign Callback handler (priv key) */
+        CallbackRsaVerify RsaVerifyCb;     /* User RsaVerify Callback handler (pub key) */
+        CallbackRsaVerify RsaVerifySignCb; /* User RsaVerifySign Callback handler (priv key) */
         #ifdef WC_RSA_PSS
-            CallbackRsaPssSign   RsaPssSignCb;    /* User RsaPssSign */
-            CallbackRsaPssVerify RsaPssVerifyCb;  /* User RsaPssVerify */
+            CallbackRsaPssSign   RsaPssSignCb;       /* User RsaPssSign (priv key) */
+            CallbackRsaPssVerify RsaPssVerifyCb;     /* User RsaPssVerify (pub key) */
+            CallbackRsaPssVerify RsaPssVerifySignCb; /* User RsaPssVerifySign (priv key) */
         #endif
         CallbackRsaEnc    RsaEncCb;     /* User Rsa Public Encrypt  handler */
         CallbackRsaDec    RsaDecCb;     /* User Rsa Private Decrypt handler */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3831,11 +3831,9 @@ WOLFSSL_LOCAL int SetTicket(WOLFSSL*, const byte*, word32);
                                                  enum wc_HashType hashType);
             WOLFSSL_LOCAL int ConvertHashPss(int hashAlgo, enum wc_HashType* hashType, int* mgf);
         #endif
-        WOLFSSL_LOCAL int VerifyRsaSign(WOLFSSL* ssl,
-                                        byte* verifySig, word32 sigSz,
-                                        const byte* plain, word32 plainSz,
-                                        int sigAlgo, int hashAlgo,
-                                        RsaKey* key);
+        WOLFSSL_LOCAL int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig,
+            word32 sigSz, const byte* plain, word32 plainSz, int sigAlgo,
+            int hashAlgo, RsaKey* key, const byte* keyBuf, word32 keySz, void* ctx);
         WOLFSSL_LOCAL int RsaSign(WOLFSSL* ssl, const byte* in, word32 inSz,
             byte* out, word32* outSz, int sigAlgo, int hashAlgo, RsaKey* key,
             const byte* keyBuf, word32 keySz, void* ctx);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2507,13 +2507,13 @@ struct WOLFSSL_CTX {
         CallbackDhAgree DhAgreeCb;      /* User DH Agree Callback handler */
     #endif
     #ifndef NO_RSA
-        CallbackRsaSign   RsaSignCb;       /* User RsaSign Callback handler (priv key) */
-        CallbackRsaVerify RsaVerifyCb;     /* User RsaVerify Callback handler (pub key) */
-        CallbackRsaVerify RsaVerifySignCb; /* User RsaVerifySign Callback handler (priv key) */
+        CallbackRsaSign   RsaSignCb;      /* User RsaSign Callback handler (priv key) */
+        CallbackRsaVerify RsaVerifyCb;    /* User RsaVerify Callback handler (pub key) */
+        CallbackRsaVerify RsaSignCheckCb; /* User VerifyRsaSign Callback handler (priv key) */
         #ifdef WC_RSA_PSS
-            CallbackRsaPssSign   RsaPssSignCb;       /* User RsaPssSign (priv key) */
-            CallbackRsaPssVerify RsaPssVerifyCb;     /* User RsaPssVerify (pub key) */
-            CallbackRsaPssVerify RsaPssVerifySignCb; /* User RsaPssVerifySign (priv key) */
+            CallbackRsaPssSign   RsaPssSignCb;       /* User RsaSign (priv key) */
+            CallbackRsaPssVerify RsaPssVerifyCb;     /* User RsaVerify (pub key) */
+            CallbackRsaPssVerify RsaPssSignCheckCb; /* User VerifyRsaSign (priv key) */
         #endif
         CallbackRsaEnc    RsaEncCb;     /* User Rsa Public Encrypt  handler */
         CallbackRsaDec    RsaDecCb;     /* User Rsa Private Decrypt handler */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1893,7 +1893,7 @@ typedef int (*CallbackRsaVerify)(WOLFSSL* ssl,
        const unsigned char* keyDer, unsigned int keySz,
        void* ctx);
 WOLFSSL_API void  wolfSSL_CTX_SetRsaVerifyCb(WOLFSSL_CTX*, CallbackRsaVerify);
-WOLFSSL_API void  wolfSSL_CTX_SetRsaVerifySignCb(WOLFSSL_CTX*, CallbackRsaVerify);
+WOLFSSL_API void  wolfSSL_CTX_SetRsaSignCheckCb(WOLFSSL_CTX*, CallbackRsaVerify);
 WOLFSSL_API void  wolfSSL_SetRsaVerifyCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetRsaVerifyCtx(WOLFSSL* ssl);
 
@@ -1916,7 +1916,7 @@ typedef int (*CallbackRsaPssVerify)(WOLFSSL* ssl,
        void* ctx);
 WOLFSSL_API void  wolfSSL_CTX_SetRsaPssVerifyCb(WOLFSSL_CTX*,
                                                 CallbackRsaPssVerify);
-WOLFSSL_API void  wolfSSL_CTX_SetRsaPssVerifySignCb(WOLFSSL_CTX*,
+WOLFSSL_API void  wolfSSL_CTX_SetRsaPssSignCheckCb(WOLFSSL_CTX*,
                                                     CallbackRsaPssVerify);
 WOLFSSL_API void  wolfSSL_SetRsaPssVerifyCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetRsaPssVerifyCtx(WOLFSSL* ssl);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1893,6 +1893,7 @@ typedef int (*CallbackRsaVerify)(WOLFSSL* ssl,
        const unsigned char* keyDer, unsigned int keySz,
        void* ctx);
 WOLFSSL_API void  wolfSSL_CTX_SetRsaVerifyCb(WOLFSSL_CTX*, CallbackRsaVerify);
+WOLFSSL_API void  wolfSSL_CTX_SetRsaVerifySignCb(WOLFSSL_CTX*, CallbackRsaVerify);
 WOLFSSL_API void  wolfSSL_SetRsaVerifyCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetRsaVerifyCtx(WOLFSSL* ssl);
 
@@ -1915,6 +1916,8 @@ typedef int (*CallbackRsaPssVerify)(WOLFSSL* ssl,
        void* ctx);
 WOLFSSL_API void  wolfSSL_CTX_SetRsaPssVerifyCb(WOLFSSL_CTX*,
                                                 CallbackRsaPssVerify);
+WOLFSSL_API void  wolfSSL_CTX_SetRsaPssVerifySignCb(WOLFSSL_CTX*,
+                                                    CallbackRsaPssVerify);
 WOLFSSL_API void  wolfSSL_SetRsaPssVerifyCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetRsaPssVerifyCtx(WOLFSSL* ssl);
 #endif

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2121,7 +2121,7 @@ static INLINE int myRsaVerify(WOLFSSL* ssl, byte* sig, word32 sigSz,
     return ret;
 }
 
-static INLINE int myRsaVerifySign(WOLFSSL* ssl, byte* sig, word32 sigSz,
+static INLINE int myRsaSignCheck(WOLFSSL* ssl, byte* sig, word32 sigSz,
         byte** out, const byte* key, word32 keySz, void* ctx)
 {
     int     ret;
@@ -2239,7 +2239,7 @@ static INLINE int myRsaPssVerify(WOLFSSL* ssl, byte* sig, word32 sigSz,
     return ret;
 }
 
-static INLINE int myRsaPssVerifySign(WOLFSSL* ssl, byte* sig, word32 sigSz,
+static INLINE int myRsaPssSignCheck(WOLFSSL* ssl, byte* sig, word32 sigSz,
         byte** out, int hash, int mgf, const byte* key, word32 keySz, void* ctx)
 {
     enum wc_HashType hashType = WC_HASH_TYPE_NONE;
@@ -2371,11 +2371,11 @@ static INLINE void SetupPkCallbacks(WOLFSSL_CTX* ctx, WOLFSSL* ssl)
     #ifndef NO_RSA
         wolfSSL_CTX_SetRsaSignCb(ctx, myRsaSign);
         wolfSSL_CTX_SetRsaVerifyCb(ctx, myRsaVerify);
-        wolfSSL_CTX_SetRsaVerifySignCb(ctx, myRsaVerifySign);
+        wolfSSL_CTX_SetRsaSignCheckCb(ctx, myRsaSignCheck);
         #ifdef WC_RSA_PSS
             wolfSSL_CTX_SetRsaPssSignCb(ctx, myRsaPssSign);
             wolfSSL_CTX_SetRsaPssVerifyCb(ctx, myRsaPssVerify);
-            wolfSSL_CTX_SetRsaPssVerifySignCb(ctx, myRsaPssVerifySign);
+            wolfSSL_CTX_SetRsaPssSignCheckCb(ctx, myRsaPssSignCheck);
         #endif
         wolfSSL_CTX_SetRsaEncCb(ctx, myRsaEnc);
         wolfSSL_CTX_SetRsaDecCb(ctx, myRsaDec);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2101,9 +2101,7 @@ static INLINE int myRsaSign(WOLFSSL* ssl, const byte* in, word32 inSz,
 
 
 static INLINE int myRsaVerify(WOLFSSL* ssl, byte* sig, word32 sigSz,
-        byte** out,
-        const byte* key, word32 keySz,
-        void* ctx)
+        byte** out, const byte* key, word32 keySz, void* ctx)
 {
     int     ret;
     word32  idx = 0;
@@ -2115,6 +2113,27 @@ static INLINE int myRsaVerify(WOLFSSL* ssl, byte* sig, word32 sigSz,
     ret = wc_InitRsaKey(&myKey, NULL);
     if (ret == 0) {
         ret = wc_RsaPublicKeyDecode(key, &idx, &myKey, keySz);
+        if (ret == 0)
+            ret = wc_RsaSSL_VerifyInline(sig, sigSz, out, &myKey);
+        wc_FreeRsaKey(&myKey);
+    }
+
+    return ret;
+}
+
+static INLINE int myRsaVerifySign(WOLFSSL* ssl, byte* sig, word32 sigSz,
+        byte** out, const byte* key, word32 keySz, void* ctx)
+{
+    int     ret;
+    word32  idx = 0;
+    RsaKey  myKey;
+
+    (void)ssl;
+    (void)ctx;
+
+    ret = wc_InitRsaKey(&myKey, NULL);
+    if (ret == 0) {
+        ret = wc_RsaPrivateKeyDecode(key, &idx, &myKey, keySz);
         if (ret == 0)
             ret = wc_RsaSSL_VerifyInline(sig, sigSz, out, &myKey);
         wc_FreeRsaKey(&myKey);
@@ -2219,6 +2238,48 @@ static INLINE int myRsaPssVerify(WOLFSSL* ssl, byte* sig, word32 sigSz,
 
     return ret;
 }
+
+static INLINE int myRsaPssVerifySign(WOLFSSL* ssl, byte* sig, word32 sigSz,
+        byte** out, int hash, int mgf, const byte* key, word32 keySz, void* ctx)
+{
+    enum wc_HashType hashType = WC_HASH_TYPE_NONE;
+    int              ret;
+    word32           idx = 0;
+    RsaKey           myKey;
+
+    (void)ssl;
+    (void)ctx;
+
+    switch (hash) {
+#ifndef NO_SHA256
+        case SHA256h:
+            hashType = WC_HASH_TYPE_SHA256;
+            break;
+#endif
+#ifdef WOLFSSL_SHA384
+        case SHA384h:
+            hashType = WC_HASH_TYPE_SHA384;
+            break;
+#endif
+#ifdef WOLFSSL_SHA512
+        case SHA512h:
+            hashType = WC_HASH_TYPE_SHA512;
+            break;
+#endif
+    }
+
+    ret = wc_InitRsaKey(&myKey, NULL);
+    if (ret == 0) {
+        ret = wc_RsaPrivateKeyDecode(key, &idx, &myKey, keySz);
+        if (ret == 0) {
+            ret = wc_RsaPSS_VerifyInline(sig, sigSz, out, hashType, mgf,
+                                         &myKey);
+            }
+        wc_FreeRsaKey(&myKey);
+    }
+
+    return ret;
+}
 #endif
 
 
@@ -2310,9 +2371,11 @@ static INLINE void SetupPkCallbacks(WOLFSSL_CTX* ctx, WOLFSSL* ssl)
     #ifndef NO_RSA
         wolfSSL_CTX_SetRsaSignCb(ctx, myRsaSign);
         wolfSSL_CTX_SetRsaVerifyCb(ctx, myRsaVerify);
+        wolfSSL_CTX_SetRsaVerifySignCb(ctx, myRsaVerifySign);
         #ifdef WC_RSA_PSS
             wolfSSL_CTX_SetRsaPssSignCb(ctx, myRsaPssSign);
             wolfSSL_CTX_SetRsaPssVerifyCb(ctx, myRsaPssVerify);
+            wolfSSL_CTX_SetRsaPssVerifySignCb(ctx, myRsaPssVerifySign);
         #endif
         wolfSSL_CTX_SetRsaEncCb(ctx, myRsaEnc);
         wolfSSL_CTX_SetRsaDecCb(ctx, myRsaDec);


### PR DESCRIPTION
* Added new callbacks for the VerifyRsaSign, which uses a private key to verify a created signature.
* The new callbacks API's are `wolfSSL_CTX_SetRsaSignCheckCb` and `wolfSSL_CTX_SetRsaPssSignCheckCb`.
* These use the same callback prototype as the CallbackRsaVerify and use the sign context.