### PR TITLE
fix for initialize PKCS7 structure with signer

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -17450,7 +17450,7 @@ static void test_PKCS7_signed_enveloped(void)
 
     /* check verify fails */
     AssertNotNull(pkcs7 = wc_PKCS7_New(NULL, 0));
-    AssertIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, certSz), 0);
+    AssertIntEQ(wc_PKCS7_InitWithCert(pkcs7, NULL, 0), 0);
     AssertIntEQ(wc_PKCS7_VerifySignedData(pkcs7, sig, sigSz),
             PKCS7_SIGNEEDS_CHECK);
 
@@ -17473,6 +17473,12 @@ static void test_PKCS7_signed_enveloped(void)
         /* verify was success */
     }
 
+    wc_PKCS7_Free(pkcs7);
+
+    /* initializing the PKCS7 struct with the signing certificate should pass */
+    AssertNotNull(pkcs7 = wc_PKCS7_New(NULL, 0));
+    AssertIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, certSz), 0);
+    AssertIntEQ(wc_PKCS7_VerifySignedData(pkcs7, sig, sigSz), 0);
     wc_PKCS7_Free(pkcs7);
 
     /* create valid degenerate bundle */

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -946,6 +946,8 @@ int wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* derCert, word32 derCertSz)
 
         pkcs7->singleCert = derCert;
         pkcs7->singleCertSz = derCertSz;
+        pkcs7->cert[0] = derCert;
+        pkcs7->certSz[0] = derCertSz;
 
         /* create new Pkcs7Cert for recipient, freed during cleanup */
         cert = (Pkcs7Cert*)XMALLOC(sizeof(Pkcs7Cert), pkcs7->heap,


### PR DESCRIPTION
SCEP use case for a bundle sent without signer certificate but having the signer loaded into the PKCS7 structure on initialization.