### PR TITLE
Added translated japanese message to the example client and server

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -65,7 +65,7 @@
  * test mode and (2) the testsuite which uses this code and sets up the correct
  * port numbers when the internal thread using the server code using port 0. */
 
-
+static int lng_index = 0;
 #ifdef WOLFSSL_CALLBACKS
     Timeval timeout;
     static int handShakeCB(HandShakeInfo* info)
@@ -251,6 +251,20 @@ static void SetKeyShare(WOLFSSL* ssl, int onlyKeyShare, int useX25519)
 
 /* Measures average time to create, connect and disconnect a connection (TPS).
 Benchmark = number of connections. */
+static const char* client_bench_conmsg[][5] = {
+    /* English */
+    {
+        "wolfSSL_resume  avg took:", "milliseconds\n",
+        "wolfSSL_connect avg took:", "milliseconds\n",
+        NULL
+    },
+    /* Japanese */
+    {
+        "wolfSSL_resume  平均時間:", "ミリ秒\n",
+        "wolfSSL_connect 平均時間:", "ミリ秒\n",
+    }
+};
+
 static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
     int dtlsUDP, int dtlsSCTP, int benchmark, int resumeSession, int useX25519,
     int helloRetry, int onlyKeyShare, int version)
@@ -266,6 +280,7 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
     byte* reply[80];
     static const char msg[] = "GET /index.html HTTP/1.0\r\n\r\n";
 #endif
+    const char** words = client_bench_conmsg[lng_index];
 
     (void)resumeSession;
     (void)useX25519;
@@ -356,10 +371,10 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
         avg *= 1000;   /* milliseconds */
     #ifndef NO_SESSION_CACHE
         if (benchResume)
-            printf("wolfSSL_resume  avg took: %8.3f milliseconds\n", avg);
+            printf("%s %8.3f %s\n", words[0],avg, words[1]);
         else
     #endif
-            printf("wolfSSL_connect avg took: %8.3f milliseconds\n", avg);
+            printf("%s %8.3f %s\n", words[2],avg, words[3]);
 
         WOLFSSL_TIME(times);
     }
@@ -776,146 +791,420 @@ static void EarlyData(WOLFSSL_CTX* ctx, WOLFSSL* ssl, char* msg, int msgSz,
 }
 #endif
 
+/* when adding new option, please follow the steps below: */
+/*  1. add new option message in English section          */
+/*  2. increase the number of the second dimention        */
+/*  3. add the same message into Japanese section         */
+/*     (will be translated later)                         */
+static const char* client_usage_msg[][59] = {
+    /* English */
+    {
+        " NOTE: All files relative to wolfSSL home dir\n",          /* 0 */
+        "Max RSA key size in bits for build is set at : ",          /* 1 */
+#ifdef NO_RSA
+        "RSA not supported\n",                                      /* 2 */
+#elif defined(WOLFSSL_SP_MATH) /* case of SP math only */
+#ifndef WOLFSSL_SP_NO_3072
+        "3072\n",                                                   /* 2 */
+#elif !defined(WOLFSSL_SP_NO_2048)
+        "2048\n",                                                   /* 2 */
+#else
+        "0\n",                                                      /* 2 */
+#endif
+#elif defined(USE_FAST_MATH)
+#else
+        "INFINITE\n",                                               /* 2 */
+#endif
+        "-? <num>    Help, print this usage\n            0: English, 1: Japanese\n",   /* 3 */
+        "-h <host>   Host to connect to, default",                  /* 4 */
+        "-p <num>    Port to connect on, not 0, default",           /* 5 */
+
+#ifndef WOLFSSL_TLS13
+        "-v <num>    SSL version [0-3], SSLv3(0) - TLS1.2(3)), default",        /* 6 */
+        "-V          Prints valid ssl version numbers, SSLv3(0) - TLS1.2(3)\n", /* 7 */
+#else
+        "-v <num>    SSL version [0-4], SSLv3(0) - TLS1.3(4)), default",   /* 6 */
+        "-V          Prints valid ssl version numbers, SSLv3(0) - TLS1.3(4)\n", /* 7 */
+#endif
+        "-l <str>    Cipher suite list (: delimited)\n",                        /* 8 */
+        "-c <file>   Certificate file,           default",                      /* 9 */
+        "-k <file>   Key file,                   default",                      /* 10 */
+        "-A <file>   Certificate Authority file, default",                      /* 11 */
+#ifndef NO_DH
+        "-Z <num>    Minimum DH key bits,        default",                    /* 12 */
+#endif
+        "-b <num>    Benchmark <num> connections and print stats\n",            /* 13 */
+#ifdef HAVE_ALPN
+        "-L <str>    Application-Layer Protocol Negotiation ({C,F}:<list>)\n",  /* 14 */
+#endif
+        "-B <num>    Benchmark throughput using <num> bytes and print stats\n", /* 15 */
+        "-s          Use pre Shared keys\n",                                    /* 16 */
+        "-d          Disable peer checks\n",                                    /* 17 */
+        "-D          Override Date Errors example\n",                           /* 18 */
+        "-e          List Every cipher suite available, \n",                    /* 19 */
+        "-g          Send server HTTP GET\n",                                   /* 20 */
+        "-u          Use UDP DTLS, add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default)\n", /* 21 */
+#ifdef WOLFSSL_SCTP
+        "-G          Use SCTP DTLS, add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default)\n",    /* 22 */
+#endif
+        "-m          Match domain name in cert\n",                                      /* 23 */
+        "-N          Use Non-blocking sockets\n",                                       /* 24 */
+#ifndef NO_SESSION_CACHE
+        "-r          Resume session\n",                                                 /* 25 */
+#endif 
+        "-w          Wait for bidirectional shutdown\n",                                /* 26 */
+        "-M <prot>   Use STARTTLS, using <prot> protocol (smtp)\n",                     /* 27 */
+#ifdef HAVE_SECURE_RENEGOTIATION
+        "-R          Allow Secure Renegotiation\n",                                     /* 28 */
+        "-i          Force client Initiated Secure Renegotiation\n",                    /* 29 */
+#endif
+        "-f          Fewer packets/group messages\n",                                   /* 30 */
+        "-x          Disable client cert/key loading\n",                                /* 31 */
+        "-X          Driven by eXternal test case\n",                                   /* 32 */
+        "-j          Use verify callback override\n",                                   /* 33 */
+#ifdef SHOW_SIZES
+        "-z          Print structure sizes\n",                                          /* 34 */
+#endif
+#ifdef HAVE_SNI
+        "-S <str>    Use Host Name Indication\n",                                       /* 35 */
+#endif
+#ifdef HAVE_MAX_FRAGMENT
+        "-F <num>    Use Maximum Fragment Length [1-6]\n",                              /* 36 */
+#endif
+#ifdef HAVE_TRUNCATED_HMAC
+        "-T          Use Truncated HMAC\n",                                             /* 37 */
+#endif
+#ifdef HAVE_EXTENDED_MASTER
+        "-n          Disable Extended Master Secret\n",                                 /* 38 */
+#endif
+#ifdef HAVE_OCSP
+        "-o          Perform OCSP lookup on peer certificate\n",                        /* 39 */
+        "-O <url>    Perform OCSP lookup using <url> as responder\n",                   /* 40 */
+#endif
+#if defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
+ || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
+        "-W <num>    Use OCSP Stapling (1 v1, 2 v2, 3 v2 multi)\n",                     /* 41 */
+#endif
+#ifdef ATOMIC_USER
+        "-U          Atomic User Record Layer Callbacks\n",                             /* 42 */
+#endif
+#ifdef HAVE_PK_CALLBACKS
+        "-P          Public Key Callbacks\n",                                           /* 43 */
+#endif
+#ifdef HAVE_ANON
+        "-a          Anonymous client\n",                                               /* 44 */
+#endif
+#ifdef HAVE_CRL
+        "-C          Disable CRL\n",                                                    /* 45 */
+#endif
+#ifdef WOLFSSL_TRUST_PEER_CERT
+        "-E <file>   Path to load trusted peer cert\n",                                 /* 46 */
+#endif
+#ifdef HAVE_WNR
+        "-q <file>   Whitewood config file,      defaults\n",                           /* 47 */      
+#endif
+        "-H <arg>    Internal tests [defCipherList, exitWithRet, verifyFail]\n",        /* 48 */
+#ifdef WOLFSSL_TLS13
+        "-J          Use HelloRetryRequest to choose group for KE\n",                   /* 49 */
+        "-K          Key Exchange for PSK not using (EC)DHE\n",                         /* 50 */
+        "-I          Update keys and IVs before sending data\n",                        /* 51 */
+#ifndef NO_DH
+        "-y          Key Share with FFDHE named groups only\n",                         /* 52 */
+#endif
+#ifdef HAVE_ECC
+        "-Y          Key Share with ECC named groups only\n",                           /* 53 */
+#endif
+#endif /* WOLFSSL_TLS13 */
+#ifdef HAVE_CURVE25519
+        "-t          Use X25519 for key exchange\n",                                    /* 54 */
+#endif
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
+        "-Q          Support requesting certificate post-handshake\n",                  /* 55 */
+#endif
+#ifdef WOLFSSL_EARLY_DATA
+        "-0          Early data sent to server (0-RTT handshake)\n",                    /* 56 */
+#endif
+#ifdef WOLFSSL_MULTICAST
+        "-3 <grpid>  Multicast, grpid < 256\n",                                         /* 57 */
+#endif
+        "-1 <num>    Display a result by specified language.\n            0: English, 1: Japanese\n", /* 58 */
+        NULL,
+    },
+    /* Japanese */
+        {
+        " 注意 : 全てのファイルは wolfSSL ホーム・ディレクトリからの相対です。\n",     /* 0 */
+        "RSAの最大ビットは次のように設定されています: ",                               /* 1 */
+#ifdef NO_RSA
+        "RSAはサポートされていません。\n",                                             /* 2 */
+#elif defined(WOLFSSL_SP_MATH) /* case of SP math only */
+#ifndef WOLFSSL_SP_NO_3072
+        "3072\n",                                                                      /* 2 */
+#elif !defined(WOLFSSL_SP_NO_2048)
+        "2048\n",                                                                      /* 2 */
+#else
+        "0\n",                                                                         /* 2 */
+#endif
+#elif defined(USE_FAST_MATH)
+#else
+        "無限\n",                                                                      /* 2 */
+#endif
+        "-? <num>    ヘルプ, 使い方を表示\n            0: 英語、 1: 日本語\n",         /* 3 */
+        "-h <host>   接続先ホスト, 既定値",                                            /* 4 */
+        "-p <num>    接続先ポート, 0は無効, 既定値",                                   /* 5 */
+
+#ifndef WOLFSSL_TLS13
+        "-v <num>    SSL バージョン [0-3], SSLv3(0) - TLS1.2(3)), 既定値",             /* 6 */
+        "-V          有効な ssl バージョン番号を出力, SSLv3(0) - TLS1.2(3)\n",         /* 7 */
+#else
+        "-v <num>    SSL バージョン [0-4], SSLv3(0) - TLS1.3(4)), 既定値",           /* 6 */
+        "-V          有効な ssl バージョン番号を出力, SSLv3(0) - TLS1.3(4)\n",         /* 7 */
+#endif
+        "-l <str>    暗号スイートリスト (区切り文字 :)\n",                             /* 8 */
+        "-c <file>   証明書ファイル,  既定値",                                         /* 9 */
+        "-k <file>   鍵ファイル,      既定値",                                         /* 10 */
+        "-A <file>   認証局ファイル,  既定値",                                         /* 11 */
+#ifndef NO_DH
+        "-Z <num>    最小 DH 鍵 ビット, 既定値",                                       /* 12 */
+#endif
+        "-b <num>    ベンチマーク <num> 接続及び結果出力する\n",                       /* 13 */
+#ifdef HAVE_ALPN
+        "-L <str>    アプリケーション層プロトコルネゴシエーションを行う ({C,F}:<list>)\n",   /* 14 */
+#endif
+        "-B <num>    <num> バイトを用いてのベンチマーク・スループット測定と結果を出力する\n", /* 15 */
+        "-s          事前共有鍵を使用する\n",                                                 /* 16 */
+        "-d          ピア確認を無効とする\n",                                                 /* 17 */
+        "-D          日付エラー用コールバック例の上書きを行う\n",                             /* 18 */
+        "-e          利用可能な全ての暗号スイートをリスト, \n",                               /* 19 */
+        "-g          サーバーへ HTTP GET を送信\n",                                           /* 20 */
+        "-u          UDP DTLSを使用する。-v 2 を追加指定すると DTLSv1, -v 3 を追加指定すると DTLSv1.2 (既定値)\n",    /* 21 */
+#ifdef WOLFSSL_SCTP
+        "-G          SCTP DTLSを使用する。-v 2 を追加指定すると DTLSv1, -v 3 を追加指定すると DTLSv1.2 (既定値)\n",   /* 22 */
+#endif
+        "-m          証明書内のドメイン名一致を確認する\n",                               /* 23 */
+        "-N          ノンブロッキング・ソケットを使用する\n",                             /* 24 */
+#ifndef NO_SESSION_CACHE
+        "-r          セッションを継続する\n",                                             /* 25 */
+#endif 
+        "-w          双方向シャットダウンを待つ\n",                                       /* 26 */
+        "-M <prot>   STARTTLSを使用する, <prot>プロトコル(smtp)を使用する\n",             /* 27 */
+#ifdef HAVE_SECURE_RENEGOTIATION
+        "-R          セキュアな再ネゴシエーションを許可する\n",                           /* 28 */
+        "-i          クライアント主導のネゴシエーションを強制する\n",                     /* 29 */
+#endif
+        "-f          より少ないパケット/グループメッセージを使用する\n",                  /* 30 */
+        "-x          クライアントの証明書/鍵のロードを無効する\n",                        /* 31 */
+        "-X          外部テスト・ケースにより動作する\n",                                 /* 32 */
+        "-j          コールバック・オーバーライドの検証を使用する\n",                     /* 33 */
+#ifdef SHOW_SIZES
+        "-z          構造体のサイズを表示する\n",                                         /* 34 */
+#endif
+#ifdef HAVE_SNI
+        "-S <str>    ホスト名表示を使用する\n",                                           /* 35 */
+#endif
+#ifdef HAVE_MAX_FRAGMENT
+        "-F <num>    最大フラグメント長[1-6]を設定する\n",                                /* 36 */
+#endif
+#ifdef HAVE_TRUNCATED_HMAC
+        "-T          Truncated HMACを使用する\n",                                         /* 37 */
+#endif
+#ifdef HAVE_EXTENDED_MASTER
+        "-n          マスターシークレット拡張を無効にする\n",                             /* 38 */
+#endif
+#ifdef HAVE_OCSP
+        "-o          OCSPルックアップをピア証明書で実施する\n",                           /* 39 */
+        "-O <url>    OCSPルックアップを、<url>を使用し応答者として実施する\n",            /* 40 */
+#endif
+#if defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
+ || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
+        "-W <num>    OCSP Staplingを使用する (1 v1, 2 v2, 3 v2 multi)\n",                 /* 41 */
+#endif
+#ifdef ATOMIC_USER
+        "-U          アトミック・ユーザー記録のコールバックを利用する\n",                 /* 42 */
+#endif
+#ifdef HAVE_PK_CALLBACKS
+        "-P          公開鍵コールバック\n",                                               /* 43 */
+#endif
+#ifdef HAVE_ANON
+        "-a          匿名クライアント\n",                                                 /* 44 */
+#endif
+#ifdef HAVE_CRL
+        "-C          CRLを無効\n",                                                        /* 45 */
+#endif
+#ifdef WOLFSSL_TRUST_PEER_CERT
+        "-E <file>   信頼出来るピアの証明書ロードの為のパス\n",                          /* 46 */
+#endif
+#ifdef HAVE_WNR
+        "-q <file>   Whitewood コンフィグファイル,      既定値\n",                        /* 47 */      
+#endif
+        "-H <arg>    内部テスト [defCipherList, exitWithRet, verifyFail]\n",              /* 48 */
+#ifdef WOLFSSL_TLS13
+        "-J          HelloRetryRequestをKEのグループ選択に使用する\n",                    /* 49 */
+        "-K          鍵交換にPSKを使用、(EC)DHEは使用しない\n",                           /* 50 */
+        "-I          データ送信前に、鍵とIVを更新する\n",                                 /* 51 */
+#ifndef NO_DH
+        "-y          FFDHE名前付きグループとの鍵共有のみ\n",                              /* 52 */
+#endif
+#ifdef HAVE_ECC
+        "-Y          ECC名前付きグループとの鍵共有のみ\n",                                /* 53 */
+#endif
+#endif /* WOLFSSL_TLS13 */
+#ifdef HAVE_CURVE25519
+        "-t          X25519を鍵交換に使用する\n",                                         /* 54 */
+#endif
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
+        "-Q          ポストハンドシェークの証明要求をサポートする\n",                     /* 55 */
+#endif
+#ifdef WOLFSSL_EARLY_DATA
+        "-0          Early data をサーバーへ送信する（0-RTTハンドシェイク）\n",                /* 56 */
+#endif
+#ifdef WOLFSSL_MULTICAST
+        "-3 <grpid>  マルチキャスト, grpid < 256\n",                                      /* 57 */
+#endif
+        "-1 <num>    指定された言語で結果を表示します。\n            0: 英語、 1: 日本語\n", /* 58 */
+        NULL,
+    },
+
+};
+
 static void Usage(void)
 {
-    printf("wolfSSL client "    LIBWOLFSSL_VERSION_STRING
-           " NOTE: All files relative to wolfSSL home dir\n");
+    int msgid = 0;
+    const char** msg = client_usage_msg[lng_index];
+
+    printf("%s%s%s", "wolfSSL client ",    LIBWOLFSSL_VERSION_STRING,
+           msg[msgid]);
 
     /* print out so that scripts can know what the max supported key size is */
-    printf("Max RSA key size in bits for build is set at : ");
+    printf("%s", msg[++msgid]);
 #ifdef NO_RSA
-    printf("RSA not supported\n");
+    printf("%s", msg[++msgid]);
 #elif defined(WOLFSSL_SP_MATH) /* case of SP math only */
     #ifndef WOLFSSL_SP_NO_3072
-        printf("3072\n");
+        printf("%s", msg[++msgid]);
     #elif !defined(WOLFSSL_SP_NO_2048)
-        printf("2048\n");
+        printf("%s", msg[++msgid]);
     #else
-        printf("0\n");
+        printf("%s", msg[++msgid]);
     #endif
 #elif defined(USE_FAST_MATH)
     printf("%d\n", FP_MAX_BITS/2);
 #else
     /* normal math has unlimited max size */
-    printf("INFINITE\n");
+    printf("%s", msg[++msgid]);
 #endif
 
-    printf("-?          Help, print this usage\n");
-    printf("-h <host>   Host to connect to, default %s\n", wolfSSLIP);
-    printf("-p <num>    Port to connect on, not 0, default %d\n", wolfSSLPort);
+    printf("%s", msg[++msgid]); /* ? */
+    printf("%s %s\n", msg[++msgid], wolfSSLIP);   /* -h */
+    printf("%s %d\n", msg[++msgid], wolfSSLPort); /* -p */
 #ifndef WOLFSSL_TLS13
-    printf("-v <num>    SSL version [0-3], SSLv3(0) - TLS1.2(3)), default %d\n",
-                                 CLIENT_DEFAULT_VERSION);
-    printf("-V          Prints valid ssl version numbers, SSLv3(0) - TLS1.2(3)\n");
+    printf("%s %d\n", msg[++msgid], CLIENT_DEFAULT_VERSION); /* -v */
+    printf("%s", msg[++msgid]); /* -V */
 #else
-    printf("-v <num>    SSL version [0-4], SSLv3(0) - TLS1.3(4)), default %d\n",
-                                 CLIENT_DEFAULT_VERSION);
-    printf("-V          Prints valid ssl version numbers, SSLv3(0) - TLS1.3(4)\n");
+    printf("%s %d\n", msg[++msgid], CLIENT_DEFAULT_VERSION); /* -v */
+    printf("%s", msg[++msgid]);                              /* -V */
 #endif
-    printf("-l <str>    Cipher suite list (: delimited)\n");
-    printf("-c <file>   Certificate file,           default %s\n", cliCertFile);
-    printf("-k <file>   Key file,                   default %s\n", cliKeyFile);
-    printf("-A <file>   Certificate Authority file, default %s\n", caCertFile);
+    printf("%s", msg[++msgid]); /* -l */
+    printf("%s %s\n", msg[++msgid], cliCertFile); /* -c */
+    printf("%s %s\n", msg[++msgid], cliKeyFile);  /* -k */
+    printf("%s %s\n", msg[++msgid], caCertFile);  /* -A */
 #ifndef NO_DH
-    printf("-Z <num>    Minimum DH key bits,        default %d\n",
-                                 DEFAULT_MIN_DHKEY_BITS);
+    printf("%s %d\n", msg[++msgid], DEFAULT_MIN_DHKEY_BITS);
 #endif
-    printf("-b <num>    Benchmark <num> connections and print stats\n");
+    printf("%s", msg[++msgid]); /* -b */
 #ifdef HAVE_ALPN
-    printf("-L <str>    Application-Layer Protocol Negotiation ({C,F}:<list>)\n");
+    printf("%s", msg[++msgid]); /* -L <str> */
 #endif
-    printf("-B <num>    Benchmark throughput using <num> bytes and print stats\n");
-    printf("-s          Use pre Shared keys\n");
-    printf("-d          Disable peer checks\n");
-    printf("-D          Override Date Errors example\n");
-    printf("-e          List Every cipher suite available, \n");
-    printf("-g          Send server HTTP GET\n");
-    printf("-u          Use UDP DTLS,"
-           " add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default)\n");
+    printf("%s", msg[++msgid]); /* -B <num> */
+    printf("%s", msg[++msgid]); /* -s */
+    printf("%s", msg[++msgid]); /* -d */
+    printf("%s", msg[++msgid]); /* -D */
+    printf("%s", msg[++msgid]); /* -e */
+    printf("%s", msg[++msgid]); /* -g */
+    printf("%s", msg[++msgid]); /* -u */
 #ifdef WOLFSSL_SCTP
-    printf("-G          Use SCTP DTLS,"
-           " add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default)\n");
+    printf("%s", msg[++msgid]); /* -G */
 #endif
-    printf("-m          Match domain name in cert\n");
-    printf("-N          Use Non-blocking sockets\n");
+    printf("%s", msg[++msgid]); /* -m */
+    printf("%s", msg[++msgid]); /* -N */
 #ifndef NO_SESSION_CACHE
-    printf("-r          Resume session\n");
+    printf("%s", msg[++msgid]); /* -r */
 #endif
-    printf("-w          Wait for bidirectional shutdown\n");
-    printf("-M <prot>   Use STARTTLS, using <prot> protocol (smtp)\n");
+    printf("%s", msg[++msgid]); /* -w */
+    printf("%s", msg[++msgid]); /* -M */
 #ifdef HAVE_SECURE_RENEGOTIATION
-    printf("-R          Allow Secure Renegotiation\n");
-    printf("-i          Force client Initiated Secure Renegotiation\n");
+    printf("%s", msg[++msgid]); /* -R */
+    printf("%s", msg[++msgid]); /* -i */
 #endif
-    printf("-f          Fewer packets/group messages\n");
-    printf("-x          Disable client cert/key loading\n");
-    printf("-X          Driven by eXternal test case\n");
-    printf("-j          Use verify callback override\n");
+    printf("%s", msg[++msgid]); /* -f */
+    printf("%s", msg[++msgid]); /* -x */
+    printf("%s", msg[++msgid]); /* -X */
+    printf("%s", msg[++msgid]); /* -j */
 #ifdef SHOW_SIZES
-    printf("-z          Print structure sizes\n");
+    printf("%s", msg[++msgid]); /* -z */
 #endif
 #ifdef HAVE_SNI
-    printf("-S <str>    Use Host Name Indication\n");
+    printf("%s", msg[++msgid]); /* -S */
 #endif
 #ifdef HAVE_MAX_FRAGMENT
-    printf("-F <num>    Use Maximum Fragment Length [0-6]\n");
+    printf("%s", msg[++msgid]); /* -F */
 #endif
 #ifdef HAVE_TRUNCATED_HMAC
-    printf("-T          Use Truncated HMAC\n");
+    printf("%s", msg[++msgid]); /* -T */
 #endif
 #ifdef HAVE_EXTENDED_MASTER
-    printf("-n          Disable Extended Master Secret\n");
+    printf("%s", msg[++msgid]); /* -n */
 #endif
 #ifdef HAVE_OCSP
-    printf("-o          Perform OCSP lookup on peer certificate\n");
-    printf("-O <url>    Perform OCSP lookup using <url> as responder\n");
+    printf("%s", msg[++msgid]); /* -o */
+    printf("%s", msg[++msgid]); /* -O */
 #endif
 #if defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
  || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
-    printf("-W <num>    Use OCSP Stapling (1 v1, 2 v2, 3 v2 multi)\n");
+    printf("%s", msg[++msgid]); /* -W */
 #endif
 #ifdef ATOMIC_USER
-    printf("-U          Atomic User Record Layer Callbacks\n");
+    printf("%s", msg[++msgid]); /* -U */
 #endif
 #ifdef HAVE_PK_CALLBACKS
-    printf("-P          Public Key Callbacks\n");
+    printf("%s", msg[++msgid]); /* -P */
 #endif
 #ifdef HAVE_ANON
-    printf("-a          Anonymous client\n");
+    printf("%s", msg[++msgid]); /* -a */
 #endif
 #ifdef HAVE_CRL
-    printf("-C          Disable CRL\n");
+    printf("%s", msg[++msgid]); /* -C */
 #endif
 #ifdef WOLFSSL_TRUST_PEER_CERT
-    printf("-E <file>   Path to load trusted peer cert\n");
+    printf("%s", msg[++msgid]); /* -E */
 #endif
 #ifdef HAVE_WNR
-    printf("-q <file>   Whitewood config file,      default %s\n", wnrConfig);
+    printf("%s %s\n", msg[++msgid], wnrConfig); /* -q */
 #endif
-    printf("-H <arg>    Internal tests [defCipherList, exitWithRet, verifyFail]\n");
+    printf("%s", msg[++msgid]);                /* -H  */
 #ifdef WOLFSSL_TLS13
-    printf("-J          Use HelloRetryRequest to choose group for KE\n");
-    printf("-K          Key Exchange for PSK not using (EC)DHE\n");
-    printf("-I          Update keys and IVs before sending data\n");
+    printf("%s", msg[++msgid]); /* -J */
+    printf("%s", msg[++msgid]); /* -K */
+    printf("%s", msg[++msgid]); /* -I */
 #ifndef NO_DH
-    printf("-y          Key Share with FFDHE named groups only\n");
+    printf("%s", msg[++msgid]); /* -y */
 #endif
 #ifdef HAVE_ECC
-    printf("-Y          Key Share with ECC named groups only\n");
+    printf("%s", msg[++msgid]); /* -Y */
 #endif
 #endif /* WOLFSSL_TLS13 */
 #ifdef HAVE_CURVE25519
-    printf("-t          Use X25519 for key exchange\n");
+    printf("%s", msg[++msgid]); /* -t */
 #endif
 #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
-    printf("-Q          Support requesting certificate post-handshake\n");
+    printf("%s", msg[++msgid]); /* -Q */
 #endif
 #ifdef WOLFSSL_EARLY_DATA
-    printf("-0          Early data sent to server (0-RTT handshake)\n");
+    printf("%s", msg[++msgid]); /* -0 */
 #endif
 #ifdef WOLFSSL_MULTICAST
-    printf("-3 <grpid>  Multicast, grpid < 256\n");
+    printf("%s", msg[++msgid]); /* -3 */
 #endif
+    printf("%s", msg[++msgid]);  /* -1 */
 }
 
 THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
@@ -1101,12 +1390,18 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
 #ifndef WOLFSSL_VXWORKS
     /* Not used: All used */
-    while ((ch = mygetopt(argc, argv, "?"
+    while ((ch = mygetopt(argc, argv, "?:"
             "ab:c:defgh:ijk:l:mnop:q:rstuv:wxyz"
             "A:B:CDE:F:GH:IJKL:M:NO:PQRS:TUVW:XYZ:"
-            "03:")) != -1) {
+            "01:3:")) != -1) {
         switch (ch) {
             case '?' :
+                if(myoptarg!=NULL) {
+                    lng_index = atoi(myoptarg);
+                    if(lng_index<0||lng_index>1){
+                        lng_index = 0;
+                    }
+                }
                 Usage();
                 XEXIT_T(EXIT_SUCCESS);
 
@@ -1221,7 +1516,6 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             case 'l' :
                 cipherList = myoptarg;
                 break;
-
             case 'H' :
                 if (XSTRNCMP(myoptarg, "defCipherList", 13) == 0) {
                     printf("Using default cipher list for testing\n");
@@ -1482,7 +1776,12 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 earlyData = 1;
             #endif
                 break;
-
+            case '1' :
+                lng_index = atoi(myoptarg);
+                if(lng_index<0||lng_index>1){
+                      lng_index = 0;
+                }
+                break;
             case '3' :
                 #ifdef WOLFSSL_MULTICAST
                     doMcast = 1;
@@ -2337,7 +2636,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         goto exit;
     }
 
-    showPeer(ssl);
+    showPeerEx(ssl, lng_index);
 
 #ifdef OPENSSL_EXTRA
     {
@@ -2594,7 +2893,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             err_sys("wolfSSL_connect resume failed");
         }
 
-        showPeer(sslResume);
+        showPeerEx(sslResume, lng_index);
 
         if (wolfSSL_session_reused(sslResume))
             printf("reused session id\n");

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -73,7 +73,7 @@ static const char webServerMsg[] =
     "</html>\n";
 
 int runWithErrors = 0; /* Used with -x flag to run err_sys vs. print errors */
-
+static int lng_index = 0;
 
 #ifdef WOLFSSL_CALLBACKS
     Timeval srvTo;
@@ -344,107 +344,310 @@ static void ServerWrite(WOLFSSL* ssl, const char* output, int outputLen)
         err_sys_ex(runWithErrors, "SSL_write failed");
     }
 }
+/* when adding new option, please follow the steps below: */
+/*  1. add new option message in English section          */
+/*  2. increase the number of the second dimention        */
+/*  3. add the same message into Japanese section         */
+/*     (will be translated later)                         */
+static const char* server_usage_msg[][49] = {
+    /* English */
+    {
+        " NOTE: All files relative to wolfSSL home dir\n",          /* 0 */
+        "-? <num>    Help, print this usage\n            0: English, 1: Japanese\n",    /* 1 */
+        "-p <num>    Port to listen on, not 0, default",            /* 2 */
+#ifndef WOLFSSL_TLS13
+        "-v <num>    SSL version [0-3], SSLv3(0) - TLS1.2(3)), default",   /* 3 */
+#else
+        "-v <num>    SSL version [0-4], SSLv3(0) - TLS1.3(4)), default",    /* 3 */
+#endif
+        "-l <str>    Cipher suite list (: delimited)\n",                    /* 4 */
+        "-c <file>   Certificate file,           default",                  /* 5 */
+        "-k <file>   Key file,                   default",                  /* 6 */
+        "-A <file>   Certificate Authority file, default",                  /* 7 */
+        "-R <file>   Create Ready file for external monitor default none\n",  /* 8 */
+#ifndef NO_DH
+        "-D <file>   Diffie-Hellman Params file, default",          /* 9 */
+        "-Z <num>    Minimum DH key bits,        default",          /* 10 */
+#endif
+#ifdef HAVE_ALPN
+        "-L <str>    Application-Layer Protocol Negotiation ({C,F}:<list>)\n",  /* 11 */
+#endif
+        "-d          Disable client cert check\n",                  /* 12 */
+        "-b          Bind to any interface instead of localhost only\n",    /* 13 */
+        "-s          Use pre Shared keys\n",                        /* 14 */
+        "-u          Use UDP DTLS,"
+           " add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default)\n",   /* 15 */
+#ifdef WOLFSSL_SCTP
+        "-G          Use SCTP DTLS,"
+           " add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default)\n",   /* 16 */
+#endif
+        "-f          Fewer packets/group messages\n",               /* 17 */
+        "-r          Allow one client Resumption\n",                /* 18 */
+        "-N          Use Non-blocking sockets\n",                   /* 19 */
+        "-S <str>    Use Host Name Indication\n",                   /* 20 */
+        "-w          Wait for bidirectional shutdown\n",            /* 21 */
+#ifdef HAVE_OCSP
+        "-o          Perform OCSP lookup on peer certificate\n",        /* 22 */
+        "-O <url>    Perform OCSP lookup using <url> as responder\n",   /* 23 */
+#endif
+#ifdef HAVE_PK_CALLBACKS
+        "-P          Public Key Callbacks\n",                       /* 24 */
+#endif
+#ifdef HAVE_ANON
+        "-a          Anonymous server\n",                           /* 25 */
+#endif
+#ifndef NO_PSK
+        "-I          Do not send PSK identity hint\n",              /* 26 */
+#endif
+        "-x          Print server errors but do not close connection\n",    /* 27 */
+        "-i          Loop indefinitely (allow repeated connections)\n",     /* 28 */
+        "-e          Echo data mode (return raw bytes received)\n",         /* 29 */
+#ifdef HAVE_NTRU
+        "-n          Use NTRU key (needed for NTRU suites)\n",              /* 30 */
+#endif
+        "-B <num>    Benchmark throughput using <num> bytes and print stats\n",     /* 31 */
+#ifdef HAVE_CRL
+        "-V          Disable CRL\n",                            /* 32 */
+#endif
+#ifdef WOLFSSL_TRUST_PEER_CERT
+        "-E <file>   Path to load trusted peer cert\n",         /* 33 */
+#endif
+#ifdef HAVE_WNR
+        "-q <file>   Whitewood config file,      default",      /* 34 */
+#endif
+        "-g          Return basic HTML web page\n",             /* 35 */
+        "-C <num>    The number of connections to accept, default: 1\n",            /* 36 */
+        "-H <arg>    Internal tests [defCipherList, exitWithRet, verifyFail]\n",    /* 37 */
+#ifdef WOLFSSL_TLS13
+        "-U          Update keys and IVs before sending\n",     /* 38 */
+        "-K          Key Exchange for PSK not using (EC)DHE\n", /* 39 */
+#ifndef NO_DH
+        "-y          Pre-generate Key Share using FFDHE_2048 only\n",   /* 40 */
+#endif
+#ifdef HAVE_ECC
+        "-Y          Pre-generate Key Share using P-256 only \n",       /* 41 */
+#endif
+#ifdef HAVE_CURVE25519
+        "-t          Pre-generate Key share using Curve25519 only\n",   /* 42 */
+#endif
+#ifdef HAVE_SESSION_TICKET
+        "-T          Do not generate session ticket\n",                 /* 43 */
+#endif
+#ifdef WOLFSSL_POST_HANDSHAKE_AUTH
+        "-Q          Request certificate from client post-handshake\n",     /* 44 */
+#endif
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+        "-J          Server sends Cookie Extension containing state\n",     /* 45 */
+#endif
+#endif /* WOLFSSL_TLS13 */ 
+#ifdef WOLFSSL_EARLY_DATA
+        "-0          Early data read from client (0-RTT handshake)\n",      /* 46 */
+#endif
+#ifdef WOLFSSL_MULTICAST
+        "-3 <grpid>  Multicast, grpid < 256\n",     /* 47 */
+#endif
+        "-1 <num>    Display a result by specified language.\n            0: English, 1: Japanese\n", /* 48 */
+        NULL,
+    },
+    /* Japanese */
+    {
+        " 注意 : 全てのファイルは wolfSSL ホーム・ディレクトリからの相対です。\n",      /* 0 */
+        "-? <num>    ヘルプ, 使い方を表示\n            0: 英語、 1: 日本語\n",          /* 1 */
+        "-p <num>    接続先ポート, 0は無効, 既定値",                         /* 2 */
+#ifndef WOLFSSL_TLS13
+        "-v <num>    SSL バージョン [0-3], SSLv3(0) - TLS1.2(3)), 既定値",   /* 3 */
+#else
+        "-v <num>    SSL バージョン [0-4], SSLv3(0) - TLS1.3(4)), 既定値",   /* 3 */
+#endif
+        "-l <str>    暗号スイートリスト (区切り文字 :)\n",      /* 4 */
+        "-c <file>   証明書ファイル,  既定値",                  /* 5 */
+        "-k <file>   鍵ファイル,      既定値",                  /* 6 */
+        "-A <file>   認証局ファイル,  既定値",                  /* 7 */
+        "-R <file>   外部モニタ用の準備完了ファイルを作成する。既定値  なし\n",  /* 8 */
+#ifndef NO_DH
+        "-D <file>   ディフィー・ヘルマンのパラメータファイル, 既定値",          /* 9 */
+        "-Z <num>    最小 DH 鍵 ビット, 既定値",                    /* 10 */
+#endif
+#ifdef HAVE_ALPN
+        "-L <str>    アプリケーション層プロトコルネゴシエーションを行う ({C,F}:<list>)\n",  /* 11 */
+#endif
+        "-d          クライアント認証を無効とする\n",                               /* 12 */
+        "-b          ローカルホスト以外のインターフェースへもバインドする\n",       /* 13 */
+        "-s          事前共有鍵を使用する\n",                                       /* 14 */
+        "-u          UDP DTLSを使用する。-v 2 を追加指定すると DTLSv1, -v 3 を追加指定すると DTLSv1.2 (既定値)\n",      /* 15 */
+#ifdef WOLFSSL_SCTP
+        "-G          SCTP DTLSを使用する。-v 2 を追加指定すると DTLSv1, -v 3 を追加指定すると DTLSv1.2 (既定値)\n",     /* 16 */
+#endif
+        "-f          より少ないパケット/グループメッセージを使用する\n",                /* 17 */
+        "-r          クライアントの再開を許可する\n",                                   /* 18 */
+        "-N          ノンブロッキング・ソケットを使用する\n",                           /* 19 */
+        "-S <str>    ホスト名表示を使用する\n",                                         /* 20 */
+        "-w          双方向シャットダウンを待つ\n",                                     /* 21 */
+#ifdef HAVE_OCSP
+        "-o          OCSPルックアップをピア証明書で実施する\n",                         /* 22 */
+        "-O <url>    OCSPルックアップを、<url>を使用し応答者として実施する\n",          /* 23 */
+#endif
+#ifdef HAVE_PK_CALLBACKS
+        "-P          公開鍵コールバック\n",                                             /* 24 */
+#endif
+#ifdef HAVE_ANON
+        "-a          匿名サーバー\n",                                                   /* 25 */
+#endif
+#ifndef NO_PSK
+        "-I          PSKアイデンティティのヒントを送信しない\n",                        /* 26 */
+#endif
+        "-x          サーバーエラーを出力するが接続を切断しない\n",                     /* 27 */
+        "-i          無期限にループする(繰り返し接続を許可)\n",                         /* 28 */
+        "-e          エコー・データモード(受け取ったバイトデータを返す)\n",             /* 29 */
+#ifdef HAVE_NTRU
+        "-n          NTRU鍵を使用する(NTRUスイートに必要)\n",                           /* 30 */
+#endif
+        "-B <num>    <num> バイトを用いてのベンチマーク・スループット測定と結果を出力する\n",     /* 31 */
+#ifdef HAVE_CRL
+        "-V          CRLを無効とする\n",                                                /* 32 */
+#endif
+#ifdef WOLFSSL_TRUST_PEER_CERT
+        "-E <file>   信頼出来るピアの証明書ロードの為のパス\n\n",       /* 33 */
+#endif
+#ifdef HAVE_WNR
+        "-q <file>   Whitewood コンフィグファイル,      既定値",        /* 34 */
+#endif
+        "-g          基本的な Web ページを返す\n",                      /* 35 */
+        "-C <num>    アクセプト可能な接続数を指定する。既定値: 1\n",            /* 36 */
+        "-H <arg>    内部テスト [defCipherList, exitWithRet, verifyFail]\n",    /* 37 */
+#ifdef WOLFSSL_TLS13
+        "-U          データ送信前に、鍵とIVを更新する\n",               /* 38 */
+        "-K          鍵交換にPSKを使用、(EC)DHEは使用しない\n",         /* 39 */
+#ifndef NO_DH
+        "-y          FFDHE_2048のみを使用して鍵共有を事前生成する\n",   /* 40 */
+#endif
+#ifdef HAVE_ECC
+        "-Y          P-256のみを使用したキー共有の事前生成\n",          /* 41 */
+#endif
+#ifdef HAVE_CURVE25519
+        "-t          Curve25519のみを使用して鍵共有を事前生成する\n",   /* 42 */
+#endif
+#ifdef HAVE_SESSION_TICKET
+        "-T         セッションチケットを生成しない\n",                 /* 43 */
+#endif
+#ifdef WOLFSSL_POST_HANDSHAKE_AUTH
+        "-Q          クライアントのポストハンドシェイクから証明書を要求する\n",     /* 44 */
+#endif
+#ifdef WOLFSSL_SEND_HRR_COOKIE
+        "-J          サーバーの状態を含むTLS Cookie 拡張を送信する\n",     /* 45 */
+#endif
+#endif /* WOLFSSL_TLS13 */ 
+#ifdef WOLFSSL_EARLY_DATA
+        "-0          クライアントからの Early Data 読み取り（0-RTTハンドシェイク）\n",      /* 46 */
+#endif
+#ifdef WOLFSSL_MULTICAST
+        "-3 <grpid>  マルチキャスト, grpid < 256\n",     /* 47 */
+#endif
+        "-1 <num>    指定された言語で結果を表示します。\n            0: 英語、 1: 日本語\n", /* 48 */
+        NULL,
+    },
+
+};
 
 static void Usage(void)
 {
-    printf("server "    LIBWOLFSSL_VERSION_STRING
-           " NOTE: All files relative to wolfSSL home dir\n");
-    printf("-?          Help, print this usage\n");
-    printf("-p <num>    Port to listen on, not 0, default %d\n", wolfSSLPort);
+    int msgId = 0;
+    const char** msg = server_usage_msg[lng_index];
+
+    printf("%s%s%s", "server ", LIBWOLFSSL_VERSION_STRING, 
+           msg[msgId]);
+    printf("%s", msg[++msgId]);                     /* ? */
+    printf("%s %d\n", msg[++msgId], wolfSSLPort);   /* -p */
 #ifndef WOLFSSL_TLS13
-    printf("-v <num>    SSL version [0-3], SSLv3(0) - TLS1.2(3)), default %d\n",
-                                 SERVER_DEFAULT_VERSION);
+    printf("%s %d\n", msg[++msgId], SERVER_DEFAULT_VERSION); /* -v */
 #else
-    printf("-v <num>    SSL version [0-4], SSLv3(0) - TLS1.3(4)), default %d\n",
-                                 SERVER_DEFAULT_VERSION);
+    printf("%s %d\n", msg[++msgId], SERVER_DEFAULT_VERSION); /* -v */
 #endif
-    printf("-l <str>    Cipher suite list (: delimited)\n");
-    printf("-c <file>   Certificate file,           default %s\n", svrCertFile);
-    printf("-k <file>   Key file,                   default %s\n", svrKeyFile);
-    printf("-A <file>   Certificate Authority file, default %s\n", cliCertFile);
-    printf("-R <file>   Create Ready file for external monitor default none\n");
+    printf("%s", msg[++msgId]);     /* -l */
+    printf("%s %s\n", msg[++msgId], svrCertFile);    /* -c */
+    printf("%s %s\n", msg[++msgId], svrKeyFile);     /* -k */
+    printf("%s %s\n", msg[++msgId], cliCertFile);    /* -A */
+    printf("%s", msg[++msgId]);     /* -R */
 #ifndef NO_DH
-    printf("-D <file>   Diffie-Hellman Params file, default %s\n", dhParamFile);
-    printf("-Z <num>    Minimum DH key bits,        default %d\n",
-                                 DEFAULT_MIN_DHKEY_BITS);
+    printf("%s %s\n", msg[++msgId], dhParamFile);           /* -D */
+    printf("%s %d\n", msg[++msgId], DEFAULT_MIN_DHKEY_BITS);/* -Z */
 #endif
 #ifdef HAVE_ALPN
-    printf("-L <str>    Application-Layer Protocol Negotiation ({C,F}:<list>)\n");
+    printf("%s", msg[++msgId]);     /* -L */
 #endif
-    printf("-d          Disable client cert check\n");
-    printf("-b          Bind to any interface instead of localhost only\n");
-    printf("-s          Use pre Shared keys\n");
-    printf("-u          Use UDP DTLS,"
-           " add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default)\n");
+    printf("%s", msg[++msgId]);     /* -d */
+    printf("%s", msg[++msgId]);     /* -b */
+    printf("%s", msg[++msgId]);     /* -s */
+    printf("%s", msg[++msgId]);     /* -u */
 #ifdef WOLFSSL_SCTP
-    printf("-G          Use SCTP DTLS,"
-           " add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default)\n");
+    printf("%s", msg[++msgId]);     /* -G */
 #endif
-    printf("-f          Fewer packets/group messages\n");
-    printf("-r          Allow one client Resumption\n");
-    printf("-N          Use Non-blocking sockets\n");
-    printf("-S <str>    Use Host Name Indication\n");
-    printf("-w          Wait for bidirectional shutdown\n");
+    printf("%s", msg[++msgId]);     /* -f */
+    printf("%s", msg[++msgId]);     /* -r */
+    printf("%s", msg[++msgId]);     /* -N */
+    printf("%s", msg[++msgId]);     /* -S */
+    printf("%s", msg[++msgId]);     /* -w */
 #ifdef HAVE_OCSP
-    printf("-o          Perform OCSP lookup on peer certificate\n");
-    printf("-O <url>    Perform OCSP lookup using <url> as responder\n");
+    printf("%s", msg[++msgId]);     /* -o */
+    printf("%s", msg[++msgId]);     /* -O */
 #endif
 #ifdef HAVE_PK_CALLBACKS
-    printf("-P          Public Key Callbacks\n");
+    printf("%s", msg[++msgId]);     /* -P */
 #endif
 #ifdef HAVE_ANON
-    printf("-a          Anonymous server\n");
+    printf("%s", msg[++msgId]);     /* -a */
 #endif
 #ifndef NO_PSK
-    printf("-I          Do not send PSK identity hint\n");
+    printf("%s", msg[++msgId]);     /* -I */
 #endif
-    printf("-x          Print server errors but do not close connection\n");
-    printf("-i          Loop indefinitely (allow repeated connections)\n");
-    printf("-e          Echo data mode (return raw bytes received)\n");
+    printf("%s", msg[++msgId]);     /* -x */
+    printf("%s", msg[++msgId]);     /* -i */
+    printf("%s", msg[++msgId]);     /* -e */
 #ifdef HAVE_NTRU
-    printf("-n          Use NTRU key (needed for NTRU suites)\n");
+    printf("%s", msg[++msgId]);     /* -n */
 #endif
-    printf("-B <num>    Benchmark throughput using <num> bytes and print stats\n");
+    printf("%s", msg[++msgId]);     /* -B */
 #ifdef HAVE_CRL
-    printf("-V          Disable CRL\n");
+    printf("%s", msg[++msgId]);     /* -V */
 #endif
 #ifdef WOLFSSL_TRUST_PEER_CERT
-    printf("-E <file>   Path to load trusted peer cert\n");
+    printf("%s", msg[++msgId]);     /* -E */
 #endif
 #ifdef HAVE_WNR
-    printf("-q <file>   Whitewood config file,      default %s\n", wnrConfig);
+    printf("%s %s\n", msg[++msgId], wnrConfig);  /* -q */
 #endif
-    printf("-g          Return basic HTML web page\n");
-    printf("-C <num>    The number of connections to accept, default: 1\n");
-    printf("-H <arg>    Internal tests [defCipherList, exitWithRet, verifyFail]\n");
+    printf("%s", msg[++msgId]);     /* -g */
+    printf("%s", msg[++msgId]);     /* -C */
+   printf("%s", msg[++msgId]);      /* -H */
 #ifdef WOLFSSL_TLS13
-    printf("-U          Update keys and IVs before sending\n");
-    printf("-K          Key Exchange for PSK not using (EC)DHE\n");
+    printf("%s", msg[++msgId]);     /* -U */
+    printf("%s", msg[++msgId]);     /* -K */
 #ifndef NO_DH
-    printf("-y          Pre-generate Key Share using FFDHE_2048 only\n");
+    printf("%s", msg[++msgId]);     /* -y */
 #endif
 #ifdef HAVE_ECC
-    printf("-Y          Pre-generate Key Share using P-256 only \n");
+    printf("%s", msg[++msgId]);     /* -Y */
 #endif
 #ifdef HAVE_CURVE25519
-    printf("-t          Pre-generate Key share using Curve25519 only\n");
+    printf("%s", msg[++msgId]);     /* -t */
 #endif
 #ifdef HAVE_SESSION_TICKET
-    printf("-T          Do not generate session ticket\n");
+    printf("%s", msg[++msgId]);     /* -T */
 #endif
 #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
-    printf("-Q          Request certificate from client post-handshake\n");
+    printf("%s", msg[++msgId]);     /* -Q */
 #endif
 #ifdef WOLFSSL_SEND_HRR_COOKIE
-    printf("-J          Server sends Cookie Extension containing state\n");
+    printf("%s", msg[++msgId]);     /* -J */
 #endif
 #endif /* WOLFSSL_TLS13 */
 #ifdef WOLFSSL_EARLY_DATA
-    printf("-0          Early data read from client (0-RTT handshake)\n");
+    printf("%s", msg[++msgId]);     /* -0 */
 #endif
 #ifdef WOLFSSL_MULTICAST
-    printf("-3 <grpid>  Multicast, grpid < 256\n");
+    printf("%s", msg[++msgId]);     /* -3 */
 #endif
+    printf("%s", msg[++msgId]);     /* -1 */
 }
 
 THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
@@ -616,12 +819,18 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     useAnyAddr = 1;
 #else
     /* Not Used: h, m, z, F, M, T, V, W, X */
-    while ((ch = mygetopt(argc, argv, "?"
+    while ((ch = mygetopt(argc, argv, "?:"
                 "abc:defgijk:l:nop:q:rstuv:wxy"
                 "A:B:C:D:E:GH:IJKL:NO:PQR:S:TUVYZ:"
-                "03:")) != -1) {
+                "01:3:")) != -1) {
         switch (ch) {
             case '?' :
+                if(myoptarg!=NULL) {
+                    lng_index = atoi(myoptarg);
+                    if(lng_index<0||lng_index>1){
+                        lng_index = 0;
+                    }
+                }
                 Usage();
                 XEXIT_T(EXIT_SUCCESS);
 
@@ -924,7 +1133,12 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 earlyData = 1;
             #endif
                 break;
-
+            case '1' :
+                lng_index = atoi(myoptarg);
+                if(lng_index<0||lng_index>1){
+                    lng_index = 0;
+                }
+                break;
             case '3' :
                 #ifdef WOLFSSL_MULTICAST
                     doMcast = 1;
@@ -1590,7 +1804,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             goto exit;
         }
 
-        showPeer(ssl);
+        showPeerEx(ssl, lng_index);
         if (SSL_state(ssl) != 0) {
             err_sys_ex(runWithErrors, "SSL in error state");
         }

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -513,10 +513,53 @@ static WC_INLINE int PasswordCallBack(char* passwd, int sz, int rw, void* userda
 
 #endif
 
+static const char* client_showpeer_msg[][8] = {
+    /* English */
+    {
+        "SSL version is",
+        "SSL cipher suite is",
+        "SSL curve name is",
+        "SSL DH size is",
+        "SSL reused session",
+        "Alternate cert chain used",
+        "peer's cert info:",
+        NULL
+    },
+    /* Japanese */
+    {
+        "SSL バージョンは",
+        "SSL 暗号スイートは",
+        "SSL 曲線名は",
+        "SSL DH サイズは",
+        "SSL 再利用セッション",
+        "代替証明チェーンを使用",
+        "相手方証明書情報",
+        NULL
+    }
+};
 
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
+static const char* client_showx509_msg[][5] = {
+    /* English */
+    {
+        "issuer",
+        "subject",
+        "altname",
+        "serial number",
+        NULL
+    },
+    /* Japanese */
+    {
+        "発行者",
+        "サブジェクト",
+        "代替名",
+        "シリアル番号",
+        NULL
+    },
+};
 
-static WC_INLINE void ShowX509(WOLFSSL_X509* x509, const char* hdr)
+/* lng_index is to specify the language for displaying message. 0:English, 1:Japanese */
+static WC_INLINE void ShowX509Ex(WOLFSSL_X509* x509, const char* hdr, int lng_index)
 {
     char* altName;
     char* issuer;
@@ -524,21 +567,22 @@ static WC_INLINE void ShowX509(WOLFSSL_X509* x509, const char* hdr)
     byte  serial[32];
     int   ret;
     int   sz = sizeof(serial);
+    const char** words = client_showx509_msg[lng_index];
 
     if (x509 == NULL) {
         printf("%s No Cert\n", hdr);
         return;
     }
-
+    
     issuer  = wolfSSL_X509_NAME_oneline(
                                       wolfSSL_X509_get_issuer_name(x509), 0, 0);
     subject = wolfSSL_X509_NAME_oneline(
                                      wolfSSL_X509_get_subject_name(x509), 0, 0);
 
-    printf("%s\n issuer : %s\n subject: %s\n", hdr, issuer, subject);
+    printf("%s\n %s : %s\n %s: %s\n", hdr, words[0], issuer, words[1], subject);
 
     while ( (altName = wolfSSL_X509_get_next_altname(x509)) != NULL)
-        printf(" altname = %s\n", altName);
+        printf(" %s = %s\n", words[2], altName);
 
     ret = wolfSSL_X509_get_serial_number(x509, serial, &sz);
     if (ret == WOLFSSL_SUCCESS) {
@@ -548,7 +592,7 @@ static WC_INLINE void ShowX509(WOLFSSL_X509* x509, const char* hdr)
 
         /* testsuite has multiple threads writing to stdout, get output
            message ready to write once */
-        strLen = sprintf(serialMsg, " serial number");
+        strLen = sprintf(serialMsg, " %s", words[3]);
         for (i = 0; i < sz; i++)
             sprintf(serialMsg + strLen + (i*3), ":%02x ", serial[i]);
         printf("%s\n", serialMsg);
@@ -581,6 +625,11 @@ static WC_INLINE void ShowX509(WOLFSSL_X509* x509, const char* hdr)
     }
 #endif
 }
+/* original ShowX509 to maintain compatibility */
+static WC_INLINE void ShowX509(WOLFSSL_X509* x509, const char* hdr)
+{
+    ShowX509Ex(x509, hdr, 0);
+}
 
 #endif /* KEEP_PEER_CERT || SESSION_CERTS */
 
@@ -608,9 +657,12 @@ static WC_INLINE void ShowX509Chain(WOLFSSL_X509_CHAIN* chain, int count,
 }
 #endif
 
-static WC_INLINE void showPeer(WOLFSSL* ssl)
+/* lng_index is to specify the language for displaying message. 0:English, 1:Japanese */
+static WC_INLINE void showPeerEx(WOLFSSL* ssl, int lng_index)
 {
     WOLFSSL_CIPHER* cipher;
+    const char** words = client_showpeer_msg[lng_index];
+
 #ifdef HAVE_ECC
     const char *name;
 #endif
@@ -620,7 +672,7 @@ static WC_INLINE void showPeer(WOLFSSL* ssl)
 #ifdef KEEP_PEER_CERT
     WOLFSSL_X509* peer = wolfSSL_get_peer_certificate(ssl);
     if (peer)
-        ShowX509(peer, "peer's cert info:");
+        ShowX509Ex(peer, words[6], lng_index);
     else
         printf("peer has no cert!\n");
     wolfSSL_FreeX509(peer);
@@ -629,28 +681,28 @@ static WC_INLINE void showPeer(WOLFSSL* ssl)
     ShowX509(wolfSSL_get_certificate(ssl), "our cert info:");
     printf("Peer verify result = %lu\n", wolfSSL_get_verify_result(ssl));
 #endif /* SHOW_CERTS */
-    printf("SSL version is %s\n", wolfSSL_get_version(ssl));
+    printf("%s %s\n", words[0], wolfSSL_get_version(ssl));
 
     cipher = wolfSSL_get_current_cipher(ssl);
 #ifdef HAVE_QSH
-    printf("SSL cipher suite is %s%s\n", (wolfSSL_isQSH(ssl))? "QSH:": "",
+    printf("%s %s%s\n", words[1], (wolfSSL_isQSH(ssl))? "QSH:": "",
             wolfSSL_CIPHER_get_name(cipher));
 #else
-    printf("SSL cipher suite is %s\n", wolfSSL_CIPHER_get_name(cipher));
+    printf("%s %s\n", words[1], wolfSSL_CIPHER_get_name(cipher));
 #endif
 #ifdef HAVE_ECC
     if ((name = wolfSSL_get_curve_name(ssl)) != NULL)
-        printf("SSL curve name is %s\n", name);
+        printf("%s %s\n", words[2], name);
 #endif
 #ifndef NO_DH
     if ((bits = wolfSSL_GetDhKey_Sz(ssl)) > 0)
-        printf("SSL DH size is %d bits\n", bits);
+        printf("%s %d bits\n", words[3], bits);
 #endif
     if (wolfSSL_session_reused(ssl))
-        printf("SSL reused session\n");
+        printf("%s\n", words[4]);
 #ifdef WOLFSSL_ALT_CERT_CHAINS
     if (wolfSSL_is_peer_alt_cert_chain(ssl))
-        printf("Alternate cert chain used\n");
+        printf("%s\n", words[5]);
 #endif
 
 #if defined(SESSION_CERTS) && defined(SHOW_CERTS)
@@ -670,7 +722,11 @@ static WC_INLINE void showPeer(WOLFSSL* ssl)
 #endif /* SESSION_CERTS && SHOW_CERTS */
   (void)ssl;
 }
-
+/* original showPeer to maintain compatibility */
+static WC_INLINE void showPeer(WOLFSSL* ssl)
+{
+    showPeerEx(ssl, 0);
+}
 
 static WC_INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
                               word16 port, int udp, int sctp)


### PR DESCRIPTION
Added an option switch to benchmark program:
-1 Display benchmark result by specified language.
0: English, 1: Japanese

This can switch a result message to English or Japanese. In addition to that, usage message(-? option) can be switch to English or Japanese when it is specified by 0 or 1.