### PR TITLE
Fix unused variable with NO_WOLFSSL_SERVER defined

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1783,7 +1783,7 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
 /* In case contexts are held in array and don't want to free actual ctx */
 void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
 {
-#ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
+#if !defined(NO_WOLFSSL_SERVER) && defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
     int i;
 #endif
 


### PR DESCRIPTION
This fixes:

	src/internal.c: In function ‘SSL_CtxResourceFree’:
	src/internal.c:1787:9: error: unused variable ‘i’ [-Werror=unused-variable]
	     int i;
	         ^