### PR TITLE
Fixes for different configurations

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -893,7 +893,7 @@ int GetInt(mp_int* mpi, const byte* input, word32* inOutIdx, word32 maxIdx)
 
 #if (!defined(WOLFSSL_KEY_GEN) && !defined(OPENSSL_EXTRA) && defined(RSA_LOW_MEM)) \
     || defined(WOLFSSL_RSA_PUBLIC_ONLY) || (!defined(NO_DSA))
-#if !defined(NO_RSA) && !defined(HAVE_USER_RSA)
+#if (!defined(NO_RSA) && !defined(HAVE_USER_RSA)) || !defined(NO_DSA)
 static int SkipInt(const byte* input, word32* inOutIdx, word32 maxIdx)
 {
     word32 idx = *inOutIdx;
@@ -1368,12 +1368,7 @@ end:
 }
 #endif
 
-#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN)
-
-#if (!defined(NO_RSA) && !defined(HAVE_USER_RSA)) || \
-    defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
-
-#ifdef WOLFSSL_CERT_EXT
+#if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_CERT_GEN)
 /* Set the DER/BER encoding of the ASN.1 BIT_STRING with a 16-bit value.
  *
  * val         16-bit value to encode.
@@ -1406,11 +1401,7 @@ static word32 SetBitString16Bit(word16 val, byte* output)
 
     return idx;
 }
-#endif /* WOLFSSL_CERT_EXT */
-#endif /* !NO_RSA || HAVE_ECC || HAVE_ED25519 || defined(HAVE_ED448) */
-#endif /* WOLFSSL_CERT_GEN || WOLFSSL_KEY_GEN */
-
-
+#endif /* WOLFSSL_CERT_EXT || WOLFSSL_CERT_GEN */
 
 /* hashType */
 #ifdef WOLFSSL_MD2
@@ -5150,7 +5141,7 @@ static int GetKey(DecodedCert* cert)
 #ifndef NO_DSA
     int tmpLen;
 #endif
-#if defined(HAVE_ECC) || defined(HAVE_NTRU)
+#if defined(HAVE_ECC) || defined(HAVE_NTRU) || !defined(NO_DSA)
     int tmpIdx = cert->srcIdx;
 #endif
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11783,6 +11783,8 @@ done:
 #endif
 
 #if defined(WC_RSA_PSS) && !defined(HAVE_FIPS_VERSION) /* not supported with FIPSv1 */
+/* Need to create known good signatures to test with this. */
+#ifndef WOLFSSL_RSA_VERIFY_ONLY
 static int rsa_pss_test(WC_RNG* rng, RsaKey* key)
 {
     byte             digest[WC_MAX_DIGEST_SIZE];
@@ -12090,6 +12092,7 @@ exit_rsa_pss:
 
     return ret;
 }
+#endif /* WOLFSSL_RSA_VERIFY_ONLY */
 #endif
 
 #ifdef WC_RSA_NO_PADDING
@@ -13919,7 +13922,10 @@ int rsa_test(void)
 #endif /* WOLFSSL_CERT_GEN */
 
 #if defined(WC_RSA_PSS) && !defined(HAVE_FIPS_VERSION) /* not supported with FIPSv1 */
+/* Need to create known good signatures to test with this. */
+#ifndef WOLFSSL_RSA_VERIFY_ONLY
     ret = rsa_pss_test(&rng, &key);
+#endif
 #endif
 
 exit_rsa:

--- a/wolfssl/openssl/asn1.h
+++ b/wolfssl/openssl/asn1.h
@@ -107,7 +107,7 @@ typedef enum {
 } WOLFSSL_ASN1_TYPES;
 
 #define ASN1_SEQUENCE(type) \
-    static const type __##type##_dummy_struct;\
+    static type __##type##_dummy_struct;\
     static const WOLFSSL_ASN1_TEMPLATE type##_member_data[]
 
 #define ASN1_SIMPLE(type, member, member_type) \


### PR DESCRIPTION
Fix SkipInt() to work with DSA.
Fix protection around SetBitString16Bit() - when WOLFSSL_CERT_GEN and
WOLFSSL_CERT_EXT defined is only use.
WOLFSSL_RSA_VERIFY_ONLY and PSS means testing of PSS won't work.
Fix g++ build around ASN1_SEQUENCE - const variable required to be
initialized.