### PR TITLE
Refactor of the verify callback

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8390,13 +8390,13 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
         }
     }
 #ifdef WOLFSSL_ALWAYS_VERIFY_CB
-    /* use verify callback for success on peer leaf cert (not just failure) */
-    if (args->certIdx == 0 && ret == 0) {
+    /* always use verify callback on peer leaf cert */
+    if (args->certIdx == 0) {
         use_cb = 1;
     }
 #endif
 #ifdef WOLFSSL_VERIFY_CB_ALL_CERTS
-    /* only perform verify callback if not peer leaf cert at index 0 */
+    /* perform verify callback on other intermediate certs (not just peer) */
     if (args->certIdx > 0) {
         use_cb = 1;
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14439,6 +14439,9 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     WOLFSSL_X509* wolfSSL_get_peer_certificate(WOLFSSL* ssl)
     {
         WOLFSSL_ENTER("SSL_get_peer_certificate");
+        if (ssl == NULL)
+            return NULL;
+
         if (ssl->peerCert.issuer.sz)
             return &ssl->peerCert;
 #ifdef SESSION_CERTS

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -349,8 +349,10 @@ typedef struct WOLFSSL_BUFFER_INFO {
 
 typedef struct WOLFSSL_X509_STORE_CTX {
     WOLFSSL_X509_STORE* store;    /* Store full of a CA cert chain */
-    WOLFSSL_X509* current_cert;   /* stunnel dereference */
+    WOLFSSL_X509* current_cert;   /* current X509 (OPENSSL_EXTRA) */
+#ifdef WOLFSSL_ASIO
     WOLFSSL_X509* current_issuer; /* asio dereference */
+#endif
     WOLFSSL_X509_CHAIN* sesChain; /* pointer to WOLFSSL_SESSION peer chain */
     WOLFSSL_STACK* chain;
 #ifdef OPENSSL_EXTRA

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1417,6 +1417,7 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
      * store->certs[i]:     A `WOLFSSL_BUFFER_INFO` with plain DER for each cert
      * store->store:        WOLFSSL_X509_STORE with CA cert chain
      * store->store->cm:    WOLFSSL_CERT_MANAGER
+     * store->ex_data:      The WOLFSSL object pointer
      */
 
     printf("In verification callback, error = %d, %s\n", store->error,

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1408,6 +1408,17 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
 #endif
     (void)preverify;
 
+    /* Verify Callback Arguments:
+     * preverify:           1=Verify Okay, 0=Failure
+     * store->current_cert: Current WOLFSSL_X509 object (only with OPENSSL_EXTRA)
+     * store->error_depth:  Current Index
+     * store->domain:       Subject CN as string (null term)
+     * store->totalCerts:   Number of certs presented by peer
+     * store->certs[i]:     A `WOLFSSL_BUFFER_INFO` with plain DER for each cert
+     * store->store:        WOLFSSL_X509_STORE with CA cert chain
+     * store->store->cm:    WOLFSSL_CERT_MANAGER
+     */
+
     printf("In verification callback, error = %d, %s\n", store->error,
                                  wolfSSL_ERR_error_string(store->error, buffer));
 #ifdef OPENSSL_EXTRA
@@ -1436,9 +1447,11 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
     #endif
 #endif
 
-    printf("\tSubject's domain name is %s\n", store->domain);
+    printf("\tSubject's domain name at %d is %s\n", store->error_depth, store->domain);
 
-    printf("\tAllowing to continue anyway (shouldn't do this, EVER!!!)\n");
+    printf("\tAllowing to continue anyway (shouldn't do this)\n");
+
+    /* A non-zero return code indicates failure override */
     return 1;
 }
 


### PR DESCRIPTION
* Refactor of the verify callback to eliminate duplicate code and provide consistency with various build options.
* Fixes issue with the `store->current_cert` not being populated for final callback for cert index 0 (peer leaf cert). Applies to building with OPENSSL_EXTRA only.
* Fix for `store->domain` not always being populated.
* Added documentation for callback build options.
* Added code comments for new DoVerifyCallback function.
* Added documentation in test.h `myVerify` function for arguments and return code.
* Fix from commit da1ac36 which added `current_cert` to `WOLFSSL_X509_STORE_CTX`, but is only required for ASIO compatibility and is not used.
* Improvement to make sure ex_data is always populated.
* Added NULL arg check on `wolfSSL_get_peer_certificate`.

For ZD 4186.