### PR TITLE
Update for RSA calls to Xilsecure

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -2340,11 +2340,13 @@ exit:
 
 void bench_aesgcm(int doAsync)
 {
-#if defined(WOLFSSL_AES_128) && !defined(WOLFSSL_AFALG_XILINX_AES)
+#if defined(WOLFSSL_AES_128) && !defined(WOLFSSL_AFALG_XILINX_AES) \
+	&& !defined(WOLFSSL_XILINX_CRYPT)
     bench_aesgcm_internal(doAsync, bench_key, 16, bench_iv, 12,
                           "AES-128-GCM-enc", "AES-128-GCM-dec");
 #endif
-#if defined(WOLFSSL_AES_192) && !defined(WOLFSSL_AFALG_XILINX_AES)
+#if defined(WOLFSSL_AES_192) && !defined(WOLFSSL_AFALG_XILINX_AES) \
+	&& !defined(WOLFSSL_XILINX_CRYPT)
     bench_aesgcm_internal(doAsync, bench_key, 24, bench_iv, 12,
                           "AES-192-GCM-enc", "AES-192-GCM-dec");
 #endif

--- a/wolfcrypt/src/port/xilinx/xil-sha3.c
+++ b/wolfcrypt/src/port/xilinx/xil-sha3.c
@@ -130,13 +130,17 @@ int wc_Sha3_384_GetHash(wc_Sha3* sha, byte* out)
     if (sha == NULL || out == NULL) {
         return BAD_FUNC_ARG;
     }
+#ifdef WOLFSSL_XILINX_CRYPTO_OLD
+        if (wc_Sha3_384_Copy(sha, &s) != 0) {
+            WOLFSSL_MSG("Unable to copy SHA3 structure");
+            return MEMORY_E;
+        }
 
-    if (wc_Sha3_384_Copy(sha, &s) != 0) {
-        WOLFSSL_MSG("Unable to copy SHA3 structure");
-        return MEMORY_E;
-    }
-
-    return wc_Sha3_384_Final(&s, out);
+        return wc_Sha3_384_Final(&s, out);
+#else
+    XSecure_Sha3_ReadHash(&(sha->hw), out);
+    return 0;
+#endif
 }
 
 
@@ -151,8 +155,13 @@ int wc_Sha3_384_Copy(wc_Sha3* src, wc_Sha3* dst)
         return BAD_FUNC_ARG;
     }
 
+#ifdef WOLFSSL_XILINX_CRYPTO_OLD
     XMEMCPY((byte*)dst, (byte*)src, sizeof(wc_Sha3));
     return 0;
+#else
+    WOLFSSL_MSG("Copy of SHA3 struct not supported with this build");
+    return -1;
+#endif
 }
 
 #endif

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1851,6 +1851,7 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
                     ret = BAD_STATE_E;
                 }
             }
+            XFREE(d, key->heap, DYNAMIC_TYPE_PRIVATE_KEY);
         }
     #endif
         break;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11251,7 +11251,7 @@ static int rsa_sig_test(RsaKey* key, word32 keyLen, int modLen, WC_RNG* rng)
      *     -101 = USER_CRYPTO_ERROR
      */
     if (ret == 0)
-#elif defined(WOLFSSL_AFALG_XILINX_RSA)
+#elif defined(WOLFSSL_AFALG_XILINX_RSA) || defined(WOLFSSL_XILINX_CRYPT)
     /* blinding / rng handled with hardware acceleration */
     if (ret != 0)
 #elif defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLF_CRYPTO_CB)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -7513,10 +7513,10 @@ static int aes_cbc_test(void)
 
 int aes_test(void)
 {
-#if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_COUNTER)
+#if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_DIRECT)
     Aes enc;
     byte cipher[AES_BLOCK_SIZE * 4];
-#if defined(HAVE_AES_DECRYPT) || defined(WOLFSSL_AES_COUNTER)
+#if defined(HAVE_AES_DECRYPT) || defined(WOLFSSL_AES_COUNTER) || defined(WOLFSSL_AES_DIRECT)
     Aes dec;
     byte plain [AES_BLOCK_SIZE * 4];
 #endif


### PR DESCRIPTION
Running benchmark on zcu102 standalone bsp with these changes:

```
------------------------------------------------------------------------------
wolfSSL version 4.4.0
------------------------------------------------------------------------------
wolfCrypt Benchmark (block bytes 1024, min  sec each)
RNG                  2 MB took 1.010 seconds,    1.571 MB/s
AES-256-GCM-enc      2 MB took 1.005 seconds,    1.749 MB/s
AES-256-GCM-dec   1000 KB took 1.004 seconds,  996.016 KB/s
AES-128-ECB-enc      3 MB took 1.000 seconds,    3.435 MB/s
AES-128-ECB-dec      3 MB took 1.000 seconds,    3.336 MB/s
AES-192-ECB-enc      3 MB took 1.000 seconds,    3.182 MB/s
AES-192-ECB-dec      3 MB took 1.000 seconds,    3.097 MB/s
AES-256-ECB-enc      3 MB took 1.000 seconds,    2.964 MB/s
AES-256-ECB-dec      3 MB took 1.000 seconds,    2.890 MB/s
CHACHA               6 MB took 1.003 seconds,    6.207 MB/s
CHA-POLY             5 MB took 1.003 seconds,    4.722 MB/s
POLY1305            27 MB took 1.000 seconds,   26.685 MB/s
SHA-256              4 MB took 1.006 seconds,    3.519 MB/s
SHA-384              8 MB took 1.001 seconds,    8.244 MB/s
SHA-512              8 MB took 1.001 seconds,    8.244 MB/s
SHA3-384             9 MB took 1.001 seconds,    9.341 MB/s
HMAC-SHA256          4 MB took 1.006 seconds,    3.495 MB/s
HMAC-SHA384          8 MB took 1.002 seconds,    8.114 MB/s
HMAC-SHA512          8 MB took 1.001 seconds,    8.122 MB/s
PBKDF2             480 bytes took 1.065 seconds,  450.704 bytes/s
RSA     2048 public        768 ops took 1.000 sec, avg 1.302 ms, 768.000 ops/sec
RSA     2048 private        38 ops took 1.029 sec, avg 27.079 ms, 36.929 ops/sec
DH      2048 key gen        14 ops took 1.056 sec, avg 75.429 ms, 13.258 ops/sec
DH      2048 agree           8 ops took 1.255 sec, avg 156.875 ms, 6.375 ops/sec
ECC      256 key gen        20 ops took 1.031 sec, avg 51.550 ms, 19.399 ops/sec
ECDHE    256 agree          20 ops took 1.027 sec, avg 51.350 ms, 19.474 ops/sec
ECDSA    256 sign           20 ops took 1.044 sec, avg 52.200 ms, 19.157 ops/sec
ECDSA    256 verify         36 ops took 1.002 sec, avg 27.833 ms, 35.928 ops/sec
CURVE  25519 key gen       276 ops took 1.002 sec, avg 3.630 ms, 275.449 ops/sec
CURVE  25519 agree         280 ops took 1.002 sec, avg 3.579 ms, 279.441 ops/sec
ED     25519 key gen       746 ops took 1.000 sec, avg 1.340 ms, 746.000 ops/sec
ED     25519 sign          694 ops took 1.001 sec, avg 1.442 ms, 693.307 ops/sec
ED     25519 verify        244 ops took 1.006 sec, avg 4.123 ms, 242.545 ops/sec

```