### PR TITLE
Fix for SP ASM arm and no DH

### DIFF
--- a/wolfcrypt/src/sp_arm32.c
+++ b/wolfcrypt/src/sp_arm32.c
@@ -4170,6 +4170,10 @@ static int sp_2048_mod_exp_32(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_2048_mont_mul_32(r, r, t[y], m, mp);
         }
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_2048_mont_sqr_32(r, r, m, mp);
+        sp_2048_mont_mul_32(r, r, t[y], m, mp);
 
         XMEMSET(&r[32], 0, sizeof(sp_digit) * 32);
         sp_2048_mont_reduce_32(r, m, mp);
@@ -4310,11 +4314,9 @@ static int sp_2048_mod_exp_32(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_2048_mont_mul_32(r, r, t[y], m, mp);
         }
-        y = e[0] & 0xf;
-        sp_2048_mont_sqr_32(r, r, m, mp);
-        sp_2048_mont_sqr_32(r, r, m, mp);
-        sp_2048_mont_sqr_32(r, r, m, mp);
-        sp_2048_mont_sqr_32(r, r, m, mp);
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_2048_mont_sqr_32(r, r, m, mp);
         sp_2048_mont_mul_32(r, r, t[y], m, mp);
 
         XMEMSET(&r[32], 0, sizeof(sp_digit) * 32);
@@ -4335,6 +4337,7 @@ static int sp_2048_mod_exp_32(sp_digit* r, sp_digit* a, sp_digit* e,
 
 #endif /* !SP_RSA_PRIVATE_EXP_D && WOLFSSL_HAVE_SP_RSA */
 
+#ifdef WOLFSSL_HAVE_SP_DH
 /* r = 2^n mod m where n is the number of bits to reduce by.
  * Given m must be 2048 bits, just need to subtract.
  *
@@ -4349,6 +4352,7 @@ static void sp_2048_mont_norm_64(sp_digit* r, sp_digit* m)
     sp_2048_sub_in_place_64(r, m);
 }
 
+#endif /* WOLFSSL_HAVE_SP_DH */
 /* Conditionally subtract b from a using the mask m.
  * m is -1 to subtract and 0 when not copying.
  *
@@ -6766,6 +6770,10 @@ static int sp_2048_mod_exp_64(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_2048_mont_mul_64(r, r, t[y], m, mp);
         }
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_2048_mont_sqr_64(r, r, m, mp);
+        sp_2048_mont_mul_64(r, r, t[y], m, mp);
 
         XMEMSET(&r[64], 0, sizeof(sp_digit) * 64);
         sp_2048_mont_reduce_64(r, m, mp);
@@ -6906,10 +6914,9 @@ static int sp_2048_mod_exp_64(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_2048_mont_mul_64(r, r, t[y], m, mp);
         }
-        y = e[0] & 0x7;
-        sp_2048_mont_sqr_64(r, r, m, mp);
-        sp_2048_mont_sqr_64(r, r, m, mp);
-        sp_2048_mont_sqr_64(r, r, m, mp);
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_2048_mont_sqr_64(r, r, m, mp);
         sp_2048_mont_mul_64(r, r, t[y], m, mp);
 
         XMEMSET(&r[64], 0, sizeof(sp_digit) * 64);
@@ -12617,6 +12624,10 @@ static int sp_3072_mod_exp_48(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_3072_mont_mul_48(r, r, t[y], m, mp);
         }
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_3072_mont_sqr_48(r, r, m, mp);
+        sp_3072_mont_mul_48(r, r, t[y], m, mp);
 
         XMEMSET(&r[48], 0, sizeof(sp_digit) * 48);
         sp_3072_mont_reduce_48(r, m, mp);
@@ -12757,8 +12768,9 @@ static int sp_3072_mod_exp_48(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_3072_mont_mul_48(r, r, t[y], m, mp);
         }
-        y = e[0] & 0x1;
-        sp_3072_mont_sqr_48(r, r, m, mp);
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_3072_mont_sqr_48(r, r, m, mp);
         sp_3072_mont_mul_48(r, r, t[y], m, mp);
 
         XMEMSET(&r[48], 0, sizeof(sp_digit) * 48);
@@ -12779,6 +12791,7 @@ static int sp_3072_mod_exp_48(sp_digit* r, sp_digit* a, sp_digit* e,
 
 #endif /* !SP_RSA_PRIVATE_EXP_D && WOLFSSL_HAVE_SP_RSA */
 
+#ifdef WOLFSSL_HAVE_SP_DH
 /* r = 2^n mod m where n is the number of bits to reduce by.
  * Given m must be 3072 bits, just need to subtract.
  *
@@ -12793,6 +12806,7 @@ static void sp_3072_mont_norm_96(sp_digit* r, sp_digit* m)
     sp_3072_sub_in_place_96(r, m);
 }
 
+#endif /* WOLFSSL_HAVE_SP_DH */
 /* Conditionally subtract b from a using the mask m.
  * m is -1 to subtract and 0 when not copying.
  *
@@ -16170,6 +16184,10 @@ static int sp_3072_mod_exp_96(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_3072_mont_mul_96(r, r, t[y], m, mp);
         }
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_3072_mont_sqr_96(r, r, m, mp);
+        sp_3072_mont_mul_96(r, r, t[y], m, mp);
 
         XMEMSET(&r[96], 0, sizeof(sp_digit) * 96);
         sp_3072_mont_reduce_96(r, m, mp);
@@ -16310,9 +16328,9 @@ static int sp_3072_mod_exp_96(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_3072_mont_mul_96(r, r, t[y], m, mp);
         }
-        y = e[0] & 0x3;
-        sp_3072_mont_sqr_96(r, r, m, mp);
-        sp_3072_mont_sqr_96(r, r, m, mp);
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_3072_mont_sqr_96(r, r, m, mp);
         sp_3072_mont_mul_96(r, r, t[y], m, mp);
 
         XMEMSET(&r[96], 0, sizeof(sp_digit) * 96);
@@ -23984,7 +24002,7 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng, mp_int* priv,
                     mp_int* rm, mp_int* sm, void* heap)
 {
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
-    sp_digit* d;
+    sp_digit* d = NULL;
 #else
     sp_digit ed[2*8];
     sp_digit xd[2*8];

--- a/wolfcrypt/src/sp_arm64.c
+++ b/wolfcrypt/src/sp_arm64.c
@@ -2804,6 +2804,10 @@ static int sp_2048_mod_exp_16(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_2048_mont_mul_16(r, r, t[y], m, mp);
         }
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_2048_mont_sqr_16(r, r, m, mp);
+        sp_2048_mont_mul_16(r, r, t[y], m, mp);
 
         XMEMSET(&r[16], 0, sizeof(sp_digit) * 16);
         sp_2048_mont_reduce_16(r, m, mp);
@@ -2944,11 +2948,9 @@ static int sp_2048_mod_exp_16(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_2048_mont_mul_16(r, r, t[y], m, mp);
         }
-        y = e[0] & 0xf;
-        sp_2048_mont_sqr_16(r, r, m, mp);
-        sp_2048_mont_sqr_16(r, r, m, mp);
-        sp_2048_mont_sqr_16(r, r, m, mp);
-        sp_2048_mont_sqr_16(r, r, m, mp);
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_2048_mont_sqr_16(r, r, m, mp);
         sp_2048_mont_mul_16(r, r, t[y], m, mp);
 
         XMEMSET(&r[16], 0, sizeof(sp_digit) * 16);
@@ -2969,6 +2971,7 @@ static int sp_2048_mod_exp_16(sp_digit* r, sp_digit* a, sp_digit* e,
 
 #endif /* !SP_RSA_PRIVATE_EXP_D && WOLFSSL_HAVE_SP_RSA */
 
+#ifdef WOLFSSL_HAVE_SP_DH
 /* r = 2^n mod m where n is the number of bits to reduce by.
  * Given m must be 2048 bits, just need to subtract.
  *
@@ -2983,6 +2986,7 @@ static void sp_2048_mont_norm_32(sp_digit* r, sp_digit* m)
     sp_2048_sub_in_place_32(r, m);
 }
 
+#endif /* WOLFSSL_HAVE_SP_DH */
 /* Conditionally subtract b from a using the mask m.
  * m is -1 to subtract and 0 when not copying.
  *
@@ -4496,6 +4500,10 @@ static int sp_2048_mod_exp_32(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_2048_mont_mul_32(r, r, t[y], m, mp);
         }
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_2048_mont_sqr_32(r, r, m, mp);
+        sp_2048_mont_mul_32(r, r, t[y], m, mp);
 
         XMEMSET(&r[32], 0, sizeof(sp_digit) * 32);
         sp_2048_mont_reduce_32(r, m, mp);
@@ -4636,10 +4644,9 @@ static int sp_2048_mod_exp_32(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_2048_mont_mul_32(r, r, t[y], m, mp);
         }
-        y = e[0] & 0x7;
-        sp_2048_mont_sqr_32(r, r, m, mp);
-        sp_2048_mont_sqr_32(r, r, m, mp);
-        sp_2048_mont_sqr_32(r, r, m, mp);
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_2048_mont_sqr_32(r, r, m, mp);
         sp_2048_mont_mul_32(r, r, t[y], m, mp);
 
         XMEMSET(&r[32], 0, sizeof(sp_digit) * 32);
@@ -9276,6 +9283,10 @@ static int sp_3072_mod_exp_24(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_3072_mont_mul_24(r, r, t[y], m, mp);
         }
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_3072_mont_sqr_24(r, r, m, mp);
+        sp_3072_mont_mul_24(r, r, t[y], m, mp);
 
         XMEMSET(&r[24], 0, sizeof(sp_digit) * 24);
         sp_3072_mont_reduce_24(r, m, mp);
@@ -9416,8 +9427,9 @@ static int sp_3072_mod_exp_24(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_3072_mont_mul_24(r, r, t[y], m, mp);
         }
-        y = e[0] & 0x1;
-        sp_3072_mont_sqr_24(r, r, m, mp);
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_3072_mont_sqr_24(r, r, m, mp);
         sp_3072_mont_mul_24(r, r, t[y], m, mp);
 
         XMEMSET(&r[24], 0, sizeof(sp_digit) * 24);
@@ -9438,6 +9450,7 @@ static int sp_3072_mod_exp_24(sp_digit* r, sp_digit* a, sp_digit* e,
 
 #endif /* !SP_RSA_PRIVATE_EXP_D && WOLFSSL_HAVE_SP_RSA */
 
+#ifdef WOLFSSL_HAVE_SP_DH
 /* r = 2^n mod m where n is the number of bits to reduce by.
  * Given m must be 3072 bits, just need to subtract.
  *
@@ -9452,6 +9465,7 @@ static void sp_3072_mont_norm_48(sp_digit* r, sp_digit* m)
     sp_3072_sub_in_place_48(r, m);
 }
 
+#endif /* WOLFSSL_HAVE_SP_DH */
 /* Conditionally subtract b from a using the mask m.
  * m is -1 to subtract and 0 when not copying.
  *
@@ -11477,6 +11491,10 @@ static int sp_3072_mod_exp_48(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_3072_mont_mul_48(r, r, t[y], m, mp);
         }
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_3072_mont_sqr_48(r, r, m, mp);
+        sp_3072_mont_mul_48(r, r, t[y], m, mp);
 
         XMEMSET(&r[48], 0, sizeof(sp_digit) * 48);
         sp_3072_mont_reduce_48(r, m, mp);
@@ -11617,9 +11635,9 @@ static int sp_3072_mod_exp_48(sp_digit* r, sp_digit* a, sp_digit* e,
 
             sp_3072_mont_mul_48(r, r, t[y], m, mp);
         }
-        y = e[0] & 0x3;
-        sp_3072_mont_sqr_48(r, r, m, mp);
-        sp_3072_mont_sqr_48(r, r, m, mp);
+        y = e[0] & ((1 << c) - 1);
+        for (; c > 0; c--)
+            sp_3072_mont_sqr_48(r, r, m, mp);
         sp_3072_mont_mul_48(r, r, t[y], m, mp);
 
         XMEMSET(&r[48], 0, sizeof(sp_digit) * 48);
@@ -28915,7 +28933,7 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng, mp_int* priv,
                     mp_int* rm, mp_int* sm, void* heap)
 {
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
-    sp_digit* d;
+    sp_digit* d = NULL;
 #else
     sp_digit ed[2*4];
     sp_digit xd[2*4];

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -11888,7 +11888,7 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng, mp_int* priv,
                     mp_int* rm, mp_int* sm, void* heap)
 {
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
-    sp_digit* d;
+    sp_digit* d = NULL;
 #else
     sp_digit ed[2*10];
     sp_digit xd[2*10];

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -11099,7 +11099,7 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng, mp_int* priv,
                     mp_int* rm, mp_int* sm, void* heap)
 {
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
-    sp_digit* d;
+    sp_digit* d = NULL;
 #else
     sp_digit ed[2*5];
     sp_digit xd[2*5];

--- a/wolfcrypt/src/sp_x86_64.c
+++ b/wolfcrypt/src/sp_x86_64.c
@@ -7422,6 +7422,7 @@ static int sp_2048_mod_exp_avx2_16(sp_digit* r, sp_digit* a, sp_digit* e,
 
 #endif /* !SP_RSA_PRIVATE_EXP_D && WOLFSSL_HAVE_SP_RSA */
 
+#ifdef WOLFSSL_HAVE_SP_DH
 /* r = 2^n mod m where n is the number of bits to reduce by.
  * Given m must be 2048 bits, just need to subtract.
  *
@@ -7436,6 +7437,7 @@ static void sp_2048_mont_norm_32(sp_digit* r, sp_digit* m)
     sp_2048_sub_in_place_32(r, m);
 }
 
+#endif /* WOLFSSL_HAVE_SP_DH */
 /* Conditionally subtract b from a using the mask m.
  * m is -1 to subtract and 0 when not copying.
  *
@@ -24029,6 +24031,7 @@ static int sp_3072_mod_exp_avx2_24(sp_digit* r, sp_digit* a, sp_digit* e,
 
 #endif /* !SP_RSA_PRIVATE_EXP_D && WOLFSSL_HAVE_SP_RSA */
 
+#ifdef WOLFSSL_HAVE_SP_DH
 /* r = 2^n mod m where n is the number of bits to reduce by.
  * Given m must be 3072 bits, just need to subtract.
  *
@@ -24043,6 +24046,7 @@ static void sp_3072_mont_norm_48(sp_digit* r, sp_digit* m)
     sp_3072_sub_in_place_48(r, m);
 }
 
+#endif /* WOLFSSL_HAVE_SP_DH */
 /* Conditionally subtract b from a using the mask m.
  * m is -1 to subtract and 0 when not copying.
  *
@@ -45799,7 +45803,7 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng, mp_int* priv,
                     mp_int* rm, mp_int* sm, void* heap)
 {
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
-    sp_digit* d;
+    sp_digit* d = NULL;
 #else
     sp_digit ed[2*4];
     sp_digit xd[2*4];


### PR DESCRIPTION
Fix mod exp in ARM asm to work for different size exponents.
In ASM code, mont_norm is not used in RSA so protect from no DH.