### PR TITLE
Use snprintf with Win build

### DIFF
--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -124,11 +124,6 @@ static int loggingEnabled = 0;
 static struct log mynewt_log;
 #endif /* WOLFSSL_APACHE_MYNEWT */
 
-#ifdef _MSC_VER
-/* 4996 warning to use MS extensions e.g., sprintf_s instead of XSPRINTF */
-#pragma warning(disable: 4996)
-#endif /* _MSC_VER */
-
 #endif /* DEBUG_WOLFSSL */
 
 

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -124,6 +124,11 @@ static int loggingEnabled = 0;
 static struct log mynewt_log;
 #endif /* WOLFSSL_APACHE_MYNEWT */
 
+#ifdef _MSC_VER
+/* 4996 warning to use MS extensions e.g., sprintf_s instead of XSPRINTF */
+#pragma warning(disable: 4996)
+#endif /* _MSC_VER */
+
 #endif /* DEBUG_WOLFSSL */
 
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -382,13 +382,27 @@
 
         /* snprintf is used in asn.c for GetTimeString, PKCS7 test, and when
            debugging is turned on */
-        #if defined(NO_FILESYSTEM) && (defined(OPENSSL_EXTRA) || \
-               defined(HAVE_PKCS7)) && !defined(NO_STDIO_FILESYSTEM)
-            /* case where stdio is not included else where but is needed for
-             * snprintf */
-            #include <stdio.h>
+        #ifndef USE_WINDOWS_API
+            #if defined(NO_FILESYSTEM) && (defined(OPENSSL_EXTRA) || \
+                   defined(HAVE_PKCS7)) && !defined(NO_STDIO_FILESYSTEM)
+                /* case where stdio is not included else where but is needed
+                   for snprintf */
+                #include <stdio.h>
+            #endif
+            #define XSNPRINTF snprintf
+        #else
+            #if defined(_MSC_VER) && (_MSC_VER >= 1900)
+                /* Beginning with the UCRT in Visual Studio 2015 and
+                   Windows 10, snprintf is no longer identical to
+                   _snprintf. The snprintf function behavior is now
+                   C99 standard compliant. */
+                #define XSNPRINTF snprintf
+            #else
+                /* _snprintf only null terminates the string if return len
+                   is less than count */
+                #define XSNPRINTF _snprintf
+            #endif
         #endif
-        #define XSNPRINTF snprintf
 
         #if defined(WOLFSSL_CERT_EXT) || defined(HAVE_ALPN)
             /* use only Thread Safe version of strtok */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -382,17 +382,13 @@
 
         /* snprintf is used in asn.c for GetTimeString, PKCS7 test, and when
            debugging is turned on */
-        #ifndef USE_WINDOWS_API
-            #if defined(NO_FILESYSTEM) && (defined(OPENSSL_EXTRA) || \
-                   defined(HAVE_PKCS7)) && !defined(NO_STDIO_FILESYSTEM)
-                /* case where stdio is not included else where but is needed for
-                 * snprintf */
-                #include <stdio.h>
-            #endif
-            #define XSNPRINTF snprintf
-        #else
-            #define XSNPRINTF _snprintf
+        #if defined(NO_FILESYSTEM) && (defined(OPENSSL_EXTRA) || \
+               defined(HAVE_PKCS7)) && !defined(NO_STDIO_FILESYSTEM)
+            /* case where stdio is not included else where but is needed for
+             * snprintf */
+            #include <stdio.h>
         #endif
+        #define XSNPRINTF snprintf
 
         #if defined(WOLFSSL_CERT_EXT) || defined(HAVE_ALPN)
             /* use only Thread Safe version of strtok */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -391,18 +391,35 @@
             #endif
             #define XSNPRINTF snprintf
         #else
-            #if defined(_MSC_VER) && (_MSC_VER >= 1900)
-                /* Beginning with the UCRT in Visual Studio 2015 and
-                   Windows 10, snprintf is no longer identical to
-                   _snprintf. The snprintf function behavior is now
-                   C99 standard compliant. */
-                #define XSNPRINTF snprintf
-            #else
-                /* _snprintf only null terminates the string if return len
-                   is less than count */
-                #define XSNPRINTF _snprintf
-            #endif
-        #endif
+            #ifdef _MSC_VER
+                #if (_MSC_VER >= 1900)
+                    /* Beginning with the UCRT in Visual Studio 2015 and
+                       Windows 10, snprintf is no longer identical to
+                       _snprintf. The snprintf function behavior is now
+                       C99 standard compliant. */
+                    #define XSNPRINTF snprintf
+                #else
+                    /* 4996 warning to use MS extensions e.g., _sprintf_s
+                       instead of _snprintf */
+                    #pragma warning(disable: 4996)
+                    static WC_INLINE
+                    int xsnprintf(char *buffer, size_t bufsize,
+                            const char *format, ...) {
+                        va_list ap;
+                        int ret;
+
+                        if ((int)bufsize <= 0) return -1;
+                        va_start(ap, format);
+                        ret = vsnprintf(buffer, bufsize, format, ap);
+                        if (ret >= (int)bufsize)
+                            ret = -1;
+                        va_end(ap);
+                        return ret;
+                    }
+                    #define XSNPRINTF xsnprintf
+                #endif /* (_MSC_VER >= 1900) */
+            #endif /* _MSC_VER */
+        #endif /* USE_WINDOWS_API */
 
         #if defined(WOLFSSL_CERT_EXT) || defined(HAVE_ALPN)
             /* use only Thread Safe version of strtok */


### PR DESCRIPTION
In the Windows environment, when debugging is enabled, the logging macro `XSNPRINTF` was defined to use `_snprintf`. This was identified as a potential liability, as described in https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l?view=vs-2017#remarks

Changed `XSNPRINTF` to use `snprintf`.
Added pragma to address warnings for `XSPRINTF` not using `sprintf_s`.
Added wrapper for versions of MSC older than VS2015.

Thanks to David Parnell (Cambridge Consultants)