### PR TITLE
Fix for DH compute key compatibility function failure

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -29795,7 +29795,7 @@ int wolfSSL_DH_compute_key(unsigned char* key, WOLFSSL_BIGNUM* otherPub,
         privSz = wolfSSL_BN_bn2bin(dh->priv_key, priv);
         pubSz  = wolfSSL_BN_bn2bin(otherPub, pub);
         if (dh->inSet == 0 && SetDhInternal(dh) != SSL_SUCCESS){
-                WOLFSSL_MSG("Bad DH set internal");
+            WOLFSSL_MSG("Bad DH set internal");
         }
         if (privSz <= 0 || pubSz <= 0)
             WOLFSSL_MSG("Bad BN2bin set");
@@ -29810,6 +29810,8 @@ int wolfSSL_DH_compute_key(unsigned char* key, WOLFSSL_BIGNUM* otherPub,
     XFREE(pub,  NULL, DYNAMIC_TYPE_PUBLIC_KEY);
     XFREE(priv, NULL, DYNAMIC_TYPE_PRIVATE_KEY);
 #endif
+
+    WOLFSSL_LEAVE("wolfSSL_DH_compute_key", ret);
 
     return ret;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -27628,7 +27628,7 @@ static void test_wolfSSL_X509_sign(void)
     byte sn[16];
     int snSz = sizeof(sn);
 
-    printf(testingFmt, "wolfSSL_X509_sign\n");
+    printf(testingFmt, "wolfSSL_X509_sign");
 
     /* Set X509_NAME fields */
     AssertNotNull(name = X509_NAME_new());
@@ -32653,6 +32653,7 @@ static void test_wolfSSL_OCSP_get0_info()
 static void test_wolfSSL_EVP_PKEY_derive(void)
 {
 #ifdef OPENSSL_ALL
+    printf(testingFmt, "wolfSSL_EVP_PKEY_derive()");
 #if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION>2))
     EVP_PKEY_CTX *ctx;
     unsigned char *skey;
@@ -32702,6 +32703,7 @@ static void test_wolfSSL_EVP_PKEY_derive(void)
     XFREE(skey, NULL, DYNAMIC_TYPE_OPENSSL);
 #endif /* HAVE_ECC */
 #endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
+    printf(resultFmt, "passed");
 #endif /* OPENSSL_ALL */
 }
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1385,8 +1385,9 @@ int wolfSSL_EVP_PKEY_derive(WOLFSSL_EVP_PKEY_CTX *ctx, unsigned char *key, size_
             if (*keylen < (size_t)len) {
                 return WOLFSSL_FAILURE;
             }
+            /* computed DH agreement can be less than DH size if leading zeros */
             if (wolfSSL_DH_compute_key(key, ctx->peerKey->dh->pub_key,
-                                       ctx->pkey->dh) != len) {
+                                       ctx->pkey->dh) <= 0) {
                 return WOLFSSL_FAILURE;
             }
         }


### PR DESCRIPTION
Fix for `DH_compute_key` incorrectly reporting failure if computed secret had leading zeros. Fixes for occasional unit.test failure in `test_wolfSSL_EVP_PKEY_derive`. Test runs with `--enable-all` or `--enable-opensslall`.