### PR TITLE
Enabled PKCS7 support without RSA

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3907,8 +3907,9 @@ AS_IF([test "x$ENABLED_OCSP" = "xyes" && \
 
 # checks for pkcs7 needed enables
 AS_IF([test "x$ENABLED_PKCS7" = "xyes" && \
-       test "x$ENABLED_RSA" = "xno"],
-      [AC_MSG_ERROR([please enable rsa if enabling pkcs7.])])
+       test "x$ENABLED_RSA" = "xno" && \
+       test "x$ENABLED_ECC" = "xno"],
+      [AC_MSG_ERROR([please enable ecc or rsa if enabling pkcs7.])])
 
 AS_IF([test "x$ENABLED_PKCS7" = "xyes" && \
        test "x$ENABLED_SHA" = "xno"],

--- a/tests/api.c
+++ b/tests/api.c
@@ -307,6 +307,9 @@
 #ifndef USE_CERT_BUFFERS_2048
     #define USE_CERT_BUFFERS_2048
 #endif
+#ifndef USE_CERT_BUFFERS_256
+    #define USE_CERT_BUFFERS_256
+#endif
 #include <wolfssl/certs_test.h>
 
 typedef struct testVector {
@@ -13918,6 +13921,7 @@ static void test_wc_PKCS7_InitWithCert (void)
 #if defined(HAVE_PKCS7)
     PKCS7       pkcs7;
 
+#ifndef NO_RSA
     #if defined(USE_CERT_BUFFERS_2048)
         unsigned char    cert[sizeof_client_cert_der_2048];
         int              certSz = (int)sizeof(cert);
@@ -13932,14 +13936,33 @@ static void test_wc_PKCS7_InitWithCert (void)
         unsigned char   cert[ONEK_BUF];
         FILE*           fp;
         int             certSz;
-        fp = fopen("./certs/client_cert_der_1024", "rb");
+        fp = fopen("./certs/1024/client-cert.der", "rb");
 
         AssertNotNull(fp);
 
         certSz = fread(cert, 1, sizeof_client_cert_der_1024, fp);
         fclose(fp);
     #endif
+#elif defined(HAVE_ECC)
+    #if defined(USE_CERT_BUFFERS_256)
+        unsigned char    cert[sizeof_cliecc_cert_der_256];
+        int              certSz = (int)sizeof(cert);
+        XMEMSET(cert, 0, certSz);
+        XMEMCPY(cert, cliecc_cert_der_256, sizeof_cliecc_cert_der_256);
+    #else
+        unsigned char   cert[ONEK_BUF];
+        FILE*           fp;
+        int             certSz;
+        fp = fopen("./certs/client-ecc-cert.der", "rb");
 
+        AssertNotNull(fp);
+
+        certSz = fread(cert, 1, sizeof_cliecc_cert_der_256, fp);
+        fclose(fp);
+    #endif
+#else
+        #error PKCS7 requires ECC or RSA
+#endif
     printf(testingFmt, "wc_PKCS7_InitWithCert()");
     /* If initialization is not successful, it's free'd in init func. */
     AssertIntEQ(wc_PKCS7_InitWithCert(&pkcs7, (byte*)cert, (word32)certSz), 0);
@@ -13972,6 +13995,7 @@ static void test_wc_PKCS7_EncodeData (void)
     byte        output[FOURK_BUF];
     byte        data[] = "My encoded DER cert.";
 
+#ifndef NO_RSA
     #if defined(USE_CERT_BUFFERS_2048)
         unsigned char cert[sizeof_client_cert_der_2048];
         unsigned char key[sizeof_client_key_der_2048];
@@ -13998,16 +14022,43 @@ static void test_wc_PKCS7_EncodeData (void)
         int             certSz;
         int             keySz;
 
-        fp = fopen("./certs/client_cert_der_1024", "rb");
+        fp = fopen("./certs/1024/client-cert.der", "rb");
         AssertNotNull(fp);
         certSz = fread(cert, 1, sizeof_client_cert_der_1024, fp);
         fclose(fp);
 
-        fp = fopen("./certs/client_key_der_1024", "rb");
+        fp = fopen("./certs/1024/client-key.der", "rb");
         AssertNotNull(fp);
         keySz = fread(key, 1, sizeof_client_key_der_1024, fp);
         fclose(fp);
     #endif
+#elif defined(HAVE_ECC)
+    #if defined(USE_CERT_BUFFERS_256)
+        unsigned char    cert[sizeof_cliecc_cert_der_256];
+        unsigned char    key[sizeof_ecc_clikey_der_256];
+        int              certSz = (int)sizeof(cert);
+        int              keySz = (int)sizeof(key);
+        XMEMSET(cert, 0, certSz);
+        XMEMSET(key, 0, keySz);
+        XMEMCPY(cert, cliecc_cert_der_256, sizeof_cliecc_cert_der_256);
+        XMEMCPY(key, ecc_clikey_der_256, sizeof_ecc_clikey_der_256);
+    #else
+        unsigned char   cert[ONEK_BUF];
+        unsigned char   key[ONEK_BUF];
+        FILE*           fp;
+        int             certSz, keySz;
+
+        fp = fopen("./certs/client-ecc-cert.der", "rb");
+        AssertNotNull(fp);
+        certSz = fread(cert, 1, sizeof_cliecc_cert_der_256, fp);
+        fclose(fp);
+
+        fp = fopen("./certs/client-ecc-key.der", "rb");
+        AssertNotNull(fp);
+        keySz = fread(key, 1, sizeof_ecc_clikey_der_256, fp);
+        fclose(fp);
+    #endif
+#endif
 
     XMEMSET(output, 0, sizeof(output));
 
@@ -14049,6 +14100,7 @@ static void test_wc_PKCS7_EncodeSignedData (void)
     word32      badOutSz = (word32)sizeof(badOut);
     byte        data[] = "Test data to encode.";
 
+#ifndef NO_RSA
     #if defined(USE_CERT_BUFFERS_2048)
         byte        key[sizeof_client_key_der_2048];
         byte        cert[sizeof_client_cert_der_2048];
@@ -14074,16 +14126,43 @@ static void test_wc_PKCS7_EncodeSignedData (void)
         int             certSz;
         int             keySz;
 
-        fp = fopen("./certs/client_cert_der_1024", "rb");
+        fp = fopen("./certs/1024/client-cert.der", "rb");
         AssertNotNull(fp);
         certSz = fread(cert, 1, sizeof_client_cert_der_1024, fp);
         fclose(fp);
 
-        fp = fopen("./certs/client_key_der_1024", "rb");
+        fp = fopen("./certs/1024/client-key.der", "rb");
         AssertNotNull(fp);
         keySz = fread(key, 1, sizeof_client_key_der_1024, fp);
         fclose(fp);
     #endif
+#elif defined(HAVE_ECC)
+    #if defined(USE_CERT_BUFFERS_256)
+        unsigned char    cert[sizeof_cliecc_cert_der_256];
+        unsigned char    key[sizeof_ecc_clikey_der_256];
+        int              certSz = (int)sizeof(cert);
+        int              keySz = (int)sizeof(key);
+        XMEMSET(cert, 0, certSz);
+        XMEMSET(key, 0, keySz);
+        XMEMCPY(cert, cliecc_cert_der_256, sizeof_cliecc_cert_der_256);
+        XMEMCPY(key, ecc_clikey_der_256, sizeof_ecc_clikey_der_256);
+    #else
+        unsigned char   cert[ONEK_BUF];
+        unsigned char   key[ONEK_BUF];
+        FILE*           fp;
+        int             certSz, keySz;
+
+        fp = fopen("./certs/client-ecc-cert.der", "rb");
+        AssertNotNull(fp);
+        certSz = fread(cert, 1, sizeof_cliecc_cert_der_256, fp);
+        fclose(fp);
+
+        fp = fopen("./certs/client-ecc-key.der", "rb");
+        AssertNotNull(fp);
+        keySz = fread(key, 1, sizeof_ecc_clikey_der_256, fp);
+        fclose(fp);
+    #endif
+#endif
 
     XMEMSET(output, 0, outputSz);
     AssertIntEQ(wc_InitRng(&rng), 0);
@@ -14135,6 +14214,7 @@ static void test_wc_PKCS7_VerifySignedData(void)
     word32      badOutSz = (word32)sizeof(badOut);
     byte        data[] = "Test data to encode.";
 
+#ifndef NO_RSA
     #if defined(USE_CERT_BUFFERS_2048)
         byte        key[sizeof_client_key_der_2048];
         byte        cert[sizeof_client_cert_der_2048];
@@ -14160,16 +14240,43 @@ static void test_wc_PKCS7_VerifySignedData(void)
         int             certSz;
         int             keySz;
 
-        fp = fopen("./certs/client_cert_der_1024", "rb");
+        fp = fopen("./certs/1024/client-cert.der", "rb");
         AssertNotNull(fp);
         certSz = fread(cert, 1, sizeof_client_cert_der_1024, fp);
         fclose(fp);
 
-        fp = fopen("./certs/client_key_der_1024", "rb");
+        fp = fopen("./certs/1024/client-key.der", "rb");
         AssertNotNull(fp);
         keySz = fread(key, 1, sizeof_client_key_der_1024, fp);
         fclose(fp);
     #endif
+#elif defined(HAVE_ECC)
+    #if defined(USE_CERT_BUFFERS_256)
+        unsigned char    cert[sizeof_cliecc_cert_der_256];
+        unsigned char    key[sizeof_ecc_clikey_der_256];
+        int              certSz = (int)sizeof(cert);
+        int              keySz = (int)sizeof(key);
+        XMEMSET(cert, 0, certSz);
+        XMEMSET(key, 0, keySz);
+        XMEMCPY(cert, cliecc_cert_der_256, sizeof_cliecc_cert_der_256);
+        XMEMCPY(key, ecc_clikey_der_256, sizeof_ecc_clikey_der_256);
+    #else
+        unsigned char   cert[ONEK_BUF];
+        unsigned char   key[ONEK_BUF];
+        FILE*           fp;
+        int             certSz, keySz;
+
+        fp = fopen("./certs/client-ecc-cert.der", "rb");
+        AssertNotNull(fp);
+        certSz = fread(cert, 1, sizeof_cliecc_cert_der_256, fp);
+        fclose(fp);
+
+        fp = fopen("./certs/client-ecc-key.der", "rb");
+        AssertNotNull(fp);
+        keySz = fread(key, 1, sizeof_ecc_clikey_der_256, fp);
+        fclose(fp);
+    #endif
+#endif
 
     XMEMSET(output, 0, outputSz);
     AssertIntEQ(wc_InitRng(&rng), 0);

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -2908,6 +2908,7 @@ static int wc_CreateKeyAgreeRecipientInfo(PKCS7* pkcs7, const byte* cert,
 
 #endif /* HAVE_ECC */
 
+#ifndef NO_RSA
 
 /* create ASN.1 formatted RecipientInfo structure, returns sequence size */
 static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
@@ -3128,6 +3129,7 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
 
     return totalSz;
 }
+#endif /* !NO_RSA */
 
 
 /* encrypt content using encryptOID algo */
@@ -3457,7 +3459,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
 
     /* build RecipientInfo, only handle 1 for now */
     switch (pkcs7->publicKeyOID) {
-
+#ifndef NO_RSA
         case RSAk:
             recipSz = wc_CreateRecipientInfo(pkcs7->singleCert,
                                     pkcs7->singleCertSz,
@@ -3466,7 +3468,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
                                     contentKeyEnc, &contentKeyEncSz, recip,
                                     MAX_RECIP_SZ, pkcs7->heap);
             break;
-
+#endif
 #ifdef HAVE_ECC
         case ECDSAk:
             recipSz = wc_CreateKeyAgreeRecipientInfo(pkcs7, pkcs7->singleCert,
@@ -3656,7 +3658,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     return idx;
 }
 
-
+#ifndef NO_RSA
 /* decode KeyTransRecipientInfo (ktri), return 0 on success, <0 on error */
 static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
                                word32* idx, byte* decryptedKey,
@@ -3819,7 +3821,7 @@ static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
 
     return 0;
 }
-
+#endif /* !NO_RSA */
 
 #ifdef HAVE_ECC
 
@@ -4353,12 +4355,16 @@ static int wc_PKCS7_DecodeRecipientInfos(PKCS7* pkcs7, byte* pkiMsg,
             if (version != 0)
                 return ASN_VERSION_E;
 
+        #ifndef NO_RSA
             /* found ktri */
             ret = wc_PKCS7_DecodeKtri(pkcs7, pkiMsg, pkiMsgSz, idx,
                                       decryptedKey, decryptedKeySz,
                                       recipFound);
             if (ret != 0)
                 return ret;
+        #else
+            return NOT_COMPILED_IN;
+        #endif
         }
         else {
             /* kari is IMPLICIT[1] */


### PR DESCRIPTION
Added support for building and using PKCS7 without RSA (and ECC is enabled). Updated the API tests to support using an ECC key.

Enables subset of PKCS7 functionality with just ECC enabled:
`./configure --enable-pkcs7 --disable-rsa --enable-ecc`

PKCS7 must have ECC and/or RSA enabled.