### PR TITLE
FIPS Fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2305,6 +2305,9 @@ AC_ARG_ENABLE([fips],
 if test "x$ENABLED_FIPS" != "xno"
 then
     FIPS_VERSION=$ENABLED_FIPS
+    AS_IF([test "x$FIPS_VERSION" = "xready"],
+          [FIPS_READY="yes"; FIPS_VERSION="v2"],
+          [FIPS_READY="no"])
     ENABLED_FIPS=yes
     # requires thread local storage
     if test "$thread_ls_on" = "no"
@@ -2369,6 +2372,7 @@ fi
 
 AM_CONDITIONAL([BUILD_FIPS], [test "x$ENABLED_FIPS" = "xyes"])
 AM_CONDITIONAL([BUILD_FIPS_V2], [test "x$FIPS_VERSION" = "xv2"])
+AM_CONDITIONAL([BUILD_FIPS_READY], [test "x$FIPS_READY" = "xyes"])
 AM_CONDITIONAL([BUILD_CMAC], [test "x$ENABLED_CMAC" = "xyes"])
 
 # SELFTEST

--- a/src/include.am
+++ b/src/include.am
@@ -70,6 +70,12 @@ src_libwolfssl_la_SOURCES += \
                wolfcrypt/src/random.c \
                wolfcrypt/src/sha256.c
 
+if BUILD_INTELASM
+if BUILD_FIPS_READY
+src_libwolfssl_la_SOURCES += wolfcrypt/src/sha256_asm.S
+endif
+endif
+
 if BUILD_RSA
 src_libwolfssl_la_SOURCES += wolfcrypt/src/rsa.c
 endif
@@ -84,6 +90,9 @@ endif
 
 if BUILD_AESNI
 src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_asm.S
+if BUILD_FIPS_READY
+src_libwolfssl_la_SOURCES += wolfcrypt/src/aes_gcm_asm.S
+endif
 endif
 
 if BUILD_DES3
@@ -96,6 +105,11 @@ endif
 
 if BUILD_SHA512
 src_libwolfssl_la_SOURCES += wolfcrypt/src/sha512.c
+if BUILD_INTELASM
+if BUILD_FIPS_READY
+src_libwolfssl_la_SOURCES += wolfcrypt/src/sha512_asm.S
+endif
+endif
 endif
 
 if BUILD_SHA3

--- a/tests/api.c
+++ b/tests/api.c
@@ -20358,6 +20358,10 @@ static void test_wolfSSL_PKCS8_Compat(void)
 
 static void test_wolfSSL_PKCS8_d2i(void)
 {
+#ifndef WOLFSSL_FIPS
+    /* This test ends up using HMAC as a part of PBKDF2, and HMAC
+     * requires a 12 byte password in FIPS mode. This test ends up
+     * trying to use an 8 byte password. */
 #ifdef OPENSSL_ALL
     WOLFSSL_EVP_PKEY* pkey = NULL;
 #ifndef NO_FILESYSTEM
@@ -20511,6 +20515,7 @@ static void test_wolfSSL_PKCS8_d2i(void)
 
     printf(resultFmt, passed);
 #endif
+#endif /* WOLFSSL_FIPS */
 }
 
 static void test_wolfSSL_ERR_put_error(void)

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -1628,7 +1628,8 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
         #endif
 
         /* if input and output same will overwrite input iv */
-        XMEMCPY(aes->tmp, inBlock, AES_BLOCK_SIZE);
+        if ((const byte*)aes->tmp != inBlock)
+            XMEMCPY(aes->tmp, inBlock, AES_BLOCK_SIZE);
         AES_ECB_decrypt(inBlock, outBlock, AES_BLOCK_SIZE, (byte*)aes->key,
                         aes->rounds);
         return;


### PR DESCRIPTION
Discovered a few FIPS build issues.
1. Added an inline patch to the fips-check script that adds a change to aes.c so it doesn't error out with the inline assembly on macOS builds.
2. When using the OpenSSL ALL build with FIPSv2 and IntelASM enabled, a test case fails because HMAC in FIPSs mode rejects keys shorter than 12 bytes.
3. Due to some changes in the location of assembly source code, the FIPS Ready build with IntelASM doesn't work, this is fixed with adding an enable for fips=ready.
4. Incidental additional check by GCC-8 on macOS found a potential call to memcpy of data over itself. Added a check to see if the pointers are the same.