### PR TITLE
windows build update for warnings

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -3147,12 +3147,12 @@ int TraditionalEnc(byte* key, word32 keySz, byte* out, word32* outSz,
 #endif
     byte cbcIv[MAX_IV_SIZE];
     byte *pkcs8Key = NULL;
-    word32 pkcs8KeySz, padSz = 0;
-    int algId;
+    word32 pkcs8KeySz = 0, padSz = 0;
+    int algId = 0;
     const byte* curveOid = NULL;
     word32 curveOidSz = 0;
     const byte* pbeOid = NULL;
-    word32 pbeOidSz;
+    word32 pbeOidSz = 0;
     const byte* encOid = NULL;
     int encOidSz = 0;
     word32 pbeLen = 0, kdfLen = 0, encLen = 0;


### PR DESCRIPTION
Fix a couple warnings from a windows build regarding uninitialized variables.