### PR TITLE
Fix for asynchronous TLS v1.3 issue

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12182,7 +12182,13 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         }
         #endif
 
-        if (ssl->buffers.outputBuffer.length > 0) {
+        if (ssl->buffers.outputBuffer.length > 0
+        #ifdef WOLFSSL_ASYNC_CRYPT
+            /* do not send buffered or advance state if last error was an 
+                async pending operation */
+            && ssl->error != WC_PENDING_E
+        #endif
+        ) {
             if ( (ssl->error = SendBuffered(ssl)) == 0) {
                 /* fragOffset is non-zero when sending fragments. On the last
                  * fragment, fragOffset is zero again, and the state can be
@@ -12580,7 +12586,13 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         }
     #endif
 
-        if (ssl->buffers.outputBuffer.length > 0) {
+        if (ssl->buffers.outputBuffer.length > 0
+        #ifdef WOLFSSL_ASYNC_CRYPT
+            /* do not send buffered or advance state if last error was an 
+                async pending operation */
+            && ssl->error != WC_PENDING_E
+        #endif
+        ) {
             if ( (ssl->error = SendBuffered(ssl)) == 0) {
                 /* fragOffset is non-zero when sending fragments. On the last
                  * fragment, fragOffset is zero again, and the state can be

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -7870,7 +7870,13 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
         return WOLFSSL_FATAL_ERROR;
     }
 
-    if (ssl->buffers.outputBuffer.length > 0) {
+    if (ssl->buffers.outputBuffer.length > 0
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        /* do not send buffered or advance state if last error was an 
+            async pending operation */
+        && ssl->error != WC_PENDING_E
+    #endif
+    ) {
         if ((ssl->error = SendBuffered(ssl)) == 0) {
             /* fragOffset is non-zero when sending fragments. On the last
              * fragment, fragOffset is zero again, and the state can be
@@ -8592,7 +8598,13 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
     }
 #endif
 
-    if (ssl->buffers.outputBuffer.length > 0) {
+    if (ssl->buffers.outputBuffer.length > 0
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        /* do not send buffered or advance state if last error was an 
+            async pending operation */
+        && ssl->error != WC_PENDING_E
+    #endif
+    ) {
         if ((ssl->error = SendBuffered(ssl)) == 0) {
             /* fragOffset is non-zero when sending fragments. On the last
              * fragment, fragOffset is zero again, and the state can be


### PR DESCRIPTION
* Fix for asynchronous TLS v1.3 issue where connect or accept state is incorrectly advanced when there is data to queued to send.

ZD 10092