### PR TITLE
Fix for bad pre-processor logic

### DIFF
--- a/cyassl/ctaocrypt/settings.h
+++ b/cyassl/ctaocrypt/settings.h
@@ -341,7 +341,9 @@
         #undef SIZEOF_LONG
         #define SIZEOF_LONG_LONG 8
     #else
-        #sslpro: settings.h - please implement SIZEOF_LONG and SIZEOF_LONG_LONG
+        #if !defined(SIZEOF_LONG) && !defined(SIZEOF_LONG_LONG)
+            #error settings.h - please implement SIZEOF_LONG and SIZEOF_LONG_LONG
+        #endif
     #endif
 
     #define XMALLOC(s, h, type) ((void *)rtp_malloc((s), SSL_PRO_MALLOC))

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -831,7 +831,9 @@ extern void uITRON4_free(void *p) ;
         #undef SIZEOF_LONG
         #define SIZEOF_LONG_LONG 8
     #else
-        #error settings.h - please implement SIZEOF_LONG and SIZEOF_LONG_LONG
+        #if !defined(SIZEOF_LONG) && !defined(SIZEOF_LONG_LONG)
+            #error settings.h - please implement SIZEOF_LONG and SIZEOF_LONG_LONG
+        #endif
     #endif
 
     #define XMALLOC(s, h, type) ((void *)rtp_malloc((s), SSL_PRO_MALLOC))
@@ -841,7 +843,9 @@ extern void uITRON4_free(void *p) ;
     #if (WINMSP3)
         #define XSTRNCASECMP(s1,s2,n)  _strnicmp((s1),(s2),(n))
     #else
-        #sslpro: settings.h - please implement XSTRNCASECMP - needed for HAVE_ECC
+        #ifndef XSTRNCASECMP
+            #error settings.h - please implement XSTRNCASECMP - needed for HAVE_ECC
+        #endif
     #endif
 
     #define WOLFSSL_HAVE_MAX


### PR DESCRIPTION
Some compilers are unhappy with the `#sslpro` even in a block of code not used!