### PR TITLE
fix for memory management on edge case with staticmemory

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -336,7 +336,15 @@ WOLFSSL_CTX* wolfSSL_CTX_new_ex(WOLFSSL_METHOD* method, void* heap)
 
     ctx = (WOLFSSL_CTX*) XMALLOC(sizeof(WOLFSSL_CTX), heap, DYNAMIC_TYPE_CTX);
     if (ctx) {
-        if (InitSSL_Ctx(ctx, method, heap) < 0) {
+        int ret;
+
+        ret = InitSSL_Ctx(ctx, method, heap);
+    #ifdef WOLFSSL_STATIC_MEMORY
+        if (heap != NULL) {
+            ctx->onHeap = 1; /* free the memory back to heap when done */
+        }
+    #endif
+        if (ret < 0) {
             WOLFSSL_MSG("Init CTX failed");
             wolfSSL_CTX_free(ctx);
             ctx = NULL;
@@ -1440,7 +1448,6 @@ int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx, wolfSSL_method_func method
             WOLFSSL_MSG("Error creating ctx");
             return WOLFSSL_FAILURE;
         }
-        (*ctx)->onHeap = 1; /* free the memory back to heap when done */
     }
 
     /* determine what max applies too */


### PR DESCRIPTION
Fixes case where the heap hint is created before ctx, when calling wc_LoadStaticMemory instead of wolfSSL_CTX_load_static_memory. In that case the flag for if the ctx belongs to the heap was not set. The flag onHeap is for cases where users have created a ctx using older API and it should not be free'd back to the heap hint that the ctx points to (test cases for this are in unit.test).

Changes the example client to initialize the heap hint this way for testing (example server is left calling wolfSSL_CTX_load_static_memory to create ctx).