### PR TITLE
Fix memory leak

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -36119,18 +36119,22 @@ int wolfSSL_EC_POINT_get_affine_coordinates_GFp(const WOLFSSL_EC_GROUP *group,
         /* Map the Jacobian point back to affine space */
         if (mp_read_radix(&modulus, ecc_sets[group->curve_idx].prime, MP_RADIX_HEX) != MP_OKAY) {
             WOLFSSL_MSG("mp_read_radix failed");
+            mp_clear(&modulus);
             return WOLFSSL_FAILURE;
         }
         if (mp_montgomery_setup(&modulus, &mp) != MP_OKAY) {
             WOLFSSL_MSG("mp_montgomery_setup failed");
+            mp_clear(&modulus);
             return WOLFSSL_FAILURE;
         }
         if (ecc_map((ecc_point*)point->internal, &modulus, mp) != MP_OKAY) {
             WOLFSSL_MSG("ecc_map failed");
+            mp_clear(&modulus);
             return WOLFSSL_FAILURE;
         }
         if (SetECPointExternal((WOLFSSL_EC_POINT *)point) != WOLFSSL_SUCCESS) {
             WOLFSSL_MSG("SetECPointExternal failed");
+            mp_clear(&modulus);
             return WOLFSSL_FAILURE;
         }
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -18298,7 +18298,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
-                ret = wc_AesXtsSetKey(&ctx->cipher.xts, key, ctx->keyLen, 
+                ret = wc_AesXtsSetKey(&ctx->cipher.xts, key, ctx->keyLen,
                     ctx->enc ? AES_ENCRYPTION : AES_DECRYPTION, NULL, 0);
                 if (ret != 0) {
                     WOLFSSL_MSG("wc_AesXtsSetKey() failed");
@@ -18328,7 +18328,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             if (enc == 0 || enc == 1)
                 ctx->enc = enc ? 1 : 0;
             if (key) {
-                ret = wc_AesXtsSetKey(&ctx->cipher.xts, key, ctx->keyLen, 
+                ret = wc_AesXtsSetKey(&ctx->cipher.xts, key, ctx->keyLen,
                         ctx->enc ? AES_ENCRYPTION : AES_DECRYPTION, NULL, 0);
                 if (ret != 0) {
                     WOLFSSL_MSG("wc_AesXtsSetKey() failed");
@@ -36137,6 +36137,7 @@ int wolfSSL_EC_POINT_get_affine_coordinates_GFp(const WOLFSSL_EC_GROUP *group,
 
     BN_copy(x, point->X);
     BN_copy(y, point->Y);
+    mp_clear(&modulus);
 
     return WOLFSSL_SUCCESS;
 }
@@ -48640,8 +48641,10 @@ int wolfSSL_BN_clear_bit(WOLFSSL_BIGNUM* bn, int n)
             goto cleanup;
         }
     }
+
     ret = WOLFSSL_SUCCESS;
 cleanup:
+    mp_clear(tmp);
 #ifdef WOLFSSL_SMALL_STACK
     if (tmp)
         XFREE(tmp, NULL, DYNAMIC_TYPE_BIGINT);

--- a/tests/api.c
+++ b/tests/api.c
@@ -1839,7 +1839,6 @@ static void test_wolfSSL_EC(void)
     /* Force non-affine coordinates */
     AssertIntEQ(wolfSSL_BN_add(new_point->Z, (WOLFSSL_BIGNUM*)BN_value_one(),
                                              (WOLFSSL_BIGNUM*)BN_value_one()), 1);
-    new_point->inSet = 0;
 
     /* extract the coordinates from point */
     AssertIntEQ(EC_POINT_get_affine_coordinates_GFp(group, new_point, X, Y, ctx), WOLFSSL_SUCCESS);


### PR DESCRIPTION
This PR fixes memory leaks detected with Valgrind with this configuration.

./configure C_FLAGS="-fdebug-types-section -g1" CPPFLAGS="-DWOLFSSL_OLD_PRIME_CHECK" --disable-shared --enable-static --enable-certgen --enable-certreq --enable-sha512 --enable-opensslextra --enable-hashdrbg --enable-sessioncerts --enable-keygen --enable-crl --enable-ecc --enable-dsa --enable-hkdf --disable-fpecc --enable-eccencrypt --enable-savecert --enable-supportedcurves --disable-fastmath

```
==17139== HEAP SUMMARY:
==17139==     in use at exit: 344 bytes in 5 blocks
==17139==   total heap usage: 7,674,535 allocs, 7,674,530 frees, 1,075,828,562 bytes allocated
==17139== 
==17139== Searching for pointers to 5 not-freed blocks
==17139== Checked 714,112 bytes
==17139== 
==17139== 32 bytes in 1 blocks are definitely lost in loss record 1 of 5
==17139==    at 0x4C2FDE0: malloc (vg_replace_malloc.c:308)
==17139==    by 0x4C32130: realloc (vg_replace_malloc.c:836)
==17139==    by 0x1764C5: mp_grow (integer.c:428)
==17139==    by 0x17785B: mp_set_bit (integer.c:2843)
==17139==    by 0x1A7249: wolfSSL_BN_clear_bit (ssl.c:48636)
==17139==    by 0x122202: test_wolfSSL_BN (api.c:22524)
==17139==    by 0x14CF10: ApiTest (api.c:31686)
==17139==    by 0x10F3F1: unit_test (unit.c:76)
==17139==    by 0x541BB96: (below main) (libc-start.c:310)
==17139== 
==17139== 48 bytes in 1 blocks are definitely lost in loss record 2 of 5
==17139==    at 0x4C321AF: realloc (vg_replace_malloc.c:836)
==17139==    by 0x1764C5: mp_grow (integer.c:428)
==17139==    by 0x17AA85: mp_add_d (integer.c:4229)
==17139==    by 0x17B5F2: mp_read_radix (integer.c:5137)
==17139==    by 0x1AA076: wolfSSL_EC_POINT_get_affine_coordinates_GFp (ssl.c:36120)
==17139==    by 0x13A652: test_wolfSSL_EC (api.c:1845)
==17139==    by 0x1523A6: ApiTest (api.c:32003)
==17139==    by 0x10F3F1: unit_test (unit.c:76)
==17139==    by 0x541BB96: (below main) (libc-start.c:310)
==17139== 
==17139== 56 bytes in 1 blocks are definitely lost in loss record 3 of 5
==17139==    at 0x4C2FDE0: malloc (vg_replace_malloc.c:308)
==17139==    by 0x4C32130: realloc (vg_replace_malloc.c:836)
==17139==    by 0x1764C5: mp_grow (integer.c:428)
==17139==    by 0x176552: mp_copy (integer.c:376)
==17139==    by 0x17D0D5: wc_ecc_mulmod_ex (ecc.c:2933)
==17139==    by 0x17D161: wc_ecc_mulmod (ecc.c:3001)
==17139==    by 0x1AA1EE: wolfSSL_EC_POINT_mul (ssl.c:36228)
==17139==    by 0x13A525: test_wolfSSL_EC (api.c:1834)
==17139==    by 0x1523A6: ApiTest (api.c:32003)
==17139==    by 0x10F3F1: unit_test (unit.c:76)
==17139==    by 0x541BB96: (below main) (libc-start.c:310)
==17139== 
==17139== 104 bytes in 1 blocks are definitely lost in loss record 4 of 5
==17139==    at 0x4C321AF: realloc (vg_replace_malloc.c:836)
==17139==    by 0x1764C5: mp_grow (integer.c:428)
==17139==    by 0x178D34: fast_s_mp_mul_digs (integer.c:3346)
==17139==    by 0x1791F1: mp_mul (integer.c:3039)
==17139==    by 0x17CA46: ecc_map (ecc.c:2424)
==17139==    by 0x17D0FE: wc_ecc_mulmod_ex (ecc.c:2939)
==17139==    by 0x17D161: wc_ecc_mulmod (ecc.c:3001)
==17139==    by 0x1AA1EE: wolfSSL_EC_POINT_mul (ssl.c:36228)
==17139==    by 0x13A525: test_wolfSSL_EC (api.c:1834)
==17139==    by 0x1523A6: ApiTest (api.c:32003)
==17139==    by 0x10F3F1: unit_test (unit.c:76)
==17139==    by 0x541BB96: (below main) (libc-start.c:310)
==17139== 
==17139== 104 bytes in 1 blocks are definitely lost in loss record 5 of 5
==17139==    at 0x4C321AF: realloc (vg_replace_malloc.c:836)
==17139==    by 0x1764C5: mp_grow (integer.c:428)
==17139==    by 0x178D34: fast_s_mp_mul_digs (integer.c:3346)
==17139==    by 0x1791F1: mp_mul (integer.c:3039)
==17139==    by 0x17CA6E: ecc_map (ecc.c:2428)
==17139==    by 0x17D0FE: wc_ecc_mulmod_ex (ecc.c:2939)
==17139==    by 0x17D161: wc_ecc_mulmod (ecc.c:3001)
==17139==    by 0x1AA1EE: wolfSSL_EC_POINT_mul (ssl.c:36228)
==17139==    by 0x13A525: test_wolfSSL_EC (api.c:1834)
==17139==    by 0x1523A6: ApiTest (api.c:32003)
==17139==    by 0x10F3F1: unit_test (unit.c:76)
==17139==    by 0x541BB96: (below main) (libc-start.c:310)
==17139== 
==17139== LEAK SUMMARY:
==17139==    definitely lost: 344 bytes in 5 blocks
==17139==    indirectly lost: 0 bytes in 0 blocks
==17139==      possibly lost: 0 bytes in 0 blocks
==17139==    still reachable: 0 bytes in 0 blocks
==17139==         suppressed: 0 bytes in 0 blocks
==17139== 
==17139== ERROR SUMMARY: 5 errors from 5 contexts (suppressed: 0 from 0)
```