### PR TITLE
expose mp_toradix() when WOLFSSL_PUBLIC_MP is defined

### DIFF
--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -4813,7 +4813,8 @@ int mp_read_radix (mp_int * a, const char *str, int radix)
 #endif /* !defined(NO_DSA) || defined(HAVE_ECC) */
 
 #if defined(WOLFSSL_KEY_GEN) || defined(HAVE_COMP_KEY) || \
-    defined(WOLFSSL_DEBUG_MATH) || defined(DEBUG_WOLFSSL)
+    defined(WOLFSSL_DEBUG_MATH) || defined(DEBUG_WOLFSSL) || \
+    defined(WOLFSSL_PUBLIC_MP)
 
 /* returns size of ASCII representation */
 int mp_radix_size (mp_int *a, int radix, int *size)

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -2606,7 +2606,8 @@ int mp_montgomery_calc_normalization(mp_int *a, mp_int *b)
 
 
 #if defined(WOLFSSL_KEY_GEN) || defined(HAVE_COMP_KEY) || \
-    defined(WOLFSSL_DEBUG_MATH) || defined(DEBUG_WOLFSSL)
+    defined(WOLFSSL_DEBUG_MATH) || defined(DEBUG_WOLFSSL) || \
+    defined(WOLFSSL_PUBLIC_MP)
 
 #ifdef WOLFSSL_KEY_GEN
 /* swap the elements of two integers, for cases where you can't simply swap the
@@ -3263,7 +3264,8 @@ int mp_set(fp_int *a, fp_digit b)
 #endif
 
 #if defined(WOLFSSL_KEY_GEN) || defined(HAVE_COMP_KEY) || \
-    defined(WOLFSSL_DEBUG_MATH) || defined(DEBUG_WOLFSSL)
+    defined(WOLFSSL_DEBUG_MATH) || defined(DEBUG_WOLFSSL) || \
+    defined(WOLFSSL_PUBLIC_MP)
 
 /* returns size of ASCII representation */
 int mp_radix_size (mp_int *a, int radix, int *size)


### PR DESCRIPTION
This PR compiles in the mp_toradix() function if WOLFSSL_PUBLIC_MP has been defined.

wolfSSH requires users define WOLFSSL_PUBLIC_MP when compiling wolfSSL/wolfCrypt, and SCP uses mp_toradix().