### PR TITLE
Build fixes for a few configurations

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -56,11 +56,20 @@
 #endif
 #endif /* HAVE_QSH */
 
-#if !defined(NO_WOLFSSL_SERVER) && defined(WOLFSSL_TLS13) && \
-                                          !defined(WOLFSSL_NO_SERVER_GROUPS_EXT)
+#if (!defined(NO_WOLFSSL_SERVER) && defined(WOLFSSL_TLS13) && \
+        !defined(WOLFSSL_NO_SERVER_GROUPS_EXT)) || \
+    (defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES))
 static int TLSX_KeyShare_IsSupported(int namedGroup);
+#endif
+
+#if (!defined(NO_WOLFSSL_SERVER) && defined(WOLFSSL_TLS13) && \
+        !defined(WOLFSSL_NO_SERVER_GROUPS_EXT)) || \
+    (defined(WOLFSSL_TLS13) && !defined(HAVE_ECC) && \
+        defined(HAVE_SUPPORTED_CURVES)) || \
+    (defined(HAVE_ECC) && defined(HAVE_SUPPORTED_CURVES))
 static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions);
 #endif
+
 
 #ifndef NO_TLS
 
@@ -8130,9 +8139,13 @@ static byte* TLSX_QSHKeyFind_Pub(QSHKey* qsh, word16* pubLen, word16 name)
 }
 #endif /* HAVE_QSH */
 
+#if (!defined(NO_WOLFSSL_SERVER) && defined(WOLFSSL_TLS13) && !defined(WOLFSSL_NO_SERVER_GROUPS_EXT)) || \
+    (defined(WOLFSSL_TLS13) && !defined(HAVE_ECC) && defined(HAVE_SUPPORTED_CURVES)) || \
+    (defined(HAVE_ECC) && defined(HAVE_SUPPORTED_CURVES))
+
 static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions)
 {
-    int ret;
+    int ret = WOLFSSL_SUCCESS;
 #ifdef WOLFSSL_TLS13
     int i;
 
@@ -8151,7 +8164,7 @@ static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions)
         }
         return WOLFSSL_SUCCESS;
     }
-#endif
+#endif /* WOLFSSL_TLS13 */
 
 #if defined(HAVE_ECC) && defined(HAVE_SUPPORTED_CURVES)
     #ifndef HAVE_FIPS
@@ -8205,6 +8218,7 @@ static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions)
             #endif
         #endif
 #endif /* HAVE_ECC && HAVE_SUPPORTED_CURVES */
+
         #ifndef HAVE_FIPS
             #if defined(HAVE_CURVE25519)
                 ret = TLSX_UseSupportedCurve(extensions,
@@ -8212,6 +8226,7 @@ static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions)
                 if (ret != WOLFSSL_SUCCESS) return ret;
             #endif
         #endif /* HAVE_FIPS */
+
 #if defined(HAVE_ECC) && defined(HAVE_SUPPORTED_CURVES)
         #if !defined(NO_ECC256)  || defined(HAVE_ALL_CURVES)
             #ifdef HAVE_ECC_KOBLITZ
@@ -8251,7 +8266,7 @@ static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions)
                 if (ret != WOLFSSL_SUCCESS) return ret;
             #endif
         #endif
-#endif
+#endif /* HAVE_ECC && HAVE_SUPPORTED_CURVES */
 
     #ifdef WOLFSSL_TLS13
         if (IsAtLeastTLSv1_3(ssl->version)) {
@@ -8287,10 +8302,15 @@ static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions)
                     return ret;
         #endif
         }
-    #endif
+    #endif /* WOLFSSL_TLS13 */
 
-    return WOLFSSL_SUCCESS;
+    (void)ssl;
+    (void)extensions;
+
+    return ret;
 }
+
+#endif
 
 int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
 {
@@ -8430,7 +8450,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                 return ret;
             }
 
-        #if !defined(HAVE_ECC) && defined(HAVE_SUPPORTED_CURVES)
+    #if !defined(HAVE_ECC) && defined(HAVE_SUPPORTED_CURVES)
         if (TLSX_Find(ssl->ctx->extensions, TLSX_SUPPORTED_GROUPS) == NULL) {
             /* Put in DH groups for TLS 1.3 only. */
             ret = TLSX_PopulateSupportedGroups(ssl, &ssl->extensions);
@@ -8438,7 +8458,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                 return ret;
             ret = 0;
         }
-        #endif /* !HAVE_ECC && HAVE_SUPPORTED_CURVES */
+    #endif /* !HAVE_ECC && HAVE_SUPPORTED_CURVES */
 
         #if !defined(WOLFSSL_TLS13_DRAFT_18) && !defined(WOLFSSL_TLS13_DRAFT_22)
             if (ssl->certHashSigAlgoSz > 0) {

--- a/wolfssl/wolfcrypt/wc_encrypt.h
+++ b/wolfssl/wolfcrypt/wc_encrypt.h
@@ -42,7 +42,7 @@
     #define WC_MAX_SYM_KEY_SIZE     (AES_MAX_KEY_SIZE/8)
 #elif defined(HAVE_CHACHA)
     #define WC_MAX_SYM_KEY_SIZE     CHACHA_MAX_KEY_SZ
-#elif !defined(NO_DES)
+#elif !defined(NO_DES3)
     #define WC_MAX_SYM_KEY_SIZE     DES3_KEY_SIZE
 #elif !defined(NO_RC4)
     #define WC_MAX_SYM_KEY_SIZE     RC4_KEY_SIZE


### PR DESCRIPTION
* Fixes build issue using wrong DES define for `WC_MAX_SYM_KEY_SIZE` macro. Reproduced using `./configure --enable-leanpsk --enable-des3`. Occurred when AES and ChaCha20 were both disabled. Fixes issue #1518.
* Fixes Jenkins report `Expected Configurations Test - NIGHTLY BUILD #267`, building `./configure --disable-asn --disable-ecc --disable-rsa --enable-psk --enable-sni`. Reported unused variables, parameters and function.