### PR TITLE
DTLS Redundant Check

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7768,9 +7768,7 @@ static int GetRecordHeader(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     }
 
 #ifdef WOLFSSL_DTLS
-    if (IsDtlsNotSctpMode(ssl) &&
-        (!DtlsCheckWindow(ssl) ||
-         (ssl->options.handShakeDone && ssl->keys.curEpoch == 0))) {
+    if (IsDtlsNotSctpMode(ssl) && !DtlsCheckWindow(ssl)) {
             WOLFSSL_LEAVE("GetRecordHeader()", SEQUENCE_ERROR);
             return SEQUENCE_ERROR;
     }


### PR DESCRIPTION
Remove a redundant sequence number check for epoch 0.