### PR TITLE
ABI Failure Test: Missing Function

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -831,24 +831,6 @@ static int _InitRng(WC_RNG* rng, byte* nonce, word32 nonceSz,
 
 
 WOLFSSL_ABI
-WC_RNG* wc_rng_new(byte* nonce, word32 nonceSz, void* heap)
-{
-    WC_RNG* rng;
-
-    rng = (WC_RNG*)XMALLOC(sizeof(WC_RNG), heap, DYNAMIC_TYPE_RNG);
-    if (rng) {
-        int error = _InitRng(rng, nonce, nonceSz, heap, INVALID_DEVID) != 0;
-        if (error) {
-            XFREE(rng, heap, DYNAMIC_TYPE_RNG);
-            rng = NULL;
-        }
-    }
-
-    return rng;
-}
-
-
-WOLFSSL_ABI
 void wc_rng_free(WC_RNG* rng)
 {
     if (rng) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8714,19 +8714,6 @@ static int random_rng_test(void)
 
     if (ret != 0) return ret;
 
-#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
-    {
-        byte nonce[8] = { 0 };
-        /* Test dynamic RNG. */
-        rng = wc_rng_new(nonce, (word32)sizeof(nonce), HEAP_HINT);
-        if (rng == NULL) return -6310;
-
-        ret = _rng_test(rng, -6310);
-
-        wc_rng_free(rng);
-    }
-#endif
-
     return ret;
 }
 

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -200,7 +200,6 @@ int wc_GenerateSeed(OS_Seed* os, byte* seed, word32 sz);
 #endif /* HAVE_WNR */
 
 
-WOLFSSL_ABI WOLFSSL_API WC_RNG* wc_rng_new(byte*, word32, void*);
 WOLFSSL_ABI WOLFSSL_API void wc_rng_free(WC_RNG*);
 
 


### PR DESCRIPTION
1. Removed the wc_rng_new() from the library completely.

DO NOT ACCEPT OR MERGE THIS PULL REQUEST. TESTING PURPOSES ONLY.