### PR TITLE
DTLS Size Fix

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -593,7 +593,6 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
                         printf("SSL_write bench error %d!\n", err);
                         if (!exitWithRet)
                             err_sys("SSL_write failed");
-                        ret = err;
                         goto doExit;
                     }
                     tx_time += current_time(0) - start;

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -486,7 +486,7 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
 /* Measures throughput in kbps. Throughput = number of bytes */
 static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
     int dtlsUDP, int dtlsSCTP, int block, size_t throughput, int useX25519,
-    int useX448)
+    int useX448, int exitWithRet)
 {
     double start, conn_time = 0, tx_time = 0, rx_time = 0;
     SOCKET_T sockfd;
@@ -591,7 +591,10 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
                     } while (err == WC_PENDING_E);
                     if (ret != len) {
                         printf("SSL_write bench error %d!\n", err);
-                        err_sys("SSL_write failed");
+                        if (!exitWithRet)
+                            err_sys("SSL_write failed");
+                        ret = err;
+                        goto doExit;
                     }
                     tx_time += current_time(0) - start;
 
@@ -645,6 +648,7 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
         else {
             err_sys("Client buffer malloc failed");
         }
+doExit:
         if(tx_buffer) XFREE(tx_buffer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if(rx_buffer) XFREE(rx_buffer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
@@ -655,6 +659,9 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
     wolfSSL_shutdown(ssl);
     wolfSSL_free(ssl); ssl = NULL;
     CloseSocket(sockfd);
+
+    if (exitWithRet)
+        return err;
 
 #if !defined(__MINGW32__)
     printf("wolfSSL Client Benchmark %zu bytes\n"
@@ -1594,6 +1601,9 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     (void)loadCertKeyIntoSSLObj;
 
     StackTrap();
+
+    /* Reinitialize the global myVerifyAction. */
+    myVerifyAction = VERIFY_OVERRIDE_ERROR;
 
 #ifndef WOLFSSL_VXWORKS
     /* Not used: All used */
@@ -2613,9 +2623,13 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     if (throughput) {
         ((func_args*)args)->return_code =
             ClientBenchmarkThroughput(ctx, host, port, dtlsUDP, dtlsSCTP,
-                                      block, throughput, useX25519, useX448);
+                                      block, throughput, useX25519, useX448,
+                                      exitWithRet);
         wolfSSL_CTX_free(ctx); ctx = NULL;
-        XEXIT_T(EXIT_SUCCESS);
+        if (!exitWithRet)
+            XEXIT_T(EXIT_SUCCESS);
+        else
+            goto exit;
     }
 
     #if defined(WOLFSSL_MDK_ARM)

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -3165,12 +3165,16 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     err = ClientWrite(ssl, msg, msgSz, "", exitWithRet);
     if (exitWithRet && (err != 0)) {
         ((func_args*)args)->return_code = err;
+        wolfSSL_free(ssl); ssl = NULL;
+        wolfSSL_CTX_free(ctx); ctx = NULL;
         goto exit;
     }
 
     err = ClientRead(ssl, reply, sizeof(reply)-1, 1, "", exitWithRet);
     if (exitWithRet && (err != 0)) {
         ((func_args*)args)->return_code = err;
+        wolfSSL_free(ssl); ssl = NULL;
+        wolfSSL_CTX_free(ctx); ctx = NULL;
         goto exit;
     }
 

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -381,8 +381,10 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
                         err_sys_ex(runWithErrors, "SSL_read failed");
                         break;
                     }
-                    if (err == WOLFSSL_ERROR_ZERO_RETURN)
+                    if (err == WOLFSSL_ERROR_ZERO_RETURN) {
+                        free(buffer);
                         return WOLFSSL_ERROR_ZERO_RETURN;
+                    }
                 }
                 else {
                     rx_pos += ret;
@@ -1813,7 +1815,8 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         SSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER |
                             (usePskPlus ? WOLFSSL_VERIFY_FAIL_EXCEPT_PSK :
                                 WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT),
-                  myVerifyAction == VERIFY_OVERRIDE_DATE_ERR ? myVerify : NULL);
+                  (myVerifyAction == VERIFY_OVERRIDE_DATE_ERR ||
+                   myVerifyAction == VERIFY_FORCE_FAIL) ? myVerify : NULL);
 
     #ifdef TEST_BEFORE_DATE
         verify_flags |= WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY;

--- a/src/internal.c
+++ b/src/internal.c
@@ -10007,6 +10007,8 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
     /* Determine if verify was okay */
     if (ret == 0) {
         verify_ok = 1;
+        use_cb = 1; /* use verify callback on success, in case callback
+                     * could force fail a cert */
     }
 
     /* Determine if verify callback should be used */

--- a/tests/include.am
+++ b/tests/include.am
@@ -31,6 +31,7 @@ EXTRA_DIST += tests/test.conf \
               tests/test-psk-no-id.conf \
               tests/test-psk-no-id-sha2.conf \
               tests/test-dtls.conf \
+              tests/test-dtls-fails.conf \
               tests/test-dtls-group.conf \
               tests/test-dtls-reneg-client.conf \
               tests/test-dtls-reneg-server.conf \

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -455,6 +455,7 @@ static int execute_test_case(int svr_argc, char** svr_argv,
         return NOT_BUILT_IN;
     }
     printf("trying client command line[%d]: %s\n", tests, commandLine);
+    tests++;
 
     /* determine based on args if this test is expected to fail */
     if (XSTRSTR(commandLine, exitWithRetFlag) != NULL) {
@@ -881,6 +882,20 @@ int SuiteTest(int argc, char** argv)
         goto exit;
     }
 #endif
+#ifndef WOLFSSL_NO_DTLS_SIZE_CHECK
+    /* failure tests */
+    args.argc = 3;
+    strcpy(argv0[1], "tests/test-dtls-fails.conf");
+    strcpy(argv0[2], "expFail"); /* tests are expected to fail */
+    printf("starting dtls tests that expect failure\n");
+    test_harness(&args);
+    if (args.return_code != 0) {
+        printf("error from script %d\n", args.return_code);
+        args.return_code = EXIT_FAILURE;
+        goto exit;
+    }
+    strcpy(argv0[2], "");
+#endif
 #endif
 #ifdef WOLFSSL_SCTP
     /* add dtls-sctp extra suites */
@@ -1038,7 +1053,7 @@ int SuiteTest(int argc, char** argv)
     args.argc = 3;
     strcpy(argv0[1], "tests/test-dhprime.conf");
     strcpy(argv0[2], "doDH"); /* add DH prime flag */
-    printf("starting tests that expect failure\n");
+    printf("starting dh prime tests\n");
     test_harness(&args);
     if (args.return_code != 0) {
         printf("error from script %d\n", args.return_code);

--- a/tests/test-dtls-fails.conf
+++ b/tests/test-dtls-fails.conf
@@ -1,0 +1,16 @@
+# DTLS test
+# server DTLSv1.2 too big test
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+-u
+-B 9000
+
+# client DTLSv1.2 too big test
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+-u
+-B 9000
+

--- a/tests/test-fails.conf
+++ b/tests/test-fails.conf
@@ -114,7 +114,6 @@
 # server
 -v 3
 -l ECDHE-RSA-AES128-GCM-SHA256
--H verifyFail
 
 # client verify should fail
 -v 3
@@ -129,12 +128,10 @@
 # client
 -v 3
 -l ECDHE-RSA-AES128-GCM-SHA256
--H verifyFail
 
 # server
 -v 3
 -l ECDHE-ECDSA-AES128-GCM-SHA256
--H verifyFail
 
 # client verify should fail
 -v 3
@@ -149,7 +146,6 @@
 # client
 -v 3
 -l ECDHE-ECDSA-AES128-GCM-SHA256
--H verifyFail
 
 # error going into callback, return error
 # server
@@ -157,7 +153,6 @@
 -l ECDHE-RSA-AES128-GCM-SHA256
 -c ./certs/test/server-cert-rsa-badsig.pem
 -k ./certs/server-key.pem
--H verifyFail
 
 # client verify should fail
 -v 3
@@ -169,7 +164,6 @@
 -l ECDHE-ECDSA-AES128-GCM-SHA256
 -c ./certs/test/server-cert-ecc-badsig.pem
 -k ./certs/ecc-key.pem
--H verifyFail
 
 # client verify should fail
 -v 3
@@ -179,12 +173,10 @@
 # server send alert on no mutual authentication
 -v 3
 -F
--H verifyFail
 
 # client send alert on no mutual authentication
 -v 3
 -x
--H verifyFail
 
 # server TLSv1.3 fail on no client certificate
 # server always sets WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT unless using -d
@@ -195,3 +187,4 @@
 -v 4
 -l TLS13-AES128-GCM-SHA256
 -x
+

--- a/tests/test-fails.conf
+++ b/tests/test-fails.conf
@@ -114,6 +114,7 @@
 # server
 -v 3
 -l ECDHE-RSA-AES128-GCM-SHA256
+-H verifyFail
 
 # client verify should fail
 -v 3
@@ -128,10 +129,12 @@
 # client
 -v 3
 -l ECDHE-RSA-AES128-GCM-SHA256
+-H verifyFail
 
 # server
 -v 3
 -l ECDHE-ECDSA-AES128-GCM-SHA256
+-H verifyFail
 
 # client verify should fail
 -v 3
@@ -146,6 +149,7 @@
 # client
 -v 3
 -l ECDHE-ECDSA-AES128-GCM-SHA256
+-H verifyFail
 
 # error going into callback, return error
 # server
@@ -153,6 +157,7 @@
 -l ECDHE-RSA-AES128-GCM-SHA256
 -c ./certs/test/server-cert-rsa-badsig.pem
 -k ./certs/server-key.pem
+-H verifyFail
 
 # client verify should fail
 -v 3
@@ -164,6 +169,7 @@
 -l ECDHE-ECDSA-AES128-GCM-SHA256
 -c ./certs/test/server-cert-ecc-badsig.pem
 -k ./certs/ecc-key.pem
+-H verifyFail
 
 # client verify should fail
 -v 3
@@ -173,10 +179,12 @@
 # server send alert on no mutual authentication
 -v 3
 -F
+-H verifyFail
 
 # client send alert on no mutual authentication
 -v 3
 -x
+-H verifyFail
 
 # server TLSv1.3 fail on no client certificate
 # server always sets WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT unless using -d
@@ -187,4 +195,3 @@
 -v 4
 -l TLS13-AES128-GCM-SHA256
 -x
-

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -167,6 +167,7 @@ enum wolfSSL_ErrorCodes {
     CLIENT_CERT_CB_ERROR         = -436,   /* Client cert callback error */
     SSL_SHUTDOWN_ALREADY_DONE_E  = -437,   /* Shutdown called redundantly */
     TLS13_SECRET_CB_E            = -438,   /* TLS1.3 secret Cb fcn failure */
+    DTLS_SIZE_ERROR              = -439,   /* Trying to send too much data */
 
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1684,7 +1684,7 @@ enum {
     VERIFY_USE_PREVERFIY,
     VERIFY_OVERRIDE_DATE_ERR,
 };
-static int myVerifyAction = VERIFY_OVERRIDE_ERROR;
+static THREAD_LS_T int myVerifyAction = VERIFY_OVERRIDE_ERROR;
 
 /* The verify callback is called for every certificate only when
  * --enable-opensslextra is defined because it sets WOLFSSL_ALWAYS_VERIFY_CB and


### PR DESCRIPTION
When attempting to send a message with DTLS, if it is too large, return an error rather than splitting it across records. (ZD 10602)