### PR TITLE
Add secure renegotiation to DTLS 1.2

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -3050,13 +3050,28 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         } else {
             if (!resumeScr) {
                 printf("Beginning secure rengotiation.\n");
-                if (wolfSSL_Rehandshake(ssl) != WOLFSSL_SUCCESS) {
+                if ((ret = wolfSSL_Rehandshake(ssl)) != WOLFSSL_SUCCESS) {
                     err = wolfSSL_get_error(ssl, 0);
-                    printf("err = %d, %s\n", err,
-                                    wolfSSL_ERR_error_string(err, buffer));
-                    wolfSSL_free(ssl); ssl = NULL;
-                    wolfSSL_CTX_free(ctx); ctx = NULL;
-                    err_sys("wolfSSL_Rehandshake failed");
+#ifdef WOLFSSL_ASYNC_CRYPT
+                    while (err == WC_PENDING_E) {
+                        err = 0;
+                        ret = wolfSSL_negotiate(ssl);
+                        if (ret != WOLFSSL_SUCCESS) {
+                            err = wolfSSL_get_error(ssl, 0);
+                            if (err == WC_PENDING_E) {
+                                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
+                                if (ret < 0) break;
+                            }
+                        }
+                    }
+#endif
+                    if (ret != WOLFSSL_SUCCESS) {
+                        printf("err = %d, %s\n", err,
+                                        wolfSSL_ERR_error_string(err, buffer));
+                        wolfSSL_free(ssl); ssl = NULL;
+                        wolfSSL_CTX_free(ctx); ctx = NULL;
+                        err_sys("wolfSSL_Rehandshake failed");
+                    }
                 }
                 else {
                     printf("RENEGOTIATION SUCCESSFUL\n");

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -3079,13 +3079,28 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             }
             else {
                 printf("Beginning secure resumption.\n");
-                if (wolfSSL_SecureResume(ssl) != WOLFSSL_SUCCESS) {
+                if ((ret = wolfSSL_SecureResume(ssl)) != WOLFSSL_SUCCESS) {
                     err = wolfSSL_get_error(ssl, 0);
-                    printf("err = %d, %s\n", err,
-                                    wolfSSL_ERR_error_string(err, buffer));
-                    wolfSSL_free(ssl); ssl = NULL;
-                    wolfSSL_CTX_free(ctx); ctx = NULL;
-                    err_sys("wolfSSL_SecureResume failed");
+#ifdef WOLFSSL_ASYNC_CRYPT
+                    while (err == WC_PENDING_E) {
+                        err = 0;
+                        ret = wolfSSL_negotiate(ssl);
+                        if (ret != WOLFSSL_SUCCESS) {
+                            err = wolfSSL_get_error(ssl, 0);
+                            if (err == WC_PENDING_E) {
+                                ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
+                                if (ret < 0) break;
+                            }
+                        }
+                    }
+#endif
+                    if (ret != WOLFSSL_SUCCESS) {
+                        printf("err = %d, %s\n", err,
+                                        wolfSSL_ERR_error_string(err, buffer));
+                        wolfSSL_free(ssl); ssl = NULL;
+                        wolfSSL_CTX_free(ctx); ctx = NULL;
+                        err_sys("wolfSSL_SecureResume failed");
+                    }
                 }
                 else {
                     printf("SECURE RESUMPTION SUCCESSFUL\n");

--- a/src/internal.c
+++ b/src/internal.c
@@ -13094,7 +13094,6 @@ static int DtlsMsgDrain(WOLFSSL* ssl)
         }
     #ifdef WOLFSSL_ASYNC_CRYPT
         if (ret == WC_PENDING_E) {
-            ssl->keys.dtls_expected_peer_handshake_number--;
             break;
         }
     #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -15162,10 +15162,6 @@ int ProcessReply(WOLFSSL* ssl)
                             ssl->keys.padSz += 1;
                             ssl->keys.decryptedCur = 1;
                         }
-                        else {
-                            ssl->keys.padSz += 1;
-                            ssl->keys.padSz -= 1;
-                        }
                     }
                     else
             #endif
@@ -23855,7 +23851,10 @@ int SendCertificateVerify(WOLFSSL* ssl)
     WOLFSSL_ENTER("SendCertificateVerify");
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
+    /* BuildMessage does its own Pop */
+    if (ssl->error != WC_PENDING_E ||
+            ssl->options.asyncState != TLS_ASYNC_END)
+        ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
     if (ret != WC_NOT_PENDING_E) {
         /* Check for error */
         if (ret < 0)

--- a/src/internal.c
+++ b/src/internal.c
@@ -15534,7 +15534,8 @@ int ProcessReply(WOLFSSL* ssl)
                          * skipped. Also skip if out of order. */
                             if (ret != DUPLICATE_MSG_E && ret != OUT_OF_ORDER_E)
                                 return ret;
-
+                            /* Reset error */
+                            ret = 0;
                             break;
                         #endif /* WOLFSSL_DTLS */
                         }
@@ -16389,9 +16390,9 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
     #if defined(HAVE_SECURE_RENEGOTIATION) && defined(WOLFSSL_DTLS)
             /* If we want the PREV_ORDER then modify CUR_ORDER sequence number
              * for all encryption algos that use it for encryption parameters */
-            word16 dtls_epoch;
-            word16 dtls_sequence_number_hi;
-            word32 dtls_sequence_number_lo;
+            word16 dtls_epoch = 0;
+            word16 dtls_sequence_number_hi = 0;
+            word32 dtls_sequence_number_lo = 0;
             int swap_seq = ssl->options.dtls && epochOrder == PREV_ORDER &&
                     DtlsUseSCRKeys(ssl);
             if (swap_seq) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -16076,7 +16076,7 @@ void FreeBuildMsgArgs(BuildMsgArgs* args)
 {
     if (args) {
         if (args->iv)
-            XFREE(args->iv, ssl->heap, DYNAMIC_TYPE_SALT);
+            XFREE(args->iv, NULL, DYNAMIC_TYPE_SALT);
         XMEMSET(args, 0, sizeof(BuildMsgArgs));
     }
 }
@@ -17762,8 +17762,6 @@ int ReceiveData(WOLFSSL* ssl, byte* output, int sz, int peek)
         WOLFSSL_MSG("User calling wolfSSL_read in error state, not allowed");
         return ssl->error;
     }
-
-    if (ssl->error != 0) fprintf(stderr, "ignoring err %d\n", ssl->error);
 
 #ifdef WOLFSSL_EARLY_DATA
     if (ssl->earlyData != no_early_data) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -15155,10 +15155,17 @@ int ProcessReply(WOLFSSL* ssl)
                                       in->buffer + in->idx,
                                       in->buffer + in->idx,
                                       ssl->curSize - digestSz);
-                         ssl->keys.padSz =
-                              in->buffer[in->idx + ssl->curSize - digestSz - 1];
-                         ssl->keys.padSz += 1;
-                         ssl->keys.decryptedCur = 1;
+                        if (ret == 0) {
+                            ssl->keys.padSz =
+                                    in->buffer[in->idx + ssl->curSize -
+                                               digestSz - 1];
+                            ssl->keys.padSz += 1;
+                            ssl->keys.decryptedCur = 1;
+                        }
+                        else {
+                            ssl->keys.padSz += 1;
+                            ssl->keys.padSz -= 1;
+                        }
                     }
                     else
             #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -28265,7 +28265,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         #endif
         }
 
-        if (IsEncryptionOn(ssl, 1))
+        if (IsEncryptionOn(ssl, 1) && ssl->options.handShakeDone)
             sendSz += cipherExtraData(ssl);
 
         /* check for available size */
@@ -28326,7 +28326,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
         ssl->buffers.outputBuffer.length += sendSz;
 
-        ret = SendBuffered(ssl);
+        if (!ssl->options.groupMessages)
+            ret = SendBuffered(ssl);
 
         WOLFSSL_LEAVE("SendTicket", ret);
         WOLFSSL_END(WC_FUNC_TICKET_SEND);

--- a/src/internal.c
+++ b/src/internal.c
@@ -15459,15 +15459,20 @@ int ProcessReply(WOLFSSL* ssl)
                     }
 
                     if (IsEncryptionOn(ssl, 0) && ssl->options.handShakeDone) {
-                        ssl->buffers.inputBuffer.idx += ssl->keys.padSz;
-                        ssl->curSize -= (word16)ssl->keys.padSz;
 #ifdef HAVE_AEAD
-                        if (ssl->specs.cipher_type == aead &&
-                            ssl->specs.bulk_cipher_algorithm != wolfssl_chacha)
-                            ssl->curSize -= AESGCM_EXP_IV_SZ;
+                        if (ssl->specs.cipher_type == aead) {
+                            if (ssl->specs.bulk_cipher_algorithm != wolfssl_chacha)
+                                ssl->curSize -= AESGCM_EXP_IV_SZ;
+                            ssl->buffers.inputBuffer.idx += ssl->specs.aead_mac_size;
+                            ssl->curSize -= ssl->specs.aead_mac_size;
+                        }
                         else
 #endif
+                        {
+                            ssl->buffers.inputBuffer.idx += ssl->keys.padSz;
+                            ssl->curSize -= (word16)ssl->keys.padSz;
                             ssl->curSize -= ssl->specs.iv_size;
+                        }
 
             #if defined(HAVE_ENCRYPT_THEN_MAC) && !defined(WOLFSSL_AEAD_ONLY)
                         if (ssl->options.startedETMRead) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -6183,7 +6183,7 @@ void FreeKeyExchange(WOLFSSL* ssl)
         ssl->async.freeArgs(ssl, ssl->async.args);
         ssl->async.freeArgs = NULL;
     }
-    FreeBuildMsgArgs(&ssl->async.buildArgs);
+    FreeBuildMsgArgs(ssl, &ssl->async.buildArgs);
 #endif
 }
 
@@ -16072,11 +16072,11 @@ int BuildCertHashes(WOLFSSL* ssl, Hashes* hashes)
 }
 
 #ifndef WOLFSSL_NO_TLS12
-void FreeBuildMsgArgs(BuildMsgArgs* args)
+void FreeBuildMsgArgs(WOLFSSL* ssl, BuildMsgArgs* args)
 {
     if (args) {
-        if (args->iv)
-            XFREE(args->iv, NULL, DYNAMIC_TYPE_SALT);
+        if (ssl && args->iv)
+            XFREE(args->iv, ssl->heap, DYNAMIC_TYPE_SALT);
         XMEMSET(args, 0, sizeof(BuildMsgArgs));
     }
 }
@@ -16516,7 +16516,7 @@ exit_buildmsg:
         ret = args->sz;
 
     /* Final cleanup */
-    FreeBuildMsgArgs(args);
+    FreeBuildMsgArgs(ssl, args);
 
     return ret;
 #endif /* !WOLFSSL_NO_TLS12 */

--- a/src/keys.c
+++ b/src/keys.c
@@ -3241,7 +3241,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
             ssl->secure_renegotiation->cache_status == SCR_CACHE_NEEDED) {
         keys = &ssl->secure_renegotiation->tmp_keys;
 #ifdef WOLFSSL_DTLS
-        /* epoch is incremented after StoreKeys call */
+        /* epoch is incremented after StoreKeys is called */
         ssl->secure_renegotiation->tmp_keys.dtls_epoch = ssl->keys.dtls_epoch + 1;
         /* we only need to copy keys on second and future renegotiations */
         if (ssl->keys.dtls_epoch > 1)

--- a/src/keys.c
+++ b/src/keys.c
@@ -3066,7 +3066,11 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
 #ifdef HAVE_SECURE_RENEGOTIATION
     if (ssl->secure_renegotiation && ssl->secure_renegotiation->cache_status) {
         keys = &ssl->secure_renegotiation->tmp_keys;
-        copy = 1;
+#ifdef WOLFSSL_DTLS
+        /* For DTLS, copy is done in StoreKeys */
+        if (!ssl->options.dtls)
+#endif
+            copy = 1;
     }
 #endif /* HAVE_SECURE_RENEGOTIATION */
 
@@ -3141,6 +3145,15 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
                   ssl->heap, ssl->devId, ssl->rng, ssl->options.tls1_3);
 
 #ifdef HAVE_SECURE_RENEGOTIATION
+#ifdef WOLFSSL_DTLS
+    if (ret == 0 && ssl->options.dtls) {
+        if (wc_encrypt)
+            wc_encrypt->src = keys == &ssl->keys ? KEYS : SCR;
+        if (wc_decrypt)
+            wc_decrypt->src = keys == &ssl->keys ? KEYS : SCR;
+    }
+#endif
+
     if (copy) {
         int clientCopy = 0;
 
@@ -3217,11 +3230,25 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
 {
     int sz, i = 0;
     Keys* keys = &ssl->keys;
+#ifdef WOLFSSL_DTLS
+    /* In case of DTLS, ssl->keys is updated here */
+    int scr_copy = 0;
+#endif
 
 #ifdef HAVE_SECURE_RENEGOTIATION
-    if (ssl->secure_renegotiation && ssl->secure_renegotiation->cache_status ==
-                                                            SCR_CACHE_NEEDED) {
+    if (ssl->options.dtls &&
+            ssl->secure_renegotiation &&
+            ssl->secure_renegotiation->cache_status == SCR_CACHE_NEEDED) {
         keys = &ssl->secure_renegotiation->tmp_keys;
+#ifdef WOLFSSL_DTLS
+        /* epoch is incremented after StoreKeys call */
+        ssl->secure_renegotiation->tmp_keys.dtls_epoch = ssl->keys.dtls_epoch + 1;
+        /* we only need to copy keys on second and future renegotiations */
+        if (ssl->keys.dtls_epoch > 1)
+            scr_copy = 1;
+        ssl->encrypt.src = KEYS_NOT_SET;
+        ssl->decrypt.src = KEYS_NOT_SET;
+#endif
         CacheStatusPP(ssl->secure_renegotiation);
     }
 #endif /* HAVE_SECURE_RENEGOTIATION */
@@ -3232,23 +3259,54 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
         if (ssl->specs.cipher_type != aead) {
             sz = ssl->specs.hash_size;
     #ifndef WOLFSSL_AEAD_ONLY
+
+    #ifdef WOLFSSL_DTLS
+            if (scr_copy) {
+                XMEMCPY(ssl->keys.client_write_MAC_secret,
+                        keys->client_write_MAC_secret, sz);
+                XMEMCPY(ssl->keys.server_write_MAC_secret,
+                        keys->server_write_MAC_secret, sz);
+            }
+    #endif
             XMEMCPY(keys->client_write_MAC_secret,&keyData[i], sz);
             XMEMCPY(keys->server_write_MAC_secret,&keyData[i], sz);
     #endif
             i += sz;
         }
         sz = ssl->specs.key_size;
+    #ifdef WOLFSSL_DTLS
+        if (scr_copy) {
+            XMEMCPY(ssl->keys.client_write_key,
+                    keys->client_write_key, sz);
+            XMEMCPY(ssl->keys.server_write_key,
+                    keys->server_write_key, sz);
+        }
+    #endif
         XMEMCPY(keys->client_write_key, &keyData[i], sz);
         XMEMCPY(keys->server_write_key, &keyData[i], sz);
         i += sz;
 
         sz = ssl->specs.iv_size;
+    #ifdef WOLFSSL_DTLS
+        if (scr_copy) {
+            XMEMCPY(ssl->keys.client_write_IV,
+                    keys->client_write_IV, sz);
+            XMEMCPY(ssl->keys.server_write_IV,
+                    keys->server_write_IV, sz);
+        }
+    #endif
         XMEMCPY(keys->client_write_IV, &keyData[i], sz);
         XMEMCPY(keys->server_write_IV, &keyData[i], sz);
 
 #ifdef HAVE_AEAD
         if (ssl->specs.cipher_type == aead) {
             /* Initialize the AES-GCM/CCM explicit IV to a zero. */
+        #ifdef WOLFSSL_DTLS
+            if (scr_copy) {
+                XMEMCPY(ssl->keys.aead_exp_IV,
+                        keys->aead_exp_IV, AEAD_MAX_EXP_SZ);
+            }
+        #endif
             XMEMSET(keys->aead_exp_IV, 0, AEAD_MAX_EXP_SZ);
         }
 #endif /* HAVE_AEAD */
@@ -3261,12 +3319,22 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
         sz = ssl->specs.hash_size;
         if (side & PROVISION_CLIENT) {
     #ifndef WOLFSSL_AEAD_ONLY
+        #ifdef WOLFSSL_DTLS
+            if (scr_copy)
+                XMEMCPY(ssl->keys.client_write_MAC_secret,
+                        keys->client_write_MAC_secret, sz);
+        #endif
             XMEMCPY(keys->client_write_MAC_secret,&keyData[i], sz);
     #endif
             i += sz;
         }
         if (side & PROVISION_SERVER) {
     #ifndef WOLFSSL_AEAD_ONLY
+        #ifdef WOLFSSL_DTLS
+            if (scr_copy)
+                XMEMCPY(ssl->keys.server_write_MAC_secret,
+                        keys->server_write_MAC_secret, sz);
+        #endif
             XMEMCPY(keys->server_write_MAC_secret,&keyData[i], sz);
     #endif
             i += sz;
@@ -3274,25 +3342,51 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
     }
     sz = ssl->specs.key_size;
     if (side & PROVISION_CLIENT) {
+    #ifdef WOLFSSL_DTLS
+        if (scr_copy)
+            XMEMCPY(ssl->keys.client_write_key,
+                    keys->client_write_key, sz);
+    #endif
         XMEMCPY(keys->client_write_key, &keyData[i], sz);
         i += sz;
     }
     if (side & PROVISION_SERVER) {
+    #ifdef WOLFSSL_DTLS
+        if (scr_copy)
+            XMEMCPY(ssl->keys.server_write_key,
+                    keys->server_write_key, sz);
+    #endif
         XMEMCPY(keys->server_write_key, &keyData[i], sz);
         i += sz;
     }
 
     sz = ssl->specs.iv_size;
     if (side & PROVISION_CLIENT) {
+    #ifdef WOLFSSL_DTLS
+        if (scr_copy)
+            XMEMCPY(ssl->keys.client_write_IV,
+                    keys->client_write_IV, sz);
+    #endif
         XMEMCPY(keys->client_write_IV, &keyData[i], sz);
         i += sz;
     }
-    if (side & PROVISION_SERVER)
+    if (side & PROVISION_SERVER) {
+    #ifdef WOLFSSL_DTLS
+        if (scr_copy)
+            XMEMCPY(ssl->keys.server_write_IV,
+                    keys->server_write_IV, sz);
+    #endif
         XMEMCPY(keys->server_write_IV, &keyData[i], sz);
+    }
 
 #ifdef HAVE_AEAD
     if (ssl->specs.cipher_type == aead) {
         /* Initialize the AES-GCM/CCM explicit IV to a zero. */
+    #ifdef WOLFSSL_DTLS
+        if (scr_copy)
+            XMEMCPY(ssl->keys.aead_exp_IV,
+                    keys->aead_exp_IV, AEAD_MAX_EXP_SZ);
+    #endif
         XMEMSET(keys->aead_exp_IV, 0, AEAD_MAX_EXP_SZ);
     }
 #endif

--- a/src/keys.c
+++ b/src/keys.c
@@ -3236,18 +3236,19 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
 #endif
 
 #ifdef HAVE_SECURE_RENEGOTIATION
-    if (ssl->options.dtls &&
-            ssl->secure_renegotiation &&
+    if (ssl->secure_renegotiation &&
             ssl->secure_renegotiation->cache_status == SCR_CACHE_NEEDED) {
         keys = &ssl->secure_renegotiation->tmp_keys;
 #ifdef WOLFSSL_DTLS
-        /* epoch is incremented after StoreKeys is called */
-        ssl->secure_renegotiation->tmp_keys.dtls_epoch = ssl->keys.dtls_epoch + 1;
-        /* we only need to copy keys on second and future renegotiations */
-        if (ssl->keys.dtls_epoch > 1)
-            scr_copy = 1;
-        ssl->encrypt.src = KEYS_NOT_SET;
-        ssl->decrypt.src = KEYS_NOT_SET;
+        if (ssl->options.dtls) {
+            /* epoch is incremented after StoreKeys is called */
+            ssl->secure_renegotiation->tmp_keys.dtls_epoch = ssl->keys.dtls_epoch + 1;
+            /* we only need to copy keys on second and future renegotiations */
+            if (ssl->keys.dtls_epoch > 1)
+                scr_copy = 1;
+            ssl->encrypt.src = KEYS_NOT_SET;
+            ssl->decrypt.src = KEYS_NOT_SET;
+        }
 #endif
         CacheStatusPP(ssl->secure_renegotiation);
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3241,36 +3241,18 @@ const byte* wolfSSL_GetDtlsMacSecret(WOLFSSL* ssl, int verify, int epochOrder)
         return NULL;
 
 #ifdef HAVE_SECURE_RENEGOTIATION
-    /* ssl->keys contains the current cipher parameters only for epoch 1. For
-     * epochs >1 ssl->secure_renegotiation->tmp_keys contains the current
-     * cipher parameters */
     switch (epochOrder) {
     case PEER_ORDER:
-        if (ssl->secure_renegotiation &&
-            ssl->secure_renegotiation->tmp_keys.dtls_epoch != 0 &&
-            ssl->keys.curEpoch ==
-                    ssl->secure_renegotiation->tmp_keys.dtls_epoch)
+        if (IsDtlsMsgSCRKeys(ssl))
             keys = &ssl->secure_renegotiation->tmp_keys;
         else
             keys = &ssl->keys;
         break;
     case PREV_ORDER:
-        if (ssl->keys.dtls_epoch > 1 ||
-            (ssl->secure_renegotiation &&
-             ssl->secure_renegotiation->tmp_keys.dtls_epoch != 0))
-            keys = &ssl->keys;
-        else {
-            WOLFSSL_MSG("No previous cipher epoch");
-            return NULL;
-        }
+        keys = &ssl->keys;
         break;
     case CUR_ORDER:
-        if (ssl->secure_renegotiation &&
-                ssl->secure_renegotiation->tmp_keys.dtls_epoch != 0 &&
-                ssl->secure_renegotiation->tmp_keys.dtls_epoch ==
-                        ssl->keys.dtls_epoch)
-            /* new keys are in scr and are only current when the
-             * ssl->keys.dtls_epoch matches */
+        if (DtlsUseSCRKeys(ssl))
             keys = &ssl->secure_renegotiation->tmp_keys;
         else
             keys = &ssl->keys;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3240,6 +3240,9 @@ const byte* wolfSSL_GetDtlsMacSecret(WOLFSSL* ssl, int verify, int epochOrder)
         return NULL;
 
 #ifdef HAVE_SECURE_RENEGOTIATION
+    /* ssl->keys contains the current cipher parameters only for epoch 1. For
+     * epochs >1 ssl->secure_renegotiation->tmp_keys contains the current
+     * cipher parameters */
     switch (epochOrder) {
     case PEER_ORDER:
         if (ssl->secure_renegotiation &&

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11783,6 +11783,14 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
             }
 #endif /* WOLFSSL_DTLS */
 
+#if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_SECURE_RENEGOTIATION)
+            /* This may be necessary in async so that we don't try to
+             * renegotiate again */
+            if (ssl->secure_renegotiation && ssl->secure_renegotiation->startScr) {
+                ssl->secure_renegotiation->startScr = 0;
+            }
+#endif /* WOLFSSL_ASYNC_CRYPT && HAVE_SECURE_RENEGOTIATION */
+
             WOLFSSL_LEAVE("SSL_connect()", WOLFSSL_SUCCESS);
             return WOLFSSL_SUCCESS;
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -1474,7 +1474,7 @@ static void AddTls13FragHeaders(byte* output, word32 fragSz, word32 fragOffset,
  * verifyOrder  Which set of sequence numbers to use.
  * out          The buffer to write into.
  */
-static WC_INLINE void WriteSEQ(WOLFSSL* ssl, int verifyOrder, byte* out)
+static WC_INLINE void WriteSEQTls13(WOLFSSL* ssl, int verifyOrder, byte* out)
 {
     word32 seq[2] = {0, 0};
 
@@ -1510,7 +1510,7 @@ static WC_INLINE void BuildTls13Nonce(WOLFSSL* ssl, byte* nonce, const byte* iv,
     int  i;
 
     /* The nonce is the IV with the sequence XORed into the last bytes. */
-    WriteSEQ(ssl, order, nonce + AEAD_NONCE_SZ - SEQ_SZ);
+    WriteSEQTls13(ssl, order, nonce + AEAD_NONCE_SZ - SEQ_SZ);
     for (i = 0; i < AEAD_NONCE_SZ - SEQ_SZ; i++)
         nonce[i] = iv[i];
     for (; i < AEAD_NONCE_SZ; i++)

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -318,7 +318,9 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 
     WOLFSSL_ENTER("EmbedReceiveFrom()");
 
-    if (ssl->options.handShakeDone)
+    /* Don't use ssl->options.handShakeDone since it is true even if
+     * we are in the process of renegotiation */
+    if (ssl->options.handShakeState == HANDSHAKE_DONE)
         dtls_timeout = 0;
 
     if (!wolfSSL_get_using_nonblock(ssl)) {

--- a/tests/include.am
+++ b/tests/include.am
@@ -31,6 +31,9 @@ EXTRA_DIST += tests/test.conf \
               tests/test-psk-no-id.conf \
               tests/test-psk-no-id-sha2.conf \
               tests/test-dtls.conf \
+              tests/test-dtls-group.conf \
+              tests/test-dtls-reneg-client.conf \
+              tests/test-dtls-reneg-server.conf \
               tests/test-dtls-sha2.conf \
               tests/test-sctp.conf \
               tests/test-sctp-sha2.conf \

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -822,6 +822,34 @@ int SuiteTest(int argc, char** argv)
         args.return_code = EXIT_FAILURE;
         goto exit;
     }
+    /* add dtls grouping suites */
+    strcpy(argv0[1], "tests/test-dtls-group.conf");
+    printf("starting dtls message grouping tests\n");
+    test_harness(&args);
+    if (args.return_code != 0) {
+        printf("error from script %d\n", args.return_code);
+        args.return_code = EXIT_FAILURE;
+        goto exit;
+    }
+#ifdef HAVE_SECURE_RENEGOTIATION
+    /* add dtls renegotiation tests */
+    strcpy(argv0[1], "tests/test-dtls-reneg-client.conf");
+    printf("starting dtls secure renegotiation client tests\n");
+    test_harness(&args);
+    if (args.return_code != 0) {
+        printf("error from script %d\n", args.return_code);
+        args.return_code = EXIT_FAILURE;
+        goto exit;
+    }
+    strcpy(argv0[1], "tests/test-dtls-reneg-server.conf");
+    printf("starting dtls secure renegotiation server tests\n");
+    test_harness(&args);
+    if (args.return_code != 0) {
+        printf("error from script %d\n", args.return_code);
+        args.return_code = EXIT_FAILURE;
+        goto exit;
+    }
+#endif
 #ifdef WOLFSSL_OLDTLS_SHA2_CIPHERSUITES
     /* add dtls extra suites */
     strcpy(argv0[1], "tests/test-dtls-sha2.conf");

--- a/tests/test-dtls-group.conf
+++ b/tests/test-dtls-group.conf
@@ -1,0 +1,1045 @@
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305
+-u
+-f
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305
+-u
+-f
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+
+# server DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305
+-u
+-f
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305
+
+# client DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305
+-u
+-f
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305
+
+# server DTLSv1.2 ECDHE-EDCSA-CHACHA20-POLY1305
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-CHACHA20-POLY1305
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 DHE-PSK-CHACHA20-POLY1305
+-u
+-f
+-v 3
+-s
+-l DHE-PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 DHE-PSK-CHACHA20-POLY1305
+-u
+-f
+-v 3
+-s
+-l DHE-PSK-CHACHA20-POLY1305
+
+# server TLSv1.2 ECDHE-PSK-CHACHA20-POLY1305
+-u
+-f
+-v 3
+-s
+-l ECDHE-PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 ECDHE-PSK-CHACHA20-POLY1305
+-u
+-f
+-v 3
+-s
+-l ECDHE-PSK-CHACHA20-POLY1305
+
+# server TLSv1.2 PSK-CHACHA20-POLY1305
+-u
+-f
+-v 3
+-s
+-l PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 PSK-CHACHA20-POLY1305
+-u
+-f
+-v 3
+-s
+-l PSK-CHACHA20-POLY1305
+
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305-OLD
+-u
+-f
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305-OLD
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305-OLD
+-u
+-f
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305-OLD
+
+# server DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305-OLD
+-u
+-f
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305-OLD
+
+# client DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305-OLD
+-u
+-f
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305-OLD
+
+# server DTLSv1.2 ECDHE-EDCSA-CHACHA20-POLY1305-OLD
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1 IDEA-CBC-SHA
+-u
+-f
+-v 2
+-l IDEA-CBC-SHA
+
+# client DTLSv1 IDEA-CBC-SHA
+-u
+-f
+-v 2
+-l IDEA-CBC-SHA
+
+# server DTLSv1 DES-CBC3-SHA
+-u
+-f
+-v 2
+-l DES-CBC3-SHA
+
+# client DTLSv1 DES-CBC3-SHA
+-u
+-f
+-v 2
+-l DES-CBC3-SHA
+
+# server DTLSv1.2 DES-CBC3-SHA
+-u
+-f
+-v 3
+-l DES-CBC3-SHA
+
+# client DTLSv1.2 DES-CBC3-SHA
+-u
+-f
+-v 3
+-l DES-CBC3-SHA
+
+# server DTLSv1 AES128-SHA
+-u
+-f
+-v 2
+-l AES128-SHA
+
+# client DTLSv1 AES128-SHA
+-u
+-f
+-v 2
+-l AES128-SHA
+
+# server DTLSv1.2 AES128-SHA
+-u
+-f
+-v 3
+-l AES128-SHA
+
+# client DTLSv1.2 AES128-SHA
+-u
+-f
+-v 3
+-l AES128-SHA
+
+# server DTLSv1 AES256-SHA
+-u
+-f
+-v 2
+-l AES256-SHA
+
+# client DTLSv1 AES256-SHA
+-u
+-f
+-v 2
+-l AES256-SHA
+
+# server DTLSv1.2 AES256-SHA
+-u
+-f
+-v 3
+-l AES256-SHA
+
+# client DTLSv1.2 AES256-SHA
+-u
+-f
+-v 3
+-l AES256-SHA
+
+# server DTLSv1.2 AES128-SHA256
+-u
+-f
+-v 3
+-l AES128-SHA256
+
+# client DTLSv1.2 AES128-SHA256
+-u
+-f
+-v 3
+-l AES128-SHA256
+
+# server DTLSv1.2 AES256-SHA256
+-u
+-f
+-v 3
+-l AES256-SHA256
+
+# client DTLSv1.2 AES256-SHA256
+-u
+-f
+-v 3
+-l AES256-SHA256
+
+# server DTLSv1.1 ECDHE-RSA-DES3
+-u
+-f
+-v 2
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# client DTLSv1.1 ECDHE-RSA-DES3
+-u
+-f
+-v 2
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# server DTLSv1.1 ECDHE-RSA-AES128
+-u
+-f
+-v 2
+-l ECDHE-RSA-AES128-SHA
+
+# client DTLSv1.1 ECDHE-RSA-AES128
+-u
+-f
+-v 2
+-l ECDHE-RSA-AES128-SHA
+
+# server DTLSv1.1 ECDHE-RSA-AES256
+-u
+-f
+-v 2
+-l ECDHE-RSA-AES256-SHA
+
+# client DTLSv1.1 ECDHE-RSA-AES256
+-u
+-f
+-v 2
+-l ECDHE-RSA-AES256-SHA
+
+# server DTLSv1.2 ECDHE-RSA-DES3
+-u
+-f
+-v 3
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# client DTLSv1.2 ECDHE-RSA-DES3
+-u
+-f
+-v 3
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# server DTLSv1.2 ECDHE-RSA-AES128
+-u
+-f
+-v 3
+-l ECDHE-RSA-AES128-SHA
+
+# client DTLSv1.2 ECDHE-RSA-AES128
+-u
+-f
+-v 3
+-l ECDHE-RSA-AES128-SHA
+
+# server DTLSv1.2 ECDHE-RSA-AES128-SHA256
+-u
+-f
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# client DTLSv1.2 ECDHE-RSA-AES128-SHA256
+-u
+-f
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# server DTLSv1.2 ECDHE-RSA-AES256
+-u
+-f
+-v 3
+-l ECDHE-RSA-AES256-SHA
+
+# client DTLSv1.2 ECDHE-RSA-AES256
+-u
+-f
+-v 3
+-l ECDHE-RSA-AES256-SHA
+
+# server TLSv1 ECDHE-ECDSA-NULL-SHA
+-u
+-f
+-v 1
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1 ECDHE-ECDSA-NULL-SHA
+-u
+-f
+-v 1
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.1 ECDHE-ECDSA-NULL-SHA
+-u
+-f
+-v 2
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1 ECDHE-ECDSA-NULL-SHA
+-u
+-f
+-v 2
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-ECDSA-NULL-SHA
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-NULL-SHA
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-DES3
+-u
+-f
+-v 2
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-DES3
+-u
+-f
+-v 2
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-AES128
+-u
+-f
+-v 2
+-l ECDHE-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-AES128
+-u
+-f
+-v 2
+-l ECDHE-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-AES256
+-u
+-f
+-v 2
+-l ECDHE-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-AES256
+-u
+-f
+-v 2
+-l ECDHE-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-DES3
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-DES3
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-SHA256
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-SHA256
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-RSA-DES3
+-u
+-f
+-v 2
+-l ECDH-RSA-DES-CBC3-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-DES3
+-u
+-f
+-v 2
+-l ECDH-RSA-DES-CBC3-SHA
+
+# server DTLSv1.1 ECDH-RSA-AES128
+-u
+-f
+-v 2
+-l ECDH-RSA-AES128-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-AES128
+-u
+-f
+-v 2
+-l ECDH-RSA-AES128-SHA
+
+# server DTLSv1.1 ECDH-RSA-AES256
+-u
+-f
+-v 2
+-l ECDH-RSA-AES256-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-AES256
+-u
+-f
+-v 2
+-l ECDH-RSA-AES256-SHA
+
+# server DTLSv1.2 ECDH-RSA-DES3
+-u
+-f
+-v 3
+-l ECDH-RSA-DES-CBC3-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-DES3
+-u
+-f
+-v 3
+-l ECDH-RSA-DES-CBC3-SHA
+
+# server DTLSv1.2 ECDH-RSA-AES128
+-u
+-f
+-v 3
+-l ECDH-RSA-AES128-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128
+-u
+-f
+-v 3
+-l ECDH-RSA-AES128-SHA
+
+# server DTLSv1.2 ECDH-RSA-AES128-SHA256
+-u
+-f
+-v 3
+-l ECDH-RSA-AES128-SHA256
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128-SHA256
+-u
+-f
+-v 3
+-l ECDH-RSA-AES128-SHA256
+
+# server DTLSv1.2 ECDH-RSA-AES256
+-u
+-f
+-v 3
+-l ECDH-RSA-AES256-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256
+-u
+-f
+-v 3
+-l ECDH-RSA-AES256-SHA
+
+# server DTLSv1.1 ECDH-ECDSA-DES3
+-u
+-f
+-v 2
+-l ECDH-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-DES3
+-u
+-f
+-v 2
+-l ECDH-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-ECDSA-AES128
+-u
+-f
+-v 2
+-l ECDH-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-AES128
+-u
+-f
+-v 2
+-l ECDH-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-ECDSA-AES256
+-u
+-f
+-v 2
+-l ECDH-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-AES256
+-u
+-f
+-v 2
+-l ECDH-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-DES3
+-u
+-f
+-v 3
+-l ECDH-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-DES3
+-u
+-f
+-v 3
+-l ECDH-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128
+-u
+-f
+-v 3
+-l ECDH-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128
+-u
+-f
+-v 3
+-l ECDH-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128-SHA256
+-u
+-f
+-v 3
+-l ECDH-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128-SHA256
+-u
+-f
+-v 3
+-l ECDH-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES256
+-u
+-f
+-v 3
+-l ECDH-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256
+-u
+-f
+-v 3
+-l ECDH-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-RSA-AES256-SHA384
+-u
+-f
+-v 3
+-l ECDHE-RSA-AES256-SHA384
+
+# client DTLSv1.2 ECDHE-RSA-AES256-SHA384
+-u
+-f
+-v 3
+-l ECDHE-RSA-AES256-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-SHA384
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-SHA384
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-RSA-AES256-SHA384
+-u
+-f
+-v 3
+-l ECDH-RSA-AES256-SHA384
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256-SHA384
+-u
+-f
+-v 3
+-l ECDH-RSA-AES256-SHA384
+
+# server DTLSv1.2 ECDH-ECDSA-AES256-SHA384
+-u
+-f
+-v 3
+-l ECDH-ECDSA-AES256-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256-SHA384
+-u
+-f
+-v 3
+-l ECDH-ECDSA-AES256-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-PSK-AES128-SHA256
+-s
+-u
+-f
+-v 3
+-l ECDHE-PSK-AES128-SHA256
+
+# client TLSv1.2 ECDHE-PSK-AES128-SHA256
+-s
+-u
+-f
+-v 3
+-l ECDHE-PSK-AES128-SHA256
+
+# server TLSv1.2 ECDHE-PSK-NULL-SHA256
+-s
+-u
+-f
+-v 3
+-l ECDHE-PSK-NULL-SHA256
+
+# client TLSv1.2 ECDHE-PSK-NULL-SHA256
+-s
+-u
+-f
+-v 3
+-l ECDHE-PSK-NULL-SHA256
+
+# server DTLSv1 PSK-AES128
+-s
+-u
+-f
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# client DTLSv1 PSK-AES128
+-s
+-u
+-f
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# server DTLSv1 PSK-AES256
+-s
+-u
+-f
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# client DTLSv1 PSK-AES256
+-s
+-u
+-f
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# server DTLSv1.2 PSK-AES128
+-s
+-u
+-f
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# client DTLSv1.2 PSK-AES128
+-s
+-u
+-f
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# server DTLSv1.2 PSK-AES256
+-s
+-u
+-f
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# client DTLSv1.2 PSK-AES256
+-s
+-u
+-f
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# server DTLSv1.2 PSK-AES128-SHA256
+-s
+-u
+-f
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# client DTLSv1.2 PSK-AES128-SHA256
+-s
+-u
+-f
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# server DTLSv1.2 PSK-AES256-SHA384
+-s
+-u
+-f
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# client DTLSv1.2 PSK-AES256-SHA384
+-s
+-u
+-f
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-GCM-SHA256
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-GCM-SHA256
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-GCM-SHA384
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-GCM-SHA384
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128-GCM-SHA256
+-u
+-f
+-v 3
+-l ECDH-ECDSA-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128-GCM-SHA256
+-u
+-f
+-v 3
+-l ECDH-ECDSA-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES256-GCM-SHA384
+-u
+-f
+-v 3
+-l ECDH-ECDSA-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256-GCM-SHA384
+-u
+-f
+-v 3
+-l ECDH-ECDSA-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-RSA-AES128-GCM-SHA256
+-u
+-f
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+
+# client DTLSv1.2 ECDHE-RSA-AES128-GCM-SHA256
+-u
+-f
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+
+# server DTLSv1.2 ECDHE-RSA-AES256-GCM-SHA384
+-u
+-f
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+
+# client DTLSv1.2 ECDHE-RSA-AES256-GCM-SHA384
+-u
+-f
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+
+# server DTLSv1.2 ECDH-RSA-AES128-GCM-SHA256
+-u
+-f
+-v 3
+-l ECDH-RSA-AES128-GCM-SHA256
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128-GCM-SHA256
+-u
+-f
+-v 3
+-l ECDH-RSA-AES128-GCM-SHA256
+
+# server DTLSv1.2 ECDH-RSA-AES256-GCM-SHA384
+-u
+-f
+-v 3
+-l ECDH-RSA-AES256-GCM-SHA384
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256-GCM-SHA384
+-u
+-f
+-v 3
+-l ECDH-RSA-AES256-GCM-SHA384
+
+# server DTLSv1.2 PSK-AES128-GCM-SHA256
+-u
+-f
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# client DTLSv1.2 PSK-AES128-GCM-SHA256
+-u
+-f
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# server DTLSv1.2 PSK-AES256-GCM-SHA384
+-u
+-f
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# client DTLSv1.2 PSK-AES256-GCM-SHA384
+-u
+-f
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM-8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM-8
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-CCM-8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM-8
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ADH-AES128-SHA
+-u
+-f
+-a
+-v 3
+-l ADH-AES128-SHA
+
+# client DTLSv1.2 ADH-AES128-SHA
+-u
+-f
+-a
+-v 3
+-l ADH-AES128-SHA
+
+# server DTLSv1.0 ADH-AES128-SHA
+-u
+-f
+-a
+-v 2
+-l ADH-AES128-SHA
+
+# client DTLSv1.0 ADH-AES128-SHA
+-u
+-f
+-a
+-v 2
+-l ADH-AES128-SHA

--- a/tests/test-dtls-reneg-client.conf
+++ b/tests/test-dtls-reneg-client.conf
@@ -1,0 +1,1045 @@
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305
+-M
+-u
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305
+-i
+-u
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+
+# server DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305
+-M
+-u
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305
+
+# client DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305
+-i
+-u
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305
+
+# server DTLSv1.2 ECDHE-EDCSA-CHACHA20-POLY1305
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-CHACHA20-POLY1305
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 DHE-PSK-CHACHA20-POLY1305
+-M
+-u
+-v 3
+-s
+-l DHE-PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 DHE-PSK-CHACHA20-POLY1305
+-i
+-u
+-v 3
+-s
+-l DHE-PSK-CHACHA20-POLY1305
+
+# server TLSv1.2 ECDHE-PSK-CHACHA20-POLY1305
+-M
+-u
+-v 3
+-s
+-l ECDHE-PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 ECDHE-PSK-CHACHA20-POLY1305
+-i
+-u
+-v 3
+-s
+-l ECDHE-PSK-CHACHA20-POLY1305
+
+# server TLSv1.2 PSK-CHACHA20-POLY1305
+-M
+-u
+-v 3
+-s
+-l PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 PSK-CHACHA20-POLY1305
+-i
+-u
+-v 3
+-s
+-l PSK-CHACHA20-POLY1305
+
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305-OLD
+-M
+-u
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305-OLD
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305-OLD
+-i
+-u
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305-OLD
+
+# server DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305-OLD
+-M
+-u
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305-OLD
+
+# client DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305-OLD
+-i
+-u
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305-OLD
+
+# server DTLSv1.2 ECDHE-EDCSA-CHACHA20-POLY1305-OLD
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1 IDEA-CBC-SHA
+-M
+-u
+-v 2
+-l IDEA-CBC-SHA
+
+# client DTLSv1 IDEA-CBC-SHA
+-i
+-u
+-v 2
+-l IDEA-CBC-SHA
+
+# server DTLSv1 DES-CBC3-SHA
+-M
+-u
+-v 2
+-l DES-CBC3-SHA
+
+# client DTLSv1 DES-CBC3-SHA
+-i
+-u
+-v 2
+-l DES-CBC3-SHA
+
+# server DTLSv1.2 DES-CBC3-SHA
+-M
+-u
+-v 3
+-l DES-CBC3-SHA
+
+# client DTLSv1.2 DES-CBC3-SHA
+-i
+-u
+-v 3
+-l DES-CBC3-SHA
+
+# server DTLSv1 AES128-SHA
+-M
+-u
+-v 2
+-l AES128-SHA
+
+# client DTLSv1 AES128-SHA
+-i
+-u
+-v 2
+-l AES128-SHA
+
+# server DTLSv1.2 AES128-SHA
+-M
+-u
+-v 3
+-l AES128-SHA
+
+# client DTLSv1.2 AES128-SHA
+-i
+-u
+-v 3
+-l AES128-SHA
+
+# server DTLSv1 AES256-SHA
+-M
+-u
+-v 2
+-l AES256-SHA
+
+# client DTLSv1 AES256-SHA
+-i
+-u
+-v 2
+-l AES256-SHA
+
+# server DTLSv1.2 AES256-SHA
+-M
+-u
+-v 3
+-l AES256-SHA
+
+# client DTLSv1.2 AES256-SHA
+-i
+-u
+-v 3
+-l AES256-SHA
+
+# server DTLSv1.2 AES128-SHA256
+-M
+-u
+-v 3
+-l AES128-SHA256
+
+# client DTLSv1.2 AES128-SHA256
+-i
+-u
+-v 3
+-l AES128-SHA256
+
+# server DTLSv1.2 AES256-SHA256
+-M
+-u
+-v 3
+-l AES256-SHA256
+
+# client DTLSv1.2 AES256-SHA256
+-i
+-u
+-v 3
+-l AES256-SHA256
+
+# server DTLSv1.1 ECDHE-RSA-DES3
+-M
+-u
+-v 2
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# client DTLSv1.1 ECDHE-RSA-DES3
+-i
+-u
+-v 2
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# server DTLSv1.1 ECDHE-RSA-AES128
+-M
+-u
+-v 2
+-l ECDHE-RSA-AES128-SHA
+
+# client DTLSv1.1 ECDHE-RSA-AES128
+-i
+-u
+-v 2
+-l ECDHE-RSA-AES128-SHA
+
+# server DTLSv1.1 ECDHE-RSA-AES256
+-M
+-u
+-v 2
+-l ECDHE-RSA-AES256-SHA
+
+# client DTLSv1.1 ECDHE-RSA-AES256
+-i
+-u
+-v 2
+-l ECDHE-RSA-AES256-SHA
+
+# server DTLSv1.2 ECDHE-RSA-DES3
+-M
+-u
+-v 3
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# client DTLSv1.2 ECDHE-RSA-DES3
+-i
+-u
+-v 3
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# server DTLSv1.2 ECDHE-RSA-AES128
+-M
+-u
+-v 3
+-l ECDHE-RSA-AES128-SHA
+
+# client DTLSv1.2 ECDHE-RSA-AES128
+-i
+-u
+-v 3
+-l ECDHE-RSA-AES128-SHA
+
+# server DTLSv1.2 ECDHE-RSA-AES128-SHA256
+-M
+-u
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# client DTLSv1.2 ECDHE-RSA-AES128-SHA256
+-i
+-u
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# server DTLSv1.2 ECDHE-RSA-AES256
+-M
+-u
+-v 3
+-l ECDHE-RSA-AES256-SHA
+
+# client DTLSv1.2 ECDHE-RSA-AES256
+-i
+-u
+-v 3
+-l ECDHE-RSA-AES256-SHA
+
+# server TLSv1 ECDHE-ECDSA-NULL-SHA
+-M
+-u
+-v 1
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1 ECDHE-ECDSA-NULL-SHA
+-i
+-u
+-v 1
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.1 ECDHE-ECDSA-NULL-SHA
+-M
+-u
+-v 2
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1 ECDHE-ECDSA-NULL-SHA
+-i
+-u
+-v 2
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-ECDSA-NULL-SHA
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-NULL-SHA
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-DES3
+-M
+-u
+-v 2
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-DES3
+-i
+-u
+-v 2
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-AES128
+-M
+-u
+-v 2
+-l ECDHE-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-AES128
+-i
+-u
+-v 2
+-l ECDHE-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-AES256
+-M
+-u
+-v 2
+-l ECDHE-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-AES256
+-i
+-u
+-v 2
+-l ECDHE-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-DES3
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-DES3
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-SHA256
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-SHA256
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-RSA-DES3
+-M
+-u
+-v 2
+-l ECDH-RSA-DES-CBC3-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-DES3
+-i
+-u
+-v 2
+-l ECDH-RSA-DES-CBC3-SHA
+
+# server DTLSv1.1 ECDH-RSA-AES128
+-M
+-u
+-v 2
+-l ECDH-RSA-AES128-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-AES128
+-i
+-u
+-v 2
+-l ECDH-RSA-AES128-SHA
+
+# server DTLSv1.1 ECDH-RSA-AES256
+-M
+-u
+-v 2
+-l ECDH-RSA-AES256-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-AES256
+-i
+-u
+-v 2
+-l ECDH-RSA-AES256-SHA
+
+# server DTLSv1.2 ECDH-RSA-DES3
+-M
+-u
+-v 3
+-l ECDH-RSA-DES-CBC3-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-DES3
+-i
+-u
+-v 3
+-l ECDH-RSA-DES-CBC3-SHA
+
+# server DTLSv1.2 ECDH-RSA-AES128
+-M
+-u
+-v 3
+-l ECDH-RSA-AES128-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128
+-i
+-u
+-v 3
+-l ECDH-RSA-AES128-SHA
+
+# server DTLSv1.2 ECDH-RSA-AES128-SHA256
+-M
+-u
+-v 3
+-l ECDH-RSA-AES128-SHA256
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128-SHA256
+-i
+-u
+-v 3
+-l ECDH-RSA-AES128-SHA256
+
+# server DTLSv1.2 ECDH-RSA-AES256
+-M
+-u
+-v 3
+-l ECDH-RSA-AES256-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256
+-i
+-u
+-v 3
+-l ECDH-RSA-AES256-SHA
+
+# server DTLSv1.1 ECDH-ECDSA-DES3
+-M
+-u
+-v 2
+-l ECDH-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-DES3
+-i
+-u
+-v 2
+-l ECDH-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-ECDSA-AES128
+-M
+-u
+-v 2
+-l ECDH-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-AES128
+-i
+-u
+-v 2
+-l ECDH-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-ECDSA-AES256
+-M
+-u
+-v 2
+-l ECDH-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-AES256
+-i
+-u
+-v 2
+-l ECDH-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-DES3
+-M
+-u
+-v 3
+-l ECDH-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-DES3
+-i
+-u
+-v 3
+-l ECDH-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128
+-M
+-u
+-v 3
+-l ECDH-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128
+-i
+-u
+-v 3
+-l ECDH-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128-SHA256
+-M
+-u
+-v 3
+-l ECDH-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128-SHA256
+-i
+-u
+-v 3
+-l ECDH-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES256
+-M
+-u
+-v 3
+-l ECDH-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256
+-i
+-u
+-v 3
+-l ECDH-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-RSA-AES256-SHA384
+-M
+-u
+-v 3
+-l ECDHE-RSA-AES256-SHA384
+
+# client DTLSv1.2 ECDHE-RSA-AES256-SHA384
+-i
+-u
+-v 3
+-l ECDHE-RSA-AES256-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-SHA384
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-SHA384
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-RSA-AES256-SHA384
+-M
+-u
+-v 3
+-l ECDH-RSA-AES256-SHA384
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256-SHA384
+-i
+-u
+-v 3
+-l ECDH-RSA-AES256-SHA384
+
+# server DTLSv1.2 ECDH-ECDSA-AES256-SHA384
+-M
+-u
+-v 3
+-l ECDH-ECDSA-AES256-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256-SHA384
+-i
+-u
+-v 3
+-l ECDH-ECDSA-AES256-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-PSK-AES128-SHA256
+-M
+-s
+-u
+-v 3
+-l ECDHE-PSK-AES128-SHA256
+
+# client TLSv1.2 ECDHE-PSK-AES128-SHA256
+-i
+-s
+-u
+-v 3
+-l ECDHE-PSK-AES128-SHA256
+
+# server TLSv1.2 ECDHE-PSK-NULL-SHA256
+-M
+-s
+-u
+-v 3
+-l ECDHE-PSK-NULL-SHA256
+
+# client TLSv1.2 ECDHE-PSK-NULL-SHA256
+-i
+-s
+-u
+-v 3
+-l ECDHE-PSK-NULL-SHA256
+
+# server DTLSv1 PSK-AES128
+-M
+-s
+-u
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# client DTLSv1 PSK-AES128
+-i
+-s
+-u
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# server DTLSv1 PSK-AES256
+-M
+-s
+-u
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# client DTLSv1 PSK-AES256
+-i
+-s
+-u
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# server DTLSv1.2 PSK-AES128
+-M
+-s
+-u
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# client DTLSv1.2 PSK-AES128
+-i
+-s
+-u
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# server DTLSv1.2 PSK-AES256
+-M
+-s
+-u
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# client DTLSv1.2 PSK-AES256
+-i
+-s
+-u
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# server DTLSv1.2 PSK-AES128-SHA256
+-M
+-s
+-u
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# client DTLSv1.2 PSK-AES128-SHA256
+-i
+-s
+-u
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# server DTLSv1.2 PSK-AES256-SHA384
+-M
+-s
+-u
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# client DTLSv1.2 PSK-AES256-SHA384
+-i
+-s
+-u
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-GCM-SHA256
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-GCM-SHA256
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-GCM-SHA384
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-GCM-SHA384
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128-GCM-SHA256
+-M
+-u
+-v 3
+-l ECDH-ECDSA-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128-GCM-SHA256
+-i
+-u
+-v 3
+-l ECDH-ECDSA-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES256-GCM-SHA384
+-M
+-u
+-v 3
+-l ECDH-ECDSA-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256-GCM-SHA384
+-i
+-u
+-v 3
+-l ECDH-ECDSA-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-RSA-AES128-GCM-SHA256
+-M
+-u
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+
+# client DTLSv1.2 ECDHE-RSA-AES128-GCM-SHA256
+-i
+-u
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+
+# server DTLSv1.2 ECDHE-RSA-AES256-GCM-SHA384
+-M
+-u
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+
+# client DTLSv1.2 ECDHE-RSA-AES256-GCM-SHA384
+-i
+-u
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+
+# server DTLSv1.2 ECDH-RSA-AES128-GCM-SHA256
+-M
+-u
+-v 3
+-l ECDH-RSA-AES128-GCM-SHA256
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128-GCM-SHA256
+-i
+-u
+-v 3
+-l ECDH-RSA-AES128-GCM-SHA256
+
+# server DTLSv1.2 ECDH-RSA-AES256-GCM-SHA384
+-M
+-u
+-v 3
+-l ECDH-RSA-AES256-GCM-SHA384
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256-GCM-SHA384
+-i
+-u
+-v 3
+-l ECDH-RSA-AES256-GCM-SHA384
+
+# server DTLSv1.2 PSK-AES128-GCM-SHA256
+-M
+-u
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# client DTLSv1.2 PSK-AES128-GCM-SHA256
+-i
+-u
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# server DTLSv1.2 PSK-AES256-GCM-SHA384
+-M
+-u
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# client DTLSv1.2 PSK-AES256-GCM-SHA384
+-i
+-u
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM-8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM-8
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-CCM-8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM-8
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ADH-AES128-SHA
+-M
+-u
+-a
+-v 3
+-l ADH-AES128-SHA
+
+# client DTLSv1.2 ADH-AES128-SHA
+-i
+-u
+-a
+-v 3
+-l ADH-AES128-SHA
+
+# server DTLSv1.0 ADH-AES128-SHA
+-M
+-u
+-a
+-v 2
+-l ADH-AES128-SHA
+
+# client DTLSv1.0 ADH-AES128-SHA
+-i
+-u
+-a
+-v 2
+-l ADH-AES128-SHA

--- a/tests/test-dtls-reneg-server.conf
+++ b/tests/test-dtls-reneg-server.conf
@@ -1,0 +1,1045 @@
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305
+-m
+-u
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305
+-R
+-u
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+
+# server DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305
+-m
+-u
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305
+
+# client DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305
+-R
+-u
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305
+
+# server DTLSv1.2 ECDHE-EDCSA-CHACHA20-POLY1305
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-CHACHA20-POLY1305
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 DHE-PSK-CHACHA20-POLY1305
+-m
+-u
+-v 3
+-s
+-l DHE-PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 DHE-PSK-CHACHA20-POLY1305
+-R
+-u
+-v 3
+-s
+-l DHE-PSK-CHACHA20-POLY1305
+
+# server TLSv1.2 ECDHE-PSK-CHACHA20-POLY1305
+-m
+-u
+-v 3
+-s
+-l ECDHE-PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 ECDHE-PSK-CHACHA20-POLY1305
+-R
+-u
+-v 3
+-s
+-l ECDHE-PSK-CHACHA20-POLY1305
+
+# server TLSv1.2 PSK-CHACHA20-POLY1305
+-m
+-u
+-v 3
+-s
+-l PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 PSK-CHACHA20-POLY1305
+-R
+-u
+-v 3
+-s
+-l PSK-CHACHA20-POLY1305
+
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305-OLD
+-m
+-u
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305-OLD
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305-OLD
+-R
+-u
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305-OLD
+
+# server DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305-OLD
+-m
+-u
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305-OLD
+
+# client DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305-OLD
+-R
+-u
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305-OLD
+
+# server DTLSv1.2 ECDHE-EDCSA-CHACHA20-POLY1305-OLD
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1 IDEA-CBC-SHA
+-m
+-u
+-v 2
+-l IDEA-CBC-SHA
+
+# client DTLSv1 IDEA-CBC-SHA
+-R
+-u
+-v 2
+-l IDEA-CBC-SHA
+
+# server DTLSv1 DES-CBC3-SHA
+-m
+-u
+-v 2
+-l DES-CBC3-SHA
+
+# client DTLSv1 DES-CBC3-SHA
+-R
+-u
+-v 2
+-l DES-CBC3-SHA
+
+# server DTLSv1.2 DES-CBC3-SHA
+-m
+-u
+-v 3
+-l DES-CBC3-SHA
+
+# client DTLSv1.2 DES-CBC3-SHA
+-R
+-u
+-v 3
+-l DES-CBC3-SHA
+
+# server DTLSv1 AES128-SHA
+-m
+-u
+-v 2
+-l AES128-SHA
+
+# client DTLSv1 AES128-SHA
+-R
+-u
+-v 2
+-l AES128-SHA
+
+# server DTLSv1.2 AES128-SHA
+-m
+-u
+-v 3
+-l AES128-SHA
+
+# client DTLSv1.2 AES128-SHA
+-R
+-u
+-v 3
+-l AES128-SHA
+
+# server DTLSv1 AES256-SHA
+-m
+-u
+-v 2
+-l AES256-SHA
+
+# client DTLSv1 AES256-SHA
+-R
+-u
+-v 2
+-l AES256-SHA
+
+# server DTLSv1.2 AES256-SHA
+-m
+-u
+-v 3
+-l AES256-SHA
+
+# client DTLSv1.2 AES256-SHA
+-R
+-u
+-v 3
+-l AES256-SHA
+
+# server DTLSv1.2 AES128-SHA256
+-m
+-u
+-v 3
+-l AES128-SHA256
+
+# client DTLSv1.2 AES128-SHA256
+-R
+-u
+-v 3
+-l AES128-SHA256
+
+# server DTLSv1.2 AES256-SHA256
+-m
+-u
+-v 3
+-l AES256-SHA256
+
+# client DTLSv1.2 AES256-SHA256
+-R
+-u
+-v 3
+-l AES256-SHA256
+
+# server DTLSv1.1 ECDHE-RSA-DES3
+-m
+-u
+-v 2
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# client DTLSv1.1 ECDHE-RSA-DES3
+-R
+-u
+-v 2
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# server DTLSv1.1 ECDHE-RSA-AES128
+-m
+-u
+-v 2
+-l ECDHE-RSA-AES128-SHA
+
+# client DTLSv1.1 ECDHE-RSA-AES128
+-R
+-u
+-v 2
+-l ECDHE-RSA-AES128-SHA
+
+# server DTLSv1.1 ECDHE-RSA-AES256
+-m
+-u
+-v 2
+-l ECDHE-RSA-AES256-SHA
+
+# client DTLSv1.1 ECDHE-RSA-AES256
+-R
+-u
+-v 2
+-l ECDHE-RSA-AES256-SHA
+
+# server DTLSv1.2 ECDHE-RSA-DES3
+-m
+-u
+-v 3
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# client DTLSv1.2 ECDHE-RSA-DES3
+-R
+-u
+-v 3
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# server DTLSv1.2 ECDHE-RSA-AES128
+-m
+-u
+-v 3
+-l ECDHE-RSA-AES128-SHA
+
+# client DTLSv1.2 ECDHE-RSA-AES128
+-R
+-u
+-v 3
+-l ECDHE-RSA-AES128-SHA
+
+# server DTLSv1.2 ECDHE-RSA-AES128-SHA256
+-m
+-u
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# client DTLSv1.2 ECDHE-RSA-AES128-SHA256
+-R
+-u
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# server DTLSv1.2 ECDHE-RSA-AES256
+-m
+-u
+-v 3
+-l ECDHE-RSA-AES256-SHA
+
+# client DTLSv1.2 ECDHE-RSA-AES256
+-R
+-u
+-v 3
+-l ECDHE-RSA-AES256-SHA
+
+# server TLSv1 ECDHE-ECDSA-NULL-SHA
+-m
+-u
+-v 1
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1 ECDHE-ECDSA-NULL-SHA
+-R
+-u
+-v 1
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.1 ECDHE-ECDSA-NULL-SHA
+-m
+-u
+-v 2
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1 ECDHE-ECDSA-NULL-SHA
+-R
+-u
+-v 2
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-ECDSA-NULL-SHA
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-NULL-SHA
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-DES3
+-m
+-u
+-v 2
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-DES3
+-R
+-u
+-v 2
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-AES128
+-m
+-u
+-v 2
+-l ECDHE-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-AES128
+-R
+-u
+-v 2
+-l ECDHE-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-AES256
+-m
+-u
+-v 2
+-l ECDHE-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-AES256
+-R
+-u
+-v 2
+-l ECDHE-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-DES3
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-DES3
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-SHA256
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-SHA256
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-RSA-DES3
+-m
+-u
+-v 2
+-l ECDH-RSA-DES-CBC3-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-DES3
+-R
+-u
+-v 2
+-l ECDH-RSA-DES-CBC3-SHA
+
+# server DTLSv1.1 ECDH-RSA-AES128
+-m
+-u
+-v 2
+-l ECDH-RSA-AES128-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-AES128
+-R
+-u
+-v 2
+-l ECDH-RSA-AES128-SHA
+
+# server DTLSv1.1 ECDH-RSA-AES256
+-m
+-u
+-v 2
+-l ECDH-RSA-AES256-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-AES256
+-R
+-u
+-v 2
+-l ECDH-RSA-AES256-SHA
+
+# server DTLSv1.2 ECDH-RSA-DES3
+-m
+-u
+-v 3
+-l ECDH-RSA-DES-CBC3-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-DES3
+-R
+-u
+-v 3
+-l ECDH-RSA-DES-CBC3-SHA
+
+# server DTLSv1.2 ECDH-RSA-AES128
+-m
+-u
+-v 3
+-l ECDH-RSA-AES128-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128
+-R
+-u
+-v 3
+-l ECDH-RSA-AES128-SHA
+
+# server DTLSv1.2 ECDH-RSA-AES128-SHA256
+-m
+-u
+-v 3
+-l ECDH-RSA-AES128-SHA256
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128-SHA256
+-R
+-u
+-v 3
+-l ECDH-RSA-AES128-SHA256
+
+# server DTLSv1.2 ECDH-RSA-AES256
+-m
+-u
+-v 3
+-l ECDH-RSA-AES256-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256
+-R
+-u
+-v 3
+-l ECDH-RSA-AES256-SHA
+
+# server DTLSv1.1 ECDH-ECDSA-DES3
+-m
+-u
+-v 2
+-l ECDH-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-DES3
+-R
+-u
+-v 2
+-l ECDH-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-ECDSA-AES128
+-m
+-u
+-v 2
+-l ECDH-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-AES128
+-R
+-u
+-v 2
+-l ECDH-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-ECDSA-AES256
+-m
+-u
+-v 2
+-l ECDH-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-AES256
+-R
+-u
+-v 2
+-l ECDH-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-DES3
+-m
+-u
+-v 3
+-l ECDH-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-DES3
+-R
+-u
+-v 3
+-l ECDH-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128
+-m
+-u
+-v 3
+-l ECDH-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128
+-R
+-u
+-v 3
+-l ECDH-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128-SHA256
+-m
+-u
+-v 3
+-l ECDH-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128-SHA256
+-R
+-u
+-v 3
+-l ECDH-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES256
+-m
+-u
+-v 3
+-l ECDH-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256
+-R
+-u
+-v 3
+-l ECDH-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-RSA-AES256-SHA384
+-m
+-u
+-v 3
+-l ECDHE-RSA-AES256-SHA384
+
+# client DTLSv1.2 ECDHE-RSA-AES256-SHA384
+-R
+-u
+-v 3
+-l ECDHE-RSA-AES256-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-SHA384
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-SHA384
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-RSA-AES256-SHA384
+-m
+-u
+-v 3
+-l ECDH-RSA-AES256-SHA384
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256-SHA384
+-R
+-u
+-v 3
+-l ECDH-RSA-AES256-SHA384
+
+# server DTLSv1.2 ECDH-ECDSA-AES256-SHA384
+-m
+-u
+-v 3
+-l ECDH-ECDSA-AES256-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256-SHA384
+-R
+-u
+-v 3
+-l ECDH-ECDSA-AES256-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-PSK-AES128-SHA256
+-m
+-s
+-u
+-v 3
+-l ECDHE-PSK-AES128-SHA256
+
+# client TLSv1.2 ECDHE-PSK-AES128-SHA256
+-R
+-s
+-u
+-v 3
+-l ECDHE-PSK-AES128-SHA256
+
+# server TLSv1.2 ECDHE-PSK-NULL-SHA256
+-m
+-s
+-u
+-v 3
+-l ECDHE-PSK-NULL-SHA256
+
+# client TLSv1.2 ECDHE-PSK-NULL-SHA256
+-R
+-s
+-u
+-v 3
+-l ECDHE-PSK-NULL-SHA256
+
+# server DTLSv1 PSK-AES128
+-m
+-s
+-u
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# client DTLSv1 PSK-AES128
+-R
+-s
+-u
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# server DTLSv1 PSK-AES256
+-m
+-s
+-u
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# client DTLSv1 PSK-AES256
+-R
+-s
+-u
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# server DTLSv1.2 PSK-AES128
+-m
+-s
+-u
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# client DTLSv1.2 PSK-AES128
+-R
+-s
+-u
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# server DTLSv1.2 PSK-AES256
+-m
+-s
+-u
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# client DTLSv1.2 PSK-AES256
+-R
+-s
+-u
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# server DTLSv1.2 PSK-AES128-SHA256
+-m
+-s
+-u
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# client DTLSv1.2 PSK-AES128-SHA256
+-R
+-s
+-u
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# server DTLSv1.2 PSK-AES256-SHA384
+-m
+-s
+-u
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# client DTLSv1.2 PSK-AES256-SHA384
+-R
+-s
+-u
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-GCM-SHA256
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-GCM-SHA256
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-GCM-SHA384
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-GCM-SHA384
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128-GCM-SHA256
+-m
+-u
+-v 3
+-l ECDH-ECDSA-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128-GCM-SHA256
+-R
+-u
+-v 3
+-l ECDH-ECDSA-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES256-GCM-SHA384
+-m
+-u
+-v 3
+-l ECDH-ECDSA-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256-GCM-SHA384
+-R
+-u
+-v 3
+-l ECDH-ECDSA-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-RSA-AES128-GCM-SHA256
+-m
+-u
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+
+# client DTLSv1.2 ECDHE-RSA-AES128-GCM-SHA256
+-R
+-u
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+
+# server DTLSv1.2 ECDHE-RSA-AES256-GCM-SHA384
+-m
+-u
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+
+# client DTLSv1.2 ECDHE-RSA-AES256-GCM-SHA384
+-R
+-u
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+
+# server DTLSv1.2 ECDH-RSA-AES128-GCM-SHA256
+-m
+-u
+-v 3
+-l ECDH-RSA-AES128-GCM-SHA256
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128-GCM-SHA256
+-R
+-u
+-v 3
+-l ECDH-RSA-AES128-GCM-SHA256
+
+# server DTLSv1.2 ECDH-RSA-AES256-GCM-SHA384
+-m
+-u
+-v 3
+-l ECDH-RSA-AES256-GCM-SHA384
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256-GCM-SHA384
+-R
+-u
+-v 3
+-l ECDH-RSA-AES256-GCM-SHA384
+
+# server DTLSv1.2 PSK-AES128-GCM-SHA256
+-m
+-u
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# client DTLSv1.2 PSK-AES128-GCM-SHA256
+-R
+-u
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# server DTLSv1.2 PSK-AES256-GCM-SHA384
+-m
+-u
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# client DTLSv1.2 PSK-AES256-GCM-SHA384
+-R
+-u
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM-8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM-8
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-CCM-8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM-8
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ADH-AES128-SHA
+-m
+-u
+-a
+-v 3
+-l ADH-AES128-SHA
+
+# client DTLSv1.2 ADH-AES128-SHA
+-R
+-u
+-a
+-v 3
+-l ADH-AES128-SHA
+
+# server DTLSv1.0 ADH-AES128-SHA
+-m
+-u
+-a
+-v 2
+-l ADH-AES128-SHA
+
+# client DTLSv1.0 ADH-AES128-SHA
+-R
+-u
+-a
+-v 2
+-l ADH-AES128-SHA

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4616,7 +4616,7 @@ WOLFSSL_LOCAL void FreeHandshakeHashes(WOLFSSL* ssl);
 
 
 #ifndef WOLFSSL_NO_TLS12
-WOLFSSL_LOCAL void FreeBuildMsgArgs(BuildMsgArgs* args);
+WOLFSSL_LOCAL void FreeBuildMsgArgs(WOLFSSL* ssl, BuildMsgArgs* args);
 #endif
 WOLFSSL_LOCAL int BuildMessage(WOLFSSL* ssl, byte* output, int outSz,
                         const byte* input, int inSz, int type, int hashOutput,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4516,10 +4516,14 @@ WOLFSSL_LOCAL  int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength);
     WOLFSSL_LOCAL int  DtlsMsgPoolSend(WOLFSSL*, int);
 #endif /* WOLFSSL_DTLS */
 
-#ifndef NO_TLS
+#if defined(HAVE_SECURE_RENEGOTIATION) && defined(WOLFSSL_DTLS)
+    WOLFSSL_LOCAL int DtlsSCRKeysSet(WOLFSSL* ssl);
+    WOLFSSL_LOCAL int IsDtlsMsgSCRKeys(WOLFSSL* ssl);
+    WOLFSSL_LOCAL int DtlsUseSCRKeys(WOLFSSL* ssl);
+    WOLFSSL_LOCAL int DtlsCheckOrder(WOLFSSL* ssl, int order);
+#endif
 
-
-#endif /* NO_TLS */
+    WOLFSSL_LOCAL void WriteSEQ(WOLFSSL* ssl, int verifyOrder, byte* out);
 
 #if defined(WOLFSSL_TLS13) && (defined(HAVE_SESSION_TICKET) || !defined(NO_PSK))
     WOLFSSL_LOCAL word32 TimeNowInMilliseconds(void);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3815,6 +3815,20 @@ typedef struct HS_Hashes {
 } HS_Hashes;
 
 
+#ifndef WOLFSSL_NO_TLS12
+/* Persistable BuildMessage arguments */
+typedef struct BuildMsgArgs {
+    word32 digestSz;
+    word32 sz;
+    word32 pad;
+    word32 idx;
+    word32 headerSz;
+    word16 size;
+    word32 ivSz;      /* TLSv1.1  IV */
+    byte*  iv;
+} BuildMsgArgs;
+#endif
+
 #ifdef WOLFSSL_ASYNC_CRYPT
     #define MAX_ASYNC_ARGS 18
     typedef void (*FreeArgsCb)(struct WOLFSSL* ssl, void* pArgs);
@@ -3823,6 +3837,7 @@ typedef struct HS_Hashes {
         WC_ASYNC_DEV* dev;
         FreeArgsCb    freeArgs; /* function pointer to cleanup args */
         word32        args[MAX_ASYNC_ARGS]; /* holder for current args */
+        BuildMsgArgs  buildArgs; /* holder for current BuildMessage args */
     };
 #endif
 
@@ -4603,6 +4618,10 @@ WOLFSSL_LOCAL int SetDhExternal(WOLFSSL_DH *dh);
 WOLFSSL_LOCAL int InitHandshakeHashes(WOLFSSL* ssl);
 WOLFSSL_LOCAL void FreeHandshakeHashes(WOLFSSL* ssl);
 
+
+#ifndef WOLFSSL_NO_TLS12
+WOLFSSL_LOCAL void FreeBuildMsgArgs(BuildMsgArgs* args);
+#endif
 WOLFSSL_LOCAL int BuildMessage(WOLFSSL* ssl, byte* output, int outSz,
                         const byte* input, int inSz, int type, int hashOutput,
                         int sizeOnly, int asyncOkay, int epochOrder);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3050,7 +3050,8 @@ typedef struct Ciphers {
     byte    state;
     byte    setup;       /* have we set it up flag for detection */
 #if defined(WOLFSSL_DTLS) && defined(HAVE_SECURE_RENEGOTIATION)
-    enum CipherSrc src;
+    enum CipherSrc src;  /* DTLS uses this to determine which keys
+                          * are currently loaded */
 #endif
 } Ciphers;
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4382,10 +4382,6 @@ WOLFSSL_LOCAL int IsTLS(const WOLFSSL* ssl);
 WOLFSSL_LOCAL int IsAtLeastTLSv1_2(const WOLFSSL* ssl);
 WOLFSSL_LOCAL int IsAtLeastTLSv1_3(const ProtocolVersion pv);
 
-#if defined(WOLFSSL_DTLS) || !defined(WOLFSSL_NO_TLS12)
-WOLFSSL_LOCAL int IsInitialRenegotiationState(WOLFSSL* ssl);
-#endif /* DTLS || !WOLFSSL_NO_TLS12 */
-
 WOLFSSL_LOCAL void FreeHandshakeResources(WOLFSSL* ssl);
 WOLFSSL_LOCAL void ShrinkInputBuffer(WOLFSSL* ssl, int forcedFree);
 WOLFSSL_LOCAL void ShrinkOutputBuffer(WOLFSSL* ssl);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2431,6 +2431,7 @@ WOLFSSL_API void  wolfSSL_SetVerifyDecryptCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetVerifyDecryptCtx(WOLFSSL* ssl);
 
 WOLFSSL_API const unsigned char* wolfSSL_GetMacSecret(WOLFSSL*, int);
+WOLFSSL_API const unsigned char* wolfSSL_GetDtlsMacSecret(WOLFSSL*, int, int);
 WOLFSSL_API const unsigned char* wolfSSL_GetClientWriteKey(WOLFSSL*);
 WOLFSSL_API const unsigned char* wolfSSL_GetClientWriteIV(WOLFSSL*);
 WOLFSSL_API const unsigned char* wolfSSL_GetServerWriteKey(WOLFSSL*);


### PR DESCRIPTION
- Hash of fragmented certificate was not calculated as a single message and instead we were hashing individual fragments which produced the wrong digest, shared secret, etc...
- Reset handshake number after server Finished packet is sent or received (depending on side)
- Reserve space in buffer for cipher stuff
- Take `DTLS_RECORD_EXTRA` and  `DTLS_HANDSHAKE_EXTRA` into size and offset calculations for DTLS path
- Fix renegotiation in DTLS with AES128-SHA
- Fix renegotiation in DTLS with AES-GCM
- Support HelloVerify request during secure renegotiation
- Save renegotiation handshake messages for retransmission in timeout
- Handle cipher parameters from different epochs. DTLS may need to resend and receive messages from previous epochs so handling different sets of encryption and decryption parameters is crucial.