### PR TITLE
Fixes for various build configurations

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -48359,12 +48359,15 @@ int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
     }
     if (ret == 0 && enc == NULL) {
         type = PKCS8_PRIVATEKEY_TYPE;
+    #ifdef HAVE_ECC
         if (pkey->type == EVP_PKEY_EC) {
             algId = ECDSAk;
             ret = wc_ecc_get_oid(pkey->ecc->group->curve_oid, &curveOid,
                                                                         &oidSz);
         }
-        else {
+        else
+    #endif
+        {
             algId = RSAk;
             curveOid = NULL;
             oidSz = 0;

--- a/tests/api.c
+++ b/tests/api.c
@@ -22146,7 +22146,9 @@ static int test_wc_SetSubjectKeyIdFromPublicKey_ex (void)
     RsaKey          rsaKey;
     int             bits = 2048;
 #endif
+#if defined(HAVE_ECC)
     ecc_key         eccKey;
+#endif
 #if defined(HAVE_ED448)
     ed448_key       ed448Key;
 #endif
@@ -22185,6 +22187,7 @@ static int test_wc_SetSubjectKeyIdFromPublicKey_ex (void)
         wc_FreeRsaKey(&rsaKey);
     }
 #endif
+#if defined(HAVE_ECC)
     if (ret == 0) { /*ECC*/
         ret = wc_ecc_init(&eccKey);
         if (ret == 0) {
@@ -22195,6 +22198,7 @@ static int test_wc_SetSubjectKeyIdFromPublicKey_ex (void)
         }
         wc_ecc_free(&eccKey);
     }
+#endif
 #if defined(HAVE_ED448) && (defined(WOLFSSL_CERT_GEN) || \
                               defined(WOLFSSL_KEY_GEN))
 
@@ -22233,7 +22237,9 @@ static int test_wc_SetAuthKeyIdFromPublicKey_ex (void)
     RsaKey          rsaKey;
     int             bits = 2048;
 #endif
+#if defined(HAVE_ECC)
     ecc_key         eccKey;
+#endif
 #if defined(HAVE_ED448)
     ed448_key       ed448Key;
 #endif
@@ -22272,6 +22278,7 @@ static int test_wc_SetAuthKeyIdFromPublicKey_ex (void)
         wc_FreeRsaKey(&rsaKey);
     }
 #endif
+#if defined(HAVE_ECC)
     if (ret == 0) { /*ECC*/
         ret = wc_ecc_init(&eccKey);
         if (ret == 0) {
@@ -22282,6 +22289,7 @@ static int test_wc_SetAuthKeyIdFromPublicKey_ex (void)
         }
         wc_ecc_free(&eccKey);
     }
+#endif
 #if defined(HAVE_ED448) && (defined(WOLFSSL_CERT_GEN) || \
                               defined(WOLFSSL_KEY_GEN))
 
@@ -29249,7 +29257,9 @@ static void test_wolfSSL_PKCS8_d2i(void)
     XFILE file;
 #ifndef NO_BIO
     BIO* bio;
+    #if defined(HAVE_ECC)
     WOLFSSL_EVP_PKEY* evpPkey = NULL;
+    #endif
 #endif
 #endif
     #ifndef NO_RSA
@@ -34759,6 +34769,7 @@ static void test_wolfSSL_EVP_PKEY_derive(void)
     EVP_PKEY *pkey, *peerkey;
     const unsigned char* key;
 
+#ifndef NO_DH
     /* DH */
     key = dh_key_der_2048;
     AssertNotNull((pkey = d2i_PrivateKey(EVP_PKEY_DH, NULL, &key,
@@ -34779,6 +34790,7 @@ static void test_wolfSSL_EVP_PKEY_derive(void)
     EVP_PKEY_free(peerkey);
     EVP_PKEY_free(pkey);
     XFREE(skey, NULL, DYNAMIC_TYPE_OPENSSL);
+#endif
 
 #ifdef HAVE_ECC
     /* ECDH */

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7875,6 +7875,7 @@ int wc_ecc_import_private_key_ex(const byte* priv, word32 privSz,
             ret = wc_EccPublicKeyDecode(pub, &idx, key, pubSz);
         key->type = ECC_PRIVATEKEY;
     #else
+        (void)pubSz;
         ret = NOT_COMPILED_IN;
     #endif
     }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6359,6 +6359,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
         /* perform blocking call to non-blocking function */
         ecc_nb_ctx_t nb_ctx;
         XMEMSET(&nb_ctx, 0, sizeof(nb_ctx));
+        err = NOT_COMPILED_IN; /* set default error */
     #endif
     #ifndef WOLFSSL_SP_NO_256
         if (ecc_sets[key->idx].id == ECC_SECP256R1) {

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1432,7 +1432,7 @@ int wolfSSL_EVP_PKEY_derive_set_peer(WOLFSSL_EVP_PKEY_CTX *ctx, WOLFSSL_EVP_PKEY
     return WOLFSSL_SUCCESS;
 }
 
-#if !defined(NO_DH) && defined(HAVE_ECC)
+#if !defined(NO_DH) || defined(HAVE_ECC)
 #if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION!=2))
 int wolfSSL_EVP_PKEY_derive(WOLFSSL_EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen)
 {
@@ -1542,7 +1542,7 @@ int wolfSSL_EVP_PKEY_derive(WOLFSSL_EVP_PKEY_CTX *ctx, unsigned char *key, size_
     return WOLFSSL_SUCCESS;
 }
 #endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
-#endif
+#endif /* !NO_DH || HAVE_ECC */
 
 /* Uses the WOLFSSL_EVP_PKEY_CTX to decrypt a buffer.
  *

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -19349,7 +19349,7 @@ done:
 /* returns 0 on success */
 static int ecc_test_make_pub(WC_RNG* rng)
 {
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     ecc_key *key = (ecc_key *)XMALLOC(sizeof *key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 #if defined(HAVE_ECC_DHE) && defined(HAVE_ECC_KEY_EXPORT)
     ecc_key *pub = (ecc_key *)XMALLOC(sizeof *pub, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -19372,7 +19372,7 @@ static int ecc_test_make_pub(WC_RNG* rng)
     int verify = 0;
 #endif
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     if ((key == NULL) ||
 #if defined(HAVE_ECC_DHE) && defined(HAVE_ECC_KEY_EXPORT)
         (pub == NULL) ||
@@ -19451,6 +19451,7 @@ static int ecc_test_make_pub(WC_RNG* rng)
     }
     TEST_SLEEP();
 
+#ifndef WOLFSSL_NO_MALLOC
     pubPoint = wc_ecc_new_point_h(HEAP_HINT);
     if (pubPoint == NULL) {
         ERROR_OUT(-9625, done);
@@ -19471,6 +19472,7 @@ static int ecc_test_make_pub(WC_RNG* rng)
         ERROR_OUT(-9627, done);
     }
 #endif /* HAVE_ECC_KEY_EXPORT */
+#endif /* !WOLFSSL_NO_MALLOC */
 #endif /* !NO_ECC256 */
 
     /* create a new key since above test for loading key is not supported */
@@ -19590,7 +19592,7 @@ done:
 
     wc_ecc_del_point_h(pubPoint, HEAP_HINT);
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     if (key != NULL) {
         wc_ecc_free(key);
         XFREE(key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -20256,9 +20258,10 @@ static int ecc_test_curve(WC_RNG* rng, int keySize)
     return 0;
 }
 
-#if !defined(NO_ECC256) || defined(HAVE_ALL_CURVES)
+#if (!defined(NO_ECC256) || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 256
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
-    defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT)
+    defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT) && \
+    !defined(WOLFSSL_NO_MALLOC)
 static int ecc_point_test(void)
 {
     int        ret;
@@ -21919,7 +21922,8 @@ static int ecc_test(void)
         goto done;
     }
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
-    defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT)
+    defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT) && \
+    !defined(WOLFSSL_NO_MALLOC)
     ret = ecc_point_test();
     if (ret < 0) {
         goto done;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -10663,7 +10663,7 @@ static int random_rng_test(void)
 
     if (ret != 0) return ret;
 
-#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && !defined(WOLFSSL_NO_MALLOC)
     {
         byte nonce[8] = { 0 };
         /* Test dynamic RNG. */
@@ -10834,7 +10834,7 @@ static int simple_mem_test(int sz)
 static int memory_test(void)
 {
     int ret = 0;
-#ifndef USE_FAST_MATH
+#if !defined(USE_FAST_MATH) && !defined(WOLFSSL_NO_MALLOC)
     byte* b = NULL;
 #endif
 #if defined(COMPLEX_MEM_TEST) || defined(WOLFSSL_STATIC_MEMORY)
@@ -10951,7 +10951,7 @@ static int memory_test(void)
     }
 #endif
 
-#ifndef USE_FAST_MATH
+#if !defined(USE_FAST_MATH) && !defined(WOLFSSL_NO_MALLOC)
     /* realloc test */
     b = (byte*)XMALLOC(MEM_TEST_SZ, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (b) {
@@ -19610,6 +19610,7 @@ done:
     return ret;
 }
 
+#if defined(HAVE_ECC_KEY_EXPORT) && !defined(NO_ASN_CRYPT)
 static int ecc_test_key_decode(WC_RNG* rng, int keySize)
 {
     int ret;
@@ -19687,8 +19688,10 @@ static int ecc_test_key_decode(WC_RNG* rng, int keySize)
 
     return ret;
 }
+#endif /* HAVE_ECC_KEY_EXPORT && !NO_ASN_CRYPT */
 #endif /* HAVE_ECC_KEY_IMPORT */
 
+#if defined(HAVE_ECC_KEY_EXPORT) && !defined(NO_ASN_CRYPT)
 static int ecc_test_key_gen(WC_RNG* rng, int keySize)
 {
     int    ret = 0;
@@ -19784,6 +19787,7 @@ done:
 
     return ret;
 }
+#endif /* HAVE_ECC_KEY_EXPORT && !NO_ASN_CRYPT */
 
 static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     int curve_id, const ecc_set_type* dp)
@@ -20222,6 +20226,8 @@ static int ecc_test_curve(WC_RNG* rng, int keySize)
     }
 #endif
 
+#if defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT) && \
+    !defined(NO_ASN_CRYPT)
     ret = ecc_test_key_decode(rng, keySize);
     if (ret < 0) {
         if (ret == ECC_CURVE_OID_E) {
@@ -20232,7 +20238,9 @@ static int ecc_test_curve(WC_RNG* rng, int keySize)
             return ret;
         }
     }
+#endif
 
+#if defined(HAVE_ECC_KEY_EXPORT) && !defined(NO_ASN_CRYPT)
     ret = ecc_test_key_gen(rng, keySize);
     if (ret < 0) {
         if (ret == ECC_CURVE_OID_E) {
@@ -20243,6 +20251,7 @@ static int ecc_test_curve(WC_RNG* rng, int keySize)
             return ret;
         }
     }
+#endif
 
     return 0;
 }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -21393,7 +21393,7 @@ exit:
 }
 #endif /* WOLFSSL_CERT_GEN */
 
-#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && !defined(WOLFSSL_NO_MALLOC)
 /* Test for the wc_ecc_key_new() and wc_ecc_key_free() functions. */
 static int ecc_test_allocator(WC_RNG* rng)
 {
@@ -21993,10 +21993,11 @@ static int ecc_test(void)
         goto done;
     }
 #endif
-#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && !defined(WOLFSSL_NO_MALLOC)
     ret = ecc_test_allocator(&rng);
     if (ret != 0) {
         printf("ecc_test_allocator failed!: %d\n", ret);
+        goto done;
     }
 #endif
 
@@ -22005,6 +22006,7 @@ static int ecc_test(void)
     ret = ecc_test_nonblock(&rng);
     if (ret != 0) {
         printf("ecc_test_nonblock failed!: %d\n", ret);
+        goto done;
     }
 #endif
 
@@ -22217,7 +22219,8 @@ done:
 #if defined(USE_CERT_BUFFERS_256) && !defined(WOLFSSL_ATECC508A) && \
     !defined(WOLFSSL_ATECC608A) && !defined(NO_ECC256) && \
     defined(HAVE_ECC_VERIFY) && defined(HAVE_ECC_SIGN)
-static int ecc_test_buffers(void) {
+static int ecc_test_buffers(void)
+{
     size_t bytes;
 #ifdef WOLFSSL_SMALL_STACK
     ecc_key *cliKey = (ecc_key *)XMALLOC(sizeof *cliKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);


### PR DESCRIPTION
* Fixes for building with `--disable-ecc` or `--disable-dh`.
* Fix for unused parameter with `NO_ASN` in ECC.
* Fixes for building with `WOLFSSL_NO_MALLOC` and/or `NO_ASN_CRYPT` defined.
* Fix for Coverity report with possible use of uninitialized value "err" in `WC_ECC_NONBLOCK` case. 