### PR TITLE
Fixes for Alternate chain processing

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -16746,6 +16746,8 @@ int SendAlert(WOLFSSL* ssl, int severity, int type)
     int  outputSz;
     int  dtlsExtra = 0;
 
+    WOLFSSL_ENTER("SendAlert");
+
 #ifdef HAVE_WRITE_DUP
     if (ssl->dupWrite && ssl->dupSide == READ_DUP_SIDE) {
         int notifyErr = 0;
@@ -16842,7 +16844,11 @@ int SendAlert(WOLFSSL* ssl, int severity, int type)
     ssl->buffers.outputBuffer.length += sendSz;
     ssl->options.sendAlertState = 1;
 
-    return SendBuffered(ssl);
+    ret = SendBuffered(ssl);
+
+    WOLFSSL_LEAVE("SendAlert", ret);
+
+    return ret;
 }
 
 const char* wolfSSL_ERR_reason_error_string(unsigned long e)

--- a/src/internal.c
+++ b/src/internal.c
@@ -10250,12 +10250,15 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     }
             #endif /* HAVE_OCSP || HAVE_CRL */
 
+                    /* Do verify callback */
+                    ret = DoVerifyCallback(ssl, ret, args);
+
                 #ifdef WOLFSSL_ALT_CERT_CHAINS
                     /* For alternate cert chain, its okay for a CA cert to fail
                         with ASN_NO_SIGNER_E here. The "alternate" certificate
                         chain mode only requires that the peer certificate
                         validate to a trusted CA */
-                    if (ret != 0) {
+                    if (ret != 0 && args->dCert->isCA) {
                         if (ret == ASN_NO_SIGNER_E) {
                             if (!ssl->options.usingAltCertChain) {
                                 WOLFSSL_MSG("Trying alternate cert chain");
@@ -10265,10 +10268,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             ret = 0; /* clear error and continue */
                         }
                     }
+                    else /* do not add to certificate manager */
                 #endif /* WOLFSSL_ALT_CERT_CHAINS */
-
-                    /* Do verify callback */
-                    ret = DoVerifyCallback(ssl, ret, args);
 
                     /* If valid CA then add to Certificate Manager */
                     if (ret == 0 && args->dCert->isCA && !ssl->options.verifyNone) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -10161,6 +10161,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     && !args->haveTrustPeer
                 #endif /* WOLFSSL_TRUST_PEER_CERT */
                 ) {
+                    int skipAddCA = 0;
+                    
                     /* select last certificate */
                     args->certIdx = args->count - 1;
 
@@ -10268,12 +10270,15 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
                             ret = 0; /* clear error and continue */
                         }
+
+                        /* do not add to certificate manager */
+                        skipAddCA = 1;
                     }
-                    else /* do not add to certificate manager */
                 #endif /* WOLFSSL_ALT_CERT_CHAINS */
 
                     /* If valid CA then add to Certificate Manager */
-                    if (ret == 0 && args->dCert->isCA && !ssl->options.verifyNone) {
+                    if (ret == 0 && args->dCert->isCA &&
+                            !ssl->options.verifyNone && !skipAddCA) {
                         buffer* cert = &args->certs[args->certIdx];
 
                         /* Is valid CA */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4807,7 +4807,7 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
     }
 #ifndef ALLOW_INVALID_CERTSIGN
     else if (ret == 0 && cert->isCA == 1 && type != WOLFSSL_USER_CA &&
-             (cert->extKeyUsage & KEYUSE_KEY_CERT_SIGN) == 0) {
+        !cert->selfSigned && (cert->extKeyUsage & KEYUSE_KEY_CERT_SIGN) == 0) {
         /* Intermediate CA certs are required to have the keyCertSign
         * extension set. User loaded root certs are not. */
         WOLFSSL_MSG("\tDoesn't have key usage certificate signing");


### PR DESCRIPTION
* Fix for alternate chain logic where presented peer's CA could be marked as trusted. When building with `WOLFSSL_ALT_CERT_CHAINS` a peer's presented CA could be incorrectly added to the certificate manager, marking it as trusted. Broken in PR #1934.
* Fix to check/send fatal alert after verify cert callback, alternate chain logic and AddCA.
* Allow `AddCA` for root CA's over the wire that do not have the extended key usage cert_sign set.
* Added logging for SendAlert call.

ZD 9626