### PR TITLE
Sniffer Statistics

### DIFF
--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -87,18 +87,68 @@ static void FreeAll(void)
 #endif
 }
 
-static void sig_handler(const int sig)
+
+#ifdef WOLFSSL_SNIFFER_STATS
+
+static void DumpStats(void)
 {
     SSLStats sslStats;
     ssl_ReadStatistics(&sslStats);
-    printf("SSL Stats (sslStandardConns):%u\n", sslStats.sslStandardConns);
-    printf("SSL Stats (sslClientAuthConns):%u\n", sslStats.sslClientAuthConns);
-    printf("SSL Stats (sslResumedConns):%u\n", sslStats.sslResumedConns);
-    printf("SSL Stats (sslResumeMisses):%u\n", sslStats.sslResumeMisses);
-    printf("SSL Stats (sslAlerts):%u\n", sslStats.sslAlerts);
 
+    printf("SSL Stats (sslStandardConns):%u\n",
+            sslStats.sslStandardConns);
+    printf("SSL Stats (sslRehandshakeConns):%u\n",
+            sslStats.sslRehandshakeConns);
+    printf("SSL Stats (sslClientAuthConns):%u\n",
+            sslStats.sslClientAuthConns);
+    printf("SSL Stats (sslResumedConns):%u\n",
+            sslStats.sslResumedConns);
+    printf("SSL Stats (sslResumedRehandshakeConns):%u\n",
+            sslStats.sslResumedRehandshakeConns);
+    printf("SSL Stats (sslClientAuthRehandshakeConns):%u\n",
+            sslStats.sslClientAuthRehandshakeConns);
+    printf("SSL Stats (sslEphemeralMisses):%u\n",
+            sslStats.sslEphemeralMisses);
+    printf("SSL Stats (sslResumeMisses):%u\n",
+            sslStats.sslResumeMisses);
+    printf("SSL Stats (sslCiphersUnsupported):%u\n",
+            sslStats.sslCiphersUnsupported);
+    printf("SSL Stats (sslKeysUnmatched):%u\n",
+            sslStats.sslKeysUnmatched);
+    printf("SSL Stats (sslKeyFails):%u\n",
+            sslStats.sslKeyFails);
+    printf("SSL Stats (sslDecodeFails):%u\n",
+            sslStats.sslDecodeFails);
+    printf("SSL Stats (sslAlerts):%u\n",
+            sslStats.sslAlerts);
+    printf("SSL Stats (sslDecryptedBytes):%u\n",
+            sslStats.sslDecryptedBytes);
+    printf("SSL Stats (sslEncryptedBytes):%u\n",
+            sslStats.sslEncryptedBytes);
+    printf("SSL Stats (sslEncryptedPackets):%u\n",
+            sslStats.sslEncryptedPackets);
+    printf("SSL Stats (sslDecryptedPackets):%u\n",
+            sslStats.sslDecryptedPackets);
+    printf("SSL Stats (sslEncryptedConnsPerSecond):%u\n",
+            sslStats.sslEncryptedConnsPerSecond);
+    printf("SSL Stats (sslKeyMatches):%u\n",
+            sslStats.sslKeyMatches);
+    printf("SSL Stats (sslActiveEncryptedConnsPerSecond):%u\n",
+            sslStats.sslActiveEncryptedConnsPerSecond);
+    printf("SSL Stats (sslActiveFlowsPerSecond):%u\n",
+            sslStats.sslActiveFlowsPerSecond);
+}
+
+#endif
+
+
+static void sig_handler(const int sig)
+{
     printf("SIGINT handled = %d.\n", sig);
     FreeAll();
+#ifdef WOLFSSL_SNIFFER_STATS
+    DumpStats();
+#endif
     if (sig)
         exit(EXIT_SUCCESS);
 }

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -95,37 +95,37 @@ static void DumpStats(void)
     SSLStats sslStats;
     ssl_ReadStatistics(&sslStats);
 
-    printf("SSL Stats (sslStandardConns):%u\n",
+    printf("SSL Stats (sslStandardConns):%lu\n",
             sslStats.sslStandardConns);
-    printf("SSL Stats (sslClientAuthConns):%u\n",
+    printf("SSL Stats (sslClientAuthConns):%lu\n",
             sslStats.sslClientAuthConns);
-    printf("SSL Stats (sslResumedConns):%u\n",
+    printf("SSL Stats (sslResumedConns):%lu\n",
             sslStats.sslResumedConns);
-    printf("SSL Stats (sslEphemeralMisses):%u\n",
+    printf("SSL Stats (sslEphemeralMisses):%lu\n",
             sslStats.sslEphemeralMisses);
-    printf("SSL Stats (sslResumeMisses):%u\n",
+    printf("SSL Stats (sslResumeMisses):%lu\n",
             sslStats.sslResumeMisses);
-    printf("SSL Stats (sslCiphersUnsupported):%u\n",
+    printf("SSL Stats (sslCiphersUnsupported):%lu\n",
             sslStats.sslCiphersUnsupported);
-    printf("SSL Stats (sslKeysUnmatched):%u\n",
+    printf("SSL Stats (sslKeysUnmatched):%lu\n",
             sslStats.sslKeysUnmatched);
-    printf("SSL Stats (sslKeyFails):%u\n",
+    printf("SSL Stats (sslKeyFails):%lu\n",
             sslStats.sslKeyFails);
-    printf("SSL Stats (sslDecodeFails):%u\n",
+    printf("SSL Stats (sslDecodeFails):%lu\n",
             sslStats.sslDecodeFails);
-    printf("SSL Stats (sslAlerts):%u\n",
+    printf("SSL Stats (sslAlerts):%lu\n",
             sslStats.sslAlerts);
-    printf("SSL Stats (sslDecryptedBytes):%u\n",
+    printf("SSL Stats (sslDecryptedBytes):%lu\n",
             sslStats.sslDecryptedBytes);
-    printf("SSL Stats (sslEncryptedBytes):%u\n",
+    printf("SSL Stats (sslEncryptedBytes):%lu\n",
             sslStats.sslEncryptedBytes);
-    printf("SSL Stats (sslEncryptedPackets):%u\n",
+    printf("SSL Stats (sslEncryptedPackets):%lu\n",
             sslStats.sslEncryptedPackets);
-    printf("SSL Stats (sslDecryptedPackets):%u\n",
+    printf("SSL Stats (sslDecryptedPackets):%lu\n",
             sslStats.sslDecryptedPackets);
-    printf("SSL Stats (sslKeyMatches):%u\n",
+    printf("SSL Stats (sslKeyMatches):%lu\n",
             sslStats.sslKeyMatches);
-    printf("SSL Stats (sslEncryptedConns):%u\n",
+    printf("SSL Stats (sslEncryptedConns):%lu\n",
             sslStats.sslEncryptedConns);
 }
 

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -97,16 +97,10 @@ static void DumpStats(void)
 
     printf("SSL Stats (sslStandardConns):%u\n",
             sslStats.sslStandardConns);
-    printf("SSL Stats (sslRehandshakeConns):%u\n",
-            sslStats.sslRehandshakeConns);
     printf("SSL Stats (sslClientAuthConns):%u\n",
             sslStats.sslClientAuthConns);
     printf("SSL Stats (sslResumedConns):%u\n",
             sslStats.sslResumedConns);
-    printf("SSL Stats (sslResumedRehandshakeConns):%u\n",
-            sslStats.sslResumedRehandshakeConns);
-    printf("SSL Stats (sslClientAuthRehandshakeConns):%u\n",
-            sslStats.sslClientAuthRehandshakeConns);
     printf("SSL Stats (sslEphemeralMisses):%u\n",
             sslStats.sslEphemeralMisses);
     printf("SSL Stats (sslResumeMisses):%u\n",
@@ -129,14 +123,10 @@ static void DumpStats(void)
             sslStats.sslEncryptedPackets);
     printf("SSL Stats (sslDecryptedPackets):%u\n",
             sslStats.sslDecryptedPackets);
-    printf("SSL Stats (sslEncryptedConnsPerSecond):%u\n",
-            sslStats.sslEncryptedConnsPerSecond);
     printf("SSL Stats (sslKeyMatches):%u\n",
             sslStats.sslKeyMatches);
-    printf("SSL Stats (sslActiveEncryptedConnsPerSecond):%u\n",
-            sslStats.sslActiveEncryptedConnsPerSecond);
-    printf("SSL Stats (sslActiveFlowsPerSecond):%u\n",
-            sslStats.sslActiveFlowsPerSecond);
+    printf("SSL Stats (sslEncryptedConns):%u\n",
+            sslStats.sslEncryptedConns);
 }
 
 #endif

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -89,6 +89,14 @@ static void FreeAll(void)
 
 static void sig_handler(const int sig)
 {
+    SSLStats sslStats;
+    ssl_ReadStatistics(&sslStats);
+    printf("SSL Stats (sslStandardConns):%u\n", sslStats.sslStandardConns);
+    printf("SSL Stats (sslClientAuthConns):%u\n", sslStats.sslClientAuthConns);
+    printf("SSL Stats (sslResumedConns):%u\n", sslStats.sslResumedConns);
+    printf("SSL Stats (sslResumeMisses):%u\n", sslStats.sslResumeMisses);
+    printf("SSL Stats (sslAlerts):%u\n", sslStats.sslAlerts);
+
     printf("SIGINT handled = %d.\n", sig);
     FreeAll();
     if (sig)

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -136,22 +136,22 @@ SSL_SNIFFER_API int ssl_SetConnectionCtx(void* ctx);
 
 typedef struct SSLStats
 {
-    unsigned int sslStandardConns;
-    unsigned int sslClientAuthConns;
-    unsigned int sslResumedConns;
-    unsigned int sslEphemeralMisses;
-    unsigned int sslResumeMisses;
-    unsigned int sslCiphersUnsupported;
-    unsigned int sslKeysUnmatched;
-    unsigned int sslKeyFails;
-    unsigned int sslDecodeFails;
-    unsigned int sslAlerts;
-    unsigned int sslDecryptedBytes;
-    unsigned int sslEncryptedBytes;
-    unsigned int sslEncryptedPackets;
-    unsigned int sslDecryptedPackets;
-    unsigned int sslKeyMatches;
-    unsigned int sslEncryptedConns;
+    unsigned long int sslStandardConns;
+    unsigned long int sslClientAuthConns;
+    unsigned long int sslResumedConns;
+    unsigned long int sslEphemeralMisses;
+    unsigned long int sslResumeMisses;
+    unsigned long int sslCiphersUnsupported;
+    unsigned long int sslKeysUnmatched;
+    unsigned long int sslKeyFails;
+    unsigned long int sslDecodeFails;
+    unsigned long int sslAlerts;
+    unsigned long int sslDecryptedBytes;
+    unsigned long int sslEncryptedBytes;
+    unsigned long int sslEncryptedPackets;
+    unsigned long int sslDecryptedPackets;
+    unsigned long int sslKeyMatches;
+    unsigned long int sslEncryptedConns;
 } SSLStats;
 
 

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -137,11 +137,8 @@ SSL_SNIFFER_API int ssl_SetConnectionCtx(void* ctx);
 typedef struct SSLStats
 {
     unsigned int sslStandardConns;
-    unsigned int sslRehandshakeConns;
     unsigned int sslClientAuthConns;
     unsigned int sslResumedConns;
-    unsigned int sslResumedRehandshakeConns;
-    unsigned int sslClientAuthRehandshakeConns;
     unsigned int sslEphemeralMisses;
     unsigned int sslResumeMisses;
     unsigned int sslCiphersUnsupported;
@@ -153,10 +150,8 @@ typedef struct SSLStats
     unsigned int sslEncryptedBytes;
     unsigned int sslEncryptedPackets;
     unsigned int sslDecryptedPackets;
-    unsigned int sslEncryptedConnsPerSecond;
     unsigned int sslKeyMatches;
-    unsigned int sslActiveEncryptedConnsPerSecond;
-    unsigned int sslActiveFlowsPerSecond;
+    unsigned int sslEncryptedConns;
 } SSLStats;
 
 
@@ -166,6 +161,10 @@ SSL_SNIFFER_API int ssl_ResetStatistics(void);
 
 WOLFSSL_API
 SSL_SNIFFER_API int ssl_ReadStatistics(SSLStats* stats);
+
+
+WOLFSSL_API
+SSL_SNIFFER_API int ssl_ReadResetStatistics(SSLStats* stats);
 
 
 #ifdef __cplusplus

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -134,6 +134,40 @@ WOLFSSL_API
 SSL_SNIFFER_API int ssl_SetConnectionCtx(void* ctx);
 
 
+typedef struct SSLStats
+{
+    unsigned int sslStandardConns;
+    unsigned int sslRehandshakeConns;
+    unsigned int sslClientAuthConns;
+    unsigned int sslResumedConns;
+    unsigned int sslResumedRehandshakeConns;
+    unsigned int sslClientAuthRehandshakeConns;
+    unsigned int sslEphemeralMisses;
+    unsigned int sslResumeMisses;
+    unsigned int sslCiphersUnsupported;
+    unsigned int sslKeysUnmatched;
+    unsigned int sslKeyFails;
+    unsigned int sslDecodeFails;
+    unsigned int sslAlerts;
+    unsigned int sslDecryptedBytes;
+    unsigned int sslEncryptedBytes;
+    unsigned int sslEncryptedPackets;
+    unsigned int sslDecryptedPackets;
+    unsigned int sslEncryptedConns;
+    unsigned int sslKeyMatches;
+    unsigned int sslEncryptedConnsPerSecond;
+    unsigned int sslActiveFlowsPerSecond;
+} SSLStats;
+
+
+WOLFSSL_API
+SSL_SNIFFER_API int ssl_ResetStatistics(void);
+
+
+WOLFSSL_API
+SSL_SNIFFER_API int ssl_ReadStatistics(SSLStats* stats);
+
+
 #ifdef __cplusplus
     }  /* extern "C" */
 #endif

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -137,11 +137,11 @@ SSL_SNIFFER_API int ssl_SetConnectionCtx(void* ctx);
 typedef struct SSLStats
 {
     unsigned int sslStandardConns;
-    unsigned int sslRehandshakeConns;
+    unsigned int sslRehandshakeConns; /* unsupported */
     unsigned int sslClientAuthConns;
     unsigned int sslResumedConns;
-    unsigned int sslResumedRehandshakeConns;
-    unsigned int sslClientAuthRehandshakeConns;
+    unsigned int sslResumedRehandshakeConns; /* unsupported */
+    unsigned int sslClientAuthRehandshakeConns; /* unsupported */
     unsigned int sslEphemeralMisses;
     unsigned int sslResumeMisses;
     unsigned int sslCiphersUnsupported;
@@ -153,9 +153,9 @@ typedef struct SSLStats
     unsigned int sslEncryptedBytes;
     unsigned int sslEncryptedPackets;
     unsigned int sslDecryptedPackets;
-    unsigned int sslEncryptedConns;
-    unsigned int sslKeyMatches;
     unsigned int sslEncryptedConnsPerSecond;
+    unsigned int sslKeyMatches;
+    unsigned int sslActiveEncryptedConnsPerSecond;
     unsigned int sslActiveFlowsPerSecond;
 } SSLStats;
 

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -136,25 +136,25 @@ SSL_SNIFFER_API int ssl_SetConnectionCtx(void* ctx);
 
 typedef struct SSLStats
 {
-    unsigned int sslStandardConns;
+    unsigned int sslStandardConns; /* X */
     unsigned int sslRehandshakeConns; /* unsupported */
-    unsigned int sslClientAuthConns;
-    unsigned int sslResumedConns;
+    unsigned int sslClientAuthConns; /* X */
+    unsigned int sslResumedConns; /* X */
     unsigned int sslResumedRehandshakeConns; /* unsupported */
     unsigned int sslClientAuthRehandshakeConns; /* unsupported */
     unsigned int sslEphemeralMisses;
-    unsigned int sslResumeMisses;
-    unsigned int sslCiphersUnsupported;
-    unsigned int sslKeysUnmatched;
+    unsigned int sslResumeMisses; /* X */
+    unsigned int sslCiphersUnsupported; /* X */
+    unsigned int sslKeysUnmatched; /* X */
     unsigned int sslKeyFails;
     unsigned int sslDecodeFails;
-    unsigned int sslAlerts;
+    unsigned int sslAlerts; /* X */
     unsigned int sslDecryptedBytes;
     unsigned int sslEncryptedBytes;
     unsigned int sslEncryptedPackets;
     unsigned int sslDecryptedPackets;
     unsigned int sslEncryptedConnsPerSecond;
-    unsigned int sslKeyMatches;
+    unsigned int sslKeyMatches; /* X */
     unsigned int sslActiveEncryptedConnsPerSecond;
     unsigned int sslActiveFlowsPerSecond;
 } SSLStats;

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -136,25 +136,25 @@ SSL_SNIFFER_API int ssl_SetConnectionCtx(void* ctx);
 
 typedef struct SSLStats
 {
-    unsigned int sslStandardConns; /* X */
-    unsigned int sslRehandshakeConns; /* unsupported */
-    unsigned int sslClientAuthConns; /* X */
-    unsigned int sslResumedConns; /* X */
-    unsigned int sslResumedRehandshakeConns; /* unsupported */
-    unsigned int sslClientAuthRehandshakeConns; /* unsupported */
+    unsigned int sslStandardConns;
+    unsigned int sslRehandshakeConns;
+    unsigned int sslClientAuthConns;
+    unsigned int sslResumedConns;
+    unsigned int sslResumedRehandshakeConns;
+    unsigned int sslClientAuthRehandshakeConns;
     unsigned int sslEphemeralMisses;
-    unsigned int sslResumeMisses; /* X */
-    unsigned int sslCiphersUnsupported; /* X */
-    unsigned int sslKeysUnmatched; /* X */
+    unsigned int sslResumeMisses;
+    unsigned int sslCiphersUnsupported;
+    unsigned int sslKeysUnmatched;
     unsigned int sslKeyFails;
     unsigned int sslDecodeFails;
-    unsigned int sslAlerts; /* X */
+    unsigned int sslAlerts;
     unsigned int sslDecryptedBytes;
     unsigned int sslEncryptedBytes;
     unsigned int sslEncryptedPackets;
     unsigned int sslDecryptedPackets;
     unsigned int sslEncryptedConnsPerSecond;
-    unsigned int sslKeyMatches; /* X */
+    unsigned int sslKeyMatches;
     unsigned int sslActiveEncryptedConnsPerSecond;
     unsigned int sslActiveFlowsPerSecond;
 } SSLStats;


### PR DESCRIPTION
Added an option to the wolfSSL sniffer that will log statistics on a set of events. Provides a method to read and reset the statistics.