### PR TITLE
Fixes for cases where mutex was not being free'd

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -3464,6 +3464,10 @@ void FreeX509(WOLFSSL_X509* x509)
         FreeAltNames(x509->altNames, x509->heap);
         x509->altNames = NULL;
     }
+
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
+        wc_FreeMutex(&x509->refMutex);
+    #endif
 }
 
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -22893,6 +22893,8 @@ void wolfSSL_EVP_PKEY_free(WOLFSSL_EVP_PKEY* key)
                 default:
                 break;
             }
+
+            wc_FreeMutex(&key->refMutex);
             XFREE(key, key->heap, DYNAMIC_TYPE_PUBLIC_KEY);
         }
     }


### PR DESCRIPTION
Found two cases where "refMutex" was not being free'd properly.
* `FreeX509`
* `wolfSSL_EVP_PKEY_free`

Applies to `OPENSSL_EXTRA` or `--enable-opensslextra` build cases.

ZD 9453