### PR TITLE
add wolfSSL_get_ocsp_producedDate().

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,10 +67,45 @@ AC_CHECK_SIZEOF([long long])
 AC_CHECK_SIZEOF([long])
 AC_CHECK_SIZEOF([time_t])
 AC_CHECK_TYPES([__uint128_t])
-AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday gmtime_r inet_ntoa memset socket strftime])
+
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stddef.h time.h sys/ioctl.h sys/socket.h sys/time.h errno.h])
 AC_CHECK_LIB([network],[socket])
 AC_C_BIGENDIAN
+
+# check if functions of interest are linkable, but also check if
+# they're declared by the expected headers, and if not, supersede the
+# unusable positive from AC_CHECK_FUNCS().
+AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday gmtime_r inet_ntoa memset socket strftime])
+AC_CHECK_DECLS([gethostbyname, getaddrinfo, gettimeofday, gmtime_r, inet_ntoa, memset, socket, strftime], [], [
+if test "$(eval echo \$"$(eval 'echo ac_cv_func_${as_decl_name}')")" = "yes"
+then
+    echo "    note: earlier check for $(eval 'echo ${as_decl_name}') superseded."
+    eval "$(eval 'echo ac_cv_func_${as_decl_name}=no')"
+    _mask_varname=HAVE_`eval "echo '${as_decl_name}'" | tr 'a-z' 'A-Z'`
+    echo "g/#define $_mask_varname 1/s//\/* #undef $_mask_varname *\//
+wq
+." | ed -s confdefs.h
+fi
+], [[
+#ifdef HAVE_SYS_SOCKET_H
+    #include <sys/socket.h>
+#endif
+#ifdef HAVE_STRING_H
+    #include <string.h>
+#endif
+#ifdef HAVE_NETDB_H
+    #include <netdb.h>
+#endif
+#ifdef HAVE_ARPA_INET_H
+    #include <arpa/inet.h>
+#endif
+#ifdef HAVE_SYS_TIME_H
+    #include <sys/time.h>
+#endif
+#ifdef HAVE_TIME_H
+    #include <time.h>
+#endif
+]])
 
 AC_PROG_INSTALL
 AC_TYPE_SIZE_T
@@ -2163,7 +2198,9 @@ fi
 if test "$ENABLED_STACKSIZE" = "yes"
 then
     AC_CHECK_FUNC([posix_memalign], [], [AC_MSG_ERROR(stacksize needs posix_memalign)])
+    AC_CHECK_DECL([posix_memalign], [], [AC_MSG_ERROR(stacksize needs posix_memalign)])
     AC_CHECK_FUNC([pthread_attr_setstack], [], AC_CHECK_LIB([pthread],[pthread_attr_setstack]))
+    AC_CHECK_DECL([pthread_attr_setstack], [], [AC_MSG_ERROR(stacksize needs pthread_attr_setstack)], [[#include <pthread.h>]])
     AM_CFLAGS="$AM_CFLAGS -DHAVE_STACK_SIZE"
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -67,8 +67,8 @@ AC_CHECK_SIZEOF([long long])
 AC_CHECK_SIZEOF([long])
 AC_CHECK_SIZEOF([time_t])
 AC_CHECK_TYPES([__uint128_t])
-AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday gmtime_r inet_ntoa memset socket])
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stddef.h sys/ioctl.h sys/socket.h sys/time.h errno.h])
+AC_CHECK_FUNCS([gethostbyname getaddrinfo gettimeofday gmtime_r inet_ntoa memset socket strftime])
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stddef.h time.h sys/ioctl.h sys/socket.h sys/time.h errno.h])
 AC_CHECK_LIB([network],[socket])
 AC_C_BIGENDIAN
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -3007,6 +3007,16 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     showPeerEx(ssl, lng_index);
 
+#ifdef HAVE_OCSP
+    {
+        struct tm tm;
+        char date[32];
+        ret = wolfSSL_get_ocsp_producedDate(ssl, &tm);
+        if ((ret == 0) && (strftime(date, sizeof date, "%Y-%m-%d %H:%M:%S %z",&tm) > 0))
+            printf("OCSP response timestamp: %s\n",date);
+    }
+#endif
+
 #ifdef OPENSSL_EXTRA
     printf("Session timeout set to %ld seconds\n", wolfSSL_get_timeout(ssl));
     {

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -3011,7 +3011,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     {
         struct tm tm;
         char date[32];
-        ret = wolfSSL_get_ocsp_producedDate(ssl, &tm);
+        ret = wolfSSL_get_ocsp_producedDate_tm(ssl, &tm);
         if ((ret == 0) && (strftime(date, sizeof date, "%Y-%m-%d %H:%M:%S %z",&tm) > 0))
             printf("OCSP response timestamp: %s\n",date);
     }

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -3007,14 +3007,24 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     showPeerEx(ssl, lng_index);
 
-#ifdef HAVE_OCSP
+#if defined(HAVE_OCSP) && !defined(NO_ASN_TIME)
+#ifdef HAVE_STRFTIME
     {
         struct tm tm;
         char date[32];
         ret = wolfSSL_get_ocsp_producedDate_tm(ssl, &tm);
-        if ((ret == 0) && (strftime(date, sizeof date, "%Y-%m-%d %H:%M:%S %z",&tm) > 0))
-            printf("OCSP response timestamp: %s\n",date);
+        if ((ret == 0) && (strftime(date, sizeof date, "%Y-%m-%d %H:%M:%S %z", &tm) > 0))
+            printf("OCSP response timestamp: %s\n", date);
     }
+#else
+    {
+        byte date[MAX_DATE_SIZE];
+        int asn_date_format;
+        ret = wolfSSL_get_ocsp_producedDate(ssl, date, sizeof date, &asn_date_format);
+        if (ret == 0)
+            printf("OCSP response timestamp: %s (ASN.1 type %d)\n", (char *)date, asn_date_format);
+    }
+#endif
 #endif
 
 #ifdef OPENSSL_EXTRA

--- a/src/internal.c
+++ b/src/internal.c
@@ -9857,6 +9857,11 @@ static int ProcessCSR(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     else if (response->status->status != CERT_GOOD)
         ret = BAD_CERTIFICATE_STATUS_ERROR;
 
+    else {
+        XMEMCPY(ssl->ocspProducedDate, response->producedDate, sizeof ssl->ocspProducedDate);
+        ssl->ocspProducedDateFormat = response->producedDateFormat;
+    }
+
     *inOutIdx += status_length;
 
     #ifdef WOLFSSL_SMALL_STACK

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -44135,16 +44135,39 @@ int wolfSSL_set_ocsp_url(WOLFSSL* ssl, char* url)
 #endif /* OPENSSL_ALL || WOLFSSL_NGINX  || WOLFSSL_HAPROXY */
 
 #ifdef HAVE_OCSP
-int wolfSSL_get_ocsp_producedDate(WOLFSSL *ssl, struct tm *producedTime) {
-    int idx = 0;
-
-    if ((producedTime == NULL) || (ssl->ocspProducedDate == NULL))
-        return BAD_FUNC_ARG;
+int wolfSSL_get_ocsp_producedDate(
+    WOLFSSL *ssl,
+    byte *producedDate,
+    size_t producedDate_space,
+    int *producedDateFormat)
+{
     if ((ssl->ocspProducedDateFormat != ASN_UTC_TIME) &&
         (ssl->ocspProducedDateFormat != ASN_GENERALIZED_TIME))
         return BAD_FUNC_ARG;
 
-    if (ExtractDate(ssl->ocspProducedDate, ssl->ocspProducedDateFormat, producedTime, &idx))
+    if ((producedDate == NULL) || (producedDateFormat == NULL))
+        return BAD_FUNC_ARG;
+
+    if (XSTRLEN((char *)ssl->ocspProducedDate) >= producedDate_space)
+        return BUFFER_E;
+
+    XSTRNCPY((char *)producedDate, (const char *)ssl->ocspProducedDate, producedDate_space);
+    *producedDateFormat = ssl->ocspProducedDateFormat;
+
+    return 0;
+}
+
+int wolfSSL_get_ocsp_producedDate_tm(WOLFSSL *ssl, struct tm *produced_tm) {
+    int idx = 0;
+
+    if ((ssl->ocspProducedDateFormat != ASN_UTC_TIME) &&
+        (ssl->ocspProducedDateFormat != ASN_GENERALIZED_TIME))
+        return BAD_FUNC_ARG;
+
+    if (produced_tm == NULL)
+        return BAD_FUNC_ARG;
+
+    if (ExtractDate(ssl->ocspProducedDate, ssl->ocspProducedDateFormat, produced_tm, &idx))
         return 0;
     else
         return ASN_PARSE_E;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -44134,6 +44134,24 @@ int wolfSSL_set_ocsp_url(WOLFSSL* ssl, char* url)
 #endif /* OCSP */
 #endif /* OPENSSL_ALL || WOLFSSL_NGINX  || WOLFSSL_HAPROXY */
 
+#ifdef HAVE_OCSP
+int wolfSSL_get_ocsp_producedDate(WOLFSSL *ssl, struct tm *producedTime) {
+    int idx = 0;
+
+    if ((producedTime == NULL) || (ssl->ocspProducedDate == NULL))
+        return BAD_FUNC_ARG;
+    if ((ssl->ocspProducedDateFormat != ASN_UTC_TIME) &&
+        (ssl->ocspProducedDateFormat != ASN_GENERALIZED_TIME))
+        return BAD_FUNC_ARG;
+
+    if (ExtractDate(ssl->ocspProducedDate, ssl->ocspProducedDateFormat, producedTime, &idx))
+        return 0;
+    else
+        return ASN_PARSE_E;
+}
+#endif
+
+
 #if defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || \
     defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
 int wolfSSL_CTX_get_extra_chain_certs(WOLFSSL_CTX* ctx, WOLF_STACK_OF(X509)** chain)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -44134,7 +44134,7 @@ int wolfSSL_set_ocsp_url(WOLFSSL* ssl, char* url)
 #endif /* OCSP */
 #endif /* OPENSSL_ALL || WOLFSSL_NGINX  || WOLFSSL_HAPROXY */
 
-#ifdef HAVE_OCSP
+#if defined(HAVE_OCSP) && !defined(NO_ASN_TIME)
 int wolfSSL_get_ocsp_producedDate(
     WOLFSSL *ssl,
     byte *producedDate,

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4167,6 +4167,8 @@ struct WOLFSSL {
 #endif /* HAVE_TLS_EXTENSIONS */
 #ifdef HAVE_OCSP
         void*       ocspIOCtx;
+        byte ocspProducedDate[MAX_DATE_SZ];
+        int ocspProducedDateFormat;
     #ifdef OPENSSL_EXTRA
         byte*       ocspResp;
         int         ocspRespSz;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3735,6 +3735,16 @@ WOLFSSL_API void *wolfSSL_OPENSSL_memdup(const void *data,
 WOLFSSL_API void wolfSSL_ERR_load_BIO_strings(void);
 #endif
 
+#ifdef HAVE_OCSP
+    WOLFSSL_API int wolfSSL_get_ocsp_producedDate(
+        WOLFSSL *ssl,
+        byte *producedDate,
+        size_t producedDate_space,
+        int *producedDateFormat);
+    WOLFSSL_API int wolfSSL_get_ocsp_producedDate_tm(WOLFSSL *ssl,
+        struct tm *produced_tm);
+#endif
+
 #if defined(OPENSSL_ALL) \
     || defined(WOLFSSL_NGINX) \
     || defined(WOLFSSL_HAPROXY) \
@@ -3789,10 +3799,6 @@ WOLFSSL_API int wolfSSL_i2a_ASN1_INTEGER(WOLFSSL_BIO *bp,
 WOLFSSL_API int wolfSSL_CTX_set_tlsext_ticket_key_cb(WOLFSSL_CTX *, int (*)(
     WOLFSSL *ssl, unsigned char *name, unsigned char *iv,
     WOLFSSL_EVP_CIPHER_CTX *ectx, WOLFSSL_HMAC_CTX *hctx, int enc));
-#endif
-
-#ifdef HAVE_OCSP
-    WOLFSSL_API int wolfSSL_get_ocsp_producedDate(WOLFSSL *ssl, struct tm *producedTime);
 #endif
 
 #if defined(HAVE_OCSP) || defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL) || \

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3791,6 +3791,10 @@ WOLFSSL_API int wolfSSL_CTX_set_tlsext_ticket_key_cb(WOLFSSL_CTX *, int (*)(
     WOLFSSL_EVP_CIPHER_CTX *ectx, WOLFSSL_HMAC_CTX *hctx, int enc));
 #endif
 
+#ifdef HAVE_OCSP
+    WOLFSSL_API int wolfSSL_get_ocsp_producedDate(WOLFSSL *ssl, struct tm *producedTime);
+#endif
+
 #if defined(HAVE_OCSP) || defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL) || \
     defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
 WOLFSSL_API int wolfSSL_CTX_get_extra_chain_certs(WOLFSSL_CTX* ctx,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3735,7 +3735,7 @@ WOLFSSL_API void *wolfSSL_OPENSSL_memdup(const void *data,
 WOLFSSL_API void wolfSSL_ERR_load_BIO_strings(void);
 #endif
 
-#ifdef HAVE_OCSP
+#if defined(HAVE_OCSP) && !defined(NO_ASN_TIME)
     WOLFSSL_API int wolfSSL_get_ocsp_producedDate(
         WOLFSSL *ssl,
         byte *producedDate,


### PR DESCRIPTION
This patch adds a method for applications to access the `producedDate` value from the OCSP response, properly canonicalized to a `struct tm`.  For background c.f. ZD 11019.
