### PR TITLE
AES assembly file name change

### DIFF
--- a/src/include.am
+++ b/src/include.am
@@ -204,7 +204,7 @@ src_libwolfssl_la_SOURCES += wolfcrypt/src/dsa.c
 endif
 
 if BUILD_AESNI
-src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_asm.s
+src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_asm.S
 endif
 
 if BUILD_CAMELLIA

--- a/wolfcrypt/src/aes_asm.S
+++ b/wolfcrypt/src/aes_asm.S
@@ -1,4 +1,4 @@
-/* aes_asm.s
+/* aes_asm.S
  *
  * Copyright (C) 2006-2017 wolfSSL Inc.
  *


### PR DESCRIPTION
Some versions of GCC on the Mac will not run the file aes_asm.s through the preprocessor. There are some ifdefs in the file that are included when they shouldn't be. This is not a problem on Linux. Renaming the file to have a capital S extension forces the assembler to run with the preprocessor.