### PR TITLE
Linear print of ciphers

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -166,8 +166,45 @@ static void ShowCiphers(void)
 
     int ret = wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
 
-    if (ret == WOLFSSL_SUCCESS)
+    if (ret == WOLFSSL_SUCCESS) {
+#if defined(WOLFSSL_CERT_EXT) || defined(HAVE_ALPN)
+        int tmpLen = 0;
+        int strLen = (int) XSTRLEN(ciphers);
+
+        char* tmpSingle = NULL;
+        char* tmp = NULL;
+        char* strPntr = ciphers;
+        char* noCiphers;
+
+        const char* delim = ":";
+#endif
         printf("%s\n", ciphers);
+
+#if defined(WOLFSSL_CERT_EXT) || defined(HAVE_ALPN)
+        printf("\n");
+
+        tmp = (char*) XMALLOC((size_t) strLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (tmp == NULL) {
+            printf("malloc in ShowCiphers failed\n");
+            return;
+        }
+
+        while (strLen > 0) {
+            XMEMCPY(tmp, strPntr, strLen);
+
+            tmpSingle = XSTRTOK(tmp, delim, &noCiphers);
+            printf("%s\n", tmpSingle);
+
+            tmpLen = (int) XSTRLEN(tmpSingle);
+            strLen -= tmpLen + 1; /* subtract extracted string + colon */
+            strPntr += tmpLen + 1;
+            XMEMSET(tmpSingle, 0, tmpLen);
+        }
+
+        XFREE(tmp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+
+#endif /* WOLFSSL_CERT_EXT || HAVE_ALPN */
+    }
 }
 
 /* Shows which versions are valid */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -653,6 +653,17 @@ char* wolfSSL_get_cipher_list(int priority)
     return (char*)ciphers[priority];
 }
 
+/**
+  * Get the cipher name from the suite.
+  */
+const char* wolfSSL_get_cipher_name_from_suite_ex(WOLFSSL* ssl)
+{
+    if (ssl)
+        return wolfSSL_get_cipher_name_from_suite(ssl->options.cipherSuite,
+                                                  ssl->options.cipherSuite0);
+    else
+        return 0;
+}
 
 /**
   * Get the name of cipher at priority level passed in.

--- a/tests/api.c
+++ b/tests/api.c
@@ -1318,6 +1318,10 @@ static void test_client_nofail(void* args, void *cb)
     int  msgSz = (int)XSTRLEN(msg);
     int  ret, err = 0;
 
+    WOLFSSL_CIPHER* cipher;
+    const char* cipher1;
+    const char* cipher2;
+
 #ifdef WOLFSSL_TIRTOS
     fdOpenSession(Task_self());
 #endif
@@ -1364,6 +1368,7 @@ static void test_client_nofail(void* args, void *cb)
     }
 
     ssl = wolfSSL_new(ctx);
+
     tcp_connect(&sockfd, wolfSSLIP, ((func_args*)args)->signal->port,
                 0, 0, ssl);
     if (wolfSSL_set_fd(ssl, sockfd) != WOLFSSL_SUCCESS) {
@@ -1390,6 +1395,16 @@ static void test_client_nofail(void* args, void *cb)
             err = wolfSSL_get_error(ssl, 0);
         }
     } while (ret != WOLFSSL_SUCCESS && err == WC_PENDING_E);
+
+    /* test the various get cipher name methods */
+    /* two-step method */
+    cipher = wolfSSL_get_current_cipher(ssl);
+    cipher1 = wolfSSL_CIPHER_get_name(cipher);
+    /* one-step method */
+    cipher2 = wolfSSL_get_cipher_name_from_suite_ex(ssl);
+    AssertStrEQ(cipher1, cipher2);
+
+
 
     if (ret != WOLFSSL_SUCCESS) {
         char buff[WOLFSSL_MAX_ERROR_SZ];

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -536,6 +536,8 @@ WOLFSSL_API char* wolfSSL_get_cipher_list(int priority);
 WOLFSSL_API char* wolfSSL_get_cipher_list_ex(WOLFSSL* ssl, int priority);
 WOLFSSL_API int  wolfSSL_get_ciphers(char*, int);
 WOLFSSL_API const char* wolfSSL_get_cipher_name(WOLFSSL* ssl);
+WOLFSSL_API const char* wolfSSL_get_cipher_name_from_suite_ex(WOLFSSL* ssl);
+
 WOLFSSL_API const char* wolfSSL_get_shared_ciphers(WOLFSSL* ssl, char* buf,
     int len);
 WOLFSSL_API const char* wolfSSL_get_curve_name(WOLFSSL* ssl);


### PR DESCRIPTION
If XSTRTOK is available add functionality in ShowCiphers to print a linear list. Output:


```
kalebhimes$ ./examples/client/client -e
DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-CHACHA20-POLY1305:DHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305-OLD:ECDHE-ECDSA-CHACHA20-POLY1305-OLD:DHE-RSA-CHACHA20-POLY1305-OLD

DHE-RSA-AES128-SHA
DHE-RSA-AES256-SHA
ECDHE-RSA-AES128-SHA
ECDHE-RSA-AES256-SHA
ECDHE-ECDSA-AES128-SHA
ECDHE-ECDSA-AES256-SHA
DHE-RSA-AES128-SHA256
DHE-RSA-AES256-SHA256
DHE-RSA-AES128-GCM-SHA256
DHE-RSA-AES256-GCM-SHA384
ECDHE-RSA-AES128-GCM-SHA256
ECDHE-RSA-AES256-GCM-SHA384
ECDHE-ECDSA-AES128-GCM-SHA256
ECDHE-ECDSA-AES256-GCM-SHA384
ECDHE-RSA-AES128-SHA256
ECDHE-ECDSA-AES128-SHA256
ECDHE-RSA-AES256-SHA384
ECDHE-ECDSA-AES256-SHA384
ECDHE-RSA-CHACHA20-POLY1305
ECDHE-ECDSA-CHACHA20-POLY1305
DHE-RSA-CHACHA20-POLY1305
ECDHE-RSA-CHACHA20-POLY1305-OLD
ECDHE-ECDSA-CHACHA20-POLY1305-OLD
DHE-RSA-CHACHA20-POLY1305-OLD
```