### PR TITLE
Adds `ECC_PUBLICKEY_TYPE` to the support PEM header types

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8559,6 +8559,7 @@ int wc_PemGetHeaderFooter(int type, const char** header, const char** footer)
             break;
     #endif
         case PUBLICKEY_TYPE:
+        case ECC_PUBLICKEY_TYPE:
             if (header) *header = BEGIN_PUB_KEY;
             if (footer) *footer = END_PUB_KEY;
             ret = 0;


### PR DESCRIPTION
Adds `ECC_PUBLICKEY_TYPE` to the support PEM header types. Fixes #2097.