### PR TITLE
A couple fixes to atmel.c, mSlotList & PMS outlen

### DIFF
--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -59,9 +59,9 @@
 static int mAtcaInitDone = 0;
 
 /* ATECC slotId handling */
-static atmel_slot_alloc_cb mSlotAlloc;
-static atmel_slot_dealloc_cb mSlotDealloc;
-static byte mSlotList[ATECC_MAX_SLOT];
+static atmel_slot_alloc_cb mSlotAlloc = NULL;
+static atmel_slot_dealloc_cb mSlotDealloc = NULL;
+static byte mSlotList[ATECC_MAX_SLOT + 1];
 #ifndef SINGLE_THREADED
 static wolfSSL_Mutex mSlotMutex;
 #endif
@@ -223,7 +223,7 @@ int atmel_ecc_alloc(int slotType)
                 slotId = ATECC_SLOT_ENC_PARENT;
                 break;
             case ATMEL_SLOT_ANY:
-                for (i=0; i < ATECC_MAX_SLOT; i++) {
+                for (i=0; i <= ATECC_MAX_SLOT; i++) {
                     /* Find free slotId */
                     if (mSlotList[i] == ATECC_INVALID_SLOT) {
                         slotId = i;
@@ -260,7 +260,7 @@ void atmel_ecc_free(int slotId)
     if (mSlotDealloc) {
         mSlotDealloc(slotId);
     }
-    else if (slotId >= 0 && slotId < ATECC_MAX_SLOT) {
+    else if (slotId >= 0 && slotId <= ATECC_MAX_SLOT) {
         if (slotId != ATECC_SLOT_AUTH_PRIV && slotId != ATECC_SLOT_I2C_ENC) {
             /* Mark slotId free */
             mSlotList[slotId] = ATECC_INVALID_SLOT;
@@ -603,7 +603,7 @@ int atcatls_create_pms_cb(WOLFSSL* ssl, ecc_key* otherKey,
         }
 
         ret = atmel_ecc_create_pms(tmpKey.slot, peerKey, out);
-        *outlen = ATECC_SIG_SIZE;
+        *outlen = ATECC_KEY_SIZE;
 
     #ifndef WOLFSSL_ATECC508A_NOIDLE
         /* put chip into idle to prevent watchdog situation on chip */


### PR DESCRIPTION
The PMS created in atmel.c is 32 bytes, but the output length is getting set to 64 bytes.  This is causing a MAC Verification error in my system.

Also the ATECC_MAX_SLOT constant is inclusive of the itself, i.e. in atmel_init() it is initialised with index<=ATECC_MAX_SLOT, whereas in other parts of the code, it is index<ATECC_MAX_SLOT.

Also set a default value to use the default ecc_alloc/ecc_free functions are used.  Without this and not calling the set callback function, my platform was crashing since these were not null.