### PR TITLE
send handshake failure alert to a server

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7259,7 +7259,11 @@ static int GetRecordHeader(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             WOLFSSL_MSG("SSL version error");
             /* send alert per RFC5246 Appendix E. Backward Compatibility */
             if (ssl->options.side == WOLFSSL_CLIENT_END) {
+#ifdef WOLFSSL_MYSQL_COMPATIBLE
+                SendAlert(ssl, alert_fatal, wc_protocol_version);
+#else
                 SendAlert(ssl, alert_fatal, protocol_version);
+#endif
             }
             return VERSION_ERROR;              /* only use requested version */
         }

--- a/src/internal.c
+++ b/src/internal.c
@@ -7257,6 +7257,10 @@ static int GetRecordHeader(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             WOLFSSL_MSG("DTLS handshake, skip RH version number check");
         else {
             WOLFSSL_MSG("SSL version error");
+            /* send alert per RFC 5246 Section 7.2.1 */
+            if(ssl->options.side == WOLFSSL_CLIENT_END) {
+                SendAlert(ssl, alert_fatal, handshake_failure);
+            }
             return VERSION_ERROR;              /* only use requested version */
         }
     }

--- a/src/internal.c
+++ b/src/internal.c
@@ -7257,9 +7257,9 @@ static int GetRecordHeader(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             WOLFSSL_MSG("DTLS handshake, skip RH version number check");
         else {
             WOLFSSL_MSG("SSL version error");
-            /* send alert per RFC 5246 Section 7.2.1 */
-            if(ssl->options.side == WOLFSSL_CLIENT_END) {
-                SendAlert(ssl, alert_fatal, handshake_failure);
+            /* send alert per RFC5246 Appendix E. Backward Compatibility */
+            if (ssl->options.side == WOLFSSL_CLIENT_END) {
+                SendAlert(ssl, alert_fatal, protocol_version);
             }
             return VERSION_ERROR;              /* only use requested version */
         }


### PR DESCRIPTION
ZD ticket 5055:

When connecting from a client configured with TLS 1.3 to a server with TLS 1.2, the client encounters an  'SSL version error' and it closes the socket without notifying the server. 

With the proposed changes, the client sends a fatal handshake_failure alert message before closing the socket. 

Wireshark capture displays the handshake alert message before RST,ACK. 
...
'TLSv1.1 73  Alert (Level: Fatal, Description: Handshake Failure)'
'TCP 66  49590 → 11111 [RST, ACK]'
...