### PR TITLE
FIPS build and ECC fixes

### DIFF
--- a/fips-check.sh
+++ b/fips-check.sh
@@ -161,7 +161,7 @@ linuxv2)
   CRYPT_VERSION=$LINUXV2_CRYPT_VERSION
   CRYPT_INC_PATH=wolfssl/wolfcrypt
   CRYPT_SRC_PATH=wolfcrypt/src
-  WC_MODS+=( cmac dh )
+  WC_MODS+=( cmac dh ecc )
   FIPS_SRCS+=( wolfcrypt_first.c wolfcrypt_last.c )
   FIPS_INCS=( fips.h )
   FIPS_OPTION=v2

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6039,7 +6039,7 @@ static int ecc_check_privkey_gen_helper(ecc_key* key)
     err = BAD_COND_E;
 
 #else
-    ALLOC_CURVE_SPECS(curve, 2);
+    ALLOC_CURVE_SPECS(2);
 
     /* load curve info */
     err = wc_ecc_curve_load(key->dp, &curve,


### PR DESCRIPTION
1. The fips-check script was missing the ecc file when building the FIPSv2 test directory. The correct file was sent in for testing.
2. When building with ECC import validation enabled, one usage of the ALLOC_CURVE_SPECS macro had an extra parameter. (copy-and-paste error)