### PR TITLE
Generating serial number - clear top bit

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -11870,6 +11870,8 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
         ret = wc_RNG_GenerateBlock(rng, cert->serial, cert->serialSz);
         if (ret != 0)
             return ret;
+        /* Clear the top bit to avoid a negative value */
+        cert->serial[0] &= 0x7f;
     }
     der->serialSz = SetSerialNumber(cert->serial, cert->serialSz, der->serial,
         sizeof(der->serial), CTC_SERIAL_SIZE);


### PR DESCRIPTION
If the top bit is set then the encoding routine will drop a byte of the
serial number.
Better to ensure number is positive, top bit clear, and use as much of
the serial number data as possible.