### PR TITLE
Enable ECC, AES-GCM and SHA-512/384 by default in VS

### DIFF
--- a/IDE/WIN/user_settings.h
+++ b/IDE/WIN/user_settings.h
@@ -46,6 +46,7 @@
 
         #define HAVE_ECC
         #define ECC_SHAMIR
+        #define ECC_TIMING_RESISTANT
     #else
         /* The servers and clients */
         #define OPENSSL_EXTRA

--- a/IDE/WIN/user_settings.h
+++ b/IDE/WIN/user_settings.h
@@ -36,6 +36,16 @@
         #define WOLFSSL_SNIFFER
         #define HAVE_TLS_EXTENSIONS
         #define HAVE_SECURE_RENEGOTIATION
+
+        #define HAVE_AESGCM
+        #define WOLFSSL_SHA384
+        #define WOLFSSL_SHA512
+
+        #define HAVE_SUPPORTED_CURVES
+        #define HAVE_TLS_EXTENSIONS
+
+        #define HAVE_ECC
+        #define ECC_SHAMIR
     #else
         /* The servers and clients */
         #define OPENSSL_EXTRA


### PR DESCRIPTION
Enable ECC, AES-GCM and SHA-512/384 by default in Windows Visual Studio projects