### PR TITLE
Edge case fix for AKID not set in CA and two CAs with same issuer line

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8080,6 +8080,8 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
             if (cert->extAuthKeyIdSet)
                 cert->ca = GetCA(cm, cert->extAuthKeyId);
             if (cert->ca == NULL)
+                cert->ca = GetCA(cm, cert->extSubjKeyId);
+            if (cert->ca == NULL)
                 cert->ca = GetCAByName(cm, cert->issuerHash);
 
             /* OCSP Only: alt lookup using subject and pub key w/o sig check */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8079,7 +8079,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
     #ifndef NO_SKID
             if (cert->extAuthKeyIdSet)
                 cert->ca = GetCA(cm, cert->extAuthKeyId);
-            if (cert->ca == NULL)
+            if (cert->ca == NULL && cert->extSubjKeyIdSet)
                 cert->ca = GetCA(cm, cert->extSubjKeyId);
             if (cert->ca == NULL)
                 cert->ca = GetCAByName(cm, cert->issuerHash);


### PR DESCRIPTION
To reproduce craft two root CA's using two unique keys WITHOUT the authKeyId set and identical subject/issuer lines. Use only ONE of the CA's to sign an entity cert. Craft an entity cert with authKeyId set. Load both good and wrong CA into client and load entity cert into server. Attempt to connect. With some cert chains this will fail depending on which CA is loaded up with GetCaByName fallback. Does not fail with 100% of crafted chains but those chains that do fail, fail 100% of the time.

