### PR TITLE
Fix error with wolfCrypt-JNI having ECC_PRIVATEKEY_ONLY and d != NULL

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6428,7 +6428,10 @@ int wc_ecc_export_ex(ecc_key* key, byte* qx, word32* qxLen,
 
     /* private key, d */
     if (d != NULL) {
-        if (dLen == NULL || key->type != ECC_PRIVATEKEY)
+        if (dLen == NULL)
+            return BAD_FUNC_ARG;
+
+        if (!(key->type == ECC_PRIVATEKEY || key->type == ECC_PRIVATEKEY_ONLY))
             return BAD_FUNC_ARG;
 
     #ifdef WOLFSSL_ATECC508A

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6428,8 +6428,8 @@ int wc_ecc_export_ex(ecc_key* key, byte* qx, word32* qxLen,
 
     /* private key, d */
     if (d != NULL) {
-        if (dLen == NULL || (!(key->type == ECC_PRIVATEKEY
-                            || key->type == ECC_PRIVATEKEY_ONLY)))
+        if (dLen == NULL || 
+            (key->type != ECC_PRIVATEKEY && key->type != ECC_PRIVATEKEY_ONLY))
             return BAD_FUNC_ARG;
 
     #ifdef WOLFSSL_ATECC508A

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6428,10 +6428,8 @@ int wc_ecc_export_ex(ecc_key* key, byte* qx, word32* qxLen,
 
     /* private key, d */
     if (d != NULL) {
-        if (dLen == NULL)
-            return BAD_FUNC_ARG;
-
-        if (!(key->type == ECC_PRIVATEKEY || key->type == ECC_PRIVATEKEY_ONLY))
+        if (dLen == NULL || (!(key->type == ECC_PRIVATEKEY
+                            || key->type == ECC_PRIVATEKEY_ONLY)))
             return BAD_FUNC_ARG;
 
     #ifdef WOLFSSL_ATECC508A


### PR DESCRIPTION
Problem:
The ant test for wolfCrypt-JNI would fail due to BAD_FUNC_ARG.

Analysis:
wolfCrypt-JNI would call **wc_ecc_import_private_key_ex** with **pub** == NULL, so that **key->type** is assigned ECC_PRIVATEKEY_ONLY.

When wolfCrypt-JNI calls **wc_ecc_export_ex** it would pass in a non-NULL output corresponding to **byte* d**.  Then **wc_ecc_export_ex** would check if **d**  was non-NULL and after that passed it would fail on the check for key->type != ECC_PRIVATEKEY since it was assigned ECC_PRIVATEKEY_ONLY.
