### PR TITLE
Fix for PKCS7 unit test with AES disabled

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -15781,21 +15781,26 @@ static void test_wc_PKCS7_EncodeDecodeEnvelopedData (void)
     AssertIntEQ(wc_PKCS7_DecodeEnvelopedData(pkcs7, output, 0, decoded,
         (word32)sizeof(decoded)), BAD_FUNC_ARG);
     /* Should get a return of BAD_FUNC_ARG with structure data. Order matters.*/
+#if defined(HAVE_ECC) && !defined(NO_AES)
+    /* only a failure for KARI test cases */
     tempWrd32 = pkcs7->singleCertSz;
     pkcs7->singleCertSz = 0;
     AssertIntEQ(wc_PKCS7_DecodeEnvelopedData(pkcs7, output,
         (word32)sizeof(output), decoded, (word32)sizeof(decoded)), BAD_FUNC_ARG);
     pkcs7->singleCertSz = tempWrd32;
-    tempWrd32 = pkcs7->privateKeySz;
-    pkcs7->privateKeySz = 0;
-    AssertIntEQ(wc_PKCS7_DecodeEnvelopedData(pkcs7, output,
-        (word32)sizeof(output), decoded, (word32)sizeof(decoded)), BAD_FUNC_ARG);
-    pkcs7->privateKeySz = tempWrd32;
+
     tmpBytePtr = pkcs7->singleCert;
     pkcs7->singleCert = NULL;
     AssertIntEQ(wc_PKCS7_DecodeEnvelopedData(pkcs7, output,
         (word32)sizeof(output), decoded, (word32)sizeof(decoded)), BAD_FUNC_ARG);
     pkcs7->singleCert = tmpBytePtr;
+#endif
+    tempWrd32 = pkcs7->privateKeySz;
+    pkcs7->privateKeySz = 0;
+    AssertIntEQ(wc_PKCS7_DecodeEnvelopedData(pkcs7, output,
+        (word32)sizeof(output), decoded, (word32)sizeof(decoded)), BAD_FUNC_ARG);
+    pkcs7->privateKeySz = tempWrd32;
+
     tmpBytePtr = pkcs7->privateKey;
     pkcs7->privateKey = NULL;
     AssertIntEQ(wc_PKCS7_DecodeEnvelopedData(pkcs7, output,

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -6683,6 +6683,10 @@ int wc_PKCS7_AddRecipient_KEKRI(PKCS7* pkcs7, int keyWrapOID, byte* kek,
         return encryptedKeySz;
     }
 
+    if (encryptedKeySz > MAX_ENCRYPTED_KEY_SZ) {
+        return WC_KEY_SIZE_E;
+    }
+
     encKeyOctetStrSz = SetOctetString(encryptedKeySz, encKeyOctetStr);
     totalSz += (encKeyOctetStrSz + encryptedKeySz);
 


### PR DESCRIPTION
This PR fixes:

1.  An issue caught by Jenkins when running the wolfCrypt unit test with PKCS7 enabled and AES disabled.

2.  An array bounds warning when compiling the above configuration with gcc 8.2.0.

