### PR TITLE
Refactor of the crypto callback return code and new API version marker

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -2914,9 +2914,9 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
     #ifdef WOLF_CRYPTO_CB
         if (aes->devId != INVALID_DEVID) {
             int ret = wc_CryptoCb_AesCbcEncrypt(aes, out, in, sz);
-            if (ret != NOT_COMPILED_IN)
+            if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;
-            /* fall-through on not compiled in */
+            /* fall-through when unavailable */
         }
     #endif
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_AES)
@@ -3013,9 +3013,9 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
     #ifdef WOLF_CRYPTO_CB
         if (aes->devId != INVALID_DEVID) {
             int ret = wc_CryptoCb_AesCbcDecrypt(aes, out, in, sz);
-            if (ret != NOT_COMPILED_IN)
+            if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;
-            /* fall-through on not compiled in */
+            /* fall-through when unavailable */
         }
     #endif
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_AES)
@@ -5440,9 +5440,9 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     if (aes->devId != INVALID_DEVID) {
         int ret = wc_CryptoCb_AesGcmEncrypt(aes, out, in, sz, iv, ivSz,
             authTag, authTagSz, authIn, authInSz);
-        if (ret != NOT_COMPILED_IN)
+        if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
-        /* fall-through on not compiled in */
+        /* fall-through when unavailable */
     }
 #endif
 
@@ -5843,9 +5843,9 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     if (aes->devId != INVALID_DEVID) {
         int ret = wc_CryptoCb_AesGcmDecrypt(aes, out, in, sz, iv, ivSz,
             authTag, authTagSz, authIn, authInSz);
-        if (ret != NOT_COMPILED_IN)
+        if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
-        /* fall-through on not compiled in */
+        /* fall-through when unavailable */
     }
 #endif
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4557,9 +4557,9 @@ int CalcHashId(const byte* data, word32 len, byte* hash)
 #ifdef WOLF_CRYPTO_CB
     /* try to use a registered crypto callback */
     ret = wc_CryptoCb_Sha256Hash(NULL, data, len, hash);
-    if (ret != NOT_COMPILED_IN)
+    if (ret != CRYPTOCB_UNAVAILABLE)
         return ret;
-    /* for not compiled in case, use software method below */
+    /* fall-through when unavailable */
 #endif
 
 #if defined(NO_SHA) && !defined(NO_SHA256)

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -19,7 +19,7 @@
  */
 
 /* This framework provides a central place for crypto hardware integration
-   using the devId scheme. If not supported return `NOT_COMPILED_IN`. */
+   using the devId scheme. If not supported return `CRYPTOCB_UNAVAILABLE`. */
 
 #ifdef HAVE_CONFIG_H
     #include <config.h>
@@ -65,6 +65,15 @@ static CryptoCb* wc_CryptoCb_FindDeviceByIndex(int startIdx)
     return NULL;
 }
 
+static WC_INLINE int wc_CryptoCb_TranslateErrorCode(int ret)
+{
+    if (ret == NOT_COMPILED_IN) {
+        /* backwards compatibility for older NOT_COMPILED_IN syntax */
+        ret = CRYPTOCB_UNAVAILABLE;
+    }
+    return ret;
+}
+
 void wc_CryptoCb_Init(void)
 {
     int i;
@@ -103,7 +112,7 @@ void wc_CryptoCb_UnRegisterDevice(int devId)
 int wc_CryptoCb_Rsa(const byte* in, word32 inLen, byte* out,
     word32* outLen, int type, RsaKey* key, WC_RNG* rng)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     if (key == NULL)
@@ -127,13 +136,13 @@ int wc_CryptoCb_Rsa(const byte* in, word32 inLen, byte* out,
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 
 #ifdef WOLFSSL_KEY_GEN
 int wc_CryptoCb_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     if (key == NULL)
@@ -154,7 +163,7 @@ int wc_CryptoCb_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 #endif
 #endif /* !NO_RSA */
@@ -162,7 +171,7 @@ int wc_CryptoCb_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
 #ifdef HAVE_ECC
 int wc_CryptoCb_MakeEccKey(WC_RNG* rng, int keySize, ecc_key* key, int curveId)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     if (key == NULL)
@@ -183,13 +192,13 @@ int wc_CryptoCb_MakeEccKey(WC_RNG* rng, int keySize, ecc_key* key, int curveId)
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 
 int wc_CryptoCb_Ecdh(ecc_key* private_key, ecc_key* public_key,
     byte* out, word32* outlen)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     if (private_key == NULL)
@@ -210,13 +219,13 @@ int wc_CryptoCb_Ecdh(ecc_key* private_key, ecc_key* public_key,
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 
 int wc_CryptoCb_EccSign(const byte* in, word32 inlen, byte* out,
     word32 *outlen, WC_RNG* rng, ecc_key* key)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     if (key == NULL)
@@ -239,13 +248,13 @@ int wc_CryptoCb_EccSign(const byte* in, word32 inlen, byte* out,
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 
 int wc_CryptoCb_EccVerify(const byte* sig, word32 siglen,
     const byte* hash, word32 hashlen, int* res, ecc_key* key)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     if (key == NULL)
@@ -268,7 +277,7 @@ int wc_CryptoCb_EccVerify(const byte* sig, word32 siglen,
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 #endif /* HAVE_ECC */
 
@@ -280,7 +289,7 @@ int wc_CryptoCb_AesGcmEncrypt(Aes* aes, byte* out,
                                byte* authTag, word32 authTagSz,
                                const byte* authIn, word32 authInSz)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -312,7 +321,7 @@ int wc_CryptoCb_AesGcmEncrypt(Aes* aes, byte* out,
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 
 int wc_CryptoCb_AesGcmDecrypt(Aes* aes, byte* out,
@@ -321,7 +330,7 @@ int wc_CryptoCb_AesGcmDecrypt(Aes* aes, byte* out,
                                const byte* authTag, word32 authTagSz,
                                const byte* authIn, word32 authInSz)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -353,7 +362,7 @@ int wc_CryptoCb_AesGcmDecrypt(Aes* aes, byte* out,
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 #endif /* HAVE_AESGCM */
 
@@ -361,7 +370,7 @@ int wc_CryptoCb_AesGcmDecrypt(Aes* aes, byte* out,
 int wc_CryptoCb_AesCbcEncrypt(Aes* aes, byte* out,
                                const byte* in, word32 sz)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -388,13 +397,13 @@ int wc_CryptoCb_AesCbcEncrypt(Aes* aes, byte* out,
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 
 int wc_CryptoCb_AesCbcDecrypt(Aes* aes, byte* out,
                                const byte* in, word32 sz)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -420,7 +429,7 @@ int wc_CryptoCb_AesCbcDecrypt(Aes* aes, byte* out,
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 #endif /* HAVE_AES_CBC */
 #endif /* !NO_AES */
@@ -429,7 +438,7 @@ int wc_CryptoCb_AesCbcDecrypt(Aes* aes, byte* out,
 int wc_CryptoCb_ShaHash(wc_Sha* sha, const byte* in,
     word32 inSz, byte* digest)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -454,7 +463,7 @@ int wc_CryptoCb_ShaHash(wc_Sha* sha, const byte* in,
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 #endif /* !NO_SHA */
 
@@ -462,7 +471,7 @@ int wc_CryptoCb_ShaHash(wc_Sha* sha, const byte* in,
 int wc_CryptoCb_Sha256Hash(wc_Sha256* sha256, const byte* in,
     word32 inSz, byte* digest)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -487,7 +496,7 @@ int wc_CryptoCb_Sha256Hash(wc_Sha256* sha256, const byte* in,
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 #endif /* !NO_SHA256 */
 
@@ -495,7 +504,7 @@ int wc_CryptoCb_Sha256Hash(wc_Sha256* sha256, const byte* in,
 int wc_CryptoCb_Hmac(Hmac* hmac, int macType, const byte* in, word32 inSz,
     byte* digest)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     if (hmac == NULL)
@@ -516,14 +525,14 @@ int wc_CryptoCb_Hmac(Hmac* hmac, int macType, const byte* in, word32 inSz,
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 #endif /* !NO_HMAC */
 
 #ifndef WC_NO_RNG
 int wc_CryptoCb_RandomBlock(WC_RNG* rng, byte* out, word32 sz)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -546,12 +555,12 @@ int wc_CryptoCb_RandomBlock(WC_RNG* rng, byte* out, word32 sz)
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 
 int wc_CryptoCb_RandomSeed(OS_Seed* os, byte* seed, word32 sz)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = CRYPTOCB_UNAVAILABLE;
     CryptoCb* dev;
 
     /* locate registered callback */
@@ -567,7 +576,7 @@ int wc_CryptoCb_RandomSeed(OS_Seed* os, byte* seed, word32 sz)
         ret = dev->cb(dev->devId, &cryptoInfo, dev->ctx);
     }
 
-    return ret;
+    return wc_CryptoCb_TranslateErrorCode(ret);
 }
 #endif /* !WC_NO_RNG */
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3388,8 +3388,9 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
 #ifdef WOLF_CRYPTO_CB
     if (private_key->devId != INVALID_DEVID) {
         err = wc_CryptoCb_Ecdh(private_key, public_key, out, outlen);
-        if (err != NOT_COMPILED_IN)
+        if (err != CRYPTOCB_UNAVAILABLE)
             return err;
+        /* fall-through when unavailable */
     }
 #endif
 
@@ -3950,8 +3951,9 @@ int wc_ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key, int curve_id)
 #ifdef WOLF_CRYPTO_CB
     if (key->devId != INVALID_DEVID) {
         err = wc_CryptoCb_MakeEccKey(rng, keysize, key, curve_id);
-        if (err != NOT_COMPILED_IN)
+        if (err != CRYPTOCB_UNAVAILABLE)
             return err;
+        /* fall-through when unavailable */
     }
 #endif
 
@@ -4335,8 +4337,9 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
 #ifdef WOLF_CRYPTO_CB
     if (key->devId != INVALID_DEVID) {
         err = wc_CryptoCb_EccSign(in, inlen, out, outlen, rng, key);
-        if (err != NOT_COMPILED_IN)
+        if (err != CRYPTOCB_UNAVAILABLE)
             return err;
+        /* fall-through when unavailable */
     }
 #endif
 
@@ -5181,8 +5184,9 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
 #ifdef WOLF_CRYPTO_CB
     if (key->devId != INVALID_DEVID) {
         err = wc_CryptoCb_EccVerify(sig, siglen, hash, hashlen, res, key);
-        if (err != NOT_COMPILED_IN)
+        if (err != CRYPTOCB_UNAVAILABLE)
             return err;
+        /* fall-through when unavailable */
     }
 #endif
 

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -503,6 +503,9 @@ const char* wc_GetErrorString(int error)
     case PKCS7_NO_SIGNER_E:
         return "No signer in PKCS#7 signed data";
 
+    case CRYPTOCB_UNAVAILABLE:
+        return "Crypto callback unavailable";
+
     default:
         return "unknown error number";
 

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -703,9 +703,9 @@ int wc_HmacUpdate(Hmac* hmac, const byte* msg, word32 length)
 #ifdef WOLF_CRYPTO_CB
     if (hmac->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Hmac(hmac, hmac->macType, msg, length, NULL);
-        if (ret != NOT_COMPILED_IN)
+        if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
-        /* fall-through on not compiled in */
+        /* fall-through when unavailable */
         ret = 0; /* reset error code */
     }
 #endif
@@ -812,9 +812,9 @@ int wc_HmacFinal(Hmac* hmac, byte* hash)
 #ifdef WOLF_CRYPTO_CB
     if (hmac->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Hmac(hmac, hmac->macType, NULL, 0, hash);
-        if (ret != NOT_COMPILED_IN)
+        if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
-        /* fall-through on not compiled in */
+        /* fall-through when unavailable */
         ret = 0; /* reset error code */
     }
 #endif

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -840,9 +840,9 @@ int wc_RNG_GenerateBlock(WC_RNG* rng, byte* output, word32 sz)
 #ifdef WOLF_CRYPTO_CB
     if (rng->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_RandomBlock(rng, output, sz);
-        if (ret != NOT_COMPILED_IN)
+        if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
-        /* fall-through on not compiled in */
+        /* fall-through when unavailable */
     }
 #endif
 
@@ -1490,8 +1490,9 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
     if (os != NULL && os->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_RandomSeed(os, output, sz);
-        if (ret != NOT_COMPILED_IN)
+        if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
+        /* fall-through when unavailable */
     }
 #endif
 
@@ -2226,9 +2227,9 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 #ifdef WOLF_CRYPTO_CB
     if (os != NULL && os->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_RandomSeed(os, output, sz);
-        if (ret != NOT_COMPILED_IN)
+        if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
-        /* fall-through on not compiled in */
+        /* fall-through when unavailable */
         ret = 0; /* reset error code */
     }
 #endif

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2149,9 +2149,9 @@ int wc_RsaFunction(const byte* in, word32 inLen, byte* out,
 #ifdef WOLF_CRYPTO_CB
     if (key->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Rsa(in, inLen, out, outLen, type, key, rng);
-        if (ret != NOT_COMPILED_IN)
+        if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
-        /* fall-through on not compiled in */
+        /* fall-through when unavailable */
         ret = 0; /* reset error code and try using software */
     }
 #endif
@@ -3358,9 +3358,9 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
 #ifdef WOLF_CRYPTO_CB
     if (key->devId != INVALID_DEVID) {
         int ret = wc_CryptoCb_MakeRsaKey(key, size, e, rng);
-        if (ret != NOT_COMPILED_IN)
+        if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
-        /* fall-through on not compiled in */
+        /* fall-through when unavailable */
     }
 #endif
 

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -472,9 +472,9 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
 #ifdef WOLF_CRYPTO_CB
     if (sha->devId != INVALID_DEVID) {
         int ret = wc_CryptoCb_ShaHash(sha, data, len, NULL);
-        if (ret != NOT_COMPILED_IN)
+        if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
-        /* fall-through on not compiled in */
+        /* fall-through when unavailable */
     }
 #endif
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA)
@@ -555,9 +555,9 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
 #ifdef WOLF_CRYPTO_CB
     if (sha->devId != INVALID_DEVID) {
         int ret = wc_CryptoCb_ShaHash(sha, NULL, 0, hash);
-        if (ret != NOT_COMPILED_IN)
+        if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
-        /* fall-through on not compiled in */
+        /* fall-through when unavailable */
     }
 #endif
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA)

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
-
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
@@ -834,9 +832,9 @@ static int InitSha256(wc_Sha256* sha256)
     #ifdef WOLF_CRYPTO_CB
         if (sha256->devId != INVALID_DEVID) {
             int ret = wc_CryptoCb_Sha256Hash(sha256, data, len, NULL);
-            if (ret != NOT_COMPILED_IN)
+            if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;
-            /* fall-through on not compiled in */
+            /* fall-through when unavailable */
         }
     #endif
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA256)
@@ -981,9 +979,9 @@ static int InitSha256(wc_Sha256* sha256)
     #ifdef WOLF_CRYPTO_CB
         if (sha256->devId != INVALID_DEVID) {
             ret = wc_CryptoCb_Sha256Hash(sha256, NULL, 0, hash);
-            if (ret != NOT_COMPILED_IN)
+            if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;
-            /* fall-through on not compiled in */
+            /* fall-through when unavailable */
         }
     #endif
 

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -706,9 +706,9 @@ static int wc_Sha3Update(wc_Sha3* sha3, const byte* data, word32 len, byte p)
         /* QAT only supports SHA3_256 */
         if (p == WC_SHA3_256_COUNT) {
             ret = IntelQaSymSha3(&sha3->asyncDev, NULL, data, len);
-            if (ret != NOT_COMPILED_IN)
+            if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;
-            /* fall-through on not compiled in */
+            /* fall-through when unavailable */
         }
     #endif
     }
@@ -742,9 +742,9 @@ static int wc_Sha3Final(wc_Sha3* sha3, byte* hash, byte p, byte len)
         /* QAT SHA-3 only supported on v2 (8970 or later cards) */
         if (len == WC_SHA3_256_DIGEST_SIZE) {
             ret = IntelQaSymSha3(&sha3->asyncDev, hash, NULL, len);
-            if (ret != NOT_COMPILED_IN)
+            if (ret != CRYPTOCB_UNAVAILABLE)
                 return ret;
-            /* fall-through on not compiled in */
+            /* fall-through when unavailable */
         }
     #endif
     }

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -27,6 +27,11 @@
     extern "C" {
 #endif
 
+/* Defines the Crypto Callback interface version, for compatibility */
+/* Increment this when Crypto Callback interface changes are made */
+#define CRYPTO_CB_VER   2
+
+
 #ifdef WOLF_CRYPTO_CB
 
 #ifndef NO_RSA

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -224,7 +224,9 @@ enum {
     PKCS7_NO_SIGNER_E   = -269,  /* No signer in PKCS#7 signed data msg */
     WC_PKCS7_WANT_READ_E= -270,  /* PKCS7 operations wants more input */
 
-    WC_LAST_E           = -270,  /* Update this to indicate last error */
+    CRYPTOCB_UNAVAILABLE= -271, /* Crypto callback unavailable */
+
+    WC_LAST_E           = -271,  /* Update this to indicate last error */
     MIN_CODE_E          = -300   /* errors -101 - -299 */
 
     /* add new companion error id strings for any new error codes


### PR DESCRIPTION
* Refactor of the crypto callback return code for cases when unavailable to use new error code `CRYPTOCB_UNAVAILABLE`. Retains support for original `NOT_COMPILED_IN` error code.
* Added new `CRYPTO_CB_VER` define for helping applications handle/detect changes to crypto callback interface (currently no way to determine changes at build-time between release cycles).