### PR TITLE
DTLS Handshake Message Cap

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -12359,6 +12359,14 @@ static int DoDtlsHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         return PARSE_ERROR;
     }
 
+    /* Cap the maximum size of a handshake message to something reasonable.
+     * By default is the maximum size of a certificate message assuming
+     * nine 2048-bit RSA certificates in the chain. */
+    if (size > MAX_HANDSHAKE_SZ) {
+        WOLFSSL_MSG("Handshake message too large");
+        return HANDSHAKE_SIZE_ERROR;
+    }
+
     /* check that we have complete fragment */
     if (*inOutIdx + fragSz > totalSz) {
         WOLFSSL_ERROR(INCOMPLETE_DATA);


### PR DESCRIPTION
Cap the incoming DTLS handshake messages size the same way we do for TLS. If handshake messages claim to be larger than the largest allowed certificate message, we error out. (ZD 9519)