### PR TITLE
changes to benchmark app

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -177,6 +177,7 @@
 /* Asymmetric algorithms. */
 #define BENCH_RSA_KEYGEN         0x00000001
 #define BENCH_RSA                0x00000002
+#define BENCH_RSA_SZ             0x00000004
 #define BENCH_DH                 0x00000010
 #define BENCH_NTRU               0x00000100
 #define BENCH_NTRU_KEYGEN        0x00000200
@@ -359,6 +360,7 @@ static const bench_alg bench_asym_opt[] = {
     { "-rsa-kg",             BENCH_RSA_KEYGEN        },
     #endif
     { "-rsa",                BENCH_RSA               },
+    { "-rsa-sz",             BENCH_RSA_SZ            },
 #endif
 #ifndef NO_DH
     { "-dh",                 BENCH_DH                },
@@ -1385,6 +1387,12 @@ static void* benchmarks_do(void* args)
         bench_rsa(1);
     #endif
     }
+
+    #ifdef WOLFSSL_KEY_GEN
+    if (bench_asym_algs & BENCH_RSA_SZ) {
+        bench_rsa_key(0, bench_size);
+    }
+    #endif
 #endif
 
 #ifndef NO_DH
@@ -3758,63 +3766,18 @@ void bench_rsaKeyGen(int doAsync)
 
 #define RSA_BUF_SIZE 384  /* for up to 3072 bit */
 
-void bench_rsa(int doAsync)
+static void bench_rsa_helper(int doAsync, RsaKey rsaKey[BENCH_MAX_PENDING],
+        int rsaKeySz)
 {
     int         ret = 0, i, times, count = 0, pending = 0;
-    size_t      bytes;
     word32      idx = 0;
-    const byte* tmp;
     const char* messageStr = "Everyone gets Friday off.";
     const int   len = (int)XSTRLEN((char*)messageStr);
     double      start = 0.0f;
-    RsaKey      rsaKey[BENCH_MAX_PENDING];
-    int         rsaKeySz = RSA_BUF_SIZE * 8; /* used in printf */
 
     DECLARE_VAR_INIT(message, byte, len, messageStr, HEAP_HINT);
-    DECLARE_ARRAY(enc, byte, BENCH_MAX_PENDING, RSA_BUF_SIZE, HEAP_HINT);
-    DECLARE_ARRAY(out, byte, BENCH_MAX_PENDING, RSA_BUF_SIZE, HEAP_HINT);
-
-#ifdef USE_CERT_BUFFERS_1024
-    tmp = rsa_key_der_1024;
-    bytes = (size_t)sizeof_rsa_key_der_1024;
-    rsaKeySz = 1024;
-#elif defined(USE_CERT_BUFFERS_2048)
-    tmp = rsa_key_der_2048;
-    bytes = (size_t)sizeof_rsa_key_der_2048;
-    rsaKeySz = 2048;
-#elif defined(USE_CERT_BUFFERS_3072)
-    tmp = rsa_key_der_3072;
-    bytes = (size_t)sizeof_rsa_key_der_3072;
-    rsaKeySz = 3072;
-#else
-    #error "need a cert buffer size"
-#endif /* USE_CERT_BUFFERS */
-
-    /* clear for done cleanup */
-    XMEMSET(rsaKey, 0, sizeof(rsaKey));
-
-    /* init keys */
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        /* setup an async context for each key */
-        if ((ret = wc_InitRsaKey_ex(&rsaKey[i], HEAP_HINT,
-                                        doAsync ? devId : INVALID_DEVID)) < 0) {
-            goto exit;
-        }
-
-    #ifdef WC_RSA_BLINDING
-        ret = wc_RsaSetRNG(&rsaKey[i], &rng);
-        if (ret != 0)
-            goto exit;
-    #endif
-
-        /* decode the private key */
-        idx = 0;
-        if ((ret = wc_RsaPrivateKeyDecode(tmp, &idx, &rsaKey[i],
-                                                        (word32)bytes)) != 0) {
-            printf("wc_RsaPrivateKeyDecode failed! %d\n", ret);
-            goto exit;
-        }
-    }
+    DECLARE_ARRAY(enc, byte, BENCH_MAX_PENDING, rsaKeySz/8, HEAP_HINT);
+    DECLARE_ARRAY(out, byte, BENCH_MAX_PENDING, rsaKeySz/8, HEAP_HINT);
 
     if (!rsa_sign_verify) {
         /* begin public RSA */
@@ -3828,7 +3791,7 @@ void bench_rsa(int doAsync)
                     if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                  1, &times, ntimes, &pending)) {
                         ret = wc_RsaPublicEncrypt(message, (word32)len, enc[i],
-                                                  RSA_BUF_SIZE, &rsaKey[i],
+                                                  rsaKeySz/8, &rsaKey[i],
                                                   &rng);
                         if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(
                                             &rsaKey[i]), 1, &times, &pending)) {
@@ -3861,7 +3824,7 @@ exit_rsa_pub:
                     if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                  1, &times, ntimes, &pending)) {
                         ret = wc_RsaPrivateDecrypt(enc[i], idx, out[i],
-                                                      RSA_BUF_SIZE, &rsaKey[i]);
+                                                       rsaKeySz/8, &rsaKey[i]);
                         if (!bench_async_handle(&ret,
                                                 BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                 1, &times, &pending)) {
@@ -3888,7 +3851,7 @@ exit:
                     if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                  1, &times, ntimes, &pending)) {
                         ret = wc_RsaSSL_Sign(message, len, enc[i],
-                                                RSA_BUF_SIZE, &rsaKey[i], &rng);
+                                                rsaKeySz/8, &rsaKey[i], &rng);
                         if (!bench_async_handle(&ret,
                                                 BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                 1, &times, &pending)) {
@@ -3921,7 +3884,7 @@ exit_rsa_sign:
                     if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                  1, &times, ntimes, &pending)) {
                         ret = wc_RsaSSL_Verify(enc[i], idx, out[i],
-                                                      RSA_BUF_SIZE, &rsaKey[i]);
+                                                      rsaKeySz/8, &rsaKey[i]);
                         if (!bench_async_handle(&ret,
                                                 BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                 1, &times, &pending)) {
@@ -3937,16 +3900,112 @@ exit_rsa_verify:
                                                                     start, ret);
     }
 
-    /* cleanup */
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_FreeRsaKey(&rsaKey[i]);
-    }
-
     FREE_ARRAY(enc, BENCH_MAX_PENDING, HEAP_HINT);
     FREE_ARRAY(out, BENCH_MAX_PENDING, HEAP_HINT);
     FREE_VAR(message, HEAP_HINT);
 }
 
+
+void bench_rsa(int doAsync)
+{
+    int         ret = 0, i;
+    RsaKey      rsaKey[BENCH_MAX_PENDING];
+    int         rsaKeySz = RSA_BUF_SIZE * 8; /* used in printf */
+    size_t      bytes;
+    const byte* tmp;
+    word32      idx;
+
+#ifdef USE_CERT_BUFFERS_1024
+    tmp = rsa_key_der_1024;
+    bytes = (size_t)sizeof_rsa_key_der_1024;
+    rsaKeySz = 1024;
+#elif defined(USE_CERT_BUFFERS_2048)
+    tmp = rsa_key_der_2048;
+    bytes = (size_t)sizeof_rsa_key_der_2048;
+    rsaKeySz = 2048;
+#elif defined(USE_CERT_BUFFERS_3072)
+    tmp = rsa_key_der_3072;
+    bytes = (size_t)sizeof_rsa_key_der_3072;
+    rsaKeySz = 3072;
+#else
+    #error "need a cert buffer size"
+#endif /* USE_CERT_BUFFERS */
+
+    /* clear for done cleanup */
+    XMEMSET(rsaKey, 0, sizeof(rsaKey));
+
+    /* init keys */
+    for (i = 0; i < BENCH_MAX_PENDING; i++) {
+        /* setup an async context for each key */
+        if ((ret = wc_InitRsaKey_ex(&rsaKey[i], HEAP_HINT,
+                                        doAsync ? devId : INVALID_DEVID)) < 0) {
+            goto exit_bench_rsa;
+        }
+
+    #ifdef WC_RSA_BLINDING
+        ret = wc_RsaSetRNG(&rsaKey[i], &rng);
+        if (ret != 0)
+            goto exit_bench_rsa;
+    #endif
+
+        /* decode the private key */
+        idx = 0;
+        if ((ret = wc_RsaPrivateKeyDecode(tmp, &idx, &rsaKey[i],
+                                                        (word32)bytes)) != 0) {
+            printf("wc_RsaPrivateKeyDecode failed! %d\n", ret);
+            goto exit_bench_rsa;
+        }
+    }
+
+    bench_rsa_helper(doAsync, rsaKey, rsaKeySz);
+exit_bench_rsa:
+    /* cleanup */
+    for (i = 0; i < BENCH_MAX_PENDING; i++) {
+        wc_FreeRsaKey(&rsaKey[i]);
+    }
+}
+
+
+#ifdef WOLFSSL_KEY_GEN
+/* bench any size of RSA key */
+void bench_rsa_key(int doAsync, int rsaKeySz)
+{
+    int         ret = 0, i;
+    RsaKey      rsaKey[BENCH_MAX_PENDING];
+
+    /* clear for done cleanup */
+    XMEMSET(rsaKey, 0, sizeof(rsaKey));
+
+    /* init keys */
+    for (i = 0; i < BENCH_MAX_PENDING; i++) {
+        /* setup an async context for each key */
+        if ((ret = wc_InitRsaKey_ex(&rsaKey[i], HEAP_HINT,
+                                        doAsync ? devId : INVALID_DEVID)) < 0) {
+            goto exit_bench_rsa_key;
+        }
+
+    #ifdef WC_RSA_BLINDING
+        ret = wc_RsaSetRNG(&rsaKey[i], &rng);
+        if (ret != 0)
+            goto exit_bench_rsa_key;
+    #endif
+
+        /* create the RSA key */
+        if ((ret = wc_MakeRsaKey(&rsaKey[i], rsaKeySz, 65537, &rng)) != 0) {
+            printf("wc_MakeRsaKey failed! %d\n", ret);
+            goto exit_bench_rsa_key;
+        }
+    }
+
+    bench_rsa_helper(doAsync, rsaKey, rsaKeySz);
+exit_bench_rsa_key:
+
+    /* cleanup */
+    for (i = 0; i < BENCH_MAX_PENDING; i++) {
+        wc_FreeRsaKey(&rsaKey[i]);
+    }
+}
+#endif /* WOLFSSL_KEY_GEN */
 #endif /* !NO_RSA */
 
 
@@ -4961,6 +5020,10 @@ static void Usage(void)
     printf("-dgst_full  Full digest operation performed.\n");
 #ifndef NO_RSA
     printf("-rsa_sign   Measure RSA sign/verify instead of encrypt/decrypt.\n");
+    #ifdef WOLFSSL_KEY_GEN
+    printf("<keySz> -rsa-sz\n"
+           "            Measure RSA <key size> performance.\n");
+    #endif
 #endif
 #ifndef WOLFSSL_BENCHMARK_ALL
     printf("-<alg>      Algorithm to benchmark. Available algorithms "
@@ -5013,6 +5076,13 @@ int main(int argc, char** argv)
     while (argc > 1) {
         if (string_matches(argv[1], "-?")) {
             Usage();
+            return 0;
+        }
+        else if (string_matches(argv[1], "-v")) {
+            printf("-----------------------------------------------------------"
+                   "-------------------\n wolfSSL version %s\n-----------------"
+                   "-----------------------------------------------------------"
+                   "--\n", LIBWOLFSSL_VERSION_STRING);
             return 0;
         }
         else if (string_matches(argv[1], "-base10"))

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -28,6 +28,7 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/version.h>
 
 /* Macro to disable benchmark */
 #ifndef NO_CRYPT_BENCHMARK
@@ -1556,6 +1557,12 @@ int benchmark_test(void *args)
     int ret;
 
     (void)args;
+
+    printf(
+"------------------------------------------------------------------------------"
+"\n wolfSSL version %s\n"
+"------------------------------------------------------------------------------"
+"\n", LIBWOLFSSL_VERSION_STRING);
 
     ret = benchmark_init();
     if (ret != 0)

--- a/wolfcrypt/benchmark/benchmark.h
+++ b/wolfcrypt/benchmark/benchmark.h
@@ -76,6 +76,7 @@ void bench_hmac_sha256(int);
 void bench_hmac_sha384(int);
 void bench_hmac_sha512(int);
 void bench_rsaKeyGen(int);
+void bench_rsaKeyGen_size(int, int);
 void bench_rsa(int);
 void bench_rsa_key(int, int);
 void bench_dh(int);

--- a/wolfcrypt/benchmark/benchmark.h
+++ b/wolfcrypt/benchmark/benchmark.h
@@ -77,6 +77,7 @@ void bench_hmac_sha384(int);
 void bench_hmac_sha512(int);
 void bench_rsaKeyGen(int);
 void bench_rsa(int);
+void bench_rsa_key(int, int);
 void bench_dh(int);
 void bench_eccMakeKey(int);
 void bench_ecc(int);


### PR DESCRIPTION
* Make collecting 4096 bit RSA benchmark values easier with "./wolfcrypt/benchmark/benchmark 4096 -rsa-sz"

* Add wolfSSL version print out to benchmark app