### PR TITLE
fsanitize report fixes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10102,6 +10102,15 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             ssl->peerRsaKeyPresent = 1;
                     #ifdef HAVE_PK_CALLBACKS
                         #ifndef NO_RSA
+                            #ifdef HAVE_SECURE_RENEGOTIATION
+                            if (ssl->buffers.peerRsaKey.buffer) {
+                                XFREE(ssl->buffers.peerRsaKey.buffer,
+                                        ssl->heap, DYNAMIC_TYPE_RSA);
+                                ssl->buffers.peerRsaKey.buffer = NULL;
+                            }
+                            #endif
+
+
                             ssl->buffers.peerRsaKey.buffer =
                                    (byte*)XMALLOC(args->dCert->pubKeySize,
                                                 ssl->heap, DYNAMIC_TYPE_RSA);

--- a/src/internal.c
+++ b/src/internal.c
@@ -5652,6 +5652,10 @@ void FreeHandshakeResources(WOLFSSL* ssl)
 #ifdef HAVE_SECURE_RENEGOTIATION
     if (ssl->secure_renegotiation && ssl->secure_renegotiation->enabled) {
         WOLFSSL_MSG("Secure Renegotiation needs to retain handshake resources");
+    #ifdef KEEP_PEER_CERT
+        /* free peer cert in preparation for new handshake */
+        FreeX509(&ssl->peerCert);
+    #endif
         return;
     }
 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -9922,6 +9922,10 @@ int wolfSSL_Cleanup(void)
     if (wc_FreeMutex(&count_mutex) != 0)
         ret = BAD_MUTEX_E;
 
+#ifdef OPENSSL_EXTRA
+    wolfSSL_RAND_Cleanup();
+#endif
+
     if (wolfCrypt_Cleanup() != 0) {
         WOLFSSL_MSG("Error with wolfCrypt_Cleanup call");
         ret = WC_CLEANUP_E;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13061,6 +13061,7 @@ int dh_test(void)
         /* Test Check Key */
         ret = wc_DhSetCheckKey(&key, dh_p, sizeof(dh_p), dh_g, sizeof(dh_g),
             NULL, 0, 0, &rng);
+        keyInit = 1; /* DhSetCheckKey also initializes the key, free it */
     }
 #endif
 


### PR DESCRIPTION
These are fixes for reports from building with fsanitize address and specific configure option that includes secure renegotiation and opensslextra.