### PR TITLE
Async release v3.15.7 prep

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1541,7 +1541,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EITHER_SIDE)
                 else if (myoptarg[0] == 'e') {
                     version = EITHER_DOWNGRADE_VERSION;
+                #ifndef NO_CERTS
                     loadCertKeyIntoSSLObj = 1;
+                #endif
                     break;
                 }
             #endif
@@ -1581,7 +1583,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             #endif
                 else if (XSTRNCMP(myoptarg, "loadSSL", 7) == 0) {
                     printf("Load cert/key into wolfSSL object\n");
+                #ifndef NO_CERTS
                     loadCertKeyIntoSSLObj = 1;
+                #endif
                 }
                 else {
                     Usage();

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -953,7 +953,9 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EITHER_SIDE)
                 else if (myoptarg[0] == 'e') {
                     version = EITHER_DOWNGRADE_VERSION;
+                #ifndef NO_CERTS
                     loadCertKeyIntoSSLObj = 1;
+                #endif
                     break;
                 }
             #endif
@@ -983,7 +985,9 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 }
                 else if (XSTRNCMP(myoptarg, "loadSSL", 7) == 0) {
                     printf("Load cert/key into wolfSSL object\n");
+                #ifndef NO_CERTS
                     loadCertKeyIntoSSLObj = 1;
+                #endif
                 }
                 else {
                     Usage();

--- a/src/internal.c
+++ b/src/internal.c
@@ -8843,7 +8843,11 @@ static int ProcessPeerCertParse(WOLFSSL* ssl, ProcPeerCertArgs* args,
 #endif /* WOLFSSL_SMALL_CERT_VERIFY */
 
     /* make sure the decoded cert structure is allocated and initialized */
-    if (!args->dCertInit) {
+    if (!args->dCertInit
+    #ifdef WOLFSSL_SMALL_CERT_VERIFY
+        || args->dCert == NULL
+    #endif
+    ) {
     #ifdef WOLFSSL_SMALL_CERT_VERIFY
         if (args->dCert == NULL) {
             args->dCert = (DecodedCert*)XMALLOC(

--- a/src/internal.c
+++ b/src/internal.c
@@ -10858,7 +10858,13 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             SendAlert(ssl, alert_fatal, decode_error);
         ret = DECODE_E;
     }
-    if (ret == 0 && ssl->buffers.inputBuffer.dynamicFlag) {
+
+    if (ret == 0 && ssl->buffers.inputBuffer.dynamicFlag
+    #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
+        /* do not shrink input for async or non-block */
+        && ssl->error != WC_PENDING_E && ssl->error != OCSP_WANT_READ
+    #endif
+    ) {
         ShrinkInputBuffer(ssl, NO_FORCED_FREE);
     }
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2268,6 +2268,11 @@ static int RestartHandshakeHash(WOLFSSL* ssl)
     #endif
     }
     hashSz = ssl->specs.hash_size;
+
+    /* check hash */
+    if (hash == NULL && hashSz > 0)
+        return BAD_FUNC_ARG;
+
     AddTls13HandShakeHeader(header, hashSz, 0, 0, message_hash, ssl);
 
     WOLFSSL_MSG("Restart Hash");
@@ -2281,7 +2286,8 @@ static int RestartHandshakeHash(WOLFSSL* ssl)
 
         /* Cookie Data = Hash Len | Hash | CS | KeyShare Group */
         cookie[idx++] = hashSz;
-        XMEMCPY(cookie + idx, hash, hashSz);
+        if (hash)
+            XMEMCPY(cookie + idx, hash, hashSz);
         idx += hashSz;
         cookie[idx++] = ssl->options.cipherSuite0;
         cookie[idx++] = ssl->options.cipherSuite;
@@ -2327,6 +2333,9 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk)
 {
     int ret;
     byte suite[2];
+
+    if (psk == NULL)
+        return BAD_FUNC_ARG;
 
     if (ssl->options.noPskDheKe && ssl->arrays->preMasterSz != 0)
         return PSK_KEY_ERROR;

--- a/tests/include.am
+++ b/tests/include.am
@@ -37,6 +37,6 @@ EXTRA_DIST += tests/test.conf \
               tests/test-fails.conf \
               tests/test-chains.conf \
               tests/test-altchains.conf \
-              tests/test-trustedpeer.conf \
+              tests/test-trustpeer.conf \
               tests/test-dhprime.conf
 DISTCLEANFILES+= tests/.libs/unit.test

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -3488,7 +3488,7 @@ void bench_blake2(void)
     Blake2b b2b;
     byte    digest[64];
     double  start;
-    int     ret, i, count;
+    int     ret = 0, i, count;
 
     if (digest_stream) {
         ret = wc_InitBlake2b(&b2b, 64);

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1342,9 +1342,19 @@ static int wc_PKCS7_RsaSign(PKCS7* pkcs7, byte* in, word32 inSz, ESD* esd)
         }
     }
     if (ret == 0) {
-        ret = wc_RsaSSL_Sign(in, inSz, esd->encContentDigest,
-                             sizeof(esd->encContentDigest),
-                             privKey, pkcs7->rng);
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        do {
+            ret = wc_AsyncWait(ret, &privKey->asyncDev,
+                WC_ASYNC_FLAG_CALL_AGAIN);
+    #endif
+            if (ret >= 0) {
+                ret = wc_RsaSSL_Sign(in, inSz, esd->encContentDigest,
+                                     sizeof(esd->encContentDigest),
+                                     privKey, pkcs7->rng);
+            }
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        } while (ret == WC_PENDING_E);
+    #endif
     }
 
     wc_FreeRsaKey(privKey);
@@ -1395,8 +1405,18 @@ static int wc_PKCS7_EcdsaSign(PKCS7* pkcs7, byte* in, word32 inSz, ESD* esd)
     }
     if (ret == 0) {
         outSz = sizeof(esd->encContentDigest);
-        ret = wc_ecc_sign_hash(in, inSz, esd->encContentDigest,
-                               &outSz, pkcs7->rng, privKey);
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        do {
+            ret = wc_AsyncWait(ret, &privKey->asyncDev,
+                WC_ASYNC_FLAG_CALL_AGAIN);
+    #endif
+            if (ret >= 0) {
+                ret = wc_ecc_sign_hash(in, inSz, esd->encContentDigest,
+                                       &outSz, pkcs7->rng, privKey);
+            }
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        } while (ret == WC_PENDING_E);
+    #endif
         if (ret == 0)
             ret = (int)outSz;
     }
@@ -2771,7 +2791,18 @@ static int wc_PKCS7_RsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
             continue;
         }
 
-        ret = wc_RsaSSL_Verify(sig, sigSz, digest, MAX_PKCS7_DIGEST_SZ, key);
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        do {
+            ret = wc_AsyncWait(ret, &key->asyncDev,
+                WC_ASYNC_FLAG_CALL_AGAIN);
+    #endif
+            if (ret >= 0) {
+                ret = wc_RsaSSL_Verify(sig, sigSz, digest, MAX_PKCS7_DIGEST_SZ,
+                    key);
+            }
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        } while (ret == WC_PENDING_E);
+    #endif
         FreeDecodedCert(dCert);
         wc_FreeRsaKey(key);
 
@@ -2884,7 +2915,17 @@ static int wc_PKCS7_EcdsaVerify(PKCS7* pkcs7, byte* sig, int sigSz,
             continue;
         }
 
-        ret = wc_ecc_verify_hash(sig, sigSz, hash, hashSz, &res, key);
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        do {
+            ret = wc_AsyncWait(ret, &key->asyncDev,
+                WC_ASYNC_FLAG_CALL_AGAIN);
+    #endif
+            if (ret >= 0) {
+                ret = wc_ecc_verify_hash(sig, sigSz, hash, hashSz, &res, key);
+            }
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        } while (ret == WC_PENDING_E);
+    #endif
 
         FreeDecodedCert(dCert);
         wc_ecc_free(key);

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -9789,7 +9789,7 @@ int wc_PKCS7_EncodeAuthEnvelopedData(PKCS7* pkcs7, byte* output,
     idx += encryptedOutSz;
 
     /* authenticated attributes */
-    if (authAttribsSz > 0) {
+    if (flatAuthAttribs && authAttribsSz > 0) {
         XMEMCPY(output + idx, authAttribSet, authAttribsSetSz);
         idx += authAttribsSetSz;
         XMEMCPY(output + idx, flatAuthAttribs, authAttribsSz);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -10738,7 +10738,11 @@ static int rsa_keygen_test(WC_RNG* rng)
     if (ret != 0) {
         ERROR_OUT(-6962, exit_rsa);
     }
+
     ret = wc_MakeRsaKey(&genKey, keySz, WC_RSA_EXPONENT, rng);
+#if defined(WOLFSSL_ASYNC_CRYPT)
+    ret = wc_AsyncWait(ret, &genKey.asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
     if (ret != 0) {
         ERROR_OUT(-6963, exit_rsa);
     }

--- a/wolfssl/openssl/aes.h
+++ b/wolfssl/openssl/aes.h
@@ -43,7 +43,7 @@
  * to need the size of the structure. */
 typedef struct WOLFSSL_AES_KEY {
     /* aligned and big enough for Aes from wolfssl/wolfcrypt/aes.h */
-    ALIGN16 void* holder[(360 + WC_ASYNC_DEV_SIZE)/ sizeof(void*)];
+    ALIGN16 void* holder[(376 + WC_ASYNC_DEV_SIZE)/ sizeof(void*)];
     #ifdef GCM_TABLE
     /* key-based fast multiplication table. */
     ALIGN16 void* M0[4096 / sizeof(void*)];

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1647,9 +1647,9 @@ extern void uITRON4_free(void *p) ;
     #define HAVE_WOLF_EVENT
 
     #ifdef WOLFSSL_ASYNC_CRYPT_TEST
-        #define WC_ASYNC_DEV_SIZE 328+24
+        #define WC_ASYNC_DEV_SIZE 168
     #else
-        #define WC_ASYNC_DEV_SIZE 328
+        #define WC_ASYNC_DEV_SIZE 336
     #endif
 
     #if !defined(HAVE_CAVIUM) && !defined(HAVE_INTEL_QA) && \


### PR DESCRIPTION
* Added blocking support for PKCS 7 with async.
* Fix for RSA async key gen in wolfCryp test.
* Fix for DTLS async shrinking input buffer too soon and causing -308 (INCOMPLETE_DATA).
* Fix to adjust `WC_ASYNC_DEV_SIZE`.
* Fix for `tests/test-trustpeer.conf` typo in include.am.
* Fixes for various scan-build reports.