### PR TITLE
Sniffer Watch Cert Chain Part 2

### DIFF
--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -189,13 +189,13 @@ const byte eccHash[] = {
 
 static int myWatchCb(void* vSniffer,
         const unsigned char* certHash, unsigned int certHashSz,
-        const unsigned char* cert, unsigned int certSz,
+        const unsigned char* certChain, unsigned int certChainSz,
         void* ctx, char* error)
 {
     const char* certName = NULL;
 
-    (void)cert;
-    (void)certSz;
+    (void)certChain;
+    (void)certChainSz;
     (void)ctx;
 
     if (certHashSz == sizeof(rsaHash) &&

--- a/wolfssl/sniffer_error.h
+++ b/wolfssl/sniffer_error.h
@@ -124,6 +124,7 @@
 #define WATCH_CB_MISSING_STR 86
 #define WATCH_HASH_STR 87
 #define WATCH_FAIL_STR 88
+#define BAD_CERT_MSG_STR 89
 /* !!!! also add to msgTable in sniffer.c and .rc file !!!! */
 
 

--- a/wolfssl/sniffer_error.rc
+++ b/wolfssl/sniffer_error.rc
@@ -106,5 +106,6 @@ STRINGTABLE
     86, "Watch callback not set"
     87, "Watch hash failed"
     88, "Watch callback failed"
+    89, "Bad Certificate Message"
 }
 


### PR DESCRIPTION
1. Check the sizes picked up out of the message against the expected size of the record when looking at the certificate messages.
2. Renamed the cert and certSz in the watch callback with it being a certChain.