### PR TITLE
Fix TLS 1.3 with ED25519/CURVE25519 enabled and ECC disabled

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4725,7 +4725,12 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
         } else
 #endif
 #ifdef HAVE_ED25519
-        if (header == BEGIN_DSA_PRIV) {
+    #ifdef HAVE_ECC
+        if (header == BEGIN_DSA_PRIV)
+    #else
+        if (header == BEGIN_ENC_PRIV_KEY)
+    #endif
+        {
             header =  BEGIN_EDDSA_PRIV;     footer = END_EDDSA_PRIV;
         } else
 #endif
@@ -5319,7 +5324,9 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
                     != 0) {
                 #ifdef HAVE_ECC
                     /* could have DER ECC (or pkcs8 ecc), no easy way to tell */
-                    eccKey = 1;  /* so try it out */
+                    eccKey = 1;  /* try it next */
+                #elif defined(HAVE_ED25519)
+                    ed25519Key = 1; /* try it next */
                 #else
                     WOLFSSL_MSG("RSA decode failed and ECC not enabled to try");
                     ret = WOLFSSL_BAD_FILE;

--- a/tests/api.c
+++ b/tests/api.c
@@ -18123,6 +18123,14 @@ static int test_tls13_apis(void)
                 WOLFSSL_SUCCESS);
     AssertIntEQ(wolfSSL_UseKeyShare(clientSsl, WOLFSSL_ECC_SECP256R1),
                 WOLFSSL_SUCCESS);
+#elif defined(HAVE_CURVE25519)
+    AssertIntEQ(wolfSSL_UseKeyShare(NULL, WOLFSSL_ECC_X25519), BAD_FUNC_ARG);
+    AssertIntEQ(wolfSSL_UseKeyShare(serverSsl, WOLFSSL_ECC_X25519),
+                SIDE_ERROR);
+    AssertIntEQ(wolfSSL_UseKeyShare(clientTls12Ssl, WOLFSSL_ECC_X25519),
+                WOLFSSL_SUCCESS);
+    AssertIntEQ(wolfSSL_UseKeyShare(clientSsl, WOLFSSL_ECC_X25519),
+                WOLFSSL_SUCCESS);
 #else
     AssertIntEQ(wolfSSL_UseKeyShare(NULL, WOLFSSL_ECC_SECP256R1), BAD_FUNC_ARG);
     AssertIntEQ(wolfSSL_UseKeyShare(serverSsl, WOLFSSL_ECC_SECP256R1),


### PR DESCRIPTION
Resolves issue with using `./configure --enable-tls13 --disable-ecc --enable-curve25519 --enable-ed25519`.

* Refactor `TLSX_KeyShare_GenEccKey` to support either ECC or CURVE25519.
* Fixes for `PemToDer` to handle ED25519 without ECC enabled.