### PR TITLE
Hush Unused Param Warning

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20946,11 +20946,9 @@ int wolfSSL_X509_cmp(const WOLFSSL_X509 *a, const WOLFSSL_X509 *b)
     {
         WOLFSSL_ENTER("wolfSSL_X509_print_ex");
 
-    #ifndef NO_WOLFSSL_STUB
         /* flags currently not supported */
         (void)nmflags;
         (void)cflag;
-    #endif
 
         if (bio == NULL || x509 == NULL) {
             return WOLFSSL_FAILURE;


### PR DESCRIPTION
Removed a guard check for NO_WOLFSSL_STUB from wolfSSL_X509_print_ex(). To recreate:

    $ ./configure --enable-opensslextra CPPFLAGS="-DNO_WOLFSSL_STUB"
    $ make

(ZD 11221)