### PR TITLE
Added Japanese messages that can be enabled by option switch

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -448,7 +448,7 @@ static const char* bench_result_words1[][4] = {
 };
 
 #if defined(WOLFSSL_KEY_GEN) || defined(HAVE_NTRU) || \
-    defined(HAVE_ECC) || defined(HAVE_ECC) || defined(HAVE_ECC_ENCRYPT) || \
+    defined(HAVE_ECC) || !defined(NO_DH) || defined(HAVE_ECC_ENCRYPT) || \
     defined(HAVE_CURVE25519) || defined(HAVE_CURVE25519_SHARED_SECRET)  || \
     defined(HAVE_ED25519)
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -415,9 +415,9 @@ static const bench_alg bench_other_opt[] = {
 #endif
 
 static int lng_index = 0;
-static const char* bench_Usage_msg1[][11] = {
+static const char* bench_Usage_msg1[][10] = {
     /* 0 English  */
-    {"-?          Help, print this usage\n",
+    {   "-? <num>    Help, print this usage\n            0: English, 1: Japanese\n",
         "-csv        Print terminal output in csv format\n",
         "-base10     Display bytes as power of 10 (eg 1 kB = 1000 Bytes)\n",
         "-no_aad     No additional authentication data passed.\n",
@@ -427,10 +427,9 @@ static const char* bench_Usage_msg1[][11] = {
         "-<alg>      Algorithm to benchmark. Available algorithms include:\n",
         "-lng <num>  Display benchmark result by specified language.\n            0: English, 1: Japanese\n",
         "<num>       Size of block in bytes\n",
-        "\nNote:\n   benchmark -? 1 displays help in Japanese.\n"
     },
     /* 1 Japanese */
-    {"-?          ヘルプ, 使い方を表示します。\n",
+    {   "-? <num>    ヘルプ, 使い方を表示します。\n            0: 英語、 1: 日本語\n",
         "-csv        csv 形式で端末に出力します。\n",
         "-base10     バイトを10のべき乗で表示します。(例 1 kB = 1000 Bytes)\n",
         "-no_aad     追加の認証データを使用しません.\n",
@@ -440,7 +439,6 @@ static const char* bench_Usage_msg1[][11] = {
         "-<alg>      アルゴリズムのベンチマークを実施します。\n            利用可能なアルゴリズムは下記を含みます:\n",
         "-lng <num>  指定された言語でベンチマーク結果を表示します。\n            0: 英語、 1: 日本語\n",
         "<num>       ブロックサイズをバイト単位で指定します。\n",
-        "\nNote:\n   benchmark -? ヘルプを英語で表示します。\n"
     }, 
 };
 
@@ -5147,8 +5145,6 @@ static void Usage(void)
 #endif
     printf("%s", bench_Usage_msg1[lng_index][8]);    /* option -lng */
     printf("%s", bench_Usage_msg1[lng_index][9]);    /* option <num> */
-
-    printf("%s", bench_Usage_msg1[lng_index][10]);    /* usage another notification */
 }
 
 /* Match the command line argument with the string.

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -447,16 +447,18 @@ static const char* bench_result_words1[][4] = {
     { "を"   , "秒で処理", "1バイトあたりのサイクル数", NULL },     /* 1 Japanese */
 };
 
-static const char* bench_result_words2[][5] = {
-    { "ops took", "sec"     , "avg" , "ops/sec", NULL },            /* 0 English  */
-    { "回処理を", "秒で実施", "平均", "処理/秒", NULL },            /* 1 Japanese */
-};
+#if defined(WOLFSSL_KEY_GEN) || defined(HAVE_NTRU) || \
+    defined(HAVE_ECC) || defined(HAVE_ECC) || defined(HAVE_ECC_ENCRYPT) || \
+    defined(HAVE_CURVE25519) || defined(HAVE_CURVE25519_SHARED_SECRET)  || \
+    defined(HAVE_ED25519)
 
 static const char* bench_desc_words[][9] = {
     /* 0           1          2         3        4        5         6            7            8 */
     {"public", "private", "key gen", "agree" , "sign", "verify", "encryption", "decryption", NULL}, /* 0 English */
     {"公開鍵", "秘密鍵" ,"鍵生成" , "鍵共有" , "署名", "検証"  , "暗号化"    , "復号化"    , NULL}, /* 1 Japanese */     
 };
+
+#endif
 
 #if defined(__GNUC__) && defined(__x86_64__) && !defined(NO_ASM) && !defined(WOLFSSL_SGX)
     #define HAVE_GET_CYCLES
@@ -567,6 +569,12 @@ static const char* bench_desc_words[][9] = {
     #define BENCH_ASYM
 #endif
 
+#if defined(BENCH_ASYM)
+static const char* bench_result_words2[][5] = {
+    { "ops took", "sec"     , "avg" , "ops/sec", NULL },            /* 0 English  */
+    { "回処理を", "秒で実施", "平均", "処理/秒", NULL },            /* 1 Japanese */
+};
+#endif
 
 /* Asynchronous helper macros */
 static THREAD_LS_T int devId = INVALID_DEVID;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -414,6 +414,52 @@ static const bench_alg bench_other_opt[] = {
     #define fopen wolfSSL_fopen
 #endif
 
+static int lng_index = 0;
+static const char* bench_Usage_msg1[][11] = {
+    /* 0 English  */
+    {"-?          Help, print this usage\n",
+        "-csv        Print terminal output in csv format\n",
+        "-base10     Display bytes as power of 10 (eg 1 kB = 1000 Bytes)\n",
+        "-no_aad     No additional authentication data passed.\n",
+        "-dgst_full  Full digest operation performed.\n",
+        "-rsa_sign   Measure RSA sign/verify instead of encrypt/decrypt.\n",
+        "<keySz> -rsa-sz\n            Measure RSA <key size> performance.\n",
+        "-<alg>      Algorithm to benchmark. Available algorithms include:\n",
+        "-lng <num>  Display benchmark result by specified language.\n            0: English, 1: Japanese\n",
+        "<num>       Size of block in bytes\n",
+        "\nNote:\n   benchmark -? 1 displays help in Japanese.\n"
+    },
+    /* 1 Japanese */
+    {"-?          ヘルプ, 使い方を表示します。\n",
+        "-csv        csv 形式で端末に出力します。\n",
+        "-base10     バイトを10のべき乗で表示します。(例 1 kB = 1000 Bytes)\n",
+        "-no_aad     追加の認証データを使用しません.\n",
+        "-dgst_full  フルの digest 暗号操作を実施します。\n",
+        "-rsa_sign   暗号/復号化の代わりに RSA の署名/検証を測定します。\n",
+        "<keySz> -rsa-sz\n            RSA <key size> の性能を測定します。\n",
+        "-<alg>      アルゴリズムのベンチマークを実施します。\n            利用可能なアルゴリズムは下記を含みます:\n",
+        "-lng <num>  指定された言語でベンチマーク結果を表示します。\n            0: 英語、 1: 日本語\n",
+        "<num>       ブロックサイズをバイト単位で指定します。\n",
+        "\nNote:\n   benchmark -? ヘルプを英語で表示します。\n"
+    }, 
+};
+
+static const char* bench_result_words1[][4] = {
+    { "tooks", "seconds" , "Cycles per byte", NULL },               /* 0 English  */
+    { "を"   , "秒で処理", "1バイトあたりのサイクル数", NULL },     /* 1 Japanese */
+};
+
+static const char* bench_result_words2[][5] = {
+    { "ops took", "sec"     , "avg" , "ops/sec", NULL },            /* 0 English  */
+    { "回処理を", "秒で実施", "平均", "処理/秒", NULL },            /* 1 Japanese */
+};
+
+static const char* bench_desc_words[][9] = {
+    /* 0           1          2         3        4        5         6            7            8 */
+    {"public", "private", "key gen", "agree" , "sign", "verify", "encryption", "decryption", NULL}, /* 0 English */
+    {"公開鍵", "秘密鍵" ,"鍵生成" , "鍵共有" , "署名", "検証"  , "暗号化"    , "復号化"    , NULL}, /* 1 Japanese */     
+};
+
 #if defined(__GNUC__) && defined(__x86_64__) && !defined(NO_ASM) && !defined(WOLFSSL_SGX)
     #define HAVE_GET_CYCLES
     static WC_INLINE word64 get_intel_cycles(void);
@@ -423,7 +469,8 @@ static const bench_alg bench_other_opt[] = {
     #define END_INTEL_CYCLES   total_cycles = get_intel_cycles() - total_cycles;
     /* s == size in bytes that 1 count represents, normally BENCH_SIZE */
     #define SHOW_INTEL_CYCLES(b, n, s) \
-        XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), " Cycles per byte = %6.2f\n", \
+        XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), " %s = %6.2f\n", \
+            bench_result_words1[lng_index][2], \
             count == 0 ? 0 : (float)total_cycles / ((word64)count*s))
     #define SHOW_INTEL_CYCLES_CSV(b, n, s) \
         XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), "%.2f,\n", \
@@ -452,7 +499,8 @@ static const bench_alg bench_other_opt[] = {
 
     /* s == size in bytes that 1 count represents, normally BENCH_SIZE */
     #define SHOW_INTEL_CYCLES(b, n, s) \
-        XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), " Cycles per byte = %6.2f\n", \
+        XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), " %s = %6.2f\n", \
+        bench_result_words1[lng_index][2], \
             (float)total_cycles / (count*s))
     #define SHOW_INTEL_CYCLES_CSV(b, n, s) \
         XSNPRINTF(b + XSTRLEN(b), n - XSTRLEN(b), "%.2f,\n", \
@@ -875,6 +923,7 @@ static void bench_stats_sym_finish(const char* desc, int doAsync, int count,
     double total, persec = 0, blocks = count;
     const char* blockType;
     char msg[128] = {0};
+    const char** word = bench_result_words1[lng_index];
 
     END_INTEL_CYCLES
     total = current_time(0) - start;
@@ -921,8 +970,8 @@ static void bench_stats_sym_finish(const char* desc, int doAsync, int count,
         XSNPRINTF(msg, sizeof(msg), "%s,%.3f,", desc, persec);
         SHOW_INTEL_CYCLES_CSV(msg, sizeof(msg), countSz);
     } else {
-        XSNPRINTF(msg, sizeof(msg), "%-16s%s %5.0f %s took %5.3f seconds, %8.3f %s/s",
-        desc, BENCH_ASYNC_GET_NAME(doAsync), blocks, blockType, total,
+        XSNPRINTF(msg, sizeof(msg), "%-16s%s %5.0f %s %s %5.3f %s, %8.3f %s/s",
+        desc, BENCH_ASYNC_GET_NAME(doAsync), blocks, blockType, word[0], total, word[1], 
         persec, blockType);
         SHOW_INTEL_CYCLES(msg, sizeof(msg), countSz);
     }
@@ -947,6 +996,7 @@ static void bench_stats_asym_finish(const char* algo, int strength,
     const char* desc, int doAsync, int count, double start, int ret)
 {
     double total, each = 0, opsSec, milliEach;
+    const char **word = bench_result_words2[lng_index];
 
     total = current_time(0) - start;
     if (count > 0)
@@ -964,9 +1014,9 @@ static void bench_stats_asym_finish(const char* algo, int strength,
         }
         printf("%s %d %s,%.3f,%.3f,\n", algo, strength, desc, milliEach, opsSec);
     } else {
-        printf("%-6s %5d %-9s %s %6d ops took %5.3f sec, avg %5.3f ms,"
-        " %.3f ops/sec\n", algo, strength, desc, BENCH_ASYNC_GET_NAME(doAsync),
-        count, total, milliEach, opsSec);
+        printf("%-6s %5d %-9s %s %6d %s %5.3f %s, %s %5.3f ms,"
+        " %.3f %s\n", algo, strength, desc, BENCH_ASYNC_GET_NAME(doAsync),
+        count, word[0], total, word[1], word[2], milliEach, opsSec, word[3]);
     }
 
     /* show errors */
@@ -3717,6 +3767,7 @@ static void bench_rsaKeyGen_helper(int doAsync, int keySz)
     double start;
     int    ret = 0, i, count = 0, times, pending = 0;
     const long rsa_e_val = WC_RSA_EXPONENT;
+    const char**desc = bench_desc_words[lng_index];
 
     /* clear for done cleanup */
     XMEMSET(genKey, 0, sizeof(genKey));
@@ -3747,7 +3798,7 @@ static void bench_rsaKeyGen_helper(int doAsync, int keySz)
         count += times;
     } while (bench_stats_sym_check(start));
 exit:
-    bench_stats_asym_finish("RSA", keySz, "key gen", doAsync, count, start, ret);
+    bench_stats_asym_finish("RSA", keySz, desc[2], doAsync, count, start, ret);
 
     /* cleanup */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
@@ -3796,6 +3847,7 @@ static void bench_rsa_helper(int doAsync, RsaKey rsaKey[BENCH_MAX_PENDING],
     const char* messageStr = "Everyone gets Friday off.";
     const int   len = (int)XSTRLEN((char*)messageStr);
     double      start = 0.0f;
+    const char**desc = bench_desc_words[lng_index];
 
     DECLARE_VAR_INIT(message, byte, len, messageStr, HEAP_HINT);
     DECLARE_ARRAY(enc, byte, BENCH_MAX_PENDING, rsaKeySz/8, HEAP_HINT);
@@ -3825,7 +3877,7 @@ static void bench_rsa_helper(int doAsync, RsaKey rsaKey[BENCH_MAX_PENDING],
             count += times;
         } while (bench_stats_sym_check(start));
 exit_rsa_pub:
-        bench_stats_asym_finish("RSA", rsaKeySz, "public", doAsync, count,
+        bench_stats_asym_finish("RSA", rsaKeySz, desc[0], doAsync, count,
                                                                     start, ret);
 
         if (ret < 0) {
@@ -3858,7 +3910,7 @@ exit_rsa_pub:
             count += times;
         } while (bench_stats_sym_check(start));
 exit:
-        bench_stats_asym_finish("RSA", rsaKeySz, "private", doAsync, count,
+        bench_stats_asym_finish("RSA", rsaKeySz, desc[1], doAsync, count,
                                                                     start, ret);
     }
     else {
@@ -3885,7 +3937,7 @@ exit:
             count += times;
         } while (bench_stats_sym_check(start));
 exit_rsa_sign:
-        bench_stats_asym_finish("RSA", rsaKeySz, "sign", doAsync, count, start,
+        bench_stats_asym_finish("RSA", rsaKeySz, desc[4], doAsync, count, start,
                                                                            ret);
 
         if (ret < 0) {
@@ -3918,7 +3970,7 @@ exit_rsa_sign:
             count += times;
         } while (bench_stats_sym_check(start));
 exit_rsa_verify:
-        bench_stats_asym_finish("RSA", rsaKeySz, "verify", doAsync, count,
+        bench_stats_asym_finish("RSA", rsaKeySz, desc[5], doAsync, count,
                                                                     start, ret);
     }
 
@@ -4073,6 +4125,7 @@ void bench_dh(int doAsync)
     double start = 0.0f;
     DhKey  dhKey[BENCH_MAX_PENDING];
     int    dhKeySz = BENCH_DH_KEY_SIZE * 8; /* used in printf */
+    const char**desc = bench_desc_words[lng_index];
 #ifndef NO_ASN
     size_t bytes;
     word32 idx;
@@ -4155,7 +4208,7 @@ void bench_dh(int doAsync)
         count += times;
     } while (bench_stats_sym_check(start));
 exit_dh_gen:
-    bench_stats_asym_finish("DH", dhKeySz, "key gen", doAsync, count, start, ret);
+    bench_stats_asym_finish("DH", dhKeySz, desc[2], doAsync, count, start, ret);
 
     if (ret < 0) {
         goto exit;
@@ -4187,7 +4240,7 @@ exit_dh_gen:
         count += times;
     } while (bench_stats_sym_check(start));
 exit:
-    bench_stats_asym_finish("DH", dhKeySz, "agree", doAsync, count, start, ret);
+    bench_stats_asym_finish("DH", dhKeySz, desc[3], doAsync, count, start, ret);
 
     /* cleanup */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
@@ -4241,6 +4294,7 @@ void bench_ntru(void)
     word16 ciphertext_len;
     byte plaintext[16];
     word16 plaintext_len;
+    const char**desc = bench_desc_words[lng_index];
 
     DRBG_HANDLE drbg;
     static byte const aes_key[] = {
@@ -4316,7 +4370,7 @@ void bench_ntru(void)
                 return;
             }
         }
-        bench_stats_asym_finish("NTRU", ntruBits, "encryption", 0, i, start, ret);
+        bench_stats_asym_finish("NTRU", ntruBits, desc[6], 0, i, start, ret);
 
         ret = ntru_crypto_drbg_uninstantiate(drbg);
         if (ret != DRBG_OK) {
@@ -4345,7 +4399,7 @@ void bench_ntru(void)
                 return;
             }
         }
-        bench_stats_asym_finish("NTRU", ntruBits, "decryption", 0, i, start, ret);
+        bench_stats_asym_finish("NTRU", ntruBits, desc[7], 0, i, start, ret);
     }
 
 }
@@ -4398,7 +4452,7 @@ void bench_ntruKeyGen(void)
                                          public_key, &private_key_len,
                                          private_key);
         }
-        bench_stats_asym_finish("NTRU", ntruBits, "key gen", 0, i, start, ret);
+        bench_stats_asym_finish("NTRU", ntruBits, desc[2], 0, i, start, ret);
 
         if (ret != NTRU_OK) {
             return;
@@ -4426,6 +4480,7 @@ void bench_eccMakeKey(int doAsync)
     const int keySize = BENCH_ECC_SIZE;
     ecc_key genKey[BENCH_MAX_PENDING];
     double start;
+    const char**desc = bench_desc_words[lng_index];
 
     /* clear for done cleanup */
     XMEMSET(&genKey, 0, sizeof(genKey));
@@ -4456,7 +4511,7 @@ void bench_eccMakeKey(int doAsync)
         count += times;
     } while (bench_stats_sym_check(start));
 exit:
-    bench_stats_asym_finish("ECC", keySize * 8, "key gen", doAsync, count, start, ret);
+    bench_stats_asym_finish("ECC", keySize * 8, desc[2], doAsync, count, start, ret);
 
     /* cleanup */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
@@ -4479,6 +4534,7 @@ void bench_ecc(int doAsync)
 #endif
     word32 x[BENCH_MAX_PENDING];
     double start;
+    const char**desc = bench_desc_words[lng_index];
 
 #ifdef HAVE_ECC_DHE
     DECLARE_ARRAY(shared, byte, BENCH_MAX_PENDING, BENCH_ECC_SIZE, HEAP_HINT);
@@ -4541,7 +4597,7 @@ void bench_ecc(int doAsync)
         count += times;
     } while (bench_stats_sym_check(start));
 exit_ecdhe:
-    bench_stats_asym_finish("ECDHE", keySize * 8, "agree", doAsync, count, start, ret);
+    bench_stats_asym_finish("ECDHE", keySize * 8, desc[3], doAsync, count, start, ret);
 
     if (ret < 0) {
         goto exit;
@@ -4579,7 +4635,7 @@ exit_ecdhe:
         count += times;
     } while (bench_stats_sym_check(start));
 exit_ecdsa_sign:
-    bench_stats_asym_finish("ECDSA", keySize * 8, "sign", doAsync, count, start, ret);
+    bench_stats_asym_finish("ECDSA", keySize * 8, desc[4], doAsync, count, start, ret);
 
     if (ret < 0) {
         goto exit;
@@ -4609,7 +4665,7 @@ exit_ecdsa_sign:
         count += times;
     } while (bench_stats_sym_check(start));
 exit_ecdsa_verify:
-    bench_stats_asym_finish("ECDSA", keySize * 8, "verify", doAsync, count, start, ret);
+    bench_stats_asym_finish("ECDSA", keySize * 8, desc[5], doAsync, count, start, ret);
 #endif /* HAVE_ECC_VERIFY */
 #endif /* !NO_ASN && HAVE_ECC_SIGN */
 
@@ -4644,6 +4700,7 @@ void bench_eccEncrypt(void)
     word32  bench_plainSz = BENCH_SIZE;
     int     ret, i, count;
     double start;
+    const char**desc = bench_desc_words[lng_index];
 
     ret = wc_ecc_init_ex(&userA, HEAP_HINT, devId);
     if (ret != 0) {
@@ -4687,7 +4744,7 @@ void bench_eccEncrypt(void)
         count += i;
     } while (bench_stats_sym_check(start));
 exit_enc:
-    bench_stats_asym_finish("ECC", keySize * 8, "encrypt", 0, count, start, ret);
+    bench_stats_asym_finish("ECC", keySize * 8, desc[6], 0, count, start, ret);
 
     bench_stats_start(&count, &start);
     do {
@@ -4702,7 +4759,7 @@ exit_enc:
         count += i;
     } while (bench_stats_sym_check(start));
 exit_dec:
-    bench_stats_asym_finish("ECC", keySize * 8, "decrypt", 0, count, start, ret);
+    bench_stats_asym_finish("ECC", keySize * 8, desc[7], 0, count, start, ret);
 
 exit:
 
@@ -4719,6 +4776,7 @@ void bench_curve25519KeyGen(void)
     curve25519_key genKey;
     double start;
     int    ret = 0, i, count;
+    const char**desc = bench_desc_words[lng_index];
 
     /* Key Gen */
     bench_stats_start(&count, &start);
@@ -4733,7 +4791,7 @@ void bench_curve25519KeyGen(void)
         }
         count += i;
     } while (bench_stats_sym_check(start));
-    bench_stats_asym_finish("CURVE", 25519, "key gen", 0, count, start, ret);
+    bench_stats_asym_finish("CURVE", 25519, desc[2], 0, count, start, ret);
 }
 
 #ifdef HAVE_CURVE25519_SHARED_SECRET
@@ -4743,6 +4801,7 @@ void bench_curve25519KeyAgree(void)
     double start;
     int    ret, i, count;
     byte   shared[32];
+	const char**desc = bench_desc_words[lng_index];
     word32 x = 0;
 
     wc_curve25519_init(&genKey);
@@ -4774,7 +4833,7 @@ void bench_curve25519KeyAgree(void)
         count += i;
     } while (bench_stats_sym_check(start));
 exit:
-    bench_stats_asym_finish("CURVE", 25519, "agree", 0, count, start, ret);
+    bench_stats_asym_finish("CURVE", 25519, desc[3], 0, count, start, ret);
 
     wc_curve25519_free(&genKey2);
     wc_curve25519_free(&genKey);
@@ -4788,6 +4847,7 @@ void bench_ed25519KeyGen(void)
     ed25519_key genKey;
     double start;
     int    i, count;
+    const char**desc = bench_desc_words[lng_index];
 
     /* Key Gen */
     bench_stats_start(&count, &start);
@@ -4799,7 +4859,7 @@ void bench_ed25519KeyGen(void)
         }
         count += i;
     } while (bench_stats_sym_check(start));
-    bench_stats_asym_finish("ED", 25519, "key gen", 0, count, start, 0);
+    bench_stats_asym_finish("ED", 25519, desc[2], 0, count, start, 0);
 }
 
 
@@ -4814,6 +4874,7 @@ void bench_ed25519KeySign(void)
     byte   msg[512];
     word32 x = 0;
 #endif
+    const char**desc = bench_desc_words[lng_index];
 
     wc_ed25519_init(&genKey);
 
@@ -4841,7 +4902,7 @@ void bench_ed25519KeySign(void)
         count += i;
     } while (bench_stats_sym_check(start));
 exit_ed_sign:
-    bench_stats_asym_finish("ED", 25519, "sign", 0, count, start, ret);
+    bench_stats_asym_finish("ED", 25519, desc[4], 0, count, start, ret);
 
 #ifdef HAVE_ED25519_VERIFY
     bench_stats_start(&count, &start);
@@ -4858,7 +4919,7 @@ exit_ed_sign:
         count += i;
     } while (bench_stats_sym_check(start));
 exit_ed_verify:
-    bench_stats_asym_finish("ED", 25519, "verify", 0, count, start, ret);
+    bench_stats_asym_finish("ED", 25519, desc[5], 0, count, start, ret);
 #endif /* HAVE_ED25519_VERIFY */
 #endif /* HAVE_ED25519_SIGN */
 
@@ -5047,23 +5108,21 @@ static void Usage(void)
 #endif
 
     printf("benchmark\n");
-    printf("-?          Help, print this usage\n");
-    printf("-csv        Print terminal output in csv format\n");
-    printf("-base10     Display bytes as power of 10 (eg 1 kB = 1000 Bytes)\n");
+    printf("%s", bench_Usage_msg1[lng_index][0]);    /* option -? */
+    printf("%s", bench_Usage_msg1[lng_index][1]);    /* option -csv */
+    printf("%s", bench_Usage_msg1[lng_index][2]);    /* option -base10 */
 #if defined(HAVE_AESGCM) || defined(HAVE_AESCCM)
-    printf("-no_aad     No additional authentication data passed.\n");
+    printf("%s", bench_Usage_msg1[lng_index][3]);    /* option -no_add */
 #endif
-    printf("-dgst_full  Full digest operation performed.\n");
+    printf("%s", bench_Usage_msg1[lng_index][4]);    /* option -dgst_full */
 #ifndef NO_RSA
-    printf("-rsa_sign   Measure RSA sign/verify instead of encrypt/decrypt.\n");
+    printf("%s", bench_Usage_msg1[lng_index][5]);    /* option -ras_sign */
     #ifdef WOLFSSL_KEY_GEN
-    printf("<keySz> -rsa-sz\n"
-           "            Measure RSA <key size> performance.\n");
+    printf("%s", bench_Usage_msg1[lng_index][6]);    /* option -rsa-sz */
     #endif
 #endif
 #ifndef WOLFSSL_BENCHMARK_ALL
-    printf("-<alg>      Algorithm to benchmark. Available algorithms "
-                        "include:\n");
+    printf("%s", bench_Usage_msg1[lng_index][7]);    /* option -<alg> */
     printf("             ");
     line = 13;
     for (i=0; bench_cipher_opt[i].str != NULL; i++)
@@ -5086,7 +5145,10 @@ static void Usage(void)
         print_alg(bench_other_opt[i].str + 1, &line);
     printf("\n");
 #endif
-    printf("<num>       Size of block in bytes\n");
+    printf("%s", bench_Usage_msg1[lng_index][8]);    /* option -lng */
+    printf("%s", bench_Usage_msg1[lng_index][9]);    /* option <num> */
+
+    printf("%s", bench_Usage_msg1[lng_index][10]);    /* usage another notification */
 }
 
 /* Match the command line argument with the string.
@@ -5111,6 +5173,12 @@ int main(int argc, char** argv)
 
     while (argc > 1) {
         if (string_matches(argv[1], "-?")) {
+            if(--argc>1){
+                lng_index = atoi((++argv)[1]);
+                if(lng_index<0||lng_index>1) {
+                    lng_index = 0;
+                }
+            }
             Usage();
             return 0;
         }
@@ -5120,6 +5188,17 @@ int main(int argc, char** argv)
                    "-----------------------------------------------------------"
                    "--\n", LIBWOLFSSL_VERSION_STRING);
             return 0;
+        }
+        else if (string_matches(argv[1], "-lng")) {
+            argc--;
+            argv++;
+            if(argc>1) {
+                lng_index = atoi(argv[1]);
+                if(lng_index<0||lng_index>1){
+                    printf("invalid number(%d) is specified. [<num> :0-1]\n",lng_index);
+                    lng_index = 0;
+                }
+            }
         }
         else if (string_matches(argv[1], "-base10"))
             base2 = 0;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -447,7 +447,7 @@ static const char* bench_result_words1[][4] = {
     { "を"   , "秒で処理", "1バイトあたりのサイクル数", NULL },     /* 1 Japanese */
 };
 
-#if defined(WOLFSSL_KEY_GEN) || defined(HAVE_NTRU) || \
+#if !defined(NO_RSA)  ||defined(WOLFSSL_KEY_GEN) || defined(HAVE_NTRU) || \
     defined(HAVE_ECC) || !defined(NO_DH) || defined(HAVE_ECC_ENCRYPT) || \
     defined(HAVE_CURVE25519) || defined(HAVE_CURVE25519_SHARED_SECRET)  || \
     defined(HAVE_ED25519)


### PR DESCRIPTION
Added an option switch to benchmark program:
 -lng <num>   Display benchmark result by specified language.
                        0: English, 1: Japanese

This can switch result message to English or Japanese. In addition to that, usage message(-? option) can be switch to English or Japanese when it is specified by 0 or 1.
