### PR TITLE
Fix for CSR generation email value

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9466,7 +9466,9 @@ static char GetNameType(CertName* name, int idx)
 #else
     case 7:
 #endif
-
+        /* FALL THROUGH */
+        /* The last index, email name, does not have encoding type.
+           The empty case here is to keep track of it for future reference. */
     default:
        return 0;
     }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9461,7 +9461,12 @@ static char GetNameType(CertName* name, int idx)
 #ifdef WOLFSSL_CERT_EXT
     case 7:
         return name->busCatEnc;
+
+    case 8:
+#else
+    case 7:
 #endif
+
     default:
        return 0;
     }
@@ -9493,8 +9498,15 @@ static byte GetNameId(int idx)
     case 6:
        return ASN_COMMON_NAME;
 
+#ifdef WOLFSSL_CERT_EXT
     case 7:
-       return ASN_EMAIL_NAME;
+        return ASN_BUS_CAT;
+
+    case 8:
+#else
+    case 7:
+#endif
+        return ASN_EMAIL_NAME;
 
     default:
        return 0;


### PR DESCRIPTION
New issue after PR (https://github.com/wolfSSL/wolfssl/pull/1734). This resolves issue with email name in CSR. (Thanks to Forum post https://www.wolfssl.com/forums/post4137.html).

Failed examples:

```
145:d=5  hl=2 l=  16 prim: EOC
      0000 - 69 6e 66 6f 40 77 6f 6c-66 73 73 6c 2e 63 6f 6d   info@wolfssl.com
```

```
SET {
138  23:         SEQUENCE {
140   3:           OBJECT IDENTIFIER objectClass (2 5 4 0)
       :             Error: Spurious EOC in definite-length item.
```

Success Examples:

```
140:d=5  hl=2 l=   9 prim: OBJECT            :emailAddress
  151:d=5  hl=2 l=  16 prim: IA5STRING         :info@wolfssl.com
```

```
SET {
138  29:         SEQUENCE {
140   9:           OBJECT IDENTIFIER emailAddress (1 2 840 113549 1 9 1)
151  16:           IA5String 'info@wolfssl.com'
```