### PR TITLE
Dead code in wolfSSL_BIO_gets()

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -580,8 +580,8 @@ int wolfSSL_BIO_gets(WOLFSSL_BIO* bio, char* buf, int sz)
                 const byte* c;
                 int   cSz;
                 cSz = wolfSSL_BIO_pending(bio);
-                if (cSz <= 0) {
-                    ret = (ret == 0) ? 0 /* Nothing read */ : cSz /* error */;
+                if (cSz == 0) {
+                    ret = 0; /* Nothing to read */
                     buf[0] = '\0';
                     break;
                 }


### PR DESCRIPTION

1. int ret = WOLFSSL_BIO_UNSET; 
2, if NO_FILESYSTEM is defined, there is no change made to this variable until 
3. ret = (ret == 0) ? 0 /* Nothing read */ : cSz /* error */;

where ret == 0 can never / will always happen depending on WOLFSSL_BIO_UNSET being equal to 0.