### PR TITLE
Fix wc_KeyPemToDer with PKCS1 and empty key

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -20052,7 +20052,7 @@ static void test_wc_PemToDer(void)
 
     printf(testingFmt, "wc_PemToDer()");
 
-    memset(&info, 0, sizeof(info));
+    XMEMSET(&info, 0, sizeof(info));
 
     ret = load_file(ca_cert, &cert_buf, &cert_sz);
     if (ret == 0) {
@@ -25686,7 +25686,7 @@ static void test_wolfSSL_RSA(void)
         AssertTrue((f != XBADFILE));
         bytes = (int)XFREAD(buff, 1, sizeof(buff), f);
         XFCLOSE(f);
-        memset(der, 0, sizeof(der));
+        XMEMSET(der, 0, sizeof(der));
         /* test that error value is returned with no password */
         AssertIntLT(wc_KeyPemToDer(buff, bytes, der, (word32)sizeof(der), ""), 0);
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -25671,6 +25671,27 @@ static void test_wolfSSL_RSA(void)
     AssertNull(RSA_generate_key(4097, 3, NULL, NULL)); /* RSA_MAX_SIZE + 1 */
     AssertNull(RSA_generate_key(2048, 0, NULL, NULL));
 
+
+#if !defined(NO_FILESYSTEM) && !defined(NO_ASN)
+    {
+        byte buff[FOURK_BUF];
+        byte der[FOURK_BUF];
+        const char PrivKeyPemFile[] = "certs/client-keyEnc.pem";
+
+        XFILE f;
+        int bytes;
+
+        /* test loading encrypted RSA private pem w/o password */
+        f = XFOPEN(PrivKeyPemFile, "rb");
+        AssertTrue((f != XBADFILE));
+        bytes = (int)XFREAD(buff, 1, sizeof(buff), f);
+        XFCLOSE(f);
+        memset(der, 0, sizeof(der));
+        /* test that error value is returned with no password */
+        AssertIntLT(wc_KeyPemToDer(buff, bytes, der, (word32)sizeof(der), ""), 0);
+    }
+#endif
+
     printf(resultFmt, passed);
 #endif
 }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -10562,11 +10562,8 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
             }
             /* decrypt the key */
             else {
-                int length;
-                word32 inOutIdx = 0;
-                if ((passwordSz == 0) &&
-                    (GetSequence(der->buffer, &inOutIdx, &length,
-                            der->length) < 0)) {
+                if (passwordSz == 0) {
+                    /* The key is encrypted but does not have a password */
                     ret = ASN_PARSE_E;
                 }
                 else {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -10564,7 +10564,8 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
             else {
                 if (passwordSz == 0) {
                     /* The key is encrypted but does not have a password */
-                    ret = ASN_PARSE_E;
+                    WOLFSSL_MSG("No password for encrypted key");
+                    ret = NO_PASSWORD;
                 }
                 else {
                     ret = wc_BufferKeyDecrypt(info, der->buffer, der->length,

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -10562,20 +10562,28 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
             }
             /* decrypt the key */
             else {
-                ret = wc_BufferKeyDecrypt(info, der->buffer, der->length,
-                    (byte*)password, passwordSz, WC_MD5);
+                int length;
+                word32 inOutIdx = 0;
+                if ((passwordSz == 0) &&
+                    (GetSequence(der->buffer, &inOutIdx, &length,
+                            der->length) < 0)) {
+                    ret = ASN_PARSE_E;
+                }
+                else {
+                    ret = wc_BufferKeyDecrypt(info, der->buffer, der->length,
+                        (byte*)password, passwordSz, WC_MD5);
 
 #ifndef NO_WOLFSSL_SKIP_TRAILING_PAD
-            #ifndef NO_DES3
-                if (info->cipherType == WC_CIPHER_DES3) {
-                    padVal = der->buffer[der->length-1];
-                    if (padVal <= DES_BLOCK_SIZE) {
-                        der->length -= padVal;
+                #ifndef NO_DES3
+                    if (info->cipherType == WC_CIPHER_DES3) {
+                        padVal = der->buffer[der->length-1];
+                        if (padVal <= DES_BLOCK_SIZE) {
+                            der->length -= padVal;
+                        }
                     }
-                }
-            #endif /* !NO_DES3 */
+                #endif /* !NO_DES3 */
 #endif /* !NO_WOLFSSL_SKIP_TRAILING_PAD */
-
+                }
             }
 #ifdef OPENSSL_EXTRA
             if (ret) {


### PR DESCRIPTION
Adds error code response is using an encrypted PEM and no password is provided.
Test case requires `./configure --enable-opensslextra --enable-keygen --enable-enckeys --enable-pwdbased --enable-des3`.
ZD9916