### PR TITLE
Fix SP cache resistant build (reverts part of PR 2970)

### DIFF
--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -1990,7 +1990,7 @@ static int sp_2048_mod_exp_45(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* td;
 #else
-    sp_digit td[90];
+    sp_digit td[3 * 90];
 #endif
     sp_digit* t[3];
     sp_digit* norm;
@@ -2014,7 +2014,7 @@ static int sp_2048_mod_exp_45(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 45 * 2);
 #else
-            t[i] = &td[i * 45 * 2)];
+            t[i] = &td[i * 45 * 2];
 #endif
         }
 
@@ -2943,7 +2943,7 @@ static int sp_2048_mod_exp_90(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* td;
 #else
-    sp_digit td[180];
+    sp_digit td[3 * 180];
 #endif
     sp_digit* t[3];
     sp_digit* norm;
@@ -2967,7 +2967,7 @@ static int sp_2048_mod_exp_90(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 90 * 2);
 #else
-            t[i] = &td[i * 90 * 2)];
+            t[i] = &td[i * 90 * 2];
 #endif
         }
 
@@ -5831,7 +5831,7 @@ static int sp_3072_mod_exp_67(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* td;
 #else
-    sp_digit td[134];
+    sp_digit td[3 * 134];
 #endif
     sp_digit* t[3];
     sp_digit* norm;
@@ -5855,7 +5855,7 @@ static int sp_3072_mod_exp_67(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 67 * 2);
 #else
-            t[i] = &td[i * 67 * 2)];
+            t[i] = &td[i * 67 * 2];
 #endif
         }
 
@@ -6820,7 +6820,7 @@ static int sp_3072_mod_exp_134(sp_digit* r, const sp_digit* a, const sp_digit* e
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* td;
 #else
-    sp_digit td[268];
+    sp_digit td[3 * 268];
 #endif
     sp_digit* t[3];
     sp_digit* norm;
@@ -6844,7 +6844,7 @@ static int sp_3072_mod_exp_134(sp_digit* r, const sp_digit* a, const sp_digit* e
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 134 * 2);
 #else
-            t[i] = &td[i * 134 * 2)];
+            t[i] = &td[i * 134 * 2];
 #endif
         }
 
@@ -9895,7 +9895,7 @@ static int sp_4096_mod_exp_98(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* td;
 #else
-    sp_digit td[196];
+    sp_digit td[3 * 196];
 #endif
     sp_digit* t[3];
     sp_digit* norm;
@@ -9919,7 +9919,7 @@ static int sp_4096_mod_exp_98(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 98 * 2);
 #else
-            t[i] = &td[i * 98 * 2)];
+            t[i] = &td[i * 98 * 2];
 #endif
         }
 
@@ -10861,7 +10861,7 @@ static int sp_4096_mod_exp_196(sp_digit* r, const sp_digit* a, const sp_digit* e
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* td;
 #else
-    sp_digit td[392];
+    sp_digit td[3 * 392];
 #endif
     sp_digit* t[3];
     sp_digit* norm;
@@ -10885,7 +10885,7 @@ static int sp_4096_mod_exp_196(sp_digit* r, const sp_digit* a, const sp_digit* e
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 196 * 2);
 #else
-            t[i] = &td[i * 196 * 2)];
+            t[i] = &td[i * 196 * 2];
 #endif
         }
 

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -1638,7 +1638,7 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* td;
 #else
-    sp_digit td[36];
+    sp_digit td[3 * 36];
 #endif
     sp_digit* t[3];
     sp_digit* norm;
@@ -1662,7 +1662,7 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 18 * 2);
 #else
-            t[i] = &td[i * 18 * 2)];
+            t[i] = &td[i * 18 * 2];
 #endif
         }
 
@@ -2583,7 +2583,7 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* td;
 #else
-    sp_digit td[72];
+    sp_digit td[3 * 72];
 #endif
     sp_digit* t[3];
     sp_digit* norm;
@@ -2607,7 +2607,7 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 36 * 2);
 #else
-            t[i] = &td[i * 36 * 2)];
+            t[i] = &td[i * 36 * 2];
 #endif
         }
 
@@ -5819,7 +5819,7 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* td;
 #else
-    sp_digit td[54];
+    sp_digit td[3 * 54];
 #endif
     sp_digit* t[3];
     sp_digit* norm;
@@ -5843,7 +5843,7 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 27 * 2);
 #else
-            t[i] = &td[i * 27 * 2)];
+            t[i] = &td[i * 27 * 2];
 #endif
         }
 
@@ -6734,7 +6734,7 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* td;
 #else
-    sp_digit td[108];
+    sp_digit td[3 * 108];
 #endif
     sp_digit* t[3];
     sp_digit* norm;
@@ -6758,7 +6758,7 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 54 * 2);
 #else
-            t[i] = &td[i * 54 * 2)];
+            t[i] = &td[i * 54 * 2];
 #endif
         }
 
@@ -10116,7 +10116,7 @@ static int sp_4096_mod_exp_39(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* td;
 #else
-    sp_digit td[78];
+    sp_digit td[3 * 78];
 #endif
     sp_digit* t[3];
     sp_digit* norm;
@@ -10140,7 +10140,7 @@ static int sp_4096_mod_exp_39(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 39 * 2);
 #else
-            t[i] = &td[i * 39 * 2)];
+            t[i] = &td[i * 39 * 2];
 #endif
         }
 
@@ -11130,7 +11130,7 @@ static int sp_4096_mod_exp_78(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* td;
 #else
-    sp_digit td[156];
+    sp_digit td[3 * 156];
 #endif
     sp_digit* t[3];
     sp_digit* norm;
@@ -11154,7 +11154,7 @@ static int sp_4096_mod_exp_78(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 78 * 2);
 #else
-            t[i] = &td[i * 78 * 2)];
+            t[i] = &td[i * 78 * 2];
 #endif
         }
 


### PR DESCRIPTION
Revert SP changes in https://github.com/wolfSSL/wolfssl/pull/2970 that broke `--enable-sp CFLAGS="-DWOLFSSL_SP_CACHE_RESISTANT"`. This was generated with latest scripts.