### PR TITLE
reduce size of state only save and add option to remove peer info

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4284,13 +4284,19 @@ AC_ARG_ENABLE([sessionexport],
     [ ENABLED_SESSIONEXPORT=no ]
     )
 
-if test "$ENABLED_SESSIONEXPORT" = "yes"
+if test "$ENABLED_SESSIONEXPORT" = "yes" ||
+   test "$ENABLED_SESSIONEXPORT" = "nopeer"
 then
     if test "$ENABLED_DTLS" = "no"
     then
         AC_MSG_ERROR([Only DTLS supported with session export])
     fi
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SESSION_EXPORT"
+
+    if test "$ENABLED_SESSIONEXPORT" = "nopeer"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SESSION_EXPORT_NOPEER"
+    fi
 fi
 
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1286,13 +1286,13 @@ enum Misc {
     DTLS_EXPORT_OPT_SZ_3     = 59, /* amount of bytes used from Options */
     DTLS_EXPORT_KEY_SZ       = 325 + (DTLS_SEQ_SZ * 2),
                                    /* max amount of bytes used from Keys */
-    DTLS_EXPORT_MIN_KEY_SZ   = 78 + (DTLS_SEQ_SZ * 2),
+    DTLS_EXPORT_MIN_KEY_SZ   = 85 + (DTLS_SEQ_SZ * 2),
                                    /* min amount of bytes used from Keys */
     DTLS_EXPORT_SPC_SZ       = 16, /* amount of bytes used from CipherSpecs */
     DTLS_EXPORT_LEN          = 2,  /* 2 bytes for length and protocol */
     DTLS_EXPORT_IP           = 46, /* max ip size IPv4 mapped IPv6 */
     MAX_EXPORT_BUFFER        = 514, /* max size of buffer for exporting */
-    MAX_EXPORT_STATE_BUFFER  = DTLS_EXPORT_KEY_SZ + 3 * DTLS_EXPORT_LEN,
+    MAX_EXPORT_STATE_BUFFER  = (DTLS_EXPORT_MIN_KEY_SZ) + (3 * DTLS_EXPORT_LEN),
                                     /* max size of buffer for exporting state */
     FINISHED_LABEL_SZ   = 15,  /* TLS finished label size */
     TLS_FINISHED_SZ     = 12,  /* TLS has a shorter size  */


### PR DESCRIPTION
reduces size of expected buffer returned from wolfSSL_dtls_export_state_only from 347 to 107 bytes and adds (--enable-sessionexport=nopeer , WOLFSSL_SESSION_EXPORT_NOPEER) to disable exporting of peer info structure.