### PR TITLE
RSA-NULL-MD5 cipher suite

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2702,6 +2702,13 @@ void InitSuites(Suites* suites, ProtocolVersion pv, int keySz, word16 haveRSA,
     }
 #endif
 
+#ifdef BUILD_TLS_RSA_WITH_NULL_MD5
+    if (tls && haveRSA) {
+        suites->suites[idx++] = CIPHER_BYTE;
+        suites->suites[idx++] = TLS_RSA_WITH_NULL_MD5;
+    }
+#endif
+
 #ifdef BUILD_TLS_RSA_WITH_NULL_SHA
     if (tls && haveRSA) {
         suites->suites[idx++] = CIPHER_BYTE;
@@ -8096,6 +8103,7 @@ static int BuildFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
                 return 1;
             break;
 
+        case TLS_RSA_WITH_NULL_MD5 :
         case TLS_RSA_WITH_NULL_SHA :
         case TLS_RSA_WITH_NULL_SHA256 :
             if (requirement == REQUIRES_RSA)
@@ -16320,6 +16328,10 @@ static const CipherSuiteInfo cipher_names[] =
 
 #ifdef BUILD_TLS_RSA_WITH_AES_256_CBC_SHA
     SUITE_INFO("AES256-SHA","TLS_RSA_WITH_AES_256_CBC_SHA",CIPHER_BYTE,TLS_RSA_WITH_AES_256_CBC_SHA),
+#endif
+
+#ifdef BUILD_TLS_RSA_WITH_NULL_MD5
+    SUITE_INFO("NULL-MD5","TLS_RSA_WITH_NULL_MD5",CIPHER_BYTE,TLS_RSA_WITH_NULL_MD5),
 #endif
 
 #ifdef BUILD_TLS_RSA_WITH_NULL_SHA

--- a/src/keys.c
+++ b/src/keys.c
@@ -1294,6 +1294,23 @@ int SetCipherSpecs(WOLFSSL* ssl)
         break;
 #endif
 
+#ifdef BUILD_TLS_RSA_WITH_NULL_MD5
+    case TLS_RSA_WITH_NULL_MD5 :
+        ssl->specs.bulk_cipher_algorithm = wolfssl_cipher_null;
+        ssl->specs.cipher_type           = stream;
+        ssl->specs.mac_algorithm         = md5_mac;
+        ssl->specs.kea                   = rsa_kea;
+        ssl->specs.sig_algo              = rsa_sa_algo;
+        ssl->specs.hash_size             = WC_MD5_DIGEST_SIZE;
+        ssl->specs.pad_size              = PAD_MD5;
+        ssl->specs.static_ecdh           = 0;
+        ssl->specs.key_size              = 0;
+        ssl->specs.block_size            = 0;
+        ssl->specs.iv_size               = 0;
+
+        break;
+#endif
+
 #ifdef BUILD_TLS_RSA_WITH_NULL_SHA
     case TLS_RSA_WITH_NULL_SHA :
         ssl->specs.bulk_cipher_algorithm = wolfssl_cipher_null;

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -1397,6 +1397,30 @@
 -v 3
 -l PSK-NULL-SHA256
 
+# server TLSv1.0 RSA-NULL-MD5
+-v 1
+-l NULL-MD5
+
+# client TLSv1.0 RSA-NULL-MD5
+-v 1
+-l NULL-MD5
+
+# server TLSv1.1 RSA-NULL-MD5
+-v 2
+-l NULL-MD5
+
+# client TLSv1.1 RSA-NULL-MD5
+-v 2
+-l NULL-MD5
+
+# server TLSv1.2 RSA-NULL-MD5
+-v 3
+-l NULL-MD5
+
+# client TLSv1.2 RSA-NULL-MD5
+-v 3
+-l NULL-MD5
+
 # server TLSv1.0 RSA-NULL-SHA
 -v 1
 -l NULL-SHA

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -422,6 +422,9 @@
     #if !defined(NO_TLS) && defined(HAVE_NULL_CIPHER)
         #if !defined(NO_RSA)
             #if defined(WOLFSSL_STATIC_RSA)
+                #ifndef NO_MD5
+                    #define BUILD_TLS_RSA_WITH_NULL_MD5
+                #endif
                 #if !defined(NO_SHA)
                     #define BUILD_TLS_RSA_WITH_NULL_SHA
                 #endif
@@ -921,6 +924,7 @@ enum {
     TLS_DH_anon_WITH_AES_128_CBC_SHA  = 0x34,
     TLS_RSA_WITH_AES_256_CBC_SHA      = 0x35,
     TLS_RSA_WITH_AES_128_CBC_SHA      = 0x2F,
+    TLS_RSA_WITH_NULL_MD5             = 0x01,
     TLS_RSA_WITH_NULL_SHA             = 0x02,
     TLS_PSK_WITH_AES_256_CBC_SHA      = 0x8d,
     TLS_PSK_WITH_AES_128_CBC_SHA256   = 0xae,


### PR DESCRIPTION
Add the cipher suite TLS_RSA_WITH_NULL_MD5 for use with the sniffer.