### PR TITLE
Fix building with openssl extra x509 small writes to heap without alloc

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10563,7 +10563,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         #endif
 
             /* allocate buffer for certs */
-        #ifdef OPENSSL_EXTRA
+        #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
             args->certs = (buffer*)XMALLOC(sizeof(buffer) *
                     (ssl->verifyDepth + 1), ssl->heap, DYNAMIC_TYPE_DER);
             if (args->certs == NULL) {


### PR DESCRIPTION
Thanks to K.G. for the report on ZD9610.

Test to reproduce issue:

```
#!/bin/sh
./autogen.sh

WOLF_FLAGS="-DMAX_CHAIN_DEPTH=3"
WOLF_FEATURES="--enable-opensslextra=x509small"

export CFLAGS="$WOLF_FLAGS"
export CC="gcc -fsanitize=address"

./configure ${WOLF_FEATURES}

make

echo ""
echo "Server started..."
echo ""

./examples/server/server -c certs/test-pathlen/chainI-assembled.pem \
                         -k certs/test-pathlen/chainI-entity-key.pem
```