### PR TITLE
openSSL compatibility APIs: X509_CRL

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -490,7 +490,7 @@ int BufferLoadCRL(WOLFSSL_CRL* crl, const byte* buff, long sz, int type,
     return ret ? ret : WOLFSSL_SUCCESS; /* convert 0 to WOLFSSL_SUCCESS */
 }
 
-#if defined(OPENSSL_EXTRA) || defined(HAVE_CRL)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_CRL)
 int wolfSSL_X509_STORE_add_crl(WOLFSSL_X509_STORE *store, WOLFSSL_X509_CRL *newcrl)
 {
     CRL_Entry   *crle;

--- a/src/crl.c
+++ b/src/crl.c
@@ -155,7 +155,6 @@ void FreeCRL(WOLFSSL_CRL* crl, int dynamic)
     CRL_Entry* tmp = crl->crlList;
 
     WOLFSSL_ENTER("FreeCRL");
-    printf("sizeof(CRL_Entry)=%lu\n", sizeof(CRL_Entry));
     if (crl->monitors[0].path)
         XFREE(crl->monitors[0].path, crl->heap, DYNAMIC_TYPE_CRL_MONITOR);
 

--- a/src/crl.c
+++ b/src/crl.c
@@ -49,8 +49,10 @@
 int InitCRL(WOLFSSL_CRL* crl, WOLFSSL_CERT_MANAGER* cm)
 {
     WOLFSSL_ENTER("InitCRL");
-
-    crl->heap = cm->heap;
+    if(cm != NULL)
+        crl->heap = cm->heap;
+    else
+        crl->heap = NULL;
     crl->cm = cm;
     crl->crlList = NULL;
     crl->monitors[0].path = NULL;
@@ -153,7 +155,7 @@ void FreeCRL(WOLFSSL_CRL* crl, int dynamic)
     CRL_Entry* tmp = crl->crlList;
 
     WOLFSSL_ENTER("FreeCRL");
-
+    printf("sizeof(CRL_Entry)=%lu\n", sizeof(CRL_Entry));
     if (crl->monitors[0].path)
         XFREE(crl->monitors[0].path, crl->heap, DYNAMIC_TYPE_CRL_MONITOR);
 

--- a/src/crl.c
+++ b/src/crl.c
@@ -490,6 +490,34 @@ int BufferLoadCRL(WOLFSSL_CRL* crl, const byte* buff, long sz, int type,
     return ret ? ret : WOLFSSL_SUCCESS; /* convert 0 to WOLFSSL_SUCCESS */
 }
 
+#if defined(OPENSSL_EXTRA) || defined(HAVE_CRL)
+int wolfSSL_X509_STORE_add_crl(WOLFSSL_X509_STORE *store, WOLFSSL_X509_CRL *newcrl)
+{
+    CRL_Entry   *crle;
+    WOLFSSL_CRL *crl;
+
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_add_crl");
+    if (store == NULL || newcrl == NULL)
+        return BAD_FUNC_ARG;
+
+    crl = store->crl;
+    crle = newcrl->crlList;
+
+    if (wc_LockMutex(&crl->crlLock) != 0)
+    {
+        WOLFSSL_MSG("wc_LockMutex failed");
+        return BAD_MUTEX_E;
+    }
+    crle->next = crl->crlList;
+    crl->crlList = crle;
+    newcrl->crlList = NULL;
+    wc_UnLockMutex(&crl->crlLock);
+
+    WOLFSSL_LEAVE("wolfSSL_X509_STORE_add_crl", WOLFSSL_SUCCESS);
+    
+    return WOLFSSL_SUCCESS;
+}
+#endif
 
 #ifdef HAVE_CRL_MONITOR
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -27478,6 +27478,7 @@ WOLFSSL_RSA *wolfSSL_d2i_RSAPublicKey(WOLFSSL_RSA **r, const unsigned char **pp,
     return rsa;
 }
 
+#if !defined(HAVE_FAST_RSA)
 int wolfSSL_i2d_RSAPublicKey(WOLFSSL_RSA *rsa, const unsigned char **pp)
 {
     byte *der;
@@ -27507,12 +27508,12 @@ int wolfSSL_i2d_RSAPublicKey(WOLFSSL_RSA *rsa, const unsigned char **pp)
     return ret;
 }
 
-
 /* return WOLFSSL_SUCCESS if success, WOLFSSL_FATAL_ERROR if error */
 int wolfSSL_RSA_LoadDer(WOLFSSL_RSA* rsa, const unsigned char* derBuf, int derSz)
 {
   return wolfSSL_RSA_LoadDer_ex(rsa, derBuf, derSz, WOLFSSL_RSA_LOAD_PRIVATE);
 }
+#endif /* #if !defined(HAVE_FAST_RSA) */
 
 int wolfSSL_RSA_LoadDer_ex(WOLFSSL_RSA* rsa, const unsigned char* derBuf,
                                                      int derSz, int opt)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -27497,7 +27497,7 @@ int wolfSSL_i2d_RSAPublicKey(WOLFSSL_RSA *rsa, const unsigned char **pp)
         return WOLFSSL_FATAL_ERROR;
     der = (byte*)XMALLOC(derLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (der == NULL) {
-        ret = WOLFSSL_FATAL_ERROR;
+        return WOLFSSL_FATAL_ERROR;
     }
     if((ret = SetRsaInternal(rsa)) != WOLFSSL_SUCCESS) {
         WOLFSSL_MSG("SetRsaInternal Failed");

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28499,7 +28499,7 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
         return x509;
     }
 
-#ifndef NO_FILESYSTEM
+#if defined(HAVE_CRL) && !defined(NO_FILESYSTEM)
     WOLFSSL_API WOLFSSL_X509_CRL* wolfSSL_PEM_read_X509_CRL(FILE *fp, WOLFSSL_X509_CRL **crl,
                                                     pem_password_cb *cb, void *u)
     {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -29310,6 +29310,102 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
         }
     }
 #endif /* ! NO_SHA256 */
+
+#if defined(WOLFSSL_SHA384) && defined(WOLFSSL_SHA512) 
+     /* One shot SHA384 hash of message.
+      *
+      * d  message to hash
+      * n  size of d buffer
+      * md buffer to hold digest. Should be WC_SHA256_DIGEST_SIZE.
+      *
+      * Note: if md is null then a static buffer of WC_SHA256_DIGEST_SIZE is used.
+      *       When the static buffer is used this function is not thread safe.
+      *
+      * Returns a pointer to the message digest on success and NULL on failure.
+      */
+     unsigned char *wolfSSL_SHA384(const unsigned char *d, size_t n,
+             unsigned char *md)
+     {
+         static byte dig[WC_SHA384_DIGEST_SIZE];
+         wc_Sha384 sha;
+
+         WOLFSSL_ENTER("wolfSSL_SHA384");
+
+         if (wc_InitSha384_ex(&sha, NULL, 0) != 0) {
+             WOLFSSL_MSG("SHA384 Init failed");
+             return NULL;
+         }
+
+         if (wc_Sha384Update(&sha, (const byte*)d, (word32)n) != 0) {
+             WOLFSSL_MSG("SHA384 Update failed");
+             return NULL;
+         }
+
+         if (wc_Sha384Final(&sha, dig) != 0) {
+             WOLFSSL_MSG("SHA384 Final failed");
+             return NULL;
+         }
+
+         wc_Sha384Free(&sha);
+
+         if (md != NULL) {
+             XMEMCPY(md, dig, WC_SHA384_DIGEST_SIZE);
+             return md;
+         }
+         else {
+             return (unsigned char*)dig;
+         }
+     }
+#endif /* defined(WOLFSSL_SHA384) && defined(WOLFSSL_SHA512)  */
+
+
+#if defined(WOLFSSL_SHA512) 
+     /* One shot SHA512 hash of message.
+      *
+      * d  message to hash
+      * n  size of d buffer
+      * md buffer to hold digest. Should be WC_SHA256_DIGEST_SIZE.
+      *
+      * Note: if md is null then a static buffer of WC_SHA256_DIGEST_SIZE is used.
+      *       When the static buffer is used this function is not thread safe.
+      *
+      * Returns a pointer to the message digest on success and NULL on failure.
+      */
+     unsigned char *wolfSSL_SHA512(const unsigned char *d, size_t n,
+             unsigned char *md)
+     {
+         static byte dig[WC_SHA512_DIGEST_SIZE];
+         wc_Sha384 sha;
+
+         WOLFSSL_ENTER("wolfSSL_SHA512");
+
+         if (wc_InitSha512_ex(&sha, NULL, 0) != 0) {
+             WOLFSSL_MSG("SHA512 Init failed");
+             return NULL;
+         }
+
+         if (wc_Sha512Update(&sha, (const byte*)d, (word32)n) != 0) {
+             WOLFSSL_MSG("SHA512 Update failed");
+             return NULL;
+         }
+
+         if (wc_Sha512Final(&sha, dig) != 0) {
+             WOLFSSL_MSG("SHA512 Final failed");
+             return NULL;
+         }
+
+         wc_Sha512Free(&sha);
+
+         if (md != NULL) {
+             XMEMCPY(md, dig, WC_SHA512_DIGEST_SIZE);
+             return md;
+         }
+         else {
+             return (unsigned char*)dig;
+         }
+     }
+#endif /* defined(WOLFSSL_SHA512)  */
+
     char wolfSSL_CTX_use_certificate(WOLFSSL_CTX *ctx, WOLFSSL_X509 *x)
     {
         int ret;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17983,7 +17983,7 @@ int wolfSSL_X509_verify_cert(WOLFSSL_X509_STORE_CTX* ctx)
 #ifndef NO_FILESYSTEM
 static void *wolfSSL_d2i_X509_fp_ex(XFILE file, void **x509, int type)
 {
-    void *new = NULL;
+    void *newx509 = NULL;
     DerBuffer*   der = NULL;
     byte *fileBuffer = NULL;
 
@@ -18010,13 +18010,13 @@ static void *wolfSSL_d2i_X509_fp_ex(XFILE file, void **x509, int type)
                 goto err_exit;
             }          
             if(type == CERT_TYPE)
-                new = (void *)wolfSSL_X509_d2i(NULL, fileBuffer, (int)sz);
+                newx509 = (void *)wolfSSL_X509_d2i(NULL, fileBuffer, (int)sz);
             #ifdef HAVE_CRL
             else if(type == CRL_TYPE)
-                new = (void *)wolfSSL_d2i_X509_CRL(NULL, fileBuffer, (int)sz);
+                newx509 = (void *)wolfSSL_d2i_X509_CRL(NULL, fileBuffer, (int)sz);
             #endif
             else goto err_exit;
-            if(new == NULL)
+            if(newx509 == NULL)
             {
                 WOLFSSL_MSG("X509 failed");
                 goto err_exit;
@@ -18024,18 +18024,18 @@ static void *wolfSSL_d2i_X509_fp_ex(XFILE file, void **x509, int type)
         }
     }
     if (x509 != NULL)
-        *x509 = new;
+        *x509 = newx509;
 
     goto _exit;
 
 err_exit:
-    if(new != NULL){
+    if(newx509 != NULL){
         if(type == CERT_TYPE)
-            wolfSSL_X509_free(new);
+            wolfSSL_X509_free((WOLFSSL_X509*)newx509);
         #ifdef HAVE_CRL
         else {
            if(type == CRL_TYPE)
-                wolfSSL_X509_CRL_free(new);
+                wolfSSL_X509_CRL_free((WOLFSSL_X509_CRL*)newx509);
         }
         #endif
     }
@@ -18044,7 +18044,7 @@ _exit:
         FreeDer(&der);
     if(fileBuffer != NULL)
         XFREE(fileBuffer, NULL, DYNAMIC_TYPE_FILE);
-    return new;
+    return newx509;
 }
 
 WOLFSSL_X509 *wolfSSL_d2i_X509_fp(XFILE fp, WOLFSSL_X509 **x509)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17993,7 +17993,7 @@ WOLFSSL_X509_CRL* wolfSSL_d2i_X509_CRL(WOLFSSL_X509_CRL** crl, const unsigned ch
 
 err_exit:
     if(newcrl != NULL)
-        XFREE(newcrl, NULL, DYNAMIC_TYPE_FILE); 
+        wolfSSL_X509_CRL_free(newcrl); 
     newcrl = NULL;
 _exit:
     return newcrl;
@@ -18046,7 +18046,7 @@ WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL_fp(WOLFSSL_X509_CRL **crl, XFILE file)
 
 err_exit:
     if(newcrl != NULL)
-        XFREE(newcrl, NULL, DYNAMIC_TYPE_FILE);
+        wolfSSL_X509_CRL_free(newcrl);
 _exit:
     if(der != NULL)
         FreeDer(&der);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -27502,20 +27502,19 @@ int wolfSSL_i2d_RSAPublicKey(WOLFSSL_RSA *rsa, const unsigned char **pp)
     if((ret = SetRsaInternal(rsa)) != WOLFSSL_SUCCESS) {
         WOLFSSL_MSG("SetRsaInternal Failed");
         XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        return _REXT_OK;
+        return ret;
     }
 
-#if 0
     if((ret = wc_RsaKeyToPublicDer((RsaKey *)rsa->internal, der, derLen)) < 0){
         WOLFSSL_MSG("RsaKeyToPublicDer failed");
         XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return ret;
     }
-#endif
 
     *pp = der;
     return ret;
 }
+
 
 /* return WOLFSSL_SUCCESS if success, WOLFSSL_FATAL_ERROR if error */
 int wolfSSL_RSA_LoadDer(WOLFSSL_RSA* rsa, const unsigned char* derBuf, int derSz)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -27507,13 +27507,14 @@ int wolfSSL_i2d_RSAPublicKey(WOLFSSL_RSA *rsa, const unsigned char **pp)
     *pp = der;
     return ret;
 }
+#endif /* #if !defined(HAVE_FAST_RSA) */
 
 /* return WOLFSSL_SUCCESS if success, WOLFSSL_FATAL_ERROR if error */
 int wolfSSL_RSA_LoadDer(WOLFSSL_RSA* rsa, const unsigned char* derBuf, int derSz)
 {
   return wolfSSL_RSA_LoadDer_ex(rsa, derBuf, derSz, WOLFSSL_RSA_LOAD_PRIVATE);
 }
-#endif /* #if !defined(HAVE_FAST_RSA) */
+
 
 int wolfSSL_RSA_LoadDer_ex(WOLFSSL_RSA* rsa, const unsigned char* derBuf,
                                                      int derSz, int opt)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17963,7 +17963,6 @@ int wolfSSL_X509_verify_cert(WOLFSSL_X509_STORE_CTX* ctx)
 WOLFSSL_X509_CRL* wolfSSL_d2i_X509_CRL(WOLFSSL_X509_CRL** crl, const unsigned char* in, int len)
 {
     WOLFSSL_X509_CRL *newcrl = NULL;
-    WOLFSSL_CERT_MANAGER *cert= NULL;
     int ret ;
 
     WOLFSSL_ENTER("wolfSSL_X509_CRL_d2i");
@@ -17978,12 +17977,7 @@ WOLFSSL_X509_CRL* wolfSSL_d2i_X509_CRL(WOLFSSL_X509_CRL** crl, const unsigned ch
         WOLFSSL_MSG("New CRL allocation failed");
         return NULL;
     }
-    cert = wolfSSL_CertManagerNew();
-    if (cert == NULL){
-        WOLFSSL_MSG("CertManagerNew failed");
-        goto err_exit;
-    }
-    if (InitCRL(newcrl, cert) < 0) {
+    if (InitCRL(newcrl, NULL) < 0) {
         WOLFSSL_MSG("Init tmp CRL failed");
         goto err_exit;
     }
@@ -18001,8 +17995,6 @@ err_exit:
     if(newcrl != NULL)
         XFREE(newcrl, NULL, DYNAMIC_TYPE_FILE); 
     newcrl = NULL;
-    if(cert != NULL)
-        wolfSSL_CertManagerFree(cert); 
 _exit:
     return newcrl;
 }
@@ -27481,8 +27473,8 @@ WOLFSSL_RSA *wolfSSL_d2i_RSAPublicKey(WOLFSSL_RSA **r, const unsigned char **pp,
         WOLFSSL_MSG("RSA_LoadDer failed");
         return NULL;
     }
-    
-    *r = rsa;
+    if(r != NULL)
+        *r = rsa;
     return rsa;
 }
 
@@ -28542,10 +28534,13 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
             goto err_exit;
         if((PemToDer(pem, pemSz, CRL_TYPE, &der, NULL, NULL, NULL)) < 0)
             goto err_exit;
+        XFREE(pem, 0, DYNAMIC_TYPE_PEM);
 
         derSz = der->length;
         if((newcrl = wolfSSL_d2i_X509_CRL(crl, (const unsigned char *)der->buffer, derSz)) == NULL)
             goto err_exit;
+        FreeDer(&der);
+
         return newcrl;
 
     err_exit:

--- a/tests/api.c
+++ b/tests/api.c
@@ -9854,7 +9854,7 @@ static int test_wc_RsaKeyToDer (void)
 static int test_wc_RsaKeyToPublicDer (void)
 { 
     int         ret = 0;
-#if (!defined(NO_RSA) || !defined(HAVE_FAST_RSA) || defined(WOLFSSL_KEY_GEN)) && \
+#if (!defined(NO_RSA) || !defined(HAVE_FAST_RSA)) && defined(WOLFSSL_KEY_GEN) && \
     (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
     RsaKey      key;
     WC_RNG      rng;

--- a/tests/api.c
+++ b/tests/api.c
@@ -17753,7 +17753,7 @@ static void test_wolfSSL_SHA(void)
     }
     #endif
 
-    #if !defined(WOLFSSL_SHA512)
+    #if defined(WOLFSSL_SHA512)
     {
         const unsigned char in[] = "abc";
         unsigned char expected[] = "\xdd\xaf\x35\xa1\x93\x61\x7a\xba\xcc\x41\x73\x49\xae\x20\x41"

--- a/tests/api.c
+++ b/tests/api.c
@@ -9852,9 +9852,10 @@ static int test_wc_RsaKeyToDer (void)
  *  Testing wc_RsaKeyToPublicDer()
  */
 static int test_wc_RsaKeyToPublicDer (void)
-{
+{ 
     int         ret = 0;
-#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
+#if (!defined(NO_RSA) || !defined(HAVE_FAST_RSA) || defined(WOLFSSL_KEY_GEN)) && \
+    (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
     RsaKey      key;
     WC_RNG      rng;
     byte*       der;

--- a/tests/api.c
+++ b/tests/api.c
@@ -17376,6 +17376,42 @@ static void test_wolfSSL_RSA(void)
 #endif
 }
 
+static void test_wolfSSL_RSA_DER(void)
+{
+#if defined(OPENSSL_EXTRA) && !defined(NO_RSA)
+
+    RSA *rsa;
+    int i;
+
+    struct
+    {
+        const unsigned char *der;
+        int sz;
+    } tbl[] = {
+#ifdef USE_CERT_BUFFERS_1024
+        {client_key_der_1024, sizeof_client_key_der_1024},
+        {server_key_der_1024, sizeof_server_key_der_1024},
+#endif
+#ifdef USE_CERT_BUFFERS_2048
+        {client_key_der_2048, sizeof_client_key_der_2048},
+        {server_key_der_2048, sizeof_server_key_der_2048},
+#endif
+        {NULL, 0}
+    };
+
+    printf(testingFmt, "test_wolfSSL_RSA_DER()");
+
+    for (i = 0; tbl[i].der != NULL; i++)
+    {
+        AssertNotNull(d2i_RSAPublicKey(&rsa, &tbl[i].der, tbl[i].sz));
+        AssertNotNull(rsa);
+        RSA_free(rsa);
+    }
+    printf(resultFmt, passed);
+
+#endif
+}
+
 static void test_wolfSSL_verify_depth(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_RSA)
@@ -18570,6 +18606,62 @@ static int test_wc_RNG_GenerateBlock()
 }
 #endif
 
+static void test_wolfSSL_X509_CRL(void)
+{
+#if defined(OPENSSL_EXTRA) && defined(HAVE_CRL)
+
+    X509_CRL *crl;
+    char pem[][100] = {
+        "./certs/crl/crl.pem",
+        "./certs/crl/crl2.pem",
+        "./certs/crl/caEccCrl.pem",
+        "./certs/crl/eccCliCRL.pem",
+        "./certs/crl/eccSrvCRL.pem",
+        ""
+    };
+
+    char der[][100] = {
+        "./certs/crl/crl.der",
+        "./certs/crl/crl2.der",
+        ""};
+
+    FILE * fp;
+    int i;
+
+    printf(testingFmt, "test_wolfSSL_X509_CRL");
+
+    for (i = 0; pem[i][0] != '\0'; i++)
+    {
+        AssertNotNull(fp = XFOPEN(pem[i], "rb"));
+        AssertNotNull(crl = (X509_CRL *)PEM_read_X509_CRL(fp, (X509_CRL **)NULL, NULL, NULL));
+        AssertNotNull(crl);
+        X509_CRL_free(crl);
+        XFCLOSE(fp);
+        AssertNotNull(fp = XFOPEN(pem[i], "rb"));
+        AssertNotNull((X509_CRL *)PEM_read_X509_CRL(fp, (X509_CRL **)&crl, NULL, NULL));
+        AssertNotNull(crl);
+        X509_CRL_free(crl);
+        XFCLOSE(fp);
+    }
+
+    for(i = 0; der[i][0] != '\0'; i++){
+        AssertNotNull(fp = XFOPEN(der[i], "rb"));
+        AssertNotNull(crl = (X509_CRL *)d2i_X509_CRL_fp((X509_CRL **)NULL, fp));
+        AssertNotNull(crl);
+        X509_CRL_free(crl);
+        XFCLOSE(fp);
+        AssertNotNull(fp = XFOPEN(der[i], "rb"));
+        AssertNotNull((X509_CRL *)d2i_X509_CRL_fp((X509_CRL **)&crl, fp));
+        AssertNotNull(crl);
+        X509_CRL_free(crl);
+        XFCLOSE(fp);
+    }
+
+    printf(resultFmt, passed);
+#endif
+        return;
+}
+
 /*----------------------------------------------------------------------------*
  | Main
  *----------------------------------------------------------------------------*/
@@ -18668,6 +18760,7 @@ void ApiTest(void)
     test_wolfSSL_sk_GENERAL_NAME();
     test_wolfSSL_MD4();
     test_wolfSSL_RSA();
+    test_wolfSSL_RSA_DER();
     test_wolfSSL_verify_depth();
     test_wolfSSL_HMAC_CTX();
     test_wolfSSL_msg_callback();
@@ -18676,6 +18769,7 @@ void ApiTest(void)
     test_wolfSSL_AES_ecb_encrypt();
     test_wolfSSL_SHA256();
     test_wolfSSL_X509_get_serialNumber();
+    test_wolfSSL_X509_CRL();
 
     /* test the no op functions for compatibility */
     test_no_op_functions();

--- a/tests/api.c
+++ b/tests/api.c
@@ -16671,6 +16671,9 @@ static void test_wolfSSL_X509(void)
     X509_STORE_CTX* ctx;
     X509_STORE* store;
 
+    char der[] = "certs/ca-cert.der";
+    XFILE fp;
+
     printf(testingFmt, "wolfSSL_X509()");
 
     AssertNotNull(x509 = X509_new());
@@ -16694,6 +16697,18 @@ static void test_wolfSSL_X509(void)
 
     X509_STORE_CTX_free(ctx);
     BIO_free(bio);
+
+    /** d2i_X509_fp test **/
+    AssertNotNull(fp = XFOPEN(der, "rb"));
+    AssertNotNull(x509 = (X509 *)d2i_X509_fp(fp, (X509 **)NULL));
+    AssertNotNull(x509);
+    X509_free(x509);
+    XFCLOSE(fp);
+    AssertNotNull(fp = XFOPEN(der, "rb"));
+    AssertNotNull((X509 *)d2i_X509_fp(fp, (X509 **)&x509));
+    AssertNotNull(x509);
+    X509_free(x509);
+    XFCLOSE(fp);
 
     printf(resultFmt, passed);
     #endif
@@ -18724,12 +18739,12 @@ static void test_wolfSSL_X509_CRL(void)
 #ifdef HAVE_TEST_d2i_X509_CRL_fp
     for(i = 0; der[i][0] != '\0'; i++){
         AssertNotNull(fp = XFOPEN(der[i], "rb"));
-        AssertNotNull(crl = (X509_CRL *)d2i_X509_CRL_fp((X509_CRL **)NULL, fp));
+        AssertNotNull(crl = (X509_CRL *)d2i_X509_CRL_fp((fp, X509_CRL **)NULL));
         AssertNotNull(crl);
         X509_CRL_free(crl);
         XFCLOSE(fp);
         AssertNotNull(fp = XFOPEN(der[i], "rb"));
-        AssertNotNull((X509_CRL *)d2i_X509_CRL_fp((X509_CRL **)&crl, fp));
+        AssertNotNull((X509_CRL *)d2i_X509_CRL_fp(fp, (X509_CRL **)&crl));
         AssertNotNull(crl);
         X509_CRL_free(crl);
         XFCLOSE(fp);

--- a/tests/api.c
+++ b/tests/api.c
@@ -17708,6 +17708,52 @@ static void test_wolfSSL_SHA(void)
         AssertIntEQ(XMEMCMP(out, expected, WC_SHA_DIGEST_SIZE), 0);
     }
     #endif
+
+    #if !defined(NO_SHA256)
+    {
+        const unsigned char in[] = "abc";
+        unsigned char expected[] = "\xBA\x78\x16\xBF\x8F\x01\xCF\xEA\x41\x41\x40\xDE\x5D\xAE\x22"
+            "\x23\xB0\x03\x61\xA3\x96\x17\x7A\x9C\xB4\x10\xFF\x61\xF2\x00"
+            "\x15\xAD";
+        unsigned char out[WC_SHA256_DIGEST_SIZE];
+     
+        XMEMSET(out, 0, WC_SHA256_DIGEST_SIZE);
+        AssertNotNull(SHA256(in, XSTRLEN((char*)in), out));
+        AssertIntEQ(XMEMCMP(out, expected, WC_SHA256_DIGEST_SIZE), 0);
+    }
+    #endif
+
+    #if defined(WOLFSSL_SHA384) && defined(WOLFSSL_SHA512) 
+    {
+        const unsigned char in[] = "abc";
+        unsigned char expected[] = "\xcb\x00\x75\x3f\x45\xa3\x5e\x8b\xb5\xa0\x3d\x69\x9a\xc6\x50"
+            "\x07\x27\x2c\x32\xab\x0e\xde\xd1\x63\x1a\x8b\x60\x5a\x43\xff"
+            "\x5b\xed\x80\x86\x07\x2b\xa1\xe7\xcc\x23\x58\xba\xec\xa1\x34"
+            "\xc8\x25\xa7";
+        unsigned char out[WC_SHA384_DIGEST_SIZE];
+
+        XMEMSET(out, 0, WC_SHA384_DIGEST_SIZE);
+        AssertNotNull(SHA384(in, XSTRLEN((char*)in), out));
+        AssertIntEQ(XMEMCMP(out, expected, WC_SHA384_DIGEST_SIZE), 0);
+    }
+    #endif
+
+    #if !defined(WOLFSSL_SHA512)
+    {
+        const unsigned char in[] = "abc";
+        unsigned char expected[] = "\xdd\xaf\x35\xa1\x93\x61\x7a\xba\xcc\x41\x73\x49\xae\x20\x41"
+           "\x31\x12\xe6\xfa\x4e\x89\xa9\x7e\xa2\x0a\x9e\xee\xe6\x4b\x55"
+            "\xd3\x9a\x21\x92\x99\x2a\x27\x4f\xc1\xa8\x36\xba\x3c\x23\xa3"
+            "\xfe\xeb\xbd\x45\x4d\x44\x23\x64\x3c\xe8\x0e\x2a\x9a\xc9\x4f"
+            "\xa5\x4c\xa4\x9f";
+        unsigned char out[WC_SHA512_DIGEST_SIZE];
+
+        XMEMSET(out, 0, WC_SHA512_DIGEST_SIZE);
+        AssertNotNull(SHA512(in, XSTRLEN((char*)in), out));
+        AssertIntEQ(XMEMCMP(out, expected, WC_SHA512_DIGEST_SIZE), 0);
+    }
+    #endif
+
     printf(resultFmt, passed);
 #endif
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -9516,7 +9516,8 @@ static int test_wc_RsaPublicKeyDecodeRaw (void)
 } /* END test_wc_RsaPublicKeyDecodeRaw */
 
 
-#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
+#if (!defined(NO_RSA) || !defined(HAVE_FAST_RSA)) && (defined(WOLFSSL_KEY_GEN) || \
+    defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
     /* In FIPS builds, wc_MakeRsaKey() will return an error if it cannot find
      * a probable prime in 5*(modLen/2) attempts. In non-FIPS builds, it keeps
      * trying until it gets a probable prime. */
@@ -9854,8 +9855,7 @@ static int test_wc_RsaKeyToDer (void)
 static int test_wc_RsaKeyToPublicDer (void)
 { 
     int         ret = 0;
-#if (!defined(NO_RSA) || !defined(HAVE_FAST_RSA)) && defined(WOLFSSL_KEY_GEN) && \
-    (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
+#if (!defined(NO_RSA) || !defined(HAVE_FAST_RSA)) && defined(WOLFSSL_KEY_GEN)
     RsaKey      key;
     WC_RNG      rng;
     byte*       der;
@@ -17379,7 +17379,7 @@ static void test_wolfSSL_RSA(void)
 
 static void test_wolfSSL_RSA_DER(void)
 {
-#if defined(OPENSSL_EXTRA) && !defined(NO_RSA)
+#if defined(OPENSSL_EXTRA) && !defined(NO_RSA) && !defined(HAVE_FAST_RSA)
 
     RSA *rsa;
     int i;

--- a/tests/api.c
+++ b/tests/api.c
@@ -18620,10 +18620,12 @@ static void test_wolfSSL_X509_CRL(void)
         ""
     };
 
+#ifdef HAVE_TEST_d2i_X509_CRL_fp
     char der[][100] = {
         "./certs/crl/crl.der",
         "./certs/crl/crl2.der",
         ""};
+#endif
 
     FILE * fp;
     int i;
@@ -18644,6 +18646,7 @@ static void test_wolfSSL_X509_CRL(void)
         XFCLOSE(fp);
     }
 
+#ifdef HAVE_TEST_d2i_X509_CRL_fp
     for(i = 0; der[i][0] != '\0'; i++){
         AssertNotNull(fp = XFOPEN(der[i], "rb"));
         AssertNotNull(crl = (X509_CRL *)d2i_X509_CRL_fp((X509_CRL **)NULL, fp));
@@ -18656,6 +18659,7 @@ static void test_wolfSSL_X509_CRL(void)
         X509_CRL_free(crl);
         XFCLOSE(fp);
     }
+#endif
 
     printf(resultFmt, passed);
 #endif

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8186,7 +8186,7 @@ int wc_PemPubKeyToDer(const char* fileName,
 
 
 #if !defined(NO_RSA) && (defined(WOLFSSL_CERT_GEN) || \
-        (defined(WOLFSSL_KEY_GEN) && !defined(HAVE_USER_RSA)))
+    ((defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA)) && !defined(HAVE_USER_RSA)))
 /* USER RSA ifdef portions used instead of refactor in consideration for
    possible fips build */
 /* Write a public RSA key to output */
@@ -8438,8 +8438,9 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
 
     return outLen;
 }
+#endif
 
-
+#if (defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA)) && !defined(NO_RSA) && !defined(HAVE_USER_RSA)
 /* Convert Rsa Public key to DER format, write to output (inLen), return bytes
    written */
 int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7244,6 +7244,11 @@ const char* const END_PUB_KEY          = "-----END PUBLIC KEY-----";
     const char* const BEGIN_EDDSA_PRIV = "-----BEGIN EDDSA PRIVATE KEY-----";
     const char* const END_EDDSA_PRIV   = "-----END EDDSA PRIVATE KEY-----";
 #endif
+#ifdef HAVE_CRL
+    const char *const BEGIN_CRL = "-----BEGIN X509 CRL-----";
+    const char* const END_CRL   = "-----END X509 CRL-----";
+#endif
+
 
 
 int wc_PemGetHeaderFooter(int type, const char** header, const char** footer)
@@ -7715,6 +7720,11 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
     #endif
         {
             header =  BEGIN_EDDSA_PRIV;     footer = END_EDDSA_PRIV;
+        } else
+#endif
+#ifdef HAVE_CRL
+        if (type == CRL_TYPE) {
+            header =  BEGIN_CRL;        footer = END_CRL;
         } else
 #endif
         {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -502,7 +502,7 @@ char* GetSigName(int oid) {
 #if !defined(NO_DSA) || defined(HAVE_ECC) || \
    (!defined(NO_RSA) && \
         (defined(WOLFSSL_CERT_GEN) || \
-        (defined(WOLFSSL_KEY_GEN) && !defined(HAVE_USER_RSA))))
+        ((defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA)) && !defined(HAVE_USER_RSA))))
 /* Set the DER/BER encoding of the ASN.1 INTEGER header.
  *
  * len        Length of data to encode.
@@ -526,7 +526,7 @@ static int SetASNInt(int len, byte firstByte, byte* output)
 #endif
 
 #if !defined(NO_DSA) || defined(HAVE_ECC) || defined(WOLFSSL_CERT_GEN) || \
-    (defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA) && !defined(HAVE_USER_RSA))
+    ((defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA)) && !defined(NO_RSA) && !defined(HAVE_USER_RSA))
 /* Set the DER/BER encoding of the ASN.1 INTEGER element with an mp_int.
  * The number is assumed to be positive.
  *
@@ -750,10 +750,10 @@ static int CheckBitString(const byte* input, word32* inOutIdx, int* len,
 
 /* RSA (with CertGen or KeyGen) OR ECC OR ED25519 (with CertGen or KeyGen) */
 #if (!defined(NO_RSA) && !defined(HAVE_USER_RSA) && \
-        (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN))) || \
+        (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA))) || \
      defined(HAVE_ECC) || \
     (defined(HAVE_ED25519) && \
-        (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN)))
+        (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA)))
 
 /* Set the DER/BER encoding of the ASN.1 BIT_STRING header.
  *

--- a/wolfssl/openssl/sha.h
+++ b/wolfssl/openssl/sha.h
@@ -148,7 +148,11 @@ typedef WOLFSSL_SHA384_CTX SHA384_CTX;
 #define SHA384_Init   wolfSSL_SHA384_Init
 #define SHA384_Update wolfSSL_SHA384_Update
 #define SHA384_Final  wolfSSL_SHA384_Final
-
+#if defined(NO_OLD_SHA256_NAMES) && !defined(HAVE_FIPS)
+    /* SHA384 is only available in non-fips mode because of SHA256 enum in FIPS
+     * build. */
+    #define SHA384 wolfSSL_SHA384
+#endif
 #endif /* WOLFSSL_SHA384 */
 
 #ifdef WOLFSSL_SHA512
@@ -173,7 +177,11 @@ typedef WOLFSSL_SHA512_CTX SHA512_CTX;
 #define SHA512_Init   wolfSSL_SHA512_Init
 #define SHA512_Update wolfSSL_SHA512_Update
 #define SHA512_Final  wolfSSL_SHA512_Final
-
+#if defined(NO_OLD_SHA256_NAMES) && !defined(HAVE_FIPS)
+    /* SHA256 is only available in non-fips mode because of SHA256 enum in FIPS
+     * build. */
+    #define SHA512 wolfSSL_SHA512
+#endif
 #endif /* WOLFSSL_SHA512 */
 
 

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -322,6 +322,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 
 #define X509_STORE_CTX_get_current_cert wolfSSL_X509_STORE_CTX_get_current_cert
 #define X509_STORE_add_cert             wolfSSL_X509_STORE_add_cert
+#define X509_STORE_add_crl              wolfSSL_X509_STORE_add_crl
 #define X509_STORE_set_flags            wolfSSL_X509_STORE_set_flags
 #define X509_STORE_CTX_set_verify_cb    wolfSSL_X509_STORE_CTX_set_verify_cb
 #define X509_STORE_CTX_free             wolfSSL_X509_STORE_CTX_free
@@ -348,7 +349,8 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define X509_LOOKUP_file wolfSSL_X509_LOOKUP_file
 
 #define X509_STORE_add_lookup wolfSSL_X509_STORE_add_lookup
-#define X509_STORE_new wolfSSL_X509_STORE_new
+#define X509_STORE_new        wolfSSL_X509_STORE_new
+#define X509_STORE_free       wolfSSL_X509_STORE_free
 #define X509_STORE_get_by_subject wolfSSL_X509_STORE_get_by_subject
 #define X509_STORE_CTX_init wolfSSL_X509_STORE_CTX_init
 #define X509_STORE_CTX_cleanup wolfSSL_X509_STORE_CTX_cleanup
@@ -555,7 +557,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define X509_NAME_free wolfSSL_X509_NAME_free
 #define X509_NAME_new  wolfSSL_X509_NAME_new
 
-typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
+    typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 
 #define SSL_CTX_use_certificate wolfSSL_CTX_use_certificate
 #define SSL_CTX_use_PrivateKey wolfSSL_CTX_use_PrivateKey

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -576,6 +576,13 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define X509_NAME_ENTRY_get_data wolfSSL_X509_NAME_ENTRY_get_data
 #define sk_X509_NAME_pop_free  wolfSSL_sk_X509_NAME_pop_free
 #define SHA1 wolfSSL_SHA1
+
+#ifdef OPENSSL_EXTRA
+#define SHA256 wolfSSL_SHA256
+#define SHA384 wolfSSL_SHA384
+#define SHA512 wolfSSL_SHA512
+#endif
+
 #define X509_check_private_key wolfSSL_X509_check_private_key
 #define SSL_dup_CA_list wolfSSL_dup_CA_list
 

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -513,6 +513,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define sk_X509_free wolfSSL_sk_X509_free
 #define i2d_X509_bio wolfSSL_i2d_X509_bio
 #define d2i_X509_bio wolfSSL_d2i_X509_bio
+#define d2i_X509_fp wolfSSL_d2i_X509_fp
 #define i2d_X509     wolfSSL_i2d_X509
 #define d2i_X509     wolfSSL_d2i_X509
 #define d2i_RSAPublicKey wolfSSL_d2i_RSAPublicKey

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -516,6 +516,8 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define d2i_X509_fp wolfSSL_d2i_X509_fp
 #define i2d_X509     wolfSSL_i2d_X509
 #define d2i_X509     wolfSSL_d2i_X509
+#define d2i_PKCS12_bio   wolfSSL_d2i_PKCS12_bio
+#define d2i_PKCS12_fp   wolfSSL_d2i_PKCS12_fp
 #define d2i_RSAPublicKey wolfSSL_d2i_RSAPublicKey
 #define i2d_RSAPublicKey wolfSSL_i2d_RSAPublicKey
 #define d2i_X509_CRL wolfSSL_d2i_X509_CRL

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -513,6 +513,11 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define d2i_X509_bio wolfSSL_d2i_X509_bio
 #define i2d_X509     wolfSSL_i2d_X509
 #define d2i_X509     wolfSSL_d2i_X509
+#define d2i_RSAPublicKey wolfSSL_d2i_RSAPublicKey
+#define i2d_RSAPublicKey wolfSSL_i2d_RSAPublicKey
+#define d2i_X509_CRL wolfSSL_d2i_X509_CRL
+#define d2i_X509_CRL_fp wolfSSL_d2i_X509_CRL_fp
+#define X509_CRL_free wolfSSL_X509_CRL_free
 
 #define SSL_CTX_get_ex_data wolfSSL_CTX_get_ex_data
 #define SSL_CTX_set_ex_data wolfSSL_CTX_set_ex_data
@@ -528,6 +533,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define SSL_CTX_get_ex_new_index wolfSSL_CTX_get_ex_new_index
 #define PEM_read_bio_X509 wolfSSL_PEM_read_bio_X509
 #define PEM_read_bio_X509_AUX wolfSSL_PEM_read_bio_X509_AUX
+#define PEM_read_X509_CRL wolfSSL_PEM_read_X509_CRL
 
 /*#if OPENSSL_API_COMPAT < 0x10100000L*/
 #define CONF_modules_free()

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -300,6 +300,9 @@ struct WOLFSSL_X509_STORE {
 #ifdef OPENSSL_EXTRA
     int                   isDynamic;
 #endif
+#if defined(OPENSSL_EXTRA) && defined(HAVE_CRL)
+    WOLFSSL_X509_CRL *crl;
+#endif
 };
 
 #ifdef OPENSSL_EXTRA
@@ -2883,6 +2886,7 @@ WOLFSSL_API int i2t_ASN1_OBJECT(char *buf, int buf_len, WOLFSSL_ASN1_OBJECT *a);
 WOLFSSL_API void SSL_CTX_set_tmp_dh_callback(WOLFSSL_CTX *ctx, WOLFSSL_DH *(*dh) (WOLFSSL *ssl, int is_export, int keylength));
 WOLFSSL_API WOLF_STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void);
 WOLFSSL_API int X509_STORE_load_locations(WOLFSSL_X509_STORE *ctx, const char *file, const char *dir);
+WOLFSSL_API int wolfSSL_X509_STORE_add_crl(WOLFSSL_X509_STORE *ctx, WOLFSSL_X509_CRL *x);
 WOLFSSL_API int wolfSSL_sk_SSL_CIPHER_num(const void * p);
 WOLFSSL_API int wolfSSL_sk_SSL_COMP_zero(WOLFSSL_STACK* st);
 WOLFSSL_API WOLFSSL_CIPHER* wolfSSL_sk_SSL_CIPHER_value(void *ciphers, int idx);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1554,6 +1554,10 @@ WOLFSSL_API int  wolfSSL_connect_cert(WOLFSSL* ssl);
 typedef struct WC_PKCS12 WC_PKCS12;
 WOLFSSL_API WC_PKCS12* wolfSSL_d2i_PKCS12_bio(WOLFSSL_BIO* bio,
                                        WC_PKCS12** pkcs12);
+#ifndef NO_FILESYSTEM
+WOLFSSL_API WC_PKCS12* wolfSSL_d2i_PKCS12_fp(XFILE fp,
+                                       WC_PKCS12** pkcs12);
+#endif
 WOLFSSL_API int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
      WOLFSSL_EVP_PKEY** pkey, WOLFSSL_X509** cert,
      WOLF_STACK_OF(WOLFSSL_X509)** ca);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2586,6 +2586,8 @@ WOLFSSL_API WOLFSSL_X509_NAME_ENTRY *wolfSSL_X509_NAME_get_entry(WOLFSSL_X509_NA
 WOLFSSL_API void wolfSSL_sk_X509_NAME_pop_free(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk, void f (WOLFSSL_X509_NAME*));
 WOLFSSL_API unsigned char *wolfSSL_SHA1(const unsigned char *d, size_t n, unsigned char *md);
 WOLFSSL_API unsigned char *wolfSSL_SHA256(const unsigned char *d, size_t n, unsigned char *md);
+WOLFSSL_API unsigned char *wolfSSL_SHA384(const unsigned char *d, size_t n, unsigned char *md);
+WOLFSSL_API unsigned char *wolfSSL_SHA512(const unsigned char *d, size_t n, unsigned char *md);
 WOLFSSL_API int wolfSSL_X509_check_private_key(WOLFSSL_X509*, WOLFSSL_EVP_PKEY*);
 WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_NAME) *wolfSSL_dup_CA_list( WOLF_STACK_OF(WOLFSSL_X509_NAME) *sk );
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1521,7 +1521,7 @@ WOLFSSL_API int wolfSSL_i2d_X509(WOLFSSL_X509* x509, unsigned char** out);
 WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL(WOLFSSL_X509_CRL **crl,
                                                    const unsigned char *in, int len);
 #ifndef NO_FILESYSTEM
-WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL_fp(WOLFSSL_X509_CRL **crl, XFILE file);
+WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL_fp(XFILE file, WOLFSSL_X509_CRL **crl);
 #endif
 WOLFSSL_API void wolfSSL_X509_CRL_free(WOLFSSL_X509_CRL *crl);
 
@@ -2537,6 +2537,10 @@ WOLFSSL_API int wolfSSL_SESSION_get_master_key_length(const WOLFSSL_SESSION* ses
 WOLFSSL_API void wolfSSL_CTX_set_cert_store(WOLFSSL_CTX* ctx,
                                                        WOLFSSL_X509_STORE* str);
 WOLFSSL_API int wolfSSL_i2d_X509_bio(WOLFSSL_BIO* bio, WOLFSSL_X509* x509);
+#if !defined(NO_FILESYSTEM)
+WOLFSSL_API WOLFSSL_X509* wolfSSL_d2i_X509_fp(XFILE fp,
+                                               WOLFSSL_X509** x509);
+#endif
 WOLFSSL_API WOLFSSL_X509* wolfSSL_d2i_X509_bio(WOLFSSL_BIO* bio,
                                                WOLFSSL_X509** x509);
 WOLFSSL_API WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(WOLFSSL_CTX* ctx);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1517,7 +1517,9 @@ WOLFSSL_API WOLFSSL_X509*
 WOLFSSL_API int wolfSSL_i2d_X509(WOLFSSL_X509* x509, unsigned char** out);
 WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL(WOLFSSL_X509_CRL **crl,
                                                    const unsigned char *in, int len);
+#ifndef NO_FILESYSTEM
 WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL_fp(WOLFSSL_X509_CRL **crl, XFILE file);
+#endif
 WOLFSSL_API void wolfSSL_X509_CRL_free(WOLFSSL_X509_CRL *crl);
 
 #ifndef NO_FILESYSTEM
@@ -2545,10 +2547,7 @@ WOLFSSL_API int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *p
 WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 **x, pem_password_cb *cb, void *u);
 WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
         (WOLFSSL_BIO *bp, WOLFSSL_X509 **x, pem_password_cb *cb, void *u);
-WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL(WOLFSSL_X509_CRL **crl,
-                                                   const unsigned char *in, int len);
 #ifndef NO_FILESYSTEM
-WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL_fp(WOLFSSL_X509_CRL **crl, XFILE file);
 WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_PEM_read_X509_CRL(FILE *fp, WOLFSSL_X509_CRL **x,
                                                     pem_password_cb *cb, void *u);
 #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -164,7 +164,7 @@ typedef struct WOLFSSL_ECDSA_SIG      WOLFSSL_ECDSA_SIG;
 typedef struct WOLFSSL_CIPHER         WOLFSSL_CIPHER;
 typedef struct WOLFSSL_X509_LOOKUP    WOLFSSL_X509_LOOKUP;
 typedef struct WOLFSSL_X509_LOOKUP_METHOD WOLFSSL_X509_LOOKUP_METHOD;
-typedef struct WOLFSSL_X509_CRL       WOLFSSL_X509_CRL;
+typedef struct WOLFSSL_CRL            WOLFSSL_X509_CRL;
 typedef struct WOLFSSL_X509_STORE     WOLFSSL_X509_STORE;
 typedef struct WOLFSSL_X509_VERIFY_PARAM  WOLFSSL_X509_VERIFY_PARAM;
 typedef struct WOLFSSL_BIO            WOLFSSL_BIO;
@@ -987,8 +987,10 @@ WOLFSSL_API const char* wolfSSL_state_string_long(const WOLFSSL*);
 
 WOLFSSL_API WOLFSSL_RSA* wolfSSL_RSA_generate_key(int, unsigned long,
                                                void(*)(int, int, void*), void*);
-WOLFSSL_API void wolfSSL_CTX_set_tmp_rsa_callback(WOLFSSL_CTX*,
-                                             WOLFSSL_RSA*(*)(WOLFSSL*, int, int));
+WOLFSSL_API WOLFSSL_RSA *wolfSSL_d2i_RSAPublicKey(WOLFSSL_RSA **r, const unsigned char **pp, long len);
+WOLFSSL_API int wolfSSL_i2d_RSAPublicKey(WOLFSSL_RSA *r, const unsigned char **pp);
+WOLFSSL_API void wolfSSL_CTX_set_tmp_rsa_callback(WOLFSSL_CTX *,
+                                           WOLFSSL_RSA *(*)(WOLFSSL *, int, int));
 
 WOLFSSL_API int wolfSSL_PEM_def_callback(char*, int num, int w, void* key);
 
@@ -1513,6 +1515,11 @@ WOLFSSL_API WOLFSSL_X509* wolfSSL_d2i_X509(WOLFSSL_X509** x509,
 WOLFSSL_API WOLFSSL_X509*
     wolfSSL_X509_d2i(WOLFSSL_X509** x509, const unsigned char* in, int len);
 WOLFSSL_API int wolfSSL_i2d_X509(WOLFSSL_X509* x509, unsigned char** out);
+WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL(WOLFSSL_X509_CRL **crl,
+                                                   const unsigned char *in, int len);
+WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL_fp(WOLFSSL_X509_CRL **crl, XFILE file);
+WOLFSSL_API void wolfSSL_X509_CRL_free(WOLFSSL_X509_CRL *crl);
+
 #ifndef NO_FILESYSTEM
     #ifndef NO_STDIO_FILESYSTEM
     WOLFSSL_API WOLFSSL_X509*
@@ -2538,6 +2545,13 @@ WOLFSSL_API int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *p
 WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 **x, pem_password_cb *cb, void *u);
 WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
         (WOLFSSL_BIO *bp, WOLFSSL_X509 **x, pem_password_cb *cb, void *u);
+WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL(WOLFSSL_X509_CRL **crl,
+                                                   const unsigned char *in, int len);
+#ifndef NO_FILESYSTEM
+WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_d2i_X509_CRL_fp(WOLFSSL_X509_CRL **crl, XFILE file);
+WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_PEM_read_X509_CRL(FILE *fp, WOLFSSL_X509_CRL **x,
+                                                    pem_password_cb *cb, void *u);
+#endif
 
 /*lighttp compatibility */
 

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -247,8 +247,9 @@ WOLFSSL_API int wc_RsaExportKey(RsaKey* key,
                                 byte* p, word32* pSz,
                                 byte* q, word32* qSz);
 
+WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey*, byte* output, word32 inLen);
+
 #ifdef WOLFSSL_KEY_GEN
-    WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey*, byte* output, word32 inLen);
     WOLFSSL_API int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng);
     WOLFSSL_API int wc_CheckProbablePrime(const byte* p, word32 pSz,
                                           const byte* q, word32 qSz,

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -64,7 +64,9 @@
 
 #ifndef NO_OLD_WC_NAMES
     #define Sha             wc_Sha
-    #define SHA             WC_SHA
+    #if !defined(OPENSSL_EXTRA)
+    #define SHA WC_SHA
+    #endif
     #define SHA_BLOCK_SIZE  WC_SHA_BLOCK_SIZE
     #define SHA_DIGEST_SIZE WC_SHA_DIGEST_SIZE
     #define SHA_PAD_SIZE    WC_SHA_PAD_SIZE

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -81,7 +81,7 @@
     #define SHA256_NOINLINE
 #endif
 
-#if !defined(NO_OLD_SHA256_NAMES) || !defined(OPENSSL_EXTRA)
+#if !defined(NO_OLD_SHA256_NAMES)
     #define SHA256             WC_SHA256
 #endif
 

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -81,9 +81,10 @@
     #define SHA256_NOINLINE
 #endif
 
-#ifndef NO_OLD_SHA256_NAMES
+#if !defined(NO_OLD_SHA256_NAMES) || !defined(OPENSSL_EXTRA)
     #define SHA256             WC_SHA256
 #endif
+
 #ifndef NO_OLD_WC_NAMES
     #define Sha256             wc_Sha256
     #define SHA256_BLOCK_SIZE  WC_SHA256_BLOCK_SIZE

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -71,9 +71,11 @@
     #define SHA512_NOINLINE
 #endif
 
-#if !defined(NO_OLD_WC_NAMES) && !defined(OPENSSL_EXTRA)
+#if !defined(NO_OLD_WC_NAMES)
     #define Sha512             wc_Sha512
+    #if !defined(OPENSSL_EXTRA)
     #define SHA512             WC_SHA512
+    #endif
     #define SHA512_BLOCK_SIZE  WC_SHA512_BLOCK_SIZE
     #define SHA512_DIGEST_SIZE WC_SHA512_DIGEST_SIZE
     #define SHA512_PAD_SIZE    WC_SHA512_PAD_SIZE
@@ -123,9 +125,11 @@ WOLFSSL_API int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst);
 
 #ifndef HAVE_FIPS /* avoid redefinition of structs */
 
-#if !defined(NO_OLD_SHA_NAMES) && !defined(OPENSSL_EXTRA)
+#if !defined(NO_OLD_SHA_NAMES)
     #define Sha384             wc_Sha384
+    #if !defined(OPENSSL_EXTRA)
     #define SHA384             WC_SHA384
+    #endif
     #define SHA384_BLOCK_SIZE  WC_SHA384_BLOCK_SIZE
     #define SHA384_DIGEST_SIZE WC_SHA384_DIGEST_SIZE
     #define SHA384_PAD_SIZE    WC_SHA384_PAD_SIZE

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -71,7 +71,7 @@
     #define SHA512_NOINLINE
 #endif
 
-#ifndef NO_OLD_WC_NAMES
+#if !defined(NO_OLD_WC_NAMES) && !defined(OPENSSL_EXTRA)
     #define Sha512             wc_Sha512
     #define SHA512             WC_SHA512
     #define SHA512_BLOCK_SIZE  WC_SHA512_BLOCK_SIZE
@@ -123,7 +123,7 @@ WOLFSSL_API int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst);
 
 #ifndef HAVE_FIPS /* avoid redefinition of structs */
 
-#ifndef NO_OLD_WC_NAMES
+#if !defined(NO_OLD_SHA_NAMES) && !defined(OPENSSL_EXTRA)
     #define Sha384             wc_Sha384
     #define SHA384             WC_SHA384
     #define SHA384_BLOCK_SIZE  WC_SHA384_BLOCK_SIZE

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -73,9 +73,6 @@
 
 #if !defined(NO_OLD_WC_NAMES)
     #define Sha512             wc_Sha512
-    #if !defined(OPENSSL_EXTRA)
-    #define SHA512             WC_SHA512
-    #endif
     #define SHA512_BLOCK_SIZE  WC_SHA512_BLOCK_SIZE
     #define SHA512_DIGEST_SIZE WC_SHA512_DIGEST_SIZE
     #define SHA512_PAD_SIZE    WC_SHA512_PAD_SIZE
@@ -127,9 +124,6 @@ WOLFSSL_API int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst);
 
 #if !defined(NO_OLD_SHA_NAMES)
     #define Sha384             wc_Sha384
-    #if !defined(OPENSSL_EXTRA)
-    #define SHA384             WC_SHA384
-    #endif
     #define SHA384_BLOCK_SIZE  WC_SHA384_BLOCK_SIZE
     #define SHA384_DIGEST_SIZE WC_SHA384_DIGEST_SIZE
     #define SHA384_PAD_SIZE    WC_SHA384_PAD_SIZE


### PR DESCRIPTION
openSSL compatibility APIs
- d2i_X509_CRL, d2i_X509_CRL_fp, X509_CRL_free
- PEM_read_X509_CRL
- d2i_RSAPublicKey, i2d_RSAPublicKey
- X509 CRL to PemToDer
- X509_STORE_add_crl
- SHA256, SHA384, SHA512
- d2i_X509_fp


