### PR TITLE
Fixes for using Keil with single precision math.

### DIFF
--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -263,7 +263,7 @@ static int ed25519_sign_msg(const byte* in, word32 inLen, byte* out,
 int wc_ed25519_sign_msg(const byte* in, word32 inLen, byte* out,
                         word32 *outLen, ed25519_key* key)
 {
-    return ed25519_sign_msg(in, inLen, out, outLen, key, Ed25519, NULL, 0);
+    return ed25519_sign_msg(in, inLen, out, outLen, key, (byte)Ed25519, NULL, 0);
 }
 
 /*
@@ -439,8 +439,8 @@ static int ed25519_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
 int wc_ed25519_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
                           word32 msgLen, int* res, ed25519_key* key)
 {
-    return ed25519_verify_msg(sig, sigLen, msg, msgLen, res, key, Ed25519, NULL,
-                                                                             0);
+    return ed25519_verify_msg(sig, sigLen, msg, msgLen, res, key, (byte)Ed25519,
+                                                                       NULL, 0);
 }
 
 /*

--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -50,6 +50,10 @@
 #define __asm__        asm
 #define __volatile__   volatile
 #endif /* __IAR_SYSTEMS_ICC__ */
+#ifdef __KEIL__
+#define __asm__        __asm
+#define __volatile__   volatile
+#endif
 
 #ifdef WOLFSSL_SP_ARM_CORTEX_M_ASM
 #if defined(WOLFSSL_HAVE_SP_RSA) || defined(WOLFSSL_HAVE_SP_DH)

--- a/wolfssl/wolfcrypt/sp.h
+++ b/wolfssl/wolfcrypt/sp.h
@@ -37,7 +37,7 @@
 
 #if defined(_MSC_VER)
     #define SP_NOINLINE __declspec(noinline)
-#elif defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__)
+#elif defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__) || defined(__KEIL__)
     #define SP_NOINLINE __attribute__((noinline))
 #else
     #define SP_NOINLINE

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -205,14 +205,17 @@
     #endif
 
     /* GCC 7 has new switch() fall-through detection */
+    /* default to FALL_THROUGH stub */
+    #ifndef FALL_THROUGH
+    #define FALL_THROUGH
+
     #if defined(__GNUC__)
         #if ((__GNUC__ > 7) || ((__GNUC__ == 7) && (__GNUC_MINOR__ >= 1)))
-            #define FALL_THROUGH __attribute__ ((fallthrough))
+            #undef  FALL_THROUGH
+            #define FALL_THROUGH __attribute__ ((fallthrough));
         #endif
     #endif
-    #ifndef FALL_THROUGH
-        #define FALL_THROUGH
-    #endif
+    #endif /* FALL_THROUGH */
 
     /* Micrium will use Visual Studio for compilation but not the Win32 API */
     #if defined(_WIN32) && !defined(MICRIUM) && !defined(FREERTOS) && \


### PR DESCRIPTION
Various compiler warning cleanups. Tested with Keil ARM v6.

ZD 5142
Fixes https://github.com/wolfSSL/wolfssl/issues/2473