### PR TITLE
Fixes from cppcheck

### DIFF
--- a/IDE/Espressif/ESP-IDF/test/test_wolfssl.c
+++ b/IDE/Espressif/ESP-IDF/test/test_wolfssl.c
@@ -171,7 +171,7 @@ static void tskAes256_Test(void *pvParam)
 }
 #endif
 
-#if !defined(NO_RSA) || defined(HAVE_ECC)
+#if (!defined(NO_RSA) || defined(HAVE_ECC)) && !defined(WC_NO_RNG)
 
 int mp_performance_check(int mul, int mulmod, int exptmod)
 {
@@ -636,7 +636,7 @@ TEST_CASE("wolfssl mp mul performance test"   , "[wolfssl]")
 
     TEST_ASSERT_EQUAL(0, mp_performance_check(mul, mulmod, exptmod));
 }
-#endif/* !NO_RSA || HAVE_ECC */
+#endif/* (!NO_RSA || HAVE_ECC) && !WC_NO_RNG */
 
 TEST_CASE("wolfssl aes test"  , "[wolfssl]")
 {

--- a/IDE/MDK5-ARM/Projects/wolfSSL-Full/shell.c
+++ b/IDE/MDK5-ARM/Projects/wolfSSL-Full/shell.c
@@ -630,7 +630,9 @@ void shell_main(void *arg) {
     int i ;
     func_args args ;
     int bf_flg ;
+#if defined(WOLFSSL_CMSIS_RTOS)
     osThreadId 	 cmd ;
+#endif
     i = BackGround ;
         /* Dummy for avoiding warning: BackGround is defined but not used. */
 

--- a/IDE/Renesas/e2studio/DK-S7G2/benchmark-template/src/app_entry.c
+++ b/IDE/Renesas/e2studio/DK-S7G2/benchmark-template/src/app_entry.c
@@ -58,7 +58,9 @@ static void benchmark_TLS(int version, char* suites, int group)
     int i;
     NX_TCP_SOCKET sockfd;
     int ret;
+#ifdef WOLFSSL_TLS13
     int groups[1];
+#endif
     double start;
     WOLFSSL_METHOD* method = NULL;
 

--- a/IDE/zephyr/wolfssl_tls_sock/src/tls_sock.c
+++ b/IDE/zephyr/wolfssl_tls_sock/src/tls_sock.c
@@ -100,9 +100,7 @@ static int wolfssl_client_new(WOLFSSL_CTX** ctx, WOLFSSL** ssl)
     if (ret == 0) {
         /* make wolfSSL object nonblocking */
         wolfSSL_set_using_nonblock(client_ssl, 1);
-    }
 
-    if (ret == 0) {
         /* Return newly created wolfSSL context and object */
         *ctx = client_ctx;
         *ssl = client_ssl;
@@ -178,9 +176,7 @@ static int wolfssl_server_new(WOLFSSL_CTX** ctx, WOLFSSL** ssl)
     if (ret == 0) {
         /* make wolfSSL object nonblocking */
         wolfSSL_set_using_nonblock(server_ssl, 1);
-    }
 
-    if (ret == 0) {
         /* Return newly created wolfSSL context and object */
         *ctx = server_ctx;
         *ssl = server_ssl;
@@ -355,9 +351,9 @@ void server_thread(void* arg1, void* arg2, void* arg3)
         printf("unable to load static memory");
         ret = -1;
     }
-#endif
 
     if (ret == 0)
+#endif
         ret = wolfssl_server_new(&server_ctx, &server_ssl);
 
     if (ret == 0)
@@ -415,8 +411,7 @@ int wolfssl_client_connect_tcp(WOLFSSL* ssl, SOCKET_T* fd)
     if (ret == 0) {
         *fd = sockfd;
         tcp_set_nonblocking(&sockfd);
-    }
-    if (ret == 0) {
+
         printf("Client Connect\n");
         if (connect(sockfd, res->ai_addr, res->ai_addrlen) != 0)
             ret = -1;
@@ -446,11 +441,13 @@ void client_thread()
         printf("unable to load static memory");
         ret = -1;
     }
-#endif
 
-    /* Client connection */
     if (ret == 0)
+#endif
+    {
+        /* Client connection */
         ret = wolfssl_client_new(&client_ctx, &client_ssl);
+    }
 
     if (ret == 0)
         ret = wolfssl_client_connect_tcp(client_ssl, &sockfd);
@@ -462,12 +459,12 @@ void client_thread()
             break;
     }
 
-    if (ret == 0)
+    if (ret == 0) {
         printf("Handshake complete\n");
 
-    /* Send HTTP request */
-    if (ret == 0)
+        /* Send HTTP request */
         ret = wolfssl_send(client_ssl, msgHTTPGet);
+    }
     /* Receive HTTP response */
     while (ret == 0) {
         k_sleep(10);

--- a/IDE/zephyr/wolfssl_tls_thread/src/tls_threaded.c
+++ b/IDE/zephyr/wolfssl_tls_thread/src/tls_threaded.c
@@ -181,9 +181,7 @@ static int wolfssl_client_new(WOLFSSL_CTX** ctx, WOLFSSL** ssl)
         /* Register callbacks */
         wolfSSL_SetIORecv(client_ctx, recv_client);
         wolfSSL_SetIOSend(client_ctx, send_client);
-    }
 
-    if (ret == 0) {
         /* Create a WOLFSSL object */
         if ((client_ssl = wolfSSL_new(client_ctx)) == NULL) {
             printf("ERROR: failed to create WOLFSSL object\n");
@@ -194,9 +192,7 @@ static int wolfssl_client_new(WOLFSSL_CTX** ctx, WOLFSSL** ssl)
     if (ret == 0) {
         /* make wolfSSL object nonblocking */
         wolfSSL_set_using_nonblock(client_ssl, 1);
-    }
 
-    if (ret == 0) {
         /* Return newly created wolfSSL context and object */
         *ctx = client_ctx;
         *ssl = client_ssl;
@@ -264,9 +260,7 @@ static int wolfssl_server_new(WOLFSSL_CTX** ctx, WOLFSSL** ssl)
         /* Register callbacks */
         wolfSSL_SetIORecv(server_ctx, recv_server);
         wolfSSL_SetIOSend(server_ctx, send_server);
-    }
 
-    if (ret == 0) {
         /* Create a WOLFSSL object */
         if ((server_ssl = wolfSSL_new(server_ctx)) == NULL) {
             printf("ERROR: failed to create WOLFSSL object\n");
@@ -277,9 +271,7 @@ static int wolfssl_server_new(WOLFSSL_CTX** ctx, WOLFSSL** ssl)
     if (ret == 0) {
         /* make wolfSSL object nonblocking */
         wolfSSL_set_using_nonblock(server_ssl, 1);
-    }
 
-    if (ret == 0) {
         /* Return newly created wolfSSL context and object */
         *ctx = server_ctx;
         *ssl = server_ssl;
@@ -406,9 +398,9 @@ void server_thread(void* arg1, void* arg2, void* arg3)
         printf("unable to load static memory");
         ret = -1;
     }
-#endif
 
     if (ret == 0)
+#endif
         ret = wolfssl_server_new(&server_ctx, &server_ssl);
 
     while (ret == 0) {
@@ -458,11 +450,13 @@ int main()
         printf("unable to load static memory");
         ret = -1;
     }
-#endif
 
-    /* Client connection */
     if (ret == 0)
+#endif
+    {
+        /* Client connection */
         ret = wolfssl_client_new(&client_ctx, &client_ssl);
+    }
 
     while (ret == 0) {
         ret = wolfssl_client_connect(client_ssl);
@@ -471,12 +465,12 @@ int main()
         k_sleep(10);
     }
 
-    if (ret == 0)
+    if (ret == 0) {
         printf("Handshake complete\n");
 
-    /* Send HTTP request */
-    if (ret == 0)
+        /* Send HTTP request */
         ret = wolfssl_send(client_ssl, msgHTTPGet);
+    }
     /* Receive HTTP response */
     while (ret == 0) {
         k_sleep(10);

--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -211,7 +211,7 @@ static const char* kTestStr =
 
 #if !defined(NO_WOLFSSL_SERVER)
 /* dh2048 p */
-static const unsigned char p[] =
+static const unsigned char dhp[] =
 {
     0xb0, 0xa1, 0x08, 0x06, 0x9c, 0x08, 0x13, 0xba, 0x59, 0x06, 0x3c, 0xbc, 0x30,
     0xd5, 0xf5, 0x00, 0xc1, 0x4f, 0x44, 0xa7, 0xd6, 0xef, 0x4a, 0xc6, 0x25, 0x27,
@@ -236,7 +236,7 @@ static const unsigned char p[] =
 };
 
 /* dh2048 g */
-static const unsigned char g[] =
+static const unsigned char dhg[] =
 {
     0x02,
 };
@@ -575,12 +575,11 @@ static int ReceiveFrom(WOLFSSL *ssl, int sd, char *buf, int sz)
 }
 
 static int SendTo(int sd, char *buf, int sz, const struct sockaddr *peer, 
-                                                            socklen_t peerSz)
+                  socklen_t peerSz)
 {
     int sent;
-    int len = sz;
 
-    sent = (int)sendto(sd, &buf[sz - len], len, 0, peer, peerSz);
+    sent = (int)sendto(sd, buf, sz, 0, peer, peerSz);
 
     if (sent < 0) {
         if (errno == SOCKET_EWOULDBLOCK || errno == SOCKET_EAGAIN) {
@@ -1312,7 +1311,7 @@ static int bench_tls_server(info_t* info)
         wolfSSL_SetIOReadCtx(srv_ssl, info);
         wolfSSL_SetIOWriteCtx(srv_ssl, info);
     #ifndef NO_DH
-        wolfSSL_SetTmpDH(srv_ssl, p, sizeof(p), g, sizeof(g));
+        wolfSSL_SetTmpDH(srv_ssl, dhp, sizeof(dhp), dhg, sizeof(dhg));
     #endif
 
         /* accept TLS connection */

--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -59,8 +59,10 @@ void echoclient_test(void* args)
     FILE* fin   = stdin  ;
     FILE* fout = stdout;
 
+#ifndef WOLFSSL_MDK_SHELL
     int inCreated  = 0;
     int outCreated = 0;
+#endif
 
     char msg[1024];
     char reply[1024+1];
@@ -106,11 +108,11 @@ void echoclient_test(void* args)
 #ifdef CYASSL_LEANPSK
     doPSK = 1;
 #endif
-
 #if defined(NO_RSA) && !defined(HAVE_ECC) && !defined(HAVE_ED25519) && \
                                                             !defined(HAVE_ED448)
     doPSK = 1;
 #endif
+    (void)doPSK;
 
 #if defined(NO_MAIN_DRIVER) && !defined(USE_WINDOWS_API) && !defined(WOLFSSL_MDK_SHELL)
     port = ((func_args*)args)->signal->port;
@@ -151,8 +153,8 @@ void echoclient_test(void* args)
     /* don't use EDH, can't sniff tmp keys */
     SSL_CTX_set_cipher_list(ctx, "AES256-SHA");
 #endif
-    if (doPSK) {
 #ifndef NO_PSK
+    if (doPSK) {
         const char *defaultCipherList;
 
         CyaSSL_CTX_set_psk_client_callback(ctx, my_psk_client_cb);
@@ -165,8 +167,8 @@ void echoclient_test(void* args)
         #endif
         if (CyaSSL_CTX_set_cipher_list(ctx,defaultCipherList) !=WOLFSSL_SUCCESS)
             err_sys("client can't set cipher list 2");
-#endif
     }
+#endif
 
 #ifdef WOLFSSL_ENCRYPTED_KEYS
     SSL_CTX_set_default_passwd_cb(ctx, PasswordCallBack);
@@ -318,8 +320,10 @@ void echoclient_test(void* args)
 #endif
 
     fflush(fout);
+#ifndef WOLFSSL_MDK_SHELL
     if (inCreated)  fclose(fin);
     if (outCreated) fclose(fout);
+#endif
 
     CloseSocket(sockfd);
     ((func_args*)args)->return_code = 0;

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -201,7 +201,6 @@ static int TestEmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
     WOLFSSL_TEST_DTLS_CTX* dtlsCtx = (WOLFSSL_TEST_DTLS_CTX*)ctx;
     int sd = dtlsCtx->wfd;
     int sent;
-    int len = sz;
     int err;
 
     (void)ssl;
@@ -218,9 +217,8 @@ static int TestEmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
         }
     }
 
-    sent = (int)sendto(sd, &buf[sz - len], len, 0,
-                                (const SOCKADDR*)&dtlsCtx->peer.sa,
-                                dtlsCtx->peer.sz);
+    sent = (int)sendto(sd, buf, sz, 0, (const SOCKADDR*)&dtlsCtx->peer.sa,
+                                                             dtlsCtx->peer.sz);
 
     sent = TranslateReturnCode(sent, sd);
 
@@ -428,7 +426,11 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
     #endif
             "\tRX      %8.3f ms (%8.3f MBps)\n"
             "\tTX      %8.3f ms (%8.3f MBps)\n",
+    #if !defined(__MINGW32__)
             throughput,
+    #else
+            (int)throughput,
+    #endif
             tx_time * 1000, throughput / tx_time / 1024 / 1024,
             rx_time * 1000, throughput / rx_time / 1024 / 1024
         );
@@ -900,7 +902,9 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 #endif
     int    useWebServerMsg = 0;
     char   input[80];
+#ifndef WOLFSSL_VXWORKS
     int    ch;
+#endif
     int    version = SERVER_DEFAULT_VERSION;
 #ifndef WOLFSSL_NO_CLIENT_AUTH
     int    doCliCertCheck = 1;
@@ -2197,11 +2201,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             }
             #endif
             tcp_set_nonblocking(&clientfd);
-        }
-#endif
 
-#ifndef WOLFSSL_CALLBACKS
-        if (nonBlocking) {
             ret = NonBlockingSSL_Accept(ssl);
         }
         else {

--- a/src/internal.c
+++ b/src/internal.c
@@ -6293,27 +6293,29 @@ void SSL_ResourceFree(WOLFSSL* ssl)
 #endif
 #if defined(HAVE_ECC) || defined(HAVE_CURVE25519) ||defined(HAVE_CURVE448)
     {
-        int dtype;
+        int dtype = 0;
     #ifdef HAVE_ECC
         dtype = DYNAMIC_TYPE_ECC;
     #endif
     #ifdef HAVE_CURVE25519
+        if (ssl->peerX25519KeyPresent
     #ifdef HAVE_ECC
-        if (ssl->peerX25519KeyPresent ||
-                              ssl->eccTempKeyPresent == DYNAMIC_TYPE_CURVE25519)
+                           || ssl->eccTempKeyPresent == DYNAMIC_TYPE_CURVE25519
     #endif /* HAVE_ECC */
-         {
+           )
+        {
             dtype = DYNAMIC_TYPE_CURVE25519;
-         }
+        }
     #endif /* HAVE_CURVE25519 */
     #ifdef HAVE_CURVE448
+        if (ssl->peerX448KeyPresent
     #ifdef HAVE_ECC
-        if (ssl->peerX448KeyPresent ||
-                                ssl->eccTempKeyPresent == DYNAMIC_TYPE_CURVE448)
+                             || ssl->eccTempKeyPresent == DYNAMIC_TYPE_CURVE448
     #endif /* HAVE_ECC */
-         {
+           )
+        {
             dtype = DYNAMIC_TYPE_CURVE448;
-         }
+        }
     #endif /* HAVE_CURVE448 */
         FreeKey(ssl, dtype, (void**)&ssl->eccTempKey);
         ssl->eccTempKeyPresent = 0;
@@ -11217,7 +11219,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         }
 
                         if (keyRet != 0 || wc_RsaPublicKeyDecode(
-                                args->dCert->publicKey, &keyIdx, ssl->peerRsaKey,
+                               args->dCert->publicKey, &keyIdx, ssl->peerRsaKey,
                                                 args->dCert->pubKeySize) != 0) {
                             ret = PEER_KEY_ERROR;
                         }
@@ -11230,10 +11232,10 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 ssl->peerTsipEncRsaKeyIndex = (byte*)XMALLOC(
                                     TSIP_TLS_ENCPUBKEY_SZ_BY_CERTVRFY,
                                     ssl->heap, DYNAMIC_TYPE_RSA);
-                            }
-                            if (!ssl->peerTsipEncRsaKeyIndex) {
-                                args->lastErr = MEMORY_E;
-                                goto exit_ppc;
+                                if (!ssl->peerTsipEncRsaKeyIndex) {
+                                    args->lastErr = MEMORY_E;
+                                    goto exit_ppc;
+                                }
                             }
 
                             XMEMCPY(ssl->peerTsipEncRsaKeyIndex,
@@ -19749,7 +19751,7 @@ exit_dpk:
         }
 #endif
 
-        if ((*inOutIdx - begin) + OPAQUE16_LEN + OPAQUE8_LEN > size)
+        if (OPAQUE16_LEN + OPAQUE8_LEN > size)
             return BUFFER_ERROR;
 
         XMEMCPY(&pv, input + *inOutIdx, OPAQUE16_LEN);
@@ -20294,7 +20296,7 @@ exit_dpk:
                 AddLateName("CertificateRequest", &ssl->timeoutInfo);
         #endif
 
-        if ((*inOutIdx - begin) + OPAQUE8_LEN > size)
+        if (OPAQUE8_LEN > size)
             return BUFFER_ERROR;
 
         len = input[(*inOutIdx)++];
@@ -23945,7 +23947,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         return SESSION_TICKET_EXPECT_E;
     }
 
-    if ((*inOutIdx - begin) + OPAQUE32_LEN > size)
+    if (OPAQUE32_LEN > size)
         return BUFFER_ERROR;
 
     ato32(input + *inOutIdx, &lifetime);
@@ -26459,7 +26461,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (ssl->toInfoOn) AddLateName("ClientHello", &ssl->timeoutInfo);
 #endif
         /* protocol version, random and session id length check */
-        if ((i - begin) + OPAQUE16_LEN + RAN_LEN + OPAQUE8_LEN > helloSz)
+        if (OPAQUE16_LEN + RAN_LEN + OPAQUE8_LEN > helloSz)
             return BUFFER_ERROR;
 
         /* protocol version */
@@ -29003,7 +29005,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         ret = args->lastErr;
                         args->lastErr = 0; /* reset */
                         /* On error 'ret' will be negative - top bit set */
-                        mask = (ret >> ((sizeof(ret) * 8) - 1)) - 1;
+                        mask = ((unsigned int)ret >>
+                                                   ((sizeof(ret) * 8) - 1)) - 1;
 
                         /* build PreMasterSecret */
                         ssl->arrays->preMasterSecret[0] = ssl->chVersion.major;

--- a/src/keys.c
+++ b/src/keys.c
@@ -2227,14 +2227,16 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
 #ifdef BUILD_ARC4
     if (specs->bulk_cipher_algorithm == wolfssl_rc4) {
         word32 sz = specs->key_size;
-        if (enc && enc->arc4 == NULL)
+        if (enc && enc->arc4 == NULL) {
             enc->arc4 = (Arc4*)XMALLOC(sizeof(Arc4), heap, DYNAMIC_TYPE_CIPHER);
-        if (enc && enc->arc4 == NULL)
-            return MEMORY_E;
-        if (dec && dec->arc4 == NULL)
+            if (enc->arc4 == NULL)
+                 return MEMORY_E;
+        }
+        if (dec && dec->arc4 == NULL) {
             dec->arc4 = (Arc4*)XMALLOC(sizeof(Arc4), heap, DYNAMIC_TYPE_CIPHER);
-        if (dec && dec->arc4 == NULL)
-            return MEMORY_E;
+            if (dec->arc4 == NULL)
+                return MEMORY_E;
+        }
 
         if (enc) {
             if (wc_Arc4Init(enc->arc4, heap, devId) != 0) {
@@ -2903,16 +2905,16 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
             if (enc && enc->hmac == NULL) {
                 enc->hmac = (Hmac*)XMALLOC(sizeof(Hmac), heap,
                                                            DYNAMIC_TYPE_CIPHER);
+                if (enc->hmac == NULL)
+                    return MEMORY_E;
             }
-            if (enc && enc->hmac == NULL)
-                return MEMORY_E;
 
             if (dec && dec->hmac == NULL) {
                 dec->hmac = (Hmac*)XMALLOC(sizeof(Hmac), heap,
                                                            DYNAMIC_TYPE_CIPHER);
+                if (dec->hmac == NULL)
+                    return MEMORY_E;
             }
-            if (dec && dec->hmac == NULL)
-                return MEMORY_E;
 
             if (enc) {
                 if (wc_HmacInit(enc->hmac, heap, devId) != 0) {

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -1875,14 +1875,14 @@ static int ProcessClientKeyExchange(const byte* input, int* sslBytes,
             }
         }
 
-        if (ret == 0) {
         #ifdef WC_RSA_BLINDING
+        if (ret == 0) {
             ret = wc_RsaSetRNG(&key, session->sslServer->rng);
             if (ret != 0) {
                 SetError(RSA_DECRYPT_STR, error, session, FATAL_ERROR_STATE);
             }
-        #endif
         }
+        #endif
 
         if (ret == 0) {
             session->keySz = length * WOLFSSL_BIT_SIZE;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1152,10 +1152,9 @@ int wolfSSL_CTX_mcast_set_member_id(WOLFSSL_CTX* ctx, word16 id)
 #ifndef WOLFSSL_USER_IO
         ctx->CBIORecv = EmbedReceiveFromMcast;
 #endif /* WOLFSSL_USER_IO */
-    }
 
-    if (ret == 0)
         ret = WOLFSSL_SUCCESS;
+    }
     WOLFSSL_LEAVE("wolfSSL_CTX_mcast_set_member_id()", ret);
     return ret;
 }
@@ -6384,9 +6383,8 @@ static int ProcessChainBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
         ret = ProcessBuffer(ctx, buff + used, sz - used, format, type, ssl,
                             &consumed, 0, verify);
 
-#ifdef WOLFSSL_WPAS
-#ifdef HAVE_CRL
         if (ret < 0) {
+#if defined(WOLFSSL_WPAS) && defined(HAVE_CRL)
             DerBuffer*    der = NULL;
             EncryptedInfo info;
 
@@ -6395,15 +6393,13 @@ static int ProcessChainBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
                                                                    NULL) == 0) {
                 WOLFSSL_MSG("   Processed a CRL");
                 wolfSSL_CertManagerLoadCRLBuffer(ctx->cm, der->buffer,
-                                                der->length, WOLFSSL_FILETYPE_ASN1);
+                                            der->length, WOLFSSL_FILETYPE_ASN1);
                 FreeDer(&der);
                 used += info.consumed;
                 continue;
             }
-        }
 #endif
-#endif
-        if (ret < 0) {
+
             if (consumed > 0) { /* Made progress in file */
                 WOLFSSL_ERROR(ret);
                 WOLFSSL_MSG("CA Parse failed, with progress in file.");
@@ -13471,9 +13467,7 @@ int AddSession(WOLFSSL* ssl)
             session->ticket = session->staticTicket;
             session->isDynamic = 0;
         }
-    }
 
-    if (error == 0) {
         session->ticketLen = (word16)ticLen;
         XMEMCPY(session->ticket, ssl->session.ticket, ticLen);
     } else { /* cleanup, reset state */
@@ -39327,8 +39321,6 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
     #ifdef WOLFSSL_CERT_EXT
         cName->busCat[0] = '\0';
         cName->busCatEnc = CTC_UTF8;
-        cName->serialDev[0] = '\0';
-        cName->serialDevEnc = CTC_PRINTABLE;
         cName->joiC[0] = '\0';
         cName->joiCEnc = CTC_PRINTABLE;
         cName->joiSt[0] = '\0';
@@ -40260,10 +40252,8 @@ err:
         if (ret == WOLFSSL_SUCCESS) {
             XSTRNCPY(nameStr, pem + PEM_BEGIN_SZ, nameLen);
             nameStr[nameLen] = '\0';
-        }
 
-        /* Get header of PEM - encryption header. */
-        if (ret == WOLFSSL_SUCCESS) {
+            /* Get header of PEM - encryption header. */
             headerLen = 0;
             while ((pemLen = wolfSSL_BIO_gets(bio, pem, sizeof(pem) - 1)) > 0) {
                 while (pemLen > 0 && (pem[pemLen - 1] == '\r' ||
@@ -43695,7 +43685,9 @@ long wolfSSL_ctrl(WOLFSSL* ssl, int cmd, long opt, void* pt)
 
 long wolfSSL_CTX_ctrl(WOLFSSL_CTX* ctx, int cmd, long opt, void* pt)
 {
+#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
     long ctrl_opt;
+#endif
     long ret = WOLFSSL_SUCCESS;
 
     WOLFSSL_ENTER("wolfSSL_CTX_ctrl");

--- a/src/tls.c
+++ b/src/tls.c
@@ -8996,13 +8996,13 @@ static int TLSX_EarlyData_Parse(WOLFSSL* ssl, byte* input, word16 length,
         return TLSX_EarlyData_Use(ssl, 1);
     }
     if (msgType == session_ticket) {
-        word32 max;
+        word32 maxSz;
 
         if (length != OPAQUE32_LEN)
             return BUFFER_E;
-        ato32(input, &max);
+        ato32(input, &maxSz);
 
-        ssl->session.maxEarlyDataSz = max;
+        ssl->session.maxEarlyDataSz = maxSz;
         return 0;
     }
 

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -392,12 +392,11 @@ int EmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
     WOLFSSL_DTLS_CTX* dtlsCtx = (WOLFSSL_DTLS_CTX*)ctx;
     int sd = dtlsCtx->wfd;
     int sent;
-    int len = sz;
     int err;
 
     WOLFSSL_ENTER("EmbedSendTo()");
 
-    sent = (int)SENDTO_FUNCTION(sd, &buf[sz - len], len, ssl->wflags,
+    sent = (int)SENDTO_FUNCTION(sd, buf, sz, ssl->wflags,
                                 (const SOCKADDR*)dtlsCtx->peer.sa,
                                 dtlsCtx->peer.sz);
 
@@ -1928,12 +1927,11 @@ int MicriumSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
     WOLFSSL_DTLS_CTX* dtlsCtx = (WOLFSSL_DTLS_CTX*)ctx;
     NET_SOCK_ID sd = dtlsCtx->wfd;
     NET_SOCK_RTN_CODE ret;
-    int len = sz;
     NET_ERR err;
 
     WOLFSSL_ENTER("MicriumSendTo()");
 
-    ret = NetSock_TxDataTo(sd, &buf[sz - len], len, ssl->wflags,
+    ret = NetSock_TxDataTo(sd, buf, sz, ssl->wflags,
                            (NET_SOCK_ADDR*)dtlsCtx->peer.sa,
                            (NET_SOCK_ADDR_LEN)dtlsCtx->peer.sz,
                            &err);

--- a/tests/api.c
+++ b/tests/api.c
@@ -13728,8 +13728,7 @@ static int test_wc_DsaPublicPrivateKeyDecode (void)
                 priv = WOLFSSL_FATAL_ERROR;
             }
         }
-    } /* END Private Key  */
-    if (ret == 0) {
+
         wc_FreeDsaKey(&key);
         ret = wc_InitDsaKey(&key);
     }
@@ -27085,11 +27084,12 @@ static void test_wolfSSL_sk_CIPHER_description(void)
         }
 
         /* Search cipher description string for "unknown" descriptor */
-        for (j=0; j < (int)XSTRLEN(buf); j++) {
-            k=0;
-            while ((buf[j] == badStr[k]) && (k < (int)XSTRLEN(badStr))) {
+        for (j = 0; j < (int)XSTRLEN(buf); j++) {
+            k = 0;
+            while ((k < (int)XSTRLEN(badStr)) && (buf[j] == badStr[k])) {
                 test_str[k] = badStr[k];
-                j++,k++;
+                j++;
+                k++;
             }
         }
         /* Fail if test_str == badStr == "unknown" */
@@ -28782,11 +28782,13 @@ static void test_wc_ecc_get_curve_id_from_name(void)
 static void test_wc_ecc_get_curve_id_from_dp_params(void)
 {
     int id;
+#if !defined(NO_ECC256) && !defined(NO_ECC_SECP)
     int curve_id;
-    int ret = 0;
-    WOLFSSL_EC_KEY *ecKey;
     ecc_key* key;
     const ecc_set_type* params;
+    int ret;
+#endif
+    WOLFSSL_EC_KEY *ecKey = NULL;
 
     printf(testingFmt, "wc_ecc_get_curve_id_from_dp_params");
 

--- a/tests/srp.c
+++ b/tests/srp.c
@@ -38,7 +38,7 @@ static word32 usernameSz = 4;
 static byte password[] = "password";
 static word32 passwordSz = 8;
 
-static byte N[] = {
+static byte srp_N[] = {
     0xD4, 0xC7, 0xF8, 0xA2, 0xB3, 0x2C, 0x11, 0xB8, 0xFB, 0xA9, 0x58, 0x1E,
     0xC4, 0xBA, 0x4F, 0x1B, 0x04, 0x21, 0x56, 0x42, 0xEF, 0x73, 0x55, 0xE3,
     0x7C, 0x0F, 0xC0, 0x44, 0x3E, 0xF7, 0x56, 0xEA, 0x2C, 0x6B, 0x8E, 0xEB,
@@ -47,15 +47,15 @@ static byte N[] = {
     0xDB, 0xDF, 0xCA, 0x43
 };
 
-static byte g[] = {
+static byte srp_g[] = {
     0x02
 };
 
-static byte salt[] = {
+static byte srp_salt[] = {
     0x80, 0x66, 0x61, 0x5B, 0x7D, 0x33, 0xA2, 0x2E, 0x79, 0x18
 };
 
-static byte verifier[] = {
+static byte srp_verifier[] = {
     0x24, 0x5F, 0xA5, 0x1B, 0x2A, 0x28, 0xF8, 0xFF, 0xE2, 0xA0, 0xF8, 0x61,
     0x7B, 0x0F, 0x3C, 0x05, 0xD6, 0x4A, 0x55, 0xDF, 0x74, 0x31, 0x54, 0x47,
     0xA1, 0xFA, 0x9D, 0x25, 0x7B, 0x02, 0x88, 0x0A, 0xE8, 0x5A, 0xBA, 0x8B,
@@ -64,13 +64,13 @@ static byte verifier[] = {
     0x38, 0x19, 0xAB, 0x24
 };
 
-static byte a[] = {
+static byte srp_a[] = {
     0x37, 0x95, 0xF2, 0xA6, 0xF1, 0x6F, 0x0D, 0x58, 0xBF, 0xED, 0x44, 0x87,
     0xE0, 0xB6, 0xCC, 0x1C, 0xA0, 0x50, 0xC6, 0x61, 0xBB, 0x36, 0xE0, 0x9A,
     0xF3, 0xF7, 0x1E, 0x7A, 0x61, 0x86, 0x5A, 0xF5
 };
 
-static byte A[] = {
+static byte srp_A[] = {
     0x8D, 0x28, 0xC5, 0x6A, 0x46, 0x5C, 0x82, 0xDB, 0xC7, 0xF6, 0x8B, 0x62,
     0x1A, 0xAD, 0xA1, 0x76, 0x1B, 0x55, 0xFF, 0xAB, 0x10, 0x2F, 0xFF, 0x4A,
     0xAA, 0x46, 0xAD, 0x33, 0x64, 0xDE, 0x28, 0x2E, 0x82, 0x7A, 0xBE, 0xEA,
@@ -79,13 +79,13 @@ static byte A[] = {
     0xBF, 0xCF, 0x2D, 0xB0
 };
 
-static byte b[] = {
+static byte srp_b[] = {
     0x2B, 0xDD, 0x30, 0x30, 0x53, 0xAF, 0xD8, 0x3A, 0xE7, 0xE0, 0x17, 0x82,
     0x39, 0x44, 0x2C, 0xDB, 0x30, 0x88, 0x0F, 0xC8, 0x88, 0xC2, 0xB2, 0xC1,
     0x78, 0x43, 0x2F, 0xD5, 0x60, 0xD4, 0xDA, 0x43
 };
 
-static byte B[] = {
+static byte srp_B[] = {
     0xB5, 0x80, 0x36, 0x7F, 0x50, 0x89, 0xC1, 0x04, 0x42, 0x98, 0xD7, 0x6A,
     0x37, 0x8E, 0xF1, 0x81, 0x52, 0xC5, 0x7A, 0xA1, 0xD5, 0xB7, 0x66, 0x84,
     0xA1, 0x3E, 0x32, 0x82, 0x2B, 0x3A, 0xB5, 0xD7, 0x3D, 0x50, 0xF1, 0x58,
@@ -94,19 +94,19 @@ static byte B[] = {
     0x0E, 0xC7, 0x92, 0xAD
 };
 
-static byte key[] = {
+static byte srp_key[] = {
     0x66, 0x00, 0x9D, 0x58, 0xB3, 0xD2, 0x0D, 0x4B, 0x69, 0x7F, 0xCF, 0x48,
     0xFF, 0x8F, 0x15, 0x81, 0x4C, 0x4B, 0xFE, 0x9D, 0x85, 0x77, 0x88, 0x60,
     0x1D, 0x1E, 0x51, 0xCF, 0x75, 0xCC, 0x58, 0x00, 0xE7, 0x8D, 0x22, 0x87,
     0x13, 0x6C, 0x88, 0x55
 };
 
-static byte client_proof[] = {
+static byte srp_client_proof[] = {
     0x0D, 0x49, 0xE1, 0x9C, 0x3A, 0x88, 0x43, 0x15, 0x45, 0xA8, 0xAC, 0xAB,
     0xEA, 0x15, 0x1A, 0xEE, 0xF9, 0x38, 0x4D, 0x21
 };
 
-static byte server_proof[] = {
+static byte srp_server_proof[] = {
     0xBD, 0xB1, 0x20, 0x70, 0x46, 0xC9, 0xD6, 0xCC, 0xE2, 0x1D, 0x75, 0xA2,
     0xD0, 0xAF, 0xC5, 0xBC, 0xAE, 0x12, 0xFC, 0x75
 };
@@ -151,34 +151,39 @@ static void test_SrpSetParams(void)
     AssertIntEQ(0, wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_CLIENT_SIDE));
 
     /* invalid call order */
-    AssertIntEQ(SRP_CALL_ORDER_E, wc_SrpSetParams(&srp, N,    sizeof(N),
-                                                        g,    sizeof(g),
-                                                        salt, sizeof(salt)));
+    AssertIntEQ(SRP_CALL_ORDER_E, wc_SrpSetParams(&srp,
+                                                  srp_N,    sizeof(srp_N),
+                                                  srp_g,    sizeof(srp_g),
+                                                  srp_salt, sizeof(srp_salt)));
 
     /* fix call order */
     AssertIntEQ(0, wc_SrpSetUsername(&srp, username, usernameSz));
 
     /* invalid params */
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetParams(NULL, N,    sizeof(N),
-                                                    g,    sizeof(g),
-                                                    salt, sizeof(salt)));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetParams(&srp, NULL, sizeof(N),
-                                                    g,    sizeof(g),
-                                                    salt, sizeof(salt)));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetParams(&srp, N,    sizeof(N),
-                                                    NULL, sizeof(g),
-                                                    salt, sizeof(salt)));
-    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetParams(&srp, N,    sizeof(N),
-                                                    g,    sizeof(g),
-                                                    NULL, sizeof(salt)));
+    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetParams(NULL,
+                                              srp_N,    sizeof(srp_N),
+                                              srp_g,    sizeof(srp_g),
+                                              srp_salt, sizeof(srp_salt)));
+    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetParams(&srp,
+                                              NULL,     sizeof(srp_N),
+                                              srp_g,    sizeof(srp_g),
+                                              srp_salt, sizeof(srp_salt)));
+    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetParams(&srp,
+                                              srp_N,    sizeof(srp_N),
+                                              NULL,      sizeof(srp_g),
+                                              srp_salt, sizeof(srp_salt)));
+    AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetParams(&srp,
+                                              srp_N,    sizeof(srp_N),
+                                              srp_g,    sizeof(srp_g),
+                                              NULL,     sizeof(srp_salt)));
 
     /* success */
-    AssertIntEQ(0, wc_SrpSetParams(&srp, N,    sizeof(N),
-                                         g,    sizeof(g),
-                                         salt, sizeof(salt)));
+    AssertIntEQ(0, wc_SrpSetParams(&srp, srp_N,    sizeof(srp_N),
+                                         srp_g,    sizeof(srp_g),
+                                         srp_salt, sizeof(srp_salt)));
 
-    AssertIntEQ(sizeof(salt), srp.saltSz);
-    AssertIntEQ(0, XMEMCMP(srp.salt, salt, srp.saltSz));
+    AssertIntEQ(sizeof(srp_salt), srp.saltSz);
+    AssertIntEQ(0, XMEMCMP(srp.salt, srp_salt, srp.saltSz));
 
     wc_SrpTerm(&srp);
 }
@@ -199,9 +204,9 @@ static void test_SrpSetPassword(void)
                 wc_SrpGetVerifier(&srp, v, &vSz));
 
     /* fix call order */
-    AssertIntEQ(0, wc_SrpSetParams(&srp, N,    sizeof(N),
-                                         g,    sizeof(g),
-                                         salt, sizeof(salt)));
+    AssertIntEQ(0, wc_SrpSetParams(&srp, srp_N,    sizeof(srp_N),
+                                         srp_g,    sizeof(srp_g),
+                                         srp_salt, sizeof(srp_salt)));
 
     /* invalid params */
     AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetPassword(NULL, password, passwordSz));
@@ -218,8 +223,8 @@ static void test_SrpSetPassword(void)
     /* success */
     vSz = sizeof(v);
     AssertIntEQ(0, wc_SrpGetVerifier(&srp, v, &vSz));
-    AssertIntEQ(vSz, sizeof(verifier));
-    AssertIntEQ(0, XMEMCMP(verifier, v, vSz));
+    AssertIntEQ(vSz, sizeof(srp_verifier));
+    AssertIntEQ(0, XMEMCMP(srp_verifier, v, vSz));
 
     /* invalid params - client side srp */
     AssertIntEQ(BAD_FUNC_ARG, wc_SrpSetVerifier(&srp, v, vSz));
@@ -245,9 +250,9 @@ static void test_SrpGetPublic(void)
 
     AssertIntEQ(0, wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_CLIENT_SIDE));
     AssertIntEQ(0, wc_SrpSetUsername(&srp, username, usernameSz));
-    AssertIntEQ(0, wc_SrpSetParams(&srp, N,    sizeof(N),
-                                         g,    sizeof(g),
-                                         salt, sizeof(salt)));
+    AssertIntEQ(0, wc_SrpSetParams(&srp, srp_N,    sizeof(srp_N),
+                                         srp_g,    sizeof(srp_g),
+                                         srp_salt, sizeof(srp_salt)));
 
     /* invalid call order */
     AssertIntEQ(SRP_CALL_ORDER_E, wc_SrpGetPublic(&srp, pub, &pubSz));
@@ -263,30 +268,30 @@ static void test_SrpGetPublic(void)
 
     /* success */
     pubSz = sizeof(pub);
-    AssertIntEQ(0, wc_SrpSetPrivate(&srp, a, sizeof(a)));
+    AssertIntEQ(0, wc_SrpSetPrivate(&srp, srp_a, sizeof(srp_a)));
     AssertIntEQ(0, wc_SrpGetPublic(&srp, pub, &pubSz));
-    AssertIntEQ(pubSz, sizeof(A));
-    AssertIntEQ(0, XMEMCMP(pub, A, pubSz));
+    AssertIntEQ(pubSz, sizeof(srp_A));
+    AssertIntEQ(0, XMEMCMP(pub, srp_A, pubSz));
 
     wc_SrpTerm(&srp);
 
     AssertIntEQ(0, wc_SrpInit(&srp, SRP_TYPE_SHA, SRP_SERVER_SIDE));
     AssertIntEQ(0, wc_SrpSetUsername(&srp, username, usernameSz));
-    AssertIntEQ(0, wc_SrpSetParams(&srp, N,    sizeof(N),
-                                         g,    sizeof(g),
-                                         salt, sizeof(salt)));
+    AssertIntEQ(0, wc_SrpSetParams(&srp, srp_N,    sizeof(srp_N),
+                                         srp_g,    sizeof(srp_g),
+                                         srp_salt, sizeof(srp_salt)));
 
     /* invalid call order */
     AssertIntEQ(SRP_CALL_ORDER_E, wc_SrpGetPublic(&srp, pub, &pubSz));
 
     /* fix call order */
-    AssertIntEQ(0, wc_SrpSetVerifier(&srp, verifier, sizeof(verifier)));
+    AssertIntEQ(0, wc_SrpSetVerifier(&srp, srp_verifier, sizeof(srp_verifier)));
 
     /* success */
-    AssertIntEQ(0, wc_SrpSetPrivate(&srp, b, sizeof(b)));
+    AssertIntEQ(0, wc_SrpSetPrivate(&srp, srp_b, sizeof(srp_b)));
     AssertIntEQ(0, wc_SrpGetPublic(&srp, pub, &pubSz));
-    AssertIntEQ(pubSz, sizeof(B));
-    AssertIntEQ(0, XMEMCMP(pub, B, pubSz));
+    AssertIntEQ(pubSz, sizeof(srp_B));
+    AssertIntEQ(0, XMEMCMP(pub, srp_B, pubSz));
 
     wc_SrpTerm(&srp);
 }
@@ -311,22 +316,22 @@ static void test_SrpComputeKey(void)
     AssertIntEQ(0, wc_SrpSetUsername(&cli, username, usernameSz));
     AssertIntEQ(0, wc_SrpSetUsername(&srv, username, usernameSz));
 
-    AssertIntEQ(0, wc_SrpSetParams(&cli, N,    sizeof(N),
-                                         g,    sizeof(g),
-                                         salt, sizeof(salt)));
-    AssertIntEQ(0, wc_SrpSetParams(&srv, N,    sizeof(N),
-                                         g,    sizeof(g),
-                                         salt, sizeof(salt)));
+    AssertIntEQ(0, wc_SrpSetParams(&cli, srp_N,    sizeof(srp_N),
+                                         srp_g,    sizeof(srp_g),
+                                         srp_salt, sizeof(srp_salt)));
+    AssertIntEQ(0, wc_SrpSetParams(&srv, srp_N,    sizeof(srp_N),
+                                         srp_g,    sizeof(srp_g),
+                                         srp_salt, sizeof(srp_salt)));
 
     AssertIntEQ(0, wc_SrpSetPassword(&cli, password, passwordSz));
-    AssertIntEQ(0, wc_SrpSetVerifier(&srv, verifier, sizeof(verifier)));
+    AssertIntEQ(0, wc_SrpSetVerifier(&srv, srp_verifier, sizeof(srp_verifier)));
 
-    AssertIntEQ(0, wc_SrpSetPrivate(&cli, a, sizeof(a)));
+    AssertIntEQ(0, wc_SrpSetPrivate(&cli, srp_a, sizeof(srp_a)));
     AssertIntEQ(0, wc_SrpGetPublic(&cli, clientPubKey, &clientPubKeySz));
-    AssertIntEQ(0, XMEMCMP(clientPubKey, A, clientPubKeySz));
-    AssertIntEQ(0, wc_SrpSetPrivate(&srv, b, sizeof(b)));
+    AssertIntEQ(0, XMEMCMP(clientPubKey, srp_A, clientPubKeySz));
+    AssertIntEQ(0, wc_SrpSetPrivate(&srv, srp_b, sizeof(srp_b)));
     AssertIntEQ(0, wc_SrpGetPublic(&srv, serverPubKey, &serverPubKeySz));
-    AssertIntEQ(0, XMEMCMP(serverPubKey, B, serverPubKeySz));
+    AssertIntEQ(0, XMEMCMP(serverPubKey, srp_B, serverPubKeySz));
 
     /* invalid params */
     AssertIntEQ(BAD_FUNC_ARG, wc_SrpComputeKey(NULL,
@@ -350,8 +355,8 @@ static void test_SrpComputeKey(void)
                                           serverPubKey, serverPubKeySz));
     AssertIntEQ(0, wc_SrpComputeKey(&srv, clientPubKey, clientPubKeySz,
                                           serverPubKey, serverPubKeySz));
-    AssertIntEQ(0, XMEMCMP(cli.key, key, sizeof(key)));
-    AssertIntEQ(0, XMEMCMP(srv.key, key, sizeof(key)));
+    AssertIntEQ(0, XMEMCMP(cli.key, srp_key, sizeof(srp_key)));
+    AssertIntEQ(0, XMEMCMP(srv.key, srp_key, sizeof(srp_key)));
 
     wc_SrpTerm(&cli);
     wc_SrpTerm(&srv);
@@ -375,31 +380,31 @@ static void test_SrpGetProofAndVerify(void)
     AssertIntEQ(0, wc_SrpSetUsername(&cli, username, usernameSz));
     AssertIntEQ(0, wc_SrpSetUsername(&srv, username, usernameSz));
 
-    AssertIntEQ(0, wc_SrpSetParams(&cli, N,    sizeof(N),
-                                         g,    sizeof(g),
-                                         salt, sizeof(salt)));
-    AssertIntEQ(0, wc_SrpSetParams(&srv, N,    sizeof(N),
-                                         g,    sizeof(g),
-                                         salt, sizeof(salt)));
+    AssertIntEQ(0, wc_SrpSetParams(&cli, srp_N,    sizeof(srp_N),
+                                         srp_g,    sizeof(srp_g),
+                                         srp_salt, sizeof(srp_salt)));
+    AssertIntEQ(0, wc_SrpSetParams(&srv, srp_N,    sizeof(srp_N),
+                                         srp_g,    sizeof(srp_g),
+                                         srp_salt, sizeof(srp_salt)));
 
     AssertIntEQ(0, wc_SrpSetPassword(&cli, password, passwordSz));
-    AssertIntEQ(0, wc_SrpSetVerifier(&srv, verifier, sizeof(verifier)));
+    AssertIntEQ(0, wc_SrpSetVerifier(&srv, srp_verifier, sizeof(srp_verifier)));
 
-    AssertIntEQ(0, wc_SrpSetPrivate(&cli, a, sizeof(a)));
+    AssertIntEQ(0, wc_SrpSetPrivate(&cli, srp_a, sizeof(srp_a)));
     AssertIntEQ(0, wc_SrpGetPublic(&cli, clientPubKey, &clientPubKeySz));
-    AssertIntEQ(0, XMEMCMP(clientPubKey, A, clientPubKeySz));
+    AssertIntEQ(0, XMEMCMP(clientPubKey, srp_A, clientPubKeySz));
 
-    AssertIntEQ(0, wc_SrpSetPrivate(&srv, b, sizeof(b)));
+    AssertIntEQ(0, wc_SrpSetPrivate(&srv, srp_b, sizeof(srp_b)));
     AssertIntEQ(0, wc_SrpGetPublic(&srv, serverPubKey, &serverPubKeySz));
-    AssertIntEQ(0, XMEMCMP(serverPubKey, B, serverPubKeySz));
+    AssertIntEQ(0, XMEMCMP(serverPubKey, srp_B, serverPubKeySz));
 
     AssertIntEQ(0, wc_SrpComputeKey(&cli, clientPubKey, clientPubKeySz,
                                           serverPubKey, serverPubKeySz));
-    AssertIntEQ(0, XMEMCMP(cli.key, key, sizeof(key)));
+    AssertIntEQ(0, XMEMCMP(cli.key, srp_key, sizeof(srp_key)));
 
     AssertIntEQ(0, wc_SrpComputeKey(&srv, clientPubKey, clientPubKeySz,
                                           serverPubKey, serverPubKeySz));
-    AssertIntEQ(0, XMEMCMP(srv.key, key, sizeof(key)));
+    AssertIntEQ(0, XMEMCMP(srv.key, srp_key, sizeof(srp_key)));
 
     /* invalid params */
     serverProofSz = 0;
@@ -418,10 +423,12 @@ static void test_SrpGetProofAndVerify(void)
 
     /* success */
     AssertIntEQ(0, wc_SrpGetProof(&cli, clientProof, &clientProofSz));
-    AssertIntEQ(0, XMEMCMP(clientProof, client_proof, sizeof(client_proof)));
+    AssertIntEQ(0, XMEMCMP(clientProof, srp_client_proof,
+                           sizeof(srp_client_proof)));
     AssertIntEQ(0, wc_SrpVerifyPeersProof(&srv, clientProof, clientProofSz));
     AssertIntEQ(0, wc_SrpGetProof(&srv, serverProof, &serverProofSz));
-    AssertIntEQ(0, XMEMCMP(serverProof, server_proof, sizeof(server_proof)));
+    AssertIntEQ(0, XMEMCMP(serverProof, srp_server_proof,
+                           sizeof(srp_server_proof)));
     AssertIntEQ(0, wc_SrpVerifyPeersProof(&cli, serverProof, serverProofSz));
 
     wc_SrpTerm(&cli);

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -242,14 +242,10 @@ void simple_test(func_args* args)
     for (i = 0; i < 3; i++)
         cliArgv[i] = argvc[i];
 
+    strcpy(argvs[0], "SimpleServer");
     svrArgs.argc = 1;
     svrArgs.argv = svrArgv;
     svrArgs.return_code = 0;
-    cliArgs.argc = 1;
-    cliArgs.argv = cliArgv;
-    cliArgs.return_code = 0;
-
-    strcpy(argvs[0], "SimpleServer");
     #if !defined(USE_WINDOWS_API) && !defined(WOLFSSL_SNIFFER)  && \
                                      !defined(WOLFSSL_TIRTOS)
         strcpy(argvs[svrArgs.argc++], "-p");
@@ -264,10 +260,14 @@ void simple_test(func_args* args)
 
     /* Setting the actual port number. */
     strcpy(argvc[0], "SimpleClient");
+    cliArgs.argv = cliArgv;
+    cliArgs.return_code = 0;
     #ifndef USE_WINDOWS_API
         cliArgs.argc = NUMARGS;
         strcpy(argvc[1], "-p");
         snprintf(argvc[2], sizeof(argvc[2]), "%d", svrArgs.signal->port);
+    #else
+        cliArgs.argc = 1;
     #endif
 
     client_test(&cliArgs);

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -2178,18 +2178,19 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
     int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
             const byte* iv, int dir)
     {
-        word32 *rk = aes->key;
+        word32 *rk;
 
         (void)dir;
 
-        if (keylen != 16 &&
+        if (aes == NULL || (keylen != 16 &&
         #ifdef WOLFSSL_AES_192
             keylen != 24 &&
         #endif
-            keylen != 32) {
+            keylen != 32)) {
             return BAD_FUNC_ARG;
         }
 
+        rk = aes->key;
         aes->keylen = keylen;
         aes->rounds = keylen/4 + 6;
         XMEMCPY(rk, userKey, keylen);
@@ -2305,7 +2306,7 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
         const byte* iv, int dir)
     {
         int ret;
-        byte* rk = (byte*)aes->key;
+        byte* rk;
         byte* tmpKey = (byte*)userKey;
         int tmpKeyDynamic = 0;
         word32 alignOffset = 0;
@@ -2314,7 +2315,10 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 
         if (!((keylen == 16) || (keylen == 24) || (keylen == 32)))
             return BAD_FUNC_ARG;
+        if (aes == NULL)
+            return BAD_FUNC_ARG;
 
+        rk = (byte*)aes->key;
         if (rk == NULL)
             return BAD_FUNC_ARG;
 
@@ -2379,7 +2383,7 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
         (void)dir;
         (void)iv;
 
-        if (keylen != 16)
+        if (aes == NULL || keylen != 16)
             return BAD_FUNC_ARG;
 
         aes->keylen = keylen;
@@ -2408,7 +2412,7 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
         (void)dir;
         (void)iv;
 
-        if ( aes == NULL || (keylen != 16 && keylen != 24 && keylen != 32)) {
+        if (aes == NULL || (keylen != 16 && keylen != 24 && keylen != 32)) {
             return BAD_FUNC_ARG;
         }
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -11387,11 +11387,7 @@ static
 void wc_SetCert_Free(Cert* cert)
 {
     if (cert != NULL) {
-
-        if (cert->der != NULL) {
-            cert->der = NULL;
-        }
-
+        cert->der = NULL;
         if (cert->decodedCert) {
             FreeDecodedCert((DecodedCert*)cert->decodedCert);
 
@@ -17086,8 +17082,8 @@ static int GetRevoked(const byte* buff, word32* idx, DecodedCRL* dcrl,
         return ret;
     }
 
-    if (*idx != end)  /* skip extensions */
-        *idx = end;
+    /* skip extensions */
+    *idx = end;
 
     return 0;
 }
@@ -17458,7 +17454,6 @@ int wc_ParseCertPIV(wc_CertPIV* piv, const byte* buf, word32 totalSz)
         if (GetASNHeader(buf, ASN_PIV_SIGNED_NONCE, &idx, &length, totalSz) >= 0) {
             piv->signedNonce =   &buf[idx];
             piv->signedNonceSz = length;
-            idx += length;
         }
 
         idx = 0;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4016,18 +4016,19 @@ static int wc_ecc_make_pub_ex(ecc_key* key, ecc_curve_spec* curveIn,
     }
 
 
+    if (err != MP_OKAY) {
+    }
+    else
 #ifdef WOLFSSL_HAVE_SP_ECC
 #ifndef WOLFSSL_SP_NO_256
     if (key->idx != ECC_CUSTOM_IDX && ecc_sets[key->idx].id == ECC_SECP256R1) {
-        if (err == MP_OKAY)
-            err = sp_ecc_mulmod_base_256(&key->k, pub, 1, key->heap);
+        err = sp_ecc_mulmod_base_256(&key->k, pub, 1, key->heap);
     }
     else
 #endif
 #ifdef WOLFSSL_SP_384
     if (key->idx != ECC_CUSTOM_IDX && ecc_sets[key->idx].id == ECC_SECP384R1) {
-        if (err == MP_OKAY)
-            err = sp_ecc_mulmod_base_384(&key->k, pub, 1, key->heap);
+        err = sp_ecc_mulmod_base_384(&key->k, pub, 1, key->heap);
     }
     else
 #endif
@@ -4038,11 +4039,9 @@ static int wc_ecc_make_pub_ex(ecc_key* key, ecc_curve_spec* curveIn,
     {
         mp_digit mp;
 
-        if (err == MP_OKAY) {
-            base = wc_ecc_new_point_h(key->heap);
-            if (base == NULL)
-                err = MEMORY_E;
-        }
+        base = wc_ecc_new_point_h(key->heap);
+        if (base == NULL)
+            err = MEMORY_E;
         /* read in the x/y for this key */
         if (err == MP_OKAY)
             err = mp_copy(curve->Gx, base->x);
@@ -6292,7 +6291,9 @@ int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
                             ecc_point* point)
 {
     int err = 0;
+#ifdef HAVE_COMP_KEY
     int compressed = 0;
+#endif
     int keysize;
     byte pointType;
 
@@ -6425,8 +6426,12 @@ int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
     }
 #endif
 
-    if (err == MP_OKAY && compressed == 0)
-        err = mp_read_unsigned_bin(point->y, (byte*)in + keysize, keysize);
+    if (err == MP_OKAY) {
+#ifdef HAVE_COMP_KEY
+        if (compressed == 0)
+#endif
+            err = mp_read_unsigned_bin(point->y, (byte*)in + keysize, keysize);
+     }
     if (err == MP_OKAY)
         err = mp_set(point->z, 1);
 
@@ -7040,7 +7045,9 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
                           int curve_id)
 {
     int err = MP_OKAY;
+#ifdef HAVE_COMP_KEY
     int compressed = 0;
+#endif
     int keysize = 0;
     byte pointType;
 
@@ -7092,9 +7099,11 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
 
 #ifdef WOLFSSL_ATECC508A
     /* For SECP256R1 only save raw public key for hardware */
-    if (curve_id == ECC_SECP256R1 && !compressed &&
-                                            inLen <= sizeof(key->pubkey_raw)) {
-        XMEMCPY(key->pubkey_raw, (byte*)in, inLen);
+    if (curve_id == ECC_SECP256R1 && inLen <= sizeof(key->pubkey_raw)) {
+    #ifdef HAVE_COMP_KEY
+        if (!compressed)
+    #endif
+            XMEMCPY(key->pubkey_raw, (byte*)in, inLen);
     }
 #endif
 
@@ -7195,8 +7204,15 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
     }
 #endif /* HAVE_COMP_KEY */
 
-    if (err == MP_OKAY && compressed == 0)
-        err = mp_read_unsigned_bin(key->pubkey.y, (byte*)in + keysize, keysize);
+    if (err == MP_OKAY) {
+    #ifdef HAVE_COMP_KEY
+        if (compressed == 0)
+    #endif
+        {
+            err = mp_read_unsigned_bin(key->pubkey.y, (byte*)in + keysize,
+                                                                      keysize);
+        }
+    }
     if (err == MP_OKAY)
         err = mp_set(key->pubkey.z, 1);
 
@@ -7598,18 +7614,15 @@ int wc_ecc_sig_to_rs(const byte* sig, word32 sigLen, byte* r, word32* rLen,
     /* rtmp and stmp are initialized */
     if (err == MP_OKAY) {
         tmp_valid = 1;
-    }
 
-    /* extract r */
-    if (err == MP_OKAY) {
+        /* extract r */
         x = mp_unsigned_bin_size(rtmp);
         if (*rLen < x)
             err = BUFFER_E;
-
-        if (err == MP_OKAY) {
-            *rLen = x;
-            err = mp_to_unsigned_bin(rtmp, r);
-        }
+    }
+    if (err == MP_OKAY) {
+        *rLen = x;
+        err = mp_to_unsigned_bin(rtmp, r);
     }
 
     /* extract s */
@@ -7716,19 +7729,21 @@ static int wc_ecc_import_raw_private(ecc_key* key, const char* qx,
         keySz = (word32)key->dp->size;
         err = wc_export_int(key->pubkey.x, &key_raw[1], &keySz, keySz,
             WC_TYPE_UNSIGNED_BIN);
-        if (err == MP_OKAY)
+        if (err == MP_OKAY) {
             err = wc_export_int(key->pubkey.y, &key_raw[1+keySz],
                 &keySz, keySz, WC_TYPE_UNSIGNED_BIN);
+        }
 
+        if (err == MP_OKAY) {
+            pDomain = CRYS_ECPKI_GetEcDomain(cc310_mapCurve(curve_id));
 
-        pDomain = CRYS_ECPKI_GetEcDomain(cc310_mapCurve(curve_id));
-
-        /* create public key from external key buffer */
-        err = CRYS_ECPKI_BuildPublKeyFullCheck(pDomain,
-                                               key_raw,
-                                               keySz*2 + 1,
-                                               &key->ctx.pubKey,
-                                               &tempBuff);
+            /* create public key from external key buffer */
+            err = CRYS_ECPKI_BuildPublKeyFullCheck(pDomain,
+                                                   key_raw,
+                                                   keySz*2 + 1,
+                                                   &key->ctx.pubKey,
+                                                   &tempBuff);
+        }
 
         if (err != SA_SILIB_RET_OK){
             WOLFSSL_MSG("CRYS_ECPKI_BuildPublKeyFullCheck failed");
@@ -9073,10 +9088,8 @@ static int accel_fp_mul2add(int idx1, int idx2,
                                                               mp)) != MP_OKAY) {
                 break;
              }
-          }
 
-          /* add if not first, otherwise copy */
-          if (!first) {
+             /* add if not first, otherwise copy */
              if (zA) {
                 if ((err = ecc_projective_add_point(R, fp_cache[idx1].LUT[zA],
                                                R, a, modulus, mp)) != MP_OKAY) {
@@ -9274,11 +9287,10 @@ int ecc_mul2add(ecc_point* A, mp_int* kA,
          ++(fp_cache[idx1].lru_count);
       }
 
-      if (err == MP_OKAY)
+      if (err == MP_OKAY) {
         /* find point */
         idx2 = find_base(B);
 
-      if (err == MP_OKAY) {
         /* no entry? */
         if (idx2 == -1) {
            /* find hole and add it */
@@ -10471,8 +10483,9 @@ int wc_ecc_get_oid(word32 oidSum, const byte** oid, word32* oidSz)
     /* find matching OID sum (based on encoded value) */
     for (x = 0; ecc_sets[x].size != 0; x++) {
         if (ecc_sets[x].oidSum == oidSum) {
-            int ret = 0;
+            int ret;
         #ifdef HAVE_OID_ENCODING
+            ret = 0;
             /* check cache */
             oid_cache_t* o = &ecc_oid_cache[x];
             if (o->oidSz == 0) {
@@ -10486,6 +10499,10 @@ int wc_ecc_get_oid(word32 oidSum, const byte** oid, word32* oidSz)
             if (oid) {
                 *oid = o->oid;
             }
+            /* on success return curve id */
+            if (ret == 0) {
+                ret = ecc_sets[x].id;
+            }
         #else
             if (oidSz) {
                 *oidSz = ecc_sets[x].oidSz;
@@ -10493,11 +10510,8 @@ int wc_ecc_get_oid(word32 oidSum, const byte** oid, word32* oidSz)
             if (oid) {
                 *oid = ecc_sets[x].oid;
             }
+            ret = ecc_sets[x].id;
         #endif
-            /* on success return curve id */
-            if (ret == 0) {
-                ret = ecc_sets[x].id;
-            }
             return ret;
         }
     }

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -606,14 +606,15 @@ int wc_ed25519_import_public(const byte* in, word32 inLen, ed25519_key* key)
             key->pointY[i] = *(in + 2*ED25519_KEY_SIZE - i);
         }
         XMEMCPY(key->p, key->pointY, ED25519_KEY_SIZE);
+        key->pubKeySet = 1;
         ret = 0;
 #else
         /* pass in (x,y) and store compressed key */
         ret = ge_compress_key(key->p, in+1,
                               in+1+ED25519_PUB_KEY_SIZE, ED25519_PUB_KEY_SIZE);
-#endif /* FREESCALE_LTC_ECC */
         if (ret == 0)
             key->pubKeySet = 1;
+#endif /* FREESCALE_LTC_ECC */
         return ret;
     }
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1841,10 +1841,11 @@ static int wolfSSL_evp_digest_pk_init(WOLFSSL_EVP_MD_CTX *ctx,
     else {
         int ret;
 
-        if (ctx->pctx == NULL)
+        if (ctx->pctx == NULL) {
             ctx->pctx = wolfSSL_EVP_PKEY_CTX_new(pkey, e);
-        if (ctx->pctx == NULL)
-            return WOLFSSL_FAILURE;
+            if (ctx->pctx == NULL)
+                return WOLFSSL_FAILURE;
+        }
 
         ret = wolfSSL_EVP_DigestInit(ctx, type);
         if (ret == WOLFSSL_SUCCESS && pctx != NULL)

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -2230,7 +2230,7 @@ int mp_exptmod_base_2(mp_int * X, mp_int * P, mp_int * Y)
 #else
   mp_int   res[1];
 #endif
-  int     (*redux)(mp_int*,mp_int*,mp_digit);
+  int     (*redux)(mp_int*,mp_int*,mp_digit) = NULL;
 
   /* automatically pick the comba one if available (saves quite a few
      calls/ifs) */

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -715,7 +715,7 @@ int wc_i2d_PKCS12(WC_PKCS12* pkcs12, byte** der, int* derSz)
     }
 
     /* Create the MAC portion */
-    if ((ret == 0) && (pkcs12->signData != NULL)) {
+    if (pkcs12->signData != NULL) {
         MacData *mac = (MacData*)pkcs12->signData;
         word32 innerSz = 0;
         word32 outerSz = 0;

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
@@ -429,23 +429,25 @@ int tsip_generateSeesionKey(struct WOLFSSL *ssl)
             dec = &ssl->decrypt;
             
             if (enc) {
-                if (enc->aes == NULL)
+                if (enc->aes == NULL) {
                     enc->aes = (Aes*)XMALLOC(sizeof(Aes), ssl->heap, 
                                                     DYNAMIC_TYPE_CIPHER);
-                if (enc->aes == NULL) 
-                    return MEMORY_E;
+                    if (enc->aes == NULL)
+                        return MEMORY_E;
+                }
                 
                 XMEMSET(enc->aes, 0, sizeof(Aes));
             }
             if (dec) {
-                if (dec->aes == NULL)
+                if (dec->aes == NULL) {
                     dec->aes = (Aes*)XMALLOC(sizeof(Aes), ssl->heap, 
                                                     DYNAMIC_TYPE_CIPHER);
-                if (dec->aes == NULL) {
-                    if (enc) {
-                        XFREE(enc->aes, NULL, DYNAMIC_TYPE_CIPHER);
+                    if (dec->aes == NULL) {
+                        if (enc) {
+                            XFREE(enc->aes, NULL, DYNAMIC_TYPE_CIPHER);
+                        }
+                        return MEMORY_E;
                     }
-                    return MEMORY_E;
                 }
                 
                 XMEMSET(dec->aes, 0, sizeof(Aes));

--- a/wolfcrypt/src/port/intel/quickassist_sync.c
+++ b/wolfcrypt/src/port/intel/quickassist_sync.c
@@ -1628,7 +1628,7 @@ static void* _qaeMemAlloc(size_t size, void* heap, int type
         ptr = qaeMemAllocNUMA((Cpa32U)(size + sizeof(qaeMemHeader)), 0,
             alignment);
     }
-    else if (ptr == NULL) {
+    else {
         isNuma = 0;
         ptr = malloc(size + sizeof(qaeMemHeader));
     }

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1728,7 +1728,7 @@ static int wc_RsaFunctionXil(const byte* in, word32 inLen, byte* out,
                           word32* outLen, int type, RsaKey* key, WC_RNG* rng)
 {
     int    ret = 0;
-    word32 keyLen, len;
+    word32 keyLen;
     (void)rng;
 
     keyLen = wc_RsaEncryptSize(key);

--- a/wolfcrypt/src/sp_arm32.c
+++ b/wolfcrypt/src/sp_arm32.c
@@ -7489,6 +7489,63 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+    sp_digit* a;
+    sp_digit* d = NULL;
+    sp_digit* m;
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 256U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 2048) {
+           err = MP_READ_E;
+        }
+        if (inLen > 256) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 2048) {
+            err = MP_READ_E;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+    if (err == MP_OKAY) {
+        a = d + 64;
+        m = a + 128;
+        r = a;
+
+        sp_2048_from_bin(a, 64, in, inLen);
+        sp_2048_from_mp(d, 64, dm);
+        sp_2048_from_mp(m, 64, mm);
+        err = sp_2048_mod_exp_64(r, a, d, 2048, m, 0);
+    }
+    if (err == MP_OKAY) {
+        sp_2048_to_bin(r, out);
+        *outLen = 256;
+    }
+
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 64);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+
+    return err;
+#else
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
 /* Conditionally add a and b using the mask m.
  * m is -1 to add and 0 when not.
@@ -7816,6 +7873,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -7839,10 +7897,10 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 64; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -7850,7 +7908,7 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -18977,6 +19035,63 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+    sp_digit* a;
+    sp_digit* d = NULL;
+    sp_digit* m;
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 384U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 3072) {
+           err = MP_READ_E;
+        }
+        if (inLen > 384) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 3072) {
+            err = MP_READ_E;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 96 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+    if (err == MP_OKAY) {
+        a = d + 96;
+        m = a + 192;
+        r = a;
+
+        sp_3072_from_bin(a, 96, in, inLen);
+        sp_3072_from_mp(d, 96, dm);
+        sp_3072_from_mp(m, 96, mm);
+        err = sp_3072_mod_exp_96(r, a, d, 3072, m, 0);
+    }
+    if (err == MP_OKAY) {
+        sp_3072_to_bin(r, out);
+        *outLen = 384;
+    }
+
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 96);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+
+    return err;
+#else
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
 /* Conditionally add a and b using the mask m.
  * m is -1 to add and 0 when not.
@@ -19384,6 +19499,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -19407,10 +19523,10 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 96; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -19418,7 +19534,7 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -71539,6 +71655,63 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+    sp_digit* a;
+    sp_digit* d = NULL;
+    sp_digit* m;
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 512U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 4096) {
+           err = MP_READ_E;
+        }
+        if (inLen > 512) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 4096) {
+            err = MP_READ_E;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 128 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+    if (err == MP_OKAY) {
+        a = d + 128;
+        m = a + 256;
+        r = a;
+
+        sp_4096_from_bin(a, 128, in, inLen);
+        sp_4096_from_mp(d, 128, dm);
+        sp_4096_from_mp(m, 128, mm);
+        err = sp_4096_mod_exp_128(r, a, d, 4096, m, 0);
+    }
+    if (err == MP_OKAY) {
+        sp_4096_to_bin(r, out);
+        *outLen = 512;
+    }
+
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 128);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+
+    return err;
+#else
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
 /* Conditionally add a and b using the mask m.
  * m is -1 to add and 0 when not.
@@ -72026,6 +72199,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, mp_int* dm,
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -72049,10 +72223,10 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 128; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -72060,7 +72234,7 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -73192,7 +73366,7 @@ static int sp_256_point_new_ex_8(void* heap, sp_point_256* sp, sp_point_256** p)
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -73579,10 +73753,10 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 8; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -73590,7 +73764,7 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -76112,7 +76286,7 @@ static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, cons
         n <<= 4;
         for (; i>=0 || c>=4; ) {
             if (c < 4) {
-                n |= k[i--] << (0 - c);
+                n |= k[i--];
                 c += 32;
             }
             y = (n >> 28) & 0xf;
@@ -81204,7 +81378,7 @@ static int sp_384_point_new_ex_12(void* heap, sp_point_384* sp, sp_point_384** p
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -81458,10 +81632,10 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 12; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -81469,7 +81643,7 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -84781,7 +84955,7 @@ static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, con
         n <<= 4;
         for (; i>=0 || c>=4; ) {
             if (c < 4) {
-                n |= k[i--] << (0 - c);
+                n |= k[i--];
                 c += 32;
             }
             y = (n >> 28) & 0xf;

--- a/wolfcrypt/src/sp_arm64.c
+++ b/wolfcrypt/src/sp_arm64.c
@@ -4989,6 +4989,63 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+    sp_digit* a;
+    sp_digit* d = NULL;
+    sp_digit* m;
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 256U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 2048) {
+           err = MP_READ_E;
+        }
+        if (inLen > 256) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 2048) {
+            err = MP_READ_E;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+    if (err == MP_OKAY) {
+        a = d + 32;
+        m = a + 64;
+        r = a;
+
+        sp_2048_from_bin(a, 32, in, inLen);
+        sp_2048_from_mp(d, 32, dm);
+        sp_2048_from_mp(m, 32, mm);
+        err = sp_2048_mod_exp_32(r, a, d, 2048, m, 0);
+    }
+    if (err == MP_OKAY) {
+        sp_2048_to_bin(r, out);
+        *outLen = 256;
+    }
+
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 32);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+
+    return err;
+#else
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
 /* Conditionally add a and b using the mask m.
  * m is -1 to add and 0 when not.
@@ -5212,6 +5269,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -5235,10 +5293,10 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 32; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 64) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -5246,7 +5304,7 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 64 - s;
@@ -12633,6 +12691,63 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+    sp_digit* a;
+    sp_digit* d = NULL;
+    sp_digit* m;
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 384U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 3072) {
+           err = MP_READ_E;
+        }
+        if (inLen > 384) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 3072) {
+            err = MP_READ_E;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 48 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+    if (err == MP_OKAY) {
+        a = d + 48;
+        m = a + 96;
+        r = a;
+
+        sp_3072_from_bin(a, 48, in, inLen);
+        sp_3072_from_mp(d, 48, dm);
+        sp_3072_from_mp(m, 48, mm);
+        err = sp_3072_mod_exp_48(r, a, d, 3072, m, 0);
+    }
+    if (err == MP_OKAY) {
+        sp_3072_to_bin(r, out);
+        *outLen = 384;
+    }
+
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 48);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+
+    return err;
+#else
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
 /* Conditionally add a and b using the mask m.
  * m is -1 to add and 0 when not.
@@ -12884,6 +12999,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -12907,10 +13023,10 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 48; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 64) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -12918,7 +13034,7 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 64 - s;
@@ -17504,6 +17620,63 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+    sp_digit* a;
+    sp_digit* d = NULL;
+    sp_digit* m;
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 512U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 4096) {
+           err = MP_READ_E;
+        }
+        if (inLen > 512) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 4096) {
+            err = MP_READ_E;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+    if (err == MP_OKAY) {
+        a = d + 64;
+        m = a + 128;
+        r = a;
+
+        sp_4096_from_bin(a, 64, in, inLen);
+        sp_4096_from_mp(d, 64, dm);
+        sp_4096_from_mp(m, 64, mm);
+        err = sp_4096_mod_exp_64(r, a, d, 4096, m, 0);
+    }
+    if (err == MP_OKAY) {
+        sp_4096_to_bin(r, out);
+        *outLen = 512;
+    }
+
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 64);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+
+    return err;
+#else
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
 /* Conditionally add a and b using the mask m.
  * m is -1 to add and 0 when not.
@@ -17783,6 +17956,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, mp_int* dm,
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -17806,10 +17980,10 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 64; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 64) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -17817,7 +17991,7 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 64 - s;
@@ -18568,7 +18742,7 @@ static int sp_256_point_new_ex_4(void* heap, sp_point_256* sp, sp_point_256** p)
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -18787,10 +18961,10 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 4; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 64) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -18798,7 +18972,7 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 64 - s;
@@ -36352,7 +36526,7 @@ static int sp_384_point_new_ex_6(void* heap, sp_point_384* sp, sp_point_384** p)
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -36624,10 +36798,10 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 6; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 64) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -36635,7 +36809,7 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 64 - s;

--- a/wolfcrypt/src/sp_armthumb.c
+++ b/wolfcrypt/src/sp_armthumb.c
@@ -4362,6 +4362,63 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+    sp_digit* a;
+    sp_digit* d = NULL;
+    sp_digit* m;
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 256U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 2048) {
+           err = MP_READ_E;
+        }
+        if (inLen > 256) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 2048) {
+            err = MP_READ_E;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+    if (err == MP_OKAY) {
+        a = d + 64;
+        m = a + 128;
+        r = a;
+
+        sp_2048_from_bin(a, 64, in, inLen);
+        sp_2048_from_mp(d, 64, dm);
+        sp_2048_from_mp(m, 64, mm);
+        err = sp_2048_mod_exp_64(r, a, d, 2048, m, 0);
+    }
+    if (err == MP_OKAY) {
+        sp_2048_to_bin(r, out);
+        *outLen = 256;
+    }
+
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 64);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+
+    return err;
+#else
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
 /* Conditionally add a and b using the mask m.
  * m is -1 to add and 0 when not.
@@ -4522,6 +4579,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -4545,10 +4603,10 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 64; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -4556,7 +4614,7 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -10105,6 +10163,63 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+    sp_digit* a;
+    sp_digit* d = NULL;
+    sp_digit* m;
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 384U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 3072) {
+           err = MP_READ_E;
+        }
+        if (inLen > 384) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 3072) {
+            err = MP_READ_E;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 96 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+    if (err == MP_OKAY) {
+        a = d + 96;
+        m = a + 192;
+        r = a;
+
+        sp_3072_from_bin(a, 96, in, inLen);
+        sp_3072_from_mp(d, 96, dm);
+        sp_3072_from_mp(m, 96, mm);
+        err = sp_3072_mod_exp_96(r, a, d, 3072, m, 0);
+    }
+    if (err == MP_OKAY) {
+        sp_3072_to_bin(r, out);
+        *outLen = 384;
+    }
+
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 96);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+
+    return err;
+#else
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
 /* Conditionally add a and b using the mask m.
  * m is -1 to add and 0 when not.
@@ -10265,6 +10380,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -10288,10 +10404,10 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 96; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -10299,7 +10415,7 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -14507,6 +14623,63 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+    sp_digit* a;
+    sp_digit* d = NULL;
+    sp_digit* m;
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 512U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 4096) {
+           err = MP_READ_E;
+        }
+        if (inLen > 512) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 4096) {
+            err = MP_READ_E;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 128 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+    if (err == MP_OKAY) {
+        a = d + 128;
+        m = a + 256;
+        r = a;
+
+        sp_4096_from_bin(a, 128, in, inLen);
+        sp_4096_from_mp(d, 128, dm);
+        sp_4096_from_mp(m, 128, mm);
+        err = sp_4096_mod_exp_128(r, a, d, 4096, m, 0);
+    }
+    if (err == MP_OKAY) {
+        sp_4096_to_bin(r, out);
+        *outLen = 512;
+    }
+
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 128);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+
+    return err;
+#else
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
 /* Conditionally add a and b using the mask m.
  * m is -1 to add and 0 when not.
@@ -14668,6 +14841,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, mp_int* dm,
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -14691,10 +14865,10 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 128; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -14702,7 +14876,7 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -15852,7 +16026,7 @@ static int sp_256_point_new_ex_8(void* heap, sp_point_256* sp, sp_point_256** p)
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -16075,10 +16249,10 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 8; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -16086,7 +16260,7 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -17789,7 +17963,7 @@ static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, cons
         n <<= 4;
         for (; i>=0 || c>=4; ) {
             if (c < 4) {
-                n |= k[i--] << (0 - c);
+                n |= k[i--];
                 c += 32;
             }
             y = (n >> 28) & 0xf;
@@ -21937,7 +22111,7 @@ static int sp_384_point_new_ex_12(void* heap, sp_point_384* sp, sp_point_384** p
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -22191,10 +22365,10 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 12; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -22202,7 +22376,7 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -23576,7 +23750,7 @@ static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, con
         n <<= 4;
         for (; i>=0 || c>=4; ) {
             if (c < 4) {
-                n |= k[i--] << (0 - c);
+                n |= k[i--];
                 c += 32;
             }
             y = (n >> 28) & 0xf;

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -3420,7 +3420,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
     }
     if (err == MP_OKAY) {
         a = d + 90;
-        m = a + 90;
+        m = a + 180;
         r = a;
 
         sp_2048_from_bin(a, 90, in, inLen);
@@ -3652,10 +3652,10 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 90; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 23) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -3663,7 +3663,7 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 23 - s;
@@ -7257,7 +7257,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
     }
     if (err == MP_OKAY) {
         a = d + 134;
-        m = a + 134;
+        m = a + 268;
         r = a;
 
         sp_3072_from_bin(a, 134, in, inLen);
@@ -7489,10 +7489,10 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 134; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 23) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -7500,7 +7500,7 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 23 - s;
@@ -11258,7 +11258,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, mp_int* dm,
     }
     if (err == MP_OKAY) {
         a = d + 196;
-        m = a + 196;
+        m = a + 392;
         r = a;
 
         sp_4096_from_bin(a, 196, in, inLen);
@@ -11490,10 +11490,10 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 196; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 21) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -11501,7 +11501,7 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 21 - s;
@@ -12454,7 +12454,7 @@ static int sp_256_point_new_ex_10(void* heap, sp_point_256* sp, sp_point_256** p
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -12742,10 +12742,10 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 10; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 26) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -12753,7 +12753,7 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 26 - s;
@@ -17779,7 +17779,7 @@ static int sp_384_point_new_ex_15(void* heap, sp_point_384* sp, sp_point_384** p
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -18108,10 +18108,10 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 15; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 26) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -18119,7 +18119,7 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 26 - s;

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -3060,7 +3060,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
     }
     if (err == MP_OKAY) {
         a = d + 36;
-        m = a + 36;
+        m = a + 72;
         r = a;
 
         sp_2048_from_bin(a, 36, in, inLen);
@@ -3292,10 +3292,10 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 36; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 57) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -3303,7 +3303,7 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 57 - s;
@@ -7171,7 +7171,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
     }
     if (err == MP_OKAY) {
         a = d + 54;
-        m = a + 54;
+        m = a + 108;
         r = a;
 
         sp_3072_from_bin(a, 54, in, inLen);
@@ -7403,10 +7403,10 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 54; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 57) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -7414,7 +7414,7 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 57 - s;
@@ -11527,7 +11527,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, mp_int* dm,
     }
     if (err == MP_OKAY) {
         a = d + 78;
-        m = a + 78;
+        m = a + 156;
         r = a;
 
         sp_4096_from_bin(a, 78, in, inLen);
@@ -11759,10 +11759,10 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 78; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 53) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -11770,7 +11770,7 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 53 - s;
@@ -12488,7 +12488,7 @@ static int sp_256_point_new_ex_5(void* heap, sp_point_256* sp, sp_point_256** p)
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -12759,10 +12759,10 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 5; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 52) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -12770,7 +12770,7 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 52 - s;
@@ -17566,7 +17566,7 @@ static int sp_384_point_new_ex_7(void* heap, sp_point_384* sp, sp_point_384** p)
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -17868,10 +17868,10 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 7; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 55) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -17879,7 +17879,7 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 55 - s;

--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -4116,6 +4116,63 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+    sp_digit* a;
+    sp_digit* d = NULL;
+    sp_digit* m;
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 256U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 2048) {
+           err = MP_READ_E;
+        }
+        if (inLen > 256) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 2048) {
+            err = MP_READ_E;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+    if (err == MP_OKAY) {
+        a = d + 64;
+        m = a + 128;
+        r = a;
+
+        sp_2048_from_bin(a, 64, in, inLen);
+        sp_2048_from_mp(d, 64, dm);
+        sp_2048_from_mp(m, 64, mm);
+        err = sp_2048_mod_exp_64(r, a, d, 2048, m, 0);
+    }
+    if (err == MP_OKAY) {
+        sp_2048_to_bin(r, out);
+        *outLen = 256;
+    }
+
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 64);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+
+    return err;
+#else
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
 /* Conditionally add a and b using the mask m.
  * m is -1 to add and 0 when not.
@@ -4274,6 +4331,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -4297,10 +4355,10 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 64; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -4308,7 +4366,7 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -8708,6 +8766,63 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+    sp_digit* a;
+    sp_digit* d = NULL;
+    sp_digit* m;
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 384U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 3072) {
+           err = MP_READ_E;
+        }
+        if (inLen > 384) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 3072) {
+            err = MP_READ_E;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 96 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+    if (err == MP_OKAY) {
+        a = d + 96;
+        m = a + 192;
+        r = a;
+
+        sp_3072_from_bin(a, 96, in, inLen);
+        sp_3072_from_mp(d, 96, dm);
+        sp_3072_from_mp(m, 96, mm);
+        err = sp_3072_mod_exp_96(r, a, d, 3072, m, 0);
+    }
+    if (err == MP_OKAY) {
+        sp_3072_to_bin(r, out);
+        *outLen = 384;
+    }
+
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 96);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+
+    return err;
+#else
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
 /* Conditionally add a and b using the mask m.
  * m is -1 to add and 0 when not.
@@ -8866,6 +8981,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -8889,10 +9005,10 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 96; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -8900,7 +9016,7 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -12246,6 +12362,63 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+    sp_digit* a;
+    sp_digit* d = NULL;
+    sp_digit* m;
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 512U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 4096) {
+           err = MP_READ_E;
+        }
+        if (inLen > 512) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 4096) {
+            err = MP_READ_E;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 128 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+    if (err == MP_OKAY) {
+        a = d + 128;
+        m = a + 256;
+        r = a;
+
+        sp_4096_from_bin(a, 128, in, inLen);
+        sp_4096_from_mp(d, 128, dm);
+        sp_4096_from_mp(m, 128, mm);
+        err = sp_4096_mod_exp_128(r, a, d, 4096, m, 0);
+    }
+    if (err == MP_OKAY) {
+        sp_4096_to_bin(r, out);
+        *outLen = 512;
+    }
+
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 128);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+
+    return err;
+#else
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
 /* Conditionally add a and b using the mask m.
  * m is -1 to add and 0 when not.
@@ -12405,6 +12578,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, mp_int* dm,
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -12428,10 +12602,10 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 128; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -12439,7 +12613,7 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -13587,7 +13761,7 @@ static int sp_256_point_new_ex_8(void* heap, sp_point_256* sp, sp_point_256** p)
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -13810,10 +13984,10 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 8; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -13821,7 +13995,7 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -16032,7 +16206,7 @@ static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, cons
         n <<= 4;
         for (; i>=0 || c>=4; ) {
             if (c < 4) {
-                n |= k[i--] << (0 - c);
+                n |= k[i--];
                 c += 32;
             }
             y = (n >> 28) & 0xf;
@@ -20048,7 +20222,7 @@ static int sp_384_point_new_ex_12(void* heap, sp_point_384* sp, sp_point_384** p
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -20302,10 +20476,10 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 12; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 32) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -20313,7 +20487,7 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 32 - s;
@@ -21538,7 +21712,7 @@ static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, con
         n <<= 4;
         for (; i>=0 || c>=4; ) {
             if (c < 4) {
-                n |= k[i--] << (0 - c);
+                n |= k[i--];
                 c += 32;
             }
             y = (n >> 28) & 0xf;

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -309,7 +309,7 @@ int sp_count_bits(sp_int* a)
         r *= SP_WORD_SIZE;
         if (d >= (1L << (SP_WORD_SIZE / 2))) {
             r += SP_WORD_SIZE;
-            while ((d & (1L << (SP_WORD_SIZE - 1))) == 0) {
+            while ((d & (1UL << (SP_WORD_SIZE - 1))) == 0) {
                 r--;
                 d <<= 1;
             }

--- a/wolfcrypt/src/sp_x86_64.c
+++ b/wolfcrypt/src/sp_x86_64.c
@@ -1466,6 +1466,100 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+/* RSA private key operation.
+ *
+ * in      Array of bytes representing the number to exponentiate, base.
+ * inLen   Number of bytes in base.
+ * dm      Private exponent.
+ * pm      First prime.
+ * qm      Second prime.
+ * dpm     First prime's CRT exponent.
+ * dqm     Second prime's CRT exponent.
+ * qim     Inverse of second prime mod p.
+ * mm      Modulus.
+ * out     Buffer to hold big-endian bytes of exponentiation result.
+ *         Must be at least 256 bytes long.
+ * outLen  Number of bytes in result.
+ * returns 0 on success, MP_TO_E when the outLen is too small, MP_READ_E when
+ * an array is too long and MEMORY_E when dynamic memory allocation fails.
+ */
+int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
+    mp_int* pm, mp_int* qm, mp_int* dpm, mp_int* dqm, mp_int* qim, mp_int* mm,
+    byte* out, word32* outLen)
+{
+#if !defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)
+    sp_digit a[64], d[32], m[32];
+#else
+    sp_digit* d = NULL;
+    sp_digit* a;
+    sp_digit* m;
+#endif
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 256U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 2048) {
+            err = MP_READ_E;
+        }
+        if (inLen > 256U) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 2048) {
+            err = MP_READ_E;
+        }
+    }
+
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 4, NULL,
+                                                             DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+#endif
+
+    if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        a = d + 32;
+        m = a + 64;
+#endif
+        r = a;
+
+        sp_2048_from_bin(a, 32, in, inLen);
+        sp_2048_from_mp(d, 32, dm);
+        sp_2048_from_mp(m, 32, mm);
+        err = sp_2048_mod_exp_32(r, a, d, 2048, m, 0);
+    }
+
+    if (err == MP_OKAY) {
+        sp_2048_to_bin(r, out);
+        *outLen = 256;
+    }
+
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 32);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+#else
+    XMEMSET(d, 0, sizeof(sp_digit) * 32);
+#endif
+
+    return err;
+}
+
+#else
 extern sp_digit sp_2048_cond_add_16(sp_digit* r, const sp_digit* a, const sp_digit* b, sp_digit m);
 extern sp_digit sp_2048_cond_add_avx2_16(sp_digit* r, const sp_digit* a, const sp_digit* b, sp_digit m);
 /* RSA private key operation.
@@ -1627,6 +1721,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, mp_int* dm,
 
     return err;
 }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -1650,10 +1745,10 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 32; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 64) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -1661,7 +1756,7 @@ static int sp_2048_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 64 - s;
@@ -3520,6 +3615,100 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+/* RSA private key operation.
+ *
+ * in      Array of bytes representing the number to exponentiate, base.
+ * inLen   Number of bytes in base.
+ * dm      Private exponent.
+ * pm      First prime.
+ * qm      Second prime.
+ * dpm     First prime's CRT exponent.
+ * dqm     Second prime's CRT exponent.
+ * qim     Inverse of second prime mod p.
+ * mm      Modulus.
+ * out     Buffer to hold big-endian bytes of exponentiation result.
+ *         Must be at least 384 bytes long.
+ * outLen  Number of bytes in result.
+ * returns 0 on success, MP_TO_E when the outLen is too small, MP_READ_E when
+ * an array is too long and MEMORY_E when dynamic memory allocation fails.
+ */
+int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
+    mp_int* pm, mp_int* qm, mp_int* dpm, mp_int* dqm, mp_int* qim, mp_int* mm,
+    byte* out, word32* outLen)
+{
+#if !defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)
+    sp_digit a[96], d[48], m[48];
+#else
+    sp_digit* d = NULL;
+    sp_digit* a;
+    sp_digit* m;
+#endif
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 384U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 3072) {
+            err = MP_READ_E;
+        }
+        if (inLen > 384U) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 3072) {
+            err = MP_READ_E;
+        }
+    }
+
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 48 * 4, NULL,
+                                                             DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+#endif
+
+    if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        a = d + 48;
+        m = a + 96;
+#endif
+        r = a;
+
+        sp_3072_from_bin(a, 48, in, inLen);
+        sp_3072_from_mp(d, 48, dm);
+        sp_3072_from_mp(m, 48, mm);
+        err = sp_3072_mod_exp_48(r, a, d, 3072, m, 0);
+    }
+
+    if (err == MP_OKAY) {
+        sp_3072_to_bin(r, out);
+        *outLen = 384;
+    }
+
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 48);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+#else
+    XMEMSET(d, 0, sizeof(sp_digit) * 48);
+#endif
+
+    return err;
+}
+
+#else
 extern sp_digit sp_3072_cond_add_24(sp_digit* r, const sp_digit* a, const sp_digit* b, sp_digit m);
 extern sp_digit sp_3072_cond_add_avx2_24(sp_digit* r, const sp_digit* a, const sp_digit* b, sp_digit m);
 /* RSA private key operation.
@@ -3681,6 +3870,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, mp_int* dm,
 
     return err;
 }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -3704,10 +3894,10 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 48; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 64) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -3715,7 +3905,7 @@ static int sp_3072_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 64 - s;
@@ -5028,6 +5218,100 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
     return err;
 }
 
+#if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
+/* RSA private key operation.
+ *
+ * in      Array of bytes representing the number to exponentiate, base.
+ * inLen   Number of bytes in base.
+ * dm      Private exponent.
+ * pm      First prime.
+ * qm      Second prime.
+ * dpm     First prime's CRT exponent.
+ * dqm     Second prime's CRT exponent.
+ * qim     Inverse of second prime mod p.
+ * mm      Modulus.
+ * out     Buffer to hold big-endian bytes of exponentiation result.
+ *         Must be at least 512 bytes long.
+ * outLen  Number of bytes in result.
+ * returns 0 on success, MP_TO_E when the outLen is too small, MP_READ_E when
+ * an array is too long and MEMORY_E when dynamic memory allocation fails.
+ */
+int sp_RsaPrivate_4096(const byte* in, word32 inLen, mp_int* dm,
+    mp_int* pm, mp_int* qm, mp_int* dpm, mp_int* dqm, mp_int* qim, mp_int* mm,
+    byte* out, word32* outLen)
+{
+#if !defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)
+    sp_digit a[128], d[64], m[64];
+#else
+    sp_digit* d = NULL;
+    sp_digit* a;
+    sp_digit* m;
+#endif
+    sp_digit* r;
+    int err = MP_OKAY;
+
+    (void)pm;
+    (void)qm;
+    (void)dpm;
+    (void)dqm;
+    (void)qim;
+
+    if (*outLen < 512U) {
+        err = MP_TO_E;
+    }
+    if (err == MP_OKAY) {
+        if (mp_count_bits(dm) > 4096) {
+            err = MP_READ_E;
+        }
+        if (inLen > 512U) {
+            err = MP_READ_E;
+        }
+        if (mp_count_bits(mm) != 4096) {
+            err = MP_READ_E;
+        }
+    }
+
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+    if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 4, NULL,
+                                                             DYNAMIC_TYPE_RSA);
+        if (d == NULL) {
+            err = MEMORY_E;
+        }
+    }
+#endif
+
+    if (err == MP_OKAY) {
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+        a = d + 64;
+        m = a + 128;
+#endif
+        r = a;
+
+        sp_4096_from_bin(a, 64, in, inLen);
+        sp_4096_from_mp(d, 64, dm);
+        sp_4096_from_mp(m, 64, mm);
+        err = sp_4096_mod_exp_64(r, a, d, 4096, m, 0);
+    }
+
+    if (err == MP_OKAY) {
+        sp_4096_to_bin(r, out);
+        *outLen = 512;
+    }
+
+#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+    if (d != NULL) {
+        XMEMSET(d, 0, sizeof(sp_digit) * 64);
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+    }
+#else
+    XMEMSET(d, 0, sizeof(sp_digit) * 64);
+#endif
+
+    return err;
+}
+
+#else
 extern sp_digit sp_4096_cond_add_32(sp_digit* r, const sp_digit* a, const sp_digit* b, sp_digit m);
 extern sp_digit sp_4096_cond_add_avx2_32(sp_digit* r, const sp_digit* a, const sp_digit* b, sp_digit m);
 /* RSA private key operation.
@@ -5189,6 +5473,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, mp_int* dm,
 
     return err;
 }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 #endif /* WOLFSSL_HAVE_SP_RSA */
 #if defined(WOLFSSL_HAVE_SP_DH) || (defined(WOLFSSL_HAVE_SP_RSA) && \
                                               !defined(WOLFSSL_RSA_PUBLIC_ONLY))
@@ -5212,10 +5497,10 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 64; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 64) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -5223,7 +5508,7 @@ static int sp_4096_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 64 - s;
@@ -5693,7 +5978,7 @@ static int sp_256_point_new_ex_4(void* heap, sp_point_256* sp, sp_point_256** p)
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -5912,10 +6197,10 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 4; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 64) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -5923,7 +6208,7 @@ static int sp_256_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 64 - s;
@@ -23529,7 +23814,7 @@ static int sp_384_point_new_ex_6(void* heap, sp_point_384* sp, sp_point_384** p)
 #else
     *p = sp;
 #endif
-    if (p == NULL) {
+    if (*p == NULL) {
         ret = MEMORY_E;
     }
     return ret;
@@ -23801,10 +24086,10 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
 
         r->dp[0] = 0;
         for (i = 0; i < 6; i++) {
-            r->dp[j] |= a[i] << s;
+            r->dp[j] |= (mp_digit)(a[i] << s);
             r->dp[j] &= (1L << DIGIT_BIT) - 1;
             s = DIGIT_BIT - s;
-            r->dp[++j] = a[i] >> s;
+            r->dp[++j] = (mp_digit)(a[i] >> s);
             while (s + DIGIT_BIT <= 64) {
                 s += DIGIT_BIT;
                 r->dp[j++] &= (1L << DIGIT_BIT) - 1;
@@ -23812,7 +24097,7 @@ static int sp_384_to_mp(const sp_digit* a, mp_int* r)
                     r->dp[j] = 0;
                 }
                 else {
-                    r->dp[j] = a[i] >> s;
+                    r->dp[j] = (mp_digit)(a[i] >> s);
                 }
             }
             s = 64 - s;

--- a/wolfcrypt/src/wolfmath.c
+++ b/wolfcrypt/src/wolfmath.c
@@ -212,9 +212,9 @@ int wc_bigint_alloc(WC_BIGINT* a, word32 sz)
         }
         if (a->buf == NULL) {
             a->buf = (byte*)XMALLOC(sz, a->heap, DYNAMIC_TYPE_WOLF_BIGINT);
-        }
-        if (a->buf == NULL) {
-            err = MP_MEM;
+            if (a->buf == NULL) {
+                err = MP_MEM;
+            }
         }
         else {
             XMEMSET(a->buf, 0, sz);


### PR DESCRIPTION
Added PRIVATE_D version of rsa private key operation for SP
implementation for specific platforms.
WC_NO_RNG results in warnings when RNG calls don't do anything.
Added ifdef checks for variables not used otherwise.
Remove superfluous if statements like when checking ret == 0.
Change names of globals that are generic and are used locally before
global definition.
Remove definition of variable len that isn't used except as a
replacement for sz which is parameter.
Don't subtract two variables when one has just been assigned the value
of the other.
Fix shifting of signed value.
Fix parameter checking in aes.c and des3.c for platform specific code.