### PR TITLE
Fix for GCC9 warning

### DIFF
--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4309,8 +4309,8 @@ enum ProvisionSide {
 };
 
 
-static const byte client[SIZEOF_SENDER] = { 0x43, 0x4C, 0x4E, 0x54 };
-static const byte server[SIZEOF_SENDER] = { 0x53, 0x52, 0x56, 0x52 };
+static const byte client[SIZEOF_SENDER+1] = { 0x43, 0x4C, 0x4E, 0x54, 0x00 }; /* CLNT */
+static const byte server[SIZEOF_SENDER+1] = { 0x53, 0x52, 0x56, 0x52, 0x00 }; /* SRVR */
 
 static const byte tls_client[FINISHED_LABEL_SZ + 1] = "client finished";
 static const byte tls_server[FINISHED_LABEL_SZ + 1] = "server finished";


### PR DESCRIPTION

```
gcc -v
gcc version 9.1.1 20190605 (Red Hat 9.1.1-2) (GCC)
...
make
...
src/tls.c:201:13: note: in expansion of macro 'XSTRNCMP'
  201 |         if (XSTRNCMP((const char*)sender, (const char*)client, SIZEOF_SENDER) == 0)
      |             ^~~~~~~~
In file included from src/tls.c:33:
./wolfssl/internal.h:4312:19: note: referenced argument declared here
 4312 | static const byte client[SIZEOF_SENDER] = { 0x43, 0x4C, 0x4E, 0x54 };
      |                   ^~~~~~
```

Note: This is the only use of `client` and I could not find any use of `server`.