### PR TITLE
Fixes for Sniffer (Max Fragment, ECC Static and SNI)

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -2778,6 +2778,10 @@ static int ProcessServerHello(int msgSz, const byte* input, int* sslBytes,
                 session->sslServer->version.minor = input[1];
                 session->sslClient->version.major = input[0];
                 session->sslClient->version.minor = input[1];
+                if (IsAtLeastTLSv1_3(session->sslServer->version)) {
+                    /* The server side handshake encryption is on for future packets */
+                    session->flags.serverCipherOn = 1;
+                }
                 break;
             case EXT_MASTER_SECRET:
             #ifdef HAVE_EXTENDED_MASTER
@@ -3131,9 +3135,6 @@ static int ProcessClientHello(const byte* input, int* sslBytes,
                 break;
             }
             XMEMCPY(session->cliKeyShare, &input[2], ksLen);
-
-            /* The server side handshake encryption is on for future packets */
-            session->flags.serverCipherOn = 1;
             break;
         }
         #ifdef HAVE_SESSION_TICKET

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -3000,6 +3000,10 @@ static int ProcessClientHello(const byte* input, int* sslBytes,
             }
             wc_UnLockMutex(&session->context->namedKeysMutex);
         }
+        if (ret > 0) {
+            /* make sure WOLFSSL_SUCCESS is converted to zero error code */
+            ret = 0;
+        }
     }
 #endif
 

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -3442,6 +3442,8 @@ static int DoHandShake(const byte* input, int* sslBytes,
     int  ret = 0;
     WOLFSSL* ssl;
 
+    (void)rhSize;
+
 #ifdef HAVE_MAX_FRAGMENT
     if (session->tlsFragBuf) {
         XMEMCPY(session->tlsFragBuf + session->tlsFragOffset, input, rhSize);

--- a/sslSniffer/README.md
+++ b/sslSniffer/README.md
@@ -43,9 +43,9 @@ All options may be enabled with the following configure command line:
 
 ```sh
 ./configure --enable-sniffer \
-    CPPFLAGS=”-DWOLFSSL_SNIFFER_STATS -DWOLFSSL_SNIFFER_WATCH \
+    CPPFLAGS="-DWOLFSSL_SNIFFER_STATS -DWOLFSSL_SNIFFER_WATCH \
     -DWOLFSSL_SNIFFER_STORE_DATA_CB -DWOLFSSL_SNIFFER_CHAIN_INPUT \
-    -DSTARTTLS_ALLOWED”
+    -DSTARTTLS_ALLOWED"
 ```
 
 To add some other cipher support to the sniffer, you can add options like:

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -267,8 +267,11 @@ static int myWatchCb(void* vSniffer,
         certName = DEFAULT_SERVER_KEY_ECC;
     }
 
-    if (certName == NULL)
-        return -1;
+    if (certName == NULL) {
+        /* don't return error if key is not loaded */
+        printf("Warning: No matching key found for cert hash\n");
+        return 0;
+    }
 
     return ssl_SetWatchKey_file(vSniffer, certName, FILETYPE_PEM, NULL, error);
 }


### PR DESCRIPTION
* Fixes for sniffer when using static ECC keys. Adds back TLS v1.2 static ECC key fallback detection and fixes new ECC RNG requirement for timing resistance. ZD 10926
* Fix for sniffer with SNI enabled to properly handle WOLFSSL_SUCCESS error code in `ProcessClientHello`. ZD 10926
* Fix for sniffer using `HAVE_MAX_FRAGMENT` in "certificate" type message. ZD 10903
* Fix build error with unused "ret" when building with `WOLFSSL_SNIFFER_WATCH`.
* Fix to not treat cert/key not found as error in `myWatchCb` and `WOLFSSL_SNIFFER_WATCH`.
* Fixed bad characters in sniffer `README.md` configure example.
* Fix to free the wolfSSL objects first then wolfSSL_CTX.
* Added support for 802.11Q VLAN frames.