### PR TITLE
Fix a seg fault when cert not loaded prior to key check

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6798,7 +6798,7 @@ int wolfSSL_CTX_check_private_key(const WOLFSSL_CTX* ctx)
 
     WOLFSSL_ENTER("wolfSSL_CTX_check_private_key");
 
-    if (ctx == NULL) {
+    if (ctx == NULL || ctx->certificate == NULL) {
         return WOLFSSL_FAILURE;
     }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -20637,8 +20637,12 @@ static void test_wolfSSL_private_keys(void)
     #else
     AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_client_method()));
     #endif
-    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCertFile, WOLFSSL_FILETYPE_PEM));
     AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, WOLFSSL_FILETYPE_PEM));
+    /* Have to load a cert before you can check the private key against that
+     * certificates public key! */
+    AssertIntEQ(wolfSSL_CTX_check_private_key(ctx), WOLFSSL_FAILURE);
+    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCertFile, WOLFSSL_FILETYPE_PEM));
+    AssertIntEQ(wolfSSL_CTX_check_private_key(ctx), WOLFSSL_SUCCESS);
     AssertNotNull(ssl = SSL_new(ctx));
 
     AssertIntEQ(wolfSSL_check_private_key(ssl), WOLFSSL_SUCCESS);


### PR DESCRIPTION
If users were call `wolfSSL_CTX_use_PrivateKey_file()` and then call `wolfSSL_CTX_check_private_key()` without first loading a cert they would experience a NULL dereference.

Added a test case to check this and added a sanity check on the certificate in `wolfSSL_CTX_check_private_key()`.