### PR TITLE
DTLS Test Speed Fix Redux

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -65,7 +65,7 @@
 #define OCSP_STAPLINGV2_MULTI 3
 #define OCSP_STAPLING_OPT_MAX OCSP_STAPLINGV2_MULTI
 
-#if defined(XUSLEEP) && defined(NO_MAIN_DRIVER)
+#if defined(XSLEEP_US) && defined(NO_MAIN_DRIVER)
     /* This is to force the server's thread to get a chance to
      * execute before continuing the resume in non-blocking
      * DTLS test cases. */

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -156,6 +156,7 @@
         select(0, NULL, NULL, NULL, &tv); \
     } while (0)
     #define XSLEEP_US(u) XSELECT_WAIT(0,u)
+    #define XSLEEP_MS(m) XSELECT_WAIT(0,(m)*1000)
 #endif /* USE_WINDOWS_API */
 
 #ifndef XSLEEP_MS


### PR DESCRIPTION
1. Fix the check for XSLEEP_US in the client.
2. Added XSLEEP_MS to mirror XSLEEP_US, in terms of XSELECT().

Configured with DTLS only. Timed the unit test. Took 4 minutes before the fix. With the fix the unit test takes 22 seconds.