### PR TITLE
Adding compatibility API phase 2

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -11366,6 +11366,33 @@ WOLFSSL_API int wolfSSL_check_private_key(const WOLFSSL* ssl);
 /*!
     \ingroup CertsKeys
 
+    \brief This function looks for and returns the extension index
+    matching the passed in NID value.
+
+    \return >= 0 If successful the extension index is returned.
+    \return -1 If extension is not found or error is encountered.
+
+    \param x509 certificate to get parse through for extension.
+    \param nid extension OID to be found.
+    \param lastPos start search from extension after lastPos.
+                   Set to -1 initially.
+
+    _Example_
+    \code
+    const WOLFSSL_X509* x509;
+    int lastPos = -1;
+    int idx;
+
+    idx = wolfSSL_X509_get_ext_by_NID(x509, NID_basic_constraints, lastPos);
+    \endcode
+
+*/
+WOLFSSL_API int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509,
+                                             int nid, int lastPos);
+
+/*!
+    \ingroup CertsKeys
+
     \brief This function looks for and returns the extension
     matching the passed in NID value.
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -3283,6 +3283,24 @@ void FreeX509(WOLFSSL_X509* x509)
             XFREE(x509->authInfo, x509->heap, DYNAMIC_TYPE_X509_EXT);
             x509->authInfo = NULL;
         }
+        #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+        if (x509->authInfoCaIssuer != NULL) {
+            XFREE(x509->authInfoCaIssuer, x509->heap, DYNAMIC_TYPE_X509_EXT);
+        }
+        if (x509->notBeforeTime != NULL) {
+            XFREE(x509->notBeforeTime, x509->heap, DYNAMIC_TYPE_OPENSSL);
+        }
+        if (x509->notAfterTime != NULL) {
+            XFREE(x509->notAfterTime, x509->heap, DYNAMIC_TYPE_OPENSSL);
+        }
+        if (x509->ext_sk != NULL) {
+            wolfSSL_sk_X509_EXTENSION_free(x509->ext_sk);
+        }
+        /* Free serialNumber that was set by wolfSSL_X509_get_serialNumber */
+        if (x509->serialNumber != NULL) {
+            wolfSSL_ASN1_INTEGER_free(x509->serialNumber);
+        }
+        #endif /* OPENSSL_ALL || WOLFSSL_QT */
         if (x509->extKeyUsageSrc != NULL) {
             XFREE(x509->extKeyUsageSrc, x509->heap, DYNAMIC_TYPE_X509_EXT);
             x509->extKeyUsageSrc= NULL;

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1622,3 +1622,29 @@ WOLFSSL_API int wolfSSL_PKCS5_PBKDF2_HMAC_SHA1(const char *pass, int passlen,
         return WOLFSSL_FAILURE;
 }
 #endif /* OPENSSL_EXTRA && !NO_PWDBASED !NO_SHA*/
+
+#if defined(OPENSSL_EXTRA) && !defined(NO_PWDBASED)
+WOLFSSL_API int wolfSSL_PKCS5_PBKDF2_HMAC(const char *pass, int passlen,
+                                           const unsigned char *salt,
+                                           int saltlen, int iter,
+                                           const WOLFSSL_EVP_MD *digest,
+                                           int keylen, unsigned char *out)
+{
+    const char *nostring = "";
+    int ret = 0;
+
+    if (pass == NULL) {
+        passlen = 0;
+        pass = nostring;
+    } else if (passlen == -1) {
+        passlen = (int)XSTRLEN(pass);
+    }
+
+    ret = wc_PBKDF2((byte*)out, (byte*)pass, passlen, (byte*)salt, saltlen,
+                    iter, keylen, wolfSSL_EVP_MD_type(digest));
+    if (ret == 0)
+        return WOLFSSL_SUCCESS;
+    else
+        return WOLFSSL_FAILURE;
+}
+#endif /* OPENSSL_EXTRA && !NO_PWDBASED */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3442,19 +3442,21 @@ struct WOLFSSL_STACK {
     unsigned long num; /* number of nodes in stack
                         * (safety measure for freeing and shortcut for count) */
     union {
-        WOLFSSL_X509*        x509;
-        WOLFSSL_X509_NAME*   name;
-        WOLFSSL_BIO*         bio;
-        WOLFSSL_ASN1_OBJECT* obj;
-    #if defined(OPENSSL_ALL)
+        WOLFSSL_X509*          x509;
+        WOLFSSL_X509_NAME*     name;
+        WOLFSSL_BIO*           bio;
+        WOLFSSL_ASN1_OBJECT*   obj;
+        WOLFSSL_CIPHER*        cipher;
+        #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
         WOLFSSL_ACCESS_DESCRIPTION* access;
-    #endif
-        char*                string;
+        WOLFSSL_X509_EXTENSION* ext;
+        #endif
+        void*                  generic;
+        char*                  string;
     } data;
     WOLFSSL_STACK* next;
     byte type;     /* Identifies type of stack. */
 };
-
 
 struct WOLFSSL_X509_NAME {
     char  *name;
@@ -3492,11 +3494,19 @@ struct WOLFSSL_X509 {
     byte             hwType[EXTERNAL_SERIAL_SIZE];
     int              hwSerialNumSz;
     byte             hwSerialNum[EXTERNAL_SERIAL_SIZE];
-    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-        byte             certPolicySet;
-        byte             certPolicyCrit;
-    #endif /* OPENSSL_EXTRA */
-#endif
+#endif /* WOLFSSL_SEP */
+#if (defined(WOLFSSL_SEP) || defined(WOLFSSL_QT) || defined (OPENSSL_ALL)) && \
+    (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
+    byte             certPolicySet;
+    byte             certPolicyCrit;
+#endif /* (WOLFSSL_SEP || WOLFSSL_QT) && (OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL) */
+#if defined(WOLFSSL_QT) || defined(OPENSSL_ALL)
+    WOLFSSL_ASN1_TIME* notAfterTime;
+    WOLFSSL_ASN1_TIME* notBeforeTime;
+    WOLFSSL_STACK* ext_sk; /* Store X509_EXTENSIONS from wolfSSL_X509_get_ext */
+    WOLFSSL_STACK* ext_d2i;/* Store d2i extensions from wolfSSL_X509_get_ext_d2i */
+    WOLFSSL_ASN1_INTEGER* serialNumber; /* Stores SN from wolfSSL_X509_get_serialNumber */
+#endif /* WOLFSSL_QT || OPENSSL_ALL */
     int              notBeforeSz;
     int              notAfterSz;
     byte             notBefore[MAX_DATE_SZ];
@@ -3507,12 +3517,12 @@ struct WOLFSSL_X509 {
     buffer           pubKey;
     int              pubKeyOID;
     DNS_entry*       altNamesNext;                   /* hint for retrieval */
-    #if defined(HAVE_ECC) || defined(HAVE_ED25519)
-        word32       pkCurveOID;
-    #endif /* HAVE_ECC */
-    #ifndef NO_CERTS
-        DerBuffer*   derCert;                        /* may need  */
-    #endif
+#if defined(HAVE_ECC) || defined(HAVE_ED25519)
+    word32       pkCurveOID;
+#endif /* HAVE_ECC */
+#ifndef NO_CERTS
+    DerBuffer*   derCert;                            /* may need  */
+#endif
     void*            heap;                           /* heap hint */
     byte             dynamicMemory;                  /* dynamic memory flag */
     byte             isCa:1;
@@ -3533,6 +3543,10 @@ struct WOLFSSL_X509 {
     byte*            extKeyUsageSrc;
     const byte*      CRLInfo;
     byte*            authInfo;
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+    byte*            authInfoCaIssuer;
+    int              authInfoCaIssuerSz;
+#endif
     word32           pathLength;
     word16           keyUsage;
     int              CRLInfoSz;

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -436,6 +436,11 @@ WOLFSSL_API int wolfSSL_PKCS5_PBKDF2_HMAC_SHA1(const char * pass, int passlen,
                                                int saltlen, int iter,
                                                int keylen, unsigned char *out);
 
+WOLFSSL_API int wolfSSL_PKCS5_PBKDF2_HMAC(const char *pass, int passlen,
+                                           const unsigned char *salt,
+                                           int saltlen, int iter,
+                                           const WOLFSSL_EVP_MD *digest,
+                                           int keylen, unsigned char *out);
 #define EVP_CIPH_STREAM_CIPHER WOLFSSL_EVP_CIPH_STREAM_CIPHER
 #define EVP_CIPH_ECB_MODE WOLFSSL_EVP_CIPH_ECB_MODE
 #define EVP_CIPH_CBC_MODE WOLFSSL_EVP_CIPH_CBC_MODE
@@ -611,6 +616,7 @@ typedef WOLFSSL_EVP_CIPHER_CTX EVP_CIPHER_CTX;
 #define wolfSSL_OPENSSL_add_all_algorithms_noconf wolfSSL_OpenSSL_add_all_algorithms_noconf
 
 #define PKCS5_PBKDF2_HMAC_SHA1     wolfSSL_PKCS5_PBKDF2_HMAC_SHA1
+#define PKCS5_PBKDF2_HMAC          wolfSSL_PKCS5_PBKDF2_HMAC
 
 #ifndef EVP_MAX_MD_SIZE
     #define EVP_MAX_MD_SIZE   64     /* sha512 */

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -88,6 +88,7 @@ typedef WOLFSSL_ASN1_STRING    ASN1_STRING;
 typedef WOLFSSL_dynlock_value  CRYPTO_dynlock_value;
 typedef WOLFSSL_BUF_MEM        BUF_MEM;
 typedef WOLFSSL_GENERAL_NAME   GENERAL_NAME;
+typedef WOLFSSL_GENERAL_NAMES  GENERAL_NAMES;
 
 #define ASN1_UTCTIME         WOLFSSL_ASN1_TIME
 #define ASN1_GENERALIZEDTIME WOLFSSL_ASN1_TIME
@@ -261,9 +262,16 @@ typedef WOLFSSL_X509_VERIFY_PARAM X509_VERIFY_PARAM;
 #define SSL_SESSION_get_master_key      wolfSSL_SESSION_get_master_key
 #define SSL_SESSION_get_master_key_length wolfSSL_SESSION_get_master_key_length
 
-#if defined(OPENSSL_ALL)
+#if defined(WOLFSSL_QT) || defined(OPENSSL_ALL)
+    #define ASN1_BOOLEAN                WOLFSSL_ASN1_BOOLEAN
+    #define X509_get_ext                wolfSSL_X509_get_ext
     #define X509_cmp                    wolfSSL_X509_cmp
     #define X509_get_ext_count          wolfSSL_X509_get_ext_count
+    #define X509_EXTENSION_get_object   wolfSSL_X509_EXTENSION_get_object
+    #define X509_EXTENSION_get_critical wolfSSL_X509_EXTENSION_get_critical
+    #define X509_EXTENSION_get_data     wolfSSL_X509_EXTENSION_get_data
+    #define X509_EXTENSION_new          wolfSSL_X509_EXTENSION_new
+    #define X509_EXTENSION_free         wolfSSL_X509_EXTENSION_free
 #endif
 
 #define DSA_dup_DH                      wolfSSL_DSA_dup_DH
@@ -292,6 +300,7 @@ typedef WOLFSSL_X509_VERIFY_PARAM X509_VERIFY_PARAM;
 #define X509_load_certificate_file      wolfSSL_X509_load_certificate_file
 #define X509_digest                     wolfSSL_X509_digest
 #define X509_get_ext_d2i                wolfSSL_X509_get_ext_d2i
+#define X509_get_ext_by_NID             wolfSSL_X509_get_ext_by_NID
 #define X509_get_issuer_name            wolfSSL_X509_get_issuer_name
 #define X509_get_subject_name           wolfSSL_X509_get_subject_name
 #define X509_get_pubkey                 wolfSSL_X509_get_pubkey
@@ -487,11 +496,14 @@ typedef WOLFSSL_ASN1_BIT_STRING    ASN1_BIT_STRING;
 #define ASN1_INTEGER_set                wolfSSL_ASN1_INTEGER_set
 #define ASN1_INTEGER_to_BN              wolfSSL_ASN1_INTEGER_to_BN
 
+#define i2a_ASN1_OBJECT                 wolfSSL_i2a_ASN1_OBJECT
+
 #define ASN1_STRING_data                wolfSSL_ASN1_STRING_data
 #define ASN1_STRING_get0_data           wolfSSL_ASN1_STRING_data
 #define ASN1_STRING_length              wolfSSL_ASN1_STRING_length
 #define ASN1_STRING_to_UTF8             wolfSSL_ASN1_STRING_to_UTF8
 #define ASN1_STRING_print_ex            wolfSSL_ASN1_STRING_print_ex
+#define ASN1_STRING_print(x, y)         wolfSSL_ASN1_STRING_print ((WOLFSSL_BIO*)(x), (WOLFSSL_ASN1_STRING*)(y))
 
 #define ASN1_UTCTIME_pr                 wolfSSL_ASN1_UTCTIME_pr
 
@@ -504,7 +516,7 @@ typedef WOLFSSL_ASN1_BIT_STRING    ASN1_BIT_STRING;
 #define SSL_CTX_get_client_CA_list      wolfSSL_SSL_CTX_get_client_CA_list
 #define SSL_CTX_set_client_CA_list      wolfSSL_CTX_set_client_CA_list
 #define SSL_CTX_set_cert_store          wolfSSL_CTX_set_cert_store
-#define SSL_CTX_get_cert_store          wolfSSL_CTX_get_cert_store
+#define SSL_CTX_get_cert_store(x)       wolfSSL_CTX_get_cert_store ((WOLFSSL_CTX*) (x))
 #define SSL_get_ex_data_X509_STORE_CTX_idx wolfSSL_get_ex_data_X509_STORE_CTX_idx
 #define SSL_get_ex_data                 wolfSSL_get_ex_data
 
@@ -701,7 +713,6 @@ enum {
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_ASIO)
 #include <wolfssl/openssl/pem.h>
 
-typedef STACK_OF(WOLFSSL_ASN1_OBJECT) GENERAL_NAMES;
 #define SSL_CTRL_CHAIN       88
 #define BIO_CTRL_WPENDING    13
 #define GEN_IPADD            7
@@ -717,7 +728,6 @@ typedef STACK_OF(WOLFSSL_ASN1_OBJECT) GENERAL_NAMES;
 #define d2i_PrivateKey_bio              wolfSSL_d2i_PrivateKey_bio
 #define BIO_new_bio_pair                wolfSSL_BIO_new_bio_pair
 #define SSL_get_verify_callback         wolfSSL_get_verify_callback
-#define GENERAL_NAMES_free(GENERAL_NAMES)NULL
 
 #define SSL_set_mode(ssl,op)         wolfSSL_ctrl((ssl),SSL_CTRL_MODE,(op),NULL)
 
@@ -856,6 +866,7 @@ typedef STACK_OF(WOLFSSL_ASN1_OBJECT) GENERAL_NAMES;
 #define SSL_SESSION_get_id              wolfSSL_SESSION_get_id
 #define sk_GENERAL_NAME_pop_free        wolfSSL_sk_GENERAL_NAME_pop_free
 #define GENERAL_NAME_free               wolfSSL_GENERAL_NAME_free
+#define GENERAL_NAMES_free              wolfSSL_GENERAL_NAMES_free
 
 #define SSL3_AL_FATAL                   2
 #define SSL_TLSEXT_ERR_OK               0

--- a/wolfssl/openssl/x509v3.h
+++ b/wolfssl/openssl/x509v3.h
@@ -31,12 +31,67 @@
     extern "C" {
 #endif
 
+/* Forward reference */
+typedef struct WOLFSSL_v3_ext_method WOLFSSL_v3_ext_method;
+
+typedef void *(*X509V3_EXT_D2I)(void *, const unsigned char **, long);
+typedef STACK_OF(CONF_VALUE) *(*X509V3_EXT_I2V) (
+                                struct WOLFSSL_v3_ext_method *method,
+                                void *ext, STACK_OF(CONF_VALUE) *extlist);
+typedef char *(*X509V3_EXT_I2S)(struct WOLFSSL_v3_ext_method *method, void *ext);
+typedef int (*X509V3_EXT_I2R) (struct WOLFSSL_v3_ext_method *method,
+                               void *ext, BIO *out, int indent);
+typedef struct WOLFSSL_v3_ext_method X509V3_EXT_METHOD;
+
+struct WOLFSSL_v3_ext_method {
+    int ext_nid;
+    int ext_flags;
+    void *usr_data;
+    X509V3_EXT_D2I d2i;
+    X509V3_EXT_I2V i2v;
+    X509V3_EXT_I2S i2s;
+    X509V3_EXT_I2R i2r;
+};
+
+#define WOLFSSL_ASN1_BOOLEAN int
+
+struct WOLFSSL_X509_EXTENSION {
+    WOLFSSL_ASN1_OBJECT *obj;
+    WOLFSSL_ASN1_BOOLEAN crit;
+    WOLFSSL_ASN1_STRING value;
+    WOLFSSL_v3_ext_method ext_method;
+    WOLFSSL_STACK* ext_sk; /* For extension specific data */
+};
+
 struct WOLFSSL_ACCESS_DESCRIPTION {
     WOLFSSL_ASN1_OBJECT *method;
     WOLFSSL_GENERAL_NAME *location;
 };
 
+typedef struct WOLFSSL_AUTHORITY_KEYID AUTHORITY_KEYID;
+typedef struct WOLFSSL_BASIC_CONSTRAINTS BASIC_CONSTRAINTS;
 typedef struct WOLFSSL_ACCESS_DESCRIPTION ACCESS_DESCRIPTION;
+typedef WOLF_STACK_OF(WOLFSSL_ACCESS_DESCRIPTION) WOLFSSL_AUTHORITY_INFO_ACCESS;
+
+WOLFSSL_API void wolfSSL_BASIC_CONSTRAINTS_free(WOLFSSL_BASIC_CONSTRAINTS *bc);
+WOLFSSL_API void wolfSSL_AUTHORITY_KEYID_free(WOLFSSL_AUTHORITY_KEYID *id);
+WOLFSSL_API const WOLFSSL_v3_ext_method* wolfSSL_X509V3_EXT_get(
+                                                    WOLFSSL_X509_EXTENSION* ex);
+WOLFSSL_API void* wolfSSL_X509V3_EXT_d2i(WOLFSSL_X509_EXTENSION* ex);
+WOLFSSL_API char* wolfSSL_i2s_ASN1_STRING(WOLFSSL_v3_ext_method *method,
+                                          const WOLFSSL_ASN1_STRING *s);
+WOLFSSL_API int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out,
+        WOLFSSL_X509_EXTENSION *ext, unsigned long flag, int indent);
+
+#define BASIC_CONSTRAINTS_free    wolfSSL_BASIC_CONSTRAINTS_free
+#define AUTHORITY_KEYID_free      wolfSSL_AUTHORITY_KEYID_free
+#define SSL_CTX_get_cert_store(x) wolfSSL_CTX_get_cert_store ((WOLFSSL_CTX*) (x))
+#define ASN1_INTEGER              WOLFSSL_ASN1_INTEGER
+#define ASN1_OCTET_STRING         WOLFSSL_ASN1_STRING
+#define X509V3_EXT_get            wolfSSL_X509V3_EXT_get
+#define X509V3_EXT_d2i            wolfSSL_X509V3_EXT_d2i
+#define i2s_ASN1_OCTET_STRING     wolfSSL_i2s_ASN1_STRING
+#define X509V3_EXT_print          wolfSSL_X509V3_EXT_print
 
 #ifdef  __cplusplus
 }

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -168,6 +168,7 @@ enum
     NID_info_access = 69,
     NID_sinfo_access = 79,      /* id-pe 11 */
     NID_name_constraints = 144, /* 2.5.29.30 */
+    NID_crl_distribution_points = 145, /* 2.5.29.31 */
     NID_certificate_policies = 146,
     NID_policy_mappings = 147,
     NID_policy_constraints = 150,


### PR DESCRIPTION
Adding openssl API compatibility for:
* GENERAL_NAMES_free
* i2a_ASN1_OBJECT
* PKCS5_PBKDF2_HMAC
* X509_get_ext_by_NID
* X509V3_EXT_print
* ASN1_STRING_print
* GENERAL_NAME_free
* X509_EXTENSION_get_critical
* X509_EXTENSION_get_object
* X509_get_ext
* X509V3_EXT_d2i