### PR TITLE
Added PKCS7 dynamic allocation support

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -3263,7 +3263,7 @@ static void test_wolfSSL_mcast(void)
  |  Wolfcrypt
  *----------------------------------------------------------------------------*/
 
-/* 
+/*
  * Unit test for the wc_InitBlake2b()
  */
 static int test_wc_InitBlake2b (void)
@@ -7609,7 +7609,7 @@ static int test_wc_Des3_SetKey (void)
     return ret;
 
 } /* END test_wc_Des3_SetKey */
- 
+
 
 /*
  * Test function for wc_Des3_CbcEncrypt and wc_Des3_CbcDecrypt
@@ -7856,7 +7856,7 @@ static int test_wc_Chacha_SetKey (void)
 static int test_wc_Poly1305SetKey(void)
 {
     int ret = 0;
-    
+
 #ifdef HAVE_POLY1305
     Poly1305      ctx;
     const byte  key[] =
@@ -7868,8 +7868,8 @@ static int test_wc_Poly1305SetKey(void)
     };
 
     printf(testingFmt, "wc_Poly1305_SetKey()");
-    
-    ret = wc_Poly1305SetKey(&ctx, key, (word32)(sizeof(key)/sizeof(byte))); 
+
+    ret = wc_Poly1305SetKey(&ctx, key, (word32)(sizeof(key)/sizeof(byte)));
     /* Test bad args. */
     if (ret == 0) {
         ret = wc_Poly1305SetKey(NULL, key, (word32)(sizeof(key)/sizeof(byte)));
@@ -7887,7 +7887,7 @@ static int test_wc_Poly1305SetKey(void)
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
-    
+
 #endif
     return ret;
 } /* END test_wc_Poly1305_SetKey() */
@@ -10112,7 +10112,7 @@ static int test_wc_RsaKeyToDer (void)
  *  Testing wc_RsaKeyToPublicDer()
  */
 static int test_wc_RsaKeyToPublicDer (void)
-{ 
+{
     int         ret = 0;
 #if !defined(NO_RSA) && !defined(HAVE_FAST_RSA) && defined(WOLFSSL_KEY_GEN) &&\
      (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
@@ -14186,6 +14186,25 @@ static int test_wc_ecc_is_valid_idx (void)
 
 
 /*
+ * Testing wc_PKCS7_New()
+ */
+static void test_wc_PKCS7_New (void)
+{
+#if defined(HAVE_PKCS7)
+    PKCS7*      pkcs7;
+    void*       heap = NULL;
+
+    printf(testingFmt, "wc_PKCS7_New()");
+
+    pkcs7 = wc_PKCS7_New(heap, devId);
+    AssertNotNull(pkcs7);
+
+    printf(resultFmt, passed);
+    wc_PKCS7_Free(pkcs7);
+#endif
+} /* END test-wc_PKCS7_New */
+
+/*
  * Testing wc_PKCS7_Init()
  */
 static void test_wc_PKCS7_Init (void)
@@ -15038,43 +15057,43 @@ static void test_wc_PKCS7_EncodeEncryptedData (void)
 
 /* Testing wc_SignatureGetSize() for signature type ECC */
 static int test_wc_SignatureGetSize_ecc(void)
-{    
-    int ret = 0; 
+{
+    int ret = 0;
     #if defined(HAVE_ECC) && !defined(NO_ECC256)
         enum wc_SignatureType sig_type;
         word32 key_len;
 
         /* Initialize ECC Key */
-        ecc_key ecc; 
+        ecc_key ecc;
         const char* qx =
             "fa2737fb93488d19caef11ae7faf6b7f4bcd67b286e3fc54e8a65c2b74aeccb0";
-        const char* qy = 
+        const char* qy =
             "d4ccd6dae698208aa8c3a6f39e45510d03be09b2f124bfc067856c324f9b4d09";
-        const char* d = 
+        const char* d =
             "be34baa8d040a3b991f9075b56ba292f755b90e4b6dc10dad36715c33cfdac25";
-    
+
         ret = wc_ecc_init(&ecc);
         if (ret == 0) {
             ret = wc_ecc_import_raw(&ecc, qx, qy, d, "SECP256R1");
         }
         printf(testingFmt, "wc_SigntureGetSize_ecc()");
-        if (ret == 0) { 
+        if (ret == 0) {
             /* Input for signature type ECC */
             sig_type = WC_SIGNATURE_TYPE_ECC;
             key_len = sizeof(ecc_key);
             ret = wc_SignatureGetSize(sig_type, &ecc, key_len);
-            
-            /* Test bad args */ 
+
+            /* Test bad args */
             if (ret > 0) {
                 sig_type = (enum wc_SignatureType) 100;
                 ret = wc_SignatureGetSize(sig_type, &ecc, key_len);
                 if (ret == BAD_FUNC_ARG) {
                     sig_type = WC_SIGNATURE_TYPE_ECC;
                     ret = wc_SignatureGetSize(sig_type, NULL, key_len);
-                }  
+                }
                 if (ret >= 0) {
                     key_len = (word32) 0;
-                    ret = wc_SignatureGetSize(sig_type, &ecc, key_len); 
+                    ret = wc_SignatureGetSize(sig_type, &ecc, key_len);
                 }
                 if (ret == BAD_FUNC_ARG) {
                     ret = SIG_TYPE_E;
@@ -15102,7 +15121,7 @@ static int test_wc_SignatureGetSize_ecc(void)
 /* Testing wc_SignatureGetSize() for signature type rsa */
 static int test_wc_SignatureGetSize_rsa(void)
 {
-    int ret = 0; 
+    int ret = 0;
     #ifndef NO_RSA
         enum wc_SignatureType sig_type;
         word32 key_len;
@@ -15112,7 +15131,7 @@ static int test_wc_SignatureGetSize_rsa(void)
         RsaKey rsa_key;
         byte* tmp = NULL;
         size_t bytes;
-     
+
         #ifdef USE_CERT_BUFFERS_1024
             bytes = (size_t)sizeof_client_key_der_1024;
             if (bytes < (size_t)sizeof_client_key_der_1024)
@@ -15128,10 +15147,10 @@ static int test_wc_SignatureGetSize_rsa(void)
         tmp = (byte*)XMALLOC(bytes, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         if (tmp != NULL) {
             #ifdef USE_CERT_BUFFERS_1024
-                XMEMCPY(tmp, client_key_der_1024, 
+                XMEMCPY(tmp, client_key_der_1024,
                     (size_t)sizeof_client_key_der_1024);
             #elif defined(USE_CERT_BUFFERS_2048)
-                XMEMCPY(tmp, client_key_der_2048, 
+                XMEMCPY(tmp, client_key_der_2048,
                     (size_t)sizeof_client_key_der_2048);
             #elif !defined(NO_FILESYSTEM)
                 file = fopen(clientKey, "rb");
@@ -15148,7 +15167,7 @@ static int test_wc_SignatureGetSize_rsa(void)
             if (ret == 0) {
                 ret = wc_InitRsaKey_ex(&rsa_key, HEAP_HINT, devId);
                 if (ret == 0) {
-                    ret = wc_RsaPrivateKeyDecode(tmp, &idx, &rsa_key, 
+                    ret = wc_RsaPrivateKeyDecode(tmp, &idx, &rsa_key,
                         (word32)bytes);
                 }
             }
@@ -15162,7 +15181,7 @@ static int test_wc_SignatureGetSize_rsa(void)
             sig_type = WC_SIGNATURE_TYPE_RSA;
             key_len = sizeof(RsaKey);
             ret = wc_SignatureGetSize(sig_type, &rsa_key, key_len);
-            
+
             /* Test bad args */
             if (ret > 0) {
                 sig_type = (enum wc_SignatureType) 100;
@@ -15173,7 +15192,7 @@ static int test_wc_SignatureGetSize_rsa(void)
                 }
             #ifndef HAVE_USER_RSA
                 if (ret == BAD_FUNC_ARG) {
-            #else        
+            #else
                 if (ret == 0) {
             #endif
                     key_len = (word32)0;
@@ -15191,21 +15210,21 @@ static int test_wc_SignatureGetSize_rsa(void)
     #else
         ret = SIG_TYPE_E;
     #endif
-            
+
     if (ret == SIG_TYPE_E) {
         ret = 0;
     }else {
         ret = WOLFSSL_FATAL_ERROR;
     }
- 
+
    printf(resultFmt, ret == 0 ? passed : failed);
    return ret;
 }/* END test_wc_SignatureGetSize_rsa(void) */
-  
+
 /*----------------------------------------------------------------------------*
  | hash.h Tests
  *----------------------------------------------------------------------------*/
-  
+
 static int test_wc_HashInit(void)
 {
     int ret = 0, i;  /* 0 indicates tests passed, 1 indicates failure */
@@ -15604,7 +15623,7 @@ static void test_wolfSSL_ASN1_GENERALIZEDTIME_free(){
 
     XMEMSET(nullstr, 0, 32);
     asn1_gtime = (WOLFSSL_ASN1_GENERALIZEDTIME*)XMALLOC(
-                    sizeof(WOLFSSL_ASN1_GENERALIZEDTIME), NULL, 
+                    sizeof(WOLFSSL_ASN1_GENERALIZEDTIME), NULL,
                     DYNAMIC_TYPE_TMP_BUFFER);
     XMEMCPY(asn1_gtime->data,"20180504123500Z",ASN_GENERALIZED_TIME_SIZE);
     wolfSSL_ASN1_GENERALIZEDTIME_free(asn1_gtime);
@@ -18374,14 +18393,14 @@ static void test_wolfSSL_SHA(void)
             "\x23\xB0\x03\x61\xA3\x96\x17\x7A\x9C\xB4\x10\xFF\x61\xF2\x00"
             "\x15\xAD";
         unsigned char out[WC_SHA256_DIGEST_SIZE];
-     
+
         XMEMSET(out, 0, WC_SHA256_DIGEST_SIZE);
         AssertNotNull(SHA256(in, XSTRLEN((char*)in), out));
         AssertIntEQ(XMEMCMP(out, expected, WC_SHA256_DIGEST_SIZE), 0);
     }
     #endif
 
-    #if defined(WOLFSSL_SHA384) && defined(WOLFSSL_SHA512) 
+    #if defined(WOLFSSL_SHA384) && defined(WOLFSSL_SHA512)
     {
         const unsigned char in[] = "abc";
         unsigned char expected[] = "\xcb\x00\x75\x3f\x45\xa3\x5e\x8b\xb5\xa0\x3d\x69\x9a\xc6\x50"
@@ -18590,9 +18609,9 @@ static void test_wolfSSL_ASN1_STRING_print_ex(void){
     unsigned long flags;
     int p_len;
     unsigned char rbuf[255];
-    
+
     printf(testingFmt, "wolfSSL_ASN1_STRING_print_ex()");
-    
+
     /* setup */
     XMEMSET(rbuf, 0, 255);
     bio = BIO_new(BIO_s_mem());
@@ -19777,7 +19796,7 @@ static void test_wolfSSL_i2c_ASN1_INTEGER()
                 DYNAMIC_TYPE_TMP_BUFFER));
     tpp = pp;
     XMEMSET(pp, 0, ret + 1);
-    wolfSSL_i2c_ASN1_INTEGER(a, &pp); 
+    wolfSSL_i2c_ASN1_INTEGER(a, &pp);
     pp--;
     AssertIntEQ(*pp, 40);
     XFREE(tpp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -19792,7 +19811,7 @@ static void test_wolfSSL_i2c_ASN1_INTEGER()
                 DYNAMIC_TYPE_TMP_BUFFER));
     tpp = pp;
     XMEMSET(pp, 0, ret + 1);
-    wolfSSL_i2c_ASN1_INTEGER(a, &pp); 
+    wolfSSL_i2c_ASN1_INTEGER(a, &pp);
     pp--;
     AssertIntEQ(*(pp--), 128);
     AssertIntEQ(*pp, 0);
@@ -19809,7 +19828,7 @@ static void test_wolfSSL_i2c_ASN1_INTEGER()
                 DYNAMIC_TYPE_TMP_BUFFER));
     tpp = pp;
     XMEMSET(pp, 0, ret + 1);
-    wolfSSL_i2c_ASN1_INTEGER(a, &pp); 
+    wolfSSL_i2c_ASN1_INTEGER(a, &pp);
     pp--;
     AssertIntEQ(*pp, 216);
     XFREE(tpp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -19825,7 +19844,7 @@ static void test_wolfSSL_i2c_ASN1_INTEGER()
                 DYNAMIC_TYPE_TMP_BUFFER));
     tpp = pp;
     XMEMSET(pp, 0, ret + 1);
-    wolfSSL_i2c_ASN1_INTEGER(a, &pp); 
+    wolfSSL_i2c_ASN1_INTEGER(a, &pp);
     pp--;
     AssertIntEQ(*pp, 128);
     XFREE(tpp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -19841,13 +19860,13 @@ static void test_wolfSSL_i2c_ASN1_INTEGER()
             DYNAMIC_TYPE_TMP_BUFFER));
     tpp = pp;
     XMEMSET(pp, 0, ret + 1);
-    wolfSSL_i2c_ASN1_INTEGER(a, &pp); 
+    wolfSSL_i2c_ASN1_INTEGER(a, &pp);
     pp--;
     AssertIntEQ(*(pp--), 56);
     AssertIntEQ(*pp, 255);
 
     XFREE(tpp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    wolfSSL_ASN1_INTEGER_free(a); 
+    wolfSSL_ASN1_INTEGER_free(a);
 
     printf(resultFmt, passed);
 #endif /* OPENSSL_EXTRA */
@@ -20176,6 +20195,7 @@ void ApiTest(void)
     AssertIntEQ(test_wc_ecc_mulmod(), 0);
     AssertIntEQ(test_wc_ecc_is_valid_idx(), 0);
 
+    test_wc_PKCS7_New();
     test_wc_PKCS7_Init();
     test_wc_PKCS7_InitWithCert();
     test_wc_PKCS7_EncodeData();
@@ -20183,7 +20203,7 @@ void ApiTest(void)
     test_wc_PKCS7_VerifySignedData();
     test_wc_PKCS7_EncodeDecodeEnvelopedData();
     test_wc_PKCS7_EncodeEncryptedData();
-     
+
     printf(" End API Tests\n");
 
 }

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -308,7 +308,7 @@ int wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* cert, word32 certSz)
         if (ret < 0) {
             FreeDecodedCert(dCert);
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(dCert, NULL, DYNAMIC_TYPE_DCERT);
+            XFREE(dCert, pkcs7->heap, DYNAMIC_TYPE_DCERT);
 #endif
             return ret;
         }
@@ -324,7 +324,7 @@ int wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* cert, word32 certSz)
         FreeDecodedCert(dCert);
 
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(dCert, NULL, DYNAMIC_TYPE_DCERT);
+        XFREE(dCert, pkcs7->heap, DYNAMIC_TYPE_DCERT);
 #endif
     }
 
@@ -613,7 +613,8 @@ static int wc_PKCS7_RsaSign(PKCS7* pkcs7, byte* in, word32 inSz, ESD* esd)
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    privKey = (RsaKey*)XMALLOC(sizeof(RsaKey), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    privKey = (RsaKey*)XMALLOC(sizeof(RsaKey), pkcs7->heap,
+        DYNAMIC_TYPE_TMP_BUFFER);
     if (privKey == NULL)
         return MEMORY_E;
 #endif
@@ -637,7 +638,7 @@ static int wc_PKCS7_RsaSign(PKCS7* pkcs7, byte* in, word32 inSz, ESD* esd)
 
     wc_FreeRsaKey(privKey);
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(privKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(privKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return ret;
@@ -665,7 +666,8 @@ static int wc_PKCS7_EcdsaSign(PKCS7* pkcs7, byte* in, word32 inSz, ESD* esd)
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    privKey = (ecc_key*)XMALLOC(sizeof(ecc_key), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    privKey = (ecc_key*)XMALLOC(sizeof(ecc_key), pkcs7->heap,
+        DYNAMIC_TYPE_TMP_BUFFER);
     if (privKey == NULL)
         return MEMORY_E;
 #endif
@@ -691,7 +693,7 @@ static int wc_PKCS7_EcdsaSign(PKCS7* pkcs7, byte* in, word32 inSz, ESD* esd)
 
     wc_ecc_free(privKey);
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(privKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(privKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return ret;
@@ -960,7 +962,8 @@ static int wc_PKCS7_SignedDataBuildSignature(PKCS7* pkcs7,
         return BAD_FUNC_ARG;
 
 #ifdef WOLFSSL_SMALL_STACK
-    digestInfo = (byte*)XMALLOC(digestInfoSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    digestInfo = (byte*)XMALLOC(digestInfoSz, pkcs7->heap,
+        DYNAMIC_TYPE_TMP_BUFFER);
     if (digestInfo == NULL) {
         return MEMORY_E;
     }
@@ -971,7 +974,7 @@ static int wc_PKCS7_SignedDataBuildSignature(PKCS7* pkcs7,
                                    &digestInfoSz);
     if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -992,7 +995,7 @@ static int wc_PKCS7_SignedDataBuildSignature(PKCS7* pkcs7,
             hashSz = wc_HashGetDigestSize(esd->hashType);
             if (hashSz < 0) {
             #ifdef WOLFSSL_SMALL_STACK
-                XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+                XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
             #endif
                 return hashSz;
             }
@@ -1008,7 +1011,7 @@ static int wc_PKCS7_SignedDataBuildSignature(PKCS7* pkcs7,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     if (ret >= 0) {
@@ -1062,7 +1065,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    esd = (ESD*)XMALLOC(sizeof(ESD), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    esd = (ESD*)XMALLOC(sizeof(ESD), pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (esd == NULL)
         return MEMORY_E;
 #endif
@@ -1073,7 +1076,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     ret = wc_HashGetDigestSize(esd->hashType);
     if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(esd, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(esd, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -1082,7 +1085,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     ret = wc_HashInit(&esd->hash, esd->hashType);
     if (ret != 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(esd, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(esd, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -1093,7 +1096,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
                             pkcs7->content, pkcs7->contentSz);
         if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(esd, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(esd, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
         }
@@ -1103,7 +1106,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
                            &esd->contentDigest[2]);
         if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(esd, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(esd, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
         }
@@ -1134,7 +1137,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
                                           &digEncAlgoType);
     if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(esd, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(esd, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -1151,7 +1154,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
                                     messageDigestOid, sizeof(messageDigestOid));
         if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(esd, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(esd, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
             return MEMORY_E;
         }
@@ -1161,7 +1164,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         flatSignedAttribsSz = esd->signedAttribsSz;
         if (flatSignedAttribs == NULL) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(esd, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(esd, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
             return MEMORY_E;
         }
@@ -1179,7 +1182,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         if (pkcs7->signedAttribsSz != 0)
             XFREE(flatSignedAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(esd, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(esd, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -1221,7 +1224,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         if (pkcs7->signedAttribsSz != 0)
             XFREE(flatSignedAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(esd, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(esd, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return BUFFER_E;
     }
@@ -1289,7 +1292,7 @@ int wc_PKCS7_EncodeSignedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     idx += esd->encContentDigestSz;
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(esd, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(esd, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return idx;
@@ -1318,15 +1321,15 @@ static int wc_PKCS7_RsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    digest = (byte*)XMALLOC(MAX_PKCS7_DIGEST_SZ, NULL,
+    digest = (byte*)XMALLOC(MAX_PKCS7_DIGEST_SZ, pkcs7->heap,
                             DYNAMIC_TYPE_TMP_BUFFER);
 
     if (digest == NULL)
         return MEMORY_E;
 
-    key = (RsaKey*)XMALLOC(sizeof(RsaKey), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    key = (RsaKey*)XMALLOC(sizeof(RsaKey), pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (key == NULL) {
-        XFREE(digest, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(digest, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
         return MEMORY_E;
     }
 #endif
@@ -1336,8 +1339,8 @@ static int wc_PKCS7_RsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
     ret = wc_InitRsaKey_ex(key, pkcs7->heap, pkcs7->devId);
     if (ret != 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(digest, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(key,    NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(digest, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(key,    pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -1347,8 +1350,8 @@ static int wc_PKCS7_RsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
         WOLFSSL_MSG("ASN RSA key decode error");
         wc_FreeRsaKey(key);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(digest, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(key,    NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(digest, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(key,    pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return PUBLIC_KEY_E;
     }
@@ -1362,8 +1365,8 @@ static int wc_PKCS7_RsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(digest, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(key,    NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(digest, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(key,    pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return ret;
@@ -1394,15 +1397,15 @@ static int wc_PKCS7_EcdsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
         return BAD_FUNC_ARG;
 
 #ifdef WOLFSSL_SMALL_STACK
-    digest = (byte*)XMALLOC(MAX_PKCS7_DIGEST_SZ, NULL,
+    digest = (byte*)XMALLOC(MAX_PKCS7_DIGEST_SZ, pkcs7->heap,
                             DYNAMIC_TYPE_TMP_BUFFER);
 
     if (digest == NULL)
         return MEMORY_E;
 
-    key = (ecc_key*)XMALLOC(sizeof(ecc_key), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    key = (ecc_key*)XMALLOC(sizeof(ecc_key), pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (key == NULL) {
-        XFREE(digest, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(digest, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
         return MEMORY_E;
     }
 #endif
@@ -1412,8 +1415,8 @@ static int wc_PKCS7_EcdsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
     ret = wc_ecc_init_ex(key, pkcs7->heap, pkcs7->devId);
     if (ret != 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(digest, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(key,    NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(digest, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(key,    pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -1423,8 +1426,8 @@ static int wc_PKCS7_EcdsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
         WOLFSSL_MSG("ASN ECDSA key decode error");
         wc_ecc_free(key);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(digest, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(key,    NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(digest, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(key,    pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return PUBLIC_KEY_E;
     }
@@ -1438,8 +1441,8 @@ static int wc_PKCS7_EcdsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(digest, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(key,    NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(digest, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(key,    pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return ret;
@@ -1488,7 +1491,8 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    digestInfo = (byte*)XMALLOC(MAX_PKCS7_DIGEST_SZ, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    digestInfo = (byte*)XMALLOC(MAX_PKCS7_DIGEST_SZ, pkcs7->heap,
+        DYNAMIC_TYPE_TMP_BUFFER);
     if (digestInfo == NULL)
         return MEMORY_E;
 #endif
@@ -1501,7 +1505,7 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
     ret = wc_HashGetDigestSize(hashType);
     if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -1511,7 +1515,7 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
     ret = wc_HashInit(&hash, hashType);
     if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -1520,7 +1524,7 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
 
         if (signedAttrib == NULL) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
             return BAD_FUNC_ARG;
         }
@@ -1529,7 +1533,7 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
         ret = wc_HashUpdate(&hash, hashType, attribSet, attribSetSz);
         if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
             return ret;
         }
@@ -1537,7 +1541,7 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
         ret = wc_HashUpdate(&hash, hashType, signedAttrib, signedAttribSz);
         if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
             return ret;
         }
@@ -1545,7 +1549,7 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
         ret = wc_HashFinal(&hash, hashType, digest);
         if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
             return ret;
         }
@@ -1554,7 +1558,7 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
 
         if (pkcs7->content == NULL) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
             return BAD_FUNC_ARG;
         }
@@ -1562,7 +1566,7 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
         ret = wc_HashUpdate(&hash, hashType, pkcs7->content, pkcs7->contentSz);
         if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
             return ret;
         }
@@ -1570,7 +1574,7 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
         ret = wc_HashFinal(&hash, hashType, digest);
         if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
             return ret;
         }
@@ -1600,7 +1604,7 @@ static int wc_PKCS7_BuildSignedDataDigest(PKCS7* pkcs7, byte* signedAttrib,
     *plainDigestSz = hashSz;
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(digestInfo, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(digestInfo, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
     return 0;
 }
@@ -1633,7 +1637,7 @@ static int wc_PKCS7_SignedDataVerifySignature(PKCS7* pkcs7, byte* sig,
         return BAD_FUNC_ARG;
 
 #ifdef WOLFSSL_SMALL_STACK
-    pkcs7Digest = (byte*)XMALLOC(MAX_PKCS7_DIGEST_SZ, NULL,
+    pkcs7Digest = (byte*)XMALLOC(MAX_PKCS7_DIGEST_SZ, pkcs7->heap,
                                  DYNAMIC_TYPE_TMP_BUFFER);
     if (pkcs7Digest == NULL)
         return MEMORY_E;
@@ -1647,7 +1651,7 @@ static int wc_PKCS7_SignedDataVerifySignature(PKCS7* pkcs7, byte* sig,
                                          &plainDigestSz);
     if (ret < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(pkcs7Digest, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(pkcs7Digest, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -1679,7 +1683,7 @@ static int wc_PKCS7_SignedDataVerifySignature(PKCS7* pkcs7, byte* sig,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-     XFREE(pkcs7Digest, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+     XFREE(pkcs7Digest, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
     return ret;
 }
@@ -2416,8 +2420,8 @@ static int wc_PKCS7_KariGenerateEphemeralKey(WC_PKCS7_KARI* kari, WC_RNG* rng)
         rng == NULL)
         return BAD_FUNC_ARG;
 
-    kari->senderKeyExport = (byte*)XMALLOC(kari->decoded->pubKeySize, kari->heap,
-                                           DYNAMIC_TYPE_PKCS7);
+    kari->senderKeyExport = (byte*)XMALLOC(kari->decoded->pubKeySize,
+                                           kari->heap, DYNAMIC_TYPE_PKCS7);
     if (kari->senderKeyExport == NULL)
         return MEMORY_E;
 
@@ -2927,15 +2931,15 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
     RsaKey* pubKey;
     DecodedCert* decoded;
 
-    serial = (byte*)XMALLOC(MAX_SN_SZ, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    keyAlgArray = (byte*)XMALLOC(MAX_SN_SZ, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    decoded = (DecodedCert*)XMALLOC(sizeof(DecodedCert), NULL,
+    serial = (byte*)XMALLOC(MAX_SN_SZ, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    keyAlgArray = (byte*)XMALLOC(MAX_SN_SZ, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    decoded = (DecodedCert*)XMALLOC(sizeof(DecodedCert), heap,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
 
     if (decoded == NULL || serial == NULL || keyAlgArray == NULL) {
-        if (serial)      XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        if (keyAlgArray) XFREE(keyAlgArray, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        if (decoded)     XFREE(decoded,     NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (serial)      XFREE(serial,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        if (keyAlgArray) XFREE(keyAlgArray, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        if (decoded)     XFREE(decoded,     heap, DYNAMIC_TYPE_TMP_BUFFER);
         return MEMORY_E;
     }
 
@@ -2954,9 +2958,9 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
     if (ret < 0) {
         FreeDecodedCert(decoded);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(keyAlgArray, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(decoded,     NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(keyAlgArray, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(decoded,     heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -2969,9 +2973,9 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
         WOLFSSL_MSG("DecodedCert lacks raw issuer pointer and length");
         FreeDecodedCert(decoded);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(keyAlgArray, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(decoded,     NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(keyAlgArray, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(decoded,     heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return -1;
     }
@@ -2982,9 +2986,9 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
         WOLFSSL_MSG("DecodedCert missing serial number");
         FreeDecodedCert(decoded);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(keyAlgArray, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(decoded,     NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(keyAlgArray, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(decoded,     heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return -1;
     }
@@ -2997,9 +3001,9 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
     if (keyEncAlgo != RSAk) {
         FreeDecodedCert(decoded);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(keyAlgArray, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(decoded,     NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(keyAlgArray, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(decoded,     heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ALGO_ID_E;
     }
@@ -3008,20 +3012,20 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
     if (keyEncAlgSz == 0) {
         FreeDecodedCert(decoded);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(keyAlgArray, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(decoded,     NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(keyAlgArray, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(decoded,     heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return BAD_FUNC_ARG;
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    pubKey = (RsaKey*)XMALLOC(sizeof(RsaKey), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    pubKey = (RsaKey*)XMALLOC(sizeof(RsaKey), heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (pubKey == NULL) {
         FreeDecodedCert(decoded);
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(keyAlgArray, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(decoded,     NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(keyAlgArray, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(decoded,     heap, DYNAMIC_TYPE_TMP_BUFFER);
         return MEMORY_E;
     }
 #endif
@@ -3031,10 +3035,10 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
     if (ret != 0) {
         FreeDecodedCert(decoded);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(pubKey,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(keyAlgArray, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(decoded,     NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(pubKey,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(keyAlgArray, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(decoded,     heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -3045,10 +3049,10 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
         wc_FreeRsaKey(pubKey);
         FreeDecodedCert(decoded);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(pubKey,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(keyAlgArray, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(decoded,     NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(pubKey,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(keyAlgArray, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(decoded,     heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return PUBLIC_KEY_E;
     }
@@ -3058,16 +3062,16 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
     wc_FreeRsaKey(pubKey);
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(pubKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(pubKey, heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     if (*keyEncSz < 0) {
         WOLFSSL_MSG("RSA Public Encrypt failed");
         FreeDecodedCert(decoded);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(keyAlgArray, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(decoded,     NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(keyAlgArray, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(decoded,     heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return *keyEncSz;
     }
@@ -3084,9 +3088,9 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
         WOLFSSL_MSG("RecipientInfo output buffer too small");
         FreeDecodedCert(decoded);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(keyAlgArray, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(decoded,     NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(keyAlgArray, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(decoded,     heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return BUFFER_E;
     }
@@ -3113,9 +3117,9 @@ static int wc_CreateRecipientInfo(const byte* cert, word32 certSz,
     FreeDecodedCert(decoded);
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(keyAlgArray, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(decoded,     NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(serial,      heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(keyAlgArray, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(decoded,     heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return totalSz;
@@ -3436,12 +3440,13 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    recip         = (byte*)XMALLOC(MAX_RECIP_SZ, NULL, DYNAMIC_TYPE_PKCS7);
-    contentKeyEnc = (byte*)XMALLOC(MAX_ENCRYPTED_KEY_SZ, NULL,
+    recip         = (byte*)XMALLOC(MAX_RECIP_SZ, pkcs7->heap,
+                                                       DYNAMIC_TYPE_PKCS7);
+    contentKeyEnc = (byte*)XMALLOC(MAX_ENCRYPTED_KEY_SZ, pkcs7->heap,
                                                        DYNAMIC_TYPE_PKCS7);
     if (contentKeyEnc == NULL || recip == NULL) {
-        if (recip)         XFREE(recip,         NULL, DYNAMIC_TYPE_PKCS7);
-        if (contentKeyEnc) XFREE(contentKeyEnc, NULL, DYNAMIC_TYPE_PKCS7);
+        if (recip)         XFREE(recip,         pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+        if (contentKeyEnc) XFREE(contentKeyEnc, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         wc_FreeRng(&rng);
         return MEMORY_E;
     }
@@ -3480,14 +3485,14 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     ForceZero(contentKeyEnc, MAX_ENCRYPTED_KEY_SZ);
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(contentKeyEnc, NULL, DYNAMIC_TYPE_PKCS7);
+    XFREE(contentKeyEnc, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
 
     if (recipSz < 0) {
         WOLFSSL_MSG("Failed to create RecipientInfo");
         wc_FreeRng(&rng);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return recipSz;
     }
@@ -3498,7 +3503,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     wc_FreeRng(&rng);
     if (ret != 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -3507,7 +3512,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     contentTypeSz = wc_SetContentType(pkcs7->contentOID, contentType);
     if (contentTypeSz == 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return BAD_FUNC_ARG;
     }
@@ -3536,7 +3541,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     if (encryptedContent == NULL) {
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return MEMORY_E;
     }
@@ -3553,7 +3558,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return BAD_FUNC_ARG;
     }
@@ -3567,7 +3572,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return ret;
     }
@@ -3603,7 +3608,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return BUFFER_E;
     }
@@ -3643,7 +3648,7 @@ int wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7, byte* output, word32 outputSz)
     XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(recip, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(recip, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return idx;
@@ -3692,15 +3697,15 @@ static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    serialNum = (mp_int*)XMALLOC(sizeof(mp_int), NULL,
-                                                   DYNAMIC_TYPE_TMP_BUFFER);
+    serialNum = (mp_int*)XMALLOC(sizeof(mp_int), pkcs7->heap,
+                                 DYNAMIC_TYPE_TMP_BUFFER);
     if (serialNum == NULL)
         return MEMORY_E;
 #endif
 
     if (GetInt(serialNum, pkiMsg, idx, pkiMsgSz) < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(serialNum,    NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serialNum, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ASN_PARSE_E;
     }
@@ -3708,7 +3713,7 @@ static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     mp_clear(serialNum);
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(serialNum, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(serialNum, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     if (GetAlgoId(pkiMsg, idx, &encOID, oidKeyType, pkiMsgSz) < 0)
@@ -3720,7 +3725,7 @@ static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
 
     /* read encryptedKey */
 #ifdef WOLFSSL_SMALL_STACK
-    encryptedKey = (byte*)XMALLOC(MAX_ENCRYPTED_KEY_SZ, NULL,
+    encryptedKey = (byte*)XMALLOC(MAX_ENCRYPTED_KEY_SZ, pkcs7->heap,
                                   DYNAMIC_TYPE_TMP_BUFFER);
     if (encryptedKey == NULL)
         return MEMORY_E;
@@ -3728,14 +3733,14 @@ static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
 
     if (pkiMsg[(*idx)++] != ASN_OCTET_STRING) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(encryptedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ASN_PARSE_E;
     }
 
     if (GetLength(pkiMsg, idx, &encryptedKeySz, pkiMsgSz) < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(encryptedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ASN_PARSE_E;
     }
@@ -3746,18 +3751,19 @@ static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
 
     /* load private key */
 #ifdef WOLFSSL_SMALL_STACK
-    privKey = (RsaKey*)XMALLOC(sizeof(RsaKey), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    privKey = (RsaKey*)XMALLOC(sizeof(RsaKey), pkcs7->heap,
+        DYNAMIC_TYPE_TMP_BUFFER);
     if (privKey == NULL) {
-        XFREE(encryptedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
         return MEMORY_E;
     }
 #endif
 
-    ret = wc_InitRsaKey_ex(privKey, NULL, INVALID_DEVID);
+    ret = wc_InitRsaKey_ex(privKey, pkcs7->heap, INVALID_DEVID);
     if (ret != 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(encryptedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(privKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(privKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -3774,8 +3780,8 @@ static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
         WOLFSSL_MSG("Failed to decode RSA private key");
         wc_FreeRsaKey(privKey);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(encryptedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(privKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(privKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -3801,8 +3807,8 @@ static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     if (keySz <= 0 || outKey == NULL) {
         ForceZero(encryptedKey, MAX_ENCRYPTED_KEY_SZ);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(encryptedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(privKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(privKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return keySz;
     } else {
@@ -3812,8 +3818,8 @@ static int wc_PKCS7_DecodeKtri(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(encryptedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(privKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(privKey, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return 0;
@@ -4041,23 +4047,23 @@ static int wc_PKCS7_KariGetIssuerAndSerialNumber(WC_PKCS7_KARI* kari,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    serial = (mp_int*)XMALLOC(sizeof(mp_int), NULL,
+    serial = (mp_int*)XMALLOC(sizeof(mp_int), kari->heap,
                               DYNAMIC_TYPE_TMP_BUFFER);
     if (serial == NULL)
         return MEMORY_E;
 
-    recipSerial = (mp_int*)XMALLOC(sizeof(mp_int), NULL,
+    recipSerial = (mp_int*)XMALLOC(sizeof(mp_int), kari->heap,
                                    DYNAMIC_TYPE_TMP_BUFFER);
     if (recipSerial == NULL) {
-        XFREE(serial, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial, kari->heap, DYNAMIC_TYPE_TMP_BUFFER);
         return MEMORY_E;
     }
 #endif
 
     if (GetInt(serial, pkiMsg, idx, pkiMsgSz) < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(recipSerial, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      kari->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(recipSerial, kari->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ASN_PARSE_E;
     }
@@ -4068,8 +4074,8 @@ static int wc_PKCS7_KariGetIssuerAndSerialNumber(WC_PKCS7_KARI* kari,
         mp_clear(serial);
         WOLFSSL_MSG("Failed to parse CMS recipient serial number");
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(recipSerial, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      kari->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(recipSerial, kari->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return ret;
     }
@@ -4079,8 +4085,8 @@ static int wc_PKCS7_KariGetIssuerAndSerialNumber(WC_PKCS7_KARI* kari,
         mp_clear(recipSerial);
         WOLFSSL_MSG("CMS serial number does not match recipient");
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(recipSerial, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(serial,      kari->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(recipSerial, kari->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
         return PKCS7_RECIP_E;
     }
@@ -4089,8 +4095,8 @@ static int wc_PKCS7_KariGetIssuerAndSerialNumber(WC_PKCS7_KARI* kari,
     mp_clear(recipSerial);
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(serial,      NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    XFREE(recipSerial, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(serial,      kari->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(recipSerial, kari->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return 0;
@@ -4189,7 +4195,7 @@ static int wc_PKCS7_DecodeKari(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
         return MEMORY_E;
 
 #ifdef WOLFSSL_SMALL_STACK
-    encryptedKey = (byte*)XMALLOC(MAX_ENCRYPTED_KEY_SZ, NULL,
+    encryptedKey = (byte*)XMALLOC(MAX_ENCRYPTED_KEY_SZ, pkcs7->heap,
                                   DYNAMIC_TYPE_PKCS7);
     if (encryptedKey == NULL) {
         wc_PKCS7_KariFree(kari);
@@ -4205,7 +4211,7 @@ static int wc_PKCS7_DecodeKari(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     if (ret != 0) {
         wc_PKCS7_KariFree(kari);
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(encryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+            XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         #endif
         return ret;
     }
@@ -4216,7 +4222,7 @@ static int wc_PKCS7_DecodeKari(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     if (ret != 0) {
         wc_PKCS7_KariFree(kari);
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(encryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+            XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         #endif
         return ret;
     }
@@ -4226,7 +4232,7 @@ static int wc_PKCS7_DecodeKari(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     if (ret != 0) {
         wc_PKCS7_KariFree(kari);
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(encryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+            XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         #endif
         return ret;
     }
@@ -4238,7 +4244,7 @@ static int wc_PKCS7_DecodeKari(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     if (ret != 0) {
         wc_PKCS7_KariFree(kari);
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(encryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+            XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         #endif
         return ret;
     }
@@ -4265,7 +4271,7 @@ static int wc_PKCS7_DecodeKari(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
         default:
             wc_PKCS7_KariFree(kari);
             #ifdef WOLFSSL_SMALL_STACK
-                XFREE(encryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+                XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
             #endif
             WOLFSSL_MSG("AES key wrap algorithm unsupported");
             return BAD_KEYWRAP_ALG_E;
@@ -4277,7 +4283,7 @@ static int wc_PKCS7_DecodeKari(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     if (ret != 0) {
         wc_PKCS7_KariFree(kari);
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(encryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+            XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         #endif
         return ret;
     }
@@ -4287,7 +4293,7 @@ static int wc_PKCS7_DecodeKari(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     if (ret != 0) {
         wc_PKCS7_KariFree(kari);
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(encryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+            XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         #endif
         return ret;
     }
@@ -4299,7 +4305,7 @@ static int wc_PKCS7_DecodeKari(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
     if (keySz <= 0) {
         wc_PKCS7_KariFree(kari);
         #ifdef WOLFSSL_SMALL_STACK
-            XFREE(encryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+            XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         #endif
         return keySz;
     }
@@ -4307,7 +4313,7 @@ static int wc_PKCS7_DecodeKari(PKCS7* pkcs7, byte* pkiMsg, word32 pkiMsgSz,
 
     wc_PKCS7_KariFree(kari);
     #ifdef WOLFSSL_SMALL_STACK
-        XFREE(encryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
     #endif
 
     return 0;
@@ -4504,7 +4510,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
         return ASN_PARSE_E;
 
 #ifdef WOLFSSL_SMALL_STACK
-    decryptedKey = (byte*)XMALLOC(MAX_ENCRYPTED_KEY_SZ, NULL,
+    decryptedKey = (byte*)XMALLOC(MAX_ENCRYPTED_KEY_SZ, pkcs7->heap,
                                                        DYNAMIC_TYPE_PKCS7);
     if (decryptedKey == NULL)
         return MEMORY_E;
@@ -4516,7 +4522,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
                                         &recipFound);
     if (ret != 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return ret;
     }
@@ -4524,7 +4530,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
     if (recipFound == 0) {
         WOLFSSL_MSG("No recipient found in envelopedData that matches input");
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return PKCS7_RECIP_E;
     }
@@ -4532,21 +4538,21 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
     /* remove EncryptedContentInfo */
     if (GetSequence(pkiMsg, &idx, &length, pkiMsgSz) < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return ASN_PARSE_E;
     }
 
     if (wc_GetContentType(pkiMsg, &idx, &contentType, pkiMsgSz) < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return ASN_PARSE_E;
     }
 
     if (GetAlgoId(pkiMsg, &idx, &encOID, oidBlkType, pkiMsgSz) < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return ASN_PARSE_E;
     }
@@ -4554,7 +4560,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
     blockKeySz = wc_PKCS7_GetOIDKeySize(encOID);
     if (blockKeySz < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return blockKeySz;
     }
@@ -4562,7 +4568,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
     expBlockSz = wc_PKCS7_GetOIDBlockSize(encOID);
     if (expBlockSz < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return expBlockSz;
     }
@@ -4570,14 +4576,14 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
     /* get block cipher IV, stored in OPTIONAL parameter of AlgoID */
     if (pkiMsg[idx++] != ASN_OCTET_STRING) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return ASN_PARSE_E;
     }
 
     if (GetLength(pkiMsg, &idx, &length, pkiMsgSz) < 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return ASN_PARSE_E;
     }
@@ -4585,7 +4591,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
     if (length != expBlockSz) {
         WOLFSSL_MSG("Incorrect IV length, must be of content alg block size");
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return ASN_PARSE_E;
     }
@@ -4599,7 +4605,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
     if (pkiMsg[idx] != (ASN_CONTEXT_SPECIFIC | 0) &&
         pkiMsg[idx] != (ASN_CONTEXT_SPECIFIC | ASN_CONSTRUCTED | 0)) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return ASN_PARSE_E;
     }
@@ -4607,7 +4613,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
 
     if (GetLength(pkiMsg, &idx, &encryptedContentSz, pkiMsgSz) <= 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return ASN_PARSE_E;
     }
@@ -4615,14 +4621,14 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
     if (explicitOctet) {
         if (pkiMsg[idx++] != ASN_OCTET_STRING) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+            XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
             return ASN_PARSE_E;
         }
 
         if (GetLength(pkiMsg, &idx, &encryptedContentSz, pkiMsgSz) <= 0) {
 #ifdef WOLFSSL_SMALL_STACK
-            XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+            XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
             return ASN_PARSE_E;
         }
@@ -4632,7 +4638,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
                                                        DYNAMIC_TYPE_PKCS7);
     if (encryptedContent == NULL) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return MEMORY_E;
     }
@@ -4646,7 +4652,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
     if (ret != 0) {
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+        XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
         return ret;
     }
@@ -4661,7 +4667,7 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
     ForceZero(encryptedContent, encryptedContentSz);
     XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(decryptedKey, NULL, DYNAMIC_TYPE_PKCS7);
+    XFREE(decryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 #endif
 
     return encryptedContentSz - padLen;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2834,7 +2834,7 @@ int hash_test(void)
     if (hashType != WC_HASH_TYPE_NONE)
         return -3071;
 #endif
-    
+
     ret = wc_HashGetOID(WC_HASH_TYPE_MD5_SHA);
 #ifndef NO_MD5
     if (ret == HASH_TYPE_E || ret == BAD_FUNC_ARG)
@@ -18050,7 +18050,7 @@ static int pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
 
     byte   enveloped[2048];
     byte   decoded[2048];
-    PKCS7  pkcs7;
+    PKCS7* pkcs7;
 #ifdef PKCS7_OUTPUT_TEST_BUNDLES
     FILE*  pkcs7File;
 #endif
@@ -18128,64 +18128,75 @@ static int pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
     testSz = sizeof(testVectors) / sizeof(pkcs7EnvelopedVector);
 
     for (i = 0; i < testSz; i++) {
-        ret = wc_PKCS7_Init(&pkcs7, HEAP_HINT,
+        pkcs7 = wc_PKCS7_New(HEAP_HINT,
         #ifdef WOLFSSL_ASYNC_CRYPT
             INVALID_DEVID /* async PKCS7 is not supported */
         #else
             devId
         #endif
         );
-        if (ret != 0)
+        if (pkcs7 == NULL)
             return -9214;
 
-        ret = wc_PKCS7_InitWithCert(&pkcs7, testVectors[i].cert,
+        ret = wc_PKCS7_InitWithCert(pkcs7, testVectors[i].cert,
                                     (word32)testVectors[i].certSz);
-        if (ret != 0)
+        if (ret != 0) {
+            wc_PKCS7_Free(pkcs7);
             return -9215;
+        }
 
-        pkcs7.content      = (byte*)testVectors[i].content;
-        pkcs7.contentSz    = testVectors[i].contentSz;
-        pkcs7.contentOID   = testVectors[i].contentOID;
-        pkcs7.encryptOID   = testVectors[i].encryptOID;
-        pkcs7.keyWrapOID   = testVectors[i].keyWrapOID;
-        pkcs7.keyAgreeOID  = testVectors[i].keyAgreeOID;
-        pkcs7.privateKey   = testVectors[i].privateKey;
-        pkcs7.privateKeySz = testVectors[i].privateKeySz;
-        pkcs7.ukm          = testVectors[i].optionalUkm;
-        pkcs7.ukmSz        = testVectors[i].optionalUkmSz;
+        pkcs7->content      = (byte*)testVectors[i].content;
+        pkcs7->contentSz    = testVectors[i].contentSz;
+        pkcs7->contentOID   = testVectors[i].contentOID;
+        pkcs7->encryptOID   = testVectors[i].encryptOID;
+        pkcs7->keyWrapOID   = testVectors[i].keyWrapOID;
+        pkcs7->keyAgreeOID  = testVectors[i].keyAgreeOID;
+        pkcs7->privateKey   = testVectors[i].privateKey;
+        pkcs7->privateKeySz = testVectors[i].privateKeySz;
+        pkcs7->ukm          = testVectors[i].optionalUkm;
+        pkcs7->ukmSz        = testVectors[i].optionalUkmSz;
 
         /* encode envelopedData */
-        envelopedSz = wc_PKCS7_EncodeEnvelopedData(&pkcs7, enveloped,
+        envelopedSz = wc_PKCS7_EncodeEnvelopedData(pkcs7, enveloped,
                                                    sizeof(enveloped));
         if (envelopedSz <= 0) {
             printf("DEBUG: i = %d, envelopedSz = %d\n", i, envelopedSz);
+            wc_PKCS7_Free(pkcs7);
             return -9216;
         }
 
         /* decode envelopedData */
-        decodedSz = wc_PKCS7_DecodeEnvelopedData(&pkcs7, enveloped, envelopedSz,
+        decodedSz = wc_PKCS7_DecodeEnvelopedData(pkcs7, enveloped, envelopedSz,
                                                  decoded, sizeof(decoded));
-        if (decodedSz <= 0)
+        if (decodedSz <= 0) {
+            wc_PKCS7_Free(pkcs7);
             return -9217;
+        }
 
         /* test decode result */
-        if (XMEMCMP(decoded, data, sizeof(data)) != 0)
+        if (XMEMCMP(decoded, data, sizeof(data)) != 0){
+            wc_PKCS7_Free(pkcs7);
             return -9218;
+        }
 
 #ifdef PKCS7_OUTPUT_TEST_BUNDLES
         /* output pkcs7 envelopedData for external testing */
         pkcs7File = fopen(testVectors[i].outFileName, "wb");
-        if (!pkcs7File)
+        if (!pkcs7File) {
+            wc_PKCS7_Free(pkcs7);
             return -9219;
+        }
 
         ret = (int)fwrite(enveloped, 1, envelopedSz, pkcs7File);
         fclose(pkcs7File);
         if (ret != envelopedSz) {
+            wc_PKCS7_Free(pkcs7);
             return -9220;
         }
 #endif /* PKCS7_OUTPUT_TEST_BUNDLES */
 
-        wc_PKCS7_Free(&pkcs7);
+        wc_PKCS7_Free(pkcs7);
+        pkcs7 = NULL;
     }
 
 #if !defined(HAVE_ECC) || defined(NO_AES)
@@ -18313,7 +18324,7 @@ int pkcs7encrypted_test(void)
     int ret = 0;
     int i, testSz;
     int encryptedSz, decodedSz, attribIdx;
-    PKCS7 pkcs7;
+    PKCS7* pkcs7;
     byte  encrypted[2048];
     byte  decoded[2048];
 #ifdef PKCS7_OUTPUT_TEST_BUNDLES
@@ -18437,55 +18448,65 @@ int pkcs7encrypted_test(void)
     testSz = sizeof(testVectors) / sizeof(pkcs7EncryptedVector);
 
     for (i = 0; i < testSz; i++) {
-        ret = wc_PKCS7_Init(&pkcs7, HEAP_HINT, devId);
-        if (ret != 0)
+        pkcs7 = wc_PKCS7_New(HEAP_HINT, devId);
+        if (pkcs7 == NULL)
             return -9400;
 
-        pkcs7.content              = (byte*)testVectors[i].content;
-        pkcs7.contentSz            = testVectors[i].contentSz;
-        pkcs7.contentOID           = testVectors[i].contentOID;
-        pkcs7.encryptOID           = testVectors[i].encryptOID;
-        pkcs7.encryptionKey        = testVectors[i].encryptionKey;
-        pkcs7.encryptionKeySz      = testVectors[i].encryptionKeySz;
-        pkcs7.unprotectedAttribs   = testVectors[i].attribs;
-        pkcs7.unprotectedAttribsSz = testVectors[i].attribsSz;
+        pkcs7->content              = (byte*)testVectors[i].content;
+        pkcs7->contentSz            = testVectors[i].contentSz;
+        pkcs7->contentOID           = testVectors[i].contentOID;
+        pkcs7->encryptOID           = testVectors[i].encryptOID;
+        pkcs7->encryptionKey        = testVectors[i].encryptionKey;
+        pkcs7->encryptionKeySz      = testVectors[i].encryptionKeySz;
+        pkcs7->unprotectedAttribs   = testVectors[i].attribs;
+        pkcs7->unprotectedAttribsSz = testVectors[i].attribsSz;
 
         /* encode encryptedData */
-        encryptedSz = wc_PKCS7_EncodeEncryptedData(&pkcs7, encrypted,
+        encryptedSz = wc_PKCS7_EncodeEncryptedData(pkcs7, encrypted,
                                                    sizeof(encrypted));
-        if (encryptedSz <= 0)
+        if (encryptedSz <= 0) {
+            wc_PKCS7_Free(pkcs7);
             return -9401;
+        }
 
         /* decode encryptedData */
-        decodedSz = wc_PKCS7_DecodeEncryptedData(&pkcs7, encrypted, encryptedSz,
+        decodedSz = wc_PKCS7_DecodeEncryptedData(pkcs7, encrypted, encryptedSz,
                                                  decoded, sizeof(decoded));
-        if (decodedSz <= 0)
+        if (decodedSz <= 0){
+            wc_PKCS7_Free(pkcs7);
             return -9402;
+        }
 
         /* test decode result */
-        if (XMEMCMP(decoded, data, sizeof(data)) != 0)
+        if (XMEMCMP(decoded, data, sizeof(data)) != 0) {
+            wc_PKCS7_Free(pkcs7);
             return -9403;
+        }
 
         /* verify decoded unprotected attributes */
-        if (pkcs7.decodedAttrib != NULL) {
-            decodedAttrib = pkcs7.decodedAttrib;
+        if (pkcs7->decodedAttrib != NULL) {
+            decodedAttrib = pkcs7->decodedAttrib;
             attribIdx = 1;
 
             while (decodedAttrib != NULL) {
 
                 /* expected attribute, stored list is reversed */
-                expectedAttrib = &(pkcs7.unprotectedAttribs
-                        [pkcs7.unprotectedAttribsSz - attribIdx]);
+                expectedAttrib = &(pkcs7->unprotectedAttribs
+                        [pkcs7->unprotectedAttribsSz - attribIdx]);
 
                 /* verify oid */
                 if (XMEMCMP(decodedAttrib->oid, expectedAttrib->oid,
-                            decodedAttrib->oidSz) != 0)
+                            decodedAttrib->oidSz) != 0) {
+                    wc_PKCS7_Free(pkcs7);
                     return -9404;
+                }
 
                 /* verify value */
                 if (XMEMCMP(decodedAttrib->value, expectedAttrib->value,
-                            decodedAttrib->valueSz) != 0)
+                            decodedAttrib->valueSz) != 0) {
+                    wc_PKCS7_Free(pkcs7);
                     return -9405;
+                }
 
                 decodedAttrib = decodedAttrib->next;
                 attribIdx++;
@@ -18495,8 +18516,10 @@ int pkcs7encrypted_test(void)
 #ifdef PKCS7_OUTPUT_TEST_BUNDLES
         /* output pkcs7 envelopedData for external testing */
         pkcs7File = fopen(testVectors[i].outFileName, "wb");
-        if (!pkcs7File)
+        if (!pkcs7File) {
+            wc_PKCS7_Free(pkcs7);
             return -9406;
+        }
 
         ret = (int)fwrite(encrypted, encryptedSz, 1, pkcs7File);
         fclose(pkcs7File);
@@ -18505,7 +18528,7 @@ int pkcs7encrypted_test(void)
             ret = 0;
 #endif
 
-        wc_PKCS7_Free(&pkcs7);
+        wc_PKCS7_Free(pkcs7);
     }
 
     return ret;
@@ -18539,7 +18562,7 @@ static int pkcs7signed_run_vectors(byte* rsaCert, word32 rsaCertSz,
     byte*  out;
     word32 outSz;
     WC_RNG rng;
-    PKCS7  pkcs7;
+    PKCS7* pkcs7;
 #ifdef PKCS7_OUTPUT_TEST_BUNDLES
     FILE*  file;
 #endif
@@ -18679,26 +18702,30 @@ static int pkcs7signed_run_vectors(byte* rsaCert, word32 rsaCertSz,
     }
 
     for (i = 0; i < testSz; i++) {
+        pkcs7 = wc_PKCS7_New(HEAP_HINT, INVALID_DEVID);
+        if (pkcs7 == NULL)
+            return -9410;
 
-        pkcs7.heap = HEAP_HINT;
-        pkcs7.devId = INVALID_DEVID;
-        ret = wc_PKCS7_InitWithCert(&pkcs7, testVectors[i].cert,
+        pkcs7->heap = HEAP_HINT;
+        pkcs7->devId = INVALID_DEVID;
+        ret = wc_PKCS7_InitWithCert(pkcs7, testVectors[i].cert,
                                     (word32)testVectors[i].certSz);
 
         if (ret != 0) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            wc_PKCS7_Free(pkcs7);
             return -9410;
         }
 
-        pkcs7.rng             = &rng;
-        pkcs7.content         = (byte*)testVectors[i].content;
-        pkcs7.contentSz       = testVectors[i].contentSz;
-        pkcs7.hashOID         = testVectors[i].hashOID;
-        pkcs7.encryptOID      = testVectors[i].encryptOID;
-        pkcs7.privateKey      = testVectors[i].privateKey;
-        pkcs7.privateKeySz    = testVectors[i].privateKeySz;
-        pkcs7.signedAttribs   = testVectors[i].signedAttribs;
-        pkcs7.signedAttribsSz = testVectors[i].signedAttribsSz;
+        pkcs7->rng             = &rng;
+        pkcs7->content         = (byte*)testVectors[i].content;
+        pkcs7->contentSz       = testVectors[i].contentSz;
+        pkcs7->hashOID         = testVectors[i].hashOID;
+        pkcs7->encryptOID      = testVectors[i].encryptOID;
+        pkcs7->privateKey      = testVectors[i].privateKey;
+        pkcs7->privateKeySz    = testVectors[i].privateKeySz;
+        pkcs7->signedAttribs   = testVectors[i].signedAttribs;
+        pkcs7->signedAttribsSz = testVectors[i].signedAttribsSz;
 
         /* generate senderNonce */
         {
@@ -18708,7 +18735,7 @@ static int pkcs7signed_run_vectors(byte* rsaCert, word32 rsaCertSz,
             ret = wc_RNG_GenerateBlock(&rng, &senderNonce[2], PKCS7_NONCE_SZ);
             if (ret != 0) {
                 XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-                wc_PKCS7_Free(&pkcs7);
+                wc_PKCS7_Free(pkcs7);
                 return -9411;
             }
         }
@@ -18731,20 +18758,20 @@ static int pkcs7signed_run_vectors(byte* rsaCert, word32 rsaCertSz,
             ret = wc_InitSha_ex(&sha, HEAP_HINT, devId);
             if (ret != 0) {
                 XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-                wc_PKCS7_Free(&pkcs7);
+                wc_PKCS7_Free(pkcs7);
                 return -9412;
             }
-            wc_ShaUpdate(&sha, pkcs7.publicKey, pkcs7.publicKeySz);
+            wc_ShaUpdate(&sha, pkcs7->publicKey, pkcs7->publicKeySz);
             wc_ShaFinal(&sha, digest);
             wc_ShaFree(&sha);
         #else
             ret = wc_InitSha256_ex(&sha, HEAP_HINT, devId);
             if (ret != 0) {
                 XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-                wc_PKCS7_Free(&pkcs7);
+                wc_PKCS7_Free(pkcs7);
                 return -9413;
             }
-            wc_Sha256Update(&sha, pkcs7.publicKey, pkcs7.publicKeySz);
+            wc_Sha256Update(&sha, pkcs7->publicKey, pkcs7->publicKeySz);
             wc_Sha256Final(&sha, digest);
             wc_Sha256Free(&sha);
         #endif
@@ -18754,10 +18781,10 @@ static int pkcs7signed_run_vectors(byte* rsaCert, word32 rsaCertSz,
             }
         }
 
-        encodedSz = wc_PKCS7_EncodeSignedData(&pkcs7, out, outSz);
+        encodedSz = wc_PKCS7_EncodeSignedData(pkcs7, out, outSz);
         if (encodedSz < 0) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-            wc_PKCS7_Free(&pkcs7);
+            wc_PKCS7_Free(pkcs7);
             return -9414;
         }
 
@@ -18766,34 +18793,37 @@ static int pkcs7signed_run_vectors(byte* rsaCert, word32 rsaCertSz,
         file = fopen(testVectors[i].outFileName, "wb");
         if (!file) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-            wc_PKCS7_Free(&pkcs7);
+            wc_PKCS7_Free(pkcs7);
             return -9415;
         }
         ret = (int)fwrite(out, 1, encodedSz, file);
         fclose(file);
         if (ret != (int)encodedSz) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-            wc_PKCS7_Free(&pkcs7);
+            wc_PKCS7_Free(pkcs7);
             return -9416;
         }
     #endif /* PKCS7_OUTPUT_TEST_BUNDLES */
 
-        wc_PKCS7_Free(&pkcs7);
-        wc_PKCS7_InitWithCert(&pkcs7, NULL, 0);
+        wc_PKCS7_Free(pkcs7);
 
-        ret = wc_PKCS7_VerifySignedData(&pkcs7, out, outSz);
+        pkcs7 = wc_PKCS7_New(HEAP_HINT, INVALID_DEVID);
+        if (pkcs7 == NULL)
+            return -9410;
+        wc_PKCS7_InitWithCert(pkcs7, NULL, 0);
+
+        ret = wc_PKCS7_VerifySignedData(pkcs7, out, outSz);
         if (ret < 0) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-            wc_PKCS7_Free(&pkcs7);
+            wc_PKCS7_Free(pkcs7);
             return -9417;
         }
 
-        if (pkcs7.singleCert == NULL || pkcs7.singleCertSz == 0) {
+        if (pkcs7->singleCert == NULL || pkcs7->singleCertSz == 0) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-            wc_PKCS7_Free(&pkcs7);
+            wc_PKCS7_Free(pkcs7);
             return -9418;
         }
-
 
         {
             /* check getting signed attributes */
@@ -18807,25 +18837,25 @@ static int pkcs7signed_run_vectors(byte* rsaCert, word32 rsaCertSz,
             int bufSz = 0;
 
             if (testVectors[i].signedAttribs != NULL &&
-                    wc_PKCS7_GetAttributeValue(&pkcs7, oidPt, oidSz,
+                    wc_PKCS7_GetAttributeValue(pkcs7, oidPt, oidSz,
                     NULL, (word32*)&bufSz) != LENGTH_ONLY_E) {
                 XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-                wc_PKCS7_Free(&pkcs7);
+                wc_PKCS7_Free(pkcs7);
                 return -9419;
             }
 
             if (bufSz > (int)sizeof(buf)) {
                 XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-                wc_PKCS7_Free(&pkcs7);
+                wc_PKCS7_Free(pkcs7);
                 return -9420;
             }
 
-            bufSz = wc_PKCS7_GetAttributeValue(&pkcs7, oidPt, oidSz,
+            bufSz = wc_PKCS7_GetAttributeValue(pkcs7, oidPt, oidSz,
                     buf, (word32*)&bufSz);
             if ((testVectors[i].signedAttribs != NULL && bufSz < 0) ||
                 (testVectors[i].signedAttribs == NULL && bufSz > 0)) {
                 XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-                wc_PKCS7_Free(&pkcs7);
+                wc_PKCS7_Free(pkcs7);
                 return -9421;
             }
         }
@@ -18834,14 +18864,14 @@ static int pkcs7signed_run_vectors(byte* rsaCert, word32 rsaCertSz,
         file = fopen("./pkcs7cert.der", "wb");
         if (!file) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-            wc_PKCS7_Free(&pkcs7);
+            wc_PKCS7_Free(pkcs7);
             return -9422;
         }
-        ret = (int)fwrite(pkcs7.singleCert, 1, pkcs7.singleCertSz, file);
+        ret = (int)fwrite(pkcs7->singleCert, 1, pkcs7->singleCertSz, file);
         fclose(file);
     #endif /* PKCS7_OUTPUT_TEST_BUNDLES */
 
-        wc_PKCS7_Free(&pkcs7);
+        wc_PKCS7_Free(pkcs7);
     }
 
     XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -95,10 +95,13 @@ typedef struct PKCS7DecodedAttrib {
 } PKCS7DecodedAttrib;
 
 
+/* Public Structure Warning:
+ * Existing members must not be changed to maintain backwards compatibility! 
+ */
 typedef struct PKCS7 {
     WC_RNG* rng;
     PKCS7Attrib* signedAttribs;
-    byte* content;                /* inner content, not owner             */
+    byte*  content;               /* inner content, not owner             */
     byte*  singleCert;            /* recipient cert, DER, not owner       */
     byte*  issuer;                /* issuer name of singleCert            */
     byte*  privateKey;            /* private key, DER, not owner          */
@@ -136,11 +139,17 @@ typedef struct PKCS7 {
     int devId;                    /* device ID for HW based private key   */
     byte issuerHash[KEYID_SIZE];  /* hash of all alt Names                */
     byte issuerSn[MAX_SN_SZ];     /* singleCert's serial number           */
-    byte publicKey[MAX_RSA_INT_SZ + MAX_RSA_E_SZ ];/*MAX RSA key size (m + e)*/
+    byte publicKey[MAX_RSA_INT_SZ + MAX_RSA_E_SZ]; /* MAX RSA key size (m + e)*/
     word32 certSz[MAX_PKCS7_CERTS];
+    
+     /* flags - up to 32-bits */
+    word16 isDynamic:1;
+
+    /* !! NEW DATA MEMBERS MUST BE ADDED AT END !! */
 } PKCS7;
 
 
+WOLFSSL_API PKCS7* wc_PKCS7_New(void* heap, int devId);
 WOLFSSL_API int  wc_PKCS7_Init(PKCS7* pkcs7, void* heap, int devId);
 WOLFSSL_API int  wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* cert, word32 certSz);
 WOLFSSL_API void wc_PKCS7_Free(PKCS7* pkcs7);

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -142,7 +142,7 @@ typedef struct PKCS7 {
     byte publicKey[MAX_RSA_INT_SZ + MAX_RSA_E_SZ]; /* MAX RSA key size (m + e)*/
     word32 certSz[MAX_PKCS7_CERTS];
     
-     /* flags - up to 32-bits */
+     /* flags - up to 16-bits */
     word16 isDynamic:1;
 
     /* !! NEW DATA MEMBERS MUST BE ADDED AT END !! */


### PR DESCRIPTION
* Added support for dynamic allocation of PKCS7 structure using `wc_PKCS7_New` and `wc_PKCS7_Free`.
* Updated the test examples to use the dynamic method.
* Add API unit test for `wc_PKCS7_New`.
* Updated all PKCS7 XMALLOC/XFREE to use heap pointer (even small stack).

Note: The first commit https://github.com/wolfSSL/wolfssl/commit/07401d909c6c30ae3843304e00e723d21963efd2 shows the primary change for allowing dynamic allocation.