### PR TITLE
Fixes for track memory and API unit test cleanup

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -673,7 +673,6 @@ static void test_for_double_Free(void)
         /* First test freeing SSL, then CTX */
         wolfSSL_free(ssl);
         wolfSSL_CTX_free(ctx);
-        wolfSSL_Cleanup();
 
 #ifndef NO_WOLFSSL_CLIENT
         AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));

--- a/wolfssl/wolfcrypt/mem_track.h
+++ b/wolfssl/wolfcrypt/mem_track.h
@@ -184,6 +184,7 @@
             header->next = NULL;
             if (ourMemList.tail == NULL)  {
                 ourMemList.head = header;
+                header->prev = NULL;
             }
             else {
                 ourMemList.tail->next = header;


### PR DESCRIPTION
* Fix for track memory case where the "prev" wasn't getting initialized for the first malloc. Caused issue on last free with fsantize because pointers are not zero'd by default.

* API unit test fix to remove improperly placed `wolfSSL_Cleanup()` call in `test_for_double_Free`. This caused erroneous report with `fsanitize=address`.