### PR TITLE
VxWorks Strings

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -458,6 +458,7 @@
     #define NO_MAIN_DRIVER
     #define NO_DEV_RANDOM
     #define NO_WRITEV
+    #define HAVE_STRINGS_H
 #endif
 
 


### PR DESCRIPTION
When building for VxWorks, set HAVE_STRINGS_H as it uses strings.h, not string.h.