### PR TITLE
Fix for building with `NO_WOLFSSL_DIR`

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28430,7 +28430,7 @@ WOLFSSL_API WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_PrivateKey(XFILE fp, WOLFSSL_EVP_
 #endif
 #endif
 
-#if !defined(NO_FILESYSTEM)
+#if !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR)
 /* Loads certificate(s) files in pem format into X509_STORE struct from either
  * a file or directory.
  * Returns WOLFSSL_SUCCESS on success or WOLFSSL_FAILURE if an error occurs.
@@ -28530,7 +28530,7 @@ WOLFSSL_API int wolfSSL_X509_STORE_load_locations(WOLFSSL_X509_STORE *str,
 
     return ret;
 }
-#endif
+#endif /* !NO_FILESYSTEM && !NO_WOLFSSL_DIR */
 
 #ifndef NO_WOLFSSL_STUB
 /*** TBD ***/


### PR DESCRIPTION
Fix for building with `NO_WOLFSSL_DIR` when compatibility layer is enabled. ZD 10117.