### PR TITLE
Sniffer fixes for handling TCP `out-of-range sequence number`

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -2648,7 +2648,7 @@ static int ProcessServerHello(int msgSz, const byte* input, int* sslBytes,
     (void)initialBytes;
 
     /* make sure we didn't miss ClientHello */
-    if (session->flags.clientHello == 0) {
+    if (session->flags.clientHello == 0 || session->sslClient->arrays == NULL) {
         SetError(MISSED_CLIENT_HELLO_STR, error, session, FATAL_ERROR_STATE);
         return -1;
     }


### PR DESCRIPTION
* Fixes for handling TCP `out-of-range sequence number`.
ZD 11245