### PR TITLE
Initial support atecc608a on 32se

### DIFF
--- a/IDE/Espressif/ESP-IDF/README_esp32.md
+++ b/IDE/Espressif/ESP-IDF/README_esp32.md
@@ -22,7 +22,7 @@ Including the following examples:
  
  3. Uncomment out #define WOLFSSL_ESPWROOM32SE in /path/to/wolfssl/wolfssl/wolfcrypt/settings.h
  
-    Note : Need to enable both WOLFSSL_ESPIDF and WOLFSSL_ESPWROOM32  
+    Note : Need to enable WOLFSSL_ESPIDF  
     Note : crypt test will fail if enabled WOLFSSL_ESPWROOM32SE
  
 ## Configuration

--- a/IDE/Espressif/ESP-IDF/README_esp32.md
+++ b/IDE/Espressif/ESP-IDF/README_esp32.md
@@ -1,0 +1,42 @@
+# DEMO program with ATECC608A on ESP-WROOM-32SE
+## Overview
+ Running demo programs with ATECC608A on 32SE by setting *WOLFSSL_ESPWROOM32SE* definition
+
+Including the following examples:
+
+* simple tls_client/tls_server
+* crypt benchmark
+
+ The *user_settings.h* file enables some of the hardened settings. 
+ 
+## Requirements
+ 1. ESP-IDF development framework  
+    [https://docs.espressif.com/projects/esp-idf/en/latest/get-started/]
+
+ 2. Microchip CryptoAuthentication Library  
+    [https://github.com/MicrochipTech/cryptoauthlib]
+    
+## Setup
+ 1. wolfSSL under ESP-IDF. Please see [README.md](https://github.com/wolfSSL/wolfssl/blob/master/IDE/Espressif/ESP-IDF/README.md)
+ 2. CryptoAuthentication Library under ESP-IDF. Please see [README.md](https://github.com/miyazakh/cryptoauthlib_esp_idf/blob/master/README.md)
+ 
+ 3. Uncomment out #define WOLFSSL_ESPWROOM32SE in /path/to/wolfssl/wolfssl/wolfcrypt/settings.h
+ 
+    Note : Need to enable both WOLFSSL_ESPIDF and WOLFSSL_ESPWROOM32  
+    Note : crypt test will fail if enabled WOLFSSL_ESPWROOM32SE
+ 
+## Configuration
+ 1. The *user_settings.h* can be found in /path/to/esp-idf/components/wolfssl/include/user_settings.h
+
+## Build examples
+ 1. See README in each example folder
+
+## Support
+ For question please email [support@wolfssl.com]
+
+ Note: This is tested with the following condition:
+ 
+- Model    : ESP32-WROOM-32SE  
+- ESP-IDF  : v3.3-beta1-39-g6cb37ecc5(commit hash : 6cb37ecc5)  
+- CryptAuthLib: commit hash : c6b176e
+- OS       : Ubuntu 18.04.1 LTS (Bionic Beaver)

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main/helper.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main/helper.c
@@ -169,10 +169,8 @@ void app_main(void)
 {
     ESP_LOGI(TAG, "Start app_main...");
     ESP_ERROR_CHECK(nvs_flash_init());
-    
 
-    ESP_LOGI(TAG, "Start benchmark..");
-    wolf_benchmark_task( );
+#ifndef NO_CRYPT_BENCHMARK
 
     /* when using atecc608a on esp32-wroom-32se */
 #if defined(WOLFSSL_ESPWROOM32SE) && defined(HAVE_PK_CALLBACKS) \
@@ -185,8 +183,14 @@ void app_main(void)
     atmel_set_slot_allocator(my_atmel_alloc, my_atmel_free);
     #endif
 #endif
+    
+    ESP_LOGI(TAG, "Start benchmark..");
+    wolf_benchmark_task();
 
-    benchmark_test(NULL);
+#else
+    ESP_LOGI(TAG, "no crypt benchmark");
+
+#endif /* NO_CRYPT_BENCHMARK */
 
 }
 

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main/helper.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main/helper.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfcrypt/benchmark/benchmark.h>
 
 #include "sdkconfig.h"
 #include "freertos/FreeRTOS.h"
@@ -36,15 +37,8 @@
 
 /* proto-type */
 extern void wolf_benchmark_task();
-extern int benchmark_init();
-extern int benchmark_test(void *args);
 
-#ifdef WOLFSSL_ESPWROOM32SE
-const static char* TAG = "wolfbenchmark";
-#else
-const char* TAG = "wolfbenchmark";
-#endif
-
+static const char* const TAG = "wolfbenchmark";
 
 char* __argv[22];
 
@@ -53,16 +47,11 @@ char* __argv[22];
 
 #include "wolfssl/wolfcrypt/port/atmel/atmel.h"
 
-int atcatls_set_callbacks(struct WOLFSSL_CTX* ctx);
-
 /* when you need to use a custom slot allocation, */
 /* enable the definition CUSTOM_SLOT_ALLOCAION.   */
-
 #if defined(CUSTOM_SLOT_ALLOCATION)
 
 static byte mSlotList[ATECC_MAX_SLOT];
-
-int atmel_set_slot_allocator(atmel_slot_alloc_cb alloc, atmel_slot_dealloc_cb dealloc);
 
 /* initialize slot array */
 void my_atmel_slotInit()

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main/helper.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_benchmark/main/helper.c
@@ -1,6 +1,6 @@
 /* helper.c
  *
- * Copyright (C) 2006-2018 wolfSSL Inc.
+ * Copyright (C) 2006-2019 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -21,12 +21,108 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <wolfssl/wolfcrypt/settings.h>
 
 #include "sdkconfig.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
 
-#define WOLFSSL_BENCH_ARGV              CONFIG_BENCH_ARGV
+#define WOLFSSL_BENCH_ARGV                 CONFIG_BENCH_ARGV
+#define WOLFSSLBENCHMARK_TASK_NAME         "wolfsslbenchmark_name"
+#define WOLFSSLBENCHMARK_TASK_WORDS        10240
+#define WOLFSSLBENCHMARK_TASK_PRIORITY     8
+
+/* proto-type */
+extern void wolf_benchmark_task();
+extern int benchmark_init();
+extern int benchmark_test(void *args);
+
+#ifdef WOLFSSL_ESPWROOM32SE
+const static char* TAG = "wolfbenchmark";
+#else
+const char* TAG = "wolfbenchmark";
+#endif
+
 
 char* __argv[22];
+
+#if defined(WOLFSSL_ESPWROOM32SE) && defined(HAVE_PK_CALLBACKS) \
+                                  && defined(WOLFSSL_ATECC508A)
+
+#include "wolfssl/wolfcrypt/port/atmel/atmel.h"
+
+int atcatls_set_callbacks(struct WOLFSSL_CTX* ctx);
+
+/* when you need to use a custom slot allocation, */
+/* enable the definition CUSTOM_SLOT_ALLOCAION.   */
+
+#if defined(CUSTOM_SLOT_ALLOCATION)
+
+static byte mSlotList[ATECC_MAX_SLOT];
+
+int atmel_set_slot_allocator(atmel_slot_alloc_cb alloc, atmel_slot_dealloc_cb dealloc);
+
+/* initialize slot array */
+void my_atmel_slotInit()
+{
+    int i;
+
+    for(i=0;i<ATECC_MAX_SLOT; i++) {
+        mSlotList[i] = ATECC_INVALID_SLOT;
+    }
+}
+
+/* allocate slot depending on slotType */
+int my_atmel_alloc(int slotType)
+{
+    int i, slot = -1;
+ 
+    ESP_LOGI(TAG, "Enter my_atmel_alloc");
+
+    switch(slotType){
+        case ATMEL_SLOT_ENCKEY:
+            slot = 4;
+            break;
+        case ATMEL_SLOT_DEVICE:
+            slot = 0;
+            break;
+        case ATMEL_SLOT_ECDHE:
+            slot = 2;
+            break;
+        case ATMEL_SLOT_ECDHE_ENC:
+            slot = 4;
+            break;
+        case ATMEL_SLOT_ANY:
+            for(i=0;i<ATECC_MAX_SLOT;i++){
+                if(mSlotList[i] == ATECC_INVALID_SLOT){
+                    slot = i;
+                    break;
+                }
+            }
+    }
+
+    ESP_LOGI(TAG, "Leave my_atmel_alloc\n");
+
+    return slot;
+}
+
+/* free slot array       */
+void my_atmel_free(int slotId)
+{
+    ESP_LOGI(TAG, "Enter my_atmel_alloc");
+    
+    if(slotId >= 0 && slotId <= ATECC_MAX_SLOT){
+        mSlotList[slotId] = ATECC_INVALID_SLOT;
+    }
+    
+    ESP_LOGI(TAG, "Leave my_atmel_alloc");
+
+}
+
+#endif /* CUSTOM_SLOT_ALLOCATION                                       */
+#endif /* WOLFSSL_ESPWROOM32SE && HAVE_PK_CALLBACK && WOLFSSL_ATECC508A */
 
 int construct_argv()
 {
@@ -78,3 +174,30 @@ int construct_argv()
 
     return (cnt);
 }
+
+/* entry point */
+void app_main(void)
+{
+    ESP_LOGI(TAG, "Start app_main...");
+    ESP_ERROR_CHECK(nvs_flash_init());
+    
+
+    ESP_LOGI(TAG, "Start benchmark..");
+    wolf_benchmark_task( );
+
+    /* when using atecc608a on esp32-wroom-32se */
+#if defined(WOLFSSL_ESPWROOM32SE) && defined(HAVE_PK_CALLBACKS) \
+                                  && defined(WOLFSSL_ATECC508A)
+    #if defined(CUSTOM_SLOT_ALLOCATION)
+    ESP_LOGI(TAG, "register callback for slot allocation");
+    my_atmel_slotInit();
+    /* to register the callback, it needs to be initialized. */
+    benchmark_init();
+    atmel_set_slot_allocator(my_atmel_alloc, my_atmel_free);
+    #endif
+#endif
+
+    benchmark_test(NULL);
+
+}
+

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/client-tls.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/client-tls.c
@@ -40,15 +40,13 @@
     #include <wolfssl/wolfcrypt/mem_track.h>
 #endif
 
-#ifdef WOLFSSL_ESPWROOM32SE
-static const char* TAG = "tls_client";
-#else
-const char*  TAG = "tls_client";
-#endif
+static const char* const TAG = "tls_client";
+
+#if defined(DEBUG_WOLFSSL)
 
 static void ShowCiphers(void)
 {
-    static char ciphers[4096];
+    char ciphers[4096];
 
     int ret = wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
 
@@ -56,12 +54,12 @@ static void ShowCiphers(void)
         printf("%s\n", ciphers);
 }
 
+#endif
+
 #if defined(WOLFSSL_ESPWROOM32SE) && defined(HAVE_PK_CALLBACKS) \
                                   && defined(WOLFSSL_ATECC508A)
 
 #include "wolfssl/wolfcrypt/port/atmel/atmel.h"
-
-int atcatls_set_callbacks(struct WOLFSSL_CTX* ctx);
 
 /* when you want to use custome slot allocation */
 /* enable the definition CUSTOM_SLOT_ALLOCATION.*/
@@ -147,8 +145,6 @@ void tls_smp_client_task()
     WOLFSSL_MSG("Debug ON");
     wolfSSL_Debugging_ON();
     ShowCiphers();
-#else
-    (void)ShowCiphers;
 #endif
     /* Initialize wolfSSL */
     wolfSSL_Init();

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/client-tls.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/client-tls.c
@@ -1,6 +1,6 @@
 /* client-tls-callback.c
  *
- * Copyright (C) 2006-2018 wolfSSL Inc.
+ * Copyright (C) 2006-2019 wolfSSL Inc.
  *
  * This file is part of wolfSSL. (formerly known as CyaSSL)
  *
@@ -28,10 +28,8 @@
 #include "wifi_connect.h"
 
 /* socket includes */
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <unistd.h>
+#include "lwip/netdb.h"
+#include "lwip/sockets.h"
 
 /* wolfSSL */
 #include <wolfssl/wolfcrypt/settings.h>
@@ -42,25 +40,115 @@
     #include <wolfssl/wolfcrypt/mem_track.h>
 #endif
 
-const char *TAG = "tls_client";
+#ifdef WOLFSSL_ESPWROOM32SE
+static const char* TAG = "tls_client";
+#else
+const char*  TAG = "tls_client";
+#endif
 
+static void ShowCiphers(void)
+{
+    static char ciphers[4096];
+
+    int ret = wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
+
+    if (ret == WOLFSSL_SUCCESS)
+        printf("%s\n", ciphers);
+}
+
+#if defined(WOLFSSL_ESPWROOM32SE) && defined(HAVE_PK_CALLBACKS) \
+                                  && defined(WOLFSSL_ATECC508A)
+
+#include "wolfssl/wolfcrypt/port/atmel/atmel.h"
+
+int atcatls_set_callbacks(struct WOLFSSL_CTX* ctx);
+
+/* when you want to use custome slot allocation */
+/* enable the definition CUSTOM_SLOT_ALLOCATION.*/
+
+#if defined(CUSTOM_SLOT_ALLOCATION)
+
+static byte mSlotList[ATECC_MAX_SLOT];
+
+int atmel_set_slot_allocator(atmel_slot_alloc_cb alloc, 
+                                                atmel_slot_dealloc_cb dealloc);
+/* initialize slot array */
+void my_atmel_slotInit()
+{
+    int i;
+
+    for(i=0;i<ATECC_MAX_SLOT; i++) {
+        mSlotList[i] = ATECC_INVALID_SLOT;
+    }
+}
+/* allocate slot depending on slotType */
+int my_atmel_alloc(int slotType)
+{
+    int i, slot = -1;
+
+    switch(slotType){
+        case ATMEL_SLOT_ENCKEY:
+            slot = 2;
+            break;
+        case ATMEL_SLOT_DEVICE:
+            slot = 0;
+            break;
+        case ATMEL_SLOT_ECDHE:
+            slot = 0;
+            break;
+        case ATMEL_SLOT_ECDHE_ENC:
+            slot = 4;
+            break;
+        case ATMEL_SLOT_ANY:
+            for(i=0;i<ATECC_MAX_SLOT;i++){
+                if(mSlotList[i] == ATECC_INVALID_SLOT){
+                    slot = i;
+                    break;
+                }
+            }
+    }
+
+    return slot;
+}
+/* free slot array       */
+void my_atmel_free(int slotId)
+{
+    if(slotId >= 0 && slotId <= ATECC_MAX_SLOT){
+        mSlotList[slotId] = ATECC_INVALID_SLOT;
+    }
+}
+#endif /* CUSTOM_SLOT_ALLOCATION                                       */
+#endif /* WOLFSSL_ESPWROOM32SE && HAVE_PK_CALLBACK && WOLFSSL_ATECC508A */
+
+/* client task */
 void tls_smp_client_task()
 {
     int ret;
     int sockfd;
+    int doPeerCheck;
+    int sendGet;
     struct sockaddr_in servAddr;
     char buff[256];
+    const char* ch = TLS_SMP_TARGET_HOST;
     size_t len;
+    struct hostent *hp;
+    struct ip4_addr *ip4_addr;
 
     /* declare wolfSSL objects */
     WOLFSSL_CTX *ctx;
     WOLFSSL *ssl;
 
-   WOLFSSL_ENTER("tls_smp_client_task");
+    WOLFSSL_ENTER("tls_smp_client_task");
+
+    doPeerCheck = 0;
+    sendGet = 0;
 
 #ifdef DEBUG_WOLFSSL
-   WOLFSSL_MSG("Debug ON");
-   wolfSSL_Debugging_ON();
+    WOLFSSL_MSG("Debug ON");
+    wolfSSL_Debugging_ON();
+    ShowCiphers();
+#else
+    (void)ShowCiphers;
 #endif
     /* Initialize wolfSSL */
     wolfSSL_Init();
@@ -69,17 +157,48 @@ void tls_smp_client_task()
      * Sets the socket to be stream based (TCP),
      * 0 means choose the default protocol. */
     if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-        printf("ERROR: failed to create the socket\n");
+        ESP_LOGE(TAG,"ERROR: failed to create the socket\n");
+    }
+
+    ESP_LOGI(TAG, "get target IP address");
+
+    hp = gethostbyname(TLS_SMP_TARGET_HOST);
+    if (!hp) {
+         ESP_LOGE(TAG, "Failed to get host name.");
+         ip4_addr = NULL;
+    } else {
+         
+         ip4_addr = (struct ip4_addr *)hp->h_addr;
+         ESP_LOGI(TAG, IPSTR, IP2STR(ip4_addr));
     }
     /* Create and initialize WOLFSSL_CTX */
     if ((ctx = wolfSSL_CTX_new(wolfSSLv23_client_method())) == NULL) {
-        printf("ERROR: failed to create WOLFSSL_CTX\n");
+        ESP_LOGE(TAG,"ERROR: failed to create WOLFSSL_CTX\n");
     }
     WOLFSSL_MSG("Loading...cert");
     /* Load client certificates into WOLFSSL_CTX */
     if ((ret = wolfSSL_CTX_load_verify_buffer(ctx, ca_cert_der_2048,
         sizeof_ca_cert_der_2048, WOLFSSL_FILETYPE_ASN1)) != SSL_SUCCESS) {
-        printf("ERROR: failed to load %d, please check the file.\n",ret);
+        ESP_LOGE(TAG,"ERROR: failed to load %d, please check the file.\n",ret);
+    }
+    /* not peer check */
+    if( doPeerCheck == 0 ){
+        wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, 0);
+    } else {
+        WOLFSSL_MSG("Loading... our cert");
+        /* load our certificate */
+   	    if ((ret = wolfSSL_CTX_use_certificate_chain_buffer_format(ctx, client_cert_der_2048,
+            sizeof_client_cert_der_2048, WOLFSSL_FILETYPE_ASN1)) != SSL_SUCCESS) {
+            ESP_LOGE(TAG,"ERROR: failed to load chain %d, please check the file.\n",ret);
+        }
+    
+        if ((ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx, client_key_der_2048,
+            sizeof_client_key_der_2048, WOLFSSL_FILETYPE_ASN1))  != SSL_SUCCESS) {
+            wolfSSL_CTX_free(ctx); ctx = NULL;
+            ESP_LOGE(TAG,"ERROR: failed to load key %d, please check the file.\n", ret);
+        }
+
+        wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, 0);
     }
 
     /* Initialize the server address struct with zeros */
@@ -89,27 +208,43 @@ void tls_smp_client_task()
     servAddr.sin_family = AF_INET;           /* using IPv4      */
     servAddr.sin_port = htons(DEFAULT_PORT); /* on DEFAULT_PORT */
 
-    /* Get the server IPv4 address from the command line call */
-    WOLFSSL_MSG("inet_pton");
-    if ((ret = inet_pton(AF_INET, TLS_SMP_TARGET_HOST,
-             &servAddr.sin_addr)) != 1) {
-        printf("ERROR: invalid address ret=%d\n", ret);
+    if(*ch >= '1' && *ch <= '9') {
+        /* Get the server IPv4 address from the command line call */
+        WOLFSSL_MSG("inet_pton");
+        if ((ret = inet_pton(AF_INET, TLS_SMP_TARGET_HOST,
+                 &servAddr.sin_addr)) != 1) {
+            ESP_LOGE(TAG,"ERROR: invalid address ret=%d\n", ret);
+        }
+    } else {
+        servAddr.sin_addr.s_addr = ip4_addr->addr;
     }
 
     /* Connect to the server */
     sprintf(buff, "Connecting to server....%s(port:%d)", TLS_SMP_TARGET_HOST
                                                       , DEFAULT_PORT);
     WOLFSSL_MSG(buff);
+    printf("%s\n",buff);
     if ((ret = connect(sockfd, (struct sockaddr *)&servAddr,
                                     sizeof(servAddr))) == -1){
-        printf("ERROR: failed to connect ret=%d\n", ret);
+        ESP_LOGE(TAG,"ERROR: failed to connect ret=%d\n", ret);
     }
 
     WOLFSSL_MSG("Create a WOLFSSL object");
     /* Create a WOLFSSL object */
     if ((ssl = wolfSSL_new(ctx)) == NULL) {
-        printf("ERROR: failed to create WOLFSSL object\n");
+        ESP_LOGE(TAG,"ERROR: failed to create WOLFSSL object\n");
     }
+
+    /* when using atecc608a on esp32-wroom-32se */ 
+#if defined(WOLFSSL_ESPWROOM32SE) && defined(HAVE_PK_CALLBACKS) \
+                                  && defined(WOLFSSL_ATECC508A)
+    atcatls_set_callbacks(ctx);
+    /* when using custome slot-allocation */
+    #if defined(CUSTOM_SLOT_ALLOCATION)
+    my_atmel_slotInit();
+    atmel_set_slot_allocator(my_atmel_alloc, my_atmel_free);
+    #endif
+#endif
 
     /* Attach wolfSSL to the socket */
     wolfSSL_set_fd(ssl, sockfd);
@@ -117,28 +252,36 @@ void tls_smp_client_task()
     WOLFSSL_MSG("Connect to wolfSSL on the server side");
     /* Connect to wolfSSL on the server side */
     if (wolfSSL_connect(ssl) != SSL_SUCCESS) {
-        printf("ERROR: failed to connect to wolfSSL\n");
+        ESP_LOGE(TAG,"ERROR: failed to connect to wolfSSL\n");
     }
 
     /* Get a message for the server from stdin */
     WOLFSSL_MSG("Message for server: ");
     memset(buff, 0, sizeof(buff));
-    sprintf(buff, "message from client\n");
-    len = strnlen(buff, sizeof(buff));
+    
+    if(sendGet){
+        printf("SSL connect ok, sending GET...\n");
+        len = 28;
+        strncpy(buff, "GET /index.html HTTP/1.0\r\n\r\n", 28);
+        buff[len] = '\0';
+    } else {
+        sprintf(buff, "message from esp32 tls client\n");
+        len = strnlen(buff, sizeof(buff));
+    }
     /* Send the message to the server */
     if (wolfSSL_write(ssl, buff, len) != len) {
-        printf("ERROR: failed to write\n");
+        ESP_LOGE(TAG,"ERROR: failed to write\n");
     }
 
     /* Read the server data into our buff array */
     memset(buff, 0, sizeof(buff));
     if (wolfSSL_read(ssl, buff, sizeof(buff) - 1) == -1) {
-        printf("ERROR: failed to read\n");
+        ESP_LOGE(TAG,"ERROR: failed to read\n");
     }
 
     /* Print to stdout any data the server sends */
-    WOLFSSL_MSG("Server:");
-    WOLFSSL_MSG(buff);
+    printf("Server:");
+    printf("%s", buff);
     /* Cleanup and return */
     wolfSSL_free(ssl);     /* Free the wolfSSL object                  */
     wolfSSL_CTX_free(ctx); /* Free the wolfSSL context object          */

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/server-tls.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/server-tls.c
@@ -48,7 +48,7 @@ static const char* const TAG = "tls_server";
 
 static void ShowCiphers(void)
 {
-    static char ciphers[4096];
+    char ciphers[4096];
 
     int ret = wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
 
@@ -62,8 +62,6 @@ static void ShowCiphers(void)
                                   && defined(WOLFSSL_ATECC508A)
 
 #include "wolfssl/wolfcrypt/port/atmel/atmel.h"
-
-int atcatls_set_callbacks(struct WOLFSSL_CTX* ctx);
 
 /* when you want to use a custom slot allocation */
 /* enable the difinition CUSTOM_SLOT_ALLOCATION. */

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/server-tls.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/server-tls.c
@@ -1,6 +1,6 @@
 /* server-tls-callback.c
  *
- * Copyright (C) 2006-2018 wolfSSL Inc.
+ * Copyright (C) 2006-2019 wolfSSL Inc.
  *
  * This file is part of wolfSSL. (formerly known as CyaSSL)
  *
@@ -42,11 +42,9 @@
     #include <wolfssl/wolfcrypt/mem_track.h>
 #endif
 
-#if defined(WOLFSSL_ESPWROOM32SE)
-static const char* TAG = "tls_server";
-#else
-const char* TAG = "tls_server";
-#endif
+static const char* const TAG = "tls_server";
+
+#if defined(DEBUG_WOLFSSL)
 
 static void ShowCiphers(void)
 {
@@ -57,6 +55,8 @@ static void ShowCiphers(void)
     if (ret == WOLFSSL_SUCCESS)
         printf("%s\n", ciphers);
 }
+
+#endif
 
 #if defined(WOLFSSL_ESPWROOM32SE) && defined(HAVE_PK_CALLBACKS) \
                                   && defined(WOLFSSL_ATECC508A)
@@ -146,8 +146,6 @@ void tls_smp_server_task()
     WOLFSSL_MSG("Debug ON");
     wolfSSL_Debugging_ON();
     ShowCiphers();
-#else
-    (void)ShowCiphers;
 #endif
 
     /* Initialize wolfSSL */

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/server-tls.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/server-tls.c
@@ -42,7 +42,87 @@
     #include <wolfssl/wolfcrypt/mem_track.h>
 #endif
 
-const char *TAG = "tls_server";
+#if defined(WOLFSSL_ESPWROOM32SE)
+static const char* TAG = "tls_server";
+#else
+const char* TAG = "tls_server";
+#endif
+
+static void ShowCiphers(void)
+{
+    static char ciphers[4096];
+
+    int ret = wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
+
+    if (ret == WOLFSSL_SUCCESS)
+        printf("%s\n", ciphers);
+}
+
+#if defined(WOLFSSL_ESPWROOM32SE) && defined(HAVE_PK_CALLBACKS) \
+                                  && defined(WOLFSSL_ATECC508A)
+
+#include "wolfssl/wolfcrypt/port/atmel/atmel.h"
+
+int atcatls_set_callbacks(struct WOLFSSL_CTX* ctx);
+
+/* when you want to use a custom slot allocation */
+/* enable the difinition CUSTOM_SLOT_ALLOCATION. */
+
+#if defined(CUSTOM_SLOT_ALLOCATION)
+
+static byte mSlotList[ATECC_MAX_SLOT];
+
+int atmel_set_slot_allocator(atmel_slot_alloc_cb alloc, atmel_slot_dealloc_cb dealloc);
+
+/* initialize slot array */
+void my_atmel_slotInit()
+{
+    int i;
+
+    for(i=0;i<ATECC_MAX_SLOT; i++) {
+        mSlotList[i] = ATECC_INVALID_SLOT;
+    }
+}
+
+/* allocate slot depending on slotType */
+int my_atmel_alloc(int slotType)
+{
+    int i, slot = -1;
+
+    switch(slotType){
+        case ATMEL_SLOT_ENCKEY:
+            slot = 4;
+            break;
+        case ATMEL_SLOT_DEVICE:
+            slot = 0;
+            break;
+        case ATMEL_SLOT_ECDHE:
+            slot = 0;
+            break;
+        case ATMEL_SLOT_ECDHE_ENC:
+            slot = 4;
+            break;
+        case ATMEL_SLOT_ANY:
+            for(i=0;i<ATECC_MAX_SLOT;i++){
+                if(mSlotList[i] == ATECC_INVALID_SLOT){
+                    slot = i;
+                    break;
+                }
+            }
+    }
+
+    return slot;
+}
+
+/* free slot array       */
+void my_atmel_free(int slotId)
+{
+    if(slotId >= 0 && slotId <= ATECC_MAX_SLOT){
+        mSlotList[slotId] = ATECC_INVALID_SLOT;
+    }
+}
+#endif /* CUSTOM_SLOT_ALLOCATION                                       */
+#endif /* WOLFSSL_ESPWROOM32SE && HAVE_PK_CALLBACK && WOLFSSL_ATECC508A */
 
 void tls_smp_server_task()
 {
@@ -65,7 +145,11 @@ void tls_smp_server_task()
 #ifdef DEBUG_WOLFSSL
     WOLFSSL_MSG("Debug ON");
     wolfSSL_Debugging_ON();
+    ShowCiphers();
+#else
+    (void)ShowCiphers;
 #endif
+
     /* Initialize wolfSSL */
     WOLFSSL_MSG("Start wolfSSL_Init()");
     wolfSSL_Init();
@@ -75,28 +159,33 @@ void tls_smp_server_task()
      * 0 means choose the default protocol. */
     WOLFSSL_MSG( "start socket())");
     if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
-        printf("ERROR: failed to create the socket");
+        ESP_LOGE(TAG, "ERROR: failed to create the socket");
     }
 
     /* Create and initialize WOLFSSL_CTX */
     WOLFSSL_MSG("Create and initialize WOLFSSL_CTX");
     if ((ctx = wolfSSL_CTX_new(wolfSSLv23_server_method())) == NULL) {
-        printf("ERROR: failed to create WOLFSSL_CTX");
+        ESP_LOGE(TAG, "ERROR: failed to create WOLFSSL_CTX");
     }
     WOLFSSL_MSG("Loading certificate...");
     /* Load server certificates into WOLFSSL_CTX */
+    
     if ((ret = wolfSSL_CTX_use_certificate_buffer(ctx, server_cert_der_2048,
                         sizeof_server_cert_der_2048,
                         WOLFSSL_FILETYPE_ASN1)) != SSL_SUCCESS) {
-        printf("ERROR: failed to load cert");
+        ESP_LOGE(TAG, "ERROR: failed to load cert");
     }
     WOLFSSL_MSG("Loading key info...");
     /* Load server key into WOLFSSL_CTX */
+    
     if((ret=wolfSSL_CTX_use_PrivateKey_buffer(ctx,
                             server_key_der_2048, sizeof_server_key_der_2048,
                             WOLFSSL_FILETYPE_ASN1)) != SSL_SUCCESS) {
-        printf("ERROR: failed to load privatekey");
+        ESP_LOGE(TAG, "ERROR: failed to load privatekey");
     }
+
+    /* TO DO when using ECDSA, it loads the provisioned certificate and present it.*/
+    /* TO DO when using ECDSA, it uses the generated key instead of loading key    */
 
     /* Initialize the server address struct with zeros */
     memset(&servAddr, 0, sizeof(servAddr));
@@ -107,37 +196,48 @@ void tls_smp_server_task()
 
     /* Bind the server socket to our port */
     if (bind(sockfd, (struct sockaddr*)&servAddr, sizeof(servAddr)) == -1) {
-         printf("ERROR: failed to bind");
+         ESP_LOGE(TAG, "ERROR: failed to bind");
     }
 
     /* Listen for a new connection, allow 5 pending connections */
     if (listen(sockfd, 5) == -1) {
-         printf("ERROR: failed to listen");
+         ESP_LOGE(TAG, "ERROR: failed to listen");
     }
+
+#if defined(WOLFSSL_ESPWROOM32SE) && defined(HAVE_PK_CALLBACKS) \
+                                  && defined(WOLFSSL_ATECC508A)
+    atcatls_set_callbacks(ctx);
+    /* when using a custom slot allocation */
+    #if defined(CUSTOM_SLOT_ALLOCATION)
+    my_atmel_slotInit();
+    atmel_set_slot_allocator(my_atmel_alloc, my_atmel_free);
+    #endif
+#endif
+
     /* Continue to accept clients until shutdown is issued */
     while (!shutdown) {
          WOLFSSL_MSG("Waiting for a connection...");
         /* Accept client connections */
         if ((connd = accept(sockfd, (struct sockaddr*)&clientAddr, &size))
             == -1) {
-             printf("ERROR: failed to accept the connection");
+             ESP_LOGE(TAG, "ERROR: failed to accept the connection");
         }
         /* Create a WOLFSSL object */
         if ((ssl = wolfSSL_new(ctx)) == NULL) {
-             printf("ERROR: failed to create WOLFSSL object");
+             ESP_LOGE(TAG, "ERROR: failed to create WOLFSSL object");
         }
         /* Attach wolfSSL to the socket */
         wolfSSL_set_fd(ssl, connd);
         /* Establish TLS connection */
         ret = wolfSSL_accept(ssl);
         if (ret != SSL_SUCCESS) {
-            printf("wolfSSL_accept error %d", wolfSSL_get_error(ssl, ret));
+            ESP_LOGE(TAG, "wolfSSL_accept error %d", wolfSSL_get_error(ssl, ret));
         }
         WOLFSSL_MSG("Client connected successfully");
         /* Read the client data into our buff array */
         memset(buff, 0, sizeof(buff));
         if (wolfSSL_read(ssl, buff, sizeof(buff)-1) == -1) {
-            printf("ERROR: failed to read");
+            ESP_LOGE(TAG, "ERROR: failed to read");
         }
         /* Print to stdout any data the client sends */
         WOLFSSL_MSG("Client sends:");
@@ -153,7 +253,7 @@ void tls_smp_server_task()
         len = strnlen(buff, sizeof(buff));
         /* Reply back to the client */
         if (wolfSSL_write(ssl, buff, len) != len) {
-            printf("ERROR: failed to write");
+            ESP_LOGE(TAG, "ERROR: failed to write");
         }
         /* Cleanup after this connection */
         wolfSSL_free(ssl);      /* Free the wolfSSL object              */

--- a/IDE/Espressif/ESP-IDF/libs/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/libs/CMakeLists.txt
@@ -11,6 +11,7 @@ set(INCLUDE_PATH ${WOLFSSL_ROOT})
 set(COMPONENT_SRCDIRS "./src/"
                       "./wolfcrypt/src/"
                       "./wolfcrypt/src/port/Espressif/"
+                      "./wolfcrypt/src/port/atmel/"
                       )
 
 set(COMPONENT_REQUIRES lwip)

--- a/IDE/Espressif/ESP-IDF/libs/CMakeLists.txt
+++ b/IDE/Espressif/ESP-IDF/libs/CMakeLists.txt
@@ -23,6 +23,10 @@ set(COMPONENT_ADD_INCLUDEDIRS
     "${WOLFSSL_ROOT}"
     )
 
+if(IS_DIRECTORY ${IDF_PATH}/components/cryptoauthlib)
+    list(APPEND COMPONENT_ADD_INCLUDEDIRS "../cryptoauthlib/lib")
+endif()
+
 set(COMPONENT_SRCEXCLUDE
     "wolfcrypt/src/aes_asm.S"
     "wolfcrypt/src/evp.c"

--- a/IDE/Espressif/ESP-IDF/libs/component.mk
+++ b/IDE/Espressif/ESP-IDF/libs/component.mk
@@ -7,6 +7,7 @@ COMPONENT_ADD_INCLUDEDIRS += ../freertos/include/freertos/
 
 COMPONENT_SRCDIRS := src wolfcrypt/src
 COMPONENT_SRCDIRS += wolfcrypt/src/port/Espressif
+COMPONENT_SRCDIRS += wolfcrypt/src/port/atmel
 
 CFLAGS +=-DWOLFSSL_USER_SETTINGS
 

--- a/IDE/Espressif/ESP-IDF/test/README.md
+++ b/IDE/Espressif/ESP-IDF/test/README.md
@@ -8,8 +8,4 @@ When you want to run the app
 3. "make menuconfig" to configure unit test app.  
 4. "make TEST_COMPONENTS=wolfssl" to build wolfssl unit test app.  
 
-NOTE:  
- You should remove *user_settings.h* file at wolfssl/ folder after finishing run  
- the unit test app.
-
 See [https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/unit-tests.html] for more information about unit test app.

--- a/IDE/Espressif/ESP-IDF/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/user_settings.h
@@ -44,10 +44,16 @@
 #define CURVE25519_SMALL
 #define HAVE_ED25519
 
-/* when you want to use a custom slot allocation for ATECC608A */
-/* unless your configuration is unusual, you can use default   */
-/* implementation.                                             */
-/* #define CUSTOM_SLOT_ALLOCATION */
+/* esp32-wroom-32se specific definition */
+#if defined(WOLFSSL_ESPWROOM32SE)
+    #define WOLFSSL_ATECC508A
+    #define HAVE_PK_CALLBACKS
+    /* when you want to use a custom slot allocation for ATECC608A */
+    /* unless your configuration is unusual, you can use default   */
+    /* implementation.                                             */
+    /* #define CUSTOM_SLOT_ALLOCATION                              */
+#endif
+
 
 /* debug options */
 /* #define DEBUG_WOLFSSL */

--- a/IDE/Espressif/ESP-IDF/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/user_settings.h
@@ -1,6 +1,6 @@
 /* user_settings.h
  *
- * Copyright (C) 2006-2018 wolfSSL Inc.
+ * Copyright (C) 2006-2019 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -44,9 +44,15 @@
 #define CURVE25519_SMALL
 #define HAVE_ED25519
 
+/* when you want to use a custom slot allocation for ATECC608A */
+/* unless your configuration is unusual, you can use default   */
+/* implementation.                                             */
+/* #define CUSTOM_SLOT_ALLOCATION */
+
 /* debug options */
 /* #define DEBUG_WOLFSSL */
 /* #define WOLFSSL_ESP32WROOM32_CRYPT_DEBUG */
+/* #define WOLFSSL_ATECC508A_DEBUG          */
 
 /* date/time                               */
 /* if it cannot adjust time in the device, */

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -5491,9 +5491,7 @@ int main(int argc, char** argv)
 #ifdef HAVE_STACK_SIZE
     ret = StackSizeCheck(NULL, benchmark_test);
 #else
-#ifndef WOLFSSL_ESPIDF
     ret = benchmark_test(NULL);
-#endif
 #endif
 
     return ret;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -5367,7 +5367,7 @@ static int string_matches(const char* arg, const char* str)
     return XSTRNCMP(arg, str, len) == 0;
 }
 #ifdef WOLFSSL_ESPIDF
-int app_main( )
+int wolf_benchmark_task( )
 #else
 int main(int argc, char** argv)
 #endif
@@ -5491,7 +5491,9 @@ int main(int argc, char** argv)
 #ifdef HAVE_STACK_SIZE
     ret = StackSizeCheck(NULL, benchmark_test);
 #else
+#ifndef WOLFSSL_ESPIDF
     ret = benchmark_test(NULL);
+#endif
 #endif
 
     return ret;

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -1,6 +1,6 @@
 /* logging.c
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2019 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -255,8 +255,7 @@ static void wolfssl_log(const int logLevel, const char *const logMessage)
 #elif defined(WOLFSSL_APACHE_MYNEWT)
         LOG_DEBUG(&mynewt_log, LOG_MODULE_DEFAULT, "%s\n", logMessage);
 #elif defined(WOLFSSL_ESPIDF)
-        extern char* TAG;
-        ESP_LOGI(TAG, "%s", logMessage);
+        ESP_LOGI("wolfssl", "%s", logMessage);
 #else
         fprintf(stderr, "%s\n", logMessage);
 #endif

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -1,6 +1,6 @@
 ﻿/* atmel.c
  *
- * Copyright (C) 2006-2018 wolfSSL Inc.
+ * Copyright (C) 2006-2019 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -338,7 +338,7 @@ int atmel_ecc_create_pms(int slotId, const uint8_t* peerKey, uint8_t* pms)
     int slotIdEnc;
 
     slotIdEnc = atmel_ecc_alloc(ATMEL_SLOT_ECDHE_ENC);
-    if (slotIdEnc != ATECC_INVALID_SLOT)
+    if (slotIdEnc == ATECC_INVALID_SLOT)
         return BAD_FUNC_ARG;
 
     /* get encryption key */

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2073,7 +2073,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     }
 
 #elif defined(WOLFSSL_ESPIDF)
-    #if defined(WOLFSSL_ESPWROOM32)
+    #if defined(WOLFSSL_ESPWROOM32) || defined(WOLFSSL_ESPWROOM32SE)
         #include <esp_system.h>
 
         int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -241,11 +241,6 @@
         #define WOLFSSL_ESP32WROOM32_CRYPT
     #endif
 #endif
-#if defined(WOLFSSL_ESPWROOM32SE)
-    /* esp32-wroom-32se specific definition */
-    #define WOLFSSL_ATECC508A
-    #define HAVE_PK_CALLBACKS
-#endif
 #if !defined(WOLFSSL_USER_SETTINGS)
     #define HAVE_ECC
 #endif /* !WOLFSSL_USER_SETTINGS */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1,6 +1,6 @@
 /* settings.h
  *
- * Copyright (C) 2006-2017 wolfSSL Inc.
+ * Copyright (C) 2006-2019 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -181,6 +181,9 @@
 /* Uncomment next line if using Espressif ESP32-WROOM-32 */
 /* #define WOLFSSL_ESPWROOM32 */
 
+/* Uncomment next line if using Espressif ESP32-WROOM-32SE */
+/* #define WOLFSSL_ESPWROOM32SE */
+
 #include <wolfssl/wolfcrypt/visibility.h>
 
 #ifdef WOLFSSL_USER_SETTINGS
@@ -233,10 +236,15 @@
     #define TFM_TIMING_RESISTANT
     #define ECC_TIMING_RESISTANT
     #define WC_RSA_BLINDING
-#if defined(WOLFSSL_ESPWROOM32)
+#if defined(WOLFSSL_ESPWROOM32) || defined(WOLFSSL_ESPWROOM32SE)
    #ifndef NO_ESP32WROOM32_CRYPT
         #define WOLFSSL_ESP32WROOM32_CRYPT
     #endif
+#endif
+#if defined(WOLFSSL_ESPWROOM32SE)
+    /* esp32-wroom-32se specific definition */
+    #define WOLFSSL_ATECC508A
+    #define HAVE_PK_CALLBACKS
 #endif
 #if !defined(WOLFSSL_USER_SETTINGS)
     #define HAVE_ECC


### PR DESCRIPTION
This PR is a checkpoint to support atecc608a on esp-wroom-32se.

- Add WOLFSS_ESPWROOM32SE definition to enable atecc608a(atecc508a) use with wolfssl
- Modified simple tls_server/tls_clinet 
- Use cryptoauthlib to access 608a on 32se