### PR TITLE
fix for some warnings and edge case build

### DIFF
--- a/mcapi/mcapi_test.c
+++ b/mcapi/mcapi_test.c
@@ -404,7 +404,7 @@ static int check_hmac(void)
     byte           mcDigest[CRYPT_SHA512_DIGEST_SIZE];
     byte           defDigest[WC_SHA512_DIGEST_SIZE];
 
-    strncpy((char*)key, "Jefe", 4);
+    memcpy((char*)key, "Jefe", 4);
 
     /* SHA1 */
     CRYPT_HMAC_SetKey(&mcHmac, CRYPT_HMAC_SHA, key, 4);
@@ -684,8 +684,8 @@ static int check_des3(void)
     byte           out1[TDES_TEST_SIZE];
     byte           out2[TDES_TEST_SIZE];
 
-    strncpy((char*)key, "1234567890abcdefghijklmn", 24);
-    strncpy((char*)iv,  "12345678", 8);
+    memcpy((char*)key, "1234567890abcdefghijklmn", 24);
+    memcpy((char*)iv,  "12345678", 8);
 
     /* cbc encrypt */
     ret = CRYPT_TDES_KeySet(&mcDes3, key, iv, CRYPT_TDES_ENCRYPTION);
@@ -765,8 +765,8 @@ static int check_aescbc(void)
     byte          out1[AES_TEST_SIZE];
     byte          out2[AES_TEST_SIZE];
 
-    strncpy((char*)key, "1234567890abcdefghijklmnopqrstuv", 32);
-    strncpy((char*)iv,  "1234567890abcdef", 16);
+    memcpy((char*)key, "1234567890abcdefghijklmnopqrstuv", 32);
+    memcpy((char*)iv,  "1234567890abcdef", 16);
 
     /* 128 cbc encrypt */
     ret = CRYPT_AES_KeySet(&mcAes, key, 16, iv, CRYPT_AES_ENCRYPTION);
@@ -942,8 +942,8 @@ static int check_aesctr(void)
     byte          out1[AES_TEST_SIZE];
     byte          out2[AES_TEST_SIZE];
 
-    strncpy((char*)key, "1234567890abcdefghijklmnopqrstuv", 32);
-    strncpy((char*)iv,  "1234567890abcdef", 16);
+    memcpy((char*)key, "1234567890abcdefghijklmnopqrstuv", 32);
+    memcpy((char*)iv,  "1234567890abcdef", 16);
 
     /* 128 ctr encrypt */
     ret = CRYPT_AES_KeySet(&mcAes, key, 16, iv, CRYPT_AES_ENCRYPTION);
@@ -1110,8 +1110,8 @@ static int check_aesdirect(void)
     byte          out1[CRYPT_AES_BLOCK_SIZE];
     byte          out2[16];  /* one block at a time */
 
-    strncpy((char*)key, "1234567890abcdefghijklmnopqrstuv", 32);
-    strncpy((char*)iv,  "1234567890abcdef", 16);
+    memcpy((char*)key, "1234567890abcdefghijklmnopqrstuv", 32);
+    memcpy((char*)iv,  "1234567890abcdef", 16);
 
     /* 128 direct encrypt */
     ret = CRYPT_AES_KeySet(&mcAes, key, 16, iv, CRYPT_AES_ENCRYPTION);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2567,10 +2567,6 @@ int SendTls13ClientHello(WOLFSSL* ssl)
         return ret;
     }
 #endif
-#ifdef HAVE_QSH
-    if (QSH_Init(ssl) != 0)
-        return MEMORY_E;
-#endif
     /* Include length of TLS extensions. */
     ret = TLSX_GetRequestSize(ssl, client_hello, &length);
     if (ret != 0)
@@ -3888,10 +3884,6 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         i += OPAQUE16_LEN;
         if ((i - begin) + totalExtSz > helloSz)
             return BUFFER_ERROR;
-
-    #ifdef HAVE_QSH
-        QSH_Init(ssl);
-    #endif
 
         /* Auto populate extensions supported unless user defined. */
         if ((ret = TLSX_PopulateExtensions(ssl, 1)) != 0)

--- a/wolfcrypt/src/port/af_alg/wc_afalg.c
+++ b/wolfcrypt/src/port/af_alg/wc_afalg.c
@@ -75,7 +75,7 @@ int wc_Afalg_Socket(void)
 /* binds and creates the read fd */
 int wc_Afalg_CreateRead(int sock, const char* type, const char* name)
 {
-    struct sockaddr_alg sa = {};
+    struct sockaddr_alg sa = {0};
     wc_Afalg_SockAddr(&sa, type, name);
     return wc_Afalg_Accept(&sa, sizeof(sa), sock);
 }

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -308,15 +308,17 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
     while ((ctx->entry = readdir(ctx->dir)) != NULL) {
         dnameLen = (int)XSTRLEN(ctx->entry->d_name);
 
-        if (pathLen + dnameLen + 2 > MAX_FILENAME_SZ) {
+        if (pathLen + dnameLen + 2 >= MAX_FILENAME_SZ) {
             ret = BAD_PATH_ERROR;
             break;
         }
         XSTRNCPY(ctx->name, path, pathLen + 1);
         ctx->name[pathLen] = '/';
-        XSTRNCPY(ctx->name + pathLen + 1,
-                 ctx->entry->d_name, MAX_FILENAME_SZ - pathLen - 1);
 
+        /* Use dnameLen + 1 for GCC 8 warnings of truncating d_name. Because
+         * of earlier check it is known that dnameLen is less than
+         * MAX_FILENAME_SZ - (pathLen + 2)  so dnameLen +1 will fit */
+        XSTRNCPY(ctx->name + pathLen + 1, ctx->entry->d_name, dnameLen + 1);
         if (stat(ctx->name, &ctx->s) != 0) {
             WOLFSSL_MSG("stat on name failed");
             ret = BAD_PATH_ERROR;
@@ -372,14 +374,16 @@ int wc_ReadDirNext(ReadDirCtx* ctx, const char* path, char** name)
     while ((ctx->entry = readdir(ctx->dir)) != NULL) {
         dnameLen = (int)XSTRLEN(ctx->entry->d_name);
 
-        if (pathLen + dnameLen + 2 > MAX_FILENAME_SZ) {
+        if (pathLen + dnameLen + 2 >= MAX_FILENAME_SZ) {
             ret = BAD_PATH_ERROR;
             break;
         }
         XSTRNCPY(ctx->name, path, pathLen + 1);
         ctx->name[pathLen] = '/';
-        XSTRNCPY(ctx->name + pathLen + 1,
-                 ctx->entry->d_name, MAX_FILENAME_SZ - pathLen - 1);
+        /* Use dnameLen + 1 for GCC 8 warnings of truncating d_name. Because
+         * of earlier check it is known that dnameLen is less than
+         * MAX_FILENAME_SZ - (pathLen + 2) so that dnameLen +1 will fit */
+        XSTRNCPY(ctx->name + pathLen + 1, ctx->entry->d_name, dnameLen + 1);
 
         if (stat(ctx->name, &ctx->s) != 0) {
             WOLFSSL_MSG("stat on name failed");


### PR DESCRIPTION
- gcc 8 string warnings fix
- init value af_alg with gcc 4.8
- QSH and TLS 1.3 enabled build