### PR TITLE
avoid mutex lock test after freeing it on NetBSD

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -23495,10 +23495,12 @@ int mutex_test(void)
         return -9904;
     if (wc_FreeMutex(&m) != 0)
         return -9905;
+#ifndef WOLFSSL_NO_MUTEXLOCK_AFTER_FREE
     if (wc_LockMutex(&m) != BAD_MUTEX_E)
         return -9906;
     if (wc_UnLockMutex(&m) != BAD_MUTEX_E)
         return -9907;
+#endif
 #endif
 
     return 0;


### PR DESCRIPTION
On NetBSD 6.0.1, pthread_mutex_lock() returns zero even after freeing mutex.
The changes are to avoid test failure on such system.

Zendesk #5196