### PR TITLE
HMAC Init

### DIFF
--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -293,10 +293,16 @@ int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
         return BAD_FUNC_ARG;
     }
 
+#ifndef HAVE_FIPS
     /* if set key has already been run then make sure and free existing */
-    if (hmac->macType != 0) {
+    /* This is for async and PIC32MZ situations, and just normally OK,
+       provided the user calls wc_HmacInit() first. That function is not
+       available in FIPS builds. In current FIPS builds, the hashes are
+       not allocating resources. */
+    if (hmac->macType != WC_HASH_TYPE_NONE) {
         wc_HmacFree(hmac);
     }
+#endif
 
     hmac->innerHashKeyed = 0;
     hmac->macType = (byte)type;
@@ -979,6 +985,7 @@ int wc_HmacInit(Hmac* hmac, void* heap, int devId)
         return BAD_FUNC_ARG;
 
     XMEMSET(hmac, 0, sizeof(Hmac));
+    hmac->macType = WC_HASH_TYPE_NONE;
     hmac->heap = heap;
 #ifdef WOLF_CRYPTO_CB
     hmac->devId = devId;


### PR DESCRIPTION
wc_HmacSetKey() has a check against the hmac's type that assumes one has called wc_HmacInit() on the object first. In FIPS Ready builds we do not have wc_HmacInit() in the boundary. This change removes that check and action when making a FIPS build. The free called doesn't do anything in the FIPS build case.