### PR TITLE
Fix issue with ECC signature size leaking memory with normal math

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4310,6 +4310,7 @@ static int wc_ecc_get_curve_order_bit_count(const ecc_set_type* dp)
     }
     orderBits = mp_count_bits(curve->order);
 
+    wc_ecc_curve_free(curve);
     FREE_CURVE_SPECS();
     return (int)orderBits;
 }


### PR DESCRIPTION
Fix for issue with new `wc_ecc_get_curve_order_bit_count` function not free'ing memory when used with normal math. Started in https://github.com/wolfSSL/wolfssl/pull/2201