### PR TITLE
X.509 and Secure Renegotiation

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6029,10 +6029,6 @@ void FreeHandshakeResources(WOLFSSL* ssl)
 #ifdef HAVE_SECURE_RENEGOTIATION
     if (ssl->secure_renegotiation && ssl->secure_renegotiation->enabled) {
         WOLFSSL_MSG("Secure Renegotiation needs to retain handshake resources");
-    #if defined(KEEP_PEER_CERT) && !defined(WOLFSSL_APACHE_HTTPD)
-        /* free peer cert in preparation for new handshake */
-        FreeX509(&ssl->peerCert);
-    #endif
         return;
     }
 #endif
@@ -10414,11 +10410,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     #ifdef HAVE_SECURE_RENEGOTIATION
                         if (ssl->secure_renegotiation &&
                                            ssl->secure_renegotiation->enabled) {
-                        #if defined(OPENSSL_ALL) || defined(WOLFSSL_APACHE_HTTPD)
                             /* free old peer cert */
-                            if (ssl->peerCert.issuer.sz)
-                                FreeX509(&ssl->peerCert);
-                        #endif
+                            FreeX509(&ssl->peerCert);
                         }
                     #endif
 


### PR DESCRIPTION
1. When retaining the handshake resources for a session using resumption, do not delete the peer's certificate. If keeping peer certificates is enabled, the certificate needs to exist so it may be examined.
2. Free the saved peer certificate when receiving a peer certificate during a renegotiation.