### PR TITLE
mmCAU Classic AES key alignment, IAR warnings fixes

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -2768,7 +2768,7 @@ int fp_montgomery_reduce(fp_int *a, fp_int *m, fp_digit mp)
    fp_digit *c;
 #endif
    fp_digit *_c, *tmpm, mu = 0;
-   int      oldused, x, y, pa, err;
+   int      oldused, x, y, pa, err = 0;
 
    IF_HAVE_INTEL_MULX(err = fp_montgomery_reduce_mulx(a, m, mp), return err) ;
    (void)err;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -862,7 +862,8 @@
     #endif
 
 
-    #if defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__)
+    #if (defined(__IAR_SYSTEMS_ICC__) && (__IAR_SYSTEMS_ICC__ > 8)) || \
+         defined(__GNUC__)
         #define WOLFSSL_PACK __attribute__ ((packed))
     #else
         #define WOLFSSL_PACK


### PR DESCRIPTION
This PR:

- Aligns AES key if needed when mmCAU classic (FREESCALE_MMCAU_CLASSIC) is used and NO_WOLFSSL_ALLOC_ALIGN is not defined.
- Fixes IAR warnings with IAR-EWARM 7.50.2