### PR TITLE
include wolfssl/options.h in settings.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4482,7 +4482,7 @@ fi
 # Expose HAVE___UINT128_T to options flags"
 if test "$ac_cv_type___uint128_t" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DHAVE___UINT128_T"
+    AM_CFLAGS="$AM_CFLAGS -DHAVE___UINT128_T=1"
 fi
 
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -27,6 +27,8 @@
 #ifndef WOLF_CRYPT_SETTINGS_H
 #define WOLF_CRYPT_SETTINGS_H
 
+#include <wolfssl/options.h>
+
 #ifdef __cplusplus
     extern "C" {
 #endif


### PR DESCRIPTION
include wolfssl/options.h in wolfssl/wolfcrypt/settings.h

Doing so provides better openssl compatibility, since applications will
not have to special-case #include <wolfssl/options.h> in application
code when built with WolfSSL openssl compatibility layer.

Since config.h does not have include guards, define HAVE___UINT128_T 1
so that wolfssl/options.h definition does not conflict with config.h

x-ref: https://github.com/lighttpd/lighttpd1.4/pull/92