### PR TITLE
Trusted CA Key Indication Extension

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -168,6 +168,7 @@ then
     enable_maxfragment=yes
     enable_alpn=yes
     enable_truncatedhmac=yes
+    enable_trusted_ca=yes
     enable_supportedcurves=yes
     enable_session_ticket=yes
     enable_tlsx=yes
@@ -2863,6 +2864,14 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_TLS_EXTENSIONS -DHAVE_MAX_FRAGMENT"
 fi
 
+# Trusted CA Indication Extension
+AC_ARG_ENABLE([trustedca],
+    [AS_HELP_STRING([--enable-trustedca],[Enable Trusted CA Indication (default: disabled)])],
+    [ ENABLED_TRUSTED_CA=$enableval ],[ ENABLED_TRUSTED_CA=no ])
+
+AS_IF([test "x$ENABLED_TRUSTED_CA" = "xyes"],
+      [AM_CFLAGS="$AM_CFLAGS -DHAVE_TLS_EXTENSIONS -DHAVE_TRUSTED_CA"])
+
 # Truncated HMAC
 AC_ARG_ENABLE([truncatedhmac],
     [AS_HELP_STRING([--enable-truncatedhmac],[Enable Truncated HMAC (default: disabled)])],
@@ -2992,7 +3001,8 @@ then
     ENABLED_MAX_FRAGMENT=yes
     ENABLED_TRUNCATED_HMAC=yes
     ENABLED_ALPN=yes
-    AM_CFLAGS="$AM_CFLAGS -DHAVE_TLS_EXTENSIONS -DHAVE_SNI -DHAVE_MAX_FRAGMENT -DHAVE_TRUNCATED_HMAC -DHAVE_ALPN"
+    ENABLED_TRUSTED_CA=yes
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_TLS_EXTENSIONS -DHAVE_SNI -DHAVE_MAX_FRAGMENT -DHAVE_TRUNCATED_HMAC -DHAVE_ALPN -DHAVE_TRUSTED_CA"
     # Check the ECC supported curves prereq
     AS_IF([test "x$ENABLED_ECC" = "xyes" || test "x$ENABLED_CURVE25519" = "xyes"],
           [ENABLED_SUPPORTED_CURVES=yes
@@ -4930,6 +4940,7 @@ echo "   * Whitewood netRandom:        $ENABLED_WNR"
 echo "   * Server Name Indication:     $ENABLED_SNI"
 echo "   * ALPN:                       $ENABLED_ALPN"
 echo "   * Maximum Fragment Length:    $ENABLED_MAX_FRAGMENT"
+echo "   * Trusted CA Indication:      $ENABLED_TRUSTED_CA"
 echo "   * Truncated HMAC:             $ENABLED_TRUNCATED_HMAC"
 echo "   * Supported Elliptic Curves:  $ENABLED_SUPPORTED_CURVES"
 echo "   * FFDHE only in client:       $ENABLED_FFDHE_ONLY"

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -988,7 +988,12 @@ static const char* client_usage_msg[][59] = {
     !defined(HAVE_SELFTEST) && !defined(WOLFSSL_OLD_PRIME_CHECK)
         "-2          Disable DH Prime check\n",                         /* 59 */
 #endif
+#ifdef HAVE_SECURE_RENEGOTIATION
         "-4          Use resumption for renegotiation\n",               /* 60 */
+#endif
+#ifdef HAVE_TRUSTED_CA
+        "-5          Use Trusted CA Key Indication\n",                  /* 61 */
+#endif
         NULL,
     },
 #ifndef NO_MULTIBYTE_PRINT
@@ -1147,6 +1152,9 @@ static const char* client_usage_msg[][59] = {
 #ifdef HAVE_SECURE_RENEGOTIATION
         "-4          再交渉に再開を使用\n",                             /* 60 */
 #endif
+#ifdef HAVE_TRUSTED_CA
+        "-5          信頼できる認証局の鍵表示を使用する\n",             /* 61 */
+#endif
         NULL,
     },
 #endif
@@ -1291,9 +1299,6 @@ static void Usage(void)
 #ifdef WOLFSSL_MULTICAST
     printf("%s", msg[++msgid]); /* -3 */
 #endif
-#ifdef HAVE_TRUSTED_CA
-    printf("-5          Use Trusted CA Key Indication\n");
-#endif
     printf("%s", msg[++msgid]);  /* -1 */
 #if !defined(NO_DH) && !defined(HAVE_FIPS) && \
     !defined(HAVE_SELFTEST) && !defined(WOLFSSL_OLD_PRIME_CHECK)
@@ -1301,6 +1306,9 @@ static void Usage(void)
 #endif
 #ifdef HAVE_SECURE_RENEGOTIATION
     printf("%s", msg[++msgid]);  /* -4 */
+#endif
+#ifdef HAVE_TRUSTED_CA
+    printf("%s", msg[++msgid]);  /* -5 */
 #endif
 }
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1379,6 +1379,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                     doBlockSeq = 1;
                     dtlsCtx.blockSeq = atoi(myoptarg);
                 #endif
+                    break;
 
             case '5' :
             #ifdef HAVE_TRUSTED_CA

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -594,6 +594,9 @@ static const char* server_usage_msg[][49] = {
 #endif
         "-1 <num>    Display a result by specified language."
                              "\n            0: English, 1: Japanese\n", /* 48 */
+#ifdef HAVE_TRUSTED_CA
+        "-5          Use Trusted CA Key Indication\n",                  /* 51 */
+#endif
         NULL,
     },
 #ifndef NO_MULTIBYTE_PRINT
@@ -709,10 +712,12 @@ static const char* server_usage_msg[][49] = {
 #endif
         "-1 <num>    指定された言語で結果を表示します。"
                                  "\n            0: 英語、 1: 日本語\n", /* 48 */
+#ifdef HAVE_TRUSTED_CA
+        "-5          信頼できる認証局の鍵表示を使用する\n",             /* 51 */
+#endif
         NULL,
     },
 #endif
-
 };
 
 static void Usage(void)
@@ -826,7 +831,7 @@ static void Usage(void)
 #endif
     printf("%s", msg[++msgId]);     /* -1 */
 #ifdef HAVE_TRUSTED_CA
-    printf("-5          Use Trusted CA Key Indication\n");
+    printf("%s", msg[++msgId]);     /* -5 */
 #endif /* HAVE_TRUSTED_CA */
 }
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -825,6 +825,9 @@ static void Usage(void)
     printf("%s", msg[++msgId]);     /* -3 */
 #endif
     printf("%s", msg[++msgId]);     /* -1 */
+#ifdef HAVE_TRUSTED_CA
+    printf("-5          Use Trusted CA Key Indication\n");
+#endif /* HAVE_TRUSTED_CA */
 }
 
 THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
@@ -913,6 +916,10 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 #ifdef HAVE_SNI
     char*  sniHostName = NULL;
 #endif
+
+#ifdef HAVE_TRUSTED_CA
+    int trustedCaKeyId = 0;
+#endif /* HAVE_TRUSTED_CA */
 
 #ifdef HAVE_OCSP
     int    useOcsp  = 0;
@@ -1010,7 +1017,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     while ((ch = mygetopt(argc, argv, "?:"
                 "abc:defgijk:l:mnop:q:rstuv:wxy"
                 "A:B:C:D:E:GH:IJKL:MNO:PQR:S:TUVYZ:"
-                "01:23:4:")) != -1) {
+                "01:23:4:5")) != -1) {
         switch (ch) {
             case '?' :
                 if(myoptarg!=NULL) {
@@ -1372,6 +1379,11 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                     doBlockSeq = 1;
                     dtlsCtx.blockSeq = atoi(myoptarg);
                 #endif
+
+            case '5' :
+            #ifdef HAVE_TRUSTED_CA
+                trustedCaKeyId = 1;
+            #endif /* HAVE_TRUSTED_CA */
                 break;
 
             default:
@@ -1952,6 +1964,15 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         if (SSL_set_fd(ssl, clientfd) != WOLFSSL_SUCCESS) {
             err_sys_ex(runWithErrors, "error in setting fd");
         }
+
+#ifdef HAVE_TRUSTED_CA
+        if (trustedCaKeyId) {
+            if (wolfSSL_UseTrustedCA(ssl, WOLFSSL_TRUSTED_CA_PRE_AGREED,
+                        NULL, 0) != WOLFSSL_SUCCESS) {
+                err_sys_ex(runWithErrors, "UseTrustedCA failed");
+            }
+        }
+#endif /* HAVE_TRUSTED_CA */
 
 #ifdef HAVE_ALPN
         if (alpnList != NULL) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -15947,6 +15947,12 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
     case DH_PARAMS_NOT_FFDHE_E:
         return "Server DH parameters were not from the FFDHE set as required";
 
+    case TCA_INVALID_ID_TYPE:
+        return "TLS Extension Trusted CA ID type invalid";
+
+    case TCA_ABSENT_ERROR:
+        return "TLS Extension Trusted CA ID response absent";
+
     default :
         return "unknown error number";
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1963,12 +1963,31 @@ int wolfSSL_SNI_GetFromBuffer(const byte* clientHello, word32 helloSz,
 #ifdef HAVE_TRUSTED_CA
 
 WOLFSSL_API int wolfSSL_UseTrustedCA(WOLFSSL* ssl, byte type,
-            const byte* cert, word32 certSz)
+            const byte* certId, word32 certIdSz)
 {
     if (ssl == NULL)
         return BAD_FUNC_ARG;
 
-    return TLSX_UseTrustedCA(&ssl->extensions, type, cert, certSz, ssl->heap);
+    if (type == WOLFSSL_TRUSTED_CA_PRE_AGREED) {
+        if (certId != NULL || certIdSz != 0)
+            return BAD_FUNC_ARG;
+    }
+    else if (type == WOLFSSL_TRUSTED_CA_X509_NAME) {
+        if (certId == NULL || certIdSz == 0)
+            return BAD_FUNC_ARG;
+    }
+    #ifndef NO_SHA
+    else if (type == WOLFSSL_TRUSTED_CA_KEY_SHA1 ||
+            type == WOLFSSL_TRUSTED_CA_CERT_SHA1) {
+        if (certId == NULL || certIdSz != SHA_DIGEST_SIZE)
+            return BAD_FUNC_ARG;
+    }
+    #endif
+    else
+        return BAD_FUNC_ARG;
+
+    return TLSX_UseTrustedCA(&ssl->extensions,
+            type, certId, certIdSz, ssl->heap);
 }
 
 #endif /* HAVE_TRUSTED_CA */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1960,6 +1960,30 @@ int wolfSSL_SNI_GetFromBuffer(const byte* clientHello, word32 helloSz,
 #endif /* HAVE_SNI */
 
 
+#ifdef HAVE_TRUSTED_CA
+
+WOLFSSL_API int wolfSSL_UseTrustedCA(WOLFSSL* ssl, byte type,
+            const byte* cert, word32 certSz)
+{
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
+
+    return TLSX_UseTrustedCA(&ssl->extensions, type, cert, certSz, ssl->heap);
+}
+
+
+WOLFSSL_API int wolfSSL_CTX_UseTrustedCA(WOLFSSL_CTX* ctx, byte type,
+            const byte* cert, word32 certSz)
+{
+    if (ctx == NULL)
+        return BAD_FUNC_ARG;
+
+    return TLSX_UseTrustedCA(&ctx->extensions, type, cert, certSz, ctx->heap);
+}
+
+#endif /* HAVE_TRUSTED_CA */
+
+
 #ifdef HAVE_MAX_FRAGMENT
 #ifndef NO_WOLFSSL_CLIENT
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1971,16 +1971,6 @@ WOLFSSL_API int wolfSSL_UseTrustedCA(WOLFSSL* ssl, byte type,
     return TLSX_UseTrustedCA(&ssl->extensions, type, cert, certSz, ssl->heap);
 }
 
-
-WOLFSSL_API int wolfSSL_CTX_UseTrustedCA(WOLFSSL_CTX* ctx, byte type,
-            const byte* cert, word32 certSz)
-{
-    if (ctx == NULL)
-        return BAD_FUNC_ARG;
-
-    return TLSX_UseTrustedCA(&ctx->extensions, type, cert, certSz, ctx->heap);
-}
-
 #endif /* HAVE_TRUSTED_CA */
 
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -2559,11 +2559,13 @@ static int TLSX_TCA_Parse(WOLFSSL* ssl, const byte* input, word16 length,
                 return TCA_INVALID_ID_TYPE;
         }
 
+        /* Find the type/ID in the TCA list. */
         tca = TLSX_TCA_Find((TCA*)extension->data, type, id, idSz);
-        if (!tca)
-            continue;
-
-        TLSX_SetResponse(ssl, TLSX_TRUSTED_CA_KEYS);
+        if (tca != NULL) {
+            /* Found it. Set the response flag and break out of the loop. */
+            TLSX_SetResponse(ssl, TLSX_TRUSTED_CA_KEYS);
+            break;
+        }
     }
 #else
     (void)input;
@@ -2572,6 +2574,7 @@ static int TLSX_TCA_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     return 0;
 }
 
+/* Checks to see if the server sent a response for the TCA. */
 static int TLSX_TCA_VerifyParse(WOLFSSL* ssl, byte isRequest)
 {
     (void)ssl;

--- a/tests/api.c
+++ b/tests/api.c
@@ -3037,36 +3037,21 @@ static void test_wolfSSL_UseTrustedCA(void)
     XMEMSET(id, 0, sizeof(id));
 
     /* error cases */
-    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(NULL, 0, NULL, 0));
     AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(NULL, 0, NULL, 0));
-    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
-                WOLFSSL_TRUSTED_CA_CERT_SHA1+1, NULL, 0));
     AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
                 WOLFSSL_TRUSTED_CA_CERT_SHA1+1, NULL, 0));
-    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
-                WOLFSSL_TRUSTED_CA_CERT_SHA1, NULL, 0));
     AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
                 WOLFSSL_TRUSTED_CA_CERT_SHA1, NULL, 0));
-    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
-                WOLFSSL_TRUSTED_CA_CERT_SHA1, id, 5));
     AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
                 WOLFSSL_TRUSTED_CA_CERT_SHA1, id, 5));
-    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
-                WOLFSSL_TRUSTED_CA_X509_NAME, id, 0));
     AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
                 WOLFSSL_TRUSTED_CA_X509_NAME, id, 0));
 
     /* success cases */
-    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
-                WOLFSSL_TRUSTED_CA_PRE_AGREED, NULL, 0));
     AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
                 WOLFSSL_TRUSTED_CA_PRE_AGREED, NULL, 0));
-    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
-                WOLFSSL_TRUSTED_CA_KEY_SHA1, id, sizeof(id)));
     AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
                 WOLFSSL_TRUSTED_CA_KEY_SHA1, id, sizeof(id)));
-    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
-                WOLFSSL_TRUSTED_CA_X509_NAME, id, 5));
     AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
                 WOLFSSL_TRUSTED_CA_X509_NAME, id, 5));
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -3044,14 +3044,20 @@ static void test_wolfSSL_UseTrustedCA(void)
                 WOLFSSL_TRUSTED_CA_CERT_SHA1, NULL, 0));
     AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
                 WOLFSSL_TRUSTED_CA_CERT_SHA1, id, 5));
+#ifdef NO_SHA
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
+                WOLFSSL_TRUSTED_CA_KEY_SHA1, id, sizeof(id)));
+#endif
     AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
                 WOLFSSL_TRUSTED_CA_X509_NAME, id, 0));
 
     /* success cases */
     AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
                 WOLFSSL_TRUSTED_CA_PRE_AGREED, NULL, 0));
+#ifndef NO_SHA
     AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
                 WOLFSSL_TRUSTED_CA_KEY_SHA1, id, sizeof(id)));
+#endif
     AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
                 WOLFSSL_TRUSTED_CA_X509_NAME, id, 5));
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -3025,6 +3025,56 @@ static void test_wolfSSL_UseSNI(void)
 #endif
 }
 
+static void test_wolfSSL_UseTrustedCA(void)
+{
+#ifdef HAVE_TRUSTED_CA
+    WOLFSSL_CTX *ctx;
+    WOLFSSL     *ssl;
+    byte        id[20];
+
+    AssertNotNull((ctx = wolfSSL_CTX_new(wolfSSLv23_client_method())));
+    AssertNotNull((ssl = wolfSSL_new(ctx)));
+    XMEMSET(id, 0, sizeof(id));
+
+    /* error cases */
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(NULL, 0, NULL, 0));
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(NULL, 0, NULL, 0));
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
+                WOLFSSL_TRUSTED_CA_CERT_SHA1+1, NULL, 0));
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
+                WOLFSSL_TRUSTED_CA_CERT_SHA1+1, NULL, 0));
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
+                WOLFSSL_TRUSTED_CA_CERT_SHA1, NULL, 0));
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
+                WOLFSSL_TRUSTED_CA_CERT_SHA1, NULL, 0));
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
+                WOLFSSL_TRUSTED_CA_CERT_SHA1, id, 5));
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
+                WOLFSSL_TRUSTED_CA_CERT_SHA1, id, 5));
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
+                WOLFSSL_TRUSTED_CA_X509_NAME, id, 0));
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
+                WOLFSSL_TRUSTED_CA_X509_NAME, id, 0));
+
+    /* success cases */
+    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
+                WOLFSSL_TRUSTED_CA_PRE_AGREED, NULL, 0));
+    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
+                WOLFSSL_TRUSTED_CA_PRE_AGREED, NULL, 0));
+    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
+                WOLFSSL_TRUSTED_CA_KEY_SHA1, id, sizeof(id)));
+    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
+                WOLFSSL_TRUSTED_CA_KEY_SHA1, id, sizeof(id)));
+    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_UseTrustedCA(ctx,
+                WOLFSSL_TRUSTED_CA_X509_NAME, id, 5));
+    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_UseTrustedCA(ssl,
+                WOLFSSL_TRUSTED_CA_X509_NAME, id, 5));
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif /* HAVE_TRUSTED_CA */
+}
+
 static void test_wolfSSL_UseMaxFragment(void)
 {
 #if defined(HAVE_MAX_FRAGMENT) && !defined(NO_WOLFSSL_CLIENT)
@@ -23409,6 +23459,7 @@ void ApiTest(void)
 
     /* TLS extensions tests */
     test_wolfSSL_UseSNI();
+    test_wolfSSL_UseTrustedCA();
     test_wolfSSL_UseMaxFragment();
     test_wolfSSL_UseTruncatedHMAC();
     test_wolfSSL_UseSupportedCurve();

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -2438,3 +2438,11 @@
 -v 3
 -l ECDHE-RSA-AES128-GCM-SHA256
 -i -4
+
+# server TLSv1.2 with Trusted CA Indication (pre-shared)
+-v 3
+-5
+
+# client TLSv1.2 with Trusted CA Indication (pre-shared)
+-v 3
+-5

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -161,6 +161,8 @@ enum wolfSSL_ErrorCodes {
     PRF_MISSING                  = -430,   /* PRF not compiled in */
     DTLS_RETX_OVER_TX            = -431,   /* Retransmit DTLS flight over */
     DH_PARAMS_NOT_FFDHE_E        = -432,   /* DH params from server not FFDHE */
+    TCA_INVALID_ID_TYPE          = -433,   /* TLSX TCA ID type invalid */
+    TCA_ABSENT_ERROR             = -434,   /* TLSX TCA ID no response */
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* begin negotiation parameter errors */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2055,6 +2055,7 @@ typedef struct Keys {
 typedef enum {
     TLSX_SERVER_NAME                = 0x0000, /* a.k.a. SNI  */
     TLSX_MAX_FRAGMENT_LENGTH        = 0x0001,
+    TLSX_TRUSTED_CA_KEYS            = 0x0003,
     TLSX_TRUNCATED_HMAC             = 0x0004,
     TLSX_STATUS_REQUEST             = 0x0005, /* a.k.a. OCSP stapling   */
     TLSX_SUPPORTED_GROUPS           = 0x000a, /* a.k.a. Supported Curves */
@@ -2125,6 +2126,7 @@ WOLFSSL_LOCAL int   TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length,
 
 #elif defined(HAVE_SNI)                           \
    || defined(HAVE_MAX_FRAGMENT)                  \
+   || defined(HAVE_TRUSTED_CA)                    \
    || defined(HAVE_TRUNCATED_HMAC)                \
    || defined(HAVE_CERTIFICATE_STATUS_REQUEST)    \
    || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2) \
@@ -2166,6 +2168,24 @@ WOLFSSL_LOCAL int    TLSX_SNI_GetFromBuffer(const byte* buffer, word32 bufferSz,
 #endif
 
 #endif /* HAVE_SNI */
+
+/* Trusted CA Key Indication - RFC 6066 (section 6) */
+#ifdef HAVE_TRUSTED_CA
+
+typedef struct TCA {
+    byte                       type;    /* TCA Type            */
+    byte*                      id;      /* TCA identifier      */
+    word16                     idSz;    /* TCA identifier size */
+    struct TCA*                next;    /* List Behavior       */
+#ifndef NO_WOLFSSL_CLIENT
+    byte                       options; /* Behavior options    */
+#endif /* NO_WOLFSSL_CLIENT */
+} TCA;
+
+WOLFSSL_LOCAL int TLSX_UseTrustedCA(TLSX** extensions, byte type,
+                    const byte* id, word16 idSz, void* heap);
+
+#endif /* HAVE_TRUSTED_CA */
 
 /* Application-Layer Protocol Negotiation - RFC 7301 */
 #ifdef HAVE_ALPN

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2177,9 +2177,6 @@ typedef struct TCA {
     byte*                      id;      /* TCA identifier      */
     word16                     idSz;    /* TCA identifier size */
     struct TCA*                next;    /* List Behavior       */
-#ifndef NO_WOLFSSL_CLIENT
-    byte                       options; /* Behavior options    */
-#endif /* NO_WOLFSSL_CLIENT */
 } TCA;
 
 WOLFSSL_LOCAL int TLSX_UseTrustedCA(TLSX** extensions, byte type,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2261,8 +2261,6 @@ enum {
 
 WOLFSSL_API int wolfSSL_UseTrustedCA(WOLFSSL* ssl, unsigned char type,
             const unsigned char* cert, unsigned int certSz);
-WOLFSSL_API int wolfSSL_CTX_UseTrustedCA(WOLFSSL_CTX* ctx, unsigned char type,
-            const unsigned char* cert, unsigned int certSz);
 #endif /* HAVE_TRUSTED_CA */
 
 /* Application-Layer Protocol Negotiation */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2260,7 +2260,7 @@ enum {
 };
 
 WOLFSSL_API int wolfSSL_UseTrustedCA(WOLFSSL* ssl, unsigned char type,
-            const unsigned char* cert, unsigned int certSz);
+            const unsigned char* certId, unsigned int certIdSz);
 #endif /* HAVE_TRUSTED_CA */
 
 /* Application-Layer Protocol Negotiation */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2248,6 +2248,23 @@ WOLFSSL_API unsigned short wolfSSL_SNI_GetRequest(WOLFSSL *ssl,
 
 #endif /* HAVE_SNI */
 
+/* Trusted CA Key Indication - RFC 6066 (Section 6) */
+#ifdef HAVE_TRUSTED_CA
+
+/* TCA Identifier Type */
+enum {
+    WOLFSSL_TRUSTED_CA_PRE_AGREED = 0,
+    WOLFSSL_TRUSTED_CA_KEY_SHA1 = 1,
+    WOLFSSL_TRUSTED_CA_X509_NAME = 2,
+    WOLFSSL_TRUSTED_CA_CERT_SHA1 = 3
+};
+
+WOLFSSL_API int wolfSSL_UseTrustedCA(WOLFSSL* ssl, unsigned char type,
+            const unsigned char* cert, unsigned int certSz);
+WOLFSSL_API int wolfSSL_CTX_UseTrustedCA(WOLFSSL_CTX* ctx, unsigned char type,
+            const unsigned char* cert, unsigned int certSz);
+#endif /* HAVE_TRUSTED_CA */
+
 /* Application-Layer Protocol Negotiation */
 #ifdef HAVE_ALPN
 


### PR DESCRIPTION
Added an API for enabling the Trusted CA Key Indication extension from RFC6066 section 6. If the server doesn't have a match for the client, the client will abandon the session.