### PR TITLE
Fix for minor typos in the MDK5 examples

### DIFF
--- a/IDE/MDK5-ARM/Conf/user_settings.h
+++ b/IDE/MDK5-ARM/Conf/user_settings.h
@@ -55,11 +55,11 @@
 #define STM32F7xx
 #endif
 
-//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <2=>SafeRTOS<3=>Windows
-//         <4=>PThread <5=>ThreadX<6=> ThreadX/NetX
-//         <7=>Micrium <8=>EBSnet<9=>MQX 
-//         <10=>T-RTOS <11=>uITRON4<12=>uTKERNEL2 
-//         <13=>Frosted <14=>CMSIS RTOS<15=>CMSIS RTOSv2<16=>Others
+//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <3=>SafeRTOS <4=>Windows
+//         <5=>PThread <6=>ThreadX
+//         <7=>Micrium <8=>EBSnet <9=>MQX
+//         <10=>T-RTOS <11=>uITRON4 <12=>uTKERNEL2
+//         <13=>Frosted <14=>CMSIS RTOS <15=>CMSIS RTOSv2 <16=>Others
 #define MDK_CONF_THREAD 15
 #if MDK_CONF_THREAD== 0
 #define SINGLE_THREADED
@@ -247,7 +247,7 @@
 
 //      <e>HC128
 #define MDK_CONF_HC128 1
-#if MDK_CONF_AESGCM == 0
+#if MDK_CONF_HC128 == 0
 #define NO_HC128
 #endif
 //  </e>
@@ -516,4 +516,3 @@
 //  </e>
 
 //</h>
-

--- a/IDE/MDK5-ARM/Projects/CryptBenchmark/RTE/wolfSSL/user_settings.h
+++ b/IDE/MDK5-ARM/Projects/CryptBenchmark/RTE/wolfSSL/user_settings.h
@@ -55,10 +55,10 @@
 #define STM32F7xx
 #endif
 
-//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <2=>SafeRTOS<3=>Windows
-//         <4=>PThread <5=>ThreadX<6=> ThreadX/NetX
-//         <7=>Micrium <8=>EBSnet<9=>MQX 
-//         <10=>T-RTOS <11=>uITRON4<12=>uTKERNEL2 
+//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <3=>SafeRTOS<4=>Windows
+//         <5=>PThread <6=>ThreadX
+//         <7=>Micrium <8=>EBSnet<9=>MQX
+//         <10=>T-RTOS <11=>uITRON4<12=>uTKERNEL2
 //         <13=>Frosted <14=>CMSIS RTOS<15=>CMSIS RTOSv2<16=>Others
 #define MDK_CONF_THREAD 15
 #if MDK_CONF_THREAD== 0
@@ -247,7 +247,7 @@
 
 //      <e>HC128
 #define MDK_CONF_HC128 1
-#if MDK_CONF_AESGCM == 0
+#if MDK_CONF_HC128 == 0
 #define NO_HC128
 #endif
 //  </e>
@@ -516,4 +516,3 @@
 //  </e>
 
 //</h>
-

--- a/IDE/MDK5-ARM/Projects/CryptTest/RTE/wolfSSL/user_settings.h
+++ b/IDE/MDK5-ARM/Projects/CryptTest/RTE/wolfSSL/user_settings.h
@@ -55,11 +55,11 @@
 #define STM32F7xx
 #endif
 
-//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <2=>SafeRTOS<3=>Windows
-//         <4=>PThread <5=>ThreadX<6=> ThreadX/NetX
-//         <7=>Micrium <8=>EBSnet<9=>MQX 
-//         <10=>T-RTOS <11=>uITRON4<12=>uTKERNEL2 
-//         <13=>Frosted <14=>CMSIS RTOS<15=>CMSIS RTOSv2<16=>Others
+//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <3=>SafeRTOS <4=>Windows
+//         <5=>PThread <6=>ThreadX
+//         <7=>Micrium <8=>EBSnet <9=>MQX
+//         <10=>T-RTOS <11=>uITRON4 <12=>uTKERNEL2
+//         <13=>Frosted <14=>CMSIS RTOS <15=>CMSIS RTOSv2 <16=>Others
 #define MDK_CONF_THREAD 15
 #if MDK_CONF_THREAD== 0
 #define SINGLE_THREADED
@@ -247,7 +247,7 @@
 
 //      <e>HC128
 #define MDK_CONF_HC128 1
-#if MDK_CONF_AESGCM == 0
+#if MDK_CONF_HC128 == 0
 #define NO_HC128
 #endif
 //  </e>
@@ -516,4 +516,3 @@
 //  </e>
 
 //</h>
-

--- a/IDE/MDK5-ARM/Projects/EchoClient/RTE/wolfSSL/user_settings.h
+++ b/IDE/MDK5-ARM/Projects/EchoClient/RTE/wolfSSL/user_settings.h
@@ -55,11 +55,11 @@
 #define STM32F7xx
 #endif
 
-//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <2=>SafeRTOS<3=>Windows
-//         <4=>PThread <5=>ThreadX<6=> ThreadX/NetX
-//         <7=>Micrium <8=>EBSnet<9=>MQX 
-//         <10=>T-RTOS <11=>uITRON4<12=>uTKERNEL2 
-//         <13=>Frosted <14=>CMSIS RTOS<15=>Others
+//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <3=>SafeRTOS <4=>Windows
+//         <5=>PThread <6=>ThreadX
+//         <7=>Micrium <8=>EBSnet <9=>MQX
+//         <10=>T-RTOS <11=>uITRON4 <12=>uTKERNEL2
+//         <13=>Frosted <14=>CMSIS RTOS <15=>CMSIS RTOSv2 <16=>Others
 #define MDK_CONF_THREAD 14
 #if MDK_CONF_THREAD== 0
 #define SINGLE_THREADED
@@ -245,7 +245,7 @@
 
 //      <e>HC128
 #define MDK_CONF_HC128 1
-#if MDK_CONF_AESGCM == 0
+#if MDK_CONF_HC128 == 0
 #define NO_HC128
 #endif
 //  </e>
@@ -514,4 +514,3 @@
 //  </e>
 
 //</h>
-

--- a/IDE/MDK5-ARM/Projects/EchoServer/RTE/wolfSSL/user_settings.h
+++ b/IDE/MDK5-ARM/Projects/EchoServer/RTE/wolfSSL/user_settings.h
@@ -55,11 +55,11 @@
 #define STM32F7xx
 #endif
 
-//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <2=>SafeRTOS<3=>Windows
-//         <4=>PThread <5=>ThreadX<6=> ThreadX/NetX
-//         <7=>Micrium <8=>EBSnet<9=>MQX 
-//         <10=>T-RTOS <11=>uITRON4<12=>uTKERNEL2 
-//         <13=>Frosted <14=>CMSIS RTOS<15=>CMSIS RTOSv2<16=>Others
+//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <3=>SafeRTOS <4=>Windows
+//         <5=>PThread <6=>ThreadX
+//         <7=>Micrium <8=>EBSnet <9=>MQX
+//         <10=>T-RTOS <11=>uITRON4 <12=>uTKERNEL2
+//         <13=>Frosted <14=>CMSIS RTOS <15=>CMSIS RTOSv2 <16=>Others
 #define MDK_CONF_THREAD 14
 #if MDK_CONF_THREAD== 0
 #define SINGLE_THREADED
@@ -247,7 +247,7 @@
 
 //      <e>HC128
 #define MDK_CONF_HC128 1
-#if MDK_CONF_AESGCM == 0
+#if MDK_CONF_HC128 == 0
 #define NO_HC128
 #endif
 //  </e>
@@ -516,4 +516,3 @@
 //  </e>
 
 //</h>
-

--- a/IDE/MDK5-ARM/Projects/SimpleClient/RTE/wolfSSL/user_settings.h
+++ b/IDE/MDK5-ARM/Projects/SimpleClient/RTE/wolfSSL/user_settings.h
@@ -55,11 +55,11 @@
 #define STM32F7xx
 #endif
 
-//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <2=>SafeRTOS<3=>Windows
-//         <4=>PThread <5=>ThreadX<6=> ThreadX/NetX
-//         <7=>Micrium <8=>EBSnet<9=>MQX 
-//         <10=>T-RTOS <11=>uITRON4<12=>uTKERNEL2 
-//         <13=>Frosted <14=>CMSIS RTOS<15=>CMSIS RTOSv2<16=>Others
+//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <3=>SafeRTOS <4=>Windows
+//         <5=>PThread <6=>ThreadX
+//         <7=>Micrium <8=>EBSnet <9=>MQX
+//         <10=>T-RTOS <11=>uITRON4 <12=>uTKERNEL2
+//         <13=>Frosted <14=>CMSIS RTOS <15=>CMSIS RTOSv2 <16=>Others
 #define MDK_CONF_THREAD 15
 #if MDK_CONF_THREAD== 0
 #define SINGLE_THREADED
@@ -247,7 +247,7 @@
 
 //      <e>HC128
 #define MDK_CONF_HC128 1
-#if MDK_CONF_AESGCM == 0
+#if MDK_CONF_HC128 == 0
 #define NO_HC128
 #endif
 //  </e>
@@ -516,4 +516,3 @@
 //  </e>
 
 //</h>
-

--- a/IDE/MDK5-ARM/Projects/SimpleServer/RTE/wolfSSL/user_settings.h
+++ b/IDE/MDK5-ARM/Projects/SimpleServer/RTE/wolfSSL/user_settings.h
@@ -55,11 +55,11 @@
 #define STM32F7xx
 #endif
 
-//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <2=>SafeRTOS<3=>Windows
-//         <4=>PThread <5=>ThreadX<6=> ThreadX/NetX
-//         <7=>Micrium <8=>EBSnet<9=>MQX 
-//         <10=>T-RTOS <11=>uITRON4<12=>uTKERNEL2 
-//         <13=>Frosted <14=>CMSIS RTOS<15=>CMSIS RTOSv2<16=>Others
+//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <3=>SafeRTOS <4=>Windows
+//         <5=>PThread <6=>ThreadX
+//         <7=>Micrium <8=>EBSnet <9=>MQX
+//         <10=>T-RTOS <11=>uITRON4 <12=>uTKERNEL2
+//         <13=>Frosted <14=>CMSIS RTOS <15=>CMSIS RTOSv2 <16=>Others
 #define MDK_CONF_THREAD 15
 #if MDK_CONF_THREAD== 0
 #define SINGLE_THREADED
@@ -247,7 +247,7 @@
 
 //      <e>HC128
 #define MDK_CONF_HC128 1
-#if MDK_CONF_AESGCM == 0
+#if MDK_CONF_HC128 == 0
 #define NO_HC128
 #endif
 //  </e>
@@ -516,4 +516,3 @@
 //  </e>
 
 //</h>
-

--- a/IDE/MDK5-ARM/Projects/wolfSSL-Lib/RTE/wolfSSL/user_settings.h
+++ b/IDE/MDK5-ARM/Projects/wolfSSL-Lib/RTE/wolfSSL/user_settings.h
@@ -55,11 +55,11 @@
 #define STM32F7xx
 #endif
 
-//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <2=>SafeRTOS<3=>Windows
-//         <4=>PThread <5=>ThreadX<6=> ThreadX/NetX
-//         <7=>Micrium <8=>EBSnet<9=>MQX 
-//         <10=>T-RTOS <11=>uITRON4<12=>uTKERNEL2 
-//         <13=>Frosted <14=>CMSIS RTOS<15=>CMSIS RTOSv2<16=>Others
+//        <o> Thread/RTOS<0=>Single Threaded <1=>FreeRTOS <3=>SafeRTOS <4=>Windows
+//         <5=>PThread <6=>ThreadX
+//         <7=>Micrium <8=>EBSnet <9=>MQX
+//         <10=>T-RTOS <11=>uITRON4 <12=>uTKERNEL2
+//         <13=>Frosted <14=>CMSIS RTOS <15=>CMSIS RTOSv2 <16=>Others
 #define MDK_CONF_THREAD 15
 #if MDK_CONF_THREAD== 0
 #define SINGLE_THREADED
@@ -247,7 +247,7 @@
 
 //      <e>HC128
 #define MDK_CONF_HC128 1
-#if MDK_CONF_AESGCM == 0
+#if MDK_CONF_HC128 == 0
 #define NO_HC128
 #endif
 //  </e>
@@ -516,4 +516,3 @@
 //  </e>
 
 //</h>
-

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -56,12 +56,6 @@
     #include <stdio.h>
 #endif
 
-#ifndef NO_WOLFSSL_SMALL_STACK
-    #ifndef WOLFSSL_SMALL_STACK
-        #define WOLFSSL_SMALL_STACK
-    #endif
-#endif
-
 #ifdef SHOW_GEN
     #ifndef NO_STDIO_FILESYSTEM
         #include <stdio.h>

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2114,6 +2114,10 @@ extern void uITRON4_free(void *p) ;
     #define MAX_EX_DATA 5  /* allow for five items of ex_data */
 #endif
 
+#ifdef NO_WOLFSSL_SMALL_STACK
+    #undef WOLFSSL_SMALL_STACK
+#endif
+
 #ifdef __cplusplus
     }   /* extern "C" */
 #endif


### PR DESCRIPTION
Moved `NO_WOLFSSL_SMALL_STACK` into settings.h.