### PR TITLE
Fix build issue when building wolfrand on a Freescale platform.

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1070,7 +1070,9 @@ extern void uITRON4_free(void *p) ;
     #define ECC_TIMING_RESISTANT
 
     #undef  HAVE_ECC
+    #ifndef WOLFCRYPT_FIPS_RAND
     #define HAVE_ECC
+    #endif
     #ifndef NO_AES
         #undef  HAVE_AESCCM
         #define HAVE_AESCCM
@@ -1165,7 +1167,9 @@ extern void uITRON4_free(void *p) ;
         #endif
 
         #if defined(FSL_FEATURE_LTC_HAS_PKHA) && FSL_FEATURE_LTC_HAS_PKHA
+            #ifndef WOLFCRYPT_FIPS_RAND
             #define FREESCALE_LTC_ECC
+            #endif
             #define FREESCALE_LTC_TFM
 
             /* the LTC PKHA hardware limit is 2048 bits (256 bytes) for integer arithmetic.


### PR DESCRIPTION
This fixes building wolfrand FIPS on Freescale platforms, since we don't have a NO_ECC flag, I have to prevent HAVE_ECC being defined if we're using wolfrand.