### PR TITLE
Add wc_SetIssuerRaw and EncodeCert with raw fields

### DIFF
--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -560,6 +560,72 @@ WOLFSSL_API int  wc_SetIssuerBuffer(Cert*, const byte*, int);
 /*!
     \ingroup ASN
 
+    \brief This function sets the raw issuer for a certificate from the
+    issuer in the provided der buffer. This method is used to set the raw
+    issuer field prior to signing.
+
+    \return 0 Returned on successfully setting the issuer for the certificate
+    \return MEMORY_E Returned if there is an error allocating memory
+    with XMALLOC
+    \return ASN_PARSE_E Returned if there is an error parsing the cert
+    header file
+    \return ASN_OBJECT_ID_E Returned if there is an error parsing the
+    encryption type from the cert
+    \return ASN_EXPECT_0_E Returned if there is a formatting error in the
+    encryption specification of the cert file
+    \return ASN_BEFORE_DATE_E Returned if the date is before the certificate
+    start date
+    \return ASN_AFTER_DATE_E Returned if the date is after the certificate
+    expiration date
+    \return ASN_BITSTR_E Returned if there is an error parsing a bit string
+    from the certificate
+    \return ASN_NTRU_KEY_E Returned if there is an error parsing the NTRU key
+    from the certificate
+    \return ECC_CURVE_OID_E Returned if there is an error parsing the ECC key
+    from the certificate
+    \return ASN_UNKNOWN_OID_E Returned if the certificate is using an unknown
+    key object id
+    \return ASN_VERSION_E Returned if the ALLOW_V1_EXTENSIONS option is not
+    defined and the certificate is a V1 or V2 certificate
+    \return BAD_FUNC_ARG Returned if there is an error processing the
+    certificate extension
+    \return ASN_CRIT_EXT_E Returned if an unfamiliar critical extension is
+    encountered in processing the certificate
+    \return ASN_SIG_OID_E Returned if the signature encryption type is not
+    the same as the encryption type of the certificate in the provided file
+    \return ASN_SIG_CONFIRM_E Returned if confirming the certification
+    signature fails
+    \return ASN_NAME_INVALID_E Returned if the certificate’s name is not
+    permitted by the CA name constraints
+    \return ASN_NO_SIGNER_E Returned if there is no CA signer to verify the
+    certificate’s authenticity
+
+    \param cert pointer to the cert for which to set the raw issuer
+    \param der pointer to the buffer containing the der formatted certificate
+    from which to grab the subject
+    \param derSz size of the buffer containing the der formatted certificate
+    from which to grab the subject
+
+    _Example_
+    \code
+    Cert myCert;
+    // initialize myCert
+    byte* der;
+    der = (byte*)malloc(FOURK_BUF);
+    // initialize der
+    if(wc_SetIssuerRaw(&myCert, der, FOURK_BUF) != 0) {
+        // error setting subject
+    }
+    \endcode
+
+    \sa wc_InitCert
+    \sa wc_SetIssuer
+*/
+WOLFSSL_API int  wc_SetIssuerRaw(Cert* cert, const byte* der, int derSz);
+
+/*!
+    \ingroup ASN
+
     \brief This function sets the subject for a certificate from the subject in
     the provided der buffer. This method is used to set fields prior to signing.
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -8074,6 +8074,9 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX)
     x509->subject.rawLen = min(dCert->subjectRawLen, sizeof(x509->subject.raw));
     XMEMCPY(x509->subject.raw, dCert->subjectRaw, x509->subject.rawLen);
+
+    x509->issuer.rawLen = min(dCert->issuerRawLen, sizeof(x509->issuer.raw));
+    XMEMCPY(x509->issuer.raw, dCert->issuerRaw, x509->issuer.rawLen);
 #endif
 
     XMEMCPY(x509->serial, dCert->serial, EXTERNAL_SERIAL_SIZE);

--- a/tests/api.c
+++ b/tests/api.c
@@ -19454,6 +19454,32 @@ static void test_wc_GetSubjectRaw(void)
 #endif
 }
 
+static void test_wc_SetIssuerRaw(void)
+{
+#if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && \
+    defined(WOLFSSL_CERT_EXT) && defined(OPENSSL_EXTRA)
+    char joiCertFile[] = "./certs/test/cert-ext-joi.pem";
+    WOLFSSL_X509* x509;
+    int peerCertSz;
+    const byte* peerCertBuf;
+    Cert forgedCert;
+
+    printf(testingFmt, "test_wc_SetIssuerRaw()");
+
+    AssertNotNull(x509 = wolfSSL_X509_load_certificate_file(joiCertFile, WOLFSSL_FILETYPE_PEM));
+
+    AssertNotNull(peerCertBuf = wolfSSL_X509_get_der(x509, &peerCertSz));
+
+    AssertIntEQ(0, wc_InitCert(&forgedCert));
+
+    AssertIntEQ(0, wc_SetIssuerRaw(&forgedCert, peerCertBuf, peerCertSz));
+
+    wolfSSL_FreeX509(x509);
+
+    printf(resultFmt, passed);
+#endif
+}
+
 /*----------------------------------------------------------------------------*
  | wolfCrypt ECC
  *----------------------------------------------------------------------------*/
@@ -20696,6 +20722,7 @@ void ApiTest(void)
     test_wc_GetPkcs8TraditionalOffset();
     test_wc_SetSubjectRaw();
     test_wc_GetSubjectRaw();
+    test_wc_SetIssuerRaw();
 
     /* wolfCrypt ECC tests */
     test_wc_ecc_get_curve_size_from_name();

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -297,7 +297,6 @@ WOLFSSL_API int wc_MakeSelfCert(Cert*, byte* derBuffer, word32 derSz, RsaKey*,
                              WC_RNG*);
 WOLFSSL_API int wc_SetIssuer(Cert*, const char*);
 WOLFSSL_API int wc_SetSubject(Cert*, const char*);
-WOLFSSL_API int wc_SetSubjectRaw(Cert*, const byte* der, int derSz);
 #ifdef WOLFSSL_ALT_NAMES
     WOLFSSL_API int wc_SetAltNames(Cert*, const char*);
 #endif
@@ -324,6 +323,8 @@ WOLFSSL_API int wc_SetSubjectKeyIdFromPublicKey(Cert *cert, RsaKey *rsakey,
                                                 ecc_key *eckey);
 WOLFSSL_API int wc_SetSubjectKeyId(Cert *cert, const char* file);
 WOLFSSL_API int wc_GetSubjectRaw(byte **subjectRaw, Cert *cert);
+WOLFSSL_API int wc_SetSubjectRaw(Cert* cert, const byte* der, int derSz);
+WOLFSSL_API int wc_SetIssuerRaw(Cert* cert, const byte* der, int derSz);
 
 #ifdef HAVE_NTRU
 WOLFSSL_API int wc_SetSubjectKeyIdFromNtruPublicKey(Cert *cert, byte *ntruKey,


### PR DESCRIPTION
This change adds a method for setting the raw issuer from a der buffer. Also enable copying the raw subject and issuer in the Cert struct to a new cert with ```EncodeCert```. A test was added for the new ```wc_SetIssuerRaw``` API.