### PR TITLE
allow EXTERNAL_SERIAL_SIZE to be user definable

### DIFF
--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3490,12 +3490,12 @@ struct WOLFSSL_X509_NAME {
 #endif
 };
 
-#ifndef EXTERNAL_SERIAL_SIZE
-    #define EXTERNAL_SERIAL_SIZE 32
-#endif
-
 #ifdef NO_ASN
     typedef struct DNS_entry DNS_entry;
+
+    #ifndef EXTERNAL_SERIAL_SIZE
+        #define EXTERNAL_SERIAL_SIZE 32
+    #endif
 #endif
 
 struct WOLFSSL_X509 {

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -62,6 +62,10 @@
     #define WC_SHA256_DIGEST_SIZE 32
 #endif
 
+#ifndef EXTERNAL_SERIAL_SIZE
+    #define EXTERNAL_SERIAL_SIZE 32
+#endif
+
 #ifdef __cplusplus
     extern "C" {
 #endif
@@ -69,8 +73,6 @@
 enum {
     ISSUER  = 0,
     SUBJECT = 1,
-
-    EXTERNAL_SERIAL_SIZE = 32,
 
     BEFORE  = 0,
     AFTER   = 1


### PR DESCRIPTION
This PR allows EXTERNAL_SERIAL_SIZE to be user-definable, adjusting enum in internal.h to define.