### PR TITLE
Fix for an OCSP Response signed by issuer

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8137,8 +8137,10 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
     #ifndef NO_SKID
             if (cert->extAuthKeyIdSet)
                 cert->ca = GetCA(cm, cert->extAuthKeyId);
-            if (cert->ca == NULL && cert->extSubjKeyIdSet)
+            if (cert->ca == NULL && cert->extSubjKeyIdSet \
+                                 && verify != VERIFY_OCSP) {
                 cert->ca = GetCA(cm, cert->extSubjKeyId);
+            }
             if (cert->ca == NULL)
                 cert->ca = GetCAByName(cm, cert->issuerHash);
 


### PR DESCRIPTION
Fixes a case where an OCSP Response signed by the issuer which is already loaded as a CA with the 
Same Subject Key Identifier (SKID) and issuer name. 

For internal reference: 
PR#2147 fixes zendesk ticket#4615
But it becomes a problem for zendesk ticket#4963. 
This PR resolves both #4615 and #4963.
