### PR TITLE
BUGFIX: Properly determine how much data to consume when handshake me…

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10944,6 +10944,11 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     }
 
     inputLength = ssl->buffers.inputBuffer.length - *inOutIdx;
+    if (ssl->arrays->pendingMsgSz != 0) {
+        inputLength = min(inputLength,
+                          ssl->arrays->pendingMsgSz - ssl->arrays->pendingMsgOffset);
+    }
+
 
     /* If there is a pending fragmented handshake message,
      * pending message size will be non-zero. */


### PR DESCRIPTION
We have a scenario where large (32K+ bytes) certificate request messages are received during the handshake. After increasing MAX_HANDSHAKE_SZ to accommodate for this, I ran into an issue where inputLength in DoHandShakeMsg was incorrectly calculated.

I am unsure, if this could also happen without increasing MAX_HANDSHAKE_SZ, but thought I'd submit a patch anyhow. Someone more familiar with the code base can probably assign value to this patch easily.

Thanks,
Thomas.