### PR TITLE
Fixes for NXP K64

### DIFF
--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -410,6 +410,7 @@ static int InitSha256(wc_Sha256* sha256)
         if (ret != 0) {
             return ret;
         }
+
     #ifdef FREESCALE_MMCAU_CLASSIC_SHA
         cau_sha256_initialize_output(sha256->digest);
     #else
@@ -420,6 +421,9 @@ static int InitSha256(wc_Sha256* sha256)
         sha256->buffLen = 0;
         sha256->loLen   = 0;
         sha256->hiLen   = 0;
+    #ifdef WOLFSSL_SMALL_STACK_CACHE
+        sha256->W = NULL;
+    #endif
 
         return ret;
     }

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -86,13 +86,13 @@ WOLFSSL_LOCAL int sp_ModExp_4096(mp_int* base, mp_int* exp, mp_int* mod,
 #endif
 
 
-
+#ifndef WOLFSSL_SP_MATH
 /* math settings check */
 word32 CheckRunTimeSettings(void)
 {
     return CTC_SETTINGS;
 }
-
+#endif
 
 /* math settings size check */
 word32 CheckRunTimeFastMath(void)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -620,6 +620,13 @@ initDefaultName();
         test_pass("asn      test passed!\n");
 #endif
 
+#ifndef WC_NO_RNG
+    if ( (ret = random_test()) != 0)
+        return err_sys("RANDOM   test failed!\n", ret);
+    else
+        test_pass("RANDOM   test passed!\n");
+#endif /* WC_NO_RNG */
+
 #ifndef NO_MD5
     if ( (ret = md5_test()) != 0)
         return err_sys("MD5      test failed!\n", ret);
@@ -900,13 +907,6 @@ initDefaultName();
     else
         test_pass("IDEA     test passed!\n");
 #endif
-
-#ifndef WC_NO_RNG
-    if ( (ret = random_test()) != 0)
-        return err_sys("RANDOM   test failed!\n", ret);
-    else
-        test_pass("RANDOM   test passed!\n");
-#endif /* WC_NO_RNG */
 
 #ifndef NO_RSA
     #ifdef WC_RSA_NO_PADDING


### PR DESCRIPTION
* Fix for K64 MMCAU with `WOLFSSL_SMALL_STACK_CACHE`.
* Fix to avoid duplicate symbol for `CheckRunTimeSettings` when SP and TFM are built. Specifically with these build options: `USE_FAST_MATH`, `WOLFSSL_SP` and `WOLFSSL_SP_MATH`.
* Moved random test prior to cipher tests (was getting called first time in GMAC test).