### PR TITLE
Handle incomplete shutdown

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2563,6 +2563,9 @@ int wolfSSL_shutdown(WOLFSSL* ssl)
             } else if (ssl->options.closeNotify) {
                 ssl->error = WOLFSSL_ERROR_SYSCALL;   /* simulate OpenSSL behavior */
                 ret = WOLFSSL_SUCCESS;
+            } else if ((ssl->error == WOLFSSL_ERROR_NONE) &&
+                       (ret < WOLFSSL_SUCCESS)) {
+                ret = WOLFSSL_SHUTDOWN_NOT_DONE;
             }
         }
     }


### PR DESCRIPTION
In the case of a bidirectional shutdown, if the call to `wolfSSL_read` should return zero (bytes read) and there was not an error indicated by `ssl->error`, then shutdown has not completed and the return status should be `WOLFSSL_SHUTDOWN_NOT_DONE`.