### PR TITLE
Fix for memory tracking cleanup

### DIFF
--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -46,9 +46,9 @@
 
 
 /* Set these to default values initially. */
-static wolfSSL_Malloc_cb  malloc_function = 0;
-static wolfSSL_Free_cb    free_function = 0;
-static wolfSSL_Realloc_cb realloc_function = 0;
+static wolfSSL_Malloc_cb  malloc_function = NULL;
+static wolfSSL_Free_cb    free_function = NULL;
+static wolfSSL_Realloc_cb realloc_function = NULL;
 
 int wolfSSL_SetAllocators(wolfSSL_Malloc_cb  mf,
                           wolfSSL_Free_cb    ff,
@@ -72,6 +72,16 @@ int wolfSSL_SetAllocators(wolfSSL_Malloc_cb  mf,
         res = BAD_FUNC_ARG;
 
     return res;
+}
+
+int wolfSSL_ResetAllocators(void)
+{
+    /* allow nulls to be set for callbacks to restore defaults */
+    malloc_function = NULL;
+    free_function = NULL;
+    realloc_function = NULL;
+
+    return 0;
 }
 
 int wolfSSL_GetAllocators(wolfSSL_Malloc_cb*  mf,

--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -237,6 +237,12 @@
                                        (unsigned long)ourMemStats.currentBytes);
     #endif
     }
+
+    STATIC WC_INLINE int CleanupMemoryTracker(void)
+    {
+        /* restore default allocators */
+        return wolfSSL_ResetAllocators();
+    }
 #endif
 
 #endif /* USE_WOLFSSL_MEMORY */

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -77,7 +77,7 @@
 WOLFSSL_API int wolfSSL_SetAllocators(wolfSSL_Malloc_cb,
                                       wolfSSL_Free_cb,
                                       wolfSSL_Realloc_cb);
-
+WOLFSSL_API int wolfSSL_ResetAllocators(void);
 WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb*,
                                       wolfSSL_Free_cb*,
                                       wolfSSL_Realloc_cb*);


### PR DESCRIPTION
This resolves issue with trying to free memory allocated prior to InitMemoryTracker.

* Added new API `wolfSSL_ResetAllocators` to allow reset of memory callbacks to defaults.
* Added new `CleanupMemoryTracker` which restores memory callback functions. 