### PR TITLE
Improvements to the maximum ECC signature calculations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1500,6 +1500,7 @@ fi
 
 AM_CONDITIONAL([BUILD_ECC], [test "x$ENABLED_ECC" = "xyes"])
 
+
 # ECC Custom Curves
 AC_ARG_ENABLE([ecccustcurves],
     [AS_HELP_STRING([--enable-ecccustcurves],[Enable ECC custom curves (default: disabled)])],
@@ -1511,7 +1512,7 @@ if test "$ENABLED_ECCCUSTCURVES" != "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_CUSTOM_CURVES"
 
-    # For distro or all builds, enable all curve types
+    # For distro, all or ecccustcurves=all builds, enable all curve types
     if test "$ENABLED_DISTRO" = "yes" || test "$ENABLED_ALL" = "yes" || test "$ENABLED_ECCCUSTCURVES" = "all"
     then
         # Enable ECC SECPR2, SECPR3, BRAINPOOL and KOBLITZ curves
@@ -1519,6 +1520,12 @@ then
 
         # Enable ECC Cofactor support
         AM_CFLAGS="$AM_CFLAGS -DHAVE_ECC_CDH"
+
+        # If fastmath enabled and on x86 use speedups
+        if test "x$ENABLED_FASTMATH" = "xyes" && test "$host_cpu" = "x86_64"
+        then
+            AM_CFLAGS="$AM_CFLAGS -DTFM_ECC192 -DTFM_ECC224 -DTFM_ECC256 -DTFM_ECC384 -DTFM_ECC521"
+        fi
     fi
 fi
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -14737,7 +14737,7 @@ static int test_wc_ecc_sig_size (void)
 
     if (ret == 0) {
         ret = wc_ecc_sig_size(&key);
-        if (ret == (2 * keySz + SIG_HEADER_SZ + ECC_MAX_PAD_SZ)) {
+        if (ret <= (2 * keySz + SIG_HEADER_SZ + ECC_MAX_PAD_SZ)) {
             ret = 0;
         }
     }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7088,11 +7088,13 @@ int wc_ecc_sig_size_calc(int sz)
     int maxSigSz = 0;
 
     /* calculate based on key bits */
-    maxSigSz = (sz * 2) + (SIG_HEADER_SZ - 1) + ECC_MAX_PAD_SZ;
+    /* maximum possible signature header size is 7 bytes plus 2 bytes padding */
+    maxSigSz = (sz * 2) + SIG_HEADER_SZ + ECC_MAX_PAD_SZ;
 
-    /* if total length exceeds 127 then add 1 */
-    if (maxSigSz >= 127)
-        maxSigSz += 1;
+    /* if total length is less than or equal to 128 then subtract 1 */
+    if (maxSigSz <= 128) {
+        maxSigSz -= 1;
+    }
 
     return maxSigSz;
 }
@@ -7111,15 +7113,15 @@ int wc_ecc_sig_size(ecc_key* key)
         extra byte for r and s, so add 2 */
     keySz = key->dp->size;
     orderBits = wc_ecc_get_curve_order_bit_count(key->dp);
-    /* signature header is minimum of 6 */
-    maxSigSz = (keySz * 2) + (SIG_HEADER_SZ - 1);
+    /* maximum possible signature header size is 7 bytes */
+    maxSigSz = (keySz * 2) + SIG_HEADER_SZ;
     if ((orderBits % 8) == 0) {
         /* MSB can be set, so add 2 */
         maxSigSz += ECC_MAX_PAD_SZ;
     }
-    /* if total length exceeds 127 then add 1 */
-    if (maxSigSz >= 127) {
-        maxSigSz += 1;
+    /* if total length is less than or equal to 128 then subtract 1 */
+    if (maxSigSz <= 128) {
+        maxSigSz -= 1;
     }
 
     return maxSigSz;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7091,8 +7091,8 @@ int wc_ecc_sig_size_calc(int sz)
     /* maximum possible signature header size is 7 bytes plus 2 bytes padding */
     maxSigSz = (sz * 2) + SIG_HEADER_SZ + ECC_MAX_PAD_SZ;
 
-    /* if total length is less than or equal to 128 then subtract 1 */
-    if (maxSigSz <= 128) {
+    /* if total length is less than 128 + SEQ(1)+LEN(1) then subtract 1 */
+    if (maxSigSz < (128 + 2)) {
         maxSigSz -= 1;
     }
 
@@ -7119,8 +7119,8 @@ int wc_ecc_sig_size(ecc_key* key)
         /* MSB can be set, so add 2 */
         maxSigSz += ECC_MAX_PAD_SZ;
     }
-    /* if total length is less than or equal to 128 then subtract 1 */
-    if (maxSigSz <= 128) {
+    /* if total length is less than 128 + SEQ(1)+LEN(1) then subtract 1 */
+    if (maxSigSz < (128 + 2)) {
         maxSigSz -= 1;
     }
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4236,7 +4236,6 @@ static int wc_ecc_get_curve_order_bit_count(const ecc_set_type* dp)
     word32 orderBits;
     DECLARE_CURVE_SPECS(curve, 1);
 
-    /* if the input is larger than curve order, we must truncate */
     ALLOC_CURVE_SPECS(1);
     err = wc_ecc_curve_load(dp, &curve, ECC_CURVE_FIELD_ORDER);
     if (err != 0) {
@@ -4272,6 +4271,7 @@ static int wc_ecc_sign_hash_hw(const byte* in, word32 inlen,
             return ECC_BAD_ARG_E;
         }
 
+        /* if the input is larger than curve order, we must truncate */
         if ((inlen * WOLFSSL_BIT_SIZE) > orderBits) {
            inlen = (orderBits + WOLFSSL_BIT_SIZE - 1) / WOLFSSL_BIT_SIZE;
         }

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -111,12 +111,12 @@ enum {
     ECC_PRIVATEKEY      = 2,
     ECC_PRIVATEKEY_ONLY = 3,
     ECC_MAXNAME     = 16,   /* MAX CURVE NAME LENGTH */
-    SIG_HEADER_SZ   =  6,   /* ECC signature header size */
+    SIG_HEADER_SZ   =  7,   /* ECC signature header size (30 81 87 02 42 [R] 02 42 [S]) */
     ECC_BUFSIZE     = 256,  /* for exported keys temp buffer */
     ECC_MINSIZE     = 20,   /* MIN Private Key size */
     ECC_MAXSIZE     = 66,   /* MAX Private Key size */
     ECC_MAXSIZE_GEN = 74,   /* MAX Buffer size required when generating ECC keys*/
-    ECC_MAX_PAD_SZ  = 4,    /* ECC maximum padding size */
+    ECC_MAX_PAD_SZ  = 2,    /* ECC maximum padding size (when MSB is set extra byte required for R and S) */
     ECC_MAX_OID_LEN = 16,
     ECC_MAX_SIG_SIZE= ((MAX_ECC_BYTES * 2) + ECC_MAX_PAD_SZ + SIG_HEADER_SZ),
 

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -105,6 +105,10 @@
     #define MAX_ECC_BYTES     ((MAX_ECC_BITS / 8) + 1)
 #endif
 
+#ifndef ECC_MAX_PAD_SZ
+    /* ECC maximum padding size (when MSB is set extra byte required for R and S) */
+    #define ECC_MAX_PAD_SZ 2
+#endif
 
 enum {
     ECC_PUBLICKEY       = 1,
@@ -116,7 +120,6 @@ enum {
     ECC_MINSIZE     = 20,   /* MIN Private Key size */
     ECC_MAXSIZE     = 66,   /* MAX Private Key size */
     ECC_MAXSIZE_GEN = 74,   /* MAX Buffer size required when generating ECC keys*/
-    ECC_MAX_PAD_SZ  = 2,    /* ECC maximum padding size (when MSB is set extra byte required for R and S) */
     ECC_MAX_OID_LEN = 16,
     ECC_MAX_SIG_SIZE= ((MAX_ECC_BYTES * 2) + ECC_MAX_PAD_SZ + SIG_HEADER_SZ),
 


### PR DESCRIPTION
* The `wc_ecc_sig_size` function provides actual max based on curve order. 
* The `wc_ecc_sig_size_calc` has also been adjusted to provide a more accurate maximum size.
* Enable the TFM speedups when used with `--enable-ecccustcurves=all` and fastmath and x86.

The test application and results are here:
https://github.com/wolfSSL/wolfssl-examples/pull/137

Built wolfSSL with: `./configure --enable-ecccustcurves=all && make && sudo make install`

CurveMax = wc_ecc_sig_size(key)
ActMax = wc_ecc_sign_hash()
CalcMax = wc_ecc_sig_size_calc()

```
./eccsiglentest Makefile 
Signature Length Test: Loops 1000
File Makefile is 658 bytes
ECC Curve SECP192R1, KeySz 24, Sig: CurveMax 56, ActMax 56, CalcMax 56
ECC Curve PRIME192V2, KeySz 24, Sig: CurveMax 56, ActMax 56, CalcMax 56
ECC Curve PRIME192V3, KeySz 24, Sig: CurveMax 56, ActMax 56, CalcMax 56
ECC Curve PRIME239V1, KeySz 30, Sig: CurveMax 66, ActMax 66, CalcMax 68
ECC Curve PRIME239V2, KeySz 30, Sig: CurveMax 66, ActMax 66, CalcMax 68
ECC Curve PRIME239V3, KeySz 30, Sig: CurveMax 66, ActMax 66, CalcMax 68
ECC Curve SECP256R1, KeySz 32, Sig: CurveMax 72, ActMax 72, CalcMax 72
ECC Curve SECP112R1, KeySz 14, Sig: CurveMax 36, ActMax 36, CalcMax 36
ECC Curve SECP112R2, KeySz 14, Sig: CurveMax 34, ActMax 34, CalcMax 36
ECC Curve SECP128R1, KeySz 16, Sig: CurveMax 40, ActMax 40, CalcMax 40
ECC Curve SECP128R2, KeySz 16, Sig: CurveMax 38, ActMax 38, CalcMax 40
ECC Curve SECP160R1, KeySz 20, Sig: CurveMax 46, ActMax 46, CalcMax 48
ECC Curve SECP160R2, KeySz 20, Sig: CurveMax 46, ActMax 46, CalcMax 48
ECC Curve SECP224R1, KeySz 28, Sig: CurveMax 64, ActMax 64, CalcMax 64
ECC Curve SECP384R1, KeySz 48, Sig: CurveMax 104, ActMax 104, CalcMax 104
ECC Curve SECP521R1, KeySz 66, Sig: CurveMax 139, ActMax 139, CalcMax 141
ECC Curve SECP160K1, KeySz 20, Sig: CurveMax 46, ActMax 46, CalcMax 48
ECC Curve SECP192K1, KeySz 24, Sig: CurveMax 56, ActMax 56, CalcMax 56
ECC Curve SECP224K1, KeySz 28, Sig: CurveMax 62, ActMax 62, CalcMax 64
ECC Curve SECP256K1, KeySz 32, Sig: CurveMax 72, ActMax 72, CalcMax 72
ECC Curve BRAINPOOLP160R1, KeySz 20, Sig: CurveMax 48, ActMax 48, CalcMax 48
ECC Curve BRAINPOOLP192R1, KeySz 24, Sig: CurveMax 56, ActMax 56, CalcMax 56
ECC Curve BRAINPOOLP224R1, KeySz 28, Sig: CurveMax 64, ActMax 64, CalcMax 64
ECC Curve BRAINPOOLP256R1, KeySz 32, Sig: CurveMax 72, ActMax 72, CalcMax 72
ECC Curve BRAINPOOLP320R1, KeySz 40, Sig: CurveMax 88, ActMax 88, CalcMax 88
ECC Curve BRAINPOOLP384R1, KeySz 48, Sig: CurveMax 104, ActMax 104, CalcMax 104
```

Note: The extra 2-bytes of padding is to account for the case where R or S has the Most Significant Bit (MSB) set.