### PR TITLE
Fix for verify callback override not adding to trusted CA list

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -2346,7 +2346,11 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     if (!usePsk && !useAnon && !useVerifyCb && !myVerifyFail) {
     #ifndef TEST_LOAD_BUFFER
-        if (wolfSSL_CTX_load_verify_locations(ctx, verifyCert, 0)
+        unsigned int verify_flags = 0;
+    #ifdef TEST_BEFORE_DATE
+        verify_flags |= WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY;
+    #endif
+        if (wolfSSL_CTX_load_verify_locations_ex(ctx, verifyCert, 0, verify_flags)
                                                            != WOLFSSL_SUCCESS) {
             wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("can't load ca file, Please run from wolfSSL home dir");
@@ -2358,7 +2362,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     #ifdef HAVE_ECC
         /* load ecc verify too, echoserver uses it by default w/ ecc */
         #ifndef TEST_LOAD_BUFFER
-        if (wolfSSL_CTX_load_verify_locations(ctx, eccCertFile, 0)
+        if (wolfSSL_CTX_load_verify_locations_ex(ctx, eccCertFile, 0, verify_flags)
                                                            != WOLFSSL_SUCCESS) {
             wolfSSL_CTX_free(ctx); ctx = NULL;
             err_sys("can't load ecc ca file, Please run from wolfSSL home dir");

--- a/src/internal.c
+++ b/src/internal.c
@@ -9547,7 +9547,8 @@ static int ProcessPeerCertParse(WOLFSSL* ssl, ProcPeerCertArgs* args,
 
     /* Parse Certificate */
     ret = ParseCertRelative(args->dCert, certType, verify, ssl->ctx->cm);
-    if (ret == 0) {
+    /* perform below checks for date failure cases */
+    if (ret == 0 || ret == ASN_BEFORE_DATE_E || ret == ASN_AFTER_DATE_E) {
         /* get subject and determine if already loaded */
     #ifndef NO_SKID
         if (args->dCert->extAuthKeyIdSet)
@@ -9963,39 +9964,13 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             "not adding as CA");
                     }
                     else if (ret == 0) {
-                        buffer* cert = &args->certs[args->certIdx];
-
-                        /* Is valid CA */
-                    #if defined(SESSION_CERTS) && defined(WOLFSSL_ALT_CERT_CHAINS)
-                        /* if using alternate chain, store the cert used */
-                        if (ssl->options.usingAltCertChain) {
-                            AddSessionCertToChain(&ssl->session.altChain,
-                                cert->buffer, cert->length);
-                        }
-                    #endif /* SESSION_CERTS && WOLFSSL_ALT_CERT_CHAINS */
                     #ifdef OPENSSL_EXTRA
                         if (args->certIdx > args->untrustedDepth) {
                             args->untrustedDepth = (char)args->certIdx + 1;
                         }
                     #endif
 
-                        if (!alreadySigner) {
-                            DerBuffer* add = NULL;
-                            ret = AllocDer(&add, cert->length, CA_TYPE, ssl->heap);
-                            if (ret < 0)
-                                goto exit_ppc;
-
-                            XMEMCPY(add->buffer, cert->buffer, cert->length);
-
-                            /* CA already verified above in ParseCertRelative */
-                            WOLFSSL_MSG("Adding CA from chain");
-                            ret = AddCA(ssl->ctx->cm, &add, WOLFSSL_CHAIN_CA,
-                                NO_VERIFY);
-                            if (ret == WOLFSSL_SUCCESS) {
-                                ret = 0;
-                            }
-                        }
-                        else {
+                        if (alreadySigner) {
                             WOLFSSL_MSG("Verified CA from chain and already had it");
                         }
                     }
@@ -10076,6 +10051,36 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
                     /* Do verify callback */
                     ret = DoVerifyCallback(ssl, ret, args);
+
+                    /* If valid CA then add to Certificate Manager */
+                    if (ret == 0) {
+                        buffer* cert = &args->certs[args->certIdx];
+
+                        /* Is valid CA */
+                    #if defined(SESSION_CERTS) && defined(WOLFSSL_ALT_CERT_CHAINS)
+                        /* if using alternate chain, store the cert used */
+                        if (ssl->options.usingAltCertChain) {
+                            AddSessionCertToChain(&ssl->session.altChain,
+                                cert->buffer, cert->length);
+                        }
+                    #endif /* SESSION_CERTS && WOLFSSL_ALT_CERT_CHAINS */
+                        if (!alreadySigner) {
+                            DerBuffer* add = NULL;
+                            ret = AllocDer(&add, cert->length, CA_TYPE, ssl->heap);
+                            if (ret < 0)
+                                goto exit_ppc;
+
+                            XMEMCPY(add->buffer, cert->buffer, cert->length);
+
+                            /* CA already verified above in ParseCertRelative */
+                            WOLFSSL_MSG("Adding CA from chain");
+                            ret = AddCA(ssl->ctx->cm, &add, WOLFSSL_CHAIN_CA,
+                                NO_VERIFY);
+                            if (ret == WOLFSSL_SUCCESS) {
+                                ret = 0;
+                            }
+                        }
+                    }
 
                     /* Handle error codes */
                     if (ret != 0 && args->lastErr == 0) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -10053,7 +10053,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     ret = DoVerifyCallback(ssl, ret, args);
 
                     /* If valid CA then add to Certificate Manager */
-                    if (ret == 0) {
+                    if (ret == 0 && args->dCert->isCA && !ssl->options.verifyNone) {
                         buffer* cert = &args->certs[args->certIdx];
 
                         /* Is valid CA */

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -642,7 +642,11 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
 
 /* Map default time functions */
 #if !defined(XTIME) && !defined(TIME_OVERRIDES) && !defined(USER_TIME)
+    #ifdef TEST_BEFORE_DATE
+    #define XTIME(tl)       (946681200UL) /* Jan 1, 2000 */
+    #else
     #define XTIME(tl)       time((tl))
+    #endif
 #endif
 #if !defined(XGMTIME) && !defined(TIME_OVERRIDES)
     #if defined(WOLFSSL_GMTIME) || !defined(HAVE_GMTIME_R) || defined(WOLF_C99)


### PR DESCRIPTION
Fix for verify callback override of intermediate CA provided by peer not being added to trusted CA list.

Feature: Added support for testing date override at build-time using `TEST_BEFORE_DATE`.

```
./examples/server/server -H overrideDateErr -A ./certs/ca-cert.pem -k ./certs/server-key.pem -c ./certs/intermediate/server-chain.pem &

./examples/client/client -D -A ./certs/ca-cert.pem -k ./certs/client-key.pem -c ./certs/intermediate/client-chain.pem
```

ZD 5658