### PR TITLE
Fix for memory leak in wolfSSL_BN_hex2bn

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -22163,6 +22163,7 @@ int wolfSSL_BN_hex2bn(WOLFSSL_BIGNUM** bn, const char* str)
 #else
     byte    decoded[1024];
 #endif
+    int     weOwn = 0;
 
     WOLFSSL_MSG("wolfSSL_BN_hex2bn");
 
@@ -22179,14 +22180,20 @@ int wolfSSL_BN_hex2bn(WOLFSSL_BIGNUM** bn, const char* str)
     else if (bn == NULL)
         ret = decSz;
     else {
-        if (*bn == NULL)
+        if (*bn == NULL) {
             *bn = wolfSSL_BN_new();
+            if (*bn != NULL) {
+                weOwn = 1;
+            }
+        }
 
         if (*bn == NULL)
             WOLFSSL_MSG("BN new failed");
         else if (wolfSSL_BN_bin2bn(decoded, decSz, *bn) == NULL) {
             WOLFSSL_MSG("Bad bin2bn error");
-            wolfSSL_BN_free(*bn); /* Free new BN */
+            if (weOwn == 1) {
+                wolfSSL_BN_free(*bn); /* Free new BN */
+            }
         }
         else
             ret = WOLFSSL_SUCCESS;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -22184,8 +22184,10 @@ int wolfSSL_BN_hex2bn(WOLFSSL_BIGNUM** bn, const char* str)
 
         if (*bn == NULL)
             WOLFSSL_MSG("BN new failed");
-        else if (wolfSSL_BN_bin2bn(decoded, decSz, *bn) == NULL)
+        else if (wolfSSL_BN_bin2bn(decoded, decSz, *bn) == NULL) {
             WOLFSSL_MSG("Bad bin2bn error");
+            wolfSSL_BN_free(*bn); /* Free new BN */
+        }
         else
             ret = WOLFSSL_SUCCESS;
     }


### PR DESCRIPTION
Reported potential memory leak fixed by adding a call to wolfSSL_BN_free if wolfSSL_BN_bin2bn fails.