### PR TITLE
add --disable-errorqueue option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1692,6 +1692,19 @@ else
 fi
 
 
+# ERROR QUEUE
+AC_ARG_ENABLE([errorqueue],
+    [AS_HELP_STRING([--disable-errorqueue],[Disables adding nodes to error queue when compiled with OPENSSL_EXTRA (default: enabled)])],
+    [ ENABLED_ERROR_QUEUE=$enableval ],
+    [ ENABLED_ERROR_QUEUE=yes ]
+    )
+
+if test "$ENABLED_ERROR_QUEUE" = "no"
+then
+    AM_CFLAGS="$AM_CFLAGS -DNO_ERROR_QUEUE"
+fi
+
+
 # OLD TLS
 AC_ARG_ENABLE([oldtls],
     [AS_HELP_STRING([--enable-oldtls],[Enable old TLS versions < 1.2 (default: enabled)])],

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17876,7 +17876,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     }
 
 
-#if defined(DEBUG_WOLFSSL) || defined(OPENSSL_EXTRA)
+#if (defined(DEBUG_WOLFSSL) || defined(OPENSSL_EXTRA)) && \
+    (!defined(_WIN32) && !defined(NO_ERROR_QUEUE))
     static const char WOLFSSL_SYS_ACCEPT_T[]  = "accept";
     static const char WOLFSSL_SYS_BIND_T[]    = "bind";
     static const char WOLFSSL_SYS_CONNECT_T[] = "connect";
@@ -17933,7 +17934,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         (void)file;
         (void)line;
         WOLFSSL_MSG("Not compiled in debug mode");
-        #elif defined(OPENSSL_EXTRA) && defined(_WIN32)
+        #elif defined(OPENSSL_EXTRA) && \
+                (defined(_WIN32) || defined(NO_ERROR_QUEUE))
         (void)fun;
         (void)file;
         (void)line;

--- a/tests/api.c
+++ b/tests/api.c
@@ -20247,7 +20247,7 @@ static void test_wolfSSL_ERR_peek_last_error_line(void)
     #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
        !defined(NO_FILESYSTEM) && defined(DEBUG_WOLFSSL) && \
        !defined(NO_OLD_TLS) && !defined(WOLFSSL_NO_TLS12) && \
-       defined(HAVE_IO_TESTS_DEPENDENCIES)
+       defined(HAVE_IO_TESTS_DEPENDENCIES) && !defined(NO_ERROR_QUEUE)
     tcp_ready ready;
     func_args client_args;
     func_args server_args;
@@ -22552,7 +22552,8 @@ static void test_wolfSSL_PKCS8_d2i(void)
 
 static void test_wolfSSL_ERR_put_error(void)
 {
-    #if defined(OPENSSL_EXTRA) && defined(DEBUG_WOLFSSL)
+    #if !defined(NO_ERROR_QUEUE) && defined(OPENSSL_EXTRA) && \
+        defined(DEBUG_WOLFSSL)
     const char* file;
     int line;
 
@@ -22621,7 +22622,8 @@ static void test_wolfSSL_ERR_put_error(void)
 
 static void test_wolfSSL_ERR_print_errors(void)
 {
-    #if defined(OPENSSL_EXTRA) && defined(DEBUG_WOLFSSL)
+    #if !defined(NO_ERROR_QUEUE) && defined(OPENSSL_EXTRA) && \
+        defined(DEBUG_WOLFSSL)
     BIO* bio;
     char buf[1024];
 

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -166,7 +166,8 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
 #if defined(DEBUG_WOLFSSL) || defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) ||\
     defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA)
 
-    #if (defined(OPENSSL_EXTRA) && !defined(_WIN32)) || defined(DEBUG_WOLFSSL_VERBOSE)
+    #if (!defined(NO_ERROR_QUEUE) && defined(OPENSSL_EXTRA) && !defined(_WIN32))\
+        || defined(DEBUG_WOLFSSL_VERBOSE)
         WOLFSSL_API void WOLFSSL_ERROR_LINE(int err, const char* func, unsigned int line,
             const char* file, void* ctx);
         #define WOLFSSL_ERROR(x) \


### PR DESCRIPTION
For disabling adding error nodes when --enable-opensslextra is used. This is to help performance and to remove the need to clean out nodes for users who want functionality that opensslextra has but do not want an error queue.