### PR TITLE
ECC improvement to get curve param and example curve macro check fix

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -248,7 +248,7 @@ static void SetKeyShare(WOLFSSL* ssl, int onlyKeyShare, int useX25519)
     #endif
         {
     #ifdef HAVE_ECC
-        #if defined(HAVE_ECC256) || defined(HAVE_ALL_CURVES)
+        #if !defined(NO_ECC256) || defined(HAVE_ALL_CURVES)
             groups[count++] = WOLFSSL_ECC_SECP256R1;
             if (wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_SECP256R1)
                                                            != WOLFSSL_SUCCESS) {
@@ -2582,7 +2582,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             }
         #endif
         #ifdef HAVE_ECC
-            #if defined(HAVE_ECC256) || defined(HAVE_ALL_CURVES)
+            #if !defined(NO_ECC256) || defined(HAVE_ALL_CURVES)
             if (wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_SECP256R1)
                                                            != WOLFSSL_SUCCESS) {
                 err_sys("unable to use curve secp256r1");

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -200,7 +200,7 @@ static int TestEmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 
     if (dtlsCtx->failOnce) {
         word32 seq = 0;
-        
+
         if (PeekSeq(buf, &seq) && seq == dtlsCtx->blockSeq) {
             dtlsCtx->failOnce = 0;
             WOLFSSL_MSG("Forcing WANT_WRITE");
@@ -604,7 +604,7 @@ static const char* server_usage_msg[][49] = {
 #ifdef WOLFSSL_SEND_HRR_COOKIE
         "-J          Server sends Cookie Extension containing state\n", /* 45 */
 #endif
-#endif /* WOLFSSL_TLS13 */ 
+#endif /* WOLFSSL_TLS13 */
 #ifdef WOLFSSL_EARLY_DATA
         "-0          Early data read from client (0-RTT handshake)\n",  /* 46 */
 #endif
@@ -721,7 +721,7 @@ static const char* server_usage_msg[][49] = {
 #ifdef WOLFSSL_SEND_HRR_COOKIE
         "-J          サーバーの状態を含むTLS Cookie 拡張を送信する\n",  /* 45 */
 #endif
-#endif /* WOLFSSL_TLS13 */ 
+#endif /* WOLFSSL_TLS13 */
 #ifdef WOLFSSL_EARLY_DATA
         "-0          クライアントからの Early Data 読み取り"
                                       "（0-RTTハンドシェイク）\n",      /* 46 */
@@ -744,7 +744,7 @@ static void Usage(void)
     int msgId = 0;
     const char** msg = server_usage_msg[lng_index];
 
-    printf("%s%s%s", "server ", LIBWOLFSSL_VERSION_STRING, 
+    printf("%s%s%s", "server ", LIBWOLFSSL_VERSION_STRING,
            msg[msgId]);
     printf("%s", msg[++msgId]);                     /* ? */
     printf("%s %d\n", msg[++msgId], wolfSSLPort);   /* -p */
@@ -1948,7 +1948,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 else
                 {
         #ifdef HAVE_ECC
-            #if defined(HAVE_ECC256) || defined(HAVE_ALL_CURVES)
+            #if !defined(NO_ECC256) || defined(HAVE_ALL_CURVES)
                     int groups[1] = { WOLFSSL_ECC_SECP256R1 };
 
                     if (wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_SECP256R1)

--- a/tests/api.c
+++ b/tests/api.c
@@ -14307,6 +14307,28 @@ static int test_wc_ecc_size (void)
     return ret;
 } /* END test_wc_ecc_size */
 
+static void test_wc_ecc_params(void)
+{
+    /* FIPS module does not have `wc_ecc_get_curve_params`.
+        It was added after certifications */
+#if defined(HAVE_ECC) && !defined(HAVE_FIPS)
+    const ecc_set_type* ecc_set;
+#if !defined(NO_ECC256) && !defined(NO_ECC_SECP)
+    /* Test for SECP256R1 curve */
+    int curve_id = ECC_SECP256R1;
+    int curve_idx = wc_ecc_get_curve_idx(curve_id);
+    AssertIntNE(curve_idx, ECC_CURVE_INVALID);
+    ecc_set = wc_ecc_get_curve_params(curve_idx);
+    AssertNotNull(ecc_set);
+    AssertIntEQ(ecc_set->id, curve_id);
+#endif
+    /* Test case when SECP256R1 is not enabled */
+    /* Test that we get curve params for index 0 */
+    ecc_set = wc_ecc_get_curve_params(0);
+    AssertNotNull(ecc_set);
+#endif /* HAVE_ECC && !HAVE_FIPS */
+}
+
 /*
  * Testing wc_ecc_sign_hash() and wc_ecc_verify_hash()
  */
@@ -25235,6 +25257,7 @@ void ApiTest(void)
     AssertIntEQ(test_wc_ecc_init(), 0);
     AssertIntEQ(test_wc_ecc_check_key(), 0);
     AssertIntEQ(test_wc_ecc_size(), 0);
+    test_wc_ecc_params();
     AssertIntEQ(test_wc_ecc_signVerify_hash(), 0);
     AssertIntEQ(test_wc_ecc_shared_secret(), 0);
     AssertIntEQ(test_wc_ecc_export_x963(), 0);

--- a/tests/api.c
+++ b/tests/api.c
@@ -14309,9 +14309,9 @@ static int test_wc_ecc_size (void)
 
 static void test_wc_ecc_params(void)
 {
-    /* FIPS module does not have `wc_ecc_get_curve_params`.
+    /* FIPS/CAVP self-test modules do not have `wc_ecc_get_curve_params`.
         It was added after certifications */
-#if defined(HAVE_ECC) && !defined(HAVE_FIPS)
+#if defined(HAVE_ECC) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
     const ecc_set_type* ecc_set;
 #if !defined(NO_ECC256) && !defined(NO_ECC_SECP)
     /* Test for SECP256R1 curve */
@@ -14326,7 +14326,7 @@ static void test_wc_ecc_params(void)
     /* Test that we get curve params for index 0 */
     ecc_set = wc_ecc_get_curve_params(0);
     AssertNotNull(ecc_set);
-#endif /* HAVE_ECC && !HAVE_FIPS */
+#endif /* HAVE_ECC && !HAVE_FIPS && !HAVE_SELFTEST */
 }
 
 /*

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3395,6 +3395,17 @@ int wc_ecc_get_curve_id_from_oid(const byte* oid, word32 len)
     return ecc_sets[curve_idx].id;
 }
 
+/* Get curve parameters using curve index */
+const ecc_set_type* wc_ecc_get_curve_params(int curve_idx)
+{
+    const ecc_set_type* ecc_set = NULL;
+
+    if (curve_idx >= 0 && curve_idx < (int)ECC_SET_COUNT) {
+        ecc_set = &ecc_sets[curve_idx];
+    }
+    return ecc_set;
+}
+
 
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ECC)
 static WC_INLINE int wc_ecc_alloc_mpint(ecc_key* key, mp_int** mp)

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -528,6 +528,8 @@ int wc_ecc_get_curve_id_from_dp_params(const ecc_set_type* dp);
 WOLFSSL_API
 int wc_ecc_get_curve_id_from_oid(const byte* oid, word32 len);
 
+WOLFSSL_API const ecc_set_type* wc_ecc_get_curve_params(int curve_idx);
+
 WOLFSSL_API
 ecc_point* wc_ecc_new_point(void);
 WOLFSSL_API


### PR DESCRIPTION
* Adds new `wc_ecc_get_curve_params` API for getting the `ecc_set_type` params for a curve index.
* Fix for example client and server using wrong macro for detecting ECC 256-bit enabled.