### PR TITLE
NULL Check

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5699,8 +5699,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
         case TLS_ASYNC_DO:
         {
         #ifndef NO_RSA
-            if (args->sigAlgo == rsa_sa_algo ||
-                                             args->sigAlgo == rsa_pss_sa_algo) {
+            if (ssl->peerRsaKey != NULL && ssl->peerRsaKeyPresent != 0) {
                 WOLFSSL_MSG("Doing RSA peer cert verify");
 
                 ret = RsaVerify(ssl, sig->buffer, sig->length, &args->output,


### PR DESCRIPTION
When using the async option, the RSA key is checked on the first call to
DoTls13CertificateVerify() when the async state machine is set up. On
the subsequent call, the pointer to the key isn't checked again. Added a
check. (This was from a static analysis report.)