### PR TITLE
Fixes for key size detection when using PK callbacks

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1433,6 +1433,17 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 #endif
     }
 
+
+#ifdef HAVE_ECC
+    /* Use ECDHE key size that matches long term key.
+     * Zero means use ctx->privateKeySz.
+     * Default ECDHE_SIZE is 32 bytes
+     */
+    if (wolfSSL_CTX_SetTmpEC_DHE_Sz(ctx, 0) != WOLFSSL_SUCCESS){
+        err_sys_ex(runWithErrors, "Error setting ECDHE size");
+    }
+#endif
+
     if (useAnon) {
 #ifdef HAVE_ANON
         wolfSSL_CTX_allow_anon_cipher(ctx);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3438,22 +3438,20 @@ exit_dc:
 #ifndef NO_RSA
 
 #ifndef HAVE_USER_RSA
-int wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
-                       word32 inSz)
+int wc_RsaPublicKeyDecode_ex(const byte* input, word32* inOutIdx, word32 inSz,
+    const byte** n, word32* nSz, const byte** e, word32* eSz)
 {
-    int  length;
+    int ret = 0;
+    int length;
 #if defined(OPENSSL_EXTRA) || defined(RSA_DECODE_EXTRA)
     byte b;
 #endif
-    int ret;
 
-    if (input == NULL || inOutIdx == NULL || key == NULL)
+    if (input == NULL || inOutIdx == NULL)
         return BAD_FUNC_ARG;
 
     if (GetSequence(input, inOutIdx, &length, inSz) < 0)
         return ASN_PARSE_E;
-
-    key->type = RSA_PUBLIC;
 
 #if defined(OPENSSL_EXTRA) || defined(RSA_DECODE_EXTRA)
     if ((*inOutIdx + 1) > inSz)
@@ -3488,20 +3486,47 @@ int wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
     }
 #endif /* OPENSSL_EXTRA */
 
-    if (GetInt(&key->n,  input, inOutIdx, inSz) < 0)
-        return ASN_RSA_KEY_E;
-    if (GetInt(&key->e,  input, inOutIdx, inSz) < 0) {
-        mp_clear(&key->n);
+    /* Get modulus */
+    ret = GetASNInt(input, inOutIdx, &length, inSz);
+    if (ret < 0) {
         return ASN_RSA_KEY_E;
     }
+    if (nSz)
+        *nSz = length;
+    if (n)
+        *n = &input[*inOutIdx];
+    *inOutIdx += length;
 
-#ifdef WOLFSSL_XILINX_CRYPT
-    if (wc_InitRsaHw(key) != 0) {
-        return BAD_STATE_E;
+    /* Get exponent */
+    ret = GetASNInt(input, inOutIdx, &length, inSz);
+    if (ret < 0) {
+        return ASN_RSA_KEY_E;
     }
-#endif
+    if (eSz)
+        *eSz = length;
+    if (e)
+        *e = &input[*inOutIdx];
+    *inOutIdx += length;
 
-    return 0;
+    return ret;
+}
+
+int wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
+                       word32 inSz)
+{
+    int ret;
+    const byte *n = NULL, *e = NULL;
+    word32 nSz = 0, eSz = 0;
+
+    if (key == NULL)
+        return BAD_FUNC_ARG;
+
+    ret = wc_RsaPublicKeyDecode_ex(input, inOutIdx, inSz, &n, &nSz, &e, &eSz);
+    if (ret == 0) {
+        ret = wc_RsaPublicKeyDecodeRaw(n, nSz, e, eSz, key);
+    }
+
+    return ret;
 }
 
 /* import RSA public key elements (n, e) into RsaKey structure (key) */
@@ -3554,7 +3579,7 @@ int wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz, const byte* e,
     return 0;
 }
 #endif /* HAVE_USER_RSA */
-#endif
+#endif /* !NO_RSA */
 
 #ifndef NO_DH
 
@@ -4114,7 +4139,7 @@ WOLFSSL_LOCAL int OBJ_sn2nid(const char *sn)
         }
     }
     #endif
-    
+
     for(i=0; sn2nid[i].sn != NULL; i++) {
         if(XSTRNCMP(sn, sn2nid[i].sn, XSTRLEN(sn2nid[i].sn)) == 0) {
             return sn2nid[i].nid;
@@ -9119,7 +9144,6 @@ int RsaPublicKeyDerSize(RsaKey* key, int with_header)
 
 #if defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA) && !defined(HAVE_USER_RSA)
 
-
 static mp_int* GetRsaInt(RsaKey* key, int idx)
 {
     if (idx == 0)
@@ -9235,7 +9259,7 @@ int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen)
     return SetRsaPublicKey(output, key, inLen, 1);
 }
 
-#endif /* WOLFSSL_KEY_GEN && !NO_RSA && !HAVE_USER_RSA */
+#endif /* (WOLFSSL_KEY_GEN || OPENSSL_EXTRA) && !NO_RSA && !HAVE_USER_RSA */
 
 
 #ifdef WOLFSSL_CERT_GEN
@@ -9367,6 +9391,7 @@ static word32 SetUTF8String(word32 len, byte* output)
 #endif /* WOLFSSL_CERT_REQ */
 
 #endif /* WOLFSSL_CERT_GEN */
+
 
 #if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT)
 
@@ -11983,7 +12008,7 @@ int wc_SetAuthKeyId(Cert *cert, const char* file)
     return ret;
 }
 
-#endif /* NO_FILESYSTEM */
+#endif /* !NO_FILESYSTEM */
 
 /* Set KeyUsage from human readable string */
 int wc_SetKeyUsage(Cert *cert, const char *value)
@@ -12576,7 +12601,7 @@ int wc_SetAltNames(Cert* cert, const char* file)
 
 #endif /* WOLFSSL_ALT_NAMES */
 
-#endif /* NO_FILESYSTEM */
+#endif /* !NO_FILESYSTEM */
 
 /* Set cert issuer from DER buffer */
 int wc_SetIssuerBuffer(Cert* cert, const byte* der, int derSz)
@@ -12871,7 +12896,7 @@ static int ASNToHexString(const byte* input, word32* inOutIdx, char** out,
 
     return 0;
 }
-#endif
+#endif /* WOLFSSL_CUSTOM_CURVES */
 
 int wc_EccPublicKeyDecode(const byte* input, word32* inOutIdx,
                           ecc_key* key, word32 inSz)
@@ -13003,7 +13028,7 @@ int wc_EccPublicKeyDecode(const byte* input, word32* inOutIdx,
             return ret;
 #else
         return ASN_PARSE_E;
-#endif
+#endif /* WOLFSSL_CUSTOM_CURVES */
     }
     else {
         /* ecc params information */
@@ -13151,7 +13176,6 @@ static int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 inLen,
     return totalSz;
 }
 
-#ifndef NO_ASN_CRYPT
 /* Write a Private ecc key, including public to DER format,
  * length on success else < 0 */
 int wc_EccKeyToDer(ecc_key* key, byte* output, word32 inLen)
@@ -13166,7 +13190,6 @@ int wc_EccPrivateKeyToDer(ecc_key* key, byte* output, word32 inLen)
 {
     return wc_BuildEccKeyDer(key, output, inLen, 0);
 }
-#endif /* !NO_ASN_CRYPT */
 
 /* Write only private ecc key to unencrypted PKCS#8 format.
  *
@@ -13237,8 +13260,8 @@ int wc_EccPrivateKeyToPKCS8(ecc_key* key, byte* output, word32* outLen)
     return ret;
 }
 
-#endif /* HAVE_ECC_KEY_EXPORT */
-#endif  /* HAVE_ECC */
+#endif /* HAVE_ECC_KEY_EXPORT && !NO_ASN_CRYPT */
+#endif /* HAVE_ECC */
 
 
 #ifdef HAVE_ED25519
@@ -13415,7 +13438,7 @@ int wc_Ed25519PrivateKeyToDer(ed25519_key* key, byte* output, word32 inLen)
 
 #endif /* WOLFSSL_KEY_GEN */
 
-#endif  /* HAVE_ED25519 */
+#endif /* HAVE_ED25519 */
 
 
 #if defined(HAVE_OCSP) || defined(HAVE_CRL)
@@ -13438,7 +13461,7 @@ static int GetBasicDate(const byte* source, word32* idx, byte* date,
     return 0;
 }
 
-#endif
+#endif /* HAVE_OCSP || HAVE_CRL */
 
 
 #ifdef HAVE_OCSP
@@ -14196,7 +14219,7 @@ int CompareOcspReqResp(OcspRequest* req, OcspResponse* resp)
     return 0;
 }
 
-#endif
+#endif /* HAVE_OCSP */
 
 
 /* store WC_SHA hash of NAME */

--- a/wolfcrypt/user-crypto/include/user_rsa.h
+++ b/wolfcrypt/user-crypto/include/user_rsa.h
@@ -100,6 +100,8 @@ WOLFSSL_API int  wc_RsaEncryptSize(RsaKey* key);
 
 WOLFSSL_API int  wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
                                                                RsaKey*, word32);
+WOLFSSL_API int  wc_RsaPublicKeyDecode_ex(const byte* input, word32* inOutIdx,
+        word32 inSz, const byte** n, word32* nSz, const byte** e, word32* eSz);
 WOLFSSL_API int  wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx,
                                                                RsaKey*, word32);
 WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
@@ -133,5 +135,3 @@ WOLFSSL_API int  wc_RsaSetRNG(RsaKey* key, WC_RNG* rng);
 
 #endif /* NO_RSA */
 #endif /* USER_WOLF_CRYPT_RSA_H */
-
-

--- a/wolfcrypt/user-crypto/src/rsa.c
+++ b/wolfcrypt/user-crypto/src/rsa.c
@@ -1095,7 +1095,6 @@ int wc_RsaPublicKeyDecode_ex(const byte* input, word32* inOutIdx,
 {
     IppStatus ret = 0;
     int length;
-    int keySz = 0;
 #if defined(OPENSSL_EXTRA) || defined(RSA_DECODE_EXTRA)
     byte b;
 #endif

--- a/wolfcrypt/user-crypto/src/rsa.c
+++ b/wolfcrypt/user-crypto/src/rsa.c
@@ -833,32 +833,61 @@ static int GetLength(const byte* input, word32* inOutIdx, int* len,
     return length;
 }
 
+static int GetASNHeader(const byte* input, byte tag, word32* inOutIdx, int* len,
+                        word32 maxIdx)
+{
+    word32 idx = *inOutIdx;
+    byte   b;
+    int    length;
+
+    if ((idx + 1) > maxIdx)
+        return USER_CRYPTO_ERROR;
+
+    b = input[idx++];
+    if (b != tag)
+        return USER_CRYPTO_ERROR;
+
+    if (GetLength(input, &idx, &length, maxIdx) < 0)
+        return USER_CRYPTO_ERROR;
+
+    *len      = length;
+    *inOutIdx = idx;
+    return length;
+}
+
+static int GetASNInt(const byte* input, word32* inOutIdx, int* len,
+                     word32 maxIdx)
+{
+    int    ret;
+
+    ret = GetASNHeader(input, ASN_INTEGER, inOutIdx, len, maxIdx);
+    if (ret < 0)
+        return ret;
+
+    if (*len > 0) {
+        /* remove leading zero, unless there is only one 0x00 byte */
+        if ((input[*inOutIdx] == 0x00) && (*len > 1)) {
+            (*inOutIdx)++;
+            (*len)--;
+
+            if (*len > 0 && (input[*inOutIdx] & 0x80) == 0)
+                return USER_CRYPTO_ERROR;
+        }
+    }
+
+    return 0;
+}
 
 static int GetInt(IppsBigNumState** mpi, const byte* input, word32* inOutIdx,
                   word32 maxIdx)
 {
     IppStatus ret;
     word32 idx = *inOutIdx;
-    byte   b;
     int    length;
     int    ctxSz;
 
-    if ((idx + 1) > maxIdx)
+    if (GetASNInt(input, &idx, &length, maxIdx) < 0) {
         return USER_CRYPTO_ERROR;
-
-    b = input[idx++];
-    if (b != 0x02)
-        return USER_CRYPTO_ERROR;
-
-    if (GetLength(input, &idx, &length, maxIdx) < 0)
-        return USER_CRYPTO_ERROR;
-
-    if (length > 0) {
-        /* remove leading zero */
-        if ( (b = input[idx++]) == 0x00)
-            length--;
-        else
-            idx--;
     }
 
     ret = ippsBigNumGetSize(length, &ctxSz);
@@ -1061,27 +1090,24 @@ int wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
 }
 
 
-/* read in a public RSA key */
-int wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
-                       word32 inSz)
+int wc_RsaPublicKeyDecode_ex(const byte* input, word32* inOutIdx,
+        word32 inSz, const byte** n, word32* nSz, const byte** e, word32* eSz)
 {
-    int  length;
-    int  ctxSz;
-    IppStatus ret;
+    IppStatus ret = 0;
+    int length;
+    int keySz = 0;
 #if defined(OPENSSL_EXTRA) || defined(RSA_DECODE_EXTRA)
     byte b;
 #endif
 
-    if (input == NULL || inOutIdx == NULL || key == NULL) {
+    if (input == NULL || inOutIdx == NULL) {
         return USER_CRYPTO_ERROR;
     }
 
-    USER_DEBUG(("Entering wc_RsaPublicKeyDecode\n"));
+    USER_DEBUG(("Entering wc_RsaPublicKeyDecode_ex\n"));
 
     if (GetSequence(input, inOutIdx, &length, inSz) < 0)
         return USER_CRYPTO_ERROR;
-
-    key->type = RSA_PUBLIC;
 
 #if defined(OPENSSL_EXTRA) || defined(RSA_DECODE_EXTRA)
     if ((*inOutIdx + 1) > inSz)
@@ -1133,62 +1159,55 @@ int wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
     }
 #endif /* OPENSSL_EXTRA || RSA_DECODE_EXTRA */
 
-    if (GetInt(&key->n,  input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->e,  input, inOutIdx, inSz) < 0) {
+    /* Get modulus */
+    ret = GetASNInt(input, inOutIdx, &length, inSz);
+    if (ret < 0) {
         return USER_CRYPTO_ERROR;
     }
+    if (nSz)
+        *nSz = length;
+    if (n)
+        *n = &input[*inOutIdx];
+    *inOutIdx += length;
 
-    /* get sizes set for IPP BN states */
-    ret = ippsGetSize_BN(key->n, &key->nSz);
-    if (ret != ippStsNoErr) {
-        USER_DEBUG(("ippsGetSize_BN error %s\n", ippGetStatusString(ret)));
+    /* Get exponent */
+    ret = GetASNInt(input, inOutIdx, &length, inSz);
+    if (ret < 0) {
         return USER_CRYPTO_ERROR;
     }
+    if (eSz)
+        *eSz = length;
+    if (e)
+        *e = &input[*inOutIdx];
+    *inOutIdx += length;
 
-    ret = ippsGetSize_BN(key->e, &key->eSz);
-    if (ret != ippStsNoErr) {
-        USER_DEBUG(("ippsGetSize_BN error %s\n", ippGetStatusString(ret)));
-        return USER_CRYPTO_ERROR;
-    }
+    USER_DEBUG(("\tExit wc_RsaPublicKeyDecode_ex\n"));
 
-    key->sz = key->nSz; /* set modulus size */
+    return ret;
+}
 
-    /* convert to size in bits */
-    key->nSz = key->nSz * 8;
-    key->eSz = key->eSz * 8;
+/* read in a public RSA key */
+int wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
+                       word32 inSz)
+{
+    IppStatus ret;
+    const byte *n = NULL, *e = NULL;
+    word32 nSz = 0, eSz = 0;
 
-    /* set up public key state */
-    ret = ippsRSA_GetSizePublicKey(key->nSz, key->eSz, &ctxSz);
-    if (ret != ippStsNoErr) {
-        USER_DEBUG(("ippsRSA_GetSizePublicKey error %s\n",
-                ippGetStatusString(ret)));
-        return USER_CRYPTO_ERROR;
-    }
-
-    key->pPub = (IppsRSAPublicKeyState*)XMALLOC(ctxSz, NULL,
-                                                      DYNAMIC_TYPE_USER_CRYPTO);
-    if (key->pPub == NULL)
+    if (key == NULL)
         return USER_CRYPTO_ERROR;
 
-    ret = ippsRSA_InitPublicKey(key->nSz, key->eSz, key->pPub, ctxSz);
-    if (ret != ippStsNoErr) {
-        USER_DEBUG(("ippsRSA_InitPublicKey error %s\n",
-                    ippGetStatusString(ret)));
-        return USER_CRYPTO_ERROR;
-    }
+    USER_DEBUG(("Entering wc_RsaPublicKeyDecode\n"));
 
-    ret = ippsRSA_SetPublicKey(key->n, key->e, key->pPub);
-    if (ret != ippStsNoErr) {
-        USER_DEBUG(("ippsRSA_SetPublicKey error %s\n",
-                    ippGetStatusString(ret)));
-        return USER_CRYPTO_ERROR;
+    ret = wc_RsaPublicKeyDecode_ex(input, inOutIdx, inSz, &n, &nSz, &e, &eSz);
+    if (ret == 0) {
+        ret = wc_RsaPublicKeyDecodeRaw(n, nSz, e, eSz, key);
     }
 
     USER_DEBUG(("\tExit RsaPublicKeyDecode\n"));
 
-    return 0;
+    return ret;
 }
-
 
 /* import RSA public key elements (n, e) into RsaKey structure (key) */
 int wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz, const byte* e,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1323,7 +1323,9 @@ enum Misc {
 
     EVP_SALT_SIZE       =  8,  /* evp salt size 64 bits   */
 
+#ifndef ECDHE_SIZE /* allow this to be overriden at compile-time */
     ECDHE_SIZE          = 32,  /* ECHDE server size defaults to 256 bit */
+#endif
     MAX_EXPORT_ECC_SZ   = 256, /* Export ANS X9.62 max future size */
     MAX_CURVE_NAME_SZ   = 16,  /* Maximum size of curve name string */
 

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -417,6 +417,11 @@ WOLFSSL_API void wc_FreeDer(DerBuffer** pDer);
                                 word32 outputSz, byte *cipherIno, int type);
 #endif
 
+#if !defined(NO_RSA) && !defined(HAVE_USER_RSA)
+    WOLFSSL_API int wc_RsaPublicKeyDecode_ex(const byte* input, word32* inOutIdx,
+        word32 inSz, const byte** n, word32* nSz, const byte** e, word32* eSz);
+#endif
+
 #ifdef HAVE_ECC
     /* private key helpers */
     WOLFSSL_API int wc_EccPrivateKeyDecode(const byte*, word32*,


### PR DESCRIPTION
* Fixes for key size detection when using PK callbacks (HSM) and no private key has been loaded (affects `HAVE_PK_CALLBACKS` on server side only when no dummy private key is loaded).
* Fix for possible leak during ECC min key size failure with small stack.
* Added new API `wc_RsaPublicKeyDecode_ex` for parsing an RSA public key for the modulus and exponent.
* Changed `wolfSSL_CTX_SetTmpEC_DHE_Sz` to support a `size == 0` for using the long-term private key's size.
* Changed `ECDHE_SIZE` so it can be overridden and build-time.
* Added tests for `wolfSSL_CTX_SetTmpEC_DHE_Sz` and `wolfSSL_SetTmpEC_DHE_Sz`.
* Added optional logging for example PK callbacks in test.h enabled with `DEBUG_PK_CB`.