### PR TITLE
cpuid and SP ASM: ensure WOLFSSL_X86_64_BUILD is defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4883,11 +4883,16 @@ if test "$ENABLED_SP_ASM" = "yes"; then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_X86_64_ASM"
     AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_X86_64_ASM"
     ENABLED_SP_X86_64_ASM=yes
+    if test "x$ENABLED_FASTMATH" = "xno"
+    then
+      AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_X86_64_BUILD"
+    fi
     ;;
   *)
     AC_MSG_ERROR([ASM not available for CPU. Supported CPUs: x86_64, aarch64, arm])
     ;;
   esac
+
 fi
 
 if test "$ENABLED_SP_MATH" = "yes"; then

--- a/wolfcrypt/src/cpuid.c
+++ b/wolfcrypt/src/cpuid.c
@@ -29,8 +29,7 @@
 #include <wolfssl/wolfcrypt/cpuid.h>
 
 #if (defined(WOLFSSL_X86_64_BUILD) || defined(USE_INTEL_SPEEDUP) || \
-     defined(WOLFSSL_AESNI) || defined(WOLFSSL_SP_ASM)) && \
-     !defined(WOLFSSL_NO_ASM)
+     defined(WOLFSSL_AESNI)) && !defined(WOLFSSL_NO_ASM)
     /* Each platform needs to query info type 1 from cpuid to see if aesni is
      * supported. Also, let's setup a macro for proper linkage w/o ABI conflicts
      */

--- a/wolfssl/wolfcrypt/cpuid.h
+++ b/wolfssl/wolfcrypt/cpuid.h
@@ -33,7 +33,8 @@
 #endif
 
 #if defined(WOLFSSL_X86_64_BUILD) || defined(USE_INTEL_SPEEDUP) || \
-    defined(WOLFSSL_AESNI) || defined(WOLFSSL_SP_ASM)
+    defined(WOLFSSL_AESNI)
+
     #define CPUID_AVX1   0x0001
     #define CPUID_AVX2   0x0002
     #define CPUID_RDRAND 0x0004


### PR DESCRIPTION
WOLFSSL_X86_64_BUILD is defined only when fast math is enabled.
Define it when SP ASM is enabled and on an x86_64 host.
Undo cpuid code being enabled when WOLFSSL_SP_ASM as it shouldn't for
non-Intel CPUs.