### PR TITLE
Adding check for invalid SAN ext with no entries

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7635,6 +7635,13 @@ static int DecodeAltNames(const byte* input, int sz, DecodedCert* cert)
         return ASN_PARSE_E;
     }
 
+    if (length == 0) {
+        /* RFC 5280 4.2.1.6.  Subject Alternative Name
+           If the subjectAltName extension is present, the sequence MUST
+           contain at least one entry. */
+        return ASN_PARSE_E;
+    }
+
     cert->weOwnAltNames = 1;
 
     while (length > 0) {


### PR DESCRIPTION
Adding a check for the invalid SAN extension. This is the more applicable rule from the RFC, and the one I applied to the error condition:

https://tools.ietf.org/html/rfc5280#section-4.2.1.6

```
  If the subjectAltName extension is present, the sequence MUST contain
   at least one entry.  Unlike the subject field, conforming CAs MUST
   NOT issue certificates with subjectAltNames containing empty
   GeneralName fields.  For example, an rfc822Name is represented as an
   IA5String.  While an empty string is a valid IA5String, such an
   rfc822Name is not permitted by this profile.  The behavior of clients
   that encounter such a certificate when processing a certification
   path is not defined by this profile.
```

The offending cert was provided to me, which I used to test against. I was unable to generate a cert with an empty SAN, so there is not a new test case. 

This fixes an issue from ZD9564