### PR TITLE
Refactor IO callback function names to use `_CTX_`

### DIFF
--- a/IDE/GCC-ARM/Source/tls_client.c
+++ b/IDE/GCC-ARM/Source/tls_client.c
@@ -108,8 +108,8 @@ static int tls_client(void)
     /*------------------------------------------------------------------------*/
     /* END CIPHER SUITE OPTIONS */
     /*------------------------------------------------------------------------*/
-    wolfSSL_SetIORecv(ctx, CbIORecv);
-    wolfSSL_SetIOSend(ctx, CbIOSend);
+    wolfSSL_CTX_SetIORecv(ctx, CbIORecv);
+    wolfSSL_CTX_SetIOSend(ctx, CbIOSend);
 
     if ((ssl = wolfSSL_new(ctx)) == NULL) {
         error = wolfSSL_get_error(ssl, 0);

--- a/cyassl/ssl.h
+++ b/cyassl/ssl.h
@@ -498,8 +498,8 @@
  */
 
 #define CyaSSL_accept_ex              wolfSSL_accept_ex
-#define CyaSSL_SetIORecv              wolfSSL_SetIORecv
-#define CyaSSL_SetIOSend              wolfSSL_SetIOSend
+#define CyaSSL_SetIORecv              wolfSSL_CTX_SetIORecv
+#define CyaSSL_SetIOSend              wolfSSL_CTX_SetIOSend
 #define CyaSSL_connect_ex             wolfSSL_connect_ex
 #define CyaSSL_CTX_SetCACb            wolfSSL_CTX_SetCACb
 #define CyaSSL_SetIOReadCtx           wolfSSL_SetIOReadCtx

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -1489,8 +1489,8 @@ WOLFSSL_API WOLFSSL* wolfSSL_new(WOLFSSL_CTX*);
     }
     \endcode
     
-    \sa wolfSSL_SetIOSend
-    \sa wolfSSL_SetIORecv
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_CTX_SetIORecv
     \sa wolfSSL_SetIOReadCtx
     \sa wolfSSL_SetIOWriteCtx
 */

--- a/doc/dox_comments/header_files/wolfio.h
+++ b/doc/dox_comments/header_files/wolfio.h
@@ -232,18 +232,18 @@
     // Receive callback prototype
     int MyEmbedReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
     // Register the custom receive callback with wolfSSL
-    wolfSSL_SetIORecv(ctx, MyEmbedReceive);
+    wolfSSL_CTX_SetIORecv(ctx, MyEmbedReceive);
     int MyEmbedReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx)                   
     {
 	    // custom EmbedReceive function
     }
     \endcode
     
-    \sa wolfSSL_SetIOSend
+    \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_SetIOReadCtx
     \sa wolfSSL_SetIOWriteCtx
 */
-WOLFSSL_API void wolfSSL_SetIORecv(WOLFSSL_CTX*, CallbackIORecv);
+WOLFSSL_API void wolfSSL_CTX_SetIORecv(WOLFSSL_CTX*, CallbackIORecv);
 /*!
     \brief This function registers a context for the SSL session’s receive 
     callback function.  By default, wolfSSL sets the file descriptor passed to 
@@ -269,8 +269,8 @@ WOLFSSL_API void wolfSSL_SetIORecv(WOLFSSL_CTX*, CallbackIORecv);
     ...
     \endcode
     
-    \sa wolfSSL_SetIORecv
-    \sa wolfSSL_SetIOSend
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_SetIOWriteCtx
 */
 WOLFSSL_API void wolfSSL_SetIOReadCtx( WOLFSSL* ssl, void *ctx);
@@ -299,8 +299,8 @@ WOLFSSL_API void wolfSSL_SetIOReadCtx( WOLFSSL* ssl, void *ctx);
     ...
     \endcode
     
-    \sa wolfSSL_SetIORecv
-    \sa wolfSSL_SetIOSend
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_SetIOReadCtx
 */
 WOLFSSL_API void wolfSSL_SetIOWriteCtx(WOLFSSL* ssl, void *ctx);
@@ -330,7 +330,7 @@ WOLFSSL_API void wolfSSL_SetIOWriteCtx(WOLFSSL* ssl, void *ctx);
     \sa wolfSSL_SetIOReadFlags
     \sa wolfSSL_SetIOWriteCtx
     \sa wolfSSL_SetIOReadCtx
-    \sa wolfSSL_SetIOSend
+    \sa wolfSSL_CTX_SetIOSend
 */
 WOLFSSL_API void* wolfSSL_GetIOReadCtx( WOLFSSL* ssl);
 /*!
@@ -358,14 +358,14 @@ WOLFSSL_API void* wolfSSL_GetIOReadCtx( WOLFSSL* ssl);
     \sa wolfSSL_GetIOReadCtx
     \sa wolfSSL_SetIOWriteCtx
     \sa wolfSSL_SetIOReadCtx
-    \sa wolfSSL_SetIOSend
+    \sa wolfSSL_CTX_SetIOSend
 */
 WOLFSSL_API void* wolfSSL_GetIOWriteCtx(WOLFSSL* ssl);
 /*!
     \brief This function sets the flags for the receive callback to use for 
     the given SSL session.  The receive callback could be either the default 
     wolfSSL EmbedReceive callback, or a custom callback specified by the user 
-    (see  wolfSSL_SetIORecv). The default flag value is set internally by 
+    (see  wolfSSL_CTX_SetIORecv). The default flag value is set internally by 
     wolfSSL to the value of 0. The default wolfSSL receive callback uses the 
     recv() function to receive data from the socket. From the recv() man page: 
     “The flags argument to a recv() function is formed by or'ing one or more 
@@ -397,8 +397,8 @@ WOLFSSL_API void* wolfSSL_GetIOWriteCtx(WOLFSSL* ssl);
     ...
     \endcode
     
-    \sa wolfSSL_SetIORecv
-    \sa wolfSSL_SetIOSend
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_SetIOReadCtx
 */
 WOLFSSL_API void wolfSSL_SetIOReadFlags( WOLFSSL* ssl, int flags);
@@ -406,7 +406,7 @@ WOLFSSL_API void wolfSSL_SetIOReadFlags( WOLFSSL* ssl, int flags);
     \brief This function sets the flags for the send callback to use for the 
     given SSL session.  The send callback could be either the default wolfSSL 
     EmbedSend callback, or a custom callback specified by the user (see  
-    wolfSSL_SetIOSend). The default flag value is set internally by wolfSSL 
+    wolfSSL_CTX_SetIOSend). The default flag value is set internally by wolfSSL 
     to the value of 0. The default wolfSSL send callback uses the send() 
     function to send data from the socket.  From the send() man page: “The 
     flags parameter may include one or more of the following: 
@@ -431,8 +431,8 @@ WOLFSSL_API void wolfSSL_SetIOReadFlags( WOLFSSL* ssl, int flags);
     ...
     \endcode
     
-    \sa wolfSSL_SetIORecv
-    \sa wolfSSL_SetIOSend
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_SetIOReadCtx
 */
 WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);

--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -397,8 +397,8 @@ static void* client_thread(void* args)
     if (ret != WOLFSSL_SUCCESS) err_sys("error loading CA");
 #endif
 
-    wolfSSL_SetIOSend(cli_ctx, ClientSend);
-    wolfSSL_SetIORecv(cli_ctx, ClientRecv);
+    wolfSSL_CTX_SetIOSend(cli_ctx, ClientSend);
+    wolfSSL_CTX_SetIORecv(cli_ctx, ClientRecv);
 
     /* set cipher suite */
     ret = wolfSSL_CTX_set_cipher_list(cli_ctx, info->cipher);
@@ -507,8 +507,8 @@ static void* server_thread(void* args)
     if (ret != WOLFSSL_SUCCESS) err_sys("error loading server cert");
 #endif
 
-    wolfSSL_SetIOSend(srv_ctx, ServerSend);
-    wolfSSL_SetIORecv(srv_ctx, ServerRecv);
+    wolfSSL_CTX_SetIOSend(srv_ctx, ServerSend);
+    wolfSSL_CTX_SetIORecv(srv_ctx, ServerRecv);
 
     /* set cipher suite */
     ret = wolfSSL_CTX_set_cipher_list(srv_ctx, info->cipher);

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -46,7 +46,7 @@
 Possible IO enable options:
  * WOLFSSL_USER_IO:     Disables default Embed* callbacks and     default: off
                         allows user to define their own using
-                        wolfSSL_SetIORecv and wolfSSL_SetIOSend
+                        wolfSSL_CTX_SetIORecv and wolfSSL_CTX_SetIOSend
  * USE_WOLFSSL_IO:      Enables the wolfSSL IO functions          default: off
  * HAVE_HTTP_CLIENT:    Enables HTTP client API's                 default: off
                                      (unless HAVE_OCSP or HAVE_CRL_IO defined)
@@ -103,9 +103,11 @@ static INLINE int wolfSSL_LastError(void)
 
 
 #ifdef OPENSSL_EXTRA
-/* Use the WOLFSSL read BIO for receiving data. This is set by the fucntion wolfSSL_set_bio and can also be set by wolfSSL_SetIORecv.
+/* Use the WOLFSSL read BIO for receiving data. This is set by the function
+ * wolfSSL_set_bio and can also be set by wolfSSL_CTX_SetIORecv.
  *
- * ssl  WOLFSSL struct passed in that has this function set as the receive callback.
+ * ssl  WOLFSSL struct passed in that has this function set as the receive
+ *      callback.
  * buf  buffer to fill with data read
  * sz   size of buf buffer
  * ctx  a user set context
@@ -144,7 +146,8 @@ int BioReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx)
 }
 
 
-/* Use the WOLFSSL write BIO for sending data. This is set by the fucntion wolfSSL_set_bio and can also be set by wolfSSL_SetIOSend.
+/* Use the WOLFSSL write BIO for sending data. This is set by the function
+ * wolfSSL_set_bio and can also be set by wolfSSL_CTX_SetIOSend.
  *
  * ssl  WOLFSSL struct passed in that has this function set as the send callback.
  * buf  buffer with data to write out
@@ -1452,13 +1455,13 @@ int EmbedCrlLookup(WOLFSSL_CRL* crl, const char* url, int urlSz)
 
 
 
-WOLFSSL_API void wolfSSL_SetIORecv(WOLFSSL_CTX *ctx, CallbackIORecv CBIORecv)
+WOLFSSL_API void wolfSSL_CTX_SetIORecv(WOLFSSL_CTX *ctx, CallbackIORecv CBIORecv)
 {
     ctx->CBIORecv = CBIORecv;
 }
 
 
-WOLFSSL_API void wolfSSL_SetIOSend(WOLFSSL_CTX *ctx, CallbackIOSend CBIOSend)
+WOLFSSL_API void wolfSSL_CTX_SetIOSend(WOLFSSL_CTX *ctx, CallbackIOSend CBIOSend)
 {
     ctx->CBIOSend = CBIOSend;
 }

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -346,8 +346,11 @@ WOLFSSL_API int BioReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 /* I/O callbacks */
 typedef int (*CallbackIORecv)(WOLFSSL *ssl, char *buf, int sz, void *ctx);
 typedef int (*CallbackIOSend)(WOLFSSL *ssl, char *buf, int sz, void *ctx);
-WOLFSSL_API void wolfSSL_SetIORecv(WOLFSSL_CTX*, CallbackIORecv);
-WOLFSSL_API void wolfSSL_SetIOSend(WOLFSSL_CTX*, CallbackIOSend);
+WOLFSSL_API void wolfSSL_CTX_SetIORecv(WOLFSSL_CTX*, CallbackIORecv);
+WOLFSSL_API void wolfSSL_CTX_SetIOSend(WOLFSSL_CTX*, CallbackIOSend);
+/* deprecated old name */
+#define wolfSSL_SetIORecv wolfSSL_CTX_SetIORecv
+#define wolfSSL_SetIOSend wolfSSL_CTX_SetIOSend
 
 WOLFSSL_API void wolfSSL_SetIOReadCtx( WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void wolfSSL_SetIOWriteCtx(WOLFSSL* ssl, void *ctx);


### PR DESCRIPTION
Refactor IO callback function names to use `_CTX_` to eliminate confusion about the first parameter. Old names are supported through macro.