### PR TITLE
Script Portability

### DIFF
--- a/fips-check.sh
+++ b/fips-check.sh
@@ -346,8 +346,9 @@ if [ "x$CAVP_SELFTEST_ONLY" == "xno" ];
 then
     NEWHASH=$(./wolfcrypt/test/testwolfcrypt | sed -n 's/hash = \(.*\)/\1/p')
     if [ -n "$NEWHASH" ]; then
-        sed -i.bak "s/^\".*\";/\"${NEWHASH}\";/" $CRYPT_SRC_PATH/fips_test.c
-        $MAKE clean
+        cp $CRYPT_SRC_PATH/fips_test.c $CRYPT_SRC_PATH/fips_test.c.bak
+        sed "s/^\".*\";/\"${NEWHASH}\";/" $CRYPT_SRC_PATH/fips_test.c.bak >$CRYPT_SRC_PATH/fips_test.c
+        make clean
     fi
 fi
 

--- a/fips-hash.sh
+++ b/fips-hash.sh
@@ -15,6 +15,7 @@ fi
 NEWHASH=$(./wolfcrypt/test/testwolfcrypt | sed -n 's/hash = \(.*\)/\1/p')
 if test -n "$NEWHASH"
 then
-    sed -i.bak "s/^\".*\";/\"${NEWHASH}\";/" wolfcrypt/src/fips_test.c
+    cp wolfcrypt/src/fips_test.c wolfcrypt/src/fips_test.c.bak
+    sed "s/^\".*\";/\"${NEWHASH}\";/" wolfcrypt/src/fips_test.c.bak >wolfcrypt/src/fips_test.c
 fi
 

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -2,12 +2,16 @@
 
 #openssl.test
 
+if test -n "$WOLFSSL_OPENSSL_TEST"; then
+    echo "WOLFSSL_OPENSSL_TEST set, running test..."
+else
+    echo "WOLFSSL_OPENSSL_TEST NOT set, won't run"
+    exit 0
+fi
+
 # need a unique port since may run the same time as testsuite
 generate_port() {
-    port=`LC_CTYPE=C tr -cd 0-9 </dev/urandom | head -c 7`
-    port=$((`LC_CTYPE=C tr -cd 1-9 </dev/urandom | head -c 1`$port))
-    port=$(($port % (65535-49512)))
-    port=$(($port + 49512))
+    port=$(($(od -An -N2 /dev/random) % (65535-49512) + 49512))
 }
 
 
@@ -67,13 +71,6 @@ do_trap() {
 }
 
 trap do_trap INT TERM
-
-if test -n "$WOLFSSL_OPENSSL_TEST"; then
-    echo "WOLFSSL_OPENSSL_TEST set, running test..."
-else
-    echo "WOLFSSL_OPENSSL_TEST NOT set, won't run"
-    exit 0
-fi
 
 echo -e "\nTesting existence of openssl command...\n"
 command -v $OPENSSL >/dev/null 2>&1 || { echo >&2 "Requires openssl command, but it's not installed.  Ending."; exit 0; }


### PR DESCRIPTION
1. The openssl interop test script should check that it should run before doing anything else.
2. The process to create a random port number was using a non-portable option to the head command. Changed to use the od tool reading from
/dev/random.
3. Ran into a sed that doesn't use the -i option, so changed it to cp its own bak file and sed from that.