### PR TITLE
Fixes for NXP MMCAU/LTC mutex locking and build

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -3393,11 +3393,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
             for (i = 0; i < AES_BLOCK_SIZE; i++)
                 temp_block[i] ^= iv[i];
 
-            i = wolfSSL_CryptHwMutexLock();
-            if (i != 0)
-                return i;
             wc_AesEncrypt(aes, temp_block, out + offset);
-            wolfSSL_CryptHwMutexUnLock();
 
             offset += AES_BLOCK_SIZE;
 
@@ -3421,11 +3417,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         while (blocks--) {
             XMEMCPY(temp_block, in + offset, AES_BLOCK_SIZE);
 
-            i = wolfSSL_CryptHwMutexLock();
-            if (i != 0)
-                return i;
             wc_AesDecrypt(aes, in + offset, out + offset);
-            wolfSSL_CryptHwMutexUnLock();
 
             /* XOR block with IV for CBC */
             for (i = 0; i < AES_BLOCK_SIZE; i++)

--- a/wolfcrypt/src/port/nxp/ksdk_port.c
+++ b/wolfcrypt/src/port/nxp/ksdk_port.c
@@ -768,6 +768,15 @@ int wc_ecc_mulmod_ex(mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
     return res;
 }
 
+int wc_ecc_mulmod_ex2(mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
+                      mp_int* modulus, mp_int* order, WC_RNG* rng, int map,
+                      void* heap)
+{
+    (void)order;
+    (void)rng;
+    return wc_ecc_mulmod_ex(k, G, R, a, modulus, map, heap);
+}
+
 int wc_ecc_point_add(ecc_point *mG, ecc_point *mQ, ecc_point *mR, mp_int *m)
 {
     int res;

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -725,6 +725,15 @@ int wc_ecc_mulmod_ex(mp_int *k, ecc_point *G, ecc_point *R, mp_int* a,
     return res;
 }
 
+int wc_ecc_mulmod_ex2(mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
+                      mp_int* modulus, mp_int* order, WC_RNG* rng, int map,
+                      void* heap)
+{
+    (void)order;
+    (void)rng;
+    return wc_ecc_mulmod_ex(k, G, R, a, modulus, map, heap);
+}
+
 int stm32_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
                     word32 hashlen, int* res, ecc_key* key)
 {


### PR DESCRIPTION
* Fix MMCAU and LTC hardware mutex locking to prevent double lock.
* Fix to add wrapper for new timing resistant `wc_ecc_mulmod_ex2` function version in HW ECC acceleration. Broken in PR #2982.