### PR TITLE
Added missing ATECC508A-pubkey_raw value for peerEccKey

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6296,6 +6296,11 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
     /* adjust to skip first byte */
     inLen -= 1;
     in += 1;
+    
+    #ifdef WOLFSSL_ATECC508A
+    /* populate key->pubkey_raw */
+    XMEMCPY(key->pubkey_raw, (byte*)in, sizeof(key->pubkey_raw));
+    #endif
 
     if (err == MP_OKAY) {
     #ifdef HAVE_COMP_KEY

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -177,7 +177,7 @@ static int atmel_init_enc_key(void)
 	uint8_t read_key[ATECC_KEY_SIZE] = { 0 };
 
 	XMEMSET(read_key, 0xFF, sizeof(read_key));
-	ret = atcab_write_bytes_slot(TLS_SLOT_ENC_PARENT, 0, read_key, sizeof(read_key));
+    ret = atcab_write_bytes_zone(ATCA_ZONE_DATA, TLS_SLOT_ENC_PARENT, 0, read_key, sizeof(read_key));
 	if (ret != ATCA_SUCCESS) {
 		WOLFSSL_MSG("Failed to write key");
 		return -1;


### PR DESCRIPTION
As discussed in [issue 1793](https://github.com/wolfSSL/wolfssl/issues/1793) the `ssl->hsKey` `public_raw` value for `EccSharedSecret` was empty when using the WOLFSSL_ATECC508A define.