### PR TITLE
rc2.c to Visual Studio projects, fix warnings

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -9373,7 +9373,7 @@ int CheckForAltNames(DecodedCert* dCert, const char* domain, int* checkCN)
                 XMEMSET(tmp, 0, sizeof(tmp));
                 XSNPRINTF(tmp, sizeof(tmp), (altName->len <= 4) ? "%u" : "%02X",
                         altName->name[i]);
-                idx += XSTRLEN(tmp);
+                idx += (word32)XSTRLEN(tmp);
                 XSTRNCAT(name, tmp, (altName->len <= 4) ? 3 : 2);
                 if ((idx < WOLFSSL_MAX_IPSTR ) && ((i + 1) < altName->len)) {
                     name[idx++] = (altName->len <= 4) ? '.' : ':';

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -41207,12 +41207,12 @@ int wolfSSL_BIO_new_bio_pair(WOLFSSL_BIO **bio1_p, size_t writebuf1,
         }
     }
     if (ret && writebuf1) {
-        if (!(ret = wolfSSL_BIO_set_write_buf_size(bio1, writebuf1))) {
+        if (!(ret = wolfSSL_BIO_set_write_buf_size(bio1, (long)writebuf1))) {
             WOLFSSL_MSG("wolfSSL_BIO_set_write_buf() failure");
         }
     }
     if (ret && writebuf2) {
-        if (!(ret = wolfSSL_BIO_set_write_buf_size(bio2, writebuf2))) {
+        if (!(ret = wolfSSL_BIO_set_write_buf_size(bio2, (long)writebuf2))) {
             WOLFSSL_MSG("wolfSSL_BIO_set_write_buf() failure");
         }
     }

--- a/wolfssl-ntru.vcproj
+++ b/wolfssl-ntru.vcproj
@@ -291,6 +291,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\wolfcrypt\src\rc2.c"
+				>
+			</File>
+			<File
 				RelativePath=".\wolfcrypt\src\ripemd.c"
 				>
 			</File>

--- a/wolfssl.vcproj
+++ b/wolfssl.vcproj
@@ -320,6 +320,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\wolfcrypt\src\rc2.c"
+				>
+			</File>
+			<File
 				RelativePath=".\wolfcrypt\src\ripemd.c"
 				>
 			</File>

--- a/wolfssl.vcxproj
+++ b/wolfssl.vcxproj
@@ -321,6 +321,7 @@
     <ClCompile Include="wolfcrypt\src\pwdbased.c" />
     <ClCompile Include="wolfcrypt\src\rabbit.c" />
     <ClCompile Include="wolfcrypt\src\random.c" />
+    <ClCompile Include="wolfcrypt\src\rc2.c" />
     <ClCompile Include="wolfcrypt\src\ripemd.c" />
     <ClCompile Include="wolfcrypt\src\rsa.c" />
     <ClCompile Include="wolfcrypt\src\sha.c" />


### PR DESCRIPTION
This PR adds rc2.c to Visual Studio project files in case users want to define WC_RC2.  It also fixes three Visual Studio 2017 type conversion/cast warnings.