### PR TITLE
fix unused param warning with NO_ERROR_STRINGS

### DIFF
--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -216,7 +216,8 @@ enum {
 #ifdef NO_ERROR_STRINGS
     #define wc_GetErrorString(error) "no support for error strings built in"
     #define wc_ErrorString(err, buf) \
-        XSTRNCPY((buf), wc_GetErrorString((err)), WOLFSSL_MAX_ERROR_SZ);
+        (void)err; XSTRNCPY((buf), wc_GetErrorString((err)), \
+        WOLFSSL_MAX_ERROR_SZ);
 
 #else
 WOLFSSL_API void wc_ErrorString(int err, char* buff);


### PR DESCRIPTION
Fixes a Jenkins nightly expected configs report that shows up with "--enable-mcapi" and "--disable-errorstrings":

```
./configure C_EXTRA_FLAGS="-fdebug-types-section -g1" --enable-jobserver=4 --enable-mcapi --enable-ecc --enable-sha512 --with-libz --disable-errorstrings

1 mcapi/crypto.c:773:31: error: unused parameter ‘err’ [-Werror=unused-parameter]

2 Make Check: Fail.
```