### PR TITLE
change grep message for RSA key size with tests

### DIFF
--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -158,7 +158,7 @@ if [ $? -eq 0 ]; then
 fi
 
 # check if supported key size is large enough to handle 4096 bit RSA
-size=`./examples/client/client -? | grep "Max key"`
+size=`./examples/client/client -? | grep "Max RSA key"`
 size=`echo ${size//[^0-9]/}`
 if [ ! -z "$size" ]; then
     printf 'check on max key size of %d ...' $size

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -168,7 +168,7 @@ trap cleanup EXIT INT TERM HUP
 [ ! -x ./examples/client/client ] && echo -e "\n\nClient doesn't exist" && exit 1
 
 # check if supported key size is large enough to handle 4096 bit RSA
-size=`./examples/client/client -? | grep "Max key"`
+size=`./examples/client/client -? | grep "Max RSA key"`
 size=`echo ${size//[^0-9]/}`
 if [ ! -z "$size" ]; then
     printf 'check on max key size of %d ...' $size


### PR DESCRIPTION
Avoids failed test cases where systems do not have 4096 bit key support compiled in by default. This case is avoided due to one intermediate certificate using 4096 bit RSA keys with OCSP testing.