### PR TITLE
Align return values for EVP_DigestUpdate/Final for OpenSSL Compatibility

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -13400,7 +13400,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     }
 
 
-    /* WOLFSSL_SUCCESS on ok */
+    /* WOLFSSL_SUCCESS on ok, WOLFSSL_FAILURE on failure */
     int wolfSSL_EVP_DigestUpdate(WOLFSSL_EVP_MD_CTX* ctx, const void* data,
                                 size_t sz)
     {
@@ -13450,7 +13450,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                 break;
 #endif /* WOLFSSL_SHA512 */
             default:
-                return BAD_FUNC_ARG;
+                return WOLFSSL_FAILURE;
         }
 
         return WOLFSSL_SUCCESS;
@@ -13506,7 +13506,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                 break;
 #endif /* WOLFSSL_SHA512 */
             default:
-                return BAD_FUNC_ARG;
+                return WOLFSSL_FAILURE;
         }
 
         return WOLFSSL_SUCCESS;


### PR DESCRIPTION
Both of the following OpenSSL compatibility functions should return 1 on success (WOLFSSL_SUCCESS) and 0 upon failure (WOLFSSL_FAILURE).

This PR adjusts the error returns to return WOLFSSL_FAILURE instead of BAD_FUNC_ARG:

```
wolfSSL_EVP_DigestUpdate()
wolfSSL_EVP_DigestFinal()
```