### PR TITLE
TLS v1.3 support for Draft 23 and Draft 27

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -307,6 +307,18 @@ then
 fi
 
 
+# TLS v1.3 Draft 23
+AC_ARG_ENABLE([tls13-draft23],
+    [AS_HELP_STRING([--enable-tls13-draft23],[Enable wolfSSL TLS v1.3 Draft 23 (default: disabled)])],
+    [ ENABLED_TLS13_DRAFT23=$enableval ],
+    [ ENABLED_TLS13_DRAFT23=no ]
+    )
+if test "$ENABLED_TLS13_DRAFT23" = "yes"
+then
+  AM_CFLAGS="-DWOLFSSL_TLS13_DRAFT_23 $AM_CFLAGS"
+fi
+
+
 # TLS v1.3
 AC_ARG_ENABLE([tls13],
     [AS_HELP_STRING([--enable-tls13],[Enable wolfSSL TLS v1.3 (default: disabled)])],
@@ -314,7 +326,7 @@ AC_ARG_ENABLE([tls13],
     [ ENABLED_TLS13=no ]
     )
 
-if test "$ENABLED_TLS13_DRAFT18" = "yes" || test "$ENABLED_TLS13_DRAFT22" = "yes"
+if test "$ENABLED_TLS13_DRAFT18" = "yes" || test "$ENABLED_TLS13_DRAFT22" = "yes" || test "$ENABLED_TLS13_DRAFT23" = "yes"
 then
     ENABLED_TLS13="yes"
 fi
@@ -4311,6 +4323,8 @@ echo "   * SSL version 3.0:            $ENABLED_SSLV3"
 echo "   * TLS v1.0:                   $ENABLED_TLSV10"
 echo "   * TLS v1.3:                   $ENABLED_TLS13"
 echo "   * TLS v1.3 Draft 18:          $ENABLED_TLS13_DRAFT18"
+echo "   * TLS v1.3 Draft 22:          $ENABLED_TLS13_DRAFT22"
+echo "   * TLS v1.3 Draft 23:          $ENABLED_TLS13_DRAFT23"
 echo "   * Post-handshake Auth:        $ENABLED_TLS13_POST_AUTH"
 echo "   * Early Data:                 $ENABLED_TLS13_EARLY_DATA"
 echo "   * Send State in HRR Cookie:   $ENABLED_SEND_HRR_COOKIE"

--- a/src/internal.c
+++ b/src/internal.c
@@ -12244,10 +12244,20 @@ int ProcessReply(WOLFSSL* ssl)
                     }
                     else {
                     #ifdef WOLFSSL_TLS13
+                    #if defined(WOLFSSL_TLS13_DRAFT_18) || \
+                        defined(WOLFSSL_TLS13_DRAFT_22) || \
+                        defined(WOLFSSL_TLS13_DRAFT_23)
                         ret = DecryptTls13(ssl,
                                            in->buffer + in->idx,
                                            in->buffer + in->idx,
-                                           ssl->curSize);
+                                           ssl->curSize, NULL, 0);
+                    #else
+                        ret = DecryptTls13(ssl,
+                                        in->buffer + in->idx,
+                                        in->buffer + in->idx,
+                                        ssl->curSize,
+                                        (byte*)&ssl->curRL, RECORD_HEADER_SZ);
+                    #endif
                     #else
                         ret = DECRYPT_ERROR;
                     #endif /* WOLFSSL_TLS13 */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1030,8 +1030,10 @@ enum Misc {
     TLS_DRAFT_MINOR = 0x12,     /* Minor version number of TLS draft */
 #elif defined(WOLFSSL_TLS13_DRAFT_22)
     TLS_DRAFT_MINOR = 0x16,     /* Minor version number of TLS draft */
-#else
+#elif defined(WOLFSSL_TLS13_DRAFT_23)
     TLS_DRAFT_MINOR = 0x17,     /* Minor version number of TLS draft */
+#else
+    TLS_DRAFT_MINOR = 0x1b,     /* Minor version number of TLS draft */
 #endif
     OLD_HELLO_ID    = 0x01,     /* SSLv2 Client Hello Indicator */
     INVALID_BYTE    = 0xff,     /* Used to initialize cipher specs values */
@@ -1506,7 +1508,7 @@ WOLFSSL_LOCAL int SNI_Callback(WOLFSSL* ssl);
 #endif
 #ifdef WOLFSSL_TLS13
 WOLFSSL_LOCAL int  DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
-                                word16 sz);
+                                word16 sz, const byte* aad, word16 aadSz);
 WOLFSSL_LOCAL int  DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input,
                                            word32* inOutIdx, byte type,
                                            word32 size, word32 totalSz);


### PR DESCRIPTION
Draft 24: Second ClientHello uses version 0x0303 - no change.
Draft 25: The record layer header is now additional authentication data to
encryption.
Draft 26: Disallow SupportedVersion being used in ServerHello for
negotiating below TLS v1.3.
Draft 27: Older versions can be negotiated (by exclusion of 0x0304) in
SupportedVersion - no change.