### PR TITLE
Fix Client Usage

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1310,7 +1310,9 @@ static void Usage(void)
     printf("%s", msg[++msgid]); /* -L <str> */
 #endif
     printf("%s", msg[++msgid]); /* -B <num> */
+#ifndef NO_PSK
     printf("%s", msg[++msgid]); /* -s */
+#endif
     printf("%s", msg[++msgid]); /* -d */
     printf("%s", msg[++msgid]); /* -D */
     printf("%s", msg[++msgid]); /* -e */


### PR DESCRIPTION
A string in the client's usage text was made optional depending on the NO_PSK option, but there was still an attempt to print it. This lead to a NULL being printed instead. Fixed the print statement.

To recreate:

    $ ./autogen.sh&&./configure&&make
    $ ./examples/client/client --help
    wolfSSL client 4.5.0 NOTE: All files relative to wolfSSL home dir
    Max RSA key size in bits for build is set at : 4096
    ...
    -Y          Key Share with ECC named groups only
    -1 <num>    Display a result by specified language.
                0: English, 1: Japanese
    -2          Disable DH Prime check
    (null)%

The string "(null)%" indicates the problem.