### PR TITLE
Fix for TLS v1.3 and PK callbacks

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3401,7 +3401,11 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
 #endif
 
     if (ssl->buffers.certificate && ssl->buffers.certificate->buffer &&
-        ssl->buffers.key && ssl->buffers.key->buffer) {
+        ((ssl->buffers.key && ssl->buffers.key->buffer)
+        #ifdef HAVE_PK_CALLBACKS
+            || wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)
+        #endif
+    )) {
 #ifndef WOLFSSL_TLS13_DRAFT_18
         if (PickHashSigAlgo(ssl, peerSuites.hashSigAlgo,
                                                peerSuites.hashSigAlgoSz) != 0) {
@@ -3410,8 +3414,9 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
 #endif
         ssl->options.sendVerify = SEND_CERT;
     }
-    else
+    else {
         ssl->options.sendVerify = SEND_BLANK_CERT;
+    }
 
     /* This message is always encrypted so add encryption padding. */
     *inOutIdx += ssl->keys.padSz;


### PR DESCRIPTION
Reproduce issue with client not sending certificate using:

```c
./configure --enable-tls13 CFLAGS="-DTEST_PK_PRIVKEY -DHAVE_PK_CALLBACKS"
./examples/server/server -P -v 4
./examples/client/client -P -v 4
```

ZD 5645