### PR TITLE
SendTls13CertificateVerify: args is local ifndef WOLFSSL_ASYNC_CRYPT

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -5779,7 +5779,9 @@ exit_scv:
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
     /* Final cleanup */
+#ifdef WOLFSSL_ASYNC_CRYPT
     FreeScv13Args(ssl, args);
+#endif
     FreeKeyExchange(ssl);
 
     return ret;


### PR DESCRIPTION
As such, don't free it.