### PR TITLE
Fix for building wolfSSL with `NO_64BIT` on a 64-bit processor

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2430,6 +2430,13 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 
+/* SHA2-512/384 requires 64-bit (word64) */
+#if (defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)) && defined(NO_64BIT)
+    #undef WOLFSSL_SHA512
+    #undef WOLFSSL_SHA384
+#endif
+
+
 #ifdef __cplusplus
     }   /* extern "C" */
 #endif

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -176,7 +176,7 @@ decouple library dependencies with standard string, memory and so on.
 
 #else
         #undef WORD64_AVAILABLE
-        typedef word32 wolfssl_word;
+        typedef size_t wolfssl_word;
         #define MP_16BIT  /* for mp_int, mp_word needs to be twice as big as
                              mp_digit, no 64 bit type so make mp_digit 16 bit */
         #define WC_32BIT_CPU


### PR DESCRIPTION
Fix for uses of `wolfssl_word` casting to a pointer, which was causing warnings.

Reproduced using Ubuntu 18.4 with GCC 7.4.0:

```sh
./configure CFLAGS="-DNO_64BIT" --disable-sha512 --disable-sha384 && make

./wolfcrypt/src/misc.c:185:10: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
     if (((wolfssl_word)buf | (wolfssl_word)mask | count) % WOLFSSL_WORD_SIZE == 0)
          ^
./wolfcrypt/src/misc.c:185:30: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
     if (((wolfssl_word)buf | (wolfssl_word)mask | count) % WOLFSSL_WORD_SIZE == 0)
                              ^
  CC       wolfcrypt/src/src_libwolfssl_la-rsa.lo
```