### PR TITLE
Expose serialization/deserialization methods separately from OpenSSL extra

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26326,8 +26326,6 @@ void wolfSSL_CTX_sess_set_remove_cb(WOLFSSL_CTX* ctx, void (*f)(WOLFSSL_CTX*,
 }
 #endif /* OPENSSL_EXTRA || HAVE_EXT_CACHE */
 
-#ifdef OPENSSL_EXTRA
-
 /*
  *
  * Note: It is expected that the importing and exporting function have been
@@ -26704,6 +26702,8 @@ end:
 #endif
     return s;
 }
+
+#ifdef OPENSSL_EXTRA
 
 
 long wolfSSL_SESSION_get_timeout(const WOLFSSL_SESSION* sess)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26326,6 +26326,7 @@ void wolfSSL_CTX_sess_set_remove_cb(WOLFSSL_CTX* ctx, void (*f)(WOLFSSL_CTX*,
 }
 #endif /* OPENSSL_EXTRA || HAVE_EXT_CACHE */
 
+#if defined(OPENSSL_EXTRA) || defined (WOLFSSL_SESSION_SER)
 /*
  *
  * Note: It is expected that the importing and exporting function have been
@@ -26703,8 +26704,9 @@ end:
     return s;
 }
 
-#ifdef OPENSSL_EXTRA
+#endif /* OPENSSL_EXTRA || WOLFSSL_SESSION_SER */
 
+#ifdef OPENSSL_EXTRA
 
 long wolfSSL_SESSION_get_timeout(const WOLFSSL_SESSION* sess)
 {


### PR DESCRIPTION
Hello,

This is the intermediate version of WolfSSL 4.2.0c that we use in our FreeRTOS based application that exposes `WOLFSSL_SESSION` structure serialzation/deserialization methods without OpenSSL extra.
Let me know if it is required to update `configure.ac` to:
* introduce a flag for setting up the `WOLFSSL_SESSION_SER` macro
* update `user_settings.h` in `GCC_ARM` for example

Look forward to hearing from you.