### PR TITLE
Clarify wolfSSL_shutdown error on subsequent calls

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -17304,6 +17304,9 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
     case CLIENT_CERT_CB_ERROR:
         return "Error importing client cert or key from callback";
 
+    case SSL_SHUTDOWN_ALREADY_DONE_E:
+        return "Shutdown has already occurred";
+
     default :
         return "unknown error number";
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2884,6 +2884,14 @@ int wolfSSL_shutdown(WOLFSSL* ssl)
             }
         }
 
+#ifdef WOLFSSL_SHUTDOWNONCE
+        if (ssl->options.isClosed || ssl->options.connReset) {
+            /* Shutdown has already occurred.
+             * Caller is free to ignore this error. */
+            return SSL_SHUTDOWN_ALREADY_DONE_E;
+        }
+#endif
+
         /* call wolfSSL_shutdown again for bidirectional shutdown */
         if (ssl->options.sentNotify && !ssl->options.closeNotify) {
             ret = wolfSSL_read(ssl, &tmp, 0);

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -165,6 +165,8 @@ enum wolfSSL_ErrorCodes {
     TCA_ABSENT_ERROR             = -434,   /* TLSX TCA ID no response */
     TSIP_MAC_DIGSZ_E             = -435,   /* Invalid MAC size for TSIP */
     CLIENT_CERT_CB_ERROR         = -436,   /* Client cert callback error */
+    SSL_SHUTDOWN_ALREADY_DONE_E  = -437,   /* Shutdown called redundantly */
+
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 
     /* begin negotiation parameter errors */


### PR DESCRIPTION
In cases where the connection has already been closed by an internal error, and the application attempts to shutdown the connection after receiving the error. The shutdown would return a `-1` error, and the code stored in the ssl structure is still set to the previous error. After enabling `WOLFSSL_SHUTDOWNONCE`, shutdown will return a specific code, `SSL_SHUTDOWN_ALREADY_DONE_E`, to indicate to the application that the shutdown has already occurred.