### PR TITLE
DTLS session resumption fixes

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -3407,8 +3407,6 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
         (void)ClientRead(sslResume, reply, sizeof(reply)-1, sendGET,
                          "Server resume: ", 0);
-        /* try to send session break */
-        (void)ClientWrite(sslResume, msg, msgSz, " resume 2", 0);
 
         ret = wolfSSL_shutdown(sslResume);
         if (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE)

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2139,6 +2139,10 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                        dtlsUDP, dtlsSCTP, serverReadyFile ? 1 : 0, doListen);
         doListen = 0; /* Don't listen next time */
 
+        if (port == 0) {
+            port = readySignal->port;
+        }
+
         if (SSL_set_fd(ssl, clientfd) != WOLFSSL_SUCCESS) {
             err_sys_ex(catastrophic, "error in setting fd");
         }

--- a/tests/include.am
+++ b/tests/include.am
@@ -34,6 +34,7 @@ EXTRA_DIST += tests/test.conf \
               tests/test-dtls-group.conf \
               tests/test-dtls-reneg-client.conf \
               tests/test-dtls-reneg-server.conf \
+              tests/test-dtls-resume.conf \
               tests/test-dtls-sha2.conf \
               tests/test-sctp.conf \
               tests/test-sctp-sha2.conf \

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -822,9 +822,18 @@ int SuiteTest(int argc, char** argv)
         args.return_code = EXIT_FAILURE;
         goto exit;
     }
-    /* add dtls grouping suites */
+    /* add dtls grouping tests */
     strcpy(argv0[1], "tests/test-dtls-group.conf");
     printf("starting dtls message grouping tests\n");
+    test_harness(&args);
+    if (args.return_code != 0) {
+        printf("error from script %d\n", args.return_code);
+        args.return_code = EXIT_FAILURE;
+        goto exit;
+    }
+    /* add dtls session resumption tests */
+    strcpy(argv0[1], "tests/test-dtls-resume.conf");
+    printf("starting dtls session resumption tests\n");
     test_harness(&args);
     if (args.return_code != 0) {
         printf("error from script %d\n", args.return_code);

--- a/tests/test-dtls-resume.conf
+++ b/tests/test-dtls-resume.conf
@@ -1,0 +1,1045 @@
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305
+-u
+-r
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305
+-u
+-r
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+
+# server DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305
+-u
+-r
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305
+
+# client DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305
+-u
+-r
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305
+
+# server DTLSv1.2 ECDHE-EDCSA-CHACHA20-POLY1305
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-CHACHA20-POLY1305
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 DHE-PSK-CHACHA20-POLY1305
+-u
+-r
+-v 3
+-s
+-l DHE-PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 DHE-PSK-CHACHA20-POLY1305
+-u
+-r
+-v 3
+-s
+-l DHE-PSK-CHACHA20-POLY1305
+
+# server TLSv1.2 ECDHE-PSK-CHACHA20-POLY1305
+-u
+-r
+-v 3
+-s
+-l ECDHE-PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 ECDHE-PSK-CHACHA20-POLY1305
+-u
+-r
+-v 3
+-s
+-l ECDHE-PSK-CHACHA20-POLY1305
+
+# server TLSv1.2 PSK-CHACHA20-POLY1305
+-u
+-r
+-v 3
+-s
+-l PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 PSK-CHACHA20-POLY1305
+-u
+-r
+-v 3
+-s
+-l PSK-CHACHA20-POLY1305
+
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305-OLD
+-u
+-r
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305-OLD
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305-OLD
+-u
+-r
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305-OLD
+
+# server DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305-OLD
+-u
+-r
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305-OLD
+
+# client DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305-OLD
+-u
+-r
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305-OLD
+
+# server DTLSv1.2 ECDHE-EDCSA-CHACHA20-POLY1305-OLD
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1 IDEA-CBC-SHA
+-u
+-r
+-v 2
+-l IDEA-CBC-SHA
+
+# client DTLSv1 IDEA-CBC-SHA
+-u
+-r
+-v 2
+-l IDEA-CBC-SHA
+
+# server DTLSv1 DES-CBC3-SHA
+-u
+-r
+-v 2
+-l DES-CBC3-SHA
+
+# client DTLSv1 DES-CBC3-SHA
+-u
+-r
+-v 2
+-l DES-CBC3-SHA
+
+# server DTLSv1.2 DES-CBC3-SHA
+-u
+-r
+-v 3
+-l DES-CBC3-SHA
+
+# client DTLSv1.2 DES-CBC3-SHA
+-u
+-r
+-v 3
+-l DES-CBC3-SHA
+
+# server DTLSv1 AES128-SHA
+-u
+-r
+-v 2
+-l AES128-SHA
+
+# client DTLSv1 AES128-SHA
+-u
+-r
+-v 2
+-l AES128-SHA
+
+# server DTLSv1.2 AES128-SHA
+-u
+-r
+-v 3
+-l AES128-SHA
+
+# client DTLSv1.2 AES128-SHA
+-u
+-r
+-v 3
+-l AES128-SHA
+
+# server DTLSv1 AES256-SHA
+-u
+-r
+-v 2
+-l AES256-SHA
+
+# client DTLSv1 AES256-SHA
+-u
+-r
+-v 2
+-l AES256-SHA
+
+# server DTLSv1.2 AES256-SHA
+-u
+-r
+-v 3
+-l AES256-SHA
+
+# client DTLSv1.2 AES256-SHA
+-u
+-r
+-v 3
+-l AES256-SHA
+
+# server DTLSv1.2 AES128-SHA256
+-u
+-r
+-v 3
+-l AES128-SHA256
+
+# client DTLSv1.2 AES128-SHA256
+-u
+-r
+-v 3
+-l AES128-SHA256
+
+# server DTLSv1.2 AES256-SHA256
+-u
+-r
+-v 3
+-l AES256-SHA256
+
+# client DTLSv1.2 AES256-SHA256
+-u
+-r
+-v 3
+-l AES256-SHA256
+
+# server DTLSv1.1 ECDHE-RSA-DES3
+-u
+-r
+-v 2
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# client DTLSv1.1 ECDHE-RSA-DES3
+-u
+-r
+-v 2
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# server DTLSv1.1 ECDHE-RSA-AES128
+-u
+-r
+-v 2
+-l ECDHE-RSA-AES128-SHA
+
+# client DTLSv1.1 ECDHE-RSA-AES128
+-u
+-r
+-v 2
+-l ECDHE-RSA-AES128-SHA
+
+# server DTLSv1.1 ECDHE-RSA-AES256
+-u
+-r
+-v 2
+-l ECDHE-RSA-AES256-SHA
+
+# client DTLSv1.1 ECDHE-RSA-AES256
+-u
+-r
+-v 2
+-l ECDHE-RSA-AES256-SHA
+
+# server DTLSv1.2 ECDHE-RSA-DES3
+-u
+-r
+-v 3
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# client DTLSv1.2 ECDHE-RSA-DES3
+-u
+-r
+-v 3
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# server DTLSv1.2 ECDHE-RSA-AES128
+-u
+-r
+-v 3
+-l ECDHE-RSA-AES128-SHA
+
+# client DTLSv1.2 ECDHE-RSA-AES128
+-u
+-r
+-v 3
+-l ECDHE-RSA-AES128-SHA
+
+# server DTLSv1.2 ECDHE-RSA-AES128-SHA256
+-u
+-r
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# client DTLSv1.2 ECDHE-RSA-AES128-SHA256
+-u
+-r
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# server DTLSv1.2 ECDHE-RSA-AES256
+-u
+-r
+-v 3
+-l ECDHE-RSA-AES256-SHA
+
+# client DTLSv1.2 ECDHE-RSA-AES256
+-u
+-r
+-v 3
+-l ECDHE-RSA-AES256-SHA
+
+# server TLSv1 ECDHE-ECDSA-NULL-SHA
+-u
+-r
+-v 1
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1 ECDHE-ECDSA-NULL-SHA
+-u
+-r
+-v 1
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.1 ECDHE-ECDSA-NULL-SHA
+-u
+-r
+-v 2
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1 ECDHE-ECDSA-NULL-SHA
+-u
+-r
+-v 2
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-ECDSA-NULL-SHA
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-NULL-SHA
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-DES3
+-u
+-r
+-v 2
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-DES3
+-u
+-r
+-v 2
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-AES128
+-u
+-r
+-v 2
+-l ECDHE-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-AES128
+-u
+-r
+-v 2
+-l ECDHE-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-AES256
+-u
+-r
+-v 2
+-l ECDHE-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-AES256
+-u
+-r
+-v 2
+-l ECDHE-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-DES3
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-DES3
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-SHA256
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-SHA256
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-RSA-DES3
+-u
+-r
+-v 2
+-l ECDH-RSA-DES-CBC3-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-DES3
+-u
+-r
+-v 2
+-l ECDH-RSA-DES-CBC3-SHA
+
+# server DTLSv1.1 ECDH-RSA-AES128
+-u
+-r
+-v 2
+-l ECDH-RSA-AES128-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-AES128
+-u
+-r
+-v 2
+-l ECDH-RSA-AES128-SHA
+
+# server DTLSv1.1 ECDH-RSA-AES256
+-u
+-r
+-v 2
+-l ECDH-RSA-AES256-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-AES256
+-u
+-r
+-v 2
+-l ECDH-RSA-AES256-SHA
+
+# server DTLSv1.2 ECDH-RSA-DES3
+-u
+-r
+-v 3
+-l ECDH-RSA-DES-CBC3-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-DES3
+-u
+-r
+-v 3
+-l ECDH-RSA-DES-CBC3-SHA
+
+# server DTLSv1.2 ECDH-RSA-AES128
+-u
+-r
+-v 3
+-l ECDH-RSA-AES128-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128
+-u
+-r
+-v 3
+-l ECDH-RSA-AES128-SHA
+
+# server DTLSv1.2 ECDH-RSA-AES128-SHA256
+-u
+-r
+-v 3
+-l ECDH-RSA-AES128-SHA256
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128-SHA256
+-u
+-r
+-v 3
+-l ECDH-RSA-AES128-SHA256
+
+# server DTLSv1.2 ECDH-RSA-AES256
+-u
+-r
+-v 3
+-l ECDH-RSA-AES256-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256
+-u
+-r
+-v 3
+-l ECDH-RSA-AES256-SHA
+
+# server DTLSv1.1 ECDH-ECDSA-DES3
+-u
+-r
+-v 2
+-l ECDH-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-DES3
+-u
+-r
+-v 2
+-l ECDH-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-ECDSA-AES128
+-u
+-r
+-v 2
+-l ECDH-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-AES128
+-u
+-r
+-v 2
+-l ECDH-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-ECDSA-AES256
+-u
+-r
+-v 2
+-l ECDH-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-AES256
+-u
+-r
+-v 2
+-l ECDH-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-DES3
+-u
+-r
+-v 3
+-l ECDH-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-DES3
+-u
+-r
+-v 3
+-l ECDH-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128
+-u
+-r
+-v 3
+-l ECDH-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128
+-u
+-r
+-v 3
+-l ECDH-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128-SHA256
+-u
+-r
+-v 3
+-l ECDH-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128-SHA256
+-u
+-r
+-v 3
+-l ECDH-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES256
+-u
+-r
+-v 3
+-l ECDH-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256
+-u
+-r
+-v 3
+-l ECDH-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-RSA-AES256-SHA384
+-u
+-r
+-v 3
+-l ECDHE-RSA-AES256-SHA384
+
+# client DTLSv1.2 ECDHE-RSA-AES256-SHA384
+-u
+-r
+-v 3
+-l ECDHE-RSA-AES256-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-SHA384
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES256-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-SHA384
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES256-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-RSA-AES256-SHA384
+-u
+-r
+-v 3
+-l ECDH-RSA-AES256-SHA384
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256-SHA384
+-u
+-r
+-v 3
+-l ECDH-RSA-AES256-SHA384
+
+# server DTLSv1.2 ECDH-ECDSA-AES256-SHA384
+-u
+-r
+-v 3
+-l ECDH-ECDSA-AES256-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256-SHA384
+-u
+-r
+-v 3
+-l ECDH-ECDSA-AES256-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-PSK-AES128-SHA256
+-s
+-u
+-r
+-v 3
+-l ECDHE-PSK-AES128-SHA256
+
+# client TLSv1.2 ECDHE-PSK-AES128-SHA256
+-s
+-u
+-r
+-v 3
+-l ECDHE-PSK-AES128-SHA256
+
+# server TLSv1.2 ECDHE-PSK-NULL-SHA256
+-s
+-u
+-r
+-v 3
+-l ECDHE-PSK-NULL-SHA256
+
+# client TLSv1.2 ECDHE-PSK-NULL-SHA256
+-s
+-u
+-r
+-v 3
+-l ECDHE-PSK-NULL-SHA256
+
+# server DTLSv1 PSK-AES128
+-s
+-u
+-r
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# client DTLSv1 PSK-AES128
+-s
+-u
+-r
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# server DTLSv1 PSK-AES256
+-s
+-u
+-r
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# client DTLSv1 PSK-AES256
+-s
+-u
+-r
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# server DTLSv1.2 PSK-AES128
+-s
+-u
+-r
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# client DTLSv1.2 PSK-AES128
+-s
+-u
+-r
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# server DTLSv1.2 PSK-AES256
+-s
+-u
+-r
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# client DTLSv1.2 PSK-AES256
+-s
+-u
+-r
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# server DTLSv1.2 PSK-AES128-SHA256
+-s
+-u
+-r
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# client DTLSv1.2 PSK-AES128-SHA256
+-s
+-u
+-r
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# server DTLSv1.2 PSK-AES256-SHA384
+-s
+-u
+-r
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# client DTLSv1.2 PSK-AES256-SHA384
+-s
+-u
+-r
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-GCM-SHA256
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-GCM-SHA256
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-GCM-SHA384
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-GCM-SHA384
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128-GCM-SHA256
+-u
+-r
+-v 3
+-l ECDH-ECDSA-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128-GCM-SHA256
+-u
+-r
+-v 3
+-l ECDH-ECDSA-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES256-GCM-SHA384
+-u
+-r
+-v 3
+-l ECDH-ECDSA-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256-GCM-SHA384
+-u
+-r
+-v 3
+-l ECDH-ECDSA-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-RSA-AES128-GCM-SHA256
+-u
+-r
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+
+# client DTLSv1.2 ECDHE-RSA-AES128-GCM-SHA256
+-u
+-r
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+
+# server DTLSv1.2 ECDHE-RSA-AES256-GCM-SHA384
+-u
+-r
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+
+# client DTLSv1.2 ECDHE-RSA-AES256-GCM-SHA384
+-u
+-r
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+
+# server DTLSv1.2 ECDH-RSA-AES128-GCM-SHA256
+-u
+-r
+-v 3
+-l ECDH-RSA-AES128-GCM-SHA256
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128-GCM-SHA256
+-u
+-r
+-v 3
+-l ECDH-RSA-AES128-GCM-SHA256
+
+# server DTLSv1.2 ECDH-RSA-AES256-GCM-SHA384
+-u
+-r
+-v 3
+-l ECDH-RSA-AES256-GCM-SHA384
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256-GCM-SHA384
+-u
+-r
+-v 3
+-l ECDH-RSA-AES256-GCM-SHA384
+
+# server DTLSv1.2 PSK-AES128-GCM-SHA256
+-u
+-r
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# client DTLSv1.2 PSK-AES128-GCM-SHA256
+-u
+-r
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# server DTLSv1.2 PSK-AES256-GCM-SHA384
+-u
+-r
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# client DTLSv1.2 PSK-AES256-GCM-SHA384
+-u
+-r
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES128-CCM-8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES128-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM-8
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES256-CCM-8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM-8
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES256-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ADH-AES128-SHA
+-u
+-r
+-a
+-v 3
+-l ADH-AES128-SHA
+
+# client DTLSv1.2 ADH-AES128-SHA
+-u
+-r
+-a
+-v 3
+-l ADH-AES128-SHA
+
+# server DTLSv1.0 ADH-AES128-SHA
+-u
+-r
+-a
+-v 2
+-l ADH-AES128-SHA
+
+# client DTLSv1.0 ADH-AES128-SHA
+-u
+-r
+-a
+-v 2
+-l ADH-AES128-SHA


### PR DESCRIPTION
- `SendFinished` resetting`dtls_expected_peer_handshake_number` should depend on side and if we are resuming a connection
- No need to do a cookie exchange on session resumption
- Add session resumption testing for DTLS