### PR TITLE
Fixes for building with Microchip

### DIFF
--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -29,10 +29,8 @@
 
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
     defined(WOLFSSL_ATECC_PKCB)
-    #undef  SHA_BLOCK_SIZE
-    #define SHA_BLOCK_SIZE  SHA_BLOCK_SIZE_REMAP
-    #include <cryptoauthlib.h>
     #undef SHA_BLOCK_SIZE
+    #include <cryptoauthlib.h>
 #endif
 
 /* ATECC508A/608A only supports ECC P-256 */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -358,12 +358,13 @@
     #define NO_FILESYSTEM
     #define USE_FAST_MATH
     #define TFM_TIMING_RESISTANT
-    #define WOLFSSL_HAVE_MIN
-    #define WOLFSSL_HAVE_MAX
     #define NO_BIG_INT
 #endif
 
 #ifdef WOLFSSL_MICROCHIP_PIC32MZ
+    #define WOLFSSL_HAVE_MIN
+    #define WOLFSSL_HAVE_MAX
+
     #ifndef NO_PIC32MZ_CRYPT
         #define WOLFSSL_PIC32MZ_CRYPT
     #endif


### PR DESCRIPTION
* The min/max patch allows non PIC32MZ parts to build in MPLABX.
* The cryptoauthlib already defines `SHA_BLOCK_SIZE`, so undef to prevent redef error.