### PR TITLE
Fix for proper detection of PKCS7 buffer overflow case

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -2068,6 +2068,10 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7, ESD* esd,
             totalSz -= pkcs7->contentSz;
         }
     }
+    else {
+        /* if using single output buffer include content and footer */
+        totalSz += total2Sz;
+    }
 
     if (totalSz > *outputSz) {
         if (pkcs7->signedAttribsSz != 0)


### PR DESCRIPTION
Fix for proper detection of buffer overflow case when calling `wc_PKCS7_EncodeSignedData`.