### PR TITLE
Fix memory leak in dh_test

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13096,6 +13096,8 @@ static int dh_test_ffdhe(WC_RNG *rng, const DhParams* params)
     }
 
 done:
+    wc_FreeDhKey(&key);
+    wc_FreeDhKey(&key2);
     return ret;
 }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13039,6 +13039,9 @@ static int dh_test_ffdhe(WC_RNG *rng, const DhParams* params)
     DhKey  key;
     DhKey  key2;
 
+    XMEMSET(&key, 0, sizeof(DhKey));
+    XMEMSET(&key2, 0, sizeof(DhKey));
+
     ret = wc_InitDhKey_ex(&key, HEAP_HINT, devId);
     if (ret != 0) {
         ERROR_OUT(-7180, done);


### PR DESCRIPTION
Allows valgrind test to pass with valgrind_known_configs build