### PR TITLE
Make ByteReverseWords available for big and little endian

### DIFF
--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -120,7 +120,6 @@ WC_STATIC WC_INLINE word32 ByteReverseWord32(word32 value)
     return rotlFixed(value, 16U);
 #endif
 }
-#if defined(LITTLE_ENDIAN_ORDER)
 /* This routine performs a byte swap of words array of a given count. */
 WC_STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
                                     word32 byteCount)
@@ -131,7 +130,6 @@ WC_STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
         out[i] = ByteReverseWord32(in[i]);
 
 }
-#endif /* LITTLE_ENDIAN_ORDER */
 
 #if defined(WORD64_AVAILABLE) && !defined(WOLFSSL_NO_WORD64_OPS)
 


### PR DESCRIPTION

This PR fixes a build error by removing the ifdef endianess check around ByteReverseWords(). 
It turned out some libraries (e.g. md4.c) default to checking BIG_ENDIAN_ORDER before calling ByteReverseWords() while other modules such as sha256.c check LITTLE_ENDIAN_ORDER before calling ByteReverseWords().  So ByteReverseWords() needs to be available for both big and little-endian systems. 

Steps to reproduce error:
./configure CFLAGS="-DBIG_ENDIAN_ORDER" --enable-md4
make
```
wolfcrypt/src/md4.c: In function ‘wc_Md4Update’:
wolfcrypt/src/md4.c:156:17: error: implicit declaration of function ‘ByteReverseWords’; did you mean ‘ByteReverseWords64’? [-Werror=implicit-function-declaration]
                 ByteReverseWords(md4->buffer, md4->buffer, MD4_BLOCK_SIZE);
                 ^~~~~~~~~~~~~~~~
                 ByteReverseWords64
wolfcrypt/src/md4.c:156:17: error: nested extern declaration of ‘ByteReverseWords’ [-Werror=nested-externs]
  CC       wolfcrypt/src/src_libwolfssl_la-chacha20_poly1305.lo
cc1: all warnings being treated as errors
Makefile:4667: recipe for target 'wolfcrypt/src/src_libwolfssl_la-md4.lo' failed
make[1]: *** [wolfcrypt/src/src_libwolfssl_la-md4.lo] Error 1
make[1]: *** Waiting for unfinished jobs....
wolfcrypt/src/md5.c: In function ‘wc_Md5Update’:
wolfcrypt/src/md5.c:378:13: error: implicit declaration of function ‘ByteReverseWords’; did you mean ‘ByteReverseWords64’? [-Werror=implicit-function-declaration]
             ByteReverseWords(md5->buffer, md5->buffer, WC_MD5_BLOCK_SIZE);
             ^~~~~~~~~~~~~~~~
             ByteReverseWords64
wolfcrypt/src/md5.c:378:13: error: nested extern declaration of ‘ByteReverseWords’ [-Werror=nested-externs]
cc1: all warnings being treated as errors
Makefile:4674: recipe for target 'wolfcrypt/src/src_libwolfssl_la-md5.lo' failed
make[1]: *** [wolfcrypt/src/src_libwolfssl_la-md5.lo] Error 1
make[1]: Leaving directory '/home/tesfa/wolfssl'
Makefile:3141: recipe for target 'all' failed
make: *** [all] Error 2

```