### PR TITLE
wolfCrypt ECC FP cleanup for thread local storage cases

### DIFF
--- a/doc/dox_comments/header_files/wc_port.h
+++ b/doc/dox_comments/header_files/wc_port.h
@@ -1,6 +1,28 @@
 /*!
     \ingroup wolfCrypt
     
+    \brief Used to initialize resources used by wolfCrypt.
+    
+    \return 0 upon success.
+    \return <0 upon failure of init resources.
+    
+    \param none No parameters.
+    
+    _Example_
+    \code
+    ...
+    if (wolfCrypt_Init() != 0) {
+        WOLFSSL_MSG("Error with wolfCrypt_Init call");
+    }
+    \endcode
+    
+    \sa wolfCrypt_Cleanup
+*/
+WOLFSSL_API int wolfCrypt_Init(void);
+
+/*!
+    \ingroup wolfCrypt
+    
     \brief Used to clean up resources used by wolfCrypt.
     
     \return 0 upon success.

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1439,6 +1439,11 @@ exit:
     wolfAsync_DevClose(&devId);
 #endif
 
+/* cleanup the thread if fixed point cache is enabled and have thread local */
+#if defined(HAVE_THREAD_LS) && defined(HAVE_ECC) && defined(FP_ECC)
+    wc_ecc_fp_free();
+#endif
+
     (void)bench_cipher_algs;
     (void)bench_digest_algs;
     (void)bench_mac_algs;


### PR DESCRIPTION
* Added call to `wc_ecc_fp_free()` in wolfCrypt test/benchmark to resolve leak when ECC operations happen from new thread, such as what happens when building with `--enable-stacksize`.
* Added missing `wolfCrypt_Init`to API docs.

Noticed leak with FP_ECC (`--enable-fpecc`) when profiling memory with `--enable-stacksize --enable-trackmemory`. Found variables allocated with THREAD_LS not being free'd in `wolfCrypt_Cleanup` if ECC operations run in a different thread.