### PR TITLE
Hash OID cleanup

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4898,9 +4898,10 @@ word32 wc_EncodeSignature(byte* out, const byte* digest, word32 digSz,
 int wc_GetCTC_HashOID(int type)
 {
     int ret;
+    enum wc_HashType hType;
 
-    /* hash type is same as enum HashType (ex WC_SHA is WC_HASH_TYPE_SHA) */
-    ret = wc_HashGetOID((enum wc_HashType)type);
+    hType = wc_HashTypeConvert(type);
+    ret = wc_HashGetOID(hType);
     if (ret < 0)
         ret = 0; /* backwards compatibility */
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4897,38 +4897,14 @@ word32 wc_EncodeSignature(byte* out, const byte* digest, word32 digSz,
 
 int wc_GetCTC_HashOID(int type)
 {
-    switch (type) {
-#ifdef WOLFSSL_MD2
-        case MD2:
-            return MD2h;
-#endif
-#ifndef NO_MD5
-        case WC_MD5:
-            return MD5h;
-#endif
-#ifndef NO_SHA
-        case WC_SHA:
-            return SHAh;
-#endif
-#ifdef WOLFSSL_SHA224
-        case WC_SHA224:
-            return SHA224h;
-#endif
-#ifndef NO_SHA256
-        case WC_SHA256:
-            return SHA256h;
-#endif
-#ifdef WOLFSSL_SHA384
-        case WC_SHA384:
-            return SHA384h;
-#endif
-#ifdef WOLFSSL_SHA512
-        case WC_SHA512:
-            return SHA512h;
-#endif
-        default:
-            return 0;
-    };
+    int ret;
+
+    /* hash type is same as enum HashType (ex WC_SHA is WC_HASH_TYPE_SHA) */
+    ret = wc_HashGetOID((enum wc_HashType)type);
+    if (ret < 0)
+        ret = 0; /* backwards compatibility */
+
+    return ret;
 }
 
 void InitSignatureCtx(SignatureCtx* sigCtx, void* heap, int devId)

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -126,7 +126,7 @@ int wc_HashGetOID(enum wc_HashType hash_type)
         #endif
             break;
         case WC_HASH_TYPE_SHA224:
-        #if defined(WOLFSSL_SHA224)
+        #ifdef WOLFSSL_SHA224
             oid = SHA224h;
         #endif
             break;
@@ -136,7 +136,7 @@ int wc_HashGetOID(enum wc_HashType hash_type)
         #endif
             break;
         case WC_HASH_TYPE_SHA384:
-        #if defined(WOLFSSL_SHA512) && defined(WOLFSSL_SHA384)
+        #ifdef WOLFSSL_SHA384
             oid = SHA384h;
         #endif
             break;
@@ -159,6 +159,52 @@ int wc_HashGetOID(enum wc_HashType hash_type)
             break;
     }
     return oid;
+}
+
+enum wc_HashType wc_OidGetHash(int oid)
+{
+    enum wc_HashType hash_type = WC_HASH_TYPE_NONE;
+    switch (oid)
+    {
+        case MD2h:
+        #ifdef WOLFSSL_MD2
+            hash_type = WC_HASH_TYPE_MD2;
+        #endif
+            break;
+        case MD5h:
+        #ifndef NO_MD5
+            hash_type = WC_HASH_TYPE_MD5;
+        #endif
+            break;
+        case SHAh:
+        #ifndef NO_SHA
+            hash_type = WC_HASH_TYPE_SHA;
+        #endif
+            break;
+        case SHA224h:
+        #if defined(WOLFSSL_SHA224)
+            hash_type = WC_HASH_TYPE_SHA224;
+        #endif
+            break;
+        case SHA256h:
+        #ifndef NO_SHA256
+            hash_type = WC_HASH_TYPE_SHA256;
+        #endif
+            break;
+        case SHA384h:
+        #ifdef WOLFSSL_SHA384
+            hash_type = WC_HASH_TYPE_SHA384;
+        #endif
+            break;
+        case SHA512h:
+        #ifdef WOLFSSL_SHA512
+            hash_type = WC_HASH_TYPE_SHA512;
+        #endif
+            break;
+        default:
+            break;
+    }
+    return hash_type;
 }
 #endif /* !NO_ASN || !NO_DH || HAVE_ECC */
 

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -117,6 +117,7 @@ typedef union {
 
 #if !defined(NO_ASN) || !defined(NO_DH) || defined(HAVE_ECC)
 WOLFSSL_API int wc_HashGetOID(enum wc_HashType hash_type);
+WOLFSSL_API enum wc_HashType wc_OidGetHash(int oid);
 #endif
 
 WOLFSSL_API enum wc_HashType wc_HashTypeConvert(int hashType);


### PR DESCRIPTION
* Added new `wc_OidGetHash` API for getting the hash type from a hash OID.
* Refactor PKCS7 and PKCS12 to use new API and reduce duplicate code.
* Updated `wc_GetCTC_HashOID` to use `wc_HashGetOID` and maintain back compat.