### PR TITLE
Fixes SSLv3 use of ECDH in sniffer

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -2268,7 +2268,7 @@ static int SetupKeys(const byte* input, int* sslBytes, SnifferSession* session,
             length = wc_ecc_size(&key) * 2 + 1;
             /* The length should be 2 times the key size (x and y), plus 1
              * for the type byte. */
-            if (IsTLS(session->sslServer) && !IsAtLeastTLSv1_3(session->sslServer->version)) {
+            if (!IsAtLeastTLSv1_3(session->sslServer->version)) {
                 input += 1; /* Don't include the TLS length for the key. */
             }
 


### PR DESCRIPTION
The public key length byte needs to be skipped for import with SSLv3 and TLS (not TLS v1.3).
Note: Issue existed prior to TLS v1.3 changes and occurred in v4.4.0 as well.
ZD 11085