### PR TITLE
Convert a header file to UTF-8 encoding.

### DIFF
--- a/cyassl/ctaocrypt/tfm.h
+++ b/cyassl/ctaocrypt/tfm.h
@@ -28,7 +28,7 @@
 
 
 /**
- *  Edited by MoisÈs Guimar„es (moises.guimaraes@phoebus.com.br)
+ *  Edited by Mois√©s Guimar√£es (moises.guimaraes@phoebus.com.br)
  *  to fit CyaSSL's needs.
  */
 


### PR DESCRIPTION
The file contained characters from the `ISO 8859-1` legacy text encoding. This commit converts the file to `UTF-8`.