### PR TITLE
Deos: Corrected a typo in TLS client connect call

### DIFF
--- a/IDE/ECLIPSE/DEOS/tls_wolfssl.c
+++ b/IDE/ECLIPSE/DEOS/tls_wolfssl.c
@@ -166,7 +166,7 @@ void wolfssl_client_test(uintData_t statusPtr) {
     server_addr.sin_port = htons(TCP_SERVER_PORT);
 
     printf("Calling connect on socket\n");
-    if (connect(sock, (sockaddr *) &server_addr, sizeof(server_addr) < 0 )) {
+    if (connect(sock, (sockaddr *) &server_addr, sizeof(server_addr)) < 0 ) {
         printf("ERROR: connect, err = %d\n", errno);
         closesocket(sock);
         return;


### PR DESCRIPTION
Got feedback from Mike @ DDCI to correct a misplaced parenthesis. 

1. He confirmed that the connect call worked successfully on one of their real hardware targets. It still does not work on QEMU because the QEMU target is not on the internet with access to the server IP set in the code.  Everything else works fine. 

2.  The size of the deosWolfssl.zip project was a concern for us. The zip contained duplicate wolfSSL source code and I couldn't get the relative file paths to work in the OpenArbor IDE so I removed the project from out GitHub. 