### PR TITLE
Cleanup ParseCertRelative code

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -890,7 +890,9 @@ struct DecodedCert {
 #ifndef NO_CERTS
     SignatureCtx sigCtx;
 #endif
+#ifdef WOLFSSL_RENESAS_TSIP
     byte*  tsip_encRsaKeyIdx;
+#endif
 
     int badDate;
     int criticalExt;


### PR DESCRIPTION
Fix for case:
- can't find a signer for a certificate with the AKID
- find it by name
Has to error as the signer's SKID is always set for signer and would
have matched the AKID.
Simplify the path length code - don't look up CA twice.
Don't require the tsip_encRsaKeyIdx field in DecodedCert when
!WOLFSSL_RENESAS_TSIP - use local variable.