### PR TITLE
CAVP self test build fixes for AES-CCM and PKCS7

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -51,12 +51,6 @@
     #include <wolfcrypt/src/misc.c>
 #endif
 
-#ifdef HAVE_SELFTEST
-enum {
-    GCM_NONCE_MID_SZ = 12, /* The usual default nonce size for AES-GCM. */
-};
-#endif
-
 /* direction for processing, encoding or decoding */
 typedef enum {
     WC_PKCS7_ENCODE,

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -7939,8 +7939,12 @@ int aesccm_test(void)
     XMEMSET(p2, 0, sizeof(p2));
     XMEMSET(iv2, 0, sizeof(iv2));
 
+#ifndef HAVE_SELFTEST
+    /* selftest build does not have wc_AesCcmSetNonce() or
+     * wc_AesCcmEncrypt_ex() */
     if (wc_AesCcmSetKey(&enc, k, sizeof(k)) != 0)
         return -8220;
+
     if (wc_AesCcmSetNonce(&enc, iv, sizeof(iv)) != 0)
         return -8221;
     if (wc_AesCcmEncrypt_ex(&enc, c2, p, sizeof(c2), iv2, sizeof(iv2),
@@ -7952,6 +7956,7 @@ int aesccm_test(void)
         return -8224;
     if (XMEMCMP(t, t2, sizeof(t2)))
         return -8225;
+#endif
 
     return 0;
 }

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -153,9 +153,11 @@ enum Pkcs7_Misc {
     MAX_RECIP_SZ          = MAX_VERSION_SZ +
                             MAX_SEQ_SZ + ASN_NAME_MAX + MAX_SN_SZ +
                             MAX_SEQ_SZ + MAX_ALGO_SZ + 1 + MAX_ENCRYPTED_KEY_SZ,
-#if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
-    /* In the event of fips cert 3389 these enums are not in aes.h for use
-     * with pkcs7 so enumerate it here outside the fips boundary */
+#if (defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
+     (HAVE_FIPS_VERSION >= 2)) || defined(HAVE_SELFTEST)
+    /* In the event of fips cert 3389 or CAVP selftest build, these enums are
+     * not in aes.h for use with pkcs7 so enumerate it here outside the fips
+     * boundary */
     GCM_NONCE_MID_SZ = 12, /* The usual default nonce size for AES-GCM. */
     CCM_NONCE_MIN_SZ = 7,
 #endif


### PR DESCRIPTION
This PR fixes the CAVP selftest build with AES-CCM enabled.