### PR TITLE
fix ed25519 sign msg test failure in ESP32

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2175,10 +2175,16 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
         int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         {
-            int i;
-
-            for (i = 0; i< sz; i++) {
-               output[i] =  esp_random( );
+            word32 rand;
+            while (sz > 0) {
+                word32 len = sizeof(rand);
+                if (sz < len)
+                    len = sz;
+                /* Get one random 32-bit word from hw RNG */  
+                rand = esp_random( );
+                XMEMCPY(output, &rand, sz);
+                output += len;
+                sz -= len;
             }
 
             return 0;

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2182,7 +2182,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
                     len = sz;
                 /* Get one random 32-bit word from hw RNG */  
                 rand = esp_random( );
-                XMEMCPY(output, &rand, sz);
+                XMEMCPY(output, &rand, len);
                 output += len;
                 sz -= len;
             }
@@ -2228,7 +2228,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
                 if (sz < len)
                     len = sz;
                 rand = sys_rand32_get();
-                XMEMCPY(output, &rand, sz);
+                XMEMCPY(output, &rand, len);
                 output += len;
                 sz -= len;
             }

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -752,6 +752,9 @@ static WC_INLINE int Sha512Final(wc_Sha512* sha512)
      defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
         ret = Transform_Sha512(sha512);
 #else
+       if(sha512->ctx.mode == ESP32_SHA_INIT) {
+            esp_sha_try_hw_lock(&sha512->ctx);
+       }
         ret = esp_sha512_process(sha512);
         if(ret == 0 && sha512->ctx.mode == ESP32_SHA_SW){
             ret = Transform_Sha512(sha512);


### PR DESCRIPTION
1. Need to check hw state before calling  esp_sha512_process() in Sha512Final. The function is usually called in Sha512Update(). However, there is a rare case that it isn't called until Sha512Final. This caused ed25519 sign msg test failure.

2. Better random number handling