### PR TITLE
add Android debug for logcat

### DIFF
--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -218,6 +218,8 @@ void WOLFSSL_TIME(int count)
 #elif defined(WOLFSSL_TELIT_M2MB)
     #include <stdio.h>
     #include "m2m_log.h"
+#elif defined(WOLFSSL_ANDROID_DEBUG)
+    #include <android/log.h>
 #else
     #include <stdio.h>   /* for default printf stuff */
 #endif
@@ -260,6 +262,8 @@ static void wolfssl_log(const int logLevel, const char *const logMessage)
         printk("%s\n", logMessage);
 #elif defined(WOLFSSL_TELIT_M2MB)
         M2M_LOG_INFO("%s\n", logMessage);
+#elif defined(WOLFSSL_ANDROID_DEBUG)
+        __android_log_print(ANDROID_LOG_VERBOSE, "[wolfSSL]", "%s", logMessage);
 #else
         fprintf(stderr, "%s\n", logMessage);
 #endif


### PR DESCRIPTION
This PR adds a new WOLFSSL_ANDROID_DEBUG section in wolfSSL's logging function (wolfssl_log) allowing debug messages to print to Android logcat.