### PR TITLE
Fixes for Xilinx SDK and Zynq UltraScale+ MPSoC

### DIFF
--- a/IDE/XilinxSDK/.cproject
+++ b/IDE/XilinxSDK/.cproject
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="xilinx.gnu.arm.a53.exe.debug.1827297552">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="xilinx.gnu.arm.a53.exe.debug.1827297552" moduleId="org.eclipse.cdt.core.settings" name="Debug">
+				<externalSettings/>
+				<extensions>
+					<extension id="com.xilinx.sdk.managedbuilder.XELF.arm.a53" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactExtension="elf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" id="xilinx.gnu.arm.a53.exe.debug.1827297552" name="Debug" parent="xilinx.gnu.arm.a53.exe.debug">
+					<folderInfo id="xilinx.gnu.arm.a53.exe.debug.1827297552." name="/" resourcePath="">
+						<toolChain id="xilinx.gnu.arm.a53.exe.debug.toolchain.1778690979" name="Xilinx ARM v8 GNU Toolchain" superClass="xilinx.gnu.arm.a53.exe.debug.toolchain">
+							<targetPlatform binaryParser="com.xilinx.sdk.managedbuilder.XELF.arm.a53" id="xilinx.arm.a53.target.gnu.base.debug.1998927146" isAbstract="false" name="Debug Platform" superClass="xilinx.arm.a53.target.gnu.base.debug"/>
+							<builder buildPath="${workspace_loc:/wolfcrypt}/Debug" enableAutoBuild="false" id="xilinx.gnu.arm.a53.toolchain.builder.debug.1050904189" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="GNU make" parallelBuildOn="true" parallelizationNumber="optimal" superClass="xilinx.gnu.arm.a53.toolchain.builder.debug"/>
+							<tool id="xilinx.gnu.arm.a53.c.toolchain.assembler.debug.1235650078" name="ARM v8 gcc assembler" superClass="xilinx.gnu.arm.a53.c.toolchain.assembler.debug">
+								<inputType id="xilinx.gnu.assembler.input.1793262662" superClass="xilinx.gnu.assembler.input"/>
+							</tool>
+							<tool id="xilinx.gnu.arm.a53.c.toolchain.compiler.debug.1150820611" name="ARM v8 gcc compiler" superClass="xilinx.gnu.arm.a53.c.toolchain.compiler.debug">
+								<option defaultValue="gnu.c.optimization.level.none" id="xilinx.gnu.compiler.option.optimization.level.1778867695" name="Optimization Level" superClass="xilinx.gnu.compiler.option.optimization.level" value="gnu.c.optimization.level.none" valueType="enumerated"/>
+								<option id="xilinx.gnu.compiler.option.debugging.level.411446517" name="Debug Level" superClass="xilinx.gnu.compiler.option.debugging.level" value="gnu.c.debugging.level.max" valueType="enumerated"/>
+								<option id="xilinx.gnu.compiler.inferred.swplatform.includes.280052319" name="Software Platform Include Path" superClass="xilinx.gnu.compiler.inferred.swplatform.includes" valueType="includePath">
+									<listOptionValue builtIn="false" value="../../standalone_bsp_0/psu_cortexa53_0/include"/>
+								</option>
+								<option id="xilinx.gnu.compiler.inferred.swplatform.flags.1025792701" name="Software Platform Inferred Flags" superClass="xilinx.gnu.compiler.inferred.swplatform.flags" value=" " valueType="string"/>
+								<option id="xilinx.gnu.compiler.symbols.defined.1615500863" name="Defined symbols (-D)" superClass="xilinx.gnu.compiler.symbols.defined" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="WOLFSSL_USER_SETTINGS"/>
+								</option>
+								<option id="xilinx.gnu.compiler.dircategory.includes.146371306" name="Include Paths" superClass="xilinx.gnu.compiler.dircategory.includes" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/IDE/XilinxSDK}&quot;"/>
+								</option>
+								<option id="xilinx.gnu.compiler.misc.other.673474022" name="Other flags" superClass="xilinx.gnu.compiler.misc.other" value="-mcpu=generic+crypto -mstrict-align -c -fmessage-length=0 -MT&quot;$@&quot;" valueType="string"/>
+								<inputType id="xilinx.gnu.arm.a53.c.compiler.input.1610926744" name="C source files" superClass="xilinx.gnu.arm.a53.c.compiler.input"/>
+							</tool>
+							<tool id="xilinx.gnu.arm.a53.cxx.toolchain.compiler.debug.133197353" name="ARM v8 g++ compiler" superClass="xilinx.gnu.arm.a53.cxx.toolchain.compiler.debug">
+								<option defaultValue="gnu.c.optimization.level.none" id="xilinx.gnu.compiler.option.optimization.level.1375707008" name="Optimization Level" superClass="xilinx.gnu.compiler.option.optimization.level" value="gnu.c.optimization.level.size" valueType="enumerated"/>
+								<option id="xilinx.gnu.compiler.option.debugging.level.220476081" name="Debug Level" superClass="xilinx.gnu.compiler.option.debugging.level" value="gnu.c.debugging.level.max" valueType="enumerated"/>
+								<option id="xilinx.gnu.compiler.inferred.swplatform.includes.1309932230" name="Software Platform Include Path" superClass="xilinx.gnu.compiler.inferred.swplatform.includes" valueType="includePath">
+									<listOptionValue builtIn="false" value="../../standalone_bsp_0/psu_cortexa53_0/include"/>
+								</option>
+								<option id="xilinx.gnu.compiler.inferred.swplatform.flags.1716674098" name="Software Platform Inferred Flags" superClass="xilinx.gnu.compiler.inferred.swplatform.flags" value=" " valueType="string"/>
+								<option id="xilinx.gnu.compiler.symbols.defined.1670072821" name="Defined symbols (-D)" superClass="xilinx.gnu.compiler.symbols.defined" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="WOLFSSL_USER_SETTINGS"/>
+								</option>
+								<option id="xilinx.gnu.compiler.dircategory.includes.448720788" name="Include Paths" superClass="xilinx.gnu.compiler.dircategory.includes" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/IDE/XilinxSDK}&quot;"/>
+								</option>
+								<option id="xilinx.gnu.compiler.misc.other.1805270122" name="Other flags" superClass="xilinx.gnu.compiler.misc.other" value="-mcpu=generic+crypto -mstrict-align -c -fmessage-length=0 -MT&quot;$@&quot;" valueType="string"/>
+							</tool>
+							<tool id="xilinx.gnu.arm.a53.toolchain.archiver.84380305" name="ARM v8 archiver" superClass="xilinx.gnu.arm.a53.toolchain.archiver"/>
+							<tool id="xilinx.gnu.arm.a53.c.toolchain.linker.debug.2013001292" name="ARM v8 gcc linker" superClass="xilinx.gnu.arm.a53.c.toolchain.linker.debug">
+								<option id="xilinx.gnu.linker.inferred.swplatform.lpath.63981241" name="Software Platform Library Path" superClass="xilinx.gnu.linker.inferred.swplatform.lpath" valueType="libPaths">
+									<listOptionValue builtIn="false" value="../../standalone_bsp_0/psu_cortexa53_0/lib"/>
+								</option>
+								<option id="xilinx.gnu.linker.inferred.swplatform.flags.1059714080" name="Software Platform Inferred Flags" superClass="xilinx.gnu.linker.inferred.swplatform.flags" valueType="libs">
+									<listOptionValue builtIn="false" value="-Wl,--start-group,-lxil,-lgcc,-lc,--end-group"/>
+									<listOptionValue builtIn="false" value="-Wl,--start-group,-lxilskey,-lxil,-lgcc,-lc,--end-group"/>
+								</option>
+								<option id="xilinx.gnu.c.linker.option.lscript.2091431004" name="Linker Script" superClass="xilinx.gnu.c.linker.option.lscript" value="../IDE/XilinxSDK/lscript.ld" valueType="string"/>
+								<inputType id="xilinx.gnu.linker.input.423515284" superClass="xilinx.gnu.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+								<inputType id="xilinx.gnu.linker.input.lscript.841596912" name="Linker Script" superClass="xilinx.gnu.linker.input.lscript"/>
+							</tool>
+							<tool id="xilinx.gnu.arm.a53.cxx.toolchain.linker.debug.69747276" name="ARM v8 g++ linker" superClass="xilinx.gnu.arm.a53.cxx.toolchain.linker.debug">
+								<option id="xilinx.gnu.linker.inferred.swplatform.lpath.985393589" name="Software Platform Library Path" superClass="xilinx.gnu.linker.inferred.swplatform.lpath" valueType="libPaths">
+									<listOptionValue builtIn="false" value="../../standalone_bsp_0/psu_cortexa53_0/lib"/>
+								</option>
+								<option id="xilinx.gnu.linker.inferred.swplatform.flags.1689872780" name="Software Platform Inferred Flags" superClass="xilinx.gnu.linker.inferred.swplatform.flags" valueType="libs">
+									<listOptionValue builtIn="false" value="-Wl,--start-group,-lxil,-lgcc,-lc,--end-group"/>
+									<listOptionValue builtIn="false" value="-Wl,--start-group,-lxilskey,-lxil,-lgcc,-lc,--end-group"/>
+								</option>
+								<option id="xilinx.gnu.c.linker.option.lscript.1259834570" name="Linker Script" superClass="xilinx.gnu.c.linker.option.lscript" value="../IDE/XilinxSDK/lscript.ld" valueType="string"/>
+							</tool>
+							<tool id="xilinx.gnu.arm.a53.size.debug.1035168567" name="ARM v8 Print Size" superClass="xilinx.gnu.arm.a53.size.debug"/>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry excluding="wrapper|tirtos|testsuite|tests|swig|support|sslSniffer|scripts|rpm|mqx|mplabx|mcapi|m4|lib|IPP|examples|doc|IDE/zephyr|IDE/XCODE|IDE/WORKBENCH|IDE/WIN-SGX|IDE/WIN10|IDE/WIN|IDE/WICED-STUDIO|IDE/VS-AZURE-SPHERE|IDE/VS-ARM|IDE/TRUESTUDIO|IDE/ROWLEY-CROSSWORKS-ARM|IDE/RISCV|IDE/Renesas|IDE/OPENSTM32|IDE/MYSQL|IDE/mynewt|IDE/MDK-ARM|IDE/MDK5-ARM|IDE/M68K|IDE/LPCXPRESSO|IDE/LINUX-SGX|IDE/KDS|IDE/INTIME-RTOS|IDE/IAR-EWARM|IDE/HEXIWEAR|IDE/HEXAGON|IDE/GCC-ARM|IDE/Espressif|IDE/ECLIPSE|IDE/CSBENCH|IDE/CRYPTOCELL|IDE/ARDUINO|wolfcrypt/src/sp_x86_64_asm.S|wolfcrypt/src/sha512_asm.S|wolfcrypt/src/sha256_asm.S|wolfcrypt/src/poly1305_asm.S|wolfcrypt/src/fe_x25519_asm.S|wolfcrypt/src/chacha_asm.S|wolfcrypt/src/aes_gcm_asm.S|wolfcrypt/src/aes_asm.S|src/wolfssl/wolfcrypt/src/sp_x86_64_asm.S|src/wolfssl/wolfcrypt/src/sha512_asm.S|src/wolfssl/wolfcrypt/src/sha256_asm.S|src/wolfssl/wolfcrypt/src/poly1305_asm.S|src/wolfssl/wolfcrypt/src/fe_x25519_asm.S|src/wolfssl/wolfcrypt/src/chacha_asm.S|src/wolfssl/wolfcrypt/src/aes_gcm_asm.S|src/wolfssl/wolfcrypt/src/aes_asm.S|src/wolfssl/wolfcrypt/src/aes_asm.asm" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+		<cconfiguration id="xilinx.gnu.arm.a53.exe.release.1797079080">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="xilinx.gnu.arm.a53.exe.release.1797079080" moduleId="org.eclipse.cdt.core.settings" name="Release">
+				<externalSettings/>
+				<extensions>
+					<extension id="com.xilinx.sdk.managedbuilder.XELF.arm.a53" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactExtension="elf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.release" cleanCommand="rm -rf" description="" id="xilinx.gnu.arm.a53.exe.release.1797079080" name="Release" parent="xilinx.gnu.arm.a53.exe.release">
+					<folderInfo id="xilinx.gnu.arm.a53.exe.release.1797079080." name="/" resourcePath="">
+						<toolChain id="xilinx.gnu.arm.a53.exe.release.toolchain.814173101" name="Xilinx ARM v8 GNU Toolchain" superClass="xilinx.gnu.arm.a53.exe.release.toolchain">
+							<targetPlatform binaryParser="com.xilinx.sdk.managedbuilder.XELF.arm.a53" id="xilinx.arm.a53.target.gnu.base.release.897062454" isAbstract="false" name="Release Platform" superClass="xilinx.arm.a53.target.gnu.base.release"/>
+							<builder buildPath="${workspace_loc:/wolfcrypt}/Release" enableAutoBuild="false" id="xilinx.gnu.arm.a53.toolchain.builder.release.1330749491" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="GNU make" parallelBuildOn="true" parallelizationNumber="optimal" superClass="xilinx.gnu.arm.a53.toolchain.builder.release"/>
+							<tool id="xilinx.gnu.arm.a53.c.toolchain.assembler.release.700382346" name="ARM v8 gcc assembler" superClass="xilinx.gnu.arm.a53.c.toolchain.assembler.release">
+								<inputType id="xilinx.gnu.assembler.input.1654730515" superClass="xilinx.gnu.assembler.input"/>
+							</tool>
+							<tool id="xilinx.gnu.arm.a53.c.toolchain.compiler.release.1945855372" name="ARM v8 gcc compiler" superClass="xilinx.gnu.arm.a53.c.toolchain.compiler.release">
+								<option defaultValue="gnu.c.optimization.level.more" id="xilinx.gnu.compiler.option.optimization.level.321722241" name="Optimization Level" superClass="xilinx.gnu.compiler.option.optimization.level" value="gnu.c.optimization.level.size" valueType="enumerated"/>
+								<option id="xilinx.gnu.compiler.option.debugging.level.1296679815" name="Debug Level" superClass="xilinx.gnu.compiler.option.debugging.level" value="gnu.c.debugging.level.none" valueType="enumerated"/>
+								<option id="xilinx.gnu.compiler.inferred.swplatform.includes.1075729227" name="Software Platform Include Path" superClass="xilinx.gnu.compiler.inferred.swplatform.includes" valueType="includePath">
+									<listOptionValue builtIn="false" value="../../standalone_bsp_0/psu_cortexa53_0/include"/>
+								</option>
+								<option id="xilinx.gnu.compiler.inferred.swplatform.flags.251779745" name="Software Platform Inferred Flags" superClass="xilinx.gnu.compiler.inferred.swplatform.flags" value=" " valueType="string"/>
+								<option id="xilinx.gnu.compiler.symbols.defined.1642126610" name="Defined symbols (-D)" superClass="xilinx.gnu.compiler.symbols.defined" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="WOLFSSL_USER_SETTINGS"/>
+								</option>
+								<option id="xilinx.gnu.compiler.dircategory.includes.1627573150" name="Include Paths" superClass="xilinx.gnu.compiler.dircategory.includes" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/IDE/XilinxSDK}&quot;"/>
+								</option>
+								<option id="xilinx.gnu.compiler.misc.other.1235490199" name="Other flags" superClass="xilinx.gnu.compiler.misc.other" value="-mcpu=generic+crypto -mstrict-align -c -fmessage-length=0 -MT&quot;$@&quot;" valueType="string"/>
+								<inputType id="xilinx.gnu.arm.a53.c.compiler.input.1389468801" name="C source files" superClass="xilinx.gnu.arm.a53.c.compiler.input"/>
+							</tool>
+							<tool id="xilinx.gnu.arm.a53.cxx.toolchain.compiler.release.1390130886" name="ARM v8 g++ compiler" superClass="xilinx.gnu.arm.a53.cxx.toolchain.compiler.release">
+								<option defaultValue="gnu.c.optimization.level.more" id="xilinx.gnu.compiler.option.optimization.level.1135940555" name="Optimization Level" superClass="xilinx.gnu.compiler.option.optimization.level" value="gnu.c.optimization.level.size" valueType="enumerated"/>
+								<option id="xilinx.gnu.compiler.option.debugging.level.137425578" name="Debug Level" superClass="xilinx.gnu.compiler.option.debugging.level" value="gnu.c.debugging.level.none" valueType="enumerated"/>
+								<option id="xilinx.gnu.compiler.inferred.swplatform.includes.592755901" name="Software Platform Include Path" superClass="xilinx.gnu.compiler.inferred.swplatform.includes" valueType="includePath">
+									<listOptionValue builtIn="false" value="../../standalone_bsp_0/psu_cortexa53_0/include"/>
+								</option>
+								<option id="xilinx.gnu.compiler.inferred.swplatform.flags.844972549" name="Software Platform Inferred Flags" superClass="xilinx.gnu.compiler.inferred.swplatform.flags" value=" " valueType="string"/>
+								<option id="xilinx.gnu.compiler.symbols.defined.1997633271" name="Defined symbols (-D)" superClass="xilinx.gnu.compiler.symbols.defined" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="WOLFSSL_USER_SETTINGS"/>
+								</option>
+								<option id="xilinx.gnu.compiler.dircategory.includes.78998943" name="Include Paths" superClass="xilinx.gnu.compiler.dircategory.includes" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/IDE/XilinxSDK}&quot;"/>
+								</option>
+								<option id="xilinx.gnu.compiler.misc.other.2105999656" name="Other flags" superClass="xilinx.gnu.compiler.misc.other" value="-mcpu=generic+crypto -mstrict-align -c -fmessage-length=0 -MT&quot;$@&quot;" valueType="string"/>
+							</tool>
+							<tool id="xilinx.gnu.arm.a53.toolchain.archiver.215710983" name="ARM v8 archiver" superClass="xilinx.gnu.arm.a53.toolchain.archiver"/>
+							<tool id="xilinx.gnu.arm.a53.c.toolchain.linker.release.784692165" name="ARM v8 gcc linker" superClass="xilinx.gnu.arm.a53.c.toolchain.linker.release">
+								<option id="xilinx.gnu.linker.inferred.swplatform.lpath.1667736006" name="Software Platform Library Path" superClass="xilinx.gnu.linker.inferred.swplatform.lpath" valueType="libPaths">
+									<listOptionValue builtIn="false" value="../../standalone_bsp_0/psu_cortexa53_0/lib"/>
+								</option>
+								<option id="xilinx.gnu.linker.inferred.swplatform.flags.317807099" name="Software Platform Inferred Flags" superClass="xilinx.gnu.linker.inferred.swplatform.flags" valueType="libs">
+									<listOptionValue builtIn="false" value="-Wl,--start-group,-lxil,-lgcc,-lc,--end-group"/>
+									<listOptionValue builtIn="false" value="-Wl,--start-group,-lxilskey,-lxil,-lgcc,-lc,--end-group"/>
+								</option>
+								<option id="xilinx.gnu.c.linker.option.lscript.2003489255" name="Linker Script" superClass="xilinx.gnu.c.linker.option.lscript" value="../IDE/XilinxSDK/lscript.ld" valueType="string"/>
+								<inputType id="xilinx.gnu.linker.input.1756561282" superClass="xilinx.gnu.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+								<inputType id="xilinx.gnu.linker.input.lscript.1763544067" name="Linker Script" superClass="xilinx.gnu.linker.input.lscript"/>
+							</tool>
+							<tool id="xilinx.gnu.arm.a53.cxx.toolchain.linker.release.870635809" name="ARM v8 g++ linker" superClass="xilinx.gnu.arm.a53.cxx.toolchain.linker.release">
+								<option id="xilinx.gnu.linker.inferred.swplatform.lpath.981751982" name="Software Platform Library Path" superClass="xilinx.gnu.linker.inferred.swplatform.lpath" valueType="libPaths">
+									<listOptionValue builtIn="false" value="../../standalone_bsp_0/psu_cortexa53_0/lib"/>
+								</option>
+								<option id="xilinx.gnu.linker.inferred.swplatform.flags.449458929" name="Software Platform Inferred Flags" superClass="xilinx.gnu.linker.inferred.swplatform.flags" valueType="libs">
+									<listOptionValue builtIn="false" value="-Wl,--start-group,-lxil,-lgcc,-lc,--end-group"/>
+									<listOptionValue builtIn="false" value="-Wl,--start-group,-lxilskey,-lxil,-lgcc,-lc,--end-group"/>
+								</option>
+								<option id="xilinx.gnu.c.linker.option.lscript.1644924019" name="Linker Script" superClass="xilinx.gnu.c.linker.option.lscript" value="../IDE/XilinxSDK/lscript.ld" valueType="string"/>
+							</tool>
+							<tool id="xilinx.gnu.arm.a53.size.release.716945764" name="ARM v8 Print Size" superClass="xilinx.gnu.arm.a53.size.release"/>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry excluding="wrapper|tirtos|testsuite|tests|swig|support|sslSniffer|scripts|rpm|mqx|mplabx|mcapi|m4|lib|IPP|examples|doc|IDE/zephyr|IDE/XCODE|IDE/WORKBENCH|IDE/WIN-SGX|IDE/WIN10|IDE/WIN|IDE/WICED-STUDIO|IDE/VS-AZURE-SPHERE|IDE/VS-ARM|IDE/TRUESTUDIO|IDE/ROWLEY-CROSSWORKS-ARM|IDE/RISCV|IDE/Renesas|IDE/OPENSTM32|IDE/MYSQL|IDE/mynewt|IDE/MDK-ARM|IDE/MDK5-ARM|IDE/M68K|IDE/LPCXPRESSO|IDE/LINUX-SGX|IDE/KDS|IDE/INTIME-RTOS|IDE/IAR-EWARM|IDE/HEXIWEAR|IDE/HEXAGON|IDE/GCC-ARM|IDE/Espressif|IDE/ECLIPSE|IDE/CSBENCH|IDE/CRYPTOCELL|IDE/ARDUINO|wolfcrypt/src/sp_x86_64_asm.S|wolfcrypt/src/sha512_asm.S|wolfcrypt/src/sha256_asm.S|wolfcrypt/src/poly1305_asm.S|wolfcrypt/src/fe_x25519_asm.S|wolfcrypt/src/chacha_asm.S|wolfcrypt/src/aes_gcm_asm.S|wolfcrypt/src/aes_asm.S|src/wolfssl/wolfcrypt/src/sp_x86_64_asm.S|src/wolfssl/wolfcrypt/src/sha512_asm.S|src/wolfssl/wolfcrypt/src/sha256_asm.S|src/wolfssl/wolfcrypt/src/poly1305_asm.S|src/wolfssl/wolfcrypt/src/fe_x25519_asm.S|src/wolfssl/wolfcrypt/src/chacha_asm.S|src/wolfssl/wolfcrypt/src/aes_gcm_asm.S|src/wolfssl/wolfcrypt/src/aes_asm.S|src/wolfssl/wolfcrypt/src/aes_asm.asm" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="wolfcrypt.xilinx.gnu.arm.a53.exe.1701851846" name="Xilinx ARM v8 Executable" projectType="xilinx.gnu.arm.a53.exe"/>
+	</storageModule>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="xilinx.gnu.arm.a53.exe.debug.1827297552;xilinx.gnu.arm.a53.exe.debug.1827297552.;xilinx.gnu.arm.a53.c.toolchain.compiler.debug.1150820611;xilinx.gnu.arm.a53.c.compiler.input.1610926744">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId="com.xilinx.managedbuilder.ui.ARMA53GCCManagedMakePerProjectProfileC"/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="xilinx.gnu.arm.a53.exe.debug.1827297552;xilinx.gnu.arm.a53.exe.debug.1827297552.">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId="com.xilinx.managedbuilder.ui.ARMA53GCCManagedMakePerProjectProfileC"/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="xilinx.gnu.arm.a53.exe.release.1797079080;xilinx.gnu.arm.a53.exe.release.1797079080.">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId="com.xilinx.managedbuilder.ui.ARMA53GCCManagedMakePerProjectProfileC"/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="xilinx.gnu.arm.a53.exe.release.1797079080;xilinx.gnu.arm.a53.exe.release.1797079080.;xilinx.gnu.arm.a53.c.toolchain.compiler.release.1945855372;xilinx.gnu.arm.a53.c.compiler.input.1389468801">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId="com.xilinx.managedbuilder.ui.ARMA53GCCManagedMakePerProjectProfileC"/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Multiple configurations">
+			<resource resourceType="PROJECT" workspacePath="/wolfcrypt"/>
+		</configuration>
+		<configuration configurationName="Debug">
+			<resource resourceType="PROJECT" workspacePath="/wolfcrypt"/>
+		</configuration>
+		<configuration configurationName="Release">
+			<resource resourceType="PROJECT" workspacePath="/wolfcrypt"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/IDE/XilinxSDK/.project
+++ b/IDE/XilinxSDK/.project
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>wolfcrypt</name>
+	<comment>Created by SDK v2018.2. standalone_bsp_0 - psu_cortexa53_0</comment>
+	<projects>
+		<project>standalone_bsp_0</project>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/IDE/XilinxSDK/README.md
+++ b/IDE/XilinxSDK/README.md
@@ -1,0 +1,58 @@
+# Xilinx SDK wolfCrypt Project
+
+To use this example project:
+1. Start a new workspace
+2. Create a new BSP called `standalone_bsp_0`.
+3. Copy `.cproject` and `.project` into the wolfSSL root.
+4. From the Xilinx SDK Import wolfBoot using "Import" -> "Existing Projects into Workspace".
+
+## Platform
+
+Tested on the Zynq UltraScale+ MPSoC (ZUC102).
+
+This is a bare-metal example for wolfCrypt only with algorithm support for:
+* RNG
+* RSA
+* ECC
+* AES-GCM
+* ChaCha20
+* Poly1305
+* SHA2
+* SHA3
+* PBKDF2
+
+## Benchmark Results
+
+```
+------------------------------------------------------------------------------
+ wolfSSL version 4.3.0
+------------------------------------------------------------------------------
+wolfCrypt Benchmark (block bytes 1024, min  sec each)
+RNG                 72 MB took 1.000 seconds,   72.388 MB/s
+AES-128-GCM-enc    370 MB took 1.000 seconds,  370.312 MB/s
+AES-128-GCM-dec    187 MB took 1.000 seconds,  187.451 MB/s
+AES-192-GCM-enc    341 MB took 1.000 seconds,  341.382 MB/s
+AES-192-GCM-dec    180 MB took 1.000 seconds,  179.663 MB/s
+AES-256-GCM-enc    316 MB took 1.000 seconds,  316.382 MB/s
+AES-256-GCM-dec    172 MB took 1.000 seconds,  172.485 MB/s
+CHACHA             256 MB took 1.000 seconds,  255.859 MB/s
+CHA-POLY            98 MB took 1.000 seconds,   97.559 MB/s
+POLY1305           517 MB took 1.000 seconds,  516.895 MB/s
+SHA-256            535 MB took 1.000 seconds,  534.595 MB/s
+SHA-384            123 MB took 1.000 seconds,  123.291 MB/s
+SHA-512            124 MB took 1.000 seconds,  123.657 MB/s
+SHA3-224            70 MB took 1.000 seconds,   70.337 MB/s
+SHA3-256            67 MB took 1.000 seconds,   66.528 MB/s
+SHA3-384            53 MB took 1.000 seconds,   52.710 MB/s
+SHA3-512            38 MB took 1.000 seconds,   37.598 MB/s
+HMAC-SHA256        520 MB took 1.000 seconds,  520.093 MB/s
+HMAC-SHA384        121 MB took 1.000 seconds,  121.265 MB/s
+HMAC-SHA512        121 MB took 1.000 seconds,  121.289 MB/s
+PBKDF2              28 KB took 1.000 seconds,   28.375 KB/s
+ECC      256 key gen      8518 ops took 1.000 sec, avg 0.117 ms, 8518.000 ops/sec
+ECDHE    256 agree        1818 ops took 1.000 sec, avg 0.550 ms, 1818.000 ops/sec
+ECDSA    256 sign         4448 ops took 1.000 sec, avg 0.225 ms, 4448.000 ops/sec
+ECDSA    256 verify       1430 ops took 1.000 sec, avg 0.699 ms, 1430.000 ops/sec
+Benchmark complete
+Benchmark Test: Return code 0
+```

--- a/IDE/XilinxSDK/include.am
+++ b/IDE/XilinxSDK/include.am
@@ -1,0 +1,10 @@
+# vim:ft=automake
+# included from Top Level Makefile.am
+# All paths should be given relative to the root
+
+EXTRA_DIST+= IDE/XilinxSDK/README.md
+EXTRA_DIST+= IDE/XilinxSDK/user_settings.h
+EXTRA_DIST+= IDE/XilinxSDK/wolfssl_example.c
+EXTRA_DIST+= IDE/XilinxSDK/lscript.ld
+EXTRA_DIST+= IDE/XilinxSDK/.cproject
+EXTRA_DIST+= IDE/XilinxSDK/.project

--- a/IDE/XilinxSDK/lscript.ld
+++ b/IDE/XilinxSDK/lscript.ld
@@ -1,0 +1,309 @@
+
+/* Linker Script for Zynq MP */
+
+/* Stack and Heap increased to 64KB  */
+_STACK_SIZE = DEFINED(_STACK_SIZE) ? _STACK_SIZE : 0x10000;
+_HEAP_SIZE = DEFINED(_HEAP_SIZE) ? _HEAP_SIZE : 0x10000;
+
+_EL0_STACK_SIZE = DEFINED(_EL0_STACK_SIZE) ? _EL0_STACK_SIZE : 1024;
+_EL1_STACK_SIZE = DEFINED(_EL1_STACK_SIZE) ? _EL1_STACK_SIZE : 2048;
+_EL2_STACK_SIZE = DEFINED(_EL2_STACK_SIZE) ? _EL2_STACK_SIZE : 1024;
+
+/* Define Memories in the system */
+MEMORY
+{
+   ddr4_ctrl_C0_DDR4_ADDRESS_BLOCK : ORIGIN = 0x500000000, LENGTH = 0x20000000
+   psu_ddr_0_MEM_0 : ORIGIN = 0x0, LENGTH = 0x7FF00000
+   psu_ddr_1_MEM_0 : ORIGIN = 0x800000000, LENGTH = 0x80000000
+   psu_ocm_ram_0_MEM_0 : ORIGIN = 0xFFFC0000, LENGTH = 0x40000
+   psu_qspi_linear_0_MEM_0 : ORIGIN = 0xC0000000, LENGTH = 0x20000000
+}
+
+/* Specify the default entry point to the program */
+ENTRY(_vector_table)
+
+/* Define the sections, and where they are mapped in memory */
+SECTIONS
+{
+.text : {
+   KEEP (*(.vectors))
+   *(.boot)
+   *(.text)
+   *(.text.*)
+   *(.gnu.linkonce.t.*)
+   *(.plt)
+   *(.gnu_warning)
+   *(.gcc_execpt_table)
+   *(.glue_7)
+   *(.glue_7t)
+   *(.ARM.extab)
+   *(.gnu.linkonce.armextab.*)
+} > psu_ddr_0_MEM_0
+
+.init (ALIGN(64)) : {
+   KEEP (*(.init))
+} > psu_ddr_0_MEM_0
+
+.fini (ALIGN(64)) : {
+   KEEP (*(.fini))
+} > psu_ddr_0_MEM_0
+
+.interp : {
+   KEEP (*(.interp))
+} > psu_ddr_0_MEM_0
+
+.note-ABI-tag : {
+   KEEP (*(.note-ABI-tag))
+} > psu_ddr_0_MEM_0
+
+.rodata : {
+   . = ALIGN(64);
+   __rodata_start = .;
+   *(.rodata)
+   *(.rodata.*)
+   *(.gnu.linkonce.r.*)
+   __rodata_end = .;
+} > psu_ddr_0_MEM_0
+
+.rodata1 : {
+   . = ALIGN(64);
+   __rodata1_start = .;
+   *(.rodata1)
+   *(.rodata1.*)
+   __rodata1_end = .;
+} > psu_ddr_0_MEM_0
+
+.sdata2 : {
+   . = ALIGN(64);
+   __sdata2_start = .;
+   *(.sdata2)
+   *(.sdata2.*)
+   *(.gnu.linkonce.s2.*)
+   __sdata2_end = .;
+} > psu_ddr_0_MEM_0
+
+.sbss2 : {
+   . = ALIGN(64);
+   __sbss2_start = .;
+   *(.sbss2)
+   *(.sbss2.*)
+   *(.gnu.linkonce.sb2.*)
+   __sbss2_end = .;
+} > psu_ddr_0_MEM_0
+
+.data : {
+   . = ALIGN(64);
+   __data_start = .;
+   *(.data)
+   *(.data.*)
+   *(.gnu.linkonce.d.*)
+   *(.jcr)
+   *(.got)
+   *(.got.plt)
+   __data_end = .;
+} > psu_ddr_0_MEM_0
+
+.data1 : {
+   . = ALIGN(64);
+   __data1_start = .;
+   *(.data1)
+   *(.data1.*)
+   __data1_end = .;
+} > psu_ddr_0_MEM_0
+
+.got : {
+   *(.got)
+} > psu_ddr_0_MEM_0
+
+.got1 : {
+   *(.got1)
+} > psu_ddr_0_MEM_0
+
+.got2 : {
+   *(.got2)
+} > psu_ddr_0_MEM_0
+
+.ctors : {
+   . = ALIGN(64);
+   __CTOR_LIST__ = .;
+   ___CTORS_LIST___ = .;
+   KEEP (*crtbegin.o(.ctors))
+   KEEP (*(EXCLUDE_FILE(*crtend.o) .ctors))
+   KEEP (*(SORT(.ctors.*)))
+   KEEP (*(.ctors))
+   __CTOR_END__ = .;
+   ___CTORS_END___ = .;
+} > psu_ddr_0_MEM_0
+
+.dtors : {
+   . = ALIGN(64);
+   __DTOR_LIST__ = .;
+   ___DTORS_LIST___ = .;
+   KEEP (*crtbegin.o(.dtors))
+   KEEP (*(EXCLUDE_FILE(*crtend.o) .dtors))
+   KEEP (*(SORT(.dtors.*)))
+   KEEP (*(.dtors))
+   __DTOR_END__ = .;
+   ___DTORS_END___ = .;
+} > psu_ddr_0_MEM_0
+
+.fixup : {
+   __fixup_start = .;
+   *(.fixup)
+   __fixup_end = .;
+} > psu_ddr_0_MEM_0
+
+.eh_frame : {
+   *(.eh_frame)
+} > psu_ddr_0_MEM_0
+
+.eh_framehdr : {
+   __eh_framehdr_start = .;
+   *(.eh_framehdr)
+   __eh_framehdr_end = .;
+} > psu_ddr_0_MEM_0
+
+.gcc_except_table : {
+   *(.gcc_except_table)
+} > psu_ddr_0_MEM_0
+
+.mmu_tbl0 (ALIGN(4096)) : {
+   __mmu_tbl0_start = .;
+   *(.mmu_tbl0)
+   __mmu_tbl0_end = .;
+} > psu_ddr_0_MEM_0
+
+.mmu_tbl1 (ALIGN(4096)) : {
+   __mmu_tbl1_start = .;
+   *(.mmu_tbl1)
+   __mmu_tbl1_end = .;
+} > psu_ddr_0_MEM_0
+
+.mmu_tbl2 (ALIGN(4096)) : {
+   __mmu_tbl2_start = .;
+   *(.mmu_tbl2)
+   __mmu_tbl2_end = .;
+} > psu_ddr_0_MEM_0
+
+.ARM.exidx : {
+   __exidx_start = .;
+   *(.ARM.exidx*)
+   *(.gnu.linkonce.armexidix.*.*)
+   __exidx_end = .;
+} > psu_ddr_0_MEM_0
+
+.preinit_array : {
+   . = ALIGN(64);
+   __preinit_array_start = .;
+   KEEP (*(SORT(.preinit_array.*)))
+   KEEP (*(.preinit_array))
+   __preinit_array_end = .;
+} > psu_ddr_0_MEM_0
+
+.init_array : {
+   . = ALIGN(64);
+   __init_array_start = .;
+   KEEP (*(SORT(.init_array.*)))
+   KEEP (*(.init_array))
+   __init_array_end = .;
+} > psu_ddr_0_MEM_0
+
+.fini_array : {
+   . = ALIGN(64);
+   __fini_array_start = .;
+   KEEP (*(SORT(.fini_array.*)))
+   KEEP (*(.fini_array))
+   __fini_array_end = .;
+} > psu_ddr_0_MEM_0
+
+.ARM.attributes : {
+   __ARM.attributes_start = .;
+   *(.ARM.attributes)
+   __ARM.attributes_end = .;
+} > psu_ddr_0_MEM_0
+
+.sdata : {
+   . = ALIGN(64);
+   __sdata_start = .;
+   *(.sdata)
+   *(.sdata.*)
+   *(.gnu.linkonce.s.*)
+   __sdata_end = .;
+} > psu_ddr_0_MEM_0
+
+.sbss (NOLOAD) : {
+   . = ALIGN(64);
+   __sbss_start = .;
+   *(.sbss)
+   *(.sbss.*)
+   *(.gnu.linkonce.sb.*)
+   . = ALIGN(64);
+   __sbss_end = .;
+} > psu_ddr_0_MEM_0
+
+.tdata : {
+   . = ALIGN(64);
+   __tdata_start = .;
+   *(.tdata)
+   *(.tdata.*)
+   *(.gnu.linkonce.td.*)
+   __tdata_end = .;
+} > psu_ddr_0_MEM_0
+
+.tbss : {
+   . = ALIGN(64);
+   __tbss_start = .;
+   *(.tbss)
+   *(.tbss.*)
+   *(.gnu.linkonce.tb.*)
+   __tbss_end = .;
+} > psu_ddr_0_MEM_0
+
+.bss (NOLOAD) : {
+   . = ALIGN(64);
+   __bss_start__ = .;
+   *(.bss)
+   *(.bss.*)
+   *(.gnu.linkonce.b.*)
+   *(COMMON)
+   . = ALIGN(64);
+   __bss_end__ = .;
+} > psu_ddr_0_MEM_0
+
+_SDA_BASE_ = __sdata_start + ((__sbss_end - __sdata_start) / 2 );
+
+_SDA2_BASE_ = __sdata2_start + ((__sbss2_end - __sdata2_start) / 2 );
+
+/* Generate Stack and Heap definitions */
+
+.heap (NOLOAD) : {
+   . = ALIGN(64);
+   _heap = .;
+   HeapBase = .;
+   _heap_start = .;
+   . += _HEAP_SIZE;
+   _heap_end = .;
+   HeapLimit = .;
+} > psu_ddr_0_MEM_0
+
+.stack (NOLOAD) : {
+   . = ALIGN(64);
+   _el3_stack_end = .;
+   . += _STACK_SIZE;
+   __el3_stack = .;
+   _el2_stack_end = .;
+   . += _EL2_STACK_SIZE;
+   . = ALIGN(64);
+   __el2_stack = .;
+   _el1_stack_end = .;
+   . += _EL1_STACK_SIZE;
+   . = ALIGN(64);
+   __el1_stack = .;
+   _el0_stack_end = .;
+   . += _EL0_STACK_SIZE;
+   . = ALIGN(64);
+   __el0_stack = .;
+} > psu_ddr_0_MEM_0
+
+_end = .;
+}

--- a/IDE/XilinxSDK/user_settings.h
+++ b/IDE/XilinxSDK/user_settings.h
@@ -1,0 +1,117 @@
+/* user_settings.h
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/*
+ * user_settings.h
+ *
+ *  Created on: Mar 20, 2020
+ *  Generated using: 
+ * ./configure --enable-cryptonly --enable-armasm --enable-ecc --enable-aesgcm --enable-pwdbased --enable-sp --enable-sp-asm \
+ *     --disable-dh --disable-sha --disable-md5 --disable-sha224 --disable-aescbc --disable-shake256 
+ *  Result: wolfssl/options.h
+ */
+
+#ifndef SRC_USER_SETTINGS_H_
+#define SRC_USER_SETTINGS_H_
+
+/* Disable all TLS support, only wolfCrypt features */
+#define WOLFCRYPT_ONLY
+
+/* Xilinx SDK */
+#define WOLFSSL_XILINX
+#define SINGLE_THREADED
+#define NO_FILESYSTEM
+
+/* Platform - remap printf */
+#include "xil_printf.h"
+#define XPRINTF xil_printf
+
+/* Enable ARMv8 (Aarch64) assembly speedups - SHA256 / AESGCM */
+/* Note: Requires CFLAGS="-mcpu=generic+crypto -mstrict-align" */
+#define WOLFSSL_ARMASM
+
+/* Math */
+#define USE_FAST_MATH
+#define FP_MAX_BITS (4096 * 2) /* Max RSA 4096-bit */
+
+/* Use Single Precision assembly math speedups for ECC */
+#define WOLFSSL_SP
+#define WOLFSSL_SP_ASM
+#define WOLFSSL_SP_ARM64_ASM
+#define WOLFSSL_HAVE_SP_ECC
+#define WOLFSSL_HAVE_SP_RSA
+
+/* Random: HashDRGB / P-RNG (SHA256) */
+#define HAVE_HASHDRBG
+extern unsigned char my_rng_seed_gen(void);
+#define CUSTOM_RAND_GENERATE  my_rng_seed_gen
+
+/* Timing Resistance */
+#define TFM_TIMING_RESISTANT
+#define ECC_TIMING_RESISTANT
+#define WC_RSA_BLINDING
+
+/* ECC */
+#define HAVE_ECC
+#define TFM_ECC256
+#define ECC_SHAMIR
+
+/* AES-GCM Only */
+#define NO_AES_CBC
+#define HAVE_AESGCM
+
+/* Hashing */
+#define WOLFSSL_SHA512
+#define WOLFSSL_SHA384
+#define WOLFSSL_SHA3
+#define WOLFSSL_NO_HASH_RAW /* not supported with ARMASM */
+
+/* ChaCha20 / Poly1305 */
+#define HAVE_CHACHA
+#define HAVE_POLY1305
+
+/* Disable Algorithms */
+#define NO_DH
+#define NO_DSA
+#define NO_RC4
+#define NO_MD4
+#define NO_MD5
+#define NO_SHA
+#define NO_HC128
+#define NO_RABBIT
+#define NO_PSK
+#define NO_DES3
+
+/* Other */
+#define WOLFSSL_IGNORE_FILE_WARN /* Ignore file include warnings */
+#define NO_MAIN_DRIVER /* User supplied "main" entry point */
+#define BENCH_EMBEDDED /* Use smaller buffers for benchmarking */
+
+/* Test with "wolfssl/certs_test.h" buffers - no file system */
+#define USE_CERT_BUFFERS_256
+#define USE_CERT_BUFFERS_2048
+
+/* Debugging */
+#if 0
+	#define DEBUG_WOLFSSL
+#endif
+
+#endif /* SRC_USER_SETTINGS_H_ */

--- a/IDE/XilinxSDK/user_settings.h
+++ b/IDE/XilinxSDK/user_settings.h
@@ -74,6 +74,24 @@ extern unsigned char my_rng_seed_gen(void);
 #define TFM_ECC256
 #define ECC_SHAMIR
 
+/* DH */
+#undef NO_DH
+#define WOLFSSL_DH_CONST
+#define HAVE_FFDHE_2048
+#define HAVE_FFDHE_4096
+
+/* Curve25519 / Ed25519 */
+#define HAVE_CURVE25519
+#define HAVE_ED25519 /* ED25519 Requires SHA512 */
+/* 25519 assumes UINT128_T is available for Aarch64 */
+#ifndef HAVE___UINT128_T
+#define HAVE___UINT128_T
+#endif
+
+/* ChaCha20 / Poly1305 */
+#define HAVE_CHACHA
+#define HAVE_POLY1305
+
 /* AES-GCM Only */
 #define NO_AES_CBC
 #define HAVE_AESGCM
@@ -84,12 +102,10 @@ extern unsigned char my_rng_seed_gen(void);
 #define WOLFSSL_SHA3
 #define WOLFSSL_NO_HASH_RAW /* not supported with ARMASM */
 
-/* ChaCha20 / Poly1305 */
-#define HAVE_CHACHA
-#define HAVE_POLY1305
+/* HKDF */
+#define HAVE_HKDF
 
 /* Disable Algorithms */
-#define NO_DH
 #define NO_DSA
 #define NO_RC4
 #define NO_MD4

--- a/IDE/XilinxSDK/wolfssl_example.c
+++ b/IDE/XilinxSDK/wolfssl_example.c
@@ -1,0 +1,119 @@
+/* wolfssl_example.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#include "xil_printf.h"
+#include "xrtcpsu.h"
+
+#include "wolfssl/wolfcrypt/settings.h"
+#include "wolfssl/wolfcrypt/wc_port.h"
+#include "wolfssl/wolfcrypt/error-crypt.h"
+#include "wolfssl/wolfcrypt/logging.h"
+#include "wolfcrypt/test/test.h"
+#include "wolfcrypt/benchmark/benchmark.h"
+
+/*****************************************************************************
+ * Configuration
+ ****************************************************************************/
+
+/*****************************************************************************
+ * Private types/enumerations/variables
+ ****************************************************************************/
+
+/*****************************************************************************
+ * Public types/enumerations/variables
+ ****************************************************************************/
+typedef struct func_args {
+	int argc;
+	char** argv;
+	int return_code;
+} func_args;
+
+const char menu1[] = "\n"
+		"\tt. WolfCrypt Test\n"
+		"\tb. WolfCrypt Benchmark\n";
+
+/*****************************************************************************
+ * Private functions
+ ****************************************************************************/
+/* Test RNG Seed Function */
+/* TODO: Must provide real seed to RNG */
+unsigned char my_rng_seed_gen(void)
+{
+	static unsigned int kTestSeed = 1;
+	return kTestSeed++;
+}
+
+/*****************************************************************************
+ * Public functions
+ ****************************************************************************/
+int main()
+{
+	uint8_t cmd;
+	func_args args;
+
+#ifdef DEBUG_WOLFSSL
+    wolfSSL_Debugging_ON();
+#endif
+
+    /* initialize wolfSSL */
+    wolfCrypt_Init();
+
+	while (1) {
+        memset(&args, 0, sizeof(args));
+        args.return_code = NOT_COMPILED_IN; /* default */
+
+		xil_printf("\n\t\t\t\tMENU\n");
+		xil_printf(menu1);
+		xil_printf("Please select one of the above options:\n");
+
+        do {
+        	cmd = inbyte();
+        } while (cmd == '\n' || cmd == '\r');
+
+		switch (cmd) {
+		case 't':
+			xil_printf("Running wolfCrypt Tests...\n");
+        #ifndef NO_CRYPT_TEST
+			args.return_code = 0;
+			wolfcrypt_test(&args);
+        #endif
+			xil_printf("Crypt Test: Return code %d\n", args.return_code);
+			break;
+
+		case 'b':
+			xil_printf("Running wolfCrypt Benchmarks...\n");
+        #ifndef NO_CRYPT_BENCHMARK
+			args.return_code = 0;
+			benchmark_test(&args);
+        #endif
+			xil_printf("Benchmark Test: Return code %d\n", args.return_code);
+			break;
+
+		default:
+			xil_printf("\nSelection out of range\n");
+			break;
+		}
+	}
+
+    wolfCrypt_Cleanup();
+
+    return 0;
+}

--- a/IDE/include.am
+++ b/IDE/include.am
@@ -30,5 +30,6 @@ include IDE/CRYPTOCELL/include.am
 include IDE/M68K/include.am
 include IDE/HEXAGON/include.am
 include IDE/RISCV/include.am
+include IDE/XilinxSDK/include.am
 
 EXTRA_DIST+= IDE/IAR-EWARM IDE/MDK-ARM IDE/MDK5-ARM IDE/MYSQL IDE/LPCXPRESSO IDE/HEXIWEAR IDE/Espressif IDE/zephyr

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1268,6 +1268,7 @@ static void bench_stats_asym_finish(const char* algo, int strength,
     double total, each = 0, opsSec, milliEach;
     const char **word = bench_result_words2[lng_index];
     const char* kOpsSec = "Ops/Sec";
+    char msg[128] = {0};
 
     total = current_time(0) - start;
     if (count > 0)
@@ -1283,12 +1284,13 @@ static void bench_stats_asym_finish(const char* algo, int strength,
             printf("Algorithm,avg ms,ops/sec,\n");
             csv_header_count++;
         }
-        printf("%s %d %s,%.3f,%.3f,\n", algo, strength, desc, milliEach, opsSec);
+        XSNPRINTF(msg, sizeof(msg), "%s %d %s,%.3f,%.3f,\n", algo, strength, desc, milliEach, opsSec);
     } else {
-        printf("%-6s %5d %-9s %s %6d %s %5.3f %s, %s %5.3f ms,"
+        XSNPRINTF(msg, sizeof(msg), "%-6s %5d %-9s %s %6d %s %5.3f %s, %s %5.3f ms,"
         " %.3f %s\n", algo, strength, desc, BENCH_ASYNC_GET_NAME(doAsync),
         count, word[0], total, word[1], word[2], milliEach, opsSec, word[3]);
     }
+    printf("%s", msg);
 
     /* show errors */
     if (ret < 0) {

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -5979,6 +5979,28 @@ exit_ed_verify:
         (void)reset;
         return (double) tx_time_get() / TX_TIMER_TICKS_PER_SECOND;
     }
+
+#elif defined(WOLFSSL_XILINX)
+    #ifndef XPAR_CPU_CORTEXA53_0_TIMESTAMP_CLK_FREQ
+    #define XPAR_CPU_CORTEXA53_0_TIMESTAMP_CLK_FREQ 50000000
+    #endif
+    #ifndef COUNTS_PER_SECOND
+    #define COUNTS_PER_SECOND     XPAR_CPU_CORTEXA53_0_TIMESTAMP_CLK_FREQ
+    #endif
+
+    double current_time(int reset)
+    {
+        double timer;
+        uint64_t cntPct = 0;
+        asm volatile("mrs %0, CNTPCT_EL0" : "=r" (cntPct));
+
+        /* Convert to milliseconds */
+        timer = (double)(cntPct / (COUNTS_PER_SECOND / 1000));
+        /* Convert to seconds.millisecond */
+        timer /= 1000;
+        return timer;
+    }
+
 #else
 
     #include <sys/time.h>

--- a/wolfcrypt/src/chacha.c
+++ b/wolfcrypt/src/chacha.c
@@ -37,7 +37,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#ifdef HAVE_CHACHA
+#if defined(HAVE_CHACHA) && !defined(WOLFSSL_ARMASM)
 
 #include <wolfssl/wolfcrypt/chacha.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2522,11 +2522,11 @@ int wc_ecc_mulmod_ex(mp_int* k, ecc_point *G, ecc_point *R,
 
    ecc_point     *tG, *M[M_POINTS];
    int           i, err;
-#ifdef WOLFSSL_SMALL_STACK
-   mp_int*       mu = NULL;
 #ifdef WOLFSSL_SMALL_STACK_CACHE
    ecc_key       key;
 #endif
+#ifdef WOLFSSL_SMALL_STACK
+   mp_int*       mu = NULL;
 #else
    mp_int        mu[1];
 #endif
@@ -5339,11 +5339,11 @@ int ecc_mul2add(ecc_point* A, mp_int* kA,
                     void* heap)
 #endif
 {
-#ifdef WOLFSSL_SMALL_STACK
-  ecc_point**    precomp = NULL;
 #ifdef WOLFSSL_SMALL_STACK_CACHE
   ecc_key        key;
 #endif
+#ifdef WOLFSSL_SMALL_STACK
+  ecc_point**    precomp = NULL;
 #else
   ecc_point*     precomp[SHAMIR_PRECOMP_SZ];
 #endif

--- a/wolfcrypt/src/port/arm/armv8-chacha.c
+++ b/wolfcrypt/src/port/arm/armv8-chacha.c
@@ -2853,5 +2853,5 @@ int wc_Chacha_Process(ChaCha* ctx, byte* output, const byte* input,
     return 0;
 }
 
-#endif /* HAVE_CHACHA*/
+#endif /* HAVE_CHACHA */
 #endif /* WOLFSSL_ARMASM */

--- a/wolfcrypt/src/port/arm/armv8-curve25519.c
+++ b/wolfcrypt/src/port/arm/armv8-curve25519.c
@@ -30,6 +30,8 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_ARMASM
 #include <wolfssl/wolfcrypt/fe_operations.h>
 #include <stdint.h>
 
@@ -6719,4 +6721,5 @@ void fe_ge_sub(fe rx, fe ry, fe rz, fe rt, const fe px, const fe py, const fe pz
     (void)qyminusx;
 }
 
+#endif /* WOLFSSL_ARMASM */
 #endif /* __aarch64__ */

--- a/wolfcrypt/src/port/arm/armv8-sha512-asm.c
+++ b/wolfcrypt/src/port/arm/armv8-sha512-asm.c
@@ -25,6 +25,14 @@
  */
 #ifdef __aarch64__
 #include <stdint.h>
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_ARMASM
 #include <wolfssl/wolfcrypt/sha512.h>
 
 static const uint64_t L_SHA512_transform_neon_len_k[] = {
@@ -1029,4 +1037,5 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
     );
 }
 
+#endif /* WOLFSSL_ARMASM */
 #endif /* __aarch64__ */

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -26,7 +26,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
+#if (defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)) && !defined(WOLFSSL_ARMASM)
 
 #if defined(HAVE_FIPS) && \
 	defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)

--- a/wolfssl/wolfcrypt/port/st/stsafe.h
+++ b/wolfssl/wolfcrypt/port/st/stsafe.h
@@ -23,9 +23,16 @@
 #define _WOLFPORT_STSAFE_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/ssl.h>
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
+
+#ifdef WOLF_CRYPTO_CB
+#include <wolfssl/wolfcrypt/cryptocb.h>
+#endif
+
+#if !defined(WOLFCRYPT_ONLY) && defined(HAVE_PK_CALLBACKS)
+#include <wolfssl/ssl.h>
+#endif
 
 #ifdef WOLFSSL_STSAFEA100
 
@@ -46,7 +53,7 @@
 WOLFSSL_API int SSL_STSAFE_LoadDeviceCertificate(byte** pRawCertificate,
     word32* pRawCertificateLen);
 
-#ifdef HAVE_PK_CALLBACKS
+#if !defined(WOLFCRYPT_ONLY) && defined(HAVE_PK_CALLBACKS)
 WOLFSSL_API int SSL_STSAFE_CreateKeyCb(WOLFSSL* ssl, ecc_key* key, word32 keySz,
     int ecc_curve, void* ctx);
 WOLFSSL_API int SSL_STSAFE_VerifyPeerCertCb(WOLFSSL* ssl,
@@ -71,8 +78,6 @@ WOLFSSL_API int SSL_STSAFE_SetupPkCallbackCtx(WOLFSSL* ssl, void* user_ctx);
 
 
 #ifdef WOLF_CRYPTO_CB
-
-#include <wolfssl/wolfcrypt/cryptocb.h>
 
 /* Device ID that's unique and valid (not INVALID_DEVID -2) */
 #define WOLF_STSAFE_DEVID 0x53545341; /* STSA */

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -527,7 +527,7 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
     #endif
     #define NEED_TMP_TIME
 
-#elif defined(WOLFSSL_XILINX) && defined(FREERTOS)
+#elif defined(WOLFSSL_XILINX)
     #define USER_TIME
     #include <time.h>
 


### PR DESCRIPTION
* Fixes for building with `WOLFSSL_ARMASM` and wildcard include.
* Fix for XTIME issue on bare-metal.
* Fix for building with `WOLFSSL_SMALL_STACK_CACHE` only (no `WOLFSSL_SMALL_STACK`).
* Added Zynqmp benchmark timer support.
* Added IDE/XilinxSDK project and README.md.