### PR TITLE
Improvements to SHA-1, SHA-256 and MD5 performance

### DIFF
--- a/IDE/ROWLEY-CROSSWORKS-ARM/kinetis_hw.c
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/kinetis_hw.c
@@ -89,7 +89,6 @@
 
 /* Note: You will also need to update the UART clock gate in hw_uart_init (SIM_SCGC1_UART5_MASK) */
 /* Note: TWR-K60 is UART3, PTC17 */
-/* Note: FRDM-K64 is UART4, PTE24 */
 /* Note: FRDM-K64 is UART4, PTE24 or UART0 PTB17 for OpenOCD  (SIM_SCGC4_UART0_MASK)*/
 /* Note: TWR-K64 is UART5, PTE8 */
 /* Note: FRDM-K82F is LPUART0 A2, LPUART4 PTC15 */

--- a/IDE/ROWLEY-CROSSWORKS-ARM/test_main.c
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/test_main.c
@@ -65,7 +65,7 @@ void main(void)
         test_num++;
     } while(args.return_code == 0);
 
-    /*Print this again for redundancy*/
+    /* Print this again for redundancy */
     #ifdef WOLFSSL_FRDM_K64_JENKINS
         printf("\n&&&&&&&&&&&&&& done &&&&&&&&&&&&&\n");
         delay_us(1000000);

--- a/IDE/ROWLEY-CROSSWORKS-ARM/user_settings.h
+++ b/IDE/ROWLEY-CROSSWORKS-ARM/user_settings.h
@@ -208,6 +208,7 @@ extern "C" {
 /* MD5 */
 #undef  NO_MD5
 #if 1
+#else
     #define NO_MD5
 #endif
 

--- a/wolfcrypt/src/md5.c
+++ b/wolfcrypt/src/md5.c
@@ -154,13 +154,7 @@ static int Transform_Len(wc_Md5* md5, const byte* data, word32 len)
 #define HAVE_MD5_CUST_API
 #else
 #define NEED_SOFT_MD5
-
 #endif /* End Hardware Acceleration */
-
-#ifndef WC_MD5_DATA_ALIGNMENT
-    /* default to 32-bit alignement */
-    #define WC_MD5_DATA_ALIGNMENT 4
-#endif
 
 #ifdef NEED_SOFT_MD5
 

--- a/wolfcrypt/src/md5.c
+++ b/wolfcrypt/src/md5.c
@@ -379,8 +379,8 @@ int wc_Md5Update(wc_Md5* md5, const byte* data, word32 len)
     while (len >= WC_MD5_BLOCK_SIZE) {
         /* optimization to avoid memcpy if data pointer is properly aligned */
         /* Big Endian requires byte swap, so can't use data directly */
-    #if defined(WC_MD5_DATA_ALIGNMENT) && !defined(BIG_ENDIAN_ORDER)
-        if (((size_t)data % WC_MD5_DATA_ALIGNMENT) == 0) {
+    #if defined(WC_HASH_DATA_ALIGNMENT) && !defined(BIG_ENDIAN_ORDER)
+        if (((size_t)data % WC_HASH_DATA_ALIGNMENT) == 0) {
             local32 = (word32*)data;
         }
         else

--- a/wolfcrypt/src/md5.c
+++ b/wolfcrypt/src/md5.c
@@ -311,8 +311,7 @@ int wc_Md5Update(wc_Md5* md5, const byte* data, word32 len)
 {
     int ret = 0;
     word32 blocksLen;
-    byte*   local;
-    word32* local32;
+    byte* local;
 
     if (md5 == NULL || (data == NULL && len > 0)) {
         return BAD_FUNC_ARG;
@@ -339,7 +338,6 @@ int wc_Md5Update(wc_Md5* md5, const byte* data, word32 len)
     AddLength(md5, len);
 
     local = (byte*)md5->buffer;
-    local32 = md5->buffer;
 
     /* process any remainder from previous operation */
     if (md5->buffLen > 0) {
@@ -352,7 +350,7 @@ int wc_Md5Update(wc_Md5* md5, const byte* data, word32 len)
 
         if (md5->buffLen == WC_MD5_BLOCK_SIZE) {
         #if defined(BIG_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
-            ByteReverseWords(local32, local32, WC_MD5_BLOCK_SIZE);
+            ByteReverseWords(md5->buffer, md5->buffer, WC_MD5_BLOCK_SIZE);
         #endif
 
             ret = XTRANSFORM(md5, (const byte*)local);
@@ -377,6 +375,7 @@ int wc_Md5Update(wc_Md5* md5, const byte* data, word32 len)
     }
 #else
     while (len >= WC_MD5_BLOCK_SIZE) {
+        word32* local32 = md5->buffer;
         /* optimization to avoid memcpy if data pointer is properly aligned */
         /* Big Endian requires byte swap, so can't use data directly */
     #if defined(WC_HASH_DATA_ALIGNMENT) && !defined(BIG_ENDIAN_ORDER)

--- a/wolfcrypt/src/port/Espressif/esp32_sha.c
+++ b/wolfcrypt/src/port/Espressif/esp32_sha.c
@@ -279,7 +279,7 @@ static void esp_digest_state(WC_ESP32SHA* ctx, byte* hash, enum SHA_TYPE sha_typ
 /*
 * sha1 process
 */
-int esp_sha_process(struct wc_Sha* sha)
+int esp_sha_process(struct wc_Sha* sha, const byte* data)
 {
     int ret = 0;
 
@@ -287,7 +287,7 @@ int esp_sha_process(struct wc_Sha* sha)
 
     word32 SHA_START_REG = SHA_1_START_REG;
 
-    esp_process_block(&sha->ctx, SHA_START_REG, sha->buffer,
+    esp_process_block(&sha->ctx, SHA_START_REG, (const word32*)data,
                                         WC_SHA_BLOCK_SIZE);
 
     ESP_LOGV(TAG, "leave esp_sha_process");
@@ -322,7 +322,7 @@ int esp_sha_digest_process(struct wc_Sha* sha, byte blockproc)
 /*
 * sha256 process
 */
-int esp_sha256_process(struct wc_Sha256* sha)
+int esp_sha256_process(struct wc_Sha256* sha, const byte* data)
 {
     int ret = 0;
     word32 SHA_START_REG = SHA_1_START_REG;
@@ -332,8 +332,8 @@ int esp_sha256_process(struct wc_Sha256* sha)
     /* start register offset */
     SHA_START_REG += (SHA2_256 << 4);
 
-    esp_process_block(&sha->ctx, SHA_START_REG, sha->buffer,
-                                            WC_SHA256_BLOCK_SIZE);
+    esp_process_block(&sha->ctx, SHA_START_REG, (const word32*)data,
+        WC_SHA256_BLOCK_SIZE);
 
     ESP_LOGV(TAG, "leave esp_sha256_process");
 

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -205,7 +205,9 @@
     #endif
 
     #define USE_SHA_SOFTWARE_IMPL /* Only for API's, actual transform is here */
-    #define XTRANSFORM(S,B)   Transform((S),(B))
+
+    #define XTRANSFORM(S,B)       Transform((S),(B))
+    #define XTRANSFORM_LEN(S,B,L) Transform_Len((S),(B),(L))
 
     static int InitSha(wc_Sha* sha)
     {
@@ -228,14 +230,29 @@
         return ret;
     }
 
-    static int Transform(wc_Sha* sha, byte* data)
+    static int Transform(wc_Sha* sha, const byte* data)
     {
         int ret = wolfSSL_CryptHwMutexLock();
         if(ret == 0) {
     #ifdef FREESCALE_MMCAU_CLASSIC_SHA
-            cau_sha1_hash_n(data, 1, sha->digest);
+            cau_sha1_hash_n((byte*)data, 1, sha->digest);
     #else
-            MMCAU_SHA1_HashN(data, 1, (uint32_t*)sha->digest);
+            MMCAU_SHA1_HashN((byte*)data, 1, (uint32_t*)sha->digest);
+    #endif
+            wolfSSL_CryptHwMutexUnLock();
+        }
+        return ret;
+    }
+
+    static int Transform_Len(wc_Sha* sha, const byte* data, word32 len)
+    {
+        int ret = wolfSSL_CryptHwMutexLock();
+        if(ret == 0) {
+    #ifdef FREESCALE_MMCAU_CLASSIC_SHA
+            cau_sha1_hash_n((byte*)data, len/WC_SHA_BLOCK_SIZE, sha->digest);
+    #else
+            MMCAU_SHA1_HashN((byte*)data, len/WC_SHA_BLOCK_SIZE,
+                (uint32_t*)sha->digest);
     #endif
             wolfSSL_CryptHwMutexUnLock();
         }
@@ -280,12 +297,12 @@
 
         return ret;
     }
-    
+
 #elif defined(WOLFSSL_RENESAS_TSIP_CRYPT) && \
     !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
-    
+
     /* implemented in wolfcrypt/src/port/Renesas/renesas_tsip_sha.c */
-    
+
 #else
     /* Software implementation */
     #define USE_SHA_SOFTWARE_IMPL
@@ -312,6 +329,10 @@
 
 #endif /* End Hardware Acceleration */
 
+#ifndef WC_SHA_DATA_ALIGNMENT
+    /* default to 32-bit alignement */
+    #define WC_SHA_DATA_ALIGNMENT 4
+#endif
 
 /* Software implementation */
 #ifdef USE_SHA_SOFTWARE_IMPL
@@ -327,7 +348,7 @@ static WC_INLINE void AddLength(wc_Sha* sha, word32 len)
 #ifndef XTRANSFORM
     #define XTRANSFORM(S,B)   Transform((S),(B))
 
-    #define blk0(i) (W[i] = sha->buffer[i])
+    #define blk0(i) (W[i] = *((word32*)&data[i*sizeof(word32)]))
     #define blk1(i) (W[(i)&15] = \
         rotlFixed(W[((i)+13)&15]^W[((i)+8)&15]^W[((i)+2)&15]^W[(i)&15],1))
 
@@ -356,7 +377,7 @@ static WC_INLINE void AddLength(wc_Sha* sha, word32 len)
     #define R4(v,w,x,y,z,i) (z)+= f4((w),(x),(y)) + blk1((i)) + 0xCA62C1D6+ \
         rotlFixed((v),5); (w) = rotlFixed((w),30);
 
-    static void Transform(wc_Sha* sha, byte* data)
+    static int Transform(wc_Sha* sha, const byte* data)
     {
         word32 W[WC_SHA_BLOCK_SIZE / sizeof(word32)];
 
@@ -431,6 +452,8 @@ static WC_INLINE void AddLength(wc_Sha* sha, word32 len)
         sha->digest[4] += e;
 
         (void)data; /* Not used */
+
+        return 0;
     }
 #endif /* !USE_CUSTOM_SHA_TRANSFORM */
 
@@ -466,16 +489,17 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
     return ret;
 }
 
+/* do block size increments/updates */
 int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
 {
+    int ret = 0;
+    word32 blocksLen;
     byte* local;
+    word32* local32;
 
-    if (sha == NULL ||(data == NULL && len > 0)) {
+    if (sha == NULL || (data == NULL && len > 0)) {
         return BAD_FUNC_ARG;
     }
-
-    /* do block size increments */
-    local = (byte*)sha->buffer;
 
 #ifdef WOLF_CRYPTO_CB
     if (sha->devId != INVALID_DEVID) {
@@ -497,37 +521,107 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
     if (sha->buffLen >= WC_SHA_BLOCK_SIZE)
         return BUFFER_E;
 
-    while (len) {
-        word32 add = min(len, WC_SHA_BLOCK_SIZE - sha->buffLen);
-        XMEMCPY(&local[sha->buffLen], data, add);
+    if (data == NULL && len == 0) {
+        /* valid, but do nothing */
+        return 0;
+    }
 
-        sha->buffLen += add;
-        data         += add;
-        len          -= add;
+    /* add length for final */
+    AddLength(sha, len);
+
+    local = (byte*)sha->buffer;
+    local32 = sha->buffer;
+
+    /* process any remainder from previous operation */
+    if (sha->buffLen > 0) {
+        blocksLen = min(len, WC_SHA_BLOCK_SIZE - sha->buffLen);
+        XMEMCPY(&local[sha->buffLen], data, blocksLen);
+
+        sha->buffLen += blocksLen;
+        data         += blocksLen;
+        len          -= blocksLen;
 
         if (sha->buffLen == WC_SHA_BLOCK_SIZE) {
-#if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
-            ByteReverseWords(sha->buffer, sha->buffer, WC_SHA_BLOCK_SIZE);
-#endif
-#if !defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-    defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
-            XTRANSFORM(sha, local);
-#else
-            if(sha->ctx.mode == ESP32_SHA_INIT){
+        #if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
+            ByteReverseWords(local32, local32, WC_SHA_BLOCK_SIZE);
+        #endif
+
+        #if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
+            !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+            if (sha->ctx.mode == ESP32_SHA_INIT) {
                 esp_sha_try_hw_lock(&sha->ctx);
             }
-            if(sha->ctx.mode == ESP32_SHA_SW){
-                XTRANSFORM(sha, local);
+            if (sha->ctx.mode == ESP32_SHA_SW {
+                ret = XTRANSFORM(sha, (const byte*)local);
             } else {
-                esp_sha_process(sha);
+                esp_sha_process(sha, (const byte*)local);
             }
-#endif
-            AddLength(sha, WC_SHA_BLOCK_SIZE);
+        #else
+            ret = XTRANSFORM(sha, (const byte*)local);
+        #endif
+            if (ret != 0)
+                return ret;
+
             sha->buffLen = 0;
         }
     }
 
-    return 0;
+    /* process blocks */
+#ifdef XTRANSFORM_LEN
+    /* get number of blocks */
+    /* 64-1 = 0x3F (~ Inverted = 0xFFFFFFC0) */
+    /* len (masked by 0xFFFFFFC0) returns block aligned length */
+    blocksLen = len & ~(WC_SHA_BLOCK_SIZE-1);
+    if (blocksLen > 0) {
+        /* Byte reversal performed in function if required. */
+        XTRANSFORM_LEN(sha, data, blocksLen);
+        data += blocksLen;
+        len  -= blocksLen;
+    }
+#else
+    while (len >= WC_SHA_BLOCK_SIZE) {
+        /* optimization to avoid memcpy if data pointer is properly aligned */
+        /* Little Endian requires byte swap, so can't use data directly */
+    #if defined(WC_SHA_DATA_ALIGNMENT) && !defined(LITTLE_ENDIAN_ORDER)
+        if (((size_t)data % WC_SHA_DATA_ALIGNMENT) == 0) {
+            local32 = (word32*)data;
+        }
+        else
+    #endif
+        {
+            XMEMCPY(local32, data, WC_SHA_BLOCK_SIZE);
+        }
+
+        data += WC_SHA_BLOCK_SIZE;
+        len  -= WC_SHA_BLOCK_SIZE;
+
+    #if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
+        ByteReverseWords(local32, local32, WC_SHA_BLOCK_SIZE);
+    #endif
+
+    #if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
+        !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+        if (sha->ctx.mode == ESP32_SHA_INIT){
+            esp_sha_try_hw_lock(&sha->ctx);
+        }
+        if (sha->ctx.mode == ESP32_SHA_SW){
+            ret = XTRANSFORM(sha, (const byte*)local32);
+        } else {
+            esp_sha_process(sha, (const byte*)local32);
+        }
+    #else
+        ret = XTRANSFORM(sha, (const byte*)local32);
+    #endif
+    }
+#endif /* XTRANSFORM_LEN */
+
+    /* save remainder */
+    if (len > 0) {
+        XMEMCPY(local, data, len);
+        sha->buffLen = len;
+    }
+
+    return ret;
 }
 
 int wc_ShaFinalRaw(wc_Sha* sha, byte* hash)
@@ -552,6 +646,7 @@ int wc_ShaFinalRaw(wc_Sha* sha, byte* hash)
 
 int wc_ShaFinal(wc_Sha* sha, byte* hash)
 {
+    int ret;
     byte* local;
 
     if (sha == NULL || hash == NULL) {
@@ -576,8 +671,6 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
-    AddLength(sha, sha->buffLen);  /* before adding pads */
-
     local[sha->buffLen++] = 0x80;  /* add 1 */
 
     /* pad with zeros */
@@ -585,22 +678,26 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
         XMEMSET(&local[sha->buffLen], 0, WC_SHA_BLOCK_SIZE - sha->buffLen);
         sha->buffLen += WC_SHA_BLOCK_SIZE - sha->buffLen;
 
-#if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
+    #if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
         ByteReverseWords(sha->buffer, sha->buffer, WC_SHA_BLOCK_SIZE);
-#endif
-#if !defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-    defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
-        XTRANSFORM(sha, local);
-#else
-        if(sha->ctx.mode == ESP32_SHA_INIT){
+    #endif
+
+    #if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
+        !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+        if (sha->ctx.mode == ESP32_SHA_INIT) {
             esp_sha_try_hw_lock(&sha->ctx);
         }
-        if(sha->ctx.mode == ESP32_SHA_SW){
-            XTRANSFORM(sha, local);
+        if (sha->ctx.mode == ESP32_SHA_SW) {
+            ret = XTRANSFORM(sha, (const byte*)local);
         } else {
-            esp_sha_process(sha);
+            esp_sha_process(sha, (const byte*)local);
         }
-#endif
+    #else
+        ret = XTRANSFORM(sha, (const byte*)local);
+    #endif
+        if (ret != 0)
+            return ret;
+
         sha->buffLen = 0;
     }
     XMEMSET(&local[sha->buffLen], 0, WC_SHA_PAD_SIZE - sha->buffLen);
@@ -625,26 +722,29 @@ int wc_ShaFinal(wc_Sha* sha, byte* hash)
                      2 * sizeof(word32));
 #endif
 
-#if !defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-    defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
-    XTRANSFORM(sha, local);
-#else
-    if(sha->ctx.mode == ESP32_SHA_INIT){
+#if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
+    !defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)
+    if (sha->ctx.mode == ESP32_SHA_INIT) {
         esp_sha_try_hw_lock(&sha->ctx);
     }
-    if(sha->ctx.mode == ESP32_SHA_SW){
-        XTRANSFORM(sha, local);
+    if (sha->ctx.mode == ESP32_SHA_SW) {
+        ret = XTRANSFORM(sha, (const byte*)local);
     } else {
         esp_sha_digest_process(sha, 1);
     }
+#else
+    ret = XTRANSFORM(sha, (const byte*)local);
 #endif
 
 #ifdef LITTLE_ENDIAN_ORDER
     ByteReverseWords(sha->digest, sha->digest, WC_SHA_DIGEST_SIZE);
 #endif
+
     XMEMCPY(hash, sha->digest, WC_SHA_DIGEST_SIZE);
 
-    return InitSha(sha); /* reset state */
+    (void)InitSha(sha); /* reset state */
+
+    return ret;
 }
 
 #endif /* USE_SHA_SOFTWARE_IMPL */
@@ -707,7 +807,7 @@ int wc_ShaGetHash(wc_Sha* sha, byte* hash)
         sha->ctx.mode = ESP32_SHA_SW;
 #endif
 
-    
+
     }
     return ret;
 }

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -489,7 +489,6 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
     int ret = 0;
     word32 blocksLen;
     byte* local;
-    word32* local32;
 
     if (sha == NULL || (data == NULL && len > 0)) {
         return BAD_FUNC_ARG;
@@ -524,7 +523,6 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
     AddLength(sha, len);
 
     local = (byte*)sha->buffer;
-    local32 = sha->buffer;
 
     /* process any remainder from previous operation */
     if (sha->buffLen > 0) {
@@ -537,7 +535,7 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
 
         if (sha->buffLen == WC_SHA_BLOCK_SIZE) {
         #if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
-            ByteReverseWords(local32, local32, WC_SHA_BLOCK_SIZE);
+            ByteReverseWords(sha->buffer, sha->buffer, WC_SHA_BLOCK_SIZE);
         #endif
 
         #if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \
@@ -574,6 +572,7 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
     }
 #else
     while (len >= WC_SHA_BLOCK_SIZE) {
+        word32* local32 = sha->buffer;
         /* optimization to avoid memcpy if data pointer is properly aligned */
         /* Little Endian requires byte swap, so can't use data directly */
     #if defined(WC_HASH_DATA_ALIGNMENT) && !defined(LITTLE_ENDIAN_ORDER)

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -576,8 +576,8 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
     while (len >= WC_SHA_BLOCK_SIZE) {
         /* optimization to avoid memcpy if data pointer is properly aligned */
         /* Little Endian requires byte swap, so can't use data directly */
-    #if defined(WC_SHA_DATA_ALIGNMENT) && !defined(LITTLE_ENDIAN_ORDER)
-        if (((size_t)data % WC_SHA_DATA_ALIGNMENT) == 0) {
+    #if defined(WC_HASH_DATA_ALIGNMENT) && !defined(LITTLE_ENDIAN_ORDER)
+        if (((size_t)data % WC_HASH_DATA_ALIGNMENT) == 0) {
             local32 = (word32*)data;
         }
         else

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -326,13 +326,7 @@
 
         return ret;
     }
-
 #endif /* End Hardware Acceleration */
-
-#ifndef WC_SHA_DATA_ALIGNMENT
-    /* default to 32-bit alignement */
-    #define WC_SHA_DATA_ALIGNMENT 4
-#endif
 
 /* Software implementation */
 #ifdef USE_SHA_SOFTWARE_IMPL

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -900,9 +900,9 @@ static int InitSha256(wc_Sha256* sha256)
                 /* optimization to avoid memcpy if data pointer is properly aligned */
                 /* Intel transform function requires use of sha256->buffer */
                 /* Little Endian requires byte swap, so can't use data directly */
-            #if defined(WC_SHA256_DATA_ALIGNMENT) && !defined(LITTLE_ENDIAN_ORDER) && \
+            #if defined(WC_HASH_DATA_ALIGNMENT) && !defined(LITTLE_ENDIAN_ORDER) && \
                 !defined(HAVE_INTEL_AVX1) && !defined(HAVE_INTEL_AVX2)
-                if (((size_t)data % WC_SHA256_DATA_ALIGNMENT) == 0) {
+                if (((size_t)data % WC_HASH_DATA_ALIGNMENT) == 0) {
                     local32 = (word32*)data;
                 }
                 else

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -201,9 +201,6 @@ static int InitSha256(wc_Sha256* sha256)
     /* in case intel instructions aren't available, plus we need the K[] global */
     #define NEED_SOFT_SHA256
 
-    /* requires 128-bit alignment */
-    #define WC_SHA256_DATA_ALIGNMENT 16
-
     /*****
     Intel AVX1/AVX2 Macro Control Structure
 
@@ -613,11 +610,6 @@ static int InitSha256(wc_Sha256* sha256)
         return ret;
     }
 #endif /* End Hardware Acceleration */
-
-#ifndef WC_SHA256_DATA_ALIGNMENT
-    /* default is 32-bit alignment required */
-    #define WC_SHA256_DATA_ALIGNMENT 4
-#endif
 
 #ifdef NEED_SOFT_SHA256
 

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -810,8 +810,7 @@ static int InitSha256(wc_Sha256* sha256)
     {
         int ret = 0;
         word32 blocksLen;
-        byte*   local;
-        word32* local32;
+        byte* local;
 
         if (sha256 == NULL || (data == NULL && len > 0)) {
             return BAD_FUNC_ARG;
@@ -831,7 +830,6 @@ static int InitSha256(wc_Sha256* sha256)
         AddLength(sha256, len);
 
         local = (byte*)sha256->buffer;
-        local32 = sha256->buffer;
 
         /* process any remainder from previous operation */
         if (sha256->buffLen > 0) {
@@ -848,7 +846,8 @@ static int InitSha256(wc_Sha256* sha256)
                 if (!IS_INTEL_AVX1(intel_flags) && !IS_INTEL_AVX2(intel_flags))
                 #endif
                 {
-                    ByteReverseWords(local32, local32, WC_SHA256_BLOCK_SIZE);
+                    ByteReverseWords(sha256->buffer, sha256->buffer,
+                        WC_SHA256_BLOCK_SIZE);
                 }
             #endif
 
@@ -897,6 +896,7 @@ static int InitSha256(wc_Sha256* sha256)
     #if !defined(XTRANSFORM_LEN) || defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2)
         {
             while (len >= WC_SHA256_BLOCK_SIZE) {
+                word32* local32 = sha256->buffer;
                 /* optimization to avoid memcpy if data pointer is properly aligned */
                 /* Intel transform function requires use of sha256->buffer */
                 /* Little Endian requires byte swap, so can't use data directly */

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -114,12 +114,12 @@ void esp_sha_hw_unlock( void );
 
 struct wc_Sha;
 int esp_sha_digest_process(struct wc_Sha* sha, byte bockprocess);
-int esp_sha_process(struct wc_Sha* sha);
+int esp_sha_process(struct wc_Sha* sha, const byte* data);
 
 #ifndef NO_SHA256
     struct wc_Sha256;
     int esp_sha256_digest_process(struct wc_Sha256* sha, byte bockprocess);
-    int esp_sha256_process(struct wc_Sha256* sha);
+    int esp_sha256_process(struct wc_Sha256* sha, const byte* data);
 #endif
 
 #if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
@@ -140,7 +140,7 @@ struct fp_int;
 int esp_mp_mul(struct fp_int* X, struct fp_int* Y, struct fp_int* Z);
 int esp_mp_exptmod(struct fp_int* G, struct fp_int* X, word32 Xbits, struct fp_int* P,
                                      struct fp_int* Y);
-int esp_mp_mulmod(struct fp_int* X, struct fp_int* Y, struct fp_int* M, 
+int esp_mp_mulmod(struct fp_int* X, struct fp_int* Y, struct fp_int* M,
                                      struct fp_int* Z);
 
 #endif /* NO_RSA || HAVE_ECC*/


### PR DESCRIPTION
* Added optional buffer alignment detection macro `WC_HASH_DATA_ALIGNMENT` to avoid memcpy.
* Added MD5 and SHA-1 support for `XTRANSFORM_LEN` to process blocks.
* Cleanups for consistency between algorithms and code commenting.
* Enhancement for NXP MMCAU to process more than one block at a time.
* Improved MMCAU performance: SHA-1 by 35%, SHA-256 by 20% and MD5 by 78%.

```
NXP K64 w/MMCAU after:

MD5                  8 MB took 1.000 seconds,    7.910 MB/s
SHA                  4 MB took 1.005 seconds,    3.644 MB/s
SHA-256              2 MB took 1.006 seconds,    2.306 MB/s

NXP K64 w/MMCAU before:
MD5                  4 MB took 1.004 seconds,    4.450 MB/s
SHA                  3 MB took 1.006 seconds,    2.670 MB/s
SHA-256              2 MB took 1.008 seconds,    1.913 MB/s
```

ZD 5713