### PR TITLE
Remove NULL check before pub and priv have a chance to be set

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -23928,7 +23928,7 @@ int wolfSSL_DH_generate_key(WOLFSSL_DH* dh)
 #ifdef WOLFSSL_SMALL_STACK
     tmpRNG = (WC_RNG*)XMALLOC(sizeof(WC_RNG), NULL, DYNAMIC_TYPE_RNG);
 
-    if (tmpRNG == NULL || pub == NULL || priv == NULL) {
+    if (tmpRNG == NULL) {
         XFREE(tmpRNG, NULL, DYNAMIC_TYPE_RNG);
         return ret;
     }


### PR DESCRIPTION
**Source**: "int wolfSSL_DH_generate_key(WOLFSSL_DH* dh)" inside "src/ssl.c"

**Error**:  If WOLFSSL_SMALL_STACK is defined and wolfSSL_DH_generate_key is called then the return value will always be WOLFSSL_FAILURE at line 23933.

**Reason**:  pub and priv are set to NULL on like 23923 and 23924.  They will always be unmodified by the time they are NULL checked at line 23931.  The if statement will always be entered and return the original "ret" value of WOLFSSL_FAILURE.

**Solution**: Remove pub and priv NULL check before they have a chance to be XMALLOCed.  Sanity check resumes at line 23955 through 23957.



