### PR TITLE
Fixed a filename in the pkcs7.h comments

### DIFF
--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -20,7 +20,7 @@
  */
 
 /*!
-    \file wolfssl/wolfcrypt/pksc7.h
+    \file wolfssl/wolfcrypt/pkcs7.h
 */
 
 #ifndef WOLF_CRYPT_PKCS7_H


### PR DESCRIPTION
Filename was wrong in the wolfssl/wolfcrypt/pkcs7.h file