### PR TITLE
client_test(): add array index bounds checking in parsing for new mustStaple option detection.

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1949,9 +1949,13 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                         Usage();
                         XEXIT_T(MY_EX_USAGE);
                     }
-                    if (myoptarg[XSTRLEN(myoptarg)-1] == 'M' ||
-                                         myoptarg[XSTRLEN(myoptarg)-1] == 'm') {
-                        mustStaple = 1;
+                    {
+                        size_t arglen = XSTRLEN(myoptarg);
+                        if ((arglen > 0) &&
+                            ((myoptarg[arglen-1] == 'M') ||
+                             (myoptarg[arglen-1] == 'm'))) {
+                            mustStaple = 1;
+                        }
                     }
                 #endif
                 break;


### PR DESCRIPTION
See https://test.wolfssl.com/jenkins/job/PRB-scan-build-distro-check-v-1-0/6970/

```
examples/client/client.c:1952:55: warning: The left operand of '==' is a garbage value due to array index out of bounds
                    if (myoptarg[XSTRLEN(myoptarg)-1] == 'M' ||
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
```
