### PR TITLE
Fix for building certext without certgen

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1207,10 +1207,6 @@ AC_ARG_ENABLE([certext],
 
 if test "$ENABLED_CERTEXT" = "yes"
 then
-    if test "$ENABLED_CERTGEN" = "no"
-    then
-        AC_MSG_ERROR([cannot enable certext without enabling certgen.])
-    fi
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_CERT_EXT"
 fi
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -10076,7 +10076,7 @@ static int test_RsaDecryptBoundsCheck(void)
 static int test_wc_SetKeyUsage (void)
 {
     int     ret = 0;
-#if !defined(NO_RSA) && defined(WOLFSSL_CERT_EXT) && !defined(HAVE_FIPS)
+#if !defined(NO_RSA) && defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_CERT_GEN) && !defined(HAVE_FIPS)
     Cert    myCert;
 
     ret = wc_InitCert(&myCert);
@@ -18217,7 +18217,7 @@ static void test_wolfSSL_d2i_PrivateKeys_bio(void)
     EVP_PKEY* pkey  = NULL;
     RSA*  rsa  = NULL;
     WOLFSSL_CTX* ctx;
-    
+
 #if defined(WOLFSSL_KEY_GEN)
     unsigned char buffer[4096];
     unsigned char* bufPtr;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8510,7 +8510,7 @@ byte GetEntropy(ENTROPY_CMD cmd, byte* out)
 #endif /* HAVE_ECC */
 
 #ifndef NO_RSA
-    #if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
+    #ifdef WOLFSSL_CERT_GEN
         static const char* otherCertDerFile = CERT_PREFIX "othercert.der";
         static const char* certDerFile = CERT_PREFIX "cert.der";
     #endif

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -158,8 +158,7 @@ typedef struct EncryptedInfo {
 } EncryptedInfo;
 
 
-#ifdef WOLFSSL_CERT_GEN
-
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
 #ifdef WOLFSSL_EKU_OID
     #ifndef CTC_MAX_EKU_NB
         #define CTC_MAX_EKU_NB 1
@@ -171,7 +170,9 @@ typedef struct EncryptedInfo {
     #undef CTC_MAX_EKU_OID_SZ
     #define CTC_MAX_EKU_OID_SZ 0
 #endif
+#endif /* WOLFSSL_CERT_GEN || WOLFSSL_CERT_EXT */
 
+#ifdef WOLFSSL_CERT_GEN
 
 #ifdef WOLFSSL_MULTI_ATTRIB
 #ifndef CTC_MAX_ATTRIB


### PR DESCRIPTION
* Fix for building `WOLFSSL_CERT_EXT` without `WOLFSSL_CERT_GEN`. It had error with missing `CTC_MAX_EKU_OID_SZ`.
* Change to allow --enable-certext without certgen.