### PR TITLE
Correct PSK build error

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8030,8 +8030,6 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PUBKEY_bio(WOLFSSL_BIO* bio,
     return pkey;
 }
 
-
-
 /* Converts a DER encoded public key to a WOLFSSL_EVP_PKEY structure.
  *
  * out  pointer to new WOLFSSL_EVP_PKEY structure. Can be NULL
@@ -8045,17 +8043,28 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PUBKEY(WOLFSSL_EVP_PKEY** out, unsigned char** in,
         long inSz)
 {
     WOLFSSL_EVP_PKEY* pkey = NULL;
+#if !defined(NO_RSA) ||   \
+    defined (HAVE_ECC) || \
+    !defined(NO_DSA) ||   \
+    !defined(NO_DH) && (defined(WOLFSSL_QT) || defined(OPENSSL_ALL))
     const unsigned char* mem;
     long memSz = inSz;
-
+#endif
     WOLFSSL_ENTER("wolfSSL_d2i_PUBKEY");
 
     if (in == NULL || inSz < 0) {
         WOLFSSL_MSG("Bad argument");
         return NULL;
     }
-    mem = *in;
 
+#if !defined(NO_RSA) ||   \
+    defined (HAVE_ECC) || \
+    !defined(NO_DSA) ||   \
+    !defined(NO_DH) && (defined(WOLFSSL_QT) || defined(OPENSSL_ALL))
+    mem = *in;
+#else
+    (void)out;
+#endif
     #if !defined(NO_RSA)
     {
         RsaKey rsa;
@@ -8241,7 +8250,6 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PUBKEY(WOLFSSL_EVP_PKEY** out, unsigned char** in,
     return pkey;
 }
 
-
 /* Reads in a DER format key. If PKCS8 headers are found they are stripped off.
  *
  * type  type of key
@@ -8259,6 +8267,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey(int type, WOLFSSL_EVP_PKEY** out,
     word32 idx = 0;
     int    ret;
     word32 algId;
+    (void)out;
 
     WOLFSSL_ENTER("wolfSSL_d2i_PrivateKey");
 

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -35,6 +35,7 @@
 #include <wolfssl/wolfcrypt/coding.h>
 #include <wolfssl/wolfcrypt/pwdbased.h>
 #include <wolfssl/wolfcrypt/logging.h>
+#include <wolfssl/wolfcrypt/wc_encrypt.h>
 
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -187,8 +187,12 @@ enum {
 
     PEM_PASS_READ  = 0,
     PEM_PASS_WRITE = 1,
-};
+#if defined(NO_ASN)
+    PKCS5_SALT_SZ  = 8,
+    HMAC_SHA256_OID   = 653,
+#endif
 
+};
 
 typedef int (pem_password_cb)(char* passwd, int sz, int rw, void* userdata);
 
@@ -207,7 +211,6 @@ typedef struct EncryptedInfo {
 
     word16   set:1;            /* if encryption set */
 } EncryptedInfo;
-
 
 #define WOLFSSL_ASN1_INTEGER_MAX 20
 typedef struct WOLFSSL_ASN1_INTEGER {

--- a/wolfssl/wolfcrypt/wc_encrypt.h
+++ b/wolfssl/wolfcrypt/wc_encrypt.h
@@ -32,6 +32,7 @@
 #include <wolfssl/wolfcrypt/chacha.h>
 #include <wolfssl/wolfcrypt/des3.h>
 #include <wolfssl/wolfcrypt/arc4.h>
+#include <wolfssl/wolfcrypt/asn_public.h>
 
 #ifdef __cplusplus
     extern "C" {
@@ -76,11 +77,7 @@ WOLFSSL_API int wc_Des3_CbcDecryptWithKey(byte* out,
                                           const byte* key, const byte* iv);
 #endif /* !NO_DES3 */
 
-
-
-
 #ifdef WOLFSSL_ENCRYPTED_KEYS
-    struct EncryptedInfo;
     WOLFSSL_API int wc_BufferKeyDecrypt(struct EncryptedInfo* info, byte* der, word32 derSz,
         const byte* password, int passwordSz, int hashType);
     WOLFSSL_API int wc_BufferKeyEncrypt(struct EncryptedInfo* info, byte* der, word32 derSz,
@@ -88,7 +85,7 @@ WOLFSSL_API int wc_Des3_CbcDecryptWithKey(byte* out,
 #endif /* WOLFSSL_ENCRYPTED_KEYS */
 
 #ifndef NO_PWDBASED
-    WOLFSSL_LOCAL int wc_CryptKey(const char* password, int passwordSz, 
+    WOLFSSL_LOCAL int wc_CryptKey(const char* password, int passwordSz,
         byte* salt, int saltSz, int iterations, int id, byte* input, int length,
         int version, byte* cbcIv, int enc, int shaOid);
 #endif


### PR DESCRIPTION
This PR fixes build errors encountered with the following configurations:

```
./configure --enable-enckeys --disable-asn --disable-rsa --disable-ecc --enable-psk

```