### PR TITLE
Fixed compile error under ESP-IDF framework

### DIFF
--- a/IDE/Espressif/ESP-IDF/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/user_settings.h
@@ -27,7 +27,6 @@
 #define HAVE_TLS_EXTENSIONS
 #define WC_RSA_PSS
 #define HAVE_HKDF
-#define HAVE_FFDHE_2048
 #define HAVE_AEAD
 #define HAVE_SUPPORTED_CURVES
 


### PR DESCRIPTION
Removed HAVE_FFDHE_2048 definition. HAVE_FFDHE_2048 was no meaning because of defined NO_DH.
The definition causes build-error after PR#2100. 