### PR TITLE
FIPS on Solaris

### DIFF
--- a/fips-check.sh
+++ b/fips-check.sh
@@ -34,12 +34,15 @@ Platform is one of:
     fips-ready
     stm32l4-v2 (FIPSv2, use for STM32L4)
     wolfrand
+    solaris
 Keep (default off) retains the XXX-fips-test temp dir for inspection.
 
 Example:
     $0 windows keep
 usageText
 }
+
+MAKE=make
 
 LINUX_FIPS_VERSION=v3.2.6
 LINUX_FIPS_REPO=git@github.com:wolfSSL/fips.git
@@ -229,6 +232,19 @@ wolfrand)
   FIPS_INCS=( fips.h )
   FIPS_OPTION=rand
   ;;
+solaris)
+  FIPS_VERSION=WCv4-stable
+  FIPS_REPO=git@github.com:wolfssl/fips.git
+  CRYPT_VERSION=WCv4-stable
+  CRYPT_INC_PATH=wolfssl/wolfcrypt
+  CRYPT_SRC_PATH=wolfcrypt/src
+  WC_MODS+=( cmac dh ecc sha3 )
+  RNG_VERSION=WCv4-rng-stable
+  FIPS_SRCS+=( wolfcrypt_first.c wolfcrypt_last.c )
+  FIPS_INCS=( fips.h )
+  FIPS_OPTION=v2
+  MAKE=gmake
+  ;;
 *)
   Usage
   exit 1
@@ -321,7 +337,7 @@ then
 else
     ./configure --enable-fips=$FIPS_OPTION
 fi
-if ! make; then
+if ! $MAKE; then
     echo "fips-check: Make failed. Debris left for analysis."
     exit 3
 fi
@@ -331,11 +347,11 @@ then
     NEWHASH=$(./wolfcrypt/test/testwolfcrypt | sed -n 's/hash = \(.*\)/\1/p')
     if [ -n "$NEWHASH" ]; then
         sed -i.bak "s/^\".*\";/\"${NEWHASH}\";/" $CRYPT_SRC_PATH/fips_test.c
-        make clean
+        $MAKE clean
     fi
 fi
 
-if ! make test; then
+if ! $MAKE test; then
     echo "fips-check: Test failed. Debris left for analysis."
     exit 3
 fi

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -12360,7 +12360,7 @@ static int rsa_certgen_test(RsaKey* key, RsaKey* keypub, WC_RNG* rng, byte* tmp)
     FreeDecodedCert(&decode);
 #endif
 
-    ret = SaveDerAndPem(der, certSz, certDerFile, certPemFile, 
+    ret = SaveDerAndPem(der, certSz, certDerFile, certPemFile,
         CERT_TYPE, -5578);
     if (ret != 0) {
         goto exit_rsa;
@@ -12523,7 +12523,7 @@ static int rsa_certgen_test(RsaKey* key, RsaKey* keypub, WC_RNG* rng, byte* tmp)
     FreeDecodedCert(&decode);
 #endif
 
-    ret = SaveDerAndPem(der, certSz, otherCertDerFile, otherCertPemFile, 
+    ret = SaveDerAndPem(der, certSz, otherCertDerFile, otherCertPemFile,
         CERT_TYPE, -5598);
     if (ret != 0) {
         goto exit_rsa;
@@ -12714,7 +12714,7 @@ static int rsa_ecc_certgen_test(WC_RNG* rng, byte* tmp)
     FreeDecodedCert(&decode);
 #endif
 
-    ret = SaveDerAndPem(der, certSz, certEccRsaDerFile, certEccRsaPemFile, 
+    ret = SaveDerAndPem(der, certSz, certEccRsaDerFile, certEccRsaPemFile,
         CERT_TYPE, -5616);
     if (ret != 0) {
         goto exit_rsa;
@@ -12786,7 +12786,7 @@ static int rsa_keygen_test(WC_RNG* rng)
         ERROR_OUT(-7667, exit_rsa);
     }
 
-    ret = SaveDerAndPem(der, derSz, keyDerFile, keyPemFile, 
+    ret = SaveDerAndPem(der, derSz, keyDerFile, keyPemFile,
         PRIVATEKEY_TYPE, -5555);
     if (ret != 0) {
         goto exit_rsa;
@@ -13736,7 +13736,7 @@ int rsa_test(void)
         FreeDecodedCert(&decode);
     #endif
 
-        ret = SaveDerAndPem(der, certSz, "./ntru-cert.der", "./ntru-cert.pem", 
+        ret = SaveDerAndPem(der, certSz, "./ntru-cert.der", "./ntru-cert.pem",
             CERT_TYPE, -5637);
         if (ret != 0) {
             goto exit_rsa;
@@ -13841,7 +13841,7 @@ int rsa_test(void)
         }
         derSz = ret;
 
-        ret = SaveDerAndPem(der, derSz, certReqDerFile, certReqPemFile, 
+        ret = SaveDerAndPem(der, derSz, certReqDerFile, certReqPemFile,
             CERTREQ_TYPE, -5650);
         if (ret != 0) {
             goto exit_rsa;
@@ -14629,7 +14629,7 @@ int dsa_test(void)
         return -8013;
     }
 
-    ret = SaveDerAndPem(der, derSz, keyDerFile, keyPemFile, 
+    ret = SaveDerAndPem(der, derSz, keyDerFile, keyPemFile,
         DSA_PRIVATEKEY_TYPE, -5814);
     if (ret != 0) {
         XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -18487,7 +18487,7 @@ static int ecc_test_key_gen(WC_RNG* rng, int keySize)
         ERROR_OUT(derSz, done);
     }
 
-    ret = SaveDerAndPem(der, derSz, eccCaKeyTempFile, eccCaKeyPemFile, 
+    ret = SaveDerAndPem(der, derSz, eccCaKeyTempFile, eccCaKeyPemFile,
         ECC_PRIVATEKEY_TYPE, -8347);
     if (ret != 0) {
         goto done;
@@ -19924,7 +19924,7 @@ static int ecc_test_cert_gen(WC_RNG* rng)
     FreeDecodedCert(&decode);
 #endif
 
-    ret = SaveDerAndPem(der, certSz, certEccDerFile, certEccPemFile, 
+    ret = SaveDerAndPem(der, certSz, certEccDerFile, certEccPemFile,
         CERT_TYPE, -6735);
     if (ret != 0) {
         goto exit;
@@ -27921,13 +27921,15 @@ int mutex_test(void)
         return -12701;
     if (wc_LockMutex(&m) != 0)
         return -12702;
+#if !defined(WOLFSSL_SOLARIS)
     if (wc_FreeMutex(&m) != BAD_MUTEX_E)
         return -12703;
+#endif
     if (wc_UnLockMutex(&m) != 0)
         return -12704;
     if (wc_FreeMutex(&m) != 0)
         return -12705;
-#ifndef WOLFSSL_NO_MUTEXLOCK_AFTER_FREE
+#if !defined(WOLFSSL_NO_MUTEXLOCK_AFTER_FREE)
     if (wc_LockMutex(&m) != BAD_MUTEX_E)
         return -12706;
     if (wc_UnLockMutex(&m) != BAD_MUTEX_E)

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -209,6 +209,9 @@
 /* Uncomment next line if using RENESAS RX64N */
 /* #define WOLFSSL_RENESAS_RX65N */
 
+/* Uncomment next line if using Solaris OS*/
+/* #define WOLFSSL_SOLARIS */
+
 #include <wolfssl/wolfcrypt/visibility.h>
 
 #ifdef WOLFSSL_USER_SETTINGS
@@ -703,7 +706,7 @@ extern void uITRON4_free(void *p) ;
         https://github.com/wolfSSL/wolfssl-freertos/pull/3/files */
     #if !defined(USE_FAST_MATH) || defined(HAVE_ED25519) || defined(HAVE_ED448)
         #if defined(WOLFSSL_ESPIDF)
-            /*In IDF, realloc(p, n) is equivalent to 
+            /*In IDF, realloc(p, n) is equivalent to
             heap_caps_realloc(p, s, MALLOC_CAP_8BIT) */
             #define XREALLOC(p, n, h, t) realloc((p), (n))
         #else
@@ -1399,6 +1402,23 @@ extern void uITRON4_free(void *p) ;
         #define LITTLE_ENDIAN_ORDER
     #endif
 #endif /* MICRIUM */
+
+#if defined(sun) || defined(__sun)
+# if defined(__SVR4) || defined(__svr4__)
+    /* Solaris */
+    #ifndef WOLFSSL_SOLARIS
+        #define WOLFSSL_SOLARIS
+    #endif
+# else
+    /* SunOS */
+# endif
+#endif
+
+#ifdef WOLFSSL_SOLARIS
+    #define WOLFSSL_NO_MUTEXLOCK_AFTER_FREE
+    /* Avoid naming clash with fp_zero from math.h > ieefp.h */
+    #define WOLFSSL_DH_CONST
+#endif
 
 #ifdef WOLFSSL_MCF5441X
     #define BIG_ENDIAN_ORDER


### PR DESCRIPTION
This PR adds support for building and running FIPS140-2 wolfcrypt test on Solaris. 
