### PR TITLE
Fix for configure used in wolfssl-examples/signature/rsa_vfy_only.…

### DIFF
--- a/wolfcrypt/src/wolfmath.c
+++ b/wolfcrypt/src/wolfmath.c
@@ -71,6 +71,7 @@
 #endif
 
 
+#if !defined(WOLFSSL_SP_MATH)
 int get_digit_count(mp_int* a)
 {
     if (a == NULL)
@@ -78,6 +79,7 @@ int get_digit_count(mp_int* a)
 
     return a->used;
 }
+#endif
 
 mp_digit get_digit(mp_int* a, int n)
 {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11587,7 +11587,7 @@ int rsa_test(void)
 #if defined(HAVE_NTRU)
     RsaKey caKey;
 #endif
-#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) || defined(WOLFSSL_MP_PUBLIC)
+#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) || defined(WOLFSSL_PUBLIC_MP)
     word32 idx = 0;
     const char* inStr = "Everyone gets Friday off.";
     word32      inLen = (word32)XSTRLEN((char*)inStr);
@@ -11607,7 +11607,7 @@ int rsa_test(void)
     DecodedCert cert;
 #endif
 
-#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) || defined(WOLFSSL_MP_PUBLIC)
+#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) || defined(WOLFSSL_PUBLIC_MP)
     DECLARE_VAR_INIT(in, byte, inLen, inStr, HEAP_HINT);
     DECLARE_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
     DECLARE_VAR(plain, byte, RSA_TEST_BYTES, HEAP_HINT);
@@ -11802,7 +11802,7 @@ int rsa_test(void)
     }
     TEST_SLEEP();
 
-#elif defined(WOLFSSL_MP_PUBLIC)
+#elif defined(WOLFSSL_PUBLIC_MP)
     (void)outSz;
     (void)inLen;
     (void)res;
@@ -11846,7 +11846,7 @@ int rsa_test(void)
     }
 #endif
 
-#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) || defined(WOLFSSL_MP_PUBLIC)
+#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) || defined(WOLFSSL_PUBLIC_MP)
     idx = (word32)ret;
     XMEMSET(plain, 0, plainSz);
     do {


### PR DESCRIPTION
...and a fix for wrong WOLFSSL_MP_PUBLIC defines.

The define around get_digit_count is due to multiple definitions of sp_get_digit_count

./configure CFLAGS=-DWOLFSSL_PUBLIC_MP --disable-asn --disable-filesystem --enable-static --enable-shared --enable-cryptonly --enable-sp=smallrsa2048 --enable-sp-math --disable-dh --disable-ecc --disable-sha224 --enable-rsavfy

