### PR TITLE
EVP CIPHER: fix block size, mode and table

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -920,7 +920,6 @@ WOLFSSL_API int  wolfSSL_EVP_DecryptFinal_legacy(WOLFSSL_EVP_CIPHER_CTX *ctx,
 }
 #endif
 
-
 int wolfSSL_EVP_CIPHER_CTX_block_size(const WOLFSSL_EVP_CIPHER_CTX *ctx)
 {
     if (ctx == NULL) return BAD_FUNC_ARG;
@@ -1119,7 +1118,7 @@ int wolfSSL_EVP_CIPHER_block_size(const WOLFSSL_EVP_CIPHER *cipher)
       case AES_128_GCM_TYPE:
       case AES_192_GCM_TYPE:
       case AES_256_GCM_TYPE:
-          return AES_BLOCK_SIZE;
+          return 1;
   #endif
   #if defined(WOLFSSL_AES_COUNTER)
       case AES_128_CTR_TYPE:
@@ -1132,6 +1131,29 @@ int wolfSSL_EVP_CIPHER_block_size(const WOLFSSL_EVP_CIPHER *cipher)
       case AES_192_ECB_TYPE:
       case AES_256_ECB_TYPE:
           return AES_BLOCK_SIZE;
+  #endif
+  #if defined(WOLFSSL_AES_CFB)
+      case AES_128_CFB1_TYPE:
+      case AES_192_CFB1_TYPE:
+      case AES_256_CFB1_TYPE:
+      case AES_128_CFB8_TYPE:
+      case AES_192_CFB8_TYPE:
+      case AES_256_CFB8_TYPE:
+      case AES_128_CFB128_TYPE:
+      case AES_192_CFB128_TYPE:
+      case AES_256_CFB128_TYPE:
+          return 1;
+  #endif
+  #if defined(WOLFSSL_AES_OFB)
+      case AES_128_OFB_TYPE:
+      case AES_192_OFB_TYPE:
+      case AES_256_OFB_TYPE:
+          return 1;
+  #endif
+  #if defined(HAVE_AES_XTS)
+      case AES_128_XTS_TYPE:
+      case AES_256_XTS_TYPE:
+          return 1;
   #endif
 #endif /* NO_AES */
   #ifndef NO_DES3
@@ -1167,11 +1189,34 @@ unsigned long WOLFSSL_CIPHER_mode(const WOLFSSL_EVP_CIPHER *cipher)
         case AES_256_CTR_TYPE:
             return WOLFSSL_EVP_CIPH_CTR_MODE;
     #endif
+    #if defined(WOLFSSL_AES_CFB)
+        case AES_128_CFB1_TYPE:
+        case AES_192_CFB1_TYPE:
+        case AES_256_CFB1_TYPE:
+        case AES_128_CFB8_TYPE:
+        case AES_192_CFB8_TYPE:
+        case AES_256_CFB8_TYPE:
+        case AES_128_CFB128_TYPE:
+        case AES_192_CFB128_TYPE:
+        case AES_256_CFB128_TYPE:
+            return WOLFSSL_EVP_CIPH_CFB_MODE;
+    #endif
+    #if defined(WOLFSSL_AES_OFB)
+        case AES_128_OFB_TYPE:
+        case AES_192_OFB_TYPE:
+        case AES_256_OFB_TYPE:
+            return WOLFSSL_EVP_CIPH_OFB_MODE;
+    #endif
+    #if defined(WOLFSSL_AES_XTS)
+        case AES_128_XTS_TYPE:
+        case AES_256_XTS_TYPE:
+            return WOLFSSL_EVP_CIPH_XTS_MODE;
+    #endif
         case AES_128_ECB_TYPE:
         case AES_192_ECB_TYPE:
         case AES_256_ECB_TYPE:
             return WOLFSSL_EVP_CIPH_ECB_MODE;
-#endif /* NO_ASE */
+#endif /* NO_AES */
     #ifndef NO_DES3
         case DES_CBC_TYPE:
         case DES_EDE3_CBC_TYPE:
@@ -2754,7 +2799,6 @@ static const struct cipher{
         {AES_256_ECB_TYPE, EVP_AES_256_ECB, NID_aes_256_ecb},
     #endif
     #endif
-
 #endif
 
 #ifndef NO_DES3


### PR DESCRIPTION
Block size incorrect for GCM - 1.
Add block size for more ciphers in wolfSSL_EVP_CIPHER_block_size().
Add more ciphers to WOLFSSL_CIPHER_mode().
Cipher table was compiling in entries without support.