### PR TITLE
Fix Atollic TrueSTUDIO warning, add WOLFSSL_STM32F427_RNG

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -4764,6 +4764,8 @@ exit_ed_verify:
 
 #elif defined FREERTOS
 
+    #include "task.h"
+
     double current_time(int reset)
     {
         portTickType tickCount;

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1308,6 +1308,7 @@ static int wc_PKCS12_create_key_bag(WC_PKCS12* pkcs12, WC_RNG* rng,
     tmpSz = SetSequence(totalSz, out);
     XMEMMOVE(out + tmpSz, out + MAX_SEQ_SZ, totalSz);
 
+    (void)heap;
     return totalSz + tmpSz;
 }
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1008,6 +1008,9 @@ extern void uITRON4_free(void *p) ;
     #ifndef NO_STM32_RNG
         #undef  STM32_RNG
         #define STM32_RNG
+        #ifdef WOLFSSL_STM32F427_RNG
+            #include "stm32f427xx.h"
+        #endif
     #endif
     #ifndef NO_STM32_CRYPTO
         #undef  STM32_CRYPTO


### PR DESCRIPTION
This PR:

- Fixes a few build warnings seen when compiling in Atollic TrueSTUDIO v9.0.1
- Adds a new define for enabling STM32F427 hardware RNG support through the "stm32f427xx.h" header (WOLFSSL_STM32F427_RNG)