### PR TITLE
Add section to assembly files to avoid executable stack

### DIFF
--- a/wolfcrypt/src/aes_asm.S
+++ b/wolfcrypt/src/aes_asm.S
@@ -1333,6 +1333,7 @@ pxor  %xmm4, %xmm3
 pxor   %xmm2, %xmm3
 ret
 
-#if defined(__linux__) && defined(__ELF__)
-    .section .note.GNU-stack,"",%progbits
+/* prevent library to declare stack as executable */
+#if defined(__ELF__) && defined(__linux__)
+        .section	.note.GNU-stack,"",%progbits
 #endif

--- a/wolfcrypt/src/aes_gcm_asm.S
+++ b/wolfcrypt/src/aes_gcm_asm.S
@@ -8731,3 +8731,8 @@ L_AES_GCM_decrypt_avx2_cmp_tag_done:
 .size	AES_GCM_decrypt_avx2,.-AES_GCM_decrypt_avx2
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+/* prevent library to declare stack as executable */
+#if defined(__ELF__) && defined(__linux__)
+        .section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/chacha_asm.S
+++ b/wolfcrypt/src/chacha_asm.S
@@ -1418,3 +1418,8 @@ L_chacha20_avx2_end256:
 .size	chacha_encrypt_avx2,.-chacha_encrypt_avx2
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+/* prevent library to declare stack as executable */
+#if defined(__ELF__) && defined(__linux__)
+        .section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/fe_x25519_asm.S
+++ b/wolfcrypt/src/fe_x25519_asm.S
@@ -16540,3 +16540,8 @@ _fe_ge_sub_avx2:
 .size	fe_ge_sub_avx2,.-fe_ge_sub_avx2
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+/* prevent library to declare stack as executable */
+#if defined(__ELF__) && defined(__linux__)
+        .section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/poly1305_asm.S
+++ b/wolfcrypt/src/poly1305_asm.S
@@ -1103,3 +1103,8 @@ L_poly1305_avx2_final_cmp_copy:
 .size	poly1305_final_avx2,.-poly1305_final_avx2
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+/* prevent library to declare stack as executable */
+#if defined(__ELF__) && defined(__linux__)
+        .section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/port/arm/armv8-32-curve25519.S
+++ b/wolfcrypt/src/port/arm/armv8-32-curve25519.S
@@ -6010,3 +6010,8 @@ fe_ge_sub:
 	.size	fe_ge_sub,.-fe_ge_sub
 #endif /* !__aarch64__ */
 #endif /* WOLFSSL_ARMASM */
+
+/* prevent library to declare stack as executable */
+#if defined(__ELF__) && defined(__linux__)
+        .section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
@@ -5333,3 +5333,8 @@ L_sha512_len_neon_start:
 #endif /* !WOLFSSL_ARMASM_NO_NEON */
 #endif /* !__aarch64__ */
 #endif /* WOLFSSL_ARMASM */
+
+/* prevent library to declare stack as executable */
+#if defined(__ELF__) && defined(__linux__)
+        .section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/port/arm/armv8-curve25519.S
+++ b/wolfcrypt/src/port/arm/armv8-curve25519.S
@@ -6713,3 +6713,8 @@ fe_ge_sub:
 	ret
 	.size	fe_ge_sub,.-fe_ge_sub
 #endif /* __aarch64__ */
+
+/* prevent library to declare stack as executable */
+#if defined(__ELF__) && defined(__linux__)
+        .section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/port/arm/armv8-sha512-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-sha512-asm.S
@@ -1044,3 +1044,8 @@ L_sha512_len_neon_start:
 	ret
 	.size	Transform_Sha512_Len,.-Transform_Sha512_Len
 #endif /* __aarch64__ */
+
+/* prevent library to declare stack as executable */
+#if defined(__ELF__) && defined(__linux__)
+        .section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/sha256_asm.S
+++ b/wolfcrypt/src/sha256_asm.S
@@ -22651,3 +22651,8 @@ L_sha256_len_avx2_rorx_done:
 .size	Transform_Sha256_AVX2_RORX_Len,.-Transform_Sha256_AVX2_RORX_Len
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+/* prevent library to declare stack as executable */
+#if defined(__ELF__) && defined(__linux__)
+        .section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/sha512_asm.S
+++ b/wolfcrypt/src/sha512_asm.S
@@ -10739,3 +10739,8 @@ L_sha512_len_avx2_rorx_done:
 .size	Transform_Sha512_AVX2_RORX_Len,.-Transform_Sha512_AVX2_RORX_Len
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+/* prevent library to declare stack as executable */
+#if defined(__ELF__) && defined(__linux__)
+        .section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/sp_x86_64_asm.S
+++ b/wolfcrypt/src/sp_x86_64_asm.S
@@ -34779,3 +34779,8 @@ _sp_384_mul_d_avx2_6:
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
 #endif /* WOLFSSL_SP_384 */
+
+/* prevent library to declare stack as executable */
+#if defined(__ELF__) && defined(__linux__)
+        .section	.note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
When build as dependency for mariadb these assembly files cause the resulting library to declare the stack as executable.
Lintian warns like:

    W: libmariadbd19: shlib-with-executable-stack usr/lib/x86_64-linux-gnu/libmariadbd.so.19

and SELinux triggers on map() calls due to the executable stack:

    type=PROCTITLE msg=audit(02/25/20 00:29:15.732:13133) : proctitle=/usr/sbin/mysqld
    type=MMAP msg=audit(02/25/20 00:29:15.732:13133) : fd=162 flags=MAP_SHARED|MAP_NORESERVE
    type=SYSCALL msg=audit(02/25/20 00:29:15.732:13133) : arch=x86_64 syscall=mmap per=unknown-personality(0x400000) success=yes exit=140459061235712 a0=0x0 a1=0x7 a2=PROT_READ|PROT_WRITE a3=MAP_SHARED|MAP_NORESERVE items=0 ppid=1 pid=1397327 auid=unset uid=mysql gid=mysql euid=mysql suid=mysql fsuid=mysql egid=mysql sgid=mysql fsgid=mysql tty=(none) ses=unset comm=mysqld exe=/usr/sbin/mysqld subj=system_u:system_r:mysqld_t:s0 key=(null)
    type=AVC msg=audit(02/25/20 00:29:15.732:13133) : avc:  denied  { execute } for  pid=1397327 comm=mysqld path=/tmp/#sql_15524f_0.MAD dev="sda1" ino=786732 scontext=system_u:system_r:mysqld_t:s0 tcontext=system_u:object_r:mysqld_tmp_t:s0 tclass=file permissive=1
    ----
    type=PROCTITLE msg=audit(02/25/20 00:29:32.088:13134) : proctitle=/usr/sbin/mysqld
    type=SYSCALL msg=audit(02/25/20 00:29:32.088:13134) : arch=x86_64 syscall=mprotect per=unknown-personality(0x400000) success=yes exit=0 a0=0x7fbf1c2be000 a1=0x5000 a2=PROT_READ|PROT_WRITE a3=0x7fbf1c2be000 items=0 ppid=1 pid=1397327 auid=unset uid=mysql gid=mysql euid=mysql suid=mysql fsuid=mysql egid=mysql sgid=mysql fsgid=mysql tty=(none) ses=unset comm=mysqld exe=/usr/sbin/mysqld subj=system_u:system_r:mysqld_t:s0 key=(null)
    type=AVC msg=audit(02/25/20 00:29:32.088:13134) : avc:  denied  { execmem } for  pid=1397327 comm=mysqld scontext=system_u:system_r:mysqld_t:s0 tcontext=system_u:system_r:mysqld_t:s0 tclass=process permissive=1
    ----
    type=PROCTITLE msg=audit(02/25/20 00:31:02.198:13135) : proctitle=/usr/sbin/mysqld
    type=SYSCALL msg=audit(02/25/20 00:31:02.198:13135) : arch=x86_64 syscall=mprotect per=unknown-personality(0x400000) success=yes exit=0 a0=0x7fbef0032000 a1=0x4000 a2=PROT_READ|PROT_WRITE a3=0x7fbef0032000 items=0 ppid=1 pid=1397327 auid=unset uid=mysql gid=mysql euid=mysql suid=mysql fsuid=mysql egid=mysql sgid=mysql fsgid=mysql tty=(none) ses=unset comm=mysqld exe=/usr/sbin/mysqld subj=system_u:system_r:mysqld_t:s0 key=(null)
    type=AVC msg=audit(02/25/20 00:31:02.198:13135) : avc:  denied  { execmem } for  pid=1397327 comm=mysqld scontext=system_u:system_r:mysqld_t:s0 tcontext=system_u:system_r:mysqld_t:s0 tclass=process permissive=1
    ----
    type=PROCTITLE msg=audit(02/25/20 00:50:30.784:13436) : proctitle=/usr/sbin/mysqld
    type=MMAP msg=audit(02/25/20 00:50:30.784:13436) : fd=3 flags=MAP_PRIVATE
    type=SYSCALL msg=audit(02/25/20 00:50:30.784:13436) : arch=x86_64 syscall=mmap per=unknown-personality(0x400000) success=no exit=EACCES(Permission denied) a0=0x0 a1=0x4d12 a2=PROT_READ a3=MAP_PRIVATE items=0 ppid=1 pid=1400666 auid=unset uid=mysql gid=mysql euid=mysql suid=mysql fsuid=mysql egid=mysql sgid=mysql fsgid=mysql tty=(none) ses=unset comm=mysqld exe=/usr/sbin/mysqld subj=system_u:system_r:mysqld_t:s0 key=(null)
    type=AVC msg=audit(02/25/20 00:50:30.784:13436) : avc:  denied  { execute } for  pid=1400666 comm=mysqld path=/etc/ld.so.cache dev="sda1" ino=1048745 scontext=system_u:system_r:mysqld_t:s0 tcontext=root:object_r:ld_so_cache_t:s0 tclass=file permissive=0

Add a GNU-stack note to prevent it.