### PR TITLE
fix build failure when enabling MYSQL_COMPATIBLE

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -5789,7 +5789,11 @@ static int TLSX_SupportedVersions_Parse(WOLFSSL* ssl, byte* input,
             set = 1;
         }
         if (!set) {
+ #ifdef WOLFSSL_MYSQL_COMPATIBLE
+            SendAlert(ssl, alert_fatal, wc_protocol_version);
+ #else
             SendAlert(ssl, alert_fatal, protocol_version);
+ #endif
             return VERSION_ERROR;
         }
     }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3952,7 +3952,11 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     i += OPAQUE16_LEN;
     if (pv.major < SSLv3_MAJOR) {
         WOLFSSL_MSG("Legacy version field contains unsupported value");
+ #ifdef WOLFSSL_MYSQL_COMPATIBLE
+        SendAlert(ssl, alert_fatal, wc_protocol_version);
+ #else
         SendAlert(ssl, alert_fatal, protocol_version);
+ #endif
         return INVALID_PARAMETER;
     }
     /* Legacy protocol version cannot negotiate TLS 1.3 or higher. */


### PR DESCRIPTION
Fix build failure w/ enabled MYSQL_COMPATIBLE.

This is found while checking build w/ a customer configuration.
