### PR TITLE
Verify Callback Fix

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10017,8 +10017,6 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
     /* Determine if verify was okay */
     if (ret == 0) {
         verify_ok = 1;
-        use_cb = 1; /* use verify callback on success, in case callback
-                     * could force fail a cert */
     }
 
     /* Determine if verify callback should be used */

--- a/tests/test-fails.conf
+++ b/tests/test-fails.conf
@@ -114,6 +114,7 @@
 # server
 -v 3
 -l ECDHE-RSA-AES128-GCM-SHA256
+-H verifyFail
 
 # client verify should fail
 -v 3
@@ -128,10 +129,12 @@
 # client
 -v 3
 -l ECDHE-RSA-AES128-GCM-SHA256
+-H verifyFail
 
 # server
 -v 3
 -l ECDHE-ECDSA-AES128-GCM-SHA256
+-H verifyFail
 
 # client verify should fail
 -v 3
@@ -146,6 +149,7 @@
 # client
 -v 3
 -l ECDHE-ECDSA-AES128-GCM-SHA256
+-H verifyFail
 
 # error going into callback, return error
 # server
@@ -153,6 +157,7 @@
 -l ECDHE-RSA-AES128-GCM-SHA256
 -c ./certs/test/server-cert-rsa-badsig.pem
 -k ./certs/server-key.pem
+-H verifyFail
 
 # client verify should fail
 -v 3
@@ -164,6 +169,7 @@
 -l ECDHE-ECDSA-AES128-GCM-SHA256
 -c ./certs/test/server-cert-ecc-badsig.pem
 -k ./certs/ecc-key.pem
+-H verifyFail
 
 # client verify should fail
 -v 3
@@ -173,10 +179,12 @@
 # server send alert on no mutual authentication
 -v 3
 -F
+-H verifyFail
 
 # client send alert on no mutual authentication
 -v 3
 -x
+-H verifyFail
 
 # server TLSv1.3 fail on no client certificate
 # server always sets WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT unless using -d
@@ -187,4 +195,3 @@
 -v 4
 -l TLS13-AES128-GCM-SHA256
 -x
-


### PR DESCRIPTION
1. Removed a flag set that would force all certificates in a chain to be verified. There was a compile time option to make that happen already.
2. Replace some options for some test failure test cases that were added and immediately removed.
(ZD 11292)