### PR TITLE
Fixes for handling 6144 and 8192 bit with TLS v1.3

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -9646,6 +9646,7 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte msgType,
 #ifdef WOLFSSL_TLS13
                 if (IsAtLeastTLSv1_3(ssl->ctx->method->version) &&
                         msgType != client_hello &&
+                        msgType != server_hello &&
                         msgType != encrypted_extensions) {
                     return EXT_NOT_ALLOWED;
                 }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1160,8 +1160,9 @@ enum Misc {
     HELLO_EXT_EXTMS = 0x0017,   /* ID for the extended master secret ext */
     SECRET_LEN      = WOLFSSL_MAX_MASTER_KEY_LENGTH,
                                 /* pre RSA and all master */
-#if defined(WOLFSSL_MYSQL_COMPATIBLE)
-    ENCRYPT_LEN     = 1024,     /* allow larger static buffer with mysql */
+#if defined(WOLFSSL_MYSQL_COMPATIBLE) || \
+    (defined(USE_FAST_MATH) && defined(FP_MAX_BITS) && FP_MAX_BITS > 8192)
+    ENCRYPT_LEN     = 1024,     /* allow 8192 bit static buffer */
 #else
     ENCRYPT_LEN     = 512,      /* allow 4096 bit static buffer */
 #endif


### PR DESCRIPTION
* Fix to detect larger key size requirement based on `FP_MAX_BITS`. ZD 4754
* Disallow SupportedGroups in ServerHello for TLS 1.3.

Use of this requires `./configure CFLAGS="-DFP_MAX_BITS=16384" and using `WOLFSSL_FFDHE_8192` in `wolfSSL_UseKeyShare` call.