### PR TITLE
Fix cppcheck

### DIFF
--- a/IDE/GCC-ARM/Source/armtarget.c
+++ b/IDE/GCC-ARM/Source/armtarget.c
@@ -142,20 +142,20 @@ void HardFault_HandlerC( uint32_t *hardfault_args )
     _BFAR = (*((volatile uint32_t *)(0xE000ED38)));
 
     printf ("\n\nHard fault handler (all numbers in hex):\n");
-    printf ("R0 = %lx\n", (unsigned long)stacked_r0);
-    printf ("R1 = %lx\n", (unsigned long)stacked_r1);
-    printf ("R2 = %lx\n", (unsigned long)stacked_r2);
-    printf ("R3 = %lx\n", (unsigned long)stacked_r3);
-    printf ("R12 = %lx\n", (unsigned long)stacked_r12);
-    printf ("LR [R14] = %lx  subroutine call return address\n", (unsigned long)stacked_lr);
-    printf ("PC [R15] = %lx  program counter\n", (unsigned long)stacked_pc);
-    printf ("PSR = %lx\n", (unsigned long)stacked_psr);
-    printf ("CFSR = %lx\n", (unsigned long)_CFSR);
-    printf ("HFSR = %lx\n", (unsigned long)_HFSR);
-    printf ("DFSR = %lx\n", (unsigned long)_DFSR);
-    printf ("AFSR = %lx\n", (unsigned long)_AFSR);
-    printf ("MMAR = %lx\n", (unsigned long)_MMAR);
-    printf ("BFAR = %lx\n", (unsigned long)_BFAR);
+    printf ("R0 = %ux\n", stacked_r0);
+    printf ("R1 = %ux\n", stacked_r1);
+    printf ("R2 = %ux\n", stacked_r2);
+    printf ("R3 = %ux\n", stacked_r3);
+    printf ("R12 = %ux\n", stacked_r12);
+    printf ("LR [R14] = %ux  subroutine call return address\n", stacked_lr);
+    printf ("PC [R15] = %ux  program counter\n", stacked_pc);
+    printf ("PSR = %ux\n", stacked_psr);
+    printf ("CFSR = %ux\n", _CFSR);
+    printf ("HFSR = %ux\n", _HFSR);
+    printf ("DFSR = %ux\n", _DFSR);
+    printf ("AFSR = %ux\n", _AFSR);
+    printf ("MMAR = %ux\n", _MMAR);
+    printf ("BFAR = %ux\n", _BFAR);
 
     // Break into the debugger
     __asm("BKPT #0\n");

--- a/IDE/IAR-EWARM/Projects/benchmark/current_time.c
+++ b/IDE/IAR-EWARM/Projects/benchmark/current_time.c
@@ -64,10 +64,10 @@ double current_time(int reset)
 
 /* dummy */
 double current_time(int reset) {
-    static double t; 
+    static double t;
     t += 1.0; /* for avoid infinite loop of waiting time */
     if(reset)t = 0.0;
-    return t ; 
-} 
+    return t ;
+}
 
 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19379,7 +19379,8 @@ void wolfSSL_ACCESS_DESCRIPTION_free(WOLFSSL_ACCESS_DESCRIPTION* access)
         wolfSSL_ASN1_OBJECT_free(access->method);
     if (access->location)
         wolfSSL_GENERAL_NAME_free(access->location);
-    access = NULL;
+
+    /* access = NULL, don't try to access or double free it */
 }
 #endif
 
@@ -30144,6 +30145,8 @@ void wolfSSL_DSA_free(WOLFSSL_DSA* dsa)
         InitwolfSSL_DSA(dsa);  /* set back to NULLs for safety */
 
         XFREE(dsa, NULL, DYNAMIC_TYPE_DSA);
+
+        /* dsa = NULL, don't try to access or double free it */
     }
 }
 
@@ -33324,6 +33327,7 @@ void wolfSSL_EC_KEY_free(WOLFSSL_EC_KEY *key)
         InitwolfSSL_ECKey(key); /* set back to NULLs for safety */
 
         XFREE(key, NULL, DYNAMIC_TYPE_ECC);
+        /* key = NULL, don't try to access or double free it */
     }
 }
 #endif /* HAVE_ECC && (OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL) */
@@ -33608,6 +33612,7 @@ void wolfSSL_EC_GROUP_free(WOLFSSL_EC_GROUP *group)
     WOLFSSL_ENTER("wolfSSL_EC_GROUP_free");
 
     XFREE(group, NULL, DYNAMIC_TYPE_ECC);
+    /* group = NULL, don't try to access or double free it */
 }
 #endif
 
@@ -34124,6 +34129,7 @@ void wolfSSL_EC_POINT_free(WOLFSSL_EC_POINT *p)
         p->inSet = p->exSet = 0;
 
         XFREE(p, NULL, DYNAMIC_TYPE_ECC);
+        /* p = NULL, don't try to access or double free it */
     }
 }
 #endif
@@ -47190,6 +47196,7 @@ void wolfSSL_BN_free(WOLFSSL_BIGNUM* bn)
             bn->internal = NULL;
         }
         XFREE(bn, NULL, DYNAMIC_TYPE_BIGINT);
+        /* bn = NULL, don't try to access or double free it */
     }
 }
 
@@ -47263,6 +47270,8 @@ void wolfSSL_RSA_free(WOLFSSL_RSA* rsa)
         InitwolfSSL_Rsa(rsa);  /* set back to NULLs for safety */
 
         XFREE(rsa, NULL, DYNAMIC_TYPE_RSA);
+
+        /* rsa = NULL, don't try to access or double free it */
     }
 }
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -137,7 +137,7 @@ static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions);
                                 const byte *cr,const byte *sr,
                                 byte *ms/* out */);
     int tsip_generateSeesionKey(WOLFSSL *ssl);
-    int tsip_generateVerifyData(const byte *ms, const byte *side, 
+    int tsip_generateVerifyData(const byte *ms, const byte *side,
                                 const byte *handshake_hash,
                                 byte *hashes /* out */);
 #endif
@@ -1194,10 +1194,10 @@ int TLS_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz, int padSz,
     !defined(NO_WOLFSSL_RENESAS_TSIP_TLS_SESSION)
     if (tsip_useable(ssl)) {
         if (ssl->specs.hash_size == WC_SHA_DIGEST_SIZE)
-            ret = tsip_Sha1Hmac(ssl, myInner, WOLFSSL_TLS_HMAC_INNER_SZ, 
+            ret = tsip_Sha1Hmac(ssl, myInner, WOLFSSL_TLS_HMAC_INNER_SZ,
                                                         in, sz, digest, verify);
         else if (ssl->specs.hash_size == WC_SHA256_DIGEST_SIZE)
-            ret = tsip_Sha256Hmac(ssl, myInner, WOLFSSL_TLS_HMAC_INNER_SZ, 
+            ret = tsip_Sha256Hmac(ssl, myInner, WOLFSSL_TLS_HMAC_INNER_SZ,
                                                         in, sz, digest, verify);
         else
             ret = TSIP_MAC_DIGSZ_E;
@@ -5573,6 +5573,8 @@ int TLSX_UseQSHScheme(TLSX** extensions, word16 name, byte* pKey, word16 pkeySz,
     /* sanity check */
     if (extensions == NULL || (pKey == NULL && pkeySz != 0))
         return BAD_FUNC_ARG;
+
+    extension = TLSX_Find(*extensions, TLSX_QUANTUM_SAFE_HYBRID);
 
     /* if scheme is implemented than add */
     if (TLSX_HaveQSHScheme(name)) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -2175,6 +2175,9 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
     int ret, err = 0;
     int sharedCtx = 0;
 
+    if (args)
+        return -1;
+
 #ifdef WOLFSSL_TIRTOS
     fdOpenSession(Task_self());
 #endif
@@ -2396,6 +2399,9 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_loop(void* args)
     int sharedCtx = 0;
     int loop_count = ((func_args*)args)->argc;
     int count = 0;
+
+    if (args)
+        return -1;
 
 #ifdef WOLFSSL_TIRTOS
     fdOpenSession(Task_self());
@@ -2992,6 +2998,9 @@ static THREAD_RETURN WOLFSSL_THREAD run_wolfssl_server(void* args)
     char input[1024];
     int  idx;
     int  ret, err = 0;
+
+    if (args)
+        return -1;
 
 #ifdef WOLFSSL_TIRTOS
     fdOpenSession(Task_self());

--- a/tests/api.c
+++ b/tests/api.c
@@ -2175,9 +2175,6 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
     int ret, err = 0;
     int sharedCtx = 0;
 
-    if (args)
-        return -1;
-
 #ifdef WOLFSSL_TIRTOS
     fdOpenSession(Task_self());
 #endif
@@ -2261,7 +2258,7 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
 
 #ifdef WOLFSSL_SESSION_EXPORT
     /* only add in more complex nonblocking case with session export tests */
-    if (((func_args*)args)->argc > 0) {
+    if (args && ((func_args*)args)->argc > 0) {
         /* set as nonblock and time out for waiting on read/write */
         tcp_set_nonblocking(&clientfd);
         wolfSSL_dtls_set_using_nonblock(ssl, 1);
@@ -2399,9 +2396,6 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_loop(void* args)
     int sharedCtx = 0;
     int loop_count = ((func_args*)args)->argc;
     int count = 0;
-
-    if (args)
-        return -1;
 
 #ifdef WOLFSSL_TIRTOS
     fdOpenSession(Task_self());
@@ -2998,9 +2992,6 @@ static THREAD_RETURN WOLFSSL_THREAD run_wolfssl_server(void* args)
     char input[1024];
     int  idx;
     int  ret, err = 0;
-
-    if (args)
-        return -1;
 
 #ifdef WOLFSSL_TIRTOS
     fdOpenSession(Task_self());

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -10041,6 +10041,7 @@ int wc_EncryptedInfoParse(EncryptedInfo* info, char** pBuffer, size_t bufSz)
         newline = SkipEndOfLineChars(newline, bufferEnd);
 
         /* return new headerEnd */
+
         *pBuffer = newline;
     }
 

--- a/wolfcrypt/src/fe_operations.c
+++ b/wolfcrypt/src/fe_operations.c
@@ -134,16 +134,16 @@ int curve25519(byte* q, byte* n, byte* p)
 #if 0
   unsigned char e[32];
 #endif
-  fe x1;
-  fe x2;
-  fe z2;
-  fe x3;
-  fe z3;
-  fe tmp0;
-  fe tmp1;
-  int pos;
-  unsigned int swap;
-  unsigned int b;
+  fe x1 = {0};
+  fe x2 = {0};
+  fe z2 = {0};
+  fe x3 = {0};
+  fe z3 = {0};
+  fe tmp0 = {0};
+  fe tmp1 = {0};
+  int pos = 0;
+  unsigned int swap = 0;
+  unsigned int b = 0;
 
   /* Clamp already done during key generation and import */
 #if 0
@@ -645,11 +645,11 @@ void fe_frombytes(fe h,const unsigned char *s)
 
 void fe_invert(fe out,const fe z)
 {
-  fe t0;
-  fe t1;
-  fe t2;
-  fe t3;
-  int i;
+  fe t0 = {0};
+  fe t1 = {0};
+  fe t2 = {0};
+  fe t3 = {0};
+  int i = 0;
 
   /* pow225521 */
   fe_sq(t0,z); for (i = 1;i < 1;++i) fe_sq(t0,t0);
@@ -1263,10 +1263,10 @@ void fe_sq2(fe h,const fe f)
 
 void fe_pow22523(fe out,const fe z)
 {
-  fe t0;
-  fe t1;
-  fe t2;
-  int i;
+  fe t0 = {0};
+  fe t1 = {0};
+  fe t2 = {0};
+  int i = 0;
 
   fe_sq(t0,z); for (i = 1;i < 1;++i) fe_sq(t0,t0);
   fe_sq(t1,t0); for (i = 1;i < 2;++i) fe_sq(t1,t1);


### PR DESCRIPTION
This PR fixes errors and warnings found with cppcheck.

$ cd ~/wolfssl
$ cppcheck --force --enable=all . 2>&1 | tee cppcheck.enable-all.txt
$ grep error cppcheck.enable-all.txt
$ grep warning cppcheck.enable-all.txt

Fixes #2570