### PR TITLE
Micrium Updates

### DIFF
--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -39,9 +39,9 @@
  */
 
 #ifdef NO_INLINE
-    #define STATIC
+    #define WC_STATIC
 #else
-    #define STATIC static
+    #define WC_STATIC static
 #endif
 
 /* Check for if compiling misc.c when not needed. */
@@ -66,25 +66,25 @@
      * i.e., _rotl and _rotr */
     #pragma intrinsic(_lrotl, _lrotr)
 
-    STATIC WC_INLINE word32 rotlFixed(word32 x, word32 y)
+    WC_STATIC WC_INLINE word32 rotlFixed(word32 x, word32 y)
     {
         return y ? _lrotl(x, y) : x;
     }
 
-    STATIC WC_INLINE word32 rotrFixed(word32 x, word32 y)
+    WC_STATIC WC_INLINE word32 rotrFixed(word32 x, word32 y)
     {
         return y ? _lrotr(x, y) : x;
     }
 
 #else /* generic */
 
-    STATIC WC_INLINE word32 rotlFixed(word32 x, word32 y)
+    WC_STATIC WC_INLINE word32 rotlFixed(word32 x, word32 y)
     {
         return (x << y) | (x >> (sizeof(y) * 8 - y));
     }
 
 
-    STATIC WC_INLINE word32 rotrFixed(word32 x, word32 y)
+    WC_STATIC WC_INLINE word32 rotrFixed(word32 x, word32 y)
     {
         return (x >> y) | (x << (sizeof(y) * 8 - y));
     }
@@ -92,7 +92,7 @@
 #endif
 
 
-STATIC WC_INLINE word32 ByteReverseWord32(word32 value)
+WC_STATIC WC_INLINE word32 ByteReverseWord32(word32 value)
 {
 #ifdef PPC_INTRINSICS
     /* PPC: load reverse indexed instruction */
@@ -116,7 +116,7 @@ STATIC WC_INLINE word32 ByteReverseWord32(word32 value)
 }
 
 
-STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
+WC_STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
                                     word32 byteCount)
 {
     word32 count = byteCount/(word32)sizeof(word32), i;
@@ -130,19 +130,19 @@ STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
 #if defined(WORD64_AVAILABLE) && !defined(WOLFSSL_NO_WORD64_OPS)
 
 
-STATIC WC_INLINE word64 rotlFixed64(word64 x, word64 y)
+WC_STATIC WC_INLINE word64 rotlFixed64(word64 x, word64 y)
 {
     return (x << y) | (x >> (sizeof(y) * 8 - y));
 }
 
 
-STATIC WC_INLINE word64 rotrFixed64(word64 x, word64 y)
+WC_STATIC WC_INLINE word64 rotrFixed64(word64 x, word64 y)
 {
     return (x >> y) | (x << (sizeof(y) * 8 - y));
 }
 
 
-STATIC WC_INLINE word64 ByteReverseWord64(word64 value)
+WC_STATIC WC_INLINE word64 ByteReverseWord64(word64 value)
 {
 #if defined(WOLF_ALLOW_BUILTIN) && defined(__GNUC_PREREQ) && __GNUC_PREREQ(4, 3)
     return (word64)__builtin_bswap64(value);
@@ -159,7 +159,7 @@ STATIC WC_INLINE word64 ByteReverseWord64(word64 value)
 }
 
 
-STATIC WC_INLINE void ByteReverseWords64(word64* out, const word64* in,
+WC_STATIC WC_INLINE void ByteReverseWords64(word64* out, const word64* in,
                                       word32 byteCount)
 {
     word32 count = byteCount/(word32)sizeof(word64), i;
@@ -172,7 +172,7 @@ STATIC WC_INLINE void ByteReverseWords64(word64* out, const word64* in,
 #endif /* WORD64_AVAILABLE && !WOLFSSL_NO_WORD64_OPS */
 
 #ifndef WOLFSSL_NO_XOR_OPS
-STATIC WC_INLINE void XorWords(wolfssl_word* r, const wolfssl_word* a, word32 n)
+WC_STATIC WC_INLINE void XorWords(wolfssl_word* r, const wolfssl_word* a, word32 n)
 {
     word32 i;
 
@@ -180,7 +180,7 @@ STATIC WC_INLINE void XorWords(wolfssl_word* r, const wolfssl_word* a, word32 n)
 }
 
 
-STATIC WC_INLINE void xorbuf(void* buf, const void* mask, word32 count)
+WC_STATIC WC_INLINE void xorbuf(void* buf, const void* mask, word32 count)
 {
     if (((wolfssl_word)buf | (wolfssl_word)mask | count) % WOLFSSL_WORD_SIZE == 0)
         XorWords( (wolfssl_word*)buf,
@@ -197,7 +197,7 @@ STATIC WC_INLINE void xorbuf(void* buf, const void* mask, word32 count)
 
 #ifndef WOLFSSL_NO_FORCE_ZERO
 /* Make sure compiler doesn't skip */
-STATIC WC_INLINE void ForceZero(const void* mem, word32 len)
+WC_STATIC WC_INLINE void ForceZero(const void* mem, word32 len)
 {
     volatile byte* z = (volatile byte*)mem;
 
@@ -223,7 +223,7 @@ STATIC WC_INLINE void ForceZero(const void* mem, word32 len)
 
 #ifndef WOLFSSL_NO_CONST_CMP
 /* check all length bytes for equality, return 0 on success */
-STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b, int length)
+WC_STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b, int length)
 {
     int i;
     int compareSum = 0;
@@ -242,7 +242,7 @@ STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b, int length)
     #if defined(HAVE_FIPS) && !defined(min) /* so ifdef check passes */
         #define min min
     #endif
-    STATIC WC_INLINE word32 min(word32 a, word32 b)
+    WC_STATIC WC_INLINE word32 min(word32 a, word32 b)
     {
         return a > b ? b : a;
     }
@@ -253,7 +253,7 @@ STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b, int length)
     #if defined(HAVE_FIPS) && !defined(max) /* so ifdef check passes */
         #define max max
     #endif
-    STATIC WC_INLINE word32 max(word32 a, word32 b)
+    WC_STATIC WC_INLINE word32 max(word32 a, word32 b)
     {
         return a > b ? a : b;
     }
@@ -261,7 +261,7 @@ STATIC WC_INLINE int ConstantCompare(const byte* a, const byte* b, int length)
 
 #ifndef WOLFSSL_NO_INT_ENCODE
 /* converts a 32 bit integer to 24 bit */
-STATIC WC_INLINE void c32to24(word32 in, word24 out)
+WC_STATIC WC_INLINE void c32to24(word32 in, word24 out)
 {
     out[0] = (in >> 16) & 0xff;
     out[1] = (in >>  8) & 0xff;
@@ -269,14 +269,14 @@ STATIC WC_INLINE void c32to24(word32 in, word24 out)
 }
 
 /* convert 16 bit integer to opaque */
-STATIC WC_INLINE void c16toa(word16 wc_u16, byte* c)
+WC_STATIC WC_INLINE void c16toa(word16 wc_u16, byte* c)
 {
     c[0] = (wc_u16 >> 8) & 0xff;
     c[1] =  wc_u16 & 0xff;
 }
 
 /* convert 32 bit integer to opaque */
-STATIC WC_INLINE void c32toa(word32 wc_u32, byte* c)
+WC_STATIC WC_INLINE void c32toa(word32 wc_u32, byte* c)
 {
     c[0] = (wc_u32 >> 24) & 0xff;
     c[1] = (wc_u32 >> 16) & 0xff;
@@ -287,32 +287,32 @@ STATIC WC_INLINE void c32toa(word32 wc_u32, byte* c)
 
 #ifndef WOLFSSL_NO_INT_DECODE
 /* convert a 24 bit integer into a 32 bit one */
-STATIC WC_INLINE void c24to32(const word24 wc_u24, word32* wc_u32)
+WC_STATIC WC_INLINE void c24to32(const word24 wc_u24, word32* wc_u32)
 {
     *wc_u32 = ((word32)wc_u24[0] << 16) | (wc_u24[1] << 8) | wc_u24[2];
 }
 
 
 /* convert opaque to 24 bit integer */
-STATIC WC_INLINE void ato24(const byte* c, word32* wc_u24)
+WC_STATIC WC_INLINE void ato24(const byte* c, word32* wc_u24)
 {
     *wc_u24 = ((word32)c[0] << 16) | (c[1] << 8) | c[2];
 }
 
 /* convert opaque to 16 bit integer */
-STATIC WC_INLINE void ato16(const byte* c, word16* wc_u16)
+WC_STATIC WC_INLINE void ato16(const byte* c, word16* wc_u16)
 {
     *wc_u16 = (word16) ((c[0] << 8) | (c[1]));
 }
 
 /* convert opaque to 32 bit integer */
-STATIC WC_INLINE void ato32(const byte* c, word32* wc_u32)
+WC_STATIC WC_INLINE void ato32(const byte* c, word32* wc_u32)
 {
     *wc_u32 = ((word32)c[0] << 24) | ((word32)c[1] << 16) | (c[2] << 8) | c[3];
 }
 
 
-STATIC WC_INLINE word32 btoi(byte b)
+WC_STATIC WC_INLINE word32 btoi(byte b)
 {
     return (word32)(b - 0x30);
 }
@@ -321,63 +321,63 @@ STATIC WC_INLINE word32 btoi(byte b)
 
 #ifndef WOLFSSL_NO_CT_OPS
 /* Constant time - mask set when a > b. */
-STATIC WC_INLINE byte ctMaskGT(int a, int b)
+WC_STATIC WC_INLINE byte ctMaskGT(int a, int b)
 {
     return (((word32)a - b - 1) >> 31) - 1;
 }
 
 /* Constant time - mask set when a >= b. */
-STATIC WC_INLINE byte ctMaskGTE(int a, int b)
+WC_STATIC WC_INLINE byte ctMaskGTE(int a, int b)
 {
     return (((word32)a - b    ) >> 31) - 1;
 }
 
 /* Constant time - mask set when a < b. */
-STATIC WC_INLINE byte ctMaskLT(int a, int b)
+WC_STATIC WC_INLINE byte ctMaskLT(int a, int b)
 {
     return (((word32)b - a - 1) >> 31) - 1;
 }
 
 /* Constant time - mask set when a <= b. */
-STATIC WC_INLINE byte ctMaskLTE(int a, int b)
+WC_STATIC WC_INLINE byte ctMaskLTE(int a, int b)
 {
     return (((word32)b - a    ) >> 31) - 1;
 }
 
 /* Constant time - mask set when a == b. */
-STATIC WC_INLINE byte ctMaskEq(int a, int b)
+WC_STATIC WC_INLINE byte ctMaskEq(int a, int b)
 {
     return 0 - (a == b);
 }
 
 /* Constant time - mask set when a != b. */
-STATIC WC_INLINE byte ctMaskNotEq(int a, int b)
+WC_STATIC WC_INLINE byte ctMaskNotEq(int a, int b)
 {
     return 0 - (a != b);
 }
 
 /* Constant time - select a when mask is set and b otherwise. */
-STATIC WC_INLINE byte ctMaskSel(byte m, byte a, byte b)
+WC_STATIC WC_INLINE byte ctMaskSel(byte m, byte a, byte b)
 {
     return (b & ((byte)~(word32)m)) | (a & m);
 }
 
 /* Constant time - select integer a when mask is set and integer b otherwise. */
-STATIC WC_INLINE int ctMaskSelInt(byte m, int a, int b)
+WC_STATIC WC_INLINE int ctMaskSelInt(byte m, int a, int b)
 {
     return (b & (~(signed int)(signed char)m)) |
            (a & ( (signed int)(signed char)m));
 }
 
 /* Constant time - bit set when a <= b. */
-STATIC WC_INLINE byte ctSetLTE(int a, int b)
+WC_STATIC WC_INLINE byte ctSetLTE(int a, int b)
 {
     return ((word32)a - b - 1) >> 31;
 }
 #endif
 
 
-#undef STATIC
+#undef WC_STATIC
 
 #endif /* !WOLFSSL_MISC_INCLUDED && !NO_INLINE */
 

--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -121,7 +121,7 @@
 
     /* if defined to not using inline then declare function prototypes */
     #ifdef NO_INLINE
-        #define STATIC
+        #define WC_STATIC
 		#ifdef WOLFSSL_DEBUG_MEMORY
 			WOLFSSL_LOCAL void* TrackMalloc(size_t sz, const char* func, unsigned int line);
 			WOLFSSL_LOCAL void TrackFree(void* ptr, const char* func, unsigned int line);
@@ -134,13 +134,13 @@
         WOLFSSL_LOCAL int InitMemoryTracker(void);
         WOLFSSL_LOCAL void ShowMemoryTracker(void);
     #else
-        #define STATIC static
+        #define WC_STATIC static
     #endif
 
 #ifdef WOLFSSL_DEBUG_MEMORY
-    STATIC WC_INLINE void* TrackMalloc(size_t sz, const char* func, unsigned int line)
+    WC_STATIC WC_INLINE void* TrackMalloc(size_t sz, const char* func, unsigned int line)
 #else
-    STATIC WC_INLINE void* TrackMalloc(size_t sz)
+    WC_STATIC WC_INLINE void* TrackMalloc(size_t sz)
 #endif
     {
         memoryTrack* mt;
@@ -201,9 +201,9 @@
 
 
 #ifdef WOLFSSL_DEBUG_MEMORY
-    STATIC WC_INLINE void TrackFree(void* ptr, const char* func, unsigned int line)
+    WC_STATIC WC_INLINE void TrackFree(void* ptr, const char* func, unsigned int line)
 #else
-    STATIC WC_INLINE void TrackFree(void* ptr)
+    WC_STATIC WC_INLINE void TrackFree(void* ptr)
 #endif
     {
         memoryTrack* mt;
@@ -270,9 +270,9 @@
 
 
 #ifdef WOLFSSL_DEBUG_MEMORY
-    STATIC WC_INLINE void* TrackRealloc(void* ptr, size_t sz, const char* func, unsigned int line)
+    WC_STATIC WC_INLINE void* TrackRealloc(void* ptr, size_t sz, const char* func, unsigned int line)
 #else
-    STATIC WC_INLINE void* TrackRealloc(void* ptr, size_t sz)
+    WC_STATIC WC_INLINE void* TrackRealloc(void* ptr, size_t sz)
 #endif
     {
     #ifdef WOLFSSL_DEBUG_MEMORY
@@ -312,7 +312,7 @@
     static wolfSSL_Free_cb ffDefault = NULL;
     static wolfSSL_Realloc_cb rfDefault = NULL;
 
-    STATIC WC_INLINE int InitMemoryTracker(void)
+    WC_STATIC WC_INLINE int InitMemoryTracker(void)
     {
         int ret;
 
@@ -349,7 +349,7 @@
         return ret;
     }
 
-    STATIC WC_INLINE void ShowMemoryTracker(void)
+    WC_STATIC WC_INLINE void ShowMemoryTracker(void)
     {
     #ifdef DO_MEM_LIST
         if (pthread_mutex_lock(&memLock) == 0)
@@ -387,7 +387,7 @@
     #endif
     }
 
-    STATIC WC_INLINE int CleanupMemoryTracker(void)
+    WC_STATIC WC_INLINE int CleanupMemoryTracker(void)
     {
         /* restore default allocators */
         return wolfSSL_SetAllocators(mfDefault, ffDefault, rfDefault);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -751,7 +751,7 @@ extern void uITRON4_free(void *p) ;
         #undef SIZEOF_LONG
         #define SIZEOF_LONG_LONG 8
     #else
-        #sslpro: settings.h - please implement SIZEOF_LONG and SIZEOF_LONG_LONG
+        #error settings.h - please implement SIZEOF_LONG and SIZEOF_LONG_LONG
     #endif
 
     #define XMALLOC(s, h, type) ((void *)rtp_malloc((s), SSL_PRO_MALLOC))

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1276,12 +1276,14 @@ extern void uITRON4_free(void *p) ;
                     ((CPU_CHAR *)Str_Cat_N((CPU_CHAR *)(pstr_dest), \
                      (const CPU_CHAR *)(pstr_cat),(CPU_SIZE_T)(len_max)))
     #define XMEMSET(pmem, data_val, size) \
-                    ((void)Mem_Set((void *)(pmem), (CPU_INT08U) (data_val), \
+                    ((void)Mem_Set((void *)(pmem), \
+                    (CPU_INT08U) (data_val), \
                     (CPU_SIZE_T)(size)))
     #define XMEMCPY(pdest, psrc, size) ((void)Mem_Copy((void *)(pdest), \
                      (void *)(psrc), (CPU_SIZE_T)(size)))
     #define XMEMCMP(pmem_1, pmem_2, size) \
-                   (((CPU_BOOLEAN)Mem_Cmp((void *)(pmem_1), (void *)(pmem_2), \
+                   (((CPU_BOOLEAN)Mem_Cmp((void *)(pmem_1), \
+                                          (void *)(pmem_2), \
                      (CPU_SIZE_T)(size))) ? DEF_NO : DEF_YES)
     #define XMEMMOVE XMEMCPY
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -154,6 +154,12 @@
             #define WC_INLINE inline
         #elif defined(THREADX)
             #define WC_INLINE _Inline
+        #elif defined(__ghc__)
+            #ifndef __cplusplus
+                #define WC_INLINE __inline
+            #else
+                #define WC_INLINE inline
+            #endif
         #else
             #define WC_INLINE
         #endif


### PR DESCRIPTION
Updates for the Micrium build. They include:
1. rename a strange preprocessor directive as an "#error" because a specific compiler was complaining about it
2. added an inline flag for that compiler
3. rename the macro STATIC as WC_STATIC to avoid namespace collisions