### PR TITLE
RIOT-OS support with GNRC TCP/IP sockets

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1706,6 +1706,9 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
 #elif defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP)
     ctx->CBIORecv = Mynewt_Receive;
     ctx->CBIOSend = Mynewt_Send;
+#elif defined(WOLFSSL_GNRC)
+    ctx->CBIORecv = GNRC_Receive;
+    ctx->CBIOSend = GNRC_Send;
 #endif
 
 #ifdef HAVE_NTRU
@@ -5021,8 +5024,10 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     }
     ssl->IOCB_ReadCtx  = ssl->mnCtx;  /* default Mynewt IO ctx, same for read */
     ssl->IOCB_WriteCtx = ssl->mnCtx;  /* and write */
+#elif defined (WOLFSSL_GNRC)
+    ssl->IOCB_ReadCtx = ssl->gnrcCtx;
+    ssl->IOCB_WriteCtx = ssl->gnrcCtx;
 #endif
-
     /* initialize states */
     ssl->options.serverState = NULL_STATE;
     ssl->options.clientState = NULL_STATE;

--- a/src/internal.c
+++ b/src/internal.c
@@ -1707,8 +1707,8 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
     ctx->CBIORecv = Mynewt_Receive;
     ctx->CBIOSend = Mynewt_Send;
 #elif defined(WOLFSSL_GNRC)
-    ctx->CBIORecv = GNRC_Receive;
-    ctx->CBIOSend = GNRC_Send;
+    ctx->CBIORecv = GNRC_ReceiveFrom;
+    ctx->CBIOSend = GNRC_SendTo;
 #endif
 
 #ifdef HAVE_NTRU

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -2241,11 +2241,13 @@ int uIPGenerateCookie(WOLFSSL* ssl, byte *buf, int sz, void *_ctx)
  * return : bytes sent, or error
  */
 
-int GNRC_Send(WOLFSSL* ssl, char* buf, int sz, void* _ctx)
+int GNRC_SendTo(WOLFSSL* ssl, char* buf, int sz, void* _ctx)
 {
     sock_tls_t *ctx = (sock_tls_t *)_ctx;
     int ret = 0;
     (void)ssl;
+    if (!ctx)
+        return WOLFSSL_CBIO_ERR_GENERAL;
     ret = sock_udp_send(&ctx->conn.udp, (unsigned char *)buf, sz, &ctx->peer_addr);
     if (ret == 0)
         return WOLFSSL_CBIO_ERR_WANT_WRITE;
@@ -2255,7 +2257,7 @@ int GNRC_Send(WOLFSSL* ssl, char* buf, int sz, void* _ctx)
 /* The GNRC TCP/IP receive callback
  *  return : nb bytes read, or error
  */
-int GNRC_Receive(WOLFSSL *ssl, char *buf, int sz, void *_ctx)
+int GNRC_ReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *_ctx)
 {
     sock_udp_ep_t ep;
     int ret;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3924,6 +3924,9 @@ struct WOLFSSL {
 #if defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP)
     void*           mnCtx;             /* mynewt mn_socket IO Context */
 #endif /* defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP) */
+#ifdef WOLFSSL_GNRC
+    struct gnrc_wolfssl_ctx *gnrcCtx;  /* Riot-OS GNRC UDP/IP context */
+#endif
 #ifdef SESSION_INDEX
     int sessionIndex;                  /* Session's location in the cache. */
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -529,6 +529,9 @@
     #define TFM_NO_ASM
     #define NO_FILESYSTEM
     #define USE_CERT_BUFFERS_2048
+    #if defined(WOLFSSL_GNRC) && !defined(WOLFSSL_DTLS)
+        #define WOLFSSL_DTLS
+    #endif
 #endif
 
 #ifdef WOLFSSL_CHIBIOS

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -527,7 +527,6 @@
 #ifdef WOLFSSL_RIOT_OS
     #define NO_WRITEV
     #define TFM_NO_ASM
-    #define USE_FAST_MATH
     #define NO_FILESYSTEM
     #define USE_CERT_BUFFERS_2048
 #endif

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -830,9 +830,7 @@
     #endif
 
 
-    #ifdef WOLFSSL_RIOT_OS
-        #define EXIT_TEST(ret) exit(ret)
-    #elif defined(HAVE_STACK_SIZE)
+    #if defined(HAVE_STACK_SIZE)
         #define EXIT_TEST(ret) return (void*)((size_t)(ret))
     #else
         #define EXIT_TEST(ret) return ret

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -133,7 +133,8 @@
             #include "rtipapi.h"  /* errno */
             #include "socket.h"
         #elif !defined(DEVKITPRO) && !defined(WOLFSSL_PICOTCP) \
-                && !defined(WOLFSSL_CONTIKI) && !defined(WOLFSSL_WICED)
+                && !defined(WOLFSSL_CONTIKI) && !defined(WOLFSSL_WICED) \
+                && !defined(WOLFSSL_GNRC) && !defined(WOLFSSL_RIOT_OS)
             #include <sys/socket.h>
             #include <arpa/inet.h>
             #include <netinet/in.h>
@@ -490,6 +491,37 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
     WOLFSSL_LOCAL int uIPSendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 
 #endif
+
+#ifdef WOLFSSL_GNRC
+    #include <sock_types.h>
+    #include <net/gnrc.h>
+    #include <net/af.h>
+    #include <net/sock.h>
+    #include <net/gnrc/tcp.h>
+    #include <net/gnrc/udp.h>
+
+    struct gnrc_wolfssl_ctx {
+        union socket_connector {
+        #ifdef MODULE_SOCK_TCP
+            sock_tcp_t tcp;
+        #endif
+            sock_udp_t udp;
+        } conn;
+        WOLFSSL_CTX *ctx;
+        WOLFSSL *ssl;
+
+        int closing;
+        struct _sock_tl_ep peer_addr;
+    };
+
+    typedef struct gnrc_wolfssl_ctx sock_tls_t;
+
+    WOLFSSL_LOCAL int GNRC_Receive(WOLFSSL* ssl, char* buf, int sz,
+                                     void* ctx);
+    WOLFSSL_LOCAL int GNRC_SendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+
+#endif
+
 
 #ifdef WOLFSSL_DTLS
     typedef int (*CallbackGenCookie)(WOLFSSL* ssl, unsigned char* buf, int sz,

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -516,9 +516,9 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
 
     typedef struct gnrc_wolfssl_ctx sock_tls_t;
 
-    WOLFSSL_LOCAL int GNRC_Receive(WOLFSSL* ssl, char* buf, int sz,
+    WOLFSSL_LOCAL int GNRC_ReceiveFrom(WOLFSSL* ssl, char* buf, int sz,
                                      void* ctx);
-    WOLFSSL_LOCAL int GNRC_Send(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+    WOLFSSL_LOCAL int GNRC_SendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 
 #endif
 

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -518,7 +518,7 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
 
     WOLFSSL_LOCAL int GNRC_Receive(WOLFSSL* ssl, char* buf, int sz,
                                      void* ctx);
-    WOLFSSL_LOCAL int GNRC_SendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+    WOLFSSL_LOCAL int GNRC_Send(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 
 #endif
 


### PR DESCRIPTION
Add support for RIOT-OS GNRC TCP/IP sockets via WOLFSSL_GNRC