### PR TITLE
fix no_hash_raw for esp32 hw acceleration

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -1216,7 +1216,7 @@ static int Hmac_UpdateFinal(Hmac* hmac, byte* digest, const byte* in,
     byte       dummy[WC_MAX_BLOCK_SIZE] = {0};
     int        ret;
     word32     msgSz, blockSz, macSz, padSz, maxSz, realSz;
-    word32     currSz, offset;
+    word32     currSz, offset = 0;
     int        msgBlocks, blocks, blockBits;
     int        i;
 

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -78,6 +78,9 @@ uint64_t  wc_esp32elapsedTime();
       defined(WOLFSSL_SHA512)) && \
     !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
 
+/* RAW hash function APIs are not implemented with esp32 hardware acceleration*/
+#define WOLFSSL_NO_HASH_RAW
+
 #include "rom/sha.h"
 
 typedef enum {


### PR DESCRIPTION
This change is to fix no_hash_raw when enabling esp32 sha hw acceleration.