### PR TITLE
fix dtl server example of CSharp when freeing stuff

### DIFF
--- a/wrapper/CSharp/wolfSSL-DTLS-Server/wolfSSL-DTLS-Server.cs
+++ b/wrapper/CSharp/wolfSSL-DTLS-Server/wolfSSL-DTLS-Server.cs
@@ -174,8 +174,8 @@ public class wolfSSL_DTLS_Server
         }
 
         Console.WriteLine("At the end freeing stuff");
-        udp.Close();
         wolfssl.shutdown(ssl);
+        udp.Close();
         clean(ssl, ctx);
     }
 }


### PR DESCRIPTION
Close Udpclinet sockets after wolfssl shutting down