### PR TITLE
CMS expansion, SignedData detached signature support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,7 @@ pkcs7signedData_RSA_SHA256.der
 pkcs7signedData_RSA_SHA256_firmwarePkgData.der
 pkcs7signedData_RSA_SHA256_SKID.der
 pkcs7signedData_RSA_SHA256_with_ca_cert.der
+pkcs7signedData_RSA_SHA256_detachedSig.der
 pkcs7signedData_RSA_SHA384.der
 pkcs7signedData_RSA_SHA512.der
 pkcs7signedData_RSA_SHA.der

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,6 +88,7 @@ CLEANFILES+= cert.der \
              pkcs7signedData_RSA_SHA256_custom_contentType.der \
              pkcs7signedData_RSA_SHA256_with_ca_cert.der \
              pkcs7signedData_RSA_SHA256_SKID.der \
+             pkcs7signedData_RSA_SHA256_detachedSig.der \
              pkcs7signedData_RSA_SHA384.der \
              pkcs7signedData_RSA_SHA512.der \
              pkcs7signedData_ECDSA_SHA.der \

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1858,12 +1858,20 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7, ESD* esd,
     esd->contentDigest[1] = (byte)hashSz;
     XMEMCPY(&esd->contentDigest[2], hashBuf, hashSz);
 
-    esd->innerOctetsSz = SetOctetString(pkcs7->contentSz, esd->innerOctets);
-    esd->innerContSeqSz = SetExplicit(0, esd->innerOctetsSz + pkcs7->contentSz,
-                                esd->innerContSeq);
-    esd->contentInfoSeqSz = SetSequence(pkcs7->contentSz + esd->innerOctetsSz +
-                                     pkcs7->contentTypeSz + esd->innerContSeqSz,
-                                     esd->contentInfoSeq);
+    if (pkcs7->detached == 1) {
+        /* do not include content if generating detached signature */
+        esd->innerOctetsSz = 0;
+        esd->innerContSeqSz = 0;
+        esd->contentInfoSeqSz = SetSequence(pkcs7->contentTypeSz,
+                                            esd->contentInfoSeq);
+    } else {
+        esd->innerOctetsSz = SetOctetString(pkcs7->contentSz, esd->innerOctets);
+        esd->innerContSeqSz = SetExplicit(0, esd->innerOctetsSz +
+                                    pkcs7->contentSz, esd->innerContSeq);
+        esd->contentInfoSeqSz = SetSequence(pkcs7->contentSz +
+                                    esd->innerOctetsSz + pkcs7->contentTypeSz +
+                                    esd->innerContSeqSz, esd->contentInfoSeq);
+    }
 
     /* SignerIdentifier */
     if (pkcs7->sidType == CMS_ISSUER_AND_SERIAL_NUMBER) {
@@ -1992,6 +2000,10 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7, ESD* esd,
               esd->innerContSeqSz + esd->innerOctetsSz + pkcs7->contentSz;
     total2Sz = esd->certsSetSz + certSetSz + signerInfoSz;
 
+    if (pkcs7->detached) {
+        totalSz -= pkcs7->contentSz;
+    }
+
     esd->innerSeqSz = SetSequence(totalSz + total2Sz, esd->innerSeq);
     totalSz += esd->innerSeqSz;
     esd->outerContentSz = SetExplicit(0, totalSz + total2Sz, esd->outerContent);
@@ -2009,7 +2021,10 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7, ESD* esd,
         #endif
             return BUFFER_E;
         }
-        totalSz -= pkcs7->contentSz;
+
+        if (!pkcs7->detached) {
+            totalSz -= pkcs7->contentSz;
+        }
     }
 
     if (totalSz > *outputSz) {
@@ -2051,8 +2066,10 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7, ESD* esd,
         idx = 0;
     }
     else {
-        XMEMCPY(output + idx, pkcs7->content, pkcs7->contentSz);
-        idx += pkcs7->contentSz;
+        if (!pkcs7->detached) {
+            XMEMCPY(output + idx, pkcs7->content, pkcs7->contentSz);
+            idx += pkcs7->contentSz;
+        }
         output2 = output;
     }
 
@@ -2170,6 +2187,29 @@ int wc_PKCS7_EncodeSignedData_ex(PKCS7* pkcs7, const byte* hashBuf, word32 hashS
 #endif
 
     return ret;
+}
+
+/* Toggle detached signature mode on/off for PKCS#7/CMS SignedData content type.
+ * By default wolfCrypt includes the data to be signed in the SignedData
+ * bundle. This data can be ommited in the case when a detached signature is
+ * being created. To enable generation of detached signatures, set flag to "1",
+ * otherwise set to "0":
+ *
+ *     flag 1 turns on support
+ *     flag 0 turns off support
+ *
+ * pkcs7 - pointer to initialized PKCS7 structure
+ * flag  - turn on/off detached signature generation (1 or 0)
+ *
+ * Returns 0 on success, negative upon error. */
+int wc_PKCS7_SetDetached(PKCS7* pkcs7, word16 flag)
+{
+    if (pkcs7 == NULL || (flag != 0 && flag != 1))
+        return BAD_FUNC_ARG;
+
+    pkcs7->detached = flag;
+
+    return 0;
 }
 
 /* return codes: >0: Size of signed PKCS7 output buffer, negative: error */
@@ -3291,6 +3331,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
     int contentSz = 0, sigSz = 0, certSz = 0, signedAttribSz = 0;
     word32 localIdx, start;
     byte degenerate = 0;
+    byte detached = 0;
 #ifdef ASN_BER_TO_DER
     byte* der;
 #endif
@@ -3527,8 +3568,8 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                 if (pkiMsg[localIdx++] != ASN_OCTET_STRING)
                     ret = ASN_PARSE_E;
 
-                if (ret == 0 && GetLength_ex(pkiMsg, &localIdx, &length, pkiMsgSz,
-                            NO_USER_CHECK) < 0)
+                if (ret == 0 && GetLength_ex(pkiMsg, &localIdx,
+                            &length, pkiMsgSz, NO_USER_CHECK) < 0)
                     ret = ASN_PARSE_E;
             }
 
@@ -3541,8 +3582,17 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                 idx = localIdx;
             }
             else {
-                if (!degenerate && ret != 0)
+
+                /* if pkcs7->content and pkcs7->contentSz are set, try to
+                   process as a detached signature */
+                if (!degenerate &&
+                    (pkcs7->content != NULL && pkcs7->contentSz != 0)) {
+                    detached = 1;
+                }
+
+                if (!degenerate && !detached && ret != 0)
                     break;
+
                 length = 0; /* no content to read */
                 pkiMsg2   = pkiMsg;
                 pkiMsg2Sz = pkiMsgSz;
@@ -3700,7 +3750,7 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
             /* If getting the content info failed with non degenerate then return the
              * error case. Otherwise with a degenerate it is ok if the content
              * info was omitted */
-            if (!degenerate && ret != 0) {
+            if (!degenerate && !detached && ret != 0) {
                 break;
             }
             else {
@@ -3722,6 +3772,12 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                 }
         #ifndef NO_PKCS7_STREAM
             /* save content */
+            if (detached == 1) {
+                /* if detached, use content from user in pkcs7 struct */
+                content = pkcs7->content;
+                contentSz = pkcs7->contentSz;
+            }
+
             if (content != NULL) {
                 XFREE(pkcs7->stream->content, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 pkcs7->stream->content = (byte*)XMALLOC(contentSz, pkcs7->heap,
@@ -3866,9 +3922,32 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                 idx += length;
             }
 
-            /* set content and size after init of PKCS7 structure */
-            pkcs7->content   = content;
-            pkcs7->contentSz = contentSz;
+            if (!detached) {
+                /* set content and size after init of PKCS7 structure */
+                pkcs7->content   = content;
+                pkcs7->contentSz = contentSz;
+            }
+        #ifndef NO_PKCS7_STREAM
+            else {
+                /* save content if detached and using streaming API */
+                if (pkcs7->content != NULL) {
+                    XFREE(pkcs7->stream->content, pkcs7->heap,
+                          DYNAMIC_TYPE_PKCS7);
+                    pkcs7->stream->content = (byte*)XMALLOC(pkcs7->contentSz,
+                                                            pkcs7->heap,
+                                                            DYNAMIC_TYPE_PKCS7);
+                    if (pkcs7->stream->content == NULL) {
+                        ret = MEMORY_E;
+                        break;
+                    }
+                    else {
+                        XMEMCPY(pkcs7->stream->content, pkcs7->content,
+                                contentSz);
+                        pkcs7->stream->contentSz = pkcs7->contentSz;
+                    }
+                }
+            }
+        #endif
 
             if (ret != 0) {
                 break;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -20826,12 +20826,10 @@ static int pkcs7signed_run_vectors(
     }
 
     for (i = 0; i < testSz; i++) {
-        pkcs7 = wc_PKCS7_New(HEAP_HINT, INVALID_DEVID);
+        pkcs7 = wc_PKCS7_New(HEAP_HINT, devId);
         if (pkcs7 == NULL)
             return -9513;
 
-        pkcs7->heap = HEAP_HINT;
-        pkcs7->devId = INVALID_DEVID;
         ret = wc_PKCS7_InitWithCert(pkcs7, testVectors[i].cert,
                                     (word32)testVectors[i].certSz);
 
@@ -20976,7 +20974,7 @@ static int pkcs7signed_run_vectors(
 
         wc_PKCS7_Free(pkcs7);
 
-        pkcs7 = wc_PKCS7_New(HEAP_HINT, INVALID_DEVID);
+        pkcs7 = wc_PKCS7_New(HEAP_HINT, devId);
         if (pkcs7 == NULL)
             return -9525;
         wc_PKCS7_InitWithCert(pkcs7, NULL, 0);
@@ -21328,12 +21326,10 @@ static int pkcs7signed_run_SingleShotVectors(
     }
 
     for (i = 0; i < testSz; i++) {
-        pkcs7 = wc_PKCS7_New(HEAP_HINT, INVALID_DEVID);
+        pkcs7 = wc_PKCS7_New(HEAP_HINT, devId);
         if (pkcs7 == NULL)
             return -9553;
 
-        pkcs7->heap = HEAP_HINT;
-        pkcs7->devId = INVALID_DEVID;
         ret = wc_PKCS7_InitWithCert(pkcs7, testVectors[i].cert,
                                     (word32)testVectors[i].certSz);
 
@@ -21469,7 +21465,7 @@ static int pkcs7signed_run_SingleShotVectors(
 
         wc_PKCS7_Free(pkcs7);
 
-        pkcs7 = wc_PKCS7_New(HEAP_HINT, INVALID_DEVID);
+        pkcs7 = wc_PKCS7_New(HEAP_HINT, devId);
         if (pkcs7 == NULL)
             return -9564;
         wc_PKCS7_InitWithCert(pkcs7, NULL, 0);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -20577,6 +20577,7 @@ typedef struct {
     word32       encryptKeySz; /* for single-shot, encryptedData */
     PKCS7Attrib* unprotectedAttribs;   /* for single-shot, encryptedData */
     word32       unprotectedAttribsSz; /* for single-shot, encryptedData */
+    word16       detachedSignature;    /* generate detached signature (0:1) */
 } pkcs7SignedVector;
 
 
@@ -20645,14 +20646,15 @@ static int pkcs7signed_run_vectors(
         {data, (word32)sizeof(data), SHAh, RSAk, rsaClientPrivKeyBuf,
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
-         "pkcs7signedData_RSA_SHA.der", 0, NULL, 0, 0, 0, 0, NULL, 0, NULL, 0},
+         "pkcs7signedData_RSA_SHA.der", 0, NULL, 0, 0, 0, 0, NULL, 0, NULL,
+         0, 0},
 
         /* RSA with SHA, no signed attributes */
         {data, (word32)sizeof(data), SHAh, RSAk, rsaClientPrivKeyBuf,
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz,
          NULL, 0, NULL, 0,
          "pkcs7signedData_RSA_SHA_noattr.der", 0, NULL, 0, 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
     #endif
     #ifdef WOLFSSL_SHA224
         /* RSA with SHA224 */
@@ -20660,7 +20662,7 @@ static int pkcs7signed_run_vectors(
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_RSA_SHA224.der", 0, NULL, 0, 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
     #endif
     #ifndef NO_SHA256
         /* RSA with SHA256 */
@@ -20668,14 +20670,21 @@ static int pkcs7signed_run_vectors(
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_RSA_SHA256.der", 0, NULL, 0, 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
+
+        /* RSA with SHA256, detached signature */
+        {data, (word32)sizeof(data), SHA256h, RSAk, rsaClientPrivKeyBuf,
+         rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
+         attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
+         "pkcs7signedData_RSA_SHA256_detachedSig.der", 0, NULL, 0, 0, 0, 0,
+         NULL, 0, NULL, 0, 1},
 
         /* RSA with SHA256 and SubjectKeyIdentifier in SignerIdentifier */
         {data, (word32)sizeof(data), SHA256h, RSAk, rsaClientPrivKeyBuf,
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_RSA_SHA256_SKID.der", 0, NULL, 0, CMS_SKID, 0, 0,
-        NULL, 0, NULL, 0},
+        NULL, 0, NULL, 0, 0},
 
         /* RSA with SHA256 and custom contentType */
         {data, (word32)sizeof(data), SHA256h, RSAk, rsaClientPrivKeyBuf,
@@ -20683,14 +20692,14 @@ static int pkcs7signed_run_vectors(
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_RSA_SHA256_custom_contentType.der", 0,
          customContentType, sizeof(customContentType), 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
 
         /* RSA with SHA256 and FirmwarePkgData contentType */
         {data, (word32)sizeof(data), SHA256h, RSAk, rsaClientPrivKeyBuf,
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_RSA_SHA256_firmwarePkgData.der",
-         FIRMWARE_PKG_DATA, NULL, 0, 0, 0, 0, NULL, 0, NULL, 0},
+         FIRMWARE_PKG_DATA, NULL, 0, 0, 0, 0, NULL, 0, NULL, 0, 0},
 
         /* RSA with SHA256 using server cert and ca cert */
         {data, (word32)sizeof(data), SHA256h, RSAk, rsaServerPrivKeyBuf,
@@ -20698,7 +20707,7 @@ static int pkcs7signed_run_vectors(
          rsaCaCertBuf, rsaCaCertBufSz,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_RSA_SHA256_with_ca_cert.der", 0, NULL, 0, 0, 0, 0,
-        NULL, 0, NULL, 0},
+        NULL, 0, NULL, 0, 0},
     #endif
     #if defined(WOLFSSL_SHA384)
         /* RSA with SHA384 */
@@ -20706,7 +20715,7 @@ static int pkcs7signed_run_vectors(
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_RSA_SHA384.der", 0, NULL, 0, 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
     #endif
     #if defined(WOLFSSL_SHA512)
         /* RSA with SHA512 */
@@ -20714,7 +20723,7 @@ static int pkcs7signed_run_vectors(
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_RSA_SHA512.der", 0, NULL, 0, 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
     #endif
 #endif /* NO_RSA */
 
@@ -20725,14 +20734,14 @@ static int pkcs7signed_run_vectors(
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_ECDSA_SHA.der", 0, NULL, 0, 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
 
         /* ECDSA with SHA, no signed attributes */
         {data, (word32)sizeof(data), SHAh, ECDSAk, eccClientPrivKeyBuf,
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz,
          NULL, 0, NULL, 0,
          "pkcs7signedData_ECDSA_SHA_noattr.der", 0, NULL, 0, 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
     #endif
     #ifdef WOLFSSL_SHA224
         /* ECDSA with SHA224 */
@@ -20740,7 +20749,7 @@ static int pkcs7signed_run_vectors(
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_ECDSA_SHA224.der", 0, NULL, 0, 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
     #endif
     #ifndef NO_SHA256
         /* ECDSA with SHA256 */
@@ -20748,14 +20757,14 @@ static int pkcs7signed_run_vectors(
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_ECDSA_SHA256.der", 0, NULL, 0, 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
 
         /* ECDSA with SHA256 and SubjectKeyIdentifier in SigherIdentifier */
         {data, (word32)sizeof(data), SHA256h, ECDSAk, eccClientPrivKeyBuf,
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_ECDSA_SHA256_SKID.der", 0, NULL, 0, CMS_SKID, 0, 0,
-        NULL, 0, NULL, 0},
+        NULL, 0, NULL, 0, 0},
 
         /* ECDSA with SHA256 and custom contentType */
         {data, (word32)sizeof(data), SHA256h, ECDSAk, eccClientPrivKeyBuf,
@@ -20763,14 +20772,14 @@ static int pkcs7signed_run_vectors(
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_ECDSA_SHA256_custom_contentType.der", 0,
          customContentType, sizeof(customContentType), 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
 
         /* ECDSA with SHA256 and FirmwarePkgData contentType */
         {data, (word32)sizeof(data), SHA256h, ECDSAk, eccClientPrivKeyBuf,
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_ECDSA_SHA256_firmwarePkgData.der",
-         FIRMWARE_PKG_DATA, NULL, 0, 0, 0, 0, NULL, 0, NULL, 0},
+         FIRMWARE_PKG_DATA, NULL, 0, 0, 0, 0, NULL, 0, NULL, 0, 0},
     #endif
     #ifdef WOLFSSL_SHA384
         /* ECDSA with SHA384 */
@@ -20778,7 +20787,7 @@ static int pkcs7signed_run_vectors(
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_ECDSA_SHA384.der", 0, NULL, 0, 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
     #endif
     #ifdef WOLFSSL_SHA512
         /* ECDSA with SHA512 */
@@ -20786,7 +20795,7 @@ static int pkcs7signed_run_vectors(
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedData_ECDSA_SHA512.der", 0, NULL, 0, 0, 0, 0, NULL, 0,
-         NULL, 0},
+         NULL, 0, 0},
     #endif
 #endif /* HAVE_ECC */
     };
@@ -20931,11 +20940,21 @@ static int pkcs7signed_run_vectors(
             }
         }
 
+        /* enable detached signature generation, if set */
+        if (testVectors[i].detachedSignature == 1) {
+            ret = wc_PKCS7_SetDetached(pkcs7, 1);
+            if (ret != 0) {
+            XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+            wc_PKCS7_Free(pkcs7);
+            return -9521;
+            }
+        }
+
         encodedSz = wc_PKCS7_EncodeSignedData(pkcs7, out, outSz);
         if (encodedSz < 0) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_PKCS7_Free(pkcs7);
-            return -9521;
+            return -9522;
         }
 
     #ifdef PKCS7_OUTPUT_TEST_BUNDLES
@@ -20944,14 +20963,14 @@ static int pkcs7signed_run_vectors(
         if (!file) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_PKCS7_Free(pkcs7);
-            return -9522;
+            return -9523;
         }
         ret = (int)fwrite(out, 1, encodedSz, file);
         fclose(file);
         if (ret != (int)encodedSz) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_PKCS7_Free(pkcs7);
-            return -9526;
+            return -9524;
         }
     #endif /* PKCS7_OUTPUT_TEST_BUNDLES */
 
@@ -20959,30 +20978,36 @@ static int pkcs7signed_run_vectors(
 
         pkcs7 = wc_PKCS7_New(HEAP_HINT, INVALID_DEVID);
         if (pkcs7 == NULL)
-            return -9527;
+            return -9525;
         wc_PKCS7_InitWithCert(pkcs7, NULL, 0);
+
+        if (testVectors[i].detachedSignature == 1) {
+            /* set content for verifying detached signatures */
+            pkcs7->content         = (byte*)testVectors[i].content;
+            pkcs7->contentSz       = testVectors[i].contentSz;
+        }
 
         ret = wc_PKCS7_VerifySignedData(pkcs7, out, outSz);
         if (ret < 0) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_PKCS7_Free(pkcs7);
-            return -9528;
+            return -9526;
         }
 
         /* verify contentType extracted successfully for custom content types */
         if (testVectors[i].contentTypeSz > 0) {
             if (pkcs7->contentTypeSz != testVectors[i].contentTypeSz) {
-                return -9529;
+                return -9527;
             } else if (XMEMCMP(pkcs7->contentType, testVectors[i].contentType,
                        pkcs7->contentTypeSz) != 0) {
-                return -9530;
+                return -9528;
             }
         }
 
         if (pkcs7->singleCert == NULL || pkcs7->singleCertSz == 0) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_PKCS7_Free(pkcs7);
-            return -9531;
+            return -9529;
         }
 
         {
@@ -21001,13 +21026,13 @@ static int pkcs7signed_run_vectors(
                     NULL, (word32*)&bufSz) != LENGTH_ONLY_E) {
                 XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
                 wc_PKCS7_Free(pkcs7);
-                return -9532;
+                return -9530;
             }
 
             if (bufSz > (int)sizeof(buf)) {
                 XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
                 wc_PKCS7_Free(pkcs7);
-                return -9533;
+                return -9531;
             }
 
             bufSz = wc_PKCS7_GetAttributeValue(pkcs7, oidPt, oidSz,
@@ -21016,7 +21041,7 @@ static int pkcs7signed_run_vectors(
                 (testVectors[i].signedAttribs == NULL && bufSz > 0)) {
                 XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
                 wc_PKCS7_Free(pkcs7);
-                return -9534;
+                return -9532;
             }
         }
 
@@ -21025,7 +21050,7 @@ static int pkcs7signed_run_vectors(
         if (!file) {
             XFREE(out, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
             wc_PKCS7_Free(pkcs7);
-            return -9535;
+            return -9533;
         }
         ret = (int)fwrite(pkcs7->singleCert, 1, pkcs7->singleCertSz, file);
         fclose(file);
@@ -21115,21 +21140,21 @@ static int pkcs7signed_run_SingleShotVectors(
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          NULL, 0,
          "pkcs7signedFirmwarePkgData_RSA_SHA256_noattr.der", 0, NULL, 0, 0,
-         0, 0, NULL, 0, NULL, 0},
+         0, 0, NULL, 0, NULL, 0, 0},
 
         /* Signed FirmwarePkgData, RSA, SHA256, attrs */
         {data, (word32)sizeof(data), SHA256h, RSAk, rsaClientPrivKeyBuf,
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedFirmwarePkgData_RSA_SHA256.der", 0, NULL, 0, 0, 0, 0,
-        NULL, 0, NULL, 0},
+        NULL, 0, NULL, 0, 0},
 
         /* Signed FirmwarePkgData, RSA, SHA256, SubjectKeyIdentifier, attrs */
         {data, (word32)sizeof(data), SHA256h, RSAk, rsaClientPrivKeyBuf,
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedFirmwarePkgData_RSA_SHA256_SKID.der", 0, NULL,
-         0, CMS_SKID, 0, 0, NULL, 0, NULL, 0},
+         0, CMS_SKID, 0, 0, NULL, 0, NULL, 0, 0},
 
         /* Signed FirmwraePkgData, RSA, SHA256, server cert and ca cert, attr */
         {data, (word32)sizeof(data), SHA256h, RSAk, rsaServerPrivKeyBuf,
@@ -21137,7 +21162,7 @@ static int pkcs7signed_run_SingleShotVectors(
          rsaCaCertBuf, rsaCaCertBufSz,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedFirmwarePkgData_RSA_SHA256_with_ca_cert.der", 0, NULL,
-         0, 0, 0, 0, NULL, 0, NULL, 0},
+         0, 0, 0, 0, NULL, 0, NULL, 0, 0},
 
     #if defined(WOLFSSL_AES_256) && !defined(NO_PKCS7_ENCRYPTED_DATA)
         /* Signed Encrypted FirmwarePkgData, RSA, SHA256, no attribs */
@@ -21145,7 +21170,7 @@ static int pkcs7signed_run_SingleShotVectors(
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          NULL, 0,
          "pkcs7signedEncryptedFirmwarePkgData_RSA_SHA256_noattr.der", 0,
-         NULL, 0, 0, AES256CBCb, 1, aes256Key, sizeof(aes256Key), NULL, 0},
+         NULL, 0, 0, AES256CBCb, 1, aes256Key, sizeof(aes256Key), NULL, 0, 0},
 
         /* Signed Encrypted FirmwarePkgData, RSA, SHA256, attribs */
         {data, (word32)sizeof(data), SHA256h, RSAk, rsaClientPrivKeyBuf,
@@ -21153,7 +21178,7 @@ static int pkcs7signed_run_SingleShotVectors(
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedEncryptedFirmwarePkgData_RSA_SHA256.der", 0,
          NULL, 0, 0, AES256CBCb, 1, aes256Key, sizeof(aes256Key),
-         attribs, (sizeof(attribs)/sizeof(PKCS7Attrib))},
+         attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)), 0},
     #endif /* WOLFSSL_AES_256 && !NO_PKCS7_ENCRYPTED_DATA */
 
     #if defined(HAVE_LIBZ) && !defined(NO_PKCS7_COMPRESSED_DATA)
@@ -21162,14 +21187,14 @@ static int pkcs7signed_run_SingleShotVectors(
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          NULL, 0,
          "pkcs7signedCompressedFirmwarePkgData_RSA_SHA256_noattr.der", 0,
-         NULL, 0, 0, 0, 2, NULL, 0, NULL, 0},
+         NULL, 0, 0, 0, 2, NULL, 0, NULL, 0, 0},
 
         /* Signed Compressed FirmwarePkgData, RSA, SHA256, attribs */
         {data, (word32)sizeof(data), SHA256h, RSAk, rsaClientPrivKeyBuf,
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedCompressedFirmwarePkgData_RSA_SHA256.der", 0,
-         NULL, 0, 0, 0, 2, NULL, 0, NULL, 0},
+         NULL, 0, 0, 0, 2, NULL, 0, NULL, 0, 0},
 
     #ifndef NO_PKCS7_ENCRYPTED_DATA
         /* Signed Encrypted Compressed FirmwarePkgData, RSA, SHA256,
@@ -21178,7 +21203,8 @@ static int pkcs7signed_run_SingleShotVectors(
          rsaClientPrivKeyBufSz, rsaClientCertBuf, rsaClientCertBufSz, NULL, 0,
          NULL, 0,
          "pkcs7signedEncryptedCompressedFirmwarePkgData_RSA_SHA256_noattr.der",
-         0, NULL, 0, 0, AES256CBCb, 3, aes256Key, sizeof(aes256Key), NULL, 0},
+         0, NULL, 0, 0, AES256CBCb, 3, aes256Key, sizeof(aes256Key), NULL,
+         0, 0},
 
         /* Signed Encrypted Compressed FirmwarePkgData, RSA, SHA256,
            attribs */
@@ -21187,7 +21213,7 @@ static int pkcs7signed_run_SingleShotVectors(
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedEncryptedCompressedFirmwarePkgData_RSA_SHA256.der",
          0, NULL, 0, 0, AES256CBCb, 3, aes256Key, sizeof(aes256Key),
-         attribs, (sizeof(attribs)/sizeof(PKCS7Attrib))},
+         attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)), 0},
     #endif /* !NO_PKCS7_ENCRYPTED_DATA */
 
     #endif /* HAVE_LIBZ && !NO_PKCS7_COMPRESSED_DATA */
@@ -21202,21 +21228,21 @@ static int pkcs7signed_run_SingleShotVectors(
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          NULL, 0,
          "pkcs7signedFirmwarePkgData_ECDSA_SHA256_noattr.der", 0, NULL,
-         0, 0, 0, 0, NULL, 0, NULL, 0},
+         0, 0, 0, 0, NULL, 0, NULL, 0, 0},
 
         /* Signed FirmwarePkgData, ECDSA, SHA256, attribs */
         {data, (word32)sizeof(data), SHA256h, ECDSAk, eccClientPrivKeyBuf,
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedFirmwarePkgData_ECDSA_SHA256.der", 0, NULL,
-         0, 0, 0, 0, NULL, 0, NULL, 0},
+         0, 0, 0, 0, NULL, 0, NULL, 0, 0},
 
         /* Signed FirmwarePkgData, ECDSA, SHA256, SubjectKeyIdentifier, attr */
         {data, (word32)sizeof(data), SHA256h, ECDSAk, eccClientPrivKeyBuf,
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedFirmwarePkgData_ECDSA_SHA256_SKID.der", 0, NULL,
-         0, CMS_SKID, 0, 0, NULL, 0, NULL, 0},
+         0, CMS_SKID, 0, 0, NULL, 0, NULL, 0, 0},
 
     #if defined(WOLFSSL_AES_256) && !defined(NO_PKCS7_ENCRYPTED_DATA)
         /* Signed Encrypted FirmwarePkgData, ECDSA, SHA256, no attribs */
@@ -21224,7 +21250,7 @@ static int pkcs7signed_run_SingleShotVectors(
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          NULL, 0,
          "pkcs7signedEncryptedFirmwarePkgData_ECDSA_SHA256_noattr.der", 0, NULL,
-         0, 0, AES256CBCb, 1, aes256Key, sizeof(aes256Key), NULL, 0},
+         0, 0, AES256CBCb, 1, aes256Key, sizeof(aes256Key), NULL, 0, 0},
 
         /* Signed Encrypted FirmwarePkgData, ECDSA, SHA256, attribs */
         {data, (word32)sizeof(data), SHA256h, ECDSAk, eccClientPrivKeyBuf,
@@ -21232,7 +21258,7 @@ static int pkcs7signed_run_SingleShotVectors(
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedEncryptedFirmwarePkgData_ECDSA_SHA256.der", 0, NULL,
          0, 0, AES256CBCb, 1, aes256Key, sizeof(aes256Key),
-         attribs, (sizeof(attribs)/sizeof(PKCS7Attrib))},
+         attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)), 0},
     #endif /* WOLFSSL_AES_256 && !NO_PKCS7_ENCRYPTED_DATA */
 
     #if defined(HAVE_LIBZ) && !defined(NO_PKCS7_COMPRESSED_DATA)
@@ -21241,14 +21267,14 @@ static int pkcs7signed_run_SingleShotVectors(
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          NULL, 0,
          "pkcs7signedCompressedFirmwarePkgData_ECDSA_SHA256_noattr.der", 0, NULL,
-         0, 0, 0, 2, NULL, 0, NULL, 0},
+         0, 0, 0, 2, NULL, 0, NULL, 0, 0},
 
         /* Signed Compressed FirmwarePkgData, ECDSA, SHA256, attrib */
         {data, (word32)sizeof(data), SHA256h, ECDSAk, eccClientPrivKeyBuf,
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
          "pkcs7signedCompressedFirmwarePkgData_ECDSA_SHA256.der", 0, NULL,
-         0, 0, 0, 2, NULL, 0, NULL, 0},
+         0, 0, 0, 2, NULL, 0, NULL, 0, 0},
 
     #ifndef NO_PKCS7_ENCRYPTED_DATA
         /* Signed Encrypted Compressed FirmwarePkgData, ECDSA, SHA256,
@@ -21257,7 +21283,8 @@ static int pkcs7signed_run_SingleShotVectors(
          eccClientPrivKeyBufSz, eccClientCertBuf, eccClientCertBufSz, NULL, 0,
          NULL, 0,
         "pkcs7signedEncryptedCompressedFirmwarePkgData_ECDSA_SHA256_noattr.der",
-         0, NULL, 0, 0, AES256CBCb, 3, aes256Key, sizeof(aes256Key), NULL, 0},
+         0, NULL, 0, 0, AES256CBCb, 3, aes256Key, sizeof(aes256Key), NULL,
+         0, 0},
 
         /* Signed Encrypted Compressed FirmwarePkgData, ECDSA, SHA256,
            attribs */
@@ -21266,7 +21293,7 @@ static int pkcs7signed_run_SingleShotVectors(
          attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)),
         "pkcs7signedEncryptedCompressedFirmwarePkgData_ECDSA_SHA256.der",
          0, NULL, 0, 0, AES256CBCb, 3, aes256Key, sizeof(aes256Key),
-         attribs, (sizeof(attribs)/sizeof(PKCS7Attrib))},
+         attribs, (sizeof(attribs)/sizeof(PKCS7Attrib)), 0},
     #endif /* !NO_PKCS7_ENCRYPTED_DATA */
 
     #endif /* HAVE_LIBZ && !NO_PKCS7_COMPRESSED_DATA */
@@ -21739,7 +21766,7 @@ int pkcs7signed_test(void)
         XFREE(rsaClientPrivKeyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         XFREE(eccClientCertBuf,    HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         XFREE(eccClientPrivKeyBuf, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        return -9509;
+        return ret;
     }
 
     ret = pkcs7signed_run_SingleShotVectors(

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -251,6 +251,7 @@ struct PKCS7 {
      /* flags - up to 16-bits */
     word16 isDynamic:1;
     word16 noDegenerate:1; /* allow degenerate case in verify function */
+    word16 detached:1;     /* generate detached SignedData signature bundles */
 
     byte contentType[MAX_OID_SZ]; /* custom contentType byte array */
     word32 contentTypeSz;         /* size of contentType, bytes */
@@ -307,6 +308,7 @@ WOLFSSL_API int  wc_PKCS7_EncodeData(PKCS7* pkcs7, byte* output,
                                        word32 outputSz);
 
 /* CMS/PKCS#7 SignedData */
+WOLFSSL_API int  wc_PKCS7_SetDetached(PKCS7* pkcs7, word16 flag);
 WOLFSSL_API int  wc_PKCS7_EncodeSignedData(PKCS7* pkcs7,
                                           byte* output, word32 outputSz);
 WOLFSSL_API int  wc_PKCS7_EncodeSignedData_ex(PKCS7* pkcs7, const byte* hashBuf, 


### PR DESCRIPTION
This PR adds support for generating and verifying PKCS#7/CMS SignedData bundles with detached signatures.

A SignedData bundle signature is "detached" if it excludes the EncapsulatedContentInfo eContent (ie: the content being signed).

This introduces a new API to be used before calling wc_PKCS7_EncodeSignedData():

```
int wc_PKCS7_SetDetached(PKCS7* pkcs7, word16 flag);
```

When decoding/verifying, the content and content size needs to be set in the PKCS7 structure before calling wc_PKCS7_VerifySignedData():

```
pkcs7->content = <content buffer>;
pkcs7->contentSz = <size of content buffer>;
```