### PR TITLE
Fix for static RSA cipher suite with PK callback and no loaded private key

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -17030,6 +17030,15 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
     int      keySz;
     word32   idx;
 
+#ifdef HAVE_PK_CALLBACKS
+    /* allow no private key if using PK callbacks and CB is set */
+    if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)) {
+        *length = GetPrivateKeySigSize(ssl);
+        return 0;
+    }
+    else
+#endif
+
     /* make sure private key exists */
     if (ssl->buffers.key == NULL || ssl->buffers.key->buffer == NULL) {
         WOLFSSL_MSG("Private key missing!");


### PR DESCRIPTION
Test case:

```
./configure --enable-debug --disable-shared --enable-pkcallbacks --enable-aes --enable-wpas CFLAGS="-DTEST_PK_PRIVKEY"
make
./examples/server/server -P -l AES128-GCM-SHA256
./examples/client/client -P -l AES128-GCM-SHA256
```

ZD 5092