### PR TITLE
Fixed typo in the definition of macro FALL_THROUGH

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -183,7 +183,7 @@
     /* GCC 7 has new switch() fall-through detection */
     #if defined(__GNUC__)
         #if ((__GNUC__ > 7) || ((__GNUC__ == 7) && (__GNUC_MINOR__ >= 1)))
-            #define FALL_THROUGH __attribute__ ((fallthrough));
+            #define FALL_THROUGH __attribute__ ((fallthrough))
         #endif
     #endif
     #ifndef FALL_THROUGH


### PR DESCRIPTION
Definitin of macro FALL_THROUGH should not have ';' at the end