### PR TITLE
Nightly Scan-Build Test Fixes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -3337,7 +3337,7 @@ void InitX509Name(WOLFSSL_X509_NAME* name, int dynamicFlag, void* heap)
         name->sz = 0;
         name->heap = heap;
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-        XMEMSET(&name->entry, 0, sizeof(name->entry));
+        XMEMSET(name->entry, 0, sizeof(name->entry));
         name->x509 = NULL;
         name->entrySz = 0;
 #endif /* OPENSSL_EXTRA */
@@ -3357,7 +3357,7 @@ void FreeX509Name(WOLFSSL_X509_NAME* name)
             int i;
             for (i = 0; i < MAX_NAME_ENTRIES; i++) {
                 if (name->entry[i].set) {
-                    wolfSSL_ASN1_OBJECT_free(&name->entry[i].object);
+                    wolfSSL_ASN1_OBJECT_free(name->entry[i].object);
                     wolfSSL_ASN1_STRING_free(name->entry[i].value);
                 }
             }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -38732,7 +38732,7 @@ err:
                 }
             }
             ne->nid = nid;
-            wolfSSL_OBJ_nid2obj_ex(nid, ne->object);
+            ne->object = wolfSSL_OBJ_nid2obj_ex(nid, ne->object);
             ne->value = wolfSSL_ASN1_STRING_type_new(type);
             if (ne->value != NULL) {
                 wolfSSL_ASN1_STRING_set(ne->value, (const void*)data, dataSz);

--- a/tests/api.c
+++ b/tests/api.c
@@ -29373,7 +29373,6 @@ static void test_wolfSSL_OBJ(void)
             AssertTrue((nid = OBJ_obj2nid(asn1Name)) > 0);
         }
         BIO_free(bio);
-        ASN1_OBJECT_free(asn1Name);
         X509_free(x509);
 
     }
@@ -29397,7 +29396,6 @@ static void test_wolfSSL_OBJ(void)
             AssertTrue((nid = OBJ_obj2nid(asn1Name)) > 0);
         }
         BIO_free(bio);
-        ASN1_OBJECT_free(asn1Name);
         X509_free(x509);
     }
 

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -11751,10 +11751,10 @@ int wc_PKCS7_EncodeEncryptedData(PKCS7* pkcs7, byte* output, word32 outputSz)
 
     if (totalSz > (int)outputSz) {
         WOLFSSL_MSG("PKCS#7 output buffer too small");
-        if (pkcs7->unprotectedAttribsSz != 0) {
+        if (attribs != NULL)
             XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+        if (flatAttribs != NULL)
             XFREE(flatAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
-        }
         XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
         return BUFFER_E;
@@ -11790,10 +11790,12 @@ int wc_PKCS7_EncodeEncryptedData(PKCS7* pkcs7, byte* output, word32 outputSz)
         idx += attribsSetSz;
         XMEMCPY(output + idx, flatAttribs, attribsSz);
         idx += attribsSz;
-        XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
-        XFREE(flatAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
     }
 
+    if (attribs != NULL)
+        XFREE(attribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
+    if (flatAttribs != NULL)
+        XFREE(flatAttribs, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
     XFREE(encryptedContent, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
     XFREE(plain, pkcs7->heap, DYNAMIC_TYPE_PKCS7);
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3472,7 +3472,7 @@ int wc_RsaPSS_VerifyCheckInline(byte* in, word32 inLen, byte** out,
 
     hLen = wc_HashGetDigestSize(hash);
     if (hLen < 0)
-        return hLen;
+        return BAD_FUNC_ARG;
     if ((word32)hLen != digestLen)
         return BAD_FUNC_ARG;
 

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -374,7 +374,7 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
                       int saltSz, int iterations, int id, byte* input,
                       int length, int version, byte* cbcIv, int enc, int shaOid)
 {
-    int typeH;
+    int typeH = WC_HASH_TYPE_NONE;
     int derivedLen = 0;
     int ret = 0;
 #ifdef WOLFSSL_SMALL_STACK

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3239,7 +3239,7 @@ WOLFSSL_API int wolfSSL_accept_ex(WOLFSSL*, HandShakeCallBack, TimeoutCallBack,
 
 #include <wolfssl/openssl/asn1.h>
 struct WOLFSSL_X509_NAME_ENTRY {
-    WOLFSSL_ASN1_OBJECT  object;  /* static object just for keeping grp, type */
+    WOLFSSL_ASN1_OBJECT* object;  /* static object just for keeping grp, type */
     WOLFSSL_ASN1_STRING* value;  /* points to data, for lighttpd port */
     int nid; /* i.e. ASN_COMMON_NAME */
     int set;


### PR DESCRIPTION
1. Fixed a warning in wc_encrypt because of an uninitialized value, and an issue in RSA related to the fix.
2. In PKCS7 changed the free of a couple buffers to be dependent on the buffer pointers rather than on a flag.