### PR TITLE
check on if free'ing ctx/method back to heap hint

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1398,6 +1398,7 @@ int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx, wolfSSL_method_func method
             WOLFSSL_MSG("Error creating ctx");
             return WOLFSSL_FAILURE;
         }
+        (*ctx)->onHeap = 1; /* free the memory back to heap when done */
     }
 
     /* determine what max applies too */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2569,6 +2569,9 @@ struct WOLFSSL_CTX {
 #endif
     Suites*     suites;           /* make dynamic, user may not need/set */
     void*       heap;             /* for user memory overrides */
+#ifdef WOLFSSL_STATIC_MEMORY
+    byte        onHeap; /* whether the ctx/method is put on heap hint */
+#endif
     byte        verifyDepth;
     byte        verifyPeer:1;
     byte        verifyNone:1;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2569,9 +2569,6 @@ struct WOLFSSL_CTX {
 #endif
     Suites*     suites;           /* make dynamic, user may not need/set */
     void*       heap;             /* for user memory overrides */
-#ifdef WOLFSSL_STATIC_MEMORY
-    byte        onHeap; /* whether the ctx/method is put on heap hint */
-#endif
     byte        verifyDepth;
     byte        verifyPeer:1;
     byte        verifyNone:1;
@@ -2613,6 +2610,9 @@ struct WOLFSSL_CTX {
 #endif
 #ifdef HAVE_ENCRYPT_THEN_MAC
     byte        disallowEncThenMac:1;  /* Don't do Encrypt-Then-MAC */
+#endif
+#ifdef WOLFSSL_STATIC_MEMORY
+    byte        onHeap:1; /* whether the ctx/method is put on heap hint */
 #endif
 #ifdef WOLFSSL_MULTICAST
     byte        haveMcast;        /* multicast requested */


### PR DESCRIPTION
Case where CTX/method was created before the heap hint was loaded in. This happens in our suites test with tests/unit.c