### PR TITLE
Compatiblity Layer Fixes for serial number / ASN1 time / and order of name components

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -37446,7 +37446,7 @@ static int CopyX509NameToCertName(WOLFSSL_X509_NAME* n, CertName* cName)
             int  serialSz = EXTERNAL_SERIAL_SIZE;
 
             ret = wolfSSL_X509_get_serial_number(x509, serial, &serialSz);
-            if (ret != WOLFSSL_SUCCESS || serialSz < 3) {
+            if (ret != WOLFSSL_SUCCESS) {
                 WOLFSSL_MSG("Serial size error");
                 return WOLFSSL_FAILURE;
             }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -37284,7 +37284,7 @@ static int CopyX509NameToCertName(WOLFSSL_X509_NAME* n, CertName* cName)
 
             if (j >= CTC_MAX_ATTRIB) {
                 WOLFSSL_MSG("No more space left in CertName");
-                break;
+                return MEMORY_E;
             }
 
             cName->name[j].sz   = length;
@@ -48354,7 +48354,7 @@ int wolfSSL_X509_set_serialNumber(WOLFSSL_X509* x509, WOLFSSL_ASN1_INTEGER* s)
     if (s->length < 3) {
         return WOLFSSL_FAILURE;
     }
-    XSTRNCPY((char*)x509->serial, (char*)s->data + 2, s->length - 2);
+    XMEMCPY(x509->serial, s->data + 2, s->length - 2);
     x509->serialSz = s->length - 2;
     x509->serial[s->length] = 0;
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -37743,12 +37743,18 @@ static int CopyX509NameToCertName(WOLFSSL_X509_NAME* n, CertName* cName)
         return ret;
     }
 
+
+    #ifndef WC_MAX_X509_GEN
+        /* able to override max size until dynamic buffer created */
+        #define WC_MAX_X509_GEN 4096
+    #endif
+
     /* returns the size of signature on success */
     int wolfSSL_X509_sign(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey,
             const WOLFSSL_EVP_MD* md)
     {
         int  ret;
-        byte der[4096]; /* @TODO dynamic set based on expected cert size */
+        byte der[WC_MAX_X509_GEN]; /* @TODO dynamic based on expected cert size */
         int  derSz = sizeof(der);
 
         WOLFSSL_ENTER("wolfSSL_X509_sign");

--- a/tests/api.c
+++ b/tests/api.c
@@ -27763,6 +27763,7 @@ static void test_wolfSSL_X509_sign(void)
     EVP_PKEY_free(priv);
     EVP_PKEY_free(pub);
     X509_free(x509);
+    X509_free(ca);
 
     printf(resultFmt, passed);
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -30534,6 +30534,8 @@ static void test_wolfSSL_X509_get_serialNumber(void)
     BIGNUM* bn;
     X509*   x509;
     char *serialHex;
+    byte serial[1];
+    int  serialSz;
 
     printf(testingFmt, "wolfSSL_X509_get_serialNumber()");
 
@@ -30543,6 +30545,17 @@ static void test_wolfSSL_X509_get_serialNumber(void)
 
     /* check on value of ASN1 Integer */
     AssertNotNull(bn = ASN1_INTEGER_to_BN(a, NULL));
+
+
+    /* test setting serial number and then retrieving it */
+    AssertNotNull(a = ASN1_INTEGER_new());
+    ASN1_INTEGER_set(a, 3);
+    AssertIntEQ(X509_set_serialNumber(x509, a), WOLFSSL_SUCCESS);
+    serialSz = sizeof(serial);
+    AssertIntEQ(wolfSSL_X509_get_serial_number(x509, serial, &serialSz),
+            WOLFSSL_SUCCESS);
+    AssertIntEQ(serialSz, 1);
+    AssertIntEQ(serial[0], 3);
 
     X509_free(x509); /* free's a */
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -30534,7 +30534,7 @@ static void test_wolfSSL_X509_get_serialNumber(void)
     BIGNUM* bn;
     X509*   x509;
     char *serialHex;
-    byte serial[1];
+    byte serial[3];
     int  serialSz;
 
     printf(testingFmt, "wolfSSL_X509_get_serialNumber()");
@@ -30556,6 +30556,29 @@ static void test_wolfSSL_X509_get_serialNumber(void)
             WOLFSSL_SUCCESS);
     AssertIntEQ(serialSz, 1);
     AssertIntEQ(serial[0], 3);
+    ASN1_INTEGER_free(a);
+
+    /* test setting serial number with 0's in it */
+    serial[0] = 0x01;
+    serial[1] = 0x00;
+    serial[2] = 0x02;
+
+    AssertNotNull(a = wolfSSL_ASN1_INTEGER_new());
+    a->data[0] = ASN_INTEGER;
+    a->data[1] = sizeof(serial);
+    XMEMCPY(&a->data[2], serial, sizeof(serial));
+    a->length = sizeof(serial) + 2;
+    AssertIntEQ(X509_set_serialNumber(x509, a), WOLFSSL_SUCCESS);
+
+    XMEMSET(serial, 0, sizeof(serial));
+    serialSz = sizeof(serial);
+    AssertIntEQ(wolfSSL_X509_get_serial_number(x509, serial, &serialSz),
+            WOLFSSL_SUCCESS);
+    AssertIntEQ(serialSz, 3);
+    AssertIntEQ(serial[0], 0x01);
+    AssertIntEQ(serial[1], 0x00);
+    AssertIntEQ(serial[2], 0x02);
+    ASN1_INTEGER_free(a);
 
     X509_free(x509); /* free's a */
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -6644,13 +6644,14 @@ WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_ex(void* heap)
 #else
         ret = wc_InitRng(&pkey->rng);
 #endif
+        pkey->references = 1;
+        wc_InitMutex(&pkey->refMutex); /* init of mutex needs to come before
+                                        * wolfSSL_EVP_PKEY_free */
         if (ret != 0){
             wolfSSL_EVP_PKEY_free(pkey);
             WOLFSSL_MSG("memory failure");
             return NULL;
         }
-        pkey->references = 1;
-        wc_InitMutex(&pkey->refMutex);
     }
     else {
         WOLFSSL_MSG("memory failure");

--- a/wolfssl/openssl/asn1.h
+++ b/wolfssl/openssl/asn1.h
@@ -69,6 +69,7 @@
 #define V_ASN1_OBJECT                   6
 #define V_ASN1_UTCTIME                  23
 #define V_ASN1_GENERALIZEDTIME          24
+#define V_ASN1_PRINTABLESTRING          19
 
 #define ASN1_STRING_FLAG_BITS_LEFT       0x008
 #define ASN1_STRING_FLAG_NDEF            0x010

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -366,7 +366,6 @@ enum Misc_ASN {
     MAX_CERTPOL_SZ      = CTC_MAX_CERTPOL_SZ,
 #endif
     MAX_AIA_SZ          = 2,       /* Max Authority Info Access extension size*/
-    MAX_NAME_ENTRIES    = 13,      /* entries added to x509 name struct */
     OCSP_NONCE_EXT_SZ   = 35,      /* OCSP Nonce Extension size */
     MAX_OCSP_EXT_SZ     = 58,      /* Max OCSP Extension length */
     MAX_OCSP_NONCE_SZ   = 16,      /* OCSP Nonce size           */
@@ -394,6 +393,12 @@ enum Misc_ASN {
     PEM_LINE_SZ        = 64,               /* Length of Base64 encoded line, not including new line */
     PEM_LINE_LEN       = PEM_LINE_SZ + 12, /* PEM line max + fudge */
 };
+
+#ifndef WC_MAX_NAME_ENTRIES
+    /* entries added to x509 name struct */
+    #define WC_MAX_NAME_ENTRIES 13
+#endif
+#define MAX_NAME_ENTRIES WC_MAX_NAME_ENTRIES
 
 
 enum Oid_Types {

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -330,6 +330,8 @@ typedef struct Cert {
 #endif
     char    certPolicies[CTC_MAX_CERTPOL_NB][CTC_MAX_CERTPOL_SZ];
     word16  certPoliciesNb;              /* Number of Cert Policy */
+#endif
+#if defined(WOLFSSL_CERT_EXT) || defined(OPENSSL_EXTRA)
     byte     issRaw[sizeof(CertName)];   /* raw issuer info */
     byte     sbjRaw[sizeof(CertName)];   /* raw subject info */
 #endif


### PR DESCRIPTION
Compatibility Layer Fixes:

* Fix for setting serial number wolfSSL_X509_set_serialNumber
* Fix for setting ASN1 time not before / not after with WOLFSSL_X509
* Fix for mutex free'ing during RNG failure case with EVP_KEY creation
* Fix for order of components in issuer name when using X509_sign

Added macros to adjust max size of certificate and max entries. 
WC_MAX_NAME_ENTRIES
WC_MAX_X509_GEN