### PR TITLE
Fixes to work when compiled with TLS 1.3 only

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2794,6 +2794,10 @@ then
     AM_CFLAGS="-DWOLFSSL_EARLY_DATA $AM_CFLAGS"
 fi
 
+if test "$ENABLED_TLSV12" = "no" && test "$ENABLED_TLS13" = "yes" && test "x$ENABLED_SESSION_TICKET" = "xno"
+then
+    AM_CFLAGS="$AM_CFLAGS -DNO_SESSION_CACHE"
+fi
 
 # PKCS7
 AC_ARG_ENABLE([pkcs7],

--- a/scripts/external.test
+++ b/scripts/external.test
@@ -7,22 +7,28 @@ ca=./certs/wolfssl-website-ca.pem
 
 [ ! -x ./examples/client/client ] && echo -e "\n\nClient doesn't exist" && exit 1
 
-# cloudflare seems to change CAs quickly, disabled by default
-if test -n "$WOLFSSL_EXTERNAL_TEST"; then
-    echo "WOLFSSL_EXTERNAL_TEST set, running test..."
-else
-    echo "WOLFSSL_EXTERNAL_TEST NOT set, won't run"
-    exit 0
+# www.wolfssl.com isn't using RFC 8446 yet but the draft instead.
+./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
+if [ $? -ne 0 ]; then
+
+    # cloudflare seems to change CAs quickly, disabled by default
+    if test -n "$WOLFSSL_EXTERNAL_TEST"; then
+        echo "WOLFSSL_EXTERNAL_TEST set, running test..."
+    else
+        echo "WOLFSSL_EXTERNAL_TEST NOT set, won't run"
+        exit 0
+    fi
+
+    # is our desired server there?
+    ./scripts/ping.test $server 2
+    RESULT=$?
+    [ $RESULT -ne 0 ] && exit 0
+
+    # client test against the server
+    ./examples/client/client -X -C -h $server -p 443 -g -A $ca
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
+
 fi
-
-# is our desired server there?
-./scripts/ping.test $server 2
-RESULT=$?
-[ $RESULT -ne 0 ] && exit 0
-
-# client test against the server
-./examples/client/client -X -C -h $server -p 443 -g -A $ca
-RESULT=$?
-[ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 
 exit 0

--- a/scripts/ocsp-stapling-with-ca-as-responder.test
+++ b/scripts/ocsp-stapling-with-ca-as-responder.test
@@ -1,6 +1,15 @@
 #!/bin/bash
 # ocsp-stapling.test
 
+
+./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
+if [ $? -eq 0 ]; then
+    echo "TLS 1.2 or lower required"
+    echo "Skipped"
+    exit 0
+fi
+
+
 WORKSPACE=`pwd`
 CERT_DIR="./certs/ocsp"
 resume_port=0

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -2,6 +2,15 @@
 
 # ocsp-stapling.test
 
+
+./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
+if [ $? -eq 0 ]; then
+    echo "TLS 1.2 or lower required"
+    echo "Skipped"
+    exit 0
+fi
+
+
 # create a unique ready file ending in PID for the script instance ($$) to take
 # advantage of port zero solution
 WORKSPACE=`pwd`

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -1,6 +1,15 @@
 #!/bin/bash
 # ocsp-stapling.test
 
+
+./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
+if [ $? -eq 0 ]; then
+    echo "TLS 1.2 or lower required"
+    echo "Skipped"
+    exit 0
+fi
+
+
 WORKSPACE=`pwd`
 CERT_DIR="certs/ocsp"
 

--- a/scripts/ocsp.test
+++ b/scripts/ocsp.test
@@ -8,6 +8,13 @@ ca=certs/external/ca-globalsign-root.pem
 [ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
                                   && exit 1
 
+./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
+if [ $? -eq 0 ]; then
+    echo "TLS 1.2 or lower required"
+    echo "Skipped"
+    exit 0
+fi
+
 # is our desired server there?
 ./scripts/ping.test $server 2
 RESULT=$?

--- a/scripts/resume.test
+++ b/scripts/resume.test
@@ -119,6 +119,11 @@ if [ $? -ne 0 ]; then
     fi
 fi
 
+./examples/client/client -? 2>&1 | grep -- 'Resume session'
+if [ $? -ne 0 ]; then
+    RUN_TEST="Y"
+fi
+
 if [ "$RUN_TEST" = "Y" ]; then
     do_test
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -6539,7 +6539,8 @@ static void AddRecordHeader(byte* output, word32 length, byte type, WOLFSSL* ssl
 }
 
 
-#if !defined(WOLFSSL_NO_TLS12) || defined(HAVE_SESSION_TICKET)
+#if !defined(WOLFSSL_NO_TLS12) || (defined(HAVE_SESSION_TICKET) && \
+                                                    !defined(NO_WOLFSSL_SERVER))
 /* add handshake header for message */
 static void AddHandShakeHeader(byte* output, word32 length,
                                word32 fragOffset, word32 fragLength,
@@ -6586,7 +6587,7 @@ static void AddHeaders(byte* output, word32 length, byte type, WOLFSSL* ssl)
     AddRecordHeader(output, length + lengthAdj, handshake, ssl);
     AddHandShakeHeader(output + outputAdj, length, 0, length, type, ssl);
 }
-#endif /* !WOLFSSL_NO_TLS12 || HAVE_SESSION_TICKET */
+#endif /* !WOLFSSL_NO_TLS12 || (HAVE_SESSION_TICKET && !NO_WOLFSSL_SERVER) */
 
 
 #ifndef WOLFSSL_NO_TLS12


### PR DESCRIPTION
TLS 1.3 Early Data can be used with PSK and not session tickets.
If only TLS 1.3 and no session tickets then no resumption.
External sites don't support TLS 1.3 yet.