### PR TITLE
Fixes from using cppcheck tool

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -2892,7 +2892,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     #endif
 #endif
 
-    if (doSTARTTLS) {
+    if (doSTARTTLS && starttlsProt != NULL) {
         if (XSTRNCMP(starttlsProt, "smtp", 4) == 0) {
             if (SMTP_Shutdown(ssl, wc_shutdown) != WOLFSSL_SUCCESS) {
                 wolfSSL_free(ssl); ssl = NULL;

--- a/mcapi/mcapi_test.c
+++ b/mcapi/mcapi_test.c
@@ -233,8 +233,13 @@ static int check_md5(void)
         ret = wc_Md5Final(&defMd5, defDigest);
     }
 
-    if (memcmp(mcDigest, defDigest, CRYPT_MD5_DIGEST_SIZE) != 0) {
-        printf("md5 final memcmp fialed\n");
+    if (ret != 0) {
+        printf("md5 failed\n");
+        return -1;
+    }
+
+    if (ret == 0 && memcmp(mcDigest, defDigest, CRYPT_MD5_DIGEST_SIZE) != 0) {
+        printf("md5 final memcmp failed\n");
         return -1;
     }
     printf("md5         mcapi test passed\n");

--- a/src/internal.c
+++ b/src/internal.c
@@ -19425,7 +19425,7 @@ static int GetDhPublicKey(WOLFSSL* ssl, const byte* input, word32 size,
     word16          length;
 #ifdef HAVE_FFDHE
     const DhParams* params = NULL;
-    int             group;
+    int             group = 0;
 #endif
 
     /* p */

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -1259,7 +1259,10 @@ static int LoadKeyFile(byte** keyBuf, word32* keyBufSz,
 
     file = XFOPEN(keyFile, "rb");
     if (file == XBADFILE) return -1;
-    if(XFSEEK(file, 0, XSEEK_END) != 0) return -1;
+    if(XFSEEK(file, 0, XSEEK_END) != 0) {
+        XFCLOSE(file);
+        return -1;
+    }
     fileSz = XFTELL(file);
     XREWIND(file);
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -1801,6 +1801,8 @@ static SNI* TLSX_SNI_New(byte type, const void* data, word16 size, void* heap)
 {
     SNI* sni = (SNI*)XMALLOC(sizeof(SNI), heap, DYNAMIC_TYPE_TLSX);
 
+    (void)heap;
+
     if (sni) {
         sni->type = type;
         sni->next = NULL;
@@ -4076,7 +4078,7 @@ int TLSX_SupportedFFDHE_Set(WOLFSSL* ssl)
     SupportedCurve* serverGroup;
     SupportedCurve* clientGroup;
     SupportedCurve* group;
-    const DhParams* params;
+    const DhParams* params = NULL;
     int found = 0;
 
     extension = TLSX_Find(ssl->extensions, TLSX_SUPPORTED_GROUPS);
@@ -4148,9 +4150,9 @@ int TLSX_SupportedFFDHE_Set(WOLFSSL* ssl)
                     params = wc_Dh_ffdhe8192_Get();
                     break;
             #endif
-                default:
-                    return BAD_FUNC_ARG;
             }
+            if (params == NULL)
+                return BAD_FUNC_ARG;
             if (params->p_len >= ssl->options.minDhKeySz &&
                                      params->p_len <= ssl->options.maxDhKeySz) {
                 break;
@@ -4983,6 +4985,8 @@ WOLFSSL_LOCAL SessionTicket* TLSX_SessionTicket_Create(word32 lifetime,
         ticket->lifetime = lifetime;
     }
 
+    (void)heap;
+
     return ticket;
 }
 WOLFSSL_LOCAL void TLSX_SessionTicket_Free(SessionTicket* ticket, void* heap)
@@ -5598,7 +5602,7 @@ int TLSX_UseQSHScheme(TLSX** extensions, word16 name, byte* pKey, word16 pkeySz,
 #define QSH_GET_SIZE TLSX_QSH_GetSize
 #define QSH_WRITE    TLSX_QSH_Write
 #else
-#define QSH_GET_SIZE(list)         0
+#define QSH_GET_SIZE(list, a)      0
 #define QSH_WRITE(a, b)            0
 #endif
 
@@ -9340,7 +9344,7 @@ static word32 GetEntropy(unsigned char* out, word32 num_bytes)
 #ifdef HAVE_QSH
 static int TLSX_CreateQSHKey(WOLFSSL* ssl, int type)
 {
-    int ret;
+    int ret = -1;
 
     (void)ssl;
 
@@ -9354,7 +9358,7 @@ static int TLSX_CreateQSHKey(WOLFSSL* ssl, int type)
 #endif
         default:
             WOLFSSL_MSG("Unknown type for creating NTRU key");
-            return -1;
+            break;
     }
 
     return ret;

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -2230,7 +2230,7 @@ int uIPReceive(WOLFSSL *ssl, char *buf, int sz, void *_ctx)
  */
 int uIPGenerateCookie(WOLFSSL* ssl, byte *buf, int sz, void *_ctx)
 {
-    uip_wolfssl_ctx *ctx = (uip_wolfssl_ctx *)ctx;
+    uip_wolfssl_ctx *ctx = (uip_wolfssl_ctx *)_ctx;
     byte token[32];
     byte digest[WC_SHA_DIGEST_SIZE];
     int  ret = 0;

--- a/swig/wolfssl_adds.c
+++ b/swig/wolfssl_adds.c
@@ -209,7 +209,7 @@ RsaKey* GetRsaPrivateKey(const char* keyFile)
         word32 idx = 0;
         XFILE  file = XFOPEN(keyFile, "rb");
 
-        if (file != XBADFILE)
+        if (file == XBADFILE)
         {
             free(key);
             return 0;

--- a/tests/api.c
+++ b/tests/api.c
@@ -5223,9 +5223,7 @@ static int test_wc_Md5Update (void)
     if (!flag) {
         a.input = "a";
         a.inLen = XSTRLEN(a.input);
-    }
 
-    if (!flag){
         ret = wc_Md5Update(&md5, (byte*)a.input, (word32)a.inLen);
         if (ret != 0) {
             flag = ret;
@@ -5435,9 +5433,7 @@ static int test_wc_ShaUpdate (void)
     if (!flag) {
         a.input = "a";
         a.inLen = XSTRLEN(a.input);
-    }
 
-    if (!flag) {
         ret = wc_ShaUpdate(&sha, (byte*)a.input, (word32)a.inLen);
         if (ret != 0) {
             flag = ret;
@@ -5645,9 +5641,7 @@ static int test_wc_Sha256Update (void)
     if (!flag) {
         a.input = "a";
         a.inLen = XSTRLEN(a.input);
-    }
 
-    if (!flag) {
         ret = wc_Sha256Update(&sha256, (byte*)a.input, (word32)a.inLen);
         if (ret != 0) {
             flag = ret;
@@ -5860,16 +5854,12 @@ static int test_wc_Sha512Update (void)
     if (!flag) {
         a.input = "a";
         a.inLen = XSTRLEN(a.input);
-    }
 
-    if (!flag) {
         ret = wc_Sha512Update(&sha512, (byte*)a.input, (word32)a.inLen);
         if (ret != 0) {
             flag = ret;
         }
-    }
 
-    if (!flag) {
         ret = wc_Sha512Final(&sha512, hash);
         if (ret != 0) {
             flag = ret;
@@ -6074,9 +6064,7 @@ static int test_wc_Sha384Update (void)
     if (!flag) {
         a.input = "a";
         a.inLen = XSTRLEN(a.input);
-    }
 
-    if (!flag) {
         ret = wc_Sha384Update(&sha384, (byte*)a.input, (word32)a.inLen);
         if (ret != 0) {
             flag = ret;
@@ -6287,9 +6275,7 @@ static int test_wc_Sha224Update (void)
     if (!flag) {
         a.input = "a";
         a.inLen = XSTRLEN(a.input);
-    }
 
-    if (!flag) {
         ret = wc_Sha224Update(&sha224, (byte*)a.input, (word32)a.inLen);
         if (ret != 0) {
             flag = ret;
@@ -6501,9 +6487,7 @@ static int test_wc_RipeMdUpdate (void)
     if (!flag) {
         a.input = "a";
         a.inLen = XSTRLEN(a.input);
-    }
 
-    if (!flag) {
         ret = wc_RipeMdUpdate(&ripemd, (byte*)a.input, (word32)a.inLen);
         if (ret != 0) {
             flag = ret;
@@ -12742,9 +12726,9 @@ static int test_wc_AesCcmEncryptDecrypt (void)
                                         sizeof(plainOut), iv, sizeof(iv),
                                         authTag, sizeof(authTag),
                                         authIn, sizeof(authIn));
-             }
-            if (XMEMCMP(plainOut, plainT, sizeof(plainT)) && ccmD == 0) {
-                ccmD = WOLFSSL_FATAL_ERROR;
+                if (XMEMCMP(plainOut, plainT, sizeof(plainT)) && ccmD == 0) {
+                    ccmD = WOLFSSL_FATAL_ERROR;
+                }
             }
         #endif
     }
@@ -18126,7 +18110,8 @@ static void test_wc_i2d_PKCS12(void)
 
     printf(testingFmt, "wc_i2d_PKCS12");
 
-    AssertNotNull(f = XFOPEN(p12_f, "rb"));
+    f =  XFOPEN(p12_f, "rb");
+    AssertNotNull(f);
     derSz = (int)XFREAD(der, 1, sizeof(der), f);
     AssertIntGT(derSz, 0);
     XFCLOSE(f);
@@ -18267,15 +18252,15 @@ static int test_wc_SignatureGetSize_rsa(void)
             #else
                 ret = WOLFSSL_FATAL_ERROR;
             #endif
-            if (ret == 0) {
-                ret = wc_InitRsaKey_ex(&rsa_key, HEAP_HINT, devId);
-                if (ret == 0) {
-                    ret = wc_RsaPrivateKeyDecode(tmp, &idx, &rsa_key,
-                        (word32)bytes);
-                }
-            }
         } else {
             ret = WOLFSSL_FATAL_ERROR;
+        }
+
+        if (ret == 0) {
+            ret = wc_InitRsaKey_ex(&rsa_key, HEAP_HINT, devId);
+        }
+        if (ret == 0) {
+            ret = wc_RsaPrivateKeyDecode(tmp, &idx, &rsa_key, (word32)bytes);
         }
 
         printf(testingFmt, "wc_SigntureGetSize_rsa()");

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -11210,6 +11210,8 @@ static int SetAKID(byte* output, word32 outSz,
     static const byte akid_oid[] = { 0x06, 0x03, 0x55, 0x1d, 0x23, 0x04 };
     static const byte akid_cs[] = { 0x80 };
 
+    (void)heap;
+
     if (output == NULL || input == NULL)
         return BAD_FUNC_ARG;
 
@@ -11347,6 +11349,8 @@ int EncodePolicyOID(byte *out, word32 *outSz, const char *in, void* heap)
     word32 val, idx = 0, nb_val;
     char *token, *str, *ptr;
     word32 len;
+
+    (void)heap;
 
     if (out == NULL || outSz == NULL || *outSz < 2 || in == NULL)
         return BAD_FUNC_ARG;
@@ -12167,6 +12171,7 @@ static int MakeSignature(CertSignCtx* certSignCtx, const byte* buffer, int sz,
     (void)eccKey;
     (void)ed25519Key;
     (void)rng;
+    (void)heap;
 
     switch (certSignCtx->state) {
     case CERTSIGN_STATE_BEGIN:

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4689,7 +4689,7 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
 int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
                      ecc_key* key, mp_int *r, mp_int *s)
 {
-   int    err;
+   int    err = 0;
 #ifndef WOLFSSL_SP_MATH
    mp_int* e;
 #if (!defined(WOLFSSL_ASYNC_CRYPT) || !defined(HAVE_CAVIUM_V)) && \

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -2217,9 +2217,9 @@ LBL_M:
 int mp_exptmod_base_2(mp_int * X, mp_int * P, mp_int * Y)
 {
   mp_digit buf, mp;
-  int      err, bitbuf, bitcpy, bitcnt, digidx, x, y;
+  int      err = MP_OKAY, bitbuf, bitcpy, bitcnt, digidx, x, y;
 #ifdef WOLFSSL_SMALL_STACK
-  mp_int  *res;
+  mp_int  *res = NULL;
 #else
   mp_int   res[1];
 #endif

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -5070,7 +5070,7 @@ static int wc_PKCS7_KeyWrap(byte* cek, word32 cekSz, byte* kek,
                             word32 kekSz, byte* out, word32 outSz,
                             int keyWrapAlgo, int direction)
 {
-    int ret;
+    int ret = 0;
 
     if (cek == NULL || kek == NULL || out == NULL)
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/port/ti/ti-hash.c
+++ b/wolfcrypt/src/port/ti/ti-hash.c
@@ -104,6 +104,8 @@ static int hashGetHash(wolfssl_TI_Hash *hash, byte* result, word32 algo, word32 
 #else
     (void) hash;
     (void) algo;
+
+    XMEMSET(h, 0, sizeof(h));
 #endif
     XMEMCPY(result, h, hsize);
 

--- a/wolfcrypt/src/sp_arm32.c
+++ b/wolfcrypt/src/sp_arm32.c
@@ -4824,13 +4824,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 64;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_32(norm, m);
 
@@ -4952,13 +4951,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 64;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_32(norm, m);
 
@@ -7072,13 +7070,12 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 128;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_64(norm, m);
 
@@ -7200,13 +7197,12 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 128;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_64(norm, m);
 
@@ -8096,17 +8092,17 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
                             DYNAMIC_TYPE_TMP_BUFFER);
     if (td == NULL)
         err = MEMORY_E;
-
-    if (err == MP_OKAY) {
-        norm = td;
-        tmp  = td + 128;
-    }
-#else
-    norm = nd;
-    tmp  = td;
 #endif
 
     if (err == MP_OKAY) {
+#ifdef WOLFSSL_SMALL_STACK
+        norm = td;
+        tmp  = td + 128;
+#else
+        norm = nd;
+        tmp  = td;
+#endif
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_64(norm, m);
 
@@ -15221,13 +15217,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 96;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_48(norm, m);
 
@@ -15349,13 +15344,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 96;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_48(norm, m);
 
@@ -18269,13 +18263,12 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 192;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_96(norm, m);
 
@@ -18397,13 +18390,12 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 192;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_96(norm, m);
 
@@ -19485,17 +19477,17 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
                             DYNAMIC_TYPE_TMP_BUFFER);
     if (td == NULL)
         err = MEMORY_E;
-
-    if (err == MP_OKAY) {
-        norm = td;
-        tmp  = td + 192;
-    }
-#else
-    norm = nd;
-    tmp  = td;
 #endif
 
     if (err == MP_OKAY) {
+#ifdef WOLFSSL_SMALL_STACK
+        norm = td;
+        tmp  = td + 192;
+#else
+        norm = nd;
+        tmp  = td;
+#endif
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_96(norm, m);
 
@@ -26640,7 +26632,7 @@ static void sp_256_mont_inv_order_8(sp_digit* r, const sp_digit* a,
     /* t2= a^ffffffff00000000ffffffffffffffffbce6 */
     for (i=127; i>=112; i--) {
         sp_256_mont_sqr_order_8(t2, t2);
-        if (p256_order_low[i / 32] & ((sp_digit)1 << (i % 32)))
+        if (p256_order_low[i / 32] & ((sp_int_digit)1 << (i % 32)))
             sp_256_mont_mul_order_8(t2, t2, a);
     }
     /* t2= a^ffffffff00000000ffffffffffffffffbce6f */
@@ -26732,27 +26724,28 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng, mp_int* priv,
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 8, heap,
                                                               DYNAMIC_TYPE_ECC);
-        if (d != NULL) {
-            e = d + 0 * 8;
-            x = d + 2 * 8;
-            k = d + 4 * 8;
-            r = d + 6 * 8;
-            tmp = d + 8 * 8;
-        }
-        else
+        if (d == NULL)
             err = MEMORY_E;
     }
-#else
-    e = ed;
-    x = xd;
-    k = kd;
-    r = rd;
-    tmp = td;
 #endif
-    s = e;
-    kInv = k;
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        e = d + 0 * 8;
+        x = d + 2 * 8;
+        k = d + 4 * 8;
+        r = d + 6 * 8;
+        tmp = d + 8 * 8;
+#else
+        e = ed;
+        x = xd;
+        k = kd;
+        r = rd;
+        tmp = td;
+#endif
+        s = e;
+        kInv = k;
+
         if (hashLen > 32)
             hashLen = 32;
 
@@ -27370,18 +27363,19 @@ static int sp_256_mont_sqrt_8(sp_digit* y)
 
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (d != NULL) {
-        t1 = d + 0 * 8;
-        t2 = d + 2 * 8;
-    }
-    else
+    if (d == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = d + 0 * 8;
+        t2 = d + 2 * 8;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         {
             /* t2 = y ^ 0x2 */
             sp_256_mont_sqr_8(t2, y, p256_mod, p256_mp_mod);
@@ -27448,8 +27442,12 @@ int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
         x = d + 0 * 8;
         y = d + 2 * 8;
     }
-    else
+    else {
         err = MEMORY_E;
+        /* Compiler doesn't always know that err is not MP_OKAY. */
+        x = NULL;
+        y = NULL;
+    }
 #else
     x = xd;
     y = yd;

--- a/wolfcrypt/src/sp_arm64.c
+++ b/wolfcrypt/src/sp_arm64.c
@@ -3061,13 +3061,12 @@ static int sp_2048_mod_exp_16(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 32;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_16(norm, m);
 
@@ -3189,13 +3188,12 @@ static int sp_2048_mod_exp_16(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 32;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_16(norm, m);
 
@@ -4429,13 +4427,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 64;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_32(norm, m);
 
@@ -4557,13 +4554,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 64;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_32(norm, m);
 
@@ -5259,17 +5255,17 @@ static int sp_2048_mod_exp_2_32(sp_digit* r, const sp_digit* e, int bits,
                             DYNAMIC_TYPE_TMP_BUFFER);
     if (td == NULL)
         err = MEMORY_E;
-
-    if (err == MP_OKAY) {
-        norm = td;
-        tmp  = td + 64;
-    }
-#else
-    norm = nd;
-    tmp  = td;
 #endif
 
     if (err == MP_OKAY) {
+#ifdef WOLFSSL_SMALL_STACK
+        norm = td;
+        tmp  = td + 64;
+#else
+        norm = nd;
+        tmp  = td;
+#endif
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_32(norm, m);
 
@@ -10054,13 +10050,12 @@ static int sp_3072_mod_exp_24(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 48;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_24(norm, m);
 
@@ -10182,13 +10177,12 @@ static int sp_3072_mod_exp_24(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 48;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_24(norm, m);
 
@@ -11790,13 +11784,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 96;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_48(norm, m);
 
@@ -11918,13 +11911,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 96;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_48(norm, m);
 
@@ -12716,17 +12708,17 @@ static int sp_3072_mod_exp_2_48(sp_digit* r, const sp_digit* e, int bits,
                             DYNAMIC_TYPE_TMP_BUFFER);
     if (td == NULL)
         err = MEMORY_E;
-
-    if (err == MP_OKAY) {
-        norm = td;
-        tmp  = td + 96;
-    }
-#else
-    norm = nd;
-    tmp  = td;
 #endif
 
     if (err == MP_OKAY) {
+#ifdef WOLFSSL_SMALL_STACK
+        norm = td;
+        tmp  = td + 96;
+#else
+        norm = nd;
+        tmp  = td;
+#endif
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_48(norm, m);
 
@@ -29685,7 +29677,7 @@ static void sp_256_mont_inv_order_4(sp_digit* r, const sp_digit* a,
     /* t2= a^ffffffff00000000ffffffffffffffffbce6 */
     for (i=127; i>=112; i--) {
         sp_256_mont_sqr_order_4(t2, t2);
-        if (p256_order_low[i / 64] & ((sp_digit)1 << (i % 64)))
+        if (p256_order_low[i / 64] & ((sp_int_digit)1 << (i % 64)))
             sp_256_mont_mul_order_4(t2, t2, a);
     }
     /* t2= a^ffffffff00000000ffffffffffffffffbce6f */
@@ -29777,27 +29769,28 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng, mp_int* priv,
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 4, heap,
                                                               DYNAMIC_TYPE_ECC);
-        if (d != NULL) {
-            e = d + 0 * 4;
-            x = d + 2 * 4;
-            k = d + 4 * 4;
-            r = d + 6 * 4;
-            tmp = d + 8 * 4;
-        }
-        else
+        if (d == NULL)
             err = MEMORY_E;
     }
-#else
-    e = ed;
-    x = xd;
-    k = kd;
-    r = rd;
-    tmp = td;
 #endif
-    s = e;
-    kInv = k;
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        e = d + 0 * 4;
+        x = d + 2 * 4;
+        k = d + 4 * 4;
+        r = d + 6 * 4;
+        tmp = d + 8 * 4;
+#else
+        e = ed;
+        x = xd;
+        k = kd;
+        r = rd;
+        tmp = td;
+#endif
+        s = e;
+        kInv = k;
+
         if (hashLen > 32)
             hashLen = 32;
 
@@ -30415,18 +30408,19 @@ static int sp_256_mont_sqrt_4(sp_digit* y)
 
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 4, NULL, DYNAMIC_TYPE_ECC);
-    if (d != NULL) {
-        t1 = d + 0 * 4;
-        t2 = d + 2 * 4;
-    }
-    else
+    if (d == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = d + 0 * 4;
+        t2 = d + 2 * 4;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         {
             /* t2 = y ^ 0x2 */
             sp_256_mont_sqr_4(t2, y, p256_mod, p256_mp_mod);
@@ -30493,8 +30487,12 @@ int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
         x = d + 0 * 4;
         y = d + 2 * 4;
     }
-    else
+    else {
         err = MEMORY_E;
+        /* Compiler doesn't always know that err is not MP_OKAY. */
+        x = NULL;
+        y = NULL;
+    }
 #else
     x = xd;
     y = yd;

--- a/wolfcrypt/src/sp_armthumb.c
+++ b/wolfcrypt/src/sp_armthumb.c
@@ -3122,13 +3122,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 64;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_32(norm, m);
 
@@ -3250,13 +3249,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 64;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_32(norm, m);
 
@@ -3945,13 +3943,12 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 128;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_64(norm, m);
 
@@ -4073,13 +4070,12 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 128;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_64(norm, m);
 
@@ -4975,17 +4971,17 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
                             DYNAMIC_TYPE_TMP_BUFFER);
     if (td == NULL)
         err = MEMORY_E;
-
-    if (err == MP_OKAY) {
-        norm = td;
-        tmp  = td + 128;
-    }
-#else
-    norm = nd;
-    tmp  = td;
 #endif
 
     if (err == MP_OKAY) {
+#ifdef WOLFSSL_SMALL_STACK
+        norm = td;
+        tmp  = td + 128;
+#else
+        norm = nd;
+        tmp  = td;
+#endif
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_64(norm, m);
 
@@ -8733,13 +8729,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 96;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_48(norm, m);
 
@@ -8861,13 +8856,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 96;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_48(norm, m);
 
@@ -9562,13 +9556,12 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 192;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_96(norm, m);
 
@@ -9690,13 +9683,12 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 192;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_96(norm, m);
 
@@ -10790,17 +10782,17 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
                             DYNAMIC_TYPE_TMP_BUFFER);
     if (td == NULL)
         err = MEMORY_E;
-
-    if (err == MP_OKAY) {
-        norm = td;
-        tmp  = td + 192;
-    }
-#else
-    norm = nd;
-    tmp  = td;
 #endif
 
     if (err == MP_OKAY) {
+#ifdef WOLFSSL_SMALL_STACK
+        norm = td;
+        tmp  = td + 192;
+#else
+        norm = nd;
+        tmp  = td;
+#endif
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_96(norm, m);
 
@@ -16018,7 +16010,7 @@ static void sp_256_mont_inv_order_8(sp_digit* r, const sp_digit* a,
     /* t2= a^ffffffff00000000ffffffffffffffffbce6 */
     for (i=127; i>=112; i--) {
         sp_256_mont_sqr_order_8(t2, t2);
-        if (p256_order_low[i / 32] & ((sp_digit)1 << (i % 32)))
+        if (p256_order_low[i / 32] & ((sp_int_digit)1 << (i % 32)))
             sp_256_mont_mul_order_8(t2, t2, a);
     }
     /* t2= a^ffffffff00000000ffffffffffffffffbce6f */
@@ -16110,27 +16102,28 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng, mp_int* priv,
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 8, heap,
                                                               DYNAMIC_TYPE_ECC);
-        if (d != NULL) {
-            e = d + 0 * 8;
-            x = d + 2 * 8;
-            k = d + 4 * 8;
-            r = d + 6 * 8;
-            tmp = d + 8 * 8;
-        }
-        else
+        if (d == NULL)
             err = MEMORY_E;
     }
-#else
-    e = ed;
-    x = xd;
-    k = kd;
-    r = rd;
-    tmp = td;
 #endif
-    s = e;
-    kInv = k;
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        e = d + 0 * 8;
+        x = d + 2 * 8;
+        k = d + 4 * 8;
+        r = d + 6 * 8;
+        tmp = d + 8 * 8;
+#else
+        e = ed;
+        x = xd;
+        k = kd;
+        r = rd;
+        tmp = td;
+#endif
+        s = e;
+        kInv = k;
+
         if (hashLen > 32)
             hashLen = 32;
 
@@ -16748,18 +16741,19 @@ static int sp_256_mont_sqrt_8(sp_digit* y)
 
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (d != NULL) {
-        t1 = d + 0 * 8;
-        t2 = d + 2 * 8;
-    }
-    else
+    if (d == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = d + 0 * 8;
+        t2 = d + 2 * 8;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         {
             /* t2 = y ^ 0x2 */
             sp_256_mont_sqr_8(t2, y, p256_mod, p256_mp_mod);
@@ -16826,8 +16820,12 @@ int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
         x = d + 0 * 8;
         y = d + 2 * 8;
     }
-    else
+    else {
         err = MEMORY_E;
+        /* Compiler doesn't always know that err is not MP_OKAY. */
+        x = NULL;
+        y = NULL;
+    }
 #else
     x = xd;
     y = yd;

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -1746,25 +1746,26 @@ static int sp_2048_div_45(const sp_digit* a, const sp_digit* d, sp_digit* m,
     sp_digit* sd;
     int err = MP_OKAY;
 
+    (void)m;
+
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 45 + 3), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td != NULL) {
+    if (td == NULL)
+        err = MEMORY_E;
+#endif
+
+    if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
         t1 = td;
         t2 = td + 90 + 1;
         sd = t2 + 45 + 1;
-    }
-    else
-        err = MEMORY_E;
 #else
-    t1 = t1d;
-    t2 = t2d;
-    sd = sdd;
+        t1 = t1d;
+        t2 = t2d;
+        sd = sdd;
 #endif
 
-    (void)m;
-
-    if (err == MP_OKAY) {
         sp_2048_mul_d_45(sd, d, 1 << 11);
         sp_2048_mul_d_90(t1, a, 1 << 11);
         div = sd[44];
@@ -1872,7 +1873,7 @@ static int sp_2048_mod_exp_45(sp_digit* r, const sp_digit* a, const sp_digit* e,
             XMEMCPY(t[1], a, sizeof(sp_digit) * 45);
     }
     if (err == MP_OKAY) {
-        sp_2048_mul_45(t[1], t[1], norm);
+        sp_2048_mul_45(t[1], t[1], t[0]);
         err = sp_2048_mod_45(t[1], t[1], m);
     }
 
@@ -1938,13 +1939,12 @@ static int sp_2048_mod_exp_45(sp_digit* r, const sp_digit* a, const sp_digit* e,
         t[0] = td;
         t[1] = &td[45 * 2];
         t[2] = &td[2 * 45 * 2];
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_45(norm, m);
 
@@ -2022,13 +2022,12 @@ static int sp_2048_mod_exp_45(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 90;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_45(norm, m);
 
@@ -2649,25 +2648,26 @@ static int sp_2048_div_90(const sp_digit* a, const sp_digit* d, sp_digit* m,
     sp_digit* sd;
     int err = MP_OKAY;
 
+    (void)m;
+
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 90 + 3), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td != NULL) {
+    if (td == NULL)
+        err = MEMORY_E;
+#endif
+
+    if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
         t1 = td;
         t2 = td + 180 + 1;
         sd = t2 + 90 + 1;
-    }
-    else
-        err = MEMORY_E;
 #else
-    t1 = t1d;
-    t2 = t2d;
-    sd = sdd;
+        t1 = t1d;
+        t2 = t2d;
+        sd = sdd;
 #endif
 
-    (void)m;
-
-    if (err == MP_OKAY) {
         sp_2048_mul_d_90(sd, d, 1 << 22);
         sp_2048_mul_d_180(t1, a, 1 << 22);
         div = sd[89];
@@ -2777,7 +2777,7 @@ static int sp_2048_mod_exp_90(sp_digit* r, const sp_digit* a, const sp_digit* e,
             XMEMCPY(t[1], a, sizeof(sp_digit) * 90);
     }
     if (err == MP_OKAY) {
-        sp_2048_mul_90(t[1], t[1], norm);
+        sp_2048_mul_90(t[1], t[1], t[0]);
         err = sp_2048_mod_90(t[1], t[1], m);
     }
 
@@ -2843,13 +2843,12 @@ static int sp_2048_mod_exp_90(sp_digit* r, const sp_digit* a, const sp_digit* e,
         t[0] = td;
         t[1] = &td[90 * 2];
         t[2] = &td[2 * 90 * 2];
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_90(norm, m);
 
@@ -2927,13 +2926,12 @@ static int sp_2048_mod_exp_90(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 180;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_90(norm, m);
 
@@ -3427,7 +3425,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
     }
     if (err == MP_OKAY) {
         sp_2048_sub_45(tmpa, tmpa, tmpb);
-        sp_2048_mask_45(tmp, p, tmpa[44] >> 31);
+        sp_2048_mask_45(tmp, p, 0 - ((sp_int_digit)tmpa[44] >> 31));
         sp_2048_add_45(tmpa, tmpa, tmp);
 
         sp_2048_from_mp(qi, 45, qim);
@@ -3480,7 +3478,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
 
     if (err == MP_OKAY) {
         sp_2048_sub_45(tmpa, tmpa, tmpb);
-        sp_2048_mask_45(tmp, p, tmpa[44] >> 31);
+        sp_2048_mask_45(tmp, p, 0 - ((sp_int_digit)tmpa[44] >> 31));
         sp_2048_add_45(tmpa, tmpa, tmp);
         sp_2048_mul_45(tmpa, tmpa, qi);
         err = sp_2048_mod_45(tmpa, tmpa, p);
@@ -3821,17 +3819,17 @@ static int sp_2048_mod_exp_2_90(sp_digit* r, const sp_digit* e, int bits, const 
                             DYNAMIC_TYPE_TMP_BUFFER);
     if (td == NULL)
         err = MEMORY_E;
-
-    if (err == MP_OKAY) {
-        norm = td;
-        tmp  = td + 180;
-    }
-#else
-    norm = nd;
-    tmp  = td;
 #endif
 
     if (err == MP_OKAY) {
+#ifdef WOLFSSL_SMALL_STACK
+        norm = td;
+        tmp  = td + 180;
+#else
+        norm = nd;
+        tmp  = td;
+#endif
+
         XMEMSET(td, 0, sizeof(td));
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_90(norm, m);
@@ -5252,23 +5250,24 @@ static int sp_3072_div_67(const sp_digit* a, const sp_digit* d, sp_digit* m,
     sp_digit* t2;
     int err = MP_OKAY;
 
+    (void)m;
+
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 67 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td != NULL) {
-        t1 = td;
-        t2 = td + 2 * 67;
-    }
-    else
+    if (td == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
-    (void)m;
-
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = td;
+        t2 = td + 2 * 67;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         div = d[66];
         XMEMCPY(t1, a, sizeof(*t1) * 2 * 67);
         for (i=66; i>=0; i--) {
@@ -5372,7 +5371,7 @@ static int sp_3072_mod_exp_67(sp_digit* r, const sp_digit* a, const sp_digit* e,
             XMEMCPY(t[1], a, sizeof(sp_digit) * 67);
     }
     if (err == MP_OKAY) {
-        sp_3072_mul_67(t[1], t[1], norm);
+        sp_3072_mul_67(t[1], t[1], t[0]);
         err = sp_3072_mod_67(t[1], t[1], m);
     }
 
@@ -5438,13 +5437,12 @@ static int sp_3072_mod_exp_67(sp_digit* r, const sp_digit* a, const sp_digit* e,
         t[0] = td;
         t[1] = &td[67 * 2];
         t[2] = &td[2 * 67 * 2];
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_67(norm, m);
 
@@ -5522,13 +5520,12 @@ static int sp_3072_mod_exp_67(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 134;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_67(norm, m);
 
@@ -6185,25 +6182,26 @@ static int sp_3072_div_134(const sp_digit* a, const sp_digit* d, sp_digit* m,
     sp_digit* sd;
     int err = MP_OKAY;
 
+    (void)m;
+
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 134 + 3), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td != NULL) {
+    if (td == NULL)
+        err = MEMORY_E;
+#endif
+
+    if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
         t1 = td;
         t2 = td + 268 + 1;
         sd = t2 + 134 + 1;
-    }
-    else
-        err = MEMORY_E;
 #else
-    t1 = t1d;
-    t2 = t2d;
-    sd = sdd;
+        t1 = t1d;
+        t2 = t2d;
+        sd = sdd;
 #endif
 
-    (void)m;
-
-    if (err == MP_OKAY) {
         sp_3072_mul_d_134(sd, d, 1 << 10);
         sp_3072_mul_d_268(t1, a, 1 << 10);
         div = sd[133];
@@ -6313,7 +6311,7 @@ static int sp_3072_mod_exp_134(sp_digit* r, const sp_digit* a, const sp_digit* e
             XMEMCPY(t[1], a, sizeof(sp_digit) * 134);
     }
     if (err == MP_OKAY) {
-        sp_3072_mul_134(t[1], t[1], norm);
+        sp_3072_mul_134(t[1], t[1], t[0]);
         err = sp_3072_mod_134(t[1], t[1], m);
     }
 
@@ -6379,13 +6377,12 @@ static int sp_3072_mod_exp_134(sp_digit* r, const sp_digit* a, const sp_digit* e
         t[0] = td;
         t[1] = &td[134 * 2];
         t[2] = &td[2 * 134 * 2];
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_134(norm, m);
 
@@ -6463,13 +6460,12 @@ static int sp_3072_mod_exp_134(sp_digit* r, const sp_digit* a, const sp_digit* e
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 268;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_134(norm, m);
 
@@ -6961,7 +6957,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
     }
     if (err == MP_OKAY) {
         sp_3072_sub_67(tmpa, tmpa, tmpb);
-        sp_3072_mask_67(tmp, p, tmpa[66] >> 31);
+        sp_3072_mask_67(tmp, p, 0 - ((sp_int_digit)tmpa[66] >> 31));
         sp_3072_add_67(tmpa, tmpa, tmp);
 
         sp_3072_from_mp(qi, 67, qim);
@@ -7014,7 +7010,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
 
     if (err == MP_OKAY) {
         sp_3072_sub_67(tmpa, tmpa, tmpb);
-        sp_3072_mask_67(tmp, p, tmpa[66] >> 31);
+        sp_3072_mask_67(tmp, p, 0 - ((sp_int_digit)tmpa[66] >> 31));
         sp_3072_add_67(tmpa, tmpa, tmp);
         sp_3072_mul_67(tmpa, tmpa, qi);
         err = sp_3072_mod_67(tmpa, tmpa, p);
@@ -7399,17 +7395,17 @@ static int sp_3072_mod_exp_2_134(sp_digit* r, const sp_digit* e, int bits, const
                             DYNAMIC_TYPE_TMP_BUFFER);
     if (td == NULL)
         err = MEMORY_E;
-
-    if (err == MP_OKAY) {
-        norm = td;
-        tmp  = td + 268;
-    }
-#else
-    norm = nd;
-    tmp  = td;
 #endif
 
     if (err == MP_OKAY) {
+#ifdef WOLFSSL_SMALL_STACK
+        norm = td;
+        tmp  = td + 268;
+#else
+        norm = nd;
+        tmp  = td;
+#endif
+
         XMEMSET(td, 0, sizeof(td));
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_134(norm, m);
@@ -7865,18 +7861,19 @@ static int sp_256_mod_mul_norm_10(sp_digit* r, const sp_digit* a, const sp_digit
 
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     td = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (td != NULL) {
-        t = td;
-        a32 = td + 8;
-    }
-    else
+    if (td == NULL)
         err = MEMORY_E;
-#else
-    t = td;
-    a32 = a32d;
 #endif
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t = td;
+        a32 = td + 8;
+#else
+        t = td;
+        a32 = a32d;
+#endif
+
         a32[0] = a[0];
         a32[0] |= a[1] << 26;
         a32[0] &= 0xffffffff;
@@ -11788,23 +11785,24 @@ static int sp_256_div_10(const sp_digit* a, const sp_digit* d, sp_digit* m,
     sp_digit* t2;
     int err = MP_OKAY;
 
+    (void)m;
+
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 10 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td != NULL) {
-        t1 = td;
-        t2 = td + 2 * 10;
-    }
-    else
+    if (td == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
-    (void)m;
-
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = td;
+        t2 = td + 2 * 10;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         div = d[9];
         XMEMCPY(t1, a, sizeof(*t1) * 2 * 10);
         for (i=9; i>=0; i--) {
@@ -11978,7 +11976,7 @@ static void sp_256_mont_inv_order_10(sp_digit* r, const sp_digit* a,
     /* t2= a^ffffffff00000000ffffffffffffffffbce6 */
     for (i=127; i>=112; i--) {
         sp_256_mont_sqr_order_10(t2, t2);
-        if (p256_order_low[i / 32] & ((sp_digit)1 << (i % 32)))
+        if (p256_order_low[i / 32] & ((sp_int_digit)1 << (i % 32)))
             sp_256_mont_mul_order_10(t2, t2, a);
     }
     /* t2= a^ffffffff00000000ffffffffffffffffbce6f */
@@ -12070,27 +12068,28 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng, mp_int* priv,
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 10, heap,
                                                               DYNAMIC_TYPE_ECC);
-        if (d != NULL) {
-            e = d + 0 * 10;
-            x = d + 2 * 10;
-            k = d + 4 * 10;
-            r = d + 6 * 10;
-            tmp = d + 8 * 10;
-        }
-        else
+        if (d == NULL)
             err = MEMORY_E;
     }
-#else
-    e = ed;
-    x = xd;
-    k = kd;
-    r = rd;
-    tmp = td;
 #endif
-    s = e;
-    kInv = k;
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        e = d + 0 * 10;
+        x = d + 2 * 10;
+        k = d + 4 * 10;
+        r = d + 6 * 10;
+        tmp = d + 8 * 10;
+#else
+        e = ed;
+        x = xd;
+        k = kd;
+        r = rd;
+        tmp = td;
+#endif
+        s = e;
+        kInv = k;
+
         if (hashLen > 32)
             hashLen = 32;
 
@@ -12708,18 +12707,19 @@ static int sp_256_mont_sqrt_10(sp_digit* y)
 
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 10, NULL, DYNAMIC_TYPE_ECC);
-    if (d != NULL) {
-        t1 = d + 0 * 10;
-        t2 = d + 2 * 10;
-    }
-    else
+    if (d == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = d + 0 * 10;
+        t2 = d + 2 * 10;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         {
             /* t2 = y ^ 0x2 */
             sp_256_mont_sqr_10(t2, y, p256_mod, p256_mp_mod);
@@ -12786,8 +12786,12 @@ int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
         x = d + 0 * 10;
         y = d + 2 * 10;
     }
-    else
+    else {
         err = MEMORY_E;
+        /* Compiler doesn't always know that err is not MP_OKAY. */
+        x = NULL;
+        y = NULL;
+    }
 #else
     x = xd;
     y = yd;

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -1354,23 +1354,24 @@ static int sp_2048_div_18(const sp_digit* a, const sp_digit* d, sp_digit* m,
     sp_digit* t2;
     int err = MP_OKAY;
 
+    (void)m;
+
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 18 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td != NULL) {
-        t1 = td;
-        t2 = td + 2 * 18;
-    }
-    else
+    if (td == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
-    (void)m;
-
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = td;
+        t2 = td + 2 * 18;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         div = d[17];
         XMEMCPY(t1, a, sizeof(*t1) * 2 * 18);
         for (i=17; i>=0; i--) {
@@ -1474,7 +1475,7 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a, const sp_digit* e,
             XMEMCPY(t[1], a, sizeof(sp_digit) * 18);
     }
     if (err == MP_OKAY) {
-        sp_2048_mul_18(t[1], t[1], norm);
+        sp_2048_mul_18(t[1], t[1], t[0]);
         err = sp_2048_mod_18(t[1], t[1], m);
     }
 
@@ -1540,13 +1541,12 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a, const sp_digit* e,
         t[0] = td;
         t[1] = &td[18 * 2];
         t[2] = &td[2 * 18 * 2];
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_18(norm, m);
 
@@ -1624,13 +1624,12 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 36;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_18(norm, m);
 
@@ -2205,23 +2204,24 @@ static int sp_2048_div_36(const sp_digit* a, const sp_digit* d, sp_digit* m,
     sp_digit* t2;
     int err = MP_OKAY;
 
+    (void)m;
+
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 36 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td != NULL) {
-        t1 = td;
-        t2 = td + 2 * 36;
-    }
-    else
+    if (td == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
-    (void)m;
-
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = td;
+        t2 = td + 2 * 36;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         div = d[35];
         XMEMCPY(t1, a, sizeof(*t1) * 2 * 36);
         for (i=35; i>=0; i--) {
@@ -2327,7 +2327,7 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
             XMEMCPY(t[1], a, sizeof(sp_digit) * 36);
     }
     if (err == MP_OKAY) {
-        sp_2048_mul_36(t[1], t[1], norm);
+        sp_2048_mul_36(t[1], t[1], t[0]);
         err = sp_2048_mod_36(t[1], t[1], m);
     }
 
@@ -2393,13 +2393,12 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
         t[0] = td;
         t[1] = &td[36 * 2];
         t[2] = &td[2 * 36 * 2];
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_36(norm, m);
 
@@ -2477,13 +2476,12 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 72;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_36(norm, m);
 
@@ -2974,7 +2972,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
     }
     if (err == MP_OKAY) {
         sp_2048_sub_18(tmpa, tmpa, tmpb);
-        sp_2048_mask_18(tmp, p, tmpa[17] >> 63);
+        sp_2048_mask_18(tmp, p, 0 - ((sp_int_digit)tmpa[17] >> 63));
         sp_2048_add_18(tmpa, tmpa, tmp);
 
         sp_2048_from_mp(qi, 18, qim);
@@ -3027,7 +3025,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
 
     if (err == MP_OKAY) {
         sp_2048_sub_18(tmpa, tmpa, tmpb);
-        sp_2048_mask_18(tmp, p, tmpa[17] >> 63);
+        sp_2048_mask_18(tmp, p, 0 - ((sp_int_digit)tmpa[17] >> 63));
         sp_2048_add_18(tmpa, tmpa, tmp);
         sp_2048_mul_18(tmpa, tmpa, qi);
         err = sp_2048_mod_18(tmpa, tmpa, p);
@@ -3314,17 +3312,17 @@ static int sp_2048_mod_exp_2_36(sp_digit* r, const sp_digit* e, int bits, const 
                             DYNAMIC_TYPE_TMP_BUFFER);
     if (td == NULL)
         err = MEMORY_E;
-
-    if (err == MP_OKAY) {
-        norm = td;
-        tmp  = td + 72;
-    }
-#else
-    norm = nd;
-    tmp  = td;
 #endif
 
     if (err == MP_OKAY) {
+#ifdef WOLFSSL_SMALL_STACK
+        norm = td;
+        tmp  = td + 72;
+#else
+        norm = nd;
+        tmp  = td;
+#endif
+
         XMEMSET(td, 0, sizeof(td));
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_36(norm, m);
@@ -5155,23 +5153,24 @@ static int sp_3072_div_27(const sp_digit* a, const sp_digit* d, sp_digit* m,
     sp_digit* t2;
     int err = MP_OKAY;
 
+    (void)m;
+
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 27 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td != NULL) {
-        t1 = td;
-        t2 = td + 2 * 27;
-    }
-    else
+    if (td == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
-    (void)m;
-
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = td;
+        t2 = td + 2 * 27;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         div = d[26];
         XMEMCPY(t1, a, sizeof(*t1) * 2 * 27);
         for (i=26; i>=0; i--) {
@@ -5275,7 +5274,7 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a, const sp_digit* e,
             XMEMCPY(t[1], a, sizeof(sp_digit) * 27);
     }
     if (err == MP_OKAY) {
-        sp_3072_mul_27(t[1], t[1], norm);
+        sp_3072_mul_27(t[1], t[1], t[0]);
         err = sp_3072_mod_27(t[1], t[1], m);
     }
 
@@ -5341,13 +5340,12 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a, const sp_digit* e,
         t[0] = td;
         t[1] = &td[27 * 2];
         t[2] = &td[2 * 27 * 2];
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_27(norm, m);
 
@@ -5425,13 +5423,12 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 54;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_27(norm, m);
 
@@ -5978,23 +5975,24 @@ static int sp_3072_div_54(const sp_digit* a, const sp_digit* d, sp_digit* m,
     sp_digit* t2;
     int err = MP_OKAY;
 
+    (void)m;
+
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 54 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td != NULL) {
-        t1 = td;
-        t2 = td + 2 * 54;
-    }
-    else
+    if (td == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
-    (void)m;
-
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = td;
+        t2 = td + 2 * 54;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         div = d[53];
         XMEMCPY(t1, a, sizeof(*t1) * 2 * 54);
         for (i=53; i>=0; i--) {
@@ -6100,7 +6098,7 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
             XMEMCPY(t[1], a, sizeof(sp_digit) * 54);
     }
     if (err == MP_OKAY) {
-        sp_3072_mul_54(t[1], t[1], norm);
+        sp_3072_mul_54(t[1], t[1], t[0]);
         err = sp_3072_mod_54(t[1], t[1], m);
     }
 
@@ -6166,13 +6164,12 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
         t[0] = td;
         t[1] = &td[54 * 2];
         t[2] = &td[2 * 54 * 2];
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_54(norm, m);
 
@@ -6250,13 +6247,12 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 108;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_54(norm, m);
 
@@ -6748,7 +6744,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
     }
     if (err == MP_OKAY) {
         sp_3072_sub_27(tmpa, tmpa, tmpb);
-        sp_3072_mask_27(tmp, p, tmpa[26] >> 63);
+        sp_3072_mask_27(tmp, p, 0 - ((sp_int_digit)tmpa[26] >> 63));
         sp_3072_add_27(tmpa, tmpa, tmp);
 
         sp_3072_from_mp(qi, 27, qim);
@@ -6801,7 +6797,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
 
     if (err == MP_OKAY) {
         sp_3072_sub_27(tmpa, tmpa, tmpb);
-        sp_3072_mask_27(tmp, p, tmpa[26] >> 63);
+        sp_3072_mask_27(tmp, p, 0 - ((sp_int_digit)tmpa[26] >> 63));
         sp_3072_add_27(tmpa, tmpa, tmp);
         sp_3072_mul_27(tmpa, tmpa, qi);
         err = sp_3072_mod_27(tmpa, tmpa, p);
@@ -7106,17 +7102,17 @@ static int sp_3072_mod_exp_2_54(sp_digit* r, const sp_digit* e, int bits, const 
                             DYNAMIC_TYPE_TMP_BUFFER);
     if (td == NULL)
         err = MEMORY_E;
-
-    if (err == MP_OKAY) {
-        norm = td;
-        tmp  = td + 108;
-    }
-#else
-    norm = nd;
-    tmp  = td;
 #endif
 
     if (err == MP_OKAY) {
+#ifdef WOLFSSL_SMALL_STACK
+        norm = td;
+        tmp  = td + 108;
+#else
+        norm = nd;
+        tmp  = td;
+#endif
+
         XMEMSET(td, 0, sizeof(td));
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_54(norm, m);
@@ -7573,18 +7569,19 @@ static int sp_256_mod_mul_norm_5(sp_digit* r, const sp_digit* a, const sp_digit*
 
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     td = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (td != NULL) {
-        t = td;
-        a32 = td + 8;
-    }
-    else
+    if (td == NULL)
         err = MEMORY_E;
-#else
-    t = td;
-    a32 = a32d;
 #endif
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t = td;
+        a32 = td + 8;
+#else
+        t = td;
+        a32 = a32d;
+#endif
+
         a32[0] = (sp_digit)(a[0]) & 0xffffffff;
         a32[1] = (sp_digit)(a[0] >> 32);
         a32[1] |= a[1] << 20;
@@ -11271,23 +11268,24 @@ static int sp_256_div_5(const sp_digit* a, const sp_digit* d, sp_digit* m,
     sp_digit* t2;
     int err = MP_OKAY;
 
+    (void)m;
+
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 5 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td != NULL) {
-        t1 = td;
-        t2 = td + 2 * 5;
-    }
-    else
+    if (td == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
-    (void)m;
-
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = td;
+        t2 = td + 2 * 5;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         div = d[4];
         XMEMCPY(t1, a, sizeof(*t1) * 2 * 5);
         for (i=4; i>=0; i--) {
@@ -11461,7 +11459,7 @@ static void sp_256_mont_inv_order_5(sp_digit* r, const sp_digit* a,
     /* t2= a^ffffffff00000000ffffffffffffffffbce6 */
     for (i=127; i>=112; i--) {
         sp_256_mont_sqr_order_5(t2, t2);
-        if (p256_order_low[i / 64] & ((sp_digit)1 << (i % 64)))
+        if (p256_order_low[i / 64] & ((sp_int_digit)1 << (i % 64)))
             sp_256_mont_mul_order_5(t2, t2, a);
     }
     /* t2= a^ffffffff00000000ffffffffffffffffbce6f */
@@ -11553,27 +11551,28 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng, mp_int* priv,
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 5, heap,
                                                               DYNAMIC_TYPE_ECC);
-        if (d != NULL) {
-            e = d + 0 * 5;
-            x = d + 2 * 5;
-            k = d + 4 * 5;
-            r = d + 6 * 5;
-            tmp = d + 8 * 5;
-        }
-        else
+        if (d == NULL)
             err = MEMORY_E;
     }
-#else
-    e = ed;
-    x = xd;
-    k = kd;
-    r = rd;
-    tmp = td;
 #endif
-    s = e;
-    kInv = k;
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        e = d + 0 * 5;
+        x = d + 2 * 5;
+        k = d + 4 * 5;
+        r = d + 6 * 5;
+        tmp = d + 8 * 5;
+#else
+        e = ed;
+        x = xd;
+        k = kd;
+        r = rd;
+        tmp = td;
+#endif
+        s = e;
+        kInv = k;
+
         if (hashLen > 32)
             hashLen = 32;
 
@@ -12191,18 +12190,19 @@ static int sp_256_mont_sqrt_5(sp_digit* y)
 
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 5, NULL, DYNAMIC_TYPE_ECC);
-    if (d != NULL) {
-        t1 = d + 0 * 5;
-        t2 = d + 2 * 5;
-    }
-    else
+    if (d == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = d + 0 * 5;
+        t2 = d + 2 * 5;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         {
             /* t2 = y ^ 0x2 */
             sp_256_mont_sqr_5(t2, y, p256_mod, p256_mp_mod);
@@ -12269,8 +12269,12 @@ int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
         x = d + 0 * 5;
         y = d + 2 * 5;
     }
-    else
+    else {
         err = MEMORY_E;
+        /* Compiler doesn't always know that err is not MP_OKAY. */
+        x = NULL;
+        y = NULL;
+    }
 #else
     x = xd;
     y = yd;

--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -3431,13 +3431,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 64;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_32(norm, m);
 
@@ -3559,13 +3558,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 64;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_32(norm, m);
 
@@ -4112,13 +4110,12 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 128;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_64(norm, m);
 
@@ -4240,13 +4237,12 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 128;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_64(norm, m);
 
@@ -5142,17 +5138,17 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
                             DYNAMIC_TYPE_TMP_BUFFER);
     if (td == NULL)
         err = MEMORY_E;
-
-    if (err == MP_OKAY) {
-        norm = td;
-        tmp  = td + 128;
-    }
-#else
-    norm = nd;
-    tmp  = td;
 #endif
 
     if (err == MP_OKAY) {
+#ifdef WOLFSSL_SMALL_STACK
+        norm = td;
+        tmp  = td + 128;
+#else
+        norm = nd;
+        tmp  = td;
+#endif
+
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_64(norm, m);
 
@@ -8468,13 +8464,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 96;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_48(norm, m);
 
@@ -8596,13 +8591,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 96;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_48(norm, m);
 
@@ -9155,13 +9149,12 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<16; i++)
             t[i] = td + i * 192;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_96(norm, m);
 
@@ -9283,13 +9276,12 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
     if (err == MP_OKAY) {
         for (i=0; i<32; i++)
             t[i] = td + i * 192;
-        norm = t[0];
     }
-#else
-    norm = t[0];
 #endif
 
     if (err == MP_OKAY) {
+        norm = t[0];
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_96(norm, m);
 
@@ -10381,17 +10373,17 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
                             DYNAMIC_TYPE_TMP_BUFFER);
     if (td == NULL)
         err = MEMORY_E;
-
-    if (err == MP_OKAY) {
-        norm = td;
-        tmp  = td + 192;
-    }
-#else
-    norm = nd;
-    tmp  = td;
 #endif
 
     if (err == MP_OKAY) {
+#ifdef WOLFSSL_SMALL_STACK
+        norm = td;
+        tmp  = td + 192;
+#else
+        norm = nd;
+        tmp  = td;
+#endif
+
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_96(norm, m);
 
@@ -16089,7 +16081,7 @@ static void sp_256_mont_inv_order_8(sp_digit* r, const sp_digit* a,
     /* t2= a^ffffffff00000000ffffffffffffffffbce6 */
     for (i=127; i>=112; i--) {
         sp_256_mont_sqr_order_8(t2, t2);
-        if (p256_order_low[i / 32] & ((sp_digit)1 << (i % 32)))
+        if (p256_order_low[i / 32] & ((sp_int_digit)1 << (i % 32)))
             sp_256_mont_mul_order_8(t2, t2, a);
     }
     /* t2= a^ffffffff00000000ffffffffffffffffbce6f */
@@ -16181,27 +16173,28 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng, mp_int* priv,
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 8, heap,
                                                               DYNAMIC_TYPE_ECC);
-        if (d != NULL) {
-            e = d + 0 * 8;
-            x = d + 2 * 8;
-            k = d + 4 * 8;
-            r = d + 6 * 8;
-            tmp = d + 8 * 8;
-        }
-        else
+        if (d == NULL)
             err = MEMORY_E;
     }
-#else
-    e = ed;
-    x = xd;
-    k = kd;
-    r = rd;
-    tmp = td;
 #endif
-    s = e;
-    kInv = k;
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        e = d + 0 * 8;
+        x = d + 2 * 8;
+        k = d + 4 * 8;
+        r = d + 6 * 8;
+        tmp = d + 8 * 8;
+#else
+        e = ed;
+        x = xd;
+        k = kd;
+        r = rd;
+        tmp = td;
+#endif
+        s = e;
+        kInv = k;
+
         if (hashLen > 32)
             hashLen = 32;
 
@@ -16819,18 +16812,19 @@ static int sp_256_mont_sqrt_8(sp_digit* y)
 
 #if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
     d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (d != NULL) {
-        t1 = d + 0 * 8;
-        t2 = d + 2 * 8;
-    }
-    else
+    if (d == NULL)
         err = MEMORY_E;
-#else
-    t1 = t1d;
-    t2 = t2d;
 #endif
 
     if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        t1 = d + 0 * 8;
+        t2 = d + 2 * 8;
+#else
+        t1 = t1d;
+        t2 = t2d;
+#endif
+
         {
             /* t2 = y ^ 0x2 */
             sp_256_mont_sqr_8(t2, y, p256_mod, p256_mp_mod);
@@ -16897,8 +16891,12 @@ int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
         x = d + 0 * 8;
         y = d + 2 * 8;
     }
-    else
+    else {
         err = MEMORY_E;
+        /* Compiler doesn't always know that err is not MP_OKAY. */
+        x = NULL;
+        y = NULL;
+    }
 #else
     x = xd;
     y = yd;

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -4281,6 +4281,8 @@ int fp_randprime(fp_int* N, int len, WC_RNG* rng, void* heap)
          * it is proven composite. */
     byte* buf;
 
+    (void)heap;
+
     /* get type */
     if (len < 0) {
         type = USE_BBS;

--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -1190,7 +1190,7 @@ static int Pkcs11FindEccKey(CK_OBJECT_HANDLE* key, CK_OBJECT_CLASS keyClass,
     int             ret = 0;
     int             i;
     unsigned char*  ecPoint = NULL;
-    word32          len;
+    word32          len = 0;
     CK_RV           rv;
     CK_ULONG        count;
     CK_UTF8CHAR     params[MAX_EC_PARAM_LEN];

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -583,7 +583,7 @@ XFILE z_fs_open(const char* filename, const char* perm)
     file = XMALLOC(sizeof(*file), NULL, DYNAMIC_TYPE_FILE);
     if (file != NULL) {
         if (fs_open(file, filename) != 0) {
-            XFREE(file);
+            XFREE(file, NULL, DYNAMIC_TYPE_FILE);
             file = NULL;
         }
     }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8921,7 +8921,7 @@ int memory_test(void)
     word32 size[] = { WOLFMEM_BUCKETS };
     word32 dist[] = { WOLFMEM_DIST };
     byte buffer[30000]; /* make large enough to involve many bucket sizes */
-    int pad = -(int)((wolfssl_word)&(buffer[0])) & (WOLFSSL_STATIC_ALIGN - 1);
+    int pad = -(int)((wolfssl_word)buffer) & (WOLFSSL_STATIC_ALIGN - 1);
               /* pad to account for if head of buffer is not at set memory
                * alignment when tests are ran */
 #endif
@@ -11683,7 +11683,7 @@ int rsa_test(void)
 #ifndef NO_SIG_WRAPPER
     modLen = wc_RsaEncryptSize(&key);
 #endif
-#elif defined(WOLFSSL_RSA_PUBLIC_ONLY) && defined(WOLFSSL_MP_PUBLIC)
+#else
     #ifdef USE_CERT_BUFFERS_2048
         ret = mp_read_unsigned_bin(&key.n, &tmp[12], 256);
         if (ret != 0) {
@@ -14232,7 +14232,7 @@ int openssl_test(void)
     byte       hash[WC_SHA256_DIGEST_SIZE*2];  /* max size */
 
     a.inLen = 0;
-    b = c = d = e = f = a;
+    b.inLen = c.inLen = d.inLen = e.inLen = f.inLen = a.inLen;
 
     (void)a;
     (void)b;

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -64,8 +64,13 @@
   #elif SP_WORD_SIZE == 64
     typedef int64_t sp_digit;
     typedef uint64_t sp_int_digit;
-    typedef unsigned long uint128_t __attribute__ ((mode(TI)));
-    typedef long int128_t __attribute__ ((mode(TI)));
+    #ifdef __SIZEOF_INT128__
+      typedef __uint128_t uint128_t;
+      typedef __int128_t int128_t;
+    #else
+      typedef unsigned long uint128_t __attribute__ ((mode(TI)));
+      typedef long int128_t __attribute__ ((mode(TI)));
+    #endif
     typedef uint128_t sp_int_word;
   #else
     #error Word size not defined
@@ -78,8 +83,13 @@
   #elif SP_WORD_SIZE == 64
     typedef uint64_t sp_digit;
     typedef uint64_t sp_int_digit;
-    typedef unsigned long uint128_t __attribute__ ((mode(TI)));
-    typedef long int128_t __attribute__ ((mode(TI)));
+    #ifdef __SIZEOF_INT128__
+      typedef __uint128_t uint128_t;
+      typedef __int128_t int128_t;
+    #else
+      typedef unsigned long uint128_t __attribute__ ((mode(TI)));
+      typedef long int128_t __attribute__ ((mode(TI)));
+    #endif
     typedef uint128_t sp_int_word;
   #else
     #error Word size not defined

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -294,7 +294,7 @@
         #else
         /* just use plain C stdlib stuff if desired */
         #include <stdlib.h>
-        #define XMALLOC(s, h, t)     ((void)h, (void)t, malloc((s)))
+        #define XMALLOC(s, h, t)     malloc((s))
         #define XFREE(p, h, t)       {void* xp = (p); if((xp)) free((xp));}
         #define XREALLOC(p, n, h, t) realloc((p), (n))
         #endif


### PR DESCRIPTION
Various fixes for uninitialized variable use.
sniffer.c: close file when seek fails
tls.c: fix QSH_GET_SIZE macro
wolfio.c: uIPGenerateCookie: use the parameter, _ctx, instead of self
referencing.
wolfssl_adds.c: check for equivalent to XBADFILE to indicate error.
SP: change right shift of signed value to unsigned
sp_int.h: define 128-bit types
types.h: change a XMALLOC define to not use (,,) - cppcheck doesn't like
it and is unnecessary.