### PR TITLE
STM32 Cube Pack and AES GCM improvements

### DIFF
--- a/IDE/STM32Cube/README.md
+++ b/IDE/STM32Cube/README.md
@@ -87,6 +87,47 @@ Please select one of the above options:
 
 See [STM32_Benchmarks.md](STM32_Benchmarks.md).
 
+## STM32 Printf
+
+In main.c make the following changes:
+
+```
+/* Retargets the C library printf function to the USART. */
+#include <stdio.h>
+#include <wolfssl/wolfcrypt/settings.h>
+#ifdef __GNUC__
+int __io_putchar(int ch)
+#else
+int fputc(int ch, FILE *f)
+#endif
+{
+    HAL_UART_Transmit(&HAL_CONSOLE_UART, (uint8_t *)&ch, 1, 0xFFFF);
+
+    return ch;
+}
+#ifdef __GNUC__
+int _write(int file,char *ptr, int len)
+{
+    int DataIdx;
+    for (DataIdx= 0; DataIdx< len; DataIdx++) {
+        __io_putchar(*ptr++);
+    }
+    return len;
+}
+#endif
+
+int main(void)
+{
+    /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
+    HAL_Init();
+
+    /* Turn off buffers, so I/O occurs immediately */
+    setvbuf(stdin, NULL, _IONBF, 0);
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
+```
+
 ## Support
 
 For questions please email [support@wolfssl.com](mailto:support@wolfssl.com)

--- a/IDE/STM32Cube/README.md
+++ b/IDE/STM32Cube/README.md
@@ -14,8 +14,13 @@ These examples use the Cube HAL for STM32.
 
 ## Configuration
 
-The settings for the wolfSTM32 project are located in `<wolfssl-root>/IDE/STM32Cube/wolfSSL.wolfSSL_conf.h`. The section for "Hardware platform" may need to be adjusted depending on your processor and board:
+The settings for the wolfSSL CubeMX pack are in the generated `wolfSSL.wolfSSL_conf.h` file. An example of this is located in `IDE/STM32Cube/wolfSSL_conf.h` (renamed to avoid possible conflicts with generated file).
 
+The template used for generation is `IDE/STM32Cube/default_conf.ftl` which can be updated at `STM32Cube/Repository/Packs/wolfSSL/wolfSSL/[Version]/CubeMX/templates/default_conf.ftl`.
+
+The section for "Hardware platform" may need to be adjusted depending on your processor and board:
+
+* To enable STM32F1 support define `WOLFSSL_STM32F1`.
 * To enable STM32F2 support define `WOLFSSL_STM32F2`.
 * To enable STM32F4 support define `WOLFSSL_STM32F4`.
 * To enable STM32F7 support define `WOLFSSL_STM32F7`.
@@ -39,7 +44,7 @@ If you'd like to use the older Standard Peripheral library undefine `WOLFSSL_STM
 
 If you are using FreeRTOS make sure your `FreeRTOSConfig.h` has its `configTOTAL_HEAP_SIZE` increased.
 
-The TLS client/server benchmark example requires about 76 KB for allocated tasks (with stack) and peak heap.
+The TLS client/server benchmark example requires about 76 KB for allocated tasks (with stack) and peak heap. This uses both a TLS client and server to test a TLS connection locally for each enabled TLS cipher suite.
 
 ## STM32 Cube Pack
 
@@ -49,6 +54,7 @@ The TLS client/server benchmark example requires about 76 KB for allocated tasks
 2. Run the “STM32CubeMX” tool.
 3. Under “Manage software installations” click “INSTALL/REMOVE” button.
 4. From Local and choose “I-CUBE-WOLFSSL-WOLFSSL.pack”.
+5. Accept the GPLv2 license. Contact wolfSSL at sales@wolfssl.com for a commercial license and support/maintenance.
 
 ### STM32 Cube Pack Usage
 
@@ -56,9 +62,10 @@ The TLS client/server benchmark example requires about 76 KB for allocated tasks
 2. Under “Software Packs” choose “Select Components”.
 3. Find and check all components for the wolfSSL.wolfSSL packs (wolfSSL / Core, wolfCrypt / Core and wolfCrypt / Test). Close
 4. Under the “Software Packs” section click on “wolfSSL.wolfSSL” and configure the parameters.
-5. For Cortex-M recommend “Math Configuration” -> “Single Precision Cortex-M Math”
+5. For Cortex-M recommend “Math Configuration” -> “Single Precision Cortex-M Math” for the fastest option.
 6. Generate Code
 7. The Benchmark example uses float. To enable go to "Project Properties" -> "C/C++ Build" -> "Settings" -> "Tool Settings" -> "MCU Settings" -> Check "Use float with printf".
+8. To enable printf make the `main.c` changes below in the [STM32 Printf](#stm32-printf) section.
 
 ### STM32 Cube Pack Examples
 
@@ -86,6 +93,8 @@ Please select one of the above options:
 ## Benchmarks
 
 See [STM32_Benchmarks.md](STM32_Benchmarks.md).
+
+Note: The Benchmark example uses float. To enable go to "Project Properties" -> "C/C++ Build" -> "Settings" -> "Tool Settings" -> "MCU Settings" -> Check "Use float with printf".
 
 ## STM32 Printf
 

--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -1,119 +1,63 @@
-/* wolfSSL.wolfSSL_conf.h
- *
- * Copyright (C) 2006-2020 wolfSSL Inc.
- *
- * This file is part of wolfSSL.
- *
- * wolfSSL is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * wolfSSL is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
- */
-
-/* STM32 Cube Configuration File 
- * Included automatically when USE_HAL_DRIVER is defined 
- * (and not WOLFSSL_USER_SETTINGS or HAVE_CONF_H).
- * 
- * Generated automatically using `default_conf.ftl` template
- */
-
-#ifndef __WOLFSSL_WOLFSSL_CONF_H__
-#define __WOLFSSL_WOLFSSL_CONF_H__
+[#ftl]
+/**
+  ******************************************************************************
+  * File Name          : ${name}
+  * Description        : This file provides code for the configuration
+  *                      of the ${name} instances.
+  ******************************************************************************
+[@common.optinclude name=mxTmpFolder+"/license.tmp"/][#--include License text --]
+  ******************************************************************************
+  */
+[#assign s = name]
+[#assign toto = s?replace(".","_")]
+[#assign toto = toto?replace("/","")]
+[#assign inclusion_protection = toto?upper_case]
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __${inclusion_protection}__
+#define __${inclusion_protection}__
 
 #ifdef __cplusplus
-extern "C" {
+ extern "C" {
 #endif
 
-/*---------- Debug Support -----------*/
-#define WOLF_CONF_DEBUG      0 
- 
-/*---------- wolfCrypt Only -----------*/
-#define WOLF_CONF_WOLFCRYPT_ONLY      0 
- 
-/*---------- TLS v1.3 -----------*/
-#define WOLF_CONF_TLS13      1 
- 
-/*---------- TLS v1.2 -----------*/
-#define WOLF_CONF_TLS12      1 
- 
-/*---------- DTLS Support -----------*/
-#define WOLF_CONF_DTLS      0 
- 
-/*---------- Math Configuration -----------*/
-#define WOLF_CONF_MATH      4 
- 
-/*---------- RTOS -----------*/
-#define WOLF_CONF_RTOS      2 
- 
-/*---------- RSA Support -----------*/
-#define WOLF_CONF_RSA      1 
- 
-/*---------- ECC Support -----------*/
-#define WOLF_CONF_ECC      1 
- 
-/*---------- DH (Diffie–Hellman) Support -----------*/
-#define WOLF_CONF_DH      1 
- 
-/*---------- AES GCM Support -----------*/
-#define WOLF_CONF_AESGCM      1 
- 
-/*---------- AES CBC Support -----------*/
-#define WOLF_CONF_AESCBC      0 
- 
-/*---------- ChaCha20 / Poly1305 Support -----------*/
-#define WOLF_CONF_CHAPOLY      1 
- 
-/*---------- Ed25519 / Curve25519 Support -----------*/
-#define WOLF_CONF_EDCURVE25519      0 
- 
-/*---------- MD5 Support -----------*/
-#define WOLF_CONF_MD5      0 
- 
-/*---------- SHA1 Support -----------*/
-#define WOLF_CONF_SHA1      0 
- 
-/*---------- SHA2-224 Support -----------*/
-#define WOLF_CONF_SHA2_224      0 
- 
-/*---------- SHA2-256 Support -----------*/
-#define WOLF_CONF_SHA2_256      1 
- 
-/*---------- SHA2-384 Support -----------*/
-#define WOLF_CONF_SHA2_384      0 
- 
-/*---------- SHA2-512 Support -----------*/
-#define WOLF_CONF_SHA2_512      0 
- 
-/*---------- SHA3 Support -----------*/
-#define WOLF_CONF_SHA3      0 
- 
-/*---------- Pre-Shared-Key Support -----------*/
-#define WOLF_CONF_PSK      0 
- 
-/*---------- Pwd Based Key Derivation Support -----------*/
-#define WOLF_CONF_PWDBASED      0 
- 
-/*---------- Keep Peer Cert Support -----------*/
-#define WOLF_CONF_KEEP_PEER_CERT      0 
- 
-/*---------- Base64 Encode Support -----------*/
-#define WOLF_CONF_BASE64_ENCODE      0 
- 
-/*---------- OpenSSL Extra Support -----------*/
-#define WOLF_CONF_OPENSSL_EXTRA      0 
- 
-/*---------- wolfCrypt test/benchmark -----------*/
-#define WOLF_CONF_TEST      1 
- 
+/* Includes ------------------------------------------------------------------*/
+[#if includes??]
+[#list includes as include]
+#include "${include}"
+[/#list]
+[/#if]
+
+[#-- SWIPdatas is a list of SWIPconfigModel --]  
+[#list SWIPdatas as SWIP]  
+[#-- Global variables --]
+[#if SWIP.variables??]
+	[#list SWIP.variables as variable]
+extern ${variable.value} ${variable.name};
+	[/#list]
+[/#if]
+
+[#-- Global variables --]
+
+[#assign instName = SWIP.ipName]   
+[#assign fileName = SWIP.fileName]   
+[#assign version = SWIP.version]   
+
+/**
+	MiddleWare name : ${instName}
+	MiddleWare fileName : ${fileName}
+	MiddleWare version : ${version}
+*/
+[#if SWIP.defines??]
+	[#list SWIP.defines as definition]	
+/*---------- [#if definition.comments??]${definition.comments}[/#if] -----------*/
+#define ${definition.name} #t#t ${definition.value} 
+[#if definition.description??]${definition.description} [/#if]
+	[/#list]
+[/#if]
+
+
+
+[/#list]
 
 /* ------------------------------------------------------------------------- */
 /* Hardware platform */
@@ -182,6 +126,7 @@ extern "C" {
     #define HAL_CONSOLE_UART huart4
 #endif
 
+
 /* ------------------------------------------------------------------------- */
 /* Platform */
 /* ------------------------------------------------------------------------- */
@@ -193,6 +138,7 @@ extern "C" {
 #define WOLFSSL_NO_SOCK
 #define WOLFSSL_IGNORE_FILE_WARN
 
+
 /* ------------------------------------------------------------------------- */
 /* Operating System */
 /* ------------------------------------------------------------------------- */
@@ -201,6 +147,7 @@ extern "C" {
 #else
     #define SINGLE_THREADED
 #endif
+
 
 /* ------------------------------------------------------------------------- */
 /* Math Configuration */
@@ -235,6 +182,7 @@ extern "C" {
     #endif
 #endif
 
+
 /* ------------------------------------------------------------------------- */
 /* Enable Features */
 /* ------------------------------------------------------------------------- */
@@ -257,7 +205,7 @@ extern "C" {
 #if defined(WOLF_CONF_PWDBASED) && WOLF_CONF_PWDBASED == 0
     #define NO_PWDBASED
 #endif
-#if defined(WOLF_CONF_KEEPPEERCERT) && WOLF_CONF_KEEPPEERCERT == 1
+#if defined(WOLF_CONF_KEEP_PEER_CERT) && WOLF_CONF_KEEP_PEER_CERT == 1
     #define KEEP_PEER_CERT
 #endif
 #if defined(WOLF_CONF_BASE64_ENCODE) && WOLF_CONF_BASE64_ENCODE == 1
@@ -273,6 +221,7 @@ extern "C" {
 #else
     #define NO_SESSION_CACHE
 #endif
+
 
 /* ------------------------------------------------------------------------- */
 /* Crypto */
@@ -412,6 +361,7 @@ extern "C" {
     #define CURVED25519_SMALL
 #endif
 
+
 /* ------------------------------------------------------------------------- */
 /* Hashing */
 /* ------------------------------------------------------------------------- */
@@ -469,6 +419,7 @@ extern "C" {
     #define NO_MD5
 #endif
 
+
 /* ------------------------------------------------------------------------- */
 /* Benchmark / Test */
 /* ------------------------------------------------------------------------- */
@@ -476,6 +427,7 @@ extern "C" {
 #define BENCH_EMBEDDED
 #define USE_CERT_BUFFERS_2048
 #define USE_CERT_BUFFERS_256
+
 
 /* ------------------------------------------------------------------------- */
 /* Debugging */
@@ -495,6 +447,7 @@ extern "C" {
     //#define NO_ERROR_STRINGS
 #endif
 
+
 /* ------------------------------------------------------------------------- */
 /* Port */
 /* ------------------------------------------------------------------------- */
@@ -503,11 +456,13 @@ extern "C" {
 /* Allows custom "custom_time()" function to be used for benchmark */
 #define WOLFSSL_USER_CURRTIME
 
+
 /* ------------------------------------------------------------------------- */
 /* RNG */
 /* ------------------------------------------------------------------------- */
 #define NO_OLD_RNGNAME /* conflicts with STM RNG macro */
 #define HAVE_HASHDRBG
+
 
 /* ------------------------------------------------------------------------- */
 /* Disable Features */
@@ -557,5 +512,10 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+#endif /*__ ${inclusion_protection}_H */
 
-#endif /*__WOLFSSL_WOLFSSL_CONF_H__ */
+/**
+  * @}
+  */
+
+/*****END OF FILE****/

--- a/IDE/STM32Cube/include.am
+++ b/IDE/STM32Cube/include.am
@@ -8,3 +8,4 @@ EXTRA_DIST+= IDE/STM32Cube/wolfssl_example.c
 EXTRA_DIST+= IDE/STM32Cube/wolfSSL.wolfSSL_conf.h
 EXTRA_DIST+= IDE/STM32Cube/wolfssl_example.h
 EXTRA_DIST+= IDE/STM32Cube/STM32_Benchmarks.md
+EXTRA_DIST+= IDE/STM32Cube/default_conf.ftl

--- a/IDE/STM32Cube/include.am
+++ b/IDE/STM32Cube/include.am
@@ -5,7 +5,7 @@
 EXTRA_DIST+= IDE/STM32Cube/README.md
 EXTRA_DIST+= IDE/STM32Cube/main.c
 EXTRA_DIST+= IDE/STM32Cube/wolfssl_example.c
-EXTRA_DIST+= IDE/STM32Cube/wolfSSL.wolfSSL_conf.h
+EXTRA_DIST+= IDE/STM32Cube/wolfSSL_conf.h
 EXTRA_DIST+= IDE/STM32Cube/wolfssl_example.h
 EXTRA_DIST+= IDE/STM32Cube/STM32_Benchmarks.md
 EXTRA_DIST+= IDE/STM32Cube/default_conf.ftl

--- a/IDE/STM32Cube/main.c
+++ b/IDE/STM32Cube/main.c
@@ -25,6 +25,7 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "wolfssl_example.h"
+#include "wolfssl/wolfcrypt/settings.h"
 
 /* Private variables ---------------------------------------------------------*/
 CRYP_HandleTypeDef hcryp;
@@ -66,7 +67,7 @@ int __io_putchar(int ch)
 int fputc(int ch, FILE *f)
 #endif
 {
-    HAL_UART_Transmit(&huart4, (uint8_t *)&ch, 1, 0xFFFF);
+    HAL_UART_Transmit(&HAL_CONSOLE_UART, (uint8_t *)&ch, 1, 0xFFFF);
 
     return ch;
 }

--- a/IDE/STM32Cube/wolfSSL_conf.h
+++ b/IDE/STM32Cube/wolfSSL_conf.h
@@ -1,4 +1,4 @@
-/* wolfSSL.wolfSSL_conf.h
+/* wolfSSL_conf.h (example of generated wolfSSL.wolfSSL_conf.h)
  *
  * Copyright (C) 2006-2020 wolfSSL Inc.
  *
@@ -19,11 +19,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-/* STM32 Cube Configuration File 
+/* STM32 Cube Sample Configuration File 
+ * Generated automatically using `default_conf.ftl` template
+ *
  * Included automatically when USE_HAL_DRIVER is defined 
  * (and not WOLFSSL_USER_SETTINGS or HAVE_CONF_H).
- * 
- * Generated automatically using `default_conf.ftl` template
  */
 
 #ifndef __WOLFSSL_WOLFSSL_CONF_H__

--- a/IDE/STM32Cube/wolfssl_example.c
+++ b/IDE/STM32Cube/wolfssl_example.c
@@ -510,11 +510,11 @@ static int ServerMemSend(info_t* info, char* buf, int sz)
         sz = MEM_BUFFER_SZ - info->to_client.write_idx;
 #endif
 
+    if (info->showVerbose >= 2)
+        printf("Server Send: %d\n", sz);
     XMEMCPY(&info->to_client.buf[info->to_client.write_idx], buf, sz);
     info->to_client.write_idx += sz;
     info->to_client.write_bytes += sz;
-    if (info->showVerbose >= 3)
-        printf("Server Send: %d\n", sz);
 
 #ifdef CMSIS_OS2_H_
     osThreadFlagsSet(info->client.threadId, 1);
@@ -565,16 +565,17 @@ static int ServerMemRecv(info_t* info, char* buf, int sz)
     XMEMCPY(buf, &info->to_server.buf[info->to_server.read_idx], sz);
     info->to_server.read_idx += sz;
     info->to_server.read_bytes += sz;
-    if (info->showVerbose >= 2)    
-        printf("Server Recv: %d\n", sz);
 
     /* if the rx has caught up with pending then reset buffer positions */
     if (info->to_server.read_bytes == info->to_server.write_bytes) {
         info->to_server.read_bytes = info->to_server.read_idx = 0;
         info->to_server.write_bytes = info->to_server.write_idx = 0;
     }
+    if (info->showVerbose >= 2)
+        printf("Server Recv: %d\n", sz);
 
     osSemaphoreRelease(info->server.mutex);
+
 
 #ifdef BENCH_USE_NONBLOCK
     if (sz == 0)
@@ -660,14 +661,14 @@ static int ClientMemRecv(info_t* info, char* buf, int sz)
     XMEMCPY(buf, &info->to_client.buf[info->to_client.read_idx], sz);
     info->to_client.read_idx += sz;
     info->to_client.read_bytes += sz;
-    if (info->showVerbose >= 2)
-        printf("Client Recv: %d\n", sz);
 
     /* if the rx has caught up with pending then reset buffer positions */
     if (info->to_client.read_bytes == info->to_client.write_bytes) {
         info->to_client.read_bytes = info->to_client.read_idx = 0;
         info->to_client.write_bytes = info->to_client.write_idx = 0;
     }
+    if (info->showVerbose >= 2)
+        printf("Client Recv: %d\n", sz);
 
     osSemaphoreRelease(info->client.mutex);
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1259,11 +1259,11 @@ extern void uITRON4_free(void *p) ;
     #endif
     #define NO_OLD_RNGNAME
     #ifdef WOLFSSL_STM32_CUBEMX
-		#if defined(WOLFSSL_STM32F1)
-			#include "stm32f1xx_hal.h"
+        #if defined(WOLFSSL_STM32F1)
+            #include "stm32f1xx_hal.h"
         #elif defined(WOLFSSL_STM32F2)
             #include "stm32f2xx_hal.h"
-		#elif defined(WOLFSSL_STM32L5)
+        #elif defined(WOLFSSL_STM32L5)
             #include "stm32l5xx_hal.h"
         #elif defined(WOLFSSL_STM32L4)
             #include "stm32l4xx_hal.h"
@@ -1302,7 +1302,7 @@ extern void uITRON4_free(void *p) ;
             #ifdef STM32_HASH
                 #include "stm32f4xx_hash.h"
             #endif
-		#elif defined(WOLFSSL_STM32L5)
+        #elif defined(WOLFSSL_STM32L5)
             #include "stm32l5xx.h"
             #ifdef STM32_CRYPTO
                 #include "stm32l5xx_cryp.h"
@@ -1310,7 +1310,7 @@ extern void uITRON4_free(void *p) ;
             #ifdef STM32_HASH
                 #include "stm32l5xx_hash.h"
             #endif
-    	#elif defined(WOLFSSL_STM32L4)
+        #elif defined(WOLFSSL_STM32L4)
             #include "stm32l4xx.h"
             #ifdef STM32_CRYPTO
                 #include "stm32l4xx_cryp.h"
@@ -1327,7 +1327,7 @@ extern void uITRON4_free(void *p) ;
         #endif
     #endif /* WOLFSSL_STM32_CUBEMX */
 #endif /* WOLFSSL_STM32F2 || WOLFSSL_STM32F4 || WOLFSSL_STM32L4 || 
-		  WOLFSSL_STM32L5 || WOLFSSL_STM32F7 || WOLFSSL_STMWB || WOLFSSL_STM32H7 */
+          WOLFSSL_STM32L5 || WOLFSSL_STM32F7 || WOLFSSL_STMWB || WOLFSSL_STM32H7 */
 #ifdef WOLFSSL_DEOS
     #include <deos.h>
     #include <timeout.h>


### PR DESCRIPTION
* Fix for STM32 issue with some Cube HAL versions (such as F777) which could modify non-block aligned bytes in the output buffer during decrypt. For TLS these bytes are the authentication tag. Workaround is to save off the incoming expected authentication tag. ZD 10961.
* Fix for STM32 example timeout.
* Added the wolfSSL configuration template that is used for the Cube pack. This will be the source for the template going forward.
* Added some useful debugging options and increased the timeout for the TLS example.

