### PR TITLE
wolfSSL Asynchronous release v4 fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3860,7 +3860,7 @@ AC_ARG_WITH([intelqa],
             -I$QAT_DIR/quickassist/utilities/libusdm_drv"
 
         LDFLAGS="$LDFLAGS -L$QAT_DIR/build -Wl,-Map=output.map"
-        LIBS="$LIBS -lqat_s"
+        LIBS="$LIBS -lqat_s -lusdm_drv_s"
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cpa_cy_common.h"]], [[ Cpa16U count = 0; cpaCyGetNumInstances(&count); ]])],
             [ intelqa_linked=yes ],[ intelqa_linked=no ])
@@ -3884,7 +3884,7 @@ AC_ARG_WITH([intelqa],
         if test "x$BUILD_INTEL_QAT_VERSION" == "x1" ; then
             LIB_ADD="-ladf_proxy -losal -lrt $LIB_ADD"
         else
-            LIB_ADD="-lusdm_drv_s -losal -lrt $LIB_ADD"
+            LIB_ADD="-losal -lrt $LIB_ADD"
         fi
 
         ENABLED_INTEL_QA=yes

--- a/configure.ac
+++ b/configure.ac
@@ -3859,7 +3859,7 @@ AC_ARG_WITH([intelqa],
             -I$QAT_DIR/quickassist/lookaside/access_layer/src/common/include -I$srcdir/wolfssl -I$srcdir/wolfssl/wolfcrypt/port/intel \
             -I$QAT_DIR/quickassist/utilities/libusdm_drv"
 
-        LDFLAGS="$LDFLAGS -L$QAT_DIR/build -Wl,-Map=output.map"
+        LDFLAGS="$LDFLAGS -L$QAT_DIR/build"
         LIBS="$LIBS -lqat_s -lusdm_drv_s"
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include "cpa_cy_common.h"]], [[ Cpa16U count = 0; cpaCyGetNumInstances(&count); ]])],

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2127,15 +2127,15 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
                     goto exit_buildmsg;
             }
 
+            /* The real record content type goes at the end of the data. */
+            output[args->idx++] = (byte)type;
+
             ssl->options.buildMsgState = BUILD_MSG_ENCRYPT;
         }
         FALL_THROUGH;
 
         case BUILD_MSG_ENCRYPT:
         {
-            /* The real record content type goes at the end of the data. */
-            output[args->idx++] = (byte)type;
-
         #ifdef ATOMIC_USER
             if (ssl->ctx->MacEncryptCb) {
                 /* User Record Layer Callback handling */
@@ -2183,6 +2183,9 @@ exit_buildmsg:
 
     /* Final cleanup */
     FreeBuildMsg13Args(ssl, args);
+#ifdef WOLFSSL_ASYNC_CRYPT
+    ssl->async.freeArgs = NULL;
+#endif
 
     return ret;
 }

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -706,7 +706,7 @@ static int wc_Sha3Update(wc_Sha3* sha3, const byte* data, word32 len, byte p)
         /* QAT only supports SHA3_256 */
         if (p == WC_SHA3_256_COUNT) {
             ret = IntelQaSymSha3(&sha3->asyncDev, NULL, data, len);
-            if (ret != CRYPTOCB_UNAVAILABLE)
+            if (ret != NOT_COMPILED_IN)
                 return ret;
             /* fall-through when unavailable */
         }
@@ -742,7 +742,7 @@ static int wc_Sha3Final(wc_Sha3* sha3, byte* hash, byte p, byte len)
         /* QAT SHA-3 only supported on v2 (8970 or later cards) */
         if (len == WC_SHA3_256_DIGEST_SIZE) {
             ret = IntelQaSymSha3(&sha3->asyncDev, hash, NULL, len);
-            if (ret != CRYPTOCB_UNAVAILABLE)
+            if (ret != NOT_COMPILED_IN)
                 return ret;
             /* fall-through when unavailable */
         }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -7110,7 +7110,7 @@ int aesgcm_test(void)
     result = wc_AesGcmDecrypt(&dec, resultP, resultC, sizeof(c1),
                       iv1, sizeof(iv1), resultT, sizeof(resultT), a, sizeof(a));
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    result = wc_AsyncWait(result, &enc.asyncDev, WC_ASYNC_FLAG_NONE);
+    result = wc_AsyncWait(result, &dec.asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (result != 0)
         return -5705;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -16175,7 +16175,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     wc_ecc_set_flags(&userA, WC_ECC_FLAG_COFACTOR);
     wc_ecc_set_flags(&userB, WC_ECC_FLAG_COFACTOR);
 
-    x = sizeof(sharedA);
+    x = ECC_SHARED_SIZE;
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
         ret = wc_AsyncWait(ret, &userA.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
@@ -16187,7 +16187,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
         goto done;
     }
 
-    y = sizeof(sharedB);
+    y = ECC_SHARED_SIZE;
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
         ret = wc_AsyncWait(ret, &userB.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);


### PR DESCRIPTION
* Fix for latest QAT v1.7 detection. The qat library requires usdm_drv.
* Fix for SHA-3 runtime detection for not supported in hardware using NOT_COMPILED_IN.

Additional post v4.0 release fixes:
* Fix for Async TLS v1.3 wolfSSL_write with AES GCM offload. The `args->idx` was being incremented on the repeated call with `BUILD_MSG_HASH` state.
* Remove remnant debug `-Map` from `--with-intelqa` build option.
* Fix for `HAVE_ECC_CDH` wolfCrypt test with async using the wrong size for x and y.
* Fix for AES GCM decrypt test with Async.