### PR TITLE
Fix macos only option in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,14 @@ find_package (Threads)
 # Let CMake choose default compiler
 
 # Silence ranlib warning "has no symbols"
+if(APPLE)
+    SET(WOLFSSL_RANLIB_OPTIONS "-no_warning_for_no_symbols")
+endif()
+
 SET(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
 SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
-SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
-SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> ${WOLFSSL_RANLIB_OPTIONS} -c <TARGET>")
+SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> ${WOLFSSL_RANLIB_OPTIONS} -c <TARGET>")
 
 ####################################################
 # Cross Compile Example


### PR DESCRIPTION
-no_warning_for_no_symbols is not a valid option with gcc/clang.
See [HERE](https://travis-ci.org/github/RPCS3/rpcs3/jobs/725194700#L1842) and [HERE](https://travis-ci.org/github/RPCS3/rpcs3/jobs/725194699#L1910).

From a quick google the option seems only valid for Apple products so added a check for it.