### PR TITLE
Fix for wolfCrypt test and CAVP selftest build

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1208,7 +1208,9 @@ static const byte extCertPolicyOid[] = {85, 29, 32};
 static const byte extKeyUsageOid[] = {85, 29, 15};
 static const byte extInhibitAnyOid[] = {85, 29, 54};
 static const byte extExtKeyUsageOid[] = {85, 29, 37};
-static const byte extNameConsOid[] = {85, 29, 30};
+#ifndef IGNORE_NAME_CONSTRAINTS
+    static const byte extNameConsOid[] = {85, 29, 30};
+#endif
 
 /* certAuthInfoType */
 #ifdef HAVE_OCSP

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14566,12 +14566,14 @@ static int ecc_exp_imp_test(ecc_key* key)
         goto done;
     }
 
+#ifndef HAVE_SELFTEST
     /* test import of public */
     ret = wc_ecc_import_unsigned(&keyImp, pub, &pub[32], NULL, ECC_SECP256R1);
     if (ret != 0) {
         ret = -6638;
         goto done;
     }
+#endif
 
     wc_ecc_free(&keyImp);
     wc_ecc_init(&keyImp);
@@ -14585,12 +14587,14 @@ static int ecc_exp_imp_test(ecc_key* key)
         goto done;
     }
 
+#ifndef HAVE_SELFTEST
     /* test import of private and public */
     ret = wc_ecc_import_unsigned(&keyImp, pub, &pub[32], priv, ECC_SECP256R1);
     if (ret != 0) {
         ret = -6640;
         goto done;
     }
+#endif
 
 done:
     wc_ecc_free(&keyImp);


### PR DESCRIPTION
In our (in-process) CAVP validated version of wolfCrypt with the self test, the ECC module (ecc.c) did not have the wc_ecc_import_unsigned() function available.

This PR excludes running that test when HAVE_SELFTEST is defined.

This fixes the build that is created by running:

```
$ ./fips-check.sh netbsd-selftest
<and subsequently>
$ ./configure --enable-selftest
$ make
```

This also fixes a unused variable warning that showed up on Jenkins:

```
./configure C_EXTRA_FLAGS="-fdebug-types-section -g1" --enable-jobserver=4 --enable-opensslextra CFLAGS=-DIGNORE_NAME_CONSTRAINTS

wolfcrypt/src/asn.c:1211:19: error: ‘extNameConsOid’ defined but not used [-Werror=unused-const-variable=]
 static const byte extNameConsOid[] = {85, 29, 30};
```