### PR TITLE
Code coverage tests and fixes

### DIFF
--- a/doc/dox_comments/header_files/evp.h
+++ b/doc/dox_comments/header_files/evp.h
@@ -377,6 +377,28 @@ WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_set_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, i
 /*!
     \ingroup openSSL
 
+    \brief Clearing function for WOLFSSL_EVP_CIPHER_CTX structure.
+
+    \return none No returns.
+
+    \param ctx structure to clear flag.
+    \param flag flag value to clear in structure.
+
+    _Example_
+    \code
+    WOLFSSL_EVP_CIPHER_CTX* ctx;
+    int flag;
+    // create ctx
+    wolfSSL_EVP_CIPHER_CTX_clear_flags(ctx, flag);
+    \endcode
+
+    \sa wolfSSL_EVP_CIPHER_flags
+*/
+WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_clear_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags);
+
+/*!
+    \ingroup openSSL
+
     \brief Setter function for WOLFSSL_EVP_CIPHER_CTX structure to use padding.
 
     \return SSL_SUCCESS If successfully set.

--- a/tests/api.c
+++ b/tests/api.c
@@ -19849,7 +19849,7 @@ static void test_wolfSSL_SESSION(void)
 #ifdef HAVE_SESSION_TICKET
     /* Test set/get session ticket */
     {
-        const char ticket[] = "This is a session ticket";
+        const char* ticket = "This is a session ticket";
         char buf[64] = {0};
         word32 bufSz = (word32)sizeof(buf);
 
@@ -21218,7 +21218,7 @@ static void test_wc_SetSubjectRaw(void)
 {
 #if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
-    char joiCertFile[] = "./certs/test/cert-ext-joi.pem";
+    const char* joiCertFile = "./certs/test/cert-ext-joi.pem";
     WOLFSSL_X509* x509;
     int peerCertSz;
     const byte* peerCertBuf;
@@ -21260,7 +21260,7 @@ static void test_wc_SetIssuerRaw(void)
 {
 #if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
-    char joiCertFile[] = "./certs/test/cert-ext-joi.pem";
+    const char* joiCertFile = "./certs/test/cert-ext-joi.pem";
     WOLFSSL_X509* x509;
     int peerCertSz;
     const byte* peerCertBuf;
@@ -21286,7 +21286,7 @@ static void test_wc_SetIssueBuffer(void)
 {
 #if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
-    const char joiCertFile[] = "./certs/test/cert-ext-joi.pem";
+    const char* joiCertFile = "./certs/test/cert-ext-joi.pem";
     WOLFSSL_X509* x509;
     int peerCertSz;
     const byte* peerCertBuf;
@@ -21316,7 +21316,7 @@ static void test_wc_SetSubjectKeyId(void)
 #if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
     Cert cert;
-    const char file[] = "certs/ecc-client-keyPub.pem";
+    const char* file = "certs/ecc-client-keyPub.pem";
 
     printf(testingFmt, "wc_SetSubjectKeyId()");
 
@@ -21338,7 +21338,7 @@ static void test_wc_SetSubject(void)
 #if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
     Cert cert;
-    const char file[] = "./certs/ca-ecc-cert.pem";
+    const char* file = "./certs/ca-ecc-cert.pem";
 
     printf(testingFmt, "wc_SetSubject()");
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -19849,7 +19849,7 @@ static void test_wolfSSL_SESSION(void)
 #ifdef HAVE_SESSION_TICKET
     /* Test set/get session ticket */
     {
-        const char* ticket = "This is a session ticket";
+        const char ticket[] = "This is a session ticket";
         char buf[64] = {0};
         word32 bufSz = (word32)sizeof(buf);
 
@@ -21286,7 +21286,7 @@ static void test_wc_SetIssueBuffer(void)
 {
 #if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
-    const char* joiCertFile = "./certs/test/cert-ext-joi.pem";
+    const char joiCertFile[] = "./certs/test/cert-ext-joi.pem";
     WOLFSSL_X509* x509;
     int peerCertSz;
     const byte* peerCertBuf;
@@ -21316,7 +21316,7 @@ static void test_wc_SetSubjectKeyId(void)
 #if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
     Cert cert;
-    char file[] = "certs/ecc-client-keyPub.pem";
+    const char file[] = "certs/ecc-client-keyPub.pem";
 
     printf(testingFmt, "wc_SetSubjectKeyId()");
 
@@ -21338,7 +21338,7 @@ static void test_wc_SetSubject(void)
 #if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
     Cert cert;
-    char file[] = "./certs/ca-ecc-cert.pem";
+    const char file[] = "./certs/ca-ecc-cert.pem";
 
     printf(testingFmt, "wc_SetSubject()");
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -16662,10 +16662,8 @@ static void test_wc_PemPubKeyToDer(void)
 
     printf(testingFmt, "wc_PemPubKeyToDer()");
 
-#if 0 /* NULL filename causes valgrind failure */
     ret = wc_PemPubKeyToDer(NULL, cert_der, (int)cert_dersz);
-    AssertIntGE(ret, BUFFER_E);
-#endif
+    AssertIntGE(ret, BAD_FUNC_ARG);
 
     if (cert_der) {
         ret = wc_PemPubKeyToDer(key, cert_der, (int)cert_dersz);
@@ -19851,7 +19849,7 @@ static void test_wolfSSL_SESSION(void)
 #ifdef HAVE_SESSION_TICKET
     /* Test set/get session ticket */
     {
-        char ticket[] = "This is a session ticket";
+        const char* ticket = "This is a session ticket";
         char buf[64] = {0};
         word32 bufSz = (word32)sizeof(buf);
 
@@ -21288,7 +21286,7 @@ static void test_wc_SetIssueBuffer(void)
 {
 #if !defined(NO_ASN) && !defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
-    char joiCertFile[] = "./certs/test/cert-ext-joi.pem";
+    const char* joiCertFile = "./certs/test/cert-ext-joi.pem";
     WOLFSSL_X509* x509;
     int peerCertSz;
     const byte* peerCertBuf;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9252,15 +9252,22 @@ int wc_PemCertToDer(const char* fileName, unsigned char* derBuf, int derSz)
     int    dynamic = 0;
     int    ret     = 0;
     long   sz      = 0;
-    XFILE  file    = XFOPEN(fileName, "rb");
+    XFILE  file;
     DerBuffer* converted = NULL;
 
     WOLFSSL_ENTER("wc_PemCertToDer");
 
-    if (file == XBADFILE) {
-        ret = BUFFER_E;
+    if (fileName == NULL) {
+        ret = BAD_FUNC_ARG;
     }
     else {
+        file = XFOPEN(fileName, "rb");
+        if (file == XBADFILE) {
+            ret = BUFFER_E;
+        }
+    }
+
+    if (ret == 0) {
         if(XFSEEK(file, 0, XSEEK_END) != 0)
             ret = BUFFER_E;
         sz = XFTELL(file);
@@ -9326,15 +9333,22 @@ int wc_PemPubKeyToDer(const char* fileName,
     int    dynamic = 0;
     int    ret     = 0;
     long   sz      = 0;
-    XFILE  file    = XFOPEN(fileName, "rb");
+    XFILE  file;
     DerBuffer* converted = NULL;
 
     WOLFSSL_ENTER("wc_PemPubKeyToDer");
 
-    if (file == XBADFILE) {
-        ret = BUFFER_E;
+    if (fileName == NULL) {
+        ret = BAD_FUNC_ARG;
     }
     else {
+        file = XFOPEN(fileName, "rb");
+        if (file == XBADFILE) {
+            ret = BUFFER_E;
+        }
+    }
+
+    if (ret == 0) {
         if(XFSEEK(file, 0, XSEEK_END) != 0)
             ret = BUFFER_E;
         sz = XFTELL(file);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -13017,8 +13017,13 @@ int wc_SetIssuer(Cert* cert, const char* issuerFile)
 {
     int         ret;
     int         derSz;
-    byte*       der = (byte*)XMALLOC(EIGHTK_BUF, cert->heap, DYNAMIC_TYPE_CERT);
+    byte*       der;
 
+    if (cert == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    der = (byte*)XMALLOC(EIGHTK_BUF, cert->heap, DYNAMIC_TYPE_CERT);
     if (der == NULL) {
         WOLFSSL_MSG("wc_SetIssuer OOF Problem");
         return MEMORY_E;
@@ -13037,12 +13042,18 @@ int wc_SetSubject(Cert* cert, const char* subjectFile)
 {
     int         ret;
     int         derSz;
-    byte*       der = (byte*)XMALLOC(EIGHTK_BUF, cert->heap, DYNAMIC_TYPE_CERT);
+    byte*       der;
 
+    if (cert == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    der = (byte*)XMALLOC(EIGHTK_BUF, cert->heap, DYNAMIC_TYPE_CERT);
     if (der == NULL) {
         WOLFSSL_MSG("wc_SetSubject OOF Problem");
         return MEMORY_E;
     }
+
     derSz = wc_PemCertToDer(subjectFile, der, EIGHTK_BUF);
     ret = SetNameFromCert(&cert->subject, der, derSz);
     XFREE(der, cert->heap, DYNAMIC_TYPE_CERT);
@@ -13057,8 +13068,13 @@ int wc_SetAltNames(Cert* cert, const char* file)
 {
     int         ret;
     int         derSz;
-    byte*       der = (byte*)XMALLOC(EIGHTK_BUF, cert->heap, DYNAMIC_TYPE_CERT);
+    byte*       der;
 
+    if (cert == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    der = (byte*)XMALLOC(EIGHTK_BUF, cert->heap, DYNAMIC_TYPE_CERT);
     if (der == NULL) {
         WOLFSSL_MSG("wc_SetAltNames OOF Problem");
         return MEMORY_E;
@@ -13077,6 +13093,10 @@ int wc_SetAltNames(Cert* cert, const char* file)
 /* Set cert issuer from DER buffer */
 int wc_SetIssuerBuffer(Cert* cert, const byte* der, int derSz)
 {
+    if (cert == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
     cert->selfSigned = 0;
     return SetNameFromCert(&cert->issuer, der, derSz);
 }
@@ -13084,6 +13104,10 @@ int wc_SetIssuerBuffer(Cert* cert, const byte* der, int derSz)
 /* Set cert subject from DER buffer */
 int wc_SetSubjectBuffer(Cert* cert, const byte* der, int derSz)
 {
+    if (cert == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
     return SetNameFromCert(&cert->subject, der, derSz);
 }
 #ifdef WOLFSSL_CERT_EXT

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -175,22 +175,24 @@ WOLFSSL_API int  wolfSSL_EVP_EncryptFinal_ex(WOLFSSL_EVP_CIPHER_CTX *ctx,
 WOLFSSL_API int  wolfSSL_EVP_DecryptFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
                                    unsigned char *out, int *outl)
 {
-  if (ctx && ctx->enc)
-      return WOLFSSL_FAILURE;
-  else {
-      WOLFSSL_ENTER("wolfSSL_EVP_DecryptFinal");
-      return wolfSSL_EVP_CipherFinal(ctx, out, outl);
-  }
+    if (ctx && ctx->enc) {
+        WOLFSSL_ENTER("wolfSSL_EVP_DecryptFinal");
+        return wolfSSL_EVP_CipherFinal(ctx, out, outl);
+    }
+    else {
+        return WOLFSSL_FAILURE;
+    }
 }
 
 WOLFSSL_API int  wolfSSL_EVP_DecryptFinal_ex(WOLFSSL_EVP_CIPHER_CTX *ctx,
                                    unsigned char *out, int *outl)
 {
-    if (ctx && ctx->enc)
-        return WOLFSSL_FAILURE;
-    else {
+    if (ctx && ctx->enc) {
         WOLFSSL_ENTER("wolfSSL_EVP_CipherFinal_ex");
         return wolfSSL_EVP_CipherFinal(ctx, out, outl);
+    }
+    else {
+        return WOLFSSL_FAILURE;
     }
 }
 
@@ -613,7 +615,14 @@ WOLFSSL_API unsigned long WOLFSSL_EVP_CIPHER_mode(const WOLFSSL_EVP_CIPHER *ciph
 WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_set_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags)
 {
     if (ctx != NULL) {
-        ctx->flags = flags;
+        ctx->flags |= flags;
+    }
+}
+
+WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_clear_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags)
+{
+    if (ctx != NULL) {
+        ctx->flags &= ~flags;
     }
 }
 

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -414,6 +414,7 @@ WOLFSSL_API unsigned long WOLFSSL_EVP_CIPHER_mode(const WOLFSSL_EVP_CIPHER *ciph
 WOLFSSL_API unsigned long WOLFSSL_CIPHER_mode(const WOLFSSL_EVP_CIPHER *cipher);
 WOLFSSL_API unsigned long wolfSSL_EVP_CIPHER_flags(const WOLFSSL_EVP_CIPHER *cipher);
 WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_set_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags);
+WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_clear_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags);
 WOLFSSL_API unsigned long wolfSSL_EVP_CIPHER_CTX_mode(const WOLFSSL_EVP_CIPHER_CTX *ctx);
 WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_set_padding(WOLFSSL_EVP_CIPHER_CTX *c, int pad);
 WOLFSSL_API int  wolfSSL_EVP_add_digest(const WOLFSSL_EVP_MD *digest);
@@ -585,6 +586,7 @@ typedef WOLFSSL_EVP_CIPHER_CTX EVP_CIPHER_CTX;
 #define EVP_CIPHER_block_size      wolfSSL_EVP_CIPHER_block_size
 #define EVP_CIPHER_flags           wolfSSL_EVP_CIPHER_flags
 #define EVP_CIPHER_CTX_set_flags   wolfSSL_EVP_CIPHER_CTX_set_flags
+#define EVP_CIPHER_CTX_clear_flags wolfSSL_EVP_CIPHER_CTX_clear_flags
 #define EVP_CIPHER_CTX_set_padding wolfSSL_EVP_CIPHER_CTX_set_padding
 #define EVP_CIPHER_CTX_flags       wolfSSL_EVP_CIPHER_CTX_flags
 #define EVP_add_digest             wolfSSL_EVP_add_digest


### PR DESCRIPTION
New tests to increase code coverage percentages. Also fix for `wolfSSL_EVP_CIPHER_CTX_set_flags` and adding `wolfSSL_EVP_CIPHER_CTX_clear_flags` to match behavior in openssl.