### PR TITLE
fix build failrue on esp-idf

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -33,11 +33,10 @@
 #elif defined(WOLFCRYPT_ONLY)
 #else
 
+#if defined(OPENSSL_EXTRA)
 
 #include <wolfssl/openssl/ecdsa.h>
 #include <wolfssl/openssl/evp.h>
-
-#if defined(OPENSSL_EXTRA)
 
 #ifndef NO_AES
     #ifdef HAVE_AES_CBC


### PR DESCRIPTION
includes evp.h and ecdsa.h only when OPENSSL_EXTRA is enabled. 