### PR TITLE
Hush ar warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,10 @@ AC_CONFIG_AUX_DIR([build-aux])
 : ${CFLAGS=""}
 : ${CXXFLAGS=""}
 
+# Test ar for the "U" option. Should be checked before the libtool macros.
+xxx_ar_flags=$((ar --help) 2>&1)
+AS_CASE([$xxx_ar_flags],[*'use actual timestamps and uids/gids'*],[: ${AR_FLAGS="Ucru"}])
+
 AC_CANONICAL_HOST
 AC_CANONICAL_BUILD
 


### PR DESCRIPTION
At some point, ar on Ubuntu started throwing the following warning:

    ar: `u' modifier ignored since `D' is the default (see `U')

Add the "U" option to the ar flags if the version of ar supports it. (The version used by macOS does not support the flag, for example.) The AR_FLAGS set in configure will later be used by libtool.