### PR TITLE
add alert number and string for "unknown_ca" (48)

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19625,6 +19625,13 @@ const char* wolfSSL_alert_type_string_long(int alertID)
                 return illegal_parameter_str;
             }
 
+        case unknown_ca:
+            {
+                static const char unknown_ca_str[] =
+                    "unknown_ca";
+                return unknown_ca_str;
+            }
+
         case decode_error:
             {
                 static const char decode_error_str[] =

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -391,6 +391,7 @@ enum AlertDescription {
     certificate_expired             =  45,
     certificate_unknown             =  46,
     illegal_parameter               =  47,
+    unknown_ca                      =  48,
     decode_error                    =  50,
     decrypt_error                   =  51,
     #ifdef WOLFSSL_MYSQL_COMPATIBLE


### PR DESCRIPTION
This PR adds the "unknown_ca" alert number and string.  From the TLS 1.2 RFC:

```
enum {
          ...
          unknown_ca(48),
          ...
      } AlertDescription;
```

This allows users to get back this ID/string if received from the peer.  They can call wolfSSL_get_alert_history(), then wolfSSL_alert_type_string_long() or wolfSSL_alert_desc_string_long().

One of the test cases for Python urllib3 checks against this string.