### PR TITLE
Fix PKCS7 Sign Verify

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1864,7 +1864,6 @@ int wc_PKCS7_VerifySignedData(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz)
         pkcs7->der = (byte*)XMALLOC(len, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         if (pkcs7->der == NULL)
             return MEMORY_E;
-        len = 0;
         ret = wc_BerToDer(pkiMsg, pkiMsgSz, pkcs7->der, &len);
         if (ret < 0)
             return ret;


### PR DESCRIPTION
When decoding a PKCS7 blob to verify the signature when it was an indefinite length, the output is processed without a length to calculate the size of the output, then processed a second time with an actual buffer. The buffer length was zeroed out before being used.