### PR TITLE
Added strict cipher suite check on client server_hello processing

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -18172,6 +18172,23 @@ exit_dpk:
         ssl->options.cipherSuite  = cs1;
         compression = input[i++];
 
+#ifdef WOLFSSL_STRICT_CIPHER_SUITE
+        {
+            word32 idx, found = 0;
+            /* confirm server_hello cipher suite is one sent in client_hello */
+            for (idx = 0; idx < ssl->suites->suiteSz; idx += 2) {
+                if (ssl->suites->suites[idx]   == cs0 &&
+                    ssl->suites->suites[idx+1] == cs1) {
+                    found = idx;
+                }
+            }
+            if (!found) {
+                WOLFSSL_MSG("ServerHello did not use cipher suite from ClientHello");
+                return MATCH_SUITE_ERROR;
+            }
+        }
+#endif
+
         if (compression != NO_COMPRESSION && !ssl->options.usingCompression) {
             WOLFSSL_MSG("Server forcing compression w/o support");
             return COMPRESSION_ERROR;

--- a/src/internal.c
+++ b/src/internal.c
@@ -18172,14 +18172,15 @@ exit_dpk:
         ssl->options.cipherSuite  = cs1;
         compression = input[i++];
 
-#ifdef WOLFSSL_STRICT_CIPHER_SUITE
+#ifndef WOLFSSL_NO_STRICT_CIPHER_SUITE
         {
             word32 idx, found = 0;
             /* confirm server_hello cipher suite is one sent in client_hello */
             for (idx = 0; idx < ssl->suites->suiteSz; idx += 2) {
                 if (ssl->suites->suites[idx]   == cs0 &&
                     ssl->suites->suites[idx+1] == cs1) {
-                    found = idx;
+                    found = 1;
+                    break;
                 }
             }
             if (!found) {
@@ -18187,7 +18188,7 @@ exit_dpk:
                 return MATCH_SUITE_ERROR;
             }
         }
-#endif
+#endif /* !WOLFSSL_NO_STRICT_CIPHER_SUITE */
 
         if (compression != NO_COMPRESSION && !ssl->options.usingCompression) {
             WOLFSSL_MSG("Server forcing compression w/o support");


### PR DESCRIPTION
Added check to enforce cipher suite in `server_hello` from server. Some cipher suites could be allowed if they were supported a build-time even though not sent in the cipher suite list in `client_hello`.  Disabled using `WOLFSSL_NO_STRICT_CIPHER_SUITE`.

Example log output for test case where `client_hello` sent a cipher suite list and server choose a cipher suite not in the list:

```
wolfSSL Entering DoServerHello
ServerHello did not use cipher suite from ClientHello
wolfSSL Leaving DoHandShakeMsgType(), return -501
wolfSSL Leaving DoHandShakeMsg(), return -501
```

RFC 5246: 7.4.1.3: Server Hello:  `cipher_suite: The single cipher suite selected by the server from the list in ClientHello.cipher_suites.`