### PR TITLE
DH Fix 2

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -21231,6 +21231,9 @@ static int GetDhPublicKey(WOLFSSL* ssl, const byte* input, word32 size,
     if (length > ssl->options.maxDhKeySz) {
         WOLFSSL_MSG("Server using a DH key generator that is too big");
         SendAlert(ssl, alert_fatal, handshake_failure);
+        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap,
+                DYNAMIC_TYPE_PUBLIC_KEY);
+        ssl->buffers.serverDH_P.buffer = NULL;
         ERROR_OUT(DH_KEY_SIZE_E, exit_gdpk);
     }
 
@@ -21277,11 +21280,23 @@ static int GetDhPublicKey(WOLFSSL* ssl, const byte* input, word32 size,
     if (length < ssl->options.minDhKeySz) {
         WOLFSSL_MSG("Server using a public DH key that is too small");
         SendAlert(ssl, alert_fatal, handshake_failure);
+        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap,
+                DYNAMIC_TYPE_PUBLIC_KEY);
+        ssl->buffers.serverDH_P.buffer = NULL;
+        XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap,
+                DYNAMIC_TYPE_PUBLIC_KEY);
+        ssl->buffers.serverDH_G.buffer = NULL;
         ERROR_OUT(DH_KEY_SIZE_E, exit_gdpk);
     }
     if (length > ssl->options.maxDhKeySz) {
         WOLFSSL_MSG("Server using a public DH key that is too big");
         SendAlert(ssl, alert_fatal, handshake_failure);
+        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap,
+                DYNAMIC_TYPE_PUBLIC_KEY);
+        ssl->buffers.serverDH_P.buffer = NULL;
+        XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap,
+                DYNAMIC_TYPE_PUBLIC_KEY);
+        ssl->buffers.serverDH_G.buffer = NULL;
         ERROR_OUT(DH_KEY_SIZE_E, exit_gdpk);
     }
 


### PR DESCRIPTION
1. Add some missing frees for the error cases when the server DH public key is rejected.