### PR TITLE
ALPN is returned in ServerHello even in TLS 1.3

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -9951,6 +9951,7 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte msgType,
 #ifdef WOLFSSL_TLS13
                 if (IsAtLeastTLSv1_3(ssl->ctx->method->version) &&
                         msgType != client_hello &&
+                        msgType != server_hello &&
                         msgType != encrypted_extensions) {
                     return EXT_NOT_ALLOWED;
                 }


### PR DESCRIPTION
Specification only says to expect it in ClientHello and
EncryptedExtensions.