### PR TITLE
Fix alpn buffer overrun

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2409,7 +2409,7 @@ WOLFSSL_ABI
 int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
                     word32 protocol_name_listSz, byte options)
 {
-    char    *list, *ptr, *token[10];
+    char    *list, *ptr, *token[WOLFSSL_MAX_ALPN_NUMBER]={NULL};
     word16  len;
     int     idx = 0;
     int     ret = WOLFSSL_FAILURE;
@@ -2445,7 +2445,7 @@ int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
 
     /* read all protocol name from the list */
     token[idx] = XSTRTOK(list, ",", &ptr);
-    while (token[idx] != NULL)
+    while (token[idx] != NULL && idx < WOLFSSL_MAX_ALPN_NUMBER)
         token[++idx] = XSTRTOK(NULL, ",", &ptr);
 
     /* add protocol name list in the TLS extension in reverse order */


### PR DESCRIPTION
The PR fixes a segfault when the list of the Application-Layer Protocol Negotiation (ALPN) Protocol exceeds 10. 

With this fix, you will no longer see a segfault with the following build as an example: 

./configure --enable-alpn
make
./examples/client/client -L "C:h2,h2,h2,h2,h2,h2,h2,h2,h2,h2,h2,h2,h2,h2,h2,h2,h2,h2"
