### PR TITLE
Fixes for `mutex_test` and API unit test `derSz`

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -131,7 +131,7 @@
         #endif
     #endif
     #if !defined(DER_SZ)
-        #define DER_SZ (keySz * 2 + 1)
+        #define DER_SZ(ks) (ks * 2 + 1)
     #endif
 #endif
 #ifndef NO_ASN
@@ -20018,9 +20018,9 @@ static int test_wc_ecc_pointFns (void)
     ecc_point*  cpypt = NULL;
     int         idx = 0;
     int         keySz = KEY32;
-    byte        der[DER_SZ];
+    byte        der[DER_SZ(KEY32)];
     word32      derlenChk = 0;
-    word32      derSz = (int)sizeof(der);
+    word32      derSz = DER_SZ(KEY32);
 
     /* Init stack variables. */
     XMEMSET(der, 0, derSz);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -28493,12 +28493,15 @@ int mutex_test(void)
     XFREE(mm, NULL, DYNAMIC_TYPE_MUTEX);
 #endif
 
+    /* Can optionally enable advanced pthread tests using "ENABLE_PTHREAD_LOCKFREE_TESTS" */
 #ifdef WOLFSSL_PTHREADS
     if (wc_InitMutex(&m) != 0)
         return -12701;
     if (wc_LockMutex(&m) != 0)
         return -12702;
-#if !defined(WOLFSSL_SOLARIS)
+#if !defined(WOLFSSL_SOLARIS) && defined(ENABLE_PTHREAD_LOCKFREE_TESTS)
+    /* trying to free a locked mutex is not portable behavior with pthread */
+    /* Attempting to destroy a locked mutex results in undefined behavior */
     if (wc_FreeMutex(&m) != BAD_MUTEX_E)
         return -12703;
 #endif
@@ -28506,7 +28509,8 @@ int mutex_test(void)
         return -12704;
     if (wc_FreeMutex(&m) != 0)
         return -12705;
-#if !defined(WOLFSSL_NO_MUTEXLOCK_AFTER_FREE)
+#if !defined(WOLFSSL_SOLARIS) && defined(ENABLE_PTHREAD_LOCKFREE_TESTS)
+    /* Trying to use a pthread after free'ing is not portable behavior */
     if (wc_LockMutex(&m) != BAD_MUTEX_E)
         return -12706;
     if (wc_UnLockMutex(&m) != BAD_MUTEX_E)

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1450,7 +1450,6 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 #ifdef WOLFSSL_SOLARIS
-    #define WOLFSSL_NO_MUTEXLOCK_AFTER_FREE
     /* Avoid naming clash with fp_zero from math.h > ieefp.h */
     #define WOLFSSL_DH_CONST
 #endif


### PR DESCRIPTION
* Improve the `mutex_test` test with pthreads. Fixes #3109
* Fix for `derSz` calculation on non-const value `keySz`. ZD 10654