### PR TITLE
Fixed OpenSSL compatibility issues in wolfSSL_EVP_BytesToKey

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12249,29 +12249,29 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         XMEMSET(info, 0, sizeof(EncryptedInfo));
 
         ret = wc_EncryptedInfoGet(info, type);
-		if (ret < 0)
-			goto end;
+        if (ret < 0)
+            goto end;
 
-		if (data == NULL) {
-			ret = info->keySz;
-			goto end;
-		}
+        if (data == NULL) {
+            ret = info->keySz;
+            goto end;
+        }
 
-		ret = wolfSSL_EVP_get_hashinfo(md, &hashType, NULL);
-		if (ret == WOLFSSL_FAILURE)
-			goto end;
+        ret = wolfSSL_EVP_get_hashinfo(md, &hashType, NULL);
+        if (ret == WOLFSSL_FAILURE)
+            goto end;
         
-		ret = wc_PBKDF1_ex(key, info->keySz, iv, info->ivSz, data, sz, salt,
-                            EVP_SALT_SIZE, count, hashType, NULL);
-		if (ret == 0)
-			ret = info->keySz;
+        ret = wc_PBKDF1_ex(key, info->keySz, iv, info->ivSz, data, sz, salt,
+                           EVP_SALT_SIZE, count, hashType, NULL);
+        if (ret == 0)
+            ret = info->keySz;
 
-	end:
+    end:
     #ifdef WOLFSSL_SMALL_STACK
         XFREE(info, NULL, DYNAMIC_TYPE_ENCRYPTEDINFO);
     #endif
-		if (ret < 0)
-			return 0; /* failure - for compatibility */
+        if (ret < 0)
+            return 0; /* failure - for compatibility */
 
         return ret;
     }


### PR DESCRIPTION
* Fixed wrong error checks
* Changed return value to the size of the derived key
* Added support for the case where data == NULL
* Removed the assignment of a constant value to 'info->ivSz' (the correct value is assigned to it inside 'wc_EncryptedInfoGet')