### PR TITLE
TLS 1.3: Never send CertiifcateRequest when PSK

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3711,6 +3711,8 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
 
             /* Default to ciphersuite if cb doesn't specify. */
             ssl->options.resuming = 0;
+            /* Don't send certificate request when using PSK. */
+            ssl->options.verifyPeer = 0;
 
             /* PSK age is always zero. */
             if (current->ticketAge != ssl->session.ticketAdd)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1515,7 +1515,7 @@ enum Misc {
 
 /* number of items in the signature algo list */
 #ifndef WOLFSSL_MAX_SIGALGO
-    #define WOLFSSL_MAX_SIGALGO 32
+    #define WOLFSSL_MAX_SIGALGO 36
 #endif
 
 


### PR DESCRIPTION
Server must not send a CertificateRequest when authenticating with a
PSK.
Increase the max size of the signature algorithms as ED448 has been
added.