### PR TITLE
Adds strict checking of the ECDSA signature DER encoding length

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -13275,9 +13275,17 @@ int DecodeECC_DSA_Sig(const byte* sig, word32 sigLen, mp_int* r, mp_int* s)
         return ASN_ECC_KEY_E;
     }
 
+#ifndef NO_STRICT_ECDSA_LEN
+    /* enable strict length checking for signature */
+    if (sigLen != idx + (word32)len) {
+        return ASN_ECC_KEY_E;
+    }
+#else
+    /* allow extra signature bytes at end */
     if ((word32)len > (sigLen - idx)) {
         return ASN_ECC_KEY_E;
     }
+#endif
 
     if (GetInt(r, sig, &idx, sigLen) < 0) {
         return ASN_ECC_KEY_E;


### PR DESCRIPTION
With this change the total signature size should be (sequence + r int + s int) as ASN.1 encoded. While I could not find any "must" rules for the signature length I do think this is a good change.

If the old length checking method is desired `NO_STRICT_ECDSA_LEN` can be used. This would allow extra signature byes at the end (unused and not altering verification result). This is kept for possible backwards compatibility.

Per RFC6979: `How a signature is to be encoded is not covered by the DSA and ECDSA standards themselves; a common way is to use a DER-encoded ASN.1 structure (a SEQUENCE of two INTEGERs, for r and s, in that order).`

ANSI X9.62: ASN.1 Encoding of ECDSA:

```
ECDSA-Sig-Value ::= SEQUENCE {
  r INTEGER,
  s INTEGER
}
```

Fixes #2088