### PR TITLE
New memory testing feature and fixes for null checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,4 @@ wolfcrypt/src/port/intel/qat_test
 
 # Arduino Generated Files
 /IDE/ARDUINO/wolfSSL
+scripts/memtest.txt

--- a/configure.ac
+++ b/configure.ac
@@ -4009,6 +4009,19 @@ then
 fi
 
 
+# Memory Tests
+AC_ARG_ENABLE([memtest],
+    [AS_HELP_STRING([--enable-memtest],[Memory testing option, for internal use (default: disabled)])],
+    [ ENABLED_MEMTEST=$enableval ],
+    [ ENABLED_MEMTEST=no ]
+    )
+
+if test "x$ENABLED_MEMTEST" != "xno"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_TRACK_MEMORY -DWOLFSSL_DEBUG_MEMORY -DWOLFSSL_FORCE_MALLOC_FAIL_TEST"
+fi
+
+
 # Default optimization CFLAGS enable
 AC_ARG_ENABLE([optflags],
     [AS_HELP_STRING([--enable-optflags],[Enable default optimization CFLAGS for the compiler (default: enabled)])],

--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -778,6 +778,7 @@ static void ShowCiphers(void)
 
 int bench_tls(void* args)
 {
+    int ret = 0;
     info_t *theadInfo, *info;
     int i, doShutdown;
     char *cipher, *next_cipher, ciphers[4096];
@@ -793,7 +794,8 @@ int bench_tls(void* args)
     int argThreadPairs = THREAD_PAIRS;
     int argShowVerbose = SHOW_VERBOSE;
 
-    ((func_args*)args)->return_code = -1; /* error state */
+    if (args)
+        ((func_args*)args)->return_code = -1; /* error state */
 
     /* Initialize wolfSSL */
     wolfSSL_Init();
@@ -803,7 +805,7 @@ int bench_tls(void* args)
         switch (ch) {
             case '?' :
                 Usage();
-                exit(EXIT_SUCCESS);
+                XEXIT(EXIT_SUCCESS);
 
             case 'b' :
                 argTestSizeBytes = atoi(myoptarg);
@@ -817,7 +819,7 @@ int bench_tls(void* args)
 
             case 'e' :
                 ShowCiphers();
-                exit(EXIT_SUCCESS);
+                XEXIT(EXIT_SUCCESS);
 
             case 'i' :
                 argShowPeerInfo = 1;
@@ -845,7 +847,7 @@ int bench_tls(void* args)
 
             default:
                 Usage();
-                exit(MY_EX_USAGE);
+                XEXIT(MY_EX_USAGE);
         }
     }
 
@@ -985,7 +987,10 @@ int bench_tls(void* args)
     free(theadInfo);
 
     /* Return reporting a success */
-    return (((func_args*)args)->return_code = 0);
+    if (args)
+        ((func_args*)args)->return_code = ret;
+
+    return ret;
 }
 #endif /* !NO_WOLFSSL_CLIENT && !NO_WOLFSSL_SERVER */
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -334,7 +334,7 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
                 benchSession = wolfSSL_get_session(ssl);
             }
     #endif
-            wolfSSL_free(ssl);
+            wolfSSL_free(ssl); ssl = NULL;
             CloseSocket(sockfd);
         }
         avg = current_time(0) - start;
@@ -512,7 +512,7 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
     }
 
     wolfSSL_shutdown(ssl);
-    wolfSSL_free(ssl);
+    wolfSSL_free(ssl); ssl = NULL;
     CloseSocket(sockfd);
 
     printf("wolfSSL Client Benchmark %d bytes\n"
@@ -1574,14 +1574,14 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
 #ifdef SINGLE_THREADED
     if (wolfSSL_CTX_new_rng(ctx) != WOLFSSL_SUCCESS) {
-        wolfSSL_CTX_free(ctx);
+        wolfSSL_CTX_free(ctx); ctx = NULL;
         err_sys("Single Threaded new rng at CTX failed");
     }
 #endif
 
     if (cipherList && !useDefCipherList) {
         if (wolfSSL_CTX_set_cipher_list(ctx, cipherList) != WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("client can't set cipher list 1");
         }
     }
@@ -1624,7 +1624,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         #endif
             if (wolfSSL_CTX_set_cipher_list(ctx,defaultCipherList)
                                                             !=WOLFSSL_SUCCESS) {
-                wolfSSL_CTX_free(ctx);
+                wolfSSL_CTX_free(ctx); ctx = NULL;
                 err_sys("client can't set cipher list 2");
             }
         }
@@ -1643,7 +1643,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                                 "ADH-AES128-SHA";
             if (wolfSSL_CTX_set_cipher_list(ctx,defaultCipherList)
                                                            != WOLFSSL_SUCCESS) {
-                wolfSSL_CTX_free(ctx);
+                wolfSSL_CTX_free(ctx); ctx = NULL;
                 err_sys("client can't set cipher list 4");
             }
         }
@@ -1666,7 +1666,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     if (cipherList == NULL) {
         /* don't use EDH, can't sniff tmp keys */
         if (wolfSSL_CTX_set_cipher_list(ctx, "AES128-SHA") != WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("client can't set cipher list 3");
         }
     }
@@ -1708,7 +1708,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     #ifndef NO_FILESYSTEM
         if (wolfSSL_CTX_use_certificate_chain_file(ctx, ourCert)
                                                            != WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("can't load client cert file, check file and run from"
                     " wolfSSL home dir");
         }
@@ -1725,7 +1725,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     #ifndef NO_FILESYSTEM
         if (wolfSSL_CTX_use_PrivateKey_file(ctx, ourKey, WOLFSSL_FILETYPE_PEM)
                                          != WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("can't load client private key file, check file and run "
                     "from wolfSSL home dir");
         }
@@ -1738,7 +1738,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     #if !defined(NO_FILESYSTEM)
         if (wolfSSL_CTX_load_verify_locations(ctx, verifyCert,0)
                                                            != WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("can't load ca file, Please run from wolfSSL home dir");
         }
     #else
@@ -1749,7 +1749,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         #ifndef NO_FILESYSTEM
         if (wolfSSL_CTX_load_verify_locations(ctx, eccCertFile, 0)
                                                            != WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("can't load ecc ca file, Please run from wolfSSL home dir");
         }
         #else
@@ -1760,7 +1760,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         if (trustCert) {
             if ((ret = wolfSSL_CTX_trust_peer_cert(ctx, trustCert,
                                     WOLFSSL_FILETYPE_PEM)) != WOLFSSL_SUCCESS) {
-                wolfSSL_CTX_free(ctx);
+                wolfSSL_CTX_free(ctx); ctx = NULL;
                 err_sys("can't load trusted peer cert file");
             }
         }
@@ -1786,34 +1786,34 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     if (sniHostName)
         if (wolfSSL_CTX_UseSNI(ctx, 0, sniHostName,
                     (word16) XSTRLEN(sniHostName)) != WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("UseSNI failed");
     }
 #endif
 #ifdef HAVE_MAX_FRAGMENT
     if (maxFragment)
         if (wolfSSL_CTX_UseMaxFragment(ctx, maxFragment) != WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("UseMaxFragment failed");
         }
 #endif
 #ifdef HAVE_TRUNCATED_HMAC
     if (truncatedHMAC)
         if (wolfSSL_CTX_UseTruncatedHMAC(ctx) != WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("UseTruncatedHMAC failed");
         }
 #endif
 #ifdef HAVE_SESSION_TICKET
     if (wolfSSL_CTX_UseSessionTicket(ctx) != WOLFSSL_SUCCESS) {
-        wolfSSL_CTX_free(ctx);
+        wolfSSL_CTX_free(ctx); ctx = NULL;
         err_sys("UseSessionTicket failed");
     }
 #endif
 #ifdef HAVE_EXTENDED_MASTER
     if (disableExtMasterSecret)
         if (wolfSSL_CTX_DisableExtendedMasterSecret(ctx) != WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("DisableExtendedMasterSecret failed");
         }
 #endif
@@ -1848,7 +1848,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             ClientBenchmarkConnections(ctx, host, port, dtlsUDP, dtlsSCTP,
                                        benchmark, resumeSession, useX25519,
                                        helloRetry, onlyKeyShare, version);
-        wolfSSL_CTX_free(ctx);
+        wolfSSL_CTX_free(ctx); ctx = NULL;
         XEXIT_T(EXIT_SUCCESS);
     }
 
@@ -1856,7 +1856,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         ((func_args*)args)->return_code =
             ClientBenchmarkThroughput(ctx, host, port, dtlsUDP, dtlsSCTP,
                                       block, throughput, useX25519);
-        wolfSSL_CTX_free(ctx);
+        wolfSSL_CTX_free(ctx); ctx = NULL;
         XEXIT_T(EXIT_SUCCESS);
     }
 
@@ -1866,11 +1866,11 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     #if defined(OPENSSL_EXTRA)
     if (wolfSSL_CTX_get_read_ahead(ctx) != 0) {
-        wolfSSL_CTX_free(ctx);
+        wolfSSL_CTX_free(ctx); ctx = NULL;
         err_sys("bad read ahead default value");
     }
     if (wolfSSL_CTX_set_read_ahead(ctx, 1) != WOLFSSL_SUCCESS) {
-        wolfSSL_CTX_free(ctx);
+        wolfSSL_CTX_free(ctx); ctx = NULL;
         err_sys("error setting read ahead value");
     }
     #endif
@@ -1888,7 +1888,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         wolfSSL_CTX_mcast_set_member_id(ctx, mcastID);
         if (wolfSSL_CTX_set_cipher_list(ctx, "WDM-NULL-SHA256")
                                                            != WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("Couldn't set multicast cipher list.");
         }
 #endif
@@ -1901,7 +1901,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     ssl = wolfSSL_new(ctx);
     if (ssl == NULL) {
-        wolfSSL_CTX_free(ctx);
+        wolfSSL_CTX_free(ctx); ctx = NULL;
         err_sys("unable to get SSL object");
     }
 
@@ -1970,7 +1970,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
         if (wolfSSL_set_secret(ssl, 1, pms, sizeof(pms), cr, sr, suite)
                                                            != WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("unable to set mcast secret");
         }
 #endif
@@ -1995,8 +1995,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             case WOLFSSL_CSR_OCSP:
                 if (wolfSSL_UseOCSPStapling(ssl, WOLFSSL_CSR_OCSP,
                                WOLFSSL_CSR_OCSP_USE_NONCE) != WOLFSSL_SUCCESS) {
-                    wolfSSL_free(ssl);
-                    wolfSSL_CTX_free(ctx);
+                    wolfSSL_free(ssl); ssl = NULL;
+                    wolfSSL_CTX_free(ctx); ctx = NULL;
                     err_sys("UseCertificateStatusRequest failed");
                 }
 
@@ -2016,8 +2016,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 if (wolfSSL_UseOCSPStaplingV2(ssl,
                     WOLFSSL_CSR2_OCSP, WOLFSSL_CSR2_OCSP_USE_NONCE)
                                                            != WOLFSSL_SUCCESS) {
-                    wolfSSL_free(ssl);
-                    wolfSSL_CTX_free(ctx);
+                    wolfSSL_free(ssl); ssl = NULL;
+                    wolfSSL_CTX_free(ctx); ctx = NULL;
                     err_sys("UseCertificateStatusRequest failed");
                 }
             break;
@@ -2025,8 +2025,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 if (wolfSSL_UseOCSPStaplingV2(ssl,
                     WOLFSSL_CSR2_OCSP_MULTI, 0)
                                                            != WOLFSSL_SUCCESS) {
-                    wolfSSL_free(ssl);
-                    wolfSSL_CTX_free(ctx);
+                    wolfSSL_free(ssl); ssl = NULL;
+                    wolfSSL_CTX_free(ctx); ctx = NULL;
                     err_sys("UseCertificateStatusRequest failed");
                 }
             break;
@@ -2039,16 +2039,16 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     tcp_connect(&sockfd, host, port, dtlsUDP, dtlsSCTP, ssl);
     if (wolfSSL_set_fd(ssl, sockfd) != WOLFSSL_SUCCESS) {
-        wolfSSL_free(ssl);
-        wolfSSL_CTX_free(ctx);
+        wolfSSL_free(ssl); ssl = NULL;
+        wolfSSL_CTX_free(ctx); ctx = NULL;
         err_sys("error in setting fd");
     }
 
     /* STARTTLS */
     if (doSTARTTLS) {
         if (StartTLS_Init(&sockfd) != WOLFSSL_SUCCESS) {
-            wolfSSL_free(ssl);
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_free(ssl); ssl = NULL;
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("error during STARTTLS protocol");
         }
     }
@@ -2060,19 +2060,19 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     #endif
 
         if (wolfSSL_EnableCRL(ssl, WOLFSSL_CRL_CHECKALL) != WOLFSSL_SUCCESS) {
-            wolfSSL_free(ssl);
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_free(ssl); ssl = NULL;
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("can't enable crl check");
         }
         if (wolfSSL_LoadCRL(ssl, crlPemDir, WOLFSSL_FILETYPE_PEM, 0)
                                                            != WOLFSSL_SUCCESS) {
-            wolfSSL_free(ssl);
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_free(ssl); ssl = NULL;
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("can't load crl, check crlfile and date validity");
         }
         if (wolfSSL_SetCRL_Cb(ssl, CRL_CallBack) != WOLFSSL_SUCCESS) {
-            wolfSSL_free(ssl);
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_free(ssl); ssl = NULL;
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("can't set crl callback");
         }
     }
@@ -2080,8 +2080,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #ifdef HAVE_SECURE_RENEGOTIATION
     if (scr) {
         if (wolfSSL_UseSecureRenegotiation(ssl) != WOLFSSL_SUCCESS) {
-            wolfSSL_free(ssl);
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_free(ssl); ssl = NULL;
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("can't enable secure renegotiation");
         }
     }
@@ -2132,8 +2132,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             wolfSSL_ERR_error_string(err, buffer));
 
         /* cleanup */
-        wolfSSL_free(ssl);
-        wolfSSL_CTX_free(ctx);
+        wolfSSL_free(ssl); ssl = NULL;
+        wolfSSL_CTX_free(ctx); ctx = NULL;
         CloseSocket(sockfd);
 
         if (!exitWithRet)
@@ -2156,23 +2156,23 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         /* get size of buffer then print */
         size = wolfSSL_get_client_random(NULL, NULL, 0);
         if (size == 0) {
-            wolfSSL_free(ssl);
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_free(ssl); ssl = NULL;
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("error getting client random buffer size");
         }
 
         rnd = (byte*)XMALLOC(size, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (rnd == NULL) {
-            wolfSSL_free(ssl);
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_free(ssl); ssl = NULL;
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("error creating client random buffer");
         }
 
         size = wolfSSL_get_client_random(ssl, rnd, size);
         if (size == 0) {
             XFREE(rnd, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-            wolfSSL_free(ssl);
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_free(ssl); ssl = NULL;
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("error getting client random buffer");
         }
 
@@ -2186,16 +2186,16 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     if (doSTARTTLS) {
         if (XSTRNCMP(starttlsProt, "smtp", 4) == 0) {
             if (SMTP_Shutdown(ssl, wc_shutdown) != WOLFSSL_SUCCESS) {
-                wolfSSL_free(ssl);
-                wolfSSL_CTX_free(ctx);
+                wolfSSL_free(ssl); ssl = NULL;
+                wolfSSL_CTX_free(ctx); ctx = NULL;
                 err_sys("error closing STARTTLS connection");
             }
         }
 
-        wolfSSL_free(ssl);
+        wolfSSL_free(ssl); ssl = NULL;
         CloseSocket(sockfd);
 
-        wolfSSL_CTX_free(ctx);
+        wolfSSL_CTX_free(ctx); ctx = NULL;
 
         ((func_args*)args)->return_code = 0;
         return 0;
@@ -2227,8 +2227,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 err = wolfSSL_get_error(ssl, 0);
                 printf("err = %d, %s\n", err,
                                 wolfSSL_ERR_error_string(err, buffer));
-                wolfSSL_free(ssl);
-                wolfSSL_CTX_free(ctx);
+                wolfSSL_free(ssl); ssl = NULL;
+                wolfSSL_CTX_free(ctx); ctx = NULL;
                 err_sys("wolfSSL_Rehandshake failed");
             }
         }
@@ -2305,14 +2305,14 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     fprintf(stderr, "total connection frees    = %d\n\n", ssl_stats.totalFr);
 #endif
 
-    wolfSSL_free(ssl);
+    wolfSSL_free(ssl); ssl = NULL;
     CloseSocket(sockfd);
 
 #ifndef NO_SESSION_CACHE
     if (resumeSession) {
         sslResume = wolfSSL_new(ctx);
         if (sslResume == NULL) {
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("unable to get SSL object");
         }
 
@@ -2327,8 +2327,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         }
         tcp_connect(&sockfd, host, port, dtlsUDP, dtlsSCTP, sslResume);
         if (wolfSSL_set_fd(sslResume, sockfd) != WOLFSSL_SUCCESS) {
-            wolfSSL_free(sslResume);
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_free(sslResume); sslResume = NULL;
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("error in setting fd");
         }
 #ifdef HAVE_ALPN
@@ -2341,8 +2341,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #ifdef HAVE_SECURE_RENEGOTIATION
         if (scr) {
             if (wolfSSL_UseSecureRenegotiation(sslResume) != WOLFSSL_SUCCESS) {
-                wolfSSL_free(sslResume);
-                wolfSSL_CTX_free(ctx);
+                wolfSSL_free(sslResume); sslResume = NULL;
+                wolfSSL_CTX_free(ctx); ctx = NULL;
                 err_sys("can't enable secure renegotiation");
             }
         }
@@ -2389,8 +2389,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 if (ret != msgSz) {
                     printf("SSL_write_early_data msg error %d, %s\n", err,
                                          wolfSSL_ERR_error_string(err, buffer));
-                    wolfSSL_free(sslResume);
-                    wolfSSL_CTX_free(ctx);
+                    wolfSSL_free(sslResume); sslResume = NULL;
+                    wolfSSL_CTX_free(ctx); ctx = NULL;
                     err_sys("SSL_write_early_data failed");
                 }
                 do {
@@ -2411,8 +2411,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 if (ret != msgSz) {
                     printf("SSL_write_early_data msg error %d, %s\n", err,
                                          wolfSSL_ERR_error_string(err, buffer));
-                    wolfSSL_free(sslResume);
-                    wolfSSL_CTX_free(ctx);
+                    wolfSSL_free(sslResume); sslResume = NULL;
+                    wolfSSL_CTX_free(ctx); ctx = NULL;
                     err_sys("SSL_write_early_data failed");
                 }
             }
@@ -2440,8 +2440,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         if (ret != WOLFSSL_SUCCESS) {
             printf("wolfSSL_connect resume error %d, %s\n", err,
                 wolfSSL_ERR_error_string(err, buffer));
-            wolfSSL_free(sslResume);
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_free(sslResume); sslResume = NULL;
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("wolfSSL_connect resume failed");
         }
 
@@ -2497,8 +2497,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         if (ret != resumeSz) {
             printf("SSL_write resume error %d, %s\n", err,
                     wolfSSL_ERR_error_string(err, buffer));
-            wolfSSL_free(sslResume);
-            wolfSSL_CTX_free(ctx);
+            wolfSSL_free(sslResume); sslResume = NULL;
+            wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("SSL_write failed");
         }
 
@@ -2559,8 +2559,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             if (err != WOLFSSL_ERROR_WANT_READ) {
                 printf("SSL_read resume error %d, %s\n", err,
                     wolfSSL_ERR_error_string(err, buffer));
-                wolfSSL_free(sslResume);
-                wolfSSL_CTX_free(ctx);
+                wolfSSL_free(sslResume); sslResume = NULL;
+                wolfSSL_CTX_free(ctx); ctx = NULL;
                 err_sys("SSL_read failed");
             }
         }
@@ -2599,12 +2599,12 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         fprintf(stderr, "total connection frees    = %d\n\n", ssl_stats.totalFr);
     #endif
 
-        wolfSSL_free(sslResume);
+        wolfSSL_free(sslResume); sslResume = NULL;
         CloseSocket(sockfd);
     }
 #endif /* NO_SESSION_CACHE */
 
-    wolfSSL_CTX_free(ctx);
+    wolfSSL_CTX_free(ctx); ctx = NULL;
 
     ((func_args*)args)->return_code = 0;
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1019,7 +1019,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         switch (ch) {
             case '?' :
                 Usage();
-                exit(EXIT_SUCCESS);
+                XEXIT_T(EXIT_SUCCESS);
 
             case 'g' :
                 sendGET = 1;
@@ -1031,7 +1031,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
             case 'e' :
                 ShowCiphers();
-                exit(EXIT_SUCCESS);
+                XEXIT_T(EXIT_SUCCESS);
 
             case 'D' :
                 overrideDateErrors = 1;
@@ -1114,13 +1114,13 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 version = atoi(myoptarg);
                 if (version < 0 || version > 4) {
                     Usage();
-                    exit(MY_EX_USAGE);
+                    XEXIT_T(MY_EX_USAGE);
                 }
                 break;
 
             case 'V' :
                 ShowVersions();
-                exit(EXIT_SUCCESS);
+                XEXIT_T(EXIT_SUCCESS);
 
             case 'l' :
                 cipherList = myoptarg;
@@ -1137,7 +1137,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 }
                 else {
                     Usage();
-                    exit(MY_EX_USAGE);
+                    XEXIT_T(MY_EX_USAGE);
                 }
                 break;
 
@@ -1158,7 +1158,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                     minDhKeyBits = atoi(myoptarg);
                     if (minDhKeyBits <= 0 || minDhKeyBits > 16000) {
                         Usage();
-                        exit(MY_EX_USAGE);
+                        XEXIT_T(MY_EX_USAGE);
                     }
                 #endif
                 break;
@@ -1167,7 +1167,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 benchmark = atoi(myoptarg);
                 if (benchmark < 0 || benchmark > 1000000) {
                     Usage();
-                    exit(MY_EX_USAGE);
+                    XEXIT_T(MY_EX_USAGE);
                 }
                 break;
 
@@ -1181,7 +1181,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 }
                 if (throughput <= 0 || block <= 0) {
                     Usage();
-                    exit(MY_EX_USAGE);
+                    XEXIT_T(MY_EX_USAGE);
                 }
                 break;
 
@@ -1228,7 +1228,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                     if (maxFragment < WOLFSSL_MFL_2_9 ||
                                                maxFragment > WOLFSSL_MFL_2_13) {
                         Usage();
-                        exit(MY_EX_USAGE);
+                        XEXIT_T(MY_EX_USAGE);
                     }
                 #endif
                 break;
@@ -1281,7 +1281,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                         alpn_opt = WOLFSSL_ALPN_FAILED_ON_MISMATCH;
                     else {
                         Usage();
-                        exit(MY_EX_USAGE);
+                        XEXIT_T(MY_EX_USAGE);
                     }
 
                     alpnList += 2;
@@ -1295,7 +1295,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
                 if (XSTRNCMP(starttlsProt, "smtp", 4) != 0) {
                     Usage();
-                    exit(MY_EX_USAGE);
+                    XEXIT_T(MY_EX_USAGE);
                 }
 
                 break;
@@ -1371,7 +1371,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
             default:
                 Usage();
-                exit(MY_EX_USAGE);
+                XEXIT_T(MY_EX_USAGE);
         }
     }
 
@@ -1457,7 +1457,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             printf("external test can't be run in this mode");
 
             ((func_args*)args)->return_code = 0;
-            exit(EXIT_SUCCESS);
+            XEXIT_T(EXIT_SUCCESS);
         }
     }
 
@@ -1849,7 +1849,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                                        benchmark, resumeSession, useX25519,
                                        helloRetry, onlyKeyShare, version);
         wolfSSL_CTX_free(ctx);
-        exit(EXIT_SUCCESS);
+        XEXIT_T(EXIT_SUCCESS);
     }
 
     if(throughput) {
@@ -1857,7 +1857,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             ClientBenchmarkThroughput(ctx, host, port, dtlsUDP, dtlsSCTP,
                                       block, throughput, useX25519);
         wolfSSL_CTX_free(ctx);
-        exit(EXIT_SUCCESS);
+        XEXIT_T(EXIT_SUCCESS);
     }
 
     #if defined(WOLFSSL_MDK_ARM)

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1512,8 +1512,8 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             printf("SSL_accept error %d, %s\n", err,
                                                 ERR_error_string(err, buffer));
             /* cleanup */
-            SSL_free(ssl);
-            SSL_CTX_free(ctx);
+            SSL_free(ssl); ssl = NULL;
+            SSL_CTX_free(ctx); ctx = NULL;
             CloseSocket(clientfd);
             CloseSocket(sockfd);
 
@@ -1679,7 +1679,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         fprintf(stderr, "total connection frees    = %d\n\n", ssl_stats.totalFr);
 
 #endif
-        SSL_free(ssl);
+        SSL_free(ssl); ssl = NULL;
 
         CloseSocket(clientfd);
 
@@ -1704,7 +1704,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 #endif
 
     CloseSocket(sockfd);
-    SSL_CTX_free(ctx);
+    SSL_CTX_free(ctx); ctx = NULL;
 
     ((func_args*)args)->return_code = 0;
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -621,7 +621,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         switch (ch) {
             case '?' :
                 Usage();
-                exit(EXIT_SUCCESS);
+                XEXIT_T(EXIT_SUCCESS);
 
             case 'x' :
                 runWithErrors = 1;
@@ -701,7 +701,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 version = atoi(myoptarg);
                 if (version < 0 || version > 4) {
                     Usage();
-                    exit(MY_EX_USAGE);
+                    XEXIT_T(MY_EX_USAGE);
                 }
                 break;
 
@@ -720,7 +720,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 }
                 else {
                     Usage();
-                    exit(MY_EX_USAGE);
+                    XEXIT_T(MY_EX_USAGE);
                 }
                 break;
 
@@ -747,7 +747,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                     minDhKeyBits = atoi(myoptarg);
                     if (minDhKeyBits <= 0 || minDhKeyBits > 16000) {
                         Usage();
-                        exit(MY_EX_USAGE);
+                        XEXIT_T(MY_EX_USAGE);
                     }
                 #endif
                 break;
@@ -796,7 +796,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                         alpn_opt = WOLFSSL_ALPN_FAILED_ON_MISMATCH;
                     else {
                         Usage();
-                        exit(MY_EX_USAGE);
+                        XEXIT_T(MY_EX_USAGE);
                     }
 
                     alpnList += 2;
@@ -812,7 +812,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 loops = atoi(myoptarg);
                 if (loops <= 0) {
                     Usage();
-                    exit(MY_EX_USAGE);
+                    XEXIT_T(MY_EX_USAGE);
                 }
                 break;
 
@@ -830,7 +830,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 }
                 if (throughput <= 0 || block <= 0) {
                     Usage();
-                    exit(MY_EX_USAGE);
+                    XEXIT_T(MY_EX_USAGE);
                 }
                 break;
 
@@ -917,7 +917,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 
             default:
                 Usage();
-                exit(MY_EX_USAGE);
+                XEXIT_T(MY_EX_USAGE);
         }
     }
 

--- a/scripts/include.am
+++ b/scripts/include.am
@@ -13,6 +13,7 @@ if BUILD_EXAMPLE_SERVERS
 dist_noinst_SCRIPTS+= scripts/resume.test
 
 EXTRA_DIST+= scripts/benchmark.test
+EXTRA_DIST+= scripts/memtest.sh
 
 if BUILD_CRL
 # make revoked test rely on completion of resume test

--- a/scripts/memtest.sh
+++ b/scripts/memtest.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Run this script from the wolfSSL root as `./scripts/memtest.sh`.
+
+./autogen.sh
+./configure --enable-debug --disable-shared --enable-memtest \
+	--enable-opensslextra --enable-des3 --enable-dh --enable-ecc --enable-aesgcm --enable-aesccm --enable-hc128 \
+	--enable-sniffer --enable-psk --enable-rabbit --enable-camellia --enable-sha512 --enable-crl --enable-ocsp --enable-savesession \
+	--enable-savecert --enable-atomicuser --enable-pkcallbacks --enable-scep;
+
+	#DTLS has issue with trapping client/server failure disconnect since its stateless. Need to find way to communicate failure through file system.
+	#--enable-dtls
+make
+
+for i in {1..1000}
+do
+    echo "Trying $i...\n"
+
+ 	./tests/unit.test > ./scripts/memtest.txt 2>&1
+
+ 	RESULT=$?
+ 	[ $RESULT -eq 139 ] && echo "Mem Seg Fault" && exit 1
+done
+echo "Loop SUCCESS"

--- a/src/internal.c
+++ b/src/internal.c
@@ -1502,18 +1502,24 @@ void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
 #endif /* HAVE_WOLF_EVENT */
 
     XFREE(ctx->method, ctx->heap, DYNAMIC_TYPE_METHOD);
-    if (ctx->suites)
+    ctx->method = NULL;
+    if (ctx->suites) {
         XFREE(ctx->suites, ctx->heap, DYNAMIC_TYPE_SUITES);
+        ctx->suites = NULL;
+    }
 
 #ifndef NO_DH
     XFREE(ctx->serverDH_G.buffer, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+    ctx->serverDH_G.buffer = NULL;
     XFREE(ctx->serverDH_P.buffer, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+    ctx->serverDH_P.buffer = NULL;
 #endif /* !NO_DH */
 
 #ifdef SINGLE_THREADED
     if (ctx->rng) {
         wc_FreeRng(ctx->rng);
         XFREE(ctx->rng, ctx->heap, DYNAMIC_TYPE_RNG);
+        ctx->rng = NULL;
     }
 #endif /* SINGLE_THREADED */
 
@@ -1524,10 +1530,12 @@ void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
         if (ctx->ourCert && ctx->ownOurCert) {
             FreeX509(ctx->ourCert);
             XFREE(ctx->ourCert, ctx->heap, DYNAMIC_TYPE_X509);
+            ctx->ourCert = NULL;
         }
     #endif /* KEEP_OUR_CERT */
     FreeDer(&ctx->certChain);
     wolfSSL_CertManagerFree(ctx->cm);
+    ctx->cm = NULL;
     #ifdef OPENSSL_EXTRA
 	/* ctx->cm was free'd so cm of x509 store should now be NULL */
         if (ctx->x509_store_pt != NULL) {
@@ -1568,6 +1576,7 @@ void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
         if (ctx->chainOcspRequest[i]) {
             FreeOcspRequest(ctx->chainOcspRequest[i]);
             XFREE(ctx->chainOcspRequest[i], ctx->heap, DYNAMIC_TYPE_OCSP_REQUEST);
+            ctx->chainOcspRequest[i] = NULL;
         }
     }
 #endif /* HAVE_CERTIFICATE_STATUS_REQUEST_V2 */
@@ -1575,8 +1584,10 @@ void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
 
 #endif /* HAVE_TLS_EXTENSIONS */
 #ifdef OPENSSL_EXTRA
-    if(ctx->alpn_cli_protos)
+    if(ctx->alpn_cli_protos) {
         XFREE((void *)ctx->alpn_cli_protos, NULL, DYNAMIC_TYPE_OPENSSL);
+        ctx->alpn_cli_protos = NULL;
+    }
 #endif
 #ifdef WOLFSSL_STATIC_MEMORY
     if (ctx->heap != NULL) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -1349,6 +1349,10 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
     port = wolfSSLPort;
 #endif
 
+    /* do it here to detect failure */
+    tcp_accept(&sockfd, &clientfd, (func_args*)args, port, 0, 0, 0, 0, 1);
+    CloseSocket(sockfd);
+
     wolfSSL_CTX_set_verify(ctx,
                           WOLFSSL_VERIFY_PEER | WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT, 0);
 
@@ -1382,8 +1386,6 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
     }
 
     ssl = wolfSSL_new(ctx);
-    tcp_accept(&sockfd, &clientfd, (func_args*)args, port, 0, 0, 0, 0, 1);
-    CloseSocket(sockfd);
 
     if (wolfSSL_set_fd(ssl, clientfd) != WOLFSSL_SUCCESS) {
         /*err_sys("SSL_set_fd failed");*/
@@ -1506,6 +1508,10 @@ static void test_client_nofail(void* args, void *cb)
     wolfSSL_CTX_set_default_passwd_cb(ctx, PasswordCallBack);
 #endif
 
+    /* Do connect here so server detects failures */
+    tcp_connect(&sockfd, wolfSSLIP, ((func_args*)args)->signal->port,
+                0, 0, NULL);
+
     if (wolfSSL_CTX_load_verify_locations(ctx, caCertFile, 0) != WOLFSSL_SUCCESS)
     {
         /* err_sys("can't load ca file, Please run from wolfSSL home dir");*/
@@ -1532,8 +1538,6 @@ static void test_client_nofail(void* args, void *cb)
     }
 
     ssl = wolfSSL_new(ctx);
-    tcp_connect(&sockfd, wolfSSLIP, ((func_args*)args)->signal->port,
-                0, 0, ssl);
     if (wolfSSL_set_fd(ssl, sockfd) != WOLFSSL_SUCCESS) {
         /*err_sys("SSL_set_fd failed");*/
         goto done2;

--- a/tests/api.c
+++ b/tests/api.c
@@ -1051,7 +1051,6 @@ static int test_wolfSSL_SetMinVersion(void)
         const int versions[]  =  { WOLFSSL_TLSV1_3 };
     #endif
 
-    AssertTrue(wolfSSL_Init());
     #ifndef WOLFSSL_NO_TLS12
         ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
     #else
@@ -1071,7 +1070,6 @@ static int test_wolfSSL_SetMinVersion(void)
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
-    AssertTrue(wolfSSL_Cleanup());
 #endif
     return failFlag;
 
@@ -3100,9 +3098,6 @@ static void test_wolfSSL_PKCS8(void)
     bytes = (int)fread(buffer, 1, sizeof(buffer), f);
     fclose(f);
 
-    /* Note that wolfSSL_Init() or wolfCrypt_Init() has been called before these
-     * function calls */
-
 #ifndef NO_WOLFSSL_CLIENT
     #ifndef WOLFSSL_NO_TLS12
         AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method()));
@@ -3210,7 +3205,6 @@ static int test_wolfSSL_CTX_SetMinVersion(void)
 
     failFlag = WOLFSSL_SUCCESS;
 
-    AssertTrue(wolfSSL_Init());
 #ifndef WOLFSSL_NO_TLS12
     ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
 #else
@@ -3228,7 +3222,6 @@ static int test_wolfSSL_CTX_SetMinVersion(void)
     printf(resultFmt, failFlag == WOLFSSL_SUCCESS ? passed : failed);
 
     wolfSSL_CTX_free(ctx);
-    AssertTrue(wolfSSL_Cleanup());
 #endif
     return failFlag;
 
@@ -3253,7 +3246,6 @@ static int test_wolfSSL_UseOCSPStapling(void)
         WOLFSSL_CTX*    ctx;
         WOLFSSL*        ssl;
 
-        wolfSSL_Init();
 #ifndef NO_WOLFSSL_CLIENT
     #ifndef WOLFSSL_NO_TLS12
         ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
@@ -3279,12 +3271,7 @@ static int test_wolfSSL_UseOCSPStapling(void)
         wolfSSL_free(ssl);
         wolfSSL_CTX_free(ctx);
 
-        if(ret != WOLFSSL_SUCCESS){
-            wolfSSL_Cleanup();
-            return WOLFSSL_FAILURE;
-        }
-
-        return wolfSSL_Cleanup();
+        return ret;
     #else
         return WOLFSSL_SUCCESS;
     #endif
@@ -3305,7 +3292,6 @@ static int test_wolfSSL_UseOCSPStaplingV2 (void)
         WOLFSSL_CTX*        ctx;
         WOLFSSL*            ssl;
 
-        wolfSSL_Init();
 #ifndef NO_WOLFSSL_CLIENT
     #ifndef WOLFSSL_NO_TLS12
         ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method());
@@ -3330,12 +3316,7 @@ static int test_wolfSSL_UseOCSPStaplingV2 (void)
         wolfSSL_free(ssl);
         wolfSSL_CTX_free(ctx);
 
-        if (ret != WOLFSSL_SUCCESS){
-            wolfSSL_Cleanup();
-            return WOLFSSL_FAILURE;
-        }
-
-        return wolfSSL_Cleanup();
+        return ret;
     #else
         return WOLFSSL_SUCCESS;
     #endif
@@ -18941,7 +18922,6 @@ static void test_wolfSSL_OPENSSL_add_all_algorithms(void){
     printf(testingFmt, "wolfSSL_OPENSSL_add_all_algorithms()");
 
     AssertIntEQ(wolfSSL_OPENSSL_add_all_algorithms_noconf(),WOLFSSL_SUCCESS);
-    wolfSSL_Cleanup();
 
     printf(resultFmt, passed);
 #endif
@@ -20393,8 +20373,6 @@ void ApiTest(void)
     /* test the no op functions for compatibility */
     test_no_op_functions();
 
-    AssertIntEQ(test_wolfSSL_Cleanup(), WOLFSSL_SUCCESS);
-
     /* wolfCrypt ASN tests */
     test_wc_GetPkcs8TraditionalOffset();
 
@@ -20603,6 +20581,8 @@ void ApiTest(void)
     test_wc_PKCS7_EncodeEncryptedData();
 
     AssertIntEQ(test_ForceZero(), 0);
+
+    AssertIntEQ(test_wolfSSL_Cleanup(), WOLFSSL_SUCCESS);
 
     printf(" End API Tests\n");
 

--- a/tests/srp.c
+++ b/tests/srp.c
@@ -817,6 +817,7 @@ static void test_SrpKeyGenFunc_cb(void)
 void SrpTest(void)
 {
 #if defined(WOLFCRYPT_HAVE_SRP) && defined(WOLFSSL_SHA512)
+    wolfCrypt_Init();
     test_SrpInit();
     test_SrpSetUsername();
     test_SrpSetParams();
@@ -825,5 +826,6 @@ void SrpTest(void)
     test_SrpComputeKey();
     test_SrpGetProofAndVerify();
     test_SrpKeyGenFunc_cb();
+    wolfCrypt_Cleanup();
 #endif
 }

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -395,14 +395,14 @@ static int execute_test_case(int svr_argc, char** svr_argv,
     if ((cliArgs.return_code != 0 && testShouldFail == 0) ||
         (cliArgs.return_code == 0 && testShouldFail != 0)) {
         printf("client_test failed\n");
-        exit(EXIT_FAILURE);
+        XEXIT(EXIT_FAILURE);
     }
 
     join_thread(serverThread);
     if ((svrArgs.return_code != 0 && testShouldFail == 0) ||
         (svrArgs.return_code == 0 && testShouldFail != 0)) {
         printf("server_test failed\n");
-        exit(EXIT_FAILURE);
+        XEXIT(EXIT_FAILURE);
     }
 
 #ifdef WOLFSSL_TIRTOS
@@ -619,7 +619,8 @@ int SuiteTest(void)
     cipherSuiteCtx = wolfSSL_CTX_new(wolfSSLv23_client_method());
     if (cipherSuiteCtx == NULL) {
         printf("can't get cipher suite ctx\n");
-        exit(EXIT_FAILURE);
+        args.return_code = EXIT_FAILURE;
+        goto exit;
     }
 
     /* load in static memory buffer if enabled */
@@ -662,7 +663,8 @@ int SuiteTest(void)
     test_harness(&args);
     if (args.return_code != 0) {
         printf("error from script %d\n", args.return_code);
-        exit(EXIT_FAILURE);
+        args.return_code = EXIT_FAILURE;
+        goto exit;
     }
     #ifdef HAVE_ECC
     /* add TLSv13 ECC extra suites */
@@ -671,7 +673,8 @@ int SuiteTest(void)
     test_harness(&args);
     if (args.return_code != 0) {
         printf("error from script %d\n", args.return_code);
-        exit(EXIT_FAILURE);
+        args.return_code = EXIT_FAILURE;
+        goto exit;
     }
     #endif
     #ifndef WOLFSSL_NO_TLS12
@@ -681,7 +684,8 @@ int SuiteTest(void)
     test_harness(&args);
     if (args.return_code != 0) {
         printf("error from script %d\n", args.return_code);
-        exit(EXIT_FAILURE);
+        args.return_code = EXIT_FAILURE;
+        goto exit;
     }
     #endif
 #endif
@@ -692,7 +696,8 @@ int SuiteTest(void)
     test_harness(&args);
     if (args.return_code != 0) {
         printf("error from script %d\n", args.return_code);
-        exit(EXIT_FAILURE);
+        args.return_code = EXIT_FAILURE;
+        goto exit;
     }
 #endif
 #ifdef WOLFSSL_DTLS

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -49,6 +49,15 @@ int unit_test(int argc, char** argv)
 
     (void)argc;
     (void)argv;
+
+#ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
+    if (argc > 1) {
+        word32 memFailCount = atoi(argv[1]);
+        printf("\n--- SET RNG MALLOC FAIL AT %d---\n", memFailCount);
+        wolfSSL_SetMemFailCount(memFailCount);
+    }
+#endif
+
     printf("starting unit tests...\n");
 
 #if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND)

--- a/tests/unit.h
+++ b/tests/unit.h
@@ -29,7 +29,7 @@
 #ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
 #define XABORT()
 #else
-#define XABORT() abort
+#define XABORT() abort()
 #endif
 
 #define Fail(description, result) do {                                         \

--- a/tests/unit.h
+++ b/tests/unit.h
@@ -26,11 +26,17 @@
 #include <wolfssl/ssl.h>
 #include <wolfssl/test.h>    /* thread and tcp stuff */
 
+#ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
+#define XABORT()
+#else
+#define XABORT() abort
+#endif
+
 #define Fail(description, result) do {                                         \
     printf("\nERROR - %s line %d failed with:", __FILE__, __LINE__);           \
     printf("\n    expected: "); printf description;                            \
     printf("\n    result:   "); printf result; printf("\n\n");                 \
-    abort();                                                                   \
+    XABORT();                                                                  \
 } while(0)
 
 #define Assert(test, description, result) if (!(test)) Fail(description, result)
@@ -62,7 +68,7 @@
 #define AssertStr(x, y, op, er) do {                                           \
     const char* _x = x;                                                        \
     const char* _y = y;                                                        \
-    int   _z = strcmp(_x, _y);                                                 \
+    int   _z = (_x && _y) ? strcmp(_x, _y) : -1;                               \
                                                                                \
     Assert(_z op 0, ("%s " #op " %s", #x, #y),                                 \
                                             ("\"%s\" " #er " \"%s\"", _x, _y));\

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5304,6 +5304,8 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
     switch (sigCtx->state) {
         case SIG_STATE_BEGIN:
         {
+            sigCtx->keyOID = keyOID; /* must set early for cleanup */
+
             sigCtx->digest = (byte*)XMALLOC(WC_MAX_DIGEST_SIZE, sigCtx->heap,
                                                     DYNAMIC_TYPE_DIGEST);
             if (sigCtx->digest == NULL) {
@@ -5328,8 +5330,6 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
 
         case SIG_STATE_KEY:
         {
-            sigCtx->keyOID = keyOID;
-
             switch (keyOID) {
             #ifndef NO_RSA
                 case RSAk:

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -86,6 +86,17 @@ int wolfCrypt_Init(void)
     if (initRefCount == 0) {
         WOLFSSL_ENTER("wolfCrypt_Init");
 
+    #ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
+        {
+            word32 rngMallocFail;
+            time_t seed = time(NULL);
+            srand((word32)seed);
+            rngMallocFail = rand() % 2000; /* max 2000 */
+            printf("\n--- RNG MALLOC FAIL AT %d---\n", rngMallocFail);
+            wolfSSL_SetMemFailCount(rngMallocFail);
+        }
+    #endif
+
     #ifdef WOLF_CRYPTO_DEV
         wc_CryptoDev_Init();
     #endif

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -383,7 +383,31 @@ void join_thread(THREAD_TYPE);
 static const word16      wolfSSLPort = 11111;
 
 
-static WC_INLINE WC_NORETURN void err_sys(const char* msg)
+
+#ifndef MY_EX_USAGE
+#define MY_EX_USAGE 2
+#endif
+
+#ifndef EXIT_FAILURE
+#define EXIT_FAILURE 1
+#endif
+
+#ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
+    #define XEXIT(rc)   return rc
+    #define XEXIT_T(rc) return (THREAD_RETURN)rc
+#else
+    #define XEXIT(rc)   exit((int)(rc))
+    #define XEXIT_T(rc) exit((int)(rc))
+#endif
+
+
+static WC_INLINE 
+#ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
+THREAD_RETURN
+#else
+WC_NORETURN void 
+#endif
+err_sys(const char* msg)
 {
     printf("wolfSSL error: %s\n", msg);
 
@@ -397,12 +421,10 @@ static WC_INLINE WC_NORETURN void err_sys(const char* msg)
     if (msg)
 #endif
     {
-        exit(EXIT_FAILURE);
+        XEXIT((THREAD_RETURN)EXIT_FAILURE);
     }
 }
 
-
-#define MY_EX_USAGE 2
 
 extern int   myoptind;
 extern char* myoptarg;

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2802,8 +2802,8 @@ static WC_INLINE const char* mymktemp(char *tempfn, int len, int num)
         byte key[CHACHA20_POLY1305_AEAD_KEYSIZE]; /* cipher key */
     } key_ctx;
 
-    static key_ctx myKey_ctx;
-    static WC_RNG myKey_rng;
+    static THREAD_LS_T key_ctx myKey_ctx;
+    static THREAD_LS_T WC_RNG myKey_rng;
 
     static WC_INLINE int TicketInit(void)
     {

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -421,7 +421,7 @@ err_sys(const char* msg)
     if (msg)
 #endif
     {
-        XEXIT((THREAD_RETURN)EXIT_FAILURE);
+        XEXIT_T(EXIT_FAILURE);
     }
 }
 

--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -95,7 +95,7 @@
     typedef struct memoryTrack {
         union {
             memHint hint;
-            byte    alignit[sizeof(memHint) + (16-1 & ~(16-1))]; /* make sure we have strong alignment */
+            byte    alignit[sizeof(memHint) + ((16-1) & ~(16-1))]; /* make sure we have strong alignment */
         } u;
     } memoryTrack;
 
@@ -263,6 +263,7 @@
         (void)line;
 #endif
 #endif
+        (void)sz;
 
         free(mt);
     }

--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -62,30 +62,62 @@
 
     #include "wolfssl/wolfcrypt/logging.h"
 
+    #if defined(WOLFSSL_TRACK_MEMORY)
+        #define DO_MEM_STATS
+        #if defined(__linux__) || defined(__MACH__)
+            #define DO_MEM_LIST
+        #endif
+    #endif
+
+
     typedef struct memoryStats {
-        size_t totalAllocs;     /* number of allocations */
-        size_t totalDeallocs;   /* number of deallocations */
-        size_t totalBytes;      /* total number of bytes allocated */
-        size_t peakBytes;       /* concurrent max bytes */
-        size_t currentBytes;    /* total current bytes in use */
+        long totalAllocs;     /* number of allocations */
+        long totalDeallocs;   /* number of deallocations */
+        long totalBytes;      /* total number of bytes allocated */
+        long peakBytes;       /* concurrent max bytes */
+        long currentBytes;    /* total current bytes in use */
     } memoryStats;
 
     typedef struct memHint {
         size_t thisSize;      /* size of this memory */
+
+    #ifdef DO_MEM_LIST
+        struct memHint* next;
+        struct memHint* prev;
+        #ifdef WOLFSSL_DEBUG_MEMORY
+            const char* func;
+            unsigned int line;
+        #endif
+    #endif
         void*  thisMemory;    /* actual memory for user */
     } memHint;
 
     typedef struct memoryTrack {
         union {
             memHint hint;
-            byte    alignit[16];   /* make sure we have strong alignment */
+            byte    alignit[sizeof(memHint) + (16-1 & ~(16-1))]; /* make sure we have strong alignment */
         } u;
     } memoryTrack;
 
-    #if defined(WOLFSSL_TRACK_MEMORY)
-        #define DO_MEM_STATS
-        static memoryStats ourMemStats;
+#ifdef DO_MEM_LIST
+    /* track allocations and report at end */
+    typedef struct memoryList {
+        memHint* head;
+        memHint* tail;
+        uint32_t count;
+    } memoryList;
+#endif
+
+#if defined(WOLFSSL_TRACK_MEMORY)
+    static memoryStats ourMemStats;
+
+    #ifdef DO_MEM_LIST
+        #include <pthread.h>
+        static memoryList ourMemList;
+        static pthread_mutex_t memLock = PTHREAD_MUTEX_INITIALIZER;
     #endif
+#endif
+
 
     /* if defined to not using inline then declare function prototypes */
     #ifdef NO_INLINE
@@ -112,6 +144,7 @@
 #endif
     {
         memoryTrack* mt;
+        memHint* header;
 
         if (sz == 0)
             return NULL;
@@ -120,22 +153,50 @@
         if (mt == NULL)
             return NULL;
 
-        mt->u.hint.thisSize   = sz;
-        mt->u.hint.thisMemory = (byte*)mt + sizeof(memoryTrack);
+        header = &mt->u.hint;
+        header->thisSize   = sz;
+        header->thisMemory = (byte*)mt + sizeof(memoryTrack);
 
-#ifdef WOLFSSL_DEBUG_MEMORY_PRINT
-        printf("Alloc: %p -> %u at %s:%d\n", mt->u.hint.thisMemory, (word32)sz, func, line);
-#endif
+    #ifdef WOLFSSL_DEBUG_MEMORY
+    #ifdef WOLFSSL_DEBUG_MEMORY_PRINT
+        printf("Alloc: %p -> %u at %s:%d\n", header->thisMemory, (word32)sz, func, line);
+    #else
+        (void)func;
+        (void)line;
+    #endif
+    #endif
 
-#ifdef DO_MEM_STATS
+    #ifdef DO_MEM_STATS
         ourMemStats.totalAllocs++;
         ourMemStats.totalBytes   += sz;
         ourMemStats.currentBytes += sz;
         if (ourMemStats.currentBytes > ourMemStats.peakBytes)
             ourMemStats.peakBytes = ourMemStats.currentBytes;
-#endif
+    #endif
+    #ifdef DO_MEM_LIST
+        if (pthread_mutex_lock(&memLock) == 0) {
+        #ifdef WOLFSSL_DEBUG_MEMORY
+            header->func = func;
+            header->line = line;
+        #endif
 
-        return mt->u.hint.thisMemory;
+            /* Setup event */
+            header->next = NULL;
+            if (ourMemList.tail == NULL)  {
+                ourMemList.head = header;
+            }
+            else {
+                ourMemList.tail->next = header;
+                header->prev = ourMemList.tail;
+            }
+            ourMemList.tail = header;      /* add to the end either way */
+            ourMemList.count++;
+
+            pthread_mutex_unlock(&memLock);
+        }
+    #endif
+
+        return header->thisMemory;
     }
 
 
@@ -146,21 +207,61 @@
 #endif
     {
         memoryTrack* mt;
+        memHint* header;
+        size_t sz;
 
         if (ptr == NULL) {
             return;
         }
 
-        mt = (memoryTrack*)ptr;
-        --mt;   /* same as minus sizeof(memoryTrack), removes header */
+        mt = (memoryTrack*)((byte*)ptr - sizeof(memoryTrack));
+        header = &mt->u.hint;
+        sz = header->thisSize;
 
-#ifdef DO_MEM_STATS
-        ourMemStats.currentBytes -= mt->u.hint.thisSize;
-        ourMemStats.totalDeallocs++;
-#endif
+    #ifdef DO_MEM_LIST
+        if (pthread_mutex_lock(&memLock) == 0) 
+        {
+    #endif
 
+    #ifdef DO_MEM_STATS
+            ourMemStats.currentBytes -= header->thisSize;
+            ourMemStats.totalDeallocs++;
+    #endif
+
+    #ifdef DO_MEM_LIST
+            if (header == ourMemList.head && header == ourMemList.tail) {
+                ourMemList.head = NULL;
+                ourMemList.tail = NULL;
+            }
+            else if (header == ourMemList.head) {
+                ourMemList.head = header->next;
+                ourMemList.head->prev = NULL;
+            }
+            else if (header == ourMemList.tail) {
+                ourMemList.tail = header->prev;
+                ourMemList.tail->next = NULL;
+            }
+            else {
+                memHint* next = header->next;
+                memHint* prev = header->prev;
+                if (next)
+                    next->prev = prev;
+                if (prev)
+                    prev->next = next;
+            }
+            ourMemList.count--;
+
+            pthread_mutex_unlock(&memLock);
+        }
+    #endif
+
+#ifdef WOLFSSL_DEBUG_MEMORY
 #ifdef WOLFSSL_DEBUG_MEMORY_PRINT
-        printf("Free: %p -> %u at %s:%d\n", ptr, (word32)mt->u.hint.thisSize, func, line);
+        printf("Free: %p -> %u at %s:%d\n", ptr, (word32)sz, func, line);
+#else
+        (void)func;
+        (void)line;
+#endif
 #endif
 
         free(mt);
@@ -181,11 +282,14 @@
 
         if (ptr) {
             /* if realloc is bigger, don't overread old ptr */
-            memoryTrack* mt = (memoryTrack*)ptr;
-            --mt;  /* same as minus sizeof(memoryTrack), removes header */
+            memoryTrack* mt;
+            memHint* header;
 
-            if (mt->u.hint.thisSize < sz)
-                sz = mt->u.hint.thisSize;
+            mt = (memoryTrack*)((byte*)ptr - sizeof(memoryTrack));
+            header = &mt->u.hint;
+
+            if (header->thisSize < sz)
+                sz = header->thisSize;
         }
 
         if (ret && ptr)
@@ -211,6 +315,11 @@
             return ret;
         }
 
+    #ifdef DO_MEM_LIST
+        if (pthread_mutex_lock(&memLock) == 0)
+        {
+    #endif
+
     #ifdef DO_MEM_STATS
         ourMemStats.totalAllocs  = 0;
         ourMemStats.totalDeallocs = 0;
@@ -218,23 +327,52 @@
         ourMemStats.peakBytes    = 0;
         ourMemStats.currentBytes = 0;
     #endif
+    
+    #ifdef DO_MEM_LIST
+        XMEMSET(&ourMemList, 0, sizeof(ourMemList));
+
+        pthread_mutex_unlock(&memLock);
+        }
+    #endif
 
         return ret;
     }
 
     STATIC WC_INLINE void ShowMemoryTracker(void)
     {
+    #ifdef DO_MEM_LIST
+        if (pthread_mutex_lock(&memLock) == 0)
+        {
+    #endif
+
     #ifdef DO_MEM_STATS
-        printf("total   Allocs   = %9lu\n",
-                                       (unsigned long)ourMemStats.totalAllocs);
-        printf("total   Deallocs = %9lu\n",
-                                       (unsigned long)ourMemStats.totalDeallocs);
-        printf("total   Bytes    = %9lu\n",
-                                       (unsigned long)ourMemStats.totalBytes);
-        printf("peak    Bytes    = %9lu\n",
-                                       (unsigned long)ourMemStats.peakBytes);
-        printf("current Bytes    = %9lu\n",
-                                       (unsigned long)ourMemStats.currentBytes);
+        printf("total   Allocs   = %9ld\n", ourMemStats.totalAllocs);
+        printf("total   Deallocs = %9ld\n", ourMemStats.totalDeallocs);
+        printf("total   Bytes    = %9ld\n", ourMemStats.totalBytes);
+        printf("peak    Bytes    = %9ld\n", ourMemStats.peakBytes);
+        printf("current Bytes    = %9ld\n", ourMemStats.currentBytes);
+    #endif
+
+    #ifdef DO_MEM_LIST
+        if (ourMemList.count > 0) {
+            /* print list of allocations */
+            memHint* header;
+            for (header = ourMemList.head; header != NULL; header = header->next) {
+                printf("Leak: Ptr %p, Size %u"
+                #ifdef WOLFSSL_DEBUG_MEMORY
+                    ", Func %s, Line %d"
+                #endif
+                    "\n",
+                    (byte*)header + sizeof(memHint), (unsigned int)header->thisSize
+                #ifdef WOLFSSL_DEBUG_MEMORY
+                    , header->func, header->line
+                #endif
+                );
+            }
+        }
+
+        pthread_mutex_unlock(&memLock);
+        }
     #endif
     }
 

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -36,6 +36,10 @@
     extern "C" {
 #endif
 
+#ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
+    WOLFSSL_API void wolfSSL_SetMemFailCount(int memFailCount);
+#endif
+
 #ifdef WOLFSSL_STATIC_MEMORY
     #ifdef WOLFSSL_DEBUG_MEMORY
         typedef void *(*wolfSSL_Malloc_cb)(size_t size, void* heap, int type, const char* func, unsigned int line);


### PR DESCRIPTION
* Added new build option `--enable-memtest` or `WOLFSSL_FORCE_MALLOC_FAIL_TEST` which enables random malloc failures for testing. This test supresses the `abort()` calls to detect seg faults. A new script `./scripts/memtest.sh` starts the test. If an issue is found it can be reviewed with the `./scripts/memtest.txt` log and reproduced using the seed printed at top of unit test as `--- RNG MALLOC FAIL AT 295---` and rerun using `./tests/unit.test 295`.

* Enhanced the `--enable-memtrack` option to keep list of pointers allocated and reports leaked memory at end.
* Cleanup of the wolfCrypt_Init and wolfCrypt_Cleanup calls in unit.test and SrpTest memory tracking feature.

First pass at bugs found with `./scripts/memtest.sh`:
* Fixes for NULL pointer checks, making sure free'd pointers are reset, making sure pointers are initialized and making sure memory is always free'd.
* Fix for TicketInit() which was using non-thread safe RNG and key_ctx.
* Fix for possible double free case in `wolfSSL_PEM_read_X509_CRL`.