### PR TITLE
Sniffer Logging

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -1605,7 +1605,7 @@ static int ProcessClientKeyExchange(const byte* input, int* sslBytes,
         }
 
         if (ret == 0) {
-            session->keySz = length * 8;
+            session->keySz = length * WOLFSSL_BIT_SIZE;
             /* length is the key size in bytes */
             session->sslServer->arrays->preMasterSz = SECRET_LEN;
 
@@ -1674,9 +1674,10 @@ static int ProcessClientKeyExchange(const byte* input, int* sslBytes,
         }
 
         if (ret == 0) {
-            session->keySz = (length - 1) * 4;
-            /* The length is the key size in bytes, times 2 for the (x,y)
-             * coordinates, plus 1 for the type. */
+            session->keySz = ((length - 1) / 2) * WOLFSSL_BIT_SIZE;
+            /* Length is in bytes. Subtract 1 for the ECC key type. Divide
+             * by two as the key is in (x,y) coordinates, where x and y are
+             * the same size, the key size. Convert from bytes to bits. */
             session->sslServer->arrays->preMasterSz = ENCRYPT_LEN;
 
             do {

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -115,6 +115,8 @@ typedef struct SSLInfo
     unsigned char  serverCipherSuite;       /* second byte, actual suite */
     unsigned char  serverCipherSuiteName[256];
             /* cipher name, e.g., "TLS_RSA_..." */
+    unsigned char  serverNameIndication[128];
+    unsigned int   keySize;
 } WOLFSSL_PACK SSLInfo;
 
 

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -125,6 +125,14 @@ SSL_SNIFFER_API int ssl_DecodePacketWithSessionInfo(
                         const unsigned char* packet, int length,
                         unsigned char** data, SSLInfo* sslInfo, char* error);
 
+typedef void (*SSLConnCb)(const void* session, SSLInfo* info, void* ctx);
+
+WOLFSSL_API
+SSL_SNIFFER_API int ssl_SetConnectionCb(SSLConnCb cb);
+
+WOLFSSL_API
+SSL_SNIFFER_API int ssl_SetConnectionCtx(void* ctx);
+
 
 #ifdef __cplusplus
     }  /* extern "C" */


### PR DESCRIPTION
1. Capture SNI in the SSLInfo record if enabled.
2. Capture private key length in the SSLInfo record.
3. Added a callback hook that is called at the end of processing the client key exchange message. The SSLInfo is passed to the callback, along with a private context, and a blind reference to the session info.