### PR TITLE
Skip Server Supported Curve Extension

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -3627,8 +3627,13 @@ static int TLSX_SupportedCurve_Parse(WOLFSSL* ssl, byte* input, word16 length,
     word16 name;
     int ret;
 
-    if(!isRequest && !IsAtLeastTLSv1_3(ssl->version))
+    if(!isRequest && !IsAtLeastTLSv1_3(ssl->version)) {
+#ifdef WOLFSSL_ALLOW_SERVER_SC_EXT
+        return 0;
+#else
         return BUFFER_ERROR; /* servers doesn't send this extension. */
+#endif
+    }
 
     if (OPAQUE16_LEN > length || length % OPAQUE16_LEN)
         return BUFFER_ERROR;


### PR DESCRIPTION
Added a build option, WOLFSSL_ALLOW_SERVER_SC_EXT, that skips the client's parsing of the supported curve extension if sent by the server for sessions using < TLSv1.3. The server doesn't need to send it and the RFCs don't specify what should happen if it does in TLSv1.2, but it is sent in response from one particular Java based TLS server.