### PR TITLE
Sniffer Watch Cert Chain

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -2314,6 +2314,8 @@ static int ProcessCertificate(const byte* input, int* sslBytes,
         SnifferSession* session, char* error)
 {
     Sha256 sha;
+    const byte* certChain;
+    word32 certChainSz;
     word32 certSz;
     int ret;
     byte digest[SHA256_DIGEST_SIZE];
@@ -2330,7 +2332,9 @@ static int ProcessCertificate(const byte* input, int* sslBytes,
         return -1;
     }
 
+    ato24(input, &certChainSz);
     input += CERT_HEADER_SZ;
+    certChain = input;
     ato24(input, &certSz);
     input += OPAQUE24_LEN;
 
@@ -2344,8 +2348,8 @@ static int ProcessCertificate(const byte* input, int* sslBytes,
         return -1;
     }
 
-    ret = WatchCb((void*)session, digest, sizeof(digest), input, certSz,
-            WatchCbCtx, error);
+    ret = WatchCb((void*)session, digest, sizeof(digest),
+            certChain, certChainSz, WatchCbCtx, error);
     if (ret != 0) {
 #ifdef WOLFSSL_SNIFFER_STATS
         INC_STAT(SnifferStats.sslKeysUnmatched);

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -168,8 +168,10 @@ SSL_SNIFFER_API int ssl_ReadResetStatistics(SSLStats* stats);
 
 
 typedef int (*SSLWatchCb)(void* vSniffer,
-                        const unsigned char* certHash, unsigned int certHashSz,
-                        const unsigned char* cert, unsigned int certSz,
+                        const unsigned char* certHash,
+                        unsigned int certHashSz,
+                        const unsigned char* certChain,
+                        unsigned int certChainSz,
                         void* ctx, char* error);
 
 WOLFSSL_API


### PR DESCRIPTION
Modifed the sniffer watch callback so it provides a SHA-256 hash of the peer certificate, as before, and the entire certificate chain sent by the server in the Certificate handshake message. The chain is taken directly from the message payload, unprocessed. It'll be a list of pairs of 24-bit certificate length and a DER encoded certificate, all in network byte order.