### PR TITLE
Fix to resolve issue with fips_check.sh

### DIFF
--- a/fips-check.sh
+++ b/fips-check.sh
@@ -224,7 +224,8 @@ then
        [ "x$PLATFORM" != "xnetos-7.6" ];
     then
         pushd old-tree || exit 2
-        $GIT checkout v3.6.0
+        $GIT fetch origin v3.6.0
+        $GIT checkout FETCH_HEAD
         popd || exit 2
         cp "old-tree/$CRYPT_SRC_PATH/random.c" $CRYPT_SRC_PATH
         cp "old-tree/$CRYPT_INC_PATH/random.h" $CRYPT_INC_PATH


### PR DESCRIPTION
Fix to resolve issue with fips_check.sh after --depth=1 change in PR #1920. Fixes Jenkins report `error: pathspec 'v3.6.0' did not match any file(s) known to git`.