### PR TITLE
Fix a return value from wolfSSL_BIO_BASE64_write()

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -274,7 +274,7 @@ static int wolfSSL_BIO_BASE64_write(WOLFSSL_BIO* bio, const void* data,
     }
 
     if (ret != WOLFSSL_FATAL_ERROR) {
-        ret = (int)*outLen;
+        ret = (int) inLen;
         XMEMCPY(out, tmp, *outLen);
 
     }
@@ -427,6 +427,7 @@ static int wolfSSL_BIO_MEMORY_write(WOLFSSL_BIO* bio, const void* data,
 int wolfSSL_BIO_write(WOLFSSL_BIO* bio, const void* data, int len)
 {
     int  ret = 0;
+    int  retB64 = 0;
     WOLFSSL_BIO* front = bio;
     void*  frmt   = NULL;
     word32 frmtSz = 0;
@@ -494,8 +495,8 @@ int wolfSSL_BIO_write(WOLFSSL_BIO* bio, const void* data, int len)
 
             if (ret >= 0) {
                 /* change so that data is formated buffer */
-                ret = wolfSSL_BIO_BASE64_write(bio, data, (word32)len,
-                        (byte*)frmt, &frmtSz);
+                retB64 = wolfSSL_BIO_BASE64_write(bio, data, (word32)len,
+                         (byte*)frmt, &frmtSz);
                 data = frmt;
                 len  = frmtSz;
             }
@@ -541,7 +542,10 @@ int wolfSSL_BIO_write(WOLFSSL_BIO* bio, const void* data, int len)
                                  (const char*)data, 0, 0, ret);
     }
 
-    return ret;
+    if (retB64 != 0)
+        return retB64;
+    else
+        return ret;
 }
 
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -22982,7 +22982,7 @@ static void test_wolfSSL_BIO_write(void)
     AssertNotNull(bio   = BIO_push(bio64, BIO_new(BIO_s_mem())));
 
     /* now should convert to base64 then write to memory */
-    AssertIntEQ(BIO_write(bio, msg, sizeof(msg)), 25);
+    AssertIntEQ(BIO_write(bio, msg, sizeof(msg)), sizeof(msg));
     BIO_flush(bio);
 
     /* test BIO chain */
@@ -22997,7 +22997,7 @@ static void test_wolfSSL_BIO_write(void)
     AssertIntEQ(XMEMCMP(out, expected, sz), 0);
 
     /* write then read should return the same message */
-    AssertIntEQ(BIO_write(bio, msg, sizeof(msg)), 25);
+    AssertIntEQ(BIO_write(bio, msg, sizeof(msg)), sizeof(msg));
     sz = sizeof(out);
     XMEMSET(out, 0, sz);
     AssertIntEQ(BIO_read(bio, out, sz), 16);
@@ -23005,7 +23005,7 @@ static void test_wolfSSL_BIO_write(void)
 
     /* now try encoding with no line ending */
     BIO_set_flags(bio64, BIO_FLAG_BASE64_NO_NL);
-    AssertIntEQ(BIO_write(bio, msg, sizeof(msg)), 24);
+    AssertIntEQ(BIO_write(bio, msg, sizeof(msg)), sizeof(msg));
     BIO_flush(bio);
     sz = sizeof(out);
     XMEMSET(out, 0, sz);
@@ -23019,8 +23019,8 @@ static void test_wolfSSL_BIO_write(void)
     AssertNotNull(bio   = BIO_push(BIO_new(BIO_f_base64()), bio64));
     AssertNotNull(BIO_push(bio64, BIO_new(BIO_s_mem())));
 
-    /* now should convert to base64(x2) when stored and then decode with read */
-    AssertIntEQ(BIO_write(bio, msg, sizeof(msg)), 37);
+    /* now should convert to base64 when stored and then decode with read */
+    AssertIntEQ(BIO_write(bio, msg, sizeof(msg)), 25);
     BIO_flush(bio);
     sz = sizeof(out);
     XMEMSET(out, 0, sz);

--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -130,7 +130,7 @@ int Base64_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
             }
         }
     }
-
+/* If the output buffer has a room for an extra byte, add a null terminator */
     if (out && *outLen > i)
         out[i]= '\0';
 
@@ -324,7 +324,7 @@ static int DoBase64_Encode(const byte* in, word32 inLen, byte* out,
 
     if (i != outSz && escaped != 1 && ret == 0)
         return ASN_INPUT_E;
-
+/* If the output buffer has a room for an extra byte, add a null terminator */
     if (out && *outLen > i)
         out[i]= '\0';
 


### PR DESCRIPTION
This PR corrects an issue with the return value of BIO_write(). 

Previously, a call to BIO_write() returns an incorrect amount of data written to the BIO.

The underlying issue was that the return value for wolfSSL_BIO_BASE64_write() was computed after a base64 conversion instead of the input data size. 


