### PR TITLE
Fixes for asynchronous crypto issues

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -31765,7 +31765,7 @@ int wolfSSL_EVP_PKEY_set1_DH(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_DH *key)
 
     if (ret <= 0) {
         WOLFSSL_MSG("Failed to export DH Key");
-        XFREE(derBuf, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(derBuf, pkey->heap, DYNAMIC_TYPE_TMP_BUFFER);
         return WOLFSSL_FAILURE;
     }
 
@@ -45047,6 +45047,7 @@ WOLFSSL_BIGNUM *wolfSSL_ASN1_INTEGER_to_BN(const WOLFSSL_ASN1_INTEGER *ai,
     ret = GetInt(&mpi, ai->data, &idx, ai->dataMax);
     if (ret != 0) {
     #ifdef WOLFSSL_QT
+        mp_init(&mpi); /* must init mpi */
         /* Serial number in QT starts at index 0 of data */
         if (mp_read_unsigned_bin(&mpi, (byte*)ai->data, ai->length) != 0) {
                 mp_clear(&mpi);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4858,8 +4858,10 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 #else
    #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_ECC) && \
       (defined(HAVE_CAVIUM_V) || defined(HAVE_INTEL_QA))
-   if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_ECC)
+   if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_ECC) {
       ALLOC_CURVE_SPECS(ECC_CURVE_FIELD_COUNT);
+      err = wc_ecc_curve_load(key->dp, &curve, ECC_CURVE_FIELD_ALL);
+   }
    else
    #endif
    {


### PR DESCRIPTION
wolfCrypt fixes for asynchronous (--enable-asynccrypt):
* Fix for ECC and using NULL curve->order (wasn't loaded).
* Fix for QT case where GetInt failure retry did not "init" the mp_int.
* Fix for typo on heap.