### PR TITLE
Increased ciphers buffer size for testsuite and ECC API for getting curve from dp

### DIFF
--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -1372,7 +1372,7 @@ int bench_tls(void* args)
         if (ciphers == NULL) {
             goto exit;
         }
-        wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
+        wolfSSL_get_ciphers(ciphers, WOLFSSL_CIPHER_LIST_MAX_SIZE);
         cipher = ciphers;
     }
 

--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -1230,7 +1230,7 @@ static void Usage(void)
 
 static void ShowCiphers(void)
 {
-    char ciphers[4096];
+    char ciphers[WOLFSSL_CIPHER_LIST_MAX_SIZE];
 
     int ret = wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
 
@@ -1368,12 +1368,11 @@ int bench_tls(void* args)
     }
     else {
         /* Run for each cipher */
-        const int ciphersSz = 4096;
-        ciphers = (char*)XMALLOC(ciphersSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        ciphers = (char*)XMALLOC(WOLFSSL_CIPHER_LIST_MAX_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (ciphers == NULL) {
             goto exit;
         }
-        wolfSSL_get_ciphers(ciphers, ciphersSz);
+        wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
         cipher = ciphers;
     }
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -195,7 +195,7 @@ static int NonBlockingSSL_Connect(WOLFSSL* ssl)
 
 static void ShowCiphers(void)
 {
-    static char ciphers[4096];
+    static char ciphers[WOLFSSL_CIPHER_LIST_MAX_SIZE];
 
     int ret = wolfSSL_get_ciphers(ciphers, (int)sizeof(ciphers));
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -22719,22 +22719,21 @@ static void test_wc_ecc_get_curve_id_from_dp_params(void)
     #if !defined(NO_ECC256) && !defined(NO_ECC_SECP)
         id = wc_ecc_get_curve_id_from_name("SECP256R1");
         AssertIntEQ(id, ECC_SECP256R1);
+
+        ecKey = wolfSSL_EC_KEY_new_by_curve_name(id);
+        AssertNotNull(ecKey);
+
+        ret = wolfSSL_EC_KEY_generate_key(ecKey);
+
+        if (ret == 0) {
+            /* normal test */
+            key = (ecc_key*)ecKey->internal;
+            params = key->dp;
+
+            curve_id = wc_ecc_get_curve_id_from_dp_params(params);
+            AssertIntEQ(curve_id, id);
+        }
     #endif
-
-    ecKey = wolfSSL_EC_KEY_new_by_curve_name(id);
-    AssertNotNull(ecKey);
-
-    ret = wolfSSL_EC_KEY_generate_key(ecKey);
-
-    if (ret == 0) {
-        /* normal test */
-        key = (ecc_key*)ecKey->internal;
-        params = key->dp;
-
-        curve_id = wc_ecc_get_curve_id_from_dp_params(params);
-        AssertIntEQ(curve_id, id);
-    }
-
     /* invalid case, NULL input*/
 
     id = wc_ecc_get_curve_id_from_dp_params(NULL);

--- a/tests/api.c
+++ b/tests/api.c
@@ -22739,6 +22739,7 @@ static void test_wc_ecc_get_curve_id_from_dp_params(void)
 
     id = wc_ecc_get_curve_id_from_dp_params(NULL);
     AssertIntEQ(id, BAD_FUNC_ARG);
+    wolfSSL_EC_KEY_free(ecKey);
 
     printf(resultFmt, passed);
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -22701,10 +22701,12 @@ static void test_wc_ecc_get_curve_id_from_name(void)
 #endif /* HAVE_ECC */
 }
 
-#if defined(OPENSSL_EXTRA)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_ECC) && \
+    !defined(HAVE_SELFTEST) && \
+    !(defined(HAVE_FIPS) || defined(HAVE_FIPS_VERSION))
+
 static void test_wc_ecc_get_curve_id_from_dp_params(void)
 {
-#ifdef HAVE_ECC
     int id;
     int curve_id;
     int ret = 0;
@@ -22739,9 +22741,8 @@ static void test_wc_ecc_get_curve_id_from_dp_params(void)
     AssertIntEQ(id, BAD_FUNC_ARG);
 
     printf(resultFmt, passed);
-#endif /* HAVE_ECC */
 }
-#endif /* OPENSSL_EXTRA */
+#endif /* defined(OPENSSL_EXTRA) && defined(HAVE_ECC) */
 
 static void test_wc_ecc_get_curve_id_from_params(void)
 {
@@ -24689,6 +24690,10 @@ void ApiTest(void)
     test_wolfSSL_EVP_get_cipherbynid();
     test_wolfSSL_EC();
     test_wolfSSL_ECDSA_SIG();
+#endif
+#if defined(OPENSSL_EXTRA) && defined(HAVE_ECC) && \
+    !defined(HAVE_SELFTEST) && \
+    !(defined(HAVE_FIPS) || defined(HAVE_FIPS_VERSION))
     test_wc_ecc_get_curve_id_from_dp_params();
 #endif
 

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -180,7 +180,7 @@ int testsuite_test(int argc, char** argv)
 
     /* show ciphers */
     {
-        char ciphers[1024*2];
+        char ciphers[WOLFSSL_CIPHER_LIST_MAX_SIZE];
         XMEMSET(ciphers, 0, sizeof(ciphers));
         wolfSSL_get_ciphers(ciphers, sizeof(ciphers)-1);
         printf("ciphers = %s\n", ciphers);

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -180,7 +180,7 @@ int testsuite_test(int argc, char** argv)
 
     /* show ciphers */
     {
-        char ciphers[1024];
+        char ciphers[1024*2];
         XMEMSET(ciphers, 0, sizeof(ciphers));
         wolfSSL_get_ciphers(ciphers, sizeof(ciphers)-1);
         printf("ciphers = %s\n", ciphers);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3190,6 +3190,9 @@ static int wc_ecc_cmp_param(const char* curveParam,
     if (param == NULL || curveParam == NULL)
         return BAD_FUNC_ARG;
 
+    if (encType == WC_TYPE_HEX_STR)
+        return XSTRNCMP(curveParam, (char*) param, paramSz);
+
 #ifdef WOLFSSL_SMALL_STACK
     a = (mp_int*)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_ECC);
     if (a == NULL)
@@ -3210,10 +3213,7 @@ static int wc_ecc_cmp_param(const char* curveParam,
     }
 
     if (err == MP_OKAY) {
-        if (encType == WC_TYPE_HEX_STR)
-            err = mp_read_radix(a, (char*) param, MP_RADIX_HEX);
-        else
-            err = mp_read_unsigned_bin(a, param, paramSz);
+        err = mp_read_unsigned_bin(a, param, paramSz);
     }
     if (err == MP_OKAY)
         err = mp_read_radix(b, curveParam, MP_RADIX_HEX);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3307,9 +3307,6 @@ int wc_ecc_get_curve_id_from_dp_params(const ecc_set_type* dp)
 {
     int idx;
 
-    if (dp == NULL)
-        return BAD_FUNC_ARG;
-
     if (dp == NULL || dp->prime == NULL ||  dp->Af == NULL ||
         dp->Bf == NULL || dp->order == NULL || dp->Gx == NULL || dp->Gy == NULL)
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3296,6 +3296,13 @@ int wc_ecc_get_curve_id_from_params(int fieldSize,
     return ecc_sets[idx].id;
 }
 
+/* Returns the curve id in ecc_sets[] that corresponds
+ * to a given domain parameters pointer.
+ *
+ * dp   domain parameters pointer
+ *
+ * return curve id, from ecc_sets[] on success, negative on error
+ */
 int wc_ecc_get_curve_id_from_dp_params(const ecc_set_type* dp)
 {
     int idx;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3173,11 +3173,11 @@ int wc_ecc_get_curve_id_from_name(const char* curveName)
 }
 
 /* Compares a curve parameter (hex, from ecc_sets[]) to given input
- * parameter (byte array) for equality.
- *
+ * parameter for equality.
+ * encType is WC_TYPE_UNSIGNED_BIN or WC_TYPE_HEX_STR
  * Returns MP_EQ on success, negative on error */
 static int wc_ecc_cmp_param(const char* curveParam,
-                            const byte* param, word32 paramSz)
+                            const byte* param, word32 paramSz, int encType)
 {
     int err = MP_OKAY;
 #ifdef WOLFSSL_SMALL_STACK
@@ -3209,9 +3209,12 @@ static int wc_ecc_cmp_param(const char* curveParam,
         return err;
     }
 
-    if (err == MP_OKAY)
-        err = mp_read_unsigned_bin(a, param, paramSz);
-
+    if (err == MP_OKAY) {
+        if (encType == WC_TYPE_HEX_STR)
+            err = mp_read_radix(a, (char*) param, MP_RADIX_HEX);
+        else
+            err = mp_read_unsigned_bin(a, param, paramSz);
+    }
     if (err == MP_OKAY)
         err = mp_read_radix(b, curveParam, MP_RADIX_HEX);
 
@@ -3270,14 +3273,55 @@ int wc_ecc_get_curve_id_from_params(int fieldSize,
     for (idx = 0; ecc_sets[idx].size != 0; idx++) {
         if (curveSz == ecc_sets[idx].size) {
             if ((wc_ecc_cmp_param(ecc_sets[idx].prime, prime,
-                            primeSz) == MP_EQ) &&
-                (wc_ecc_cmp_param(ecc_sets[idx].Af, Af, AfSz) == MP_EQ) &&
-                (wc_ecc_cmp_param(ecc_sets[idx].Bf, Bf, BfSz) == MP_EQ) &&
+                            primeSz, WC_TYPE_UNSIGNED_BIN) == MP_EQ) &&
+                (wc_ecc_cmp_param(ecc_sets[idx].Af, Af, AfSz,
+                                  WC_TYPE_UNSIGNED_BIN) == MP_EQ) &&
+                (wc_ecc_cmp_param(ecc_sets[idx].Bf, Bf, BfSz,
+                                  WC_TYPE_UNSIGNED_BIN) == MP_EQ) &&
                 (wc_ecc_cmp_param(ecc_sets[idx].order, order,
-                                  orderSz) == MP_EQ) &&
-                (wc_ecc_cmp_param(ecc_sets[idx].Gx, Gx, GxSz) == MP_EQ) &&
-                (wc_ecc_cmp_param(ecc_sets[idx].Gy, Gy, GySz) == MP_EQ) &&
+                                  orderSz, WC_TYPE_UNSIGNED_BIN) == MP_EQ) &&
+                (wc_ecc_cmp_param(ecc_sets[idx].Gx, Gx, GxSz,
+                                  WC_TYPE_UNSIGNED_BIN) == MP_EQ) &&
+                (wc_ecc_cmp_param(ecc_sets[idx].Gy, Gy, GySz,
+                                  WC_TYPE_UNSIGNED_BIN) == MP_EQ) &&
                 (cofactor == ecc_sets[idx].cofactor)) {
+                    break;
+            }
+        }
+    }
+
+    if (ecc_sets[idx].size == 0)
+        return ECC_CURVE_INVALID;
+
+    return ecc_sets[idx].id;
+}
+
+int wc_ecc_get_curve_id_from_dp_params(const ecc_set_type* dp)
+{
+    int idx;
+
+    if (dp == NULL)
+        return BAD_FUNC_ARG;
+
+    if (dp == NULL || dp->prime == NULL ||  dp->Af == NULL ||
+        dp->Bf == NULL || dp->order == NULL || dp->Gx == NULL || dp->Gy == NULL)
+        return BAD_FUNC_ARG;
+
+    for (idx = 0; ecc_sets[idx].size != 0; idx++) {
+        if (dp->size == ecc_sets[idx].size) {
+            if ((wc_ecc_cmp_param(ecc_sets[idx].prime, (const byte*)dp->prime,
+                    (word32)XSTRLEN(dp->prime), WC_TYPE_HEX_STR) == MP_EQ) &&
+                (wc_ecc_cmp_param(ecc_sets[idx].Af, (const byte*)dp->Af,
+                    (word32)XSTRLEN(dp->Af),WC_TYPE_HEX_STR) == MP_EQ) &&
+                (wc_ecc_cmp_param(ecc_sets[idx].Bf, (const byte*)dp->Bf,
+                    (word32)XSTRLEN(dp->Bf),WC_TYPE_HEX_STR) == MP_EQ) &&
+                (wc_ecc_cmp_param(ecc_sets[idx].order, (const byte*)dp->order,
+                    (word32)XSTRLEN(dp->order),WC_TYPE_HEX_STR) == MP_EQ) &&
+                (wc_ecc_cmp_param(ecc_sets[idx].Gx, (const byte*)dp->Gx,
+                    (word32)XSTRLEN(dp->Gx),WC_TYPE_HEX_STR) == MP_EQ) &&
+                (wc_ecc_cmp_param(ecc_sets[idx].Gy, (const byte*)dp->Gy,
+                    (word32)XSTRLEN(dp->Gy),WC_TYPE_HEX_STR) == MP_EQ) &&
+                (dp->cofactor == ecc_sets[idx].cofactor)) {
                     break;
             }
         }

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -155,10 +155,12 @@
     #pragma warning(disable:4244 4996)
 #endif
 
-#define WOLFSSL_CIPHER_LIST_MAX_SIZE 4096
+#ifndef WOLFSSL_CIPHER_LIST_MAX_SIZE
+    #define WOLFSSL_CIPHER_LIST_MAX_SIZE 4096
+#endif
 /* Buffer for benchmark tests */
 #ifndef TEST_BUFFER_SIZE
-#define TEST_BUFFER_SIZE 16384
+    #define TEST_BUFFER_SIZE 16384
 #endif
 
 #ifndef WOLFSSL_HAVE_MIN

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -155,6 +155,7 @@
     #pragma warning(disable:4244 4996)
 #endif
 
+#define WOLFSSL_CIPHER_LIST_MAX_SIZE 4096
 /* Buffer for benchmark tests */
 #ifndef TEST_BUFFER_SIZE
 #define TEST_BUFFER_SIZE 16384

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -501,6 +501,8 @@ int wc_ecc_get_curve_id_from_params(int fieldSize,
         const byte* prime, word32 primeSz, const byte* Af, word32 AfSz,
         const byte* Bf, word32 BfSz, const byte* order, word32 orderSz,
         const byte* Gx, word32 GxSz, const byte* Gy, word32 GySz, int cofactor);
+WOLFSSL_API
+int wc_ecc_get_curve_id_from_dp_params(const ecc_set_type* dp);
 
 WOLFSSL_API
 int wc_ecc_get_curve_id_from_oid(const byte* oid, word32 len);


### PR DESCRIPTION
This PR provides a fix in the test suite and expands functionality in ECC: 

- Increased test suite ciphers buffer size (ticket #5000))
- Enhancement to support ECC domain param HEX string or unsigned bin comparison (ticket #5035)

zendesk ticket #5000:
There were three TLS13-* cipher suites missing from the 'ciphers' list because the buffer was not large enough to hold all the ciphers. 

Steps to reproduce:
./configure --enable-tls13 --enable-aesccm --enable-jni --enable-keygen && make && testsuite/testsuite.test

With the suggested changes, you will see all five TLS13-* ciphers at the end of the list. 
ciphers =  ...
TLS13-AES128-GCM-SHA256:TLS13-AES256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256:TLS13-AES128-CCM-SHA256:TLS13-AES128-CCM-8-SHA256

zendesk ticket #5035: 
Adds support to get curve id from dp params. 

Here's a fragment of code from a user working with JCE JNI that didn't return a correct curve-id of an ECC key. 
...
void paramTest(WOLFSSL_EC_KEY* ecKey, const char *inName)
{
    // get params from key
    ecc_key* key = (ecc_key*)ecKey->internal;
    const ecc_set_type* params = key->dp;
    int n = params->size;
    const unsigned char* p = params->prime;
    const unsigned char* a = params->Af;
    const unsigned char* b = params->Bf;
    const unsigned char* o = params->order;
    const unsigned char* x = params->Gx;
    const unsigned char* y = params->Gy;
    int c = params->cofactor;

    // get id from params
    int curve_id = wc_ecc_get_curve_id_from_params(n*8,
                                                   p, strlen(p),
                                                   a, strlen(a),
                                                   b, strlen(b),
                                                   o, strlen(o),
                                                   x, strlen(x),
                                                   y, strlen(y),
                                                   c);
    if (curve_id > 0)
    {
...

The issue was that the value of the domain parameters must be converted from HEX string to unsigned bin before calling wc_ecc_get_curve_id_from_params().  

The new wc_ecc_get_curve_id_from_dp_params() simplifies the need to do the conversion and you can call it:
    curve_id = wc_ecc_get_curve_id_from_dp_params(params);

