### PR TITLE
Changes for CMS signedData default signed attributes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -21933,8 +21933,18 @@ static void test_wolfssl_PKCS7(void)
     AssertNotNull(pkcs7 = d2i_PKCS7(NULL, &p, len));
     AssertIntEQ(wolfSSL_PKCS7_verify(NULL, NULL, NULL, NULL, NULL,
                                               PKCS7_NOVERIFY), WOLFSSL_FAILURE);
+    PKCS7_free(pkcs7);
+
+    /* fail case, without PKCS7_NOVERIFY */
+    p = data;
+    AssertNotNull(pkcs7 = d2i_PKCS7(NULL, &p, len));
     AssertIntEQ(wolfSSL_PKCS7_verify(pkcs7, NULL, NULL, NULL, NULL,
                                                            0), WOLFSSL_FAILURE);
+    PKCS7_free(pkcs7);
+
+    /* success case, with PKCS7_NOVERIFY */
+    p = data;
+    AssertNotNull(pkcs7 = d2i_PKCS7(NULL, &p, len));
     AssertIntEQ(wolfSSL_PKCS7_verify(pkcs7, NULL, NULL, NULL, NULL,
                                               PKCS7_NOVERIFY), WOLFSSL_SUCCESS);
 

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1458,6 +1458,7 @@ static int wc_PKCS7_BuildSignedAttributes(PKCS7* pkcs7, ESD* esd,
     int timeSz;
     PKCS7Attrib cannedAttribs[3];
 #endif
+    word32 idx = 0;
     word32 cannedAttribsCount;
 
     if (pkcs7 == NULL || esd == NULL || contentType == NULL ||
@@ -1483,20 +1484,22 @@ static int wc_PKCS7_BuildSignedAttributes(PKCS7* pkcs7, ESD* esd,
 
         cannedAttribsCount = sizeof(cannedAttribs)/sizeof(PKCS7Attrib);
 
-        cannedAttribs[0].oid     = contentTypeOid;
-        cannedAttribs[0].oidSz   = contentTypeOidSz;
-        cannedAttribs[0].value   = contentType;
-        cannedAttribs[0].valueSz = contentTypeSz;
-        cannedAttribs[1].oid     = messageDigestOid;
-        cannedAttribs[1].oidSz   = messageDigestOidSz;
-        cannedAttribs[1].value   = esd->contentDigest;
-        cannedAttribs[1].valueSz = hashSz + 2;  /* ASN.1 heading */
+        cannedAttribs[idx].oid     = contentTypeOid;
+        cannedAttribs[idx].oidSz   = contentTypeOidSz;
+        cannedAttribs[idx].value   = contentType;
+        cannedAttribs[idx].valueSz = contentTypeSz;
+        idx++;
     #ifndef NO_ASN_TIME
-        cannedAttribs[2].oid     = signingTimeOid;
-        cannedAttribs[2].oidSz   = signingTimeOidSz;
-        cannedAttribs[2].value   = signingTime;
-        cannedAttribs[2].valueSz = timeSz;
+        cannedAttribs[idx].oid     = signingTimeOid;
+        cannedAttribs[idx].oidSz   = signingTimeOidSz;
+        cannedAttribs[idx].value   = signingTime;
+        cannedAttribs[idx].valueSz = timeSz;
+        idx++;
     #endif
+        cannedAttribs[idx].oid     = messageDigestOid;
+        cannedAttribs[idx].oidSz   = messageDigestOidSz;
+        cannedAttribs[idx].value   = esd->contentDigest;
+        cannedAttribs[idx].valueSz = hashSz + 2;  /* ASN.1 heading */
 
         esd->signedAttribsCount += cannedAttribsCount;
         esd->signedAttribsSz += EncodeAttributes(&esd->signedAttribs[0], 3,

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -284,6 +284,8 @@ struct PKCS7 {
 #endif
     word32 state;
 
+    word16 skipDefaultSignedAttribs:1; /* skip adding default signed attribs */
+
     /* !! NEW DATA MEMBERS MUST BE ADDED AT END !! */
 };
 
@@ -310,6 +312,7 @@ WOLFSSL_API int  wc_PKCS7_EncodeData(PKCS7* pkcs7, byte* output,
 
 /* CMS/PKCS#7 SignedData */
 WOLFSSL_API int  wc_PKCS7_SetDetached(PKCS7* pkcs7, word16 flag);
+WOLFSSL_API int  wc_PKCS7_NoDefaultSignedAttribs(PKCS7* pkcs7);
 WOLFSSL_API int  wc_PKCS7_EncodeSignedData(PKCS7* pkcs7,
                                           byte* output, word32 outputSz);
 WOLFSSL_API int  wc_PKCS7_EncodeSignedData_ex(PKCS7* pkcs7, const byte* hashBuf, 


### PR DESCRIPTION
This PR makes a few changes to how the PKCS#7/CMS default signed attributes in SignedData bundle creation are treated, including:

- Default signed attributes (messageDigest, signingTime, contentType) are always included unless explicitly disabled with wc_PKCS7_NoDefaultSignedAttribs()
- Default signed attribute order has been re-arranged to match that of OpenSSL, for better compatibility
