### PR TITLE
Update "enable-jni" option for current JSSE requirements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3424,7 +3424,7 @@ AC_ARG_ENABLE([jni],
     )
 if test "$ENABLED_JNI" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_JNI"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_JNI -DHAVE_EX_DATA"
 
     # Enable prereqs if not already enabled
     if test "x$ENABLED_DTLS" = "xno"
@@ -3436,6 +3436,11 @@ then
     then
         ENABLED_OPENSSLEXTRA="yes"
         AM_CFLAGS="$AM_CFLAGS -DOPENSSL_EXTRA"
+    fi
+    if test "x$ENABLED_OPENSSLALL" = "xno"
+    then
+        ENABLED_OPENSSLALL="yes"
+        AM_CFLAGS="$AM_CFLAGS -DOPENSSL_ALL"
     fi
     if test "x$ENABLED_CRL" = "xno"
     then
@@ -3505,6 +3510,11 @@ then
     then
         ENABLED_SNI="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_TLS_EXTENSIONS -DHAVE_SNI"
+    fi
+    if test "x$ENABLED_ALPN" = "xno"
+    then
+        ENABLED_ALPN="yes"
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_ALPN"
     fi
 fi
 


### PR DESCRIPTION
This PR updates the "--enable-jni" configure option to match requirements of the current wolfJSSE provider, adding "HAVE_EX_DATA, OPENSSL_ALL, and HAVE_ALPN" by default.