### PR TITLE
Support FFDHE in TLS 1.2 and below. Better TLS 1.3 version support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,7 +193,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_AES_DECRYPT -DHAVE_AES_ECB -DWOLFSSL_ALT_NAMES -DWOLFSSL_DER_LOAD -DKEEP_OUR_CERT -DKEEP_PEER_CERT -DHAVE_CRL_IO -DHAVE_IO_TIMEOUT"
 
     # Enable DH const table speedups (eliminates `-lm` math lib dependency)
-    AM_CFLAGS="$AM_CFLAGS -DHAVE_FFDHE_2048 -DHAVE_FFDHE_3072 -DHAVE_FFDHE_4096 -DHAVE_FFDHE_6144 -DHAVE_FFDHE_8192"
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_FFDHE_2048 -DHAVE_FFDHE_3072 -DFP_MAX_BITS=6144"
 fi
 AM_CONDITIONAL([BUILD_ALL], [test "x$ENABLED_ALL" = "xyes"])
 
@@ -1908,11 +1908,6 @@ else
     fi
 fi
 
-if test "$ENABLED_TLS13" = "yes" && test "$ENABLED_DH" = "yes"
-then
-    AM_CFLAGS="-DHAVE_FFDHE_2048 $AM_CFLAGS"
-fi
-
 AM_CONDITIONAL([BUILD_DH], [test "x$ENABLED_DH" = "xyes"])
 
 
@@ -2919,6 +2914,35 @@ then
     AS_IF([test "x$ENABLED_ECC" = "xno" && test "x$ENABLED_CURVE25519" = "xno"],
           [ENABLED_SUPPORTED_CURVES=no],
           [AM_CFLAGS="$AM_CFLAGS -DHAVE_TLS_EXTENSIONS -DHAVE_SUPPORTED_CURVES"])
+fi
+
+# Diffie-Hellman
+if test "$ENABLED_DH" = "yes"
+then
+    if test "$ENABLED_TLS13" = "yes" || test "$ENABLED_SUPPORTED_CURVES" = "yes"
+    then
+        AM_CFLAGS="-DHAVE_FFDHE_2048 $AM_CFLAGS"
+    fi
+fi
+
+# FFDHE parameters only
+AC_ARG_ENABLE([ffdhe-only],
+    [AS_HELP_STRING([--enable-ffdhe-only],[Enable using only FFDHE in client (default: disabled)])],
+    [ ENABLED_FFDHE_ONLY=$enableval ],
+    [ ENABLED_FFDHE_ONLY=no ]
+    )
+
+if test "x$ENABLED_FFDHE_ONLY" = "xyes"
+then
+    if test "$ENABLED_DH" = "no"
+    then
+        AC_MSG_ERROR([FFDHE only support requires DH support])
+    fi
+    if test "$ENABLED_SUPPORTED_CURVES" = "no"
+    then
+        AC_MSG_ERROR([FFDHE only support requires Supported Curves extension])
+    fi
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_REQUIRE_FFDHE"
 fi
 
 # Session Ticket Extension
@@ -4904,6 +4928,7 @@ echo "   * ALPN:                       $ENABLED_ALPN"
 echo "   * Maximum Fragment Length:    $ENABLED_MAX_FRAGMENT"
 echo "   * Truncated HMAC:             $ENABLED_TRUNCATED_HMAC"
 echo "   * Supported Elliptic Curves:  $ENABLED_SUPPORTED_CURVES"
+echo "   * FFDHE only in client:       $ENABLED_FFDHE_ONLY"
 echo "   * Session Ticket:             $ENABLED_SESSION_TICKET"
 echo "   * Extended Master Secret:     $ENABLED_EXTENDED_MASTER"
 echo "   * Renegotiation Indication:   $ENABLED_RENEGOTIATION_INDICATION"

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1361,9 +1361,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     int   doSTARTTLS    = 0;
     char* starttlsProt = NULL;
     int   useVerifyCb = 0;
-#ifdef HAVE_ECC
     int   useSupCurve = 0;
-#endif
 
 #ifdef WOLFSSL_TRUST_PEER_CERT
     const char* trustCert  = NULL;
@@ -1466,9 +1464,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     (void)useX25519;
     (void)helloRetry;
     (void)onlyKeyShare;
-#ifdef HAVE_ECC
     (void)useSupCurve;
-#endif
     (void)loadCertKeyIntoSSLObj;
 
     StackTrap();
@@ -1617,12 +1613,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                     printf("Verify should fail\n");
                     myVerifyFail = 1;
                 }
-            #ifdef HAVE_ECC
                 else if (XSTRNCMP(myoptarg, "useSupCurve", 11) == 0) {
                     printf("Test use supported curve\n");
                     useSupCurve = 1;
                 }
-            #endif
                 else if (XSTRNCMP(myoptarg, "loadSSL", 7) == 0) {
                     printf("Load cert/key into wolfSSL object\n");
                 #ifndef NO_CERTS
@@ -2395,6 +2389,14 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         #endif
     }
     #endif /* HAVE_ECC */
+    #ifdef HAVE_FFDHE_2048
+    if (useSupCurve) {
+        if (wolfSSL_CTX_UseSupportedCurve(ctx, WOLFSSL_FFDHE_2048)
+                                                           != WOLFSSL_SUCCESS) {
+            err_sys("unable to support FFDHE 2048");
+        }
+    }
+    #endif
 #endif /* HAVE_SUPPORTED_CURVES */
 
 #ifdef WOLFSSL_TLS13

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -3185,6 +3185,11 @@ exit:
     wolfAsync_DevClose(&devId);
 #endif
 
+#if defined(HAVE_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS) \
+                                         && defined(HAVE_STACK_SIZE)
+    wc_ecc_fp_free();  /* free per thread cache */
+#endif
+
     /* There are use cases  when these assignments are not read. To avoid
      * potential confusion those warnings have been handled here.
      */

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2279,8 +2279,8 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 
 exit:
 
-#if defined(NO_MAIN_DRIVER) && defined(HAVE_ECC) && defined(FP_ECC) \
-                            && defined(HAVE_THREAD_LS)
+#if defined(HAVE_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS) \
+                      && (defined(NO_MAIN_DRIVER) || defined(HAVE_STACK_SIZE))
     wc_ecc_fp_free();  /* free per thread cache */
 #endif
 

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -164,6 +164,7 @@ enum wolfSSL_ErrorCodes {
     UNSUPPORTED_EXTENSION        = -429,   /* TLSX not requested by client */
     PRF_MISSING                  = -430,   /* PRF not compiled in */
     DTLS_RETX_OVER_TX            = -431,   /* Retransmit DTLS flight over */
+    DH_PARAMS_NOT_FFDHE_E        = -432,   /* DH params from server not FFDHE */
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* begin negotiation parameter errors */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1167,11 +1167,20 @@ enum Misc {
     HELLO_EXT_EXTMS = 0x0017,   /* ID for the extended master secret ext */
     SECRET_LEN      = WOLFSSL_MAX_MASTER_KEY_LENGTH,
                                 /* pre RSA and all master */
+    MAX_PSK_ID_LEN     = 128,  /* max psk identity/hint supported */
 #if defined(WOLFSSL_MYSQL_COMPATIBLE) || \
     (defined(USE_FAST_MATH) && defined(FP_MAX_BITS) && FP_MAX_BITS > 8192)
+#ifndef NO_PSK
+    ENCRYPT_LEN     = 1024 + MAX_PSK_ID_LEN + 2,   /* 8192 bit static buffer */
+#else
     ENCRYPT_LEN     = 1024,     /* allow 8192 bit static buffer */
+#endif
+#else
+#ifndef NO_PSK
+    ENCRYPT_LEN     = 512 + MAX_PSK_ID_LEN + 2,    /* 4096 bit static buffer */
 #else
     ENCRYPT_LEN     = 512,      /* allow 4096 bit static buffer */
+#endif
 #endif
     SIZEOF_SENDER   =  4,       /* clnt or srvr           */
     FINISHED_SZ     = 36,       /* WC_MD5_DIGEST_SIZE + WC_SHA_DIGEST_SIZE */
@@ -1361,7 +1370,6 @@ enum Misc {
     DTLS_TIMEOUT_MAX        = 64, /* default max timeout for DTLS receive */
     DTLS_TIMEOUT_MULTIPLIER =  2, /* default timeout multiplier for DTLS recv */
 
-    MAX_PSK_ID_LEN     = 128,  /* max psk identity/hint supported */
     NULL_TERM_LEN      =   1,  /* length of null '\0' termination character */
     MAX_PSK_KEY_LEN    =  64,  /* max psk key supported */
     MIN_PSK_ID_LEN     =   6,  /* min length of identities */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2106,6 +2106,8 @@ WOLFSSL_LOCAL int   TLSX_WriteResponse(WOLFSSL *ssl, byte* output, byte msgType,
                                         word16* pOffset);
 #endif
 
+WOLFSSL_LOCAL int   TLSX_ParseVersion(WOLFSSL* ssl, byte* input, word16 length,
+                                      byte msgType, int* found);
 WOLFSSL_LOCAL int   TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length,
                                byte msgType, Suites *suites);
 
@@ -2260,6 +2262,7 @@ WOLFSSL_LOCAL int TLSX_UsePointFormat(TLSX** extensions, byte point,
 WOLFSSL_LOCAL int TLSX_ValidateSupportedCurves(WOLFSSL* ssl, byte first,
                                                                    byte second);
 WOLFSSL_LOCAL int TLSX_SupportedCurve_CheckPriority(WOLFSSL* ssl);
+WOLFSSL_LOCAL int TLSX_SupportedFFDHE_Set(WOLFSSL* ssl);
 #endif
 WOLFSSL_LOCAL int TLSX_SupportedCurve_Preferred(WOLFSSL* ssl,
                                                             int checkSupported);
@@ -3697,8 +3700,10 @@ struct WOLFSSL {
     byte            maxRequest;
     byte            user_set_QSHSchemes;
 #endif
-#ifdef WOLFSSL_TLS13
+#if defined(WOLFSSL_TLS13) || defined(HAVE_FFDHE)
     word16          namedGroup;
+#endif
+#ifdef WOLFSSL_TLS13
     word16          group[WOLFSSL_MAX_GROUP_COUNT];
     byte            numGroups;
 #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2393,7 +2393,6 @@ enum {
     WOLFSSL_ECC_BRAINPOOLP384R1 = 27,
     WOLFSSL_ECC_BRAINPOOLP512R1 = 28,
     WOLFSSL_ECC_X25519    = 29,
-#ifdef WOLFSSL_TLS13
     /* Not implemented. */
     WOLFSSL_ECC_X448      = 30,
 
@@ -2402,7 +2401,6 @@ enum {
     WOLFSSL_FFDHE_4096    = 258,
     WOLFSSL_FFDHE_6144    = 259,
     WOLFSSL_FFDHE_8192    = 260,
-#endif
 };
 
 enum {

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -670,7 +670,7 @@ static WC_INLINE void showPeerEx(WOLFSSL* ssl, int lng_index)
     WOLFSSL_CIPHER* cipher;
     const char** words = client_showpeer_msg[lng_index];
 
-#ifdef HAVE_ECC
+#if defined(HAVE_ECC) || !defined(NO_DH)
     const char *name;
 #endif
 #ifndef NO_DH
@@ -697,12 +697,12 @@ static WC_INLINE void showPeerEx(WOLFSSL* ssl, int lng_index)
 #else
     printf("%s %s\n", words[1], wolfSSL_CIPHER_get_name(cipher));
 #endif
-#ifdef HAVE_ECC
+#if defined(HAVE_ECC) || !defined(NO_DH)
     if ((name = wolfSSL_get_curve_name(ssl)) != NULL)
         printf("%s %s\n", words[2], name);
 #endif
 #ifndef NO_DH
-    if ((bits = wolfSSL_GetDhKey_Sz(ssl)) > 0)
+    else if ((bits = wolfSSL_GetDhKey_Sz(ssl)) > 0)
         printf("%s %d bits\n", words[3], bits);
 #endif
     if (wolfSSL_session_reused(ssl))

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -194,7 +194,13 @@ WOLFSSL_API int wc_Sha512Hash(const byte*, word32, byte*);
 #endif /* WOLFSSL_SHA512 */
 
 enum max_prf {
+#ifdef HAVE_FFDHE_8192
+    MAX_PRF_HALF        = 512, /* Maximum half secret len */
+#elif defined(HAVE_FFDHE_6144)
+    MAX_PRF_HALF        = 384, /* Maximum half secret len */
+#else
     MAX_PRF_HALF        = 256, /* Maximum half secret len */
+#endif
     MAX_PRF_LABSEED     = 128, /* Maximum label + seed len */
     MAX_PRF_DIG         = 224  /* Maximum digest len      */
 };

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -195,11 +195,11 @@ WOLFSSL_API int wc_Sha512Hash(const byte*, word32, byte*);
 
 enum max_prf {
 #ifdef HAVE_FFDHE_8192
-    MAX_PRF_HALF        = 512, /* Maximum half secret len */
+    MAX_PRF_HALF        = 516, /* Maximum half secret len */
 #elif defined(HAVE_FFDHE_6144)
-    MAX_PRF_HALF        = 384, /* Maximum half secret len */
+    MAX_PRF_HALF        = 388, /* Maximum half secret len */
 #else
-    MAX_PRF_HALF        = 256, /* Maximum half secret len */
+    MAX_PRF_HALF        = 260, /* Maximum half secret len */
 #endif
     MAX_PRF_LABSEED     = 128, /* Maximum label + seed len */
     MAX_PRF_DIG         = 224  /* Maximum digest len      */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1808,6 +1808,14 @@ extern void uITRON4_free(void *p) ;
     #define SSL_CTRL_SET_TLSEXT_HOSTNAME
 #endif
 
+#if !defined(NO_DH) && !defined(HAVE_FFDHE)
+    #if defined(HAVE_FFDHE_2048) || defined(HAVE_FFDHE_3072) || \
+            defined(HAVE_FFDHE_4096) || defined(HAVE_FFDHE_6144) || \
+            defined(HAVE_FFDHE_8192)
+        #define HAVE_FFDHE
+    #endif
+#endif
+
 /* both CURVE and ED small math should be enabled */
 #ifdef CURVED25519_SMALL
         #define CURVE25519_SMALL

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1815,6 +1815,29 @@ extern void uITRON4_free(void *p) ;
         #define HAVE_FFDHE
     #endif
 #endif
+#ifdef FP_MAX_BITS
+    #if defined(HAVE_FFDHE_8192) && FP_MAX_BITS < 16384
+        #undef  FP_MAX_BITS
+        #define FP_MAX_BITS     16384
+    #endif
+    #if defined(HAVE_FFDHE_6144) && FP_MAX_BITS < 12288
+        #undef  FP_MAX_BITS
+        #define FP_MAX_BITS     12288
+    #endif
+    #if defined(HAVE_FFDHE_4096) && FP_MAX_BITS < 8192
+        #undef  FP_MAX_BITS
+        #define FP_MAX_BITS     8192
+    #endif
+    #if defined(HAVE_FFDHE_3072) && FP_MAX_BITS < 6144
+        #undef  FP_MAX_BITS
+        #define FP_MAX_BITS     6144
+    #endif
+    #if defined(HAVE_FFDHE_2048) && FP_MAX_BITS < 4096
+        #undef  FP_MAX_BITS
+        #define FP_MAX_BITS     4096
+    #endif
+#endif
+
 
 /* both CURVE and ED small math should be enabled */
 #ifdef CURVED25519_SMALL

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1642,11 +1642,39 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_AEAD_ONLY
 #endif
 
+#if !defined(NO_DH) && !defined(HAVE_FFDHE)
+    #if defined(HAVE_FFDHE_2048) || defined(HAVE_FFDHE_3072) || \
+            defined(HAVE_FFDHE_4096) || defined(HAVE_FFDHE_6144) || \
+            defined(HAVE_FFDHE_8192)
+        #define HAVE_FFDHE
+    #endif
+#endif
+#if defined(HAVE_FFDHE_8192)
+    #define MIN_FFDHE_FP_MAX_BITS 16384
+#elif defined(HAVE_FFDHE_6144)
+    #define MIN_FFDHE_FP_MAX_BITS 12288
+#elif defined(HAVE_FFDHE_4096)
+    #define MIN_FFDHE_FP_MAX_BITS 8192
+#elif defined(HAVE_FFDHE_3072)
+    #define MIN_FFDHE_FP_MAX_BITS 6144
+#elif defined(HAVE_FFDHE_2048)
+    #define MIN_FFDHE_FP_MAX_BITS 4096
+#else
+    #define MIN_FFDHE_FP_MAX_BITS 0
+#endif
+#if defined(HAVE_FFDHE) && defined(FP_MAX_BITS)
+    #if MIN_FFDHE_FP_MAX_BITS > FP_MAX_BITS
+        #error "FFDHE parameters are too large for FP_MAX_BIT as set"
+    #endif
+#endif
+
 /* if desktop type system and fastmath increase default max bits */
 #ifdef WOLFSSL_X86_64_BUILD
-    #ifdef USE_FAST_MATH
-        #ifndef FP_MAX_BITS
+    #if defined(USE_FAST_MATH) && !defined(FP_MAX_BITS)
+        #if MIN_FFDHE_FP_MAX_BITS <= 8192
             #define FP_MAX_BITS 8192
+        #else
+            #define FP_MAX_BITS MIN_FFDHE_FP_MAX_BITS
         #endif
     #endif
 #endif
@@ -1806,36 +1834,6 @@ extern void uITRON4_free(void *p) ;
 
 #if defined(WOLFSSL_NGINX)
     #define SSL_CTRL_SET_TLSEXT_HOSTNAME
-#endif
-
-#if !defined(NO_DH) && !defined(HAVE_FFDHE)
-    #if defined(HAVE_FFDHE_2048) || defined(HAVE_FFDHE_3072) || \
-            defined(HAVE_FFDHE_4096) || defined(HAVE_FFDHE_6144) || \
-            defined(HAVE_FFDHE_8192)
-        #define HAVE_FFDHE
-    #endif
-#endif
-#ifdef FP_MAX_BITS
-    #if defined(HAVE_FFDHE_8192) && FP_MAX_BITS < 16384
-        #undef  FP_MAX_BITS
-        #define FP_MAX_BITS     16384
-    #endif
-    #if defined(HAVE_FFDHE_6144) && FP_MAX_BITS < 12288
-        #undef  FP_MAX_BITS
-        #define FP_MAX_BITS     12288
-    #endif
-    #if defined(HAVE_FFDHE_4096) && FP_MAX_BITS < 8192
-        #undef  FP_MAX_BITS
-        #define FP_MAX_BITS     8192
-    #endif
-    #if defined(HAVE_FFDHE_3072) && FP_MAX_BITS < 6144
-        #undef  FP_MAX_BITS
-        #define FP_MAX_BITS     6144
-    #endif
-    #if defined(HAVE_FFDHE_2048) && FP_MAX_BITS < 4096
-        #undef  FP_MAX_BITS
-        #define FP_MAX_BITS     4096
-    #endif
 #endif
 
 


### PR DESCRIPTION
Add support for the fixed FFDHE curves to TLS 1.2. Same curves in TLS
1.3 already. On by default - no checking of prime required.
Add option to require client to see FFDHE parameters from server as per
'may' requirements in RFC 7919.

Change TLS 1.3 ClientHello and ServerHello parsing to find the
SupportedVersions extension first and process it. Then it can handle
other extensions knowing which protocol we are using.