### PR TITLE
add "module", "modules_install", and "clean_module" rules for linuxkm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -162,21 +162,15 @@ include swig/include.am
 include src/include.am
 include support/include.am
 include wolfcrypt/user-crypto/include.am
-if !BUILD_LINUXKM
 include wolfcrypt/benchmark/include.am
-endif
 include wolfcrypt/src/include.am
-if !BUILD_LINUXKM
 include wolfcrypt/test/include.am
-endif
 include examples/include.am
 include testsuite/include.am
 include tests/include.am
 include sslSniffer/sslSnifferTest/include.am
 include rpm/include.am
-if BUILD_LINUXKM
 include linuxkm/include.am
-endif
 
 # Exclude references to non-DFSG sources from build files
 if !BUILD_DISTRO
@@ -212,6 +206,16 @@ if BUILD_LINUXKM
         CFLAGS_AUTO_VECTORIZE_DISABLE CFLAGS_AUTO_VECTORIZE_ENABLE \
         ASFLAGS_FPU_DISABLE_SIMD_ENABLE ASFLAGS_FPU_ENABLE_SIMD_DISABLE \
         ASFLAGS_FPUSIMD_DISABLE ASFLAGS_FPUSIMD_ENABLE
+
+module:
+	+make -C linuxkm libwolfssl.ko
+
+clean_module:
+	+make -C linuxkm clean
+
+install_module modules_install:
+	+make -C linuxkm modules_install
+
 endif
 
 if USE_VALGRIND

--- a/linuxkm/Makefile
+++ b/linuxkm/Makefile
@@ -56,14 +56,10 @@ libwolfssl.ko:
 	@mkdir -p linuxkm src wolfcrypt/src wolfcrypt/test
 	@if test ! -h $(SRC_TOP)/Kbuild; then ln -s $(MODULE_TOP)/Kbuild $(SRC_TOP)/Kbuild; fi
 	+make -C $(KERNEL_ROOT) M=$(MODULE_TOP) src=$(SRC_TOP)
-	@echo Linux kernel module build succeeded.
-	@echo Module is libwolfssl.ko in $(MODULE_TOP).
 
-.PHONY: install
-install:
-	@echo Automatic Linux kernel module installation not yet supported.
-	@echo Module is $(MODULE_TOP)/libwolfssl.ko
-	@exit 1
+.PHONY: install modules_install
+install modules_install:
+	+make -C $(KERNEL_ROOT) M=$(MODULE_TOP) src=$(SRC_TOP) INSTALL_MOD_DIR=wolfssl modules_install
 
 .PHONY: clean
 clean:

--- a/scripts/include.am
+++ b/scripts/include.am
@@ -12,9 +12,6 @@ if BUILD_EXAMPLE_SERVERS
 
 dist_noinst_SCRIPTS+= scripts/resume.test
 
-EXTRA_DIST+= scripts/benchmark.test
-EXTRA_DIST+= scripts/memtest.sh
-
 # The CRL and OCSP tests use RSA certificates.
 if BUILD_RSA
 
@@ -94,7 +91,10 @@ EXTRA_DIST +=  scripts/testsuite.pcap \
                scripts/sniffer-tls13-dh.pcap \
                scripts/sniffer-tls13-ecc.pcap \
                scripts/sniffer-tls13-gen.sh \
-               scripts/ping.test
+               scripts/ping.test \
+               scripts/benchmark.test \
+               scripts/memtest.sh
+
 
 # leave openssl.test as extra until non bash works
 EXTRA_DIST +=  scripts/openssl.test

--- a/wolfcrypt/benchmark/include.am
+++ b/wolfcrypt/benchmark/include.am
@@ -2,13 +2,18 @@
 # All paths should be given relative to the root
 
 if BUILD_WOLFCRYPT_TESTS
+if !BUILD_LINUXKM
+
 noinst_PROGRAMS += wolfcrypt/benchmark/benchmark
 wolfcrypt_benchmark_benchmark_SOURCES      = wolfcrypt/benchmark/benchmark.c
 wolfcrypt_benchmark_benchmark_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD)
 wolfcrypt_benchmark_benchmark_DEPENDENCIES = src/libwolfssl.la
 noinst_HEADERS += wolfcrypt/benchmark/benchmark.h
+
 endif
-EXTRA_DIST += wolfcrypt/benchmark/benchmark.sln 
+endif
+
+EXTRA_DIST += wolfcrypt/benchmark/benchmark.sln
 EXTRA_DIST += wolfcrypt/benchmark/benchmark.vcproj
 EXTRA_DIST += wolfcrypt/benchmark/README.md
 DISTCLEANFILES+= wolfcrypt/benchmark/.libs/benchmark

--- a/wolfcrypt/test/include.am
+++ b/wolfcrypt/test/include.am
@@ -2,6 +2,8 @@
 # All paths should be given relative to the root
 
 if BUILD_WOLFCRYPT_TESTS
+if !BUILD_LINUXKM
+
 noinst_PROGRAMS+= wolfcrypt/test/testwolfcrypt
 if BUILD_CRYPTONLY
 check_PROGRAMS+= wolfcrypt/test/testwolfcrypt
@@ -11,7 +13,10 @@ wolfcrypt_test_testwolfcrypt_SOURCES      = wolfcrypt/test/test.c
 wolfcrypt_test_testwolfcrypt_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD)
 wolfcrypt_test_testwolfcrypt_DEPENDENCIES = src/libwolfssl.la
 noinst_HEADERS += wolfcrypt/test/test.h
+
 endif
+endif
+
 EXTRA_DIST += wolfcrypt/test/test.sln
 EXTRA_DIST += wolfcrypt/test/test.vcproj
 EXTRA_DIST += wolfcrypt/test/README.md


### PR DESCRIPTION
add "module", "modules_install", and "clean_module" rules to BUILD_LINUXKM section of Makefile.am, and add working install rule to linuxkm/Makefile, so that "make module" and "make modules_install" now work when --enable-linuxkm.
