### PR TITLE
Fixes for cpp extern c

### DIFF
--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -47,23 +47,6 @@
 
 #include <wolfssl/wolfcrypt/mpi_class.h>
 
-/* wolf big int and common functions */
-#include <wolfssl/wolfcrypt/wolfmath.h>
-
-
-#ifdef WOLFSSL_PUBLIC_MP
-    #define MP_API   WOLFSSL_API
-#else
-    #define MP_API
-#endif
-
-#ifndef MIN
-   #define MIN(x,y) ((x)<(y)?(x):(y))
-#endif
-
-#ifndef MAX
-   #define MAX(x,y) ((x)>(y)?(x):(y))
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -204,7 +187,13 @@ typedef int           mp_err;
 #define MP_WARRAY  ((mp_word)1 << (sizeof(mp_word) * CHAR_BIT - 2 * DIGIT_BIT + 1))
 
 #ifdef HAVE_WOLF_BIGINT
-    struct WC_BIGINT;
+    /* raw big integer */
+    typedef struct WC_BIGINT {
+        byte*   buf;
+        word32  len;
+        void*   heap;
+    } WC_BIGINT;
+    #define WOLF_BIGINT_DEFINED
 #endif
 
 /* the mp_int structure */
@@ -216,7 +205,10 @@ typedef struct mp_int {
     struct WC_BIGINT raw; /* unsigned binary (big endian) */
 #endif
 } mp_int;
-#define MP_INT_DEFINED
+
+/* wolf big int and common functions */
+#include <wolfssl/wolfcrypt/wolfmath.h>
+
 
 /* callback for mp_prime_random, should fill dst with random bytes and return
    how many read [up to len] */
@@ -397,10 +389,6 @@ MP_API int mp_radix_size (mp_int * a, int radix, int *size);
 
 MP_API int mp_cnt_lsb(mp_int *a);
 MP_API int mp_mod_d(mp_int* a, mp_digit b, mp_digit* c);
-
-
-/* wolf big int and common functions */
-#include <wolfssl/wolfcrypt/wolfmath.h>
 
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -85,20 +85,6 @@
 #ifdef WOLFSSL_SP_MATH
 #include <wolfssl/wolfcrypt/random.h>
 
-#ifndef MIN
-   #define MIN(x,y) ((x)<(y)?(x):(y))
-#endif
-
-#ifndef MAX
-   #define MAX(x,y) ((x)>(y)?(x):(y))
-#endif
-
-#ifdef WOLFSSL_PUBLIC_MP
-    #define MP_API   WOLFSSL_API
-#else
-    #define MP_API   WOLFSSL_LOCAL
-#endif
-
 #if !defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_HAVE_SP_DH)
     #if !defined(NO_PWDBASED) && defined(WOLFSSL_SHA512)
         #define SP_INT_DIGITS        ((512 + SP_WORD_SIZE) / SP_WORD_SIZE)
@@ -113,11 +99,29 @@
 
 #define sp_isodd(a) (a->used != 0 && (a->dp[0] & 1))
 
+#ifdef HAVE_WOLF_BIGINT
+    /* raw big integer */
+    typedef struct WC_BIGINT {
+        byte*   buf;
+        word32  len;
+        void*   heap;
+    } WC_BIGINT;
+    #define WOLF_BIGINT_DEFINED
+#endif
+
 typedef struct sp_int {
     int used;
     int size;
     sp_int_digit dp[SP_INT_DIGITS];
+#ifdef HAVE_WOLF_BIGINT
+    struct WC_BIGINT raw; /* unsigned binary (big endian) */
+#endif
 } sp_int;
+
+typedef sp_int mp_int;
+typedef sp_digit mp_digit;
+
+#include <wolfssl/wolfcrypt/wolfmath.h>
 
 
 MP_API int sp_init(sp_int* a);
@@ -148,8 +152,6 @@ MP_API int sp_add(sp_int* a, sp_int* b, sp_int* r);
 MP_API int sp_set_int(sp_int* a, unsigned long b);
 MP_API int sp_tohex(sp_int* a, char* str);
 
-typedef sp_int mp_int;
-typedef sp_digit mp_digit;
 
 #define MP_OKAY    0
 #define MP_NO      0
@@ -198,9 +200,6 @@ typedef sp_digit mp_digit;
 #define mp_set_int                  sp_set_int
 #define mp_tohex                    sp_tohex
 
-#define MP_INT_DEFINED
-
-#include <wolfssl/wolfcrypt/wolfmath.h>
 #endif
 
 #endif /* WOLF_CRYPT_SP_H */

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -46,25 +46,8 @@
 
 #include <wolfssl/wolfcrypt/random.h>
 
-/* wolf big int and common functions */
-#include <wolfssl/wolfcrypt/wolfmath.h>
-
 #ifdef __cplusplus
     extern "C" {
-#endif
-
-#ifdef WOLFSSL_PUBLIC_MP
-    #define MP_API   WOLFSSL_API
-#else
-    #define MP_API
-#endif
-
-#ifndef MIN
-   #define MIN(x,y) ((x)<(y)?(x):(y))
-#endif
-
-#ifndef MAX
-   #define MAX(x,y) ((x)>(y)?(x):(y))
 #endif
 
 #ifdef WOLFSSL_NO_ASM
@@ -256,6 +239,7 @@
 
 #endif /* WOLFSSL_BIGINT_TYPES */
 
+
 /* # of digits this is */
 #define DIGIT_BIT   ((CHAR_BIT) * SIZEOF_FP_DIGIT)
 
@@ -310,7 +294,13 @@
 #define FP_NO         0   /* no response */
 
 #ifdef HAVE_WOLF_BIGINT
-    struct WC_BIGINT;
+    /* raw big integer */
+    typedef struct WC_BIGINT {
+        byte*   buf;
+        word32  len;
+        void*   heap;
+    } WC_BIGINT;
+    #define WOLF_BIGINT_DEFINED
 #endif
 
 /* a FP type */
@@ -326,6 +316,16 @@ typedef struct fp_int {
     struct WC_BIGINT raw; /* unsigned binary (big endian) */
 #endif
 } fp_int;
+
+/* Types */
+typedef fp_digit mp_digit;
+typedef fp_word  mp_word;
+typedef fp_int   mp_int;
+
+
+/* wolf big int and common functions */
+#include <wolfssl/wolfcrypt/wolfmath.h>
+
 
 /* externally define this symbol to ignore the default settings, useful for changing the build from the make process */
 #ifndef TFM_ALREADY_SET
@@ -679,12 +679,6 @@ int  fp_sqr_comba64(fp_int *a, fp_int *b);
  * Used by wolfSSL
  */
 
-/* Types */
-typedef fp_digit mp_digit;
-typedef fp_word  mp_word;
-typedef fp_int mp_int;
-#define MP_INT_DEFINED
-
 /* Constants */
 #define MP_LT   FP_LT   /* less than    */
 #define MP_EQ   FP_EQ   /* equal to     */
@@ -814,10 +808,6 @@ WOLFSSL_API word32 CheckRunTimeFastMath(void);
 /* If user uses RSA, DH, DSA, or ECC math lib directly then fast math FP_SIZE
    must match, return 1 if a match otherwise 0 */
 #define CheckFastMathSettings() (FP_SIZE == CheckRunTimeFastMath())
-
-
-/* wolf big int and common functions */
-#include <wolfssl/wolfcrypt/wolfmath.h>
 
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/wc_pkcs11.h
+++ b/wolfssl/wolfcrypt/wc_pkcs11.h
@@ -33,6 +33,11 @@
 #include <wolfssl/wolfcrypt/cryptocb.h>
 #include <wolfssl/wolfcrypt/pkcs11.h>
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+
 typedef struct Pkcs11Dev {
     void*             dlHandle;         /* Handle to library  */
     CK_FUNCTION_LIST* func;             /* Array of functions */
@@ -52,10 +57,6 @@ typedef struct Pkcs11Session {
     CK_SLOT_ID        slotId;           /* Id of slot to use                  */
     CK_SESSION_HANDLE handle;           /* Handle to active session           */
 } Pkcs11Session;
-
-#ifdef __cplusplus
-    extern "C" {
-#endif
 
 /* Types of keys that can be stored. */
 enum Pkcs11KeyType {

--- a/wolfssl/wolfcrypt/wolfmath.h
+++ b/wolfssl/wolfcrypt/wolfmath.h
@@ -19,69 +19,78 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifndef __WOLFMATH_H__
+#define __WOLFMATH_H__
+
 #ifdef __cplusplus
     extern "C" {
 #endif
 
-/* This section is included prior to wolfmath.h below */
-#if defined(HAVE_WOLF_BIGINT) && !defined(WOLF_BIGINT_DEFINED)
-    /* raw big integer */
-    typedef struct WC_BIGINT {
-        byte*   buf;
-        word32  len;
-        void*   heap;
-    } WC_BIGINT;
-
-    #define WOLF_BIGINT_DEFINED
+#ifdef WOLFSSL_PUBLIC_MP
+    #define MP_API   WOLFSSL_API
+#else
+    #define MP_API   WOLFSSL_LOCAL
 #endif
 
-/* only define functions if mp_int has been declared */
-/* The MP_INT_DEFINED is defined in tfm.h and integer.h after mp_int */
-#ifdef MP_INT_DEFINED
+#ifndef MIN
+   #define MIN(x,y) ((x)<(y)?(x):(y))
+#endif
 
-#ifndef __WOLFMATH_H__
-#define __WOLFMATH_H__
+#ifndef MAX
+   #define MAX(x,y) ((x)>(y)?(x):(y))
+#endif
 
-    /* timing resistance array */
-    #if !defined(WC_NO_CACHE_RESISTANT) && \
-        ((defined(HAVE_ECC) && defined(ECC_TIMING_RESISTANT)) || \
-         (defined(USE_FAST_MATH) && defined(TFM_TIMING_RESISTANT)))
+/* timing resistance array */
+#if !defined(WC_NO_CACHE_RESISTANT) && \
+    ((defined(HAVE_ECC) && defined(ECC_TIMING_RESISTANT)) || \
+     (defined(USE_FAST_MATH) && defined(TFM_TIMING_RESISTANT)))
 
-        extern const wolfssl_word wc_off_on_addr[2];
+    extern const wolfssl_word wc_off_on_addr[2];
+#endif
+
+
+/* common math functions */
+MP_API int get_digit_count(mp_int* a);
+MP_API mp_digit get_digit(mp_int* a, int n);
+MP_API int get_rand_digit(WC_RNG* rng, mp_digit* d);
+
+WOLFSSL_API int mp_rand(mp_int* a, int digits, WC_RNG* rng);
+
+enum {
+    /* format type */
+    WC_TYPE_HEX_STR = 1,
+    WC_TYPE_UNSIGNED_BIN = 2,
+};
+
+WOLFSSL_API int wc_export_int(mp_int* mp, byte* buf, word32* len,
+    word32 keySz, int encType);
+
+#ifdef HAVE_WOLF_BIGINT
+    #if !defined(WOLF_BIGINT_DEFINED)
+        /* raw big integer */
+        typedef struct WC_BIGINT {
+            byte*   buf;
+            word32  len;
+            void*   heap;
+        } WC_BIGINT;
+        #define WOLF_BIGINT_DEFINED
     #endif
 
-    /* common math functions */
-    int get_digit_count(mp_int* a);
-    mp_digit get_digit(mp_int* a, int n);
-    int get_rand_digit(WC_RNG* rng, mp_digit* d);
-    int mp_rand(mp_int* a, int digits, WC_RNG* rng);
+    WOLFSSL_LOCAL void wc_bigint_init(WC_BIGINT* a);
+    WOLFSSL_LOCAL int wc_bigint_alloc(WC_BIGINT* a, word32 sz);
+    WOLFSSL_LOCAL int wc_bigint_from_unsigned_bin(WC_BIGINT* a, const byte* in, word32 inlen);
+    WOLFSSL_LOCAL int wc_bigint_to_unsigned_bin(WC_BIGINT* a, byte* out, word32* outlen);
+    WOLFSSL_LOCAL void wc_bigint_zero(WC_BIGINT* a);
+    WOLFSSL_LOCAL void wc_bigint_free(WC_BIGINT* a);
 
-    enum {
-        /* format type */
-        WC_TYPE_HEX_STR = 1,
-        WC_TYPE_UNSIGNED_BIN = 2,
-    };
+    WOLFSSL_LOCAL int wc_mp_to_bigint(mp_int* src, WC_BIGINT* dst);
+    WOLFSSL_LOCAL int wc_mp_to_bigint_sz(mp_int* src, WC_BIGINT* dst, word32 sz);
+    WOLFSSL_LOCAL int wc_bigint_to_mp(WC_BIGINT* src, mp_int* dst);
+#endif /* HAVE_WOLF_BIGINT */
 
-    WOLFSSL_API int wc_export_int(mp_int* mp, byte* buf, word32* len,
-        word32 keySz, int encType);
-
-    #ifdef HAVE_WOLF_BIGINT
-        void wc_bigint_init(WC_BIGINT* a);
-        int wc_bigint_alloc(WC_BIGINT* a, word32 sz);
-        int wc_bigint_from_unsigned_bin(WC_BIGINT* a, const byte* in, word32 inlen);
-        int wc_bigint_to_unsigned_bin(WC_BIGINT* a, byte* out, word32* outlen);
-        void wc_bigint_zero(WC_BIGINT* a);
-        void wc_bigint_free(WC_BIGINT* a);
-
-        int wc_mp_to_bigint(mp_int* src, WC_BIGINT* dst);
-        int wc_mp_to_bigint_sz(mp_int* src, WC_BIGINT* dst, word32 sz);
-        int wc_bigint_to_mp(WC_BIGINT* src, mp_int* dst);
-    #endif /* HAVE_WOLF_BIGINT */
-
-#endif /* __WOLFMATH_H__ */
-
-#endif /* MP_INT_DEFINED */
 
 #ifdef __cplusplus
     } /* extern "C" */
 #endif
+
+#endif /* __WOLFMATH_H__ */

--- a/wolfssl/wolfcrypt/wolfmath.h
+++ b/wolfssl/wolfcrypt/wolfmath.h
@@ -19,6 +19,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+/* This section is included prior to wolfmath.h below */
 #if defined(HAVE_WOLF_BIGINT) && !defined(WOLF_BIGINT_DEFINED)
     /* raw big integer */
     typedef struct WC_BIGINT {
@@ -30,8 +35,8 @@
     #define WOLF_BIGINT_DEFINED
 #endif
 
-
 /* only define functions if mp_int has been declared */
+/* The MP_INT_DEFINED is defined in tfm.h and integer.h after mp_int */
 #ifdef MP_INT_DEFINED
 
 #ifndef __WOLFMATH_H__
@@ -57,7 +62,7 @@
         WC_TYPE_UNSIGNED_BIN = 2,
     };
 
-    WOLFSSL_API int wc_export_int(mp_int* mp, byte* buf, word32* len, 
+    WOLFSSL_API int wc_export_int(mp_int* mp, byte* buf, word32* len,
         word32 keySz, int encType);
 
     #ifdef HAVE_WOLF_BIGINT
@@ -76,3 +81,7 @@
 #endif /* __WOLFMATH_H__ */
 
 #endif /* MP_INT_DEFINED */
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif


### PR DESCRIPTION
Add extern "C" to headers. Some files are missing this, which can cause issues with some compilers when using the C++ mode.

ZD 5194