### PR TITLE
check max key size with ocsp stapling test

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -718,8 +718,18 @@ static void ClientRead(WOLFSSL* ssl, char* reply, int replyLen, int mustRead)
 
 static void Usage(void)
 {
-    printf("client "    LIBWOLFSSL_VERSION_STRING
+    printf("wolfSSL client "    LIBWOLFSSL_VERSION_STRING
            " NOTE: All files relative to wolfSSL home dir\n");
+
+    /* print out so that scripts can know what the max supported key size is */
+    printf("Max key size in bits for build is set at : ");
+#ifdef USE_FAST_MATH
+    printf("%d\n", FP_MAX_BITS/2);
+#else
+    /* normal math has unlimited max size */
+    printf("INFINITE\n");
+#endif
+
     printf("-?          Help, print this usage\n");
     printf("-h <host>   Host to connect to, default %s\n", wolfSSLIP);
     printf("-p <num>    Port to connect on, not 0, default %d\n", wolfSSLPort);

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -722,8 +722,18 @@ static void Usage(void)
            " NOTE: All files relative to wolfSSL home dir\n");
 
     /* print out so that scripts can know what the max supported key size is */
-    printf("Max key size in bits for build is set at : ");
-#ifdef USE_FAST_MATH
+    printf("Max RSA key size in bits for build is set at : ");
+#ifdef NO_RSA
+    printf("RSA not supported\n");
+#elif defined(WOLFSSL_SP_MATH) /* case of SP math only */
+    #ifndef WOLFSSL_SP_NO_3072
+        printf("3072\n");
+    #elif !defined(WOLFSSL_SP_NO_2048)
+        printf("2048\n");
+    #else
+        printf("0\n");
+    #endif
+#elif defined(USE_FAST_MATH)
     printf("%d\n", FP_MAX_BITS/2);
 #else
     /* normal math has unlimited max size */

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -157,6 +157,18 @@ if [ $? -eq 0 ]; then
     exit 0
 fi
 
+# check if supported key size is large enough to handle 4096 bit RSA
+size=`./examples/client/client -? | grep "Max key"`
+size=`echo ${size//[^0-9]/}`
+if [ ! -z "$size" ]; then
+    printf 'check on max key size of %d ...' $size
+    if [ $size -lt 4096 ]; then
+        printf '%s\n' "4096 bit RSA keys not supported"
+        exit 0
+    fi
+    printf 'OK\n'
+fi
+
 # create a port 0 port to use with openssl ocsp responder
 ./examples/server/server -R $ready_file -p $resume_port &
 wait_for_readyFile $ready_file

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -167,6 +167,18 @@ trap cleanup EXIT INT TERM HUP
 
 [ ! -x ./examples/client/client ] && echo -e "\n\nClient doesn't exist" && exit 1
 
+# check if supported key size is large enough to handle 4096 bit RSA
+size=`./examples/client/client -? | grep "Max key"`
+size=`echo ${size//[^0-9]/}`
+if [ ! -z "$size" ]; then
+    printf 'check on max key size of %d ...' $size
+    if [ $size -lt 4096 ]; then
+        printf '%s\n' "4096 bit RSA keys not supported"
+        exit 0
+    fi
+    printf 'OK\n'
+fi
+
 #get four unique ports
 # 1:
 ./examples/server/server -R $ready_file1 -p $resume_port &


### PR DESCRIPTION
Intermediate certificate in test case requires the wolfSSL library to be able to handle 4096 bit RSA keys.