### PR TITLE
fix for afalg header install and macro set

### DIFF
--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -77,9 +77,12 @@ noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/caam/wolfcaam.h \
                          wolfssl/wolfcrypt/port/caam/wolfcaam_sha.h \
                          wolfssl/wolfcrypt/port/st/stm32.h \
-                         wolfssl/wolfcrypt/port/st/stsafe.h \
-                         wolfssl/wolfcrypt/port/af_alg/afalg_hash.h \
-                         wolfssl/wolfcrypt/port/af_alg/wc_afalg.h
+                         wolfssl/wolfcrypt/port/st/stsafe.h
+
+if BUILD_AFALG
+nobase_include_HEADERS+= wolfssl/wolfcrypt/port/af_alg/afalg_hash.h
+nobase_include_HEADERS+= wolfssl/wolfcrypt/port/af_alg/wc_afalg.h
+endif
 
 if BUILD_DEVCRYPTO
 nobase_include_HEADERS+= wolfssl/wolfcrypt/port/devcrypto/wc_devcrypto.h

--- a/wolfssl/wolfcrypt/port/af_alg/wc_afalg.h
+++ b/wolfssl/wolfcrypt/port/af_alg/wc_afalg.h
@@ -31,6 +31,15 @@
 
 #define WC_SOCK_NOTSET -1
 
+/* In some cases these flags are not set in AF_ALG header files.
+ * Documentation provided at kernel.org/doc/html/v4.16/crypto/userspace-if.html
+ * suggests using these values if not set */
+#ifndef AF_ALG
+    #define AF_ALG 38
+#endif
+#ifndef SOL_ALG
+    #define SOL_ALG 279
+#endif
 
 WOLFSSL_LOCAL void wc_Afalg_SockAddr(struct sockaddr_alg* in, const char* type, const char* name);
 WOLFSSL_LOCAL int wc_Afalg_Accept(struct sockaddr_alg* in, int inSz, int sock);


### PR DESCRIPTION
Installs the wolfSSL header files needed so application can link to wolfSSL and use AF_ALG.

Checks and sets macros that may not exist on some systems.