### PR TITLE
Fixes for Arduino

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,6 @@ IDE/LINUX-SGX/*.a
 wolfcrypt/src/port/intel/qat_test
 /mplabx/wolfssl.X/dist/default/
 /mplabx/wolfcrypt_test.X/dist/default/
+
+# Arduino Generated Files
+/IDE/ARDUINO/wolfSSL

--- a/IDE/ARDUINO/README.md
+++ b/IDE/ARDUINO/README.md
@@ -4,22 +4,23 @@
 This is a shell script that will re-organize the wolfSSL library to be 
 compatible with Arduino projects. The Arduino IDE requires a library's source
 files to be in the library's root directory with a header file in the name of 
-the library. This script moves all src/ files to the root wolfssl directory and 
-creates a stub header file called wolfssl.h.
+the library. This script moves all src/ files to the `IDE/ARDUINO/wolfSSL`
+directory and creates a stub header file called `wolfssl.h`.
 
 Step 1: To configure wolfSSL with Arduino, enter the following from within the
 wolfssl/IDE/ARDUINO directory:
 
-        ./wolfssl-arduino.sh
+        `./wolfssl-arduino.sh`
 
 
-Step 2: Edit <wolfssl-root>/wolfssl/wolfcrypt/settings.h uncomment the define for
-WOLFSSL_ARDUINO
+Step 2: Edit `<wolfssl-root>/IDE/ARDUINO/wolfSSL/wolfssl/wolfcrypt/settings.h` uncomment the define for `WOLFSSL_ARDUINO`
+If building for Intel Galileo platform also uncomment the define for `INTEL_GALILEO`.
 
-also uncomment the define for INTEL_GALILEO if building for that platform
-    
 #####Including wolfSSL in Arduino Libraries (for Arduino version 1.6.6)
-1. Copy the wolfSSL directory into Arduino/libraries (or wherever Arduino searches for libraries).
-2. In the Arduino IDE:
-    - Go to ```Sketch > Include Libraries > Manage Libraries```. This refreshes your changes to the libraries.
-    - Next go to ```Sketch > Include Libraries > wolfSSL```. This includes wolfSSL in your sketch.
+
+1. In the Arduino IDE:
+    - In `Sketch -> Include Library -> Add .ZIP Library...` and choose the
+        `IDE/ARDUNIO/wolfSSL` folder.
+    - In `Sketch -> Include Library` choose wolfSSL.
+
+An example wolfSSL client INO sketch exists here: `sketches/wolfssl_client/wolfssl_client.ino`

--- a/IDE/ARDUINO/sketches/wolfssl_client/wolfssl_client.ino
+++ b/IDE/ARDUINO/sketches/wolfssl_client/wolfssl_client.ino
@@ -1,6 +1,6 @@
 /* wolfssl_client.ino
  *
- * Copyright (C) 2006-2016 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -142,4 +142,3 @@ void loop() {
   }
   delay(1000);
 }
-

--- a/IDE/ARDUINO/wolfssl-arduino.sh
+++ b/IDE/ARDUINO/wolfssl-arduino.sh
@@ -7,20 +7,29 @@
 DIR=${PWD##*/}
 
 if [ "$DIR" = "ARDUINO" ]; then
-    cp ../../src/*.c ../../
-    cp ../../wolfcrypt/src/*.c ../../
-    echo "/* stub header file for Arduino compatibility */" >> ../../wolfssl.h
+	rm -rf wolfSSL
+	mkdir wolfSSL
+
+    cp ../../src/*.c ./wolfSSL
+    cp ../../wolfcrypt/src/*.c ./wolfSSL
+
+    mkdir wolfSSL/wolfssl
+    cp ../../wolfssl/*.h ./wolfSSL/wolfssl
+    mkdir wolfSSL/wolfssl/wolfcrypt
+    cp ../../wolfssl/wolfcrypt/*.h ./wolfSSL/wolfssl/wolfcrypt
+
+    # support misc.c as include in wolfcrypt/src
+    mkdir ./wolfSSL/wolfcrypt
+    mkdir ./wolfSSL/wolfcrypt/src
+    cp ../../wolfcrypt/src/misc.c ./wolfSSL/wolfcrypt/src
+
+    # put bio and evp as includes
+    mv ./wolfSSL/bio.c ./wolfSSL/wolfssl
+	mv ./wolfSSL/evp.c ./wolfSSL/wolfssl
+
+    echo "/* Generated wolfSSL header file for Arduino */" >> ./wolfSSL/wolfssl.h
+    echo "#include <wolfssl/wolfcrypt/settings.h>" >> ./wolfSSL/wolfssl.h
+    echo "#include <wolfssl/ssl.h>" >> ./wolfSSL/wolfssl.h
 else
     echo "ERROR: You must be in the IDE/ARDUINO directory to run this script"
 fi
-
-#UPDATED: 19 Apr 2017 to remove bio.c and evp.c from the root directory since
-#         they are included inline and should not be compiled directly
-
-ARDUINO_DIR=${PWD}
-cd ../../
-rm bio.c
-rm evp.c
-cd $ARDUINO_DIR
-# end script in the origin directory for any future functionality that may be added.
-#End UPDATE: 19 Apr 2017

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -34,7 +34,7 @@
 #endif
 
 /* detect C99 */
-#if !defined(WOLF_C99) && defined(__STDC_VERSION__)
+#if !defined(WOLF_C99) && defined(__STDC_VERSION__) && !defined(WOLFSSL_ARDUINO)
     #if __STDC_VERSION__ >= 199901L
         #define WOLF_C99
     #endif


### PR DESCRIPTION
Don't use C99 for Arduino. Enhanced the script to create a new folder in `IDE/ARDUINO/wolfSSL`. Updated README.md.