### PR TITLE
Fix for build with cert extensions and openssl extra only

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -19551,8 +19551,8 @@ static void test_wc_GetPkcs8TraditionalOffset(void)
 
 static void test_wc_SetSubjectRaw(void)
 {
-#if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && \
-    defined(WOLFSSL_CERT_EXT) && defined(OPENSSL_EXTRA)
+#if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
+    defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
     char joiCertFile[] = "./certs/test/cert-ext-joi.pem";
     WOLFSSL_X509* x509;
     int peerCertSz;
@@ -19577,8 +19577,8 @@ static void test_wc_SetSubjectRaw(void)
 
 static void test_wc_GetSubjectRaw(void)
 {
-#if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && \
-    defined(WOLFSSL_CERT_EXT) && defined(OPENSSL_EXTRA)
+#if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
+    defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
     Cert cert;
     byte *subjectRaw;
 
@@ -19593,8 +19593,8 @@ static void test_wc_GetSubjectRaw(void)
 
 static void test_wc_SetIssuerRaw(void)
 {
-#if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && \
-    defined(WOLFSSL_CERT_EXT) && defined(OPENSSL_EXTRA)
+#if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
+    defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
     char joiCertFile[] = "./certs/test/cert-ext-joi.pem";
     WOLFSSL_X509* x509;
     int peerCertSz;


### PR DESCRIPTION
The wrong macro check is used in the API unit tests.

`./configure --enable-certext --enable-opensslextra`