### PR TITLE
Fix to restore notBefore/notAfter functions

### DIFF
--- a/cyassl/ssl.h
+++ b/cyassl/ssl.h
@@ -164,6 +164,8 @@
 /* get index cert in PEM */
 #define CyaSSL_X509_get_subjectCN wolfSSL_X509_get_subjectCN
 #define CyaSSL_X509_get_der       wolfSSL_X509_get_der
+#define CyaSSL_X509_notBefore     wolfSSL_X509_notBefore
+#define CyaSSL_X509_notAfter      wolfSSL_X509_notAfter
 #define CyaSSL_X509_get_notBefore wolfSSL_X509_get_notBefore
 #define CyaSSL_X509_get_notAfter  wolfSSL_X509_get_notAfter
 #define CyaSSL_X509_version       wolfSSL_X509_version

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17889,6 +17889,41 @@ WOLFSSL_X509* wolfSSL_X509_d2i(WOLFSSL_X509** x509, const byte* in, int len)
         return x509->derCert->buffer;
     }
 
+    /* used by JSSE (not a standard compatibility function) */
+    /* this is not thread safe */
+    const byte* wolfSSL_X509_notBefore(WOLFSSL_X509* x509)
+    {
+        static byte notBeforeData[CTC_DATE_SIZE]; /* temp buffer for date */
+        WOLFSSL_ENTER("wolfSSL_X509_notBefore");
+
+        if (x509 == NULL)
+            return NULL;
+
+        XMEMSET(notBeforeData, 0, sizeof(notBeforeData));
+        notBeforeData[0] = (byte)x509->notBefore.type;
+        notBeforeData[1] = (byte)x509->notBefore.length;
+        XMEMCPY(&notBeforeData[2], x509->notBefore.data, x509->notBefore.length);
+
+        return notBeforeData;
+    }
+    /* used by JSSE (not a standard compatibility function) */
+    /* this is not thread safe */
+    const byte* wolfSSL_X509_notAfter(WOLFSSL_X509* x509)
+    {
+        static byte notAfterData[CTC_DATE_SIZE]; /* temp buffer for date */
+        WOLFSSL_ENTER("wolfSSL_X509_notAfter");
+
+        if (x509 == NULL)
+            return NULL;
+
+        XMEMSET(notAfterData, 0, sizeof(notAfterData));
+        notAfterData[0] = (byte)x509->notAfter.type;
+        notAfterData[1] = (byte)x509->notAfter.length;
+        XMEMCPY(&notAfterData[2], x509->notAfter.data, x509->notAfter.length);
+
+        return notAfterData;
+    }
+
 
     /* get the buffer to be signed (tbs) from the WOLFSSL_X509 certificate
      *

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1999,6 +1999,8 @@ WOLFSSL_API int  wolfSSL_X509_get_serial_number(WOLFSSL_X509*,unsigned char*,int
 WOLFSSL_API char*  wolfSSL_X509_get_subjectCN(WOLFSSL_X509*);
 WOLFSSL_API const unsigned char* wolfSSL_X509_get_der(WOLFSSL_X509*, int*);
 WOLFSSL_API const unsigned char* wolfSSL_X509_get_tbs(WOLFSSL_X509*, int*);
+WOLFSSL_API const byte* wolfSSL_X509_notBefore(WOLFSSL_X509* x509);
+WOLFSSL_API const byte* wolfSSL_X509_notAfter(WOLFSSL_X509* x509);
 WOLFSSL_API int wolfSSL_X509_version(WOLFSSL_X509*);
 
 WOLFSSL_API int wolfSSL_cmp_peer_cert_to_file(WOLFSSL*, const char*);


### PR DESCRIPTION
Fix to restore notBefore/notAfter functions that were removed in PR #2462. These are not openssl compatibility functions, but are used by JSSE.