### PR TITLE
Added support for the STM32L4 and fixed mixed enum warnings

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8618,8 +8618,9 @@ int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen)
 */
 int wc_InitCert(Cert* cert)
 {
+#ifdef WOLFSSL_MULTI_ATTRIB
     int i;
-
+#endif
     if (cert == NULL) {
         return BAD_FUNC_ARG;
     }
@@ -8665,7 +8666,6 @@ int wc_InitCert(Cert* cert)
     cert->heap = (void*)WOLFSSL_HEAP_TEST;
 #endif
 
-    (void)i;
     return 0;
 }
 
@@ -8674,7 +8674,7 @@ int wc_InitCert(Cert* cert)
 typedef struct DerCert {
     byte size[MAX_LENGTH_SZ];          /* length encoded */
     byte version[MAX_VERSION_SZ];      /* version encoded */
-    byte serial[CTC_SERIAL_SIZE + MAX_LENGTH_SZ]; /* serial number encoded */
+    byte serial[(int)CTC_SERIAL_SIZE + (int)MAX_LENGTH_SZ]; /* serial number encoded */
     byte sigAlgo[MAX_ALGO_SZ];         /* signature algo encoded */
     byte issuer[ASN_NAME_MAX];         /* issuer  encoded */
     byte subject[ASN_NAME_MAX];        /* subject encoded */

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -270,7 +270,7 @@ int wc_HashGetDigestSize(enum wc_HashType hash_type)
             break;
         case WC_HASH_TYPE_MD5_SHA: /* Old TLS Specific */
         #if !defined(NO_MD5) && !defined(NO_SHA)
-            dig_size = WC_MD5_DIGEST_SIZE + WC_SHA_DIGEST_SIZE;
+            dig_size = (int)WC_MD5_DIGEST_SIZE + (int)WC_SHA_DIGEST_SIZE;
         #endif
             break;
 
@@ -354,7 +354,7 @@ int wc_HashGetBlockSize(enum wc_HashType hash_type)
             break;
         case WC_HASH_TYPE_MD5_SHA: /* Old TLS Specific */
         #if !defined(NO_MD5) && !defined(NO_SHA)
-            block_size = WC_MD5_BLOCK_SIZE + WC_SHA_BLOCK_SIZE;
+            block_size = (int)WC_MD5_BLOCK_SIZE + (int)WC_SHA_BLOCK_SIZE;
         #endif
             break;
 

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -41,6 +41,10 @@
 
 #ifdef STM32_HASH
 
+#ifdef WOLFSSL_STM32L4
+    #define HASH_STR_NBW HASH_STR_NBLW
+#endif
+
 /* User can override STM32_HASH_CLOCK_ENABLE and STM32_HASH_CLOCK_DISABLE */
 #ifndef STM32_HASH_CLOCK_ENABLE
     static WC_INLINE void wc_Stm32_Hash_Clock_Enable(STM32_HASH_Context* stmCtx)

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -97,6 +97,14 @@ enum {
     AES_BLOCK_SIZE      = 16,
 
     KEYWRAP_BLOCK_SIZE  = 8,
+
+    GCM_NONCE_MAX_SZ = 16, /* wolfCrypt's maximum nonce size allowed. */
+    GCM_NONCE_MID_SZ = 12, /* The usual default nonce size for AES-GCM. */
+    GCM_NONCE_MIN_SZ = 8,  /* wolfCrypt's minimum nonce size allowed. */
+    CCM_NONCE_MIN_SZ = 7,
+    CCM_NONCE_MAX_SZ = 13,
+    CTR_SZ   = 4,
+    AES_IV_FIXED_SZ = 4
 };
 
 

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -95,16 +95,15 @@ enum ASN_Tags {
     CRL_EXTENSIONS        = 0xa0,
     ASN_EXTENSIONS        = 0xa3,
     ASN_LONG_LENGTH       = 0x80,
-    ASN_INDEF_LENGTH      = 0x80
+    ASN_INDEF_LENGTH      = 0x80,
+
+    /* ASN_Flags - Bitmask */
+    ASN_CONSTRUCTED       = 0x20,
+    ASN_CONTEXT_SPECIFIC  = 0x80,
 };
 
 #define ASN_UTC_TIME_SIZE 14
 #define ASN_GENERALIZED_TIME_SIZE 16
-
-enum ASN_Flags {
-    ASN_CONSTRUCTED       = 0x20,
-    ASN_CONTEXT_SPECIFIC  = 0x80
-};
 
 enum DN_Tags {
     ASN_COMMON_NAME   = 0x03,   /* CN */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -986,7 +986,8 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 #if defined(WOLFSSL_STM32F2) || defined(WOLFSSL_STM32F4) || \
-    defined(WOLFSSL_STM32F7) || defined(WOLFSSL_STM32F1)
+    defined(WOLFSSL_STM32F7) || defined(WOLFSSL_STM32F1) || \
+    defined(WOLFSSL_STM32L4)
 
     #define SIZEOF_LONG_LONG 8
     #define NO_DEV_RANDOM
@@ -1012,6 +1013,8 @@ extern void uITRON4_free(void *p) ;
     #ifdef WOLFSSL_STM32_CUBEMX
         #if defined(WOLFSSL_STM32F2)
             #include "stm32f2xx_hal.h"
+        #elif defined(WOLFSSL_STM32L4)
+            #include "stm32l4xx_hal.h"
         #elif defined(WOLFSSL_STM32F4)
             #include "stm32f4xx_hal.h"
         #elif defined(WOLFSSL_STM32F7)
@@ -1039,6 +1042,14 @@ extern void uITRON4_free(void *p) ;
             #endif
             #ifdef STM32_HASH
                 #include "stm32f4xx_hash.h"
+            #endif
+        #elif defined(WOLFSSL_STM32L4)
+            #include "stm32l4xx.h"
+            #ifdef STM32_CRYPTO
+                #include "stm32l4xx_cryp.h"
+            #endif
+            #ifdef STM32_HASH
+                #include "stm32l4xx_hash.h"
             #endif
         #elif defined(WOLFSSL_STM32F7)
             #include "stm32f7xx.h"


### PR DESCRIPTION
Added support for the STM32L4 with AES/SHA hardware acceleration.
Fixed a few minor compiler warnings with mis-matched enum types.