### PR TITLE
Fix out of bounds read when writing to very long buffer

### DIFF
--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -321,9 +321,14 @@ int mp_to_unsigned_bin_len(mp_int * a, unsigned char *b, int c)
 
     len = mp_unsigned_bin_size(a);
 
+    if (len > c) {
+      return MP_VAL;
+    }
+
     /* pad front w/ zeros to match length */
-    for (i = 0; i < c - len; i++)
-        b[i] = 0x00;
+    for (i = 0; i < c - len; i++) {
+      b[i] = 0x00;
+    }
     return mp_to_unsigned_bin(a, b + i);
 }
 

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -442,12 +442,15 @@ int sp_to_unsigned_bin_len(sp_int* a, byte* out, int outSz)
     int i, j, b;
 
     j = outSz - 1;
-    for (i=0; j>=0; i++) {
+    for (i = 0; j >= 0 && i < a->used; i++) {
         for (b = 0; b < SP_WORD_SIZE; b += 8) {
             out[j--] = a->dp[i] >> b;
             if (j < 0)
                 break;
         }
+    }
+    for (; j >= 0; j--) {
+        out[j] = 0;
     }
 
     return MP_OKAY;

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3645,11 +3645,14 @@ int fp_to_unsigned_bin_len(fp_int *a, unsigned char *b, int c)
 #if DIGIT_BIT == 64 || DIGIT_BIT == 32
   int i, j, x;
 
-  for (x=c-1,j=0,i=0; x >= 0; x--) {
+  for (x=c-1, j=0, i=0; x >= 0 && i < a->used; x--) {
      b[x] = (unsigned char)(a->dp[i] >> j);
      j += 8;
      i += j == DIGIT_BIT;
      j &= DIGIT_BIT - 1;
+  }
+  for (; x >= 0; x--) {
+     b[x] = 0;
   }
 
   return FP_OKAY;


### PR DESCRIPTION
mp_to_unsigned_bin_len() didn't handle buffers longer than maximum MP
size. Fixed tfm and sp_int versions.