### PR TITLE
Fix for possible leak with normal math and ECC verify fail for R and S

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4353,6 +4353,13 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
             key->state = ECC_STATE_VERIFY_DO;
 
             err = wc_ecc_verify_hash_ex(r, s, hash, hashlen, res, key);
+
+        #ifndef WOLFSSL_ASYNC_CRYPT
+            /* done with R/S */
+            mp_clear(r);
+            mp_clear(s);
+        #endif
+
             if (err < 0) {
                 break;
             }
@@ -4361,10 +4368,6 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
         case ECC_STATE_VERIFY_RES:
             key->state = ECC_STATE_VERIFY_RES;
             err = 0;
-
-            /* done with R/S */
-            mp_clear(r);
-            mp_clear(s);
             break;
 
         default:


### PR DESCRIPTION
If using normal math and `wc_ecc_verify_hash_ex` fails the local `mp_int` for `r` and `s` can leak.

For the async case (`WOLFSSL_ASYNC_CRYPT`) case the R and S are free'd in `wc_ecc_free_async`.