### PR TITLE
PKCS#7: Reset variables correctly in VerifySignedData

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -4563,14 +4563,14 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
 
                     if (ret == 0) {
                         idx += length;
-
-                        pkiMsg2   = pkiMsg;
-                        pkiMsg2Sz = pkiMsgSz;
-                    #ifndef NO_PKCS7_STREAM
-                        pkcs7->stream->varOne = pkiMsg2Sz;
-                        pkcs7->stream->flagOne = 1;
-                    #endif
                     }
+
+                    pkiMsg2   = pkiMsg;
+                    pkiMsg2Sz = pkiMsgSz;
+                #ifndef NO_PKCS7_STREAM
+                    pkcs7->stream->varOne = pkiMsg2Sz;
+                    pkcs7->stream->flagOne = 1;
+                #endif
                 }
             }
             else {


### PR DESCRIPTION
This PR addresses a report in ZD 11001.

In some cases when a malformed PKCS#7 bundle is being processed the following length check can fail in PKCS7_VerifySignedData() resulting in "ret" being set to BUFFER_E:

```
if ((word32)length > pkiMsgSz - localIdx) {
    ret = BUFFER_E;
}
```

With ret in an error state, pkiMsg2/pkiMsg2 size need to be reset accordingly in the case where separate header/footer are not being used.