### PR TITLE
wc_ecc_rs_to_sig(): move r and s zero check before StoreECC_DSA_Sig()

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -20467,6 +20467,7 @@ static int test_wc_ecc_rs_to_sig (void)
     /* first [P-192,SHA-1] vector from FIPS 186-3 NIST vectors */
     const char*   R = "6994d962bdd0d793ffddf855ec5bf2f91a9698b46258a63e";
     const char*   S = "02ba6465a234903744ab02bc8521405b73cf5fc00e1a9f41";
+    const char*   zeroStr = "0";
     byte          sig[ECC_MAX_SIG_SIZE];
     word32        siglen = (word32)sizeof(sig);
     /*R and S max size is the order of curve. 2^192.*/
@@ -20497,6 +20498,12 @@ static int test_wc_ecc_rs_to_sig (void)
             ret = wc_ecc_rs_to_sig(R, S, NULL, &siglen);
         }
         if (ret == ECC_BAD_ARG_E) {
+            ret = wc_ecc_rs_to_sig(R, zeroStr, sig, &siglen);
+        }
+        if (ret == MP_ZERO_E) {
+            ret = wc_ecc_rs_to_sig(zeroStr, S, sig, &siglen);
+        }
+        if (ret == MP_ZERO_E) {
             ret = 0;
         } else {
             ret = WOLFSSL_FATAL_ERROR;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -8003,14 +8003,14 @@ int wc_ecc_rs_to_sig(const char* r, const char* s, byte* out, word32* outlen)
     if (err == MP_OKAY)
         err = mp_read_radix(stmp, s, MP_RADIX_HEX);
 
-    /* convert mp_ints to ECDSA sig, initializes rtmp and stmp internally */
-    if (err == MP_OKAY)
-        err = StoreECC_DSA_Sig(out, outlen, rtmp, stmp);
-
     if (err == MP_OKAY) {
         if (mp_iszero(rtmp) == MP_YES || mp_iszero(stmp) == MP_YES)
             err = MP_ZERO_E;
     }
+
+    /* convert mp_ints to ECDSA sig, initializes rtmp and stmp internally */
+    if (err == MP_OKAY)
+        err = StoreECC_DSA_Sig(out, outlen, rtmp, stmp);
 
     mp_clear(rtmp);
     mp_clear(stmp);


### PR DESCRIPTION
This PR is related to ZD 11287.

Signature components (r, s) should be checked for zero before processing with StoreECC_DSA_Sig() instead of after.  This PR also adds unit tests for wc_ecc_rs_to_sig() to check for MP_ZERO_E.