### PR TITLE
Renesas RA Crypto Hardware Acceleration

### DIFF
--- a/IDE/Renesas/e2studio/DK-S7G2/user_settings.h
+++ b/IDE/Renesas/e2studio/DK-S7G2/user_settings.h
@@ -2,6 +2,8 @@
 #ifndef USER_SETTINGS_H
 #define USER_SETTINGS_H
 
+#define WOLFSSL_RENESAS_S7G2
+
 //#define DEBUG_WOLFSSL
 
 #define NO_MAIN_DRIVER

--- a/IDE/Renesas/e2studio/RA6M3G/benchmark-wolfcrypt/.cproject
+++ b/IDE/Renesas/e2studio/RA6M3G/benchmark-wolfcrypt/.cproject
@@ -97,7 +97,6 @@
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs.2089894925" name="Defined symbols (-D)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs" useByScannerDiscovery="true" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="_RENESAS_RA_"/>
 									<listOptionValue builtIn="false" value="WOLFSSL_USER_SETTINGS"/>
-									<listOptionValue builtIn="false" value="WOLFSSL_RENESAS_RA6M3G"/>
 									<listOptionValue builtIn="false" value="USE_CERT_BUFFERS_1024"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.1135574874" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input"/>

--- a/IDE/Renesas/e2studio/RA6M3G/benchmark-wolfcrypt/src/wolfssl_thread_entry.c
+++ b/IDE/Renesas/e2studio/RA6M3G/benchmark-wolfcrypt/src/wolfssl_thread_entry.c
@@ -19,12 +19,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 #include <wolfssl/wolfcrypt/settings.h>
-#include "wolfcrypt/benchmark/benchmark.h"
-#include "common/util.h"
+#include <wolfcrypt/benchmark/benchmark.h>
 
 void wolfssl_thread_entry(void *pvParameters) {
     FSP_PARAMETER_NOT_USED(pvParameters);
     initialise_monitor_handles();
     benchmark_test(0);
-    while (1);
+    while (1)
+        ;
 }

--- a/IDE/Renesas/e2studio/RA6M3G/common/user_settings.h
+++ b/IDE/Renesas/e2studio/RA6M3G/common/user_settings.h
@@ -21,21 +21,26 @@
 #ifndef USER_SETTINGS_H_
 #define USER_SETTINGS_H_
 
+/* Hardware Acceleration:  Renesas Secure Cryptography Engine (SCE) */
+#define WOLFSSL_SCE
+
 /* Temporary defines. Not suitable for production. */
-#define WOLFSSL_GENSEED_FORTEST /* Warning: define your own seed gen */
+#ifndef WOLFSSL_SCE
+    #define WOLFSSL_GENSEED_FORTEST /* Warning: define your own seed gen */
+    #define NO_DEV_RANDOM
+#endif
 /* End temporary defines */
 
 /* Operating Environment and Threading */
 #define FREERTOS
 #define FREERTOS_TCP
-#define NO_DEV_RANDOM
 #define NO_WRITEV
 #define NO_MAIN_DRIVER
 #define BENCH_EMBEDDED
 
 /* Filesystem and IO */
-#define NO_WOLFSSL_DIR
 #define WOLFSSL_NO_CURRDIR
+#define NO_WOLFSSL_DIR
 #define NO_FILESYSTEM
 
 /* Cryptography Enable Options */
@@ -51,17 +56,7 @@
 #define HAVE_ALPN
 #define HAVE_SNI
 #define HAVE_OCSP
-#define HAVE_AESGCM
 #define HAVE_ONE_TIME_AUTH
-
-/* Non-Fast Math may call realloc. This project has no realloc support */
-#define USE_FAST_MATH
-#define ALT_ECC_SIZE
-#define TFM_TIMING_RESISTANT
-#define ECC_TIMING_RESISTANT
-#define WC_RSA_BLINDING
-#define WOLFSSL_SMALL_STACK
-#define WOLFSSL_DH_CONST
 
 /* Cryptography Disable options */
 #define NO_PWDBASED
@@ -70,6 +65,40 @@
 #define NO_RABBIT
 #define NO_RC4
 #define NO_MD4
+
+/* AES */
+#define WOLFSSL_AES_DIRECT
+#define HAVE_AES_DECRYPT
+/* Cipher Modes */
+#define HAVE_AESGCM
+#define HAVE_AES_ECB
+#define WOLFSSL_AES_COUNTER
+#define WOLFSSL_AES_XTS
+/* No AES 192 hardware support */
+#ifdef WOLFSSL_SCE
+    #define NO_AES_192
+    #ifdef WOLFSSL_AES_192
+        #undef WOLFSSL_AES_192
+    #endif
+#endif
+
+/* wolfSSL/wolfCrypt Software Optimizations */
+#define WOLFSSL_HAVE_SP_RSA
+#define WOLFSSL_HAVE_SP_ECC
+#define WOLFSSL_SP_ARM_CORTEX_M_ASM
+
+/* Non-Fast Math may call realloc.
+ * This project uses Amazon FreeRTOS and has no realloc support
+ */
+#define USE_FAST_MATH
+#define ALT_ECC_SIZE
+#define WOLFSSL_SMALL_STACK
+#define WOLFSSL_DH_CONST
+
+/* Hardening */
+#define TFM_TIMING_RESISTANT
+#define ECC_TIMING_RESISTANT
+#define WC_RSA_BLINDING
 
 void wolfssl_thread_entry(void *pvParameters);
 extern void initialise_monitor_handles(void);

--- a/IDE/Renesas/e2studio/RA6M3G/test-wolfcrypt/.cproject
+++ b/IDE/Renesas/e2studio/RA6M3G/test-wolfcrypt/.cproject
@@ -91,11 +91,12 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M3G/ra_cfg/aws}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M3G/ra_cfg/fsp_cfg/bsp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M3G/ra_cfg/fsp_cfg/driver}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M3G/ra/fsp/src/r_sce}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M3G/ra/fsp/src/r_sce/common}&quot;"/>
 								</option>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs.1484906637" name="Defined symbols (-D)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.defs" useByScannerDiscovery="true" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="_RENESAS_RA_"/>
 									<listOptionValue builtIn="false" value="WOLFSSL_USER_SETTINGS"/>
-									<listOptionValue builtIn="false" value="WOLFSSL_RENESAS_RA6M3G"/>
 									<listOptionValue builtIn="false" value="USE_CERT_BUFFERS_1024"/>
 									<listOptionValue builtIn="false" value="USE_CERT_BUFFERS_256"/>
 								</option>
@@ -140,6 +141,9 @@
 							</tool>
 						</toolChain>
 					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+					</sourceEntries>
 				</configuration>
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
@@ -282,6 +286,9 @@
 							</tool>
 						</toolChain>
 					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+					</sourceEntries>
 				</configuration>
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>

--- a/IDE/Renesas/e2studio/RA6M3G/test-wolfcrypt/src/wolfssl_thread_entry.c
+++ b/IDE/Renesas/e2studio/RA6M3G/test-wolfcrypt/src/wolfssl_thread_entry.c
@@ -18,15 +18,15 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
-
 #include <wolfssl/wolfcrypt/settings.h>
-#include "wolfcrypt/test/test.h"
+#include <wolfcrypt/test/test.h>
 
 void wolfssl_thread_entry(void* pvParameters)
 {
     FSP_PARAMETER_NOT_USED (pvParameters);
-    /* Benchmark output is displayed to Renesas Debug Virtual Console */
     initialise_monitor_handles();
+    wolfCrypt_Init();
     wolfcrypt_test(0);
-    while(1);
+    while(1)
+        ;
 }

--- a/IDE/Renesas/e2studio/RA6M3G/wolfssl/.cproject
+++ b/IDE/Renesas/e2studio/RA6M3G/wolfssl/.cproject
@@ -80,6 +80,8 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/fsp/src/rm_freertos_plus_tcp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/aws/amazon-freertos/libraries/freertos_plus/standard/freertos_plus_tcp/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra_cfg/fsp_cfg/driver}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/fsp/src/r_sce/common}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/fsp/src/r_sce}&quot;"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input.1944945543" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input"/>
 							</tool>
@@ -108,6 +110,8 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/fsp/src/rm_freertos_plus_tcp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra_cfg/fsp_cfg/driver}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/wolfSSL_RA6M3G/ra/aws/amazon-freertos/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/fsp/src/r_sce/common}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/fsp/src/r_sce}&quot;"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.1304089417" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input"/>
 							</tool>
@@ -147,9 +151,7 @@
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>
-						<entry excluding="common|wolfcrypt|src|src/crl.c|src/bio.c|ra|ra_gen" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="ra"/>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="ra_gen"/>
+						<entry excluding="common|wolfcrypt|src|src/crl.c|src/bio.c" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
 						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="src"/>
 						<entry excluding="sp_x86_64_asm.S|sha512_asm.S|sha256_asm.S|poly1305_asm.S|fe_x25519_asm.S|chacha_asm.S|aes_gcm_asm.S|aes_asm.asm|aes_asm.S" flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name="wolfcrypt"/>
 					</sourceEntries>
@@ -238,6 +240,8 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/fsp/src/rm_freertos_plus_tcp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/aws/amazon-freertos/libraries/freertos_plus/standard/freertos_plus_tcp/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra_cfg/fsp_cfg/driver}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/fsp/src/r_sce/common}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/fsp/src/r_sce}&quot;"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input.1333795089" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input"/>
 							</tool>
@@ -267,6 +271,8 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/fsp/src/rm_freertos_plus_tcp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/aws/amazon-freertos/libraries/freertos_plus/standard/freertos_plus_tcp/include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra_cfg/fsp_cfg/driver}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/fsp/src/r_sce/common}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/ra/fsp/src/r_sce}&quot;"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.179918099" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input"/>
 							</tool>

--- a/IDE/Renesas/e2studio/RA6M3G/wolfssl/.project
+++ b/IDE/Renesas/e2studio/RA6M3G/wolfssl/.project
@@ -446,6 +446,11 @@
 			<locationURI>PARENT-5-PROJECT_LOC/wolfcrypt/src/port/Renesas/README.md</locationURI>
 		</link>
 		<link>
+			<name>wolfcrypt/port/Renesas/renesas_sce_ra6m3g.c</name>
+			<type>1</type>
+			<locationURI>PARENT-5-PROJECT_LOC/wolfcrypt/src/port/Renesas/renesas_sce_ra6m3g.c</locationURI>
+		</link>
+		<link>
 			<name>wolfcrypt/port/Renesas/renesas_tsip_aes.c</name>
 			<type>1</type>
 			<locationURI>PARENT-5-PROJECT_LOC/wolfcrypt/src/port/Renesas/renesas_tsip_aes.c</locationURI>

--- a/IDE/Renesas/e2studio/RA6M3G/wolfssl/configuration.xml
+++ b/IDE/Renesas/e2studio/RA6M3G/wolfssl/configuration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<raConfiguration version="4">
+<raConfiguration version="5">
   <generalSettings>
     <option key="#Board#" value="board.ra6m3gek"/>
     <option key="CPU" value="RA6M3"/>
@@ -63,7 +63,7 @@
       <property id="config.bsp.fsp.mcu.adc.max_freq_hz" value="60000000"/>
     </config>
     <config id="config.bsp.ra">
-      <property id="config.bsp.common.main" value="0x400"/>
+      <property id="config.bsp.common.main" value="0x4000"/>
       <property id="config.bsp.common.heap" value="4000"/>
       <property id="config.bsp.common.vcc" value="3300"/>
       <property id="config.bsp.common.checking" value="config.bsp.common.checking.disabled"/>
@@ -178,7 +178,12 @@
       <description>Amazon FreeRTOS - Buffer Allocation 2</description>
       <originalPack>Amazon.AWS.0.8.0.pack</originalPack>
     </component>
+    <component apiversion="" class="HAL Drivers" condition="" group="all" subgroup="r_sce_ra6" variant="" vendor="Renesas" version="0.8.0">
+      <description>Secure Cryptography Engine on RA6</description>
+      <originalPack>Renesas.RA.0.8.0.pack</originalPack>
+    </component>
   </raComponentSelection>
+  <raElcConfiguration/>
   <raIcuConfiguration/>
   <raModuleConfiguration>
     <module id="module.driver.ioport_on_ioport.0">

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -2037,7 +2037,7 @@ void bench_rng(void)
         count += i;
     } while (bench_stats_sym_check(start));
 exit_rng:
-    bench_stats_sym_finish("RNG", 0, count, bench_size, start, ret);
+    bench_stats_sym_finish("RNG", 0, count, (int)bench_size, start, ret);
 
     wc_FreeRng(&myrng);
 }
@@ -2092,7 +2092,7 @@ static void bench_aescbc_internal(int doAsync, const byte* key, word32 keySz,
         count += times;
     } while (bench_stats_sym_check(start));
 exit_aes_enc:
-    bench_stats_sym_finish(encLabel, doAsync, count, bench_size, start, ret);
+    bench_stats_sym_finish(encLabel, doAsync, count, (int)bench_size, start, ret);
 
     if (ret < 0) {
         goto exit;
@@ -2127,7 +2127,7 @@ exit_aes_enc:
         count += times;
     } while (bench_stats_sym_check(start));
 exit_aes_dec:
-    bench_stats_sym_finish(decLabel, doAsync, count, bench_size, start, ret);
+    bench_stats_sym_finish(decLabel, doAsync, count, (int)bench_size, start, ret);
 
 #endif /* HAVE_AES_DECRYPT */
 
@@ -2223,7 +2223,7 @@ static void bench_aesgcm_internal(int doAsync, const byte* key, word32 keySz,
         count += times;
     } while (bench_stats_sym_check(start));
 exit_aes_gcm:
-    bench_stats_sym_finish(encLabel, doAsync, count, bench_size, start, ret);
+    bench_stats_sym_finish(encLabel, doAsync, count, (int)bench_size, start, ret);
 
 #ifdef HAVE_AES_DECRYPT
     /* init keys */
@@ -2262,7 +2262,7 @@ exit_aes_gcm:
         count += times;
     } while (bench_stats_sym_check(start));
 exit_aes_gcm_dec:
-    bench_stats_sym_finish(decLabel, doAsync, count, bench_size, start, ret);
+    bench_stats_sym_finish(decLabel, doAsync, count, (int)bench_size, start, ret);
 #endif /* HAVE_AES_DECRYPT */
 
     (void)decLabel;
@@ -2490,7 +2490,7 @@ void bench_aesxts(void)
         }
         count += i;
     } while (bench_stats_sym_check(start));
-    bench_stats_sym_finish("AES-XTS-enc", 0, count, bench_size, start, ret);
+    bench_stats_sym_finish("AES-XTS-enc", 0, count, (int)bench_size, start, ret);
     wc_AesXtsFree(&aes);
 
     /* decryption benchmark */
@@ -2512,7 +2512,7 @@ void bench_aesxts(void)
         }
         count += i;
     } while (bench_stats_sym_check(start));
-    bench_stats_sym_finish("AES-XTS-dec", 0, count, bench_size, start, ret);
+    bench_stats_sym_finish("AES-XTS-dec", 0, count, (int)bench_size, start, ret);
     wc_AesXtsFree(&aes);
 }
 #endif /* WOLFSSL_AES_XTS */
@@ -2538,7 +2538,7 @@ static void bench_aesctr_internal(const byte* key, word32 keySz, const byte* iv,
         }
         count += i;
     } while (bench_stats_sym_check(start));
-    bench_stats_sym_finish(label, 0, count, bench_size, start, ret);
+    bench_stats_sym_finish(label, 0, count, (int)bench_size, start, ret);
 }
 
 void bench_aesctr(void)
@@ -2631,7 +2631,7 @@ void bench_poly1305(void)
             wc_Poly1305Final(&enc, mac);
             count += i;
         } while (bench_stats_sym_check(start));
-        bench_stats_sym_finish("POLY1305", 0, count, bench_size, start, ret);
+        bench_stats_sym_finish("POLY1305", 0, count, (int)bench_size, start, ret);
     }
     else {
         bench_stats_start(&count, &start);
@@ -2651,7 +2651,7 @@ void bench_poly1305(void)
             }
             count += i;
         } while (bench_stats_sym_check(start));
-        bench_stats_sym_finish("POLY1305", 0, count, bench_size, start, ret);
+        bench_stats_sym_finish("POLY1305", 0, count, (int)bench_size, start, ret);
     }
 }
 #endif /* HAVE_POLY1305 */
@@ -2882,7 +2882,7 @@ void bench_chacha(void)
         }
         count += i;
     } while (bench_stats_sym_check(start));
-    bench_stats_sym_finish("CHACHA", 0, count, bench_size, start, 0);
+    bench_stats_sym_finish("CHACHA", 0, count, (int)bench_size, start, 0);
 }
 #endif /* HAVE_CHACHA*/
 
@@ -2907,7 +2907,7 @@ void bench_chacha20_poly1305_aead(void)
         }
         count += i;
     } while (bench_stats_sym_check(start));
-    bench_stats_sym_finish("CHA-POLY", 0, count, bench_size, start, ret);
+    bench_stats_sym_finish("CHA-POLY", 0, count, (int)bench_size, start, ret);
 }
 #endif /* HAVE_CHACHA && HAVE_POLY1305 */
 
@@ -2984,7 +2984,7 @@ void bench_md5(int doAsync)
         } while (bench_stats_sym_check(start));
     }
 exit_md5:
-    bench_stats_sym_finish("MD5", doAsync, count, bench_size, start, ret);
+    bench_stats_sym_finish("MD5", doAsync, count, (int)bench_size, start, ret);
 
 exit:
 
@@ -3071,7 +3071,7 @@ void bench_sha(int doAsync)
         } while (bench_stats_sym_check(start));
     }
 exit_sha:
-    bench_stats_sym_finish("SHA", doAsync, count, bench_size, start, ret);
+    bench_stats_sym_finish("SHA", doAsync, count, (int)bench_size, start, ret);
 
 exit:
 
@@ -3235,7 +3235,7 @@ void bench_sha256(int doAsync)
         } while (bench_stats_sym_check(start));
     }
 exit_sha256:
-    bench_stats_sym_finish("SHA-256", doAsync, count, bench_size, start, ret);
+    bench_stats_sym_finish("SHA-256", doAsync, count, (int)bench_size, start, ret);
 
 exit:
 
@@ -3992,10 +3992,10 @@ static void bench_hmac(int doAsync, int type, int digestSz,
 #ifdef WOLFSSL_ASYNC_CRYPT
     DECLARE_ARRAY(digest, byte, BENCH_MAX_PENDING, WC_MAX_DIGEST_SIZE, HEAP_HINT);
 #else
-	byte digest[BENCH_MAX_PENDING][WC_MAX_DIGEST_SIZE];
+    byte digest[BENCH_MAX_PENDING][WC_MAX_DIGEST_SIZE];
 #endif
 
-	(void)digestSz;
+    (void)digestSz;
 
     /* clear for done cleanup */
     XMEMSET(hmac, 0, sizeof(hmac));
@@ -4052,7 +4052,7 @@ static void bench_hmac(int doAsync, int type, int digestSz,
         } while (pending > 0);
     } while (bench_stats_sym_check(start));
 exit_hmac:
-    bench_stats_sym_finish(label, doAsync, count, bench_size, start, ret);
+    bench_stats_sym_finish(label, doAsync, count, (int)bench_size, start, ret);
 
 exit:
 
@@ -4395,10 +4395,10 @@ static void bench_rsa_helper(int doAsync, RsaKey rsaKey[BENCH_MAX_PENDING],
         byte* out[BENCH_MAX_PENDING];
     #endif
 
-    DECLARE_ARRAY_DYNAMIC_EXE(enc, byte, BENCH_MAX_PENDING, rsaKeySz, HEAP_HINT);
+    DECLARE_ARRAY_DYNAMIC_EXE(enc, byte, BENCH_MAX_PENDING, (word32)rsaKeySz, HEAP_HINT);
     #if !defined(WOLFSSL_RSA_VERIFY_INLINE) && \
                     !defined(WOLFSSL_RSA_PUBLIC_ONLY)
-        DECLARE_ARRAY_DYNAMIC_EXE(out, byte, BENCH_MAX_PENDING, rsaKeySz, HEAP_HINT);
+        DECLARE_ARRAY_DYNAMIC_EXE(out, byte, BENCH_MAX_PENDING, (word32)rsaKeySz, HEAP_HINT);
     #endif
 
     if (!rsa_sign_verify) {
@@ -4414,7 +4414,7 @@ static void bench_rsa_helper(int doAsync, RsaKey rsaKey[BENCH_MAX_PENDING],
                     if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                  1, &times, ntimes, &pending)) {
                         ret = wc_RsaPublicEncrypt(message, (word32)len, enc[i],
-                                                  rsaKeySz/8, &rsaKey[i],
+                                                  (word32)rsaKeySz/8, &rsaKey[i],
                                                   &rng);
                         if (!bench_async_handle(&ret, BENCH_ASYNC_GET_DEV(
                                             &rsaKey[i]), 1, &times, &pending)) {
@@ -4449,7 +4449,7 @@ exit_rsa_pub:
                     if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                  1, &times, ntimes, &pending)) {
                         ret = wc_RsaPrivateDecrypt(enc[i], idx, out[i],
-                                                       rsaKeySz/8, &rsaKey[i]);
+                                                  (word32)rsaKeySz/8, &rsaKey[i]);
                         if (!bench_async_handle(&ret,
                                                 BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                 1, &times, &pending)) {
@@ -4477,8 +4477,8 @@ exit:
                 for (i = 0; i < BENCH_MAX_PENDING; i++) {
                     if (bench_async_check(&ret, BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                  1, &times, ntimes, &pending)) {
-                        ret = wc_RsaSSL_Sign(message, len, enc[i],
-                                                rsaKeySz/8, &rsaKey[i], &rng);
+                        ret = wc_RsaSSL_Sign(message, (word32)len, enc[i],
+                                            (word32)rsaKeySz/8, &rsaKey[i], &rng);
                         if (!bench_async_handle(&ret,
                                                 BENCH_ASYNC_GET_DEV(&rsaKey[i]),
                                                 1, &times, &pending)) {
@@ -4499,7 +4499,7 @@ exit_rsa_sign:
 #endif
 
         /* capture resulting encrypt length */
-        idx = rsaKeySz/8;
+        idx = (word32)rsaKeySz/8;
 
         /* begin RSA verify */
         bench_stats_start(&count, &start);
@@ -4514,7 +4514,7 @@ exit_rsa_sign:
                     #if !defined(WOLFSSL_RSA_VERIFY_INLINE) && \
                         !defined(WOLFSSL_RSA_PUBLIC_ONLY)
                         ret = wc_RsaSSL_Verify(enc[i], idx, out[i],
-                                                      rsaKeySz/8, &rsaKey[i]);
+                                              (word32)rsaKeySz/8, &rsaKey[i]);
                     #elif defined(USE_CERT_BUFFERS_2048)
                         XMEMCPY(enc[i], rsa_2048_sig, sizeof(rsa_2048_sig));
                         idx = sizeof(rsa_2048_sig);
@@ -5429,7 +5429,7 @@ void bench_curve25519KeyAgree(void)
     double start;
     int    ret, i, count;
     byte   shared[32];
-	const char**desc = bench_desc_words[lng_index];
+    const char**desc = bench_desc_words[lng_index];
     word32 x = 0;
 
     wc_curve25519_init(&genKey);
@@ -5758,7 +5758,7 @@ void benchmark_configure(int block_size)
 {
     /* must be greater than 0 */
     if (block_size > 0) {
-        numBlocks = numBlocks * bench_size / block_size;
+        numBlocks = numBlocks * (int)bench_size / block_size;
         bench_size = (word32)block_size;
     }
 }

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -774,6 +774,28 @@
 #elif defined(WOLFSSL_DEVCRYPTO_AES)
 
 #elif defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_AES)
+
+    #if defined(WOLFSSL_RENESAS_RA6M3G) /* Renesas RA6M3 MCU */
+    #include <wolfssl/wolfcrypt/port/Renesas/renesas_sce_ra6m3g.h>
+
+    static int wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
+    {
+        int ret;
+        ret = wc_Renesas_AesEcbEncrypt(aes, outBlock, inBlock, AES_BLOCK_SIZE);
+        return ret;
+    }
+
+    #ifdef HAVE_AES_DECRYPT
+    static int wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
+    {
+        int ret;
+        ret = wc_Renesas_AesEcbDecrypt(aes, outBlock, inBlock, AES_BLOCK_SIZE);
+        return ret;
+    }
+    #endif /* HAVE_AES_DECRYPT */
+
+    #elif defined(WOLFSSL_RENESAS_S7G2) /* Renesas S7G2 MCU */
+
     #include "hal_data.h"
 
     #ifndef WOLFSSL_SCE_AES256_HANDLE
@@ -900,8 +922,7 @@
 
         return 0;
     }
-
-    #endif
+    #endif /* HAVE_AES_DECRYPT */
 
     #if defined(HAVE_AESGCM) || defined(WOLFSSL_AES_DIRECT)
     static int wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
@@ -916,6 +937,7 @@
         return AES_ECB_decrypt(aes, inBlock, outBlock, AES_BLOCK_SIZE);
     }
     #endif
+    #endif /* WOLFSSL_RENESAS_RA6M3 */
 #else
 
     /* using wolfCrypt software implementation */
@@ -1471,7 +1493,7 @@ static const word32 Td[4][256] = {
 
 
 #if (defined(HAVE_AES_CBC) && !defined(WOLFSSL_DEVCRYPTO_CBC)) \
-			|| defined(WOLFSSL_AES_DIRECT)
+                       || defined(WOLFSSL_AES_DIRECT)
 static const byte Td4[256] =
 {
     0x52U, 0x09U, 0x6aU, 0xd5U, 0x30U, 0x36U, 0xa5U, 0x38U,
@@ -1599,7 +1621,8 @@ static void wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
         #endif
     }
 #endif
-#if defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_AES)
+#if defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_AES) && \
+    defined(WOLFSSL_RENESAS_S7G2)
     AES_ECB_encrypt(aes, inBlock, outBlock, AES_BLOCK_SIZE);
     return;
 #endif
@@ -1801,7 +1824,8 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
         #endif
     }
 #endif /* WOLFSSL_AESNI */
-#if defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_AES)
+#if defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_AES) && \
+    defined(WOLFSSL_RENESAS_S7G2)
     return AES_ECB_decrypt(aes, inBlock, outBlock, AES_BLOCK_SIZE);
 #endif
 
@@ -2298,7 +2322,8 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
         XMEMCPY(rk, userKey, keylen);
     #if defined(LITTLE_ENDIAN_ORDER) && !defined(WOLFSSL_PIC32MZ_CRYPT) && \
         (!defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
-          defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_AES))
+          defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_AES)) && \
+         !defined(WOLFSSL_RENESAS_RA6M3G)
         ByteReverseWords(rk, rk, keylen);
     #endif
 
@@ -2430,13 +2455,16 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
     #else
         (void)dir;
     #endif /* HAVE_AES_DECRYPT */
+
 #endif /* NEED_AES_TABLES */
 
 #if defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_AES)
         XMEMCPY((byte*)aes->key, userKey, keylen);
+    #if defined(WOLFSSL_RENESAS_S7G2)
         if (WOLFSSL_SCE_GSCE_HANDLE.p_cfg->endian_flag == CRYPTO_WORD_ENDIAN_BIG) {
             ByteReverseWords(aes->key, aes->key, 32);
         }
+    #endif
 #endif
 
         return wc_AesSetIV(aes, iv);
@@ -2470,6 +2498,23 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
                 !((keylen == 16) || (keylen == 24) || (keylen == 32))) {
             return BAD_FUNC_ARG;
         }
+
+    #if defined(WOLFSSL_SCE) && defined(WOLFSSL_RENESAS_RA6M3G)
+    #if !defined(WOLFSSL_AES_128)
+        if (keylen == 16)
+            return BAD_FUNC_ARG;
+    #endif
+
+    #if  !defined(WOLFSSL_AES_192)
+        if (keylen == 24)
+            return BAD_FUNC_ARG;
+    #endif
+
+    #if !defined(WOLFSSL_AES_256)
+        if (keylen == 32)
+            return BAD_FUNC_ARG;
+    #endif
+    #endif /* WOLFSSL_SCE && WOLFSSL_RENESAS_RA6M3 */
 
     #if defined(AES_MAX_KEY_SIZE)
         /* Check key length */
@@ -2636,7 +2681,6 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
             }
         }
         #endif /* HAVE_AES_DECRYPT */
-
     #else
         /* Allow direct access to one block encrypt */
         void wc_AesEncryptDirect(Aes* aes, byte* out, const byte* in)
@@ -3239,6 +3283,20 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 #elif defined(WOLFSSL_DEVCRYPTO_CBC)
     /* implemented in wolfcrypt/src/port/devcrypt/devcrypto_aes.c */
 
+#elif defined(WOLFSSL_SCE) && defined(WOLFSSL_RENESAS_RA6M3G) && \
+      !defined(WOLFSSL_SCE_NO_AES)
+
+    int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz) {
+        return wc_Renesas_AesCbcEncrypt(aes, out, in, sz);
+    }
+
+    #ifdef HAVE_AES_DECRYPT
+    int wc_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+    {
+        return wc_Renesas_AesCbcDecrypt(aes, out, in, sz);
+    }
+    #endif /* HAVE_AES_DECRYPT */
+
 #else
 
     /* Software AES - CBC Encrypt */
@@ -3607,6 +3665,13 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 
     #elif defined(WOLFSSL_DEVCRYPTO_AES)
         /* implemented in wolfcrypt/src/port/devcrypt/devcrypto_aes.c */
+
+#elif defined(WOLFSSL_SCE) && defined(WOLFSSL_RENESAS_RA6M3G) && \
+      !defined(WOLFSSL_SCE_NO_AES)
+
+    int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz) {
+        return wc_Renesas_AesCtrEncrypt(aes, out, in, sz);
+    }
 
     #else
 
@@ -7201,18 +7266,26 @@ int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     if ((in == NULL) || (out == NULL) || (aes == NULL))
         return BAD_FUNC_ARG;
-
+    #if defined(WOLFSSL_RENESAS_S7G2)
         return AES_ECB_encrypt(aes, in, out, sz);
+    #elif defined(WOLFSSL_RENESAS_RA6M3G)
+        return wc_Renesas_AesEcbEncrypt(aes, out, in, sz);
+    #endif
 }
 
-
+#ifdef HAVE_AES_DECRYPT
 int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     if ((in == NULL) || (out == NULL) || (aes == NULL))
         return BAD_FUNC_ARG;
 
+    #if defined(WOLFSSL_RENESAS_S7G2)
         return AES_ECB_decrypt(aes, in, out, sz);
+    #elif defined(WOLFSSL_RENESAS_RA6M3G)
+        return wc_Renesas_AesEcbDecrypt(aes, out, in, sz);
+    #endif
 }
+#endif /* HAVE_AES_DECRYPT */
 
 #else
 

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -82,6 +82,7 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/Espressif/README.md \
               wolfcrypt/src/port/arm/cryptoCell.c \
               wolfcrypt/src/port/arm/cryptoCellHash.c \
+              wolfcrypt/src/port/Renesas/renesas_sce_ra6m3g.c \
               wolfcrypt/src/port/Renesas/renesas_tsip_aes.c \
               wolfcrypt/src/port/Renesas/renesas_tsip_sha.c \
               wolfcrypt/src/port/Renesas/renesas_tsip_util.c \

--- a/wolfcrypt/src/port/Renesas/renesas_sce_ra6m3g.c
+++ b/wolfcrypt/src/port/Renesas/renesas_sce_ra6m3g.c
@@ -1,0 +1,417 @@
+/* test.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* wolfSSL and wolfCrypt */
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/ssl.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/port/Renesas/renesas_sce_ra6m3g.h>
+/* Renesas RA SCE */
+#include "common/hw_sce_common.h"
+#include "hw_sce_private.h"
+#include "hw_sce_trng_private.h"
+#include "hw_sce_hash_private.h"
+#include "hw_sce_aes_private.h"
+
+int wc_Renesas_SCE_init(void) {
+    fsp_err_t ret;
+
+    HW_SCE_PowerOn();
+    HW_SCE_SoftReset();
+
+    ret = HW_SCE_Initialization1();
+    if (FSP_SUCCESS == ret) {
+        ret = HW_SCE_Initialization2();
+    }
+
+    if (FSP_SUCCESS == ret) {
+        ret = HW_SCE_secureBoot();
+        HW_SCE_EndianSetLittle();
+    }
+
+    return (int)ret;
+}
+
+/* TRNG */
+int wc_Renesas_GenerateSeed(OS_Seed* os, byte* output, word32 sz) {
+    int ret = FSP_SUCCESS;
+    uint32_t tmpOut[4] = {0};
+
+    if (!(os && output && sz > 0))
+        ret = BAD_FUNC_ARG;
+
+    /* Fill output with multiples of 128-bit random numbers */
+    while (sz >= sizeof(tmpOut) && ret == FSP_SUCCESS) {
+        ret = HW_SCE_RNG_Read((uint32_t*) output);
+        output += sizeof(tmpOut);
+        sz -= sizeof(tmpOut);
+    }
+
+    /* Truncate random number when sz is less than 128-bits */
+    if (sz > 0 && ret == FSP_SUCCESS) {
+        ret = HW_SCE_RNG_Read(tmpOut);
+        XMEMCPY(output, tmpOut, sz);
+    }
+
+    if (ret == FSP_SUCCESS)
+        ret = 0;
+
+    return ret;
+}
+
+/* SHA-256 */
+int wc_Renesas_Sha256Transform(wc_Sha256* sha256, const byte* data) {
+    int ret = WOLFSSL_SUCCESS;
+    (void) data;
+
+    if (sha256 == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (ret != BAD_FUNC_ARG) {
+        ret = wolfSSL_CryptHwMutexLock();
+        HW_SCE_EndianSetBig();
+    }
+
+    if (ret == 0) {
+        ret = HW_SCE_SHA256_UpdateHash((const uint32_t*) sha256->buffer,
+                            (uint32_t) WC_SHA256_BLOCK_SIZE  / sizeof(word32),
+                            (uint32_t*) sha256->digest);
+        wolfSSL_CryptHwMutexUnLock();
+    }
+
+    if (ret != FSP_SUCCESS && ret != BAD_FUNC_ARG)
+        ret = WC_HW_E;
+
+    return ret;
+}
+
+/* AES */
+int wc_Renesas_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    word32 keySize = 0;
+    uint32_t num_words = 0;
+    int ret = 0;
+
+    /* Only accept input with size that is a multiple AES_BLOCK_SIZE */
+    if (sz % AES_BLOCK_SIZE != 0) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (aes == NULL || out == NULL || in == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (ret != BAD_FUNC_ARG) {
+        wc_AesGetKeySize(aes, &keySize);
+    }
+
+    if (ret != BAD_FUNC_ARG && wolfSSL_CryptHwMutexLock() == 0 && sz)
+    {
+        /* Format AES Key for Little Endian HW */
+        if (keySize == 16 || keySize == 32) {
+            HW_SCE_EndianSetLittle();
+        }
+
+        num_words = (sz / sizeof(word32));
+
+        switch (keySize) {
+        case 16:
+            ret =  HW_SCE_AES_128CbcEncrypt((const uint32_t *) aes->key,
+                                            (const uint32_t *) aes->reg,
+                                            (const uint32_t)   num_words,
+                                            (const uint32_t *) in,
+                                            (uint32_t *) out,
+                                            (uint32_t *) aes->reg);
+            break;
+        case 32:
+            ret =  HW_SCE_AES_256CbcEncrypt((const uint32_t *) aes->key,
+                                            (const uint32_t *) aes->reg,
+                                            (const uint32_t)   num_words,
+                                            (const uint32_t *) in,
+                                            (uint32_t *) out,
+                                            (uint32_t *) aes->reg);
+            break;
+        default:
+            ret = BAD_FUNC_ARG;
+            break;
+        }
+    }
+    wolfSSL_CryptHwMutexUnLock();
+
+    if (ret != FSP_SUCCESS && ret != BAD_FUNC_ARG)
+        ret = WC_HW_E;
+
+    return ret;
+}
+
+int wc_Renesas_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    word32 keySize = 0;
+    uint32_t num_words = 0;
+    int ret = 0;
+
+    /* Only accept input with size that is a multiple AES_BLOCK_SIZE */
+    if (sz % AES_BLOCK_SIZE != 0) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (aes == NULL || out == NULL || in == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (ret != BAD_FUNC_ARG) {
+        wc_AesGetKeySize(aes, &keySize);
+    }
+
+    if (ret != BAD_FUNC_ARG && wolfSSL_CryptHwMutexLock() == 0 && sz)
+    {
+        /* Format AES Key for Little Endian HW */
+        if (keySize == 16 || keySize == 32) {
+            HW_SCE_EndianSetLittle();
+        }
+
+        num_words = (sz / sizeof(word32));
+
+        switch (keySize) {
+        case 16:
+            ret =  HW_SCE_AES_128CbcDecrypt((const uint32_t *) aes->key,
+                                            (const uint32_t *) aes->reg,
+                                            (const uint32_t)   num_words,
+                                            (const uint32_t *) in,
+                                            (uint32_t *) out,
+                                            (uint32_t *) aes->reg);
+            break;
+        case 32:
+            ret =  HW_SCE_AES_256CbcDecrypt((const uint32_t *) aes->key,
+                                            (const uint32_t *) aes->reg,
+                                            (const uint32_t)   num_words,
+                                            (const uint32_t *) in,
+                                            (uint32_t *) out,
+                                            (uint32_t *) aes->reg);
+            break;
+        default:
+            ret = BAD_FUNC_ARG;
+            break;
+        }
+    }
+    wolfSSL_CryptHwMutexUnLock();
+
+    if (ret != FSP_SUCCESS && ret != BAD_FUNC_ARG)
+        ret = WC_HW_E;
+
+    return ret;
+}
+
+int wc_Renesas_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    word32 keySize = 0;
+    uint32_t num_words = 0;
+    int ret = 0;
+
+    /* Only accept input with size that is a multiple AES_BLOCK_SIZE */
+    if (sz % AES_BLOCK_SIZE != 0) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (aes == NULL || out == NULL || in == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (ret != BAD_FUNC_ARG) {
+        wc_AesGetKeySize(aes, &keySize);
+    }
+
+    if (ret != BAD_FUNC_ARG && wolfSSL_CryptHwMutexLock() == 0 && sz)
+    {
+        /* Format AES Key for Little Endian HW */
+        if (keySize == 16 || keySize == 32) {
+            HW_SCE_EndianSetLittle();
+        }
+
+        num_words = (sz / sizeof(word32));
+
+        switch (keySize) {
+        case 16:
+            ret = HW_SCE_AES_128EcbEncrypt((const uint32_t*)  aes->key,
+                                            (const uint32_t)  num_words,
+                                            (const uint32_t*) in,
+                                            (uint32_t*) out);
+            break;
+        case 32:
+            ret = HW_SCE_AES_256EcbEncrypt((const uint32_t*)  aes->key,
+                                            (const uint32_t)  num_words,
+                                            (const uint32_t*) in,
+                                            (uint32_t*) out);
+            break;
+        default:
+            ret = BAD_FUNC_ARG;
+            break;
+        }
+        wolfSSL_CryptHwMutexUnLock();
+    }
+
+    if (ret != FSP_SUCCESS && ret != BAD_FUNC_ARG)
+        ret = WC_HW_E;
+
+    return ret;
+}
+
+int wc_Renesas_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    word32 keySize = 0;
+    uint32_t num_words = 0;
+    int ret = 0;
+
+    /* Only accept input with size that is a multiple AES_BLOCK_SIZE */
+    if (sz % AES_BLOCK_SIZE != 0) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (aes == NULL || out == NULL || in == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (ret != BAD_FUNC_ARG) {
+        wc_AesGetKeySize(aes, &keySize);
+    }
+
+    if (ret != BAD_FUNC_ARG && wolfSSL_CryptHwMutexLock() == 0 && sz)
+    {
+        /* Format AES Key for Little Endian HW */
+        if (keySize == 16 || keySize == 32) {
+            HW_SCE_EndianSetLittle();
+        }
+
+        num_words = (sz / sizeof(word32));
+
+        switch (keySize) {
+        case 16:
+            ret = HW_SCE_AES_128EcbDecrypt((const uint32_t*)  aes->key,
+                                            (const uint32_t)  num_words,
+                                            (const uint32_t*) in,
+                                            (uint32_t*) out);
+            break;
+        case 32:
+            ret = HW_SCE_AES_256EcbDecrypt((const uint32_t*)  aes->key,
+                                            (const uint32_t)  num_words,
+                                            (const uint32_t*) in,
+                                            (uint32_t*) out);
+            break;
+        default:
+            ret = BAD_FUNC_ARG;
+            break;
+        }
+        wolfSSL_CryptHwMutexUnLock();
+    }
+
+    if (ret != FSP_SUCCESS && ret != BAD_FUNC_ARG)
+        ret = WC_HW_E;
+
+    return ret;
+}
+
+int wc_Renesas_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz) {
+    const byte aes_blk_words = AES_BLOCK_SIZE / sizeof(word32);
+    word32 keySize = 0;
+    int ret = WOLFSSL_SUCCESS;
+    const byte* tmp;
+    uint32_t* outTmp;
+    byte inTmp[16] = {0};
+
+    if (aes == NULL || out == NULL || in == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    /* Format AES Key for Little Endian HW */
+    HW_SCE_EndianSetLittle();
+    wc_AesGetKeySize(aes, &keySize);
+    if (!(keySize == 16 || keySize == 32)) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    /* Use remaining AES stream from previous non-AES_BLOCK_SIZE operation */
+    tmp = (byte*)aes->tmp + AES_BLOCK_SIZE - aes->left;
+    while (aes->left && sz && ret != BAD_FUNC_ARG) {
+       *(out++) = *(in++) ^ *(tmp++);
+       aes->left--;
+       sz--;
+    }
+
+    while (sz) {
+        tmp = in;
+        outTmp = (word32*) out;
+
+        if (sz < AES_BLOCK_SIZE) {
+            /* Copy remaining bytes into AES_BLOCK_SIZE buffer */
+            XMEMCPY(inTmp, in, sz);
+            tmp = inTmp;
+            /* Set output to aes->tmp for future stream re-use */
+            outTmp = aes->tmp;
+        }
+
+        ret = wolfSSL_CryptHwMutexLock();
+        if (ret != 0) {
+            break;
+        }
+
+        if (keySize == 16) {
+            ret = HW_SCE_AES_128CtrEncrypt((const uint32_t*) aes->key,
+                                           (const uint32_t*) aes->reg,
+                                           (const uint32_t)  aes_blk_words,
+                                           (const uint32_t*) tmp,
+                                           (uint32_t*) outTmp,
+                                           (uint32_t*) aes->reg);
+        } else if (keySize == 32) {
+            ret = HW_SCE_AES_256CtrEncrypt((const uint32_t*) aes->key,
+                                           (const uint32_t*) aes->reg,
+                                           (const uint32_t)  aes_blk_words,
+                                           (const uint32_t*) tmp,
+                                           (uint32_t*) outTmp,
+                                           (uint32_t*) aes->reg);
+        } else {
+            ret = BAD_FUNC_ARG;
+        }
+        wolfSSL_CryptHwMutexUnLock();
+
+        if (ret != FSP_SUCCESS)
+            break;
+
+        if (sz < AES_BLOCK_SIZE) {
+            /* Finished remaining bytes.
+             * Bookkeeping for future stream re-use.
+             */
+            XMEMCPY(out, aes->tmp, sz);
+            aes->left = AES_BLOCK_SIZE - sz;
+            break;
+        } else {
+            out += AES_BLOCK_SIZE;
+            in  += AES_BLOCK_SIZE;
+            sz  -= AES_BLOCK_SIZE;
+            aes->left = 0;
+        }
+    }
+
+    if (ret != FSP_SUCCESS && ret != BAD_FUNC_ARG)
+        ret = WC_HW_E;
+
+    return ret;
+}

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -156,6 +156,9 @@ int wc_RNG_GenerateByte(WC_RNG* rng, byte* b)
 #elif defined(WOLFSSL_ZEPHYR)
 #elif defined(WOLFSSL_TELIT_M2MB)
 #elif defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_TRNG)
+    #if defined(WOLFSSL_RENESAS_RA6M3G)
+        #include "wolfssl/wolfcrypt/port/Renesas/renesas_sce_ra6m3g.h"
+    #endif
 #else
     /* include headers that may be needed to get good seed */
     #include <fcntl.h>
@@ -2295,7 +2298,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 #endif
     #include "r_bsp/platform.h"
     #include "r_tsip_rx_if.h"
-    
+
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
         int ret;
@@ -2303,7 +2306,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 
         while (sz > 0) {
             uint32_t len = sizeof(buffer);
-            
+
             if (sz < len) {
                 len = sz;
             }
@@ -2320,6 +2323,13 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     }
 
 #elif defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_TRNG)
+
+    #if defined(WOLFSSL_RENESAS_RA6M3G) /* Renesas RA6M3G MCU */
+    int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz) {
+        return wc_Renesas_GenerateSeed(os, output, sz);
+    }
+    #elif defined(WOLFSSL_RENESAS_S7G2) /* Renesas S7G2 MCU */
+
     #include "hal_data.h"
 
     #ifndef WOLFSSL_SCE_TRNG_HANDLE
@@ -2370,6 +2380,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         }
         return 0;
     }
+    #endif /* WOLFSSL_RENESAS_RA6M3 */
 #elif defined(CUSTOM_RAND_GENERATE_BLOCK)
     /* #define CUSTOM_RAND_GENERATE_BLOCK myRngFunc
      * extern int myRngFunc(byte* output, word32 sz);

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -46,7 +46,7 @@
 #if !defined(NO_SHA256) && !defined(WOLFSSL_ARMASM)
 
 #if defined(HAVE_FIPS) && \
-	defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
+    defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
 
     /* set NO_WRAPPERS before headers, use direct internal f()s not wrappers */
     #define FIPS_NO_WRAPPERS
@@ -545,8 +545,13 @@ static int InitSha256(wc_Sha256* sha256)
     /* implemented in wolfcrypt/src/port/devcrypto/devcrypt_hash.c */
 
 #elif defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_HASH)
-    #include "hal_data.h"
 
+    #if defined(WOLFSSL_RENESAS_RA6M3G)  /* Renesas RA6M3G MCU */
+        #include <wolfssl/wolfcrypt/port/Renesas/renesas_sce_ra6m3g.h>
+        #define XTRANSFORM(S, D) wc_Renesas_Sha256Transform((S), (D))
+
+    #elif defined(WOLFSSL_RENESAS_S7G2) /* Renesas S7G2 MCU */
+    #include "hal_data.h"
     #ifndef WOLFSSL_SCE_SHA256_HANDLE
         #define WOLFSSL_SCE_SHA256_HANDLE g_sce_hash_0
     #endif
@@ -582,7 +587,7 @@ static int InitSha256(wc_Sha256* sha256)
 
         return 0;
     }
-
+    #endif /* WOLFSSL_RENESAS_RA6M3G */
 
     int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
     {

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -83,7 +83,11 @@
 #endif
 
 #ifdef WOLFSSL_SCE
-    #include "hal_data.h"
+    #if defined(WOLFSSL_RENESAS_S7G2)
+        #include "hal_data.h"
+    #elif defined(WOLFSSL_RENESAS_RA6M3G)
+        #include <wolfssl/wolfcrypt/port/Renesas/renesas_sce_ra6m3g.h>
+    #endif
 #endif
 
 #if defined(WOLFSSL_DSP) && !defined(WOLFSSL_DSP_BUILD)
@@ -228,7 +232,8 @@ int wolfCrypt_Init(void)
     #endif
 #endif
 
-#ifdef WOLFSSL_SCE
+#if defined(WOLFSSL_SCE)
+#if defined(WOLFSSL_RENESAS_S7G2)
         ret = (int)WOLFSSL_SCE_GSCE_HANDLE.p_api->open(
                 WOLFSSL_SCE_GSCE_HANDLE.p_ctrl, WOLFSSL_SCE_GSCE_HANDLE.p_cfg);
         if (ret == SSP_ERR_CRYPTO_SCE_ALREADY_OPEN) {
@@ -239,7 +244,10 @@ int wolfCrypt_Init(void)
             WOLFSSL_MSG("Error opening SCE");
             return -1; /* FATAL_ERROR */
         }
-#endif
+#elif defined(WOLFSSL_RENESAS_RA6M3G)
+        wc_Renesas_SCE_init();
+#endif /* WOLFSSL_RENESAS_S7G2 */
+#endif /* WOLFSSL_SCE */
 
 #if defined(WOLFSSL_IMX6_CAAM) || defined(WOLFSSL_IMX6_CAAM_RNG) || \
     defined(WOLFSSL_IMX6_CAAM_BLOB)
@@ -249,7 +257,7 @@ int wolfCrypt_Init(void)
 #endif
 
 #if defined(WOLFSSL_DSP) && !defined(WOLFSSL_DSP_BUILD)
-	if ((ret = wolfSSL_InitHandle()) != 0) {
+        if ((ret = wolfSSL_InitHandle()) != 0) {
             return ret;
         }
         rpcmem_init();
@@ -293,7 +301,7 @@ int wolfCrypt_Cleanup(void)
     #ifdef WOLFSSL_ASYNC_CRYPT
         wolfAsync_HardwareStop();
     #endif
-    #ifdef WOLFSSL_SCE
+    #if defined(WOLFSSL_SCE) && defined(WOLFSSL_RENESAS_S7G2)
         WOLFSSL_SCE_GSCE_HANDLE.p_api->close(WOLFSSL_SCE_GSCE_HANDLE.p_ctrl);
     #endif
     #if defined(WOLFSSL_IMX6_CAAM) || defined(WOLFSSL_IMX6_CAAM_RNG) || \

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -78,6 +78,7 @@ noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/st/stsafe.h \
                          wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h \
                          wolfssl/wolfcrypt/port/arm/cryptoCell.h \
+                         wolfssl/wolfcrypt/port/Renesas/renesas_sce_ra6m3g.h \
                          wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h
 
 if BUILD_CRYPTOAUTHLIB

--- a/wolfssl/wolfcrypt/port/Renesas/renesas_sce_ra6m3g.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas_sce_ra6m3g.h
@@ -1,0 +1,25 @@
+#ifndef WOLFSSL_RENESAS_RA6M3G_SCE_H
+#define WOLFSSL_RENESAS_RA6M3G_SCE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <wolfssl/wolfcrypt/sha256.h>
+#include <wolfssl/wolfcrypt/aes.h>
+
+/* Renesas RA6M3G Secure Cryptogrpahy Engine (SCE) drivers for wolfCrypt */
+int wc_Renesas_SCE_init(void);
+int wc_Renesas_GenerateSeed(OS_Seed* os, byte* output, word32 sz);
+int wc_Renesas_Sha256Transform(wc_Sha256*, const byte*);
+int wc_Renesas_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+int wc_Renesas_AesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+int wc_Renesas_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+int wc_Renesas_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+int wc_Renesas_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WOLFSSL_RA6M3G_SCE_H */


### PR DESCRIPTION
Includes:
* Hardware support for TRNG, SHA-256, and AES-(ECB/CBC/CTR). 
(Secure Cryptography Engine / SCE)

* WOLFSSL_RENESAS_S7G2 and WOLFSSL_RENESAS_RA6M3G defines to differentiate Renesas MCUs that have Hardware Acceleration.

*  int or word32 typecasts in benchmark and test to silence warnings. 

* Some reformatting for tabs to spaces.