### PR TITLE
Apache: Return WANT_READ in wolfSSLReceive if BIO retry and read flags are set

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7414,6 +7414,15 @@ retry:
     if (recvd < 0) {
         switch (recvd) {
             case WOLFSSL_CBIO_ERR_GENERAL:        /* general/unknown error */
+                #if defined(OPENSSL_ALL) || defined(WOLFSSL_APACHE_HTTPD)
+                    if (ssl->biord) {
+                        /* If retry and read flags are set, return WANT_READ */
+                        if ((ssl->biord->flags & WOLFSSL_BIO_FLAG_READ) &&
+                            (ssl->biord->flags & WOLFSSL_BIO_FLAG_RETRY)) {
+                            return WANT_READ;
+                        }
+                    }
+                #endif
                 return -1;
 
             case WOLFSSL_CBIO_ERR_WANT_READ:      /* want read, would block */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -43692,6 +43692,7 @@ static int bio_get_data(WOLFSSL_BIO* bio, byte** data)
     return ret;
 }
 
+#ifndef NO_WOLFSSL_STUB
 void wolfSSL_BIO_set_init(WOLFSSL_BIO* bio, int init)
 {
     WOLFSSL_STUB("wolfSSL_BIO_set_init");
@@ -43712,12 +43713,14 @@ int wolfSSL_BIO_get_shutdown(WOLFSSL_BIO* bio)
     (void)bio;
     return 0;
 }
+#endif /* NO_WOLFSSL_STUB */
 
-int wolfSSL_BIO_clear_retry_flags(WOLFSSL_BIO* bio)
+void wolfSSL_BIO_clear_retry_flags(WOLFSSL_BIO* bio)
 {
-    WOLFSSL_STUB("wolfSSL_BIO_clear_retry_flags");
-    (void)bio;
-    return 0;
+    WOLFSSL_ENTER("wolfSSL_BIO_clear_retry_flags");
+
+    if (bio)
+        bio->flags &= ~(WOLFSSL_BIO_FLAG_READ|WOLFSSL_BIO_FLAG_RETRY);
 }
 
 /* DER data is PKCS#8 encrypted. */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1156,7 +1156,7 @@ WOLFSSL_API void wolfSSL_BIO_set_data(WOLFSSL_BIO*, void*);
 WOLFSSL_API void* wolfSSL_BIO_get_data(WOLFSSL_BIO*);
 WOLFSSL_API void wolfSSL_BIO_set_shutdown(WOLFSSL_BIO*, int);
 WOLFSSL_API int wolfSSL_BIO_get_shutdown(WOLFSSL_BIO*);
-WOLFSSL_API int wolfSSL_BIO_clear_retry_flags(WOLFSSL_BIO*);
+WOLFSSL_API void wolfSSL_BIO_clear_retry_flags(WOLFSSL_BIO*);
 
 WOLFSSL_API WOLFSSL_BIO_METHOD *wolfSSL_BIO_meth_new(int, const char*);
 WOLFSSL_API void wolfSSL_BIO_meth_free(WOLFSSL_BIO_METHOD*);


### PR DESCRIPTION
- Fix in wolfSSLReceive to return `WANT_READ` when the I/O callback returns -1 and the BIO retry and read flags are set. This moves changes previously applied in Apache's mod_ssl to wolfSSL
- Adds `wolfSSL_BIO_clear_retry_flags` implementation