### PR TITLE
Apache httpd w/TLS 1.3 support

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10357,6 +10357,30 @@ void wolfSSL_set_verify_result(WOLFSSL *ssl, long v)
 #endif
 }
 
+/* For TLS v1.3 perform rehandshake. Returns 1=WOLFSSL_SUCCESS or 0=WOLFSSL_FAILURE */
+int wolfSSL_verify_client_post_handshake(WOLFSSL* ssl)
+{
+    int ret = NOT_COMPILED_IN;
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH) && \
+    (!defined(NO_WOLFSSL_SERVER) || !defined(NO_WOLFSSL_CLIENT))
+    #ifndef NO_WOLFSSL_SERVER
+    if (ssl->options.side == WOLFSSL_SERVER_END) {
+        ret = wolfSSL_request_certificate(ssl);
+    }
+    #endif
+    #ifndef NO_WOLFSSL_CLIENT
+    if (ssl->options.side == WOLFSSL_CLIENT_END) {
+        ret = wolfSSL_allow_post_handshake_auth(ssl);
+    }
+    #endif
+#else
+    (void)ssl;
+#endif
+    ret = (ret == 0) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
+    
+    return ret;
+}
+
 /* store user ctx for verify callback */
 void wolfSSL_SetCertCbCtx(WOLFSSL* ssl, void* ctx)
 {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -31584,6 +31584,20 @@ void *wolfSSL_OPENSSL_malloc(size_t a)
   return XMALLOC(a, NULL, DYNAMIC_TYPE_OPENSSL);
 }
 
+int wolfSSL_OPENSSL_init_ssl(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
+{
+    (void)opts;
+    (void)settings;
+    return wolfSSL_library_init();
+}
+
+int wolfSSL_OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS* settings)
+{
+    (void)opts;
+    (void)settings;
+    return wolfSSL_library_init();
+}
+
 #if defined(WOLFSSL_KEY_GEN) && defined(WOLFSSL_PEM_TO_DER)
 
 static int EncryptDerKey(byte *der, int *derSz, const EVP_CIPHER* cipher,

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10367,7 +10367,7 @@ int wolfSSL_verify_client_post_handshake(WOLFSSL* ssl)
     return (ret == 0) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
 }
 
-void wolfSSL_CTX_set_post_handshake_auth(WOLFSSL_CTX* ctx, int val)
+int wolfSSL_CTX_set_post_handshake_auth(WOLFSSL_CTX* ctx, int val)
 {
     int ret = wolfSSL_CTX_allow_post_handshake_auth(ctx);
     if (ret == 0) {
@@ -10375,7 +10375,7 @@ void wolfSSL_CTX_set_post_handshake_auth(WOLFSSL_CTX* ctx, int val)
     }
     return (ret == 0) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
 }
-void wolfSSL_set_post_handshake_auth(WOLFSSL* ssl, int val)
+int wolfSSL_set_post_handshake_auth(WOLFSSL* ssl, int val)
 {
     int ret = wolfSSL_allow_post_handshake_auth(ssl);
     if (ret == 0) {

--- a/wolfssl/openssl/crypto.h
+++ b/wolfssl/openssl/crypto.h
@@ -39,6 +39,8 @@ WOLFSSL_API unsigned long wolfSSLeay(void);
 WOLFSSL_API unsigned long wolfSSL_OpenSSL_version_num(void);
 
 #ifdef OPENSSL_EXTRA
+#include <stdint.h>
+
 WOLFSSL_API void wolfSSL_OPENSSL_free(void*);
 WOLFSSL_API void *wolfSSL_OPENSSL_malloc(size_t a);
 

--- a/wolfssl/openssl/crypto.h
+++ b/wolfssl/openssl/crypto.h
@@ -24,9 +24,10 @@
 #ifndef WOLFSSL_CRYPTO_H_
 #define WOLFSSL_CRYPTO_H_
 
-#include <wolfssl/openssl/opensslv.h>
-
 #include <wolfssl/wolfcrypt/settings.h>
+
+#include <wolfssl/openssl/opensslv.h>
+#include <wolfssl/openssl/conf.h>
 
 #ifdef WOLFSSL_PREFIX
 #include "prefix_crypto.h"
@@ -40,6 +41,8 @@ WOLFSSL_API unsigned long wolfSSL_OpenSSL_version_num(void);
 #ifdef OPENSSL_EXTRA
 WOLFSSL_API void wolfSSL_OPENSSL_free(void*);
 WOLFSSL_API void *wolfSSL_OPENSSL_malloc(size_t a);
+
+WOLFSSL_API int wolfSSL_OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings);
 #endif
 
 #define CRYPTO_THREADID void
@@ -62,11 +65,13 @@ WOLFSSL_API void *wolfSSL_OPENSSL_malloc(size_t a);
 #define OPENSSL_free wolfSSL_OPENSSL_free
 #define OPENSSL_malloc wolfSSL_OPENSSL_malloc
 
-#ifdef WOLFSSL_QT
-    #define OPENSSL_INIT_ADD_ALL_CIPHERS    0x00000004L
-    #define OPENSSL_INIT_ADD_ALL_DIGESTS    0x00000008L
-    #define OPENSSL_INIT_LOAD_CONFIG        0x00000040L
-#endif
+#define OPENSSL_INIT_ENGINE_ALL_BUILTIN 0x00000001L
+#define OPENSSL_INIT_ADD_ALL_CIPHERS    0x00000004L
+#define OPENSSL_INIT_ADD_ALL_DIGESTS    0x00000008L
+#define OPENSSL_INIT_LOAD_CONFIG        0x00000040L
+
+#define OPENSSL_init_crypto wolfSSL_OPENSSL_init_crypto
+
 
 #if defined(OPENSSL_ALL) || defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
     defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA)

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -68,6 +68,7 @@
 #endif
 
 #ifdef OPENSSL_EXTRA
+#include <stdint.h>
 WOLFSSL_API int wolfSSL_OPENSSL_init_ssl(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings);
 #endif
 

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -279,6 +279,7 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define SSL_CTX_set_cert_verify_callback wolfSSL_CTX_set_cert_verify_callback
 #define SSL_set_verify                  wolfSSL_set_verify
 #define SSL_set_verify_result           wolfSSL_set_verify_result
+#define SSL_verify_client_post_handshake wolfSSL_verify_client_post_handshake
 #define SSL_pending                     wolfSSL_pending
 #define SSL_load_error_strings          wolfSSL_load_error_strings
 #define SSL_library_init                wolfSSL_library_init

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -67,6 +67,9 @@
     #undef ASN1_INTEGER
 #endif
 
+#ifdef OPENSSL_EXTRA
+WOLFSSL_API int wolfSSL_OPENSSL_init_ssl(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings);
+#endif
 
 typedef WOLFSSL          SSL;
 typedef WOLFSSL_SESSION  SSL_SESSION;
@@ -283,6 +286,7 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define SSL_pending                     wolfSSL_pending
 #define SSL_load_error_strings          wolfSSL_load_error_strings
 #define SSL_library_init                wolfSSL_library_init
+#define OPENSSL_init_ssl                wolfSSL_OPENSSL_init_ssl
 #define OpenSSL_add_ssl_algorithms      wolfSSL_library_init
 #define SSL_CTX_set_session_cache_mode  wolfSSL_CTX_set_session_cache_mode
 #define SSL_CTX_set_cipher_list         wolfSSL_CTX_set_cipher_list

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -284,6 +284,8 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define SSL_set_verify                  wolfSSL_set_verify
 #define SSL_set_verify_result           wolfSSL_set_verify_result
 #define SSL_verify_client_post_handshake wolfSSL_verify_client_post_handshake
+#define SSL_set_post_handshake_auth     wolfSSL_set_post_handshake_auth
+#define SSL_CTX_set_post_handshake_auth wolfSSL_CTX_set_post_handshake_auth
 #define SSL_pending                     wolfSSL_pending
 #define SSL_load_error_strings          wolfSSL_load_error_strings
 #define SSL_library_init                wolfSSL_library_init

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -977,9 +977,9 @@ WOLFSSL_API void wolfSSL_set_verify_result(WOLFSSL*, long);
 
 #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
     defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
-WOLFSSL_API int  wolfSSL_verify_client_post_handshake(WOLFSSL*);
-WOLFSSL_API void wolfSSL_CTX_set_post_handshake_auth(WOLFSSL_CTX*, int);
-WOLFSSL_API void wolfSSL_set_post_handshake_auth(WOLFSSL*, int);
+WOLFSSL_API int wolfSSL_verify_client_post_handshake(WOLFSSL*);
+WOLFSSL_API int wolfSSL_CTX_set_post_handshake_auth(WOLFSSL_CTX*, int);
+WOLFSSL_API int wolfSSL_set_post_handshake_auth(WOLFSSL*, int);
 #endif
 
 WOLFSSL_API void wolfSSL_SetCertCbCtx(WOLFSSL*, void*);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -974,7 +974,13 @@ WOLFSSL_API void wolfSSL_CTX_set_cert_verify_callback(WOLFSSL_CTX* ctx,
 
 WOLFSSL_API void wolfSSL_set_verify(WOLFSSL*, int, VerifyCallback verify_callback);
 WOLFSSL_API void wolfSSL_set_verify_result(WOLFSSL*, long);
+
+#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
+    defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
 WOLFSSL_API int  wolfSSL_verify_client_post_handshake(WOLFSSL*);
+WOLFSSL_API void wolfSSL_CTX_set_post_handshake_auth(WOLFSSL_CTX*, int);
+WOLFSSL_API void wolfSSL_set_post_handshake_auth(WOLFSSL*, int);
+#endif
 
 WOLFSSL_API void wolfSSL_SetCertCbCtx(WOLFSSL*, void*);
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -974,6 +974,8 @@ WOLFSSL_API void wolfSSL_CTX_set_cert_verify_callback(WOLFSSL_CTX* ctx,
 
 WOLFSSL_API void wolfSSL_set_verify(WOLFSSL*, int, VerifyCallback verify_callback);
 WOLFSSL_API void wolfSSL_set_verify_result(WOLFSSL*, long);
+WOLFSSL_API int  wolfSSL_verify_client_post_handshake(WOLFSSL*);
+
 WOLFSSL_API void wolfSSL_SetCertCbCtx(WOLFSSL*, void*);
 
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_pending(WOLFSSL*);


### PR DESCRIPTION
* Add support for TLS v1.3 compatibility API `SSL_verify_client_post_handshake` for the server-side to support rehandshake (Required for Apache v2.4.39 with TLS v1.3)
* Added `SSL_CTX_set_post_handshake_auth` and `SSL_set_post_handshake_auth` API's for enabling or disabling post handshake authentication for TLS v1.3
* Add `OPENSSL_init_crypto` and `OPENSSL_init_ssl` API's.