### PR TITLE
Nginx fix

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10151,7 +10151,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
                 #ifdef OPENSSL_EXTRA
                     /* Determine untrusted depth */
-                    if (!alreadySigner) {
+                    if (!alreadySigner && (!args->dCert ||
+                            !args->dCertInit || !args->dCert->selfSigned)) {
                         args->untrustedDepth = 1;
                     }
                 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -35453,7 +35453,8 @@ err:
     #define PEM_END_SZ             9
     #define PEM_HDR_FIN            "-----"
     #define PEM_HDR_FIN_SZ         5
-    #define PEM_HDR_FIN_EOL        "-----\n"
+    #define PEM_HDR_FIN_EOL_NEWLINE   "-----\n"
+    #define PEM_HDR_FIN_EOL_NULL_TERM "-----\0"
     #define PEM_HDR_FIN_EOL_SZ     6
 
     int wolfSSL_PEM_read_bio(WOLFSSL_BIO* bio, char **name, char **header,
@@ -35589,8 +35590,12 @@ err:
                 ret = WOLFSSL_FAILURE;
         }
         if (ret == WOLFSSL_SUCCESS) {
-            if (XSTRNCMP(pem + PEM_END_SZ + nameLen, PEM_HDR_FIN_EOL,
-                                                     PEM_HDR_FIN_EOL_SZ) != 0) {
+            if (XSTRNCMP(pem + PEM_END_SZ + nameLen,
+                    PEM_HDR_FIN_EOL_NEWLINE,
+                    PEM_HDR_FIN_EOL_SZ) != 0 &&
+                XSTRNCMP(pem + PEM_END_SZ + nameLen,
+                        PEM_HDR_FIN_EOL_NULL_TERM,
+                        PEM_HDR_FIN_EOL_SZ) != 0) {
                 ret = WOLFSSL_FAILURE;
             }
         }
@@ -35654,8 +35659,8 @@ err:
         if (!err)
             err = wolfSSL_BIO_write(bio, name, nameLen) != nameLen;
         if (!err) {
-            err = wolfSSL_BIO_write(bio, PEM_HDR_FIN_EOL, PEM_HDR_FIN_EOL_SZ) !=
-                                                        (int)PEM_HDR_FIN_EOL_SZ;
+            err = wolfSSL_BIO_write(bio, PEM_HDR_FIN_EOL_NEWLINE,
+                    PEM_HDR_FIN_EOL_SZ) != (int)PEM_HDR_FIN_EOL_SZ;
         }
         if (!err && headerLen > 0) {
             err = wolfSSL_BIO_write(bio, header, headerLen) != headerLen;
@@ -35672,8 +35677,8 @@ err:
         if (!err)
             err = wolfSSL_BIO_write(bio, name, nameLen) != nameLen;
         if (!err) {
-            err = wolfSSL_BIO_write(bio, PEM_HDR_FIN_EOL, PEM_HDR_FIN_EOL_SZ) !=
-                                                        (int)PEM_HDR_FIN_EOL_SZ;
+            err = wolfSSL_BIO_write(bio, PEM_HDR_FIN_EOL_NEWLINE,
+                    PEM_HDR_FIN_EOL_SZ) != (int)PEM_HDR_FIN_EOL_SZ;
         }
 
         if (!err) {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -16130,8 +16130,8 @@ int ParseCRL(DecodedCRL* dcrl, const byte* buff, word32 sz, void* cm)
     if (ParseCRL_CertList(dcrl, buff, &idx, idx + len) < 0)
         return ASN_PARSE_E;
 
-    if (ParseCRL_Extensions(dcrl, buff, &idx, idx + len) < 0)
-        return ASN_PARSE_E;
+    /* CRL Extensions optional, ignoring errors */
+    ParseCRL_Extensions(dcrl, buff, &idx, idx + len);
 
     idx = dcrl->sigIndex;
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -16030,14 +16030,17 @@ static int ParseCRL_Extensions(DecodedCRL* dcrl, const byte* buf,
 
     idx = *inOutIdx;
 
+    /* CRL Extensions are optional */
     if ((idx + 1) > sz)
-        return BUFFER_E;
+        return 0;
 
+    /* CRL Extensions are optional */
     if (GetASNTag(buf, &idx, &tag, sz) < 0)
-        return ASN_PARSE_E;
+        return 0;
 
+    /* CRL Extensions are optional */
     if (tag != (ASN_CONSTRUCTED | ASN_CONTEXT_SPECIFIC | 0))
-        return ASN_PARSE_E;
+        return 0;
 
     if (GetLength(buf, &idx, &length, sz) < 0)
         return ASN_PARSE_E;
@@ -16130,8 +16133,8 @@ int ParseCRL(DecodedCRL* dcrl, const byte* buff, word32 sz, void* cm)
     if (ParseCRL_CertList(dcrl, buff, &idx, idx + len) < 0)
         return ASN_PARSE_E;
 
-    /* CRL Extensions optional, ignoring errors */
-    ParseCRL_Extensions(dcrl, buff, &idx, idx + len);
+    if (ParseCRL_Extensions(dcrl, buff, &idx, idx + len) < 0)
+        return ASN_PARSE_E;
 
     idx = dcrl->sigIndex;
 


### PR DESCRIPTION
Cert verification depth of 0 should allow self signed certificates.
X509 CRL extensions are optional so a failure in their parsing should not cause a failure in overall CRL parsing. Maybe this should be done by checking the tag first instead?