### PR TITLE
Ensure space for name string. Reset policy count.

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -27628,14 +27628,7 @@ static void test_wolfSSL_X509_print()
     AssertNotNull(bio = BIO_new(BIO_s_mem()));
     AssertIntEQ(X509_print(bio, x509), SSL_SUCCESS);
 
-#ifdef WOLFSSL_WPAS
-    /* WPAS adds extra "="" */
-    /* WPAS Issuer: /C==US/ST==Montana/L==Bozeman/O==Sawtooth/... */
-    /* NORM Issuer: /C=US/ST=Montana/L=Bozeman/O=Sawtooth/... */
-    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3230);
-#else
     AssertIntEQ(BIO_get_mem_data(bio, NULL), 3212);
-#endif
     BIO_free(bio);
 
     /* print to stdout */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -144,6 +144,9 @@ enum DN_Tags {
 #define WOLFSSL_JOI_ST           "/jurisdictionST="
 #define WOLFSSL_EMAIL_ADDR       "/emailAddress="
 
+#define WOLFSSL_USER_ID          "/UID="
+#define WOLFSSL_DOMAIN_COMPONENT "/DC="
+
 #if defined(WOLFSSL_APACHE_HTTPD)
     /* otherName strings */
     #define WOLFSSL_SN_MS_UPN       "msUPN"


### PR DESCRIPTION
Only set the name string in one place, keeping a length of the name type
to copy. Also only move cert data index once.
Reset certificate extension policy number/count in case of malicious
cert with multiple policy extensions.