### PR TITLE
Maintenance Fixes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -19059,6 +19059,11 @@ const char* GetCipherKeaStr(char n[][MAX_SEGMENT_SZ]) {
     n3 = n[3];
     n4 = n[4];
 
+#if HAVE_NTRU
+    if (XSTRNCMP(n0,"NTRU",4) == 0)
+        return "NTRU";
+#endif
+
     if (XSTRNCMP(n0,"ECDHE",5) == 0 && XSTRNCMP(n1,"PSK",3) == 0)
         keaStr = "ECDHEPSK";
     else if (XSTRNCMP(n0,"ECDH",4) == 0)
@@ -19093,6 +19098,11 @@ const char* GetCipherAuthStr(char n[][MAX_SEGMENT_SZ]) {
     n0 = n[0];
     n1 = n[1];
     n2 = n[2];
+
+#ifdef HAVE_NTRU
+    if (XSTRNCMP(n0,"NTRU",4) == 0)
+        return "NTRU";
+#endif
 
     if ((XSTRNCMP(n0,"AES128",6) == 0) || (XSTRNCMP(n0,"AES256",6) == 0)  ||
         ((XSTRNCMP(n0,"TLS13",5) == 0) && ((XSTRNCMP(n1,"AES128",6) == 0) ||
@@ -19158,10 +19168,13 @@ const char* GetCipherEncStr(char n[][MAX_SEGMENT_SZ]) {
     else if ((XSTRNCMP(n0,"CAMELLIA128",11) == 0) ||
              (XSTRNCMP(n2,"CAMELLIA128",11) == 0))
         encStr = "CAMELLIA(128)";
-    else if ((XSTRNCMP(n0,"RC4",3) == 0) || (XSTRNCMP(n2,"RC4",3) == 0))
+    else if ((XSTRNCMP(n0,"RC4",3) == 0) || (XSTRNCMP(n1,"RC4",3) == 0) ||
+            (XSTRNCMP(n2,"RC4",3) == 0))
         encStr = "RC4";
-    else if (((XSTRNCMP(n0,"DES",3) == 0)  || (XSTRNCMP(n2,"DES",3) == 0)) &&
-             ((XSTRNCMP(n1,"CBC3",4) == 0) || (XSTRNCMP(n3,"CBC3",4) == 0)))
+    else if (((XSTRNCMP(n0,"DES",3) == 0)  || (XSTRNCMP(n1,"DES",3) == 0) ||
+              (XSTRNCMP(n2,"DES",3) == 0)) &&
+             ((XSTRNCMP(n1,"CBC3",4) == 0) || (XSTRNCMP(n2,"CBC3",4) == 0) ||
+              (XSTRNCMP(n3,"CBC3",4) == 0)))
         encStr = "3DES";
     else if ((XSTRNCMP(n1,"CHACHA20",8) == 0 && XSTRNCMP(n2,"POLY1305",8) == 0) ||
              (XSTRNCMP(n2,"CHACHA20",8) == 0 && XSTRNCMP(n3,"POLY1305",8) == 0))

--- a/src/internal.c
+++ b/src/internal.c
@@ -19059,7 +19059,7 @@ const char* GetCipherKeaStr(char n[][MAX_SEGMENT_SZ]) {
     n3 = n[3];
     n4 = n[4];
 
-#if HAVE_NTRU
+#ifdef HAVE_NTRU
     if (XSTRNCMP(n0,"NTRU",4) == 0)
         return "NTRU";
 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -43502,7 +43502,8 @@ unsigned long wolfSSL_ERR_peek_error_line_data(const char **file, int *line,
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
 
 
-static WC_INLINE int SKIP_SUITE(byte suite0, byte suite)
+/* Is the specified cipher suite a fake one used an an extension proxy? */
+static WC_INLINE int SCSV_Check(byte suite0, byte suite)
 {
     (void)suite0;
     (void)suite;
@@ -43511,6 +43512,7 @@ static WC_INLINE int SKIP_SUITE(byte suite0, byte suite)
         return 1;
 #endif
 #ifdef BUILD_TLS_QSH
+    /* This isn't defined as a SCSV, but it acts like one. */
     if (suite0 == QSH_BYTE && suite == TLS_QSH)
         return 1;
 #endif
@@ -43553,7 +43555,7 @@ WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl)
 
             /* A couple of suites are placeholders for special options,
              * skip those. */
-            if (SKIP_SUITE(suites->suites[i], suites->suites[i+1])) {
+            if (SCSV_Check(suites->suites[i], suites->suites[i+1])) {
                 continue;
             }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -43504,6 +43504,8 @@ unsigned long wolfSSL_ERR_peek_error_line_data(const char **file, int *line,
 
 static WC_INLINE int SKIP_SUITE(byte suite0, byte suite)
 {
+    (void)suite0;
+    (void)suite;
 #ifdef HAVE_RENEGOTIATION_INDICATION
     if (suite0 == CIPHER_BYTE && suite == TLS_EMPTY_RENEGOTIATION_INFO_SCSV)
         return 1;

--- a/tests/api.c
+++ b/tests/api.c
@@ -33329,8 +33329,7 @@ static void test_wolfSSL_X509V3_EXT_print(void)
         };
         int* n;
 
-        printf(testingFmt, "wolfSSL_X509V3_EXT_print");
-        AssertNotNull(bio = BIO_new_fp(stderr, BIO_NOCLOSE));
+        AssertNotNull(bio = BIO_new_fp(stdout, BIO_NOCLOSE));
 
         AssertNotNull(x509 = wolfSSL_X509_load_certificate_file(cliCertFileExt,
             WOLFSSL_FILETYPE_PEM));

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11087,7 +11087,7 @@ static int decodedCertCache_test(void)
         /* load cert.der */
         file = XFOPEN(certDerFile, "rb");
         if (file != NULL) {
-            derSz = XFREAD(der, 1, FOURK_BUF, file);
+            derSz = (word32)XFREAD(der, 1, FOURK_BUF, file);
             XFCLOSE(file);
         }
         else


### PR DESCRIPTION
1. Add1. The test_wolfSSL_X509V3_EXT_print() test was using stderr for output, changed to stdout.
2. A call to XFREAD wasn't typecasting its output to the size of the variable getting the output in decodedCertCache_test(). (fixes #3375)
3. Improve the reporting of the NTRU based cipher suites with the function wolfSSL_sk_CIPHER_description().
4. When building the list of ciphers with wolfSSL_get_ciphers_compat(), skip the fake indicator ciphers like the renegotiation indication and the quantum-safe hybrid since they do not have encryption or mac algorithms associated to them. (fixes #3376)