### PR TITLE
add "CCM8" variants to cipher_names "CCM-8" ciphers, for OpenSSL compat

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2449,6 +2449,50 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             err_sys_ex(runWithErrors, "SSL in error state");
         }
 
+        /* if the caller requested a particular cipher, check here that either
+         * a canonical name of the established cipher matches the requested
+         * cipher name, or the requested cipher name is marked as an alias
+         * that matches the established cipher.
+         */
+        if (cipherList && (! XSTRSTR(cipherList, ":"))) {
+            WOLFSSL_CIPHER* established_cipher = wolfSSL_get_current_cipher(ssl);
+            byte requested_cipherSuite0, requested_cipherSuite;
+            int requested_cipherFlags;
+            if (established_cipher &&
+                /* don't test for pseudo-ciphers like "ALL" and "DEFAULT". */
+                (wolfSSL_get_cipher_suite_from_name(cipherList,
+                                                    &requested_cipherSuite0,
+                                                    &requested_cipherSuite,
+                                                    &requested_cipherFlags) == 0)) {
+                word32 established_cipher_id = wolfSSL_CIPHER_get_id(established_cipher);
+                byte established_cipherSuite0 = (established_cipher_id >> 8) & 0xff;
+                byte established_cipherSuite = established_cipher_id & 0xff;
+                const char *established_cipher_name =
+                    wolfSSL_get_cipher_name_from_suite(established_cipherSuite0,
+                                                       established_cipherSuite);
+                const char *established_cipher_name_iana =
+                    wolfSSL_get_cipher_name_iana_from_suite(established_cipherSuite0,
+                                                            established_cipherSuite);
+
+                if (established_cipher_name == NULL)
+                    err_sys_ex(catastrophic, "error looking up name of established cipher");
+
+                if (strcmp(cipherList, established_cipher_name) &&
+                    ((established_cipher_name_iana == NULL) ||
+                     strcmp(cipherList, established_cipher_name_iana))) {
+                    if (! (requested_cipherFlags & WOLFSSL_CIPHER_SUITE_FLAG_NAMEALIAS))
+                        err_sys_ex(
+                            catastrophic,
+                            "Unexpected mismatch between names of requested and established ciphers.");
+                    else if ((requested_cipherSuite0 != established_cipherSuite0) ||
+                             (requested_cipherSuite != established_cipherSuite))
+                        err_sys_ex(
+                            catastrophic,
+                            "Mismatch between IDs of requested and established ciphers.");
+                }
+            }
+        }
+
 #ifdef OPENSSL_EXTRA
     {
         byte*  rnd;

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -833,7 +833,7 @@ do
             cmpSuite="TLS_AES_128_CCM_SHA256"
             tls13_suite="yes"
             ;;
-        "TLS13-AES128-CCM-8-SHA256")
+        "TLS13-AES128-CCM-8-SHA256"|"TLS13-AES128-CCM8-SHA256")
             cmpSuite="TLS_AES_128_CCM_8_SHA256"
             tls13_suite="yes"
             ;;

--- a/src/internal.c
+++ b/src/internal.c
@@ -18614,19 +18614,49 @@ void SetErrorString(int error, char* str)
     str[WOLFSSL_MAX_ERROR_SZ-1] = 0;
 }
 
-#ifndef NO_ERROR_STRINGS
-    #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
-        #define SUITE_INFO(x,y,z,w,v,u) {(x),(y),(z),(w),(v),(u)}
+#ifdef NO_CIPHER_SUITE_ALIASES
+    #ifndef NO_ERROR_STRINGS
+        #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+            #define SUITE_INFO(x,y,z,w,v,u) {(x),(y),(z),(w),(v),(u),WOLFSSL_CIPHER_SUITE_FLAG_NONE}
+            #define SUITE_ALIAS(x,z,w,v,u)
+        #else
+            #define SUITE_INFO(x,y,z,w,v,u) {(x),(y),(z),(w),WOLFSSL_CIPHER_SUITE_FLAG_NONE}
+            #define SUITE_ALIAS(x,z,w,v,u)
+        #endif
     #else
-        #define SUITE_INFO(x,y,z,w,v,u) {(x),(y),(z),(w)}
+        #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+            #define SUITE_INFO(x,y,z,w,v,u) {(x),(z),(w),(v),(u),WOLFSSL_CIPHER_SUITE_FLAG_NONE}
+            #define SUITE_ALIAS(x,z,w,v,u)
+        #else
+            #define SUITE_INFO(x,y,z,w,v,u) {(x),(z),(w),WOLFSSL_CIPHER_SUITE_FLAG_NONE}
+            #define SUITE_ALIAS(x,z,w,v,u)
+        #endif
     #endif
-#else
-    #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
-        #define SUITE_INFO(x,y,z,w,v,u) {(x),(z),(w),(v),(u)}
+#else /* !NO_CIPHER_SUITE_ALIASES */
+
+    /* note that the comma is included at the end of the SUITE_ALIAS() macro
+     * definitions, to allow aliases to be gated out by the above null macros
+     * in the NO_CIPHER_SUITE_ALIASES section.
+     */
+
+    #ifndef NO_ERROR_STRINGS
+        #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+            #define SUITE_INFO(x,y,z,w,v,u) {(x),(y),(z),(w),(v),(u),WOLFSSL_CIPHER_SUITE_FLAG_NONE}
+            #define SUITE_ALIAS(x,z,w,v,u) {(x),"",(z),(w),(v),(u),WOLFSSL_CIPHER_SUITE_FLAG_NAMEALIAS},
+        #else
+            #define SUITE_INFO(x,y,z,w,v,u) {(x),(y),(z),(w),WOLFSSL_CIPHER_SUITE_FLAG_NONE}
+            #define SUITE_ALIAS(x,z,w,v,u) {(x),"",(z),(w),WOLFSSL_CIPHER_SUITE_FLAG_NAMEALIAS},
+        #endif
     #else
-        #define SUITE_INFO(x,y,z,w,v,u) {(x),(z),(w)}
+        #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+            #define SUITE_INFO(x,y,z,w,v,u) {(x),(z),(w),(v),(u),WOLFSSL_CIPHER_SUITE_FLAG_NONE}
+            #define SUITE_ALIAS(x,z,w,v,u) {(x),(z),(w),(v),(u),WOLFSSL_CIPHER_SUITE_FLAG_NAMEALIAS},
+        #else
+            #define SUITE_INFO(x,y,z,w,v,u) {(x),(z),(w),WOLFSSL_CIPHER_SUITE_FLAG_NONE}
+            #define SUITE_ALIAS(x,z,w,v,u) {(x),(z),(w),WOLFSSL_CIPHER_SUITE_FLAG_NAMEALIAS},
+        #endif
     #endif
-#endif
+#endif /* NO_CIPHER_SUITE_ALIASES */
 
 static const CipherSuiteInfo cipher_names[] =
 {
@@ -18649,6 +18679,7 @@ static const CipherSuiteInfo cipher_names[] =
 
 #ifdef BUILD_TLS_AES_128_CCM_8_SHA256
     SUITE_INFO("TLS13-AES128-CCM-8-SHA256","TLS_AES_128_CCM_8_SHA256",TLS13_BYTE,TLS_AES_128_CCM_8_SHA256,TLSv1_3_MINOR, SSLv3_MAJOR),
+    SUITE_ALIAS("TLS13-AES128-CCM8-SHA256",TLS13_BYTE,TLS_AES_128_CCM_8_SHA256,TLSv1_3_MINOR, SSLv3_MAJOR)
 #endif
 
 #ifdef BUILD_TLS_SHA256_SHA256
@@ -18759,10 +18790,12 @@ static const CipherSuiteInfo cipher_names[] =
 
 #ifdef BUILD_TLS_PSK_WITH_AES_128_CCM_8
     SUITE_INFO("PSK-AES128-CCM-8","TLS_PSK_WITH_AES_128_CCM_8",ECC_BYTE,TLS_PSK_WITH_AES_128_CCM_8,TLSv1_MINOR,SSLv3_MAJOR),
+    SUITE_ALIAS("PSK-AES128-CCM8",ECC_BYTE,TLS_PSK_WITH_AES_128_CCM_8,TLSv1_MINOR,SSLv3_MAJOR)
 #endif
 
 #ifdef BUILD_TLS_PSK_WITH_AES_256_CCM_8
     SUITE_INFO("PSK-AES256-CCM-8","TLS_PSK_WITH_AES_256_CCM_8",ECC_BYTE,TLS_PSK_WITH_AES_256_CCM_8,TLSv1_MINOR,SSLv3_MAJOR),
+    SUITE_ALIAS("PSK-AES256-CCM8",ECC_BYTE,TLS_PSK_WITH_AES_256_CCM_8,TLSv1_MINOR,SSLv3_MAJOR)
 #endif
 
 #ifdef BUILD_TLS_DHE_PSK_WITH_NULL_SHA384
@@ -18815,10 +18848,12 @@ static const CipherSuiteInfo cipher_names[] =
 
 #ifdef BUILD_TLS_RSA_WITH_AES_128_CCM_8
     SUITE_INFO("AES128-CCM-8","TLS_RSA_WITH_AES_128_CCM_8",ECC_BYTE,TLS_RSA_WITH_AES_128_CCM_8, TLSv1_2_MINOR, SSLv3_MAJOR),
+    SUITE_ALIAS("AES128-CCM8",ECC_BYTE,TLS_RSA_WITH_AES_128_CCM_8, TLSv1_2_MINOR, SSLv3_MAJOR)
 #endif
 
 #ifdef BUILD_TLS_RSA_WITH_AES_256_CCM_8
     SUITE_INFO("AES256-CCM-8","TLS_RSA_WITH_AES_256_CCM_8",ECC_BYTE,TLS_RSA_WITH_AES_256_CCM_8, TLSv1_2_MINOR, SSLv3_MAJOR),
+    SUITE_ALIAS("AES256-CCM8",ECC_BYTE,TLS_RSA_WITH_AES_256_CCM_8, TLSv1_2_MINOR, SSLv3_MAJOR)
 #endif
 
 #ifdef BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM
@@ -18827,10 +18862,12 @@ static const CipherSuiteInfo cipher_names[] =
 
 #ifdef BUILD_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
     SUITE_INFO("ECDHE-ECDSA-AES128-CCM-8","TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8",ECC_BYTE,TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8, TLSv1_2_MINOR, SSLv3_MAJOR),
+    SUITE_ALIAS("ECDHE-ECDSA-AES128-CCM8",ECC_BYTE,TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8, TLSv1_2_MINOR, SSLv3_MAJOR)
 #endif
 
 #ifdef BUILD_TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8
     SUITE_INFO("ECDHE-ECDSA-AES256-CCM-8","TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8",ECC_BYTE,TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8, TLSv1_2_MINOR, SSLv3_MAJOR),
+    SUITE_ALIAS("ECDHE-ECDSA-AES256-CCM8",ECC_BYTE,TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8, TLSv1_2_MINOR, SSLv3_MAJOR)
 #endif
 
 #ifdef BUILD_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
@@ -19126,7 +19163,11 @@ const char* GetCipherNameInternal(const byte cipherSuite0, const byte cipherSuit
 
     for (i = 0; i < GetCipherNamesSize(); i++) {
         if ((cipher_names[i].cipherSuite0 == cipherSuite0) &&
-            (cipher_names[i].cipherSuite  == cipherSuite)) {
+            (cipher_names[i].cipherSuite  == cipherSuite)
+#ifndef NO_CIPHER_SUITE_ALIASES
+            && (! (cipher_names[i].flags & WOLFSSL_CIPHER_SUITE_FLAG_NAMEALIAS))
+#endif
+            ) {
             nameInternal = cipher_names[i].name;
             break;
         }
@@ -19349,7 +19390,11 @@ const char* GetCipherNameIana(const byte cipherSuite0, const byte cipherSuite)
 
     for (i = 0; i < GetCipherNamesSize(); i++) {
         if ((cipher_names[i].cipherSuite0 == cipherSuite0) &&
-            (cipher_names[i].cipherSuite  == cipherSuite)) {
+            (cipher_names[i].cipherSuite  == cipherSuite)
+#ifndef NO_CIPHER_SUITE_ALIASES
+            && (! (cipher_names[i].flags & WOLFSSL_CIPHER_SUITE_FLAG_NAMEALIAS))
+#endif
+            ) {
             nameIana = cipher_names[i].name_iana;
             break;
         }
@@ -19381,7 +19426,7 @@ const char* wolfSSL_get_cipher_name_iana(WOLFSSL* ssl)
 }
 
 int GetCipherSuiteFromName(const char* name, byte* cipherSuite0,
-                           byte* cipherSuite)
+                           byte* cipherSuite, int* flags)
 {
     int           ret = BAD_FUNC_ARG;
     int           i;
@@ -19396,9 +19441,11 @@ int GetCipherSuiteFromName(const char* name, byte* cipherSuite0,
         len = (unsigned long)XSTRLEN(name);
 
     for (i = 0; i < GetCipherNamesSize(); i++) {
-        if (XSTRNCMP(name, cipher_names[i].name, len) == 0) {
+        if ((XSTRNCMP(name, cipher_names[i].name, len) == 0) &&
+            (cipher_names[i].name[len] == 0)) {
             *cipherSuite0 = cipher_names[i].cipherSuite0;
             *cipherSuite  = cipher_names[i].cipherSuite;
+            *flags = cipher_names[i].flags;
             ret = 0;
             break;
         }
@@ -19731,7 +19778,11 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
         int i;
         int sz = GetCipherNamesSize();
 
-        for (i = 0; i < sz; i++)
+        for (i = 0; i < sz; i++) {
+#ifndef NO_CIPHER_SUITE_ALIASES
+            if (cipher_names[i].flags & WOLFSSL_CIPHER_SUITE_FLAG_NAMEALIAS)
+                continue;
+#endif
             if (info->ssl->options.cipherSuite ==
                                             (byte)cipher_names[i].cipherSuite) {
                 if (info->ssl->options.cipherSuite0 == ECC_BYTE)
@@ -19740,6 +19791,7 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
                 info->cipherName[MAX_CIPHERNAME_SZ] = '\0';
                 break;
             }
+        }
 
         /* error max and min are negative numbers */
         if (info->ssl->error <= MIN_PARAM_ERR && info->ssl->error >= MAX_PARAM_ERR)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -904,6 +904,10 @@ int wolfSSL_get_ciphers_iana(char* buf, int len)
 
     /* Add each member to the buffer delimited by a : */
     for (i = 0; i < ciphersSz; i++) {
+#ifndef NO_CIPHER_SUITE_ALIASES
+        if (ciphers[i].flags & WOLFSSL_CIPHER_SUITE_FLAG_NAMEALIAS)
+            continue;
+#endif
         cipherNameSz = (int)XSTRLEN(ciphers[i].name_iana);
         if (cipherNameSz + 1 < len) {
             XSTRNCPY(buf, ciphers[i].name_iana, len);
@@ -20056,6 +20060,16 @@ const char* wolfSSL_get_cipher_name_iana_from_suite(const byte cipherSuite0,
         const byte cipherSuite)
 {
     return GetCipherNameIana(cipherSuite0, cipherSuite);
+}
+
+int wolfSSL_get_cipher_suite_from_name(const char* name, byte* cipherSuite0,
+                                       byte* cipherSuite, int *flags) {
+    if ((name == NULL) ||
+        (cipherSuite0 == NULL) ||
+        (cipherSuite == NULL) ||
+        (flags == NULL))
+        return BAD_FUNC_ARG;
+    return GetCipherSuiteFromName(name, cipherSuite0, cipherSuite, flags);
 }
 
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -10250,6 +10250,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                 /* Default ciphersuite. */
                 byte cipherSuite0 = TLS13_BYTE;
                 byte cipherSuite = WOLFSSL_DEF_PSK_CIPHER;
+                int cipherSuiteFlags = WOLFSSL_CIPHER_SUITE_FLAG_NONE;
                 const char* cipherName = NULL;
 
                 if (ssl->options.client_psk_tls13_cb != NULL) {
@@ -10258,7 +10259,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                         ssl->arrays->client_identity, MAX_PSK_ID_LEN,
                         ssl->arrays->psk_key, MAX_PSK_KEY_LEN, &cipherName);
                     if (GetCipherSuiteFromName(cipherName, &cipherSuite0,
-                                                           &cipherSuite) != 0) {
+                                               &cipherSuite, &cipherSuiteFlags) != 0) {
                         return PSK_KEY_ERROR;
                     }
                 }
@@ -10275,6 +10276,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                 /* TODO: Callback should be able to change ciphersuite. */
                 ssl->options.cipherSuite0 = cipherSuite0;
                 ssl->options.cipherSuite  = cipherSuite;
+                (void)cipherSuiteFlags;
                 ret = SetCipherSpecs(ssl);
                 if (ret != 0)
                     return ret;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -2492,6 +2492,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk)
     #ifndef WOLFSSL_PSK_ONE_ID
         const char* cipherName = NULL;
         byte cipherSuite0 = TLS13_BYTE, cipherSuite = WOLFSSL_DEF_PSK_CIPHER;
+        int cipherSuiteFlags = WOLFSSL_CIPHER_SUITE_FLAG_NONE;
 
         /* Get the pre-shared key. */
         if (ssl->options.client_psk_tls13_cb != NULL) {
@@ -2500,7 +2501,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk)
                     MAX_PSK_ID_LEN, ssl->arrays->psk_key, MAX_PSK_KEY_LEN,
                     &cipherName);
             if (GetCipherSuiteFromName(cipherName, &cipherSuite0,
-                                                           &cipherSuite) != 0) {
+                                       &cipherSuite, &cipherSuiteFlags) != 0) {
                 return PSK_KEY_ERROR;
             }
         }
@@ -2518,6 +2519,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk)
                                               psk->cipherSuite != cipherSuite) {
             return PSK_KEY_ERROR;
         }
+        (void)cipherSuiteFlags;
     #else
         /* PSK information loaded during setting of default TLS extensions. */
     #endif
@@ -3306,6 +3308,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
     const char*   cipherName = NULL;
     byte          cipherSuite0 = TLS13_BYTE;
     byte          cipherSuite  = WOLFSSL_DEF_PSK_CIPHER;
+    int           cipherSuiteFlags = WOLFSSL_CIPHER_SUITE_FLAG_NONE;
 #endif
 
     WOLFSSL_ENTER("DoPreSharedKeys");
@@ -3420,7 +3423,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
                              ssl->arrays->client_identity, ssl->arrays->psk_key,
                              MAX_PSK_KEY_LEN, &cipherName)) != 0 &&
              GetCipherSuiteFromName(cipherName, &cipherSuite0,
-                                                          &cipherSuite) == 0) ||
+                                    &cipherSuite, &cipherSuiteFlags) == 0) ||
             (ssl->options.server_psk_cb != NULL &&
              (ssl->arrays->psk_keySz = ssl->options.server_psk_cb(ssl,
                              ssl->arrays->client_identity, ssl->arrays->psk_key,
@@ -3431,6 +3434,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
             /* Check whether PSK ciphersuite is in SSL. */
             suite[0] = cipherSuite0;
             suite[1] = cipherSuite;
+            (void)cipherSuiteFlags;
             if (!FindSuiteSSL(ssl, suite)) {
                 current = current->next;
                 continue;

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -1156,6 +1156,10 @@ int SuiteTest(int argc, char** argv)
     }
 
 exit:
+
+    if (args.return_code == 0)
+        printf("\n Success -- All results as expected.\n");
+
     printf(" End Cipher Suite Tests\n");
 
     wolfSSL_CTX_free(cipherSuiteCtx);

--- a/tests/test-dtls-group.conf
+++ b/tests/test-dtls-group.conf
@@ -1016,6 +1016,36 @@
 -l ECDHE-ECDSA-AES256-CCM-8
 -A ./certs/ca-ecc-cert.pem
 
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-u
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-A ./certs/ca-ecc-cert.pem
+
 # server DTLSv1.2 ADH-AES128-SHA
 -u
 -f

--- a/tests/test-dtls-reneg-client.conf
+++ b/tests/test-dtls-reneg-client.conf
@@ -1097,6 +1097,37 @@
 -l ECDHE-ECDSA-AES256-CCM-8
 -A ./certs/ca-ecc-cert.pem
 
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-M
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-i
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+
 # server DTLSv1.2 ADH-AES128-SHA
 -M
 -u

--- a/tests/test-dtls-reneg-server.conf
+++ b/tests/test-dtls-reneg-server.conf
@@ -1016,6 +1016,36 @@
 -l ECDHE-ECDSA-AES256-CCM-8
 -A ./certs/ca-ecc-cert.pem
 
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-m
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-R
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-A ./certs/ca-ecc-cert.pem
+
 # server DTLSv1.2 ADH-AES128-SHA
 -m
 -u

--- a/tests/test-dtls-resume.conf
+++ b/tests/test-dtls-resume.conf
@@ -1016,6 +1016,36 @@
 -l ECDHE-ECDSA-AES256-CCM-8
 -A ./certs/ca-ecc-cert.pem
 
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-u
+-r
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-A ./certs/ca-ecc-cert.pem
+
 # server DTLSv1.2 ADH-AES128-SHA
 -u
 -r

--- a/tests/test-dtls.conf
+++ b/tests/test-dtls.conf
@@ -868,6 +868,32 @@
 -l ECDHE-ECDSA-AES256-CCM-8
 -A ./certs/ca-ecc-cert.pem
 
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-u
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-u
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-A ./certs/ca-ecc-cert.pem
+
 # server DTLSv1.2 ADH-AES128-SHA
 -u
 -a

--- a/tests/test-qsh.conf
+++ b/tests/test-qsh.conf
@@ -1473,6 +1473,22 @@
 -v 3
 -l QSH:AES256-CCM-8
 
+# server TLSv1.2 AES128-CCM8 (OpenSSL-compat alias)
+-v 3
+-l QSH:AES128-CCM8
+
+# client TLSv1.2 AES128-CCM8 (OpenSSL-compat alias)
+-v 3
+-l QSH:AES128-CCM8
+
+# server TLSv1.2 AES256-CCM8 (OpenSSL-compat alias)
+-v 3
+-l QSH:AES256-CCM8
+
+# client TLSv1.2 AES256-CCM8 (OpenSSL-compat alias)
+-v 3
+-l QSH:AES256-CCM8
+
 # server TLSv1.2 ECDHE-ECDSA-AES128-CCM
 -v 3
 -l QSH:ECDHE-ECDSA-AES128-CCM
@@ -1504,6 +1520,28 @@
 # client TLSv1.2 ECDHE-ECDSA-AES256-CCM-8
 -v 3
 -l QSH:ECDHE-ECDSA-AES256-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-v 3
+-l QSH:ECDHE-ECDSA-AES128-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-v 3
+-l QSH:ECDHE-ECDSA-AES128-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-v 3
+-l QSH:ECDHE-ECDSA-AES256-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-v 3
+-l QSH:ECDHE-ECDSA-AES256-CCM8
 -A ./certs/ca-ecc-cert.pem
 
 # server TLSv1.2 PSK-AES128-CCM
@@ -1545,6 +1583,26 @@
 -s
 -v 3
 -l QSH:PSK-AES256-CCM-8
+
+# server TLSv1.2 PSK-AES128-CCM8 (OpenSSL-compat alias)
+-s
+-v 3
+-l QSH:PSK-AES128-CCM8
+
+# client TLSv1.2 PSK-AES128-CCM8 (OpenSSL-compat alias)
+-s
+-v 3
+-l QSH:PSK-AES128-CCM8
+
+# server TLSv1.2 PSK-AES256-CCM8 (OpenSSL-compat alias)
+-s
+-v 3
+-l QSH:PSK-AES256-CCM8
+
+# client TLSv1.2 PSK-AES256-CCM8 (OpenSSL-compat alias)
+-s
+-v 3
+-l QSH:PSK-AES256-CCM8
 
 # server TLSv1.2 DHE-PSK-AES128-CBC-SHA256
 -s

--- a/tests/test-sctp.conf
+++ b/tests/test-sctp.conf
@@ -984,6 +984,32 @@
 -l ECDHE-ECDSA-AES256-CCM-8
 -A ./certs/ca-ecc-cert.pem
 
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-G
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-G
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-G
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-G
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-A ./certs/ca-ecc-cert.pem
+
 # server DTLSv1.2 ADH-AES128-SHA
 -G
 -a

--- a/tests/test-sig.conf
+++ b/tests/test-sig.conf
@@ -217,3 +217,14 @@
 -v 3
 -l ECDHE-ECDSA-AES128-CCM-8
 -A ./certs/ca-cert.pem
+
+# server TLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-A ./certs/ca-cert.pem

--- a/tests/test-tls13-ecc.conf
+++ b/tests/test-tls13-ecc.conf
@@ -53,6 +53,17 @@
 -l TLS13-AES128-CCM-8-SHA256
 -A ./certs/ca-ecc-cert.pem
 
+# server TLSv1.3 TLS13-AES128-CCM8-SHA256 (OpenSSL-compat alias)
+-v 4
+-l TLS13-AES128-CCM8-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.3 TLS13-AES128-CCM8-SHA256 (OpenSSL-compat alias)
+-v 4
+-l TLS13-AES128-CCM8-SHA256
+-A ./certs/ca-ecc-cert.pem
+
 # server TLSv1.3 TLS13-AES128-GCM-SHA256
 -v 4
 -l TLS13-AES128-GCM-SHA256

--- a/tests/test-tls13.conf
+++ b/tests/test-tls13.conf
@@ -38,6 +38,14 @@
 -v 4
 -l TLS13-AES128-CCM-8-SHA256
 
+# server TLSv1.3 TLS13-AES128-CCM8-SHA256 (OpenSSL-compat alias)
+-v 4
+-l TLS13-AES128-CCM8-SHA256
+
+# client TLSv1.3 TLS13-AES128-CCM8-SHA256 (OpenSSL-compat alias)
+-v 4
+-l TLS13-AES128-CCM8-SHA256
+
 # server TLSv1.3 resumption
 -v 4
 -l TLS13-AES128-GCM-SHA256

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -1513,6 +1513,22 @@
 -v 3
 -l AES256-CCM-8
 
+# server TLSv1.2 AES128-CCM8 (OpenSSL-compat alias)
+-v 3
+-l AES128-CCM8
+
+# client TLSv1.2 AES128-CCM8 (OpenSSL-compat alias)
+-v 3
+-l AES128-CCM8
+
+# server TLSv1.2 AES256-CCM8 (OpenSSL-compat alias)
+-v 3
+-l AES256-CCM8
+
+# client TLSv1.2 AES256-CCM8 (OpenSSL-compat alias)
+-v 3
+-l AES256-CCM8
+
 # server TLSv1.2 ECDHE-ECDSA-AES128-CCM
 -v 3
 -l ECDHE-ECDSA-AES128-CCM
@@ -1544,6 +1560,28 @@
 # client TLSv1.2 ECDHE-ECDSA-AES256-CCM-8
 -v 3
 -l ECDHE-ECDSA-AES256-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
 -A ./certs/ca-ecc-cert.pem
 
 # server TLSv1.2 PSK-AES128-CCM
@@ -1585,6 +1623,26 @@
 -s
 -v 3
 -l PSK-AES256-CCM-8
+
+# server TLSv1.2 PSK-AES128-CCM8 (OpenSSL-compat alias)
+-s
+-v 3
+-l PSK-AES128-CCM8
+
+# client TLSv1.2 PSK-AES128-CCM8 (OpenSSL-compat alias)
+-s
+-v 3
+-l PSK-AES128-CCM8
+
+# server TLSv1.2 PSK-AES256-CCM8 (OpenSSL-compat alias)
+-s
+-v 3
+-l PSK-AES256-CCM8
+
+# client TLSv1.2 PSK-AES256-CCM8 (OpenSSL-compat alias)
+-s
+-v 3
+-l PSK-AES256-CCM8
 
 # server TLSv1.2 DHE-PSK-AES128-CBC-SHA256
 -s

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9044,7 +9044,7 @@ static int aesgcm_test(void)
     byte *large_output = (byte *)XMALLOC(BENCH_AESGCM_LARGE + AES_BLOCK_SIZE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     byte *large_outdec = (byte *)XMALLOC(BENCH_AESGCM_LARGE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
-    if ((! large_input) || (! large_input) || (! large_input))
+    if ((! large_input) || (! large_output) || (! large_outdec))
         ERROR_OUT(MEMORY_E, out);
 
     XMEMSET(large_input, 0, BENCH_AESGCM_LARGE);

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4606,6 +4606,7 @@ typedef struct CipherSuiteInfo {
     byte minor;
     byte major;
 #endif
+    byte flags;
 } CipherSuiteInfo;
 
 WOLFSSL_LOCAL const CipherSuiteInfo* GetCipherNames(void);
@@ -4627,7 +4628,8 @@ WOLFSSL_LOCAL const char* GetCipherNameIana(const byte cipherSuite0, const byte 
 WOLFSSL_LOCAL const char* wolfSSL_get_cipher_name_internal(WOLFSSL* ssl);
 WOLFSSL_LOCAL const char* wolfSSL_get_cipher_name_iana(WOLFSSL* ssl);
 WOLFSSL_LOCAL int GetCipherSuiteFromName(const char* name, byte* cipherSuite0,
-                                         byte* cipherSuite);
+                                         byte* cipherSuite, int* flags);
+
 
 enum encrypt_side {
     ENCRYPT_SIDE_ONLY = 1,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -795,6 +795,9 @@ WOLFSSL_API long wolfSSL_CTX_get_verify_depth(WOLFSSL_CTX* ctx);
 WOLFSSL_API void wolfSSL_CTX_set_verify_depth(WOLFSSL_CTX *ctx,int depth);
 #endif /* !NO_CERTS */
 
+#define WOLFSSL_CIPHER_SUITE_FLAG_NONE          0x0
+#define WOLFSSL_CIPHER_SUITE_FLAG_NAMEALIAS     0x1
+
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS)
 
 WOLFSSL_API int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX*, const char*,
@@ -854,6 +857,8 @@ WOLFSSL_API const char* wolfSSL_get_cipher_name_from_suite(const unsigned char,
     const unsigned char);
 WOLFSSL_API const char* wolfSSL_get_cipher_name_iana_from_suite(
     const unsigned char, const unsigned char);
+WOLFSSL_API int wolfSSL_get_cipher_suite_from_name(const char* name,
+    byte* cipherSuite0, byte* cipherSuite, int* flags);
 WOLFSSL_API const char* wolfSSL_get_shared_ciphers(WOLFSSL* ssl, char* buf,
     int len);
 WOLFSSL_API const char* wolfSSL_get_curve_name(WOLFSSL* ssl);


### PR DESCRIPTION
Harmonize with OpenSSL names.  Fixes ZD#11127.

Includes backward compatibility.
