### PR TITLE
Various cleanups and fixes

### DIFF
--- a/IDE/RISCV/SIFIVE-UNLEASHED/README.md
+++ b/IDE/RISCV/SIFIVE-UNLEASHED/README.md
@@ -9,7 +9,7 @@ SiFive Freedom U540 SoC at 1.5GHz
 Getting started guide: 
 https://sifive.cdn.prismic.io/sifive%2Ffa3a584a-a02f-4fda-b758-a2def05f49f9_hifive-unleashed-getting-started-guide-v1p1.pdf
 
-Make sure your ethernet is attached and power up board. You can connecct the micro-usb to get a UART console that will display the DHCP IP address. Default login password is "sifive".
+Make sure your ethernet is attached and power up board. You can connecct the micro-usb to get a UART console that will display the DHCP IP address. Default user is "root" and login password is "sifive".
 
 ## Building Freedom-U-SDK
 
@@ -99,10 +99,10 @@ make
 
 ## Benchmark Results
 
-The following is running the wolfCrypt benchmark at 1.5GHz on a single thread (default CPU speed is 1.0GHz).
+The following is running the wolfCrypt benchmark at 1.4GHz on a single thread (default CPU speed is 1.0GHz).
 
 ```sh
-echo 1500000000 > /sys/devices/platform/soc/10000000.prci/rate
+echo 1400000000 > /sys/devices/platform/soc/10000000.prci/rate
 
 ./benchmark
 ------------------------------------------------------------------------------
@@ -144,6 +144,60 @@ ECDHE    256 agree         400 ops took 1.243 sec, avg 3.107 ms, 321.830 ops/sec
 ECDSA    256 sign         1000 ops took 1.043 sec, avg 1.043 ms, 958.539 ops/sec
 ECDSA    256 verify        300 ops took 1.104 sec, avg 3.680 ms, 271.766 ops/sec
 Benchmark complete
+```
+
+## TLS Benchmarks
+
+```
+echo 1400000000 > /sys/devices/platform/soc/10000000.prci/rate
+./examples/benchmark/tls_bench -p 8192 -m
+Side    Cipher                             Total Bytes  Num Conns      Rx ms      Tx ms    Rx MB/s    Tx MB/s   Connect Total ms   Connect Avg ms
+Server  DHE-RSA-AES128-SHA                      557056         18     94.722     34.548      2.804      7.689            915.005           50.834
+Client  DHE-RSA-AES128-SHA                      557056         18    113.339     34.464      2.344      7.707            896.122           49.785
+Server  DHE-RSA-AES256-SHA                      524288         17    102.691     37.624      2.434      6.645            866.921           50.995
+Client  DHE-RSA-AES256-SHA                      524288         17    123.016     37.391      2.032      6.686            846.925           49.819
+Server  ECDHE-RSA-AES128-SHA                    851968         27    144.719     52.871      2.807      7.684            828.128           30.671
+Client  ECDHE-RSA-AES128-SHA                    851968         27    173.414     52.593      2.343      7.724            799.406           29.608
+Server  ECDHE-ECDSA-AES128-SHA                 1245184         39    210.728     75.683      2.818      7.845            702.403           18.010
+Client  ECDHE-ECDSA-AES128-SHA                 1245184         39    251.039     76.824      2.365      7.729            660.166           16.927
+Server  ECDHE-ECDSA-AES256-SHA                 1179648         37    232.303     85.585      2.421      6.572            673.207           18.195
+Client  ECDHE-ECDSA-AES256-SHA                 1179648         37    277.830     85.551      2.025      6.575            626.807           16.941
+Server  DHE-RSA-AES128-SHA256                   524288         17    106.848     39.533      2.340      6.324            867.397           51.023
+Client  DHE-RSA-AES128-SHA256                   524288         17    127.601     39.334      1.959      6.356            846.556           49.797
+Server  DHE-RSA-AES256-SHA256                   524288         17    120.685     45.184      2.072      5.533            870.931           51.231
+Client  DHE-RSA-AES256-SHA256                   524288         17    144.842     44.807      1.726      5.579            847.038           49.826
+Server  DHE-RSA-AES128-GCM-SHA256               524288         17    124.636     49.373      2.006      5.064            869.243           51.132
+Client  DHE-RSA-AES128-GCM-SHA256               524288         17    148.326     49.277      1.685      5.073            845.442           49.732
+Server  DHE-RSA-AES256-GCM-SHA384               491520         16    129.714     51.389      1.807      4.561            822.309           51.394
+Client  DHE-RSA-AES256-GCM-SHA384               491520         16    154.349     51.488      1.518      4.552            797.458           49.841
+Server  ECDHE-RSA-AES128-GCM-SHA256             753664         24    179.251     71.130      2.005      5.052            744.773           31.032
+Client  ECDHE-RSA-AES128-GCM-SHA256             753664         24    213.410     71.098      1.684      5.055            710.151           29.590
+Server  ECDHE-RSA-AES256-GCM-SHA384             753664         24    198.233     78.075      1.813      4.603            751.299           31.304
+Client  ECDHE-RSA-AES256-GCM-SHA384             753664         24    235.646     78.914      1.525      4.554            712.908           29.705
+Server  ECDHE-ECDSA-AES128-GCM-SHA256          1114112         35    263.646    103.830      2.015      5.117            641.739           18.335
+Client  ECDHE-ECDSA-AES128-GCM-SHA256          1114112         35    312.647    105.155      1.699      5.052            590.693           16.877
+Server  ECDHE-ECDSA-AES256-GCM-SHA384          1048576         33    275.753    117.824      1.813      4.244            615.062           18.638
+Client  ECDHE-ECDSA-AES256-GCM-SHA384          1048576         33    336.538    109.886      1.486      4.550            561.107           17.003
+Server  ECDHE-RSA-AES128-SHA256                 786432         25    159.515     58.314      2.351      6.431            777.706           31.108
+Client  ECDHE-RSA-AES128-SHA256                 786432         25    190.152     58.939      1.972      6.362            746.025           29.841
+Server  ECDHE-ECDSA-AES128-SHA256              1179648         37    239.776     87.656      2.346      6.417            675.020           18.244
+Client  ECDHE-ECDSA-AES128-SHA256              1179648         37    285.535     88.530      1.970      6.354            626.898           16.943
+Server  ECDHE-RSA-AES256-SHA384                 786432         25    173.038     63.549      2.167      5.901            780.063           31.203
+Client  ECDHE-RSA-AES256-SHA384                 786432         25    206.355     63.950      1.817      5.864            745.912           29.836
+Server  ECDHE-ECDSA-AES256-SHA384              1146880         36    252.686     94.012      2.164      5.817            666.287           18.508
+Client  ECDHE-ECDSA-AES256-SHA384              1146880         36    302.699     93.089      1.807      5.875            616.081           17.113
+Server  ECDHE-RSA-CHACHA20-POLY1305             983040         31     67.015     25.344      6.995     18.496            929.187           29.974
+Client  ECDHE-RSA-CHACHA20-POLY1305             983040         31     79.041     25.765      5.930     18.193            916.451           29.563
+Server  ECDHE-ECDSA-CHACHA20-POLY1305          1572864         49    110.132     40.284      6.810     18.618            848.004           17.306
+Client  ECDHE-ECDSA-CHACHA20-POLY1305          1572864         49    131.014     41.404      5.725     18.114            824.766           16.832
+Server  DHE-RSA-CHACHA20-POLY1305               589824         19     40.016     15.086      7.028     18.643            951.114           50.059
+Client  DHE-RSA-CHACHA20-POLY1305               589824         19     46.994     15.467      5.985     18.184            943.807           49.674
+Server  ECDHE-RSA-CHACHA20-POLY1305-OLD         983040         31     66.802     25.246      7.017     18.567            928.078           29.938
+Client  ECDHE-RSA-CHACHA20-POLY1305-OLD         983040         31     78.402     25.915      5.979     18.088            915.354           29.528
+Server  ECDHE-ECDSA-CHACHA20-POLY1305-OLD      1572864         49    106.853     40.000      7.019     18.750            844.887           17.243
+Client  ECDHE-ECDSA-CHACHA20-POLY1305-OLD      1572864         49    124.956     41.720      6.002     17.977            824.284           16.822
+Server  DHE-RSA-CHACHA20-POLY1305-OLD           589824         19     40.200     14.991      6.996     18.762            951.477           50.078
+Client  DHE-RSA-CHACHA20-POLY1305-OLD           589824         19     46.852     15.688      6.003     17.928            944.071           49.688
 ```
 
 ## Support

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -333,11 +333,12 @@ static int NonBlockingSSL_Accept(SSL* ssl)
 
 /* Echo number of bytes specified by -e arg */
 int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
-                   int throughput)
+                   size_t throughput)
 {
     int ret = 0, err;
     double start = 0, rx_time = 0, tx_time = 0;
-    int xfer_bytes = 0, select_ret, len, rx_pos;
+    int select_ret, len, rx_pos;
+    size_t xfer_bytes = 0;
     char* buffer;
 
     buffer = (char*)malloc(block);
@@ -351,7 +352,7 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
         select_ret = tcp_select(clientfd, 1); /* Timeout=1 second */
         if (select_ret == TEST_RECV_READY) {
 
-            len = min(block, throughput - xfer_bytes);
+            len = min(block, (int)(throughput - xfer_bytes));
             rx_pos = 0;
 
             if (throughput) {
@@ -416,7 +417,7 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
     free(buffer);
 
     if (throughput) {
-        printf("wolfSSL Server Benchmark %d bytes\n"
+        printf("wolfSSL Server Benchmark %zu bytes\n"
             "\tRX      %8.3f ms (%8.3f MBps)\n"
             "\tTX      %8.3f ms (%8.3f MBps)\n",
             throughput,
@@ -917,7 +918,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     int    cnt = 0;
     int    echoData = 0;
     int    block = TEST_BUFFER_SIZE;
-    int    throughput = 0;
+    size_t throughput = 0;
     int    minDhKeyBits  = DEFAULT_MIN_DHKEY_BITS;
     short  minRsaKeyBits = DEFAULT_MIN_RSAKEY_BITS;
     short  minEccKeyBits = DEFAULT_MIN_ECCKEY_BITS;
@@ -1302,7 +1303,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 break;
 
             case 'B':
-                throughput = atoi(myoptarg);
+                throughput = atol(myoptarg);
                 for (; *myoptarg != '\0'; myoptarg++) {
                     if (*myoptarg == ',') {
                         block = atoi(myoptarg + 1);

--- a/examples/server/server.h
+++ b/examples/server/server.h
@@ -29,8 +29,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args);
 /* Echo bytes using buffer of blockSize until [echoData] bytes are complete. */
 /* If [bechmarkThroughput] set the statistcs will be output at the end */
 int ServerEchoData(WOLFSSL* ssl, int clientfd, int echoData, int blockSize,
-                   int benchmarkThroughput);
+                   size_t benchmarkThroughput);
 
 
 #endif /* WOLFSSL_SERVER_H */
-

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -27,6 +27,9 @@
     #include <config.h>
 #endif
 
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/version.h>
 #include <wolfssl/wolfcrypt/wc_port.h>
@@ -663,7 +666,7 @@ static const char* bench_desc_words[][9] = {
 #endif
 
 #if (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || !defined(NO_DH) \
-                        || defined(WOLFSSL_KEYGEN) || defined(HAVE_ECC) \
+                        || defined(WOLFSSL_KEY_GEN) || defined(HAVE_ECC) \
                         || defined(HAVE_CURVE25519) || defined(HAVE_ED25519)
     #define HAVE_LOCAL_RNG
     static THREAD_LS_T WC_RNG rng;

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2846,6 +2846,7 @@ static int RsaPrivateDecryptEx(byte* in, word32 inLen, byte* out,
                             WC_RNG* rng)
 {
     int ret = RSA_WRONG_TYPE_E;
+    byte* pad = NULL;
 
     if (in == NULL || inLen == 0 || out == NULL || key == NULL) {
         return BAD_FUNC_ARG;
@@ -2935,8 +2936,6 @@ static int RsaPrivateDecryptEx(byte* in, word32 inLen, byte* out,
         FALL_THROUGH;
 
     case RSA_STATE_DECRYPT_UNPAD:
-    {
-        byte* pad = NULL;
 #if !defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_VERIFY_INLINE)
         ret = wc_RsaUnPad_ex(key->data, key->dataLen, &pad, pad_value, pad_type,
                              hash, mgf, label, labelSz, saltLen,
@@ -2983,9 +2982,8 @@ static int RsaPrivateDecryptEx(byte* in, word32 inLen, byte* out,
         }
 
         key->state = RSA_STATE_DECRYPT_RES;
-
         FALL_THROUGH;
-    }
+
     case RSA_STATE_DECRYPT_RES:
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_RSA) && \
             defined(HAVE_CAVIUM)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -24,6 +24,9 @@
     #include <config.h>
 #endif
 
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/version.h>
 #include <wolfssl/wolfcrypt/wc_port.h>
@@ -538,8 +541,11 @@ int wolfcrypt_test(void* args)
 #endif
 
 #if !defined(NO_BIG_INT)
-    if (CheckCtcSettings() != 1)
+    if (CheckCtcSettings() != 1) {
+        printf("Sizeof mismatch (build) %x != (run) %x\n",
+            CTC_SETTINGS, CheckRunTimeSettings());
         return err_sys("Build vs runtime math mismatch\n", -1000);
+    }
 
 #if defined(USE_FAST_MATH) && \
 	(!defined(NO_RSA) || !defined(NO_DH) || defined(HAVE_ECC))

--- a/wolfssl/wolfcrypt/port/st/stm32.h
+++ b/wolfssl/wolfcrypt/port/st/stm32.h
@@ -28,7 +28,8 @@
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/types.h>
 
-#if defined(WOLFSSL_STM32_PKA)
+#if defined(WOLFSSL_STM32_PKA) && defined(HAVE_ECC)
+    #include <wolfssl/wolfcrypt/integer.h>
     #include <wolfssl/wolfcrypt/ecc.h>
 #endif
 
@@ -129,13 +130,12 @@ int  wc_Stm32_Hash_Final(STM32_HASH_Context* stmCtx, word32 algo,
 
 #endif /* STM32_CRYPTO */
 
-#ifdef WOLFSSL_STM32_PKA
+#if defined(WOLFSSL_STM32_PKA) && defined(HAVE_ECC)
 int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
                     word32 hashlen, int* res, ecc_key* key);
 
 int stm32_ecc_sign_hash_ex(const byte* hash, word32 hashlen, WC_RNG* rng,
                      ecc_key* key, mp_int *r, mp_int *s);
-
 #endif
 
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2020,8 +2020,8 @@ extern void uITRON4_free(void *p) ;
 #endif /* OPENSSL_EXTRA */
 
 /* support for converting DER to PEM */
-#if defined(WOLFSSL_KEY_GEN) || defined(WOLFSSL_CERT_GEN) || \
-        defined(OPENSSL_EXTRA)
+#if (defined(WOLFSSL_KEY_GEN) && !defined(WOLFSSL_NO_DER_TO_PEM)) || \
+    defined(WOLFSSL_CERT_GEN) || defined(OPENSSL_EXTRA)
     #undef  WOLFSSL_DER_TO_PEM
     #define WOLFSSL_DER_TO_PEM
 #endif


### PR DESCRIPTION
* Fix for key gen macro name in benchmark.c
* Fix for possible RSA fall-through warning.
* Fix for building `WOLFSSL_STM32_PKA` without `HAVE_ECC`.
* Added option to build RSA keygen without the DER to PEM using `WOLFSSL_NO_DER_TO_PEM`.
* Added options.h includes for test.c and benchmark.c.
* Added printf warning on the math size mismatch in test.c.
* Added support for benchmarking larger sizes.
* TLS benchmarks for HiFive unleashed.

These are various items from different branches that would be nice to get in for the release.