### PR TITLE
Fix SIZEOF_LONG and SIZEOF_LONG_LONG logic

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -86,14 +86,14 @@ decouple library dependencies with standard string, memory and so on.
 
     /* try to set SIZEOF_LONG or SIZEOF_LONG_LONG if user didn't */
     #if defined(_MSC_VER) || defined(HAVE_LIMITS_H)
-        #if !defined(SIZEOF_LONG_LONG) && !defined(SIZEOF_LONG)
+        #if !defined(SIZEOF_LONG_LONG) || !defined(SIZEOF_LONG)
             #include <limits.h>
-            #if defined(ULONG_MAX) && (ULONG_MAX == 0xffffffffUL)
-                #define SIZEOF_LONG 4
-            #endif
-            #if defined(ULLONG_MAX) && (ULLONG_MAX == 0xffffffffffffffffULL)
-                #define SIZEOF_LONG_LONG 8
-            #endif
+        #endif
+        #if !defined(SIZEOF_LONG) && defined(ULONG_MAX) && (ULONG_MAX == 0xffffffffUL)
+            #define SIZEOF_LONG 4
+        #endif
+        #if !defined(SIZEOF_LONG_LONG) && defined(ULLONG_MAX) && (ULLONG_MAX == 0xffffffffffffffffULL)
+            #define SIZEOF_LONG_LONG 8
         #endif
     #elif !defined(__BCPLUSPLUS__) && !defined(__EMSCRIPTEN__)
         #if !defined(SIZEOF_LONG_LONG) && !defined(SIZEOF_LONG)


### PR DESCRIPTION
Somehow we're hitting a case where one is defined but not the other, improved logic so that both are guaranteed to be defined.

To be specific we're hitting an #error below in the same file: `#error "bad math long / long long settings"` because SIZEOF_LONG is defined as 4 and SIZEOF_LONG_LONG is undefined so it's hitting none of the cases listed(and on msvc it should hit the SIZEOF_LONG_LONG==8 cases).