### PR TITLE
DH SP Fix

### DIFF
--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -2083,7 +2083,7 @@ static int sp_2048_mod_exp_45(sp_digit* r, sp_digit* a, sp_digit* e, int bits,
             n |= e[i--] << (9 - c);
             c += 23;
         }
-        y = n >> 27;
+        y = (n >> 27) & 0x1f;
         n <<= 5;
         c -= 5;
         XMEMCPY(rt, t[y], sizeof(rt));
@@ -3016,7 +3016,7 @@ static int sp_2048_mod_exp_90(sp_digit* r, sp_digit* a, sp_digit* e, int bits,
             n |= e[i--] << (9 - c);
             c += 23;
         }
-        y = n >> 27;
+        y = (n >> 27) & 0x1f;
         n <<= 5;
         c -= 5;
         XMEMCPY(rt, t[y], sizeof(rt));

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -1593,7 +1593,7 @@ static int sp_2048_mod_exp_18(sp_digit* r, sp_digit* a, sp_digit* e, int bits,
             n |= e[i--] << (7 - c);
             c += 57;
         }
-        y = n >> 59;
+        y = (n >> 59) & 0x1f;
         n <<= 5;
         c -= 5;
         XMEMCPY(rt, t[y], sizeof(rt));
@@ -2442,7 +2442,7 @@ static int sp_2048_mod_exp_36(sp_digit* r, sp_digit* a, sp_digit* e, int bits,
             n |= e[i--] << (7 - c);
             c += 57;
         }
-        y = n >> 59;
+        y = (n >> 59) & 0x1f;
         n <<= 5;
         c -= 5;
         XMEMCPY(rt, t[y], sizeof(rt));


### PR DESCRIPTION
When doing the sp_2048_mod_exp_*() is processed, one of the index
variables is masked with 0x1f when it was updated. Added the masking to
the initial set of the index.