### PR TITLE
ECC verify: validate r and s before any use

### DIFF
--- a/wolfcrypt/src/sp_arm32.c
+++ b/wolfcrypt/src/sp_arm32.c
@@ -4792,7 +4792,8 @@ static WC_INLINE int sp_2048_div_32(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[31];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 32);
     for (i=31; i>=0; i--) {
-        r1 = div_2048_word_32(t1[32 + i], t1[32 + i - 1], div);
+        sp_digit hi = t1[32 + i] - (t1[32 + i] == div);
+        r1 = div_2048_word_32(hi, t1[32 + i - 1], div);
 
         sp_2048_mul_d_32(t2, d, r1);
         t1[32 + i] += sp_2048_sub_in_place_32(&t1[i], t2);
@@ -7024,7 +7025,8 @@ static WC_INLINE int sp_2048_div_64(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[63];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 64);
     for (i=63; i>=0; i--) {
-        r1 = div_2048_word_64(t1[64 + i], t1[64 + i - 1], div);
+        sp_digit hi = t1[64 + i] - (t1[64 + i] == div);
+        r1 = div_2048_word_64(hi, t1[64 + i - 1], div);
 
         sp_2048_mul_d_64(t2, d, r1);
         t1[64 + i] += sp_2048_sub_in_place_64(&t1[i], t2);
@@ -7076,7 +7078,8 @@ static WC_INLINE int sp_2048_div_64_cond(const sp_digit* a, const sp_digit* d, s
     div = d[63];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 64);
     for (i=63; i>=0; i--) {
-        r1 = div_2048_word_64(t1[64 + i], t1[64 + i - 1], div);
+        sp_digit hi = t1[64 + i] - (t1[64 + i] == div);
+        r1 = div_2048_word_64(hi, t1[64 + i - 1], div);
 
         sp_2048_mul_d_64(t2, d, r1);
         t1[64 + i] += sp_2048_sub_in_place_64(&t1[i], t2);
@@ -15606,7 +15609,8 @@ static WC_INLINE int sp_3072_div_48(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[47];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 48);
     for (i=47; i>=0; i--) {
-        r1 = div_3072_word_48(t1[48 + i], t1[48 + i - 1], div);
+        sp_digit hi = t1[48 + i] - (t1[48 + i] == div);
+        r1 = div_3072_word_48(hi, t1[48 + i - 1], div);
 
         sp_3072_mul_d_48(t2, d, r1);
         t1[48 + i] += sp_3072_sub_in_place_48(&t1[i], t2);
@@ -18638,7 +18642,8 @@ static WC_INLINE int sp_3072_div_96(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[95];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 96);
     for (i=95; i>=0; i--) {
-        r1 = div_3072_word_96(t1[96 + i], t1[96 + i - 1], div);
+        sp_digit hi = t1[96 + i] - (t1[96 + i] == div);
+        r1 = div_3072_word_96(hi, t1[96 + i - 1], div);
 
         sp_3072_mul_d_96(t2, d, r1);
         t1[96 + i] += sp_3072_sub_in_place_96(&t1[i], t2);
@@ -18690,7 +18695,8 @@ static WC_INLINE int sp_3072_div_96_cond(const sp_digit* a, const sp_digit* d, s
     div = d[95];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 96);
     for (i=95; i>=0; i--) {
-        r1 = div_3072_word_96(t1[96 + i], t1[96 + i - 1], div);
+        sp_digit hi = t1[96 + i] - (t1[96 + i] == div);
+        r1 = div_3072_word_96(hi, t1[96 + i - 1], div);
 
         sp_3072_mul_d_96(t2, d, r1);
         t1[96 + i] += sp_3072_sub_in_place_96(&t1[i], t2);
@@ -26658,7 +26664,8 @@ static WC_INLINE int sp_4096_div_128(const sp_digit* a, const sp_digit* d, sp_di
     div = d[127];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 128);
     for (i=127; i>=0; i--) {
-        r1 = div_4096_word_128(t1[128 + i], t1[128 + i - 1], div);
+        sp_digit hi = t1[128 + i] - (t1[128 + i] == div);
+        r1 = div_4096_word_128(hi, t1[128 + i - 1], div);
 
         sp_4096_mul_d_128(t2, d, r1);
         t1[128 + i] += sp_4096_sub_in_place_128(&t1[i], t2);
@@ -26710,7 +26717,8 @@ static WC_INLINE int sp_4096_div_128_cond(const sp_digit* a, const sp_digit* d, 
     div = d[127];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 128);
     for (i=127; i>=0; i--) {
-        r1 = div_4096_word_128(t1[128 + i], t1[128 + i - 1], div);
+        sp_digit hi = t1[128 + i] - (t1[128 + i] == div);
+        r1 = div_4096_word_128(hi, t1[128 + i - 1], div);
 
         sp_4096_mul_d_128(t2, d, r1);
         t1[128 + i] += sp_4096_sub_in_place_128(&t1[i], t2);
@@ -35925,7 +35933,8 @@ static WC_INLINE int sp_256_div_8(const sp_digit* a, const sp_digit* d, sp_digit
     div = d[7];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 8);
     for (i=7; i>=0; i--) {
-        r1 = div_256_word_8(t1[8 + i], t1[8 + i - 1], div);
+        sp_digit hi = t1[8 + i] - (t1[8 + i] == div);
+        r1 = div_256_word_8(hi, t1[8 + i - 1], div);
 
         sp_256_mul_d_8(t2, d, r1);
         t1[8 + i] += sp_256_sub_in_place_8(&t1[i], t2);
@@ -45126,7 +45135,8 @@ static WC_INLINE int sp_384_div_12(const sp_digit* a, const sp_digit* d, sp_digi
     div = d[11];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 12);
     for (i=11; i>=0; i--) {
-        r1 = div_384_word_12(t1[12 + i], t1[12 + i - 1], div);
+        sp_digit hi = t1[12 + i] - (t1[12 + i] == div);
+        r1 = div_384_word_12(hi, t1[12 + i - 1], div);
 
         sp_384_mul_d_12(t2, d, r1);
         t1[12 + i] += sp_384_sub_in_place_12(&t1[i], t2);

--- a/wolfcrypt/src/sp_arm32.c
+++ b/wolfcrypt/src/sp_arm32.c
@@ -37387,6 +37387,15 @@ int sp_ecc_check_key_256(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
     }
 #endif
 
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+        (mp_count_bits(pY) > 256) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
+
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         priv = privd;
@@ -46135,6 +46144,15 @@ int sp_ecc_check_key_384(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
         }
     }
 #endif
+
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+        (mp_count_bits(pY) > 384) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
 
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)

--- a/wolfcrypt/src/sp_arm64.c
+++ b/wolfcrypt/src/sp_arm64.c
@@ -37792,6 +37792,15 @@ int sp_ecc_check_key_256(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
     }
 #endif
 
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+        (mp_count_bits(pY) > 256) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
+
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         priv = privd;
@@ -44244,6 +44253,15 @@ int sp_ecc_check_key_384(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
         }
     }
 #endif
+
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+        (mp_count_bits(pY) > 384) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
 
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)

--- a/wolfcrypt/src/sp_arm64.c
+++ b/wolfcrypt/src/sp_arm64.c
@@ -3112,7 +3112,8 @@ static WC_INLINE int sp_2048_div_16(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[15];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 16);
     for (i=15; i>=0; i--) {
-        r1 = div_2048_word_16(t1[16 + i], t1[16 + i - 1], div);
+        sp_digit hi = t1[16 + i] - (t1[16 + i] == div);
+        r1 = div_2048_word_16(hi, t1[16 + i - 1], div);
 
         sp_2048_mul_d_16(t2, d, r1);
         t1[16 + i] += sp_2048_sub_in_place_16(&t1[i], t2);
@@ -4376,7 +4377,8 @@ static WC_INLINE int sp_2048_div_32(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[31];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 32);
     for (i=31; i>=0; i--) {
-        r1 = div_2048_word_32(t1[32 + i], t1[32 + i - 1], div);
+        sp_digit hi = t1[32 + i] - (t1[32 + i] == div);
+        r1 = div_2048_word_32(hi, t1[32 + i - 1], div);
 
         sp_2048_mul_d_32(t2, d, r1);
         t1[32 + i] += sp_2048_sub_in_place_32(&t1[i], t2);
@@ -4564,7 +4566,8 @@ static WC_INLINE int sp_2048_div_32_cond(const sp_digit* a, const sp_digit* d, s
     div = d[31];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 32);
     for (i=31; i>=0; i--) {
-        r1 = div_2048_word_32(t1[32 + i], t1[32 + i - 1], div);
+        sp_digit hi = t1[32 + i] - (t1[32 + i] == div);
+        r1 = div_2048_word_32(hi, t1[32 + i - 1], div);
 
         sp_2048_mul_d_32(t2, d, r1);
         t1[32 + i] += sp_2048_sub_in_place_32(&t1[i], t2);
@@ -10509,7 +10512,8 @@ static WC_INLINE int sp_3072_div_24(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[23];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 24);
     for (i=23; i>=0; i--) {
-        r1 = div_3072_word_24(t1[24 + i], t1[24 + i - 1], div);
+        sp_digit hi = t1[24 + i] - (t1[24 + i] == div);
+        r1 = div_3072_word_24(hi, t1[24 + i - 1], div);
 
         sp_3072_mul_d_24(t2, d, r1);
         t1[24 + i] += sp_3072_sub_in_place_24(&t1[i], t2);
@@ -12101,7 +12105,8 @@ static WC_INLINE int sp_3072_div_48(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[47];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 48);
     for (i=47; i>=0; i--) {
-        r1 = div_3072_word_48(t1[48 + i], t1[48 + i - 1], div);
+        sp_digit hi = t1[48 + i] - (t1[48 + i] == div);
+        r1 = div_3072_word_48(hi, t1[48 + i - 1], div);
 
         sp_3072_mul_d_48(t2, d, r1);
         t1[48 + i] += sp_3072_sub_in_place_48(&t1[i], t2);
@@ -12329,7 +12334,8 @@ static WC_INLINE int sp_3072_div_48_cond(const sp_digit* a, const sp_digit* d, s
     div = d[47];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 48);
     for (i=47; i>=0; i--) {
-        r1 = div_3072_word_48(t1[48 + i], t1[48 + i - 1], div);
+        sp_digit hi = t1[48 + i] - (t1[48 + i] == div);
+        r1 = div_3072_word_48(hi, t1[48 + i - 1], div);
 
         sp_3072_mul_d_48(t2, d, r1);
         t1[48 + i] += sp_3072_sub_in_place_48(&t1[i], t2);
@@ -17026,7 +17032,8 @@ static WC_INLINE int sp_4096_div_64(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[63];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 64);
     for (i=63; i>=0; i--) {
-        r1 = div_4096_word_64(t1[64 + i], t1[64 + i - 1], div);
+        sp_digit hi = t1[64 + i] - (t1[64 + i] == div);
+        r1 = div_4096_word_64(hi, t1[64 + i - 1], div);
 
         sp_4096_mul_d_64(t2, d, r1);
         t1[64 + i] += sp_4096_sub_in_place_64(&t1[i], t2);
@@ -17294,7 +17301,8 @@ static WC_INLINE int sp_4096_div_64_cond(const sp_digit* a, const sp_digit* d, s
     div = d[63];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 64);
     for (i=63; i>=0; i--) {
-        r1 = div_4096_word_64(t1[64 + i], t1[64 + i - 1], div);
+        sp_digit hi = t1[64 + i] - (t1[64 + i] == div);
+        r1 = div_4096_word_64(hi, t1[64 + i - 1], div);
 
         sp_4096_mul_d_64(t2, d, r1);
         t1[64 + i] += sp_4096_sub_in_place_64(&t1[i], t2);
@@ -36686,7 +36694,8 @@ static WC_INLINE int sp_256_div_4(const sp_digit* a, const sp_digit* d, sp_digit
     div = d[3];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 4);
     for (i=3; i>=0; i--) {
-        r1 = div_256_word_4(t1[4 + i], t1[4 + i - 1], div);
+        sp_digit hi = t1[4 + i] - (t1[4 + i] == div);
+        r1 = div_256_word_4(hi, t1[4 + i - 1], div);
 
         sp_256_mul_d_4(t2, d, r1);
         t1[4 + i] += sp_256_sub_in_place_4(&t1[i], t2);
@@ -43241,7 +43250,8 @@ static WC_INLINE int sp_384_div_6(const sp_digit* a, const sp_digit* d, sp_digit
     div = d[5];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 6);
     for (i=5; i>=0; i--) {
-        r1 = div_384_word_6(t1[6 + i], t1[6 + i - 1], div);
+        sp_digit hi = t1[6 + i] - (t1[6 + i] == div);
+        r1 = div_384_word_6(hi, t1[6 + i - 1], div);
 
         sp_384_mul_d_6(t2, d, r1);
         t1[6 + i] += sp_384_sub_in_place_6(&t1[i], t2);

--- a/wolfcrypt/src/sp_armthumb.c
+++ b/wolfcrypt/src/sp_armthumb.c
@@ -22160,6 +22160,15 @@ int sp_ecc_check_key_256(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
     }
 #endif
 
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+        (mp_count_bits(pY) > 256) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
+
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         priv = privd;
@@ -28977,6 +28986,15 @@ int sp_ecc_check_key_384(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
         }
     }
 #endif
+
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+        (mp_count_bits(pY) > 384) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
 
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)

--- a/wolfcrypt/src/sp_armthumb.c
+++ b/wolfcrypt/src/sp_armthumb.c
@@ -3086,7 +3086,8 @@ static WC_INLINE int sp_2048_div_32(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[31];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 32);
     for (i=31; i>=0; i--) {
-        r1 = div_2048_word_32(t1[32 + i], t1[32 + i - 1], div);
+        sp_digit hi = t1[32 + i] - (t1[32 + i] == div);
+        r1 = div_2048_word_32(hi, t1[32 + i - 1], div);
 
         sp_2048_mul_d_32(t2, d, r1);
         t1[32 + i] += sp_2048_sub_in_place_32(&t1[i], t2);
@@ -3891,7 +3892,8 @@ static WC_INLINE int sp_2048_div_64(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[63];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 64);
     for (i=63; i>=0; i--) {
-        r1 = div_2048_word_64(t1[64 + i], t1[64 + i - 1], div);
+        sp_digit hi = t1[64 + i] - (t1[64 + i] == div);
+        r1 = div_2048_word_64(hi, t1[64 + i - 1], div);
 
         sp_2048_mul_d_64(t2, d, r1);
         t1[64 + i] += sp_2048_sub_in_place_64(&t1[i], t2);
@@ -3941,7 +3943,8 @@ static WC_INLINE int sp_2048_div_64_cond(const sp_digit* a, const sp_digit* d, s
     div = d[63];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 64);
     for (i=63; i>=0; i--) {
-        r1 = div_2048_word_64(t1[64 + i], t1[64 + i - 1], div);
+        sp_digit hi = t1[64 + i] - (t1[64 + i] == div);
+        r1 = div_2048_word_64(hi, t1[64 + i - 1], div);
 
         sp_2048_mul_d_64(t2, d, r1);
         t1[64 + i] += sp_2048_sub_in_place_64(&t1[i], t2);
@@ -8941,7 +8944,8 @@ static WC_INLINE int sp_3072_div_48(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[47];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 48);
     for (i=47; i>=0; i--) {
-        r1 = div_3072_word_48(t1[48 + i], t1[48 + i - 1], div);
+        sp_digit hi = t1[48 + i] - (t1[48 + i] == div);
+        r1 = div_3072_word_48(hi, t1[48 + i - 1], div);
 
         sp_3072_mul_d_48(t2, d, r1);
         t1[48 + i] += sp_3072_sub_in_place_48(&t1[i], t2);
@@ -9752,7 +9756,8 @@ static WC_INLINE int sp_3072_div_96(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[95];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 96);
     for (i=95; i>=0; i--) {
-        r1 = div_3072_word_96(t1[96 + i], t1[96 + i - 1], div);
+        sp_digit hi = t1[96 + i] - (t1[96 + i] == div);
+        r1 = div_3072_word_96(hi, t1[96 + i - 1], div);
 
         sp_3072_mul_d_96(t2, d, r1);
         t1[96 + i] += sp_3072_sub_in_place_96(&t1[i], t2);
@@ -9802,7 +9807,8 @@ static WC_INLINE int sp_3072_div_96_cond(const sp_digit* a, const sp_digit* d, s
     div = d[95];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 96);
     for (i=95; i>=0; i--) {
-        r1 = div_3072_word_96(t1[96 + i], t1[96 + i - 1], div);
+        sp_digit hi = t1[96 + i] - (t1[96 + i] == div);
+        r1 = div_3072_word_96(hi, t1[96 + i - 1], div);
 
         sp_3072_mul_d_96(t2, d, r1);
         t1[96 + i] += sp_3072_sub_in_place_96(&t1[i], t2);
@@ -13672,7 +13678,8 @@ static WC_INLINE int sp_4096_div_128(const sp_digit* a, const sp_digit* d, sp_di
     div = d[127];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 128);
     for (i=127; i>=0; i--) {
-        r1 = div_4096_word_128(t1[128 + i], t1[128 + i - 1], div);
+        sp_digit hi = t1[128 + i] - (t1[128 + i] == div);
+        r1 = div_4096_word_128(hi, t1[128 + i - 1], div);
 
         sp_4096_mul_d_128(t2, d, r1);
         t1[128 + i] += sp_4096_sub_in_place_128(&t1[i], t2);
@@ -13722,7 +13729,8 @@ static WC_INLINE int sp_4096_div_128_cond(const sp_digit* a, const sp_digit* d, 
     div = d[127];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 128);
     for (i=127; i>=0; i--) {
-        r1 = div_4096_word_128(t1[128 + i], t1[128 + i - 1], div);
+        sp_digit hi = t1[128 + i] - (t1[128 + i] == div);
+        r1 = div_4096_word_128(hi, t1[128 + i - 1], div);
 
         sp_4096_mul_d_128(t2, d, r1);
         t1[128 + i] += sp_4096_sub_in_place_128(&t1[i], t2);
@@ -21127,7 +21135,8 @@ static WC_INLINE int sp_256_div_8(const sp_digit* a, const sp_digit* d, sp_digit
     div = d[7];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 8);
     for (i=7; i>=0; i--) {
-        r1 = div_256_word_8(t1[8 + i], t1[8 + i - 1], div);
+        sp_digit hi = t1[8 + i] - (t1[8 + i] == div);
+        r1 = div_256_word_8(hi, t1[8 + i - 1], div);
 
         sp_256_mul_d_8(t2, d, r1);
         t1[8 + i] += sp_256_sub_in_place_8(&t1[i], t2);
@@ -27968,7 +27977,8 @@ static WC_INLINE int sp_384_div_12(const sp_digit* a, const sp_digit* d, sp_digi
     div = d[11];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 12);
     for (i=11; i>=0; i--) {
-        r1 = div_384_word_12(t1[12 + i], t1[12 + i - 1], div);
+        sp_digit hi = t1[12 + i] - (t1[12 + i] == div);
+        r1 = div_384_word_12(hi, t1[12 + i - 1], div);
 
         sp_384_mul_d_12(t2, d, r1);
         t1[12 + i] += sp_384_sub_in_place_12(&t1[i], t2);

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -1261,7 +1261,7 @@ SP_NOINLINE static void sp_2048_mul_d_90(sp_digit* r, const sp_digit* a,
 #else
     int64_t tb = b;
     int64_t t = 0;
-    sp_digit t2;
+    int64_t t2;
     int64_t p[4];
     int i;
 
@@ -1271,19 +1271,19 @@ SP_NOINLINE static void sp_2048_mul_d_90(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 3] = t2;
     }
@@ -1636,7 +1636,7 @@ SP_NOINLINE static void sp_2048_mul_d_45(sp_digit* r, const sp_digit* a,
 #else
     int64_t tb = b;
     int64_t t = 0;
-    sp_digit t2;
+    int64_t t2;
     int64_t p[4];
     int i;
 
@@ -1646,19 +1646,19 @@ SP_NOINLINE static void sp_2048_mul_d_45(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 3] = t2;
     }
@@ -1837,15 +1837,17 @@ static int sp_2048_div_45(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_2048_mul_d_90(t1, a, 1L << 11);
         dv = sd[44];
         for (i=45; i>=0; i--) {
+            sp_digit hi;
             t1[45 + i] += t1[45 + i - 1] >> 23;
             t1[45 + i - 1] &= 0x7fffff;
+            hi = t1[45 + i] - (t1[45 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_32
-            d1 = t1[45 + i];
+            d1 = hi;
             d1 <<= 23;
             d1 += t1[45 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_2048_div_word_45(t1[45 + i], t1[45 + i - 1], dv);
+            r1 = sp_2048_div_word_45(hi, t1[45 + i - 1], dv);
 #endif
 
             sp_2048_mul_d_45(t2, sd, r1);
@@ -2575,7 +2577,7 @@ SP_NOINLINE static void sp_2048_mul_d_180(sp_digit* r, const sp_digit* a,
 #else
     int64_t tb = b;
     int64_t t = 0;
-    sp_digit t2;
+    int64_t t2;
     int64_t p[4];
     int i;
 
@@ -2585,19 +2587,19 @@ SP_NOINLINE static void sp_2048_mul_d_180(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 3] = t2;
     }
@@ -2787,15 +2789,17 @@ static int sp_2048_div_90(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_2048_mul_d_180(t1, a, 1L << 22);
         dv = sd[89];
         for (i=90; i>=0; i--) {
+            sp_digit hi;
             t1[90 + i] += t1[90 + i - 1] >> 23;
             t1[90 + i - 1] &= 0x7fffff;
+            hi = t1[90 + i] - (t1[90 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_32
-            d1 = t1[90 + i];
+            d1 = hi;
             d1 <<= 23;
             d1 += t1[90 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_2048_div_word_90(t1[90 + i], t1[90 + i - 1], dv);
+            r1 = sp_2048_div_word_90(hi, t1[90 + i - 1], dv);
 #endif
 
             sp_2048_mul_d_90(t2, sd, r1);
@@ -5152,7 +5156,7 @@ SP_NOINLINE static void sp_3072_mul_d_134(sp_digit* r, const sp_digit* a,
 #else
     int64_t tb = b;
     int64_t t = 0;
-    sp_digit t2;
+    int64_t t2;
     int64_t p[4];
     int i;
 
@@ -5162,19 +5166,19 @@ SP_NOINLINE static void sp_3072_mul_d_134(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 3] = t2;
     }
@@ -5519,7 +5523,7 @@ SP_NOINLINE static void sp_3072_mul_d_67(sp_digit* r, const sp_digit* a,
 #else
     int64_t tb = b;
     int64_t t = 0;
-    sp_digit t2;
+    int64_t t2;
     int64_t p[4];
     int i;
 
@@ -5529,19 +5533,19 @@ SP_NOINLINE static void sp_3072_mul_d_67(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 3] = t2;
     }
@@ -5691,15 +5695,17 @@ static int sp_3072_div_67(const sp_digit* a, const sp_digit* d, sp_digit* m,
         dv = d[66];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 67U);
         for (i=66; i>=0; i--) {
+            sp_digit hi;
             t1[67 + i] += t1[67 + i - 1] >> 23;
             t1[67 + i - 1] &= 0x7fffff;
+            hi = t1[67 + i] - (t1[67 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_32
-            d1 = t1[67 + i];
+            d1 = hi;
             d1 <<= 23;
             d1 += t1[67 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_3072_div_word_67(t1[67 + i], t1[67 + i - 1], dv);
+            r1 = sp_3072_div_word_67(hi, t1[67 + i - 1], dv);
 #endif
 
             sp_3072_mul_d_67(t2, d, r1);
@@ -6454,7 +6460,7 @@ SP_NOINLINE static void sp_3072_mul_d_268(sp_digit* r, const sp_digit* a,
 #else
     int64_t tb = b;
     int64_t t = 0;
-    sp_digit t2;
+    int64_t t2;
     int64_t p[4];
     int i;
 
@@ -6464,19 +6470,19 @@ SP_NOINLINE static void sp_3072_mul_d_268(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x7fffff);
+        t2 = t & 0x7fffff;
         t >>= 23;
         r[i + 3] = t2;
     }
@@ -6674,15 +6680,17 @@ static int sp_3072_div_134(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_3072_mul_d_268(t1, a, 1L << 10);
         dv = sd[133];
         for (i=134; i>=0; i--) {
+            sp_digit hi;
             t1[134 + i] += t1[134 + i - 1] >> 23;
             t1[134 + i - 1] &= 0x7fffff;
+            hi = t1[134 + i] - (t1[134 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_32
-            d1 = t1[134 + i];
+            d1 = hi;
             d1 <<= 23;
             d1 += t1[134 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_3072_div_word_134(t1[134 + i], t1[134 + i - 1], dv);
+            r1 = sp_3072_div_word_134(hi, t1[134 + i - 1], dv);
 #endif
 
             sp_3072_mul_d_134(t2, sd, r1);
@@ -9192,7 +9200,7 @@ SP_NOINLINE static void sp_4096_mul_d_196(sp_digit* r, const sp_digit* a,
 #else
     int64_t tb = b;
     int64_t t = 0;
-    sp_digit t2;
+    int64_t t2;
     int64_t p[4];
     int i;
 
@@ -9202,19 +9210,19 @@ SP_NOINLINE static void sp_4096_mul_d_196(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x1fffff);
+        t2 = t & 0x1fffff;
         t >>= 21;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x1fffff);
+        t2 = t & 0x1fffff;
         t >>= 21;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x1fffff);
+        t2 = t & 0x1fffff;
         t >>= 21;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x1fffff);
+        t2 = t & 0x1fffff;
         t >>= 21;
         r[i + 3] = t2;
     }
@@ -9541,7 +9549,7 @@ SP_NOINLINE static void sp_4096_mul_d_98(sp_digit* r, const sp_digit* a,
 #else
     int64_t tb = b;
     int64_t t = 0;
-    sp_digit t2;
+    int64_t t2;
     int64_t p[4];
     int i;
 
@@ -9551,19 +9559,19 @@ SP_NOINLINE static void sp_4096_mul_d_98(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x1fffff);
+        t2 = t & 0x1fffff;
         t >>= 21;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x1fffff);
+        t2 = t & 0x1fffff;
         t >>= 21;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x1fffff);
+        t2 = t & 0x1fffff;
         t >>= 21;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x1fffff);
+        t2 = t & 0x1fffff;
         t >>= 21;
         r[i + 3] = t2;
     }
@@ -9759,15 +9767,17 @@ static int sp_4096_div_98(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_4096_mul_d_196(t1, a, 1L << 10);
         dv = sd[97];
         for (i=98; i>=0; i--) {
+            sp_digit hi;
             t1[98 + i] += t1[98 + i - 1] >> 21;
             t1[98 + i - 1] &= 0x1fffff;
+            hi = t1[98 + i] - (t1[98 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_32
-            d1 = t1[98 + i];
+            d1 = hi;
             d1 <<= 21;
             d1 += t1[98 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_4096_div_word_98(t1[98 + i], t1[98 + i - 1], dv);
+            r1 = sp_4096_div_word_98(hi, t1[98 + i - 1], dv);
 #endif
 
             sp_4096_mul_d_98(t2, sd, r1);
@@ -10512,7 +10522,7 @@ SP_NOINLINE static void sp_4096_mul_d_392(sp_digit* r, const sp_digit* a,
 #else
     int64_t tb = b;
     int64_t t = 0;
-    sp_digit t2;
+    int64_t t2;
     int64_t p[4];
     int i;
 
@@ -10522,19 +10532,19 @@ SP_NOINLINE static void sp_4096_mul_d_392(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x1fffff);
+        t2 = t & 0x1fffff;
         t >>= 21;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x1fffff);
+        t2 = t & 0x1fffff;
         t >>= 21;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x1fffff);
+        t2 = t & 0x1fffff;
         t >>= 21;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x1fffff);
+        t2 = t & 0x1fffff;
         t >>= 21;
         r[i + 3] = t2;
     }
@@ -10728,15 +10738,17 @@ static int sp_4096_div_196(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_4096_mul_d_392(t1, a, 1L << 20);
         dv = sd[195];
         for (i=196; i>=0; i--) {
+            sp_digit hi;
             t1[196 + i] += t1[196 + i - 1] >> 21;
             t1[196 + i - 1] &= 0x1fffff;
+            hi = t1[196 + i] - (t1[196 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_32
-            d1 = t1[196 + i];
+            d1 = hi;
             d1 <<= 21;
             d1 += t1[196 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_4096_div_word_196(t1[196 + i], t1[196 + i - 1], dv);
+            r1 = sp_4096_div_word_196(hi, t1[196 + i - 1], dv);
 #endif
 
             sp_4096_mul_d_196(t2, sd, r1);
@@ -17519,15 +17531,17 @@ static int sp_256_div_10(const sp_digit* a, const sp_digit* d, sp_digit* m,
         dv = d[9];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 10U);
         for (i=9; i>=0; i--) {
+            sp_digit hi;
             t1[10 + i] += t1[10 + i - 1] >> 26;
             t1[10 + i - 1] &= 0x3ffffff;
+            hi = t1[10 + i] - (t1[10 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_32
-            d1 = t1[10 + i];
+            d1 = hi;
             d1 <<= 26;
             d1 += t1[10 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_256_div_word_10(t1[10 + i], t1[10 + i - 1], dv);
+            r1 = sp_256_div_word_10(hi, t1[10 + i - 1], dv);
 #endif
 
             sp_256_mul_d_10(t2, d, r1);
@@ -24870,15 +24884,17 @@ static int sp_384_div_15(const sp_digit* a, const sp_digit* d, sp_digit* m,
         dv = d[14];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 15U);
         for (i=14; i>=0; i--) {
+            sp_digit hi;
             t1[15 + i] += t1[15 + i - 1] >> 26;
             t1[15 + i - 1] &= 0x3ffffff;
+            hi = t1[15 + i] - (t1[15 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_32
-            d1 = t1[15 + i];
+            d1 = hi;
             d1 <<= 26;
             d1 += t1[15 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_384_div_word_15(t1[15 + i], t1[15 + i - 1], dv);
+            r1 = sp_384_div_word_15(hi, t1[15 + i - 1], dv);
 #endif
 
             sp_384_mul_d_15(t2, d, r1);

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -18589,6 +18589,15 @@ int sp_ecc_check_key_256(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
     }
 #endif
 
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+        (mp_count_bits(pY) > 256) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
+
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         priv = privd;
@@ -25918,6 +25927,15 @@ int sp_ecc_check_key_384(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
         }
     }
 #endif
+
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+        (mp_count_bits(pY) > 384) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
 
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -900,7 +900,7 @@ SP_NOINLINE static void sp_2048_mul_d_36(sp_digit* r, const sp_digit* a,
 #else
     int128_t tb = b;
     int128_t t = 0;
-    sp_digit t2;
+    int128_t t2;
     int128_t p[4];
     int i;
 
@@ -910,19 +910,19 @@ SP_NOINLINE static void sp_2048_mul_d_36(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 3] = t2;
     }
@@ -1243,7 +1243,7 @@ SP_NOINLINE static void sp_2048_mul_d_18(sp_digit* r, const sp_digit* a,
 #else
     int128_t tb = b;
     int128_t t = 0;
-    sp_digit t2;
+    int128_t t2;
     int128_t p[4];
     int i;
 
@@ -1253,19 +1253,19 @@ SP_NOINLINE static void sp_2048_mul_d_18(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 3] = t2;
     }
@@ -1487,15 +1487,17 @@ static int sp_2048_div_18(const sp_digit* a, const sp_digit* d, sp_digit* m,
         dv = d[17];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 18U);
         for (i=17; i>=0; i--) {
+            sp_digit hi;
             t1[18 + i] += t1[18 + i - 1] >> 57;
             t1[18 + i - 1] &= 0x1ffffffffffffffL;
+            hi = t1[18 + i] - (t1[18 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_64
-            d1 = t1[18 + i];
+            d1 = hi;
             d1 <<= 57;
             d1 += t1[18 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_2048_div_word_18(t1[18 + i], t1[18 + i - 1], dv);
+            r1 = sp_2048_div_word_18(hi, t1[18 + i - 1], dv);
 #endif
 
             sp_2048_mul_d_18(t2, d, r1);
@@ -2430,15 +2432,17 @@ static int sp_2048_div_36(const sp_digit* a, const sp_digit* d, sp_digit* m,
         dv = d[35];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 36U);
         for (i=35; i>=0; i--) {
+            sp_digit hi;
             t1[36 + i] += t1[36 + i - 1] >> 57;
             t1[36 + i - 1] &= 0x1ffffffffffffffL;
+            hi = t1[36 + i] - (t1[36 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_64
-            d1 = t1[36 + i];
+            d1 = hi;
             d1 <<= 57;
             d1 += t1[36 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_2048_div_word_36(t1[36 + i], t1[36 + i - 1], dv);
+            r1 = sp_2048_div_word_36(hi, t1[36 + i - 1], dv);
 #endif
 
             sp_2048_mul_d_36(t2, d, r1);
@@ -5103,7 +5107,7 @@ SP_NOINLINE static void sp_3072_mul_d_54(sp_digit* r, const sp_digit* a,
 #else
     int128_t tb = b;
     int128_t t = 0;
-    sp_digit t2;
+    int128_t t2;
     int128_t p[4];
     int i;
 
@@ -5113,19 +5117,19 @@ SP_NOINLINE static void sp_3072_mul_d_54(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 3] = t2;
     }
@@ -5470,7 +5474,7 @@ SP_NOINLINE static void sp_3072_mul_d_27(sp_digit* r, const sp_digit* a,
 #else
     int128_t tb = b;
     int128_t t = 0;
-    sp_digit t2;
+    int128_t t2;
     int128_t p[4];
     int i;
 
@@ -5480,19 +5484,19 @@ SP_NOINLINE static void sp_3072_mul_d_27(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x1ffffffffffffffL);
+        t2 = t & 0x1ffffffffffffffL;
         t >>= 57;
         r[i + 3] = t2;
     }
@@ -5679,15 +5683,17 @@ static int sp_3072_div_27(const sp_digit* a, const sp_digit* d, sp_digit* m,
         dv = d[26];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 27U);
         for (i=26; i>=0; i--) {
+            sp_digit hi;
             t1[27 + i] += t1[27 + i - 1] >> 57;
             t1[27 + i - 1] &= 0x1ffffffffffffffL;
+            hi = t1[27 + i] - (t1[27 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_64
-            d1 = t1[27 + i];
+            d1 = hi;
             d1 <<= 57;
             d1 += t1[27 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_3072_div_word_27(t1[27 + i], t1[27 + i - 1], dv);
+            r1 = sp_3072_div_word_27(hi, t1[27 + i - 1], dv);
 #endif
 
             sp_3072_mul_d_27(t2, d, r1);
@@ -6592,15 +6598,17 @@ static int sp_3072_div_54(const sp_digit* a, const sp_digit* d, sp_digit* m,
         dv = d[53];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 54U);
         for (i=53; i>=0; i--) {
+            sp_digit hi;
             t1[54 + i] += t1[54 + i - 1] >> 57;
             t1[54 + i - 1] &= 0x1ffffffffffffffL;
+            hi = t1[54 + i] - (t1[54 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_64
-            d1 = t1[54 + i];
+            d1 = hi;
             d1 <<= 57;
             d1 += t1[54 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_3072_div_word_54(t1[54 + i], t1[54 + i - 1], dv);
+            r1 = sp_3072_div_word_54(hi, t1[54 + i - 1], dv);
 #endif
 
             sp_3072_mul_d_54(t2, d, r1);
@@ -9351,7 +9359,7 @@ SP_NOINLINE static void sp_4096_mul_d_78(sp_digit* r, const sp_digit* a,
 #else
     int128_t tb = b;
     int128_t t = 0;
-    sp_digit t2;
+    int128_t t2;
     int128_t p[4];
     int i;
 
@@ -9361,19 +9369,19 @@ SP_NOINLINE static void sp_4096_mul_d_78(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x1fffffffffffffL);
+        t2 = t & 0x1fffffffffffffL;
         t >>= 53;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x1fffffffffffffL);
+        t2 = t & 0x1fffffffffffffL;
         t >>= 53;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x1fffffffffffffL);
+        t2 = t & 0x1fffffffffffffL;
         t >>= 53;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x1fffffffffffffL);
+        t2 = t & 0x1fffffffffffffL;
         t >>= 53;
         r[i + 3] = t2;
     }
@@ -9741,7 +9749,7 @@ SP_NOINLINE static void sp_4096_mul_d_39(sp_digit* r, const sp_digit* a,
 #else
     int128_t tb = b;
     int128_t t = 0;
-    sp_digit t2;
+    int128_t t2;
     int128_t p[4];
     int i;
 
@@ -9751,19 +9759,19 @@ SP_NOINLINE static void sp_4096_mul_d_39(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x1fffffffffffffL);
+        t2 = t & 0x1fffffffffffffL;
         t >>= 53;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x1fffffffffffffL);
+        t2 = t & 0x1fffffffffffffL;
         t >>= 53;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x1fffffffffffffL);
+        t2 = t & 0x1fffffffffffffL;
         t >>= 53;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x1fffffffffffffL);
+        t2 = t & 0x1fffffffffffffL;
         t >>= 53;
         r[i + 3] = t2;
     }
@@ -9976,15 +9984,17 @@ static int sp_4096_div_39(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_4096_mul_d_78(t1, a, 1L << 19);
         dv = sd[38];
         for (i=39; i>=0; i--) {
+            sp_digit hi;
             t1[39 + i] += t1[39 + i - 1] >> 53;
             t1[39 + i - 1] &= 0x1fffffffffffffL;
+            hi = t1[39 + i] - (t1[39 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_64
-            d1 = t1[39 + i];
+            d1 = hi;
             d1 <<= 53;
             d1 += t1[39 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_4096_div_word_39(t1[39 + i], t1[39 + i - 1], dv);
+            r1 = sp_4096_div_word_39(hi, t1[39 + i - 1], dv);
 #endif
 
             sp_4096_mul_d_39(t2, sd, r1);
@@ -10743,7 +10753,7 @@ SP_NOINLINE static void sp_4096_mul_d_156(sp_digit* r, const sp_digit* a,
 #else
     int128_t tb = b;
     int128_t t = 0;
-    sp_digit t2;
+    int128_t t2;
     int128_t p[4];
     int i;
 
@@ -10753,19 +10763,19 @@ SP_NOINLINE static void sp_4096_mul_d_156(sp_digit* r, const sp_digit* a,
         p[2] = tb * a[i + 2];
         p[3] = tb * a[i + 3];
         t += p[0];
-        t2 = (sp_digit)(t & 0x1fffffffffffffL);
+        t2 = t & 0x1fffffffffffffL;
         t >>= 53;
         r[i + 0] = t2;
         t += p[1];
-        t2 = (sp_digit)(t & 0x1fffffffffffffL);
+        t2 = t & 0x1fffffffffffffL;
         t >>= 53;
         r[i + 1] = t2;
         t += p[2];
-        t2 = (sp_digit)(t & 0x1fffffffffffffL);
+        t2 = t & 0x1fffffffffffffL;
         t >>= 53;
         r[i + 2] = t2;
         t += p[3];
-        t2 = (sp_digit)(t & 0x1fffffffffffffL);
+        t2 = t & 0x1fffffffffffffL;
         t >>= 53;
         r[i + 3] = t2;
     }
@@ -10987,15 +10997,17 @@ static int sp_4096_div_78(const sp_digit* a, const sp_digit* d, sp_digit* m,
         sp_4096_mul_d_156(t1, a, 1L << 38);
         dv = sd[77];
         for (i=78; i>=0; i--) {
+            sp_digit hi;
             t1[78 + i] += t1[78 + i - 1] >> 53;
             t1[78 + i - 1] &= 0x1fffffffffffffL;
+            hi = t1[78 + i] - (t1[78 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_64
-            d1 = t1[78 + i];
+            d1 = hi;
             d1 <<= 53;
             d1 += t1[78 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_4096_div_word_78(t1[78 + i], t1[78 + i - 1], dv);
+            r1 = sp_4096_div_word_78(hi, t1[78 + i - 1], dv);
 #endif
 
             sp_4096_mul_d_78(t2, sd, r1);
@@ -17250,15 +17262,17 @@ static int sp_256_div_5(const sp_digit* a, const sp_digit* d, sp_digit* m,
         dv = d[4];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 5U);
         for (i=4; i>=0; i--) {
+            sp_digit hi;
             t1[5 + i] += t1[5 + i - 1] >> 52;
             t1[5 + i - 1] &= 0xfffffffffffffL;
+            hi = t1[5 + i] - (t1[5 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_64
-            d1 = t1[5 + i];
+            d1 = hi;
             d1 <<= 52;
             d1 += t1[5 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_256_div_word_5(t1[5 + i], t1[5 + i - 1], dv);
+            r1 = sp_256_div_word_5(hi, t1[5 + i - 1], dv);
 #endif
 
             sp_256_mul_d_5(t2, d, r1);
@@ -24075,15 +24089,17 @@ static int sp_384_div_7(const sp_digit* a, const sp_digit* d, sp_digit* m,
         dv = d[6];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 7U);
         for (i=6; i>=0; i--) {
+            sp_digit hi;
             t1[7 + i] += t1[7 + i - 1] >> 55;
             t1[7 + i - 1] &= 0x7fffffffffffffL;
+            hi = t1[7 + i] - (t1[7 + i] == dv);
 #ifndef WOLFSSL_SP_DIV_64
-            d1 = t1[7 + i];
+            d1 = hi;
             d1 <<= 55;
             d1 += t1[7 + i - 1];
             r1 = (sp_digit)(d1 / dv);
 #else
-            r1 = sp_384_div_word_7(t1[7 + i], t1[7 + i - 1], dv);
+            r1 = sp_384_div_word_7(hi, t1[7 + i - 1], dv);
 #endif
 
             sp_384_mul_d_7(t2, d, r1);

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -18315,6 +18315,15 @@ int sp_ecc_check_key_256(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
     }
 #endif
 
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+        (mp_count_bits(pY) > 256) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
+
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         priv = privd;
@@ -25115,6 +25124,15 @@ int sp_ecc_check_key_384(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
         }
     }
 #endif
+
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+        (mp_count_bits(pY) > 384) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
 
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)

--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -22166,6 +22166,15 @@ int sp_ecc_check_key_256(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
     }
 #endif
 
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+        (mp_count_bits(pY) > 256) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
+
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         priv = privd;
@@ -28773,6 +28782,15 @@ int sp_ecc_check_key_384(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
         }
     }
 #endif
+
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+        (mp_count_bits(pY) > 384) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
 
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)

--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -3105,7 +3105,8 @@ static WC_INLINE int sp_2048_div_32(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[31];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 32);
     for (i=31; i>=0; i--) {
-        r1 = div_2048_word_32(t1[32 + i], t1[32 + i - 1], div);
+        sp_digit hi = t1[32 + i] - (t1[32 + i] == div);
+        r1 = div_2048_word_32(hi, t1[32 + i - 1], div);
 
         sp_2048_mul_d_32(t2, d, r1);
         t1[32 + i] += sp_2048_sub_in_place_32(&t1[i], t2);
@@ -3785,7 +3786,8 @@ static WC_INLINE int sp_2048_div_64(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[63];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 64);
     for (i=63; i>=0; i--) {
-        r1 = div_2048_word_64(t1[64 + i], t1[64 + i - 1], div);
+        sp_digit hi = t1[64 + i] - (t1[64 + i] == div);
+        r1 = div_2048_word_64(hi, t1[64 + i - 1], div);
 
         sp_2048_mul_d_64(t2, d, r1);
         t1[64 + i] += sp_2048_sub_in_place_64(&t1[i], t2);
@@ -3835,7 +3837,8 @@ static WC_INLINE int sp_2048_div_64_cond(const sp_digit* a, const sp_digit* d, s
     div = d[63];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 64);
     for (i=63; i>=0; i--) {
-        r1 = div_2048_word_64(t1[64 + i], t1[64 + i - 1], div);
+        sp_digit hi = t1[64 + i] - (t1[64 + i] == div);
+        r1 = div_2048_word_64(hi, t1[64 + i - 1], div);
 
         sp_2048_mul_d_64(t2, d, r1);
         t1[64 + i] += sp_2048_sub_in_place_64(&t1[i], t2);
@@ -7995,7 +7998,8 @@ static WC_INLINE int sp_3072_div_48(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[47];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 48);
     for (i=47; i>=0; i--) {
-        r1 = div_3072_word_48(t1[48 + i], t1[48 + i - 1], div);
+        sp_digit hi = t1[48 + i] - (t1[48 + i] == div);
+        r1 = div_3072_word_48(hi, t1[48 + i - 1], div);
 
         sp_3072_mul_d_48(t2, d, r1);
         t1[48 + i] += sp_3072_sub_in_place_48(&t1[i], t2);
@@ -8678,7 +8682,8 @@ static WC_INLINE int sp_3072_div_96(const sp_digit* a, const sp_digit* d, sp_dig
     div = d[95];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 96);
     for (i=95; i>=0; i--) {
-        r1 = div_3072_word_96(t1[96 + i], t1[96 + i - 1], div);
+        sp_digit hi = t1[96 + i] - (t1[96 + i] == div);
+        r1 = div_3072_word_96(hi, t1[96 + i - 1], div);
 
         sp_3072_mul_d_96(t2, d, r1);
         t1[96 + i] += sp_3072_sub_in_place_96(&t1[i], t2);
@@ -8728,7 +8733,8 @@ static WC_INLINE int sp_3072_div_96_cond(const sp_digit* a, const sp_digit* d, s
     div = d[95];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 96);
     for (i=95; i>=0; i--) {
-        r1 = div_3072_word_96(t1[96 + i], t1[96 + i - 1], div);
+        sp_digit hi = t1[96 + i] - (t1[96 + i] == div);
+        r1 = div_3072_word_96(hi, t1[96 + i - 1], div);
 
         sp_3072_mul_d_96(t2, d, r1);
         t1[96 + i] += sp_3072_sub_in_place_96(&t1[i], t2);
@@ -11991,7 +11997,8 @@ static WC_INLINE int sp_4096_div_128(const sp_digit* a, const sp_digit* d, sp_di
     div = d[127];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 128);
     for (i=127; i>=0; i--) {
-        r1 = div_4096_word_128(t1[128 + i], t1[128 + i - 1], div);
+        sp_digit hi = t1[128 + i] - (t1[128 + i] == div);
+        r1 = div_4096_word_128(hi, t1[128 + i - 1], div);
 
         sp_4096_mul_d_128(t2, d, r1);
         t1[128 + i] += sp_4096_sub_in_place_128(&t1[i], t2);
@@ -12041,7 +12048,8 @@ static WC_INLINE int sp_4096_div_128_cond(const sp_digit* a, const sp_digit* d, 
     div = d[127];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 128);
     for (i=127; i>=0; i--) {
-        r1 = div_4096_word_128(t1[128 + i], t1[128 + i - 1], div);
+        sp_digit hi = t1[128 + i] - (t1[128 + i] == div);
+        r1 = div_4096_word_128(hi, t1[128 + i - 1], div);
 
         sp_4096_mul_d_128(t2, d, r1);
         t1[128 + i] += sp_4096_sub_in_place_128(&t1[i], t2);
@@ -20782,7 +20790,8 @@ static WC_INLINE int sp_256_div_8(const sp_digit* a, const sp_digit* d, sp_digit
     div = d[7];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 8);
     for (i=7; i>=0; i--) {
-        r1 = div_256_word_8(t1[8 + i], t1[8 + i - 1], div);
+        sp_digit hi = t1[8 + i] - (t1[8 + i] == div);
+        r1 = div_256_word_8(hi, t1[8 + i - 1], div);
 
         sp_256_mul_d_8(t2, d, r1);
         t1[8 + i] += sp_256_sub_in_place_8(&t1[i], t2);
@@ -27764,7 +27773,8 @@ static WC_INLINE int sp_384_div_12(const sp_digit* a, const sp_digit* d, sp_digi
     div = d[11];
     XMEMCPY(t1, a, sizeof(*t1) * 2 * 12);
     for (i=11; i>=0; i--) {
-        r1 = div_384_word_12(t1[12 + i], t1[12 + i - 1], div);
+        sp_digit hi = t1[12 + i] - (t1[12 + i] == div);
+        r1 = div_384_word_12(hi, t1[12 + i - 1], div);
 
         sp_384_mul_d_12(t2, d, r1);
         t1[12 + i] += sp_384_sub_in_place_12(&t1[i], t2);

--- a/wolfcrypt/src/sp_x86_64.c
+++ b/wolfcrypt/src/sp_x86_64.c
@@ -23916,6 +23916,15 @@ int sp_ecc_check_key_256(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
     }
 #endif
 
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+        (mp_count_bits(pY) > 256) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
+
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         priv = privd;
@@ -30910,6 +30919,15 @@ int sp_ecc_check_key_384(mp_int* pX, mp_int* pY, mp_int* privm, void* heap)
         }
     }
 #endif
+
+    /* Quick check the lengs of public key ordinates and private key are in
+     * range. Proper check later.
+     */
+    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+        (mp_count_bits(pY) > 384) ||
+        ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
+        err = ECC_OUT_OF_RANGE_E;
+    }
 
     if (err == MP_OKAY) {
 #if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)

--- a/wolfcrypt/src/sp_x86_64.c
+++ b/wolfcrypt/src/sp_x86_64.c
@@ -348,7 +348,8 @@ static WC_INLINE int sp_2048_div_16(const sp_digit* a, const sp_digit* d, sp_dig
 #endif
         sp_2048_cond_sub_16(&t1[16], &t1[16], d, (sp_digit)0 - r1);
     for (i=15; i>=0; i--) {
-        r1 = div_2048_word_16(t1[16 + i], t1[16 + i - 1], div);
+        sp_digit hi = t1[16 + i] - (t1[16 + i] == div);
+        r1 = div_2048_word_16(hi, t1[16 + i - 1], div);
 
 #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_BMI2(cpuid_flags) && IS_INTEL_ADX(cpuid_flags))
@@ -904,7 +905,8 @@ static WC_INLINE int sp_2048_div_32(const sp_digit* a, const sp_digit* d, sp_dig
 #endif
         sp_2048_cond_sub_32(&t1[32], &t1[32], d, (sp_digit)0 - r1);
     for (i=31; i>=0; i--) {
-        r1 = div_2048_word_32(t1[32 + i], t1[32 + i - 1], div);
+        sp_digit hi = t1[32 + i] - (t1[32 + i] == div);
+        r1 = div_2048_word_32(hi, t1[32 + i - 1], div);
 
 #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_BMI2(cpuid_flags) && IS_INTEL_ADX(cpuid_flags))
@@ -976,7 +978,8 @@ static WC_INLINE int sp_2048_div_32_cond(const sp_digit* a, const sp_digit* d, s
         sp_2048_sub_in_place_32(&t1[32], d);
     }
     for (i=31; i>=0; i--) {
-        r1 = div_2048_word_32(t1[32 + i], t1[32 + i - 1], div);
+        sp_digit hi = t1[32 + i] - (t1[32 + i] == div);
+        r1 = div_2048_word_32(hi, t1[32 + i - 1], div);
 
 #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_BMI2(cpuid_flags) && IS_INTEL_ADX(cpuid_flags))
@@ -2622,7 +2625,8 @@ static WC_INLINE int sp_3072_div_24(const sp_digit* a, const sp_digit* d, sp_dig
 #endif
         sp_3072_cond_sub_24(&t1[24], &t1[24], d, (sp_digit)0 - r1);
     for (i=23; i>=0; i--) {
-        r1 = div_3072_word_24(t1[24 + i], t1[24 + i - 1], div);
+        sp_digit hi = t1[24 + i] - (t1[24 + i] == div);
+        r1 = div_3072_word_24(hi, t1[24 + i - 1], div);
 
 #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_BMI2(cpuid_flags) && IS_INTEL_ADX(cpuid_flags))
@@ -3178,7 +3182,8 @@ static WC_INLINE int sp_3072_div_48(const sp_digit* a, const sp_digit* d, sp_dig
 #endif
         sp_3072_cond_sub_48(&t1[48], &t1[48], d, (sp_digit)0 - r1);
     for (i=47; i>=0; i--) {
-        r1 = div_3072_word_48(t1[48 + i], t1[48 + i - 1], div);
+        sp_digit hi = t1[48 + i] - (t1[48 + i] == div);
+        r1 = div_3072_word_48(hi, t1[48 + i - 1], div);
 
 #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_BMI2(cpuid_flags) && IS_INTEL_ADX(cpuid_flags))
@@ -3250,7 +3255,8 @@ static WC_INLINE int sp_3072_div_48_cond(const sp_digit* a, const sp_digit* d, s
         sp_3072_sub_in_place_48(&t1[48], d);
     }
     for (i=47; i>=0; i--) {
-        r1 = div_3072_word_48(t1[48 + i], t1[48 + i - 1], div);
+        sp_digit hi = t1[48 + i] - (t1[48 + i] == div);
+        r1 = div_3072_word_48(hi, t1[48 + i - 1], div);
 
 #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_BMI2(cpuid_flags) && IS_INTEL_ADX(cpuid_flags))
@@ -4874,7 +4880,8 @@ static WC_INLINE int sp_4096_div_64(const sp_digit* a, const sp_digit* d, sp_dig
 #endif
         sp_4096_cond_sub_64(&t1[64], &t1[64], d, (sp_digit)0 - r1);
     for (i=63; i>=0; i--) {
-        r1 = div_4096_word_64(t1[64 + i], t1[64 + i - 1], div);
+        sp_digit hi = t1[64 + i] - (t1[64 + i] == div);
+        r1 = div_4096_word_64(hi, t1[64 + i - 1], div);
 
 #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_BMI2(cpuid_flags) && IS_INTEL_ADX(cpuid_flags))
@@ -4946,7 +4953,8 @@ static WC_INLINE int sp_4096_div_64_cond(const sp_digit* a, const sp_digit* d, s
         sp_4096_sub_in_place_64(&t1[64], d);
     }
     for (i=63; i>=0; i--) {
-        r1 = div_4096_word_64(t1[64 + i], t1[64 + i - 1], div);
+        sp_digit hi = t1[64 + i] - (t1[64 + i] == div);
+        r1 = div_4096_word_64(hi, t1[64 + i - 1], div);
 
 #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_BMI2(cpuid_flags) && IS_INTEL_ADX(cpuid_flags))
@@ -22611,7 +22619,8 @@ static WC_INLINE int sp_256_div_4(const sp_digit* a, const sp_digit* d, sp_digit
 #endif
         sp_256_cond_sub_4(&t1[4], &t1[4], d, (sp_digit)0 - r1);
     for (i=3; i>=0; i--) {
-        r1 = div_256_word_4(t1[4 + i], t1[4 + i - 1], div);
+        sp_digit hi = t1[4 + i] - (t1[4 + i] == div);
+        r1 = div_256_word_4(hi, t1[4 + i - 1], div);
 
 #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_BMI2(cpuid_flags) && IS_INTEL_ADX(cpuid_flags))
@@ -29663,7 +29672,8 @@ static WC_INLINE int sp_384_div_6(const sp_digit* a, const sp_digit* d, sp_digit
 #endif
         sp_384_cond_sub_6(&t1[6], &t1[6], d, (sp_digit)0 - r1);
     for (i=5; i>=0; i--) {
-        r1 = div_384_word_6(t1[6 + i], t1[6 + i - 1], div);
+        sp_digit hi = t1[6 + i] - (t1[6 + i] == div);
+        r1 = div_384_word_6(hi, t1[6 + i - 1], div);
 
 #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_BMI2(cpuid_flags) && IS_INTEL_ADX(cpuid_flags))


### PR DESCRIPTION
SP code assumes r and s are valid values.
Code for ATECC508A, ATECC608A and CRYPTOCELL assumes that the r and s
are the size of the key when converting to byte arrays.