### PR TITLE
Various fixes, improvements to build options for reduced code size and static benchmarks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3658,6 +3658,20 @@ then
 fi
 
 
+# PKCS#12
+AC_ARG_ENABLE([pkcs12],
+    [AS_HELP_STRING([--enable-pkcs12],[Enable pkcs12 (default: enabled)])],
+    [ ENABLED_PKCS12=$enableval ],
+    [ ENABLED_PKCS12=yes ]
+    )
+
+if test "x$ENABLED_PKCS12" = "xno"
+then
+    AM_CFLAGS="$AM_CFLAGS -DNO_PKCS12"
+fi
+AM_CONDITIONAL([BUILD_PKCS12], [test "x$ENABLED_PKCS12" = "xyes"])
+
+
 # cavium
 trycaviumdir=""
 AC_ARG_WITH([cavium],
@@ -4988,6 +5002,7 @@ echo "   * Fast RSA:                   $ENABLED_FAST_RSA"
 echo "   * Single Precision:           $ENABLED_SP"
 echo "   * Async Crypto:               $ENABLED_ASYNCCRYPT"
 echo "   * PKCS#11:                    $ENABLED_PKCS11"
+echo "   * PKCS#12:                    $ENABLED_PKCS12"
 echo "   * Cavium:                     $ENABLED_CAVIUM"
 echo "   * ARM ASM:                    $ENABLED_ARMASM"
 echo "   * AES Key Wrap:               $ENABLED_AESKEYWRAP"

--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -57,6 +57,7 @@ bench_tls(args);
 #include <string.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <errno.h>
 
 /* For testing no pthread support */
 #if 0

--- a/src/internal.c
+++ b/src/internal.c
@@ -6871,7 +6871,7 @@ static int wolfSSLReceive(WOLFSSL* ssl, byte* buf, word32 sz)
 
 retry:
     recvd = ssl->CBIORecv(ssl, (char *)buf, (int)sz, ssl->IOCB_ReadCtx);
-    if (recvd < 0)
+    if (recvd < 0) {
         switch (recvd) {
             case WOLFSSL_CBIO_ERR_GENERAL:        /* general/unknown error */
                 return -1;
@@ -6926,8 +6926,10 @@ retry:
                 return -1;
 
             default:
+                WOLFSSL_MSG("Unexpected recv return code");
                 return recvd;
         }
+    }
 
     return recvd;
 }

--- a/wolfcrypt/benchmark/benchmark.h
+++ b/wolfcrypt/benchmark/benchmark.h
@@ -92,6 +92,9 @@ void bench_ntruKeyGen(void);
 void bench_rng(void);
 void bench_blake2b(void);
 void bench_blake2s(void);
+void bench_pbkdf2(void);
+
+void bench_stats_print(void);
 
 
 #ifdef __cplusplus

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -2305,6 +2305,8 @@ int wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx, RsaKey* key,
 #endif /* HAVE_USER_RSA */
 #endif /* NO_RSA */
 
+#ifdef HAVE_PKCS8
+
 /* Remove PKCS8 header, place inOutIdx at beginning of traditional,
  * return traditional length on success, negative on error */
 int ToTraditionalInline_ex(const byte* input, word32* inOutIdx, word32 sz,
@@ -2502,7 +2504,9 @@ int wc_CreatePKCS8Key(byte* out, word32* outSz, byte* key, word32 keySz,
         return tmpSz + sz;
 }
 
+#endif /* HAVE_PKCS8 */
 
+#ifdef HAVE_PKCS12
 /* check that the private key is a pair for the public key in certificate
  * return 1 (true) on match
  * return 0 or negative value on failure/error
@@ -2705,8 +2709,11 @@ int wc_CheckPrivateKey(byte* key, word32 keySz, DecodedCert* der)
     return ret;
 }
 
+#endif /* HAVE_PKCS12 */
+
 #ifndef NO_PWDBASED
 
+#ifdef HAVE_PKCS8
 /* Check To see if PKCS version algo is supported, set id if it is return 0
    < 0 on error */
 static int CheckAlgo(int first, int second, int* id, int* version, int* blockSz)
@@ -3482,6 +3489,9 @@ exit_tte:
     return ret;
 }
 
+#endif /* HAVE_PKCS8 */
+
+#ifdef HAVE_PKCS12
 
 /* encrypt PKCS 12 content
  *
@@ -3837,6 +3847,7 @@ exit_dc:
 
     return ret;
 }
+#endif /* HAVE_PKCS12 */
 #endif /* NO_PWDBASED */
 
 #ifndef NO_RSA
@@ -4196,7 +4207,6 @@ int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen)
 
 #endif /* NO_DSA */
 
-
 void InitDecodedCert(DecodedCert* cert,
                      const byte* source, word32 inSz, void* heap)
 {
@@ -4218,7 +4228,9 @@ void InitDecodedCert(DecodedCert* cert,
         cert->subjectOUEnc    = CTC_UTF8;
     #endif /* WOLFSSL_CERT_GEN */
 
+    #ifndef NO_CERTS
         InitSignatureCtx(&cert->sigCtx, heap, INVALID_DEVID);
+    #endif
     }
 }
 
@@ -4282,7 +4294,9 @@ void FreeDecodedCert(DecodedCert* cert)
     if (cert->subjectName.fullName != NULL)
         XFREE(cert->subjectName.fullName, cert->heap, DYNAMIC_TYPE_X509);
 #endif /* OPENSSL_EXTRA */
+#ifndef NO_CERTS
     FreeSignatureCtx(&cert->sigCtx);
+#endif
 }
 
 static int GetCertHeader(DecodedCert* cert)
@@ -5729,7 +5743,6 @@ int wc_GetPubX509(DecodedCert* cert, int verify, int* badDate)
     return ret;
 }
 
-
 int DecodeToKey(DecodedCert* cert, int verify)
 {
     int badDate = 0;
@@ -5963,6 +5976,8 @@ word32 wc_EncodeSignature(byte* out, const byte* digest, word32 digSz,
     return encDigSz + algoSz + seqSz;
 }
 
+
+#ifndef NO_CERTS
 
 int wc_GetCTC_HashOID(int type)
 {
@@ -8460,6 +8475,8 @@ WOLFSSL_LOCAL int SetSerialNumber(const byte* sn, word32 snSz, byte* output,
     return i;
 }
 
+#endif /* !NO_CERTS */
+
 WOLFSSL_LOCAL int GetSerialNumber(const byte* input, word32* inOutIdx,
     byte* serial, int* serialSz, word32 maxIdx)
 {
@@ -8494,6 +8511,7 @@ WOLFSSL_LOCAL int GetSerialNumber(const byte* input, word32* inOutIdx,
     return result;
 }
 
+#ifndef NO_CERTS
 
 int AllocDer(DerBuffer** pDer, word32 length, int type, void* heap)
 {
@@ -13391,6 +13409,7 @@ int wc_SetDatesBuffer(Cert* cert, const byte* der, int derSz)
 
 #endif /* WOLFSSL_CERT_GEN */
 
+#endif /* !NO_CERTS */
 
 #ifdef HAVE_ECC
 

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -26,7 +26,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#if !defined(NO_ASN) && !defined(NO_PWDBASED)
+#if !defined(NO_ASN) && !defined(NO_PWDBASED) && defined(HAVE_PKCS12)
 
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
@@ -2076,4 +2076,4 @@ void* wc_PKCS12_GetHeap(WC_PKCS12* pkcs12)
 
 #undef ERROR_OUT
 
-#endif /* !NO_ASN && !NO_PWDBASED */
+#endif /* !NO_ASN && !NO_PWDBASED && HAVE_PKCS12 */

--- a/wolfcrypt/src/port/st/stsafe.c
+++ b/wolfcrypt/src/port/st/stsafe.c
@@ -22,6 +22,10 @@
 #include <wolfssl/wolfcrypt/port/st/stsafe.h>
 #include <wolfssl/wolfcrypt/logging.h>
 
+#ifndef STSAFE_INTERFACE_PRINTF
+#define STSAFE_INTERFACE_PRINTF(...)
+#endif
+
 #ifdef WOLFSSL_STSAFEA100
 
 int SSL_STSAFE_LoadDeviceCertificate(byte** pRawCertificate,
@@ -357,7 +361,7 @@ int wolfSSL_STSAFE_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
 #ifdef HAVE_ECC
     else if (info->algo_type == WC_ALGO_TYPE_PK) {
     #ifdef USE_STSAFE_VERBOSE
-        printf("STSAFE Pk: Type %d\n", info->pk.type);
+        STSAFE_INTERFACE_PRINTF("STSAFE Pk: Type %d\n", info->pk.type);
     #endif
 
         if (info->pk.type == WC_PK_TYPE_EC_KEYGEN) {
@@ -502,7 +506,7 @@ int wolfSSL_STSAFE_CryptoDevCb(int devId, wc_CryptoInfo* info, void* ctx)
     if (rc != 0 && rc != CRYPTOCB_UNAVAILABLE) {
         WOLFSSL_MSG("STSAFE: CryptoCb failed");
     #ifdef USE_STSAFE_VERBOSE
-        printf("STSAFE: CryptoCb failed %d\n", rc);
+        STSAFE_INTERFACE_PRINTF("STSAFE: CryptoCb failed %d\n", rc);
     #endif
         rc = WC_HW_E;
     }

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -42,6 +42,8 @@
 #endif
 
 
+#ifdef HAVE_PBKDF1
+
 /* PKCS#5 v1.5 with non standard extension to optionally derive the extra data (IV) */
 int wc_PBKDF1_ex(byte* key, int keyLen, byte* iv, int ivLen,
     const byte* passwd, int passwdLen, const byte* salt, int saltLen,
@@ -165,6 +167,9 @@ int wc_PBKDF1(byte* output, const byte* passwd, int pLen, const byte* salt,
         passwd, pLen, salt, sLen, iterations, hashType, NULL);
 }
 
+#endif /* HAVE_PKCS5 */
+
+#ifdef HAVE_PBKDF2
 
 int wc_PBKDF2(byte* output, const byte* passwd, int pLen, const byte* salt,
            int sLen, int iterations, int kLen, int hashType)
@@ -264,6 +269,10 @@ int wc_PBKDF2(byte* output, const byte* passwd, int pLen, const byte* salt,
 
     return ret;
 }
+
+#endif /* HAVE_PBKDF2 */
+
+#ifdef HAVE_PKCS12
 
 /* helper for PKCS12_PBKDF(), does hash operation */
 static int DoPKCS12Hash(int hashType, byte* buffer, word32 totalLen,
@@ -502,6 +511,8 @@ int wc_PKCS12_PBKDF_ex(byte* output, const byte* passwd, int passLen,
     return ret;
 }
 
+#endif /* HAVE_PKCS12 */
+
 #ifdef HAVE_SCRYPT
 /* Rotate the 32-bit value a by b bits to the left.
  *
@@ -737,9 +748,6 @@ end:
 
     return ret;
 }
-#endif
-
-#undef WC_MAX_DIGEST_SIZE
+#endif /* HAVE_SCRYPT */
 
 #endif /* NO_PWDBASED */
-

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -570,6 +570,7 @@ int wc_FreeRsaKey(RsaKey* key)
 }
 
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
+#if defined(WOLFSSL_KEY_GEN) && !defined(WOLFSSL_NO_RSA_KEY_CHECK)
 /* Check the pair-wise consistency of the RSA key.
  * From NIST SP 800-56B, section 6.4.1.1.
  * Verify that k = (k^e)^d, for some k: 1 < k < n-1. */
@@ -661,6 +662,7 @@ int wc_CheckRsaKey(RsaKey* key)
 
     return ret;
 }
+#endif
 #endif
 
 
@@ -3765,9 +3767,11 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
     mp_clear(&p);
     mp_clear(&q);
 
+#if defined(WOLFSSL_KEY_GEN) && !defined(WOLFSSL_NO_RSA_KEY_CHECK)
     /* Perform the pair-wise consistency test on the new key. */
     if (err == 0)
         err = wc_CheckRsaKey(key);
+#endif
 
     if (err != 0) {
         wc_FreeRsaKey(key);

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1856,6 +1856,7 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
 
 #ifdef WOLFSSL_SP_MATH
     (void)rng;
+    WOLFSSL_MSG("SP Key Size Error");
     return WC_KEY_SIZE_E;
 #else
     (void)rng;

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -365,6 +365,7 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
 
 #ifndef NO_PWDBASED
 
+#if defined(HAVE_PKCS8) || defined(HAVE_PKCS12)
 /* Decrypt/Encrypt input in place from parameters based on id
  *
  * returns a negative value on fail case
@@ -617,4 +618,5 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
     return ret;
 }
 
+#endif /* HAVE_PKCS8 || HAVE_PKCS12 */
 #endif /* !NO_PWDBASED */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -503,6 +503,10 @@ int wolfcrypt_test(void* args)
 {
     int ret;
 
+    printf("------------------------------------------------------------------------------\n");
+    printf(" wolfSSL version %s\n", LIBWOLFSSL_VERSION_STRING);
+    printf("------------------------------------------------------------------------------\n");
+
     if (args)
         ((func_args*)args)->return_code = -1; /* error state */
 

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -826,7 +826,9 @@ struct DecodedCert {
 #endif /* defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT) */
 
     Signer* ca;
+#ifndef NO_CERTS
     SignatureCtx sigCtx;
+#endif
 
     /* Option Bits */
     byte subjectCNStored : 1;      /* have we saved a copy we own */

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -320,7 +320,7 @@ WOLFSSL_API int wc_RsaDirect(byte* in, word32 inLen, byte* out, word32* outSz,
                    RsaKey* key, int type, WC_RNG* rng);
 #endif
 
-#endif /* HAVE_FIPS*/
+#endif /* HAVE_FIPS */
 
 WOLFSSL_API int  wc_RsaFlattenPublicKey(RsaKey*, byte*, word32*, byte*,
                                                                        word32*);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1837,6 +1837,27 @@ extern void uITRON4_free(void *p) ;
     #endif
 #endif
 
+#ifndef NO_PKCS12
+    #undef  HAVE_PKCS12
+    #define HAVE_PKCS12
+#endif
+
+#ifndef NO_PKCS8
+    #undef  HAVE_PKCS8
+    #define HAVE_PKCS8
+#endif
+
+#if !defined(NO_PBKDF1) || defined(WOLFSSL_ENCRYPTED_KEYS) || defined(HAVE_PKCS8) || defined(HAVE_PKCS12)
+    #undef  HAVE_PBKDF1
+    #define HAVE_PBKDF1
+#endif
+
+#if !defined(NO_PBKDF2) || defined(HAVE_PKCS7) || defined(HAVE_SCRYPT)
+    #undef  HAVE_PBKDF2
+    #define HAVE_PBKDF2
+#endif
+
+
 #if !defined(WOLFCRYPT_ONLY) && !defined(NO_OLD_TLS) && \
         (defined(NO_SHA) || defined(NO_MD5))
     #error old TLS requires MD5 and SHA

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -55,7 +55,12 @@
    #define TFM_NO_ASM
 #endif
 
-#ifndef NO_64BIT
+#ifdef NO_64BIT
+   #undef  NO_TFM_64BIT
+   #define NO_TFM_64BIT
+#endif
+
+#ifndef NO_TFM_64BIT
 /* autodetect x86-64 and make sure we are using 64-bit digits with x86-64 asm */
 #if defined(__x86_64__)
    #if defined(TFM_X86) || defined(TFM_SSE2) || defined(TFM_ARM)
@@ -79,7 +84,7 @@
     #undef FP_64BIT
     #undef TFM_X86_64
 #endif
-#endif /* NO_64BIT */
+#endif /* NO_TFM_64BIT */
 
 /* try to detect x86-32 */
 #if defined(__i386__) && !defined(TFM_SSE2)
@@ -218,7 +223,7 @@
    typedef unsigned long      fp_word __attribute__ ((mode(TI)));
 #else
 
-   #ifndef NO_64BIT
+   #ifndef NO_TFM_64BIT
       #if defined(_MSC_VER) || defined(__BORLANDC__)
          typedef unsigned __int64   ulong64;
       #else


### PR DESCRIPTION
* Fix for building with `USE_STSAFE_VERBOSE` to avoid printf use.
* Fix to include errno.h in tls_bench.c
* Add useful log message in RSA when SP math key size is invalid.
* Added warning message if user IO read callback returns negative that is not supported.
* Improvements for disabled sections in pwdbased.c, asn.c, rsa.c, pkcs12.c and wc_encrypt.c.
* Adds `--enable-pkcs12`, `HAVE_PKCS12` / `NO_PKCS12`, `HAVE_PKCS8` / `NO_PKCS8` and `HAVE_PBKDF1` / `NO_PBKDF1`.
* Added `NO_TFM_64BIT` option to disable 64-bit for TFM only (also enabled with `NO_64BIT`. This allows other areas like SHA512/ChaCha20 to still have the 64-bit type, but not use it for TFM.
* Added PBKDF2 benchmark.
* Benchmark improvements to capture results in static buffer to help benchmarking on systems without printf support. Adds "-print" option to benchmark tool to print summary at end.
* Added wolfCrypt test version header.