### PR TITLE
Fix for FIPS MISSING_RNG_E

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3876,7 +3876,10 @@ static int wc_ecc_shared_secret_gen_sync(ecc_key* private_key, ecc_point* point,
             return MEMORY_E;
         }
 
-#ifdef ECC_TIMING_RESISTANT
+#if defined(ECC_TIMING_RESISTANT) && (!defined(HAVE_FIPS) || \
+    (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2))) && \
+    !defined(HAVE_SELFTEST)
+
         if (private_key->rng == NULL) {
             err = MISSING_RNG_E;
         }


### PR DESCRIPTION
ZD#10957:
- Add missing preprocessor directives for FIPS. 

Issue reported on wolfssl-4.5.0-gplv3-fips-ready release with FIPS DTLS Windows 10 target returning -236 error (MISSING_RNG_E) from EccSharedSecret during the DTLS handshake.