### PR TITLE
Improvements around the ECC max bits calculation

### DIFF
--- a/IDE/GCC-ARM/Header/user_settings.h
+++ b/IDE/GCC-ARM/Header/user_settings.h
@@ -189,14 +189,17 @@ extern "C" {
 
     /* Use alternate ECC size for ECC math */
     #ifdef USE_FAST_MATH
+        /* MAX ECC BITS = ROUND8(MAX ECC) * 2 */
         #ifdef NO_RSA
             /* Custom fastmath size if not using RSA */
-            /* MAX = ROUND32(ECC BITS 256) + SIZE_OF_MP_DIGIT(32) */
             #undef  FP_MAX_BITS
-            #define FP_MAX_BITS     (256 + 32)
+            #define FP_MAX_BITS     (256 * 2)
         #else
             #undef  ALT_ECC_SIZE
             #define ALT_ECC_SIZE
+            /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+            //#undef  FP_MAX_BITS_ECC
+            //#define FP_MAX_BITS_ECC (256 * 2)
         #endif
 
         /* Speedups specific to curve */

--- a/IDE/IAR-EWARM/embOS/SAMV71_XULT/embOS_SAMV71_XULT_user_settings/user_settings.h
+++ b/IDE/IAR-EWARM/embOS/SAMV71_XULT/embOS_SAMV71_XULT_user_settings/user_settings.h
@@ -34,11 +34,11 @@
     #undef ECC_USER_CURVES
     #define ECC_USER_CURVES
 
-    #undef ECC_ALT_SIZE
-    #define ECC_ALT_SIZE
+    #undef ALT_ECC_SIZE
+    #define ALT_ECC_SIZE
 
     #undef FP_MAX_BITS_ECC
-    #define FP_MAX_BITS_ECC 528
+    #define FP_MAX_BITS_ECC (256 * 2)
 
     #undef TFM_TIMING_RESISTANT
     #define TFM_TIMING_RESISTANT

--- a/IDE/IAR-EWARM/embOS/SAMV71_XULT/embOS_SAMV71_XULT_user_settings/user_settings_verbose_example.h
+++ b/IDE/IAR-EWARM/embOS/SAMV71_XULT/embOS_SAMV71_XULT_user_settings/user_settings_verbose_example.h
@@ -84,11 +84,13 @@
     #define ECC_TIMING_RESISTANT
 
     #ifdef USE_FAST_MATH
-        /* Max ECC bits (curve size * 8). ECC521 is (66*8) = 528. */
         #undef  ALT_ECC_SIZE
         #define ALT_ECC_SIZE
-        #undef  FP_MAX_BITS_ECC
-        #define FP_MAX_BITS_ECC     528
+
+        /* wolfSSL will compute the FP_MAX_BITS_ECC, but it can be overriden */
+        /* MAX ECC BITS = ROUND8(MAX ECC) * 2 */
+        //#undef  FP_MAX_BITS_ECC
+        //#define FP_MAX_BITS_ECC (528 * 2)
 
         /* Enable TFM optimizations for ECC */
         #define TFM_ECC192

--- a/IDE/IAR-EWARM/embOS/custom_port/custom_port_user_settings/user_settings.h
+++ b/IDE/IAR-EWARM/embOS/custom_port/custom_port_user_settings/user_settings.h
@@ -31,11 +31,11 @@
     #undef ECC_USER_CURVES
     #define ECC_USER_CURVES
 
-    #undef ECC_ALT_SIZE
-    #define ECC_ALT_SIZE
+    #undef ALT_ECC_SIZE
+    #define ALT_ECC_SIZE
 
     #undef FP_MAX_BITS_ECC
-    #define FP_MAX_BITS_ECC 528
+    #define FP_MAX_BITS_ECC (256 * 2)
 
     #undef TFM_TIMING_RESISTANT
     #define TFM_TIMING_RESISTANT

--- a/IDE/LPCXPRESSO/lib_wolfssl/user_settings.h
+++ b/IDE/LPCXPRESSO/lib_wolfssl/user_settings.h
@@ -22,7 +22,8 @@
 
 #define FP_LUT                   4
 #define FP_MAX_BITS              2048 /* 4096 */
-#define FP_MAX_BITS_ECC          512
+#define ECC_USER_CURVES /* Disables P-112, P-128, P-160, P-192, P-224, P-384, P-521 but leaves P-256 enabled */
+#define FP_MAX_BITS_ECC          (256 * 2)
 #define ALT_ECC_SIZE
 #define USE_FAST_MATH
 #define SMALL_SESSION_CACHE
@@ -52,7 +53,6 @@
 #define NO_64BIT
 #define NO_WOLFSSL_SERVER
 #define NO_OLD_TLS
-#define ECC_USER_CURVES /* Disables P-112, P-128, P-160, P-192, P-224, P-384, P-521 but leaves P-256 enabled */
 #define NO_DES3
 #define NO_MD5
 #define NO_RC4

--- a/IDE/WICED-STUDIO/user_settings.h
+++ b/IDE/WICED-STUDIO/user_settings.h
@@ -595,7 +595,7 @@ extern unsigned int my_rng_seed_gen(void);
 #endif
 
 #if 1
-    #define FP_MAX_BITS_ECC 512
+    #define FP_MAX_BITS_ECC (256 + 32)
 #endif
 
 /* ------------------------------------------------------------------------- */

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -1485,7 +1485,7 @@ int wc_DhCheckPubKey_ex(DhKey* key, const byte* pub, word32 pubSz,
         }
         else
 #endif
-#ifdef WOLFSSL_SP_NO_4096
+#ifdef WOLFSSL_SP_4096
         if (mp_count_bits(&key->p) == 4096) {
             ret = sp_ModExp_4096(y, q, p, y);
             if (ret != 0)

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -43,7 +43,6 @@
  * WOLFSSL_SP_NO_MALLOC:        Always use stack, no heap XMALLOC/XFREE allowed
  * WOLFSSL_SP_NO_2048:          Disable RSA/DH 2048-bit support
  * WOLFSSL_SP_NO_3072:          Disable RSA/DH 3072-bit support
- * WOLFSSL_SP_NO_4096:          Disable RSA/DH 4096-bit support
  * WOLFSSL_SP_4096:             Enable RSA/RH 4096-bit support
  * WOLFSSL_SP_384               Enable ECC 384-bit SECP384R1 support
  * WOLFSSL_SP_NO_256            Disable ECC 256-bit SECP256R1 support
@@ -1659,7 +1658,7 @@ int sp_exptmod(sp_int* b, sp_int* e, sp_int* m, sp_int* r)
         }
         else
 #endif
-#ifdef WOLFSSL_SP_NO_4096
+#ifdef WOLFSSL_SP_4096
         if ((mBits == 4096) && sp_isodd(m) && (bBits <= 4096) &&
             (eBits <= 4096)) {
             err = sp_ModExp_4096(b, e, m, r);


### PR DESCRIPTION
* Improvements to the ECC max bits calculation (`FP_MAX_BITS_ECC`) used with fast math and alternate ECC size (`USE_FAST_MATH` and `ALT_ECC_SIZE`).
* Updated example code comments to reflect accurate ECC max bits calculation.
* Fix to correct SP 4096-bit enable. Replaces nonexistent `WOLFSSL_SP_NO_4096` with `WOLFSSL_SP_4096`.

ZD 10343