### PR TITLE
Find CRL Signer By AuthKeyId

### DIFF
--- a/cyassl/ctaocrypt/settings.h
+++ b/cyassl/ctaocrypt/settings.h
@@ -706,12 +706,6 @@
     #endif
 #endif
 
-#ifdef HAVE_CRL
-    /* not widely supported yet */
-    #undef NO_SKID
-    #define NO_SKID
-#endif
-
 
 #ifdef __INTEL_COMPILER
     #pragma warning(disable:2259) /* explicit casts to smaller sizes, disable */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -371,6 +371,7 @@ enum Oid_Types {
     oidCompressType     = 16,
     oidCertNameType     = 17,
     oidTlsExtType       = 18,
+    oidCrlExtType       = 19,
     oidIgnoreType
 };
 
@@ -1341,17 +1342,19 @@ struct DecodedCRL {
     word32  sigLength;               /* length of signature              */
     word32  signatureOID;            /* sum of algorithm object id       */
     byte*   signature;               /* pointer into raw source, not owned */
-    byte    issuerHash[SIGNER_DIGEST_SIZE]; /* issuer hash               */
+    byte    issuerHash[SIGNER_DIGEST_SIZE]; /* issuer name hash          */
     byte    crlHash[SIGNER_DIGEST_SIZE]; /* raw crl data hash            */
     byte    lastDate[MAX_DATE_SIZE]; /* last date updated  */
     byte    nextDate[MAX_DATE_SIZE]; /* next update date   */
-    byte    extAuthKeyId[KEYID_SIZE]; /* Authority Key ID                */
     byte    lastDateFormat;          /* format of last date */
     byte    nextDateFormat;          /* format of next date */
     RevokedCert* certs;              /* revoked cert list  */
     int          totalCerts;         /* number on list     */
     void*   heap;
-    byte    extAuthKeyIdSet;         /* Set when the AKID was read from CRL */
+#ifndef NO_SKID
+    byte    extAuthKeyIdSet;
+    byte    extAuthKeyId[SIGNER_DIGEST_SIZE]; /* Authority Key ID        */
+#endif
 };
 
 WOLFSSL_LOCAL void InitDecodedCRL(DecodedCRL*, void* heap);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1618,12 +1618,6 @@ extern void uITRON4_free(void *p) ;
     #define XGEN_ALIGN
 #endif
 
-#ifdef HAVE_CRL
-    /* may not be widely supported */
-    /* #undef NO_SKID */
-    /* #define NO_SKID */
-#endif
-
 
 #ifdef __INTEL_COMPILER
     #pragma warning(disable:2259) /* explicit casts to smaller sizes, disable */


### PR DESCRIPTION
1. Add parsing of CRL extensions, specifically the Auth Key ID extension.
2. To verify CRL, search for CA signer by AuthKeyId first, then by name.  If NO_SKID is set, just use name.
3. Update the ctaocrypt settings.h for the NO_SKID option with CRL so FIPS builds work.