### PR TITLE
expose wolfSSL_get_cipher_name_from_suite via _ex option and add test…

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -653,6 +653,17 @@ char* wolfSSL_get_cipher_list(int priority)
     return (char*)ciphers[priority];
 }
 
+/**
+  * Get the cipher name from the suite.
+  */
+const char* wolfSSL_get_cipher_name_from_suite_ex(WOLFSSL* ssl)
+{
+    if (ssl)
+        return wolfSSL_get_cipher_name_from_suite(ssl->options.cipherSuite,
+                                                  ssl->options.cipherSuite0);
+    else
+        return 0;
+}
 
 /**
   * Get the name of cipher at priority level passed in.

--- a/tests/api.c
+++ b/tests/api.c
@@ -1318,6 +1318,10 @@ static void test_client_nofail(void* args, void *cb)
     int  msgSz = (int)XSTRLEN(msg);
     int  ret, err = 0;
 
+    WOLFSSL_CIPHER* cipher;
+    const char* cipher1;
+    const char* cipher2;
+
 #ifdef WOLFSSL_TIRTOS
     fdOpenSession(Task_self());
 #endif
@@ -1364,6 +1368,7 @@ static void test_client_nofail(void* args, void *cb)
     }
 
     ssl = wolfSSL_new(ctx);
+
     tcp_connect(&sockfd, wolfSSLIP, ((func_args*)args)->signal->port,
                 0, 0, ssl);
     if (wolfSSL_set_fd(ssl, sockfd) != WOLFSSL_SUCCESS) {
@@ -1390,6 +1395,16 @@ static void test_client_nofail(void* args, void *cb)
             err = wolfSSL_get_error(ssl, 0);
         }
     } while (ret != WOLFSSL_SUCCESS && err == WC_PENDING_E);
+
+    /* test the various get cipher name methods */
+    /* two-step method */
+    cipher = wolfSSL_get_current_cipher(ssl);
+    cipher1 = wolfSSL_CIPHER_get_name(cipher);
+    /* one-step method */
+    cipher2 = wolfSSL_get_cipher_name_from_suite_ex(ssl);
+    AssertStrEQ(cipher1, cipher2);
+
+
 
     if (ret != WOLFSSL_SUCCESS) {
         char buff[WOLFSSL_MAX_ERROR_SZ];

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -536,6 +536,8 @@ WOLFSSL_API char* wolfSSL_get_cipher_list(int priority);
 WOLFSSL_API char* wolfSSL_get_cipher_list_ex(WOLFSSL* ssl, int priority);
 WOLFSSL_API int  wolfSSL_get_ciphers(char*, int);
 WOLFSSL_API const char* wolfSSL_get_cipher_name(WOLFSSL* ssl);
+WOLFSSL_API const char* wolfSSL_get_cipher_name_from_suite_ex(WOLFSSL* ssl);
+
 WOLFSSL_API const char* wolfSSL_get_shared_ciphers(WOLFSSL* ssl, char* buf,
     int len);
 WOLFSSL_API const char* wolfSSL_get_curve_name(WOLFSSL* ssl);


### PR DESCRIPTION
… cases

Added functionality to the client.c example to test out XSTRTOK use and print a line-by-line list of the short-hand-ciphers when configured and using ```./examples/client/client -e``` option.

Exposed get_cipher_name and added test case using the two-step method to get the cipher name and comparing the result to the new method to ensure same functionality.