### PR TITLE
fix for macro typo's

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -10803,7 +10803,7 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
                                                  word32 inSz, byte* output,
                                                  word32 outputSz)
 {
-#if defined(HAVE_AESGCM) || defined(HAVE_AESCC)
+#if defined(HAVE_AESGCM) || defined(HAVE_AESCCM)
     int recipFound = 0;
     int ret = 0, length;
     word32 idx = 0;

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -818,7 +818,7 @@ struct DecodedCert {
     const byte* issuerRaw;           /* pointer to issuer inside source */
     int     issuerRawLen;
 #endif
-#ifndef IGNORE_NAME_CONSTRAINT
+#ifndef IGNORE_NAME_CONSTRAINTS
     const byte* subjectRaw;          /* pointer to subject inside source */
     int     subjectRawLen;
 #endif

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -818,7 +818,7 @@ struct DecodedCert {
     const byte* issuerRaw;           /* pointer to issuer inside source */
     int     issuerRawLen;
 #endif
-#ifndef IGNORE_NAME_CONSTRAINTS
+#if !defined(IGNORE_NAME_CONSTRAINTS) || defined(WOLFSSL_CERT_EXT)
     const byte* subjectRaw;          /* pointer to subject inside source */
     int     subjectRawLen;
 #endif


### PR DESCRIPTION
Thanks to the report by @guangqing at github issue https://github.com/wolfSSL/wolfssl/issues/2546