### PR TITLE
Nitrox V fixes and additions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3290,8 +3290,8 @@ AC_ARG_WITH([cavium-v],
     [  --with-cavium-v=PATH    PATH to Cavium V/software dir ],
     [
         AC_MSG_CHECKING([for cavium])
-        CPPFLAGS="$CPPFLAGS -DHAVE_CAVIUM -DHAVE_CAVIUM_V"
-        LIB_ADD="-lrt $LIB_ADD"
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_CAVIUM -DHAVE_CAVIUM_V"
+        LIB_ADD="-lrt -lcrypto $LIB_ADD"
 
         if test "x$withval" == "xyes" ; then
             AC_MSG_ERROR([need a PATH for --with-cavium])
@@ -3300,21 +3300,17 @@ AC_ARG_WITH([cavium-v],
             trycaviumdir=$withval
         fi
 
-        LDFLAGS="$AM_LDFLAGS $trycaviumdir/api/obj/cavium_common.o $trycaviumdir/api/obj/cavium_sym_crypto.o $trycaviumdir/api/obj/cavium_asym_crypto.o"
-        CPPFLAGS="$CPPFLAGS -I$trycaviumdir/include"
+        AC_CHECK_FILES([$trycaviumdir/lib/libnitrox.a], [AM_CPPFLAGS="-I$trycaviumdir/include $AM_CPPFLAGS"], [ENABLED_CAVIUM_V=no])
+        LIB_STATIC_ADD="$trycaviumdir/lib/libnitrox.a $LIB_STATIC_ADD"
 
-        #AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cavium_common.h"]], [[ CspShutdown(0); ]])],[ cavium_linked=yes ],[ cavium_linked=no ])
-
-        if test "x$cavium_linked" == "xno" ; then
-            AC_MSG_ERROR([cavium isn't found.
-            If it's already installed, specify its path using --with-cavium-v=/dir/])
-        else
-            AM_CFLAGS="$AM_CFLAGS -DHAVE_CAVIUM -DHAVE_CAVIUM_V"
+        if test "$ENABLED_CAVIUM_V" = "no"; then
+            AC_MSG_ERROR([Could not find Nitrox library])
         fi
-        AC_MSG_RESULT([yes])
 
         enable_shared=no
         enable_static=yes
+        enable_opensslextra=yes
+
         ENABLED_CAVIUM=yes
         ENABLED_CAVIUM_V=yes
     ],
@@ -3325,6 +3321,7 @@ AC_ARG_WITH([cavium-v],
 )
 
 AM_CONDITIONAL([BUILD_CAVIUM], [test "x$ENABLED_CAVIUM" = "xyes"])
+AM_CONDITIONAL([BUILD_CAVIUM_V], [test "x$ENABLED_CAVIUM_V" = "xyes"])
 
 
 # Intel Quick Assist

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -7544,10 +7544,17 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_AES)
     /* if async and byte count above threshold */
+    /* only 12-byte IV is supported in HW */
     if (aes->asyncDev.marker == WOLFSSL_ASYNC_MARKER_AES &&
-                                                sz >= WC_ASYNC_THRESH_AES_GCM) {
+                            sz >= WC_ASYNC_THRESH_AES_GCM && ivSz == NONCE_SZ) {
     #if defined(HAVE_CAVIUM)
-        /* Not yet supported, contact wolfSSL if interested in using */
+        #ifdef HAVE_CAVIUM_V
+        if (authInSz == 20) { /* Nitrox V GCM is only working with 20 byte AAD */
+            return NitroxAesGcmEncrypt(aes, out, in, sz,
+                (const byte*)aes->asyncKey, aes->keylen, iv, ivSz,
+                authTag, authTagSz, authIn, authInSz);
+        }
+        #endif
     #elif defined(HAVE_INTEL_QA)
         return IntelQaSymAesGcmEncrypt(&aes->asyncDev, out, in, sz,
             (const byte*)aes->asyncKey, aes->keylen, iv, ivSz,
@@ -7887,10 +7894,17 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_AES)
     /* if async and byte count above threshold */
+    /* only 12-byte IV is supported in HW */
     if (aes->asyncDev.marker == WOLFSSL_ASYNC_MARKER_AES &&
-                                                sz >= WC_ASYNC_THRESH_AES_GCM) {
+                            sz >= WC_ASYNC_THRESH_AES_GCM && ivSz == NONCE_SZ) {
     #if defined(HAVE_CAVIUM)
-        /* Not yet supported, contact wolfSSL if interested in using */
+        #ifdef HAVE_CAVIUM_V
+        if (authInSz == 20) { /* Nitrox V GCM is only working with 20 byte AAD */
+            return NitroxAesGcmDecrypt(aes, out, in, sz,
+                (const byte*)aes->asyncKey, aes->keylen, iv, ivSz,
+                authTag, authTagSz, authIn, authInSz);
+        }
+        #endif
     #elif defined(HAVE_INTEL_QA)
         return IntelQaSymAesGcmDecrypt(&aes->asyncDev, out, in, sz,
             (const byte*)aes->asyncKey, aes->keylen, iv, ivSz,

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5534,7 +5534,7 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     /* make sure we're right justified */
                     encodedSigSz = wc_EncodeSignature(encodedSig,
                             sigCtx->digest, sigCtx->digestSz, sigCtx->typeH);
-                    if (encodedSigSz == verifySz &&
+                    if (encodedSigSz == verifySz && sigCtx->out != NULL &&
                         XMEMCMP(sigCtx->out, encodedSig, encodedSigSz) == 0) {
                         ret = 0;
                     }

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1465,6 +1465,7 @@ static int wc_RsaFunctionAsync(const byte* in, word32 inLen, byte* out,
     case RSA_PRIVATE_DECRYPT:
     case RSA_PRIVATE_ENCRYPT:
     #ifdef HAVE_CAVIUM
+        key->dataLen = key->n.raw.len;
         ret = NitroxRsaExptMod(in, inLen,
                                key->d.raw.buf, key->d.raw.len,
                                key->n.raw.buf, key->n.raw.len,
@@ -1489,6 +1490,7 @@ static int wc_RsaFunctionAsync(const byte* in, word32 inLen, byte* out,
     case RSA_PUBLIC_ENCRYPT:
     case RSA_PUBLIC_DECRYPT:
     #ifdef HAVE_CAVIUM
+        key->dataLen = key->n.raw.len;
         ret = NitroxRsaExptMod(in, inLen,
                                key->e.raw.buf, key->e.raw.len,
                                key->n.raw.buf, key->n.raw.len,
@@ -1731,7 +1733,8 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
 
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_RSA) && \
             defined(HAVE_CAVIUM)
-        if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA && key->n.raw.buf) {
+        if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA &&
+                                 pad_type != WC_RSA_PSS_PAD && key->n.raw.buf) {
             /* Async operations that include padding */
             if (rsa_type == RSA_PUBLIC_ENCRYPT &&
                                                 pad_value == RSA_BLOCK_TYPE_2) {
@@ -1833,14 +1836,14 @@ static int RsaPrivateDecryptEx(byte* in, word32 inLen, byte* out,
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_RSA) && \
             defined(HAVE_CAVIUM)
         /* Async operations that include padding */
-        if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA) {
+        if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA &&
+                                                   pad_type != WC_RSA_PSS_PAD) {
             if (rsa_type == RSA_PRIVATE_DECRYPT &&
                                                 pad_value == RSA_BLOCK_TYPE_2) {
                 key->state = RSA_STATE_DECRYPT_RES;
                 key->data = NULL;
-                if (outPtr)
-                    *outPtr = in;
-                return NitroxRsaPrivateDecrypt(in, inLen, out, &key->dataLen, key);
+                return NitroxRsaPrivateDecrypt(in, inLen, out, &key->dataLen,
+                                               key);
             }
             else if (rsa_type == RSA_PUBLIC_DECRYPT &&
                                                 pad_value == RSA_BLOCK_TYPE_1) {
@@ -1911,14 +1914,14 @@ static int RsaPrivateDecryptEx(byte* in, word32 inLen, byte* out,
     case RSA_STATE_DECRYPT_RES:
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_RSA) && \
             defined(HAVE_CAVIUM)
-        if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA) {
-            /* return event ret */
-            ret = key->asyncDev.event.ret;
-            if (ret == 0) {
-                /* convert result */
-                byte* dataLen = (byte*)&key->dataLen;
-                ret = (dataLen[0] << 8) | (dataLen[1]);
-            }
+        if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA &&
+                                                   pad_type != WC_RSA_PSS_PAD) {
+            /* convert result */
+            byte* dataLen = (byte*)&key->dataLen;
+            ret = (dataLen[0] << 8) | (dataLen[1]);
+
+            if (outPtr)
+                *outPtr = in;
         }
     #endif
         break;

--- a/wolfcrypt/src/wolfmath.c
+++ b/wolfcrypt/src/wolfmath.c
@@ -235,20 +235,44 @@ void wc_bigint_free(WC_BIGINT* a)
     }
 }
 
-int wc_mp_to_bigint(mp_int* src, WC_BIGINT* dst)
+/* sz: make sure the buffer is at least that size and zero padded.
+ *     A `sz == 0` will use the size of `src`.
+ *     The calulcates sz is stored into dst->len in `wc_bigint_alloc`.
+ */
+int wc_mp_to_bigint_sz(mp_int* src, WC_BIGINT* dst, word32 sz)
 {
     int err;
-    word32 sz;
+    word32 x, y;
 
     if (src == NULL || dst == NULL)
         return BAD_FUNC_ARG;
 
-    sz = mp_unsigned_bin_size(src);
+    /* get size of source */
+    x = mp_unsigned_bin_size(src);
+    if (sz < x)
+        sz = x;
+
+    /* make sure destination is allocated and large enough */
     err = wc_bigint_alloc(dst, sz);
-    if (err == MP_OKAY)
-        err = mp_to_unsigned_bin(src, dst->buf);
+    if (err == MP_OKAY) {
+
+        /* leading zero pad */
+        y = sz - x;
+        XMEMSET(dst->buf, 0, y);
+
+        /* export src as unsigned bin to destination buf */
+        err = mp_to_unsigned_bin(src, dst->buf + y);
+    }
 
     return err;
+}
+
+int wc_mp_to_bigint(mp_int* src, WC_BIGINT* dst)
+{
+    if (src == NULL || dst == NULL)
+        return BAD_FUNC_ARG;
+
+    return wc_mp_to_bigint_sz(src, dst, 0);
 }
 
 int wc_bigint_to_mp(WC_BIGINT* src, mp_int* dst)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6128,7 +6128,7 @@ int aesgcm_test(void)
     };
 
     /* FIPS, QAT and STM32F2/4 HW Crypto only support 12-byte IV */
-#if !defined(HAVE_FIPS) && !defined(HAVE_INTEL_QA) && \
+#if !defined(HAVE_FIPS) && \
         !defined(STM32_CRYPTO) && !defined(WOLFSSL_PIC32MZ_CRYPT) && \
         !defined(WOLFSSL_XILINX_CRYPT)
 
@@ -13987,6 +13987,13 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     if (ret != 0)
         goto done;
 
+    /* only perform the below tests if the key size matches */
+    if (dp == NULL && keySize > 0 && wc_ecc_size(&userA) != keySize) {
+        ret = ECC_CURVE_OID_E;
+        goto done;
+    }
+
+
 #ifdef HAVE_ECC_DHE
     x = ECC_SHARED_SIZE;
     do {
@@ -14965,11 +14972,16 @@ static int ecc_test_custom_curves(WC_RNG* rng)
     }
     #endif
 
+    ret = wc_ecc_init_ex(&key, HEAP_HINT, devId);
+    if (ret != 0) {
+        return -6715;
+    }
+
     inOutIdx = 0;
     ret = wc_EccPublicKeyDecode(eccKeyExplicitCurve, &inOutIdx, &key,
                                                    sizeof(eccKeyExplicitCurve));
     if (ret != 0)
-        return -6715;
+        return -6716;
 
     wc_ecc_free(&key);
 

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -326,6 +326,10 @@ struct ecc_key {
     mp_int* r;          /* sign/verify temps */
     mp_int* s;
     WC_ASYNC_DEV asyncDev;
+    #ifdef HAVE_CAVIUM_V
+        mp_int* e;      /* Sign, Verify and Shared Secret */
+        mp_int* signK;
+    #endif
     #ifdef WOLFSSL_CERT_GEN
         CertSignCtx certSignCtx; /* context info for cert sign (MakeSignature) */
     #endif

--- a/wolfssl/wolfcrypt/hmac.h
+++ b/wolfssl/wolfcrypt/hmac.h
@@ -157,10 +157,6 @@ typedef struct Hmac {
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
     word16       keyLen;          /* hmac key length (key in ipad) */
-    #ifdef HAVE_CAVIUM
-        byte*    data;            /* buffered input data for one call */
-        word16   dataLen;
-    #endif /* HAVE_CAVIUM */
 #endif /* WOLFSSL_ASYNC_CRYPT */
 } Hmac;
 

--- a/wolfssl/wolfcrypt/wolfevent.h
+++ b/wolfssl/wolfcrypt/wolfevent.h
@@ -29,9 +29,6 @@
 #ifndef SINGLE_THREADED
     #include <wolfssl/wolfcrypt/wc_port.h>
 #endif
-#ifdef HAVE_CAVIUM
-    #include <wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h>
-#endif
 
 #ifndef WOLFSSL_WOLFSSL_TYPE_DEFINED
 #define WOLFSSL_WOLFSSL_TYPE_DEFINED
@@ -74,7 +71,10 @@ struct WOLF_EVENT {
 #endif
     } dev;
 #ifdef HAVE_CAVIUM
-    CavReqId            reqId;
+    word64              reqId;
+    #ifdef WOLFSSL_NITROX_DEBUG
+    word32              pendCount;
+    #endif
 #endif
 #ifndef WC_NO_ASYNC_THREADING
     pthread_t           threadId;

--- a/wolfssl/wolfcrypt/wolfmath.h
+++ b/wolfssl/wolfcrypt/wolfmath.h
@@ -61,6 +61,7 @@
         void wc_bigint_free(WC_BIGINT* a);
 
         int wc_mp_to_bigint(mp_int* src, WC_BIGINT* dst);
+        int wc_mp_to_bigint_sz(mp_int* src, WC_BIGINT* dst, word32 sz);
         int wc_bigint_to_mp(WC_BIGINT* src, mp_int* dst);
     #endif /* HAVE_WOLF_BIGINT */
 


### PR DESCRIPTION
* Added support for Nitrox V ECC, AES-GCM and HMAC (SHA-224/384/512 and SHA3).
* ECC refactor for so key based  `r` and `s` apply only when building with `WOLFSSL_ASYNC_CRYPT`.
* ECC refactor for `e` and `ecdhK` to use key based pointer for Nitrox V.
* Improved the Nitrox V HMAC to use start, update and final API's instead of caching updates.
* New debug option `WOLFSSL_NITROX_DEBUG` to add pending count.