### PR TITLE
ECC mulmod: some curves can't do order-1

### DIFF
--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -546,6 +546,14 @@ void mp_exch (mp_int * a, mp_int * b)
   *b = t;
 }
 
+int mp_cond_swap_ct (mp_int * a, mp_int * b, int c, int m)
+{
+    (void)c;
+    if (m == 1)
+        mp_exch(a, b);
+    return MP_OKAY;
+}
+
 
 /* shift right a certain number of bits */
 void mp_rshb (mp_int *c, int x)

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -305,6 +305,7 @@ MP_API int  mp_div_2d (mp_int * a, int b, mp_int * c, mp_int * d);
 MP_API void mp_zero (mp_int * a);
 MP_API void mp_clamp (mp_int * a);
 MP_API void mp_exch (mp_int * a, mp_int * b);
+MP_API int  mp_cond_swap_ct (mp_int * a, mp_int * b, int c, int m);
 MP_API void mp_rshd (mp_int * a, int b);
 MP_API void mp_rshb (mp_int * a, int b);
 MP_API int  mp_mod_2d (mp_int * a, int b, mp_int * c);

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -832,6 +832,7 @@ MP_API int  mp_lcm(fp_int *a, fp_int *b, fp_int *c);
 MP_API int  mp_rand_prime(mp_int* N, int len, WC_RNG* rng, void* heap);
 MP_API int  mp_exch(mp_int *a, mp_int *b);
 #endif /* WOLFSSL_KEY_GEN */
+MP_API int  mp_cond_swap_ct (mp_int * a, mp_int * b, int c, int m);
 
 MP_API int  mp_cnt_lsb(fp_int *a);
 MP_API int  mp_div_2d(fp_int *a, int b, fp_int *c, fp_int *d);


### PR DESCRIPTION
Change implementation of timing resistant scalar multiplication to use
Joye double-add ladder.
No longer have fake operations being performed therefore can remove the
order adding operations.
Still need to check for boundary condition: order-1 wil not work with
SECP256K1 as it results in an add of order/2 and (order/2)+1 times base
point which are the negatives of each other. The sum is infinity and not
handled by maths.
Added mp_cond_swap_t - Conditionally swap in constant time.