### PR TITLE
macro guards for re-defines

### DIFF
--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -130,7 +130,7 @@ enum {
 };
 
 
-typedef struct Aes {
+struct Aes {
     /* AESNI needs key first, rounds 2nd, not sure why yet */
     ALIGN16 word32 key[60];
     word32  rounds;
@@ -202,7 +202,12 @@ typedef struct Aes {
     aes_context_t ctx;
 #endif
     void*  heap; /* memory hint to use */
-} Aes;
+};
+
+#ifndef WC_AES_TYPE_DEFINED
+    typedef struct Aes Aes;
+    #define WC_AES_TYPE_DEFINED
+#endif
 
 #ifdef WOLFSSL_AES_XTS
 typedef struct XtsAes {

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -41,7 +41,11 @@
 #if !defined(HAVE_FIPS) || \
     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))
 
-typedef struct Cmac {
+#ifndef WC_CMAC_TYPE_DEFINED
+    typedef struct Cmac Cmac;
+    #define WC_CMAC_TYPE_DEFINED
+#endif
+struct Cmac {
     Aes aes;
     byte buffer[AES_BLOCK_SIZE]; /* partially stored block */
     byte digest[AES_BLOCK_SIZE]; /* running digest */
@@ -49,7 +53,8 @@ typedef struct Cmac {
     byte k2[AES_BLOCK_SIZE];
     word32 bufferSz;
     word32 totalSz;
-} Cmac;
+};
+
 
 
 typedef enum CmacType {

--- a/wolfssl/wolfcrypt/des3.h
+++ b/wolfssl/wolfcrypt/des3.h
@@ -95,7 +95,7 @@ typedef struct Des {
 
 
 /* DES3 encryption and decryption */
-typedef struct Des3 {
+struct Des3 {
     word32 key[3][DES_KS_SIZE];
     word32 reg[DES_BLOCK_SIZE / sizeof(word32)];      /* for CBC mode */
     word32 tmp[DES_BLOCK_SIZE / sizeof(word32)];      /* same         */
@@ -109,7 +109,12 @@ typedef struct Des3 {
     void*  devCtx;
 #endif
     void* heap;
-} Des3;
+};
+
+#ifndef WC_DES3_TYPE_DEFINED
+    typedef struct Des3 Des3;
+    #define WC_DES3_TYPE_DEFINED
+#endif
 #endif /* HAVE_FIPS */
 
 

--- a/wolfssl/wolfcrypt/dh.h
+++ b/wolfssl/wolfcrypt/dh.h
@@ -57,14 +57,18 @@ typedef struct DhParams {
 } DhParams;
 
 /* Diffie-Hellman Key */
-typedef struct DhKey {
+struct DhKey {
     mp_int p, g, q;                         /* group parameters  */
     void* heap;
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
 #endif
-} DhKey;
+};
 
+#ifndef WC_DH_TYPE_DEFINED
+    typedef struct DhKey DhKey;
+    #define WC_DH_TYPE_DEFINED
+#endif
 
 #ifdef HAVE_FFDHE_2048
 WOLFSSL_API const DhParams* wc_Dh_ffdhe2048_Get(void);

--- a/wolfssl/wolfcrypt/hmac.h
+++ b/wolfssl/wolfcrypt/hmac.h
@@ -143,7 +143,7 @@ typedef union {
 } Hash;
 
 /* Hmac digest */
-typedef struct Hmac {
+struct Hmac {
     Hash    hash;
     word32  ipad[WC_HMAC_BLOCK_SIZE  / sizeof(word32)];  /* same block size all*/
     word32  opad[WC_HMAC_BLOCK_SIZE  / sizeof(word32)];
@@ -166,7 +166,13 @@ typedef struct Hmac {
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLF_CRYPTO_CB)
     word16  keyLen;          /* hmac key length (key in ipad) */
 #endif
-} Hmac;
+};
+
+#ifndef WC_HMAC_TYPE_DEFINED
+    typedef struct Hmac Hmac;
+    #define WC_HMAC_TYPE_DEFINED
+#endif
+
 
 #endif /* HAVE_FIPS */
 

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -100,8 +100,9 @@ enum {
     #include "wolfssl/wolfcrypt/port/caam/wolfcaam_sha.h"
 
 #else
+
 /* Sha digest */
-typedef struct wc_Sha {
+struct wc_Sha {
 #ifdef FREESCALE_LTC_SHA
         ltc_hash_ctx_t ctx;
 #elif defined(STM32_HASH)
@@ -135,7 +136,12 @@ typedef struct wc_Sha {
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
     word32 flags; /* enum wc_HashFlags in hash.h */
 #endif
-} wc_Sha;
+};
+
+#ifndef WC_SHA_TYPE_DEFINED
+    typedef struct wc_Sha wc_Sha;
+    #define WC_SHA_TYPE_DEFINED
+#endif
 
 #endif /* WOLFSSL_TI_HASH */
 

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -124,8 +124,9 @@ enum {
 #elif defined(WOLFSSL_AFALG_HASH)
     #include "wolfssl/wolfcrypt/port/af_alg/afalg_hash.h"
 #else
+
 /* wc_Sha256 digest */
-typedef struct wc_Sha256 {
+struct wc_Sha256 {
 #ifdef FREESCALE_LTC_SHA
     ltc_hash_ctx_t ctx;
 #elif defined(STM32_HASH)
@@ -168,7 +169,12 @@ typedef struct wc_Sha256 {
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
     word32 flags; /* enum wc_HashFlags in hash.h */
 #endif
-} wc_Sha256;
+};
+
+#ifndef WC_SHA256_TYPE_DEFINED
+    typedef struct wc_Sha256 wc_Sha256;
+    #define WC_SHA256_TYPE_DEFINED
+#endif
 
 #endif
 
@@ -215,7 +221,10 @@ enum {
 };
 
 
-typedef wc_Sha256 wc_Sha224;
+#ifndef WC_SHA224_TYPE_DEFINED
+    typedef struct wc_Sha256 wc_Sha224;
+    #define WC_SHA224_TYPE_DEFINED
+#endif
 #endif /* HAVE_FIPS */
 
 WOLFSSL_API int wc_InitSha224(wc_Sha224*);

--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -87,8 +87,9 @@ enum {
 #elif defined(WOLFSSL_AFALG_XILINX_SHA3)
     #include <wolfssl/wolfcrypt/port/af_alg/afalg_hash.h>
 #else
+
 /* Sha3 digest */
-typedef struct Sha3 {
+struct Sha3 {
     /* State data that is processed for each block. */
     word64 s[25];
     /* Unprocessed message data. */
@@ -104,7 +105,13 @@ typedef struct Sha3 {
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
     word32 flags; /* enum wc_HashFlags in hash.h */
 #endif
-} wc_Sha3;
+};
+
+#ifndef WC_SHA3_TYPE_DEFINED
+    typedef struct wc_Sha3 Sha3;
+    #define WC_SHA3_TYPE_DEFINED
+#endif
+
 #endif
 
 

--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -108,7 +108,7 @@ struct Sha3 {
 };
 
 #ifndef WC_SHA3_TYPE_DEFINED
-    typedef struct wc_Sha3 Sha3;
+    typedef struct Sha3 wc_Sha3;
     #define WC_SHA3_TYPE_DEFINED
 #endif
 

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -113,7 +113,7 @@ enum {
     #include "wolfssl/wolfcrypt/port/caam/wolfcaam_sha.h"
 #else
 /* wc_Sha512 digest */
-typedef struct wc_Sha512 {
+struct wc_Sha512 {
     word64  digest[WC_SHA512_DIGEST_SIZE / sizeof(word64)];
     word64  buffer[WC_SHA512_BLOCK_SIZE  / sizeof(word64)];
     word32  buffLen;   /* in bytes          */
@@ -136,7 +136,12 @@ typedef struct wc_Sha512 {
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
     word32 flags; /* enum wc_HashFlags in hash.h */
 #endif
-} wc_Sha512;
+};
+
+#ifndef WC_SHA512_TYPE_DEFINED
+    typedef struct wc_Sha512 wc_Sha512;
+    #define WC_SHA512_TYPE_DEFINED
+#endif
 #endif
 
 #endif /* HAVE_FIPS */
@@ -191,7 +196,10 @@ enum {
 };
 
 
-typedef wc_Sha512 wc_Sha384;
+#ifndef WC_SHA384_TYPE_DEFINED
+    typedef struct wc_Sha512 wc_Sha384;
+    #define WC_SHA384_TYPE_DEFINED
+#endif
 #endif /* HAVE_FIPS */
 
 WOLFSSL_API int wc_InitSha384(wc_Sha384*);


### PR DESCRIPTION
Avoid redefinition warnings with new OE's in the future. ZD 5643