### PR TITLE
Fix DTLS+OPENSSLALL+FIPS Failure

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1626,6 +1626,17 @@ int InitSSL_Side(WOLFSSL* ssl, word16 side)
     }
 #endif /* HAVE_EXTENDED_MASTER && !NO_WOLFSSL_CLIENT */
 
+#if defined(WOLFSSL_DTLS) && !defined(NO_WOLFSSL_SERVER)
+    if (ssl->options.dtls && ssl->options.side == WOLFSSL_SERVER_END) {
+        int ret;
+        ret = wolfSSL_DTLS_SetCookieSecret(ssl, NULL, 0);
+        if (ret != 0) {
+            WOLFSSL_MSG("DTLS Cookie Secret error");
+            return ret;
+        }
+    }
+#endif /* WOLFSSL_DTLS && !NO_WOLFSSL_SERVER */
+
     return InitSSL_Suites(ssl);
 }
 #endif /* OPENSSL_EXTRA || WOLFSSL_EITHER_SIDE */


### PR DESCRIPTION
There was a problem with the combination of DTLS, OpenSSL Compatibility, and FIPSv2 where the DTLS server would fail out because a HMAC key was too short. FIPS requires a HMAC key be a minimum size. The DTLS server uses HMAC to generate the first cookie key when initialized. When using OpenSSL, the feature for creating a DTLS endpoint with its side being set late is tested. The DTLS cookie wasn't getting set at init because the server was "neither" at the time. Added a call to set cookie when initializing a neither endpoint into a server.