### PR TITLE
Cypress PSoC6 wolfcrypt driver

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -141,6 +141,10 @@ ECC Curve Sizes:
     #include <wolfssl/wolfcrypt/port/st/stm32.h>
 #endif
 
+#if defined(WOLFSSL_PSOC6_CRYPTO)
+    #include <wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h>
+#endif
+
 #ifdef WOLFSSL_SP_MATH
     #define GEN_MEM_ERR MP_MEM
 #elif defined(USE_FAST_MATH)
@@ -5845,6 +5849,10 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 #if defined(WOLFSSL_STM32_PKA)
 {
     return stm32_ecc_verify_hash_ex(r, s, hash, hashlen, res, key);
+}
+#elif defined(WOLFSSL_PSOC6_CRYPTO)
+{
+    return psoc6_ecc_verify_hash_ex(r, s, hash, hashlen, res, key);
 }
 #else
 {

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -85,7 +85,8 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/Renesas/renesas_tsip_aes.c \
               wolfcrypt/src/port/Renesas/renesas_tsip_sha.c \
               wolfcrypt/src/port/Renesas/renesas_tsip_util.c \
-              wolfcrypt/src/port/Renesas/README.md
+              wolfcrypt/src/port/Renesas/README.md \
+              wolfcrypt/src/port/cypress/psoc6_crypto.c
 
 
 if BUILD_CRYPTOCB

--- a/wolfcrypt/src/port/cypress/psoc6_crypto.c
+++ b/wolfcrypt/src/port/cypress/psoc6_crypto.c
@@ -1,0 +1,107 @@
+/* psoc6_crypto.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+
+#if defined(WOLFSSL_PSOC6_CRYPTO)
+
+#include <wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h>
+#include <wolfssl/wolfcrypt/random.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/logging.h>
+#include <stdint.h>
+
+static CRYPTO_Type *crypto_base = PSOC6_CRYPTO_BASE;
+
+/* Hook for device specific initialization */
+int psoc6_crypto_port_init(void)
+{
+    Cy_Crypto_Core_Enable(crypto_base);
+    return 0;
+}
+
+#ifndef NO_SHA256
+
+int wc_InitSha256(wc_Sha256* sha)
+{
+    cy_en_crypto_status_t res;
+    if (!sha)
+        return BAD_FUNC_ARG;
+    Cy_Crypto_Core_MemSet(crypto_base, sha, 0, sizeof(sha));
+    res = Cy_Crypto_Core_Sha_Init(crypto_base, &sha->hash_state, CY_CRYPTO_MODE_SHA256, &sha->sha_buffers);
+    if (res != CY_CRYPTO_SUCCESS)
+       return (int)res;
+    return (int) Cy_Crypto_Core_Sha_Start(crypto_base, &sha->hash_state);
+}
+
+int wc_Sha256Update(wc_Sha256* sha, const byte* in, word32 sz)
+{
+    if ((!sha) || (!in))
+        return BAD_FUNC_ARG;
+    if (sz == 0)
+        return 0;
+
+    return (int)Cy_Crypto_Core_Sha_Update(crypto_base, &sha->hash_state, in, sz);
+}
+
+int wc_Sha256Final(wc_Sha256* sha, byte* hash)
+{
+    if ((!sha) || (!hash))
+        return BAD_FUNC_ARG;
+    return (int)Cy_Crypto_Core_Sha_Finish(crypto_base, &sha->hash_state, hash);
+}
+
+int wc_Sha256GetHash(wc_Sha256* sha, byte* hash)
+{
+    if ((!sha) || (!hash))
+        return BAD_FUNC_ARG;
+    Cy_Crypto_Core_MemCpy(crypto_base, hash, sha->hash_state.hash, WC_SHA256_DIGEST_SIZE);
+    return 0;
+}
+
+int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
+{
+    cy_en_crypto_status_t res;
+    if ((!dst) || (!src))
+        return BAD_FUNC_ARG;
+    Cy_Crypto_Core_MemCpy(crypto_base, dst, src, sizeof(wc_Sha256));
+    return (int)Cy_Crypto_Core_Sha_Init(crypto_base, &dst->hash_state, CY_CRYPTO_MODE_SHA256, &dst->sha_buffers);
+}
+
+void wc_Sha256Free(wc_Sha256* sha)
+{
+    if (sha)
+        Cy_Crypto_Core_Sha_Free(crypto_base, &sha->hash_state);
+}
+#endif /* NO_SHA256 */
+
+#endif /* defined(WOLFSSL_PSOC6_CRYPTO) */
+

--- a/wolfcrypt/src/port/cypress/psoc6_crypto.c
+++ b/wolfcrypt/src/port/cypress/psoc6_crypto.c
@@ -48,7 +48,63 @@ int psoc6_crypto_port_init(void)
     return 0;
 }
 
+#ifdef WOLFSSL_SHA512
+int wc_InitSha512(wc_Sha512* sha)
+{
+    cy_en_crypto_status_t res;
+    if (!sha)
+        return BAD_FUNC_ARG;
+    Cy_Crypto_Core_MemSet(crypto_base, sha, 0, sizeof(sha));
+    res = Cy_Crypto_Core_Sha_Init(crypto_base, &sha->hash_state, CY_CRYPTO_MODE_SHA512, &sha->sha_buffers);
+    if (res != CY_CRYPTO_SUCCESS)
+       return (int)res;
+    return (int) Cy_Crypto_Core_Sha_Start(crypto_base, &sha->hash_state);
+}
+
+int wc_Sha512Update(wc_Sha512* sha, const byte* in, word32 sz)
+{
+    if ((!sha) || (!in))
+        return BAD_FUNC_ARG;
+    if (sz == 0)
+        return 0;
+
+    return (int)Cy_Crypto_Core_Sha_Update(crypto_base, &sha->hash_state, in, sz);
+}
+
+int wc_Sha512Final(wc_Sha512* sha, byte* hash)
+{
+    if ((!sha) || (!hash))
+        return BAD_FUNC_ARG;
+    return (int)Cy_Crypto_Core_Sha_Finish(crypto_base, &sha->hash_state, hash);
+}
+
+int wc_Sha512GetHash(wc_Sha512* sha, byte* hash)
+{
+    if ((!sha) || (!hash))
+        return BAD_FUNC_ARG;
+    Cy_Crypto_Core_MemCpy(crypto_base, hash, sha->hash_state.hash, WC_SHA512_DIGEST_SIZE);
+    return 0;
+}
+
+int wc_Sha512Copy(wc_Sha512* src, wc_Sha512* dst)
+{
+    cy_en_crypto_status_t res;
+    if ((!dst) || (!src))
+        return BAD_FUNC_ARG;
+    Cy_Crypto_Core_MemCpy(crypto_base, dst, src, sizeof(wc_Sha512));
+    return (int)Cy_Crypto_Core_Sha_Init(crypto_base, &dst->hash_state, CY_CRYPTO_MODE_SHA512, &dst->sha_buffers);
+}
+
+void wc_Sha512Free(wc_Sha512* sha)
+{
+    if (sha)
+        Cy_Crypto_Core_Sha_Free(crypto_base, &sha->hash_state);
+}
+
+#endif
+
 #ifndef NO_SHA256
+
 
 int wc_InitSha256(wc_Sha256* sha)
 {

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -119,6 +119,10 @@
     /* #include <wolfcrypt/src/port/ti/ti-hash.c> included by wc_port.c */
 #elif defined(WOLFSSL_CRYPTOCELL)
     /* wc_port.c includes wolfcrypt/src/port/arm/cryptoCellHash.c */
+
+#elif defined(WOLFSSL_PSOC6_CRYPTO)
+
+
 #else
 
 #include <wolfssl/wolfcrypt/logging.h>
@@ -164,7 +168,8 @@
     (!defined(WOLFSSL_IMX6_CAAM) || defined(NO_IMX6_CAAM_HASH)) && \
     !defined(WOLFSSL_AFALG_HASH) && !defined(WOLFSSL_DEVCRYPTO_HASH) && \
     (!defined(WOLFSSL_ESP32WROOM32_CRYPT) || defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)) && \
-    (!defined(WOLFSSL_RENESAS_TSIP_CRYPT) || defined(NO_WOLFSSL_RENESAS_TSIP_HASH))
+    (!defined(WOLFSSL_RENESAS_TSIP_CRYPT) || defined(NO_WOLFSSL_RENESAS_TSIP_HASH)) && \
+    !defined(WOLFSSL_PSOC6_CRYPTO)
 
 static int InitSha256(wc_Sha256* sha256)
 {
@@ -662,6 +667,10 @@ static int InitSha256(wc_Sha256* sha256)
     !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
 
     /* implemented in wolfcrypt/src/port/Renesas/renesas_tsip_sha.c */
+
+#elif defined(WOLFSSL_PSOC6_CRYPTO)
+
+    /* implemented in wolfcrypt/src/port/cypress/psoc6_crypto.c */
 
 #else
     #define NEED_SOFT_SHA256
@@ -1559,6 +1568,8 @@ void wc_Sha256Free(wc_Sha256* sha256)
     !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
 
     /* implemented in wolfcrypt/src/port/Renesas/renesas_tsip_sha.c */
+#elif defined(WOLFSSL_PSOC6_CRYPTO)
+    /* implemented in wolfcrypt/src/port/cypress/psoc6_crypto.c */
 #else
 
 int wc_Sha256GetHash(wc_Sha256* sha256, byte* hash)

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -26,7 +26,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#if (defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)) && !defined(WOLFSSL_ARMASM)
+#if (defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)) && !defined(WOLFSSL_ARMASM) && !defined(WOLFSSL_PSOC6_CRYPTO)
 
 #if defined(HAVE_FIPS) && \
 	defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -46,6 +46,10 @@
     #include <wolfssl/wolfcrypt/port/nxp/ksdk_port.h>
 #endif
 
+#ifdef WOLFSSL_PSOC6_CRYPTO
+    #include <wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h>
+#endif
+
 #if defined(WOLFSSL_ATMEL) || defined(WOLFSSL_ATECC508A) || \
     defined(WOLFSSL_ATECC608A)
     #include <wolfssl/wolfcrypt/port/atmel/atmel.h>
@@ -199,6 +203,14 @@ int wolfCrypt_Init(void)
     #endif
     #if defined(WOLFSSL_STSAFEA100)
         stsafe_interface_init();
+    #endif
+
+    #if defined(WOLFSSL_PSOC6_CRYPTO)
+        ret = psoc6_crypto_port_init();
+        if (ret != 0) {
+            WOLFSSL_MSG("PSoC6 crypto engine init failed");
+            return ret;
+        }
     #endif
 
     #ifdef WOLFSSL_ARMASM

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -82,7 +82,8 @@ noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/st/stsafe.h \
                          wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h \
                          wolfssl/wolfcrypt/port/arm/cryptoCell.h \
-                         wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h
+                         wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h \
+                         wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
 
 if BUILD_CRYPTOAUTHLIB
 nobase_include_HEADERS+= wolfssl/wolfcrypt/port/atmel/atmel.h

--- a/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
+++ b/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
@@ -36,9 +36,19 @@
 #include "cy_crypto_common.h"
 #include "cy_crypto_core.h"
 
+#ifdef WOLFSSL_SHA512
+typedef struct wc_Sha512 {
+    cy_stc_crypto_sha_state_t hash_state;
+    cy_en_crypto_sha_mode_t sha_mode;
+    cy_stc_crypto_v2_sha512_buffers_t sha_buffers;
+} wc_Sha512;
+
+#define WC_SHA512_TYPE_DEFINED
+#include <wolfssl/wolfcrypt/sha512.h>
+#endif
+
 #ifndef NO_SHA256
 
-#include "cy_crypto_core_sha.h"
 typedef struct wc_Sha256 {
     cy_stc_crypto_sha_state_t hash_state;
     cy_en_crypto_sha_mode_t sha_mode;

--- a/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
+++ b/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
@@ -1,0 +1,59 @@
+/* psoc6_crypto.h
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef _PSOC6_CRYPTO_PORT_H_
+#define _PSOC6_CRYPTO_PORT_H_
+
+#include <wolfssl/wolfcrypt/settings.h>
+#ifdef USE_FAST_MATH
+    #include <wolfssl/wolfcrypt/tfm.h>
+#elif defined WOLFSSL_SP_MATH
+    #include <wolfssl/wolfcrypt/sp_int.h>
+#else
+    #include <wolfssl/wolfcrypt/integer.h>
+#endif
+#include "cy_crypto_core_sha.h"
+#include "cy_device_headers.h"
+#include "psoc6_02_config.h"
+#include "cy_crypto_common.h"
+#include "cy_crypto_core.h"
+
+#ifndef NO_SHA256
+
+#include "cy_crypto_core_sha.h"
+typedef struct wc_Sha256 {
+    cy_stc_crypto_sha_state_t hash_state;
+    cy_en_crypto_sha_mode_t sha_mode;
+    cy_stc_crypto_v2_sha256_buffers_t sha_buffers;
+} wc_Sha256;
+
+
+#endif /* !def NO_SHA256 */
+
+#include <wolfssl/wolfcrypt/sha.h>
+#include <wolfssl/wolfcrypt/sha256.h>
+
+#define PSOC6_CRYPTO_BASE ((CRYPTO_Type*) CRYPTO_BASE)
+
+/* Crypto HW engine initialization */
+int psoc6_crypto_port_init(void);
+
+#endif /* _PSOC6_CRYPTO_PORT_H_ */

--- a/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
+++ b/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
@@ -55,11 +55,16 @@ typedef struct wc_Sha256 {
     cy_stc_crypto_v2_sha256_buffers_t sha_buffers;
 } wc_Sha256;
 
-
-#endif /* !def NO_SHA256 */
-
 #include <wolfssl/wolfcrypt/sha.h>
 #include <wolfssl/wolfcrypt/sha256.h>
+#endif /* !def NO_SHA256 */
+
+
+#ifdef HAVE_ECC
+#include <wolfssl/wolfcrypt/ecc.h>
+int psoc6_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
+                    word32 hashlen, int* verif_res, ecc_key* key);
+#endif /* HAVE_ECC */
 
 #define PSOC6_CRYPTO_BASE ((CRYPTO_Type*) CRYPTO_BASE)
 

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -101,6 +101,8 @@ enum {
 #elif defined(WOLFSSL_RENESAS_TSIP_CRYPT) && \
    !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
     #include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
+#elif defined(WOLFSSL_PSOC6_CRYPTO)
+    #include "wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h"
 #else
 
 /* Sha digest */

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -126,6 +126,8 @@ enum {
 #elif defined(WOLFSSL_RENESAS_TSIP_CRYPT) && \
    !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
     #include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
+#elif defined(WOLFSSL_PSOC6_CRYPTO)
+    #include "wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h"
 #else
 
 /* wc_Sha256 digest */

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -31,6 +31,7 @@
 
 #if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 
+
 #if defined(HAVE_FIPS) && \
     defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
     #include <wolfssl/wolfcrypt/fips.h>
@@ -111,6 +112,8 @@ enum {
 
 #ifdef WOLFSSL_IMX6_CAAM
     #include "wolfssl/wolfcrypt/port/caam/wolfcaam_sha.h"
+#elif defined (WOLFSSL_PSOC6_CRYPTO)
+    #include "wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h"
 #else
 /* wc_Sha512 digest */
 struct wc_Sha512 {
@@ -152,6 +155,7 @@ WOLFSSL_LOCAL void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data,
 #endif
 
 #ifdef WOLFSSL_SHA512
+
 
 WOLFSSL_API int wc_InitSha512(wc_Sha512*);
 WOLFSSL_API int wc_InitSha512_ex(wc_Sha512*, void*, int);


### PR DESCRIPTION
- support for SHA HW acceleration (SHA256 and SHA512)
- support for ECDSA verification (ECC192 to ECC521)

Tested using wolfBoot.