### PR TITLE
remove pkcs7 requirement of x963kdf when ecc is disabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3957,7 +3957,7 @@ then
         ENABLED_AESKEYWRAP="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_AES_KEYWRAP -DWOLFSSL_AES_DIRECT"
     fi
-    if test "x$ENABLED_X963KDF" = "xno"
+    if test "x$ENABLED_X963KDF" = "xno" && test "$ENABLED_ECC" = "yes"
     then
         ENABLED_X963KDF="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_X963_KDF"

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1564,7 +1564,7 @@ extern void uITRON4_free(void *p) ;
     #ifndef HAVE_AES_KEYWRAP
         #error PKCS7 requires AES key wrap please define HAVE_AES_KEYWRAP
     #endif
-    #ifndef HAVE_X963_KDF
+    #if defined(HAVE_ECC) && !defined(HAVE_X963_KDF)
         #error PKCS7 requires X963 KDF please define HAVE_X963_KDF
     #endif
 #endif


### PR DESCRIPTION
Changes X963 KDF to be off when ECC is disabled and PKCS7 is enabled. ```./configure --disable-ecc --disable-x963kdf --enable-pkcs7```.