### PR TITLE
Configuration fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -22059,7 +22059,7 @@ static int test_wc_Ed448PrivateKeyToDer (void)
 static int test_wc_SetSubjectBuffer (void)
 {
     int ret = 0;
-#if defined(WOLFSSL_CERT_GEN)
+#if defined(WOLFSSL_CERT_GEN) && !defined(NO_RSA)
     Cert    cert;
     FILE*   file;
     byte*   der;

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -80,6 +80,11 @@ char* myoptarg = NULL;
 #ifdef HAVE_STACK_SIZE
 static void *echoclient_test_wrapper(void* args) {
     echoclient_test(args);
+
+#if defined(HAVE_ECC) && defined(FP_ECC) && defined(HAVE_THREAD_LS)
+    wc_ecc_fp_free();  /* free per thread cache */
+#endif
+
     return (void *)0;
 }
 #endif

--- a/wolfcrypt/src/cpuid.c
+++ b/wolfcrypt/src/cpuid.c
@@ -29,7 +29,8 @@
 #include <wolfssl/wolfcrypt/cpuid.h>
 
 #if (defined(WOLFSSL_X86_64_BUILD) || defined(USE_INTEL_SPEEDUP) || \
-     defined(WOLFSSL_AESNI)) && !defined(WOLFSSL_NO_ASM)
+     defined(WOLFSSL_AESNI) || defined(WOLFSSL_SP_ASM)) && \
+     !defined(WOLFSSL_NO_ASM)
     /* Each platform needs to query info type 1 from cpuid to see if aesni is
      * supported. Also, let's setup a macro for proper linkage w/o ABI conflicts
      */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -13810,11 +13810,11 @@ static int rsa_test(void)
 #endif
 #else
     #ifdef USE_CERT_BUFFERS_2048
-        ret = mp_read_unsigned_bin(key.n, &tmp[12], 256);
+        ret = mp_read_unsigned_bin(&key->n, &tmp[12], 256);
         if (ret != 0) {
             ERROR_OUT(-7705, exit_rsa);
         }
-        ret = mp_set_int(key.e, WC_RSA_EXPONENT);
+        ret = mp_set_int(&key->e, WC_RSA_EXPONENT);
         if (ret != 0) {
             ERROR_OUT(-7706, exit_rsa);
         }

--- a/wolfssl/wolfcrypt/cpuid.h
+++ b/wolfssl/wolfcrypt/cpuid.h
@@ -33,7 +33,7 @@
 #endif
 
 #if defined(WOLFSSL_X86_64_BUILD) || defined(USE_INTEL_SPEEDUP) || \
-    defined(WOLFSSL_AESNI)
+    defined(WOLFSSL_AESNI) || defined(WOLFSSL_SP_ASM)
     #define CPUID_AVX1   0x0001
     #define CPUID_AVX2   0x0002
     #define CPUID_RDRAND 0x0004


### PR DESCRIPTION
--enable-sp --enable-sp-asm --disable-fastmath:
    cpuid.h - check for WOLFSSL_SP_ASM as well

-enable-curve448 --enable-ed448 --disable-rsa --disable-dh
--enable-tls13 --disable-ecc --enable-certgen --enable-keygen:
    api.c - certificate loaded that was RSA but RSA disabled

--enable-sp --enable-sp-asm --enable-sp-math:
    cpuid.c - check for WOLFSSL_SP_ASM as well

--disable-shared --disable-ecc --disable-dh --enable-cryptonly
--enable-rsavfy --disable-asn --disable-rng --disable-filesystem:
    test.c - rsa_test()

'CC=clang -fsanitize=address' '-enable-distro' '--enable-stacksize':
testsuit.c - echoclient_test_wrapper needs to free ECC FP cache when
it is in a separate thread