### PR TITLE
Fix mp_radix_size off by 1 error

### DIFF
--- a/IDE/Espressif/ESP-IDF/test/test_wolfssl.c
+++ b/IDE/Espressif/ESP-IDF/test/test_wolfssl.c
@@ -335,7 +335,7 @@ int mp_unitest_mul(const char* strZ, const char* strX, const char* strY, int ver
     }
 
     mp_radix_size(&z, 16, &radixZ_size);
-    bufZ = (char*)XMALLOC(radixZ_size + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    bufZ = (char*)XMALLOC(radixZ_size, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if(bufZ != NULL) {
         mp_toradix(&z, bufZ, 16);
         bufZ[radixZ_size] ='\0';
@@ -350,7 +350,7 @@ int mp_unitest_mul(const char* strZ, const char* strX, const char* strY, int ver
         mp_radix_size(&y, 16, &radixY_size);
         radixX_size = max(radixX_size, radixY_size);
 
-        buf = (char*)XMALLOC(radixX_size + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        buf = (char*)XMALLOC(radixX_size, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if(buf != NULL) {
             mp_toradix(&x, buf, 16);
             buf[radixX_size] ='\0';
@@ -410,7 +410,7 @@ int mp_unitest_mulmod(const char* strZ, const char* strX, const char* strY,
     }
 
     mp_radix_size(&z, 16, &radixZ_size);
-    bufZ = (char*)XMALLOC(radixZ_size + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    bufZ = (char*)XMALLOC(radixZ_size, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if(bufZ != NULL) {
         mp_toradix(&z, bufZ, 16);
         bufZ[radixZ_size] ='\0';
@@ -427,7 +427,7 @@ int mp_unitest_mulmod(const char* strZ, const char* strX, const char* strY,
         mp_radix_size(&m, 16, &radixM_size);
         radixX_size = max(radixX_size, max(radixY_size, radixM_size));
 
-        buf = (char*)XMALLOC(radixX_size + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        buf = (char*)XMALLOC(radixX_size, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if(buf != NULL) {
             mp_toradix(&x, buf, 16);
             buf[radixX_size] ='\0';
@@ -491,7 +491,7 @@ int mp_unitest_exptmod(const char* strZ, const char* strX, const char* strY,
     }
 
     mp_radix_size(&z, 16, &radixZ_size);
-    bufZ = (char*)XMALLOC(radixZ_size + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    bufZ = (char*)XMALLOC(radixZ_size, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if(bufZ != NULL) {
         mp_toradix(&z, bufZ, 16);
         bufZ[radixZ_size] ='\0';
@@ -508,7 +508,7 @@ int mp_unitest_exptmod(const char* strZ, const char* strX, const char* strY,
         mp_radix_size(&m, 16, &radixM_size);
         radixX_size = max(radixX_size, max(radixY_size, radixM_size));
 
-        buf = (char*)XMALLOC(radixX_size + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        buf = (char*)XMALLOC(radixX_size, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if(buf != NULL) {
             mp_toradix(&x, buf, 16);
             buf[radixX_size] ='\0';

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -46562,7 +46562,6 @@ char *wolfSSL_BN_bn2hex(const WOLFSSL_BIGNUM *bn)
         WOLFSSL_MSG("mp_radix_size failure");
         return NULL;
     }
-    len += 1; /* add one for null terminator */
 
     buf = (char*)XMALLOC(len, NULL, DYNAMIC_TYPE_OPENSSL);
     if (buf == NULL) {

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -5242,7 +5242,7 @@ int mp_radix_size (mp_int *a, int radix, int *size)
     }
 
     /* digs is the digit count */
-    digs = 0;
+    digs = 1;
 
     /* if it's negative add one for the sign */
     if (a->sign == MP_NEG) {

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -5244,11 +5244,6 @@ int mp_radix_size (mp_int *a, int radix, int *size)
     /* digs is the digit count */
     digs = 0;
 
-    /* if it's negative add one for the sign */
-    if (a->sign == MP_NEG) {
-        ++digs;
-    }
-
     /* init a copy of the input */
     if ((res = mp_init_copy (&t, a)) != MP_OKAY) {
         return res;
@@ -5273,6 +5268,11 @@ int mp_radix_size (mp_int *a, int radix, int *size)
         ++digs;
     }
 #endif
+
+    /* if it's negative add one for the sign */
+    if (a->sign == MP_NEG) {
+        ++digs;
+    }
 
     /* return digs + 1, the 1 is for the NULL byte that would be required. */
     *size = digs + 1;

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -5242,7 +5242,7 @@ int mp_radix_size (mp_int *a, int radix, int *size)
     }
 
     /* digs is the digit count */
-    digs = 1;
+    digs = 0;
 
     /* if it's negative add one for the sign */
     if (a->sign == MP_NEG) {
@@ -5266,6 +5266,13 @@ int mp_radix_size (mp_int *a, int radix, int *size)
         ++digs;
     }
     mp_clear (&t);
+
+#ifndef WC_DISABLE_RADIX_ZERO_PAD
+    /* For hexadecimal output, add zero padding when number of digits is odd */
+    if ((digs & 1) && (radix == 16)) {
+        ++digs;
+    }
+#endif
 
     /* return digs + 1, the 1 is for the NULL byte that would be required. */
     *size = digs + 1;

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5453,11 +5453,6 @@ int mp_radix_size (mp_int *a, int radix, int *size)
     /* digs is the digit count */
     digs = 0;
 
-    /* if it's negative add one for the sign */
-    if (a->sign == FP_NEG) {
-        ++digs;
-    }
-
 #ifdef WOLFSSL_SMALL_STACK
     t = (fp_int*)XMALLOC(sizeof(fp_int), NULL, DYNAMIC_TYPE_BIGINT);
     if (t == NULL)
@@ -5485,10 +5480,15 @@ int mp_radix_size (mp_int *a, int radix, int *size)
 
 #ifndef WC_DISABLE_RADIX_ZERO_PAD
     /* For hexadecimal output, add zero padding when number of digits is odd */
-    if (((a->sign == FP_NEG) ? !(digs & 1) : (digs & 1)) && (radix == 16)) {
+    if ((digs & 1) && (radix == 16)) {
         ++digs;
     }
 #endif
+
+    /* if it's negative add one for the sign */
+    if (a->sign == FP_NEG) {
+        ++digs;
+    }
 
     /* return digs + 1, the 1 is for the NULL byte that would be required. */
     *size = digs + 1;

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5485,7 +5485,7 @@ int mp_radix_size (mp_int *a, int radix, int *size)
 
 #ifndef WC_DISABLE_RADIX_ZERO_PAD
     /* For hexadecimal output, add zero padding when number of digits is odd */
-    if ((digs & 1) && (radix == 16)) {
+    if (((a->sign == FP_NEG) ? !(digs & 1) : (digs & 1)) && (radix == 16)) {
         ++digs;
     }
 #endif

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5451,7 +5451,7 @@ int mp_radix_size (mp_int *a, int radix, int *size)
     }
 
     /* digs is the digit count */
-    digs = 1;
+    digs = 0;
 
     /* if it's negative add one for the sign */
     if (a->sign == FP_NEG) {
@@ -5482,6 +5482,13 @@ int mp_radix_size (mp_int *a, int radix, int *size)
         ++digs;
     }
     fp_zero (t);
+
+#ifndef WC_DISABLE_RADIX_ZERO_PAD
+    /* For hexadecimal output, add zero padding when number of digits is odd */
+    if ((digs & 1) && (radix == 16)) {
+        ++digs;
+    }
+#endif
 
     /* return digs + 1, the 1 is for the NULL byte that would be required. */
     *size = digs + 1;

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5451,7 +5451,7 @@ int mp_radix_size (mp_int *a, int radix, int *size)
     }
 
     /* digs is the digit count */
-    digs = 0;
+    digs = 1;
 
     /* if it's negative add one for the sign */
     if (a->sign == FP_NEG) {


### PR DESCRIPTION
The 'size' set by `mp_radix_size` should conditionally add one when WC_DISABLE_RADIX_ZERO_PAD is defined and the zero padding would be added. This issue could lead to a buffer overflow when passed to `mp_toradix` (or other API allocating a buffer based on the size being string length + 1).

This issue was reported in ZD10901.