### PR TITLE
compile for NO_WOLFSSL_STUB

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -21031,9 +21031,11 @@ int wolfSSL_sk_push(WOLFSSL_STACK* sk, const void *data)
         case STACK_TYPE_X509:
             ret = wolfSSL_sk_X509_push(sk, (WOLFSSL_X509*) data);
             break;
+        #ifndef NO_WOLFSSL_STUB
         case STACK_TYPE_CIPHER:
             ret = wolfSSL_sk_CIPHER_push(sk, (WOLFSSL_CIPHER*) data);
             break;
+        #endif
         case STACK_TYPE_GEN_NAME:
             ret = wolfSSL_sk_ASN1_OBJECT_push(sk, (WOLFSSL_ASN1_OBJECT*) data);
             break;
@@ -41811,7 +41813,6 @@ err:
         return (ret == 0) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
     }
 
-    #ifndef NO_WOLFSSL_STUB
     int wolfSSL_BIO_read_filename(WOLFSSL_BIO *b, const char *name) {
     #ifndef NO_FILESYSTEM
         XFILE fp;
@@ -41840,7 +41841,6 @@ err:
         return WOLFSSL_NOT_IMPLEMENTED;
     #endif
     }
-    #endif
 
     /* Return the corresponding short name for the nid <n>.
      * or NULL if short name can't be found.

--- a/tests/api.c
+++ b/tests/api.c
@@ -25802,6 +25802,7 @@ static void test_wolfSSL_RSA_meth(void)
     AssertNotNull(rsa_meth =
             RSA_meth_new("placeholder RSA method", RSA_METHOD_FLAG_NO_CHECK));
 
+#ifndef NO_WOLFSSL_STUB
     AssertIntEQ(RSA_meth_set_pub_enc(rsa_meth, NULL), 1);
     AssertIntEQ(RSA_meth_set_pub_dec(rsa_meth, NULL), 1);
     AssertIntEQ(RSA_meth_set_priv_enc(rsa_meth, NULL), 1);
@@ -25809,6 +25810,7 @@ static void test_wolfSSL_RSA_meth(void)
     AssertIntEQ(RSA_meth_set_init(rsa_meth, NULL), 1);
     AssertIntEQ(RSA_meth_set_finish(rsa_meth, NULL), 1);
     AssertIntEQ(RSA_meth_set0_app_data(rsa_meth, NULL), 1);
+#endif
 
     AssertNotNull(rsa = RSA_new());
     AssertIntEQ(RSA_set_method(rsa, rsa_meth), 1);
@@ -31177,7 +31179,9 @@ static void test_openssl_generate_key_and_cert(void)
         AssertNotNull(pkey);
         AssertNotNull(ec_key);
 
+    #ifndef NO_WOLFSSL_STUB
         EC_KEY_set_asn1_flag(ec_key, OPENSSL_EC_NAMED_CURVE);
+    #endif
 
         AssertIntNE(EC_KEY_generate_key(ec_key), 0);
         AssertIntNE(EVP_PKEY_assign_EC_KEY(pkey, ec_key), 0);


### PR DESCRIPTION
Fix for build "./configure --enable-all CPPFLAGS=-DNO_WOLFSSL_STUB"


Expected to have 2 warnings with the build because the flags are not implemented yet
```
  CC       wolfcrypt/test/test.o
src/ssl.c: In function 'wolfSSL_X509_print_ex':
src/ssl.c:23386:23: warning: unused parameter 'nmflags' [-Wunused-parameter]
23386 |         unsigned long nmflags, unsigned long cflag)
      |         ~~~~~~~~~~~~~~^~~~~~~
src/ssl.c:23386:46: warning: unused parameter 'cflag' [-Wunused-parameter]
23386 |         unsigned long nmflags, unsigned long cflag)
      |                                ~~~~~~~~~~~~~~^~~~~
```
