### PR TITLE
TLS OCSP Stapling: MUST staple option

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1040,65 +1040,66 @@ static const char* client_usage_msg[][66] = {
 #if defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
  || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
         "-W <num>    Use OCSP Stapling (1 v1, 2 v2, 3 v2 multi)\n",     /* 41 */
+        "            With 'm' at end indicates MUST staple\n",          /* 42 */
 #endif
 #if defined(ATOMIC_USER) && !defined(WOLFSSL_AEAD_ONLY)
-        "-U          Atomic User Record Layer Callbacks\n",             /* 42 */
+        "-U          Atomic User Record Layer Callbacks\n",             /* 43 */
 #endif
 #ifdef HAVE_PK_CALLBACKS
-        "-P          Public Key Callbacks\n",                           /* 43 */
+        "-P          Public Key Callbacks\n",                           /* 44 */
 #endif
 #ifdef HAVE_ANON
-        "-a          Anonymous client\n",                               /* 44 */
+        "-a          Anonymous client\n",                               /* 45 */
 #endif
 #ifdef HAVE_CRL
-        "-C          Disable CRL\n",                                    /* 45 */
+        "-C          Disable CRL\n",                                    /* 46 */
 #endif
 #ifdef WOLFSSL_TRUST_PEER_CERT
-        "-E <file>   Path to load trusted peer cert\n",                 /* 46 */
+        "-E <file>   Path to load trusted peer cert\n",                 /* 47 */
 #endif
 #ifdef HAVE_WNR
-        "-q <file>   Whitewood config file,      defaults\n",           /* 47 */
+        "-q <file>   Whitewood config file,      defaults\n",           /* 48 */
 #endif
         "-H <arg>    Internal tests"
-            " [defCipherList, exitWithRet, verifyFail, useSupCurve,\n", /* 48 */
-        "                            loadSSL, disallowETM]\n",          /* 49 */
+            " [defCipherList, exitWithRet, verifyFail, useSupCurve,\n", /* 49 */
+        "                            loadSSL, disallowETM]\n",          /* 50 */
 #ifdef WOLFSSL_TLS13
-        "-J          Use HelloRetryRequest to choose group for KE\n",   /* 50 */
-        "-K          Key Exchange for PSK not using (EC)DHE\n",         /* 51 */
-        "-I          Update keys and IVs before sending data\n",        /* 52 */
+        "-J          Use HelloRetryRequest to choose group for KE\n",   /* 51 */
+        "-K          Key Exchange for PSK not using (EC)DHE\n",         /* 52 */
+        "-I          Update keys and IVs before sending data\n",        /* 53 */
 #ifndef NO_DH
-        "-y          Key Share with FFDHE named groups only\n",         /* 53 */
+        "-y          Key Share with FFDHE named groups only\n",         /* 54 */
 #endif
 #ifdef HAVE_ECC
-        "-Y          Key Share with ECC named groups only\n",           /* 54 */
+        "-Y          Key Share with ECC named groups only\n",           /* 55 */
 #endif
 #endif /* WOLFSSL_TLS13 */
 #ifdef HAVE_CURVE25519
-        "-t          Use X25519 for key exchange\n",                    /* 55 */
+        "-t          Use X25519 for key exchange\n",                    /* 56 */
 #endif
 #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
-        "-Q          Support requesting certificate post-handshake\n",  /* 56 */
+        "-Q          Support requesting certificate post-handshake\n",  /* 57 */
 #endif
 #ifdef WOLFSSL_EARLY_DATA
-        "-0          Early data sent to server (0-RTT handshake)\n",    /* 57 */
+        "-0          Early data sent to server (0-RTT handshake)\n",    /* 58 */
 #endif
 #ifdef WOLFSSL_MULTICAST
-        "-3 <grpid>  Multicast, grpid < 256\n",                         /* 58 */
+        "-3 <grpid>  Multicast, grpid < 256\n",                         /* 59 */
 #endif
         "-1 <num>    Display a result by specified language.\n"
-                               "            0: English, 1: Japanese\n", /* 59 */
+                               "            0: English, 1: Japanese\n", /* 60 */
 #if !defined(NO_DH) && !defined(HAVE_FIPS) && \
     !defined(HAVE_SELFTEST) && !defined(WOLFSSL_OLD_PRIME_CHECK)
-        "-2          Disable DH Prime check\n",                         /* 60 */
+        "-2          Disable DH Prime check\n",                         /* 61 */
 #endif
 #ifdef HAVE_SECURE_RENEGOTIATION
-        "-4          Use resumption for renegotiation\n",               /* 61 */
+        "-4          Use resumption for renegotiation\n",               /* 62 */
 #endif
 #ifdef HAVE_TRUSTED_CA
-        "-5          Use Trusted CA Key Indication\n",                  /* 62 */
+        "-5          Use Trusted CA Key Indication\n",                  /* 63 */
 #endif
 #ifdef HAVE_CURVE448
-        "-8          Use X448 for key exchange\n",                      /* 65 */
+        "-8          Use X448 for key exchange\n",                      /* 66 */
 #endif
 #ifdef HAVE_CRL
         "-C          Disable CRL\n",
@@ -1208,67 +1209,68 @@ static const char* client_usage_msg[][66] = {
  || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
         "-W <num>    OCSP Staplingを使用する"
                                          " (1 v1, 2 v2, 3 v2 multi)\n", /* 41 */
+        "            With 'm' at end indicates MUST staple\n",          /* 42 */
 #endif
 #if defined(ATOMIC_USER) && !defined(WOLFSSL_AEAD_ONLY)
         "-U          アトミック・ユーザー記録の"
-                                           "コールバックを利用する\n",  /* 42 */
+                                           "コールバックを利用する\n",  /* 43 */
 #endif
 #ifdef HAVE_PK_CALLBACKS
-        "-P          公開鍵コールバック\n",                             /* 43 */
+        "-P          公開鍵コールバック\n",                             /* 44 */
 #endif
 #ifdef HAVE_ANON
-        "-a          匿名クライアント\n",                               /* 44 */
+        "-a          匿名クライアント\n",                               /* 45 */
 #endif
 #ifdef HAVE_CRL
-        "-C          CRLを無効\n",                                      /* 45 */
+        "-C          CRLを無効\n",                                      /* 46 */
 #endif
 #ifdef WOLFSSL_TRUST_PEER_CERT
-        "-E <file>   信頼出来るピアの証明書ロードの為のパス\n",         /* 46 */
+        "-E <file>   信頼出来るピアの証明書ロードの為のパス\n",         /* 47 */
 #endif
 #ifdef HAVE_WNR
-        "-q <file>   Whitewood コンフィグファイル,      既定値\n",      /* 47 */
+        "-q <file>   Whitewood コンフィグファイル,      既定値\n",      /* 48 */
 #endif
         "-H <arg>    内部テスト"
-            " [defCipherList, exitWithRet, verifyFail, useSupCurve,\n", /* 48 */
-        "                            loadSSL, disallowETM]\n",          /* 49 */
+            " [defCipherList, exitWithRet, verifyFail, useSupCurve,\n", /* 49 */
+        "                            loadSSL, disallowETM]\n",          /* 50 */
 #ifdef WOLFSSL_TLS13
-        "-J          HelloRetryRequestをKEのグループ選択に使用する\n",  /* 50 */
-        "-K          鍵交換にPSKを使用、(EC)DHEは使用しない\n",         /* 51 */
-        "-I          データ送信前に、鍵とIVを更新する\n",               /* 52 */
+        "-J          HelloRetryRequestをKEのグループ選択に使用する\n",  /* 51 */
+        "-K          鍵交換にPSKを使用、(EC)DHEは使用しない\n",         /* 52 */
+        "-I          データ送信前に、鍵とIVを更新する\n",               /* 53 */
 #ifndef NO_DH
-        "-y          FFDHE名前付きグループとの鍵共有のみ\n",            /* 53 */
+        "-y          FFDHE名前付きグループとの鍵共有のみ\n",            /* 54 */
 #endif
 #ifdef HAVE_ECC
-        "-Y          ECC名前付きグループとの鍵共有のみ\n",              /* 54 */
+        "-Y          ECC名前付きグループとの鍵共有のみ\n",              /* 55 */
 #endif
 #endif /* WOLFSSL_TLS13 */
 #ifdef HAVE_CURVE25519
-        "-t          X25519を鍵交換に使用する\n",                       /* 55 */
+        "-t          X25519を鍵交換に使用する\n",                       /* 56 */
 #endif
 #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
-        "-Q          ポストハンドシェークの証明要求をサポートする\n",   /* 56 */
+        "-Q          ポストハンドシェークの証明要求をサポートする\n",   /* 57 */
 #endif
 #ifdef WOLFSSL_EARLY_DATA
         "-0          Early data をサーバーへ送信する"
-                            "（0-RTTハンドシェイク）\n",                /* 57 */
+                            "（0-RTTハンドシェイク）\n",                /* 58 */
 #endif
 #ifdef WOLFSSL_MULTICAST
-        "-3 <grpid>  マルチキャスト, grpid < 256\n",                    /* 58 */
+        "-3 <grpid>  マルチキャスト, grpid < 256\n",                    /* 59 */
 #endif
         "-1 <num>    指定された言語で結果を表示します。\n"
-                                   "            0: 英語、 1: 日本語\n", /* 59 */
+                                   "            0: 英語、 1: 日本語\n", /* 60 */
 #if !defined(NO_DH) && !defined(HAVE_FIPS) && \
     !defined(HAVE_SELFTEST) && !defined(WOLFSSL_OLD_PRIME_CHECK)
-        "-2          DHプライム番号チェックを無効にする\n",             /* 60 */
+        "-2          DHプライム番号チェックを無効にする\n",             /* 61 */
 #endif
 #ifdef HAVE_SECURE_RENEGOTIATION
-        "-4          再交渉に再開を使用\n",                             /* 61 */
+        "-4          再交渉に再開を使用\n",                             /* 62 */
 #endif
 #ifdef HAVE_TRUSTED_CA
-        "-5          信頼できる認証局の鍵表示を使用する\n",             /* 62 */
+        "-5          信頼できる認証局の鍵表示を使用する\n",             /* 63 */
 #endif
 #ifdef HAVE_CURVE448
-        "-8          Use X448 for key exchange\n",                      /* 65 */
+        "-8          Use X448 for key exchange\n",                      /* 66 */
 #endif
         NULL,
     },
@@ -1526,6 +1528,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #if defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
  || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
     byte statusRequest = 0;
+    byte mustStaple = 0;
 #endif
 #ifdef HAVE_EXTENDED_MASTER
     byte disableExtMasterSecret = 0;
@@ -1935,6 +1938,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                     if (statusRequest > OCSP_STAPLING_OPT_MAX) {
                         Usage();
                         XEXIT_T(MY_EX_USAGE);
+                    }
+                    if (myoptarg[XSTRLEN(myoptarg)-1] == 'M' ||
+                                         myoptarg[XSTRLEN(myoptarg)-1] == 'm') {
+                        mustStaple = 1;
                     }
                 #endif
                 break;
@@ -2885,6 +2892,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
         if (wolfSSL_CTX_EnableOCSPStapling(ctx) != WOLFSSL_SUCCESS)
             err_sys("can't enable OCSP Stapling Certificate Manager");
+        if (mustStaple) {
+            if (wolfSSL_CTX_EnableOCSPMustStaple(ctx) != WOLFSSL_SUCCESS)
+                err_sys("can't enable OCSP Must Staple");
+        }
 
         switch (statusRequest) {
         #ifdef HAVE_CERTIFICATE_STATUS_REQUEST

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -334,6 +334,58 @@ if [ $? -ne 0 ]; then
     printf '%s\n\n' "Test successfully REVOKED!"
 fi
 
+# need a unique port since may run the same time as testsuite
+generate_port() {
+    port=$(($(od -An -N2 /dev/random) % (65535-49512) + 49512))
+}
+
+# Start OpenSSL server that has no OCSP responses to return
+generate_port
+openssl s_server -cert ./certs/server-cert.pem -key certs/server-key.pem -www -port $port &
+openssl_pid=$!
+sleep 0.1
+
+printf '%s\n\n' "------------- TEST CASE 5 SHOULD PASS ----------------------"
+# client asks for OCSP staple but doesn't fail when none returned
+./examples/client/client -p $port -g -v 3 -W 1
+
+RESULT=$?
+[ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 5 failed" && exit 1
+printf '%s\n\n' "Test PASSED!"
+
+printf '%s\n\n' "------------- TEST CASE 6 SHOULD UNKNOWN -------------------"
+# client asks for OCSP staple but doesn't fail when none returned
+./examples/client/client -p $port -g -v 3 -W 1m
+
+RESULT=$?
+[ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection 6 succeeded $RESULT" \
+                  && exit 1
+printf '%s\n\n' "Test PASSED!"
+
+openssl ciphers -tls1_3
+openssl_tls13=$?
+./examples/client/client -v 4 2>&1 | grep -- 'Bad SSL version'
+wolfssl_not_tls13=$?
+if [ "$openssl_tls13" = "0" -a "wolfssl_not_tls13" != "0" ]; then
+    printf '%s\n\n' "------------- TEST CASE 7 SHOULD PASS --------------------"
+    # client asks for OCSP staple but doesn't fail when none returned
+    ./examples/client/client -p $port -g -v 4 -W 1
+
+    RESULT=$?
+    [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 7 failed" && exit 1
+    printf '%s\n\n' "Test PASSED!"
+
+    printf '%s\n\n' "------------- TEST CASE 8 SHOULD UNKNOWN -----------------"
+    # client asks for OCSP staple but doesn't fail when none returned
+    ./examples/client/client -p $port -g -v 4 -W 1m
+
+    RESULT=$?
+    [ $RESULT -ne 1 ] \
+                  && printf '\n\n%s\n' "Client connection 8 succeeded $RESULT" \
+                  && exit 1
+    printf '%s\n\n' "Test PASSED!"
+fi
+
 printf '%s\n\n' "------------------- TESTS COMPLETE ---------------------------"
 
 exit 0

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -423,6 +423,35 @@ if [ $? -ne 1 ]; then
 fi
 printf '%s\n\n' "Test successfully REVOKED!"
 
+# need a unique port since may run the same time as testsuite
+generate_port() {
+    port=$(($(od -An -N2 /dev/random) % (65535-49512) + 49512))
+}
+
+# Start OpenSSL server that has no OCSP responses to return
+generate_port
+openssl s_server -cert ./certs/server-cert.pem -key certs/server-key.pem -www -port $port &
+openssl_pid=$!
+sleep 0.1
+
+printf '%s\n\n' "------------- TEST CASE 9 SHOULD PASS ----------------------"
+# client asks for OCSP staple but doesn't fail when none returned
+./examples/client/client -p $port -g -v 3 -W 2
+
+RESULT=$?
+[ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 9 failed" && exit 1
+printf '%s\n\n' "Test PASSED!"
+
+printf '%s\n\n' "------------- TEST CASE 10 SHOULD UNKNOWN -------------------"
+# client asks for OCSP staple but doesn't fail when none returned
+./examples/client/client -p $port -g -v 3 -W 2m
+
+RESULT=$?
+[ $RESULT -ne 1 ] \
+                 && printf '\n\n%s\n' "Client connection 10 succeeded $RESULT" \
+                 && exit 1
+printf '%s\n\n' "Test PASSED!"
+
 printf '%s\n\n' "------------------- TESTS COMPLETE ---------------------------"
 
 exit 0

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6293,6 +6293,48 @@ int wolfSSL_CertManagerDisableOCSPStapling(WOLFSSL_CERT_MANAGER* cm)
     return ret;
 }
 
+/* require OCSP stapling response */
+int wolfSSL_CertManagerEnableOCSPMustStaple(WOLFSSL_CERT_MANAGER* cm)
+{
+    int ret = WOLFSSL_SUCCESS;
+
+    WOLFSSL_ENTER("wolfSSL_CertManagerEnableOCSPMustStaple");
+
+    if (cm == NULL)
+        return BAD_FUNC_ARG;
+
+#if defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
+ || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
+    #ifndef NO_WOLFSSL_CLIENT
+        cm->ocspMustStaple = 1;
+    #endif
+#else
+    ret = NOT_COMPILED_IN;
+#endif
+
+    return ret;
+}
+
+int wolfSSL_CertManagerDisableOCSPMustStaple(WOLFSSL_CERT_MANAGER* cm)
+{
+    int ret = WOLFSSL_SUCCESS;
+
+    WOLFSSL_ENTER("wolfSSL_CertManagerDisableOCSPMustStaple");
+
+    if (cm == NULL)
+        return BAD_FUNC_ARG;
+
+#if defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
+ || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
+    #ifndef NO_WOLFSSL_CLIENT
+        cm->ocspMustStaple = 0;
+    #endif
+#else
+    ret = NOT_COMPILED_IN;
+#endif
+    return ret;
+}
+
 #ifdef HAVE_OCSP
 /* check CRL if enabled, WOLFSSL_SUCCESS  */
 int wolfSSL_CertManagerCheckOCSP(WOLFSSL_CERT_MANAGER* cm, byte* der, int sz)
@@ -6510,6 +6552,24 @@ int wolfSSL_CTX_DisableOCSPStapling(WOLFSSL_CTX* ctx)
     WOLFSSL_ENTER("wolfSSL_CTX_DisableOCSPStapling");
     if (ctx)
         return wolfSSL_CertManagerDisableOCSPStapling(ctx->cm);
+    else
+        return BAD_FUNC_ARG;
+}
+
+int wolfSSL_CTX_EnableOCSPMustStaple(WOLFSSL_CTX* ctx)
+{
+    WOLFSSL_ENTER("wolfSSL_CTX_EnableOCSPMustStaple");
+    if (ctx)
+        return wolfSSL_CertManagerEnableOCSPMustStaple(ctx->cm);
+    else
+        return BAD_FUNC_ARG;
+}
+
+int wolfSSL_CTX_DisableOCSPMustStaple(WOLFSSL_CTX* ctx)
+{
+    WOLFSSL_ENTER("wolfSSL_CTX_DisableOCSPMustStaple");
+    if (ctx)
+        return wolfSSL_CertManagerDisableOCSPMustStaple(ctx->cm);
     else
         return BAD_FUNC_ARG;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -1581,6 +1581,8 @@ static void test_wolfSSL_CTX_enable_disable(void)
       defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
     AssertIntEQ(wolfSSL_CTX_DisableOCSPStapling(ctx), BAD_FUNC_ARG);
     AssertIntEQ(wolfSSL_CTX_EnableOCSPStapling(ctx), BAD_FUNC_ARG);
+    AssertIntEQ(wolfSSL_CTX_DisableOCSPMustStaple(ctx), BAD_FUNC_ARG);
+    AssertIntEQ(wolfSSL_CTX_EnableOCSPMustStaple(ctx), BAD_FUNC_ARG);
   #endif
 
   #ifndef NO_WOLFSSL_CLIENT
@@ -1620,6 +1622,8 @@ static void test_wolfSSL_CTX_enable_disable(void)
       defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
     AssertIntEQ(wolfSSL_CTX_DisableOCSPStapling(ctx), WOLFSSL_SUCCESS);
     AssertIntEQ(wolfSSL_CTX_EnableOCSPStapling(ctx), WOLFSSL_SUCCESS);
+    AssertIntEQ(wolfSSL_CTX_DisableOCSPMustStaple(ctx), WOLFSSL_SUCCESS);
+    AssertIntEQ(wolfSSL_CTX_DisableOCSPMustStaple(ctx), WOLFSSL_SUCCESS);
   #endif
     wolfSSL_CTX_free(ctx);
 #endif /* NO_CERTS */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1998,18 +1998,22 @@ struct WOLFSSL_CERT_MANAGER {
 #ifndef NO_WOLFSSL_CM_VERIFY
     VerifyCallback  verifyCallback;      /* Verify callback */
 #endif
-    CallbackCACache caCacheCallback;     /* CA cache addition callback */
-    CbMissingCRL    cbMissingCRL;        /* notify through cb of missing crl */
-    CbOCSPIO        ocspIOCb;            /* I/O callback for OCSP lookup */
-    CbOCSPRespFree  ocspRespFreeCb;      /* Frees OCSP Response from IO Cb */
-    wolfSSL_Mutex   caLock;              /* CA list lock */
-    byte            crlEnabled;          /* is CRL on ? */
-    byte            crlCheckAll;         /* always leaf, but all ? */
-    byte            ocspEnabled;         /* is OCSP on ? */
-    byte            ocspCheckAll;        /* always leaf, but all ? */
-    byte            ocspSendNonce;       /* send the OCSP nonce ? */
-    byte            ocspUseOverrideURL;  /* ignore cert's responder, override */
-    byte            ocspStaplingEnabled; /* is OCSP Stapling on ? */
+    CallbackCACache caCacheCallback;       /* CA cache addition callback */
+    CbMissingCRL    cbMissingCRL;          /* notify thru cb of missing crl */
+    CbOCSPIO        ocspIOCb;              /* I/O callback for OCSP lookup */
+    CbOCSPRespFree  ocspRespFreeCb;        /* Frees OCSP Response from IO Cb */
+    wolfSSL_Mutex   caLock;                /* CA list lock */
+    byte            crlEnabled:1;          /* is CRL on ? */
+    byte            crlCheckAll:1;         /* always leaf, but all ? */
+    byte            ocspEnabled:1;         /* is OCSP on ? */
+    byte            ocspCheckAll:1;        /* always leaf, but all ? */
+    byte            ocspSendNonce:1;       /* send the OCSP nonce ? */
+    byte            ocspUseOverrideURL:1;  /* ignore cert responder, override */
+    byte            ocspStaplingEnabled:1; /* is OCSP Stapling on ? */
+#if !defined(NO_WOLFSSL_CLIENT) && (defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
+                               ||  defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2))
+    byte            ocspMustStaple:1;      /* server must respond with staple */
+#endif
 
 #ifndef NO_RSA
     short           minRsaKeySz;         /* minimum allowed RSA key size */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2772,6 +2772,10 @@ WOLFSSL_API void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl);
                                                       WOLFSSL_CERT_MANAGER* cm);
     WOLFSSL_API int wolfSSL_CertManagerDisableOCSPStapling(
                                                       WOLFSSL_CERT_MANAGER* cm);
+    WOLFSSL_API int wolfSSL_CertManagerEnableOCSPMustStaple(
+                                                      WOLFSSL_CERT_MANAGER* cm);
+    WOLFSSL_API int wolfSSL_CertManagerDisableOCSPMustStaple(
+                                                      WOLFSSL_CERT_MANAGER* cm);
 #if defined(OPENSSL_EXTRA) && defined(WOLFSSL_SIGNER_DER_CERT) && !defined(NO_FILESYSTEM)
 WOLFSSL_API WOLFSSL_STACK* wolfSSL_CertManagerGetCerts(WOLFSSL_CERT_MANAGER* cm);
 #endif
@@ -2808,6 +2812,8 @@ WOLFSSL_API WOLFSSL_STACK* wolfSSL_CertManagerGetCerts(WOLFSSL_CERT_MANAGER* cm)
                                                CbOCSPIO, CbOCSPRespFree, void*);
     WOLFSSL_API int wolfSSL_CTX_EnableOCSPStapling(WOLFSSL_CTX*);
     WOLFSSL_API int wolfSSL_CTX_DisableOCSPStapling(WOLFSSL_CTX*);
+    WOLFSSL_API int wolfSSL_CTX_EnableOCSPMustStaple(WOLFSSL_CTX*);
+    WOLFSSL_API int wolfSSL_CTX_DisableOCSPMustStaple(WOLFSSL_CTX*);
 #endif /* !NO_CERTS */
 
 


### PR DESCRIPTION
Can enable OCSP Must Staple option to mean that if the client sends a
request for an OCSP Staple then it must receive a response.