### PR TITLE
TLS 1.3: allow wolfSSL_peek() to return WANT_READ

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -17876,6 +17876,16 @@ startScr:
                 goto startScr;
             }
         #endif
+    #ifdef WOLFSSL_TLS13
+        if (IsAtLeastTLSv1_3(ssl->version) && ssl->options.handShakeDone &&
+                                         ssl->curRL.type == handshake && peek) {
+            WOLFSSL_MSG("Got Handshake Messge in APP data");
+            if (ssl->buffers.inputBuffer.length == 0) {
+                ssl->error = WOLFSSL_ERROR_WANT_READ;
+                return 0;
+            }
+        }
+    #endif
     }
 
     if (sz < (int)ssl->buffers.clearOutputBuffer.length)


### PR DESCRIPTION
When handshake message is processed in wolfSSL_peek() then return
WANT_READ from peek instead of blocking waiting for application data.

Server may send an alert if the client certificate is invalid.
The server also may send NewSesionTicket after client has sent finished
message.
To detect alert before handling application data, then the socket needs
to be checked for data. If the data is an alert then wolfSSL_peek() will
handle the alert, but if it is a NewSessionTicket then wolfSSL_peek()
will process it and block waiting for application data - so return
WANT_READ if no application data seen after processing handshake
message.