### PR TITLE
#2870 , Fix "tautological pointer compare" clang warning

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5542,7 +5542,7 @@ int wc_OBJ_sn2nid(const char *sn)
     if (XSTRNCMP(sn, "secp384r1", 10) == 0)
         sn = "SECP384R1";
     /* find based on name and return NID */
-    for (i = 0; ecc_sets[i].size != 0 && ecc_sets[i].name != NULL; i++) {
+    for (i = 0; ecc_sets[i].size != 0; i++) {
         if (XSTRNCMP(sn, ecc_sets[i].name, ECC_MAXNAME) == 0) {
             eccEnum = ecc_sets[i].id;
             /* Convert enum value in ecc_curve_id to OpenSSL NID */


### PR DESCRIPTION
ecc_set_type::name is defined as an array "const char name[MAX_ECC_NAME]",
can't be NULL.