### PR TITLE
Resolve snprintf build issue with pkcs7 and no filesystem

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -361,8 +361,9 @@
         /* snprintf is used in asn.c for GetTimeString, PKCS7 test, and when
            debugging is turned on */
         #ifndef USE_WINDOWS_API
-            #if defined(NO_FILESYSTEM) && defined(OPENSSL_EXTRA) && \
-               !defined(NO_STDIO_FILESYSTEM)
+            #if defined(NO_FILESYSTEM) && \
+                ( defined(HAVE_PKCS7) || defined(OPENSSL_EXTRA) ) && \
+                !defined(NO_STDIO_FILESYSTEM)
                 /* case where stdio is not included else where but is needed for
                  * snprintf */
                 #include <stdio.h>


### PR DESCRIPTION
Tested configuration: --enable-pkcs7 --disable-filesystem