### PR TITLE
User configurable DTLS Timeouts for receive and post handshake

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4524,7 +4524,7 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         ssl->dtls_expected_rx = MAX_MTU;
     #endif
     ssl->dtls_timeout_init              = DTLS_TIMEOUT_INIT;
-    ssl->dtls_timeout_max               = DTLS_TIMEOUT_MAX;
+    ssl->dtls_timeout_max               = WOLFSSL_DTLS_TIMEOUT_MAX;
     ssl->dtls_timeout                   = ssl->dtls_timeout_init;
     ssl->buffers.dtlsCtx.rfd            = -1;
     ssl->buffers.dtlsCtx.wfd            = -1;

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -291,7 +291,7 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     WOLFSSL_ENTER("EmbedReceiveFrom()");
 
     if (ssl->options.handShakeDone)
-        dtls_timeout = 0;
+        dtls_timeout = WOLFSSL_DTLS_POST_HNDSHK_TIMEOUT;
 
     if (!wolfSSL_get_using_nonblock(ssl)) {
         #ifdef USE_WINDOWS_API

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1253,7 +1253,6 @@ enum Misc {
     MAX_SUITE_NAME     =  48,  /* maximum length of cipher suite string */
 
     DTLS_TIMEOUT_INIT       =  1, /* default timeout init for DTLS receive  */
-    DTLS_TIMEOUT_MAX        = 64, /* default max timeout for DTLS receive */
     DTLS_TIMEOUT_MULTIPLIER =  2, /* default timeout multiplier for DTLS recv */
 
     MAX_PSK_ID_LEN     = 128,  /* max psk identity/hint supported */

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -224,6 +224,17 @@
     #endif
 #endif
 
+#ifdef WOLFSSL_DTLS
+    #ifndef WOLFSSL_DTLS_POST_HNDSHK_TIMEOUT
+        #define WOLFSSL_DTLS_POST_HNDSHK_TIMEOUT 0 /* default max timeout for
+                                                    * DTLS post handshake */
+    #endif
+    #ifndef WOLFSSL_DTLS_TIMEOUT_MAX
+        #define WOLFSSL_DTLS_TIMEOUT_MAX 64 /* default max timeout for DTLS
+                                             * receive */
+    #endif
+#endif
+
 
 
 #ifdef DEVKITPRO


### PR DESCRIPTION
Allows users to configure the post handshake timeout for DTLS
Allows users to set a smaller default receive max timeout for DTLS