### PR TITLE
DH Fix

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -21178,6 +21178,9 @@ static int GetDhPublicKey(WOLFSSL* ssl, const byte* input, word32 size,
     }
 
     ato16(input + args->idx, &length);
+    if (length < MIN_DHKEY_SZ || length > MAX_DHKEY_SZ) {
+        ERROR_OUT(DH_KEY_SIZE_E, exit_gdpk);
+    }
     args->idx += OPAQUE16_LEN;
 
     if ((args->idx - args->begin) + length > size) {
@@ -21219,6 +21222,12 @@ static int GetDhPublicKey(WOLFSSL* ssl, const byte* input, word32 size,
     }
 
     ato16(input + args->idx, &length);
+    if (length > MAX_DHKEY_SZ) {
+        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap,
+                DYNAMIC_TYPE_PUBLIC_KEY);
+        ssl->buffers.serverDH_P.buffer = NULL;
+        ERROR_OUT(DH_KEY_SIZE_E, exit_gdpk);
+    }
     args->idx += OPAQUE16_LEN;
 
     if ((args->idx - args->begin) + length > size) {
@@ -21256,6 +21265,16 @@ static int GetDhPublicKey(WOLFSSL* ssl, const byte* input, word32 size,
     }
 
     ato16(input + args->idx, &length);
+    if (length < MIN_DHKEY_SZ || length > MAX_DHKEY_SZ) {
+        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap,
+                DYNAMIC_TYPE_PUBLIC_KEY);
+        ssl->buffers.serverDH_P.buffer = NULL;
+        XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap,
+                DYNAMIC_TYPE_PUBLIC_KEY);
+        ssl->buffers.serverDH_G.buffer = NULL;
+        ERROR_OUT(BUFFER_ERROR, exit_gdpk);
+        ERROR_OUT(DH_KEY_SIZE_E, exit_gdpk);
+    }
     args->idx += OPAQUE16_LEN;
 
     if ((args->idx - args->begin) + length > size) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -21164,11 +21164,12 @@ static int GetDhPublicKey(WOLFSSL* ssl, const byte* input, word32 size,
             ssl->buffers.serverDH_G.buffer = NULL;
         }
 
-        if (ssl->buffers.serverDH_Pub.buffer) {
-            XFREE(ssl->buffers.serverDH_Pub.buffer, ssl->heap,
-                    DYNAMIC_TYPE_PUBLIC_KEY);
-            ssl->buffers.serverDH_Pub.buffer = NULL;
-        }
+    }
+
+    if (ssl->buffers.serverDH_Pub.buffer) {
+        XFREE(ssl->buffers.serverDH_Pub.buffer, ssl->heap,
+                DYNAMIC_TYPE_PUBLIC_KEY);
+        ssl->buffers.serverDH_Pub.buffer = NULL;
     }
 
     /* p */
@@ -23219,9 +23220,8 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                     args->output += OPAQUE16_LEN;
                     XMEMCPY(args->output, ssl->arrays->client_identity, esSz);
                     args->output += esSz;
+                    args->length = args->encSz - esSz - OPAQUE16_LEN;
                     args->encSz = esSz + OPAQUE16_LEN;
-
-                    args->length = 0;
 
                     ret = AllocKey(ssl, DYNAMIC_TYPE_DH,
                                             (void**)&ssl->buffers.serverDH_Key);
@@ -25161,6 +25161,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             if (ssl->buffers.serverDH_Pub.buffer == NULL) {
                                 ERROR_OUT(MEMORY_E, exit_sske);
                             }
+                            ssl->buffers.serverDH_Pub.length =
+                                ssl->buffers.serverDH_P.length + OPAQUE16_LEN;
                         }
 
                         if (ssl->buffers.serverDH_Priv.buffer == NULL) {
@@ -25171,6 +25173,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             if (ssl->buffers.serverDH_Priv.buffer == NULL) {
                                 ERROR_OUT(MEMORY_E, exit_sske);
                             }
+                            ssl->buffers.serverDH_Priv.length =
+                                ssl->buffers.serverDH_P.length + OPAQUE16_LEN;
                         }
 
                         ssl->options.dhKeySz =

--- a/src/internal.c
+++ b/src/internal.c
@@ -21272,7 +21272,6 @@ static int GetDhPublicKey(WOLFSSL* ssl, const byte* input, word32 size,
         XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap,
                 DYNAMIC_TYPE_PUBLIC_KEY);
         ssl->buffers.serverDH_G.buffer = NULL;
-        ERROR_OUT(BUFFER_ERROR, exit_gdpk);
         ERROR_OUT(DH_KEY_SIZE_E, exit_gdpk);
     }
     args->idx += OPAQUE16_LEN;

--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -1237,6 +1237,7 @@ static int GeneratePublicDh(DhKey* key, byte* priv, word32 privSz,
 {
     int ret = 0;
 #ifndef WOLFSSL_SP_MATH
+    word32 binSz = 0;
 #ifdef WOLFSSL_SMALL_STACK
     mp_int* x;
     mp_int* y;
@@ -1245,7 +1246,6 @@ static int GeneratePublicDh(DhKey* key, byte* priv, word32 privSz,
     mp_int y[1];
 #endif
 #endif
-    word32 binSz;
 
 #ifdef WOLFSSL_HAVE_SP_DH
 #ifndef WOLFSSL_SP_NO_2048

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14642,6 +14642,11 @@ static int dh_test_ffdhe(WC_RNG *rng, const DhParams* params)
         ERROR_OUT(-7835, done);
 #endif
 
+    pubSz = FFDHE_KEY_SIZE;
+    pubSz2 = FFDHE_KEY_SIZE;
+    privSz = FFDHE_KEY_SIZE;
+    privSz2 = FFDHE_KEY_SIZE;
+
     XMEMSET(key, 0, sizeof *key);
     XMEMSET(key2, 0, sizeof *key2);
 
@@ -14763,8 +14768,8 @@ static int dh_test(void)
     byte *agree2 = (byte *)XMALLOC(DH_TEST_BUF_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 
     if ((tmp == NULL) || (priv == NULL) || (pub == NULL) ||
-	(priv2 == NULL) || (pub2 == NULL) || (agree == NULL) ||
-	(agree2 == NULL))
+        (priv2 == NULL) || (pub2 == NULL) || (agree == NULL) ||
+        (agree2 == NULL))
         ERROR_OUT(-7960, done);
 #else
     DhKey  key_buf, *key = &key_buf;
@@ -14809,6 +14814,11 @@ static int dh_test(void)
     (void)idx;
     (void)tmp;
     (void)bytes;
+
+    pubSz = DH_TEST_BUF_SIZE;
+    pubSz2 = DH_TEST_BUF_SIZE;
+    privSz = DH_TEST_BUF_SIZE;
+    privSz2 = DH_TEST_BUF_SIZE;
 
     XMEMSET(&rng, 0, sizeof(rng));
     /* Use API for coverage. */


### PR DESCRIPTION
These changes fix several fuzz testing reports. (ZD 11088 and ZD 11101)

1. In GetDhPublicKey(), the DH Pubkey is owned by the SSL session. It doesn't need to be in the check for weOwnDh before freeing. There could be a chance it leaks.
2. In GeneratePublicDh() and GeneratePrivateDh(), the size of the destination buffer should be stored at the location pointed to by the size pointer. Check that before writing into the destination buffer.
3. Ensure the size of the private and public key values are in the size value before generating or getting the DH keys.
4. Check the length values for the DH key domain and public key in the server key exchange message to make sure they are within the bounds set by the configuration. (Minimum key size is 2048 bits for DH.)
