### PR TITLE
Tweak CMakeLists.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,8 @@ IDE/XCODE/Index
 
 # Emacs
 *~
+
+# CMake
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # Project
 ####################################################
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.0)
 project(wolfssl)
 
 ####################################################
@@ -79,14 +79,100 @@ if(CMAKE_USE_PTHREADS_INIT)
 endif()
 
 ####################################################
-# Library Target and Source Files
+# Library Target
 ####################################################
 
-file(GLOB LIB_SOURCE_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/src/*.c)
-
-add_library(wolfssl ${LIB_SOURCE_FILES})
+add_library(wolfssl
+    src/bio.c
+    src/crl.c
+    src/internal.c
+    src/keys.c
+    src/ocsp.c
+    src/sniffer.c
+    src/ssl.c
+    src/tls.c
+    src/tls13.c
+    src/wolfio.c
+    wolfcrypt/src/aes.c
+    wolfcrypt/src/arc4.c
+    wolfcrypt/src/asm.c
+    wolfcrypt/src/asn.c
+    wolfcrypt/src/async.c
+    wolfcrypt/src/blake2b.c
+    wolfcrypt/src/blake2s.c
+    wolfcrypt/src/camellia.c
+    wolfcrypt/src/chacha.c
+    wolfcrypt/src/chacha20_poly1305.c
+    wolfcrypt/src/cmac.c
+    wolfcrypt/src/coding.c
+    wolfcrypt/src/compress.c
+    wolfcrypt/src/cpuid.c
+    wolfcrypt/src/cryptocb.c
+    wolfcrypt/src/curve25519.c
+    wolfcrypt/src/curve448.c
+    wolfcrypt/src/debug.c
+    wolfcrypt/src/des3.c
+    wolfcrypt/src/dh.c
+    wolfcrypt/src/dsa.c
+    wolfcrypt/src/ecc.c
+    wolfcrypt/src/ecc_fp.c
+    wolfcrypt/src/ed25519.c
+    wolfcrypt/src/ed448.c
+    wolfcrypt/src/error.c
+    wolfcrypt/src/evp.c
+    wolfcrypt/src/fe_448.c
+    wolfcrypt/src/fe_low_mem.c
+    wolfcrypt/src/fe_operations.c
+    wolfcrypt/src/fips.c
+    wolfcrypt/src/fips_test.c
+    wolfcrypt/src/ge_448.c
+    wolfcrypt/src/ge_low_mem.c
+    wolfcrypt/src/ge_operations.c
+    wolfcrypt/src/hash.c
+    wolfcrypt/src/hc128.c
+    wolfcrypt/src/hmac.c
+    wolfcrypt/src/idea.c
+    wolfcrypt/src/integer.c
+    wolfcrypt/src/logging.c
+    wolfcrypt/src/md2.c
+    wolfcrypt/src/md4.c
+    wolfcrypt/src/md5.c
+    wolfcrypt/src/memory.c
+    wolfcrypt/src/misc.c
+    wolfcrypt/src/pkcs12.c
+    wolfcrypt/src/pkcs7.c
+    wolfcrypt/src/poly1305.c
+    wolfcrypt/src/pwdbased.c
+    wolfcrypt/src/rabbit.c
+    wolfcrypt/src/random.c
+    wolfcrypt/src/ripemd.c
+    wolfcrypt/src/rsa.c
+    wolfcrypt/src/selftest.c
+    wolfcrypt/src/sha.c
+    wolfcrypt/src/sha256.c
+    wolfcrypt/src/sha3.c
+    wolfcrypt/src/sha512.c
+    wolfcrypt/src/signature.c
+    wolfcrypt/src/sp_arm32.c
+    wolfcrypt/src/sp_arm64.c
+    wolfcrypt/src/sp_armthumb.c
+    wolfcrypt/src/sp_c32.c
+    wolfcrypt/src/sp_c64.c
+    wolfcrypt/src/sp_cortexm.c
+    wolfcrypt/src/sp_dsp32.c
+    wolfcrypt/src/sp_int.c
+    wolfcrypt/src/sp_x86_64.c
+    wolfcrypt/src/srp.c
+    wolfcrypt/src/tfm.c
+    wolfcrypt/src/wc_dsp.c
+    wolfcrypt/src/wc_encrypt.c
+    wolfcrypt/src/wc_pkcs11.c
+    wolfcrypt/src/wc_port.c
+    wolfcrypt/src/wolfcrypt_first.c
+    wolfcrypt/src/wolfcrypt_last.c
+    wolfcrypt/src/wolfevent.c
+    wolfcrypt/src/wolfmath.c
+)
 
 ####################################################
 # Include Directories
@@ -153,15 +239,17 @@ if(BUILD_TESTS)
     target_link_libraries(tls_bench wolfssl)
     target_link_libraries(tls_bench Threads::Threads)
 
-    file(GLOB TEST_SOURCE_FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/examples/server/server.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/examples/client/client.c)
-
     # Build Unit Tests
     add_executable(unit_test
-        ${TEST_SOURCE_FILES})
-    set_target_properties( unit_test PROPERTIES COMPILE_FLAGS "-DNO_MAIN_DRIVER" )
+        tests/api.c
+        tests/hash.c
+        tests/srp.c
+        tests/suites.c
+        tests/unit.c
+        examples/server/server.c
+        examples/client/client.c
+    )
+    target_compile_options(unit_test PUBLIC "-DNO_MAIN_DRIVER")
     target_link_libraries(unit_test wolfssl)
     target_link_libraries(unit_test Threads::Threads)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,18 @@
 # To build with debugging use:
 # $ cmake .. -DCMAKE_BUILD_TYPE=Debug
 
-
-cmake_minimum_required (VERSION 2.6)
-
 ####################################################
 # Project
 ####################################################
+
+cmake_minimum_required(VERSION 2.6)
 project(wolfssl)
-find_package (Threads)
+
+####################################################
+# Dependencies
+####################################################
+
+find_package(Threads)
 
 ####################################################
 # Compiler
@@ -32,10 +36,10 @@ find_package (Threads)
 
 if(APPLE)
     # Silence ranlib warning "has no symbols"
-    SET(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
-    SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
-    SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
-    SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+    set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    set(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+    set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 endif()
 
 ####################################################
@@ -55,45 +59,49 @@ endif()
 ####################################################
 # Build Options
 ####################################################
-SET(BUILD_TESTS YES CACHE BOOL "Build test applications")
+
+option(BUILD_TESTS "Build test applications" YES)
 
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/wolfssl/options.h")
     # Copy generated ./options.h
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/wolfssl/options.h 
-                   ${CMAKE_CURRENT_BINARY_DIR}/user_settings.h)
+                   ${CMAKE_CURRENT_SOURCE_DIR}/user_settings.h)
 else()
    # Use template
    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/wolfssl/options.h.in 
-                  ${CMAKE_CURRENT_BINARY_DIR}/user_settings.h)
+                  ${CMAKE_CURRENT_SOURCE_DIR}/user_settings.h)
 endif()
 
 add_definitions(-DWOLFSSL_USER_SETTINGS)
 add_definitions(-DWOLFSSL_IGNORE_FILE_WARN)
-if(CMAKE_HAVE_PTHREAD_H)
+if(CMAKE_USE_PTHREADS_INIT)
   add_definitions(-DHAVE_PTHREAD)
 endif()
 
 ####################################################
-# Source Files
+# Library Target and Source Files
 ####################################################
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/.)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/.)
 
 file(GLOB LIB_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c
     ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/src/*.c)
 
-file(GLOB TEST_SOURCE_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/examples/server/server.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/examples/client/client.c)
-
-####################################################
-# Output Files
-####################################################
-
-# Build wolfssl library
 add_library(wolfssl ${LIB_SOURCE_FILES})
+
+####################################################
+# Include Directories
+####################################################
+
+target_include_directories(wolfssl
+    PUBLIC
+        $<INSTALL_INTERFACE:wolfssl>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/wolfssl>
+        ${CMAKE_CURRENT_SOURCE_DIR}/. # Needed for user_settings.h to be visible
+)
+
+####################################################
+# Link Libraries
+####################################################
 
 if(WIN32)
     # For Windows link ws2_32
@@ -102,6 +110,10 @@ else()
     # DH requires math (m) library
     target_link_libraries(wolfssl PUBLIC m)
 endif()
+
+####################################################
+# Tests and Examples
+####################################################
 
 # Optionally build example and test applications
 if(BUILD_TESTS)
@@ -140,6 +152,11 @@ if(BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/examples/benchmark/tls_bench.c)
     target_link_libraries(tls_bench wolfssl)
     target_link_libraries(tls_bench Threads::Threads)
+
+    file(GLOB TEST_SOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/examples/server/server.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/examples/client/client.c)
 
     # Build Unit Tests
     add_executable(unit_test


### PR DESCRIPTION
- Add generated CMake files/directories to .gitignore.
- Use lowercase for CMake commands, UPPERCASE for variables.
- Favor the CMake "option" command over SET(... CACHE BOOL ...).
- Use CMAKE_CURRENT_SOURCE_DIR in place of CMAKE_CURRENT_BINARY_DIR.
- Use CMAKE_USE_PTHREADS_INIT instead of CMAKE_HAVE_PTHREAD_H.
- Use target_include_directories on the wolfssl library target instead of include_directories.