### PR TITLE
Removed inclusion of openSSL header

### DIFF
--- a/wolfssl/openssl/x509.h
+++ b/wolfssl/openssl/x509.h
@@ -1,6 +1,7 @@
 /* x509.h for openssl */
 
 #include <wolfssl/openssl/ssl.h>
+#include <wolfssl/openssl/dh.h>
 
 /* wolfSSL_X509_print_ex flags */
 #define X509_FLAG_COMPAT        (0UL)

--- a/wolfssl/openssl/x509.h
+++ b/wolfssl/openssl/x509.h
@@ -2,9 +2,6 @@
 
 #include <wolfssl/openssl/ssl.h>
 
-/* for compatibility, this is expected to be included */
-#include <openssl/dh.h>
-
 /* wolfSSL_X509_print_ex flags */
 #define X509_FLAG_COMPAT        (0UL)
 #define X509_FLAG_NO_HEADER     (1UL << 0)


### PR DESCRIPTION
This PR suggests to eliminate an alien inclusion, introduced in PR #2466.

Several distributions include wolfSSL as openSSL alternative, and don't include any openSSL sources. The include statement seems to introduce a build dependency on openSSL.

Without the include I was able to compile wolfssl both with `--enable-openssl-all` and `--enable-apachehttpd`.

@cariepointer @dgarske are you sure this include is needed for apache httpd compatibility? If so, is there an alternative solution (e.g. duplicate the missing declarations, or add the include elsewhere in the application?)