### PR TITLE
Port for using AWS FreeRTOS

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -21079,6 +21079,7 @@ int wolfSSL_RAND_write_file(const char* fname)
     return bytes;
 }
 
+#ifndef FREERTOS_TCP
 
 /* These constant values are protocol values made by egd */
 #if defined(USE_WOLFSSL_IO) && !defined(USE_WINDOWS_API)
@@ -21243,6 +21244,7 @@ int wolfSSL_RAND_egd(const char* nm)
 #endif /* defined(USE_WOLFSSL_IO) && !defined(USE_WINDOWS_API) */
 }
 
+#endif /* !FREERTOS_TCP */
 
 void wolfSSL_RAND_Cleanup(void)
 {

--- a/src/tls.c
+++ b/src/tls.c
@@ -6280,6 +6280,8 @@ static int TLSX_KeyShare_New(KeyShareEntry** list, int group, void *heap,
     *list = kse;
     *keyShareEntry = kse;
 
+    (void)heap;
+
     return 0;
 }
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -302,7 +302,7 @@ static int DeriveKeyMsg(WOLFSSL* ssl, byte* output, int outputLen,
     word32      hashSz = 0;
     const byte* protocol;
     word32      protocolLen;
-    int         digestAlg;
+    int         digestAlg = -1;
     int         ret = BAD_FUNC_ARG;
 
     switch (hashAlgo) {
@@ -345,7 +345,13 @@ static int DeriveKeyMsg(WOLFSSL* ssl, byte* output, int outputLen,
             digestAlg = WC_SHA512;
             break;
 #endif
+        default:
+            digestAlg = -1;
+            break;
     }
+
+    if (digestAlg < 0)
+        return HASH_TYPE_E;
 
     if (ret != 0)
         return ret;
@@ -3729,7 +3735,7 @@ static int RestartHandshakeHashWithCookie(WOLFSSL* ssl, Cookie* cookie)
 int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                        word32 helloSz)
 {
-    int             ret;
+    int             ret = VERSION_ERROR;
     byte            b;
     ProtocolVersion pv;
     Suites          clSuites;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -171,7 +171,7 @@
 	    #if defined(_MSC_VER)
 	        #define THREAD_LS_T __declspec(thread)
 	    /* Thread local storage only in FreeRTOS v8.2.1 and higher */
-	    #elif defined(FREERTOS)
+	    #elif defined(FREERTOS) || defined(FREERTOS_TCP)
 	        #define THREAD_LS_T
 	    #else
 	        #define THREAD_LS_T __thread
@@ -329,7 +329,7 @@
         #if defined(MICROCHIP_PIC32) || defined(WOLFSSL_TIRTOS)
             /* XC32 does not support strncasecmp, so use case sensitive one */
             #define XSTRNCASECMP(s1,s2,n) strncmp((s1),(s2),(n))
-        #elif defined(USE_WINDOWS_API)
+        #elif defined(USE_WINDOWS_API) || defined(FREERTOS_TCP_WINSIM)
 	        #define XSTRNCASECMP(s1,s2,n) _strnicmp((s1),(s2),(n))
         #else
             #if (defined(HAVE_STRINGS_H) || defined(WOLF_C99)) && \

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -219,6 +219,9 @@
 #else
     #define CloseSocket(s) close(s)
     #define StartTCP()
+    #ifdef FREERTOS_TCP_WINSIM
+        extern int close(int);
+    #endif
 #endif
 
 


### PR DESCRIPTION
* Fixes for building openssl compatibility with FreeRTOS. 
* Adds new define `FREERTOS_TCP_WINSIM` for building on Windows with the simulator.
* Fixes for TLS 1.3 possibly uninitialized vars.

Relates to https://github.com/wolfSSL/wolfssl-freertos/pull/2