### PR TITLE
Fix to NOT enable SSLV3 and TLS v1.0 with `--enable-all`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1884,7 +1884,7 @@ AC_ARG_ENABLE([sslv3],
     [ ENABLED_SSLV3=no]
     )
 
-if test "x$ENABLED_HAPROXY" = "xyes"
+if test "x$ENABLED_HAPROXY" = "xyes" && test "x$ENABLED_ALL" = "xno"
 then
     ENABLED_SSLV3="yes"
 fi
@@ -1981,9 +1981,13 @@ then
         ENABLED_OPENSSLEXTRA="yes"
         AM_CFLAGS="$AM_CFLAGS -DOPENSSL_EXTRA -DOPENSSL_ALL -DHAVE_EX_DATA"
     fi
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_QT -DWOLFSSL_ALLOW_TLSV10 -DSESSION_CERTS -DOPENSSL_NO_SSL2"
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALLOW_SSLV3 -DWOLFSSL_KEY_GEN -DHAVE_EX_DATA"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_QT -DSESSION_CERTS -DOPENSSL_NO_SSL2"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_KEY_GEN -DHAVE_EX_DATA"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_CUSTOM_CURVES -DHAVE_ECC_SECPR2 -DHAVE_ECC_SECPR3 -DHAVE_ECC_BRAINPOOL -DHAVE_ECC_KOBLITZ"
+    if test "x$ENABLED_ALL" = "xno"; then
+        # Don't enable old SSL/TLS for --enable-all, which is used by distro
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ALLOW_SSLV3 -DWOLFSSL_ALLOW_TLSV10"
+    fi
 
     # Requires OCSP make sure on
     if test "x$ENABLED_OCSP" = "xno"
@@ -5544,9 +5548,10 @@ echo "   * DTLS:                       $ENABLED_DTLS"
 echo "   * SCTP:                       $ENABLED_SCTP"
 echo "   * Indefinite Length:          $ENABLED_BER_INDEF"
 echo "   * Multicast:                  $ENABLED_MCAST"
-echo "   * Old TLS Versions:           $ENABLED_OLD_TLS"
-echo "   * SSL version 3.0:            $ENABLED_SSLV3"
-echo "   * TLS v1.0:                   $ENABLED_TLSV10"
+echo "   * SSL v3.0 (Old):             $ENABLED_SSLV3"
+echo "   * TLS v1.0 (Old):             $ENABLED_TLSV10"
+echo "   * TLS v1.1 (Old):             $ENABLED_OLD_TLS"
+echo "   * TLS v1.2:                   $ENABLED_TLSV12"
 echo "   * TLS v1.3:                   $ENABLED_TLS13"
 echo "   * Post-handshake Auth:        $ENABLED_TLS13_POST_AUTH"
 echo "   * Early Data:                 $ENABLED_TLS13_EARLY_DATA"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11412,7 +11412,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     }
     #endif
 
-    #ifdef WOLFSSL_ALLOW_SSLV3
+    #if defined(WOLFSSL_ALLOW_SSLV3) && !defined(NO_OLD_TLS)
     WOLFSSL_METHOD* wolfSSLv3_client_method(void)
     {
         return wolfSSLv3_client_method_ex(NULL);
@@ -11428,7 +11428,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
             InitSSL_Method(method, MakeSSLv3());
         return method;
     }
-    #endif /* WOLFSSL_ALLOW_SSLV3 */
+    #endif /* WOLFSSL_ALLOW_SSLV3 && !NO_OLD_TLS */
 
 
     WOLFSSL_METHOD* wolfSSLv23_client_method(void)
@@ -11804,7 +11804,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     }
     #endif
 
-    #ifdef WOLFSSL_ALLOW_SSLV3
+    #if defined(WOLFSSL_ALLOW_SSLV3) && !defined(NO_OLD_TLS)
     WOLFSSL_METHOD* wolfSSLv3_server_method(void)
     {
         return wolfSSLv3_server_method_ex(NULL);
@@ -11822,7 +11822,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         }
         return method;
     }
-    #endif /* WOLFSSL_ALLOW_SSLV3 */
+    #endif /* WOLFSSL_ALLOW_SSLV3 && !NO_OLD_TLS */
 
     WOLFSSL_METHOD* wolfSSLv23_server_method(void)
     {


### PR DESCRIPTION
* Fix for `--enable-all` (also used by `--enable-distro`) to NOT enable SSLV3 and TLS v1.0.
* Fix for missing `MakeSSLv3` when building `WOLFSSL_ALLOW_SSLV3` only.

I do not think it was the intension to ever have these on by default for `--enable-all` and `--enable-distro`. The QT and HAPROXY enables are set in `[all]`.