### PR TITLE
Fix for async date check issue

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8584,8 +8584,6 @@ int CheckCertSignature(const byte* cert, word32 certSz, void* heap, void* cm)
 int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
 {
     int    ret = 0;
-    int    badDate = 0;
-    int    criticalExt = 0;
     int    checkPathLen = 0;
     int    decrementMaxPathLen = 0;
     word32 confirmOID;
@@ -8597,9 +8595,11 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
     }
 
     if (cert->sigCtx.state == SIG_STATE_BEGIN) {
+        cert->badDate = 0;
+        cert->criticalExt = 0;
         if ((ret = DecodeToKey(cert, verify)) < 0) {
             if (ret == ASN_BEFORE_DATE_E || ret == ASN_AFTER_DATE_E)
-                badDate = ret;
+                cert->badDate = ret;
             else
                 return ret;
         }
@@ -8621,7 +8621,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
 
             if ((ret = DecodeCertExtensions(cert)) < 0) {
                 if (ret == ASN_CRIT_EXT_E)
-                    criticalExt = ret;
+                    cert->criticalExt = ret;
                 else
                     return ret;
             }
@@ -8911,11 +8911,15 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
 exit_pcr:
 #endif
 
-    if (badDate != 0 && verify != VERIFY_SKIP_DATE)
-        return badDate;
+    if (cert->badDate != 0) {
+        if (verify != VERIFY_SKIP_DATE) {
+            return cert->badDate;
+        }
+        WOLFSSL_MSG("Date error: Verify option is skipping");
+    }
 
-    if (criticalExt != 0)
-        return criticalExt;
+    if (cert->criticalExt != 0)
+        return cert->criticalExt;
 
     return ret;
 }

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -890,6 +890,9 @@ struct DecodedCert {
 #endif
     byte*  tsip_encRsaKeyIdx;
 
+    int badDate;
+    int criticalExt;
+
     /* Option Bits */
     byte subjectCNStored : 1;      /* have we saved a copy we own */
     byte extSubjKeyIdSet : 1;      /* Set when the SKID was read from cert */


### PR DESCRIPTION
Fix for async issue with "badDate" and "criticalExt" check getting skipped on call to `ConfirmSignature` with `WC_PENDING_E` response. Added log message when date failure is skipped.

Broken in PR #2413.
ZD 9619