### PR TITLE
OCSP and ECDSA Signers

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4237,6 +4237,10 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
     #endif
         XMEMCPY(signer->subjectNameHash, cert->subjectHash,
                 SIGNER_DIGEST_SIZE);
+    #ifdef HAVE_OCSP
+        XMEMCPY(signer->subjectKeyHash, cert->subjectKeyHash,
+                KEYID_SIZE);
+    #endif
         signer->keyUsage = cert->extKeyUsageSet ? cert->extKeyUsage
                                                 : 0xFFFF;
         signer->next    = NULL; /* If Key Usage not set, all uses valid. */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -696,6 +696,7 @@ struct DecodedCert {
     byte    subjectHash[KEYID_SIZE]; /* hash of all Names                */
     byte    issuerHash[KEYID_SIZE];  /* hash of all Names                */
 #ifdef HAVE_OCSP
+    byte    subjectKeyHash[KEYID_SIZE]; /* hash of the public Key         */
     byte    issuerKeyHash[KEYID_SIZE]; /* hash of the public Key         */
 #endif /* HAVE_OCSP */
     const byte* signature;           /* not owned, points into raw cert  */
@@ -873,6 +874,9 @@ struct Signer {
     #ifndef NO_SKID
         byte    subjectKeyIdHash[SIGNER_DIGEST_SIZE];
                                      /* sha hash of names in certificate */
+    #endif
+    #ifdef HAVE_OCSP
+        byte subjectKeyHash[KEYID_SIZE];
     #endif
 #ifdef WOLFSSL_SIGNER_DER_CERT
     DerBuffer* derCert;


### PR DESCRIPTION
OCSP uses an identified hash of the issuer's public key to identify the certificate's signer. (Typically this is SHA-1, but can be any SHA hash.) The AKID/SKID for the certificates usually are the SHA-1 hash of the public key, but may be anything. We cannot depend on the AKID for OCSP purposes. For OCSP lookups, wolfSSL calculates the hash of the public key based on the copy saved for use with the handshake signing. For RSA, that was fine. For ECDSA, we use the whole public key including the curve ID, but for OCSP the curve ID isn't hashed. Stored the hash of the public key at the point where we are looking at the key when reading in the certificate, and saving the hash in the signer record.