### PR TITLE
Nightly Test Fix 2

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -9399,6 +9399,7 @@ void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509, int nid, int* c,
                 obj = wolfSSL_ASN1_OBJECT_new();
                 if (obj == NULL) {
                     WOLFSSL_MSG("Issue creating WOLFSSL_ASN1_OBJECT struct");
+                    wolfSSL_AUTHORITY_KEYID_free(akey);
                     return NULL;
                 }
                 obj->type  = AUTH_KEY_OID;


### PR DESCRIPTION
When making a AUTHORITY KEY object, if the ASN1 OBJECT fails, the key object is leaked. Release it before returning NULL.