### PR TITLE
redundant certificate fix

### DIFF
--- a/certs/ed25519/include.am
+++ b/certs/ed25519/include.am
@@ -23,7 +23,6 @@ EXTRA_DIST += \
          certs/ed25519/root-ed25519-priv.pem \
          certs/ed25519/server-ed25519.der \
          certs/ed25519/server-ed25519.pem \
-         certs/ed25519/server-ed25519-cert.pem \
          certs/ed25519/server-ed25519-key.der \
          certs/ed25519/server-ed25519-key.pem \
          certs/ed25519/server-ed25519-priv.der \

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -272,7 +272,7 @@
 #define cliEccCertFile "certs/client-ecc-cert.pem"
 #define caEccCertFile  "certs/ca-ecc-cert/pem"
 #define crlPemDir      "certs/crl"
-#define edCertFile     "certs/ed25519/server-ed25519-cert.pem"
+#define edCertFile     "certs/ed25519/server-ed25519.pem"
 #define edKeyFile      "certs/ed25519/server-ed25519-priv.pem"
 #define cliEdCertFile  "certs/ed25519/client-ed25519.pem"
 #define cliEdKeyFile   "certs/ed25519/client-ed25519-priv.pem"


### PR DESCRIPTION
a certificate was named in an automake include that isn't actually in the tree, a similar named certificate is actually used