### PR TITLE
Fixes for fuzz testing

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -8698,7 +8698,10 @@ static int TLSX_EarlyData_Parse(WOLFSSL* ssl, byte* input, word16 length,
         if (length != 0)
             return BUFFER_E;
 
-        return TLSX_EarlyData_Use(ssl, 0);
+        if (ssl->earlyData == expecting_early_data)
+            return TLSX_EarlyData_Use(ssl, 0);
+        ssl->earlyData = early_data_ext;
+        return 0;
     }
     if (msgType == encrypted_extensions) {
         if (length != 0)

--- a/tests/api.c
+++ b/tests/api.c
@@ -2026,6 +2026,12 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
         ctx = wolfSSL_CTX_new(method);
     }
 
+#if defined(HAVE_SESSION_TICKET) && defined(HAVE_CHACHA) && \
+                                    defined(HAVE_POLY1305)
+    TicketInit();
+    wolfSSL_CTX_set_TicketEncCb(ctx, myTicketEncCb);
+#endif
+
 #if defined(USE_WINDOWS_API)
     port = ((func_args*)args)->signal->port;
 #elif defined(NO_MAIN_DRIVER) && !defined(WOLFSSL_SNIFFER) && \
@@ -2186,6 +2192,11 @@ done:
 #if defined(NO_MAIN_DRIVER) && defined(HAVE_ECC) && defined(FP_ECC) \
                             && defined(HAVE_THREAD_LS)
     wc_ecc_fp_free();  /* free per thread cache */
+#endif
+
+#if defined(HAVE_SESSION_TICKET) && defined(HAVE_CHACHA) && \
+                                    defined(HAVE_POLY1305)
+    TicketCleanup();
 #endif
 
 #ifndef WOLFSSL_TIRTOS
@@ -21905,6 +21916,7 @@ static void test_wolfSSL_SESSION(void)
     tcp_ready ready;
     func_args server_args;
     THREAD_TYPE serverThread;
+    char msg[80];
 
     printf(testingFmt, "wolfSSL_SESSION()");
     AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
@@ -21953,6 +21965,10 @@ static void test_wolfSSL_SESSION(void)
         }
     } while (ret != SSL_SUCCESS && err == WC_PENDING_E);
     AssertIntEQ(ret, SSL_SUCCESS);
+
+    AssertIntEQ(wolfSSL_write(ssl, "GET", 3), 3);
+    AssertIntEQ(wolfSSL_read(ssl, msg, sizeof(msg)), 23);
+
     sess = wolfSSL_get_session(ssl);
     wolfSSL_shutdown(ssl);
     wolfSSL_free(ssl);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1156,7 +1156,19 @@ enum {
 #endif
 #define MAX_DHKEY_SZ (WOLFSSL_MAX_DHKEY_BITS / 8)
 
+#ifndef MAX_PSK_ID_LEN
+    /* max psk identity/hint supported */
+    #if defined(WOLFSSL_TLS13)
+        #define MAX_PSK_ID_LEN 256
+    #else
+        #define MAX_PSK_ID_LEN 128
+    #endif
+#endif
 
+#ifndef MAX_EARLY_DATA_SZ
+    /* maximum early data size */
+    #define MAX_EARLY_DATA_SZ  4096
+#endif
 
 enum Misc {
     CIPHER_BYTE = 0x00,            /* Default ciphers */
@@ -1199,11 +1211,6 @@ enum Misc {
     HELLO_EXT_EXTMS = 0x0017,   /* ID for the extended master secret ext */
     SECRET_LEN      = WOLFSSL_MAX_MASTER_KEY_LENGTH,
                                 /* pre RSA and all master */
-#if defined(WOLFSSL_TLS13)
-    MAX_PSK_ID_LEN     = 256,  /* max psk identity/hint supported */
-#else
-    MAX_PSK_ID_LEN     = 128,  /* max psk identity/hint supported */
-#endif
 #if defined(WOLFSSL_MYSQL_COMPATIBLE) || \
     (defined(USE_FAST_MATH) && defined(FP_MAX_BITS) && FP_MAX_BITS > 8192)
 #ifndef NO_PSK
@@ -1260,7 +1267,6 @@ enum Misc {
     DEF_TICKET_NONCE_SZ = 1,   /* Default ticket nonce size */
     MAX_TICKET_NONCE_SZ = 8,   /* maximum ticket nonce size */
     MAX_LIFETIME   = 604800,   /* maximum ticket lifetime */
-    MAX_EARLY_DATA_SZ = 4096,  /* maximum early data size */
 
     RAN_LEN      = 32,         /* random length           */
     SEED_LEN     = RAN_LEN * 2, /* tls prf seed length    */
@@ -3738,6 +3744,7 @@ struct CertReqCtx {
 #ifdef WOLFSSL_EARLY_DATA
 typedef enum EarlyDataState {
     no_early_data,
+    early_data_ext,
     expecting_early_data,
     process_early_data,
     done_early_data


### PR DESCRIPTION
Changes
- Don't ignore decryption errors when doing TLS 1.3 and after Client
Finished.
- Put out an alert when TLS 1.3 decryption fails.
- Properly ignore RSA pss_pss algorithms when checking for matching
cipher suite.
- Check X25519 public value before import in TLS v1.2-
- REcognise TLS 1.3 integrity-only cipher suites as not negotiable with
TLS 1.2-.
- Send decode_error alert when bad message data in CertificateVerify.
- Negotiate protocol version in TLS 1.3 using extension and keep
decision when using TLS 1.2 parsing.
- Must have a signature algorithms extension in TLS 1.3 if not doing
PSK.
- More TLS v1.3 alerts.
- MAX_PSK_ID_LEN needs to be modified at compile time for tlsfuzzer to
work.
- change the good ecc public key to be a real public key when compiled
to check imported public keys
- Fix early data in TLS 1.3
- Make max early data size able to be changed at compile time - default
4K but fuzzer sends 16K
- Fix HRR, PSK and message hashes: Don't initialize hashes in parsing
ClientHello as need to keep hash state from previous ClientHello and
HelloRetryRequest