### PR TITLE
Fix leak in SetIndividualInternal

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -44418,7 +44418,7 @@ int SetIndividualInternal(WOLFSSL_BIGNUM* bn, mp_int* mpi)
         return WOLFSSL_FATAL_ERROR;
     }
 
-    if (mpi == NULL || (mp_init(mpi) != MP_OKAY)) {
+    if (mpi == NULL) {
         WOLFSSL_MSG("mpi NULL error");
         return WOLFSSL_FATAL_ERROR;
     }


### PR DESCRIPTION
SetIndividualInternal should not do mp_init on mpi since it should have been zero'ed during allocation and if it isn't zero'ed then it must mean that memory has already been allocated to it
