### PR TITLE
Make Dist Automation Tweak

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -207,4 +207,7 @@ merge-clean:
 	@find ./ | $(GREP) \.OTHER | xargs rm -f
 	@find ./ | $(GREP) \.BASE | xargs rm -f
 	@find ./ | $(GREP) \~$$ | xargs rm -f
-	
+
+dist-hook:
+	cp $(distdir)/wolfssl/options.h.in $(distdir)/wolfssl/options.h
+


### PR DESCRIPTION
Added a dist-hook target to the Makefile to copy the default options.h.in over options.h.