### PR TITLE
DTLS Test Speedup

### DIFF
--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -1285,7 +1285,7 @@ static int bench_tls_server(info_t* info)
             ret = SocketWaitClient(info);
         #ifdef BENCH_USE_NONBLOCK
             if (ret == -2) {
-                sleep(0);
+                XSLEEP_MS(0);
                 continue;
             }
         #endif
@@ -1831,7 +1831,7 @@ int bench_tls(void* args)
                     info = &theadInfo[i];
                     if (!info->to_client.done || !info->to_server.done) {
                         doShutdown = 0;
-                        sleep(1); /* Allow other threads to run */
+                        XSLEEP_MS(1000); /* Allow other threads to run */
                     }
 
                 }

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -65,12 +65,14 @@
 #define OCSP_STAPLINGV2_MULTI 3
 #define OCSP_STAPLING_OPT_MAX OCSP_STAPLINGV2_MULTI
 
-#define WXSLEEP(x,y) do { \
-    struct timeval tv = {(x),(y)}; \
-    select(0, NULL, NULL, NULL, &tv); \
-} while (0)
-#define WUSLEEP(x) WXSLEEP(0,x)
-#define WSLEEP(x) WXSLEEP(x,0)
+#if defined(XUSLEEP) && defined(NO_MAIN_DRIVER)
+    /* This is to force the server's thread to get a chance to
+     * execute before continuing the resume in non-blocking
+     * DTLS test cases. */
+    #define TEST_DELAY() XSLEEP_US(10000)
+#else
+    #define TEST_DELAY() XSLEEP_MS(1000)
+#endif
 
 /* Note on using port 0: the client standalone example doesn't utilize the
  * port 0 port sharing; that is used by (1) the server in external control
@@ -3142,20 +3144,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
 /* allow some time for exporting the session */
 #ifdef WOLFSSL_SESSION_EXPORT_DEBUG
-#ifdef USE_WINDOWS_API
-    Sleep(500);
-#elif defined(WOLFSSL_TIRTOS)
-    Task_sleep(1);
-#else
-    /* This is to force the server's thread to get a chance to
-     * execute before continuing the resume in non-blocking
-     * DTLS test cases. */
-#ifdef NO_MAIN_DRIVER
-        WUSLEEP(10000);
-#else
-        WSLEEP(1);
-#endif
-#endif
+    TEST_DELAY();
 #endif /* WOLFSSL_SESSION_EXPORT_DEBUG */
 
 #ifdef WOLFSSL_TLS13
@@ -3254,20 +3243,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif
 
         if (dtlsUDP) {
-#ifdef USE_WINDOWS_API
-            Sleep(500);
-#elif defined(WOLFSSL_TIRTOS)
-            Task_sleep(1);
-#else
-    /* This is to force the server's thread to get a chance to
-     * execute before continuing the resume in non-blocking
-     * DTLS test cases. */
-    #ifdef NO_MAIN_DRIVER
-            WUSLEEP(10000);
-    #else
-            WSLEEP(1);
-    #endif
-#endif
+            TEST_DELAY();
         }
         tcp_connect(&sockfd, host, port, dtlsUDP, dtlsSCTP, sslResume);
         if (wolfSSL_set_fd(sslResume, sockfd) != WOLFSSL_SUCCESS) {
@@ -3389,20 +3365,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     /* allow some time for exporting the session */
     #ifdef WOLFSSL_SESSION_EXPORT_DEBUG
-        #ifdef USE_WINDOWS_API
-            Sleep(500);
-        #elif defined(WOLFSSL_TIRTOS)
-            Task_sleep(1);
-        #else
-            /* This is to force the server's thread to get a chance to
-             * execute before continuing the resume in non-blocking
-             * DTLS test cases. */
-            #ifdef NO_MAIN_DRIVER
-                WUSLEEP(10000);
-            #else
-                WSLEEP(1);
-            #endif
-        #endif
+        TEST_DELAY();
     #endif /* WOLFSSL_SESSION_EXPORT_DEBUG */
 
 #ifdef HAVE_SECURE_RENEGOTIATION

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -65,6 +65,13 @@
 #define OCSP_STAPLINGV2_MULTI 3
 #define OCSP_STAPLING_OPT_MAX OCSP_STAPLINGV2_MULTI
 
+#define WXSLEEP(x,y) do { \
+    struct timeval tv = {(x),(y)}; \
+    select(0, NULL, NULL, NULL, &tv); \
+} while (0)
+#define WUSLEEP(x) WXSLEEP(0,x)
+#define WSLEEP(x) WXSLEEP(x,0)
+
 /* Note on using port 0: the client standalone example doesn't utilize the
  * port 0 port sharing; that is used by (1) the server in external control
  * test mode and (2) the testsuite which uses this code and sets up the correct
@@ -3140,7 +3147,14 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #elif defined(WOLFSSL_TIRTOS)
     Task_sleep(1);
 #else
-    sleep(1);
+    /* This is to force the server's thread to get a chance to
+     * execute before continuing the resume in non-blocking
+     * DTLS test cases. */
+#ifdef NO_MAIN_DRIVER
+        WUSLEEP(10000);
+#else
+        WSLEEP(1);
+#endif
 #endif
 #endif /* WOLFSSL_SESSION_EXPORT_DEBUG */
 
@@ -3245,7 +3259,14 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #elif defined(WOLFSSL_TIRTOS)
             Task_sleep(1);
 #else
-            sleep(1);
+    /* This is to force the server's thread to get a chance to
+     * execute before continuing the resume in non-blocking
+     * DTLS test cases. */
+    #ifdef NO_MAIN_DRIVER
+            WUSLEEP(10000);
+    #else
+            WSLEEP(1);
+    #endif
 #endif
         }
         tcp_connect(&sockfd, host, port, dtlsUDP, dtlsSCTP, sslResume);
@@ -3373,7 +3394,14 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         #elif defined(WOLFSSL_TIRTOS)
             Task_sleep(1);
         #else
-            sleep(1);
+            /* This is to force the server's thread to get a chance to
+             * execute before continuing the resume in non-blocking
+             * DTLS test cases. */
+            #ifdef NO_MAIN_DRIVER
+                WUSLEEP(10000);
+            #else
+                WSLEEP(1);
+            #endif
         #endif
     #endif /* WOLFSSL_SESSION_EXPORT_DEBUG */
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -34432,7 +34432,7 @@ static void test_wolfSSL_ASN1_STRING_print(void){
 
     asnStr = ASN1_STRING_type_new(V_ASN1_OCTET_STRING);
     ASN1_STRING_set(asnStr,(const void*)unprintableData,
-            sizeof(unprintableData));
+            (int)sizeof(unprintableData));
     /* test */
     p_len = wolfSSL_ASN1_STRING_print(bio, asnStr);
     AssertIntEQ(p_len, 46);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -55,6 +55,7 @@
     #endif
     #define SOCKET_T SOCKET
     #define SNPRINTF _snprintf
+    #define XSLEEP_MS(t) Sleep(t)
 #elif defined(WOLFSSL_MDK_ARM) || defined(WOLFSSL_KEIL_TCP_NET)
     #include <string.h>
     #include "rl_net.h"
@@ -69,9 +70,9 @@
         return(ret) ;
     }
     #if defined(HAVE_KEIL_RTX)
-        #define sleep(t) os_dly_wait(t/1000+1);
+        #define XSLEEP_MS(t)  os_dly_wait(t)
     #elif defined(WOLFSSL_CMSIS_RTOS) || defined(WOLFSSL_CMSIS_RTOSv2)
-        #define sleep(t) osDelay(t/1000+1);
+        #define XSLEEP_MS(t)  osDelay(t)
     #endif
 #elif defined(WOLFSSL_TIRTOS)
     #include <string.h>
@@ -88,6 +89,7 @@
         char **h_addr_list; /* list of addresses from name server */
     };
     #define SOCKET_T int
+    #define XSLEEP_MS(t) Task_sleep(t/1000)
 #elif defined(WOLFSSL_VXWORKS)
     #include <hostLib.h>
     #include <sockLib.h>
@@ -148,7 +150,17 @@
         #include <signal.h>  /* ignore SIGPIPE */
     #endif
     #define SNPRINTF snprintf
+
+    #define XSELECT_WAIT(x,y) do { \
+        struct timeval tv = {(x),(y)}; \
+        select(0, NULL, NULL, NULL, &tv); \
+    } while (0)
+    #define XSLEEP_US(u) XSELECT_WAIT(0,u)
 #endif /* USE_WINDOWS_API */
+
+#ifndef XSLEEP_MS
+    #define XSLEEP_MS(t) sleep(t/1000)
+#endif
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     #include <wolfssl/wolfcrypt/async.h>


### PR DESCRIPTION
Change the example client to use select instead of sleep. If building for the standalone client, it will wait 1 second. If built for no main driver, it'll wait 10ms rather than 1 second.