### PR TITLE
PKCS#7: check PKCS7 VerifySignedData content length against total bundle size

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -4397,6 +4397,16 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                 /* support using header and footer without content */
                 if (pkiMsg2 && pkiMsg2Sz > 0 && hashBuf && hashSz > 0) {
                     localIdx = 0;
+
+                } else if (pkiMsg2 == NULL && hashBuf == NULL) {
+                    /* header/footer not separate, check content length is
+                     * not larger than total bundle size */
+                    if ((localIdx + length) > pkiMsgSz) {
+                        WOLFSSL_MSG("Content length detected is larger than "
+                                    "total bundle size");
+                        ret = BUFFER_E;
+                        break;
+                    }
                 }
                 idx = localIdx;
             }

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -4375,9 +4375,13 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                     ret = ASN_PARSE_E;
 
                 if (ret == 0) {
-                    /* Use single OCTET_STRING directly. */
-                    if (localIdx - start + length == (word32)contentLen)
+                    /* Use single OCTET_STRING directly, or reset length. */
+                    if (localIdx - start + length == (word32)contentLen) {
                         multiPart = 0;
+                    } else {
+                        /* reset length to outer OCTET_STRING (contentLen) */
+                        length = contentLen;
+                    }
                     localIdx = start;
                 }
             }

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -4379,10 +4379,16 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                     if (localIdx - start + length == (word32)contentLen) {
                         multiPart = 0;
                     } else {
-                        /* reset length to outer OCTET_STRING (contentLen) */
+                        /* reset length to outer OCTET_STRING for bundle size
+                         * check below */
                         length = contentLen;
                     }
                     localIdx = start;
+                }
+
+                if (ret != 0) {
+                    /* failed ASN1 parsing during OCTET_STRING checks */
+                    break;
                 }
             }
 
@@ -4426,7 +4432,10 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                 if (!degenerate && !detached && ret != 0)
                     break;
 
-                length = 0; /* no content to read */
+                /* no content to read */
+                length = 0;
+                contentLen = 0;
+
                 pkiMsg2   = pkiMsg;
                 pkiMsg2Sz = pkiMsgSz;
             }


### PR DESCRIPTION
This PR addresses a report in ZD 11003.

Malformed PKCS#7 SignedData bundles can potentially have an invalid content length that is much larger than the bundle itself. wolfCrypt PKCS#7 correctly errors out in this case, but it can lead to an extraneous and possibly large memory allocation.

This PR adds a check in the case where a separate header/footer are not being used to compare the detected content length agains the remaining bundle size.  BUFFER_E will be returned to the application in this case.  A second fix is also included to reset the content length variable used when multi-part OCTET_STRING encodings are used.