### PR TITLE
Fix CheckAltNames to handle IP type

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -9526,20 +9526,16 @@ err:
 
 #ifdef OPENSSL_EXTRA
 #ifndef NO_CERTS
-int wolfSSL_X509_add_altname(WOLFSSL_X509* x509, const char* name, int type)
+int wolfSSL_X509_add_altname_ex(WOLFSSL_X509* x509, const char* name,
+        word32 nameSz, int type)
 {
     DNS_entry* newAltName = NULL;
     char* nameCopy = NULL;
-    word32 nameSz;
 
     if (x509 == NULL)
         return WOLFSSL_FAILURE;
 
-    if (name == NULL)
-        return WOLFSSL_SUCCESS;
-
-    nameSz = (word32)XSTRLEN(name);
-    if (nameSz == 0)
+    if ((name == NULL) || (nameSz == 0))
         return WOLFSSL_SUCCESS;
 
     newAltName = (DNS_entry*)XMALLOC(sizeof(DNS_entry),
@@ -9553,7 +9549,9 @@ int wolfSSL_X509_add_altname(WOLFSSL_X509* x509, const char* name, int type)
         return WOLFSSL_FAILURE;
     }
 
-    XMEMCPY(nameCopy, name, nameSz + 1);
+    XMEMCPY(nameCopy, name, nameSz);
+
+    nameCopy[nameSz] = '\0';
 
     newAltName->next = x509->altNames;
     newAltName->type = type;
@@ -9562,6 +9560,25 @@ int wolfSSL_X509_add_altname(WOLFSSL_X509* x509, const char* name, int type)
     x509->altNames = newAltName;
 
     return WOLFSSL_SUCCESS;
+}
+
+int wolfSSL_X509_add_altname(WOLFSSL_X509* x509, const char* name, int type)
+{
+    word32 nameSz;
+
+    if (name == NULL)
+        return WOLFSSL_SUCCESS;
+
+    nameSz = (word32)XSTRLEN(name);
+    if (nameSz == 0)
+        return WOLFSSL_SUCCESS;
+
+    if (type == ASN_IP_TYPE) {
+        WOLFSSL_MSG("Type not supported, use wolfSSL_X509_add_altname_ex");
+        return WOLFSSL_FAILURE;
+    }
+
+    return wolfSSL_X509_add_altname_ex(x509, name, nameSz, type);
 }
 
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -26832,7 +26832,7 @@ static void test_wolfSSL_X509_sign(void)
 #ifdef WOLFSSL_ALT_NAMES
     /* Add some subject alt names */
     AssertIntNE(wolfSSL_X509_add_altname(NULL,
-                NULL, ASN_DNS_TYPE), SSL_SUCCESS);
+                "ipsum", ASN_DNS_TYPE), SSL_SUCCESS);
     AssertIntEQ(wolfSSL_X509_add_altname(x509,
                 NULL, ASN_DNS_TYPE), SSL_SUCCESS);
     AssertIntEQ(wolfSSL_X509_add_altname(x509,
@@ -26844,13 +26844,25 @@ static void test_wolfSSL_X509_sign(void)
     AssertIntEQ(wolfSSL_X509_add_altname(x509,
                 "Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch",
                 ASN_DNS_TYPE), SSL_SUCCESS);
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+    {
+        unsigned char ip_type[] = {127,0,0,1};
+        AssertIntEQ(wolfSSL_X509_add_altname_ex(x509, (char*)ip_type,
+                sizeof(ip_type), ASN_IP_TYPE), SSL_SUCCESS);
+    }
+#endif
 #endif /* WOLFSSL_ALT_NAMES */
+
     /* Test invalid parameters */
     AssertIntEQ(X509_sign(NULL, priv, EVP_sha256()), 0);
     AssertIntEQ(X509_sign(x509, NULL, EVP_sha256()), 0);
     AssertIntEQ(X509_sign(x509, priv, NULL), 0);
 
     ret = X509_sign(x509, priv, EVP_sha256());
+
+#if defined(WOLFSSL_ALT_NAMES) && (defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME))
+    AssertIntEQ(wolfSSL_X509_check_ip_asc(x509, "127.0.0.1", 0), 1);
+#endif
 
 #if 0
     /* example for writing to file */
@@ -26881,8 +26893,13 @@ static void test_wolfSSL_X509_sign(void)
     /* Valid case - size should be 798 with 16 byte serial number */
     AssertIntEQ(ret, 782 + snSz);
 #else /* WOLFSSL_ALT_NAMES */
+    #if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+    /* Valid case - size should be 936 with 16 byte serial number */
+    AssertIntEQ(ret, 920 + snSz);
+    #else
     /* Valid case - size should be 927 with 16 byte serial number */
     AssertIntEQ(ret, 911 + snSz);
+    #endif
 #endif /* WOLFSSL_ALT_NAMES */
 
     X509_NAME_free(name);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1694,7 +1694,7 @@ WOLFSSL_LOCAL void FreeSuites(WOLFSSL* ssl);
 WOLFSSL_LOCAL int  ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx, word32 size);
 WOLFSSL_LOCAL int  MatchDomainName(const char* pattern, int len, const char* str);
 #ifndef NO_CERTS
-WOLFSSL_LOCAL int  CheckAltNames(DecodedCert* dCert, char* domain);
+WOLFSSL_LOCAL int  CheckForAltNames(DecodedCert* dCert, const char* domain, int* checkCN);
 WOLFSSL_LOCAL int  CheckIPAddr(DecodedCert* dCert, const char* ipasc);
 #endif
 WOLFSSL_LOCAL int  CreateTicket(WOLFSSL* ssl);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2149,6 +2149,7 @@ WOLFSSL_API int wolfSSL_X509_version(WOLFSSL_X509*);
 WOLFSSL_API int wolfSSL_cmp_peer_cert_to_file(WOLFSSL*, const char*);
 
 WOLFSSL_ABI WOLFSSL_API char* wolfSSL_X509_get_next_altname(WOLFSSL_X509*);
+WOLFSSL_API int wolfSSL_X509_add_altname_ex(WOLFSSL_X509*, const char*, word32, int);
 WOLFSSL_API int wolfSSL_X509_add_altname(WOLFSSL_X509*, const char*, int);
 
 WOLFSSL_API WOLFSSL_X509* wolfSSL_d2i_X509(WOLFSSL_X509** x509,


### PR DESCRIPTION
An IP address octet (`ASN_IP_TYPE`) can be parsed into the subject alternative name field of the decoded cert structure. However, when checking against a string domain name IP address, the check fails because the octet value is not a string. This feature is enabled using the `--enable-ip-alt-name` config option.

This addresses an issue from ZD10655