### PR TITLE
Cleanup after TLS 1.3 tests

### DIFF
--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -106,9 +106,9 @@ RESULT=$?
 remove_ready_file
 if [ $RESULT -eq 0 ]; then
     echo -e "\n\nIssue with mismatched TLS v1.3 cipher suites"
-    do_cleanup
     exit 1
 fi
+do_cleanup
 echo ""
 
 cat ./wolfssl/options.h | grep -- 'NO_CERTS'
@@ -124,9 +124,9 @@ if [ $? -ne 0 ]; then
     remove_ready_file
     if [ $RESULT -eq 0 ]; then
         echo -e "\n\nIssue with requiring mutual authentication"
-        do_cleanup
         exit 1
     fi
+    do_cleanup
     echo ""
 fi
 
@@ -143,9 +143,9 @@ if [ $? -ne 0 ]; then
     remove_ready_file
     if [ $RESULT -eq 0 ]; then
         echo -e "\n\nIssue with TLS v1.3 server downgrading to TLS v1.2"
-        do_cleanup
         exit 1
     fi
+    do_cleanup
     echo ""
 
     # TLS 1.2 server / TLS 1.3 client.
@@ -159,9 +159,9 @@ if [ $? -ne 0 ]; then
     remove_ready_file
     if [ $RESULT -eq 0 ]; then
         echo -e "\n\nIssue with TLS v1.3 client upgrading server to TLS v1.3"
-        do_cleanup
         exit 1
     fi
+    do_cleanup
     echo ""
 
     echo "Find usable TLS 1.2 cipher suite"
@@ -173,6 +173,7 @@ if [ $? -ne 0 ]; then
             TLS12_CS=$CS
             break
         fi
+        do_cleanup
     done
     if [ "$TLS12_CS" != "" ]; then
         # TLS 1.3 downgrade server and client - no common TLS 1.3 ciphers
@@ -188,9 +189,9 @@ if [ $? -ne 0 ]; then
         remove_ready_file
         if [ $RESULT -eq 0 ]; then
             echo -e "\n\nTLS v1.3 downgrading to TLS v1.2 due to ciphers"
-            do_cleanup
             exit 1
         fi
+        do_cleanup
         echo ""
     else
         echo "No usable TLS 1.2 cipher suite found"


### PR DESCRIPTION
Make sure the server is dead after each test.
Client may not connect to server if cipher suite not supported and
return error as expected.