### PR TITLE
Configure script fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,10 +14,6 @@ AC_CONFIG_AUX_DIR([build-aux])
 # We do not want the default "-g -O2" that AC_PROG_CC sets automatically.
 : ${CFLAGS=""}
 
-# Test ar for the "U" option. Should be checked before the libtool macros.
-xxx_ar_flags=$((ar --help) 2>&1)
-AS_CASE([$xxx_ar_flags],[*'use actual timestamps and uids/gids'*],[: ${AR_FLAGS="Ucru"}])
-
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_CANONICAL_HOST


### PR DESCRIPTION
Backing out a hack to hush up warnings from the static library archiver in certain situations. Those situations appear to be fixed. The ar tool doesn't need the one option at this point. The defaults set in autoconfig are appropriate.