### PR TITLE
Enable HAVE_EX_DATA for libwebsockets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,7 +120,7 @@ AS_CASE([$ENABLED_FIPS],
         ENABLED_FIPS="yes"
         FIPS_VERSION="v1"
     ])
-    
+
 
 # Distro build feature subset (Debian, Ubuntu, etc.)
 AC_ARG_ENABLE([distro],
@@ -491,7 +491,7 @@ AC_ARG_ENABLE([libwebsockets],
     )
 if test "$ENABLED_LIBWEBSOCKETS" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LIBWEBSOCKETS -DOPENSSL_NO_EC"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LIBWEBSOCKETS -DHAVE_EX_DATA -DOPENSSL_NO_EC"
 fi
 
 
@@ -4190,7 +4190,7 @@ AC_ARG_WITH([octeon-sync],
         AM_CFLAGS="$AM_CFLAGS -I$OCTEON_ROOT/executive"
         AS_CASE([$OCTEON_HOST],['linux'],[AM_CFLAGS="$AM_CFLAGS -DCVMX_BUILD_FOR_LINUX_HOST"])
 
-        #-I$OCTEON_ROOT/target/include 
+        #-I$OCTEON_ROOT/target/include
         AM_LDFLAGS="$AM_LDFLAGS -lrt -Xlinker -T -Xlinker $OCTEON_ROOT/executive/cvmx-shared-linux.ld"
         AM_LDFLAGS="$AM_LDFLAGS -L$OCTEON_ROOT/executive/$OCTEON_OBJ -lcvmx -lfdt"
 


### PR DESCRIPTION
This PR fixes libwebsockets build.

I think the build was broken due to 
https://github.com/wolfSSL/wolfssl/pull/2959/files#diff-a25959c07e4b4538d7045da811e2c5b9L39182

Additionally,  libwebsockets has refactored the top-level CMakeLists.txt file in the project root and updated each sub dir to include a cmake files. It appears that the cmake build options are not being propagated into libwebsockets/lib/tls/CMakeLists.txt.  I'm currently looking into it. 


