### PR TITLE
Fixes for async release v4.4.0

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15774,7 +15774,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         (void)sizeof(sha_test);
 
         WOLFSSL_ENTER("SHA3_256_Init");
-        ret = wc_InitSha3_256((wc_Sha3*)sha3_256, NULL, 0);
+        ret = wc_InitSha3_256((wc_Sha3*)sha3_256, NULL, INVALID_DEVID);
 
         /* return 1 on success, 0 otherwise */
         if (ret == 0)

--- a/tests/api.c
+++ b/tests/api.c
@@ -28688,7 +28688,8 @@ static void test_wolfSSL_EC_get_builtin_curves(void)
 
     for (i = 0; i < crv_len; i++)
     {
-        AssertStrEQ(OBJ_nid2sn(curves[i].nid), curves[i].comment);
+        if (curves[i].comment != NULL)
+            AssertStrEQ(OBJ_nid2sn(curves[i].nid), curves[i].comment);
     }
 
     XFREE(curves, NULL, DYNAMIC_TYPE_TMP_BUFFER);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -15614,16 +15614,12 @@ int openssl_test(void)
     /* test malloc / free , 10 is an arbitrary amount of memory chosen */
     {
         byte* p;
-        p = (byte*)CRYPTO_malloc(10, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+        p = (byte*)CRYPTO_malloc(10);
         if (p == NULL) {
             return -8400;
         }
         XMEMSET(p, 0, 10);
-        #ifdef WOLFSSL_QT
-            CRYPTO_free(p);
-        #else
-            CRYPTO_free(p, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        #endif
+        CRYPTO_free(p);
     }
 
 #ifndef NO_MD5

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -125,17 +125,8 @@ typedef WOLFSSL_X509_VERIFY_PARAM X509_VERIFY_PARAM;
 #define CONF_get1_default_config_file   wolfSSL_CONF_get1_default_config_file
 typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 
-#ifdef WOLFSSL_QT
-    #if defined(NO_WOLFSSL_MEMORY)
-        #define CRYPTO_free(xp)         XFREE(xp, NULL, NULL);
-    #else
-        #define CRYPTO_free(xp) { if((xp)) wolfSSL_Free((xp));}
-    #endif
-#else
-  #define CRYPTO_free                     XFREE
-#endif
-
-#define CRYPTO_malloc                   XMALLOC
+#define CRYPTO_free(xp)                 XFREE(xp, NULL, DYNAMIC_TYPE_TMP_BUFFER)
+#define CRYPTO_malloc(sz)               XMALLOC(sz, NULL, DYNAMIC_TYPE_TMP_BUFFER)
 #define CRYPTO_EX_new                   WOLFSSL_CRYPTO_EX_new
 #define CRYPTO_EX_dup                   WOLFSSL_CRYPTO_EX_dup
 #define CRYPTO_EX_free                  WOLFSSL_CRYPTO_EX_free


### PR DESCRIPTION
* Fix for use of incorrect devId for `wolfSSL_SHA3_256_Init`.
* Fix for NULL == NULL test case in `test_wolfSSL_EC_get_builtin_curves`.
* Resolve issues with the openssl compatibility `CRYPTO_malloc` and `CRYPTO_free`.