### PR TITLE
call hamc init with blake2 software test

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -3448,7 +3448,7 @@ int hmac_blake2b_test(void)
             continue; /* cavium can't handle short keys, fips not allowed */
 #endif
 
-    #if defined(HAVE_CAVIUM) && !defined(HAVE_CAVIUM_V)
+    #if !defined(HAVE_CAVIUM_V)
         /* Blake2 only supported on Cavium Nitrox III */
         if (wc_HmacInit(&hmac, HEAP_HINT, devId) != 0)
             return -3600;


### PR DESCRIPTION
Fix for "Conditional jump or move depends on uninitialised value(s)" on hmac->macType.