### PR TITLE
Additional OpenSSL compat stuff for OpenSSH

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1406,7 +1406,7 @@ AC_ARG_ENABLE([certgen],
     [ ENABLED_CERTGEN=$enableval ],
     [ ENABLED_CERTGEN=no ]
     )
-if test "$ENABLED_OPENVPN" = "yes"
+if test "$ENABLED_OPENVPN" = "yes" || test "$ENABLED_OPENSSH" = "yes"
 then
     ENABLED_CERTGEN=yes
 fi

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -37339,12 +37339,12 @@ static int CopyX509NameToCertName(WOLFSSL_X509_NAME* n, CertName* cName)
         /* Parse the X509 subject name */
         if (GetName(&cert, SUBJECT, (int)length) != 0) {
             WOLFSSL_MSG("WOLFSSL_X509_NAME parse error");
-            return NULL;
+            goto cleanup;
         }
 
         if (!(tmp = wolfSSL_X509_NAME_new())) {
             WOLFSSL_MSG("wolfSSL_X509_NAME_new error");
-            return NULL;
+            goto cleanup;
         }
 
         XSTRNCPY(tmp->staticName, cert.subject, ASN_NAME_MAX);
@@ -37353,7 +37353,8 @@ static int CopyX509NameToCertName(WOLFSSL_X509_NAME* n, CertName* cName)
 
         if (name)
             *name = tmp;
-
+cleanup:
+        FreeDecodedCert(&cert);
         return tmp;
     }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7619,11 +7619,12 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PUBKEY(WOLFSSL_EVP_PKEY** out,
 static int wolfSSL_EVP_PKEY_get_der(const WOLFSSL_EVP_PKEY* key, unsigned char** der)
 {
     unsigned char* pt;
-    int sz = key->pkey_sz;
+    int sz;
 
     if (!key || !key->pkey_sz)
         return WOLFSSL_FATAL_ERROR;
 
+    sz = key->pkey_sz;
     if (der) {
         pt = (unsigned char*)key->pkey.ptr;
         if (*der) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -31855,14 +31855,8 @@ WOLFSSL_EC_KEY *wolfSSL_EC_KEY_new_by_curve_name(int nid)
 {
     WOLFSSL_EC_KEY *key;
     int x;
-    int eccEnum;
 
     WOLFSSL_ENTER("wolfSSL_EC_KEY_new_by_curve_name");
-
-    /* If NID passed in is OpenSSL type, convert it to ecc_curve_id enum */
-    eccEnum = NIDToEccEnum(nid);
-    if (eccEnum == -1)
-        eccEnum = nid;
 
     key = wolfSSL_EC_KEY_new();
     if (key == NULL) {
@@ -31871,7 +31865,7 @@ WOLFSSL_EC_KEY *wolfSSL_EC_KEY_new_by_curve_name(int nid)
     }
 
     /* set the nid of the curve */
-    key->group->curve_nid = eccEnum;
+    key->group->curve_nid = nid;
 
     /* search and set the corresponding internal curve idx */
     for (x = 0; ecc_sets[x].size != 0; x++)
@@ -32117,8 +32111,11 @@ int wolfSSL_EC_KEY_generate_key(WOLFSSL_EC_KEY *key)
         return 0;
     }
 
+    /* NIDToEccEnum return -1 for invalid NID so if key->group->curve_nid
+     * is 0 then pass 0 as arg */
     if (wc_ecc_make_key_ex(rng, 0, (ecc_key*)key->internal,
-                                        key->group->curve_nid) != MP_OKAY) {
+            key->group->curve_nid ? NIDToEccEnum(key->group->curve_nid) : 0
+            ) != MP_OKAY) {
         WOLFSSL_MSG("wolfSSL_EC_KEY_generate_key wc_ecc_make_key failed");
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(tmpRNG, NULL, DYNAMIC_TYPE_RNG);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -33329,12 +33329,12 @@ int wolfSSL_EC_POINT_add(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *r,
 
     if (ecc_projective_add_point(montP1, montP2, (ecc_point*)r->internal,
             &a, &prime, mp) != MP_OKAY) {
-        WOLFSSL_MSG("wc_ecc_mulmod nqm error");
+        WOLFSSL_MSG("ecc_projective_add_point error");
         goto cleanup;
     }
 
     if (ecc_map((ecc_point*)r->internal, &prime, mp) != MP_OKAY) {
-        WOLFSSL_MSG("ecc_map nqm error");
+        WOLFSSL_MSG("ecc_map error");
         goto cleanup;
     }
 
@@ -33428,14 +33428,14 @@ int wolfSSL_EC_POINT_mul(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *r,
             goto cleanup;
         }
         /* r = generator * n */
-        if (wc_ecc_mulmod((mp_int*)n->internal, result, result, &a, &prime, 1)
+        if (wc_ecc_mulmod((mp_int*)n->internal, result, result, &a, &prime, 0)
                 != MP_OKAY) {
             WOLFSSL_MSG("wc_ecc_mulmod nqm error");
             goto cleanup;
         }
         /* tmp = q * m */
         if (wc_ecc_mulmod((mp_int*)m->internal, (ecc_point*)q->internal,
-                tmp, &a, &prime, 1) != MP_OKAY) {
+                tmp, &a, &prime, 0) != MP_OKAY) {
             WOLFSSL_MSG("wc_ecc_mulmod nqm error");
             goto cleanup;
         }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -32453,6 +32453,13 @@ int wolfSSL_EC_GROUP_cmp(const WOLFSSL_EC_GROUP *a, const WOLFSSL_EC_GROUP *b,
     return 1;
 }
 
+WOLFSSL_EC_GROUP *wolfSSL_EC_GROUP_dup(const WOLFSSL_EC_GROUP *src)
+{
+    if (!src)
+        return NULL;
+    return wolfSSL_EC_GROUP_new_by_curve_name(src->curve_nid);
+}
+
 #endif /* HAVE_ECC */
 #endif /* OPENSSL_EXTRA */
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -37317,6 +37317,42 @@ static int CopyX509NameToCertName(WOLFSSL_X509_NAME* n, CertName* cName)
 #endif /* WOLFSSL_CERT_GEN */
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
 
+    WOLFSSL_X509_NAME *wolfSSL_d2i_X509_NAME(WOLFSSL_X509_NAME **name,
+                                             unsigned char **in, long length)
+    {
+        WOLFSSL_X509_NAME* tmp = NULL;
+        DecodedCert cert;
+
+        WOLFSSL_ENTER("wolfSSL_d2i_X509_NAME");
+
+        if (!in || !*in || length <= 0) {
+            WOLFSSL_MSG("Bad argument");
+            return NULL;
+        }
+
+        InitDecodedCert(&cert, *in, length, NULL);
+
+        if (GetName(&cert, SUBJECT, length) != 0) {
+            WOLFSSL_MSG("WOLFSSL_X509_NAME parse error");
+            return NULL;
+        }
+
+        if (!(tmp = wolfSSL_X509_NAME_new())) {
+            WOLFSSL_MSG("wolfSSL_X509_NAME_new error");
+            return NULL;
+        }
+
+        XSTRNCPY(tmp->staticName, cert.subject, ASN_NAME_MAX);
+        tmp->staticName[ASN_NAME_MAX - 1] = '\0';
+        tmp->sz = (int)XSTRLEN(tmp->staticName) + 1;
+
+        if (name)
+            *name = tmp;
+
+        return tmp;
+    }
+
+
     /* Compares the two X509 names. If the size of x is larger then y then a
      * positive value is returned if x is smaller a negative value is returned.
      * In the case that the sizes are equal a the value of strcmp between the

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -33502,12 +33502,11 @@ int wolfSSL_EC_POINT_invert(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *a,
 
     WOLFSSL_ENTER("wolfSSL_EC_POINT_invert");
 
-    if (!group || !a || setupPoint(a) != WOLFSSL_SUCCESS) {
+    if (!group || !a || !a->internal || setupPoint(a) != WOLFSSL_SUCCESS) {
         return WOLFSSL_FAILURE;
     }
 
     p = (ecc_point*)a->internal;
-
 
     /* read the curve prime and a */
     if (mp_init_multi(&prime, NULL, NULL, NULL, NULL, NULL) != MP_OKAY) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -32964,7 +32964,8 @@ WOLFSSL_EC_KEY *wolfSSL_d2i_ECPrivateKey(WOLFSSL_EC_KEY **key, const unsigned ch
         return NULL;
     }
 
-    if (wc_ecc_import_private_key(*in, len, NULL, 0, (ecc_key*)eckey->internal) != MP_OKAY) {
+    if (wc_ecc_import_private_key(*in, (word32)len, NULL, 0,
+            (ecc_key*)eckey->internal) != MP_OKAY) {
         WOLFSSL_MSG("wc_ecc_import_private_key error");
         goto error;
     }
@@ -37333,10 +37334,10 @@ static int CopyX509NameToCertName(WOLFSSL_X509_NAME* n, CertName* cName)
 
         /* Set the X509_NAME buffer as the input data for cert.
          * in is NOT a full certificate. Just the name. */
-        InitDecodedCert(&cert, *in, length, NULL);
+        InitDecodedCert(&cert, *in, (word32)length, NULL);
 
         /* Parse the X509 subject name */
-        if (GetName(&cert, SUBJECT, length) != 0) {
+        if (GetName(&cert, SUBJECT, (int)length) != 0) {
             WOLFSSL_MSG("WOLFSSL_X509_NAME parse error");
             return NULL;
         }

--- a/tests/api.c
+++ b/tests/api.c
@@ -2137,7 +2137,7 @@ static void test_wolfSSL_ECDSA_SIG(void)
 
 static void test_EC_i2d(void)
 {
-#ifdef HAVE_ECC
+#if defined(HAVE_ECC) && !defined(HAVE_FIPS)
     EC_KEY *key;
     EC_KEY *copy;
     int len;

--- a/tests/api.c
+++ b/tests/api.c
@@ -1946,6 +1946,7 @@ static void test_wolfSSL_EC(void)
 
 #ifndef HAVE_SELFTEST
     /* perform point multiplication */
+    AssertIntEQ(EC_POINT_add(group, new_point, new_point, Gxy, ctx), WOLFSSL_SUCCESS);
     AssertIntEQ(EC_POINT_mul(group, new_point, Gx, Gxy, k, ctx), WOLFSSL_SUCCESS);
     AssertIntEQ(BN_is_zero(new_point->X), 0);
     AssertIntEQ(BN_is_zero(new_point->Y), 0);
@@ -1991,6 +1992,9 @@ static void test_wolfSSL_EC(void)
 
     /* Test copying */
     AssertIntEQ(EC_POINT_copy(new_point, set_point), 1);
+
+    /* Test inverting */
+    AssertIntEQ(EC_POINT_invert(group, new_point, ctx), 1);
 
     AssertPtrEq(EC_POINT_point2bn(group, set_point, POINT_CONVERSION_UNCOMPRESSED,
                                   set_point_bn, ctx), set_point_bn);
@@ -2135,8 +2139,10 @@ static void test_EC_i2d(void)
 {
 #ifdef HAVE_ECC
     EC_KEY *key;
+    EC_KEY *copy;
     int len;
     unsigned char *buf = NULL;
+    const unsigned char *tmp = NULL;
 
     AssertNotNull(key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
     AssertIntEQ(EC_KEY_generate_key(key), 1);
@@ -2150,8 +2156,12 @@ static void test_EC_i2d(void)
     AssertIntGT((len = i2d_ECPrivateKey(key, NULL)), 0);
     AssertIntEQ(i2d_ECPrivateKey(key, &buf), len);
 
+    tmp = buf;
+    AssertNotNull(d2i_ECPrivateKey(&copy, &tmp, len));
+
     XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     EC_KEY_free(key);
+    EC_KEY_free(copy);
 #endif /* HAVE_ECC */
 }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -1884,6 +1884,7 @@ static void test_wolfSSL_EC(void)
 #if defined(HAVE_ECC)
     BN_CTX *ctx;
     EC_GROUP *group;
+    EC_GROUP *group2;
     EC_POINT *Gxy, *new_point, *set_point;
     BIGNUM *k = NULL, *Gx = NULL, *Gy = NULL, *Gz = NULL;
     BIGNUM *X, *Y;
@@ -1923,6 +1924,7 @@ static void test_wolfSSL_EC(void)
 
     AssertNotNull(ctx = BN_CTX_new());
     AssertNotNull(group = EC_GROUP_new_by_curve_name(NID_X9_62_prime256v1));
+    AssertNotNull(group2 = EC_GROUP_dup(group));
     AssertIntEQ((group_bits = EC_GROUP_order_bits(group)), 256);
     AssertNotNull(Gxy = EC_POINT_new(group));
     AssertNotNull(new_point = EC_POINT_new(group));
@@ -2074,6 +2076,7 @@ static void test_wolfSSL_EC(void)
     EC_POINT_free(set_point);
     EC_POINT_free(Gxy);
     EC_GROUP_free(group);
+    EC_GROUP_free(group2);
     BN_CTX_free(ctx);
 #endif /* HAVE_ECC */
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -2136,7 +2136,7 @@ static void test_ECDSA_size_sign(void)
     id = wc_ecc_get_curve_id_from_name("SECP256R1");
     AssertIntEQ(id, ECC_SECP256R1);
 
-    AssertNotNull(key = wolfSSL_EC_KEY_new_by_curve_name(id));
+    AssertNotNull(key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
     AssertIntEQ(EC_KEY_generate_key(key), 1);
     AssertIntEQ(ECDSA_sign(0, hash, sizeof(hash), sig, &sigSz, key), 1);
     AssertIntGE(ECDSA_size(key), sigSz);
@@ -32246,10 +32246,10 @@ static void test_wc_ecc_get_curve_id_from_dp_params(void)
         id = wc_ecc_get_curve_id_from_name("SECP256R1");
         AssertIntEQ(id, ECC_SECP256R1);
 
-        ecKey = wolfSSL_EC_KEY_new_by_curve_name(id);
+        ecKey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
         AssertNotNull(ecKey);
 
-        ret = wolfSSL_EC_KEY_generate_key(ecKey);
+        ret = EC_KEY_generate_key(ecKey);
 
         if (ret == 0) {
             /* normal test */

--- a/tests/api.c
+++ b/tests/api.c
@@ -5519,7 +5519,7 @@ static void test_wolfSSL_X509_verify(void)
     WOLFSSL_X509* server;
     WOLFSSL_EVP_PKEY* pkey;
     unsigned char buf[2048];
-    const unsigned char* pt;
+    const unsigned char* pt = NULL;
     int bufSz;
 
     printf(testingFmt, "wolfSSL X509 verify");
@@ -5546,6 +5546,9 @@ static void test_wolfSSL_X509_verify(void)
     /* success case */
     pt = buf;
     AssertNotNull(pkey = wolfSSL_d2i_PUBKEY(NULL, &pt, bufSz));
+
+    AssertIntEQ(i2d_PUBKEY(pkey, NULL), bufSz);
+
     AssertIntEQ(wolfSSL_X509_verify(server, pkey), WOLFSSL_SUCCESS);
     wolfSSL_EVP_PKEY_free(pkey);
 
@@ -31744,7 +31747,7 @@ static void test_wolfSSL_i2d_PrivateKey()
         EVP_PKEY* pkey;
         const unsigned char* server_key = (const unsigned char*)server_key_der_2048;
         unsigned char buf[FOURK_BUF];
-        unsigned char* pt;
+        unsigned char* pt = NULL;
         int bufSz;
 
         AssertNotNull(pkey = d2i_PrivateKey(EVP_PKEY_RSA, NULL, &server_key,
@@ -31763,7 +31766,7 @@ static void test_wolfSSL_i2d_PrivateKey()
         const unsigned char* client_key =
             (const unsigned char*)ecc_clikey_der_256;
         unsigned char buf[FOURK_BUF];
-        unsigned char* pt;
+        unsigned char* pt = NULL;
         int bufSz;
 
         AssertNotNull((pkey = d2i_PrivateKey(EVP_PKEY_EC, NULL, &client_key,

--- a/tests/api.c
+++ b/tests/api.c
@@ -23033,6 +23033,7 @@ static void test_wolfSSL_X509_NAME(void)
     XFILE f;
     const X509_NAME* a;
     const X509_NAME* b;
+    X509_NAME* d2i_name;
     int sz;
     unsigned char* tmp;
     char file[] = "./certs/ca-cert.der";
@@ -23068,6 +23069,9 @@ static void test_wolfSSL_X509_NAME(void)
         abort();
     }
 
+    tmp = buf;
+    AssertNotNull(d2i_name = d2i_X509_NAME(NULL, &tmp, sz));
+
     /* retry but with the function creating a buffer */
     tmp = NULL;
     AssertIntGT((sz = i2d_X509_NAME((X509_NAME*)b, &tmp)), 0);
@@ -23077,6 +23081,7 @@ static void test_wolfSSL_X509_NAME(void)
     AssertNotNull(b = X509_NAME_dup((X509_NAME*)a));
     AssertIntEQ(X509_NAME_cmp(a, b), 0);
     X509_NAME_free((X509_NAME*)b);
+    X509_NAME_free(d2i_name);
 
     X509_free(x509);
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5550,7 +5550,7 @@ int CalcHashId(const byte* data, word32 len, byte* hash)
 
 /* process NAME, either issuer or subject
  * returns 0 on success and negative values on fail */
-static int GetName(DecodedCert* cert, int nameType, int maxIdx)
+int GetName(DecodedCert* cert, int nameType, int maxIdx)
 {
     int    length;  /* length of all distinguished names */
     int    dummy;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3893,6 +3893,35 @@ int wc_ecc_shared_secret_ex(ecc_key* private_key, ecc_point* point,
 #endif /* !WOLFSSL_ATECC508A && !WOLFSSL_CRYPTOCELL */
 #endif /* HAVE_ECC_DHE */
 
+#ifdef USE_ECC_B_PARAM
+/* Checks if a point p lies on the curve with index curve_idx */
+int wc_ecc_point_is_on_curve(ecc_point *p, int curve_idx)
+{
+    int err;
+    DECLARE_CURVE_SPECS(curve, 3);
+
+    if (p == NULL)
+        return BAD_FUNC_ARG;
+
+    /* is the IDX valid ?  */
+    if (wc_ecc_is_valid_idx(curve_idx) != 1) {
+       return ECC_BAD_ARG_E;
+    }
+
+    ALLOC_CURVE_SPECS(3);
+    err = wc_ecc_curve_load(wc_ecc_get_curve_params(curve_idx), &curve,
+                                ECC_CURVE_FIELD_PRIME | ECC_CURVE_FIELD_AF |
+                                ECC_CURVE_FIELD_BF);
+    if (err == MP_OKAY) {
+        err = wc_ecc_is_point(p, curve->Af, curve->Bf, curve->prime);
+    }
+
+    wc_ecc_curve_free(curve);
+    FREE_CURVE_SPECS();
+
+    return err;
+}
+#endif /* USE_ECC_B_PARAM */
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
     !defined(WOLFSSL_CRYPTOCELL)

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -148,12 +148,18 @@ int wolfSSL_EC_POINT_oct2point(const WOLFSSL_EC_GROUP *group,
 WOLFSSL_API
 int wolfSSL_i2o_ECPublicKey(const WOLFSSL_EC_KEY *in, unsigned char **out);
 WOLFSSL_API
+int wolfSSL_i2d_ECPrivateKey(const WOLFSSL_EC_KEY *in, unsigned char **out);
+WOLFSSL_API
 void wolfSSL_EC_KEY_set_conv_form(WOLFSSL_EC_KEY *eckey, char form);
 WOLFSSL_API
 WOLFSSL_BIGNUM *wolfSSL_EC_POINT_point2bn(const WOLFSSL_EC_GROUP *group,
                                           const WOLFSSL_EC_POINT *p,
                                           char form,
                                           WOLFSSL_BIGNUM *in, WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
+int wolfSSL_EC_POINT_is_on_curve(const WOLFSSL_EC_GROUP *group,
+                                 const WOLFSSL_EC_POINT *point,
+                                 WOLFSSL_BN_CTX *ctx);
 
 WOLFSSL_API
 int wolfSSL_EC_KEY_LoadDer(WOLFSSL_EC_KEY* key,
@@ -304,7 +310,10 @@ char* wolfSSL_EC_POINT_point2hex(const WOLFSSL_EC_GROUP* group,
 #define EC_POINT_point2oct              wolfSSL_EC_POINT_point2oct
 #define EC_POINT_oct2point              wolfSSL_EC_POINT_oct2point
 #define EC_POINT_point2bn               wolfSSL_EC_POINT_point2bn
+#define EC_POINT_is_on_curve            wolfSSL_EC_POINT_is_on_curve
 #define i2o_ECPublicKey                 wolfSSL_i2o_ECPublicKey
+#define i2d_EC_PUBKEY                   wolfSSL_i2o_ECPublicKey
+#define i2d_ECPrivateKey                wolfSSL_i2d_ECPrivateKey
 #define EC_KEY_set_conv_form            wolfSSL_EC_KEY_set_conv_form
 
 #ifndef HAVE_SELFTEST

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -204,6 +204,8 @@ WOLFSSL_API
 int wolfSSL_EC_GROUP_cmp(const WOLFSSL_EC_GROUP *a, const WOLFSSL_EC_GROUP *b,
                          WOLFSSL_BN_CTX *ctx);
 WOLFSSL_API
+WOLFSSL_EC_GROUP *wolfSSL_EC_GROUP_dup(const WOLFSSL_EC_GROUP *src);
+WOLFSSL_API
 int wolfSSL_EC_GROUP_get_curve_name(const WOLFSSL_EC_GROUP *group);
 WOLFSSL_API
 int wolfSSL_EC_GROUP_get_degree(const WOLFSSL_EC_GROUP *group);
@@ -283,6 +285,7 @@ char* wolfSSL_EC_POINT_point2hex(const WOLFSSL_EC_GROUP* group,
 #define EC_GROUP_set_asn1_flag          wolfSSL_EC_GROUP_set_asn1_flag
 #define EC_GROUP_new_by_curve_name      wolfSSL_EC_GROUP_new_by_curve_name
 #define EC_GROUP_cmp                    wolfSSL_EC_GROUP_cmp
+#define EC_GROUP_dup                    wolfSSL_EC_GROUP_dup
 #define EC_GROUP_get_curve_name         wolfSSL_EC_GROUP_get_curve_name
 #define EC_GROUP_get_degree             wolfSSL_EC_GROUP_get_degree
 #define EC_GROUP_get_order              wolfSSL_EC_GROUP_get_order

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -148,6 +148,9 @@ int wolfSSL_EC_POINT_oct2point(const WOLFSSL_EC_GROUP *group,
 WOLFSSL_API
 int wolfSSL_i2o_ECPublicKey(const WOLFSSL_EC_KEY *in, unsigned char **out);
 WOLFSSL_API
+WOLFSSL_EC_KEY *wolfSSL_d2i_ECPrivateKey(WOLFSSL_EC_KEY **key, const unsigned char **in,
+                                         long len);
+WOLFSSL_API
 int wolfSSL_i2d_ECPrivateKey(const WOLFSSL_EC_KEY *in, unsigned char **out);
 WOLFSSL_API
 void wolfSSL_EC_KEY_set_conv_form(WOLFSSL_EC_KEY *eckey, char form);
@@ -236,10 +239,17 @@ int wolfSSL_EC_POINT_set_affine_coordinates_GFp(const WOLFSSL_EC_GROUP *group,
                                                 const WOLFSSL_BIGNUM *y,
                                                 WOLFSSL_BN_CTX *ctx);
 WOLFSSL_API
+int wolfSSL_EC_POINT_add(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *r,
+                         const WOLFSSL_EC_POINT *p1,
+                         const WOLFSSL_EC_POINT *p2, WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
 int wolfSSL_EC_POINT_mul(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *r,
                          const WOLFSSL_BIGNUM *n,
                          const WOLFSSL_EC_POINT *q, const WOLFSSL_BIGNUM *m,
                          WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
+int wolfSSL_EC_POINT_invert(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *a,
+                            WOLFSSL_BN_CTX *ctx);
 WOLFSSL_API
 void wolfSSL_EC_POINT_clear_free(WOLFSSL_EC_POINT *point);
 WOLFSSL_API
@@ -300,7 +310,9 @@ char* wolfSSL_EC_POINT_point2hex(const WOLFSSL_EC_GROUP* group,
                                      wolfSSL_EC_POINT_get_affine_coordinates_GFp
 #define EC_POINT_set_affine_coordinates_GFp \
                                      wolfSSL_EC_POINT_set_affine_coordinates_GFp
+#define EC_POINT_add                    wolfSSL_EC_POINT_add
 #define EC_POINT_mul                    wolfSSL_EC_POINT_mul
+#define EC_POINT_invert                 wolfSSL_EC_POINT_invert
 #define EC_POINT_clear_free             wolfSSL_EC_POINT_clear_free
 #define EC_POINT_cmp                    wolfSSL_EC_POINT_cmp
 #define EC_POINT_copy                   wolfSSL_EC_POINT_copy
@@ -316,6 +328,7 @@ char* wolfSSL_EC_POINT_point2hex(const WOLFSSL_EC_GROUP* group,
 #define EC_POINT_is_on_curve            wolfSSL_EC_POINT_is_on_curve
 #define i2o_ECPublicKey                 wolfSSL_i2o_ECPublicKey
 #define i2d_EC_PUBKEY                   wolfSSL_i2o_ECPublicKey
+#define d2i_ECPrivateKey                wolfSSL_d2i_ECPrivateKey
 #define i2d_ECPrivateKey                wolfSSL_i2d_ECPrivateKey
 #define EC_KEY_set_conv_form            wolfSSL_EC_KEY_set_conv_form
 

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -178,11 +178,11 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define PKCS8_PRIV_KEY_INFO_free        wolfSSL_EVP_PKEY_free
 #define d2i_PKCS12_fp                   wolfSSL_d2i_PKCS12_fp
 
+#define i2d_PUBKEY                      wolfSSL_i2d_PUBKEY
 #define d2i_PUBKEY                      wolfSSL_d2i_PUBKEY
 #define d2i_PUBKEY_bio                  wolfSSL_d2i_PUBKEY_bio
 #define d2i_PrivateKey                  wolfSSL_d2i_PrivateKey
 #define d2i_AutoPrivateKey              wolfSSL_d2i_AutoPrivateKey
-#define i2d_PrivateKey                  wolfSSL_i2d_PrivateKey
 #define SSL_use_PrivateKey              wolfSSL_use_PrivateKey
 #define SSL_use_PrivateKey_ASN1         wolfSSL_use_PrivateKey_ASN1
 #define SSL_use_RSAPrivateKey_ASN1      wolfSSL_use_RSAPrivateKey_ASN1

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -449,6 +449,7 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define sk_X509_INFO_free               wolfSSL_sk_X509_INFO_free
 
 #define i2d_X509_NAME                   wolfSSL_i2d_X509_NAME
+#define d2i_X509_NAME                   wolfSSL_d2i_X509_NAME
 #define X509_NAME_new                   wolfSSL_X509_NAME_new
 #define X509_NAME_free                  wolfSSL_X509_NAME_free
 #define X509_NAME_dup                   wolfSSL_X509_NAME_dup

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1320,7 +1320,6 @@ WOLFSSL_API int wolfSSL_i2d_X509_NAME(WOLFSSL_X509_NAME* n,
                                                            unsigned char** out);
 WOLFSSL_API WOLFSSL_X509_NAME *wolfSSL_d2i_X509_NAME(WOLFSSL_X509_NAME **name,
                                               unsigned char **in, long length);
-WOLFSSL_API
 #ifndef NO_RSA
 WOLFSSL_API int wolfSSL_RSA_print(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa, int offset);
 #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1318,6 +1318,9 @@ WOLFSSL_API void wolfSSL_X509_STORE_set_verify_cb(WOLFSSL_X509_STORE *st,
                                  WOLFSSL_X509_STORE_CTX_verify_cb verify_cb);
 WOLFSSL_API int wolfSSL_i2d_X509_NAME(WOLFSSL_X509_NAME* n,
                                                            unsigned char** out);
+WOLFSSL_API WOLFSSL_X509_NAME *wolfSSL_d2i_X509_NAME(WOLFSSL_X509_NAME **name,
+                                              unsigned char **in, long length);
+WOLFSSL_API
 #ifndef NO_RSA
 WOLFSSL_API int wolfSSL_RSA_print(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa, int offset);
 #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1427,11 +1427,12 @@ WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_PUBKEY_bio(WOLFSSL_BIO* bio,
                                          WOLFSSL_EVP_PKEY** out);
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_PUBKEY(WOLFSSL_EVP_PKEY** key,
         const unsigned char** in, long inSz);
+WOLFSSL_API int wolfSSL_i2d_PUBKEY(const WOLFSSL_EVP_PKEY *key, unsigned char **der);
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey(int type,
         WOLFSSL_EVP_PKEY** out, const unsigned char **in, long inSz);
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_EVP(WOLFSSL_EVP_PKEY** key,
         unsigned char** in, long inSz);
-WOLFSSL_API int wolfSSL_i2d_PrivateKey(WOLFSSL_EVP_PKEY* key,
+WOLFSSL_API int wolfSSL_i2d_PrivateKey(const WOLFSSL_EVP_PKEY* key,
         unsigned char** der);
 WOLFSSL_API int       wolfSSL_X509_cmp_current_time(const WOLFSSL_ASN1_TIME*);
 #ifdef OPENSSL_EXTRA

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1006,6 +1006,7 @@ struct TrustedPeerCert {
 #endif
 
 WOLFSSL_LOCAL int CalcHashId(const byte* data, word32 len, byte* hash);
+WOLFSSL_LOCAL int GetName(DecodedCert* cert, int nameType, int maxIdx);
 
 WOLFSSL_ASN_API int wc_BerToDer(const byte* ber, word32 berSz, byte* der,
                                 word32* derSz);

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -592,6 +592,8 @@ WOLFSSL_API
 int wc_ecc_cmp_point(ecc_point* a, ecc_point *b);
 WOLFSSL_API
 int wc_ecc_point_is_at_infinity(ecc_point *p);
+WOLFSSL_API
+int wc_ecc_point_is_on_curve(ecc_point *p, int curve_idx);
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
 WOLFSSL_API


### PR DESCRIPTION
- group->curve_nid is now set to the real NID of the curve
- Fix memory leak with EncryptDerKey

New functions implemented
- `EC_POINT_is_on_curve`
- `i2d_EC_PUBKEY`
- `i2d_ECPrivateKey`
- `wc_ecc_point_is_on_curve`
- `wolfSSL_i2d_PUBKEY`
- `wolfSSL_i2d_PrivateKey`
- `wolfSSL_EC_GROUP_dup`
- `wolfSSL_d2i_ECPrivateKey`
- `wolfSSL_EC_POINT_add`
- `wolfSSL_EC_POINT_invert`
- `wolfSSL_d2i_X509_NAME`