### PR TITLE
Fix warnings with NetBSD gcc compiler

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -22551,7 +22551,7 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(WOLFSSL_X509_STORE_CTX* ctx)
 WOLFSSL_STACK* wolfSSL_sk_X509_dup(WOLFSSL_STACK* sk)
 {
     unsigned long i;
-    WOLFSSL_STACK* dup = NULL;
+    WOLFSSL_STACK* copy = NULL;
     WOLFSSL_STACK* node = NULL;
     WOLFSSL_STACK *dIdx = NULL, *sIdx = sk;
 
@@ -22565,7 +22565,7 @@ WOLFSSL_STACK* wolfSSL_sk_X509_dup(WOLFSSL_STACK* sk)
                                          DYNAMIC_TYPE_X509);
         if (node == NULL) {
             if (i != 0) {
-                wolfSSL_sk_free(dup);
+                wolfSSL_sk_free(copy);
             }
             WOLFSSL_MSG("Memory error");
             return NULL;
@@ -22578,7 +22578,7 @@ WOLFSSL_STACK* wolfSSL_sk_X509_dup(WOLFSSL_STACK* sk)
 
         /* insert node into list, progress idx */
         if (i == 0) {
-            dup = node;
+            copy = node;
         } else {
             dIdx->next = node;
         }
@@ -22587,7 +22587,7 @@ WOLFSSL_STACK* wolfSSL_sk_X509_dup(WOLFSSL_STACK* sk)
         sIdx = sIdx->next;
     }
 
-    return dup;
+    return copy;
 }
 
 
@@ -22597,7 +22597,7 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get1_chain(WOLFSSL_X509_STORE_CTX* ctx)
 {
     unsigned long i;
     WOLFSSL_STACK* ref;
-    WOLFSSL_STACK* dup;
+    WOLFSSL_STACK* copy;
 
     if (ctx == NULL) {
         return NULL;
@@ -22610,14 +22610,14 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get1_chain(WOLFSSL_X509_STORE_CTX* ctx)
     }
 
     /* create duplicate of ctx chain */
-    dup = wolfSSL_sk_X509_dup(ref);
-    if (dup == NULL) {
+    copy = wolfSSL_sk_X509_dup(ref);
+    if (copy == NULL) {
         return NULL;
     }
 
     /* increase ref counts of inner data X509 */
-    ref = dup;
-    for (i = 0; i < dup->num && ref != NULL; i++) {
+    ref = copy;
+    for (i = 0; i < copy->num && ref != NULL; i++) {
         if (wc_LockMutex(&ref->data.x509->refMutex) != 0) {
             WOLFSSL_MSG("Failed to lock x509 mutex");
         }
@@ -22626,7 +22626,7 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get1_chain(WOLFSSL_X509_STORE_CTX* ctx)
         ref = ref->next;
     }
 
-    return dup;
+    return copy;
 }
 
 
@@ -23530,34 +23530,34 @@ void wolfSSL_ASN1_INTEGER_free(WOLFSSL_ASN1_INTEGER* in)
  */
 WOLFSSL_ASN1_INTEGER* wolfSSL_ASN1_INTEGER_dup(const WOLFSSL_ASN1_INTEGER* src)
 {
-    WOLFSSL_ASN1_INTEGER* dup;
+    WOLFSSL_ASN1_INTEGER* copy;
     WOLFSSL_ENTER("wolfSSL_ASN1_INTEGER_dup");
     if (!src)
         return NULL;
 
-    dup = wolfSSL_ASN1_INTEGER_new();
+    copy = wolfSSL_ASN1_INTEGER_new();
 
-    if (dup == NULL)
+    if (copy == NULL)
         return NULL;
 
-    dup->negative  = src->negative;
-    dup->dataMax   = src->dataMax;
-    dup->isDynamic = src->isDynamic;
+    copy->negative  = src->negative;
+    copy->dataMax   = src->dataMax;
+    copy->isDynamic = src->isDynamic;
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
-    dup->length    = src->length;
+    copy->length    = src->length;
 #endif
-    XSTRNCPY((char*)dup->intData,(const char*)src->intData,WOLFSSL_ASN1_INTEGER_MAX);
+    XSTRNCPY((char*)copy->intData,(const char*)src->intData,WOLFSSL_ASN1_INTEGER_MAX);
 
-    if (dup->isDynamic && src->data && dup->dataMax) {
-        dup->data = (unsigned char*)
+    if (copy->isDynamic && src->data && copy->dataMax) {
+        copy->data = (unsigned char*)
             XMALLOC(src->dataMax,NULL,DYNAMIC_TYPE_OPENSSL);
-        if (dup->data == NULL) {
-            wolfSSL_ASN1_INTEGER_free(dup);
+        if (copy->data == NULL) {
+            wolfSSL_ASN1_INTEGER_free(copy);
             return NULL;
         }
-        XMEMCPY(dup->data,src->data,dup->dataMax);
+        XMEMCPY(copy->data, src->data, copy->dataMax);
     }
-    return dup;
+    return copy;
 }
 
 
@@ -36260,7 +36260,7 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
        Returns a new WOLFSSL_X509_NAME structure or NULL on failure */
     WOLFSSL_X509_NAME* wolfSSL_X509_NAME_dup(WOLFSSL_X509_NAME *name)
     {
-        WOLFSSL_X509_NAME* dup = NULL;
+        WOLFSSL_X509_NAME* copy = NULL;
 
         WOLFSSL_ENTER("wolfSSL_X509_NAME_dup");
 
@@ -36269,50 +36269,50 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
             return NULL;
         }
 
-        if (!(dup = wolfSSL_X509_NAME_new())) {
+        if (!(copy = wolfSSL_X509_NAME_new())) {
             return NULL;
         }
 
         /* copy contents */
-        XMEMCPY(dup, name, sizeof(WOLFSSL_X509_NAME));
-        InitX509Name(dup, 1);
-        dup->sz = name->sz;
+        XMEMCPY(copy, name, sizeof(WOLFSSL_X509_NAME));
+        InitX509Name(copy, 1);
+        copy->sz = name->sz;
 
         /* handle dynamic portions */
         if (name->dynamicName) {
-            if (!(dup->name = (char*)XMALLOC(name->sz, 0,
+            if (!(copy->name = (char*)XMALLOC(name->sz, 0,
                                              DYNAMIC_TYPE_OPENSSL))) {
                 goto err;
             }
         }
-        XMEMCPY(dup->name, name->name, name->sz);
+        XMEMCPY(copy->name, name->name, name->sz);
     #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
         !defined(NO_ASN)
-        if (!(dup->fullName.fullName = (char*)XMALLOC(name->fullName.fullNameLen,
+        if (!(copy->fullName.fullName = (char*)XMALLOC(name->fullName.fullNameLen,
                                                    0, DYNAMIC_TYPE_OPENSSL))) {
             goto err;
         }
-        XMEMCPY(dup->fullName.fullName, name->fullName.fullName,
+        XMEMCPY(copy->fullName.fullName, name->fullName.fullName,
             name->fullName.fullNameLen);
     #endif
 
-        return dup;
+        return copy;
 
     err:
-        if (dup) {
-            if (dup->dynamicName && dup->name) {
-                XFREE(dup->name, 0, DYNAMIC_TYPE_OPENSSL);
-                dup->name = NULL;
+        if (copy) {
+            if (copy->dynamicName && copy->name) {
+                XFREE(copy->name, 0, DYNAMIC_TYPE_OPENSSL);
+                copy->name = NULL;
             }
         #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
             !defined(NO_ASN)
-            if (dup->fullName.fullName &&
-                dup->fullName.fullName != name->fullName.fullName) {
-                XFREE(dup->fullName.fullName, 0, DYNAMIC_TYPE_OPENSSL);
-                dup->fullName.fullName = NULL;
+            if (copy->fullName.fullName &&
+                copy->fullName.fullName != name->fullName.fullName) {
+                XFREE(copy->fullName.fullName, 0, DYNAMIC_TYPE_OPENSSL);
+                copy->fullName.fullName = NULL;
             }
         #endif
-            wolfSSL_X509_NAME_free(dup);
+            wolfSSL_X509_NAME_free(copy);
         }
         return NULL;
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -31034,16 +31034,16 @@ static void test_wolfSSL_ASN1_INTEGER_set()
     wolfSSL_ASN1_INTEGER_free(a);
 
 #ifndef TIME_T_NOT_64BIT
-    /* 2147483648 */
+    /* int max (2147483647) */
     a = wolfSSL_ASN1_INTEGER_new();
-    val = 2147483648;
+    val = 2147483647;
     ret = ASN1_INTEGER_set(a, val);
     AssertIntEQ(ret, 1);
     wolfSSL_ASN1_INTEGER_free(a);
 
-    /* -2147483648 */
+    /* int min (-2147483648) */
     a = wolfSSL_ASN1_INTEGER_new();
-    val = -2147483648;
+    val = -2147483647 - 1;
     ret = ASN1_INTEGER_set(a, val);
     AssertIntEQ(a->negative, 1);
     AssertIntEQ(ret, 1);

--- a/tests/api.c
+++ b/tests/api.c
@@ -4869,16 +4869,21 @@ static void test_wolfSSL_PKCS12(void)
 
 #if !defined(NO_FILESYSTEM) && !defined(NO_ASN) && defined(HAVE_PKCS8) \
     && defined(HAVE_ECC) && defined(WOLFSSL_ENCRYPTED_KEYS)
+
+/* used to keep track if FailTestCallback was called */
+static int failTestCallbackCalled = 0;
+
 static WC_INLINE int FailTestCallBack(char* passwd, int sz, int rw, void* userdata)
 {
     (void)passwd;
     (void)sz;
     (void)rw;
     (void)userdata;
-    Fail(("Password callback should not be called by default"),
-            ("Password callback was called without attempting "
-             "to first decipher private key without password."));
-    return 0;
+
+    /* mark called, test_wolfSSL_no_password_cb() will check and fail if set */
+    failTestCallbackCalled = 1;
+
+    return -1;
 }
 #endif
 
@@ -4917,6 +4922,12 @@ static void test_wolfSSL_no_password_cb(void)
                 WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
 
     wolfSSL_CTX_free(ctx);
+
+    if (failTestCallbackCalled != 0) {
+        Fail(("Password callback should not be called by default"),
+            ("Password callback was called without attempting "
+             "to first decipher private key without password."));
+}
 
     printf(resultFmt, passed);
 #endif


### PR DESCRIPTION
This PR fixes warnings on NetBSD with the "i486--netbsdelf-gcc (NetBSD nb2 20111202) 4.5.3" compiler, specifically:

1.  Variable "dup" shadowing a global declaration.  This PR changes the "dup" variable to "copy" in mentioned functions:

```
src/ssl.c: In function 'wolfSSL_sk_X509_dup':
src/ssl.c:22554:20: warning: declaration of 'dup' shadows a global declaration
src/ssl.c: In function 'wolfSSL_X509_STORE_CTX_get1_chain':
src/ssl.c:22600:20: warning: declaration of 'dup' shadows a global declaration
src/ssl.c: In function 'wolfSSL_ASN1_INTEGER_dup':
src/ssl.c:23533:27: warning: declaration of 'dup' shadows a global declaration
src/ssl.c: In function 'wolfSSL_X509_NAME_dup':
src/ssl.c:36263:28: warning: declaration of 'dup' shadows a global declaration
```

2.  Decimal value unsigned only in ISO C90 warnings from tests/api.c:

```
tests/api.c: In function 'test_wolfSSL_ASN1_INTEGER_set':
tests/api.c:31039:5: warning: this decimal constant is unsigned only in ISO C90
tests/api.c:31046:5: warning: this decimal constant is unsigned only in ISO C90
```

3.  Allow tests/api.c FailTestCallBack to correctly return a value:

```
tests/api.c: In function 'FailTestCallBack':
tests/api.c:4872:22: warning: function might be possible candidate for attribute 'noreturn'
```