### PR TITLE
Cleanup of the socket close code

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11563,16 +11563,6 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         return bio;
     }
 
-
-#ifdef USE_WINDOWS_API
-    #define CloseSocket(s) closesocket(s)
-#elif defined(WOLFSSL_MDK_ARM)  || defined(WOLFSSL_KEIL_TCP_NET)
-    #define CloseSocket(s) closesocket(s)
-    extern int closesocket(int);
-#else
-    #define CloseSocket(s) close(s)
-#endif
-
     /*
      * Note : If the flag BIO_NOCLOSE is set then freeing memory buffers is up
      *        to the application.

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -1337,7 +1337,7 @@ int EmbedOcspLookup(void* ctx, const char* url, int urlSz,
                                                  HTTP_SCRATCH_BUFFER_SIZE, ctx);
             }
 
-            close(sfd);
+            CloseSocket(sfd);
             XFREE(httpBuf, ctx, DYNAMIC_TYPE_OCSP);
         }
     }
@@ -1438,7 +1438,7 @@ int EmbedCrlLookup(WOLFSSL_CRL* crl, const char* url, int urlSz)
                                                       HTTP_SCRATCH_BUFFER_SIZE);
             }
 
-            close(sfd);
+            CloseSocket(sfd);
             XFREE(httpBuf, crl->heap, DYNAMIC_TYPE_CRL);
         }
     }

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -183,17 +183,6 @@
 #endif
 
 
-#ifdef USE_WINDOWS_API
-    #define CloseSocket(s) closesocket(s)
-    #define StartTCP() { WSADATA wsd; WSAStartup(0x0002, &wsd); }
-#elif defined(WOLFSSL_MDK_ARM) || defined(WOLFSSL_KEIL_TCP_NET)
-    #define CloseSocket(s) closesocket(s)
-    #define StartTCP()
-#else
-    #define CloseSocket(s) close(s)
-    #define StartTCP()
-#endif
-
 
 #ifdef SINGLE_THREADED
     typedef unsigned int  THREAD_RETURN;

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -147,7 +147,6 @@
     #define SOCKET_EPIPE       WSAEPIPE
     #define SOCKET_ECONNREFUSED WSAENOTCONN
     #define SOCKET_ECONNABORTED WSAECONNABORTED
-    #define close(s) closesocket(s)
 #elif defined(__PPU)
     #define SOCKET_EWOULDBLOCK SYS_NET_EWOULDBLOCK
     #define SOCKET_EAGAIN      SYS_NET_EAGAIN
@@ -208,6 +207,20 @@
     #define SOCKET_ECONNREFUSED ECONNREFUSED
     #define SOCKET_ECONNABORTED ECONNABORTED
 #endif /* USE_WINDOWS_API */
+
+
+#ifdef USE_WINDOWS_API
+    #define CloseSocket(s) closesocket(s)
+    #define StartTCP() { WSADATA wsd; WSAStartup(0x0002, &wsd); }
+#elif defined(WOLFSSL_MDK_ARM) || defined(WOLFSSL_KEIL_TCP_NET)
+    extern int closesocket(int);
+    #define CloseSocket(s) closesocket(s)
+    #define StartTCP()
+#else
+    #define CloseSocket(s) close(s)
+    #define StartTCP()
+#endif
+
 
 
 #ifdef DEVKITPRO


### PR DESCRIPTION
* Socket close is used for examples, CRL/OCSP and BIO.
* Now only a single macro `CloseSocket ` is responsible for closing a socket.
* Removed duplicate socket close code.