### PR TITLE
Define to allow badly formed ASN integers

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -460,8 +460,10 @@ static int GetASNInt(const byte* input, word32* inOutIdx, int* len,
             (*inOutIdx)++;
             (*len)--;
 
+#ifndef WOLFSSL_ASN_INT_LEAD_0_ANY
             if (*len > 0 && (input[*inOutIdx] & 0x80) == 0)
                 return ASN_PARSE_E;
+#endif
         }
     }
 


### PR DESCRIPTION
Define: WOLFSSL_ASN_INT_LEAD_0_ANY
Allows positive integers to have a leading 0 byte.
DER/BER encoding specifies that leding 0 only on negative numbers
(highest bit of first octet set).