### PR TITLE
CMS SignedData RSA sign callback for raw digest

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -16850,6 +16850,7 @@ static void test_wc_PKCS7_EncodeSignedData(void)
     !defined(NO_RSA) && !defined(NO_SHA256)
     /* test RSA sign raw digest callback, if using RSA and compiled in.
      * Example callback assumes SHA-256, so only run test if compiled in. */
+    wc_PKCS7_Free(pkcs7);
     AssertNotNull(pkcs7 = wc_PKCS7_New(HEAP_HINT, devId));
     AssertIntEQ(wc_PKCS7_InitWithCert(pkcs7, cert, certSz), 0);
 

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -220,6 +220,14 @@ typedef int (*CallbackWrapCEK)(PKCS7* pkcs7, byte* cek, word32 cekSz,
                                   byte* out, word32 outSz,
                                   int keyWrapAlgo, int type, int dir);
 
+#if defined(HAVE_PKCS7_RSA_RAW_SIGN_CALLBACK) && !defined(NO_RSA)
+/* RSA sign raw digest callback, user builds DigestInfo */
+typedef int (*CallbackRsaSignRawDigest)(PKCS7* pkcs7, byte* digest,
+                                   word32 digestSz, byte* out, word32 outSz,
+                                   byte* privateKey, word32 privateKeySz,
+                                   int devId, int hashOID);
+#endif
+
 /* Public Structure Warning:
  * Existing members must not be changed to maintain backwards compatibility!
  */
@@ -318,6 +326,10 @@ struct PKCS7 {
     word32 signatureSz;
     word32 plainDigestSz;
     word32 pkcs7DigestSz;
+
+#if defined(HAVE_PKCS7_RSA_RAW_SIGN_CALLBACK) && !defined(NO_RSA)
+    CallbackRsaSignRawDigest rsaSignRawDigestCb;
+#endif
     /* !! NEW DATA MEMBERS MUST BE ADDED AT END !! */
 };
 
@@ -438,6 +450,11 @@ WOLFSSL_API int  wc_PKCS7_AddRecipient_ORI(PKCS7* pkcs7, CallbackOriEncrypt cb,
                                            int options);
 WOLFSSL_API int  wc_PKCS7_SetWrapCEKCb(PKCS7* pkcs7,
         CallbackWrapCEK wrapCEKCb);
+
+#if defined(HAVE_PKCS7_RSA_RAW_SIGN_CALLBACK) && !defined(NO_RSA)
+WOLFSSL_API int  wc_PKCS7_SetRsaSignRawDigestCb(PKCS7* pkcs7,
+        CallbackRsaSignRawDigest cb);
+#endif
 
 /* CMS/PKCS#7 EnvelopedData */
 WOLFSSL_API int  wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7,


### PR DESCRIPTION
This PR adds a CMS/PKCS#7 callback for signing SignedData raw digests.  This is intended for users whose own crypto implementation or hardware crypto module builds up the encoded DigestInfo structure on their own.

Test is included in tests/api.c both for testing and to provide a usage example if needed.

This introduces one new preprocessor define, **HAVE_PKCS7_RSA_RAW_SIGN_CALLBACK** to enable this callback feature, along with one new API:

```
#include <wolfssl/wolfcrypt/pkcs7.h>

typedef int (*CallbackRsaSignRawDigest)(PKCS7* pkcs7, byte* digest,             
             word32 digestSz, byte* out, word32 outSz,    
             byte* privateKey, word32 privateKeySz,       
             int devId, int hashOID);

int wc_PKCS7_SetRsaSignRawDigestCb(PKCS7* pkcs7, CallbackRsaSignRawDigest cb);
```
The arguments to the callback are:

pkcs7 - [INPUT] pointer to active PKCS7 structure
digest - [INPUT] raw digest to sign, of size digestSz, type of digest represented by hashOID
digestSz - [INPUT] size of digest, octets
out - [OUTPUT] output buffer to place signature in
outSz - [INPUT] size of output buffer, octets
privateKey - [INPUT] private key used with PKCS7 structure. This may be NULL if using HW crypto, or crypto callbacks with devId
privateKeySz - [INPUT] size of private key, octets
devId - [INPUT] devID associated with PKCS7 structure if set with wc_PKCS7_Init()
hashOID - [INPUT] hash OID from Hash_Sum enum in <wolfssl/wolfcrypt/asn.h> (ex: "SHA256h")