### PR TITLE
Reset ChaCha20 state after deriving 256 bit Poly1305 key

### DIFF
--- a/doc/dox_comments/header_files/chacha.h
+++ b/doc/dox_comments/header_files/chacha.h
@@ -97,3 +97,29 @@ WOLFSSL_API int wc_Chacha_Process(ChaCha* ctx, byte* cipher, const byte* plain,
     \sa wc_Chacha_Process
 */
 WOLFSSL_API int wc_Chacha_SetKey(ChaCha* ctx, const byte* key, word32 keySz);
+
+/*!
+    \ingroup ChaCha
+
+    \brief This function resets the pending states in ChaCha object.
+    This is needed after deriving one time Poly1305 key.
+
+    \return none No returns.
+
+    \param ctx pointer to the ChaCha structure in which to set the key
+
+    _Example_
+    \code
+    byte poly_key[CHACHA20_256_KEY_SIZE];
+    XMEMSET(poly_key, 0, sizeof(poly_key));
+    if (wc_Chacha_Process(chacha_ctx, poly_key, poly_key, sizeof(poly_key)) != 0) {
+        // error deriving one time Poly1305 key
+        return -1;
+    }
+    wc_Chacha_Reset(ctx);
+    \endcode
+
+    \sa wc_Chacha_SetIV
+    \sa wc_Chacha_Process
+*/
+WOLFSSL_API void wc_Chacha_Reset(ChaCha* ctx);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -1658,6 +1658,7 @@ static int ChaCha20Poly1305_Encrypt(WOLFSSL* ssl, byte* output,
     ret = wc_Chacha_Process(ssl->encrypt.chacha, poly, poly, sizeof(poly));
     if (ret != 0)
         return ret;
+    wc_Chacha_Reset(ssl->encrypt.chacha);
     /* Encrypt the plain text. */
     ret = wc_Chacha_Process(ssl->encrypt.chacha, output, input, sz);
     if (ret != 0) {
@@ -1941,6 +1942,7 @@ static int ChaCha20Poly1305_Decrypt(WOLFSSL* ssl, byte* output,
     ret = wc_Chacha_Process(ssl->decrypt.chacha, poly, poly, sizeof(poly));
     if (ret != 0)
         return ret;
+    wc_Chacha_Reset(ssl->decrypt.chacha);
 
     /* Set key for Poly1305. */
     ret = wc_Poly1305SetKey(ssl->auth.poly1305, poly, sizeof(poly));

--- a/wolfcrypt/src/chacha.c
+++ b/wolfcrypt/src/chacha.c
@@ -343,6 +343,12 @@ int wc_Chacha_Process(ChaCha* ctx, byte* output, const byte* input,
     return 0;
 }
 
+void wc_Chacha_Reset(ChaCha* ctx)
+{
+    ctx->left = 0;
+    ctx->X[CHACHA_IV_BYTES] = PLUSONE(ctx->X[CHACHA_IV_BYTES]);
+}
+
 #endif /* HAVE_CHACHA*/
 
 #endif /* WOLFSSL_ARMASM */

--- a/wolfssl/wolfcrypt/chacha.h
+++ b/wolfssl/wolfcrypt/chacha.h
@@ -74,6 +74,8 @@ WOLFSSL_API int wc_Chacha_Process(ChaCha* ctx, byte* cipher, const byte* plain,
                               word32 msglen);
 WOLFSSL_API int wc_Chacha_SetKey(ChaCha* ctx, const byte* key, word32 keySz);
 
+WOLFSSL_API void wc_Chacha_Reset(ChaCha* ctx);
+
 #ifdef __cplusplus
     } /* extern "C" */
 #endif


### PR DESCRIPTION
Changes in `wc_Chacha_encrypt_bytes` function at https://github.com/wolfSSL/wolfssl/commit/0ec7b311d8f50b576c28ff49d0753a406dfaaa08 breaks the interoperability of TLS ChaCha20Poly1305 Ciphersuite. 

I feel the issue lies in `ChaCha20Poly1305_xxcrypt` function, which does not resets the ChaCha20 state after deriving 256 bit Poly1305 key as per Section 2.8 and [2.6](https://tools.ietf.org/html/rfc7539#section-2.6) of RFC 7539.