### PR TITLE
Fix missing fips.h error

### DIFF
--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -20,7 +20,6 @@ nobase_include_HEADERS+= \
                          wolfssl/wolfcrypt/fe_operations.h \
                          wolfssl/wolfcrypt/ge_operations.h \
                          wolfssl/wolfcrypt/error-crypt.h \
-                         wolfssl/wolfcrypt/fips.h \
                          wolfssl/wolfcrypt/fips_test.h \
                          wolfssl/wolfcrypt/hash.h \
                          wolfssl/wolfcrypt/hc128.h \
@@ -115,3 +114,6 @@ if BUILD_SELFTEST
 nobase_include_HEADERS+= wolfssl/wolfcrypt/selftest.h
 endif
 
+if BUILD_FIPS_V2
+nobase_include_HEADERS+= wolfssl/wolfcrypt/fips.h
+endif


### PR DESCRIPTION
Reapplying fix from PR #1423. Fixes issue #1415 (again).

Steps to reproduce:

```
https://github.com/wolfSSL/wolfssl/archive/master.zip
unzip master.zip
cd wolfssl-master
./autogen.sh
./configure
make

/Applications/Xcode.app/Contents/Developer/usr/bin/make -j9  all-am
  CC       wolfcrypt/test/testsuite_testsuite_test-test.o
  CC       examples/client/testsuite_testsuite_test-client.o
  CC       examples/echoclient/testsuite_testsuite_test-echoclient.o
  CC       examples/client/tests_unit_test-client.o
  CC       examples/server/tests_unit_test-server.o
make[1]: *** No rule to make target `wolfssl/wolfcrypt/fips.h', needed by `all-am'.  Stop.
make[1]: *** Waiting for unfinished jobs....
make: *** [all] Error 2
```
This fips.h is not created by autogen.sh when .git does not exist. We should not be trying to include fips.h if not using FIPS v2 build.