### PR TITLE
Autoconf Update

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,6 @@ then
     enable_static=yes
     enable_all=yes
 fi
-AM_CONDITIONAL([BUILD_DISTRO], [test "x$ENABLED_DISTRO" = "xyes"])
 
 
 # ALL FEATURES
@@ -199,7 +198,6 @@ then
     # Enable multiple attribute additions such as DC
     AM_CFLAGS="-DWOLFSSL_MULTI_ATTRIB $AM_CFLAGS"
 fi
-AM_CONDITIONAL([BUILD_ALL], [test "x$ENABLED_ALL" = "xyes"])
 
 
 # Support for forcing 32-bit mode
@@ -349,9 +347,6 @@ then
     AM_CFLAGS="-DWOLFSSL_TLS13 -DHAVE_TLS_EXTENSIONS -DHAVE_SUPPORTED_CURVES $AM_CFLAGS"
 fi
 
-# check if TLS v1.3 was enabled for conditionally running tls13.test script
-AM_CONDITIONAL([BUILD_TLS13], [test "x$ENABLED_TLS13" = "xyes"])
-
 
 # Post-handshake Authentication
 AC_ARG_ENABLE([postauth],
@@ -395,7 +390,6 @@ if test "$ENABLED_RNG" = "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DWC_NO_RNG"
 fi
-AM_CONDITIONAL([BUILD_RNG], [test "x$ENABLED_RNG" = "xyes"])
 
 
 # DTLS-SCTP
@@ -403,8 +397,6 @@ AC_ARG_ENABLE([sctp],
     [AS_HELP_STRING([--enable-sctp],[Enable wolfSSL DTLS-SCTP support (default: disabled)])],
     [ENABLED_SCTP=$enableval],
     [ENABLED_SCTP=no])
-
-AM_CONDITIONAL([BUILD_SCTP], [test "x$ENABLED_SCTP" = "xyes"])
 
 AS_IF([test "x$ENABLED_SCTP" = "xyes"],
         [AC_MSG_CHECKING([for SCTP])
@@ -427,8 +419,6 @@ AC_ARG_ENABLE([mcast],
     [ENABLED_MCAST=$enableval],
     [ENABLED_MCAST=no])
 
-AM_CONDITIONAL([BUILD_MCAST], [test "x$ENABLED_MCAST" = "xyes"])
-
 
 # RNG
 AC_ARG_ENABLE([rng],
@@ -441,8 +431,6 @@ if test "$ENABLED_RNG" = "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DWC_NO_RNG"
 fi
-AM_CONDITIONAL([BUILD_RNG], [test "x$ENABLED_RNG" = "xyes"])
-
 
 
 # List of open source project defines using our openssl compatibility layer:
@@ -614,8 +602,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DTEST_IPV6 -DWOLFSSL_IPV6"
 fi
 
-AM_CONDITIONAL([BUILD_IPV6], [test "x$ENABLED_IPV6" = "xyes"])
-
 
 if test "$ENABLED_WPAS" = "yes"
 then
@@ -658,8 +644,6 @@ then
     enable_lowresource=yes
 fi
 
-AM_CONDITIONAL([BUILD_LEANPSK], [test "x$ENABLED_LEANPSK" = "xyes"])
-
 
 # lean TLS build (TLS 1.2 client only (no client auth), ECC256, AES128 and SHA256 w/o Shamir)
 AC_ARG_ENABLE([leantls],
@@ -673,8 +657,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LEANTLS -DNO_WRITEV -DHAVE_ECC -DTFM_ECC256 -DECC_USER_CURVES -DNO_WOLFSSL_SERVER -DNO_RABBIT -DNO_RSA -DNO_DSA -DNO_DH -DNO_PWDBASED -DNO_MD5 -DNO_ERROR_STRINGS -DNO_OLD_TLS -DNO_RC4 -DNO_SHA -DNO_PSK -DNO_WOLFSSL_MEMORY"
     enable_lowresource=yes
 fi
-
-AM_CONDITIONAL([BUILD_LEANTLS], [test "x$ENABLED_LEANTLS" = "xyes"])
 
 
 # low resource options to reduce flash and memory use
@@ -692,8 +674,6 @@ then
     # low flash flags
     AM_CFLAGS="$AM_CFLAGS -DUSE_SLOW_SHA -DUSE_SLOW_SHA256 -DUSE_SLOW_SHA512"
 fi
-
-AM_CONDITIONAL([BUILD_LOWMEM], [test "x$ENABLED_LOWRESOURCE" = "xyes"])
 
 
 # big cache
@@ -799,8 +779,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_PK_CALLBACKS"
 fi
 
-AM_CONDITIONAL([BUILD_PKCALLBACKS],   [ test "x$ENABLED_PKCALLBACKS" = "xyes" ])
-
 
 # Microchip/Atmel CryptoAuthLib
 ENABLED_CRYPTOAUTHLIB="no"
@@ -843,7 +821,6 @@ AC_ARG_WITH([cryptoauthlib],
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ATECC508A"
     ]
 )
-AM_CONDITIONAL([BUILD_CRYPTOAUTHLIB], [test "x$ENABLED_CRYPTOAUTHLIB" = "xyes"])
 
 
 # sniffer doesn't work in maxstrength mode
@@ -861,9 +838,6 @@ AS_IF([ test "x$ENABLED_SNIFFER" = "xyes" ],
               [ AC_MSG_WARN([cannot enable sniffer test without having libpcap available.]) ]
           )
       ])
-
-AM_CONDITIONAL([BUILD_SNIFFER],   [ test "x$ENABLED_SNIFFER"   = "xyes" ])
-AM_CONDITIONAL([BUILD_SNIFFTEST], [ test "x$ENABLED_SNIFFTEST" = "xyes" ])
 
 
 # AES-CBC
@@ -917,8 +891,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_AESGCM"
 fi
 
-AM_CONDITIONAL([BUILD_AESGCM], [test "x$ENABLED_AESGCM" = "xyes"])
-
 
 # AES-CCM
 AC_ARG_ENABLE([aesccm],
@@ -931,8 +903,6 @@ if test "$ENABLED_AESCCM" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_AESCCM"
 fi
-
-AM_CONDITIONAL([BUILD_AESCCM], [test "x$ENABLED_AESCCM" = "xyes"])
 
 
 # AES-CTR
@@ -1007,7 +977,6 @@ then
     esac
 fi
 
-AM_CONDITIONAL([BUILD_ARMASM], [test "x$ENABLED_ARMASM" = "xyes"])
 
 # Xilinx hardened crypto
 AC_ARG_ENABLE([xilinx],
@@ -1020,7 +989,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_XILINX -DWOLFSSL_XILINX_CRYPT"
 fi
 
-AM_CONDITIONAL([BUILD_XILINX], [test "x$ENABLED_XILINX" = "xyes"])
 
 # INTEL AES-NI
 AC_ARG_ENABLE([aesni],
@@ -1078,9 +1046,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_INTEL_RDRAND"
 fi
 
-AM_CONDITIONAL([BUILD_AESNI], [test "x$ENABLED_AESNI" = "xyes"])
-AM_CONDITIONAL([BUILD_INTELASM], [test "x$ENABLED_INTELASM" = "xyes"])
-
 
 # Linux af_alg 
 AC_ARG_ENABLE([afalg],
@@ -1128,8 +1093,6 @@ then
     ENABLED_XILINX="yes"
 fi
 
-AM_CONDITIONAL([BUILD_AFALG], [test "x$ENABLED_AFALG" = "xyes"])
-
 
 # Support for Linux dev/crypto calls
 AC_ARG_ENABLE([devcrypto],
@@ -1171,7 +1134,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_NO_HASH_RAW"
     ENABLED_DEVCRYPTO=yes
 fi
-AM_CONDITIONAL([BUILD_DEVCRYPTO], [test "x$ENABLED_DEVCRYPTO" = "xyes"])
 
 
 # Camellia
@@ -1185,8 +1147,6 @@ if test "$ENABLED_CAMELLIA" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_CAMELLIA"
 fi
-
-AM_CONDITIONAL([BUILD_CAMELLIA], [test "x$ENABLED_CAMELLIA" = "xyes"])
 
 
 # MD2
@@ -1205,8 +1165,6 @@ if test "$ENABLED_MD2" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_MD2"
 fi
-
-AM_CONDITIONAL([BUILD_MD2], [test "x$ENABLED_MD2" = "xyes"])
 
 
 # NULL CIPHER
@@ -1243,8 +1201,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_RIPEMD"
 fi
 
-AM_CONDITIONAL([BUILD_RIPEMD], [test "x$ENABLED_RIPEMD" = "xyes"])
-
 
 # BLAKE2
 AC_ARG_ENABLE([blake2],
@@ -1258,7 +1214,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_BLAKE2 -DHAVE_BLAKE2B"
 fi
 
-AM_CONDITIONAL([BUILD_BLAKE2], [test "x$ENABLED_BLAKE2" = "xyes"])
 
 AC_ARG_ENABLE([blake2s],
     [AS_HELP_STRING([--enable-blake2s],[Enable wolfSSL BLAKE2s support (default: disabled)])],
@@ -1271,8 +1226,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_BLAKE2S"
     ENABLED_BLAKE2="yes"
 fi
-
-AM_CONDITIONAL([BUILD_BLAKE2S], [test "x$ENABLED_BLAKE2S" = "xyes"])
 
 
 # SHA512
@@ -1300,7 +1253,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA512"
 fi
 
-AM_CONDITIONAL([BUILD_SHA512], [test "x$ENABLED_SHA512" = "xyes"])
 
 # SHA384
 AC_ARG_ENABLE([sha384],
@@ -1324,8 +1276,6 @@ if test "$ENABLED_SHA384" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA384"
 fi
-
-AM_CONDITIONAL([BUILD_SHA512], [test "x$ENABLED_SHA384" = "xyes"])
 
 
 # SESSION CERTS
@@ -1476,9 +1426,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DNO_DSA"
 fi
 
-AM_CONDITIONAL([BUILD_DSA], [test "x$ENABLED_DSA" = "xyes"])
-
-
 
 # ECC Shamir
 AC_ARG_ENABLE([eccshamir],
@@ -1514,8 +1461,6 @@ then
         AM_CFLAGS="$AM_CFLAGS -DECC_SHAMIR"
     fi
 fi
-
-AM_CONDITIONAL([BUILD_ECC], [test "x$ENABLED_ECC" = "xyes"])
 
 
 # ECC Custom Curves
@@ -1632,13 +1577,6 @@ then
     ENABLED_GEMATH=yes
     AM_CFLAGS="$AM_CFLAGS -DHAVE_ED25519"
 fi
-
-AM_CONDITIONAL([BUILD_ED25519], [test "x$ENABLED_ED25519" = "xyes"])
-AM_CONDITIONAL([BUILD_ED25519_SMALL], [test "x$ENABLED_ED25519_SMALL" = "xyes"])
-AM_CONDITIONAL([BUILD_FEMATH],  [test "x$ENABLED_FEMATH" = "xyes"])
-AM_CONDITIONAL([BUILD_GEMATH],  [test "x$ENABLED_GEMATH" = "xyes"])
-AM_CONDITIONAL([BUILD_CURVE25519], [test "x$ENABLED_CURVE25519" = "xyes"])
-AM_CONDITIONAL([BUILD_CURVE25519_SMALL], [test "x$ENABLED_CURVE25519_SMALL" = "xyes"])
 
 
 # FP ECC, Fixed Point cache ECC
@@ -1819,8 +1757,6 @@ else
     fi
 fi
 
-AM_CONDITIONAL([BUILD_MEMORY], [test "x$ENABLED_MEMORY" = "xyes"])
-
 
 # MEMORY SIZE info
 AC_ARG_ENABLE([trackmemory],
@@ -1927,8 +1863,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_RSA_VERIFY_INLINE -DNO_SIG_WRAPPER"
 fi
 
-AM_CONDITIONAL([BUILD_RSA], [test "x$ENABLED_RSA" = "xyes"])
-
 
 # RSA-PSS
 AC_ARG_ENABLE([rsapss],
@@ -1975,8 +1909,6 @@ else
         ENABLED_DH=no
     fi
 fi
-
-AM_CONDITIONAL([BUILD_DH], [test "x$ENABLED_DH" = "xyes"])
 
 
 # Anonymous
@@ -2049,8 +1981,6 @@ then
     ENABLED_SLOWMATH=no
 fi
 
-AM_CONDITIONAL([BUILD_ASN], [test "x$ENABLED_ASN" != "xno"])
-
 
 # AES
 AC_ARG_ENABLE([aes],
@@ -2091,8 +2021,6 @@ else
     fi
 fi
 
-AM_CONDITIONAL([BUILD_AES], [test "x$ENABLED_AES" = "xyes"])
-
 
 # CODING
 AC_ARG_ENABLE([coding],
@@ -2112,8 +2040,6 @@ else
         ENABLED_CODING=no
     fi
 fi
-
-AM_CONDITIONAL([BUILD_CODING], [test "x$ENABLED_CODING" = "xyes"])
 
 
 # Base64 Encode
@@ -2169,9 +2095,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_IDEA"
 fi
 
-AM_CONDITIONAL([BUILD_IDEA], [test "x$ENABLED_IDEA" = "xyes"])
-
-
 
 # ARC4
 AC_ARG_ENABLE([arc4],
@@ -2197,8 +2120,6 @@ else
     fi
 fi
 
-AM_CONDITIONAL([BUILD_RC4], [test "x$ENABLED_ARC4" = "xyes"])
-
 
 # MD5
 AC_ARG_ENABLE([md5],
@@ -2218,8 +2139,6 @@ else
         ENABLED_MD5=no
     fi
 fi
-
-AM_CONDITIONAL([BUILD_MD5], [test "x$ENABLED_MD5" = "xyes"])
 
 
 # SHA
@@ -2241,8 +2160,6 @@ else
     fi
 fi
 
-AM_CONDITIONAL([BUILD_SHA], [test "x$ENABLED_SHA" = "xyes"])
-
 
 # CMAC
 AC_ARG_ENABLE([cmac],
@@ -2258,9 +2175,6 @@ fi
 
 AS_IF([test "x$ENABLED_CMAC" = "xyes"],
       [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_CMAC -DWOLFSSL_AES_DIRECT"])
-
-#AM_CONDITIONAL([BUILD_CMAC], [test "x$ENABLED_CMAC" = "xyes"])
-#moved to FIPS section
 
 
 # AES-XTS
@@ -2313,8 +2227,6 @@ else
     AM_CFLAGS="$AM_CFLAGS -DHAVE_HC128"
 fi
 
-AM_CONDITIONAL([BUILD_HC128], [test "x$ENABLED_HC128" = "xyes"])
-
 
 # RABBIT
 AC_ARG_ENABLE([rabbit],
@@ -2329,8 +2241,6 @@ then
 else
     AM_CFLAGS="$AM_CFLAGS -DHAVE_RABBIT"
 fi
-
-AM_CONDITIONAL([BUILD_RABBIT], [test "x$ENABLED_RABBIT" = "xyes"])
 
 
 # FIPS
@@ -2354,14 +2264,12 @@ then
     then
         ENABLED_SHA512="yes"
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA512 -DWOLFSSL_SHA384"
-        AM_CONDITIONAL([BUILD_SHA512], [test "x$ENABLED_SHA512" = "xyes"])
     fi
     # requires AESGCM
     if test "x$ENABLED_AESGCM" != "xyes"
     then
         ENABLED_AESGCM="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_AESGCM"
-        AM_CONDITIONAL([BUILD_SHA512], [test "x$ENABLED_SHA512" = "xyes"])
     fi
     # requires DES3
     if test "x$ENABLED_DES3" = "xno"
@@ -2405,9 +2313,6 @@ else
     fi
 fi
 
-AM_CONDITIONAL([BUILD_FIPS], [test "x$ENABLED_FIPS" = "xyes"])
-AM_CONDITIONAL([BUILD_FIPS_V2], [test "x$FIPS_VERSION" = "xv2"])
-AM_CONDITIONAL([BUILD_CMAC], [test "x$ENABLED_CMAC" = "xyes"])
 
 # SELFTEST
 AC_ARG_ENABLE([selftest],
@@ -2420,8 +2325,6 @@ if test "x$ENABLED_SELFTEST" = "xyes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_SELFTEST"
 fi
-
-AM_CONDITIONAL([BUILD_SELFTEST], [test "x$ENABLED_SELFTEST" = "xyes"])
 
 
 # set sha224 default
@@ -2445,8 +2348,6 @@ if test "$ENABLED_SHA224" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA224"
 fi
-
-AM_CONDITIONAL([BUILD_SHA224], [test "x$ENABLED_SHA224" = "xyes"])
 
 
 # set sha3 default
@@ -2477,8 +2378,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SHA3"
 fi
 
-AM_CONDITIONAL([BUILD_SHA3], [test "x$ENABLED_SHA3" = "xyes"])
-
 
 # set POLY1305 default
 POLY1305_DEFAULT=yes
@@ -2505,8 +2404,6 @@ if test "$ENABLED_POLY1305" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_POLY1305 -DHAVE_ONE_TIME_AUTH"
 fi
-
-AM_CONDITIONAL([BUILD_POLY1305], [test "x$ENABLED_POLY1305" = "xyes"])
 
 
 # set CHACHA default
@@ -2539,8 +2436,6 @@ if test "$ENABLED_CHACHA" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_CHACHA"
 fi
-
-AM_CONDITIONAL([BUILD_CHACHA], [test "x$ENABLED_CHACHA" = "xyes"])
 
 
 # Hash DRBG
@@ -2597,8 +2492,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DNO_INLINE"
 fi
 
-AM_CONDITIONAL([BUILD_INLINE], [test "x$ENABLED_INLINE" = "xyes"])
-
 
 # OCSP
 AC_ARG_ENABLE([ocsp],
@@ -2616,8 +2509,6 @@ if test "$ENABLED_OCSP" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_OCSP"
 fi
-
-AM_CONDITIONAL([BUILD_OCSP], [test "x$ENABLED_OCSP" = "xyes"])
 
 
 if test "$ENABLED_OCSP" = "yes"
@@ -2655,11 +2546,9 @@ then
     then
         ENABLED_OCSP="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_OCSP"
-        AM_CONDITIONAL([BUILD_OCSP], [test "x$ENABLED_OCSP" = "xyes"])
     fi
 fi
 
-AM_CONDITIONAL([BUILD_OCSP_STAPLING], [test "x$ENABLED_CERTIFICATE_STATUS_REQUEST" = "xyes"])
 
 # Certificate Status Request v2 : a.k.a. OCSP stapling v2
 AC_ARG_ENABLE([ocspstapling2],
@@ -2682,11 +2571,9 @@ then
     then
         ENABLED_OCSP="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_OCSP"
-        AM_CONDITIONAL([BUILD_OCSP], [test "x$ENABLED_OCSP" = "xyes"])
     fi
 fi
 
-AM_CONDITIONAL([BUILD_OCSP_STAPLING_V2], [test "x$ENABLED_CERTIFICATE_STATUS_REQUEST_V2" = "xyes"])
 
 # CRL
 AC_ARG_ENABLE([crl],
@@ -2706,7 +2593,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_CRL"
 fi
 
-AM_CONDITIONAL([BUILD_CRL], [test "x$ENABLED_CRL" = "xyes"])
 
 # CRL Monitor
 AC_ARG_ENABLE([crl-monitor],
@@ -2729,8 +2615,6 @@ then
         break;;
     esac
 fi
-
-AM_CONDITIONAL([BUILD_CRL_MONITOR], [test "x$ENABLED_CRL_MONITOR" = "xyes"])
 
 
 # USER CRYPTO
@@ -2781,9 +2665,6 @@ AC_ARG_WITH([user-crypto],
     ]
 )
 
-AM_CONDITIONAL([BUILD_USER_RSA], [test "x$ENABLED_USER_RSA" = "xyes"] )
-AM_CONDITIONAL([BUILD_USER_CRYPTO], [test "x$ENABLED_USER_CRYPTO" = "xyes"])
-
 if test "$ENABLED_USER_CRYPTO" = "yes" && test "$ENABLED_FIPS" = "yes"
 then
     AC_MSG_ERROR([cannot enable user crypto and fips, user crypto posibility of using code in fips boundary.])
@@ -2829,8 +2710,6 @@ AC_ARG_WITH([ntru],
         ENABLED_NTRU="yes"
     ]
 )
-
-AM_CONDITIONAL([BUILD_NTRU], [test "x$ENABLED_NTRU" = "xyes"])
 
 
 # QSH
@@ -2890,8 +2769,6 @@ AC_ARG_WITH([wnr],
         ENABLED_WNR="yes"
     ]
 )
-
-AM_CONDITIONAL([BUILD_WNR], [test "x$ENABLED_WNR" = "xyes"])
 
 
 # SNI
@@ -3143,8 +3020,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFCRYPT_HAVE_SRP"
 fi
 
-AM_CONDITIONAL([BUILD_SRP], [test "x$ENABLED_SRP" = "xyes"])
-
 
 # Indefinite length encoded BER message support
 AC_ARG_ENABLE([indef],
@@ -3209,8 +3084,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_VALGRIND"
 fi
 
-AM_CONDITIONAL([USE_VALGRIND], [test "x$ENABLED_VALGRIND" = "xyes"])
-
 
 # Test certs, use internal cert functions for extra testing
 AC_ARG_ENABLE([testcert],
@@ -3261,7 +3134,6 @@ then
     then
         ENABLED_ECC="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_ECC -DTFM_ECC256"
-        AM_CONDITIONAL([BUILD_ECC], [test "x$ENABLED_ECC" = "xyes"])
 
         if test "$ENABLED_ECC_SHAMIR" = "yes"
         then
@@ -3302,13 +3174,11 @@ then
     then
         ENABLED_CRL="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_CRL"
-        AM_CONDITIONAL([BUILD_CRL], [test "x$ENABLED_CRL" = "xyes"])
     fi
     if test "x$ENABLED_OCSP" = "xno"
     then
         ENABLED_OCSP="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_OCSP"
-        AM_CONDITIONAL([BUILD_OCSP], [test "x$ENABLED_OCSP" = "xyes"])
     fi
     if test "x$ENABLED_CRL_MONITOR" = "xno" && test "x$ENABLED_DISTRO" = "xno"
     then
@@ -3334,7 +3204,6 @@ then
     then
         ENABLED_ECC="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_ECC -DTFM_ECC256"
-        AM_CONDITIONAL([BUILD_ECC], [test "x$ENABLED_ECC" = "xyes"])
 
         if test "$ENABLED_ECC_SHAMIR" = "yes"
         then
@@ -3448,7 +3317,6 @@ then
     then
         ENABLED_OCSP="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_OCSP"
-        AM_CONDITIONAL([BUILD_OCSP], [test "x$ENABLED_OCSP" = "xyes"])
     fi
 fi
 
@@ -3476,7 +3344,6 @@ then
     then
         ENABLED_OCSP="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_OCSP"
-        AM_CONDITIONAL([BUILD_OCSP], [test "x$ENABLED_OCSP" = "xyes"])
     fi
 
     # Requires coding make sure on
@@ -3497,7 +3364,6 @@ then
     then
         ENABLED_CRL="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_CRL"
-        AM_CONDITIONAL([BUILD_CRL], [test "x$ENABLED_CRL" = "xyes"])
     fi
 
     # Requires DES3, make sure on
@@ -3524,7 +3390,6 @@ then
         ENABLED_OPENSSLEXTRA="yes"
         ENABLED_ECC="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_ECC -DTFM_ECC256"
-        AM_CONDITIONAL([BUILD_ECC], [test "x$ENABLED_ECC" = "xyes"])
 
         if test "$ENABLED_ECC_SHAMIR" = "yes"
         then
@@ -3567,8 +3432,6 @@ then
     fi
 fi
 
-AM_CONDITIONAL([BUILD_MD4], [test "x$ENABLED_MD4" = "xyes"])
-
 
 # Encrypted keys
 AC_ARG_ENABLE([enckeys],
@@ -3607,8 +3470,6 @@ then
     fi
 fi
 
-AM_CONDITIONAL([BUILD_PWDBASED], [test "x$ENABLED_PWDBASED" = "xyes"])
-
 
 AC_ARG_ENABLE([scrypt],
     [AS_HELP_STRING([--enable-scrypt],[Enable SCRYPT (default: disabled)])],
@@ -3625,8 +3486,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_SCRYPT"
 fi
 
-AM_CONDITIONAL([BUILD_SCRYPT], [test "x$ENABLED_SCRYPT" = "xyes"])
-
 
 # wolfCrypt Only Build
 AC_ARG_ENABLE([cryptonly],
@@ -3638,8 +3497,6 @@ if test "$ENABLED_CRYPTONLY" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFCRYPT_ONLY"
 fi
-
-AM_CONDITIONAL([BUILD_CRYPTONLY], [test "x$ENABLED_CRYPTONLY" = "xyes"])
 
 if test "x$ENABLED_CRYPTONLY" = "xno"
 then
@@ -3728,9 +3585,6 @@ then
     ENABLED_SLOWMATH="no"
 fi
 
-AM_CONDITIONAL([BUILD_FASTMATH], [test "x$ENABLED_FASTMATH" = "xyes"])
-AM_CONDITIONAL([BUILD_SLOWMATH], [test "x$ENABLED_SLOWMATH" = "xyes"])
-
 
 # Enable Examples, used to disable examples
 AC_ARG_ENABLE([examples],
@@ -3742,10 +3596,7 @@ AC_ARG_ENABLE([examples],
 AS_IF([test "x$ENABLED_FILESYSTEM" = "xno"], [ENABLED_EXAMPLES="no"])
 AS_IF([test "x$ENABLED_INLINE" = "xno"], [ENABLED_EXAMPLES="no"])
 AS_IF([test "x$ENABLED_CRYPTONLY" = "xyes"], [ENABLED_EXAMPLES="no"])
-AM_CONDITIONAL([BUILD_EXAMPLE_SERVERS], [test "x$ENABLED_EXAMPLES" = "xyes" && test "x$ENABLED_LEANTLS" = "xno"])
-AM_CONDITIONAL([BUILD_EXAMPLE_CLIENTS], [test "x$ENABLED_EXAMPLES" = "xyes"])
-AM_CONDITIONAL([BUILD_TESTS], [test "x$ENABLED_EXAMPLES" = "xyes" && test "x$ENABLED_LEANTLS" = "xno"])
-AM_CONDITIONAL([BUILD_THREADED_EXAMPLES], [test "x$ENABLED_SINGLETHREADED" = "xno" && test "x$ENABLED_EXAMPLES" = "xyes" && test "x$ENABLED_LEANTLS" = "xno"])
+
 
 # Enable wolfCrypt test and benchmark
 AC_ARG_ENABLE([crypttests],
@@ -3754,7 +3605,6 @@ AC_ARG_ENABLE([crypttests],
     [ ENABLED_CRYPT_TESTS=yes ]
     )
 
-AM_CONDITIONAL([BUILD_WOLFCRYPT_TESTS], [test "x$ENABLED_CRYPT_TESTS" = "xyes"])
 
 # LIBZ
 ENABLED_LIBZ="no"
@@ -3792,7 +3642,6 @@ AC_ARG_WITH([libz],
         ENABLED_LIBZ="yes"
     ]
 )
-AM_CONDITIONAL([BUILD_LIBZ], [test "x$ENABLED_LIBZ" = "xyes"])
 
 
 # PKCS#11
@@ -3807,7 +3656,6 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_PKCS11 -DHAVE_WOLF_BIGINT"
     LIBS="$LIBS -ldl"
 fi
-AM_CONDITIONAL([BUILD_PKCS11], [test "x$ENABLED_PKCS11" = "xyes"])
 
 
 # cavium
@@ -3881,9 +3729,6 @@ AC_ARG_WITH([cavium-v],
     ]
 )
 
-AM_CONDITIONAL([BUILD_CAVIUM], [test "x$ENABLED_CAVIUM" = "xyes"])
-AM_CONDITIONAL([BUILD_CAVIUM_V], [test "x$ENABLED_CAVIUM_V" = "xyes"])
-
 
 # Intel QuickAssist
 QAT_DIR=""
@@ -3941,7 +3786,7 @@ AC_ARG_WITH([intelqa],
         ENABLED_INTEL_QA=no
     ]
 )
-AM_CONDITIONAL([BUILD_INTEL_QA], [test "x$ENABLED_INTEL_QA" = "xyes"])
+
 
 # Single Precision maths implementation
 AC_ARG_ENABLE([sp],
@@ -4140,14 +3985,6 @@ if test "$ENABLED_SP_MATH" = "yes"; then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_MATH"
 fi
 
-AM_CONDITIONAL([BUILD_SP], [test "x$ENABLED_SP" = "xyes"])
-AM_CONDITIONAL([BUILD_SP_C], [test "x$ENABLED_SP" = "xyes" && test "x$ENABLED_SP_ASM" = "xno" ])
-AM_CONDITIONAL([BUILD_SP_ARM64], [test "x$ENABLED_SP_ARM64_ASM" = "xyes" ])
-AM_CONDITIONAL([BUILD_SP_ARM32], [test "x$ENABLED_SP_ARM32_ASM" = "xyes" ])
-AM_CONDITIONAL([BUILD_SP_ARM_THUMB], [test "x$ENABLED_SP_ARM_THUMB_ASM" = "xyes" ])
-AM_CONDITIONAL([BUILD_SP_ARM_CORTEX], [test "x$ENABLED_SP_ARM_CORTEX_ASM" = "xyes" ])
-AM_CONDITIONAL([BUILD_SP_X86_64], [test "x$ENABLED_SP_X86_64_ASM" = "xyes" ])
-AM_CONDITIONAL([BUILD_SP_INT], [test "x$ENABLED_SP_MATH" = "xyes" ])
 
 # Fast RSA using Intel IPP
 ippdir="${srcdir}/IPP"
@@ -4296,7 +4133,6 @@ fi
 AC_SUBST([IPPLIBS])
 AC_SUBST([IPPHEADERS])
 AC_SUBST([IPPLINK])
-AM_CONDITIONAL([BUILD_FAST_RSA], [test "x$ENABLED_FAST_RSA" = "xyes"])
 
 
 # static memory use
@@ -4352,8 +4188,6 @@ then
     AC_MSG_ERROR([please use --with-libz if enabling mcapi.])
 fi
 
-AM_CONDITIONAL([BUILD_MCAPI], [test "x$ENABLED_MCAPI" = "xyes"])
-
 
 # Asynchronous Crypto
 AC_ARG_ENABLE([asynccrypt],
@@ -4374,9 +4208,6 @@ then
     fi
 fi
 
-AM_CONDITIONAL([BUILD_ASYNCCRYPT], [test "x$ENABLED_ASYNCCRYPT" = "xyes"])
-
-AM_CONDITIONAL([BUILD_WOLFEVENT], [test "x$ENABLED_ASYNCCRYPT" = "xyes"])
 
 # check for async if using Intel QuckAssist or Cavium
 if test "x$ENABLED_INTEL_QA" = "xyes" || test "x$ENABLED_CAVIUM" = "xyes" ; then
@@ -4429,7 +4260,6 @@ if test "$ENABLED_CRYPTOCB" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLF_CRYPTO_CB"
 fi
-AM_CONDITIONAL([BUILD_CRYPTOCB], [test "x$ENABLED_CRYPTOCB" = "xyes"])
 
 
 # Session Export
@@ -4510,10 +4340,6 @@ AC_ARG_ENABLE([optflags],
     )
 
 
-# check if PSK was enabled for conditionally running psk.test script
-AM_CONDITIONAL([BUILD_PSK], [test "x$ENABLED_PSK" = "xyes"])
-
-
 # check if should run the trusted peer certs test
 # (for now checking both C_FLAGS and C_EXTRA_FLAGS)
 case $C_EXTRA_FLAGS in
@@ -4532,7 +4358,6 @@ if test "$have_tp" = "no"; then
         have_tp=no ;;
     esac
 fi
-AM_CONDITIONAL([BUILD_TRUST_PEER_CERT], [test "x$have_tp" = "xyes"])
 
 
 # dertermine if we have key validation mechanism
@@ -4543,8 +4368,6 @@ then
         ENABLED_PKI="yes"
     fi
 fi
-AM_CONDITIONAL([BUILD_PKI], [test "x$ENABLED_PKI" = "xyes"])
-
 
 
 ################################################################################
@@ -4670,8 +4493,6 @@ else
     fi
 fi
 
-AM_CONDITIONAL([BUILD_DES3], [test "x$ENABLED_DES3" = "xyes"])
-AM_CONDITIONAL([BUILD_PKCS7], [test "x$ENABLED_PKCS7" = "xyes"])
 
 AS_IF([test "x$ENABLED_MAXSTRENGTH" = "xyes"],
       [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_MAX_STRENGTH"])
@@ -4792,6 +4613,113 @@ then
     CFLAGS="$CFLAGS $USER_C_EXTRA_FLAGS"
 fi
 OPTION_FLAGS="$USER_CFLAGS $USER_C_EXTRA_FLAGS $CPPFLAGS $AM_CFLAGS"
+
+
+# The following AM_CONDITIONAL statements set flags for use in the Makefiles.
+# Some of these affect build targets and objects, some trigger different
+# test scripts for make check.
+AM_CONDITIONAL([BUILD_DISTRO],[test "x$ENABLED_DISTRO" = "xyes"])
+AM_CONDITIONAL([BUILD_ALL],[test "x$ENABLED_ALL" = "xyes"])
+AM_CONDITIONAL([BUILD_TLS13],[test "x$ENABLED_TLS13" = "xyes"])
+AM_CONDITIONAL([BUILD_RNG],[test "x$ENABLED_RNG" = "xyes"])
+AM_CONDITIONAL([BUILD_SCTP],[test "x$ENABLED_SCTP" = "xyes"])
+AM_CONDITIONAL([BUILD_MCAST],[test "x$ENABLED_MCAST" = "xyes"])
+AM_CONDITIONAL([BUILD_IPV6],[test "x$ENABLED_IPV6" = "xyes"])
+AM_CONDITIONAL([BUILD_LEANPSK],[test "x$ENABLED_LEANPSK" = "xyes"])
+AM_CONDITIONAL([BUILD_LEANTLS],[test "x$ENABLED_LEANTLS" = "xyes"])
+AM_CONDITIONAL([BUILD_LOWMEM],[test "x$ENABLED_LOWRESOURCE" = "xyes"])
+AM_CONDITIONAL([BUILD_PKCALLBACKS],  [ test "x$ENABLED_PKCALLBACKS" = "xyes" ])
+AM_CONDITIONAL([BUILD_CRYPTOAUTHLIB],[test "x$ENABLED_CRYPTOAUTHLIB" = "xyes"])
+AM_CONDITIONAL([BUILD_SNIFFER],  [ test "x$ENABLED_SNIFFER"   = "xyes" ])
+AM_CONDITIONAL([BUILD_SNIFFTEST],[ test "x$ENABLED_SNIFFTEST" = "xyes" ])
+AM_CONDITIONAL([BUILD_AESGCM],[test "x$ENABLED_AESGCM" = "xyes"])
+AM_CONDITIONAL([BUILD_AESCCM],[test "x$ENABLED_AESCCM" = "xyes"])
+AM_CONDITIONAL([BUILD_ARMASM],[test "x$ENABLED_ARMASM" = "xyes"])
+AM_CONDITIONAL([BUILD_XILINX],[test "x$ENABLED_XILINX" = "xyes"])
+AM_CONDITIONAL([BUILD_AESNI],[test "x$ENABLED_AESNI" = "xyes"])
+AM_CONDITIONAL([BUILD_INTELASM],[test "x$ENABLED_INTELASM" = "xyes"])
+AM_CONDITIONAL([BUILD_AFALG],[test "x$ENABLED_AFALG" = "xyes"])
+AM_CONDITIONAL([BUILD_DEVCRYPTO],[test "x$ENABLED_DEVCRYPTO" = "xyes"])
+AM_CONDITIONAL([BUILD_CAMELLIA],[test "x$ENABLED_CAMELLIA" = "xyes"])
+AM_CONDITIONAL([BUILD_MD2],[test "x$ENABLED_MD2" = "xyes"])
+AM_CONDITIONAL([BUILD_RIPEMD],[test "x$ENABLED_RIPEMD" = "xyes"])
+AM_CONDITIONAL([BUILD_BLAKE2],[test "x$ENABLED_BLAKE2" = "xyes"])
+AM_CONDITIONAL([BUILD_BLAKE2S],[test "x$ENABLED_BLAKE2S" = "xyes"])
+AM_CONDITIONAL([BUILD_SHA512],[test "x$ENABLED_SHA512" = "xyes" || test "x$ENABLED_SHA384" = "xyes"])
+AM_CONDITIONAL([BUILD_DSA],[test "x$ENABLED_DSA" = "xyes"])
+AM_CONDITIONAL([BUILD_ECC],[test "x$ENABLED_ECC" = "xyes"])
+AM_CONDITIONAL([BUILD_ED25519],[test "x$ENABLED_ED25519" = "xyes"])
+AM_CONDITIONAL([BUILD_ED25519_SMALL],[test "x$ENABLED_ED25519_SMALL" = "xyes"])
+AM_CONDITIONAL([BUILD_FEMATH], [test "x$ENABLED_FEMATH" = "xyes"])
+AM_CONDITIONAL([BUILD_GEMATH], [test "x$ENABLED_GEMATH" = "xyes"])
+AM_CONDITIONAL([BUILD_CURVE25519],[test "x$ENABLED_CURVE25519" = "xyes"])
+AM_CONDITIONAL([BUILD_CURVE25519_SMALL],[test "x$ENABLED_CURVE25519_SMALL" = "xyes"])
+AM_CONDITIONAL([BUILD_MEMORY],[test "x$ENABLED_MEMORY" = "xyes"])
+AM_CONDITIONAL([BUILD_RSA],[test "x$ENABLED_RSA" = "xyes"])
+AM_CONDITIONAL([BUILD_DH],[test "x$ENABLED_DH" = "xyes"])
+AM_CONDITIONAL([BUILD_ASN],[test "x$ENABLED_ASN" != "xno"])
+AM_CONDITIONAL([BUILD_AES],[test "x$ENABLED_AES" = "xyes"])
+AM_CONDITIONAL([BUILD_CODING],[test "x$ENABLED_CODING" = "xyes"])
+AM_CONDITIONAL([BUILD_IDEA],[test "x$ENABLED_IDEA" = "xyes"])
+AM_CONDITIONAL([BUILD_RC4],[test "x$ENABLED_ARC4" = "xyes"])
+AM_CONDITIONAL([BUILD_MD5],[test "x$ENABLED_MD5" = "xyes"])
+AM_CONDITIONAL([BUILD_SHA],[test "x$ENABLED_SHA" = "xyes"])
+AM_CONDITIONAL([BUILD_HC128],[test "x$ENABLED_HC128" = "xyes"])
+AM_CONDITIONAL([BUILD_RABBIT],[test "x$ENABLED_RABBIT" = "xyes"])
+AM_CONDITIONAL([BUILD_FIPS],[test "x$ENABLED_FIPS" = "xyes"])
+AM_CONDITIONAL([BUILD_FIPS_V2],[test "x$FIPS_VERSION" = "xv2"])
+AM_CONDITIONAL([BUILD_CMAC],[test "x$ENABLED_CMAC" = "xyes"])
+AM_CONDITIONAL([BUILD_SELFTEST],[test "x$ENABLED_SELFTEST" = "xyes"])
+AM_CONDITIONAL([BUILD_SHA224],[test "x$ENABLED_SHA224" = "xyes"])
+AM_CONDITIONAL([BUILD_SHA3],[test "x$ENABLED_SHA3" = "xyes"])
+AM_CONDITIONAL([BUILD_POLY1305],[test "x$ENABLED_POLY1305" = "xyes"])
+AM_CONDITIONAL([BUILD_CHACHA],[test "x$ENABLED_CHACHA" = "xyes"])
+AM_CONDITIONAL([BUILD_INLINE],[test "x$ENABLED_INLINE" = "xyes"])
+AM_CONDITIONAL([BUILD_OCSP],[test "x$ENABLED_OCSP" = "xyes"])
+AM_CONDITIONAL([BUILD_OCSP_STAPLING],[test "x$ENABLED_CERTIFICATE_STATUS_REQUEST" = "xyes"])
+AM_CONDITIONAL([BUILD_OCSP_STAPLING_V2],[test "x$ENABLED_CERTIFICATE_STATUS_REQUEST_V2" = "xyes"])
+AM_CONDITIONAL([BUILD_CRL],[test "x$ENABLED_CRL" = "xyes"])
+AM_CONDITIONAL([BUILD_CRL_MONITOR],[test "x$ENABLED_CRL_MONITOR" = "xyes"])
+AM_CONDITIONAL([BUILD_USER_RSA],[test "x$ENABLED_USER_RSA" = "xyes"] )
+AM_CONDITIONAL([BUILD_USER_CRYPTO],[test "x$ENABLED_USER_CRYPTO" = "xyes"])
+AM_CONDITIONAL([BUILD_NTRU],[test "x$ENABLED_NTRU" = "xyes"])
+AM_CONDITIONAL([BUILD_WNR],[test "x$ENABLED_WNR" = "xyes"])
+AM_CONDITIONAL([BUILD_SRP],[test "x$ENABLED_SRP" = "xyes"])
+AM_CONDITIONAL([USE_VALGRIND],[test "x$ENABLED_VALGRIND" = "xyes"])
+AM_CONDITIONAL([BUILD_MD4],[test "x$ENABLED_MD4" = "xyes"])
+AM_CONDITIONAL([BUILD_PWDBASED],[test "x$ENABLED_PWDBASED" = "xyes"])
+AM_CONDITIONAL([BUILD_SCRYPT],[test "x$ENABLED_SCRYPT" = "xyes"])
+AM_CONDITIONAL([BUILD_CRYPTONLY],[test "x$ENABLED_CRYPTONLY" = "xyes"])
+AM_CONDITIONAL([BUILD_FASTMATH],[test "x$ENABLED_FASTMATH" = "xyes"])
+AM_CONDITIONAL([BUILD_SLOWMATH],[test "x$ENABLED_SLOWMATH" = "xyes"])
+AM_CONDITIONAL([BUILD_EXAMPLE_SERVERS],[test "x$ENABLED_EXAMPLES" = "xyes" && test "x$ENABLED_LEANTLS" = "xno"])
+AM_CONDITIONAL([BUILD_EXAMPLE_CLIENTS],[test "x$ENABLED_EXAMPLES" = "xyes"])
+AM_CONDITIONAL([BUILD_TESTS],[test "x$ENABLED_EXAMPLES" = "xyes" && test "x$ENABLED_LEANTLS" = "xno"])
+AM_CONDITIONAL([BUILD_THREADED_EXAMPLES],[test "x$ENABLED_SINGLETHREADED" = "xno" && test "x$ENABLED_EXAMPLES" = "xyes" && test "x$ENABLED_LEANTLS" = "xno"])
+AM_CONDITIONAL([BUILD_WOLFCRYPT_TESTS],[test "x$ENABLED_CRYPT_TESTS" = "xyes"])
+AM_CONDITIONAL([BUILD_LIBZ],[test "x$ENABLED_LIBZ" = "xyes"])
+AM_CONDITIONAL([BUILD_PKCS11],[test "x$ENABLED_PKCS11" = "xyes"])
+AM_CONDITIONAL([BUILD_CAVIUM],[test "x$ENABLED_CAVIUM" = "xyes"])
+AM_CONDITIONAL([BUILD_CAVIUM_V],[test "x$ENABLED_CAVIUM_V" = "xyes"])
+AM_CONDITIONAL([BUILD_INTEL_QA],[test "x$ENABLED_INTEL_QA" = "xyes"])
+AM_CONDITIONAL([BUILD_SP],[test "x$ENABLED_SP" = "xyes"])
+AM_CONDITIONAL([BUILD_SP_C],[test "x$ENABLED_SP" = "xyes" && test "x$ENABLED_SP_ASM" = "xno" ])
+AM_CONDITIONAL([BUILD_SP_ARM64],[test "x$ENABLED_SP_ARM64_ASM" = "xyes" ])
+AM_CONDITIONAL([BUILD_SP_ARM32],[test "x$ENABLED_SP_ARM32_ASM" = "xyes" ])
+AM_CONDITIONAL([BUILD_SP_ARM_THUMB],[test "x$ENABLED_SP_ARM_THUMB_ASM" = "xyes" ])
+AM_CONDITIONAL([BUILD_SP_ARM_CORTEX],[test "x$ENABLED_SP_ARM_CORTEX_ASM" = "xyes" ])
+AM_CONDITIONAL([BUILD_SP_X86_64],[test "x$ENABLED_SP_X86_64_ASM" = "xyes" ])
+AM_CONDITIONAL([BUILD_SP_INT],[test "x$ENABLED_SP_MATH" = "xyes" ])
+AM_CONDITIONAL([BUILD_FAST_RSA],[test "x$ENABLED_FAST_RSA" = "xyes"])
+AM_CONDITIONAL([BUILD_MCAPI],[test "x$ENABLED_MCAPI" = "xyes"])
+AM_CONDITIONAL([BUILD_ASYNCCRYPT],[test "x$ENABLED_ASYNCCRYPT" = "xyes"])
+AM_CONDITIONAL([BUILD_WOLFEVENT],[test "x$ENABLED_ASYNCCRYPT" = "xyes"])
+AM_CONDITIONAL([BUILD_CRYPTOCB],[test "x$ENABLED_CRYPTOCB" = "xyes"])
+AM_CONDITIONAL([BUILD_PSK],[test "x$ENABLED_PSK" = "xyes"])
+AM_CONDITIONAL([BUILD_TRUST_PEER_CERT],[test "x$have_tp" = "xyes"])
+AM_CONDITIONAL([BUILD_PKI],[test "x$ENABLED_PKI" = "xyes"])
+AM_CONDITIONAL([BUILD_DES3],[test "x$ENABLED_DES3" = "xyes"])
+AM_CONDITIONAL([BUILD_PKCS7],[test "x$ENABLED_PKCS7" = "xyes"])
 
 
 CREATE_HEX_VERSION


### PR DESCRIPTION
Consolidate all the AM_CONDITIONAL statements in one place in the configure process. This replaces the set of repeat checks of enable flags to conditionally check the AM_CONDITIONAL.