### PR TITLE
Unused var error

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -42972,8 +42972,10 @@ WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl)
 {
     WOLF_STACK_OF(WOLFSSL_CIPHER)* ret = NULL;
     Suites* suites;
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
     const CipherSuiteInfo* cipher_names = GetCipherNames();
     int cipherSz = GetCipherNamesSize();
+#endif
 
     WOLFSSL_ENTER("wolfSSL_get_ciphers_compat");
     if (ssl == NULL || (ssl->suites == NULL && ssl->ctx->suites == NULL)) {


### PR DESCRIPTION
Testing with 

```
 ./configure --enable-nginx --enable-webserver --enable-tls13 --enable-sha --enable-aes --enable-rsa --enable-psk --enable-sha512 --enable-aesgcm --enable-aescfb --enable-dtls --enable-debug --enable-sha3 --enable-singlethreaded CPPFLAGS="-DWOLFSSL_STATIC_RSA -DWOLFSSL_STATIC_PSK"
```
the following build errors were produced:
```
src/ssl.c: In function ‘wolfSSL_get_ciphers_compat’:
src/ssl.c:42976:9: error: unused variable ‘cipherSz’ [-Werror=unused-variable]
     int cipherSz = GetCipherNamesSize();
         ^~~~~~~~
src/ssl.c:42975:28: error: unused variable ‘cipher_names’ [-Werror=unused-variable]
     const CipherSuiteInfo* cipher_names = GetCipherNames();
                            ^~~~~~~~~~~~
```
This fixes an issue reported in ZD10457