### PR TITLE
Making DSA signature sizes configurable

### DIFF
--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -42,14 +42,6 @@
     #include <wolfcrypt/src/misc.c>
 #endif
 
-
-enum {
-    DSA_HALF_SIZE = 20,   /* r and s size  */
-    DSA_SIG_SIZE  = 40    /* signature size */
-};
-
-
-
 int wc_InitDsaKey(DsaKey* key)
 {
     if (key == NULL)

--- a/wolfssl/wolfcrypt/dsa.h
+++ b/wolfssl/wolfcrypt/dsa.h
@@ -46,6 +46,12 @@
     extern "C" {
 #endif
 
+#ifndef DSA_HALF_SIZE
+  #define DSA_HALF_SIZE 20    /* r and s size  */
+#endif
+#ifndef DSA_SIG_SIZE          /* signature size */
+  #define DSA_SIG_SIZE  2*DSA_HALF_SIZE
+#endif
 
 enum {
     DSA_PUBLIC   = 0,


### PR DESCRIPTION
Zendesk ticket #5068.

Currently, a hardcoded 320-bit long DSA signature is supported.
This change will allow signature sizes 448 and 512-bits long. 
