### PR TITLE
Maintenance: Configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3385,7 +3385,6 @@ then
     then
         ENABLED_OCSP="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_OCSP"
-        AM_CONDITIONAL([BUILD_OCSP], [test "x$ENABLED_OCSP" = "xyes"])
     fi
 
     # Requires sessioncerts make sure on
@@ -3407,7 +3406,6 @@ then
     then
         ENABLED_CRL="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_CRL"
-        AM_CONDITIONAL([BUILD_CRL], [test "x$ENABLED_CRL" = "xyes"])
     fi
 
     # Requires Certificate Generation, Request and Extensions
@@ -3825,7 +3823,6 @@ if test "x$ENABLED_PKCS12" = "xno"
 then
     AM_CFLAGS="$AM_CFLAGS -DNO_PKCS12"
 fi
-AM_CONDITIONAL([BUILD_PKCS12], [test "x$ENABLED_PKCS12" = "xyes"])
 
 
 # cavium
@@ -4966,6 +4963,7 @@ AM_CONDITIONAL([BUILD_THREADED_EXAMPLES],[test "x$ENABLED_SINGLETHREADED" = "xno
 AM_CONDITIONAL([BUILD_WOLFCRYPT_TESTS],[test "x$ENABLED_CRYPT_TESTS" = "xyes"])
 AM_CONDITIONAL([BUILD_LIBZ],[test "x$ENABLED_LIBZ" = "xyes"])
 AM_CONDITIONAL([BUILD_PKCS11],[test "x$ENABLED_PKCS11" = "xyes"])
+AM_CONDITIONAL([BUILD_PKCS12],[test "x$ENABLED_PKCS12" = "xyes"])
 AM_CONDITIONAL([BUILD_CAVIUM],[test "x$ENABLED_CAVIUM" = "xyes"])
 AM_CONDITIONAL([BUILD_CAVIUM_V],[test "x$ENABLED_CAVIUM_V" = "xyes"])
 AM_CONDITIONAL([BUILD_OCTEON_SYNC],[test "x$ENABLED_OCTEON_SYNC" = "xyes"])


### PR DESCRIPTION
1. Remove some redundant AM_CONDITIONAL macros checking for OCSP and CRL.
2. Moved the AM_CONDITIONAL macro setting BUILD_PKCS12 to the other AM_CONDITIONALS.