### PR TITLE
increase max_xx_sz to cover the potential additional byte

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5752,6 +5752,7 @@ WOLFSSL_LOCAL word32 SetSequence(word32 len, byte* output)
     return SetLength(len, output + 1) + 1;
 }
 
+/* return value would be 2 - 6 depending on len.      */
 WOLFSSL_LOCAL word32 SetOctetString(word32 len, byte* output)
 {
     output[0] = ASN_OCTET_STRING;
@@ -5759,12 +5760,14 @@ WOLFSSL_LOCAL word32 SetOctetString(word32 len, byte* output)
 }
 
 /* Write a set header to output */
+/* return value would be 2 - 6 depending on len.      */
 WOLFSSL_LOCAL word32 SetSet(word32 len, byte* output)
 {
     output[0] = ASN_SET | ASN_CONSTRUCTED;
     return SetLength(len, output + 1) + 1;
 }
 
+/* return value would be 2 - 6 depending on len.      */
 WOLFSSL_LOCAL word32 SetImplicit(byte tag, byte number, word32 len, byte* output)
 {
 
@@ -5773,6 +5776,7 @@ WOLFSSL_LOCAL word32 SetImplicit(byte tag, byte number, word32 len, byte* output
     return SetLength(len, output + 1) + 1;
 }
 
+/* return value would be 2 - 6 depending on len.      */
 WOLFSSL_LOCAL word32 SetExplicit(byte number, word32 len, byte* output)
 {
     output[0] = ASN_CONSTRUCTED | ASN_CONTEXT_SPECIFIC | number;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -703,7 +703,7 @@ static int SetShortInt(byte* input, word32* inOutIdx, word32 number,
     word32 idx = *inOutIdx;
     word32 len = 0;
     int    i;
-    byte ar[MAX_LENGTH_SZ];
+    byte ar[MAX_LENGTH_SZ - 1];/* expect size 4 byte */
 
     /* check for room for type and length bytes */
     if ((idx + 2) > maxIdx)
@@ -711,24 +711,24 @@ static int SetShortInt(byte* input, word32* inOutIdx, word32 number,
 
     input[idx++] = ASN_INTEGER;
     idx++; /* place holder for length byte */
-    if (MAX_LENGTH_SZ + idx > maxIdx)
+    if (MAX_LENGTH_SZ - 1 + idx > maxIdx)
         return ASN_PARSE_E;
 
     /* find first non zero byte */
-    XMEMSET(ar, 0, MAX_LENGTH_SZ);
+    XMEMSET(ar, 0, MAX_LENGTH_SZ - 1);
     c32toa(number, ar);
-    for (i = 0; i < MAX_LENGTH_SZ; i++) {
+    for (i = 0; i < (MAX_LENGTH_SZ - 1); i++) {
         if (ar[i] != 0) {
             break;
         }
     }
 
     /* handle case of 0 */
-    if (i == MAX_LENGTH_SZ) {
+    if (i == (MAX_LENGTH_SZ - 1)) {
         input[idx++] = 0; len++;
     }
 
-    for (; i < MAX_LENGTH_SZ && idx < maxIdx; i++) {
+    for (; i < (MAX_LENGTH_SZ - 1) && idx < maxIdx; i++) {
         input[idx++] = ar[i]; len++;
     }
 
@@ -5725,7 +5725,7 @@ static word32 BytePrecision(word32 value)
 
     return i;
 }
-
+/* return value will be 1 - 5 according to length     */
 WOLFSSL_LOCAL word32 SetLength(word32 length, byte* output)
 {
     word32 i = 0, j;
@@ -5745,14 +5745,14 @@ WOLFSSL_LOCAL word32 SetLength(word32 length, byte* output)
 }
 
 
-/* return value would be 2 - 6 depending on len.      */
+/* return value will be 2 - 6 depending on len.       */
 WOLFSSL_LOCAL word32 SetSequence(word32 len, byte* output)
 {
     output[0] = ASN_SEQUENCE | ASN_CONSTRUCTED;
     return SetLength(len, output + 1) + 1;
 }
 
-/* return value would be 2 - 6 depending on len.      */
+/* return value will be 2 - 6 depending on len.       */
 WOLFSSL_LOCAL word32 SetOctetString(word32 len, byte* output)
 {
     output[0] = ASN_OCTET_STRING;
@@ -5760,14 +5760,14 @@ WOLFSSL_LOCAL word32 SetOctetString(word32 len, byte* output)
 }
 
 /* Write a set header to output */
-/* return value would be 2 - 6 depending on len.      */
+/* return value will be 2 - 6 depending on len.       */
 WOLFSSL_LOCAL word32 SetSet(word32 len, byte* output)
 {
     output[0] = ASN_SET | ASN_CONSTRUCTED;
     return SetLength(len, output + 1) + 1;
 }
 
-/* return value would be 2 - 6 depending on len.      */
+/* return value will be 2 - 6 depending on len.       */
 WOLFSSL_LOCAL word32 SetImplicit(byte tag, byte number, word32 len, byte* output)
 {
 
@@ -5776,7 +5776,7 @@ WOLFSSL_LOCAL word32 SetImplicit(byte tag, byte number, word32 len, byte* output
     return SetLength(len, output + 1) + 1;
 }
 
-/* return value would be 2 - 6 depending on len.      */
+/* return value will be 2 - 6 depending on len.       */
 WOLFSSL_LOCAL word32 SetExplicit(byte number, word32 len, byte* output)
 {
     output[0] = ASN_CONSTRUCTED | ASN_CONTEXT_SPECIFIC | number;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4109,7 +4109,7 @@ static WC_INLINE void FreeTmpDsas(byte** tmps, void* heap)
 int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen)
 {
     word32 seqSz, verSz, rawLen, intTotalLen = 0;
-    word32 sizes[DSA_INTS_SZ];
+    word32 sizes[DSA_INTS];
     int    i, j, outLen, ret = 0, mpSz;
 
     byte  seq[MAX_SEQ_SZ];

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4109,12 +4109,12 @@ static WC_INLINE void FreeTmpDsas(byte** tmps, void* heap)
 int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen)
 {
     word32 seqSz, verSz, rawLen, intTotalLen = 0;
-    word32 sizes[DSA_INTS];
+    word32 sizes[DSA_INTS_SZ];
     int    i, j, outLen, ret = 0, mpSz;
 
     byte  seq[MAX_SEQ_SZ];
     byte  ver[MAX_VERSION_SZ];
-    byte* tmps[DSA_INTS];
+    byte* tmps[DSA_INTS_SZ];
 
     if (!key || !output)
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5726,7 +5726,6 @@ static word32 BytePrecision(word32 value)
     return i;
 }
 
-
 WOLFSSL_LOCAL word32 SetLength(word32 length, byte* output)
 {
     word32 i = 0, j;
@@ -5746,6 +5745,7 @@ WOLFSSL_LOCAL word32 SetLength(word32 length, byte* output)
 }
 
 
+/* return value would be 2 - 6 depending on len.      */
 WOLFSSL_LOCAL word32 SetSequence(word32 len, byte* output)
 {
     output[0] = ASN_SEQUENCE | ASN_CONSTRUCTED;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -679,7 +679,8 @@ int GetShortInt(const byte* input, word32* inOutIdx, int* number, word32 maxIdx)
         return ASN_PARSE_E;
 
     len = input[idx++];
-    if (len > 4)
+    /* check if len exceeds max size 4 bytes */
+    if (len > MAX_SHORTINT_SZ)
         return ASN_PARSE_E;
 
     if (len + idx > maxIdx)
@@ -703,7 +704,7 @@ static int SetShortInt(byte* input, word32* inOutIdx, word32 number,
     word32 idx = *inOutIdx;
     word32 len = 0;
     int    i;
-    byte ar[MAX_LENGTH_SZ - 1];/* expect size 4 byte */
+    byte ar[MAX_SHORTINT_SZ];/* expect max size 4 bytes */
 
     /* check for room for type and length bytes */
     if ((idx + 2) > maxIdx)
@@ -711,24 +712,25 @@ static int SetShortInt(byte* input, word32* inOutIdx, word32 number,
 
     input[idx++] = ASN_INTEGER;
     idx++; /* place holder for length byte */
-    if (MAX_LENGTH_SZ - 1 + idx > maxIdx)
+    if (MAX_SHORTINT_SZ + idx > maxIdx)
         return ASN_PARSE_E;
 
     /* find first non zero byte */
-    XMEMSET(ar, 0, MAX_LENGTH_SZ - 1);
+    XMEMSET(ar, 0, MAX_SHORTINT_SZ);
+    /* c32toa converts 32 bit integer to 4 bytes array */
     c32toa(number, ar);
-    for (i = 0; i < (MAX_LENGTH_SZ - 1); i++) {
+    for (i = 0; i < MAX_SHORTINT_SZ; i++) {
         if (ar[i] != 0) {
             break;
         }
     }
 
     /* handle case of 0 */
-    if (i == (MAX_LENGTH_SZ - 1)) {
+    if (i == MAX_SHORTINT_SZ) {
         input[idx++] = 0; len++;
     }
 
-    for (; i < (MAX_LENGTH_SZ - 1) && idx < maxIdx; i++) {
+    for (; i < MAX_SHORTINT_SZ && idx < maxIdx; i++) {
         input[idx++] = ar[i]; len++;
     }
 

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -230,7 +230,8 @@ enum Misc_ASN {
     KEYID_SIZE          = WC_SHA_DIGEST_SIZE,
 #endif
     RSA_INTS            =   8,     /* RSA ints in private key */
-    DSA_INTS            =   6,     /* DSA ints in private key */
+    DSA_INTS            =   5,     /* DSA ints in private key */
+    DSA_INTS_SZ         =   6,     /* DSA length */
     MIN_DATE_SIZE       =  13,
     MAX_DATE_SIZE       =  32,
     ASN_GEN_TIME_SZ     =  15,     /* 7 numbers * 2 + Zulu tag */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -245,10 +245,10 @@ enum Misc_ASN {
     MAX_ALGO_SZ         =  20,
     MAX_SHORT_SZ        =   6,     /* asn int + byte len + 4 byte length */
     MAX_SEQ_SZ          =   6,     /* enum(seq | con) + 1 + length(4) */
-    MAX_SET_SZ          =   5,     /* enum(set | con) + length(4) */
-    MAX_OCTET_STR_SZ    =   5,     /* enum(set | con) + length(4) */
-    MAX_EXP_SZ          =   5,     /* enum(contextspec|con|exp) + length(4) */
-    MAX_PRSTR_SZ        =   5,     /* enum(prstr) + length(4) */
+    MAX_SET_SZ          =   6,     /* enum(set | con) + 1 + length(4) */
+    MAX_OCTET_STR_SZ    =   6,     /* enum(set | con) + 1 + length(4) */
+    MAX_EXP_SZ          =   6,     /* enum(contextspec|con|exp) + 1 + length(4) */
+    MAX_PRSTR_SZ        =   6,     /* enum(prstr) + 1 + length(4) */
     MAX_VERSION_SZ      =   5,     /* enum + id + version(byte) + (header(2))*/
     MAX_ENCODED_DIG_ASN_SZ= 9,     /* enum(bit or octet) + length(4) */
     MAX_ENCODED_DIG_SZ  =  64 + MAX_ENCODED_DIG_ASN_SZ, /* asn header + sha512 */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -244,7 +244,7 @@ enum Misc_ASN {
     MAX_SIG_SZ          = 256,
     MAX_ALGO_SZ         =  20,
     MAX_SHORT_SZ        =   6,     /* asn int + byte len + 4 byte length */
-    MAX_SEQ_SZ          =   5,     /* enum(seq | con) + length(4) */
+    MAX_SEQ_SZ          =   6,     /* enum(seq | con) + 1 + length(4) */
     MAX_SET_SZ          =   5,     /* enum(set | con) + length(4) */
     MAX_OCTET_STR_SZ    =   5,     /* enum(set | con) + length(4) */
     MAX_EXP_SZ          =   5,     /* enum(contextspec|con|exp) + length(4) */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -230,7 +230,7 @@ enum Misc_ASN {
     KEYID_SIZE          = WC_SHA_DIGEST_SIZE,
 #endif
     RSA_INTS            =   8,     /* RSA ints in private key */
-    DSA_INTS            =   5,     /* DSA ints in private key */
+    DSA_INTS            =   6,     /* DSA ints in private key */
     MIN_DATE_SIZE       =  13,
     MAX_DATE_SIZE       =  32,
     ASN_GEN_TIME_SZ     =  15,     /* 7 numbers * 2 + Zulu tag */
@@ -252,7 +252,7 @@ enum Misc_ASN {
     MAX_VERSION_SZ      =   5,     /* enum + id + version(byte) + (header(2))*/
     MAX_ENCODED_DIG_ASN_SZ= 9,     /* enum(bit or octet) + length(4) */
     MAX_ENCODED_DIG_SZ  =  64 + MAX_ENCODED_DIG_ASN_SZ, /* asn header + sha512 */
-    MAX_RSA_INT_SZ      = 517,     /* RSA raw sz 4096 for bits + tag + len(4) */
+    MAX_RSA_INT_SZ      = 518,     /* RSA raw sz 4096 for bits + tag + len(5) */
     MAX_NTRU_KEY_SZ     = 610,     /* NTRU 112 bit public key */
     MAX_NTRU_ENC_SZ     = 628,     /* NTRU 112 bit DER public encoding */
     MAX_LENGTH_SZ       =   5,     /* Max length size for DER encoding */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -244,11 +244,11 @@ enum Misc_ASN {
     MAX_SIG_SZ          = 256,
     MAX_ALGO_SZ         =  20,
     MAX_SHORT_SZ        =   6,     /* asn int + byte len + 4 byte length */
-    MAX_SEQ_SZ          =   6,     /* enum(seq | con) + 1 + length(4) */
-    MAX_SET_SZ          =   6,     /* enum(set | con) + 1 + length(4) */
-    MAX_OCTET_STR_SZ    =   6,     /* enum(set | con) + 1 + length(4) */
-    MAX_EXP_SZ          =   6,     /* enum(contextspec|con|exp) + 1 + length(4) */
-    MAX_PRSTR_SZ        =   6,     /* enum(prstr) + 1 + length(4) */
+    MAX_SEQ_SZ          =   6,     /* enum(seq | con) + length(5) */
+    MAX_SET_SZ          =   6,     /* enum(set | con) + length(5) */
+    MAX_OCTET_STR_SZ    =   6,     /* enum(set | con) + length(5) */
+    MAX_EXP_SZ          =   6,     /* enum(contextspec|con|exp) + length(5) */
+    MAX_PRSTR_SZ        =   6,     /* enum(prstr) + length(5)     */
     MAX_VERSION_SZ      =   5,     /* enum + id + version(byte) + (header(2))*/
     MAX_ENCODED_DIG_ASN_SZ= 9,     /* enum(bit or octet) + length(4) */
     MAX_ENCODED_DIG_SZ  =  64 + MAX_ENCODED_DIG_ASN_SZ, /* asn header + sha512 */
@@ -256,6 +256,7 @@ enum Misc_ASN {
     MAX_NTRU_KEY_SZ     = 610,     /* NTRU 112 bit public key */
     MAX_NTRU_ENC_SZ     = 628,     /* NTRU 112 bit DER public encoding */
     MAX_LENGTH_SZ       =   5,     /* Max length size for DER encoding */
+    MAX_SHORTINT_SZ     =   4,     /* SHORTINT max length size*/
     MAX_RSA_E_SZ        =  16,     /* Max RSA public e size */
     MAX_CA_SZ           =  32,     /* Max encoded CA basic constraint length */
     MAX_SN_SZ           =  35,     /* Max encoded serial number (INT) length */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -255,7 +255,7 @@ enum Misc_ASN {
     MAX_RSA_INT_SZ      = 517,     /* RSA raw sz 4096 for bits + tag + len(4) */
     MAX_NTRU_KEY_SZ     = 610,     /* NTRU 112 bit public key */
     MAX_NTRU_ENC_SZ     = 628,     /* NTRU 112 bit DER public encoding */
-    MAX_LENGTH_SZ       =   4,     /* Max length size for DER encoding */
+    MAX_LENGTH_SZ       =   5,     /* Max length size for DER encoding */
     MAX_RSA_E_SZ        =  16,     /* Max RSA public e size */
     MAX_CA_SZ           =  32,     /* Max encoded CA basic constraint length */
     MAX_SN_SZ           =  35,     /* Max encoded serial number (INT) length */


### PR DESCRIPTION
Increasing max_xxx_szs value to cover a potential out of range access when copying data by using specified value returned from SetLength(). SetLength() returns bytes corresponding input length to a caller. If the length is lager than 0x00ffffff, it returns 5 as a maximum, but not 4.  Therefore, to cover a edge case, the definition of related MAX_xxx_SZ is increased. This comes from the result of static code analysis(Zendesk#4678)