### PR TITLE
Fix changelog error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -128,7 +128,6 @@ Release 4.4.0 of wolfSSL embedded TLS has bug fixes and new features including:
 * Smaller table version of AES encrypt/decrypt.
 * Support IAR with position independent code (ROPI).
 * Improve speed of AArch64 assembly.
-* Support AES-CTR with AES-NI.
 * Support AES-CTR on esp32.
 * Add a no malloc option for small SP math.
 

--- a/README
+++ b/README
@@ -173,7 +173,6 @@ Release 4.4.0 of wolfSSL embedded TLS has bug fixes and new features including:
 * Smaller table version of AES encrypt/decrypt.
 * Support IAR with position independent code (ROPI).
 * Improve speed of AArch64 assembly.
-* Support AES-CTR with AES-NI.
 * Support AES-CTR on esp32.
 * Add a no malloc option for small SP math.
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ Release 4.4.0 of wolfSSL embedded TLS has bug fixes and new features including:
 * Smaller table version of AES encrypt/decrypt.
 * Support IAR with position independent code (ROPI).
 * Improve speed of AArch64 assembly.
-* Support AES-CTR with AES-NI.
 * Support AES-CTR on esp32.
 * Add a no malloc option for small SP math.
 


### PR DESCRIPTION
Fix error in the changelog. AES-NI support for AES-CCM was added, not AES-CTR.