### PR TITLE
TFM Read Radix 16 OOB Read

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5296,13 +5296,13 @@ static int fp_read_radix_16(fp_int *a, const char *str)
       else
           return FP_VAL;
 
+      k += j == DIGIT_BIT;
+      j &= DIGIT_BIT - 1;
       if (k >= FP_SIZE)
           return FP_VAL;
 
       a->dp[k] |= ((fp_digit)ch) << j;
       j += 4;
-      k += j == DIGIT_BIT;
-      j &= DIGIT_BIT - 1;
   }
 
   a->used = k + 1;


### PR DESCRIPTION
Change the location of the update of the write index when in fp_read_radix_16(). It will do multiple writes into a word, and update the index when the word is full and there is more to write. If there isn't more to write, the index isn't incremented. This ensures the used value in the mp_digit is correct, and not off-by-one when the last word is full. (ZD 11056)