### PR TITLE
RSA Key Generation Speedup

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3749,8 +3749,10 @@ int mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng)
         /* do trial division */
         for (r = 0; r < FP_PRIME_SIZE; r++) {
             if (fp_mod_d(a, primes[r], &d) == MP_OKAY) {
-                if (d == 0)
-                    ret = FP_NO;
+                if (d == 0) {
+                    *result = FP_NO;
+                    return FP_OKAY;
+                }
             }
             else
                 return FP_VAL;


### PR DESCRIPTION
When doing the test divides on the first few primes, short circuit out of the loop if the prospective possible prime divides evenly.