### PR TITLE
Fix for STM32 AES GCM crypto hardware with less than block size

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -5323,7 +5323,7 @@ static int wc_AesGcmEncrypt_STM32(Aes* aes, byte* out, const byte* in, word32 sz
     word32 keyCopy[AES_256_KEY_SIZE/sizeof(word32)];
 #endif
     word32 keySize;
-    int status = 0;
+    int status = HAL_OK;
     word32 blocks = sz / AES_BLOCK_SIZE;
     word32 partial = sz % AES_BLOCK_SIZE;
     byte tag[AES_BLOCK_SIZE];
@@ -5390,8 +5390,10 @@ static int wc_AesGcmEncrypt_STM32(Aes* aes, byte* out, const byte* in, word32 sz
     if (status == HAL_OK) {
         /* GCM payload phase - blocks */
         hcryp.Init.GCMCMACPhase  = CRYP_PAYLOAD_PHASE;
-        status = HAL_CRYPEx_AES_Auth(&hcryp, in, (blocks * AES_BLOCK_SIZE), out,
-            STM32_HAL_TIMEOUT);
+        if (blocks) {
+            status = HAL_CRYPEx_AES_Auth(&hcryp, (byte*)in,
+                (blocks * AES_BLOCK_SIZE), out, STM32_HAL_TIMEOUT);
+        }
     }
     if (status == HAL_OK && partial != 0) {
         /* GCM payload phase - partial remainder */
@@ -5408,9 +5410,11 @@ static int wc_AesGcmEncrypt_STM32(Aes* aes, byte* out, const byte* in, word32 sz
     }
 #else
     HAL_CRYP_Init(&hcryp);
-    /* GCM payload phase - blocks */
-    status = HAL_CRYPEx_AESGCM_Encrypt(&hcryp, (byte*)in,
-        (blocks * AES_BLOCK_SIZE), out, STM32_HAL_TIMEOUT);
+    if (blocks) {
+        /* GCM payload phase - blocks */
+        status = HAL_CRYPEx_AESGCM_Encrypt(&hcryp, (byte*)in,
+            (blocks * AES_BLOCK_SIZE), out, STM32_HAL_TIMEOUT);
+    }
     if (status == HAL_OK && partial != 0) {
         /* GCM payload phase - partial remainder */
         XMEMSET(partialBlock, 0, sizeof(partialBlock));
@@ -5718,7 +5722,7 @@ static int wc_AesGcmDecrypt_STM32(Aes* aes, byte* out,
     word32 keyCopy[AES_256_KEY_SIZE/sizeof(word32)];
 #endif
     word32 keySize;
-    int status;
+    int status = HAL_OK;
     word32 blocks = sz / AES_BLOCK_SIZE;
     word32 partial = sz % AES_BLOCK_SIZE;
     byte tag[AES_BLOCK_SIZE];
@@ -5785,8 +5789,10 @@ static int wc_AesGcmDecrypt_STM32(Aes* aes, byte* out,
     if (status == HAL_OK) {
         /* GCM payload phase - blocks */
         hcryp.Init.GCMCMACPhase  = CRYP_PAYLOAD_PHASE;
-        status = HAL_CRYPEx_AES_Auth(&hcryp, in, (blocks * AES_BLOCK_SIZE), out,
-            STM32_HAL_TIMEOUT);
+        if (blocks) {
+            status = HAL_CRYPEx_AES_Auth(&hcryp, (byte*)in,
+                (blocks * AES_BLOCK_SIZE), out, STM32_HAL_TIMEOUT);
+        }
     }
     if (status == HAL_OK && partial != 0) {
         /* GCM payload phase - partial remainder */
@@ -5803,9 +5809,11 @@ static int wc_AesGcmDecrypt_STM32(Aes* aes, byte* out,
     }
 #else
     HAL_CRYP_Init(&hcryp);
-    /* GCM payload phase - blocks */
-    status = HAL_CRYPEx_AESGCM_Decrypt(&hcryp, (byte*)in,
-        (blocks * AES_BLOCK_SIZE), out, STM32_HAL_TIMEOUT);
+    if (blocks) {
+        /* GCM payload phase - blocks */
+        status = HAL_CRYPEx_AESGCM_Decrypt(&hcryp, (byte*)in,
+            (blocks * AES_BLOCK_SIZE), out, STM32_HAL_TIMEOUT);
+    }
     if (status == HAL_OK && partial != 0) {
         /* GCM payload phase - partial remainder */
         XMEMSET(partialBlock, 0, sizeof(partialBlock));

--- a/wolfcrypt/src/fe_x25519_asm.S
+++ b/wolfcrypt/src/fe_x25519_asm.S
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#if defined(USE_INTEL_SPEEDUP) && (defined(HAVE_ED25519) || defined(HAVE_CURVE25519))
-
 #ifndef HAVE_INTEL_AVX1
 #define HAVE_INTEL_AVX1
 #endif /* HAVE_INTEL_AVX1 */
@@ -16177,5 +16175,3 @@ _fe_ge_sub_avx2:
 .size	fe_ge_sub_avx2,.-fe_ge_sub_avx2
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
-
-#endif /* USE_INTEL_SPEEDUP && (HAVE_ED25519 || HAVE_CURVE25519) */

--- a/wolfcrypt/src/fe_x25519_asm.S
+++ b/wolfcrypt/src/fe_x25519_asm.S
@@ -19,6 +19,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#if defined(USE_INTEL_SPEEDUP) && (defined(HAVE_ED25519) || defined(HAVE_CURVE25519))
+
 #ifndef HAVE_INTEL_AVX1
 #define HAVE_INTEL_AVX1
 #endif /* HAVE_INTEL_AVX1 */
@@ -16175,3 +16177,5 @@ _fe_ge_sub_avx2:
 .size	fe_ge_sub_avx2,.-fe_ge_sub_avx2
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+#endif /* USE_INTEL_SPEEDUP && (HAVE_ED25519 || HAVE_CURVE25519) */

--- a/wolfcrypt/src/port/arm/armv8-32-curve25519.S
+++ b/wolfcrypt/src/port/arm/armv8-32-curve25519.S
@@ -23,6 +23,8 @@
  *   cd ../scripts
  *   ruby ./x25519/x25519.rb arm32 ../wolfssl/wolfcrypt/src/port/arm/armv8-32-curve25519.S
  */
+
+#ifdef WOLFSSL_ARMASM
 #ifndef __aarch64__
 	.text
 	.align	2
@@ -6007,3 +6009,4 @@ fe_ge_sub:
 	pop	{r4, r5, r6, r7, r8, r9, r10, r11, pc}
 	.size	fe_ge_sub,.-fe_ge_sub
 #endif /* !__aarch64__ */
+#endif /* WOLFSSL_ARMASM */

--- a/wolfcrypt/src/port/arm/armv8-32-curve25519.c
+++ b/wolfcrypt/src/port/arm/armv8-32-curve25519.c
@@ -23,13 +23,17 @@
  *   cd ../scripts
  *   ruby ./x25519/x25519.rb arm32 ../wolfssl/wolfcrypt/src/port/arm/armv8-32-curve25519.c
  */
+
 #ifndef __aarch64__
+
 #include <stdint.h>
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_ARMASM
 #include <wolfssl/wolfcrypt/fe_operations.h>
 #include <stdint.h>
 
@@ -5573,4 +5577,5 @@ void fe_ge_sub(fe rx, fe ry, fe rz, fe rt, const fe px, const fe py, const fe pz
     (void)qyminusx;
 }
 
+#endif /* WOLFSSL_ARMASM */
 #endif /* !__aarch64__ */

--- a/wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
@@ -23,6 +23,8 @@
  *   cd ../scripts
  *   ruby ./sha2/sha512.rb arm32 ../wolfssl/wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
  */
+
+#ifdef WOLFSSL_ARMASM
 #ifndef __aarch64__
 #ifdef WOLFSSL_ARMASM_NO_NEON
 	.text
@@ -5330,3 +5332,4 @@ L_sha512_len_neon_start:
 	.size	Transform_Sha512_Len,.-Transform_Sha512_Len
 #endif /* !WOLFSSL_ARMASM_NO_NEON */
 #endif /* !__aarch64__ */
+#endif /* WOLFSSL_ARMASM */

--- a/wolfcrypt/src/port/arm/armv8-32-sha512-asm.c
+++ b/wolfcrypt/src/port/arm/armv8-32-sha512-asm.c
@@ -23,8 +23,17 @@
  *   cd ../scripts
  *   ruby ./sha2/sha512.rb arm32 ../wolfssl/wolfcrypt/src/port/arm/armv8-32-sha512-asm.c
  */
+
 #ifndef __aarch64__
 #include <stdint.h>
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_ARMASM
 #include <wolfssl/wolfcrypt/sha512.h>
 
 #ifdef WOLFSSL_ARMASM_NO_NEON
@@ -4770,4 +4779,5 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
 }
 
 #endif /* !WOLFSSL_ARMASM_NO_NEON */
+#endif /* WOLFSSL_ARMASM */
 #endif /* !__aarch64__ */

--- a/wolfcrypt/src/port/arm/armv8-aes.c
+++ b/wolfcrypt/src/port/arm/armv8-aes.c
@@ -4650,5 +4650,4 @@ int wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len)
         }
     #endif /* HAVE_AES_DECRYPT */
 #endif /* WOLFSSL_AES_DIRECT */
-#endif /* NO_AES */
-
+#endif /* !NO_AES && WOLFSSL_ARMASM */

--- a/wolfcrypt/src/port/arm/armv8-chacha.c
+++ b/wolfcrypt/src/port/arm/armv8-chacha.c
@@ -24,14 +24,13 @@
  *  https://cryptojedi.org/papers/neoncrypto-20120320.pdf
  */
 
-#ifdef WOLFSSL_ARMASM
-
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
 
+#ifdef WOLFSSL_ARMASM
 #ifdef HAVE_CHACHA
 
 #include <wolfssl/wolfcrypt/chacha.h>
@@ -2854,5 +2853,4 @@ int wc_Chacha_Process(ChaCha* ctx, byte* output, const byte* input,
 }
 
 #endif /* HAVE_CHACHA*/
-
 #endif /* WOLFSSL_ARMASM */

--- a/wolfcrypt/src/port/arm/armv8-curve25519.S
+++ b/wolfcrypt/src/port/arm/armv8-curve25519.S
@@ -23,6 +23,8 @@
  *   cd ../scripts
  *   ruby ./x25519/x25519.rb arm64 ../wolfssl/wolfcrypt/src/port/arm/armv8-curve25519.S
  */
+
+#ifdef WOLFSSL_ARMASM
 #ifdef __aarch64__
 	.text
 	.align	2
@@ -6693,3 +6695,4 @@ fe_ge_sub:
 	ret
 	.size	fe_ge_sub,.-fe_ge_sub
 #endif /* __aarch64__ */
+#endif /* WOLFSSL_ARMASM */

--- a/wolfcrypt/src/port/arm/armv8-curve25519.c
+++ b/wolfcrypt/src/port/arm/armv8-curve25519.c
@@ -24,12 +24,15 @@
  *   ruby ./x25519/x25519.rb arm64 ../wolfssl/wolfcrypt/src/port/arm/armv8-curve25519.c
  */
 #ifdef __aarch64__
+
 #include <stdint.h>
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_ARMASM
 #include <wolfssl/wolfcrypt/fe_operations.h>
 #include <stdint.h>
 
@@ -6715,4 +6718,5 @@ void fe_ge_sub(fe rx, fe ry, fe rz, fe rt, const fe px, const fe py, const fe pz
     (void)qyminusx;
 }
 
+#endif /* WOLFSSL_ARMASM */
 #endif /* __aarch64__ */

--- a/wolfcrypt/src/port/arm/armv8-poly1305.c
+++ b/wolfcrypt/src/port/arm/armv8-poly1305.c
@@ -25,7 +25,7 @@
  */
 
 
-#if defined(WOLFSSL_ARMASM) && defined(__aarch64__)
+#ifdef __aarch64__
 
 #ifdef HAVE_CONFIG_H
     #include <config.h>
@@ -33,6 +33,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
+#ifdef WOLFSSL_ARMASM
 #ifdef HAVE_POLY1305
 #include <wolfssl/wolfcrypt/poly1305.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
@@ -1166,4 +1167,4 @@ int wc_Poly1305Final(Poly1305* ctx, byte* mac)
 
 #endif /* HAVE_POLY1305 */
 #endif /* WOLFSSL_ARMASM */
-
+#endif /* __aarch64__ */

--- a/wolfcrypt/src/port/arm/armv8-sha512-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-sha512-asm.S
@@ -23,6 +23,8 @@
  *   cd ../scripts
  *   ruby ./sha2/sha512.rb arm64 ../wolfssl/wolfcrypt/src/port/arm/armv8-sha512-asm.S
  */
+
+#ifdef WOLFSSL_ARMASM
 #ifdef __aarch64__
 	.text
 	.section	.rodata
@@ -1044,3 +1046,4 @@ L_sha512_len_neon_start:
 	ret
 	.size	Transform_Sha512_Len,.-Transform_Sha512_Len
 #endif /* __aarch64__ */
+#endif /* WOLFSSL_ARMASM */

--- a/wolfcrypt/src/port/arm/armv8-sha512-asm.c
+++ b/wolfcrypt/src/port/arm/armv8-sha512-asm.c
@@ -24,7 +24,16 @@
  *   ruby ./sha2/sha512.rb arm64 ../wolfssl/wolfcrypt/src/port/arm/armv8-sha512-asm.c
  */
 #ifdef __aarch64__
+
 #include <stdint.h>
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_ARMASM
+
 #include <wolfssl/wolfcrypt/sha512.h>
 
 static const uint64_t L_SHA512_transform_neon_len_k[] = {
@@ -1029,4 +1038,5 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
     );
 }
 
+#endif /* WOLFSSL_ARMASM */
 #endif /* __aarch64__ */

--- a/wolfcrypt/src/port/arm/armv8-sha512.c
+++ b/wolfcrypt/src/port/arm/armv8-sha512.c
@@ -19,13 +19,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
 
+#ifdef WOLFSSL_ARMASM
 #if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 
 #include <wolfssl/wolfcrypt/sha512.h>
@@ -706,3 +706,4 @@ int wc_Sha384GetFlags(wc_Sha384* sha384, word32* flags)
 #endif /* WOLFSSL_SHA384 */
 
 #endif /* WOLFSSL_SHA512 || WOLFSSL_SHA384 */
+#endif /* WOLFSSL_ARMASM */


### PR DESCRIPTION
* Fixes issue with STM32 (CubeMX HAL) AES GCM crypto hardware when encrypting/decrypting less than a block size (16) is used.
* Add macro checks around new .c/.S files to allow wildcard include of source files (such as in Eclipse).
ZD 5441