### PR TITLE
Clarify intent of code. Thanks to Jordy Z. on ZD 9836 for the report

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -22683,8 +22683,18 @@ int SendCertificateVerify(WOLFSSL* ssl)
         #ifndef NO_OLD_TLS
             else {
                 /* if old TLS load MD5 and SHA hash as value to sign */
+            #ifndef NO_MD5
                 XMEMCPY(ssl->buffers.sig.buffer,
-                    (byte*)ssl->hsHashes->certHashes.md5, FINISHED_SZ);
+                    (byte*)ssl->hsHashes->certHashes.md5, WC_MD5_DIGEST_SIZE);
+            #else
+                #error "old TLS requires MD5 and SHA"
+            #endif
+            #ifndef NO_SHA
+                XMEMCPY(ssl->buffers.sig.buffer + WC_MD5_DIGEST_SIZE,
+                    (byte*)ssl->hsHashes->certHashes.sha, WC_SHA_DIGEST_SIZE);
+            #else
+                #error "old TLS requires MD5 and SHA"
+            #endif
             }
         #endif
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -26276,7 +26276,11 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         }
                     }
                     else {
-                        if (args->sendSz != FINISHED_SZ || !args->output ||
+                        if (args->sendSz != FINISHED_SZ || !args->output
+                        #if !defined(NO_MD5) && !defined(NO_OLD_TLS) && \
+                            !defined(NO_SHA)
+                                ||
+                        #endif
                         #if !defined(NO_MD5) && !defined(NO_OLD_TLS)
                                 (
                                 XMEMCMP(args->output,

--- a/src/internal.c
+++ b/src/internal.c
@@ -26277,8 +26277,22 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                     }
                     else {
                         if (args->sendSz != FINISHED_SZ || !args->output ||
-                            XMEMCMP(args->output,
-                                &ssl->hsHashes->certHashes, FINISHED_SZ) != 0) {
+                        #if !defined(NO_MD5) && !defined(NO_OLD_TLS)
+                                (
+                                XMEMCMP(args->output,
+                                        &ssl->hsHashes->certHashes.md5,
+                                        WC_MD5_DIGEST_SIZE) != 0
+                                &&
+                        #endif
+                        #ifndef NO_SHA
+                                XMEMCMP(args->output + WC_MD5_DIGEST_SIZE,
+                                        &ssl->hsHashes->certHashes.sha,
+                                        WC_SHA_DIGEST_SIZE) != 0
+                        #endif
+                        #if !defined(NO_MD5) && !defined(NO_OLD_TLS)
+                                )
+                        #endif
+                            ) {
                             ret = VERIFY_CERT_ERROR;
                         }
                     }


### PR DESCRIPTION
This change is to make the intent of the code much clearer by copying each of the buffers with their given lengths rather than relying on them being presented in sequence and using a sum of their lengths.

This code worked as intended since the Hashes.md5 and Hashes.sha buffers happened to be in sequence in the struct Hashes so that a copy of 36 bytes was getting exactly what was desired (md5 and sha digests). However if in the future one of our devs were to modify the layout of that internal structure (Hashes) this could result in the wrong digests getting copied over.

Hashes Structure:

```
 /* hashes type */
 typedef struct Hashes {
     #if !defined(NO_MD5) && !defined(NO_OLD_TLS)
         byte md5[WC_MD5_DIGEST_SIZE];
     #endif
     #if !defined(NO_SHA)
         byte sha[WC_SHA_DIGEST_SIZE];
     #endif
     #ifndef NO_SHA256
         byte sha256[WC_SHA256_DIGEST_SIZE];
     #endif
     #ifdef WOLFSSL_SHA384
         byte sha384[WC_SHA384_DIGEST_SIZE];
     #endif
     #ifdef WOLFSSL_SHA512
         byte sha512[WC_SHA512_DIGEST_SIZE];
     #endif
 } Hashes;
```

Potentially problematic copy (FINISHED_SZ (36), ssl->hsHashes->certHashes.md5 is only WC_MD5_DIGEST_SIZE (16)) :

```
XMEMCPY(ssl->buffers.sig.buffer, (byte*)ssl->hsHashes->certHashes.md5, FINISHED_SZ);
```