### PR TITLE
Add CAVP selftest version API prototype

### DIFF
--- a/fips-check.sh
+++ b/fips-check.sh
@@ -92,7 +92,7 @@ NETOS_7_6_CRYPT_REPO=git@github.com:cyassl/cyassl.git
 
 # non-FIPS, CAVP only but pull in selftest
 # will reset above variables below in platform switch
-NETBSD_FIPS_VERSION=v3.14.2a
+NETBSD_FIPS_VERSION=v3.14.2b
 NETBSD_FIPS_REPO=git@github.com:wolfssl/fips.git
 NETBSD_CRYPT_VERSION=v3.14.2
 NETBSD_CRYPT_REPO=git@github.com:wolfssl/wolfssl.git

--- a/wolfssl/wolfcrypt/selftest.h
+++ b/wolfssl/wolfcrypt/selftest.h
@@ -32,6 +32,9 @@
 #endif
 
 #ifdef HAVE_SELFTEST
+    /* Get wolfCrypt CAVP version */
+    WOLFSSL_API const char* wolfCrypt_GetVersion_CAVP_selftest(void);
+
     /* wolfCrypt self test, runs CAVP KATs */
     WOLFSSL_API int wolfCrypt_SelfTest(void);
 #endif


### PR DESCRIPTION
This PR accompanies the following PR in the fips repo.  It is dependent on the merging of PR 115 and the tagging of the fips repo (v3.14.2b):

https://github.com/wolfSSL/fips/pull/115

This adds a function which allows CAVP selftest users to get the underlying CAVP selftest version of wolfCrypt.  Similar to wolfCrypt_GetVersion_fips(), but for CAVP selftest.