### PR TITLE
exclude wolfSSL_EC_POINT_point2hex() in CAVP selftest build

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26974,6 +26974,9 @@ int wolfSSL_EC_KEY_set_public_key(WOLFSSL_EC_KEY *key,
 /* End EC_KEY */
 
 
+#ifndef HAVE_SELFTEST
+/* ECC point compression types were not included in selftest ecc.h */
+
 char* wolfSSL_EC_POINT_point2hex(const WOLFSSL_EC_GROUP* group,
                                  const WOLFSSL_EC_POINT* point, int form,
                                  WOLFSSL_BN_CTX* ctx)
@@ -27030,6 +27033,8 @@ char* wolfSSL_EC_POINT_point2hex(const WOLFSSL_EC_GROUP* group,
 
     return hex;
 }
+
+#endif /* HAVE_SELFTEST */
 
 void wolfSSL_EC_POINT_dump(const char *msg, const WOLFSSL_EC_POINT *p)
 {

--- a/tests/api.c
+++ b/tests/api.c
@@ -1431,8 +1431,11 @@ static void test_wolfSSL_EC(void)
     /* NISTP256R1 Gx/Gy */
     const char* kGx   = "6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296";
     const char* kGy   = "4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5";
+
+#ifndef HAVE_SELFTEST
     const char* uncompG   = "046B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C2964FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5";
     const char* compG   = "036B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296";
+#endif
 
     AssertNotNull(ctx = BN_CTX_new());
     AssertNotNull(group = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1));
@@ -1489,6 +1492,7 @@ static void test_wolfSSL_EC(void)
 #endif
     XFREE(hexStr, NULL, DYNAMIC_TYPE_ECC);
 
+#ifndef HAVE_SELFTEST
     hexStr = EC_POINT_point2hex(group, Gxy, POINT_CONVERSION_UNCOMPRESSED, ctx);
     AssertStrEQ(hexStr, uncompG);
     XFREE(hexStr, NULL, DYNAMIC_TYPE_ECC);
@@ -1496,6 +1500,7 @@ static void test_wolfSSL_EC(void)
     hexStr = EC_POINT_point2hex(group, Gxy, POINT_CONVERSION_COMPRESSED, ctx);
     AssertStrEQ(hexStr, compG);
     XFREE(hexStr, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     /* cleanup */
     BN_free(X);

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -184,10 +184,12 @@ WOLFSSL_API
 int wolfSSL_EC_POINT_is_at_infinity(const WOLFSSL_EC_GROUP *group,
                                     const WOLFSSL_EC_POINT *a);
 
+#ifndef HAVE_SELFTEST
 WOLFSSL_API
 char* wolfSSL_EC_POINT_point2hex(const WOLFSSL_EC_GROUP* group,
                                  const WOLFSSL_EC_POINT* point, int form,
                                  WOLFSSL_BN_CTX* ctx);
+#endif
 
 #define EC_KEY_new                      wolfSSL_EC_KEY_new
 #define EC_KEY_free                     wolfSSL_EC_KEY_free
@@ -218,7 +220,10 @@ char* wolfSSL_EC_POINT_point2hex(const WOLFSSL_EC_GROUP* group,
 #define EC_POINT_cmp                    wolfSSL_EC_POINT_cmp
 #define EC_POINT_is_at_infinity         wolfSSL_EC_POINT_is_at_infinity
 
-#define EC_POINT_point2hex              wolfSSL_EC_POINT_point2hex
+#ifndef HAVE_SELFTEST
+    #define EC_POINT_point2hex          wolfSSL_EC_POINT_point2hex
+#endif
+
 #define EC_POINT_dump                   wolfSSL_EC_POINT_dump
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR fixes the CAVP selftest build by excluding the wolfSSL_EC_POINT_point2hex() when "--enable-selftest" (-DHAVE_SELFTEST) is used.

The CAVP selftest uses an older version of wolfCrypt that did not have the ECC point compression types in <wolfssl/wolfcrypt/ecc.h>.

This fixes the failing Jenkins "CAVP Self Test - NIGHTLY BUILD":

```
ERRORS
Total : 6 error(s)
1 src/ssl.c: In function ‘wolfSSL_EC_POINT_point2hex’:

2 src/ssl.c:27011:58: error: ‘ECC_POINT_COMP_ODD’ undeclared (first use in this function); did you mean ‘ECC_PRIME239V3_OID’?
3 src/ssl.c:27012:58: error: ‘ECC_POINT_COMP_EVEN’ undeclared (first use in this function); did you mean ‘ECC_POINT_COMP_ODD’?
4 src/ssl.c:27015:18: error: ‘ECC_POINT_UNCOMP’ undeclared (first use in this function); did you mean ‘ECC_POINT_COMP_ODD’?

5 Makefile:4119: recipe for target 'src/src_libwolfssl_la-ssl.lo' failed
6 Makefile:2569: recipe for target 'all' failed

Total : 0 warning(s)
```