### PR TITLE
Fixes for STM32 AES GCM crypto hardware acceleration

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1868,7 +1868,9 @@ static void bench_aesgcm_internal(int doAsync, const byte* key, word32 keySz,
 {
     int    ret = 0, i, count = 0, times, pending = 0;
     Aes    enc[BENCH_MAX_PENDING];
+#ifdef HAVE_AES_DECRYPT
     Aes    dec[BENCH_MAX_PENDING];
+#endif
     double start;
 
     DECLARE_VAR(bench_additional, byte, AES_AUTH_ADD_SZ, HEAP_HINT);
@@ -1876,14 +1878,17 @@ static void bench_aesgcm_internal(int doAsync, const byte* key, word32 keySz,
 
     /* clear for done cleanup */
     XMEMSET(enc, 0, sizeof(enc));
+#ifdef HAVE_AES_DECRYPT
+    XMEMSET(dec, 0, sizeof(dec));
+#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     if (bench_additional)
 #endif
-    {   XMEMSET(bench_additional, 0, AES_AUTH_ADD_SZ); }
+        XMEMSET(bench_additional, 0, AES_AUTH_ADD_SZ);
 #ifdef WOLFSSL_ASYNC_CRYPT
     if (bench_tag)
 #endif
-    {   XMEMSET(bench_tag, 0, AES_AUTH_TAG_SZ); }
+        XMEMSET(bench_tag, 0, AES_AUTH_TAG_SZ);
 
     /* init keys */
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
@@ -1962,10 +1967,6 @@ exit_aes_gcm:
     } while (bench_stats_sym_check(start));
 exit_aes_gcm_dec:
     bench_stats_sym_finish(decLabel, doAsync, count, bench_size, start, ret);
-
-    for (i = 0; i < BENCH_MAX_PENDING; i++) {
-        wc_AesFree(&dec[i]);
-    }
 #endif /* HAVE_AES_DECRYPT */
 
     (void)decLabel;
@@ -1975,7 +1976,11 @@ exit:
     if (ret < 0) {
         printf("bench_aesgcm failed: %d\n", ret);
     }
-
+#ifdef HAVE_AES_DECRYPT
+    for (i = 0; i < BENCH_MAX_PENDING; i++) {
+        wc_AesFree(&dec[i]);
+    }
+#endif
     for (i = 0; i < BENCH_MAX_PENDING; i++) {
         wc_AesFree(&enc[i]);
     }

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -8224,7 +8224,7 @@ static WC_INLINE int wc_AesGcmEncrypt_STM32(Aes* aes, byte* out, const byte* in,
     }
     XMEMCPY(outPadded, in, sz);
 
-    if ((authInSz % AES_BLOCK_SIZE) != 0) {
+    if (authInSz == 0 || (authInSz % AES_BLOCK_SIZE) != 0) {
         /* Need to pad the AAD to a full block with zeros. */
         authPadSz = ((authInSz / AES_BLOCK_SIZE) + 1) * AES_BLOCK_SIZE;
         authInPadded = (byte*)XMALLOC(authPadSz, aes->heap,
@@ -8446,8 +8446,8 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                               defined(WOLFSSL_STM32F7) || \
                               defined(WOLFSSL_STM32L4))
 
-    /* additional argument checks - STM32 HW only supports 12 byte IV */
-    if (ivSz == GCM_NONCE_MID_SZ) {
+    /* STM32 HW only supports 12 byte IV and 16 byte auth */
+    if (ivSz == GCM_NONCE_MID_SZ && authInSz == AES_BLOCK_SIZE) {
         return wc_AesGcmEncrypt_STM32(aes, out, in, sz, iv, ivSz,
                                       authTag, authTagSz, authIn, authInSz);
     }
@@ -8611,7 +8611,7 @@ static WC_INLINE int wc_AesGcmDecrypt_STM32(Aes* aes, byte* out,
     }
     XMEMCPY(outPadded, in, sz);
 
-    if ((authInSz % AES_BLOCK_SIZE) != 0) {
+    if (authInSz == 0 || (authInSz % AES_BLOCK_SIZE) != 0) {
         /* Need to pad the AAD to a full block with zeros. */
         authPadSz = ((authInSz / AES_BLOCK_SIZE) + 1) * AES_BLOCK_SIZE;
         authInPadded = (byte*)XMALLOC(authPadSz, aes->heap,
@@ -8848,8 +8848,8 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
                               defined(WOLFSSL_STM32F7) || \
                               defined(WOLFSSL_STM32L4))
 
-    /* additional argument checks - STM32 HW only supports 12 byte IV */
-    if (ivSz == GCM_NONCE_MID_SZ) {
+    /* STM32 HW only supports 12 byte IV and 16 byte auth */
+    if (ivSz == GCM_NONCE_MID_SZ && authInSz == AES_BLOCK_SIZE) {
         return wc_AesGcmDecrypt_STM32(aes, out, in, sz, iv, ivSz,
                                       authTag, authTagSz, authIn, authInSz);
     }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -6133,7 +6133,7 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
 
         #ifdef WOLFSSL_ASYNC_CRYPT
             if (sigCtx->devId != INVALID_DEVID && sigCtx->asyncDev && sigCtx->asyncCtx) {
-                /* make sure event is intialized */
+                /* make sure event is initialized */
                 WOLF_EVENT* event = &sigCtx->asyncDev->event;
                 ret = wolfAsync_EventInit(event, WOLF_EVENT_TYPE_ASYNC_WOLFSSL,
                     sigCtx->asyncCtx, WC_ASYNC_FLAG_CALL_AGAIN);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -769,7 +769,8 @@ initDefaultName();
         printf( "AES256   test passed!\n");
 #endif
 #ifdef HAVE_AESGCM
-    #if !defined(WOLFSSL_AFALG) && !defined(WOLFSSL_DEVCRYPTO) && !defined(STM32_CRYPTO)
+    #if !defined(WOLFSSL_AFALG) && !defined(WOLFSSL_DEVCRYPTO) && \
+        !defined(STM32_CRYPTO)
     if ( (ret = aesgcm_test()) != 0)
         return err_sys("AES-GCM  test failed!\n", ret);
     else
@@ -6630,8 +6631,8 @@ static int aesgcm_default_test_helper(byte* key, int keySz, byte* iv, int ivSz,
 		byte* plain, int plainSz, byte* cipher, int cipherSz,
 		byte* aad, int aadSz, byte* tag, int tagSz)
 {
-Aes enc;
-Aes dec;
+    Aes enc;
+    Aes dec;
 
     byte resultT[AES_BLOCK_SIZE];
     byte resultP[AES_BLOCK_SIZE * 3];


### PR DESCRIPTION
* Fixes to ensure the "const" input buffer is not modified for AES GCM calls with STM32 hardware crypto.
* Improvements to allow AES GCM hardware acceleration for inputs that are not a multiple of AES block size.
* Switched the wolfCrypt test for STM32_CRYPTO to use the standard AES GCM tests with 12-byte IV and less than 16-byte auth data.
* Fixes for building AES GCM with the standard peripheral library.
* Fixes for building with `NO_AES_DECRYPT`.
`./configure --enable-debug --disable-shared --enable-cryptonly CFLAGS="-DNO_AES_DECRYPT"`
* Various spelling fixes.

ZD 4590