### PR TITLE
ECC add points: more cases where add point is a double or infinity

### DIFF
--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -471,6 +471,10 @@ ECC_API int ecc_projective_add_point(ecc_point* P, ecc_point* Q, ecc_point* R,
 ECC_API int ecc_projective_dbl_point(ecc_point* P, ecc_point* R, mp_int* a,
                                      mp_int* modulus, mp_digit mp);
 
+WOLFSSL_LOCAL
+int ecc_projective_add_point_safe(ecc_point* A, ecc_point* B, ecc_point* R,
+    mp_int* a, mp_int* modulus, mp_digit mp, int* infinity);
+
 #endif
 
 WOLFSSL_API


### PR DESCRIPTION
Extract method to perform safe point add (handling double and infinity
result).
Replace all instances of the extracted code.