### PR TITLE
return err from fp_invmod_slow() when fp_add() fails

### DIFF
--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -1211,7 +1211,7 @@ top:
     #ifdef WOLFSSL_SMALL_STACK
       XFREE(x, NULL, DYNAMIC_TYPE_BIGINT);
     #endif
-      return FP_OKAY;
+      return err;
     }
   }
 
@@ -1222,7 +1222,7 @@ top:
     #ifdef WOLFSSL_SMALL_STACK
       XFREE(x, NULL, DYNAMIC_TYPE_BIGINT);
     #endif
-      return FP_OKAY;
+      return err;
     }
   }
 

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -1098,7 +1098,7 @@ top:
       #ifdef WOLFSSL_SMALL_STACK
         XFREE(x, NULL, DYNAMIC_TYPE_BIGINT);
       #endif
-        return FP_OKAY;
+        return err;
       }
       err = fp_sub (B, x, B);
       if (err != FP_OKAY) {
@@ -1126,7 +1126,7 @@ top:
       #ifdef WOLFSSL_SMALL_STACK
         XFREE(x, NULL, DYNAMIC_TYPE_BIGINT);
       #endif
-        return FP_OKAY;
+        return err;
       }
       err = fp_sub (D, x, D);
       if (err != FP_OKAY) {


### PR DESCRIPTION
This PR is related to ZD 11268.

In scenarios where FP_MAX_BITS is not set high enough, fp_add() can fail with an error return value due to FP_SIZE not being large enough.  This PR adjusts fp_invmod_slow() to correctly propagate that error to the caller instead of returning FP_OKAY.