### PR TITLE
Fix redefinition conflict W64LIT

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -113,22 +113,27 @@ decouple library dependencies with standard string, memory and so on.
 
     #if defined(_MSC_VER) || defined(__BCPLUSPLUS__)
         #define WORD64_AVAILABLE
+        #undef W64LIT
         #define W64LIT(x) x##ui64
         typedef unsigned __int64 word64;
     #elif defined(__EMSCRIPTEN__)
         #define WORD64_AVAILABLE
+        #undef W64LIT
         #define W64LIT(x) x##ull
         typedef unsigned long long word64;
     #elif defined(SIZEOF_LONG) && SIZEOF_LONG == 8
         #define WORD64_AVAILABLE
+        #undef W64LIT
         #define W64LIT(x) x##LL
         typedef unsigned long word64;
     #elif defined(SIZEOF_LONG_LONG) && SIZEOF_LONG_LONG == 8
         #define WORD64_AVAILABLE
+        #undef W64LIT
         #define W64LIT(x) x##LL
         typedef unsigned long long word64;
     #elif defined(__SIZEOF_LONG_LONG__) && __SIZEOF_LONG_LONG__ == 8
         #define WORD64_AVAILABLE
+        #undef W64LIT
         #define W64LIT(x) x##LL
         typedef unsigned long long word64;
     #endif


### PR DESCRIPTION
The `W64LIT` define conflicted with the Crypto++ library definition. 

This fixed an issue reported in ZD10728