### PR TITLE
Fix for evp.c included and FREERTOS realloc

### DIFF
--- a/certs/1024/include.am
+++ b/certs/1024/include.am
@@ -24,4 +24,3 @@ EXTRA_DIST += \
          certs/1024/rsa1024.der \
          certs/1024/server-cert.der \
          certs/1024/server-key.der
-

--- a/certs/3072/include.am
+++ b/certs/3072/include.am
@@ -5,6 +5,6 @@
 EXTRA_DIST += \
          certs/3072/client-cert.der \
          certs/3072/client-cert.pem \
-		 certs/3072/client-key.der \
+         certs/3072/client-key.der \
          certs/3072/client-key.pem \
-		 certs/3072/client-keyPub.der
+         certs/3072/client-keyPub.der

--- a/certs/4096/include.am
+++ b/certs/4096/include.am
@@ -5,5 +5,3 @@
 EXTRA_DIST += \
          certs/4096/client-cert.pem \
          certs/4096/client-key.pem
-
-

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -2086,7 +2086,6 @@ int wolfSSL_EVP_read_pw_string(char* buf, int bufSz, const char* banner, int v)
     return 0;
 }
 #endif /* WOLFSSL_APACHE_HTTPD */
-#endif /* WOLFSSL_EVP_INCLUDED */
 
 #if defined(OPENSSL_EXTRA) && !defined(NO_PWDBASED) && !defined(NO_SHA)
 int wolfSSL_PKCS5_PBKDF2_HMAC_SHA1(const char *pass, int passlen,
@@ -2139,3 +2138,5 @@ WOLFSSL_API int wolfSSL_PKCS5_PBKDF2_HMAC(const char *pass, int passlen,
         return WOLFSSL_FAILURE;
 }
 #endif /* OPENSSL_EXTRA && !NO_PWDBASED */
+
+#endif /* WOLFSSL_EVP_INCLUDED */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -682,14 +682,15 @@ extern void uITRON4_free(void *p) ;
 #ifdef FREERTOS
     #include "FreeRTOS.h"
 
-    /* FreeRTOS pvPortRealloc() only in AVR32_UC3 port */
     #if !defined(XMALLOC_USER) && !defined(NO_WOLFSSL_MEMORY) && \
         !defined(WOLFSSL_STATIC_MEMORY)
         #define XMALLOC(s, h, type)  pvPortMalloc((s))
         #define XFREE(p, h, type)    vPortFree((p))
     #endif
-    #if defined(HAVE_ED25519) || defined(WOLFSSL_ESPIDF)
-        #define XREALLOC(p, n, h, t) wolfSSL_Realloc((p), (n))
+    /* FreeRTOS pvPortRealloc() implementation can be found here:
+        https://github.com/wolfSSL/wolfssl-freertos/pull/3/files */
+    #if !defined(USE_FAST_MATH) || defined(HAVE_ED25519) || defined(WOLFSSL_ESPIDF)
+        #define XREALLOC(p, n, h, t) pvPortRealloc((p), (n))
     #endif
     #ifndef NO_WRITEV
         #define NO_WRITEV
@@ -865,6 +866,8 @@ extern void uITRON4_free(void *p) ;
         #define XMALLOC(s, h, type)  pvPortMalloc((s))
         #define XFREE(p, h, type)    vPortFree((p))
     #endif
+    /* FreeRTOS pvPortRealloc() implementation can be found here:
+        https://github.com/wolfSSL/wolfssl-freertos/pull/3/files */
     #if !defined(USE_FAST_MATH) || defined(HAVE_ED25519)
         #define XREALLOC(p, n, h, t) pvPortRealloc((p), (n))
     #endif


### PR DESCRIPTION
* Fix for `FREERTOS` to expose XREALLOC for normal math.
* Fix for evp.c when being included directly due to improperly placed WOLFSSL_EVP_INCLUDED.
ZD 9749