### PR TITLE
Fix unit.test to not fail randomly

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -36911,6 +36911,11 @@ static int CopyX509NameToCertName(WOLFSSL_X509_NAME* n, CertName* cName)
             return ret;
         }
 
+        if ((x509->serialSz == 0) && (cert.serialSz <= EXTERNAL_SERIAL_SIZE)) {
+            XMEMCPY(x509->serial, cert.serial, cert.serialSz);
+            x509->serialSz = cert.serialSz;
+        }
+
         /* Dispose of the public key object. */
     #ifndef NO_RSA
         if (x509->pubKeyOID == RSAk)

--- a/tests/api.c
+++ b/tests/api.c
@@ -26787,6 +26787,8 @@ static void test_wolfSSL_X509_sign(void)
     long clientKeySz = (long)sizeof_client_key_der_2048;
     long clientPubKeySz = (long)sizeof_client_keypub_der_2048;
 #endif
+    byte sn[16];
+    int snSz = sizeof(sn);
 
     printf(testingFmt, "wolfSSL_X509_sign\n");
 
@@ -26855,12 +26857,14 @@ static void test_wolfSSL_X509_sign(void)
     AssertIntEQ(X509_get_ext_count(x509), SSL_FAILURE);
 #endif
 
+    AssertIntEQ(wolfSSL_X509_get_serial_number(x509, sn, &snSz),
+                WOLFSSL_SUCCESS);
 #ifndef WOLFSSL_ALT_NAMES
-    /* Valid case - size should be 798 */
-    AssertIntEQ(ret, 798);
+    /* Valid case - size should be 798 with 16 byte serial number */
+    AssertIntEQ(ret, 782 + snSz);
 #else /* WOLFSSL_ALT_NAMES */
-    /* Valid case - size should be 927 */
-    AssertIntEQ(ret, 927);
+    /* Valid case - size should be 927 with 16 byte serial number */
+    AssertIntEQ(ret, 911 + snSz);
 #endif /* WOLFSSL_ALT_NAMES */
 
     X509_NAME_free(name);


### PR DESCRIPTION
Set the serial number in certificate to fix the encoding size.