### PR TITLE
Honor the status from peer and do not do internal OCSP lookup regardless

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -10360,10 +10360,6 @@ int TLSX_Parse(WOLFSSL* ssl, byte* input, word16 length, byte msgType,
             case TLSX_STATUS_REQUEST:
                 WOLFSSL_MSG("Certificate Status Request extension received");
 
-#ifdef WOLFSSL_TLS13
-                if (IsAtLeastTLSv1_3(ssl->version))
-                    break;
-#endif
                 ret = CSR_PARSE(ssl, input + offset, size, isRequest);
                 break;
 


### PR DESCRIPTION
Sean,

Please clarify if this is the intended case for TLS 1.3 to always do an internal OCSP lookup regardless of what the status is from the peer.

Cheers,

KH