### PR TITLE
Adds RSA non-blocking time support

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -55,7 +55,9 @@ Possible RSA enable options:
  * WOLFSSL_KEY_GEN:     Allows Private Key Generation               default: off
  * RSA_LOW_MEM:         NON CRT Private Operations, less memory     default: off
  * WC_NO_RSA_OAEP:      Disables RSA OAEP padding                   default: on (not defined)
-
+ * WC_RSA_NONBLOCK:     Enables support for RSA non-blocking        default: off
+ * WC_RSA_NONBLOCK_TIME:Enables support for time based blocking     default: off
+ *                      time calculation.
 */
 
 /*
@@ -2813,7 +2815,7 @@ int wc_RsaEncryptSize(RsaKey* key)
         return BAD_FUNC_ARG;
     }
 
-    ret =  mp_unsigned_bin_size(&key->n);
+    ret = mp_unsigned_bin_size(&key->n);
 
 #ifdef WOLF_CRYPTO_DEV
     if (ret == 0 && key->devId != INVALID_DEVID) {
@@ -3386,6 +3388,19 @@ int wc_RsaSetNonBlock(RsaKey* key, RsaNb* nb)
 
     return 0;
 }
+#ifdef WC_RSA_NONBLOCK_TIME
+int wc_RsaSetNonBlockTime(RsaKey* key, word32 maxBlockUs, word32 cpuMHz)
+{
+    if (key == NULL || key->nb == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* calculate maximum number of instructions to block */
+    key->nb->exptmod.maxBlockInst = cpuMHz * maxBlockUs;
+
+    return 0;
+}
+#endif /* WC_RSA_NONBLOCK_TIME */
 #endif /* WC_RSA_NONBLOCK */
 
 #endif /* NO_RSA */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9383,6 +9383,13 @@ static int rsa_nb_test(RsaKey* key, const byte* in, word32 inLen, byte* out,
     if (ret != 0)
         return ret;
 
+#ifdef WC_RSA_NONBLOCK_TIME
+    /* Enable time based RSA blocking. 8 microseconds max (3.1GHz) */
+    ret = wc_RsaSetNonBlockTime(key, 8, 3100);
+    if (ret != 0)
+        return ret;
+#endif
+
     count = 0;
     do {
         ret = wc_RsaSSL_Sign(in, inLen, out, outSz, key, rng);

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -43,6 +43,9 @@
     #ifndef USE_FAST_MATH
         #error RSA non-blocking mode only supported using fast math
     #endif
+    #ifndef TFM_TIMING_RESISTANT
+      #error RSA non-blocking mode only supported with timing resistance enabled
+    #endif
 
     /* RSA bounds check is not supported with RSA non-blocking mode */
     #undef  NO_RSA_BOUNDS_CHECK
@@ -268,6 +271,10 @@ WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
 #endif
 #ifdef WC_RSA_NONBLOCK
     WOLFSSL_API int wc_RsaSetNonBlock(RsaKey* key, RsaNb* nb);
+    #ifdef WC_RSA_NONBLOCK_TIME
+    WOLFSSL_API int wc_RsaSetNonBlockTime(RsaKey* key, word32 maxBlockUs,
+                                          word32 cpuMHz);
+    #endif
 #endif
 
 /*

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -554,6 +554,7 @@ enum tfmExptModNbState {
   TFM_EXPTMOD_NB_SQR,
   TFM_EXPTMOD_NB_SQR_RED,
   TFM_EXPTMOD_NB_RED,
+  TFM_EXPTMOD_NB_COUNT /* last item for total state count only */
 };
 
 typedef struct {
@@ -562,12 +563,24 @@ typedef struct {
 #else
   fp_int   R[2];
 #endif
-  fp_digit buf, mp;
+  fp_digit buf;
+  fp_digit mp;
   int bitcnt;
   int digidx;
   int y;
   int state; /* tfmExptModNbState */
+#ifdef WC_RSA_NONBLOCK_TIME
+  word32 maxBlockInst; /* maximum instructions to block */
+  word32 totalInst;    /* tracks total instructions */
+#endif
 } exptModNb_t;
+
+#ifdef WC_RSA_NONBLOCK_TIME
+enum {
+  TFM_EXPTMOD_NB_STOP = 0,     /* stop and return FP_WOULDBLOCK */
+  TFM_EXPTMOD_NB_CONTINUE = 1, /* keep blocking */
+};
+#endif
 
 /* non-blocking version of timing resistant fp_exptmod function */
 /* supports cache resistance */


### PR DESCRIPTION
Adds new `wc_RsaSetNonblockTime` API and `WC_RSA_NONBLOCK_TIME` build option. This new function configures the maximum amount of blocking time in microseconds. It uses a pre-computed table along with the CPU speed in megahertz to determine if the next operation can be completed within the maximum blocking time provided.

Tested and supported with PowerPC 32-bit (TFM_PPC), x86_64 (TFM_X86_64) and x86_64 with no assembly speedups (TFM_NO_ASM).

The `fp_exptmod_nb` "check time" function can be overwritten at build-time using `FP_EXPTMOD_NB_CHECKTIME` with prototype `int fp_exptmod_nb_checktime(exptModNb_t* nb)` where `TFM_EXPTMOD_NB_CONTINUE` or `TFM_EXPTMOD_NB_STOP` is returned.