### PR TITLE
Add PK_CALLBACK support for RSA/ECC verify to ConfirmSignature

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6689,9 +6689,6 @@ int wolfSSL_check_private_key(const WOLFSSL* ssl)
 #endif
 
     if (ParseCertRelative(&der, CERT_TYPE, NO_VERIFY, NULL) != 0) {
-    #ifdef HAVE_PK_CALLBACKS
-        FreeSigPkCb((WOLFSSL*)ssl, &der.sigCtx);
-    #endif
         FreeDecodedCert(&der);
         return WOLFSSL_FAILURE;
     }
@@ -6699,9 +6696,6 @@ int wolfSSL_check_private_key(const WOLFSSL* ssl)
     size = ssl->buffers.key->length;
     buff = ssl->buffers.key->buffer;
     ret  = wc_CheckPrivateKey(buff, size, &der);
-#ifdef HAVE_PK_CALLBACKS
-    FreeSigPkCb((WOLFSSL*)ssl, &der.sigCtx);
-#endif
     FreeDecodedCert(&der);
     return ret;
 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6681,7 +6681,7 @@ int wolfSSL_check_private_key(const WOLFSSL* ssl)
     buff = ssl->buffers.certificate->buffer;
     InitDecodedCert(&der, buff, size, ssl->heap);
 #ifdef HAVE_PK_CALLBACKS
-    ret = InitSigPkCb(ssl, &der.sigCtx);
+    ret = InitSigPkCb((WOLFSSL*)ssl, &der.sigCtx);
     if (ret != 0) {
         FreeDecodedCert(&der);
         return ret;
@@ -6690,7 +6690,7 @@ int wolfSSL_check_private_key(const WOLFSSL* ssl)
 
     if (ParseCertRelative(&der, CERT_TYPE, NO_VERIFY, NULL) != 0) {
     #ifdef HAVE_PK_CALLBACKS
-        FreeSigPkCb(ssl, &der.sigCtx);
+        FreeSigPkCb((WOLFSSL*)ssl, &der.sigCtx);
     #endif
         FreeDecodedCert(&der);
         return WOLFSSL_FAILURE;
@@ -6700,7 +6700,7 @@ int wolfSSL_check_private_key(const WOLFSSL* ssl)
     buff = ssl->buffers.key->buffer;
     ret  = wc_CheckPrivateKey(buff, size, &der);
 #ifdef HAVE_PK_CALLBACKS
-    FreeSigPkCb(ssl, &der.sigCtx);
+    FreeSigPkCb((WOLFSSL*)ssl, &der.sigCtx);
 #endif
     FreeDecodedCert(&der);
     return ret;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5353,7 +5353,7 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                         ret = sigCtx->pkCbRsa(
                                 sigCtx->plain, sigSz, &sigCtx->out,
                                 key, keySz,
-                                sigCtx->pkCtx);
+                                sigCtx->pkCtxRsa);
                     }
                     else
                 #endif /* HAVE_PK_CALLBACKS */
@@ -5373,7 +5373,7 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                                 sig, sigSz,
                                 sigCtx->digest, sigCtx->digestSz,
                                 key, keySz, &sigCtx->verify,
-                                sigCtx->pkCtx);
+                                sigCtx->pkCtxEcc);
                     }
                     else
                 #endif /* HAVE_PK_CALLBACKS */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5348,16 +5348,40 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
             #ifndef NO_RSA
                 case RSAk:
                 {
-                    ret = wc_RsaSSL_VerifyInline(sigCtx->plain, sigSz,
-                                                &sigCtx->out, sigCtx->key.rsa);
+                #ifdef HAVE_PK_CALLBACKS
+                    if (sigCtx->pkCbRsa) {
+                        ret = sigCtx->pkCbRsa(
+                                sigCtx->plain, sigSz, &sigCtx->out,
+                                key, keySz,
+                                sigCtx->pkCtx);
+                    }
+                    else
+                #endif /* HAVE_PK_CALLBACKS */
+                    {
+                        ret = wc_RsaSSL_VerifyInline(sigCtx->plain, sigSz,
+                                                 &sigCtx->out, sigCtx->key.rsa);
+                    }
                     break;
                 }
             #endif /* !NO_RSA */
             #ifdef HAVE_ECC
                 case ECDSAk:
                 {
-                    ret = wc_ecc_verify_hash(sig, sigSz, sigCtx->digest,
-                        sigCtx->digestSz, &sigCtx->verify, sigCtx->key.ecc);
+                #ifdef HAVE_PK_CALLBACKS
+                    if (sigCtx->pkCbEcc) {
+                        ret = sigCtx->pkCbEcc(
+                                sig, sigSz,
+                                sigCtx->digest, sigCtx->digestSz,
+                                key, keySz, &sigCtx->verify,
+                                sigCtx->pkCtx);
+                    }
+                    else
+                #endif /* HAVE_PK_CALLBACKS */
+                    {
+                        ret = wc_ecc_verify_hash(sig, sigSz, sigCtx->digest,
+                                            sigCtx->digestSz, &sigCtx->verify,
+                                            sigCtx->key.ecc);
+                    }
                     break;
                 }
             #endif /* HAVE_ECC */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1531,7 +1531,6 @@ WOLFSSL_LOCAL int  DecodePrivateKey(WOLFSSL *ssl, word16* length);
 WOLFSSL_LOCAL int GetPrivateKeySigSize(WOLFSSL* ssl);
 #ifndef NO_ASN
     WOLFSSL_LOCAL int  InitSigPkCb(WOLFSSL* ssl, SignatureCtx* sigCtx);
-    WOLFSSL_LOCAL void FreeSigPkCb(WOLFSSL* ssl, SignatureCtx* sigCtx);
 #endif
 #endif
 WOLFSSL_LOCAL void FreeKeyExchange(WOLFSSL* ssl);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1529,6 +1529,10 @@ WOLFSSL_LOCAL void PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
 WOLFSSL_LOCAL int  DecodePrivateKey(WOLFSSL *ssl, word16* length);
 #ifdef HAVE_PK_CALLBACKS
 WOLFSSL_LOCAL int GetPrivateKeySigSize(WOLFSSL* ssl);
+#ifndef NO_ASN
+    WOLFSSL_LOCAL int  InitSigPkCb(const WOLFSSL* ssl, SignatureCtx* sigCtx);
+    WOLFSSL_LOCAL void FreeSigPkCb(const WOLFSSL* ssl, SignatureCtx* sigCtx);
+#endif
 #endif
 WOLFSSL_LOCAL void FreeKeyExchange(WOLFSSL* ssl);
 WOLFSSL_LOCAL int  ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx, word32 size);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1530,8 +1530,8 @@ WOLFSSL_LOCAL int  DecodePrivateKey(WOLFSSL *ssl, word16* length);
 #ifdef HAVE_PK_CALLBACKS
 WOLFSSL_LOCAL int GetPrivateKeySigSize(WOLFSSL* ssl);
 #ifndef NO_ASN
-    WOLFSSL_LOCAL int  InitSigPkCb(const WOLFSSL* ssl, SignatureCtx* sigCtx);
-    WOLFSSL_LOCAL void FreeSigPkCb(const WOLFSSL* ssl, SignatureCtx* sigCtx);
+    WOLFSSL_LOCAL int  InitSigPkCb(WOLFSSL* ssl, SignatureCtx* sigCtx);
+    WOLFSSL_LOCAL void FreeSigPkCb(WOLFSSL* ssl, SignatureCtx* sigCtx);
 #endif
 #endif
 WOLFSSL_LOCAL void FreeKeyExchange(WOLFSSL* ssl);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1840,6 +1840,8 @@ enum KDF_MacAlgorithm {
 
 
 /* Public Key Callback support */
+#ifdef HAVE_PK_CALLBACKS
+#ifdef HAVE_ECC
 typedef int (*CallbackEccSign)(WOLFSSL* ssl,
        const unsigned char* in, unsigned int inSz,
        unsigned char* out, unsigned int* outSz,
@@ -1866,6 +1868,7 @@ typedef int (*CallbackEccSharedSecret)(WOLFSSL* ssl, struct ecc_key* otherKey,
 WOLFSSL_API void  wolfSSL_CTX_SetEccSharedSecretCb(WOLFSSL_CTX*, CallbackEccSharedSecret);
 WOLFSSL_API void  wolfSSL_SetEccSharedSecretCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetEccSharedSecretCtx(WOLFSSL* ssl);
+#endif
 
 #ifndef NO_DH
 /* Public DH Key Callback support */
@@ -1880,6 +1883,7 @@ WOLFSSL_API void  wolfSSL_SetDhAgreeCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl);
 #endif /* !NO_DH */
 
+#ifdef HAVE_ED25519
 struct ed25519_key;
 typedef int (*CallbackEd25519Sign)(WOLFSSL* ssl,
        const unsigned char* in, unsigned int inSz,
@@ -1900,7 +1904,9 @@ WOLFSSL_API void  wolfSSL_CTX_SetEd25519VerifyCb(WOLFSSL_CTX*,
                                                  CallbackEd25519Verify);
 WOLFSSL_API void  wolfSSL_SetEd25519VerifyCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetEd25519VerifyCtx(WOLFSSL* ssl);
+#endif
 
+#ifdef HAVE_CURVE25519
 struct curve25519_key;
 typedef int (*CallbackX25519SharedSecret)(WOLFSSL* ssl,
         struct curve25519_key* otherKey,
@@ -1912,7 +1918,9 @@ WOLFSSL_API void  wolfSSL_CTX_SetX25519SharedSecretCb(WOLFSSL_CTX*,
         CallbackX25519SharedSecret);
 WOLFSSL_API void  wolfSSL_SetX25519SharedSecretCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetX25519SharedSecretCtx(WOLFSSL* ssl);
+#endif
 
+#ifndef NO_RSA
 typedef int (*CallbackRsaSign)(WOLFSSL* ssl,
        const unsigned char* in, unsigned int inSz,
        unsigned char* out, unsigned int* outSz,
@@ -1976,7 +1984,8 @@ typedef int (*CallbackRsaDec)(WOLFSSL* ssl,
 WOLFSSL_API void  wolfSSL_CTX_SetRsaDecCb(WOLFSSL_CTX*, CallbackRsaDec);
 WOLFSSL_API void  wolfSSL_SetRsaDecCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl);
-
+#endif
+#endif /* HAVE_PK_CALLBACKS */
 
 #ifndef NO_CERTS
     WOLFSSL_API void wolfSSL_CTX_SetCACb(WOLFSSL_CTX*, CallbackCACache);

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -543,12 +543,13 @@ struct SignatureCtx {
 #endif
 
 #ifdef HAVE_PK_CALLBACKS
-    void* pkCtx;
 #ifdef HAVE_ECC
     wc_CallbackEccVerify pkCbEcc;
+    void* pkCtxEcc;
 #endif
 #ifndef NO_RSA
     wc_CallbackRsaVerify pkCbRsa;
+    void* pkCtxRsa;
 #endif
 #endif /* HAVE_PK_CALLBACKS */
 };

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -492,6 +492,24 @@ enum SignatureState {
     SIG_STATE_CHECK,
 };
 
+
+#ifdef HAVE_PK_CALLBACKS
+#ifdef HAVE_ECC
+    typedef int (*wc_CallbackEccVerify)(
+           const unsigned char* sig, unsigned int sigSz,
+           const unsigned char* hash, unsigned int hashSz,
+           const unsigned char* keyDer, unsigned int keySz,
+           int* result, void* ctx);
+#endif
+#ifndef NO_RSA
+    typedef int (*wc_CallbackRsaVerify)(
+           unsigned char* sig, unsigned int sigSz,
+           unsigned char** out,
+           const unsigned char* keyDer, unsigned int keySz,
+           void* ctx);
+#endif
+#endif /* HAVE_PK_CALLBACKS */
+
 struct SignatureCtx {
     void* heap;
     byte* digest;
@@ -523,6 +541,16 @@ struct SignatureCtx {
     WC_ASYNC_DEV* asyncDev;
     void* asyncCtx;
 #endif
+
+#ifdef HAVE_PK_CALLBACKS
+    void* pkCtx;
+#ifdef HAVE_ECC
+    wc_CallbackEccVerify pkCbEcc;
+#endif
+#ifndef NO_RSA
+    wc_CallbackRsaVerify pkCbRsa;
+#endif
+#endif /* HAVE_PK_CALLBACKS */
 };
 
 enum CertSignState {


### PR DESCRIPTION
Feature request / maintenance to allow public key callbacks to be made from asn.c::ConfirmSignature

To reproduce:
```
./configure --enable-pkcallbacks

./examples/server/server -A certs/client-ecc-cert.pem -c certs/server-ecc.pem -k certs/ecc-key.pem -P &
PID=$!
./examples/client/client -A certs/ca-ecc-cert.pem -c certs/client-ecc-cert.pem -k certs/ecc-client-key.pem -P
kill $PID
```