### PR TITLE
Fixes for missing `mp_add_d`

### DIFF
--- a/IDE/GCC-ARM/Header/user_settings.h
+++ b/IDE/GCC-ARM/Header/user_settings.h
@@ -48,9 +48,6 @@ extern "C" {
 /* ------------------------------------------------------------------------- */
 /* Math Configuration */
 /* ------------------------------------------------------------------------- */
-#undef  USE_FAST_MATH
-#define USE_FAST_MATH
-
 #undef  SIZEOF_LONG_LONG
 #define SIZEOF_LONG_LONG 8
 

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -4005,7 +4005,8 @@ int mp_sqrmod (mp_int * a, mp_int * b, mp_int * c)
 
 #if defined(HAVE_ECC) || !defined(NO_PWDBASED) || defined(WOLFSSL_SNIFFER) || \
     defined(WOLFSSL_HAVE_WOLFSCEP) || defined(WOLFSSL_KEY_GEN) || \
-    defined(OPENSSL_EXTRA) || defined(WC_RSA_BLINDING)
+    defined(OPENSSL_EXTRA) || defined(WC_RSA_BLINDING) || \
+    (!defined(NO_RSA) && !defined(NO_RSA_BOUNDS_CHECK))
 
 /* single digit addition */
 int mp_add_d (mp_int* a, mp_digit b, mp_int* c)

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3681,7 +3681,8 @@ int fp_gcd(fp_int *a, fp_int *b, fp_int *c)
 
 
 #if defined(HAVE_ECC) || !defined(NO_PWDBASED) || defined(OPENSSL_EXTRA) || \
-    defined(WC_RSA_BLINDING)
+    defined(WC_RSA_BLINDING) || !defined(NO_DSA) || \
+    (!defined(NO_RSA) && !defined(NO_RSA_BOUNDS_CHECK))
 /* c = a + b */
 void fp_add_d(fp_int *a, fp_digit b, fp_int *c)
 {
@@ -3714,7 +3715,8 @@ int mp_add_d(fp_int *a, fp_digit b, fp_int *c)
     return MP_OKAY;
 }
 
-#endif  /* HAVE_ECC || !NO_PWDBASED */
+#endif  /* HAVE_ECC || !NO_PWDBASED || OPENSSL_EXTRA || WC_RSA_BLINDING ||
+  !NO_DSA || (!NO_RSA && !NO_RSA_BOUNDS_CHECK) */
 
 
 #if !defined(NO_DSA) || defined(HAVE_ECC) || defined(WOLFSSL_KEY_GEN) || \


### PR DESCRIPTION
Fixes for missing `mp_add_d` with various build configurations.
Fix for IDE/GCC-ARM user_settings.h to remove redundant USE_FAST_MATH option.