### PR TITLE
adjust macro guards for additional functions

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -299,24 +299,6 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 }
 
 
-/* set the heap hint for aes struct */
-int wc_AesInit(Aes* aes, void* heap, int devId)
-{
-    if (aes == NULL)
-        return BAD_FUNC_ARG;
-
-    aes->heap = heap;
-    (void)devId;
-
-    return 0;
-}
-
-void wc_AesFree(Aes* aes)
-{
-    (void)aes;
-}
-
-
 #ifdef __aarch64__
 /* AES CCM/GCM use encrypt direct but not decrypt */
 #if defined(HAVE_AESCCM) || defined(HAVE_AESGCM) || \
@@ -4364,18 +4346,6 @@ int  wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 /* Software version of AES-CCM from wolfcrypt/src/aes.c
  * Gets some speed up from hardware acceleration of wc_AesEncrypt */
 
-int wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz)
-{
-    byte nonce[AES_BLOCK_SIZE];
-
-    if (!((keySz == 16) || (keySz == 24) || (keySz == 32)))
-        return BAD_FUNC_ARG;
-
-    XMEMSET(nonce, 0, sizeof(nonce));
-    return wc_AesSetKey(aes, key, keySz, nonce, AES_ENCRYPTION);
-}
-
-
 static void roll_x(Aes* aes, const byte* in, word32 inSz, byte* out)
 {
     /* process the bulk of the data */
@@ -4611,20 +4581,6 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
 
 
 #ifdef HAVE_AESGCM /* common GCM functions 32 and 64 bit */
-WOLFSSL_API int wc_GmacSetKey(Gmac* gmac, const byte* key, word32 len)
-{
-    return wc_AesGcmSetKey(&gmac->aes, key, len);
-}
-
-
-WOLFSSL_API int wc_GmacUpdate(Gmac* gmac, const byte* iv, word32 ivSz,
-                              const byte* authIn, word32 authInSz,
-                              byte* authTag, word32 authTagSz)
-{
-    return wc_AesGcmEncrypt(&gmac->aes, NULL, NULL, 0, iv, ivSz,
-                                         authTag, authTagSz, authIn, authInSz);
-}
-
 int wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len)
 {
     int  ret;
@@ -4694,32 +4650,5 @@ int wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len)
         }
     #endif /* HAVE_AES_DECRYPT */
 #endif /* WOLFSSL_AES_DIRECT */
-
-int wc_AesGetKeySize(Aes* aes, word32* keySize)
-{
-    int ret = 0;
-
-    if (aes == NULL || keySize == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    switch (aes->rounds) {
-    case 10:
-        *keySize = 16;
-        break;
-    case 12:
-        *keySize = 24;
-        break;
-    case 14:
-        *keySize = 32;
-        break;
-    default:
-        *keySize = 0;
-        ret = BAD_FUNC_ARG;
-    }
-
-    return ret;
-}
-
 #endif /* NO_AES */
 


### PR DESCRIPTION
fix for build with ARMv8 assembly

the issue can be reproduced with
```
./configure --enable-armasm --enable-aesgcm --enable-aesccm --host=arm-linux-gnueabihf && make
```