### PR TITLE
Scan-Build Fixes

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -2340,7 +2340,7 @@ WOLFSSL_API void       wolfSSL_flush_sessions(WOLFSSL_CTX*, long);
     \brief This function associates the client session with the server id.
     If the newSession flag is on, an existing session won’t be reused.
 
-    \return SSL_SUCCESS returned if the finction executed without error.
+    \return SSL_SUCCESS returned if the function executed without error.
     \return BAD_FUNC_ARG returned if the WOLFSSL struct or id parameter
     is NULL or if len is not greater than zero.
 
@@ -2361,7 +2361,7 @@ WOLFSSL_API void       wolfSSL_flush_sessions(WOLFSSL_CTX*, long);
     …
     int ret = wolfSSL_SetServerID(ssl, id, len, newSession);
 
-    if(ret){
+    if (ret == WOLFSSL_SUCCESS) {
 	    // The Id was successfully set
     }
     \endcode

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2451,7 +2451,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 
 #ifdef OPENSSL_EXTRA
     {
-        byte*  rnd;
+        byte*  rnd = NULL;
         byte*  pt;
         size_t size;
 
@@ -2461,8 +2461,10 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             err_sys_ex(runWithErrors, "error getting server random buffer "
                        "size");
         }
+        else {
+            rnd = (byte*)XMALLOC(size, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        }
 
-        rnd = (byte*)XMALLOC(size, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (rnd == NULL) {
             err_sys_ex(runWithErrors, "error creating server random buffer");
         }

--- a/src/internal.c
+++ b/src/internal.c
@@ -17312,13 +17312,18 @@ int SendCertificateRequest(WOLFSSL* ssl)
     (void)i;
 
         if (IsEncryptionOn(ssl, 1)) {
-            byte* input;
+            byte* input = NULL;
             int   inputSz = i; /* build msg adds rec hdr */
             int   recordHeaderSz = RECORD_HEADER_SZ;
 
             if (ssl->options.dtls)
                 recordHeaderSz += DTLS_RECORD_EXTRA;
             inputSz -= recordHeaderSz;
+
+            if (inputSz <= 0) {
+                WOLFSSL_MSG("Send Cert Req bad inputSz");
+                return BUFFER_E;
+            }
 
             input = (byte*)XMALLOC(inputSz, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
             if (input == NULL)
@@ -26691,6 +26696,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     #endif /* WOLFSSL_ASYNC_CRYPT */
 
         /* Final cleanup */
+        if (args->input != NULL) {
+            XFREE(args->input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
+            args->input = NULL;
+        }
         FreeSskeArgs(ssl, args);
         FreeKeyExchange(ssl);
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28041,8 +28041,10 @@ WOLFSSL_SESSION* wolfSSL_d2i_SSL_SESSION(WOLFSSL_SESSION** sess,
     *p += idx;
 
 end:
-    if (ret != 0 && (sess == NULL || *sess != s))
+    if (ret != 0 && (sess == NULL || *sess != s)) {
         wolfSSL_SESSION_free(s);
+        s = NULL;
+    }
 #endif
     return s;
 }
@@ -29875,8 +29877,14 @@ int wolfSSL_DH_generate_key(WOLFSSL_DH* dh)
         } else {
             privSz = pubSz;
         }
-        pub   = (unsigned char*)XMALLOC(pubSz,  NULL, DYNAMIC_TYPE_PUBLIC_KEY);
-        priv  = (unsigned char*)XMALLOC(privSz, NULL, DYNAMIC_TYPE_PRIVATE_KEY);
+        if (pubSz > 0) {
+            pub = (unsigned char*)XMALLOC(pubSz,
+                    NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+        }
+        if (privSz > 0) {
+            priv = (unsigned char*)XMALLOC(privSz,
+                    NULL, DYNAMIC_TYPE_PRIVATE_KEY);
+        }
         if (pub == NULL || priv == NULL) {
             WOLFSSL_MSG("Unable to malloc memory");
         }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10530,7 +10530,7 @@ int wolfSSL_SetServerID(WOLFSSL* ssl, const byte* id, int len, int newSession)
         if (session) {
             if (SetSession(ssl, session) != WOLFSSL_SUCCESS) {
     #ifdef HAVE_EXT_CACHE
-                wolfSSL_SESSION_free(session);
+                FreeSession(session, 0);
     #endif
                 WOLFSSL_MSG("SetSession failed");
                 session = NULL;
@@ -10546,7 +10546,7 @@ int wolfSSL_SetServerID(WOLFSSL* ssl, const byte* id, int len, int newSession)
     }
     #ifdef HAVE_EXT_CACHE
     else
-        wolfSSL_SESSION_free(session);
+        FreeSession(session, 0);
     #endif
 
     return WOLFSSL_SUCCESS;
@@ -13344,7 +13344,7 @@ int AddSession(WOLFSSL* ssl)
     if (error == 0 && ssl->ctx->new_sess_cb != NULL)
         ssl->ctx->new_sess_cb(ssl, session);
     if (ssl->options.internalCacheOff)
-        wolfSSL_SESSION_free(session);
+        FreeSession(session, 0);
 #endif
 
     return error;
@@ -19854,7 +19854,7 @@ WOLFSSL_SESSION* wolfSSL_SESSION_dup(WOLFSSL_SESSION* session)
 #endif /* HAVE_EXT_CACHE */
 }
 
-void wolfSSL_SESSION_free(WOLFSSL_SESSION* session)
+void FreeSession(WOLFSSL_SESSION* session, int isAlloced)
 {
     if (session == NULL)
         return;
@@ -19878,7 +19878,7 @@ void wolfSSL_SESSION_free(WOLFSSL_SESSION* session)
     wc_UnLockMutex(&session->refMutex);
 #endif
 #if defined(HAVE_EXT_CACHE) || defined(OPENSSL_EXTRA)
-    if (session->isAlloced) {
+    if (isAlloced) {
     #ifdef HAVE_SESSION_TICKET
         if (session->isDynamic)
             XFREE(session->ticket, NULL, DYNAMIC_TYPE_SESSION_TICK);
@@ -19888,9 +19888,22 @@ void wolfSSL_SESSION_free(WOLFSSL_SESSION* session)
 #else
     /* No need to free since cache is static */
     (void)session;
+    (void)isAlloced;
 #endif
 }
+
+void wolfSSL_SESSION_free(WOLFSSL_SESSION* session)
+{
+    if (session == NULL)
+        return;
+    
+#if defined(HAVE_EXT_CACHE) || defined(OPENSSL_EXTRA)
+    FreeSession(session, session->isAlloced);
+#else
+    FreeSession(session, 0);
 #endif
+}
+#endif /* OPENSSL_EXTRA || HAVE_EXT_CACHE */
 
 
 /* helper function that takes in a protocol version struct and returns string */

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -3203,9 +3203,9 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
 {
 #ifdef WOLFSSL_SP_SMALL
     sp_digit* d = NULL;
-    sp_digit* a;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* a = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     sp_digit* norm;
     sp_digit e[1] = {0};
     sp_digit mp;
@@ -7090,9 +7090,9 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
 {
 #ifdef WOLFSSL_SP_SMALL
     sp_digit* d = NULL;
-    sp_digit* a;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* a = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     sp_digit* norm;
     sp_digit e[1] = {0};
     sp_digit mp;
@@ -11144,9 +11144,9 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
 {
 #ifdef WOLFSSL_SP_SMALL
     sp_digit* d = NULL;
-    sp_digit* a;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* a = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     sp_digit* norm;
     sp_digit e[1] = {0};
     sp_digit mp;

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -2843,9 +2843,9 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
 {
 #ifdef WOLFSSL_SP_SMALL
     sp_digit* d = NULL;
-    sp_digit* a;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* a = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     sp_digit* norm;
     sp_digit e[1] = {0};
     sp_digit mp;
@@ -7005,9 +7005,9 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
 {
 #ifdef WOLFSSL_SP_SMALL
     sp_digit* d = NULL;
-    sp_digit* a;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* a = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     sp_digit* norm;
     sp_digit e[1] = {0};
     sp_digit mp;
@@ -11403,9 +11403,9 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, mp_int* em, mp_int* mm,
 {
 #ifdef WOLFSSL_SP_SMALL
     sp_digit* d = NULL;
-    sp_digit* a;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* a = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     sp_digit* norm;
     sp_digit e[1] = {0};
     sp_digit mp;

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -2321,9 +2321,11 @@ int sp_prime_is_prime_ex(sp_int* a, int t, int* result, WC_RNG* rng)
     if (a == NULL || result == NULL || rng == NULL)
         err = MP_VAL;
 
-    if (sp_isone(a)) {
-        *result = MP_NO;
-        return MP_OKAY;
+    if (err == MP_OKAY) {
+        if (sp_isone(a)) {
+            *result = MP_NO;
+            return MP_OKAY;
+        }
     }
 
     if (err == MP_OKAY && a->used == 1) {
@@ -2410,7 +2412,8 @@ int sp_prime_is_prime_ex(sp_int* a, int t, int* result, WC_RNG* rng)
     (void)t;
 #endif /* !WC_NO_RNG */
 
-    *result = ret;
+    if (result != NULL)
+        *result = ret;
     return err;
 }
 

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -927,6 +927,9 @@ static int sp_div(sp_int* a, sp_int* d, sp_int* r, sp_int* rem)
             d = sd;
         }
 
+        if (d->used < 0)
+            err = MP_VAL;
+
         tr->used = sa->used - d->used + 1;
         sp_clear(tr);
         tr->used = sa->used - d->used + 1;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3221,14 +3221,14 @@ struct WOLFSSL_SESSION {
 };
 
 
-WOLFSSL_LOCAL
-WOLFSSL_SESSION* GetSession(WOLFSSL*, byte*, byte);
-WOLFSSL_LOCAL
-int          SetSession(WOLFSSL*, WOLFSSL_SESSION*);
+WOLFSSL_LOCAL WOLFSSL_SESSION* GetSession(WOLFSSL*, byte*, byte);
+WOLFSSL_LOCAL int              SetSession(WOLFSSL*, WOLFSSL_SESSION*);
+WOLFSSL_LOCAL void             FreeSession(WOLFSSL_SESSION*, int);
 
 typedef int (*hmacfp) (WOLFSSL*, byte*, const byte*, word32, int, int, int, int);
 
 #ifndef NO_CLIENT_CACHE
+    WOLFSSL_LOCAL
     WOLFSSL_SESSION* GetSessionClient(WOLFSSL*, const byte*, int);
 #endif
 


### PR DESCRIPTION
1. Fixed a couple possible 0 byte allocations.
2. Fixed a couple missed frees due to error conditions.
3. Fixed a possible double free.
4. Fixed a possible garbage value in binary operation.
5. Fix for a possible dereference of a NULL pointer.
6. Fix for a few possible uninitialized pointers.
7. Fix for a possible free of global data.

To recreate:
    $ scan-build ./configure --disable-shared --enable-opensslextra=x509small --disable-memory
    $ scan-build ./configure --disable-shared --enable-opensslextra --disable-memory
    $ scan-build ./configure --enable-sp --enable-sp-asm --enable-sp-math
    $ scan-build ./configure --enable-sp=small --enable-smallstack --enable-smallstackcache CPPFLAGS="-DECC_CACHE_CURVE -DHAVE_WOLF_BIGINT"

(Still one issue outstanding using the second configure option. Leaving out disable memory doesn't report potential errors.)