### PR TITLE
Add support for id-pkix-ocsp-nocheck

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -838,7 +838,7 @@ static int SMTP_Shutdown(WOLFSSL* ssl, int wc_shutdown)
     return WOLFSSL_SUCCESS;
 }
 
-static int ClientWrite(WOLFSSL* ssl, const char* msg, int msgSz, const char* str, 
+static int ClientWrite(WOLFSSL* ssl, const char* msg, int msgSz, const char* str,
     int exitWithRet)
 {
     int ret, err;
@@ -1088,6 +1088,9 @@ static const char* client_usage_msg[][66] = {
 #endif
 #ifdef HAVE_CURVE448
         "-8          Use X448 for key exchange\n",                      /* 65 */
+#endif
+#ifdef HAVE_CRL
+        "-C          Disable CRL\n",
 #endif
         NULL,
     },
@@ -2522,7 +2525,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         }
     #endif /* WOLFSSL_TRUST_PEER_CERT && !NO_FILESYSTEM */
     }
-    if (useVerifyCb || myVerifyAction == VERIFY_FORCE_FAIL || 
+    if (useVerifyCb || myVerifyAction == VERIFY_FORCE_FAIL ||
             myVerifyAction == VERIFY_USE_PREVERFIY) {
         wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, myVerify);
     }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1616,8 +1616,9 @@ static const byte wrapPwriKekOid[] = {42, 134, 72, 134, 247, 13, 1, 9, 16, 3,9};
 
 /* ocspType */
 #ifdef HAVE_OCSP
-    static const byte ocspBasicOid[] = {43, 6, 1, 5, 5, 7, 48, 1, 1};
-    static const byte ocspNonceOid[] = {43, 6, 1, 5, 5, 7, 48, 1, 2};
+    static const byte ocspBasicOid[]    = {43, 6, 1, 5, 5, 7, 48, 1, 1};
+    static const byte ocspNonceOid[]    = {43, 6, 1, 5, 5, 7, 48, 1, 2};
+    static const byte ocspNoCheckOid[]  = {43, 6, 1, 5, 5, 7, 48, 1, 5};
 #endif /* HAVE_OCSP */
 
 /* certExtType */
@@ -1655,7 +1656,6 @@ static const byte extExtKeyUsageCodeSigningOid[]  = {43, 6, 1, 5, 5, 7, 3, 3};
 static const byte extExtKeyUsageEmailProtectOid[] = {43, 6, 1, 5, 5, 7, 3, 4};
 static const byte extExtKeyUsageTimestampOid[]    = {43, 6, 1, 5, 5, 7, 3, 8};
 static const byte extExtKeyUsageOcspSignOid[]     = {43, 6, 1, 5, 5, 7, 3, 9};
-
 /* kdfType */
 static const byte pbkdf2Oid[] = {42, 134, 72, 134, 247, 13, 1, 5, 12};
 
@@ -2035,6 +2035,12 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                 case NAME_CONS_OID:
                     oid = extNameConsOid;
                     *oidSz = sizeof(extNameConsOid);
+                    break;
+            #endif
+            #ifdef HAVE_OCSP
+                case OCSP_NOCHECK_OID:
+                    oid = ocspNoCheckOid;
+                    *oidSz = sizeof(ocspNoCheckOid);
                     break;
             #endif
             }
@@ -4440,7 +4446,7 @@ int wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz, const byte* e,
 
 #ifndef NO_DH
 /* Supports either:
- * - DH params G/P (PKCS#3 DH) file or 
+ * - DH params G/P (PKCS#3 DH) file or
  * - DH key file (if WOLFSSL_DH_EXTRA enabled) */
 /* The wc_DhParamsLoad function also loads DH params, but directly into buffers, not DhKey */
 int wc_DhKeyDecode(const byte* input, word32* inOutIdx, DhKey* key, word32 inSz)
@@ -8875,7 +8881,14 @@ static int DecodeCertExtensions(DecodedCert* cert)
                 }
                 break;
         #endif
-
+        #ifdef HAVE_OCSP
+            case OCSP_NOCHECK_OID:
+                VERIFY_AND_SET_OID(cert->ocspNoCheckSet);
+                ret = GetASNNull(input, &idx, sz);
+                if (ret != 0)
+                    return ASN_PARSE_E;
+                break;
+        #endif
             default:
             #ifndef WOLFSSL_NO_ASN_STRICT
                 /* While it is a failure to not support critical extensions,
@@ -9347,6 +9360,11 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
                     return ret;
             }
 
+        #ifdef HAVE_OCSP
+            /* trust for the lifetime of the responder's cert*/
+            if (cert->ocspNoCheckSet && verify == VERIFY_OCSP)
+                verify = NO_VERIFY;
+        #endif
             /* advance past extensions */
             cert->srcIdx = cert->sigIndex;
         }
@@ -9871,7 +9889,7 @@ void wc_FreeDer(DerBuffer** pDer)
 
 #if defined(WOLFSSL_PEM_TO_DER) || defined(WOLFSSL_DER_TO_PEM)
 
-/* Note: If items added make sure MAX_X509_HEADER_SZ is 
+/* Note: If items added make sure MAX_X509_HEADER_SZ is
     updated to reflect maximum length */
 wcchar BEGIN_CERT           = "-----BEGIN CERTIFICATE-----";
 wcchar END_CERT             = "-----END CERTIFICATE-----";
@@ -17248,7 +17266,7 @@ int CompareOcspReqResp(OcspRequest* req, OcspResponse* resp)
         WOLFSSL_MSG("\tReq missing");
         return -1;
     }
-    if (resp == NULL || resp->issuerHash == NULL || 
+    if (resp == NULL || resp->issuerHash == NULL ||
             resp->issuerKeyHash == NULL || resp->status == NULL) {
         WOLFSSL_MSG("\tResp missing");
         return 1;

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -538,7 +538,9 @@ enum Extensions_Sum {
     POLICY_CONST_OID          = 150,
     ISSUE_ALT_NAMES_OID       = 132,
     TLS_FEATURE_OID           = 92,  /* id-pe 24 */
-    NETSCAPE_CT_OID           = 753  /* 2.16.840.1.113730.1.1 */
+    NETSCAPE_CT_OID           = 753, /* 2.16.840.1.113730.1.1 */
+    OCSP_NOCHECK_OID          = 121  /* 1.3.6.1.5.5.7.48.1.5
+                                         id-pkix-ocsp-nocheck */
 };
 
 enum CertificatePolicy_Sum {
@@ -909,6 +911,9 @@ struct DecodedCert {
     byte weOwnAltNames : 1;        /* altNames haven't been given to copy */
     byte extKeyUsageSet : 1;
     byte extExtKeyUsageSet : 1;    /* Extended Key Usage set */
+#ifdef HAVE_OCSP
+    byte ocspNoCheckSet : 1;       /* id-pkix-ocsp-nocheck set */
+#endif
     byte extCRLdistSet : 1;
     byte extAuthInfoSet : 1;
     byte extBasicConstSet : 1;


### PR DESCRIPTION
ZD #10987

https://www.ietf.org/rfc/rfc2560 says
```
 - A CA may specify that an OCSP client can trust a responder for the
   lifetime of the responder's certificate. The CA does so by including
   the extension id-pkix-ocsp-nocheck. This SHOULD be a non-critical
   extension. The value of the extension should be NULL. CAs issuing
   such a certificate should realized that a compromise of the
   responder's key, is as serious as the compromise of a CA key used to
   sign CRLs, at least for the validity period of this certificate. CA's
   may choose to issue this type of certificate with a very short
   lifetime and renew it frequently.

   id-pkix-ocsp-nocheck OBJECT IDENTIFIER ::= { id-pkix-ocsp 5 }
```