### PR TITLE
Fix for handling OCSP with non-blocking

### DIFF
--- a/scripts/ocsp.test
+++ b/scripts/ocsp.test
@@ -13,7 +13,7 @@ RESULT=$?
 [ $RESULT -ne 0 ] && exit 0
 
 # client test against the server
-./examples/client/client -X -C -h $server -p 443 -A $ca -g -o
+./examples/client/client -X -C -h $server -p 443 -A $ca -g -o -N
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1725,8 +1725,11 @@ static int wolfSSL_read_internal(WOLFSSL* ssl, void* data, int sz, int peek)
 
 #ifdef HAVE_WRITE_DUP
     if (ssl->dupWrite) {
-        if (ssl->error != 0 && ssl->error != WANT_READ &&
-                               ssl->error != WC_PENDING_E) {
+        if (ssl->error != 0 && ssl->error != WANT_READ
+        #ifdef WOLFSSL_ASYNC_CRYPT
+            && ssl->error != WC_PENDING_E
+        #endif
+        ) {
             int notifyErr;
 
             WOLFSSL_MSG("Notifying write side of fatal read error");
@@ -7787,7 +7790,7 @@ static int wolfSSL_EVP_Digest(unsigned char* in, int inSz, unsigned char* out,
             if (XSTRNCMP("SHA384", evp, 6) == 0) {
                 hash = WC_HASH_TYPE_SHA384;
             }
-            else 
+            else
             #endif
             #ifdef WOLFSSL_SHA512
             if (XSTRNCMP("SHA512", evp, 6) == 0) {
@@ -15217,7 +15220,7 @@ WOLFSSL_X509* wolfSSL_X509_d2i(WOLFSSL_X509** x509, const byte* in, int len)
     return newX509;
 }
 
-#endif /* KEEP_PEER_CERT || SESSION_CERTS || OPENSSL_EXTRA || 
+#endif /* KEEP_PEER_CERT || SESSION_CERTS || OPENSSL_EXTRA ||
           OPENSSL_EXTRA_X509_SMALL */
 
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)


### PR DESCRIPTION
The `HashInput` function was being called on the re-entry, which produced a bad mac response from server.

Also cleanup for some of the `WC_PENDING_E` logic for the non-async cases to reduce code size.