### PR TITLE
Added STM32L4/ST-Safe support. Fixes for AES CBC Decrypt w/CubeMX

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3915,7 +3915,7 @@ int wc_ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key, int curve_id)
         }
     #endif
     }
-#endif /* WOLFSSL_ASYNC_CRYPT */
+#endif /* WOLFSSL_ASYNC_CRYPT && WC_ASYNC_ENABLE_ECC */
 
 #ifdef WOLFSSL_ATECC508A
    key->type = ECC_PRIVATEKEY;
@@ -3942,11 +3942,12 @@ int wc_ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key, int curve_id)
     }
     else
 #endif
-#endif
+#endif /* WOLFSSL_HAVE_SP_ECC */
+
+   { /* software key gen */
 #ifdef WOLFSSL_SP_MATH
         err = WC_KEY_SIZE_E;
 #else
-    {
         ALLOC_CURVE_SPECS(ECC_CURVE_FIELD_COUNT);
 
         /* setup the key variables */
@@ -3978,8 +3979,8 @@ int wc_ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key, int curve_id)
     #ifndef WOLFSSL_ATECC508A
         FREE_CURVE_SPECS();
     #endif
+#endif /* WOLFSSL_SP_MATH */
     }
-#endif
 
 #endif /* WOLFSSL_ATECC508A */
 
@@ -5168,6 +5169,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
                     word32 hashlen, int* res, ecc_key* key)
 {
    int           err;
+   word32        keySz;
 #ifdef WOLFSSL_ATECC508A
    byte sigRS[ATECC_KEY_SIZE*2];
 #elif !defined(WOLFSSL_SP_MATH)
@@ -5205,6 +5207,8 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
       return ECC_BAD_ARG_E;
    }
 
+   keySz = key->dp->size;
+
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ECC) && \
        defined(WOLFSSL_ASYNC_CRYPT_TEST)
     if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_ECC) {
@@ -5227,7 +5231,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     if (err != MP_OKAY) {
         return err;
     }
-    err = mp_to_unsigned_bin(s, &sigRS[ATECC_KEY_SIZE]);
+    err = mp_to_unsigned_bin(s, &sigRS[keySz]);
     if (err != MP_OKAY) {
         return err;
     }
@@ -5330,8 +5334,6 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
       if (NitroxEccIsCurveSupported(key))
    #endif
       {
-          word32 keySz = key->dp->size;
-
           err = wc_mp_to_bigint_sz(e, &e->raw, keySz);
           if (err == MP_OKAY)
               err = wc_mp_to_bigint_sz(key->pubkey.x, &key->pubkey.x->raw, keySz);
@@ -5438,7 +5440,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 #else
 #ifndef ECC_SHAMIR
     {
-        mp_digit      mp = 0;
+        mp_digit mp = 0;
 
         /* compute u1*mG + u2*mQ = mG */
         if (err == MP_OKAY) {
@@ -5464,7 +5466,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
             err = ecc_map(mG, curve->prime, mp);
     }
 #else
-       /* use Shamir's trick to compute u1*mG + u2*mQ using half the doubles */
+        /* use Shamir's trick to compute u1*mG + u2*mQ using half the doubles */
         if (err == MP_OKAY) {
             err = ecc_mul2add(mG, u1, mQ, u2, mG, curve->Af, curve->prime,
                                                                     key->heap);
@@ -5507,6 +5509,9 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 
 #endif /* WOLFSSL_SP_MATH */
 #endif /* WOLFSSL_ATECC508A */
+
+   (void)keySz;
+   (void)hashlen;
 
    return err;
 }

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -61,7 +61,8 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/caam/caam_init.c \
               wolfcrypt/src/port/caam/caam_sha.c \
               wolfcrypt/src/port/caam/caam_doc.pdf \
-              wolfcrypt/src/port/st/stm32.c
+              wolfcrypt/src/port/st/stm32.c \
+              wolfcrypt/src/port/st/stsafe.c
 
 if BUILD_CRYPTODEV
 src_libwolfssl_la_SOURCES += wolfcrypt/src/cryptodev.c

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -1,6 +1,6 @@
 /* stm32.c
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -38,6 +38,11 @@
     #define WOLFSSL_MISC_INCLUDED
     #include <wolfcrypt/src/misc.c>
 #endif
+
+#ifndef NO_AES
+    #include <wolfssl/wolfcrypt/aes.h>
+#endif
+
 
 #ifdef STM32_HASH
 
@@ -253,3 +258,105 @@ int wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
 }
 
 #endif /* STM32_HASH */
+
+
+#ifdef STM32_CRYPTO
+
+#ifndef NO_AES
+#if defined(WOLFSSL_AES_DIRECT) || defined(HAVE_AESGCM) || defined(HAVE_AESCCM)
+#ifdef WOLFSSL_STM32_CUBEMX
+int wc_Stm32_Aes_Init(Aes* aes, CRYP_HandleTypeDef* hcryp)
+{
+    int ret;
+    word32 keySize;
+
+    ret = wc_AesGetKeySize(aes, &keySize);
+    if (ret != 0)
+        return ret;
+
+    XMEMSET(hcryp, 0, sizeof(CRYP_HandleTypeDef));
+    switch (keySize) {
+        case 16: /* 128-bit key */
+            hcryp->Init.KeySize = CRYP_KEYSIZE_128B;
+            break;
+    #ifdef CRYP_KEYSIZE_192B
+        case 24: /* 192-bit key */
+            hcryp->Init.KeySize = CRYP_KEYSIZE_192B;
+            break;
+    #endif
+        case 32: /* 256-bit key */
+            hcryp->Init.KeySize = CRYP_KEYSIZE_256B;
+            break;
+        default:
+            break;
+    }
+    hcryp->Instance = CRYP;
+    hcryp->Init.DataType = CRYP_DATATYPE_8B;
+    hcryp->Init.pKey = (uint8_t*)aes->key;
+
+    return 0;
+}
+
+#else /* STD_PERI_LIB */
+
+int wc_Stm32_Aes_Init(Aes* aes, CRYP_InitTypeDef* cryptInit,
+    CRYP_KeyInitTypeDef* keyInit)
+{
+    int ret;
+    word32 keySize;
+    word32* aes_key;
+
+    ret = wc_AesGetKeySize(aes, &keySize);
+    if (ret != 0)
+        return ret;
+
+    aes_key = aes->key;
+
+    /* crypto structure initialization */
+    CRYP_KeyStructInit(keyInit);
+    CRYP_StructInit(cryptInit);
+
+    /* load key into correct registers */
+    switch (keySize) {
+        case 16: /* 128-bit key */
+            cryptInit->CRYP_KeySize = CRYP_KeySize_128b;
+            keyInit->CRYP_Key2Left  = aes_key[0];
+            keyInit->CRYP_Key2Right = aes_key[1];
+            keyInit->CRYP_Key3Left  = aes_key[2];
+            keyInit->CRYP_Key3Right = aes_key[3];
+            break;
+
+        case 24: /* 192-bit key */
+            cryptInit->CRYP_KeySize = CRYP_KeySize_192b;
+            keyInit->CRYP_Key1Left  = aes_key[0];
+            keyInit->CRYP_Key1Right = aes_key[1];
+            keyInit->CRYP_Key2Left  = aes_key[2];
+            keyInit->CRYP_Key2Right = aes_key[3];
+            keyInit->CRYP_Key3Left  = aes_key[4];
+            keyInit->CRYP_Key3Right = aes_key[5];
+            break;
+
+        case 32: /* 256-bit key */
+            cryptInit->CRYP_KeySize = CRYP_KeySize_256b;
+            keyInit->CRYP_Key0Left  = aes_key[0];
+            keyInit->CRYP_Key0Right = aes_key[1];
+            keyInit->CRYP_Key1Left  = aes_key[2];
+            keyInit->CRYP_Key1Right = aes_key[3];
+            keyInit->CRYP_Key2Left  = aes_key[4];
+            keyInit->CRYP_Key2Right = aes_key[5];
+            keyInit->CRYP_Key3Left  = aes_key[6];
+            keyInit->CRYP_Key3Right = aes_key[7];
+            break;
+
+        default:
+            break;
+    }
+    cryptInit->CRYP_DataType = CRYP_DataType_8b;
+
+    return 0;
+}
+#endif /* WOLFSSL_STM32_CUBEMX */
+#endif /* WOLFSSL_AES_DIRECT || HAVE_AESGCM || HAVE_AESCCM */
+#endif /* !NO_AES */
+
+#endif /* STM32_CRYPTO */

--- a/wolfcrypt/src/port/st/stsafe.c
+++ b/wolfcrypt/src/port/st/stsafe.c
@@ -1,0 +1,272 @@
+/* stsafe.c
+ *
+ * Copyright (C) 2006-2018 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include <wolfssl/wolfcrypt/port/st/stsafe.h>
+#include <wolfssl/wolfcrypt/logging.h>
+
+#ifdef WOLFSSL_STSAFEA100
+
+int SSL_STSAFE_LoadDeviceCertificate(byte** pRawCertificate,
+    word32* pRawCertificateLen)
+{
+    int err;
+
+    if (pRawCertificate == NULL || pRawCertificateLen == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef USE_STSAFE_VERBOSE
+    WOLFSSL_MSG("SSL_STSAFE_LoadDeviceCertificate");
+#endif
+
+    /* Try reading device certificate from ST-SAFE Zone 0 */
+    err = stsafe_interface_read_device_certificate_raw(
+        pRawCertificate, pRawCertificateLen);
+    if (err == 0) {
+    #if 0
+        /* example for loading into WOLFSSL_CTX */
+        err = wolfSSL_CTX_use_certificate_buffer(ctx,
+            *pRawCertificate, *pRawCertificateLen, SSL_FILETYPE_ASN1);
+        if (err != WOLFSSL_SUCCESS) {
+            /* failed */
+        }
+        /* can free now */
+        XFREE(*pRawCertificate, NULL, DYNAMIC_TEMP_BUFFER);
+        *pRawCertificate = NULL;
+    #endif
+    }
+
+    return err;
+}
+
+#ifdef HAVE_PK_CALLBACKS
+/**
+ * \brief Verify Peer Cert Callback.
+ */
+int SSL_STSAFE_VerifyPeerCertCb(WOLFSSL* ssl,
+                                const unsigned char* sig, unsigned int sigSz,
+                                const unsigned char* hash, unsigned int hashSz,
+                                const unsigned char* keyDer, unsigned int keySz,
+                                int* result, void* ctx)
+{
+    int err;
+    byte sigRS[STSAFE_MAX_SIG_LEN];
+    byte *r, *s;
+    word32 r_len = STSAFE_MAX_SIG_LEN/2, s_len = STSAFE_MAX_SIG_LEN/2;
+    byte pubKeyX[STSAFE_MAX_PUBKEY_RAW_LEN/2];
+    byte pubKeyY[STSAFE_MAX_PUBKEY_RAW_LEN/2];
+    word32 pubKeyX_len = sizeof(pubKeyX);
+    word32 pubKeyY_len = sizeof(pubKeyY);
+    ecc_key key;
+    word32 inOutIdx = 0;
+    StSafeA_CurveId curve_id;
+    int ecc_curve;
+
+    (void)ssl;
+    (void)ctx;
+
+#ifdef USE_STSAFE_VERBOSE
+    WOLFSSL_MSG("VerifyPeerCertCB: STSAFE");
+#endif
+
+    err = wc_ecc_init(&key);
+    if (err != 0) {
+        return err;
+    }
+
+    /* Decode the public key */
+    err = wc_EccPublicKeyDecode(keyDer, &inOutIdx, &key, keySz);
+    if (err == 0) {
+        /* Extract Raw X and Y coordinates of the public key */
+        err = wc_ecc_export_public_raw(&key, pubKeyX, &pubKeyX_len,
+            pubKeyY, &pubKeyY_len);
+    }
+    if (err == 0) {
+        int key_sz;
+
+        /* determine curve */
+        ecc_curve = key.dp->id;
+        curve_id = stsafe_get_ecc_curve_id(ecc_curve);
+        key_sz = stsafe_get_key_size(curve_id);
+
+        /* Extract R and S from signature */
+        XMEMSET(sigRS, 0, sizeof(sigRS));
+        r = &sigRS[0];
+        s = &sigRS[key_sz];
+        err = wc_ecc_sig_to_rs(sig, sigSz, r, &r_len, s, &s_len);
+        (void)r_len;
+        (void)s_len;
+    }
+
+    if (err == 0) {
+        /* Verify signature */
+        err = stsafe_interface_verify(curve_id, (uint8_t*)hash, sigRS,
+            pubKeyX, pubKeyY, result);
+    }
+
+    wc_ecc_free(&key);
+    return err;
+}
+
+/**
+ * \brief Sign Certificate Callback.
+ */
+int SSL_STSAFE_SignCertificateCb(WOLFSSL* ssl, const byte* in,
+                                 word32 inSz, byte* out, word32* outSz,
+                                 const byte* key, word32 keySz, void* ctx)
+{
+    int err;
+    byte digest[STSAFE_MAX_KEY_LEN];
+    byte sigRS[STSAFE_MAX_SIG_LEN];
+    byte *r, *s;
+    StSafeA_CurveId curve_id;
+    int key_sz;
+
+    (void)ssl;
+    (void)ctx;
+
+#ifdef USE_STSAFE_VERBOSE
+    WOLFSSL_MSG("SignCertificateCb: STSAFE");
+#endif
+
+    curve_id = stsafe_get_curve_mode();
+    key_sz = stsafe_get_key_size(curve_id);
+
+    /* Build input digest */
+    if (inSz > key_sz)
+        inSz = key_sz;
+    XMEMSET(&digest[0], 0, sizeof(digest));
+    XMEMCPY(&digest[key_sz - inSz], in, inSz);
+
+    /* Sign using slot 0: Result is R then S */
+    /* Sign will always use the curve type in slot 0 (the TLS curve needs to match) */
+    XMEMSET(sigRS, 0, sizeof(sigRS));
+    err = stsafe_interface_sign(STSAFE_A_SLOT_0, curve_id, digest, sigRS);
+    if (err != 0) {
+        return err;
+    }
+
+    /* Convert R and S to signature */
+    r = &sigRS[0];
+    s = &sigRS[key_sz];
+    err = wc_ecc_rs_raw_to_sig((const byte*)r, key_sz, (const byte*)s, key_sz,
+        out, outSz);
+    if (err !=0) {
+    #ifdef USE_STSAFE_VERBOSE
+        WOLFSSL_MSG("Error converting RS to Signature");
+    #endif
+    }
+
+    return err;
+}
+
+
+/**
+ * \brief Create pre master secret using peer's public key and self private key.
+ */
+int SSL_STSAFE_SharedSecretCb(WOLFSSL* ssl, ecc_key* otherKey,
+                              unsigned char* pubKeyDer, unsigned int* pubKeySz,
+                              unsigned char* out, unsigned int* outlen,
+                              int side, void* ctx)
+{
+    int err;
+    byte otherKeyX[STSAFE_MAX_KEY_LEN];
+    byte otherKeyY[STSAFE_MAX_KEY_LEN];
+    word32 otherKeyX_len = sizeof(otherKeyX);
+    word32 otherKeyY_len = sizeof(otherKeyY);
+    byte pubKeyRaw[STSAFE_MAX_PUBKEY_RAW_LEN];
+    StSafeA_KeySlotNumber slot;
+    StSafeA_CurveId curve_id;
+    ecc_key tmpKey;
+    int ecc_curve;
+    int key_sz;
+
+    (void)ssl;
+    (void)ctx;
+
+#ifdef USE_STSAFE_VERBOSE
+    WOLFSSL_MSG("SharedSecretCb: STSAFE");
+#endif
+
+    err = wc_ecc_init(&tmpKey);
+    if (err != 0) {
+        return err;
+    }
+
+    /* set curve */
+    ecc_curve = otherKey->dp->id;
+    curve_id = stsafe_get_ecc_curve_id(ecc_curve);
+    key_sz = stsafe_get_key_size(curve_id);
+
+    /* for client: create and export public key */
+    if (side == WOLFSSL_CLIENT_END) {
+        /* Export otherKey raw X and Y */
+        err = wc_ecc_export_public_raw(otherKey,
+            &otherKeyX[0], (word32*)&otherKeyX_len,
+            &otherKeyY[0], (word32*)&otherKeyY_len);
+        if (err != 0) {
+            return err;
+        }
+
+        err = stsafe_interface_create_key(&slot, curve_id, (uint8_t*)&pubKeyRaw[0]);
+        if (err != 0) {
+            return err;
+        }
+
+        /* convert raw unsigned public key to X.963 format for TLS */
+        err = wc_ecc_init(&tmpKey);
+        if (err == 0) {
+            err = wc_ecc_import_unsigned(&tmpKey, &pubKeyRaw[0], &pubKeyRaw[key_sz],
+                NULL, ecc_curve);
+            if (err == 0) {
+                err = wc_ecc_export_x963(&tmpKey, pubKeyDer, pubKeySz);
+            }
+            wc_ecc_free(&tmpKey);
+        }
+    }
+    /* for server: import public key */
+    else if (side == WOLFSSL_SERVER_END) {
+        /* import peer's key and export as raw unsigned for hardware */
+        err = wc_ecc_import_x963_ex(pubKeyDer, *pubKeySz, &tmpKey, ecc_curve);
+        if (err == 0) {
+            err = wc_ecc_export_public_raw(&tmpKey, otherKeyX, &otherKeyX_len,
+                otherKeyY, &otherKeyY_len);
+        }
+    }
+    else {
+        err = BAD_FUNC_ARG;
+    }
+
+    wc_ecc_free(&tmpKey);
+
+    if (err != 0) {
+        return err;
+    }
+
+    /* Compute shared secret */
+    err = stsafe_interface_shared_secret(curve_id, &otherKeyX[0], &otherKeyY[0],
+        out, (int32_t*)outlen);
+
+    return err;
+}
+#endif /* HAVE_PK_CALLBACKS */
+
+#endif /* WOLFSSL_STSAFEA100 */

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -50,6 +50,10 @@
     #include <wolfssl/wolfcrypt/port/atmel/atmel.h>
 #endif
 
+#if defined(WOLFSSL_STSAFEA100)
+    #include <wolfssl/wolfcrypt/port/st/stsafe.h>
+#endif
+
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
     #include <wolfssl/openssl/evp.h>
 #endif
@@ -139,6 +143,10 @@ int wolfCrypt_Init(void)
 
     #if defined(WOLFSSL_ATMEL) || defined(WOLFSSL_ATECC508A)
         atmel_init();
+    #endif
+
+    #if defined(WOLFSSL_STSAFEA100)
+        stsafe_interface_init();
     #endif
 
     #ifdef WOLFSSL_ARMASM

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -434,7 +434,8 @@ int wolfcrypt_test(void* args)
 {
     int ret;
 
-    ((func_args*)args)->return_code = -1; /* error state */
+    if (args)
+        ((func_args*)args)->return_code = -1; /* error state */
 
 #ifdef WOLFSSL_STATIC_MEMORY
     if (wc_LoadStaticMemory(&HEAP_HINT, gTestMemory, sizeof(gTestMemory),
@@ -1003,7 +1004,8 @@ initDefaultName();
     wc_ecc_fp_free();
 #endif
 
-    ((func_args*)args)->return_code = ret;
+    if (args)
+        ((func_args*)args)->return_code = ret;
 
     EXIT_TEST(ret);
 }
@@ -6801,7 +6803,7 @@ int aesgcm_test(void)
     }
 #endif
 
-    /* Variable authenticed data length test */
+    /* Variable authenticated data length test */
     for (alen=0; alen<(int)sizeof(p); alen++) {
          /* AES-GCM encrypt and decrypt both use AES encrypt internally */
          result = wc_AesGcmEncrypt(&enc, resultC, p, sizeof(p), iv1,
@@ -16623,8 +16625,12 @@ int ecc_test_buffers(void) {
     int verify = 0;
     word32 x;
 
-    XMEMSET(&cliKey, 0, sizeof(ecc_key));
-    XMEMSET(&servKey, 0, sizeof(ecc_key));
+    ret = wc_ecc_init_ex(&cliKey, HEAP_HINT, devId);
+    if (ret != 0)
+        return -8721;
+    ret = wc_ecc_init_ex(&servKey, HEAP_HINT, devId);
+    if (ret != 0)
+        return -8722;
 
     bytes = (size_t)sizeof_ecc_clikey_der_256;
     /* place client key into ecc_key struct cliKey */

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -48,6 +48,12 @@
 #endif
 #endif
 
+#ifndef WC_NO_RNG
+    #include <wolfssl/wolfcrypt/random.h>
+#endif
+#ifdef STM32_CRYPTO
+    #include <wolfssl/wolfcrypt/port/st/stm32.h>
+#endif
 
 #ifdef WOLFSSL_AESNI
 

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -76,7 +76,8 @@ noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/caam/caam_driver.h \
                          wolfssl/wolfcrypt/port/caam/wolfcaam.h \
                          wolfssl/wolfcrypt/port/caam/wolfcaam_sha.h \
-                         wolfssl/wolfcrypt/port/st/stm32.h
+                         wolfssl/wolfcrypt/port/st/stm32.h \
+                         wolfssl/wolfcrypt/port/st/stsafe.h
 
 if BUILD_ASYNCCRYPT
 nobase_include_HEADERS+= wolfssl/wolfcrypt/async.h

--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -1,6 +1,6 @@
 /* stm32.h
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2018 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -22,14 +22,15 @@
 #ifndef _WOLFPORT_STM32_H_
 #define _WOLFPORT_STM32_H_
 
-#ifdef STM32_HASH
-
-#define WOLFSSL_NO_HASH_RAW
-
-/* Generic STM32 Hashing Function */
+/* Generic STM32 Hashing and Crypto Functions */
 /* Supports CubeMX HAL or Standard Peripheral Library */
 
 #include <wolfssl/wolfcrypt/types.h>
+
+
+#ifdef STM32_HASH
+
+#define WOLFSSL_NO_HASH_RAW
 
 #ifdef HASH_DIGEST
     /* The HASH_DIGEST register indicates SHA224/SHA256 support */
@@ -81,5 +82,31 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
     byte* hash, int digestSize);
 
 #endif /* STM32_HASH */
+
+
+#ifdef STM32_CRYPTO
+
+#ifndef NO_AES
+    #ifdef WOLFSSL_STM32L4
+        #define STM32_CRYPTO_AES_ONLY /* crypto engine only supports AES */
+        #define CRYP AES
+    #endif
+
+    /* CRYPT_AES_GCM starts the IV with 2 */
+    #define STM32_GCM_IV_START 2
+
+    #if defined(WOLFSSL_AES_DIRECT) || defined(HAVE_AESGCM) || defined(HAVE_AESCCM)
+        struct Aes;
+        #ifdef WOLFSSL_STM32_CUBEMX
+            int wc_Stm32_Aes_Init(struct Aes* aes, CRYP_HandleTypeDef* hcryp);
+        #else /* STD_PERI_LIB */
+            int wc_Stm32_Aes_Init(struct Aes* aes, CRYP_InitTypeDef* cryptInit,
+                CRYP_KeyInitTypeDef* keyInit);
+        #endif /* WOLFSSL_STM32_CUBEMX */
+    #endif /* WOLFSSL_AES_DIRECT || HAVE_AESGCM || HAVE_AESCCM */
+#endif /* !NO_AES */
+
+#endif /* STM32_CRYPTO */
+
 
 #endif /* _WOLFPORT_STM32_H_ */

--- a/wolfssl/wolfcrypt/port/st/stsafe.h
+++ b/wolfssl/wolfcrypt/port/st/stsafe.h
@@ -1,0 +1,66 @@
+/* stsafe.h
+ *
+ * Copyright (C) 2006-2018 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef _WOLFPORT_STSAFE_H_
+#define _WOLFPORT_STSAFE_H_
+
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/ssl.h>
+#include <wolfssl/wolfcrypt/ecc.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#ifdef WOLFSSL_STSAFEA100
+
+#include "stsafe_interface.h"
+
+#ifndef STSAFE_MAX_KEY_LEN
+    #define STSAFE_MAX_KEY_LEN ((uint32_t)48) /* for up to 384-bit keys */
+#endif
+#ifndef STSAFE_MAX_PUBKEY_RAW_LEN
+    #define STSAFE_MAX_PUBKEY_RAW_LEN ((uint32_t)STSAFE_MAX_KEY_LEN * 2) /* x/y */
+#endif
+#ifndef STSAFE_MAX_SIG_LEN
+    #define STSAFE_MAX_SIG_LEN ((uint32_t)STSAFE_MAX_KEY_LEN * 2) /* r/s */
+#endif
+
+WOLFSSL_API int SSL_STSAFE_LoadDeviceCertificate(byte** pRawCertificate,
+    word32* pRawCertificateLen);
+
+#ifdef HAVE_PK_CALLBACKS
+WOLFSSL_API int SSL_STSAFE_VerifyPeerCertCb(WOLFSSL* ssl,
+   const unsigned char* sig, unsigned int sigSz,
+   const unsigned char* hash, unsigned int hashSz,
+   const unsigned char* keyDer, unsigned int keySz,
+   int* result, void* ctx);
+WOLFSSL_API int SSL_STSAFE_SignCertificateCb(WOLFSSL* ssl, 
+    const byte* in, word32 inSz,
+    byte* out, word32* outSz, 
+    const byte* key, word32 keySz, void* ctx);
+WOLFSSL_API int SSL_STSAFE_SharedSecretCb(WOLFSSL* ssl, 
+    ecc_key* otherKey,
+    unsigned char* pubKeyDer, unsigned int* pubKeySz,
+    unsigned char* out, unsigned int* outlen,
+    int side, void* ctx);
+#endif
+
+#endif /* WOLFSSL_STSAFEA100 */
+
+#endif /* _WOLFPORT_STSAFE_H_ */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -98,6 +98,9 @@
 /* Uncomment next line if using STM32F4 */
 /* #define WOLFSSL_STM32F4 */
 
+/* Uncomment next line if using STM32FL */
+/* #define WOLFSSL_STM32FL */
+
 /* Uncomment next line if using STM32F7 */
 /* #define WOLFSSL_STM32F7 */
 
@@ -1053,6 +1056,10 @@ extern void uITRON4_free(void *p) ;
     #ifndef NO_STM32_CRYPTO
         #undef  STM32_CRYPTO
         #define STM32_CRYPTO
+
+        #ifdef WOLFSSL_STM32L4
+            #define NO_AES_192 /* hardware does not support 192-bit */
+        #endif
     #endif
     #ifndef NO_STM32_HASH
         #undef  STM32_HASH
@@ -1109,7 +1116,7 @@ extern void uITRON4_free(void *p) ;
             #include "stm32f1xx.h"
         #endif
     #endif /* WOLFSSL_STM32_CUBEMX */
-#endif /* WOLFSSL_STM32F2 || WOLFSSL_STM32F4 || WOLFSSL_STM32F7 */
+#endif /* WOLFSSL_STM32F2 || WOLFSSL_STM32F4 || WOLFSSL_STM32L4 || WOLFSSL_STM32F7 */
 
 #ifdef MICRIUM
     #include <stdlib.h>


### PR DESCRIPTION
* Added support for STM32L4 AES hardware crypto.
* Fix for STM32 AES CBC Decrypt with CubeMX, which was not capturing the first input block for next IV.
* Added reference PK callbacks functions for ECC sign, verify and shared secret used by TLS in `wolfcrypt/src/port/st/stsafe.c`.
* Fix for wolfcrypt_test to not require args to be provided.
* Fix for wolfCrypt `ecc_test_buffers` to poperly init ecc_key.
* Refactor to combine STM32 AES hardware init code.

These changes are wolf owned and pulled out of the PR #1505.