### PR TITLE
Fix defines that aren't in configure.ac

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16267,7 +16267,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         switch (ctx->cipherType) {
 
 #ifndef NO_AES
-#ifdef WOLFSSL_AES_CBC
+#ifdef HAVE_AES_CBC
             case AES_128_CBC_TYPE :
             case AES_192_CBC_TYPE :
             case AES_256_CBC_TYPE :
@@ -16275,14 +16275,14 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                 XMEMCPY(ctx->iv, &ctx->cipher.aes.reg, AES_BLOCK_SIZE);
                 break;
 #endif
-#ifdef WOLFSSL_AES_GCM
+#ifdef HAVE_AESGCM
             case AES_128_GCM_TYPE :
             case AES_192_GCM_TYPE :
             case AES_256_GCM_TYPE :
                 WOLFSSL_MSG("AES GCM");
                 XMEMCPY(ctx->iv, &ctx->cipher.aes.reg, AES_BLOCK_SIZE);
                 break;
-#endif /* WOLFSSL_AES_GCM */
+#endif /* HAVE_AESGCM */
 #ifdef WOLFSSL_AES_COUNTER
             case AES_128_CTR_TYPE :
             case AES_192_CTR_TYPE :
@@ -16351,7 +16351,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                 XMEMCPY(&ctx->cipher.aes.reg, ctx->iv, AES_BLOCK_SIZE);
                 break;
 #endif
-#ifdef WOLFSSL_AES_GCM
+#ifdef HAVE_AESGCM
             case AES_128_GCM_TYPE :
             case AES_192_GCM_TYPE :
             case AES_256_GCM_TYPE :

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -773,7 +773,7 @@ unsigned long WOLFSSL_CIPHER_mode(const WOLFSSL_EVP_CIPHER *cipher)
         case AES_256_CBC_TYPE:
             return WOLFSSL_EVP_CIPH_CBC_MODE;
     #endif
-    #if defined(WOLFSSL_AES_GCM)
+    #if defined(HAVE_AESGCM)
         case AES_128_GCM_TYPE:
         case AES_192_GCM_TYPE:
         case AES_256_GCM_TYPE:


### PR DESCRIPTION
WOLFSSL_AES_CBC and WOLFSSL_AES_GCM are non-standard defines.  These are never defined in configure.ac or other sources unless the user explicitly defined it.

HAVE_AES_CBC is referenced in many places, but never is actually set in configure.ac.  Only NO_AES_CBC is set in configure.ac