### PR TITLE
Fixes for PIC32MZ hash memory leak

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -935,74 +935,21 @@ static int Hmac_HashFinalRaw(Hmac* hmac, unsigned char* hash)
 static int Hmac_OuterHash(Hmac* hmac, unsigned char* mac)
 {
     int ret = BAD_FUNC_ARG;
+    wc_HashAlg hash;
+    enum wc_HashType hashType = (enum wc_HashType)hmac->macType;
+    int digestSz = wc_HashGetDigestSize(hashType);
+    int blockSz = wc_HashGetBlockSize(hashType);
 
-    switch (hmac->macType) {
-    #ifndef NO_SHA
-        case WC_SHA:
-            ret = wc_InitSha(&hmac->hash.sha);
-            if (ret == 0) {
-                ret = wc_ShaUpdate(&hmac->hash.sha, (byte*)hmac->opad,
-                                                             WC_SHA_BLOCK_SIZE);
-                if (ret == 0)
-                    ret = wc_ShaUpdate(&hmac->hash.sha, (byte*)hmac->innerHash,
-                                                                WC_SHA_DIGEST_SIZE);
-                if (ret == 0)
-                    ret = wc_ShaFinal(&hmac->hash.sha, mac);
-                wc_ShaFree(&hmac->hash.sha);
-            }
-            break;
-    #endif /* !NO_SHA */
-
-    #ifndef NO_SHA256
-        case WC_SHA256:
-            ret = wc_InitSha256(&hmac->hash.sha256);
-            if (ret == 0) {
-                ret = wc_Sha256Update(&hmac->hash.sha256, (byte*)hmac->opad,
-                                                          WC_SHA256_BLOCK_SIZE);
-                if (ret == 0)
-                    ret = wc_Sha256Update(&hmac->hash.sha256,
-                                                             (byte*)hmac->innerHash,
-                                                             WC_SHA256_DIGEST_SIZE);
-                if (ret == 0)
-                    ret = wc_Sha256Final(&hmac->hash.sha256, mac);
-                wc_Sha256Free(&hmac->hash.sha256);
-            }
-            break;
-    #endif /* !NO_SHA256 */
-
-    #ifdef WOLFSSL_SHA384
-        case WC_SHA384:
-            ret = wc_InitSha384(&hmac->hash.sha384);
-            if (ret == 0) {
-                ret = wc_Sha384Update(&hmac->hash.sha384, (byte*)hmac->opad,
-                                                          WC_SHA384_BLOCK_SIZE);
-                if (ret == 0)
-                    ret = wc_Sha384Update(&hmac->hash.sha384,
-                                                             (byte*)hmac->innerHash,
-                                                             WC_SHA384_DIGEST_SIZE);
-                if (ret == 0)
-                    ret = wc_Sha384Final(&hmac->hash.sha384, mac);
-                wc_Sha384Free(&hmac->hash.sha384);
-            }
-            break;
-    #endif /* WOLFSSL_SHA384 */
-
-    #ifdef WOLFSSL_SHA512
-        case WC_SHA512:
-            ret = wc_InitSha512(&hmac->hash.sha512);
-            if (ret == 0) {
-                ret = wc_Sha512Update(&hmac->hash.sha512,(byte*)hmac->opad,
-                                                          WC_SHA512_BLOCK_SIZE);
-                if (ret == 0)
-                    ret = wc_Sha512Update(&hmac->hash.sha512,
-                                                             (byte*)hmac->innerHash,
-                                                             WC_SHA512_DIGEST_SIZE);
-                if (ret == 0)
-                    ret = wc_Sha512Final(&hmac->hash.sha512, mac);
-                wc_Sha512Free(&hmac->hash.sha512);
-            }
-            break;
-    #endif /* WOLFSSL_SHA512 */
+    ret = wc_HashInit(&hash, hashType);
+    if (ret == 0) {
+        ret = wc_HashUpdate(&hash, hashType, (byte*)hmac->opad,
+            blockSz);
+        if (ret == 0)
+            ret = wc_HashUpdate(&hash, hashType, (byte*)hmac->innerHash,
+                digestSz);
+        if (ret == 0)
+            ret = wc_HashFinal(&hash, hashType, mac);
+        wc_HashFree(&hash, hashType);
     }
 
     return ret;
@@ -10175,7 +10122,7 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte msgType,
         return method;
     }
     #endif /* WOLFSSL_ALLOW_TLSV10 */
-    
+
     #if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
     /* Gets a WOLFSL_METHOD type that is not set as client or server
      *

--- a/src/tls.c
+++ b/src/tls.c
@@ -940,59 +940,67 @@ static int Hmac_OuterHash(Hmac* hmac, unsigned char* mac)
     #ifndef NO_SHA
         case WC_SHA:
             ret = wc_InitSha(&hmac->hash.sha);
-            if (ret == 0)
+            if (ret == 0) {
                 ret = wc_ShaUpdate(&hmac->hash.sha, (byte*)hmac->opad,
                                                              WC_SHA_BLOCK_SIZE);
-            if (ret == 0)
-                ret = wc_ShaUpdate(&hmac->hash.sha, (byte*)hmac->innerHash,
-                                                            WC_SHA_DIGEST_SIZE);
-            if (ret == 0)
-                ret = wc_ShaFinal(&hmac->hash.sha, mac);
+                if (ret == 0)
+                    ret = wc_ShaUpdate(&hmac->hash.sha, (byte*)hmac->innerHash,
+                                                                WC_SHA_DIGEST_SIZE);
+                if (ret == 0)
+                    ret = wc_ShaFinal(&hmac->hash.sha, mac);
+                wc_ShaFree(&hmac->hash.sha);
+            }
             break;
     #endif /* !NO_SHA */
 
     #ifndef NO_SHA256
         case WC_SHA256:
             ret = wc_InitSha256(&hmac->hash.sha256);
-            if (ret == 0)
+            if (ret == 0) {
                 ret = wc_Sha256Update(&hmac->hash.sha256, (byte*)hmac->opad,
                                                           WC_SHA256_BLOCK_SIZE);
-            if (ret == 0)
-                ret = wc_Sha256Update(&hmac->hash.sha256,
-                                                         (byte*)hmac->innerHash,
-                                                         WC_SHA256_DIGEST_SIZE);
-            if (ret == 0)
-                ret = wc_Sha256Final(&hmac->hash.sha256, mac);
+                if (ret == 0)
+                    ret = wc_Sha256Update(&hmac->hash.sha256,
+                                                             (byte*)hmac->innerHash,
+                                                             WC_SHA256_DIGEST_SIZE);
+                if (ret == 0)
+                    ret = wc_Sha256Final(&hmac->hash.sha256, mac);
+                wc_Sha256Free(&hmac->hash.sha256);
+            }
             break;
     #endif /* !NO_SHA256 */
 
     #ifdef WOLFSSL_SHA384
         case WC_SHA384:
             ret = wc_InitSha384(&hmac->hash.sha384);
-            if (ret == 0)
+            if (ret == 0) {
                 ret = wc_Sha384Update(&hmac->hash.sha384, (byte*)hmac->opad,
                                                           WC_SHA384_BLOCK_SIZE);
-            if (ret == 0)
-                ret = wc_Sha384Update(&hmac->hash.sha384,
-                                                         (byte*)hmac->innerHash,
-                                                         WC_SHA384_DIGEST_SIZE);
-            if (ret == 0)
-                ret = wc_Sha384Final(&hmac->hash.sha384, mac);
+                if (ret == 0)
+                    ret = wc_Sha384Update(&hmac->hash.sha384,
+                                                             (byte*)hmac->innerHash,
+                                                             WC_SHA384_DIGEST_SIZE);
+                if (ret == 0)
+                    ret = wc_Sha384Final(&hmac->hash.sha384, mac);
+                wc_Sha384Free(&hmac->hash.sha384);
+            }
             break;
     #endif /* WOLFSSL_SHA384 */
 
     #ifdef WOLFSSL_SHA512
         case WC_SHA512:
             ret = wc_InitSha512(&hmac->hash.sha512);
-            if (ret == 0)
+            if (ret == 0) {
                 ret = wc_Sha512Update(&hmac->hash.sha512,(byte*)hmac->opad,
                                                           WC_SHA512_BLOCK_SIZE);
-            if (ret == 0)
-                ret = wc_Sha512Update(&hmac->hash.sha512,
-                                                         (byte*)hmac->innerHash,
-                                                         WC_SHA512_DIGEST_SIZE);
-            if (ret == 0)
-                ret = wc_Sha512Final(&hmac->hash.sha512, mac);
+                if (ret == 0)
+                    ret = wc_Sha512Update(&hmac->hash.sha512,
+                                                             (byte*)hmac->innerHash,
+                                                             WC_SHA512_DIGEST_SIZE);
+                if (ret == 0)
+                    ret = wc_Sha512Final(&hmac->hash.sha512, mac);
+                wc_Sha512Free(&hmac->hash.sha512);
+            }
             break;
     #endif /* WOLFSSL_SHA512 */
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -5277,6 +5277,7 @@ static int test_wc_Sha3_224_Final (void)
             ret = WOLFSSL_FATAL_ERROR;
         }
     }
+    wc_Sha3_224_Free(&sha3);
     printf(resultFmt, ret == 0 ? passed : failed);
 
     if (ret == 0) {
@@ -5370,7 +5371,9 @@ static int test_wc_Sha3_256_Final (void)
             ret = WOLFSSL_FATAL_ERROR;
         }
     }
+    wc_Sha3_256_Free(&sha3);
     printf(resultFmt, ret == 0 ? passed : failed);
+
     if (ret == 0) {
         printf(testingFmt, "wc_Sha3_256_GetHash()");
 
@@ -5461,7 +5464,9 @@ static int test_wc_Sha3_384_Final (void)
             ret = WOLFSSL_FATAL_ERROR;
         }
     }
+    wc_Sha3_384_Free(&sha3);
     printf(resultFmt, ret == 0 ? passed : failed);
+
     if (ret == 0) {
         printf(testingFmt, "wc_Sha3_384_GetHash()");
 
@@ -5554,7 +5559,9 @@ static int test_wc_Sha3_512_Final (void)
             ret = WOLFSSL_FATAL_ERROR;
         }
     }
+    wc_Sha3_512_Free(&sha3);
     printf(resultFmt, ret == 0 ? passed : failed);
+
     if (ret == 0) {
         printf(testingFmt, "wc_Sha3_512_GetHash()");
 
@@ -15390,6 +15397,8 @@ static int test_wc_HashInit(void)
             ret = 1;
             break;
         }
+        wc_HashFree(&hash, enumArray[i]);
+
         /* check for null ptr */
         if (wc_HashInit(NULL, enumArray[i]) != BAD_FUNC_ARG) {
             ret = 1;

--- a/tests/api.c
+++ b/tests/api.c
@@ -20148,6 +20148,9 @@ static int test_ForceZero(void)
     unsigned char data[32];
     unsigned int i, j, len;
 
+    /* Test case with 0 length */
+    ForceZero(data, 0);
+
     /* Test ForceZero */
     for (i = 0; i < sizeof(data); i++) {
         for (len = 1; len < sizeof(data) - i; len++) {

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -9539,36 +9539,24 @@ int wc_X963_KDF(enum wc_HashType type, const byte* secret, word32 secretSz,
 
         ret = wc_HashUpdate(hash, type, secret, secretSz);
         if (ret != 0) {
-#ifdef WOLFSSL_SMALL_STACK
-            XFREE(hash, NULL, DYNAMIC_TYPE_HASHES);
-#endif
-            return ret;
+            break;
         }
 
         ret = wc_HashUpdate(hash, type, counter, sizeof(counter));
         if (ret != 0) {
-#ifdef WOLFSSL_SMALL_STACK
-            XFREE(hash, NULL, DYNAMIC_TYPE_HASHES);
-#endif
-            return ret;
+            break;
         }
 
         if (sinfo) {
             ret = wc_HashUpdate(hash, type, sinfo, sinfoSz);
             if (ret != 0) {
-#ifdef WOLFSSL_SMALL_STACK
-                XFREE(hash, NULL, DYNAMIC_TYPE_HASHES);
-#endif
-                return ret;
+                break;
             }
         }
 
         ret = wc_HashFinal(hash, type, tmp);
         if (ret != 0) {
-#ifdef WOLFSSL_SMALL_STACK
-            XFREE(hash, NULL, DYNAMIC_TYPE_HASHES);
-#endif
-            return ret;
+            break;
         }
 
         copySz = min(remaining, digestSz);
@@ -9578,11 +9566,13 @@ int wc_X963_KDF(enum wc_HashType type, const byte* secret, word32 secretSz,
         outIdx += copySz;
     }
 
+    wc_HashFree(hash, type);
+
 #ifdef WOLFSSL_SMALL_STACK
      XFREE(hash, NULL, DYNAMIC_TYPE_HASHES);
 #endif
 
-    return 0;
+    return ret;
 }
 #endif /* HAVE_X963_KDF */
 

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -475,8 +475,7 @@ int wc_HashInit(wc_HashAlg* hash, enum wc_HashType type)
     switch (type) {
         case WC_HASH_TYPE_MD5:
 #ifndef NO_MD5
-            wc_InitMd5(&hash->md5);
-            ret = 0;
+            ret = wc_InitMd5(&hash->md5);
 #endif
             break;
         case WC_HASH_TYPE_SHA:
@@ -533,15 +532,12 @@ int wc_HashUpdate(wc_HashAlg* hash, enum wc_HashType type, const byte* data,
     switch (type) {
         case WC_HASH_TYPE_MD5:
 #ifndef NO_MD5
-            wc_Md5Update(&hash->md5, data, dataSz);
-            ret = 0;
+            ret = wc_Md5Update(&hash->md5, data, dataSz);
 #endif
             break;
         case WC_HASH_TYPE_SHA:
 #ifndef NO_SHA
             ret = wc_ShaUpdate(&hash->sha, data, dataSz);
-            if (ret != 0)
-                return ret;
 #endif
             break;
         case WC_HASH_TYPE_SHA224:
@@ -592,8 +588,7 @@ int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type, byte* out)
     switch (type) {
         case WC_HASH_TYPE_MD5:
 #ifndef NO_MD5
-            wc_Md5Final(&hash->md5, out);
-            ret = 0;
+            ret = wc_Md5Final(&hash->md5, out);
 #endif
             break;
         case WC_HASH_TYPE_SHA:
@@ -619,6 +614,68 @@ int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type, byte* out)
         case WC_HASH_TYPE_SHA512:
 #ifdef WOLFSSL_SHA512
             ret = wc_Sha512Final(&hash->sha512, out);
+#endif
+            break;
+
+        /* not supported */
+        case WC_HASH_TYPE_MD5_SHA:
+        case WC_HASH_TYPE_MD2:
+        case WC_HASH_TYPE_MD4:
+        case WC_HASH_TYPE_SHA3_224:
+        case WC_HASH_TYPE_SHA3_256:
+        case WC_HASH_TYPE_SHA3_384:
+        case WC_HASH_TYPE_SHA3_512:
+        case WC_HASH_TYPE_BLAKE2B:
+        case WC_HASH_TYPE_NONE:
+        default:
+            ret = BAD_FUNC_ARG;
+    };
+
+    return ret;
+}
+
+int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
+{
+    int ret = HASH_TYPE_E; /* Default to hash type error */
+
+    if (hash == NULL)
+        return BAD_FUNC_ARG;
+
+    switch (type) {
+        case WC_HASH_TYPE_MD5:
+#ifndef NO_MD5
+            wc_Md5Free(&hash->md5);
+            ret = 0;
+#endif
+            break;
+        case WC_HASH_TYPE_SHA:
+#ifndef NO_SHA
+            wc_ShaFree(&hash->sha);
+            ret = 0;
+#endif
+            break;
+        case WC_HASH_TYPE_SHA224:
+#ifdef WOLFSSL_SHA224
+            wc_Sha224Free(&hash->sha224);
+            ret = 0;
+#endif
+            break;
+        case WC_HASH_TYPE_SHA256:
+#ifndef NO_SHA256
+            wc_Sha256Free(&hash->sha256);
+            ret = 0;
+#endif
+            break;
+        case WC_HASH_TYPE_SHA384:
+#ifdef WOLFSSL_SHA384
+            wc_Sha384Free(&hash->sha384);
+            ret = 0;
+#endif
+            break;
+        case WC_HASH_TYPE_SHA512:
+#ifdef WOLFSSL_SHA512
+            wc_Sha512Free(&hash->sha512);
+            ret = 0;
 #endif
             break;
 

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -658,12 +658,17 @@ int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type, byte* out)
             return MEMORY_E;
     #endif
 
-        ret = wc_InitMd5(md5);
-        if (ret == 0) {
-            ret = wc_Md5Update(md5, data, len);
-            if (ret == 0) {
-                ret = wc_Md5Final(md5, hash);
+        if ((ret = wc_InitMd5(md5)) != 0) {
+            WOLFSSL_MSG("InitMd5 failed");
+        }
+        else {
+            if ((ret = wc_Md5Update(md5, data, len)) != 0) {
+                WOLFSSL_MSG("Md5Update failed");
             }
+            else if ((ret = wc_Md5Final(md5, hash)) != 0) {
+                WOLFSSL_MSG("Md5Final failed");
+            }
+            wc_Md5Free(md5);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -691,11 +696,16 @@ int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type, byte* out)
     #endif
 
         if ((ret = wc_InitSha(sha)) != 0) {
-            WOLFSSL_MSG("wc_InitSha failed");
+            WOLFSSL_MSG("InitSha failed");
         }
         else {
-            wc_ShaUpdate(sha, data, len);
-            wc_ShaFinal(sha, hash);
+            if ((ret = wc_ShaUpdate(sha, data, len)) != 0) {
+                WOLFSSL_MSG("ShaUpdate failed");
+            }
+            else if ((ret = wc_ShaFinal(sha, hash)) != 0) {
+                WOLFSSL_MSG("ShaFinal failed");
+            }
+            wc_ShaFree(sha);
         }
 
     #ifdef WOLFSSL_SMALL_STACK

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -296,6 +296,11 @@ int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
         return BAD_FUNC_ARG;
     }
 
+    /* if set key has already been run then make sure and free existing */
+    if (hmac->macType != 0) {
+        wc_HmacFree(hmac);
+    }
+
     hmac->innerHashKeyed = 0;
     hmac->macType = (byte)type;
 

--- a/wolfcrypt/src/md5.c
+++ b/wolfcrypt/src/md5.c
@@ -399,6 +399,10 @@ void wc_Md5Free(wc_Md5* md5)
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_MD5)
     wolfAsync_DevCtxFree(&md5->asyncDev, WOLFSSL_ASYNC_MARKER_MD5);
 #endif /* WOLFSSL_ASYNC_CRYPT */
+
+#ifdef WOLFSSL_PIC32MZ_HASH
+    wc_Md5Pic32Free(md5);
+#endif
 }
 
 int wc_Md5GetHash(wc_Md5* md5, byte* hash)

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -142,6 +142,8 @@ int wc_PBKDF1_ex(byte* key, int keyLen, byte* iv, int ivLen,
         }
     }
 
+    wc_HashFree(hash, hashT);
+
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(hash, heap, DYNAMIC_TYPE_HASHCTX);
 #endif
@@ -307,6 +309,8 @@ static int DoPKCS12Hash(int hashType, byte* buffer, word32 totalLen,
         if (ret == 0)
             ret = wc_HashFinal(hash, hashT, Ai);
     }
+
+    wc_HashFree(hash, hashT);
 
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(hash, NULL, DYNAMIC_TYPE_HASHCTX);

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -553,6 +553,10 @@ void wc_ShaFree(wc_Sha* sha)
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA)
     wolfAsync_DevCtxFree(&sha->asyncDev, WOLFSSL_ASYNC_MARKER_SHA);
 #endif /* WOLFSSL_ASYNC_CRYPT */
+
+#ifdef WOLFSSL_PIC32MZ_HASH
+    wc_ShaPic32Free(sha);
+#endif
 }
 
 #endif /* !WOLFSSL_TI_HASH */

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -2707,6 +2707,10 @@ SHA256_NOINLINE static int Transform_Sha256_AVX2_RORX_Len(wc_Sha256* sha256,
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA224)
         wolfAsync_DevCtxFree(&sha224->asyncDev, WOLFSSL_ASYNC_MARKER_SHA224);
     #endif /* WOLFSSL_ASYNC_CRYPT */
+
+    #ifdef WOLFSSL_PIC32MZ_HASH
+        wc_Sha256Pic32Free(sha224);
+    #endif
     }
 #endif /* WOLFSSL_SHA224 */
 
@@ -2731,6 +2735,10 @@ void wc_Sha256Free(wc_Sha256* sha256)
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA256)
     wolfAsync_DevCtxFree(&sha256->asyncDev, WOLFSSL_ASYNC_MARKER_SHA256);
 #endif /* WOLFSSL_ASYNC_CRYPT */
+
+#ifdef WOLFSSL_PIC32MZ_HASH
+    wc_Sha256Pic32Free(sha256);
+#endif
 }
 
 #endif /* !WOLFSSL_TI_HASH */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2764,6 +2764,7 @@ int hash_test(void)
         ret = wc_HashFinal(&hash, typesBad[i], out);
         if (ret != BAD_FUNC_ARG)
             return -2927 - i;
+        wc_HashFree(&hash, typesBad[i]);
     }
 
     /* Try valid hash algorithms. */
@@ -2783,6 +2784,7 @@ int hash_test(void)
         ret = wc_HashFinal(&hash, typesGood[i], out);
         if (ret != exp_ret)
             return -2957 - i;
+        wc_HashFree(&hash, typesGood[i]);
 
         digestSz = wc_HashGetDigestSize(typesGood[i]);
         if (exp_ret < 0 && digestSz != exp_ret)

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -134,7 +134,7 @@ WOLFSSL_API int wc_HashUpdate(wc_HashAlg* hash, enum wc_HashType type,
     const byte* data, word32 dataSz);
 WOLFSSL_API int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type,
     byte* out);
-
+WOLFSSL_API int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type);
 
 #ifndef NO_MD5
 #include <wolfssl/wolfcrypt/md5.h>

--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -123,7 +123,7 @@
         mt->u.hint.thisSize   = sz;
         mt->u.hint.thisMemory = (byte*)mt + sizeof(memoryTrack);
 
-#ifdef WOLFSSL_DEBUG_MEMORY
+#ifdef WOLFSSL_DEBUG_MEMORY_PRINT
         printf("Alloc: %p -> %u at %s:%d\n", mt->u.hint.thisMemory, (word32)sz, func, line);
 #endif
 
@@ -159,7 +159,7 @@
         ourMemStats.totalDeallocs++;
 #endif
 
-#ifdef WOLFSSL_DEBUG_MEMORY
+#ifdef WOLFSSL_DEBUG_MEMORY_PRINT
         printf("Free: %p -> %u at %s:%d\n", ptr, (word32)mt->u.hint.thisSize, func, line);
 #endif
 

--- a/wolfssl/wolfcrypt/port/pic32/pic32mz-crypt.h
+++ b/wolfssl/wolfcrypt/port/pic32/pic32mz-crypt.h
@@ -52,7 +52,6 @@
 /* requires exclusive access to crypto hardware done at application layer */
 #define WOLFSSL_PIC32MZ_LARGE_HASH
 
-
 #include <xc.h>
 #include <sys/endian.h>
 #include <sys/kmem.h>
@@ -200,7 +199,21 @@ int wc_Pic32DesCrypt(word32 *key, int keyLen, word32 *iv, int ivLen,
 
 int wc_Pic32Hash(const byte* in, int inLen, word32* out, int outLen, int algo);
 int wc_Pic32HashCopy(hashUpdCache* src, hashUpdCache* dst);
+
+#ifndef NO_MD5
+struct wc_Md5;
+void wc_Md5Pic32Free(struct wc_Md5* md5);
 #endif
+#ifndef NO_SHA
+struct wc_Sha;
+void wc_ShaPic32Free(struct wc_Sha* sha);
+#endif
+
+#ifndef NO_SHA256
+struct wc_Sha256;
+void wc_Sha256Pic32Free(struct wc_Sha256* sha256);
+#endif
+#endif /* WOLFSSL_PIC32MZ_HASH */
 
 #endif /* WOLFSSL_MICROCHIP_PIC32MZ */
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -247,9 +247,15 @@
 #endif
 
 #ifdef WOLFSSL_MICROCHIP_PIC32MZ
-    #define WOLFSSL_PIC32MZ_CRYPT
-    #define WOLFSSL_PIC32MZ_RNG
-    #define WOLFSSL_PIC32MZ_HASH
+    #ifndef NO_PIC32MZ_CRYPT
+        #define WOLFSSL_PIC32MZ_CRYPT
+    #endif
+    #ifndef NO_PIC32MZ_RNG
+        #define WOLFSSL_PIC32MZ_RNG
+    #endif
+    #ifndef NO_PIC32MZ_HASH
+        #define WOLFSSL_PIC32MZ_HASH
+    #endif
 #endif
 
 #ifdef MICROCHIP_TCPIP_V5


### PR DESCRIPTION
* Fixes to make sure hash free is always called (resolves memory leaks with PIC32MZ hashing hardware). 
* Added code to make sure wc_*Free is called in all cases, which ensures the PIC32MZ hardware hashing cache is free'd.
* Added new defines to disable PIC32MZ hardware features using `NO_PIC32MZ_HASH`, `NO_PIC32MZ_RNG` and `NO_PIC32MZ_CRYPT`.
* Only print Alloc/Free messages with track memory when `WOLFSSL_DEBUG_MEMORY_PRINT` is defined. 
* Added test for ForceZero with 0 length.