### PR TITLE
Added support for older KECCAK256 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -188,15 +188,13 @@ then
     enable_scrypt=yes
     enable_indef=yes
     enable_enckeys=yes
+    enable_hashflags=yes
 
     # Enable AES Decrypt, AES ECB, Alt Names, DER Load, Keep Certs, CRL IO with Timeout
     AM_CFLAGS="$AM_CFLAGS -DHAVE_AES_DECRYPT -DHAVE_AES_ECB -DWOLFSSL_ALT_NAMES -DWOLFSSL_DER_LOAD -DKEEP_OUR_CERT -DKEEP_PEER_CERT -DHAVE_CRL_IO -DHAVE_IO_TIMEOUT"
 
     # Enable DH const table speedups (eliminates `-lm` math lib dependency)
     AM_CFLAGS="$AM_CFLAGS -DHAVE_FFDHE_2048 -DHAVE_FFDHE_3072 -DFP_MAX_BITS=8192"
-
-    # Enable hash flags support
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HASH_FLAGS"
 
     # Enable multiple attribute additions such as DC
     AM_CFLAGS="-DWOLFSSL_MULTI_ATTRIB $AM_CFLAGS"
@@ -4348,6 +4346,20 @@ then
 fi
 
 
+# Enable hash flags support
+# Hash flags are useful for runtime options such as SHA3 KECCAK256 selection
+AC_ARG_ENABLE([hashflags],
+    [AS_HELP_STRING([--enable-hashflags],[Enable support for hash flags (default: disabled)])],
+    [ ENABLED_HASHFLAGS=$enableval ],
+    [ ENABLED_HASHFLAGS=no ]
+    )
+
+if test "x$ENABLED_HASHFLAGS" != "xno"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HASH_FLAGS"
+fi
+
+
 # User Settings
 AC_ARG_ENABLE([usersettings],
     [AS_HELP_STRING([--enable-usersettings],[Use your own user_settings.h and do not add Makefile CFLAGS (default: disabled)])],
@@ -4744,6 +4756,7 @@ AM_CONDITIONAL([BUILD_TRUST_PEER_CERT],[test "x$have_tp" = "xyes"])
 AM_CONDITIONAL([BUILD_PKI],[test "x$ENABLED_PKI" = "xyes"])
 AM_CONDITIONAL([BUILD_DES3],[test "x$ENABLED_DES3" = "xyes"])
 AM_CONDITIONAL([BUILD_PKCS7],[test "x$ENABLED_PKCS7" = "xyes"])
+AM_CONDITIONAL([BUILD_HASHFLAGS],[test "x$ENABLED_HASHFLAGS" = "xyes"])
 
 
 CREATE_HEX_VERSION

--- a/configure.ac
+++ b/configure.ac
@@ -195,6 +195,9 @@ then
     # Enable DH const table speedups (eliminates `-lm` math lib dependency)
     AM_CFLAGS="$AM_CFLAGS -DHAVE_FFDHE_2048 -DHAVE_FFDHE_3072 -DFP_MAX_BITS=8192"
 
+    # Enable hash flags support
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HASH_FLAGS"
+
     # Enable multiple attribute additions such as DC
     AM_CFLAGS="-DWOLFSSL_MULTI_ATTRIB $AM_CFLAGS"
 fi

--- a/wolfcrypt/src/md5.c
+++ b/wolfcrypt/src/md5.c
@@ -255,6 +255,9 @@ static int _InitMd5(wc_Md5* md5)
     md5->buffLen = 0;
     md5->loLen   = 0;
     md5->hiLen   = 0;
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+    md5->flags = 0;
+#endif
 
     return ret;
 }

--- a/wolfcrypt/src/port/arm/armv8-sha512.c
+++ b/wolfcrypt/src/port/arm/armv8-sha512.c
@@ -61,6 +61,9 @@ static int InitSha512(wc_Sha512* sha512)
     sha512->buffLen = 0;
     sha512->loLen   = 0;
     sha512->hiLen   = 0;
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+    sha512->flags = 0;
+#endif
 
     return 0;
 }
@@ -501,6 +504,9 @@ static int InitSha384(wc_Sha384* sha384)
     sha384->buffLen = 0;
     sha384->loLen   = 0;
     sha384->hiLen   = 0;
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+    sha384->flags = 0;
+#endif
 
     return 0;
 }

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -298,6 +298,9 @@
         sha->buffLen = 0;
         sha->loLen   = 0;
         sha->hiLen   = 0;
+    #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+        sha->flags = 0;
+    #endif
 
         return ret;
     }

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -184,6 +184,9 @@ static int InitSha256(wc_Sha256* sha256)
     sha256->buffLen = 0;
     sha256->loLen   = 0;
     sha256->hiLen   = 0;
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+    sha256->flags = 0;
+#endif
 
     return ret;
 }
@@ -1197,6 +1200,9 @@ static int InitSha256(wc_Sha256* sha256)
     #if defined(HAVE_INTEL_AVX1)|| defined(HAVE_INTEL_AVX2)
         /* choose best Transform function under this runtime environment */
         Sha256_SetTransform();
+    #endif
+    #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+        sha224->flags = 0;
     #endif
 
         return ret;

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -637,9 +637,15 @@ static int Sha3Final(wc_Sha3* sha3, byte* hash, byte p, byte l)
 {
     byte i;
     byte *s8 = (byte *)sha3->s;
+    byte padChar = 0x06; /* NIST SHA-3 */
 
     sha3->t[p * 8 - 1]  = 0x00;
-    sha3->t[  sha3->i]  = 0x06;
+#ifdef WOLFSSL_HASH_FLAGS
+    if (p == WC_SHA3_256_COUNT && sha3->flags & WC_HASH_SHA3_KECCAK256) {
+        padChar = 0x01;
+    }
+#endif
+    sha3->t[  sha3->i]  = padChar;
     sha3->t[p * 8 - 1] |= 0x80;
     for (i=sha3->i + 1; i < p * 8 - 1; i++)
         sha3->t[i] = 0;

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -570,6 +570,9 @@ static int InitSha3(wc_Sha3* sha3)
     for (i = 0; i < 25; i++)
         sha3->s[i] = 0;
     sha3->i = 0;
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+    sha3->flags = 0;
+#endif
 
     return 0;
 }

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -225,6 +225,9 @@ static int InitSha512(wc_Sha512* sha512)
     */
     sha512->ctx.mode = ESP32_SHA_INIT;
 #endif
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+    sha512->flags = 0;
+#endif
     return 0;
 }
 
@@ -934,6 +937,9 @@ static int InitSha384(wc_Sha384* sha384)
     */
     sha384->ctx.mode = ESP32_SHA_INIT;
 
+#endif
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+    sha384->flags = 0;
 #endif
 
     return 0;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -2619,6 +2619,18 @@ static int sha3_256_test(void)
     int ret = 0;
     int times = sizeof(test_sha) / sizeof(struct testVector), i;
 
+    byte large_input[1024];
+    const char* large_digest =
+        "\xdc\x90\xc0\xb1\x25\xdb\x2c\x34\x81\xa3\xff\xbc\x1e\x2e\x87\xeb"
+        "\x6d\x70\x85\x61\xe0\xe9\x63\x61\xff\xe5\x84\x4b\x1f\x68\x05\x15";
+
+#ifdef WOLFSSL_HASH_FLAGS
+    /* test vector with hash of empty string */
+    const char* Keccak256EmptyOut =
+        "\xc5\xd2\x46\x01\x86\xf7\x23\x3c\x92\x7e\x7d\xb2\xdc\xc7\x03\xc0"
+        "\xe5\x00\xb6\x53\xca\x82\x27\x3b\x7b\xfa\xd8\x04\x5d\x85\xa4\x70";
+#endif
+
     a.input  = "";
     a.output = "\xa7\xff\xc6\xf8\xbf\x1e\xd7\x66\x51\xc1\x47\x56\xa0\x61\xd6"
                "\x62\xf5\x80\xff\x4d\xe4\x3b\x49\xfa\x82\xd8\x0a\x4b\x80\xf8"
@@ -2667,11 +2679,6 @@ static int sha3_256_test(void)
     }
 
     /* BEGIN LARGE HASH TEST */ {
-    byte large_input[1024];
-    const char* large_digest =
-        "\xdc\x90\xc0\xb1\x25\xdb\x2c\x34\x81\xa3\xff\xbc\x1e\x2e\x87\xeb"
-        "\x6d\x70\x85\x61\xe0\xe9\x63\x61\xff\xe5\x84\x4b\x1f\x68\x05\x15";
-
     for (i = 0; i < (int)sizeof(large_input); i++) {
         large_input[i] = (byte)(i & 0xFF);
     }
@@ -2688,6 +2695,25 @@ static int sha3_256_test(void)
     if (XMEMCMP(hash, large_digest, WC_SHA3_256_DIGEST_SIZE) != 0)
         ERROR_OUT(-2608, exit);
     } /* END LARGE HASH TEST */
+
+#ifdef WOLFSSL_HASH_FLAGS
+    /* Test for Keccak256 */
+    ret = wc_Sha3_SetFlags(&sha, WC_HASH_SHA3_KECCAK256);
+    if (ret != 0) {
+        ERROR_OUT(-2609, exit);
+    }
+    ret = wc_Sha3_256_Update(&sha, (byte*)"", 0);
+    if (ret != 0) {
+        ERROR_OUT(-2610, exit);
+    }
+    ret = wc_Sha3_256_Final(&sha, hash);
+    if (ret != 0) {
+        ERROR_OUT(-2611, exit);
+    }
+    if (XMEMCMP(hash, Keccak256EmptyOut, WC_SHA3_256_DIGEST_SIZE) != 0) {
+        ERROR_OUT(-2612, exit);
+    }
+#endif
 
 exit:
     wc_Sha3_256_Free(&sha);

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -166,9 +166,9 @@ WOLFSSL_API int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type,
 WOLFSSL_API int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type);
 
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
-    WOLFSSL_LOCAL int wc_HashSetFlags(wc_HashAlg* hash, enum wc_HashType type,
+    WOLFSSL_API int wc_HashSetFlags(wc_HashAlg* hash, enum wc_HashType type,
         word32 flags);
-    WOLFSSL_LOCAL int wc_HashGetFlags(wc_HashAlg* hash, enum wc_HashType type,
+    WOLFSSL_API int wc_HashGetFlags(wc_HashAlg* hash, enum wc_HashType type,
         word32* flags);
 #endif
 

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -83,6 +83,9 @@ enum wc_HashFlags {
     WC_HASH_FLAG_NONE =     0x00000000,
     WC_HASH_FLAG_WILLCOPY = 0x00000001, /* flag to indicate hash will be copied */
     WC_HASH_FLAG_ISCOPY =   0x00000002, /* hash is copy */
+#ifdef WOLFSSL_SHA3
+    WC_HASH_SHA3_KECCAK256 =0x00010000, /* Older KECCAK256 */
+#endif
 };
 
 

--- a/wolfssl/wolfcrypt/md5.h
+++ b/wolfssl/wolfcrypt/md5.h
@@ -118,8 +118,8 @@ WOLFSSL_API void wc_Md5SizeSet(wc_Md5* md5, word32 len);
 #endif
 
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
-    WOLFSSL_LOCAL int wc_Md5SetFlags(wc_Md5* md5, word32 flags);
-    WOLFSSL_LOCAL int wc_Md5GetFlags(wc_Md5* md5, word32* flags);
+    WOLFSSL_API int wc_Md5SetFlags(wc_Md5* md5, word32 flags);
+    WOLFSSL_API int wc_Md5GetFlags(wc_Md5* md5, word32* flags);
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -157,8 +157,8 @@ WOLFSSL_API void wc_ShaSizeSet(wc_Sha* sha, word32 len);
 #endif
 
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
-    WOLFSSL_LOCAL int wc_ShaSetFlags(wc_Sha* sha, word32 flags);
-    WOLFSSL_LOCAL int wc_ShaGetFlags(wc_Sha* sha, word32* flags);
+    WOLFSSL_API int wc_ShaSetFlags(wc_Sha* sha, word32 flags);
+    WOLFSSL_API int wc_ShaGetFlags(wc_Sha* sha, word32* flags);
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -189,8 +189,8 @@ WOLFSSL_API void wc_Sha256SizeSet(wc_Sha256*, word32);
 #endif
 
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
-    WOLFSSL_LOCAL int wc_Sha256SetFlags(wc_Sha256* sha256, word32 flags);
-    WOLFSSL_LOCAL int wc_Sha256GetFlags(wc_Sha256* sha256, word32* flags);
+    WOLFSSL_API int wc_Sha256SetFlags(wc_Sha256* sha256, word32 flags);
+    WOLFSSL_API int wc_Sha256GetFlags(wc_Sha256* sha256, word32* flags);
 #endif
 
 #ifdef WOLFSSL_SHA224
@@ -228,8 +228,8 @@ WOLFSSL_API int wc_Sha224GetHash(wc_Sha224*, byte*);
 WOLFSSL_API int wc_Sha224Copy(wc_Sha224* src, wc_Sha224* dst);
 
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
-    WOLFSSL_LOCAL int wc_Sha224SetFlags(wc_Sha224* sha224, word32 flags);
-    WOLFSSL_LOCAL int wc_Sha224GetFlags(wc_Sha224* sha224, word32* flags);
+    WOLFSSL_API int wc_Sha224SetFlags(wc_Sha224* sha224, word32 flags);
+    WOLFSSL_API int wc_Sha224GetFlags(wc_Sha224* sha224, word32* flags);
 #endif
 
 #endif /* WOLFSSL_SHA224 */

--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -137,8 +137,8 @@ WOLFSSL_API int wc_Sha3_512_GetHash(wc_Sha3*, byte*);
 WOLFSSL_API int wc_Sha3_512_Copy(wc_Sha3* src, wc_Sha3* dst);
 
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
-    WOLFSSL_LOCAL int wc_Sha3_SetFlags(wc_Sha3* sha3, word32 flags);
-    WOLFSSL_LOCAL int wc_Sha3_GetFlags(wc_Sha3* sha3, word32* flags);
+    WOLFSSL_API int wc_Sha3_SetFlags(wc_Sha3* sha3, word32 flags);
+    WOLFSSL_API int wc_Sha3_GetFlags(wc_Sha3* sha3, word32* flags);
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -159,8 +159,8 @@ WOLFSSL_API int wc_Sha512GetHash(wc_Sha512*, byte*);
 WOLFSSL_API int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst);
 
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
-    WOLFSSL_LOCAL int wc_Sha512SetFlags(wc_Sha512* sha512, word32 flags);
-    WOLFSSL_LOCAL int wc_Sha512GetFlags(wc_Sha512* sha512, word32* flags);
+    WOLFSSL_API int wc_Sha512SetFlags(wc_Sha512* sha512, word32 flags);
+    WOLFSSL_API int wc_Sha512GetFlags(wc_Sha512* sha512, word32* flags);
 #endif
 
 #endif /* WOLFSSL_SHA512 */
@@ -205,8 +205,8 @@ WOLFSSL_API int wc_Sha384GetHash(wc_Sha384*, byte*);
 WOLFSSL_API int wc_Sha384Copy(wc_Sha384* src, wc_Sha384* dst);
 
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
-    WOLFSSL_LOCAL int wc_Sha384SetFlags(wc_Sha384* sha384, word32 flags);
-    WOLFSSL_LOCAL int wc_Sha384GetFlags(wc_Sha384* sha384, word32* flags);
+    WOLFSSL_API int wc_Sha384SetFlags(wc_Sha384* sha384, word32 flags);
+    WOLFSSL_API int wc_Sha384GetFlags(wc_Sha384* sha384, word32* flags);
 #endif
 
 #endif /* WOLFSSL_SHA384 */


### PR DESCRIPTION
Added support for older KECCAK256 used by Ethereum. Uses existing hash flag API's.

To use add build flag `CFLAGS="-DWOLFSSL_HASH_FLAGS"`. Off by default.

Example:

To Enable call this before the first update call: `wc_Sha3_SetFlags(&sha, WC_HASH_SHA3_KECCAK256);`

ZD 5515