### PR TITLE
Useful script to cleanup test files created

### DIFF
--- a/scripts/cleanup_testfiles.sh
+++ b/scripts/cleanup_testfiles.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Script to cleanup test files
+# This is helpful if running ./tests/unit.test as sudo,
+# which creates these files with sudoer permissions and
+# will cause issues on subsequent tests without sudo
+
+rm -f ./tests/bio_write_test.txt
+rm -f ./test-write-dhparams.pem
+rm -f ./certeccrsa.pem
+rm -f ./certeccrsa.der
+rm -f ./ecc-key.der
+rm -f ./ecc-key.pem
+rm -f ./ecc-public-key.der

--- a/scripts/include.am
+++ b/scripts/include.am
@@ -94,3 +94,5 @@ EXTRA_DIST +=  scripts/dertoc.pl
 
 # for use with wolfssl-x.x.x-commercial-fips-stm32l4-v2
 EXTRA_DIST += scripts/stm32l4-v4_0_1_build.sh
+
+EXTRA_DIST += scripts/cleanup_testfiles.sh


### PR DESCRIPTION
Script to cleanup generated test files. This is helpful if running the tests with sudoer permissions, which creates these files and will cause issues on subsequent tests without sudo.