### PR TITLE
Pathlen maintenance

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -12628,6 +12628,7 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
          * nine 2048-bit RSA certificates in the chain. */
         if (size > MAX_HANDSHAKE_SZ) {
             WOLFSSL_MSG("Handshake message too large");
+            WOLFSSL_MSG("MAX_CHAIN_DEPTH set below chain length will trigger");
             return HANDSHAKE_SIZE_ERROR;
         }
 
@@ -17887,7 +17888,7 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
         return "RSA Signature Fault Error";
 
     case HANDSHAKE_SIZE_ERROR:
-        return "Handshake message too large Error";
+        return "Handshake message too large or MAX_CHAIN_DEPTH too low Error";
 
     case UNKNOWN_ALPN_PROTOCOL_NAME_E:
         return "Unrecognized protocol name Error";

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -132,7 +132,8 @@ enum wolfSSL_ErrorCodes {
     DH_KEY_SIZE_E                = -401,   /* DH Key too small */
     SNI_ABSENT_ERROR             = -402,   /* No SNI request. */
     RSA_SIGN_FAULT               = -403,   /* RSA Sign fault */
-    HANDSHAKE_SIZE_ERROR         = -404,   /* Handshake message too large */
+    HANDSHAKE_SIZE_ERROR         = -404,   /* Handshake message too large or
+                                            * MAX_CHAIN_DEPTH too low */
     UNKNOWN_ALPN_PROTOCOL_NAME_E = -405,   /* Unrecognized protocol name Error*/
     BAD_CERTIFICATE_STATUS_ERROR = -406,   /* Bad certificate status message */
     OCSP_INVALID_STATUS          = -407,   /* Invalid OCSP Status */


### PR DESCRIPTION
Users configuring for testing with `CFLAGS="-DMAX_CHAIN_DEPTH=(some value lower than their chain)"` were confused by the return message:

```
wolfSSL_connect error -404, Handshake message too large Error
wolfSSL error: wolfSSL_connect failed
``` 

Will now output:

```
wolfSSL_connect error -404, Handshake message too large or MAX_CHAIN_DEPTH too low Error
wolfSSL error: wolfSSL_connect failed
```

To test use the following:

```
./configure CFLAGS="-DMAX_CHAIN_DEPTH=3"
./examples/server/server -c certs/test-pathlen/chainI-assembled.pem \
                         -k certs/test-pathlen/chainI-entity-key.pem &
./examples/client/client
wolfSSL_connect error -368, Maximum Chain Depth Exceeded
wolfSSL error: wolfSSL_connect failed
```

Now set it just one lower and you get a correct but confusing error -404, Handshake message too large, can be confusing when MAX_CHAIN_DEPTH is the only change.

```
./configure CFLAGS="-DMAX_CHAIN_DEPTH=2"
./examples/server/server -c certs/test-pathlen/chainI-assembled.pem \
                         -k certs/test-pathlen/chainI-entity-key.pem &
./examples/client/client
wolfSSL_connect error -404, Handshake message too large Error
wolfSSL error: wolfSSL_connect failed
```