### PR TITLE
Fixes for PK callbacks on 16-bit and ATECC

### DIFF
--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -349,6 +349,10 @@ int atmel_ecc_create_pms(int slotId, const uint8_t* peerKey, uint8_t* pms)
     /* send the encrypted version of the ECDH command */
     ret = atcab_ecdh_enc(slotId, peerKey, pms, read_key, slotIdEnc);
     ret = atmel_ecc_translate_err(ret);
+
+    /* free the ECDHE slot */
+    atmel_ecc_free(slotIdEnc);
+
     return ret;
 }
 
@@ -476,7 +480,7 @@ void atmel_finish(void)
 /**
  * \brief Used on the server-side only for creating the ephemeral key for ECDH
  */
-int atcatls_create_key_cb(WOLFSSL* ssl, ecc_key* key, word32 keySz,
+int atcatls_create_key_cb(WOLFSSL* ssl, ecc_key* key, unsigned int keySz,
     int ecc_curve, void* ctx)
 {
     int ret;
@@ -532,8 +536,8 @@ int atcatls_create_key_cb(WOLFSSL* ssl, ecc_key* key, word32 keySz,
  * \brief Creates a shared secret using a peer public key and a device key
  */
 int atcatls_create_pms_cb(WOLFSSL* ssl, ecc_key* otherKey,
-        unsigned char* pubKeyDer, unsigned int* pubKeySz,
-        unsigned char* out, unsigned int* outlen,
+        unsigned char* pubKeyDer, word32* pubKeySz,
+        unsigned char* out, word32* outlen,
         int side, void* ctx)
 {
     int ret;
@@ -674,8 +678,8 @@ exit:
 /**
  * \brief Sign received digest using private key on device
  */
-int atcatls_sign_certificate_cb(WOLFSSL* ssl, const byte* in, word32 inSz,
-    byte* out, word32* outSz, const byte* key, word32 keySz, void* ctx)
+int atcatls_sign_certificate_cb(WOLFSSL* ssl, const byte* in, unsigned int inSz,
+    byte* out, word32* outSz, const byte* key, unsigned int keySz, void* ctx)
 {
     int ret;
     byte sigRs[ATECC_SIG_SIZE];
@@ -731,8 +735,8 @@ exit:
 /**
  * \brief Verify signature received from peers to prove peer's private key.
  */
-int atcatls_verify_signature_cb(WOLFSSL* ssl, const byte* sig, word32 sigSz,
-    const byte* hash, word32 hashSz, const byte* key, word32 keySz, int* result,
+int atcatls_verify_signature_cb(WOLFSSL* ssl, const byte* sig, unsigned int sigSz,
+    const byte* hash, word32 unsigned int, const byte* key, unsigned int keySz, int* result,
     void* ctx)
 {
     int ret;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1934,7 +1934,7 @@ WOLFSSL_API void* wolfSSL_GetEccKeyGenCtx(WOLFSSL* ssl);
 
 typedef int (*CallbackEccSign)(WOLFSSL* ssl,
        const unsigned char* in, unsigned int inSz,
-       unsigned char* out, unsigned int* outSz,
+       unsigned char* out, word32* outSz,
        const unsigned char* keyDer, unsigned int keySz,
        void* ctx);
 WOLFSSL_API void  wolfSSL_CTX_SetEccSignCb(WOLFSSL_CTX*, CallbackEccSign);
@@ -1951,8 +1951,8 @@ WOLFSSL_API void  wolfSSL_SetEccVerifyCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetEccVerifyCtx(WOLFSSL* ssl);
 
 typedef int (*CallbackEccSharedSecret)(WOLFSSL* ssl, struct ecc_key* otherKey,
-        unsigned char* pubKeyDer, unsigned int* pubKeySz,
-        unsigned char* out, unsigned int* outlen,
+        unsigned char* pubKeyDer, word32* pubKeySz,
+        unsigned char* out, word32* outlen,
         int side, void* ctx); /* side is WOLFSSL_CLIENT_END or WOLFSSL_SERVER_END */
 WOLFSSL_API void  wolfSSL_CTX_SetEccSharedSecretCb(WOLFSSL_CTX*, CallbackEccSharedSecret);
 WOLFSSL_API void  wolfSSL_SetEccSharedSecretCtx(WOLFSSL* ssl, void *ctx);

--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -115,17 +115,17 @@ int  atmel_ecc_verify(const byte* message, const byte* signature,
 #endif /* WOLFSSL_ATECC508A */
 
 #ifdef HAVE_PK_CALLBACKS
-    int atcatls_create_key_cb(struct WOLFSSL* ssl, struct ecc_key* key, word32 keySz,
+    int atcatls_create_key_cb(WOLFSSL* ssl, ecc_key* key, unsigned int keySz,
         int ecc_curve, void* ctx);
-    int atcatls_create_pms_cb(struct WOLFSSL* ssl, struct ecc_key* otherKey,
-        unsigned char* pubKeyDer, unsigned int* pubKeySz,
-        unsigned char* out, unsigned int* outlen,
+    int atcatls_create_pms_cb(WOLFSSL* ssl, ecc_key* otherKey,
+        unsigned char* pubKeyDer, word32* pubKeySz,
+        unsigned char* out, word32* outlen,
         int side, void* ctx);
-    int atcatls_sign_certificate_cb(struct WOLFSSL* ssl, const byte* in, word32 inSz,
-        byte* out, word32* outSz, const byte* key, word32 keySz, void* ctx);
-    int atcatls_verify_signature_cb(struct WOLFSSL* ssl, const byte* sig, word32 sigSz,
-        const byte* hash, word32 hashSz, const byte* key, word32 keySz, int* result,
-        void* ctx);
+    int atcatls_sign_certificate_cb(WOLFSSL* ssl, const byte* in, unsigned int inSz,
+        byte* out, word32* outSz, const byte* key, unsigned int keySz, void* ctx);
+    int atcatls_verify_signature_cb(WOLFSSL* ssl, const byte* sig, unsigned int sigSz,
+        const byte* hash, word32 unsigned int, const byte* key, unsigned int keySz,
+        int* result, void* ctx);
 
     int atcatls_set_callbacks(struct WOLFSSL_CTX* ctx);
     int atcatls_set_callback_ctx(struct WOLFSSL* ssl, void* user_ctx);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -274,7 +274,7 @@
     #define NO_FILESYSTEM
     #define CUSTOM_RAND_TYPE uint16_t
     #define CUSTOM_RAND_GENERATE random_rand
-    static inline unsigned int LowResTimer(void)
+    static inline word32 LowResTimer(void)
     {
         return clock_seconds();
     }


### PR DESCRIPTION
* Fixes for PK callbacks on 16-bit system where `unsigned int*` is used.
* Fix for ATECC PK callback functions.
* Fix for `atmel_ecc_create_pms` to free the used slot.
* Fix for `LowResTimer` function ptoto not matching for 16-bit system.