### PR TITLE
Fix to detect maximum DH key size

### DIFF
--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1110,7 +1110,11 @@ enum {
 #define MIN_DHKEY_SZ (WOLFSSL_MIN_DHKEY_BITS / 8)
 /* set maximum DH key size allowed */
 #ifndef WOLFSSL_MAX_DHKEY_BITS
-    #define WOLFSSL_MAX_DHKEY_BITS 4096
+    #if (defined(USE_FAST_MATH) && defined(FP_MAX_BITS) && FP_MAX_BITS >= 16384)
+        #define WOLFSSL_MAX_DHKEY_BITS 8192
+    #else
+        #define WOLFSSL_MAX_DHKEY_BITS 4096
+    #endif
 #endif
 #if (WOLFSSL_MAX_DHKEY_BITS % 8)
     #error DH maximum bit size must be multiple of 8


### PR DESCRIPTION
Fix to increase maximum DH key size if using fast math and `FP_MAX_BITS` supports it. ZD 4754