### PR TITLE
Update DoVerifyCallback to check verify param hostName and ipasc

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -9350,7 +9350,9 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
         /* If altNames names is present, then subject common name is ignored */
         if (args->dCert->altNames != NULL) {
             if (CheckAltNames(args->dCert, ssl->param->hostName) == 0 ) {
-                return VERIFY_CERT_ERROR;
+                if (ret == 0) {
+                    ret = VERIFY_CERT_ERROR;
+                }
             }
         }
         else {
@@ -9358,7 +9360,9 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
                 if (MatchDomainName(args->dCert->subjectCN,
                                     args->dCert->subjectCNLen,
                                     ssl->param->hostName) == 0) {
-                    return VERIFY_CERT_ERROR;
+                    if (ret == 0) {
+                        ret = VERIFY_CERT_ERROR;
+                    }
                 }
             }
         }
@@ -9368,7 +9372,9 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
     if ((args->dCertInit != 0) && (args->dCert != NULL) &&
         (ssl->param != NULL) && (XSTRLEN(ssl->param->ipasc) > 0)) {
         if (CheckIPAddr(args->dCert, ssl->param->ipasc) != 0) {
-            return VERIFY_CERT_ERROR;
+            if (ret == 0) {
+                ret = VERIFY_CERT_ERROR;
+            }
         }
     }
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -9367,7 +9367,7 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
     /* perform IP address check on the peer certificate */
     if ((args->dCertInit != 0) && (args->dCert != NULL) &&
         (ssl->param != NULL) && (XSTRLEN(ssl->param->ipasc) > 0)) {
-        if (CheckIPAddr(args->dCert, ssl->param->ipasc) == 0) {
+        if (CheckIPAddr(args->dCert, ssl->param->ipasc) != 0) {
             return VERIFY_CERT_ERROR;
         }
     }

--- a/src/internal.c
+++ b/src/internal.c
@@ -9351,7 +9351,7 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
         if (args->dCert->altNames != NULL) {
             if (CheckAltNames(args->dCert, ssl->param->hostName) == 0 ) {
                 if (ret == 0) {
-                    ret = VERIFY_CERT_ERROR;
+                    ret = DOMAIN_NAME_MISMATCH;
                 }
             }
         }
@@ -9361,7 +9361,7 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
                                     args->dCert->subjectCNLen,
                                     ssl->param->hostName) == 0) {
                     if (ret == 0) {
-                        ret = VERIFY_CERT_ERROR;
+                        ret = DOMAIN_NAME_MISMATCH;
                     }
                 }
             }
@@ -9373,7 +9373,7 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
         (ssl->param != NULL) && (XSTRLEN(ssl->param->ipasc) > 0)) {
         if (CheckIPAddr(args->dCert, ssl->param->ipasc) != 0) {
             if (ret == 0) {
-                ret = VERIFY_CERT_ERROR;
+                ret = IPADDR_MISMATCH;
             }
         }
     }
@@ -16862,6 +16862,9 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
 
     case DOMAIN_NAME_MISMATCH :
         return "peer subject name mismatch";
+
+    case IPADDR_MISMATCH :
+        return "peer ip address mismatch";
 
     case WANT_READ :
     case WOLFSSL_ERROR_WANT_READ :

--- a/src/internal.c
+++ b/src/internal.c
@@ -8746,7 +8746,6 @@ int CheckAltNames(DecodedCert* dCert, char* domain)
     return match;
 }
 
-
 #ifdef OPENSSL_EXTRA
 /* Check that alternative names, if they exists, match the domain.
  * Fail if there are wild patterns and they didn't match.
@@ -8817,6 +8816,13 @@ int CheckHostName(DecodedCert* dCert, char *domainName, size_t domainNameLen)
     }
 
     return 0;
+}
+
+int CheckIPAddr(DecodedCert* dCert, char* ipasc)
+{
+    WOLFSSL_MSG("Checking IPAddr");
+
+    return CheckHostName(dCert, ipasc, (size_t)XSTRLEN(ipasc));
 }
 #endif
 
@@ -9355,6 +9361,14 @@ static int DoVerifyCallback(WOLFSSL* ssl, int ret, ProcPeerCertArgs* args)
                     return VERIFY_CERT_ERROR;
                 }
             }
+        }
+    }
+
+    /* perform IP address check on the peer certificate */
+    if ((args->dCertInit != 0) && (args->dCert != NULL) &&
+        (ssl->param != NULL) && (XSTRLEN(ssl->param->ipasc) > 0)) {
+        if (CheckIPAddr(args->dCert, ssl->param->ipasc) == 0) {
+            return VERIFY_CERT_ERROR;
         }
     }
 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -22997,7 +22997,8 @@ void wolfSSL_X509_VERIFY_PARAM_set_hostflags(WOLFSSL_X509_VERIFY_PARAM* param,
  *
  * param is a pointer to the X509_VERIFY_PARAM structure
  * ipasc is a NULL-terminated string with N.N.N.N for IPv4 and
- *       HH:HH ... HH:HH for IPv6.
+ *       HH:HH ... HH:HH for IPv6. There is no validation performed on the
+ *       parameter, and it must be an exact match with the IP in the cert.
  *
  * return 1 for success and 0 for failure*/
 int wolfSSL_X509_VERIFY_PARAM_set1_ip_asc(WOLFSSL_X509_VERIFY_PARAM *param,

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -23006,8 +23006,13 @@ int wolfSSL_X509_VERIFY_PARAM_set1_ip_asc(WOLFSSL_X509_VERIFY_PARAM *param,
     int ret = WOLFSSL_FAILURE;
 
     if (param != NULL) {
-        XSTRNCPY(param->ipasc, ipasc, WOLFSSL_MAX_IPSTR-1);
-        param->ipasc[WOLFSSL_MAX_IPSTR-1] = '\0';
+        if (ipasc == NULL) {
+            param->ipasc[0] = '\0';
+        }
+        else {
+            XSTRNCPY(param->ipasc, ipasc, WOLFSSL_MAX_IPSTR-1);
+            param->ipasc[WOLFSSL_MAX_IPSTR-1] = '\0';
+        }
         ret = WOLFSSL_SUCCESS;
     }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -21920,6 +21920,9 @@ static void test_wolfSSL_X509_VERIFY_PARAM(void)
     AssertIntEQ(1, ret);
     AssertIntEQ(0, XSTRNCMP(param->ipasc, testIPv4, WOLFSSL_MAX_IPSTR));
 
+    ret = wolfSSL_X509_VERIFY_PARAM_set1_ip_asc(param, NULL);
+    AssertIntEQ(1, ret);
+
     ret = wolfSSL_X509_VERIFY_PARAM_set1_ip_asc(param, testIPv6);
     AssertIntEQ(1, ret);
     AssertIntEQ(0, XSTRNCMP(param->ipasc, testIPv6, WOLFSSL_MAX_IPSTR));

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -57,7 +57,7 @@ enum wolfSSL_ErrorCodes {
     DOMAIN_NAME_MISMATCH         = -322,   /* peer subject name mismatch */
     WANT_READ                    = -323,   /* want read, call again    */
     NOT_READY_ERROR              = -324,   /* handshake layer not ready */
-
+    IPADDR_MISMATCH              = -325,   /* peer ip address mismatch */
     VERSION_ERROR                = -326,   /* record layer version error */
     WANT_WRITE                   = -327,   /* want write, call again   */
     BUFFER_ERROR                 = -328,   /* malformed buffer input   */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1666,6 +1666,9 @@ WOLFSSL_LOCAL int  ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 WOLFSSL_LOCAL int  MatchDomainName(const char* pattern, int len, const char* str);
 #ifndef NO_CERTS
 WOLFSSL_LOCAL int  CheckAltNames(DecodedCert* dCert, char* domain);
+#ifdef OPENSSL_EXTRA
+WOLFSSL_LOCAL int  CheckIPAddr(DecodedCert* dCert, char* ipasc);
+#endif
 #endif
 WOLFSSL_LOCAL int  CreateTicket(WOLFSSL* ssl);
 WOLFSSL_LOCAL int  HashOutputRaw(WOLFSSL* ssl, const byte* output, int sz);


### PR DESCRIPTION
The`VERIFY_PARAM` API `wolfSSL_X509_VERIFY_PARAM_set1_host` and  `wolfSSL_X509_VERIFY_PARAM_set1_ip_asc` are used to set values that are now checked in the verify callback before the actual verify CB routine is instantiated.