### PR TITLE
FIPS Ready Windows Fix

### DIFF
--- a/IDE/WIN/README.txt
+++ b/IDE/WIN/README.txt
@@ -3,6 +3,8 @@
 First, if you did not get the FIPS files with your archive, you must contact
 wolfSSL to obtain them.
 
+The IDE/WIN/wolfssl-fips.sln solution is for the original FIPS #2425 certificate. 
+See IDE/WIN10/wolfssl-fips.sln for the FIPS v2 #3389 or later Visual Studio solution.
 
 # Building the wolfssl-fips project
 

--- a/IDE/WIN10/README.txt
+++ b/IDE/WIN10/README.txt
@@ -3,6 +3,7 @@
 First, if you did not get the FIPS files with your archive, you must contact
 wolfSSL to obtain them.
 
+The IDE/WIN10/wolfssl-fips.sln solution is for the FIPS v2 #3389 certificate or later.
 
 # Building the wolfssl-fips project
 
@@ -47,6 +48,7 @@ check value when changing your application.
 The default build options should be the proper default set of options:
 
  * HAVE_FIPS
+ * HAVE_FIPS_VERSION=2 (or 3 with WOLFSSL_FIPS_READY)
  * HAVE_THREAD_LS
  * HAVE_AESGCM
  * HAVE_HASHDRBG
@@ -67,4 +69,4 @@ Additionally one may enable:
  * OPENSSL_EXTRA
  * WOLFSSL_KEY_GEN
 
-These settings are defined in IDE/WIN/user_settings.h.
+These settings are defined in IDE/WIN10/user_settings.h.

--- a/IDE/WIN10/user_settings.h
+++ b/IDE/WIN10/user_settings.h
@@ -1,6 +1,14 @@
 #ifndef _WIN_USER_SETTINGS_H_
 #define _WIN_USER_SETTINGS_H_
 
+/* For FIPS Ready, uncomment the following: */
+/* #define WOLFSSL_FIPS_READY */
+#ifdef WOLFSSL_FIPS_READY
+    #undef HAVE_FIPS_VERSION
+    #define HAVE_FIPS_VERSION 3
+#endif
+
+
 /* Verify this is Windows */
 #ifndef _WIN32
 #error This user_settings.h header is only designed for Windows

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -36,16 +36,6 @@
 #if defined(OPENSSL_EXTRA)
 
 #if !defined(HAVE_PKCS7) && \
-    ((defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
-     (HAVE_FIPS_VERSION > 2)) || defined(HAVE_SELFTEST))
-enum {
-    /* In the event of fips cert 3389 or CAVP selftest build, these enums are
-     * not in aes.h for use with evp so enumerate it here outside the fips
-     * boundary */
-    GCM_NONCE_MID_SZ = 12, /* The usual default nonce size for AES-GCM. */
-    CCM_NONCE_MIN_SZ = 7,
-};
-#elif !defined(HAVE_PKCS7) && \
       ((defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
        (HAVE_FIPS_VERSION == 2)) || defined(HAVE_SELFTEST))
     #include <wolfssl/wolfcrypt/aes.h>


### PR DESCRIPTION
1. Modify the WIN10 FIPS solution user_settings.h to check for a FIPS Ready flag and to override HAVE_FIPS_VERSION to 3 if set.
2. Removed some redundant constants from the EVP file.