### PR TITLE
Spell Check for 'assign' in evp.h (For EVP_PKEY_XXX)

### DIFF
--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -550,8 +550,8 @@ typedef WOLFSSL_EVP_CIPHER_CTX EVP_CIPHER_CTX;
 #define EVP_get_cipherbyname          wolfSSL_EVP_get_cipherbyname
 #define EVP_get_digestbyname          wolfSSL_EVP_get_digestbyname
 
-#define EVP_PKEY_asign_RSA             wolfSSL_EVP_PKEY_assign_RSA
-#define EVP_PKEY_asign_EC_KEY          wolfSSL_EVP_PKEY_assign_EC_KEY
+#define EVP_PKEY_assign_RSA            wolfSSL_EVP_PKEY_assign_RSA
+#define EVP_PKEY_assign_EC_KEY         wolfSSL_EVP_PKEY_assign_EC_KEY
 #define EVP_PKEY_get1_DSA              wolfSSL_EVP_PKEY_get1_DSA
 #define EVP_PKEY_get1_RSA              wolfSSL_EVP_PKEY_get1_RSA
 #define EVP_PKEY_get1_DSA              wolfSSL_EVP_PKEY_get1_DSA


### PR DESCRIPTION
## What is changed in this Pull Request?

- While trying to consume & use WolfSSL for my local development, found that `EVP_PKEY_assign_RSA()` & `EVP_PKEY_assign_EC_KEY()` are **misspelled** in `wolfssl/openssl/evp.h` file. 

- Keyword '**assign**' misses out of one 's', the present compatibility layer instances look like [EVP_PKEY_asign_RSA() & EVP_PKEY_asign_EC_KEY()](https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/openssl/evp.h#L553-#L554).

- Just rectified the spelling of assign.

## Reference:
Actual instance of OpenSSL functions link are present below:
1. [EVP_PKEY_assign_RSA()](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/include/openssl/evp.h#L420)
2. [EVP_PKEY_assign_EC_KEY()](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/include/openssl/evp.h#L405) 

## Reviewer:
@wolfSSL-Bot 