### PR TITLE
Fix for bidirectional shutdown

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -762,8 +762,14 @@ static int SMTP_Shutdown(WOLFSSL* ssl, int wc_shutdown)
     printf("%s\n", tmpBuf);
 
     ret = wolfSSL_shutdown(ssl);
-    if (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE)
-        wolfSSL_shutdown(ssl);    /* bidirectional shutdown */
+    while (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE) {
+        if (tcp_select(wolfSSL_get_fd(ssl), DEFAULT_TIMEOUT_SEC) ==
+                TEST_RECV_READY) {
+            ret = wolfSSL_shutdown(ssl);    /* bidirectional shutdown */
+            if (ret == WOLFSSL_SUCCESS)
+                printf("Bidirectional shutdown complete\n");
+        }
+    }
 
     return WOLFSSL_SUCCESS;
 }
@@ -3046,9 +3052,11 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     if (dtlsUDP == 0) {           /* don't send alert after "break" command */
         ret = wolfSSL_shutdown(ssl);
         while (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE) {
-            ret = wolfSSL_shutdown(ssl); /* bidirectional shutdown */
-            if (ret == WOLFSSL_SUCCESS)
-                printf("Bidirectional shutdown complete\n");
+            if (tcp_select(sockfd, DEFAULT_TIMEOUT_SEC) == TEST_RECV_READY) {
+                ret = wolfSSL_shutdown(ssl); /* bidirectional shutdown */
+                if (ret == WOLFSSL_SUCCESS)
+                    printf("Bidirectional shutdown complete\n");
+            }
         }
     }
 #if defined(ATOMIC_USER) && !defined(WOLFSSL_AEAD_ONLY)

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -3045,8 +3045,11 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     if (dtlsUDP == 0) {           /* don't send alert after "break" command */
         ret = wolfSSL_shutdown(ssl);
-        if (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE)
-            wolfSSL_shutdown(ssl);    /* bidirectional shutdown */
+        while (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE) {
+            ret = wolfSSL_shutdown(ssl); /* bidirectional shutdown */
+            if (ret == WOLFSSL_SUCCESS)
+                printf("Bidirectional shutdown complete\n");
+        }
     }
 #if defined(ATOMIC_USER) && !defined(WOLFSSL_AEAD_ONLY)
     if (atomicUser)

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -762,13 +762,15 @@ static int SMTP_Shutdown(WOLFSSL* ssl, int wc_shutdown)
     printf("%s\n", tmpBuf);
 
     ret = wolfSSL_shutdown(ssl);
-    while (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE) {
+    if (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE) {
         if (tcp_select(wolfSSL_get_fd(ssl), DEFAULT_TIMEOUT_SEC) ==
                 TEST_RECV_READY) {
             ret = wolfSSL_shutdown(ssl);    /* bidirectional shutdown */
             if (ret == WOLFSSL_SUCCESS)
                 printf("Bidirectional shutdown complete\n");
         }
+        if (ret != WOLFSSL_SUCCESS)
+            printf("Bidirectional shutdown failed\n");
     }
 
     return WOLFSSL_SUCCESS;
@@ -3051,12 +3053,14 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     if (dtlsUDP == 0) {           /* don't send alert after "break" command */
         ret = wolfSSL_shutdown(ssl);
-        while (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE) {
+        if (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE) {
             if (tcp_select(sockfd, DEFAULT_TIMEOUT_SEC) == TEST_RECV_READY) {
                 ret = wolfSSL_shutdown(ssl); /* bidirectional shutdown */
                 if (ret == WOLFSSL_SUCCESS)
                     printf("Bidirectional shutdown complete\n");
             }
+            if (ret != WOLFSSL_SUCCESS)
+                printf("Bidirectional shutdown failed\n");
         }
     }
 #if defined(ATOMIC_USER) && !defined(WOLFSSL_AEAD_ONLY)

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -51,6 +51,8 @@
     static int devId = INVALID_DEVID;
 #endif
 
+#define DEFAULT_TIMEOUT_SEC 2
+
 /* Note on using port 0: if the server uses port 0 to bind an ephemeral port
  * number and is using the ready file for scripted testing, the code in
  * test.h will write the actual port number into the ready file for use
@@ -2378,7 +2380,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 
         if (dtlsUDP == 0) {
             ret = SSL_shutdown(ssl);
-            while (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE) {
+            if (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE) {
                 ret = SSL_shutdown(ssl); /* bidirectional shutdown */
                 if (ret == WOLFSSL_SUCCESS)
                     printf("Bidirectional shutdown complete\n");

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2378,9 +2378,13 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 
         if (dtlsUDP == 0) {
             ret = SSL_shutdown(ssl);
-            if (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE)
-                SSL_shutdown(ssl);    /* bidirectional shutdown */
+            while (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE) {
+                ret = SSL_shutdown(ssl); /* bidirectional shutdown */
+                if (ret == WOLFSSL_SUCCESS)
+                    printf("Bidirectional shutdown complete\n");
+            }
         }
+
         /* display collected statistics */
 #ifdef WOLFSSL_STATIC_MEMORY
         if (wolfSSL_is_static_memory(ssl, &ssl_stats) != 1)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2947,7 +2947,7 @@ int wolfSSL_shutdown(WOLFSSL* ssl)
 
         /* call wolfSSL_shutdown again for bidirectional shutdown */
         if (ssl->options.sentNotify && !ssl->options.closeNotify) {
-            ret = wolfSSL_read(ssl, &tmp, 0);
+            ret = wolfSSL_read(ssl, &tmp, 1);
             if (ret < 0) {
                 WOLFSSL_ERROR(ssl->error);
                 ret = WOLFSSL_FATAL_ERROR;
@@ -2955,7 +2955,7 @@ int wolfSSL_shutdown(WOLFSSL* ssl)
                 ssl->error = WOLFSSL_ERROR_SYSCALL;   /* simulate OpenSSL behavior */
                 ret = WOLFSSL_SUCCESS;
             } else if ((ssl->error == WOLFSSL_ERROR_NONE) &&
-                       (ret < WOLFSSL_SUCCESS)) {
+                       (ret > 0)) {
                 ret = WOLFSSL_SHUTDOWN_NOT_DONE;
             }
         }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2908,7 +2908,6 @@ WOLFSSL_ABI
 int wolfSSL_shutdown(WOLFSSL* ssl)
 {
     int  ret = WOLFSSL_FATAL_ERROR;
-    byte tmp;
     WOLFSSL_ENTER("SSL_shutdown()");
 
     if (ssl == NULL)
@@ -2947,16 +2946,16 @@ int wolfSSL_shutdown(WOLFSSL* ssl)
 
         /* call wolfSSL_shutdown again for bidirectional shutdown */
         if (ssl->options.sentNotify && !ssl->options.closeNotify) {
-            ret = wolfSSL_read(ssl, &tmp, 1);
-            if (ret < 0) {
+            ret = ProcessReply(ssl);
+            if (ret == ZERO_RETURN) {
+                /* simulate OpenSSL behavior */
+                ssl->error = WOLFSSL_ERROR_SYSCALL;
+                ret = WOLFSSL_SUCCESS;
+            } else if (ssl->error == WOLFSSL_ERROR_NONE) {
+                ret = WOLFSSL_SHUTDOWN_NOT_DONE;
+            } else {
                 WOLFSSL_ERROR(ssl->error);
                 ret = WOLFSSL_FATAL_ERROR;
-            } else if (ssl->options.closeNotify) {
-                ssl->error = WOLFSSL_ERROR_SYSCALL;   /* simulate OpenSSL behavior */
-                ret = WOLFSSL_SUCCESS;
-            } else if ((ssl->error == WOLFSSL_ERROR_NONE) &&
-                       (ret > 0)) {
-                ret = WOLFSSL_SHUTDOWN_NOT_DONE;
             }
         }
     }

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -2188,3 +2188,9 @@
 -v 3
 -l ECDHE-RSA-AES128-SHA256
 -U
+
+# server with bidirectional shutdown
+-w
+
+# client with bidirectional shutdown
+-w


### PR DESCRIPTION
Fix for error condition in bidirectional shutdown in non-blocking app. Reported in ZD9764. Reproduced by `client-tls-nonblocking` in https://github.com/wolfSSL/wolfssl-examples/pull/190