### PR TITLE
Fixes for ASN disabled and PWDBASED enabled / Win FIPS

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -321,7 +321,7 @@ WOLFSSL_API int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
 
     *outl = 0;
     if (inl == 0) return WOLFSSL_SUCCESS;
-    
+
     if (ctx->bufUsed > 0) { /* concatinate them if there is anything */
         fill = fillBuff(ctx, in, inl);
         inl -= fill;
@@ -449,7 +449,7 @@ WOLFSSL_API int wolfSSL_EVP_CIPHER_CTX_block_size(const WOLFSSL_EVP_CIPHER_CTX *
 {
     if (ctx == NULL) return BAD_FUNC_ARG;
     switch (ctx->cipherType) {
-
+#if !defined(NO_AES) || !defined(NO_DES3)
 #if !defined(NO_AES) && defined(HAVE_AES_CBC)
     case AES_128_CBC_TYPE:
     case AES_192_CBC_TYPE:
@@ -472,6 +472,7 @@ WOLFSSL_API int wolfSSL_EVP_CIPHER_CTX_block_size(const WOLFSSL_EVP_CIPHER_CTX *
     case DES_EDE3_ECB_TYPE:
 #endif
         return ctx->block_size;
+#endif /* !NO_AES || !NO_DES3 */
     default:
         return 0;
     }

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -48,6 +48,62 @@ enum Hash_Sum  {
 };
 #endif /* !NO_ASN */
 
+
+/* function converts int hash type to enum */
+enum wc_HashType wc_HashTypeConvert(int hashType)
+{
+    /* Default to hash type none as error */
+    enum wc_HashType eHashType = WC_HASH_TYPE_NONE;
+#ifdef HAVE_FIPS
+    /* original FIPSv1 requires a mapping for unique hash type to wc_HashType */
+    switch (hashType) {
+    #ifndef NO_MD5
+        case WC_MD5:
+            eHashType = WC_HASH_TYPE_MD5;
+            break;
+    #endif /* !NO_MD5 */
+    #ifndef NO_SHA
+        case WC_SHA:
+            eHashType = WC_HASH_TYPE_SHA;
+            break;
+    #endif /* !NO_SHA */
+
+    #ifdef WOLFSSL_SHA224
+        case WC_SHA224:
+            eHashType = WC_HASH_TYPE_SHA224;
+            break;
+    #endif /* WOLFSSL_SHA224 */
+
+    #ifndef NO_SHA256
+        case WC_SHA256:
+            eHashType = WC_HASH_TYPE_SHA256;
+            break;
+    #endif /* !NO_SHA256 */
+
+    #ifdef WOLFSSL_SHA512
+    #ifdef WOLFSSL_SHA384
+        case WC_SHA384:
+            eHashType = WC_HASH_TYPE_SHA384;
+            break;
+    #endif /* WOLFSSL_SHA384 */
+        case WC_SHA512:
+            eHashType = WC_HASH_TYPE_SHA512;
+            break;
+    #endif /* WOLFSSL_SHA512 */
+        default:
+            eHashType = WC_HASH_TYPE_NONE;
+            break;
+    }
+#else
+    /* current master uses same unique types as wc_HashType */
+    if (hashType > 0 && hashType <= WC_HASH_TYPE_MAX) {
+        eHashType = (enum wc_HashType)hashType;
+    }
+#endif
+    return eHashType;
+}
+
+
 int wc_HashGetOID(enum wc_HashType hash_type)
 {
     int oid = HASH_TYPE_E; /* Default to hash type error */

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -62,15 +62,14 @@ int wc_PBKDF1_ex(byte* key, int keyLen, byte* iv, int ivLen,
 
     (void)heap;
 
-    if (key == NULL || keyLen < 0 || passwdLen < 0 || saltLen < 0 ||
-                    ivLen < 0 || hashType < 0 || hashType > WC_HASH_TYPE_MAX) {
+    if (key == NULL || keyLen < 0 || passwdLen < 0 || saltLen < 0 || ivLen < 0){
         return BAD_FUNC_ARG;
     }
 
     if (iterations <= 0)
         iterations = 1;
 
-    hashT = (enum wc_HashType)hashType;
+    hashT = wc_HashTypeConvert(hashType);
     err = wc_HashGetDigestSize(hashT);
     if (err < 0)
         return err;
@@ -180,16 +179,14 @@ int wc_PBKDF2(byte* output, const byte* passwd, int pLen, const byte* salt,
 #endif
     enum wc_HashType hashT;
 
-    if (output == NULL || pLen < 0 || sLen < 0 || kLen < 0 ||
-                                hashType < 0 || hashType > WC_HASH_TYPE_MAX) {
+    if (output == NULL || pLen < 0 || sLen < 0 || kLen < 0) {
         return BAD_FUNC_ARG;
     }
 
     if (iterations <= 0)
         iterations = 1;
 
-    hashT = (enum wc_HashType)hashType;
-
+    hashT = wc_HashTypeConvert(hashType);
     hLen = wc_HashGetDigestSize(hashT);
     if (hLen < 0)
         return BAD_FUNC_ARG;
@@ -205,7 +202,8 @@ int wc_PBKDF2(byte* output, const byte* passwd, int pLen, const byte* salt,
 
     ret = wc_HmacInit(hmac, NULL, INVALID_DEVID);
     if (ret == 0) {
-        ret = wc_HmacSetKey(hmac, hashT, passwd, pLen);
+        /* use int hashType here, since HMAC FIPS uses the old unique value */
+        ret = wc_HmacSetKey(hmac, hashType, passwd, pLen);
 
         while (ret == 0 && kLen) {
             int currentLen;
@@ -276,12 +274,11 @@ static int DoPKCS12Hash(int hashType, byte* buffer, word32 totalLen,
 #endif
     enum wc_HashType hashT;
 
-    if (buffer == NULL || Ai == NULL || hashType < 0 ||
-                                                hashType > WC_HASH_TYPE_MAX) {
+    if (buffer == NULL || Ai == NULL) {
         return BAD_FUNC_ARG;
     }
 
-    hashT = (enum wc_HashType)hashType;
+    hashT = wc_HashTypeConvert(hashType);
 
     /* initialize hash */
 #ifdef WOLFSSL_SMALL_STACK
@@ -356,16 +353,15 @@ int wc_PKCS12_PBKDF_ex(byte* output, const byte* passwd, int passLen,
     enum wc_HashType hashT;
 
     (void)heap;
-    
-    if (output == NULL || passLen < 0 || saltLen < 0 || kLen < 0 ||
-                                hashType < 0 || hashType > WC_HASH_TYPE_MAX) {
+
+    if (output == NULL || passLen < 0 || saltLen < 0 || kLen < 0) {
         return BAD_FUNC_ARG;
     }
 
     if (iterations <= 0)
         iterations = 1;
 
-    hashT = (enum wc_HashType)hashType;
+    hashT = wc_HashTypeConvert(hashType);
     ret = wc_HashGetDigestSize(hashT);
     if (ret < 0)
         return ret;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13147,15 +13147,23 @@ int pbkdf1_test(void)
 int pwdbased_test(void)
 {
    int ret = 0;
-#ifndef NO_SHA
-   ret += pbkdf1_test();
-#endif
-   ret += pbkdf2_test();
-   ret += pkcs12_test();
-#ifdef HAVE_SCRYPT
-   ret += scrypt_test();
-#endif
 
+#ifndef NO_SHA
+   ret = pbkdf1_test();
+   if (ret != 0)
+      return ret;
+#endif
+   ret = pbkdf2_test();
+   if (ret != 0)
+      return ret;
+   ret = pkcs12_test();
+   if (ret != 0)
+      return ret;
+#ifdef HAVE_SCRYPT
+   ret = scrypt_test();
+   if (ret != 0)
+      return ret;
+#endif
    return ret;
 }
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1153,15 +1153,6 @@ enum Misc {
     SESSION_FLUSH_COUNT = 256, /* Flush session cache unless user turns off */
 
 #ifdef HAVE_FIPS
-    /* these moved into wolfCrypt, but kept here for backwards compatibility with FIPS */
-    DES_KEY_SIZE        =  8,  /* des                     */
-    DES3_KEY_SIZE       = 24,  /* 3 des ede               */
-    DES_IV_SIZE         = DES_BLOCK_SIZE,
-    AES_256_KEY_SIZE    = 32,  /* for 256 bit             */
-    AES_192_KEY_SIZE    = 24,  /* for 192 bit             */
-    AES_IV_SIZE         = 16,  /* always block size       */
-    AES_128_KEY_SIZE    = 16,  /* for 128 bit             */
-
     MAX_SYM_KEY_SIZE    = AES_256_KEY_SIZE,
 #else
     MAX_SYM_KEY_SIZE    = WC_MAX_SYM_KEY_SIZE,

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -62,6 +62,16 @@
     extern "C" {
 #endif
 
+/* these are required for FIPS and non-FIPS */
+enum {    
+    AES_128_KEY_SIZE    = 16,  /* for 128 bit             */
+    AES_192_KEY_SIZE    = 24,  /* for 192 bit             */
+    AES_256_KEY_SIZE    = 32,  /* for 256 bit             */
+
+    AES_IV_SIZE         = 16,  /* always block size       */
+};
+
+
 #ifndef HAVE_FIPS /* to avoid redefinition of structures */
 
 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -74,13 +84,8 @@ enum {
     AES_DECRYPTION = 1,
 
     AES_BLOCK_SIZE      = 16,
-    AES_IV_SIZE         = AES_BLOCK_SIZE,
-    
-    KEYWRAP_BLOCK_SIZE  = 8,
 
-    AES_128_KEY_SIZE    = 16,  /* for 128 bit */
-    AES_192_KEY_SIZE    = 24,  /* for 192 bit */
-    AES_256_KEY_SIZE    = 32,  /* for 256 bit */
+    KEYWRAP_BLOCK_SIZE  = 8,
 };
 
 

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -129,18 +129,6 @@ enum DN_Tags {
 #define WOLFSSL_ORGUNIT_NAME     "/OU="
 #define WOLFSSL_DOMAIN_COMPONENT "/DC="
 
-enum PBES {
-    PBE_MD5_DES      = 0,
-    PBE_SHA1_RC4_128 = 1,
-    PBE_SHA1_DES     = 2,
-    PBE_SHA1_DES3    = 3,
-    PBE_AES256_CBC   = 4,
-
-    PBE_SHA1_RC4_128_SUM = 657,
-    PBE_SHA1_DES3_SUM    = 659,
-    PBES2            = 13       /* algo ID */
-};
-
 enum ECC_TYPES {
     ECC_PREFIX_0 = 160,
     ECC_PREFIX_1 = 161
@@ -150,12 +138,6 @@ enum Misc_ASN {
     ASN_NAME_MAX        = 256,
     MAX_SALT_SIZE       =  64,     /* MAX PKCS Salt length */
     MAX_IV_SIZE         =  64,     /* MAX PKCS Iv length */
-    MAX_KEY_SIZE        =  64,     /* MAX PKCS Key  length */
-    PKCS5               =   5,     /* PKCS oid tag */
-    PKCS5v2             =   6,     /* PKCS #5 v2.0 */
-    PKCS8v0             =   0,     /* default PKCS#8 version */
-    PKCS12v1            =  12,     /* PKCS #12 */
-    MAX_UNICODE_SZ      = 256,
     ASN_BOOL_SIZE       =   2,     /* including type */
     ASN_ECC_HEADER_SZ   =   2,     /* String type + 1 byte len */
     ASN_ECC_CONTEXT_SZ  =   2,     /* Content specific type + 1 byte len */
@@ -1071,4 +1053,36 @@ WOLFSSL_LOCAL void FreeDecodedCRL(DecodedCRL*);
 #endif
 
 #endif /* !NO_ASN */
+
+
+#if !defined(NO_ASN) || !defined(NO_PWDBASED)
+
+#ifndef MAX_KEY_SIZE
+    #define MAX_KEY_SIZE    64  /* MAX PKCS Key length */
+#endif
+#ifndef MAX_UNICODE_SZ
+    #define MAX_UNICODE_SZ  256
+#endif
+
+enum PBESTypes {
+    PBE_MD5_DES      = 0,
+    PBE_SHA1_RC4_128 = 1,
+    PBE_SHA1_DES     = 2,
+    PBE_SHA1_DES3    = 3,
+    PBE_AES256_CBC   = 4,
+
+    PBE_SHA1_RC4_128_SUM = 657,
+    PBE_SHA1_DES3_SUM    = 659,
+    PBES2            = 13       /* algo ID */
+};
+
+enum PKCSTypes {
+    PKCS5v2             =   6,     /* PKCS #5 v2.0 */
+    PKCS12v1            =  12,     /* PKCS #12 */
+    PKCS5               =   5,     /* PKCS oid tag */
+    PKCS8v0             =   0,     /* default PKCS#8 version */
+};
+
+#endif /* !NO_ASN || !NO_PWDBASED */
+
 #endif /* WOLF_CRYPT_ASN_H */

--- a/wolfssl/wolfcrypt/des3.h
+++ b/wolfssl/wolfcrypt/des3.h
@@ -39,6 +39,14 @@
     extern "C" {
 #endif
 
+/* these are required for FIPS and non-FIPS */
+enum {
+    DES_KEY_SIZE        =  8,  /* des                     */
+    DES3_KEY_SIZE       = 24,  /* 3 des ede               */
+    DES_IV_SIZE         = 16,
+};
+
+
 #ifndef HAVE_FIPS /* to avoid redefinition of macros */
 
 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -51,10 +59,6 @@ enum {
 
     DES_BLOCK_SIZE  = 8,
     DES_KS_SIZE     = 32,    /* internal DES key buffer size */
-
-    DES_KEY_SIZE    =  8,    /* des */
-    DES3_KEY_SIZE   = 24,    /* 3 des ede */
-    DES_IV_SIZE     = DES_BLOCK_SIZE,
 
     DES_ENCRYPTION  = 0,
     DES_DECRYPTION  = 1

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -119,6 +119,8 @@ typedef union {
 WOLFSSL_API int wc_HashGetOID(enum wc_HashType hash_type);
 #endif
 
+WOLFSSL_API enum wc_HashType wc_HashTypeConvert(int hashType);
+
 WOLFSSL_API int wc_HashGetDigestSize(enum wc_HashType hash_type);
 WOLFSSL_API int wc_HashGetBlockSize(enum wc_HashType hash_type);
 WOLFSSL_API int wc_Hash(enum wc_HashType hash_type,


### PR DESCRIPTION
Fixes for issues in current master due to PR #1467 and new tests:
1. Fix build for `./configure --disable-asn --enable-pwdbased`
2. Fix for Windows FIPS with missing DES/AES key/iv enum values.
3. Fix for evp.c `statement will never be executed` in `wolfSSL_EVP_CIPHER_CTX_block_size`.
4. Fix for issue with unique hash types on ctoacrypt FIPS using different values than WC_HASH_TYPE_*.
5. Add new API `wc_HashTypeConvert` to handle the conversion between `enum wc_HashType` and `int`. For FIPS it uses a switch() to convert and for non-FIPS it uses a simple cast.
6. Changed the pwdbased_test to return actual ret instead of adding values (made it difficult to track down error location).