### PR TITLE
Fix for ephemeral key size selection

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -4021,7 +4021,8 @@ int TLSX_ValidateSupportedCurves(WOLFSSL* ssl, byte first, byte second) {
             defSz = octets;
         }
 
-        if (currOid == 0 && ssl->eccTempKeySz <= octets)
+        /* The eccTempKeySz is the preferred ephemeral key size */
+        if (currOid == 0 && ssl->eccTempKeySz == octets)
             currOid = oid;
         if ((nextOid == 0 || nextSz > octets) && ssl->eccTempKeySz <= octets) {
             nextOid = oid;


### PR DESCRIPTION
Revert change from PR #1845 commit 24f9f1284494b85882c759b2f637ae72f5a943eb. This ensure the ephemeral key is P-256 or the overridden value determined by `wolfSSL_CTX_SetTmpEC_DHE_Sz` and `wolfSSL_SetTmpEC_DHE_Sz`. This restores previous behavior from last release.