### PR TITLE
Support for building with `WOLFSSL_ATECC508A` on other targets

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3271,9 +3271,12 @@ int wc_ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key, int curve_id)
    }
 
    /* populate key->pubkey */
-   err = mp_read_unsigned_bin(key->pubkey.x, key->pubkey_raw, 32);
+   err = mp_read_unsigned_bin(key->pubkey.x, key->pubkey_raw,
+                              ECC_MAX_CRYPTO_HW_SIZE);
    if (err = MP_OKAY)
-       err = mp_read_unsigned_bin(key->pubkey.y, key->pubkey_raw + 32, 32);
+       err = mp_read_unsigned_bin(key->pubkey.y,
+                                  key->pubkey_raw + ECC_MAX_CRYPTO_HW_SIZE,
+                                  ECC_MAX_CRYPTO_HW_SIZE);
 #else
 
 #ifdef WOLFSSL_HAVE_SP_ECC
@@ -4616,7 +4619,7 @@ int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
 
 #ifdef WOLFSSL_ATECC508A
     /* populate key->pubkey_raw */
-    XMEMCPY(key->pubkey_raw, (byte*)in, PUB_KEY_SIZE);
+    XMEMCPY(key->pubkey_raw, (byte*)in, sizeof(key->pubkey_raw));
 #endif
 
     /* read data */

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -25,18 +25,20 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#ifdef WOLFSSL_ATMEL
+#if defined(WOLFSSL_ATMEL) || defined(WOLFSSL_ATECC508A)
 
 #include <wolfssl/wolfcrypt/memory.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/ssl.h>
 #include <wolfssl/internal.h>
 
+#ifdef WOLFSSL_ATMEL
 #define Aes Aes_Remap
 #define Gmac Gmac_Remap
 #include "asf.h"
 #undef Aes
 #undef Gmac
+#endif /* WOLFSSL_ATMEL */
 
 #include <wolfssl/wolfcrypt/port/atmel/atmel.h>
 
@@ -102,16 +104,20 @@ int atmel_get_random_block(unsigned char* output, unsigned int sz)
 	return atmel_get_random_number((uint32_t)sz, (uint8_t*)output);
 }
 
+#ifdef WOLFSSL_ATMEL
 extern struct rtc_module *_rtc_instance[RTC_INST_NUM];
+#endif
 long atmel_get_curr_time_and_date(long* tm)
 {
     (void)tm;
 
+#ifdef WOLFSSL_ATMEL
 	/* Get current time */
     //struct rtc_calendar_time rtcTime;
 	//rtc_calendar_get_time(_rtc_instance[0], &rtcTime);
 
     /* Convert rtc_calendar_time to seconds since UTC */
+#endif
 
     return 0;
 }
@@ -241,4 +247,4 @@ void atmel_init(void)
     }
 }
 
-#endif /* WOLFSSL_ATMEL */
+#endif /* WOLFSSL_ATMEL || WOLFSSL_ATECC508A */

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -46,7 +46,7 @@
     #include <wolfssl/wolfcrypt/port/nxp/ksdk_port.h>
 #endif
 
-#ifdef WOLFSSL_ATMEL
+#if defined(WOLFSSL_ATMEL) || defined(WOLFSSL_ATECC508A)
     #include <wolfssl/wolfcrypt/port/atmel/atmel.h>
 #endif
 
@@ -129,7 +129,7 @@ int wolfCrypt_Init(void)
         }
     #endif
 
-    #ifdef WOLFSSL_ATMEL
+    #if defined(WOLFSSL_ATMEL) || defined(WOLFSSL_ATECC508A)
         atmel_init();
     #endif
 

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -122,6 +122,7 @@ enum {
     /* max crypto hardware size */
 #ifdef WOLFSSL_ATECC508A
     ECC_MAX_CRYPTO_HW_SIZE = ATECC_KEY_SIZE, /* from port/atmel/atmel.h */
+    ECC_MAX_CRYPTO_HW_PUBKEY_SIZE = (ATECC_KEY_SIZE*2)
 #elif defined(PLUTON_CRYPTO_ECC)
     ECC_MAX_CRYPTO_HW_SIZE = 32,
 #endif
@@ -316,7 +317,7 @@ struct ecc_key {
     mp_int    k;        /* private key */
 #ifdef WOLFSSL_ATECC508A
     int  slot;        /* Key Slot Number (-1 unknown) */
-    byte pubkey_raw[PUB_KEY_SIZE];
+    byte pubkey_raw[ECC_MAX_CRYPTO_HW_PUBKEY_SIZE];
 #endif
 #ifdef PLUTON_CRYPTO_ECC
     int devId;


### PR DESCRIPTION
Support for building the ATECC508A without `WOLFSSL_ATMEL` defined, which enables features specific to Atmel Studio Framework (ASF) and an embedded target.

This allows for building with `WOLFSSL_ATECC508A` defined on other targets such as Linux.

Ticket 3698.