### PR TITLE
add define to use test/benchmark.h without path prefix

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -548,7 +548,11 @@ static const char* bench_desc_words[][9] = {
     #pragma warning(disable: 4996)
 #endif
 
-#include "wolfcrypt/benchmark/benchmark.h"
+#ifdef USE_FLAT_BENCHMARK_H
+    #include "benchmark.h"
+#else
+    #include "wolfcrypt/benchmark/benchmark.h"
+#endif
 
 #ifdef WOLFSSL_CURRTIME_REMAP
     #define current_time WOLFSSL_CURRTIME_REMAP

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -216,7 +216,11 @@
     #define printf wolfssl_pb_print
 #endif
 
-#include "wolfcrypt/test/test.h"
+#ifdef USE_FLAT_TEST_H
+    #include "test.h"
+#else
+    #include "wolfcrypt/test/test.h"
+#endif
 
 #if defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_MULTI_ATTRIB)
 static void initDefaultName(void);


### PR DESCRIPTION
This PR adds a define to test.c (USE_FLAT_TEST_H) and benchmark.c (USE_FLAT_BENCHMARK_H) for the use cases where users pull out "test.c/.h" or "benchmark.c/.h" into their own project structure.  They may not have the "wolfcrypt/test" and/or "wolfcrypt/benchmark" directory structure at that point.