### PR TITLE
Enhancements and cleanup to ASN date/time

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4705,6 +4705,7 @@ int wc_GetDateAsCalendarTime(const byte* date, int length, byte format,
     return 0;
 }
 
+#ifdef WOLFSSL_CERT_GEN
 int wc_GetCertDates(Cert* cert, struct tm* before, struct tm* after)
 {
     int ret = 0;
@@ -4730,6 +4731,7 @@ int wc_GetCertDates(Cert* cert, struct tm* before, struct tm* after)
 
     return ret;
 }
+#endif /* WOLFSSL_CERT_GEN */
 #endif /* !NO_ASN_TIME */
 
 
@@ -12385,7 +12387,7 @@ static int GetBasicDate(const byte* source, word32* idx, byte* date,
                         byte* format, int maxIdx)
 {
     int    ret, length;
-    byte  *datePtr = NULL;
+    const byte *datePtr = NULL;
 
     WOLFSSL_ENTER("GetBasicDate");
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -113,18 +113,6 @@ ASN Options:
     #endif
 #endif
 
-#ifndef NO_ASN_TIME
-/* two byte date/time, add to value */
-static INLINE void GetTime(int* value, const byte* date, int* idx)
-{
-    int i = *idx;
-
-    *value += btoi(date[i++]) * 10;
-    *value += btoi(date[i++]);
-
-    *idx = i;
-}
-#endif /* !NO_ASN_TIME */
 
 #ifdef _MSC_VER
     /* 4996 warning to use MS extensions e.g., strcpy_s instead of XSTRNCPY */
@@ -4373,42 +4361,43 @@ static int GetName(DecodedCert* cert, int nameType)
 
 
 #ifndef NO_ASN_TIME
-#if !defined(NO_TIME_H) && defined(USE_WOLF_VALIDDATE)
 
-/* to the second */
-static int DateGreaterThan(const struct tm* a, const struct tm* b)
+/* two byte date/time, add to value */
+static INLINE void GetTime(int* value, const byte* date, int* idx)
 {
-    if (a->tm_year > b->tm_year)
-        return 1;
+    int i = *idx;
 
-    if (a->tm_year == b->tm_year && a->tm_mon > b->tm_mon)
-        return 1;
+    *value += btoi(date[i++]) * 10;
+    *value += btoi(date[i++]);
 
-    if (a->tm_year == b->tm_year && a->tm_mon == b->tm_mon &&
-           a->tm_mday > b->tm_mday)
-        return 1;
-
-    if (a->tm_year == b->tm_year && a->tm_mon == b->tm_mon &&
-        a->tm_mday == b->tm_mday && a->tm_hour > b->tm_hour)
-        return 1;
-
-    if (a->tm_year == b->tm_year && a->tm_mon == b->tm_mon &&
-        a->tm_mday == b->tm_mday && a->tm_hour == b->tm_hour &&
-        a->tm_min > b->tm_min)
-        return 1;
-
-    if (a->tm_year == b->tm_year && a->tm_mon == b->tm_mon &&
-        a->tm_mday == b->tm_mday && a->tm_hour == b->tm_hour &&
-        a->tm_min  == b->tm_min  && a->tm_sec > b->tm_sec)
-        return 1;
-
-    return 0; /* false */
+    *idx = i;
 }
 
-
-static INLINE int DateLessThan(const struct tm* a, const struct tm* b)
+int ExtractDate(const unsigned char* date, unsigned char format,
+                                                  struct tm* certTime, int* idx)
 {
-    return DateGreaterThan(b,a);
+    XMEMSET(certTime, 0, sizeof(struct tm));
+
+    if (format == ASN_UTC_TIME) {
+        if (btoi(date[0]) >= 5)
+            certTime->tm_year = 1900;
+        else
+            certTime->tm_year = 2000;
+    }
+    else  { /* format == GENERALIZED_TIME */
+        certTime->tm_year += btoi(date[*idx]) * 1000; *idx = *idx + 1;
+        certTime->tm_year += btoi(date[*idx]) * 100;  *idx = *idx + 1;
+    }
+
+    /* adjust tm_year, tm_mon */
+    GetTime((int*)&certTime->tm_year, date, idx); certTime->tm_year -= 1900;
+    GetTime((int*)&certTime->tm_mon,  date, idx); certTime->tm_mon  -= 1;
+    GetTime((int*)&certTime->tm_mday, date, idx);
+    GetTime((int*)&certTime->tm_hour, date, idx);
+    GetTime((int*)&certTime->tm_min,  date, idx);
+    GetTime((int*)&certTime->tm_sec,  date, idx);
+
+    return 1;
 }
 
 
@@ -4457,33 +4446,44 @@ int GetTimeString(byte* date, int format, char* buf, int len)
 }
 #endif /* OPENSSL_ALL || WOLFSSL_MYSQL_COMPATIBLE || WOLFSSL_NGINX || WOLFSSL_HAPROXY */
 
-int ExtractDate(const unsigned char* date, unsigned char format,
-                                                  struct tm* certTime, int* idx)
+
+#if defined(USE_WOLF_VALIDDATE)
+
+/* to the second */
+static int DateGreaterThan(const struct tm* a, const struct tm* b)
 {
-    XMEMSET(certTime, 0, sizeof(struct tm));
+    if (a->tm_year > b->tm_year)
+        return 1;
 
-    if (format == ASN_UTC_TIME) {
-        if (btoi(date[0]) >= 5)
-            certTime->tm_year = 1900;
-        else
-            certTime->tm_year = 2000;
-    }
-    else  { /* format == GENERALIZED_TIME */
-        certTime->tm_year += btoi(date[*idx]) * 1000; *idx = *idx + 1;
-        certTime->tm_year += btoi(date[*idx]) * 100;  *idx = *idx + 1;
-    }
+    if (a->tm_year == b->tm_year && a->tm_mon > b->tm_mon)
+        return 1;
 
-    /* adjust tm_year, tm_mon */
-    GetTime((int*)&certTime->tm_year, date, idx); certTime->tm_year -= 1900;
-    GetTime((int*)&certTime->tm_mon,  date, idx); certTime->tm_mon  -= 1;
-    GetTime((int*)&certTime->tm_mday, date, idx);
-    GetTime((int*)&certTime->tm_hour, date, idx);
-    GetTime((int*)&certTime->tm_min,  date, idx);
-    GetTime((int*)&certTime->tm_sec,  date, idx);
+    if (a->tm_year == b->tm_year && a->tm_mon == b->tm_mon &&
+           a->tm_mday > b->tm_mday)
+        return 1;
 
-    return 1;
+    if (a->tm_year == b->tm_year && a->tm_mon == b->tm_mon &&
+        a->tm_mday == b->tm_mday && a->tm_hour > b->tm_hour)
+        return 1;
+
+    if (a->tm_year == b->tm_year && a->tm_mon == b->tm_mon &&
+        a->tm_mday == b->tm_mday && a->tm_hour == b->tm_hour &&
+        a->tm_min > b->tm_min)
+        return 1;
+
+    if (a->tm_year == b->tm_year && a->tm_mon == b->tm_mon &&
+        a->tm_mday == b->tm_mday && a->tm_hour == b->tm_hour &&
+        a->tm_min  == b->tm_min  && a->tm_sec > b->tm_sec)
+        return 1;
+
+    return 0; /* false */
 }
 
+
+static INLINE int DateLessThan(const struct tm* a, const struct tm* b)
+{
+    return DateGreaterThan(b,a);
+}
 
 /* like atoi but only use first byte */
 /* Make sure before and after dates are valid */
@@ -4560,7 +4560,7 @@ int ValidateDate(const byte* date, byte format, int dateType)
 
     return 1;
 }
-#endif /* !NO_TIME_H && USE_WOLF_VALIDDATE */
+#endif /* USE_WOLF_VALIDDATE */
 
 int wc_GetTime(void* timePtr, word32 timeSize)
 {
@@ -4581,14 +4581,51 @@ int wc_GetTime(void* timePtr, word32 timeSize)
 
 #endif /* !NO_ASN_TIME */
 
-static int GetDate(DecodedCert* cert, int dateType)
-{
-    int    length;
-    byte   date[MAX_DATE_SIZE];
-    byte   b;
-    word32 startIdx = 0;
 
-    XMEMSET(date, 0, MAX_DATE_SIZE);
+/* Get date buffer, format and length. Returns 0=success or error */
+static int GetDateInfo(const byte* source, word32* idx, const byte** pDate,
+                        byte* pFormat, int* pLength, word32 maxIdx)
+{
+    int length;
+    byte format;
+
+    if (source == NULL || idx == NULL)
+        return BAD_FUNC_ARG;
+
+    /* get ASN format header */
+    if (*idx+1 > maxIdx)
+        return BUFFER_E;
+    format = source[*idx];
+    *idx += 1;
+    if (format != ASN_UTC_TIME && format != ASN_GENERALIZED_TIME)
+        return ASN_TIME_E;
+
+    /* get length */
+    if (GetLength(source, idx, &length, maxIdx) < 0)
+        return ASN_PARSE_E;
+    if (length > MAX_DATE_SIZE || length < MIN_DATE_SIZE)
+        return ASN_DATE_SZ_E;
+
+    /* return format, date and length */
+    if (pFormat)
+        *pFormat = format;
+    if (pDate)
+        *pDate = &source[*idx];
+    if (pLength)
+        *pLength = length;
+
+    *idx += length;
+
+    return 0;
+}
+
+static int GetDate(DecodedCert* cert, int dateType, int verify)
+{
+    int    ret, length;
+    const byte *datePtr = NULL;
+    byte   date[MAX_DATE_SIZE];
+    byte   format;
+    word32 startIdx = 0;
 
     if (dateType == BEFORE)
         cert->beforeDate = &cert->source[cert->srcIdx];
@@ -4596,18 +4633,13 @@ static int GetDate(DecodedCert* cert, int dateType)
         cert->afterDate = &cert->source[cert->srcIdx];
     startIdx = cert->srcIdx;
 
-    b = cert->source[cert->srcIdx++];
-    if (b != ASN_UTC_TIME && b != ASN_GENERALIZED_TIME)
-        return ASN_TIME_E;
+    ret = GetDateInfo(cert->source, &cert->srcIdx, &datePtr, &format,
+                      &length, cert->maxIdx);
+    if (ret < 0)
+        return ret;
 
-    if (GetLength(cert->source, &cert->srcIdx, &length, cert->maxIdx) < 0)
-        return ASN_PARSE_E;
-
-    if (length > MAX_DATE_SIZE || length < MIN_DATE_SIZE)
-        return ASN_DATE_SZ_E;
-
-    XMEMCPY(date, &cert->source[cert->srcIdx], length);
-    cert->srcIdx += length;
+    XMEMSET(date, 0, MAX_DATE_SIZE);
+    XMEMCPY(date, datePtr, length);
 
     if (dateType == BEFORE)
         cert->beforeDateLen = cert->srcIdx - startIdx;
@@ -4615,12 +4647,14 @@ static int GetDate(DecodedCert* cert, int dateType)
         cert->afterDateLen  = cert->srcIdx - startIdx;
 
 #ifndef NO_ASN_TIME
-    if (!XVALIDATE_DATE(date, b, dateType)) {
+    if (verify != NO_VERIFY && !XVALIDATE_DATE(date, format, dateType)) {
         if (dateType == BEFORE)
             return ASN_BEFORE_DATE_E;
         else
             return ASN_AFTER_DATE_E;
     }
+#else
+    (void)verify;
 #endif
 
     return 0;
@@ -4634,10 +4668,10 @@ static int GetValidity(DecodedCert* cert, int verify)
     if (GetSequence(cert->source, &cert->srcIdx, &length, cert->maxIdx) < 0)
         return ASN_PARSE_E;
 
-    if (GetDate(cert, BEFORE) < 0 && verify != NO_VERIFY)
-        badDate = ASN_BEFORE_DATE_E;           /* continue parsing */
+    if (GetDate(cert, BEFORE, verify) < 0)
+        badDate = ASN_BEFORE_DATE_E; /* continue parsing */
 
-    if (GetDate(cert, AFTER) < 0 && verify != NO_VERIFY)
+    if (GetDate(cert, AFTER, verify) < 0)
         return ASN_AFTER_DATE_E;
 
     if (badDate != 0)
@@ -4645,6 +4679,58 @@ static int GetValidity(DecodedCert* cert, int verify)
 
     return 0;
 }
+
+
+int wc_GetDateInfo(const byte* certDate, int certDateSz, const byte** date,
+    byte* format, int* length)
+{
+    int ret;
+    word32 idx = 0;
+
+    ret = GetDateInfo(certDate, &idx, date, format, length, certDateSz);
+    if (ret < 0)
+        return ret;
+
+    return 0;
+}
+
+#ifndef NO_ASN_TIME
+int wc_GetDateAsCalendarTime(const byte* date, int length, byte format,
+    struct tm* time)
+{
+    int idx = 0;
+    (void)length;
+    if (!ExtractDate(date, format, time, &idx))
+        return ASN_TIME_E;
+    return 0;
+}
+
+int wc_GetCertDates(Cert* cert, struct tm* before, struct tm* after)
+{
+    int ret = 0;
+    const byte* date;
+    byte format;
+    int length;
+
+    if (cert == NULL)
+        return BAD_FUNC_ARG;
+
+    if (before && cert->beforeDateSz > 0) {
+        ret = wc_GetDateInfo(cert->beforeDate, cert->beforeDateSz, &date,
+                             &format, &length);
+        if (ret == 0)
+            ret = wc_GetDateAsCalendarTime(date, length, format, before);
+    }
+    if (after && cert->afterDateSz > 0) {
+        ret = wc_GetDateInfo(cert->afterDate, cert->afterDateSz, &date,
+                             &format, &length);
+        if (ret == 0)
+            ret = wc_GetDateAsCalendarTime(date, length, format, after);
+    }
+
+    return ret;
+}
+#endif /* !NO_ASN_TIME */
 
 
 int DecodeToKey(DecodedCert* cert, int verify)
@@ -11470,7 +11556,7 @@ int wc_SetSubject(Cert* cert, const char* subjectFile)
 
 #ifdef WOLFSSL_ALT_NAMES
 
-/* Set atl names from file in PEM */
+/* Set alt names from file in PEM */
 int wc_SetAltNames(Cert* cert, const char* file)
 {
     int         ret;
@@ -12298,23 +12384,16 @@ int wc_Ed25519PrivateKeyToDer(ed25519_key* key, byte* output, word32 inLen)
 static int GetBasicDate(const byte* source, word32* idx, byte* date,
                         byte* format, int maxIdx)
 {
-    int    length;
+    int    ret, length;
+    byte  *datePtr = NULL;
 
     WOLFSSL_ENTER("GetBasicDate");
 
-    *format = source[*idx];
-    *idx += 1;
-    if (*format != ASN_UTC_TIME && *format != ASN_GENERALIZED_TIME)
-        return ASN_TIME_E;
+    ret = GetDateInfo(source, idx, &datePtr, format, &length, maxIdx);
+    if (ret < 0)
+        return ret;
 
-    if (GetLength(source, idx, &length, maxIdx) < 0)
-        return ASN_PARSE_E;
-
-    if (length > MAX_DATE_SIZE || length < MIN_DATE_SIZE)
-        return ASN_DATE_SZ_E;
-
-    XMEMCPY(date, &source[*idx], length);
-    *idx += length;
+    XMEMCPY(date, datePtr, length);
 
     return 0;
 }
@@ -13154,7 +13233,7 @@ void FreeDecodedCRL(DecodedCRL* dcrl)
 static int GetRevoked(const byte* buff, word32* idx, DecodedCRL* dcrl,
                       int maxIdx)
 {
-    int    len;
+    int    ret, len;
     word32 end;
     byte   b;
     RevokedCert* rc;
@@ -13184,21 +13263,12 @@ static int GetRevoked(const byte* buff, word32* idx, DecodedCRL* dcrl,
     dcrl->certs = rc;
     dcrl->totalCerts++;
 
-
     /* get date */
-    b = buff[*idx];
-    *idx += 1;
-
-    if (b != ASN_UTC_TIME && b != ASN_GENERALIZED_TIME) {
+    ret = GetDateInfo(buff, idx, NULL, &b, NULL, maxIdx);
+    if (ret < 0) {
         WOLFSSL_MSG("Expecting Date");
-        return ASN_PARSE_E;
+        return ret;
     }
-
-    if (GetLength(buff, idx, &len, maxIdx) < 0)
-        return ASN_PARSE_E;
-
-    /* skip for now */
-    *idx += len;
 
     if (*idx != end)  /* skip extensions */
         *idx = end;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4705,7 +4705,7 @@ int wc_GetDateAsCalendarTime(const byte* date, int length, byte format,
     return 0;
 }
 
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_ALT_NAMES)
 int wc_GetCertDates(Cert* cert, struct tm* before, struct tm* after)
 {
     int ret = 0;
@@ -4731,7 +4731,7 @@ int wc_GetCertDates(Cert* cert, struct tm* before, struct tm* after)
 
     return ret;
 }
-#endif /* WOLFSSL_CERT_GEN */
+#endif /* WOLFSSL_CERT_GEN && WOLFSSL_ALT_NAMES */
 #endif /* !NO_ASN_TIME */
 
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1281,12 +1281,6 @@ int asn_test(void)
     byte format;
     int length;
     const byte* datePart;
-
-    ret = wc_GetDateInfo(dateBuf, (int)sizeof(dateBuf), &datePart, &format,
-                         &length);
-    if (ret != 0)
-        return -1300;
-
 #ifndef NO_ASN_TIME
     struct tm time;
     #ifdef WORD64_AVAILABLE
@@ -1294,7 +1288,14 @@ int asn_test(void)
     #else
         word32 now;
     #endif
+#endif
 
+    ret = wc_GetDateInfo(dateBuf, (int)sizeof(dateBuf), &datePart, &format,
+                         &length);
+    if (ret != 0)
+        return -1300;
+
+#ifndef NO_ASN_TIME
     /* Parameter Validation tests. */
     if (wc_GetTime(NULL, sizeof(now)) != BAD_FUNC_ARG)
         return -1301;
@@ -9801,7 +9802,7 @@ int rsa_test(void)
     #ifdef WOLFSSL_TEST_CERT
         DecodedCert decode;
     #endif
-    #ifndef NO_ASN_TIME
+    #if defined(WOLFSSL_ALT_NAMES) && !defined(NO_ASN_TIME)
         struct tm beforeTime;
         struct tm afterTime;
     #endif
@@ -9946,13 +9947,6 @@ int rsa_test(void)
             ERROR_OUT(-5595, exit_rsa);
         }
 
-    #ifndef NO_ASN_TIME
-        ret = wc_GetCertDates(&myCert, &beforeTime, &afterTime);
-        if (ret < 0) {
-            ERROR_OUT(-5576, exit_rsa);
-        }
-    #endif
-
         ret = 0;
         do {
         #if defined(WOLFSSL_ASYNC_CRYPT)
@@ -9964,7 +9958,7 @@ int rsa_test(void)
             }
         } while (ret == WC_PENDING_E);
         if (ret < 0) {
-            ERROR_OUT(-5597, exit_rsa);
+            ERROR_OUT(-5596, exit_rsa);
         }
         certSz = ret;
 
@@ -9973,13 +9967,13 @@ int rsa_test(void)
         ret = ParseCert(&decode, CERT_TYPE, NO_VERIFY, 0);
         if (ret != 0) {
             FreeDecodedCert(&decode);
-            ERROR_OUT(-5598, exit_rsa);
+            ERROR_OUT(-5597, exit_rsa);
         }
         FreeDecodedCert(&decode);
     #endif
 
         ret = SaveDerAndPem(der, certSz, pem, FOURK_BUF, otherCertDerFile,
-            otherCertPemFile, CERT_TYPE, -5599);
+            otherCertPemFile, CERT_TYPE, -5598);
         if (ret != 0) {
             goto exit_rsa;
         }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1274,7 +1274,21 @@ int base16_test(void)
 #ifndef NO_ASN
 int asn_test(void)
 {
+    int ret;
+    /* ASN1 encoded date buffer */
+    const byte dateBuf[] = {0x17, 0x0d, 0x31, 0x36, 0x30, 0x38, 0x31, 0x31,
+                            0x32, 0x30, 0x30, 0x37, 0x33, 0x37, 0x5a};
+    byte format;
+    int length;
+    const byte* datePart;
+
+    ret = wc_GetDateInfo(dateBuf, (int)sizeof(dateBuf), &datePart, &format,
+                         &length);
+    if (ret != 0)
+        return -1300;
+
 #ifndef NO_ASN_TIME
+    struct tm time;
     #ifdef WORD64_AVAILABLE
         word64 now;
     #else
@@ -1283,23 +1297,27 @@ int asn_test(void)
 
     /* Parameter Validation tests. */
     if (wc_GetTime(NULL, sizeof(now)) != BAD_FUNC_ARG)
-        return -1300;
-    if (wc_GetTime(&now, 0) != BUFFER_E)
         return -1301;
+    if (wc_GetTime(&now, 0) != BUFFER_E)
+        return -1302;
 
     now = 0;
     if (wc_GetTime(&now, sizeof(now)) != 0) {
-        return -1302;
+        return -1303;
     }
     if (now == 0) {
         printf("RTC/Time not set!\n");
-        return -1303;
+        return -1304;
     }
-#endif
+
+    ret = wc_GetDateAsCalendarTime(datePart, length, format, &time);
+    if (ret != 0)
+        return -1305;
+#endif /* !NO_ASN_TIME */
 
     return 0;
 }
-#endif
+#endif /* !NO_ASN */
 
 #ifdef WOLFSSL_MD2
 int md2_test(void)
@@ -7701,6 +7719,9 @@ byte GetEntropy(ENTROPY_CMD cmd, byte* out)
         #ifdef WOLFSSL_CERT_GEN
             static const char* rsaCaKeyFile  = CERT_ROOT "ca-key.der";
             static const char* rsaCaCertFile = CERT_ROOT "ca-cert.pem";
+            #ifdef WOLFSSL_ALT_NAMES
+            static const char* rsaCaCertDerFile = CERT_ROOT "ca-cert.der";
+            #endif
         #endif
     #endif /* !NO_RSA */
     #ifndef NO_DH
@@ -7865,7 +7886,7 @@ static const CertName certDefaultName = {
 
 #ifndef NO_RSA
 
-#if !defined(NO_ASN_TIME) && defined(WOLFSSL_TEST_CERT)
+#ifdef WOLFSSL_TEST_CERT
 int cert_test(void)
 {
     DecodedCert cert;
@@ -7919,7 +7940,7 @@ done:
 
     return ret;
 }
-#endif
+#endif /* WOLFSSL_TEST_CERT */
 
 #if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_TEST_CERT)
 int certext_test(void)
@@ -9560,7 +9581,7 @@ int rsa_test(void)
 #endif
 
 #ifdef sizeof
-        #undef sizeof
+    #undef sizeof
 #endif
 
 #ifdef WOLFSSL_TEST_CERT
@@ -9780,6 +9801,10 @@ int rsa_test(void)
     #ifdef WOLFSSL_TEST_CERT
         DecodedCert decode;
     #endif
+    #ifndef NO_ASN_TIME
+        struct tm beforeTime;
+        struct tm afterTime;
+    #endif
 
         der = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         if (der == NULL) {
@@ -9789,6 +9814,54 @@ int rsa_test(void)
         if (pem == NULL) {
             ERROR_OUT(-5581, exit_rsa);
         }
+
+        /* Setup Certificate */
+        if (wc_InitCert(&myCert)) {
+            ERROR_OUT(-5582, exit_rsa);
+        }
+
+#ifdef WOLFSSL_ALT_NAMES
+        /* Get CA Cert for testing */
+    #ifdef USE_CERT_BUFFERS_1024
+        XMEMCPY(tmp, ca_cert_der_1024, sizeof_ca_cert_der_1024);
+        bytes3 = sizeof_ca_cert_der_1024;
+    #elif defined(USE_CERT_BUFFERS_2048)
+        XMEMCPY(tmp, ca_cert_der_2048, sizeof_ca_cert_der_2048);
+        bytes3 = sizeof_ca_cert_der_2048;
+    #else
+        file3 = fopen(rsaCaCertDerFile, "rb");
+        if (!file3) {
+            ERROR_OUT(-5583, exit_rsa);
+        }
+        bytes3 = fread(tmp, 1, FOURK_BUF, file3);
+        fclose(file3);
+    #endif /* USE_CERT_BUFFERS */
+
+    #ifndef NO_FILESYSTEM
+        ret = wc_SetAltNames(&myCert, rsaCaCertFile);
+        if (ret != 0) {
+            ERROR_OUT(-5584, exit_rsa);
+        }
+    #endif
+        /* get alt names from der */
+        ret = wc_SetAltNamesBuffer(&myCert, tmp, (int)bytes3);
+        if (ret != 0) {
+            ERROR_OUT(-5585, exit_rsa);
+        }
+
+        /* get dates from der */
+        ret = wc_SetDatesBuffer(&myCert, tmp, (int)bytes3);
+        if (ret != 0) {
+            ERROR_OUT(-5586, exit_rsa);
+        }
+
+    #ifndef NO_ASN_TIME
+        ret = wc_GetCertDates(&myCert, &beforeTime, &afterTime);
+        if (ret < 0) {
+            ERROR_OUT(-5587, exit_rsa);
+        }
+    #endif
+#endif /* WOLFSSL_ALT_NAMES */
 
         /* Get CA Key */
     #ifdef USE_CERT_BUFFERS_1024
@@ -9800,7 +9873,7 @@ int rsa_test(void)
     #else
         file3 = fopen(rsaCaKeyFile, "rb");
         if (!file3) {
-            ERROR_OUT(-5582, exit_rsa);
+            ERROR_OUT(-5588, exit_rsa);
         }
 
         bytes3 = fread(tmp, 1, FOURK_BUF, file3);
@@ -9809,16 +9882,11 @@ int rsa_test(void)
 
         ret = wc_InitRsaKey(&caKey, HEAP_HINT);
         if (ret != 0) {
-            ERROR_OUT(-5583, exit_rsa);
+            ERROR_OUT(-5589, exit_rsa);
         }
         ret = wc_RsaPrivateKeyDecode(tmp, &idx3, &caKey, (word32)bytes3);
         if (ret != 0) {
-            ERROR_OUT(-5584, exit_rsa);
-        }
-
-        /* Setup Certificate */
-        if (wc_InitCert(&myCert)) {
-            ERROR_OUT(-5585, exit_rsa);
+            ERROR_OUT(-5590, exit_rsa);
         }
 
     #ifndef NO_SHA256
@@ -9837,7 +9905,7 @@ int rsa_test(void)
 
         /* add SKID from the Public Key */
         if (wc_SetSubjectKeyIdFromPublicKey(&myCert, &key, NULL) != 0) {
-            ERROR_OUT(-5586, exit_rsa);
+            ERROR_OUT(-5591, exit_rsa);
         }
 
         /* add AKID from the CA certificate */
@@ -9851,12 +9919,12 @@ int rsa_test(void)
         ret = wc_SetAuthKeyId(&myCert, rsaCaCertFile);
     #endif
         if (ret != 0) {
-            ERROR_OUT(-5587, exit_rsa);
+            ERROR_OUT(-5592, exit_rsa);
         }
 
         /* add Key Usage */
         if (wc_SetKeyUsage(&myCert,"keyEncipherment,keyAgreement") != 0) {
-            ERROR_OUT(-5588, exit_rsa);
+            ERROR_OUT(-5593, exit_rsa);
         }
     #endif /* WOLFSSL_CERT_EXT */
 
@@ -9870,13 +9938,20 @@ int rsa_test(void)
         ret = wc_SetIssuer(&myCert, rsaCaCertFile);
     #endif
         if (ret < 0) {
-            ERROR_OUT(-5589, exit_rsa);
+            ERROR_OUT(-5594, exit_rsa);
         }
 
         certSz = wc_MakeCert(&myCert, der, FOURK_BUF, &key, NULL, &rng);
         if (certSz < 0) {
-            ERROR_OUT(-5590, exit_rsa);
+            ERROR_OUT(-5595, exit_rsa);
         }
+
+    #ifndef NO_ASN_TIME
+        ret = wc_GetCertDates(&myCert, &beforeTime, &afterTime);
+        if (ret < 0) {
+            ERROR_OUT(-5576, exit_rsa);
+        }
+    #endif
 
         ret = 0;
         do {
@@ -9889,7 +9964,7 @@ int rsa_test(void)
             }
         } while (ret == WC_PENDING_E);
         if (ret < 0) {
-            ERROR_OUT(-5591, exit_rsa);
+            ERROR_OUT(-5597, exit_rsa);
         }
         certSz = ret;
 
@@ -9898,13 +9973,13 @@ int rsa_test(void)
         ret = ParseCert(&decode, CERT_TYPE, NO_VERIFY, 0);
         if (ret != 0) {
             FreeDecodedCert(&decode);
-            ERROR_OUT(-5592, exit_rsa);
+            ERROR_OUT(-5598, exit_rsa);
         }
         FreeDecodedCert(&decode);
     #endif
 
         ret = SaveDerAndPem(der, certSz, pem, FOURK_BUF, otherCertDerFile,
-            otherCertPemFile, CERT_TYPE, -5593);
+            otherCertPemFile, CERT_TYPE, -5599);
         if (ret != 0) {
             goto exit_rsa;
         }

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -30,6 +30,11 @@
 
 #ifndef NO_ASN
 
+
+#if !defined(NO_ASN_TIME) && defined(NO_TIME_H)
+    #define NO_ASN_TIME /* backwards compatibility with NO_TIME_H */
+#endif
+
 #include <wolfssl/wolfcrypt/integer.h>
 
 /* fips declare of RsaPrivateKeyDecode @wc_fips */

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -288,6 +288,11 @@ WOLFSSL_API int wc_SetSubjectBuffer(Cert*, const byte*, int);
 WOLFSSL_API int wc_SetAltNamesBuffer(Cert*, const byte*, int);
 WOLFSSL_API int wc_SetDatesBuffer(Cert*, const byte*, int);
 
+#ifndef NO_ASN_TIME
+WOLFSSL_API int wc_GetCertDates(Cert* cert, struct tm* before, 
+    struct tm* after);
+#endif
+
 #ifdef WOLFSSL_CERT_EXT
 WOLFSSL_API int wc_SetAuthKeyIdFromPublicKey_ex(Cert *cert, int keyType,
                                                 void* key);
@@ -339,6 +344,12 @@ WOLFSSL_API int wc_SetExtKeyUsageOID(Cert *cert, const char *oid, word32 sz,
 
 #endif /* WOLFSSL_CERT_GEN */
 
+WOLFSSL_API int wc_GetDateInfo(const byte* certDate, int certDateSz, 
+    const byte** date, byte* format, int* length);
+#ifndef NO_ASN_TIME
+WOLFSSL_API int wc_GetDateAsCalendarTime(const byte* date, int length,
+    byte format, struct tm* time);
+#endif
 
 #if defined(WOLFSSL_PEM_TO_DER) || defined(WOLFSSL_DER_TO_PEM)
 
@@ -426,6 +437,7 @@ WOLFSSL_API int wc_GetPkcs8TraditionalOffset(byte* input,
 WOLFSSL_API int wc_CreatePKCS8Key(byte* out, word32* outSz,
        byte* key, word32 keySz, int algoID, const byte* curveOID, word32 oidSz);
 
+#ifndef NO_ASN_TIME
 /* Time */
 /* Returns seconds (Epoch/UTC)
  * timePtr: is "time_t", which is typically "long"
@@ -434,6 +446,7 @@ WOLFSSL_API int wc_CreatePKCS8Key(byte* out, word32* outSz,
     rc = wc_GetTime(&lTime, (word32)sizeof(lTime));
 */
 WOLFSSL_API int wc_GetTime(void* timePtr, word32 timeSize);
+#endif
 
 #ifdef WOLFSSL_ENCRYPTED_KEYS
     WOLFSSL_API int wc_EncryptedInfoGet(EncryptedInfo* info,


### PR DESCRIPTION
* Refactor the ASN get date logic to combine shared code.
* Added new API `wc_GetDateInfo` to get raw date, format and length.
* Added new API `wc_GetCertDates` to extract certificate before/after dates as `struct tm` type.
* Added new API `wc_GetDateAsCalendarTime` which parses the raw date string and convers to `struct tm`.
* Added tests for new API's.
* Added missing tests for `wc_SetAltNames`, `wc_SetAltNamesBuffer` and `wc_SetDatesBuffer`.
* Fixed build for older `NO_TIME_H` macro.