### PR TITLE
Fixes for ATECC support

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -14924,7 +14924,7 @@ static int test_wc_ecc_verify_hash_ex (void)
     int             ret = 0;
 
 #if defined(HAVE_ECC) && defined(HAVE_ECC_SIGN) && defined(WOLFSSL_PUBLIC_MP) \
-     && !defined(WC_NO_RNG)
+     && !defined(WC_NO_RNG) && !defined(WOLFSSL_ATECC508A)
     ecc_key         key;
     WC_RNG          rng;
     mp_int          r;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3979,11 +3979,19 @@ int wc_ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key, int curve_id)
        err = atmel_ecc_create_key(key->slot, key->pubkey_raw);
 
        /* populate key->pubkey */
-       if (err == 0 && key->pubkey.x) {
+       if (err == 0
+       #ifdef ALT_ECC_SIZE
+          && key->pubkey.x
+       #endif
+       ) {
            err = mp_read_unsigned_bin(key->pubkey.x, key->pubkey_raw,
                                       ECC_MAX_CRYPTO_HW_SIZE);
        }
-       if (err == 0 && key->pubkey.y) {
+       if (err == 0
+       #ifdef ALT_ECC_SIZE
+          && key->pubkey.y
+       #endif
+       ) {
            err = mp_read_unsigned_bin(key->pubkey.y,
                                       key->pubkey_raw + ECC_MAX_CRYPTO_HW_SIZE,
                                       ECC_MAX_CRYPTO_HW_SIZE);

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -105,7 +105,9 @@ int atmel_get_random_number(uint32_t count, uint8_t* rand_out)
 		XMEMCPY(&rand_out[i], rng_buffer, copy_count);
 		i += copy_count;
 	}
+    #ifdef ATCAPRINTF
     atcab_printbin_label((const char*)"\r\nRandom Number", rand_out, count);
+    #endif
 #else
     /* TODO: Use on-board TRNG */
 #endif

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -70,7 +70,6 @@ noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/ti/ti-ccm.h \
                          wolfssl/wolfcrypt/port/nrf51.h \
                          wolfssl/wolfcrypt/port/nxp/ksdk_port.h \
-                         wolfssl/wolfcrypt/port/atmel/atmel.h \
                          wolfssl/wolfcrypt/port/xilinx/xil-sha3.h \
                          wolfssl/wolfcrypt/port/caam/caam_driver.h \
                          wolfssl/wolfcrypt/port/caam/wolfcaam.h \
@@ -78,6 +77,10 @@ noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/st/stm32.h \
                          wolfssl/wolfcrypt/port/st/stsafe.h \
                          wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+
+if BUILD_CRYPTOAUTHLIB
+nobase_include_HEADERS+= wolfssl/wolfcrypt/port/atmel/atmel.h
+endif
 
 if BUILD_AFALG
 nobase_include_HEADERS+= wolfssl/wolfcrypt/port/af_alg/afalg_hash.h


### PR DESCRIPTION
* Fix for building ATECC without `ATCAPRINTF` defined.
* Fix for build warning with x/y always true when not building with ALT_ECC_SIZE.
* Fix for build error with undefined `wc_ecc_sign_hash_ex` when building ATECC and `WOLFSSL_PUBLIC_MP`.
* Fix to include the atmel.h with make install when using `--with-cryptoauthlib`.

Fixes #2167.