### PR TITLE
Fix for OCSP response in non-blocking mode and testing script improvements

### DIFF
--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # ocsp-stapling.test
-
+# Test requires HAVE_OCSP and HAVE_CERTIFICATE_STATUS_REQUEST
 
 ./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
 if [ $? -eq 0 ]; then
@@ -178,7 +178,8 @@ fi
 # test interop fail case
 ready_file=`pwd`/wolf_ocsp_readyF$$
 printf '%s\n' "ready file:  $ready_file"
-./examples/server/server -o -R $ready_file &
+# use random port and bind to any (allows use with IPv6)
+./examples/server/server -b -p $resume_port -o -R $ready_file &
 wolf_pid=$!
 wait_for_readyFile $ready_file
 if [ ! -f $ready_file ]; then
@@ -203,7 +204,7 @@ fi
 
 
 # create a port 0 port to use with openssl ocsp responder
-./examples/server/server -R $ready_file -p $resume_port &
+./examples/server/server -b -p $resume_port -R $ready_file &
 wait_for_readyFile $ready_file
 if [ ! -f $ready_file ]; then
     printf '%s\n' "Failed to create ready file: \"$ready_file\""
@@ -215,7 +216,7 @@ else
     ./examples/client/client -p $RPORTSELECTED
     create_new_cnf $RPORTSELECTED
 fi
-sleep 1
+sleep 0.1
 
 # is our desired server there? - login.live.com doesn't answers PING
 #./scripts/ping.test $server 2
@@ -248,7 +249,7 @@ openssl ocsp -port $RPORTSELECTED -nmin 1                       \
     -CA      certs/ocsp/intermediate1-ca-cert.pem               \
     "$@" &
 
-sleep 1
+sleep 0.1
 # "jobs" is not portable for posix. Must use bash interpreter!
 [ $(jobs -r | wc -l) -ne 1 ] && \
              printf '\n\n%s\n' "Setup ocsp responder failed, skipping" && exit 0
@@ -270,7 +271,7 @@ remove_single_rF $ready_file2
 ./examples/server/server -c certs/ocsp/server2-cert.pem -R $ready_file2 \
                          -k certs/ocsp/server2-key.pem -p $resume_port &
 wait_for_readyFile $ready_file2
-sleep 1
+sleep 0.1
 CLI_PORT=`cat $ready_file2`
 ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p $CLI_PORT
 RESULT=$?
@@ -311,5 +312,7 @@ if [ $? -ne 0 ]; then
                       && exit 1
     printf '%s\n\n' "Test successfully REVOKED!"
 fi
+
+printf '%s\n\n' "------------------- TESTS COMPLETE ---------------------------"
 
 exit 0

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -1,6 +1,7 @@
 #!/bin/bash
-# ocsp-stapling.test
 
+# ocsp-stapling2.test
+# Test requires HAVE_OCSP and HAVE_CERTIFICATE_STATUS_REQUEST_V2
 
 ./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
 if [ $? -eq 0 ]; then
@@ -9,7 +10,8 @@ if [ $? -eq 0 ]; then
     exit 0
 fi
 
-
+# create a unique ready file ending in PID for the script instance ($$) to take
+# advantage of port zero solution
 WORKSPACE=`pwd`
 CERT_DIR="certs/ocsp"
 
@@ -233,7 +235,7 @@ else
     create_new_cnf $RPORTSELECTED1 $RPORTSELECTED2 $RPORTSELECTED3 \
                    $RPORTSELECTED4
 fi
-sleep 1
+sleep 0.1
 
 # setup ocsp responders
 # OLD: ./certs/ocsp/ocspd-root-ca-and-intermediate-cas.sh &
@@ -269,7 +271,7 @@ openssl ocsp -port $RPORTSELECTED3 -nmin 1                      \
     $@                                                          \
     &
 
-sleep 1
+sleep 0.1
 # "jobs" is not portable for posix. Must use bash interpreter!
 [ $(jobs -r | wc -l) -ne 3 ] && printf '\n\n%s\n' "Setup ocsp responder failed, skipping" && exit 0
 
@@ -320,7 +322,7 @@ remove_single_rF $ready_file5
 ./examples/server/server -c certs/ocsp/server4-cert.pem \
                          -k certs/ocsp/server4-key.pem -R $ready_file5 \
                          -p $resume_port &
-sleep 1
+sleep 0.1
 CLI_PORT=`cat $ready_file5`
 ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                          -p $CLI_PORT
@@ -377,7 +379,7 @@ remove_single_rF $ready_file5
                          -k certs/ocsp/server4-key.pem -R $ready_file5 \
                          -p $resume_port -H loadSSL &
 wolf_pid=$!
-sleep 1
+sleep 0.1
 CLI_PORT=`cat $ready_file5`
 ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 3 -v 3 \
                          -p $CLI_PORT

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -453,6 +453,7 @@ int CheckOcspRequest(WOLFSSL_OCSP* ocsp, OcspRequest* ocspRequest,
     }
     else {
         /* cert doesn't have extAuthInfo, assuming CERT_GOOD */
+        WOLFSSL_MSG("Cert has no OCSP URL, assuming CERT_GOOD");
         return 0;
     }
 

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -1078,12 +1078,10 @@ int wolfIO_HttpProcessResponse(int sfd, const char** appStrList,
                 start[len] = 0;
             }
             else {
-            #ifdef WOLFSSL_NONBLOCK_OCSP
                 result = wolfSSL_LastError();
-                if (result == SOCKET_EWOULDBLOCK) {
+                if (result == SOCKET_EWOULDBLOCK || result == SOCKET_EAGAIN) {
                     return OCSP_WANT_READ;
                 }
-            #endif
 
                 WOLFSSL_MSG("wolfIO_HttpProcessResponse recv http from peer failed");
                 return -1;

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -1078,6 +1078,13 @@ int wolfIO_HttpProcessResponse(int sfd, const char** appStrList,
                 start[len] = 0;
             }
             else {
+            #ifdef WOLFSSL_NONBLOCK_OCSP
+                result = wolfSSL_LastError();
+                if (result == SOCKET_EWOULDBLOCK) {
+                    return OCSP_WANT_READ;
+                }
+            #endif
+
                 WOLFSSL_MSG("wolfIO_HttpProcessResponse recv http from peer failed");
                 return -1;
             }


### PR DESCRIPTION
* Fix for handling OCSP response in non-blocking mode.
* Fix for OCSP test with IPV6 enabled (use `-b` bind to any on server).
* Fix to use random port number for the `oscp-stapling.test` script.
* Reduce delay times in scripts.

Example: https://github.com/wolfSSL/wolfssl-examples/pull/224
ZD 10417