### PR TITLE
mp_sub_d (integer.c): return error when digit is too big

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -41804,7 +41804,7 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
             if (i < count - 1) {
                 /* tmpSz+1 for last null char */
                 XSNPRINTF(tmp, tmpSz+1, "%s=%s,", buf, str->data);
-                XSTRNCAT(fullName, tmp, tmpSz);
+                XSTRNCAT(fullName, tmp, tmpSz+1);
             }
             else {
                 XSNPRINTF(tmp, tmpSz, "%s=%s", buf, str->data);

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -4324,6 +4324,8 @@ int mp_sub_d (mp_int * a, mp_digit b, mp_int * c)
   mp_digit *tmpa, *tmpc, mu;
   int       res, ix, oldused;
 
+  if (b > MP_MASK) return MP_VAL;
+
   /* grow c as required */
   if (c->alloc < a->used + 1) {
      if ((res = mp_grow(c, a->used + 1)) != MP_OKAY) {


### PR DESCRIPTION
Code can't handle subtracting a number (an mp_digit) larger than
DIGIT_BIT. Now returns an error rather than giving wrong result.