### PR TITLE
Fixes for various build issues

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -12,38 +12,43 @@ if test -d .git; then
   ln -s -f ../../pre-push.sh .git/hooks/pre-push
 fi
 
+# touch options.h (make sure it exists)
+touch ./wolfssl/options.h
+
+# touch fips files for non fips distribution
+touch ./ctaocrypt/src/fips.c
+touch ./ctaocrypt/src/fips_test.c
+touch ./wolfcrypt/src/fips.c
+touch ./wolfcrypt/src/fips_test.c
+touch ./wolfcrypt/src/wolfcrypt_first.c
+touch ./wolfcrypt/src/wolfcrypt_last.c
+touch ./wolfssl/wolfcrypt/fips.h
+
+# touch CAVP selftest files for non-selftest distribution
+touch ./wolfcrypt/src/selftest.c
+
+# touch async crypt files
+touch ./wolfcrypt/src/async.c
+touch ./wolfssl/wolfcrypt/async.h
+
+# touch async port files
+touch ./wolfcrypt/src/port/intel/quickassist.c
+touch ./wolfcrypt/src/port/intel/quickassist_mem.c
+touch ./wolfcrypt/src/port/cavium/cavium_nitrox.c
+if [ ! -d ./wolfssl/wolfcrypt/port/intel ]; then
+  mkdir ./wolfssl/wolfcrypt/port/intel
+fi
+touch ./wolfssl/wolfcrypt/port/intel/quickassist.h
+touch ./wolfssl/wolfcrypt/port/intel/quickassist_mem.h
+if [ ! -d ./wolfssl/wolfcrypt/port/cavium ]; then
+  mkdir ./wolfssl/wolfcrypt/port/cavium
+fi
+touch ./wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h
+
 # If this is a source checkout then call autoreconf with error as well
 if test -e .git; then
   WARNINGS="all,error"
-  # touch fips files for non fips distribution
-  touch ./ctaocrypt/src/fips.c
-  touch ./ctaocrypt/src/fips_test.c
-  touch ./wolfcrypt/src/fips.c
-  touch ./wolfcrypt/src/fips_test.c
-  touch ./wolfcrypt/src/wolfcrypt_first.c
-  touch ./wolfcrypt/src/wolfcrypt_last.c
-  touch ./wolfssl/wolfcrypt/fips.h
 
-  # touch CAVP selftest files for non-selftest distribution
-  touch ./wolfcrypt/src/selftest.c
-
-  # touch async crypt files
-  touch ./wolfcrypt/src/async.c
-  touch ./wolfssl/wolfcrypt/async.h
-
-  # touch async port files
-  touch ./wolfcrypt/src/port/intel/quickassist.c
-  touch ./wolfcrypt/src/port/intel/quickassist_mem.c
-  touch ./wolfcrypt/src/port/cavium/cavium_nitrox.c
-  if [ ! -d ./wolfssl/wolfcrypt/port/intel ]; then
-    mkdir ./wolfssl/wolfcrypt/port/intel
-  fi
-  touch ./wolfssl/wolfcrypt/port/intel/quickassist.h
-  touch ./wolfssl/wolfcrypt/port/intel/quickassist_mem.h
-  if [ ! -d ./wolfssl/wolfcrypt/port/cavium ]; then
-    mkdir ./wolfssl/wolfcrypt/port/cavium
-  fi
-  touch ./wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h
 else
   WARNINGS="all"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -4456,6 +4456,14 @@ then
 fi
 
 
+# User Settings
+AC_ARG_ENABLE([usersettings],
+    [AS_HELP_STRING([--enable-usersettings],[Use your own user_settings.h and do not add Makefile CFLAGS (default: disabled)])],
+    [ ENABLED_USERSETTINGS=$enableval ],
+    [ ENABLED_USERSETTINGS=no ]
+    )
+
+
 # Default optimization CFLAGS enable
 AC_ARG_ENABLE([optflags],
     [AS_HELP_STRING([--enable-optflags],[Enable default optimization CFLAGS for the compiler (default: enabled)])],
@@ -4679,6 +4687,13 @@ AS_IF([test "x$ENABLED_WOLFSSH" = "xyes"],
 
 ################################################################################
 
+# USER SETTINGS
+if test "x$ENABLED_USERSETTINGS" = "xyes"
+then
+    # Replace all options and just use WOLFSSL_USER_SETTINGS
+    AM_CFLAGS="-DWOLFSSL_USER_SETTINGS"
+fi
+
 # OPTIMIZE FLAGS
 # For distro disable custom build options that interfere with symbol generation
 if test "$GCC" = "yes" && test "$ENABLED_DISTRO" = "no"
@@ -4710,7 +4725,7 @@ fi
 # Expose HAVE___UINT128_T to options flags"
 if test "$ac_cv_type___uint128_t" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DHAVE___UINT128_T"
+    AM_CFLAGS="$AM_CFLAGS -DHAVE___UINT128_T=1"
 fi
 
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -11625,7 +11625,7 @@ static int test_wc_RsaPublicEncryptDecrypt (void)
 
     /* Decrypt */
     printf(testingFmt, "wc_RsaPrivateDecrypt()");
-    #if defined(WC_RSA_BLINDING)
+    #if defined(WC_RSA_BLINDING) && !defined(HAVE_FIPS)
         /* Bind rng */
         if (ret == 0) {
             ret = wc_RsaSetRNG(&key, &rng);
@@ -11713,7 +11713,7 @@ static int test_wc_RsaPublicEncryptDecrypt_ex (void)
 
     /* Decrypt */
     printf(testingFmt, "wc_RsaPrivateDecrypt_ex()");
-    #if defined(WC_RSA_BLINDING)
+    #if defined(WC_RSA_BLINDING) && !defined(HAVE_FIPS)
         if (ret == 0) {
             ret = wc_RsaSetRNG(&key, &rng);
         }


### PR DESCRIPTION
Fixes for wolfSSL build issues in the following cases:
* Fixes for building wolfSSL from GitHub sources download, where .git does exist. The autogen.sh still needs to "touch" files for the build to work.
* Fix for FIPS case where `wc_RsaSetRNG` is not available.
* Added new `./configure --enable-usersettings` option to not populate the Makefile with build options and instead define `WOLFSSL_USER_SETTINGS` and expect a user provided `user_settings.h` file.
* Fix for `HAVE___UINT128_T` to match config.h generated value to eliminate warning.