### PR TITLE
Fix VS Warning

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -58,6 +58,14 @@
     #include <stdio.h>
 #endif
 
+#ifdef USE_WINDOWS_API
+    #pragma warning(disable:4127)
+    /* Disables the warning:
+     *   4127: conditional expression is constant
+     * in this file.
+     */
+#endif
+
 #if defined(WOLFSSL_HAVE_SP_RSA) || defined(WOLFSSL_HAVE_SP_DH)
 WOLFSSL_LOCAL int sp_ModExp_1024(mp_int* base, mp_int* exp, mp_int* mod,
     mp_int* res);


### PR DESCRIPTION
Add a pragma to ignore a particular warning when compiling the fast math file for Windows. (The wolfSSH build test uses tools v110.)