### PR TITLE
Bitfield Fixes

### DIFF
--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -154,7 +154,7 @@ typedef struct EncryptedInfo {
     char     name[NAME_SZ];    /* cipher name, such as "DES-CBC" */
     byte     iv[IV_SZ];        /* salt or encrypted IV */
 
-    int      set:1;            /* if encryption set */
+    word16   set:1;            /* if encryption set */
 } EncryptedInfo;
 
 

--- a/wolfssl/wolfcrypt/ed25519.h
+++ b/wolfssl/wolfcrypt/ed25519.h
@@ -77,7 +77,7 @@ struct ed25519_key {
     byte pointX[ED25519_KEY_SIZE]; /* recovered X coordinate */
     byte pointY[ED25519_KEY_SIZE]; /* Y coordinate is the public key with The most significant bit of the final octet always zero. */
 #endif
-    int pubKeySet:1;
+    word16 pubKeySet:1;
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
 #endif


### PR DESCRIPTION
A couple flags were being implemented as bitfields from an int type. GCC-8 is being more strict of type and value checking and is treating single bit ints as both 1 and -1 and complaining about value changes. Change the two int bitfields to use word16 bitfields as is the pattern elsewhere.