### PR TITLE
Initialized sendVerify when calling wolfSSL_clear

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14748,7 +14748,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         ssl->options.isClosed = 0;
         ssl->options.connReset = 0;
         ssl->options.sentNotify = 0;
-
+        ssl->options.sendVerify = 0;
         ssl->options.serverState = NULL_STATE;
         ssl->options.clientState = NULL_STATE;
         ssl->options.connectState = CONNECT_BEGIN;


### PR DESCRIPTION
Un-initialized sendVerify by calling wolfSSL_clear caused intentionally sending client Certificate though server doesn't request client Certificate.
Zendesk ticket #4868