### PR TITLE
Fixed Freescale LTC crypto module to compile with SP math

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5543,26 +5543,26 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
    CRYS_ECDSA_VerifyUserContext_t sigCtxTemp;
    word32 msgLenInBytes = hashlen;
    CRYS_ECPKI_HASH_OpMode_t hash_mode;
-#elif !defined(WOLFSSL_SP_MATH)
+#elif !defined(WOLFSSL_SP_MATH) || defined(FREESCALE_LTC_ECC)
    int          did_init = 0;
    ecc_point    *mG = NULL, *mQ = NULL;
-#ifdef WOLFSSL_SMALL_STACK
+   #ifdef WOLFSSL_SMALL_STACK
    mp_int*       v = NULL;
    mp_int*       w = NULL;
    mp_int*       u1 = NULL;
    mp_int*       u2 = NULL;
-#if !defined(WOLFSSL_ASYNC_CRYPT) || !defined(HAVE_CAVIUM_V)
+      #if !defined(WOLFSSL_ASYNC_CRYPT) || !defined(HAVE_CAVIUM_V)
    mp_int*       e_lcl = NULL;
-#endif
-#else /* WOLFSSL_SMALL_STACK */
+      #endif
+   #else /* WOLFSSL_SMALL_STACK */
    mp_int        v[1];
    mp_int        w[1];
    mp_int        u1[1];
    mp_int        u2[1];
-#if !defined(WOLFSSL_ASYNC_CRYPT) || !defined(HAVE_CAVIUM_V)
+      #if !defined(WOLFSSL_ASYNC_CRYPT) || !defined(HAVE_CAVIUM_V)
    mp_int        e_lcl[1];
-#endif
-#endif /* WOLFSSL_SMALL_STACK */
+      #endif
+   #endif /* WOLFSSL_SMALL_STACK */
    mp_int*       e;
    DECLARE_CURVE_SPECS(curve, ECC_CURVE_FIELD_COUNT);
 #endif
@@ -5661,7 +5661,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
       }
   }
 
-#ifdef WOLFSSL_SP_MATH
+#if defined(WOLFSSL_SP_MATH) && !defined(FREESCALE_LTC_ECC)
   if (key->idx != ECC_CUSTOM_IDX && ecc_sets[key->idx].id == ECC_SECP256R1) {
       return sp_ecc_verify_256(hash, hashlen, key->pubkey.x, key->pubkey.y,
                                            key->pubkey.z, r, s, res, key->heap);
@@ -5669,7 +5669,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
   else
       return WC_KEY_SIZE_E;
 #else
-#ifdef WOLFSSL_HAVE_SP_ECC
+#if defined WOLFSSL_HAVE_SP_ECC && !defined(FREESCALE_LTC_ECC)
 #ifndef WOLFSSL_SP_NO_256
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ECC)
     if (key->asyncDev.marker != WOLFSSL_ASYNC_MARKER_ECC)

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -52,6 +52,16 @@ WOLFSSL_LOCAL int sp_ModExp_3072(sp_int* base, sp_int* exp, sp_int* mod,
 
 #endif
 
+int sp_get_digit_count(sp_int *a)
+{
+    int ret;
+    if (!a)
+        ret = 0;
+    else
+        ret = a->used;
+    return ret;
+}
+
 /* Initialize the big number to be zero.
  *
  * a  SP integer.
@@ -388,6 +398,18 @@ int sp_copy(sp_int* a, sp_int* r)
     }
     return MP_OKAY;
 }
+
+/* creates "a" then copies b into it */
+int sp_init_copy (sp_int * a, sp_int * b)
+{
+  int     res;
+  if ((res = sp_init(a)) == MP_OKAY) {
+      if((res = sp_copy (b, a)) != MP_OKAY) {
+          sp_clear(a);
+      }
+  }
+  return res;
+}
 #endif
 
 /* Set the big number to be the value of the digit.
@@ -561,7 +583,7 @@ int sp_sub(sp_int* a, sp_int* b, sp_int* r)
  * n    Number of bits to shift.
  * r    SP integer result.
  */
-static void sp_rshb(sp_int* a, int n, sp_int* r)
+void sp_rshb(sp_int* a, int n, sp_int* r)
 {
     int i;
     int j;
@@ -704,6 +726,8 @@ static int sp_div(sp_int* a, sp_int* d, sp_int* r, sp_int* rem)
     return err;
 }
 
+
+#ifndef FREESCALE_LTC_TFM
 /* Calculate the remainder of dividing a by m: r = a mod m.
  *
  * a  SP integer.
@@ -715,6 +739,7 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
 {
     return sp_div(a, m, NULL, r);
 }
+#endif
 #endif
 
 /* Clear all data in the big number and sets value to zero.

--- a/wolfssl/wolfcrypt/port/nxp/ksdk_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/ksdk_port.h
@@ -25,6 +25,8 @@
 #include <wolfssl/wolfcrypt/settings.h>
 #ifdef USE_FAST_MATH
     #include <wolfssl/wolfcrypt/tfm.h>
+#elif defined WOLFSSL_SP_MATH
+    #include <wolfssl/wolfcrypt/sp_int.h>
 #else
     #include <wolfssl/wolfcrypt/integer.h>
 #endif
@@ -44,6 +46,10 @@ int ksdk_port_init(void);
 	int wolfcrypt_mp_mod(mp_int *a, mp_int *b, mp_int *c);
 	int wolfcrypt_mp_invmod(mp_int *a, mp_int *b, mp_int *c);
 	int wolfcrypt_mp_exptmod(mp_int *G, mp_int *X, mp_int *P, mp_int *Y);
+
+    /* Exported mp_mulmod function */
+    int mp_mulmod(mp_int *a, mp_int *b, mp_int *c, mp_int *d);
+
 #endif /* FREESCALE_LTC_TFM */
 
 #if defined(FREESCALE_LTC_ECC)

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -187,6 +187,10 @@ MP_API int sp_exptmod(sp_int* b, sp_int* e, sp_int* m, sp_int* r);
 MP_API int sp_prime_is_prime(mp_int* a, int t, int* result);
 MP_API int sp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng);
 MP_API int sp_exch(sp_int* a, sp_int* b);
+MP_API int sp_get_digit_count(sp_int *a);
+MP_API int sp_init_copy (sp_int * a, sp_int * b);
+MP_API void sp_rshb(sp_int* a, int n, sp_int* r);
+
 
 #define MP_OKAY    0
 #define MP_NO      0
@@ -249,6 +253,9 @@ MP_API int sp_exch(sp_int* a, sp_int* b);
 #define mp_prime_is_prime           sp_prime_is_prime
 #define mp_prime_is_prime_ex        sp_prime_is_prime_ex
 #define mp_exch                     sp_exch
+#define get_digit_count             sp_get_digit_count
+#define mp_init_copy                sp_init_copy
+#define mp_rshb(A,x)                sp_rshb(A,x,A)
 
 #endif
 


### PR DESCRIPTION
This PR allows to compile ksdk_port.c and use the ECC accelerator from Freescale also with `WOLFSSL_SP_MATH`.

Tested ecc_verify on Kinetis K82 using wolfboot.