### PR TITLE
Get IANA Name From Cipher Suite

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16553,6 +16553,12 @@ const char* wolfSSL_get_cipher_name_from_suite(const byte cipherSuite0,
     return GetCipherNameInternal(cipherSuite0, cipherSuite);
 }
 
+const char* wolfSSL_get_cipher_name_iana_from_suite(const byte cipherSuite0,
+        const byte cipherSuite)
+{
+    return GetCipherNameIana(cipherSuite0, cipherSuite);
+}
+
 
 #if defined(HAVE_ECC) || !defined(NO_DH)
 #ifdef HAVE_FFDHE

--- a/tests/api.c
+++ b/tests/api.c
@@ -2446,11 +2446,16 @@ static void test_client_nofail(void* args, void *cb)
 
     /* IANA Cipher Suites Names */
     /* Unless WOLFSSL_CIPHER_INTERNALNAME or NO_ERROR_STRINGS,
-        then its the internal cipher suite name */
+        then it's the internal cipher suite name */
     cipher = wolfSSL_get_current_cipher(ssl);
     cipherName1 = wolfSSL_CIPHER_get_name(cipher);
     cipherName2 = wolfSSL_get_cipher(ssl);
     AssertStrEQ(cipherName1, cipherName2);
+#if !defined(WOLFSSL_CIPHER_INTERNALNAME) && !defined(NO_ERROR_STRINGS)
+    cipherName1 = wolfSSL_get_cipher_name_iana_from_suite(
+            (cipherSuite >> 8), cipherSuite & 0xFF);
+    AssertStrEQ(cipherName1, cipherName2);
+#endif
 
     if (cb != NULL)
         ((cbType)cb)(ctx, ssl);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -590,6 +590,8 @@ WOLFSSL_API int wolfSSL_get_ciphers_iana(char*, int);
 WOLFSSL_API const char* wolfSSL_get_cipher_name(WOLFSSL* ssl);
 WOLFSSL_API const char* wolfSSL_get_cipher_name_from_suite(const unsigned char,
     const unsigned char);
+WOLFSSL_API const char* wolfSSL_get_cipher_name_iana_from_suite(
+    const unsigned char, const unsigned char);
 WOLFSSL_API const char* wolfSSL_get_shared_ciphers(WOLFSSL* ssl, char* buf,
     int len);
 WOLFSSL_API const char* wolfSSL_get_curve_name(WOLFSSL* ssl);


### PR DESCRIPTION
Add function wolfSSL_get_cipher_name_iana_from_suite() a wrapper around internal API GetCipherNameIana().