### PR TITLE
Fix for EVP Digest return code for SHA3-512

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -5505,7 +5505,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                 break;
             case WC_HASH_TYPE_SHA3_512:
         #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_512)
-                wolfSSL_SHA3_512_Update((SHA3_512_CTX*)&ctx->hash, data,
+                ret = wolfSSL_SHA3_512_Update((SHA3_512_CTX*)&ctx->hash, data,
                                      (unsigned long)sz);
         #endif
                 break;


### PR DESCRIPTION
* Fix for `wolfSSL_EVP_DigestUpdate()` returning default failure with SHA3_512