### PR TITLE
Fix EVP API to return NID types / SHA3 for RSA sign

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -161,8 +161,7 @@ static int wolfSSL_BIO_MD_read(WOLFSSL_BIO* bio, void* buf, int sz)
 {
     int ret = sz;
 
-    if (wolfSSL_EVP_MD_CTX_type((WOLFSSL_EVP_MD_CTX*)bio->ptr) ==
-            (NID_hmac & 0xFF)) {
+    if (wolfSSL_EVP_MD_CTX_type((WOLFSSL_EVP_MD_CTX*)bio->ptr) == NID_hmac) {
         if (wolfSSL_EVP_DigestSignUpdate((WOLFSSL_EVP_MD_CTX*)bio->ptr, buf,
                         sz) != WOLFSSL_SUCCESS)
         {
@@ -470,8 +469,7 @@ static int wolfSSL_BIO_MD_write(WOLFSSL_BIO* bio, const void* data, int len)
         return BAD_FUNC_ARG;
     }
 
-    if (wolfSSL_EVP_MD_CTX_type((WOLFSSL_EVP_MD_CTX*)bio->ptr) ==
-            (NID_hmac & 0xFF)) {
+    if (wolfSSL_EVP_MD_CTX_type((WOLFSSL_EVP_MD_CTX*)bio->ptr) == NID_hmac) {
         if (wolfSSL_EVP_DigestSignUpdate((WOLFSSL_EVP_MD_CTX*)bio->ptr, data,
                     len) != WOLFSSL_SUCCESS) {
             ret = WOLFSSL_BIO_ERROR;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16039,7 +16039,6 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         return WOLFSSL_SUCCESS;
     }
 
-
     /* set internal IV from external, WOLFSSL_SUCCESS on success */
     int  wolfSSL_SetInternalIV(WOLFSSL_EVP_CIPHER_CTX* ctx)
     {
@@ -29245,7 +29244,7 @@ static void show(const char *title, const unsigned char *out, unsigned int outle
 #define show(a,b,c)
 #endif
 
-/* return SSL_SUCCES on ok, 0 otherwise */
+/* return SSL_SUCCESS on ok, 0 otherwise */
 int wolfSSL_RSA_sign(int type, const unsigned char* m,
                            unsigned int mLen, unsigned char* sigRet,
                            unsigned int* sigLen, WOLFSSL_RSA* rsa)
@@ -29296,6 +29295,18 @@ int wolfSSL_RSA_sign_ex(int type, const unsigned char* m,
     #endif
     #ifdef WOLFSSL_SHA512
         case NID_sha512:    type = SHA512h; break;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_224
+        case NID_sha3_224:  type = SHA3_224h; break;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_256
+        case NID_sha3_256:  type = SHA3_256h; break;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_384
+        case NID_sha3_384:  type = SHA3_384h; break;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_512
+        case NID_sha3_512:  type = SHA3_512h; break;
     #endif
         default:
             WOLFSSL_MSG("This NID (md type) not configured or not implemented");

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -185,7 +185,7 @@ struct WOLFSSL_EVP_MD_CTX {
         Hmac hmac;
     #endif
     } hash;
-    unsigned char macType;
+    int macType;
     WOLFSSL_EVP_PKEY_CTX *pctx;
 };
 
@@ -239,6 +239,7 @@ enum {
     NID_sha1          = 64,
     NID_sha224        = 65,
     NID_md2           = 77,
+    NID_md4           = 257,
     NID_md5           =  4,
     NID_hmac          = 855,
     NID_dhKeyAgreement= 28,


### PR DESCRIPTION
Fix OpenSSL compatibility for `EVP_MD_type` and `EVP_MD_CTX_type` to return NID values instead of WC_*** types. Also adding support for SHA3 in `wolfSSL_RSA_sign_ex`.

This fixes an issue from ZD9856