### PR TITLE
DES IV

### DIFF
--- a/wolfssl/wolfcrypt/des3.h
+++ b/wolfssl/wolfcrypt/des3.h
@@ -49,7 +49,7 @@
 enum {
     DES_KEY_SIZE        =  8,  /* des                     */
     DES3_KEY_SIZE       = 24,  /* 3 des ede               */
-    DES_IV_SIZE         = 16,
+    DES_IV_SIZE         =  8,  /* should be the same as DES_BLOCK_SIZE */
 };
 
 


### PR DESCRIPTION
Change the DES_IV_SIZE back to 8 bytes, rather than 16.

DES/DES3 was passing the wolfCrypt test becuase the main DES code uses
the DES_BLOCK_SIZE when handling the IV. The TLS/SSL code uses the
DES_IV_SIZE when generating the session keys.