### PR TITLE
Enhancements to the GCC-ARM example

### DIFF
--- a/IDE/GCC-ARM/Makefile
+++ b/IDE/GCC-ARM/Makefile
@@ -13,4 +13,4 @@ WolfSSLStaticLib:
 
 clean:
 	rm -f $(BUILD_DIR)/*.elf $(BUILD_DIR)/*.hex $(BUILD_DIR)/*.map
-	rm -f $(BUILD_DIR)/*.o $(BUILD_DIR)/*.sym $(BUILD_DIR)/*.disasm
+	rm -f $(BUILD_DIR)/*.o $(BUILD_DIR)/*.a $(BUILD_DIR)/*.sym $(BUILD_DIR)/*.disasm

--- a/IDE/GCC-ARM/Makefile.common
+++ b/IDE/GCC-ARM/Makefile.common
@@ -5,50 +5,8 @@ CMD_ECHO =
 BUILD_DIR = ./Build
 
 # Toolchain location and prefix
+#TOOLCHAIN = 
 TOOLCHAIN = /opt/gcc-arm-none-eabi/bin/arm-none-eabi-
-
-INC = -I./Header \
-	  -I./Source \
-	  -I../..
-
-# Memory Map
-SRC_LD = -T./linker.ld
-
-# Defines
-DEF = -DWOLFSSL_USER_SETTINGS
-
-# Compiler and linker flags
-ARCHFLAGS = -mcpu=cortex-m0 -mthumb -mabi=aapcs
-DBGFLAGS = -ggdb
-ASFLAGS = $(ARCHFLAGS)
-
-# CC: Place functions and data into separate sections to allow dead code removal
-# by the linker (-f*-sections). Enable link time optimization (-flto)
-CFLAGS = $(ARCHFLAGS) -std=gnu99 -Wall -Wno-cpp \
-		 -ffunction-sections -fdata-sections \
-		 -Os -flto $(DBGFLAGS)
-
-# LD: Remove unused sections
-LDFLAGS = $(ARCHFLAGS) -Wl,--gc-sections
-
-# LD: Link with newlib-nano implementation
-LDFLAGS += --specs=nano.specs --specs=nosys.specs
-
-# LD: generate map
-LDFLAGS += -Wl,-Map=$(BUILD_DIR)/$(BIN).map $(DBGFLAGS)
-
-# LD: Entry point
-LDFLAGS += -Wl,-ereset_handler
-
-# Math lib (for DH)
-LIBS = -lm
-
-SRC_C += ./Source/armtarget.c
-SRC_C += $(wildcard ../../src/*.c ../../wolfcrypt/src/*.c ../../wolfcrypt/benchmark/*.c ../../wolfcrypt/test/*.c)
-FILENAMES_C = $(notdir $(SRC_C))
-FILENAMES_C := $(filter-out evp.c, $(FILENAMES_C))
-OBJS_C = $(addprefix $(BUILD_DIR)/, $(FILENAMES_C:.c=.o))
-vpath %.c $(dir $(SRC_C))
 
 # Tools selection
 CC = $(TOOLCHAIN)gcc
@@ -59,6 +17,147 @@ NM = $(TOOLCHAIN)nm
 OBJCOPY = $(TOOLCHAIN)objcopy
 OBJDUMP = $(TOOLCHAIN)objdump
 SIZE = $(TOOLCHAIN)size
+
+# Includes
+INC = -I./Header \
+	  -I./Source \
+	  -I../..
+
+# Defines
+DEF = -DWOLFSSL_USER_SETTINGS
+
+# Architecture
+ARCHFLAGS = -mcpu=cortex-m0 -mthumb -mabi=aapcs -DUSE_WOLF_ARM_STARTUP
+#ARCHFLAGS = -mcpu=cortex-r5 -mthumb -mabi=aapcs
+#ARCHFLAGS = -mcpu=cortex-a53 -mthumb -mabi=aapcs
+
+# Compiler and linker flags
+ASFLAGS = $(ARCHFLAGS)
+CFLAGS = $(ARCHFLAGS) -std=gnu99 -Wall -Wno-cpp
+LDFLAGS = $(ARCHFLAGS)
+
+# LD: Link with nosys
+LDFLAGS += --specs=nosys.specs
+
+# LD: Link with nano or rdimon implementation for standard library
+LDFLAGS += --specs=nano.specs
+#LDFLAGS += --specs=rdimon.specs
+
+# LD: generate map
+LDFLAGS += -Wl,-Map=$(BUILD_DIR)/$(BIN).map
+
+# LD: Entry point
+LDFLAGS += -Wl,-ereset_handler
+
+# Math lib (for DH)
+LIBS = -lm
+
+# Memory Map
+SRC_LD = -T./linker.ld
+
+# Optimization level and place functions / data into separate sections to allow dead code removal
+CFLAGS += -Os -ffunction-sections -fdata-sections -fno-builtin
+# Remove unused sections and link time optimizations
+LDFLAGS += -Wl,--gc-sections -flto
+
+# Debugging
+#DBGFLAGS = -ggdb -g3
+CFLAGS += $(DBGFLAGS)
+LDFLAGS += $(DBGFLAGS)
+
+
+# FILES
+
+# Port and Test/Benchmark
+SRC_C += ./Source/wolf_main.c
+SRC_C += ./Source/armtarget.c
+SRC_C += ../../wolfcrypt/test/test.c
+SRC_C += ../../wolfcrypt/benchmark/benchmark.c
+
+# WOLFSSL TLS FILES
+SRC_C += ../../src/crl.c
+SRC_C += ../../src/internal.c
+SRC_C += ../../src/keys.c
+SRC_C += ../../src/ocsp.c
+SRC_C += ../../src/sniffer.c
+SRC_C += ../../src/ssl.c
+SRC_C += ../../src/tls.c
+SRC_C += ../../src/tls13.c
+SRC_C += ../../src/wolfio.c
+
+# wolfCrypt Core (FIPS)
+SRC_C += ../../wolfcrypt/src/wolfcrypt_first.c
+SRC_C += ../../wolfcrypt/src/aes.c
+SRC_C += ../../wolfcrypt/src/cmac.c
+SRC_C += ../../wolfcrypt/src/des3.c
+SRC_C += ../../wolfcrypt/src/dh.c
+SRC_C += ../../wolfcrypt/src/ecc.c
+SRC_C += ../../wolfcrypt/src/hmac.c
+SRC_C += ../../wolfcrypt/src/random.c
+SRC_C += ../../wolfcrypt/src/rsa.c
+SRC_C += ../../wolfcrypt/src/sha.c
+SRC_C += ../../wolfcrypt/src/sha256.c
+SRC_C += ../../wolfcrypt/src/sha512.c
+SRC_C += ../../wolfcrypt/src/sha3.c
+SRC_C += ../../wolfcrypt/src/fips.c
+SRC_C += ../../wolfcrypt/src/fips_test.c
+SRC_C += ../../wolfcrypt/src/wolfcrypt_last.c
+
+# wolfCrypt Additional
+SRC_C += ../../wolfcrypt/src/asn.c
+SRC_C += ../../wolfcrypt/src/chacha.c
+SRC_C += ../../wolfcrypt/src/cmac.c
+SRC_C += ../../wolfcrypt/src/coding.c
+SRC_C += ../../wolfcrypt/src/compress.c
+SRC_C += ../../wolfcrypt/src/cpuid.c
+SRC_C += ../../wolfcrypt/src/cryptodev.c
+SRC_C += ../../wolfcrypt/src/curve25519.c
+SRC_C += ../../wolfcrypt/src/ed25519.c
+SRC_C += ../../wolfcrypt/src/error.c
+SRC_C += ../../wolfcrypt/src/fe_low_mem.c
+SRC_C += ../../wolfcrypt/src/fe_operations.c
+SRC_C += ../../wolfcrypt/src/ge_low_mem.c
+SRC_C += ../../wolfcrypt/src/ge_operations.c
+SRC_C += ../../wolfcrypt/src/hash.c
+SRC_C += ../../wolfcrypt/src/integer.c
+SRC_C += ../../wolfcrypt/src/logging.c
+SRC_C += ../../wolfcrypt/src/md5.c
+SRC_C += ../../wolfcrypt/src/memory.c
+SRC_C += ../../wolfcrypt/src/misc.c
+SRC_C += ../../wolfcrypt/src/pkcs12.c
+SRC_C += ../../wolfcrypt/src/pkcs7.c
+SRC_C += ../../wolfcrypt/src/poly1305.c
+SRC_C += ../../wolfcrypt/src/pwdbased.c
+SRC_C += ../../wolfcrypt/src/signature.c
+SRC_C += ../../wolfcrypt/src/srp.c
+SRC_C += ../../wolfcrypt/src/sp_arm32.c
+SRC_C += ../../wolfcrypt/src/sp_arm64.c
+SRC_C += ../../wolfcrypt/src/sp_c32.c
+SRC_C += ../../wolfcrypt/src/sp_int.c
+SRC_C += ../../wolfcrypt/src/tfm.c
+SRC_C += ../../wolfcrypt/src/wc_encrypt.c
+SRC_C += ../../wolfcrypt/src/wc_port.c
+SRC_C += ../../wolfcrypt/src/wolfevent.c
+SRC_C += ../../wolfcrypt/src/wolfmath.c
+
+# wolfCrypt non-standard algorithms (disabled by default)
+SRC_C += ../../wolfcrypt/src/arc4.c
+SRC_C += ../../wolfcrypt/src/blake2b.c
+SRC_C += ../../wolfcrypt/src/camellia.c
+SRC_C += ../../wolfcrypt/src/dsa.c
+SRC_C += ../../wolfcrypt/src/hc128.c
+SRC_C += ../../wolfcrypt/src/idea.c
+SRC_C += ../../wolfcrypt/src/md2.c
+SRC_C += ../../wolfcrypt/src/md4.c
+SRC_C += ../../wolfcrypt/src/rabbit.c
+SRC_C += ../../wolfcrypt/src/ripemd.c
+
+
+FILENAMES_C = $(notdir $(SRC_C))
+FILENAMES_C := $(filter-out evp.c, $(FILENAMES_C))
+OBJS_C = $(addprefix $(BUILD_DIR)/, $(FILENAMES_C:.c=.o))
+vpath %.c $(dir $(SRC_C))
+
 
 build_hex: $(BUILD_DIR) $(BUILD_DIR)/$(BIN).hex
 	@echo ""
@@ -90,6 +189,9 @@ $(BUILD_DIR)/$(BIN).elf: $(OBJS_ASM) $(OBJS_C)
 	@echo "Generating name list: $(BIN).sym"
 	$(CMD_ECHO) $(NM) -n $@ > $(BUILD_DIR)/$(BIN).sym
 
+	@echo "Showing final size:"
+	$(CMD_ECHO) ls -la $@
+
 	@echo "Generating disassembly: $(BIN).disasm"
 	$(CMD_ECHO) $(OBJDUMP) -S $@ > $(BUILD_DIR)/$(BIN).disasm
 
@@ -99,6 +201,9 @@ $(BUILD_DIR)/$(BIN).a: $(OBJS_ASM) $(OBJS_C)
 
 	@echo "Generating name list: $(BIN).sym"
 	$(CMD_ECHO) $(NM) -n $@ > $(BUILD_DIR)/$(BIN).sym
+
+	@echo "Showing final size:"
+	$(CMD_ECHO) ls -la $@
 
 	@echo "Generating disassembly: $(BIN).disasm"
 	$(CMD_ECHO) $(OBJDUMP) -S $@ > $(BUILD_DIR)/$(BIN).disasm

--- a/IDE/GCC-ARM/README.md
+++ b/IDE/GCC-ARM/README.md
@@ -14,50 +14,69 @@ This example is for Cortex M series, but can be adopted for other architectures.
 1. Make sure you have `gcc-arm-none-eabi` installed.
 2. Modify the `Makefile.common`:
   * Use correct toolchain path `TOOLCHAIN`.
-  * Use correct architecture 'ARCHFLAGS' (default is cortex-m0 / thumb). See [GCC ARM Options](https://gcc.gnu.org/onlinedocs/gcc-4.7.3/gcc/ARM-Options.html) `-mcpu=name`.
-3. Use `make` and it will build the static library and wolfCrypt test/benchmark and wolfSSL TLS client targets as `.elf` and `.hex` in `/Build`.
+  * Use correct architecture 'ARCHFLAGS'. See [GCC ARM Options](https://gcc.gnu.org/onlinedocs/gcc-4.7.3/gcc/ARM-Options.html) `-mcpu=name`.
+  * Confirm memory map in linker.ld matches your flash/ram or comment out `SRC_LD = -T./linker.ld` in Makefile.common.
+3. Use `make` to build the static library (libwolfssl.a), wolfCrypt test/benchmark and wolfSSL TLS client targets as `.elf` and `.hex` in `/Build`.
 
-### Building for Raspberry Pi
 
-Example `Makefile.common` changes for Rasperry Pi with Cortex-A53:
+## Building for Raspberry Pi
 
-1. Change ARCHFLAGS to `ARCHFLAGS = -mcpu=cortex-a53 -mthumb -mabi=aapcs` to specify Cortex-A53.
+Example `Makefile.common` changes for Raspberry Pi with Cortex-A53:
+
+1. In Makefile.common change `ARCHFLAGS` to `-mcpu=cortex-a53 -mthumb`.
 2. Comment out `SRC_LD`, since custom memory map is not applicable.
 3. Clear `TOOLCHAIN`, so it will use default `gcc`. Set `TOOLCHAIN = `
-4. Comment out `LDFLAGS += --specs=nano.specs --specs=nosys.specs` to disable newlib-nano.
+4. Comment out `LDFLAGS += --specs=nano.specs` and `LDFLAGS += --specs=nosys.specs` to nosys and nano.
 
 Note: To comment out a line in a Makefile use place `#` in front of line.
 
-### Example Build
+## Building for FIPS
+
+1. Request evaluation from wolfSSL by emailing fips@wolfss.com.
+2. Modify user_settings.h so section for `HAVE_FIPS` is enabled.
+3. Use `make`.
+4. Run the wolfCrypt test `./Build/WolfCryptTest.elf` to generate the FIPS boundary HASH
+
+Example:
 
 ```
-make clean && make
-
-   text	   data	    bss	    dec	    hex   filename
-  50076	   2508	     44	  52628	   cd94   ./Build/WolfCryptTest.elf
-
-   text	   data	    bss	    dec	    hex   filename
-  39155	   2508	     60	  41723	   a2fb   ./Build/WolfCryptBench.elf
-
-   text	   data	    bss	    dec	    hex	filename
-  70368	    464	     36	  70868	  114d4	./Build/WolfSSLClient.elf
+$ Crypt Test
+error    test passed!
+base64   test passed!
+base16   test passed!
+asn      test passed!
+in my Fips callback, ok = 0, err = -203
+message = In Core Integrity check FIPS error
+hash = F607C7B983D1D283590448A56381DE460F1E83CB02584F4D77B7F2C583A8F5CD
+In core integrity hash check failure, copy above hash
+into verifyCore[] in fips_test.c and rebuild
+SHA      test failed!
+ error = -1802
+Crypt Test: Return code -1
 ```
 
-### Building with configure
+5. Update the `../../wolfcrypt/src/fips_test.c` array `static const char verifyCore[] = {}` with the correct core hash check.
+6. Build again using `make`.
+7. Run the wolfCrypt test.
+
+## Building with configure
 
 The configure script in the main project directory can perform a cross-compile
 build with the the gcc-arm-none-eabi tools. Assuming the tools are installed in
 your executable path:
 
 ```
-$ ./configure CFLAGS="-march=armv8-a \
-    --specs=nosys.specs -DHAVE_PK_CALLBACKS \
-    -DWOLFSSL_USER_IO -DNO_WRITEV" \
-    --host=arm-non-eabi --disable-filesystem \
-    --enable-fastmath --disable-shared \
-    CC=arm-none-eabi-gcc AR=arm-none-eabi-ar \
-    STRIP=arm-none-eabi-strip RANLIB=arm-none-eabi-ranlib \
-    --prefix=/path/to/build/wolfssl-arm
+$ ./configure \
+    --host=arm-non-eabi \
+    CC=arm-none-eabi-gcc \
+    AR=arm-none-eabi-ar \
+    STRIP=arm-none-eabi-strip \
+    RANLIB=arm-none-eabi-ranlib \
+    --prefix=/path/to/build/wolfssl-arm \
+    CFLAGS="-march=armv8-a --specs=nosys.specs \
+        -DHAVE_PK_CALLBACKS -DWOLFSSL_USER_IO -DNO_WRITEV" \
+    --disable-filesystem --enable-fastmath \
+    --disable-shared
 $ make
 $ make install
 ```
@@ -65,7 +84,22 @@ $ make install
 If you are building for a 32-bit architecture, add `-DTIME_T_NOT_LONG` to the
 list of CFLAGS.
 
-## Performace Tuning Options
+## Example Build Output
+
+```
+make clean && make
+
+   text    data     bss     dec     hex   filename
+  50076    2508      44   52628    cd94   ./Build/WolfCryptTest.elf
+
+   text    data     bss     dec     hex   filename
+  39155    2508      60   41723    a2fb   ./Build/WolfCryptBench.elf
+
+   text    data     bss     dec     hex filename
+  70368     464      36   70868   114d4 ./Build/WolfSSLClient.elf
+```
+
+## Performance Tuning Options
 
 These settings are located in `Header/user_settings.h`.
 
@@ -79,7 +113,7 @@ These settings are located in `Header/user_settings.h`.
 * `ECC_TIMING_RESISTANT`: Enables timing resistance for ECC and uses slightly less memory.
 * `ECC_SHAMIR`: Doubles heap usage, but slightly faster
 * `RSA_LOW_MEM`: Half as much memory but twice as slow. Uses Non-CRT method for private key.
-AES GCM: `GCM_SMALL`, `GCM_WORD32` or `GCM_TABLE`: Tunes performance and flash/memory usage.
+* AES GCM: `GCM_SMALL`, `GCM_WORD32` or `GCM_TABLE`: Tunes performance and flash/memory usage.
 * `CURVED25519_SMALL`: Enables small versions of Ed/Curve (FE/GE math).
 * `USE_SLOW_SHA`: Enables smaller/slower version of SHA.
 * `USE_SLOW_SHA256`: About 2k smaller and about 25% slower
@@ -87,3 +121,5 @@ AES GCM: `GCM_SMALL`, `GCM_WORD32` or `GCM_TABLE`: Tunes performance and flash/m
 * `USE_CERT_BUFFERS_1024` or `USE_CERT_BUFFERS_2048`: Size of RSA certs / keys to test with. 
 * `BENCH_EMBEDDED`: Define this if using the wolfCrypt test/benchmark and using a low memory target.
 * `ECC_USER_CURVES`: Allows user to defines curve sizes to enable. Default is 256-bit on. To enable others use `HAVE_ECC192`, `HAVE_ECC224`, etc....
+* `TFM_ARM`, `TFM_SSE2`, `TFM_AVR32`, `TFM_PPC32`, `TFM_MIPS`, `TFM_X86` or `TFM_X86_64`: These are assembly optimizations available with USE_FAST_MATH.
+* Single Precision Math for ARM: See `WOLFSSL_SP`. Optimized math for ARM performance of specific RSA, DH and ECC algorithms.

--- a/IDE/GCC-ARM/Source/benchmark_main.c
+++ b/IDE/GCC-ARM/Source/benchmark_main.c
@@ -20,10 +20,12 @@
  */
 
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfcrypt/benchmark/benchmark.h>
 #include <stdio.h>
 
+#ifndef NO_CRYPT_BENCHMARK
 typedef struct func_args {
     int    argc;
     char** argv;
@@ -31,17 +33,22 @@ typedef struct func_args {
 } func_args;
 
 static func_args args = { 0 } ;
-
+#endif
 
 int main(void)
 {
+    int ret;
+#ifndef NO_CRYPT_BENCHMARK
 	wolfCrypt_Init();
 
 	printf("\nBenchmark Test\n");
 	benchmark_test(&args);
-	printf("Benchmark Test: Return code %d\n", args.return_code);
+    ret = args.return_code;
+	printf("Benchmark Test: Return code %d\n", ret);
 
 	wolfCrypt_Cleanup();
-
-	return 0;
+#else
+    ret = NOT_COMPILED_IN;
+#endif
+	return ret;
 }

--- a/IDE/GCC-ARM/Source/test_main.c
+++ b/IDE/GCC-ARM/Source/test_main.c
@@ -22,9 +22,11 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/logging.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfcrypt/test/test.h>
 #include <stdio.h>
 
+#ifndef NO_CRYPT_TEST
 typedef struct func_args {
     int    argc;
     char** argv;
@@ -32,16 +34,22 @@ typedef struct func_args {
 } func_args;
 
 static func_args args = { 0 } ;
+#endif
 
 int main(void)
 {
+    int ret;
+#ifndef NO_CRYPT_TEST
 	wolfCrypt_Init();
 
 	printf("\nCrypt Test\n");
 	wolfcrypt_test(&args);
-	printf("Crypt Test: Return code %d\n", args.return_code);
+    ret = args.return_code;
+	printf("Crypt Test: Return code %d\n", ret);
 
 	wolfCrypt_Cleanup();
-
-	return 0;
+#else
+    ret = NOT_COMPILED_IN;
+#endif
+	return ret;
 }

--- a/IDE/GCC-ARM/Source/tls_client.c
+++ b/IDE/GCC-ARM/Source/tls_client.c
@@ -21,6 +21,10 @@
 
 
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#ifndef WOLFCRYPT_ONLY
+
 #include <wolfssl/ssl.h>
 #include <wolfssl/wolfcrypt/logging.h>
 #include <stdio.h>
@@ -182,17 +186,22 @@ fail:
 
     return -1;
 }
+#endif
 
 
 int main(void)
 {
     int ret;
 
+#ifndef WOLFCRYPT_ONLY
     wolfSSL_Init();
 
     ret = tls_client();
 
     wolfSSL_Cleanup();
+#else
+    ret = NOT_COMPILED_IN;
+#endif
 
 	return ret;
 }

--- a/IDE/GCC-ARM/Source/wolf_main.c
+++ b/IDE/GCC-ARM/Source/wolf_main.c
@@ -1,0 +1,142 @@
+/* wolf_main.c
+ *
+ * Copyright (C) 2006-2018 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/random.h> /* for CUSTOM_RAND_TYPE */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+
+
+/* TIME CODE */
+/* TODO: Implement real RTC */
+/* Optionally you can define NO_ASN_TIME to disable all cert time checks */
+static int gTimeMs;
+static int hw_get_time_sec(void)
+{
+    #warning Must implement your own time source if validating certificates
+
+	return ++gTimeMs;
+}
+
+/* This is used by wolfCrypt asn.c for cert time checking */
+unsigned long my_time(unsigned long* timer)
+{
+    (void)timer;
+    return hw_get_time_sec();
+}
+
+#ifndef WOLFCRYPT_ONLY
+/* This is used by TLS only */
+unsigned int LowResTimer(void)
+{
+    return hw_get_time_sec();
+}
+#endif
+
+#ifndef NO_CRYPT_BENCHMARK
+/* This is used by wolfCrypt benchmark tool only */
+double current_time(int reset)
+{
+    double time;
+	int timeMs = gTimeMs;
+    (void)reset;
+    time = (timeMs / 1000); // sec
+    time += (double)(timeMs % 1000) / 1000; // ms
+    return time;
+}
+#endif
+
+/* RNG CODE */
+/* TODO: Implement real RNG */
+static unsigned int gCounter;
+unsigned int hw_rand(void)
+{
+    #warning Must implement your own random source
+
+    return ++gCounter;
+}
+
+unsigned int my_rng_seed_gen(void)
+{
+    return hw_rand();
+}
+
+int my_rng_gen_block(unsigned char* output, unsigned int sz)
+{
+    uint32_t i = 0;
+
+    while (i < sz)
+    {
+        /* If not aligned or there is odd/remainder */
+        if( (i + sizeof(CUSTOM_RAND_TYPE)) > sz ||
+            ((uint32_t)&output[i] % sizeof(CUSTOM_RAND_TYPE)) != 0
+        ) {
+            /* Single byte at a time */
+            output[i++] = (unsigned char)my_rng_seed_gen();
+        }
+        else {
+            /* Use native 8, 16, 32 or 64 copy instruction */
+            *((CUSTOM_RAND_TYPE*)&output[i]) = my_rng_seed_gen();
+            i += sizeof(CUSTOM_RAND_TYPE);
+        }
+    }
+
+    return 0;
+}
+
+
+#ifdef XMALLOC_OVERRIDE
+void *myMalloc(size_t n, void* heap, int type)
+{
+    (void)n;
+    (void)heap;
+    (void)type;
+
+    #warning Must implement your own malloc
+
+    return NULL;
+}
+void myFree(void *p, void* heap, int type)
+{
+    (void)p;
+    (void)heap;
+    (void)type;
+
+    #warning Must implement your own free
+}
+
+/* Required for normal math (!USE_FAST_MATH) */
+void *myRealloc(void *p, size_t n, void* heap, int type)
+{
+    (void)p;
+    (void)n;
+    (void)heap;
+    (void)type;
+
+    #warning Must implement your own realloc
+
+    return NULL;
+}
+#endif /* XMALLOC_OVERRIDE */

--- a/IDE/GCC-ARM/include.am
+++ b/IDE/GCC-ARM/include.am
@@ -4,6 +4,7 @@
 
 EXTRA_DIST+= IDE/GCC-ARM/Header/user_settings.h
 EXTRA_DIST+= IDE/GCC-ARM/Source/armtarget.c
+EXTRA_DIST+= IDE/GCC-ARM/Source/wolf_main.c
 EXTRA_DIST+= IDE/GCC-ARM/Source/benchmark_main.c
 EXTRA_DIST+= IDE/GCC-ARM/Source/test_main.c
 EXTRA_DIST+= IDE/GCC-ARM/Source/tls_client.c


### PR DESCRIPTION
* Fixes for building without test, benchmark or TLS.
* Additional build options for FIPS, SP, DH, AES modes, DES3, SHA224.
* Added examples for memory overrides and standard library overrides.
* Changed the ARM startup code to only work for the Cortex M0 example using the define `USE_WOLF_ARM_STARTUP`.