### PR TITLE
Fix for TLS server with TLSv1.2 or less `wolfSSL_get_curve_name`

### DIFF
--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -1481,7 +1481,7 @@ WOLFSSL_API int wc_EccKeyToDer(ecc_key*, byte* output, word32 inLen);
     word32 idx = 0;
     byte buff[] = { // initialize with key };
     ecc_key pubKey;
-    wc_ecc_init_key(&pubKey);
+    wc_ecc_init(&pubKey);
     if ( wc_EccPublicKeyDecode(buff, &idx, &pubKey, sizeof(buff)) != 0) {
             // error decoding key
     }

--- a/doc/dox_comments/header_files/ecc.h
+++ b/doc/dox_comments/header_files/ecc.h
@@ -1012,7 +1012,7 @@ int wc_ecc_export_x963_ex(ecc_key*, byte* out, word32* outLen, int compressed);
     byte buff[] = { initialize with ANSI X9.63 formatted key };
 
     ecc_key pubKey;
-    wc_ecc_init_key(&pubKey);
+    wc_ecc_init(&pubKey);
 
     ret = wc_ecc_import_x963(buff, sizeof(buff), &pubKey);
     if ( ret != 0) {
@@ -1081,7 +1081,7 @@ NOT_COMPILED_IN Returned if the HAVE_COMP_KEY was not enabled at compile
     byte priv[] = { initialize with the raw private key };
 
     ecc_key key;
-    wc_ecc_init_key(&key);
+    wc_ecc_init(&key);
     ret = wc_ecc_import_private_key(priv, sizeof(priv), pub, sizeof(pub),
     &key);
     if ( ret != 0) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -18867,7 +18867,9 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
                                       ssl->suites->sigAlgo == ecc_dsa_sa_algo) {
                 ssl->suites->sigAlgo = sigAlgo;
                 ssl->suites->hashAlgo = sha512_mac;
+            #if defined(WOLFSSL_TLS13) || defined(HAVE_FFDHE)
                 ssl->namedGroup = 0;
+            #endif
                 ret = 0;
                 break;
             }
@@ -18882,7 +18884,9 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
                                       ssl->suites->sigAlgo == ecc_dsa_sa_algo) {
                 ssl->suites->sigAlgo = sigAlgo;
                 ssl->suites->hashAlgo = sha512_mac;
+            #if defined(WOLFSSL_TLS13) || defined(HAVE_FFDHE)
                 ssl->namedGroup = 0;
+            #endif
                 ret = 0;
                 break;
             }
@@ -18904,7 +18908,9 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
             if (digestSz == ssl->eccTempKeySz) {
                 ssl->suites->hashAlgo = hashAlgo;
                 ssl->suites->sigAlgo = sigAlgo;
+            #if defined(WOLFSSL_TLS13) || defined(HAVE_FFDHE)
                 ssl->namedGroup = 0;
+            #endif
                 ret = 0;
                 break; /* done selected sig/hash algorithms */
             }
@@ -18915,7 +18921,9 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
             /* mark as highest and check remainder of hashSigAlgo list */
             ssl->suites->hashAlgo = hashAlgo;
             ssl->suites->sigAlgo = sigAlgo;
+        #if defined(WOLFSSL_TLS13) || defined(HAVE_FFDHE)
             ssl->namedGroup = 0;
+        #endif
             ret = 0;
         }
         else
@@ -18956,7 +18964,9 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
                     /* mark as highest and check remainder of hashSigAlgo list */
                     ssl->suites->hashAlgo = hashAlgo;
                     ssl->suites->sigAlgo = sigAlgo;
+                #if defined(WOLFSSL_TLS13) || defined(HAVE_FFDHE)
                     ssl->namedGroup = 0;
+                #endif
                     break;
                 default:
                     continue;

--- a/src/internal.c
+++ b/src/internal.c
@@ -18915,6 +18915,7 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
             /* mark as highest and check remainder of hashSigAlgo list */
             ssl->suites->hashAlgo = hashAlgo;
             ssl->suites->sigAlgo = sigAlgo;
+            ssl->namedGroup = 0;
             ret = 0;
         }
         else
@@ -18955,6 +18956,7 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
                     /* mark as highest and check remainder of hashSigAlgo list */
                     ssl->suites->hashAlgo = hashAlgo;
                     ssl->suites->sigAlgo = sigAlgo;
+                    ssl->namedGroup = 0;
                     break;
                 default:
                     continue;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11963,20 +11963,41 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     }
     WOLFSSL_METHOD* wolfSSLv23_method_ex(void* heap)
     {
-        WOLFSSL_METHOD* m;
+        WOLFSSL_METHOD* m = NULL;
         WOLFSSL_ENTER("SSLv23_method");
     #if !defined(NO_WOLFSSL_CLIENT)
         m = wolfSSLv23_client_method_ex(heap);
-        m->side = WOLFSSL_NEITHER_END;
     #elif !defined(NO_WOLFSSL_SERVER)
         m = wolfSSLv23_server_method_ex(heap);
-        m->side = WOLFSSL_NEITHER_END;
-    #else
-        m = NULL;
     #endif
+        if (m != NULL) {
+            m->side = WOLFSSL_NEITHER_END;
+        }
 
         return m;
     }
+
+    #ifdef WOLFSSL_ALLOW_SSLV3
+    WOLFSSL_METHOD* wolfSSLv3_method(void)
+    {
+        return wolfSSLv3_method_ex(NULL);
+    }
+    WOLFSSL_METHOD* wolfSSLv3_method_ex(void* heap)
+    {
+        WOLFSSL_METHOD* m = NULL;
+        WOLFSSL_ENTER("SSLv3_method");
+    #if !defined(NO_WOLFSSL_CLIENT)
+        m = wolfSSLv3_client_method_ex(heap);
+    #elif !defined(NO_WOLFSSL_SERVER)
+        m = wolfSSLv3_server_method_ex(heap);
+    #endif
+        if (m != NULL) {
+            m->side = WOLFSSL_NEITHER_END;
+        }
+
+        return m;
+    }
+    #endif
 #endif /* OPENSSL_EXTRA || WOLFSSL_EITHER_SIDE */
 
 /* client only parts */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -659,6 +659,7 @@ typedef WOLFSSL_METHOD* (*wolfSSL_method_func)(void* heap);
 /* CTX Method EX Constructor Functions */
 WOLFSSL_API WOLFSSL_METHOD *wolfTLS_client_method_ex(void* heap);
 WOLFSSL_API WOLFSSL_METHOD *wolfTLS_server_method_ex(void* heap);
+WOLFSSL_API WOLFSSL_METHOD *wolfSSLv3_method_ex(void* heap);
 WOLFSSL_API WOLFSSL_METHOD *wolfSSLv3_server_method_ex(void* heap);
 WOLFSSL_API WOLFSSL_METHOD *wolfSSLv3_client_method_ex(void* heap);
 WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_method_ex(void* heap);
@@ -695,6 +696,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfSSLv23_client_method_ex(void* heap);
 /* CTX Method Constructor Functions */
 WOLFSSL_API WOLFSSL_METHOD *wolfTLS_client_method(void);
 WOLFSSL_API WOLFSSL_METHOD *wolfTLS_server_method(void);
+WOLFSSL_API WOLFSSL_METHOD *wolfSSLv3_method(void);
 WOLFSSL_API WOLFSSL_METHOD *wolfSSLv23_method(void);
 WOLFSSL_API WOLFSSL_METHOD *wolfSSLv3_server_method(void);
 WOLFSSL_API WOLFSSL_METHOD *wolfSSLv3_client_method(void);


### PR DESCRIPTION
* Fix for TLS server reporting the incorrect curve using `wolfSSL_get_curve_name` with ECDHE and TLS v1.2 or less. The `PickHashSigAlgo` needed to clear `ssl->namedGroup` to indicate a named group was not used.
* Fix for typo with `wc_ecc_init` in documentation.
* Added "either" side functions for SSLv3. These are only enabled with `WOLFSSL_EITHER_SIDE` and `WOLFSSL_ALLOW_SSLV3`. ZD 9984.