### PR TITLE
Add fips-check.sh target for marvell-linux-selftest, selftest v2 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2531,13 +2531,29 @@ AS_IF([test "x$ENABLED_FIPS" = "xyes" && test "x$FIPS_VERSION" != "xrand"],
 AC_ARG_ENABLE([selftest],
     [AS_HELP_STRING([--enable-selftest],[Enable selftest, Will NOT work w/o CAVP selftest license (default: disabled)])],
     [ ENABLED_SELFTEST=$enableval ],
-    [ ENABLED_SELFTEST=no ]
+    [ ENABLED_SELFTEST="no" ]
     )
 
-if test "x$ENABLED_SELFTEST" = "xyes"
-then
-    AM_CFLAGS="$AM_CFLAGS -DHAVE_SELFTEST"
-fi
+AS_CASE([$ENABLED_SELFTEST],
+    ["v2"],[
+        # selftest v2 (wolfCrypt 4.1.0)
+        ENABLED_SELFTEST="yes"
+        SELFTEST_VERSION="v2"
+    ],
+    ["no"],[SELFTEST_VERSION="none"],
+    [
+        # selftest v1 (wolfCrypt 3.14.2)
+        ENABLED_SELFTEST="yes"
+        SELFTEST_VERSION="v1"
+    ])
+
+AS_CASE([$SELFTEST_VERSION],
+    ["v2"],[
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_SELFTEST -DHAVE_SELFTEST_VERSION=2"
+    ],
+    ["v1"],[
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_SELFTEST"
+    ])
 
 
 # set sha224 default

--- a/fips-check.sh
+++ b/fips-check.sh
@@ -28,6 +28,7 @@ Platform is one of:
     openrtos-3.9.2
     linux-ecc
     netbsd-selftest
+    marvell-linux-selftest
     sgx
     netos-7.6
     linuxv2 (FIPSv2, use for Win10)
@@ -99,6 +100,13 @@ NETBSD_FIPS_VERSION=v3.14.2b
 NETBSD_FIPS_REPO=git@github.com:wolfssl/fips.git
 NETBSD_CRYPT_VERSION=v3.14.2
 NETBSD_CRYPT_REPO=git@github.com:wolfssl/wolfssl.git
+
+# non-FIPS, CAVP only but pull in selftest
+# will reset above variables below in platform switch
+MARVELL_LINUX_FIPS_VERSION=v3.14.2b
+MARVELL_LINUX_FIPS_REPO=git@github.com:wolfssl/fips.git
+MARVELL_LINUX_CRYPT_VERSION=v4.1.0-stable
+MARVELL_LINUX_CRYPT_REPO=git@github.com:wolfssl/wolfssl.git
 
 STM32L4_V2_FIPS_VERSION=WCv4.0.1-stable
 STM32L4_V2_FIPS_REPO=git@github.com:wolfSSL/fips.git
@@ -184,6 +192,18 @@ netbsd-selftest)
   CRYPT_INC_PATH=wolfssl/wolfcrypt
   CRYPT_SRC_PATH=wolfcrypt/src
   CAVP_SELFTEST_ONLY="yes"
+  ;;
+marvell-linux-selftest)
+  FIPS_VERSION=$MARVELL_LINUX_FIPS_VERSION
+  FIPS_REPO=$MARVELL_LINUX_FIPS_REPO
+  CRYPT_VERSION=$MARVELL_LINUX_CRYPT_VERSION
+  CRYPT_REPO=$MARVELL_LINUX_CRYPT_REPO
+  FIPS_SRCS=( selftest.c )
+  WC_MODS=( dh ecc rsa dsa aes sha sha256 sha512 hmac random )
+  CRYPT_INC_PATH=wolfssl/wolfcrypt
+  CRYPT_SRC_PATH=wolfcrypt/src
+  CAVP_SELFTEST_ONLY="yes"
+  CAVP_SELFTEST_OPTION=v2
   ;;
 sgx)
   FIPS_VERSION=$SGX_FIPS_VERSION
@@ -333,7 +353,12 @@ done
 ./autogen.sh
 if [ "x$CAVP_SELFTEST_ONLY" == "xyes" ];
 then
-    ./configure --enable-selftest
+    if [ "x$CAVP_SELFTEST_OPTION" == "xv2" ]
+    then
+        ./configure --enable-selftest=v2
+    else
+        ./configure --enable-selftest
+    fi
 else
     ./configure --enable-fips=$FIPS_OPTION
 fi

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -128,9 +128,10 @@ extern int wc_InitRsaHw(RsaKey* key);
 
 #define ERROR_OUT(err, eLabel) { ret = (err); goto eLabel; }
 
-#if defined(HAVE_SELFTEST) || ( !defined(NO_SKID) && \
-                                ( !defined(HAVE_FIPS) || \
-                                  !defined(HAVE_FIPS_VERSION) ))
+#if !defined(NO_SKID) && (!defined(HAVE_FIPS) || !defined(HAVE_FIPS_VERSION))
+    #if !defined(HAVE_SELFTEST) || (defined(HAVE_SELFTEST) && \
+                                   (!defined(HAVE_SELFTEST_VERSION) || \
+                                    HAVE_SELFTEST_VERSION < 2))
     #ifndef WOLFSSL_AES_KEY_SIZE_ENUM
     #define WOLFSSL_AES_KEY_SIZE_ENUM
     enum Asn_Misc {
@@ -140,6 +141,7 @@ extern int wc_InitRsaHw(RsaKey* key);
         AES_256_KEY_SIZE    = 32
     };
     #endif
+    #endif /* HAVE_SELFTEST */
 #endif
 #ifdef WOLFSSL_RENESAS_TSIP_TLS
 void tsip_inform_key_position(const word32 key_n_start,

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11876,7 +11876,8 @@ static int rsa_pss_test(WC_RNG* rng, RsaKey* key)
             plainSz = ret;
             TEST_SLEEP();
 
-#ifdef HAVE_SELFTEST
+#if defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_SELFTEST_VERSION) || (HAVE_SELFTEST_VERSION < 2))
             ret = wc_RsaPSS_CheckPadding_ex(digest, digestSz, plain, plainSz,
                                          hash[j], -1);
 #else
@@ -11951,7 +11952,8 @@ static int rsa_pss_test(WC_RNG* rng, RsaKey* key)
             WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
         if (ret >= 0) {
-#ifdef HAVE_SELFTEST
+#if defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_SELFTEST_VERSION) || (HAVE_SELFTEST_VERSION < 2))
             ret = wc_RsaPSS_CheckPadding_ex(digest, digestSz, sig, plainSz,
                 hash[0], 0);
 #else
@@ -11980,7 +11982,8 @@ static int rsa_pss_test(WC_RNG* rng, RsaKey* key)
     plainSz = ret;
     TEST_SLEEP();
 
-#ifdef HAVE_SELFTEST
+#if defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_SELFTEST_VERSION) || (HAVE_SELFTEST_VERSION < 2))
     ret = wc_RsaPSS_CheckPadding_ex(digest, digestSz, plain, plainSz, hash[0],
                                     0);
 #else
@@ -12058,7 +12061,8 @@ static int rsa_pss_test(WC_RNG* rng, RsaKey* key)
 #else
     len = -3;
 #endif
-#ifdef HAVE_SELFTEST
+#if defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_SELFTEST_VERSION) || (HAVE_SELFTEST_VERSION < 2))
     ret = wc_RsaPSS_CheckPadding_ex(digest, digestSz, plain, plainSz, hash[0],
                                     len);
 #else
@@ -12072,7 +12076,8 @@ static int rsa_pss_test(WC_RNG* rng, RsaKey* key)
 #else
     len = plainSz - digestSz - 1;
 #endif
-#ifdef HAVE_SELFTEST
+#if defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_SELFTEST_VERSION) || (HAVE_SELFTEST_VERSION < 2))
     ret = wc_RsaPSS_CheckPadding_ex(digest, digestSz, plain, plainSz, hash[0],
                                     len);
 #else

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1358,7 +1358,8 @@ enum Misc {
     #endif
 #endif
 
-#ifdef HAVE_SELFTEST
+#if defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_SELFTEST_VERSION) || (HAVE_SELFTEST_VERSION < 2))
     #ifndef WOLFSSL_AES_KEY_SIZE_ENUM
     #define WOLFSSL_AES_KEY_SIZE_ENUM
     AES_IV_SIZE         = 16,

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -154,8 +154,9 @@ enum Pkcs7_Misc {
                             MAX_SEQ_SZ + ASN_NAME_MAX + MAX_SN_SZ +
                             MAX_SEQ_SZ + MAX_ALGO_SZ + 1 + MAX_ENCRYPTED_KEY_SZ,
 #if (defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
-     (HAVE_FIPS_VERSION >= 2)) || defined(HAVE_SELFTEST)
-    /* In the event of fips cert 3389 or CAVP selftest build, these enums are
+     (HAVE_FIPS_VERSION >= 2)) || (defined(HAVE_SELFTEST) && \
+     (!defined(HAVE_SELFTEST_VERSION) || HAVE_SELFTEST_VERSION < 2))
+    /* In the event of fips cert 3389 or CAVP selftest v1 build, these enums are
      * not in aes.h for use with pkcs7 so enumerate it here outside the fips
      * boundary */
     GCM_NONCE_MID_SZ = 12, /* The usual default nonce size for AES-GCM. */

--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -58,7 +58,8 @@ enum {
     WC_SHA3_512_DIGEST_SIZE  = 64,
     WC_SHA3_512_COUNT        =  9,
 
-#ifndef HAVE_SELFTEST
+#if !defined(HAVE_SELFTEST) || \
+    defined(HAVE_SELFTEST_VERSION) && (HAVE_SELFTEST_VERSION >= 2)
     /* These values are used for HMAC, not SHA-3 directly.
      * They come from from FIPS PUB 202. */
     WC_SHA3_224_BLOCK_SIZE = 144,


### PR DESCRIPTION
This PR adds a fips-check.sh target for "marvell-linux-selftest" to match our recent CAVP-only validation.  Along with this validation, this adds "--enable-selftest=v2" support for building selftest code with wolfCrypt 4.1.0 and later.  Note: selftest v1 is for wolfCrypt 3.14.2 which matches our original CAVP-only selftest build.

To test selftest v2:

```
$ ./fips-check.sh marvell-linux-selftest keep
$ cd XXX-fips-test
$ ./configure --enable-selftest=v2
$ make
$ ./wolfcrypt/test/testwolfcrypt
```