### PR TITLE
wolfSSL Async Release v3.15.5 Fixes

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1310,7 +1310,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     int   doSTARTTLS    = 0;
     char* starttlsProt = NULL;
     int   useVerifyCb = 0;
+#ifdef HAVE_ECC
     int   useSupCurve = 0;
+#endif
 
 #ifdef WOLFSSL_TRUST_PEER_CERT
     const char* trustCert  = NULL;
@@ -1410,7 +1412,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     (void)useX25519;
     (void)helloRetry;
     (void)onlyKeyShare;
+#ifdef HAVE_ECC
     (void)useSupCurve;
+#endif
     (void)loadCertKeyIntoSSLObj;
 
     StackTrap();
@@ -1557,10 +1561,12 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                     printf("Verify should fail\n");
                     myVerifyFail = 1;
                 }
+            #ifdef HAVE_ECC
                 else if (XSTRNCMP(myoptarg, "useSupCurve", 11) == 0) {
                     printf("Test use supported curve\n");
                     useSupCurve = 1;
                 }
+            #endif
                 else if (XSTRNCMP(myoptarg, "loadSSL", 7) == 0) {
                     printf("Load cert/key into wolfSSL object\n");
                     loadCertKeyIntoSSLObj = 1;
@@ -1785,9 +1791,11 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             case 't' :
                 #ifdef HAVE_CURVE25519
                     useX25519 = 1;
+                    #ifdef HAVE_ECC
                     useSupCurve = 1;
-                    #if defined(WOLFSSL_TLS13) && defined(HAVE_ECC)
+                        #ifdef WOLFSSL_TLS13
                         onlyKeyShare = 2;
+                        #endif
                     #endif
                 #endif
                 break;

--- a/src/internal.c
+++ b/src/internal.c
@@ -1980,7 +1980,7 @@ void InitSuites(Suites* suites, ProtocolVersion pv, int keySz, word16 haveRSA,
 
 #ifndef WOLFSSL_NO_TLS12
 
-#ifndef NO_WOLFSSL_SERVER
+#if !defined(NO_WOLFSSL_SERVER) && !defined(NO_RSA)
     if (side == WOLFSSL_SERVER_END && haveStaticECC) {
         haveRSA = 0;   /* can't do RSA with ECDSA key */
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -13179,6 +13179,9 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             ctx->lastUsed = 0;
             ctx->flags   = 0;
         }
+
+        XMEMSET(&ctx->cipher, 0, sizeof(ctx->cipher));
+
 #ifndef NO_AES
     #ifdef HAVE_AES_CBC
         #ifdef WOLFSSL_AES_128
@@ -14251,6 +14254,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         XMEMCPY(&key[DES_BLOCK_SIZE * 2], *ks3, DES_BLOCK_SIZE);
         lb_sz = sz%DES_BLOCK_SIZE;
         blk   = sz/DES_BLOCK_SIZE;
+
+        /* OpenSSL compat, no ret */
+        wc_Des3Init(&des, NULL, INVALID_DEVID);
+
         if (enc) {
             wc_Des3_SetKey(&des, key, (const byte*)ivec, DES_ENCRYPTION);
             wc_Des3_CbcEncrypt(&des, output, input, (word32)blk*DES_BLOCK_SIZE);
@@ -14269,6 +14276,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                 XMEMCPY(output+sz-lb_sz, lastblock, lb_sz);
             }
         }
+        wc_Des3Free(&des);
     }
 
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -9008,22 +9008,24 @@ int wc_Gmac(const byte* key, word32 keySz, byte* iv, word32 ivSz,
             byte* authTag, word32 authTagSz, WC_RNG* rng)
 {
     Aes aes;
-    int ret = 0;
+    int ret;
 
     if (key == NULL || iv == NULL || (authIn == NULL && authInSz != 0) ||
         authTag == NULL || authTagSz == 0 || rng == NULL) {
 
-        ret = BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
     }
 
-    if (ret == 0)
+    ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+    if (ret == 0) {
         ret = wc_AesGcmSetKey(&aes, key, keySz);
-    if (ret == 0)
-        ret = wc_AesGcmSetIV(&aes, ivSz, NULL, 0, rng);
-    if (ret == 0)
-        ret = wc_AesGcmEncrypt_ex(&aes, NULL, NULL, 0, iv, ivSz,
+        if (ret == 0)
+            ret = wc_AesGcmSetIV(&aes, ivSz, NULL, 0, rng);
+        if (ret == 0)
+            ret = wc_AesGcmEncrypt_ex(&aes, NULL, NULL, 0, iv, ivSz,
                                   authTag, authTagSz, authIn, authInSz);
-    wc_AesFree(&aes);
+        wc_AesFree(&aes);
+    }
     ForceZero(&aes, sizeof(aes));
 
     return ret;
@@ -9035,20 +9037,22 @@ int wc_GmacVerify(const byte* key, word32 keySz,
                   const byte* authTag, word32 authTagSz)
 {
     Aes aes;
-    int ret = 0;
+    int ret;
 
     if (key == NULL || iv == NULL || (authIn == NULL && authInSz != 0) ||
         authTag == NULL || authTagSz == 0 || authTagSz > AES_BLOCK_SIZE) {
 
-        ret = BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
     }
 
-    if (ret == 0)
+    ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+    if (ret == 0) {
         ret = wc_AesGcmSetKey(&aes, key, keySz);
-    if (ret == 0)
-        ret = wc_AesGcmDecrypt(&aes, NULL, NULL, 0, iv, ivSz,
+        if (ret == 0)
+            ret = wc_AesGcmDecrypt(&aes, NULL, NULL, 0, iv, ivSz,
                                   authTag, authTagSz, authIn, authInSz);
-    wc_AesFree(&aes);
+        wc_AesFree(&aes);
+    }
     ForceZero(&aes, sizeof(aes));
 
     return ret;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -8876,14 +8876,21 @@ int wc_ecc_encrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
            case ecAES_128_CBC:
                {
                    Aes aes;
-                   ret = wc_AesSetKey(&aes, encKey, KEY_SIZE_128, encIv,
+                   ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+                   if (ret == 0) {
+                       ret = wc_AesSetKey(&aes, encKey, KEY_SIZE_128, encIv,
                                                                 AES_ENCRYPTION);
+                       if (ret == 0) {
+                           ret = wc_AesCbcEncrypt(&aes, out, msg, msgSz);
+                       #if defined(WOLFSSL_ASYNC_CRYPT)
+                           ret = wc_AsyncWait(ret, &aes.asyncDev,
+                                              WC_ASYNC_FLAG_NONE);
+                       #endif
+                       }
+                       wc_AesFree(&aes);
+                   }
                    if (ret != 0)
-                       break;
-                   ret = wc_AesCbcEncrypt(&aes, out, msg, msgSz);
-                #if defined(WOLFSSL_ASYNC_CRYPT)
-                   ret = wc_AsyncWait(ret, &aes.asyncDev, WC_ASYNC_FLAG_NONE);
-                #endif
+                      break;
                }
                break;
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5165,10 +5165,10 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
     r = key->r;
     s = key->s;
 #else
-#ifndef WOLFSSL_SMALL_STACK
+    #ifndef WOLFSSL_SMALL_STACK
     r = r_lcl;
     s = s_lcl;
-#else
+    #else
     r = (mp_int*)XMALLOC(sizeof(mp_int), key->heap, DYNAMIC_TYPE_ECC);
     if (r == NULL)
         return MEMORY_E;
@@ -5177,8 +5177,10 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
         XFREE(r, key->heap, DYNAMIC_TYPE_ECC);
         return MEMORY_E;
     }
-#endif
-#endif
+    #endif
+    XMEMSET(r, 0, sizeof(mp_int));
+    XMEMSET(s, 0, sizeof(mp_int));
+#endif /* WOLFSSL_ASYNC_CRYPT */
 
     switch(key->state) {
         case ECC_STATE_NONE:

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -5525,10 +5525,13 @@ static int wc_PKCS7_EncryptContent(int encryptOID, byte* key, int keySz,
                     (ivSz  != AES_BLOCK_SIZE) )
                 return BAD_FUNC_ARG;
 
-            ret = wc_AesSetKey(&aes, key, keySz, iv, AES_ENCRYPTION);
-            if (ret == 0)
-                ret = wc_AesCbcEncrypt(&aes, out, in, inSz);
-
+            ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+            if (ret == 0) {
+                ret = wc_AesSetKey(&aes, key, keySz, iv, AES_ENCRYPTION);
+                if (ret == 0)
+                    ret = wc_AesCbcEncrypt(&aes, out, in, inSz);
+                wc_AesFree(&aes);
+            }
             break;
     #ifdef HAVE_AESGCM
         #ifdef WOLFSSL_AES_128
@@ -5545,10 +5548,14 @@ static int wc_PKCS7_EncryptContent(int encryptOID, byte* key, int keySz,
             if (authTag == NULL)
                 return BAD_FUNC_ARG;
 
-            ret = wc_AesGcmSetKey(&aes, key, keySz);
-            if (ret == 0)
-                ret = wc_AesGcmEncrypt(&aes, out, in, inSz, iv, ivSz,
-                                       authTag, authTagSz, aad, aadSz);
+            ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+            if (ret == 0) {
+                ret = wc_AesGcmSetKey(&aes, key, keySz);
+                if (ret == 0)
+                    ret = wc_AesGcmEncrypt(&aes, out, in, inSz, iv, ivSz,
+                                           authTag, authTagSz, aad, aadSz);
+                wc_AesFree(&aes);
+            }
             break;
         #endif
     #endif /* HAVE_AESGCM */
@@ -5567,10 +5574,14 @@ static int wc_PKCS7_EncryptContent(int encryptOID, byte* key, int keySz,
             if (authTag == NULL)
                 return BAD_FUNC_ARG;
 
-            ret = wc_AesCcmSetKey(&aes, key, keySz);
-            if (ret == 0)
-                ret = wc_AesCcmEncrypt(&aes, out, in, inSz, iv, ivSz,
-                                       authTag, authTagSz, aad, aadSz);
+            ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+            if (ret == 0) {
+                ret = wc_AesCcmSetKey(&aes, key, keySz);
+                if (ret == 0)
+                    ret = wc_AesCcmEncrypt(&aes, out, in, inSz, iv, ivSz,
+                                           authTag, authTagSz, aad, aadSz);
+                wc_AesFree(&aes);
+            }
             break;
         #endif
     #endif /* HAVE_AESCCM */
@@ -5590,10 +5601,13 @@ static int wc_PKCS7_EncryptContent(int encryptOID, byte* key, int keySz,
             if (keySz != DES3_KEYLEN || ivSz != DES_BLOCK_SIZE)
                 return BAD_FUNC_ARG;
 
-            ret = wc_Des3_SetKey(&des3, key, iv, DES_ENCRYPTION);
-            if (ret == 0)
-                ret = wc_Des3_CbcEncrypt(&des3, out, in, inSz);
-
+            ret = wc_Des3Init(&des3, NULL, INVALID_DEVID);
+            if (ret == 0) {
+                ret = wc_Des3_SetKey(&des3, key, iv, DES_ENCRYPTION);
+                if (ret == 0)
+                    ret = wc_Des3_CbcEncrypt(&des3, out, in, inSz);
+                wc_Des3Free(&des3);
+            }
             break;
 #endif
         default:
@@ -5652,11 +5666,13 @@ static int wc_PKCS7_DecryptContent(int encryptOID, byte* key, int keySz,
                 #endif
                     (ivSz  != AES_BLOCK_SIZE) )
                 return BAD_FUNC_ARG;
-
-            ret = wc_AesSetKey(&aes, key, keySz, iv, AES_DECRYPTION);
-            if (ret == 0)
-                ret = wc_AesCbcDecrypt(&aes, out, in, inSz);
-
+            ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+            if (ret == 0) {
+                ret = wc_AesSetKey(&aes, key, keySz, iv, AES_DECRYPTION);
+                if (ret == 0)
+                    ret = wc_AesCbcDecrypt(&aes, out, in, inSz);
+                wc_AesFree(&aes);
+            }
             break;
     #ifdef HAVE_AESGCM
         #ifdef WOLFSSL_AES_128
@@ -5673,10 +5689,14 @@ static int wc_PKCS7_DecryptContent(int encryptOID, byte* key, int keySz,
             if (authTag == NULL)
                 return BAD_FUNC_ARG;
 
-            ret = wc_AesGcmSetKey(&aes, key, keySz);
-            if (ret == 0)
-                ret = wc_AesGcmDecrypt(&aes, out, in, inSz, iv, ivSz,
-                                       authTag, authTagSz, aad, aadSz);
+            ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+            if (ret == 0) {
+                ret = wc_AesGcmSetKey(&aes, key, keySz);
+                if (ret == 0)
+                    ret = wc_AesGcmDecrypt(&aes, out, in, inSz, iv, ivSz,
+                                           authTag, authTagSz, aad, aadSz);
+                wc_AesFree(&aes);
+            }
             break;
         #endif
     #endif /* HAVE_AESGCM */
@@ -5695,10 +5715,14 @@ static int wc_PKCS7_DecryptContent(int encryptOID, byte* key, int keySz,
             if (authTag == NULL)
                 return BAD_FUNC_ARG;
 
-            ret = wc_AesCcmSetKey(&aes, key, keySz);
-            if (ret == 0)
-                ret = wc_AesCcmDecrypt(&aes, out, in, inSz, iv, ivSz,
-                                       authTag, authTagSz, aad, aadSz);
+            ret = wc_AesInit(&aes, NULL, INVALID_DEVID);
+            if (ret == 0) {
+                ret = wc_AesCcmSetKey(&aes, key, keySz);
+                if (ret == 0)
+                    ret = wc_AesCcmDecrypt(&aes, out, in, inSz, iv, ivSz,
+                                           authTag, authTagSz, aad, aadSz);
+                wc_AesFree(&aes);
+            }
             break;
         #endif
     #endif /* HAVE_AESCCM */
@@ -5717,9 +5741,13 @@ static int wc_PKCS7_DecryptContent(int encryptOID, byte* key, int keySz,
             if (keySz != DES3_KEYLEN || ivSz != DES_BLOCK_SIZE)
                 return BAD_FUNC_ARG;
 
-            ret = wc_Des3_SetKey(&des3, key, iv, DES_DECRYPTION);
-            if (ret == 0)
-                ret = wc_Des3_CbcDecrypt(&des3, out, in, inSz);
+            ret = wc_Des3Init(&des3, NULL, INVALID_DEVID);
+            if (ret == 0) {
+                ret = wc_Des3_SetKey(&des3, key, iv, DES_DECRYPTION);
+                if (ret == 0)
+                    ret = wc_Des3_CbcDecrypt(&des3, out, in, inSz);
+                wc_Des3Free(&des3);
+            }
 
             break;
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5081,6 +5081,14 @@ int des3_test(void)
         };
 #endif /* WOLFSSL_AES_256 */
 
+
+    if (wc_AesInit(&enc, HEAP_HINT, devId) != 0)
+        return -4750;
+#ifdef HAVE_AES_DECRYPT
+    if (wc_AesInit(&dec, HEAP_HINT, devId) != 0)
+        return -4751;
+#endif
+
 #ifdef WOLFSSL_AES_128
         /* 128 key tests */
         ret = wc_AesSetKey(&enc, key1, AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
@@ -5238,14 +5246,12 @@ static int aes_key_size_test(void)
     word32 keySize;
 #endif
 
-#ifdef WC_INITAES_H
-    ret = wc_InitAes_h(NULL, NULL);
+    ret = wc_AesInit(NULL, HEAP_HINT, devId);
     if (ret != BAD_FUNC_ARG)
         return -4800;
-    ret = wc_InitAes_h(&aes, NULL);
+    ret = wc_AesInit(&aes, HEAP_HINT, devId);
     if (ret != 0)
         return -4801;
-#endif
 
 #ifndef HAVE_FIPS
     /* Parameter Validation testing. */
@@ -5909,12 +5915,10 @@ int aes_test(void)
     byte key[] = "0123456789abcdef   ";  /* align */
     byte iv[]  = "1234567890abcdef   ";  /* align */
 
-#ifdef WOLFSSL_ASYNC_CRYPT
     if (wc_AesInit(&enc, HEAP_HINT, devId) != 0)
         return -5400;
     if (wc_AesInit(&dec, HEAP_HINT, devId) != 0)
         return -5401;
-#endif
 
     ret = wc_AesSetKey(&enc, key, AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
     if (ret != 0)
@@ -6621,7 +6625,10 @@ Aes dec;
     XMEMSET(resultP, 0, sizeof(resultP));
 
     if (wc_AesInit(&enc, HEAP_HINT, devId) != 0) {
-        return -5700;
+        return -4700;
+    }
+    if (wc_AesInit(&dec, HEAP_HINT, devId) != 0) {
+        return -4700;
     }
 
     result = wc_AesGcmSetKey(&enc, key, keySz);
@@ -9880,6 +9887,7 @@ static int rsa_pss_test(WC_RNG* rng, RsaKey* key)
 
     ret = 0;
 exit_rsa_pss:
+    FREE_VAR(sig, HEAP_HINT);
     FREE_VAR(in, HEAP_HINT);
     FREE_VAR(out, HEAP_HINT);
 
@@ -19342,6 +19350,11 @@ static int pkcs7enveloped_run_vectors(byte* rsaCert, word32 rsaCertSz,
 
         } else {
             /* KTRI or KARI recipient types */
+
+            ret = wc_PKCS7_Init(pkcs7, pkcs7->heap, pkcs7->devId);
+            if (ret != 0) {
+                return -9321;
+            }
 
             ret = wc_PKCS7_InitWithCert(pkcs7, testVectors[i].cert,
                                         (word32)testVectors[i].certSz);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11871,6 +11871,7 @@ int dh_test(void)
     DhKey  key;
     DhKey  key2;
     WC_RNG rng;
+    int keyInit = 0;
 
 #ifdef USE_CERT_BUFFERS_1024
     XMEMCPY(tmp, dh_key_der_1024, (size_t)sizeof_dh_key_der_1024);
@@ -11907,6 +11908,7 @@ int dh_test(void)
     if (ret != 0) {
         ERROR_OUT(-7103, done);
     }
+    keyInit = 1;
     ret = wc_InitDhKey_ex(&key2, HEAP_HINT, devId);
     if (ret != 0) {
         ERROR_OUT(-7104, done);
@@ -11985,6 +11987,9 @@ int dh_test(void)
         ret = dh_fips_generate_test(&rng);
 
 
+    wc_FreeDhKey(&key);
+    keyInit = 0;
+
 #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && \
     !defined(WOLFSSL_OLD_PRIME_CHECK)
     if (ret == 0) {
@@ -11996,7 +12001,8 @@ int dh_test(void)
 
 done:
 
-    wc_FreeDhKey(&key);
+    if (keyInit)
+        wc_FreeDhKey(&key);
     wc_FreeDhKey(&key2);
     wc_FreeRng(&rng);
 


### PR DESCRIPTION
Fix for warnings with possible use of uninitialized variable in async with GMAC, DES3, AES and DH.
Fix for warning about possible case where `r` and `s` aren't initialized for `wc_ecc_verify_hash`.
Fix for unused `useSupCurve` in example client with `--disable-ecc`.
Fix for unused variables with `--disable-rsa --enable-tls13` case in `InitSuites`.