### PR TITLE
Fixes for NXP LTC support with K82

### DIFF
--- a/IDE/ROWLEY-CROSSWORKS-ARM/arm_startup.c
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/arm_startup.c
@@ -155,7 +155,7 @@ void HardFault_HandlerC( uint32_t *hardfault_args )
     printf ("BFAR = %x\n", _BFAR);
 
     // Break into the debugger
-	__asm("BKPT #0\n");
+    __asm("BKPT #0\n");
 }
 
 __attribute__( ( naked ) )

--- a/IDE/ROWLEY-CROSSWORKS-ARM/benchmark_main.c
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/benchmark_main.c
@@ -25,6 +25,7 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfcrypt/benchmark/benchmark.h>
 #include <stdio.h>
 
@@ -42,6 +43,7 @@ void main(void)
 {
     int test_num = 0;
 
+    wolfCrypt_Init(); /* required for ksdk_port_init */
     do
     {
         /* Used for testing, must have a delay so no data is missed while serial is initializing */
@@ -68,6 +70,8 @@ void main(void)
         printf("\n&&&&&&&&&&&&&& done &&&&&&&&&&&&&\n");
         delay_us(1000000);
     #endif
+
+    wolfCrypt_Cleanup();
 }
 
 /*

--- a/IDE/ROWLEY-CROSSWORKS-ARM/test_main.c
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/test_main.c
@@ -26,6 +26,7 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfcrypt/test/test.h>
 #include <stdio.h>
 #include "hw.h"
@@ -43,6 +44,7 @@ void main(void)
 {
     int test_num = 0;
 
+    wolfCrypt_Init(); /* required for ksdk_port_init */
     do
     {
         /* Used for testing, must have a delay so no data is missed while serial is initializing */
@@ -68,6 +70,8 @@ void main(void)
         printf("\n&&&&&&&&&&&&&& done &&&&&&&&&&&&&\n");
         delay_us(1000000);
     #endif
+
+    wolfCrypt_Cleanup();
 }
 
 

--- a/IDE/ROWLEY-CROSSWORKS-ARM/user_settings.h
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/user_settings.h
@@ -19,7 +19,10 @@ extern "C" {
 #define SINGLE_THREADED
 
 #undef  WOLFSSL_SMALL_STACK
-#define WOLFSSL_SMALL_STACK
+//#define WOLFSSL_SMALL_STACK
+
+#undef  WOLFSSL_SMALL_STACK_CACHE
+//#define WOLFSSL_SMALL_STACK_CACHE
 
 
 /* ------------------------------------------------------------------------- */
@@ -58,7 +61,7 @@ extern "C" {
     #define HAVE_ECC224
     #undef NO_ECC256
     #define HAVE_ECC384
-    #ifndef USE_NXP_LTC /* NXP LTC HW supports up to 512 */
+    #ifndef USE_NXP_LTC /* NXP LTC HW supports up to 384 */
         #define HAVE_ECC521
     #endif
 
@@ -221,7 +224,7 @@ extern "C" {
         #endif
         #ifdef USE_NXP_LTC
             #define FREESCALE_USE_LTC
-            #define LTC_MAX_ECC_BITS    (512)
+            #define LTC_MAX_ECC_BITS    (384)
             #define LTC_MAX_INT_BYTES   (256)
 
             //#define FREESCALE_LTC_TFM_RSA_4096_ENABLE

--- a/IDE/ROWLEY-CROSSWORKS-ARM/wolfssl_ltc.hzp
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/wolfssl_ltc.hzp
@@ -4,7 +4,7 @@
     <configuration
       Name="Common"
       build_output_file_name="$(OutDir)/$(ProjectName)$(LibExt)$(LIB)"
-      c_preprocessor_definitions="WOLFSSL_ROWLEY_ARM;WOLFSSL_USER_SETTINGS"
+      c_preprocessor_definitions="WOLFSSL_ROWLEY_ARM;WOLFSSL_USER_SETTINGS;USE_NXP_MMCAU;USE_NXP_LTC"
       c_user_include_directories=".;../;../../;./drivers;./mmcau_2.0.0;./CMSIS/Include"
       project_directory=""
       project_type="Library" />
@@ -338,7 +338,7 @@
       arm_simulator_memory_simulation_parameter="MK82FN256xxx15;0x40000;0x0;0x0;0x40000;4"
       arm_target_loader_applicable_loaders="Flash"
       arm_target_loader_default_loader="Flash"
-      c_preprocessor_definitions="WOLFSSL_ROWLEY_ARM;WOLFSSL_USER_SETTINGS"
+      c_preprocessor_definitions="WOLFSSL_ROWLEY_ARM;WOLFSSL_USER_SETTINGS;USE_NXP_MMCAU;USE_NXP_LTC"
       c_user_include_directories=".;./drivers;./mmcau_2.0.0;./CMSIS/Include;../;../../;$(TargetsDir);$(TargetsDir)/Kinetis;$(TargetsDir)/Kinetis/CMSIS;$(TargetsDir)/Kinetis/CMSIS/include;$(TargetsDir)/CMSIS_3/CMSIS/include"
       debug_register_definition_file="$(TargetsDir)/Kinetis/MK82F25615_Peripherals.xml"
       linker_memory_map_file="$(TargetsDir)/Kinetis/MK82FN256xxx15_MemoryMap.xml"
@@ -511,7 +511,7 @@
   <configuration
     Name="Kinetis"
     arm_target_debug_interface_type="ADIv5"
-    c_preprocessor_definitions="FREESCALE;K_SERIES;CPU_MK82FN256VLL15;FREESCALE_KSDK_BM;USE_NXP_LTC;USE_NXP_MMCAU"
+    c_preprocessor_definitions="FREESCALE;K_SERIES;CPU_MK82FN256VLL15;FREESCALE_KSDK_BM;USE_NXP_MMCAU;USE_NXP_LTC"
     hidden="Yes"
     linker_section_placement_file="$(ProjectDir)/Kinetis_FlashPlacement.xml" />
   <configuration

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -60,6 +60,10 @@ Possible memory options:
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
 
+#if defined(WOLFSSL_DEBUG_MEMORY) && defined(WOLFSSL_DEBUG_MEMORY_PRINT)
+#include <stdio.h>
+#endif
+
 #ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
     static int gMemFailCountSeed;
     static int gMemFailCount;

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -608,8 +608,7 @@ static WC_INLINE int Sha512Update(wc_Sha512* sha512, const byte* data, word32 le
     }
     else
 #endif
-#if !defined(LITTLE_ENDIAN_ORDER) || defined(FREESCALE_MMCAU_SHA) || \
-                            defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2)
+#if !defined(LITTLE_ENDIAN_ORDER) || defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2)
     {
         word32 blocksLen = len & ~(WC_SHA512_BLOCK_SIZE-1);
 
@@ -1035,7 +1034,7 @@ static word64 mBYTE_FLIP_MASK[] =  { 0x0001020304050607, 0x08090a0b0c0d0e0f };
     "addq	" L1 ", "#h"\n\t"                    \
     /* L2 = a */                                     \
     "movq	"#a", " L2 "\n\t"                    \
- 
+
 #define RND_1_8(a,b,c,d,e,f,g,h,i)                   \
     /* L3 = (a ^ b) & (b ^ c) */                     \
     "andq	" L4 ", " L3 "\n\t"                  \

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6802,6 +6802,7 @@ int aesgcm_test(void)
     /* FIPS, QAT and STM32F2/4 HW Crypto only support 12-byte IV */
 #if !defined(HAVE_FIPS) && \
         !defined(STM32_CRYPTO) && !defined(WOLFSSL_PIC32MZ_CRYPT) && \
+        !defined(FREESCALE_LTC) && !defined(FREESCALE_MMCAU) && \
         !defined(WOLFSSL_XILINX_CRYPT)
 
     #define ENABLE_NON_12BYTE_IV_TEST
@@ -10556,12 +10557,12 @@ int rsa_test(void)
 
 #ifdef USE_CERT_BUFFERS_1024
     bytes = (size_t)sizeof_client_key_der_1024;
-	if (bytes < (size_t)sizeof_client_cert_der_1024)
-		bytes = (size_t)sizeof_client_cert_der_1024;
+    if (bytes < (size_t)sizeof_client_cert_der_1024)
+        bytes = (size_t)sizeof_client_cert_der_1024;
 #elif defined(USE_CERT_BUFFERS_2048)
     bytes = (size_t)sizeof_client_key_der_2048;
-	if (bytes < (size_t)sizeof_client_cert_der_2048)
-		bytes = (size_t)sizeof_client_cert_der_2048;
+    if (bytes < (size_t)sizeof_client_cert_der_2048)
+        bytes = (size_t)sizeof_client_cert_der_2048;
 #else
 	bytes = FOURK_BUF;
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1022,15 +1022,7 @@ extern void uITRON4_free(void *p) ;
                     #define HAVE_ECC224
                     #undef  NO_ECC256
                     #define HAVE_ECC384
-                #endif
-
-                /* enable features */
-                #undef  HAVE_CURVE25519
-                #define HAVE_CURVE25519
-                #undef  HAVE_ED25519
-                #define HAVE_ED25519
-                #undef  WOLFSSL_SHA512
-                #define WOLFSSL_SHA512
+                #endif          
             #endif
         #endif
     #endif


### PR DESCRIPTION
* Fix for SHA384/512 due to improperly placed `FREESCALE_MMCAU_SHA` check.
* Fix for AES CBC not storing previous IV. 
* Fix for `wc_AesSetKey` arg check.
* Fix for AES GCM IV != 12 test.
* Changed LTC default in settings.h to not enable SHA512 and Ed/Curve25519. 
* Tested using Rowley Crossworks v4.2.0 on a FRDM-K82F. 

Note: There is an initial stack pointer issue with the arm-startup code here for Rowley still outstanding, but these fixes are valid as-is.