### PR TITLE
Linux __kernel_time_t version test

### DIFF
--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -786,7 +786,7 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
     #ifdef BUILDING_WOLFSSL
 
     /* includes are all above, with incompatible warnings masked out. */
-    #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 5, 0)
     typedef __kernel_time_t time_t;
     #else
     typedef __kernel_time64_t time_t;


### PR DESCRIPTION
wc_port.h: fix threshold of change in __kernel_time_t typedef from kernel 5.0.0 to 5.5.0 to accommodate Ubuntu 20.02 (kernel 5.4) -- see https://github.com/torvalds/linux/commit/2a785996cc5e2fc1d1d29d196f530905f68d2dc2#diff-2cd5bedb19d5e0a575d6f73a6c3290ecf8d9c01eb7567ba6fa282cb1b0ce2d54