### PR TITLE
OCSP Script Update

### DIFF
--- a/scripts/ocsp.test
+++ b/scripts/ocsp.test
@@ -15,6 +15,7 @@ if [ $? -eq 0 ]; then
     exit 0
 fi
 
+GL_UNREACHABLE=0
 # Global Sign now requires server name indication extension to work, check
 # enabled prior to testing
 OUTPUT=$(eval "./examples/client/client -S check")


### PR DESCRIPTION
The check status variable GL_UNREACHABLE is not initialized and there are times when it is checked and hasn't been set. Initialize it to zero.