### PR TITLE
Fixes for using static memory with no malloc

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8876,7 +8876,7 @@ int aesgcm_test(void)
         WC_RNG rng;
         byte randIV[12];
 
-        result = wc_InitRng(&rng);
+        result = wc_InitRng_ex(&rng, HEAP_HINT, devId);
         if (result != 0)
             return -6135;
 


### PR DESCRIPTION
* Fix for using static memory AES GCM test.
* Fix for using signature wrapper with `WOLFSSL_NO_MALLOC`. Improve `wc_SignatureVerifyHash` to use RSA verify inline.
* Fix for TFM `_fp_exptmod_nct` with `WOLFSSL_NO_MALLOC`.