### PR TITLE
Added support for RISC-V SiFive HiFive Freedom platforms

### DIFF
--- a/IDE/ECLIPSE/SIFIVE/Makefile
+++ b/IDE/ECLIPSE/SIFIVE/Makefile
@@ -3,6 +3,7 @@ PROGRAM ?= wolfcrypt
 # This line must be added in your freedom-e-sdk/scripts/standalone.mk
 # RISCV_CFLAGS   += -I$(WOLFSSL_SRC_DIR) -I$(WOLFSSL_SRC_DIR)/IDE/ECLIPSE/SIFIVE -DWOLFSSL_USER_SETTINGS
 # WOLFSSL_SRC_DIR variable must be set in the environment when GNU make is started.
+# export WOLFSSL_SRC_DIR=~/freedom-e-sdk/software/wolfssl
 
 WOLFSSL_CFLAGS += -I$(WOLFSSL_SRC_DIR) \
 				  -I$(WOLFSSL_SRC_DIR)/IDE/ECLIPSE/SIFIVE \

--- a/IDE/ECLIPSE/SIFIVE/Makefile
+++ b/IDE/ECLIPSE/SIFIVE/Makefile
@@ -26,7 +26,8 @@ OPT_CFLAGS = -specs=nano.specs
 # The __stack_size and __heap_size symbols are defined in the linker metal.default.ld 
 # script in the freedom-e-sdk. 
 override CFLAGS += $(OPT_CFLAGS) $(WOLFSSL_CFLAGS) \
-                     -Xlinker --defsym=__stack_size=0x1000
+                     -Xlinker --defsym=__stack_size=0x1200 \
+                     -Xlinker --defsym=__heap_size=0x800
 
 $(PROGRAM): $(SRC)
 	$(CC) $(CFLAGS) $(SRC) $(LDFLAGS) $(LDLIBS) -o $@

--- a/IDE/ECLIPSE/SIFIVE/Makefile
+++ b/IDE/ECLIPSE/SIFIVE/Makefile
@@ -22,12 +22,14 @@ OPT_CFLAGS = -specs=nano.specs
 #OPT_CFLAGS += -O3 -DTIME -DNOENUM -Wno-implicit -mexplicit-relocs -save-temps
 #OPT_CFLAGS += -fno-inline -fno-builtin-printf -fno-common -falign-functions=4
 
-# ovewrite the __stack_size default value of 0x400 with 0x1000(4 Kbytes).
+# override the __stack_size and __heap_size default values of 0x400 
+# SiFive HiFive1 has 16KB of data SRAM
 # The __stack_size and __heap_size symbols are defined in the linker metal.default.ld 
 # script in the freedom-e-sdk. 
 override CFLAGS += $(OPT_CFLAGS) $(WOLFSSL_CFLAGS) \
                      -Xlinker --defsym=__stack_size=0x1200 \
                      -Xlinker --defsym=__heap_size=0x800
+
 
 $(PROGRAM): $(SRC)
 	$(CC) $(CFLAGS) $(SRC) $(LDFLAGS) $(LDLIBS) -o $@

--- a/IDE/ECLIPSE/SIFIVE/Makefile
+++ b/IDE/ECLIPSE/SIFIVE/Makefile
@@ -1,0 +1,31 @@
+PROGRAM ?= wolfcrypt
+
+# This line must be added in your freedom-e-sdk/scripts/standalone.mk
+# RISCV_CFLAGS   += -I$(WOLFSSL_SRC_DIR) -I$(WOLFSSL_SRC_DIR)/IDE/ECLIPSE/SIFIVE -DWOLFSSL_USER_SETTINGS
+# WOLFSSL_SRC_DIR variable must be set in the environment when GNU make is started.
+
+WOLFSSL_CFLAGS += -I$(WOLFSSL_SRC_DIR) \
+				  -I$(WOLFSSL_SRC_DIR)/IDE/ECLIPSE/SIFIVE \
+				  -DWOLFSSL_USER_SETTINGS
+
+SRC_FILES  = $(wildcard $(WOLFSSL_SRC_DIR)/src/*.c)
+SRC_FILES += $(wildcard $(WOLFSSL_SRC_DIR)/wolfcrypt/src/*.c)
+SRC_FILES := $(filter-out %bio.c %misc.c %evp.c, $(SRC_FILES))
+
+SRC =$(WOLFSSL_SRC_DIR)/IDE/ECLIPSE/SIFIVE/main.c \
+	 $(SRC_FILES) \
+	 $(WOLFSSL_SRC_DIR)/wolfcrypt/test/test.c \
+	 $(WOLFSSL_SRC_DIR)/wolfcrypt/benchmark/benchmark.c
+
+OPT_CFLAGS = -specs=nano.specs
+#OPT_CFLAGS += -O3 -DTIME -DNOENUM -Wno-implicit -mexplicit-relocs -save-temps
+#OPT_CFLAGS += -fno-inline -fno-builtin-printf -fno-common -falign-functions=4
+
+override CFLAGS += $(OPT_CFLAGS) $(WOLFSSL_CFLAGS) \
+                     -Xlinker --defsym=__stack_size=0x1000
+
+$(PROGRAM): $(SRC)
+	$(CC) $(CFLAGS) $(SRC) $(LDFLAGS) $(LDLIBS) -o $@
+
+clean:
+	rm -f $(PROGRAM) $(PROGRAM).hex

--- a/IDE/ECLIPSE/SIFIVE/Makefile
+++ b/IDE/ECLIPSE/SIFIVE/Makefile
@@ -21,6 +21,9 @@ OPT_CFLAGS = -specs=nano.specs
 #OPT_CFLAGS += -O3 -DTIME -DNOENUM -Wno-implicit -mexplicit-relocs -save-temps
 #OPT_CFLAGS += -fno-inline -fno-builtin-printf -fno-common -falign-functions=4
 
+# ovewrite the __stack_size default value of 0x400 with 0x1000(4 Kbytes).
+# The __stack_size and __heap_size symbols are defined in the linker metal.default.ld 
+# script in the freedom-e-sdk. 
 override CFLAGS += $(OPT_CFLAGS) $(WOLFSSL_CFLAGS) \
                      -Xlinker --defsym=__stack_size=0x1000
 

--- a/IDE/ECLIPSE/SIFIVE/README.md
+++ b/IDE/ECLIPSE/SIFIVE/README.md
@@ -103,10 +103,15 @@ base64   test passed!
 asn      test passed!
 SHA      test passed!
 SHA-256  test passed!
+SHA-512  test passed!
 Hash     test passed!
 HMAC-SHA test passed!
 HMAC-SHA256 test passed!
+HMAC-SHA512 test passed!
 GMAC     test passed!
+Chacha   test passed!
+POLY1305 test passed!
+ChaCha20-Poly1305 AEAD test passed!
 AES      test passed!
 AES192   test passed!
 AES256   test passed!
@@ -114,6 +119,8 @@ AES-GCM  test passed!
 RANDOM   test passed!
 ECC      test passed!
 ECC buffer test passed!
+CURVE25519 test passed!
+ED25519  test passed!
 logging  test passed!
 mutex    test passed!
 Test complete
@@ -125,45 +132,62 @@ benchmark_test() prints a message on the target console similar to the following
 TARGET=sifive-hifive1-revb:
 
 ```
+SiFive HiFive1 Demo
+Setting clock to 320MHz
+Actual Clock 320MHz
+
 ------------------------------------------------------------------------------
  wolfSSL version 4.0.0
 ------------------------------------------------------------------------------
 wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
-RNG                 12 MB took 1.000 seconds,   11.666 MB/s
-AES-128-CBC-enc     50 KB took 1.659 seconds,   30.131 KB/s
-AES-128-CBC-dec     50 KB took 1.657 seconds,   30.183 KB/s
-AES-192-CBC-enc     50 KB took 1.839 seconds,   27.189 KB/s
-AES-192-CBC-dec     50 KB took 1.836 seconds,   27.230 KB/s
-AES-256-CBC-enc     25 KB took 1.010 seconds,   24.759 KB/s
-AES-256-CBC-dec     25 KB took 1.008 seconds,   24.791 KB/s
-AES-128-GCM-enc     25 KB took 1.508 seconds,   16.576 KB/s
-AES-128-GCM-dec     25 KB took 1.510 seconds,   16.559 KB/s
-AES-192-GCM-enc     25 KB took 1.605 seconds,   15.573 KB/s
-AES-192-GCM-dec     25 KB took 1.607 seconds,   15.558 KB/s
-AES-256-GCM-enc     25 KB took 1.699 seconds,   14.716 KB/s
-AES-256-GCM-dec     25 KB took 1.700 seconds,   14.702 KB/s
-SHA                  2 MB took 1.014 seconds,    1.589 MB/s
-SHA-256            425 KB took 1.009 seconds,  421.068 KB/s
-HMAC-SHA             1 MB took 1.013 seconds,    1.325 MB/s
-HMAC-SHA256        425 KB took 1.018 seconds,  417.420 KB/s
-ECC      256 key gen         2 ops took 1.393 sec, avg 696.503 ms, 1.436 ops/sec
-ECDHE    256 agree           2 ops took 1.386 sec, avg 692.917 ms, 1.443 ops/sec
-ECDSA    256 sign            2 ops took 1.406 sec, avg 703.064 ms, 1.422 ops/sec
-ECDSA    256 verify          2 ops took 2.773 sec, avg 1386.597 ms, 0.721 ops/sec
+RNG                200 KB took 1.044 seconds,  191.519 KB/s
+AES-128-CBC-enc     50 KB took 1.657 seconds,   30.174 KB/s
+AES-128-CBC-dec     50 KB took 1.659 seconds,   30.141 KB/s
+AES-192-CBC-enc     50 KB took 1.837 seconds,   27.220 KB/s
+AES-192-CBC-dec     50 KB took 1.839 seconds,   27.194 KB/s
+AES-256-CBC-enc     25 KB took 1.009 seconds,   24.784 KB/s
+AES-256-CBC-dec     25 KB took 1.010 seconds,   24.761 KB/s
+AES-128-GCM-enc     25 KB took 1.493 seconds,   16.739 KB/s
+AES-128-GCM-dec     25 KB took 1.564 seconds,   15.986 KB/s
+AES-192-GCM-enc     25 KB took 1.591 seconds,   15.716 KB/s
+AES-192-GCM-dec     25 KB took 1.662 seconds,   15.044 KB/s
+AES-256-GCM-enc     25 KB took 1.684 seconds,   14.843 KB/s
+AES-256-GCM-dec     25 KB took 1.755 seconds,   14.245 KB/s
+CHACHA               1 MB took 1.004 seconds,    0.997 MB/s
+CHA-POLY           675 KB took 1.021 seconds,  661.060 KB/s
+POLY1305             2 MB took 1.007 seconds,    2.230 MB/s
+SHA                  1 MB took 1.016 seconds,    1.321 MB/s
+SHA-256            425 KB took 1.005 seconds,  422.909 KB/s
+SHA-512             25 KB took 2.043 seconds,   12.239 KB/s
+HMAC-SHA             1 MB took 1.010 seconds,    1.378 MB/s
+HMAC-SHA256        425 KB took 1.037 seconds,  409.781 KB/s
+HMAC-SHA512         25 KB took 2.075 seconds,   12.050 KB/s
+ECC      256 key gen         2 ops took 1.099 sec, avg 549.271 ms, 1.821 ops/sec
+ECDHE    256 agree           2 ops took 1.093 sec, avg 546.555 ms, 1.830 ops/sec
+ECDSA    256 sign            2 ops took 1.167 sec, avg 583.694 ms, 1.713 ops/sec
+ECDSA    256 verify          2 ops took 2.136 sec, avg 1067.795 ms, 0.937 ops/sec
+CURVE  25519 key gen         2 ops took 1.693 sec, avg 846.451 ms, 1.181 ops/sec
+CURVE  25519 agree           2 ops took 1.689 sec, avg 844.299 ms, 1.184 ops/sec
+ED     25519 key gen         1 ops took 1.702 sec, avg 1702.057 ms, 0.588 ops/sec
+ED     25519 sign            2 ops took 3.650 sec, avg 1824.753 ms, 0.548 ops/sec
+ED     25519 verify          2 ops took 5.788 sec, avg 2894.012 ms, 0.346 ops/sec
 Benchmark complete
 ```
 
 ## Tested Configurations
-- SHA-1
-- SHA-256
-- AES CBC/GCM
-- ECC 256 sign/verify/shared secret with fast math library
+- P-RNG (NIST DRBG) with SHA-256
+- SHA 1/256/512
+- AES 128/192/256 CBC/GCM
+- ECC 256 sign/verify/shared secret with fast math or Single Precision (SP) library
+- ED25519/Curve25519
+- HMAC
+- ChaCha20/Poly1305
 
 ## Known Caveats
 - If you find the wolfcrypt test stuck on early_trap_vector error, it is like related to memory issues
 - Using the `__stack_size` default value of 0x400 will not be enough for the ECC test to pass.
 The `IDE/ECLIPSE/SIFIVE/Makefile` overwrites the value with 0x1000 (4 KBytes)
-- Enabling RSA will cause the ECC test to fail due to memory shortage
+- Enabling RSA will cause the ECC test to fail due to memory shortage.
 
 ## References
 

--- a/IDE/ECLIPSE/SIFIVE/README.md
+++ b/IDE/ECLIPSE/SIFIVE/README.md
@@ -1,0 +1,185 @@
+# SiFive RISC-V HiFive Port
+## Overview
+You can enable the wolfSSL support for RISC-V using the `#define WOLFSSL_SIFIVE_RISC_V`.
+
+## Prerequisites
+1. Follow the instructions on the SiFive GitHub [here](https://github.com/sifive/freedom-e-sdk) and SiFive website [here](https://www.sifive.com/) to download the freedom-e-sdk and software tools.
+3. Run a simple hello application on your development board to confirm that your board functions as expected and the communication between your computer and the board works.
+
+## Usage
+You can start with a wolfcrypt example project to integrate the wolfSSL source code.
+wolfSSL supports a compile-time user configurable options in the `IDE/ECLIPSE/SIFIVE/user_settings.h` file.
+
+The `IDE/ECLIPSE/SIFIVE/main.c` example application provides a function to run the selected examples at compile time through the following two #defines in user_settings.h. You can define these macro options to disable the test run.
+```
+- #undef NO_CRYPT_TEST
+- #undef NO_CRYPT_BENCHMARK
+```
+
+## Setup
+### Setting up the SDK with wolfSSL
+1. Download the wolfSSL source code or a zip file from GitHub and place it under your SDK `$HOME` directory. You can also copy or simlink to the source.
+```
+  For example,
+  $ cd $HOME
+  $ git clone --depth=1 https://github.com/wolfSSL/wolfssl.git
+
+```
+2. Copy the wolfcrypt example project into your `freedom-e-sdk/software` directory.
+
+```
+  $ cp -rf ~/wolfssl/IDE/ECLIPSE/SIFIVE ~/freedom-e-sdk/software/wolfcrypt
+```
+
+3. Edit your `~/freedom-e-sdk/scripts/standalone.mk` and add the following line after the last RISCV_CFLAGS entry:
+
+```
+  RISCV_CFLAGS += -I$(WOLFSSL_SRC_DIR) -I$(WOLFSSL_SRC_DIR)/IDE/ECLIPSE/SIFIVE -DWOLFSSL_USER_SETTINGS
+```
+
+4. WOLFSSL_SRC_DIR variable must be set in the environment when GNU make is started.
+
+```
+  $ export WOLFSSL_SRC_DIR=~/wolfssl
+```
+
+5. Setup your riscv64 compiler 
+
+```
+  $ export RISCV_OPENOCD_PATH=/opt/riscv-openocd
+```
+6. (Optional) Setup OpenOCD if your target supports it:
+
+```
+  $ export RISCV_OPENOCD_PATH=/opt/riscv-openocd
+```
+## Building and Running
+
+You can build from source or create a static library.
+
+1. Using command-line:
+
+```
+  $ cd freedom-e-sdk
+  $ make PROGRAM=wolfcrypt TARGET=sifive-hifive1-revb CONFIGURATION=debug clean software upload
+```
+This example cleans, builds and uploads the software on the sifive-hifive1-revb target but you can also combine and build for any of the supported targets. 
+
+Review the test results on the target console.
+
+2. Building a static library for RISC-V using a cross-compiler:
+
+```
+$ cd $WOLFSSL_SRC_DIR
+
+$./configure --host=riscv64-unknown-elf  \
+CC=riscv64-unknown-elf-gcc \
+AR=riscv64-unknown-elf-ar \
+AS=riscv64-unknown-elf-as \
+RANLIB=$RISCV_PATH/bin/riscv64-unknown-elf-gcc-ranlib \
+LD=riscv64-unknown-elf-ld \
+CXX=riscv64-unknown-elf-g++ \
+--disable-examples --enable-static --disable-shared \
+CFLAGS="-march=rv32imac -mabi=ilp32 -mcmodel=medlow -ffunction-sections -fdata-sections -I~/freedom-e-sdk/bsp/sifive-hifive1/install/include -O0 -g -DNO_FILESYSTEM -DWOLFSSL_NO_SOCK -DNO_WRITEV -DWOLFCRYPT_ONLY -DWOLFSSL_GENSEED_FORTEST -DWOLFSSL_SIFIVE_RISC_V"
+
+$make
+$sudo make install
+```
+You can now build and link your software to the wolfSSL libwolfssl.a static library.
+
+### `wolfcrypt_test()`
+wolfcrypt_test() prints a message on the target console similar to the following output:
+```
+wolfCrypt Test Started
+error    test passed!
+base64   test passed!
+asn      test passed!
+SHA      test passed!
+SHA-256  test passed!
+Hash     test passed!
+HMAC-SHA test passed!
+HMAC-SHA256 test passed!
+GMAC     test passed!
+AES      test passed!
+AES192   test passed!
+AES256   test passed!
+AES-GCM  test passed!
+RANDOM   test passed!
+ECC      test passed!
+ECC buffer test passed!
+logging  test passed!
+mutex    test passed!
+Test complete
+...
+wolfCrypt Test Completed
+```
+### `benchmark_test()`
+benchmark_test() prints a message on the target console similar to the following output.
+TARGET=sifive-hifive1-revb:
+```
+------------------------------------------------------------------------------
+ wolfSSL version 4.0.0
+------------------------------------------------------------------------------
+wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
+RNG                 25 KB took 3.000 seconds,    8.333 KB/s
+AES-128-CBC-enc     25 KB took 16.000 seconds,    1.562 KB/s
+AES-128-CBC-dec     25 KB took 17.000 seconds,    1.471 KB/s
+AES-192-CBC-enc     25 KB took 19.000 seconds,    1.316 KB/s
+AES-192-CBC-dec     25 KB took 18.000 seconds,    1.389 KB/s
+AES-256-CBC-enc     25 KB took 20.000 seconds,    1.250 KB/s
+AES-256-CBC-dec     25 KB took 21.000 seconds,    1.190 KB/s
+AES-128-GCM-enc     25 KB took 30.000 seconds,    0.833 KB/s
+AES-128-GCM-dec     25 KB took 30.000 seconds,    0.833 KB/s
+AES-192-GCM-enc     25 KB took 32.000 seconds,    0.781 KB/s
+AES-192-GCM-dec     25 KB took 32.000 seconds,    0.781 KB/s
+AES-256-GCM-enc     25 KB took 34.000 seconds,    0.735 KB/s
+AES-256-GCM-dec     25 KB took 34.000 seconds,    0.735 KB/s
+SHA                 50 KB took 1.000 seconds,   50.000 KB/s
+SHA-256             25 KB took 1.000 seconds,   25.000 KB/s
+HMAC-SHA            50 KB took 1.000 seconds,   50.000 KB/s
+HMAC-SHA256         25 KB took 1.000 seconds,   25.000 KB/s
+ECC      256 key gen         1 ops took 11.000 sec, avg 11000.000 ms, 0.091 ops/sec
+ECDHE    256 agree           2 ops took 22.000 sec, avg 11000.000 ms, 0.091 ops/sec
+ECDSA    256 sign            2 ops took 23.000 sec, avg 11500.000 ms, 0.087 ops/sec
+ECDSA    256 verify          2 ops took 45.000 sec, avg 22500.000 ms, 0.044 ops/sec
+Benchmark complete
+
+
+```
+TARGET=sifive-hifive1
+```
+------------------------------------------------------------------------------
+ wolfSSL version 4.0.0
+------------------------------------------------------------------------------
+wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
+RNG                 25 KB took 2.000 seconds,   12.500 KB/s
+AES-128-CBC-enc     25 KB took 17.000 seconds,    1.471 KB/s
+AES-128-CBC-dec     25 KB took 17.000 seconds,    1.471 KB/s
+AES-192-CBC-enc     25 KB took 18.000 seconds,    1.389 KB/s
+AES-192-CBC-dec     25 KB took 18.000 seconds,    1.389 KB/s
+AES-256-CBC-enc     25 KB took 20.000 seconds,    1.250 KB/s
+AES-256-CBC-dec     25 KB took 20.000 seconds,    1.250 KB/s
+AES-128-GCM-enc     25 KB took 31.000 seconds,    0.806 KB/s
+AES-128-GCM-dec     25 KB took 30.000 seconds,    0.833 KB/s
+AES-192-GCM-enc     25 KB took 33.000 seconds,    0.758 KB/s
+AES-192-GCM-dec     25 KB took 33.000 seconds,    0.758 KB/s
+AES-256-GCM-enc     25 KB took 34.000 seconds,    0.735 KB/s
+AES-256-GCM-dec     25 KB took 35.000 seconds,    0.714 KB/s
+SHA                 50 KB took 1.000 seconds,   50.000 KB/s
+SHA-256             25 KB took 1.000 seconds,   25.000 KB/s
+HMAC-SHA            25 KB took 1.000 seconds,   25.000 KB/s
+HMAC-SHA256         25 KB took 1.000 seconds,   25.000 KB/s
+ECC      256 key gen         1 ops took 12.000 sec, avg 12000.000 ms, 0.083 ops/sec
+ECDHE    256 agree           2 ops took 24.000 sec, avg 12000.000 ms, 0.083 ops/sec
+ECDSA    256 sign            2 ops took 25.000 sec, avg 12500.000 ms, 0.080 ops/sec
+ECDSA    256 verify          2 ops took 48.000 sec, avg 24000.000 ms, 0.042 ops/sec
+Benchmark complete
+```
+
+## References
+The test results were collected from a SiFive reference platform target with the following hardware, software and tool chains:
+- HiFive1 Rev A/Rev B: HiFive1 Development Board with the Freedom Everywhere SoC, E300
+- freedom-e-sdk
+- wolfssl [latest version](https://github.com/wolfSSL/wolfssl)
+
+For more information or questions, please email [support@wolfssl.com](mailto:support@wolfssl.com)

--- a/IDE/ECLIPSE/SIFIVE/README.md
+++ b/IDE/ECLIPSE/SIFIVE/README.md
@@ -1,4 +1,5 @@
-# SiFive RISC-V HiFive Port
+# SiFive RISC-V HiFive1 Port
+
 ## Overview
 You can enable the wolfSSL support for RISC-V using the `#define WOLFSSL_SIFIVE_RISC_V`.
 
@@ -15,6 +16,7 @@ The `IDE/ECLIPSE/SIFIVE/main.c` example application provides a function to run t
 - #undef NO_CRYPT_TEST
 - #undef NO_CRYPT_BENCHMARK
 ```
+
 ## Setup
 ### Setting up the SDK with wolfSSL
 1. Download the wolfSSL source code or a zip file from GitHub and place it under your SDK `$HOME` directory. You can also copy or simlink to the source.
@@ -87,10 +89,16 @@ $sudo make install
 You can now build and link your software to the wolfSSL libwolfssl.a static library.
 
 ### `wolfcrypt_test()`
+
 wolfcrypt_test() prints a message on the target console similar to the following output:
+
 ```
-wolfCrypt Test Started
+SiFive HiFive1 Demo
+Setting clock to 320MHz
+Actual Clock 320MHz
+
 error    test passed!
+MEMORY   test passed!
 base64   test passed!
 asn      test passed!
 SHA      test passed!
@@ -109,73 +117,46 @@ ECC buffer test passed!
 logging  test passed!
 mutex    test passed!
 Test complete
-...
-wolfCrypt Test Completed
 ```
 ### `benchmark_test()`
+
 benchmark_test() prints a message on the target console similar to the following output.
+
 TARGET=sifive-hifive1-revb:
+
 ```
 ------------------------------------------------------------------------------
  wolfSSL version 4.0.0
 ------------------------------------------------------------------------------
 wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
-RNG                 25 KB took 3.000 seconds,    8.333 KB/s
-AES-128-CBC-enc     25 KB took 16.000 seconds,    1.562 KB/s
-AES-128-CBC-dec     25 KB took 17.000 seconds,    1.471 KB/s
-AES-192-CBC-enc     25 KB took 19.000 seconds,    1.316 KB/s
-AES-192-CBC-dec     25 KB took 18.000 seconds,    1.389 KB/s
-AES-256-CBC-enc     25 KB took 20.000 seconds,    1.250 KB/s
-AES-256-CBC-dec     25 KB took 21.000 seconds,    1.190 KB/s
-AES-128-GCM-enc     25 KB took 30.000 seconds,    0.833 KB/s
-AES-128-GCM-dec     25 KB took 30.000 seconds,    0.833 KB/s
-AES-192-GCM-enc     25 KB took 32.000 seconds,    0.781 KB/s
-AES-192-GCM-dec     25 KB took 32.000 seconds,    0.781 KB/s
-AES-256-GCM-enc     25 KB took 34.000 seconds,    0.735 KB/s
-AES-256-GCM-dec     25 KB took 34.000 seconds,    0.735 KB/s
-SHA                 50 KB took 1.000 seconds,   50.000 KB/s
-SHA-256             25 KB took 1.000 seconds,   25.000 KB/s
-HMAC-SHA            50 KB took 1.000 seconds,   50.000 KB/s
-HMAC-SHA256         25 KB took 1.000 seconds,   25.000 KB/s
-ECC      256 key gen         1 ops took 11.000 sec, avg 11000.000 ms, 0.091 ops/sec
-ECDHE    256 agree           2 ops took 22.000 sec, avg 11000.000 ms, 0.091 ops/sec
-ECDSA    256 sign            2 ops took 23.000 sec, avg 11500.000 ms, 0.087 ops/sec
-ECDSA    256 verify          2 ops took 45.000 sec, avg 22500.000 ms, 0.044 ops/sec
+RNG                 12 MB took 1.000 seconds,   11.666 MB/s
+AES-128-CBC-enc     50 KB took 1.659 seconds,   30.131 KB/s
+AES-128-CBC-dec     50 KB took 1.657 seconds,   30.183 KB/s
+AES-192-CBC-enc     50 KB took 1.839 seconds,   27.189 KB/s
+AES-192-CBC-dec     50 KB took 1.836 seconds,   27.230 KB/s
+AES-256-CBC-enc     25 KB took 1.010 seconds,   24.759 KB/s
+AES-256-CBC-dec     25 KB took 1.008 seconds,   24.791 KB/s
+AES-128-GCM-enc     25 KB took 1.508 seconds,   16.576 KB/s
+AES-128-GCM-dec     25 KB took 1.510 seconds,   16.559 KB/s
+AES-192-GCM-enc     25 KB took 1.605 seconds,   15.573 KB/s
+AES-192-GCM-dec     25 KB took 1.607 seconds,   15.558 KB/s
+AES-256-GCM-enc     25 KB took 1.699 seconds,   14.716 KB/s
+AES-256-GCM-dec     25 KB took 1.700 seconds,   14.702 KB/s
+SHA                  2 MB took 1.014 seconds,    1.589 MB/s
+SHA-256            425 KB took 1.009 seconds,  421.068 KB/s
+HMAC-SHA             1 MB took 1.013 seconds,    1.325 MB/s
+HMAC-SHA256        425 KB took 1.018 seconds,  417.420 KB/s
+ECC      256 key gen         2 ops took 1.393 sec, avg 696.503 ms, 1.436 ops/sec
+ECDHE    256 agree           2 ops took 1.386 sec, avg 692.917 ms, 1.443 ops/sec
+ECDSA    256 sign            2 ops took 1.406 sec, avg 703.064 ms, 1.422 ops/sec
+ECDSA    256 verify          2 ops took 2.773 sec, avg 1386.597 ms, 0.721 ops/sec
 Benchmark complete
 ```
-TARGET=sifive-hifive1
-```
-------------------------------------------------------------------------------
- wolfSSL version 4.0.0
-------------------------------------------------------------------------------
-wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
-RNG                 25 KB took 2.000 seconds,   12.500 KB/s
-AES-128-CBC-enc     25 KB took 17.000 seconds,    1.471 KB/s
-AES-128-CBC-dec     25 KB took 17.000 seconds,    1.471 KB/s
-AES-192-CBC-enc     25 KB took 18.000 seconds,    1.389 KB/s
-AES-192-CBC-dec     25 KB took 18.000 seconds,    1.389 KB/s
-AES-256-CBC-enc     25 KB took 20.000 seconds,    1.250 KB/s
-AES-256-CBC-dec     25 KB took 20.000 seconds,    1.250 KB/s
-AES-128-GCM-enc     25 KB took 31.000 seconds,    0.806 KB/s
-AES-128-GCM-dec     25 KB took 30.000 seconds,    0.833 KB/s
-AES-192-GCM-enc     25 KB took 33.000 seconds,    0.758 KB/s
-AES-192-GCM-dec     25 KB took 33.000 seconds,    0.758 KB/s
-AES-256-GCM-enc     25 KB took 34.000 seconds,    0.735 KB/s
-AES-256-GCM-dec     25 KB took 35.000 seconds,    0.714 KB/s
-SHA                 50 KB took 1.000 seconds,   50.000 KB/s
-SHA-256             25 KB took 1.000 seconds,   25.000 KB/s
-HMAC-SHA            25 KB took 1.000 seconds,   25.000 KB/s
-HMAC-SHA256         25 KB took 1.000 seconds,   25.000 KB/s
-ECC      256 key gen         1 ops took 12.000 sec, avg 12000.000 ms, 0.083 ops/sec
-ECDHE    256 agree           2 ops took 24.000 sec, avg 12000.000 ms, 0.083 ops/sec
-ECDSA    256 sign            2 ops took 25.000 sec, avg 12500.000 ms, 0.080 ops/sec
-ECDSA    256 verify          2 ops took 48.000 sec, avg 24000.000 ms, 0.042 ops/sec
-Benchmark complete
-```
+
 ## Tested Configurations
 - SHA-1
 - SHA-256
-- AES CBC
+- AES CBC/GCM
 - ECC 256 sign/verify/shared secret with fast math library
 
 ## Known Caveats
@@ -185,6 +166,7 @@ The `IDE/ECLIPSE/SIFIVE/Makefile` overwrites the value with 0x1000 (4 KBytes)
 - Enabling RSA will cause the ECC test to fail due to memory shortage
 
 ## References
+
 The test results were collected from a SiFive reference platform target with the following hardware, software and tool chains:
 - HiFive1 Rev A/Rev B: HiFive1 Development Board with the Freedom Everywhere SoC, E300
 - freedom-e-sdk

--- a/IDE/ECLIPSE/SIFIVE/README.md
+++ b/IDE/ECLIPSE/SIFIVE/README.md
@@ -15,6 +15,11 @@ The `IDE/ECLIPSE/SIFIVE/main.c` example application provides a function to run t
 - #undef NO_CRYPT_TEST
 - #undef NO_CRYPT_BENCHMARK
 ```
+## Tested Configurations
+- SHA-1
+- SHA-256
+- AES CBC
+- ECC sign/verify/shared secret with fast math library
 
 ## Setup
 ### Setting up the SDK with wolfSSL
@@ -80,7 +85,7 @@ RANLIB=$RISCV_PATH/bin/riscv64-unknown-elf-gcc-ranlib \
 LD=riscv64-unknown-elf-ld \
 CXX=riscv64-unknown-elf-g++ \
 --disable-examples --enable-static --disable-shared \
-CFLAGS="-march=rv32imac -mabi=ilp32 -mcmodel=medlow -ffunction-sections -fdata-sections -I~/freedom-e-sdk/bsp/sifive-hifive1/install/include -O0 -g -DNO_FILESYSTEM -DWOLFSSL_NO_SOCK -DNO_WRITEV -DWOLFCRYPT_ONLY -DWOLFSSL_GENSEED_FORTEST -DWOLFSSL_SIFIVE_RISC_V"
+CFLAGS="-march=rv32imac -mabi=ilp32 -mcmodel=medlow -ffunction-sections -fdata-sections -I~/freedom-e-sdk/bsp/sifive-hifive1/install/include -O0 -g -DNO_FILESYSTEM -DWOLFSSL_NO_SOCK -DNO_WRITEV -DWOLFCRYPT_ONLY -DWOLFSSL_SIFIVE_RISC_V"
 
 $make
 $sudo make install
@@ -143,8 +148,6 @@ ECDHE    256 agree           2 ops took 22.000 sec, avg 11000.000 ms, 0.091 ops/
 ECDSA    256 sign            2 ops took 23.000 sec, avg 11500.000 ms, 0.087 ops/sec
 ECDSA    256 verify          2 ops took 45.000 sec, avg 22500.000 ms, 0.044 ops/sec
 Benchmark complete
-
-
 ```
 TARGET=sifive-hifive1
 ```
@@ -175,6 +178,11 @@ ECDSA    256 sign            2 ops took 25.000 sec, avg 12500.000 ms, 0.080 ops/
 ECDSA    256 verify          2 ops took 48.000 sec, avg 24000.000 ms, 0.042 ops/sec
 Benchmark complete
 ```
+## Known Caveats
+- If you find the wolfcrypt test stuck on early_trap_vector error, it is like related to memory issues
+- Using the `__stack_size` default value of 0x400 will not be enough for the ECC test to pass.
+The `IDE/ECLIPSE/SIFIVE/Makefile` overwrites the value with 0x1000 (4 KBytes)
+- Enabling RSA will cause the ECC test to fail due to memory shortage
 
 ## References
 The test results were collected from a SiFive reference platform target with the following hardware, software and tool chains:

--- a/IDE/ECLIPSE/SIFIVE/README.md
+++ b/IDE/ECLIPSE/SIFIVE/README.md
@@ -158,7 +158,7 @@ CHA-POLY           675 KB took 1.021 seconds,  661.060 KB/s
 POLY1305             2 MB took 1.007 seconds,    2.230 MB/s
 SHA                  1 MB took 1.016 seconds,    1.321 MB/s
 SHA-256            425 KB took 1.005 seconds,  422.909 KB/s
-SHA-512             25 KB took 2.043 seconds,   12.239 KB/s
+SHA-512            225 KB took 1.009 seconds,  223.073 KB/s
 HMAC-SHA             1 MB took 1.010 seconds,    1.378 MB/s
 HMAC-SHA256        425 KB took 1.037 seconds,  409.781 KB/s
 HMAC-SHA512         25 KB took 2.075 seconds,   12.050 KB/s

--- a/IDE/ECLIPSE/SIFIVE/README.md
+++ b/IDE/ECLIPSE/SIFIVE/README.md
@@ -15,12 +15,6 @@ The `IDE/ECLIPSE/SIFIVE/main.c` example application provides a function to run t
 - #undef NO_CRYPT_TEST
 - #undef NO_CRYPT_BENCHMARK
 ```
-## Tested Configurations
-- SHA-1
-- SHA-256
-- AES CBC
-- ECC sign/verify/shared secret with fast math library
-
 ## Setup
 ### Setting up the SDK with wolfSSL
 1. Download the wolfSSL source code or a zip file from GitHub and place it under your SDK `$HOME` directory. You can also copy or simlink to the source.
@@ -178,6 +172,12 @@ ECDSA    256 sign            2 ops took 25.000 sec, avg 12500.000 ms, 0.080 ops/
 ECDSA    256 verify          2 ops took 48.000 sec, avg 24000.000 ms, 0.042 ops/sec
 Benchmark complete
 ```
+## Tested Configurations
+- SHA-1
+- SHA-256
+- AES CBC
+- ECC 256 sign/verify/shared secret with fast math library
+
 ## Known Caveats
 - If you find the wolfcrypt test stuck on early_trap_vector error, it is like related to memory issues
 - Using the `__stack_size` default value of 0x400 will not be enough for the ECC test to pass.

--- a/IDE/ECLIPSE/SIFIVE/README.md
+++ b/IDE/ECLIPSE/SIFIVE/README.md
@@ -140,37 +140,37 @@ Actual Clock 320MHz
  wolfSSL version 4.0.0
 ------------------------------------------------------------------------------
 wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
-RNG                200 KB took 1.044 seconds,  191.519 KB/s
-AES-128-CBC-enc     50 KB took 1.657 seconds,   30.174 KB/s
-AES-128-CBC-dec     50 KB took 1.659 seconds,   30.141 KB/s
-AES-192-CBC-enc     50 KB took 1.837 seconds,   27.220 KB/s
-AES-192-CBC-dec     50 KB took 1.839 seconds,   27.194 KB/s
-AES-256-CBC-enc     25 KB took 1.009 seconds,   24.784 KB/s
-AES-256-CBC-dec     25 KB took 1.010 seconds,   24.761 KB/s
-AES-128-GCM-enc     25 KB took 1.493 seconds,   16.739 KB/s
-AES-128-GCM-dec     25 KB took 1.564 seconds,   15.986 KB/s
-AES-192-GCM-enc     25 KB took 1.591 seconds,   15.716 KB/s
-AES-192-GCM-dec     25 KB took 1.662 seconds,   15.044 KB/s
-AES-256-GCM-enc     25 KB took 1.684 seconds,   14.843 KB/s
-AES-256-GCM-dec     25 KB took 1.755 seconds,   14.245 KB/s
-CHACHA               1 MB took 1.004 seconds,    0.997 MB/s
-CHA-POLY           675 KB took 1.021 seconds,  661.060 KB/s
-POLY1305             2 MB took 1.007 seconds,    2.230 MB/s
-SHA                  1 MB took 1.016 seconds,    1.321 MB/s
-SHA-256            425 KB took 1.005 seconds,  422.909 KB/s
-SHA-512            225 KB took 1.009 seconds,  223.073 KB/s
-HMAC-SHA             1 MB took 1.010 seconds,    1.378 MB/s
-HMAC-SHA256        425 KB took 1.037 seconds,  409.781 KB/s
-HMAC-SHA512         25 KB took 2.075 seconds,   12.050 KB/s
-ECC      256 key gen         2 ops took 1.099 sec, avg 549.271 ms, 1.821 ops/sec
-ECDHE    256 agree           2 ops took 1.093 sec, avg 546.555 ms, 1.830 ops/sec
-ECDSA    256 sign            2 ops took 1.167 sec, avg 583.694 ms, 1.713 ops/sec
-ECDSA    256 verify          2 ops took 2.136 sec, avg 1067.795 ms, 0.937 ops/sec
-CURVE  25519 key gen         2 ops took 1.693 sec, avg 846.451 ms, 1.181 ops/sec
-CURVE  25519 agree           2 ops took 1.689 sec, avg 844.299 ms, 1.184 ops/sec
-ED     25519 key gen         1 ops took 1.702 sec, avg 1702.057 ms, 0.588 ops/sec
-ED     25519 sign            2 ops took 3.650 sec, avg 1824.753 ms, 0.548 ops/sec
-ED     25519 verify          2 ops took 5.788 sec, avg 2894.012 ms, 0.346 ops/sec
+RNG                250 KB took 1.098 seconds,  227.714 KB/s
+AES-128-CBC-enc     50 KB took 1.132 seconds,   44.175 KB/s
+AES-128-CBC-dec     50 KB took 1.142 seconds,   43.778 KB/s
+AES-192-CBC-enc     50 KB took 1.250 seconds,   40.007 KB/s
+AES-192-CBC-dec     50 KB took 1.260 seconds,   39.677 KB/s
+AES-256-CBC-enc     50 KB took 1.368 seconds,   36.552 KB/s
+AES-256-CBC-dec     50 KB took 1.378 seconds,   36.279 KB/s
+AES-128-GCM-enc     25 KB took 1.225 seconds,   20.412 KB/s
+AES-128-GCM-dec     25 KB took 1.225 seconds,   20.402 KB/s
+AES-192-GCM-enc     25 KB took 1.290 seconds,   19.373 KB/s
+AES-192-GCM-dec     25 KB took 1.291 seconds,   19.366 KB/s
+AES-256-GCM-enc     25 KB took 1.352 seconds,   18.487 KB/s
+AES-256-GCM-dec     25 KB took 1.353 seconds,   18.478 KB/s
+CHACHA               1 MB took 1.006 seconds,    1.020 MB/s
+CHA-POLY           700 KB took 1.032 seconds,  678.045 KB/s
+POLY1305             2 MB took 1.007 seconds,    2.255 MB/s
+SHA                  2 MB took 1.002 seconds,    1.511 MB/s
+SHA-256            525 KB took 1.011 seconds,  519.279 KB/s
+SHA-512            275 KB took 1.017 seconds,  270.477 KB/s
+HMAC-SHA             1 MB took 1.013 seconds,    1.399 MB/s
+HMAC-SHA256        525 KB took 1.019 seconds,  515.020 KB/s
+HMAC-SHA512        275 KB took 1.032 seconds,  266.351 KB/s
+ECC      256 key gen         2 ops took 1.104 sec, avg 551.834 ms, 1.812 ops/sec
+ECDHE    256 agree           2 ops took 1.101 sec, avg 550.400 ms, 1.817 ops/sec
+ECDSA    256 sign            2 ops took 1.173 sec, avg 586.502 ms, 1.705 ops/sec
+ECDSA    256 verify          2 ops took 2.153 sec, avg 1076.294 ms, 0.929 ops/sec
+CURVE  25519 key gen         2 ops took 1.629 sec, avg 814.423 ms, 1.228 ops/sec
+CURVE  25519 agree           2 ops took 1.626 sec, avg 813.156 ms, 1.230 ops/sec
+ED     25519 key gen         1 ops took 1.436 sec, avg 1436.096 ms, 0.696 ops/sec
+ED     25519 sign            2 ops took 2.913 sec, avg 1456.421 ms, 0.687 ops/sec
+ED     25519 verify          2 ops took 5.012 sec, avg 2506.012 ms, 0.399 ops/sec
 Benchmark complete
 ```
 

--- a/IDE/ECLIPSE/SIFIVE/include.am
+++ b/IDE/ECLIPSE/SIFIVE/include.am
@@ -1,0 +1,9 @@
+# vim:ft=automake
+# included from Top Level Makefile.am
+# All paths should be given relative to the root
+
+EXTRA_DIST += \
+    IDE/ECLIPSE/SIFIVE/README.md \
+    IDE/ECLIPSE/SIFIVE/main.c \
+    IDE/ECLIPSE/SIFIVE/Makefile\
+    IDE/ECLIPSE/SIFIVE/user_settings.h

--- a/IDE/ECLIPSE/SIFIVE/main.c
+++ b/IDE/ECLIPSE/SIFIVE/main.c
@@ -150,6 +150,11 @@ int main(void)
 #endif
     printf("Actual Clock %dMHz\n", clk_Hz/1000000);
 
+    /* Reconfigure the SPI Bus for dual mode */
+    #define QSPI0_CTRL       0x10014000UL
+    #define FESPI_REG_FFMT   (*((volatile uint32_t *)(QSPI0_CTRL + 0x64)))
+    FESPI_REG_FFMT = 0xbb1447;
+
 #ifdef DEBUG_WOLFSSL
     wolfSSL_Debugging_ON();
 #endif

--- a/IDE/ECLIPSE/SIFIVE/main.c
+++ b/IDE/ECLIPSE/SIFIVE/main.c
@@ -69,17 +69,16 @@ void check(int depth) {
     free(ptr);
 }
 
-void mtime_sleep(uint64_t ticks) {
-    uint64_t now = CLINT_REG_MTIME;
-    uint64_t then = now + ticks;
+void mtime_sleep(uint32_t ticks) {
+    uint32_t start = CLINT_REG_MTIME;
 
-    while((*mtime - now) < ticks) {
+    while((CLINT_REG_MTIME - start) < ticks) {
 
     }
 }
 
-void delay(int sec) {
-    uint64_t ticks = sec * RTC_FREQ;
+void delay(uint32_t sec) {
+    uint32_t ticks = sec * RTC_FREQ;
     mtime_sleep(ticks);
 }
 #endif /* WOLFSSL_SIFIVE_RISC_V_DEBUG */

--- a/IDE/ECLIPSE/SIFIVE/main.c
+++ b/IDE/ECLIPSE/SIFIVE/main.c
@@ -130,7 +130,7 @@ int my_rng_gen_block(unsigned char* output, unsigned int sz)
 int main(void)
 {
     int ret;
-    long clkHz = 16000000; /* default */
+    long clk_Hz = 16000000; /* default */
 
 #if WOLFSSL_SIFIVE_RISC_V_DEBUG
     printf("check stack and heap addresses\n");
@@ -144,11 +144,11 @@ int main(void)
     /* Speed up clock */
     printf("SiFive HiFive1 Demo\n");
     printf("Setting clock to %dMHz\n", USE_CLOCK_HZ/1000000);
-    clkHz = metal_clock_set_rate_hz(
+    clk_Hz = metal_clock_set_rate_hz(
         &__METAL_DT_SIFIVE_FE310_G000_PLL_HANDLE->clock, USE_CLOCK_HZ
     );
 #endif
-    printf("Actual Clock %dMHz\n", clkHz/1000000);
+    printf("Actual Clock %dMHz\n", clk_Hz/1000000);
 
 #ifdef DEBUG_WOLFSSL
     wolfSSL_Debugging_ON();

--- a/IDE/ECLIPSE/SIFIVE/main.c
+++ b/IDE/ECLIPSE/SIFIVE/main.c
@@ -1,0 +1,115 @@
+/* main.c
+ *
+ * Copyright (C) 2019 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfcrypt/test/test.h>
+#include <wolfcrypt/benchmark/benchmark.h>
+
+/* wolfCrypt_Init/wolfCrypt_Cleanup */
+#include <wolfssl/wolfcrypt/wc_port.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#ifndef NO_CRYPT_BENCHMARK
+
+/*-specs=nano.specs doesn’t include support for floating point in printf()*/
+asm (".global _printf_float");
+
+#define RTC_FREQ    32768
+#define CLINT_MTIME_ADDR  0x200bff8
+#define WOLFSSL_SIFIVE_RISC_V_DEBUG 0
+
+double current_time(int reset)
+{
+    volatile uint64_t * mtime  = (uint64_t*) (CLINT_MTIME_ADDR);
+    uint64_t now = *mtime;
+    (void)reset;
+    return now/RTC_FREQ;
+}
+#endif
+
+void check(int depth) {
+    char ch;
+    char *ptr = malloc(1);
+
+    printf("stack at %p, heap at %p\n", &ch, ptr);
+    if (depth <= 0) 
+        return;
+    
+    check(depth-1);
+}
+
+void mtime_sleep( uint64_t ticks) {
+    volatile uint64_t * mtime  = (uint64_t*) (CLINT_MTIME_ADDR);
+    uint64_t now = *mtime;
+    uint64_t then = now + ticks;
+
+    while((*mtime - now) < ticks) {
+        
+    }
+}
+
+void delay(int sec) {
+    uint64_t ticks = sec * RTC_FREQ;
+    mtime_sleep(ticks);
+}
+
+int main(void) 
+{
+    int ret;
+
+#if WOLFSSL_SIFIVE_RISC_V_DEBUG
+    printf("check stack and heap addresses\n");
+    check(10);
+    printf("sleep for 10 seconds to verify timer\n");
+    delay(10);
+    printf("awake after sleeping for 10 seconds\n");
+#endif    
+    
+    #ifdef DEBUG_WOLFSSL
+        wolfSSL_Debugging_ON();
+    #endif
+    #ifdef HAVE_STACK_SIZE
+        StackSizeCheck(&args, server_test);
+    #endif
+    if ((ret = wolfCrypt_Init()) != 0) {
+        printf("wolfCrypt_Init failed %d\n", ret);
+        return -1;
+    }
+
+#ifndef NO_CRYPT_TEST
+    printf("\nwolfCrypt Test Started\n");
+    wolfcrypt_test(NULL);
+    printf("\nwolfCrypt Test Completed\n");
+#endif
+
+#ifndef NO_CRYPT_BENCHMARK
+    printf("\nBenchmark Test Started\n");
+    benchmark_test(NULL);
+    printf("\nBenchmark Test Completed\n");
+#endif
+    if ((ret = wolfCrypt_Cleanup()) != 0) {
+        printf("wolfCrypt_Cleanup failed %d\n", ret);
+        return -1;
+    }
+    return 0;
+}
+

--- a/IDE/ECLIPSE/SIFIVE/main.c
+++ b/IDE/ECLIPSE/SIFIVE/main.c
@@ -33,16 +33,27 @@
 /*-specs=nano.specs doesn’t include support for floating point in printf()*/
 asm (".global _printf_float");
 
-#define RTC_FREQ    32768
+#ifndef RTC_FREQ
+    #define RTC_FREQ    32768
+#endif
+
 #define CLINT_MTIME_ADDR  0x200bff8
 #define WOLFSSL_SIFIVE_RISC_V_DEBUG 0
+
+unsigned long get_cpu_freq(void)
+{
+    /* If clocking up the CPU, you need to add a logic to measure cpu freq */
+
+    return RTC_FREQ;
+}
 
 double current_time(int reset)
 {
     volatile uint64_t * mtime  = (uint64_t*) (CLINT_MTIME_ADDR);
     uint64_t now = *mtime;
     (void)reset;
-    return now/RTC_FREQ;
+    /**/
+    return now/get_cpu_freq();
 }
 #endif
 
@@ -70,7 +81,7 @@ void mtime_sleep( uint64_t ticks) {
 }
 
 void delay(int sec) {
-    uint64_t ticks = sec * RTC_FREQ;
+    uint64_t ticks = sec * get_cpu_freq();
     mtime_sleep(ticks);
 }
 #endif 
@@ -120,7 +131,7 @@ int main(void)
 #if WOLFSSL_SIFIVE_RISC_V_DEBUG
     printf("check stack and heap addresses\n");
     check(8);
-    printf("sleep for 10 seconds to verify timer\n");
+    printf("sleep for 10 seconds to verify timer, measure using a stopwatch\n");
     delay(10);
     printf("awake after sleeping for 10 seconds\n");
 #endif    

--- a/IDE/ECLIPSE/SIFIVE/user_settings.h
+++ b/IDE/ECLIPSE/SIFIVE/user_settings.h
@@ -117,12 +117,12 @@ extern "C" {
     #define ECC_USER_CURVES
 
     #ifdef ECC_USER_CURVES
-        /* Manual Curve Selection */
-        #define HAVE_ECC192
-        #define HAVE_ECC224
+        /* Manual Curve Selection, FP_MAX_BITS must be adjusted accordingly */
+        // #define HAVE_ECC192
+        // #define HAVE_ECC224
         #undef NO_ECC256
-        #define HAVE_ECC384
-        #define HAVE_ECC521
+        // #define HAVE_ECC384
+        // #define HAVE_ECC521
     #endif
 
     /* Fixed point cache (speeds repeated operations against same private key) */

--- a/IDE/ECLIPSE/SIFIVE/user_settings.h
+++ b/IDE/ECLIPSE/SIFIVE/user_settings.h
@@ -1,0 +1,566 @@
+/* user_settings.h
+ *
+ * Copyright (C) 2019 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* Example Settings for SiFive HiFive1 */
+
+#ifndef WOLFSSL_USER_SETTINGS_H
+#define WOLFSSL_USER_SETTINGS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ------------------------------------------------------------------------- */
+/* SiFive HiFive */
+/* ------------------------------------------------------------------------- */
+#undef  WOLFSSL_SIFIVE_RISC_V
+#define WOLFSSL_SIFIVE_RISC_V
+
+
+/* ------------------------------------------------------------------------- */
+/* Platform */
+/* ------------------------------------------------------------------------- */
+
+#undef  WOLFSSL_GENERAL_ALIGNMENT
+#define WOLFSSL_GENERAL_ALIGNMENT   4
+
+#undef  SINGLE_THREADED
+#define SINGLE_THREADED
+
+#undef  WOLFSSL_SMALL_STACK
+#define WOLFSSL_SMALL_STACK
+
+#undef  WOLFSSL_USER_IO
+#define WOLFSSL_USER_IO
+
+
+/* ------------------------------------------------------------------------- */
+/* Math Configuration */
+/* ------------------------------------------------------------------------- */
+#undef  SIZEOF_LONG_LONG
+#define SIZEOF_LONG_LONG 8
+
+#undef USE_FAST_MATH
+
+#if 1
+    #define USE_FAST_MATH
+
+    #undef  TFM_TIMING_RESISTANT
+    #define TFM_TIMING_RESISTANT
+
+    /* Optimizations */
+    //#define TFM_ARM
+#endif
+
+/* ------------------------------------------------------------------------- */
+/* Crypto */
+/* ------------------------------------------------------------------------- */
+/* RSA */
+#undef NO_RSA
+#if 0
+    #ifdef USE_FAST_MATH
+        /* Maximum math bits (Max RSA key bits * 2) */
+        #undef  FP_MAX_BITS
+        #define FP_MAX_BITS     4096
+    #endif
+
+    /* half as much memory but twice as slow */
+    #undef  RSA_LOW_MEM
+    #define RSA_LOW_MEM
+
+    /* Enables blinding mode, to prevent timing attacks */
+    #if 1
+        #undef  WC_RSA_BLINDING
+        #define WC_RSA_BLINDING
+    #else
+        #undef  WC_NO_HARDEN
+        #define WC_NO_HARDEN
+    #endif
+
+    /* RSA PSS Support */
+    #if 0
+        #define WC_RSA_PSS
+    #endif
+
+    #if 0
+        #define WC_RSA_NO_PADDING
+    #endif
+#else
+    #define NO_RSA
+#endif
+
+/* ECC */
+#undef HAVE_ECC
+#if 1
+    #define HAVE_ECC
+
+    /* Manually define enabled curves */
+    #undef  ECC_USER_CURVES
+    #define ECC_USER_CURVES
+
+    #ifdef ECC_USER_CURVES
+        /* Manual Curve Selection */
+        //#define HAVE_ECC192
+        //#define HAVE_ECC224
+        #undef NO_ECC256
+        //#define HAVE_ECC384
+        //#define HAVE_ECC521
+    #endif
+
+    /* Fixed point cache (speeds repeated operations against same private key) */
+    #undef  FP_ECC
+    //#define FP_ECC
+    #ifdef FP_ECC
+        /* Bits / Entries */
+        #undef  FP_ENTRIES
+        #define FP_ENTRIES  2
+        #undef  FP_LUT
+        #define FP_LUT      4
+    #endif
+
+    /* Optional ECC calculation method */
+    /* Note: doubles heap usage, but slightly faster */
+    #undef  ECC_SHAMIR
+    //#define ECC_SHAMIR
+
+    /* Reduces heap usage, but slower */
+    #undef  ECC_TIMING_RESISTANT
+    #define ECC_TIMING_RESISTANT
+
+    /* Enable cofactor support */
+    #undef  HAVE_ECC_CDH
+    //#define HAVE_ECC_CDH
+
+    /* Validate import */
+    #undef  WOLFSSL_VALIDATE_ECC_IMPORT
+    //#define WOLFSSL_VALIDATE_ECC_IMPORT
+
+    /* Compressed Key Support */
+    #undef  HAVE_COMP_KEY
+    //#define HAVE_COMP_KEY
+
+    /* Use alternate ECC size for ECC math */
+    #ifdef USE_FAST_MATH
+        #ifdef NO_RSA
+            /* Custom fastmath size if not using RSA */
+            /* MAX = ROUND32(ECC BITS 256) + SIZE_OF_MP_DIGIT(32) */
+            #undef  FP_MAX_BITS
+            #define FP_MAX_BITS     (256 + 32)
+        #else
+            #undef  ALT_ECC_SIZE
+            #define ALT_ECC_SIZE
+        #endif
+
+        /* Speedups specific to curve */
+        #ifndef NO_ECC256
+            #undef  TFM_ECC256
+            //#define TFM_ECC256
+        #endif
+        #ifndef HAVE_ECC384
+            #undef  TFM_ECC384
+            //#define TFM_ECC384
+        #endif
+    #endif
+#endif
+
+/* DH */
+#undef  NO_DH
+#if 0
+    /* Use table for DH instead of -lm (math) lib dependency */
+    #if 0
+        #define WOLFSSL_DH_CONST
+    #endif
+
+    #define HAVE_FFDHE_2048
+    //#define HAVE_FFDHE_4096
+    //#define HAVE_FFDHE_6144
+    //#define HAVE_FFDHE_8192
+#else
+    #define NO_DH
+#endif
+
+
+/* AES */
+#undef NO_AES
+#if 1
+    #undef  HAVE_AES_CBC
+    #define HAVE_AES_CBC
+
+    /* If you need other than AES-CBC mode, you must undefine WOLFSSL_CRYPTOCELL_AES */
+    #if !defined(WOLFSSL_CRYPTOCELL_AES)
+        #undef  HAVE_AESGCM
+        #define HAVE_AESGCM
+
+        /* GCM Method: GCM_SMALL, GCM_WORD32 or GCM_TABLE */
+        #define GCM_SMALL
+
+        #undef  WOLFSSL_AES_DIRECT
+        //#define WOLFSSL_AES_DIRECT
+
+        #undef  HAVE_AES_ECB
+        //#define HAVE_AES_ECB
+
+        #undef  WOLFSSL_AES_COUNTER
+        //#define WOLFSSL_AES_COUNTER
+
+        #undef  HAVE_AESCCM
+        //#define HAVE_AESCCM
+    #endif
+#else
+    #define NO_AES
+#endif
+
+
+/* DES3 */
+#undef NO_DES3
+#if 0
+#else
+    #define NO_DES3
+#endif
+
+/* ChaCha20 / Poly1305 */
+#undef HAVE_CHACHA
+#undef HAVE_POLY1305
+#if 0
+    #define HAVE_CHACHA
+    #define HAVE_POLY1305
+
+    /* Needed for Poly1305 */
+    #undef  HAVE_ONE_TIME_AUTH
+    #define HAVE_ONE_TIME_AUTH
+#endif
+
+/* Ed25519 / Curve25519 */
+#undef HAVE_CURVE25519
+#undef HAVE_ED25519
+#if 0
+    #define HAVE_CURVE25519
+    #define HAVE_ED25519 /* ED25519 Requires SHA512 */
+
+    /* Optionally use small math (less flash usage, but much slower) */
+    #if 1
+        #define CURVED25519_SMALL
+    #endif
+#endif
+
+
+/* ------------------------------------------------------------------------- */
+/* Hashing */
+/* ------------------------------------------------------------------------- */
+/* Sha */
+#undef NO_SHA
+#if 1
+    /* 1k smaller, but 25% slower */
+    //#define USE_SLOW_SHA
+#else
+    #define NO_SHA
+#endif
+
+/* Sha256 */
+#undef NO_SHA256
+#if 1
+    /* not unrolled - ~2k smaller and ~25% slower */
+    //#define USE_SLOW_SHA256
+
+    /* Sha224 */
+    #if 0
+        #define WOLFSSL_SHA224
+    #endif
+#else
+    #define NO_SHA256
+#endif
+
+/* Sha512 */
+#undef WOLFSSL_SHA512
+#if 0
+    #define WOLFSSL_SHA512
+
+    /* Sha384 */
+    #undef  WOLFSSL_SHA384
+    #if 0
+        #define WOLFSSL_SHA384
+    #endif
+
+    /* over twice as small, but 50% slower */
+    //#define USE_SLOW_SHA512
+#endif
+
+/* Sha3 */
+#undef WOLFSSL_SHA3
+#if 0
+    #define WOLFSSL_SHA3
+#endif
+
+/* MD5 */
+#undef  NO_MD5
+#if 0
+
+#else
+    #define NO_MD5
+#endif
+
+/* HKDF */
+#undef HAVE_HKDF
+#if 0
+    #define HAVE_HKDF
+#endif
+
+/* CMAC */
+#undef WOLFSSL_CMAC
+#if 0
+    #define WOLFSSL_CMAC
+#endif
+
+
+/* ------------------------------------------------------------------------- */
+/* Benchmark / Test */
+/* ------------------------------------------------------------------------- */
+/* Use reduced benchmark / test sizes */
+#undef  BENCH_EMBEDDED
+#define BENCH_EMBEDDED
+
+#undef  USE_CERT_BUFFERS_2048
+//#define USE_CERT_BUFFERS_2048
+
+#undef  USE_CERT_BUFFERS_1024
+//#define USE_CERT_BUFFERS_1024
+
+#undef  USE_CERT_BUFFERS_256
+#define USE_CERT_BUFFERS_256
+
+
+/* ------------------------------------------------------------------------- */
+/* Debugging */
+/* ------------------------------------------------------------------------- */
+
+#undef DEBUG_WOLFSSL
+#undef NO_ERROR_STRINGS
+#if 0
+    #define DEBUG_WOLFSSL
+#else
+    #if 0
+        #define NO_ERROR_STRINGS
+    #endif
+#endif
+
+
+/* ------------------------------------------------------------------------- */
+/* Memory */
+/* ------------------------------------------------------------------------- */
+
+/* Override Memory API's */
+#if 0
+    #undef  XMALLOC_OVERRIDE
+    #define XMALLOC_OVERRIDE
+
+    /* prototypes for user heap override functions */
+    /* Note: Realloc only required for normal math */
+    #include <stddef.h>  /* for size_t */
+    extern void *myMalloc(size_t n, void* heap, int type);
+    extern void myFree(void *p, void* heap, int type);
+    extern void *myRealloc(void *p, size_t n, void* heap, int type);
+
+    #define XMALLOC(n, h, t)     myMalloc(n, h, t)
+    #define XFREE(p, h, t)       myFree(p, h, t)
+    #define XREALLOC(p, n, h, t) myRealloc(p, n, h, t)
+#endif
+
+#if 0
+    /* Static memory requires fast math */
+    #define WOLFSSL_STATIC_MEMORY
+
+    /* Disable fallback malloc/free */
+    #define WOLFSSL_NO_MALLOC
+    #if 1
+        #define WOLFSSL_MALLOC_CHECK /* trap malloc failure */
+    #endif
+#endif
+
+/* Memory callbacks */
+#if 0
+    #undef  USE_WOLFSSL_MEMORY
+    #define USE_WOLFSSL_MEMORY
+
+    /* Use this to measure / print heap usage */
+    #if 1
+        #undef  WOLFSSL_TRACK_MEMORY
+        #define WOLFSSL_TRACK_MEMORY
+
+        #undef  WOLFSSL_DEBUG_MEMORY
+        #define WOLFSSL_DEBUG_MEMORY
+    #endif
+#else
+    #ifndef WOLFSSL_STATIC_MEMORY
+        #define NO_WOLFSSL_MEMORY
+        /* Otherwise we will use stdlib malloc, free and realloc */
+    #endif
+#endif
+
+
+/* ------------------------------------------------------------------------- */
+/* Port */
+/* ------------------------------------------------------------------------- */
+
+/* Override Current Time */
+/* Allows custom "custom_time()" function to be used for benchmark */
+#if defined(WOLFSSL_SIFIVE_RISC_V)
+    #define WOLFSSL_USER_CURRTIME
+    #define WOLFSSL_GMTIME
+    #define USER_TICKS
+#endif
+
+#if !defined(WOLFSSL_SIFIVE_RISC_V)
+// extern unsigned long my_time(unsigned long* timer);
+// #define XTIME my_time
+#endif
+
+/* ------------------------------------------------------------------------- */
+/* RNG */
+/* ------------------------------------------------------------------------- */
+
+#if defined(WOLFSSL_SIFIVE_RISC_V)
+    /* Override P-RNG with HW RNG */
+    //extern int my_random_generate(byte* output, word32 sz);
+    //#undef  CUSTOM_RAND_GENERATE_BLOCK
+    //#define CUSTOM_RAND_GENERATE_BLOCK  my_random_generate
+    #define WOLFSSL_GENSEED_FORTEST /* for software RNG*/
+#else
+    #define WOLFSSL_GENSEED_FORTEST
+#endif
+
+
+/* ------------------------------------------------------------------------- */
+/* Enable Features */
+/* ------------------------------------------------------------------------- */
+#undef WOLFSSL_TLS13
+#if 0
+    #define WOLFSSL_TLS13
+#endif
+
+#undef WOLFSSL_KEY_GEN
+#if 0
+    #define WOLFSSL_KEY_GEN
+#endif
+
+/* reduce DH test time */
+#define WOLFSSL_OLD_PRIME_CHECK
+
+#undef  KEEP_PEER_CERT
+//#define KEEP_PEER_CERT
+
+#undef  HAVE_COMP_KEY
+//#define HAVE_COMP_KEY
+
+#undef  HAVE_TLS_EXTENSIONS
+#define HAVE_TLS_EXTENSIONS
+
+#undef  HAVE_SUPPORTED_CURVES
+#define HAVE_SUPPORTED_CURVES
+
+#undef  WOLFSSL_BASE64_ENCODE
+#define WOLFSSL_BASE64_ENCODE
+
+/* TLS Session Cache */
+#if 0
+    #define SMALL_SESSION_CACHE
+#else
+    #define NO_SESSION_CACHE
+#endif
+
+
+/* ------------------------------------------------------------------------- */
+/* Disable Features */
+/* ------------------------------------------------------------------------- */
+#undef  NO_WOLFSSL_SERVER
+//#define NO_WOLFSSL_SERVER
+
+#undef  NO_WOLFSSL_CLIENT
+//#define NO_WOLFSSL_CLIENT
+
+#undef  NO_CRYPT_TEST
+//#define NO_CRYPT_TEST
+
+#undef  NO_CRYPT_BENCHMARK
+//#define NO_CRYPT_BENCHMARK
+
+#undef  WOLFCRYPT_ONLY
+//#define WOLFCRYPT_ONLY
+
+/* In-lining of misc.c functions */
+/* If defined, must include wolfcrypt/src/misc.c in build */
+/* Slower, but about 1k smaller */
+#undef  NO_INLINE
+//#define NO_INLINE
+
+#undef  NO_FILESYSTEM
+#define NO_FILESYSTEM
+
+#undef  NO_WRITEV
+#define NO_WRITEV
+
+#undef  NO_MAIN_DRIVER
+#define NO_MAIN_DRIVER
+
+#undef  NO_DEV_RANDOM
+#define NO_DEV_RANDOM
+
+#undef  NO_DSA
+#define NO_DSA
+
+#undef  NO_RC4
+#define NO_RC4
+
+#undef  NO_OLD_TLS
+#define NO_OLD_TLS
+
+#undef  NO_HC128
+#define NO_HC128
+
+#undef  NO_RABBIT
+#define NO_RABBIT
+
+#undef  NO_PSK
+#define NO_PSK
+
+#undef  NO_MD4
+#define NO_MD4
+
+#undef  NO_PWDBASED
+#define NO_PWDBASED
+
+#undef  NO_CODING
+//#define NO_CODING
+
+#undef  NO_ASN_TIME
+//#define NO_ASN_TIME
+
+#undef  NO_CERTS
+//#define NO_CERTS
+
+#undef  NO_SIG_WRAPPER
+//#define NO_SIG_WRAPPER
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WOLFSSL_USER_SETTINGS_H */
+

--- a/IDE/ECLIPSE/SIFIVE/user_settings.h
+++ b/IDE/ECLIPSE/SIFIVE/user_settings.h
@@ -70,22 +70,9 @@ extern "C" {
     //#define TFM_ARM
 #endif
 
-/* Wolf Single Precision Math */
-/* Optional ECC SECP256R1 acceleration using optimized C code */
-#undef WOLFSSL_SP
-#if 1
-    #define WOLFSSL_SP
-    #define WOLFSSL_SP_SMALL  /* use smaller version of code (requires heap) */
-    #define SP_WORD_SIZE 32   /* force 32-bit type */
-    #define WOLFSSL_SP_MATH   /* only SP math - eliminates fast math code */
-    //#define WOLFSSL_SP_DIV_32 /* do not use 64-bit divides */
-
-    #define WOLFSSL_HAVE_SP_ECC
-    //#define WOLFSSL_HAVE_SP_RSA
-#endif
 
 /* ------------------------------------------------------------------------- */
-/* Crypto */
+/* Asymmetric */
 /* ------------------------------------------------------------------------- */
 /* RSA */
 /* Not enabled due to memory constraints on HiFive1 */
@@ -205,6 +192,43 @@ extern "C" {
 #endif
 
 
+/* Wolf Single Precision Math */
+/* Optional ECC SECP256R1 acceleration using optimized C code */
+#undef WOLFSSL_SP
+#if 1
+    #define WOLFSSL_SP
+    #define WOLFSSL_SP_SMALL  /* use smaller version of code (requires heap) */
+    #define SP_WORD_SIZE 32   /* force 32-bit type */
+    #define WOLFSSL_SP_MATH   /* only SP math - eliminates fast math code */
+    //#define WOLFSSL_SP_DIV_32 /* do not use 64-bit divides */
+
+    #ifdef HAVE_ECC
+        #define WOLFSSL_HAVE_SP_ECC
+    #endif
+    #ifndef NO_RSA
+        #define WOLFSSL_HAVE_SP_RSA
+    #endif
+#endif
+
+/* Ed25519 / Curve25519 */
+#undef HAVE_CURVE25519
+#undef HAVE_ED25519
+#if 1
+    #define HAVE_CURVE25519
+    #define HAVE_ED25519 /* ED25519 Requires SHA512 */
+
+    /* Optionally use small math (less flash usage, but much slower) */
+    #if 1
+        /* Curve and Ed 25519 small */
+        #define CURVED25519_SMALL
+    #endif
+#endif
+
+
+/* ------------------------------------------------------------------------- */
+/* Symmetric Ciphers */
+/* ------------------------------------------------------------------------- */
+
 /* AES */
 #undef NO_AES
 #if 1
@@ -230,7 +254,6 @@ extern "C" {
     //#define HAVE_AESCCM
 #endif
 
-
 /* DES3 */
 #undef NO_DES3
 #if 0
@@ -250,23 +273,9 @@ extern "C" {
     #define HAVE_ONE_TIME_AUTH
 #endif
 
-/* Ed25519 / Curve25519 */
-#undef HAVE_CURVE25519
-#undef HAVE_ED25519
-#if 1
-    #define HAVE_CURVE25519
-    #define HAVE_ED25519 /* ED25519 Requires SHA512 */
-
-    /* Optionally use small math (less flash usage, but much slower) */
-    #if 1
-        /* Curve and Ed 25519 small */
-        #define CURVED25519_SMALL
-    #endif
-#endif
-
 
 /* ------------------------------------------------------------------------- */
-/* Hashing */
+/* Symmetric Hashing */
 /* ------------------------------------------------------------------------- */
 /* Sha */
 #undef NO_SHA
@@ -318,6 +327,18 @@ extern "C" {
 
 #else
     #define NO_MD5
+#endif
+
+/* Blake2B */
+#undef HAVE_BLAKE2
+#if 0
+    #define HAVE_BLAKE2
+#endif
+
+/* Blake2S */
+#undef HAVE_BLAKE2S
+#if 0
+    #define HAVE_BLAKE2S
 #endif
 
 /* HKDF */
@@ -386,6 +407,7 @@ extern "C" {
     #define XREALLOC(p, n, h, t) myRealloc(p, n, h, t)
 #endif
 
+/* Static memory */
 #if 0
     /* Static memory requires fast math */
     #define WOLFSSL_STATIC_MEMORY
@@ -423,9 +445,8 @@ extern "C" {
 /* ------------------------------------------------------------------------- */
 
 /* Override Current Time */
-/* Allows custom "custom_time()" function to be used for benchmark */
 #if defined(WOLFSSL_SIFIVE_RISC_V)
-    #define WOLFSSL_USER_CURRTIME
+    #define WOLFSSL_USER_CURRTIME /* for benchmarks, uses "custom_time()" function */
     #define WOLFSSL_GMTIME
     #define USER_TICKS
 #else
@@ -569,4 +590,3 @@ extern "C" {
 #endif
 
 #endif /* WOLFSSL_USER_SETTINGS_H */
-

--- a/IDE/ECLIPSE/SIFIVE/user_settings.h
+++ b/IDE/ECLIPSE/SIFIVE/user_settings.h
@@ -70,10 +70,25 @@ extern "C" {
     //#define TFM_ARM
 #endif
 
+/* Wolf Single Precision Math */
+/* Optional ECC SECP256R1 acceleration using optimized C code */
+#undef WOLFSSL_SP
+#if 1
+    #define WOLFSSL_SP
+    #define WOLFSSL_SP_SMALL  /* use smaller version of code (requires heap) */
+    #define SP_WORD_SIZE 32   /* force 32-bit type */
+    #define WOLFSSL_SP_MATH   /* only SP math - eliminates fast math code */
+    //#define WOLFSSL_SP_DIV_32 /* do not use 64-bit divides */
+
+    #define WOLFSSL_HAVE_SP_ECC
+    //#define WOLFSSL_HAVE_SP_RSA
+#endif
+
 /* ------------------------------------------------------------------------- */
 /* Crypto */
 /* ------------------------------------------------------------------------- */
 /* RSA */
+/* Not enabled due to memory constraints on HiFive1 */
 #undef NO_RSA
 #if 0
     #ifdef USE_FAST_MATH
@@ -166,17 +181,9 @@ extern "C" {
             #define FP_MAX_BITS     (256 + 32)
         #else
             #undef  ALT_ECC_SIZE
-            #define ALT_ECC_SIZE
-        #endif
-
-        /* Speedups specific to curve */
-        #ifndef NO_ECC256
-            #undef  TFM_ECC256
-            //#define TFM_ECC256
-        #endif
-        #ifndef HAVE_ECC384
-            #undef  TFM_ECC384
-            //#define TFM_ECC384
+            /* Disable alternate ECC size, since it uses HEAP allocations.
+                Heap is limited resource on HiFive1 */
+            //#define ALT_ECC_SIZE
         #endif
     #endif
 #endif
@@ -203,7 +210,7 @@ extern "C" {
 #if 1
     #undef  HAVE_AES_CBC
     #define HAVE_AES_CBC
-    
+
     #undef  HAVE_AESGCM
     #define HAVE_AESGCM
 
@@ -234,7 +241,7 @@ extern "C" {
 /* ChaCha20 / Poly1305 */
 #undef HAVE_CHACHA
 #undef HAVE_POLY1305
-#if 0
+#if 1
     #define HAVE_CHACHA
     #define HAVE_POLY1305
 
@@ -246,12 +253,13 @@ extern "C" {
 /* Ed25519 / Curve25519 */
 #undef HAVE_CURVE25519
 #undef HAVE_ED25519
-#if 0
+#if 1
     #define HAVE_CURVE25519
     #define HAVE_ED25519 /* ED25519 Requires SHA512 */
 
     /* Optionally use small math (less flash usage, but much slower) */
     #if 1
+        /* Curve and Ed 25519 small */
         #define CURVED25519_SMALL
     #endif
 #endif
@@ -285,7 +293,7 @@ extern "C" {
 
 /* Sha512 */
 #undef WOLFSSL_SHA512
-#if 0
+#if 1
     #define WOLFSSL_SHA512
 
     /* Sha384 */
@@ -333,7 +341,7 @@ extern "C" {
 #define BENCH_EMBEDDED
 
 #undef  USE_CERT_BUFFERS_2048
-//#define USE_CERT_BUFFERS_2048
+#define USE_CERT_BUFFERS_2048
 
 #undef  USE_CERT_BUFFERS_1024
 //#define USE_CERT_BUFFERS_1024
@@ -420,23 +428,20 @@ extern "C" {
     #define WOLFSSL_USER_CURRTIME
     #define WOLFSSL_GMTIME
     #define USER_TICKS
-#endif
-
-#if !defined(WOLFSSL_SIFIVE_RISC_V)
-// extern unsigned long my_time(unsigned long* timer);
-// #define XTIME my_time
+#else
+    // extern unsigned long my_time(unsigned long* timer);
+    // #define XTIME my_time
 #endif
 
 /* ------------------------------------------------------------------------- */
 /* RNG */
 /* ------------------------------------------------------------------------- */
-
-#if 1
-/* Bypass P-RNG and use only HW RNG */
-#define CUSTOM_RAND_TYPE      unsigned int
-extern int my_rng_gen_block(unsigned char* output, unsigned int sz);
-#undef  CUSTOM_RAND_GENERATE_BLOCK
-#define CUSTOM_RAND_GENERATE_BLOCK  my_rng_gen_block
+#if 0
+    /* Bypass P-RNG and use only HW RNG */
+    #define CUSTOM_RAND_TYPE      unsigned int
+    extern int my_rng_gen_block(unsigned char* output, unsigned int sz);
+    #undef  CUSTOM_RAND_GENERATE_BLOCK
+    #define CUSTOM_RAND_GENERATE_BLOCK  my_rng_gen_block
 #else
     #define HAVE_HASHDRBG
 
@@ -477,7 +482,7 @@ extern int my_rng_gen_block(unsigned char* output, unsigned int sz);
 #define HAVE_SUPPORTED_CURVES
 
 #undef  WOLFSSL_BASE64_ENCODE
-#define WOLFSSL_BASE64_ENCODE
+//#define WOLFSSL_BASE64_ENCODE
 
 /* TLS Session Cache */
 #if 0

--- a/IDE/ECLIPSE/SIFIVE/user_settings.h
+++ b/IDE/ECLIPSE/SIFIVE/user_settings.h
@@ -312,7 +312,7 @@ extern "C" {
     #endif
 
     /* over twice as small, but 50% slower */
-    //#define USE_SLOW_SHA512
+    #define USE_SLOW_SHA512
 #endif
 
 /* Sha3 */

--- a/IDE/ECLIPSE/SIFIVE/user_settings.h
+++ b/IDE/ECLIPSE/SIFIVE/user_settings.h
@@ -118,11 +118,11 @@ extern "C" {
 
     #ifdef ECC_USER_CURVES
         /* Manual Curve Selection */
-        //#define HAVE_ECC192
-        //#define HAVE_ECC224
+        #define HAVE_ECC192
+        #define HAVE_ECC224
         #undef NO_ECC256
-        //#define HAVE_ECC384
-        //#define HAVE_ECC521
+        #define HAVE_ECC384
+        #define HAVE_ECC521
     #endif
 
     /* Fixed point cache (speeds repeated operations against same private key) */
@@ -203,29 +203,24 @@ extern "C" {
 #if 1
     #undef  HAVE_AES_CBC
     #define HAVE_AES_CBC
+    
+    #undef  HAVE_AESGCM
+    #define HAVE_AESGCM
 
-    /* If you need other than AES-CBC mode, you must undefine WOLFSSL_CRYPTOCELL_AES */
-    #if !defined(WOLFSSL_CRYPTOCELL_AES)
-        #undef  HAVE_AESGCM
-        #define HAVE_AESGCM
+    /* GCM Method: GCM_SMALL, GCM_WORD32 or GCM_TABLE */
+    #define GCM_SMALL
 
-        /* GCM Method: GCM_SMALL, GCM_WORD32 or GCM_TABLE */
-        #define GCM_SMALL
+    #undef  WOLFSSL_AES_DIRECT
+    //#define WOLFSSL_AES_DIRECT
 
-        #undef  WOLFSSL_AES_DIRECT
-        //#define WOLFSSL_AES_DIRECT
+    #undef  HAVE_AES_ECB
+    //#define HAVE_AES_ECB
 
-        #undef  HAVE_AES_ECB
-        //#define HAVE_AES_ECB
+    #undef  WOLFSSL_AES_COUNTER
+    //#define WOLFSSL_AES_COUNTER
 
-        #undef  WOLFSSL_AES_COUNTER
-        //#define WOLFSSL_AES_COUNTER
-
-        #undef  HAVE_AESCCM
-        //#define HAVE_AESCCM
-    #endif
-#else
-    #define NO_AES
+    #undef  HAVE_AESCCM
+    //#define HAVE_AESCCM
 #endif
 
 
@@ -436,16 +431,22 @@ extern "C" {
 /* RNG */
 /* ------------------------------------------------------------------------- */
 
-#if defined(WOLFSSL_SIFIVE_RISC_V)
-    /* Override P-RNG with HW RNG */
-    //extern int my_random_generate(byte* output, word32 sz);
-    //#undef  CUSTOM_RAND_GENERATE_BLOCK
-    //#define CUSTOM_RAND_GENERATE_BLOCK  my_random_generate
-    #define WOLFSSL_GENSEED_FORTEST /* for software RNG*/
+#if 1
+/* Bypass P-RNG and use only HW RNG */
+#define CUSTOM_RAND_TYPE      unsigned int
+extern int my_rng_gen_block(unsigned char* output, unsigned int sz);
+#undef  CUSTOM_RAND_GENERATE_BLOCK
+#define CUSTOM_RAND_GENERATE_BLOCK  my_rng_gen_block
 #else
-    #define WOLFSSL_GENSEED_FORTEST
-#endif
+    #define HAVE_HASHDRBG
 
+    /* Seed Source */
+    /* Size of returned HW RNG value */
+    #define CUSTOM_RAND_TYPE      unsigned int
+    extern unsigned int my_rng_seed_gen(void);
+    #undef  CUSTOM_RAND_GENERATE
+    #define CUSTOM_RAND_GENERATE  my_rng_seed_gen
+#endif
 
 /* ------------------------------------------------------------------------- */
 /* Enable Features */

--- a/IDE/include.am
+++ b/IDE/include.am
@@ -18,6 +18,7 @@ include IDE/GCC-ARM/include.am
 include IDE/CSBENCH/include.am
 include IDE/ECLIPSE/DEOS/include.am
 include IDE/ECLIPSE/MICRIUM/include.am
+include IDE/ECLIPSE/SIFIVE/include.am
 include IDE/mynewt/include.am
 include IDE/Renesas/cs+/Projects/include.am
 include IDE/Renesas/e2studio/Projects/include.am

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2327,12 +2327,13 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 #endif
 
 #ifdef USE_TEST_GENSEED
+#ifndef WOLFSSL_SIFIVE_RISC_V    
     #ifndef _MSC_VER
         #warning "write a real random seed!!!!, just for testing now"
     #else
         #pragma message("Warning: write a real random seed!!!!, just for testing now")
     #endif
-
+#endif /* !WOLFSSL_SIFIVE_RISC_V*/
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
         word32 i;

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2327,13 +2327,11 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 #endif
 
 #ifdef USE_TEST_GENSEED
-#ifndef WOLFSSL_SIFIVE_RISC_V    
     #ifndef _MSC_VER
         #warning "write a real random seed!!!!, just for testing now"
     #else
         #pragma message("Warning: write a real random seed!!!!, just for testing now")
     #endif
-#endif /* !WOLFSSL_SIFIVE_RISC_V*/
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
         word32 i;

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -7369,7 +7369,7 @@ static int sp_256_mod_mul_norm_10(sp_digit* r, sp_digit* a, sp_digit* m)
     (void)m;
 
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
-    td = (sp_digit*)XMALLOC(sizeof(int64_t) * 2 * 8, NULL, DYNAMIC_TYPE_ECC);
+    td = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 8, NULL, DYNAMIC_TYPE_ECC);
     if (td != NULL) {
         t = td;
         a32 = td + 8;

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -7212,7 +7212,7 @@ static int sp_256_mod_mul_norm_5(sp_digit* r, sp_digit* a, sp_digit* m)
     (void)m;
 
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
-    td = (sp_digit*)XMALLOC(sizeof(int64_t) * 2 * 8, NULL, DYNAMIC_TYPE_ECC);
+    td = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 8, NULL, DYNAMIC_TYPE_ECC);
     if (td != NULL) {
         t = td;
         a32 = td + 8;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -15904,6 +15904,19 @@ static int ecc_test_make_pub(WC_RNG* rng)
 
     wc_ecc_init_ex(&key, HEAP_HINT, devId);
 
+#ifdef USE_CERT_BUFFERS_256
+    tmp = (byte*)XMALLOC((size_t)sizeof_ecc_key_der_256, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    if (tmp == NULL) {
+        return -8311;
+    }
+    exportBuf = (byte*)XMALLOC((size_t)sizeof_ecc_key_der_256, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    if (exportBuf == NULL) {
+        XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        return -8312;
+    }
+    XMEMCPY(tmp, ecc_key_der_256, (size_t)sizeof_ecc_key_der_256);
+    tmpSz = (size_t)sizeof_ecc_key_der_256;
+#else
     tmp = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (tmp == NULL) {
         return -8311;
@@ -15913,11 +15926,6 @@ static int ecc_test_make_pub(WC_RNG* rng)
         XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
         return -8312;
     }
-
-#ifdef USE_CERT_BUFFERS_256
-    XMEMCPY(tmp, ecc_key_der_256, (size_t)sizeof_ecc_key_der_256);
-    tmpSz = (size_t)sizeof_ecc_key_der_256;
-#else
     file = XFOPEN(eccKeyDerFile, "rb");
     if (!file) {
         ERROR_OUT(-8313, done);


### PR DESCRIPTION
- Added support for SiFive HiFive E31 RISC‐V core family
- Created freedom-e-sdk based makefile to build wolfSSL similar to the existing examples
- Updated ECC test code to not allocate more memory than required
- Run wolfcrypt and benchmark tests on the SiFive HiFive1 rev A and B targets
  For details, see the README file. 