### PR TITLE
Fixes for data types, cast warnings and shift operations when using 16-bit platform

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -208,6 +208,18 @@ AC_ARG_ENABLE([32bit],
     [ ENABLED_32BIT=no ]
     )
 
+# 16-bit compiler support
+AC_ARG_ENABLE([16bit],
+    [AS_HELP_STRING([--enable-16bit],[Enables 16-bit support (default: disabled)])],
+    [ ENABLED_16BIT=$enableval ],
+    [ ENABLED_16BIT=no ]
+    )
+if test "$ENABLED_16BIT" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWC_16BIT_CPU"
+fi
+
+
 
 # Support for disabling all ASM
 AC_ARG_ENABLE([asm],
@@ -798,11 +810,11 @@ AC_ARG_WITH([cryptoauthlib],
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <cryptoauthlib.h>]], [[ atcab_init(0); ]])],[ libatca_linked=yes ],[ libatca_linked=no ])
 
-        if test "x$libatca_linked" == "xno" ; then
+        if test "x$libatca_linked" = "xno" ; then
             if test "x$withval" != "xno" ; then
                 trylibatcadir=$withval
             fi
-            if test "x$withval" == "xyes" ; then
+            if test "x$withval" = "xyes" ; then
                 trylibatcadir="/usr"
             fi
 
@@ -811,7 +823,7 @@ AC_ARG_WITH([cryptoauthlib],
 
             AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <cryptoauthlib.h>]], [[ atcab_init(0); ]])],[ libatca_linked=yes ],[ libatca_linked=no ])
 
-            if test "x$libatca_linked" == "xno" ; then
+            if test "x$libatca_linked" = "xno" ; then
                 AC_MSG_ERROR([cryptoauthlib isn't found.
                 If it's already installed, specify its path using --with-cryptoauthlib=/dir/])
             fi
@@ -1253,9 +1265,9 @@ AC_ARG_ENABLE([sha512],
     )
 
 # options that don't require sha512
-if test "$ENABLED_LEANPSK" = "yes" || test "$ENABLED_LEANTLS" = "yes"
+if test "$ENABLED_LEANPSK" = "yes" || test "$ENABLED_LEANTLS" = "yes" || test "$ENABLED_32BIT" = "yes" || test "$ENABLED_16BIT" = "yes"
 then
-    ENABLED_SHA512=no
+    ENABLED_SHA512="no"
 fi
 
 # options that require sha512
@@ -1265,7 +1277,7 @@ then
     ENABLED_SHA384="yes"
 fi
 
-if test "$ENABLED_SHA512" = "yes" && test "$ENABLED_32BIT" = "no"
+if test "$ENABLED_SHA512" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA512"
 fi
@@ -1279,10 +1291,10 @@ AC_ARG_ENABLE([sha384],
     [ ENABLED_SHA384=yes ]
     )
 
-# options that don't require sha512
-if test "$ENABLED_LEANPSK" = "yes" || test "$ENABLED_LEANTLS" = "yes"
+# options that don't require sha384
+if test "$ENABLED_LEANPSK" = "yes" || test "$ENABLED_LEANTLS" = "yes" || test "$ENABLED_32BIT" = "yes" || test "$ENABLED_16BIT" = "yes"
 then
-    ENABLED_SHA384=no
+    ENABLED_SHA384="no"
 fi
 
 # options that require sha384
@@ -1290,7 +1302,7 @@ if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_WPAS" = "yes" || test "$ENA
 then
     ENABLED_SHA384="yes"
 fi
-if test "$ENABLED_SHA384" = "yes" && test "$ENABLED_32BIT" = "no"
+if test "$ENABLED_SHA384" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA384"
 fi
@@ -1944,7 +1956,7 @@ AC_ARG_ENABLE([asn],
 if test "$ENABLED_ASN" = "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_CERTS"
-    if test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" == "no"
+    if test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" = "no"
     then
         # DH and ECC need bigint
         AM_CFLAGS="$AM_CFLAGS -DNO_BIG_INT"
@@ -2348,7 +2360,7 @@ AC_ARG_ENABLE([selftest],
     [ ENABLED_SELFTEST=no ]
     )
 
-if test "x$ENABLED_SELFTEST" == "xyes"
+if test "x$ENABLED_SELFTEST" = "xyes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_SELFTEST"
 fi
@@ -2679,7 +2691,7 @@ AC_ARG_WITH([user-crypto],
         if test "x$withval" != "xno" ; then
             trycryptodir=$withval
         fi
-        if test "x$withval" == "xyes" ; then
+        if test "x$withval" = "xyes" ; then
             trycryptodir="/usr/local"
         fi
 
@@ -2689,7 +2701,7 @@ AC_ARG_WITH([user-crypto],
         #Look for RSA Init function in usercrypto lib
         AC_CHECK_LIB([usercrypto], [wc_InitRsaKey], [user_rsa_linked=yes], [user_rsa_linked=no])
 
-       if test "x$user_rsa_linked" == "xyes" ; then
+       if test "x$user_rsa_linked" = "xyes" ; then
             AC_MSG_NOTICE([User user_rsa.h being used])
             AM_CFLAGS="$AM_CFLAGS -DHAVE_USER_RSA"
             ENABLED_USER_RSA=yes
@@ -2699,7 +2711,7 @@ AC_ARG_WITH([user-crypto],
 
         #Display check and find result of link attempts
         AC_MSG_CHECKING([for USER_CRYPTO])
-        if test "x$ENABLED_USER_CRYPTO" == "xno" ; then
+        if test "x$ENABLED_USER_CRYPTO" = "xno" ; then
             AC_MSG_RESULT([no])
             AC_MSG_ERROR([USER_CRYPTO not found. Either move to /usr/include and /usr/lib or
                     Specify its path using --with-user-crypto=/dir/])
@@ -2713,7 +2725,7 @@ AC_ARG_WITH([user-crypto],
     ]
 )
 
-AM_CONDITIONAL([BUILD_USER_RSA], [test "x$ENABLED_USER_RSA" == "xyes"] )
+AM_CONDITIONAL([BUILD_USER_RSA], [test "x$ENABLED_USER_RSA" = "xyes"] )
 AM_CONDITIONAL([BUILD_USER_CRYPTO], [test "x$ENABLED_USER_CRYPTO" = "xyes"])
 
 if test "$ENABLED_USER_CRYPTO" = "yes" && test "$ENABLED_FIPS" = "yes"
@@ -2734,11 +2746,11 @@ AC_ARG_WITH([ntru],
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <libntruencrypt/ntru_crypto_drbg.h>]], [[ ntru_crypto_drbg_instantiate(0, 0, 0, 0, 0); ]])], [ ntru_linked=yes ],[ ntru_linked=no ])
 
-        if test "x$ntru_linked" == "xno" ; then
+        if test "x$ntru_linked" = "xno" ; then
             if test "x$withval" != "xno" ; then
                 tryntrudir=$withval
             fi
-            if test "x$withval" == "xyes" ; then
+            if test "x$withval" = "xyes" ; then
                 tryntrudir="/usr"
             fi
 
@@ -2747,7 +2759,7 @@ AC_ARG_WITH([ntru],
 
             AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <libntruencrypt/ntru_crypto_drbg.h>]], [[ ntru_crypto_drbg_instantiate(0, 0, 0, 0, 0); ]])], [ ntru_linked=yes ],[ ntru_linked=no ])
 
-            if test "x$ntru_linked" == "xno" ; then
+            if test "x$ntru_linked" = "xno" ; then
                 AC_MSG_ERROR([NTRU isn't found.
                 If it's already installed, specify its path using --with-ntru=/dir/])
             fi
@@ -2795,11 +2807,11 @@ AC_ARG_WITH([wnr],
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <wnr.h>]], [[ wnr_setup(0, 0); ]])], [ wnr_linked=yes ],[ wnr_linked=no ])
 
-        if test "x$wnr_linked" == "xno" ; then
+        if test "x$wnr_linked" = "xno" ; then
             if test "x$withval" != "xno" ; then
                 trywnrdir=$withval
             fi
-            if test "x$withval" == "xyes" ; then
+            if test "x$withval" = "xyes" ; then
                 trywnrdir="/usr/local"
             fi
 
@@ -2808,7 +2820,7 @@ AC_ARG_WITH([wnr],
 
             AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <wnr.h>]], [[ wnr_setup(0, 0); ]])], [ wnr_linked=yes ],[ wnr_linked=no ])
 
-            if test "x$wnr_linked" == "xno" ; then
+            if test "x$wnr_linked" = "xno" ; then
                 AC_MSG_ERROR([Whitewood netRandom isn't found.
                 If it's already installed, specify its path using --with-wnr=/dir/])
             fi
@@ -3681,11 +3693,11 @@ AC_ARG_WITH([libz],
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <zlib.h>]], [[ deflateInit(0, 8); ]])],[ libz_linked=yes ],[ libz_linked=no ])
 
-        if test "x$libz_linked" == "xno" ; then
+        if test "x$libz_linked" = "xno" ; then
             if test "x$withval" != "xno" ; then
                 trylibzdir=$withval
             fi
-            if test "x$withval" == "xyes" ; then
+            if test "x$withval" = "xyes" ; then
                 trylibzdir="/usr"
             fi
 
@@ -3694,7 +3706,7 @@ AC_ARG_WITH([libz],
 
             AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <zlib.h>]], [[ deflateInit(0, 8); ]])],[ libz_linked=yes ],[ libz_linked=no ])
 
-            if test "x$libz_linked" == "xno" ; then
+            if test "x$libz_linked" = "xno" ; then
                 AC_MSG_ERROR([libz isn't found.
                 If it's already installed, specify its path using --with-libz=/dir/])
             fi
@@ -3732,7 +3744,7 @@ AC_ARG_WITH([cavium],
         CPPFLAGS="$CPPFLAGS -DHAVE_CAVIUM"
         LIB_ADD="-lrt $LIB_ADD"
 
-        if test "x$withval" == "xyes" ; then
+        if test "x$withval" = "xyes" ; then
             AC_MSG_ERROR([need a PATH for --with-cavium])
         fi
         if test "x$withval" != "xno" ; then
@@ -3744,7 +3756,7 @@ AC_ARG_WITH([cavium],
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cavium_common.h"]], [[ CspShutdown(CAVIUM_DEV_ID); ]])],[ cavium_linked=yes ],[ cavium_linked=no ])
 
-        if test "x$cavium_linked" == "xno" ; then
+        if test "x$cavium_linked" = "xno" ; then
             AC_MSG_ERROR([cavium isn't found.
             If it's already installed, specify its path using --with-cavium=/dir/])
         else
@@ -3767,7 +3779,7 @@ AC_ARG_WITH([cavium-v],
         AM_CFLAGS="$AM_CFLAGS -DHAVE_CAVIUM -DHAVE_CAVIUM_V"
         LIB_ADD="-lrt -lcrypto $LIB_ADD"
 
-        if test "x$withval" == "xyes" ; then
+        if test "x$withval" = "xyes" ; then
             AC_MSG_ERROR([need a PATH for --with-cavium])
         fi
         if test "x$withval" != "xno" ; then
@@ -3808,7 +3820,7 @@ AC_ARG_WITH([intelqa],
         CPPFLAGS="$CPPFLAGS -DHAVE_INTEL_QA -DDO_CRYPTO -DUSER_SPACE"
         OLD_LIBS="$LIBS"
 
-        if test "x$withval" == "xyes" ; then
+        if test "x$withval" = "xyes" ; then
             AC_MSG_ERROR([need a PATH for --with-intelqa])
         fi
         if test "x$withval" != "xno" ; then
@@ -3825,13 +3837,13 @@ AC_ARG_WITH([intelqa],
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cpa_cy_common.h"]], [[ Cpa16U count = 0; cpaCyGetNumInstances(&count); ]])],
             [ intelqa_linked=yes ],[ intelqa_linked=no ])
-        if test "x$intelqa_linked" == "xno" ; then
+        if test "x$intelqa_linked" = "xno" ; then
             # Try old QAT driver libraries
             LIBS="$OLD_LIBS -licp_qa_al_s"
 
             AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cpa_cy_common.h"]], [[ Cpa16U count = 0; cpaCyGetNumInstances(&count); ]])],
                 [ intelqa_linked=yes ],[ intelqa_linked=no ])
-            if test "x$intelqa_linked" == "xno" ; then
+            if test "x$intelqa_linked" = "xno" ; then
                 AC_MSG_ERROR([Intel QuickAssist not found.
                 If it's already installed, specify its path using --with-intelqa=/dir/])
             else

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -896,7 +896,7 @@ WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_file(WOLFSSL_CTX*, const char*, int);
     as NULL if not needed.  If path is specified and NO_WOLFSSL_DIR was not
     defined when building the library, wolfSSL will load all CA certificates
     located in the given directory. This function will attempt to load all
-    files in the directory. This function expects PEM formatted CERT_TYPE 
+    files in the directory. This function expects PEM formatted CERT_TYPE
     file with header “-----BEGIN CERTIFICATE-----”.
 
     \return SSL_SUCCESS up success.
@@ -962,7 +962,7 @@ WOLFSSL_API int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX*, const char*,
     as NULL if not needed.  If path is specified and NO_WOLFSSL_DIR was not
     defined when building the library, wolfSSL will load all CA certificates
     located in the given directory. This function will attempt to load all
-    files in the directory based on flags specified. This function expects PEM 
+    files in the directory based on flags specified. This function expects PEM
     formatted CERT_TYPE files with header “-----BEGIN CERTIFICATE-----”.
 
     \return SSL_SUCCESS up success.
@@ -983,7 +983,7 @@ WOLFSSL_API int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX*, const char*,
     certificates.
     \param path pointer to the name of a directory to load PEM-formatted
     certificates from.
-    \param flags possible mask values are: WOLFSSL_LOAD_FLAG_IGNORE_ERR, 
+    \param flags possible mask values are: WOLFSSL_LOAD_FLAG_IGNORE_ERR,
     WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY and WOLFSSL_LOAD_FLAG_PEM_CA_ONLY
 
     _Example_
@@ -991,7 +991,7 @@ WOLFSSL_API int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX*, const char*,
     int ret = 0;
     WOLFSSL_CTX* ctx;
     ...
-    ret = wolfSSL_CTX_load_verify_locations_ex(ctx, NUULL, “./certs/external", 
+    ret = wolfSSL_CTX_load_verify_locations_ex(ctx, NUULL, “./certs/external",
         WOLFSSL_LOAD_FLAG_PEM_CA_ONLY);
     if (ret != WOLFSSL_SUCCESS) {
         // error loading CA certs
@@ -2781,7 +2781,7 @@ WOLFSSL_API int  wolfSSL_set_session_secret_cb(WOLFSSL*, SessionSecretCb, void*)
     \code
     const char* fname;
     ...
-    if(wolfSSL_save_session_cache(fname) != SSL_SUCCESS){	
+    if(wolfSSL_save_session_cache(fname) != SSL_SUCCESS){
     	// Fail to write to file.
     }
     \endcode
@@ -5133,7 +5133,7 @@ WOLFSSL_API void wolfSSL_set_psk_server_callback(WOLFSSL*,
 	    wolfSSL_CTX_allow_anon_cipher(ctx);
 	    if(wolfSSL_CTX_set_cipher_list(ctx, “ADH_AES128_SHA”) != SSL_SUCCESS){
 		    // failure case
-	    }	
+	    }
     }
     #endif
     \endcode
@@ -5418,7 +5418,7 @@ WOLFSSL_API const char* wolfSSL_lib_version(void);
 
     \sa wolfSSL_lib_version
 */
-WOLFSSL_API unsigned int wolfSSL_lib_version_hex(void);
+WOLFSSL_API word32 wolfSSL_lib_version_hex(void);
 
 /*!
     \ingroup IO
@@ -6479,7 +6479,7 @@ WOLFSSL_API int  wolfSSL_CTX_SetTmpDH_file(WOLFSSL_CTX*, const char* f,
     \sa wolfSSL_GetDhKey_Sz
     \sa wolfSSL_CTX_SetTMpDH_file
 */
-WOLFSSL_API int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX*, unsigned short);
+WOLFSSL_API int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX*, word16);
 
 /*!
     \ingroup CertsKeys
@@ -6507,7 +6507,7 @@ WOLFSSL_API int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX*, unsigned short);
     \sa wolfSSL_CTX_SetMinDhKey_Sz
     \sa wolfSSL_GetDhKey_Sz
 */
-WOLFSSL_API int wolfSSL_SetMinDhKey_Sz(WOLFSSL*, unsigned short);
+WOLFSSL_API int wolfSSL_SetMinDhKey_Sz(WOLFSSL*, word16);
 
 /*!
     \ingroup CertsKeys
@@ -6536,7 +6536,7 @@ WOLFSSL_API int wolfSSL_SetMinDhKey_Sz(WOLFSSL*, unsigned short);
     \sa wolfSSL_GetDhKey_Sz
     \sa wolfSSL_CTX_SetTMpDH_file
 */
-WOLFSSL_API int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX*, unsigned short);
+WOLFSSL_API int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX*, word16);
 
 /*!
     \ingroup CertsKeys
@@ -6564,7 +6564,7 @@ WOLFSSL_API int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX*, unsigned short);
     \sa wolfSSL_CTX_SetMaxDhKey_Sz
     \sa wolfSSL_GetDhKey_Sz
 */
-WOLFSSL_API int wolfSSL_SetMaxDhKey_Sz(WOLFSSL*, unsigned short);
+WOLFSSL_API int wolfSSL_SetMaxDhKey_Sz(WOLFSSL*, word16);
 
 /*!
     \ingroup CertsKeys
@@ -8082,7 +8082,7 @@ WOLFSSL_API int                  wolfSSL_GetCipherType(WOLFSSL*);
     \sa wolfSSL_GetHmacType
 */
 WOLFSSL_API int                  wolfSSL_SetTlsHmacInner(WOLFSSL*, unsigned char*,
-                                                       unsigned int, int, int);
+                                                       word32, int, int);
 
 /*!
     \brief Allows caller to set the Public Key Callback for ECC Signing.
@@ -9568,7 +9568,7 @@ WOLFSSL_API int wolfSSL_CTX_LoadCRL(WOLFSSL_CTX*, const char*, int, int);
     \param cb a pointer to a callback function of type CbMissingCRL.
     Signature requirement:
 	void (*CbMissingCRL)(const char* url);
-	
+
     _Example_
     \code
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new( protocol method );
@@ -10379,7 +10379,7 @@ WOLFSSL_API int wolfSSL_CTX_UseTruncatedHMAC(WOLFSSL_CTX* ctx);
     WOLFSSL* ssl = wolfSSL_new(ctx);
     …
     if (wolfSSL_UseOCSPStapling(ssl, WOLFSSL_CSR2_OCSP,
-    WOLFSSL_CSR2_OCSP_USE_NONCE) != SSL_SUCCESS){ 	
+    WOLFSSL_CSR2_OCSP_USE_NONCE) != SSL_SUCCESS){
 	    // Failed case.
     }
     \endcode
@@ -10537,7 +10537,7 @@ WOLFSSL_API int wolfSSL_CTX_UseOCSPStaplingV2(WOLFSSL_CTX* ctx,
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_UseSupportedCurve
 */
-WOLFSSL_API int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, unsigned short name);
+WOLFSSL_API int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, word16 name);
 
 /*!
     \brief This function is called on the client side to enable the use of
@@ -10576,7 +10576,7 @@ WOLFSSL_API int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, unsigned short name);
     \sa wolfSSL_UseSupportedCurve
 */
 WOLFSSL_API int wolfSSL_CTX_UseSupportedCurve(WOLFSSL_CTX* ctx,
-                                                           unsigned short name);
+                                                           word16 name);
 
 /*!
     \ingroup IO
@@ -10737,7 +10737,7 @@ WOLFSSL_API int wolfSSL_CTX_UseSessionTicket(WOLFSSL_CTX* ctx);
     \sa wolfSSL_UseSessionTicket
     \sa wolfSSL_set_SessionTicket
 */
-WOLFSSL_API int wolfSSL_get_SessionTicket(WOLFSSL*, unsigned char*, unsigned int*);
+WOLFSSL_API int wolfSSL_get_SessionTicket(WOLFSSL*, unsigned char*, word32*);
 
 /*!
     \ingroup IO
@@ -10771,7 +10771,7 @@ WOLFSSL_API int wolfSSL_get_SessionTicket(WOLFSSL*, unsigned char*, unsigned int
 
     \sa wolfSSL_set_SessionTicket_cb
 */
-WOLFSSL_API int wolfSSL_set_SessionTicket(WOLFSSL*, const unsigned char*, unsigned int);
+WOLFSSL_API int wolfSSL_set_SessionTicket(WOLFSSL*, const unsigned char*, word32);
 
 /*!
     \brief This function sets the session ticket callback. The type
@@ -11123,8 +11123,8 @@ WOLFSSL_API int wolfSSL_get_session_stats(unsigned int* active,
     \sa MakeTlsMasterSecret
 */
 WOLFSSL_API
-int wolfSSL_MakeTlsMasterSecret(unsigned char* ms, unsigned int msLen,
-                               const unsigned char* pms, unsigned int pmsLen,
+int wolfSSL_MakeTlsMasterSecret(unsigned char* ms, word32 msLen,
+                               const unsigned char* pms, word32 pmsLen,
                                const unsigned char* cr, const unsigned char* sr,
                                int tls1_2, int hash_type);
 
@@ -11170,8 +11170,8 @@ int wolfSSL_MakeTlsMasterSecret(unsigned char* ms, unsigned int msLen,
     \sa IsAtLeastTLSv1_2
 */
 WOLFSSL_API
-int wolfSSL_DeriveTlsKeys(unsigned char* key_data, unsigned int keyLen,
-                               const unsigned char* ms, unsigned int msLen,
+int wolfSSL_DeriveTlsKeys(unsigned char* key_data, word32 keyLen,
+                               const unsigned char* ms, word32 msLen,
                                const unsigned char* sr, const unsigned char* cr,
                                int tls1_2, int hash_type);
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -19810,6 +19810,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
             #ifndef NO_DH
                 case diffie_hellman_kea:
                 {
+                    word32 sigLen;
                     ssl->buffers.sig.length = ENCRYPT_LEN;
                     ssl->buffers.sig.buffer = (byte*)XMALLOC(ENCRYPT_LEN,
                                             ssl->heap, DYNAMIC_TYPE_SIGNATURE);
@@ -19853,11 +19854,13 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                     }
 
                     /* for DH, encSecret is Yc, agree is pre-master */
+                    sigLen = ssl->buffers.sig.length;
                     ret = DhGenKeyPair(ssl, ssl->buffers.serverDH_Key,
-                        ssl->buffers.sig.buffer, &ssl->buffers.sig.length,
+                        ssl->buffers.sig.buffer, &sigLen,
                         args->encSecret, &args->encSz);
 
                     /* set the max agree result size */
+                    ssl->buffers.sig.length = (unsigned int)sigLen;
                     ssl->arrays->preMasterSz = ENCRYPT_LEN;
                     break;
                 }
@@ -20875,10 +20878,11 @@ int SendCertificateVerify(WOLFSSL* ssl)
         #ifdef HAVE_ECC
            if (ssl->hsType == DYNAMIC_TYPE_ECC) {
                 ecc_key* key = (ecc_key*)ssl->hsKey;
+                word32 sigLen = ssl->buffers.sig.length;
 
                 ret = EccSign(ssl,
                     ssl->buffers.digest.buffer, ssl->buffers.digest.length,
-                    ssl->buffers.sig.buffer, &ssl->buffers.sig.length,
+                    ssl->buffers.sig.buffer, &sigLen,
                     key,
             #ifdef HAVE_PK_CALLBACKS
                     ssl->buffers.key
@@ -20886,6 +20890,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
                     NULL
             #endif
                 );
+                ssl->buffers.sig.length = (unsigned int)sigLen;
             }
         #endif /* HAVE_ECC */
         #if defined(HAVE_ED25519) && !defined(NO_ED25519_CLIENT_AUTH)
@@ -21681,6 +21686,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                     case diffie_hellman_kea:
                 #endif
                     {
+                        word32 dhPrivLen, dhPubLen;
+
                         /* Allocate DH key buffers and generate key */
                         if (ssl->buffers.serverDH_P.buffer == NULL ||
                             ssl->buffers.serverDH_G.buffer == NULL) {
@@ -21747,11 +21754,13 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             }
                         }
 
+                        dhPrivLen = ssl->buffers.serverDH_Priv.length;
+                        dhPubLen = ssl->buffers.serverDH_Pub.length;
                         ret = DhGenKeyPair(ssl, ssl->buffers.serverDH_Key,
-                            ssl->buffers.serverDH_Priv.buffer,
-                            &ssl->buffers.serverDH_Priv.length,
-                            ssl->buffers.serverDH_Pub.buffer,
-                            &ssl->buffers.serverDH_Pub.length);
+                            ssl->buffers.serverDH_Priv.buffer, &dhPrivLen,
+                            ssl->buffers.serverDH_Pub.buffer, &dhPubLen);
+                        ssl->buffers.serverDH_Priv.length = (unsigned int)dhPrivLen;
+                        ssl->buffers.serverDH_Pub.length = (unsigned int)dhPubLen;
                         break;
                     }
                 #endif /* !NO_DH && (!NO_PSK || !NO_RSA) */

--- a/src/internal.c
+++ b/src/internal.c
@@ -11545,8 +11545,8 @@ static int Poly1305TagOld(WOLFSSL* ssl, byte* additional, const byte* out,
     /* 32 bit size of cipher to 64 bit endian */
     padding[0] =  msglen        & 0xff;
     padding[1] = (msglen >>  8) & 0xff;
-    padding[2] = (msglen >> 16) & 0xff;
-    padding[3] = (msglen >> 24) & 0xff;
+    padding[2] = ((word32)msglen >> 16) & 0xff;
+    padding[3] = ((word32)msglen >> 24) & 0xff;
     if ((ret = wc_Poly1305Update(ssl->auth.poly1305, padding, sizeof(padding)))
         != 0)
         return ret;
@@ -17358,7 +17358,7 @@ exit_dpk:
 
             if (IsAtLeastTLSv1_2(ssl)) {
                 if (ssl->suites->hashSigAlgoSz) {
-                    int i;
+                    word16 i;
                     /* extension type */
                     c16toa(HELLO_EXT_SIG_ALGO, output + idx);
                     idx += HELLO_EXT_TYPE_SZ;
@@ -17369,7 +17369,7 @@ exit_dpk:
                     /* sig algos length */
                     c16toa(ssl->suites->hashSigAlgoSz, output + idx);
                     idx += HELLO_EXT_SIGALGO_SZ;
-                    for (i = 0; i < ssl->suites->hashSigAlgoSz; i++, idx++) {
+                    for (i=0; i < ssl->suites->hashSigAlgoSz; i++, idx++) {
                         output[idx] = ssl->suites->hashSigAlgo[i];
                     }
                 }
@@ -24615,7 +24615,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                     et->enc_ticket, inLen, &outLen,
                                     ssl->ctx->ticketEncCtx);
         if (ret == WOLFSSL_TICKET_RET_FATAL || ret < 0) return ret;
-        if (outLen > inLen || outLen < (int)sizeof(InternalTicket)) {
+        if (outLen > (int)inLen || outLen < (int)sizeof(InternalTicket)) {
             WOLFSSL_MSG("Bad user ticket decrypt len");
             return BAD_TICKET_KEY_CB_SZ;
         }
@@ -26092,7 +26092,7 @@ int wolfSSL_GetMaxRecordSize(WOLFSSL* ssl, int maxFragment)
     }
 
 #ifdef HAVE_MAX_FRAGMENT
-    if ((ssl->max_fragment != 0) && (maxFragment > ssl->max_fragment)) {
+    if ((ssl->max_fragment != 0) && ((word16)maxFragment > ssl->max_fragment)) {
         maxFragment = ssl->max_fragment;
     }
 #endif /* HAVE_MAX_FRAGMENT */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1471,9 +1471,9 @@ int wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
     if (ssl == NULL || p == NULL || g == NULL)
         return BAD_FUNC_ARG;
 
-    if (pSz < ssl->options.minDhKeySz)
+    if ((word16)pSz < ssl->options.minDhKeySz)
         return DH_KEY_SIZE_E;
-    if (pSz > ssl->options.maxDhKeySz)
+    if ((word16)pSz > ssl->options.maxDhKeySz)
         return DH_KEY_SIZE_E;
 
     /* this function is for server only */
@@ -1571,9 +1571,9 @@ int wolfSSL_CTX_SetTmpDH(WOLFSSL_CTX* ctx, const unsigned char* p, int pSz,
     WOLFSSL_ENTER("wolfSSL_CTX_SetTmpDH");
     if (ctx == NULL || p == NULL || g == NULL) return BAD_FUNC_ARG;
 
-    if (pSz < ctx->minDhKeySz)
+    if ((word16)pSz < ctx->minDhKeySz)
         return DH_KEY_SIZE_E;
-    if (pSz > ctx->maxDhKeySz)
+    if ((word16)pSz > ctx->maxDhKeySz)
         return DH_KEY_SIZE_E;
 
     #if !defined(WOLFSSL_OLD_PRIME_CHECK) && !defined(HAVE_FIPS) && \
@@ -3748,7 +3748,7 @@ int wolfSSL_SetVersion(WOLFSSL* ssl, int version)
 /* Make a work from the front of random hash */
 static WC_INLINE word32 MakeWordFromHash(const byte* hashID)
 {
-    return ((word32)hashID[0] << 24) | (hashID[1] << 16) |
+    return ((word32)hashID[0] << 24) | ((word32)hashID[1] << 16) |
         (hashID[2] <<  8) | hashID[3];
 }
 
@@ -10107,7 +10107,7 @@ static int GetDeepCopySession(WOLFSSL* ssl, WOLFSSL_SESSION* copyFrom)
             return BAD_MUTEX_E;
         }
 
-        if (ticketLen != copyFrom->ticketLen) {
+        if ((word16)ticketLen != copyFrom->ticketLen) {
             /* Another thread modified the ssl-> session ticket during alloc.
              * Treat as error, since ticket different than when copy requested */
             ret = VAR_STATE_CHANGE_E;
@@ -10298,7 +10298,7 @@ int AddSession(WOLFSSL* ssl)
 
 #ifdef HAVE_SESSION_TICKET
     /* Check if another thread modified ticket since alloc */
-    if (ticLen != ssl->session.ticketLen) {
+    if ((word16)ticLen != ssl->session.ticketLen) {
         error = VAR_STATE_CHANGE_E;
     }
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -854,11 +854,12 @@ static int Hmac_UpdateFinal_CT(Hmac* hmac, byte* digest, const byte* in,
     byte lenBytes[8];
     int  i, j, k;
     int  blockBits, blockMask;
-    int  realLen, lastBlockLen, macLen, extraLen, eocIndex;
+    int  lastBlockLen, macLen, extraLen, eocIndex;
     int  blocks, safeBlocks, lenBlock, eocBlock;
     int  maxLen;
     int  blockSz, padSz;
     int  ret;
+    word32 realLen;
     byte extraBlock;
 
     switch (hmac->macType) {
@@ -3383,7 +3384,7 @@ static int TLSX_PointFormat_Append(PointFormat* list, byte format, void* heap)
 
 static void TLSX_SupportedCurve_ValidateRequest(WOLFSSL* ssl, byte* semaphore)
 {
-    int i;
+    word16 i;
 
     for (i = 0; i < ssl->suites->suiteSz; i+= 2) {
         if (ssl->suites->suites[i] == TLS13_BYTE)
@@ -3407,7 +3408,7 @@ static void TLSX_SupportedCurve_ValidateRequest(WOLFSSL* ssl, byte* semaphore)
 
 static void TLSX_PointFormat_ValidateRequest(WOLFSSL* ssl, byte* semaphore)
 {
-    int i;
+    word16 i;
 
     for (i = 0; i < ssl->suites->suiteSz; i+= 2) {
         if (ssl->suites->suites[i] == TLS13_BYTE)
@@ -3787,7 +3788,7 @@ static int TLSX_PointFormat_Parse(WOLFSSL* ssl, byte* input, word16 length,
     int ret;
 
     /* validating formats list length */
-    if (ENUM_LEN > length || length != ENUM_LEN + input[0])
+    if (ENUM_LEN > length || length != (word16)ENUM_LEN + input[0])
         return BUFFER_ERROR;
 
     if (isRequest) {
@@ -5370,7 +5371,7 @@ static int TLSX_SupportedVersions_Parse(WOLFSSL* ssl, byte* input,
         len = *input;
 
         /* Protocol version array must fill rest of data. */
-        if (length != OPAQUE8_LEN + len)
+        if (length != (word16)OPAQUE8_LEN + len)
             return BUFFER_ERROR;
 
         input++;
@@ -6845,7 +6846,7 @@ static int TLSX_KeyShare_Parse(WOLFSSL* ssl, byte* input, word16 length,
             return BUFFER_ERROR;
         offset += OPAQUE16_LEN;
 
-        while (offset < length) {
+        while (offset < (int)length) {
             ret = TLSX_KeyShareEntry_Parse(ssl, &input[offset], length - offset,
                                                                 &keyShareEntry);
             if (ret < 0)
@@ -6875,7 +6876,7 @@ static int TLSX_KeyShare_Parse(WOLFSSL* ssl, byte* input, word16 length,
 
         /* ServerHello contains one key share entry. */
         len = TLSX_KeyShareEntry_Parse(ssl, input, length, &keyShareEntry);
-        if (len != length)
+        if (len != (int)length)
             return BUFFER_ERROR;
 
         /* Not in list sent if there isn't a private key. */
@@ -7154,7 +7155,7 @@ static int TLSX_KeyShare_GroupRank(WOLFSSL* ssl, int group)
     }
 
     for (i = 0; i < ssl->numGroups; i++)
-        if (ssl->group[i] == group)
+        if (ssl->group[i] == (word16)group)
             return i;
 
     return -1;
@@ -7891,7 +7892,7 @@ static int TLSX_PskKeModes_Parse(WOLFSSL* ssl, byte* input, word16 length,
     if (msgType == client_hello) {
         /* Format: Len | Modes* */
         int   idx = 0;
-        int   len;
+        word16 len;
         byte  modes = 0;
 
         /* Ensure length byte exists. */
@@ -9750,7 +9751,7 @@ int TLSX_ParseVersion(WOLFSSL* ssl, byte* input, word16 length, byte msgType,
     int offset = 0;
 
     *found = 0;
-    while (offset < length) {
+    while (offset < (int)length) {
         word16 type;
         word16 size;
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2196,7 +2196,7 @@ exit_buildmsg:
  */
 static int FindSuiteSSL(WOLFSSL* ssl, byte* suite)
 {
-    int i;
+    word16 i;
 
     for (i = 0; i < ssl->suites->suiteSz; i += 2) {
         if (ssl->suites->suites[i+0] == suite[0] &&
@@ -3278,7 +3278,7 @@ static void RefineSuites(WOLFSSL* ssl, Suites* peerSuites)
 {
     byte suites[WOLFSSL_MAX_SUITE_SZ];
     int suiteSz = 0;
-    int i, j;
+    word16 i, j;
 
     for (i = 0; i < ssl->suites->suiteSz; i += 2) {
         for (j = 0; j < peerSuites->suiteSz; j += 2) {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5395,15 +5395,17 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
         {
         #ifdef HAVE_ECC
            if (ssl->hsType == DYNAMIC_TYPE_ECC) {
+                word32 sigLen = sig->length;
                 ret = EccSign(ssl, args->sigData, args->sigDataSz,
                     args->verify + HASH_SIG_SIZE + VERIFY_HEADER,
-                    &sig->length, (ecc_key*)ssl->hsKey,
+                    &sigLen, (ecc_key*)ssl->hsKey,
             #ifdef HAVE_PK_CALLBACKS
                     ssl->buffers.key
             #else
                     NULL
             #endif
                 );
+                sig->length = (unsigned int)sigLen;
                 args->length = (word16)sig->length;
             }
         #endif /* HAVE_ECC */
@@ -5423,8 +5425,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
         #endif
         #ifndef NO_RSA
             if (ssl->hsType == DYNAMIC_TYPE_RSA) {
-
-                ret = RsaSign(ssl, sig->buffer, sig->length,
+                ret = RsaSign(ssl, sig->buffer, (word32)sig->length,
                     args->verify + HASH_SIG_SIZE + VERIFY_HEADER, &args->sigLen,
                     args->sigAlgo, ssl->suites->hashAlgo,
                     (RsaKey*)ssl->hsKey,
@@ -5459,7 +5460,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
             if (ssl->hsType == DYNAMIC_TYPE_RSA) {
                 /* check for signature faults */
                 ret = VerifyRsaSign(ssl, args->sigData, args->sigLen,
-                    sig->buffer, sig->length, args->sigAlgo,
+                    sig->buffer, (word32)sig->length, args->sigAlgo,
                     ssl->suites->hashAlgo, (RsaKey*)ssl->hsKey,
                     ssl->buffers.key
                 );
@@ -5777,7 +5778,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
             if (ssl->peerRsaKey != NULL && ssl->peerRsaKeyPresent != 0) {
                 WOLFSSL_MSG("Doing RSA peer cert verify");
 
-                ret = RsaVerify(ssl, sig->buffer, sig->length, &args->output,
+                ret = RsaVerify(ssl, sig->buffer, (word32)sig->length, &args->output,
                     args->sigAlgo, args->hashAlgo, ssl->peerRsaKey,
                 #ifdef HAVE_PK_CALLBACKS
                     &ssl->buffers.peerRsaKey

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -992,8 +992,8 @@ static void bench_stats_sym_finish(const char* desc, int doAsync, int count,
 
     if (base2) {
         /* determine if we should show as KB or MB */
-        if (blocks > (1024 * 1024)) {
-            blocks /= (1024 * 1024);
+        if (blocks > (1024ul * 1024ul)) {
+            blocks /= (1024ul * 1024ul);
             blockType = "MB";
         }
         else if (blocks > 1024) {
@@ -1006,8 +1006,8 @@ static void bench_stats_sym_finish(const char* desc, int doAsync, int count,
     }
     else {
         /* determine if we should show as kB or mB */
-        if (blocks > (1000 * 1000)) {
-            blocks /= (1000 * 1000);
+        if (blocks > (1000ul * 1000ul)) {
+            blocks /= (1000ul * 1000ul);
             blockType = "mB";
         }
         else if (blocks > 1000) {
@@ -1666,13 +1666,13 @@ int benchmark_init(void)
 
     if (csv_format == 1) {
         printf("wolfCrypt Benchmark (block bytes %d, min %.1f sec each)\n",
-        BENCH_SIZE, BENCH_MIN_RUNTIME_SEC);
+        (int)BENCH_SIZE, BENCH_MIN_RUNTIME_SEC);
         printf("This format allows you to easily copy the output to a csv file.");
         printf("\n\nSymmetric Ciphers:\n\n");
         printf("Algorithm,MB/s,Cycles per byte,\n");
     } else {
         printf("wolfCrypt Benchmark (block bytes %d, min %.1f sec each)\n",
-        BENCH_SIZE, BENCH_MIN_RUNTIME_SEC);
+        (int)BENCH_SIZE, BENCH_MIN_RUNTIME_SEC);
     }
 
 #ifdef HAVE_WNR
@@ -1778,7 +1778,7 @@ void bench_rng(void)
 {
     int    ret, i, count;
     double start;
-    int    pos, len, remain;
+    long   pos, len, remain;
     WC_RNG myrng;
 
 #ifndef HAVE_FIPS
@@ -4301,7 +4301,7 @@ void bench_rsa_key(int doAsync, int rsaKeySz)
     int     ret = 0, i, pending = 0;
     RsaKey  rsaKey[BENCH_MAX_PENDING];
     int     isPending[BENCH_MAX_PENDING];
-    int     exp = 65537;
+    long    exp = 65537l;
 
     /* clear for done cleanup */
     XMEMSET(rsaKey, 0, sizeof(rsaKey));

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1150,11 +1150,9 @@ const ecc_set_type ecc_sets[] = {
 static int wc_ecc_export_x963_compressed(ecc_key*, byte* out, word32* outLen);
 #endif
 
-#ifdef WOLFSSL_ATECC508A
-    typedef void* ecc_curve_spec;
-#else
 
-#if defined(WOLFSSL_VALIDATE_ECC_KEYGEN) || !defined(WOLFSSL_SP_MATH)
+#if (defined(WOLFSSL_VALIDATE_ECC_KEYGEN) || !defined(WOLFSSL_SP_MATH)) && \
+    !defined(WOLFSSL_ATECC508A)
 static int ecc_check_pubkey_order(ecc_key* key, ecc_point* pubkey, mp_int* a,
         mp_int* prime, mp_int* order);
 #endif
@@ -1438,8 +1436,6 @@ void wc_ecc_curve_cache_free(void)
 #endif
 }
 #endif /* ECC_CACHE_CURVE */
-
-#endif /* WOLFSSL_ATECC508A */
 
 
 /* Retrieve the curve name for the ECC curve id.

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -1950,7 +1950,7 @@ int mp_exptmod_fast (mp_int * G, mp_int * X, mp_int * P, mp_int * Y,
      /* automatically pick the comba one if available (saves quite a few
         calls/ifs) */
 #ifdef BN_FAST_MP_MONTGOMERY_REDUCE_C
-     if (((P->used * 2 + 1) < MP_WARRAY) &&
+     if (((P->used * 2 + 1) < (int)MP_WARRAY) &&
           P->used < (1 << ((CHAR_BIT * sizeof (mp_word)) - (2 * DIGIT_BIT)))) {
         redux = fast_mp_montgomery_reduce;
      } else
@@ -2395,7 +2395,7 @@ int mp_montgomery_reduce (mp_int * x, mp_int * n, mp_digit rho)
    * are fixed up in the inner loop.
    */
   digs = n->used * 2 + 1;
-  if ((digs < MP_WARRAY) &&
+  if ((digs < (int)MP_WARRAY) &&
       n->used <
       (1 << ((CHAR_BIT * sizeof (mp_word)) - (2 * DIGIT_BIT)))) {
     return fast_mp_montgomery_reduce (x, n, rho);
@@ -2797,7 +2797,7 @@ int mp_sqr (mp_int * a, mp_int * b)
   {
 #ifdef BN_FAST_S_MP_SQR_C
     /* can we use the fast comba multiplier? */
-    if ((a->used * 2 + 1) < MP_WARRAY &&
+    if ((a->used * 2 + 1) < (int)MP_WARRAY &&
          a->used <
          (1 << (sizeof(mp_word) * CHAR_BIT - 2*DIGIT_BIT - 1))) {
       res = fast_s_mp_sqr (a, b);
@@ -2834,7 +2834,7 @@ int mp_mul (mp_int * a, mp_int * b, mp_int * c)
     int     digs = a->used + b->used + 1;
 
 #ifdef BN_FAST_S_MP_MUL_DIGS_C
-    if ((digs < MP_WARRAY) &&
+    if ((digs < (int)MP_WARRAY) &&
         MIN(a->used, b->used) <=
         (1 << ((CHAR_BIT * sizeof (mp_word)) - (2 * DIGIT_BIT)))) {
       res = fast_s_mp_mul_digs (a, b, c, digs);
@@ -3032,7 +3032,7 @@ int fast_s_mp_sqr (mp_int * a, mp_int * b)
     }
   }
 
-  if (pa > MP_WARRAY)
+  if (pa > (int)MP_WARRAY)
     return MP_RANGE;  /* TAO range check */
 
 #ifdef WOLFSSL_SMALL_STACK
@@ -3151,7 +3151,7 @@ int fast_s_mp_mul_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
 
   /* number of output digits to produce */
   pa = MIN(digs, a->used + b->used);
-  if (pa > MP_WARRAY)
+  if (pa > (int)MP_WARRAY)
     return MP_RANGE;  /* TAO range check */
 
 #ifdef WOLFSSL_SMALL_STACK
@@ -3297,7 +3297,7 @@ int s_mp_mul_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
   mp_digit tmpx, *tmpt, *tmpy;
 
   /* can we use the fast multiplier? */
-  if (((digs) < MP_WARRAY) &&
+  if ((digs < (int)MP_WARRAY) &&
       MIN (a->used, b->used) <
           (1 << ((CHAR_BIT * sizeof (mp_word)) - (2 * DIGIT_BIT)))) {
     return fast_s_mp_mul_digs (a, b, c, digs);
@@ -3805,7 +3805,7 @@ int s_mp_mul_high_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
 
   /* can we use the fast multiplier? */
 #ifdef BN_FAST_S_MP_MUL_HIGH_DIGS_C
-  if (((a->used + b->used + 1) < MP_WARRAY)
+  if (((a->used + b->used + 1) < (int)MP_WARRAY)
       && MIN (a->used, b->used) <
       (1 << ((CHAR_BIT * sizeof (mp_word)) - (2 * DIGIT_BIT)))) {
     return fast_s_mp_mul_high_digs (a, b, c, digs);
@@ -3884,7 +3884,7 @@ int fast_s_mp_mul_high_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
     }
   }
 
-  if (pa > MP_WARRAY)
+  if (pa > (int)MP_WARRAY)
     return MP_RANGE;  /* TAO range check */
 
 #ifdef WOLFSSL_SMALL_STACK

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -289,14 +289,14 @@ STATIC WC_INLINE void c32toa(word32 wc_u32, byte* c)
 /* convert a 24 bit integer into a 32 bit one */
 STATIC WC_INLINE void c24to32(const word24 wc_u24, word32* wc_u32)
 {
-    *wc_u32 = (wc_u24[0] << 16) | (wc_u24[1] << 8) | wc_u24[2];
+    *wc_u32 = ((word32)wc_u24[0] << 16) | (wc_u24[1] << 8) | wc_u24[2];
 }
 
 
 /* convert opaque to 24 bit integer */
 STATIC WC_INLINE void ato24(const byte* c, word32* wc_u24)
 {
-    *wc_u24 = (c[0] << 16) | (c[1] << 8) | c[2];
+    *wc_u24 = ((word32)c[0] << 16) | (c[1] << 8) | c[2];
 }
 
 /* convert opaque to 16 bit integer */
@@ -308,7 +308,7 @@ STATIC WC_INLINE void ato16(const byte* c, word16* wc_u16)
 /* convert opaque to 32 bit integer */
 STATIC WC_INLINE void ato32(const byte* c, word32* wc_u32)
 {
-    *wc_u32 = ((word32)c[0] << 24) | (c[1] << 16) | (c[2] << 8) | c[3];
+    *wc_u32 = ((word32)c[0] << 24) | ((word32)c[1] << 16) | (c[2] << 8) | c[3];
 }
 
 

--- a/wolfcrypt/src/poly1305.c
+++ b/wolfcrypt/src/poly1305.c
@@ -301,7 +301,7 @@ static void poly1305_blocks(Poly1305* ctx, const unsigned char *m,
     ctx->h[2] = h2;
 
 #else /* if not 64 bit then use 32 bit */
-    const word32 hibit = (ctx->finished) ? 0 : (1 << 24); /* 1 << 128 */
+    const word32 hibit = (ctx->finished) ? 0 : ((word32)1 << 24); /* 1 << 128 */
     word32 r0,r1,r2,r3,r4;
     word32 s1,s2,s3,s4;
     word32 h0,h1,h2,h3,h4;
@@ -593,10 +593,10 @@ int wc_Poly1305Final(Poly1305* ctx, byte* mac)
     g1 = h1 + c; c = g1 >> 26; g1 &= 0x3ffffff;
     g2 = h2 + c; c = g2 >> 26; g2 &= 0x3ffffff;
     g3 = h3 + c; c = g3 >> 26; g3 &= 0x3ffffff;
-    g4 = h4 + c - (1 << 26);
+    g4 = h4 + c - ((word32)1 << 26);
 
     /* select h if h < p, or h + -p if h >= p */
-    mask = (g4 >> ((sizeof(word32) * 8) - 1)) - 1;
+    mask = ((word32)g4 >> ((sizeof(word32) * 8) - 1)) - 1;
     g0 &= mask;
     g1 &= mask;
     g2 &= mask;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1380,7 +1380,7 @@ enum Misc {
     MIN_PSK_BINDERS_LEN=  33,  /* min length of binders */
     MAX_TICKET_AGE_SECS=  10,  /* maximum ticket age in seconds */
 
-    MAX_WOLFSSL_FILE_SIZE = 1024 * 1024 * 4,  /* 4 mb file size alloc limit */
+    MAX_WOLFSSL_FILE_SIZE = 1024ul * 1024ul * 4,  /* 4 mb file size alloc limit */
 
 #if defined(HAVE_EX_DATA) || defined(FORTRESS)
     MAX_EX_DATA        =   5,  /* allow for five items of ex_data */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -347,7 +347,7 @@ typedef struct WOLFSSL_X509_OBJECT {
 
 typedef struct WOLFSSL_BUFFER_INFO {
     unsigned char* buffer;
-    word32 length;
+    unsigned int length;
 } WOLFSSL_BUFFER_INFO;
 
 typedef struct WOLFSSL_X509_STORE_CTX {

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -347,7 +347,7 @@ typedef struct WOLFSSL_X509_OBJECT {
 
 typedef struct WOLFSSL_BUFFER_INFO {
     unsigned char* buffer;
-    unsigned int length;
+    word32 length;
 } WOLFSSL_BUFFER_INFO;
 
 typedef struct WOLFSSL_X509_STORE_CTX {
@@ -1547,7 +1547,7 @@ WOLFSSL_API int wolfSSL_Cleanup(void);
 /* which library version do we have */
 WOLFSSL_API const char* wolfSSL_lib_version(void);
 /* which library version do we have in hex */
-WOLFSSL_API unsigned int wolfSSL_lib_version_hex(void);
+WOLFSSL_API word32 wolfSSL_lib_version_hex(void);
 
 /* do accept or connect depedning on side */
 WOLFSSL_API int wolfSSL_negotiate(WOLFSSL* ssl);
@@ -1668,10 +1668,10 @@ WOLFSSL_API int  wolfSSL_CTX_SetTmpDH_buffer(WOLFSSL_CTX*, const unsigned char* 
                                              int format);
 #endif
 
-WOLFSSL_API int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX*, unsigned short);
-WOLFSSL_API int wolfSSL_SetMinDhKey_Sz(WOLFSSL*, unsigned short);
-WOLFSSL_API int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX*, unsigned short);
-WOLFSSL_API int wolfSSL_SetMaxDhKey_Sz(WOLFSSL*, unsigned short);
+WOLFSSL_API int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX*, word16);
+WOLFSSL_API int wolfSSL_SetMinDhKey_Sz(WOLFSSL*, word16);
+WOLFSSL_API int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX*, word16);
+WOLFSSL_API int wolfSSL_SetMaxDhKey_Sz(WOLFSSL*, word16);
 WOLFSSL_API int wolfSSL_GetDhKey_Sz(WOLFSSL*);
 #endif /* NO_DH */
 
@@ -1685,8 +1685,8 @@ WOLFSSL_API int wolfSSL_CTX_SetMinEccKey_Sz(WOLFSSL_CTX*, short);
 WOLFSSL_API int wolfSSL_SetMinEccKey_Sz(WOLFSSL*, short);
 #endif /* NO_RSA */
 
-WOLFSSL_API int  wolfSSL_SetTmpEC_DHE_Sz(WOLFSSL*, unsigned short);
-WOLFSSL_API int  wolfSSL_CTX_SetTmpEC_DHE_Sz(WOLFSSL_CTX*, unsigned short);
+WOLFSSL_API int  wolfSSL_SetTmpEC_DHE_Sz(WOLFSSL*, word16);
+WOLFSSL_API int  wolfSSL_CTX_SetTmpEC_DHE_Sz(WOLFSSL_CTX*, word16);
 
 /* keyblock size in bytes or -1 */
 /* need to call wolfSSL_KeepArrays before handshake to save keys */
@@ -1874,7 +1874,7 @@ WOLFSSL_API int                  wolfSSL_GetHmacSize(WOLFSSL*);
 WOLFSSL_API int                  wolfSSL_GetHmacType(WOLFSSL*);
 WOLFSSL_API int                  wolfSSL_GetCipherType(WOLFSSL*);
 WOLFSSL_API int                  wolfSSL_SetTlsHmacInner(WOLFSSL*, unsigned char*,
-                                                       unsigned int, int, int);
+                                                       word32, int, int);
 
 /* Atomic User Needs */
 enum {
@@ -2416,15 +2416,15 @@ enum {
 #ifdef HAVE_SUPPORTED_CURVES
 #ifndef NO_WOLFSSL_CLIENT
 
-WOLFSSL_API int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, unsigned short name);
+WOLFSSL_API int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, word16 name);
 WOLFSSL_API int wolfSSL_CTX_UseSupportedCurve(WOLFSSL_CTX* ctx,
-                                                           unsigned short name);
+                                                           word16 name);
 
 #endif
 #endif
 
 #ifdef WOLFSSL_TLS13
-WOLFSSL_API int wolfSSL_UseKeyShare(WOLFSSL* ssl, unsigned short group);
+WOLFSSL_API int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group);
 WOLFSSL_API int wolfSSL_NoKeyShares(WOLFSSL* ssl);
 #endif
 
@@ -2443,8 +2443,8 @@ WOLFSSL_API int wolfSSL_Rehandshake(WOLFSSL* ssl);
 #ifndef NO_WOLFSSL_CLIENT
 WOLFSSL_API int wolfSSL_UseSessionTicket(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_CTX_UseSessionTicket(WOLFSSL_CTX* ctx);
-WOLFSSL_API int wolfSSL_get_SessionTicket(WOLFSSL*, unsigned char*, unsigned int*);
-WOLFSSL_API int wolfSSL_set_SessionTicket(WOLFSSL*, const unsigned char*, unsigned int);
+WOLFSSL_API int wolfSSL_get_SessionTicket(WOLFSSL*, unsigned char*, word32*);
+WOLFSSL_API int wolfSSL_set_SessionTicket(WOLFSSL*, const unsigned char*, word32);
 typedef int (*CallbackSessionTicket)(WOLFSSL*, const unsigned char*, int, void*);
 WOLFSSL_API int wolfSSL_set_SessionTicket_cb(WOLFSSL*,
                                                   CallbackSessionTicket, void*);
@@ -2523,20 +2523,20 @@ WOLFSSL_API int wolfSSL_get_session_stats(unsigned int* active,
                                           unsigned int* maxSessions);
 /* External facing KDF */
 WOLFSSL_API
-int wolfSSL_MakeTlsMasterSecret(unsigned char* ms, unsigned int msLen,
-                               const unsigned char* pms, unsigned int pmsLen,
+int wolfSSL_MakeTlsMasterSecret(unsigned char* ms, word32 msLen,
+                               const unsigned char* pms, word32 pmsLen,
                                const unsigned char* cr, const unsigned char* sr,
                                int tls1_2, int hash_type);
 
 WOLFSSL_API
-int wolfSSL_MakeTlsExtendedMasterSecret(unsigned char* ms, unsigned int msLen,
-                              const unsigned char* pms, unsigned int pmsLen,
-                              const unsigned char* sHash, unsigned int sHashLen,
+int wolfSSL_MakeTlsExtendedMasterSecret(unsigned char* ms, word32 msLen,
+                              const unsigned char* pms, word32 pmsLen,
+                              const unsigned char* sHash, word32 sHashLen,
                               int tls1_2, int hash_type);
 
 WOLFSSL_API
-int wolfSSL_DeriveTlsKeys(unsigned char* key_data, unsigned int keyLen,
-                               const unsigned char* ms, unsigned int msLen,
+int wolfSSL_DeriveTlsKeys(unsigned char* key_data, word32 keyLen,
+                               const unsigned char* ms, word32 msLen,
                                const unsigned char* sr, const unsigned char* cr,
                                int tls1_2, int hash_type);
 

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -108,9 +108,17 @@ extern "C" {
  * [any size beyond that is ok provided it doesn't overflow the data type]
  */
 #ifdef MP_8BIT
+   /* 8-bit */
    typedef unsigned char      mp_digit;
    typedef unsigned short     mp_word;
-#elif defined(MP_16BIT) || defined(NO_64BIT)
+   /* don't define DIGIT_BIT, so its calculated below */
+#elif defined(MP_16BIT)
+   /* 16-bit */
+   typedef unsigned int       mp_digit;
+   typedef unsigned long      mp_word;
+   /* don't define DIGIT_BIT, so its calculated below */
+#elif defined(NO_64BIT)
+   /* 32-bit */
    typedef unsigned short     mp_digit;
    typedef unsigned int       mp_word;
    #define DIGIT_BIT          12
@@ -118,7 +126,6 @@ extern "C" {
    /* for GCC only on supported platforms */
    typedef unsigned long long mp_digit;  /* 64 bit type, 128 uses mode(TI) */
    typedef unsigned long      mp_word __attribute__ ((mode(TI)));
-
    #define DIGIT_BIT          60
 #else
    /* this is the default case, 28-bit digits */
@@ -132,14 +139,14 @@ extern "C" {
    typedef unsigned int       mp_digit;  /* long could be 64 now, changed TAO */
    typedef ulong64            mp_word;
 
-#ifdef MP_31BIT
-   /* this is an extension that uses 31-bit digits */
-   #define DIGIT_BIT          31
-#else
-   /* default case is 28-bit digits, defines MP_28BIT as a handy test macro */
-   #define DIGIT_BIT          28
-   #define MP_28BIT
-#endif
+   #ifdef MP_31BIT
+      /* this is an extension that uses 31-bit digits */
+      #define DIGIT_BIT          31
+   #else
+      /* default case is 28-bit digits, defines MP_28BIT as a handy test macro */
+      #define DIGIT_BIT          28
+      #define MP_28BIT
+   #endif
 #endif
 
 #endif /* WOLFSSL_BIGINT_TYPES */
@@ -193,7 +200,7 @@ typedef int           mp_err;
 
 /* size of comba arrays, should be at least 2 * 2**(BITS_PER_WORD -
    BITS_PER_DIGIT*2) */
-#define MP_WARRAY  (1 << (sizeof(mp_word) * CHAR_BIT - 2 * DIGIT_BIT + 1))
+#define MP_WARRAY  ((mp_word)1 << (sizeof(mp_word) * CHAR_BIT - 2 * DIGIT_BIT + 1))
 
 #ifdef HAVE_WOLF_BIGINT
     struct WC_BIGINT;

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -118,17 +118,18 @@ extern "C" {
    typedef unsigned long      mp_word;
    /* don't define DIGIT_BIT, so its calculated below */
 #elif defined(NO_64BIT)
-   /* 32-bit */
+   /* 32-bit forced to 16-bit */
    typedef unsigned short     mp_digit;
    typedef unsigned int       mp_word;
    #define DIGIT_BIT          12
 #elif defined(MP_64BIT)
+   /* 64-bit */
    /* for GCC only on supported platforms */
    typedef unsigned long long mp_digit;  /* 64 bit type, 128 uses mode(TI) */
    typedef unsigned long      mp_word __attribute__ ((mode(TI)));
    #define DIGIT_BIT          60
 #else
-   /* this is the default case, 28-bit digits */
+   /* 32-bit default case */
 
    #if defined(_MSC_VER) || defined(__BORLANDC__)
       typedef unsigned __int64   ulong64;

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -48,9 +48,9 @@
  /* Maximum generate block length */
 #ifndef RNG_MAX_BLOCK_LEN
     #ifdef HAVE_INTEL_QA
-        #define RNG_MAX_BLOCK_LEN (0xFFFF)
+        #define RNG_MAX_BLOCK_LEN (0xFFFFl)
     #else
-        #define RNG_MAX_BLOCK_LEN (0x10000)
+        #define RNG_MAX_BLOCK_LEN (0x10000l)
     #endif
 #endif
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -614,7 +614,8 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 
-#if defined(WOLFSSL_LEANPSK) && !defined(XMALLOC_USER)
+#if defined(WOLFSSL_LEANPSK) && !defined(XMALLOC_USER) && \
+        !defined(NO_WOLFSSL_MEMORY)
     #include <stdlib.h>
     #define XMALLOC(s, h, type)  malloc((s))
     #define XFREE(p, h, type)    free((p))

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -224,7 +224,11 @@
 
 /* some default configurations.
  */
-#if defined(FP_64BIT)
+#if defined(WC_16BIT_CPU)
+   typedef unsigned int    fp_digit;
+   #define SIZEOF_FP_DIGIT 2
+   typedef unsigned long   fp_word;
+#elif defined(FP_64BIT)
    /* for GCC only on supported platforms */
    typedef unsigned long long fp_digit;   /* 64bit, 128 uses mode(TI) below */
    #define SIZEOF_FP_DIGIT 8

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -46,8 +46,13 @@
         #ifndef byte
             typedef unsigned char  byte;
         #endif
-        typedef unsigned short word16;
-        typedef unsigned int   word32;
+        #ifdef WC_16BIT_CPU
+            typedef unsigned int   word16;
+            typedef unsigned long  word32;
+        #else
+            typedef unsigned short word16;
+            typedef unsigned int   word32;
+        #endif
         typedef byte           word24[3];
     #endif
 
@@ -91,7 +96,7 @@
         typedef unsigned long long word64;
     #endif
 
-#if !defined(NO_64BIT) && defined(WORD64_AVAILABLE)
+#if !defined(NO_64BIT) && defined(WORD64_AVAILABLE) && !defined(WC_16BIT_CPU)
     /* These platforms have 64-bit CPU registers.  */
     #if (defined(__alpha__) || defined(__ia64__) || defined(_ARCH_PPC64) || \
          defined(__mips64)  || defined(__x86_64__) || defined(_M_X64)) || \
@@ -112,6 +117,13 @@
             #define WOLFCRYPT_SLOW_WORD64
         #endif
     #endif
+
+#elif defined(WC_16BIT_CPU)
+        #undef WORD64_AVAILABLE
+        typedef unsigned short wolfssl_word;
+        #define MP_16BIT  /* for mp_int, mp_word needs to be twice as big as
+                             mp_digit, no 64 bit type so make mp_digit 16 bit */
+
 #else
         #undef WORD64_AVAILABLE
         typedef word32 wolfssl_word;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -120,7 +120,7 @@
 
 #elif defined(WC_16BIT_CPU)
         #undef WORD64_AVAILABLE
-        typedef unsigned short wolfssl_word;
+        typedef word16 wolfssl_word;
         #define MP_16BIT  /* for mp_int, mp_word needs to be twice as big as
                              mp_digit, no 64 bit type so make mp_digit 16 bit */
 


### PR DESCRIPTION
* Added new `--enable-16bit` build option, which defines `WC_16BIT_CPU`.
* Fix build error when using `WOLFSSL_LEANPSK` and `NO_WOLFSSL_MEMORY`.

Tested using `avr-gcc` version 8.3.0 with `./configure --host=avr --enable-16bit --disable-filesystem --enable-singlethreaded CFLAGS="-DWOLFSSL_GENSEED_FORTEST -DWOLFSSL_USER_CURRTIME -DWOLFSSL_USER_IO -DWOLFSSL_NO_SOCK -DNO_WRITEV -DUSER_TICKS" --enable-tls13 --enable-compkey --enable-certgen --enable-certext --enable-keygen --enable-session-ticket --enable-maxfragment`. Also with `--enable-fastmath`.