### PR TITLE
Fix TLS 1.3 integrity only for interop

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -1074,7 +1074,7 @@ int SetCipherSpecs(WOLFSSL* ssl)
         ssl->specs.hash_size             = WC_SHA256_DIGEST_SIZE;
         ssl->specs.pad_size              = PAD_SHA;
         ssl->specs.static_ecdh           = 0;
-        ssl->specs.key_size              = WC_SHA256_DIGEST_SIZE / 2;
+        ssl->specs.key_size              = WC_SHA256_DIGEST_SIZE;
         ssl->specs.block_size            = 0;
         ssl->specs.iv_size               = HMAC_NONCE_SZ;
         ssl->specs.aead_mac_size         = WC_SHA256_DIGEST_SIZE;
@@ -1092,7 +1092,7 @@ int SetCipherSpecs(WOLFSSL* ssl)
         ssl->specs.hash_size             = WC_SHA384_DIGEST_SIZE;
         ssl->specs.pad_size              = PAD_SHA;
         ssl->specs.static_ecdh           = 0;
-        ssl->specs.key_size              = WC_SHA384_DIGEST_SIZE / 2;
+        ssl->specs.key_size              = WC_SHA384_DIGEST_SIZE;
         ssl->specs.block_size            = 0;
         ssl->specs.iv_size               = HMAC_NONCE_SZ;
         ssl->specs.aead_mac_size         = WC_SHA384_DIGEST_SIZE;
@@ -2931,11 +2931,15 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
 
             if (side == WOLFSSL_CLIENT_END) {
                 if (enc) {
+                    XMEMCPY(keys->aead_enc_imp_IV, keys->client_write_IV,
+                            HMAC_NONCE_SZ);
                     hmacRet = wc_HmacSetKey(enc->hmac, hashType,
                                        keys->client_write_key, specs->key_size);
                     if (hmacRet != 0) return hmacRet;
                 }
                 if (dec) {
+                    XMEMCPY(keys->aead_dec_imp_IV, keys->server_write_IV,
+                            HMAC_NONCE_SZ);
                     hmacRet = wc_HmacSetKey(dec->hmac, hashType,
                                        keys->server_write_key, specs->key_size);
                     if (hmacRet != 0) return hmacRet;
@@ -2943,11 +2947,15 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
             }
             else {
                 if (enc) {
+                    XMEMCPY(keys->aead_enc_imp_IV, keys->server_write_IV,
+                            HMAC_NONCE_SZ);
                     hmacRet = wc_HmacSetKey(enc->hmac, hashType,
                                        keys->server_write_key, specs->key_size);
                     if (hmacRet != 0) return hmacRet;
                 }
                 if (dec) {
+                    XMEMCPY(keys->aead_dec_imp_IV, keys->client_write_IV,
+                            HMAC_NONCE_SZ);
                     hmacRet = wc_HmacSetKey(dec->hmac, hashType,
                                        keys->client_write_key, specs->key_size);
                     if (hmacRet != 0) return hmacRet;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -72,6 +72,9 @@
 #ifndef NO_SHA256
     #include <wolfssl/wolfcrypt/sha256.h>
 #endif
+#if defined(WOLFSSL_SHA384)
+    #include <wolfssl/wolfcrypt/sha512.h>
+#endif
 #ifdef HAVE_OCSP
     #include <wolfssl/ocsp.h>
 #endif
@@ -1355,7 +1358,17 @@ enum Misc {
     (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2))
     MAX_SYM_KEY_SIZE    = AES_256_KEY_SIZE,
 #else
-    MAX_SYM_KEY_SIZE    = WC_MAX_SYM_KEY_SIZE,
+    #if defined(HAVE_NULL_CIPHER) && defined(WOLFSSL_TLS13)
+        #if defined(WOLFSSL_SHA384) && WC_MAX_SYM_KEY_SIZE < 48
+            MAX_SYM_KEY_SIZE    = WC_SHA384_DIGEST_SIZE,
+        #elif !defined(NO_SHA256) && WC_MAX_SYM_KEY_SIZE < 32
+            MAX_SYM_KEY_SIZE    = WC_SHA256_DIGEST_SIZE,
+        #else
+            MAX_SYM_KEY_SIZE    = WC_MAX_SYM_KEY_SIZE,
+        #endif
+    #else
+        MAX_SYM_KEY_SIZE    = WC_MAX_SYM_KEY_SIZE,
+    #endif
 #endif
 
 #ifdef HAVE_SELFTEST


### PR DESCRIPTION
Allow nonce to be include in HMAC data with
WOLFSSL_TLS13_INTEGRITY_NONCE.