### PR TITLE
Fixes for ATECC508A

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -788,6 +788,20 @@ fi
 AM_CONDITIONAL([BUILD_PKCALLBACKS],   [ test "x$ENABLED_PKCALLBACKS" = "xyes" ])
 
 
+AC_ARG_ENABLE([cryptoauthlib],
+    [AS_HELP_STRING([--enable-cryptoauthlib],[Enable CryptoAuthLib (default: disabled)])],
+    [ ENABLED_CRYPTOAUTHLIB=$enableval ],
+    [ ENABLED_CRYPTOAUTHLIB=no ]
+    )
+
+if test "$ENABLED_CRYPTOAUTHLIB" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ATECC508A"
+fi
+
+AM_CONDITIONAL([BUILD_CRYPTOAUTHLIB],   [ test "x$ENABLED_CRYPTOAUTHLIB" = "xyes" ])
+
+
 # sniffer doesn't work in maxstrength mode
 if test "$ENABLED_SNIFFER" = "yes" && test "$ENABLED_MAXSTRENGTH" = "yes"
 then

--- a/configure.ac
+++ b/configure.ac
@@ -788,18 +788,43 @@ fi
 AM_CONDITIONAL([BUILD_PKCALLBACKS],   [ test "x$ENABLED_PKCALLBACKS" = "xyes" ])
 
 
-AC_ARG_ENABLE([cryptoauthlib],
-    [AS_HELP_STRING([--enable-cryptoauthlib],[Enable CryptoAuthLib (default: disabled)])],
-    [ ENABLED_CRYPTOAUTHLIB=$enableval ],
-    [ ENABLED_CRYPTOAUTHLIB=no ]
-    )
+# Microchip/Atmel CryptoAuthLib
+ENABLED_CRYPTOAUTHLIB="no"
+trylibatcadir=""
+AC_ARG_WITH([cryptoauthlib],
+    [AS_HELP_STRING([--with-cryptoauthlib=PATH],[PATH to CryptoAuthLib install (default /usr/)])],
+    [
+        AC_MSG_CHECKING([for cryptoauthlib])
+        CPPFLAGS="$CPPFLAGS -DWOLFSSL_ATECC508A"
+        LIBS="$LIBS -lcryptoauth"
 
-if test "$ENABLED_CRYPTOAUTHLIB" = "yes"
-then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ATECC508A"
-fi
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <cryptoauthlib.h>]], [[ atcab_init(0); ]])],[ libatca_linked=yes ],[ libatca_linked=no ])
 
-AM_CONDITIONAL([BUILD_CRYPTOAUTHLIB],   [ test "x$ENABLED_CRYPTOAUTHLIB" = "xyes" ])
+        if test "x$libatca_linked" == "xno" ; then
+            if test "x$withval" != "xno" ; then
+                trylibatcadir=$withval
+            fi
+            if test "x$withval" == "xyes" ; then
+                trylibatcadir="/usr"
+            fi
+
+            LDFLAGS="$LDFLAGS -L$trylibatcadir/lib"
+            CPPFLAGS="$CPPFLAGS -I$trylibatcadir/lib"
+
+            AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <cryptoauthlib.h>]], [[ atcab_init(0); ]])],[ libatca_linked=yes ],[ libatca_linked=no ])
+
+            if test "x$libatca_linked" == "xno" ; then
+                AC_MSG_ERROR([cryptoauthlib isn't found.
+                If it's already installed, specify its path using --with-cryptoauthlib=/dir/])
+            fi
+            AC_MSG_RESULT([yes])
+        else
+            AC_MSG_RESULT([yes])
+        fi
+        ENABLED_CRYPTOAUTHLIB="yes"
+    ]
+)
+AM_CONDITIONAL([BUILD_CRYPTOAUTHLIB], [test "x$ENABLED_CRYPTOAUTHLIB" = "xyes"])
 
 
 # sniffer doesn't work in maxstrength mode
@@ -3542,7 +3567,7 @@ AC_ARG_WITH([libz],
                 trylibzdir="/usr"
             fi
 
-            AM_LDFLAGS="$AM_LDFLAGS -L$trylibzdir/lib"
+            LDFLAGS="$LDFLAGS -L$trylibzdir/lib"
             CPPFLAGS="$CPPFLAGS -I$trylibzdir/include"
 
             AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <zlib.h>]], [[ deflateInit(0, 8); ]])],[ libz_linked=yes ],[ libz_linked=no ])

--- a/configure.ac
+++ b/configure.ac
@@ -817,11 +817,16 @@ AC_ARG_WITH([cryptoauthlib],
                 AC_MSG_ERROR([cryptoauthlib isn't found.
                 If it's already installed, specify its path using --with-cryptoauthlib=/dir/])
             fi
+
+            AM_LDFLAGS="$AM_LDFLAGS -L$trylibatcadir/lib"
+            AM_CFLAGS="$AM_CFLAGS -I$trylibatcadir/lib"
             AC_MSG_RESULT([yes])
         else
             AC_MSG_RESULT([yes])
         fi
+
         ENABLED_CRYPTOAUTHLIB="yes"
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ATECC508A"
     ]
 )
 AM_CONDITIONAL([BUILD_CRYPTOAUTHLIB], [test "x$ENABLED_CRYPTOAUTHLIB" = "xyes"])

--- a/tests/api.c
+++ b/tests/api.c
@@ -14266,7 +14266,8 @@ static int test_wc_ecc_pointFns (void)
 {
     int         ret = 0;
 
-#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG)
+#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && \
+    !defined(WC_NO_RNG) && !defined(WOLFSSL_ATECC508A)
     ecc_key     key;
     WC_RNG      rng;
     ecc_point*  point = NULL;
@@ -14440,7 +14441,8 @@ static int test_wc_ecc_shared_secret_ssh (void)
 {
     int         ret = 0;
 
-#if defined(HAVE_ECC) && defined(HAVE_ECC_DHE) && !defined(WC_NO_RNG)
+#if defined(HAVE_ECC) && defined(HAVE_ECC_DHE) && \
+    !defined(WC_NO_RNG) && !defined(WOLFSSL_ATECC508A)
     ecc_key     key, key2;
     WC_RNG      rng;
     int         keySz = KEY32;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6314,7 +6314,7 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
     /* For SECP256R1 only save raw public key for hardware */
     if (curve_id == ECC_SECP256R1 && !compressed &&
                                             inLen <= sizeof(key->pubkey_raw)) {
-        XMEMCPY(key->pubkey_raw, (byte*)in, sizeof(key->pubkey_raw));
+        XMEMCPY(key->pubkey_raw, (byte*)in, inLen);
     }
 #endif
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6329,6 +6329,11 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
     inLen -= 1;
     in += 1;
 
+#ifdef WOLFSSL_ATECC508A
+    /* populate key->pubkey_raw */
+    XMEMCPY(key->pubkey_raw, (byte*)in, sizeof(key->pubkey_raw));
+#endif
+
     if (err == MP_OKAY) {
     #ifdef HAVE_COMP_KEY
         /* adjust inLen if compressed */

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -52,7 +52,6 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/arm/armv8-aes.c \
               wolfcrypt/src/port/arm/armv8-sha256.c \
               wolfcrypt/src/port/nxp/ksdk_port.c \
-              wolfcrypt/src/port/atmel/atmel.c \
               wolfcrypt/src/port/atmel/README.md \
               wolfcrypt/src/port/xilinx/xil-sha3.c \
               wolfcrypt/src/port/xilinx/xil-aesgcm.c \
@@ -95,4 +94,8 @@ src_libwolfssl_la_SOURCES += wolfcrypt/src/port/intel/quickassist.c
 src_libwolfssl_la_SOURCES += wolfcrypt/src/port/intel/quickassist_mem.c
 
 EXTRA_DIST += wolfcrypt/src/port/intel/README.md
+endif
+
+if BUILD_CRYPTOAUTHLIB
+src_libwolfssl_la_SOURCES += wolfcrypt/src/port/atmel/atmel.c
 endif

--- a/wolfcrypt/src/port/atmel/README.md
+++ b/wolfcrypt/src/port/atmel/README.md
@@ -1,17 +1,36 @@
-# Atmel ATECC508A Port
+# Microchip/Atmel ATECC508A/ATECC608A Support
 
-* Adds wolfCrypt support for ECC Hardware acceleration using the ATECC508A 
-	* The new defines added for this port are: `WOLFSSL_ATMEL` and `WOLFSSL_ATECC508A`.
-* Adds new PK callback for Pre Master Secret.
+Support for ATECC508A using these methods:
+* TLS: Using the PK callbacks and reference ATECC508A callbacks. See Coding section below. Requires options `HAVE_PK_CALLBACKS` and `WOLFSSL_ATECC_PKCB or WOLFSSL_ATECC508A`
+* wolfCrypt: Native wc_ecc_* API's using the `./configure CFLAGS="-DWOLFSSL_ATECC508A"` or `#define WOLFSSL_ATECC508A`.
+
+## Dependency
+
+Requires the Microchip CryptoAuthLib. The examples in `wolfcrypt/src/port/atmel/atmel.c` make calls to the `atcatls_*` API's.
 
 
 ## Building
 
-`./configure --enable-pkcallbacks CFLAGS="-DWOLFSSL_ATECC508A"`
+### Build Options
+
+* `HAVE_PK_CALLBACKS`: Option for enabling wolfSSL's PK callback support for TLS.
+* `WOLFSSL_ATECC508A`: Enables support for initializing the CryptoAuthLib and setting up the encryption key used for the I2C communication.
+* `WOLFSSL_ATECC_PKCB`: Enables support for the reference PK callbacks without init.
+* `WOLFSSL_ATMEL`: Enables ASF hooks seeding random data using the `atmel_get_random_number` function.
+* `WOLFSSL_ATMEL_TIME`: Enables the built-in `atmel_get_curr_time_and_date` function get getting time from ASF RTC. 
+* `ATECC_GET_ENC_KEY`: Macro to define your own function for getting the encryption key.
+* `ATECC_SLOT_I2C_ENC`: Macro for the default encryption key slot. Can also get via the slot callback with `ATMEL_SLOT_ENCKEY`.
+* `ATECC_MAX_SLOT`: Macro for the maximum dynamically allocated slots.
+
+### Build Command Examples
+
+`./configure --enable-pkcallbacks CFLAGS="-DWOLFSSL_ATECC_PKCB"`
+`#define HAVE_PK_CALLBACKS`
+`#define WOLFSSL_ATECC_PKCB`
 
 or 
 
-`#define HAVE_PK_CALLBACKS`
+`./configure CFLAGS="-DWOLFSSL_ATECC508A"`
 `#define WOLFSSL_ATECC508A`
 
 
@@ -31,7 +50,7 @@ wolfSSL_CTX_SetEccSharedSecretCb(ctx, atcatls_create_pms_cb);
 The reference ATECC508A PK callback functions are located in the `wolfcrypt/src/port/atmel/atmel.c` file.
 
 
-Adding a custom contex to the callbacks:
+Adding a custom context to the callbacks:
 
 ```
 /* Setup PK Callbacks context */
@@ -49,7 +68,7 @@ wolfSSL_SetEccSharedSecretCtx(ssl, myOwnCtx);
 
 TLS Establishment Times:
 
-* Hardware accelerated ATECC508A: 2.342 seconds avgerage
+* Hardware accelerated ATECC508A: 2.342 seconds average
 * Software only: 13.422 seconds average
 
 The TLS connection establishment time is 5.73 times faster with the ATECC508A.

--- a/wolfcrypt/src/port/atmel/README.md
+++ b/wolfcrypt/src/port/atmel/README.md
@@ -64,6 +64,8 @@ wolfSSL_SetEccSharedSecretCtx(ssl, myOwnCtx);
 
 ## Benchmarks
 
+Supports ECC SECP256R1 (NIST P-256)
+
 ### TLS
 
 TLS Establishment Times:
@@ -77,16 +79,16 @@ The TLS connection establishment time is 5.73 times faster with the ATECC508A.
 
 Software only implementation (SAMD21 48Mhz Cortex-M0, Fast Math TFM-ASM):
 
-`ECC  256 key generation  3123.000 milliseconds, avg over 5 iterations`
-`EC-DHE   key agreement   3117.000 milliseconds, avg over 5 iterations`
-`EC-DSA   sign   time     1997.000 milliseconds, avg over 5 iterations`
-`EC-DSA   verify time     5057.000 milliseconds, avg over 5 iterations`
+`EC-DHE   key generation  3123.000 milliseconds, avg over 5 iterations, 1.601 ops/sec`
+`EC-DHE   key agreement   3117.000 milliseconds, avg over 5 iterations, 1.604 ops/sec`
+`EC-DSA   sign   time     1997.000 milliseconds, avg over 5 iterations, 2.504 ops/sec`
+`EC-DSA   verify time     5057.000 milliseconds, avg over 5 iterations, 0.988 ops/sec`
 
 ATECC508A HW accelerated implementation:
-`ECC  256 key generation  144.400 milliseconds, avg over 5 iterations`
-`EC-DHE   key agreement   134.200 milliseconds, avg over 5 iterations`
-`EC-DSA   sign   time     293.400 milliseconds, avg over 5 iterations`
-`EC-DSA   verify time     208.400 milliseconds, avg over 5 iterations`
+`EC-DHE   key generation  144.400 milliseconds, avg over 5 iterations, 34.722 ops/sec`
+`EC-DHE   key agreement   134.200 milliseconds, avg over 5 iterations, 37.313 ops/sec`
+`EC-DSA   sign   time     293.400 milliseconds, avg over 5 iterations, 17.065 ops/sec`
+`EC-DSA   verify time     208.400 milliseconds, avg over 5 iterations, 24.038 ops/sec`
 
 
 For details see our [wolfSSL Atmel ATECC508A](https://wolfssl.com/wolfSSL/wolfssl-atmel.html) page.

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -308,7 +308,7 @@ static int atmel_init_enc_key(void)
 	return ret;
 }
 
-int atmel_get_rev_info(byte* revision)
+int atmel_get_rev_info(word32* revision)
 {
     int ret;
     ret = atcab_info((uint8_t*)revision);
@@ -319,7 +319,7 @@ int atmel_get_rev_info(byte* revision)
 void atmel_show_rev_info(void)
 {
 #ifdef WOLFSSL_ATECC508A_DEBUG
-    byte revision = 0;
+    word32 revision = 0;
     atmel_get_rev_info(&revision);
     printf("ATECC508A Revision: %x\n", (word32)revision);
 #endif

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -62,6 +62,17 @@ static byte mSlotList[ATECC_MAX_SLOT];
 static wolfSSL_Mutex mSlotMutex;
 #endif
 
+/* Raspberry Pi uses /dev/i2c-1 */
+#ifndef ATECC_I2C_ADDR
+#define ATECC_I2C_ADDR 0xC0
+#endif
+#ifndef ATECC_I2C_BUS
+#define ATECC_I2C_BUS  1
+#endif
+#ifndef ATECC_DEV_TYPE
+#define ATECC_DEV_TYPE ATECC508A
+#endif
+static ATCAIfaceCfg cfg_ateccx08a_i2c_pi;
 #endif /* WOLFSSL_ATECC508A */
 
 
@@ -390,8 +401,18 @@ int atmel_init(void)
             }
         }
 
+        /* Setup the hardware interface */
+        XMEMSET(&cfg_ateccx08a_i2c_pi, 0, sizeof(cfg_ateccx08a_i2c_pi));
+        cfg_ateccx08a_i2c_pi.iface_type             = ATCA_I2C_IFACE;
+        cfg_ateccx08a_i2c_pi.devtype                = ATECC_DEV_TYPE;
+        cfg_ateccx08a_i2c_pi.atcai2c.slave_address  = ATECC_I2C_ADDR;
+        cfg_ateccx08a_i2c_pi.atcai2c.bus            = ATECC_I2C_BUS;
+        cfg_ateccx08a_i2c_pi.atcai2c.baud           = 400000;
+        cfg_ateccx08a_i2c_pi.wake_delay             = 1500;
+        cfg_ateccx08a_i2c_pi.rx_retries             = 20;
+
         /* Initialize the CryptoAuthLib to communicate with ATECC508A */
-        status = atcab_init(&cfg_ateccx08a_i2c_default);
+        status = atcab_init(&cfg_ateccx08a_i2c_pi);
         if (status != ATCA_SUCCESS) {
             WOLFSSL_MSG("Failed to initialize atcab");
             return WC_HW_E;

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -92,7 +92,7 @@ int atmel_get_random_number(uint32_t count, uint8_t* rand_out)
 		XMEMCPY(&rand_out[i], rng_buffer, copy_count);
 		i += copy_count;
 	}
-    atcab_printbin_label((const uint8_t*)"\r\nRandom Number", rand_out, count);
+    atcab_printbin_label((const char*)"\r\nRandom Number", rand_out, count);
 #else
     // TODO: Use on-board TRNG
 #endif
@@ -156,7 +156,7 @@ void atmel_ecc_free(int slot)
 /**
  * \brief Give enc key to read pms.
  */
-static int atmel_set_enc_key(uint8_t* enckey, int16_t keysize)
+static ATCA_STATUS atmel_get_enc_key(uint8_t* enckey, int16_t keysize)
 {
     if (enckey == NULL || keysize != ATECC_KEY_SIZE) {
         return -1;
@@ -177,13 +177,13 @@ static int atmel_init_enc_key(void)
 	uint8_t read_key[ATECC_KEY_SIZE] = { 0 };
 
 	XMEMSET(read_key, 0xFF, sizeof(read_key));
-	ret = atcab_write_bytes_slot(TLS_SLOT_ENC_PARENT, 0, read_key, sizeof(read_key));
+    ret = atcatls_set_enckey(read_key, TLS_SLOT_ENC_PARENT, 0);
 	if (ret != ATCA_SUCCESS) {
 		WOLFSSL_MSG("Failed to write key");
 		return -1;
 	}
 
-	ret = atcatlsfn_set_get_enckey(atmel_set_enc_key);
+	ret = atcatlsfn_set_get_enckey(atmel_get_enc_key);
 	if (ret != ATCA_SUCCESS) {
 		WOLFSSL_MSG("Failed to set enckey");
 		return -1;

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -153,7 +153,11 @@ int wolfCrypt_Init(void)
     #endif
 
     #if defined(WOLFSSL_ATMEL) || defined(WOLFSSL_ATECC508A)
-        atmel_init();
+        ret = atmel_init();
+        if (ret != 0) {
+            WOLFSSL_MSG("CryptoAuthLib init failed");
+            return ret;
+        }
     #endif
 
     #if defined(WOLFSSL_STSAFEA100)

--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -70,6 +70,7 @@ extern t_atcert atcert;
 void atmel_init(void);
 void atmel_finish(void);
 int  atmel_get_random_number(uint32_t count, uint8_t* rand_out);
+int atmel_get_random_block(unsigned char* output, unsigned int sz);
 long atmel_get_curr_time_and_date(long* tm);
 
 #ifdef WOLFSSL_ATECC508A

--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -31,9 +31,7 @@
     #undef  SHA_BLOCK_SIZE
     #define SHA_BLOCK_SIZE  SHA_BLOCK_SIZE_REMAP
     #include <cryptoauthlib.h>
-    #include <tls/atcatls.h>
     #include <atcacert/atcacert_client.h>
-    #include <tls/atcatls_cfg.h>
     #undef SHA_BLOCK_SIZE
 #endif
 
@@ -44,7 +42,24 @@
 #ifndef ATECC_MAX_SLOT
 #define ATECC_MAX_SLOT      (0x7) /* Only use 0-7 */
 #endif
-#define ATECC_INVALID_SLOT  (-1)
+#define ATECC_INVALID_SLOT  (0xFF)
+
+/* Device Key for signing */
+#ifndef ATECC_SLOT_AUTH_PRIV
+#define ATECC_SLOT_AUTH_PRIV      (0x0)
+#endif
+/* Ephemeral key */
+#ifndef ATECC_SLOT_ECDHE_PRIV
+#define ATECC_SLOT_ECDHE_PRIV     (0x2)
+#endif
+/* Symmetric encryption key */
+#ifndef ATECC_SLOT_I2C_ENC
+#define ATECC_SLOT_I2C_ENC        (0x04)
+#endif
+/* Parent encryption key */
+#ifndef ATECC_SLOT_ENC_PARENT
+#define ATECC_SLOT_ENC_PARENT     (0x7)
+#endif
 
 /* ATECC_KEY_SIZE required for ecc.h */
 #include <wolfssl/wolfcrypt/ecc.h>
@@ -54,23 +69,11 @@ struct WOLFSSL_CTX;
 struct WOLFSSL_X509_STORE_CTX;
 struct ecc_key;
 
-/* Cert Structure */
-typedef struct t_atcert {
-	uint32_t signer_ca_size;
-	uint8_t signer_ca[512];
-	uint8_t signer_ca_pubkey[64];
-	uint32_t end_user_size;
-	uint8_t end_user[512];
-	uint8_t end_user_pubkey[64];
-} t_atcert;
-
-extern t_atcert atcert;
-
-/* Amtel port functions */
-void atmel_init(void);
+/* Atmel port functions */
+int  atmel_init(void);
 void atmel_finish(void);
 int  atmel_get_random_number(uint32_t count, uint8_t* rand_out);
-int atmel_get_random_block(unsigned char* output, unsigned int sz);
+int  atmel_get_random_block(unsigned char* output, unsigned int sz);
 long atmel_get_curr_time_and_date(long* tm);
 
 #ifdef WOLFSSL_ATECC508A
@@ -80,16 +83,32 @@ enum atmelSlotType {
     ATMEL_SLOT_ENCKEY,
     ATMEL_SLOT_DEVICE,
     ATMEL_SLOT_ECDHE,
-    ATMEL_SLOT_ECDHEPUB,
+    ATMEL_SLOT_ECDHE_ENC,
 };
 
 int  atmel_ecc_alloc(int slotType);
-void atmel_ecc_free(int slot);
+void atmel_ecc_free(int slotId);
 
 typedef int  (*atmel_slot_alloc_cb)(int);
 typedef void (*atmel_slot_dealloc_cb)(int);
-int atmel_set_slot_allocator(atmel_slot_alloc_cb alloc, 
+int atmel_set_slot_allocator(atmel_slot_alloc_cb alloc,
     atmel_slot_dealloc_cb dealloc);
+
+int  atmel_ecc_translate_err(int status);
+int  atmel_get_rev_info(byte* revision);
+void atmel_show_rev_info(void);
+
+/* The macro ATECC_GET_ENC_KEY can be set to override the default
+   encryption key with your own at build-time */
+#ifndef ATECC_GET_ENC_KEY
+    #define ATECC_GET_ENC_KEY(enckey, keysize) atmel_get_enc_key_default((enckey), (keysize))
+#endif
+int  atmel_get_enc_key_default(byte* enckey, word16 keysize);
+int  atmel_ecc_create_pms(int slotId, const uint8_t* peerKey, uint8_t* pms);
+int  atmel_ecc_create_key(int slotId, byte* peerKey);
+int  atmel_ecc_sign(int slotId, const byte* message, byte* signature);
+int  atmel_ecc_verify(const byte* message, const byte* signature,
+    const byte* pubkey, int* verified);
 
 #endif /* WOLFSSL_ATECC508A */
 

--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -26,7 +26,6 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/ssl.h>
-#include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifdef WOLFSSL_ATECC508A
@@ -71,6 +70,7 @@ long atmel_get_curr_time_and_date(long* tm);
 int atmel_ecc_alloc(void);
 void atmel_ecc_free(int slot);
 
+#include <wolfssl/wolfcrypt/ecc.h>
 
 #ifdef HAVE_PK_CALLBACKS
     int atcatls_create_key_cb(WOLFSSL* ssl, ecc_key* key, word32 keySz,

--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -94,7 +94,7 @@ int atmel_set_slot_allocator(atmel_slot_alloc_cb alloc,
     atmel_slot_dealloc_cb dealloc);
 
 int  atmel_ecc_translate_err(int status);
-int  atmel_get_rev_info(byte* revision);
+int  atmel_get_rev_info(word32* revision);
 void atmel_show_rev_info(void);
 
 /* The macro ATECC_GET_ENC_KEY can be set to override the default

--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -31,11 +31,10 @@
     #undef  SHA_BLOCK_SIZE
     #define SHA_BLOCK_SIZE  SHA_BLOCK_SIZE_REMAP
     #include <cryptoauthlib.h>
-    #include <atcacert/atcacert_client.h>
     #undef SHA_BLOCK_SIZE
 #endif
 
-/* ATECC508A only supports ECC-256 */
+/* ATECC508A only supports ECC P-256 */
 #define ATECC_KEY_SIZE      (32)
 #define ATECC_PUBKEY_SIZE   (ATECC_KEY_SIZE*2) /* X and Y */
 #define ATECC_SIG_SIZE      (ATECC_KEY_SIZE*2) /* R and S */

--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -48,7 +48,7 @@
 struct WOLFSSL;
 struct WOLFSSL_X509_STORE_CTX;
 
-// Cert Structure
+/* Cert Structure */
 typedef struct t_atcert {
 	uint32_t signer_ca_size;
 	uint8_t signer_ca[512];
@@ -60,15 +60,19 @@ typedef struct t_atcert {
 
 extern t_atcert atcert;
 
-
 /* Amtel port functions */
 void atmel_init(void);
 void atmel_finish(void);
-int atmel_get_random_number(uint32_t count, uint8_t* rand_out);
+int  atmel_get_random_number(uint32_t count, uint8_t* rand_out);
 long atmel_get_curr_time_and_date(long* tm);
 
-int atmel_ecc_alloc(void);
+int  atmel_ecc_alloc(void);
 void atmel_ecc_free(int slot);
+
+typedef int  (*atmel_slot_alloc_cb)(void);
+typedef void (*atmel_slot_dealloc_cb)(int);
+int atmel_set_slot_allocator(atmel_slot_alloc_cb alloc, 
+    atmel_slot_dealloc_cb dealloc);
 
 #include <wolfssl/wolfcrypt/ecc.h>
 


### PR DESCRIPTION
* Fixes for building with `WOLFSSL_ATECC508A` with latest CryptoAuthLib (without atcatls).
* Fix for shared secret callback for client side, where it was not using the provided peer's public key. 
* Fix for ATECC508A to put it into idle mode after operations to prevent watchdog fault mode (can be disabled by defining `WOLFSSL_ATECC508A_NOIDLE`).
* Fixes for callbacks to support using software for non P-256 curves (can be disabled by defining `WOLFSSL_ATECC508A_NOSOFTECC`).
* Fix for `wc_ecc_import_x963_ex` to handle ATECC508A raw public key. PR #1804
* Fix to make sure read encryption key is cleared from stack buffer.
* Added new macro `ATECC_GET_ENC_KEY` to allow setting your own function at build-time for getting the encryption key.
* Added slot callbacks with type. Replaces PR #1510 with wolf authored version.
* Cleanup of the ATECC508A encryption key support.
* Improvements for the Atmel time support.
* Finished the ATECC508A ECC functions to support native TLS with the WOLFSSL_ATECC508A option and SECP256R1.
* Added helper functions for setting the PK callbacks and custom content.
* Updated the README.md with build options.
* Added support for overriding the `ATECC_MAX_SLOT`.
* Added overridable define for all default slot numbers.
* Added new build option `WOLFSSL_ATECC_PKCB` for using just the reference PK callbacks.