### PR TITLE
update NetBSD fips-check version to include selftest ECDSA fix

### DIFF
--- a/fips-check.sh
+++ b/fips-check.sh
@@ -66,7 +66,7 @@ CAVP_SELFTEST_ONLY="no"
 
 # non-FIPS, CAVP only but pull in selftest
 # will reset above variables below in platform switch
-NETBSD_FIPS_VERSION=v3.14.2
+NETBSD_FIPS_VERSION=v3.14.2a
 NETBSD_FIPS_REPO=git@github.com:wolfssl/fips.git
 NETBSD_CTAO_VERSION=v3.14.2
 NETBSD_CTAO_REPO=git@github.com:wolfssl/wolfssl.git


### PR DESCRIPTION
This PR updates fips-check.sh for the NetBSD selftest build to a tag on the FIPS repo that includes the selftest fix for the ECDSA pairwise agreement test.