### PR TITLE
enable SNI by default for JNI/JSSE build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3515,6 +3515,11 @@ then
         ENABLED_CERTGEN="yes"
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_CERT_GEN"
     fi
+    if test "x$ENABLED_SNI" = "xno"
+    then
+        ENABLED_SNI="yes"
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_TLS_EXTENSIONS -DHAVE_SNI"
+    fi
 fi
 
 # lighty Support


### PR DESCRIPTION
This PR enables SNI by default on JNI/JSSE builds (--enable-jni).