### PR TITLE
fix minor IAR warnings in test.c

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8573,7 +8573,7 @@ int aesgcm_test(void)
     byte resultT[sizeof(t1)];
     byte resultP[sizeof(p) + AES_BLOCK_SIZE];
     byte resultC[sizeof(p) + AES_BLOCK_SIZE];
-    int  result;
+    int  result = 0;
 #ifdef WOLFSSL_AES_256
     int  alen;
     #if !defined(WOLFSSL_AFALG_XILINX_AES) && !defined(WOLFSSL_XILINX_CRYPT)
@@ -18542,7 +18542,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
 #ifdef HAVE_ECC_KEY_EXPORT
     byte    exportBuf[MAX_ECC_BYTES * 2 + 32];
 #endif
-    word32  x;
+    word32  x = 0;
 #if defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)
     word32  y;
 #endif
@@ -20664,7 +20664,7 @@ int curve25519_test(void)
 #ifdef HAVE_CURVE25519_KEY_EXPORT
     byte    exportBuf[32];
 #endif
-    word32  x;
+    word32  x = 0;
     curve25519_key userA, userB, pubKey;
 
 #if defined(HAVE_CURVE25519_SHARED_SECRET) && \


### PR DESCRIPTION
This PR fixes three minor warnings that are showing up in the Jenkins IAR 7.3 and 8.3 builds:

```
C:\jenkins\workspace\nightly-IAR-build-only-v-7-3\wolfssl\wolfcrypt\test\test.c(8597) : Warning[Pe549]: variable "result" is used before its value is set
C:\jenkins\workspace\nightly-IAR-build-only-v-7-3\wolfssl\wolfcrypt\test\test.c(18563) : Warning[Pe549]: variable "x" is used before its value is set
C:\jenkins\workspace\nightly-IAR-build-only-v-7-3\wolfssl\wolfcrypt\test\test.c(20717) : Warning[Pe549]: variable "x" is used before its value is set
```