### PR TITLE
Cryptocell RSA improvements to sign/verify more digest types

### DIFF
--- a/wolfcrypt/src/port/arm/cryptoCell.c
+++ b/wolfcrypt/src/port/arm/cryptoCell.c
@@ -146,34 +146,37 @@ CRYS_ECPKI_DomainID_t cc310_mapCurve(int curve_id)
 #endif /* HAVE_ECC */
 
 #ifndef NO_RSA
-CRYS_RSA_HASH_OpMode_t cc310_hashModeRSA(enum wc_HashType hash_type)
+CRYS_RSA_HASH_OpMode_t cc310_hashModeRSA(enum wc_HashType hash_type, int isHashed)
 {
     switch(hash_type)
     {
         case WC_HASH_TYPE_MD5:
         #ifndef NO_MD5
-            return CRYS_RSA_HASH_MD5_mode;
+            return isHashed? CRYS_RSA_After_MD5_mode : CRYS_RSA_HASH_MD5_mode;
         #endif
         case WC_HASH_TYPE_SHA:
         #ifndef NO_SHA
-            return CRYS_RSA_HASH_SHA1_mode;
+            return isHashed? CRYS_RSA_After_SHA1_mode : CRYS_RSA_HASH_SHA1_mode;
         #endif
         case WC_HASH_TYPE_SHA224:
         #ifdef WOLFSSL_SHA224
-            return CRYS_RSA_HASH_SHA224_mode;
+            return isHashed? CRYS_RSA_After_SHA224_mode : CRYS_RSA_HASH_SHA224_mode;
         #endif
         case WC_HASH_TYPE_SHA256:
         #ifndef NO_SHA256
-            return CRYS_RSA_HASH_SHA256_mode;
+            return isHashed? CRYS_RSA_After_SHA256_mode : CRYS_RSA_HASH_SHA256_mode;
         #endif
         case WC_HASH_TYPE_SHA384:
         #ifdef WOLFSSL_SHA384
-            return CRYS_RSA_HASH_SHA384_mode;
+            return isHashed? CRYS_RSA_After_SHA384_mode : CRYS_RSA_HASH_SHA384_mode;
         #endif
         case WC_HASH_TYPE_SHA512:
         #ifdef WOLFSSL_SHA512
-            return CRYS_RSA_HASH_SHA512_mode;
+            return isHashed? CRYS_RSA_After_SHA512_mode : CRYS_RSA_HASH_SHA512_mode;
         #endif
+        case WC_HASH_TYPE_NONE:
+            /* default to SHA256 */
+            return isHashed? CRYS_RSA_After_SHA256_mode : CRYS_RSA_HASH_SHA256_mode;
         default:
             return CRYS_RSA_After_HASH_NOT_KNOWN_mode;
     }

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2522,17 +2522,12 @@ static int cc310_RsaPublicDecrypt(const byte* in, word32 inLen, byte* out,
     return actualOutLen;
 }
 
-static int cc310_RsaSSL_Sign(const byte* in, word32 inLen, byte* out,
-                            word32 outLen, RsaKey* key, enum wc_HashType hash)
+int cc310_RsaSSL_Sign(const byte* in, word32 inLen, byte* out,
+                  word32 outLen, RsaKey* key, CRYS_RSA_HASH_OpMode_t mode)
 {
     CRYSError_t ret = 0;
     uint16_t actualOutLen = outLen*sizeof(byte);
     CRYS_RSAPrivUserContext_t  contextPrivate;
-    CRYS_RSA_HASH_OpMode_t mode = cc310_hashModeRSA(hash);
-
-    if (mode == CRYS_RSA_After_HASH_NOT_KNOWN_mode) {
-        mode = CRYS_RSA_HASH_SHA256_mode;
-    }
 
     ret =  CRYS_RSA_PKCS1v15_Sign(&wc_rndState,
                 wc_rndGenVectFunc,
@@ -2551,16 +2546,12 @@ static int cc310_RsaSSL_Sign(const byte* in, word32 inLen, byte* out,
     return actualOutLen;
 }
 
-static int cc310_RsaSSL_Verify(const byte* in, word32 inLen, byte* sig,
-                               RsaKey* key, enum wc_HashType hash)
+int cc310_RsaSSL_Verify(const byte* in, word32 inLen, byte* sig,
+                               RsaKey* key, CRYS_RSA_HASH_OpMode_t mode)
 {
     CRYSError_t ret = 0;
     CRYS_RSAPubUserContext_t contextPub;
-    CRYS_RSA_HASH_OpMode_t mode = cc310_hashModeRSA(hash);
 
-    if (mode == CRYS_RSA_After_HASH_NOT_KNOWN_mode) {
-        mode = CRYS_RSA_HASH_SHA256_mode;
-    }
     /* verify the signature in the sig pointer */
     ret =  CRYS_RSA_PKCS1v15_Verify(&contextPub,
                 &key->ctx.pubKey,
@@ -2765,7 +2756,8 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
         }
         else if (rsa_type == RSA_PRIVATE_ENCRYPT &&
                                          pad_value == RSA_BLOCK_TYPE_1) {
-         return cc310_RsaSSL_Sign(in, inLen, out, outLen, key, hash);
+         return cc310_RsaSSL_Sign(in, inLen, out, outLen, key,
+                                  cc310_hashModeRSA(hash, 0));
         }
     #endif /* WOLFSSL_CRYPTOCELL */
 
@@ -2887,7 +2879,8 @@ static int RsaPrivateDecryptEx(byte* in, word32 inLen, byte* out,
         }
         else if (rsa_type == RSA_PUBLIC_DECRYPT &&
                                             pad_value == RSA_BLOCK_TYPE_1) {
-            return cc310_RsaSSL_Verify(in, inLen, out, key, hash);
+            return cc310_RsaSSL_Verify(in, inLen, out, key,
+                                       cc310_hashModeRSA(hash, 0));
         }
     #endif /* WOLFSSL_CRYPTOCELL */
 

--- a/wolfssl/wolfcrypt/port/arm/cryptoCell.h
+++ b/wolfssl/wolfcrypt/port/arm/cryptoCell.h
@@ -78,7 +78,7 @@ extern "C" {
         CRYS_RSAUserPrivKey_t privKey;
         CRYS_RSAUserPubKey_t  pubKey;
     } rsa_context_t;
-CRYS_RSA_HASH_OpMode_t cc310_hashModeRSA(enum wc_HashType hash_type);
+CRYS_RSA_HASH_OpMode_t cc310_hashModeRSA(enum wc_HashType hash_type, int isHashed);
 #endif
 
 #ifdef HAVE_ECC


### PR DESCRIPTION
The PR makes RSA sign/verify Cryptocell improvements. 

cc310_RsaSSL_Sign() and cc310_RsaSSL_Verify() no longer defaults to performing SHA-256 with Cryptocell sign/verify.

It's now possible to perform RSA sign/verify of any message lengths provided it is one of the supported hash lengths by Cryptocell.

Workaround for Cryptocell feature:
When using WC_SIGNATURE_TYPE_RSA_W_ENC option, the digest of the original message with DER encoding will be hashed again using SHA-256 by the Cryptocell since Cryptocell requires the length of the input data to be one of the specific hash lengths and already be in hash format. 
