### PR TITLE
Example Client OCSP Option Fix

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1944,15 +1944,21 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             case 'W' :
                 #if defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
                  || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
+                {
+                    word32 myoptargSz;
+
                     statusRequest = atoi(myoptarg);
                     if (statusRequest > OCSP_STAPLING_OPT_MAX) {
                         Usage();
                         XEXIT_T(MY_EX_USAGE);
                     }
-                    if (myoptarg[XSTRLEN(myoptarg)-1] == 'M' ||
-                                         myoptarg[XSTRLEN(myoptarg)-1] == 'm') {
+
+                    myoptargSz = (word32)XSTRLEN(myoptarg);
+                    if (myoptargSz > 0 &&
+                            XTOUPPER(myoptarg[myoptargSz-1]) == 'M') {
                         mustStaple = 1;
                     }
+                }
                 #endif
                 break;
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -21330,17 +21330,6 @@ static int GetDhPublicKey(WOLFSSL* ssl, const byte* input, word32 size,
         ERROR_OUT(BUFFER_ERROR, exit_gdpk);
     }
 
-    if (length < ssl->options.minDhKeySz) {
-        WOLFSSL_MSG("Server using a public DH key that is too small");
-        SendAlert(ssl, alert_fatal, handshake_failure);
-        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap,
-                DYNAMIC_TYPE_PUBLIC_KEY);
-        ssl->buffers.serverDH_P.buffer = NULL;
-        XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap,
-                DYNAMIC_TYPE_PUBLIC_KEY);
-        ssl->buffers.serverDH_G.buffer = NULL;
-        ERROR_OUT(DH_KEY_SIZE_E, exit_gdpk);
-    }
     if (length > ssl->options.maxDhKeySz) {
         WOLFSSL_MSG("Server using a public DH key that is too big");
         SendAlert(ssl, alert_fatal, handshake_failure);


### PR DESCRIPTION
Before checking to see if the must staple flag is on the 'W' option, check the length of myoptarg.