### PR TITLE
Fix AES-GCM in EVP layer to have compatiblity with OpenSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -440,7 +440,7 @@ AC_ARG_ENABLE([mcast],
 
 # List of open source project defines using our openssl compatibility layer:
 # openssh (--enable-openssh) WOLFSSL_OPENSSH
-# openvpn (--enable-openvpn)
+# openvpn (--enable-openvpn) WOLFSSL_OPENVPN
 # nginix (--enable-nginx) WOLFSSL_NGINX
 # haproxy (--enable-haproxy) WOLFSSL_HAPROXY
 # wpa_supplicant (--enable-wpas) WOLFSSL_WPAS
@@ -3543,7 +3543,7 @@ fi
 
 if test "$ENABLED_OPENVPN" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB -DHAVE_EX_DATA -DWOLFSSL_KEY_GEN"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DES_ECB -DHAVE_EX_DATA -DWOLFSSL_KEY_GEN -DWOLFSSL_OPENVPN"
 fi
 
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -30844,10 +30844,10 @@ static void test_wolfssl_EVP_aes_gcm(void)
 
         }
         AssertIntEQ(1, EVP_DecryptUpdate(&de[i], NULL, &len, aad, aadSz));
-        AssertIntEQ(1, EVP_CIPHER_CTX_ctrl(&de[i], EVP_CTRL_GCM_SET_TAG, AES_BLOCK_SIZE, tag));
         AssertIntEQ(1, EVP_DecryptUpdate(&de[i], decryptedtxt, &len, ciphertxt, ciphertxtSz));
         decryptedtxtSz = len;
-        AssertIntGT(EVP_DecryptFinal_ex(&de[i], decryptedtxt, &len), 0);
+        AssertIntEQ(1, EVP_CIPHER_CTX_ctrl(&de[i], EVP_CTRL_GCM_SET_TAG, AES_BLOCK_SIZE, tag));
+        AssertIntEQ(1, EVP_DecryptFinal_ex(&de[i], decryptedtxt, &len));
         decryptedtxtSz += len;
         AssertIntEQ(ciphertxtSz, decryptedtxtSz);
         AssertIntEQ(0, XMEMCMP(plaintxt, decryptedtxt, decryptedtxtSz));
@@ -30857,7 +30857,8 @@ static void test_wolfssl_EVP_aes_gcm(void)
         AssertIntEQ(1, EVP_DecryptUpdate(&de[i], NULL, &len, aad, aadSz));
         AssertIntEQ(1, EVP_CIPHER_CTX_ctrl(&de[i], EVP_CTRL_GCM_SET_TAG, AES_BLOCK_SIZE, tag));
         /* fail due to wrong tag */
-        AssertIntEQ(0, EVP_DecryptUpdate(&de[i], decryptedtxt, &len, ciphertxt, ciphertxtSz));
+        AssertIntEQ(1, EVP_DecryptUpdate(&de[i], decryptedtxt, &len, ciphertxt, ciphertxtSz));
+        AssertIntEQ(0, EVP_DecryptFinal_ex(&de[i], decryptedtxt, &len));
         AssertIntEQ(0, len);
     }
     printf(resultFmt, passed);

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -753,7 +753,8 @@ int  wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
         case AES_128_GCM_TYPE:
         case AES_192_GCM_TYPE:
         case AES_256_GCM_TYPE:
-            if (!ctx->enc && ctx->gcmDecryptBuffer && ctx->gcmDecryptBufferLen > 0) {
+            if (!ctx->enc && ctx->gcmDecryptBuffer &&
+                    ctx->gcmDecryptBufferLen > 0) {
                 /* decrypt confidential data*/
                 ret = wc_AesGcmDecrypt(&ctx->cipher.aes, out,
                         ctx->gcmDecryptBuffer, ctx->gcmDecryptBufferLen,
@@ -820,7 +821,8 @@ int  wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
                         XMEMCPY(out, ctx->lastBlock, fl);
                         *outl = fl;
                         if (ctx->lastUsed == 0 && ctx->bufUsed == 0) {
-                            /* return error in cases where the block length is incorrect */
+                            /* return error in cases where the block length is
+                             * incorrect */
                             WOLFSSL_MSG("Final Cipher Block bad length");
                             ret = WOLFSSL_FAILURE;
                         }
@@ -830,7 +832,8 @@ int  wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
                     }
                 }
                 else if (ctx->lastUsed == 0 && ctx->bufUsed == 0) {
-                    /* return error in cases where the block length is incorrect */
+                    /* return error in cases where the block length is
+                     * incorrect */
                     ret = WOLFSSL_FAILURE;
                 }
             }

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -350,6 +350,10 @@ struct WOLFSSL_EVP_CIPHER_CTX {
     defined(HAVE_AESGCM) || defined (WOLFSSL_AES_XTS)
 #define HAVE_WOLFSSL_EVP_CIPHER_CTX_IV
     int    ivSz;
+#ifdef HAVE_AESGCM
+    byte*   gcmDecryptBuffer;
+    int     gcmDecryptBufferLen;
+#endif
     ALIGN16 unsigned char authTag[AES_BLOCK_SIZE];
     int     authTagSz;
 #endif

--- a/wolfssl/openssl/opensslv.h
+++ b/wolfssl/openssl/opensslv.h
@@ -31,10 +31,10 @@
      #define OPENSSL_VERSION_NUMBER 0x10100000L
 #elif defined(OPENSSL_ALL) || defined(HAVE_STUNNEL) || defined(HAVE_LIGHTY) || \
     defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || \
-    defined(WOLFSSL_OPENSSH) || defined(WOLFSSL_QT)
+    defined(WOLFSSL_OPENSSH) || defined(WOLFSSL_QT) || defined(WOLFSSL_OPENVPN)
      /* version number can be increased for Lighty after compatibility for ECDH
         is added */
-     #define OPENSSL_VERSION_NUMBER 0x1000100fL
+     #define OPENSSL_VERSION_NUMBER 0x10001040L
 #else
      #define OPENSSL_VERSION_NUMBER 0x0090810fL
 #endif


### PR DESCRIPTION
- Tag checking in AES-GCM is done in Final call
- Reset `WOLFSSL_EVP_CIPHER_CTX` structure after Final call
- Don't zero `ctx->authTag` struct in Init call so that user can get the AES-GCM tag using `EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, AES_BLOCK_SIZE, tag)`
- `ctx->authTag` is only zeroed before authenticated, non-confidential data Update call since this means we are entering a new Udate-Final cycle. This doesn't need to be done in the decrypt case since the tag should be supplied by the user before the final call using `EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, AES_BLOCK_SIZE, tag)`