### PR TITLE
updates to CMS and callback functions

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -9110,6 +9110,14 @@ static int wc_PKCS7_DecryptKari(PKCS7* pkcs7, byte* in, word32 inSz,
                         decryptedKey, *decryptedKeySz,
                         keyWrapOID, (int)PKCS7_KARI, direction);
                 XFREE(tmpKeyDer, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
+
+                if (keySz  > 0) {
+                    /* If unwrapping was successful then consider recipient
+                     * found. Checking for NULL singleCert to confirm previous
+                     * SID check was not done */
+                    if (pkcs7->singleCert == NULL)
+                        *recipFound = 1;
+                }
             }
             else {
                 /* create KEK */

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -9955,10 +9955,18 @@ WOLFSSL_API int wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* in,
             }
 
             /* decrypt encryptedContent */
-            ret = wc_PKCS7_DecryptContent(encOID, decryptedKey, blockKeySz,
+            if (pkcs7->decryptionCb != NULL) {
+                ret = pkcs7->decryptionCb(pkcs7, encOID, tmpIv, expBlockSz,
+                                      NULL, 0, NULL, 0, encryptedContent,
+                                      encryptedContentSz, encryptedContent,
+                                      pkcs7->decryptionCtx);
+            }
+            else {
+                ret = wc_PKCS7_DecryptContent(encOID, decryptedKey, blockKeySz,
                                   tmpIv, expBlockSz, NULL, 0, NULL, 0,
                                   encryptedContent, encryptedContentSz,
                                   encryptedContent);
+            }
             if (ret != 0) {
                 XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                 break;

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -9036,11 +9036,18 @@ static int wc_PKCS7_DecryptKari(PKCS7* pkcs7, byte* in, word32 inSz,
                     break;
         #endif
                 default:
+                    WOLFSSL_MSG("AES key wrap algorithm unsupported");
+                    if (pkcs7->wrapCEKCb) {
+                        WOLFSSL_MSG("Direction not set!");
+                        break; /* if unwrapping callback is set then do not
+                                * force restriction of supported wrap
+                                * algorithms */
+                    }
+
                     wc_PKCS7_KariFree(kari);
                     #ifdef WOLFSSL_SMALL_STACK
                         XFREE(encryptedKey, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
                     #endif
-                    WOLFSSL_MSG("AES key wrap algorithm unsupported");
                     return BAD_KEYWRAP_ALG_E;
             }
 


### PR DESCRIPTION
- Adds the decryption callback to decoding enveloped data and a test case for it's use.
- Removes restriction on wrap type when callback is set
- Adds handling of optional ECC parameters with KARI
- Accounts for callback case where certificate is not set with KARI