### PR TITLE
check on cipher suites for AEAD

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -5227,8 +5227,9 @@ void FreeSSL(WOLFSSL* ssl, void* heap)
     (void)heap;
 }
 
-#if !defined(NO_OLD_TLS) || defined(HAVE_CHACHA) || defined(HAVE_AESCCM) \
-    || defined(HAVE_AESGCM) || defined(WOLFSSL_DTLS)
+#if !defined(NO_OLD_TLS) || defined(WOLFSSL_DTLS) || \
+    ((defined(HAVE_CHACHA) || defined(HAVE_AESCCM) || defined(HAVE_AESGCM)) \
+     && defined(HAVE_AEAD))
 static INLINE void GetSEQIncrement(WOLFSSL* ssl, int verify, word32 seq[2])
 {
     if (verify) {
@@ -5341,7 +5342,6 @@ static INLINE void WriteSEQ(WOLFSSL* ssl, int verifyOrder, byte* out)
     c32toa(seq[1], out + OPAQUE32_LEN);
 }
 #endif
-
 
 #ifdef WOLFSSL_DTLS
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -773,6 +773,25 @@
     defined(BUILD_TLS_PSK_WITH_AES_256_GCM_SHA384) || \
     defined(BUILD_TLS_DHE_PSK_WITH_AES_256_GCM_SHA384)
     #define BUILD_AESGCM
+#else
+    /* No AES-GCM cipher suites available with build */
+    #define NO_AESGCM_AEAD
+#endif
+
+#if defined(BUILD_TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256) || \
+    defined(BUILD_TLS_DHE_RSA_WITH_CHACHA20_OLD_POLY1305_SHA256) || \
+    defined(BUILD_TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256) || \
+    defined(BUILD_TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256) || \
+    defined(BUILD_TLS_ECDHE_ECDSA_WITH_CHACHA20_OLD_POLY1305_SHA256) || \
+    defined(BUILD_TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256) || \
+    defined(BUILD_TLS_ECDHE_RSA_WITH_CHACHA20_OLD_POLY1305_SHA256) || \
+    defined(BUILD_TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256) || \
+    defined(BUILD_TLS_PSK_WITH_CHACHA20_POLY1305_SHA256) || \
+    defined(BUILD_TLS_CHACHA20_POLY1305_SHA256)
+    /* Have an available ChaCha Poly cipher suite */
+#else
+    /* No ChaCha Poly cipher suites available with build */
+    #define NO_CHAPOL_AEAD
 #endif
 
 #if defined(BUILD_TLS_RSA_WITH_HC_128_SHA) || \
@@ -810,8 +829,9 @@
 #endif
 
 #if defined(WOLFSSL_MAX_STRENGTH) || \
-    defined(HAVE_AESGCM) || defined(HAVE_AESCCM) || \
-    (defined(HAVE_CHACHA) && defined(HAVE_POLY1305))
+    (defined(HAVE_AESGCM) && !defined(NO_AESGCM_AEAD)) || \
+     defined(HAVE_AESCCM) || \
+    (defined(HAVE_CHACHA) && defined(HAVE_POLY1305) && !defined(NO_CHAPOL_AEAD))
 
     #define HAVE_AEAD
 #endif


### PR DESCRIPTION
This checks if an AES-GCM or a CHACHA-POLY suite is available before setting HAVE_AEAD. It was added to avoid the case where clang gives a warning of unused functions when HAVE_AEAD is enabled but no AEAD cipher suites where.

Fail case

```
$ ./configure --enable-aesgcm --disable-sha512 --disable-chacha C_EXTRA_FLAGS=-DNO_AES_128 CC=clang && make
```

Pass case

```
$ ./configure --enable-aesgcm --enable-sha512 --enable-sha384 --disable-chacha C_EXTRA_FLAGS=-DNO_AES_128 CC=clang && make
```

With the second case the cipher suite "ECDHE-RSA-AES256-GCM-SHA384" is available which will use the TLS AEAD increment code.