### PR TITLE
Patches for various build errors

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -120,7 +120,7 @@ static int NonBlockingSSL_Accept(SSL* ssl)
 #ifndef WOLFSSL_CALLBACKS
     int ret = SSL_accept(ssl);
 #else
-    int ret = SSL_accept_ex(ssl, srvHandShakeCB, srvTimeoutCB, srvTo);
+    int ret = wolfSSL_accept_ex(ssl, srvHandShakeCB, srvTimeoutCB, srvTo);
 #endif
     int error = SSL_get_error(ssl, 0);
     SOCKET_T sockfd = (SOCKET_T)SSL_get_fd(ssl);
@@ -163,7 +163,7 @@ static int NonBlockingSSL_Accept(SSL* ssl)
             #ifndef WOLFSSL_CALLBACKS
                 ret = SSL_accept(ssl);
             #else
-                ret = SSL_accept_ex(ssl,
+                ret = wolfSSL_accept_ex(ssl,
                                     srvHandShakeCB, srvTimeoutCB, srvTo);
             #endif
             error = SSL_get_error(ssl, 0);

--- a/src/internal.c
+++ b/src/internal.c
@@ -16346,7 +16346,7 @@ void PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
             char* packetName = info->packetNames[info->numberPackets];
             XSTRNCPY(packetName, name, MAX_PACKETNAME_SZ);
             packetName[MAX_PACKETNAME_SZ] = '\0';
-            info->numberPackets++
+            info->numberPackets++;
         }
     #endif
         (void)ssl;

--- a/wolfssl/callbacks.h
+++ b/wolfssl/callbacks.h
@@ -52,7 +52,15 @@ typedef struct handShakeInfo_st {
 } HandShakeInfo;
 
 
-typedef struct timeval Timeval;
+#ifdef HAVE_SYS_TIME_H
+    typedef struct timeval Timeval;
+#else /* HAVE_SYS_TIME_H */
+    /* Define the Timeval explicitly. */
+    typedef struct {
+        long tv_sec;  /* Seconds. */
+        long tv_usec; /* Microseconds. */
+    } Timeval;
+#endif /* HAVE_SYS_TIME_H */
 
 
 typedef struct packetInfo_st {

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -315,7 +315,8 @@
     #endif
 
     #if !defined(USE_WOLF_STRTOK) && \
-            (defined(__MINGW32__) || defined(WOLFSSL_TIRTOS) || defined(WOLF_C99))
+            ((defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)) || \
+             defined(WOLFSSL_TIRTOS) || defined(WOLF_C99))
         #define USE_WOLF_STRTOK
     #endif
     #if !defined(USE_WOLF_STRSEP) && (defined(WOLF_C99))


### PR DESCRIPTION
1. Define Timeval in callbacks.h if the file sys/time.h is missing.
2. When picking the correct strtok() function, take into account MINGW64.
3. In the example server, changed the call to SSL_accept_ex() as it doesn't exist. Using wolfSSL_accept_ex(). Only a problem when setting WOLFSSL_CALLBACKS.
4. PickHashSigAlgo() is missing a ; when WOLFSSL_CALLBACKS is set.