### PR TITLE
Scan-Build Fixes for PKCS7 and PKCS12

### DIFF
--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -1070,7 +1070,7 @@ int wc_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
                 ERROR_OUT(ASN_PARSE_E, exit_pk12par);
             }
             if ((ret = GetLength(data, &idx, &size, ci->dataSz)) <= 0) {
-                goto exit_pk12par;
+                ERROR_OUT(ASN_PARSE_E, exit_pk12par);
             }
 
             if (GetASNTag(data, &idx, &tag, ci->dataSz) < 0) {

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1390,6 +1390,19 @@ typedef struct FlatAttrib {
     word32 dataSz;
 } FlatAttrib;
 
+/* Returns a pointer to FlatAttrib whose members are initialized to 0.
+*  Caller is expected to free.
+*/
+static FlatAttrib* NewAttrib(void* heap)
+{
+    FlatAttrib* fb = (FlatAttrib*) XMALLOC(sizeof(FlatAttrib), heap,
+                                                   DYNAMIC_TYPE_TMP_BUFFER);
+    if (fb != NULL) {
+        ForceZero(fb, sizeof(FlatAttrib));
+    }
+    (void)heap;
+    return fb;
+}
 
 /* Free FlatAttrib array and memory allocated to internal struct members */
 static void FreeAttribArray(PKCS7* pkcs7, FlatAttrib** arr, int rows)
@@ -1513,11 +1526,10 @@ static int FlattenAttributes(PKCS7* pkcs7, byte* output, EncodedAttrib* ea,
     if (derArr == NULL) {
         return MEMORY_E;
     }
-    ForceZero(derArr, eaSz * sizeof(FlatAttrib*));
+    XMEMSET(derArr, 0, eaSz * sizeof(FlatAttrib*));
 
     for (i = 0; i < eaSz; i++) {
-        derArr[i] = (FlatAttrib*) XMALLOC(sizeof(FlatAttrib), pkcs7->heap,
-                                          DYNAMIC_TYPE_TMP_BUFFER);
+        derArr[i] = NewAttrib(pkcs7->heap);
         if (derArr[i] == NULL) {
             FreeAttribArray(pkcs7, derArr, eaSz);
             return MEMORY_E;


### PR DESCRIPTION
This is a scan-build fix.

FreeAttribArray used to receive (eaSz - i) amount of uninitialized nodes in derArr.  

scan-build would throw a garbage value warning inside FreeAttribArray.

**Reproducing the Error**:

1. 
./configure CFLAGS="-fdebug-types-section -g1" --enable-static --enable-filesystem --enable-opensslextra=x509small --enable-fastmath --enable-aesgcm=small --enable-oldnames --enable-scep --enable-base64encode --enable-coding --enable-keygen --enable-certreq --enable-certgen --disable-shared --disable-examples --disable-crypttests --disable-errorstrings --disable-memory --disable-extended-master --disable-eccshamir --disable-ecc --disable-poly1305 --disable-md5 --disable-sha224 --disable-sha512 --disable-sha3 --disable-oldtls --disable-chacha --disable-des3 --disable-sha --enable-pwdbased C_EXTRA_FLAGS="-DWOLFSSL_NO_DH186 -DWC_NO_RSA_OAEP -DRSA_DECODE_EXTRA -DNO_AES_128 -DNO_AES_192 -Os -DNO_WOLFSSL_SERVER -DNO_SESSION_CACHE -DNO_WOLFSSL_DIR -DNO_WRITEV -DRSA_LOW_MEM -DWOLFSSL_DH_CONST -DAES_GCM_AESNI_NO_UNROLL -DUSE_SLOW_SHA256 -DNO_SKID -DIGNORE_NAME_CONSTRAINTS -DMAX_CHAIN_DEPTH=5" --enable-jobserver=4

2. Run "scan-build make"


**Error Output:**
wolfcrypt/src/pkcs7.c:1401:17: warning: Branch condition evaluates to a garbage value
            if (arr[i]) {
                ^~~~~~
wolfcrypt/src/pkcs7.c:1402:21: warning: Branch condition evaluates to a garbage value
                if (arr[i]->data) {

