### PR TITLE
Automake Fixes

### DIFF
--- a/certs/include.am
+++ b/certs/include.am
@@ -114,7 +114,3 @@ include certs/test/include.am
 include certs/test-pathlen/include.am
 include certs/intermediate/include.am
 
-if BUILD_FIPS_V2
-else
-noinst_DATA += certs/check_dates.sh
-endif

--- a/certs/p521/include.am
+++ b/certs/p521/include.am
@@ -29,10 +29,3 @@ EXTRA_DIST += \
          certs/p521/server-p521-priv.der \
          certs/p521/server-p521-priv.pem
 
-if BUILD_FIPS_V2
-else
-noinst_DATA+= \
-         certs/p521/gen-p521-certs.sh \
-         certs/p521/gen-p521-keys.sh
-endif
-


### PR DESCRIPTION
1. A couple cert scripts needed to be included in Makefile as EXTRA_DIST, not optional.
2. The unit test is in the tests directory, build and run it from there.