### PR TITLE
Fix failing build for rsa_verify_only example

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -498,7 +498,7 @@ void sp_clamp(sp_int* a)
     a->used = i + 1;
 }
 
-#if !defined(WOLFSSL_RSA_VERIFY_ONLY) || (!defined(NO_DH) || defined(HAVE_ECC))
+#if defined(WOLFSSL_RSA_VERIFY_ONLY) || (!defined(NO_DH) || defined(HAVE_ECC))
 /* Grow big number to be able to hold l digits.
  * This function does nothing as the number of digits is fixed.
  *
@@ -516,7 +516,9 @@ int sp_grow(sp_int* a, int l)
 
     return err;
 }
+#endif
 
+#if !defined(WOLFSSL_RSA_VERIFY_ONLY) || (!defined(NO_DH) || defined(HAVE_ECC))
 /* Sub a one digit number from the big number.
  *
  * a  SP integer.


### PR DESCRIPTION
rsa verify only example uses sp_grow with settings

```
CFLAGS="-DWOLFSSL_PUBLIC_MP" --disable-asn --disable-filesystem --enable-static --enable-shared --enable-cryptonly --enable-sp=smallrsa2048 --enable-sp-math --disable-dh --disable-ecc --disable-sha224 --enable-rsavfy
```