### PR TITLE
Improvements to TLS write handling in error cases

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -368,6 +368,7 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
                                              err != WOLFSSL_ERROR_ZERO_RETURN) {
                         printf("SSL_read echo error %d\n", err);
                         err_sys_ex(runWithErrors, "SSL_read failed");
+                        break;
                     }
                 }
                 else {
@@ -2217,8 +2218,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         }
 #endif /* HAVE_SECURE_RENEGOTIATION */
 
-        if (err != WOLFSSL_ERROR_ZERO_RETURN && echoData == 0 &&
-                                                              throughput == 0) {
+        if (err == 0 && echoData == 0 && throughput == 0) {
             const char* write_msg;
             int write_msg_sz;
 
@@ -2247,7 +2247,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 ServerRead(ssl, input, sizeof(input)-1);
 #endif
         }
-        else {
+        else if (err == 0 || err == WOLFSSL_ERROR_ZERO_RETURN) {
             ServerEchoData(ssl, clientfd, echoData, block, throughput);
         }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -15223,14 +15223,18 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
         ssl->error = 0;
     }
 
-#ifdef WOLFSSL_DTLS
-    if (ssl->options.dtls) {
-        /* In DTLS mode, we forgive some errors and allow the session
-         * to continue despite them. */
-        if (ssl->error == VERIFY_MAC_ERROR || ssl->error == DECRYPT_ERROR)
+    /* don't allow write after decrypt or mac error */
+    if (ssl->error == VERIFY_MAC_ERROR || ssl->error == DECRYPT_ERROR) {
+        /* For DTLS allow these possible errors and allow the session
+            to continue despite them */
+        if (ssl->options.dtls) {
             ssl->error = 0;
+        }
+        else {
+            WOLFSSL_MSG("Not allowing write after decrypt or mac error");
+            return WOLFSSL_FATAL_ERROR;
+        }
     }
-#endif /* WOLFSSL_DTLS */
 
 #ifdef WOLFSSL_EARLY_DATA
     if (ssl->earlyData != no_early_data) {


### PR DESCRIPTION
Improvement to wolfSSL_write to not allow for `VERIFY_MAC_ERROR` or `DECRYPT_ERROR` errors. This resolves possible end user application implentation issue where a wolfSSL_read failure isn't handled and a wolfSSL_write is done anyways.

Improves our support for using the example server against TLS testing tools. 

Typical syntax use is: 
RSA:  `./examples/server/server -g -i -x -d`
ECC: `./examples/server/server -g -i -x -d -c ./certs/server-ecc.pem -k./certs/ecc-key.pem`