### PR TITLE
Fix Checks

### DIFF
--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -643,7 +643,11 @@ static int bench_tls_client(info_t* info)
     }
 
 #ifndef NO_DH
-    wolfSSL_CTX_SetMinDhKey_Sz(cli_ctx, MIN_DHKEY_BITS);
+    ret = wolfSSL_CTX_SetMinDhKey_Sz(cli_ctx, MIN_DHKEY_BITS);
+    if (ret != WOLFSSL_SUCCESS) {
+        printf("Error setting minimum DH key size\n");
+        goto exit;
+    }
 #endif
 
     /* Allocate and initialize a packet sized buffer */
@@ -960,7 +964,11 @@ static int bench_tls_server(info_t* info)
     }
 
 #ifndef NO_DH
-    wolfSSL_CTX_SetMinDhKey_Sz(srv_ctx, MIN_DHKEY_BITS);
+    ret = wolfSSL_CTX_SetMinDhKey_Sz(srv_ctx, MIN_DHKEY_BITS);
+    if (ret != WOLFSSL_SUCCESS) {
+        printf("Error setting minimum DH key size\n");
+        goto exit;
+    }
 #endif
 
     /* Allocate read buffer */

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -2122,7 +2122,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         wolfSSL_CTX_set_group_messages(ctx);
 
 #ifndef NO_DH
-    wolfSSL_CTX_SetMinDhKey_Sz(ctx, (word16)minDhKeyBits);
+    if (wolfSSL_CTX_SetMinDhKey_Sz(ctx, (word16)minDhKeyBits)
+            != WOLFSSL_SUCCESS) {
+        err_sys("Error setting minimum DH key size");
+    }
 #endif
 
     if (usePsk) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -6479,6 +6479,9 @@ int HashOutput(WOLFSSL* ssl, const byte* output, int sz, int ivSz)
     int ret = 0;
     const byte* adj;
 
+    if (ssl->hsHashes == NULL)
+        return BAD_FUNC_ARG;
+
     adj = output + RECORD_HEADER_SZ + ivSz;
     sz -= RECORD_HEADER_SZ;
 


### PR DESCRIPTION
1. In the client, check the return code on wolfSSL_CTX_SetMinDhKey_Sz() as it is checked in the server. (Resolves issue #2037.)
2. In HashOutput(), check that the hsHashes exists for the session before hashing. (Resolves issue #2038.)