### PR TITLE
Add Typecasts

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2499,7 +2499,7 @@ static int RsaPrivateDecryptEx(byte* in, word32 inLen, byte* out,
                     c  = ctMaskGTE(j, start);
                     c &= ctMaskLT(i, outLen);
                     /* 0 - no add, -1 add */
-                    i += -c;
+                    i += (word32)((byte)(-c));
                 }
 #else
                 XMEMCPY(out, pad, ret);


### PR DESCRIPTION
Add some typecasts to the RSA constant time data copy so it doesn't misbehave with some embedded compilers that do the integer promotion in a different order than expected.