### PR TITLE
Fix mem leak in DSA

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4622,6 +4622,7 @@ int DsaPrivateKeyDecode(const byte* input, word32* inOutIdx, DsaKey* key,
         GetInt(&key->g, input, inOutIdx, inSz) < 0 ||
         GetOctetString(input, inOutIdx, &length, inSz) < 0 ||
         GetInt(&key->y, input, inOutIdx, inSz) < 0) {
+            wc_FreeDsaKey(key);
             ret = ASN_PARSE_E;
     }
     if (ret == ASN_PARSE_E) {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4617,14 +4617,49 @@ int DsaPrivateKeyDecode(const byte* input, word32* inOutIdx, DsaKey* key,
 
     temp = (int)*inOutIdx;
 
-    if (GetInt(&key->p, input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->q, input, inOutIdx, inSz) < 0 ||
-        GetInt(&key->g, input, inOutIdx, inSz) < 0 ||
-        GetOctetString(input, inOutIdx, &length, inSz) < 0 ||
-        GetInt(&key->y, input, inOutIdx, inSz) < 0) {
-            wc_FreeDsaKey(key);
-            ret = ASN_PARSE_E;
+    /* Default case expects a certificate with OctetString but no version ID */
+    ret = GetInt(&key->p, input, inOutIdx, inSz);
+    if (ret < 0) {
+        mp_clear(&key->p);
+        ret = ASN_PARSE_E;
     }
+    else {
+        ret = GetInt(&key->q, input, inOutIdx, inSz);
+        if (ret < 0) {
+            mp_clear(&key->p);
+            mp_clear(&key->q);
+            ret = ASN_PARSE_E;
+        }
+        else {
+            ret = GetInt(&key->g, input, inOutIdx, inSz);
+            if (ret < 0) {
+                mp_clear(&key->p);
+                mp_clear(&key->q);
+                mp_clear(&key->g);
+                ret = ASN_PARSE_E;
+            }
+            else {
+                ret = GetOctetString(input, inOutIdx, &length, inSz);
+                if (ret < 0) {
+                    mp_clear(&key->p);
+                    mp_clear(&key->q);
+                    mp_clear(&key->g);
+                    ret = ASN_PARSE_E;
+                }
+                else {
+                    ret = GetInt(&key->y, input, inOutIdx, inSz);
+                    if (ret < 0) {
+                        mp_clear(&key->p);
+                        mp_clear(&key->q);
+                        mp_clear(&key->g);
+                        mp_clear(&key->y);
+                        ret = ASN_PARSE_E;
+                    }
+                }
+            }
+        }
+    }
+    /* An alternate pass if default certificate fails parsing */
     if (ret == ASN_PARSE_E) {
         *inOutIdx = temp;
         if (GetMyVersion(input, inOutIdx, &version, inSz) < 0)


### PR DESCRIPTION
This PR corrects a memory leak reported with the following configurations. 

./configure --disable-fastmath CC="gcc -fsanitize=address" --enable-debug --enable-static --disable-shared --enable-dsa && make && ./testsuite/testsuite.test