### PR TITLE
fixed compile time errors and warnings for IAR-EWARM projects

### DIFF
--- a/IDE/IAR-EWARM/Projects/lib/wolfSSL-Lib.ewp
+++ b/IDE/IAR-EWARM/Projects/lib/wolfSSL-Lib.ewp
@@ -937,7 +937,7 @@
         </option>
         <option>
           <name>IarchiveOutput</name>
-          <state>C:\wolfSSL\Support\EWARM\wolfssl\IDE\IAR-EWARM\Projects\lib\ewarm\Exe\wolfSSL-Lib.a</state>
+          <state>$PROJ_DIR$\..\lib\ewarm\Exe\wolfSSL-Lib.a</state>
         </option>
       </data>
     </settings>
@@ -1961,9 +1961,6 @@
       <name>$PROJ_DIR$\..\..\..\..\wolfcrypt\src\error.c</name>
     </file>
     <file>
-      <name>$PROJ_DIR$\..\..\..\..\wolfcrypt\src\evp.c</name>
-    </file>
-    <file>
       <name>$PROJ_DIR$\..\..\..\..\wolfcrypt\src\fe_low_mem.c</name>
     </file>
     <file>
@@ -2045,7 +2042,19 @@
       <name>$PROJ_DIR$\..\..\..\..\wolfcrypt\src\signature.c</name>
     </file>
     <file>
-      <name>$PROJ_DIR$\..\..\..\..\wolfcrypt\src\sp.c</name>
+      <name>$PROJ_DIR$\..\..\..\..\wolfcrypt\src\sp_arm32.c</name>
+    </file>
+    <file>
+      <name>$PROJ_DIR$\..\..\..\..\wolfcrypt\src\sp_arm64.c</name>
+    </file>
+    <file>
+      <name>$PROJ_DIR$\..\..\..\..\wolfcrypt\src\sp_c32.c</name>
+    </file>
+    <file>
+      <name>$PROJ_DIR$\..\..\..\..\wolfcrypt\src\sp_c64.c</name>
+    </file>
+    <file>
+      <name>$PROJ_DIR$\..\..\..\..\wolfcrypt\src\sp_int.c</name>
     </file>
     <file>
       <name>$PROJ_DIR$\..\..\..\..\wolfcrypt\src\srp.c</name>
@@ -2068,9 +2077,6 @@
   </group>
   <group>
     <name>wolfSSL</name>
-    <file>
-      <name>$PROJ_DIR$\..\..\..\..\src\bio.c</name>
-    </file>
     <file>
       <name>$PROJ_DIR$\..\..\..\..\src\crl.c</name>
     </file>

--- a/IDE/IAR-EWARM/Projects/user_settings.h
+++ b/IDE/IAR-EWARM/Projects/user_settings.h
@@ -9,11 +9,12 @@
 #define SIZEOF_LONG_LONG 8
 #define NO_WOLFSSL_DIR 
 #define WOLFSSL_NO_CURRDIR
+#define NO_WOLF_C99
 
 #define XVALIDATEDATE(d, f,t) (0)
 #define WOLFSSL_USER_CURRTIME /* for benchmark */
 
-#define WOLFSSL_GENSEED_FORTEST /* Wardning: define your own seed gen */
+#define WOLFSSL_GENSEED_FORTEST /* Warning: define your own seed gen */
 
 #define TFM_TIMING_RESISTANT
 #define ECC_TIMING_RESISTANT


### PR DESCRIPTION
**Changes**:
The sp.c file was removed and the following were added: sp_arm32.c, sp_arm64.c, sp_32.c, sp_64.c and sp_int.c

evp.c and bio.c were removed from compiling since a warning was given that they don't need to be compiled seperately from ssl.c

**Status**:
The following is the only warning given now and is due to a test environment.

wolfssl\wolfcrypt\src\random.c(2027) : Warning[Pa183]: #warning directive: "write a real random seed!!!!, just for testing now"