### PR TITLE
Apache updates

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20061,7 +20061,7 @@ int wolfSSL_X509_cmp(const WOLFSSL_X509 *a, const WOLFSSL_X509 *b)
 
 #ifndef NO_WOLFSSL_STUB
     WOLFSSL_ASN1_STRING* wolfSSL_d2i_DISPLAYTEXT(WOLFSSL_ASN1_STRING **asn,
-                                                  unsigned char **in, long len)
+                                             const unsigned char **in, long len)
     {
         WOLFSSL_STUB("d2i_DISPLAYTEXT");
         (void)asn;
@@ -24445,7 +24445,7 @@ const WOLFSSL_X509_ALGOR* wolfSSL_X509_get0_tbs_sigalg(const WOLFSSL_X509 *x509)
 }
 
 /* Sets paobj pointer to X509_ALGOR signature algorithm */
-void wolfSSL_X509_ALGOR_get0(WOLFSSL_ASN1_OBJECT **paobj, int *pptype,
+void wolfSSL_X509_ALGOR_get0(const WOLFSSL_ASN1_OBJECT **paobj, int *pptype,
                             const void **ppval, const WOLFSSL_X509_ALGOR *algor)
 {
     (void)pptype;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8124,19 +8124,24 @@ int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out, WOLFSSL_X509_EXTENSION *ext,
         case ALT_NAMES_OID:
             {
                 WOLFSSL_STACK* sk;
-                char val[sz];
+                char* val;
+                int len;
                 tmp[0] = '\0'; /* Make sure tmp is null-terminated */
 
                 sk = ext->ext_sk;
                 while (sk != NULL) {
                     /* str is GENERAL_NAME for subject alternative name ext */
                     str = sk->data.gn->d.ia5;
+                    len = str->length + 2; /* + 2 for NULL char and "," */
+                    val = (char*)XMALLOC(len + indent, NULL,
+                                                       DYNAMIC_TYPE_TMP_BUFFER);
                     if (sk->next)
-                        XSNPRINTF(val, sz, "%*s%s, ", indent, "", str->strData);
+                        XSNPRINTF(val, len, "%*s%s, ", indent, "", str->strData);
                     else
-                        XSNPRINTF(val, sz, "%*s%s", indent, "", str->strData);
+                        XSNPRINTF(val, len, "%*s%s", indent, "", str->strData);
 
                     XSTRNCAT(tmp, val, sz);
+                    XFREE(val, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                     sk = sk->next;
                 }
                 break;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8140,7 +8140,7 @@ int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out, WOLFSSL_X509_EXTENSION *ext,
                     else
                         XSNPRINTF(val, len, "%*s%s", indent, "", str->strData);
 
-                    XSTRNCAT(tmp, val, sz);
+                    XSTRNCAT(tmp, val, len);
                     XFREE(val, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                     sk = sk->next;
                 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -40565,10 +40565,10 @@ void wolfSSL_sk_X509_NAME_free(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk)
     XFREE(sk, sk->heap, DYNAMIC_TYPE_OPENSSL);
 }
 
-#if defined(WOLFSSL_APACHE_HTTPD)
+#if defined(WOLFSSL_APACHE_HTTPD) || defined(OPENSSL_ALL)
 /* Helper function for X509_NAME_print_ex. Sets *buf to string for domain
    name attribute based on NID. Returns size of buf */
-int get_dn_attr_by_nid(int n, char** buf)
+static int get_dn_attr_by_nid(int n, char** buf)
 {
     int len = 0;
     const char *str;
@@ -40617,7 +40617,7 @@ int get_dn_attr_by_nid(int n, char** buf)
 int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
                 int indent, unsigned long flags)
 {
-#if defined(WOLFSSL_APACHE_HTTPD)
+#if defined(WOLFSSL_APACHE_HTTPD) || defined(OPENSSL_ALL)
     int count = 0, len = 0, totalSz = 0, tmpSz = 0;
     char tmp[ASN_NAME_MAX];
     char fullName[ASN_NAME_MAX];
@@ -40636,7 +40636,7 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
 
     /* If XN_FLAG_DN_REV is present, print X509_NAME in reverse order */
     if (flags == (XN_FLAG_RFC2253 & ~XN_FLAG_DN_REV)) {
-#if defined(WOLFSSL_APACHE_HTTPD)
+#if defined(WOLFSSL_APACHE_HTTPD) || defined(OPENSSL_ALL)
         fullName[0] = '\0';
         count = wolfSSL_X509_NAME_entry_count(name);
         for (i = 0; i < count; i++) {
@@ -40652,7 +40652,7 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
             if (len == 0 || buf == NULL)
                 return WOLFSSL_FAILURE;
 
-            tmpSz = str->length + len + 2;
+            tmpSz = str->length + len + 2; /* + 2 for '=' and null char */
             if (i < count - 1) {
                 XSNPRINTF(tmp, tmpSz+1, "%s=%s,", buf, str->data);
                 XSTRNCAT(fullName, tmp, tmpSz);
@@ -40666,7 +40666,7 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
         if (wolfSSL_BIO_write(bio, fullName, totalSz) != totalSz)
             return WOLFSSL_FAILURE;
         return WOLFSSL_SUCCESS;
-#endif
+#endif /* WOLFSSL_APACHE_HTTPD || OPENSSL_ALL */
     }
     else if (flags == XN_FLAG_RFC2253) {
         if (wolfSSL_BIO_write(bio, name->name + 1, name->sz - 2)

--- a/tests/api.c
+++ b/tests/api.c
@@ -25028,11 +25028,21 @@ static void test_wolfSSL_X509V3_EXT_print(void)
     AssertNotNull(x509 = wolfSSL_PEM_read_X509(f, NULL, NULL, NULL));
     fclose(f);
 
+    AssertNotNull(bio = wolfSSL_BIO_new(BIO_s_mem()));
+
     loc = wolfSSL_X509_get_ext_by_NID(x509, NID_basic_constraints, -1);
     AssertIntGT(loc, -1);
     AssertNotNull(ext = wolfSSL_X509_get_ext(x509, loc));
-    AssertNotNull(bio = wolfSSL_BIO_new(BIO_s_mem()));
+    AssertIntEQ(wolfSSL_X509V3_EXT_print(bio, ext, 0, 0), WOLFSSL_SUCCESS);
 
+    loc = wolfSSL_X509_get_ext_by_NID(x509, NID_subject_key_identifier, -1);
+    AssertIntGT(loc, -1);
+    AssertNotNull(ext = wolfSSL_X509_get_ext(x509, loc));
+    AssertIntEQ(wolfSSL_X509V3_EXT_print(bio, ext, 0, 0), WOLFSSL_SUCCESS);
+
+    loc = wolfSSL_X509_get_ext_by_NID(x509, NID_authority_key_identifier, -1);
+    AssertIntGT(loc, -1);
+    AssertNotNull(ext = wolfSSL_X509_get_ext(x509, loc));
     AssertIntEQ(wolfSSL_X509V3_EXT_print(bio, ext, 0, 0), WOLFSSL_SUCCESS);
 
     wolfSSL_BIO_free(bio);

--- a/tests/api.c
+++ b/tests/api.c
@@ -21836,7 +21836,7 @@ static void test_wolfSSL_X509_ALGOR_get0(void)
 {
 #if (defined(OPENSSL_ALL) || defined(WOLFSSL_APACHE_HTTPD)) && !defined(NO_SHA256)
     X509* x509 = NULL;
-    ASN1_OBJECT* obj = NULL;
+    const ASN1_OBJECT* obj = NULL;
     const X509_ALGOR* alg;
     printf(testingFmt, "wolfSSL_X509_ALGOR_get0");
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1666,6 +1666,7 @@ enum {
     XN_FLAG_SEP_CPLUS_SPC = (2 << 16),
     XN_FLAG_ONELINE = 0,
     XN_FLAG_RFC2253 = 1,
+    XN_FLAG_DN_REV = (1 << 20),
 
     CRYPTO_LOCK = 1,
     CRYPTO_NUM_LOCKS = 10,
@@ -3346,7 +3347,9 @@ WOLFSSL_API void wolfSSL_sk_X509_NAME_pop_free(WOLF_STACK_OF(WOLFSSL_X509_NAME)*
     void f (WOLFSSL_X509_NAME*));
 WOLFSSL_API void wolfSSL_sk_X509_NAME_free(WOLF_STACK_OF(WOLFSSL_X509_NAME) *);
 
-
+#if defined(WOLFSSL_APACHE_HTTPD)
+WOLFSSL_API int get_dn_attr_by_nid(int n, char** buf);
+#endif
 WOLFSSL_API int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO*,WOLFSSL_X509_NAME*,int,
         unsigned long);
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1280,7 +1280,7 @@ WOLFSSL_API WOLFSSL_ASN1_STRING* wolfSSL_X509_NAME_ENTRY_get_data(WOLFSSL_X509_N
 WOLFSSL_API WOLFSSL_ASN1_STRING* wolfSSL_ASN1_STRING_new(void);
 WOLFSSL_API WOLFSSL_ASN1_STRING* wolfSSL_ASN1_STRING_type_new(int type);
 WOLFSSL_API int wolfSSL_ASN1_STRING_type(const WOLFSSL_ASN1_STRING* asn1);
-WOLFSSL_API WOLFSSL_ASN1_STRING* wolfSSL_d2i_DISPLAYTEXT(WOLFSSL_ASN1_STRING **asn, unsigned char **in, long len);
+WOLFSSL_API WOLFSSL_ASN1_STRING* wolfSSL_d2i_DISPLAYTEXT(WOLFSSL_ASN1_STRING **asn, const unsigned char **in, long len);
 WOLFSSL_API void wolfSSL_ASN1_STRING_free(WOLFSSL_ASN1_STRING* asn1);
 WOLFSSL_API int wolfSSL_ASN1_STRING_set(WOLFSSL_ASN1_STRING* asn1,
                                                   const void* data, int dataSz);
@@ -3579,7 +3579,7 @@ WOLFSSL_API size_t SSL_get_peer_finished(const WOLFSSL *s, void *buf, size_t cou
 WOLFSSL_API int SSL_SESSION_set1_id(WOLFSSL_SESSION *s, const unsigned char *sid, unsigned int sid_len);
 WOLFSSL_API int SSL_SESSION_set1_id_context(WOLFSSL_SESSION *s, const unsigned char *sid_ctx, unsigned int sid_ctx_len);
 WOLFSSL_API const WOLFSSL_X509_ALGOR* wolfSSL_X509_get0_tbs_sigalg(const WOLFSSL_X509 *x);
-WOLFSSL_API void wolfSSL_X509_ALGOR_get0(WOLFSSL_ASN1_OBJECT **paobj, int *pptype, const void **ppval, const WOLFSSL_X509_ALGOR *algor);
+WOLFSSL_API void wolfSSL_X509_ALGOR_get0(const WOLFSSL_ASN1_OBJECT **paobj, int *pptype, const void **ppval, const WOLFSSL_X509_ALGOR *algor);
 WOLFSSL_API WOLFSSL_X509_PUBKEY *wolfSSL_X509_get_X509_PUBKEY(const WOLFSSL_X509* x509);
 WOLFSSL_API int wolfSSL_X509_PUBKEY_get0_param(WOLFSSL_ASN1_OBJECT **ppkalg, const unsigned char **pk, int *ppklen, void **pa, WOLFSSL_X509_PUBKEY *pub);
 WOLFSSL_API int i2t_ASN1_OBJECT(char *buf, int buf_len, WOLFSSL_ASN1_OBJECT *a);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3347,9 +3347,6 @@ WOLFSSL_API void wolfSSL_sk_X509_NAME_pop_free(WOLF_STACK_OF(WOLFSSL_X509_NAME)*
     void f (WOLFSSL_X509_NAME*));
 WOLFSSL_API void wolfSSL_sk_X509_NAME_free(WOLF_STACK_OF(WOLFSSL_X509_NAME) *);
 
-#if defined(WOLFSSL_APACHE_HTTPD)
-WOLFSSL_API int get_dn_attr_by_nid(int n, char** buf);
-#endif
 WOLFSSL_API int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO*,WOLFSSL_X509_NAME*,int,
         unsigned long);
 


### PR DESCRIPTION
- Fixes several build warnings in Apache httpd

Various fixes with X509 extensions for Apache httpd's ssl tests:
- Adds ALT_NAMES_OID support to wolfSSL_X509_set_ext
- Updates to wolfSSL_X509V3_EXT_print and associated unit test for printing different extension types
- Updates to wolfSSL_X509_NAME_print_ex for printing domain name in reverse order when XN_FLAG_RFC2253 and XN_FLAG_DN_REV flags are present; helper function get_dn_attr_by_nid() also added