### PR TITLE
DH EXTRA test: Disable DH test unless not FIPS or FIPS > 2

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14913,7 +14913,8 @@ static int dh_test(void)
 #endif
 
     /* Test DH key import / export */
-#ifdef WOLFSSL_DH_EXTRA
+#if defined(WOLFSSL_DH_EXTRA) && (!defined(HAVE_FIPS) || \
+        (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2)))
     wc_FreeDhKey(key);
     ret = wc_InitDhKey_ex(key, HEAP_HINT, devId);
     if (ret != 0) {


### PR DESCRIPTION
statickeys/dh-ffdhe2048.der is an alternate format that is supported
when WOLFSSL_DH_EXTRA is defined.
The decoding is not supported when FIPS and FIPS version is less than 3.
Fix test to not use file unless not FIPS or FIPS > 2.