### PR TITLE
Added support for NXP DCP (i.MX-RT series)

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -1743,6 +1743,13 @@ static void wc_AesEncrypt(Aes* aes, const byte* inBlock, byte* outBlock)
     return;
 #endif
 
+#if defined(WOLFSSL_IMXRT_DCP)
+    if (aes->keylen == 16) {
+        DCPAesEcbEncrypt(aes, outBlock, inBlock, AES_BLOCK_SIZE);
+        return;
+    }
+#endif
+
     /*
      * map byte array block to cipher state
      * and add initial round key:
@@ -2026,6 +2033,12 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 #endif /* WOLFSSL_AESNI */
 #if defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_AES)
     return AES_ECB_decrypt(aes, inBlock, outBlock, AES_BLOCK_SIZE);
+#endif
+#if defined(WOLFSSL_IMXRT_DCP)
+    if (aes->keylen == 16) {
+        DCPAesEcbDecrypt(aes, outBlock, inBlock, AES_BLOCK_SIZE);
+        return;
+    }
 #endif
 
     /*
@@ -2584,7 +2597,6 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 
 #elif defined(WOLFSSL_DEVCRYPTO_AES)
     /* implemented in wolfcrypt/src/port/devcrypto/devcrypto_aes.c */
-
 
 #else
 
@@ -4182,6 +4194,14 @@ int wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len)
 
 #ifdef WOLFSSL_IMX6_CAAM_BLOB
     ForceZero(local, sizeof(local));
+#endif
+
+#ifdef WOLFSSL_IMXRT_DCP
+    ret = 0;
+    if (len == 16)
+        ret = DCPAesSetKey(aes, key, len, iv, AES_ENCRYPTION);
+    if (ret != 0)
+        return WC_HW_E;
 #endif
 
     return ret;

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -7564,6 +7564,11 @@ int wc_AesInit(Aes* aes, void* heap, int devId)
 #if defined(WOLFSSL_CRYPTOCELL) && defined(WOLFSSL_CRYPTOCELL_AES)
     XMEMSET(&aes->ctx, 0, sizeof(aes->ctx));
 #endif
+#if defined(WOLFSSL_IMXRT_DCP)
+    DCPAesInit(aes);
+#endif
+
+
 #ifdef HAVE_AESGCM
 #ifdef OPENSSL_EXTRA
     XMEMSET(aes->aadH, 0, sizeof(aes->aadH));

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -65,6 +65,10 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
     #include <wolfssl/wolfcrypt/cryptocb.h>
 #endif
 
+#ifdef WOLFSSL_IMXRT_DCP
+    #include <wolfssl/wolfcrypt/port/nxp/dcp_port.h>
+#endif
+
 
 /* fips wrapper calls, user can call direct */
 #if defined(HAVE_FIPS) && \
@@ -2266,7 +2270,6 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
         defined(WOLFSSL_AES_OFB)
         aes->left = 0;
     #endif
-
         return wc_AesSetIV(aes, iv);
     }
     #if defined(WOLFSSL_AES_DIRECT)
@@ -2582,6 +2585,7 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
 #elif defined(WOLFSSL_DEVCRYPTO_AES)
     /* implemented in wolfcrypt/src/port/devcrypto/devcrypto_aes.c */
 
+
 #else
 
     /* Software AES - SetKey */
@@ -2681,6 +2685,15 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
         (!defined(WOLFSSL_ESP32WROOM32_CRYPT) || \
           defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_AES))
         ByteReverseWords(rk, rk, keylen);
+    #endif
+
+    #ifdef WOLFSSL_IMXRT_DCP
+        /* Implemented in wolfcrypt/src/port/nxp/dcp_port.c */
+        temp = 0;
+        if (keylen == 16)
+            temp = DCPAesSetKey(aes, userKey, keylen, iv, dir);
+        if (temp != 0)
+            return WC_HW_E;
     #endif
 
 #ifdef NEED_AES_TABLES
@@ -2889,7 +2902,6 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         XMEMCPY(aes->reg, iv, AES_BLOCK_SIZE);
     else
         XMEMSET(aes->reg,  0, AES_BLOCK_SIZE);
-
     return 0;
 }
 
@@ -3518,6 +3530,11 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         if (sz == 0) {
             return 0;
         }
+    #ifdef WOLFSSL_IMXRT_DCP
+        /* Implemented in wolfcrypt/src/port/nxp/dcp_port.c */
+        if (aes->keylen == 16)
+            return DCPAesCbcEncrypt(aes, out, in, sz);
+    #endif
 
     #ifdef WOLF_CRYPTO_CB
         if (aes->devId != INVALID_DEVID) {
@@ -3625,6 +3642,11 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
         if (sz == 0) {
             return 0;
         }
+    #ifdef WOLFSSL_IMXRT_DCP
+        /* Implemented in wolfcrypt/src/port/nxp/dcp_port.c */
+        if (aes->keylen == 16)
+            return DCPAesCbcDecrypt(aes, out, in, sz);
+    #endif
 
     #ifdef WOLF_CRYPTO_CB
         if (aes->devId != INVALID_DEVID) {
@@ -6177,7 +6199,6 @@ int AES_GCM_encrypt_C(Aes* aes, byte* out, const byte* in, word32 sz,
     }
     else
 #endif /* HAVE_AES_ECB && !WOLFSSL_PIC32MZ_CRYPT */
-
     while (blocks--) {
         IncrementGcmCounter(ctr);
     #if !defined(WOLFSSL_PIC32MZ_CRYPT)
@@ -7678,6 +7699,10 @@ int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 
     if ((in == NULL) || (out == NULL) || (aes == NULL))
       return BAD_FUNC_ARG;
+#ifdef WOLFSSL_IMXRT_DCP
+    if (aes->keylen == 16)
+        return DCPAesEcbEncrypt(aes, out, in, sz);
+#endif
     while (blocks > 0) {
       wc_AesEncryptDirect(aes, out, in);
       out += AES_BLOCK_SIZE;
@@ -7695,6 +7720,10 @@ int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 
     if ((in == NULL) || (out == NULL) || (aes == NULL))
       return BAD_FUNC_ARG;
+#ifdef WOLFSSL_IMXRT_DCP
+    if (aes->keylen == 16)
+        return DCPAesEcbDecrypt(aes, out, in, sz);
+#endif
     while (blocks > 0) {
       wc_AesDecryptDirect(aes, out, in);
       out += AES_BLOCK_SIZE;

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -4195,15 +4195,6 @@ int wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len)
 #ifdef WOLFSSL_IMX6_CAAM_BLOB
     ForceZero(local, sizeof(local));
 #endif
-
-#ifdef WOLFSSL_IMXRT_DCP
-    ret = 0;
-    if (len == 16)
-        ret = DCPAesSetKey(aes, key, len, iv, AES_ENCRYPTION);
-    if (ret != 0)
-        return WC_HW_E;
-#endif
-
     return ret;
 }
 
@@ -7644,6 +7635,9 @@ void wc_AesFree(Aes* aes)
     (defined(WOLFSSL_DEVCRYPTO_AES) || defined(WOLFSSL_DEVCRYPTO_CBC))) || \
     (defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_AES))
     ForceZero((byte*)aes->devKey, AES_MAX_KEY_SIZE/WOLFSSL_BIT_SIZE);
+#endif
+#if defined(WOLFSSL_IMXRT_DCP)
+    DCPAesFree(aes);
 #endif
 }
 

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -58,6 +58,7 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/arm/armv8-sha512-asm.c \
               wolfcrypt/src/port/arm/armv8-32-sha512-asm.c \
               wolfcrypt/src/port/nxp/ksdk_port.c \
+              wolfcrypt/src/port/nxp/dcp_port.c \
               wolfcrypt/src/port/atmel/README.md \
               wolfcrypt/src/port/xilinx/xil-sha3.c \
               wolfcrypt/src/port/xilinx/xil-aesgcm.c \

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -1,0 +1,390 @@
+/* dcp_port.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+#ifdef NO_INLINE
+    #include <wolfssl/wolfcrypt/misc.h>
+#else
+    #define WOLFSSL_MISC_INCLUDED
+    #include <wolfcrypt/src/misc.c>
+#endif
+    
+#include <wolfssl/wolfcrypt/aes.h>
+#include <wolfssl/wolfcrypt/sha.h>
+#include <wolfssl/wolfcrypt/sha256.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#ifdef WOLFSSL_IMXRT_DCP
+
+#ifndef DCP_USE_OTP_KEY
+#define DCP_USE_OTP_KEY 0 /* Set to 1 to select OTP key for AES encryption/decryption. */
+#endif
+
+#include "fsl_device_registers.h"
+#include "fsl_debug_console.h"
+#include "fsl_dcp.h"
+
+
+static dcp_config_t dcpConfig;
+
+#if DCP_USE_OTP_KEY
+typedef enum _dcp_otp_key_select
+{
+    kDCP_OTPMKKeyLow  = 1U, /* Use [127:0] from snvs key as dcp key */
+    kDCP_OTPMKKeyHigh = 2U, /* Use [255:128] from snvs key as dcp key */
+    kDCP_OCOTPKeyLow  = 3U, /* Use [127:0] from ocotp key as dcp key */
+    kDCP_OCOTPKeyHigh = 4U  /* Use [255:128] from ocotp key as dcp key */
+} dcp_otp_key_select;
+#endif
+
+#if DCP_USE_OTP_KEY
+static status_t DCP_OTPKeySelect(dcp_otp_key_select keySelect)
+{
+    if (keySelect == kDCP_OTPMKKeyLow)
+    {
+        IOMUXC_GPR->GPR3 &= ~(1 << IOMUXC_GPR_GPR3_DCP_KEY_SEL_SHIFT);
+        IOMUXC_GPR->GPR10 &= ~(1 << IOMUXC_GPR_GPR10_DCPKEY_OCOTP_OR_KEYMUX_SHIFT);
+    }
+
+    else if (keySelect == kDCP_OTPMKKeyHigh)
+    {
+        IOMUXC_GPR->GPR3 |= (1 << IOMUXC_GPR_GPR3_DCP_KEY_SEL_SHIFT);
+        IOMUXC_GPR->GPR10 &= ~(1 << IOMUXC_GPR_GPR10_DCPKEY_OCOTP_OR_KEYMUX_SHIFT);
+    }
+
+    else if (keySelect == kDCP_OCOTPKeyLow)
+    {
+        IOMUXC_GPR->GPR3 &= ~(1 << IOMUXC_GPR_GPR3_DCP_KEY_SEL_SHIFT);
+        IOMUXC_GPR->GPR10 |= (1 << IOMUXC_GPR_GPR10_DCPKEY_OCOTP_OR_KEYMUX_SHIFT);
+    }
+
+    else if (keySelect == kDCP_OCOTPKeyHigh)
+    {
+        IOMUXC_GPR->GPR3 |= (1 << IOMUXC_GPR_GPR3_DCP_KEY_SEL_SHIFT);
+        IOMUXC_GPR->GPR10 |= (1 << IOMUXC_GPR_GPR10_DCPKEY_OCOTP_OR_KEYMUX_SHIFT);
+    }
+
+    else
+    {
+        return kStatus_InvalidArgument;
+    }
+
+    return kStatus_Success;
+}
+#endif
+
+static void dcp_init(void)
+{
+    static int dcp_is_initialized = 0;
+    if (!dcp_is_initialized) {
+        /* Initialize DCP */
+        DCP_GetDefaultConfig(&dcpConfig);
+
+#if DCP_USE_OTP_KEY
+        /* Set OTP key type in IOMUX registers before initializing DCP. */
+        /* Software reset of DCP must be issued after changing the OTP key type. */
+        DCP_OTPKeySelect(kDCP_OTPMKKeyLow);
+#endif
+
+        /* Reset and initialize DCP */
+        DCP_Init(DCP, &dcpConfig);
+        dcp_is_initialized++;
+    }
+}
+
+
+#ifndef NO_AES
+int  DCPAesSetKey(Aes* aes, const byte* key, word32 len, const byte* iv,
+                          int dir)
+{
+
+#if DCP_USE_OTP_KEY
+#warning Please update cipherAes128 variables to match expected AES ciphertext for your OTP key.
+#endif
+    status_t status;
+    if (!aes || !key)
+        return BAD_FUNC_ARG;
+
+    if (len != 16)
+        return BAD_FUNC_ARG; 
+
+    dcp_init();
+    XMEMSET(&aes->handle, 0, sizeof(aes->handle));
+    aes->handle.channel    = kDCP_Channel0;
+    aes->handle.swapConfig = kDCP_NoSwap;
+#if DCP_USE_OTP_KEY
+    aes->handle.keySlot = kDCP_OtpKey;
+#else
+    aes->handle.keySlot = kDCP_KeySlot0;
+#endif
+    status = DCP_AES_SetKey(DCP, &aes->handle, key, 16);
+    if (status != kStatus_Success)
+        return WC_HW_E;
+    if (iv)
+        XMEMCPY(aes->reg, iv, 16);
+    else
+        XMEMSET(aes->reg, 0, 16);
+    return 0;
+}
+
+int  DCPAesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    int ret;
+    if (sz % 16)
+        return BAD_FUNC_ARG;
+    ret = DCP_AES_EncryptCbc(DCP, &aes->handle, in, out, sz, (const byte *)aes->reg);
+    if (ret)
+        return WC_HW_E; 
+    XMEMCPY(aes->reg, out, AES_BLOCK_SIZE);
+    return ret;
+}
+
+int  DCPAesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    int ret;
+    if (sz % 16)
+        return BAD_FUNC_ARG;
+    ret = DCP_AES_DecryptCbc(DCP, &aes->handle, in, out, sz, (const byte *)aes->reg);
+    if (ret)
+        return WC_HW_E; 
+    XMEMCPY(aes->reg, in, AES_BLOCK_SIZE);
+    return ret;
+}
+
+int  DCPAesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    return DCP_AES_EncryptEcb(DCP, &aes->handle, in, out, sz);
+}
+
+int  DCPAesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+{
+    return DCP_AES_DecryptEcb(DCP, &aes->handle, in, out, sz);
+}
+
+#endif
+
+#ifndef NO_SHA256
+int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
+{
+    int ret;
+    if (sha256 == NULL)
+        return BAD_FUNC_ARG;
+    dcp_init();
+    (void)devId;
+    XMEMSET(sha256, 0, sizeof(wc_Sha256));
+    sha256->handle.channel    = kDCP_Channel0;
+    sha256->handle.keySlot    = kDCP_KeySlot0;
+    sha256->handle.swapConfig = kDCP_NoSwap;
+    ret = DCP_HASH_Init(DCP, &sha256->handle, &sha256->ctx, kDCP_Sha256);
+    if (ret != kStatus_Success)
+        return WC_HW_E;
+    return ret;
+}
+
+int wc_InitSha256(wc_Sha256* sha256)
+{
+    return wc_InitSha256_ex(sha256, NULL, INVALID_DEVID);
+}
+
+void wc_Sha256Free(wc_Sha256* sha256)
+{
+    (void)sha256;
+}
+
+int wc_Sha256Update(wc_Sha256* sha256, const byte* data, word32 len)
+{
+    int ret;
+    if (sha256 == NULL || (data == NULL && len != 0)) {
+        return BAD_FUNC_ARG;
+    }
+    ret = DCP_HASH_Update(DCP, &sha256->ctx, data, len);
+    if (ret != kStatus_Success)
+        return WC_HW_E;
+    return ret;
+}
+
+
+int wc_Sha256GetHash(wc_Sha256* sha256, byte* hash)
+{
+    int ret;
+    size_t outlen = WC_SHA256_DIGEST_SIZE;
+    dcp_hash_ctx_t saved_ctx;
+    if (sha256 == NULL || hash == NULL)
+        return BAD_FUNC_ARG;
+    XMEMCPY(&saved_ctx, &sha256->ctx, sizeof(dcp_hash_ctx_t));
+    XMEMSET(hash, 0, WC_SHA256_DIGEST_SIZE);
+    ret = DCP_HASH_Finish(DCP, &sha256->ctx, hash, &outlen);
+    if ((ret != kStatus_Success) || (outlen != SHA256_DIGEST_SIZE)) {
+        return WC_HW_E;
+    }
+    XMEMCPY(&sha256->ctx, &saved_ctx, sizeof(dcp_hash_ctx_t));
+    return 0;
+}
+
+int wc_Sha256Final(wc_Sha256* sha256, byte* hash)
+{
+    int ret;
+    size_t outlen = WC_SHA256_DIGEST_SIZE;
+    ret = DCP_HASH_Finish(DCP, &sha256->ctx, hash, &outlen);
+    if ((ret != kStatus_Success) || (outlen != SHA256_DIGEST_SIZE))
+        return WC_HW_E;
+    sha256->handle.channel    = kDCP_Channel0;
+    sha256->handle.keySlot    = kDCP_KeySlot0;
+    sha256->handle.swapConfig = kDCP_NoSwap;
+    ret = DCP_HASH_Init(DCP, &sha256->handle, &sha256->ctx, kDCP_Sha256);
+    if (ret < 0)
+        return WC_HW_E;
+    return ret;
+}
+
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+int wc_Sha256SetFlags(wc_Sha256* sha256, word32 flags)
+{
+    if (sha256) {
+        sha256->flags = flags;
+    }
+    return 0;
+}
+int wc_Sha256GetFlags(wc_Sha256* sha256, word32* flags)
+{
+    if (sha256 && flags) {
+        *flags = sha256->flags;
+    }
+    return 0;
+}
+#endif /* WOLFSSL_HASH_FLAGS || WOLF_CRYPTO_CB */
+
+int wc_Sha256Copy(wc_Sha256* src, wc_Sha256* dst)
+{
+    if (src == NULL || dst == NULL)
+        return BAD_FUNC_ARG;
+    XMEMCPY(&dst->ctx, &src->ctx, sizeof(dcp_hash_ctx_t));
+    return 0;
+}
+#endif /* !NO_SHA256 */
+
+
+#ifndef NO_SHA
+
+int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
+{
+    int ret;
+    if (sha == NULL)
+        return BAD_FUNC_ARG;
+    dcp_init();
+    (void)devId;
+    XMEMSET(sha, 0, sizeof(wc_Sha));
+    sha->handle.channel    = kDCP_Channel0;
+    sha->handle.keySlot    = kDCP_KeySlot0;
+    sha->handle.swapConfig = kDCP_NoSwap;
+    ret = DCP_HASH_Init(DCP, &sha->handle, &sha->ctx, kDCP_Sha1);
+    if (ret != kStatus_Success)
+        return WC_HW_E;
+    return ret;
+}
+
+int wc_InitSha(wc_Sha* sha)
+{
+    return wc_InitSha_ex(sha, NULL, INVALID_DEVID);
+}
+
+void wc_ShaFree(wc_Sha* sha)
+{
+    (void)sha;
+}
+
+int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
+{
+    int ret;
+    if (sha == NULL || (data == NULL && len != 0)) {
+        return BAD_FUNC_ARG;
+    }
+    ret = DCP_HASH_Update(DCP, &sha->ctx, data, len);
+    if (ret != kStatus_Success)
+        return WC_HW_E;
+    return ret;
+}
+
+
+int wc_ShaGetHash(wc_Sha* sha, byte* hash)
+{
+    int ret;
+    size_t outlen = WC_SHA_DIGEST_SIZE;
+    dcp_hash_ctx_t saved_ctx;
+    if (sha == NULL || hash == NULL)
+        return BAD_FUNC_ARG;
+    XMEMCPY(&saved_ctx, &sha->ctx, sizeof(dcp_hash_ctx_t));
+    XMEMSET(hash, 0, WC_SHA_DIGEST_SIZE);
+    ret = DCP_HASH_Finish(DCP, &sha->ctx, hash, &outlen);
+    if ((ret != kStatus_Success) || (outlen != WC_SHA_DIGEST_SIZE)) {
+        return WC_HW_E;
+    }
+    XMEMCPY(&sha->ctx, &saved_ctx, sizeof(dcp_hash_ctx_t));
+    return 0;
+}
+
+int wc_ShaFinal(wc_Sha* sha, byte* hash)
+{
+    int ret;
+    size_t outlen = WC_SHA_DIGEST_SIZE;
+    ret = DCP_HASH_Finish(DCP, &sha->ctx, hash, &outlen);
+    if ((ret != kStatus_Success) || (outlen != SHA_DIGEST_SIZE))
+        return WC_HW_E;
+    sha->handle.channel    = kDCP_Channel0;
+    sha->handle.keySlot    = kDCP_KeySlot0;
+    sha->handle.swapConfig = kDCP_NoSwap;
+    ret = DCP_HASH_Init(DCP, &sha->handle, &sha->ctx, kDCP_Sha1);
+    if (ret < 0)
+        return WC_HW_E;
+    return ret;
+}
+
+#if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
+int wc_ShaSetFlags(wc_Sha* sha, word32 flags)
+{
+    if (sha) {
+        sha->flags = flags;
+    }
+    return 0;
+}
+int wc_ShaGetFlags(wc_Sha* sha, word32* flags)
+{
+    if (sha && flags) {
+        *flags = sha->flags;
+    }
+    return 0;
+}
+#endif /* WOLFSSL_HASH_FLAGS || WOLF_CRYPTO_CB */
+
+int wc_ShaCopy(wc_Sha* src, wc_Sha* dst)
+{
+    if (src == NULL || dst == NULL)
+        return BAD_FUNC_ARG;
+    XMEMCPY(&dst->ctx, &src->ctx, sizeof(dcp_hash_ctx_t));
+    return 0;
+}
+#endif /* !NO_SHA */
+
+#endif /* WOLFSSL_IMXRT_DCP */

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -328,6 +328,9 @@
 
     /* implemented in wolfcrypt/src/port/Renesas/renesas_tsip_sha.c */
 
+#elif defined(WOLFSSL_IMXRT_DCP)
+    /* implemented in wolfcrypt/src/port/nxp/dcp_port.c */
+
 #else
     /* Software implementation */
     #define USE_SHA_SOFTWARE_IMPL

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -797,6 +797,9 @@ void wc_ShaFree(wc_Sha* sha)
         sha->msg = NULL;
     }
 #endif
+#ifdef WOLFSSL_IMXRT_DCP
+    DCPShaFree(sha);
+#endif
 }
 
 #endif /* !WOLFSSL_TI_HASH */

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1533,6 +1533,9 @@ void wc_Sha256Free(wc_Sha256* sha256)
         sha256->msg = NULL;
     }
 #endif
+#ifdef WOLFSSL_IMXRT_DCP
+    DCPSha256Free(sha256);
+#endif
 }
 
 #endif /* !WOLFSSL_TI_HASH */

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -179,7 +179,7 @@ where 0 <= L < 2^64.
     !defined(WOLFSSL_AFALG_HASH) && !defined(WOLFSSL_DEVCRYPTO_HASH) && \
     (!defined(WOLFSSL_ESP32WROOM32_CRYPT) || defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)) && \
     (!defined(WOLFSSL_RENESAS_TSIP_CRYPT) || defined(NO_WOLFSSL_RENESAS_TSIP_HASH)) && \
-    !defined(WOLFSSL_PSOC6_CRYPTO)
+    !defined(WOLFSSL_PSOC6_CRYPTO) && !defined(WOLFSSL_IMXRT_DCP)
 
 static int InitSha256(wc_Sha256* sha256)
 {
@@ -707,6 +707,10 @@ static int InitSha256(wc_Sha256* sha256)
 #elif defined(WOLFSSL_PSOC6_CRYPTO)
 
     /* implemented in wolfcrypt/src/port/cypress/psoc6_crypto.c */
+
+#elif defined(WOLFSSL_IMXRT_DCP)
+    #include <wolfssl/wolfcrypt/port/nxp/dcp_port.h>
+    /* implemented in wolfcrypt/src/port/nxp/dcp_port.c */
 
 #else
     #define NEED_SOFT_SHA256
@@ -1604,6 +1608,8 @@ void wc_Sha256Free(wc_Sha256* sha256)
 
     /* implemented in wolfcrypt/src/port/Renesas/renesas_tsip_sha.c */
 #elif defined(WOLFSSL_PSOC6_CRYPTO)
+    /* implemented in wolfcrypt/src/port/cypress/psoc6_crypto.c */
+#elif defined(WOLFSSL_IMXRT_DCP)
     /* implemented in wolfcrypt/src/port/cypress/psoc6_crypto.c */
 #else
 

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -1613,7 +1613,7 @@ void wc_Sha256Free(wc_Sha256* sha256)
 #elif defined(WOLFSSL_PSOC6_CRYPTO)
     /* implemented in wolfcrypt/src/port/cypress/psoc6_crypto.c */
 #elif defined(WOLFSSL_IMXRT_DCP)
-    /* implemented in wolfcrypt/src/port/cypress/psoc6_crypto.c */
+    /* implemented in wolfcrypt/src/port/nxp/dcp_port.c */
 #else
 
 int wc_Sha256GetHash(wc_Sha256* sha256, byte* hash)

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -75,6 +75,10 @@
     #include <wolfssl/wolfcrypt/port/caam/wolfcaam.h>
 #endif
 
+#ifdef WOLFSSL_IMXRT_DCP
+    #include <wolfssl/wolfcrypt/port/nxp/dcp_port.h>
+#endif
+
 #ifdef WOLF_CRYPTO_CB
     #include <wolfssl/wolfcrypt/cryptocb.h>
 #endif
@@ -109,7 +113,6 @@ static volatile int initRefCount = 0;
 int wolfCrypt_Init(void)
 {
     int ret = 0;
-
     if (initRefCount == 0) {
         WOLFSSL_ENTER("wolfCrypt_Init");
 
@@ -260,6 +263,12 @@ int wolfCrypt_Init(void)
 #if defined(WOLFSSL_IMX6_CAAM) || defined(WOLFSSL_IMX6_CAAM_RNG) || \
     defined(WOLFSSL_IMX6_CAAM_BLOB)
         if ((ret = wc_caamInit()) != 0) {
+            return ret;
+        }
+#endif
+
+#ifdef WOLFSSL_IMXRT_DCP
+        if ((ret = wc_dcp_init()) != 0) {
             return ret;
         }
 #endif

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -62,6 +62,9 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
     #include <wolfssl/wolfcrypt/port/st/stm32.h>
 #endif
 
+#ifdef WOLFSSL_IMXRT_DCP
+    #include "fsl_dcp.h"
+#endif
 
 #ifdef WOLFSSL_XILINX_CRYPT
 #include "xsecure_aes.h"
@@ -225,6 +228,9 @@ struct Aes {
 #if defined(WOLFSSL_RENESAS_TSIP_TLS) && \
     defined(WOLFSSL_RENESAS_TSIP_TLS_AES_CRYPT)
     TSIP_AES_CTX ctx;
+#endif
+#if defined(WOLFSSL_IMXRT_DCP)
+    dcp_handle_t handle;
 #endif
     void*  heap; /* memory hint to use */
 };

--- a/wolfssl/wolfcrypt/include.am
+++ b/wolfssl/wolfcrypt/include.am
@@ -74,6 +74,7 @@ noinst_HEADERS+= \
                          wolfssl/wolfcrypt/port/ti/ti-ccm.h \
                          wolfssl/wolfcrypt/port/nrf51.h \
                          wolfssl/wolfcrypt/port/nxp/ksdk_port.h \
+                         wolfssl/wolfcrypt/port/nxp/dcp_port.h \
                          wolfssl/wolfcrypt/port/xilinx/xil-sha3.h \
                          wolfssl/wolfcrypt/port/caam/caam_driver.h \
                          wolfssl/wolfcrypt/port/caam/wolfcaam.h \

--- a/wolfssl/wolfcrypt/port/nxp/dcp_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/dcp_port.h
@@ -1,4 +1,4 @@
-/* dcp_port.c
+/* dcp_port.h
  *
  * Copyright (C) 2006-2020 wolfSSL Inc.
  *

--- a/wolfssl/wolfcrypt/port/nxp/dcp_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/dcp_port.h
@@ -1,0 +1,65 @@
+/* dcp_port.c
+ *
+ * Copyright (C) 2006-2020 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+#ifndef _DCP_PORT_H_
+#define _DCP_PORT_H_
+
+#include <wolfssl/wolfcrypt/settings.h>
+#ifdef USE_FAST_MATH
+    #include <wolfssl/wolfcrypt/tfm.h>
+#elif defined WOLFSSL_SP_MATH
+    #include <wolfssl/wolfcrypt/sp_int.h>
+#else
+    #include <wolfssl/wolfcrypt/integer.h>
+#endif
+
+#include <wolfssl/wolfcrypt/aes.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+#include "fsl_device_registers.h"
+#include "fsl_debug_console.h"
+#include "fsl_dcp.h"
+
+int  DCPAesSetKey(Aes* aes, const byte* key, word32 len, const byte* iv,
+                          int dir);
+int  DCPAesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+int  DCPAesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+
+#ifdef HAVE_AES_ECB
+int  DCPAesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+int  DCPAesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+#endif
+
+#ifndef NO_SHA256
+typedef struct wc_Sha256_DCP {
+    dcp_handle_t handle;
+    dcp_hash_ctx_t ctx;
+} wc_Sha256;
+#define WC_SHA256_TYPE_DEFINED
+#endif
+
+#ifndef NO_SHA
+typedef struct wc_Sha_DCP {
+    dcp_handle_t handle;
+    dcp_hash_ctx_t ctx;
+} wc_Sha;
+#define WC_SHA_TYPE_DEFINED
+#endif
+
+#endif

--- a/wolfssl/wolfcrypt/port/nxp/dcp_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/dcp_port.h
@@ -36,6 +36,7 @@
 #include "fsl_debug_console.h"
 #include "fsl_dcp.h"
 
+int  DCPAesInit(Aes* aes);
 int  DCPAesSetKey(Aes* aes, const byte* key, word32 len, const byte* iv,
                           int dir);
 int  DCPAesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
@@ -52,6 +53,9 @@ typedef struct wc_Sha256_DCP {
     dcp_hash_ctx_t ctx;
 } wc_Sha256;
 #define WC_SHA256_TYPE_DEFINED
+
+void DCPSha256Free(wc_Sha256 *sha256);
+
 #endif
 
 #ifndef NO_SHA
@@ -60,6 +64,8 @@ typedef struct wc_Sha_DCP {
     dcp_hash_ctx_t ctx;
 } wc_Sha;
 #define WC_SHA_TYPE_DEFINED
+
+void DCPShaFree(wc_Sha *sha);
 #endif
 
 #endif

--- a/wolfssl/wolfcrypt/port/nxp/dcp_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/dcp_port.h
@@ -36,7 +36,11 @@
 #include "fsl_debug_console.h"
 #include "fsl_dcp.h"
 
+int wc_dcp_init(void);
+
 int  DCPAesInit(Aes* aes);
+void DCPAesFree(Aes *aes);
+
 int  DCPAesSetKey(Aes* aes, const byte* key, word32 len, const byte* iv,
                           int dir);
 int  DCPAesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1621,6 +1621,12 @@ extern void uITRON4_free(void *p) ;
 #endif
 #endif
 
+/* If DCP is used without SINGLE_THREADED, enforce WOLFSSL_CRYPT_HW_MUTEX */
+#if defined(WOLFSSL_IMXRT_DCP) && !defined(SINGLE_THREADED)
+    #undef WOLFSSL_CRYPT_HW_MUTEX
+    #define WOLFSSL_CRYPT_HW_MUTEX 1
+#endif
+
 #if !defined(XMALLOC_USER) && !defined(MICRIUM_MALLOC) && \
     !defined(WOLFSSL_LEANPSK) && !defined(NO_WOLFSSL_MEMORY) && \
     !defined(XMALLOC_OVERRIDE)

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -72,6 +72,9 @@
 #ifdef WOLFSSL_ESP32WROOM32_CRYPT
     #include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
 #endif
+#ifdef WOLFSSL_IMXRT_DCP
+    #include <wolfssl/wolfcrypt/port/nxp/dcp_port.h>
+#endif
 
 #if !defined(NO_OLD_SHA_NAMES)
     #define SHA             WC_SHA

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -128,6 +128,8 @@ enum {
     #include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
 #elif defined(WOLFSSL_PSOC6_CRYPTO)
     #include "wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h"
+#elif defined(WOLFSSL_IMXRT_DCP)
+    #include <wolfssl/wolfcrypt/port/nxp/dcp_port.h>
 #else
 
 /* wc_Sha256 digest */


### PR DESCRIPTION
Superseeds #3307 

Added support for NXP DCP crypto co-processor.

Supports:

  - AES-128 (CBC and ECB)
  - SHA1
  - SHA256

All wolfcrypt tests passing.

Example: https://github.com/wolfSSL/wolfssl-examples/pull/226