### PR TITLE
Maintenance: Error Strings

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -17298,8 +17298,7 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
         return "TLS Extension Trusted CA ID response absent";
 
     case TSIP_MAC_DIGSZ_E:
-        return "Invalid MAC size is specified. \
-                TSIP can only handle SHA1 and SHA256 digest size";
+        return "TSIP MAC size invalid, must be sized for SHA-1 or SHA-256";
 
     case CLIENT_CERT_CB_ERROR:
         return "Error importing client cert or key from callback";
@@ -17314,6 +17313,7 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
 void SetErrorString(int error, char* str)
 {
     XSTRNCPY(str, wolfSSL_ERR_reason_error_string(error), WOLFSSL_MAX_ERROR_SZ);
+    str[WOLFSSL_MAX_ERROR_SZ-1] = 0;
 }
 
 #ifndef NO_ERROR_STRINGS

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -521,6 +521,7 @@ const char* wc_GetErrorString(int error)
 void wc_ErrorString(int error, char* buffer)
 {
     XSTRNCPY(buffer, wc_GetErrorString(error), WOLFSSL_MAX_ERROR_SZ);
+    buffer[WOLFSSL_MAX_ERROR_SZ-1] = 0;
 }
 #endif /* !NO_ERROR_STRINGS */
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1336,6 +1336,8 @@ int error_test(void)
                 return -1103;
             if (XSTRNCMP(errStr, out, XSTRLEN(errStr)) != 0)
                 return -1104;
+            if (XSTRLEN(errStr) >= WOLFSSL_MAX_ERROR_SZ)
+                return -1109;
         }
         else {
             j++;


### PR DESCRIPTION
1. One of the error string was >80 bytes long. Shortened it.
2. The function that copies an error string to an output array needs to ensure the string is still null terminated.
3. Added a check to the wolfCrypt test to see that error strings aren't >= 80 bytes long.