### PR TITLE
Fixes for various nightly build configuration warnings

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -733,7 +733,7 @@ size_t wolfSSL_BIO_ctrl_pending(WOLFSSL_BIO *bio)
     if (bio->type == WOLFSSL_BIO_BIO && bio->pair != NULL) {
         WOLFSSL_BIO* pair = bio->pair;
         if (pair->wrIdx > 0 && pair->wrIdx <= pair->rdIdx) {
-            /* in wrap around state where begining of buffer is being
+            /* in wrap around state where beginning of buffer is being
              * overwritten */
             return pair->wrSz - pair->rdIdx + pair->wrIdx;
         }
@@ -1136,7 +1136,7 @@ int wolfSSL_BIO_seek(WOLFSSL_BIO *bio, int ofs)
           return -1;
       }
 
-      /* offset ofs from begining of file */
+      /* offset ofs from beginning of file */
       if (bio->type == WOLFSSL_BIO_FILE &&
               XFSEEK(bio->file, ofs, SEEK_SET) < 0) {
           return -1;

--- a/src/internal.c
+++ b/src/internal.c
@@ -19993,7 +19993,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                     /* length is used for public key size */
                     args->length = MAX_ENCRYPT_SZ;
 
-                    /* Create shared ECC key leaving room at the begining
+                    /* Create shared ECC key leaving room at the beginning
                        of buffer for size of shared key. */
                     ssl->arrays->preMasterSz = ENCRYPT_LEN - OPAQUE16_LEN;
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3818,7 +3818,7 @@ int wc_RsaPublicKeyDecode_ex(const byte* input, word32* inOutIdx, word32 inSz,
     const byte** n, word32* nSz, const byte** e, word32* eSz)
 {
     int ret = 0;
-    int length;
+    int length = 0;
 #if defined(OPENSSL_EXTRA) || defined(RSA_DECODE_EXTRA)
     byte b;
 #endif
@@ -12369,10 +12369,11 @@ int wc_SetSubjectKeyId(Cert *cert, const char* file)
         WOLFSSL_MSG("wc_SetSubjectKeyId memory Problem");
         return MEMORY_E;
     }
+    derSz = MAX_PUBLIC_KEY_SZ;
 
-    derSz = wc_PemPubKeyToDer(file, der, MAX_PUBLIC_KEY_SZ);
-    if (derSz <= 0)
-    {
+    XMEMSET(der, 0, derSz);
+    derSz = wc_PemPubKeyToDer(file, der, derSz);
+    if (derSz <= 0) {
         XFREE(der, cert->heap, DYNAMIC_TYPE_CERT);
         return derSz;
     }

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -416,7 +416,7 @@ static int GetSignData(WC_PKCS12* pkcs12, const byte* mem, word32* idx,
         ERROR_OUT(ASN_PARSE_E, exit_gsd);
     }
 
-    if ((ret = GetLength(mem, &curIdx, &size, totalSz)) <= 0) {
+    if ((ret = GetLength(mem, &curIdx, &size, totalSz)) < 0) {
         goto exit_gsd;
     }
     mac->saltSz = size;
@@ -1050,7 +1050,7 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                     /* put the new node into the list */
                     if (certList != NULL) {
                         WOLFSSL_MSG("Pushing new cert onto queue");
-                        tailList->next = node;
+                        certList->next = node;
                         tailList = node;
                     }
                     else {
@@ -1108,6 +1108,7 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
         /* free list, not wanted */
         wc_FreeCertList(certList, pkcs12->heap);
     }
+    (void)tailList; /* not used */
 
     ret = 0; /* success */
 

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1050,7 +1050,7 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                     /* put the new node into the list */
                     if (certList != NULL) {
                         WOLFSSL_MSG("Pushing new cert onto queue");
-                        certList->next = node;
+                        tailList->next = node;
                         tailList = node;
                     }
                     else {

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -79,7 +79,7 @@ typedef struct ContentInfo {
     struct ContentInfo* next;
     word32 encC;  /* encryptedContent */
     word32 dataSz;
-    int type; /* DATA / encrypted / envelpoed */
+    int type; /* DATA / encrypted / enveloped */
 } ContentInfo;
 
 
@@ -98,7 +98,7 @@ typedef struct MacData {
     word32 oid;
     word32 digestSz;
     word32 saltSz;
-    int itt; /* number of itterations when creating HMAC key */
+    int itt; /* number of iterations when creating HMAC key */
 } MacData;
 
 
@@ -256,7 +256,7 @@ static int GetSafeContent(WC_PKCS12* pkcs12, const byte* input,
     *idx = localIdx;
 
     /* an instance of AuthenticatedSafe is created from
-     * ContentInfo's strung together in a SEQUENCE. Here we itterate
+     * ContentInfo's strung together in a SEQUENCE. Here we iterate
      * through the ContentInfo's and add them to our
      * AuthenticatedSafe struct */
     localIdx = 0;
@@ -449,7 +449,7 @@ static int GetSignData(WC_PKCS12* pkcs12, const byte* mem, word32* idx,
     }
 
 #ifdef WOLFSSL_DEBUG_PKCS12
-    printf("\t\tITTERATIONS : %d\n", mac->itt);
+    printf("\t\tITERATIONS : %d\n", mac->itt);
 #endif
 
     *idx = curIdx;
@@ -592,7 +592,7 @@ static int wc_PKCS12_verify(WC_PKCS12* pkcs12, byte* data, word32 dataSz,
 
 
 /* Convert DER format stored in der buffer to WC_PKCS12 struct
- * Puts the raw contents of Content Info into structure without completly
+ * Puts the raw contents of Content Info into structure without completely
  * parsing or decoding.
  * der    : pointer to der buffer holding PKCS12
  * derSz  : size of der buffer
@@ -1307,7 +1307,7 @@ static int wc_PKCS12_create_key_bag(WC_PKCS12* pkcs12, WC_RNG* rng,
     XFREE(tmp, heap, DYNAMIC_TYPE_TMP_BUFFER);
     totalSz += length;
 
-    /* set begining sequence */
+    /* set beginning sequence */
     tmpSz = SetSequence(totalSz, out);
     XMEMMOVE(out + tmpSz, out + MAX_SEQ_SZ, totalSz);
 

--- a/wolfcrypt/src/port/arm/armv8-sha256.c
+++ b/wolfcrypt/src/port/arm/armv8-sha256.c
@@ -135,7 +135,7 @@ static WC_INLINE int Sha256Update(wc_Sha256* sha256, const byte* data, word32 le
             "LD1 {v24.4s-v27.4s}, [%[k]], #64    \n"
             "LD1 {v28.4s-v31.4s}, [%[k]], #64    \n"
 
-            /* begining of SHA256 block operation */
+            /* beginning of SHA256 block operation */
             "1:\n"
             /* Round 1 */
             "MOV v4.16b, v0.16b        \n"
@@ -694,7 +694,7 @@ static WC_INLINE int Sha256Update(wc_Sha256* sha256, const byte* data, word32 le
             "VMOV.32 q14, q12 \n" /* store digest for add at the end */
             "VMOV.32 q15, q13 \n"
 
-            /* begining of SHA256 block operation */
+            /* beginning of SHA256 block operation */
             "1:\n"
 
             /* Round 1 */
@@ -916,7 +916,7 @@ static WC_INLINE int Sha256Final(wc_Sha256* sha256, byte* hash)
         "VMOV.32 q14, q12 \n" /* store digest for add at the end */
         "VMOV.32 q15, q13 \n"
 
-        /* begining of SHA256 block operation */
+        /* beginning of SHA256 block operation */
         /* Round 1 */
         "VLD1.32 {q5}, [%[k]]!    \n"
         "VMOV.32 q4, q0           \n"
@@ -1116,7 +1116,7 @@ static WC_INLINE int Sha256Final(wc_Sha256* sha256, byte* hash)
         "VMOV.32 q14, q12 \n" /* store digest for add at the end */
         "VMOV.32 q15, q13 \n"
 
-        /* begining of SHA256 block operation */
+        /* beginning of SHA256 block operation */
         /* Round 1 */
         "VLD1.32 {q5}, [%[k]]!    \n"
         "VMOV.32 q4, q0           \n"

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -349,10 +349,12 @@ int scrypt_test(void);
         int pkcs7authenveloped_test(void);
     #endif
 #endif
-#if !defined(NO_ASN_TIME) && !defined(NO_RSA) && defined(WOLFSSL_TEST_CERT)
+#if !defined(NO_ASN_TIME) && !defined(NO_RSA) && defined(WOLFSSL_TEST_CERT) && \
+    !defined(NO_FILESYSTEM)
 int cert_test(void);
 #endif
-#if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_TEST_CERT)
+#if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_TEST_CERT) && \
+   !defined(NO_FILESYSTEM)
 int  certext_test(void);
 #endif
 #ifdef HAVE_IDEA
@@ -928,14 +930,16 @@ initDefaultName();
     #endif
 #endif
 
-#if !defined(NO_ASN_TIME) && !defined(NO_RSA) && defined(WOLFSSL_TEST_CERT)
+#if !defined(NO_ASN_TIME) && !defined(NO_RSA) && defined(WOLFSSL_TEST_CERT) && \
+    !defined(NO_FILESYSTEM)
     if ( (ret = cert_test()) != 0)
         return err_sys("CERT     test failed!\n", ret);
     else
         printf( "CERT     test passed!\n");
 #endif
 
-#if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_TEST_CERT)
+#if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_TEST_CERT) && \
+   !defined(NO_FILESYSTEM)
     if ( (ret = certext_test()) != 0)
         return err_sys("CERT EXT test failed!\n", ret);
     else
@@ -8830,7 +8834,7 @@ static const CertName certDefaultName = {
 
 #ifndef NO_RSA
 
-#ifdef WOLFSSL_TEST_CERT
+#if defined(WOLFSSL_TEST_CERT) && !defined(NO_FILESYSTEM)
 int cert_test(void)
 {
     DecodedCert cert;
@@ -8884,9 +8888,10 @@ done:
 
     return ret;
 }
-#endif /* WOLFSSL_TEST_CERT */
+#endif /* WOLFSSL_TEST_CERT && !NO_FILESYSTEM */
 
-#if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_TEST_CERT)
+#if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_TEST_CERT) && \
+   !defined(NO_FILESYSTEM)
 int certext_test(void)
 {
     DecodedCert cert;


### PR DESCRIPTION
* Fixes for building with no filesystem and `--enable-testcert` or `WOLFSSL_TEST_CERT`. Fixes nightly expected configurations test.
* Fixes for scan-build warnings with ASN, PKCS12 and PKCS7.
* More spelling fixes.