### PR TITLE
Fixes for various build options and warnings

### DIFF
--- a/cyassl/ctaocrypt/settings.h
+++ b/cyassl/ctaocrypt/settings.h
@@ -184,7 +184,7 @@
 #ifdef MBED
     #define CYASSL_USER_IO
     #define NO_FILESYSTEM
-    #define NO_CERT
+    #define NO_CERTS
     #define USE_CERT_BUFFERS_1024
     #define NO_WRITEV
     #define NO_DEV_RANDOM

--- a/src/internal.c
+++ b/src/internal.c
@@ -18153,8 +18153,8 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
 
                     args->idx += length;
                     ssl->peerEccKeyPresent = 1;
-                    break;
                 #endif
+                    break;
                 }
             #endif /* HAVE_ECC || HAVE_CURVE25519 */
             #if !defined(NO_DH) && !defined(NO_PSK)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -30909,7 +30909,7 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
         { OCSP_NONCE_OID, OCSP_NONCE_OID, oidOcspType, "OCSP_nonce" },
     #endif /* HAVE_OCSP */
 
-    #ifndef NO_CERT
+    #ifndef NO_CERTS
         /* oidCertExtType */
         { BASIC_CA_OID, BASIC_CA_OID, oidCertExtType, "X509 basic ca" },
         { ALT_NAMES_OID, ALT_NAMES_OID, oidCertExtType, "X509 alt names" },
@@ -35781,7 +35781,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
 }
 #endif
 
-#if defined(OPENSSL_ALL) && !defined(NO_CERT) && defined(WOLFSSL_CERT_GEN) && \
+#if defined(OPENSSL_ALL) && !defined(NO_CERTS) && defined(WOLFSSL_CERT_GEN) && \
                                                        defined(WOLFSSL_CERT_REQ)
 int wolfSSL_i2d_X509_REQ(WOLFSSL_X509* req, unsigned char** out)
 {

--- a/src/tls.c
+++ b/src/tls.c
@@ -9453,7 +9453,7 @@ int TLSX_WriteRequest(WOLFSSL* ssl, byte* output, byte msgType, word16* pOffset)
     #endif
     }
 #ifdef WOLFSSL_TLS13
-    #ifndef NO_CERT
+    #ifndef NO_CERTS
     else if (msgType == certificate_request) {
         XMEMSET(semaphore, 0xff, SEMAPHORE_SIZE);
         TURN_OFF(semaphore, TLSX_ToSemaphore(TLSX_SIGNATURE_ALGORITHMS));
@@ -9579,7 +9579,7 @@ int TLSX_GetResponseSize(WOLFSSL* ssl, byte msgType, word16* pLength)
 #endif
 
 #ifdef WOLFSSL_TLS13
-    #ifndef NO_CERT
+    #ifndef NO_CERTS
         case certificate:
             XMEMSET(semaphore, 0xff, SEMAPHORE_SIZE);
             TURN_OFF(semaphore, TLSX_ToSemaphore(TLSX_STATUS_REQUEST));

--- a/tests/api.c
+++ b/tests/api.c
@@ -21427,6 +21427,10 @@ static void test_CheckCertSignature(void)
 #endif
 #endif
 
+    (void)fp;
+    (void)cert;
+    (void)certSz;
+
     wolfSSL_CertManagerFree(cm);
 #endif
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -21613,7 +21613,7 @@ static void test_EVP_PKEY_ec(void)
 #endif
 }
 
-#if defined(OPENSSL_ALL) && !defined(NO_CERT)
+#if defined(OPENSSL_ALL) && !defined(NO_CERTS)
 static void free_x509(X509* x)
 {
     AssertIntEQ((x == (X509*)1 || x == (X509*)2), 1);
@@ -21622,7 +21622,7 @@ static void free_x509(X509* x)
 
 static void test_sk_X509(void)
 {
-#if defined(OPENSSL_ALL) && !defined(NO_CERT)
+#if defined(OPENSSL_ALL) && !defined(NO_CERTS)
     STACK_OF(X509)* s;
 
     AssertNotNull(s = sk_X509_new());
@@ -21661,7 +21661,7 @@ static void test_X509_get_signature_nid(void)
 
 static void test_X509_REQ(void)
 {
-#if defined(OPENSSL_ALL) && !defined(NO_CERT) && defined(WOLFSSL_CERT_GEN) && \
+#if defined(OPENSSL_ALL) && !defined(NO_CERTS) && defined(WOLFSSL_CERT_GEN) && \
                                                        defined(WOLFSSL_CERT_REQ)
     X509_NAME* name;
 #if !defined(NO_RSA) || defined(HAVE_ECC)

--- a/tests/api.c
+++ b/tests/api.c
@@ -21364,7 +21364,7 @@ static void test_CheckCertSignature(void)
 {
 #if !defined(NO_CERTS) && defined(WOLFSSL_SMALL_CERT_VERIFY)
     WOLFSSL_CERT_MANAGER* cm = NULL;
-#if !defined(NO_FILESYSTEM)
+#if !defined(NO_FILESYSTEM) && (!defined(NO_RSA) || defined(HAVE_ECC))
     FILE* fp;
     byte  cert[4096];
     int   certSz;

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -1012,7 +1012,7 @@ void *xmalloc(size_t n, void* heap, int type, const char* func,
     else
         p32 = malloc(n + sizeof(word32) * 4);
 
-    p32[0] = n;
+    p32[0] = (word32)n;
     p = (void*)(p32 + 4);
 
     fprintf(stderr, "Alloc: %p -> %u (%d) at %s:%s:%d\n", p, (word32)n, type,
@@ -1042,7 +1042,7 @@ void *xrealloc(void *p, size_t n, void* heap, int type, const char* func,
         p32 = realloc(oldp32, n + sizeof(word32) * 4);
 
     if (p32 != NULL) {
-        p32[0] = n;
+        p32[0] = (word32)n;
         newp = (void*)(p32 + 4);
 
         fprintf(stderr, "Alloc: %p -> %u (%d) at %s:%s:%d\n", newp, (word32)n,

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2807,7 +2807,7 @@ int wc_RsaPSS_Sign_ex(const byte* in, word32 inLen, byte* out, word32 outLen,
 #endif
 #endif
 
-#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) || !defined(WOLFSSL_SP_MATH)
+#if !defined(WOLFSSL_RSA_VERIFY_ONLY) || !defined(WOLFSSL_SP_MATH)
 int wc_RsaEncryptSize(RsaKey* key)
 {
     int ret;

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -52,7 +52,7 @@ int sp_init(sp_int* a)
     return MP_OKAY;
 }
 
-#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) && (!defined(NO_DH) || defined(HAVE_ECC))
+#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) || (!defined(NO_DH) || defined(HAVE_ECC))
 /* Initialize up to six big numbers to be zero.
  *
  * a  SP integer.
@@ -288,7 +288,7 @@ int sp_leading_bit(sp_int* a)
     return bit;
 }
 
-#if !defined(WOLFSSL_RSA_VERIFY_ONLY) && (!defined(NO_DH) || defined(HAVE_ECC))
+#if !defined(WOLFSSL_RSA_VERIFY_ONLY) || (!defined(NO_DH) || defined(HAVE_ECC))
 /* Convert the big number to an array of bytes in big-endian format.
  * The array must be large enough for encoded number - use mp_unsigned_bin_size
  * to calculate the number of bytes required.
@@ -340,7 +340,7 @@ int sp_to_unsigned_bin_len(sp_int* a, byte* out, int outSz)
     return MP_OKAY;
 }
 
-#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) && (!defined(NO_DH) || defined(HAVE_ECC))
+#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) || (!defined(NO_DH) || defined(HAVE_ECC))
 /* Ensure the data in the big number is zeroed.
  *
  * a  SP integer.
@@ -350,7 +350,9 @@ void sp_forcezero(sp_int* a)
     ForceZero(a->dp, a->used * sizeof(sp_int_digit));
     a->used = 0;
 }
+#endif
 
+#if !defined(WOLFSSL_RSA_VERIFY_ONLY) || (!defined(NO_DH) || defined(HAVE_ECC))
 /* Copy value of big number a into b.
  *
  * a  SP integer.
@@ -380,7 +382,7 @@ int sp_set(sp_int* a, sp_int_digit d)
     return MP_OKAY;
 }
 
-#if !defined(NO_DH) || defined(HAVE_ECC)
+#if defined(WC_MP_TO_RADIX) || !defined(NO_DH) || defined(HAVE_ECC)
 /* Checks whether the value of the big number is zero.
  *
  * a  SP integer.
@@ -392,7 +394,7 @@ int sp_iszero(sp_int* a)
 }
 #endif
 
-#if !defined(WOLFSSL_RSA_VERIFY_ONLY) && (!defined(NO_DH) || defined(HAVE_ECC))
+#if !defined(WOLFSSL_RSA_VERIFY_ONLY) || (!defined(NO_DH) || defined(HAVE_ECC))
 /* Recalculate the number of digits used.
  *
  * a  SP integer.
@@ -477,7 +479,7 @@ int sp_cmp_d(sp_int *a, sp_int_digit d)
     return MP_EQ;
 }
 
-#if !defined(WOLFSSL_RSA_VERIFY_ONLY) && (!defined(NO_DH) || defined(HAVE_ECC))
+#if !defined(WOLFSSL_RSA_VERIFY_ONLY) || (!defined(NO_DH) || defined(HAVE_ECC))
 /* Left shift the number by number of bits.
  * Bits may be larger than the word size.
  *
@@ -618,7 +620,7 @@ int sp_add_d(sp_int* a, sp_int_digit d, sp_int* r)
     return MP_OKAY;
 }
 
-#if !defined(WOLFSSL_RSA_VERIFY_ONLY) && (!defined(NO_DH) || defined(HAVE_ECC))
+#if !defined(WOLFSSL_RSA_VERIFY_ONLY) || (!defined(NO_DH) || defined(HAVE_ECC))
 /* Left shift the big number by a number of digits.
  * WIll chop off digits overflowing maximum size.
  *
@@ -674,7 +676,7 @@ int sp_add(sp_int* a, sp_int* b, sp_int* r)
     return MP_OKAY;
 }
 #endif /* NO_PWDBASED */
-#endif
+#endif /* !WOLFSSL_RSA_VERIFY_ONLY || (!NO_DH || HAVE_ECC) */
 
 #ifndef NO_RSA
 /* Set a number into the big number.
@@ -690,7 +692,7 @@ int sp_set_int(sp_int* a, unsigned long b)
 
     return MP_OKAY;
 }
-#endif
+#endif /* !NO_RSA */
 
 #ifdef WC_MP_TO_RADIX
 /* Hex string characters. */
@@ -731,7 +733,7 @@ int sp_tohex(sp_int* a, char* str)
 
     return MP_OKAY;
 }
-#endif
+#endif /* WC_MP_TO_RADIX */
 
 #if !defined(USE_FAST_MATH)
 /* Returns the run time settings.
@@ -742,7 +744,7 @@ word32 CheckRunTimeSettings(void)
 {
     return CTC_SETTINGS;
 }
-#endif
+#endif /* !USE_FAST_MATH */
 
-#endif
+#endif /* WOLFSSL_SP_MATH */
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9024,7 +9024,7 @@ int certext_test(void)
 }
 #endif /* WOLFSSL_CERT_EXT && WOLFSSL_TEST_CERT */
 
-#if !defined(NO_ASN) && !defined(WOLFSSL_RSA_VERIFY_ONLY)
+#if !defined(NO_ASN) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)
 static int rsa_flatten_test(RsaKey* key)
 {
     int    ret;
@@ -10903,7 +10903,7 @@ int rsa_test(void)
     if (ret != 0) {
         ERROR_OUT(-7004, exit_rsa);
     }
-#elif defined(WOLFSSL_RSA_VERIFY_ONLY)
+#elif defined(WOLFSSL_RSA_PUBLIC_ONLY)
     #ifdef USE_CERT_BUFFERS_2048
         ret = mp_read_unsigned_bin(&key.n, &tmp[12], 256);
         if (ret != 0) {

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -325,7 +325,7 @@
 #ifdef MBED
     #define WOLFSSL_USER_IO
     #define NO_FILESYSTEM
-    #define NO_CERT
+    #define NO_CERTS
     #if !defined(USE_CERT_BUFFERS_2048) && !defined(USE_CERT_BUFFERS_4096)
         #define USE_CERT_BUFFERS_1024
     #endif


### PR DESCRIPTION
Fixed build warnings for unused variables in `test_CheckCertSignature`.
Fixed cast warning with `WOLFSSL_MEMORY_LOG`.
Fix define check of `NO_CERT` to be `NO_CERTS`. (From Sean's PR #2017)
Fix to allow RSA public only to build without verify only. (From Sean's PR #2018)
Fix compiler complaints when using Curve25519. (From Sean's PR #2020)