### PR TITLE
Remove old-style function definitions

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15741,7 +15741,7 @@ const char* wolfSSL_get_curve_name(WOLFSSL* ssl)
 /* returns a pointer to a new WOLFSSL_X509 structure on success and NULL on
  * fail
  */
-WOLFSSL_X509* wolfSSL_X509_new()
+WOLFSSL_X509* wolfSSL_X509_new(void)
 {
     WOLFSSL_X509* x509;
 
@@ -16205,7 +16205,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_X509_get_pubkey(WOLFSSL_X509* x509)
      *
      * returns a pointer to the new structure created on success or NULL if fail
      */
-    WOLFSSL_ASN1_STRING* wolfSSL_ASN1_STRING_new()
+    WOLFSSL_ASN1_STRING* wolfSSL_ASN1_STRING_new(void)
     {
         WOLFSSL_ASN1_STRING* asn1;
 
@@ -18628,7 +18628,7 @@ int wolfSSL_X509_CRL_verify(WOLFSSL_X509_CRL* crl, WOLFSSL_EVP_PKEY* key)
 /* Subset of OPENSSL_EXTRA for PKEY operations PKEY free is needed by the
  * subset of X509 API */
 
-WOLFSSL_EVP_PKEY* wolfSSL_PKEY_new(){
+WOLFSSL_EVP_PKEY* wolfSSL_PKEY_new(void){
     return wolfSSL_PKEY_new_ex(NULL);
 }
 
@@ -22001,7 +22001,7 @@ int wolfSSL_RAND_bytes(unsigned char* buf, int num)
 }
 
 
-int wolfSSL_RAND_poll()
+int wolfSSL_RAND_poll(void)
 {
     byte  entropy[16];
     int  ret = 0;
@@ -28991,7 +28991,7 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
      *
      * returns NULL on failure, otherwise returns a new structure.
      */
-    WOLFSSL_X509_NAME* wolfSSL_X509_NAME_new()
+    WOLFSSL_X509_NAME* wolfSSL_X509_NAME_new(void)
     {
         WOLFSSL_X509_NAME* name;
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -16106,7 +16106,7 @@ static void test_wolfSSL_certs(void)
 }
 
 
-static void test_wolfSSL_ASN1_TIME_print()
+static void test_wolfSSL_ASN1_TIME_print(void)
 {
     #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && !defined(NO_RSA) \
         && (defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(WOLFSSL_NGINX) || \
@@ -16142,7 +16142,8 @@ static void test_wolfSSL_ASN1_TIME_print()
 }
 
 
-static void test_wolfSSL_ASN1_GENERALIZEDTIME_free(){
+static void test_wolfSSL_ASN1_GENERALIZEDTIME_free(void)
+{
     #if defined(OPENSSL_EXTRA)
     WOLFSSL_ASN1_GENERALIZEDTIME* asn1_gtime;
     unsigned char nullstr[32];
@@ -20520,7 +20521,7 @@ static void test_DhCallbacks(void)
 #ifdef HAVE_HASHDRBG
 
 #ifdef TEST_RESEED_INTERVAL
-static int test_wc_RNG_GenerateBlock_Reseed()
+static int test_wc_RNG_GenerateBlock_Reseed(void)
 {
     int i, ret;
     WC_RNG rng;
@@ -20543,7 +20544,7 @@ static int test_wc_RNG_GenerateBlock_Reseed()
 }
 #endif /* TEST_RESEED_INTERVAL */
 
-static int test_wc_RNG_GenerateBlock()
+static int test_wc_RNG_GenerateBlock(void)
 {
     int i, ret;
     WC_RNG rng;
@@ -20626,7 +20627,7 @@ static void test_wolfSSL_X509_CRL(void)
         return;
 }
 
-static void test_wolfSSL_i2c_ASN1_INTEGER()
+static void test_wolfSSL_i2c_ASN1_INTEGER(void)
 {
 #ifdef OPENSSL_EXTRA
     ASN1_INTEGER *a;

--- a/tests/hash.c
+++ b/tests/hash.c
@@ -535,7 +535,7 @@ int sha512_test(void)
 #endif
 
 #ifdef WOLFSSL_SHA384
-int sha384_test()
+int sha384_test(void)
 {
     wc_Sha384 sha;
     byte      hash[WC_SHA384_DIGEST_SIZE];

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -2157,7 +2157,7 @@ void bench_aesccm(void)
 
 
 #ifdef HAVE_POLY1305
-void bench_poly1305()
+void bench_poly1305(void)
 {
     Poly1305 enc;
     byte     mac[16];

--- a/wolfcrypt/src/fe_low_mem.c
+++ b/wolfcrypt/src/fe_low_mem.c
@@ -60,7 +60,7 @@ void lm_copy(byte* x, const byte* a)
     !defined(FREESCALE_LTC_ECC)
     /* to be Complementary to fe_low_mem.c */
 #else
-void fe_init()
+void fe_init(void)
 {
 }
 #endif

--- a/wolfcrypt/src/fe_operations.c
+++ b/wolfcrypt/src/fe_operations.c
@@ -120,7 +120,7 @@ void fe_0(fe h)
      (defined(HAVE_ED25519) && !defined(ED25519_SMALL))) && \
     !defined(FREESCALE_LTC_ECC)
 /* to be Complementary to fe_low_mem.c */
-void fe_init()
+void fe_init(void)
 {
 }
 #endif

--- a/wolfcrypt/src/fe_x25519_128.i
+++ b/wolfcrypt/src/fe_x25519_128.i
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-void fe_init()
+void fe_init(void)
 {
 }
 

--- a/wolfcrypt/src/fe_x25519_x64.i
+++ b/wolfcrypt/src/fe_x25519_x64.i
@@ -60,7 +60,7 @@ static int intelFlags;
 
 #endif
 
-void fe_init()
+void fe_init(void)
 {
 #ifdef HAVE_INTEL_AVX2
     if (cpuFlagsSet)

--- a/wolfcrypt/src/port/caam/caam_driver.c
+++ b/wolfcrypt/src/port/caam/caam_driver.c
@@ -103,7 +103,7 @@ static struct CAAM_DEVICE caam;
   ****************************************************************************/
 
 /* flush job ring and reset */
-static Error caamReset()
+static Error caamReset(void)
 {
     int t = 100000; /* time out counter for flushing job ring */
 

--- a/wolfcrypt/src/port/caam/caam_init.c
+++ b/wolfcrypt/src/port/caam/caam_init.c
@@ -84,7 +84,7 @@ int wc_caamSetResource(IODevice ioDev)
  *
  * returns 0 on success
  */
-int wc_caamInit()
+int wc_caamInit(void)
 {
     int    ret;
     word32 reg;
@@ -143,7 +143,7 @@ int wc_caamInit()
 }
 
 
-int wc_caamFree()
+int wc_caamFree(void)
 {
     return 0;
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13894,7 +13894,7 @@ openssl_pkey1_test_done:
 
 #define ERR_BASE_EVPSIG -5100
 
-int openssl_evpSig_test()
+int openssl_evpSig_test(void)
 {
 #if !defined(NO_RSA) && !defined(NO_SHA) && !defined(HAVE_USER_RSA)
   	byte*   prvTmp;


### PR DESCRIPTION
Some environments (e.g. Riot-OS) enforce the `-Wold-style-definition` compile flag.

This patch removes the obsolete old-style K&R-C definitions for functions with no arguments. 

Functions with no arguments such as:
```
void fe_init() 
{
}
```

Are replaced with the ANSI-C correct form 

```
void fe_init(void)
{
}
```

Which ensures that no warnings/errors are generated in presence of stricter compile flags.