### PR TITLE
Contiki port

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1410,7 +1410,7 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
                 #error Micrium port does not support DTLS session export yet
             #endif
         #endif
-    #elif defined UIP
+    #elif defined WOLFSSL_UIP
         ctx->CBIORecv = uIPReceive;
         ctx->CBIOSend = uIPSend;
         #ifdef WOLFSSL_DTLS

--- a/src/internal.c
+++ b/src/internal.c
@@ -1410,6 +1410,15 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
                 #error Micrium port does not support DTLS session export yet
             #endif
         #endif
+    #elif defined UIP
+        ctx->CBIORecv = uIPReceive;
+        ctx->CBIOSend = uIPSend;
+        #ifdef WOLFSSL_DTLS
+        if (method->version.major == DTLS_MAJOR) {
+            ctx->CBIOSendTo = uIPSendTo;
+            ctx->CBIORecvFrom = uIPRecvFrom;
+        }
+        #endif
     #else
         ctx->CBIORecv = EmbedReceive;
         ctx->CBIOSend = EmbedSend;

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -2068,7 +2068,7 @@ void wolfSSL_SetIO_Mynewt(WOLFSSL* ssl, struct mn_socket* mnSocket, struct mn_so
 
 #endif /* defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP) */
 
-#ifdef UIP
+#ifdef WOLFSSL_UIP
 #include <uip.h>
 
 #define SOCKLEN_UIP sizeof(struct sockaddr_uip)
@@ -2112,7 +2112,7 @@ int uIPReceive(WOLFSSL *ssl, char *buf, int sz, void *_ctx)
     if (ctx->ssl_rb_len > 0) {
         if (sz > ctx->ssl_rb_len - ctx->ssl_rb_off)
             sz = ctx->ssl_rb_len - ctx->ssl_rb_off;
-        memcpy(buf, ctx->ssl_recv_buffer + ctx->ssl_rb_off, sz);
+        XMEMCPY(buf, ctx->ssl_recv_buffer + ctx->ssl_rb_off, sz);
         ctx->ssl_rb_off += sz;
         if (ctx->ssl_rb_off >= ctx->ssl_rb_len) {
             ctx->ssl_rb_len = 0;
@@ -2145,6 +2145,6 @@ int uIPGenerateCookie(WOLFSSL* ssl, byte *buf, int sz, void *_ctx)
     return sz;
 }
 
-#endif /* UIP */
+#endif /* WOLFSSL_UIP */
 
 #endif /* WOLFCRYPT_ONLY */

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1938,7 +1938,8 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
       defined(WOLFSSL_uITRON4)  || defined(WOLFSSL_uTKERNEL2) || \
       defined(WOLFSSL_LPC43xx)  || defined(WOLFSSL_STM32F2xx) || \
       defined(MBED)             || defined(WOLFSSL_EMBOS) || \
-      defined(WOLFSSL_GENSEED_FORTEST) || defined(WOLFSSL_CHIBIOS)
+      defined(WOLFSSL_GENSEED_FORTEST) || defined(WOLFSSL_CHIBIOS) || \
+      defined(WOLFSSL_CONTIKI)
 
     /* these platforms do not have a default random seed and
        you'll need to implement your own wc_GenerateSeed or define via
@@ -2038,6 +2039,5 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 #endif
 
 /* End wc_GenerateSeed */
-
 #endif /* WC_NO_RNG */
 #endif /* HAVE_FIPS */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1669,7 +1669,7 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL*, void* key, unsigned int len,
         #elif !defined(WOLFSSL_MDK_ARM) && !defined(WOLFSSL_IAR_ARM) && \
               !defined(WOLFSSL_PICOTCP) && !defined(WOLFSSL_ROWLEY_ARM) && \
               !defined(WOLFSSL_EMBOS) && !defined(WOLFSSL_FROSTED) && \
-              !defined(WOLFSSL_CHIBIOS)
+              !defined(WOLFSSL_CHIBIOS) && !defined(WOLFSSL_CONTIKI)
             #include <sys/uio.h>
         #endif
         /* allow writev style writing */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -224,6 +224,13 @@
     #define NO_FILESYSTEM
 #endif
 
+#if defined(WOLFSSL_CONTIKI)
+    #define NO_WRITEV
+    #define SINGLE_THREADED
+    #define WOLFSSL_USER_IO
+    #define NO_FILESYSTEM
+#endif
+
 #if defined(WOLFSSL_IAR_ARM) || defined(WOLFSSL_ROWLEY_ARM)
     #define NO_MAIN_DRIVER
     #define SINGLE_THREADED

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -537,9 +537,6 @@
         #define NO_SESSION_CACHE
 #endif
 
-#ifdef WOLFSSL_CONTIKI
-#endif
-
 /* Micrium will use Visual Studio for compilation but not the Win32 API */
 #if defined(_WIN32) && !defined(MICRIUM) && !defined(FREERTOS) && \
     !defined(FREERTOS_TCP) && !defined(EBSNET) && !defined(WOLFSSL_EROAD) && \

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -225,10 +225,18 @@
 #endif
 
 #if defined(WOLFSSL_CONTIKI)
+    #include <contiki.h>
+    #define UIP
     #define NO_WRITEV
     #define SINGLE_THREADED
     #define WOLFSSL_USER_IO
     #define NO_FILESYSTEM
+    #define CUSTOM_RAND_TYPE uint16_t
+    #define CUSTOM_RAND_GENERATE random_rand
+    static inline unsigned int LowResTimer(void)
+    {
+        return clock_seconds();
+    }
 
     static inline void* XREALLOC(void *p, size_t n, void* heap, int type)
     {

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -229,6 +229,27 @@
     #define SINGLE_THREADED
     #define WOLFSSL_USER_IO
     #define NO_FILESYSTEM
+
+    static inline void* XREALLOC(void *p, size_t n, void* heap, int type)
+    {
+        (void)heap;
+        (void)type;
+        return realloc(p,n);
+    }
+
+    static inline void *XMALLOC(size_t n, void* heap, int type)
+    {
+        (void)heap;
+        (void)type;
+        return malloc(n);
+    }
+
+    static inline void XFREE(void *p, void* heap, int type)
+    {
+        (void)heap;
+        (void)type;
+        free(p);
+    }
 #endif
 
 #if defined(WOLFSSL_IAR_ARM) || defined(WOLFSSL_ROWLEY_ARM)
@@ -514,6 +535,9 @@
         #define WOLFSSL_NRF51
         #define WOLFSSL_USER_IO
         #define NO_SESSION_CACHE
+#endif
+
+#ifdef WOLFSSL_CONTIKI
 #endif
 
 /* Micrium will use Visual Studio for compilation but not the Win32 API */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -226,7 +226,8 @@
 
 #if defined(WOLFSSL_CONTIKI)
     #include <contiki.h>
-    #define UIP
+    #define WOLFSSL_UIP
+    #define NO_WOLFSSL_MEMORY
     #define NO_WRITEV
     #define SINGLE_THREADED
     #define WOLFSSL_USER_IO
@@ -236,27 +237,6 @@
     static inline unsigned int LowResTimer(void)
     {
         return clock_seconds();
-    }
-
-    static inline void* XREALLOC(void *p, size_t n, void* heap, int type)
-    {
-        (void)heap;
-        (void)type;
-        return realloc(p,n);
-    }
-
-    static inline void *XMALLOC(size_t n, void* heap, int type)
-    {
-        (void)heap;
-        (void)type;
-        return malloc(n);
-    }
-
-    static inline void XFREE(void *p, void* heap, int type)
-    {
-        (void)heap;
-        (void)type;
-        free(p);
     }
 #endif
 

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -423,6 +423,40 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
                                           struct mn_sockaddr_in* mnSockAddrIn);
 #endif /* defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP) */
 
+#ifdef UIP
+#define SSL_DATABUF_LEN 1460
+
+struct uip_wolfssl_ctx {
+    union socket_connector {
+        struct tcp_socket tcp;
+        struct udp_socket udp;
+    } conn;
+    WOLFSSL_CTX *ctx;
+    WOLFSSL *ssl;
+    uint8_t input_databuf[SSL_DATABUF_LEN];
+    uint8_t output_databuf[SSL_DATABUF_LEN];
+    uint8_t ssl_recv_buffer[SSL_DATABUF_LEN];
+    int ssl_rb_len;
+    int ssl_rb_off;
+    struct process *process;
+    tcp_socket_data_callback_t input_callback;
+    tcp_socket_event_callback_t event_callback;
+    int closing;
+    uip_ipaddr_t peer_addr;
+    uint16_t peer_port;
+};
+
+typedef struct uip_wolfssl_ctx uip_wolfssl_ctx;
+
+    WOLFSSL_LOCAL int uIPSend(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+    WOLFSSL_LOCAL int uIPReceive(WOLFSSL* ssl, char* buf, int sz,
+                                     void* ctx);
+    WOLFSSL_LOCAL int uIPReceiveFrom(WOLFSSL* ssl, char* buf, int sz,
+                                         void* ctx);
+    WOLFSSL_LOCAL int uIPSendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+
+#endif
+
 #ifdef WOLFSSL_DTLS
     typedef int (*CallbackGenCookie)(WOLFSSL* ssl, unsigned char* buf, int sz,
                                      void* ctx);

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -423,7 +423,7 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
                                           struct mn_sockaddr_in* mnSockAddrIn);
 #endif /* defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP) */
 
-#ifdef UIP
+#ifdef WOLFSSL_UIP
 #define SSL_DATABUF_LEN 1460
 
 struct uip_wolfssl_ctx {

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -39,7 +39,7 @@
 
 #if !defined(WOLFSSL_USER_IO)
     /* Micrium uses NetSock I/O callbacks in wolfio.c */
-    #if !defined(USE_WOLFSSL_IO) && !defined(MICRIUM) && !defined(CONTIKI)
+    #if !defined(USE_WOLFSSL_IO) && !defined(MICRIUM) && !defined(WOLFSSL_CONTIKI)
         #define USE_WOLFSSL_IO
     #endif
 #endif

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -39,7 +39,7 @@
 
 #if !defined(WOLFSSL_USER_IO)
     /* Micrium uses NetSock I/O callbacks in wolfio.c */
-    #if !defined(USE_WOLFSSL_IO) && !defined(MICRIUM)
+    #if !defined(USE_WOLFSSL_IO) && !defined(MICRIUM) && !defined(CONTIKI)
         #define USE_WOLFSSL_IO
     #endif
 #endif
@@ -122,7 +122,7 @@
         #elif defined(EBSNET)
             #include "rtipapi.h"  /* errno */
             #include "socket.h"
-        #elif !defined(DEVKITPRO) && !defined(WOLFSSL_PICOTCP)
+        #elif !defined(DEVKITPRO) && !defined(WOLFSSL_PICOTCP) && !defined(WOLFSSL_CONTIKI)
             #include <sys/socket.h>
             #include <arpa/inet.h>
             #include <netinet/in.h>

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -424,29 +424,28 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
 #endif /* defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP) */
 
 #ifdef WOLFSSL_UIP
-#define SSL_DATABUF_LEN 1460
 
-struct uip_wolfssl_ctx {
-    union socket_connector {
-        struct tcp_socket tcp;
-        struct udp_socket udp;
-    } conn;
-    WOLFSSL_CTX *ctx;
-    WOLFSSL *ssl;
-    uint8_t input_databuf[SSL_DATABUF_LEN];
-    uint8_t output_databuf[SSL_DATABUF_LEN];
-    uint8_t ssl_recv_buffer[SSL_DATABUF_LEN];
-    int ssl_rb_len;
-    int ssl_rb_off;
-    struct process *process;
-    tcp_socket_data_callback_t input_callback;
-    tcp_socket_event_callback_t event_callback;
-    int closing;
-    uip_ipaddr_t peer_addr;
-    uint16_t peer_port;
-};
+    struct uip_wolfssl_ctx {
+        union socket_connector {
+            struct tcp_socket tcp;
+            struct udp_socket udp;
+        } conn;
+        WOLFSSL_CTX *ctx;
+        WOLFSSL *ssl;
+        uint8_t *input_databuf;
+        uint8_t *output_databuf;
+        uint8_t *ssl_rx_databuf;
+        int ssl_rb_len;
+        int ssl_rb_off;
+        struct process *process;
+        tcp_socket_data_callback_t input_callback;
+        tcp_socket_event_callback_t event_callback;
+        int closing;
+        uip_ipaddr_t peer_addr;
+        uint16_t peer_port;
+    };
 
-typedef struct uip_wolfssl_ctx uip_wolfssl_ctx;
+    typedef struct uip_wolfssl_ctx uip_wolfssl_ctx;
 
     WOLFSSL_LOCAL int uIPSend(WOLFSSL* ssl, char* buf, int sz, void* ctx);
     WOLFSSL_LOCAL int uIPReceive(WOLFSSL* ssl, char* buf, int sz,


### PR DESCRIPTION
Simple compile-time flag to enable support for CONTIKI.

Memory-related inline functions instead of macros to avoid the warnings about unused variables when compiling with -Wall and -Werror from within contiki.

Separate glue layer required within contiki due to the nature of uip sockets (and a different API to access TCP/UDP).  See current work in progress compatibility layer  at https://github.com/danielinux/contiki/blob/wolfssl/apps/ssl/wolfssl.c