### PR TITLE
RPM Fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4238,7 +4238,7 @@ echo "#endif" >> $OPTION_FILE
 echo "" >> $OPTION_FILE
 
 for option in $OPTION_FLAGS; do
-    defonly=`echo $option | sed 's/-D//'`
+    defonly=`echo $option | sed 's/^-D//'`
     if test "$defonly" != "$option"
     then
         noequalsign=`echo $defonly | sed 's/=/ /'`

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -198,6 +198,7 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/wolfssl/wolfcrypt/ed25519.h
 %{_includedir}/wolfssl/wolfcrypt/error-crypt.h
 %{_includedir}/wolfssl/wolfcrypt/fe_operations.h
+%{_includedir}/wolfssl/wolfcrypt/fips.h
 %{_includedir}/wolfssl/wolfcrypt/fips_test.h
 %{_includedir}/wolfssl/wolfcrypt/ge_operations.h
 %{_includedir}/wolfssl/wolfcrypt/hash.h
@@ -307,7 +308,7 @@ mkdir -p $RPM_BUILD_ROOT/
 - Added header for pkcs12
 * Fri Sep 23 2016 John Safranek <john@wolfssl.com>
 - Add the dtls-sctp example sources
-* Mon Jun 14 2016 Jacob Barthelmeh <jacob@wolfssl.com>
+* Tue Jun 14 2016 Jacob Barthelmeh <jacob@wolfssl.com>
 - Change location for mem_track.h header
 - Added header for cmac.h
 * Thu Mar 17 2016 Jacob Barthelmeh <jacob@wolfssl.com>
@@ -319,5 +320,5 @@ mkdir -p $RPM_BUILD_ROOT/
 - Added recent new wolfcrypt headers for curve25519
 * Fri Jan 09 2015 John Safranek <john@wolfssl.com>
 - Update for cyassl->wolfssl name change
-* Fri Oct 20 2012 Brian Aker <brian@tangent.org>
+* Sat Oct 20 2012 Brian Aker <brian@tangent.org>
 - Initial package

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -20,6 +20,7 @@ nobase_include_HEADERS+= \
                          wolfssl/wolfcrypt/fe_operations.h \
                          wolfssl/wolfcrypt/ge_operations.h \
                          wolfssl/wolfcrypt/error-crypt.h \
+                         wolfssl/wolfcrypt/fips.h \
                          wolfssl/wolfcrypt/fips_test.h \
                          wolfssl/wolfcrypt/hash.h \
                          wolfssl/wolfcrypt/hc128.h \
@@ -97,9 +98,5 @@ endif
 
 if BUILD_SELFTEST
 nobase_include_HEADERS+= wolfssl/wolfcrypt/selftest.h
-endif
-
-if BUILD_FIPS_V2
-nobase_include_HEADERS+= wolfssl/wolfcrypt/fips.h
 endif
 


### PR DESCRIPTION
1. Fixed a few parsing checks in the dates in the RPM changelog.
2. Moved some file names between sections in the include.am and spec.in files.
3. Added the match-start-of-line to the regex for finding the -D items for the options file.