### PR TITLE
Fix for max cert chain size calculation

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -725,7 +725,7 @@ static void test_wolfSSL_CTX_load_verify_locations(void)
 static int test_wolfSSL_CTX_use_certificate_chain_file_format(void)
 {
     int ret = 0;
-#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS)
+#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_RSA)
     const char* server_chain_der = "./certs/server-cert-chain.der";
     WOLFSSL_CTX* ctx;
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -721,6 +721,25 @@ static void test_wolfSSL_CTX_load_verify_locations(void)
 #endif
 }
 
+
+static int test_wolfSSL_CTX_use_certificate_chain_file_format(void)
+{
+    int ret = 0;
+#if !defined(NO_FILESYSTEM) && !defined(NO_CERTS)
+    const char* server_chain_der = "./certs/server-cert-chain.der";
+    WOLFSSL_CTX* ctx;
+
+    ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
+    AssertNotNull(ctx);
+
+    AssertIntEQ(wolfSSL_CTX_use_certificate_chain_file_format(ctx,
+        server_chain_der, WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
+
+    wolfSSL_CTX_free(ctx);
+#endif
+    return ret;
+}
+
 static void test_wolfSSL_CTX_SetTmpDH_file(void)
 {
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_DH) && \
@@ -19894,6 +19913,7 @@ void ApiTest(void)
     AssertIntEQ(test_wolfSSL_CTX_use_certificate_buffer(), WOLFSSL_SUCCESS);
     test_wolfSSL_CTX_use_PrivateKey_file();
     test_wolfSSL_CTX_load_verify_locations();
+    test_wolfSSL_CTX_use_certificate_chain_file_format();
     test_wolfSSL_CTX_trust_peer_cert();
     test_wolfSSL_CTX_SetTmpDH_file();
     test_wolfSSL_CTX_SetTmpDH_buffer();


### PR DESCRIPTION
It was not accounting for the 3 byte header in max size calculation. Added some comments about cert chain format and spelling fixes.