### PR TITLE
fix for gcc 10+ error on snprintf

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -34639,7 +34639,8 @@ int wolfSSL_RSA_print(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa, int offset)
     RsaKey* iRsa = NULL;
     int i = 0;
     mp_int *rsaElem = NULL;
-    char rsaStr[][20] = { "Modulus:",
+    const char *rsaStr[] = {
+                          "Modulus:",
                           "PublicExponent:",
                           "PrivateExponent:",
                           "Prime1:",


### PR DESCRIPTION
https://github.com/wolfSSL/wolfssl/issues/2999

Fixes compiler error

```
make[1]: Entering directory '/home/boz-amd/Documents/Jacob/wolfssl'
  CC       src/src_libwolfssl_la-ssl.lo
src/ssl.c: In function ‘wolfSSL_RSA_print’:
src/ssl.c:34735:48: error: ‘%s’ directive output may be truncated writing up to 159 bytes into a region of size 98 [-Werror=format-truncation=]
34735 |             XSNPRINTF(tmp, sizeof(tmp) - 1, "\n%s\n    ", rsaStr[i]);
      |                                                ^~
In file included from ./wolfssl/internal.h:28,
                 from src/ssl.c:41:
./wolfssl/wolfcrypt/types.h:492:31: note: ‘snprintf’ output between 7 and 166 bytes into a destination of size 99
  492 |             #define XSNPRINTF snprintf
src/ssl.c:34735:13: note: in expansion of macro ‘XSNPRINTF’
34735 |             XSNPRINTF(tmp, sizeof(tmp) - 1, "\n%s\n    ", rsaStr[i]);
      |             ^~~~~~~~~
cc1: all warnings being treated as errors
Makefile:4829: recipe for target 'src/src_libwolfssl_la-ssl.lo' failed
```

with gcc 10+ and --enable-all