### PR TITLE
Fix for hex digits with fastmath and normal integer

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -24095,7 +24095,7 @@ static void test_wolfSSL_X509_get_serialNumber(void)
     X509_free(x509); /* free's a */
 
     AssertNotNull(serialHex = BN_bn2hex(bn));
-    AssertStrEQ(serialHex, "1");
+    AssertStrEQ(serialHex, "01");
     OPENSSL_free(serialHex);
 
     AssertIntEQ(BN_get_word(bn), 1);

--- a/tests/api.c
+++ b/tests/api.c
@@ -24095,7 +24095,7 @@ static void test_wolfSSL_X509_get_serialNumber(void)
     X509_free(x509); /* free's a */
 
     AssertNotNull(serialHex = BN_bn2hex(bn));
-#ifdef OPENSSL_EXTRA
+#ifndef WC_DISABLE_RADIX_ZERO_PAD
     AssertStrEQ(serialHex, "01");
 #else
     AssertStrEQ(serialHex, "1");

--- a/tests/api.c
+++ b/tests/api.c
@@ -24095,7 +24095,11 @@ static void test_wolfSSL_X509_get_serialNumber(void)
     X509_free(x509); /* free's a */
 
     AssertNotNull(serialHex = BN_bn2hex(bn));
+#ifdef OPENSSL_EXTRA
     AssertStrEQ(serialHex, "01");
+#else
+    AssertStrEQ(serialHex, "1");
+#endif
     OPENSSL_free(serialHex);
 
     AssertIntEQ(BN_get_word(bn), 1);

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -5233,7 +5233,13 @@ int mp_toradix (mp_int *a, char *str, int radix)
         *str++ = mp_s_rmap[d];
         ++digs;
     }
-
+#ifdef OPENSSL_EXTRA
+    /* For hexadecimal output, add zero padding when number of digits is odd */
+    if ((digs & 1) && (radix == 16)) {
+        *str++ = mp_s_rmap[0];
+        ++digs;
+    }
+#endif
     /* reverse the digits of the string.  In this case _s points
      * to the first digit [excluding the sign] of the number]
      */

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -5233,7 +5233,7 @@ int mp_toradix (mp_int *a, char *str, int radix)
         *str++ = mp_s_rmap[d];
         ++digs;
     }
-#ifdef OPENSSL_EXTRA
+#ifndef WC_DISABLE_RADIX_ZERO_PAD
     /* For hexadecimal output, add zero padding when number of digits is odd */
     if ((digs & 1) && (radix == 16)) {
         *str++ = mp_s_rmap[0];

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -4779,7 +4779,7 @@ int mp_toradix (mp_int *a, char *str, int radix)
         *str++ = fp_s_rmap[d];
         ++digs;
     }
-#ifdef OPENSSL_EXTRA
+#ifndef WC_DISABLE_RADIX_ZERO_PAD
     /* For hexadecimal output, add zero padding when number of digits is odd */
     if ((digs & 1) && (radix == 16)) {
         *str++ = fp_s_rmap[0];

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -4780,6 +4780,12 @@ int mp_toradix (mp_int *a, char *str, int radix)
         ++digs;
     }
 
+    /* For hexadecimal output, add zero when number of digits is odd */
+    if ((digs & 1) && (radix == 16)) {
+        *str++ = fp_s_rmap[0];
+        ++digs;
+    }
+
     /* reverse the digits of the string.  In this case _s points
      * to the first digit [excluding the sign] of the number]
      */

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -4779,13 +4779,13 @@ int mp_toradix (mp_int *a, char *str, int radix)
         *str++ = fp_s_rmap[d];
         ++digs;
     }
-
-    /* For hexadecimal output, add zero when number of digits is odd */
+#ifdef OPENSSL_EXTRA
+    /* For hexadecimal output, add zero padding when number of digits is odd */
     if ((digs & 1) && (radix == 16)) {
         *str++ = fp_s_rmap[0];
         ++digs;
     }
-
+#endif
     /* reverse the digits of the string.  In this case _s points
      * to the first digit [excluding the sign] of the number]
      */


### PR DESCRIPTION
ZD#5751
This PR adds a missing leading zero to a string of hexadecimal digits. 