### PR TITLE
add ECC curve in CMS KARI OriginatorPublicKey parameters

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5775,7 +5775,7 @@ WOLFSSL_LOCAL word32 SetExplicit(byte number, word32 len, byte* output)
 
 #if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT)
 
-static int SetCurve(ecc_key* key, byte* output)
+WOLFSSL_LOCAL int SetCurve(ecc_key* key, byte* output)
 {
 #ifdef HAVE_OID_ENCODING
     int ret;

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1021,6 +1021,9 @@ WOLFSSL_LOCAL word32 SetOctetString(word32 len, byte* output);
 WOLFSSL_LOCAL word32 SetImplicit(byte tag,byte number,word32 len,byte* output);
 WOLFSSL_LOCAL word32 SetExplicit(byte number, word32 len, byte* output);
 WOLFSSL_LOCAL word32 SetSet(word32 len, byte* output);
+#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT)
+WOLFSSL_LOCAL int SetCurve(ecc_key* key, byte* output);
+#endif
 WOLFSSL_LOCAL word32 SetAlgoID(int algoOID,byte* output,int type,int curveSz);
 WOLFSSL_LOCAL int SetMyVersion(word32 version, byte* output, int header);
 WOLFSSL_LOCAL int SetSerialNumber(const byte* sn, word32 snSz, byte* output,


### PR DESCRIPTION
This PR adds the optional ECC curve into the PKCS7/CMS OriginatorPublicKey parameters of a KeyAgreementRecipientInfo (KARI) type.