### PR TITLE
Handle 2+ dtls APP data records in one udp packet

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -15609,8 +15609,14 @@ int ProcessReply(WOLFSSL* ssl)
 
             ssl->options.processReply = doProcessInit;
 
-            /* input exhausted? */
-            if (ssl->buffers.inputBuffer.idx >= ssl->buffers.inputBuffer.length)
+            /* input exhausted */
+            if (ssl->buffers.inputBuffer.idx >= ssl->buffers.inputBuffer.length
+#ifdef WOLFSSL_DTLS
+                /* If app data was processed then return now to avoid
+                 * dropping any app data. */
+                || (ssl->options.dtls && ssl->curRL.type == application_data)
+#endif
+                )
                 return ret;
 
             /* more messages per record */


### PR DESCRIPTION
Just return one message at a time if processing application data