### PR TITLE
Fix HelloRetryRequest to be sent immediately and not grouped

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4235,7 +4235,11 @@ int SendTls13ServerHello(WOLFSSL* ssl, byte extMsgType)
         ssl->options.serverState = SERVER_HELLO_COMPLETE;
 #endif
 
+#ifdef WOLFSSL_TLS13_DRAFT_18
     if (!ssl->options.groupMessages)
+#else
+    if (!ssl->options.groupMessages || extMsgType != server_hello)
+#endif
         ret = SendBuffered(ssl);
 
     WOLFSSL_LEAVE("SendTls13ServerHello", ret);


### PR DESCRIPTION
The grouping of messages was incorrect when they changed the HelloRetryRequest to be a modified ServerHello. The code always groups the message with the next regardless of it being the HRR or SH. The HRR must be sent straight away while the SH can be grouped.

Reproducible with:
`./examples/server/server -v 4 -g -b -d -f`
Chrome: `https://127.0.0.1:11111/`

ZD 4575