### PR TITLE
sha256.c/sha512.c: refactor 4 instances of gccism ({}) to WC_INLINE functions

### DIFF
--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -313,24 +313,27 @@ static int InitSha256(wc_Sha256* sha256)
     static word32 intel_flags;
     static int Transform_Sha256_is_vectorized = 0;
 
-    #define XTRANSFORM(S, D) ({                        \
-        int _ret;                                      \
-        if (Transform_Sha256_is_vectorized)            \
-            SAVE_VECTOR_REGISTERS();                   \
-        _ret = (*Transform_Sha256_p)((S),(D));         \
-        if (Transform_Sha256_is_vectorized)            \
-            RESTORE_VECTOR_REGISTERS();                \
-        _ret;                                          \
-    })
-    #define XTRANSFORM_LEN(S, D, L) ({                 \
-        int _ret;                                      \
-        if (Transform_Sha256_is_vectorized)            \
-            SAVE_VECTOR_REGISTERS();                   \
-        _ret = (*Transform_Sha256_Len_p)((S),(D),(L)); \
-        if (Transform_Sha256_is_vectorized)            \
-            RESTORE_VECTOR_REGISTERS();                \
-        _ret;                                          \
-    })
+    static WC_INLINE int inline_XTRANSFORM(wc_Sha256* S, const byte* D) {
+        int ret;
+        if (Transform_Sha256_is_vectorized)
+            SAVE_VECTOR_REGISTERS();
+        ret = (*Transform_Sha256_p)(S, D);
+        if (Transform_Sha256_is_vectorized)
+            RESTORE_VECTOR_REGISTERS();
+        return ret;
+    }
+#define XTRANSFORM(...) inline_XTRANSFORM(__VA_ARGS__)
+
+    static WC_INLINE int inline_XTRANSFORM_LEN(wc_Sha256* S, const byte* D, word32 L) {
+        int ret;
+        if (Transform_Sha256_is_vectorized)
+            SAVE_VECTOR_REGISTERS();
+        ret = (*Transform_Sha256_Len_p)(S, D, L);
+        if (Transform_Sha256_is_vectorized)
+            RESTORE_VECTOR_REGISTERS();
+        return ret;
+    }
+#define XTRANSFORM_LEN(...) inline_XTRANSFORM_LEN(__VA_ARGS__)
 
     static void Sha256_SetTransform(void)
     {

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -338,30 +338,25 @@ static int InitSha512(wc_Sha512* sha512)
     static int transform_check = 0;
     static int intel_flags;
     static int Transform_Sha512_is_vectorized = 0;
-#if 0
-    #define Transform_Sha512(sha512)     (*Transform_Sha512_p)(sha512)
-    #define Transform_Sha512_Len(sha512, len) \
-                                          (*Transform_Sha512_Len_p)(sha512, len)
-#endif
 
-    #define Transform_Sha512(sha512) ({                \
-        int _ret;                                      \
-        if (Transform_Sha512_is_vectorized)            \
-            SAVE_VECTOR_REGISTERS();                   \
-        _ret = (*Transform_Sha512_p)(sha512);          \
-        if (Transform_Sha512_is_vectorized)            \
-            RESTORE_VECTOR_REGISTERS();                \
-        _ret;                                          \
-    })
-#define Transform_Sha512_Len(sha512, len) ({           \
-        int _ret;                                      \
-        if (Transform_Sha512_is_vectorized)            \
-            SAVE_VECTOR_REGISTERS();                   \
-        _ret = (*Transform_Sha512_Len_p)(sha512, len); \
-        if (Transform_Sha512_is_vectorized)            \
-            RESTORE_VECTOR_REGISTERS();                \
-        _ret;                                          \
-    })
+    static WC_INLINE int Transform_Sha512(wc_Sha512 *sha512) {
+        int ret;
+        if (Transform_Sha512_is_vectorized)
+            SAVE_VECTOR_REGISTERS();
+        ret = (*Transform_Sha512_p)(sha512);
+        if (Transform_Sha512_is_vectorized)
+            RESTORE_VECTOR_REGISTERS();
+        return ret;
+    }
+    static WC_INLINE int Transform_Sha512_Len(wc_Sha512 *sha512, word32 len) {
+        int ret;
+        if (Transform_Sha512_is_vectorized)
+            SAVE_VECTOR_REGISTERS();
+        ret = (*Transform_Sha512_Len_p)(sha512, len);
+        if (Transform_Sha512_is_vectorized)
+            RESTORE_VECTOR_REGISTERS();
+        return ret;
+    }
 
     static void Sha512_SetTransform(void)
     {


### PR DESCRIPTION
offending code was introduced with LKM megapatch #3244 .
