### PR TITLE
Fix for ECC non-blocking only to allow calling without context set

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4913,35 +4913,50 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
     #else
         mp_int* sign_k = NULL;
     #endif
+    #ifdef WC_ECC_NONBLOCK_ONLY
+        /* perform blocking call to non-blocking function */
+        ecc_nb_ctx_t nb_ctx;
+        XMEMSET(&nb_ctx, 0, sizeof(nb_ctx));
+    #endif
     #ifndef WOLFSSL_SP_NO_256
         if (ecc_sets[key->idx].id == ECC_SECP256R1) {
-        #ifdef WC_ECC_NONBLOCK
+        #if defined(WC_ECC_NONBLOCK) || defined(WC_ECC_NONBLOCK_ONLY)
             if (key->nb_ctx) {
                 return sp_ecc_sign_256_nb(&key->nb_ctx->sp_ctx, in, inlen, rng, 
                     &key->k, r, s, sign_k, key->heap);
             }
+            #ifdef WC_ECC_NONBLOCK_ONLY
+            do { /* perform blocking call to non-blocking function */
+                err = sp_ecc_sign_256_nb(&nb_ctx.sp_ctx, in, inlen, rng, 
+                    &key->k, r, s, sign_k, key->heap);
+            } while (err == FP_WOULDBLOCK);
+            return err;
+            #endif
         #endif
         #ifndef WC_ECC_NONBLOCK_ONLY
             return sp_ecc_sign_256(in, inlen, rng, &key->k, r, s, sign_k, 
                 key->heap);
-        #else
-            return NOT_COMPILED_IN;
         #endif
         }
     #endif
     #ifdef WOLFSSL_SP_384
         if (ecc_sets[key->idx].id == ECC_SECP384R1) {
-        #ifdef WC_ECC_NONBLOCK
+        #if defined(WC_ECC_NONBLOCK) || defined(WC_ECC_NONBLOCK_ONLY)
             if (key->nb_ctx) {
                 return sp_ecc_sign_384_nb(&key->nb_ctx->sp_ctx, in, inlen, rng, 
                     &key->k, r, s, sign_k, key->heap);
             }
+            #ifdef WC_ECC_NONBLOCK_ONLY
+            do { /* perform blocking call to non-blocking function */
+                err = sp_ecc_sign_384_nb(&nb_ctx.sp_ctx, in, inlen, rng, 
+                    &key->k, r, s, sign_k, key->heap);
+            } while (err == FP_WOULDBLOCK);
+            return err;
+            #endif
         #endif
         #ifndef WC_ECC_NONBLOCK_ONLY
             return sp_ecc_sign_384(in, inlen, rng, &key->k, r, s, sign_k, 
                 key->heap);
-        #else
-            return NOT_COMPILED_IN;
         #endif
         }
     #endif
@@ -6013,37 +6028,54 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
         && key->asyncDev.marker != WOLFSSL_ASYNC_MARKER_ECC
     #endif
     ) {
+    #ifdef WC_ECC_NONBLOCK_ONLY
+        /* perform blocking call to non-blocking function */
+        ecc_nb_ctx_t nb_ctx;
+        XMEMSET(&nb_ctx, 0, sizeof(nb_ctx));
+    #endif
     #ifndef WOLFSSL_SP_NO_256
         if (ecc_sets[key->idx].id == ECC_SECP256R1) {
-        #ifdef WC_ECC_NONBLOCK
+        #if defined(WC_ECC_NONBLOCK) || defined(WC_ECC_NONBLOCK_ONLY)
             if (key->nb_ctx) {
                 return sp_ecc_verify_256_nb(&key->nb_ctx->sp_ctx, hash, hashlen, 
                     key->pubkey.x, key->pubkey.y, key->pubkey.z, r, s, res, 
                     key->heap);
             }
+            #ifdef WC_ECC_NONBLOCK_ONLY
+            do { /* perform blocking call to non-blocking function */
+                err = sp_ecc_verify_256_nb(&nb_ctx->sp_ctx, hash, hashlen, 
+                    key->pubkey.x, key->pubkey.y, key->pubkey.z, r, s, res, 
+                    key->heap);
+            } while (err == FP_WOULDBLOCK);
+            return err;
+            #endif
         #endif
         #ifndef WC_ECC_NONBLOCK_ONLY
             return sp_ecc_verify_256(hash, hashlen, key->pubkey.x, 
                 key->pubkey.y, key->pubkey.z, r, s, res, key->heap);
-        #else
-            return NOT_COMPILED_IN;
         #endif
         }
     #endif
     #ifdef WOLFSSL_SP_384
         if (ecc_sets[key->idx].id == ECC_SECP384R1) {
-        #ifdef WC_ECC_NONBLOCK
+        #if defined(WC_ECC_NONBLOCK) || defined(WC_ECC_NONBLOCK_ONLY)
             if (key->nb_ctx) {
                 return sp_ecc_verify_384_nb(&key->nb_ctx->sp_ctx, hash, hashlen, 
                     key->pubkey.x,  key->pubkey.y, key->pubkey.z, r, s, res, 
                     key->heap);
             }
+            #ifdef WC_ECC_NONBLOCK_ONLY
+            do { /* perform blocking call to non-blocking function */
+                err = sp_ecc_verify_384_nb(&nb_ctx.sp_ctx, hash, hashlen, 
+                    key->pubkey.x, key->pubkey.y, key->pubkey.z, r, s, res, 
+                    key->heap);
+            } while (err == FP_WOULDBLOCK);
+            return err;
+            #endif
         #endif
         #ifndef WC_ECC_NONBLOCK_ONLY
             return sp_ecc_verify_384(hash, hashlen, key->pubkey.x, 
                 key->pubkey.y, key->pubkey.z, r, s, res, key->heap);
-        #else
-            return NOT_COMPILED_IN;
         #endif
         }
     #endif

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4913,7 +4913,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
     #else
         mp_int* sign_k = NULL;
     #endif
-    #ifdef WC_ECC_NONBLOCK_ONLY
+    #if defined(WC_ECC_NONBLOCK) && defined(WC_ECC_NONBLOCK_ONLY)
         /* perform blocking call to non-blocking function */
         ecc_nb_ctx_t nb_ctx;
         XMEMSET(&nb_ctx, 0, sizeof(nb_ctx));
@@ -6028,7 +6028,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
         && key->asyncDev.marker != WOLFSSL_ASYNC_MARKER_ECC
     #endif
     ) {
-    #ifdef WC_ECC_NONBLOCK_ONLY
+    #if defined(WC_ECC_NONBLOCK) && defined(WC_ECC_NONBLOCK_ONLY)
         /* perform blocking call to non-blocking function */
         ecc_nb_ctx_t nb_ctx;
         XMEMSET(&nb_ctx, 0, sizeof(nb_ctx));

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4920,7 +4920,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
     #endif
     #ifndef WOLFSSL_SP_NO_256
         if (ecc_sets[key->idx].id == ECC_SECP256R1) {
-        #if defined(WC_ECC_NONBLOCK) || defined(WC_ECC_NONBLOCK_ONLY)
+        #ifdef WC_ECC_NONBLOCK
             if (key->nb_ctx) {
                 return sp_ecc_sign_256_nb(&key->nb_ctx->sp_ctx, in, inlen, rng, 
                     &key->k, r, s, sign_k, key->heap);
@@ -4932,8 +4932,8 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
             } while (err == FP_WOULDBLOCK);
             return err;
             #endif
-        #endif
-        #ifndef WC_ECC_NONBLOCK_ONLY
+        #endif /* WC_ECC_NONBLOCK */
+        #if !defined(WC_ECC_NONBLOCK) || (defined(WC_ECC_NONBLOCK) && !defined(WC_ECC_NONBLOCK_ONLY))
             return sp_ecc_sign_256(in, inlen, rng, &key->k, r, s, sign_k, 
                 key->heap);
         #endif
@@ -4941,7 +4941,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
     #endif
     #ifdef WOLFSSL_SP_384
         if (ecc_sets[key->idx].id == ECC_SECP384R1) {
-        #if defined(WC_ECC_NONBLOCK) || defined(WC_ECC_NONBLOCK_ONLY)
+        #ifdef WC_ECC_NONBLOCK
             if (key->nb_ctx) {
                 return sp_ecc_sign_384_nb(&key->nb_ctx->sp_ctx, in, inlen, rng, 
                     &key->k, r, s, sign_k, key->heap);
@@ -4953,8 +4953,8 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
             } while (err == FP_WOULDBLOCK);
             return err;
             #endif
-        #endif
-        #ifndef WC_ECC_NONBLOCK_ONLY
+        #endif /* WC_ECC_NONBLOCK */
+        #if !defined(WC_ECC_NONBLOCK) || (defined(WC_ECC_NONBLOCK) && !defined(WC_ECC_NONBLOCK_ONLY))
             return sp_ecc_sign_384(in, inlen, rng, &key->k, r, s, sign_k, 
                 key->heap);
         #endif
@@ -6035,7 +6035,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     #endif
     #ifndef WOLFSSL_SP_NO_256
         if (ecc_sets[key->idx].id == ECC_SECP256R1) {
-        #if defined(WC_ECC_NONBLOCK) || defined(WC_ECC_NONBLOCK_ONLY)
+        #ifdef WC_ECC_NONBLOCK
             if (key->nb_ctx) {
                 return sp_ecc_verify_256_nb(&key->nb_ctx->sp_ctx, hash, hashlen, 
                     key->pubkey.x, key->pubkey.y, key->pubkey.z, r, s, res, 
@@ -6049,8 +6049,8 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
             } while (err == FP_WOULDBLOCK);
             return err;
             #endif
-        #endif
-        #ifndef WC_ECC_NONBLOCK_ONLY
+        #endif /* WC_ECC_NONBLOCK */
+        #if !defined(WC_ECC_NONBLOCK) || (defined(WC_ECC_NONBLOCK) && !defined(WC_ECC_NONBLOCK_ONLY))
             return sp_ecc_verify_256(hash, hashlen, key->pubkey.x, 
                 key->pubkey.y, key->pubkey.z, r, s, res, key->heap);
         #endif
@@ -6058,7 +6058,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     #endif
     #ifdef WOLFSSL_SP_384
         if (ecc_sets[key->idx].id == ECC_SECP384R1) {
-        #if defined(WC_ECC_NONBLOCK) || defined(WC_ECC_NONBLOCK_ONLY)
+        #ifdef WC_ECC_NONBLOCK
             if (key->nb_ctx) {
                 return sp_ecc_verify_384_nb(&key->nb_ctx->sp_ctx, hash, hashlen, 
                     key->pubkey.x,  key->pubkey.y, key->pubkey.z, r, s, res, 
@@ -6072,8 +6072,8 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
             } while (err == FP_WOULDBLOCK);
             return err;
             #endif
-        #endif
-        #ifndef WC_ECC_NONBLOCK_ONLY
+        #endif /* WC_ECC_NONBLOCK */
+        #if !defined(WC_ECC_NONBLOCK) || (defined(WC_ECC_NONBLOCK) && !defined(WC_ECC_NONBLOCK_ONLY))
             return sp_ecc_verify_384(hash, hashlen, key->pubkey.x, 
                 key->pubkey.y, key->pubkey.z, r, s, res, key->heap);
         #endif


### PR DESCRIPTION
Fix for ECC non-blocking to allow calling without context set and block when `WC_ECC_NONBLOCK_ONLY` is defined. In FIPS mode we need "blocking".