### PR TITLE
Fix for Intel Speedups with no AVX2

### DIFF
--- a/wolfcrypt/src/chacha.c
+++ b/wolfcrypt/src/chacha.c
@@ -55,10 +55,12 @@
 
     #if defined(__GNUC__) && ((__GNUC__ < 4) || \
                               (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
+        #undef  NO_AVX2_SUPPORT
         #define NO_AVX2_SUPPORT
     #endif
     #if defined(__clang__) && ((__clang_major__ < 3) || \
                                (__clang_major__ == 3 && __clang_minor__ <= 5))
+        #undef  NO_AVX2_SUPPORT
         #define NO_AVX2_SUPPORT
     #elif defined(__clang__) && defined(NO_AVX2_SUPPORT)
         #undef NO_AVX2_SUPPORT

--- a/wolfcrypt/src/fe_x25519_x64.i
+++ b/wolfcrypt/src/fe_x25519_x64.i
@@ -24,6 +24,7 @@
 
     #if defined(__GNUC__) && ((__GNUC__ < 4) || \
                               (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
+        #undef  NO_AVX2_SUPPORT
         #define NO_AVX2_SUPPORT
     #endif
     #if defined(__clang__) && ((__clang_major__ < 3) || \

--- a/wolfcrypt/src/poly1305.c
+++ b/wolfcrypt/src/poly1305.c
@@ -56,6 +56,7 @@
 
     #if defined(__GNUC__) && ((__GNUC__ < 4) || \
                               (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
+        #undef  NO_AVX2_SUPPORT
         #define NO_AVX2_SUPPORT
     #endif
     #if defined(__clang__) && ((__clang_major__ < 3) || \

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -115,10 +115,9 @@
 
 
 #if defined(USE_INTEL_SPEEDUP)
-    #define HAVE_INTEL_AVX1
-
     #if defined(__GNUC__) && ((__GNUC__ < 4) || \
                               (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
+        #undef  NO_AVX2_SUPPORT
         #define NO_AVX2_SUPPORT
     #endif
     #if defined(__clang__) && ((__clang_major__ < 3) || \
@@ -1192,7 +1191,7 @@ static int InitSha256(wc_Sha256* sha256)
     "xorl	%" #e ", " L1 "\n\t"                                  \
     /* L2 = (f ^ g) & e */                                            \
     "andl	%" #e ", " L2 "\n\t"                                  \
- 
+
 #define RND_STEP_0_4(a,b,c,d,e,f,g,h,i)                               \
     /* L1 = ((e>>>14) ^ e) >>> 5 */                                   \
     "rorl	$5, " L1 "\n\t"                                       \
@@ -1244,7 +1243,7 @@ static int InitSha256(wc_Sha256* sha256)
 #define RND_STEP_1_1(a,b,c,d,e,f,g,h,i)                               \
     /* L1 = e>>>14 */                                                 \
     "rorl	$14, " L1 "\n\t"                                      \
- 
+
 #define RND_STEP_1_2(a,b,c,d,e,f,g,h,i)                               \
     /* L3 = b */                                                      \
     "movl	%" #b ", " L4 "\n\t"                                  \
@@ -1254,13 +1253,13 @@ static int InitSha256(wc_Sha256* sha256)
     "addl	(" #i ")*4(" WK "), %" #h "\n\t"                      \
     /* L2 = f ^ g */                                                  \
     "xorl	%" #g ", " L2 "\n\t"                                  \
- 
+
 #define RND_STEP_1_3(a,b,c,d,e,f,g,h,i)                               \
     /* L1 = (e>>>14) ^ e */                                           \
     "xorl	%" #e ", " L1 "\n\t"                                  \
     /* L2 = (f ^ g) & e */                                            \
     "andl	%" #e ", " L2 "\n\t"                                  \
- 
+
 #define RND_STEP_1_4(a,b,c,d,e,f,g,h,i)                               \
     /* L1 = ((e>>>14) ^ e) >>> 5 */                                   \
     "rorl	$5, " L1 "\n\t"                                       \

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -146,10 +146,9 @@
 
 
 #if defined(USE_INTEL_SPEEDUP)
-    #define HAVE_INTEL_AVX1
-
     #if defined(__GNUC__) && ((__GNUC__ < 4) || \
                               (__GNUC__ == 4 && __GNUC_MINOR__ <= 8))
+        #undef  NO_AVX2_SUPPORT
         #define NO_AVX2_SUPPORT
     #endif
     #if defined(__clang__) && ((__clang_major__ < 3) || \


### PR DESCRIPTION
* Fix for Curve25519 FE math build error with Intel Speedups enabled and no AVX2.
* Fixes to allow forcing `NO_AVX2_SUPPORT`.

Reproducible with `./configure --enable-curve25519 --enable-ed25519 --enable-intelasm CFLAGS="-DNO_AVX2_SUPPORT"`.