### PR TITLE
RNG Update

### DIFF
--- a/IDE/WIN10/user_settings.h
+++ b/IDE/WIN10/user_settings.h
@@ -42,6 +42,9 @@
         #define WOLFSSL_VALIDATE_ECC_IMPORT
         #define WOLFSSL_VALIDATE_FFC_IMPORT
         #define HAVE_FFDHE_Q
+        #define WOLFSSL_AESNI
+        #define HAVE_INTEL_RDSEED
+        #define FORCE_FAILURE_RDSEED
     #endif /* FIPS v2 */
 #else
     /* Enables blinding mode, to prevent timing attacks */

--- a/fips-check.sh
+++ b/fips-check.sh
@@ -161,6 +161,8 @@ linuxv2)
   CRYPT_VERSION=$LINUXV2_CRYPT_VERSION
   CRYPT_INC_PATH=wolfssl/wolfcrypt
   CRYPT_SRC_PATH=wolfcrypt/src
+# Replace the WC_MODS list for now. Do not want to copy over random.c yet.
+  WC_MODS=( aes des3 sha sha256 sha512 rsa hmac )
   WC_MODS+=( cmac dh ecc )
   FIPS_SRCS+=( wolfcrypt_first.c wolfcrypt_last.c )
   FIPS_INCS=( fips.h )

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -225,9 +225,8 @@ int wc_RNG_GenerateByte(WC_RNG* rng, byte* b)
         /* RDSEED outputs in blocks of 64-bits. */
         #define SEED_BLOCK_SZ sizeof(word64)
     #else
-        /* Setting the default to 2. It is not unreasonable for /dev/random
-         * or /dev/urandom to return two bytes that are the same. */
-        #define SEED_BLOCK_SZ 2
+        /* Setting the default to 4. */
+        #define SEED_BLOCK_SZ 4
     #endif
 #endif
 

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1442,6 +1442,19 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
 int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 {
+    #ifdef HAVE_INTEL_RDSEED
+        if (IS_INTEL_RDSEED(intel_flags)) {
+             if (!wc_GenerateSeed_IntelRD(NULL, output, sz)) {
+                 /* success, we're done */
+                 return 0;
+             }
+        #ifdef FORCE_FAILURE_RDSEED
+             /* don't fall back to CryptoAPI */
+             return READ_RAN_E;
+        #endif
+        }
+    #endif /* HAVE_INTEL_RDSEED */
+
     if(!CryptAcquireContext(&os->handle, 0, 0, PROV_RSA_FULL,
                             CRYPT_VERIFYCONTEXT))
         return WINCRYPT_E;

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -630,8 +630,6 @@ static int Hash_DRBG_Uninstantiate(DRBG* drbg)
 
     return (compareSum == 0) ? DRBG_SUCCESS : DRBG_FAILURE;
 }
-#endif /* HAVE_HASHDRBG */
-/* End NIST DRBG Code */
 
 
 int wc_RNG_TestSeed(const byte* seed, word32 seedSz)
@@ -655,6 +653,8 @@ int wc_RNG_TestSeed(const byte* seed, word32 seedSz)
 
     return ret;
 }
+#endif /* HAVE_HASHDRBG */
+/* End NIST DRBG Code */
 
 
 static int _InitRng(WC_RNG* rng, byte* nonce, word32 nonceSz,

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8276,6 +8276,34 @@ int random_test(void)
     if ((ret = random_rng_test()) != 0)
         return ret;
 
+    /* Test the seed check function. */
+    {
+        word32 i, outputSz;
+
+        /* Repeat the same byte over and over. Should fail. */
+        outputSz = sizeof(output);
+        XMEMSET(output, 1, outputSz);
+        ret = wc_RNG_TestSeed(output, outputSz);
+        if (ret == 0)
+            return -6404;
+
+        /* Every byte of the entropy scratch is different,
+         * entropy is a single byte that shouldn't match. */
+        outputSz = (sizeof(word32) * 2) + 1;
+        for (i = 0; i < outputSz; i++)
+            output[i] = (byte)i;
+        ret = wc_RNG_TestSeed(output, outputSz);
+        if (ret != 0)
+            return -6405;
+
+        outputSz = sizeof(output);
+        for (i = 0; i < outputSz; i++)
+            output[i] = (byte)i;
+        ret = wc_RNG_TestSeed(output, outputSz);
+        if (ret != 0)
+            return -6406;
+    }
+
     return 0;
 }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8277,7 +8277,7 @@ int random_test(void)
         return ret;
 
     /* Test the seed check function. */
-#if !defined(HAVE_FIPS) || \
+#if !(defined(HAVE_FIPS) || defined(HAVE_SELFTEST)) || \
     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))
     {
         word32 i, outputSz;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8277,6 +8277,8 @@ int random_test(void)
         return ret;
 
     /* Test the seed check function. */
+#if !defined(HAVE_FIPS) || \
+    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))
     {
         word32 i, outputSz;
 
@@ -8303,7 +8305,7 @@ int random_test(void)
         if (ret != 0)
             return -6406;
     }
-
+#endif
     return 0;
 }
 

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -205,6 +205,7 @@ WOLFSSL_API int  wc_FreeRng(WC_RNG*);
 #ifdef HAVE_HASHDRBG
     WOLFSSL_LOCAL int wc_RNG_DRBG_Reseed(WC_RNG* rng, const byte* entropy,
                                         word32 entropySz);
+    WOLFSSL_API int wc_RNG_TestSeed(const byte* seed, word32 seedSz);
     WOLFSSL_API int wc_RNG_HealthTest(int reseed,
                                         const byte* entropyA, word32 entropyASz,
                                         const byte* entropyB, word32 entropyBSz,


### PR DESCRIPTION
Updated the Hash_DRBG so that the constants (security strength, entropy bits per bit, entropy source block size) are configurable and added a continuous test for the DRBG seeding value to verify blocks don't get repeated. Also, if not using FIPS builds, lowered the security strength to 256 bits.
Note: the fips-check script does not copy over a specific version of random.c yet, it is using whatever is in master.