### PR TITLE
TLSv1.3 for Windows

### DIFF
--- a/IDE/WIN/wolfssl-fips.vcxproj
+++ b/IDE/WIN/wolfssl-fips.vcxproj
@@ -306,6 +306,7 @@
     <ClCompile Include="..\..\wolfcrypt\src\signature.c" />
     <ClCompile Include="..\..\src\ssl.c" />
     <ClCompile Include="..\..\src\tls.c" />
+    <ClCompile Include="..\..\src\tls13.c" />
     <ClCompile Include="..\..\wolfcrypt\src\wc_encrypt.c" />
     <ClCompile Include="..\..\wolfcrypt\src\wolfmath.c" />
     <ClCompile Include="..\..\wolfcrypt\src\wolfevent.c" />

--- a/IDE/WIN10/wolfssl-fips.vcxproj
+++ b/IDE/WIN10/wolfssl-fips.vcxproj
@@ -276,6 +276,7 @@
     <ClCompile Include="..\..\wolfcrypt\src\signature.c" />
     <ClCompile Include="..\..\src\ssl.c" />
     <ClCompile Include="..\..\src\tls.c" />
+    <ClCompile Include="..\..\src\tls13.c" />
     <ClCompile Include="..\..\wolfcrypt\src\wc_encrypt.c" />
     <ClCompile Include="..\..\wolfcrypt\src\wolfcrypt_first.c" />
     <ClCompile Include="..\..\wolfcrypt\src\wolfcrypt_last.c" />


### PR DESCRIPTION
Add tls13.c to the VS projects for the two different Windows builds.