### PR TITLE
Maintentance: DTLS

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11572,6 +11572,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         #endif
 
             #ifdef WOLFSSL_DTLS
+            if (ssl->options.serverState ==
+                    SERVER_HELLOVERIFYREQUEST_COMPLETE) {
                 if (IsDtlsNotSctpMode(ssl)) {
                     /* re-init hashes, exclude first hello and verify request */
                     if ((ssl->error = InitHandshakeHashes(ssl)) != 0) {
@@ -11583,6 +11585,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                         return WOLFSSL_FATAL_ERROR;
                     }
                 }
+            }
             #endif
 
             ssl->options.connectState = HELLO_AGAIN_REPLY;


### PR DESCRIPTION
Client wasn't skipping a handshake state when the server sends a hello without a hello verify. It ended up resetting the handshake hash and resending Hello with its next messages.