### PR TITLE
Fixes to resolve issues with c99 compliance

### DIFF
--- a/tests/suites.c
+++ b/tests/suites.c
@@ -449,7 +449,7 @@ static void test_harness(void* vargs)
                 break;
             case '#':
                 /* Ignore lines that start with a #. */
-                comment = strsep(&cursor, "\n");
+                comment = XSTRSEP(&cursor, "\n");
 #ifdef DEBUG_SUITE_TESTS
                 printf("%s\n", comment);
 #else
@@ -460,18 +460,18 @@ static void test_harness(void* vargs)
                 /* Parameters start with a -. They end in either a newline
                  * or a space. Capture until either, save in Args list. */
                 if (cliMode)
-                    cliArgs[cliArgsSz++] = strsep(&cursor, " \n");
+                    cliArgs[cliArgsSz++] = XSTRSEP(&cursor, " \n");
                 else
-                    svrArgs[svrArgsSz++] = strsep(&cursor, " \n");
+                    svrArgs[svrArgsSz++] = XSTRSEP(&cursor, " \n");
                 break;
             default:
                 /* Anything from cursor until end of line that isn't the above
                  * is data for a paramter. Just up until the next newline in
                  * the Args list. */
                 if (cliMode)
-                    cliArgs[cliArgsSz++] = strsep(&cursor, "\n");
+                    cliArgs[cliArgsSz++] = XSTRSEP(&cursor, "\n");
                 else
-                    svrArgs[svrArgsSz++] = strsep(&cursor, "\n");
+                    svrArgs[svrArgsSz++] = XSTRSEP(&cursor, "\n");
                 if (*cursor == 0)  /* eof */
                     do_it = 1;
         }

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -265,7 +265,7 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
             WOLFSSL_MSG("stat on name failed");
             ret = BAD_PATH_ERROR;
             break;
-        } else if (ctx->s.st_mode & S_IFREG) {
+        } else if (S_ISREG(ctx->s.st_mode)) {
             if (name)
                 *name = ctx->name;
             return 0;
@@ -312,7 +312,7 @@ int wc_ReadDirNext(ReadDirCtx* ctx, const char* path, char** name)
             WOLFSSL_MSG("stat on name failed");
             ret = BAD_PATH_ERROR;
             break;
-        } else if (ctx->s.st_mode & S_IFREG) {
+        } else if (S_ISREG(ctx->s.st_mode)) {
             if (name)
                 *name = ctx->name;
             return 0;
@@ -418,6 +418,33 @@ char* wc_strtok(char *str, const char *delim, char **nextp)
     return ret;
 }
 #endif /* USE_WOLF_STRTOK */
+
+#ifdef USE_WOLF_STRSEP
+char* wc_strsep(char **stringp, const char *delim)
+{
+    char *s, *tok;
+    const char *spanp;
+
+    /* null check */
+    if (stringp == NULL || *stringp == NULL)
+        return NULL;
+
+    s = *stringp;
+    for (tok = s; *tok; ++tok) {
+        for (spanp = delim; *spanp; ++spanp) {
+            /* found delimiter */
+            if (*tok == *spanp) {
+                *tok = '\0'; /* replace delim with null term */
+                *stringp = tok + 1; /* return past delim */
+                return s;
+            }
+        }
+    }
+
+    *stringp = NULL;
+    return s;
+}
+#endif /* USE_WOLF_STRSEP */
 
 #if WOLFSSL_CRYPT_HW_MUTEX
 /* Mutex for protection of cryptography hardware */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -297,8 +297,11 @@
     #endif
 
     #if !defined(USE_WOLF_STRTOK) && \
-            (defined(__MINGW32__) || defined(WOLFSSL_TIRTOS))
+            (defined(__MINGW32__) || defined(WOLFSSL_TIRTOS) || defined(WOLF_C99))
         #define USE_WOLF_STRTOK
+    #endif
+    #if !defined(USE_WOLF_STRSEP) && (defined(WOLF_C99))
+        #define USE_WOLF_STRSEP
     #endif
 
 	#ifndef STRING_USER
@@ -317,12 +320,21 @@
 	    #define XSTRNCMP(s1,s2,n) strncmp((s1),(s2),(n))
 	    #define XSTRNCAT(s1,s2,n) strncat((s1),(s2),(n))
 
+        #ifdef USE_WOLF_STRSEP
+            #define XSTRSEP(s1,d) wc_strsep((s1),(d))
+        #else
+            #define XSTRSEP(s1,d) strsep((s1),(d))
+        #endif
+
         #if defined(MICROCHIP_PIC32) || defined(WOLFSSL_TIRTOS)
             /* XC32 does not support strncasecmp, so use case sensitive one */
             #define XSTRNCASECMP(s1,s2,n) strncmp((s1),(s2),(n))
         #elif defined(USE_WINDOWS_API)
 	        #define XSTRNCASECMP(s1,s2,n) _strnicmp((s1),(s2),(n))
         #else
+            #if defined(HAVE_STRINGS_H) || defined(WOLF_C99)
+                #include <strings.h>
+            #endif
 	        #define XSTRNCASECMP(s1,s2,n) strncasecmp((s1),(s2),(n))
 	    #endif
 
@@ -343,17 +355,20 @@
         #if defined(WOLFSSL_CERT_EXT) || defined(HAVE_ALPN)
             /* use only Thread Safe version of strtok */
             #if defined(USE_WOLF_STRTOK)
-                #define XSTRTOK wc_strtok
+                #define XSTRTOK(s1,d,ptr) wc_strtok((s1),(d),(ptr))
             #elif defined(USE_WINDOWS_API) || defined(INTIME_RTOS)
-                #define XSTRTOK strtok_s
+                #define XSTRTOK(s1,d,ptr) strtok_s((s1),(d),(ptr))
             #else
-                #define XSTRTOK strtok_r
+                #define XSTRTOK(s1,d,ptr) strtok_r((s1),(d),(ptr))
             #endif
         #endif
 	#endif
 
     #ifdef USE_WOLF_STRTOK
-        WOLFSSL_LOCAL char* wc_strtok(char *str, const char *delim, char **nextp);
+        WOLFSSL_API char* wc_strtok(char *str, const char *delim, char **nextp);
+    #endif
+    #ifdef USE_WOLF_STRSEP
+        WOLFSSL_API char* wc_strsep(char **stringp, const char *delim);
     #endif
 
     #if !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -34,7 +34,7 @@
 #endif
 
 /* detect C99 */
-#if defined(__STDC_VERSION__)
+#if !defined(WOLF_C99) && defined(__STDC_VERSION__)
     #if __STDC_VERSION__ >= 199901L
         #define WOLF_C99
     #endif

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -33,6 +33,12 @@
     extern "C" {
 #endif
 
+/* detect C99 */
+#if defined(__STDC_VERSION__)
+    #if __STDC_VERSION__ >= 199901L
+        #define WOLF_C99
+    #endif
+#endif
 
 #ifdef USE_WINDOWS_API
     #ifdef WOLFSSL_GAME_BUILD
@@ -407,6 +413,9 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
     /* default */
     /* uses complete <time.h> facility */
     #include <time.h>
+    #if defined(HAVE_SYS_TIME_H) || defined(WOLF_C99)
+        #include <sys/time.h>
+    #endif
 
     /* PowerPC time_t is int */
     #ifdef __PPC__
@@ -420,7 +429,7 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XTIME(tl)       time((tl))
 #endif
 #if !defined(XGMTIME) && !defined(TIME_OVERRIDES)
-    #if defined(WOLFSSL_GMTIME) || !defined(HAVE_GMTIME_R)
+    #if defined(WOLFSSL_GMTIME) || !defined(HAVE_GMTIME_R) || defined(WOLF_C99)
         #define XGMTIME(c, t)   gmtime((c))
     #else
         #define XGMTIME(c, t)   gmtime_r((c), (t))

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -262,6 +262,11 @@
         typedef struct hostent          HOSTENT;
     #endif /* HAVE_SOCKADDR */
 
+    /* use gethostbyname for c99 */
+    #ifdef WOLF_C99
+        #undef HAVE_GETADDRINFO
+    #endif
+
     #ifdef HAVE_GETADDRINFO
         typedef struct addrinfo         ADDRINFO;
     #endif


### PR DESCRIPTION
When building with `./configure CFLAGS="-std=c99"`

* Fix for ReadDir checking for file flag to use `S_ISREG(ctx->s.st_mode)` syntax.
* Added macro for strsep `XSTRSEP`. Added wolf implementation as `wc_strsep` enabled as C99 or `USE_WOLF_STRSEP`.
* Fix to use `gethostbyname` for c99 instead of `getaddrinfo`.
* For c99 use wolf strtok `wc_strtok`.
* Exposed API's for `wc_strtok` and `wc_strsep` when available.
* Include `<sys/time.h>` when available from autocon `HAVE_SYS_TIME_H` or c99.
* include `<strings.h>` when `HAVE_STRINGS_H` or c99.