### PR TITLE
Validate Date

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -303,7 +303,7 @@ static int CheckCertCRLList(WOLFSSL_CRL* crl, DecodedCert* cert, int *pFoundEntr
 
             if (doNextDate) {
             #ifndef NO_ASN_TIME
-                if (!ValidateDate(crle->nextDate,crle->nextDateFormat, AFTER)) {
+                if (!XVALIDATE_DATE(crle->nextDate,crle->nextDateFormat, AFTER)) {
                     WOLFSSL_MSG("CRL next date is no longer valid");
                     ret = ASN_AFTER_DATE_E;
                 }

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -224,9 +224,11 @@ static int GetOcspStatus(WOLFSSL_OCSP* ocsp, OcspRequest* request,
     }
     else if (*status) {
 #ifndef NO_ASN_TIME
-        if (ValidateDate((*status)->thisDate, (*status)->thisDateFormat, BEFORE)
+        if (XVALIDATE_DATE((*status)->thisDate,
+                                             (*status)->thisDateFormat, BEFORE)
         &&  ((*status)->nextDate[0] != 0)
-        &&  ValidateDate((*status)->nextDate, (*status)->nextDateFormat, AFTER))
+        &&  XVALIDATE_DATE((*status)->nextDate,
+                                             (*status)->nextDateFormat, AFTER))
 #endif
         {
             ret = xstat2err((*status)->status);


### PR DESCRIPTION
The ValidateDate() function is wrapped by a macro so it may be replaced in environments without ASN_TIME built in. In two cases, OCSP and CRL, ValidateDate() is called directly instead of by the macro. This change fixes that.