### PR TITLE
CMake improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ ctaocrypt/src/src/
 *.user
 configure
 config.*
+!cmake/config.in
 *Debug/
 *Release/
 *.ncb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,30 +9,52 @@
 # $ cd build
 # $ cmake ..
 # $ cmake --build .
-
-# To build library only and not build examples and test apps use:
-# $ cmake .. -DBUILD_TESTS=NO
-
+#
 # To build with debugging use:
 # $ cmake .. -DCMAKE_BUILD_TYPE=Debug
+#
+# See "Building with CMake" in INSTALL for more.
 
 ####################################################
 # Project
 ####################################################
 
-cmake_minimum_required(VERSION 3.0)
-project(wolfssl)
+cmake_minimum_required(VERSION 3.2)
 
-####################################################
-# Dependencies
-####################################################
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
+    message(FATAL_ERROR "In-source builds are not allowed.\
+     Run cmake from a separate directory from where CMakeLists.txt lives.\
+     NOTE: cmake will now create CMakeCache.txt and CMakeFiles/*.\
+     You must delete them, or cmake will refuse to work.")
+endif()
 
-find_package(Threads)
+project(wolfssl VERSION 4.5.0 LANGUAGES C)
+
+# shared library versioning
+# increment if interfaces have been added, removed or changed
+set(LIBTOOL_CURRENT 26)
+# increment if source code has changed  set to zero if current is incremented
+set(LIBTOOL_REVISION 0)
+# increment if interfaces have been added set to zero if interfaces have been
+# removed or changed
+set(LIBTOOL_AGE 2)
+
+math(EXPR LIBTOOL_SO_VERSION "${LIBTOOL_CURRENT} - ${LIBTOOL_AGE}")
+set(LIBTOOL_FULL_VERSION ${LIBTOOL_SO_VERSION}.${LIBTOOL_AGE}.${LIBTOOL_REVISION})
+
+set(WOLFSSL_DEFINITIONS)
+set(WOLFSSL_LINK_LIBS)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/functions.cmake)
 
 ####################################################
 # Compiler
 ####################################################
 # Let CMake choose default compiler
+
+# TODO: See gl_VISIBILITY in visibility.m4. Need to perform
+#       the same checks.
+# TODO: Turn on warnings.
 
 if(APPLE)
     # Silence ranlib warning "has no symbols"
@@ -41,6 +63,95 @@ if(APPLE)
     set(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
     set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 endif()
+
+include(CheckIncludeFile)
+
+check_include_file("arpa/inet.h" HAVE_ARPA_INET_H)
+check_include_file("fcntl.h" HAVE_FCNTL_H)
+check_include_file("limits.h" HAVE_LIMITS_H)
+check_include_file("netdb.h" HAVE_NETDB_H)
+check_include_file("netinet/in.h" HAVE_NETINET_IN_H)
+check_include_file("stddef.h" HAVE_STDDEF_H)
+check_include_file("time.h" HAVE_TIME_H)
+check_include_file("sys/ioctl.h" HAVE_SYS_IOCTL_H)
+check_include_file("sys/socket.h" HAVE_SYS_SOCKET_H)
+check_include_file("sys/time.h" HAVE_SYS_TIME_H)
+check_include_file("errno.h" HAVE_ERRNO_H)
+check_include_file("dlfcn.h" HAVE_DLFCN_H)
+check_include_file("inttypes.h" HAVE_INTTYPES_H)
+check_include_file("memory.h" HAVE_MEMORY_H)
+check_include_file("stdint.h" HAVE_STDINT_H)
+check_include_file("stdlib.h" HAVE_STDLIB_H)
+check_include_file("string.h" HAVE_STRING_H)
+check_include_file("strings.h" HAVE_STRINGS_H)
+check_include_file("sys/stat.h" HAVE_SYS_STAT_H)
+check_include_file("sys/types.h" HAVE_SYS_TYPES_H)
+check_include_file("unistd.h" HAVE_UNISTD_H)
+
+include(CheckFunctionExists)
+
+# TODO: Also check if these functions are declared by the
+#       expected headers. See comments around
+#       AC_CHECK_FUNCS/AC_CHECK_DECLS in configure.ac.
+check_function_exists("gethostbyname" HAVE_GETHOSTBYNAME)
+check_function_exists("getaddrinfo" HAVE_GETADDRINFO)
+check_function_exists("gettimeofday" HAVE_GETTIMEOFDAY)
+check_function_exists("gmtime_r" HAVE_GMTIME_R)
+check_function_exists("inet_ntoa" HAVE_INET_NTOA)
+check_function_exists("memset" HAVE_MEMSET)
+check_function_exists("socket" HAVE_SOCKET)
+check_function_exists("strftime" HAVE_STRFTIME)
+
+include(CheckTypeSize)
+
+check_type_size("__uint128_t" __UINT128_T)
+check_type_size("long long" SIZEOF_LONG_LONG)
+check_type_size("long" SIZEOF_LONG)
+check_type_size("time_t" SIZEOF_TIME_T)
+
+# By default, HAVE___UINT128_T gets defined as TRUE,
+# but we want it as 1.
+if(HAVE___UINT128_T)
+    set(HAVE___UINT128_T "1" CACHE INTERNAL "Result of TRY_COMPILE" FORCE)
+endif()
+
+include(TestBigEndian)
+
+test_big_endian(WORDS_BIGENDIAN)
+
+# Thread local storage
+include(CheckCSourceCompiles)
+
+set(TLS_KEYWORDS "__thread" "__declspec(thread)")
+foreach(TLS_KEYWORD IN LISTS TLS_KEYWORDS)
+    set(TLS_CODE "#include <stdlib.h>
+                  static void foo(void) {
+                     static ${TLS_KEYWORD} int bar\;
+                     exit(1)\;
+                  }
+
+                  int main() {
+                    return 0\;
+                  }"
+    )
+    check_c_source_compiles(${TLS_CODE} THREAD_LS_ON)
+
+    if(THREAD_LS_ON)
+        list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_THREAD_LS")
+        break()
+    else()
+        # THREAD_LS_ON is cached after each call to
+        # check_c_source_compiles, and the function
+        # won't run subsequent times if the variable
+        # is in the cache. To make it run again, we
+        # need to remove the variable from the cache.
+        unset(THREAD_LS_ON CACHE)
+    endif()
+endforeach()
+
+# TODO: AX_PTHREAD does a lot. Need to implement the
+#       rest of its logic.
+find_package(Threads)
 
 ####################################################
 # Cross Compile Example
@@ -59,118 +170,1150 @@ endif()
 ####################################################
 # Build Options
 ####################################################
+# TODO: - Debug
+#       - FIPS
+#       - Distro
+#       - Linux Kernel Module
+#       - Single precision math
+#       - Enable all
+#       - Enable all crypto
+#       - 32-bit mode
+#       - 16-bit mode
 
-option(BUILD_TESTS "Build test applications" YES)
+# Support for disabling all ASM
+set(WOLFSSL_ASM_HELP_STRING "Enables option for assembly (default: enabled)")
+option(WOLFSSL_ASM ${WOLFSSL_ASM_HELP_STRING} "yes")
 
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/wolfssl/options.h")
-    # Copy generated ./options.h
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/wolfssl/options.h 
-                   ${CMAKE_CURRENT_SOURCE_DIR}/user_settings.h)
+if(NOT WOLFSSL_ASM)
+    list(APPEND WOLFSSL_DEFINITIONS
+        "-DTFM_NO_ASM"
+        "-DWOLFSSL_NO_ASM")
+endif()
+
+# Single threaded
+set(WOLFSSL_SINGLE_THREADED_HELP_STRING "Enable wolfSSL single threaded (default: disabled)")
+option(WOLFSSL_SINGLE_THREADED ${WOLFSSL_SINGLE_THREADED_HELP_STRING} "no")
+
+# TODO: Logic here isn't complete, yet (see AX_PTHREAD)
+if(NOT WOLFSSL_SINGLE_THREADED)
+    if(CMAKE_USE_PTHREADS_INIT)
+        list(APPEND WOLFSSL_LINK_LIBS Threads::Threads)
+        list(APPEND WOLFSSL_DEFINITIONS
+            "-DHAVE_PTHREAD"
+            "-D_POSIX_THREADS")
+    endif()
+endif()
+
+# TODO: - DTLS
+#       - TLS v1.3 Draft 18
+
+# TLS v1.3
+set(WOLFSSL_TLS13_HELP_STRING "Enable wolfSSL TLS v1.3 (default: enabled)")
+option(WOLFSSL_TLS13 ${WOLFSSL_TLS13_HELP_STRING} "yes")
+
+if("${FIPS_VERSION}" STREQUAL "v1")
+    override_cache(WOLFSSL_TLS13 "no")
+endif()
+
+# TODO: Post-handshake authentication
+#       Hello retry request cookie
+
+# RNG
+set(WOLFSSL_RNG_HELP_STRING "Enable compiling and using RNG (default: enabled)")
+option(WOLFSSL_RNG ${WOLFSSL_RNG_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_RNG)
+    list(APPEND WOLFSSL_DEFINITIONS "-DWC_NO_RNG")
+endif()
+
+# TODO: - DTLS-SCTP
+#       - DTLS multicast
+#       - OpenSSH
+#       - OpenVPN
+#       - Nginx
+#       - HAProxy
+#       - wpa_supplicant
+#       - Fortress
+#       - libwebsockets
+#       - IP alternative name
+#       - Qt
+#       - SSL bump
+#       - sniffer
+#       - Signal
+#       - OpenSSL coexist
+#       - OpenSSL compatibility all
+#       - OpenSSL compatibility extra
+#       - Max strength
+
+# Harden, enable Timing Resistance and Blinding by default
+set(WOLFSSL_HARDEN_HELP_STRING "Enable Hardened build, Enables Timing Resistance and Blinding (default: enabled)")
+option(WOLFSSL_HARDEN ${WOLFSSL_HARDEN_HELP_STRING} "yes")
+
+if(WOLFSSL_HARDEN)
+    list(APPEND WOLFSSL_DEFINITIONS "-DTFM_TIMING_RESISTANT" "-DECC_TIMING_RESISTANT")
+
+    if(WOLFSSL_RNG)
+        list(APPEND WOLFSSL_DEFINITIONS "-DWC_RSA_BLINDING")
+    endif()
 else()
-   # Use template
-   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/wolfssl/options.h.in 
-                  ${CMAKE_CURRENT_SOURCE_DIR}/user_settings.h)
+    list(APPEND WOLFSSL_DEFINITIONS "-DWC_NO_HARDEN")
 endif()
 
-add_definitions(-DWOLFSSL_USER_SETTINGS)
-add_definitions(-DWOLFSSL_IGNORE_FILE_WARN)
-if(CMAKE_USE_PTHREADS_INIT)
-  add_definitions(-DHAVE_PTHREAD)
+# TODO: - IPv6 test apps
+
+set(WOLFSSL_SLOW_MATH "yes")
+
+# TODO: - Lean PSK
+#       - Lean TLS
+#       - Low resource
+#       - Titan cache
+#       - Huge cache
+#       - Big cache
+#       - Small cache
+#       - Persistent session cache
+#       - Persistent cert cache
+#       - Write duplicate
+#       - Atomic user record layer
+#       - Public key callbacks
+#       - Microchip/Atmel CryptoAuthLib
+
+# AES-CBC
+set(WOLFSSL_AESCBC_HELP_STRING "Enable wolfSSL AES-CBC support (default: enabled)")
+option(WOLFSSL_AESCBC ${WOLFSSL_AESCBC_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_AESCBC)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_AES_CBC")
 endif()
+
+# AES-GCM
+set(WOLFSSL_AESGCM_HELP_STRING "Enable wolfSSL AES-GCM support (default: enabled)")
+set(WOLFSSL_AESGCM "yes" CACHE STRING ${WOLFSSL_AESGCM_HELP_STRING})
+set_property(CACHE WOLFSSL_AESGCM PROPERTY STRINGS "yes" "no" "table" "small" "word32")
+
+# leanpsk and leantls don't need gcm
+if(WOLFSSL_LEAN_PSK OR (WOLFSSL_LEAN_TLS AND NOT WOLFSSL_TLS13))
+    override_cache(WOLFSSL_AESGCM "no")
+endif()
+
+if(WOLFSSL_AESGCM)
+    if("${WOLFSSL_AESGCM}" STREQUAL "word32")
+        list(APPEND WOLFSSL_DEFINITIONS "-DGCM_WORD32")
+        override_cache(WOLFSSL_AESGCM "yes")
+    endif()
+
+    if(("${WOLFSSL_AESGCM}" STREQUAL "small") OR WOLFSSL_LOW_RESOURCE)
+        list(APPEND WOLFSSL_DEFINITIONS "-DGCM_SMALL")
+        override_cache(WOLFSSL_AESGCM "yes")
+    endif()
+
+    if("${WOLFSSL_AESGCM}" STREQUAL "table")
+        list(APPEND WOLFSSL_DEFINITIONS "-DGCM_TABLE")
+        override_cache(WOLFSSL_AESGCM "yes")
+    endif()
+
+    list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_AESGCM")
+endif()
+
+# TODO: - AES-CCM
+#       - AES-CTR
+#       - AES-OFB
+#       - AES-CFB
+#       - AES-ARM
+#       - Xilinx hardened crypto
+#       - Intel AES-NI
+#       - Intel ASM
+#       - Intel RDRAND
+#       - Linux af_alg
+#       - Linux dev crpyto calls
+#       - Camellia
+#       - MD2
+#       - NULL cipher
+#       - RIPEMD
+#       - BLAKE2
+
+# SHA512
+set(WOLFSSL_SHA512_HELP_STRING "Enable wolfSSL SHA-512 support (default: enabled)")
+option(WOLFSSL_SHA512 ${WOLFSSL_SHA512_HELP_STRING} "yes")
+
+# options that don't require sha512
+if(WOLFSSL_LEAN_PSK OR
+   WOLFSSL_LEAN_TLS OR
+   WOLFSSL_32BIT OR
+   WOLFSSL_16BIT)
+    override_cache(WOLFSSL_SHA512 "no")
+endif()
+
+# options that require sha512
+if(WOLFSSL_OPENSSH OR
+   WOLFSSL_WPAS OR
+   WOLFSSL_FORTRESS)
+    override_cache(WOLFSSL_SHA512 "yes")
+endif()
+
+if(WOLFSSL_SHA512)
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_SHA512")
+endif()
+
+# SHA384
+set(WOLFSSL_SHA384_HELP_STRING "Enable wolfSSL SHA-384 support (default: enabled)")
+option(WOLFSSL_SHA384 ${WOLFSSL_SHA384_HELP_STRING} "yes")
+
+# options that don't require sha384
+if(WOLFSSL_LEAN_PSK OR
+   WOLFSSL_LEAN_TLS OR
+   WOLFSSL_32BIT OR
+   WOLFSSL_16BIT)
+    override_cache(WOLFSSL_SHA384 "no")
+endif()
+
+# options that require sha384
+if(WOLFSSL_OPENSSH OR
+   WOLFSSL_WPAS OR
+   WOLFSSL_FORTRESS)
+    override_cache(WOLFSSL_SHA384 "yes")
+endif()
+
+if(WOLFSSL_SHA384)
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_SHA384")
+endif()
+
+# TODO: - Session certs
+#       - Key generation
+#       - Cert generation
+#       - Cert request generation
+#       - Cert request extension
+#       - Decoded cert cache
+#       - SEP
+
+# HKDF
+set(WOLFSSL_HKDF_HELP_STRING "Enable HKDF (HMAC-KDF) support (default: disabled)")
+option(WOLFSSL_HKDF ${WOLFSSL_HKDF_HELP_STRING} "no")
+
+if(WOLFSSL_TLS13)
+    override_cache(WOLFSSL_HKDF "yes")
+endif()
+
+if(WOLFSSL_HKDF)
+    list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_HKDF")
+endif()
+
+# TODO: - X9.63 KDF
+
+# DSA
+set(WOLFSSL_DSA_HELP_STRING "Enable DSA (default: disabled)")
+option(WOLFSSL_DSA ${WOLFSSL_DSA_HELP_STRING} "no")
+
+if(NOT WOLFSSL_DSA AND NOT WOLFSSL_OPENSSH)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_DSA")
+endif()
+
+# ECC Shamir
+set(WOLFSSL_ECCSHAMIR_HELP_STRING "Enable ECC Shamir (default: enabled)")
+option(WOLFSSL_ECCSHAMIR ${WOLFSSL_ECCSHAMIR_HELP_STRING} "yes")
+
+# ECC
+set(WOLFSSL_ECC_HELP_STRING "Enable ECC (default: enabled)")
+set(WOLFSSL_ECC "yes" CACHE STRING ${WOLFSSL_ECC_HELP_STRING})
+set_property(CACHE WOLFSSL_ECC PROPERTY STRINGS "yes" "no" "nonblock")
+
+# lean psk doesn't need ecc
+if(WOLFSSL_LEAN_PSK)
+    override_cache(WOLFSSL_ECC "no")
+endif()
+
+if(WOLFSSL_OPENSSH OR
+   WOLFSSL_NGINX OR
+   WOLFSSL_SIGNAL)
+    override_cache(WOLFSSL_ECC "yes")
+endif()
+
+if(WOLFSSL_ECC)
+    list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_ECC" "-DTFM_ECC256")
+
+    if(WOLFSSL_ECCSHAMIR AND NOT WOLFSSL_LOW_RESOURCE)
+        list(APPEND WOLFSSL_DEFINITIONS "-DECC_SHAMIR")
+    endif()
+
+    if("${WOLFSSL_ECC}" STREQUAL "nonblock")
+        list(APPEND WOLFSSL_DEFINITIONS "-DWC_ECC_NONBLOCK")
+    endif()
+endif()
+
+# TODO: - ECC custom curves
+#       - Compressed key
+#       - CURVE25519
+#       - ED25519
+#       - CURVE448
+#       - ED448
+#       - FP ECC, fixed point cache ECC
+#       - ECC encrypt
+#       - PSK
+#       - Single PSK identity
+
+# Error strings
+set(WOLFSSL_ERROR_STRINGS_HELP_STRING "Enable error strings table (default: enabled)")
+option(WOLFSSL_ERROR_STRINGS ${WOLFSSL_ERROR_STRINGS_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_ERROR_STRINGS)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_ERROR_STRINGS")
+else()
+    # turn off error strings if leanpsk or leantls o
+    if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_ERROR_STRINGS")
+        override_cache(WOLFSSL_ERROR_STRINGS "no")
+    endif()
+endif()
+
+# Error queue
+set(WOLFSSL_ERROR_QUEUE_HELP_STRING "Enables adding nodes to error queue when compiled with OPENSSL_EXTRA (default: enabled)")
+option(WOLFSSL_ERROR_QUEUE ${WOLFSSL_DISABLE_ERROR_QUEUE_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_ERROR_QUEUE)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_ERROR_QUEUE")
+endif()
+
+# Old TLS
+set(WOLFSSL_OLD_TLS_HELP_STRING "Enable old TLS versions < 1.2 (default: enabled)")
+option(WOLFSSL_OLD_TLS ${WOLFSSL_OLD_TLS_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_OLD_TLS)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_OLD_TLS")
+else()
+    # turn off old if leanpsk or leantls on
+    if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_OLD_TLS")
+        override_cache(WOLFSSL_OLD_TLS "no")
+    endif()
+endif()
+
+# TLSv1.2
+set(WOLFSSL_TLSV12_HELP_STRING "Enable TLS versions 1.2 (default: enabled)")
+option(WOLFSSL_TLSV12 ${WOLFSSL_TLSV12_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_TLSV12)
+    list(APPEND WOLFSSL_DEFINITIONS
+        "-DWOLFSSL_NO_TLS12"
+        "-DNO_OLD_TLS")
+endif()
+
+# TODO: - TLSv1.0
+#       - SSLv3
+#       - Stack size
+#       - Stack size verbose
+
+# Memory
+set(WOLFSSL_MEMORY_HELP_STRING "Enable memory callbacks (default: enabled)")
+option(WOLFSSL_MEMORY ${WOLFSSL_MEMORY_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_MEMORY)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_WOLFSSL_MEMORY")
+else()
+    # turn off memory cb if leanpsk or leantls on
+    if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
+        # but don't turn on NO_WOLFSSL_MEMORY because using own
+        override_cache(WOLFSSL_MEMORY "no")
+    endif()
+endif()
+
+# TODO: - Track memory
+#       - Memory log
+#       - Stack log
+
+# RSA
+set(WOLFSSL_RSA_HELP_STRING "Enable RSA (default: enabled)")
+option(WOLFSSL_RSA ${WOLFSSL_RSA_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_RSA)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_RSA")
+else()
+    if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_RSA")
+        override_cache(WOLFSSL_RSA "no")
+    endif()
+endif()
+
+# OAEP
+set(WOLFSSL_OAEP_HELP_STRING "Enable RSA OAEP (default: enabled)")
+option(WOLFSSL_OAEP ${WOLFSSL_OAEP_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_OAEP)
+    list(APPEND WOLFSSL_DEFINITIONS "-DWC_NO_RSA_OAEP")
+endif()
+
+# TODO: - RSA public only
+#       - RSA verify inline only
+
+# RSA-PSS
+set(WOLFSSL_RSA_PSS_HELP_STRING "Enable RSA-PSS (default: disabled)")
+option(WOLFSSL_RSA_PSS ${WOLFSSL_RSA_PSS_HELP_STRING} "no")
+
+if(NOT WOLFSSL_RSA)
+    override_cache(WOLFSSL_RSA_PSS "no")
+else()
+    if(WOLFSSL_TLS13)
+        override_cache(WOLFSSL_RSA_PSS "yes")
+    endif()
+endif()
+if(WOLFSSL_RSA_PSS)
+    list(APPEND WOLFSSL_DEFINITIONS "-DWC_RSA_PSS") 
+endif()
+
+# DH
+set(WOLFSSL_DH_HELP_STRING "Enable DH (default: enabled)")
+option(WOLFSSL_DH ${WOLFSSL_DH_HELP_STRING} "yes")
+
+if(WOLFSSL_OPENSSH)
+    override_cache(WOLFSSL_DH "yes")
+endif()
+
+if(NOT WOLFSSL_DH)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_DH")
+else()
+    if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
+      list(APPEND WOLFSSL_DEFINITIONS "-DNO_DH")  
+      override_cache(WOLFSSL_DH "no")
+    endif()
+endif()
+
+# TODO: - Anonymous
+
+# ASN
+# turn off asn, which means no certs, no rsa, no dsa, no ecc,
+# and no big int (unless dh is on)
+set(WOLFSSL_ASN_HELP_STRING "Enable ASN (default: enabled)")
+option(WOLFSSL_ASN ${WOLFSSL_ASN_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_ASN)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_ASN" "-DNO_CERTS")
+
+    if(NOT WOLFSSL_DH AND NOT WOLFSSL_ECC)
+        # DH and ECC need bigint
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_BIG_INT")
+    endif()
+else()
+    # turn off ASN if leanpsk on
+    if(WOLFSSL_LEAN_PSK)
+        list(APPEND WOLFSSL_DEFINITIONS
+            "-DNO_ASN"
+            "-DNO_CERTS"
+            "-DNO_BIG_INT")
+        override_cache(WOLFSSL_ASN "no")
+    else()
+        if("${WOLFSSL_ASN}" STREQUAL "nocrypt")
+            list(APPEND WOLFSSL_DEFINITIONS "-DNO_ASN_CRYPT")
+            # TODO: verify that this is correct
+            override_cache(WOLFSSL_PWDBASED "no")
+        endif()
+    endif()
+endif()
+
+if(WOLFSSL_RSA AND NOT WOLFSSL_RSA_VFY AND NOT WOLFSSL_ASN)
+    message(FATAL_ERROR "please disable rsa if disabling asn.")
+endif()
+
+if(WOLFSSL_DSA AND NOT WOLFSSL_ASN)
+    message(FATAL_ERROR "please disable dsa if disabling asn.")
+endif()
+
+# DH and ECC need bigint
+if(NOT WOLFSSL_ASN AND
+   NOT WOLFSSL_DH AND
+   NOT WOLFSSL_ECC AND
+   NOT WOLFSSL_RSA)
+    override_cache(WOLFSSL_FAST_MATH "no")
+    set(WOLFSSL_SLOWMATH "no")
+endif()
+
+# AES
+set(WOLFSSL_AES_HELP_STRING "Enable AES (default: enabled)")
+option(WOLFSSL_AES ${WOLFSSL_AES_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_AES)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_AES")
+
+    if(WOLFSSL_FORTRESS)
+        message(FATAL_ERROR "fortress requires aes")
+    endif()
+    if(WOLFSSL_ECC_ENCRYPT)
+        message(FATAL_ERROR "cannot enable eccencrypt and hkdf without aes.")
+    endif()
+    if(WOLFSSL_AESGCM)
+        message(FATAL_ERROR "AESGCM requires AES.")
+    endif()
+    if(WOLFSSL_AESCCM)
+        message(FATAL_ERROR "AESCCM requires AES.")
+    endif()
+    if(WOLFSSL_AESCTR)
+        message(FATAL_ERROR "AESCTR requires AES.")
+    endif()
+else()
+    if(WOLFSSL_LEAN_PSK)
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_AES")
+        override_cache(WOLFSSL_AES "no")
+    endif()
+endif()
+
+# Coding
+set(WOLFSSL_CODING_HELP_STRING "Enable coding base 16/64 (default: enabled)")
+option(WOLFSSL_CODING ${WOLFSSL_CODING_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_CODING)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_CODING")
+else()
+    # turn off CODING if leanpsk on
+    if(WOLFSSL_LEAN_PSK)
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_CODING")
+        override_cache(WOLFSSL_CODING "no")
+    endif()
+endif()
+
+# Base64
+set(BASE64_ENCODE_DEFAULT "no")
+if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    set(BASE64_ENCODE_DEFAULT "yes")
+endif()
+
+set(WOLFSSL_BASE64_ENCODE_HELP_STRING "Enable Base64 encoding (default: enabled on x86_64)")
+option(WOLFSSL_BASE64_ENCODE ${WOLFSSL_BASE64_ENCODE_HELP_STRING} ${BASE64_ENCODE_DEFAULT})
+
+if(WOLFSSL_BASE64_ENCODE)
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_BASE64_ENCODE")  
+endif()
+
+# TODO: - Base16
+
+# DES3
+set(WOLFSSL_DES3_HELP_STRING "Enable DES3 (default: disabled)")
+option(WOLFSSL_DES3 ${WOLFSSL_DES3_HELP_STRING} "no")
+
+if(WOLFSSL_OPENSSH OR
+   WOLFSSL_QT OR
+   WOLFSSL_OPENVPN OR
+   WOLFSSL_WPAS)
+    override_cache(WOLFSSL_DES3 "yes")
+endif()
+
+# TODO: - IDEA
+
+# ARC4
+set(WOLFSSL_ARC4_HELP_STRING "Enable ARC4 (default: disabled)")
+option(WOLFSSL_ARC4 ${WOLFSSL_ARC4_HELP_STRING} "no")
+
+if(WOLFSSL_OPENSSH OR WOLFSSL_WPAS)
+    override_cache(WOLFSSL_ARC4 "yes")
+endif()
+
+if(NOT WOLFSSL_ARC4)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_RC4")
+else()
+    # turn off ARC4 if leanpsk or leantls on
+    if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_RC4")
+        override_cache(WOLFSSL_ARC4 "no")
+    endif()
+endif()
+
+# MD5
+set(WOLFSSL_MD5_HELP_STRING "Enable MD5 (default: enabled)")
+option(WOLFSSL_MD5 ${WOLFSSL_MD5_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_MD5)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_MD5" "-DNO_OLD_TLS")
+else()
+    # turn off MD5 if leanpsk or leantls on
+    if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_MD5" "-DNO_OLD_TLS")
+        override_cache(WOLFSSL_MD5 "no")
+    endif()
+endif()
+
+# SHA
+set(WOLFSSL_SHA_HELP_STRING "Enable SHA (default: enabled)")
+option(WOLFSSL_SHA ${WOLFSSL_SHA_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_SHA)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_SHA" "-DNO_OLD_TLS")
+else()
+    # turn off SHA if leanpsk or leantls on
+    if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_SHA" "-DNO_OLD_TLS")
+        override_cache(WOLFSSL_SHA "no")
+    endif()
+endif()
+
+# TODO: - CMAC
+#       - AES-XTS
+#       - Web server
+#       - Web client
+
+# HC128
+set(WOLFSSL_HC128_HELP_STRING "Enable HC-128 (default: disabled)")
+option(WOLFSSL_HC128 ${WOLFSSL_HC128_HELP_STRING} "no")
+
+if(NOT WOLFSSL_HC128)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_HC128")
+else()
+    list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_HC128")
+endif()
+
+# RABBIT
+if(NOT WOLFSSL_RABBIT)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_RABBIT")
+else()
+    list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_RABBIT")
+endif()
+
+# TODO: - RC2
+#       - FIPS, again (there's more logic for FIPS after RABBIT in configure.ac)
+#       - Selftest
+
+# SHA224
+set(SHA224_DEFAULT "no")
+if(("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64") OR
+    ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64"))
+    if(NOT WOLFSSL_AFALG AND NOT WOLFSSL_DEVCRYPTO AND
+       (NOT WOLFSSL_FIPS OR ("${FIPS_VERSION}" STREQUAL "v2")))
+        set(SHA224_DEFAULT "yes")
+    endif()
+endif()
+
+set(WOLFSSL_SHA224_HELP_STRING "Enable wolfSSL SHA-224 support (default: enabled on x86_64/aarch64)")
+option(WOLFSSL_SHA224 ${WOLFSSL_SHA224_HELP_STRING} ${SHA224_DEFAULT})
+
+if(WOLFSSL_SHA224)
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_SHA224")
+endif()
+
+# SHA3
+set(SHA3_DEFAULT "no")
+if(("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64") OR
+    ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64"))
+    if(NOT WOLFSSL_FIPS OR ("${FIPS_VERSION}" STREQUAL "v2"))
+        set(SHA3_DEFAULT "yes")
+    endif()
+endif()
+
+set(WOLFSSL_SHA3_HELP_STRING "Enable wolfSSL SHA-3 support (default: enabled on x86_64/aarch64)")
+set(WOLFSSL_SHA3 ${SHA3_DEFAULT} CACHE STRING ${WOLFSSL_SHA3_HELP_STRING})
+set_property(CACHE WOLFSSL_SHA3 PROPERTY STRINGS "yes" "no" "small")
+
+if("${WOLFSSL_SHA3}" STREQUAL "small")
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_SHA3_SMALL")
+    override_cache(WOLFSSL_SHA3 "yes")
+endif()
+
+if(WOLFSSL_SHA3 AND NOT WOLFSSL_32BIT)
+    list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_SHA3")
+endif()
+
+# SHAKE256
+set(WOLFSSL_SHAKE256_HELP_STRING "Enable wolfSSL SHAKE256 support (default: enabled on x86_64/aarch64)")
+set(WOLFSSL_SHAKE256 "no" CACHE STRING ${WOLFSSL_SHAKE256_HELP_STRING})
+set_property(CACHE WOLFSSL_SHAKE256 PROPERTY STRINGS "yes" "no" "small")
+
+if(NOT WOLFSSL_SHAKE256)
+    override_cache(WOLFSSL_SHAKE256 ${WOLFSSL_SHA3})
+endif()
+
+if(WOLFSSL_SHAKE256)
+    if(NOT WOLFSSL_32BIT)
+        list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_SHAKE256")
+
+        if(NOT WOLFSSL_SHA3)
+            message(FATAL_ERROR "Must have SHA-3 enabled: --enable-sha3")
+        endif()
+    endif()
+endif()
+
+# POLY1305
+set(POLY1305_DEFAULT "yes")
+if(WOLFSSL_FIPS)
+    set(POLY1305_DEFAULT "no")
+endif()
+
+set(WOLFSSL_POLY1305_HELP_STRING "Enable wolfSSL POLY1305 support (default: enabled)")
+option(WOLFSSL_POLY1305 ${WOLFSSL_POLY1305_HELP_STRING} ${POLY1305_DEFAULT})
+
+# leanpsk and leantls don't need poly1305
+if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
+    override_cache(WOLFSSL_POLY1305 "no")
+endif()
+
+if(WOLFSSL_POLY1305)
+    list(APPEND WOLFSSL_DEFINITIONS
+        "-DHAVE_POLY1305"
+        "-DHAVE_ONE_TIME_AUTH")
+endif()
+
+# CHACHA
+set(CHACHA_DEFAULT "yes")
+if(WOLFSSL_FIPS)
+    set(CHACHA_DEFAULT "no")
+endif()
+
+set(WOLFSSL_CHACHA_HELP_STRING "Enable CHACHA (default: enabled). Use `=noasm` to disable ASM AVX/AVX2 speedups")
+set(WOLFSSL_CHACHA ${CHACHA_DEFAULT} CACHE STRING ${WOLFSSL_CHACHA_HELP_STRING})
+set_property(CACHE WOLFSSL_CHACHA PROPERTY STRINGS "yes" "no" "noasm")
+
+# leanpsk and leantls don't need chacha
+if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
+    override_cache(WOLFSSL_CHACHA "no")
+endif()
+
+if(("${WOLFSSL_CHACHA}" STREQUAL "noasm") OR NOT WOLFSSL_ASM)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_CHACHA_ASM")
+endif()
+
+if(NOT ("${WOLFSSL_CHACHA}" STREQUAL "noasm") AND WOLFSSL_CHACHA)
+    list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_CHACHA")
+endif()
+
+# TODO: - XCHACHA
+
+# Hash DRBG
+set(WOLFSSL_HASH_DRBG_HELP_STRING "Enable Hash DRBG support (default: enabled)")
+option(WOLFSSL_HASH_DRBG ${WOLFSSL_HASH_DRBG_HELP_STRING} "yes")
+
+if(WOLFSSL_HASH_DRBG)
+    list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_HASHDRBG")
+else()
+    # turn on Hash DRBG if FIPS is on
+    if(WOLFSSL_FIPS)
+        list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_HASHDRBG")
+        override_cache(WOLFSSL_HASH_DRBG "yes")
+    else()
+        list(APPEND WOLFSSL_DEFINITIONS "-DWC_NO_HASHDRBG")
+    endif()
+endif()
+
+# Filesystem
+if(WOLFSSL_LINUX_KM)
+    set(FILESYSTEM_DEFAULT "no")
+else()
+    set(FILESYSTEM_DEFAULT "yes")
+endif()
+
+set(WOLFSSL_FILESYSTEM_HELP_STRING "Enable Filesystem support (default: enabled)")
+option(WOLFSSL_FILESYSTEM ${WOLFSSL_FILESYSTEM_HELP_STRING} ${FILESYSTEM_DEFAULT})
+
+if(NOT WOLFSSL_FILESYSTEM)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_FILESYSTEM")
+else()
+    if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_FILESYSTEM")
+        override_cache(WOLFSSL_FILESYSTEM "no")
+    endif()
+endif()
+
+# Inline function support
+set(WOLFSSL_INLINE_HELP_STRING "Enable inline functions (default: enabled)")
+option(WOLFSSL_INLINE ${WOLFSSL_INLINE_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_INLINE)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_INLINE")
+endif()
+
+# TODO: - OCSP
+#       - OCSP stapling
+#       - OCSP stapling v2
+#       - CRL
+#       - CRL monitor
+#       - User crypto
+#       - NTRU
+#       - QSH
+#       - Whitewood netRandom client library
+#       - SNI
+#       - Max fragment length
+#       - ALPN
+#       - Trusted CA indication
+#       - Truncated HMAC
+#       - Renegotiation indication
+#       - Secure renegotiation
+#       - Fallback SCSV
+
+# Supported elliptic curves extensions
+set(WOLFSSL_SUPPORTED_CURVES_HELP_STRING "Enable Supported Elliptic Curves (default: enabled)")
+option(WOLFSSL_SUPPORTED_CURVES ${WOLFSSL_SUPPORTED_CURVES_HELP_STRING} "yes")
+
+if(WOLFSSL_SUPPORTED_CURVES)
+    if(NOT WOLFSSL_ECC AND NOT WOLFSSL_CURVE25519 AND NOT WOLFSSL_CURVE448)
+        override_cache(WOLFSSL_SUPPORTED_CURVES "no")        
+    else()
+        list(APPEND WOLFSSL_DEFINITIONS
+            "-DHAVE_TLS_EXTENSIONS"
+            "-DHAVE_SUPPORTED_CURVES")
+    endif()
+endif()
+
+# Diffie-Hellman
+if(WOLFSSL_DH)
+    if(WOLFSSL_TLS13 OR WOLFSSL_SUPPORTED_CURVES)
+        list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_FFDHE_2048")
+    endif()
+endif()
+
+# TODO: - FFDHE params only
+
+# TLS 1.3 Requires either ECC or (RSA/DH), or CURVE25519/ED25519 or CURVE448/ED448
+if (NOT WOLFSSL_ECC AND
+    (NOT WOLFSSL_RSA OR NOT WOLFSSL_DH) AND
+    (NOT WOLFSSL_CURVE25519 OR NOT WOLFSSL_ED25519) AND
+    (NOT WOLFSSL_CURVE448 AND NOT WOLFSSL_ED448))
+    override_cache(WOLFSSL_TLS13 "no")
+endif()
+if (WOLFSSL_TLS13)
+    list(APPEND WOLFSSL_DEFINITIONS
+        "-DWOLFSSL_TLS13"
+        "-DHAVE_TLS_EXTENSIONS"
+        "-DHAVE_SUPPORTED_CURVES")
+endif()
+
+# TODO: - Session ticket
+
+# Extended master secret extension
+set(WOLFSSL_EXTENDED_MASTER_HELP_STRING "Enable Extended Master Secret (default: enabled)")
+option(WOLFSSL_EXTENDED_MASTER ${WOLFSSL_EXTENDED_MASTER_HELP_STRING} "yes")
+
+if(WOLFSSL_EXTENDED_MASTER)
+    list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_EXTENDED_MASTER")
+endif()
+
+# TODO: - TLS extensions
+#       - Early data handshake
+#       - PKCS7
+#       - wolfSSH options
+#       - SCEP
+#       - Secure remote password
+#       - Indefinite length encoded messages
+#       - Small stack cache
+#       - Small stack
+#       - Valgrind
+#       - Test certs
+#       - I/O pool example
+#       - Certificate service
+#       - wolfSSL JNI
+#       - lighttpd/lighty
+#       - Asio
+#       - Apache HTTPD
+
+# Encrypt-then-mac
+set(WOLFSSL_ENC_THEN_MAC_HELP_STRING "Enable Encryptr-Then-Mac extension (default: enabled)")
+option(WOLFSSL_ENC_THEN_MAC ${WOLFSSL_ENC_THEN_MAC_HELP_STRING} "yes")
+
+if(WOLFSSL_APACHE_HTTPD)
+    override_cache(WOLFSSL_ENC_THEN_MAC "no")
+endif()
+
+if(WOLFSSL_TLSX)
+    override_cache(WOLFSSL_ENC_THEN_MAC "yes")
+endif()
+
+if(WOLFSSL_SNIFFER)
+    override_cache(WOLFSSL_ENC_THEN_MAC "no")
+endif()
+
+# stunnel Support
+# TODO: rest of stunnel support
+set(WOLFSSL_STUNNEL_HELP_STRING "Enable stunnel (default: disabled)")
+option(WOLFSSL_STUNNEL ${WOLFSSL_STUNNEL_HELP_STRING} "no")
+
+if(NOT WOLFSSL_PSK AND
+   NOT WOLFSSL_LEAN_PSK AND
+   NOT WOLFSSL_STUNNEL)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_PSK")
+endif()
+
+if(WOLFSSL_ENC_THEN_MAC)
+    list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_ENCRYPT_THEN_MAC")
+endif()
+
+# MD4
+set(WOLFSSL_MD4_HELP_STRING "Enable MD4 (default: disabled)")
+option(WOLFSSL_MD4 ${WOLFSSL_MD4_HELP_STRING} "no")
+
+if(NOT WOLFSSL_MD4)
+    # turn on MD4 if using stunnel
+    if(WOLFSSL_STUNNEL OR WOLFSSL_WPAS)
+        override_cache(WOLFSSL_MD4 "yes")
+    else()
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_MD4")
+    endif()
+endif()
+
+#  TODO: - Encrypted keys
+
+# PWDBASED has to come after certservice since we want it on w/o explicit on
+# PWDBASED
+set(WOLFSSL_PWDBASED_HELP_STRING "Enable PWDBASED (default: disabled)")
+option(WOLFSSL_PWDBASED ${WOLFSSL_PWDBASED_HELP_STRING} "no")
+
+if(NOT WOLFSSL_PWDBASED)
+    if(WOLFSSL_OPENSSLEXTRA OR
+        WOLFSSL_OPENSSLALL OR
+        WOLFSSL_WEBSERVER OR
+        WOLFSSL_ENC_KEYS)
+        # opensslextra, opensslall, webserver, and enckeys needs pwdbased
+        override_cache(WOLFSSL_PWDBASED "yes")
+    else()
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_PWDBASED")
+    endif()
+endif()
+
+# TODO: - SCRYPT
+#       - wolfCrypt only
+
+# fastmath
+set(FASTMATH_DEFAULT "no")
+
+if(("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64") OR
+    ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64"))
+    set(FASTMATH_DEFAULT "yes")
+endif()
+
+if(WOLFSSL_LINUXKM_DEFAULTS)
+    set(FASTMATH_DEFAULT "no")
+endif()
+
+if(WOLFSSL_SP_MATH)
+    set(FASTMATH_DEFAULT "no")
+endif()
+
+set(WOLFSSL_FAST_MATH_HELP_STRING "Enable fast math ops (default: enabled on x86_64/aarch64)")
+option(WOLFSSL_FAST_MATH ${WOLFSSL_FAST_MATH_HELP_STRING} ${FASTMATH_DEFAULT})
+
+if(WOLFSSL_FAST_MATH)
+    # turn off fastmath if leanpsk on or asn off (w/o DH and ECC)
+    if(WOLFSSL_LEAN_PSK OR NOT WOLFSSL_ASN)
+        if(NOT WOLFSSL_DH AND
+           NOT WOLFSSL_ECC AND
+           NOT WOLFSSL_RSA)
+            override_cache(WOLFSSL_FAST_MATH "no")
+        else()
+            list(APPEND WOLFSSL_DEFINITIONS "-DUSE_FAST_MATH")
+            set(WOLFSSL_SLOWMATH "no")
+        endif()
+    else()
+        list(APPEND WOLFSSL_DEFINITIONS "-DUSE_FAST_MATH")
+        set(WOLFSSL_SLOWMATH "no")
+    endif()
+
+    if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+        # Have settings.h set FP_MAX_BITS higher if user didn't set directly
+        list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_X86_64_BUILD")
+    endif()
+endif()
+
+# TODO: - Fast huge math
+
+# Enable examples, used to disable examples
+if(WOLFSSL_LINUX_KM)
+    set(EXAMPLES_DEFAULT "no")
+else()
+    set(EXAMPLES_DEFAULT "yes")
+endif()
+
+set(WOLFSSL_EXAMPLES_HELP_STRING "Enable examples (default: enabled)")
+option(WOLFSSL_EXAMPLES ${WOLFSSL_EXAMPLES_HELP_STRING} ${EXAMPLES_DEFAULT})
+
+if(NOT WOLFSSL_FILESYSTEM OR
+   NOT WOLFSSL_INLINE OR
+   WOLFSSL_CRYPT_ONLY)
+    override_cache(WOLFSSL_EXAMPLES "no")
+endif()
+
+# Enable wolfCrypt test and benchmark
+if(WOLFSSL_LINUX_KM)
+    set(CRYPT_TESTS_DEFAULT "no")
+else()
+    set(CRYPT_TESTS_DEFAULT "yes")
+endif()
+
+set(WOLFSSL_CRYPT_TESTS_HELP_STRING "Enable Crypt Bench/Test  (default: enabled)")
+option(WOLFSSL_CRYPT_TESTS ${WOLFSSL_CRYPT_TESTS_HELP_STRING} ${CRYPT_TESTS_DEFAULT})
+
+# TODO: - LIBZ
+#       - PKCS#11
+#       - PKCS#12
+#       - Cavium
+#       - Cavium V
+#       - Cavium Octeon
+#       - Intel QuickAssist
+#       - SP ASM (and other SP logic)
+#       - Fast RSA
+#       - Static memory use
+#       - Microchip API
+#       - Asynchronous crypto
+
+# Asynchronous threading
+set(WOLFSSL_ASYNC_THREADS_HELP_STRING "Enable Asynchronous Threading (default: enabled)")
+option(WOLFSSL_ASYNC_THREADS ${WOLFSSL_ASYNC_THREADS_HELP_STRING} "yes")
+
+if(WOLFSSL_ASYNC_CRYPT AND WOLFSSL_ASYNC_THREADS)
+    if(CMAKE_USE_PTHREADS_INIT)
+        override_cache(WOLFSSL_ASYNC_THREADS "yes")
+    else()
+        override_cache(WOLFSSL_ASYNC_THREADS "no")
+    endif()
+else()
+    override_cache(WOLFSSL_ASYNC_THREADS "no")
+endif()
+
+if(WOLFSSL_ASYNC_THREADS)
+    list(APPEND WOLFSSL_LINK_LIBS Threads::Threads)
+    list(APPEND WOLFSSL_DEFINITIONS "-D_GNU_SOURCE")
+else()
+    list(APPEND WOLFSSL_DEFINITIONS "-DWC_NO_ASYNC_THREADING")
+endif()
+
+# TODO: - cryptodev
+#       - cryptocb
+#       - Session export
+#       - AES key wrap
+
+set(WOLFSSL_OLD_NAMES_HELP_STRING "Keep backwards compat with old names (default: enabled)")
+option(WOLFSSL_OLD_NAMES ${WOLFSSL_OLD_NAMES_HELP_STRING} "yes")
+
+if(NOT WOLFSSL_OLD_NAMES AND NOT WOLFSSL_OPENSSL_COEXIST)
+    list(APPEND WOLFSSL_DEFINITIONS
+        "-DNO_OLD_RNGNAME"
+        "-DNO_OLD_WC_NAMES"
+        "-DNO_OLD_SSL_NAMES"
+        "-DNO_OLD_SHA_NAMES")
+endif()
+
+# TODO: - Memory tests
+#       - Hash flags
+
+# Support for enabling setting default DH parameters
+set(WOLFSSL_DH_DEFAULT_PARAMS_HELP_STRING "Enables option for default dh parameters (default: disabled)")
+option(WOLFSSL_DH_DEFAULT_PARAMS ${WOLFSSL_DH_DEFAULT_PARAMS_HELP_STRING} "no")
+
+if(WOLFSSL_DH_DEFAULT_PARAMS OR NOT WOLFSSL_QT)
+    override_cache(WOLFSSL_DH_DEFAULT_PARAMS "yes")
+    list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_DH_DEFAULT_PARAMS")
+endif()
+
+if(NOT WOLFSSL_DES3)
+    list(APPEND WOLFSSL_DEFINITIONS "-DNO_DES3")
+else()
+    # turn off DES3 if leanpsk or leantls on
+    if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
+        list(APPEND WOLFSSL_DEFINITIONS "-DNO_DES3")
+        override_cache(WOLFSSL_DES3 "no")
+    endif()
+endif()
+
+# TODO: - User settings
+
+set(WOLFSSL_OPTFLAGS_HELP_STRING "Enable default optimization CFLAGS for the compiler (default: enabled)")
+option(WOLFSSL_OPTFLAGS ${WOLFSSL_OPTFLAGS_HELP_STRING} "yes")
+
+# Generates the BUILD_* flags. These control what source files
+# are included in the library. A series of AM_CONDITIONALs
+# handle this in configure.ac.
+generate_build_flags()
+
+# TODO: - Bit of logic after optimization flags option (above)
+#       - Check for build-type conflicts section
+#       - Update CFLAGS based on options section
+#       - User settings section
+#       - BUILD_* flags and the logic they implement to control
+#         what gets built
+
+
+# TODO: Applying definitions to everything like this, rather than
+#       individual targets, is discouraged in CMake.
+add_definitions(${WOLFSSL_DEFINITIONS})
+add_definitions("-DHAVE_CONFIG_H")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/config.h" )
+
+# Suppress some warnings about separate compilation, inlining
+add_definitions("-DWOLFSSL_IGNORE_FILE_WARN")
+
+# Generate user options header
+message("Generating user options header...")
+set(OPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/wolfssl/options.h")
+file(REMOVE ${OPTION_FILE})
+
+file(APPEND ${OPTION_FILE} "/* wolfssl options.h\n")
+file(APPEND ${OPTION_FILE} " * generated from configure options\n")
+file(APPEND ${OPTION_FILE} " *\n")
+file(APPEND ${OPTION_FILE} " * Copyright (C) 2006-2020 wolfSSL Inc.\n")
+file(APPEND ${OPTION_FILE} " *\n")
+file(APPEND ${OPTION_FILE} " * This file is part of wolfSSL. (formerly known as CyaSSL)\n")
+file(APPEND ${OPTION_FILE} " *\n")
+file(APPEND ${OPTION_FILE} " */\n\n")
+file(APPEND ${OPTION_FILE} "#ifndef WOLFSSL_OPTIONS_H\n")
+file(APPEND ${OPTION_FILE} "#define WOLFSSL_OPTIONS_H\n\n\n")
+file(APPEND ${OPTION_FILE} "#ifdef __cplusplus\n")
+file(APPEND ${OPTION_FILE} "extern \"C\" {\n")
+file(APPEND ${OPTION_FILE} "#endif\n\n")
+
+foreach(DEF IN LISTS WOLFSSL_DEFINITIONS)
+    if(DEF MATCHES "^-D")
+        if(DEF MATCHES "^-D(N)?DEBUG(=.+)?")
+            message("not outputting (N)DEBUG to ${OPTION_FILE}")
+        endif()
+
+        # allow user to ignore system options
+        if(DEF MATCHES "^-D_.*")
+            file(APPEND ${OPTION_FILE} "#ifndef WOLFSSL_OPTIONS_IGNORE_SYS\n")
+        endif()
+
+        string(REGEX REPLACE "^-D" "" DEF_NO_PREFIX ${DEF})
+        string(REGEX REPLACE "=.*$" "" DEF_NO_EQUAL_NO_VAL ${DEF_NO_PREFIX})
+        string(REPLACE "=" " " DEF_NO_EQUAL ${DEF_NO_PREFIX})
+
+        file(APPEND ${OPTION_FILE} "#undef  ${DEF_NO_EQUAL_NO_VAL}\n")
+        file(APPEND ${OPTION_FILE} "#define ${DEF_NO_EQUAL}\n")
+
+        if(DEF MATCHES "^-D_.*")
+            file(APPEND ${OPTION_FILE} "#endif\n")
+        endif()
+
+        file(APPEND ${OPTION_FILE} "\n")
+    else()
+        message("option w/o begin -D is ${DEF}, not saving to ${OPTION_FILE}")
+    endif()
+endforeach()
+
+file(APPEND ${OPTION_FILE} "\n#ifdef __cplusplus\n")
+file(APPEND ${OPTION_FILE} "}\n")
+file(APPEND ${OPTION_FILE} "#endif\n\n\n")
+file(APPEND ${OPTION_FILE} "#endif /* WOLFSSL_OPTIONS_H */\n\n")
+
+# backwards compatibility for those who have included options or version
+set(CYASSL_OPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cyassl/options.h")
+file(REMOVE ${CYASSL_OPTION_FILE})
+file(APPEND ${CYASSL_OPTION_FILE} "/* cyassl options.h\n")
+file(APPEND ${CYASSL_OPTION_FILE} " * generated from wolfssl/options.h\n")
+file(APPEND ${CYASSL_OPTION_FILE} " */\n")
+file(READ ${OPTION_FILE} OPTION_FILE_CONTENTS)
+file(APPEND ${CYASSL_OPTION_FILE} ${OPTION_FILE_CONTENTS})
+
+add_definitions(${WOLFSSL_DEFINITIONS})
+
+configure_file("${CMAKE_SOURCE_DIR}/cmake/config.in"
+               "${CMAKE_BINARY_DIR}/config.h" )
 
 ####################################################
 # Library Target
 ####################################################
 
-add_library(wolfssl
-    src/bio.c
-    src/crl.c
-    src/internal.c
-    src/keys.c
-    src/ocsp.c
-    src/sniffer.c
-    src/ssl.c
-    src/tls.c
-    src/tls13.c
-    src/wolfio.c
-    wolfcrypt/src/aes.c
-    wolfcrypt/src/arc4.c
-    wolfcrypt/src/asm.c
-    wolfcrypt/src/asn.c
-    wolfcrypt/src/async.c
-    wolfcrypt/src/blake2b.c
-    wolfcrypt/src/blake2s.c
-    wolfcrypt/src/camellia.c
-    wolfcrypt/src/chacha.c
-    wolfcrypt/src/chacha20_poly1305.c
-    wolfcrypt/src/cmac.c
-    wolfcrypt/src/coding.c
-    wolfcrypt/src/compress.c
-    wolfcrypt/src/cpuid.c
-    wolfcrypt/src/cryptocb.c
-    wolfcrypt/src/curve25519.c
-    wolfcrypt/src/curve448.c
-    wolfcrypt/src/des3.c
-    wolfcrypt/src/dh.c
-    wolfcrypt/src/dsa.c
-    wolfcrypt/src/ecc.c
-    wolfcrypt/src/ecc_fp.c
-    wolfcrypt/src/ed25519.c
-    wolfcrypt/src/ed448.c
-    wolfcrypt/src/error.c
-    wolfcrypt/src/evp.c
-    wolfcrypt/src/fe_448.c
-    wolfcrypt/src/fe_low_mem.c
-    wolfcrypt/src/fe_operations.c
-    wolfcrypt/src/fips.c
-    wolfcrypt/src/fips_test.c
-    wolfcrypt/src/ge_448.c
-    wolfcrypt/src/ge_low_mem.c
-    wolfcrypt/src/ge_operations.c
-    wolfcrypt/src/hash.c
-    wolfcrypt/src/hc128.c
-    wolfcrypt/src/hmac.c
-    wolfcrypt/src/idea.c
-    wolfcrypt/src/integer.c
-    wolfcrypt/src/logging.c
-    wolfcrypt/src/md2.c
-    wolfcrypt/src/md4.c
-    wolfcrypt/src/md5.c
-    wolfcrypt/src/memory.c
-    wolfcrypt/src/misc.c
-    wolfcrypt/src/pkcs12.c
-    wolfcrypt/src/pkcs7.c
-    wolfcrypt/src/poly1305.c
-    wolfcrypt/src/pwdbased.c
-    wolfcrypt/src/rabbit.c
-    wolfcrypt/src/random.c
-    wolfcrypt/src/ripemd.c
-    wolfcrypt/src/rsa.c
-    wolfcrypt/src/selftest.c
-    wolfcrypt/src/sha.c
-    wolfcrypt/src/sha256.c
-    wolfcrypt/src/sha3.c
-    wolfcrypt/src/sha512.c
-    wolfcrypt/src/signature.c
-    wolfcrypt/src/sp_arm32.c
-    wolfcrypt/src/sp_arm64.c
-    wolfcrypt/src/sp_armthumb.c
-    wolfcrypt/src/sp_c32.c
-    wolfcrypt/src/sp_c64.c
-    wolfcrypt/src/sp_cortexm.c
-    wolfcrypt/src/sp_dsp32.c
-    wolfcrypt/src/sp_int.c
-    wolfcrypt/src/sp_x86_64.c
-    wolfcrypt/src/srp.c
-    wolfcrypt/src/tfm.c
-    wolfcrypt/src/wc_dsp.c
-    wolfcrypt/src/wc_encrypt.c
-    wolfcrypt/src/wc_pkcs11.c
-    wolfcrypt/src/wc_port.c
-    wolfcrypt/src/wolfcrypt_first.c
-    wolfcrypt/src/wolfcrypt_last.c
-    wolfcrypt/src/wolfevent.c
-    wolfcrypt/src/wolfmath.c
+# TODO: - Build shared/static libs based on enables. Check CMake
+#         global flag BUILD_SHARED_LIBS.
+set(LIB_SOURCES "")
+# Generates a list of sources to include in the library.
+# Corresponds to the instances of "src_libwolfssl_la_SOURCES += ..."
+# in the *.am files.
+generate_lib_src_list("${LIB_SOURCES}")
+add_library(wolfssl ${LIB_SOURCES})
+
+set_target_properties(wolfssl
+    PROPERTIES
+        SOVERSION ${LIBTOOL_SO_VERSION}
+        VERSION ${LIBTOOL_FULL_VERSION}
 )
 
 ####################################################
@@ -180,65 +1323,80 @@ add_library(wolfssl
 target_include_directories(wolfssl
     PUBLIC
         $<INSTALL_INTERFACE:wolfssl>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/wolfssl>
-        ${CMAKE_CURRENT_SOURCE_DIR}/. # Needed for user_settings.h to be visible
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
 
 ####################################################
 # Link Libraries
 ####################################################
 
+target_link_libraries(wolfssl PUBLIC ${WOLFSSL_LINK_LIBS})
+
 if(WIN32)
     # For Windows link ws2_32
-    target_link_libraries(wolfssl PUBLIC $<$<PLATFORM_ID:Windows>:ws2_32>)
+    target_link_libraries(wolfssl PUBLIC
+        $<$<PLATFORM_ID:Windows>:ws2_32>)
 else()
     # DH requires math (m) library
-    target_link_libraries(wolfssl PUBLIC m)
+    target_link_libraries(wolfssl
+        PUBLIC
+            m)
 endif()
 
 ####################################################
 # Tests and Examples
 ####################################################
 
-# Optionally build example and test applications
-if(BUILD_TESTS)
-    # Build wolfCrypt test
-    add_executable(wolfcrypttest
-        ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/test/test.c)
-    target_link_libraries(wolfcrypttest wolfssl)
-
-    # Build wolfCrypt benchmark
-    add_executable(wolfcryptbench
-        ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/benchmark/benchmark.c)
-    target_link_libraries(wolfcryptbench wolfssl)
-
-    # Build wolfSSL Client example
+if(WOLFSSL_EXAMPLES)
+    # Build wolfSSL client example
     add_executable(client
         ${CMAKE_CURRENT_SOURCE_DIR}/examples/client/client.c)
     target_link_libraries(client wolfssl)
+    set_property(TARGET client
+                 PROPERTY RUNTIME_OUTPUT_DIRECTORY
+                 ${CMAKE_CURRENT_SOURCE_DIR}/examples/client)
 
-    # Build wolfSSL Server example
+    # Build wolfSSL server example
     add_executable(server
         ${CMAKE_CURRENT_SOURCE_DIR}/examples/server/server.c)
     target_link_libraries(server wolfssl)
+    set_property(TARGET server
+                 PROPERTY RUNTIME_OUTPUT_DIRECTORY
+                 ${CMAKE_CURRENT_SOURCE_DIR}/examples/server)
 
-    # Build Echo Client Example
+    # Build echo client example
     add_executable(echoclient
         ${CMAKE_CURRENT_SOURCE_DIR}/examples/echoclient/echoclient.c)
+    target_include_directories(echoclient PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR})
     target_link_libraries(echoclient wolfssl)
+    set_property(TARGET echoclient
+                 PROPERTY RUNTIME_OUTPUT_DIRECTORY
+                 ${CMAKE_CURRENT_SOURCE_DIR}/examples/echoclient)
 
-    # Build Echo Server Example
+    # Build echo server example
     add_executable(echoserver
         ${CMAKE_CURRENT_SOURCE_DIR}/examples/echoserver/echoserver.c)
+    target_include_directories(echoserver PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR})
     target_link_libraries(echoserver wolfssl)
+    set_property(TARGET echoserver
+                 PROPERTY RUNTIME_OUTPUT_DIRECTORY
+                 ${CMAKE_CURRENT_SOURCE_DIR}/examples/echoserver)
 
-    # Build TLS benchmark example
-    add_executable(tls_bench
-        ${CMAKE_CURRENT_SOURCE_DIR}/examples/benchmark/tls_bench.c)
-    target_link_libraries(tls_bench wolfssl)
-    target_link_libraries(tls_bench Threads::Threads)
+    if(NOT WIN32)
+        # Build TLS benchmark example
+        add_executable(tls_bench
+            ${CMAKE_CURRENT_SOURCE_DIR}/examples/benchmark/tls_bench.c)
+        target_link_libraries(tls_bench wolfssl)
+        target_link_libraries(tls_bench Threads::Threads)
+        set_property(TARGET tls_bench
+                 PROPERTY RUNTIME_OUTPUT_DIRECTORY
+                 ${CMAKE_CURRENT_SOURCE_DIR}/examples/benchmark)
+    endif()
 
-    # Build Unit Tests
+    # Build unit tests
     add_executable(unit_test
         tests/api.c
         tests/hash.c
@@ -246,11 +1404,105 @@ if(BUILD_TESTS)
         tests/suites.c
         tests/unit.c
         examples/server/server.c
-        examples/client/client.c
-    )
+        examples/client/client.c)
+    target_include_directories(unit_test PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR})
     target_compile_options(unit_test PUBLIC "-DNO_MAIN_DRIVER")
     target_link_libraries(unit_test wolfssl)
     target_link_libraries(unit_test Threads::Threads)
+    set_property(TARGET unit_test
+                 PROPERTY RUNTIME_OUTPUT_DIRECTORY
+                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/)
+    set_property(TARGET unit_test
+                 PROPERTY RUNTIME_OUTPUT_NAME
+                 unit.test)
 endif()
 
-# TODO: Add install() for library, headers and test applications
+if(WOLFSSL_CRYPT_TESTS)
+    # Build wolfCrypt test
+    add_executable(wolfcrypttest
+        ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/test/test.c)
+    target_link_libraries(wolfcrypttest wolfssl)
+    set_property(TARGET wolfcrypttest
+                 PROPERTY RUNTIME_OUTPUT_DIRECTORY
+                 ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/test)
+    set_property(TARGET wolfcrypttest
+                 PROPERTY RUNTIME_OUTPUT_NAME
+                 testwolfcrypt)
+
+    # Build wolfCrypt benchmark
+    add_executable(wolfcryptbench
+        ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/benchmark/benchmark.c)
+    target_include_directories(wolfcryptbench PRIVATE
+        ${CMAKE_CURRENT_BINARY_DIR})
+    target_link_libraries(wolfcryptbench wolfssl)
+    set_property(TARGET wolfcryptbench
+                 PROPERTY RUNTIME_OUTPUT_DIRECTORY
+                 ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/benchmark)
+    set_property(TARGET wolfcryptbench
+                 PROPERTY RUNTIME_OUTPUT_NAME
+                 benchmark)
+endif()
+
+####################################################
+# Installation
+####################################################
+
+include(GNUInstallDirs)
+
+set(EXCLUDED_HEADERS_REGEX
+    "(internal|\
+    options|\
+    pic32mz-crypt|\
+    ti-hash|\
+    ti-ccm|\
+    nrf51|\
+    ksdk_port|\
+    dcp_port|\
+    xil-sha3|\
+    caam_driver|\
+    wolfcaam|\
+    wolfcaam_sha|\
+    stm32|\
+    stsafe|\
+    esp32-cry|\
+    cryptoCell|\
+    renesas-tsip-crypt|\
+    psoc6_crypto).h")
+
+set(INSTALLED_EXAMPLES
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/echoserver/echoserver.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/sctp/sctp-server.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/sctp/sctp-client-dtls.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/sctp/sctp-client.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/sctp/sctp-server-dtls.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/echoclient/echoclient.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/server/server.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/benchmark/tls_bench.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/client/client.c)
+
+# Install the library
+install(TARGETS wolfssl
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        EXPORT wolfssl-targets
+        LIBRARY)
+# Install the headers
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/wolfssl/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/wolfssl
+        FILES_MATCHING PATTERN "*.h"
+        REGEX ${EXCLUDED_HEADERS_REGEX} EXCLUDE)
+# Install the examples
+install(FILES ${INSTALLED_EXAMPLES}
+        DESTINATION ${CMAKE_INSTALL_DOCDIR}/example)
+# Install README.txt and taoCert.txt
+install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/doc/README.txt
+        ${CMAKE_CURRENT_SOURCE_DIR}/certs/taoCert.txt
+        DESTINATION ${CMAKE_INSTALL_DOCDIR}/wolfssl)
+# Install the export set
+install(EXPORT wolfssl-targets
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/wolfssl
+        FILE wolfssl-config.cmake)
+
+# TODO: Distro build + rules for what to include in the distro.
+#       See various include.am files.

--- a/INSTALL
+++ b/INSTALL
@@ -78,29 +78,61 @@
     http://www.wolfssl.com/yaSSL/Docs-cyassl-manual-2-building-cyassl.html
 
 14. Building with CMake
-    Note: Primary development uses automake (./configure). The support for CMake is minimal.
+    Note: Primary development uses automake (./configure). The support for CMake
+    is still under development.
 
-    Internally cmake is setup to do the following:
-    1. Uses the ./configure generated wolfssl/options.h as the build options by coping it to the build directory as user_settings.h.
-    2. Builds wolfSSL as library.
-    3. Builds the examples.
+    For configuring wolfssl using CMake, we recommend downloading the CMake
+    GUI (https://cmake.org/download/). This tool allows you to see all of
+    wolfssl's configuration variables, set them, and view their descriptions.
+    Looking at the GUI or CMakeCache.txt (generated after running cmake once) is
+    the best way to find out what configuration options are available and what
+    they do. You can also invoke CMake from the GUI, which is described in the
+    Windows instructions below. For Unix-based systems, we describe the command
+    line work flow. Regardless of your chosen workflow, cmake will generate
+    a header options.h in the wolfssl directory that contains the options used
+    to configure the build.
 
-    Build Steps:
-    $ mkdir build
-    $ cd build
-    $ cmake ..
-    $ cmake --build .
-    $ cmake --install .
+    Unix-based Platforms
+    ---
+    1) Navigate to the wolfssl root directory containing "CMakeLists.txt".
+    2) Create a directory called "build" and change into it. This is where
+       CMake will store build files.
+    3) Run `cmake ..` to generate the target build files (e.g. UNIX Makefiles).
+       To enable or disable features, set them using -D<option>=[yes/no]. For
+       example, to disable TLS 1.3 support, run cmake .. -DWOLFSSL_TLS13=no
+       (autoconf equivalent: ./configure --disable-tls13) To enable DSA, run
+       cmake .. -DWOLFSSL_DSA=yes (autoconf equivalent: ./configure
+       --enable-dsa). Again, you can find a list of these options and their
+       descriptions either using the CMake GUI or by looking at CMakeCache.txt.
+    5) The build directory should now contain the generated build files. Build
+       with `cmake --build .`. Under the hood, this runs the target build tool
+       (by default, make). You can also invoke the target build tool directly
+       (e.g. make).
 
-    To build library only and not build examples and test apps use:
-    $ cmake .. -DBUILD_TESTS=NO
+       To build with debugging use: `cmake .. -DCMAKE_BUILD_TYPE=Debug`.
 
-    To build with debugging use:
-    $ cmake .. -DCMAKE_BUILD_TYPE=Debug
+    Windows (Visual Studio)
+    ---
+    1) Go to this page, download the appropriate Windows installer, and install
+       to get the CMake GUI: https://cmake.org/download/ Native CMake support in
+       Visual Studio 16 2019 (and possibly older versions) has proven buggy. We
+       recommend using the CMake GUI in concert with Visual Studio, as described
+    in these steps.
+    2) Open CMake.
+    3) Where is the soure code: <root directory of wolfssl containing
+       CMakeLists.txt>
+    4) Where to build the binaries: <build directory, e.g. wolfssl/build>
+    5) Hit Configure. CMake runs the code in CMakeLists.txt and builds up an
+       internal representation of the project.
+    6) Hit Generate. CMake generates the build files. For Windows, this will
+       be Visual Studio project (.vcxproj) and solution (.sln) files.
+    7) Open Visual Studio and select "Open a project or solution".
+    8) Navigate to the build directory and select wolfssl.sln to load the
+       project.
 
-    Make sure and run the built examples and test from the wolfssl-root to properly find the ./certs directory.
-
-    CMake on Windows with Visual Studio
-    1. Open Command Prompt
-    2. Run the Visual Studio batch to setup command line variables: Example: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat
-    3. Then use steps above
+    Windows (command line)
+    ---
+    1) Open Command Prompt
+    2) Run the Visual Studio batch to setup command line variables, e.g. C:\Program Files (x86)\Microsoft Visual   
+       Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat
+    3) Follow steps in "Unix-based Platforms" above.

--- a/Makefile.am
+++ b/Makefile.am
@@ -152,6 +152,7 @@ EXTRA_DIST+= LPCExpresso.project
 EXTRA_DIST+= resource.h wolfssl.rc
 EXTRA_DIST+= CMakeLists.txt
 
+include cmake/include.am
 include wrapper/include.am
 include cyassl/include.am
 include wolfssl/include.am

--- a/cmake/config.in
+++ b/cmake/config.in
@@ -1,0 +1,54 @@
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#cmakedefine HAVE_ARPA_INET_H @HAVE_ARPA_INET_H@
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#cmakedefine HAVE_SYS_SOCKET_H @HAVE_SYS_SOCKET_H@
+
+/* Define to 1 if you have the <errno.h> header file. */
+#cmakedefine HAVE_ERRNO_H @HAVE_ERRNO_H@
+
+/* Define to 1 if you have the `getaddrinfo' function. */
+#cmakedefine HAVE_GETADDRINFO @HAVE_GETADDRINFO@
+
+/* Define to 1 if you have the `gmtime_r' function. */
+#cmakedefine HAVE_GMTIME_R @HAVE_GMTIME_R@
+
+/* Define to 1 if you have the <limits.h> header file. */
+#cmakedefine HAVE_LIMITS_H @HAVE_LIMITS_H@
+
+/* Define to 1 if you have the <pcap/pcap.h> header file. */
+#cmakedefine HAVE_PCAP_PCAP_H @HAVE_PCAP_PCAP_H@
+
+/* Define if you have POSIX threads libraries and header files. */
+#cmakedefine HAVE_PTHREAD @HAVE_PTHREAD@
+
+/* Define to 1 if you have the `strftime' function. */
+#cmakedefine HAVE_STRFTIME @HAVE_STRFTIME@
+
+/* Define to 1 if you have the <strings.h> header file. */
+#cmakedefine HAVE_STRINGS_H @HAVE_STRINGS_H@
+
+/* Define to 1 if you have the <string.h> header file. */
+#cmakedefine HAVE_STRING_H @HAVE_STRING_H@
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#cmakedefine HAVE_SYS_TIME_H @HAVE_SYS_TIME_H@
+
+/* Define to 1 if the system has the type `__uint128_t'. */
+#cmakedefine HAVE___UINT128_T @HAVE___UINT128_T@
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "@CMAKE_PROJECT_NAME@"
+
+/* The size of `long', as computed by sizeof. */
+#cmakedefine SIZEOF_LONG @SIZEOF_LONG@
+
+/* The size of `long long', as computed by sizeof. */
+#cmakedefine SIZEOF_LONG_LONG @SIZEOF_LONG_LONG@
+
+/* The size of `time_t', as computed by sizeof. */
+#cmakedefine SIZEOF_TIME_T @SIZEOF_TIME_T@
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#cmakedefine WORDS_BIGENDIAN

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -1,0 +1,843 @@
+function(override_cache VAR VAL)
+    get_property(VAR_TYPE CACHE ${VAR} PROPERTY TYPE)
+    set(${VAR} ${VAL} CACHE ${VAR_TYPE} ${${VAR}_HELP_STRING} FORCE)
+endfunction()
+
+function(generate_build_flags)
+    set(BUILD_DISTRO ${WOLFSSL_DISTRO} PARENT_SCOPE)
+    set(BUILD_ALL ${WOLFSSL_ALL} PARENT_SCOPE)
+    if(WOLFSSL_TLS13 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_TLS13 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_RNG OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_RNG "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_SCTP OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SCTP "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_MCAST ${WOLFSSL_MCAST} PARENT_SCOPE)
+    set(BUILD_IPV6 ${WOLFSSL_IPV6} PARENT_SCOPE)
+    set(BUILD_LEAN_PSK ${WOLFSSL_LEAN_PSK} PARENT_SCOPE)
+    set(BUILD_LEAN_TLS ${WOLFSSL_LEAN_TLS} PARENT_SCOPE)
+    set(BUILD_LOWMEM ${WOLFSSL_LOWRESOURCE} PARENT_SCOPE)
+    set(BUILD_PKCALLBACKS ${WOLFSSL_PKCALLBACKS} PARENT_SCOPE)
+    set(BUILD_CRYPTOAUTHLIB ${WOLFSSL_CRYPTOAUTHLIB} PARENT_SCOPE)
+    if(WOLFSSL_SNIFFER OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SNIFFER "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_SNIFFTEST ${WOLFSSL_SNIFFTEST} PARENT_SCOPE)
+    if(WOLFSSL_AESGCM OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_AESGCM "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_AESCCM OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_AESCCM "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_ARM_ASM ${WOLFSSL_ARM_ASM} PARENT_SCOPE)
+    set(BUILD_XILINX ${WOLFSSL_XILINX} PARENT_SCOPE)
+    set(BUILD_AESNI ${WOLFSSL_AESNI} PARENT_SCOPE)
+    set(BUILD_INTEL_ASM ${WOLFSSL_INTEL_ASM} PARENT_SCOPE)
+    set(BUILD_AFALG ${WOLFSSL_AFALG} PARENT_SCOPE)
+    set(BUILD_DEVCRYPTO ${WOLFSSL_DEVCRYPTO} PARENT_SCOPE)
+    if(WOLFSSL_CAMELLIA OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_CAMELLIA "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_MD2 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_MD2 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_RIPEMD OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_RIPEMD "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_BLAKE2 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_BLAKE2 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_BLAKE2S OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_BLAKE2S "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_SHA512 OR WOLFSSL_SHA384 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SHA512 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_DSA OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_DSA "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_ECC OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_ECC "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_ED25519 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_ED25519 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_ED25519_SMALL OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_ED25519_SMALL "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_FEMATH OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_FEMATH "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_GEMATH OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_GEMATH "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_CURVE25519 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_CURVE25519 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_CURVE25519_SMALL OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_CURVE25519_SMALL "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_ED448 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_ED448 "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_ED448_SMALL ${WOLFSSL_ED448_SMALL} PARENT_SCOPE)
+    if(WOLFSSL_FE448 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_FE448 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_GE448 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_GE448 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_CURVE448 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_CURVE448 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_CURVE448_SMALL OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_CURVE448_SMALL "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_MEMORY OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_MEMORY "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_RSA OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_RSA "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_DH OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_DH "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_ASN OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_ASN "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_AES OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_AES "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_CODING OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_CODING "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_IDEA OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_IDEA "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_ARC4 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_RC4 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_MD5 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_MD5 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_SHA OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SHA "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_HC128 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_HC128 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_RABBIT OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_RABBIT "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_FIPS ${WOLFSSL_FIPS} PARENT_SCOPE)
+    if("${FIPS_VERSION}" STREQUAL "v1")
+        set(BUILD_FIPS_V1 "yes" PARENT_SCOPE)
+    endif()
+    if("${FIPS_VERSION}" STREQUAL "v2")
+        set(BUILD_FIPS_V2 "yes" PARENT_SCOPE)
+    endif()
+    if("${FIPS_VERSION}" STREQUAL "rand")
+        set(BUILD_FIPS_RAND "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_FIPS_READY ${FIPS_READY} PARENT_SCOPE)
+    if(WOLFSSL_CMAC OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_CMAC "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_SELFTEST ${WOLFSSL_SELFTEST} PARENT_SCOPE)
+    if(WOLFSSL_SHA224 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SHA224 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_SHA3 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SHA3 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_POLY1305 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_POLY1305 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_CHACHA OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_CHACHA "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_XCHACHA OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_XCHACHA "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_INLINE ${WOLFSSL_INLINE} PARENT_SCOPE)
+    if(WOLFSSL_OCSP OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_OCSP "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_OCSP_STAPLING ${WOLFSSL_CERTIFICATE_STATUS_REQUEST} PARENT_SCOPE)
+    set(BUILD_OCSP_STAPLING_V2 ${WOLFSSL_CERTIFICATE_STATUS_REQUEST_V2} PARENT_SCOPE)
+    if(WOLFSSL_CRL OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_CRL "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_CRL_MONITOR)
+        set(BUILD_CRL_MONITOR "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_USER_RSA ${WOLFSSL_USER_RSA} PARENT_SCOPE)
+    set(BUILD_USER_CRYPTO ${WOLFSSL_USER_CRYPTO} PARENT_SCOPE)
+    set(BUILD_NTRU ${WOLFSSL_NTRU} PARENT_SCOPE)
+    set(BUILD_WNR ${WOLFSSL_WNR} PARENT_SCOPE)
+    if(WOLFSSL_SRP OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SRP "yes" PARENT_SCOPE)
+    endif()
+    set(USE_VALGRIND ${WOLFSSL_VALGRIND})
+    if(WOLFSSL_MD4 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_MD4 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_PWDBASED OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_PWDBASED "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_SCRYPT OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SCRYPT "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_CRYPT_ONLY AND NOT WOLFSSL_OPENSSL_EXTRA)
+        set(BUILD_CRYPTONLY "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_FAST_MATH OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_FAST_MATH "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_SLOW_MATH OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SLOW_MATH "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_EXAMPLES AND NOT WOLFSSL_LEAN_TLS)
+        set(BUILD_EXAMPLE_SERVERS "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_EXAMPLE_CLIENTS ${WOLFSSL_EXAMPLES} PARENT_SCOPE)
+    set(BUILD_TESTS ${WOLFSSL_EXAMPLES} PARENT_SCOPE)
+    if(NOT WOLFSSL_SINGLETHREADED AND WOLFSSL_EXAMPLES AND NOT WOLFSSL_LEAN_TLS)
+        set(BUILD_THREADED_EXAMPLES "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_WOLFCRYPT_TESTS ${WOLFSSL_CRYPT_TESTS} PARENT_SCOPE)
+    set(BUILD_LIBZ ${WOLFSSL_LIBZ} PARENT_SCOPE)
+    if(WOLFSSL_PKCS11 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_PKCS11 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_PKCS12 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_PKCS12 "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_CAVIUM ${WOLFSSL_CAVIUM} PARENT_SCOPE)
+    set(BUILD_CAVIUM_V ${WOLFSSL_CAVIUM_V} PARENT_SCOPE)
+    set(BUILD_OCTEON_SYNC ${WOLFSSL_OCTEON_SYNC} PARENT_SCOPE)
+    set(BUILD_INTEL_QA ${WOLFSSL_INTEL_QA} PARENT_SCOPE)
+    set(BUILD_INTEL_QA_SYNC ${WOLFSSL_INTEL_QA_SYNC} PARENT_SCOPE)
+    if(WOLFSSL_SP OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SP "yes" PARENT_SCOPE)
+    endif()
+    if((WOLFSSL_SP AND NOT WOLFSSL_SP_ASM) OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SP_C "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_SP_ARM64_ASM OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SP_ARM64 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_SP_ARM32_ASM OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SP_ARM32 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_SP_ARM_THUMB_ASM OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SP_ARM_THUMB "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_SP_ARM_CORTEX_ASM OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SP_ARM_CORTEX "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_SP_X86_64_ASM OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SP_X86_64 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_SP_MATH OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_SP_INT "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_FAST_RSA ${WOLFSSL_FAST_RSA} PARENT_SCOPE)
+    set(BUILD_MCAPI ${WOLFSSL_MCAPI} PARENT_SCOPE)
+    set(BUILD_ASYNCCRYPT ${WOLFSSL_ASYNCCRYPT} PARENT_SCOPE)
+    set(BUILD_WOLFEVENT ${WOLFSSL_ASYNCCRYPT} PARENT_SCOPE)
+    if(WOLFSSL_CRYPTOCB OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_CRYPTOCB "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_PSK ${WOLFSSL_PSK} PARENT_SCOPE)
+    set(BUILD_TRUST_PEER_CERT ${WOLFSSL_TRUSTED_PEER_CERT} PARENT_SCOPE)
+    set(BUILD_PKI ${WOLFSSL_PKI} PARENT_SCOPE)
+    if(WOLFSSL_DES3 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_DES3 "yes" PARENT_SCOPE)
+    endif()
+    if(WOLFSSL_PKCS7 OR WOLFSSL_USER_SETTINGS)
+        set(BUILD_PKCS7 "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_HASHFLAGS ${WOLFSSL_HASHFLAGS} PARENT_SCOPE)
+    set(BUILD_LINUX_KM ${WOLFSSL_LINUX_KM} PARENT_SCOPE)
+    set(BUILD_NO_LIBRARY ${WOLFSSL_NO_LIBRARY} PARENT_SCOPE)
+    if(WOLFSSL_DEBUG OR WOLFSSL_STACK_SIZE)
+        set(BUILD_DEBUG "yes" PARENT_SCOPE)
+    endif()
+    set(BUILD_RC2 ${WOLFSSL_RC2} PARENT_SCOPE)
+
+    set(BUILD_FLAGS_GENERATED "yes" PARENT_SCOPE)
+endfunction()
+
+function(generate_lib_src_list LIB_SOURCES)
+    if(NOT BUILD_FLAGS_GENERATED)
+        message(FATAL_ERROR "Cannot call generate_lib_src_list without calling generate_build_flags first.")
+    endif()
+
+    # Corresponds to src/include.am
+    if(BUILD_FIPS)
+         if(BUILD_FIPS_V1)
+              # fips first  file
+              list(APPEND LIB_SOURCES ctaocrypt/src/wolfcrypt_first.c)
+              
+              list(APPEND LIB_SOURCES
+                   ctaocrypt/src/hmac.c
+                   ctaocrypt/src/random.c 
+                   ctaocrypt/src/sha256.c)
+
+              if(BUILD_RSA)
+                   list(APPEND LIB_SOURCES ctaocrypt/src/rsa.c)
+              endif()
+
+              if(BUILD_AES)
+                   list(APPEND LIB_SOURCES ctaocrypt/src/aes.c)
+              endif()
+
+              if(BUILD_DES3)
+                   list(APPEND LIB_SOURCES ctaocrypt/src/des3.c)
+              endif()
+
+              if(BUILD_SHA)
+                   list(APPEND LIB_SOURCES ctaocrypt/src/sha.c)
+              endif()
+
+              if(BUILD_SHA512)
+                   list(APPEND LIB_SOURCES ctaocrypt/src/sha512.c)
+              endif()
+
+              list(APPEND LIB_SOURCES
+                ctaocrypt/src/fips.c
+                ctaocrypt/src/fips_test.c)
+
+              # fips last file
+              list(APPEND LIB_SOURCES ctaocrypt/src/wolfcrypt_last.c)
+         endif()
+
+         if(BUILD_FIPS_V2)
+              # FIPSv2 first file
+              list(APPEND LIB_SOURCES wolfcrypt/src/wolfcrypt_first.c)
+              
+              list(APPEND LIB_SOURCES
+                wolfcrypt/src/hmac.c 
+                wolfcrypt/src/random.c 
+                wolfcrypt/src/sha256.c)
+              
+              if(BUILD_RSA)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/rsa.c)
+              endif()
+
+              if(BUILD_ECC)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/ecc.c)
+              endif()
+
+              if(BUILD_AES)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/aes.c)
+
+                   if(BUILD_ARMASM AND BUILD_FIPS_READY)
+                        list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-aes.c)
+                   endif()
+              endif()
+
+              if(BUILD_AESNI)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/aes_asm.S)
+
+                   if(BUILD_INTELASM)
+                        list(APPEND LIB_SOURCES wolfcrypt/src/aes_gcm_asm.S)
+                   endif()
+              endif()
+
+              if(BUILD_DES3)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/des3.c)
+              endif()
+
+              if(BUILD_SHA)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/sha.c)
+              endif()
+
+              if(BUILD_ARMASM AND BUILD_FIPS_READY)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-sha256.c)
+              endif()
+
+              if(BUILD_INTELASM)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/sha256_asm.S)
+              endif()
+
+              if(BUILD_SHA512)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/sha512.c)
+
+                   if(BUILD_ARMASM AND BUILD_FIPS_READY)
+                        list(APPEND LIB_SOURCES
+                             wolfcrypt/src/port/arm/armv8-sha512.c
+                             wolfcrypt/src/port/arm/armv8-sha512-asm.S
+                             wolfcrypt/src/port/arm/armv8-32-sha512-asm.S)
+                   endif()
+
+                   if(BUILD_INTELASM)
+                        list(APPEND LIB_SOURCES wolfcrypt/src/sha512_asm.S)
+                   endif()
+              endif()
+
+              if(BUILD_SHA3)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/sha3.c)
+              endif()
+
+              if(BUILD_DH)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/dh.c)
+              endif()
+
+              if(BUILD_CMAC)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/cmac.c)
+              endif()
+
+              list(APPEND LIB_SOURCES
+                   wolfcrypt/src/fips.c
+                   wolfcrypt/src/fips_test.c)
+
+              # fips last file
+              list(APPEND LIB_SOURCES wolfcrypt/src/wolfcrypt_last.c)
+         endif()
+
+         if(BUILD_FIPS_RAND)
+              list(APPEND LIB_SOURCES
+                   wolfcrypt/src/wolfcrypt_first.c 
+                   wolfcrypt/src/hmac.c 
+                   wolfcrypt/src/random.c 
+                   wolfcrypt/src/sha256.c 
+                   wolfcrypt/src/sha256_asm.S 
+                   wolfcrypt/src/fips.c 
+                   wolfcrypt/src/fips_test.c 
+                   wolfcrypt/src/wolfcrypt_last.c)
+         endif()
+    endif() 
+
+    # For wolfRand, exclude everything else.
+    if(NOT BUILD_FIPS_RAND)
+         # For FIPSV2, exclude the wolfCrypt files included above.
+         # For wolfRand, exclude just a couple files.
+         # For old FIPS, keep the wolfCrypt versions of the
+         # CtaoCrypt files included above.
+         if(NOT BUILD_FIPS_V2)
+              list(APPEND LIB_SOURCES wolfcrypt/src/hmac.c)
+         endif()
+
+         # CAVP self test
+         if(BUILD_SELFTEST)
+              list(APPEND LIB_SOURCES wolfcrypt/src/selftest.c)
+         endif()
+    endif()
+
+    list(APPEND LIB_SOURCES
+         wolfcrypt/src/hash.c 
+         wolfcrypt/src/cpuid.c)
+
+    if(NOT BUILD_FIPS_RAND)
+         if(NOT BUILD_FIPS_V2 AND BUILD_RNG)
+              list(APPEND LIB_SOURCES wolfcrypt/src/random.c)
+         endif()
+
+         if(NOT BUILD_FIPS_V2)
+              if(BUILD_ARMASM)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-sha256.c)
+              else()
+                   list(APPEND LIB_SOURCES wolfcrypt/src/sha256.c)
+
+                   if(BUILD_INTELASM)
+                        list(APPEND LIB_SOURCES wolfcrypt/src/sha256_asm.S)
+                   endif()
+              endif()
+         endif()
+
+         if(BUILD_AFALG)
+              list(APPEND LIB_SOURCES wolfcrypt/src/port/af_alg/afalg_hash.c)
+         endif()
+
+         if(BUILD_WOLFEVENT)
+              list(APPEND LIB_SOURCES wolfcrypt/src/wolfevent.c)
+         endif()
+
+         if(BUILD_ASYNCCRYPT)
+              list(APPEND LIB_SOURCES wolfcrypt/src/async.c)
+         endif()
+
+         if(NOT BUILD_USER_RSA AND BUILD_RSA)
+              if(BUILD_FAST_RSA)
+                   list(APPEND LIB_SOURCES wolfcrypt/user-crypto/src/rsa.c)
+              else()
+                   if(NOT BUILD_FIPS_V2)
+                        list(APPEND LIB_SOURCES wolfcrypt/src/rsa.c)
+                   endif()
+              endif()
+         endif()
+
+         if(BUILD_SP)
+              if(BUILD_SP_C)
+                   list(APPEND LIB_SOURCES
+                        wolfcrypt/src/sp_c32.c
+                        wolfcrypt/src/sp_c64.c)
+              endif()
+
+              if(BUILD_SP_X86_64)
+                   list(APPEND LIB_SOURCES 
+                        wolfcrypt/src/sp_x86_64.c
+                        wolfcrypt/src/sp_x86_64_asm.S)
+              endif()
+
+              if(NOT BUILD_FIPS_V2 AND BUILD_SP_ARM32)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/sp_arm32.c)
+              endif()
+
+              if(BUILD_SP_ARM_THUMB)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/sp_armthumb.c)
+              endif()
+              
+              if(BUILD_SP_ARM64)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/sp_arm64.c)
+              endif()
+
+              if(BUILD_SP_INT)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/sp_int.c)
+              endif()
+              
+              if(BUILD_SP_ARM_CORTEX)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/sp_cortexm.c)
+              endif()
+         endif()
+
+         if(NOT BUILD_FIPS_V2)
+              if(BUILD_AES)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/aes.c)
+
+                   if(BUILD_ARMASM)
+                        list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-aes.c)
+                   endif()
+
+                   if(BUILD_AFALG)
+                        list(APPEND LIB_SOURCES wolfcrypt/src/port/af_alg/afalg_aes.c)
+                   endif()
+              endif()
+         endif()
+
+         if(NOT BUILD_FIPS_V2 AND BUILD_CMAC)
+              list(APPEND LIB_SOURCES wolfcrypt/src/cmac.c)
+         endif()
+
+         if(NOT BUILD_FIPS_V2 AND BUILD_DES3)
+              list(APPEND LIB_SOURCES wolfcrypt/src/des3.c)
+         endif()
+
+         if(NOT BUILD_FIPS_V2 AND BUILD_SHA)
+              list(APPEND LIB_SOURCES wolfcrypt/src/sha.c)
+         endif()
+
+         if(NOT BUILD_FIPS_V2 AND BUILD_SHA512)
+              if(BUILD_ARMASM)
+                   list(APPEND LIB_SOURCES
+                        wolfcrypt/src/port/arm/armv8-sha512.c
+                        wolfcrypt/src/port/arm/armv8-sha512-asm.S
+                        wolfcrypt/src/port/arm/armv8-32-sha512-asm.S)
+              else()
+                   list(APPEND LIB_SOURCES wolfcrypt/src/sha512.c)
+
+                   if(BUILD_INTELASM)
+                        list(APPEND LIB_SOURCES wolfcrypt/src/sha512_asm.S)
+                   endif()
+              endif()
+         endif()
+
+         if(NOT BUILD_FIPS_V2 AND BUILD_SHA3)
+              list(APPEND LIB_SOURCES wolfcrypt/src/sha3.c)
+         endif()
+    endif()
+
+    list(APPEND LIB_SOURCES
+         wolfcrypt/src/logging.c 
+         wolfcrypt/src/wc_port.c 
+         wolfcrypt/src/error.c)
+
+    if(BUILD_DEBUG)
+         list(APPEND LIB_SOURCES
+              wolfcrypt/src/debug.c)
+    endif()
+
+    if(NOT BUILD_FIPS_RAND)
+         list(APPEND LIB_SOURCES
+              wolfcrypt/src/wc_encrypt.c 
+              wolfcrypt/src/signature.c 
+              wolfcrypt/src/wolfmath.c)
+    endif()
+
+    if(BUILD_MEMORY)
+         list(APPEND LIB_SOURCES wolfcrypt/src/memory.c)
+    endif()
+
+    if(NOT BUILD_FIPS_RAND)
+         if(NOT BUILD_FIPS_V2 AND BUILD_DH)
+              list(APPEND LIB_SOURCES wolfcrypt/src/dh.c)
+         endif()
+
+         if(BUILD_ASN)
+              list(APPEND LIB_SOURCES wolfcrypt/src/asn.c)
+         endif()
+    endif()
+
+    if(BUILD_CODING)
+         list(APPEND LIB_SOURCES wolfcrypt/src/coding.c)
+    endif()
+
+    if(NOT BUILD_FIPS_RAND)
+         if(BUILD_POLY1305)
+              if(BUILD_ARMASM)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-poly1305.c)
+              endif()
+
+              list(APPEND LIB_SOURCES wolfcrypt/src/poly1305.c)
+
+              if(BUILD_INTELASM)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/poly1305_asm.S)
+              endif()
+         endif()
+
+         if(BUILD_RC4)
+              list(APPEND LIB_SOURCES wolfcrypt/src/arc4.c)
+         endif()
+
+         if(BUILD_MD4)
+              list(APPEND LIB_SOURCES wolfcrypt/src/md4.c)
+         endif()
+
+         if(BUILD_MD5)
+              list(APPEND LIB_SOURCES wolfcrypt/src/md5.c)
+         endif()
+
+         if(BUILD_PWDBASED)
+              list(APPEND LIB_SOURCES
+                   wolfcrypt/src/pwdbased.c
+                   wolfcrypt/src/pkcs12.c)
+         endif()
+
+         if(BUILD_DSA)
+              list(APPEND LIB_SOURCES wolfcrypt/src/dsa.c)
+         endif()
+
+         if(NOT BUILD_FIPS_V2 AND BUILD_AESNI)
+              list(APPEND LIB_SOURCES
+                   wolfcrypt/src/aes_asm.S
+                   wolfcrypt/src/aes_gcm_asm.S)
+         endif()
+         
+         if(BUILD_CAMELLIA)
+              list(APPEND LIB_SOURCES wolfcrypt/src/camellia.c)
+         endif()
+
+         if(BUILD_MD2)
+              list(APPEND LIB_SOURCES wolfcrypt/src/md2.c)
+         endif()
+
+         if(BUILD_RIPEMD)
+              list(APPEND LIB_SOURCES wolfcrypt/src/ripemd.c)
+         endif()
+
+         if(BUILD_BLAKE2)
+              list(APPEND LIB_SOURCES wolfcrypt/src/blake2b.c)
+         endif()
+         
+         if(BUILD_BLAKE2S)
+              list(APPEND LIB_SOURCES wolfcrypt/src/blake2s.c)
+         endif()
+
+         if(BUILD_HC128)
+              list(APPEND LIB_SOURCES wolfcrypt/src/hc128.c)
+         endif()
+
+         if(BUILD_RABBIT)
+              list(APPEND LIB_SOURCES wolfcrypt/src/rabbit.c)
+         endif()
+
+         if(BUILD_CHACHA)
+              if(BUILD_ARMASM)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-chacha.c)
+              else()
+                   list(APPEND LIB_SOURCES wolfcrypt/src/chacha.c)
+
+                   if(BUILD_INTELASM)
+                        list(APPEND LIB_SOURCES wolfcrypt/src/chacha_asm.S)
+                   endif()
+              endif()
+
+              if(BUILD_POLY1305)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/chacha20_poly1305.c)
+              endif()
+         endif()
+
+         if(NOT BUILD_INLINE)
+              list(APPEND LIB_SOURCES wolfcrypt/src/misc.c)
+         endif()
+
+         if(BUILD_FAST_MATH)
+              list(APPEND LIB_SOURCES wolfcrypt/src/tfm.c)
+         endif()
+
+         if(BUILD_SLOW_MATH)
+              list(APPEND LIB_SOURCES wolfcrypt/src/integer.c)
+         endif()
+
+         if(NOT BUILD_FIPS_V2 AND BUILD_ECC)
+              list(APPEND LIB_SOURCES wolfcrypt/src/ecc.c)
+         endif()
+
+         if(BUILD_CURVE25519)
+              list(APPEND LIB_SOURCES wolfcrypt/src/curve25519.c)
+         endif()
+
+         if(BUILD_ED25519)
+              list(APPEND LIB_SOURCES wolfcrypt/src/ed25519.c)
+         endif()
+
+         if(BUILD_FEMATH)
+              if(BUILD_CURVE25519_SMALL)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/fe_low_mem.c)
+              else()
+                   if(BUILD_INTELASM)
+                        list(APPEND LIB_SOURCES wolfcrypt/src/fe_x25519_asm.S)
+                   else()
+                        if(BUILD_ARMASM)
+                             list(APPEND LIB_SOURCES
+                                  wolfcrypt/src/port/arm/armv8-32-curve25519.S
+                                  wolfcrypt/src/port/arm/armv8-curve25519.S)
+                        else()
+                             list(APPEND LIB_SOURCES wolfcrypt/src/fe_operations.c)
+                        endif()
+                   endif()
+              endif()
+         endif()
+
+         if(BUILD_GEMATH)
+              if(BUILD_ED25519_SMALL)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/ge_low_mem.c)
+              else()
+                   list(APPEND LIB_SOURCES wolfcrypt/src/ge_operations.c)
+
+                   if(NOT BUILD_FEMATH)
+                        if(BUILD_INTELASM)
+                             list(APPEND LIB_SOURCES wolfcrypt/src/fe_x25519_asm.S)
+                        else()
+                             if(BUILD_ARMASM)
+                                  list(APPEND LIB_SOURCES wolfcrypt/src/port/arm/armv8-curve25519.S)
+                             else()
+                                  list(APPEND LIB_SOURCES wolfcrypt/src/fe_operations.c)
+                             endif()
+                        endif()
+                   endif()
+              endif()
+         endif()
+
+         if(BUILD_CURVE448)
+              list(APPEND LIB_SOURCES wolfcrypt/src/curve448.c)
+         endif()
+
+         if(BUILD_ED448)
+              list(APPEND LIB_SOURCES wolfcrypt/src/ed448.c)
+         endif()
+
+         if(BUILD_FE448)
+              list(APPEND LIB_SOURCES wolfcrypt/src/fe_448.c)
+         endif()
+
+         if(BUILD_GE448)
+              list(APPEND LIB_SOURCES wolfcrypt/src/ge_448.c)
+
+              if(NOT BUILD_FE448)
+                   list(APPEND LIB_SOURCES wolfcrypt/src/fe_448.c)
+              endif()
+         endif()
+
+         if(BUILD_LIBZ)
+              list(APPEND LIB_SOURCES wolfcrypt/src/compress.c)
+         endif()
+
+         if(BUILD_PKCS7)
+              list(APPEND LIB_SOURCES wolfcrypt/src/pkcs7.c)
+         endif()
+
+         if(BUILD_SRP)
+              list(APPEND LIB_SOURCES wolfcrypt/src/srp.c)
+         endif()
+
+         if(BUILD_IDEA)
+              list(APPEND LIB_SOURCES wolfcrypt/src/idea.c)
+         endif()
+
+         if(BUILD_AFALG)
+              list(APPEND LIB_SOURCES wolfcrypt/src/port/af_alg/wc_afalg.c)
+         endif()
+
+         if(NOT BUILD_CRYPTONLY)
+              # ssl files
+              list(APPEND LIB_SOURCES
+                   src/internal.c 
+                   src/wolfio.c 
+                   src/keys.c 
+                   src/ssl.c 
+                   src/tls.c)
+
+              if(BUILD_TLS13)
+                   list(APPEND LIB_SOURCES src/tls13.c)
+              endif()
+
+              if(BUILD_OCSP)
+                   list(APPEND LIB_SOURCES src/ocsp.c)
+              endif()
+
+              if(BUILD_CRL)
+                   list(APPEND LIB_SOURCES src/crl.c)
+              endif()
+
+              if(BUILD_SNIFFER)
+                   list(APPEND LIB_SOURCES src/sniffer.c)
+              endif()
+         endif()
+    endif()
+
+    # Corresponds to wolfcrypt/src/include.am
+    if(BUILD_CRYPTOCB)
+           list(APPEND LIB_SOURCES wolfcrypt/src/cryptocb.c)
+    endif()
+
+    if(BUILD_PKCS11)
+           list(APPEND LIB_SOURCES wolfcrypt/src/wc_pkcs11.c)
+    endif()
+
+    if(BUILD_DEVCRYPTO)
+        list(APPEND LIB_SOURCES
+            wolfcrypt/src/port/devcrypto/devcrypto_hash.c
+            wolfcrypt/src/port/devcrypto/devcrypto_aes.c
+            wolfcrypt/src/port/devcrypto/wc_devcrypto.c)
+    endif()
+
+    if(BUILD_CAVIUM)
+        list(APPEND LIB_SOURCES wolfcrypt/src/port/cavium/cavium_nitrox.c)
+    endif()
+
+    if(BUILD_OCTEON_SYNC)
+        list(APPEND LIB_SOURCES wolfcrypt/src/port/cavium/cavium_octeon_sync.c)
+    endif()
+
+    if(BUILD_INTEL_QA)
+        list(APPEND LIB_SOURCES
+            wolfcrypt/src/port/intel/quickassist.c
+            wolfcrypt/src/port/intel/quickassist_mem.c)
+    endif()
+
+    if(BUILD_INTEL_QA_SYNC)
+        list(APPEND LIB_SOURCES wolfcrypt/src/port/intel/quickassist_sync.c)
+    endif()
+
+    if(BUILD_CRYPTOAUTHLIB)
+        list(APPEND LIB_SOURCES wolfcrypt/src/port/atmel/atmel.c)
+    endif()
+
+    set(LIB_SOURCES ${LIB_SOURCES} PARENT_SCOPE)
+endfunction()

--- a/cmake/include.am
+++ b/cmake/include.am
@@ -1,0 +1,2 @@
+EXTRA_DIST += cmake/config.in
+EXTRA_DIST += cmake/functions.cmake


### PR DESCRIPTION
- Begin adding options to enable/disable different features.
- Increase minimum CMake version to 3.2.
- Support installation of the built files.
- Add checks for necessary include files, functions etc.
- Generate options.h and config.h.
