### PR TITLE
ARM asm: fixes for compiling on Mac and ChaCha20 streaming

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1083,8 +1083,14 @@ then
     *)
         case $host_cpu in
         *aarch64*)
-            # +crypto needed for hardware acceleration
-            AM_CPPFLAGS="$AM_CPPFLAGS -mcpu=generic+crypto"
+            case $host_os in
+            *darwin*)
+                ;;
+            *)
+                # +crypto needed for hardware acceleration
+                AM_CPPFLAGS="$AM_CPPFLAGS -mcpu=generic+crypto"
+                ;;
+            esac
             # Include options.h
             AM_CCASFLAGS="$AM_CCASFLAGS -DEXTERNAL_OPTS_OPENVPN"
 

--- a/wolfssl/wolfcrypt/chacha.h
+++ b/wolfssl/wolfcrypt/chacha.h
@@ -79,7 +79,7 @@ typedef struct ChaCha {
     byte extra[12];
 #endif
     word32 left;                            /* number of bytes leftover */
-#ifdef USE_INTEL_CHACHA_SPEEDUP
+#if defined(USE_INTEL_CHACHA_SPEEDUP) || defined(WOLFSSL_ARMASM)
     word32 over[CHACHA_CHUNK_WORDS];
 #endif
 } ChaCha;


### PR DESCRIPTION
Don't set the CPU to generic on Mac.
Implement streaming for ChaCha20.