### PR TITLE
Fix clang warnings (issue #2870)

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -24153,7 +24153,7 @@ int wolfSSL_sk_CIPHER_description(WOLFSSL_CIPHER* cipher)
     const char* name;
     const char *keaStr, *authStr, *encStr, *macStr, *protocol;
     char n[MAX_SEGMENTS][MAX_SEGMENT_SZ] = {{0}};
-    uint8_t len = MAX_DESCRIPTION_SZ-1;
+    unsigned char len = MAX_DESCRIPTION_SZ-1;
     const CipherSuiteInfo* cipher_names;
     ProtocolVersion pv;
     WOLFSSL_ENTER("wolfSSL_sk_CIPHER_description");
@@ -36380,7 +36380,7 @@ size_t wolfSSL_EC_get_builtin_curves(WOLFSSL_EC_BUILTIN_CURVE *r, size_t nitems)
     size_t ecc_sets_count;
     size_t i, min_nitems;
 
-    for (i = 0; ecc_sets[i].size != 0 && ecc_sets[i].name != NULL; i++);
+    for (i = 0; ecc_sets[i].size != 0; i++);
     ecc_sets_count = i;
 
     if (r == NULL || nitems == 0)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5470,7 +5470,7 @@ int wc_OBJ_sn2nid(const char *sn)
     if (XSTRNCMP(sn, "secp384r1", 10) == 0)
         sn = "SECP384R1";
     /* find based on name and return NID */
-    for (i = 0; ecc_sets[i].size != 0 && ecc_sets[i].name != NULL; i++) {
+    for (i = 0; ecc_sets[i].size != 0; i++) {
         if (XSTRNCMP(sn, ecc_sets[i].name, ECC_MAXNAME) == 0) {
             eccEnum = ecc_sets[i].id;
             /* Convert enum value in ecc_curve_id to OpenSSL NID */


### PR DESCRIPTION
The warning was "comparison of array 'ecc_sets[i].name' not equal to a null
pointer is always true [-Wtautological-pointer-compare]"

Compiler is correct, ecc_sets[i].name  is an array of size 16, thus
can't be NULL

Also, fix build error on Windows by changing uint8_t to "unsigned char"
(alternative fix could be including stdint.h)