### PR TITLE
Maintenance: ASN.1

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -179,7 +179,11 @@ WOLFSSL_LOCAL int GetLength_ex(const byte* input, word32* inOutIdx, int* len,
     }
 
     b = input[idx++];
-    if (b >= ASN_LONG_LENGTH) {
+    if (b == ASN_LONG_LENGTH) {
+        WOLFSSL_MSG("GetLength bad length length");
+        return ASN_PARSE_E;
+    }
+    else if (b > ASN_LONG_LENGTH) {
         word32 bytes = b & 0x7F;
 
         if ((idx + bytes) > maxIdx) {   /* for reading bytes */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4553,7 +4553,10 @@ static int GetCertHeader(DecodedCert* cert)
 
     if (GetSequence(cert->source, &cert->srcIdx, &len, cert->maxIdx) < 0)
         return ASN_PARSE_E;
+
     cert->sigIndex = len + cert->srcIdx;
+    if (cert->sigIndex > cert->maxIdx)
+        return ASN_PARSE_E;
 
     if (GetExplicitVersion(cert->source, &cert->srcIdx, &cert->version,
                                                             cert->sigIndex) < 0)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -179,11 +179,7 @@ WOLFSSL_LOCAL int GetLength_ex(const byte* input, word32* inOutIdx, int* len,
     }
 
     b = input[idx++];
-    if (b == ASN_LONG_LENGTH) {
-        WOLFSSL_MSG("GetLength bad length length");
-        return ASN_PARSE_E;
-    }
-    else if (b > ASN_LONG_LENGTH) {
+    if (b >= ASN_LONG_LENGTH) {
         word32 bytes = b & 0x7F;
 
         if ((idx + bytes) > maxIdx) {   /* for reading bytes */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9247,7 +9247,8 @@ byte GetEntropy(ENTROPY_CMD cmd, byte* out)
 #endif /* HAVE_ECC */
 
 #ifndef NO_RSA
-    #if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
+    #if defined(WOLFSSL_CERT_GEN) || \
+        (defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_TEST_CERT))
         static const char* otherCertDerFile = CERT_PREFIX "othercert.der";
         static const char* certDerFile = CERT_PREFIX "cert.der";
     #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9247,7 +9247,7 @@ byte GetEntropy(ENTROPY_CMD cmd, byte* out)
 #endif /* HAVE_ECC */
 
 #ifndef NO_RSA
-    #ifdef WOLFSSL_CERT_GEN
+    #if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         static const char* otherCertDerFile = CERT_PREFIX "othercert.der";
         static const char* certDerFile = CERT_PREFIX "cert.der";
     #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -528,7 +528,8 @@
     #define XSTRNCMP(s1,s2,n)      strncmp((s1),(s2),(n))
     #define XSTRNCAT(s1,s2,n)      strncat((s1),(s2),(n))
     #define XSTRNCASECMP(s1,s2,n)  _strnicmp((s1),(s2),(n))
-    #if defined(WOLFSSL_CERT_EXT) || defined(HAVE_ALPN)
+    #if defined(WOLFSSL_CERT_EXT) || defined(OPENSSL_EXTRA) \
+            || defined(HAVE_ALPN)
         #define XSTRTOK            strtok_r
     #endif
 #endif

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -493,7 +493,8 @@
             #endif /* _MSC_VER || __CYGWIN__ || __MINGW32__ */
         #endif /* USE_WINDOWS_API */
 
-        #if defined(WOLFSSL_CERT_EXT) || defined(HAVE_ALPN)
+        #if defined(WOLFSSL_CERT_EXT) || defined(OPENSSL_EXTRA) \
+                    || defined(HAVE_ALPN)
             /* use only Thread Safe version of strtok */
             #if defined(USE_WOLF_STRTOK)
                 #define XSTRTOK(s1,d,ptr) wc_strtok((s1),(d),(ptr))


### PR DESCRIPTION
1. When parsing a certificate or CRL, do not copy a structure member beyond the bounds of the enclosing container.
2. When decoding a policy OID and turning it into a human readable string, use snprintf() rather than hand-rolling the conversion function.