### PR TITLE
Fix MSVC compile issue in chacha.c.

### DIFF
--- a/wolfcrypt/src/chacha.c
+++ b/wolfcrypt/src/chacha.c
@@ -442,7 +442,7 @@ int wc_Chacha_Process(ChaCha* ctx, byte* output, const byte* input,
 
 void wc_Chacha_purge_current_block(ChaCha* ctx) {
     if (ctx->left > 0) {
-        byte scratch[CHACHA_CHUNK_BYTES] = {};
+        byte scratch[CHACHA_CHUNK_BYTES] = {0};
         (void)wc_Chacha_Process(ctx, scratch, scratch, CHACHA_CHUNK_BYTES - ctx->left);
     }
 }

--- a/wolfcrypt/src/chacha.c
+++ b/wolfcrypt/src/chacha.c
@@ -442,7 +442,8 @@ int wc_Chacha_Process(ChaCha* ctx, byte* output, const byte* input,
 
 void wc_Chacha_purge_current_block(ChaCha* ctx) {
     if (ctx->left > 0) {
-        byte scratch[CHACHA_CHUNK_BYTES] = {0};
+        byte scratch[CHACHA_CHUNK_BYTES];
+        XMEMSET(scratch, 0, sizeof(scratch));
         (void)wc_Chacha_Process(ctx, scratch, scratch, CHACHA_CHUNK_BYTES - ctx->left);
     }
 }


### PR DESCRIPTION
MSVC generates a syntax error when you initialize
an array with {}. {0} has the same effect and compiles.