### PR TITLE
Added support for NXP DCP (i.MX-RT series)

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -7543,6 +7543,11 @@ int wc_AesInit(Aes* aes, void* heap, int devId)
 #if defined(WOLFSSL_CRYPTOCELL) && defined(WOLFSSL_CRYPTOCELL_AES)
     XMEMSET(&aes->ctx, 0, sizeof(aes->ctx));
 #endif
+#if defined(WOLFSSL_IMXRT_DCP)
+    DCPAesInit(aes);
+#endif
+
+
 #ifdef HAVE_AESGCM
 #ifdef OPENSSL_EXTRA
     XMEMSET(aes->aadH, 0, sizeof(aes->aadH));

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -58,6 +58,7 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/arm/armv8-sha512-asm.c \
               wolfcrypt/src/port/arm/armv8-32-sha512-asm.c \
               wolfcrypt/src/port/nxp/ksdk_port.c \
+              wolfcrypt/src/port/nxp/dcp_port.c \
               wolfcrypt/src/port/atmel/README.md \
               wolfcrypt/src/port/xilinx/xil-sha3.c \
               wolfcrypt/src/port/xilinx/xil-aesgcm.c \

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -1,0 +1,390 @@
+/* dcp_port.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+    
+#include <wolfssl/wolfcrypt/aes.h>
+#include <wolfssl/wolfcrypt/sha.h>
+#include <wolfssl/wolfcrypt/sha256.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#ifdef WOLFSSL_IMXRT_DCP
+
+#ifndef DCP_USE_OTP_KEY
+#define DCP_USE_OTP_KEY 0 /* Set to 1 to select OTP key for AES encryption/decryption. */
+#endif
+
+#include "fsl_device_registers.h"
+#include "fsl_debug_console.h"
+#include "fsl_dcp.h"
+
+
+static dcp_config_t dcpConfig;
+
+#if DCP_USE_OTP_KEY
+typedef enum _dcp_otp_key_select
+{
+    kDCP_OTPMKKeyLow  = 1U, /* Use [127:0] from snvs key as dcp key */
+    kDCP_OTPMKKeyHigh = 2U, /* Use [255:128] from snvs key as dcp key */
+    kDCP_OCOTPKeyLow  = 3U, /* Use [127:0] from ocotp key as dcp key */
+    kDCP_OCOTPKeyHigh = 4U  /* Use [255:128] from ocotp key as dcp key */
+} dcp_otp_key_select;
+#endif
+
+#if DCP_USE_OTP_KEY
+static status_t DCP_OTPKeySelect(dcp_otp_key_select keySelect)
+{
+    if (keySelect == kDCP_OTPMKKeyLow)
+    {
+        IOMUXC_GPR->GPR3 &= ~(1 << IOMUXC_GPR_GPR3_DCP_KEY_SEL_SHIFT);
+        IOMUXC_GPR->GPR10 &= ~(1 << IOMUXC_GPR_GPR10_DCPKEY_OCOTP_OR_KEYMUX_SHIFT);
+    }
+
+    else if (keySelect == kDCP_OTPMKKeyHigh)
+    {
+        IOMUXC_GPR->GPR3 |= (1 << IOMUXC_GPR_GPR3_DCP_KEY_SEL_SHIFT);
+        IOMUXC_GPR->GPR10 &= ~(1 << IOMUXC_GPR_GPR10_DCPKEY_OCOTP_OR_KEYMUX_SHIFT);
+    }
+
+    else if (keySelect == kDCP_OCOTPKeyLow)
+    {
+        IOMUXC_GPR->GPR3 &= ~(1 << IOMUXC_GPR_GPR3_DCP_KEY_SEL_SHIFT);
+        IOMUXC_GPR->GPR10 |= (1 << IOMUXC_GPR_GPR10_DCPKEY_OCOTP_OR_KEYMUX_SHIFT);
+    }
+
+    else if (keySelect == kDCP_OCOTPKeyHigh)
+    {
+        IOMUXC_GPR->GPR3 |= (1 << IOMUXC_GPR_GPR3_DCP_KEY_SEL_SHIFT);
+        IOMUXC_GPR->GPR10 |= (1 << IOMUXC_GPR_GPR10_DCPKEY_OCOTP_OR_KEYMUX_SHIFT);
+    }
+
+    else
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    return kStatus_Success;
+}
+#endif
+
+static void dcp_init(void)
+{
+    static int dcp_is_initialized = 0;
+    if (!dcp_is_initialized) {
+        /* Initialize DCP */
+        DCP_GetDefaultConfig(&dcpConfig);
+
+#if DCP_USE_OTP_KEY
+        /* Set OTP key type in IOMUX registers before initializing DCP. */
+        /* Software reset of DCP must be issued after changing the OTP key type. */
+        DCP_OTPKeySelect(kDCP_OTPMKKeyLow);
+#endif
+
+        /* Reset and initialize DCP */
+        DCP_Init(DCP, &dcpConfig);
+        dcp_is_initialized++;
+    }
+}
+
+
+#ifndef NO_AES
+int  DCPAesSetKey(Aes* aes, const byte* key, word32 len, const byte* iv,
+                          int dir)
+{
+
+#if DCP_USE_OTP_KEY
+#warning Please update cipherAes128 variables to match expected AES ciphertext for your OTP key.
+#endif
+    status_t status;
+    if (!aes || !key)
+        return BAD_FUNC_ARG;
+
+    if (len != 16)
+        return BAD_FUNC_ARG; 
+
+    dcp_init();
+    XMEMSET(&aes->handle, 0, sizeof(aes->handle));
+    aes->handle.channel    = kDCP_Channel0;
+    aes->handle.swapConfig = kDCP_NoSwap;
+#if DCP_USE_OTP_KEY
+    aes->handle.keySlot = kDCP_OtpKey;
+#else
+    aes->handle.keySlot = kDCP_KeySlot0;
+#endif
+    status = DCP_AES_SetKey(DCP, &aes->handle, key, 16);
+    if (status != kStatus_Success)
+        return WC_HW_E;
+    if (iv)
+        XMEMCPY(aes->reg, iv, 16);
+    else
+        XMEMSET(aes->reg, 0, 16);
+    return 0;
+}
+
+int  DCPAesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    int ret;
+    if (sz % 16)
+        return BAD_FUNC_ARG;
+    ret = DCP_AES_EncryptCbc(DCP, &aes->handle, in, out, sz, (const byte *)aes->reg);
+    if (ret)
+        return WC_HW_E; 
+    XMEMCPY(aes->reg, out, AES_BLOCK_SIZE);
+    return ret;
+}
+
+int  DCPAesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    int ret;
+    if (sz % 16)
+        return BAD_FUNC_ARG;
+    ret = DCP_AES_DecryptCbc(DCP, &aes->handle, in, out, sz, (const byte *)aes->reg);
+    if (ret)
+        return WC_HW_E; 
+    XMEMCPY(aes->reg, in, AES_BLOCK_SIZE);
+    return ret;
+}
+
+int  DCPAesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    return DCP_AES_EncryptEcb(DCP, &aes->handle, in, out, sz);
+}
+
+int  DCPAesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    return DCP_AES_DecryptEcb(DCP, &aes->handle, in, out, sz);
+}
+
+#endif
+
+#ifndef NO_SHA256
+int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
+{
+    int ret;
+    if (sha256 == NULL)
+        return BAD_FUNC_ARG;
+    dcp_init();
+    (void)devId;
+    XMEMSET(sha256, 0, sizeof(wc_Sha256));
+    sha256->handle.channel    = kDCP_Channel0;
+    sha256->handle.keySlot    = kDCP_KeySlot0;
+    sha256->handle.swapConfig = kDCP_NoSwap;
+    ret = DCP_HASH_Init(DCP, &sha256->handle, &sha256->ctx, kDCP_Sha256);
+    if (ret != kStatus_Success)
+        return WC_HW_E;
+    return ret;
+}
+
+int wc_InitSha256(wc_Sha256* sha256)
+{
+    return wc_InitSha256_ex(sha256, NULL, INVALID_DEVID);
+}
+
+void wc_Sha256Free(wc_Sha256* sha256)
+{
+    (void)sha256;
+}
+
+int wc_Sha256Update(wc_Sha256* sha256, const byte* data, word32 len)
+{
+    int ret;
+    if (sha256 == NULL || (data == NULL && len != 0)) {
+        return BAD_FUNC_ARG;
+    }
+    ret = DCP_HASH_Update(DCP, &sha256->ctx, data, len);
+    if (ret != kStatus_Success)
+        return WC_HW_E;
+    return ret;
+}
+
+
+int wc_Sha256GetHash(wc_Sha256* sha256, byte* hash)
+{
+    int ret;
+    size_t outlen = WC_SHA256_DIGEST_SIZE;
+    dcp_hash_ctx_t saved_ctx;
+    if (sha256 == NULL || hash == NULL)
+        return BAD_FUNC_ARG;
+    XMEMCPY(&saved_ctx, &sha256->ctx, sizeof(dcp_hash_ctx_t));
+    XMEMSET(hash, 0, WC_SHA256_DIGEST_SIZE);
+    ret = DCP_HASH_Finish(DCP, &sha256->ctx, hash, &outlen);
+    if ((ret != kStatus_Success) || (outlen != SHA256_DIGEST_SIZE)) {
+        return WC_HW_E;
+    }
+    XMEMCPY(&sha256->ctx, &saved_ctx, sizeof(dcp_hash_ctx_t));
+    return 0;
+}
+
+int wc_Sha256Final(wc_Sha256* sha256, byte* hash)
+{
+    int ret;
+    size_t outlen = WC_SHA256_DIGEST_SIZE;
+    ret = DCP_HASH_Finish(DCP, &sha256->ctx, hash, &outlen);
+    if ((ret != kStatus_Success) || (outlen != SHA256_DIGEST_SIZE))
+        return WC_HW_E;
+    sha256->handle.channel    = kDCP_Channel0;
+    sha256->handle.keySlot    = kDCP_KeySlot0;
+    sha256->handle.swapConfig = kDCP_NoSwap;
+    ret = DCP_HASH_Init(DCP, &sha256->handle, &sha256->ctx, kDCP_Sha256);
+    if (ret < 0)
+        return WC_HW_E;
+    return ret;
+}
+
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+int wc_Sha256SetFlags(wc_Sha256* sha256, word32 flags)
+{
+    if (sha256) {
+        sha256->flags = flags;
+    }
+    return 0;
+}
+int wc_Sha256GetFlags(wc_Sha256* sha256, word32* flags)
+{
+    if (sha256 && flags) {
+        *flags = sha256->flags;
+    }
+    return 0;
+}
+#endif /* WOLFSSL_HASH_FLAGS || WOLF_CRYPTO_CB */
+
+int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
+{
+    if (src == NULL || dst == NULL)
+        return BAD_FUNC_ARG;
+    XMEMCPY(&dst->ctx, &src->ctx, sizeof(dcp_hash_ctx_t));
+    return 0;
+}
+#endif /* !NO_SHA256 */
+
+
+#ifndef NO_SHA
+
+int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
+{
+    int ret;
+    if (sha == NULL)
+        return BAD_FUNC_ARG;
+    dcp_init();
+    (void)devId;
+    XMEMSET(sha, 0, sizeof(wc_Sha));
+    sha->handle.channel    = kDCP_Channel0;
+    sha->handle.keySlot    = kDCP_KeySlot0;
+    sha->handle.swapConfig = kDCP_NoSwap;
+    ret = DCP_HASH_Init(DCP, &sha->handle, &sha->ctx, kDCP_Sha1);
+    if (ret != kStatus_Success)
+        return WC_HW_E;
+    return ret;
+}
+
+int wc_InitSha(wc_Sha* sha)
+{
+    return wc_InitSha_ex(sha, NULL, INVALID_DEVID);
+}
+
+void wc_ShaFree(wc_Sha* sha)
+{
+    (void)sha;
+}
+
+int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
+{
+    int ret;
+    if (sha == NULL || (data == NULL && len != 0)) {
+        return BAD_FUNC_ARG;
+    }
+    ret = DCP_HASH_Update(DCP, &sha->ctx, data, len);
+    if (ret != kStatus_Success)
+        return WC_HW_E;
+    return ret;
+}
+
+
+int wc_ShaGetHash(wc_Sha* sha, byte* hash)
+{
+    int ret;
+    size_t outlen = WC_SHA_DIGEST_SIZE;
+    dcp_hash_ctx_t saved_ctx;
+    if (sha == NULL || hash == NULL)
+        return BAD_FUNC_ARG;
+    XMEMCPY(&saved_ctx, &sha->ctx, sizeof(dcp_hash_ctx_t));
+    XMEMSET(hash, 0, WC_SHA_DIGEST_SIZE);
+    ret = DCP_HASH_Finish(DCP, &sha->ctx, hash, &outlen);
+    if ((ret != kStatus_Success) || (outlen != WC_SHA_DIGEST_SIZE)) {
+        return WC_HW_E;
+    }
+    XMEMCPY(&sha->ctx, &saved_ctx, sizeof(dcp_hash_ctx_t));
+    return 0;
+}
+
+int wc_ShaFinal(wc_Sha* sha, byte* hash)
+{
+    int ret;
+    size_t outlen = WC_SHA_DIGEST_SIZE;
+    ret = DCP_HASH_Finish(DCP, &sha->ctx, hash, &outlen);
+    if ((ret != kStatus_Success) || (outlen != SHA_DIGEST_SIZE))
+        return WC_HW_E;
+    sha->handle.channel    = kDCP_Channel0;
+    sha->handle.keySlot    = kDCP_KeySlot0;
+    sha->handle.swapConfig = kDCP_NoSwap;
+    ret = DCP_HASH_Init(DCP, &sha->handle, &sha->ctx, kDCP_Sha1);
+    if (ret < 0)
+        return WC_HW_E;
+    return ret;
+}
+
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+int wc_ShaSetFlags(wc_Sha* sha, word32 flags)
+{
+    if (sha) {
+        sha->flags = flags;
+    }
+    return 0;
+}
+int wc_ShaGetFlags(wc_Sha* sha, word32* flags)
+{
+    if (sha && flags) {
+        *flags = sha->flags;
+    }
+    return 0;
+}
+#endif /* WOLFSSL_HASH_FLAGS || WOLF_CRYPTO_CB */
+
+int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
+{
+    if (src == NULL || dst == NULL)
+        return BAD_FUNC_ARG;
+    XMEMCPY(&dst->ctx, &src->ctx, sizeof(dcp_hash_ctx_t));
+    return 0;
+}
+#endif /* !NO_SHA */
+
+#endif /* WOLFSSL_IMXRT_DCP */

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -328,6 +328,9 @@
 
     /* implemented in wolfcrypt/src/port/Renesas/renesas_tsip_sha.c */
 
+#elif defined(WOLFSSL_IMXRT_DCP)
+    /* implemented in wolfcrypt/src/port/nxp/dcp_port.c */
+
 #else
     /* Software implementation */
     #define USE_SHA_SOFTWARE_IMPL

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -797,6 +797,9 @@ void wc_ShaFree(wc_Sha* sha)
         sha->msg = NULL;
     }
 #endif
+#ifdef WOLFSSL_IMXRT_DCP
+    DCPShaFree(sha);
+#endif
 }
 
 #endif /* !WOLFSSL_TI_HASH */

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -179,7 +179,7 @@ where 0 <= L < 2^64.
     !defined(WOLFSSL_AFALG_HASH) && !defined(WOLFSSL_DEVCRYPTO_HASH) && \
     (!defined(WOLFSSL_ESP32WROOM32_CRYPT) || defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)) && \
     (!defined(WOLFSSL_RENESAS_TSIP_CRYPT) || defined(NO_WOLFSSL_RENESAS_TSIP_HASH)) && \
-    !defined(WOLFSSL_PSOC6_CRYPTO)
+    !defined(WOLFSSL_PSOC6_CRYPTO) && !defined(WOLFSSL_IMXRT_DCP)
 
 static int InitSha256(wc_Sha256* sha256)
 {
@@ -685,6 +685,10 @@ static int InitSha256(wc_Sha256* sha256)
 #elif defined(WOLFSSL_PSOC6_CRYPTO)
 
     /* implemented in wolfcrypt/src/port/cypress/psoc6_crypto.c */
+
+#elif defined(WOLFSSL_IMXRT_DCP)
+    #include <wolfssl/wolfcrypt/port/nxp/dcp_port.h>
+    /* implemented in wolfcrypt/src/port/nxp/dcp_port.c */
 
 #else
     #define NEED_SOFT_SHA256
@@ -1582,6 +1586,8 @@ void wc_Sha256Free(wc_Sha256* sha256)
 
     /* implemented in wolfcrypt/src/port/Renesas/renesas_tsip_sha.c */
 #elif defined(WOLFSSL_PSOC6_CRYPTO)
+    /* implemented in wolfcrypt/src/port/cypress/psoc6_crypto.c */
+#elif defined(WOLFSSL_IMXRT_DCP)
     /* implemented in wolfcrypt/src/port/cypress/psoc6_crypto.c */
 #else
 

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1511,6 +1511,9 @@ void wc_Sha256Free(wc_Sha256* sha256)
         sha256->msg = NULL;
     }
 #endif
+#ifdef WOLFSSL_IMXRT_DCP
+    DCPSha256Free(sha256);
+#endif
 }
 
 #endif /* !WOLFSSL_TI_HASH */

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -62,6 +62,10 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
     #include <wolfssl/wolfcrypt/port/st/stm32.h>
 #endif
 
+#ifdef WOLFSSL_IMXRT_DCP
+    #include "fsl_dcp.h"
+#endif
+
 #ifdef WOLFSSL_AESNI
 
 #include <wmmintrin.h>
@@ -233,6 +237,9 @@ struct Aes {
 #if defined(WOLFSSL_RENESAS_TSIP_TLS) && \
     defined(WOLFSSL_RENESAS_TSIP_TLS_AES_CRYPT)
     TSIP_AES_CTX ctx;
+#endif
+#if defined(WOLFSSL_IMXRT_DCP)
+    dcp_handle_t handle;
 #endif
     void*  heap; /* memory hint to use */
 };

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -74,6 +74,7 @@ noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/ti/ti-ccm.h \
                          wolfssl/wolfcrypt/port/nrf51.h \
                          wolfssl/wolfcrypt/port/nxp/ksdk_port.h \
+                         wolfssl/wolfcrypt/port/nxp/dcp_port.h \
                          wolfssl/wolfcrypt/port/xilinx/xil-sha3.h \
                          wolfssl/wolfcrypt/port/caam/caam_driver.h \
                          wolfssl/wolfcrypt/port/caam/wolfcaam.h \

--- a/wolfssl/wolfcrypt/port/nxp/dcp_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/dcp_port.h
@@ -1,0 +1,65 @@
+/* dcp_port.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+#ifndef _DCP_PORT_H_
+#define _DCP_PORT_H_
+
+#include <wolfssl/wolfcrypt/settings.h>
+#ifdef USE_FAST_MATH
+    #include <wolfssl/wolfcrypt/tfm.h>
+#elif defined WOLFSSL_SP_MATH
+    #include <wolfssl/wolfcrypt/sp_int.h>
+#else
+    #include <wolfssl/wolfcrypt/integer.h>
+#endif
+
+#include <wolfssl/wolfcrypt/aes.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#include "fsl_device_registers.h"
+#include "fsl_debug_console.h"
+#include "fsl_dcp.h"
+
+int  DCPAesSetKey(Aes* aes, const byte* key, word32 len, const byte* iv,
+                          int dir);
+int  DCPAesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+int  DCPAesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+
+#ifdef HAVE_AES_ECB
+int  DCPAesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+int  DCPAesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+#endif
+
+#ifndef NO_SHA256
+typedef struct wc_Sha256_DCP {
+    dcp_handle_t handle;
+    dcp_hash_ctx_t ctx;
+} wc_Sha256;
+#define WC_SHA256_TYPE_DEFINED
+#endif
+
+#ifndef NO_SHA
+typedef struct wc_Sha_DCP {
+    dcp_handle_t handle;
+    dcp_hash_ctx_t ctx;
+} wc_Sha;
+#define WC_SHA_TYPE_DEFINED
+#endif
+
+#endif

--- a/wolfssl/wolfcrypt/port/nxp/dcp_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/dcp_port.h
@@ -36,6 +36,7 @@
 #include "fsl_debug_console.h"
 #include "fsl_dcp.h"
 
+int  DCPAesInit(Aes* aes);
 int  DCPAesSetKey(Aes* aes, const byte* key, word32 len, const byte* iv,
                           int dir);
 int  DCPAesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
@@ -52,6 +53,9 @@ typedef struct wc_Sha256_DCP {
     dcp_hash_ctx_t ctx;
 } wc_Sha256;
 #define WC_SHA256_TYPE_DEFINED
+
+void DCPSha256Free(wc_Sha256 *sha256);
+
 #endif
 
 #ifndef NO_SHA
@@ -60,6 +64,8 @@ typedef struct wc_Sha_DCP {
     dcp_hash_ctx_t ctx;
 } wc_Sha;
 #define WC_SHA_TYPE_DEFINED
+
+void DCPShaFree(wc_Sha *sha);
 #endif
 
 #endif

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -72,6 +72,9 @@
 #ifdef WOLFSSL_ESP32WROOM32_CRYPT
     #include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
 #endif
+#ifdef WOLFSSL_IMXRT_DCP
+    #include <wolfssl/wolfcrypt/port/nxp/dcp_port.h>
+#endif
 
 #if !defined(NO_OLD_SHA_NAMES)
     #define SHA             WC_SHA

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -128,6 +128,8 @@ enum {
     #include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
 #elif defined(WOLFSSL_PSOC6_CRYPTO)
     #include "wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h"
+#elif defined(WOLFSSL_IMXRT_DCP)
+    #include <wolfssl/wolfcrypt/port/nxp/dcp_port.h>
 #else
 
 /* wc_Sha256 digest */


### PR DESCRIPTION
Added support for NXP DCP crypto co-processor.

Supports: 
- AES-128 (CBC and ECB)
- SHA1
- SHA256

All wolfcrypt/test passing.

Benchmark results:

without DCP:
```
wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
------------------------------------------------------------------------------
 wolfSSL version 4.5.0
------------------------------------------------------------------------------
wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
RNG                100 KB took 1.168 seconds,   85.616 KB/s
AES-128-CBC-enc     10 MB took 1.002 seconds,    9.844 MB/s
AES-128-CBC-dec      9 MB took 1.001 seconds,    9.219 MB/s
AES-192-CBC-enc      9 MB took 1.001 seconds,    8.732 MB/s
AES-192-CBC-dec      8 MB took 1.001 seconds,    8.195 MB/s
AES-256-CBC-enc      8 MB took 1.000 seconds,    7.837 MB/s
AES-256-CBC-dec      7 MB took 1.000 seconds,    7.397 MB/s
AES-128-GCM-enc      2 MB took 1.008 seconds,    2.180 MB/s
AES-128-GCM-dec      2 MB took 1.010 seconds,    2.176 MB/s
AES-192-GCM-enc      2 MB took 1.004 seconds,    2.091 MB/s
AES-192-GCM-dec      2 MB took 1.005 seconds,    2.089 MB/s
AES-256-GCM-enc      2 MB took 1.008 seconds,    2.010 MB/s
AES-256-GCM-dec      2 MB took 1.009 seconds,    2.008 MB/s
AES-128-ECB-enc     10 MB took 1.000 seconds,   10.385 MB/s
AES-128-ECB-dec     10 MB took 1.000 seconds,   10.058 MB/s
AES-192-ECB-enc      9 MB took 1.000 seconds,    9.114 MB/s
AES-192-ECB-dec      9 MB took 1.000 seconds,    8.855 MB/s
AES-256-ECB-enc      8 MB took 1.000 seconds,    8.148 MB/s
AES-256-ECB-dec      8 MB took 1.000 seconds,    7.933 MB/s
CHACHA              26 MB took 1.000 seconds,   26.025 MB/s
MD5                 79 MB took 1.000 seconds,   79.321 MB/s
SHA                 37 MB took 1.000 seconds,   37.109 MB/s
SHA-256             22 MB took 1.000 seconds,   22.021 MB/s
SHA-512              8 MB took 1.002 seconds,    7.943 MB/s
SHA3-224             9 MB took 1.001 seconds,    8.975 MB/s
SHA3-256             8 MB took 1.001 seconds,    8.463 MB/s
SHA3-384             7 MB took 1.000 seconds,    6.519 MB/s
SHA3-512             5 MB took 1.003 seconds,    4.552 MB/s
HMAC-MD5            77 MB took 1.000 seconds,   76.880 MB/s
HMAC-SHA            36 MB took 1.000 seconds,   36.035 MB/s
HMAC-SHA256         22 MB took 1.001 seconds,   21.658 MB/s
HMAC-SHA512          8 MB took 1.002 seconds,    7.797 MB/s
PBKDF2               2 KB took 1.004 seconds,    1.587 KB/s
RSA     2048 public        222 ops took 1.008 sec, avg 4.541 ms, 220.238 ops/sec
RSA     2048 private         4 ops took 1.327 sec, avg 331.750 ms, 3.014 ops/sec
ECC      256 key gen       630 ops took 1.000 sec, avg 1.587 ms, 630.000 ops/sec
ECDHE    256 agree         284 ops took 1.000 sec, avg 3.521 ms, 284.000 ops/sec
ECDSA    256 sign          408 ops took 1.002 sec, avg 2.456 ms, 407.186 ops/sec
ECDSA    256 verify        194 ops took 1.004 sec, avg 5.175 ms, 193.227 ops/sec
ED     25519 key gen        20 ops took 1.005 sec, avg 50.250 ms, 19.900 ops/sec
ED     25519 sign           20 ops took 1.025 sec, avg 51.250 ms, 19.512 ops/sec
ED     25519 verify         10 ops took 1.055 sec, avg 105.500 ms, 9.479 ops/sec
Benchmark complete
```

with DCP:
```
wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
------------------------------------------------------------------------------
 wolfSSL version 4.5.0
------------------------------------------------------------------------------
wolfCrypt Benchmark (block bytes 1024, min 1.0 sec each)
RNG                100 KB took 1.167 seconds,   85.690 KB/s
AES-128-CBC-enc     66 MB took 1.001 seconds,   66.169 MB/s
AES-128-CBC-dec     66 MB took 1.000 seconds,   66.138 MB/s
AES-192-CBC-enc      9 MB took 1.001 seconds,    8.732 MB/s
AES-192-CBC-dec      8 MB took 1.001 seconds,    8.219 MB/s
AES-256-CBC-enc      8 MB took 1.002 seconds,    7.846 MB/s
AES-256-CBC-dec      7 MB took 1.001 seconds,    7.414 MB/s
AES-128-GCM-enc      3 MB took 1.001 seconds,    2.634 MB/s
AES-128-GCM-dec      3 MB took 1.006 seconds,    2.621 MB/s
AES-192-GCM-enc      2 MB took 1.004 seconds,    2.091 MB/s
AES-192-GCM-dec      2 MB took 1.003 seconds,    2.093 MB/s
AES-256-GCM-enc      2 MB took 1.007 seconds,    2.012 MB/s
AES-256-GCM-dec      2 MB took 1.007 seconds,    2.012 MB/s
AES-128-ECB-enc     10 MB took 1.000 seconds,   10.105 MB/s
AES-128-ECB-dec     10 MB took 1.000 seconds,   10.308 MB/s
AES-192-ECB-enc      9 MB took 1.000 seconds,    8.932 MB/s
AES-192-ECB-dec      9 MB took 1.000 seconds,    9.045 MB/s
AES-256-ECB-enc      8 MB took 1.000 seconds,    8.024 MB/s
AES-256-ECB-dec      8 MB took 1.000 seconds,    8.064 MB/s
CHACHA              26 MB took 1.000 seconds,   26.050 MB/s
MD5                 83 MB took 1.000 seconds,   82.837 MB/s
SHA                 80 MB took 1.000 seconds,   79.663 MB/s
SHA-256            104 MB took 1.000 seconds,  104.150 MB/s
SHA-512              8 MB took 1.002 seconds,    7.967 MB/s
SHA3-224             9 MB took 1.002 seconds,    8.966 MB/s
SHA3-256             8 MB took 1.001 seconds,    8.463 MB/s
SHA3-384             7 MB took 1.000 seconds,    6.519 MB/s
SHA3-512             5 MB took 1.003 seconds,    4.552 MB/s
HMAC-MD5            82 MB took 1.000 seconds,   81.763 MB/s
HMAC-SHA            86 MB took 1.000 seconds,   85.962 MB/s
HMAC-SHA256        101 MB took 1.000 seconds,  101.465 MB/s
HMAC-SHA512          8 MB took 1.002 seconds,    7.846 MB/s
PBKDF2               5 KB took 1.006 seconds,    4.846 KB/s
RSA     2048 public        220 ops took 1.000 sec, avg 4.545 ms, 220.000 ops/sec
RSA     2048 private         4 ops took 1.327 sec, avg 331.750 ms, 3.014 ops/sec
ECC      256 key gen       630 ops took 1.000 sec, avg 1.587 ms, 630.000 ops/sec
ECDHE    256 agree         286 ops took 1.001 sec, avg 3.500 ms, 285.714 ops/sec
ECDSA    256 sign          414 ops took 1.000 sec, avg 2.415 ms, 414.000 ops/sec
ECDSA    256 verify        196 ops took 1.007 sec, avg 5.138 ms, 194.638 ops/sec
ED     25519 key gen        20 ops took 1.005 sec, avg 50.250 ms, 19.900 ops/sec
ED     25519 sign           20 ops took 1.024 sec, avg 51.200 ms, 19.531 ops/sec
ED     25519 verify         10 ops took 1.056 sec, avg 105.600 ms, 9.470 ops/sec
Benchmark complete
```
