### PR TITLE
Support for not loading a private key when using `HAVE_PK_CALLBACKS`

### DIFF
--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -51,7 +51,7 @@ WOLFSSL_API int wc_InitCert(Cert*);
     \code
     Cert myCert;
     wc_InitCert(&myCert); 
-    RNG rng;
+    WC_RNG rng;
     //initialize rng;
     RsaKey key;
     //initialize key;
@@ -149,7 +149,7 @@ WOLFSSL_API int  wc_MakeCert(Cert*, byte* derBuffer, word32 derSz, RsaKey*,
     // initialize myCert, derCert
     RsaKey key;
     // initialize key;
-    RNG rng;
+    WC_RNG rng;
     // initialize rng
 
     word32 certSz;
@@ -195,7 +195,7 @@ WOLFSSL_API int  wc_SignCert(int requestSz, int sigType, byte* derBuffer,
     // initialize myCert, derCert
     RsaKey key;
     // initialize key;
-    RNG rng;
+    WC_RNG rng;
     // initialize rng
 
     word32 certSz;
@@ -899,7 +899,7 @@ WOLFSSL_API int wc_SetKeyUsage(Cert *cert, const char *value);
     \code
     Cert myCert;
     // initialize myCert
-    RNG rng;
+    WC_RNG rng;
     //initialize rng;
     byte ntruPublicKey[NTRU_KEY_SIZE];
     //initialize ntruPublicKey; 
@@ -1222,7 +1222,7 @@ WOLFSSL_API int wc_SetKeyUsage(Cert *cert, const char *value);
     \code
     ecc_key key;
     wc_ecc_init(&key);
-    WC_RNG rng;
+    WC_WC_RNG rng;
     wc_InitRng(&rng);
     wc_ecc_make_key(&rng, 24, &key);
     int derSz = // Some appropriate size for der;

--- a/doc/dox_comments/header_files/curve25519.h
+++ b/doc/dox_comments/header_files/curve25519.h
@@ -23,7 +23,7 @@
     \code
     curve25519_key key;
     wc_curve25519_init(&key); // initialize key
-    RNG rng;
+    WC_RNG rng;
     wc_InitRng(&rng); // initialize random number generator
 
     if( wc_curve25519_make_key(&rng, 32, &key) != 0) { 

--- a/doc/dox_comments/header_files/dh.h
+++ b/doc/dox_comments/header_files/dh.h
@@ -80,7 +80,7 @@ WOLFSSL_API void wc_FreeDhKey(DhKey* key);
 
     wc_InitDhKey(&key); // initialize key
     // Set DH parameters using wc_DhSetKey or wc_DhKeyDecode
-    RNG rng;
+    WC_RNG rng;
     wc_InitRng(&rng); // initialize rng
     ret = wc_DhGenerateKeyPair(&key, &rng, priv, &privSz, pub, &pubSz);
     \endcode

--- a/doc/dox_comments/header_files/dsa.h
+++ b/doc/dox_comments/header_files/dsa.h
@@ -81,7 +81,7 @@ WOLFSSL_API void wc_FreeDsaKey(DsaKey* key);
     DsaKey key;
     // initialize DSA key, load private Key
     int ret;
-    RNG rng;
+    WC_RNG rng;
     wc_InitRng(&rng);
     byte hash[] = { // initialize with hash digest };
     byte signature[40]; // signature will be 40 bytes (320 bits)
@@ -255,7 +255,7 @@ WOLFSSL_API int wc_DsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
     _Example_
     \code
     DsaKey key;
-    WC_RNG rng;
+    WC_WC_RNG rng;
     int derSz;
     int bufferSize = // Sufficient buffer size;
     byte der[bufferSize];
@@ -286,7 +286,7 @@ WOLFSSL_API int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen);
 
     _Example_
     \code
-    WC_RNG rng;
+    WC_WC_RNG rng;
     DsaKey dsa;
     wc_InitRng(&rng);
     wc_InitDsa(&dsa);
@@ -318,7 +318,7 @@ WOLFSSL_API int wc_MakeDsaKey(WC_RNG *rng, DsaKey *dsa);
     _Example_
     \code
     DsaKey key;
-    WC_RNG rng;
+    WC_WC_RNG rng;
     wc_InitDsaKey(&key);
     wc_InitRng(&rng);
     if(wc_MakeDsaParameters(&rng, 1024, &genKey) != 0)

--- a/doc/dox_comments/header_files/ecc.h
+++ b/doc/dox_comments/header_files/ecc.h
@@ -41,7 +41,7 @@
     \code
     ecc_key key;
     wc_ecc_init(&key);
-    RNG rng;
+    WC_WC_RNG rng;
     wc_InitRng(&rng);
     wc_ecc_make_key(&rng, 32, &key); // initialize 32 byte ecc key
     \endcode
@@ -51,6 +51,7 @@
 */
 WOLFSSL_API
 int wc_ecc_make_key(WC_RNG* rng, int keysize, ecc_key* key);
+
 /*!
     \ingroup ECC
     
@@ -65,7 +66,7 @@ int wc_ecc_make_key(WC_RNG* rng, int keysize, ecc_key* key);
     _Example_
     \code
     ecc_key key;
-    RNG rng;
+    WC_WC_RNG rng;
     int check_result;
     wc_ecc_init(&key);
     wc_InitRng(&rng);
@@ -86,6 +87,7 @@ int wc_ecc_make_key(WC_RNG* rng, int keysize, ecc_key* key);
 */
 WOLFSSL_API
 int wc_ecc_make_pub(ecc_key* key, ecc_point* pubOut);
+
 /*!
     \ingroup ECC
     
@@ -139,7 +141,7 @@ int wc_ecc_make_pub(ecc_key* key, ecc_point* pubOut);
     _Example_
     \code
     ecc_key priv, pub;
-    RNG rng;
+    WC_WC_RNG rng;
     byte secret[1024]; // can hold 1024 byte shared secret key
     word32 secretSz = sizeof(secret);
     int ret;
@@ -161,6 +163,7 @@ int wc_ecc_make_pub(ecc_key* key, ecc_point* pubOut);
 WOLFSSL_API
 int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
                       word32* outlen);
+
 /*!
     \ingroup ECC
     
@@ -206,6 +209,7 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
 WOLFSSL_API
 int wc_ecc_shared_secret_ex(ecc_key* private_key, ecc_point* point,
                              byte* out, word32 *outlen);
+
 /*!
     \ingroup ECC
     
@@ -254,7 +258,7 @@ int wc_ecc_shared_secret_ex(ecc_key* private_key, ecc_point* point,
     _Example_
     \code
     ecc_key key;
-    RNG rng;
+    WC_WC_RNG rng;
     int ret, sigSz;
 
     byte sig[512]; // will hold generated signature
@@ -274,6 +278,7 @@ int wc_ecc_shared_secret_ex(ecc_key* private_key, ecc_point* point,
 WOLFSSL_API
 int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
                      WC_RNG* rng, ecc_key* key);
+
 /*!
     \ingroup ECC
     
@@ -319,7 +324,7 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     _Example_
     \code
     ecc_key key;
-    WC_RNG rng;
+    WC_WC_WC_RNG rng;
     int ret, sigSz;
     mp_int r; // destination for r component of signature.
     mp_int s; // destination for s component of signature.
@@ -342,6 +347,7 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
 WOLFSSL_API
 int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
                         ecc_key* key, mp_int *r, mp_int *s);
+
 /*!
     \ingroup ECC
     
@@ -409,6 +415,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 WOLFSSL_API
 int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
                     word32 hashlen, int* stat, ecc_key* key);
+
 /*!
     \ingroup ECC
     
@@ -447,6 +454,7 @@ Note: Do not use the return value to test for valid.  Only use stat.
 WOLFSSL_API
 int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
                           word32 hashlen, int* stat, ecc_key* key);
+
 /*!
     \ingroup ECC
     
@@ -469,6 +477,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 */
 WOLFSSL_API
 int wc_ecc_init(ecc_key* key);
+
 /*!
     \ingroup ECC
     
@@ -489,6 +498,7 @@ int wc_ecc_init(ecc_key* key);
 */
 WOLFSSL_API
 int wc_ecc_free(ecc_key* key);
+
 /*!
     \ingroup ECC
     
@@ -513,6 +523,7 @@ int wc_ecc_free(ecc_key* key);
 */
 WOLFSSL_API
 void wc_ecc_fp_free(void);
+
 /*!
     \ingroup ECC
     
@@ -526,7 +537,7 @@ void wc_ecc_fp_free(void);
     _Example_
     \code
     ecc_key key;
-    RNG rng;
+    WC_WC_RNG rng;
     int is_valid;
     wc_ecc_init(&key);
     wc_InitRng(&rng);
@@ -546,6 +557,7 @@ void wc_ecc_fp_free(void);
 */
 WOLFSSL_API
 int wc_ecc_is_valid_idx(int n);
+
 /*!
     \ingroup ECC
     
@@ -573,6 +585,7 @@ int wc_ecc_is_valid_idx(int n);
 */
 WOLFSSL_API
 ecc_point* wc_ecc_new_point(void);
+
 /*!
     \ingroup ECC
     
@@ -600,6 +613,7 @@ ecc_point* wc_ecc_new_point(void);
 */
 WOLFSSL_API
 void wc_ecc_del_point(ecc_point* p);
+
 /*!
     \ingroup ECC
     
@@ -632,6 +646,7 @@ void wc_ecc_del_point(ecc_point* p);
 */
 WOLFSSL_API
 int wc_ecc_copy_point(ecc_point* p, ecc_point *r);
+
 /*!
     \ingroup ECC
     
@@ -674,6 +689,7 @@ int wc_ecc_copy_point(ecc_point* p, ecc_point *r);
 */
 WOLFSSL_API
 int wc_ecc_cmp_point(ecc_point* a, ecc_point *b);
+
 /*!
     \ingroup ECC
     
@@ -714,6 +730,7 @@ int wc_ecc_cmp_point(ecc_point* a, ecc_point *b);
 */
 WOLFSSL_API
 int wc_ecc_point_is_at_infinity(ecc_point *p);
+
 /*!
     \ingroup ECC
     
@@ -748,6 +765,7 @@ int wc_ecc_point_is_at_infinity(ecc_point *p);
 WOLFSSL_API
 int wc_ecc_mulmod(mp_int* k, ecc_point *G, ecc_point *R,
                   mp_int* a, mp_int* modulus, int map);
+
 /*!
     \ingroup ECC
     
@@ -812,6 +830,7 @@ int wc_ecc_mulmod(mp_int* k, ecc_point *G, ecc_point *R,
 */
 WOLFSSL_API
 int wc_ecc_export_x963(ecc_key*, byte* out, word32* outLen);
+
 /*!
     \ingroup ECC
     
@@ -882,6 +901,7 @@ int wc_ecc_export_x963(ecc_key*, byte* out, word32* outLen);
 */
 WOLFSSL_API
 int wc_ecc_export_x963_ex(ecc_key*, byte* out, word32* outLen, int compressed);
+
 /*!
     \ingroup ECC
     
@@ -944,6 +964,7 @@ int wc_ecc_export_x963_ex(ecc_key*, byte* out, word32* outLen, int compressed);
 */
 WOLFSSL_API
 int wc_ecc_import_x963(const byte* in, word32 inLen, ecc_key* key);
+
 /*!
     \ingroup ECC
     
@@ -1013,6 +1034,7 @@ NOT_COMPILED_IN Returned if the HAVE_COMP_KEY was not enabled at compile
 WOLFSSL_API
 int wc_ecc_import_private_key(const byte* priv, word32 privSz, const byte* pub,
                            word32 pubSz, ecc_key* key);
+
 /*!
     \ingroup ECC
     
@@ -1077,6 +1099,7 @@ int wc_ecc_import_private_key(const byte* priv, word32 privSz, const byte* pub,
 */
 WOLFSSL_API
 int wc_ecc_rs_to_sig(const char* r, const char* s, byte* out, word32* outlen);
+
 /*!
     \ingroup ECC
     
@@ -1142,6 +1165,7 @@ int wc_ecc_rs_to_sig(const char* r, const char* s, byte* out, word32* outlen);
 WOLFSSL_API
 int wc_ecc_import_raw(ecc_key* key, const char* qx, const char* qy,
                    const char* d, const char* curveName);
+
 /*!
     \ingroup ECC
     
@@ -1203,6 +1227,7 @@ int wc_ecc_import_raw(ecc_key* key, const char* qx, const char* qy,
 */
 WOLFSSL_API
 int wc_ecc_export_private_only(ecc_key* key, byte* out, word32* outLen);
+
 /*!
     \ingroup ECC
     
@@ -1235,6 +1260,7 @@ int wc_ecc_export_private_only(ecc_key* key, byte* out, word32* outLen);
 WOLFSSL_API
 int wc_ecc_export_point_der(const int curve_idx, ecc_point* point,
                             byte* out, word32* outLen);
+
 /*!
     \ingroup ECC
     
@@ -1266,6 +1292,7 @@ int wc_ecc_export_point_der(const int curve_idx, ecc_point* point,
 WOLFSSL_API
 int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
                             ecc_point* point);
+
 /*!
     \ingroup ECC
     
@@ -1292,12 +1319,40 @@ int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
 */
 WOLFSSL_API
 int wc_ecc_size(ecc_key* key);
+
 /*!
     \ingroup ECC
     
     \brief This function returns the worst case size for an ECC signature, 
-    given by: keySz * 2 + SIG_HEADER_SZ + 4 The actual signature size can 
-    be computed with wc_ecc_sign_hash.
+    given by: (keySz * 2) + SIG_HEADER_SZ + ECC_MAX_PAD_SZ.
+    The actual signature size can be computed with wc_ecc_sign_hash.
+    
+    \return returns the maximum signature 
+    size, in octets
+    
+    \param key size
+    
+    _Example_
+    \code
+    int sigSz = wc_ecc_sig_size(32);
+    if ( sigSz == 0) {
+    	// error determining sig size
+    }
+    \endcode
+
+    \sa wc_ecc_sign_hash
+    \sa wc_ecc_sig_size
+*/
+WOLFSSL_API
+int wc_ecc_sig_size_calc(int sz);
+
+
+/*!
+    \ingroup ECC
+    
+    \brief This function returns the worst case size for an ECC signature, 
+    given by: (keySz * 2) + SIG_HEADER_SZ + ECC_MAX_PAD_SZ.
+    The actual signature size can be computed with wc_ecc_sign_hash.
     
     \return Success Given a valid key, returns the maximum signature 
     size, in octets
@@ -1314,17 +1369,20 @@ int wc_ecc_size(ecc_key* key);
 
     sigSz = wc_ecc_sig_size(&key);
     if ( sigSz == 0) {
-    	// error determining sig size
+        // error determining sig size
     }
     \endcode
 
     \sa wc_ecc_sign_hash
+    \sa wc_ecc_sig_size_calc
 */
 WOLFSSL_API
 int wc_ecc_sig_size(ecc_key* key);
+
+
 /*!
     \ingroup ECC
-    
+
     \brief This function allocates and initializes space for a new ECC 
     context object to allow secure message exchange with ECC.
     
@@ -1340,11 +1398,11 @@ int wc_ecc_sig_size(ecc_key* key);
     _Example_
     \code
     ecEncCtx* ctx;
-    RNG rng;
+    WC_WC_RNG rng;
     wc_InitRng(&rng);
     ctx = wc_ecc_ctx_new(REQ_RESP_CLIENT, &rng);
     if(ctx == NULL) {
-	    // error generating new ecEncCtx object
+        // error generating new ecEncCtx object
     }
     \endcode
     
@@ -1353,6 +1411,7 @@ int wc_ecc_sig_size(ecc_key* key);
 */
 WOLFSSL_API
 ecEncCtx* wc_ecc_ctx_new(int flags, WC_RNG* rng);
+
 /*!
     \ingroup ECC
     
@@ -1366,7 +1425,7 @@ ecEncCtx* wc_ecc_ctx_new(int flags, WC_RNG* rng);
     _Example_
     \code
     ecEncCtx* ctx;
-    RNG rng;
+    WC_WC_RNG rng;
     wc_InitRng(&rng);
     ctx = wc_ecc_ctx_new(REQ_RESP_CLIENT, &rng);
     // do secure communication
@@ -1378,6 +1437,7 @@ ecEncCtx* wc_ecc_ctx_new(int flags, WC_RNG* rng);
 */
 WOLFSSL_API
 void wc_ecc_ctx_free(ecEncCtx*);
+
 /*!
     \ingroup ECC
     
@@ -1395,7 +1455,7 @@ void wc_ecc_ctx_free(ecEncCtx*);
     _Example_
     \code
     ecEncCtx* ctx;
-    RNG rng;
+    WC_WC_RNG rng;
     wc_InitRng(&rng);
     ctx = wc_ecc_ctx_new(REQ_RESP_CLIENT, &rng);
     // do secure communication
@@ -1408,6 +1468,7 @@ void wc_ecc_ctx_free(ecEncCtx*);
 */
 WOLFSSL_API
 int wc_ecc_ctx_reset(ecEncCtx*, WC_RNG*);  /* reset for use again w/o alloc/free */
+
 /*!
     \ingroup ECC
     
@@ -1426,7 +1487,7 @@ int wc_ecc_ctx_reset(ecEncCtx*, WC_RNG*);  /* reset for use again w/o alloc/free
     _Example_
     \code
     ecEncCtx* ctx;
-    RNG rng;
+    WC_WC_RNG rng;
     const byte* salt;
     wc_InitRng(&rng);
     ctx = wc_ecc_ctx_new(REQ_RESP_CLIENT, &rng);
@@ -1441,6 +1502,7 @@ int wc_ecc_ctx_reset(ecEncCtx*, WC_RNG*);  /* reset for use again w/o alloc/free
 */
 WOLFSSL_API
 const byte* wc_ecc_ctx_get_own_salt(ecEncCtx*);
+
 /*!
     \ingroup ECC
     
@@ -1461,7 +1523,7 @@ const byte* wc_ecc_ctx_get_own_salt(ecEncCtx*);
     _Example_
     \code
     ecEncCtx* cliCtx, srvCtx;
-    RNG rng;
+    WC_WC_RNG rng;
     const byte* cliSalt, srvSalt;
     int ret;
 
@@ -1478,6 +1540,7 @@ const byte* wc_ecc_ctx_get_own_salt(ecEncCtx*);
 */
 WOLFSSL_API
 int wc_ecc_ctx_set_peer_salt(ecEncCtx*, const byte* salt);
+
 /*!
     \ingroup ECC
     
@@ -1508,6 +1571,7 @@ int wc_ecc_ctx_set_peer_salt(ecEncCtx*, const byte* salt);
 */
 WOLFSSL_API
 int wc_ecc_ctx_set_info(ecEncCtx*, const byte* info, int sz);
+
 /*!
     \ingroup ECC
     
@@ -1568,6 +1632,7 @@ int wc_ecc_ctx_set_info(ecEncCtx*, const byte* info, int sz);
 WOLFSSL_API
 int wc_ecc_encrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
                 word32 msgSz, byte* out, word32* outSz, ecEncCtx* ctx);
+
 /*!
     \ingroup ECC
     

--- a/doc/dox_comments/header_files/ed25519.h
+++ b/doc/dox_comments/header_files/ed25519.h
@@ -18,7 +18,7 @@
     \code
     ed25519_key key;
     wc_ed25519_init(&key);
-    RNG rng;
+    WC_RNG rng;
     wc_InitRng(&rng);
     wc_ed25519_make_key(&rng, 32, &key); // initialize 32 byte ed25519 key
     \endcode
@@ -51,7 +51,7 @@ int wc_ed25519_make_key(WC_RNG* rng, int keysize, ed25519_key* key);
     _Example_
     \code
     ed25519_key key;
-    RNG rng;
+    WC_RNG rng;
     int ret, sigSz;
 
     byte sig[64]; // will hold generated signature
@@ -332,7 +332,7 @@ int wc_ed25519_export_private_only(ed25519_key* key, byte* out, word32* outLen);
     ed25519_key key;
     wc_ed25519_init(&key);
 
-    RNG rng;
+    WC_RNG rng;
     wc_InitRng(&rng);
 
     wc_ed25519_make_key(&rng, 32, &key); // initialize 32 byte ed25519 key
@@ -432,7 +432,7 @@ int wc_ed25519_size(ed25519_key* key);
     ed25519_key key;
     wc_ed25519_init(&key);
 
-    RNG rng;
+    WC_RNG rng;
     wc_InitRng(&rng);
 
     wc_ed25519_make_key(&rng, 32, &key); // initialize 32 byte ed25519 key
@@ -457,7 +457,7 @@ int wc_ed25519_priv_size(ed25519_key* key);
     \code
     ed25519_key key;
     wc_ed25519_init(&key);
-    RNG rng;
+    WC_RNG rng;
     wc_InitRng(&rng);
 
     wc_ed25519_make_key(&rng, 32, &key); // initialize 32 byte ed25519 key

--- a/doc/dox_comments/header_files/rsa.h
+++ b/doc/dox_comments/header_files/rsa.h
@@ -28,6 +28,7 @@
     \sa wc_FreeRsaKey
 */
 WOLFSSL_API int  wc_InitRsaKey(RsaKey* key, void* heap);
+
 /*!
     \ingroup RSA
     
@@ -49,6 +50,7 @@ WOLFSSL_API int  wc_InitRsaKey(RsaKey* key, void* heap);
     \sa wc_InitRsaKey
 */
 WOLFSSL_API int  wc_FreeRsaKey(RsaKey* key);
+
 /*!
     \ingroup RSA
     
@@ -122,6 +124,7 @@ WOLFSSL_API int  wc_FreeRsaKey(RsaKey* key);
 */
 WOLFSSL_API int  wc_RsaPublicEncrypt(const byte* in, word32 inLen, byte* out,
                                  word32 outLen, RsaKey* key, WC_RNG* rng);
+
 /*!
     \ingroup RSA
     
@@ -145,6 +148,7 @@ WOLFSSL_API int  wc_RsaPublicEncrypt(const byte* in, word32 inLen, byte* out,
 */
 WOLFSSL_API int  wc_RsaPrivateDecryptInline(byte* in, word32 inLen, byte** out,
                                         RsaKey* key);
+
 /*!
     \ingroup RSA
     
@@ -178,6 +182,7 @@ WOLFSSL_API int  wc_RsaPrivateDecryptInline(byte* in, word32 inLen, byte** out,
 */
 WOLFSSL_API int  wc_RsaPrivateDecrypt(const byte* in, word32 inLen, byte* out,
                                   word32 outLen, RsaKey* key);
+
 /*!
     \ingroup RSA
     
@@ -210,6 +215,7 @@ WOLFSSL_API int  wc_RsaPrivateDecrypt(const byte* in, word32 inLen, byte* out,
 */
 WOLFSSL_API int  wc_RsaSSL_Sign(const byte* in, word32 inLen, byte* out,
                             word32 outLen, RsaKey* key, WC_RNG* rng);
+
 /*!
     \ingroup RSA
     
@@ -227,7 +233,7 @@ WOLFSSL_API int  wc_RsaSSL_Sign(const byte* in, word32 inLen, byte* out,
     _Example_
     \code
     RsaKey key;
-    RNG rng;
+    WC_WC_RNG rng;
     int ret = 0;
     long e = 65537; // standard value to use for exponent
     wc_InitRsaKey(&key, NULL); // not using heap hint. No custom memory
@@ -247,6 +253,7 @@ WOLFSSL_API int  wc_RsaSSL_Sign(const byte* in, word32 inLen, byte* out,
 */
 WOLFSSL_API int  wc_RsaSSL_VerifyInline(byte* in, word32 inLen, byte** out,
                                     RsaKey* key);
+
 /*!
     \ingroup RSA
     
@@ -278,6 +285,7 @@ WOLFSSL_API int  wc_RsaSSL_VerifyInline(byte* in, word32 inLen, byte** out,
 */
 WOLFSSL_API int  wc_RsaSSL_Verify(const byte* in, word32 inLen, byte* out,
                               word32 outLen, RsaKey* key);
+
 /*!
     \ingroup RSA
     
@@ -298,6 +306,7 @@ WOLFSSL_API int  wc_RsaSSL_Verify(const byte* in, word32 inLen, byte* out,
     \sa XMEMSET
 */
 WOLFSSL_API int  wc_RsaEncryptSize(RsaKey* key);
+
 /*!
     \ingroup RSA
     
@@ -341,6 +350,7 @@ WOLFSSL_API int  wc_RsaEncryptSize(RsaKey* key);
 */
 WOLFSSL_API int  wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
                                                                RsaKey*, word32);
+
 /*!
     \ingroup RSA
     
@@ -389,6 +399,7 @@ WOLFSSL_API int  wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
 */
 WOLFSSL_API int  wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx,
                                                                RsaKey*, word32);
+
 /*!
     \ingroup RSA
     
@@ -433,6 +444,7 @@ WOLFSSL_API int  wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx,
 */
 WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
                                         const byte* e, word32 eSz, RsaKey* key);
+
 /*!
     \ingroup RSA
     
@@ -454,7 +466,7 @@ WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
     // Allocate memory for der
     int derSz = // Amount of memory allocated for der;
     RsaKey key;
-    RNG rng;
+    WC_WC_RNG rng;
     long e = 65537; // standard value to use for exponent
     ret = wc_MakeRsaKey(&key, 2048, e, &rng); // generate 2048 bit long 
     private key
@@ -472,6 +484,7 @@ WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
     \sa wc_InitRng
 */
     WOLFSSL_API int wc_RsaKeyToDer(RsaKey*, byte* output, word32 inLen);
+
 /*!
     \ingroup RSA
     
@@ -496,7 +509,7 @@ WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
 
     _Example_
     \code
-    WC_RNG rng;
+    WC_WC_WC_RNG rng;
     RsaKey key;
     byte in[] = “I use Turing Machines to ask questions”
     byte out[256];
@@ -516,6 +529,7 @@ WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
 WOLFSSL_API int  wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
                    word32 outLen, RsaKey* key, WC_RNG* rng, int type,
                    enum wc_HashType hash, int mgf, byte* label, word32 lableSz);
+
 /*!
     \ingroup RSA
     
@@ -542,7 +556,7 @@ WOLFSSL_API int  wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
 
     _Example_
     \code
-    WC_RNG rng;
+    WC_WC_WC_RNG rng;
     RsaKey key;
     byte in[] = “I use Turing Machines to ask questions”
     byte out[256];
@@ -568,6 +582,7 @@ WOLFSSL_API int  wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
 WOLFSSL_API int  wc_RsaPrivateDecrypt_ex(const byte* in, word32 inLen,
                    byte* out, word32 outLen, RsaKey* key, int type,
                    enum wc_HashType hash, int mgf, byte* label, word32 lableSz);
+
 /*!
     \ingroup RSA
     
@@ -598,7 +613,7 @@ WOLFSSL_API int  wc_RsaPrivateDecrypt_ex(const byte* in, word32 inLen,
 
     _Example_
     \code
-    WC_RNG rng;
+    WC_WC_WC_RNG rng;
     RsaKey key;
     byte in[] = “I use Turing Machines to ask questions”
     byte out[256];
@@ -625,6 +640,7 @@ WOLFSSL_API int  wc_RsaPrivateDecrypt_ex(const byte* in, word32 inLen,
 WOLFSSL_API int  wc_RsaPrivateDecryptInline_ex(byte* in, word32 inLen,
                       byte** out, RsaKey* key, int type, enum wc_HashType hash,
                       int mgf, byte* label, word32 lableSz);
+
 /*!
     \ingroup RSA
     
@@ -669,6 +685,7 @@ WOLFSSL_API int  wc_RsaPrivateDecryptInline_ex(byte* in, word32 inLen,
 */
 WOLFSSL_API int  wc_RsaFlattenPublicKey(RsaKey*, byte*, word32*, byte*,
                                                                        word32*);
+
 /*!
     \ingroup RSA
     
@@ -703,6 +720,7 @@ WOLFSSL_API int  wc_RsaFlattenPublicKey(RsaKey*, byte*, word32*, byte*,
     \sa wc_RsaInitKey
 */
     WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey*, byte* output, word32 inLen);
+
 /*!
     \ingroup RSA
     
@@ -757,7 +775,7 @@ WOLFSSL_API int  wc_RsaFlattenPublicKey(RsaKey*, byte*, word32*, byte*,
     _Example_
     \code
     RsaKey priv;
-    RNG rng;
+    WC_WC_RNG rng;
     int ret = 0;
     long e = 65537; // standard value to use for exponent
 

--- a/doc/dox_comments/header_files/signature.h
+++ b/doc/dox_comments/header_files/signature.h
@@ -106,7 +106,7 @@ WOLFSSL_API int wc_SignatureVerify(
     _Example_
     \code
     int ret;
-    RNG rng;
+    WC_RNG rng;
     ecc_key eccKey;
     
     wc_InitRng(&rng);

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -3589,7 +3589,7 @@ WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
     downgrade to SSLv3 if needed. In this case, the client will be able to 
     connect to a server running SSLv3 - TLSv1.2.
 
-    \return pointer upon succes a pointer to a WOLFSSL_METHOD.
+    \return pointer upon success a pointer to a WOLFSSL_METHOD.
     \return Failure If memory allocation fails when calling XMALLOC, 
     the failure value of the underlying malloc() implementation will be 
     returned (typically NULL with errno will be set to ENOMEM).

--- a/src/internal.c
+++ b/src/internal.c
@@ -2964,13 +2964,21 @@ int ConvertHashPss(int hashAlgo, enum wc_HashType* hashType, int* mgf)
 
 int RsaSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
             word32* outSz, int sigAlgo, int hashAlgo, RsaKey* key,
-            const byte* keyBuf, word32 keySz, void* ctx)
+            DerBuffer* keyBufInfo, void* ctx)
 {
     int ret;
+#ifdef HAVE_PK_CALLBACKS
+    const byte* keyBuf = NULL;
+    word32 keySz = 0;
+
+    if (keyBufInfo) {
+        keyBuf = keyBufInfo->buffer;
+        keySz = keyBufInfo->length;
+    }
+#endif
 
     (void)ssl;
-    (void)keyBuf;
-    (void)keySz;
+    (void)keyBufInfo;
     (void)ctx;
     (void)sigAlgo;
     (void)hashAlgo;
@@ -2978,7 +2986,7 @@ int RsaSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
     WOLFSSL_ENTER("RsaSign");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     if (ret != 0)
         return ret;
@@ -3036,14 +3044,21 @@ int RsaSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 }
 
 int RsaVerify(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, int sigAlgo,
-              int hashAlgo, RsaKey* key, const byte* keyBuf, word32 keySz,
-              void* ctx)
+              int hashAlgo, RsaKey* key, buffer* keyBufInfo, void* ctx)
 {
     int ret;
+#ifdef HAVE_PK_CALLBACKS
+    const byte* keyBuf = NULL;
+    word32 keySz = 0;
+
+    if (keyBufInfo) {
+        keyBuf = keyBufInfo->buffer;
+        keySz = keyBufInfo->length;
+    }
+#endif
 
     (void)ssl;
-    (void)keyBuf;
-    (void)keySz;
+    (void)keyBufInfo;
     (void)ctx;
     (void)sigAlgo;
     (void)hashAlgo;
@@ -3051,7 +3066,7 @@ int RsaVerify(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, int sigAlgo,
     WOLFSSL_ENTER("RsaVerify");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     if (ret != 0)
         return ret;
@@ -3103,21 +3118,29 @@ int RsaVerify(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, int sigAlgo,
 /* This function is used to check the sign result */
 int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
     const byte* plain, word32 plainSz, int sigAlgo, int hashAlgo, RsaKey* key,
-    const byte* keyBuf, word32 keySz, void* ctx)
+    DerBuffer* keyBufInfo, void* ctx)
 {
     byte* out = NULL;  /* inline result */
     int   ret;
+#ifdef HAVE_PK_CALLBACKS
+    const byte* keyBuf = NULL;
+    word32 keySz = 0;
+
+    if (keyBufInfo) {
+        keyBuf = keyBufInfo->buffer;
+        keySz = keyBufInfo->length;
+    }
+#endif
 
     (void)ssl;
-    (void)keyBuf;
-    (void)keySz;
+    (void)keyBufInfo;
     (void)ctx;
     (void)sigAlgo;
     (void)hashAlgo;
 
     WOLFSSL_ENTER("VerifyRsaSign");
 
-    if (verifySig == NULL || plain == NULL || key == NULL) {
+    if (verifySig == NULL || plain == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -3127,10 +3150,12 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
     }
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
-    ret = wolfSSL_AsyncInit(ssl, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
-    if (ret != 0)
-        return ret;
+    /* initialize event */
+    if (key) {
+        ret = wolfSSL_AsyncInit(ssl, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+        if (ret != 0)
+            return ret;
+    }
 #endif
 
 #if defined(WC_RSA_PSS)
@@ -3197,7 +3222,7 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (key && ret == WC_PENDING_E) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -3208,19 +3233,27 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
 }
 
 int RsaDec(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, word32* outSz,
-    RsaKey* key, const byte* keyBuf, word32 keySz, void* ctx)
+    RsaKey* key, DerBuffer* keyBufInfo, void* ctx)
 {
     int ret;
+#ifdef HAVE_PK_CALLBACKS
+    const byte* keyBuf = NULL;
+    word32 keySz = 0;
+
+    if (keyBufInfo) {
+        keyBuf = keyBufInfo->buffer;
+        keySz = keyBufInfo->length;
+    }
+#endif
 
     (void)ssl;
-    (void)keyBuf;
-    (void)keySz;
+    (void)keyBufInfo;
     (void)ctx;
 
     WOLFSSL_ENTER("RsaDec");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     if (ret != 0)
         return ret;
@@ -3261,19 +3294,27 @@ int RsaDec(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, word32* outSz,
 }
 
 int RsaEnc(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out, word32* outSz,
-    RsaKey* key, const byte* keyBuf, word32 keySz, void* ctx)
+    RsaKey* key, buffer* keyBufInfo, void* ctx)
 {
     int ret;
+#ifdef HAVE_PK_CALLBACKS
+    const byte* keyBuf = NULL;
+    word32 keySz = 0;
+
+    if (keyBufInfo) {
+        keyBuf = keyBufInfo->buffer;
+        keySz = keyBufInfo->length;
+    }
+#endif
 
     (void)ssl;
-    (void)keyBuf;
-    (void)keySz;
+    (void)keyBufInfo;
     (void)ctx;
 
     WOLFSSL_ENTER("RsaEnc");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     if (ret != 0)
         return ret;
@@ -3313,19 +3354,27 @@ int RsaEnc(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out, word32* outSz,
 #ifdef HAVE_ECC
 
 int EccSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
-    word32* outSz, ecc_key* key, byte* keyBuf, word32 keySz, void* ctx)
+    word32* outSz, ecc_key* key, DerBuffer* keyBufInfo, void* ctx)
 {
     int ret;
+#ifdef HAVE_PK_CALLBACKS
+    const byte* keyBuf = NULL;
+    word32 keySz = 0;
+
+    if (keyBufInfo) {
+        keyBuf = keyBufInfo->buffer;
+        keySz = keyBufInfo->length;
+    }
+#endif
 
     (void)ssl;
-    (void)keyBuf;
-    (void)keySz;
+    (void)keyBufInfo;
     (void)ctx;
 
     WOLFSSL_ENTER("EccSign");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     if (ret != 0)
         return ret;
@@ -3355,20 +3404,27 @@ int EccSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 }
 
 int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* out,
-    word32 outSz, ecc_key* key, byte* keyBuf, word32 keySz,
-    void* ctx)
+    word32 outSz, ecc_key* key, buffer* keyBufInfo, void* ctx)
 {
     int ret;
+#ifdef HAVE_PK_CALLBACKS
+    const byte* keyBuf = NULL;
+    word32 keySz = 0;
+
+    if (keyBufInfo) {
+        keyBuf = keyBufInfo->buffer;
+        keySz = keyBufInfo->length;
+    }
+#endif
 
     (void)ssl;
-    (void)keyBuf;
-    (void)keySz;
+    (void)keyBufInfo;
     (void)ctx;
 
     WOLFSSL_ENTER("EccVerify");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     if (ret != 0)
         return ret;
@@ -3487,7 +3543,7 @@ int EccSharedSecret(WOLFSSL* ssl, ecc_key* priv_key, ecc_key* pub_key,
 #endif
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     if (ret != 0)
         return ret;
@@ -3524,7 +3580,7 @@ int EccMakeKey(WOLFSSL* ssl, ecc_key* key, ecc_key* peer)
     WOLFSSL_ENTER("EccMakeKey");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &key->asyncDev, WC_ASYNC_FLAG_NONE);
     if (ret != 0)
         return ret;
@@ -3571,23 +3627,31 @@ int EccMakeKey(WOLFSSL* ssl, ecc_key* key, ecc_key* peer)
  * key    The private X25519 key data.
  * keySz  The length of the private key data in bytes.
  * ctx    The callback context.
- * returns 0 on succes, otherwise the valus is an error.
+ * returns 0 on success, otherwise the value is an error.
  */
 int Ed25519Sign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
-                word32* outSz, ed25519_key* key, byte* keyBuf, word32 keySz,
+                word32* outSz, ed25519_key* key, DerBuffer* keyBufInfo,
                 void* ctx)
 {
     int ret;
+#ifdef HAVE_PK_CALLBACKS
+    const byte* keyBuf = NULL;
+    word32 keySz = 0;
+
+    if (keyBufInfo) {
+        keyBuf = keyBufInfo->buffer;
+        keySz = keyBufInfo->length;
+    }
+#endif
 
     (void)ssl;
-    (void)keyBuf;
-    (void)keySz;
+    (void)keyBufInfo;
     (void)ctx;
 
     WOLFSSL_ENTER("Ed25519Sign");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     if (ret != 0)
         return ret;
@@ -3626,23 +3690,30 @@ int Ed25519Sign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
  * key    The public X25519 key data.
  * keySz  The length of the private key data in bytes.
  * ctx    The callback context.
- * returns 0 on succes, otherwise the valus is an error.
+ * returns 0 on success, otherwise the value is an error.
  */
 int Ed25519Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
-                  word32 msgSz, ed25519_key* key, byte* keyBuf, word32 keySz,
-                  void* ctx)
+                  word32 msgSz, ed25519_key* key, buffer* keyBufInfo, void* ctx)
 {
     int ret;
+#ifdef HAVE_PK_CALLBACKS
+    const byte* keyBuf = NULL;
+    word32 keySz = 0;
+
+    if (keyBufInfo) {
+        keyBuf = keyBufInfo->buffer;
+        keySz = keyBufInfo->length;
+    }
+#endif
 
     (void)ssl;
-    (void)keyBuf;
-    (void)keySz;
+    (void)keyBufInfo;
     (void)ctx;
 
     WOLFSSL_ENTER("Ed25519Verify");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     if (ret != 0)
         return ret;
@@ -3730,7 +3801,7 @@ static int X25519SharedSecret(WOLFSSL* ssl, curve25519_key* priv_key,
     WOLFSSL_ENTER("X25519SharedSecret");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &priv_key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     if (ret != 0)
         return ret;
@@ -3775,7 +3846,7 @@ static int X25519MakeKey(WOLFSSL* ssl, curve25519_key* key,
     WOLFSSL_ENTER("X25519MakeKey");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &key->asyncDev, WC_ASYNC_FLAG_NONE);
     if (ret != 0)
         return ret;
@@ -3810,7 +3881,7 @@ int DhGenKeyPair(WOLFSSL* ssl, DhKey* dhKey,
     WOLFSSL_ENTER("DhGenKeyPair");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &dhKey->asyncDev, WC_ASYNC_FLAG_NONE);
     if (ret != 0)
         return ret;
@@ -3842,7 +3913,7 @@ int DhAgree(WOLFSSL* ssl, DhKey* dhKey,
     WOLFSSL_ENTER("DhAgree");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    /* intialize event */
+    /* initialize event */
     ret = wolfSSL_AsyncInit(ssl, &dhKey->asyncDev, WC_ASYNC_FLAG_NONE);
     if (ret != 0)
         return ret;
@@ -3877,6 +3948,33 @@ int DhAgree(WOLFSSL* ssl, DhKey* dhKey,
 #endif /* !NO_DH */
 #endif /* !NO_CERTS || !NO_PSK */
 
+
+#ifdef HAVE_PK_CALLBACKS
+int wolfSSL_CTX_IsPrivatePkSet(WOLFSSL_CTX* ctx)
+{
+    int pkcbset = 0;
+#if defined(HAVE_ECC) || defined(HAVE_ED25519) || !defined(NO_RSA)
+    if (0
+    #ifdef HAVE_ECC
+        || ctx->EccSignCb != NULL
+    #endif
+    #ifdef HAVE_ED25519
+        || ctx->Ed25519SignCb != NULL
+    #endif
+    #ifndef NO_RSA
+        || ctx->RsaSignCb != NULL
+        || ctx->RsaDecCb != NULL
+        #ifdef WC_RSA_PSS
+        || ctx->RsaPssSignCb != NULL
+        #endif
+    #endif
+    ) {
+        pkcbset = 1;
+    }
+#endif
+    return pkcbset;
+}
+#endif /* HAVE_PK_CALLBACKS */
 
 /* This function inherits a WOLFSSL_CTX's fields into an SSL object.
    It is used during initialization and to switch an ssl's CTX with
@@ -4064,12 +4162,26 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         /* make sure server has cert and key unless using PSK, Anon, or
          * Multicast. This should be true even if just switching ssl ctx */
         if (ssl->options.side == WOLFSSL_SERVER_END &&
-                !havePSK && !haveAnon && !haveMcast)
-            if (!ssl->buffers.certificate || !ssl->buffers.certificate->buffer
-                || !ssl->buffers.key || !ssl->buffers.key->buffer) {
-                WOLFSSL_MSG("Server missing certificate and/or private key");
+                !havePSK && !haveAnon && !haveMcast) {
+
+            /* server certificate must be loaded */
+            if (!ssl->buffers.certificate || !ssl->buffers.certificate->buffer) {
+                WOLFSSL_MSG("Server missing certificate");
                 return NO_PRIVATE_KEY;
             }
+
+            /* allow no private key if using PK callbacks and CB is set */
+        #ifdef HAVE_PK_CALLBACKS
+            if (wolfSSL_CTX_IsPrivatePkSet(ctx)) {
+                WOLFSSL_MSG("Using PK for server private key");
+            }
+            else
+        #endif
+            if (!ssl->buffers.key || !ssl->buffers.key->buffer) {
+                WOLFSSL_MSG("Server missing private key");
+                return NO_PRIVATE_KEY;
+            }
+        }
 #endif
 
     }  /* writeDup check */
@@ -8989,7 +9101,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 ssl->buffers.peerEccDsaKey.length =
                                         args->dCert->pubKeySize;
                             }
-                    #endif /*HAVE_PK_CALLBACKS */
+                    #endif /* HAVE_PK_CALLBACKS */
                         }
 
                         /* check size of peer ECC key */
@@ -9272,12 +9384,14 @@ exit_ppc:
     return ret;
 }
 
+/* handle processing of certificate (11) */
 static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                                 word32 size)
 {
     return ProcessPeerCerts(ssl, input, inOutIdx, size);
 }
 
+/* handle processing of certificate_status (22) */
 static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                                     word32 size)
 {
@@ -10977,7 +11091,7 @@ static INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
     #ifdef BUILD_DES3
         case wolfssl_triple_des:
         #ifdef WOLFSSL_ASYNC_CRYPT
-            /* intialize event */
+            /* initialize event */
             asyncDev = &ssl->encrypt.des3->asyncDev;
             ret = wolfSSL_AsyncInit(ssl, asyncDev, event_flags);
             if (ret != 0)
@@ -10996,7 +11110,7 @@ static INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
     #ifdef BUILD_AES
         case wolfssl_aes:
         #ifdef WOLFSSL_ASYNC_CRYPT
-            /* intialize event */
+            /* initialize event */
             asyncDev = &ssl->encrypt.aes->asyncDev;
             ret = wolfSSL_AsyncInit(ssl, asyncDev, event_flags);
             if (ret != 0)
@@ -11020,7 +11134,7 @@ static INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
             const byte* additionalSrc;
 
         #ifdef WOLFSSL_ASYNC_CRYPT
-            /* intialize event */
+            /* initialize event */
             asyncDev = &ssl->encrypt.aes->asyncDev;
             ret = wolfSSL_AsyncInit(ssl, asyncDev, event_flags);
             if (ret != 0)
@@ -11241,7 +11355,7 @@ static INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
     #ifdef BUILD_DES3
         case wolfssl_triple_des:
         #ifdef WOLFSSL_ASYNC_CRYPT
-            /* intialize event */
+            /* initialize event */
             ret = wolfSSL_AsyncInit(ssl, &ssl->decrypt.des3->asyncDev,
                 WC_ASYNC_FLAG_CALL_AGAIN);
             if (ret != 0)
@@ -11260,7 +11374,7 @@ static INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
     #ifdef BUILD_AES
         case wolfssl_aes:
         #ifdef WOLFSSL_ASYNC_CRYPT
-            /* intialize event */
+            /* initialize event */
             ret = wolfSSL_AsyncInit(ssl, &ssl->decrypt.aes->asyncDev,
                 WC_ASYNC_FLAG_CALL_AGAIN);
             if (ret != 0)
@@ -11283,7 +11397,7 @@ static INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
             wc_AesAuthDecryptFunc aes_auth_fn;
 
         #ifdef WOLFSSL_ASYNC_CRYPT
-            /* intialize event */
+            /* initialize event */
             ret = wolfSSL_AsyncInit(ssl, &ssl->decrypt.aes->asyncDev,
                 WC_ASYNC_FLAG_CALL_AGAIN);
             if (ret != 0)
@@ -13417,6 +13531,7 @@ int SendFinished(WOLFSSL* ssl)
 
 
 #ifndef NO_CERTS
+/* handle generation of certificate (11) */
 int SendCertificate(WOLFSSL* ssl)
 {
     int    ret = 0;
@@ -13672,7 +13787,7 @@ int SendCertificate(WOLFSSL* ssl)
     return ret;
 }
 
-
+/* handle generation of certificate_request (13) */
 int SendCertificateRequest(WOLFSSL* ssl)
 {
     byte   *output;
@@ -13900,6 +14015,7 @@ static int BuildCertificateStatus(WOLFSSL* ssl, byte type, buffer* status,
 #endif /* NO_WOLFSSL_SERVER */
 
 
+/* handle generation of certificate_status (22) */
 int SendCertificateStatus(WOLFSSL* ssl)
 {
     int ret = 0;
@@ -16896,6 +17012,7 @@ void PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
 /* client only parts */
 #ifndef NO_WOLFSSL_CLIENT
 
+    /* handle generation of client_hello (1) */
     int SendClientHello(WOLFSSL* ssl)
     {
         byte              *output;
@@ -17127,6 +17244,7 @@ void PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
     }
 
 
+    /* handle processing of DTLS hello_verify_request (3) */
     static int DoHelloVerifyRequest(WOLFSSL* ssl, const byte* input,
                                     word32* inOutIdx, word32 size)
     {
@@ -17312,6 +17430,7 @@ void PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
         return 0;
     }
 
+    /* handle processing of server_hello (2) */
     int DoServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                       word32 helloSz)
     {
@@ -17606,7 +17725,7 @@ void PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
 
 
 #ifndef NO_CERTS
-    /* just read in and ignore for now TODO: */
+    /* handle processing of certificate_request (13) */
     static int DoCertificateRequest(WOLFSSL* ssl, const byte* input, word32*
                                     inOutIdx, word32 size)
     {
@@ -17679,15 +17798,25 @@ void PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
 
         /* don't send client cert or cert verify if user hasn't provided
            cert and private key */
-        if (ssl->buffers.certificate && ssl->buffers.certificate->buffer &&
-            ssl->buffers.key && ssl->buffers.key->buffer)
-            ssl->options.sendVerify = SEND_CERT;
+        if (ssl->buffers.certificate && ssl->buffers.certificate->buffer) {
+        #ifdef HAVE_PK_CALLBACKS
+            if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)) {
+                WOLFSSL_MSG("Using PK for client private key");
+                ssl->options.sendVerify = SEND_CERT;
+            }
+        #endif
+            if (ssl->buffers.key && ssl->buffers.key->buffer) {
+                ssl->options.sendVerify = SEND_CERT;
+            }
+        }
 	#ifdef OPENSSL_EXTRA
 		else
 	#else
         else if (IsTLS(ssl))
 	#endif
+        {
             ssl->options.sendVerify = SEND_BLANK_CERT;
+        }
 
         if (IsEncryptionOn(ssl, 0))
             *inOutIdx += ssl->keys.padSz;
@@ -17802,6 +17931,7 @@ static void FreeDskeArgs(WOLFSSL* ssl, void* pArgs)
 #endif
 }
 
+/* handle processing of server_key_exchange (12) */
 static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                word32* inOutIdx, word32 size)
 {
@@ -18488,11 +18618,10 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 args->sigAlgo, args->hashAlgo,
                                 ssl->peerRsaKey,
                             #ifdef HAVE_PK_CALLBACKS
-                                ssl->buffers.peerRsaKey.buffer,
-                                ssl->buffers.peerRsaKey.length,
+                                &ssl->buffers.peerRsaKey,
                                 ssl->RsaVerifyCtx
                             #else
-                                NULL, 0, NULL
+                                NULL, NULL
                             #endif
                             );
 
@@ -18512,11 +18641,10 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 ssl->buffers.digest.length,
                                 ssl->peerEccDsaKey,
                             #ifdef HAVE_PK_CALLBACKS
-                                ssl->buffers.peerEccDsaKey.buffer,
-                                ssl->buffers.peerEccDsaKey.length,
+                                &ssl->buffers.peerEccDsaKey,
                                 ssl->EccVerifyCtx
                             #else
-                                NULL, 0, NULL
+                                NULL, NULL
                             #endif
                             );
 
@@ -18532,11 +18660,10 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 ssl->buffers.sig.length,
                                 ssl->peerEd25519Key,
                             #ifdef HAVE_PK_CALLBACKS
-                                ssl->buffers.peerEccDsaKey.buffer,
-                                ssl->buffers.peerEccDsaKey.length,
+                                &ssl->buffers.peerEd25519Key,
                                 ssl->Ed25519VerifyCtx
                             #else
-                                NULL, 0, NULL
+                                NULL, NULL
                             #endif
                             );
 
@@ -19156,6 +19283,7 @@ static void FreeSckeArgs(WOLFSSL* ssl, void* pArgs)
     }
 }
 
+/* handle generation client_key_exchange (16) */
 int SendClientKeyExchange(WOLFSSL* ssl)
 {
     int ret = 0;
@@ -19288,7 +19416,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                     }
                 #endif
 
-                    /* create private key */
+                    /* create ephemeral private key */
                     ssl->hsType = DYNAMIC_TYPE_ECC;
                     ret = AllocKey(ssl, ssl->hsType, &ssl->hsKey);
                     if (ret != 0) {
@@ -19347,10 +19475,9 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                 #endif
                 #ifdef HAVE_ECC
                     if (ssl->specs.static_ecdh) {
-                        /* TODO: EccDsa is really fixed Ecc change naming */
-                        if (!ssl->peerEccDsaKey ||
-                                !ssl->peerEccDsaKeyPresent ||
-                                    !ssl->peerEccDsaKey->dp) {
+                        /* Note: EccDsa is really fixed Ecc key here */
+                        if (!ssl->peerEccDsaKey || !ssl->peerEccDsaKeyPresent ||
+                                                   !ssl->peerEccDsaKey->dp) {
                             ERROR_OUT(NO_PEER_KEY, exit_scke);
                         }
                         peerKey = ssl->peerEccDsaKey;
@@ -19366,7 +19493,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         ERROR_OUT(NO_PEER_KEY, exit_scke);
                     }
 
-                    /* create private key */
+                    /* create ephemeral private key */
                     ssl->hsType = DYNAMIC_TYPE_ECC;
                     ret = AllocKey(ssl, ssl->hsType, &ssl->hsKey);
                     if (ret != 0) {
@@ -19704,11 +19831,10 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         args->encSecret, &args->encSz,
                         ssl->peerRsaKey,
                     #if defined(HAVE_PK_CALLBACKS)
-                        ssl->buffers.peerRsaKey.buffer,
-                        ssl->buffers.peerRsaKey.length,
+                        &ssl->buffers.peerRsaKey,
                         ssl->RsaEncCtx
                     #else
-                        NULL, 0, NULL
+                        NULL, NULL
                     #endif
                     );
 
@@ -20163,6 +20289,44 @@ exit_scke:
 
 
 #ifndef NO_CERTS
+
+#ifdef HAVE_PK_CALLBACKS
+    int GetPrivateKeySigSize(WOLFSSL* ssl)
+    {
+        int sigSz = 0;
+
+        if (ssl == NULL)
+            return 0;
+
+        switch (ssl->buffers.keyType) {
+        #ifndef NO_RSA
+        #ifdef WC_RSA_PSS
+            case rsa_pss_sa_algo:
+        #endif
+            case rsa_sa_algo:
+                sigSz = ssl->buffers.keySz;
+                ssl->hsType = DYNAMIC_TYPE_RSA;
+                break;
+        #endif
+        #ifdef HAVE_ECC
+            case ecc_dsa_sa_algo:
+                sigSz = wc_ecc_sig_size_calc(ssl->buffers.keySz);
+                ssl->hsType = DYNAMIC_TYPE_ECC;
+                break;
+        #endif
+        #ifdef HAVE_ED25519
+            case ed25519_sa_algo:
+                sigSz = ED25519_SIG_SIZE; /* fixed known value */
+                ssl->hsType = DYNAMIC_TYPE_ED25519;
+                break;
+        #endif
+            default:
+                break;
+        }
+        return sigSz;
+    }
+#endif /* HAVE_PK_CALLBACKS */
+
 /* Decode the private key - RSA, ECC, or Ed25519 - and creates a key object.
  * The signature type is set as well.
  * The maximum length of a signature is returned.
@@ -20340,6 +20504,7 @@ static void FreeScvArgs(WOLFSSL* ssl, void* pArgs)
     }
 }
 
+/* handle generation of certificate_verify (15) */
 int SendCertificateVerify(WOLFSSL* ssl)
 {
     int ret = 0;
@@ -20406,10 +20571,24 @@ int SendCertificateVerify(WOLFSSL* ssl)
                 goto exit_scv;
             }
 
-            /* Decode private key. */
-            ret = DecodePrivateKey(ssl, &args->length);
-            if (ret != 0) {
-                goto exit_scv;
+            if (ssl->buffers.key == NULL) {
+            #ifdef HAVE_PK_CALLBACKS
+                if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx))
+                    args->length = GetPrivateKeySigSize(ssl);
+                else
+            #endif
+                    ERROR_OUT(NO_PRIVATE_KEY, exit_scv);
+            }
+            else {
+                /* Decode private key. */
+                ret = DecodePrivateKey(ssl, &args->length);
+                if (ret != 0) {
+                    goto exit_scv;
+                }
+            }
+
+            if (args->length <= 0) {
+                ERROR_OUT(NO_PRIVATE_KEY, exit_scv);
             }
 
             /* idx is used to track verify pointer offset to output */
@@ -20514,12 +20693,11 @@ int SendCertificateVerify(WOLFSSL* ssl)
                     ssl->buffers.digest.buffer, ssl->buffers.digest.length,
                     ssl->buffers.sig.buffer, &ssl->buffers.sig.length,
                     key,
-            #if defined(HAVE_PK_CALLBACKS)
-                    ssl->buffers.key->buffer,
-                    ssl->buffers.key->length,
+            #ifdef HAVE_PK_CALLBACKS
+                    ssl->buffers.key,
                     ssl->EccSignCtx
             #else
-                    NULL, 0, NULL
+                    NULL, NULL
             #endif
                 );
             }
@@ -20532,12 +20710,11 @@ int SendCertificateVerify(WOLFSSL* ssl)
                     ssl->buffers.digest.buffer, ssl->buffers.digest.length,
                     ssl->buffers.sig.buffer, &ssl->buffers.sig.length,
                     key,
-            #if defined(HAVE_PK_CALLBACKS)
-                    ssl->buffers.key->buffer,
-                    ssl->buffers.key->length,
+            #ifdef HAVE_PK_CALLBACKS
+                    ssl->buffers.key,
                     ssl->Ed25519SignCtx
             #else
-                    NULL, 0, NULL
+                    NULL, NULL
             #endif
                 );
             }
@@ -20553,7 +20730,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
                     ssl->buffers.sig.buffer, ssl->buffers.sig.length,
                     args->verify + args->extraSz + VERIFY_HEADER, &args->sigSz,
                     args->sigAlgo, ssl->suites->hashAlgo, key,
-                    ssl->buffers.key->buffer, ssl->buffers.key->length,
+                    ssl->buffers.key,
                 #ifdef HAVE_PK_CALLBACKS
                     ssl->RsaSignCtx
                 #else
@@ -20615,7 +20792,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
                     args->verifySig, args->sigSz,
                     ssl->buffers.sig.buffer, ssl->buffers.sig.length,
                     args->sigAlgo, ssl->suites->hashAlgo, key,
-                    ssl->buffers.key->buffer, ssl->buffers.key->length,
+                    ssl->buffers.key,
                 #ifdef HAVE_PK_CALLBACKS
                     ssl->RsaSignCtx
                 #else
@@ -20790,6 +20967,7 @@ int SetTicket(WOLFSSL* ssl, const byte* ticket, word32 length)
     return 0;
 }
 
+/* handle processing of session_ticket (4) */
 static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     word32 size)
 {
@@ -20842,6 +21020,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
 #ifndef NO_WOLFSSL_SERVER
 
+    /* handle generation of server_hello (2) */
     int SendServerHello(WOLFSSL* ssl)
     {
         byte              *output;
@@ -21180,6 +21359,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         (void)args;
     }
 
+    /* handle generation of server_key_exchange (12) */
     int SendServerKeyExchange(WOLFSSL* ssl)
     {
         int ret;
@@ -21238,12 +21418,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         if (ssl->specs.static_ecdh) {
                             WOLFSSL_MSG("Using Static ECDH, not sending ServerKeyExchange");
                             ERROR_OUT(0, exit_sske);
-                        }
-
-                        /* make sure private key exists */
-                        if (ssl->buffers.key == NULL ||
-                                            ssl->buffers.key->buffer == NULL) {
-                            ERROR_OUT(NO_PRIVATE_KEY, exit_sske);
                         }
 
                         WOLFSSL_MSG("Using ephemeral ECDH");
@@ -21364,8 +21538,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         }
 
                         if (ssl->eccTempKeyPresent == 0) {
-                            /* TODO: Need to first do wc_EccPrivateKeyDecode,
-                                then we know curve dp */
                             ret = EccMakeKey(ssl, ssl->eccTempKey, NULL);
                             if (ret == 0 || ret == WC_PENDING_E) {
                                 ssl->eccTempKeyPresent = DYNAMIC_TYPE_ECC;
@@ -21660,8 +21832,20 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         preSigSz  = args->length;
                         preSigIdx = args->idx;
 
-                        switch(ssl->suites->sigAlgo)
-                        {
+                        if (ssl->buffers.key == NULL) {
+                        #ifdef HAVE_PK_CALLBACKS
+                            if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)) {
+                                args->tmpSigSz = GetPrivateKeySigSize(ssl);
+                                if (args->tmpSigSz <= 0) {
+                                    ERROR_OUT(NO_PRIVATE_KEY, exit_sske);
+                                }
+                            }
+                            else
+                        #endif
+                                ERROR_OUT(NO_PRIVATE_KEY, exit_sske);
+                        }
+                        else {
+                            switch(ssl->suites->sigAlgo) {
                         #ifndef NO_RSA
                         #ifdef WC_RSA_PSS
                             case rsa_pss_sa_algo:
@@ -21669,7 +21853,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             case rsa_sa_algo:
                             {
                                 word32 i = 0;
-                                int    keySz;
+                                int keySz;
 
                                 ssl->hsType = DYNAMIC_TYPE_RSA;
                                 ret = AllocKey(ssl, ssl->hsType, &ssl->hsKey);
@@ -21724,8 +21908,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                 if (wc_ecc_size((ecc_key*)ssl->hsKey) <
                                         ssl->options.minEccKeySz) {
                                     WOLFSSL_MSG("ECC key size too small");
-                                    ret = ECC_KEY_SIZE_E;
-                                    goto exit_sske;
+                                    ERROR_OUT(ECC_KEY_SIZE_E, exit_sske);
                                 }
                                 break;
                             }
@@ -21748,6 +21931,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                 if (ret != 0) {
                                     goto exit_sske;
                                 }
+
                                 /* worst case estimate */
                                 args->tmpSigSz = ED25519_SIG_SIZE;
 
@@ -21755,15 +21939,15 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                 if (ED25519_KEY_SIZE <
                                         ssl->options.minEccKeySz) {
                                     WOLFSSL_MSG("Ed25519 key size too small");
-                                    ret = ECC_KEY_SIZE_E;
-                                    goto exit_sske;
+                                    ERROR_OUT(ECC_KEY_SIZE_E, exit_sske);
                                 }
                                 break;
                             }
-                        #endif
+                        #endif /* HAVE_ED25519 */
                             default:
                                 ERROR_OUT(ALGO_ID_E, exit_sske);  /* unsupported type */
-                        } /* switch(ssl->specs.sig_algo) */
+                            } /* switch(ssl->specs.sig_algo) */
+                        }
 
                         /* sig length */
                         args->length += LENGTH_SZ;
@@ -21951,34 +22135,43 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         preSigSz  = args->length;
 
                         if (!ssl->options.usingAnon_cipher) {
-                            word32   i = 0;
-                            int      keySz;
-
-                            /* make sure private key exists */
-                            if (ssl->buffers.key == NULL ||
-                                            ssl->buffers.key->buffer == NULL) {
-                                ERROR_OUT(NO_PRIVATE_KEY, exit_sske);
-                            }
-
-                            ssl->hsType = DYNAMIC_TYPE_RSA;
-                            ret = AllocKey(ssl, ssl->hsType, &ssl->hsKey);
-                            if (ret != 0) {
-                                goto exit_sske;
-                            }
+                            int keySz;
 
                             /* sig length */
                             args->length += LENGTH_SZ;
 
-                            ret = wc_RsaPrivateKeyDecode(
-                                ssl->buffers.key->buffer, &i,
-                                (RsaKey*)ssl->hsKey, ssl->buffers.key->length);
-                            if (ret != 0) {
-                                goto exit_sske;
+                            if (ssl->buffers.key == NULL) {
+                            #ifdef HAVE_PK_CALLBACKS
+                                if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx))
+                                    keySz = (word32)GetPrivateKeySigSize(ssl);
+                                else
+                            #endif
+                                    ERROR_OUT(NO_PRIVATE_KEY, exit_sske);
                             }
-                            keySz = wc_RsaEncryptSize((RsaKey*)ssl->hsKey);
-                            if (keySz < 0) { /* test if keySz has error */
+                            else
+                            {
+                                word32 i = 0;
+
+                                ssl->hsType = DYNAMIC_TYPE_RSA;
+                                ret = AllocKey(ssl, ssl->hsType, &ssl->hsKey);
+                                if (ret != 0) {
+                                    goto exit_sske;
+                                }
+
+                                ret = wc_RsaPrivateKeyDecode(
+                                    ssl->buffers.key->buffer, &i,
+                                    (RsaKey*)ssl->hsKey,
+                                    ssl->buffers.key->length);
+                                if (ret != 0) {
+                                    goto exit_sske;
+                                }
+                                keySz = wc_RsaEncryptSize((RsaKey*)ssl->hsKey);
+                            }
+
+                            if (keySz <= 0) { /* test if keySz has error */
                                 ERROR_OUT(keySz, exit_sske);
                             }
+
                             args->tmpSigSz = (word32)keySz;
                             args->length += args->tmpSigSz;
 
@@ -22208,8 +22401,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                     &args->sigSz,
                                     ssl->suites->sigAlgo, ssl->suites->hashAlgo,
                                     key,
-                                    ssl->buffers.key->buffer,
-                                    ssl->buffers.key->length,
+                                    ssl->buffers.key,
                             #ifdef HAVE_PK_CALLBACKS
                                     ssl->RsaSignCtx
                             #else
@@ -22229,12 +22421,11 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                     args->output + LENGTH_SZ + args->idx,
                                     &args->sigSz,
                                     key,
-                            #if defined(HAVE_PK_CALLBACKS)
-                                    ssl->buffers.key->buffer,
-                                    ssl->buffers.key->length,
+                            #ifdef HAVE_PK_CALLBACKS
+                                    ssl->buffers.key,
                                     ssl->EccSignCtx
                             #else
-                                    NULL, 0, NULL
+                                    NULL, NULL
                             #endif
                                 );
                                 break;
@@ -22249,12 +22440,11 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                     args->output + LENGTH_SZ + args->idx,
                                     &args->sigSz,
                                     key,
-                            #if defined(HAVE_PK_CALLBACKS)
-                                    ssl->buffers.key->buffer,
-                                    ssl->buffers.key->length,
+                            #ifdef HAVE_PK_CALLBACKS
+                                    ssl->buffers.key,
                                     ssl->Ed25519SignCtx
                             #else
-                                    NULL, 0, NULL
+                                    NULL, NULL
                             #endif
                                 );
                                 break;
@@ -22289,8 +22479,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                     &args->sigSz,
                                     ssl->suites->sigAlgo, ssl->suites->hashAlgo,
                                     key,
-                                    ssl->buffers.key->buffer,
-                                    ssl->buffers.key->length,
+                                    ssl->buffers.key,
                                 #ifdef HAVE_PK_CALLBACKS
                                     ssl->RsaSignCtx
                                 #else
@@ -22375,8 +22564,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                     ssl->buffers.sig.buffer,
                                     ssl->buffers.sig.length,
                                     ssl->suites->sigAlgo, ssl->suites->hashAlgo,
-                                    key, ssl->buffers.key->buffer,
-                                    ssl->buffers.key->length,
+                                    key, ssl->buffers.key,
                                 #ifdef HAVE_PK_CALLBACKS
                                     ssl->RsaSignCtx
                                 #else
@@ -22453,8 +22641,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                     ssl->buffers.sig.buffer,
                                     ssl->buffers.sig.length,
                                     ssl->suites->sigAlgo, ssl->suites->hashAlgo,
-                                    key, ssl->buffers.key->buffer,
-                                    ssl->buffers.key->length,
+                                    key, ssl->buffers.key,
                                 #ifdef HAVE_PK_CALLBACKS
                                     ssl->RsaSignCtx
                                 #else
@@ -22994,6 +23181,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #endif /* OLD_HELLO_ALLOWED */
 
 
+    /* handle processing of client_hello (1) */
     int DoClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                              word32 helloSz)
     {
@@ -23557,6 +23745,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         (void)args;
     }
 
+    /* handle processing of certificate_verify (15) */
     static int DoCertificateVerify(WOLFSSL* ssl, byte* input,
                                 word32* inOutIdx, word32 size)
     {
@@ -23702,11 +23891,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         args->sigAlgo, args->hashAlgo,
                         ssl->peerRsaKey,
                     #ifdef HAVE_PK_CALLBACKS
-                        ssl->buffers.peerRsaKey.buffer,
-                        ssl->buffers.peerRsaKey.length,
+                        &ssl->buffers.peerRsaKey,
                         ssl->RsaVerifyCtx
                     #else
-                        NULL, 0, NULL
+                        NULL, NULL
                     #endif
                     );
                     if (ret >= 0) {
@@ -23729,11 +23917,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         ssl->buffers.digest.buffer, ssl->buffers.digest.length,
                         ssl->peerEccDsaKey,
                     #ifdef HAVE_PK_CALLBACKS
-                        ssl->buffers.peerEccDsaKey.buffer,
-                        ssl->buffers.peerEccDsaKey.length,
+                        &ssl->buffers.peerEccDsaKey,
                         ssl->EccVerifyCtx
                     #else
-                        NULL, 0, NULL
+                        NULL, NULL
                     #endif
                     );
                 }
@@ -23871,6 +24058,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
 #endif /* !NO_RSA || HAVE_ECC */
 
+    /* handle generation of server_hello_done (14) */
     int SendServerHelloDone(WOLFSSL* ssl)
     {
         byte* output;
@@ -24189,6 +24377,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
 
 #ifdef WOLFSSL_DTLS
+    /* handle generation of DTLS hello_verify_request (3) */
     static int SendHelloVerifyRequest(WOLFSSL* ssl,
                                       const byte* cookie, byte cookieSz)
     {
@@ -24259,6 +24448,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         (void)args;
     }
 
+    /* handle processing client_key_exchange (16) */
     static int DoClientKeyExchange(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                                     word32 size)
     {
@@ -24345,11 +24535,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 #ifndef NO_RSA
                     case rsa_kea:
                     {
-                        /* make sure private key exists */
-                        if (ssl->buffers.key == NULL ||
-                                            ssl->buffers.key->buffer == NULL) {
-                            ERROR_OUT(NO_PRIVATE_KEY, exit_dcke);
-                        }
                         break;
                     } /* rsa_kea */
                 #endif /* !NO_RSA */
@@ -24935,18 +25120,18 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                     case rsa_kea:
                     {
                         RsaKey* key = (RsaKey*)ssl->hsKey;
+
                         ret = RsaDec(ssl,
                             input + args->idx,
                             args->length,
                             &args->output,
                             &args->sigSz,
                             key,
-                        #if defined(HAVE_PK_CALLBACKS)
-                            ssl->buffers.key->buffer,
-                            ssl->buffers.key->length,
+                        #ifdef HAVE_PK_CALLBACKS
+                            ssl->buffers.key,
                             ssl->RsaDecCtx
                         #else
-                            NULL, 0, NULL
+                            NULL, NULL
                         #endif
                         );
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -3953,6 +3953,7 @@ int DhAgree(WOLFSSL* ssl, DhKey* dhKey,
 int wolfSSL_CTX_IsPrivatePkSet(WOLFSSL_CTX* ctx)
 {
     int pkcbset = 0;
+    (void)ctx;
 #if defined(HAVE_ECC) || defined(HAVE_ED25519) || !defined(NO_RSA)
     if (0
     #ifdef HAVE_ECC

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -1616,7 +1616,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
             #ifdef BUILD_AESGCM
                 case wolfssl_aes_gcm:
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    /* intialize event */
+                    /* initialize event */
                     asyncDev = &ssl->encrypt.aes->asyncDev;
                     ret = wolfSSL_AsyncInit(ssl, asyncDev, event_flags);
                     if (ret != 0)
@@ -1633,7 +1633,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
             #ifdef HAVE_AESCCM
                 case wolfssl_aes_ccm:
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    /* intialize event */
+                    /* initialize event */
                     asyncDev = &ssl->encrypt.aes->asyncDev;
                     ret = wolfSSL_AsyncInit(ssl, asyncDev, event_flags);
                     if (ret != 0)
@@ -1841,7 +1841,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
             #ifdef BUILD_AESGCM
                 case wolfssl_aes_gcm:
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    /* intialize event */
+                    /* initialize event */
                     ret = wolfSSL_AsyncInit(ssl, &ssl->decrypt.aes->asyncDev,
                         WC_ASYNC_FLAG_CALL_AGAIN);
                     if (ret != 0)
@@ -1864,7 +1864,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
             #ifdef HAVE_AESCCM
                 case wolfssl_aes_ccm:
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    /* intialize event */
+                    /* initialize event */
                     ret = wolfSSL_AsyncInit(ssl, &ssl->decrypt.aes->asyncDev,
                         WC_ASYNC_FLAG_CALL_AGAIN);
                     if (ret != 0)
@@ -2261,6 +2261,7 @@ static int WritePSKBinders(WOLFSSL* ssl, byte* output, word32 idx)
 }
 #endif
 
+/* handle generation of TLS 1.3 client_hello (1) */
 /* Send a ClientHello message to the server.
  * Include the information required to start a handshake with servers using
  * protocol versions less than TLS v1.3.
@@ -2536,6 +2537,7 @@ static int RestartHandshakeHash(WOLFSSL* ssl)
 #endif
 
 #ifdef WOLFSSL_TLS13_DRAFT_18
+/* handle rocessing of TLS 1.3 hello_retry_request (6) */
 /* Parse and handle a HelloRetryRequest message.
  * Only a client will receive this message.
  *
@@ -2615,6 +2617,7 @@ static byte helloRetryRequestRandom[] = {
 };
 #endif
 
+/* handle processing of TLS 1.3 server_hello (2) and hello_retry_request (6) */
 /* Handle the ServerHello message from the server.
  * Only a client will receive this message.
  *
@@ -2859,6 +2862,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     return ret;
 }
 
+/* handle processing TLS 1.3 encrypted_extensions (8) */
 /* Parse and handle an EncryptedExtensions message.
  * Only a client will receive this message.
  *
@@ -2918,6 +2922,7 @@ static int DoTls13EncryptedExtensions(WOLFSSL* ssl, const byte* input,
     return ret;
 }
 
+/* handle processing TLS v1.3 certificate_request (13) */
 /* Handle a TLS v1.3 CertificateRequest message.
  * This message is always encrypted.
  * Only a client will receive this message.
@@ -3522,6 +3527,7 @@ static int RestartHandshakeHashWithCookie(WOLFSSL* ssl, Cookie* cookie)
 }
 #endif
 
+/* handle processing of TLS 1.3 client_hello (1) */
 /* Handle a ClientHello handshake message.
  * If the protocol version in the message is not TLS v1.3 or higher, use
  * DoClientHello()
@@ -3729,6 +3735,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 }
 
 #ifdef WOLFSSL_TLS13_DRAFT_18
+/* handle generation of TLS 1.3 hello_retry_request (6) */
 /* Send the HelloRetryRequest message to indicate the negotiated protocol
  * version and security parameters the server is willing to use.
  * Only a server will send this message.
@@ -3813,6 +3820,7 @@ int SendTls13HelloRetryRequest(WOLFSSL* ssl)
 #ifdef WOLFSSL_TLS13_DRAFT_18
 static
 #endif
+/* handle generation of TLS 1.3 server_hello (2) */
 int SendTls13ServerHello(WOLFSSL* ssl, byte extMsgType)
 {
     byte*  output;
@@ -3940,6 +3948,7 @@ int SendTls13ServerHello(WOLFSSL* ssl, byte extMsgType)
     return ret;
 }
 
+/* handle generation of TLS 1.3 encrypted_extensions (8) */
 /* Send the rest of the extensions encrypted under the handshake key.
  * This message is always encrypted in TLS v1.3.
  * Only a server will send this message.
@@ -4029,6 +4038,7 @@ static int SendTls13EncryptedExtensions(WOLFSSL* ssl)
 }
 
 #ifndef NO_CERTS
+/* handle generation TLS v1.3 certificate_request (13) */
 /* Send the TLS v1.3 CertificateRequest message.
  * This message is always encrypted in TLS v1.3.
  * Only a server will send this message.
@@ -4550,6 +4560,7 @@ static word32 AddCertExt(byte* cert, word32 len, word32 idx, word32 fragSz,
     return i;
 }
 
+/* handle generation TLS v1.3 certificate (11) */
 /* Send the certificate for this end and any CAs that help with validation.
  * This message is always encrypted in TLS v1.3.
  *
@@ -4799,6 +4810,7 @@ static void FreeScv13Args(WOLFSSL* ssl, void* pArgs)
     }
 }
 
+/* handle generation TLS v1.3 certificate_verify (15) */
 /* Send the TLS v1.3 CertificateVerify message.
  * A hash of all the message so far is used.
  * The signed data is:
@@ -4874,9 +4886,23 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
             args->verify =
                           &args->output[RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ];
 
-            ret = DecodePrivateKey(ssl, &args->length);
-            if (ret != 0)
-                goto exit_scv;
+            if (ssl->buffers.key == NULL) {
+            #ifdef HAVE_PK_CALLBACKS
+                if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx))
+                    args->length = GetPrivateKeySigSize(ssl);
+                else
+            #endif
+                    ERROR_OUT(NO_PRIVATE_KEY, exit_scv);
+            }
+            else {
+                ret = DecodePrivateKey(ssl, &args->length);
+                if (ret != 0)
+                    goto exit_scv;
+            }
+
+            if (args->length <= 0) {
+                ERROR_OUT(NO_PRIVATE_KEY, exit_scv);
+            }
 
             /* Add signature algorithm. */
             if (ssl->hsType == DYNAMIC_TYPE_RSA)
@@ -4952,11 +4978,11 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 ret = EccSign(ssl, args->sigData, args->sigDataSz,
                     args->verify + HASH_SIG_SIZE + VERIFY_HEADER,
                     &sig->length, (ecc_key*)ssl->hsKey,
-            #if defined(HAVE_PK_CALLBACKS)
-                    ssl->buffers.key->buffer, ssl->buffers.key->length,
+            #ifdef HAVE_PK_CALLBACKS
+                    ssl->buffers.key,
                     ssl->EccSignCtx
             #else
-                    NULL, 0, NULL
+                    NULL, NULL
             #endif
                 );
                 args->length = sig->length;
@@ -4967,11 +4993,11 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 ret = Ed25519Sign(ssl, args->sigData, args->sigDataSz,
                     args->verify + HASH_SIG_SIZE + VERIFY_HEADER,
                     &sig->length, (ed25519_key*)ssl->hsKey,
-            #if defined(HAVE_PK_CALLBACKS)
-                    ssl->buffers.key->buffer, ssl->buffers.key->length,
+            #ifdef HAVE_PK_CALLBACKS
+                    ssl->buffers.key,
                     ssl->Ed25519SignCtx
             #else
-                    NULL, 0, NULL
+                    NULL, NULL
             #endif
                 );
                 args->length = sig->length;
@@ -4984,7 +5010,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                     args->verify + HASH_SIG_SIZE + VERIFY_HEADER, &args->sigLen,
                     args->sigAlgo, ssl->suites->hashAlgo,
                     (RsaKey*)ssl->hsKey,
-                    ssl->buffers.key->buffer, ssl->buffers.key->length,
+                    ssl->buffers.key,
                 #ifdef HAVE_PK_CALLBACKS
                     ssl->RsaSignCtx
                 #else
@@ -5027,7 +5053,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 ret = VerifyRsaSign(ssl, args->verifySig, args->sigLen,
                     sig->buffer, sig->length, args->sigAlgo,
                     ssl->suites->hashAlgo, (RsaKey*)ssl->hsKey,
-                    ssl->buffers.key->buffer, ssl->buffers.key->length,
+                    ssl->buffers.key,
                 #ifdef HAVE_PK_CALLBACKS
                     ssl->RsaSignCtx
                 #else
@@ -5115,7 +5141,7 @@ exit_scv:
     return ret;
 }
 
-
+/* handle processing TLS v1.3 certificate (11) */
 /* Parse and handle a TLS v1.3 Certificate message.
  *
  * ssl       The SSL/TLS object.
@@ -5177,6 +5203,7 @@ static void FreeDcv13Args(WOLFSSL* ssl, void* pArgs)
     (void)ssl;
 }
 
+/* handle processing TLS v1.3 certificate_verify (15) */
 /* Parse and handle a TLS v1.3 CertificateVerify message.
  *
  * ssl       The SSL/TLS object.
@@ -5342,11 +5369,10 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                 ret = RsaVerify(ssl, sig->buffer, sig->length, &args->output,
                     args->sigAlgo, args->hashAlgo, ssl->peerRsaKey,
                 #ifdef HAVE_PK_CALLBACKS
-                    ssl->buffers.peerRsaKey.buffer,
-                    ssl->buffers.peerRsaKey.length,
+                    &ssl->buffers.peerRsaKey,
                     ssl->RsaVerifyCtx
                 #else
-                    NULL, 0, NULL
+                    NULL, NULL
                 #endif
                 );
                 if (ret >= 0) {
@@ -5363,11 +5389,10 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                     args->sigData, args->sigDataSz,
                     ssl->peerEccDsaKey,
                 #ifdef HAVE_PK_CALLBACKS
-                    ssl->buffers.peerEccDsaKey.buffer,
-                    ssl->buffers.peerEccDsaKey.length,
+                    &ssl->buffers.peerEccDsaKey,
                     ssl->EccVerifyCtx
                 #else
-                    NULL, 0, NULL
+                    NULL, NULL
                 #endif
                 );
             }
@@ -5380,11 +5405,10 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                     args->sigData, args->sigDataSz,
                     ssl->peerEd25519Key,
                 #ifdef HAVE_PK_CALLBACKS
-                    ssl->buffers.peerEd25519Key.buffer,
-                    ssl->buffers.peerEd25519Key.length,
+                    &ssl->buffers.peerEd25519Key,
                     ssl->Ed25519VerifyCtx
                 #else
-                    NULL, 0, NULL
+                    NULL, NULL
                 #endif
                 );
             }
@@ -5698,6 +5722,7 @@ static int SendTls13Finished(WOLFSSL* ssl)
     return ret;
 }
 
+/* handle generation TLS v1.3 key_update (24) */
 /* Send the TLS v1.3 KeyUpdate message.
  *
  * ssl  The SSL/TLS object.
@@ -5769,6 +5794,7 @@ static int SendTls13KeyUpdate(WOLFSSL* ssl)
     return ret;
 }
 
+/* handle processing TLS v1.3 key_update (24) */
 /* Parse and handle a TLS v1.3 KeyUpdate message.
  *
  * ssl       The SSL/TLS object.
@@ -5880,6 +5906,7 @@ static int SendTls13EndOfEarlyData(WOLFSSL* ssl)
 #endif /* !NO_WOLFSSL_CLIENT */
 
 #ifndef NO_WOLFSSL_SERVER
+/* handle processing of TLS 1.3 end_of_early_data (5) */
 /* Parse the TLS v1.3 EndOfEarlyData message that indicates that there will be
  * no more early application data.
  * The decryption key now changes to the pre-calculated handshake key.
@@ -7324,16 +7351,27 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
     }
 
 #ifndef NO_CERTS
-    /* in case used set_accept_state after init */
-    if (!havePSK && !haveAnon &&
-        (!ssl->buffers.certificate ||
-         !ssl->buffers.certificate->buffer ||
-         !ssl->buffers.key ||
-         !ssl->buffers.key->buffer)) {
-        WOLFSSL_MSG("accept error: don't have server cert and key");
-        ssl->error = NO_PRIVATE_KEY;
-        WOLFSSL_ERROR(ssl->error);
-        return WOLFSSL_FATAL_ERROR;
+    /* allow no private key if using PK callbacks and CB is set */
+    if (!havePSK && !haveAnon) {
+        if (!ssl->buffers.certificate ||
+            !ssl->buffers.certificate->buffer) {
+
+            WOLFSSL_MSG("accept error: server cert required");
+            WOLFSSL_ERROR(ssl->error = NO_PRIVATE_KEY);
+            return WOLFSSL_FATAL_ERROR;
+        }
+
+    #ifdef HAVE_PK_CALLBACKS
+        if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)) {
+            WOLFSSL_MSG("Using PK for server private key");
+        }
+        else
+    #endif
+        if (!ssl->buffers.key || !ssl->buffers.key->buffer) {
+            WOLFSSL_MSG("accept error: server key required");
+            WOLFSSL_ERROR(ssl->error = NO_PRIVATE_KEY);
+            return WOLFSSL_FATAL_ERROR;
+        }
     }
 #endif
 

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -231,7 +231,7 @@ static int execute_test_case(int svr_argc, char** svr_argv,
     }
 #endif
 
-    /* Build Client Command */
+    /* Build Server Command */
     if (addNoVerify) {
         printf("repeating test with client cert request off\n");
         if (svrArgs.argc >= MAX_ARGS)
@@ -261,6 +261,9 @@ static int execute_test_case(int svr_argc, char** svr_argv,
         else
             svr_argv[svrArgs.argc++] = forceDefCipherListFlag;
     }
+#ifdef TEST_PK_PRIVKEY
+    svr_argv[svrArgs.argc++] = (char*)"-P";
+#endif
 
     /* update server flags list */
     commandLine[0] = '\0';
@@ -321,6 +324,9 @@ static int execute_test_case(int svr_argc, char** svr_argv,
         else
             cli_argv[cliArgs.argc++] = forceDefCipherListFlag;
     }
+#ifdef TEST_PK_PRIVKEY
+    cli_argv[cliArgs.argc++] = (char*)"-P";
+#endif
 
     commandLine[0] = '\0';
     added = 0;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5877,6 +5877,10 @@ int wc_ecc_size(ecc_key* key)
     return key->dp->size;
 }
 
+int wc_ecc_sig_size_calc(int sz)
+{
+    return (sz * 2) + SIG_HEADER_SZ + ECC_MAX_PAD_SZ;
+}
 
 /* worst case estimate, check actual return from wc_ecc_sign_hash for actual
    value of signature size in octets */
@@ -5886,7 +5890,7 @@ int wc_ecc_sig_size(ecc_key* key)
     if (sz <= 0)
         return sz;
 
-    return (sz * 2) + SIG_HEADER_SZ + ECC_MAX_PAD_SZ;
+    return wc_ecc_sig_size_calc(sz);
 }
 
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -722,6 +722,7 @@ static int RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
 #endif /* !WC_NO_RSA_OAEP */
 
 #ifdef WC_RSA_PSS
+
 /* 0x00 .. 0x00 0x01 | Salt | Gen Hash | 0xbc
  * XOR MGF over all bytes down to end of Salt
  * Gen Hash = HASH(8 * 0x00 | Message Hash | Salt)
@@ -774,7 +775,7 @@ static int RsaPad_PSS(const byte* input, word32 inputLen, byte* pkcsBlock,
     h = pkcsBlock + pkcsBlockLen - 1 - hLen;
     if ((ret = wc_Hash(hType, s, (word32)(m - s), h, hLen)) != 0)
         return ret;
-    pkcsBlock[pkcsBlockLen - 1] = 0xbc;
+    pkcsBlock[pkcsBlockLen - 1] = RSA_PSS_PAD_TERM;
 
     ret = RsaMGF(mgf, h, hLen, pkcsBlock, pkcsBlockLen - hLen - 1, heap);
     if (ret != 0)
@@ -1028,8 +1029,8 @@ static int RsaUnPad_PSS(byte *pkcsBlock, unsigned int pkcsBlockLen,
     if ((int)pkcsBlockLen - hLen - 1 < saltLen + 2)
         return PSS_SALTLEN_E;
 
-    if (pkcsBlock[pkcsBlockLen - 1] != 0xbc) {
-        WOLFSSL_MSG("RsaUnPad_PSS: Padding Error 0xBC");
+    if (pkcsBlock[pkcsBlockLen - 1] != RSA_PSS_PAD_TERM) {
+        WOLFSSL_MSG("RsaUnPad_PSS: Padding Term Error");
         return BAD_PADDING_E;
     }
 
@@ -2139,7 +2140,7 @@ int wc_RsaPSS_Verify_ex(byte* in, word32 inLen, byte* out, word32 outLen,
  * Salt length is equal to hash length.
  *
  * in        Hash of the data that is being verified.
- * inSz      Length of hash.     
+ * inSz      Length of hash.
  * sig       Buffer holding PSS data.
  * sigSz     Size of PSS data.
  * hashType  Hash algorithm.
@@ -2156,7 +2157,7 @@ int wc_RsaPSS_CheckPadding(const byte* in, word32 inSz, byte* sig,
 /* Checks the PSS data to ensure that the signature matches.
  *
  * in        Hash of the data that is being verified.
- * inSz      Length of hash.     
+ * inSz      Length of hash.
  * sig       Buffer holding PSS data.
  * sigSz     Size of PSS data.
  * hashType  Hash algorithm.

--- a/wolfcrypt/user-crypto/src/rsa.c
+++ b/wolfcrypt/user-crypto/src/rsa.c
@@ -162,7 +162,7 @@ int wc_Rsa_unsigned_bin_size(void* bn)
 #define MP_OKAY 0
 #endif
 
-/* extract the bn value to a unsigned byte array and return MP_OKAY on succes */
+/* extract the bn value to a unsigned byte array and return MP_OKAY on success */
 int wc_Rsa_to_unsigned_bin(void* bn, byte* in, int inLen)
 {
     if (ippsGetOctString_BN((Ipp8u*)in, inLen, bn) != ippStsNoErr) {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1492,6 +1492,9 @@ WOLFSSL_LOCAL int  CheckVersion(WOLFSSL *ssl, ProtocolVersion pv);
 WOLFSSL_LOCAL void PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
                                    word32 hashSigAlgoSz);
 WOLFSSL_LOCAL int  DecodePrivateKey(WOLFSSL *ssl, word16* length);
+#ifdef HAVE_PK_CALLBACKS
+WOLFSSL_LOCAL int GetPrivateKeySigSize(WOLFSSL* ssl);
+#endif
 WOLFSSL_LOCAL void FreeKeyExchange(WOLFSSL* ssl);
 WOLFSSL_LOCAL int  ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx, word32 size);
 WOLFSSL_LOCAL int  MatchDomainName(const char* pattern, int len, const char* str);
@@ -3837,25 +3840,25 @@ WOLFSSL_LOCAL int SetTicket(WOLFSSL*, const byte*, word32);
         #endif
         WOLFSSL_LOCAL int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig,
             word32 sigSz, const byte* plain, word32 plainSz, int sigAlgo,
-            int hashAlgo, RsaKey* key, const byte* keyBuf, word32 keySz, void* ctx);
+            int hashAlgo, RsaKey* key, DerBuffer* keyBufInfo, void* ctx);
         WOLFSSL_LOCAL int RsaSign(WOLFSSL* ssl, const byte* in, word32 inSz,
             byte* out, word32* outSz, int sigAlgo, int hashAlgo, RsaKey* key,
-            const byte* keyBuf, word32 keySz, void* ctx);
+            DerBuffer* keyBufInfo, void* ctx);
         WOLFSSL_LOCAL int RsaVerify(WOLFSSL* ssl, byte* in, word32 inSz,
             byte** out, int sigAlgo, int hashAlgo, RsaKey* key,
-            const byte* keyBuf, word32 keySz, void* ctx);
+            buffer* keyBufInfo, void* ctx);
         WOLFSSL_LOCAL int RsaDec(WOLFSSL* ssl, byte* in, word32 inSz, byte** out,
-            word32* outSz, RsaKey* key, const byte* keyBuf, word32 keySz, void* ctx);
+            word32* outSz, RsaKey* key, DerBuffer* keyBufInfo, void* ctx);
         WOLFSSL_LOCAL int RsaEnc(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
-            word32* outSz, RsaKey* key, const byte* keyBuf, word32 keySz, void* ctx);
+            word32* outSz, RsaKey* key, buffer* keyBufInfo, void* ctx);
     #endif /* !NO_RSA */
 
     #ifdef HAVE_ECC
         WOLFSSL_LOCAL int EccSign(WOLFSSL* ssl, const byte* in, word32 inSz,
-            byte* out, word32* outSz, ecc_key* key, byte* keyBuf, word32 keySz,
+            byte* out, word32* outSz, ecc_key* key, DerBuffer* keyBufInfo,
             void* ctx);
         WOLFSSL_LOCAL int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz,
-            const byte* out, word32 outSz, ecc_key* key, byte* keyBuf, word32 keySz,
+            const byte* out, word32 outSz, ecc_key* key, buffer* keyBufInfo,
             void* ctx);
         WOLFSSL_LOCAL int EccSharedSecret(WOLFSSL* ssl, ecc_key* priv_key,
             ecc_key* pub_key, byte* pubKeyDer, word32* pubKeySz, byte* out,
@@ -3863,11 +3866,11 @@ WOLFSSL_LOCAL int SetTicket(WOLFSSL*, const byte*, word32);
     #endif /* HAVE_ECC */
     #ifdef HAVE_ED25519
         WOLFSSL_LOCAL int Ed25519Sign(WOLFSSL* ssl, const byte* in, word32 inSz,
-            byte* out, word32* outSz, ed25519_key* key, byte* keyBuf,
-            word32 keySz, void* ctx);
+            byte* out, word32* outSz, ed25519_key* key, DerBuffer* keyBufInfo,
+            void* ctx);
         WOLFSSL_LOCAL int Ed25519Verify(WOLFSSL* ssl, const byte* in,
             word32 inSz, const byte* msg, word32 msgSz, ed25519_key* key,
-            byte* keyBuf, word32 keySz, void* ctx);
+            buffer* keyBufInfo, void* ctx);
     #endif /* HAVE_ED25519 */
 
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2860,6 +2860,10 @@ WOLFSSL_API void wolfSSL_EC_POINT_dump(const char *msg, const WOLFSSL_EC_POINT *
 
 #endif /* OPENSSL_EXTRA */
 
+#ifdef HAVE_PK_CALLBACKS
+WOLFSSL_API int wolfSSL_CTX_IsPrivatePkSet(WOLFSSL_CTX* ctx);
+#endif
+
 #ifdef __cplusplus
     }  /* extern "C" */
 #endif

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -541,6 +541,8 @@ int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
 WOLFSSL_API
 int wc_ecc_size(ecc_key* key);
 WOLFSSL_API
+int wc_ecc_sig_size_calc(int sz);
+WOLFSSL_API
 int wc_ecc_sig_size(ecc_key* key);
 
 WOLFSSL_API

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -103,8 +103,11 @@ enum {
 
 #ifdef OPENSSL_EXTRA
     RSA_PKCS1_PADDING_SIZE = 11,
-    RSA_PKCS1_OAEP_PADDING_SIZE = 42 /* (2 * hashlen(SHA-1)) + 2 */
-  #endif
+    RSA_PKCS1_OAEP_PADDING_SIZE = 42, /* (2 * hashlen(SHA-1)) + 2 */
+#endif
+#ifdef WC_RSA_PSS
+    RSA_PSS_PAD_TERM = 0xBC,
+#endif
 };
 
 /* RSA */


### PR DESCRIPTION
* Added support for not loading a private key for server or client when `HAVE_PK_CALLBACK` is defined and the private PK callback is set. Tested with all cipher suites, TLS 1.2/1.3, client/server certs, RSA/ECC/ED25519.
* Added PK callback context tests for client/server examples (`SetupPkCallbackContexts`).
* Added new test define for `TEST_PK_PRIVKEY` to allows simulating hardware based private key.
* Added new test.h function for loading PEM key file and converting to DER (`load_key_file`).
* Added way to get private key signature size (`GetPrivateKeySigSize`).
* Added new ECC API `wc_ecc_sig_size_calc` to return max signature size for a key size.
* Added inline comments to help track down handshake message types.
* Cleanup of RSS PSS terminating byte (0xbc) to use enum value.
* Fixed bug with PK callback for `myEccVerify` public key format.
* Fixed bug with PK callback for ED25519 verify key buffer in DoServerKeyExchange.