### PR TITLE
AR flags configure update

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 : ${CFLAGS=""}
 
 # Test ar for the "U" option. Should be checked before the libtool macros.
-xxx_ar_flags=$((ar --help) 2>&1)
+xxx_ar_flags=$(ar --help 2>&1)
 AS_CASE([$xxx_ar_flags],[*'use actual timestamps and uids/gids'*],[: ${AR_FLAGS="Ucru"}])
 
 AC_PROG_CC


### PR DESCRIPTION
In at least one environment the check for particular AR options was failing due to a bash script bug. Deleted an extra pair of parenthesis triggering an arithmetic statement when redundant grouping was desired.