### PR TITLE
Fix for old certs not discarded when server does not resume session

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -9751,6 +9751,14 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     WOLFSSL_START(WC_FUNC_CERTIFICATE_DO);
     WOLFSSL_ENTER("DoCertificate");
 
+#ifdef SESSION_CERTS
+    /* Reset the session cert chain count in case the session resume failed. */
+    ssl->session.chain.count = 0;
+    #ifdef WOLFSSL_ALT_CERT_CHAINS
+        ssl->session.altChain.count = 0;
+    #endif
+#endif /* SESSION_CERTS */
+
     ret = ProcessPeerCerts(ssl, input, inOutIdx, size);
 
 #ifdef OPENSSL_EXTRA


### PR DESCRIPTION
Using TLS session certs, when resuming and the server creates a new session, the old session certificate chain is not reset. This causes the chain to grow to ```MAX_CHAIN_DEPTH``` with each failed session resume.

A non-trivial test case was provided and the fix was checked against it.