### PR TITLE
Fix for building SP math with IAR

### DIFF
--- a/wolfssl/wolfcrypt/sp.h
+++ b/wolfssl/wolfcrypt/sp.h
@@ -37,7 +37,9 @@
 
 #if defined(_MSC_VER)
     #define SP_NOINLINE __declspec(noinline)
-#elif defined(__IAR_SYSTEMS_ICC__) || defined(__GNUC__) || defined(__KEIL__)
+#elif defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
+    #define SP_NOINLINE _Pragma("inline = never")
+#elif defined(__GNUC__) || defined(__KEIL__)
     #define SP_NOINLINE __attribute__((noinline))
 #else
     #define SP_NOINLINE


### PR DESCRIPTION
Fixes issue with no inline macro. 
Tested with IAR EW 8.30.1.
ZD 10839