### PR TITLE
Fix expression-must-have-constant-value error in IAR-EWARM

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -3856,8 +3856,8 @@ static void bench_rsa_helper(int doAsync, RsaKey rsaKey[BENCH_MAX_PENDING],
     const char**desc = bench_desc_words[lng_index];
 
     DECLARE_VAR_INIT(message, byte, len, messageStr, HEAP_HINT);
-    DECLARE_ARRAY(enc, byte, BENCH_MAX_PENDING, rsaKeySz/8, HEAP_HINT);
-    DECLARE_ARRAY(out, byte, BENCH_MAX_PENDING, rsaKeySz/8, HEAP_HINT);
+    DECLARE_DYNAMIC_ARRAY(enc, byte, BENCH_MAX_PENDING, rsaKeySz/8, HEAP_HINT);
+    DECLARE_DYNAMIC_ARRAY(out, byte, BENCH_MAX_PENDING, rsaKeySz/8, HEAP_HINT);
 
     if (!rsa_sign_verify) {
         /* begin public RSA */
@@ -3980,8 +3980,8 @@ exit_rsa_verify:
                                                                     start, ret);
     }
 
-    FREE_ARRAY(enc, BENCH_MAX_PENDING, HEAP_HINT);
-    FREE_ARRAY(out, BENCH_MAX_PENDING, HEAP_HINT);
+    FREE_DYNAMIC_ARRAY(enc, BENCH_MAX_PENDING, HEAP_HINT);
+    FREE_DYNAMIC_ARRAY(out, BENCH_MAX_PENDING, HEAP_HINT);
     FREE_VAR(message, HEAP_HINT);
 }
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -314,6 +314,17 @@
         #define FREE_ARRAY(VAR_NAME, VAR_ITEMS, HEAP)  /* nothing to free, its stack */
     #endif
 
+    #define DECLARE_DYNAMIC_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
+        VAR_TYPE* VAR_NAME[VAR_ITEMS]; \
+        int idx##VAR_NAME; \
+        for (idx##VAR_NAME=0; idx##VAR_NAME<VAR_ITEMS; idx##VAR_NAME++) { \
+            VAR_NAME[idx##VAR_NAME] = (VAR_TYPE*)XMALLOC(VAR_SIZE, (HEAP), DYNAMIC_TYPE_WOLF_BIGINT); \
+        }
+    #define FREE_DYNAMIC_ARRAY(VAR_NAME, VAR_ITEMS, HEAP) \
+        for (idx##VAR_NAME=0; idx##VAR_NAME<VAR_ITEMS; idx##VAR_NAME++) { \
+            XFREE(VAR_NAME[idx##VAR_NAME], (HEAP), DYNAMIC_TYPE_WOLF_BIGINT); \
+        }
+
     #if !defined(USE_WOLF_STRTOK) && \
             ((defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)) || \
              defined(WOLFSSL_TIRTOS) || defined(WOLF_C99))


### PR DESCRIPTION
DECLARE_ARRAY is a macro that dynamically allocates memory if WOLFSSL_ASYNC_CRYPT is defined or creates an array as "VAR_TYPE VAR_NAME[VAR_ITEMS][VAR_SIZE] ".

rsaKeySz isn't constant in bench_rsa where it is then passed into bench_rsa_helper where DECLARE_ARRAY is called.

A possible problem is if there is a mismatch between RSA_KEY_SZ with rsaKeySz.  These are checked to see if they're equal.