### PR TITLE
Add more warnings to random.c when pseudo-random sources are used

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1589,7 +1589,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
 #include "rtprand.h"   /* rtp_rand () */
 #include "rtptime.h"   /* rtp_get_system_msec() */
-
+#warning "potential for not enough entropy, currently being used for testing"
 int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 {
     word32 i;
@@ -1668,6 +1668,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
             return 0;
         }
     #else  /* WOLFSSL_PIC32MZ_RNG */
+        #warning "potential for not enough entropy, currently being used for testing"
         /* uses the core timer, in nanoseconds to seed srand */
         int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         {
@@ -1954,6 +1955,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
     #include <xdc/runtime/Timestamp.h>
     #include <stdlib.h>
+    #warning "potential for not enough entropy, currently being used for testing"
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
         int i;
@@ -2244,6 +2246,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
 #elif defined(WOLFSSL_APACHE_MYNEWT)
 
+    #warning "potential for not enough entropy, currently being used for testing"
     #include <stdlib.h>
     #include "os/os_time.h"
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
@@ -2373,6 +2376,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
             }
             return myTime;
         }
+        #warning "potential for not enough entropy, currently being used for testing"
         int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         {
             int i;


### PR DESCRIPTION
When pseudo-random API (e.g. srand+rand) is used for as RNG, a warning should be issued.