### PR TITLE
Fixed SHA256 support for IMX-RT1060

### DIFF
--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -130,6 +130,8 @@ where 0 <= L < 2^64.
 #elif defined(WOLFSSL_CRYPTOCELL)
     /* wc_port.c includes wolfcrypt/src/port/arm/cryptoCellHash.c */
 
+#elif defined(WOLFSSL_IMXRT_DCP)
+
 #elif defined(WOLFSSL_PSOC6_CRYPTO)
 
 

--- a/wolfssl/wolfcrypt/port/nxp/dcp_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/dcp_port.h
@@ -38,6 +38,7 @@
 
 int wc_dcp_init(void);
 
+#ifndef NO_AES
 int  DCPAesInit(Aes* aes);
 void DCPAesFree(Aes *aes);
 
@@ -45,6 +46,7 @@ int  DCPAesSetKey(Aes* aes, const byte* key, word32 len, const byte* iv,
                           int dir);
 int  DCPAesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
 int  DCPAesCbcDecrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+#endif
 
 #ifdef HAVE_AES_ECB
 int  DCPAesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);


### PR DESCRIPTION
Two minor fixes for IMX-RT1060 support:

- in the driver, when NO_AES is defined, do not declare Aes HW acceleration prototype (may result in undefined symbol: Aes)
- In sha256.c : add exception to avoid double definition of `wc_Sha256Init()` when the driver is included

