### PR TITLE
Rename enumeration definition

### DIFF
--- a/wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h
@@ -42,7 +42,7 @@ typedef enum {
     tsip_Key_RSA1024 = 4,
     tsip_Key_RSA2048 = 5,
     tsip_Key_tls_Rsa2048 = 6,
-    UNKNOWN = -1,
+    tsip_Key_unknown = -1,
 } wolfssl_TSIP_KEY_IV;
 
 enum {


### PR DESCRIPTION
Renamed common naming enum which likely has conflicts with already defined/used.  Renamed it rather than removing it.