### PR TITLE
Use TLS v1.3 PSK callback in extension allow for one call in client

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1662,6 +1662,20 @@ AC_ARG_ENABLE([psk],
     [ ENABLED_PSK=no ]
     )
 
+# Single PSK identity
+AC_ARG_ENABLE([psk-one-id],
+    [AS_HELP_STRING([--enable-psk-one-id],[Enable PSK (default: disabled)])],
+    [ ENABLED_PSK_ONE_ID=$enableval ],
+    [ ENABLED_PSK_ONE_ID=no ]
+    )
+if test "$ENABLED_PSK_ONE_ID" = "yes"
+then
+    if test "$ENABLED_PSK" = "no"
+    then
+        ENABLED_PSK="yes"
+    fi
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_PSK_ONE_ID"
+fi
 
 # ERROR STRINGS
 AC_ARG_ENABLE([errorstrings],

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2394,6 +2394,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk)
 #endif
 #ifndef NO_PSK
     if (!psk->resumption) {
+    #ifndef WOLFSSL_PSK_ONE_ID
         const char* cipherName = NULL;
         byte cipherSuite0 = TLS13_BYTE, cipherSuite = WOLFSSL_DEF_PSK_CIPHER;
 
@@ -2422,6 +2423,9 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk)
                                               psk->cipherSuite != cipherSuite) {
             return PSK_KEY_ERROR;
         }
+    #else
+        /* PSK information loaded during setting of default TLS extensions. */
+    #endif
     }
 #endif
 


### PR DESCRIPTION
New compile time option WOLFSSL_PSK_ONE_ID. Indicates one identity
available. No need for client to call callback when generating binder -
already cached.