### PR TITLE
use const to declare array rather than variable sz - VS doesn't like …

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8492,7 +8492,7 @@ int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out, WOLFSSL_X509_EXTENSION *ext,
     int nid;
     const int sz = CTC_NAME_SIZE*2;
     int rc = WOLFSSL_FAILURE;
-    char tmp[sz];
+    char tmp[CTC_NAME_SIZE*2];
     WOLFSSL_ENTER("wolfSSL_X509V3_EXT_print");
 
     if ((out == NULL) || (ext == NULL)) {


### PR DESCRIPTION
…this