### PR TITLE
Updates to Xcode projects to add new files / features

### DIFF
--- a/IDE/XCODE/Benchmark/wolfBench.xcodeproj/project.pbxproj
+++ b/IDE/XCODE/Benchmark/wolfBench.xcodeproj/project.pbxproj
@@ -8,6 +8,24 @@
 
 /* Begin PBXBuildFile section */
 		52114C8721B5A7320022ADA1 /* sp_c64.c in Sources */ = {isa = PBXBuildFile; fileRef = 52114C8621B5A7320022ADA1 /* sp_c64.c */; };
+		A46FE16F2493E8F800A25BE7 /* armv8-chacha.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE14C2493E8F500A25BE7 /* armv8-chacha.c */; };
+		A46FE1702493E8F800A25BE7 /* sp_int.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE14D2493E8F600A25BE7 /* sp_int.c */; };
+		A46FE1732493E8F800A25BE7 /* armv8-poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE1502493E8F600A25BE7 /* armv8-poly1305.c */; };
+		A46FE1742493E8F800A25BE7 /* sp_cortexm.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE1512493E8F600A25BE7 /* sp_cortexm.c */; };
+		A46FE1752493E8F800A25BE7 /* blake2s.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE1522493E8F600A25BE7 /* blake2s.c */; };
+		A46FE1772493E8F800A25BE7 /* wc_pkcs11.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE1542493E8F600A25BE7 /* wc_pkcs11.c */; };
+		A46FE1792493E8F800A25BE7 /* sp_arm64.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE1562493E8F600A25BE7 /* sp_arm64.c */; };
+		A46FE17A2493E8F800A25BE7 /* cryptocb.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE1572493E8F600A25BE7 /* cryptocb.c */; };
+		A46FE1802493E8F800A25BE7 /* ed448.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE15D2493E8F700A25BE7 /* ed448.c */; };
+		A46FE1812493E8F800A25BE7 /* wc_dsp.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE15E2493E8F700A25BE7 /* wc_dsp.c */; };
+		A46FE1842493E8F800A25BE7 /* sp_x86_64.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE1612493E8F700A25BE7 /* sp_x86_64.c */; };
+		A46FE1852493E8F800A25BE7 /* sp_armthumb.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE1622493E8F700A25BE7 /* sp_armthumb.c */; };
+		A46FE1882493E8F800A25BE7 /* sp_arm32.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE1652493E8F700A25BE7 /* sp_arm32.c */; };
+		A46FE1892493E8F800A25BE7 /* sp_dsp32.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE1662493E8F800A25BE7 /* sp_dsp32.c */; };
+		A46FE18A2493E8F800A25BE7 /* ge_448.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE1672493E8F800A25BE7 /* ge_448.c */; };
+		A46FE18B2493E8F800A25BE7 /* curve448.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE1682493E8F800A25BE7 /* curve448.c */; };
+		A46FE18D2493E8F800A25BE7 /* fe_448.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE16A2493E8F800A25BE7 /* fe_448.c */; };
+		A46FE1912493E8F800A25BE7 /* sp_c32.c in Sources */ = {isa = PBXBuildFile; fileRef = A46FE16E2493E8F800A25BE7 /* sp_c32.c */; };
 		A47546261FD90492005176B9 /* tls_bench.c in Sources */ = {isa = PBXBuildFile; fileRef = A47546251FD90492005176B9 /* tls_bench.c */; };
 		A4ADF82F1FCE0BD300A06E90 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A4ADF82E1FCE0BD300A06E90 /* AppDelegate.m */; };
 		A4ADF8321FCE0BD300A06E90 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A4ADF8311FCE0BD300A06E90 /* ViewController.m */; };
@@ -85,6 +103,24 @@
 
 /* Begin PBXFileReference section */
 		52114C8621B5A7320022ADA1 /* sp_c64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_c64.c; path = ../../../wolfcrypt/src/sp_c64.c; sourceTree = "<group>"; };
+		A46FE14C2493E8F500A25BE7 /* armv8-chacha.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = "armv8-chacha.c"; path = "../../../wolfcrypt/src/port/arm/armv8-chacha.c"; sourceTree = "<group>"; };
+		A46FE14D2493E8F600A25BE7 /* sp_int.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_int.c; path = ../../../wolfcrypt/src/sp_int.c; sourceTree = "<group>"; };
+		A46FE1502493E8F600A25BE7 /* armv8-poly1305.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = "armv8-poly1305.c"; path = "../../../wolfcrypt/src/port/arm/armv8-poly1305.c"; sourceTree = "<group>"; };
+		A46FE1512493E8F600A25BE7 /* sp_cortexm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_cortexm.c; path = ../../../wolfcrypt/src/sp_cortexm.c; sourceTree = "<group>"; };
+		A46FE1522493E8F600A25BE7 /* blake2s.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = blake2s.c; path = ../../../wolfcrypt/src/blake2s.c; sourceTree = "<group>"; };
+		A46FE1542493E8F600A25BE7 /* wc_pkcs11.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = wc_pkcs11.c; path = ../../../wolfcrypt/src/wc_pkcs11.c; sourceTree = "<group>"; };
+		A46FE1562493E8F600A25BE7 /* sp_arm64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_arm64.c; path = ../../../wolfcrypt/src/sp_arm64.c; sourceTree = "<group>"; };
+		A46FE1572493E8F600A25BE7 /* cryptocb.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cryptocb.c; path = ../../../wolfcrypt/src/cryptocb.c; sourceTree = "<group>"; };
+		A46FE15D2493E8F700A25BE7 /* ed448.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ed448.c; path = ../../../wolfcrypt/src/ed448.c; sourceTree = "<group>"; };
+		A46FE15E2493E8F700A25BE7 /* wc_dsp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = wc_dsp.c; path = ../../../wolfcrypt/src/wc_dsp.c; sourceTree = "<group>"; };
+		A46FE1612493E8F700A25BE7 /* sp_x86_64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_x86_64.c; path = ../../../wolfcrypt/src/sp_x86_64.c; sourceTree = "<group>"; };
+		A46FE1622493E8F700A25BE7 /* sp_armthumb.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_armthumb.c; path = ../../../wolfcrypt/src/sp_armthumb.c; sourceTree = "<group>"; };
+		A46FE1652493E8F700A25BE7 /* sp_arm32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_arm32.c; path = ../../../wolfcrypt/src/sp_arm32.c; sourceTree = "<group>"; };
+		A46FE1662493E8F800A25BE7 /* sp_dsp32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_dsp32.c; path = ../../../wolfcrypt/src/sp_dsp32.c; sourceTree = "<group>"; };
+		A46FE1672493E8F800A25BE7 /* ge_448.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_448.c; path = ../../../wolfcrypt/src/ge_448.c; sourceTree = "<group>"; };
+		A46FE1682493E8F800A25BE7 /* curve448.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = curve448.c; path = ../../../wolfcrypt/src/curve448.c; sourceTree = "<group>"; };
+		A46FE16A2493E8F800A25BE7 /* fe_448.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_448.c; path = ../../../wolfcrypt/src/fe_448.c; sourceTree = "<group>"; };
+		A46FE16E2493E8F800A25BE7 /* sp_c32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_c32.c; path = ../../../wolfcrypt/src/sp_c32.c; sourceTree = "<group>"; };
 		A47546241FD9042D005176B9 /* user_settings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = user_settings.h; path = ../user_settings.h; sourceTree = "<group>"; };
 		A47546251FD90492005176B9 /* tls_bench.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tls_bench.c; path = ../../../examples/benchmark/tls_bench.c; sourceTree = "<group>"; };
 		A4ADF82A1FCE0BD300A06E90 /* wolfBench.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = wolfBench.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -233,13 +269,16 @@
 		A4ADF8601FCE0BFB00A06E90 /* wolfCrypt */ = {
 			isa = PBXGroup;
 			children = (
-				A4DFEC0F1FD4CB8500A7BB33 /* armv8-aes.c */,
-				A4DFEC0E1FD4CB8500A7BB33 /* armv8-sha256.c */,
 				A4ADF8821FCE0C4D00A06E90 /* aes.c */,
 				A4ADF8921FCE0C4E00A06E90 /* arc4.c */,
+				A4DFEC0F1FD4CB8500A7BB33 /* armv8-aes.c */,
+				A46FE14C2493E8F500A25BE7 /* armv8-chacha.c */,
+				A46FE1502493E8F600A25BE7 /* armv8-poly1305.c */,
+				A4DFEC0E1FD4CB8500A7BB33 /* armv8-sha256.c */,
 				A4ADF8A01FCE0C4F00A06E90 /* asm.c */,
 				A4ADF8C21FCE0C5300A06E90 /* asn.c */,
 				A4ADF8B11FCE0C5100A06E90 /* blake2b.c */,
+				A46FE1522493E8F600A25BE7 /* blake2s.c */,
 				A4ADF8C71FCE0C5400A06E90 /* camellia.c */,
 				A4ADF8CA1FCE0C5500A06E90 /* chacha.c */,
 				A4ADF88F1FCE0C4E00A06E90 /* chacha20_poly1305.c */,
@@ -247,16 +286,21 @@
 				A4ADF8CE1FCE0C5500A06E90 /* coding.c */,
 				A4ADF8871FCE0C4D00A06E90 /* compress.c */,
 				A4ADF8C11FCE0C5300A06E90 /* cpuid.c */,
+				A46FE1572493E8F600A25BE7 /* cryptocb.c */,
+				A46FE1682493E8F800A25BE7 /* curve448.c */,
 				A4ADF8801FCE0C4D00A06E90 /* curve25519.c */,
 				A4ADF8A81FCE0C5000A06E90 /* des3.c */,
 				A4ADF8AB1FCE0C5000A06E90 /* dh.c */,
 				A4ADF87D1FCE0C4D00A06E90 /* dsa.c */,
 				A4ADF8841FCE0C4D00A06E90 /* ecc_fp.c */,
 				A4ADF8CC1FCE0C5500A06E90 /* ecc.c */,
+				A46FE15D2493E8F700A25BE7 /* ed448.c */,
 				A4ADF8CB1FCE0C5500A06E90 /* ed25519.c */,
 				A4ADF8811FCE0C4D00A06E90 /* error.c */,
+				A46FE16A2493E8F800A25BE7 /* fe_448.c */,
 				A4ADF89C1FCE0C4F00A06E90 /* fe_low_mem.c */,
 				A4ADF8BA1FCE0C5300A06E90 /* fe_operations.c */,
+				A46FE1672493E8F800A25BE7 /* ge_448.c */,
 				A4ADF8D01FCE0C5500A06E90 /* ge_low_mem.c */,
 				A4ADF88E1FCE0C4E00A06E90 /* ge_operations.c */,
 				A4ADF89A1FCE0C4F00A06E90 /* hash.c */,
@@ -282,10 +326,20 @@
 				A4ADF8831FCE0C4D00A06E90 /* sha256.c */,
 				A4ADF8AE1FCE0C5100A06E90 /* sha512.c */,
 				A4ADF8B71FCE0C5200A06E90 /* signature.c */,
+				A46FE1652493E8F700A25BE7 /* sp_arm32.c */,
+				A46FE1562493E8F600A25BE7 /* sp_arm64.c */,
+				A46FE1622493E8F700A25BE7 /* sp_armthumb.c */,
+				A46FE16E2493E8F800A25BE7 /* sp_c32.c */,
 				52114C8621B5A7320022ADA1 /* sp_c64.c */,
+				A46FE1512493E8F600A25BE7 /* sp_cortexm.c */,
+				A46FE1662493E8F800A25BE7 /* sp_dsp32.c */,
+				A46FE14D2493E8F600A25BE7 /* sp_int.c */,
+				A46FE1612493E8F700A25BE7 /* sp_x86_64.c */,
 				A4ADF8BF1FCE0C5300A06E90 /* srp.c */,
 				A4ADF8881FCE0C4D00A06E90 /* tfm.c */,
+				A46FE15E2493E8F700A25BE7 /* wc_dsp.c */,
 				A4ADF8AA1FCE0C5000A06E90 /* wc_encrypt.c */,
+				A46FE1542493E8F600A25BE7 /* wc_pkcs11.c */,
 				A4ADF8B61FCE0C5200A06E90 /* wc_port.c */,
 				A4ADF87B1FCE0C4D00A06E90 /* wolfevent.c */,
 				A4ADF8B81FCE0C5200A06E90 /* wolfmath.c */,
@@ -381,33 +435,46 @@
 			buildActionMask = 2147483647;
 			files = (
 				A4ADF9041FCE0C5600A06E90 /* des3.c in Sources */,
+				A46FE18A2493E8F800A25BE7 /* ge_448.c in Sources */,
 				A4ADF9121FCE0C5600A06E90 /* wc_port.c in Sources */,
 				A4ADF8E41FCE0C5600A06E90 /* tfm.c in Sources */,
 				A4ADF8D91FCE0C5600A06E90 /* dsa.c in Sources */,
 				A4ADF9141FCE0C5600A06E90 /* wolfmath.c in Sources */,
 				A4ADF8FC1FCE0C5600A06E90 /* asm.c in Sources */,
+				A46FE18D2493E8F800A25BE7 /* fe_448.c in Sources */,
 				A4ADF8721FCE0C1C00A06E90 /* crl.c in Sources */,
 				A4ADF91B1FCE0C5600A06E90 /* srp.c in Sources */,
 				A4ADF9101FCE0C5600A06E90 /* rabbit.c in Sources */,
 				A4ADF9091FCE0C5600A06E90 /* idea.c in Sources */,
+				A46FE16F2493E8F800A25BE7 /* armv8-chacha.c in Sources */,
 				A4ADF8FE1FCE0C5600A06E90 /* integer.c in Sources */,
 				A4ADF9231FCE0C5600A06E90 /* camellia.c in Sources */,
 				A4ADF8321FCE0BD300A06E90 /* ViewController.m in Sources */,
+				A46FE17A2493E8F800A25BE7 /* cryptocb.c in Sources */,
+				A46FE18B2493E8F800A25BE7 /* curve448.c in Sources */,
 				A4ADF8DB1FCE0C5600A06E90 /* hc128.c in Sources */,
 				A4ADF8E31FCE0C5600A06E90 /* compress.c in Sources */,
 				A4ADF8731FCE0C1C00A06E90 /* tls13.c in Sources */,
 				A4ADF90D1FCE0C5600A06E90 /* blake2b.c in Sources */,
 				A4ADF9071FCE0C5600A06E90 /* dh.c in Sources */,
+				A46FE1912493E8F800A25BE7 /* sp_c32.c in Sources */,
 				A4ADF8F31FCE0C5600A06E90 /* rsa.c in Sources */,
+				A46FE1752493E8F800A25BE7 /* blake2s.c in Sources */,
 				A4ADF8FA1FCE0C5600A06E90 /* pkcs12.c in Sources */,
 				A4ADF86E1FCE0C1C00A06E90 /* ocsp.c in Sources */,
+				A46FE1842493E8F800A25BE7 /* sp_x86_64.c in Sources */,
+				A46FE1792493E8F800A25BE7 /* sp_arm64.c in Sources */,
+				A46FE1742493E8F800A25BE7 /* sp_cortexm.c in Sources */,
 				A4ADF9281FCE0C5600A06E90 /* ecc.c in Sources */,
+				A46FE1852493E8F800A25BE7 /* sp_armthumb.c in Sources */,
 				A4ADF91C1FCE0C5600A06E90 /* pwdbased.c in Sources */,
 				A4ADF92C1FCE0C5600A06E90 /* ge_low_mem.c in Sources */,
 				A4ADF90C1FCE0C5600A06E90 /* ripemd.c in Sources */,
 				A4ADF8D51FCE0C5600A06E90 /* md5.c in Sources */,
+				A46FE1892493E8F800A25BE7 /* sp_dsp32.c in Sources */,
 				A4ADF8DF1FCE0C5600A06E90 /* sha256.c in Sources */,
 				A4ADF8711FCE0C1C00A06E90 /* sniffer.c in Sources */,
+				A46FE1882493E8F800A25BE7 /* sp_arm32.c in Sources */,
 				A4ADF8701FCE0C1C00A06E90 /* tls.c in Sources */,
 				A4ADF8E51FCE0C5600A06E90 /* sha.c in Sources */,
 				A4DFEC101FD4CB8500A7BB33 /* armv8-sha256.c in Sources */,
@@ -416,6 +483,7 @@
 				A4ADF8D11FCE0C5600A06E90 /* hmac.c in Sources */,
 				A4ADF8F01FCE0C5600A06E90 /* memory.c in Sources */,
 				A4ADF82F1FCE0BD300A06E90 /* AppDelegate.m in Sources */,
+				A46FE1772493E8F800A25BE7 /* wc_pkcs11.c in Sources */,
 				A4ADF8D31FCE0C5600A06E90 /* random.c in Sources */,
 				A4ADF9131FCE0C5600A06E90 /* signature.c in Sources */,
 				A4DFEC3C1FD6B9CC00A7BB33 /* test.c in Sources */,
@@ -425,16 +493,19 @@
 				A4ADF91E1FCE0C5600A06E90 /* asn.c in Sources */,
 				A4ADF8F61FCE0C5600A06E90 /* hash.c in Sources */,
 				A4ADF92A1FCE0C5600A06E90 /* coding.c in Sources */,
+				A46FE1702493E8F800A25BE7 /* sp_int.c in Sources */,
 				A4ADF8741FCE0C1C00A06E90 /* ssl.c in Sources */,
 				A4ADF9051FCE0C5600A06E90 /* cmac.c in Sources */,
 				52114C8721B5A7320022ADA1 /* sp_c64.c in Sources */,
 				A4ADF8F41FCE0C5600A06E90 /* pkcs7.c in Sources */,
+				A46FE1732493E8F800A25BE7 /* armv8-poly1305.c in Sources */,
 				A4ADF90B1FCE0C5600A06E90 /* logging.c in Sources */,
 				A4ADF8E01FCE0C5600A06E90 /* ecc_fp.c in Sources */,
 				A4ADF8EB1FCE0C5600A06E90 /* chacha20_poly1305.c in Sources */,
 				A4ADF86B1FCE0C1C00A06E90 /* keys.c in Sources */,
 				A4ADF8EE1FCE0C5600A06E90 /* arc4.c in Sources */,
 				A4DFEC111FD4CB8500A7BB33 /* armv8-aes.c in Sources */,
+				A46FE1812493E8F800A25BE7 /* wc_dsp.c in Sources */,
 				A4ADF9061FCE0C5600A06E90 /* wc_encrypt.c in Sources */,
 				A4ADF8DC1FCE0C5600A06E90 /* curve25519.c in Sources */,
 				A4ADF8D81FCE0C5600A06E90 /* md4.c in Sources */,
@@ -449,6 +520,7 @@
 				A4ADF8F81FCE0C5600A06E90 /* fe_low_mem.c in Sources */,
 				A4ADF86D1FCE0C1C00A06E90 /* wolfio.c in Sources */,
 				A4ADF8D71FCE0C5600A06E90 /* wolfevent.c in Sources */,
+				A46FE1802493E8F800A25BE7 /* ed448.c in Sources */,
 				A4DFEC0D1FD4CAA300A7BB33 /* benchmark.c in Sources */,
 				A4ADF91D1FCE0C5600A06E90 /* cpuid.c in Sources */,
 			);

--- a/IDE/XCODE/user_settings.h
+++ b/IDE/XCODE/user_settings.h
@@ -46,6 +46,7 @@
     /* ARMv8 - iPhone 8/8Plus and iPhone X */
     #ifdef __ARM_FEATURE_CRYPTO
         #define WOLFSSL_ARMASM
+        #define WOLFSSL_SP_ARM64_ASM
     #endif
 
     /* newer algorithms */
@@ -75,6 +76,7 @@
     /* test certificate buffers */
     #define USE_CERT_BUFFERS_2048
     #define USE_CERT_BUFFERS_256
+    #define NO_WRITE_TEMP_FILES
 
     #define WOLFSSL_DTLS
 

--- a/IDE/XCODE/wolfssl.xcodeproj/project.pbxproj
+++ b/IDE/XCODE/wolfssl.xcodeproj/project.pbxproj
@@ -356,6 +356,75 @@
 		522DBE0F1B7927A50031F454 /* wc_encrypt.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 522DBE0E1B7927290031F454 /* wc_encrypt.h */; };
 		525BE5341B3869110054BBCD /* hash.c in Sources */ = {isa = PBXBuildFile; fileRef = 525BE5331B3869110054BBCD /* hash.c */; };
 		525BE5361B3869780054BBCD /* hash.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 525BE5351B3869430054BBCD /* hash.h */; };
+		A4DAE3062493F1C700CEF51F /* tls13.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3052493F1C700CEF51F /* tls13.c */; };
+		A4DAE3072493F1C700CEF51F /* tls13.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3052493F1C700CEF51F /* tls13.c */; };
+		A4DAE3082493F1C700CEF51F /* tls13.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3052493F1C700CEF51F /* tls13.c */; };
+		A4DAE31A2493F21900CEF51F /* srp.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3092493F21700CEF51F /* srp.c */; };
+		A4DAE31B2493F21900CEF51F /* srp.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3092493F21700CEF51F /* srp.c */; };
+		A4DAE31C2493F21900CEF51F /* srp.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3092493F21700CEF51F /* srp.c */; };
+		A4DAE31D2493F21900CEF51F /* ed448.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30A2493F21800CEF51F /* ed448.c */; };
+		A4DAE31E2493F21900CEF51F /* ed448.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30A2493F21800CEF51F /* ed448.c */; };
+		A4DAE31F2493F21900CEF51F /* ed448.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30A2493F21800CEF51F /* ed448.c */; };
+		A4DAE3202493F21900CEF51F /* cpuid.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30B2493F21800CEF51F /* cpuid.c */; };
+		A4DAE3212493F21900CEF51F /* cpuid.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30B2493F21800CEF51F /* cpuid.c */; };
+		A4DAE3222493F21900CEF51F /* cpuid.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30B2493F21800CEF51F /* cpuid.c */; };
+		A4DAE3232493F21900CEF51F /* asm.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30C2493F21800CEF51F /* asm.c */; };
+		A4DAE3242493F21900CEF51F /* asm.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30C2493F21800CEF51F /* asm.c */; };
+		A4DAE3252493F21900CEF51F /* asm.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30C2493F21800CEF51F /* asm.c */; };
+		A4DAE3262493F21900CEF51F /* fe_448.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30D2493F21800CEF51F /* fe_448.c */; };
+		A4DAE3272493F21900CEF51F /* fe_448.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30D2493F21800CEF51F /* fe_448.c */; };
+		A4DAE3282493F21900CEF51F /* fe_448.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30D2493F21800CEF51F /* fe_448.c */; };
+		A4DAE3292493F21900CEF51F /* compress.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30E2493F21800CEF51F /* compress.c */; };
+		A4DAE32A2493F21900CEF51F /* compress.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30E2493F21800CEF51F /* compress.c */; };
+		A4DAE32B2493F21900CEF51F /* compress.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30E2493F21800CEF51F /* compress.c */; };
+		A4DAE32C2493F21900CEF51F /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30F2493F21800CEF51F /* cmac.c */; };
+		A4DAE32D2493F21900CEF51F /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30F2493F21800CEF51F /* cmac.c */; };
+		A4DAE32E2493F21900CEF51F /* cmac.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE30F2493F21800CEF51F /* cmac.c */; };
+		A4DAE32F2493F21900CEF51F /* ecc_fp.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3102493F21800CEF51F /* ecc_fp.c */; };
+		A4DAE3302493F21900CEF51F /* ecc_fp.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3102493F21800CEF51F /* ecc_fp.c */; };
+		A4DAE3312493F21900CEF51F /* ecc_fp.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3102493F21800CEF51F /* ecc_fp.c */; };
+		A4DAE3322493F21900CEF51F /* cryptocb.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3112493F21800CEF51F /* cryptocb.c */; };
+		A4DAE3332493F21900CEF51F /* cryptocb.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3112493F21800CEF51F /* cryptocb.c */; };
+		A4DAE3342493F21900CEF51F /* cryptocb.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3112493F21800CEF51F /* cryptocb.c */; };
+		A4DAE3352493F21900CEF51F /* wolfevent.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3122493F21800CEF51F /* wolfevent.c */; };
+		A4DAE3362493F21900CEF51F /* wolfevent.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3122493F21800CEF51F /* wolfevent.c */; };
+		A4DAE3372493F21900CEF51F /* wolfevent.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3122493F21800CEF51F /* wolfevent.c */; };
+		A4DAE3382493F21900CEF51F /* pkcs12.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3132493F21800CEF51F /* pkcs12.c */; };
+		A4DAE3392493F21900CEF51F /* pkcs12.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3132493F21800CEF51F /* pkcs12.c */; };
+		A4DAE33A2493F21900CEF51F /* pkcs12.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3132493F21800CEF51F /* pkcs12.c */; };
+		A4DAE33B2493F21900CEF51F /* curve448.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3142493F21800CEF51F /* curve448.c */; };
+		A4DAE33C2493F21900CEF51F /* curve448.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3142493F21800CEF51F /* curve448.c */; };
+		A4DAE33D2493F21900CEF51F /* curve448.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3142493F21800CEF51F /* curve448.c */; };
+		A4DAE33E2493F21900CEF51F /* ge_448.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3152493F21800CEF51F /* ge_448.c */; };
+		A4DAE33F2493F21900CEF51F /* ge_448.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3152493F21800CEF51F /* ge_448.c */; };
+		A4DAE3402493F21900CEF51F /* ge_448.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3152493F21800CEF51F /* ge_448.c */; };
+		A4DAE3412493F21900CEF51F /* wc_dsp.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3162493F21900CEF51F /* wc_dsp.c */; };
+		A4DAE3422493F21900CEF51F /* wc_dsp.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3162493F21900CEF51F /* wc_dsp.c */; };
+		A4DAE3432493F21900CEF51F /* wc_dsp.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3162493F21900CEF51F /* wc_dsp.c */; };
+		A4DAE3442493F21900CEF51F /* wc_pkcs11.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3172493F21900CEF51F /* wc_pkcs11.c */; };
+		A4DAE3452493F21900CEF51F /* wc_pkcs11.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3172493F21900CEF51F /* wc_pkcs11.c */; };
+		A4DAE3462493F21900CEF51F /* wc_pkcs11.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3172493F21900CEF51F /* wc_pkcs11.c */; };
+		A4DAE3472493F21900CEF51F /* blake2s.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3182493F21900CEF51F /* blake2s.c */; };
+		A4DAE3482493F21900CEF51F /* blake2s.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3182493F21900CEF51F /* blake2s.c */; };
+		A4DAE3492493F21900CEF51F /* blake2s.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3182493F21900CEF51F /* blake2s.c */; };
+		A4DAE34A2493F21900CEF51F /* idea.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3192493F21900CEF51F /* idea.c */; };
+		A4DAE34B2493F21900CEF51F /* idea.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3192493F21900CEF51F /* idea.c */; };
+		A4DAE34C2493F21900CEF51F /* idea.c in Sources */ = {isa = PBXBuildFile; fileRef = A4DAE3192493F21900CEF51F /* idea.c */; };
+		A4DAE34D2493F28B00CEF51F /* sp_arm32.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5912493E20500725359 /* sp_arm32.c */; };
+		A4DAE34E2493F28C00CEF51F /* sp_arm32.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5912493E20500725359 /* sp_arm32.c */; };
+		A4DAE3502493F29100CEF51F /* sp_arm64.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5902493E20500725359 /* sp_arm64.c */; };
+		A4DAE3512493F29100CEF51F /* sp_arm64.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5902493E20500725359 /* sp_arm64.c */; };
+		A4DAE3522493F29500CEF51F /* sp_armthumb.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5942493E20500725359 /* sp_armthumb.c */; };
+		A4DAE3532493F29500CEF51F /* sp_armthumb.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5942493E20500725359 /* sp_armthumb.c */; };
+		A4DAE3542493F29B00CEF51F /* sp_cortexm.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5932493E20500725359 /* sp_cortexm.c */; };
+		A4DAE3552493F29B00CEF51F /* sp_cortexm.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5932493E20500725359 /* sp_cortexm.c */; };
+		A4DAE3562493F29E00CEF51F /* sp_dsp32.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5922493E20500725359 /* sp_dsp32.c */; };
+		A4DAE3572493F29E00CEF51F /* sp_dsp32.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5922493E20500725359 /* sp_dsp32.c */; };
+		A4E7E5952493E20500725359 /* sp_arm64.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5902493E20500725359 /* sp_arm64.c */; };
+		A4E7E5962493E20500725359 /* sp_arm32.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5912493E20500725359 /* sp_arm32.c */; };
+		A4E7E5972493E20500725359 /* sp_dsp32.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5922493E20500725359 /* sp_dsp32.c */; };
+		A4E7E5982493E20500725359 /* sp_cortexm.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5932493E20500725359 /* sp_cortexm.c */; };
+		A4E7E5992493E20500725359 /* sp_armthumb.c in Sources */ = {isa = PBXBuildFile; fileRef = A4E7E5942493E20500725359 /* sp_armthumb.c */; };
 		A4F318501BC58B1700FDF2BB /* dsa.c in Sources */ = {isa = PBXBuildFile; fileRef = 5216461A1A8992CC0062516A /* dsa.c */; };
 		A4F318511BC58B1700FDF2BB /* logging.c in Sources */ = {isa = PBXBuildFile; fileRef = 521646201A8992CC0062516A /* logging.c */; };
 		A4F318521BC58B1700FDF2BB /* sha.c in Sources */ = {isa = PBXBuildFile; fileRef = 5216462D1A8992CC0062516A /* sha.c */; };
@@ -1119,6 +1188,29 @@
 		525BE5351B3869430054BBCD /* hash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hash.h; path = ../../wolfssl/wolfcrypt/hash.h; sourceTree = "<group>"; };
 		52B1344D16F3C9E800C07B32 /* libwolfssl_ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libwolfssl_ios.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A45EA7091BC5995E00A8614A /* user_settings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = user_settings.h; sourceTree = "<group>"; };
+		A4DAE3052493F1C700CEF51F /* tls13.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = tls13.c; path = ../../src/tls13.c; sourceTree = "<group>"; };
+		A4DAE3092493F21700CEF51F /* srp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = srp.c; path = ../../wolfcrypt/src/srp.c; sourceTree = "<group>"; };
+		A4DAE30A2493F21800CEF51F /* ed448.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ed448.c; path = ../../wolfcrypt/src/ed448.c; sourceTree = "<group>"; };
+		A4DAE30B2493F21800CEF51F /* cpuid.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cpuid.c; path = ../../wolfcrypt/src/cpuid.c; sourceTree = "<group>"; };
+		A4DAE30C2493F21800CEF51F /* asm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = asm.c; path = ../../wolfcrypt/src/asm.c; sourceTree = "<group>"; };
+		A4DAE30D2493F21800CEF51F /* fe_448.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = fe_448.c; path = ../../wolfcrypt/src/fe_448.c; sourceTree = "<group>"; };
+		A4DAE30E2493F21800CEF51F /* compress.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = compress.c; path = ../../wolfcrypt/src/compress.c; sourceTree = "<group>"; };
+		A4DAE30F2493F21800CEF51F /* cmac.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cmac.c; path = ../../wolfcrypt/src/cmac.c; sourceTree = "<group>"; };
+		A4DAE3102493F21800CEF51F /* ecc_fp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ecc_fp.c; path = ../../wolfcrypt/src/ecc_fp.c; sourceTree = "<group>"; };
+		A4DAE3112493F21800CEF51F /* cryptocb.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cryptocb.c; path = ../../wolfcrypt/src/cryptocb.c; sourceTree = "<group>"; };
+		A4DAE3122493F21800CEF51F /* wolfevent.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = wolfevent.c; path = ../../wolfcrypt/src/wolfevent.c; sourceTree = "<group>"; };
+		A4DAE3132493F21800CEF51F /* pkcs12.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pkcs12.c; path = ../../wolfcrypt/src/pkcs12.c; sourceTree = "<group>"; };
+		A4DAE3142493F21800CEF51F /* curve448.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = curve448.c; path = ../../wolfcrypt/src/curve448.c; sourceTree = "<group>"; };
+		A4DAE3152493F21800CEF51F /* ge_448.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ge_448.c; path = ../../wolfcrypt/src/ge_448.c; sourceTree = "<group>"; };
+		A4DAE3162493F21900CEF51F /* wc_dsp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = wc_dsp.c; path = ../../wolfcrypt/src/wc_dsp.c; sourceTree = "<group>"; };
+		A4DAE3172493F21900CEF51F /* wc_pkcs11.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = wc_pkcs11.c; path = ../../wolfcrypt/src/wc_pkcs11.c; sourceTree = "<group>"; };
+		A4DAE3182493F21900CEF51F /* blake2s.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = blake2s.c; path = ../../wolfcrypt/src/blake2s.c; sourceTree = "<group>"; };
+		A4DAE3192493F21900CEF51F /* idea.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = idea.c; path = ../../wolfcrypt/src/idea.c; sourceTree = "<group>"; };
+		A4E7E5902493E20500725359 /* sp_arm64.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_arm64.c; path = ../../wolfcrypt/src/sp_arm64.c; sourceTree = "<group>"; };
+		A4E7E5912493E20500725359 /* sp_arm32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_arm32.c; path = ../../wolfcrypt/src/sp_arm32.c; sourceTree = "<group>"; };
+		A4E7E5922493E20500725359 /* sp_dsp32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_dsp32.c; path = ../../wolfcrypt/src/sp_dsp32.c; sourceTree = "<group>"; };
+		A4E7E5932493E20500725359 /* sp_cortexm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_cortexm.c; path = ../../wolfcrypt/src/sp_cortexm.c; sourceTree = "<group>"; };
+		A4E7E5942493E20500725359 /* sp_armthumb.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sp_armthumb.c; path = ../../wolfcrypt/src/sp_armthumb.c; sourceTree = "<group>"; };
 		A4F318EE1BC58B1700FDF2BB /* libwolfssl_osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libwolfssl_osx.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -1311,26 +1403,38 @@
 			children = (
 				521646111A8992CC0062516A /* aes.c */,
 				521646121A8992CC0062516A /* arc4.c */,
+				A4DAE30C2493F21800CEF51F /* asm.c */,
 				521646131A8992CC0062516A /* asn.c */,
 				521646141A8992CC0062516A /* blake2b.c */,
+				A4DAE3182493F21900CEF51F /* blake2s.c */,
 				521646151A8992CC0062516A /* camellia.c */,
 				521646161A8992CC0062516A /* chacha.c */,
 				1E8BEB77212F4CF80063DCC1 /* chacha20_poly1305.c */,
+				A4DAE30F2493F21800CEF51F /* cmac.c */,
 				521646171A8992CC0062516A /* coding.c */,
+				A4DAE30E2493F21800CEF51F /* compress.c */,
+				A4DAE30B2493F21800CEF51F /* cpuid.c */,
+				A4DAE3112493F21800CEF51F /* cryptocb.c */,
+				A4DAE3142493F21800CEF51F /* curve448.c */,
 				1E8BEB75212F4CF80063DCC1 /* curve25519.c */,
+				521646181A8992CC0062516A /* des3.c */,
 				521646191A8992CC0062516A /* dh.c */,
 				5216461A1A8992CC0062516A /* dsa.c */,
-				521646181A8992CC0062516A /* des3.c */,
+				A4DAE3102493F21800CEF51F /* ecc_fp.c */,
 				5216461B1A8992CC0062516A /* ecc.c */,
+				A4DAE30A2493F21800CEF51F /* ed448.c */,
 				1E8BEB76212F4CF80063DCC1 /* ed25519.c */,
 				5216461C1A8992CC0062516A /* error.c */,
+				A4DAE30D2493F21800CEF51F /* fe_448.c */,
 				1E8BEB85212F4F010063DCC1 /* fe_low_mem.c */,
 				1E8BEB84212F4F010063DCC1 /* fe_operations.c */,
+				A4DAE3152493F21800CEF51F /* ge_448.c */,
 				1E8BEB81212F4E330063DCC1 /* ge_low_mem.c */,
 				1E8BEB80212F4E330063DCC1 /* ge_operations.c */,
 				525BE5331B3869110054BBCD /* hash.c */,
 				5216461D1A8992CC0062516A /* hc128.c */,
 				5216461E1A8992CC0062516A /* hmac.c */,
+				A4DAE3192493F21900CEF51F /* idea.c */,
 				5216461F1A8992CC0062516A /* integer.c */,
 				521646201A8992CC0062516A /* logging.c */,
 				521646211A8992CC0062516A /* md2.c */,
@@ -1339,6 +1443,7 @@
 				521646241A8992CC0062516A /* memory.c */,
 				521646251A8992CC0062516A /* misc.c */,
 				521646261A8992CC0062516A /* pkcs7.c */,
+				A4DAE3132493F21800CEF51F /* pkcs12.c */,
 				521646271A8992CC0062516A /* poly1305.c */,
 				521646281A8992CC0062516A /* pwdbased.c */,
 				521646291A8992CC0062516A /* rabbit.c */,
@@ -1346,17 +1451,26 @@
 				5216462B1A8992CC0062516A /* ripemd.c */,
 				5216462C1A8992CC0062516A /* rsa.c */,
 				5216462D1A8992CC0062516A /* sha.c */,
-				5216462E1A8992CC0062516A /* sha256.c */,
 				1E8BEB6A212F49EC0063DCC1 /* sha3.c */,
+				5216462E1A8992CC0062516A /* sha256.c */,
 				5216462F1A8992CC0062516A /* sha512.c */,
 				1E8BEB7C212F4D960063DCC1 /* signature.c */,
+				A4E7E5912493E20500725359 /* sp_arm32.c */,
+				A4E7E5902493E20500725359 /* sp_arm64.c */,
+				A4E7E5942493E20500725359 /* sp_armthumb.c */,
 				1E8BEB70212F4C340063DCC1 /* sp_c32.c */,
 				1E8BEB6F212F4C340063DCC1 /* sp_c64.c */,
+				A4E7E5932493E20500725359 /* sp_cortexm.c */,
+				A4E7E5922493E20500725359 /* sp_dsp32.c */,
 				1E8BEB6E212F4C340063DCC1 /* sp_int.c */,
 				1E8BEB6C212F4AA10063DCC1 /* sp_x86_64.c */,
+				A4DAE3092493F21700CEF51F /* srp.c */,
 				521646301A8992CC0062516A /* tfm.c */,
+				A4DAE3162493F21900CEF51F /* wc_dsp.c */,
 				522DBE0C1B7926FB0031F454 /* wc_encrypt.c */,
+				A4DAE3172493F21900CEF51F /* wc_pkcs11.c */,
 				521646311A8992CC0062516A /* wc_port.c */,
+				A4DAE3122493F21800CEF51F /* wolfevent.c */,
 				1E8BEB7E212F4DCF0063DCC1 /* wolfmath.c */,
 			);
 			name = wolfCrypt;
@@ -1367,12 +1481,13 @@
 			children = (
 				521646011A89928E0062516A /* crl.c */,
 				521646021A89928E0062516A /* internal.c */,
-				521646031A89928E0062516A /* wolfio.c */,
 				521646041A89928E0062516A /* keys.c */,
 				521646051A89928E0062516A /* ocsp.c */,
 				521646061A89928E0062516A /* sniffer.c */,
 				521646071A89928E0062516A /* ssl.c */,
 				521646081A89928E0062516A /* tls.c */,
+				A4DAE3052493F1C700CEF51F /* tls13.c */,
+				521646031A89928E0062516A /* wolfio.c */,
 			);
 			name = wolfSSL;
 			sourceTree = SOURCE_ROOT;
@@ -1478,6 +1593,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 52B1344416F3C9E800C07B32;
@@ -1497,10 +1613,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A4DAE34E2493F28C00CEF51F /* sp_arm32.c in Sources */,
 				520775B42239AC3700087711 /* curve25519.c in Sources */,
 				30B060541C6DDB2B00D46008 /* crl.c in Sources */,
 				520775BA2239AC4600087711 /* ge_operations.c in Sources */,
 				30B060551C6DDB2B00D46008 /* internal.c in Sources */,
+				A4DAE3432493F21900CEF51F /* wc_dsp.c in Sources */,
 				30B060561C6DDB2B00D46008 /* wolfio.c in Sources */,
 				30B060571C6DDB2B00D46008 /* keys.c in Sources */,
 				520775C62239B25A00087711 /* sha3.c in Sources */,
@@ -1508,35 +1626,51 @@
 				520775B82239AC4600087711 /* fe_operations.c in Sources */,
 				30B060591C6DDB2B00D46008 /* sniffer.c in Sources */,
 				30B0605A1C6DDB2B00D46008 /* ssl.c in Sources */,
+				A4DAE3342493F21900CEF51F /* cryptocb.c in Sources */,
 				520775A82239ABBE00087711 /* sp_x86_64.c in Sources */,
 				30B0605B1C6DDB2B00D46008 /* tls.c in Sources */,
 				30B0605C1C6DDB2B00D46008 /* aes.c in Sources */,
 				30B0605D1C6DDB2B00D46008 /* arc4.c in Sources */,
 				30B0605E1C6DDB2B00D46008 /* asn.c in Sources */,
+				A4DAE3512493F29100CEF51F /* sp_arm64.c in Sources */,
 				30B0605F1C6DDB2B00D46008 /* blake2b.c in Sources */,
 				520775AE2239AC2100087711 /* signature.c in Sources */,
 				30B060601C6DDB2B00D46008 /* camellia.c in Sources */,
+				A4DAE31F2493F21900CEF51F /* ed448.c in Sources */,
 				30B060611C6DDB2B00D46008 /* chacha.c in Sources */,
 				30B060621C6DDB2B00D46008 /* coding.c in Sources */,
+				A4DAE31C2493F21900CEF51F /* srp.c in Sources */,
 				30B060631C6DDB2B00D46008 /* des3.c in Sources */,
+				A4DAE33D2493F21900CEF51F /* curve448.c in Sources */,
 				30B060641C6DDB2B00D46008 /* dh.c in Sources */,
 				30B060651C6DDB2B00D46008 /* dsa.c in Sources */,
 				520775BC2239AC4600087711 /* fe_low_mem.c in Sources */,
 				30B060661C6DDB2B00D46008 /* ecc.c in Sources */,
+				A4DAE3402493F21900CEF51F /* ge_448.c in Sources */,
+				A4DAE3532493F29500CEF51F /* sp_armthumb.c in Sources */,
+				A4DAE3462493F21900CEF51F /* wc_pkcs11.c in Sources */,
+				A4DAE3312493F21900CEF51F /* ecc_fp.c in Sources */,
+				A4DAE3372493F21900CEF51F /* wolfevent.c in Sources */,
 				30B060671C6DDB2B00D46008 /* error.c in Sources */,
 				520775AA2239ABBE00087711 /* sp_int.c in Sources */,
 				30B060681C6DDB2B00D46008 /* hash.c in Sources */,
+				A4DAE34C2493F21900CEF51F /* idea.c in Sources */,
 				30B060691C6DDB2B00D46008 /* hc128.c in Sources */,
 				30B0606A1C6DDB2B00D46008 /* hmac.c in Sources */,
+				A4DAE3572493F29E00CEF51F /* sp_dsp32.c in Sources */,
+				A4DAE3282493F21900CEF51F /* fe_448.c in Sources */,
 				30B0606B1C6DDB2B00D46008 /* integer.c in Sources */,
 				520775AC2239ABCD00087711 /* chacha20_poly1305.c in Sources */,
+				A4DAE3082493F1C700CEF51F /* tls13.c in Sources */,
 				30B0606C1C6DDB2B00D46008 /* logging.c in Sources */,
 				520775B22239AC3200087711 /* ed25519.c in Sources */,
 				520775B02239AC2500087711 /* wolfmath.c in Sources */,
 				30B0606D1C6DDB2B00D46008 /* md2.c in Sources */,
 				30B0606E1C6DDB2B00D46008 /* md4.c in Sources */,
 				520775B62239AC4600087711 /* ge_low_mem.c in Sources */,
+				A4DAE32E2493F21900CEF51F /* cmac.c in Sources */,
 				30B0606F1C6DDB2B00D46008 /* md5.c in Sources */,
+				A4DAE3252493F21900CEF51F /* asm.c in Sources */,
 				30B060701C6DDB2B00D46008 /* memory.c in Sources */,
 				30B060721C6DDB2B00D46008 /* pkcs7.c in Sources */,
 				30B060731C6DDB2B00D46008 /* poly1305.c in Sources */,
@@ -1547,10 +1681,15 @@
 				30B060781C6DDB2B00D46008 /* rsa.c in Sources */,
 				30B060791C6DDB2B00D46008 /* sha.c in Sources */,
 				30B0607A1C6DDB2B00D46008 /* sha256.c in Sources */,
+				A4DAE3492493F21900CEF51F /* blake2s.c in Sources */,
+				A4DAE32B2493F21900CEF51F /* compress.c in Sources */,
 				30B0607B1C6DDB2B00D46008 /* sha512.c in Sources */,
+				A4DAE33A2493F21900CEF51F /* pkcs12.c in Sources */,
 				520775A42239ABBE00087711 /* sp_c32.c in Sources */,
 				520775A62239ABBE00087711 /* sp_c64.c in Sources */,
+				A4DAE3552493F29B00CEF51F /* sp_cortexm.c in Sources */,
 				30B0607C1C6DDB2B00D46008 /* tfm.c in Sources */,
+				A4DAE3222493F21900CEF51F /* cpuid.c in Sources */,
 				30B0607D1C6DDB2B00D46008 /* wc_encrypt.c in Sources */,
 				30B0607E1C6DDB2B00D46008 /* wc_port.c in Sources */,
 			);
@@ -1560,12 +1699,19 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A4E7E5952493E20500725359 /* sp_arm64.c in Sources */,
+				A4DAE31D2493F21900CEF51F /* ed448.c in Sources */,
 				520775B52239AC3700087711 /* curve25519.c in Sources */,
+				A4DAE3442493F21900CEF51F /* wc_pkcs11.c in Sources */,
 				5216463B1A8992CC0062516A /* dsa.c in Sources */,
 				520775BB2239AC4600087711 /* ge_operations.c in Sources */,
 				521646411A8992CC0062516A /* logging.c in Sources */,
+				A4E7E5962493E20500725359 /* sp_arm32.c in Sources */,
+				A4DAE3202493F21900CEF51F /* cpuid.c in Sources */,
 				5216464E1A8992CC0062516A /* sha.c in Sources */,
+				A4DAE3412493F21900CEF51F /* wc_dsp.c in Sources */,
 				521646481A8992CC0062516A /* poly1305.c in Sources */,
+				A4DAE32C2493F21900CEF51F /* cmac.c in Sources */,
 				520775C42239B25800087711 /* sha3.c in Sources */,
 				5216463A1A8992CC0062516A /* dh.c in Sources */,
 				520775B92239AC4600087711 /* fe_operations.c in Sources */,
@@ -1573,42 +1719,58 @@
 				521646521A8992CC0062516A /* wc_port.c in Sources */,
 				520775A92239ABBE00087711 /* sp_x86_64.c in Sources */,
 				521646491A8992CC0062516A /* pwdbased.c in Sources */,
+				A4DAE3472493F21900CEF51F /* blake2s.c in Sources */,
+				A4DAE31A2493F21900CEF51F /* srp.c in Sources */,
 				5216463E1A8992CC0062516A /* hc128.c in Sources */,
 				521646341A8992CC0062516A /* asn.c in Sources */,
 				521646501A8992CC0062516A /* sha512.c in Sources */,
 				5216464A1A8992CC0062516A /* rabbit.c in Sources */,
 				520775AF2239AC2100087711 /* signature.c in Sources */,
 				525BE5341B3869110054BBCD /* hash.c in Sources */,
+				A4DAE33E2493F21900CEF51F /* ge_448.c in Sources */,
 				521646441A8992CC0062516A /* md5.c in Sources */,
 				5216460F1A89928E0062516A /* ssl.c in Sources */,
 				5216464D1A8992CC0062516A /* rsa.c in Sources */,
 				5216464B1A8992CC0062516A /* random.c in Sources */,
+				A4DAE3062493F1C700CEF51F /* tls13.c in Sources */,
 				522DBE0D1B7926FB0031F454 /* wc_encrypt.c in Sources */,
 				520775BD2239AC4600087711 /* fe_low_mem.c in Sources */,
 				521646101A89928E0062516A /* tls.c in Sources */,
 				5216460D1A89928E0062516A /* ocsp.c in Sources */,
+				A4DAE3232493F21900CEF51F /* asm.c in Sources */,
+				A4DAE3262493F21900CEF51F /* fe_448.c in Sources */,
 				520775AB2239ABBE00087711 /* sp_int.c in Sources */,
 				521646431A8992CC0062516A /* md4.c in Sources */,
 				521646321A8992CC0062516A /* aes.c in Sources */,
 				521646391A8992CC0062516A /* des3.c in Sources */,
 				521646351A8992CC0062516A /* blake2b.c in Sources */,
 				520775AD2239ABCD00087711 /* chacha20_poly1305.c in Sources */,
+				A4E7E5992493E20500725359 /* sp_armthumb.c in Sources */,
+				A4DAE32F2493F21900CEF51F /* ecc_fp.c in Sources */,
 				5216464C1A8992CC0062516A /* ripemd.c in Sources */,
+				A4DAE3322493F21900CEF51F /* cryptocb.c in Sources */,
 				520775B32239AC3200087711 /* ed25519.c in Sources */,
 				520775B12239AC2500087711 /* wolfmath.c in Sources */,
 				521646451A8992CC0062516A /* memory.c in Sources */,
+				A4DAE34A2493F21900CEF51F /* idea.c in Sources */,
+				A4DAE3382493F21900CEF51F /* pkcs12.c in Sources */,
 				5216463C1A8992CC0062516A /* ecc.c in Sources */,
+				A4DAE3292493F21900CEF51F /* compress.c in Sources */,
 				520775B72239AC4600087711 /* ge_low_mem.c in Sources */,
 				5216464F1A8992CC0062516A /* sha256.c in Sources */,
+				A4E7E5982493E20500725359 /* sp_cortexm.c in Sources */,
 				521646371A8992CC0062516A /* chacha.c in Sources */,
+				A4E7E5972493E20500725359 /* sp_dsp32.c in Sources */,
 				521646471A8992CC0062516A /* pkcs7.c in Sources */,
 				5216460E1A89928E0062516A /* sniffer.c in Sources */,
 				521646421A8992CC0062516A /* md2.c in Sources */,
 				521646381A8992CC0062516A /* coding.c in Sources */,
 				5216463D1A8992CC0062516A /* error.c in Sources */,
 				5216463F1A8992CC0062516A /* hmac.c in Sources */,
+				A4DAE3352493F21900CEF51F /* wolfevent.c in Sources */,
 				521646331A8992CC0062516A /* arc4.c in Sources */,
 				521646401A8992CC0062516A /* integer.c in Sources */,
+				A4DAE33B2493F21900CEF51F /* curve448.c in Sources */,
 				5216460A1A89928E0062516A /* internal.c in Sources */,
 				5216460B1A89928E0062516A /* wolfio.c in Sources */,
 				520775A52239ABBE00087711 /* sp_c32.c in Sources */,
@@ -1623,10 +1785,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A4DAE34D2493F28B00CEF51F /* sp_arm32.c in Sources */,
 				A4F318661BC58B1700FDF2BB /* aes.c in Sources */,
 				A4F318741BC58B1700FDF2BB /* arc4.c in Sources */,
 				A4F3185A1BC58B1700FDF2BB /* asn.c in Sources */,
 				A4F318681BC58B1700FDF2BB /* blake2b.c in Sources */,
+				A4DAE3422493F21900CEF51F /* wc_dsp.c in Sources */,
 				A4F318551BC58B1700FDF2BB /* camellia.c in Sources */,
 				A4F3186D1BC58B1700FDF2BB /* chacha.c in Sources */,
 				520775C52239B25900087711 /* sha3.c in Sources */,
@@ -1634,35 +1798,51 @@
 				A4F318711BC58B1700FDF2BB /* coding.c in Sources */,
 				A4F318791BC58B1700FDF2BB /* crl.c in Sources */,
 				1E8BEB79212F4CF90063DCC1 /* curve25519.c in Sources */,
+				A4DAE3332493F21900CEF51F /* cryptocb.c in Sources */,
 				A4F318671BC58B1700FDF2BB /* des3.c in Sources */,
 				A4F318541BC58B1700FDF2BB /* dh.c in Sources */,
 				A4F318501BC58B1700FDF2BB /* dsa.c in Sources */,
 				A4F3186B1BC58B1700FDF2BB /* ecc.c in Sources */,
 				1E8BEB7A212F4CF90063DCC1 /* ed25519.c in Sources */,
+				A4DAE3502493F29100CEF51F /* sp_arm64.c in Sources */,
 				A4F318721BC58B1700FDF2BB /* error.c in Sources */,
 				1E8BEB87212F4F010063DCC1 /* fe_low_mem.c in Sources */,
 				1E8BEB86212F4F010063DCC1 /* fe_operations.c in Sources */,
+				A4DAE31E2493F21900CEF51F /* ed448.c in Sources */,
 				1E8BEB83212F4E330063DCC1 /* ge_low_mem.c in Sources */,
 				1E8BEB82212F4E330063DCC1 /* ge_operations.c in Sources */,
+				A4DAE31B2493F21900CEF51F /* srp.c in Sources */,
 				A4F3185D1BC58B1700FDF2BB /* hash.c in Sources */,
+				A4DAE33C2493F21900CEF51F /* curve448.c in Sources */,
 				A4F318591BC58B1700FDF2BB /* hc128.c in Sources */,
 				A4F318731BC58B1700FDF2BB /* hmac.c in Sources */,
 				A4F318751BC58B1700FDF2BB /* integer.c in Sources */,
 				A4F318761BC58B1700FDF2BB /* internal.c in Sources */,
+				A4DAE33F2493F21900CEF51F /* ge_448.c in Sources */,
+				A4DAE3522493F29500CEF51F /* sp_armthumb.c in Sources */,
+				A4DAE3452493F21900CEF51F /* wc_pkcs11.c in Sources */,
+				A4DAE3302493F21900CEF51F /* ecc_fp.c in Sources */,
+				A4DAE3362493F21900CEF51F /* wolfevent.c in Sources */,
 				A4F3187A1BC58B1700FDF2BB /* keys.c in Sources */,
 				A4F318511BC58B1700FDF2BB /* logging.c in Sources */,
 				A4F318701BC58B1700FDF2BB /* md2.c in Sources */,
+				A4DAE34B2493F21900CEF51F /* idea.c in Sources */,
 				A4F318651BC58B1700FDF2BB /* md4.c in Sources */,
 				A4F3185E1BC58B1700FDF2BB /* md5.c in Sources */,
+				A4DAE3562493F29E00CEF51F /* sp_dsp32.c in Sources */,
+				A4DAE3272493F21900CEF51F /* fe_448.c in Sources */,
 				A4F3186A1BC58B1700FDF2BB /* memory.c in Sources */,
 				A4F318641BC58B1700FDF2BB /* ocsp.c in Sources */,
+				A4DAE3072493F1C700CEF51F /* tls13.c in Sources */,
 				A4F318531BC58B1700FDF2BB /* poly1305.c in Sources */,
 				A4F318571BC58B1700FDF2BB /* pwdbased.c in Sources */,
 				A4F3186E1BC58B1700FDF2BB /* pkcs7.c in Sources */,
 				520775A32239ABBE00087711 /* sp_c32.c in Sources */,
 				A4F3185C1BC58B1700FDF2BB /* rabbit.c in Sources */,
 				A4F318611BC58B1700FDF2BB /* random.c in Sources */,
+				A4DAE32D2493F21900CEF51F /* cmac.c in Sources */,
 				A4F318691BC58B1700FDF2BB /* ripemd.c in Sources */,
+				A4DAE3242493F21900CEF51F /* asm.c in Sources */,
 				A4F318601BC58B1700FDF2BB /* rsa.c in Sources */,
 				A4F318521BC58B1700FDF2BB /* sha.c in Sources */,
 				A4F3186C1BC58B1700FDF2BB /* sha256.c in Sources */,
@@ -1673,10 +1853,15 @@
 				1E8BEB71212F4C340063DCC1 /* sp_int.c in Sources */,
 				1E8BEB6D212F4AA10063DCC1 /* sp_x86_64.c in Sources */,
 				A4F3185F1BC58B1700FDF2BB /* ssl.c in Sources */,
+				A4DAE3482493F21900CEF51F /* blake2s.c in Sources */,
+				A4DAE32A2493F21900CEF51F /* compress.c in Sources */,
 				A4F318781BC58B1700FDF2BB /* tfm.c in Sources */,
+				A4DAE3392493F21900CEF51F /* pkcs12.c in Sources */,
 				A4F318631BC58B1700FDF2BB /* tls.c in Sources */,
 				A4F318621BC58B1700FDF2BB /* wc_encrypt.c in Sources */,
+				A4DAE3542493F29B00CEF51F /* sp_cortexm.c in Sources */,
 				A4F318561BC58B1700FDF2BB /* wc_port.c in Sources */,
+				A4DAE3212493F21900CEF51F /* cpuid.c in Sources */,
 				A4F318771BC58B1700FDF2BB /* wolfio.c in Sources */,
 				1E8BEB7F212F4DD00063DCC1 /* wolfmath.c in Sources */,
 			);

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -5195,16 +5195,11 @@ void bench_ntruKeyGen(void)
 
 #ifdef HAVE_ECC
 
-#ifndef BENCH_ECC_SIZE
-    #ifdef HAVE_ECC384
-        #define BENCH_ECC_SIZE  48
-    #else
-        #define BENCH_ECC_SIZE  32
-    #endif
-#endif
-
 /* Default to testing P-256 */
-static int bench_ecc_size = 32;
+#ifndef BENCH_ECC_SIZE
+    #define BENCH_ECC_SIZE  32
+#endif
+static int bench_ecc_size = BENCH_ECC_SIZE;
 
 void bench_eccMakeKey(int doAsync)
 {

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4044,7 +4044,7 @@ static int wc_ecc_make_pub_ex(ecc_key* key, ecc_curve_spec* curveIn,
         err = WC_KEY_SIZE_E;
 #else
     {
-        mp_digit mp;
+        mp_digit mp = 0;
 
         base = wc_ecc_new_point_h(key->heap);
         if (base == NULL)


### PR DESCRIPTION
* Updated Xcode project to add new files.
* Added SP Aarch64 asymmetric support.

Ran updated iPhone X benchmarks:

```
RNG                330 MB took 1.010 seconds,  326.879 MB/s
AES-128-CBC-enc    920 MB took 1.005 seconds,  915.507 MB/s
AES-128-CBC-dec   6095 MB took 1.000 seconds, 6092.130 MB/s
AES-192-CBC-enc    820 MB took 1.000 seconds,  819.644 MB/s
AES-192-CBC-dec   4860 MB took 1.001 seconds, 4855.794 MB/s
AES-256-CBC-enc    710 MB took 1.005 seconds,  706.419 MB/s
AES-256-CBC-dec   3935 MB took 1.001 seconds, 3930.830 MB/s
AES-128-GCM-enc   1245 MB took 1.003 seconds, 1241.589 MB/s
AES-128-GCM-dec    575 MB took 1.001 seconds,  574.547 MB/s
AES-192-GCM-enc   1235 MB took 1.001 seconds, 1234.343 MB/s
AES-192-GCM-dec    570 MB took 1.003 seconds,  568.521 MB/s
AES-256-GCM-enc   1230 MB took 1.003 seconds, 1226.034 MB/s
AES-256-GCM-dec    570 MB took 1.001 seconds,  569.199 MB/s
3DES                10 MB took 1.386 seconds,    7.213 MB/s
MD5                 95 MB took 1.037 seconds,   91.629 MB/s
SHA                 80 MB took 1.013 seconds,   78.943 MB/s
SHA-256           1625 MB took 1.000 seconds, 1624.565 MB/s
SHA3-224            60 MB took 1.010 seconds,   59.399 MB/s
SHA3-256            60 MB took 1.073 seconds,   55.921 MB/s
SHA3-384            45 MB took 1.042 seconds,   43.195 MB/s
SHA3-512            35 MB took 1.164 seconds,   30.063 MB/s
HMAC-MD5            95 MB took 1.044 seconds,   91.014 MB/s
HMAC-SHA            80 MB took 1.007 seconds,   79.480 MB/s
HMAC-SHA256       1705 MB took 1.001 seconds, 1703.126 MB/s
RSA     2048 public      32800 ops took 1.003 sec, avg 0.031 ms, 32716.405 ops/sec
RSA     2048 private      1200 ops took 1.041 sec, avg 0.868 ms, /33 ops/sec
DH      2048 key gen      2354 ops took 1.000 sec, avg 0.425 ms, 2353.254 ops/sec
DH      2048 agree        2500 ops took 1.013 sec, avg 0.405 ms, 2467.525 ops/sec
ECC      256 key gen     46503 ops took 1.000 sec, avg 0.022 ms, 46502.069 ops/sec
ECDHE    256 agree       14100 ops took 1.005 sec, avg 0.071 ms, 14034.697 ops/sec
ECDSA    256 sign        29600 ops took 1.003 sec, avg 0.034 ms, 29500.554 ops/sec
ECDSA    256 verify      11000 ops took 1.007 sec, avg 0.092 ms, 10921.516 ops/sec
```