### PR TITLE
misc fixes for coverage and buildability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -354,6 +354,7 @@ then
     enable_nullcipher=yes
     enable_blake2=yes
     enable_blake2s=yes
+    enable_md2=yes
     enable_md4=yes
     enable_postauth=yes
     enable_hrrcookie=yes
@@ -472,6 +473,7 @@ then
     enable_nullcipher=yes
     enable_blake2=yes
     enable_blake2s=yes
+    enable_md2=yes
     enable_md4=yes
     enable_cryptocb=yes
     enable_anon=yes
@@ -1586,7 +1588,7 @@ fi
 AC_ARG_ENABLE([blake2s],
     [AS_HELP_STRING([--enable-blake2s],[Enable wolfSSL BLAKE2s support (default: disabled)])],
     [ ENABLED_BLAKE2S=$enableval ],
-    [ ENABLED_BLAKE2S=Sno ]
+    [ ENABLED_BLAKE2S=no ]
     )
 
 if test "$ENABLED_BLAKE2S" = "yes"
@@ -3290,7 +3292,7 @@ then
         AC_MSG_ERROR([cannot enable qsh without NTRU])
     fi
 
-    AM_CFLAGS="$AM_CFLAGS -DHAVE_QSH"
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_QSH -DWOLFSSL_STATIC_DH -DWOLFSSL_STATIC_PSK"
 fi
 
 
@@ -5931,6 +5933,8 @@ echo "   * DES3:                       $ENABLED_DES3"
 echo "   * IDEA:                       $ENABLED_IDEA"
 echo "   * Camellia:                   $ENABLED_CAMELLIA"
 echo "   * NULL Cipher:                $ENABLED_NULL_CIPHER"
+echo "   * MD2:                        $ENABLED_MD2"
+echo "   * MD4:                        $ENABLED_MD4"
 echo "   * MD5:                        $ENABLED_MD5"
 echo "   * RIPEMD:                     $ENABLED_RIPEMD"
 echo "   * SHA:                        $ENABLED_SHA"

--- a/tests/api.c
+++ b/tests/api.c
@@ -6473,7 +6473,7 @@ static int test_wc_Sha256Final (void)
 static int test_wc_Sha256FinalRaw (void)
 {
     int flag = 0;
-#if !defined(NO_SHA256) && !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
+#if !defined(NO_SHA256) && !defined(HAVE_SELFTEST) && !defined(WOLFSSL_DEVCRYPTO) && (!defined(HAVE_FIPS) || \
     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 3)))
     wc_Sha256 sha256;
     byte* hash_test[3];

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -118,7 +118,7 @@ static int IsOldTlsVersion(const char* line)
 
 
 /* if the cipher suite on line is valid store in suite and return 1, else 0 */
-static int IsValidCipherSuite(const char* line, char* suite)
+static int IsValidCipherSuite(const char* line, char *suite, size_t suite_spc)
 {
     int  found = 0;
     int  valid = 0;
@@ -126,6 +126,9 @@ static int IsValidCipherSuite(const char* line, char* suite)
     const char* find = "-l ";
     const char* begin = strstr(line, find);
     const char* end;
+
+    if (suite_spc < MAX_SUITE_SZ+1)
+        return 0;
 
     suite[0] = '\0';
 
@@ -152,10 +155,10 @@ static int IsValidCipherSuite(const char* line, char* suite)
 
     /* if QSH not enabled then do not use QSH suite */
     #ifdef HAVE_QSH
-        if (XSTRNCMP(suite, "QSH", 3) == 0) {
+        if (suite[0] && (XSTRNCMP(suite, "QSH", 3) == 0)) {
             if (wolfSSL_CTX_set_cipher_list(cipherSuiteCtx, suite + 4)
                                                                  != WOLFSSL_SUCCESS)
-            return 0;
+                return 0;
         }
     #endif
 
@@ -329,7 +332,7 @@ static int execute_test_case(int svr_argc, char** svr_argv,
         strcat(commandLine, svr_argv[i]);
         strcat(commandLine, flagSep);
     }
-    if (IsValidCipherSuite(commandLine, cipherSuite) == 0) {
+    if (IsValidCipherSuite(commandLine, cipherSuite, sizeof cipherSuite) == 0) {
         #ifdef DEBUG_SUITE_TESTS
             printf("cipher suite %s not supported in build\n", cipherSuite);
         #endif


### PR DESCRIPTION
fix spelling of "Sno" to "no" for $ENABLED_BLAKE2S default; when ENABLED_QSH add -DWOLFSSL_STATIC_DH -DWOLFSSL_STATIC_PSK (relates to ZD11073); add missing gating for !defined(WOLFSSL_DEVCRYPTO) in api.c:test_wc_Sha256FinalRaw(); fix tests/api.c:IsValidCipherSuite() to build under gcc10 (relates to ZD11073).