### PR TITLE
Do not flush Client Hello when early data is available

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -14789,31 +14789,6 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
         }
     }
 
-    /* last time system socket output buffer was full, try again to send */
-    if (ssl->buffers.outputBuffer.length > 0) {
-        WOLFSSL_MSG("output buffer was full, trying to send again");
-        if ( (ssl->error = SendBuffered(ssl)) < 0) {
-            WOLFSSL_ERROR(ssl->error);
-            if (ssl->error == SOCKET_ERROR_E && (ssl->options.connReset ||
-                                                 ssl->options.isClosed)) {
-                ssl->error = SOCKET_PEER_CLOSED_E;
-                WOLFSSL_ERROR(ssl->error);
-                return 0;  /* peer reset or closed */
-            }
-            return ssl->error;
-        }
-        else {
-            /* advance sent to previous sent + plain size just sent */
-            sent = ssl->buffers.prevSent + ssl->buffers.plainSz;
-            WOLFSSL_MSG("sent write buffered data");
-
-            if (sent > sz) {
-                WOLFSSL_MSG("error: write() after WANT_WRITE with short size");
-                return ssl->error = BAD_FUNC_ARG;
-            }
-        }
-    }
-
 #ifdef WOLFSSL_DTLS
     if (ssl->options.dtls) {
         dtlsExtra = DTLS_RECORD_EXTRA;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2653,7 +2653,8 @@ int SendTls13ClientHello(WOLFSSL* ssl)
 
     ssl->buffers.outputBuffer.length += sendSz;
 
-    ret = SendBuffered(ssl);
+    if (ssl->earlyData == no_early_data)
+        ret = SendBuffered(ssl);
 
     WOLFSSL_LEAVE("SendTls13ClientHello", ret);
     WOLFSSL_END(WC_FUNC_CLIENT_HELLO_SEND);


### PR DESCRIPTION
In order to fully take advantage of TLS 1.3 and TCP Fast Open, the early data must be sent along with the Client Hello as part of the SYN's payload. From the point of view of the (Linux) socket API, this means one of two things:
 * sendmsg() must receive a buffer containing the Client Hello and early data, or
 * calling setsockopt(TCP_FASTOPEN_CONNECT), and then passing a buffer containing the same as above to send() (only on more recent versions of Linux)

This patch brings the following changes:
 * SendTls13ClientHello() doesn't call SendBuffered() if early data is present.
 * SendData() doesn't call SendBuffered() for leftover data; that data is sent out along with the first record.