### PR TITLE
Secure Renegotiation

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -2849,7 +2849,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     if (scr && forceScr) {
         if (nonBlocking) {
             printf("not doing secure renegotiation on example with"
-                   " nonblocking yet");
+                   " nonblocking yet\n");
         } else {
             if (!resumeScr) {
                 printf("Beginning secure rengotiation.\n");

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -983,6 +983,11 @@ static const char* client_usage_msg[][59] = {
 #endif
         "-1 <num>    Display a result by specified language.\n"
                                "            0: English, 1: Japanese\n", /* 58 */
+#if !defined(NO_DH) && !defined(HAVE_FIPS) && \
+    !defined(HAVE_SELFTEST) && !defined(WOLFSSL_OLD_PRIME_CHECK)
+        "-2          Disable DH Prime check\n",                         /* 59 */
+#endif
+        "-4          Use resumption for renegotiation\n",               /* 60 */
         NULL,
     },
 #ifndef NO_MULTIBYTE_PRINT
@@ -1134,6 +1139,13 @@ static const char* client_usage_msg[][59] = {
 #endif
         "-1 <num>    指定された言語で結果を表示します。\n"
                                    "            0: 英語、 1: 日本語\n", /* 58 */
+#if !defined(NO_DH) && !defined(HAVE_FIPS) && \
+    !defined(HAVE_SELFTEST) && !defined(WOLFSSL_OLD_PRIME_CHECK)
+        "-2          DHプライム番号チェックを無効にする\n",             /* 59 */
+#endif
+#ifdef HAVE_SECURE_RENEGOTIATION
+        "-4          再交渉に再開を使用\n",                             /* 60 */
+#endif
         NULL,
     },
 #endif
@@ -1208,7 +1220,6 @@ static void Usage(void)
 #ifdef HAVE_SECURE_RENEGOTIATION
     printf("%s", msg[++msgid]); /* -R */
     printf("%s", msg[++msgid]); /* -i */
-    printf("-4          Use resumption for renegotiation\n");
 #endif
     printf("%s", msg[++msgid]); /* -f */
     printf("%s", msg[++msgid]); /* -x */
@@ -1276,14 +1287,17 @@ static void Usage(void)
 #ifdef WOLFSSL_EARLY_DATA
     printf("%s", msg[++msgid]); /* -0 */
 #endif
-#if !defined(NO_DH) && !defined(HAVE_FIPS) && \
-    !defined(HAVE_SELFTEST) && !defined(WOLFSSL_OLD_PRIME_CHECK)
-    printf("-2          Disable DH Prime check\n");
-#endif
 #ifdef WOLFSSL_MULTICAST
     printf("%s", msg[++msgid]); /* -3 */
 #endif
     printf("%s", msg[++msgid]);  /* -1 */
+#if !defined(NO_DH) && !defined(HAVE_FIPS) && \
+    !defined(HAVE_SELFTEST) && !defined(WOLFSSL_OLD_PRIME_CHECK)
+    printf("%s", msg[++msgid]);  /* -2 */
+#endif
+#ifdef HAVE_SECURE_RENEGOTIATION
+    printf("%s", msg[++msgid]);  /* -4 */
+#endif
 }
 
 THREAD_RETURN WOLFSSL_THREAD client_test(void* args)

--- a/src/internal.c
+++ b/src/internal.c
@@ -9571,7 +9571,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         /* compare against previous time */
                         if (XMEMCMP(args->dCert->subjectHash,
                                     ssl->secure_renegotiation->subject_hash,
-                                    WC_SHA_DIGEST_SIZE) != 0) {
+                                    KEYID_SIZE) != 0) {
                             WOLFSSL_MSG(
                                 "Peer sent different cert during scr, fatal");
                             args->fatal = 1;
@@ -9582,7 +9582,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     /* cache peer's hash */
                     if (args->fatal == 0) {
                         XMEMCPY(ssl->secure_renegotiation->subject_hash,
-                                args->dCert->subjectHash, WC_SHA_DIGEST_SIZE);
+                                args->dCert->subjectHash, KEYID_SIZE);
                     }
                 }
             #endif /* HAVE_SECURE_RENEGOTIATION */

--- a/src/internal.c
+++ b/src/internal.c
@@ -9562,30 +9562,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     #endif
                     }
                 }
-
-            #ifdef HAVE_SECURE_RENEGOTIATION
-                if (args->fatal == 0 && ssl->secure_renegotiation
-                               && ssl->secure_renegotiation->enabled) {
-
-                    if (IsEncryptionOn(ssl, 0)) {
-                        /* compare against previous time */
-                        if (XMEMCMP(args->dCert->subjectHash,
-                                    ssl->secure_renegotiation->subject_hash,
-                                    KEYID_SIZE) != 0) {
-                            WOLFSSL_MSG(
-                                "Peer sent different cert during scr, fatal");
-                            args->fatal = 1;
-                            ret = SCR_DIFFERENT_CERT_E;
-                        }
-                    }
-
-                    /* cache peer's hash */
-                    if (args->fatal == 0) {
-                        XMEMCPY(ssl->secure_renegotiation->subject_hash,
-                                args->dCert->subjectHash, KEYID_SIZE);
-                    }
-                }
-            #endif /* HAVE_SECURE_RENEGOTIATION */
             } /* if (count > 0) */
 
             /* Check for error */
@@ -15756,9 +15732,6 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
 
     case SESSION_TICKET_EXPECT_E:
         return "Session Ticket Error";
-
-    case SCR_DIFFERENT_CERT_E:
-        return "Peer sent different cert during SCR";
 
     case SESSION_SECRET_CB_E:
         return "Session Secret Callback Error";

--- a/src/internal.c
+++ b/src/internal.c
@@ -9562,6 +9562,30 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     #endif
                     }
                 }
+
+            #ifdef HAVE_SECURE_RENEGOTIATION
+                if (args->fatal == 0 && ssl->secure_renegotiation
+                               && ssl->secure_renegotiation->enabled) {
+
+                    if (IsEncryptionOn(ssl, 0)) {
+                        /* compare against previous time */
+                        if (XMEMCMP(args->dCert->subjectHash,
+                                    ssl->secure_renegotiation->subject_hash,
+                                    KEYID_SIZE) != 0) {
+                            WOLFSSL_MSG(
+                                "Peer sent different cert during scr, fatal");
+                            args->fatal = 1;
+                            ret = SCR_DIFFERENT_CERT_E;
+                        }
+                    }
+
+                    /* cache peer's hash */
+                    if (args->fatal == 0) {
+                        XMEMCPY(ssl->secure_renegotiation->subject_hash,
+                                args->dCert->subjectHash, KEYID_SIZE);
+                    }
+                }
+            #endif /* HAVE_SECURE_RENEGOTIATION */
             } /* if (count > 0) */
 
             /* Check for error */

--- a/src/internal.c
+++ b/src/internal.c
@@ -23898,6 +23898,14 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             ret = HandleTlsResumption(ssl, bogusID, &clSuites);
             if (ret != 0)
                 return ret;
+
+            #ifdef HAVE_SECURE_RENEGOTIATION
+            if (ssl->secure_renegotiation &&
+                    ssl->secure_renegotiation->enabled &&
+                    IsEncryptionOn(ssl, 0))
+                ssl->secure_renegotiation->startScr = 1;
+            #endif
+
             if (ssl->options.clientState == CLIENT_KEYEXCHANGE_COMPLETE) {
                 WOLFSSL_LEAVE("DoClientHello", ret);
                 WOLFSSL_END(WC_FUNC_CLIENT_HELLO_DO);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2387,7 +2387,7 @@ int wolfSSL_StartSecureRenegotiation(WOLFSSL* ssl, int resume)
 #endif
 
         if (!resume) {
-            XMEMSET(ssl->session.sessionID, 0, ID_LEN);
+            XMEMSET(ssl->session.sessionID, 0, sizeof(ssl->session.sessionID));
             ssl->session.sessionIDSz = 0;
         }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2417,6 +2417,8 @@ int wolfSSL_Rehandshake(WOLFSSL* ssl)
 }
 
 
+#ifndef NO_WOLFSSL_CLIENT
+
 /* do a secure resumption handshake, user forced, we discourage */
 int wolfSSL_SecureResume(WOLFSSL* ssl)
 {
@@ -2424,6 +2426,14 @@ int wolfSSL_SecureResume(WOLFSSL* ssl)
     int ret;
 
     WOLFSSL_ENTER("wolfSSL_SecureResume()");
+
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
+
+    if (ssl->options.side == WOLFSSL_SERVER_END) {
+        ssl->error = SIDE_ERROR;
+        return SSL_FATAL_ERROR;
+    }
 
     session = wolfSSL_get_session(ssl);
     ret = wolfSSL_set_session(ssl, session);
@@ -2433,6 +2443,8 @@ int wolfSSL_SecureResume(WOLFSSL* ssl)
 
     return ret;
 }
+
+#endif /* NO_WOLFSSL_CLIENT */
 
 #endif /* HAVE_SECURE_RENEGOTIATION */
 

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -2378,3 +2378,63 @@
 -c ./certs/client-ecc384-cert.pem
 -k ./certs/client-ecc384-key.pem
 -A ./certs/ca-ecc384-cert.pem
+
+# server TLSv1.2 default with secure renegotiation (renegotiation available)
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+-M
+
+# client TLSv1.2 default with secure renegotiation (client initiated)
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+-i
+
+# server TLSv1.2 default with secure renegotiation (renegotiation available)
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+-M
+
+# client TLSv1.2 default with secure renegotiation (client initiated as resume)
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+-i -4
+
+# server TLSv1.2 default with secure renegotiation (server initiated)
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+-m
+
+# client TLSv1.2 default with secure renegotiation (renegotiation available)
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+-R
+
+# server TLSv1.2 default with secure renegotiation (server initiated)
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+-m
+
+# client TLSv1.2 default with secure renegotiation (renegotiation available as resume)
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+-R -4
+
+# server TLSv1.2 default with secure renegotiation (server initiated)
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+-m
+
+# client TLSv1.2 default with secure renegotiation (client initiated)
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+-i
+
+# server TLSv1.2 default with secure renegotiation (server initiated)
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+-m
+
+# client TLSv1.2 default with secure renegotiation (client initiated as resume)
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+-i -4

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -119,30 +119,26 @@ enum wolfSSL_ErrorCodes {
     SECURE_RENEGOTIATION_E       = -388,   /* Invalid Renegotiation Info */
     SESSION_TICKET_LEN_E         = -389,   /* Session Ticket too large */
     SESSION_TICKET_EXPECT_E      = -390,   /* Session Ticket missing   */
-    SCR_DIFFERENT_CERT_E         = -391,   /* SCR Different cert error  */
+
     SESSION_SECRET_CB_E          = -392,   /* Session secret Cb fcn failure */
     NO_CHANGE_CIPHER_E           = -393,   /* Finished before change cipher */
     SANITY_MSG_E                 = -394,   /* Sanity check on msg order error */
     DUPLICATE_MSG_E              = -395,   /* Duplicate message error */
     SNI_UNSUPPORTED              = -396,   /* SSL 3.0 does not support SNI */
     SOCKET_PEER_CLOSED_E         = -397,   /* Underlying transport closed */
-
     BAD_TICKET_KEY_CB_SZ         = -398,   /* Bad session ticket key cb size */
     BAD_TICKET_MSG_SZ            = -399,   /* Bad session ticket msg size    */
     BAD_TICKET_ENCRYPT           = -400,   /* Bad user ticket encrypt        */
-
     DH_KEY_SIZE_E                = -401,   /* DH Key too small */
     SNI_ABSENT_ERROR             = -402,   /* No SNI request. */
     RSA_SIGN_FAULT               = -403,   /* RSA Sign fault */
     HANDSHAKE_SIZE_ERROR         = -404,   /* Handshake message too large */
-
     UNKNOWN_ALPN_PROTOCOL_NAME_E = -405,   /* Unrecognized protocol name Error*/
     BAD_CERTIFICATE_STATUS_ERROR = -406,   /* Bad certificate status message */
     OCSP_INVALID_STATUS          = -407,   /* Invalid OCSP Status */
     OCSP_WANT_READ               = -408,   /* OCSP callback response WOLFSSL_CBIO_ERR_WANT_READ */
     RSA_KEY_SIZE_E               = -409,   /* RSA key too small */
     ECC_KEY_SIZE_E               = -410,   /* ECC key too small */
-
     DTLS_EXPORT_VER_E            = -411,   /* export version error */
     INPUT_SIZE_E                 = -412,   /* input size too big error */
     CTX_INIT_MUTEX_E             = -413,   /* initialize ctx mutex error */

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -119,7 +119,7 @@ enum wolfSSL_ErrorCodes {
     SECURE_RENEGOTIATION_E       = -388,   /* Invalid Renegotiation Info */
     SESSION_TICKET_LEN_E         = -389,   /* Session Ticket too large */
     SESSION_TICKET_EXPECT_E      = -390,   /* Session Ticket missing   */
-
+    SCR_DIFFERENT_CERT_E         = -391,   /* SCR Different cert error  */
     SESSION_SECRET_CB_E          = -392,   /* Session secret Cb fcn failure */
     NO_CHANGE_CIPHER_E           = -393,   /* Finished before change cipher */
     SANITY_MSG_E                 = -394,   /* Sanity check on msg order error */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2286,6 +2286,7 @@ typedef struct SecureRenegotiation {
    enum key_cache_state cache_status;  /* track key cache state */
    byte                 client_verify_data[TLS_FINISHED_SZ];  /* cached */
    byte                 server_verify_data[TLS_FINISHED_SZ];  /* cached */
+   byte                 subject_hash[KEYID_SIZE];  /* peer cert hash */
    Keys                 tmp_keys;  /* can't overwrite real keys yet */
 } SecureRenegotiation;
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2286,7 +2286,6 @@ typedef struct SecureRenegotiation {
    enum key_cache_state cache_status;  /* track key cache state */
    byte                 client_verify_data[TLS_FINISHED_SZ];  /* cached */
    byte                 server_verify_data[TLS_FINISHED_SZ];  /* cached */
-   byte                 subject_hash[KEYID_SIZE];  /* peer cert hash */
    Keys                 tmp_keys;  /* can't overwrite real keys yet */
 } SecureRenegotiation;
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2286,7 +2286,7 @@ typedef struct SecureRenegotiation {
    enum key_cache_state cache_status;  /* track key cache state */
    byte                 client_verify_data[TLS_FINISHED_SZ];  /* cached */
    byte                 server_verify_data[TLS_FINISHED_SZ];  /* cached */
-   byte                 subject_hash[WC_SHA_DIGEST_SIZE];  /* peer cert hash */
+   byte                 subject_hash[KEYID_SIZE];  /* peer cert hash */
    Keys                 tmp_keys;  /* can't overwrite real keys yet */
 } SecureRenegotiation;
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2433,7 +2433,9 @@ WOLFSSL_API int wolfSSL_NoKeyShares(WOLFSSL* ssl);
 #ifdef HAVE_SECURE_RENEGOTIATION
 
 WOLFSSL_API int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl);
+WOLFSSL_API int wolfSSL_StartSecureRenegotiation(WOLFSSL* ssl, int resume);
 WOLFSSL_API int wolfSSL_Rehandshake(WOLFSSL* ssl);
+WOLFSSL_API int wolfSSL_SecureResume(WOLFSSL* ssl);
 
 #endif
 


### PR DESCRIPTION
1. Split the wolfSSL_Rehandshake() function into wolfSSL_Rehadshake() which performs a full handshake on secure renegotiation and wolfSSL_SecureResume() which performs a session resumption on a secure renegotiation.
2. Add option to example client to perform a secure resumption instead of a full secure handshake.