### PR TITLE
Adapt wolfSSL_dtls_got_timeout to secure renegotiation usage

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6488,6 +6488,16 @@ void SSL_ResourceFree(WOLFSSL* ssl)
 void FreeHandshakeResources(WOLFSSL* ssl)
 {
 
+#ifdef WOLFSSL_DTLS
+    /* DTLS_POOL */
+    if (ssl->options.dtls) {
+        DtlsMsgPoolReset(ssl);
+        DtlsMsgListDelete(ssl->dtls_rx_msg_list, ssl->heap);
+        ssl->dtls_rx_msg_list = NULL;
+        ssl->dtls_rx_msg_list_sz = 0;
+    }
+#endif
+
 #ifdef HAVE_SECURE_RENEGOTIATION
     if (ssl->secure_renegotiation && ssl->secure_renegotiation->enabled) {
         WOLFSSL_MSG("Secure Renegotiation needs to retain handshake resources");
@@ -6531,16 +6541,6 @@ void FreeHandshakeResources(WOLFSSL* ssl)
             ssl->options.weOwnRng = 0;
         }
     }
-
-#ifdef WOLFSSL_DTLS
-    /* DTLS_POOL */
-    if (ssl->options.dtls) {
-        DtlsMsgPoolReset(ssl);
-        DtlsMsgListDelete(ssl->dtls_rx_msg_list, ssl->heap);
-        ssl->dtls_rx_msg_list = NULL;
-        ssl->dtls_rx_msg_list_sz = 0;
-    }
-#endif
 
 #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH) && \
                                                     defined(HAVE_SESSION_TICKET)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11633,7 +11633,7 @@ int wolfSSL_dtls_got_timeout(WOLFSSL* ssl)
     if (ssl == NULL)
         return WOLFSSL_FATAL_ERROR;
 
-    if (!ssl->options.handShakeDone &&
+    if ((IsSCR(ssl) || !ssl->options.handShakeDone) &&
         (DtlsMsgPoolTimeout(ssl) < 0 || DtlsMsgPoolSend(ssl, 0) < 0)) {
 
         result = WOLFSSL_FATAL_ERROR;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -25303,18 +25303,6 @@ long wolfSSL_get_options(const WOLFSSL* ssl)
 
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 
-#ifdef OPENSSL_EXTRA
-
-long wolfSSL_clear_options(WOLFSSL* ssl, long opt)
-{
-    WOLFSSL_ENTER("SSL_clear_options");
-    if(ssl == NULL)
-        return WOLFSSL_FAILURE;
-    ssl->options.mask &= ~opt;
-    return ssl->options.mask;
-}
-
-
 #if defined(HAVE_SECURE_RENEGOTIATION) \
         || defined(HAVE_SERVER_RENEGOTIATION_INFO)
 /* clears the counter for number of renegotiations done
@@ -25359,6 +25347,18 @@ int  wolfSSL_SSL_renegotiate_pending(WOLFSSL *s)
             s->options.handShakeState != HANDSHAKE_DONE ? 1 : 0;
 }
 #endif /* HAVE_SECURE_RENEGOTIATION || HAVE_SERVER_RENEGOTIATION_INFO */
+
+#ifdef OPENSSL_EXTRA
+
+long wolfSSL_clear_options(WOLFSSL* ssl, long opt)
+{
+    WOLFSSL_ENTER("SSL_clear_options");
+    if(ssl == NULL)
+        return WOLFSSL_FAILURE;
+    ssl->options.mask &= ~opt;
+    return ssl->options.mask;
+}
+
 
 #ifndef NO_DH
 long wolfSSL_set_tmp_dh(WOLFSSL *ssl, WOLFSSL_DH *dh)


### PR DESCRIPTION
Reset DTLS stored messages on a FreeHandshakeResources call even if secure renegotiation is enabled. Without this, in a server initiated rehandshake, the server would keep old messages (ChangeCipherSpec and Finished) even when it sent a HelloRequest message.