### PR TITLE
Fix failing nightly

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -19722,6 +19722,7 @@ void wolfSSL_SESSION_free(WOLFSSL_SESSION* session)
 #if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
     if (session->peer) {
         wolfSSL_X509_free(session->peer);
+        session->peer = NULL;
     }
 #endif
 


### PR DESCRIPTION
Failed tests when configured with `./configure --enable-dtls --enable-opensslextra --enable-sessioncerts`. Valgrind discovered a use after free bug. Nulling session->peer fixes the issue.