### PR TITLE
Fix for HAVE_EXT_CACHE callbacks not being available without OPENSSL_EXTRA

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1621,6 +1621,12 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     wolfSSL_CTX_SetCACb(ctx, CaCb);
 #endif
 
+#ifdef HAVE_EXT_CACHE
+    wolfSSL_CTX_sess_set_get_cb(ctx, mySessGetCb);
+    wolfSSL_CTX_sess_set_new_cb(ctx, mySessNewCb);
+    wolfSSL_CTX_sess_set_remove_cb(ctx, mySessRemCb);
+#endif
+
 #ifndef NO_CERTS
     if (useClientCert){
     #ifndef NO_FILESYSTEM

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19052,7 +19052,9 @@ void wolfSSL_EVP_PKEY_free(WOLFSSL_EVP_PKEY* key)
 }
 #endif /* OPENSSL_EXTRA_X509_SMALL */
 
+
 #ifdef OPENSSL_EXTRA
+
 void wolfSSL_X509_STORE_CTX_set_time(WOLFSSL_X509_STORE_CTX* ctx,
                                     unsigned long flags,
                                     time_t t)
@@ -19073,9 +19075,6 @@ void wolfSSL_X509_OBJECT_free_contents(WOLFSSL_X509_OBJECT* obj)
     WOLFSSL_STUB("X509_OBJECT_free_contents");
 }
 #endif
-
-
-
 
 #ifndef NO_WOLFSSL_STUB
 int wolfSSL_X509_cmp_current_time(const WOLFSSL_ASN1_TIME* asnTime)
@@ -19141,6 +19140,7 @@ WOLFSSL_ASN1_INTEGER* wolfSSL_X509_get_serialNumber(WOLFSSL_X509* x509)
     return a;
 }
 
+#endif /* OPENSSL_EXTRA */
 
 #if defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(WOLFSSL_NGINX) || \
     defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA)
@@ -19198,10 +19198,14 @@ char* wolfSSL_ASN1_TIME_to_string(WOLFSSL_ASN1_TIME* t, char* buf, int len)
 
     return buf;
 }
-#endif /* WOLFSSL_MYSQL_COMPATIBLE */
+#endif /* WOLFSSL_MYSQL_COMPATIBLE || WOLFSSL_NGINX || WOLFSSL_HAPROXY ||
+    OPENSSL_EXTRA*/
 
-#if defined(OPENSSL_EXTRA) && !defined(NO_ASN_TIME) \
-&& !defined(USER_TIME) && !defined(TIME_OVERRIDES) && !defined(NO_FILESYSTEM)
+
+#ifdef OPENSSL_EXTRA
+
+#if !defined(NO_ASN_TIME) && !defined(USER_TIME) && \
+    !defined(TIME_OVERRIDES) && !defined(NO_FILESYSTEM)
 
 WOLFSSL_ASN1_TIME* wolfSSL_ASN1_TIME_adj(WOLFSSL_ASN1_TIME *s, time_t t,
                                     int offset_day, long offset_sec)
@@ -19286,8 +19290,7 @@ WOLFSSL_ASN1_TIME* wolfSSL_ASN1_TIME_adj(WOLFSSL_ASN1_TIME *s, time_t t,
 
     return s;
 }
-#endif /* OPENSSL_EXTRA && !NO_ASN_TIME && !USER_TIME */
-       /* && !TIME_OVERRIDES && !NO_FILESYSTEM */
+#endif /* !NO_ASN_TIME && !USER_TIME && !TIME_OVERRIDES && !NO_FILESYSTEM */
 
 #ifndef NO_WOLFSSL_STUB
 int wolfSSL_ASN1_INTEGER_cmp(const WOLFSSL_ASN1_INTEGER* a,
@@ -19374,11 +19377,7 @@ unsigned long wolfSSL_ERR_peek_error(void)
 {
     WOLFSSL_ENTER("wolfSSL_ERR_peek_error");
 
-#ifdef OPENSSL_EXTRA
     return wolfSSL_ERR_peek_error_line_data(NULL, NULL, NULL, NULL);
-#else
-    return 0;
-#endif
 }
 
 
@@ -20269,7 +20268,6 @@ WOLFSSL_API int wolfSSL_sk_SSL_COMP_zero(WOLFSSL_STACK* st)
 }
 #endif
 
-#ifdef OPENSSL_EXTRA
 #ifdef HAVE_CERTIFICATE_STATUS_REQUEST
 long wolfSSL_set_tlsext_status_type(WOLFSSL *s, int type)
 {
@@ -20292,7 +20290,6 @@ long wolfSSL_set_tlsext_status_type(WOLFSSL *s, int type)
 
 }
 #endif /* HAVE_CERTIFICATE_STATUS_REQUEST */
-#endif /* OPENSSL_EXTRA */
 
 #ifndef NO_WOLFSSL_STUB
 WOLFSSL_API long wolfSSL_get_tlsext_status_exts(WOLFSSL *s, void *arg)
@@ -21467,6 +21464,9 @@ void* wolfSSL_sk_value(WOLF_STACK_OF(WOLFSSL_ASN1_OBJECT)* sk, int i)
     return (void*)sk->data.obj;
 }
 
+#endif /* OPENSSL_EXTRA */
+
+#if defined(OPENSSL_EXTRA) || defined(HAVE_EXT_CACHE)
 /* stunnel 4.28 needs */
 void wolfSSL_CTX_sess_set_get_cb(WOLFSSL_CTX* ctx,
                     WOLFSSL_SESSION*(*f)(WOLFSSL*, unsigned char*, int, int*))
@@ -21500,6 +21500,9 @@ void wolfSSL_CTX_sess_set_remove_cb(WOLFSSL_CTX* ctx, void (*f)(WOLFSSL_CTX*,
     (void)f;
 #endif
 }
+#endif /* OPENSSL_EXTRA || HAVE_EXT_CACHE */
+
+#ifdef OPENSSL_EXTRA
 
 /*
  *

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1401,6 +1401,40 @@ static INLINE int myDateCb(int preverify, WOLFSSL_X509_STORE_CTX* store)
 }
 
 
+#ifdef HAVE_EXT_CACHE
+
+static INLINE WOLFSSL_SESSION* mySessGetCb(WOLFSSL* ssl, unsigned char* id, 
+    int id_len, int* copy)
+{
+    (void)ssl;
+    (void)id;
+    (void)id_len;
+    (void)copy;
+
+    /* using internal cache, this is for testing only */
+    return NULL;
+}
+
+static INLINE int mySessNewCb(WOLFSSL* ssl, WOLFSSL_SESSION* session)
+{
+    (void)ssl;
+    (void)session;
+
+    /* using internal cache, this is for testing only */
+    return 0;
+}
+
+static INLINE void mySessRemCb(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* session)
+{
+    (void)ctx;
+    (void)session;
+
+    /* using internal cache, this is for testing only */
+}
+
+#endif /* HAVE_EXT_CACHE */
+
+
 #ifdef HAVE_CRL
 
 static INLINE void CRL_CallBack(const char* url)


### PR DESCRIPTION
* Fix for `HAVE_EXT_CACHE` callbacks not being available without `OPENSSL_EXTRA` defined.
* Added tests for external cache callbacks.