### PR TITLE
Remove redundant packing flag

### DIFF
--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -98,7 +98,8 @@ enum {
  * information associated with the SSL session.
  */
 
-#if defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__)
+#if (defined(__IAR_SYSTEMS_ICC__) && (__IAR_SYSTEMS_ICC__ > 8)) || \
+    defined(__GNUC__)
     #define WOLFSSL_PACK __attribute__ ((packed))
 #else
     #define WOLFSSL_PACK

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -98,14 +98,6 @@ enum {
  * information associated with the SSL session.
  */
 
-#if (defined(__IAR_SYSTEMS_ICC__) && (__IAR_SYSTEMS_ICC__ > 8)) || \
-    defined(__GNUC__)
-    #define WOLFSSL_PACK __attribute__ ((packed))
-#else
-    #define WOLFSSL_PACK
-#endif
-
-
 typedef struct SSLInfo
 {
     unsigned char  isValid;
@@ -118,7 +110,7 @@ typedef struct SSLInfo
             /* cipher name, e.g., "TLS_RSA_..." */
     unsigned char  serverNameIndication[128];
     unsigned int   keySize;
-} WOLFSSL_PACK SSLInfo;
+} SSLInfo;
 
 
 WOLFSSL_API


### PR DESCRIPTION
Reference: https://github.com/wolfSSL/wolfssl/blob/master/wolfssl/wolfcrypt/types.h#L880

Thanks to J.C. on ZD 9735 for the report.

Remove a redundant WOLFSSL_PACK attribute from one of the structures in the sniffer. It wasn't needed and didn't help. It was causing an issue in builds for at least one target.