### PR TITLE
PKCS#7: check PKCS7 SignedData private key is valid before using it

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1605,6 +1605,25 @@ static int wc_PKCS7_RsaSign(PKCS7* pkcs7, byte* in, word32 inSz, ESD* esd)
             ret = BAD_FUNC_ARG;
         }
     }
+
+    /* If not using old FIPS or CAVP selftest, or not using FAST,
+       or USER RSA, able to check RSA key. */
+#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) && !defined(HAVE_FAST_RSA) && \
+    !defined(HAVE_USER_RSA) && (!defined(HAVE_FIPS) || \
+    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))) && \
+    !defined(HAVE_SELFTEST) && !defined(HAVE_INTEL_QA)
+
+    #if defined(WOLFSSL_KEY_GEN) && !defined(WOLFSSL_NO_RSA_KEY_CHECK)
+    /* verify imported private key is a valid key before using it */
+    if (ret == 0) {
+        ret = wc_CheckRsaKey(privKey);
+        if (ret != 0) {
+            WOLFSSL_MSG("Invalid RSA private key, check pkcs7->privateKey");
+        }
+    }
+    #endif
+#endif
+
     if (ret == 0) {
     #ifdef WOLFSSL_ASYNC_CRYPT
         do {
@@ -1668,6 +1687,15 @@ static int wc_PKCS7_EcdsaSign(PKCS7* pkcs7, byte* in, word32 inSz, ESD* esd)
             ret = BAD_FUNC_ARG;
         }
     }
+
+    /* verify imported private key is a valid key before using it */
+    if (ret == 0) {
+        ret = wc_ecc_check_key(privKey);
+        if (ret != 0) {
+            WOLFSSL_MSG("Invalid ECC private key, check pkcs7->privateKey");
+        }
+    }
+
     if (ret == 0) {
         outSz = sizeof(esd->encContentDigest);
     #ifdef WOLFSSL_ASYNC_CRYPT


### PR DESCRIPTION
This PR addresses a report in ZD 11011.

wc_PKCS7_RsaSign() and wc_PKCS7_EcdsaSign(), called by wc_PKCS7_EncodeSignedData(), should check the private key given by the user is valid before using it in a signature operation.