### PR TITLE
STSAFE Improvements to support Crypto Callbacks

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#include <wolfssl/wolfcrypt/settings.h>
+
 #if !defined(WOLFSSL_BIO_INCLUDED)
     #ifndef WOLFSSL_IGNORE_FILE_WARN
         #warning bio.c does not need to be compiled separately from ssl.c

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#include <wolfssl/wolfcrypt/settings.h>
+
 #if !defined(WOLFSSL_EVP_INCLUDED)
     #ifndef WOLFSSL_IGNORE_FILE_WARN
         #warning evp.c does not need to be compiled seperatly from ssl.c

--- a/wolfcrypt/src/port/st/stsafe.c
+++ b/wolfcrypt/src/port/st/stsafe.c
@@ -39,7 +39,7 @@ int SSL_STSAFE_LoadDeviceCertificate(byte** pRawCertificate,
 
     /* Try reading device certificate from ST-SAFE Zone 0 */
     err = stsafe_interface_read_device_certificate_raw(
-        pRawCertificate, pRawCertificateLen);
+        pRawCertificate, (uint32_t*)pRawCertificateLen);
     if (err == 0) {
     #if 0
         /* example for loading into WOLFSSL_CTX */
@@ -154,7 +154,7 @@ int SSL_STSAFE_VerifyPeerCertCb(WOLFSSL* ssl,
     if (err == 0) {
         /* Verify signature */
         err = stsafe_interface_verify(curve_id, (uint8_t*)hash, sigRS,
-            pubKeyX, pubKeyY, result);
+            pubKeyX, pubKeyY, (int32_t*)result);
     }
 
     wc_ecc_free(&key);

--- a/wolfcrypt/src/port/st/stsafe.c
+++ b/wolfcrypt/src/port/st/stsafe.c
@@ -325,4 +325,191 @@ int SSL_STSAFE_SetupPkCallbackCtx(WOLFSSL* ssl, void* user_ctx)
 
 #endif /* HAVE_PK_CALLBACKS */
 
+#ifdef WOLF_CRYPTO_CB
+
+int wolfSSL_STSAFE_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
+{
+    int rc = CRYPTOCB_UNAVAILABLE;
+    wolfSTSAFE_CryptoCb_Ctx* stsCtx = (wolfSTSAFE_CryptoCb_Ctx*)ctx;
+
+    if (info == NULL || ctx == NULL)
+        return BAD_FUNC_ARG;
+
+    (void)devId;
+    (void)stsCtx;
+
+    if (info->algo_type == WC_ALGO_TYPE_SEED) {
+        /* use the STSAFE hardware for RNG seed */
+    #if !defined(WC_NO_RNG) && defined(USE_STSAFE_RNG_SEED)
+        while (info->seed.sz > 0) {
+            rc = stsafe_interface_getrandom(info->seed.seed, info->seed.sz);
+            if (rc < 0) {
+                return rc;
+            }
+            info->seed.seed += rc;
+            info->seed.sz -= rc;
+        }
+        rc = 0;
+    #else
+        rc = CRYPTOCB_UNAVAILABLE;
+    #endif
+    }
+#ifdef HAVE_ECC
+    else if (info->algo_type == WC_ALGO_TYPE_PK) {
+    #ifdef USE_STSAFE_VERBOSE
+        printf("STSAFE Pk: Type %d\n", info->pk.type);
+    #endif
+
+        if (info->pk.type == WC_PK_TYPE_EC_KEYGEN) {
+            byte pubKeyRaw[STSAFE_MAX_PUBKEY_RAW_LEN];
+            StSafeA_KeySlotNumber slot;
+            StSafeA_CurveId curve_id;
+            int ecc_curve, key_sz;
+
+            WOLFSSL_MSG("STSAFE: ECC KeyGen");
+
+            /* get curve */
+            ecc_curve = info->pk.eckg.curveId;
+            curve_id = stsafe_get_ecc_curve_id(ecc_curve);
+            key_sz = stsafe_get_key_size(curve_id);
+
+            /* generate new ephemeral key on device */
+            rc = stsafe_interface_create_key(&slot, curve_id,
+                (uint8_t*)pubKeyRaw);
+            if (rc != 0) {
+                return rc;
+            }
+
+            /* load generated public key into key, used by wolfSSL */
+            rc = wc_ecc_import_unsigned(info->pk.eckg.key, pubKeyRaw,
+                &pubKeyRaw[key_sz], NULL, ecc_curve);
+        }
+        else if (info->pk.type == WC_PK_TYPE_ECDSA_SIGN) {
+            byte digest[STSAFE_MAX_KEY_LEN];
+            byte sigRS[STSAFE_MAX_SIG_LEN];
+            byte *r, *s;
+            StSafeA_CurveId curve_id;
+            word32 inSz = info->pk.eccsign.inlen;
+            int key_sz;
+
+            WOLFSSL_MSG("STSAFE: ECC Sign");
+
+            curve_id = stsafe_get_curve_mode();
+            key_sz = stsafe_get_key_size(curve_id);
+
+            /* truncate input to match key size */
+            if (inSz > key_sz)
+                inSz = key_sz;
+
+            /* Build input digest */
+            XMEMSET(&digest[0], 0, sizeof(digest));
+            XMEMCPY(&digest[key_sz - inSz], info->pk.eccsign.in, inSz);
+
+            /* Sign using slot 0: Result is R then S */
+            /* Sign will always use the curve type in slot 0
+                (the TLS curve needs to match) */
+            XMEMSET(sigRS, 0, sizeof(sigRS));
+            rc = stsafe_interface_sign(STSAFE_A_SLOT_0, curve_id,
+                (uint8_t*)info->pk.eccsign.in, sigRS);
+            if (rc != 0) {
+                return rc;
+            }
+
+            /* Convert R and S to signature */
+            r = &sigRS[0];
+            s = &sigRS[key_sz];
+            rc = wc_ecc_rs_raw_to_sig((const byte*)r, key_sz, (const byte*)s,
+                key_sz, info->pk.eccsign.out, info->pk.eccsign.outlen);
+            if (rc != 0) {
+                WOLFSSL_MSG("Error converting RS to Signature");
+            }
+        }
+        else if (info->pk.type == WC_PK_TYPE_ECDSA_VERIFY) {
+            byte sigRS[STSAFE_MAX_SIG_LEN];
+            byte *r, *s;
+            word32 r_len = STSAFE_MAX_SIG_LEN/2, s_len = STSAFE_MAX_SIG_LEN/2;
+            byte pubKeyX[STSAFE_MAX_PUBKEY_RAW_LEN/2];
+            byte pubKeyY[STSAFE_MAX_PUBKEY_RAW_LEN/2];
+            word32 pubKeyX_len = sizeof(pubKeyX);
+            word32 pubKeyY_len = sizeof(pubKeyY);
+            StSafeA_CurveId curve_id;
+            int ecc_curve, key_sz;
+
+            WOLFSSL_MSG("STSAFE: ECC Verify");
+
+            if (info->pk.eccverify.key == NULL)
+                return BAD_FUNC_ARG;
+
+            /* determine curve */
+            ecc_curve = info->pk.eccverify.key->dp->id;
+            curve_id = stsafe_get_ecc_curve_id(ecc_curve);
+            key_sz = stsafe_get_key_size(curve_id);
+
+            /* Extract Raw X and Y coordinates of the public key */
+            rc = wc_ecc_export_public_raw(info->pk.eccverify.key,
+                pubKeyX, &pubKeyX_len,
+                pubKeyY, &pubKeyY_len);
+            if (rc == 0) {
+                /* Extract R and S from signature */
+                XMEMSET(sigRS, 0, sizeof(sigRS));
+                r = &sigRS[0];
+                s = &sigRS[key_sz];
+                rc = wc_ecc_sig_to_rs(info->pk.eccverify.sig,
+                    info->pk.eccverify.siglen, r, &r_len, s, &s_len);
+                (void)r_len;
+                (void)s_len;
+            }
+            if (rc == 0) {
+                /* Verify signature */
+                rc = stsafe_interface_verify(curve_id,
+                    (uint8_t*)info->pk.eccverify.hash, sigRS, pubKeyX, pubKeyY,
+                    (int32_t*)info->pk.eccverify.res);
+            }
+        }
+        else if (info->pk.type == WC_PK_TYPE_ECDH) {
+            byte otherKeyX[STSAFE_MAX_KEY_LEN];
+            byte otherKeyY[STSAFE_MAX_KEY_LEN];
+            word32 otherKeyX_len = sizeof(otherKeyX);
+            word32 otherKeyY_len = sizeof(otherKeyY);
+            StSafeA_CurveId curve_id;
+            int ecc_curve;
+
+            WOLFSSL_MSG("STSAFE: PMS");
+
+            if (info->pk.ecdh.public_key == NULL)
+                return BAD_FUNC_ARG;
+
+            /* get curve */
+            ecc_curve = info->pk.ecdh.public_key->dp->id;
+            curve_id = stsafe_get_ecc_curve_id(ecc_curve);
+
+            /* Export otherKey raw X and Y */
+            rc = wc_ecc_export_public_raw(info->pk.ecdh.public_key,
+                &otherKeyX[0], (word32*)&otherKeyX_len,
+                &otherKeyY[0], (word32*)&otherKeyY_len);
+            if (rc == 0) {
+                /* Compute shared secret */
+            	*info->pk.ecdh.outlen = 0;
+                rc = stsafe_interface_shared_secret(curve_id,
+                    otherKeyX, otherKeyY,
+                    info->pk.ecdh.out, (int32_t*)info->pk.ecdh.outlen);
+            }
+        }
+    }
+#endif /* HAVE_ECC */
+
+    /* need to return negative here for error */
+    if (rc != 0 && rc != CRYPTOCB_UNAVAILABLE) {
+        WOLFSSL_MSG("STSAFE: CryptoCb failed");
+    #ifdef USE_STSAFE_VERBOSE
+        printf("STSAFE: CryptoCb failed %d\n", rc);
+    #endif
+        rc = WC_HW_E;
+    }
+
+    return rc;
+}
+
+#endif /* WOLF_CRYPTO_CB */
+
 #endif /* WOLFSSL_STSAFEA100 */

--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -39,10 +39,6 @@
                                     defined(WOLFSSL_HAVE_SP_ECC)
 
 #ifdef RSA_LOW_MEM
-#ifndef SP_RSA_PRIVATE_EXP_D
-#define SP_RSA_PRIVATE_EXP_D
-#endif
-
 #ifndef WOLFSSL_SP_SMALL
 #define WOLFSSL_SP_SMALL
 #endif
@@ -3670,7 +3666,7 @@ static int sp_2048_mod_exp_32(sp_digit* r, sp_digit* a, sp_digit* e,
 
 #endif /* (WOLFSSL_HAVE_SP_RSA || WOLFSSL_HAVE_SP_DH) && !WOLFSSL_RSA_PUBLIC_ONLY */
 
-#ifdef WOLFSSL_HAVE_SP_DH
+#if defined(WOLFSSL_HAVE_SP_RSA) || defined(WOLFSSL_HAVE_SP_DH)
 /* r = 2^n mod m where n is the number of bits to reduce by.
  * Given m must be 2048 bits, just need to subtract.
  *
@@ -3685,7 +3681,8 @@ static void sp_2048_mont_norm_64(sp_digit* r, sp_digit* m)
     sp_2048_sub_in_place_64(r, m);
 }
 
-#endif /* WOLFSSL_HAVE_SP_DH */
+#endif /* WOLFSSL_HAVE_SP_RSA || WOLFSSL_HAVE_SP_DH */
+
 /* Conditionally subtract b from a using the mask m.
  * m is -1 to subtract and 0 when not copying.
  *
@@ -4072,8 +4069,8 @@ static WC_INLINE int sp_2048_mod_64_cond(sp_digit* r, sp_digit* a, sp_digit* m)
     return sp_2048_div_64_cond(a, m, NULL, r);
 }
 
-#if (defined(SP_RSA_PRIVATE_EXP_D) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
-                                                     defined(WOLFSSL_HAVE_SP_DH)
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
+    defined(WOLFSSL_HAVE_SP_DH)
 #ifdef WOLFSSL_SP_SMALL
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
  *
@@ -4346,7 +4343,7 @@ static int sp_2048_mod_exp_64(sp_digit* r, sp_digit* a, sp_digit* e,
     return err;
 }
 #endif /* WOLFSSL_SP_SMALL */
-#endif /* (SP_RSA_PRIVATE_EXP_D && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.
@@ -9134,7 +9131,8 @@ static int sp_3072_mod_exp_48(sp_digit* r, sp_digit* a, sp_digit* e,
 
 #endif /* (WOLFSSL_HAVE_SP_RSA || WOLFSSL_HAVE_SP_DH) && !WOLFSSL_RSA_PUBLIC_ONLY */
 
-#ifdef WOLFSSL_HAVE_SP_DH
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
+                                                     defined(WOLFSSL_HAVE_SP_DH)
 /* r = 2^n mod m where n is the number of bits to reduce by.
  * Given m must be 3072 bits, just need to subtract.
  *
@@ -9149,7 +9147,9 @@ static void sp_3072_mont_norm_96(sp_digit* r, sp_digit* m)
     sp_3072_sub_in_place_96(r, m);
 }
 
-#endif /* WOLFSSL_HAVE_SP_DH */
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
+
+
 /* Conditionally subtract b from a using the mask m.
  * m is -1 to subtract and 0 when not copying.
  *
@@ -9542,7 +9542,7 @@ static WC_INLINE int sp_3072_mod_96_cond(sp_digit* r, sp_digit* a, sp_digit* m)
     return sp_3072_div_96_cond(a, m, NULL, r);
 }
 
-#if (defined(SP_RSA_PRIVATE_EXP_D) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
                                                      defined(WOLFSSL_HAVE_SP_DH)
 #ifdef WOLFSSL_SP_SMALL
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
@@ -9816,7 +9816,7 @@ static int sp_3072_mod_exp_96(sp_digit* r, sp_digit* a, sp_digit* e,
     return err;
 }
 #endif /* WOLFSSL_SP_SMALL */
-#endif /* (SP_RSA_PRIVATE_EXP_D && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -23702,7 +23702,8 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
     }
     else if (info->algo_type == WC_ALGO_TYPE_SEED) {
     #ifndef WC_NO_RNG
-        static byte seed[] = { 0x00, 0x00, 0x00, 0x01 };
+        static byte seed[sizeof(word32)] = { 0x00, 0x00, 0x00, 0x01 };
+        word32* seedWord32 = (word32*)seed;
         word32 len;
 
         /* wc_GenerateSeed is a local symbol so we need to fake the entropy. */
@@ -23713,7 +23714,7 @@ static int myCryptoDevCb(int devIdArg, wc_CryptoInfo* info, void* ctx)
             XMEMCPY(info->seed.seed, seed, sizeof(seed));
             info->seed.seed += len;
             info->seed.sz -= len;
-            (*((word32*)seed))++;
+            (*seedWord32)++;
         }
 
         ret = 0;

--- a/wolfssl/wolfcrypt/port/st/stsafe.h
+++ b/wolfssl/wolfcrypt/port/st/stsafe.h
@@ -29,6 +29,8 @@
 
 #ifdef WOLFSSL_STSAFEA100
 
+/* The wolf STSAFE interface layer */
+/* Please contact wolfSSL for the STSAFE port files */
 #include "stsafe_interface.h"
 
 #ifndef STSAFE_MAX_KEY_LEN
@@ -52,11 +54,11 @@ WOLFSSL_API int SSL_STSAFE_VerifyPeerCertCb(WOLFSSL* ssl,
    const unsigned char* hash, unsigned int hashSz,
    const unsigned char* keyDer, unsigned int keySz,
    int* result, void* ctx);
-WOLFSSL_API int SSL_STSAFE_SignCertificateCb(WOLFSSL* ssl, 
+WOLFSSL_API int SSL_STSAFE_SignCertificateCb(WOLFSSL* ssl,
     const byte* in, word32 inSz,
-    byte* out, word32* outSz, 
+    byte* out, word32* outSz,
     const byte* key, word32 keySz, void* ctx);
-WOLFSSL_API int SSL_STSAFE_SharedSecretCb(WOLFSSL* ssl, 
+WOLFSSL_API int SSL_STSAFE_SharedSecretCb(WOLFSSL* ssl,
     ecc_key* otherKey,
     unsigned char* pubKeyDer, unsigned int* pubKeySz,
     unsigned char* out, unsigned int* outlen,
@@ -65,7 +67,27 @@ WOLFSSL_API int SSL_STSAFE_SharedSecretCb(WOLFSSL* ssl,
 /* Helper API's for setting up callbacks */
 WOLFSSL_API int SSL_STSAFE_SetupPkCallbacks(WOLFSSL_CTX* ctx);
 WOLFSSL_API int SSL_STSAFE_SetupPkCallbackCtx(WOLFSSL* ssl, void* user_ctx);
+#endif /* HAVE_PK_CALLBACKS */
+
+
+#ifdef WOLF_CRYPTO_CB
+
+#include <wolfssl/wolfcrypt/cryptocb.h>
+
+/* Device ID that's unique and valid (not INVALID_DEVID -2) */
+#define WOLF_STSAFE_DEVID 0x53545341; /* STSA */
+
+typedef struct wolfSTSAFE_CryptoCb_Ctx {
+#ifdef HAVE_ECC
+    ecc_key wolfEccKey;
 #endif
+    int devId;
+} wolfSTSAFE_CryptoCb_Ctx;
+
+WOLFSSL_API int wolfSSL_STSAFE_CryptoDevCb(int devId, wc_CryptoInfo* info,
+  void* ctx);
+
+#endif /* WOLF_CRYPTO_CB */
 
 #endif /* WOLFSSL_STSAFEA100 */
 


### PR DESCRIPTION
* Added STSAFE Crypto Callback support.
* Fix to ensure user_settings.h can be included for bio.c and evp.c when IDE or compiler tries to build it directly. Allows for wildcard .c include along with `WOLFSSL_IGNORE_FILE_WARN`.
* Fix for building SP cortex M without RSA.
* Fix for type-cast warning with STSAFE-A100.
* Improved the RNG seed test to prevent type-case warning.