### PR TITLE
Adds options to disable the hash wrappers and base64 decode

### DIFF
--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -42,6 +42,8 @@ enum {
 };
 
 
+#ifdef WOLFSSL_BASE64_DECODE
+
 static
 const byte base64Decode[] = { 62, BAD, BAD, BAD, 63,   /* + starts at 0x2B */
                               52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
@@ -144,6 +146,7 @@ int Base64_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
     return 0;
 }
 
+#endif /* WOLFSSL_BASE64_DECODE */
 
 #if defined(WOLFSSL_BASE64_ENCODE)
 

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -58,6 +58,7 @@ enum Hash_Sum  {
 };
 #endif /* !NO_ASN */
 
+#if !defined(NO_PWDBASED) || !defined(NO_ASN)
 /* function converts int hash type to enum */
 enum wc_HashType wc_HashTypeConvert(int hashType)
 {
@@ -126,6 +127,7 @@ enum wc_HashType wc_HashTypeConvert(int hashType)
 #endif
     return eHashType;
 }
+#endif /* !NO_PWDBASED || !NO_ASN */
 
 #if !defined(NO_ASN) || !defined(NO_DH) || defined(HAVE_ECC)
 
@@ -264,7 +266,7 @@ enum wc_HashType wc_OidGetHash(int oid)
 }
 #endif /* !NO_ASN || !NO_DH || HAVE_ECC */
 
-
+#ifndef NO_HASH_WRAPPER
 
 /* Get Hash digest size */
 int wc_HashGetDigestSize(enum wc_HashType hash_type)
@@ -1361,6 +1363,8 @@ int wc_HashGetFlags(wc_HashAlg* hash, enum wc_HashType type, word32* flags)
     }
 #endif /* !WOLFSSL_NOSHA3_512 */
 #endif /* WOLFSSL_SHA3 */
+
+#endif /* !NO_HASH_WRAPPER */
 
 #ifdef WOLFSSL_HAVE_PRF
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2101,6 +2101,11 @@ extern void uITRON4_free(void *p) ;
     #error TLS 1.3 requires the Signature Algorithms extension to be enabled
 #endif
 
+#ifndef NO_WOLFSSL_BASE64_DECODE
+    #define WOLFSSL_BASE64_DECODE
+#endif
+
+
 #ifdef __cplusplus
     }   /* extern "C" */
 #endif


### PR DESCRIPTION
Adds options to disable the hash wrappers (`NO_HASH_WRAPPER`) and base64 decode (`NO_WOLFSSL_BASE64_DECODE`).

Helps with code size reductions.