### PR TITLE
fix typo with getting cipher suite : Jenkins Nightly Build test 499

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16132,7 +16132,7 @@ const char* wolfSSL_SESSION_CIPHER_get_name(WOLFSSL_SESSION* session)
     #if !defined(WOLFSSL_CIPHER_INTERNALNAME) && !defined(NO_ERROR_STRINGS)
         return GetCipherNameIana(session->cipherSuite0, session->cipherSuite);
     #else
-        return GetCipherNameInternal(ession->cipherSuite0, session->cipherSuite);
+        return GetCipherNameInternal(session->cipherSuite0, session->cipherSuite);
     #endif
 #else
     return NULL;


### PR DESCRIPTION
Jenkins Nightly Build test 499

```
./configure C_EXTRA_FLAGS="-fdebug-types-section -g1" --enable-jobserver=4 --enable-sessioncerts --disable-errorstrings 
```