### PR TITLE
Various script improvements for git clone calls

### DIFF
--- a/async-check.sh
+++ b/async-check.sh
@@ -31,7 +31,7 @@ then
     echo "\n\nUsing existing async repo\n\n"
 else
     # make a clone of the wolfAsyncCrypt repository
-    git clone $ASYNC_REPO async
+    git clone --depth 1 $ASYNC_REPO async
     [ $? -ne 0 ] && echo "\n\nCouldn't checkout the wolfAsyncCrypt repository\n\n" && exit 1  
 fi
 

--- a/doc/generate_documentation.sh
+++ b/doc/generate_documentation.sh
@@ -63,7 +63,7 @@ if [ $INSTALL_DOX = true ] && [ ! "$(which doxygen)" ]; then
 mkdir -p build
 cd build
 echo "cloning doxygen 1.8.13..."
-git clone https://github.com/doxygen/doxygen --branch Release_1_8_13
+git clone --depth 1 --branch Release_1_8_13 https://github.com/doxygen/doxygen
 cmake -G "Unix Makefiles" doxygen/
 make
 cd ..

--- a/fips-check.sh
+++ b/fips-check.sh
@@ -206,7 +206,7 @@ pushd $TEST_DIR || exit 2
 if [ "x$FIPS_OPTION" == "xv1" ];
 then
     # make a clone of the last FIPS release tag
-    if ! $GIT clone -b $CRYPT_VERSION $CRYPT_REPO old-tree; then
+    if ! $GIT clone --depth 1 -b $CRYPT_VERSION $CRYPT_REPO old-tree; then
         echo "fips-check: Couldn't checkout the FIPS release."
         exit 1
     fi
@@ -239,7 +239,7 @@ else
 fi
 
 # clone the FIPS repository
-if ! $GIT clone -b $FIPS_VERSION $FIPS_REPO fips; then
+if ! $GIT clone --depth 1 -b $FIPS_VERSION $FIPS_REPO fips; then
     echo "fips-check: Couldn't checkout the FIPS repository."
     exit 1
 fi


### PR DESCRIPTION
Speedups for the `git clone` calls in check scripts to use `--depth 1`.

```
BEFORE CHANGE:

time ./fips-check.sh windows keep
Receiving objects: 100% (18408/18408), 12.61 MiB | 625.00 KiB/s, done.
Receiving objects: 100% (7045/7045), 110.48 MiB | 488.00 KiB/s, done.

real	5m4.604s
user	1m38.039s
sys	0m25.984s

AFTER CHANGE:
time ./fips-check.sh windows keep
Receiving objects: 100% (642/642), 1.02 MiB | 1.26 MiB/s, done.
Receiving objects: 100% (767/767), 24.15 MiB | 487.00 KiB/s, done.

real	1m43.194s
user	1m34.100s
sys	0m24.046s
```