### PR TITLE
Address issues when testing with WOLFSSL_OCSP_TEST set

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1297,6 +1297,14 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 break;
 
             case 'S' :
+                if (XSTRNCMP(myoptarg, "check", 5) == 0) {
+                #ifdef HAVE_SNI
+                    printf("SNI is: ON\n");
+                #else
+                    printf("SNI is: OFF\n");
+                #endif
+                    XEXIT_T(EXIT_SUCCESS);
+                }
                 #ifdef HAVE_SNI
                     sniHostName = myoptarg;
                 #endif

--- a/scripts/ocsp.test
+++ b/scripts/ocsp.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# ocsp-stapling.test
+# ocsp.test
 
 server=www.globalsign.com
 ca=certs/external/ca-globalsign-root.pem
@@ -15,16 +15,30 @@ if [ $? -eq 0 ]; then
     exit 0
 fi
 
-# is our desired server there?
-./scripts/ping.test $server 2
-RESULT=$?
-if [ $RESULT -eq 0 ]; then
-    # client test against the server
-    ./examples/client/client -X -C -h $server -p 443 -A $ca -g -o -N
-    GL_RESULT=$?
-    [ $GL_RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection failed"
+# Global Sign now requires server name indication extension to work, check
+# enabled prior to testing
+OUTPUT=$(eval "./examples/client/client -S check")
+if [ "$OUTPUT" = "SNI is: ON" ]; then
+    printf '\n\n%s\n\n' "SNI is on, proceed with globalsign test"
+
+    # is our desired server there?
+    ./scripts/ping.test $server 2
+    RESULT=$?
+    if [ $RESULT -ne 0 ]; then
+        GL_UNREACHABLE=1
+    fi
+
+    if [ $RESULT -eq 0 ]; then
+        # client test against the server
+        ./examples/client/client -X -C -h $server -p 443 -A $ca -g -o -N -v d -S $server
+        GL_RESULT=$?
+        [ $GL_RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection failed"
+    else
+        GL_RESULT=1
+    fi
 else
-    GL_RESULT=1
+    printf '\n\n%s\n\n' "SNI disabled, skipping globalsign test"
+    GL_RESULT=0
 fi
 
 server=www.google.com
@@ -47,6 +61,10 @@ if test -n "$WOLFSSL_OCSP_TEST"; then
     if [ $GL_RESULT -eq 0 ] && [ $GR_RESULT -eq 0 ]; then
         printf '\n\n%s\n' "Both OCSP connection to globalsign and google passed"
         printf '%s\n' "Test Passed!"
+        exit 0
+    elif [ $GL_UNREACHABLE -eq 1 ] && [ $GR_RESULT -eq 0 ]; then
+         printf '%s\n' "Global Sign is currently unreachable. Logging it but if"
+         printf '%s\n' "this continues to occur should be investigated"
         exit 0
     else
         # Unlike other environment variables the intent of WOLFSSL_OCSP_TEST


### PR DESCRIPTION
GlobalSign requires server name indication extension now.
Added method to check if SNI is enabled to example client
Added skip logic for global sign test when not enabled.
Added skip logic for when global sign.com is offline for updates as this occurs every few weeks or so.