### PR TITLE
Fixes for ECC sign with `WOLFSSL_ECDSA_SET_K`

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -218,9 +218,9 @@
     #include <wolfssl/wolfcrypt/blake2.h>
 #endif
 
+#include <wolfssl/wolfcrypt/hash.h>
 #ifndef NO_RSA
     #include <wolfssl/wolfcrypt/rsa.h>
-    #include <wolfssl/wolfcrypt/hash.h>
 
     #define FOURK_BUF 4096
     #define GEN_BUF  294

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -6672,6 +6672,23 @@ WOLFSSL_LOCAL word32 SetLength(word32 length, byte* output)
     return i;
 }
 
+WOLFSSL_LOCAL int SetMyVersion(word32 version, byte* output, int header)
+{
+    int i = 0;
+
+    if (output == NULL)
+        return BAD_FUNC_ARG;
+
+    if (header) {
+        output[i++] = ASN_CONTEXT_SPECIFIC | ASN_CONSTRUCTED;
+        output[i++] = 3;
+    }
+    output[i++] = ASN_INTEGER;
+    output[i++] = 0x01;
+    output[i++] = (byte)version;
+
+    return i;
+}
 
 WOLFSSL_LOCAL word32 SetSequence(word32 len, byte* output)
 {
@@ -9520,25 +9537,6 @@ void FreeTrustedPeerTable(TrustedPeerCert** table, int rows, void* heap)
     }
 }
 #endif /* WOLFSSL_TRUST_PEER_CERT */
-
-WOLFSSL_LOCAL int SetMyVersion(word32 version, byte* output, int header)
-{
-    int i = 0;
-
-    if (output == NULL)
-        return BAD_FUNC_ARG;
-
-    if (header) {
-        output[i++] = ASN_CONTEXT_SPECIFIC | ASN_CONSTRUCTED;
-        output[i++] = 3;
-    }
-    output[i++] = ASN_INTEGER;
-    output[i++] = 0x01;
-    output[i++] = (byte)version;
-
-    return i;
-}
-
 
 WOLFSSL_LOCAL int SetSerialNumber(const byte* sn, word32 snSz, byte* output,
     word32 outputSz, int maxSnSz)

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5118,9 +5118,15 @@ int wc_ecc_sign_set_k(const byte* k, word32 klen, ecc_key* key)
             if (key->sign_k == NULL) {
                 ret = MEMORY_E;
             }
+            else {
+                XMEMSET(key->sign_k, 0, sizeof(mp_int));
+            }
         }
     }
 
+    if (ret == 0) {
+        ret = mp_init(key->sign_k);
+    }
     if (ret == 0) {
         ret = mp_read_unsigned_bin(key->sign_k, k, klen);
     }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5118,9 +5118,6 @@ int wc_ecc_sign_set_k(const byte* k, word32 klen, ecc_key* key)
             if (key->sign_k == NULL) {
                 ret = MEMORY_E;
             }
-            else {
-                XMEMSET(key->sign_k, 0, sizeof(mp_int));
-            }
         }
     }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -17363,12 +17363,17 @@ done:
 static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     int curve_id, const ecc_set_type* dp)
 {
+#if defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)
     DECLARE_VAR(sharedA, byte, ECC_SHARED_SIZE, HEAP_HINT);
     DECLARE_VAR(sharedB, byte, ECC_SHARED_SIZE, HEAP_HINT);
+#endif
 #ifdef HAVE_ECC_KEY_EXPORT
     byte    exportBuf[MAX_ECC_BYTES * 2 + 32];
 #endif
-    word32  x, y;
+    word32  x;
+#if defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)
+    word32  y;
+#endif
 #ifdef HAVE_ECC_SIGN
     DECLARE_VAR(sig, byte, ECC_SIG_SIZE, HEAP_HINT);
     DECLARE_VAR(digest, byte, ECC_DIGEST_SIZE, HEAP_HINT);
@@ -17687,7 +17692,9 @@ done:
     wc_ecc_free(&userA);
 
     FREE_VAR(sharedA, HEAP_HINT);
+#if defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)
     FREE_VAR(sharedB, HEAP_HINT);
+#endif
 #ifdef HAVE_ECC_SIGN
     FREE_VAR(sig, HEAP_HINT);
     FREE_VAR(digest, HEAP_HINT);
@@ -18165,6 +18172,7 @@ done:
 }
 #endif
 
+#ifdef HAVE_ECC_DHE
 static int ecc_ssh_test(ecc_key* key)
 {
     int    ret;
@@ -18199,6 +18207,7 @@ static int ecc_ssh_test(ecc_key* key)
     TEST_SLEEP();
     return 0;
 }
+#endif /* HAVE_ECC_DHE */
 #endif
 
 static int ecc_def_curve_test(WC_RNG *rng)
@@ -18246,9 +18255,11 @@ static int ecc_def_curve_test(WC_RNG *rng)
     if (ret < 0)
         goto done;
 #endif
+#ifdef HAVE_ECC_DHE
     ret = ecc_ssh_test(&key);
     if (ret < 0)
         goto done;
+#endif
 #endif /* WOLFSSL_ATECC508A */
 done:
     wc_ecc_free(&key);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -17691,8 +17691,8 @@ done:
     wc_ecc_free(&userB);
     wc_ecc_free(&userA);
 
-    FREE_VAR(sharedA, HEAP_HINT);
 #if defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)
+    FREE_VAR(sharedA, HEAP_HINT);
     FREE_VAR(sharedB, HEAP_HINT);
 #endif
 #ifdef HAVE_ECC_SIGN

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -141,7 +141,9 @@ typedef struct WOLFSSL_EVP_CIPHER_CTX WOLFSSL_EVP_CIPHER_CTX;
 typedef struct WOLFSSL_EVP_MD_CTX {
     union {
         WOLFSSL_Hasher digest;
+    #ifndef NO_HMAC
         Hmac hmac;
+    #endif
     } hash;
     unsigned char macType;
     WOLFSSL_EVP_PKEY_CTX *pctx;


### PR DESCRIPTION
* Fixes for ECC sign with `WOLFSSL_ECDSA_SET_K` (added in PR #2581):
    1. Was not loading all curve params for the `wc_ecc_make_pub_ex` call.
    2. Not correctly setting `ALLOC_CURVE_SPECS` for `WOLFSSL_SMALL_STACK`.
* Fixes for building with ECC sign/verify only.
* Cleanup around the loading of curve specs.