### PR TITLE
Missing semicolon on HAL_CRYP_AESECB_Decrypt STM32

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -397,7 +397,7 @@
             outBlock, STM32_HAL_TIMEOUT);
     #else
         ret = HAL_CRYP_AESECB_Decrypt(&hcryp, (uint8_t*)inBlock, AES_BLOCK_SIZE,
-            outBlock, STM32_HAL_TIMEOUT)
+            outBlock, STM32_HAL_TIMEOUT);
     #endif
         if (ret != HAL_OK) {
             ret = WC_TIMEOUT_E;


### PR DESCRIPTION
Missing semicolon for STM32 when STM32_CRYPTO_AES_ONLY not defined on call to HAL_CRYP_AESECB_Decrypt function.