### PR TITLE
Add section to asm files to avoid exe stack

### DIFF
--- a/wolfcrypt/src/aes_gcm_asm.S
+++ b/wolfcrypt/src/aes_gcm_asm.S
@@ -8731,3 +8731,7 @@ L_AES_GCM_decrypt_avx2_cmp_tag_done:
 .size	AES_GCM_decrypt_avx2,.-AES_GCM_decrypt_avx2
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+#if defined(__linux__) && defined(__ELF__)
+.section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/chacha_asm.S
+++ b/wolfcrypt/src/chacha_asm.S
@@ -1418,3 +1418,7 @@ L_chacha20_avx2_end256:
 .size	chacha_encrypt_avx2,.-chacha_encrypt_avx2
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+#if defined(__linux__) && defined(__ELF__)
+.section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/fe_x25519_asm.S
+++ b/wolfcrypt/src/fe_x25519_asm.S
@@ -16540,3 +16540,7 @@ _fe_ge_sub_avx2:
 .size	fe_ge_sub_avx2,.-fe_ge_sub_avx2
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+#if defined(__linux__) && defined(__ELF__)
+.section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/poly1305_asm.S
+++ b/wolfcrypt/src/poly1305_asm.S
@@ -1103,3 +1103,7 @@ L_poly1305_avx2_final_cmp_copy:
 .size	poly1305_final_avx2,.-poly1305_final_avx2
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+#if defined(__linux__) && defined(__ELF__)
+.section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/port/arm/armv8-32-curve25519.S
+++ b/wolfcrypt/src/port/arm/armv8-32-curve25519.S
@@ -23,7 +23,6 @@
  *   cd ../scripts
  *   ruby ./x25519/x25519.rb arm32 ../wolfssl/wolfcrypt/src/port/arm/armv8-32-curve25519.S
  */
-
 #ifdef WOLFSSL_ARMASM
 #ifndef __aarch64__
 	.text
@@ -6010,3 +6009,7 @@ fe_ge_sub:
 	.size	fe_ge_sub,.-fe_ge_sub
 #endif /* !__aarch64__ */
 #endif /* WOLFSSL_ARMASM */
+
+#if defined(__linux__) && defined(__ELF__)
+.section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/port/arm/armv8-32-curve25519.c
+++ b/wolfcrypt/src/port/arm/armv8-32-curve25519.c
@@ -23,19 +23,14 @@
  *   cd ../scripts
  *   ruby ./x25519/x25519.rb arm32 ../wolfssl/wolfcrypt/src/port/arm/armv8-32-curve25519.c
  */
-
+#ifdef WOLFSSL_ARMASM
 #ifndef __aarch64__
-
 #include <stdint.h>
 #ifdef HAVE_CONFIG_H
     #include <config.h>
-#endif
-
+#endif /* HAVE_CONFIG_H */
 #include <wolfssl/wolfcrypt/settings.h>
-
-#ifdef WOLFSSL_ARMASM
 #include <wolfssl/wolfcrypt/fe_operations.h>
-#include <stdint.h>
 
 void fe_init()
 {
@@ -5577,5 +5572,5 @@ void fe_ge_sub(fe rx, fe ry, fe rz, fe rt, const fe px, const fe py, const fe pz
     (void)qyminusx;
 }
 
-#endif /* WOLFSSL_ARMASM */
 #endif /* !__aarch64__ */
+#endif /* WOLFSSL_ARMASM */

--- a/wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
@@ -23,7 +23,6 @@
  *   cd ../scripts
  *   ruby ./sha2/sha512.rb arm32 ../wolfssl/wolfcrypt/src/port/arm/armv8-32-sha512-asm.S
  */
-
 #ifdef WOLFSSL_ARMASM
 #ifndef __aarch64__
 #ifdef WOLFSSL_ARMASM_NO_NEON
@@ -5333,3 +5332,7 @@ L_sha512_len_neon_start:
 #endif /* !WOLFSSL_ARMASM_NO_NEON */
 #endif /* !__aarch64__ */
 #endif /* WOLFSSL_ARMASM */
+
+#if defined(__linux__) && defined(__ELF__)
+.section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/port/arm/armv8-32-sha512-asm.c
+++ b/wolfcrypt/src/port/arm/armv8-32-sha512-asm.c
@@ -23,17 +23,13 @@
  *   cd ../scripts
  *   ruby ./sha2/sha512.rb arm32 ../wolfssl/wolfcrypt/src/port/arm/armv8-32-sha512-asm.c
  */
-
+#ifdef WOLFSSL_ARMASM
 #ifndef __aarch64__
 #include <stdint.h>
-
 #ifdef HAVE_CONFIG_H
     #include <config.h>
-#endif
-
+#endif /* HAVE_CONFIG_H */
 #include <wolfssl/wolfcrypt/settings.h>
-
-#ifdef WOLFSSL_ARMASM
 #include <wolfssl/wolfcrypt/sha512.h>
 
 #ifdef WOLFSSL_ARMASM_NO_NEON
@@ -4779,5 +4775,5 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
 }
 
 #endif /* !WOLFSSL_ARMASM_NO_NEON */
-#endif /* WOLFSSL_ARMASM */
 #endif /* !__aarch64__ */
+#endif /* WOLFSSL_ARMASM */

--- a/wolfcrypt/src/port/arm/armv8-curve25519.S
+++ b/wolfcrypt/src/port/arm/armv8-curve25519.S
@@ -23,6 +23,7 @@
  *   cd ../scripts
  *   ruby ./x25519/x25519.rb arm64 ../wolfssl/wolfcrypt/src/port/arm/armv8-curve25519.S
  */
+#ifdef WOLFSSL_ARMASM
 #ifdef __aarch64__
 	.text
 	.align	2
@@ -6713,3 +6714,8 @@ fe_ge_sub:
 	ret
 	.size	fe_ge_sub,.-fe_ge_sub
 #endif /* __aarch64__ */
+#endif /* WOLFSSL_ARMASM */
+
+#if defined(__linux__) && defined(__ELF__)
+.section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/port/arm/armv8-curve25519.c
+++ b/wolfcrypt/src/port/arm/armv8-curve25519.c
@@ -23,17 +23,14 @@
  *   cd ../scripts
  *   ruby ./x25519/x25519.rb arm64 ../wolfssl/wolfcrypt/src/port/arm/armv8-curve25519.c
  */
+#ifdef WOLFSSL_ARMASM
 #ifdef __aarch64__
 #include <stdint.h>
 #ifdef HAVE_CONFIG_H
     #include <config.h>
-#endif
-
+#endif /* HAVE_CONFIG_H */
 #include <wolfssl/wolfcrypt/settings.h>
-
-#ifdef WOLFSSL_ARMASM
 #include <wolfssl/wolfcrypt/fe_operations.h>
-#include <stdint.h>
 
 void fe_init()
 {
@@ -6721,5 +6718,5 @@ void fe_ge_sub(fe rx, fe ry, fe rz, fe rt, const fe px, const fe py, const fe pz
     (void)qyminusx;
 }
 
-#endif /* WOLFSSL_ARMASM */
 #endif /* __aarch64__ */
+#endif /* WOLFSSL_ARMASM */

--- a/wolfcrypt/src/port/arm/armv8-sha512-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-sha512-asm.S
@@ -23,6 +23,7 @@
  *   cd ../scripts
  *   ruby ./sha2/sha512.rb arm64 ../wolfssl/wolfcrypt/src/port/arm/armv8-sha512-asm.S
  */
+#ifdef WOLFSSL_ARMASM
 #ifdef __aarch64__
 	.text
 	.section	.rodata
@@ -1044,3 +1045,8 @@ L_sha512_len_neon_start:
 	ret
 	.size	Transform_Sha512_Len,.-Transform_Sha512_Len
 #endif /* __aarch64__ */
+#endif /* WOLFSSL_ARMASM */
+
+#if defined(__linux__) && defined(__ELF__)
+.section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/port/arm/armv8-sha512-asm.c
+++ b/wolfcrypt/src/port/arm/armv8-sha512-asm.c
@@ -23,16 +23,13 @@
  *   cd ../scripts
  *   ruby ./sha2/sha512.rb arm64 ../wolfssl/wolfcrypt/src/port/arm/armv8-sha512-asm.c
  */
+#ifdef WOLFSSL_ARMASM
 #ifdef __aarch64__
 #include <stdint.h>
-
 #ifdef HAVE_CONFIG_H
     #include <config.h>
-#endif
-
+#endif /* HAVE_CONFIG_H */
 #include <wolfssl/wolfcrypt/settings.h>
-
-#ifdef WOLFSSL_ARMASM
 #include <wolfssl/wolfcrypt/sha512.h>
 
 static const uint64_t L_SHA512_transform_neon_len_k[] = {
@@ -1037,5 +1034,5 @@ void Transform_Sha512_Len(wc_Sha512* sha512, const byte* data, word32 len)
     );
 }
 
-#endif /* WOLFSSL_ARMASM */
 #endif /* __aarch64__ */
+#endif /* WOLFSSL_ARMASM */

--- a/wolfcrypt/src/sha256_asm.S
+++ b/wolfcrypt/src/sha256_asm.S
@@ -22651,3 +22651,7 @@ L_sha256_len_avx2_rorx_done:
 .size	Transform_Sha256_AVX2_RORX_Len,.-Transform_Sha256_AVX2_RORX_Len
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+#if defined(__linux__) && defined(__ELF__)
+.section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/sha512_asm.S
+++ b/wolfcrypt/src/sha512_asm.S
@@ -10739,3 +10739,7 @@ L_sha512_len_avx2_rorx_done:
 .size	Transform_Sha512_AVX2_RORX_Len,.-Transform_Sha512_AVX2_RORX_Len
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
+
+#if defined(__linux__) && defined(__ELF__)
+.section	.note.GNU-stack,"",%progbits
+#endif

--- a/wolfcrypt/src/sp_x86_64_asm.S
+++ b/wolfcrypt/src/sp_x86_64_asm.S
@@ -42865,3 +42865,7 @@ _sp_384_mul_d_avx2_6:
 #endif /* __APPLE__ */
 #endif /* HAVE_INTEL_AVX2 */
 #endif /* WOLFSSL_SP_384 */
+
+#if defined(__linux__) && defined(__ELF__)
+.section	.note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
For Linux ELF need a note section for GNU to indicate stack is not
executable.