### PR TITLE
Phase 1 of the OpenSSL Compatibility APIs

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -9054,7 +9054,16 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
         use_cb = 1;
     }
 #endif
+#if defined(OPENSSL_EXTRA)
+    /* perform domain name check on the peer certificate */
+    if (args->dCertInit && args->dCert && args->dCert->subjectCN \
+        && ssl->param && ssl->param->hostName[0]) {
 
+        if(XSTRSTR(args->dCert->subjectCN, ssl->param->hostName) == NULL) {
+            return VERIFY_CERT_ERROR;
+        }
+    }
+#endif
     /* if verify callback has been set */
     if (use_cb && ssl->verifyCallback) {
     #ifdef WOLFSSL_SMALL_STACK

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -36673,23 +36673,27 @@ int wolfSSL_PEM_write_bio_PKCS7(WOLFSSL_BIO* bio, PKCS7* p7)
     if ((wolfSSL_BIO_write(bio, pem, pemSz) == pemSz)) {
         XFREE(output, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
         XFREE(pem, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#ifdef WOLFSSL_SMALL_STACK
+        XFREE(outputHead, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(outputFoot, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
         return WOLFSSL_SUCCESS;
     }
 
 error:
 #ifdef WOLFSSL_SMALL_STACK
     if (outputHead) {
-      XFREE(outputHead, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(outputHead, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (outputFoot) {
-      XFREE(outputFoot, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(outputFoot, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
 #endif
     if (output) {
-      XFREE(output, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(output, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     if (pem) {
-      XFREE(pem, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(pem, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
     return WOLFSSL_FAILURE;
 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19766,7 +19766,7 @@ WOLFSSL_X509_VERIFY_PARAM* wolfSSL_get0_param(WOLFSSL* ssl)
     if (ssl == NULL) {
         return NULL;
     }
-    return &ssl->param;
+    return ssl->param;
 }
 
 #ifndef NO_WOLFSSL_STUB

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -36588,6 +36588,7 @@ int wolfSSL_PEM_write_bio_PKCS7(WOLFSSL_BIO* bio, PKCS7* p7)
     if (bio == NULL || p7 == NULL)
         return WOLFSSL_FAILURE;
 
+    XMEMSET(hashBuf, 0, WC_MAX_DIGEST_SIZE);
     XMEMSET(outputHead, 0, outputHeadSz);
     XMEMSET(outputFoot, 0, outputFootSz);
 
@@ -36615,6 +36616,7 @@ int wolfSSL_PEM_write_bio_PKCS7(WOLFSSL_BIO* bio, PKCS7* p7)
     if (!output)
          return WOLFSSL_FAILURE;
 
+    XMEMSET(output, 0, outputSz);
     outputSz = 0;
     XMEMCPY(&output[outputSz], outputHead, outputHeadSz);
     outputSz += outputHeadSz;
@@ -36628,9 +36630,13 @@ int wolfSSL_PEM_write_bio_PKCS7(WOLFSSL_BIO* bio, PKCS7* p7)
     if (pemSz < 0)
         goto error;
 
+    pemSz++; /* for '\0'*/
+
     /* create PEM buffer and convert from DER to PEM*/
     if ((pem = (byte*)XMALLOC(pemSz, bio->heap, DYNAMIC_TYPE_TMP_BUFFER)) == NULL)
         goto error;
+
+    XMEMSET(pem, 0, pemSz);
 
     if (wc_DerToPemEx(output, outputSz, pem, pemSz, NULL, CERT_TYPE) < 0) {
         goto error;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19745,13 +19745,21 @@ int wolfSSL_X509_VERIFY_PARAM_set1_host(WOLFSSL_X509_VERIFY_PARAM* pParam,
                                          const char* name,
                                          unsigned int nameSz)
 {
+    unsigned int sz = 0;
+
     if (pParam == NULL)
         return WOLFSSL_FAILURE;
 
     XMEMSET(pParam->hostName, 0, WOLFSSL_HOST_NAME_MAX);
+
+    if (name == NULL)
+        return WOLFSSL_SUCCESS;
+
+    sz = (unsigned int)XSTRLEN(name);
+
     /* If name is NUL-terminated, namelen can be set to zero. */
-    if(name && (nameSz == 0))
-        nameSz = (unsigned int)XSTRLEN(name);
+    if(nameSz == 0 || nameSz > sz)
+        nameSz = sz;
 
     if (nameSz > 0 && name[nameSz - 1] == '\0')
         nameSz--;
@@ -19765,7 +19773,6 @@ int wolfSSL_X509_VERIFY_PARAM_set1_host(WOLFSSL_X509_VERIFY_PARAM* pParam,
         pParam->hostName[nameSz] = '\0';
 
     return WOLFSSL_SUCCESS;
-
 }
 /******************************************************************************
 * wolfSSL_get0_param - return a pointer to the SSL verification parameters

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -36420,7 +36420,7 @@ void wolfSSL_PKCS7_free(PKCS7* pkcs7)
 }
 void wolfSSL_PKCS7_SIGNED_free(PKCS7_SIGNED* p7)
 {
-    wolfSSL_PKCS7_free((PKCS7*)p7);
+    wolfSSL_PKCS7_free(p7);
     return;
 }
 PKCS7* wolfSSL_d2i_PKCS7(PKCS7** p7, const unsigned char** in, int len)
@@ -36588,6 +36588,9 @@ int wolfSSL_PEM_write_bio_PKCS7(WOLFSSL_BIO* bio, PKCS7* p7)
     if (bio == NULL || p7 == NULL)
         return WOLFSSL_FAILURE;
 
+    XMEMSET(outputHead, 0, outputHeadSz);
+    XMEMSET(outputFoot, 0, outputFootSz);
+
     hashType = wc_OidGetHash(p7->hashOID);
     hashSz = wc_HashGetDigestSize(hashType);
     if (hashSz > WC_MAX_DIGEST_SIZE)
@@ -36602,8 +36605,9 @@ int wolfSSL_PEM_write_bio_PKCS7(WOLFSSL_BIO* bio, PKCS7* p7)
             return WOLFSSL_FAILURE;
     };
 
-    wc_PKCS7_EncodeSignedData_ex(p7, hashBuf, hashSz,
-                        outputHead, &outputHeadSz, outputFoot, &outputFootSz);
+    if ((wc_PKCS7_EncodeSignedData_ex(p7, hashBuf, hashSz,
+        outputHead, &outputHeadSz, outputFoot, &outputFootSz)) != 0)
+        return WOLFSSL_FAILURE;
 
     outputSz = outputHeadSz + p7->contentSz + outputFootSz;
     output = (byte*)XMALLOC(outputSz, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19751,7 +19751,7 @@ int wolfSSL_X509_VERIFY_PARAM_set1_host(WOLFSSL_X509_VERIFY_PARAM* pParam,
     XMEMSET(pParam->hostName, 0, WOLFSSL_HOST_NAME_MAX);
     /* If name is NUL-terminated, namelen can be set to zero. */
     if(name && (nameSz == 0))
-        nameSz = XSTRLEN(name);
+        nameSz = (unsigned int)XSTRLEN(name);
 
     if (nameSz > 0 && name[nameSz - 1] == '\0')
         nameSz--;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19256,6 +19256,11 @@ err_exit:
     if(store->crl != NULL)
         wolfSSL_X509_CRL_free(store->crl);
 #endif
+#ifdef OPENSSL_EXTRA
+        if (store->param != NULL){
+            XFREE(store->param,NULL,DYNAMIC_TYPE_OPENSSL);
+        }
+#endif
     wolfSSL_X509_STORE_free(store);
 
     return NULL;
@@ -36390,11 +36395,12 @@ PKCS7_SIGNED* wolfSSL_PKCS7_SIGNED_new(void)
     byte signedData[]= { 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x07, 0x02};
     PKCS7* pkcs7 = NULL;
 
-    pkcs7 = wolfSSL_PKCS7_new();
+    if ((pkcs7 = wolfSSL_PKCS7_new()) == NULL)
+        return NULL;
     pkcs7->contentOID = SIGNED_DATA;
     if ((wc_PKCS7_SetContentType(pkcs7, signedData, sizeof(signedData))) < 0) {
         if (pkcs7) {
-            wc_PKCS7_Free(pkcs7);
+            wolfSSL_PKCS7_free(pkcs7);
             return NULL;
         }
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -17841,7 +17841,7 @@ static void test_wolfSSL_X509_NAME(void)
 static void test_wolfSSL_X509_subject_name_hash(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && !defined(NO_FILESYSTEM) \
-    && !defined(NO_SHA)
+    && !defined(NO_SHA) && !defined(NO_RSA)
 
     X509* x509;
     X509_NAME* subjectName = NULL;
@@ -19491,7 +19491,7 @@ static void test_wolfSSL_X509_STORE_CTX_set_time(void)
 
 static void test_wolfSSL_get0_param(void)
 {
-#if defined(OPENSSL_EXTRA)
+#if defined(OPENSSL_EXTRA) && !defined(NO_RSA)
     SSL_CTX* ctx;
     SSL*     ssl;
     WOLFSSL_X509_VERIFY_PARAM* pParam;
@@ -19510,7 +19510,7 @@ static void test_wolfSSL_get0_param(void)
     SSL_free(ssl);
     SSL_CTX_free(ctx);
     printf(resultFmt, passed);
-#endif /* OPENSSL_EXTRA */
+#endif /* OPENSSL_EXTRA && !defined(NO_RSA)*/
 }
 
 static void test_wolfSSL_X509_VERIFY_PARAM_set1_host(void)

--- a/tests/api.c
+++ b/tests/api.c
@@ -23695,10 +23695,10 @@ static void test_wolfSSL_PKCS7_SIGNED_new(void)
 static void test_wolfSSL_PEM_write_bio_PKCS7(void)
 {
 #if defined(OPENSSL_ALL) && defined(HAVE_PKCS7) && !defined(NO_FILESYSTEM)
-    PKCS7* pkcs7;
-    BIO* bio;
+    PKCS7* pkcs7 = NULL;
+    BIO* bio = NULL;
     const byte* cert_buf = NULL;
-    int ret;
+    int ret = 0;
     WC_RNG rng;
     const byte data[] = { /* Hello World */
         0x48,0x65,0x6c,0x6c,0x6f,0x20,0x57,0x6f,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3739,6 +3739,7 @@ struct WOLFSSL {
     WOLFSSL_BIO*     biord;              /* socket bio read  to free/close */
     WOLFSSL_BIO*     biowr;              /* socket bio write to free/close */
     byte             sessionCtx[ID_LEN]; /* app session context ID */
+    WOLFSSL_X509_VERIFY_PARAM param;     /* verification parameters*/
 #endif
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     unsigned long    peerVerifyRet;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3739,7 +3739,7 @@ struct WOLFSSL {
     WOLFSSL_BIO*     biord;              /* socket bio read  to free/close */
     WOLFSSL_BIO*     biowr;              /* socket bio write to free/close */
     byte             sessionCtx[ID_LEN]; /* app session context ID */
-    WOLFSSL_X509_VERIFY_PARAM param;     /* verification parameters*/
+    WOLFSSL_X509_VERIFY_PARAM* param;    /* verification parameters*/
 #endif
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     unsigned long    peerVerifyRet;

--- a/wolfssl/openssl/pkcs7.h
+++ b/wolfssl/openssl/pkcs7.h
@@ -47,8 +47,9 @@ typedef struct WOLFSSL_PKCS7
 
 
 WOLFSSL_API PKCS7* wolfSSL_PKCS7_new(void);
+WOLFSSL_API PKCS7_SIGNED* wolfSSL_PKCS7_SIGNED_new(void);
 WOLFSSL_API void wolfSSL_PKCS7_free(PKCS7* p7);
-
+WOLFSSL_API void wolfSSL_PKCS7_SIGNED_free(PKCS7_SIGNED* p7);
 WOLFSSL_API PKCS7* wolfSSL_d2i_PKCS7(PKCS7** p7, const unsigned char** in,
     int len);
 WOLFSSL_API PKCS7* wolfSSL_d2i_PKCS7_bio(WOLFSSL_BIO* bio, PKCS7** p7);
@@ -56,13 +57,17 @@ WOLFSSL_API int wolfSSL_PKCS7_verify(PKCS7* p7, WOLFSSL_STACK* certs,
     WOLFSSL_X509_STORE* store, WOLFSSL_BIO* in, WOLFSSL_BIO* out, int flags);
 WOLFSSL_API WOLFSSL_STACK* wolfSSL_PKCS7_get0_signers(PKCS7* p7,
     WOLFSSL_STACK* certs, int flags);
+WOLFSSL_API int wolfSSL_PEM_write_bio_PKCS7(WOLFSSL_BIO* bio, PKCS7* p7);
 
-#define PKCS7_new                      wolfSSL_PKCS7_new 
+#define PKCS7_new                      wolfSSL_PKCS7_new
+#define PKCS7_SIGNED_new               wolfSSL_PKCS7_SIGNED_new
 #define PKCS7_free                     wolfSSL_PKCS7_free
+#define PKCS7_SIGNED_free              wolfSSL_PKCS7_SIGNED_free
 #define d2i_PKCS7                      wolfSSL_d2i_PKCS7
 #define d2i_PKCS7_bio                  wolfSSL_d2i_PKCS7_bio
 #define PKCS7_verify                   wolfSSL_PKCS7_verify
 #define PKCS7_get0_signers             wolfSSL_PKCS7_get0_signers
+#define PEM_write_bio_PKCS7            wolfSSL_PEM_write_bio_PKCS7
 
 #endif /* OPENSSL_ALL && HAVE_PKCS7 */
 

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -101,6 +101,7 @@ typedef WOLFSSL_X509_REVOKED   X509_REVOKED;
 typedef WOLFSSL_X509_OBJECT    X509_OBJECT;
 typedef WOLFSSL_X509_STORE     X509_STORE;
 typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
+typedef WOLFSSL_X509_VERIFY_PARAM X509_VERIFY_PARAM;
 
 #define EVP_CIPHER_INFO        EncryptedInfo
 
@@ -115,7 +116,6 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 /* depreciated */
 #define CRYPTO_thread_id                wolfSSL_thread_id
 #define CRYPTO_set_id_callback          wolfSSL_set_id_callback
- 
 #define CRYPTO_LOCK             0x01
 #define CRYPTO_UNLOCK           0x02
 #define CRYPTO_READ             0x04
@@ -162,6 +162,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define SSL_use_PrivateKey_ASN1         wolfSSL_use_PrivateKey_ASN1
 #define SSL_use_RSAPrivateKey_ASN1      wolfSSL_use_RSAPrivateKey_ASN1
 #define SSL_get_privatekey              wolfSSL_get_privatekey
+#define SSL_CTX_use_PrivateKey_ASN1     wolfSSL_CTX_use_PrivateKey_ASN1
 
 #define SSLv23_method                   wolfSSLv23_method
 #define SSLv23_client_method            wolfSSLv23_client_method
@@ -250,7 +251,6 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define SSL_session_reused              wolfSSL_session_reused
 #define SSL_SESSION_free                wolfSSL_SESSION_free
 #define SSL_is_init_finished            wolfSSL_is_init_finished
- 
 #define SSL_get_version                 wolfSSL_get_version
 #define SSL_get_current_cipher          wolfSSL_get_current_cipher
 
@@ -266,7 +266,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define SSL_SESSION_get_master_key_length wolfSSL_SESSION_get_master_key_length
 
 #define DSA_dup_DH                      wolfSSL_DSA_dup_DH
- 
+
 #define i2d_X509_bio                    wolfSSL_i2d_X509_bio
 #define d2i_X509_bio                    wolfSSL_d2i_X509_bio
 #define d2i_X509_fp                     wolfSSL_d2i_X509_fp
@@ -317,7 +317,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define X509_email_free                 wolfSSL_X509_email_free
 #define X509_check_issued               wolfSSL_X509_check_issued
 #define X509_dup                        wolfSSL_X509_dup
- 
+
 #define sk_X509_new                     wolfSSL_sk_X509_new
 #define sk_X509_num                     wolfSSL_sk_X509_num
 #define sk_X509_value                   wolfSSL_sk_X509_value
@@ -371,7 +371,6 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define X509_STORE_CTX_cleanup          wolfSSL_X509_STORE_CTX_cleanup
 #define X509_STORE_CTX_set_error        wolfSSL_X509_STORE_CTX_set_error
 #define X509_STORE_CTX_get_ex_data      wolfSSL_X509_STORE_CTX_get_ex_data
- 
 #define X509_STORE_new                  wolfSSL_X509_STORE_new
 #define X509_STORE_free                 wolfSSL_X509_STORE_free
 #define X509_STORE_add_lookup           wolfSSL_X509_STORE_add_lookup
@@ -382,16 +381,17 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define X509_STORE_get_by_subject       wolfSSL_X509_STORE_get_by_subject
 #define X509_STORE_CTX_get1_issuer      wolfSSL_X509_STORE_CTX_get1_issuer
 #define X509_STORE_CTX_set_time         wolfSSL_X509_STORE_CTX_set_time
+#define X509_VERIFY_PARAM_set1_host     wolfSSL_X509_VERIFY_PARAM_set1_host
 
 #define X509_LOOKUP_add_dir             wolfSSL_X509_LOOKUP_add_dir
 #define X509_LOOKUP_load_file           wolfSSL_X509_LOOKUP_load_file
 #define X509_LOOKUP_hash_dir            wolfSSL_X509_LOOKUP_hash_dir
 #define X509_LOOKUP_file                wolfSSL_X509_LOOKUP_file
- 
+
 #define d2i_X509_CRL                    wolfSSL_d2i_X509_CRL
 #define d2i_X509_CRL_fp                 wolfSSL_d2i_X509_CRL_fp
 #define PEM_read_X509_CRL               wolfSSL_PEM_read_X509_CRL
- 
+
 #define X509_CRL_free                   wolfSSL_X509_CRL_free
 #define X509_CRL_get_lastUpdate         wolfSSL_X509_CRL_get_lastUpdate
 #define X509_CRL_get_nextUpdate         wolfSSL_X509_CRL_get_nextUpdate
@@ -402,9 +402,10 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define sk_X509_REVOKED_value           wolfSSL_sk_X509_REVOKED_value
 
 #define X509_OBJECT_free_contents       wolfSSL_X509_OBJECT_free_contents
+#define X509_subject_name_hash          wolfSSL_X509_subject_name_hash
 
 #define OCSP_parse_url                  wolfSSL_OCSP_parse_url
- 
+
 #define MD4_Init                        wolfSSL_MD4_Init
 #define MD4_Update                      wolfSSL_MD4_Update
 #define MD4_Final                       wolfSSL_MD4_Final
@@ -433,7 +434,7 @@ typedef WOLFSSL_X509_STORE_CTX X509_STORE_CTX;
 #define SSL_set_bio                     wolfSSL_set_bio
 #define BIO_eof                         wolfSSL_BIO_eof
 #define BIO_set_ss                      wolfSSL_BIO_set_ss
- 
+
 #define BIO_s_mem                       wolfSSL_BIO_s_mem
 #define BIO_f_base64                    wolfSSL_BIO_f_base64
 #define BIO_set_flags                   wolfSSL_BIO_set_flags
@@ -515,7 +516,7 @@ typedef WOLFSSL_ASN1_BIT_STRING    ASN1_BIT_STRING;
 #define RSA_free                        wolfSSL_RSA_free
 #define RSA_generate_key                wolfSSL_RSA_generate_key
 #define SSL_CTX_set_tmp_rsa_callback    wolfSSL_CTX_set_tmp_rsa_callback
- 
+
 #define PEM_def_callback                wolfSSL_PEM_def_callback
 
 #define SSL_CTX_sess_accept             wolfSSL_CTX_sess_accept
@@ -609,7 +610,7 @@ typedef WOLFSSL_ASN1_BIT_STRING    ASN1_BIT_STRING;
 #define SSL_want_write                  wolfSSL_want_write
 
 #define BIO_prf                         wolfSSL_BIO_prf
- 
+
 #define sk_num                          wolfSSL_sk_num
 #define sk_value                        wolfSSL_sk_value
 
@@ -700,7 +701,7 @@ typedef STACK_OF(WOLFSSL_ASN1_OBJECT) GENERAL_NAMES;
 #define SSL_R_SHORT_READ     10
 #define ERR_R_PEM_LIB        9
 #define V_ASN1_IA5STRING     22
-#define SSL_CTRL_MODE        33       
+#define SSL_CTRL_MODE        33
 
 #define SSL_CTX_clear_chain_certs(ctx) SSL_CTX_set0_chain(ctx,NULL)
 #define d2i_RSAPrivateKey_bio           wolfSSL_d2i_RSAPrivateKey_bio
@@ -761,7 +762,7 @@ typedef STACK_OF(WOLFSSL_ASN1_OBJECT) GENERAL_NAMES;
 #define SSL_set_tlsext_status_ocsp_res  wolfSSL_set_tlsext_status_ocsp_resp
 #define SSL_set_tlsext_status_ocsp_resp  wolfSSL_set_tlsext_status_ocsp_resp
 #define SSL_get_tlsext_status_ocsp_resp  wolfSSL_get_tlsext_status_ocsp_resp
- 
+
 #define SSL_CTX_add_extra_chain_cert    wolfSSL_CTX_add_extra_chain_cert
 #define SSL_CTX_get_read_ahead          wolfSSL_CTX_get_read_ahead
 #define SSL_CTX_set_read_ahead          wolfSSL_CTX_set_read_ahead
@@ -949,7 +950,7 @@ typedef STACK_OF(WOLFSSL_ASN1_OBJECT) GENERAL_NAMES;
 #define SSL_is_server                   wolfSSL_is_server
 #define SSL_CTX_set1_curves_list        wolfSSL_CTX_set1_curves_list
 
-#endif /* WOLFSSL_NGINX || WOLFSSL_HAPROXY || WOLFSSL_MYSQL_COMPATIBLE || 
+#endif /* WOLFSSL_NGINX || WOLFSSL_HAPROXY || WOLFSSL_MYSQL_COMPATIBLE ||
           OPENSSL_ALL || HAVE_LIGHTY */
 
 #ifdef OPENSSL_EXTRA
@@ -957,9 +958,10 @@ typedef STACK_OF(WOLFSSL_ASN1_OBJECT) GENERAL_NAMES;
 #define SSL_CTX_set_srp_password        wolfSSL_CTX_set_srp_password
 #define SSL_CTX_set_srp_username        wolfSSL_CTX_set_srp_username
 #define SSL_get_SSL_CTX                 wolfSSL_get_SSL_CTX
+#define SSL_get0_param                  wolfSSL_get0_param
 
 #define ERR_NUM_ERRORS                  16
-#define EVP_PKEY_RSA                    6 
+#define EVP_PKEY_RSA                    6
 #define EVP_PKEY_RSA2                   19
 #define SN_pkcs9_emailAddress           "Email"
 #define LN_pkcs9_emailAddress           "emailAddress"

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -307,6 +307,7 @@ struct WOLFSSL_X509_STORE {
     WOLFSSL_X509_LOOKUP   lookup;
 #ifdef OPENSSL_EXTRA
     int                   isDynamic;
+    WOLFSSL_X509_VERIFY_PARAM* param;    /* certificate validation parameter */
 #endif
 #if defined(OPENSSL_EXTRA) && defined(HAVE_CRL)
     WOLFSSL_X509_CRL *crl;
@@ -317,9 +318,11 @@ struct WOLFSSL_X509_STORE {
 #define WOLFSSL_USE_CHECK_TIME 0x2
 #define WOLFSSL_NO_CHECK_TIME  0x200000
 #define WOLFSSL_NO_WILDCARDS   0x4
+#define WOLFSSL_HOST_NAME_MAX  256
 struct WOLFSSL_X509_VERIFY_PARAM {
-    time_t  check_time;
-    unsigned long flags;
+    time_t         check_time;
+    unsigned long  flags;
+    char           hostName[WOLFSSL_HOST_NAME_MAX];
 };
 #endif
 
@@ -578,6 +581,7 @@ WOLFSSL_API WOLFSSL_CTX* wolfSSL_CTX_new_ex(WOLFSSL_METHOD* method, void* heap);
 WOLFSSL_API WOLFSSL_CTX* wolfSSL_CTX_new(WOLFSSL_METHOD*);
 WOLFSSL_API WOLFSSL* wolfSSL_new(WOLFSSL_CTX*);
 WOLFSSL_API WOLFSSL_CTX* wolfSSL_get_SSL_CTX(WOLFSSL* ssl);
+WOLFSSL_API WOLFSSL_X509_VERIFY_PARAM* wolfSSL_get0_param(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_is_server(WOLFSSL*);
 WOLFSSL_API WOLFSSL* wolfSSL_write_dup(WOLFSSL*);
 WOLFSSL_API int  wolfSSL_set_fd (WOLFSSL*, int);
@@ -1014,6 +1018,10 @@ WOLFSSL_API int       wolfSSL_sk_X509_REVOKED_num(WOLFSSL_X509_REVOKED*);
 WOLFSSL_API void      wolfSSL_X509_STORE_CTX_set_time(WOLFSSL_X509_STORE_CTX*,
                                                       unsigned long flags,
                                                       time_t t);
+WOLFSSL_API void wolfSSL_X509_VERIFY_PARAM_set1_host(WOLFSSL_X509_VERIFY_PARAM* pParam,
+                                                    const char* name,
+                                                    unsigned int nameSz);
+
 #endif
 WOLFSSL_API WOLFSSL_X509_REVOKED* wolfSSL_X509_CRL_get_REVOKED(WOLFSSL_X509_CRL*);
 WOLFSSL_API WOLFSSL_X509_REVOKED* wolfSSL_sk_X509_REVOKED_value(
@@ -2689,6 +2697,8 @@ WOLFSSL_API WOLFSSL_EVP_PKEY *wolfSSL_get_privatekey(const WOLFSSL *ssl);
 WOLFSSL_API int wolfSSL_use_RSAPrivateKey_ASN1(WOLFSSL* ssl, unsigned char* der,
                                                                 long derSz);
 #endif
+WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_ASN1(int pri, WOLFSSL_CTX* ctx,
+                                            unsigned char* der, long derSz);
 #endif /* NO_CERTS */
 
 WOLFSSL_API WOLFSSL_DH *wolfSSL_DSA_dup_DH(const WOLFSSL_DSA *r);
@@ -2791,7 +2801,6 @@ WOLFSSL_API WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSAparams(WOLFSSL_BIO *bp,
 WOLFSSL_API int wolfSSL_PEM_write_bio_X509_REQ(WOLFSSL_BIO *bp,WOLFSSL_X509 *x);
 WOLFSSL_API int wolfSSL_PEM_write_bio_X509_AUX(WOLFSSL_BIO *bp,WOLFSSL_X509 *x);
 WOLFSSL_API int wolfSSL_PEM_write_bio_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 *x);
-
 #endif /* HAVE_STUNNEL || HAVE_LIGHTY */
 
 #ifdef OPENSSL_ALL
@@ -3107,6 +3116,8 @@ WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_PKCS8PrivateKey_bio(WOLFSSL_BIO* bio,
     WOLFSSL_EVP_PKEY** pkey, pem_password_cb* cb, void* u);
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(
     WOLFSSL_EVP_PKEY** pkey, const unsigned char** data, long length);
+WOLFSSL_API unsigned long  wolfSSL_X509_subject_name_hash(const WOLFSSL_X509* x509);
+
 
 #endif /* OPENSSL_EXTRA */
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1018,7 +1018,7 @@ WOLFSSL_API int       wolfSSL_sk_X509_REVOKED_num(WOLFSSL_X509_REVOKED*);
 WOLFSSL_API void      wolfSSL_X509_STORE_CTX_set_time(WOLFSSL_X509_STORE_CTX*,
                                                       unsigned long flags,
                                                       time_t t);
-WOLFSSL_API void wolfSSL_X509_VERIFY_PARAM_set1_host(WOLFSSL_X509_VERIFY_PARAM* pParam,
+WOLFSSL_API int wolfSSL_X509_VERIFY_PARAM_set1_host(WOLFSSL_X509_VERIFY_PARAM* pParam,
                                                     const char* name,
                                                     unsigned int nameSz);
 

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -198,6 +198,7 @@ typedef struct PKCS7State PKCS7State;
 typedef struct Pkcs7Cert Pkcs7Cert;
 typedef struct Pkcs7EncodedRecip Pkcs7EncodedRecip;
 typedef struct PKCS7 PKCS7;
+typedef struct PKCS7 PKCS7_SIGNED;
 typedef struct PKCS7SignerInfo PKCS7SignerInfo;
 
 /* OtherRecipientInfo decrypt callback prototype */
@@ -220,7 +221,7 @@ typedef int (*CallbackWrapCEK)(PKCS7* pkcs7, byte* cek, word32 cekSz,
                                   int keyWrapAlgo, int type, int dir);
 
 /* Public Structure Warning:
- * Existing members must not be changed to maintain backwards compatibility! 
+ * Existing members must not be changed to maintain backwards compatibility!
  */
 struct PKCS7 {
     WC_RNG* rng;
@@ -267,7 +268,7 @@ struct PKCS7 {
     byte issuerSn[MAX_SN_SZ];     /* singleCert's serial number           */
     byte publicKey[MAX_RSA_INT_SZ + MAX_RSA_E_SZ]; /* MAX RSA key size (m + e)*/
     word32 certSz[MAX_PKCS7_CERTS];
-    
+
      /* flags - up to 16-bits */
     word16 isDynamic:1;
     word16 noDegenerate:1; /* allow degenerate case in verify function */
@@ -320,7 +321,6 @@ struct PKCS7 {
     /* !! NEW DATA MEMBERS MUST BE ADDED AT END !! */
 };
 
-
 WOLFSSL_API PKCS7* wc_PKCS7_New(void* heap, int devId);
 WOLFSSL_API int  wc_PKCS7_Init(PKCS7* pkcs7, void* heap, int devId);
 WOLFSSL_API int  wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* der, word32 derSz);
@@ -346,7 +346,7 @@ WOLFSSL_API int  wc_PKCS7_SetDetached(PKCS7* pkcs7, word16 flag);
 WOLFSSL_API int  wc_PKCS7_NoDefaultSignedAttribs(PKCS7* pkcs7);
 WOLFSSL_API int  wc_PKCS7_EncodeSignedData(PKCS7* pkcs7,
                                           byte* output, word32 outputSz);
-WOLFSSL_API int  wc_PKCS7_EncodeSignedData_ex(PKCS7* pkcs7, const byte* hashBuf, 
+WOLFSSL_API int  wc_PKCS7_EncodeSignedData_ex(PKCS7* pkcs7, const byte* hashBuf,
                                           word32 hashSz, byte* outputHead,
                                           word32* outputHeadSz,
                                           byte* outputFoot,
@@ -354,7 +354,7 @@ WOLFSSL_API int  wc_PKCS7_EncodeSignedData_ex(PKCS7* pkcs7, const byte* hashBuf,
 WOLFSSL_API void wc_PKCS7_AllowDegenerate(PKCS7* pkcs7, word16 flag);
 WOLFSSL_API int  wc_PKCS7_VerifySignedData(PKCS7* pkcs7,
                                           byte* pkiMsg, word32 pkiMsgSz);
-WOLFSSL_API int  wc_PKCS7_VerifySignedData_ex(PKCS7* pkcs7, const byte* hashBuf, 
+WOLFSSL_API int  wc_PKCS7_VerifySignedData_ex(PKCS7* pkcs7, const byte* hashBuf,
                                           word32 hashSz, byte* pkiMsgHead,
                                           word32 pkiMsgHeadSz, byte* pkiMsgFoot,
                                           word32 pkiMsgFootSz);


### PR DESCRIPTION
Adding the following OpenSSL compatibility APIs: 

wolfSSL_PEM_write_bio_PKCS7
wolfSSL_PKCS7_SIGNED_new
wolfSSL_X509_subject_name_hash
wolfSSL_CTX_use_PrivateKey_ASN1
wolfSSL_get0_param
wolfSSL_X509_VERIFY_PARAM_set1_host