### PR TITLE
Coverity fix in wolfSSL 4.4.0 - part 2

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -728,7 +728,7 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     XMEMSET(tmpBuf, 0, sizeof(tmpBuf));
     if (recv(*sockfd, tmpBuf, sizeof(tmpBuf)-1, 0) < 0)
         err_sys("failed to read STARTTLS command\n");
-
+    tmpBuf[sizeof(tmpBuf)-1] = '\0';
     if (!XSTRNCMP(tmpBuf, starttlsCmd[4], XSTRLEN(starttlsCmd[4]))) {
         printf("%s\n", tmpBuf);
     } else {

--- a/src/crl.c
+++ b/src/crl.c
@@ -630,6 +630,7 @@ static CRL_Entry* DupCRL_list(CRL_Entry* crl, void* heap)
                 head = head->next;
                 FreeCRL_Entry(current, heap);
             }
+
             return NULL;
         }
         current = current->next;

--- a/src/internal.c
+++ b/src/internal.c
@@ -19215,7 +19215,7 @@ int GetCipherSuiteFromName(const char* name, byte* cipherSuite0,
     int           i;
     unsigned long len;
     const char*   nameDelim;
-    
+
     /* Support trailing : */
     nameDelim = XSTRSTR(name, ":");
     if (nameDelim)
@@ -26933,6 +26933,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             #ifdef WOLFSSL_EXTRA_ALERTS
                 SendAlert(ssl, alert_fatal, handshake_failure);
             #endif
+                #ifdef HAVE_EXT_CACHE
+                    wolfSSL_SESSION_free(session);
+                #endif
                 return EXT_MASTER_SECRET_NEEDED_E;
             }
         #ifdef HAVE_EXT_CACHE

--- a/src/keys.c
+++ b/src/keys.c
@@ -3385,7 +3385,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
         /* Initialize the AES-GCM/CCM explicit IV to a zero. */
     #ifdef WOLFSSL_DTLS
         if (scr_copy)
-            XMEMCPY(ssl->keys.aead_exp_IV,
+            XMEMMOVE(ssl->keys.aead_exp_IV,
                     keys->aead_exp_IV, AEAD_MAX_EXP_SZ);
     #endif
         XMEMSET(keys->aead_exp_IV, 0, AEAD_MAX_EXP_SZ);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2508,7 +2508,7 @@ WOLFSSL_ABI
 int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
                     word32 protocol_name_listSz, byte options)
 {
-    char    *list, *ptr, *token[WOLFSSL_MAX_ALPN_NUMBER]={NULL};
+    char    *list, *ptr, *token[WOLFSSL_MAX_ALPN_NUMBER+1]={NULL};
     word16  len;
     int     idx = 0;
     int     ret = WOLFSSL_FAILURE;
@@ -8430,6 +8430,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
                         wolfSSL_ASN1_OBJECT_free(ext->obj);
                         wolfSSL_X509_EXTENSION_free(ext);
                         FreeDecodedCert(&cert);
+                        XFREE(oidBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                         return NULL;
                     }
                     ext->obj->dynamic |= WOLFSSL_ASN1_DYNAMIC_DATA;
@@ -8499,7 +8500,7 @@ int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out, WOLFSSL_X509_EXTENSION *ext,
     int nid;
     const int sz = CTC_NAME_SIZE*2;
     int rc = WOLFSSL_FAILURE;
-    char tmp[CTC_NAME_SIZE*2];
+    char tmp[CTC_NAME_SIZE*2] = {0};
     WOLFSSL_ENTER("wolfSSL_X509V3_EXT_print");
 
     if ((out == NULL) || (ext == NULL)) {
@@ -8514,7 +8515,7 @@ int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out, WOLFSSL_X509_EXTENSION *ext,
     }
 
     str = wolfSSL_X509_EXTENSION_get_data(ext);
-    if (obj == NULL) {
+    if (str == NULL) {
         WOLFSSL_MSG("Error getting ASN1_STRING from X509_EXTENSION");
         return rc;
     }
@@ -8638,7 +8639,7 @@ const WOLFSSL_v3_ext_method* wolfSSL_X509V3_EXT_get(WOLFSSL_X509_EXTENSION* ex)
         WOLFSSL_MSG("Failed to get nid from passed extension object");
         return NULL;
     }
-
+    XMEMSET(&method, 0, sizeof(WOLFSSL_v3_ext_method));
     switch (nid) {
         case NID_basic_constraints:
             break;
@@ -11539,7 +11540,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
 
         if (ssl->buffers.outputBuffer.length > 0
         #ifdef WOLFSSL_ASYNC_CRYPT
-            /* do not send buffered or advance state if last error was an 
+            /* do not send buffered or advance state if last error was an
                 async pending operation */
             && ssl->error != WC_PENDING_E
         #endif
@@ -11951,7 +11952,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
 
         if (ssl->buffers.outputBuffer.length > 0
         #ifdef WOLFSSL_ASYNC_CRYPT
-            /* do not send buffered or advance state if last error was an 
+            /* do not send buffered or advance state if last error was an
                 async pending operation */
             && ssl->error != WC_PENDING_E
         #endif
@@ -16568,7 +16569,12 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         WOLFSSL_ENTER("DES_ncbc_encrypt");
 
         /* OpenSSL compat, no ret */
-        wc_Des_SetKey(&myDes, (const byte*)schedule, (const byte*)ivec, !enc);
+        if (wc_Des_SetKey(&myDes, (const byte*)schedule,
+                         (const byte*)ivec, !enc) != 0) {
+            WOLFSSL_MSG("wc_Des_SetKey return error.");
+            return;
+        }
+
         lb_sz = length%DES_BLOCK_SIZE;
         blk   = length/DES_BLOCK_SIZE;
         idx  -= sizeof(DES_cblock);
@@ -23741,7 +23747,7 @@ int wolfSSL_ASN1_TIME_print(WOLFSSL_BIO* bio, const WOLFSSL_ASN1_TIME* asnTime)
     if (wolfSSL_ASN1_TIME_to_string((WOLFSSL_ASN1_TIME*)asnTime, buf,
                 sizeof(buf)) == NULL) {
         XMEMSET(buf, 0, MAX_TIME_STRING_SZ);
-        XMEMCPY(buf, "Bad time value", 14);
+        XSTRNCPY(buf, "Bad time value", sizeof(buf)-1);
         ret = WOLFSSL_FAILURE;
     }
 
@@ -30419,6 +30425,7 @@ int wolfSSL_HMAC_Init_ex(WOLFSSL_HMAC_CTX* ctx, const void* key,
 int wolfSSL_HmacCopy(Hmac* des, Hmac* src)
 {
     void* heap;
+    int ret;
 
 #ifndef HAVE_FIPS
     heap = src->heap;
@@ -30433,42 +30440,45 @@ int wolfSSL_HmacCopy(Hmac* des, Hmac* src)
     switch (src->macType) {
     #ifndef NO_MD5
         case WC_MD5:
-            wc_Md5Copy(&src->hash.md5, &des->hash.md5);
+            ret = wc_Md5Copy(&src->hash.md5, &des->hash.md5);
             break;
     #endif /* !NO_MD5 */
 
     #ifndef NO_SHA
         case WC_SHA:
-            wc_ShaCopy(&src->hash.sha, &des->hash.sha);
+            ret = wc_ShaCopy(&src->hash.sha, &des->hash.sha);
             break;
     #endif /* !NO_SHA */
 
     #ifdef WOLFSSL_SHA224
         case WC_SHA224:
-            wc_Sha224Copy(&src->hash.sha224, &des->hash.sha224);
+            ret = wc_Sha224Copy(&src->hash.sha224, &des->hash.sha224);
             break;
     #endif /* WOLFSSL_SHA224 */
 
     #ifndef NO_SHA256
         case WC_SHA256:
-            wc_Sha256Copy(&src->hash.sha256, &des->hash.sha256);
+            ret = wc_Sha256Copy(&src->hash.sha256, &des->hash.sha256);
             break;
     #endif /* !NO_SHA256 */
 
     #ifdef WOLFSSL_SHA384
         case WC_SHA384:
-            wc_Sha384Copy(&src->hash.sha384, &des->hash.sha384);
+            ret = wc_Sha384Copy(&src->hash.sha384, &des->hash.sha384);
             break;
     #endif /* WOLFSSL_SHA384 */
     #ifdef WOLFSSL_SHA512
         case WC_SHA512:
-            wc_Sha512Copy(&src->hash.sha512, &des->hash.sha512);
+            ret = wc_Sha512Copy(&src->hash.sha512, &des->hash.sha512);
             break;
     #endif /* WOLFSSL_SHA512 */
 
         default:
             return WOLFSSL_FAILURE;
     }
+
+    if (ret != 0)
+        return WOLFSSL_FAILURE;
 
     XMEMCPY((byte*)des->ipad, (byte*)src->ipad, WC_HMAC_BLOCK_SIZE);
     XMEMCPY((byte*)des->opad, (byte*)src->opad, WC_HMAC_BLOCK_SIZE);
@@ -41001,7 +41011,7 @@ void wolfSSL_print_all_errors_fp(XFILE fp)
 }
 #endif /* !NO_FILESYSTEM */
 
-#endif /* OPENSSL_ALL || OPENSSL_EXTRA || HAVE_STUNNEL || WOLFSSL_NGINX || 
+#endif /* OPENSSL_ALL || OPENSSL_EXTRA || HAVE_STUNNEL || WOLFSSL_NGINX ||
     HAVE_LIGHTY || WOLFSSL_HAPROXY || WOLFSSL_OPENSSH */
 
 
@@ -41701,7 +41711,7 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
 {
 #if defined(WOLFSSL_APACHE_HTTPD) || defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX)
     int count = 0, len = 0, totalSz = 0, tmpSz = 0;
-    char tmp[ASN_NAME_MAX];
+    char tmp[ASN_NAME_MAX+1];
     char fullName[ASN_NAME_MAX];
     const char *buf = NULL;
     WOLFSSL_X509_NAME_ENTRY* ne;
@@ -42988,7 +42998,8 @@ unsigned long wolfSSL_ERR_peek_error_line_data(const char **file, int *line,
         int ret = 0;
 
         while (1) {
-            if ((ret = wc_PeekErrorNode(-1, file, NULL, line)) < 0) {
+            ret = wc_PeekErrorNode(-1, file, NULL, line);
+            if (ret == BAD_MUTEX_E || ret == BAD_FUNC_ARG || ret == BAD_STATE_E) {
                 WOLFSSL_MSG("Issue peeking at error node in queue");
                 return 0;
             }
@@ -44564,7 +44575,10 @@ WOLFSSL_BIGNUM *wolfSSL_ASN1_INTEGER_to_BN(const WOLFSSL_ASN1_INTEGER *ai,
     ret = GetInt(&mpi, ai->data, &idx, ai->dataMax);
     if (ret != 0) {
     #ifdef WOLFSSL_QT
-        mp_init(&mpi); /* must init mpi */
+        ret = mp_init(&mpi); /* must init mpi */
+        if (ret != MP_OKAY) {
+            return NULL;
+        }
         /* Serial number in QT starts at index 0 of data */
         if (mp_read_unsigned_bin(&mpi, (byte*)ai->data, ai->length) != 0) {
                 mp_clear(&mpi);

--- a/src/tls.c
+++ b/src/tls.c
@@ -3039,8 +3039,6 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, byte* input, word16 length,
 
         if (length == 0)
             return 0;
-        if (length < ENUM_LEN)
-            return BUFFER_ERROR;
 
         status_type = input[offset++];
 
@@ -3841,13 +3839,10 @@ static void TLSX_PointFormat_ValidateRequest(WOLFSSL* ssl, byte* semaphore)
             return;
         #endif
         }
-        else {
-        #ifdef HAVE_FFDHE
-            return;
-        #endif
-        }
     }
-
+ #ifdef HAVE_FFDHE
+        return;
+ #endif
     /* turns semaphore on to avoid sending this extension. */
     TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_EC_POINT_FORMATS));
 }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -7216,12 +7216,13 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 {
     int    ret = 0;
     word32 inputLength;
+    byte   type;
+    word32 size = 0;
 
     WOLFSSL_ENTER("DoTls13HandShakeMsg()");
 
     if (ssl->arrays == NULL) {
-        byte   type;
-        word32 size;
+
 
         if (GetHandshakeHeader(ssl, input, inOutIdx, &type, &size,
                                                                 totalSz) != 0) {
@@ -7238,8 +7239,6 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     /* If there is a pending fragmented handshake message,
      * pending message size will be non-zero. */
     if (ssl->arrays->pendingMsgSz == 0) {
-        byte   type;
-        word32 size;
 
         if (GetHandshakeHeader(ssl,input, inOutIdx, &type, &size, totalSz) != 0)
             return PARSE_ERROR;
@@ -7339,7 +7338,7 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
 
     if (ssl->buffers.outputBuffer.length > 0
     #ifdef WOLFSSL_ASYNC_CRYPT
-        /* do not send buffered or advance state if last error was an 
+        /* do not send buffered or advance state if last error was an
             async pending operation */
         && ssl->error != WC_PENDING_E
     #endif
@@ -8065,7 +8064,7 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
 
     if (ssl->buffers.outputBuffer.length > 0
     #ifdef WOLFSSL_ASYNC_CRYPT
-        /* do not send buffered or advance state if last error was an 
+        /* do not send buffered or advance state if last error was an
             async pending operation */
         && ssl->error != WC_PENDING_E
     #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -6504,9 +6504,9 @@ static int test_wc_Sha256GetFlags (void)
     wc_Sha256 sha256;
     word32 flags = 0;
 
-    
+
     printf(testingFmt, "wc_Sha256GetFlags()");
-    
+
     /* Initialize */
     flag = wc_InitSha256(&sha256);
     if (flag == 0) {
@@ -6517,7 +6517,7 @@ static int test_wc_Sha256GetFlags (void)
             flag = 0;
         }
     }
-    
+
     wc_Sha256Free(&sha256);
 
     printf(resultFmt, flag == 0 ? passed : failed);
@@ -6533,10 +6533,10 @@ static int test_wc_Sha256Free (void)
 {
     int flag = 0;
 #ifndef NO_SHA256
-    
+
     printf(testingFmt, "wc_Sha256Free()");
     wc_Sha256Free(NULL);
-    
+
     printf(resultFmt, flag == 0 ? passed : failed);
 
 #endif
@@ -6552,12 +6552,12 @@ static int test_wc_Sha256GetHash (void)
 #ifndef NO_SHA256
     wc_Sha256 sha256;
     byte hash1[WC_SHA256_DIGEST_SIZE];
-    
+
     printf(testingFmt, "wc_Sha256GetHash()");
-    
+
     /* Initialize */
     flag = wc_InitSha256(&sha256);
-    
+
     if (flag == 0) {
         flag = wc_Sha256GetHash(&sha256, hash1);
     }
@@ -6580,7 +6580,7 @@ static int test_wc_Sha256GetHash (void)
             flag = 0;
         }
      }
-    
+
     wc_Sha256Free(&sha256);
 
     printf(resultFmt, flag == 0 ? passed : failed);
@@ -6597,10 +6597,10 @@ static int test_wc_Sha256Copy (void)
     int flag = 0;
 #ifndef NO_SHA256
     wc_Sha256 sha256;
-    wc_Sha256 temp;    
-    
+    wc_Sha256 temp;
+
     printf(testingFmt, "wc_Sha256Copy()");
-    
+
     /* Initialize */
     flag = wc_InitSha256(&sha256);
     if (flag == 0) {
@@ -6612,7 +6612,7 @@ static int test_wc_Sha256Copy (void)
     /*test bad arguements*/
      if (flag == 0) {
         flag = wc_Sha256Copy(NULL, NULL);
-        if (flag == BAD_FUNC_ARG) { 
+        if (flag == BAD_FUNC_ARG) {
             flag = 0;
         }
      }
@@ -6630,7 +6630,7 @@ static int test_wc_Sha256Copy (void)
     }
 
     wc_Sha256Free(&sha256);
-    wc_Sha256Free(&temp);    
+    wc_Sha256Free(&temp);
 
     printf(resultFmt, flag == 0 ? passed : failed);
 
@@ -7279,9 +7279,9 @@ static int test_wc_Sha224SetFlags (void)
     (defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB))
     wc_Sha224 sha224;
     word32 flags = 0;
-    
+
     printf(testingFmt, "wc_Sha224SetFlags()");
-    
+
     /* Initialize */
     flag = wc_InitSha224(&sha224);
     if (flag == 0) {
@@ -7292,7 +7292,7 @@ static int test_wc_Sha224SetFlags (void)
             flag = 0;
         }
     }
-    
+
     wc_Sha224Free(&sha224);
 
     printf(resultFmt, flag == 0 ? passed : failed);
@@ -7311,9 +7311,9 @@ static int test_wc_Sha224GetFlags (void)
     (defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB))
     wc_Sha224 sha224;
     word32 flags = 0;
-    
+
     printf(testingFmt, "wc_Sha224GetFlags()");
-    
+
     /* Initialize */
     flag = wc_InitSha224(&sha224);
     if (flag == 0) {
@@ -7324,7 +7324,7 @@ static int test_wc_Sha224GetFlags (void)
             flag = 0;
         }
     }
-    
+
 
     wc_Sha224Free(&sha224);
 
@@ -7342,10 +7342,10 @@ static int test_wc_Sha224Free (void)
     int flag = 0;
 #if !defined(NO_SHA224) && \
     (defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB))
-    
+
     printf(testingFmt, "wc_Sha224Free()");
     wc_Sha224Free(NULL);
-    
+
 
     printf(resultFmt, flag == 0 ? passed : failed);
 
@@ -7363,12 +7363,12 @@ static int test_wc_Sha224GetHash (void)
     (defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB))
     wc_Sha224 sha224;
     byte hash1[WC_SHA224_DIGEST_SIZE];
-    
+
     printf(testingFmt, "wc_Sha224GetHash()");
-    
+
     /* Initialize */
     flag = wc_InitSha224(&sha224);
-    
+
     if (flag == 0) {
         flag = wc_Sha224GetHash(&sha224, hash1);
     }
@@ -7391,7 +7391,7 @@ static int test_wc_Sha224GetHash (void)
             flag = 0;
         }
     }
-    
+
     wc_Sha224Free(&sha224);
 
     printf(resultFmt, flag == 0 ? passed : failed);
@@ -7409,10 +7409,10 @@ static int test_wc_Sha224Copy (void)
 #if !defined(NO_SHA224) && \
     (defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB))
     wc_Sha224 sha224;
-    wc_Sha224 temp;    
-    
+    wc_Sha224 temp;
+
     printf(testingFmt, "wc_Sha224Copy()");
-    
+
     /* Initialize */
     flag = wc_InitSha224(&sha224);
     if (flag == 0) {
@@ -7440,10 +7440,10 @@ static int test_wc_Sha224Copy (void)
             flag = 0;
         }
     }
-    
+
 
     wc_Sha224Free(&sha224);
-    wc_Sha224Free(&temp);    
+    wc_Sha224Free(&temp);
 
     printf(resultFmt, flag == 0 ? passed : failed);
 
@@ -15792,7 +15792,7 @@ static int test_wc_curve25519_export_key_raw (void)
 {
 
 #if defined(HAVE_CURVE25519) && defined(HAVE_CURVE25519_KEY_EXPORT)
- 
+
     curve25519_key  key;
     WC_RNG          rng;
 
@@ -15805,7 +15805,7 @@ static int test_wc_curve25519_export_key_raw (void)
     byte            pubk[CURVE25519_KEYSIZE];
     word32          prksz;
     word32          pbksz;
-    
+
     printf(testingFmt, "wc_curve25519_export_key_raw()");
 
 
@@ -15814,30 +15814,30 @@ static int test_wc_curve25519_export_key_raw (void)
         fflush( stdout );
         return  1;
     }
-    
+
     if(0 != wc_curve25519_init(&key)){
         printf(testingFmt, "failed due to wc_curve25519_init");
         fflush( stdout );
         wc_FreeRng(&rng);
         return  1;
     }
-    
+
     if(0 != wc_curve25519_make_key(&rng, CURVE25519_KEYSIZE, &key)){
         printf(testingFmt, "failed due to wc_curve25519_make_key");
         fflush( stdout );
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
-        return  1;       
+        return  1;
     }
 
-    /* 
+    /*
         bad-argument-test cases
-        target function sould return BAD_FUNC_ARG    
+        target function sould return BAD_FUNC_ARG
     */
     prvkSz = CURVE25519_KEYSIZE;
     pubkSz = CURVE25519_KEYSIZE;
 
-    if(BAD_FUNC_ARG != wc_curve25519_export_key_raw( 
+    if(BAD_FUNC_ARG != wc_curve25519_export_key_raw(
             NULL , privateKey, &prvkSz, publicKey, &pubkSz)){
 
         printf(testingFmt,"failed at bad-arg-case-1.");
@@ -15905,7 +15905,7 @@ static int test_wc_curve25519_export_key_raw (void)
     }
 
     /*
-        cross-testing 
+        cross-testing
     */
     prksz = CURVE25519_KEYSIZE;
 
@@ -15936,21 +15936,21 @@ static int test_wc_curve25519_export_key_raw (void)
 
     if(0 != wc_curve25519_export_key_raw(&key, privateKey, &prvkSz,
                                                      publicKey,  &pubkSz)){
-        
+
         printf(testingFmt,"failed due to wc_curve25519_export_key_raw");
         fflush( stdout );
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
-        return  1;       
-    
+        return  1;
+
     }
-        
+
     if((prksz  == CURVE25519_KEYSIZE) &&
        (pbksz  == CURVE25519_KEYSIZE) &&
        (prvkSz == CURVE25519_KEYSIZE) &&
        (pubkSz == CURVE25519_KEYSIZE)){
-    
-        if( 0 == XMEMCMP(privateKey, prik, CURVE25519_KEYSIZE) && 
+
+        if( 0 == XMEMCMP(privateKey, prik, CURVE25519_KEYSIZE) &&
             0 == XMEMCMP(publicKey,  pubk, CURVE25519_KEYSIZE)){
 
             printf(resultFmt,passed);
@@ -15966,21 +15966,21 @@ static int test_wc_curve25519_export_key_raw (void)
             fflush( stdout );
             wc_curve25519_free(&key);
             wc_FreeRng(&rng);
-            return  1;   
+            return  1;
         }
     }
     else{
-        
+
         printf(testingFmt,"failed due to bad-key-size.");
         fflush( stdout );
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
-        return  1;  
+        return  1;
     }
 
 #endif
     fflush( stdout );
-    
+
     return 0;
 } /* end of test_wc_curve25519_export_key_raw */
 
@@ -16004,7 +16004,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
     byte            pubk[CURVE25519_KEYSIZE];
     word32          prksz;
     word32          pbksz;
-    
+
     printf(testingFmt, "wc_curve25519_export_key_raw_ex()");
 
     if(0 != wc_InitRng(&rng)){
@@ -16012,32 +16012,32 @@ static int test_wc_curve25519_export_key_raw_ex (void)
         fflush( stdout );
         return  1;
     }
-    
+
     if(0 != wc_curve25519_init(&key)){
         printf(testingFmt, "failed due to wc_curve25519_init");
         fflush( stdout );
         wc_FreeRng(&rng);
         return  1;
     }
-    
+
     if(0 != wc_curve25519_make_key(&rng, CURVE25519_KEYSIZE, &key)){
         printf(testingFmt, "failed due to wc_curve25519_make_key");
         fflush( stdout );
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
-        return  1;       
+        return  1;
     }
 
-    /* 
+    /*
         bad-argument-test cases
-        target function sould return BAD_FUNC_ARG    
+        target function sould return BAD_FUNC_ARG
     */
     prvkSz = CURVE25519_KEYSIZE;
     pubkSz = CURVE25519_KEYSIZE;
 
-    if(BAD_FUNC_ARG != wc_curve25519_export_key_raw_ex( NULL , privateKey, 
+    if(BAD_FUNC_ARG != wc_curve25519_export_key_raw_ex( NULL , privateKey,
                      &prvkSz, publicKey, &pubkSz, EC25519_LITTLE_ENDIAN)){
-        
+
         printf(testingFmt,"failed at bad-arg-case-1.");
         fflush( stdout );
         wc_curve25519_free(&key);
@@ -16049,7 +16049,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
     prvkSz = CURVE25519_KEYSIZE;
     pubkSz = CURVE25519_KEYSIZE;
 
-    if(BAD_FUNC_ARG != wc_curve25519_export_key_raw_ex( &key , NULL,       
+    if(BAD_FUNC_ARG != wc_curve25519_export_key_raw_ex( &key , NULL,
                     &prvkSz, publicKey, &pubkSz, EC25519_LITTLE_ENDIAN)){
 
         printf(testingFmt,"failed at bad-arg-case-2.");
@@ -16058,20 +16058,20 @@ static int test_wc_curve25519_export_key_raw_ex (void)
         wc_FreeRng(&rng);
         return  1;
     }
-        
+
     prvkSz = CURVE25519_KEYSIZE;
     pubkSz = CURVE25519_KEYSIZE;
-    
+
     if(BAD_FUNC_ARG != wc_curve25519_export_key_raw_ex( &key,privateKey,
 	                    NULL,publicKey, &pubkSz,EC25519_LITTLE_ENDIAN)){
-    
+
         printf(testingFmt,"failed at bad-arg-case-3.");
         fflush( stdout );
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
     }
-    
+
     prvkSz = CURVE25519_KEYSIZE;
     pubkSz = CURVE25519_KEYSIZE;
 
@@ -16123,7 +16123,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
         wc_FreeRng(&rng);
         return  1;
     }
-    
+
     prvkSz = CURVE25519_KEYSIZE;
     pubkSz = CURVE25519_KEYSIZE;
 
@@ -16140,7 +16140,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
     prvkSz = CURVE25519_KEYSIZE;
     pubkSz = CURVE25519_KEYSIZE;
 
-    if(BAD_FUNC_ARG != wc_curve25519_export_key_raw_ex( &key, privateKey, 
+    if(BAD_FUNC_ARG != wc_curve25519_export_key_raw_ex( &key, privateKey,
     &prvkSz, NULL, &pubkSz, EC25519_BIG_ENDIAN)){
 
         printf(testingFmt,"failed at bad-arg-case-9.");
@@ -16149,7 +16149,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
         wc_FreeRng(&rng);
         return  1;
     }
-    
+
     prvkSz = CURVE25519_KEYSIZE;
     pubkSz = CURVE25519_KEYSIZE;
 
@@ -16161,7 +16161,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
-    }        
+    }
 
     /* illegal value for endien */
 
@@ -16176,11 +16176,11 @@ static int test_wc_curve25519_export_key_raw_ex (void)
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
-    } 
-    
+    }
+
     /*
-        cross-testing 
-    */         
+        cross-testing
+    */
     prksz = CURVE25519_KEYSIZE;
 
     if(0 != wc_curve25519_export_private_raw( &key, prik, &prksz )){
@@ -16190,8 +16190,8 @@ static int test_wc_curve25519_export_key_raw_ex (void)
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
-    } 
-    
+    }
+
     pbksz = CURVE25519_KEYSIZE;
 
     if(0 != wc_curve25519_export_public( &key, pubk, &pbksz )){
@@ -16217,18 +16217,18 @@ static int test_wc_curve25519_export_key_raw_ex (void)
         return  1;
     }
 
-    if( prksz  == CURVE25519_KEYSIZE && 
+    if( prksz  == CURVE25519_KEYSIZE &&
         pbksz  == CURVE25519_KEYSIZE &&
         prvkSz == CURVE25519_KEYSIZE &&
         pubkSz == CURVE25519_KEYSIZE ){
 
-        if( 0 == XMEMCMP( privateKey, prik, CURVE25519_KEYSIZE ) && 
+        if( 0 == XMEMCMP( privateKey, prik, CURVE25519_KEYSIZE ) &&
             0 == XMEMCMP( publicKey,  pubk, CURVE25519_KEYSIZE )){
 
             if( 0 == wc_curve25519_export_key_raw_ex( &key, privateKey,
                 &prvkSz, publicKey, &pubkSz, EC25519_LITTLE_ENDIAN)){
 
-                if( prvkSz == CURVE25519_KEYSIZE && 
+                if( prvkSz == CURVE25519_KEYSIZE &&
                     pubkSz == CURVE25519_KEYSIZE ){
 
                     ;   /* proceed to the next test */
@@ -16239,7 +16239,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
                     fflush( stdout );
                     wc_curve25519_free(&key);
                     wc_FreeRng(&rng);
-                    return  1;   
+                    return  1;
                 }
             }
             else{
@@ -16259,20 +16259,20 @@ static int test_wc_curve25519_export_key_raw_ex (void)
             fflush( stdout );
             wc_curve25519_free(&key);
             wc_FreeRng(&rng);
-            return  1; 
+            return  1;
 
-        }        
-    } 
+        }
+    }
     else{
 
         printf(testingFmt,"failed due to bad-key-size");
         fflush( stdout );
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
-        return  1;  
-    }   
+        return  1;
+    }
 
-    /* 
+    /*
         try once with another endian
     */
 
@@ -16282,7 +16282,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
     if( 0 == wc_curve25519_export_key_raw_ex( &key, privateKey,
     &prvkSz, publicKey, &pubkSz, EC25519_BIG_ENDIAN)){
 
-        if( prvkSz == CURVE25519_KEYSIZE && 
+        if( prvkSz == CURVE25519_KEYSIZE &&
             pubkSz == CURVE25519_KEYSIZE ){
 
                 /* no more test*/
@@ -16298,7 +16298,7 @@ static int test_wc_curve25519_export_key_raw_ex (void)
             fflush( stdout );
             wc_curve25519_free(&key);
             wc_FreeRng(&rng);
-            return  1;   
+            return  1;
         }
     }
     else{
@@ -16309,7 +16309,6 @@ static int test_wc_curve25519_export_key_raw_ex (void)
         wc_curve25519_free(&key);
         wc_FreeRng(&rng);
         return  1;
-
     }
 
 #endif
@@ -16318,30 +16317,30 @@ static int test_wc_curve25519_export_key_raw_ex (void)
 /*
  * Testing wc_curve25519_make_key
  */
-static int test_wc_curve25519_make_key (void) 
+static int test_wc_curve25519_make_key (void)
 {
     int ret = 0;
 #if defined(HAVE_CURVE25519)
     WC_RNG          rng;
     curve25519_key  key;
     int             keysize;
-    
+
 
     printf(testingFmt, "wc_curve25519_make_key()");
-    
+
     ret = wc_curve25519_init(&key);
     if (ret == 0) {
-        ret = wc_InitRng(&rng); 
-    }      
+        ret = wc_InitRng(&rng);
+    }
     if (ret == 0) {
-    
+
         ret = wc_curve25519_make_key(&rng, CURVE25519_KEYSIZE, &key);
         if (ret == 0) {
-            keysize = wc_curve25519_size(&key); 
+            keysize = wc_curve25519_size(&key);
             if (keysize != CURVE25519_KEYSIZE) {
                 ret = SSL_FATAL_ERROR;
             }
-        }    
+        }
         if (ret == 0) {
             ret = wc_curve25519_make_key(&rng, keysize, &key);
         }
@@ -16352,7 +16351,7 @@ static int test_wc_curve25519_make_key (void)
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
-    }    
+    }
     if (ret == 0) {
         ret = wc_curve25519_make_key(&rng, keysize, NULL);
         if (ret == BAD_FUNC_ARG) {
@@ -16363,7 +16362,7 @@ static int test_wc_curve25519_make_key (void)
         ret = wc_curve25519_make_key(NULL, keysize, &key);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
-        }    
+        }
     }
     if (ret == 0) {
         ret = wc_curve25519_make_key(&rng, 0, &key);
@@ -16375,7 +16374,7 @@ static int test_wc_curve25519_make_key (void)
     wc_curve25519_free(&key);
     wc_FreeRng(&rng);
 #endif
-    return ret;    
+    return ret;
 } /*END test_wc_curve25519_make_key*/
 /*
  * Testing wc_curve25519_shared_secret_ex
@@ -16389,22 +16388,22 @@ static int test_wc_curve25519_shared_secret_ex (void)
     byte            out[CURVE25519_KEYSIZE];
     word32          outLen = sizeof(out);
     int             endian = EC25519_BIG_ENDIAN;
-    
+
 
     printf(testingFmt, "wc_curve25519_shared_secret_ex()");
-    
+
     ret = wc_curve25519_init(&private_key);
     if (ret == 0) {
         ret = wc_InitRng(&rng);
         if (ret == 0) {
             ret = wc_curve25519_make_key(&rng, CURVE25519_KEYSIZE, &private_key);
         }
-    }      
+    }
     if (ret == 0) {
         ret = wc_curve25519_make_key(&rng, CURVE25519_KEYSIZE, &public_key);
-        
+
     }
-    if (ret == 0) {    
+    if (ret == 0) {
         ret = wc_curve25519_shared_secret_ex(&private_key, &public_key, out,
                                               &outLen, endian);
     }
@@ -16416,16 +16415,16 @@ static int test_wc_curve25519_shared_secret_ex (void)
             ret = 0;
         }
     }
-    if (ret == 0) { 
+    if (ret == 0) {
         ret = wc_curve25519_shared_secret_ex(NULL, &public_key, out,
-                                             &outLen, endian);                                      
+                                             &outLen, endian);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
     }
     if (ret == 0) {
         ret = wc_curve25519_shared_secret_ex(&private_key, NULL, out,
-                                              &outLen, endian);                                        
+                                              &outLen, endian);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
@@ -16437,41 +16436,41 @@ static int test_wc_curve25519_shared_secret_ex (void)
             ret = 0;
         }
     }
-    if (ret == 0) { 
+    if (ret == 0) {
         ret = wc_curve25519_shared_secret_ex(&private_key, &public_key, out,
                                               NULL, endian);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
     }
-    
+
     if (ret == 0) {
     /*curve25519.c is checking for public_key size less than or equal to 0x7f,
      *increasing to 0x8f checks for error being returned*/
-        public_key.p.point[CURVE25519_KEYSIZE-1] = 0x8F; 
+        public_key.p.point[CURVE25519_KEYSIZE-1] = 0x8F;
         ret = wc_curve25519_shared_secret_ex(&private_key, &public_key, out,
                                               &outLen, endian);
         if (ret == ECC_BAD_ARG_E) {
            ret = 0;
-        }       
+        }
     }
-       
+
     outLen = outLen - 2;
     if (ret == 0) {
         ret = wc_curve25519_shared_secret_ex(&private_key, &public_key, out,
-                                              &outLen, endian);                                    
+                                              &outLen, endian);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
-    }                                         
-    
+    }
+
 
     printf(resultFmt, ret == 0 ? passed : failed);
     wc_curve25519_free(&private_key);
     wc_curve25519_free(&public_key);
     wc_FreeRng(&rng);
 #endif
-    return ret;    
+    return ret;
 } /*END test_wc_curve25519_shared_secret_ex*/
 /*
  * Testing test_wc_curve25519_export_public_ex
@@ -16479,31 +16478,31 @@ static int test_wc_curve25519_shared_secret_ex (void)
 static int test_wc_curve25519_export_public_ex (void)
 {
     int ret = 0;
-#if defined(HAVE_CURVE25519) 
-   
+#if defined(HAVE_CURVE25519)
+
     WC_RNG          rng;
     curve25519_key  key;
     byte            out[CURVE25519_KEYSIZE];
     word32          outLen = sizeof(out);
     int             endian = EC25519_BIG_ENDIAN;
-    
+
     printf(testingFmt, "wc_curve25519_export_public_ex()");
-    
+
     ret = wc_curve25519_init(&key);
     if (ret == 0) {
-        ret = wc_InitRng(&rng); 
-    } 
+        ret = wc_InitRng(&rng);
+    }
     if (ret == 0) {
-    
+
         ret = wc_curve25519_make_key(&rng, CURVE25519_KEYSIZE, &key);
         if (ret == 0) {
             ret = wc_curve25519_export_public(&key, out, &outLen);
-            }        
+            }
         if (ret == 0) {
             ret = wc_curve25519_export_public_ex(&key, out, &outLen, endian);
         }
     }
-    /*test bad cases*/   
+    /*test bad cases*/
     if (ret == 0) {
         ret = wc_curve25519_export_public_ex(NULL, NULL, NULL, endian);
         if (ret == BAD_FUNC_ARG) {
@@ -16511,13 +16510,13 @@ static int test_wc_curve25519_export_public_ex (void)
         }
     }
     if (ret == 0) {
-        ret = wc_curve25519_export_public_ex(NULL, out, &outLen, endian);                                         
+        ret = wc_curve25519_export_public_ex(NULL, out, &outLen, endian);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
     }
     if (ret == 0) {
-        ret = wc_curve25519_export_public_ex(&key, NULL, &outLen, endian);                                         
+        ret = wc_curve25519_export_public_ex(&key, NULL, &outLen, endian);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
@@ -16540,7 +16539,7 @@ static int test_wc_curve25519_export_public_ex (void)
     wc_curve25519_free(&key);
     wc_FreeRng(&rng);
 #endif
-    return ret;     
+    return ret;
 
 } /*END test_wc_curve25519_export_public_ex*/
 /*
@@ -16550,7 +16549,7 @@ static int test_wc_curve25519_import_private_raw_ex (void)
 {
     int ret = 0;
 #if defined(HAVE_CURVE25519)
-    WC_RNG          rng; 
+    WC_RNG          rng;
     curve25519_key  key;
     byte            priv[CURVE25519_KEYSIZE];
     byte            pub[CURVE25519_KEYSIZE];
@@ -16560,26 +16559,26 @@ static int test_wc_curve25519_import_private_raw_ex (void)
 
 
     printf(testingFmt, "wc_curve25519_import_private_raw_ex()");
-       
+
     ret = wc_curve25519_init(&key);
     if (ret == 0) {
-        ret = wc_InitRng(&rng); 
-    } 
+        ret = wc_InitRng(&rng);
+    }
     if (ret == 0) {
-    
+
         ret = wc_curve25519_make_key(&rng, CURVE25519_KEYSIZE, &key);
         if (ret == 0) {
             ret = wc_curve25519_export_private_raw_ex(&key, priv, &privSz, endian);
         }
         if (ret == 0) {
             ret = wc_curve25519_export_public(&key, pub, &pubSz);
-        }        
+        }
         if (ret == 0) {
             ret = wc_curve25519_import_private_raw_ex(priv, privSz, pub, pubSz,
                                                      &key, endian);
         }
     }
-    /*test bad cases*/   
+    /*test bad cases*/
     if (ret == 0) {
         ret = wc_curve25519_import_private_raw_ex(NULL, 0, NULL, 0, NULL,
                                                    endian);
@@ -16627,13 +16626,13 @@ static int test_wc_curve25519_import_private_raw_ex (void)
                                                  &key, EC25519_LITTLE_ENDIAN);
 
     }
-    
+
     printf(resultFmt, ret == 0 ? passed : failed);
     wc_curve25519_free(&key);
     wc_FreeRng(&rng);
-    
+
 #endif
-    return ret;   
+    return ret;
 } /*END test_wc_curve25519_import_private_raw_ex*/
 /*
  * Testing test_wc_curve25519_import_private
@@ -16642,20 +16641,20 @@ static int test_wc_curve25519_import_private (void)
 {
     int ret = 0;
 #if defined(HAVE_CURVE25519)
-    
+
     curve25519_key     key;
-    WC_RNG             rng; 
+    WC_RNG             rng;
     byte               priv[CURVE25519_KEYSIZE];
     word32             privSz = sizeof(priv);
-    
+
     printf(testingFmt, "wc_curve25519_import_private()");
-    
+
     ret = wc_curve25519_init(&key);
     if (ret == 0) {
-        ret = wc_InitRng(&rng); 
-    } 
+        ret = wc_InitRng(&rng);
+    }
     if (ret == 0) {
-    
+
         ret = wc_curve25519_make_key(&rng, CURVE25519_KEYSIZE, &key);
         if (ret == 0) {
             ret = wc_curve25519_export_private_raw(&key, priv, &privSz);
@@ -16663,39 +16662,39 @@ static int test_wc_curve25519_import_private (void)
     }
     if (ret == 0) {
         ret = wc_curve25519_import_private(priv, privSz, &key);
-    }    
+    }
     printf(resultFmt, ret == 0 ? passed : failed);
     wc_curve25519_free(&key);
-    wc_FreeRng(&rng);    
+    wc_FreeRng(&rng);
 #endif
-    return ret;        
+    return ret;
 
 } /*END test_wc_curve25519_import*/
 /*
  * Testing test_wc_curve25519_export_private_raw_ex
  */
-static int test_wc_curve25519_export_private_raw_ex (void) 
+static int test_wc_curve25519_export_private_raw_ex (void)
 {
 
     int ret = 0;
-#if defined(HAVE_CURVE25519) 
-   
+#if defined(HAVE_CURVE25519)
+
     WC_RNG          rng;
     curve25519_key  key;
     byte            out[CURVE25519_KEYSIZE];
     word32          outLen = sizeof(out);
     int             endian = EC25519_BIG_ENDIAN;
-    
+
     printf(testingFmt, "wc_curve25519_export_private_raw_ex()");
-    
+
     ret = wc_curve25519_init(&key);
     if (ret == 0) {
-        ret = wc_InitRng(&rng); 
-    } 
+        ret = wc_InitRng(&rng);
+    }
     if (ret == 0) {
         ret = wc_curve25519_export_private_raw_ex(&key, out, &outLen, endian);
     }
-    /*test bad cases*/ 
+    /*test bad cases*/
     if (ret == 0) {
         ret = wc_curve25519_export_private_raw_ex(NULL, NULL, NULL, endian);
         if (ret == BAD_FUNC_ARG) {
@@ -16731,14 +16730,15 @@ static int test_wc_curve25519_export_private_raw_ex (void)
             ret = 0;
         }
     }
-    
+
     printf(resultFmt, ret == 0 ? passed : failed);
     wc_curve25519_free(&key);
     wc_FreeRng(&rng);
 #endif
-    return ret;  
+    return ret;
 
 }/*END test_wc_curve25519_export_private_raw_ex*/
+
 /*
  * Testing wc_ed448_make_key().
  */
@@ -17479,23 +17479,23 @@ static int test_wc_curve448_make_key (void)
     WC_RNG           rng;
     curve448_key  key;
     int           keysize;
-    
+
 
     printf(testingFmt, "wc_curve448_make_key()");
-    
+
     ret = wc_curve448_init(&key);
     if (ret == 0) {
-        ret = wc_InitRng(&rng); 
-    }      
+        ret = wc_InitRng(&rng);
+    }
     if (ret == 0) {
-    
+
         ret = wc_curve448_make_key(&rng, CURVE448_KEY_SIZE, &key);
         if (ret == 0) {
-            keysize = wc_curve448_size(&key); 
+            keysize = wc_curve448_size(&key);
             if (keysize != CURVE448_KEY_SIZE) {
                 ret = SSL_FATAL_ERROR;
             }
-        }    
+        }
         if (ret == 0) {
             ret = wc_curve448_make_key(&rng, keysize, &key);
         }
@@ -17506,7 +17506,7 @@ static int test_wc_curve448_make_key (void)
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
-    }    
+    }
     if (ret == 0) {
         ret = wc_curve448_make_key(&rng, keysize, NULL);
         if (ret == BAD_FUNC_ARG) {
@@ -17517,7 +17517,7 @@ static int test_wc_curve448_make_key (void)
         ret = wc_curve448_make_key(NULL, keysize, &key);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
-        }    
+        }
     }
     if (ret == 0) {
         ret = wc_curve448_make_key(&rng, 0, &key);
@@ -17525,7 +17525,7 @@ static int test_wc_curve448_make_key (void)
             ret = 0;
         }
     }
-    
+
     if (wc_FreeRng(&rng) != 0 && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
     }
@@ -17533,7 +17533,7 @@ static int test_wc_curve448_make_key (void)
     printf(resultFmt, ret == 0 ? passed : failed);
     wc_curve448_free(&key);
 #endif
-    return ret;    
+    return ret;
 } /*END test_wc_curve448_make_key*/
 /*
  * Testing test_wc_curve448_shared_secret_ex
@@ -17541,21 +17541,21 @@ static int test_wc_curve448_make_key (void)
 static int test_wc_curve448_shared_secret_ex (void)
 {
     int ret = 0;
-#if defined(HAVE_CURVE448) 
+#if defined(HAVE_CURVE448)
     WC_RNG        rng;
     curve448_key  private_key, public_key;
     byte          out[CURVE448_KEY_SIZE];
     word32        outLen = sizeof(out);
     int           endian = EC448_BIG_ENDIAN;
-    
+
     printf(testingFmt, "wc_curve448_shared_secret_ex()");
-    
+
     ret = wc_curve448_init(&private_key);
     if (ret == 0) {
-        ret = wc_InitRng(&rng); 
+        ret = wc_InitRng(&rng);
         if (ret == 0) {
             ret = wc_curve448_make_key(&rng, CURVE448_KEY_SIZE, &private_key);
-        }  
+        }
     }
     if (ret == 0) {
         ret = wc_curve448_init(&public_key);
@@ -17565,12 +17565,12 @@ static int test_wc_curve448_shared_secret_ex (void)
             ret = wc_curve448_make_key(&rng, CURVE448_KEY_SIZE, &public_key);
         }
     }
-    
+
     if (ret == 0) {
         ret = wc_curve448_shared_secret_ex(&private_key, &public_key, out,
                                             &outLen, endian);
     }
-    /*test bad cases*/   
+    /*test bad cases*/
     if (ret == 0) {
         ret = wc_curve448_shared_secret_ex(NULL, NULL, NULL,
                                             0, endian);
@@ -17578,16 +17578,16 @@ static int test_wc_curve448_shared_secret_ex (void)
             ret = 0;
         }
     }
-    if (ret == 0) { 
+    if (ret == 0) {
         ret = wc_curve448_shared_secret_ex(NULL, &public_key, out,
-                                            &outLen, endian);                                      
+                                            &outLen, endian);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
     }
     if (ret == 0) {
         ret = wc_curve448_shared_secret_ex(&private_key, NULL, out,
-                                            &outLen, endian);                                        
+                                            &outLen, endian);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
@@ -17620,39 +17620,39 @@ static int test_wc_curve448_shared_secret_ex (void)
     wc_curve448_free(&public_key);
     wc_FreeRng(&rng);
 #endif
-    return ret;  
+    return ret;
 } /*END test_wc_curve448_shared_secret_ex*/
 /*
  * Testing test_wc_curve448_export_public_ex
  */
-static int test_wc_curve448_export_public_ex (void) 
+static int test_wc_curve448_export_public_ex (void)
 {
     int ret = 0;
-#if defined(HAVE_CURVE448) 
-   
+#if defined(HAVE_CURVE448)
+
     WC_RNG        rng;
     curve448_key  key;
     byte          out[CURVE448_KEY_SIZE];
     word32        outLen = sizeof(out);
     int           endian = EC448_BIG_ENDIAN;
-    
+
     printf(testingFmt, "wc_curve448_export_public_ex()");
-    
+
     ret = wc_curve448_init(&key);
     if (ret == 0) {
-        ret = wc_InitRng(&rng); 
-    } 
+        ret = wc_InitRng(&rng);
+    }
     if (ret == 0) {
-    
+
         ret = wc_curve448_make_key(&rng, CURVE448_KEY_SIZE, &key);
         if (ret == 0){
             ret = wc_curve448_export_public(&key, out, &outLen);
-            }        
+            }
         if (ret == 0) {
             ret = wc_curve448_export_public_ex(&key, out, &outLen, endian);
         }
     }
-    /*test bad cases*/   
+    /*test bad cases*/
     if (ret == 0) {
         ret = wc_curve448_export_public_ex(NULL, NULL, NULL, endian);
         if (ret == BAD_FUNC_ARG) {
@@ -17660,13 +17660,13 @@ static int test_wc_curve448_export_public_ex (void)
         }
     }
     if (ret == 0) {
-        ret = wc_curve448_export_public_ex(NULL, out, &outLen, endian);                                         
+        ret = wc_curve448_export_public_ex(NULL, out, &outLen, endian);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
     }
     if (ret == 0) {
-        ret = wc_curve448_export_public_ex(&key, NULL, &outLen, endian);                                         
+        ret = wc_curve448_export_public_ex(&key, NULL, &outLen, endian);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
@@ -17689,34 +17689,34 @@ static int test_wc_curve448_export_public_ex (void)
     wc_curve448_free(&key);
     wc_FreeRng(&rng);
 #endif
-    return ret;     
+    return ret;
 
 } /*END test_wc_curve448_export_public_ex*/
 /*
  * Testing test_wc_curve448_export_private_raw_ex
  */
-static int test_wc_curve448_export_private_raw_ex (void) 
+static int test_wc_curve448_export_private_raw_ex (void)
 {
 
     int ret = 0;
-#if defined(HAVE_CURVE448) 
-   
+#if defined(HAVE_CURVE448)
+
     WC_RNG        rng;
     curve448_key  key;
     byte          out[CURVE448_KEY_SIZE];
     word32        outLen = sizeof(out);
     int           endian = EC448_BIG_ENDIAN;
-    
+
     printf(testingFmt, "wc_curve448_export_private_raw_ex()");
-    
+
     ret = wc_curve448_init(&key);
     if (ret == 0) {
-        ret = wc_InitRng(&rng); 
-    } 
+        ret = wc_InitRng(&rng);
+    }
     if (ret == 0) {
         ret = wc_curve448_export_private_raw_ex(&key, out, &outLen, endian);
     }
-    /*test bad cases*/ 
+    /*test bad cases*/
     if (ret == 0) {
         ret = wc_curve448_export_private_raw_ex(NULL, NULL, NULL, endian);
         if (ret == BAD_FUNC_ARG) {
@@ -17752,12 +17752,12 @@ static int test_wc_curve448_export_private_raw_ex (void)
             ret = 0;
         }
     }
-    
+
     printf(resultFmt, ret == 0 ? passed : failed);
     wc_curve448_free(&key);
     wc_FreeRng(&rng);
 #endif
-    return ret;  
+    return ret;
 
 }/*END test_wc_curve448_export_private_raw_ex*/
 /*
@@ -17767,7 +17767,7 @@ static int test_wc_curve448_import_private_raw_ex (void)
 {
     int ret = 0;
 #if defined(HAVE_CURVE448)
-    WC_RNG             rng; 
+    WC_RNG             rng;
     curve448_key    key;
     byte            priv[CURVE448_KEY_SIZE];
     byte            pub[CURVE448_KEY_SIZE];
@@ -17776,26 +17776,26 @@ static int test_wc_curve448_import_private_raw_ex (void)
     int             endian = EC448_BIG_ENDIAN;
 
     printf(testingFmt, "wc_curve448_import_private_raw_ex()");
-       
+
     ret = wc_curve448_init(&key);
     if (ret == 0) {
-        ret = wc_InitRng(&rng); 
-    } 
+        ret = wc_InitRng(&rng);
+    }
     if (ret == 0) {
-    
+
         ret = wc_curve448_make_key(&rng, CURVE448_KEY_SIZE, &key);
         if (ret == 0){
             ret = wc_curve448_export_private_raw(&key, priv, &privSz);
         }
         if (ret == 0){
             ret = wc_curve448_export_public(&key, pub, &pubSz);
-            }        
+            }
         if (ret == 0) {
             ret = wc_curve448_import_private_raw_ex(priv, privSz, pub, pubSz,
                                                      &key, endian);
         }
     }
-    /*test bad cases*/   
+    /*test bad cases*/
     if (ret == 0) {
         ret = wc_curve448_import_private_raw_ex(NULL, 0, NULL, 0, NULL, 0);
         if (ret == BAD_FUNC_ARG) {
@@ -17842,16 +17842,16 @@ static int test_wc_curve448_import_private_raw_ex (void)
                                                  &key, EC448_LITTLE_ENDIAN);
 
     }
-    
+
     if (wc_FreeRng(&rng) != 0 && ret == 0) {
         ret = WOLFSSL_FATAL_ERROR;
     }
-    
+
     printf(resultFmt, ret == 0 ? passed : failed);
     wc_curve448_free(&key);
-    
+
 #endif
-    return ret;   
+    return ret;
 } /*END test_wc_curve448_import_private_raw_ex*/
 /*
  * Testing test_curve448_export_key_raw
@@ -17860,38 +17860,38 @@ static int test_wc_curve448_export_key_raw (void)
 {
     int ret = 0;
 #if defined(HAVE_CURVE448)
-    WC_RNG          rng; 
+    WC_RNG          rng;
     curve448_key    key;
     byte            priv[CURVE448_KEY_SIZE];
     byte            pub[CURVE448_KEY_SIZE];
     word32          privSz = sizeof(priv);
     word32          pubSz = sizeof(pub);
-    
+
     printf(testingFmt, "wc_curve448_export_key_raw()");
-    
+
     ret = wc_curve448_init(&key);
     if (ret == 0) {
-        ret = wc_InitRng(&rng); 
-    } 
+        ret = wc_InitRng(&rng);
+    }
     if (ret == 0) {
-    
+
         ret = wc_curve448_make_key(&rng, CURVE448_KEY_SIZE, &key);
         if (ret == 0) {
             ret = wc_curve448_export_private_raw(&key, priv, &privSz);
         }
         if (ret == 0) {
             ret = wc_curve448_export_public(&key, pub, &pubSz);
-            }        
+            }
         if (ret == 0) {
             ret = wc_curve448_export_key_raw(&key, priv, &privSz, pub, &pubSz);
         }
     }
-    
+
     printf(resultFmt, ret == 0 ? passed : failed);
     wc_curve448_free(&key);
-    wc_FreeRng(&rng);    
+    wc_FreeRng(&rng);
 #endif
-    return ret;  
+    return ret;
 
 }/*END test_wc_curve448_import_private_raw_ex*/
 
@@ -17899,24 +17899,24 @@ static int test_wc_curve448_export_key_raw (void)
 /*
  * Testing test_wc_curve448_import_private
  */
-static int test_wc_curve448_import_private (void) 
+static int test_wc_curve448_import_private (void)
 {
     int ret = 0;
 #if defined(HAVE_CURVE448)
-    
+
     curve448_key       key;
-    WC_RNG             rng; 
+    WC_RNG             rng;
     byte               priv[CURVE448_KEY_SIZE];
     word32             privSz = sizeof(priv);
-    
+
     printf(testingFmt, "wc_curve448_import_private()");
-    
+
     ret = wc_curve448_init(&key);
     if (ret == 0) {
-        ret = wc_InitRng(&rng); 
-    } 
+        ret = wc_InitRng(&rng);
+    }
     if (ret == 0) {
-    
+
         ret = wc_curve448_make_key(&rng, CURVE448_KEY_SIZE, &key);
         if (ret == 0) {
             ret = wc_curve448_export_private_raw(&key, priv, &privSz);
@@ -17924,12 +17924,12 @@ static int test_wc_curve448_import_private (void)
     }
     if (ret == 0) {
         ret = wc_curve448_import_private(priv, privSz, &key);
-    }    
+    }
     printf(resultFmt, ret == 0 ? passed : failed);
     wc_curve448_free(&key);
-    wc_FreeRng(&rng);    
+    wc_FreeRng(&rng);
 #endif
-    return ret;        
+    return ret;
 
 } /*END test_wc_curve448_import*/
 /*
@@ -18926,21 +18926,21 @@ static int test_wc_ecc_import_unsigned(void)
     (!defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && HAVE_FIPS_VERSION >= 2))
     ecc_key     key;
     const byte  qx[] = {
-        0xbb, 0x33, 0xac, 0x4c, 0x27, 0x50, 0x4a, 0xc6, 
-        0x4a, 0xa5, 0x04, 0xc3, 0x3c, 0xde, 0x9f, 0x36, 
-        0xdb, 0x72, 0x2d, 0xce, 0x94, 0xea, 0x2b, 0xfa, 
+        0xbb, 0x33, 0xac, 0x4c, 0x27, 0x50, 0x4a, 0xc6,
+        0x4a, 0xa5, 0x04, 0xc3, 0x3c, 0xde, 0x9f, 0x36,
+        0xdb, 0x72, 0x2d, 0xce, 0x94, 0xea, 0x2b, 0xfa,
         0xcb, 0x20, 0x09, 0x39, 0x2c, 0x16, 0xe8, 0x61
     };
     const byte  qy[] = {
-        0x02, 0xe9, 0xaf, 0x4d, 0xd3, 0x02, 0x93, 0x9a, 
-        0x31, 0x5b, 0x97, 0x92, 0x21, 0x7f, 0xf0, 0xcf, 
-        0x18, 0xda, 0x91, 0x11, 0x02, 0x34, 0x86, 0xe8, 
+        0x02, 0xe9, 0xaf, 0x4d, 0xd3, 0x02, 0x93, 0x9a,
+        0x31, 0x5b, 0x97, 0x92, 0x21, 0x7f, 0xf0, 0xcf,
+        0x18, 0xda, 0x91, 0x11, 0x02, 0x34, 0x86, 0xe8,
         0x20, 0x58, 0x33, 0x0b, 0x80, 0x34, 0x89, 0xd8
     };
     const byte  d[] = {
-        0x45, 0xb6, 0x69, 0x02, 0x73, 0x9c, 0x6c, 0x85, 
+        0x45, 0xb6, 0x69, 0x02, 0x73, 0x9c, 0x6c, 0x85,
         0xa1, 0x38, 0x5b, 0x72, 0xe8, 0xe8, 0xc7, 0xac,
-        0xc4, 0x03, 0x8d, 0x53, 0x35, 0x04, 0xfa, 0x6c, 
+        0xc4, 0x03, 0x8d, 0x53, 0x35, 0x04, 0xfa, 0x6c,
         0x28, 0xdc, 0x34, 0x8d, 0xe1, 0xa8, 0x09, 0x8c
     };
 #ifdef WOLFSSL_VALIDATE_ECC_IMPORT
@@ -18949,32 +18949,32 @@ static int test_wc_ecc_import_unsigned(void)
     int curveId = ECC_SECP256R1;
 
     ret = wc_ecc_init(&key);
- 
+
     printf(testingFmt, "wc_ecc_import_unsigned()");
 
     if (ret == 0) {
-        ret = wc_ecc_import_unsigned(&key, (byte*)qx, (byte*)qy, (byte*)d, 
+        ret = wc_ecc_import_unsigned(&key, (byte*)qx, (byte*)qy, (byte*)d,
             curveId);
     }
     /* Test bad args. */
     if (ret == 0) {
-        ret = wc_ecc_import_unsigned(NULL, (byte*)qx, (byte*)qy, (byte*)d, 
+        ret = wc_ecc_import_unsigned(NULL, (byte*)qx, (byte*)qy, (byte*)d,
             curveId);
         if (ret == BAD_FUNC_ARG) {
-            ret = wc_ecc_import_unsigned(&key, NULL, (byte*)qy, (byte*)d, 
+            ret = wc_ecc_import_unsigned(&key, NULL, (byte*)qy, (byte*)d,
                 curveId);
         }
         if (ret == BAD_FUNC_ARG) {
-            ret = wc_ecc_import_unsigned(&key, (byte*)qx, NULL, (byte*)d, 
+            ret = wc_ecc_import_unsigned(&key, (byte*)qx, NULL, (byte*)d,
                 curveId);
         }
         if (ret == BAD_FUNC_ARG) {
-            ret = wc_ecc_import_unsigned(&key, (byte*)qx, (byte*)qy, (byte*)d, 
+            ret = wc_ecc_import_unsigned(&key, (byte*)qx, (byte*)qy, (byte*)d,
                 ECC_CURVE_INVALID);
         }
     #ifdef WOLFSSL_VALIDATE_ECC_IMPORT
         if (ret == BAD_FUNC_ARG) {
-            ret = wc_ecc_import_unsigned(&key, (byte*)nullBytes, 
+            ret = wc_ecc_import_unsigned(&key, (byte*)nullBytes,
                 (byte*)nullBytes, (byte*)nullBytes, curveId);
         }
     #endif
@@ -25048,7 +25048,7 @@ static void test_wolfSSL_either_side(void)
     test_client_nofail(&client_args, NULL);
     join_thread(serverThread);
 #endif
-    
+
     wolfSSL_CTX_free(client_cb.ctx);
     FreeTcpReady(&ready);
 
@@ -34478,7 +34478,7 @@ void ApiTest(void)
     AssertFalse(test_wc_Sha256GetFlags());
     AssertFalse(test_wc_Sha256Free());
     AssertFalse(test_wc_Sha256GetHash());
-    AssertFalse(test_wc_Sha256Copy());    
+    AssertFalse(test_wc_Sha256Copy());
     AssertFalse(test_wc_InitSha512());
     AssertFalse(test_wc_Sha512Update());
     AssertFalse(test_wc_Sha512Final());
@@ -34491,7 +34491,7 @@ void ApiTest(void)
     AssertFalse(test_wc_Sha224SetFlags());
     AssertFalse(test_wc_Sha224GetFlags());
     AssertFalse(test_wc_Sha224Free());
-    AssertFalse(test_wc_Sha224GetHash());    
+    AssertFalse(test_wc_Sha224GetHash());
     AssertFalse(test_wc_Sha224Copy());
     AssertFalse(test_wc_InitBlake2b());
     AssertFalse(test_wc_InitRipeMd());

--- a/tests/api.c
+++ b/tests/api.c
@@ -2098,8 +2098,8 @@ static void test_wolfSSL_ECDSA_SIG(void)
     unsigned char outSig[8];
     unsigned char sigData[8] =
                              { 0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01 };
-
-    AssertNull(wolfSSL_d2i_ECDSA_SIG(NULL, NULL, sizeof(sigData)));
+    sig = wolfSSL_d2i_ECDSA_SIG(NULL, NULL, sizeof(sigData));
+    AssertNull(sig);
     cp = sigData;
     AssertNotNull((sig = wolfSSL_d2i_ECDSA_SIG(NULL, &cp, sizeof(sigData))));
     AssertIntEQ((cp == sigData + 8), 1);
@@ -12995,6 +12995,7 @@ static int test_RsaDecryptBoundsCheck(void)
     WC_RNG rng;
 
     printf(testingFmt, "RSA decrypt bounds check");
+    XMEMSET(&rng, 0, sizeof(rng));
 
     ret = wc_InitRng(&rng);
 
@@ -13126,6 +13127,8 @@ static int test_wc_RsaKeyToDer (void)
     /* (2 x 256) + 2 (possible leading 00) + (5 x 128) + 5 (possible leading 00)
        + 3 (e) + 8 (ASN tag) + 17 (ASN length) + 4 seqSz + 3 version */
     #endif
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&genKey, 0, sizeof(genKey));
 
     der = (byte*)XMALLOC(derSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (der == NULL) {
@@ -13230,6 +13233,9 @@ static int test_wc_RsaKeyToPublicDer (void)
     int         bits = 2048;
     word32      derLen = 290;
     #endif
+
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
 
     der = (byte*)XMALLOC(derLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (der == NULL) {
@@ -14461,6 +14467,8 @@ static int test_wc_MakeDsaKey (void)
 #if !defined(NO_DSA) && defined(WOLFSSL_KEY_GEN)
     DsaKey  genKey;
     WC_RNG  rng;
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&genKey, 0, sizeof(genKey));
 
     ret = wc_InitRng(&rng);
     if (ret == 0) {
@@ -14558,7 +14566,10 @@ static int test_wc_DsaKeyToDer (void)
     bytes = (word32) XFREAD(tmp, 1, sizeof(tmp), fp);
     XFCLOSE(fp);
 #endif /* END USE_CERT_BUFFERS_1024 */
-
+#if !defined(NO_DSA) && defined(WOLFSSL_KEY_GEN)
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&genKey, 0, sizeof(genKey));
+#endif
     ret = wc_InitRng(&rng);
     if (ret == 0) {
         ret = wc_InitDsaKey(&genKey);
@@ -14966,6 +14977,8 @@ static int test_wc_DsaExportKeyRaw (void)
     word32 xOutSz, yOutSz;
 
     printf(testingFmt, "wc_DsaExportKeyRaw()");
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
 
     ret = wc_InitRng(&rng);
     if (ret == 0) {
@@ -18059,6 +18072,9 @@ static int test_wc_ecc_check_key (void)
     WC_RNG      rng;
     ecc_key     key;
 
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
+
     ret = wc_InitRng(&rng);
     if (ret == 0) {
         ret = wc_ecc_init(&key);
@@ -18154,6 +18170,9 @@ static int test_wc_ecc_size (void)
     WC_RNG      rng;
     ecc_key     key;
 
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
+
     ret = wc_InitRng(&rng);
     if (ret == 0) {
         ret = wc_ecc_init(&key);
@@ -18233,7 +18252,7 @@ static int test_wc_ecc_signVerify_hash (void)
 
     /* Init stack var */
     XMEMSET(sig, 0, siglen);
-    XMEMSET(&key, 0, sizeof(ecc_key));
+    XMEMSET(&key, 0, sizeof(key));
 
     /* Init structs. */
     ret = wc_InitRng(&rng);
@@ -18343,6 +18362,9 @@ static int test_wc_ecc_shared_secret (void)
 
     /* Initialize variables. */
     XMEMSET(out, 0, keySz);
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
+    XMEMSET(&pubKey, 0, sizeof(pubKey));
 
     ret = wc_InitRng(&rng);
     if (ret == 0) {
@@ -18413,6 +18435,8 @@ static int test_wc_ecc_export_x963 (void)
 
     /* Initialize variables. */
     XMEMSET(out, 0, outlen);
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
 
     ret = wc_InitRng(&rng);
     if (ret == 0) {
@@ -18482,6 +18506,8 @@ static int test_wc_ecc_export_x963_ex (void)
 
     /* Init stack variables. */
     XMEMSET(out, 0, outlen);
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
 
     ret = wc_InitRng(&rng);
     if (ret == 0) {
@@ -18582,6 +18608,10 @@ static int test_wc_ecc_import_x963 (void)
 
     /* Init stack variables. */
     XMEMSET(x963, 0, x963Len);
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
+    XMEMSET(&pubKey, 0, sizeof(pubKey));
+
     ret = wc_InitRng(&rng);
     if (ret == 0) {
         ret = wc_ecc_init(&pubKey);
@@ -18653,6 +18683,9 @@ static int ecc_import_private_key (void)
     /* Init stack variables. */
     XMEMSET(privKey, 0, privKeySz);
     XMEMSET(x963Key, 0, x963KeySz);
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
+    XMEMSET(&keyImp, 0, sizeof(keyImp));
 
     ret = wc_InitRng(&rng);
     if (ret == 0) {
@@ -18725,6 +18758,8 @@ static int test_wc_ecc_export_private_only (void)
 
     /* Init stack variables. */
     XMEMSET(out, 0, outlen);
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
 
     ret = wc_InitRng(&rng);
     if (ret == 0) {
@@ -19006,6 +19041,8 @@ static int test_wc_ecc_sig_size (void)
     WC_RNG      rng;
     int         keySz = KEY16;
 
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
     ret = wc_InitRng(&rng);
     if (ret == 0) {
         ret = wc_ecc_init(&key);
@@ -19281,6 +19318,9 @@ static int test_wc_ecc_encryptDecrypt (void)
     /* Init stack variables. */
     XMEMSET(out, 0, outSz);
     XMEMSET(plain, 0, plainSz);
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&srvKey, 0, sizeof(srvKey));
+    XMEMSET(&cliKey, 0, sizeof(cliKey));
 
     ret = wc_InitRng(&rng);
     if (ret == 0) {
@@ -19427,6 +19467,8 @@ static int test_wc_ecc_pointFns (void)
 
     /* Init stack variables. */
     XMEMSET(der, 0, derSz);
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
 
     ret = wc_InitRng(&rng);
     if (ret == 0) {
@@ -19600,7 +19642,9 @@ static int test_wc_ecc_shared_secret_ssh (void)
 
     /* Init stack variables. */
     XMEMSET(secret, 0, secretLen);
-
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
+    XMEMSET(&key2, 0, sizeof(key2));
     /* Make keys */
     ret = wc_InitRng(&rng);
     if (ret == 0) {
@@ -19894,6 +19938,8 @@ static int test_wc_ecc_is_valid_idx (void)
     int         iVal = -2;
     int         iVal2 = 3000;
 
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
 
     ret = wc_InitRng(&rng);
     if (ret == 0) {
@@ -22951,7 +22997,8 @@ static void test_wolfSSL_PEM_PrivateKey(void)
         XFCLOSE(file);
 
         /* Test using BIO new mem and loading PEM private key */
-        AssertNotNull(bio = BIO_new_mem_buf(buf, (int)sz));
+        bio = BIO_new_mem_buf(buf, (int)sz);
+        AssertNotNull(bio);
         AssertNotNull((pkey = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL)));
         XFREE(buf, NULL, DYNAMIC_TYPE_FILE);
         BIO_free(bio);
@@ -23832,8 +23879,9 @@ static void test_wolfSSL_EVP_MD_ecc_signing(void)
     printf(testingFmt, "wolfSSL_EVP_MD_ecc_signing()");
 
     cp = ecc_clikey_der_256;
-    AssertNotNull((privKey = wolfSSL_d2i_PrivateKey(EVP_PKEY_EC, NULL, &cp,
-                                                   sizeof_ecc_clikey_der_256)));
+    privKey = wolfSSL_d2i_PrivateKey(EVP_PKEY_EC, NULL, &cp,
+                                                   sizeof_ecc_clikey_der_256);
+    AssertNotNull(privKey);
     p = ecc_clikeypub_der_256;
     AssertNotNull((pubKey = wolfSSL_d2i_PUBKEY(NULL, &p,
                                                 sizeof_ecc_clikeypub_der_256)));
@@ -23934,7 +23982,8 @@ static void test_wolfSSL_CTX_add_extra_chain_cert(void)
         AssertNotNull(ecX509 = wolfSSL_X509_load_certificate_file(cliEccCertFile,
                     SSL_FILETYPE_PEM));
         #endif
-        AssertNotNull(pkey = X509_get_pubkey(ecX509));
+        pkey = X509_get_pubkey(ecX509);
+        AssertNotNull(pkey);
         /* current ECC key is 256 bit (32 bytes) */
         AssertIntEQ(EVP_PKEY_size(pkey), 32);
 
@@ -24150,7 +24199,8 @@ static void test_wolfSSL_X509_STORE_CTX(void)
     AssertIntEQ(X509_STORE_add_cert(str, x509), SSL_SUCCESS);
 #ifdef OPENSSL_ALL
     /* sk_X509_new only in OPENSSL_ALL */
-    AssertNotNull(sk = sk_X509_new());
+    sk = sk_X509_new();
+    AssertNotNull(sk);
     AssertIntEQ(X509_STORE_CTX_init(ctx, str, x509, sk), SSL_SUCCESS);
 #else
     AssertIntEQ(X509_STORE_CTX_init(ctx, str, x509, NULL), SSL_SUCCESS);
@@ -24426,8 +24476,8 @@ static void test_wolfSSL_CTX_add_client_CA(void)
     printf(testingFmt, "wolfSSL_CTX_add_client_CA()");
     AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_client_method()));
     /* Add client cert */
-    AssertNotNull(x509 = X509_load_certificate_file(cliCertFile,
-                                                      SSL_FILETYPE_PEM));
+    x509 = X509_load_certificate_file(cliCertFile, SSL_FILETYPE_PEM);
+    AssertNotNull(x509);
     ret = SSL_CTX_add_client_CA(ctx, x509);
     AssertIntEQ(ret, SSL_SUCCESS);
     AssertNotNull(ca_list = SSL_CTX_get_client_CA_list(ctx));
@@ -24723,8 +24773,8 @@ static void test_wolfSSL_BN(void)
     AssertNotNull(d = BN_new());
 
     value[0] = 0x03;
-
-    AssertNotNull(ai = ASN1_INTEGER_new());
+    ai = ASN1_INTEGER_new();
+    AssertNotNull(ai);
     /* at the moment hard setting since no set function */
     ai->data[0] = 0x02; /* tag for ASN_INTEGER */
     ai->data[1] = 0x01; /* length of integer */
@@ -25206,9 +25256,11 @@ static void test_wolfSSL_set_options(void)
     SSL_CTX_free(ctx);
 
 #ifndef NO_WOLFSSL_SERVER
-    AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_server_method()));
+    ctx = SSL_CTX_new(wolfSSLv23_server_method());
+    AssertNotNull(ctx);
 #else
-    AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_client_method()));
+    ctx = SSL_CTX_new(wolfSSLv23_client_method());
+    AssertNotNull(ctx);
 #endif
     AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCertFile, SSL_FILETYPE_PEM));
     AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
@@ -26700,8 +26752,8 @@ static void test_wolfSSL_OBJ(void)
          */
         AssertStrEQ((char*)buf_dyn, "www.wolfssl.com");
         OPENSSL_free(buf_dyn);
-
-        AssertTrue((bio = BIO_new(BIO_s_mem())) != NULL);
+        bio = BIO_new(BIO_s_mem());
+        AssertTrue(bio != NULL);
         for (j = 0; j < numNames; j++)
         {
             AssertNotNull(x509NameEntry = X509_NAME_get_entry(x509Name, j));
@@ -26722,7 +26774,8 @@ static void test_wolfSSL_OBJ(void)
         AssertTrue((boolRet = PKCS12_parse(p12, "wolfSSL test", &pkey, &x509, NULL)) > 0);
         wc_PKCS12_free(p12);
         EVP_PKEY_free(pkey);
-        AssertNotNull((x509Name = X509_get_issuer_name(x509)) != NULL);
+        x509Name = X509_get_issuer_name(x509);
+        AssertNotNull(x509Name);
         AssertIntNE((numNames = X509_NAME_entry_count(x509Name)), 0);
         AssertTrue((bio = BIO_new(BIO_s_mem())) != NULL);
         for (j = 0; j < numNames; j++)
@@ -27326,7 +27379,8 @@ static void test_wolfSSL_BIO_should_retry(void)
     tcp_connect(&sockfd, wolfSSLIP, server_args.signal->port, 0, 0, NULL);
 
     /* force retry */
-    AssertNotNull(ssl = wolfSSL_new(ctx));
+    ssl = wolfSSL_new(ctx);
+    AssertNotNull(ssl);
     AssertIntEQ(wolfSSL_set_fd(ssl, sockfd), WOLFSSL_SUCCESS);
     wolfSSL_SSLSetIORecv(ssl, forceWantRead);
 
@@ -28554,8 +28608,8 @@ static void test_wolfSSL_DH_1536_prime(void)
     };
 
     printf(testingFmt, "wolfSSL_DH_1536_prime()");
-
-    AssertNotNull(bn = get_rfc3526_prime_1536(NULL));
+    bn = get_rfc3526_prime_1536(NULL);
+    AssertNotNull(bn);
     AssertIntEQ(sz, BN_bn2bin((const BIGNUM*)bn, bits));
     AssertIntEQ(0, XMEMCMP(expected, bits, sz));
 
@@ -29461,9 +29515,10 @@ static void test_wolfSSL_get_ciphers_compat(void)
     const long flags = SSL_OP_NO_SSLv2 | SSL_OP_NO_COMPRESSION;
 
     printf(testingFmt, "wolfSSL_get_ciphers_compat");
-
-    AssertNotNull(method = SSLv23_client_method());
-    AssertNotNull(ctx = SSL_CTX_new(method));
+    method = SSLv23_client_method();
+    AssertNotNull(method);
+    ctx = SSL_CTX_new(method);
+    AssertNotNull(ctx);
 
     SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, 0);
     SSL_CTX_set_verify_depth(ctx, 4);
@@ -31478,8 +31533,8 @@ static void test_wolfSSL_EVP_PKEY_sign(void)
     size_t rsaKeySz = 2048/8;  /* Bytes */
 
     printf(testingFmt, "wolfSSL_EVP_PKEY_sign()");
-
-    AssertNotNull(sig = (byte*)XMALLOC(rsaKeySz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER));
+    sig = (byte*)XMALLOC(rsaKeySz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    AssertNotNull(sig);
     XMEMSET(sig, 0, rsaKeySz);
     AssertNotNull(sigVerify = (byte*)XMALLOC(rsaKeySz, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER));
     XMEMSET(sigVerify, 0, rsaKeySz);
@@ -33753,9 +33808,11 @@ static void test_stubs_are_stubs()
     WOLFSSL_CTX* ctx = NULL;
     WOLFSSL_CTX* ctxN = NULL;
   #ifndef NO_WOLFSSL_CLIENT
-    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
+    ctx = wolfSSL_CTX_new(wolfSSLv23_client_method());
+    AssertNotNull(ctx);
   #elif !defined(NO_WOLFSSL_SERVER)
-    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
+    ctx = wolfSSL_CTX_new(wolfSSLv23_server_method());
+    AssertNotNull(ctx);
   #else
     return;
   #endif

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -856,7 +856,7 @@ int  wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
 
     if (ret == WOLFSSL_SUCCESS) {
         /* reset cipher state after final */
-        wolfSSL_EVP_CipherInit(ctx, NULL, NULL, NULL, -1);
+        ret = wolfSSL_EVP_CipherInit(ctx, NULL, NULL, NULL, -1);
     }
     return ret;
 }

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -2122,6 +2122,7 @@ static byte* PKCS12_create_cert_content(WC_PKCS12* pkcs12, int nidCert,
     XFREE(certBuf, heap, DYNAMIC_TYPE_TMP_BUFFER);
     if (ret < 0) {
         WOLFSSL_LEAVE("wc_PKCS12_create()", ret);
+        XFREE(certCi, heap, DYNAMIC_TYPE_TMP_BUFFER);
         return NULL;
     }
     *certCiSz = ret;


### PR DESCRIPTION
This PR fixes Coverity issues in wolfSSL 4.4.0 with the default "./configure --enable-all && make" configurations.