### PR TITLE
Include current cert as X509 in verify callback for small build

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -8608,13 +8608,13 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
     if (use_cb && ssl->verifyCallback) {
     #ifdef WOLFSSL_SMALL_STACK
         WOLFSSL_X509_STORE_CTX* store;
-        #ifdef OPENSSL_EXTRA
+        #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         WOLFSSL_X509* x509;
         #endif
         char* domain = NULL;
     #else
         WOLFSSL_X509_STORE_CTX store[1];
-        #ifdef OPENSSL_EXTRA
+        #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         WOLFSSL_X509           x509[1];
         #endif
         char domain[ASN_NAME_MAX];
@@ -8626,7 +8626,7 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
         if (store == NULL) {
             return MEMORY_E;
         }
-        #ifdef OPENSSL_EXTRA
+        #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), ssl->heap,
             DYNAMIC_TYPE_X509);
         if (x509 == NULL) {
@@ -8637,7 +8637,7 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
         domain = (char*)XMALLOC(ASN_NAME_MAX, ssl->heap, DYNAMIC_TYPE_STRING);
         if (domain == NULL) {
             XFREE(store, ssl->heap, DYNAMIC_TYPE_X509);
-            #ifdef OPENSSL_EXTRA
+            #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
             XFREE(x509, ssl->heap, DYNAMIC_TYPE_X509);
             #endif
             return MEMORY_E;
@@ -8645,7 +8645,7 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
     #endif /* WOLFSSL_SMALL_STACK */
 
         XMEMSET(store, 0, sizeof(WOLFSSL_X509_STORE_CTX));
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         XMEMSET(x509, 0, sizeof(WOLFSSL_X509));
     #endif
         domain[0] = '\0';
@@ -8678,11 +8678,14 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
             store->store = &ssl->ctx->x509_store;
         }
     #endif
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+        #ifdef KEEP_PEER_CERT
         if (args->certIdx == 0) {
             store->current_cert = &ssl->peerCert; /* use existing X509 */
         }
-        else {
+        else
+        #endif
+        {
             InitX509(x509, 0, ssl->heap);
             if (CopyDecodedToX509(x509, args->dCert) == 0) {
                 store->current_cert = x509;
@@ -8708,7 +8711,7 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
             /* mark as verify error */
             args->verifyErr = 1;
         }
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         if (args->certIdx > 0)
             FreeX509(x509);
     #endif
@@ -8727,7 +8730,7 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
     #endif /* SESSION_CERTS */
     #ifdef WOLFSSL_SMALL_STACK
         XFREE(domain, ssl->heap, DYNAMIC_TYPE_STRING);
-        #ifdef OPENSSL_EXTRA
+        #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         XFREE(x509, ssl->heap, DYNAMIC_TYPE_X509);
         #endif
         XFREE(store, ssl->heap, DYNAMIC_TYPE_X509_STORE);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1559,7 +1559,7 @@ static int myVerifyFail = 0;
 static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
 {
     char buffer[WOLFSSL_MAX_ERROR_SZ];
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     WOLFSSL_X509* peer;
 #endif
     (void)preverify;
@@ -1581,7 +1581,7 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
 
     printf("In verification callback, error = %d, %s\n", store->error,
                                  wolfSSL_ERR_error_string(store->error, buffer));
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     peer = store->current_cert;
     if (peer) {
         char* issuer  = wolfSSL_X509_NAME_oneline(


### PR DESCRIPTION
Fix to populate the X509 `current_cert` in the verify callback with `OPENSSL_EXTRA_X509_SMALL` defined or `./configure --enable-opensslextra=x509small`. Also supports use with `KEEP_PEER_CERT`. ZD 4632.