### PR TITLE
DO-178 sample (for a review)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -505,7 +505,7 @@ AC_ARG_ENABLE([signal],
     [ ENABLED_SIGNAL=no ]
     )
 
-# OpenSSL Coexist 
+# OpenSSL Coexist
 AC_ARG_ENABLE([opensslcoexist],
     [AS_HELP_STRING([--enable-opensslcoexist],[Enable coexistence of wolfssl/openssl (default: disabled)])],
     [ ENABLED_OPENSSLCOEXIST=$enableval ],
@@ -1065,7 +1065,7 @@ fi
 AM_CONDITIONAL([BUILD_AESNI], [test "x$ENABLED_AESNI" = "xyes"])
 
 
-# Linux af_alg 
+# Linux af_alg
 AC_ARG_ENABLE([afalg],
     [AS_HELP_STRING([--enable-afalg],[Enable Linux af_alg use for crypto (default: disabled)])],
     [ ENABLED_AFALG=$enableval ],
@@ -2268,6 +2268,21 @@ fi
 
 AM_CONDITIONAL([BUILD_RABBIT], [test "x$ENABLED_RABBIT" = "xyes"])
 
+# DO178
+AC_ARG_ENABLE([do178],
+    [AS_HELP_STRING([--enable-do178],[Enable DO-178C (default: disabled)])],
+    [ ENABLED_DO178=$enableval ],
+    [ ENABLED_DO178=no ]
+    )
+
+if test "$ENABLED_DO178" = "no"
+then
+    AM_CFLAGS="$AM_CFLAGS -DNO_DO178"
+else
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_DO178"
+fi
+
+AM_CONDITIONAL([BUILD_DO178], [test "x$ENABLED_DO178" = "xyes"])
 
 # FIPS
 AC_ARG_ENABLE([fips],
@@ -4909,6 +4924,7 @@ echo "   * Xilinx Hardware Acc.:       $ENABLED_XILINX"
 echo "   * Inline Code:                $ENABLED_INLINE"
 echo "   * Linux AF_ALG:               $ENABLED_AFALG"
 echo "   * Linux cryptodev:            $ENABLED_DEVCRYPTO"
+echo "   * DO178:                      $ENABLED_DO178"
 echo ""
 echo "---"
 

--- a/examples/include.am
+++ b/examples/include.am
@@ -1,9 +1,16 @@
 # vim:ft=automake
 # All paths should be given relative to the root
 
+if BUILD_DO178
+# none is supported yet
+
+else
+
 include examples/benchmark/include.am
 include examples/client/include.am
 include examples/echoclient/include.am
 include examples/echoserver/include.am
 include examples/server/include.am
 include examples/sctp/include.am
+
+endif # !BUILD_DO178

--- a/src/include.am
+++ b/src/include.am
@@ -9,6 +9,11 @@ src_libwolfssl_la_LIBADD = $(LIBM) $(LIB_ADD) $(LIB_STATIC_ADD)
 src_libwolfssl_la_CFLAGS = -DBUILDING_WOLFSSL $(AM_CFLAGS)
 src_libwolfssl_la_CPPFLAGS = -DBUILDING_WOLFSSL $(AM_CPPFLAGS)
 
+if BUILD_DO178
+src_libwolfssl_la_SOURCES += wolfcrypt/src/sha256_cert.c
+
+else
+
 # install the packaged IPP libraries
 if BUILD_FAST_RSA
 
@@ -418,3 +423,5 @@ src_libwolfssl_la_SOURCES += src/sniffer.c
 endif
 
 endif # !BUILD_CRYPTONLY
+
+endif # !BUILD_DO178

--- a/tests/include.am
+++ b/tests/include.am
@@ -2,6 +2,10 @@
 # included from Top Level Makefile.am
 # All paths should be given relative to the root
 
+if BUILD_DO178
+# none is supported yet
+
+else
 
 if BUILD_TESTS
 check_PROGRAMS += tests/unit.test
@@ -40,3 +44,5 @@ EXTRA_DIST += tests/test.conf \
               tests/test-trustpeer.conf \
               tests/test-dhprime.conf
 DISTCLEANFILES+= tests/.libs/unit.test
+
+endif # !BUILD_DO178

--- a/testsuite/include.am
+++ b/testsuite/include.am
@@ -2,6 +2,10 @@
 # included from Top Level Makefile.am
 # All paths should be given relative to the root
 
+if BUILD_DO178
+# none is supported yet
+
+else
 
 if BUILD_TESTS
 check_PROGRAMS += testsuite/testsuite.test
@@ -24,3 +28,5 @@ EXTRA_DIST += testsuite/testsuite.vcxproj
 EXTRA_DIST += input
 EXTRA_DIST += quit
 DISTCLEANFILES+= testsuite/.libs/testsuite.test
+
+endif # !BUILD_DO178

--- a/wolfcrypt/benchmark/include.am
+++ b/wolfcrypt/benchmark/include.am
@@ -1,6 +1,11 @@
 # vim:ft=automake
 # All paths should be given relative to the root
 
+if BUILD_DO178
+# none is supported yet
+
+else
+
 if BUILD_WOLFCRYPT_TESTS
 noinst_PROGRAMS += wolfcrypt/benchmark/benchmark
 wolfcrypt_benchmark_benchmark_SOURCES      = wolfcrypt/benchmark/benchmark.c
@@ -8,6 +13,8 @@ wolfcrypt_benchmark_benchmark_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD)
 wolfcrypt_benchmark_benchmark_DEPENDENCIES = src/libwolfssl.la
 noinst_HEADERS += wolfcrypt/benchmark/benchmark.h
 endif
-EXTRA_DIST += wolfcrypt/benchmark/benchmark.sln 
+EXTRA_DIST += wolfcrypt/benchmark/benchmark.sln
 EXTRA_DIST += wolfcrypt/benchmark/benchmark.vcproj
 DISTCLEANFILES+= wolfcrypt/benchmark/.libs/benchmark
+
+endif # !BUILD_DO178

--- a/wolfcrypt/src/sha256_cert.c
+++ b/wolfcrypt/src/sha256_cert.c
@@ -1,0 +1,362 @@
+/* sha256_cert.c
+ *
+ * Copyright (C) 2006-2019 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* For more info on the algorithm, see https://tools.ietf.org/html/rfc6234 */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/sha256.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+
+static const ALIGN32 word32 K[64] = {
+    0x428A2F98L, 0x71374491L, 0xB5C0FBCFL, 0xE9B5DBA5L, 0x3956C25BL,
+    0x59F111F1L, 0x923F82A4L, 0xAB1C5ED5L, 0xD807AA98L, 0x12835B01L,
+    0x243185BEL, 0x550C7DC3L, 0x72BE5D74L, 0x80DEB1FEL, 0x9BDC06A7L,
+    0xC19BF174L, 0xE49B69C1L, 0xEFBE4786L, 0x0FC19DC6L, 0x240CA1CCL,
+    0x2DE92C6FL, 0x4A7484AAL, 0x5CB0A9DCL, 0x76F988DAL, 0x983E5152L,
+    0xA831C66DL, 0xB00327C8L, 0xBF597FC7L, 0xC6E00BF3L, 0xD5A79147L,
+    0x06CA6351L, 0x14292967L, 0x27B70A85L, 0x2E1B2138L, 0x4D2C6DFCL,
+    0x53380D13L, 0x650A7354L, 0x766A0ABBL, 0x81C2C92EL, 0x92722C85L,
+    0xA2BFE8A1L, 0xA81A664BL, 0xC24B8B70L, 0xC76C51A3L, 0xD192E819L,
+    0xD6990624L, 0xF40E3585L, 0x106AA070L, 0x19A4C116L, 0x1E376C08L,
+    0x2748774CL, 0x34B0BCB5L, 0x391C0CB3L, 0x4ED8AA4AL, 0x5B9CCA4FL,
+    0x682E6FF3L, 0x748F82EEL, 0x78A5636FL, 0x84C87814L, 0x8CC70208L,
+    0x90BEFFFAL, 0xA4506CEBL, 0xBEF9A3F7L, 0xC67178F2L
+};
+
+#define Ch(x,y,z)       ((z) ^ ((x) & ((y) ^ (z))))
+#define Maj(x,y,z)      ((((x) | (y)) & (z)) | ((x) & (y)))
+#define R(x, n)         (((x) & 0xFFFFFFFFU) >> (n))
+
+#define S(x, n)         rotrFixed(x, n)
+#define Sigma0(x)       (S(x, 2)  ^ S(x, 13) ^ S(x, 22))
+#define Sigma1(x)       (S(x, 6)  ^ S(x, 11) ^ S(x, 25))
+#define Gamma0(x)       (S(x, 7)  ^ S(x, 18) ^ R(x, 3))
+#define Gamma1(x)       (S(x, 17) ^ S(x, 19) ^ R(x, 10))
+
+#define a(i) S[(0-i) & 7]
+#define b(i) S[(1-i) & 7]
+#define c(i) S[(2-i) & 7]
+#define d(i) S[(3-i) & 7]
+#define e(i) S[(4-i) & 7]
+#define f(i) S[(5-i) & 7]
+#define g(i) S[(6-i) & 7]
+#define h(i) S[(7-i) & 7]
+
+#define RND(j) \
+     t0 = h(j) + Sigma1(e(j)) + Ch(e(j), f(j), g(j)) + K[i+j] + W[i+j]; \
+     t1 = Sigma0(a(j)) + Maj(a(j), b(j), c(j)); \
+     d(j) += t0; \
+     h(j)  = t0 + t1
+
+static int Transform_Sha256(wc_Sha256* sha256);
+#define XTRANSFORM(S)        Transform_Sha256((S))
+
+static int Transform_Sha256(wc_Sha256* sha256)
+{
+    word32 S[8], t0, t1;
+    int i;
+    word32 W[WC_SHA256_BLOCK_SIZE];
+
+    /* Copy context->state[] to working vars */
+    for (i = 0; i < 8; i++)
+        S[i] = sha256->digest[i];
+
+    for (i = 0; i < 16; i++)
+        W[i] = sha256->buffer[i];
+
+    for (i = 16; i < WC_SHA256_BLOCK_SIZE; i++)
+         W[i] = Gamma1(W[i-2]) + W[i-7] + Gamma0(W[i-15]) + W[i-16];
+
+#ifdef USE_SLOW_SHA256
+     /* not unrolled - ~2k smaller and ~25% slower */
+    for (i = 0; i < WC_SHA256_BLOCK_SIZE; i += 8) {
+        int j;
+        for (j = 0; j < 8; j++) { /* braces needed here for macros {} */
+            RND(j);
+        }
+    }
+ #else
+    /* partially loop unrolled */
+    for (i = 0; i < WC_SHA256_BLOCK_SIZE; i += 8) {
+        RND(0); RND(1); RND(2); RND(3);
+        RND(4); RND(5); RND(6); RND(7);
+    }
+ #endif /* USE_SLOW_SHA256 */
+
+    /* Add the working vars back into digest state[] */
+    for (i = 0; i < 8; i++) {
+        sha256->digest[i] += S[i];
+    }
+
+    return 0;
+ }
+
+static int InitSha256(wc_Sha256* sha256)
+{
+    int ret = 0;
+
+    if (sha256 == NULL)
+        return BAD_FUNC_ARG;
+
+    XMEMSET(sha256->digest, 0, sizeof(sha256->digest));
+    sha256->digest[0] = 0x6A09E667L;
+    sha256->digest[1] = 0xBB67AE85L;
+    sha256->digest[2] = 0x3C6EF372L;
+    sha256->digest[3] = 0xA54FF53AL;
+    sha256->digest[4] = 0x510E527FL;
+    sha256->digest[5] = 0x9B05688CL;
+    sha256->digest[6] = 0x1F83D9ABL;
+    sha256->digest[7] = 0x5BE0CD19L;
+
+    sha256->buffLen = 0;
+    sha256->loLen   = 0;
+    sha256->hiLen   = 0;
+
+    return ret;
+ }
+
+int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
+{
+    int ret = 0;
+    (void)heap;
+    (void)devId;
+
+    if (sha256 == NULL)
+        return BAD_FUNC_ARG;
+
+    sha256->heap = heap;
+
+    ret = InitSha256(sha256);
+    if (ret != 0)
+        return ret;
+
+#ifdef WOLFSSL_SMALL_STACK_CACHE
+    sha256->W = NULL;
+#endif
+    return ret;
+ }
+
+static WC_INLINE void AddLength(wc_Sha256* sha256, word32 len)
+{
+    word32 tmp = sha256->loLen;
+    if ((sha256->loLen += len) < tmp)
+        sha256->hiLen++;                       /* carry low to high */
+}
+
+static WC_INLINE int Sha256Update(wc_Sha256* sha256, const byte* data, word32 len)
+{
+    int ret = 0;
+    byte* local;
+
+    if (sha256 == NULL || (data == NULL && len > 0)) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (data == NULL && len == 0) {
+        /* valid, but do nothing */
+        return 0;
+    }
+
+    /* do block size increments */
+    local = (byte*)sha256->buffer;
+
+    /* check that internal buffLen is valid */
+    if (sha256->buffLen >= WC_SHA256_BLOCK_SIZE)
+        return BUFFER_E;
+
+    if (sha256->buffLen > 0) {
+        word32 add = min(len, WC_SHA256_BLOCK_SIZE - sha256->buffLen);
+        XMEMCPY(&local[sha256->buffLen], data, add);
+
+        sha256->buffLen += add;
+        data            += add;
+        len             -= add;
+
+        if (sha256->buffLen == WC_SHA256_BLOCK_SIZE) {
+     #if defined(LITTLE_ENDIAN_ORDER)
+            ByteReverseWords(sha256->buffer, sha256->buffer,
+                                                       WC_SHA256_BLOCK_SIZE);
+     #endif
+        ret = XTRANSFORM(sha256);
+             if (ret == 0) {
+                 AddLength(sha256, WC_SHA256_BLOCK_SIZE);
+                 sha256->buffLen = 0;
+             }
+             else
+                 len = 0;
+         }
+     }
+
+     word32 blocksLen = len & ~(WC_SHA256_BLOCK_SIZE-1);
+     AddLength(sha256, blocksLen);
+     while (len >= WC_SHA256_BLOCK_SIZE) {
+        XMEMCPY(local, data, WC_SHA256_BLOCK_SIZE);
+
+        data += WC_SHA256_BLOCK_SIZE;
+        len  -= WC_SHA256_BLOCK_SIZE;
+
+        #if defined(LITTLE_ENDIAN_ORDER)
+            ByteReverseWords(sha256->buffer, sha256->buffer,
+                                                          WC_SHA256_BLOCK_SIZE);
+        #endif
+        /* Byte reversal performed in function if required. */
+        ret = XTRANSFORM(sha256);
+        if (ret != 0)
+            break;
+        }
+
+     if (len > 0) {
+        XMEMCPY(local, data, len);
+        sha256->buffLen = len;
+     }
+     return ret;
+ }
+
+
+int wc_Sha256Update(wc_Sha256* sha256, const byte* data, word32 len)
+{
+    return Sha256Update(sha256, data, len);
+}
+
+int wc_Sha256GetHash(wc_Sha256* sha256, byte* hash)
+{
+    int ret;
+    wc_Sha256 tmpSha256;
+
+    if (sha256 == NULL || hash == NULL)
+        return BAD_FUNC_ARG;
+    ret = wc_Sha256Copy(sha256, &tmpSha256);
+    if (ret == 0) {
+        ret = wc_Sha256Final(&tmpSha256, hash);
+    }
+    return ret;
+}
+
+int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
+{
+    int ret = 0;
+
+    if (src == NULL || dst == NULL)
+        return BAD_FUNC_ARG;
+
+    XMEMCPY(dst, src, sizeof(wc_Sha256));
+#ifdef WOLFSSL_SMALL_STACK_CACHE
+    dst->W = NULL;
+#endif
+
+   return ret;
+}
+
+static WC_INLINE int Sha256Final(wc_Sha256* sha256)
+{
+    int ret;
+    byte* local = (byte*)sha256->buffer;
+
+    if (sha256 == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    AddLength(sha256, sha256->buffLen);  /* before adding pads */
+    local[sha256->buffLen++] = 0x80;     /* add 1 */
+
+    /* pad with zeros */
+    if (sha256->buffLen > WC_SHA256_PAD_SIZE) {
+        XMEMSET(&local[sha256->buffLen], 0,
+            WC_SHA256_BLOCK_SIZE - sha256->buffLen);
+        sha256->buffLen += WC_SHA256_BLOCK_SIZE - sha256->buffLen;
+
+        {
+    #if defined(LITTLE_ENDIAN_ORDER)
+            ByteReverseWords(sha256->buffer, sha256->buffer,
+                                                      WC_SHA256_BLOCK_SIZE);
+    #endif
+        }
+        ret = XTRANSFORM(sha256);
+        if (ret != 0)
+            return ret;
+
+        sha256->buffLen = 0;
+    }
+     XMEMSET(&local[sha256->buffLen], 0, WC_SHA256_PAD_SIZE - sha256->buffLen);
+
+     /* put lengths in bits */
+     sha256->hiLen = (sha256->loLen >> (8 * sizeof(sha256->loLen) - 3)) +
+                                                      (sha256->hiLen << 3);
+     sha256->loLen = sha256->loLen << 3;
+
+     /* store lengths */
+ #if defined(LITTLE_ENDIAN_ORDER)
+     ByteReverseWords(sha256->buffer, sha256->buffer,
+                 WC_SHA256_BLOCK_SIZE);
+ #endif
+     /* ! length ordering dependent on digest endian type ! */
+     XMEMCPY(&local[WC_SHA256_PAD_SIZE], &sha256->hiLen, sizeof(word32));
+     XMEMCPY(&local[WC_SHA256_PAD_SIZE + sizeof(word32)], &sha256->loLen,
+             sizeof(word32));
+
+ #if defined(FREESCALE_MMCAU_SHA) || defined(HAVE_INTEL_AVX1) || \
+     defined(HAVE_INTEL_AVX2)
+     /* Kinetis requires only these bytes reversed */
+     #if defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2)
+         if (IS_INTEL_AVX1(intel_flags) || IS_INTEL_AVX2(intel_flags))
+     #endif
+         {
+             ByteReverseWords(
+                 &sha256->buffer[WC_SHA256_PAD_SIZE / sizeof(word32)],
+                 &sha256->buffer[WC_SHA256_PAD_SIZE / sizeof(word32)],
+                 2 * sizeof(word32));
+         }
+ #endif
+
+        return XTRANSFORM(sha256);
+
+}
+
+int wc_Sha256Final(wc_Sha256* sha256, byte* hash)
+{
+    int ret;
+
+    if (sha256 == NULL || hash == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    ret = Sha256Final(sha256);
+    if (ret != 0)
+        return ret;
+
+ #if defined(LITTLE_ENDIAN_ORDER)
+    ByteReverseWords(sha256->digest, sha256->digest, WC_SHA256_DIGEST_SIZE);
+ #endif
+    XMEMCPY(hash, sha256->digest, WC_SHA256_DIGEST_SIZE);
+
+    return InitSha256(sha256);  /* reset state */
+}

--- a/wolfcrypt/test/include.am
+++ b/wolfcrypt/test/include.am
@@ -1,13 +1,19 @@
 # vim:ft=automake
 # All paths should be given relative to the root
 
+
 if BUILD_WOLFCRYPT_TESTS
 noinst_PROGRAMS+= wolfcrypt/test/testwolfcrypt
 if BUILD_CRYPTONLY
 check_PROGRAMS+= wolfcrypt/test/testwolfcrypt
 endif
 noinst_PROGRAMS+= wolfcrypt/test/testwolfcrypt
+if BUILD_DO178
+wolfcrypt_test_testwolfcrypt_SOURCES      = wolfcrypt/test/test_cert.c
+else
 wolfcrypt_test_testwolfcrypt_SOURCES      = wolfcrypt/test/test.c
+endif
+
 wolfcrypt_test_testwolfcrypt_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD)
 wolfcrypt_test_testwolfcrypt_DEPENDENCIES = src/libwolfssl.la
 noinst_HEADERS += wolfcrypt/test/test.h

--- a/wolfcrypt/test/test_cert.c
+++ b/wolfcrypt/test/test_cert.c
@@ -1,0 +1,180 @@
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/sha256.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#define HEAP_HINT NULL
+
+static int devId = INVALID_DEVID;
+
+#define ERROR_OUT(err, eLabel) { ret = (err); goto eLabel; }
+
+/* only for stack size check */
+#ifdef HAVE_STACK_SIZE
+    #include <wolfssl/ssl.h>
+    #define err_sys err_sys_remap /* remap err_sys */
+    #include <wolfssl/test.h>
+    #undef err_sys
+#endif
+
+#ifdef HAVE_STACK_SIZE
+static THREAD_RETURN err_sys(const char* msg, int es)
+#else
+static int err_sys(const char* msg, int es)
+#endif
+{
+    printf("%s error = %d\n", msg, es);
+
+    EXIT_TEST(-1);
+}
+
+#ifndef HAVE_STACK_SIZE
+/* func_args from test.h, so don't have to pull in other stuff */
+typedef struct func_args {
+    int    argc;
+    char** argv;
+    int    return_code;
+} func_args;
+#endif /* !HAVE_STACK_SIZE */
+
+int  sha256_test(void);
+
+#ifdef HAVE_STACK_SIZE
+THREAD_RETURN WOLFSSL_THREAD wolfcrypt_test(void* args);
+#else
+int wolfcrypt_test(void* args);
+#endif
+
+typedef struct testVector {
+    const char*  input;
+    const char*  output;
+    size_t inLen;
+    size_t outLen;
+} testVector;
+#ifndef NO_SHA256
+int sha256_test(void)
+{
+    wc_Sha256 sha;
+    byte      hash[WC_SHA256_DIGEST_SIZE];
+    byte      hashcopy[WC_SHA256_DIGEST_SIZE];
+    int       ret = 0;
+
+    testVector a, b, c;
+    testVector test_sha[3];
+    int times = sizeof(test_sha) / sizeof(struct testVector), i;
+
+    a.input  = "";
+    a.output = "\xe3\xb0\xc4\x42\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99\x6f\xb9"
+               "\x24\x27\xae\x41\xe4\x64\x9b\x93\x4c\xa4\x95\x99\x1b\x78\x52"
+               "\xb8\x55";
+    a.inLen  = XSTRLEN(a.input);
+    a.outLen = WC_SHA256_DIGEST_SIZE;
+
+    b.input  = "abc";
+    b.output = "\xBA\x78\x16\xBF\x8F\x01\xCF\xEA\x41\x41\x40\xDE\x5D\xAE\x22"
+               "\x23\xB0\x03\x61\xA3\x96\x17\x7A\x9C\xB4\x10\xFF\x61\xF2\x00"
+               "\x15\xAD";
+    b.inLen  = XSTRLEN(b.input);
+    b.outLen = WC_SHA256_DIGEST_SIZE;
+
+    c.input  = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+    c.output = "\x24\x8D\x6A\x61\xD2\x06\x38\xB8\xE5\xC0\x26\x93\x0C\x3E\x60"
+               "\x39\xA3\x3C\xE4\x59\x64\xFF\x21\x67\xF6\xEC\xED\xD4\x19\xDB"
+               "\x06\xC1";
+    c.inLen  = XSTRLEN(c.input);
+    c.outLen = WC_SHA256_DIGEST_SIZE;
+
+    test_sha[0] = a;
+    test_sha[1] = b;
+    test_sha[2] = c;
+
+    ret = wc_InitSha256_ex(&sha, HEAP_HINT, devId);
+    if (ret != 0)
+        return -2100;
+
+    for (i = 0; i < times; ++i) {
+        ret = wc_Sha256Update(&sha, (byte*)test_sha[i].input,
+            (word32)test_sha[i].inLen);
+        if (ret != 0)
+            ERROR_OUT(-2110 - i, exit);
+        ret = wc_Sha256GetHash(&sha, hashcopy);
+        if (ret != 0)
+            ERROR_OUT(-2120 - i, exit);
+        ret = wc_Sha256Final(&sha, hash);
+        if (ret != 0)
+            ERROR_OUT(-2130 - i, exit);
+
+        if (XMEMCMP(hash, test_sha[i].output, WC_SHA256_DIGEST_SIZE) != 0)
+            ERROR_OUT(-2140 - i, exit);
+        if (XMEMCMP(hash, hashcopy, WC_SHA256_DIGEST_SIZE) != 0)
+            ERROR_OUT(-2150 - i, exit);
+    }
+
+    /* BEGIN LARGE HASH TEST */ {
+    byte large_input[1024];
+    const char* large_digest =
+        "\x27\x78\x3e\x87\x96\x3a\x4e\xfb\x68\x29\xb5\x31\xc9\xba\x57\xb4"
+        "\x4f\x45\x79\x7f\x67\x70\xbd\x63\x7f\xbf\x0d\x80\x7c\xbd\xba\xe0";
+
+    for (i = 0; i < (int)sizeof(large_input); i++) {
+        large_input[i] = (byte)(i & 0xFF);
+    }
+    times = 100;
+#ifdef WOLFSSL_PIC32MZ_HASH
+    wc_Sha256SizeSet(&sha, times * sizeof(large_input));
+#endif
+    for (i = 0; i < times; ++i) {
+        ret = wc_Sha256Update(&sha, (byte*)large_input,
+            (word32)sizeof(large_input));
+        if (ret != 0)
+            ERROR_OUT(-2160, exit);
+    }
+    ret = wc_Sha256Final(&sha, hash);
+    if (ret != 0)
+        ERROR_OUT(-2161, exit);
+    if (XMEMCMP(hash, large_digest, WC_SHA256_DIGEST_SIZE) != 0)
+        ERROR_OUT(-2162, exit);
+    } /* END LARGE HASH TEST */
+
+exit:
+
+#ifdef NO_DO178
+    wc_Sha256Free(&sha);
+#endif
+    return ret;
+}
+#endif
+
+#ifdef HAVE_STACK_SIZE
+THREAD_RETURN WOLFSSL_THREAD wolfcrypt_test(void* args)
+#else
+int wolfcrypt_test(void* args)
+#endif
+{
+    int ret;
+
+    if (args)
+        ((func_args*)args)->return_code = -1; /* error state */
+
+#ifndef NO_SHA256
+    if ( (ret = sha256_test()) != 0)
+        return err_sys("SHA-256  test failed!\n", ret);
+    else
+        printf( "SHA-256  test passed!\n");
+#endif
+
+    EXIT_TEST(ret);
+}
+
+int main (void)
+{
+    func_args args;
+
+    #ifdef HAVE_STACK_SIZE
+        StackSizeCheck(&args, wolfcrypt_test);
+    #else
+        wolfcrypt_test(&args);
+    #endif
+
+    return 0;
+}
+

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -113,6 +113,18 @@ enum {
     WC_SHA256_PAD_SIZE     = 56
 };
 
+#ifdef HAVE_DO178
+typedef struct wc_Sha256 {
+    /* alignment on digest and buffer speeds up ARMv8 crypto operations */
+    ALIGN16 word32  digest[WC_SHA256_DIGEST_SIZE / sizeof(word32)];
+    ALIGN16 word32  buffer[WC_SHA256_BLOCK_SIZE  / sizeof(word32)];
+    word32  buffLen;   /* in bytes          */
+    word32  loLen;     /* length in bytes   */
+    word32  hiLen;     /* length in bytes   */
+    void*   heap;
+} wc_Sha256;
+
+#else
 
 #ifdef WOLFSSL_TI_HASH
     #include "wolfssl/wolfcrypt/port/ti/ti-hash.h"
@@ -165,8 +177,18 @@ typedef struct wc_Sha256 {
 } wc_Sha256;
 
 #endif
-
+#endif  /* !HAVE_DO178 */
 #endif /* HAVE_FIPS */
+
+#ifdef HAVE_DO178
+WOLFSSL_API int wc_InitSha256(wc_Sha256*);
+WOLFSSL_API int wc_InitSha256_ex(wc_Sha256*, void*, int);
+WOLFSSL_API int wc_Sha256Update(wc_Sha256*, const byte*, word32);
+WOLFSSL_API int wc_Sha256Final(wc_Sha256*, byte*);
+WOLFSSL_API int wc_Sha256GetHash(wc_Sha256*, byte*);
+WOLFSSL_API int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst);
+
+#else
 
 WOLFSSL_API int wc_InitSha256(wc_Sha256*);
 WOLFSSL_API int wc_InitSha256_ex(wc_Sha256*, void*, int);
@@ -217,6 +239,7 @@ WOLFSSL_API int wc_Sha224GetHash(wc_Sha224*, byte*);
 WOLFSSL_API int wc_Sha224Copy(wc_Sha224* src, wc_Sha224* dst);
 
 #endif /* WOLFSSL_SHA224 */
+#endif /*  !HAVE_DO178 */
 
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
- created cert subset file derived from sha256.c
- added build and test support for DO-178
- sha256_cert test code
- refactored code

Added ./configure --enable-do178 option to allow building DO-178 and non-DO-178 code from the same source tree. Introduced HAVE_DO178 and NO_DO178 AM_CFLAGS. The default is disabled. 

To build and run the supported DO178 tests, you would do:
./configure --enable-do178 && make && ./wolfcrypt/test/testwolfcrypt

