### PR TITLE
Remove leading unicode UTF-8 BOM characters

### DIFF
--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -1,4 +1,4 @@
-﻿/* atmel.c
+/* atmel.c
  *
  * Copyright (C) 2006-2019 wolfSSL Inc.
  *


### PR DESCRIPTION
Remove leading unicode UTF-8[a] BOM characters (EF BB BF). Searched through repo and atmel.c was only one.