### PR TITLE
Fixes for building with the latest QuickAssist v1.7 driver

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3682,35 +3682,55 @@ AM_CONDITIONAL([BUILD_CAVIUM], [test "x$ENABLED_CAVIUM" = "xyes"])
 AM_CONDITIONAL([BUILD_CAVIUM_V], [test "x$ENABLED_CAVIUM_V" = "xyes"])
 
 
-# Intel Quick Assist
-tryqatdir=""
+# Intel QuickAssist
+QAT_DIR=""
+BUILD_INTEL_QAT_VERSION=2
 AC_ARG_WITH([intelqa],
-    [  --with-intelqa=PATH     PATH to Intel QuickAssit (QAT) driver dir ],
+    [  --with-intelqa=PATH     PATH to Intel QuickAssist (QAT) driver dir ],
     [
         AC_MSG_CHECKING([for intelqa])
         CPPFLAGS="$CPPFLAGS -DHAVE_INTEL_QA -DDO_CRYPTO -DUSER_SPACE"
+        OLD_LIBS="$LIBS"
 
         if test "x$withval" == "xyes" ; then
             AC_MSG_ERROR([need a PATH for --with-intelqa])
         fi
         if test "x$withval" != "xno" ; then
-            tryqatdir=$withval
+            QAT_DIR=$withval
         fi
 
-        CPPFLAGS="$CPPFLAGS -I$tryqatdir/quickassist/include -I$tryqatdir/quickassist/include/lac -I$tryqatdir/quickassist/utilities/osal/include -I$tryqatdir/quickassist/utilities/osal/src/linux/user_space/include -I$tryqatdir/quickassist/lookaside/access_layer/include -I$tryqatdir/quickassist/lookaside/access_layer/src/common/include -I$srcdir/wolfssl -I$srcdir/wolfssl/wolfcrypt/port/intel"
-        LDFLAGS="$LDFLAGS -L$tryqatdir/build -Wl,-Map=output.map"
-        LIBS="$LIBS -licp_qa_al_s"
-        LIB_ADD="-ladf_proxy -losal -lrt $LIB_ADD"
+        CPPFLAGS="$CPPFLAGS -I$QAT_DIR/quickassist/include -I$QAT_DIR/quickassist/include/lac -I$QAT_DIR/quickassist/utilities/osal/include \
+            -I$QAT_DIR/quickassist/utilities/osal/src/linux/user_space/include -I$QAT_DIR/quickassist/lookaside/access_layer/include \
+            -I$QAT_DIR/quickassist/lookaside/access_layer/src/common/include -I$srcdir/wolfssl -I$srcdir/wolfssl/wolfcrypt/port/intel \
+            -I$QAT_DIR/quickassist/utilities/libusdm_drv"
 
-        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cpa_cy_common.h"]], [[ Cpa16U count = 0; cpaCyGetNumInstances(&count); ]])],[ intelqa_linked=yes ],[ intelqa_linked=no ])
+        LDFLAGS="$LDFLAGS -L$QAT_DIR/build -Wl,-Map=output.map"
+        LIBS="$LIBS -lqat_s"
 
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cpa_cy_common.h"]], [[ Cpa16U count = 0; cpaCyGetNumInstances(&count); ]])],
+            [ intelqa_linked=yes ],[ intelqa_linked=no ])
         if test "x$intelqa_linked" == "xno" ; then
-            AC_MSG_ERROR([Intel QuickAssist not found.
-            If it's already installed, specify its path using --with-intelqa=/dir/])
+            # Try old QAT driver libraries
+            LIBS="$OLD_LIBS -licp_qa_al_s"
+
+            AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cpa_cy_common.h"]], [[ Cpa16U count = 0; cpaCyGetNumInstances(&count); ]])],
+                [ intelqa_linked=yes ],[ intelqa_linked=no ])
+            if test "x$intelqa_linked" == "xno" ; then
+                AC_MSG_ERROR([Intel QuickAssist not found.
+                If it's already installed, specify its path using --with-intelqa=/dir/])
+            else
+                BUILD_INTEL_QAT_VERSION=1
+            fi
         else
             AM_CFLAGS="$AM_CFLAGS -DHAVE_INTEL_QA -DDO_CRYPTO -DUSER_SPACE"
         fi
         AC_MSG_RESULT([yes])
+
+        if test "x$BUILD_INTEL_QAT_VERSION" == "x1" ; then
+            LIB_ADD="-ladf_proxy -losal -lrt $LIB_ADD"
+        else
+            LIB_ADD="-lusdm_drv_s -losal -lrt $LIB_ADD"
+        fi
 
         ENABLED_INTEL_QA=yes
     ],
@@ -3718,8 +3738,8 @@ AC_ARG_WITH([intelqa],
         ENABLED_INTEL_QA=no
     ]
 )
-
 AM_CONDITIONAL([BUILD_INTEL_QA], [test "x$ENABLED_INTEL_QA" = "xyes"])
+
 
 # Single Precision maths implementation
 AC_ARG_ENABLE([sp],

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -450,7 +450,7 @@ static const char* bench_Usage_msg1[][10] = {
 };
 
 static const char* bench_result_words1[][4] = {
-    { "tooks", "seconds" , "Cycles per byte", NULL },               /* 0 English  */
+    { "took", "seconds" , "Cycles per byte", NULL },           /* 0 English  */
 #ifndef NO_MULTIBYTE_PRINT
     { "を"   , "秒で処理", "1バイトあたりのサイクル数", NULL },     /* 1 Japanese */
 #endif

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -837,7 +837,7 @@ int wc_RNG_GenerateBlock(WC_RNG* rng, byte* output, word32 sz)
         /* these are blocking */
     #ifdef HAVE_CAVIUM
         return NitroxRngGenerateBlock(rng, output, sz);
-    #elif defined(HAVE_INTEL_QA)
+    #elif defined(HAVE_INTEL_QA) && defined(QAT_ENABLE_RNG)
         return IntelQaDrbg(&rng->asyncDev, output, sz);
     #else
         /* simulator not supported */

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -266,7 +266,7 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
         return BUFFER_E;
 
 #ifdef WOLFSSL_SMALL_STACK
-    key = (byte*)XMALLOC(WC_MAX_SYM_KEY_SIZE, NULL, DYNAMIC_TYPE_SYMETRIC_KEY);
+    key = (byte*)XMALLOC(WC_MAX_SYM_KEY_SIZE, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
     if (key == NULL) {
         return MEMORY_E;
     }
@@ -276,7 +276,7 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
     if ((ret = wc_PBKDF1(key, password, passwordSz, info->iv, PKCS5_SALT_SZ, 1,
                                         info->keySz, hashType)) != 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(key, NULL, DYNAMIC_TYPE_SYMETRIC_KEY);
+        XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
 #endif
         return ret;
     }
@@ -295,7 +295,7 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
 #endif /* !NO_AES && HAVE_AES_CBC && HAVE_AES_DECRYPT */
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(key, NULL, DYNAMIC_TYPE_SYMETRIC_KEY);
+    XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
 #endif
 
     return ret;
@@ -321,7 +321,7 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    key = (byte*)XMALLOC(WC_MAX_SYM_KEY_SIZE, NULL, DYNAMIC_TYPE_SYMETRIC_KEY);
+    key = (byte*)XMALLOC(WC_MAX_SYM_KEY_SIZE, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
     if (key == NULL) {
         return MEMORY_E;
     }
@@ -331,7 +331,7 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
     if ((ret = wc_PBKDF1(key, password, passwordSz, info->iv, PKCS5_SALT_SZ, 1,
                                         info->keySz, hashType)) != 0) {
 #ifdef WOLFSSL_SMALL_STACK
-        XFREE(key, NULL, DYNAMIC_TYPE_SYMETRIC_KEY);
+        XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
 #endif
         return ret;
     }
@@ -350,7 +350,7 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
 #endif /* !NO_AES && HAVE_AES_CBC */
 
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(key, NULL, DYNAMIC_TYPE_SYMETRIC_KEY);
+    XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
 #endif
 
     return ret;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -496,7 +496,7 @@
         DYNAMIC_TYPE_DIRCTX       = 81,
         DYNAMIC_TYPE_HASHCTX      = 82,
         DYNAMIC_TYPE_SEED         = 83,
-        DYNAMIC_TYPE_SYMETRIC_KEY = 84,
+        DYNAMIC_TYPE_SYMMETRIC_KEY= 84,
         DYNAMIC_TYPE_ECC_BUFFER   = 85,
         DYNAMIC_TYPE_QSH          = 86,
         DYNAMIC_TYPE_SALT         = 87,


### PR DESCRIPTION
* Updated `--with-intelqa=` to support detection of QAT driver version and use different .so libs.
* Added include and lib reference for new libusdm.
* Added `QAT_ENABLE_RNG` option.
* Fix for dynamic type spelling error (`DYNAMIC_TYPE_SYMETRIC_KEY` -> `DYNAMIC_TYPE_SYMMETRIC_KEY`).
* Fix benchmark output to use "took" not "tooks".