### PR TITLE
Disable MP_64BIT when compiling with clang-cl on Windows.

### DIFF
--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -85,7 +85,7 @@ extern "C" {
 
 
 /* detect 64-bit mode if possible */
-#if defined(__x86_64__)
+#if defined(__x86_64__) && !(defined (_MSC_VER) && defined(__clang__))
    #if !(defined(MP_64BIT) && defined(MP_16BIT) && defined(MP_8BIT))
       #define MP_64BIT
    #endif


### PR DESCRIPTION
__attribute__ ((mode(TI))) does not really work on clang-cl,
linking would fail with "unresolved external symbol __udivti3",
as reported in https://bugs.llvm.org/show_bug.cgi?id=25305

Fix to use default case with 28bit digits on clang-Windows.