### PR TITLE
Tautological Name Fix

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5550,7 +5550,13 @@ int wc_OBJ_sn2nid(const char *sn)
     if (XSTRNCMP(sn, "secp384r1", 10) == 0)
         sn = "SECP384R1";
     /* find based on name and return NID */
-    for (i = 0; ecc_sets[i].size != 0 && ecc_sets[i].name != NULL; i++) {
+    for (i = 0;
+#ifndef WOLFSSL_ECC_CURVE_STATIC
+         ecc_sets[i].size != 0 && ecc_sets[i].name != NULL;
+#else
+         ecc_sets[i].size != 0;
+#endif
+         i++) {
         if (XSTRNCMP(sn, ecc_sets[i].name, ECC_MAXNAME) == 0) {
             eccEnum = ecc_sets[i].id;
             /* Convert enum value in ecc_curve_id to OpenSSL NID */


### PR DESCRIPTION
Depending on the build option WOLFSSL_ECC_CURVE_STATIC, the name in the ecc_set may be a pointer (default) or an array. With the above set with the CFLAG -Wtautological-pointer-compare you'll get a build error. Changed the comparison in the for loop with this problem to check the name's pointer only if appropriate.

To recreate the error, build with the options:

```
$ ./configure CPPFLAGS=-DWOLFSSL_ECC_CURVE_STATIC --enable-opensslextra&&make
wolfcrypt/src/asn.c:5553:54: error: comparison of array 'ecc_sets[i].name' not
      equal to a null pointer is always true
      [-Werror,-Wtautological-pointer-compare]
    for (i = 0; ecc_sets[i].size != 0 && ecc_sets[i].name != NULL; i++) {
                                         ~~~~~~~~~~~~^~~~    ~~~~
1 error generated.
```