### PR TITLE
Free fix point ecc cache

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -5575,6 +5575,9 @@ void FreeKey(WOLFSSL* ssl, int type, void** pKey)
         #ifdef HAVE_ECC
             case DYNAMIC_TYPE_ECC:
                 wc_ecc_free((ecc_key*)*pKey);
+                #ifdef FP_ECC
+                    wc_ecc_fp_free();
+                #endif
                 break;
         #endif /* HAVE_ECC */
         #ifdef HAVE_ED25519
@@ -10193,7 +10196,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 #endif /* WOLFSSL_TRUST_PEER_CERT */
                 ) {
                     int skipAddCA = 0;
-                    
                     /* select last certificate */
                     args->certIdx = args->count - 1;
 


### PR DESCRIPTION
This PR fixes a potential memory leak from the ECC fix point cache. 

As an example, it corrects the following error reported by Valgrind:
==2365== 3,288 bytes in 1 blocks are still reachable in loss record 123 of 143
 malloc (vg_replace_malloc.c:296)
==2365==    by 0x4C90F2: wolfSSL_Malloc (memory.c:140)
==2365==    by 0x51128A: wc_ecc_new_point_h (ecc.c:2977)
==2365==    by 0x51131F: wc_ecc_new_point (ecc.c:3007)
==2365==    by 0x5171AB: add_entry (ecc.c:8309)
==2365==    by 0x5196B5: wc_ecc_mulmod_ex (ecc.c:9148)
==2365==    by 0x512389: wc_ecc_shared_secret_gen_sync (ecc.c:3594)
==2365==    by 0x512565: wc_ecc_shared_secret_gen (ecc.c:3713)
==2365==    by 0x512630: wc_ecc_shared_secret_ex (ecc.c:3757)
==2365==    by 0x51221F: wc_ecc_shared_secret (ecc.c:3528)
==2365==    by 0x546365: EccSharedSecret (internal.c:4217)
==2365==    by 0x5609C3: SendClientKeyExchange (internal.c:21698)