### PR TITLE
Fix for vasprintf with AIX

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26158,7 +26158,8 @@ int wolfSSL_BIO_printf(WOLFSSL_BIO* bio, const char* format, ...)
                 count = vsnprintf(NULL, 0, format, args);
                 if (count >= 0)
                 {
-                    pt = XMALLOC(count + 1, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+                    pt = (char*)XMALLOC(count + 1, bio->heap,
+                                        DYNAMIC_TYPE_TMP_BUFFER);
                     if (pt != NULL)
                     {
                         count = vsnprintf(pt, count + 1, format, copy);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26,7 +26,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 #if defined(OPENSSL_EXTRA) && !defined(_WIN32)
-    /* turn on GNU extensions for vasprintf with wolfSSL_BIO_printf */
+    /* turn on GNU extensions for XVASPRINTF with wolfSSL_BIO_printf */
     #undef  _GNU_SOURCE
     #define _GNU_SOURCE
 #endif
@@ -26151,7 +26151,7 @@ int wolfSSL_BIO_printf(WOLFSSL_BIO* bio, const char* format, ...)
         case WOLFSSL_BIO_SSL:
             {
                 char* pt = NULL;
-                ret = vasprintf(&pt, format, args);
+                ret = XVASPRINTF(&pt, format, args);
                 if (ret > 0 && pt != NULL) {
                     wolfSSL_BIO_write(bio, pt, ret);
                 }

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -494,9 +494,14 @@
         #endif /* USE_WINDOWS_API */
 
         /* XVASPRINTF is used in ssl.c for wolfSSL_BIO_printf */
+        #ifdef __GNUC__
+            #define VASPRINTFCHECK __attribute__((format(printf, 2, 0)))
+        #else
+            #define VASPRINTFCHECK
+        #endif /* __GNUC__ */
         #if (defined(sun) || defined(__sun) || defined(_AIX))
             #include <stdarg.h>
-            static WC_INLINE
+            VASPRINTFCHECK static WC_INLINE
             int xvasprintf(char **ret, const char *format, va_list args)
             {
                 int count;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -493,63 +493,6 @@
             #endif /* _MSC_VER || __CYGWIN__ || __MINGW32__ */
         #endif /* USE_WINDOWS_API */
 
-        /* XVASPRINTF is used in ssl.c for wolfSSL_BIO_printf */
-        #ifdef __GNUC__
-            #define VASPRINTFCHECK __attribute__((format(printf, 2, 0)))
-        #else
-            #define VASPRINTFCHECK
-        #endif /* __GNUC__ */
-        #if (defined(sun) || defined(__sun) || defined(_AIX))
-            #include <stdarg.h>
-            VASPRINTFCHECK static WC_INLINE
-            int xvasprintf(char **ret, const char *format, va_list args)
-            {
-                int count;
-                char *buffer;
-                va_list copy;
-                va_copy(copy, args);
-
-                *ret = NULL;
-
-                count = vsnprintf(NULL, 0, format, args);
-                if (count >= 0)
-                {
-                    buffer = malloc(count + 1);
-                    if (buffer == NULL)
-                    {
-                        count = -1;
-                    }
-                    else
-                    {
-                        count = vsnprintf(buffer, count + 1, format, copy);
-                        if (count < 0)
-                        {
-                            free(buffer);
-                            count = -1;
-                        }
-                        else
-                        {
-                            *ret = buffer;
-                        }
-                    }
-                }
-                va_end(copy);
-
-                return count;
-            }
-            #define XVASPRINTF xvasprintf
-        #else
-            #ifndef XVASPRINTF
-            #if defined(NO_FILESYSTEM) && (defined(OPENSSL_EXTRA) || \
-                   defined(HAVE_PKCS7)) && !defined(NO_STDIO_FILESYSTEM)
-                /* case where stdio is not included else where but is needed
-                   for vasprintf */
-                #include <stdio.h>
-            #endif
-            #define XVASPRINTF vasprintf
-            #endif
-        #endif /* defined(sun) || defined(__sun) || defined(_AIX) */
-
         #if defined(WOLFSSL_CERT_EXT) || defined(HAVE_ALPN)
             /* use only Thread Safe version of strtok */
             #if defined(USE_WOLF_STRTOK)


### PR DESCRIPTION
Added a macro for `XVASPRINTF` that can be defined for all platforms that do not include a definition for `vasprintf` in stdio. This addresses build errors with Solaris and AIX.