### PR TITLE
TSIP cleanup and DecodedCert struct size reduction

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -886,7 +886,9 @@ struct DecodedCert {
 #ifndef NO_CERTS
     SignatureCtx sigCtx;
 #endif
+#ifdef WOLFSSL_RENESAS_TSIP
     byte*  tsip_encRsaKeyIdx;
+#endif
 
     /* Option Bits */
     byte subjectCNStored : 1;      /* have we saved a copy we own */


### PR DESCRIPTION
Cleanup of TSIP code to reduce size of DecodedCert when TSIP is not enabled. Move the TSIP setup in ParseCertRelative into `SIG_STATE_BEGIN` setup state.