### PR TITLE
Fix Cert Includes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -95,10 +95,6 @@ include wrapper/include.am
 include cyassl/include.am
 include wolfssl/include.am
 include certs/include.am
-include certs/1024/include.am
-include certs/crl/include.am
-include certs/external/include.am
-include certs/ocsp/include.am
 include doc/include.am
 include swig/include.am
 

--- a/certs/ed25519/include.am
+++ b/certs/ed25519/include.am
@@ -1,0 +1,25 @@
+# vim:ft=automake
+# All paths should be given relative to the root
+#
+
+EXTRA_DIST += \
+         certs/ed25519/ca-ed25519.der \
+         certs/ed25519/ca-ed25519.pem \
+         certs/ed25519/ca-ed25519-key.der \
+         certs/ed25519/ca-ed25519-key.pem \
+         certs/ed25519/client-ed25519.der \
+         certs/ed25519/client-ed25519.pem \
+         certs/ed25519/client-ed25519-key.der \
+         certs/ed25519/client-ed25519-key.pem \
+         certs/ed25519/client-ed25519-priv.der \
+         certs/ed25519/client-ed25519-priv.pem \
+         certs/ed25519/root-ed25519.der \
+         certs/ed25519/root-ed25519.pem \
+         certs/ed25519/root-ed25519-key.der \
+         certs/ed25519/root-ed25519-key.pem \
+         certs/ed25519/server-ed25519.der \
+         certs/ed25519/server-ed25519.pem \
+         certs/ed25519/server-ed25519-key.der \
+         certs/ed25519/server-ed25519-key.pem \
+         certs/ed25519/server-ed25519-priv.der \
+         certs/ed25519/server-ed25519-priv.pem

--- a/certs/external/include.am
+++ b/certs/external/include.am
@@ -4,4 +4,5 @@
 
 EXTRA_DIST += \
 	     certs/external/ca-globalsign-root-r3.pem \
+	     certs/external/ca-digicert-ev.pem \
 	     certs/external/baltimore-cybertrust-root.pem

--- a/certs/include.am
+++ b/certs/include.am
@@ -8,6 +8,8 @@ EXTRA_DIST += \
 	     certs/client-cert.pem \
 	     certs/client-keyEnc.pem \
 	     certs/client-key.pem \
+	     certs/client-uri-cert.pem \
+	     certs/client-relative-uri.pem \
 	     certs/ecc-key.pem \
 	     certs/ecc-privkey.pem \
 	     certs/ecc-keyPkcs8Enc.pem \
@@ -63,27 +65,6 @@ EXTRA_DIST += \
 	     certs/server-ecc-self.der \
 	     certs/server-ecc-rsa.der \
 	     certs/server-cert-chain.der
-EXTRA_DIST += \
-         certs/ed25519/ca-ed25519.der \
-         certs/ed25519/ca-ed25519-key.der \
-         certs/ed25519/ca-ed25519-key.pem \
-         certs/ed25519/ca-ed25519.pem \
-         certs/ed25519/client-ed25519.der \
-         certs/ed25519/client-ed25519-key.der \
-         certs/ed25519/client-ed25519-key.pem \
-         certs/ed25519/client-ed25519.pem \
-         certs/ed25519/client-ed25519-priv.pem \
-         certs/ed25519/client-ed25519-priv.pem \
-         certs/ed25519/root-ed25519.der \
-         certs/ed25519/root-ed25519-key.der \
-         certs/ed25519/root-ed25519-key.pem \
-         certs/ed25519/root-ed25519.pem \
-         certs/ed25519/server-ed25519.der \
-         certs/ed25519/server-ed25519-key.der \
-         certs/ed25519/server-ed25519-key.pem \
-         certs/ed25519/server-ed25519.pem \
-         certs/ed25519/server-ed25519-priv.der \
-         certs/ed25519/server-ed25519-priv.pem
 
 # ECC CA prime256v1
 EXTRA_DIST += \
@@ -103,7 +84,11 @@ dist_doc_DATA+= certs/taoCert.txt
 
 EXTRA_DIST+= certs/ntru-key.raw
 
+include certs/1024/include.am
+include certs/crl/include.am
+include certs/ecc/include.am
+include certs/ed25519/include.am
+include certs/external/include.am
+include certs/ocsp/include.am
 include certs/test/include.am
 include certs/test-pathlen/include.am
-include certs/test/include.am
-include certs/ecc/include.am

--- a/certs/test/include.am
+++ b/certs/test/include.am
@@ -30,3 +30,15 @@ EXTRA_DIST += \
          certs/test/server-nomatch.key \
          certs/test/server-nomatch.pem \
          certs/test/server-nomatch.der
+
+EXTRA_DIST += \
+		 certs/test/crit-cert.pem \
+		 certs/test/crit-key.pem \
+		 certs/test/dh1024.der \
+		 certs/test/dh1024.pem \
+		 certs/test/dh512.der \
+		 certs/test/dh512.pem \
+		 certs/test/digsigku.pem \
+		 certs/test/expired-ca.pem \
+		 certs/test/expired-cert.pem \
+		 certs/test/expired-key.pem


### PR DESCRIPTION
1. Added files that were missing from the certs directory include.am files.
2. Fixed the duplicate items in the certs directory's include.am files.
3. Reorganized the certs directory include.am files to be a tree.