### PR TITLE
TLS 1.3 extension fixes

### DIFF
--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1151,8 +1151,8 @@ enum Misc {
     TLSv1_1_MINOR   = 2,        /* TLSv1_1 minor version number */
     TLSv1_2_MINOR   = 3,        /* TLSv1_2 minor version number */
     TLSv1_3_MINOR   = 4,        /* TLSv1_3 minor version number */
-#ifdef WOLFSSL_TLS13_DRAFT
     TLS_DRAFT_MAJOR = 0x7f,     /* Draft TLS major version number */
+#ifdef WOLFSSL_TLS13_DRAFT
 #ifdef WOLFSSL_TLS13_DRAFT_18
     TLS_DRAFT_MINOR = 0x12,     /* Minor version number of TLS draft */
 #elif defined(WOLFSSL_TLS13_DRAFT_22)
@@ -2825,6 +2825,20 @@ enum SignatureAlgorithm {
     ed25519_sa_algo   = 9
 };
 
+#ifdef WOLFSSL_TLS13
+#define PSS_RSAE_TO_PSS_PSS(macAlgo) \
+    (macAlgo + (pss_sha256 - sha256_mac))
+
+#define PSS_PSS_HASH_TO_MAC(macAlgo) \
+    (macAlgo - (pss_sha256 - sha256_mac))
+
+enum SigAlgRsaPss {
+    pss_sha256  = 0x09,
+    pss_sha384  = 0x0a,
+    pss_sha512  = 0x0b,
+};
+#endif
+
 
 /* Supprted ECC Curve Types */
 enum EccCurves {
@@ -3737,7 +3751,7 @@ struct WOLFSSL {
     word16          group[WOLFSSL_MAX_GROUP_COUNT];
     byte            numGroups;
 #endif
-    byte            pssAlgo;
+    word16          pssAlgo;
 #ifdef WOLFSSL_TLS13
     #if !defined(WOLFSSL_TLS13_DRAFT_18) && !defined(WOLFSSL_TLS13_DRAFT_22)
     word16          certHashSigAlgoSz;  /* SigAlgoCert ext length in bytes */


### PR DESCRIPTION
When major version is TLS Draft then this is now ignored.
If version negotitation occurs but none matched then send an alert and
return an error.
Store the rsa_pss_pss_* signature algorithms in the bit mask.
KeyShare Entry parsing returns INVALID_PARAMETER when length is 0 and
results in a different alert being sent.
Check negotiated protocol version is not TLS 1.3 when determing whether
to parse point formats.