### PR TITLE
Fix for SP ASM when building sources directly

### DIFF
--- a/IDE/GCC-ARM/Header/user_settings.h
+++ b/IDE/GCC-ARM/Header/user_settings.h
@@ -66,14 +66,15 @@ extern "C" {
 #undef WOLFSSL_SP
 #if 0
     #define WOLFSSL_SP
-    #define WOLFSSL_SP_SMALL
+    #define WOLFSSL_SP_SMALL      /* use smaller version of code */
     #define WOLFSSL_HAVE_SP_RSA
     #define WOLFSSL_HAVE_SP_DH
     #define WOLFSSL_HAVE_SP_ECC
     #define WOLFSSL_SP_CACHE_RESISTANT
-    //#define WOLFSSL_SP_MATH
+    //#define WOLFSSL_SP_MATH     /* only SP math - eliminates fast math code */
 
     /* 64 or 32 bit version */
+    //#define WOLFSSL_SP_ASM      /* required if using the ASM versions */
     //#define WOLFSSL_SP_ARM32_ASM
     //#define WOLFSSL_SP_ARM64_ASM
 #endif

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -26,6 +26,14 @@
 #include <stdint.h>
 #include <limits.h>
 
+/* Make sure WOLFSSL_SP_ASM build option defined when requested */
+#if !defined(WOLFSSL_SP_ASM) && ( \
+      defined(WOLFSSL_SP_X86_64_ASM) || defined(WOLFSSL_SP_ARM32_ASM) || \
+      defined(WOLFSSL_SP_ARM64_ASM)  || defined(WOLFSSL_SP_ARM_THUMB_ASM))
+    #define WOLFSSL_SP_ASM
+#endif
+
+
 #ifdef WOLFSSL_SP_X86_64_ASM
     #define SP_WORD_SIZE 64
 


### PR DESCRIPTION
* Added protection to ensure `WOLFSSL_SP_ASM` gets defined when required.
* Updated the SP macro comments in GCC-ARM user_settings.h. ZD 4556.