### PR TITLE
Make Dist Check Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,6 +241,9 @@ linuxkm/libwolfssl.mod.c
 linuxkm/module_exports.c
 linuxkm/linuxkm/get_thread_size
 
+# Generated scripts and headers
+scripts/unit.test
+
 # MPLAB Generated Files (OS X)
 mcapi/wolfcrypt_mcapi.X/nbproject/Makefile-*
 mcapi/wolfcrypt_mcapi.X/nbproject/Package-default.bash

--- a/configure.ac
+++ b/configure.ac
@@ -75,8 +75,8 @@ AC_C_BIGENDIAN
 # check if functions of interest are linkable, but also check if
 # they're declared by the expected headers, and if not, supersede the
 # unusable positive from AC_CHECK_FUNCS().
-AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday gmtime_r inet_ntoa memset socket strftime])
-AC_CHECK_DECLS([gethostbyname, getaddrinfo, gettimeofday, gmtime_r, inet_ntoa, memset, socket, strftime], [], [
+AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday gmtime_r inet_ntoa memset socket strftime tmpfile])
+AC_CHECK_DECLS([gethostbyname, getaddrinfo, gettimeofday, gmtime_r, inet_ntoa, memset, socket, strftime, tmpfile], [], [
 if test "$(eval echo \$"$(eval 'echo ac_cv_func_${as_decl_name}')")" = "yes"
 then
     echo "    note: earlier check for $(eval 'echo ${as_decl_name}') superseded."

--- a/configure.ac
+++ b/configure.ac
@@ -5848,10 +5848,12 @@ AC_SUBST([AM_LDFLAGS])
 AC_SUBST([AM_CCASFLAGS])
 AC_SUBST([LIB_ADD])
 AC_SUBST([LIB_STATIC_ADD])
+AC_SUBST([CERTS_DIR],[$srcdir/certs])
 
 # FINAL
 AC_CONFIG_FILES([stamp-h], [echo timestamp > stamp-h])
 AC_CONFIG_FILES([Makefile wolfssl/version.h wolfssl/options.h cyassl/options.h support/wolfssl.pc rpm/spec])
+AC_CONFIG_FILES([scripts/unit.test],[chmod +x scripts/unit.test])
 
 AX_CREATE_GENERIC_CONFIG
 AX_AM_JOBSERVER([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,7 @@ AC_CHECK_SIZEOF([long])
 AC_CHECK_SIZEOF([time_t])
 AC_CHECK_TYPES([__uint128_t])
 
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stddef.h time.h sys/ioctl.h sys/socket.h sys/time.h errno.h])
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stddef.h time.h sys/ioctl.h sys/socket.h sys/time.h errno.h stdio.h])
 AC_CHECK_LIB([network],[socket])
 AC_C_BIGENDIAN
 
@@ -104,6 +104,9 @@ fi
 #endif
 #ifdef HAVE_TIME_H
     #include <time.h>
+#endif
+#ifdef HAVE_STDIO_H
+    #include <stdio.h>
 #endif
 ]])
 

--- a/scripts/unit.test
+++ b/scripts/unit.test
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-DIRNAME="$(dirname "$0")"
-bwrap_path="$(command -v bwrap)"
-if [ -n "$bwrap_path" ]; then
-    exec "$bwrap_path" --unshare-net --dev-bind / / "$DIRNAME/../tests/unit.test" "$@"
-else
-    exec "$DIRNAME/../tests/unit.test" "$@"
-fi

--- a/scripts/unit.test.in
+++ b/scripts/unit.test.in
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+bwrap_path="$(command -v bwrap)"
+if [ -n "$bwrap_path" ]; then
+    exec "$bwrap_path" --unshare-net --dev-bind / / "@builddir@/tests/unit.test" "$@"
+else
+    exec "@builddir@/tests/unit.test" "$@"
+fi


### PR DESCRIPTION
1. Add a check to configure for the tmpfile function.
2. If tmpfile is available, wolfcrypt test will use it for the cert saving tests. Make distcheck works from a read-only directory and cannot make the save files locally.
3. Modify SaveDerAndPem() to take a pointer to a file pointer to store the temp file for later use.
4. Saving the three file pointers used more than once.