### PR TITLE
Added API's to expose alloc/free of DerBuffer and new unit tests

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -15532,6 +15532,80 @@ static void test_wolfSSL_DES(void)
     #endif /* defined(OPENSSL_EXTRA) && !defined(NO_DES3) */
 }
 
+static void test_wc_PemToDer(void)
+{
+#if !defined(NO_CERTS) && defined(WOLFSSL_PEM_TO_DER)
+    int ret;
+    DerBuffer* pDer = NULL;
+    const char* ca_cert = "./certs/server-cert.pem";
+    byte* cert_buf = NULL;
+    size_t cert_sz = 0;
+    int eccKey = 0;
+    EncryptedInfo info;
+
+    printf(testingFmt, "wc_PemToDer()");
+
+    memset(&info, 0, sizeof(info));
+
+    ret = load_file(ca_cert, &cert_buf, &cert_sz);
+    if (ret == 0) {
+        ret = wc_PemToDer(cert_buf, cert_sz, CERT_TYPE,
+            &pDer, NULL, &info, &eccKey);
+        AssertIntEQ(ret, 0);
+
+        wc_FreeDer(&pDer);
+    }
+
+    if (cert_buf)
+        free(cert_buf);
+#endif
+}
+
+static void test_wc_AllocDer(void)
+{
+#if !defined(NO_CERTS)
+    int ret;
+    DerBuffer* pDer = NULL;
+    word32 testSize = 1024;
+
+    printf(testingFmt, "wc_AllocDer()");
+
+    ret = wc_AllocDer(&pDer, testSize, CERT_TYPE, HEAP_HINT);
+    AssertIntEQ(ret, 0);
+    AssertNotNull(pDer);
+    wc_FreeDer(&pDer);
+#endif
+}
+
+static void test_wc_CertPemToDer(void)
+{
+#if !defined(NO_CERTS) && defined(WOLFSSL_PEM_TO_DER)
+    int ret;
+    const char* ca_cert = "./certs/ca-cert.pem";
+    byte* cert_buf = NULL;
+    size_t cert_sz = 0, cert_dersz = 0;
+    byte* cert_der = NULL;
+
+    printf(testingFmt, "wc_CertPemToDer()");
+
+    ret = load_file(ca_cert, &cert_buf, &cert_sz);
+    if (ret == 0) {
+        cert_dersz = cert_sz; /* DER will be smaller than PEM */
+        cert_der = (byte*)malloc(cert_dersz);
+        if (cert_der) {
+            ret = wc_CertPemToDer(cert_buf, (int)cert_sz,
+                cert_der, (int)cert_dersz, CERT_TYPE);
+            AssertIntGE(ret, 0);
+        }
+    }
+
+    if (cert_der)
+        free(cert_der);
+    if (cert_buf)
+        free(cert_buf);
+#endif
+}
+
 
 static void test_wolfSSL_certs(void)
 {
@@ -18207,7 +18281,7 @@ static void test_wolfSSL_d2i_PrivateKeys_bio(void)
     /*i2d RSAprivate key tests */
     bufPtr = buffer;
     AssertIntEQ(wolfSSL_i2d_RSAPrivateKey(NULL, NULL), BAD_FUNC_ARG);
-    AssertIntEQ(wolfSSL_i2d_RSAPrivateKey(rsa, &bufPtr), 
+    AssertIntEQ(wolfSSL_i2d_RSAPrivateKey(rsa, &bufPtr),
                                            sizeof_client_key_der_2048);
     RSA_free(rsa);
 #endif
@@ -20215,6 +20289,10 @@ void ApiTest(void)
     test_wolfSSL_PKCS8();
     test_wolfSSL_PKCS5();
     test_wolfSSL_URI();
+
+    test_wc_PemToDer();
+    test_wc_AllocDer();
+    test_wc_CertPemToDer();
 
     /*OCSP Stapling. */
     AssertIntEQ(test_wolfSSL_UseOCSPStapling(), WOLFSSL_SUCCESS);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7411,6 +7411,15 @@ void FreeDer(DerBuffer** pDer)
     }
 }
 
+int wc_AllocDer(DerBuffer** pDer, word32 length, int type, void* heap)
+{
+    return AllocDer(pDer, length, type, heap);
+}
+void wc_FreeDer(DerBuffer** pDer)
+{
+    FreeDer(pDer);
+}
+
 
 #if defined(WOLFSSL_PEM_TO_DER) || defined(WOLFSSL_DER_TO_PEM)
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -19313,7 +19313,7 @@ int berder_test(void)
 {
     int ret;
     int i;
-    word32 len, l;
+    word32 len = 0, l;
     byte out[32];
     static const byte good1_in[] = { 0x30, 0x80, 0x00, 0x00 };
     static const byte good1_out[] = { 0x30, 0x00 };

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -361,6 +361,9 @@ WOLFSSL_API int wc_GetDateAsCalendarTime(const byte* date, int length,
 
 #endif
 
+WOLFSSL_API  int wc_AllocDer(DerBuffer** pDer, word32 length, int type, void* heap);
+WOLFSSL_API void wc_FreeDer(DerBuffer** pDer);
+
 #ifdef WOLFSSL_PEM_TO_DER
     WOLFSSL_API int wc_PemToDer(const unsigned char* buff, long longSz, int type,
               DerBuffer** pDer, void* heap, EncryptedInfo* info, int* eccKey);


### PR DESCRIPTION
* Added API's to expose alloc/free of DerBuffer using `wc_AllocDer` and `wc_FreeDer`.
* Added unit tests for new API's and missing ones for `wc_PemToDer` and  `wc_CertPemToDer`.
ZD 4185.