### PR TITLE
EVP Init Fix

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14251,8 +14251,10 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
              ret = wolfSSL_SHA_Init(&(ctx->hash.digest.sha));
         }
     #endif /* NO_SHA */
-        else
+        else {
+             ctx->macType = WC_HASH_TYPE_NONE;
              return BAD_FUNC_ARG;
+        }
 
         return ret;
     }


### PR DESCRIPTION
When calling wolfSSL_EVP_DigestInit() with an unsupported string, the macType should be set to NONE, rather than ignored. In a particular build combination, functions using that EVP could false the type because of memory garbage. Just set it in the else case.