### PR TITLE
Fix build warnings while compiling wolfssl under esp-idf

### DIFF
--- a/IDE/Espressif/ESP-IDF/dummy_config_h
+++ b/IDE/Espressif/ESP-IDF/dummy_config_h
@@ -1,0 +1,24 @@
+/* config.h - dummy
+ *
+ * Copyright (C) 2006-2019 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef _CONFIG_H_
+#define _CONFIG_H_
+#endif

--- a/IDE/Espressif/ESP-IDF/setup.sh
+++ b/IDE/Espressif/ESP-IDF/setup.sh
@@ -58,6 +58,7 @@ ${CPDCMD} -r ./wolfssl/*.h ${WOLFSSLLIB_TRG_DIR}/wolfssl/
 ${CPDCMD} -r ./wolfssl/wolfcrypt ${WOLFSSLLIB_TRG_DIR}/wolfssl/
 # user_settings.h
 ${CPDCMD} -r ${WOLFSSL_ESPIDFDIR}/user_settings.h ${WOLFSSLLIB_TRG_DIR}/include/
+${CPDCMD} -r ${WOLFSSL_ESPIDFDIR}/dummy_config_h ${WOLFSSLLIB_TRG_DIR}/include/config.h
 
 # unit test app
 ${CPDCMD} -r ${WOLFSSL_ESPIDFDIR}/test/* ${WOLFSSLLIB_TRG_DIR}/test/

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -22,6 +22,7 @@
 
 #define __ESP32_CRYPT_H__
 
+#include "esp_idf_version.h"
 #include "esp_types.h"
 #include "esp_log.h"
 
@@ -38,7 +39,11 @@
 #include "soc/hwcrypto_reg.h"
 #include "soc/cpu.h"
 #include "driver/periph_ctrl.h"
+#if ESP_IDF_VERSION_MAJOR >= 4 && ESP_IDF_VERSION_MINOR >= 1
+#include <esp32/rom/ets_sys.h>
+#else
 #include <rom/ets_sys.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,7 +55,11 @@ int esp_CryptHwMutexUnLock(wolfSSL_Mutex* mutex);
 
 #ifndef NO_AES
 
+#if ESP_IDF_VERSION_MAJOR >= 4 && ESP_IDF_VERSION_MINOR >= 1
+#include "esp32/rom/aes.h"
+#else
 #include "rom/aes.h"
+#endif
 
 typedef enum tagES32_AES_PROCESS {
     ESP32_AES_LOCKHW = 1,
@@ -80,8 +89,11 @@ uint64_t  wc_esp32elapsedTime();
 
 /* RAW hash function APIs are not implemented with esp32 hardware acceleration*/
 #define WOLFSSL_NO_HASH_RAW
-
+#if ESP_IDF_VERSION_MAJOR >= 4 && ESP_IDF_VERSION_MINOR >= 1
+#include "esp32/rom/sha.h"
+#else
 #include "rom/sha.h"
+#endif
 
 typedef enum {
     ESP32_SHA_INIT = 0,


### PR DESCRIPTION
For the latest esp-idf commites aa087667d.
Copying config.h as a dummy since build system now sets HAVE_CONFIG_H macro definition
rom/sha.h, rom/aes.h and rom/ets_sys.h obsolete, uses esp32/rom/*.h