### PR TITLE
Fixes for MDK5 project

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -397,7 +397,7 @@
             outBlock, STM32_HAL_TIMEOUT);
     #else
         ret = HAL_CRYP_AESECB_Decrypt(&hcryp, (uint8_t*)inBlock, AES_BLOCK_SIZE,
-            outBlock, STM32_HAL_TIMEOUT)
+            outBlock, STM32_HAL_TIMEOUT);
     #endif
         if (ret != HAL_OK) {
             ret = WC_TIMEOUT_E;

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -525,6 +525,7 @@ static const char* client_showpeer_msg[][8] = {
         "peer's cert info:",
         NULL
     },
+#ifndef NO_MULTIBYTE_PRINT
     /* Japanese */
     {
         "SSL バージョンは",
@@ -535,7 +536,8 @@ static const char* client_showpeer_msg[][8] = {
         "代替証明チェーンを使用",
         "相手方証明書情報",
         NULL
-    }
+    },
+#endif
 };
 
 #if defined(KEEP_PEER_CERT) || defined(SESSION_CERTS)
@@ -548,6 +550,7 @@ static const char* client_showx509_msg[][5] = {
         "serial number",
         NULL
     },
+#ifndef NO_MULTIBYTE_PRINT
     /* Japanese */
     {
         "発行者",
@@ -556,6 +559,7 @@ static const char* client_showx509_msg[][5] = {
         "シリアル番号",
         NULL
     },
+#endif
 };
 
 /* lng_index is to specify the language for displaying message.              */


### PR DESCRIPTION
Fix missing semicolon for `HAL_CRYP_AESECB_Decrypt` call. Fix for `NO_MULTIBYTE_PRINT` in test.h. These fixes were pulled in from PR #1974.