### PR TITLE
Fix building test.c with NO_FILESYSTEM defined.

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -19746,10 +19746,12 @@ static int ecc_test_key_gen(WC_RNG* rng, int keySize)
         ERROR_OUT(-9640, done);
     }
 
+#ifndef NO_FILESYSTEM
     ret = SaveDerAndPem(der, derSz, eccPubKeyDerFile, NULL, 0, -8348);
     if (ret != 0) {
         goto done;
     }
+#endif /* NO_FILESYSTEM */
 
 #ifdef HAVE_PKCS8
     /* test export of PKCS#8 unencrypted private key */
@@ -19763,10 +19765,12 @@ static int ecc_test_key_gen(WC_RNG* rng, int keySize)
         ERROR_OUT(-9641, done);
     }
 
+#ifndef NO_FILESYSTEM
     ret = SaveDerAndPem(der, derSz, eccPkcs8KeyDerFile, NULL, 0, -8349);
     if (ret != 0) {
         goto done;
     }
+#endif /* NO_FILESYSTEM */
 #endif /* HAVE_PKCS8 */
 
 done:


### PR DESCRIPTION
If NO_FILESYSTEM is defined, eccPubKeyDerFile is not defined, so test.c fails to compile.  Fix by ifdefing out the parts of the test which are using files.