### PR TITLE
Check name hash after matching AKID

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -8666,11 +8666,16 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
          } else {
             cert->ca = NULL;
     #ifndef NO_SKID
-            if (cert->extAuthKeyIdSet)
+            if (cert->extAuthKeyIdSet) {
                 cert->ca = GetCA(cm, cert->extAuthKeyId);
+            }
             if (cert->ca == NULL && cert->extSubjKeyIdSet \
                                  && verify != VERIFY_OCSP) {
                 cert->ca = GetCA(cm, cert->extSubjKeyId);
+            }
+            if (cert->ca != NULL && XMEMCMP(cert->issuerHash,
+                                  cert->ca->subjectNameHash, KEYID_SIZE) != 0) {
+                cert->ca = NULL;
             }
             if (cert->ca == NULL)
                 cert->ca = GetCAByName(cm, cert->issuerHash);
@@ -8765,6 +8770,10 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
             if (cert->ca == NULL && cert->extSubjKeyIdSet \
                                  && verify != VERIFY_OCSP) {
                 cert->ca = GetCA(cm, cert->extSubjKeyId);
+            }
+            if (cert->ca != NULL && XMEMCMP(cert->issuerHash,
+                                  cert->ca->subjectNameHash, KEYID_SIZE) != 0) {
+                cert->ca = NULL;
             }
             if (cert->ca == NULL)
                 cert->ca = GetCAByName(cm, cert->issuerHash);


### PR DESCRIPTION
RFC 5280, Section 4.1.2.6:
If the subject is a CA (e.g., the basic constraints extension, as
discussed in Section 4.2.1.9, is present and the value of cA is TRUE),
then the subject field MUST be populated with a non-empty distinguished
name matching the contents of the issuer field (Section 4.1.2.4) in all
certificates issued by the subject CA.

The subject name must match - even when the AKID matches.