### PR TITLE
Adds use secure renegotiation at CTX level

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -5292,14 +5292,18 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 
 #ifdef HAVE_SECURE_RENEGOTIATION
     if (ssl->options.side == WOLFSSL_CLIENT_END) {
-    /* use secure renegotiation by default (not recommend) */
+        int useSecureReneg = ssl->ctx->useSecureReneg;
+        /* use secure renegotiation by default (not recommend) */
     #ifdef WOLFSSL_SECURE_RENEGOTIATION_ON_BY_DEFAULT
-        ret = wolfSSL_UseSecureRenegotiation(ssl);
-        if (ret != WOLFSSL_SUCCESS)
-            return ret;
+        useSecureReneg = 1;
     #endif
+        if (useSecureReneg) {
+            ret = wolfSSL_UseSecureRenegotiation(ssl);
+            if (ret != WOLFSSL_SUCCESS)
+                return ret;
+            }
     }
-#endif
+#endif /* HAVE_SECURE_RENEGOTIATION */
 
     return 0;
 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2441,6 +2441,15 @@ int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl)
     return ret;
 }
 
+int wolfSSL_CTX_UseSecureRenegotiation(WOLFSSL_CTX* ctx)
+{
+    if (ctx == NULL)
+        return BAD_FUNC_ARG;
+
+    ctx->useSecureReneg = 1;
+    return WOLFSSL_SUCCESS;
+}
+
 
 /* do a secure renegotiation handshake, user forced, we discourage */
 int wolfSSL_Rehandshake(WOLFSSL* ssl)

--- a/tests/api.c
+++ b/tests/api.c
@@ -141,7 +141,7 @@
 
 #include <stdlib.h>
 #include <wolfssl/ssl.h>  /* compatibility layer */
- #include <wolfssl/test.h>
+#include <wolfssl/test.h>
 #include <tests/unit.h>
 #include "examples/server/server.h"
      /* for testing compatibility layer callbacks */
@@ -4087,6 +4087,29 @@ static void test_wolfSSL_DisableExtendedMasterSecret(void)
     wolfSSL_CTX_free(ctx);
 #endif
 }
+
+static void test_wolfSSL_wolfSSL_UseSecureRenegotiation(void)
+{
+#if defined(HAVE_SECURE_RENEGOTIATION) && !defined(NO_WOLFSSL_CLIENT)
+    WOLFSSL_CTX *ctx = wolfSSL_CTX_new(wolfSSLv23_client_method());
+    WOLFSSL     *ssl = wolfSSL_new(ctx);
+
+    AssertNotNull(ctx);
+    AssertNotNull(ssl);
+
+    /* error cases */
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_CTX_UseSecureRenegotiation(NULL));
+    AssertIntNE(WOLFSSL_SUCCESS, wolfSSL_UseSecureRenegotiation(NULL));
+
+    /* success cases */
+    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_CTX_UseSecureRenegotiation(ctx));
+    AssertIntEQ(WOLFSSL_SUCCESS, wolfSSL_UseSecureRenegotiation(ssl));
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+#endif
+}
+
 
 /*----------------------------------------------------------------------------*
  | X509 Tests
@@ -25522,6 +25545,7 @@ void ApiTest(void)
     test_wolfSSL_UseSupportedCurve();
     test_wolfSSL_UseALPN();
     test_wolfSSL_DisableExtendedMasterSecret();
+    test_wolfSSL_wolfSSL_UseSecureRenegotiation();
 
     /* X509 tests */
     test_wolfSSL_X509_NAME_get_entry();

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2618,6 +2618,9 @@ struct WOLFSSL_CTX {
     byte        dhKeyTested:1;   /* Set when key has been tested. */
     #endif
 #endif
+#ifdef HAVE_SECURE_RENEGOTIATION
+    byte        useSecureReneg:1; /* when set will set WOLFSSL objects generated to enable */
+#endif
 #ifdef WOLFSSL_MULTICAST
     byte        haveMcast;        /* multicast requested */
     byte        mcastID;          /* multicast group ID */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2522,6 +2522,7 @@ WOLFSSL_API int wolfSSL_NoKeyShares(WOLFSSL* ssl);
 #ifdef HAVE_SECURE_RENEGOTIATION
 
 WOLFSSL_API int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl);
+WOLFSSL_API int wolfSSL_CTX_UseSecureRenegotiation(WOLFSSL_CTX* ctx);
 WOLFSSL_API int wolfSSL_StartSecureRenegotiation(WOLFSSL* ssl, int resume);
 WOLFSSL_API int wolfSSL_Rehandshake(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_SecureResume(WOLFSSL* ssl);


### PR DESCRIPTION
Adds new `wolfSSL_CTX_UseSecureRenegotiation` API for setting secure renegotiation at the `WOLFSSL_CTX` level.
ZD 5522