### PR TITLE
Base16/64 improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1759,6 +1759,18 @@ then
 fi
 
 
+# Base16
+AC_ARG_ENABLE([base16],
+    [AS_HELP_STRING([--enable-base16],[Enable Base16 encoding/decoding (default: disabled)])],
+    [ ENABLED_BASE16=$enableval ],
+    [ ENABLED_BASE16=no ]
+    )
+if test "$ENABLED_BASE16" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_BASE16"
+fi
+
+
 # DES3
 AC_ARG_ENABLE([des3],
     [AS_HELP_STRING([--enable-des3],[Enable DES3 (default: disabled)])],

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -344,12 +344,10 @@ int Base64_Encode_NoNl(const byte* in, word32 inLen, byte* out, word32* outLen)
     return DoBase64_Encode(in, inLen, out, outLen, WC_NO_NL_ENC);
 }
 
-#endif  /* defined(WOLFSSL_BASE64_ENCODE) */
+#endif /* WOLFSSL_BASE64_ENCODE */
 
 
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
-    defined(HAVE_WEBSERVER) || defined(HAVE_FIPS) || \
-    defined(HAVE_ECC_CDH) || defined(HAVE_SELFTEST)
+#ifdef WOLFSSL_BASE16
 
 static
 const byte hexDecode[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
@@ -455,6 +453,6 @@ int Base16_Encode(const byte* in, word32 inLen, byte* out, word32* outLen)
     return 0;
 }
 
-#endif /* (OPENSSL_EXTRA) || (HAVE_WEBSERVER) || (HAVE_FIPS) */
+#endif /* WOLFSSL_BASE16 */
 
-#endif /* NO_CODING */
+#endif /* !NO_CODING */

--- a/wolfssl/wolfcrypt/coding.h
+++ b/wolfssl/wolfcrypt/coding.h
@@ -66,6 +66,12 @@ WOLFSSL_API int Base64_Decode(const byte* in, word32 inLen, byte* out,
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
     defined(HAVE_WEBSERVER) || defined(HAVE_FIPS) || \
     defined(HAVE_ECC_CDH) || defined(HAVE_SELFTEST)
+    #ifndef WOLFSSL_BASE16
+        #define WOLFSSL_BASE16
+    #endif
+#endif
+
+#ifdef WOLFSSL_BASE16
     WOLFSSL_API
     int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen);
     WOLFSSL_API


### PR DESCRIPTION
* Add define `WOLFSSL_BASE16` to explicitly expose base16 support.
* Add `./configure --enable-base16` option (disabled by default in configure, but enabled in coding.h when required internally).
* Added base16 tests in test.c `base16_test`.
* Enabled base64 decode tests when `WOLFSSL_BASE64_ENCODE` is not defined.