### PR TITLE
TLS session tickets: cannot share between TLS 1.3 and TLS 1.2

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -28401,6 +28401,13 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 return VERSION_ERROR;
             }
             else if (ssl->version.minor > it.pv.minor) {
+                if (IsAtLeastTLSv1_3(it.pv) != IsAtLeastTLSv1_3(ssl->version)) {
+                    ForceZero(&it, sizeof(it));
+                    WOLFSSL_MSG("Tickets cannot be shared between "
+                                               "TLS 1.3 and TLS 1.2 and lower");
+                    return VERSION_ERROR;
+                }
+
                 if (!ssl->options.downgrade) {
                     ForceZero(&it, sizeof(it));
                     WOLFSSL_MSG("Ticket has lesser version");

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3369,7 +3369,8 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
                                      diff - MAX_TICKET_AGE_SECS * 1000 > 1000) {
                 /* Invalid difference, fallback to full handshake. */
                 ssl->options.resuming = 0;
-                break;
+                /* Hash the rest of the ClientHello. */
+                return HashRaw(ssl, input + helloSz - bindersLen, bindersLen);
             }
 
             /* Check whether resumption is possible based on suites in SSL and


### PR DESCRIPTION
When parsing ticket, check TLS version to see whether they are version
compatible.