### PR TITLE
Added ST-Safe wolfCrypt ECC support and benchmarking

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -909,7 +909,11 @@ static THREAD_LS_T int devId = INVALID_DEVID;
 
 #else
     #define BENCH_MAX_PENDING             (1)
+#ifdef WOLFSSL_STSAFEA100
+    #define BENCH_ASYNC_GET_NAME(doAsync) (doAsync) ? "HW" : "SW"
+#else
     #define BENCH_ASYNC_GET_NAME(doAsync) ""
+#endif
     #define BENCH_ASYNC_GET_DEV(obj)      NULL
 
     static WC_INLINE int bench_async_check(int* ret, void* asyncDev,
@@ -2100,6 +2104,11 @@ int benchmark_init(void)
     return ret;
 }
 
+void benchmark_set_devid(int argDevId)
+{
+    devId = argDevId;
+}
+
 int benchmark_free(void)
 {
     int ret;
@@ -2182,7 +2191,7 @@ int benchmark_test(void *args)
     XFREE(g_threadData, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 }
 #else
-    benchmarks_do(NULL);
+    benchmarks_do(args);
 #endif
 
     printf("Benchmark complete\n");
@@ -5703,6 +5712,9 @@ exit_ecdsa_sign:
     }
 
 #ifdef HAVE_ECC_VERIFY
+    /* Using genKey2 for signature verification */
+    XMEMSET(&genKey[0], 0, sizeof(genKey));
+    XMEMCPY(&genKey[0],&genKey2[0], sizeof(genKey));
 
     /* ECC Verify */
     bench_stats_start(&count, &start);

--- a/wolfcrypt/benchmark/benchmark.h
+++ b/wolfcrypt/benchmark/benchmark.h
@@ -39,6 +39,8 @@ int benchmark_test(void *args);
 int  benchmark_init(void);
 int  benchmark_free(void);
 void benchmark_configure(int block_size);
+void benchmark_set_devid(int argDevId);
+
 
 void bench_des(int);
 void bench_idea(void);

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -67,6 +67,11 @@
 #endif
 
 
+#ifdef WOLFSSL_STSAFEA100    
+    #include <wolfssl/wolfcrypt/port/st/stsafe.h>
+#endif /* WOLFSSL_STSAFEA100 */
+
+
 #ifdef __cplusplus
     extern "C" {
 #endif
@@ -155,7 +160,7 @@ enum {
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
     ECC_MAX_CRYPTO_HW_SIZE = ATECC_KEY_SIZE, /* from port/atmel/atmel.h */
     ECC_MAX_CRYPTO_HW_PUBKEY_SIZE = (ATECC_KEY_SIZE*2),
-#elif defined(PLUTON_CRYPTO_ECC)
+#elif defined(PLUTON_CRYPTO_ECC) || defined(WOLFSSL_STSAFEA100)
     ECC_MAX_CRYPTO_HW_SIZE = 32,
 #elif defined(WOLFSSL_SILABS_SE_ACCEL)
     ECC_MAX_CRYPTO_HW_SIZE = 32,
@@ -427,10 +432,12 @@ struct ecc_key {
     int    partNum; /* partition number*/
 #endif
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
-    int  slot;        /* Key Slot Number (-1 unknown) */
     byte pubkey_raw[ECC_MAX_CRYPTO_HW_PUBKEY_SIZE];
 #endif
-#if defined(PLUTON_CRYPTO_ECC) || defined(WOLF_CRYPTO_CB)
+#if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || defined(WOLFSSL_STSAFEA100)
+    int  slot;          /* Key Slot Number (ATECC -1=unknown, STSAFE 0 or 1) */
+#endif
+#if defined(PLUTON_CRYPTO_ECC) || defined(WOLF_CRYPTO_CB) || defined(WOLFSSL_STSAFEA100)
     int devId;
 #endif
 #ifdef WOLFSSL_SILABS_SE_ACCEL


### PR DESCRIPTION
* Changes to support wolfCrypt native ST-Safe ECC operations.
* Added devId support to benchmarking.

Contribution from ST