### PR TITLE
fix CAVP self test build with newer raw hash functions

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -852,7 +852,8 @@ int wolfSSL_SetTlsHmacInner(WOLFSSL* ssl, byte* inner, word32 sz, int content,
 }
 
 
-#if !defined(WOLFSSL_NO_HASH_RAW) && !defined(HAVE_FIPS)
+#if !defined(WOLFSSL_NO_HASH_RAW) && !defined(HAVE_FIPS) && \
+    !defined(HAVE_SELFTEST)
 
 /* Update the hash in the HMAC.
  *
@@ -1163,7 +1164,8 @@ static int Hmac_UpdateFinal_CT(Hmac* hmac, byte* digest, const byte* in,
 
 #endif
 
-#if defined(WOLFSSL_NO_HASH_RAW) || defined(HAVE_FIPS) || defined(HAVE_BLAKE2)
+#if defined(WOLFSSL_NO_HASH_RAW) || defined(HAVE_FIPS) || \
+    defined(HAVE_SELFTEST) || defined(HAVE_BLAKE2)
 
 /* Calculate the HMAC of the header + message data.
  * Constant time implementation using normal hashing operations.
@@ -1314,7 +1316,8 @@ int TLS_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz, int padSz,
     if (ret == 0) {
         /* Constant time verification required. */
         if (verify && padSz >= 0) {
-#if !defined(WOLFSSL_NO_HASH_RAW) && !defined(HAVE_FIPS)
+#if !defined(WOLFSSL_NO_HASH_RAW) && !defined(HAVE_FIPS) && \
+    !defined(HAVE_SELFTEST)
     #ifdef HAVE_BLAKE2
             if (wolfSSL_GetHmacType(ssl) == WC_HASH_TYPE_BLAKE2B) {
                 ret = Hmac_UpdateFinal(&hmac, digest, in, sz +


### PR DESCRIPTION
This PR fixes our CAVP self test build, which can be reproduced using:

```
$ ./fips-check.sh netbsd-selftest
```

This was caught by Jenkins last night:

```
ERRORS
Total : 13 error(s)
1 src/tls.c: In function 'Hmac_HashFinalRaw':

2 src/tls.c:910:13: error: implicit declaration of function 'wc_ShaFinalRaw' [-Werror=implicit-function-declaration]

3 src/tls.c:910:13: error: nested extern declaration of 'wc_ShaFinalRaw' [-Werror=nested-externs]

4 src/tls.c:916:13: error: implicit declaration of function 'wc_Sha256FinalRaw' [-Werror=implicit-function-declaration]

5 src/tls.c:916:13: error: nested extern declaration of 'wc_Sha256FinalRaw' [-Werror=nested-externs]

6 src/tls.c:922:13: error: implicit declaration of function 'wc_Sha384FinalRaw' [-Werror=implicit-function-declaration]

7 src/tls.c:922:13: error: nested extern declaration of 'wc_Sha384FinalRaw' [-Werror=nested-externs]

8 src/tls.c:928:13: error: implicit declaration of function 'wc_Sha512FinalRaw' [-Werror=implicit-function-declaration]

9 src/tls.c:928:13: error: nested extern declaration of 'wc_Sha512FinalRaw' [-Werror=nested-externs]

10 Makefile:3751: recipe for target 'src/src_libwolfssl_la-tls.lo' failed

11 Makefile:2314: recipe for target 'all' failed

12 \n\nMake failed. Debris left for analysis.

13 CAVP Self Test failed
```