### PR TITLE
Yet Another Configure Update

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4266,9 +4266,9 @@ for option in $OPTION_FLAGS; do
             continue
         fi
 
-        # allow user to igonore system options
+        # allow user to ignore system options
         ignoresys=no
-        if [[[ $noequalsign == _* ]]] ;
+        if test "$noequalsign = _*"
         then
             ignoresys=yes
             echo "#ifndef WOLFSSL_OPTIONS_IGNORE_SYS" >> $OPTION_FILE


### PR DESCRIPTION
1. Fix comment typo.
2. Change the parsing of the -D options to be more POSIX friendly. Removed the "==" and replaced the multi escaped [] with a test command.