### PR TITLE
Added reference PK callbacks for ATECC508A to support TLS

### DIFF
--- a/wolfcrypt/src/port/atmel/README.md
+++ b/wolfcrypt/src/port/atmel/README.md
@@ -5,4 +5,69 @@
 * Adds new PK callback for Pre Master Secret.
 
 
+## Building
+
+`./configure --enable-pkcallbacks CFLAGS="-DWOLFSSL_ATECC508A"`
+
+or 
+
+`#define HAVE_PK_CALLBACKS`
+`#define WOLFSSL_ATECC508A`
+
+
+## Coding
+
+Setup the PK callbacks for TLS using:
+
+```
+/* Setup PK Callbacks for ATECC508A */
+WOLFSSL_CTX* ctx;
+wolfSSL_CTX_SetEccKeyGenCb(ctx, atcatls_create_key_cb);
+wolfSSL_CTX_SetEccVerifyCb(ctx, atcatls_verify_signature_cb);
+wolfSSL_CTX_SetEccSignCb(ctx, atcatls_sign_certificate_cb);
+wolfSSL_CTX_SetEccSharedSecretCb(ctx, atcatls_create_pms_cb);
+```
+
+The reference ATECC508A PK callback functions are located in the `wolfcrypt/src/port/atmel/atmel.c` file.
+
+
+Adding a custom contex to the callbacks:
+
+```
+/* Setup PK Callbacks context */
+WOLFSSL* ssl;
+void* myOwnCtx;
+wolfSSL_SetEccKeyGenCtx(ssl, myOwnCtx);
+wolfSSL_SetEccVerifyCtx(ssl, myOwnCtx);
+wolfSSL_SetEccSignCtx(ssl, myOwnCtx);
+wolfSSL_SetEccSharedSecretCtx(ssl, myOwnCtx);
+```
+
+## Benchmarks
+
+### TLS
+
+TLS Establishment Times:
+
+* Hardware accelerated ATECC508A: 2.342 seconds avgerage
+* Software only: 13.422 seconds average
+
+The TLS connection establishment time is 5.73 times faster with the ATECC508A.
+
+### Cryptographic ECC
+
+Software only implementation (SAMD21 48Mhz Cortex-M0, Fast Math TFM-ASM):
+
+`ECC  256 key generation  3123.000 milliseconds, avg over 5 iterations`
+`EC-DHE   key agreement   3117.000 milliseconds, avg over 5 iterations`
+`EC-DSA   sign   time     1997.000 milliseconds, avg over 5 iterations`
+`EC-DSA   verify time     5057.000 milliseconds, avg over 5 iterations`
+
+ATECC508A HW accelerated implementation:
+`ECC  256 key generation  144.400 milliseconds, avg over 5 iterations`
+`EC-DHE   key agreement   134.200 milliseconds, avg over 5 iterations`
+`EC-DSA   sign   time     293.400 milliseconds, avg over 5 iterations`
+`EC-DSA   verify time     208.400 milliseconds, avg over 5 iterations`
+
+
 For details see our [wolfSSL Atmel ATECC508A](wolfhttps://wolfssl.com/wolfSSL/wolfssl-atmel.html) page.

--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -1,6 +1,6 @@
 /* atecc508.h
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL. (formerly known as CyaSSL)
  *
@@ -24,6 +24,11 @@
 
 #include <stdint.h>
 
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/ssl.h>
+#include <wolfssl/wolfcrypt/ecc.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
 #ifdef WOLFSSL_ATECC508A
     #undef  SHA_BLOCK_SIZE
     #define SHA_BLOCK_SIZE  SHA_BLOCK_SIZE_REMAP
@@ -36,6 +41,8 @@
 
 /* ATECC508A only supports ECC-256 */
 #define ATECC_KEY_SIZE      (32)
+#define ATECC_PUBKEY_SIZE   (ATECC_KEY_SIZE*2) /* X and Y */
+#define ATECC_SIG_SIZE      (ATECC_KEY_SIZE*2) /* R and S */
 #define ATECC_MAX_SLOT      (0x7) /* Only use 0-7 */
 #define ATECC_INVALID_SLOT  (-1)
 
@@ -57,10 +64,26 @@ extern t_atcert atcert;
 
 /* Amtel port functions */
 void atmel_init(void);
+void atmel_finish(void);
 int atmel_get_random_number(uint32_t count, uint8_t* rand_out);
 long atmel_get_curr_time_and_date(long* tm);
 
 int atmel_ecc_alloc(void);
 void atmel_ecc_free(int slot);
+
+
+#ifdef HAVE_PK_CALLBACKS
+    int atcatls_create_key_cb(WOLFSSL* ssl, ecc_key* key, word32 keySz,
+        int ecc_curve, void* ctx);
+    int atcatls_create_pms_cb(WOLFSSL* ssl, ecc_key* otherKey,
+        unsigned char* pubKeyDer, unsigned int* pubKeySz,
+        unsigned char* out, unsigned int* outlen,
+        int side, void* ctx);
+    int atcatls_sign_certificate_cb(WOLFSSL* ssl, const byte* in, word32 inSz,
+        byte* out, word32* outSz, const byte* key, word32 keySz, void* ctx);
+    int atcatls_verify_signature_cb(WOLFSSL* ssl, const byte* sig, word32 sigSz,
+        const byte* hash, word32 hashSz, const byte* key, word32 keySz, int* result,
+        void* ctx);
+#endif
 
 #endif /* _ATECC508_H_ */


### PR DESCRIPTION
Added reference PK callbacks (`HAVE_PK_CALLBACKS`) for ATECC508A device for wolfSSL TLS.