### PR TITLE
Fixes for FIPS

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -11341,7 +11341,7 @@ static int test_wc_RsaPublicKeyDecodeRaw (void)
     /* In FIPS builds, wc_MakeRsaKey() will return an error if it cannot find
      * a probable prime in 5*(modLen/2) attempts. In non-FIPS builds, it keeps
      * trying until it gets a probable prime. */
-    #ifdef WOLFSSL_FIPS
+    #ifdef HAVE_FIPS
         static int MakeRsaKeyRetry(RsaKey* key, int size, long e, WC_RNG* rng)
         {
             int ret;
@@ -20664,7 +20664,7 @@ static void test_wolfSSL_PKCS8_Compat(void)
 
 static void test_wolfSSL_PKCS8_d2i(void)
 {
-#ifndef WOLFSSL_FIPS
+#ifndef HAVE_FIPS
     /* This test ends up using HMAC as a part of PBKDF2, and HMAC
      * requires a 12 byte password in FIPS mode. This test ends up
      * trying to use an 8 byte password. */
@@ -20821,7 +20821,7 @@ static void test_wolfSSL_PKCS8_d2i(void)
 
     printf(resultFmt, passed);
 #endif
-#endif /* WOLFSSL_FIPS */
+#endif /* HAVE_FIPS */
 }
 
 static void test_wolfSSL_ERR_put_error(void)

--- a/tests/api.c
+++ b/tests/api.c
@@ -20664,6 +20664,10 @@ static void test_wolfSSL_PKCS8_Compat(void)
 
 static void test_wolfSSL_PKCS8_d2i(void)
 {
+#ifndef WOLFSSL_FIPS
+    /* This test ends up using HMAC as a part of PBKDF2, and HMAC
+     * requires a 12 byte password in FIPS mode. This test ends up
+     * trying to use an 8 byte password. */
 #ifdef OPENSSL_ALL
     WOLFSSL_EVP_PKEY* pkey = NULL;
 #ifndef NO_FILESYSTEM
@@ -20817,6 +20821,7 @@ static void test_wolfSSL_PKCS8_d2i(void)
 
     printf(resultFmt, passed);
 #endif
+#endif /* WOLFSSL_FIPS */
 }
 
 static void test_wolfSSL_ERR_put_error(void)

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -1628,7 +1628,8 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
         #endif
 
         /* if input and output same will overwrite input iv */
-        XMEMCPY(aes->tmp, inBlock, AES_BLOCK_SIZE);
+        if ((const byte*)aes->tmp != inBlock)
+            XMEMCPY(aes->tmp, inBlock, AES_BLOCK_SIZE);
         AES_ECB_decrypt(inBlock, outBlock, AES_BLOCK_SIZE, (byte*)aes->key,
                         aes->rounds);
         return;

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3654,7 +3654,7 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
             if (err == MP_OKAY)
                 err = _CheckProbablePrime(&p, NULL, &tmp3, size, &isPrime, rng);
 
-#ifdef WOLFSSL_FIPS
+#ifdef HAVE_FIPS
             i++;
 #else
             /* Keep the old retry behavior in non-FIPS build. */
@@ -3689,7 +3689,7 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
             if (err == MP_OKAY)
                 err = _CheckProbablePrime(&p, &q, &tmp3, size, &isPrime, rng);
 
-#ifdef WOLFSSL_FIPS
+#ifdef HAVE_FIPS
             i++;
 #else
             /* Keep the old retry behavior in non-FIPS build. */


### PR DESCRIPTION
1. When using the OpenSSL ALL build with FIPSv2 and IntelASM enabled, a test case fails because HMAC in FIPSs mode rejects keys shorter than 12 bytes.
2. Incidental additional check by GCC-8 on macOS found a potential call to memcpy of data over itself. Added a check to see if the pointers are the same.
3. In a few places the label WOLFSSL_FIPS was being checked for, change to the correct HAVE_FIPS.