### PR TITLE
set tag for zero inl case 2

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -37336,7 +37336,7 @@ static void test_wolfssl_EVP_aes_gcm_zeroLen()
 
     AssertIntEQ(1, EVP_EncryptInit_ex(en, EVP_aes_256_gcm(), NULL, key, iv));
     AssertIntEQ(1, EVP_CIPHER_CTX_ctrl(en, EVP_CTRL_GCM_SET_IVLEN, ivSz, NULL));
-    AssertIntEQ(1, EVP_EncryptUpdate(en, NULL, &ciphertxtSz , plaintxt, plaintxtSz));
+    AssertIntEQ(1, EVP_EncryptUpdate(en, ciphertxt, &ciphertxtSz , plaintxt, plaintxtSz));
     AssertIntEQ(1, EVP_EncryptFinal_ex(en, ciphertxt, &len));
     ciphertxtSz += len;
     AssertIntEQ(1, EVP_CIPHER_CTX_ctrl(en, EVP_CTRL_GCM_GET_TAG, 16, tag));

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -771,7 +771,7 @@ int  wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
         case AES_192_GCM_TYPE:
         case AES_256_GCM_TYPE:
             if ((ctx->gcmBuffer && ctx->gcmBufferLen > 0)
-             || (ctx->gcmBuffer == NULL && ctx->gcmBufferLen == 0)) {
+             || (ctx->gcmBufferLen == 0)) {
                 ret = 0;
                 if (ctx->gcmAuthIn) {
                     /* authenticated, non-confidential data*/


### PR DESCRIPTION
ctx->gcmBuffer is allocated when ctx->gcmBufferLen == 0 and dest != NULL
