### PR TITLE
Check HKDF-Expand length of output <= 255*HashLen

### DIFF
--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -1215,12 +1215,12 @@ int wolfSSL_GetHmacMaxSize(void)
         word32 outIdx = 0;
         word32 hashSz = wc_HmacSizeByType(type);
         byte   n = 0x1;
-        word32 N = 0;  /* rf5869: N = ceil(L/HashLen)*/
 
-        N = (outSz/hashSz) + ((outSz % hashSz) != 0);
+        /* RFC 5869 states that the length of output keying material in
+           octets must be L <= 255*HashLen or N = ceil(L/HashLen) */
 
-        if (out == NULL || N > 255)
-        	return BAD_FUNC_ARG;
+        if (out == NULL || ((outSz/hashSz) + ((outSz % hashSz) != 0)) > 255)
+            return BAD_FUNC_ARG;
 
         ret = wc_HmacInit(&myHmac, NULL, INVALID_DEVID);
         if (ret != 0)

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -1215,10 +1215,17 @@ int wolfSSL_GetHmacMaxSize(void)
         word32 outIdx = 0;
         word32 hashSz = wc_HmacSizeByType(type);
         byte   n = 0x1;
+        word32 N = 0;  /* rf5869: N = ceil(L/HashLen)*/
+
+        N = (outSz/hashSz) + ((outSz % hashSz) != 0);
+
+        if (out == NULL || N > 255)
+        	return BAD_FUNC_ARG;
 
         ret = wc_HmacInit(&myHmac, NULL, INVALID_DEVID);
         if (ret != 0)
             return ret;
+
 
         while (outIdx < outSz) {
             int    tmpSz = (n == 1) ? 0 : hashSz;


### PR DESCRIPTION
This PR adds a length check in wc_HKDF_Expand() to address issues reported in ZD#10261 and GitHub issues #2951.

RFC 5869 section 2.3 states that the length of output keying material in octets must be L <= 255*HashLen 

where HashLen is the size in octets of the hash function's digest. 

However, wc_HKDF_Expand was missing this check. 
