### PR TITLE
Override CRL error for NO_VERIFY

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10837,6 +10837,11 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
                     /* Do verify callback */
                     ret = DoVerifyCallback(ssl->ctx->cm, ssl, ret, args);
+                    if (ssl->options.verifyNone &&
+                              (ret == CRL_MISSING || ret == CRL_CERT_REVOKED)) {
+                        WOLFSSL_MSG("Ignoring CRL problem based on verify setting");
+                        ret = ssl->error = 0;
+                    }
 
                 #ifdef WOLFSSL_ALT_CERT_CHAINS
                     /* For alternate cert chain, its okay for a CA cert to fail


### PR DESCRIPTION
Leaf CRL errors should be ignored when `NO_VERIFY` is defined. This logic already existed in the non-leaf section.

This addresses an issue from ZD10216