### PR TITLE
Fix for Intel QuickAssist asynchronous build

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -31868,20 +31868,18 @@ int wolfSSL_EC_POINT_is_at_infinity(const WOLFSSL_EC_GROUP *group,
 
 size_t wolfSSL_EC_get_builtin_curves(WOLFSSL_EC_builtin_curve *r, size_t nitems)
 {
-    static size_t ecc_sets_count = 0;
-    size_t i, min;
+    size_t ecc_sets_count;
+    size_t i, min_nitems;
 
-    if (ecc_sets_count == 0) {
-        for (i = 0; ecc_sets[i].size != 0; i++);
-        ecc_sets_count = i;
-    }
+    for (i = 0; ecc_sets[i].size != 0 && ecc_sets[i].name != NULL; i++);
+    ecc_sets_count = i;
 
     if (r == NULL || nitems == 0)
         return ecc_sets_count;
 
-    min = nitems < ecc_sets_count ? nitems : ecc_sets_count;
+    min_nitems = nitems < ecc_sets_count ? nitems : ecc_sets_count;
 
-    for (i = 0; i < min; i++) {
+    for (i = 0; i < min_nitems; i++) {
         r[i].nid = ecc_sets[i].id;
         r[i].comment = ecc_sets[i].name;
     }
@@ -36875,7 +36873,7 @@ err:
         WOLFSSL_ENTER("wolfSSL_OBJ_nid2sn");
 
         /* find based on NID and return name */
-        for (i = 0; i < ecc_sets[i].size; i++) {
+        for (i = 0; ecc_sets[i].size != 0; i++) {
             if (n == ecc_sets[i].id) {
                 return ecc_sets[i].name;
             }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4811,7 +4811,7 @@ WOLFSSL_LOCAL int wc_OBJ_sn2nid(const char *sn)
     if (XSTRNCMP(sn, "secp384r1", 10) == 0)
         sn = "SECP384R1";
     /* find based on name and return NID */
-    for (i = 0; i < ecc_sets[i].size; i++) {
+    for (i = 0; ecc_sets[i].size != 0 && ecc_sets[i].name != NULL; i++) {
         if (XSTRNCMP(sn, ecc_sets[i].name, ECC_MAXNAME) == 0) {
             return ecc_sets[i].id;
         }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -3263,7 +3263,7 @@ int hash_test(void)
     if (ret != BAD_FUNC_ARG)
         return -3094;
 
-#ifndef NO_ASN
+#ifndef NO_CERTS
 #if defined(WOLFSSL_MD2) && !defined(HAVE_SELFTEST)
     ret = wc_GetCTC_HashOID(MD2);
     if (ret == 0)
@@ -11508,7 +11508,7 @@ static int rsa_keygen_test(WC_RNG* rng)
     #if !defined(HAVE_FAST_RSA) && !defined(HAVE_USER_RSA) && \
         (!defined(HAVE_FIPS) || \
          (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))) && \
-        !defined(HAVE_SELFTEST)
+        !defined(HAVE_SELFTEST) && !defined(HAVE_INTEL_QA)
     ret = wc_CheckRsaKey(&genKey);
     if (ret != 0) {
         ERROR_OUT(-8228, exit_rsa);

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -240,7 +240,7 @@
     #elif (defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_INTEL_QA)) || \
           defined(HAVE_INTEL_QA_SYNC)
         #ifndef HAVE_INTEL_QA_SYNC
-            #include <wolfssl/wolfcrypt/port/intel/quickassist.h>
+            #include <wolfssl/wolfcrypt/port/intel/quickassist_mem.h>
             #undef USE_WOLFSSL_MEMORY
             #ifdef WOLFSSL_DEBUG_MEMORY
                 #define XMALLOC(s, h, t)     IntelQaMalloc((s), (h), (t), __func__, __LINE__)


### PR DESCRIPTION
* Revert header change in #2504 for asynchronous crypto `quickassist_mem.h`. https://github.com/wolfSSL/wolfssl/pull/2504/files#diff-3c70938cabd372da05f521913dc1230aR239
* Fixes for minor test.c build configuration issues.
* Fix for issues with `wolfSSL_OBJ_nid2sn` and `wc_OBJ_sn2nid` and logic finding max item when `WOLFSSL_CUSTOM_CURVES` and `ECC_CACHE_CURVE` are defined.
* Improvements to `wolfSSL_EC_get_builtin_curves` to avoid using "min" as variable name and eliminate using a local static.