### PR TITLE
Fixes for building with `WC_NO_RNG`

### DIFF
--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -954,6 +954,7 @@ int wc_FreeDhKey(DhKey* key)
 }
 
 
+#ifndef WC_NO_RNG
 /* if defined to not use floating point values do not compile in */
 #ifndef WOLFSSL_DH_CONST
     static word32 DiscreteLogWorkFactor(word32 n)
@@ -1142,11 +1143,12 @@ static int GeneratePrivateDh186(DhKey* key, WC_RNG* rng, byte* priv,
     return err;
 }
 #endif /* WOLFSSL_NO_DH186 */
-
+#endif /* !WC_NO_RNG */
 
 static int GeneratePrivateDh(DhKey* key, WC_RNG* rng, byte* priv,
                              word32* privSz)
 {
+#ifndef WC_NO_RNG
     int ret = 0;
     word32 sz = 0;
 
@@ -1198,6 +1200,13 @@ static int GeneratePrivateDh(DhKey* key, WC_RNG* rng, byte* priv,
     }
 
     return ret;
+#else
+    (void)key;
+    (void)rng;
+    (void)priv;
+    (void)privSz;
+    return NOT_COMPILED_IN;
+#endif /* WC_NO_RNG */
 }
 
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3677,6 +3677,7 @@ int wc_ecc_point_is_at_infinity(ecc_point* p)
 /* generate random and ensure its greater than 0 and less than order */
 static int wc_ecc_gen_k(WC_RNG* rng, int size, mp_int* k, mp_int* order)
 {
+#ifndef WC_NO_RNG
     int err;
     DECLARE_VAR(buf, byte, ECC_MAXSIZE_GEN, rng->heap);
 
@@ -3708,8 +3709,15 @@ static int wc_ecc_gen_k(WC_RNG* rng, int size, mp_int* k, mp_int* order)
     FREE_VAR(buf, rng->heap);
 
     return err;
+#else
+    (void)rng;
+    (void)size;
+    (void)k;
+    (void)order;
+    return NOT_COMPILED_IN;
+#endif /* !WC_NO_RNG */
 }
-#endif
+#endif /* WOLFSSL_SP_MATH */
 #endif /* !WOLFSSL_ATECC508A */
 
 static WC_INLINE void wc_ecc_reset(ecc_key* key)

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -2947,6 +2947,7 @@ int mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng)
         }
     }
 
+#ifndef WC_NO_RNG
     /* now do a miller rabin with up to t random numbers, this should
      * give a (1/4)^t chance of a false prime. */
     if (ret == FP_YES) {
@@ -2989,12 +2990,14 @@ int mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng)
             XFREE(base, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
     }
+#else
+    (void)t;
+#endif /* !WC_NO_RNG */
 
     *result = ret;
     return FP_OKAY;
 }
-
-#endif /* NO_RSA NO_DSA NO_DH WOLFSSL_KEY_GEN */
+#endif /* !NO_RSA || !NO_DSA || !NO_DH || WOLFSSL_KEY_GEN */
 
 
 #ifdef WOLFSSL_KEY_GEN

--- a/wolfcrypt/src/wolfmath.c
+++ b/wolfcrypt/src/wolfmath.c
@@ -91,6 +91,7 @@ mp_digit get_digit(mp_int* a, int n)
     return (n >= a->used || n < 0) ? 0 : a->dp[n];
 }
 
+#ifndef WC_NO_RNG
 int get_rand_digit(WC_RNG* rng, mp_digit* d)
 {
     return wc_RNG_GenerateBlock(rng, (byte*)d, sizeof(mp_digit));
@@ -149,6 +150,7 @@ exit:
     return ret;
 }
 #endif /* WC_RSA_BLINDING */
+#endif
 
 /* export an mp_int as unsigned char or hex string
  * encType is WC_TYPE_UNSIGNED_BIN or WC_TYPE_HEX_STR

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -178,7 +178,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* seed, word32 sz);
     WOLFSSL_API int  wc_FreeNetRandom(void);
 #endif /* HAVE_WNR */
 
-
+#ifndef WC_NO_RNG
 WOLFSSL_API int  wc_InitRng(WC_RNG*);
 WOLFSSL_API int  wc_InitRng_ex(WC_RNG* rng, void* heap, int devId);
 WOLFSSL_API int  wc_InitRngNonce(WC_RNG* rng, byte* nonce, word32 nonceSz);
@@ -187,6 +187,16 @@ WOLFSSL_API int  wc_InitRngNonce_ex(WC_RNG* rng, byte* nonce, word32 nonceSz,
 WOLFSSL_API int  wc_RNG_GenerateBlock(WC_RNG*, byte*, word32 sz);
 WOLFSSL_API int  wc_RNG_GenerateByte(WC_RNG*, byte*);
 WOLFSSL_API int  wc_FreeRng(WC_RNG*);
+#else
+#define wc_InitRng(rng) NOT_COMPILED_IN
+#define wc_InitRng_ex(rng, h, d) NOT_COMPILED_IN
+#define wc_InitRngNonce(rng, n, s) NOT_COMPILED_IN
+#define wc_InitRngNonce_ex(rng, n, s, h, d) NOT_COMPILED_IN
+#define wc_RNG_GenerateBlock(rng, b, s) NOT_COMPILED_IN
+#define wc_RNG_GenerateByte(rng, b) NOT_COMPILED_IN
+#define wc_FreeRng(rng) NOT_COMPILED_IN
+#endif
+
 
 
 #ifdef HAVE_HASHDRBG

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -732,7 +732,7 @@ MP_API int mp_radix_size (mp_int * a, int radix, int *size);
 #if !defined(NO_DH) || !defined(NO_DSA) || !defined(NO_RSA) || defined(WOLFSSL_KEY_GEN)
 MP_API int  mp_prime_is_prime(mp_int* a, int t, int* result);
 MP_API int  mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng);
-#endif /* NO_DH NO_DSA NO_RSA WOLFSSL_KEY_GEN */
+#endif /* !NO_DH || !NO_DSA || !NO_RSA || WOLFSSL_KEY_GEN */
 #ifdef WOLFSSL_KEY_GEN
 MP_API int  mp_gcd(fp_int *a, fp_int *b, fp_int *c);
 MP_API int  mp_lcm(fp_int *a, fp_int *b, fp_int *c);


### PR DESCRIPTION
Applies to wolfCrypt only builds. Tested with `./configure --enable-cryptonly CFLAGS="-DWC_NO_RNG" && make`.