### PR TITLE
Fixes to resolve possible build issues with SafeRTOS.

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -784,11 +784,17 @@ extern void uITRON4_free(void *p) ;
     #ifndef SINGLE_THREADED
         #include "SafeRTOS/semphr.h"
     #endif
-
-    #include "SafeRTOS/heap.h"
-    #define XMALLOC(s, h, type)  pvPortMalloc((s))
-    #define XFREE(p, h, type)    vPortFree((p))
-    #define XREALLOC(p, n, h, t) pvPortRealloc((p), (n))
+    #ifndef WOLFSSL_NO_MALLOC
+        #include "SafeRTOS/heap.h"
+    #endif
+    #if !defined(XMALLOC_USER) && !defined(NO_WOLFSSL_MEMORY) && \
+        !defined(WOLFSSL_STATIC_MEMORY)
+        #define XMALLOC(s, h, type)  pvPortMalloc((s))
+        #define XFREE(p, h, type)    vPortFree((p))
+    #endif
+    #if !defined(USE_FAST_MATH) || defined(HAVE_ED25519)
+        #define XREALLOC(p, n, h, t) pvPortRealloc((p), (n))
+    #endif
 #endif
 
 #ifdef WOLFSSL_LOW_MEMORY

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -345,6 +345,7 @@
             #define XSTRSEP(s1,d) strsep((s1),(d))
         #endif
 
+        #ifndef XSTRNCASECMP
         #if defined(MICROCHIP_PIC32) || defined(WOLFSSL_TIRTOS)
             /* XC32 does not support strncasecmp, so use case sensitive one */
             #define XSTRNCASECMP(s1,s2,n) strncmp((s1),(s2),(n))
@@ -357,6 +358,7 @@
             #endif
             #define XSTRNCASECMP(s1,s2,n) strncasecmp((s1),(s2),(n))
         #endif
+        #endif /* !XSTRNCASECMP */
 
         /* snprintf is used in asn.c for GetTimeString, PKCS7 test, and when
            debugging is turned on */

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -390,8 +390,12 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
        time_t XTIME(time_t * timer) {}
     */
     #define WOLFSSL_GMTIME
-    #define USE_WOLF_TM
-    #define USE_WOLF_TIME_T
+    #ifndef HAVE_TM_TYPE
+        #define USE_WOLF_TM
+    #endif
+    #ifndef HAVE_TIME_T_TYPE
+        #define USE_WOLF_TIME_T
+    #endif
 
 #elif defined(TIME_OVERRIDES)
     /* Override XTIME() and XGMTIME() functionality.
@@ -491,7 +495,7 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
 #ifdef TIME_T_NOT_LONG
     /* one old reference to TIME_T_NOT_LONG in GCC-ARM example README
      * this keeps support for the old macro name */
-    #undef TIME_T_NOT_64BIT
+    #undef  TIME_T_NOT_64BIT
     #define TIME_T_NOT_64BIT
 #endif
 


### PR DESCRIPTION
* Support for building `WOLFSSL_SAFERTOS` without heap.
* Allows `XSTRNCASECMP` macro to be customized.
* USER_TIME supports checks for existing `strct tm` and `time_t`.