### PR TITLE
Improve the crypto callback for ASN

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5582,14 +5582,6 @@ int CalcHashId(const byte* data, word32 len, byte* hash)
 {
     int ret;
 
-#ifdef WOLF_CRYPTO_CB
-    /* try to use a registered crypto callback */
-    ret = wc_CryptoCb_Sha256Hash(NULL, data, len, hash);
-    if (ret != CRYPTOCB_UNAVAILABLE)
-        return ret;
-    /* fall-through when unavailable */
-#endif
-
 #if defined(NO_SHA) && !defined(NO_SHA256)
     ret = wc_Sha256Hash(data, len, hash);
 #elif !defined(NO_SHA)

--- a/wolfcrypt/src/cryptocb.c
+++ b/wolfcrypt/src/cryptocb.c
@@ -82,6 +82,16 @@ void wc_CryptoCb_Init(void)
     }
 }
 
+int wc_CryptoCb_GetDevIdAtIndex(int startIdx)
+{
+    int devId = INVALID_DEVID;
+    CryptoCb* dev = wc_CryptoCb_FindDeviceByIndex(startIdx);
+    if (dev) {
+        devId = dev->devId;
+    }
+    return devId;
+}
+
 int wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb, void* ctx)
 {
     /* find existing or new */

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -33,6 +33,7 @@
 
 #include <wolfssl/wolfcrypt/hash.h>
 #include <wolfssl/wolfcrypt/hmac.h>
+#include <wolfssl/wolfcrypt/cryptocb.h>
 
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
@@ -1033,7 +1034,8 @@ int wc_HashGetFlags(wc_HashAlg* hash, enum wc_HashType type, word32* flags)
             return MEMORY_E;
     #endif
 
-        if ((ret = wc_InitSha(sha)) != 0) {
+        if ((ret = wc_InitSha_ex(sha, NULL, 
+                wc_CryptoCb_GetDevIdAtIndex(0))) != 0) {
             WOLFSSL_MSG("InitSha failed");
         }
         else {
@@ -1109,7 +1111,8 @@ int wc_HashGetFlags(wc_HashAlg* hash, enum wc_HashType type, word32* flags)
             return MEMORY_E;
     #endif
 
-        if ((ret = wc_InitSha256(sha256)) != 0) {
+        if ((ret = wc_InitSha256_ex(sha256, NULL, 
+                wc_CryptoCb_GetDevIdAtIndex(0))) != 0) {
             WOLFSSL_MSG("InitSha256 failed");
         }
         else {

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -212,7 +212,7 @@ typedef struct wc_CryptoInfo {
 typedef int (*CryptoDevCallbackFunc)(int devId, wc_CryptoInfo* info, void* ctx);
 
 WOLFSSL_LOCAL void wc_CryptoCb_Init(void);
-
+WOLFSSL_LOCAL int wc_CryptoCb_GetDevIdAtIndex(int startIdx);
 WOLFSSL_API int  wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb, void* ctx);
 WOLFSSL_API void wc_CryptoCb_UnRegisterDevice(int devId);
 
@@ -289,6 +289,10 @@ WOLFSSL_LOCAL int wc_CryptoCb_Hmac(Hmac* hmac, int macType, const byte* in,
 WOLFSSL_LOCAL int wc_CryptoCb_RandomBlock(WC_RNG* rng, byte* out, word32 sz);
 WOLFSSL_LOCAL int wc_CryptoCb_RandomSeed(OS_Seed* os, byte* seed, word32 sz);
 #endif
+
+#else
+
+#define wc_CryptoCb_GetDevIdAtIndex(idx) (INVALID_DEVID)
 
 #endif /* WOLF_CRYPTO_CB */
 


### PR DESCRIPTION
This allows a hash context to exist for the crypto callback.
wolfssl-example https://github.com/wolfSSL/wolfssl-examples/pull/232
ZD 11180