### PR TITLE
Fixes for G++ and enable-all

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -24965,13 +24965,13 @@ void wolfSSL_ASN1_TYPE_set(WOLFSSL_ASN1_TYPE *a, int type, void *value)
     }
     switch (type) {
         case V_ASN1_OBJECT:
-            a->value.object = value;
+            a->value.object = (WOLFSSL_ASN1_OBJECT*)value;
             break;
         case V_ASN1_UTCTIME:
-            a->value.utctime = value;
+            a->value.utctime = (WOLFSSL_ASN1_TIME*)value;
             break;
         case V_ASN1_GENERALIZEDTIME:
-            a->value.generalizedtime = value;
+            a->value.generalizedtime = (WOLFSSL_ASN1_TIME*)value;
             break;
         default:
             WOLFSSL_MSG("Unknown or unsupported ASN1_TYPE");
@@ -28202,20 +28202,20 @@ WOLFSSL_ASN1_INTEGER* wolfSSL_BN_to_ASN1_INTEGER(const WOLFSSL_BIGNUM *bn, WOLFS
 }
 
 #ifdef OPENSSL_ALL
-void *wolfSSL_ASN1_item_new(const WOLFSSL_ASN1_ITEM *template)
+void *wolfSSL_ASN1_item_new(const WOLFSSL_ASN1_ITEM *tpl)
 {
     void *ret = NULL;
     const WOLFSSL_ASN1_TEMPLATE *member = NULL;
     size_t i;
     WOLFSSL_ENTER("wolfSSL_ASN1_item_new");
-    if (!template) {
+    if (!tpl) {
         return NULL;
     }
-    if (!(ret = XMALLOC(template->size, NULL, DYNAMIC_TYPE_OPENSSL))) {
+    if (!(ret = XMALLOC(tpl->size, NULL, DYNAMIC_TYPE_OPENSSL))) {
         return NULL;
     }
-    XMEMSET(ret, 0, template->size);
-    for (member = template->members, i = 0; i < template->mcount;
+    XMEMSET(ret, 0, tpl->size);
+    for (member = tpl->members, i = 0; i < tpl->mcount;
             member++, i++) {
         switch (member->type) {
             case WOLFSSL_X509_ALGOR_ASN1:
@@ -28243,17 +28243,17 @@ void *wolfSSL_ASN1_item_new(const WOLFSSL_ASN1_ITEM *template)
     }
     return ret;
 error:
-    wolfSSL_ASN1_item_free(ret, template);
+    wolfSSL_ASN1_item_free(ret, tpl);
     return NULL;
 }
 
-void wolfSSL_ASN1_item_free(void *val, const WOLFSSL_ASN1_ITEM *template)
+void wolfSSL_ASN1_item_free(void *val, const WOLFSSL_ASN1_ITEM *tpl)
 {
     const WOLFSSL_ASN1_TEMPLATE *member = NULL;
     size_t i;
     WOLFSSL_ENTER("wolfSSL_ASN1_item_free");
     if (val) {
-        for (member = template->members, i = 0; i < template->mcount;
+        for (member = tpl->members, i = 0; i < tpl->mcount;
                 member++, i++) {
             switch (member->type) {
                 case WOLFSSL_X509_ALGOR_ASN1:
@@ -28341,20 +28341,20 @@ static int i2dProcessMembers(const void *src, byte *buf,
 }
 
 int wolfSSL_ASN1_item_i2d(const void *src, byte **dest,
-                          const WOLFSSL_ASN1_ITEM *template)
+                          const WOLFSSL_ASN1_ITEM *tpl)
 {
     int len = 0;
     byte *buf = NULL;
 
     WOLFSSL_ENTER("wolfSSL_ASN1_item_i2d");
 
-    if (!src || !template) {
+    if (!src || !tpl) {
         WOLFSSL_LEAVE("wolfSSL_ASN1_item_i2d", WOLFSSL_FAILURE);
         return WOLFSSL_FAILURE;
     }
 
     if (dest && !*dest) {
-        len = wolfSSL_ASN1_item_i2d(src, NULL, template);
+        len = wolfSSL_ASN1_item_i2d(src, NULL, tpl);
         if (!len) {
             goto error;
         }
@@ -28365,18 +28365,18 @@ int wolfSSL_ASN1_item_i2d(const void *src, byte **dest,
         len = 0;
     }
 
-    switch (template->type) {
+    switch (tpl->type) {
         case ASN_SEQUENCE:
         {
-            int seq_len = i2dProcessMembers(src, NULL, template->members,
-                                         template->mcount);
+            int seq_len = i2dProcessMembers(src, NULL, tpl->members,
+                                         tpl->mcount);
             if (!seq_len) {
                 goto error;
             }
             len += SetSequence(seq_len, bufLenOrNull(buf, len));
             if (buf &&
-                    i2dProcessMembers(src, bufLenOrNull(buf, len), template->members,
-                                   template->mcount) != seq_len) {
+                    i2dProcessMembers(src, bufLenOrNull(buf, len), tpl->members,
+                                   tpl->mcount) != seq_len) {
                 WOLFSSL_MSG("Inconsistent sequence length");
                 goto error;
             }
@@ -34996,7 +34996,7 @@ int wolfSSL_RSA_padding_add_PKCS1_PSS(WOLFSSL_RSA *rsa, unsigned char *EM,
         goto cleanup;
     }
 
-    hashType = wolfSSL_EVP_md2macType(hashAlg);
+    hashType = (enum wc_HashType)wolfSSL_EVP_md2macType(hashAlg);
     if (hashType < WC_HASH_TYPE_NONE || hashType > WC_HASH_TYPE_MAX) {
         WOLFSSL_MSG("wolfSSL_EVP_md2macType error");
         goto cleanup;
@@ -35034,9 +35034,9 @@ int wolfSSL_RSA_padding_add_PKCS1_PSS(WOLFSSL_RSA *rsa, unsigned char *EM,
             }
     }
 
-    if (wc_RsaPad_ex(mHash, wolfSSL_EVP_MD_size(hashAlg), EM, emLen,
+    if (wc_RsaPad_ex(mHash, hashLen, EM, emLen,
                      RSA_BLOCK_TYPE_1, rng, WC_RSA_PSS_PAD,
-                     wolfSSL_EVP_md2macType(hashAlg), mgf, NULL, 0, saltLen,
+                     hashType, mgf, NULL, 0, saltLen,
                      wolfSSL_BN_num_bits(rsa->n), NULL) != MP_OKAY) {
         WOLFSSL_MSG("wc_RsaPad_ex error");
         goto cleanup;
@@ -35103,7 +35103,7 @@ int wolfSSL_RSA_verify_PKCS1_PSS(WOLFSSL_RSA *rsa, const unsigned char *mHash,
         return WOLFSSL_FAILURE;
     }
 
-    hashType = wolfSSL_EVP_md2macType(hashAlg);
+    hashType = (enum wc_HashType)wolfSSL_EVP_md2macType(hashAlg);
     if (hashType < WC_HASH_TYPE_NONE || hashType > WC_HASH_TYPE_MAX) {
         WOLFSSL_MSG("wolfSSL_EVP_md2macType error");
         return WOLFSSL_FAILURE;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -34996,7 +34996,7 @@ int wolfSSL_RSA_padding_add_PKCS1_PSS(WOLFSSL_RSA *rsa, unsigned char *EM,
         goto cleanup;
     }
 
-    hashType = (enum wc_HashType)wolfSSL_EVP_md2macType(hashAlg);
+    hashType = wolfSSL_EVP_md2macType(hashAlg);
     if (hashType < WC_HASH_TYPE_NONE || hashType > WC_HASH_TYPE_MAX) {
         WOLFSSL_MSG("wolfSSL_EVP_md2macType error");
         goto cleanup;
@@ -35103,7 +35103,7 @@ int wolfSSL_RSA_verify_PKCS1_PSS(WOLFSSL_RSA *rsa, const unsigned char *mHash,
         return WOLFSSL_FAILURE;
     }
 
-    hashType = (enum wc_HashType)wolfSSL_EVP_md2macType(hashAlg);
+    hashType = wolfSSL_EVP_md2macType(hashAlg);
     if (hashType < WC_HASH_TYPE_NONE || hashType > WC_HASH_TYPE_MAX) {
         WOLFSSL_MSG("wolfSSL_EVP_md2macType error");
         return WOLFSSL_FAILURE;

--- a/tests/api.c
+++ b/tests/api.c
@@ -31014,7 +31014,7 @@ static void test_wolfSSL_ASN1_INTEGER_set()
 }
 
 /* Testing code used in dpp.c in hostap */
-#ifdef OPENSSL_ALL
+#if defined(OPENSSL_ALL) && defined(HAVE_ECC) && defined(USE_CERT_BUFFERS_256)
 typedef struct {
     /* AlgorithmIdentifier ecPublicKey with optional parameters present
      * as an OID identifying the curve */
@@ -31029,7 +31029,7 @@ ASN1_SEQUENCE(DPP_BOOTSTRAPPING_KEY) = {
 } ASN1_SEQUENCE_END(DPP_BOOTSTRAPPING_KEY);
 
 IMPLEMENT_ASN1_FUNCTIONS(DPP_BOOTSTRAPPING_KEY);
-#endif /* WOLFSSL_WPAS */
+#endif
 
 static void test_wolfSSL_IMPLEMENT_ASN1_FUNCTIONS()
 {

--- a/tests/api.c
+++ b/tests/api.c
@@ -28619,7 +28619,7 @@ static void test_wolfSSL_EVP_PKEY_derive(void)
     AssertIntEQ(EVP_PKEY_derive_init(ctx), 1);
     AssertIntEQ(EVP_PKEY_derive_set_peer(ctx, peerkey), 1);
     AssertIntEQ(EVP_PKEY_derive(ctx, NULL, &skeylen), 1);
-    AssertNotNull(skey = XMALLOC(skeylen, NULL, DYNAMIC_TYPE_OPENSSL));
+    AssertNotNull(skey = (unsigned char*)XMALLOC(skeylen, NULL, DYNAMIC_TYPE_OPENSSL));
     AssertIntEQ(EVP_PKEY_derive(ctx, skey, &skeylen), 1);
 
     EVP_PKEY_CTX_free(ctx);
@@ -28639,7 +28639,7 @@ static void test_wolfSSL_EVP_PKEY_derive(void)
     AssertIntEQ(EVP_PKEY_derive_init(ctx), 1);
     AssertIntEQ(EVP_PKEY_derive_set_peer(ctx, peerkey), 1);
     AssertIntEQ(EVP_PKEY_derive(ctx, NULL, &skeylen), 1);
-    AssertNotNull(skey = XMALLOC(skeylen, NULL, DYNAMIC_TYPE_OPENSSL));
+    AssertNotNull(skey = (unsigned char*)XMALLOC(skeylen, NULL, DYNAMIC_TYPE_OPENSSL));
     AssertIntEQ(EVP_PKEY_derive(ctx, skey, &skeylen), 1);
 
     EVP_PKEY_CTX_free(ctx);
@@ -31063,7 +31063,7 @@ static void test_wolfSSL_IMPLEMENT_ASN1_FUNCTIONS()
     AssertIntGT((len = EC_POINT_point2oct(group, point, POINT_CONVERSION_UNCOMPRESSED,
                                           NULL, 0, NULL)), 0);
 #endif
-    AssertNotNull(der = XMALLOC(len, NULL, DYNAMIC_TYPE_ASN1));
+    AssertNotNull(der = (unsigned char*)XMALLOC(len, NULL, DYNAMIC_TYPE_ASN1));
 #ifdef HAVE_COMP_KEY
     AssertIntEQ(EC_POINT_point2oct(group, point, POINT_CONVERSION_COMPRESSED,
                                    der, len, NULL), len);

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3300,12 +3300,17 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     }
 
     /* returns the NID of message digest used by the ctx */
-    int wolfSSL_EVP_MD_CTX_type(const WOLFSSL_EVP_MD_CTX *ctx) {
+    int wolfSSL_EVP_MD_CTX_type(const WOLFSSL_EVP_MD_CTX *ctx)
+    {
         const struct s_ent *ent;
 
         WOLFSSL_ENTER("EVP_MD_CTX_type");
 
         if (ctx) {
+            if (ctx->isHMAC) {
+                return NID_hmac;
+            }
+
             for(ent = md_tbl; ent->name != NULL; ent++) {
                 if (ctx->macType == ent->macType) {
                     return ent->nid;
@@ -3447,6 +3452,9 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         if (ctx == NULL)
             return NULL;
         WOLFSSL_ENTER("EVP_MD_CTX_md");
+        if (ctx->isHMAC) {
+            return "HMAC";
+        }
         for(ent = md_tbl; ent->name != NULL; ent++) {
             if(ctx->macType == ent->macType) {
                 return (const WOLFSSL_EVP_MD *)ent->name;
@@ -3803,7 +3811,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         if (ctx->pctx != NULL)
             wolfSSL_EVP_PKEY_CTX_free(ctx->pctx);
 
-        if (ctx->isHMAC == NID_hmac) {
+        if (ctx->isHMAC) {
             wc_HmacFree(&ctx->hash.hmac);
             ret = 0;
         }

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3348,66 +3348,85 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             ret = wolfSSL_HmacCopy(&des->hash.hmac, (Hmac*)&src->hash.hmac);
         }
         else {
-            ret = NOT_COMPILED_IN;
             switch (src->macType) {
                 case WC_HASH_TYPE_MD5:
             #ifndef NO_MD5
                     ret = wc_Md5Copy((wc_Md5*)&src->hash.digest,
                             (wc_Md5*)&des->hash.digest);
+            #else
+                    ret = NOT_COMPILED_IN;
             #endif /* !NO_MD5 */
                     break;
                 case WC_HASH_TYPE_SHA:
             #ifndef NO_SHA
                     ret = wc_ShaCopy((wc_Sha*)&src->hash.digest,
                             (wc_Sha*)&des->hash.digest);
+            #else
+                    ret = NOT_COMPILED_IN;
             #endif /* !NO_SHA */
                     break;
                 case WC_HASH_TYPE_SHA224:
             #ifdef WOLFSSL_SHA224
                     ret = wc_Sha224Copy((wc_Sha224*)&src->hash.digest,
                             (wc_Sha224*)&des->hash.digest);
+            #else
+                    ret = NOT_COMPILED_IN;
             #endif /* WOLFSSL_SHA224 */
                     break;
                 case WC_HASH_TYPE_SHA256:
             #ifndef NO_SHA256
                     ret = wc_Sha256Copy((wc_Sha256*)&src->hash.digest,
                             (wc_Sha256*)&des->hash.digest);
+            #else
+                    ret = NOT_COMPILED_IN;
             #endif /* !NO_SHA256 */
                     break;
                 case WC_HASH_TYPE_SHA384:
             #ifdef WOLFSSL_SHA384
                     ret = wc_Sha384Copy((wc_Sha384*)&src->hash.digest,
                             (wc_Sha384*)&des->hash.digest);
+            #else
+                    ret = NOT_COMPILED_IN;
             #endif /* WOLFSSL_SHA384 */
                     break;
                 case WC_HASH_TYPE_SHA512:
             #ifdef WOLFSSL_SHA512
                     ret = wc_Sha512Copy((wc_Sha512*)&src->hash.digest,
                         (wc_Sha512*)&des->hash.digest);
+            #else
+                    ret = NOT_COMPILED_IN;
             #endif /* WOLFSSL_SHA512 */
                     break;
                 case WC_HASH_TYPE_SHA3_224:
             #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_224)
                     ret = wc_Sha3_224_Copy((wc_Sha3*)&src->hash.digest,
                             (wc_Sha3*)&des->hash.digest);
+            #else
+                    ret = NOT_COMPILED_IN;
             #endif
                     break;
                 case WC_HASH_TYPE_SHA3_256:
             #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_256)
                     ret = wc_Sha3_256_Copy((wc_Sha3*)&src->hash.digest,
                             (wc_Sha3*)&des->hash.digest);
+            #else
+                    ret = NOT_COMPILED_IN;
             #endif
                     break;
                 case WC_HASH_TYPE_SHA3_384:
             #if defined(WOLFSSL_SHA3)
                     ret = wc_Sha3_384_Copy((wc_Sha3*)&src->hash.digest,
                             (wc_Sha3*)&des->hash.digest);
+            #else
+                    ret = NOT_COMPILED_IN;
             #endif
                     break;
                 case WC_HASH_TYPE_SHA3_512:
             #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_512)
                     ret = wc_Sha3_512_Copy((wc_Sha3*)&src->hash.digest,
                         (wc_Sha3*)&des->hash.digest);
+            #else
+                    ret = NOT_COMPILED_IN;
             #endif
                     break;
                 case WC_HASH_TYPE_NONE:
@@ -3806,76 +3825,64 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
 
     int wolfSSL_EVP_MD_CTX_cleanup(WOLFSSL_EVP_MD_CTX* ctx)
     {
-        int ret;
+        int ret = WOLFSSL_SUCCESS;
         WOLFSSL_ENTER("EVP_MD_CTX_cleanup");
         if (ctx->pctx != NULL)
             wolfSSL_EVP_PKEY_CTX_free(ctx->pctx);
 
         if (ctx->isHMAC) {
             wc_HmacFree(&ctx->hash.hmac);
-            ret = 0;
         }
         else {
-            ret = NOT_COMPILED_IN;
             switch (ctx->macType) {
                 case WC_HASH_TYPE_MD5:
             #ifndef NO_MD5
                     wc_Md5Free((wc_Md5*)&ctx->hash.digest);
-                    ret = 0;
             #endif /* !NO_MD5 */
                     break;
                 case WC_HASH_TYPE_SHA:
             #ifndef NO_SHA
                     wc_ShaFree((wc_Sha*)&ctx->hash.digest);
-                    ret = 0;
             #endif /* !NO_SHA */
                     break;
                 case WC_HASH_TYPE_SHA224:
             #ifdef WOLFSSL_SHA224
                     wc_Sha224Free((wc_Sha224*)&ctx->hash.digest);
-                    ret = 0;
             #endif /* WOLFSSL_SHA224 */
                     break;
                 case WC_HASH_TYPE_SHA256:
             #ifndef NO_SHA256
                     wc_Sha256Free((wc_Sha256*)&ctx->hash.digest);
-                    ret = 0;
             #endif /* !NO_SHA256 */
                     break;
                 case WC_HASH_TYPE_SHA384:
             #ifdef WOLFSSL_SHA384
                     wc_Sha384Free((wc_Sha384*)&ctx->hash.digest);
-                    ret = 0;
             #endif /* WOLFSSL_SHA384 */
                     break;
                 case WC_HASH_TYPE_SHA512:
             #ifdef WOLFSSL_SHA512
                     wc_Sha512Free((wc_Sha512*)&ctx->hash.digest);
-                    ret = 0;
             #endif /* WOLFSSL_SHA512 */
                     break;
                 case WC_HASH_TYPE_SHA3_224:
             #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_224)
                     wc_Sha3_224_Free((wc_Sha3*)&ctx->hash.digest);
-                    ret = 0;
             #endif
                     break;
                 case WC_HASH_TYPE_SHA3_256:
             #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_256)
                     wc_Sha3_256_Free((wc_Sha3*)&ctx->hash.digest);
-                    ret = 0;
             #endif
                     break;
                 case WC_HASH_TYPE_SHA3_384:
             #if defined(WOLFSSL_SHA3)
                     wc_Sha3_384_Free((wc_Sha3*)&ctx->hash.digest);
-                    ret = 0;
             #endif
                     break;
                 case WC_HASH_TYPE_SHA3_512:
             #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_512)
                     wc_Sha3_512_Free((wc_Sha3*)&ctx->hash.digest);
-                    ret = 0;
             #endif
                     break;
                 case WC_HASH_TYPE_NONE:
@@ -3885,13 +3892,13 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                 case WC_HASH_TYPE_BLAKE2B:
                 case WC_HASH_TYPE_BLAKE2S:
                 default:
-                    ret = BAD_FUNC_ARG;
+                    ret = WOLFSSL_FAILURE;
                     break;
             }
         }
         ForceZero(ctx, sizeof(*ctx));
         ctx->macType = WC_HASH_TYPE_NONE;
-        return ret == 0 ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
+        return ret;
     }
 
     void wolfSSL_EVP_CIPHER_CTX_init(WOLFSSL_EVP_CIPHER_CTX* ctx)

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1823,7 +1823,7 @@ int wolfSSL_EVP_SignUpdate(WOLFSSL_EVP_MD_CTX *ctx, const void *data, size_t len
 }
 
 static const struct s_ent {
-    const int macType;
+    const enum wc_HashType macType;
     const int nid;
     const char *name;
 } md_tbl[] = {
@@ -1862,10 +1862,10 @@ static const struct s_ent {
 #ifndef WOLFSSL_NOSHA3_512
     {WC_HASH_TYPE_SHA3_512, NID_sha3_512, "SHA3_512"},
 #endif
-    {0, 0, NULL}
+    {WC_HASH_TYPE_NONE, 0, NULL}
 };
 
-static int wolfSSL_EVP_md2macType(const WOLFSSL_EVP_MD *md)
+static enum wc_HashType wolfSSL_EVP_md2macType(const WOLFSSL_EVP_MD *md)
 {
     const struct s_ent *ent ;
 
@@ -2101,7 +2101,7 @@ static int wolfSSL_evp_digest_pk_init(WOLFSSL_EVP_MD_CTX *ctx,
         if (wc_HmacSetKey(&ctx->hash.hmac, hashType, key, (word32)keySz) != 0)
             return WOLFSSL_FAILURE;
 
-        ctx->macType = NID_hmac;
+        ctx->isHMAC = 1;
     }
     else {
         int ret;
@@ -2128,7 +2128,7 @@ static int wolfssl_evp_digest_pk_update(WOLFSSL_EVP_MD_CTX *ctx,
                                         const void *d, unsigned int cnt)
 {
     if (ctx->pctx == NULL) {
-        if (ctx->macType != NID_hmac)
+        if (!ctx->isHMAC)
             return WOLFSSL_FAILURE;
 
         if (wc_HmacUpdate(&ctx->hash.hmac, (const byte *)d, cnt) != 0)
@@ -2152,7 +2152,7 @@ static int wolfssl_evp_digest_pk_final(WOLFSSL_EVP_MD_CTX *ctx,
     if (ctx->pctx == NULL) {
         Hmac hmacCopy;
 
-        if (ctx->macType != NID_hmac)
+        if (!ctx->isHMAC)
             return WOLFSSL_FAILURE;
 
         if (wolfSSL_HmacCopy(&hmacCopy, &ctx->hash.hmac) != WOLFSSL_SUCCESS)
@@ -2267,7 +2267,7 @@ int wolfSSL_EVP_DigestSignFinal(WOLFSSL_EVP_MD_CTX *ctx, unsigned char *sig,
 
     /* Return the maximum size of the signaure when sig is NULL. */
     if (ctx->pctx == NULL) {
-        if (ctx->macType != NID_hmac)
+        if (!ctx->isHMAC)
             return WOLFSSL_FAILURE;
 
         hashLen = wolfssl_mac_len(ctx->hash.hmac.macType);
@@ -2385,7 +2385,7 @@ int wolfSSL_EVP_DigestVerifyFinal(WOLFSSL_EVP_MD_CTX *ctx,
         return WOLFSSL_FAILURE;
 
     if (ctx->pctx == NULL) {
-        if (ctx->macType != NID_hmac)
+        if (!ctx->isHMAC)
             return WOLFSSL_FAILURE;
 
         hashLen = wolfssl_mac_len(ctx->hash.hmac.macType);
@@ -3338,83 +3338,85 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     static int wolfSSL_EVP_MD_Copy_Hasher(WOLFSSL_EVP_MD_CTX* des,
             const WOLFSSL_EVP_MD_CTX* src)
     {
-        if (src->macType == NID_hmac) {
-            wolfSSL_HmacCopy(&des->hash.hmac, (Hmac*)&src->hash.hmac);
+        int ret;
+        if (src->isHMAC) {
+            ret = wolfSSL_HmacCopy(&des->hash.hmac, (Hmac*)&src->hash.hmac);
         }
         else {
+            ret = NOT_COMPILED_IN;
             switch (src->macType) {
-            #ifndef NO_MD5
                 case WC_HASH_TYPE_MD5:
-                    wc_Md5Copy((wc_Md5*)&src->hash.digest,
+            #ifndef NO_MD5
+                    ret = wc_Md5Copy((wc_Md5*)&src->hash.digest,
                             (wc_Md5*)&des->hash.digest);
-                    break;
             #endif /* !NO_MD5 */
-
-            #ifndef NO_SHA
+                    break;
                 case WC_HASH_TYPE_SHA:
-                    wc_ShaCopy((wc_Sha*)&src->hash.digest,
+            #ifndef NO_SHA
+                    ret = wc_ShaCopy((wc_Sha*)&src->hash.digest,
                             (wc_Sha*)&des->hash.digest);
-                    break;
             #endif /* !NO_SHA */
-
-            #ifdef WOLFSSL_SHA224
+                    break;
                 case WC_HASH_TYPE_SHA224:
-                    wc_Sha224Copy((wc_Sha224*)&src->hash.digest,
+            #ifdef WOLFSSL_SHA224
+                    ret = wc_Sha224Copy((wc_Sha224*)&src->hash.digest,
                             (wc_Sha224*)&des->hash.digest);
-                    break;
             #endif /* WOLFSSL_SHA224 */
-
-            #ifndef NO_SHA256
+                    break;
                 case WC_HASH_TYPE_SHA256:
-                    wc_Sha256Copy((wc_Sha256*)&src->hash.digest,
+            #ifndef NO_SHA256
+                    ret = wc_Sha256Copy((wc_Sha256*)&src->hash.digest,
                             (wc_Sha256*)&des->hash.digest);
-                    break;
             #endif /* !NO_SHA256 */
-
-            #ifdef WOLFSSL_SHA384
+                    break;
                 case WC_HASH_TYPE_SHA384:
-                    wc_Sha384Copy((wc_Sha384*)&src->hash.digest,
+            #ifdef WOLFSSL_SHA384
+                    ret = wc_Sha384Copy((wc_Sha384*)&src->hash.digest,
                             (wc_Sha384*)&des->hash.digest);
-                    break;
             #endif /* WOLFSSL_SHA384 */
-            #ifdef WOLFSSL_SHA512
+                    break;
                 case WC_HASH_TYPE_SHA512:
-                    wc_Sha512Copy((wc_Sha512*)&src->hash.digest,
+            #ifdef WOLFSSL_SHA512
+                    ret = wc_Sha512Copy((wc_Sha512*)&src->hash.digest,
                         (wc_Sha512*)&des->hash.digest);
-                    break;
             #endif /* WOLFSSL_SHA512 */
-        #ifdef WOLFSSL_SHA3
-            #ifndef WOLFSSL_NOSHA3_224
+                    break;
                 case WC_HASH_TYPE_SHA3_224:
-                    wc_Sha3_224_Copy((wc_Sha3*)&src->hash.digest,
+            #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_224)
+                    ret = wc_Sha3_224_Copy((wc_Sha3*)&src->hash.digest,
                             (wc_Sha3*)&des->hash.digest);
-                    break;
             #endif
-
-            #ifndef WOLFSSL_NOSHA3_256
+                    break;
                 case WC_HASH_TYPE_SHA3_256:
-                    wc_Sha3_256_Copy((wc_Sha3*)&src->hash.digest,
+            #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_256)
+                    ret = wc_Sha3_256_Copy((wc_Sha3*)&src->hash.digest,
                             (wc_Sha3*)&des->hash.digest);
-                    break;
             #endif
-
+                    break;
                 case WC_HASH_TYPE_SHA3_384:
-                    wc_Sha3_384_Copy((wc_Sha3*)&src->hash.digest,
+            #if defined(WOLFSSL_SHA3)
+                    ret = wc_Sha3_384_Copy((wc_Sha3*)&src->hash.digest,
                             (wc_Sha3*)&des->hash.digest);
-                    break;
-
-            #ifndef WOLFSSL_NOSHA3_512
-                case WC_HASH_TYPE_SHA3_512:
-                    wc_Sha3_512_Copy((wc_Sha3*)&src->hash.digest,
-                        (wc_Sha3*)&des->hash.digest);
-                    break;
             #endif
-        #endif
+                    break;
+                case WC_HASH_TYPE_SHA3_512:
+            #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_512)
+                    ret = wc_Sha3_512_Copy((wc_Sha3*)&src->hash.digest,
+                        (wc_Sha3*)&des->hash.digest);
+            #endif
+                    break;
+                case WC_HASH_TYPE_NONE:
+                case WC_HASH_TYPE_MD2:
+                case WC_HASH_TYPE_MD4:
+                case WC_HASH_TYPE_MD5_SHA:
+                case WC_HASH_TYPE_BLAKE2B:
+                case WC_HASH_TYPE_BLAKE2S:
                 default:
-                    return WOLFSSL_FAILURE;
+                    ret = BAD_FUNC_ARG;
+                    break;
             }
         }
-        return WOLFSSL_SUCCESS;
+        return ret == 0 ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
     }
 
     /* copies structure in to the structure out
@@ -3796,79 +3798,92 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
 
     int wolfSSL_EVP_MD_CTX_cleanup(WOLFSSL_EVP_MD_CTX* ctx)
     {
+        int ret;
         WOLFSSL_ENTER("EVP_MD_CTX_cleanup");
         if (ctx->pctx != NULL)
             wolfSSL_EVP_PKEY_CTX_free(ctx->pctx);
 
-        if (ctx->macType == NID_hmac) {
+        if (ctx->isHMAC == NID_hmac) {
             wc_HmacFree(&ctx->hash.hmac);
+            ret = 0;
         }
         else {
+            ret = NOT_COMPILED_IN;
             switch (ctx->macType) {
-            #ifndef NO_MD5
                 case WC_HASH_TYPE_MD5:
+            #ifndef NO_MD5
                     wc_Md5Free((wc_Md5*)&ctx->hash.digest);
-                    break;
+                    ret = 0;
             #endif /* !NO_MD5 */
-
-            #ifndef NO_SHA
+                    break;
                 case WC_HASH_TYPE_SHA:
+            #ifndef NO_SHA
                     wc_ShaFree((wc_Sha*)&ctx->hash.digest);
-                    break;
+                    ret = 0;
             #endif /* !NO_SHA */
-
-            #ifdef WOLFSSL_SHA224
+                    break;
                 case WC_HASH_TYPE_SHA224:
+            #ifdef WOLFSSL_SHA224
                     wc_Sha224Free((wc_Sha224*)&ctx->hash.digest);
-                    break;
+                    ret = 0;
             #endif /* WOLFSSL_SHA224 */
-
-            #ifndef NO_SHA256
+                    break;
                 case WC_HASH_TYPE_SHA256:
+            #ifndef NO_SHA256
                     wc_Sha256Free((wc_Sha256*)&ctx->hash.digest);
-                    break;
+                    ret = 0;
             #endif /* !NO_SHA256 */
-
-            #ifdef WOLFSSL_SHA384
+                    break;
                 case WC_HASH_TYPE_SHA384:
+            #ifdef WOLFSSL_SHA384
                     wc_Sha384Free((wc_Sha384*)&ctx->hash.digest);
-                    break;
+                    ret = 0;
             #endif /* WOLFSSL_SHA384 */
-            #ifdef WOLFSSL_SHA512
+                    break;
                 case WC_HASH_TYPE_SHA512:
+            #ifdef WOLFSSL_SHA512
                     wc_Sha512Free((wc_Sha512*)&ctx->hash.digest);
-                    break;
+                    ret = 0;
             #endif /* WOLFSSL_SHA512 */
-        #ifdef WOLFSSL_SHA3
-            #ifndef WOLFSSL_NOSHA3_224
+                    break;
                 case WC_HASH_TYPE_SHA3_224:
+            #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_224)
                     wc_Sha3_224_Free((wc_Sha3*)&ctx->hash.digest);
-                    break;
+                    ret = 0;
             #endif
-
-            #ifndef WOLFSSL_NOSHA3_256
+                    break;
                 case WC_HASH_TYPE_SHA3_256:
+            #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_256)
                     wc_Sha3_256_Free((wc_Sha3*)&ctx->hash.digest);
-                    break;
+                    ret = 0;
             #endif
-
+                    break;
                 case WC_HASH_TYPE_SHA3_384:
+            #if defined(WOLFSSL_SHA3)
                     wc_Sha3_384_Free((wc_Sha3*)&ctx->hash.digest);
-                    break;
-
-            #ifndef WOLFSSL_NOSHA3_512
-                case WC_HASH_TYPE_SHA3_512:
-                    wc_Sha3_512_Free((wc_Sha3*)&ctx->hash.digest);
-                    break;
+                    ret = 0;
             #endif
-        #endif
+                    break;
+                case WC_HASH_TYPE_SHA3_512:
+            #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_512)
+                    wc_Sha3_512_Free((wc_Sha3*)&ctx->hash.digest);
+                    ret = 0;
+            #endif
+                    break;
+                case WC_HASH_TYPE_NONE:
+                case WC_HASH_TYPE_MD2:
+                case WC_HASH_TYPE_MD4:
+                case WC_HASH_TYPE_MD5_SHA:
+                case WC_HASH_TYPE_BLAKE2B:
+                case WC_HASH_TYPE_BLAKE2S:
                 default:
-                    return WOLFSSL_FAILURE;
+                    ret = BAD_FUNC_ARG;
+                    break;
             }
         }
         ForceZero(ctx, sizeof(*ctx));
         ctx->macType = WC_HASH_TYPE_NONE;
-        return 1;
+        return ret == 0 ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
     }
 
     void wolfSSL_EVP_CIPHER_CTX_init(WOLFSSL_EVP_CIPHER_CTX* ctx)
@@ -5325,165 +5340,179 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     int wolfSSL_EVP_DigestUpdate(WOLFSSL_EVP_MD_CTX* ctx, const void* data,
                                 size_t sz)
     {
-        int macType;
+        int ret = WOLFSSL_FAILURE;
+        enum wc_HashType macType;
 
         WOLFSSL_ENTER("EVP_DigestUpdate");
 
         macType = wolfSSL_EVP_md2macType(EVP_MD_CTX_md(ctx));
         switch (macType) {
-#ifndef NO_MD4
             case WC_HASH_TYPE_MD4:
+        #ifndef NO_MD4
                 wolfSSL_MD4_Update((MD4_CTX*)&ctx->hash, data,
                                   (unsigned long)sz);
+                ret = WOLFSSL_SUCCESS;
+        #endif
                 break;
-#endif
-#ifndef NO_MD5
             case WC_HASH_TYPE_MD5:
-                wolfSSL_MD5_Update((MD5_CTX*)&ctx->hash, data,
+        #ifndef NO_MD5
+                ret = wolfSSL_MD5_Update((MD5_CTX*)&ctx->hash, data,
                                   (unsigned long)sz);
+        #endif
                 break;
-#endif
-#ifndef NO_SHA
             case WC_HASH_TYPE_SHA:
-                wolfSSL_SHA_Update((SHA_CTX*)&ctx->hash, data,
+        #ifndef NO_SHA
+                ret = wolfSSL_SHA_Update((SHA_CTX*)&ctx->hash, data,
                                   (unsigned long)sz);
+        #endif
                 break;
-#endif
-#ifdef WOLFSSL_SHA224
             case WC_HASH_TYPE_SHA224:
-                wolfSSL_SHA224_Update((SHA224_CTX*)&ctx->hash, data,
+        #ifdef WOLFSSL_SHA224
+                ret = wolfSSL_SHA224_Update((SHA224_CTX*)&ctx->hash, data,
                                      (unsigned long)sz);
+        #endif
                 break;
-#endif
-#ifndef NO_SHA256
             case WC_HASH_TYPE_SHA256:
-                wolfSSL_SHA256_Update((SHA256_CTX*)&ctx->hash, data,
+        #ifndef NO_SHA256
+                ret = wolfSSL_SHA256_Update((SHA256_CTX*)&ctx->hash, data,
                                      (unsigned long)sz);
+        #endif /* !NO_SHA256 */
                 break;
-#endif /* !NO_SHA256 */
-#ifdef WOLFSSL_SHA384
             case WC_HASH_TYPE_SHA384:
-                wolfSSL_SHA384_Update((SHA384_CTX*)&ctx->hash, data,
+        #ifdef WOLFSSL_SHA384
+                ret = wolfSSL_SHA384_Update((SHA384_CTX*)&ctx->hash, data,
                                      (unsigned long)sz);
+        #endif
                 break;
-#endif
-#ifdef WOLFSSL_SHA512
             case WC_HASH_TYPE_SHA512:
-                wolfSSL_SHA512_Update((SHA512_CTX*)&ctx->hash, data,
+        #ifdef WOLFSSL_SHA512
+                ret = wolfSSL_SHA512_Update((SHA512_CTX*)&ctx->hash, data,
                                      (unsigned long)sz);
+        #endif /* WOLFSSL_SHA512 */
                 break;
-#endif /* WOLFSSL_SHA512 */
-    #ifdef WOLFSSL_SHA3
-        #ifndef WOLFSSL_NOSHA3_224
             case WC_HASH_TYPE_SHA3_224:
-                wolfSSL_SHA3_224_Update((SHA3_224_CTX*)&ctx->hash, data,
+        #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_224)
+                ret = wolfSSL_SHA3_224_Update((SHA3_224_CTX*)&ctx->hash, data,
                                      (unsigned long)sz);
-                break;
         #endif
-        #ifndef WOLFSSL_NOSHA3_256
+                break;
             case WC_HASH_TYPE_SHA3_256:
-                wolfSSL_SHA3_256_Update((SHA3_256_CTX*)&ctx->hash, data,
+        #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_256)
+                ret = wolfSSL_SHA3_256_Update((SHA3_256_CTX*)&ctx->hash, data,
                                      (unsigned long)sz);
-                break;
         #endif
-            case WC_HASH_TYPE_SHA3_384:
-                wolfSSL_SHA3_384_Update((SHA3_384_CTX*)&ctx->hash, data,
-                                     (unsigned long)sz);
                 break;
-        #ifndef WOLFSSL_NOSHA3_512
+            case WC_HASH_TYPE_SHA3_384:
+        #if defined(WOLFSSL_SHA3)
+                ret = wolfSSL_SHA3_384_Update((SHA3_384_CTX*)&ctx->hash, data,
+                                     (unsigned long)sz);
+        #endif
+                break;
             case WC_HASH_TYPE_SHA3_512:
+        #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_512)
                 wolfSSL_SHA3_512_Update((SHA3_512_CTX*)&ctx->hash, data,
                                      (unsigned long)sz);
-                break;
         #endif
-    #endif
+                break;
+            case WC_HASH_TYPE_NONE:
+            case WC_HASH_TYPE_MD2:
+            case WC_HASH_TYPE_MD5_SHA:
+            case WC_HASH_TYPE_BLAKE2B:
+            case WC_HASH_TYPE_BLAKE2S:
             default:
                 return WOLFSSL_FAILURE;
         }
 
-        return WOLFSSL_SUCCESS;
+        return ret;
     }
 
     /* WOLFSSL_SUCCESS on ok */
     int wolfSSL_EVP_DigestFinal(WOLFSSL_EVP_MD_CTX* ctx, unsigned char* md,
                                unsigned int* s)
     {
-        int macType;
+        int ret = WOLFSSL_FAILURE;
+        enum wc_HashType macType;
 
         WOLFSSL_ENTER("EVP_DigestFinal");
         macType = wolfSSL_EVP_md2macType(EVP_MD_CTX_md(ctx));
         switch (macType) {
-#ifndef NO_MD4
             case WC_HASH_TYPE_MD4:
+        #ifndef NO_MD4
                 wolfSSL_MD4_Final(md, (MD4_CTX*)&ctx->hash);
                 if (s) *s = MD4_DIGEST_SIZE;
+                ret = WOLFSSL_SUCCESS;
+        #endif
                 break;
-#endif
-#ifndef NO_MD5
             case WC_HASH_TYPE_MD5:
-                wolfSSL_MD5_Final(md, (MD5_CTX*)&ctx->hash);
+        #ifndef NO_MD5
+                ret = wolfSSL_MD5_Final(md, (MD5_CTX*)&ctx->hash);
                 if (s) *s = WC_MD5_DIGEST_SIZE;
+        #endif
                 break;
-#endif
-#ifndef NO_SHA
             case WC_HASH_TYPE_SHA:
-                wolfSSL_SHA_Final(md, (SHA_CTX*)&ctx->hash);
+        #ifndef NO_SHA
+                ret = wolfSSL_SHA_Final(md, (SHA_CTX*)&ctx->hash);
                 if (s) *s = WC_SHA_DIGEST_SIZE;
+        #endif
                 break;
-#endif
-#ifdef WOLFSSL_SHA224
             case WC_HASH_TYPE_SHA224:
-                wolfSSL_SHA224_Final(md, (SHA224_CTX*)&ctx->hash);
+        #ifdef WOLFSSL_SHA224
+                ret = wolfSSL_SHA224_Final(md, (SHA224_CTX*)&ctx->hash);
                 if (s) *s = WC_SHA224_DIGEST_SIZE;
+        #endif
                 break;
-#endif
-#ifndef NO_SHA256
             case WC_HASH_TYPE_SHA256:
-                wolfSSL_SHA256_Final(md, (SHA256_CTX*)&ctx->hash);
+        #ifndef NO_SHA256
+                ret = wolfSSL_SHA256_Final(md, (SHA256_CTX*)&ctx->hash);
                 if (s) *s = WC_SHA256_DIGEST_SIZE;
+        #endif /* !NO_SHA256 */
                 break;
-#endif /* !NO_SHA256 */
-#ifdef WOLFSSL_SHA384
             case WC_HASH_TYPE_SHA384:
-                wolfSSL_SHA384_Final(md, (SHA384_CTX*)&ctx->hash);
+        #ifdef WOLFSSL_SHA384
+                ret = wolfSSL_SHA384_Final(md, (SHA384_CTX*)&ctx->hash);
                 if (s) *s = WC_SHA384_DIGEST_SIZE;
+        #endif
                 break;
-#endif
-#ifdef WOLFSSL_SHA512
             case WC_HASH_TYPE_SHA512:
-                wolfSSL_SHA512_Final(md, (SHA512_CTX*)&ctx->hash);
+        #ifdef WOLFSSL_SHA512
+                ret = wolfSSL_SHA512_Final(md, (SHA512_CTX*)&ctx->hash);
                 if (s) *s = WC_SHA512_DIGEST_SIZE;
+        #endif /* WOLFSSL_SHA512 */
                 break;
-#endif /* WOLFSSL_SHA512 */
-    #ifdef WOLFSSL_SHA3
-        #ifndef WOLFSSL_NOSHA3_224
             case WC_HASH_TYPE_SHA3_224:
-                wolfSSL_SHA3_224_Final(md, (SHA3_224_CTX*)&ctx->hash);
+        #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_224)
+                ret = wolfSSL_SHA3_224_Final(md, (SHA3_224_CTX*)&ctx->hash);
                 if (s) *s = WC_SHA3_224_DIGEST_SIZE;
-                break;
         #endif
-        #ifndef WOLFSSL_NOSHA3_256
+                break;
             case WC_HASH_TYPE_SHA3_256:
-                wolfSSL_SHA3_256_Final(md, (SHA3_256_CTX*)&ctx->hash);
+        #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_256)
+                ret = wolfSSL_SHA3_256_Final(md, (SHA3_256_CTX*)&ctx->hash);
                 if (s) *s = WC_SHA3_256_DIGEST_SIZE;
-                break;
         #endif
+                break;
             case WC_HASH_TYPE_SHA3_384:
-                wolfSSL_SHA3_384_Final(md, (SHA3_384_CTX*)&ctx->hash);
+        #if defined(WOLFSSL_SHA3)
+                ret = wolfSSL_SHA3_384_Final(md, (SHA3_384_CTX*)&ctx->hash);
                 if (s) *s = WC_SHA3_384_DIGEST_SIZE;
-                break;
-        #ifndef WOLFSSL_NOSHA3_512
-            case WC_HASH_TYPE_SHA3_512:
-                wolfSSL_SHA3_512_Final(md, (SHA3_512_CTX*)&ctx->hash);
-                if (s) *s = WC_SHA3_512_DIGEST_SIZE;
-                break;
         #endif
-    #endif
+                break;
+            case WC_HASH_TYPE_SHA3_512:
+        #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_512)
+                ret = wolfSSL_SHA3_512_Final(md, (SHA3_512_CTX*)&ctx->hash);
+                if (s) *s = WC_SHA3_512_DIGEST_SIZE;
+        #endif
+                break;
+            case WC_HASH_TYPE_NONE:
+            case WC_HASH_TYPE_MD2:
+            case WC_HASH_TYPE_MD5_SHA:
+            case WC_HASH_TYPE_BLAKE2B:
+            case WC_HASH_TYPE_BLAKE2S:
             default:
                 return WOLFSSL_FAILURE;
         }
 
-        return WOLFSSL_SUCCESS;
+        return ret;
     }
 
     /* WOLFSSL_SUCCESS on ok */

--- a/wolfssl/openssl/asn1.h
+++ b/wolfssl/openssl/asn1.h
@@ -123,10 +123,10 @@ typedef enum {
             sizeof(type) \
     };
 
-WOLFSSL_API void *wolfSSL_ASN1_item_new(const WOLFSSL_ASN1_ITEM *template);
-WOLFSSL_API void wolfSSL_ASN1_item_free(void *val, const WOLFSSL_ASN1_ITEM *template);
+WOLFSSL_API void *wolfSSL_ASN1_item_new(const WOLFSSL_ASN1_ITEM *tpl);
+WOLFSSL_API void wolfSSL_ASN1_item_free(void *val, const WOLFSSL_ASN1_ITEM *tpl);
 WOLFSSL_API int wolfSSL_ASN1_item_i2d(const void *src, byte **dest,
-                                      const WOLFSSL_ASN1_ITEM *template);
+                                      const WOLFSSL_ASN1_ITEM *tpl);
 
 /* Need function declaration otherwise compiler complains */
 #define IMPLEMENT_ASN1_FUNCTIONS(type) \

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -185,8 +185,11 @@ struct WOLFSSL_EVP_MD_CTX {
         Hmac hmac;
     #endif
     } hash;
-    int macType;
+    enum wc_HashType macType;
     WOLFSSL_EVP_PKEY_CTX *pctx;
+#ifndef NO_HMAC
+    unsigned int isHMAC;
+#endif
 };
 
 


### PR DESCRIPTION
Fixes for `./configure CC="g++" --enable-all && make`. Resolves issues with implicit casts and use of reserved `template` keyword.