### PR TITLE
Fixes from C++ and address access checking

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -9756,7 +9756,7 @@ WOLFSSL_X509_EXTENSION *wolfSSL_X509V3_EXT_i2d(int nid, int crit,
     case NID_info_access:
         /* typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS */
     {
-        WOLFSSL_STACK* sk = data;
+        WOLFSSL_STACK* sk = (WOLFSSL_STACK*)data;
 
         if (ext->ext_sk) {
             wolfSSL_sk_free(ext->ext_sk);
@@ -9771,7 +9771,7 @@ WOLFSSL_X509_EXTENSION *wolfSSL_X509V3_EXT_i2d(int nid, int crit,
     case NID_basic_constraints:
     {
         /* WOLFSSL_BASIC_CONSTRAINTS */
-        WOLFSSL_BASIC_CONSTRAINTS* bc = data;
+        WOLFSSL_BASIC_CONSTRAINTS* bc = (WOLFSSL_BASIC_CONSTRAINTS*)data;
 
         if (!(ext->obj = wolfSSL_ASN1_OBJECT_new())) {
             WOLFSSL_MSG("wolfSSL_ASN1_OBJECT_new failed");
@@ -9791,7 +9791,7 @@ WOLFSSL_X509_EXTENSION *wolfSSL_X509V3_EXT_i2d(int nid, int crit,
     case NID_authority_key_identifier:
     {
         /* AUTHORITY_KEYID */
-        WOLFSSL_AUTHORITY_KEYID* akey = data;
+        WOLFSSL_AUTHORITY_KEYID* akey = (WOLFSSL_AUTHORITY_KEYID*)data;
 
         if (akey->keyid) {
             if (wolfSSL_ASN1_STRING_set(&ext->value, akey->keyid->data,
@@ -31883,7 +31883,7 @@ int wolfSSL_PEM_write_mem_RSAPrivateKey(RSA* rsa, const EVP_CIPHER* cipher,
         byte *tmpBuf;
 
         /* Add space for padding */
-        if (!(tmpBuf = XREALLOC(derBuf, derSz + blockSz, NULL,
+        if (!(tmpBuf = (byte*)XREALLOC(derBuf, derSz + blockSz, NULL,
                 DYNAMIC_TYPE_TMP_BUFFER))) {
             WOLFSSL_MSG("Extending DER buffer failed");
             XFREE(derBuf, NULL, DYNAMIC_TYPE_DER);

--- a/tests/api.c
+++ b/tests/api.c
@@ -21156,7 +21156,7 @@ static int test_wc_SetSubjectBuffer (void)
     printf(testingFmt, "wc_SetSubjectBuffer()");
 
     derSz = FOURK_BUF;
-    der = XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    der = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (der == NULL) {
         ret = -1;
     }
@@ -32232,11 +32232,12 @@ static void test_wolfSSL_X509V3_EXT(void) {
     AssertNotNull(ext = wolfSSL_X509_get_ext(x509, i));
     AssertNotNull(obj = wolfSSL_X509_EXTENSION_get_object(ext));
     AssertIntEQ((nid = wolfSSL_OBJ_obj2nid(obj)), NID_info_access);
-    AssertNotNull(aia = wolfSSL_X509V3_EXT_d2i(ext));
+    AssertNotNull(aia =
+                   (WOLFSSL_AUTHORITY_INFO_ACCESS*)wolfSSL_X509V3_EXT_d2i(ext));
     AssertIntEQ(wolfSSL_sk_num(aia), 1); /* Only one URI entry for this cert */
 
     /* URI entry is an ACCESS_DESCRIPTION type */
-    AssertNotNull(ad = wolfSSL_sk_value(aia, 0));
+    AssertNotNull(ad = (WOLFSSL_ACCESS_DESCRIPTION*)wolfSSL_sk_value(aia, 0));
     AssertNotNull(adObj = ad->method);
     /* Make sure nid is OCSP */
     AssertIntEQ(wolfSSL_OBJ_obj2nid(adObj), AIA_OCSP_OID);

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -58,19 +58,20 @@ static const unsigned char kCurve25519BasePoint[CURVE25519_KEYSIZE] = {9};
  * return value is propagated from curve25519() (0 on success), or ECC_BAD_ARG_E,
  * and the byte vectors are little endian.
  */
-int wc_curve25519_make_pub(int public_size, byte* public, int private_size, const byte* private) {
+int wc_curve25519_make_pub(int public_size, byte* pub, int private_size,
+                           const byte* priv) {
     int ret;
 
     if ((public_size != CURVE25519_KEYSIZE) ||
         (private_size != CURVE25519_KEYSIZE)) {
         return ECC_BAD_ARG_E;
     }
-    if ((public == NULL) || (private == NULL))
+    if ((pub == NULL) || (priv == NULL))
         return ECC_BAD_ARG_E;
 
     /* check clamping */
-    if ((private[0] & ~248) ||
-        (private[CURVE25519_KEYSIZE-1] & 128)) {
+    if ((priv[0] & ~248) ||
+        (priv[CURVE25519_KEYSIZE-1] & 128)) {
         return ECC_BAD_ARG_E;
     }
 
@@ -78,13 +79,13 @@ int wc_curve25519_make_pub(int public_size, byte* public, int private_size, cons
     {
         const ECPoint* basepoint = nxp_ltc_curve25519_GetBasePoint();
         ECPoint wc_pub;
-        ret = nxp_ltc_curve25519(&wc_pub, private, basepoint, kLTC_Weierstrass); /* input basepoint on Weierstrass curve */
+        ret = nxp_ltc_curve25519(&wc_pub, priv, basepoint, kLTC_Weierstrass); /* input basepoint on Weierstrass curve */
         if (ret == 0)
-            XMEMCPY(public, wc_pub.point, CURVE25519_KEYSIZE);
+            XMEMCPY(pub, wc_pub.point, CURVE25519_KEYSIZE);
     }
 #else
     fe_init();
-    ret = curve25519(public, private, kCurve25519BasePoint);
+    ret = curve25519(pub, priv, kCurve25519BasePoint);
 #endif
 
     return ret;

--- a/wolfcrypt/src/sp_x86_64_asm.S
+++ b/wolfcrypt/src/sp_x86_64_asm.S
@@ -39015,7 +39015,7 @@ _sp_256_get_point_33_4:
         movd	%edx, %xmm13
         addq	$200, %rsi
         movd	%eax, %xmm15
-        movq	$33, %rax
+        movq	$32, %rax
         pshufd	$0, %xmm15, %xmm15
         pshufd	$0, %xmm13, %xmm13
         pxor	%xmm14, %xmm14
@@ -39081,7 +39081,7 @@ _sp_256_get_point_33_avx2_4:
         movd	%edx, %xmm7
         addq	$200, %rsi
         movd	%eax, %xmm9
-        movq	$33, %rax
+        movq	$32, %rax
         vpxor	%ymm8, %ymm8, %ymm8
         vpermd	%ymm7, %ymm8, %ymm7
         vpermd	%ymm9, %ymm8, %ymm9
@@ -39472,7 +39472,7 @@ _sp_256_get_entry_64_4:
         movd	%edx, %xmm9
         addq	$64, %rsi
         movd	%eax, %xmm11
-        movq	$64, %rax
+        movq	$63, %rax
         pshufd	$0, %xmm11, %xmm11
         pshufd	$0, %xmm9, %xmm9
         pxor	%xmm10, %xmm10
@@ -39575,7 +39575,7 @@ _sp_256_get_entry_65_4:
         movd	%edx, %xmm9
         addq	$64, %rsi
         movd	%eax, %xmm11
-        movq	$65, %rax
+        movq	$64, %rax
         pshufd	$0, %xmm11, %xmm11
         pshufd	$0, %xmm9, %xmm9
         pxor	%xmm10, %xmm10
@@ -42016,7 +42016,7 @@ _sp_384_get_point_33_6:
         movd	%edx, %xmm13
         addq	$296, %rsi
         movd	%eax, %xmm15
-        movq	$33, %rax
+        movq	$32, %rax
         pshufd	$0, %xmm15, %xmm15
         pshufd	$0, %xmm13, %xmm13
         pxor	%xmm14, %xmm14
@@ -42060,9 +42060,9 @@ L_384_get_point_33_6_start:
         movdqu	%xmm5, 128(%rdi)
         movq	$1, %rax
         movd	%edx, %xmm13
-        addq	$296, %rsi
+        subq	$9472, %rsi
         movd	%eax, %xmm15
-        movq	$33, %rax
+        movq	$32, %rax
         pshufd	$0, %xmm15, %xmm15
         pshufd	$0, %xmm13, %xmm13
         pxor	%xmm14, %xmm14
@@ -42113,7 +42113,7 @@ _sp_384_get_point_33_avx2_6:
         movd	%edx, %xmm13
         addq	$296, %rsi
         movd	%eax, %xmm15
-        movq	$33, %rax
+        movq	$32, %rax
         vpxor	%ymm14, %ymm14, %ymm14
         vpermd	%ymm13, %ymm14, %ymm13
         vpermd	%ymm15, %ymm14, %ymm15
@@ -42888,7 +42888,7 @@ _sp_384_get_entry_256_6:
         movd	%edx, %xmm13
         addq	$96, %rsi
         movd	%eax, %xmm15
-        movq	$256, %rax
+        movq	$255, %rax
         pshufd	$0, %xmm15, %xmm15
         pshufd	$0, %xmm13, %xmm13
         pxor	%xmm14, %xmm14

--- a/wolfssl/wolfcrypt/curve25519.h
+++ b/wolfssl/wolfcrypt/curve25519.h
@@ -87,7 +87,8 @@ enum {
 };
 
 WOLFSSL_API
-int wc_curve25519_make_pub(int public_size, byte* public, int private_size, const byte* private);
+int wc_curve25519_make_pub(int public_size, byte* pub, int private_size,
+                           const byte* priv);
 
 WOLFSSL_API
 int wc_curve25519_make_key(WC_RNG* rng, int keysize, curve25519_key* key);


### PR DESCRIPTION
Fix access of table for cache resistance.
Don't name variable public or private.
Cast from void*