### PR TITLE
DTLS Revert

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -14755,8 +14755,7 @@ int ProcessReply(WOLFSSL* ssl)
                                        &ssl->curRL, &ssl->curSize);
 #ifdef WOLFSSL_DTLS
             if (ssl->options.dtls && ret == SEQUENCE_ERROR) {
-                if (ssl->keys.curEpoch == ssl->keys.dtls_epoch + 1) {
-                    /* Store if in the next epoch. Probably finished. */
+                if (ssl->keys.curEpoch != 0) {
                     word32 sz = ssl->buffers.inputBuffer.length -
                                 ssl->buffers.inputBuffer.idx +
                                 DTLS_RECORD_HEADER_SZ;

--- a/src/internal.c
+++ b/src/internal.c
@@ -6278,9 +6278,6 @@ void SSL_ResourceFree(WOLFSSL* ssl)
         ssl->dtls_rx_msg_list = NULL;
         ssl->dtls_rx_msg_list_sz = 0;
     }
-    XFREE(ssl->dtls_pending_finished, ssl->heap, DYNAMIC_TYPE_DTLS_BUFFER);
-    ssl->dtls_pending_finished = NULL;
-    ssl->dtls_pending_finished_sz = 0;
     XFREE(ssl->buffers.dtlsCtx.peer.sa, ssl->heap, DYNAMIC_TYPE_SOCKADDR);
     ssl->buffers.dtlsCtx.peer.sa = NULL;
 #ifndef NO_WOLFSSL_SERVER
@@ -6523,11 +6520,6 @@ void FreeHandshakeResources(WOLFSSL* ssl)
         DtlsMsgListDelete(ssl->dtls_rx_msg_list, ssl->heap);
         ssl->dtls_rx_msg_list = NULL;
         ssl->dtls_rx_msg_list_sz = 0;
-        if (ssl->dtls_pending_finished != NULL) {
-            XFREE(ssl->dtls_pending_finished, ssl->heap, DYNAMIC_TYPE_DTLS_MSG);
-            ssl->dtls_pending_finished = NULL;
-            ssl->dtls_pending_finished_sz = 0;
-        }
     }
 #endif
 
@@ -11742,11 +11734,6 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         default:
             ret = BUFFER_ERROR;
     }
-#ifdef WOLFSSL_DTLS
-    if (ssl->options.dtls) {
-        DtlsMsgPoolReset(ssl);
-    }
-#endif
 
     if (ret != 0)
         SendAlert(ssl, alert_fatal, bad_certificate_status_response);
@@ -12477,14 +12464,6 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     case finished:
         WOLFSSL_MSG("processing finished");
         ret = DoFinished(ssl, input, inOutIdx, size, totalSz, NO_SNIFF);
-
-        #ifdef WOLFSSL_DTLS
-        if (ssl->dtls_pending_finished != NULL) {
-            XFREE(ssl->dtls_pending_finished, ssl->heap, DYNAMIC_TYPE_DTLS_MSG);
-            ssl->dtls_pending_finished = NULL;
-            ssl->dtls_pending_finished_sz = 0;
-        }
-        #endif
         break;
 
 #ifndef NO_WOLFSSL_SERVER
@@ -12735,7 +12714,6 @@ static WC_INLINE int DtlsCheckWindow(WOLFSSL* ssl)
         window = peerSeq->prevWindow;
     }
     else {
-        WOLFSSL_MSG("Different epoch");
         return 0;
     }
 
@@ -14755,44 +14733,20 @@ int ProcessReply(WOLFSSL* ssl)
                                        &ssl->curRL, &ssl->curSize);
 #ifdef WOLFSSL_DTLS
             if (ssl->options.dtls && ret == SEQUENCE_ERROR) {
-                if (ssl->keys.curEpoch != 0) {
-                    word32 sz = ssl->buffers.inputBuffer.length -
-                                ssl->buffers.inputBuffer.idx +
-                                DTLS_RECORD_HEADER_SZ;
-
-                    if (ssl->dtls_pending_finished != NULL) {
-                        XFREE(ssl->dtls_pending_finished, ssl->heap,
-                                DYNAMIC_TYPE_DTLS_MSG);
-                    }
-
-                    ssl->dtls_pending_finished = (byte*)XMALLOC(sz, ssl->heap,
-                            DYNAMIC_TYPE_DTLS_MSG);
-                    if (ssl->dtls_pending_finished == NULL)
-                        return MEMORY_E;
-
-                    ssl->dtls_pending_finished_sz = sz;
-                    XMEMCPY(ssl->dtls_pending_finished,
-                            ssl->buffers.inputBuffer.buffer +
-                                ssl->buffers.inputBuffer.idx -
-                                DTLS_RECORD_HEADER_SZ,
-                            sz);
-                    ssl->buffers.inputBuffer.idx += ssl->curSize;
-                }
-                else {
-                    WOLFSSL_MSG("Silently dropping out of order DTLS message");
-                    ssl->options.processReply = doProcessInit;
-                    ssl->buffers.inputBuffer.length = 0;
-                    ssl->buffers.inputBuffer.idx = 0;
+                WOLFSSL_MSG("Silently dropping out of order DTLS message");
+                ssl->options.processReply = doProcessInit;
+                ssl->buffers.inputBuffer.length = 0;
+                ssl->buffers.inputBuffer.idx = 0;
 #ifdef WOLFSSL_DTLS_DROP_STATS
-                    ssl->replayDropCount++;
+                ssl->replayDropCount++;
 #endif /* WOLFSSL_DTLS_DROP_STATS */
 
-                    if (IsDtlsNotSctpMode(ssl) && ssl->options.dtlsHsRetain) {
-                        ret = DtlsMsgPoolSend(ssl, 0);
-                        if (ret != 0)
-                            return ret;
-                    }
+                if (IsDtlsNotSctpMode(ssl) && ssl->options.dtlsHsRetain) {
+                    ret = DtlsMsgPoolSend(ssl, 0);
+                    if (ret != 0)
+                        return ret;
                 }
+
                 continue;
             }
 #endif
@@ -15342,33 +15296,6 @@ int ProcessReply(WOLFSSL* ssl)
                                        server : client);
                     if (ret != 0)
                         return ret;
-#ifdef WOLFSSL_DTLS
-                    if (ssl->dtls_pending_finished != NULL &&
-                            ssl->dtls_pending_finished_sz > 0) {
-
-                        if (GrowInputBuffer(ssl, ssl->dtls_pending_finished_sz,
-                                ssl->buffers.inputBuffer.length -
-                                    ssl->buffers.inputBuffer.idx) < 0) {
-
-                            return MEMORY_E;
-                        }
-
-                        XMEMCPY(ssl->buffers.inputBuffer.buffer +
-                                    ssl->buffers.inputBuffer.idx,
-                                ssl->dtls_pending_finished,
-                                ssl->dtls_pending_finished_sz);
-                        ssl->buffers.inputBuffer.length +=
-                                ssl->dtls_pending_finished_sz;
-
-                        XFREE(ssl->dtls_pending_finished, ssl->heap,
-                                DYNAMIC_TYPE_DTLS_MSG);
-                        ssl->dtls_pending_finished = NULL;
-                        ssl->dtls_pending_finished_sz = 0;
-
-                        ssl->options.processReply = getRecordLayerHeader;
-                        continue;
-                    }
-#endif
 #endif /* !WOLFSSL_NO_TLS12 */
                     break;
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4019,8 +4019,6 @@ struct WOLFSSL {
     DtlsMsg*        dtls_tx_msg_list;
     DtlsMsg*        dtls_tx_msg;
     DtlsMsg*        dtls_rx_msg_list;
-    byte*           dtls_pending_finished;
-    word32          dtls_pending_finished_sz;
     void*           IOCB_CookieCtx;     /* gen cookie ctx */
     word32          dtls_expected_rx;
 #ifdef WOLFSSL_SESSION_EXPORT


### PR DESCRIPTION
Revert the recent changes to DTLS. The storage and use of the saved finished message is failing in fuzz testing. Will restore it after the release and finish it. (Reverts PRs: #2879 (only commit 04dcb8f) and #2905 (commit 70d03f3)).