### PR TITLE
mp_set pre-processor logic in fastmath breaking existing builds, norm…

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3886,7 +3886,8 @@ int mp_cnt_lsb(fp_int* a)
 
 #endif /* HAVE_ECC */
 
-#if defined(HAVE_ECC) || !defined(NO_RSA) || !defined(NO_DSA)
+#if defined(HAVE_ECC) || !defined(NO_RSA) || !defined(NO_DSA) || \
+    defined(WOLFSSL_KEY_GEN)
 /* fast math conversion */
 int mp_set(fp_int *a, fp_digit b)
 {

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -725,7 +725,8 @@ MP_API int mp_radix_size (mp_int * a, int radix, int *size);
     MP_API int mp_init_copy(fp_int * a, fp_int * b);
 #endif
 
-#if defined(HAVE_ECC) || !defined(NO_RSA) || !defined(NO_DSA)
+#if defined(HAVE_ECC) || !defined(NO_RSA) || !defined(NO_DSA) || \
+    defined(WOLFSSL_KEY_GEN)
     MP_API int mp_set(fp_int *a, fp_digit b);
 #endif
 


### PR DESCRIPTION
…al math not effected

Failing Configuration:  ```./configure --enable-keygen --disable-asn --disable-ecc --disable-rsa --enable-psk```

Issue was being masked by OCSP failures addressed in PR #1801 
Now that OCSP tests are passing this failure was exposed.
