### PR TITLE
Lighttpd fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3160,7 +3160,7 @@ then
     fi
 fi
 
-if test "$ENABLED_NGINX" = "yes"|| test "x$ENABLED_HAPROXY" = "xyes"
+if test "$ENABLED_NGINX" = "yes"|| test "x$ENABLED_HAPROXY" = "xyes" || test "x$ENABLED_LIGHTY" = "xyes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALWAYS_VERIFY_CB"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALWAYS_KEEP_SNI"

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -677,8 +677,9 @@ void wc_ClearErrorNodes(void)
         }
     }
 
-    wc_errors    = NULL;
-    wc_last_node = NULL;
+    wc_errors       = NULL;
+    wc_last_node    = NULL;
+    wc_current_node = NULL;
     wc_UnLockMutex(&debug_mutex);
 #endif /* DEBUG_WOLFSSL || WOLFSSL_NGINX */
 }


### PR DESCRIPTION
* Fix for case where `wc_ClearErrorNodes` is called, but then `wc_PullErrorNode` is called and `wc_current_node` is populated with invalid ->next pointer.
* Fix for Lighttpd 1.4.49, which requires `HAVE_EX_DATA`.