### PR TITLE
EVP decrypt with padding fix

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -430,6 +430,11 @@ WOLFSSL_API int  wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
             *outl = 0;
             return WOLFSSL_SUCCESS;
         }
+        if ((ctx->bufUsed % ctx->block_size) != 0) {
+            *outl = 0;
+            /* not enough padding for decrypt */
+            return WOLFSSL_FAILURE;
+        }
         if (ctx->lastUsed) {
             PRINT_BUF(ctx->lastBlock, ctx->block_size);
             if ((fl = checkPad(ctx, ctx->lastBlock)) >= 0) {

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -361,9 +361,13 @@ WOLFSSL_API int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
                 XMEMCPY(ctx->lastBlock, &out[ctx->block_size * blocks], ctx->block_size);
                 *outl+= ctx->block_size * blocks;
             } else {
-                ctx->lastUsed = 1;
-                XMEMCPY(ctx->lastBlock, &out[ctx->block_size * (blocks-1)], ctx->block_size);
-                *outl+= ctx->block_size * (blocks-1);
+                if (inl == 0) {
+                    ctx->lastUsed = 1;
+                    blocks = blocks - 1; /* save last block to check padding in
+                                          * EVP_CipherFinal call */
+                }
+                XMEMCPY(ctx->lastBlock, &out[ctx->block_size * blocks], ctx->block_size);
+                *outl+= ctx->block_size * blocks;
             }
         } else {
             *outl+= ctx->block_size * blocks;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13399,32 +13399,44 @@ int openssl_test(void)
         if (EVP_CipherInit(&ctx, EVP_aes_128_cbc(), key, iv, 0) == 0)
             return -7417;
 
-        if (EVP_CipherUpdate(&ctx, plain, &idx, cipher, cipherSz) == 0)
+        /* check partial decrypt (not enough padding for full block) */
+        if (EVP_CipherUpdate(&ctx, plain, &idx, cipher, 1) == 0)
             return -7418;
 
         plainSz = idx;
-        if (EVP_CipherFinal(&ctx, plain + plainSz, &idx) == 0)
+        if (EVP_CipherFinal(&ctx, plain + plainSz, &idx) != 0)
             return -7419;
+
+        EVP_CIPHER_CTX_init(&ctx);
+        if (EVP_CipherInit(&ctx, EVP_aes_128_cbc(), key, iv, 0) == 0)
+            return -7420;
+
+        if (EVP_CipherUpdate(&ctx, plain, &idx, cipher, cipherSz) == 0)
+            return -7421;
+
+        plainSz = idx;
+        if (EVP_CipherFinal(&ctx, plain + plainSz, &idx) == 0)
+            return -7422;
         plainSz += idx;
 
         if ((plainSz != sizeof(msg)) || XMEMCMP(plain, msg, sizeof(msg)))
-            return -7420;
+            return -7423;
 
         EVP_CIPHER_CTX_init(&ctx);
         if (EVP_CipherInit(&ctx, EVP_aes_128_cbc(), key, iv, 1) == 0)
-            return -7421;
+            return -7424;
 
         if (EVP_CipherUpdate(&ctx, cipher, &idx, msg, AES_BLOCK_SIZE) == 0)
-            return -7422;
+            return -7425;
 
         cipherSz = idx;
         if (EVP_CipherFinal(&ctx, cipher + cipherSz, &idx) == 0)
-            return -7423;
+            return -7426;
         cipherSz += idx;
 
         if ((cipherSz != (int)sizeof(verify2)) ||
                                             XMEMCMP(cipher, verify2, cipherSz))
-            return -7424;
+            return -7427;
 
     }  /* end evp_cipher test: EVP_aes_128_cbc*/
 #endif /* WOLFSSL_AES_128 && HAVE_AES_CBC */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -12665,6 +12665,75 @@ static int openssl_aes_test(void)
 
         if (XMEMCMP(plain, cbcPlain, 18))
             return -7315;
+
+        /* test with encrypting/decrypting more than 16 bytes at once */
+        total = 0;
+        EVP_CIPHER_CTX_init(&en);
+        if (EVP_CipherInit(&en, EVP_aes_128_cbc(),
+            (unsigned char*)key, (unsigned char*)iv, 1) == 0)
+            return -7316;
+        if (EVP_CipherUpdate(&en, (byte*)cipher, &outlen,
+                    (byte*)cbcPlain, 17) == 0)
+            return -7317;
+        if (outlen != 16)
+            return -7318;
+        total += outlen;
+
+        if (EVP_CipherUpdate(&en, (byte*)&cipher[total], &outlen,
+                    (byte*)&cbcPlain[17]  , 1) == 0)
+            return -7319;
+        if (outlen != 0)
+            return -7320;
+        total += outlen;
+
+        if (EVP_CipherFinal(&en, (byte*)&cipher[total], &outlen) == 0)
+            return -7321;
+        if (outlen != 16)
+            return -7322;
+        total += outlen;
+        if (total != 32)
+            return -7323;
+
+        total = 0;
+        EVP_CIPHER_CTX_init(&de);
+        if (EVP_CipherInit(&de, EVP_aes_128_cbc(),
+            (unsigned char*)key, (unsigned char*)iv, 0) == 0)
+            return -7324;
+
+        if (EVP_CipherUpdate(&de, (byte*)plain, &outlen, (byte*)cipher, 17) == 0)
+            return -7325;
+        if (outlen != 16)
+            return -7326;
+        total += outlen;
+
+        /* final call on non block size should fail */
+        if (EVP_CipherFinal(&de, (byte*)&plain[total], &outlen) != 0)
+            return -7327;
+
+        if (EVP_CipherUpdate(&de, (byte*)&plain[total], &outlen,
+                    (byte*)&cipher[17], 1) == 0)
+            return -7328;
+        if (outlen != 0)
+        total += outlen;
+
+        if (EVP_CipherUpdate(&de, (byte*)&plain[total], &outlen,
+                    (byte*)&cipher[17+1], 14) == 0)
+            return -7329;
+        if (outlen != 0)
+            return -7330;
+        total += outlen;
+
+        if (EVP_CipherFinal(&de, (byte*)&plain[total], &outlen) == 0)
+            return -7331;
+        if (outlen != 2)
+            return -7332;
+        total += outlen;
+
+        if (total != 18)
+            return -7333;
+
+        if (XMEMCMP(plain, cbcPlain, 18))
+            return -7334;
     }
 
     {  /* evp_cipher test: EVP_aes_128_cbc */
@@ -12690,23 +12759,23 @@ static int openssl_aes_test(void)
 
         EVP_CIPHER_CTX_init(&ctx);
         if (EVP_CipherInit(&ctx, EVP_aes_128_cbc(), key, iv, 1) == 0)
-            return -7316;
+            return -7335;
 
         if (EVP_Cipher(&ctx, cipher, (byte*)msg, 16) == 0)
-            return -7317;
+            return -7336;
 
         if (XMEMCMP(cipher, verify, AES_BLOCK_SIZE))
-            return -7318;
+            return -7337;
 
         EVP_CIPHER_CTX_init(&ctx);
         if (EVP_CipherInit(&ctx, EVP_aes_128_cbc(), key, iv, 0) == 0)
-            return -7319;
+            return -7338;
 
         if (EVP_Cipher(&ctx, plain, cipher, 16) == 0)
-            return -7320;
+            return -7339;
 
         if (XMEMCMP(plain, msg, AES_BLOCK_SIZE))
-            return -7321;
+            return -7340;
 
 
     }  /* end evp_cipher test: EVP_aes_128_cbc*/


### PR DESCRIPTION
Fix to error out if not enough data was added for decryption with EVP_Cipher functions and padding is turned on.

Reported in github issue https://github.com/wolfSSL/wolfssl/issues/2092.