### PR TITLE
Correct SP mod calculation

### DIFF
--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -1851,7 +1851,7 @@ static int sp_2048_div_45(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_2048_mul_d_45(t2, sd, r1);
         sp_2048_sub_45(t1, t1, t2);
         XMEMCPY(r, t1, sizeof(*r) * 2U * 45U);
-        for (i=0; i<43; i++) {
+        for (i=0; i<44; i++) {
             r[i+1] += r[i] >> 23;
             r[i] &= 0x7fffff;
         }
@@ -2802,7 +2802,7 @@ static int sp_2048_div_90(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_2048_mul_d_90(t2, sd, r1);
         sp_2048_sub_90(t1, t1, t2);
         XMEMCPY(r, t1, sizeof(*r) * 2U * 90U);
-        for (i=0; i<88; i++) {
+        for (i=0; i<89; i++) {
             r[i+1] += r[i] >> 23;
             r[i] &= 0x7fffff;
         }
@@ -6679,7 +6679,7 @@ static int sp_3072_div_134(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_3072_mul_d_134(t2, sd, r1);
         sp_3072_sub_134(t1, t1, t2);
         XMEMCPY(r, t1, sizeof(*r) * 2U * 134U);
-        for (i=0; i<132; i++) {
+        for (i=0; i<133; i++) {
             r[i+1] += r[i] >> 23;
             r[i] &= 0x7fffff;
         }
@@ -9756,7 +9756,7 @@ static int sp_4096_div_98(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_4096_mul_d_98(t2, sd, r1);
         sp_4096_sub_98(t1, t1, t2);
         XMEMCPY(r, t1, sizeof(*r) * 2U * 98U);
-        for (i=0; i<96; i++) {
+        for (i=0; i<97; i++) {
             r[i+1] += r[i] >> 21;
             r[i] &= 0x1fffff;
         }
@@ -10720,7 +10720,7 @@ static int sp_4096_div_196(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_4096_mul_d_196(t2, sd, r1);
         sp_4096_sub_196(t1, t1, t2);
         XMEMCPY(r, t1, sizeof(*r) * 2U * 196U);
-        for (i=0; i<194; i++) {
+        for (i=0; i<195; i++) {
             r[i+1] += r[i] >> 21;
             r[i] &= 0x1fffff;
         }

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -9977,7 +9977,7 @@ static int sp_4096_div_39(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_4096_mul_d_39(t2, sd, r1);
         sp_4096_sub_39(t1, t1, t2);
         XMEMCPY(r, t1, sizeof(*r) * 2U * 39U);
-        for (i=0; i<37; i++) {
+        for (i=0; i<38; i++) {
             r[i+1] += r[i] >> 53;
             r[i] &= 0x1fffffffffffffL;
         }
@@ -10989,7 +10989,7 @@ static int sp_4096_div_78(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_4096_mul_d_78(t2, sd, r1);
         sp_4096_sub_78(t1, t1, t2);
         XMEMCPY(r, t1, sizeof(*r) * 2U * 78U);
-        for (i=0; i<76; i++) {
+        for (i=0; i<77; i++) {
             r[i+1] += r[i] >> 53;
             r[i] &= 0x1fffffffffffffL;
         }

--- a/wolfcrypt/src/sp_x86_64.c
+++ b/wolfcrypt/src/sp_x86_64.c
@@ -320,7 +320,7 @@ extern int64_t sp_2048_cmp_16(const sp_digit* a, const sp_digit* b);
 /* Divide d in a and put remainder into r (m*d + r = a)
  * m is not calculated as it is not needed at this time.
  *
- * a  Nmber to be divided.
+ * a  Number to be divided.
  * d  Number to divide with.
  * m  Multiplier result.
  * r  Remainder from the division.
@@ -850,7 +850,7 @@ extern int64_t sp_2048_cmp_32(const sp_digit* a, const sp_digit* b);
 /* Divide d in a and put remainder into r (m*d + r = a)
  * m is not calculated as it is not needed at this time.
  *
- * a  Nmber to be divided.
+ * a  Number to be divided.
  * d  Number to divide with.
  * m  Multiplier result.
  * r  Remainder from the division.
@@ -922,7 +922,7 @@ extern sp_digit sp_2048_sub_32(sp_digit* r, const sp_digit* a, const sp_digit* b
 /* Divide d in a and put remainder into r (m*d + r = a)
  * m is not calculated as it is not needed at this time.
  *
- * a  Nmber to be divided.
+ * a  Number to be divided.
  * d  Number to divide with.
  * m  Multiplier result.
  * r  Remainder from the division.
@@ -2516,7 +2516,7 @@ extern int64_t sp_3072_cmp_24(const sp_digit* a, const sp_digit* b);
 /* Divide d in a and put remainder into r (m*d + r = a)
  * m is not calculated as it is not needed at this time.
  *
- * a  Nmber to be divided.
+ * a  Number to be divided.
  * d  Number to divide with.
  * m  Multiplier result.
  * r  Remainder from the division.
@@ -3046,7 +3046,7 @@ extern int64_t sp_3072_cmp_48(const sp_digit* a, const sp_digit* b);
 /* Divide d in a and put remainder into r (m*d + r = a)
  * m is not calculated as it is not needed at this time.
  *
- * a  Nmber to be divided.
+ * a  Number to be divided.
  * d  Number to divide with.
  * m  Multiplier result.
  * r  Remainder from the division.
@@ -3118,7 +3118,7 @@ extern sp_digit sp_3072_sub_48(sp_digit* r, const sp_digit* a, const sp_digit* b
 /* Divide d in a and put remainder into r (m*d + r = a)
  * m is not calculated as it is not needed at this time.
  *
- * a  Nmber to be divided.
+ * a  Number to be divided.
  * d  Number to divide with.
  * m  Multiplier result.
  * r  Remainder from the division.
@@ -4690,7 +4690,7 @@ extern int64_t sp_4096_cmp_64(const sp_digit* a, const sp_digit* b);
 /* Divide d in a and put remainder into r (m*d + r = a)
  * m is not calculated as it is not needed at this time.
  *
- * a  Nmber to be divided.
+ * a  Number to be divided.
  * d  Number to divide with.
  * m  Multiplier result.
  * r  Remainder from the division.
@@ -4762,7 +4762,7 @@ extern sp_digit sp_4096_sub_64(sp_digit* r, const sp_digit* a, const sp_digit* b
 /* Divide d in a and put remainder into r (m*d + r = a)
  * m is not calculated as it is not needed at this time.
  *
- * a  Nmber to be divided.
+ * a  Number to be divided.
  * d  Number to divide with.
  * m  Multiplier result.
  * r  Remainder from the division.
@@ -22495,7 +22495,7 @@ static void sp_256_mask_4(sp_digit* r, const sp_digit* a, sp_digit m)
 /* Divide d in a and put remainder into r (m*d + r = a)
  * m is not calculated as it is not needed at this time.
  *
- * a  Nmber to be divided.
+ * a  Number to be divided.
  * d  Number to divide with.
  * m  Multiplier result.
  * r  Remainder from the division.
@@ -28352,7 +28352,7 @@ static void sp_384_mask_6(sp_digit* r, const sp_digit* a, sp_digit m)
 /* Divide d in a and put remainder into r (m*d + r = a)
  * m is not calculated as it is not needed at this time.
  *
- * a  Nmber to be divided.
+ * a  Number to be divided.
  * d  Number to divide with.
  * m  Multiplier result.
  * r  Remainder from the division.


### PR DESCRIPTION
This PR corrects SP mod calculations. 

The sp_3072_mod_67 and sp_3072_mod_134 functions seem to return incorrect results when the dividend is a little less then a multiple of the modulus.

For example, the sp_3072_mod_67 function called with:

a = 2^1535

m = 2^1535+1

should return the result equal to "a", which is the following array of 23-bit digits (the representation both functions operate on):

{0x0, 0x0, ..., 0x0, 0x0, 0x20000}

but it returns the following invalid value:

{0x7fffff, 0x7fffff, ..., 0x7fffff, 0xffffffff, 0x0}

This error can also happen for "a" greater than "m". For example:

a = 2^1540

m = 2^1535+1

should return 2^1535-31, that is:

{0x7fffe1, 0x7fffff, ..., 0x7fffff, 0x7fffff, 0x1ffff}

but it returns the following invalid value:

{0x7fffe0, 0x7fffff, ..., 0x7fffff, 0xffffffff, 0x0}

The same problem exists for the sp_3072_mod_134 function.