### PR TITLE
Refactor of the TLSX code to support returning error codes

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -48,6 +48,7 @@
     #include "libntruencrypt/ntru_crypto.h"
     #include <wolfssl/wolfcrypt/random.h>
 #endif
+
 #ifdef HAVE_QSH
     static int TLSX_AddQSHKey(QSHKey** list, QSHKey* key);
     static byte* TLSX_QSHKeyFind_Pub(QSHKey* qsh, word16* pubLen, word16 name);
@@ -73,6 +74,18 @@ static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions);
 #else  /* TLS 1.1 or older */
     #if defined(NO_MD5) && defined(NO_SHA)
         #error Must have SHA1 and MD5 enabled for old TLS
+    #endif
+#endif
+
+#ifdef WOLFSSL_TLS13
+    #if !defined(NO_DH) && \
+        !defined(HAVE_FFDHE_2048) && !defined(HAVE_FFDHE_3072) && \
+        !defined(HAVE_FFDHE_4096) && !defined(HAVE_FFDHE_6144) && \
+        !defined(HAVE_FFDHE_8192)
+        #error Please configure your TLS 1.3 DH key size using either: HAVE_FFDHE_2048, HAVE_FFDHE_3072, HAVE_FFDHE_4096, HAVE_FFDHE_6144 or HAVE_FFDHE_8192
+    #endif
+    #if !defined(NO_RSA) && !defined(WC_RSA_PSS)
+        #error The build option WC_RSA_PSS is required for TLS 1.3 with RSA
     #endif
 #endif
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -129,10 +129,7 @@
 #endif
 
 #ifndef HAVE_HKDF
-    #error The build option `HAVE_HKDF` is required for TLS 1.3
-#endif
-#ifndef WC_RSA_PSS
-    #error The build option `WC_RSA_PSS` is required for TLS 1.3
+    #error The build option HAVE_HKDF is required for TLS 1.3
 #endif
 
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1946,26 +1946,28 @@ typedef struct TLSX {
     struct TLSX* next; /* List Behavior   */
 } TLSX;
 
-WOLFSSL_LOCAL TLSX*  TLSX_Find(TLSX* list, TLSX_Type type);
-WOLFSSL_LOCAL void   TLSX_Remove(TLSX** list, TLSX_Type type, void* heap);
-WOLFSSL_LOCAL void   TLSX_FreeAll(TLSX* list, void* heap);
-WOLFSSL_LOCAL int    TLSX_SupportExtensions(WOLFSSL* ssl);
-WOLFSSL_LOCAL int    TLSX_PopulateExtensions(WOLFSSL* ssl, byte isRequest);
+WOLFSSL_LOCAL TLSX* TLSX_Find(TLSX* list, TLSX_Type type);
+WOLFSSL_LOCAL void  TLSX_Remove(TLSX** list, TLSX_Type type, void* heap);
+WOLFSSL_LOCAL void  TLSX_FreeAll(TLSX* list, void* heap);
+WOLFSSL_LOCAL int   TLSX_SupportExtensions(WOLFSSL* ssl);
+WOLFSSL_LOCAL int   TLSX_PopulateExtensions(WOLFSSL* ssl, byte isRequest);
 
 #ifndef NO_WOLFSSL_CLIENT
-WOLFSSL_LOCAL word16 TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType);
-WOLFSSL_LOCAL word16 TLSX_WriteRequest(WOLFSSL* ssl, byte* output,
-                                       byte msgType);
+WOLFSSL_LOCAL int   TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType, 
+                                         word16* pLength);
+WOLFSSL_LOCAL int   TLSX_WriteRequest(WOLFSSL* ssl, byte* output,
+                                       byte msgType, word16* pOffset);
 #endif
 
 #ifndef NO_WOLFSSL_SERVER
-WOLFSSL_LOCAL word16 TLSX_GetResponseSize(WOLFSSL* ssl, byte msgType);
-WOLFSSL_LOCAL word16 TLSX_WriteResponse(WOLFSSL* ssl, byte* output,
-                                        byte msgType);
+WOLFSSL_LOCAL int   TLSX_GetResponseSize(WOLFSSL* ssl, byte msgType, 
+                                          word16* pLength);
+WOLFSSL_LOCAL int   TLSX_WriteResponse(WOLFSSL *ssl, byte* output, byte msgType, 
+                                        word16* pOffset);
 #endif
 
-WOLFSSL_LOCAL int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length,
-                             byte msgType, Suites *suites);
+WOLFSSL_LOCAL int   TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length,
+                               byte msgType, Suites *suites);
 
 #elif defined(HAVE_SNI)                           \
    || defined(HAVE_MAX_FRAGMENT)                  \


### PR DESCRIPTION
* Changed because of build errors with `SANITY_MSG_E` `-394` trying to be returned as word16 without a cast. Even with a cast would get interpreted as a large size and handled incorrectly. The functions that were changed to handle a normal int return code were `TLSX_SupportedVersions_GetSize`, `TLSX_SupportedVersions_Write`, `TLSX_Cookie_GetSize` and `TLSX_Cookie_Write`. This also resulted in return code changes for `TLSX_GetRequestSize`, `TLSX_WriteRequest`, `TLSX_GetResponseSize` and `TLSX_WriteResponse`.
* Added build-time checks in `tls13.c` for dependencies on `HAVE_HKDF` and `WC_RSA_PSS`.