### PR TITLE
Update docs/headers for SHA and ECC

### DIFF
--- a/doc/dox_comments/header_files/ecc.h
+++ b/doc/dox_comments/header_files/ecc.h
@@ -411,8 +411,6 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     mp_int r; // destination for r component of signature.
     mp_int s; // destination for s component of signature.
 
-    byte sig[512]; // will hold generated signature
-    sigSz = sizeof(sig);
     byte digest[] = { initialize with message hash };
     wc_InitRng(&rng); // initialize rng
     wc_ecc_init(&key); // initialize key
@@ -472,7 +470,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
     \param hash pointer to the buffer containing the hash of the message
     verified
     \param hashlen length of the hash of the message verified
-    \param stat pointer to the result of the verification. 1 indicates the
+    \param res pointer to the result of the verification. 1 indicates the
     message was successfully verified
     \param key pointer to a public ECC key with which to verify the signature
 
@@ -498,7 +496,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 */
 WOLFSSL_API
 int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
-                    word32 hashlen, int* stat, ecc_key* key);
+                    word32 hashlen, int* res, ecc_key* key);
 
 /*!
     \ingroup ECC
@@ -516,7 +514,7 @@ Note: Do not use the return value to test for valid.  Only use stat.
     \param s The signature S component to verify
     \param hash The hash (message digest) that was signed
     \param hashlen The length of the hash (octets)
-    \param stat Result of signature, 1==valid, 0==invalid
+    \param res Result of signature, 1==valid, 0==invalid
     \param key The corresponding public ECC key
 
     _Example_
@@ -537,7 +535,7 @@ Note: Do not use the return value to test for valid.  Only use stat.
 */
 WOLFSSL_API
 int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
-                          word32 hashlen, int* stat, ecc_key* key);
+                          word32 hashlen, int* res, ecc_key* key);
 
 /*!
     \ingroup ECC

--- a/doc/dox_comments/header_files/hash.h
+++ b/doc/dox_comments/header_files/hash.h
@@ -141,7 +141,7 @@ WOLFSSL_API int wc_Md5Hash(const byte* data, word32 len, byte* hash);
     \sa wc_ShaFinal
     \sa wc_InitSha
 */
-WOLFSSL_API int wc_ShaHash(const byte*, word32, byte*);
+WOLFSSL_API int wc_ShaHash(const byte* data, word32 len, byte* hash);
 
 /*!
     \ingroup SHA
@@ -166,7 +166,7 @@ WOLFSSL_API int wc_ShaHash(const byte*, word32, byte*);
     \sa wc_Sha256Final
     \sa wc_InitSha256
 */
-WOLFSSL_API int wc_Sha256Hash(const byte*, word32, byte*);
+WOLFSSL_API int wc_Sha256Hash(const byte* data, word32 len, byte* hash);
 
 /*!
     \ingroup SHA
@@ -190,7 +190,7 @@ WOLFSSL_API int wc_Sha256Hash(const byte*, word32, byte*);
     \sa wc_Sha224Update
     \sa wc_Sha224Final
 */
-WOLFSSL_API int wc_Sha224Hash(const byte*, word32, byte*);
+WOLFSSL_API int wc_Sha224Hash(const byte* data, word32 len, byte* hash);
 
 /*!
     \ingroup SHA
@@ -215,7 +215,7 @@ WOLFSSL_API int wc_Sha224Hash(const byte*, word32, byte*);
     \sa wc_Sha512Final
     \sa wc_InitSha512
 */
-WOLFSSL_API int wc_Sha512Hash(const byte*, word32, byte*);
+WOLFSSL_API int wc_Sha512Hash(const byte* data, word32 len, byte* hash);
 
 /*!
     \ingroup SHA
@@ -240,4 +240,4 @@ WOLFSSL_API int wc_Sha512Hash(const byte*, word32, byte*);
     \sa wc_Sha384Final
     \sa wc_InitSha384
 */
-WOLFSSL_API int wc_Sha384Hash(const byte*, word32, byte*);
+WOLFSSL_API int wc_Sha384Hash(const byte* data, word32 len, byte* hash);

--- a/doc/dox_comments/header_files/sha256.h
+++ b/doc/dox_comments/header_files/sha256.h
@@ -24,7 +24,7 @@
     \sa wc_Sha256Update
     \sa wc_Sha256Final
 */
-WOLFSSL_API int wc_InitSha256(wc_Sha256*);
+WOLFSSL_API int wc_InitSha256(wc_Sha256* sha256);
 
 /*!
     \ingroup SHA
@@ -57,7 +57,7 @@ WOLFSSL_API int wc_InitSha256(wc_Sha256*);
     \sa wc_Sha256Final
     \sa wc_InitSha256
 */
-WOLFSSL_API int wc_Sha256Update(wc_Sha256*, const byte*, word32);
+WOLFSSL_API int wc_Sha256Update(wc_Sha256* sha256, const byte* data, word32 len);
 
 /*!
     \ingroup SHA
@@ -73,6 +73,7 @@ WOLFSSL_API int wc_Sha256Update(wc_Sha256*, const byte*, word32);
     _Example_
     \code
     Sha256 sha256[1];
+    byte hash[32];
     byte data[] = { Data to be hashed };
     word32 len = sizeof(data);
 
@@ -89,7 +90,7 @@ WOLFSSL_API int wc_Sha256Update(wc_Sha256*, const byte*, word32);
     \sa wc_Sha256GetHash
     \sa wc_InitSha256
 */
-WOLFSSL_API int wc_Sha256Final(wc_Sha256*, byte*);
+WOLFSSL_API int wc_Sha256Final(wc_Sha256* sha256, byte* hash);
 
 /*!
     \ingroup SHA
@@ -104,6 +105,7 @@ WOLFSSL_API int wc_Sha256Final(wc_Sha256*, byte*);
     _Example_
     \code
     Sha256 sha256;
+    byte hash[32];
     byte data[] = { Data to be hashed };
     word32 len = sizeof(data);
 
@@ -121,7 +123,7 @@ WOLFSSL_API int wc_Sha256Final(wc_Sha256*, byte*);
     \sa wc_Sha256Update
     \sa wc_Sha256Final
 */
-WOLFSSL_API void wc_Sha256Free(wc_Sha256*);
+WOLFSSL_API void wc_Sha256Free(wc_Sha256* sha256);
 
 /*!
     \ingroup SHA
@@ -137,6 +139,7 @@ WOLFSSL_API void wc_Sha256Free(wc_Sha256*);
     _Example_
     \code
     Sha256 sha256[1];
+    byte hash[32];
     if ((ret = wc_InitSha356(sha256)) != 0) {
        WOLFSSL_MSG("wc_InitSha256 failed");
     }
@@ -150,7 +153,7 @@ WOLFSSL_API void wc_Sha256Free(wc_Sha256*);
     \sa wc_Sha256Final
     \sa wc_InitSha256
 */
-WOLFSSL_API int wc_Sha256GetHash(wc_Sha256*, byte*);
+WOLFSSL_API int wc_Sha256GetHash(wc_Sha256* sha256, byte* hash);
 
 /*!
     \ingroup SHA
@@ -175,7 +178,7 @@ WOLFSSL_API int wc_Sha256GetHash(wc_Sha256*, byte*);
     \sa wc_Sha224Update
     \sa wc_Sha224Final
 */
-WOLFSSL_API int wc_InitSha224(wc_Sha224*);
+WOLFSSL_API int wc_InitSha224(wc_Sha224* sha224);
 
 /*!
     \ingroup SHA
@@ -194,6 +197,7 @@ WOLFSSL_API int wc_InitSha224(wc_Sha224*);
     _Example_
     \code
     Sha224 sha224;
+    byte hash[28];
     byte data[] = { /* Data to be hashed };
     word32 len = sizeof(data);
 
@@ -210,7 +214,7 @@ WOLFSSL_API int wc_InitSha224(wc_Sha224*);
     \sa wc_Sha224Final
     \sa wc_Sha224Hash
 */
-WOLFSSL_API int wc_Sha224Update(wc_Sha224*, const byte*, word32);
+WOLFSSL_API int wc_Sha224Update(wc_Sha224* sha224, const byte* data, word32 len);
 
 /*!
     \ingroup SHA
@@ -227,6 +231,7 @@ WOLFSSL_API int wc_Sha224Update(wc_Sha224*, const byte*, word32);
     _Example_
     \code
     Sha224 sha224;
+    byte hash[28];
     byte data[] = { /* Data to be hashed };
     word32 len = sizeof(data);
 
@@ -243,4 +248,4 @@ WOLFSSL_API int wc_Sha224Update(wc_Sha224*, const byte*, word32);
     \sa wc_Sha224Hash
     \sa wc_Sha224Update
 */
-WOLFSSL_API int wc_Sha224Final(wc_Sha224*, byte*);
+WOLFSSL_API int wc_Sha224Final(wc_Sha224* sha224, byte* hash);

--- a/doc/dox_comments/header_files/sha256.h
+++ b/doc/dox_comments/header_files/sha256.h
@@ -11,7 +11,7 @@
     _Example_
     \code
     Sha256 sha256[1];
-    if ((ret = wc_InitSha356(sha256)) != 0) {
+    if ((ret = wc_InitSha256(sha256)) != 0) {
         WOLFSSL_MSG("wc_InitSha256 failed");
     }
     else {
@@ -77,7 +77,7 @@ WOLFSSL_API int wc_Sha256Update(wc_Sha256* sha256, const byte* data, word32 len)
     byte data[] = { Data to be hashed };
     word32 len = sizeof(data);
 
-    if ((ret = wc_InitSha356(sha256)) != 0) {
+    if ((ret = wc_InitSha256(sha256)) != 0) {
        WOLFSSL_MSG("wc_InitSha256 failed");
     }
     else {
@@ -140,7 +140,7 @@ WOLFSSL_API void wc_Sha256Free(wc_Sha256* sha256);
     \code
     Sha256 sha256[1];
     byte hash[32];
-    if ((ret = wc_InitSha356(sha256)) != 0) {
+    if ((ret = wc_InitSha256(sha256)) != 0) {
        WOLFSSL_MSG("wc_InitSha256 failed");
     }
     else {

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -518,10 +518,10 @@ int wc_ecc_sign_set_k(const byte* k, word32 klen, ecc_key* key);
 #ifdef HAVE_ECC_VERIFY
 WOLFSSL_API
 int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
-                    word32 hashlen, int* stat, ecc_key* key);
+                    word32 hashlen, int* res, ecc_key* key);
 WOLFSSL_API
 int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
-                          word32 hashlen, int* stat, ecc_key* key);
+                          word32 hashlen, int* res, ecc_key* key);
 #endif /* HAVE_ECC_VERIFY */
 
 WOLFSSL_API


### PR DESCRIPTION
ECC:
* remove unused variables in the example
* make consistent argument name - use name from implementation in header as well as docs 

SHA:
* add initialization of variable into examples
* add arguments' names in doc functions' definitions