### PR TITLE
Check length to avoid XSTRNCMP accessing  memory after `list`

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -33138,7 +33138,7 @@ const char* wolfSSL_EC_curve_nid2nist(int nid)
 static int populate_groups(int* groups, int max_count, char *list)
 {
     char *end;
-    size_t len;
+    int len;
     int count = 0;
     const WOLF_EC_NIST_NAME* nist_name;
 
@@ -33152,8 +33152,8 @@ static int populate_groups(int* groups, int max_count, char *list)
             return -1;
         }
         while (*end != ':' && *end != '\0') end++;
-        len = end - list; /* end points to char after end
-                           * of curve name so no need for -1 */
+        len = (int)(end - list); /* end points to char after end
+                                  * of curve name so no need for -1 */
         if ((len < kNistCurves_MIN_NAME_LEN) ||
                 (len > kNistCurves_MAX_NAME_LEN)) {
             WOLFSSL_MSG("Unrecognized curve name in list");

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -33160,7 +33160,8 @@ static int populate_groups(int* groups, int max_count, char *list)
             return -1;
         }
         for (nist_name = kNistCurves; nist_name->name != NULL; nist_name++) {
-            if (XSTRNCMP(list, nist_name->name, nist_name->name_len) == 0) {
+            if (len == nist_name->name_len &&
+                    XSTRNCMP(list, nist_name->name, nist_name->name_len) == 0) {
                 break;
             }
         }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4239,7 +4239,7 @@ static const byte tls_server[FINISHED_LABEL_SZ + 1] = "server finished";
 
 #ifdef OPENSSL_EXTRA
 typedef struct {
-    int name_len;
+    size_t name_len;
     const char *name;
     int nid;
 } WOLF_EC_NIST_NAME;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4239,7 +4239,7 @@ static const byte tls_server[FINISHED_LABEL_SZ + 1] = "server finished";
 
 #ifdef OPENSSL_EXTRA
 typedef struct {
-    size_t name_len;
+    int name_len;
     const char *name;
     int nid;
 } WOLF_EC_NIST_NAME;


### PR DESCRIPTION
Check length to avoid XSTRNCMP accessing  memory after `list`. If `nist_name->name_len` > `len` for the last curve then it is possible that `XSTRNCMP` could read from memory that was not allocated.