### PR TITLE
fixes for MQX classic 4.0 with IAR-EWARM

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -12145,7 +12145,7 @@ int TimingPadVerify(WOLFSSL* ssl, const byte* input, int padLen, int macSz,
     good |= MaskMac(input, pLen, ssl->specs.hash_size, verify);
 
     /* Non-zero on failure. */
-    good = ~(word32)good;
+    good = (byte)~(word32)good;
     good &= good >> 4;
     good &= good >> 2;
     good &= good >> 1;

--- a/src/internal.c
+++ b/src/internal.c
@@ -12145,7 +12145,7 @@ int TimingPadVerify(WOLFSSL* ssl, const byte* input, int padLen, int macSz,
     good |= MaskMac(input, pLen, ssl->specs.hash_size, verify);
 
     /* Non-zero on failure. */
-    good = ~good;
+    good = ~(word32)good;
     good &= good >> 4;
     good &= good >> 2;
     good &= good >> 1;

--- a/src/tls.c
+++ b/src/tls.c
@@ -1129,8 +1129,8 @@ static int Hmac_UpdateFinal_CT(Hmac* hmac, byte* digest, const byte* in,
                 b = in[k - WOLFSSL_TLS_HMAC_INNER_SZ];
 
             b = ctMaskSel(atEoc, b, 0x80);
-            b &= ~(word32)pastEoc;
-            b &= ~(word32)isOutBlock | isEocBlock;
+            b &= (unsigned char)~(word32)pastEoc;
+            b &= ((unsigned char)~(word32)isOutBlock) | isEocBlock;
 
             if (j >= blockSz - 8) {
                 b = ctMaskSel(isOutBlock, b, lenBytes[j - (blockSz - 8)]);

--- a/src/tls.c
+++ b/src/tls.c
@@ -1129,8 +1129,8 @@ static int Hmac_UpdateFinal_CT(Hmac* hmac, byte* digest, const byte* in,
                 b = in[k - WOLFSSL_TLS_HMAC_INNER_SZ];
 
             b = ctMaskSel(atEoc, b, 0x80);
-            b &= ~pastEoc;
-            b &= ~isOutBlock | isEocBlock;
+            b &= ~(word32)pastEoc;
+            b &= ~(word32)isOutBlock | isEocBlock;
 
             if (j >= blockSz - 8) {
                 b = ctMaskSel(isOutBlock, b, lenBytes[j - (blockSz - 8)]);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8660,7 +8660,7 @@ int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen)
 int wc_InitCert(Cert* cert)
 {
 #ifdef WOLFSSL_MULTI_ATTRIB
-    int i;
+    int i = 0;
 #endif
     if (cert == NULL) {
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1353,7 +1353,7 @@ static int wc_ecc_curve_load(const ecc_set_type* dp, ecc_curve_spec** pCurve,
     curve->dp = dp; /* set dp info */
 
     /* determine items to load */
-    load_items = (~curve->load_mask & load_mask);
+    load_items = (~(word32)curve->load_mask & load_mask);
     curve->load_mask |= load_items;
 
     /* load items */

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1353,7 +1353,7 @@ static int wc_ecc_curve_load(const ecc_set_type* dp, ecc_curve_spec** pCurve,
     curve->dp = dp; /* set dp info */
 
     /* determine items to load */
-    load_items = (~(word32)curve->load_mask & load_mask);
+    load_items = (((byte)~(word32)curve->load_mask) & load_mask);
     curve->load_mask |= load_items;
 
     /* load items */

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -344,7 +344,7 @@ STATIC WC_INLINE byte ctMaskEq(int a, int b)
 /* Constant time - select b when mask is set and a otherwise. */
 STATIC WC_INLINE byte ctMaskSel(byte m, byte a, byte b)
 {
-    return (a & ~m) | (b & m);
+    return (a & ~(word32)m) | (b & m);
 }
 
 /* Constant time - bit set when a <= b. */

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -344,7 +344,7 @@ STATIC WC_INLINE byte ctMaskEq(int a, int b)
 /* Constant time - select b when mask is set and a otherwise. */
 STATIC WC_INLINE byte ctMaskSel(byte m, byte a, byte b)
 {
-    return (a & ~(word32)m) | (b & m);
+    return (a & ((byte)~(word32)m)) | (b & m);
 }
 
 /* Constant time - bit set when a <= b. */

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1423,7 +1423,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
          */
         int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         {
-            int i;
+            word32 i;
 
             /* turn on RNGA module */
             #if defined(SIM_SCGC3_RNGA_MASK)

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -76,6 +76,9 @@
 /* Uncomment next line if building wolfSSL for LSR */
 /* #define WOLFSSL_LSR */
 
+/* Uncomment next line if building for Freescale Classic MQX version 4.0 */
+/* #define FREESCALE_MQX_4_0 */
+
 /* Uncomment next line if building for Freescale Classic MQX/RTCS/MFS */
 /* #define FREESCALE_MQX */
 
@@ -85,7 +88,8 @@
 /* Uncomment next line if building for Freescale KSDK Bare Metal */
 /* #define FREESCALE_KSDK_BM */
 
-/* Uncomment next line if building for Freescale KSDK FreeRTOS (old name FREESCALE_FREE_RTOS) */
+/* Uncomment next line if building for Freescale KSDK FreeRTOS, */
+/* (old name FREESCALE_FREE_RTOS) */
 /* #define FREESCALE_KSDK_FREERTOS */
 
 /* Uncomment next line if using STM32F2 */
@@ -709,6 +713,11 @@ extern void uITRON4_free(void *p) ;
     #define TFM_TIMING_RESISTANT
 #endif
 
+#ifdef FREESCALE_MQX_4_0
+    /* use normal Freescale MQX port, but with minor changes for 4.0 */
+    #define FREESCALE_MQX
+#endif
+
 #ifdef FREESCALE_MQX
     #define FREESCALE_COMMON
     #include "mqx.h"
@@ -725,10 +734,12 @@ extern void uITRON4_free(void *p) ;
         #include "mutex.h"
     #endif
 
-    #define XMALLOC_OVERRIDE
-    #define XMALLOC(s, h, t)    (void *)_mem_alloc_system((s))
-    #define XFREE(p, h, t)      {void* xp = (p); if ((xp)) _mem_free((xp));}
-    /* Note: MQX has no realloc, using fastmath above */
+    #if !defined(XMALLOC_OVERRIDE) && !defined(XMALLOC_USER)
+        #define XMALLOC_OVERRIDE
+        #define XMALLOC(s, h, t)    (void *)_mem_alloc_system((s))
+        #define XFREE(p, h, t)      {void* xp = (p); if ((xp)) _mem_free((xp));}
+        /* Note: MQX has no realloc, using fastmath above */
+    #endif
 #endif
 
 #ifdef FREESCALE_KSDK_MQX

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -383,8 +383,13 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XGMTIME(c, t)   gmtime((c))
 
 #elif defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
+    #ifdef FREESCALE_MQX_4_0
+        #include <time.h>
+        extern time_t mqx_time(time_t* timer);
+    #else
+        #define HAVE_GMTIME_R
+    #endif
     #define XTIME(t1)       mqx_time((t1))
-    #define HAVE_GMTIME_R
 
 #elif defined(FREESCALE_KSDK_BM) || defined(FREESCALE_FREE_RTOS) || defined(FREESCALE_KSDK_FREERTOS)
     #include <time.h>


### PR DESCRIPTION
This PR includes fixes for building wolfSSL for MQX 4.0 (an older version) using IAR-EWARM.

This adds a new define called **FREESCALE_MQX_4_0** that automatically defines **FREESCALE_MQX** but also makes a few minor adjustments to the build.

IAR-EWARM threw warnings for the code sections that used the "~" operator, similar to:
```
internal.c
Remark[PA091]: operator operates on value promoted to int (with possible unexpected result)
```
The casts to (word32) were to address these warnings.