### PR TITLE
NetBSD Selftest, TLSv1.3, and wolfCrypt v4

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -1696,6 +1696,12 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
                 #endif
 
                     nonceSz = AESGCM_NONCE_SZ;
+                #if ((defined(HAVE_FIPS) || defined(HAVE_SELFTEST)) && \
+                    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2)))
+                    ret = wc_AesGcmEncrypt(ssl->encrypt.aes, output, input,
+                        dataSz, ssl->encrypt.nonce, nonceSz,
+                        output + dataSz, macSz, aad, aadSz);
+                #else
                     ret = wc_AesGcmSetExtIV(ssl->encrypt.aes,
                             ssl->encrypt.nonce, nonceSz);
                     if (ret == 0) {
@@ -1703,6 +1709,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
                                 input, dataSz, ssl->encrypt.nonce, nonceSz,
                                 output + dataSz, macSz, aad, aadSz);
                     }
+                #endif
                     break;
             #endif
 
@@ -1717,6 +1724,12 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
                 #endif
 
                     nonceSz = AESCCM_NONCE_SZ;
+                #if ((defined(HAVE_FIPS) || defined(HAVE_SELFTEST)) && \
+                    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2)))
+                    ret = wc_AesCcmEncrypt(ssl->encrypt.aes, output, input,
+                        dataSz, ssl->encrypt.nonce, nonceSz,
+                        output + dataSz, macSz, aad, aadSz);
+                #else
                     ret = wc_AesCcmSetNonce(ssl->encrypt.aes,
                             ssl->encrypt.nonce, nonceSz);
                     if (ret == 0) {
@@ -1724,6 +1737,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
                                 input, dataSz, ssl->encrypt.nonce, nonceSz,
                                 output + dataSz, macSz, aad, aadSz);
                     }
+                #endif
                     break;
             #endif
 


### PR DESCRIPTION
When building for TLSv1.3 and the NetBSD Selftest, need to use the old pre-wolfCrypt v4 APIs for AES-GCM and AES-CCM.