### PR TITLE
Testing

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6323,6 +6323,7 @@ int ProcessFile(WOLFSSL_CTX* ctx, const char* fname, int format, int type,
                 WOLFSSL_MSG("Failed to detect certificate type");
                 if (dynamic)
                     XFREE(myBuffer, heapHint, DYNAMIC_TYPE_FILE);
+                XFCLOSE(file);
                 return WOLFSSL_BAD_CERTTYPE;
             }
         }
@@ -16892,7 +16893,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     {
         WOLFSSL_ENTER("wolfSSL_ERR_clear_error");
 
-#if defined(DEBUG_WOLFSSL) || defined(WOLFSSL_NGINX)
+#if defined(DEBUG_WOLFSSL) || defined(WOLFSSL_NGINX) || \
+    defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
         wc_ClearErrorNodes();
 #endif
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -19107,6 +19107,7 @@ static void test_wolfSSL_private_keys(void)
     SSL_free(ssl);
     SSL_CTX_free(ctx);
 #endif /* end of Ed25519 private key match tests */
+    EVP_cleanup();
 
     /* test existence of no-op macros in wolfssl/openssl/ssl.h */
     CONF_modules_free();
@@ -28165,8 +28166,6 @@ static int test_various_pathlen_chains(void)
     WOLFSSL_CERT_MANAGER* cm;
 
     /* Test chain G (large chain with varying pathLens) */
-    wolfSSL_Init();
-
     if ((cm = wolfSSL_CertManagerNew()) == NULL) {
         printf("cert manager new failed\n");
         return -1;
@@ -28648,6 +28647,7 @@ void ApiTest(void)
     AssertIntEQ(test_wc_DsaExportKeyRaw(), 0);
     AssertIntEQ(test_wc_SignatureGetSize_ecc(), 0);
     AssertIntEQ(test_wc_SignatureGetSize_rsa(), 0);
+    wolfCrypt_Cleanup();
 
 #ifdef OPENSSL_EXTRA
     /*wolfSSL_EVP_get_cipherbynid test*/
@@ -28736,6 +28736,10 @@ void ApiTest(void)
      * a need to implement a new test case
      */
     test_stubs_are_stubs();
+#if defined(HAVE_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS) \
+                      && (defined(NO_MAIN_DRIVER) || defined(HAVE_STACK_SIZE))
+    wc_ecc_fp_free();  /* free per thread cache */
+#endif
     wolfSSL_Cleanup();
 
     printf(" End API Tests\n");

--- a/tests/api.c
+++ b/tests/api.c
@@ -4321,7 +4321,8 @@ static void test_wolfSSL_PKCS12(void)
                    * Password Key
                    */
 #if defined(OPENSSL_EXTRA) && !defined(NO_DES3) && !defined(NO_FILESYSTEM) && \
-    !defined(NO_ASN) && !defined(NO_PWDBASED) && !defined(NO_RSA)
+    !defined(NO_ASN) && !defined(NO_PWDBASED) && !defined(NO_RSA) && \
+    !defined(NO_SHA)
     byte buffer[5300];
     char file[] = "./certs/test-servercert.p12";
     char order[] = "./certs/ecc-rsa-server.p12";
@@ -4614,11 +4615,11 @@ static void test_wolfSSL_PKCS8(void)
     word32 x = 0;
 #endif
 #ifdef TEST_PKCS8_ENC
-    #ifndef NO_RSA
+    #if !defined(NO_RSA) && !defined(NO_SHA)
         const char serverKeyPkcs8EncPemFile[] = "./certs/server-keyPkcs8Enc.pem";
         const char serverKeyPkcs8EncDerFile[] = "./certs/server-keyPkcs8Enc.der";
     #endif
-    #ifdef HAVE_ECC
+    #if defined(HAVE_ECC) && !defined(NO_SHA)
         const char eccPkcs8EncPrivKeyPemFile[] = "./certs/ecc-keyPkcs8Enc.pem";
         const char eccPkcs8EncPrivKeyDerFile[] = "./certs/ecc-keyPkcs8Enc.der";
     #endif
@@ -4646,7 +4647,7 @@ static void test_wolfSSL_PKCS8(void)
     wolfSSL_CTX_set_default_passwd_cb_userdata(ctx, (void*)&flag);
     flag = 1; /* used by password callback as return code */
 
-    #ifndef NO_RSA
+    #if !defined(NO_RSA) && !defined(NO_SHA)
     /* test loading PEM PKCS8 encrypted file */
     f = XFOPEN(serverKeyPkcs8EncPemFile, "rb");
     AssertTrue((f != XBADFILE));
@@ -4683,7 +4684,7 @@ static void test_wolfSSL_PKCS8(void)
                 WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
     #endif /* !NO_RSA */
 
-    #ifdef HAVE_ECC
+    #if defined(HAVE_ECC) && !defined(NO_SHA)
     /* test loading PEM PKCS8 encrypted ECC Key file */
     f = XFOPEN(eccPkcs8EncPrivKeyPemFile, "rb");
     AssertTrue((f != XBADFILE));
@@ -18118,7 +18119,7 @@ static void test_wc_i2d_PKCS12(void)
 {
 #if !defined(NO_ASN) && !defined(NO_PWDBASED) && defined(HAVE_PKCS12) \
     && !defined(NO_FILESYSTEM) && !defined(NO_RSA) \
-    && !defined(NO_AES) && !defined(NO_DES3)
+    && !defined(NO_AES) && !defined(NO_DES3) && !defined(NO_SHA)
     WC_PKCS12* pkcs12 = NULL;
     unsigned char der[FOURK_BUF * 2];
     unsigned char* pt;
@@ -22384,7 +22385,7 @@ static void test_wolfSSL_OBJ(void)
  * mode
  */
 #if defined(OPENSSL_EXTRA) && !defined(NO_SHA256) && !defined(NO_ASN) && \
-    !defined(HAVE_FIPS)
+    !defined(HAVE_FIPS) && !defined(NO_SHA)
     ASN1_OBJECT *obj = NULL;
     char buf[50];
 

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -903,7 +903,8 @@ int SuiteTest(int argc, char** argv)
     }
     #endif
 #endif
-#if defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_DES3) && !defined(NO_MD5)
+#if defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_DES3) && !defined(NO_MD5) &&\
+    !defined(NO_SHA)
     /* test encrypted keys */
     strcpy(argv0[1], "tests/test-enckeys.conf");
     printf("starting encrypted keys extra cipher suite tests\n");

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -998,6 +998,10 @@ exit:
     wolfSSL_CTX_free(cipherSuiteCtx);
     wolfSSL_Cleanup();
 
+#if defined(HAVE_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS) \
+                      && (defined(NO_MAIN_DRIVER) || defined(HAVE_STACK_SIZE))
+    wc_ecc_fp_free();  /* free per thread cache */
+#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     wolfAsync_DevClose(&devId);
 #endif

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -31,6 +31,10 @@
 #include <string.h>
 #include <wolfssl/ssl.h>
 #include <tests/unit.h>
+#if defined(HAVE_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS) \
+                      && (defined(NO_MAIN_DRIVER) || defined(HAVE_STACK_SIZE))
+#include <wolfssl/wolfcrypt/ecc.h>
+#endif
 
 
 #define MAX_ARGS 40

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4455,6 +4455,7 @@ void InitDecodedCert(DecodedCert* cert,
         cert->source          = source;  /* don't own */
         cert->maxIdx          = inSz;    /* can't go over this index */
         cert->heap            = heap;
+        cert->maxPathLen      = WOLFSSL_MAX_PATH_LEN;
     #ifdef WOLFSSL_CERT_GEN
         cert->subjectSNEnc    = CTC_UTF8;
         cert->subjectCEnc     = CTC_PRINTABLE;

--- a/wolfcrypt/src/port/arm/armv8-sha256.c
+++ b/wolfcrypt/src/port/arm/armv8-sha256.c
@@ -1345,6 +1345,23 @@ int wc_Sha256GetHash(wc_Sha256* sha256, byte* hash)
     return ret;
 }
 
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+int wc_Sha256SetFlags(wc_Sha256* sha256, word32 flags)
+{
+    if (sha256) {
+        sha256->flags = flags;
+    }
+    return 0;
+}
+int wc_Sha256GetFlags(wc_Sha256* sha256, word32* flags)
+{
+    if (sha256 && flags) {
+        *flags = sha256->flags;
+    }
+    return 0;
+}
+#endif
+
 int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
 {
     int ret = 0;
@@ -1453,6 +1470,24 @@ int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
         }
         return ret;
     }
+
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+    int wc_Sha224SetFlags(wc_Sha224* sha224, word32 flags)
+    {
+        if (sha224) {
+            sha224->flags = flags;
+        }
+        return 0;
+    }
+    int wc_Sha224GetFlags(wc_Sha224* sha224, word32* flags)
+    {
+        if (sha224 && flags) {
+            *flags = sha224->flags;
+        }
+        return 0;
+    }
+#endif
+
     int wc_Sha224Copy(wc_Sha224* src, wc_Sha224* dst)
     {
         int ret = 0;

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1535,6 +1535,7 @@ int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
 
     return ret;
 }
+#endif
 
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
 int wc_Sha256SetFlags(wc_Sha256* sha256, word32 flags)
@@ -1551,8 +1552,6 @@ int wc_Sha256GetFlags(wc_Sha256* sha256, word32* flags)
     }
     return 0;
 }
-#endif
-
 #endif
 #endif /* !WOLFSSL_TI_HASH */
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5288,7 +5288,7 @@ int des_test(void)
     if (ret != 0)
         return -4606;
 
-#ifdef WOLFSSL_ENCRYPTED_KEYS
+#if defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_SHA)
     {
         EncryptedInfo info;
         XMEMSET(&info, 0, sizeof(EncryptedInfo));
@@ -5422,7 +5422,7 @@ int des3_test(void)
     wc_Des3Free(&enc);
     wc_Des3Free(&dec);
 
-#ifdef WOLFSSL_ENCRYPTED_KEYS
+#if defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_SHA)
     {
         EncryptedInfo info;
         XMEMSET(&info, 0, sizeof(EncryptedInfo));

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -682,8 +682,8 @@ typedef WOLFSSL_EVP_CIPHER_CTX EVP_CIPHER_CTX;
 #define EVP_cleanup                wolfSSL_EVP_cleanup
 #define EVP_read_pw_string         wolfSSL_EVP_read_pw_string
 
-#define OpenSSL_add_all_digests()  wolfCrypt_Init()
-#define OpenSSL_add_all_ciphers()  wolfCrypt_Init()
+#define OpenSSL_add_all_digests()  wolfSSL_EVP_init()
+#define OpenSSL_add_all_ciphers()  wolfSSL_EVP_init()
 #define OpenSSL_add_all_algorithms wolfSSL_add_all_algorithms
 #define OpenSSL_add_all_algorithms_noconf wolfSSL_OpenSSL_add_all_algorithms_noconf
 #define wolfSSL_OPENSSL_add_all_algorithms_noconf wolfSSL_OpenSSL_add_all_algorithms_noconf


### PR DESCRIPTION
- adds initialization of max pathlen to certificates for retaining ASN no signer error when CA is not found (thanks Kaleb)
- fix for sha256 build on ARMv8
- fix for valgrind issues found; free file in error case and to avoid uneven wolfCrypt_Init/wolfSSL_Init versus the number of wolfCrypt_Cleanup/wolfSSL_Cleanup in test cases