### PR TITLE
Fix CAVP selftest build

### DIFF
--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -48,14 +48,26 @@ enum Hash_Sum  {
 };
 #endif /* !NO_ASN */
 
+#ifdef HAVE_SELFTEST
+enum {
+    /* CAVP selftest includes these in hmac.h instead of sha3.h,
+       copied here for that build */
+    WC_SHA3_224_BLOCK_SIZE = 144,
+    WC_SHA3_256_BLOCK_SIZE = 136,
+    WC_SHA3_384_BLOCK_SIZE = 104,
+    WC_SHA3_512_BLOCK_SIZE = 72,
+};
+#endif
+
 
 /* function converts int hash type to enum */
 enum wc_HashType wc_HashTypeConvert(int hashType)
 {
     /* Default to hash type none as error */
     enum wc_HashType eHashType = WC_HASH_TYPE_NONE;
-#ifdef HAVE_FIPS
-    /* original FIPSv1 requires a mapping for unique hash type to wc_HashType */
+#if defined(HAVE_FIPS) || defined(HAVE_SELFTEST)
+    /* original FIPSv1  and CAVP selftest require a mapping for unique hash
+       type to wc_HashType */
     switch (hashType) {
     #ifndef NO_MD5
         case WC_MD5:

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14074,7 +14074,7 @@ static int ecc_test_vector_item(const eccVector* vector)
     word32  sigSz;
     ecc_key userA;
     DECLARE_VAR(sig, byte, ECC_SIG_SIZE, HEAP_HINT);
-#ifndef NO_ASN
+#if !defined(NO_ASN) && !defined(HAVE_SELFTEST)
     word32  sigRawSz;
     DECLARE_VAR(sigRaw, byte, ECC_SIG_SIZE, HEAP_HINT);
 #endif
@@ -14096,7 +14096,7 @@ static int ecc_test_vector_item(const eccVector* vector)
     if (ret != 0)
         goto done;
 
-#ifndef NO_ASN
+#if !defined(NO_ASN) && !defined(HAVE_SELFTEST)
     XMEMSET(sigRaw, 0, ECC_SIG_SIZE);
     sigRawSz = ECC_SIG_SIZE;
     ret = wc_ecc_rs_raw_to_sig(vector->r, vector->rSz, vector->s, vector->sSz,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1188,6 +1188,12 @@ enum Misc {
     MAX_SYM_KEY_SIZE    = WC_MAX_SYM_KEY_SIZE,
 #endif
 
+#ifdef HAVE_SELFTEST
+    AES_256_KEY_SIZE    = 32,
+    AES_IV_SIZE         = 16,
+    AES_128_KEY_SIZE    = 16,
+#endif
+
     AEAD_SEQ_OFFSET     = 4,   /* Auth Data: Sequence number */
     AEAD_TYPE_OFFSET    = 8,   /* Auth Data: Type            */
     AEAD_VMAJ_OFFSET    = 9,   /* Auth Data: Major Version   */

--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -60,12 +60,14 @@ enum {
     WC_SHA3_512_DIGEST_SIZE  = 64,
     WC_SHA3_512_COUNT        =  9,
 
+#ifndef HAVE_SELFTEST
     /* These values are used for HMAC, not SHA-3 directly.
      * They come from from FIPS PUB 202. */
     WC_SHA3_224_BLOCK_SIZE = 144,
     WC_SHA3_256_BLOCK_SIZE = 136,
     WC_SHA3_384_BLOCK_SIZE = 104,
     WC_SHA3_512_BLOCK_SIZE = 72,
+#endif
 };
 
 #ifndef NO_OLD_WC_NAMES


### PR DESCRIPTION
This PR fixes the CAVP Selftest build, generated/run/tested by:

```
$ ./fips-check.sh netbsd-selftest
```

This was being caught by the Jenkins "CAVP Self Test" experimental nightly build.