### PR TITLE
Support for STM32_PKA accelerator

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4678,7 +4678,7 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
 }
 #endif /* !NO_ASN */
 
-#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_CRYPTOCELL) /* TODO DLX: add !defined(WOLFSSL_STM32_PKA) */
+#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_CRYPTOCELL)
 /**
   Sign a message digest
   in        The message digest to sign
@@ -4690,6 +4690,11 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
 */
 int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
                      ecc_key* key, mp_int *r, mp_int *s)
+#if defined(WOLFSSL_STM32_PKA)
+{
+    return stm32_ecc_sign_hash_ex(in, inlen, rng, key, r, s);
+}
+#else
 {
    int    err;
 #ifndef WOLFSSL_SP_MATH
@@ -5013,6 +5018,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 
    return err;
 }
+#endif /* WOLFSSL_STM32_PKA */
 #endif /* WOLFSSL_ATECC508A && WOLFSSL_CRYPTOCELL*/
 #endif /* HAVE_ECC_SIGN */
 

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -417,14 +417,14 @@ static int stm32_get_from_mp_int(uint8_t *dst, mp_int *a, int sz)
     res = mp_to_unsigned_bin(a, dst + offset);
 
     if (res == MP_OKAY) {
-        /* reverse array for LTC direct use */
+        /* reverse array for STM32_PKA direct use */
         stm32_reverse_array(dst, sz);
     }
 
     return res;
 }
 
-/* ECC specs in lsbyte at lowest address format for direct use by LTC PKHA driver functions */
+/* ECC specs in lsbyte at lowest address format for direct use by STM32_PKA PKHA driver functions */
 #if defined(HAVE_ECC192) || defined(HAVE_ALL_CURVES)
 #define ECC192
 #endif
@@ -582,7 +582,7 @@ int wc_ecc_mulmod_ex(mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
         return res;
 
     size = szModulus;
-    /* find LTC friendly parameters for the selected curve */
+    /* find STM32_PKA friendly parameters for the selected curve */
     if (0 != stm32_get_ecc_specs(&prime, &coef, &coef_sign, &gen_x, &gen_y, &order, size)) {
         return ECC_BAD_ARG_E;
     }

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -623,7 +623,7 @@ static int stm32_get_ecc_specs(const uint8_t **prime, const uint8_t **coef,
         *coef_sign = &stm32_ecc192_coef;
         break;
 #endif
-#ifdef HAVE_ECC384
+#ifdef ECC384
     case 48:
         *prime = stm32_ecc384_prime;
         *coef = stm32_ecc384_coef;
@@ -790,7 +790,7 @@ int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     XMEMCPY(Hashbin + (size - hashlen), hash, hashlen);
     pka_ecc.hash =            Hashbin;
 
-    status = HAL_PKA_ECDSAVerif(&hpka, &pka_ecc, 0xFFFFFFFF);
+    status = HAL_PKA_ECDSAVerif(&hpka, &pka_ecc, HAL_MAX_DELAY);
     if (status != HAL_OK) {
         HAL_PKA_RAMReset(&hpka);
         return WC_HW_E;
@@ -865,7 +865,7 @@ int stm32_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
     pka_ecc_out.RSign = Rbin;
     pka_ecc_out.SSign = Sbin;
 
-    status = HAL_PKA_ECDSASign(&hpka, &pka_ecc, 0xFFFFFFFF);
+    status = HAL_PKA_ECDSASign(&hpka, &pka_ecc, HAL_MAX_DELAY);
     if (status != HAL_OK) {
         HAL_PKA_RAMReset(&hpka);
         return WC_HW_E;

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -668,8 +668,8 @@ int wc_ecc_mulmod_ex(mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
     const uint32_t *coef_sign;
     (void)a;
     (void)heap;
-    memset(&pka_mul, 0x00, sizeof(PKA_ECCMulInTypeDef));
-    memset(&pka_mul_res, 0x00, sizeof(PKA_ECCMulOutTypeDef));
+    XMEMSET(&pka_mul, 0x00, sizeof(PKA_ECCMulInTypeDef));
+    XMEMSET(&pka_mul_res, 0x00, sizeof(PKA_ECCMulOutTypeDef));
     pka_mul_res.ptX = PtXbin;
     pka_mul_res.ptY = PtYbin;
 
@@ -744,7 +744,7 @@ int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     uint8_t privKeybin[STM32_MAX_ECC_SIZE];
     const uint8_t *prime, *coef, *gen_x, *gen_y, *order;
     const uint32_t *coef_sign;
-    memset(&pka_ecc, 0x00, sizeof(PKA_ECDSAVerifInTypeDef));
+    XMEMSET(&pka_ecc, 0x00, sizeof(PKA_ECDSAVerifInTypeDef));
 
     if (r == NULL || s == NULL || hash == NULL || res == NULL || key == NULL) {
         return ECC_BAD_ARG_E;
@@ -786,7 +786,7 @@ int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     pka_ecc.pPubKeyCurvePtY = Qybin;
     pka_ecc.RSign =           Rbin;
     pka_ecc.SSign =           Sbin;
-    memset(Hashbin, 0, STM32_MAX_ECC_SIZE);
+    XMEMSET(Hashbin, 0, STM32_MAX_ECC_SIZE);
     memcpy(Hashbin + (size - hashlen), hash, hashlen);
     pka_ecc.hash =            Hashbin;
 
@@ -817,8 +817,8 @@ int stm32_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
     uint8_t Hashbin[STM32_MAX_ECC_SIZE];
     const uint8_t *prime, *coef, *gen_x, *gen_y, *order;
     const uint32_t *coef_sign;
-    memset(&pka_ecc, 0x00, sizeof(PKA_ECDSASignInTypeDef));
-    memset(&pka_ecc, 0x00, sizeof(PKA_ECDSASignOutTypeDef));
+    XMEMSET(&pka_ecc, 0x00, sizeof(PKA_ECDSASignInTypeDef));
+    XMEMSET(&pka_ecc, 0x00, sizeof(PKA_ECDSASignOutTypeDef));
 
     if (r == NULL || s == NULL || hash == NULL || key == NULL) {
         return ECC_BAD_ARG_E;
@@ -855,7 +855,7 @@ int stm32_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
     pka_ecc.basePointY =      gen_y;
     pka_ecc.primeOrder =      order;
 
-    memset(Hashbin, 0, STM32_MAX_ECC_SIZE);
+    XMEMSET(Hashbin, 0, STM32_MAX_ECC_SIZE);
     memcpy(Hashbin + (size - hashlen), hash, hashlen);
     pka_ecc.hash =            Hashbin;
     pka_ecc.integer =         Intbin;

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -740,6 +740,7 @@ int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     uint8_t Sbin[STM32_MAX_ECC_SIZE];
     uint8_t Qxbin[STM32_MAX_ECC_SIZE];
     uint8_t Qybin[STM32_MAX_ECC_SIZE];
+    uint8_t Hashbin[STM32_MAX_ECC_SIZE];
     uint8_t privKeybin[STM32_MAX_ECC_SIZE];
     const uint8_t *prime, *coef, *gen_x, *gen_y, *order;
     const uint32_t *coef_sign;
@@ -785,7 +786,9 @@ int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     pka_ecc.pPubKeyCurvePtY = Qybin;
     pka_ecc.RSign =           Rbin;
     pka_ecc.SSign =           Sbin;
-    pka_ecc.hash =            hash;
+    memset(Hashbin, 0, STM32_MAX_ECC_SIZE);
+    memcpy(Hashbin + (size - hashlen), hash, hashlen);
+    pka_ecc.hash =            Hashbin;
 
     status = HAL_PKA_ECDSAVerif(&hpka, &pka_ecc, 0xFFFFFFFF);
     if (status != HAL_OK) {
@@ -811,6 +814,7 @@ int stm32_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
     uint8_t Intbin[STM32_MAX_ECC_SIZE];
     uint8_t Rbin[STM32_MAX_ECC_SIZE];
     uint8_t Sbin[STM32_MAX_ECC_SIZE];
+    uint8_t Hashbin[STM32_MAX_ECC_SIZE];
     const uint8_t *prime, *coef, *gen_x, *gen_y, *order;
     const uint32_t *coef_sign;
     memset(&pka_ecc, 0x00, sizeof(PKA_ECDSASignInTypeDef));
@@ -851,7 +855,9 @@ int stm32_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
     pka_ecc.basePointY =      gen_y;
     pka_ecc.primeOrder =      order;
 
-    pka_ecc.hash =            hash;
+    memset(Hashbin, 0, STM32_MAX_ECC_SIZE);
+    memcpy(Hashbin + (size - hashlen), hash, hashlen);
+    pka_ecc.hash =            Hashbin;
     pka_ecc.integer =         Intbin;
     pka_ecc.privateKey =      Keybin;
 

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -370,20 +370,6 @@ int wc_Stm32_Aes_Init(Aes* aes, CRYP_InitTypeDef* cryptInit,
 extern PKA_HandleTypeDef hpka;
 
 /* Reverse array in memory (in place) */
-static void stm32_reverse_array(uint8_t *src, size_t src_len)
-{
-    unsigned int i;
-
-    for (i = 0; i < src_len / 2; i++) {
-        uint8_t tmp;
-
-        tmp = src[i];
-        src[i] = src[src_len - 1 - i];
-        src[src_len - 1 - i] = tmp;
-    }
-}
-
-
 #ifdef HAVE_ECC
 #include <wolfssl/wolfcrypt/ecc.h>
 
@@ -415,12 +401,6 @@ static int stm32_get_from_mp_int(uint8_t *dst, mp_int *a, int sz)
 
     /* convert mp_int to array of bytes */
     res = mp_to_unsigned_bin(a, dst + offset);
-
-    if (res == MP_OKAY) {
-        /* reverse array for STM32_PKA direct use */
-        stm32_reverse_array(dst, sz);
-    }
-
     return res;
 }
 

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -787,7 +787,7 @@ int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     pka_ecc.RSign =           Rbin;
     pka_ecc.SSign =           Sbin;
     XMEMSET(Hashbin, 0, STM32_MAX_ECC_SIZE);
-    memcpy(Hashbin + (size - hashlen), hash, hashlen);
+    XMEMCPY(Hashbin + (size - hashlen), hash, hashlen);
     pka_ecc.hash =            Hashbin;
 
     status = HAL_PKA_ECDSAVerif(&hpka, &pka_ecc, 0xFFFFFFFF);
@@ -856,7 +856,7 @@ int stm32_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
     pka_ecc.primeOrder =      order;
 
     XMEMSET(Hashbin, 0, STM32_MAX_ECC_SIZE);
-    memcpy(Hashbin + (size - hashlen), hash, hashlen);
+    XMEMCPY(Hashbin + (size - hashlen), hash, hashlen);
     pka_ecc.hash =            Hashbin;
     pka_ecc.integer =         Intbin;
     pka_ecc.privateKey =      Keybin;

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -364,6 +364,7 @@ int wc_Stm32_Aes_Init(Aes* aes, CRYP_InitTypeDef* cryptInit,
 #endif /* STM32_CRYPTO */
 
 #ifdef WOLFSSL_STM32_PKA
+#include <stdint.h>
 #include <stm32wbxx_hal_conf.h>
 #include <stm32wbxx_hal_pka.h>
 
@@ -385,8 +386,13 @@ static int stm32_get_from_mp_int(uint8_t *dst, mp_int *a, int sz)
     int szbin;
     int offset;
 
+    if (!a || !dst || (sz < 0))
+        return -1;
+
     /* check how many bytes are in the mp_int */
     szbin = mp_unsigned_bin_size(a);
+    if ((szbin < 0) || (szbin > sz))
+        return -1;
 
     /* compute offset from dst */
     offset = sz - szbin;
@@ -421,6 +427,82 @@ static int stm32_get_from_mp_int(uint8_t *dst, mp_int *a, int sz)
 /* STM32 PKA supports up to 640bit numbers */
 #define STM32_MAX_ECC_SIZE (80)
 
+
+/* P-192 */
+#ifdef ECC192
+#define ECC192_KEYSIZE (24)
+static const uint8_t stm32_ecc192_prime[ECC192_KEYSIZE] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+};
+static const uint32_t stm32_ecc192_coef_sign = 1U;
+
+static const uint8_t stm32_ecc192_coef[ECC192_KEYSIZE] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03
+};
+
+static const uint8_t stm32_ecc192_pointX[ECC192_KEYSIZE] =  {
+    0x18, 0x8D, 0xA8, 0x0E,  0xB0, 0x30, 0x90, 0xF6,
+    0x7C, 0xBF, 0x20, 0xEB,  0x43, 0xA1, 0x88, 0x00,
+    0xF4, 0xFF, 0x0A, 0xFD,  0x82, 0xFF, 0x10, 0x12
+};
+
+const uint8_t stm32_ecc192_pointY[ECC192_KEYSIZE] = {
+    0x07, 0x19, 0x2B, 0x95,  0xFF, 0xC8, 0xDA, 0x78,
+    0x63, 0x10, 0x11, 0xED,  0x6B, 0x24, 0xCD, 0xD5,
+    0x73, 0xF9, 0x77, 0xA1,  0x1E, 0x79, 0x48, 0x11
+};
+
+const uint8_t stm32_ecc192_order[ECC192_KEYSIZE] = {
+    0xFF, 0xFF, 0xFF, 0xFF,  0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF,  0x99, 0xDE, 0xF8, 0x36,
+    0x14, 0x6B, 0xC9, 0xB1,  0xB4, 0xD2, 0x28, 0x31
+};
+const uint32_t stm32_ecc192_cofactor = 1U;
+
+#endif /* ECC192 */
+
+/* P-224 */
+#ifdef ECC224
+#define ECC224_KEYSIZE (28)
+static const uint8_t stm32_ecc224_prime[ECC224_KEYSIZE] = {
+    0xFF, 0xFF, 0xFF, 0xFF,  0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF,  0xFF, 0xFF, 0xFF, 0xFF,
+    0x00, 0x00, 0x00, 0x00,  0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x01
+};
+static const uint32_t stm32_ecc224_coef_sign = 1U;
+
+static const uint8_t stm32_ecc224_coef[ECC224_KEYSIZE] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x03
+};
+
+static const uint8_t stm32_ecc224_pointX[ECC224_KEYSIZE] =  {
+    0xB7, 0x0E, 0x0C, 0xBD, 0x6B, 0xB4, 0xBF, 0x7F,
+    0x32, 0x13, 0x90, 0xB9, 0x4A, 0x03, 0xC1, 0xD3,
+    0x56, 0xC2, 0x11, 0x22, 0x34, 0x32, 0x80, 0xD6,
+    0x11, 0x5C, 0x1D, 0x21
+};
+
+const uint8_t stm32_ecc224_pointY[ECC224_KEYSIZE] = {
+    0xBD, 0x37, 0x63, 0x88, 0xB5, 0xF7, 0x23, 0xFB,
+    0x4C, 0x22, 0xDF, 0xE6, 0xCD, 0x43, 0x75, 0xA0,
+    0x5A, 0x07, 0x47, 0x64, 0x44, 0xD5, 0x81, 0x99,
+    0x85, 0x00, 0x7E, 0x34
+};
+
+const uint8_t stm32_ecc224_order[ECC224_KEYSIZE] = {
+};
+const uint32_t stm32_ecc224_cofactor = 1U;
+
+#endif /* ECC224 */
+
 /* P-256 */
 #ifdef ECC256
 #define ECC256_KEYSIZE (32)
@@ -433,14 +515,14 @@ static const uint8_t stm32_ecc256_prime[ECC256_KEYSIZE] = {
 };
 static const uint32_t stm32_ecc256_coef_sign = 1U;
 
-static const uint8_t stm32_ecc256_coef[] = {
+static const uint8_t stm32_ecc256_coef[ECC256_KEYSIZE] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03
 };
 
-static const uint8_t stm32_ecc256_pointX[ECC256_KEYSIZE] =  {
+static const uint8_t stm32_ecc256_pointX[ECC256_KEYSIZE] = {
     0x6b, 0x17, 0xd1, 0xf2, 0xe1, 0x2c, 0x42, 0x47,
     0xf8, 0xbc, 0xe6, 0xe5, 0x63, 0xa4, 0x40, 0xf2,
     0x77, 0x03, 0x7d, 0x81, 0x2d, 0xeb, 0x33, 0xa0,
@@ -454,7 +536,7 @@ const uint8_t stm32_ecc256_pointY[ECC256_KEYSIZE] = {
     0xcb, 0xb6, 0x40, 0x68, 0x37, 0xbf, 0x51, 0xf5
 };
 
-const uint8_t stm32_ecc256_order[] = {
+const uint8_t stm32_ecc256_order[ECC256_KEYSIZE] = {
     0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00,
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
     0xbc, 0xe6, 0xfa, 0xad, 0xa7, 0x17, 0x9e, 0x84,
@@ -463,6 +545,53 @@ const uint8_t stm32_ecc256_order[] = {
 const uint32_t stm32_ecc256_cofactor = 1U;
 
 #endif /* ECC256 */
+
+/* P-384 */
+#ifdef ECC384
+#define ECC384_KEYSIZE (48)
+
+static const uint8_t stm32_ecc384_prime[ECC384_KEYSIZE] = {
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
+    0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF
+};
+static const uint32_t stm32_ecc384_coef_sign = 1U;
+
+static const uint8_t stm32_ecc384_coef[ECC384_KEYSIZE] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03
+};
+
+static const uint8_t stm32_ecc384_pointX[ECC384_KEYSIZE] =  {
+    0xAA, 0x87, 0xCA, 0x22, 0xBE, 0x8B, 0x05, 0x37,
+    0x8E, 0xB1, 0xC7, 0x1E, 0xF3, 0x20, 0xAD, 0x74,
+    0x6E, 0x1D, 0x3B, 0x62, 0x8B, 0xA7, 0x9B, 0x98,
+    0x59, 0xF7, 0x41, 0xE0, 0x82, 0x54, 0x2A, 0x38,
+    0x55, 0x02, 0xF2, 0x5D, 0xBF, 0x55, 0x29, 0x6C,
+    0x3A, 0x54, 0x5E, 0x38, 0x72, 0x76, 0x0A, 0xB7,
+};
+
+const uint8_t stm32_ecc384_pointY[ECC384_KEYSIZE] = {
+    0x36, 0x17, 0xDE, 0x4A, 0x96, 0x26, 0x2C, 0x6F,
+    0x5D, 0x9E, 0x98, 0xBF, 0x92, 0x92, 0xDC, 0x29,
+    0xF8, 0xF4, 0x1D, 0xBD, 0x28, 0x9A, 0x14, 0x7C,
+    0xE9, 0xDA, 0x31, 0x13, 0xB5, 0xF0, 0xB8, 0xC0,
+    0x0A, 0x60, 0xB1, 0xCE, 0x1D, 0x7E, 0x81, 0x9D,
+    0x7A, 0x43, 0x1D, 0x7C, 0x90, 0xEA, 0x0E, 0x5F,
+};
+
+const uint8_t stm32_ecc384_order[ECC384_KEYSIZE] = {
+};
+const uint32_t stm32_ecc384_cofactor = 1U;
+
+#endif /* ECC384 */
 static int stm32_get_ecc_specs(const uint8_t **prime, const uint8_t **coef,
     const uint32_t **coef_sign, const uint8_t **GenPointX, const uint8_t **GenPointY,
     const uint8_t **order, int size)
@@ -476,7 +605,6 @@ static int stm32_get_ecc_specs(const uint8_t **prime, const uint8_t **coef,
         *coef_sign = &stm32_ecc256_coef_sign;
         *order = stm32_ecc256_order;
         break;
-#if 0 /* TODO: Add other curves */
 #ifdef ECC224
     case 28:
         *prime = stm32_ecc224_prime;
@@ -488,7 +616,7 @@ static int stm32_get_ecc_specs(const uint8_t **prime, const uint8_t **coef,
 #endif
 #ifdef ECC192
     case 24:
-        *prime = stm32_ecc192_prime;
+        (uint8_t)*prime = stm32_ecc192_prime;
         *coef = stm32_ecc192_coef;
         *GenPointX = stm32_ecc192_pointX;
         *GenPointY = stm32_ecc192_pointY;
@@ -503,7 +631,6 @@ static int stm32_get_ecc_specs(const uint8_t **prime, const uint8_t **coef,
         *GenPointY = stm32_ecc384_pointY;
         *coef_sign = &stm32_ecc384_coef;
         break;
-#endif
 #endif
     default:
         return -1;
@@ -525,25 +652,26 @@ static int stm32_get_ecc_specs(const uint8_t **prime, const uint8_t **coef,
 int wc_ecc_mulmod_ex(mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
     mp_int *modulus, int map, void* heap)
 {
-    PKA_ECCMulInTypeDef pka_mul = { 0 };
+    PKA_ECCMulInTypeDef pka_mul;
     PKA_ECCMulOutTypeDef pka_mul_res;
     uint8_t size;
     int szModulus;
     int szkbin;
     int status;
     int res;
-
-
-    (void)a;
-    (void)heap;
-
     uint8_t Gxbin[STM32_MAX_ECC_SIZE];
     uint8_t Gybin[STM32_MAX_ECC_SIZE];
     uint8_t kbin[STM32_MAX_ECC_SIZE];
-
-
+    uint8_t PtXbin[STM32_MAX_ECC_SIZE];
+    uint8_t PtYbin[STM32_MAX_ECC_SIZE];
     const uint8_t *prime, *coef, *gen_x, *gen_y, *order;
     const uint32_t *coef_sign;
+    (void)a;
+    (void)heap;
+    memset(&pka_mul, 0x00, sizeof(PKA_ECCMulInTypeDef));
+    memset(&pka_mul_res, 0x00, sizeof(PKA_ECCMulOutTypeDef));
+    pka_mul_res.ptX = PtXbin;
+    pka_mul_res.ptY = PtYbin;
 
     if (k == NULL || G == NULL || R == NULL || modulus == NULL) {
         return ECC_BAD_ARG_E;
@@ -561,7 +689,7 @@ int wc_ecc_mulmod_ex(mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
     if (res != MP_OKAY)
         return res;
 
-    size = szModulus;
+    size = (uint8_t)szModulus;
     /* find STM32_PKA friendly parameters for the selected curve */
     if (0 != stm32_get_ecc_specs(&prime, &coef, &coef_sign, &gen_x, &gen_y, &order, size)) {
         return ECC_BAD_ARG_E;
@@ -596,9 +724,9 @@ int wc_ecc_mulmod_ex(mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
     }
     if (res == MP_OKAY)
         res = mp_set(R->z, 1);
+    HAL_PKA_RAMReset(&hpka);
     return res;
 }
-
 
 int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
                     word32 hashlen, int* res, ecc_key* key)
@@ -615,6 +743,7 @@ int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     uint8_t privKeybin[STM32_MAX_ECC_SIZE];
     const uint8_t *prime, *coef, *gen_x, *gen_y, *order;
     const uint32_t *coef_sign;
+    memset(&pka_ecc, 0x00, sizeof(PKA_ECDSAVerifInTypeDef));
 
     if (r == NULL || s == NULL || hash == NULL || res == NULL || key == NULL) {
         return ECC_BAD_ARG_E;
@@ -636,7 +765,7 @@ int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     if (status != MP_OKAY)
         return status;
 
-    size = szModulus;
+    size = (uint8_t)szModulus;
     /* find parameters for the selected curve */
     if (0 != stm32_get_ecc_specs(&prime, &coef, &coef_sign, &gen_x, &gen_y, &order, size)) {
         return ECC_BAD_ARG_E;
@@ -659,14 +788,16 @@ int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     pka_ecc.hash =            hash;
 
     status = HAL_PKA_ECDSAVerif(&hpka, &pka_ecc, 0xFFFFFFFF);
-    if (status != HAL_OK)
+    if (status != HAL_OK) {
+        HAL_PKA_RAMReset(&hpka);
         return WC_HW_E;
+    }
     *res = HAL_PKA_ECDSAVerif_IsValidSignature(&hpka);
+    HAL_PKA_RAMReset(&hpka);
     return status;
 }
 
-#if 0 /* TODO: work in progress */
-int wc_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
+int stm32_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
                      ecc_key* key, mp_int *r, mp_int *s)
 {
     PKA_ECDSASignInTypeDef pka_ecc;
@@ -678,12 +809,19 @@ int wc_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
     mp_int order_mp;
     uint8_t Keybin[STM32_MAX_ECC_SIZE];
     uint8_t Intbin[STM32_MAX_ECC_SIZE];
+    uint8_t Rbin[STM32_MAX_ECC_SIZE];
+    uint8_t Sbin[STM32_MAX_ECC_SIZE];
     const uint8_t *prime, *coef, *gen_x, *gen_y, *order;
     const uint32_t *coef_sign;
+    memset(&pka_ecc, 0x00, sizeof(PKA_ECDSASignInTypeDef));
+    memset(&pka_ecc, 0x00, sizeof(PKA_ECDSASignOutTypeDef));
 
     if (r == NULL || s == NULL || hash == NULL || key == NULL) {
         return ECC_BAD_ARG_E;
     }
+
+    mp_init(&gen_k);
+    mp_init(&order_mp);
 
     size = mp_unsigned_bin_size(key->pubkey.x);
 
@@ -717,16 +855,22 @@ int wc_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
     pka_ecc.integer =         Intbin;
     pka_ecc.privateKey =      Keybin;
 
+    /* Assign R, S static buffers */
+    pka_ecc_out.RSign = Rbin;
+    pka_ecc_out.SSign = Sbin;
+
     status = HAL_PKA_ECDSASign(&hpka, &pka_ecc, 0xFFFFFFFF);
-    if (status != HAL_OK)
+    if (status != HAL_OK) {
+        HAL_PKA_RAMReset(&hpka);
         return WC_HW_E;
+    }
     HAL_PKA_ECDSASign_GetResult(&hpka, &pka_ecc_out, NULL);
     status = mp_read_unsigned_bin(r, pka_ecc_out.RSign, size);
     if (status == MP_OKAY)
         status = mp_read_unsigned_bin(s, pka_ecc_out.SSign, size);
+    HAL_PKA_RAMReset(&hpka);
     return status;
 }
-#endif /* TODO */
 
 #endif /* HAVE_ECC */
 #endif /* WOLFSSL_STM32_PKA */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -18436,7 +18436,7 @@ int ecc_test(void)
         goto done;
     }
 #endif
-#if !defined(WOLFSSL_ATECC508A)
+#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_STM32_PKA)
     ret = ecc_test_make_pub(&rng);
     if (ret != 0) {
         printf("ecc_test_make_pub failed!: %d\n", ret);

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -711,6 +711,8 @@ WOLFSSL_API int wc_ecc_curve_cache_init(void);
 WOLFSSL_API void wc_ecc_curve_cache_free(void);
 #endif
 
+WOLFSSL_API
+int wc_ecc_gen_k(WC_RNG* rng, int size, mp_int* k, mp_int* order);
 
 #ifdef __cplusplus
     }    /* extern "C" */

--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -28,6 +28,9 @@
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/types.h>
 
+#if defined(WOLFSSL_STM32_PKA)
+    #include <wolfssl/wolfcrypt/ecc.h>
+#endif
 
 #ifdef STM32_HASH
 

--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -25,6 +25,7 @@
 /* Generic STM32 Hashing and Crypto Functions */
 /* Supports CubeMX HAL or Standard Peripheral Library */
 
+#include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/types.h>
 
 
@@ -126,6 +127,12 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
 #endif /* !NO_AES */
 
 #endif /* STM32_CRYPTO */
+
+#ifdef WOLFSSL_STM32_PKA
+int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
+                    word32 hashlen, int* res, ecc_key* key);
+
+#endif
 
 
 #endif /* _WOLFPORT_STM32_H_ */

--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -135,6 +135,9 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
 int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
                     word32 hashlen, int* res, ecc_key* key);
 
+int stm32_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
+                     ecc_key* key, mp_int *r, mp_int *s);
+
 #endif
 
 


### PR DESCRIPTION
STM32 new PKA accelerator, present in STM32WB55.

Test application:
https://github.com/danielinux/wolfssl-benchmark-stm32wb55

References: ST Microelectronics UM2442 Sec. 32.2
Implemented:
 - ECC MulMod
 - ECDSA Verify
 - ECDSA sign


