### PR TITLE
Small stack fixes and ignore RSA fields in RSA_LOW_MEM

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -23605,6 +23605,7 @@ static int SetRsaExternal(WOLFSSL_RSA* rsa)
             return WOLFSSL_FATAL_ERROR;
         }
 
+    #ifndef RSA_LOW_MEM
         if (SetIndividualExternal(&rsa->dmp1, &key->dP) != WOLFSSL_SUCCESS) {
             WOLFSSL_MSG("rsa dP key error");
             return WOLFSSL_FATAL_ERROR;
@@ -23619,6 +23620,7 @@ static int SetRsaExternal(WOLFSSL_RSA* rsa)
             WOLFSSL_MSG("rsa u key error");
             return WOLFSSL_FATAL_ERROR;
         }
+    #endif /* !RSA_LOW_MEM */
     }
     rsa->exSet = 1;
 
@@ -23677,6 +23679,7 @@ static int SetRsaInternal(WOLFSSL_RSA* rsa)
         return WOLFSSL_FATAL_ERROR;
     }
 
+#ifndef RSA_LOW_MEM
     if (rsa->dmp1 != NULL &&
         SetIndividualInternal(rsa->dmp1, &key->dP) != WOLFSSL_SUCCESS) {
         WOLFSSL_MSG("rsa dP key error");
@@ -23694,6 +23697,7 @@ static int SetRsaInternal(WOLFSSL_RSA* rsa)
         WOLFSSL_MSG("rsa u key error");
         return WOLFSSL_FATAL_ERROR;
     }
+#endif /* !RSA_LOW_MEM */
 
     rsa->inSet = 1;
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -746,6 +746,25 @@ int GetInt(mp_int* mpi, const byte* input, word32* inOutIdx, word32 maxIdx)
     return 0;
 }
 
+#ifdef RSA_LOW_MEM
+#if !defined(NO_RSA) && !defined(HAVE_USER_RSA)
+static int SkipInt(const byte* input, word32* inOutIdx, word32 maxIdx)
+{
+    word32 idx = *inOutIdx;
+    int    ret;
+    int    length;
+
+    ret = GetASNInt(input, &idx, &length, maxIdx);
+    if (ret != 0)
+        return ret;
+
+    *inOutIdx = idx + length;
+
+    return 0;
+}
+#endif
+#endif
+
 static int CheckBitString(const byte* input, word32* inOutIdx, int* len,
                           word32 maxIdx, int zeroBits, byte* unusedBits)
 {
@@ -2092,10 +2111,16 @@ int wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
         GetInt(&key->e,  input, inOutIdx, inSz) < 0 ||
         GetInt(&key->d,  input, inOutIdx, inSz) < 0 ||
         GetInt(&key->p,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->q,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->dP, input, inOutIdx, inSz) < 0 ||
+        GetInt(&key->q,  input, inOutIdx, inSz) < 0)   return ASN_RSA_KEY_E;
+#ifndef RSA_LOW_MEM
+    if (GetInt(&key->dP, input, inOutIdx, inSz) < 0 ||
         GetInt(&key->dQ, input, inOutIdx, inSz) < 0 ||
         GetInt(&key->u,  input, inOutIdx, inSz) < 0 )  return ASN_RSA_KEY_E;
+#else
+    if (SkipInt(input, inOutIdx, inSz) < 0 ||
+        SkipInt(input, inOutIdx, inSz) < 0 ||
+        SkipInt(input, inOutIdx, inSz) < 0 )  return ASN_RSA_KEY_E;
+#endif
 
 #ifdef WOLFSSL_XILINX_CRYPT
     if (wc_InitRsaHw(key) != 0) {
@@ -2310,20 +2335,45 @@ int wc_CheckPrivateKey(byte* key, word32 keySz, DecodedCert* der)
     #if !defined(NO_RSA)
     /* test if RSA key */
     if (der->keyOID == RSAk) {
-        RsaKey a, b;
+    #ifdef WOLFSSL_SMALL_STACK
+        RsaKey* a = NULL;
+        RsaKey* b = NULL;
+    #else
+        RsaKey a[1], b[1];
+    #endif
         word32 keyIdx = 0;
 
-        if ((ret = wc_InitRsaKey(&a, NULL)) < 0)
-            return ret;
-        if ((ret = wc_InitRsaKey(&b, NULL)) < 0) {
-            wc_FreeRsaKey(&a);
+    #ifdef WOLFSSL_SMALL_STACK
+        a = XMALLOC(sizeof(RsaKey), NULL, DYNAMIC_TYPE_RSA);
+        if (a == NULL)
+            return MEMORY_E;
+        b = XMALLOC(sizeof(RsaKey), NULL, DYNAMIC_TYPE_RSA);
+        if (b == NULL) {
+            XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+            return MEMORY_E;
+        }
+    #endif
+
+        if ((ret = wc_InitRsaKey(a, NULL)) < 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+            XFREE(b, NULL, DYNAMIC_TYPE_RSA);
+            XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
             return ret;
         }
-        if ((ret = wc_RsaPrivateKeyDecode(key, &keyIdx, &a, keySz)) == 0) {
+        if ((ret = wc_InitRsaKey(b, NULL)) < 0) {
+            wc_FreeRsaKey(a);
+    #ifdef WOLFSSL_SMALL_STACK
+            XFREE(b, NULL, DYNAMIC_TYPE_RSA);
+            XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+            return ret;
+        }
+        if ((ret = wc_RsaPrivateKeyDecode(key, &keyIdx, a, keySz)) == 0) {
             WOLFSSL_MSG("Checking RSA key pair");
             keyIdx = 0; /* reset to 0 for parsing public key */
 
-            if ((ret = wc_RsaPublicKeyDecode(der->publicKey, &keyIdx, &b,
+            if ((ret = wc_RsaPublicKeyDecode(der->publicKey, &keyIdx, b,
                                                        der->pubKeySize)) == 0) {
                 /* limit for user RSA crypto because of RsaKey
                  * dereference. */
@@ -2333,8 +2383,8 @@ int wc_CheckPrivateKey(byte* key, word32 keySz, DecodedCert* der)
             #else
                 /* both keys extracted successfully now check n and e
                  * values are the same. This is dereferencing RsaKey */
-                if (mp_cmp(&(a.n), &(b.n)) != MP_EQ ||
-                    mp_cmp(&(a.e), &(b.e)) != MP_EQ) {
+                if (mp_cmp(&(a->n), &(b->n)) != MP_EQ ||
+                    mp_cmp(&(a->e), &(b->e)) != MP_EQ) {
                     ret = MP_CMP_E;
                 }
                 else
@@ -2342,73 +2392,119 @@ int wc_CheckPrivateKey(byte* key, word32 keySz, DecodedCert* der)
             #endif
             }
         }
-        wc_FreeRsaKey(&b);
-        wc_FreeRsaKey(&a);
+        wc_FreeRsaKey(b);
+        wc_FreeRsaKey(a);
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(b, NULL, DYNAMIC_TYPE_RSA);
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
     }
     else
     #endif /* NO_RSA */
 
     #ifdef HAVE_ECC
     if (der->keyOID == ECDSAk) {
-        ecc_key key_pair;
-        byte    privDer[MAX_ECC_BYTES];
-        word32  privSz = MAX_ECC_BYTES;
-        word32  keyIdx = 0;
+    #ifdef WOLFSSL_SMALL_STACK
+        ecc_key* key_pair = NULL;
+        byte*    privDer;
+    #else
+        ecc_key  key_pair[1];
+        byte     privDer[MAX_ECC_BYTES];
+    #endif
+        word32   privSz = MAX_ECC_BYTES;
+        word32   keyIdx = 0;
 
-        if ((ret = wc_ecc_init(&key_pair)) < 0)
+    #ifdef WOLFSSL_SMALL_STACK
+        key_pair = XMALLOC(sizeof(ecc_key), NULL, DYNAMIC_TYPE_ECC);
+        if (key_pair == NULL)
+            return MEMORY_E;
+        privDer = XMALLOC(MAX_ECC_BYTES, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (privDer == NULL) {
+            XFREE(key_pair, NULL, DYNAMIC_TYPE_ECC);
+            return MEMORY_E;
+        }
+    #endif
+
+        if ((ret = wc_ecc_init(key_pair)) < 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+            XFREE(privDer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(key_pair, NULL, DYNAMIC_TYPE_ECC);
+    #endif
             return ret;
+        }
 
-        if ((ret = wc_EccPrivateKeyDecode(key, &keyIdx, &key_pair,
+        if ((ret = wc_EccPrivateKeyDecode(key, &keyIdx, key_pair,
                                                                  keySz)) == 0) {
             WOLFSSL_MSG("Checking ECC key pair");
 
-            if ((ret = wc_ecc_export_private_only(&key_pair, privDer, &privSz))
+            if ((ret = wc_ecc_export_private_only(key_pair, privDer, &privSz))
                                                                          == 0) {
-                wc_ecc_free(&key_pair);
-                ret = wc_ecc_init(&key_pair);
+                wc_ecc_free(key_pair);
+                ret = wc_ecc_init(key_pair);
                 if (ret == 0) {
                     ret = wc_ecc_import_private_key((const byte*)privDer,
                                             privSz, (const byte*)der->publicKey,
-                                            der->pubKeySize, &key_pair);
+                                            der->pubKeySize, key_pair);
                 }
 
                 /* public and private extracted successfuly now check if is
                  * a pair and also do sanity checks on key. wc_ecc_check_key
                  * checks that private * base generator equals pubkey */
                 if (ret == 0) {
-                    if ((ret = wc_ecc_check_key(&key_pair)) == 0) {
+                    if ((ret = wc_ecc_check_key(key_pair)) == 0) {
                         ret = 1;
                     }
                 }
                 ForceZero(privDer, privSz);
             }
         }
-        wc_ecc_free(&key_pair);
+        wc_ecc_free(key_pair);
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(privDer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(key_pair, NULL, DYNAMIC_TYPE_ECC);
+    #endif
     }
     else
     #endif /* HAVE_ECC */
 
     #ifdef HAVE_ED25519
     if (der->keyOID == ED25519k) {
-        word32  keyIdx = 0;
-        ed25519_key key_pair;
+    #ifdef WOLFSSL_SMALL_STACK
+        ed25519_key* key_pair = NULL;
+    #else
+        ed25519_key  key_pair[1];
+    #endif
+        word32       keyIdx = 0;
 
-        if ((ret = wc_ed25519_init(&key_pair)) < 0)
+    #ifdef WOLFSSL_SMALL_STACK
+        key_pair = XMALLOC(sizeof(ed25519_key), NULL, DYNAMIC_TYPE_ED25519);
+        if (key_pair == NULL)
+            return MEMORY_E;
+    #endif
+
+        if ((ret = wc_ed25519_init(key_pair)) < 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+            XFREE(key_pair, NULL, DYNAMIC_TYPE_ED25519);
+    #endif
             return ret;
-        if ((ret = wc_Ed25519PrivateKeyDecode(key, &keyIdx, &key_pair,
+        }
+        if ((ret = wc_Ed25519PrivateKeyDecode(key, &keyIdx, key_pair,
                                                                  keySz)) == 0) {
             WOLFSSL_MSG("Checking ED25519 key pair");
             keyIdx = 0;
             if ((ret = wc_ed25519_import_public(der->publicKey, der->pubKeySize,
-                                                             &key_pair)) == 0) {
+                                                              key_pair)) == 0) {
                 /* public and private extracted successfuly no check if is
                  * a pair and also do sanity checks on key. wc_ecc_check_key
                  * checks that private * base generator equals pubkey */
-                if ((ret = wc_ed25519_check_key(&key_pair)) == 0)
+                if ((ret = wc_ed25519_check_key(key_pair)) == 0)
                     ret = 1;
             }
         }
-        wc_ed25519_free(&key_pair);
+        wc_ed25519_free(key_pair);
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(key_pair, NULL, DYNAMIC_TYPE_ED25519);
+    #endif
     }
     else
     #endif

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -3054,7 +3054,8 @@ static int sp_2048_mod_exp_90(sp_digit* r, sp_digit* a, sp_digit* e, int bits,
 }
 #endif /* SP_RSA_PRIVATE_EXP_D || WOLFSSL_HAVE_SP_DH */
 
-#if defined(WOLFSSL_HAVE_SP_RSA) && !defined(SP_RSA_PRIVATE_EXP_D)
+#if defined(WOLFSSL_HAVE_SP_RSA) && !defined(SP_RSA_PRIVATE_EXP_D) && \
+                                    !defined(RSA_LOW_MEM)
 /* AND m into each word of a and store in r.
  *
  * r  A single precision integer.
@@ -3311,7 +3312,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
     mp_int* pm, mp_int* qm, mp_int* dpm, mp_int* dqm, mp_int* qim, mp_int* mm,
     byte* out, word32* outLen)
 {
-#ifdef SP_RSA_PRIVATE_EXP_D
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     sp_digit* a;
     sp_digit* d = NULL;
@@ -3521,7 +3522,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
 
     return err;
 #endif /* WOLFSSL_SP_SMALL || defined(WOLFSSL_SMALL_STACK) */
-#endif /* SP_RSA_PRIVATE_EXP_D */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 }
 
 #endif /* WOLFSSL_HAVE_SP_RSA */
@@ -6424,7 +6425,8 @@ static int sp_3072_mod_exp_136(sp_digit* r, sp_digit* a, sp_digit* e, int bits,
 }
 #endif /* SP_RSA_PRIVATE_EXP_D || WOLFSSL_HAVE_SP_DH */
 
-#if defined(WOLFSSL_HAVE_SP_RSA) && !defined(SP_RSA_PRIVATE_EXP_D)
+#if defined(WOLFSSL_HAVE_SP_RSA) && !defined(SP_RSA_PRIVATE_EXP_D) && \
+                                    !defined(RSA_LOW_MEM)
 /* AND m into each word of a and store in r.
  *
  * r  A single precision integer.
@@ -6680,7 +6682,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
     mp_int* pm, mp_int* qm, mp_int* dpm, mp_int* dqm, mp_int* qim, mp_int* mm,
     byte* out, word32* outLen)
 {
-#ifdef SP_RSA_PRIVATE_EXP_D
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     sp_digit* a;
     sp_digit* d = NULL;
@@ -6890,7 +6892,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
 
     return err;
 #endif /* WOLFSSL_SP_SMALL || defined(WOLFSSL_SMALL_STACK) */
-#endif /* SP_RSA_PRIVATE_EXP_D */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 }
 
 #endif /* WOLFSSL_HAVE_SP_RSA */

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -2480,7 +2480,8 @@ static int sp_2048_mod_exp_36(sp_digit* r, sp_digit* a, sp_digit* e, int bits,
 }
 #endif /* SP_RSA_PRIVATE_EXP_D || WOLFSSL_HAVE_SP_DH */
 
-#if defined(WOLFSSL_HAVE_SP_RSA) && !defined(SP_RSA_PRIVATE_EXP_D)
+#if defined(WOLFSSL_HAVE_SP_RSA) && !defined(SP_RSA_PRIVATE_EXP_D) && \
+                                    !defined(RSA_LOW_MEM)
 /* AND m into each word of a and store in r.
  *
  * r  A single precision integer.
@@ -2734,7 +2735,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
     mp_int* pm, mp_int* qm, mp_int* dpm, mp_int* dqm, mp_int* qim, mp_int* mm,
     byte* out, word32* outLen)
 {
-#ifdef SP_RSA_PRIVATE_EXP_D
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     sp_digit* a;
     sp_digit* d = NULL;
@@ -2944,7 +2945,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
 
     return err;
 #endif /* WOLFSSL_SP_SMALL || defined(WOLFSSL_SMALL_STACK) */
-#endif /* SP_RSA_PRIVATE_EXP_D */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 }
 
 #endif /* WOLFSSL_HAVE_SP_RSA */
@@ -5861,7 +5862,8 @@ static int sp_3072_mod_exp_54(sp_digit* r, sp_digit* a, sp_digit* e, int bits,
 }
 #endif /* SP_RSA_PRIVATE_EXP_D || WOLFSSL_HAVE_SP_DH */
 
-#if defined(WOLFSSL_HAVE_SP_RSA) && !defined(SP_RSA_PRIVATE_EXP_D)
+#if defined(WOLFSSL_HAVE_SP_RSA) && !defined(SP_RSA_PRIVATE_EXP_D) && \
+                                    !defined(RSA_LOW_MEM)
 /* AND m into each word of a and store in r.
  *
  * r  A single precision integer.
@@ -6116,7 +6118,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
     mp_int* pm, mp_int* qm, mp_int* dpm, mp_int* dqm, mp_int* qim, mp_int* mm,
     byte* out, word32* outLen)
 {
-#ifdef SP_RSA_PRIVATE_EXP_D
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     sp_digit* a;
     sp_digit* d = NULL;
@@ -6326,7 +6328,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
 
     return err;
 #endif /* WOLFSSL_SP_SMALL || defined(WOLFSSL_SMALL_STACK) */
-#endif /* SP_RSA_PRIVATE_EXP_D */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 }
 
 #endif /* WOLFSSL_HAVE_SP_RSA */

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -633,6 +633,22 @@ int sp_add(sp_int* a, sp_int* b, sp_int* r)
 }
 #endif
 
+#ifndef NO_RSA
+/* Set a number into the big number.
+ *
+ * a  SP integer.
+ * b  Value to set.
+ * returns MP_OKAY always.
+ */
+int sp_set_int(sp_int* a, unsigned long b)
+{
+    a->used = 1;
+    a->dp[0] = b;
+
+    return MP_OKAY;
+}
+#endif
+
 #if !defined(USE_FAST_MATH)
 /* Returns the run time settings.
  *

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -113,7 +113,10 @@ enum {
 
 /* RSA */
 struct RsaKey {
-    mp_int n, e, d, p, q, dP, dQ, u;
+    mp_int n, e, d, p, q;
+#if defined(WOLFSSL_KEY_GEN) || !defined(RSA_LOW_MEM)
+    mp_int dP, dQ, u;
+#endif
     void* heap;                               /* for user memory overrides */
     byte* data;                               /* temp buffer for async RSA */
     int   type;                               /* public or private */

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -133,6 +133,7 @@ MP_API void sp_zero(sp_int* a);
 MP_API int sp_add_d(sp_int* a, sp_int_digit d, sp_int* r);
 MP_API int sp_lshd(sp_int* a, int s);
 MP_API int sp_add(sp_int* a, sp_int* b, sp_int* r);
+MP_API int sp_set_int(sp_int* a, unsigned long b);
 
 typedef sp_int mp_int;
 typedef sp_digit mp_digit;
@@ -180,6 +181,7 @@ typedef sp_digit mp_digit;
 #define mp_lshd                 sp_lshd
 #define mp_add                  sp_add
 #define mp_isodd                sp_isodd
+#define mp_set_int              sp_set_int
 
 #define MP_INT_DEFINED
 


### PR DESCRIPTION
Fix asn.c and rsa.c small stack to not have large stack variables.
In RSA code don't load or store dP, dQ or u when using RSA_LOW_MEM as
they are not used.
Fix SP to recognize RSA_LOW_MEM means to use d, private exponent.
Fix wc_CheckRsaKey to work with SP.
Fix sp_int to support mp_set_int for wc_CheckRsaKey().