### PR TITLE
TLS 1.3: PSK only

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -131,6 +131,11 @@ AS_IF([test "$ax_enable_debug" = "yes"],
       [AM_CFLAGS="$AM_CFLAGS -DNDEBUG"])
 
 
+# Start without certificates enabled and enable if a certificate algorithm is
+# enabled
+ENABLED_CERTS="no"
+
+
 
 # FIPS
 AC_ARG_ENABLE([fips],
@@ -933,7 +938,7 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_EXT_CACHE"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_EITHER_SIDE"
     AM_CFLAGS="$AM_CFLAGS -DOPENSSL_EXTRA_X509_SMALL"
-    
+
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_PUBLIC_MP"
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DER_LOAD"
     AM_CFLAGS="$AM_CFLAGS -DATOMIC_USER"
@@ -963,7 +968,7 @@ AC_ARG_ENABLE([leanpsk],
 
 if test "$ENABLED_LEANPSK" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LEANPSK -DWOLFSSL_STATIC_PSK -DHAVE_NULL_CIPHER -DSINGLE_THREADED -DNO_AES -DNO_FILESYSTEM -DNO_RABBIT -DNO_RSA -DNO_DSA -DNO_DH -DNO_CERTS -DNO_PWDBASED -DNO_MD4 -DNO_MD5 -DNO_ERROR_STRINGS -DNO_OLD_TLS -DNO_RC4 -DNO_WRITEV -DNO_DEV_RANDOM -DWOLFSSL_USER_IO -DNO_SHA"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_LEANPSK -DWOLFSSL_STATIC_PSK -DHAVE_NULL_CIPHER -DSINGLE_THREADED -DNO_AES -DNO_FILESYSTEM -DNO_RABBIT -DNO_RSA -DNO_DSA -DNO_DH -DNO_PWDBASED -DNO_MD4 -DNO_MD5 -DNO_ERROR_STRINGS -DNO_OLD_TLS -DNO_RC4 -DNO_WRITEV -DNO_DEV_RANDOM -DWOLFSSL_USER_IO -DNO_SHA"
     ENABLED_SLOWMATH="no"
     ENABLED_SINGLETHREADED="yes"
     enable_lowresource=yes
@@ -1808,6 +1813,8 @@ fi
 if test "$ENABLED_DSA" = "no" && test "$ENABLED_OPENSSH" = "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DNO_DSA"
+else
+    ENABLED_CERTS=yes
 fi
 
 # ECC Shamir
@@ -1848,6 +1855,8 @@ then
     then
         AM_CFLAGS="$AM_CFLAGS -DWC_ECC_NONBLOCK"
     fi
+
+    ENABLED_CERTS=yes
 fi
 
 
@@ -1974,6 +1983,8 @@ then
     ENABLED_FEMATH=yes
     ENABLED_GEMATH=yes
     AM_CFLAGS="$AM_CFLAGS -DHAVE_ED25519"
+
+    ENABLED_CERTS=yes
 fi
 
 
@@ -2035,6 +2046,8 @@ then
     # EdDSA448 requires SHAKE256 which requires SHA-3
     ENABLED_SHAKE3=yes
     ENABLED_SHAKE256=yes
+
+    ENABLED_CERTS=yes
 fi
 
 
@@ -2376,6 +2389,8 @@ else
     then
         AM_CFLAGS="$AM_CFLAGS -DNO_RSA"
         ENABLED_RSA=no
+     else
+        ENABLED_CERTS=yes
     fi
 fi
 
@@ -2501,7 +2516,7 @@ AC_ARG_ENABLE([asn],
 
 if test "$ENABLED_ASN" = "no"
 then
-    AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_CERTS"
+    AM_CFLAGS="$AM_CFLAGS -DNO_ASN"
     if test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" = "no"
     then
         # DH and ECC need bigint
@@ -2511,7 +2526,7 @@ else
     # turn off ASN if leanpsk on
     if test "$ENABLED_LEANPSK" = "yes"
     then
-        AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_CERTS -DNO_BIG_INT"
+        AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_BIG_INT"
         ENABLED_ASN=no
     else
         if test "$ENABLED_ASN" = "nocrypt"
@@ -3535,7 +3550,7 @@ then
 fi
 
 # TLS 1.3 Requires either ECC or (RSA/DH), or CURVE25519/ED25519 or CURVE448/ED448
-if test "x$ENABLED_ECC" = "xno" && \
+if test "x$ENABLED_PSK" = "xno" && test "x$ENABLED_ECC" = "xno" && \
     (test "x$ENABLED_RSA" = "xno" || test "x$ENABLED_DH" = "xno") && \
     (test "x$ENABLED_CURVE25519" = "xno" || test "x$ENABLED_ED25519" = "xno") && \
     (test "x$ENABLED_CURVE448" = "xno" || test "x$ENABLED_ED448" = "xno")
@@ -3543,9 +3558,14 @@ then
     # disable TLS 1.3
     ENABLED_TLS13=no
 fi
+if test "$ENABLED_TLS13" = "yes" && (test "x$ENABLED_ECC" = "xyes" || \
+    test "x$ENABLED_DH" = "xyes")
+then
+    AM_CFLAGS="-DHAVE_SUPPORTED_CURVES $AM_CFLAGS"
+fi
 if test "$ENABLED_TLS13" = "yes"
 then
-    AM_CFLAGS="-DWOLFSSL_TLS13 -DHAVE_TLS_EXTENSIONS -DHAVE_SUPPORTED_CURVES $AM_CFLAGS"
+    AM_CFLAGS="-DWOLFSSL_TLS13 -DHAVE_TLS_EXTENSIONS $AM_CFLAGS"
 fi
 
 
@@ -5571,6 +5591,10 @@ if test "x$ENABLED_OPENSSLCOEXIST" = "xyes"; then
     if test "x$ENABLED_OPENSSLEXTRA" = "xyes"; then
         AC_MSG_ERROR([Cannot use --enable-opensslcoexist with --enable-opensslextra])
     fi
+fi
+
+if test "x$ENABLED_CERTS" = "xno" || test "x$ENABLED_LEANPSK" = "xyes" || test "x$ENABLED_ASN" = "xno"; then
+   AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_CERTS"
 fi
 ################################################################################
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -273,7 +273,7 @@ static void ShowVersions(void)
     printf("\n");
 }
 
-#ifdef WOLFSSL_TLS13
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
 #define MAX_GROUP_NUMBER 4
 static void SetKeyShare(WOLFSSL* ssl, int onlyKeyShare, int useX25519,
                         int useX448)
@@ -443,7 +443,7 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
             if (benchResume)
                 wolfSSL_set_session(ssl, benchSession);
         #endif
-        #ifdef WOLFSSL_TLS13
+        #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
             else if (version >= 4) {
                 if (!helloRetry)
                     SetKeyShare(ssl, onlyKeyShare, useX25519, useX448);
@@ -546,7 +546,7 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
 
     (void)useX25519;
     (void)useX448;
-    #ifdef WOLFSSL_TLS13
+    #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
         #ifdef HAVE_CURVE25519
             if (useX25519) {
                 if (wolfSSL_UseKeyShare(ssl, WOLFSSL_ECC_X25519)
@@ -983,9 +983,11 @@ static const char* client_usage_msg[][66] = {
                                             " SSLv3(0) - TLS1.3(4)\n",   /* 7 */
 #endif
         "-l <str>    Cipher suite list (: delimited)\n",                /* 8 */
+#ifndef NO_CERTS
         "-c <file>   Certificate file,           default",              /* 9 */
         "-k <file>   Key file,                   default",              /* 10 */
         "-A <file>   Certificate Authority file, default",              /* 11 */
+#endif
 #ifndef NO_DH
         "-Z <num>    Minimum DH key bits,        default",              /* 12 */
 #endif
@@ -1009,7 +1011,9 @@ static const char* client_usage_msg[][66] = {
         "-G          Use SCTP DTLS,"
                 " add -v 2 for DTLSv1, -v 3 for DTLSv1.2 (default)\n",  /* 22 */
 #endif
+#ifndef NO_CERTS
         "-m          Match domain name in cert\n",                      /* 23 */
+#endif
         "-N          Use Non-blocking sockets\n",                       /* 24 */
 #ifndef NO_SESSION_CACHE
         "-r          Resume session\n",                                 /* 25 */
@@ -1025,7 +1029,9 @@ static const char* client_usage_msg[][66] = {
         "            The string parameter is optional.\n", /* 29 */
 #endif
         "-f          Fewer packets/group messages\n",                   /* 30 */
+#ifndef NO_CERTS
         "-x          Disable client cert/key loading\n",                /* 31 */
+#endif
         "-X          Driven by eXternal test case\n",                   /* 32 */
         "-j          Use verify callback override\n",                   /* 33 */
 #ifdef SHOW_SIZES
@@ -1153,9 +1159,11 @@ static const char* client_usage_msg[][66] = {
                                                  " TLS1.3(4)\n",         /* 7 */
 #endif
         "-l <str>    暗号スイートリスト (区切り文字 :)\n",               /* 8 */
+#ifndef NO_CERTS
         "-c <file>   証明書ファイル,  既定値",                           /* 9 */
         "-k <file>   鍵ファイル,      既定値",                          /* 10 */
         "-A <file>   認証局ファイル,  既定値",                          /* 11 */
+#endif
 #ifndef NO_DH
         "-Z <num>    最小 DH 鍵 ビット, 既定値",                        /* 12 */
 #endif
@@ -1179,7 +1187,9 @@ static const char* client_usage_msg[][66] = {
         "-G          SCTP DTLSを使用する。-v 2 を追加指定すると"
                 " DTLSv1, -v 3 を追加指定すると DTLSv1.2 (既定値)\n",   /* 22 */
 #endif
+#ifndef NO_CERTS
         "-m          証明書内のドメイン名一致を確認する\n",             /* 23 */
+#endif
         "-N          ノンブロッキング・ソケットを使用する\n",           /* 24 */
 #ifndef NO_SESSION_CACHE
         "-r          セッションを継続する\n",                           /* 25 */
@@ -1192,7 +1202,9 @@ static const char* client_usage_msg[][66] = {
         "-i <str>    クライアント主導のネゴシエーションを強制する\n",   /* 29 */
 #endif
         "-f          より少ないパケット/グループメッセージを使用する\n",/* 30 */
+#ifndef NO_CERTS
         "-x          クライアントの証明書/鍵のロードを無効する\n",      /* 31 */
+#endif
         "-X          外部テスト・ケースにより動作する\n",               /* 32 */
         "-j          コールバック・オーバーライドの検証を使用する\n",   /* 33 */
 #ifdef SHOW_SIZES
@@ -1326,9 +1338,11 @@ static void Usage(void)
     printf("%s", msg[++msgid]);                              /* -V */
 #endif
     printf("%s", msg[++msgid]); /* -l */
+#ifndef NO_CERTS
     printf("%s %s\n", msg[++msgid], cliCertFile); /* -c */
     printf("%s %s\n", msg[++msgid], cliKeyFile);  /* -k */
     printf("%s %s\n", msg[++msgid], caCertFile);  /* -A */
+#endif
 #ifndef NO_DH
     printf("%s %d\n", msg[++msgid], DEFAULT_MIN_DHKEY_BITS);
 #endif
@@ -1348,7 +1362,9 @@ static void Usage(void)
 #ifdef WOLFSSL_SCTP
     printf("%s", msg[++msgid]); /* -G */
 #endif
+#ifndef NO_CERTS
     printf("%s", msg[++msgid]); /* -m */
+#endif
     printf("%s", msg[++msgid]); /* -N */
 #ifndef NO_SESSION_CACHE
     printf("%s", msg[++msgid]); /* -r */
@@ -1360,7 +1376,9 @@ static void Usage(void)
     printf("%s", msg[++msgid]); /* -i */
 #endif
     printf("%s", msg[++msgid]); /* -f */
+#ifndef NO_CERTS
     printf("%s", msg[++msgid]); /* -x */
+#endif
     printf("%s", msg[++msgid]); /* -X */
     printf("%s", msg[++msgid]); /* -j */
 #ifdef SHOW_SIZES
@@ -2041,13 +2059,15 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 break;
 
             case 'y' :
-                #if defined(WOLFSSL_TLS13) && !defined(NO_DH)
+                #if defined(WOLFSSL_TLS13) && \
+                               defined(HAVE_SUPPORTED_CURVES) && !defined(NO_DH)
                     onlyKeyShare = 1;
                 #endif
                 break;
 
             case 'Y' :
-                #if defined(WOLFSSL_TLS13) && defined(HAVE_ECC)
+                #if defined(WOLFSSL_TLS13) && \
+                             defined(HAVE_SUPPORTED_CURVES) && defined(HAVE_ECC)
                     onlyKeyShare = 2;
                 #endif
                 break;
@@ -2061,7 +2081,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                     useX25519 = 1;
                     #ifdef HAVE_ECC
                     useSupCurve = 1;
-                        #ifdef WOLFSSL_TLS13
+                        #if defined(WOLFSSL_TLS13) && \
+                                                  defined(HAVE_SUPPORTED_CURVES)
                         onlyKeyShare = 2;
                         #endif
                     #endif
@@ -2121,7 +2142,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                     useX448 = 1;
                     #ifdef HAVE_ECC
                     useSupCurve = 1;
-                        #ifdef WOLFSSL_TLS13
+                        #if defined(WOLFSSL_TLS13) && \
+                                                  defined(HAVE_SUPPORTED_CURVES)
                         onlyKeyShare = 2;
                         #endif
                     #endif
@@ -2435,11 +2457,20 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         if (defaultCipherList == NULL) {
         #if defined(HAVE_AESGCM) && !defined(NO_DH)
             #ifdef WOLFSSL_TLS13
-                defaultCipherList = "TLS13-AES128-GCM-SHA256:"
-                                    "DHE-PSK-AES128-GCM-SHA256:";
+                defaultCipherList = "TLS13-AES128-GCM-SHA256"
+                #ifndef WOLFSSL_NO_TLS12
+                                    ":DHE-PSK-AES128-GCM-SHA256"
+                #endif
+                ;
             #else
                 defaultCipherList = "DHE-PSK-AES128-GCM-SHA256";
             #endif
+        #elif defined(HAVE_AESGCM) && defined(WOLFSSL_TLS13)
+                defaultCipherList = "TLS13-AES128-GCM-SHA256"
+                #ifndef WOLFSSL_NO_TLS12
+                                    ":PSK-AES128-GCM-SHA256"
+                #endif
+                ;
         #elif defined(HAVE_NULL_CIPHER)
                 defaultCipherList = "PSK-NULL-SHA256";
         #else
@@ -2851,7 +2882,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             err_sys("error printing out memory stats");
 #endif
 
-#ifdef WOLFSSL_TLS13
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
     if (!helloRetry) {
     #if defined(WOLFSSL_TLS13) && (!defined(NO_DH) || defined(HAVE_ECC) || \
                              defined(HAVE_CURVE25519) || defined(HAVE_CURVE448))

--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -181,11 +181,20 @@ void echoclient_test(void* args)
             defaultCipherList = "PSK-NULL-SHA256";
         #elif defined(HAVE_AESGCM) && !defined(NO_DH)
             #ifdef WOLFSSL_TLS13
-            defaultCipherList = "TLS13-AES128-GCM-SHA256:"
-                                "DHE-PSK-AES128-GCM-SHA256:";
+            defaultCipherList = "TLS13-AES128-GCM-SHA256"
+                #ifndef WOLFSSL_NO_TLS12
+                                ":DHE-PSK-AES128-GCM-SHA256"
+                #endif
+                ;
             #else
             defaultCipherList = "DHE-PSK-AES128-GCM-SHA256";
             #endif
+        #elif defined(HAVE_AESGCM) && defined(WOLFSSL_TLS13)
+            defaultCipherList = "TLS13-AES128-GCM-SHA256"
+                #ifndef WOLFSSL_NO_TLS12
+                                ":DHE-PSK-AES128-GCM-SHA256"
+                #endif
+                ;
         #else
             defaultCipherList = "PSK-AES128-CBC-SHA256";
         #endif

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -265,11 +265,20 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
             defaultCipherList = "PSK-NULL-SHA256";
         #elif defined(HAVE_AESGCM) && !defined(NO_DH)
             #ifdef WOLFSSL_TLS13
-            defaultCipherList = "TLS13-AES128-GCM-SHA256:"
-                                "DHE-PSK-AES128-GCM-SHA256";
+            defaultCipherList = "TLS13-AES128-GCM-SHA256"
+                #ifndef WOLFSSL_NO_TLS12
+                                ":DHE-PSK-AES128-GCM-SHA256"
+                #endif
+                ;
             #else
             defaultCipherList = "DHE-PSK-AES128-GCM-SHA256";
             #endif
+        #elif defined(HAVE_AESGCM) && defined(WOLFSSL_TLS13)
+            defaultCipherList = "TLS13-AES128-GCM-SHA256"
+                #ifndef WOLFSSL_NO_TLS12
+                                ":PSK-AES128-GCM-SHA256"
+                #endif
+                ;
         #else
             defaultCipherList = "PSK-AES128-CBC-SHA256";
         #endif

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1869,12 +1869,21 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         if (defaultCipherList == NULL && !usePskPlus) {
         #if defined(HAVE_AESGCM) && !defined(NO_DH)
             #ifdef WOLFSSL_TLS13
-                defaultCipherList = "TLS13-AES128-GCM-SHA256:"
-                                    "DHE-PSK-AES128-GCM-SHA256";
+                defaultCipherList = "TLS13-AES128-GCM-SHA256"
+                #ifndef WOLFSSL_NO_TLS12
+                                    ":DHE-PSK-AES128-GCM-SHA256"
+                #endif
+                ;
             #else
                 defaultCipherList = "DHE-PSK-AES128-GCM-SHA256";
             #endif
                 needDH = 1;
+        #elif defined(HAVE_AESGCM) && defined(WOLFSSL_TLS13)
+                defaultCipherList = "TLS13-AES128-GCM-SHA256"
+                #ifndef WOLFSSL_NO_TLS12
+                                    ":PSK-AES128-GCM-SHA256"
+                #endif
+                ;
         #elif defined(HAVE_NULL_CIPHER)
                 defaultCipherList = "PSK-NULL-SHA256";
         #else

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -133,11 +133,11 @@ start_openssl_server() {
 
         if [ "$cert_file" != "" ]
         then
-            echo "# " $OPENSSL s_server -accept $server_port -cert $cert_file -key $key_file  -quiet -CAfile $ca_file -www -dhparam ./certs/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL"
-            $OPENSSL s_server -accept $server_port -cert $cert_file -key $key_file  -quiet -CAfile $ca_file -www -dhparam ./certs/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" &
+            echo "# " $OPENSSL s_server -accept $server_port -cert $cert_file -key $key_file  -quiet -CAfile $ca_file -www -dhparam ./certs/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" $openssl_nodhe
+            $OPENSSL s_server -accept $server_port -cert $cert_file -key $key_file  -quiet -CAfile $ca_file -www -dhparam ./certs/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" $openssl_nodhe &
         else
-            echo "# " $OPENSSL s_server -accept $server_port -quiet -nocert -www -dhparam ./certs/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL"
-            $OPENSSL s_server -accept $server_port -quiet -nocert -www -dhparam ./certs/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" &
+            echo "# " $OPENSSL s_server -accept $server_port -quiet -nocert -www -dhparam ./certs/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" $openssl_nodhe
+            $OPENSSL s_server -accept $server_port -quiet -nocert -www -dhparam ./certs/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" $openssl_nodhe &
         fi
         server_pid=$!
         # wait to see if s_server successfully starts before continuing
@@ -438,51 +438,64 @@ IFS=$OIFS #restore separator
 # Start OpenSSL servers
 #
 
-# Check if ECC certificates supported in wolfSSL
-wolf_ecc=`$WOLFSSL_CLIENT -A ./certs/ed25519/ca-ecc-cert.pem 2>&1`
-case $wolf_ecc in
-*"ca file"*)
-    wolf_ecc=""
+# Check for cerificate support in wolfSSL
+wolf_certs=`$WOLFSSL_CLIENT -help 2>&1`
+case $wolf_certs in
+*"cert"*)
     ;;
 *)
+    wolf_certs=""
     ;;
 esac
-# Check if Ed25519 certificates supported in wolfSSL
-wolf_ed25519=`$WOLFSSL_CLIENT -A ./certs/ed25519/root-ed25519.pem 2>&1`
-case $wolf_ed25519 in
-*"ca file"*)
-    wolf_ed25519=""
-    ;;
-*)
-    ;;
-esac
-# Check if Ed25519 certificates supported in OpenSSL
-openssl_ed25519=`$OPENSSL s_client -cert ./certs/ed25519/client-ed25519.pem -key ./certs/ed25519/client-ed25519-priv.pem 2>&1`
-case $openssl_ed25519 in
-*"unable to load"*)
-    wolf_ed25519=""
-    ;;
-*)
-    ;;
-esac
-# Check if Ed448 certificates supported in wolfSSL
-wolf_ed448=`$WOLFSSL_CLIENT -A ./certs/ed448/root-ed448.pem 2>&1`
-case $wolf_ed448 in
-*"ca file"*)
-    wolf_ed448=""
-    ;;
-*)
-    ;;
-esac
-# Check if Ed448 certificates supported in OpenSSL
-openssl_ed448=`$OPENSSL s_client -cert ./certs/ed448/client-ed448.pem -key ./certs/ed448/client-ed448-priv.pem 2>&1`
-case $openssl_ed448 in
-*"unable to load"*)
-    wolf_ed448=""
-    ;;
-*)
-    ;;
-esac
+
+if [ "$wolf_certs" != "" ]
+then
+    # Check if ECC certificates supported in wolfSSL
+    wolf_ecc=`$WOLFSSL_CLIENT -A ./certs/ed25519/ca-ecc-cert.pem 2>&1`
+    case $wolf_ecc in
+    *"ca file"*)
+        wolf_ecc=""
+        ;;
+    *)
+        ;;
+    esac
+    # Check if Ed25519 certificates supported in wolfSSL
+    wolf_ed25519=`$WOLFSSL_CLIENT -A ./certs/ed25519/root-ed25519.pem 2>&1`
+    case $wolf_ed25519 in
+    *"ca file"*)
+        wolf_ed25519=""
+        ;;
+    *)
+        ;;
+    esac
+    # Check if Ed25519 certificates supported in OpenSSL
+    openssl_ed25519=`$OPENSSL s_client -cert ./certs/ed25519/client-ed25519.pem -key ./certs/ed25519/client-ed25519-priv.pem 2>&1`
+    case $openssl_ed25519 in
+    *"unable to load"*)
+        wolf_ed25519=""
+        ;;
+    *)
+        ;;
+    esac
+    # Check if Ed448 certificates supported in wolfSSL
+    wolf_ed448=`$WOLFSSL_CLIENT -A ./certs/ed448/root-ed448.pem 2>&1`
+    case $wolf_ed448 in
+    *"ca file"*)
+        wolf_ed448=""
+        ;;
+    *)
+        ;;
+    esac
+    # Check if Ed448 certificates supported in OpenSSL
+    openssl_ed448=`$OPENSSL s_client -cert ./certs/ed448/client-ed448.pem -key ./certs/ed448/client-ed448-priv.pem 2>&1`
+    case $openssl_ed448 in
+    *"unable to load"*)
+        wolf_ed448=""
+        ;;
+    *)
+        ;;
+    esac
+fi
 
 openssl_tls13=`$OPENSSL s_client -help 2>&1`
 case $openssl_tls13 in
@@ -490,6 +503,17 @@ case $openssl_tls13 in
     ;;
 *)
     openssl_tls13=
+    ;;
+esac
+
+# Not all openssl versions support -allow_no_dhe_kex
+openssl_nodhe=`$OPENSSL s_client -help 2>&1`
+case $openssl_nodhe in
+*allow_no_dhe_kex*)
+    openssl_nodhe=-allow_no_dhe_kex
+    ;;
+*)
+    openssl_nodhe=
     ;;
 esac
 
@@ -651,8 +675,7 @@ fi
 
 if [ "$wolf_tls13" != "" -a "$wolf_psk" != "" ]
 then
-    cert_file="./certs/server-cert.pem"
-    key_file="./certs/server-key.pem"
+    cert_file=
 
     psk_hex="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
     openssl_suite="TLSv1.3_PSK"
@@ -1015,17 +1038,24 @@ do
                 do_openssl_client
             fi
             # PSK
-            if [ "$wolf_psk" != "" -a $wolfSuite = "TLS13-AES128-GCM-SHA256" ]
+            if [ "$wolf_psk" != "" -a $wolfSuite = "TLS13-AES128-GCM-SHA256" -a "$wolf_ecc" != "" -a $openssl_nodhe != "" ]
             then
-                cert="./certs/client-cert.pem"
-                key="./certs/client-key.pem"
-                caCert="./certs/ca-cert.pem"
+                cert=""
+                key=""
+                caCert=""
 
                 wolf_temp_cases_total=$((wolf_temp_cases_total + 1))
                 port=$tls13_psk_openssl_port
                 psk="-s"
+                # OpenSSL doesn't support DH for key exchange so do no PSK
+                # DHE when ECC not supported
+                if [ "$wolf_ecc" = "" ]
+                then
+                    adh="-K"
+                fi
                 do_wolfssl_client
                 psk=""
+                adh=""
                 openssl_psk="-psk 0123456789abcdef0123456789abcdef"
                 open_temp_cases_total=$((open_temp_cases_total + 1))
                 port=$wolfssl_port

--- a/src/internal.c
+++ b/src/internal.c
@@ -1782,6 +1782,10 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
     ctx->maxEarlyDataSz = MAX_EARLY_DATA_SZ;
 #endif
 
+#if defined(WOLFSSL_TLS13) && !defined(HAVE_SUPPORTED_CURVES)
+    ctx->noPskDheKe = 1;
+#endif
+
     ctx->heap = heap; /* wolfSSL_CTX_load_static_memory sets */
     ctx->verifyDepth = MAX_CHAIN_DEPTH;
 
@@ -15826,6 +15830,8 @@ int ProcessReply(WOLFSSL* ssl)
 }
 
 
+#if !defined(WOLFSSL_NO_TLS12) || !defined(NO_OLD_TLS) || \
+             (defined(WOLFSSL_TLS13) && defined(WOLFSSL_TLS13_MIDDLEBOX_COMPAT))
 int SendChangeCipher(WOLFSSL* ssl)
 {
     byte              *output;
@@ -15918,6 +15924,7 @@ int SendChangeCipher(WOLFSSL* ssl)
     else
         return SendBuffered(ssl);
 }
+#endif
 
 
 #if !defined(NO_OLD_TLS) && !defined(WOLFSSL_AEAD_ONLY)
@@ -26855,13 +26862,15 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
 #ifdef WOLFSSL_TLS13
         if (IsAtLeastTLSv1_3(ssl->version) &&
-            ssl->options.side == WOLFSSL_SERVER_END) {
+                                      ssl->options.side == WOLFSSL_SERVER_END) {
+    #ifdef HAVE_SUPPORTED_CURVES
             /* Try to establish a key share. */
             int ret = TLSX_KeyShare_Establish(ssl);
             if (ret == KEY_SHARE_ERROR)
                 ssl->options.serverState = SERVER_HELLO_RETRY_REQUEST_COMPLETE;
             else if (ret != 0)
                 return 0;
+    #endif
         }
         else if (first == TLS13_BYTE || (first == ECC_BYTE &&
                 (second == TLS_SHA256_SHA256 || second == TLS_SHA384_SHA384))) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -36121,8 +36121,10 @@ static int test_tls13_apis(void)
 #ifdef WOLFSSL_EARLY_DATA
     int          outSz;
 #endif
+#ifdef HAVE_SUPPORTED_CURVES
     int          groups[2] = { WOLFSSL_ECC_X25519, WOLFSSL_ECC_X448 };
     int          numGroups = 2;
+#endif
 #if defined(OPENSSL_EXTRA) && defined(HAVE_ECC)
     char         groupList[] = "P-521:P-384:P-256";
 #endif /* defined(OPENSSL_EXTRA) && defined(HAVE_ECC) */
@@ -36171,6 +36173,7 @@ static int test_tls13_apis(void)
 #endif
 #endif
 
+#ifdef HAVE_SUPPORTED_CURVES
 #ifdef HAVE_ECC
     AssertIntEQ(wolfSSL_UseKeyShare(NULL, WOLFSSL_ECC_SECP256R1), BAD_FUNC_ARG);
 #ifndef NO_WOLFSSL_SERVER
@@ -36235,6 +36238,7 @@ static int test_tls13_apis(void)
 #endif
     AssertIntEQ(wolfSSL_NoKeyShares(clientSsl), WOLFSSL_SUCCESS);
 #endif
+#endif /* HAVE_SUPPORTED_CURVES */
 
     AssertIntEQ(wolfSSL_CTX_no_ticket_TLSv13(NULL), BAD_FUNC_ARG);
 #ifndef NO_WOLFSSL_CLIENT
@@ -36342,6 +36346,7 @@ static int test_tls13_apis(void)
 #endif
 #endif
 
+#ifdef HAVE_SUPPORTED_CURVES
     AssertIntEQ(wolfSSL_CTX_set_groups(NULL, NULL, 0), BAD_FUNC_ARG);
 #ifndef NO_WOLFSSL_CLIENT
     AssertIntEQ(wolfSSL_CTX_set_groups(clientCtx, NULL, 0), BAD_FUNC_ARG);
@@ -36420,6 +36425,7 @@ static int test_tls13_apis(void)
                 WOLFSSL_SUCCESS);
 #endif
 #endif /* defined(OPENSSL_EXTRA) && defined(HAVE_ECC) */
+#endif /* HAVE_SUPPORTED_CURVES */
 
 #ifdef WOLFSSL_EARLY_DATA
     AssertIntEQ(wolfSSL_CTX_set_max_early_data(NULL, 0), BAD_FUNC_ARG);

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -272,6 +272,13 @@ static int IsClientAuth(const char* line, int* reqClientCert)
 
     return 0;
 }
+#endif
+
+#ifdef NO_CERTS
+static int IsUsingCert(const char* line)
+{
+    return XSTRSTR(line, "-c ") != NULL;
+}
 
 static int IsNoClientCert(const char* line)
 {
@@ -374,6 +381,14 @@ static int execute_test_case(int svr_argc, char** svr_argv,
         #ifdef DEBUG_SUITE_TESTS
             printf("client auth on line %s not supported in build\n",
                    commandLine);
+        #endif
+        return NOT_BUILT_IN;
+    }
+#endif
+#ifdef NO_CERTS
+    if (IsUsingCert(commandLine)) {
+        #ifdef DEBUG_SUITE_TESTS
+            printf("certificate %s not supported in build\n", commandLine);
         #endif
         return NOT_BUILT_IN;
     }
@@ -508,6 +523,14 @@ static int execute_test_case(int svr_argc, char** svr_argv,
         #ifdef DEBUG_SUITE_TESTS
             printf("client auth on line %s not supported in build\n",
                    commandLine);
+        #endif
+        return NOT_BUILT_IN;
+    }
+#endif
+#ifdef NO_CERTS
+    if (IsNoClientCert(commandLine)) {
+        #ifdef DEBUG_SUITE_TESTS
+            printf("certificate %s not supported in build\n", commandLine);
         #endif
         return NOT_BUILT_IN;
     }

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -239,7 +239,7 @@ int wc_Des3_CbcDecryptWithKey(byte* out, const byte* in, word32 sz,
 #endif /* !NO_DES3 */
 
 
-#ifdef WOLFSSL_ENCRYPTED_KEYS
+#if !defined(NO_ASN) && defined(WOLFSSL_ENCRYPTED_KEYS)
 
 int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
     const byte* password, int passwordSz, int hashType)
@@ -361,7 +361,7 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
     return ret;
 }
 
-#endif /* WOLFSSL_ENCRYPTED_KEYS */
+#endif /* !NO_ASN && WOLFSSL_ENCRYPTED_KEYS */
 
 
 #if !defined(NO_PWDBASED) && !defined(NO_ASN)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2169,7 +2169,7 @@ typedef enum {
     TLSX_STATUS_REQUEST             = 0x0005, /* a.k.a. OCSP stapling   */
     TLSX_SUPPORTED_GROUPS           = 0x000a, /* a.k.a. Supported Curves */
     TLSX_EC_POINT_FORMATS           = 0x000b,
-#if !defined(WOLFSSL_NO_SIGALG)
+#if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
     TLSX_SIGNATURE_ALGORITHMS       = 0x000d, /* HELLO_EXT_SIG_ALGO */
 #endif
     TLSX_APPLICATION_LAYER_PROTOCOL = 0x0010, /* a.k.a. ALPN */
@@ -2188,14 +2188,18 @@ typedef enum {
     TLSX_EARLY_DATA                 = 0x002a,
     #endif
     TLSX_SUPPORTED_VERSIONS         = 0x002b,
+    #ifdef WOLFSSL_SEND_HRR_COOKIE
     TLSX_COOKIE                     = 0x002c,
+    #endif
     #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
     TLSX_PSK_KEY_EXCHANGE_MODES     = 0x002d,
     #endif
     #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
     TLSX_POST_HANDSHAKE_AUTH        = 0x0031,
     #endif
+    #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
     TLSX_SIGNATURE_ALGORITHMS_CERT  = 0x0032,
+    #endif
     TLSX_KEY_SHARE                  = 0x0033,
 #endif
     TLSX_RENEGOTIATION_INFO         = 0xff01


### PR DESCRIPTION
Support building with only TLS 1.3 and PSK without code for (EC)DHE and
certificates.
Minimize build size for this configuration.

```
./configure --enable-psk --disable-tlsv12 --disable-ecc --disable-dh --disable-rsa CFLAGS="-DWOLFSSL_STATIC_PSK"
```