### PR TITLE
misc cleanups re sp-math-all, FIPS, smallstack

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -416,6 +416,16 @@ then
     then
         enable_compkey=no
     fi
+
+    if test "$ENABLED_FIPS" = "yes"
+    then
+        enable_xchacha=no
+        enable_pkcs7=no
+        enable_scep=no
+        enable_openssh=no
+        enable_ed25519=no
+        enable_ed448=no
+    fi
 fi
 
 
@@ -508,6 +518,14 @@ then
 
         # Enable ECC Import checks
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_VALIDATE_ECC_IMPORT"
+    fi
+
+    if test "$ENABLED_FIPS" = "yes"
+    then
+        enable_xchacha=no
+        enable_pkcs7=no
+        enable_ed25519=no
+        enable_ed448=no
     fi
 fi
 
@@ -3696,16 +3714,10 @@ fi
 
 
 # Small Stack - Cache on object
-if test "$ENABLED_LINUXKM_DEFAULTS" = "yes"
-then
-    ENABLED_SMALL_STACK_CACHE_DEFAULT=yes
-else
-    ENABLED_SMALL_STACK_CACHE_DEFAULT=no
-fi
 AC_ARG_ENABLE([smallstackcache],
     [AS_HELP_STRING([--enable-smallstackcache],[Enable Small Stack Usage Caching (default: disabled)])],
     [ ENABLED_SMALL_STACK_CACHE=$enableval ],
-    [ ENABLED_SMALL_STACK_CACHE=$ENABLED_SMALL_STACK_CACHE_DEFAULT ]
+    [ ENABLED_SMALL_STACK_CACHE=no ]
     )
 
 if test "x$ENABLED_SMALL_STACK_CACHE" = "xyes"
@@ -5986,10 +5998,10 @@ AM_CONDITIONAL([BUILD_NO_LIBRARY],[test "$ENABLED_NO_LIBRARY" = "yes"])
 AM_CONDITIONAL([BUILD_RC2],[test "x$ENABLED_RC2" = "xyes"])
 
 if test "$ax_enable_debug" = "yes" ||
-	test "$ENABLED_STACKSIZE" = "yes" ||
-	(test "$ENABLED_LEANTLS" = "no" &&
-	     test "$ENABLED_LEANPSK" = "no" &&
-	     test "$ENABLED_LOWRESOURCE" = "no")
+        test "$ENABLED_STACKSIZE" = "yes" ||
+        (test "$ENABLED_LEANTLS" = "no" &&
+             test "$ENABLED_LEANPSK" = "no" &&
+             test "$ENABLED_LOWRESOURCE" = "no")
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_WC_INTROSPECTION"
 fi
@@ -6145,6 +6157,11 @@ echo "   * make -j:                    $enable_jobserver"
 echo "   * VCS checkout:               $ac_cv_vcs_checkout"
 echo
 echo "   Features "
+if test "$ENABLED_FIPS" = "yes"; then
+echo "   * FIPS:                       $FIPS_VERSION"
+else
+echo "   * FIPS:                       $ENABLED_FIPS"
+fi
 echo "   * Single threaded:            $ENABLED_SINGLETHREADED"
 echo "   * Filesystem:                 $ENABLED_FILESYSTEM"
 echo "   * OpenSSH Build:              $ENABLED_OPENSSH"

--- a/configure.ac
+++ b/configure.ac
@@ -196,7 +196,7 @@ AC_ARG_ENABLE([linuxkm-defaults],
 
 if test "$ENABLED_LINUXKM_DEFAULTS" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DH_CONST -DWOLFSSL_SP_MOD_WORD_RP -DWOLFSSL_OLD_PRIME_CHECK -DWOLFSSL_SP_DIV_64 -DWOLFSSL_SP_DIV_WORD_HALF -DSP_HALF_SIZE=32 -DSP_HALF_MAX=4294967295U"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_DH_CONST -DWOLFSSL_SP_MOD_WORD_RP -DWOLFSSL_OLD_PRIME_CHECK -DWOLFSSL_SP_DIV_64 -DWOLFSSL_SP_DIV_WORD_HALF"
 fi
 
 AC_ARG_WITH([linux-source],
@@ -241,28 +241,42 @@ fi
 if test "$ENABLED_LINUXKM_DEFAULTS" = "yes"
 then
     ENABLED_SP_DEFAULT=small
+    ENABLED_SP_MATH_ALL_DEFAULT=small
 else
     ENABLED_SP_DEFAULT=no
+    ENABLED_SP_MATH_ALL_DEFAULT=no
 fi
+
 AC_ARG_ENABLE([sp],
     [AS_HELP_STRING([--enable-sp],[Enable Single Precision maths implementation (default: disabled)])],
     [ ENABLED_SP=$enableval ],
     [ ENABLED_SP=$ENABLED_SP_DEFAULT ],
     )
 
+AC_ARG_ENABLE([sp-math-all],
+    [AS_HELP_STRING([--enable-sp-math-all],[Enable Single Precision math implementation for full algorithm suite (default: disabled)])],
+    [ ENABLED_SP_MATH_ALL=$enableval ],
+    [ ENABLED_SP_MATH_ALL=$ENABLED_SP_MATH_ALL_DEFAULT ],
+    )
 
 # Single Precision maths exclusively (no fastmath)
-if test "$ENABLED_LINUXKM_DEFAULTS" = "yes" && test "$ENABLED_SP" != "no"
+if test "$ENABLED_LINUXKM_DEFAULTS" = "yes" && test "$ENABLED_SP" != "no" && test "$ENABLED_SP_MATH_ALL" = "no"
 then
     ENABLED_SP_MATH_DEFAULT=yes
 else
     ENABLED_SP_MATH_DEFAULT=no
 fi
 AC_ARG_ENABLE([sp-math],
-    [AS_HELP_STRING([--enable-sp-math],[Enable Single Precision math implementation only (default: disabled)])],
+    [AS_HELP_STRING([--enable-sp-math],[Enable Single Precision math implementation with restricted algorithm suite (default: disabled)])],
     [ ENABLED_SP_MATH=$enableval ],
     [ ENABLED_SP_MATH=$ENABLED_SP_MATH_DEFAULT ],
     )
+
+
+if test "$ENABLED_SP_MATH" != "no" && test "$ENABLED_SP_MATH_ALL" != "no"
+then
+    AC_MSG_ERROR([cannot enable sp-math and sp-math-all simultaneously.])
+fi
 
 
 # ALL FEATURES
@@ -273,101 +287,124 @@ AC_ARG_ENABLE([all],
     )
 if test "$ENABLED_ALL" = "yes"
 then
-    enable_dtls=yes
+    test "$enable_dtls" = "" && enable_dtls=yes
     if test "x$FIPS_VERSION" != "xv1"
     then
-        enable_tls13=yes
-        enable_rsapss=yes
+        test "$enable_tls13" = "" && enable_tls13=yes
+        test "$enable_rsapss" = "" && enable_rsapss=yes
     fi
-    enable_openssh=yes
-    enable_opensslextra=yes
-    enable_opensslall=yes
-    enable_savesession=yes
-    enable_savecert=yes
-    enable_atomicuser=yes
-    enable_pkcallbacks=yes
-    enable_aesgcm=yes
-    enable_aesccm=yes
-    enable_aesctr=yes
-    enable_aesofb=yes
-    enable_aescfb=yes
-    enable_camellia=yes
-    enable_ripemd=yes
-    enable_sha512=yes
-    enable_sha224=yes
-    enable_sha3=yes
-    enable_sessioncerts=yes
-    enable_keygen=yes
-    enable_certgen=yes
-    enable_certreq=yes
-    enable_certext=yes
-    enable_sep=yes
-    enable_hkdf=yes
-    enable_dsa=yes
-    enable_ecccustcurves=yes
-    enable_compkey=yes
-    enable_curve25519=yes
-    enable_curve448=yes
-    enable_ed448=yes
-    enable_ed25519=yes
-    enable_fpecc=yes
-    enable_eccencrypt=yes
-    enable_psk=yes
-    enable_idea=yes
-    enable_cmac=yes
-    enable_xts=yes
-    enable_webserver=yes
-    enable_hc128=yes
-    enable_rabbit=yes
-    enable_xchacha=yes
-    enable_ocsp=yes
-    enable_ocspstapling=yes
-    enable_ocspstapling2=yes
-    enable_crl=yes
-    enable_crl_monitor=yes
-    enable_sni=yes
-    enable_maxfragment=yes
-    enable_alpn=yes
-    enable_truncatedhmac=yes
-    enable_trusted_ca=yes
-    enable_supportedcurves=yes
-    enable_session_ticket=yes
-    enable_tlsx=yes
-    enable_pkcs7=yes
-    enable_ssh=yes
-    enable_scep=yes
-    enable_srp=yes
-    enable_certservice=yes
-    enable_jni=yes
-    enable_lighty=yes
-    enable_haproxy=yes
-    enable_stunnel=yes
-    enable_nginx=yes
-    enable_openvpn=yes
-    enable_asio=yes
-    enable_libwebsockets=yes
-    enable_qt=yes
-    enable_pwdbased=yes
-    enable_aeskeywrap=yes
-    enable_x963kdf=yes
-    enable_scrypt=yes
-    enable_indef=yes
-    enable_enckeys=yes
-    enable_hashflags=yes
-    enable_defaultdhparams=yes
-    enable_arc4=yes
-    enable_des3=yes
-    enable_nullcipher=yes
-    enable_blake2=yes
-    enable_blake2s=yes
-    enable_md2=yes
-    enable_md4=yes
-    enable_postauth=yes
-    enable_hrrcookie=yes
-    enable_cryptocb=yes
-    enable_fallback_scsv=yes
-    enable_anon=yes
-    enable_mcast=yes
+    test "$enable_savesession" = "" && enable_savesession=yes
+    test "$enable_savecert" = "" && enable_savecert=yes
+    test "$enable_atomicuser" = "" && enable_atomicuser=yes
+    test "$enable_pkcallbacks" = "" && enable_pkcallbacks=yes
+    test "$enable_aesgcm" = "" && enable_aesgcm=yes
+    test "$enable_aesccm" = "" && enable_aesccm=yes
+    test "$enable_aesctr" = "" && enable_aesctr=yes
+    test "$enable_aesofb" = "" && enable_aesofb=yes
+    test "$enable_aescfb" = "" && enable_aescfb=yes
+    test "$enable_camellia" = "" && enable_camellia=yes
+    test "$enable_ripemd" = "" && enable_ripemd=yes
+    test "$enable_sha512" = "" && enable_sha512=yes
+    test "$enable_sha224" = "" && enable_sha224=yes
+    test "$enable_sha3" = "" && enable_sha3=yes
+    test "$enable_sessioncerts" = "" && enable_sessioncerts=yes
+    test "$enable_keygen" = "" && enable_keygen=yes
+    test "$enable_certgen" = "" && enable_certgen=yes
+    test "$enable_certreq" = "" && enable_certreq=yes
+    test "$enable_certext" = "" && enable_certext=yes
+    test "$enable_sep" = "" && enable_sep=yes
+    test "$enable_hkdf" = "" && enable_hkdf=yes
+    test "$enable_curve25519" = "" && enable_curve25519=yes
+    test "$enable_curve448" = "" && enable_curve448=yes
+    test "$enable_fpecc" = "" && enable_fpecc=yes
+    test "$enable_eccencrypt" = "" && enable_eccencrypt=yes
+    test "$enable_psk" = "" && enable_psk=yes
+    test "$enable_idea" = "" && enable_idea=yes
+    test "$enable_cmac" = "" && enable_cmac=yes
+    test "$enable_xts" = "" && enable_xts=yes
+    test "$enable_webserver" = "" && enable_webserver=yes
+    test "$enable_hc128" = "" && enable_hc128=yes
+    test "$enable_rabbit" = "" && enable_rabbit=yes
+    test "$enable_ocsp" = "" && enable_ocsp=yes
+    test "$enable_ocspstapling" = "" && enable_ocspstapling=yes
+    test "$enable_ocspstapling2" = "" && enable_ocspstapling2=yes
+    test "$enable_crl" = "" && enable_crl=yes
+    test "$enable_crl_monitor" = "" && enable_crl_monitor=yes
+    test "$enable_sni" = "" && enable_sni=yes
+    test "$enable_maxfragment" = "" && enable_maxfragment=yes
+    test "$enable_alpn" = "" && enable_alpn=yes
+    test "$enable_truncatedhmac" = "" && enable_truncatedhmac=yes
+    test "$enable_trusted_ca" = "" && enable_trusted_ca=yes
+    test "$enable_supportedcurves" = "" && enable_supportedcurves=yes
+    test "$enable_session_ticket" = "" && enable_session_ticket=yes
+    test "$enable_tlsx" = "" && enable_tlsx=yes
+    test "$enable_ssh" = "" && enable_ssh=yes
+    test "$enable_pwdbased" = "" && enable_pwdbased=yes
+    test "$enable_aeskeywrap" = "" && enable_aeskeywrap=yes
+    test "$enable_x963kdf" = "" && enable_x963kdf=yes
+    test "$enable_scrypt" = "" && enable_scrypt=yes
+    test "$enable_indef" = "" && enable_indef=yes
+    test "$enable_enckeys" = "" && enable_enckeys=yes
+    test "$enable_hashflags" = "" && enable_hashflags=yes
+    test "$enable_defaultdhparams" = "" && enable_defaultdhparams=yes
+    test "$enable_arc4" = "" && enable_arc4=yes
+    test "$enable_des3" = "" && enable_des3=yes
+    test "$enable_nullcipher" = "" && enable_nullcipher=yes
+    test "$enable_blake2" = "" && enable_blake2=yes
+    test "$enable_blake2s" = "" && enable_blake2s=yes
+    test "$enable_md2" = "" && enable_md2=yes
+    test "$enable_md4" = "" && enable_md4=yes
+    test "$enable_postauth" = "" && enable_postauth=yes
+    test "$enable_hrrcookie" = "" && enable_hrrcookie=yes
+    test "$enable_cryptocb" = "" && enable_cryptocb=yes
+    test "$enable_fallback_scsv" = "" && enable_fallback_scsv=yes
+    test "$enable_anon" = "" && enable_anon=yes
+    test "$enable_mcast" = "" && enable_mcast=yes
+
+    if test "$ENABLED_LINUXKM_DEFAULTS" != "yes"
+    then
+        test "$enable_compkey" = "" && enable_compkey=yes
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_CRL_IO -DHAVE_IO_TIMEOUT"
+    fi
+
+    # sp-math is incompatible with opensslextra, ECC custom curves, and DSA.
+    if test "$ENABLED_SP_MATH" = "no"
+    then
+        test "$enable_dsa" = "" && enable_dsa=yes
+        test "$enable_ecccustcurves" = "" && enable_ecccustcurves=yes
+        test "$enable_srp" = "" && enable_srp=yes
+        # linuxkm is incompatible with opensslextra and its dependents.
+        if test "$ENABLED_LINUXKM_DEFAULTS" != "yes"
+        then
+            if test "$ENABLED_FIPS" = "no"
+            then
+                test "$enable_openssh" = "" && enable_openssh=yes
+            fi
+            test "$enable_opensslextra" = "" && enable_opensslextra=yes
+            test "$enable_opensslall" = "" && enable_opensslall=yes
+            test "$enable_certservice" = "" && enable_certservice=yes
+            test "$enable_jni" = "" && enable_jni=yes
+            test "$enable_lighty" = "" && enable_lighty=yes
+            test "$enable_haproxy" = "" && enable_haproxy=yes
+            test "$enable_stunnel" = "" && enable_stunnel=yes
+            test "$enable_nginx" = "" && enable_nginx=yes
+            test "$enable_openvpn" = "" && enable_openvpn=yes
+            test "$enable_asio" = "" && enable_asio=yes
+            test "$enable_libwebsockets" = "" && enable_libwebsockets=yes
+            test "$enable_qt" = "" && enable_qt=yes
+        fi
+        # Enable ECC Import checks
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_VALIDATE_ECC_IMPORT"
+    fi
+
+    if test "$ENABLED_FIPS" = "no"
+    then
+        test "$enable_xchacha" = "" && enable_xchacha=yes
+        test "$enable_scep" = "" && enable_scep=yes
+        test "$enable_pkcs7" = "" && enable_pkcs7=yes
+        test "$enable_ed25519" = "" && enable_ed25519=yes
+        test "$enable_ed448" = "" && enable_ed448=yes
+    fi
 
     # Enable DH const table speedups (eliminates `-lm` math lib dependency)
     AM_CFLAGS="$AM_CFLAGS -DHAVE_FFDHE_2048 -DHAVE_FFDHE_3072 -DFP_MAX_BITS=8192"
@@ -380,52 +417,6 @@ then
 
     # Enable ECC Key Gen checks
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_VALIDATE_ECC_KEYGEN"
-
-    if test "$ENABLED_LINUXKM_DEFAULTS" != "yes"
-    then
-        AM_CFLAGS="$AM_CFLAGS -DHAVE_CRL_IO -DHAVE_IO_TIMEOUT"
-    fi
-
-    if test "$ENABLED_SP_MATH" = "no"
-    then
-        # Enable ECC Import checks
-        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_VALIDATE_ECC_IMPORT"
-    else
-        # sp-math is incompatible with opensslextra, ECC custom curves, and DSA:
-
-        enable_openssh=no
-        enable_opensslextra=no
-        enable_opensslall=no
-        enable_dsa=no
-        enable_ecccustcurves=no
-        enable_srp=no
-        enable_certservice=no
-        enable_jni=no
-        enable_lighty=no
-        enable_haproxy=no
-        enable_stunnel=no
-        enable_nginx=no
-        enable_apachehttpd=no
-        enable_openvpn=no
-        enable_asio=no
-        enable_libwebsockets=no
-        enable_qt=no
-    fi
-
-    if test "$ENABLED_LINUXKM_DEFAULTS" = "yes"
-    then
-        enable_compkey=no
-    fi
-
-    if test "$ENABLED_FIPS" = "yes"
-    then
-        enable_xchacha=no
-        enable_pkcs7=no
-        enable_scep=no
-        enable_openssh=no
-        enable_ed25519=no
-        enable_ed448=no
-    fi
 fi
 
 
@@ -437,66 +428,79 @@ AC_ARG_ENABLE([all-crypto],
     )
 if test "$ENABLED_ALL_CRYPT" = "yes"
 then
-    enable_atomicuser=yes
-    enable_pkcallbacks=yes
-    enable_aesgcm=yes
-    enable_aesccm=yes
-    enable_aesctr=yes
-    enable_aesofb=yes
-    enable_aescfb=yes
-    enable_camellia=yes
-    enable_ripemd=yes
-    enable_sha512=yes
-    enable_sha224=yes
-    enable_sha3=yes
-    enable_sessioncerts=yes
-    enable_keygen=yes
-    enable_certgen=yes
-    enable_certreq=yes
-    enable_certext=yes
-    enable_sep=yes
-    enable_hkdf=yes
-    enable_curve25519=yes
-    enable_curve448=yes
-    enable_ed448=yes
-    enable_ed25519=yes
-    enable_fpecc=yes
-    enable_eccencrypt=yes
-    enable_psk=yes
-    enable_idea=yes
-    enable_cmac=yes
-    enable_xts=yes
-    enable_hc128=yes
-    enable_rabbit=yes
-    enable_xchacha=yes
-    enable_ocsp=yes
-    enable_ocspstapling=yes
-    enable_ocspstapling2=yes
-    enable_crl=yes
-    enable_supportedcurves=yes
-    enable_tlsx=yes
-    enable_pkcs7=yes
-    enable_pwdbased=yes
-    enable_aeskeywrap=yes
-    enable_x963kdf=yes
-    enable_scrypt=yes
-    enable_indef=yes
-    enable_enckeys=yes
-    enable_hashflags=yes
-    enable_defaultdhparams=yes
-    enable_arc4=yes
-    enable_des3=yes
-    enable_nullcipher=yes
-    enable_blake2=yes
-    enable_blake2s=yes
-    enable_md2=yes
-    enable_md4=yes
-    enable_cryptocb=yes
-    enable_anon=yes
+    test "$enable_atomicuser" = "" && enable_atomicuser=yes
+    test "$enable_pkcallbacks" = "" && enable_pkcallbacks=yes
+    test "$enable_aesgcm" = "" && enable_aesgcm=yes
+    test "$enable_aesccm" = "" && enable_aesccm=yes
+    test "$enable_aesctr" = "" && enable_aesctr=yes
+    test "$enable_aesofb" = "" && enable_aesofb=yes
+    test "$enable_aescfb" = "" && enable_aescfb=yes
+    test "$enable_camellia" = "" && enable_camellia=yes
+    test "$enable_ripemd" = "" && enable_ripemd=yes
+    test "$enable_sha512" = "" && enable_sha512=yes
+    test "$enable_sha224" = "" && enable_sha224=yes
+    test "$enable_sha3" = "" && enable_sha3=yes
+    test "$enable_sessioncerts" = "" && enable_sessioncerts=yes
+    test "$enable_keygen" = "" && enable_keygen=yes
+    test "$enable_certgen" = "" && enable_certgen=yes
+    test "$enable_certreq" = "" && enable_certreq=yes
+    test "$enable_certext" = "" && enable_certext=yes
+    test "$enable_sep" = "" && enable_sep=yes
+    test "$enable_hkdf" = "" && enable_hkdf=yes
+    test "$enable_curve25519" = "" && enable_curve25519=yes
+    test "$enable_curve448" = "" && enable_curve448=yes
+    test "$enable_fpecc" = "" && enable_fpecc=yes
+    test "$enable_eccencrypt" = "" && enable_eccencrypt=yes
+    test "$enable_psk" = "" && enable_psk=yes
+    test "$enable_idea" = "" && enable_idea=yes
+    test "$enable_cmac" = "" && enable_cmac=yes
+    test "$enable_xts" = "" && enable_xts=yes
+    test "$enable_hc128" = "" && enable_hc128=yes
+    test "$enable_rabbit" = "" && enable_rabbit=yes
+    test "$enable_ocsp" = "" && enable_ocsp=yes
+    test "$enable_ocspstapling" = "" && enable_ocspstapling=yes
+    test "$enable_ocspstapling2" = "" && enable_ocspstapling2=yes
+    test "$enable_crl" = "" && enable_crl=yes
+    test "$enable_supportedcurves" = "" && enable_supportedcurves=yes
+    test "$enable_tlsx" = "" && enable_tlsx=yes
+    test "$enable_pwdbased" = "" && enable_pwdbased=yes
+    test "$enable_aeskeywrap" = "" && enable_aeskeywrap=yes
+    test "$enable_x963kdf" = "" && enable_x963kdf=yes
+    test "$enable_scrypt" = "" && enable_scrypt=yes
+    test "$enable_indef" = "" && enable_indef=yes
+    test "$enable_enckeys" = "" && enable_enckeys=yes
+    test "$enable_hashflags" = "" && enable_hashflags=yes
+    test "$enable_defaultdhparams" = "" && enable_defaultdhparams=yes
+    test "$enable_arc4" = "" && enable_arc4=yes
+    test "$enable_des3" = "" && enable_des3=yes
+    test "$enable_nullcipher" = "" && enable_nullcipher=yes
+    test "$enable_blake2" = "" && enable_blake2=yes
+    test "$enable_blake2s" = "" && enable_blake2s=yes
+    test "$enable_md2" = "" && enable_md2=yes
+    test "$enable_md4" = "" && enable_md4=yes
+    test "$enable_cryptocb" = "" && enable_cryptocb=yes
+    test "$enable_anon" = "" && enable_anon=yes
 
     if test "$ENABLED_LINUXKM_DEFAULTS" != "yes"
     then
-        enable_compkey=yes
+        test "$enable_compkey" = "" && enable_compkey=yes
+    fi
+
+    if test "$ENABLED_SP_MATH" = "no"
+    then
+        test "$enable_dsa" = "" && enable_dsa=yes
+        test "$enable_ecccustcurves" = "" && enable_ecccustcurves=yes
+
+        # Enable ECC Import checks
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_VALIDATE_ECC_IMPORT"
+    fi
+
+    if test "$ENABLED_FIPS" != "yes"
+    then
+        test "$enable_xchacha" = "" && enable_xchacha=yes
+        test "$enable_ed25519" = "" && enable_ed25519=yes
+        test "$enable_ed448" = "" && enable_ed448=yes
+        test "$enable_pkcs7" = "" && enable_pkcs7=yes
     fi
 
     # Enable AES Decrypt, AES ECB, Alt Names, DER Load
@@ -511,22 +515,6 @@ then
     # Enable ECC Key Gen checks
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_VALIDATE_ECC_KEYGEN"
 
-    if test "$ENABLED_SP_MATH" = "no"
-    then
-        enable_dsa=yes
-        enable_ecccustcurves=yes
-
-        # Enable ECC Import checks
-        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_VALIDATE_ECC_IMPORT"
-    fi
-
-    if test "$ENABLED_FIPS" = "yes"
-    then
-        enable_xchacha=no
-        enable_pkcs7=no
-        enable_ed25519=no
-        enable_ed448=no
-    fi
 fi
 
 
@@ -4987,11 +4975,6 @@ if test "$ENABLED_SP_MATH" = "yes"; then
     ENABLED_SLOWMATH="no"
 fi
 
-AC_ARG_ENABLE([sp-math-all],
-    [AS_HELP_STRING([--enable-sp-math],[Enable Single Precision math implementation only (default: disabled)])],
-    [ ENABLED_SP_MATH_ALL=$enableval ],
-    [ ENABLED_SP_MATH_ALL=no ],
-    )
 for v in `echo $ENABLED_SP_MATH_ALL | tr "," " "`
 do
   case $v in
@@ -5860,8 +5843,8 @@ if test "x$ENABLED_LINUXKM" = "xyes"; then
     if test "$ENABLED_SMALL_STACK" != "yes"; then
         AC_MSG_ERROR([--enable-smallstack is required for --enable-linuxkm.])
     fi
-    if test "$ENABLED_SP_MATH" = "no"; then
-        AC_MSG_ERROR([--enable-sp-math is required for --enable-linuxkm.])
+    if test "$ENABLED_SP_MATH" = "no" && test "$ENABLED_SP_MATH_ALL" = "no"; then
+        AC_MSG_ERROR([--enable-sp-math or --enable-sp-math-all is required for --enable-linuxkm.])
     fi
     if test "$ENABLED_STACKSIZE" = "yes"; then
         AC_MSG_ERROR([--enable-stacksize is incompatible with --enable-linuxkm.])
@@ -6299,7 +6282,15 @@ echo "   * Stack sizes in tests:       $ENABLED_STACKSIZE"
 echo "   * User Crypto:                $ENABLED_USER_CRYPTO"
 echo "   * Fast RSA:                   $ENABLED_FAST_RSA"
 echo "   * Single Precision:           $ENABLED_SP"
-echo "   * SP math implementation:     $ENABLED_SP_MATH_ALL"
+if test "$ENABLED_SP_MATH_ALL" != "no"
+then
+    echo "   * SP math implementation:     all"
+elif test "$ENABLED_SP_MATH" != "no"
+then
+    echo "   * SP math implementation:     restricted"
+else
+    echo "   * SP math implementation:     no"
+fi
 echo "   * Async Crypto:               $ENABLED_ASYNCCRYPT"
 echo "   * PKCS#11:                    $ENABLED_PKCS11"
 echo "   * PKCS#12:                    $ENABLED_PKCS12"

--- a/configure.ac
+++ b/configure.ac
@@ -5026,12 +5026,12 @@ if test "$ENABLED_SP_ASM" = "yes"; then
     ;;
   *arm*)
     if test $host_alias = "thumb"; then
-      AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_THUMB_ASM -mthumb -march=armv6"
+      AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_THUMB_ASM"
       AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM_THUMB_ASM"
       ENABLED_SP_ARM_THUMB_ASM=yes
     else
       if test $host_alias = "cortex"; then
-        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_CORTEX_M_ASM -mcpu=cortex-r5"
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_CORTEX_M_ASM"
         AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM_CORTEX_M_ASM"
         ENABLED_SP_ARM_CORTEX_ASM=yes
       else

--- a/configure.ac
+++ b/configure.ac
@@ -4891,63 +4891,6 @@ if test "$ENABLED_SMALL" = "yes"; then
 fi
 
 
-AC_ARG_ENABLE([sp-asm],
-    [AS_HELP_STRING([--enable-sp-asm],[Enable Single Precision assembly implementation (default: disabled)])],
-    [ ENABLED_SP_ASM=$enableval ],
-    [ ENABLED_SP_ASM=no ],
-    )
-if test "$ENABLED_SP_ASM" = "yes"; then
-  if test "$ENABLED_SP" = "no"; then
-    AC_MSG_ERROR([Must have SP enabled: --enable-sp])
-  fi
-  if test "$ENABLED_SP_NONBLOCK" = "yes"; then
-    AC_MSG_ERROR([SP non-blocking not supported with sp-asm])
-  fi
-  if test "$ENABLED_ASM" = "no"; then
-    AC_MSG_ERROR([Assembly code turned off])
-  fi
-
-  AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ASM"
-  AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ASM"
-  case $host_cpu in
-  *aarch64*)
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM64_ASM"
-    AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM64_ASM"
-    ENABLED_SP_ARM64_ASM=yes
-    ;;
-  *arm*)
-    if test $host_alias = "thumb"; then
-      AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_THUMB_ASM"
-      AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM_THUMB_ASM"
-      ENABLED_SP_ARM_THUMB_ASM=yes
-    else
-      if test $host_alias = "cortex"; then
-        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_CORTEX_M_ASM"
-        AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM_CORTEX_M_ASM"
-        ENABLED_SP_ARM_CORTEX_ASM=yes
-      else
-        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM32_ASM"
-        AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM32_ASM"
-        ENABLED_SP_ARM32_ASM=yes
-      fi
-    fi
-    ;;
-  *x86_64*)
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_X86_64_ASM"
-    AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_X86_64_ASM"
-    ENABLED_SP_X86_64_ASM=yes
-    if test "x$ENABLED_FASTMATH" = "xno"
-    then
-      AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_X86_64_BUILD"
-    fi
-    ;;
-  *)
-    AC_MSG_ERROR([ASM not available for CPU. Supported CPUs: x86_64, aarch64, arm])
-    ;;
-  esac
-
-fi
-
 if test "$ENABLED_SP_MATH" = "yes"; then
     if test "$ENABLED_SP" = "no"; then
         AC_MSG_ERROR([Must have SP enabled: --enable-sp])
@@ -5056,9 +4999,69 @@ if test "$ENABLED_SP_MATH_ALL" = "yes"; then
   esac
 fi
 
+
+AC_ARG_ENABLE([sp-asm],
+    [AS_HELP_STRING([--enable-sp-asm],[Enable Single Precision assembly implementation (default: disabled)])],
+    [ ENABLED_SP_ASM=$enableval ],
+    [ ENABLED_SP_ASM=no ],
+    )
+if test "$ENABLED_SP_ASM" = "yes"; then
+  if test "$ENABLED_SP" = "no"; then
+    AC_MSG_ERROR([Must have SP enabled: --enable-sp])
+  fi
+  if test "$ENABLED_SP_NONBLOCK" = "yes"; then
+    AC_MSG_ERROR([SP non-blocking not supported with sp-asm])
+  fi
+  if test "$ENABLED_ASM" = "no"; then
+    AC_MSG_ERROR([Assembly code turned off])
+  fi
+
+  AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ASM"
+  AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ASM"
+  case $host_cpu in
+  *aarch64*)
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM64_ASM"
+    AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM64_ASM"
+    ENABLED_SP_ARM64_ASM=yes
+    ;;
+  *arm*)
+    if test $host_alias = "thumb"; then
+      AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_THUMB_ASM -mthumb -march=armv6"
+      AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM_THUMB_ASM"
+      ENABLED_SP_ARM_THUMB_ASM=yes
+    else
+      if test $host_alias = "cortex"; then
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM_CORTEX_M_ASM -mcpu=cortex-r5"
+        AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM_CORTEX_M_ASM"
+        ENABLED_SP_ARM_CORTEX_ASM=yes
+      else
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_ARM32_ASM"
+        AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_ARM32_ASM"
+        ENABLED_SP_ARM32_ASM=yes
+      fi
+    fi
+    ;;
+  *x86_64*)
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_X86_64_ASM"
+    AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_X86_64_ASM"
+    ENABLED_SP_X86_64_ASM=yes
+    if test "x$ENABLED_FASTMATH" = "xno"
+    then
+      AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_X86_64_BUILD"
+    fi
+    ;;
+  *)
+    AC_MSG_ERROR([ASM not available for CPU. Supported CPUs: x86_64, aarch64, arm])
+    ;;
+  esac
+
+fi
+
+
 if test "$ENABLED_SP_MATH" = "yes"; then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_MATH"
 fi
+
 
 # Fast RSA using Intel IPP
 ippdir="${srcdir}/IPP"

--- a/doc/dox_comments/header_files/sha256.h
+++ b/doc/dox_comments/header_files/sha256.h
@@ -11,7 +11,7 @@
     _Example_
     \code
     Sha256 sha256[1];
-    if ((ret = wc_InitSha356(sha256)) != 0) {
+    if ((ret = wc_InitSha256(sha256)) != 0) {
         WOLFSSL_MSG("wc_InitSha256 failed");
     }
     else {
@@ -76,7 +76,7 @@ WOLFSSL_API int wc_Sha256Update(wc_Sha256*, const byte*, word32);
     byte data[] = { Data to be hashed };
     word32 len = sizeof(data);
 
-    if ((ret = wc_InitSha356(sha256)) != 0) {
+    if ((ret = wc_InitSha256(sha256)) != 0) {
        WOLFSSL_MSG("wc_InitSha256 failed");
     }
     else {
@@ -137,7 +137,7 @@ WOLFSSL_API void wc_Sha256Free(wc_Sha256*);
     _Example_
     \code
     Sha256 sha256[1];
-    if ((ret = wc_InitSha356(sha256)) != 0) {
+    if ((ret = wc_InitSha256(sha256)) != 0) {
        WOLFSSL_MSG("wc_InitSha256 failed");
     }
     else {

--- a/src/internal.c
+++ b/src/internal.c
@@ -351,7 +351,7 @@ static word32 GetEntropy(unsigned char* out, word32 num_bytes)
     static void* myAlloc(void* opaque, unsigned int item, unsigned int size)
     {
         (void)opaque;
-        return XMALLOC(item * size, opaque, DYNAMIC_TYPE_LIBZ);
+        return (void *)XMALLOC(item * size, opaque, DYNAMIC_TYPE_LIBZ);
     }
 
 
@@ -6052,7 +6052,7 @@ int AllocKey(WOLFSSL* ssl, int type, void** pKey)
     }
 
     /* Allocate memory for key */
-    *pKey = XMALLOC(sz, ssl->heap, type);
+    *pKey = (void *)XMALLOC(sz, ssl->heap, type);
     if (*pKey == NULL) {
         return MEMORY_E;
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -47059,10 +47059,12 @@ unsigned long wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM *bn,
     }
 
     if (w <= MP_MASK) {
-        if (mp_mod_d((mp_int*)bn->internal, (WOLFSSL_BN_ULONG)w, &ret) != MP_OKAY) {
+        WOLFSSL_BN_ULONG bn_ret;
+        if (mp_mod_d((mp_int*)bn->internal, (WOLFSSL_BN_ULONG)w, &bn_ret) != MP_OKAY) {
             WOLFSSL_MSG("mp_add_d error");
             return (unsigned long)WOLFSSL_FATAL_ERROR;
         }
+        ret = (unsigned long)bn_ret;
     } else {
         int mp_ret;
         mp_int w_mp, r_mp;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -46753,16 +46753,16 @@ int wolfSSL_BN_set_word(WOLFSSL_BIGNUM* bn, unsigned long w)
     return WOLFSSL_SUCCESS;
 }
 
-static unsigned long wolfSSL_BN_get_word_1(mp_int *mp) {
+static WOLFSSL_BN_ULONG wolfSSL_BN_get_word_1(mp_int *mp) {
 #if DIGIT_BIT == (SIZEOF_LONG * 8)
-    return (unsigned long)mp->dp[0];
+    return (WOLFSSL_BN_ULONG)mp->dp[0];
 #else
-    unsigned long ret = 0UL;
+    WOLFSSL_BN_ULONG ret = 0UL;
     int digit_i;
 
     for (digit_i = 0; digit_i < mp->used; ++digit_i) {
-        ret <<= (unsigned long)DIGIT_BIT;
-        ret |= (unsigned long)mp->dp[digit_i];
+        ret <<= (WOLFSSL_BN_ULONG)DIGIT_BIT;
+        ret |= (WOLFSSL_BN_ULONG)mp->dp[digit_i];
     }
 
     return ret;
@@ -46775,7 +46775,7 @@ static unsigned long wolfSSL_BN_get_word_1(mp_int *mp) {
  *
  * Returns value or 0xFFFFFFFFL if bigger than unsigned long.
  */
-unsigned long wolfSSL_BN_get_word(const WOLFSSL_BIGNUM* bn)
+WOLFSSL_BN_ULONG wolfSSL_BN_get_word(const WOLFSSL_BIGNUM* bn)
 {
     WOLFSSL_MSG("wolfSSL_BN_get_word");
 
@@ -46893,7 +46893,7 @@ int wolfSSL_BN_rshift(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *bn, int n)
 /* return code compliant with OpenSSL :
  *   1 if success, 0 else
  */
-int wolfSSL_BN_add_word(WOLFSSL_BIGNUM *bn, unsigned long w)
+int wolfSSL_BN_add_word(WOLFSSL_BIGNUM *bn, WOLFSSL_BN_ULONG w)
 {
     WOLFSSL_MSG("wolfSSL_BN_add_word");
 
@@ -46903,7 +46903,7 @@ int wolfSSL_BN_add_word(WOLFSSL_BIGNUM *bn, unsigned long w)
     }
 
     if (w <= MP_MASK) {
-        if (mp_add_d((mp_int*)bn->internal, (WOLFSSL_BN_ULONG)w, (mp_int*)bn->internal) != MP_OKAY) {
+        if (mp_add_d((mp_int*)bn->internal, (mp_digit)w, (mp_int*)bn->internal) != MP_OKAY) {
             WOLFSSL_MSG("mp_add_d error");
             return WOLFSSL_FAILURE;
         }
@@ -47042,10 +47042,10 @@ int wolfSSL_BN_is_prime_ex(const WOLFSSL_BIGNUM *bn, int nbchecks,
 /* return code compliant with OpenSSL :
  *   (bn mod w) if success, -1 if error
  */
-unsigned long wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM *bn,
-                                     unsigned long w)
+WOLFSSL_BN_ULONG wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM *bn,
+                                     WOLFSSL_BN_ULONG w)
 {
-    unsigned long ret = 0;
+    WOLFSSL_BN_ULONG ret = 0;
 
     WOLFSSL_MSG("wolfSSL_BN_mod_word");
 
@@ -47055,12 +47055,12 @@ unsigned long wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM *bn,
     }
 
     if (w <= MP_MASK) {
-        WOLFSSL_BN_ULONG bn_ret;
+        mp_digit bn_ret;
         if (mp_mod_d((mp_int*)bn->internal, (WOLFSSL_BN_ULONG)w, &bn_ret) != MP_OKAY) {
             WOLFSSL_MSG("mp_add_d error");
-            return (unsigned long)WOLFSSL_FATAL_ERROR;
+            return (WOLFSSL_BN_ULONG)WOLFSSL_FATAL_ERROR;
         }
-        ret = (unsigned long)bn_ret;
+        ret = (WOLFSSL_BN_ULONG)bn_ret;
     } else {
         int mp_ret;
         mp_int w_mp, r_mp;
@@ -47076,7 +47076,7 @@ unsigned long wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM *bn,
         mp_free(&w_mp);
         if (mp_ret != MP_OKAY) {
             WOLFSSL_MSG("mp_mod error");
-            return (unsigned long)WOLFSSL_FAILURE;
+            return (WOLFSSL_BN_ULONG)WOLFSSL_FAILURE;
         }
     }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -46760,13 +46760,9 @@ static unsigned long wolfSSL_BN_get_word_1(mp_int *mp) {
     unsigned long ret = 0UL;
     int digit_i;
 
-    if ((unsigned long)DIGIT_BIT == (sizeof(unsigned long) * 8UL))
-        return (unsigned long)mp->dp[0];
-    else {
-        for (digit_i = 0; digit_i < mp->used; ++digit_i) {
-            ret <<= (unsigned long)DIGIT_BIT;
-            ret |= (unsigned long)mp->dp[digit_i];
-        }
+    for (digit_i = 0; digit_i < mp->used; ++digit_i) {
+        ret <<= (unsigned long)DIGIT_BIT;
+        ret |= (unsigned long)mp->dp[digit_i];
     }
 
     return ret;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -29045,7 +29045,7 @@ void *wolfSSL_ASN1_item_new(const WOLFSSL_ASN1_ITEM *tpl)
     if (!tpl) {
         return NULL;
     }
-    if (!(ret = XMALLOC(tpl->size, NULL, DYNAMIC_TYPE_OPENSSL))) {
+    if (!(ret = (void *)XMALLOC(tpl->size, NULL, DYNAMIC_TYPE_OPENSSL))) {
         return NULL;
     }
     XMEMSET(ret, 0, tpl->size);
@@ -31817,7 +31817,7 @@ void wolfSSL_OPENSSL_free(void* p)
 
 void *wolfSSL_OPENSSL_malloc(size_t a)
 {
-  return XMALLOC(a, NULL, DYNAMIC_TYPE_OPENSSL);
+    return (void *)XMALLOC(a, NULL, DYNAMIC_TYPE_OPENSSL);
 }
 
 int wolfSSL_OPENSSL_init_ssl(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -2091,7 +2091,7 @@ void* mynewt_ctx_new() {
     if(!mynewt_ctx) return NULL;
 
     XMEMSET(mynewt_ctx, 0, sizeof(Mynewt_Ctx));
-    mynewt_ctx->mnMemBuffer = XMALLOC(mempool_bytes, 0, 0);
+    mynewt_ctx->mnMemBuffer = (void *)XMALLOC(mempool_bytes, 0, 0);
     if(!mynewt_ctx->mnMemBuffer) {
         mynewt_ctx_clear((void*)mynewt_ctx);
         return NULL;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -1193,7 +1193,7 @@ int wc_BerToDer(const byte* ber, word32 berSz, byte* der, word32* derSz)
         return BAD_FUNC_ARG;
 
 #ifdef WOLFSSL_SMALL_STACK
-    indefItems = XMALLOC(sizeof(IndefItems), NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    indefItems = (IndefItems *)XMALLOC(sizeof(IndefItems), NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (indefItems == NULL) {
         ret = MEMORY_E;
         goto end;

--- a/wolfcrypt/src/chacha20_poly1305.c
+++ b/wolfcrypt/src/chacha20_poly1305.c
@@ -360,7 +360,7 @@ static WC_INLINE int wc_XChaCha20Poly1305_crypt_oneshot(
     byte *dst_i;
     size_t src_len_rem;
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
-    ChaChaPoly_Aead *aead = XMALLOC(sizeof *aead, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    ChaChaPoly_Aead *aead = (ChaChaPoly_Aead *)XMALLOC(sizeof *aead, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
     if (aead == NULL)
         return MEMORY_E;

--- a/wolfcrypt/src/compress.c
+++ b/wolfcrypt/src/compress.c
@@ -47,7 +47,7 @@
 static void* myAlloc(void* opaque, unsigned int item, unsigned int size)
 {
     (void)opaque;
-    return XMALLOC(item * size, opaque, DYNAMIC_TYPE_LIBZ);
+    return (void *)XMALLOC(item * size, opaque, DYNAMIC_TYPE_LIBZ);
 }
 
 

--- a/wolfcrypt/src/dsa.c
+++ b/wolfcrypt/src/dsa.c
@@ -654,32 +654,67 @@ int wc_DsaExportKeyRaw(DsaKey* dsa, byte* x, word32* xSz, byte* y, word32* ySz)
 
 int wc_DsaSign(const byte* digest, byte* out, DsaKey* key, WC_RNG* rng)
 {
-    mp_int  k, kInv, r, s, H;
+#ifdef WOLFSSL_SMALL_STACK
+    mp_int  *k = (mp_int *)XMALLOC(sizeof *k,
+                                   key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    mp_int  *kInv = (mp_int *)XMALLOC(sizeof *kInv,
+                                   key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    mp_int  *r = (mp_int *)XMALLOC(sizeof *r,
+                                   key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    mp_int  *s = (mp_int *)XMALLOC(sizeof *s,
+                                   key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    mp_int  *H = (mp_int *)XMALLOC(sizeof *H,
+                                   key->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #ifndef WOLFSSL_MP_INVMOD_CONSTANT_TIME
-    mp_int  b;
+    mp_int  *b = (mp_int *)XMALLOC(sizeof *b,
+                                   key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+    byte    *buffer = (byte *)XMALLOC(DSA_HALF_SIZE, key->heap,
+                                      DYNAMIC_TYPE_TMP_BUFFER);
+#else
+    mp_int  k[1], kInv[1], r[1], s[1], H[1];
+#ifndef WOLFSSL_MP_INVMOD_CONSTANT_TIME
+    mp_int  b[1];
+#endif
+    byte    buffer[DSA_HALF_SIZE];
 #endif
     mp_int* qMinus1;
-    int     ret = 0, sz;
-    byte    buffer[DSA_HALF_SIZE];
+    int     ret = 0, sz = 0;
     byte*   tmp;  /* initial output pointer */
 
-    if (digest == NULL || out == NULL || key == NULL || rng == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    tmp = out;
-
-    sz = min((int)sizeof(buffer), mp_unsigned_bin_size(&key->q));
-
 #ifdef WOLFSSL_MP_INVMOD_CONSTANT_TIME
-    if (mp_init_multi(&k, &kInv, &r, &s, &H, 0) != MP_OKAY)
+    if (mp_init_multi(k, kInv, r, s, H, 0) != MP_OKAY)
 #else
-    if (mp_init_multi(&k, &kInv, &r, &s, &H, &b) != MP_OKAY)
+    if (mp_init_multi(k, kInv, r, s, H, b) != MP_OKAY)
 #endif
     {
-        return MP_INIT_E;
+        ret = MP_INIT_E;
+        goto out;
     }
-    qMinus1 = &kInv;
+
+#ifdef WOLFSSL_SMALL_STACK
+    if ((k == NULL) ||
+        (kInv == NULL) ||
+        (r == NULL) ||
+        (s == NULL) ||
+        (H == NULL)
+#ifndef WOLFSSL_MP_INVMOD_CONSTANT_TIME
+        || (b == NULL)
+#endif
+        || (buffer == NULL)) {
+        ret = MEMORY_E;
+        goto out;
+    }
+#endif
+
+    if (digest == NULL || out == NULL || key == NULL || rng == NULL) {
+        ret = BAD_FUNC_ARG;
+        goto out;
+    }
+
+    sz = min(DSA_HALF_SIZE, mp_unsigned_bin_size(&key->q));
+    tmp = out;
+    qMinus1 = kInv;
 
     /* NIST FIPS 186-4: B.2.2
      * Per-Message Secret Number Generation by Testing Candidates
@@ -687,159 +722,248 @@ int wc_DsaSign(const byte* digest, byte* out, DsaKey* key, WC_RNG* rng)
      *   Check that k is less than q-1: range [0, q-2].
      *   Add 1 to k: range [1, q-1].
      */
-    if (mp_sub_d(&key->q, 1, qMinus1))
+    if (mp_sub_d(&key->q, 1, qMinus1)) {
         ret = MP_SUB_E;
-
-    if (ret == 0) {
-        do {
-            /* Step 4: generate k */
-            ret = wc_RNG_GenerateBlock(rng, buffer, sz);
-
-            /* Step 5 */
-            if (ret == 0 && mp_read_unsigned_bin(&k, buffer, sz) != MP_OKAY)
-                ret = MP_READ_E;
-
-            /* k is a random numnber and it should be less than q-1
-             * if k greater than repeat
-             */
-        /* Step 6 */
-        } while (ret == 0 && mp_cmp(&k, qMinus1) != MP_LT);
+        goto out;
     }
+
+    do {
+        /* Step 4: generate k */
+        if ((ret = wc_RNG_GenerateBlock(rng, buffer, sz))) {
+            goto out;
+        }
+
+        /* Step 5 */
+        if (mp_read_unsigned_bin(k, buffer, sz) != MP_OKAY) {
+            ret = MP_READ_E;
+            goto out;
+        }
+
+        /* k is a random numnber and it should be less than q-1
+         * if k greater than repeat
+         */
+        /* Step 6 */
+    } while (mp_cmp(k, qMinus1) != MP_LT);
+
     /* Step 7 */
-    if (ret == 0 && mp_add_d(&k, 1, &k) != MP_OKAY)
+    if (mp_add_d(k, 1, k) != MP_OKAY) {
         ret = MP_MOD_E;
+        goto out;
+    }
 
 #ifdef WOLFSSL_MP_INVMOD_CONSTANT_TIME
     /* inverse k mod q */
-    if (ret == 0 && mp_invmod(&k, &key->q, &kInv) != MP_OKAY)
+    if (mp_invmod(k, &key->q, kInv) != MP_OKAY) {
         ret = MP_INVMOD_E;
-
-    /* generate r, r = (g exp k mod p) mod q */
-    if (ret == 0 && mp_exptmod_ex(&key->g, &k, key->q.used, &key->p,
-                                                               &r) != MP_OKAY) {
-        ret = MP_EXPTMOD_E;
+        goto out;
     }
 
-    if (ret == 0 && mp_mod(&r, &key->q, &r) != MP_OKAY)
+    /* generate r, r = (g exp k mod p) mod q */
+    if (mp_exptmod_ex(&key->g, k, key->q.used, &key->p, r) != MP_OKAY) {
+        ret = MP_EXPTMOD_E;
+        goto out;
+    }
+
+    if (mp_mod(r, &key->q, r) != MP_OKAY) {
         ret = MP_MOD_E;
+        goto out;
+    }
 
     /* generate H from sha digest */
-    if (ret == 0 && mp_read_unsigned_bin(&H, digest,WC_SHA_DIGEST_SIZE) != MP_OKAY)
+    if (mp_read_unsigned_bin(H, digest,WC_SHA_DIGEST_SIZE) != MP_OKAY) {
         ret = MP_READ_E;
+        goto out;
+    }
 
     /* generate s, s = (kInv * (H + x*r)) % q */
-    if (ret == 0 && mp_mul(&key->x, &r, &s) != MP_OKAY)
+    if (mp_mul(&key->x, r, s) != MP_OKAY) {
         ret = MP_MUL_E;
+        goto out;
+    }
 
-    if (ret == 0 && mp_add(&s, &H, &s) != MP_OKAY)
+    if (mp_add(s, H, s) != MP_OKAY) {
         ret = MP_ADD_E;
+        goto out;
+    }
 
-    if (ret == 0 && mp_mulmod(&s, &kInv, &key->q, &s) != MP_OKAY)
+    if (mp_mulmod(s, kInv, &key->q, s) != MP_OKAY) {
         ret = MP_MULMOD_E;
+        goto out;
+    }
 #else
     /* Blinding value
      * Generate b in range [1, q-1].
      */
-    if (ret == 0) {
-        do {
-            ret = wc_RNG_GenerateBlock(rng, buffer, sz);
-            if (ret == 0 && mp_read_unsigned_bin(&b, buffer, sz) != MP_OKAY)
-                ret = MP_READ_E;
-        } while (ret == 0 && mp_cmp(&b, qMinus1) != MP_LT);
-    }
-    if (ret == 0 && mp_add_d(&b, 1, &b) != MP_OKAY)
+    do {
+        if ((ret = wc_RNG_GenerateBlock(rng, buffer, sz))) {
+            goto out;
+        }
+        if (mp_read_unsigned_bin(b, buffer, sz) != MP_OKAY) {
+            ret = MP_READ_E;
+            goto out;
+        }
+    } while (mp_cmp(b, qMinus1) != MP_LT);
+
+    if (mp_add_d(b, 1, b) != MP_OKAY) {
         ret = MP_MOD_E;
+        goto out;
+    }
 
     /* set H from sha digest */
-    if (ret == 0 && mp_read_unsigned_bin(&H, digest,
-                                               WC_SHA_DIGEST_SIZE) != MP_OKAY) {
+    if (mp_read_unsigned_bin(H, digest, WC_SHA_DIGEST_SIZE) != MP_OKAY) {
         ret = MP_READ_E;
+        goto out;
     }
 
     /* generate r, r = (g exp k mod p) mod q */
-    if (ret == 0 && mp_exptmod_ex(&key->g, &k, key->q.used, &key->p,
-                                                               &r) != MP_OKAY) {
+    if (mp_exptmod_ex(&key->g, k, key->q.used, &key->p, r) != MP_OKAY) {
         ret = MP_EXPTMOD_E;
+        goto out;
     }
 
-    /* calculate s = (H + xr)/k
-                   = b.(H/k.b + x.r/k.b) */
+    /* calculate s = (H + xr)/k = b.(H/k.b + x.r/k.b) */
 
     /* k = k.b */
-    if (ret == 0 && mp_mulmod(&k, &b, &key->q, &k) != MP_OKAY)
+    if (mp_mulmod(k, b, &key->q, k) != MP_OKAY) {
         ret = MP_MULMOD_E;
+        goto out;
+    }
 
     /* kInv = 1/k.b mod q */
-    if (ret == 0 && mp_invmod(&k, &key->q, &kInv) != MP_OKAY)
+    if (mp_invmod(k, &key->q, kInv) != MP_OKAY) {
         ret = MP_INVMOD_E;
+        goto out;
+    }
 
-    if (ret == 0 && mp_mod(&r, &key->q, &r) != MP_OKAY)
+    if (mp_mod(r, &key->q, r) != MP_OKAY) {
         ret = MP_MOD_E;
+        goto out;
+    }
 
     /* s = x.r */
-    if (ret == 0 && mp_mul(&key->x, &r, &s) != MP_OKAY)
+    if (mp_mul(&key->x, r, s) != MP_OKAY) {
         ret = MP_MUL_E;
+        goto out;
+    }
 
     /* s = x.r/k.b */
-    if (ret == 0 && mp_mulmod(&s, &kInv, &key->q, &s) != MP_OKAY)
+    if (mp_mulmod(s, kInv, &key->q, s) != MP_OKAY) {
         ret = MP_MULMOD_E;
+        goto out;
+    }
 
     /* H = H/k.b */
-    if (ret == 0 && mp_mulmod(&H, &kInv, &key->q, &H) != MP_OKAY)
+    if (mp_mulmod(H, kInv, &key->q, H) != MP_OKAY) {
         ret = MP_MULMOD_E;
+        goto out;
+    }
 
-    /* s = H/k.b + x.r/k.b
-         = (H + x.r)/k.b */
-    if (ret == 0 && mp_add(&s, &H, &s) != MP_OKAY)
+    /* s = H/k.b + x.r/k.b = (H + x.r)/k.b */
+    if (mp_add(s, H, s) != MP_OKAY) {
         ret = MP_ADD_E;
+        goto out;
+    }
 
-    /* s = b.(e + x.r)/k.b
-         = (e + x.r)/k */
-    if (ret == 0 && mp_mulmod(&s, &b, &key->q, &s) != MP_OKAY)
+    /* s = b.(e + x.r)/k.b = (e + x.r)/k */
+    if (mp_mulmod(s, b, &key->q, s) != MP_OKAY) {
         ret = MP_MULMOD_E;
+        goto out;
+    }
 
     /* s = (e + x.r)/k */
-    if (ret == 0 && mp_mod(&s, &key->q, &s) != MP_OKAY)
+    if (mp_mod(s, &key->q, s) != MP_OKAY) {
         ret = MP_MOD_E;
+        goto out;
+    }
 #endif
 
     /* detect zero r or s */
-    if (ret == 0 && (mp_iszero(&r) == MP_YES || mp_iszero(&s) == MP_YES))
+    if ((mp_iszero(r) == MP_YES) || (mp_iszero(s) == MP_YES)) {
         ret = MP_ZERO_E;
+        goto out;
+    }
 
     /* write out */
-    if (ret == 0)  {
-        int rSz = mp_unsigned_bin_size(&r);
-        int sSz = mp_unsigned_bin_size(&s);
+    {
+        int rSz = mp_unsigned_bin_size(r);
+        int sSz = mp_unsigned_bin_size(s);
 
         while (rSz++ < DSA_HALF_SIZE) {
             *out++ = 0x00;  /* pad front with zeros */
         }
 
-        if (mp_to_unsigned_bin(&r, out) != MP_OKAY)
+        if (mp_to_unsigned_bin(r, out) != MP_OKAY)
             ret = MP_TO_E;
         else {
             out = tmp + DSA_HALF_SIZE;  /* advance to s in output */
             while (sSz++ < DSA_HALF_SIZE) {
                 *out++ = 0x00;  /* pad front with zeros */
             }
-            ret = mp_to_unsigned_bin(&s, out);
+            ret = mp_to_unsigned_bin(s, out);
         }
     }
 
-    ForceZero(buffer, sz);
-    mp_forcezero(&kInv);
-    mp_forcezero(&k);
-#ifndef WOLFSSL_MP_INVMOD_CONSTANT_TIME
-    mp_forcezero(&b);
+  out:
 
-    mp_clear(&b);
+#ifdef WOLFSSL_SMALL_STACK
+    if (k) {
+        if (ret != MP_INIT_E) {
+            mp_forcezero(k);
+            mp_clear(k);
+        }
+        XFREE(k, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (kInv) {
+        if (ret != MP_INIT_E) {
+            mp_forcezero(kInv);
+            mp_clear(kInv);
+        }
+        XFREE(kInv, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (r) {
+        if (ret != MP_INIT_E)
+            mp_clear(r);
+        XFREE(r, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (s) {
+        if (ret != MP_INIT_E)
+            mp_clear(s);
+        XFREE(s, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (H) {
+        if (ret != MP_INIT_E)
+            mp_clear(H);
+        XFREE(H, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+#ifndef WOLFSSL_MP_INVMOD_CONSTANT_TIME
+    if (b) {
+        if (ret != MP_INIT_E) {
+            mp_forcezero(b);
+            mp_clear(b);
+        }
+        XFREE(b, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
 #endif
-    mp_clear(&H);
-    mp_clear(&s);
-    mp_clear(&r);
-    mp_clear(&kInv);
-    mp_clear(&k);
+    if (buffer) {
+        ForceZero(buffer, sz);
+        XFREE(buffer, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+#else /* !WOLFSSL_SMALL_STACK */
+    if (ret != MP_INIT_E) {
+        ForceZero(buffer, sz);
+        mp_forcezero(kInv);
+        mp_forcezero(k);
+#ifndef WOLFSSL_MP_INVMOD_CONSTANT_TIME
+        mp_forcezero(b);
+        mp_clear(b);
+#endif
+        mp_clear(H);
+        mp_clear(s);
+        mp_clear(r);
+        mp_clear(kInv);
+        mp_clear(k);
+    }
+#endif
 
     return ret;
 }
@@ -847,70 +971,154 @@ int wc_DsaSign(const byte* digest, byte* out, DsaKey* key, WC_RNG* rng)
 
 int wc_DsaVerify(const byte* digest, const byte* sig, DsaKey* key, int* answer)
 {
-    mp_int w, u1, u2, v, r, s;
+#ifdef WOLFSSL_SMALL_STACK
+    mp_int *w = (mp_int *)XMALLOC(sizeof *w,
+                                   key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    mp_int *u1 = (mp_int *)XMALLOC(sizeof *u1,
+                                   key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    mp_int *u2 = (mp_int *)XMALLOC(sizeof *u2,
+                                   key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    mp_int *v = (mp_int *)XMALLOC(sizeof *v,
+                                   key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    mp_int *r = (mp_int *)XMALLOC(sizeof *r,
+                                   key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    mp_int *s = (mp_int *)XMALLOC(sizeof *s,
+                                   key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#else
+    mp_int w[1], u1[1], u2[1], v[1], r[1], s[1];
+#endif
     int    ret = 0;
 
-    if (digest == NULL || sig == NULL || key == NULL || answer == NULL) {
-        return BAD_FUNC_ARG;
+    if (mp_init_multi(w, u1, u2, v, r, s) != MP_OKAY) {
+        ret = MP_INIT_E;
+        goto out;
     }
 
-    if (mp_init_multi(&w, &u1, &u2, &v, &r, &s) != MP_OKAY)
-        return MP_INIT_E;
+    if (digest == NULL || sig == NULL || key == NULL || answer == NULL) {
+        ret = BAD_FUNC_ARG;
+        goto out;
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    if ((w == NULL) ||
+        (u1 == NULL) ||
+        (u2 == NULL) ||
+        (v == NULL) ||
+        (r == NULL) ||
+        (s == NULL)) {
+        ret = MEMORY_E;
+        goto out;
+    }
+#endif
 
     /* set r and s from signature */
-    if (mp_read_unsigned_bin(&r, sig, DSA_HALF_SIZE) != MP_OKAY ||
-        mp_read_unsigned_bin(&s, sig + DSA_HALF_SIZE, DSA_HALF_SIZE) != MP_OKAY)
+    if (mp_read_unsigned_bin(r, sig, DSA_HALF_SIZE) != MP_OKAY ||
+        mp_read_unsigned_bin(s, sig + DSA_HALF_SIZE, DSA_HALF_SIZE) != MP_OKAY) {
         ret = MP_READ_E;
+        goto out;
+    }
 
     /* sanity checks */
-    if (ret == 0) {
-        if (mp_iszero(&r) == MP_YES || mp_iszero(&s) == MP_YES ||
-                mp_cmp(&r, &key->q) != MP_LT || mp_cmp(&s, &key->q) != MP_LT) {
-            ret = MP_ZERO_E;
-        }
+    if (mp_iszero(r) == MP_YES || mp_iszero(s) == MP_YES ||
+        mp_cmp(r, &key->q) != MP_LT || mp_cmp(s, &key->q) != MP_LT) {
+        ret = MP_ZERO_E;
+        goto out;
     }
 
     /* put H into u1 from sha digest */
-    if (ret == 0 && mp_read_unsigned_bin(&u1,digest,WC_SHA_DIGEST_SIZE) != MP_OKAY)
+    if (mp_read_unsigned_bin(u1,digest,WC_SHA_DIGEST_SIZE) != MP_OKAY) {
         ret = MP_READ_E;
+        goto out;
+    }
 
     /* w = s invmod q */
-    if (ret == 0 && mp_invmod(&s, &key->q, &w) != MP_OKAY)
+    if (mp_invmod(s, &key->q, w) != MP_OKAY) {
         ret = MP_INVMOD_E;
+        goto out;
+    }
 
     /* u1 = (H * w) % q */
-    if (ret == 0 && mp_mulmod(&u1, &w, &key->q, &u1) != MP_OKAY)
+    if (mp_mulmod(u1, w, &key->q, u1) != MP_OKAY) {
         ret = MP_MULMOD_E;
+        goto out;
+    }
 
     /* u2 = (r * w) % q */
-    if (ret == 0 && mp_mulmod(&r, &w, &key->q, &u2) != MP_OKAY)
+    if (mp_mulmod(r, w, &key->q, u2) != MP_OKAY) {
         ret = MP_MULMOD_E;
+        goto out;
+    }
 
     /* verify v = ((g^u1 * y^u2) mod p) mod q */
-    if (ret == 0 && mp_exptmod(&key->g, &u1, &key->p, &u1) != MP_OKAY)
+    if (mp_exptmod(&key->g, u1, &key->p, u1) != MP_OKAY) {
         ret = MP_EXPTMOD_E;
+        goto out;
+    }
 
-    if (ret == 0 && mp_exptmod(&key->y, &u2, &key->p, &u2) != MP_OKAY)
+    if (mp_exptmod(&key->y, u2, &key->p, u2) != MP_OKAY) {
         ret = MP_EXPTMOD_E;
+        goto out;
+    }
 
-    if (ret == 0 && mp_mulmod(&u1, &u2, &key->p, &v) != MP_OKAY)
+    if (mp_mulmod(u1, u2, &key->p, v) != MP_OKAY) {
         ret = MP_MULMOD_E;
+        goto out;
+    }
 
-    if (ret == 0 && mp_mod(&v, &key->q, &v) != MP_OKAY)
+    if (mp_mod(v, &key->q, v) != MP_OKAY) {
         ret = MP_MULMOD_E;
+        goto out;
+    }
 
     /* do they match */
-    if (ret == 0 && mp_cmp(&r, &v) == MP_EQ)
+    if (mp_cmp(r, v) == MP_EQ)
         *answer = 1;
     else
         *answer = 0;
 
-    mp_clear(&s);
-    mp_clear(&r);
-    mp_clear(&u1);
-    mp_clear(&u2);
-    mp_clear(&w);
-    mp_clear(&v);
+  out:
+
+#ifdef WOLFSSL_SMALL_STACK
+    if (s) {
+        if (ret != MP_INIT_E)
+            mp_clear(s);
+        XFREE(s, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (r) {
+        if (ret != MP_INIT_E)
+            mp_clear(r);
+        XFREE(r, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (u1) {
+        if (ret != MP_INIT_E)
+            mp_clear(u1);
+        XFREE(u1, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (u2) {
+        if (ret != MP_INIT_E)
+            mp_clear(u2);
+        XFREE(u2, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (w) {
+        if (ret != MP_INIT_E)
+            mp_clear(w);
+        XFREE(w, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (v) {
+        if (ret != MP_INIT_E)
+            mp_clear(v);
+        XFREE(v, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+#else
+    if (ret != MP_INIT_E) {
+        mp_clear(s);
+        mp_clear(r);
+        mp_clear(u1);
+        mp_clear(u2);
+        mp_clear(w);
+        mp_clear(v);
+    }
+#endif
 
     return ret;
 }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2938,23 +2938,28 @@ int wc_ecc_mulmod_ex(mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
    ecc_point     *tG, *M[M_POINTS];
    int           i, err;
 #ifdef WOLFSSL_SMALL_STACK_CACHE
-   ecc_key       key;
+   ecc_key       *key = (ecc_key *)XMALLOC(sizeof *key, heap, DYNAMIC_TYPE_ECC);
 #endif
    mp_digit      mp;
-
-   if (k == NULL || G == NULL || R == NULL || modulus == NULL) {
-       return ECC_BAD_ARG_E;
-   }
 
    /* init variables */
    tG = NULL;
    XMEMSET(M, 0, sizeof(M));
 
+   if (k == NULL || G == NULL || R == NULL || modulus == NULL) {
+       err = ECC_BAD_ARG_E;
+       goto exit;
+   }
+
 #ifdef WOLFSSL_SMALL_STACK_CACHE
-   err = ecc_key_tmp_init(&key, heap);
+   if (key == NULL) {
+       err = MP_MEM;
+       goto exit;
+   }
+   err = ecc_key_tmp_init(key, heap);
    if (err != MP_OKAY)
       goto exit;
-   R->key = &key;
+   R->key = key;
 #endif /* WOLFSSL_SMALL_STACK_CACHE */
 
   /* alloc ram for window temps */
@@ -2965,7 +2970,7 @@ int wc_ecc_mulmod_ex(mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
          goto exit;
       }
 #ifdef WOLFSSL_SMALL_STACK_CACHE
-      M[i]->key = &key;
+      M[i]->key = key;
 #endif
   }
 
@@ -3001,8 +3006,11 @@ exit:
        wc_ecc_del_point_h(M[i], heap);
    }
 #ifdef WOLFSSL_SMALL_STACK_CACHE
-   R->key = NULL;
-   ecc_key_tmp_final(&key, heap);
+   if (key) {
+       R->key = NULL;
+       ecc_key_tmp_final(key, heap);
+       XFREE(key, heap, DYNAMIC_TYPE_ECC);
+   }
 #endif /* WOLFSSL_SMALL_STACK_CACHE */
 
    return err;
@@ -10762,40 +10770,66 @@ int mp_sqrtmod_prime(mp_int* n, mp_int* prime, mp_int* ret)
   return res;
 #else
   int res, legendre, done = 0;
-  mp_int t1, C, Q, S, Z, M, T, R, two;
   mp_digit i;
+#ifdef WOLFSSL_SMALL_STACK
+  mp_int *t1 = (mp_int *)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  mp_int *C = (mp_int *)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  mp_int *Q = (mp_int *)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  mp_int *S = (mp_int *)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  mp_int *Z = (mp_int *)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  mp_int *M = (mp_int *)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  mp_int *T = (mp_int *)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  mp_int *R = (mp_int *)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  mp_int *two = (mp_int *)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_ECC_BUFFER);
+
+  if ((t1 == NULL) ||
+      (C == NULL) ||
+      (Q == NULL) ||
+      (S == NULL) ||
+      (Z == NULL) ||
+      (M == NULL) ||
+      (T == NULL) ||
+      (R == NULL) ||
+      (two == NULL)) {
+    res = MP_MEM;
+    goto out;
+  }
+#else
+  mp_int t1[1], C[1], Q[1], S[1], Z[1], M[1], T[1], R[1], two[1];
+#endif
 
   /* first handle the simple cases n = 0 or n = 1 */
   if (mp_cmp_d(n, 0) == MP_EQ) {
     mp_zero(ret);
-    return MP_OKAY;
+    res = MP_OKAY;
+    goto out;
   }
   if (mp_cmp_d(n, 1) == MP_EQ) {
-    return mp_set(ret, 1);
+    res = mp_set(ret, 1);
+    goto out;
   }
 
   /* prime must be odd */
   if (mp_cmp_d(prime, 2) == MP_EQ) {
-    return MP_VAL;
+    res = MP_VAL;
+    goto out;
   }
 
   /* is quadratic non-residue mod prime */
   if ((res = mp_jacobi(n, prime, &legendre)) != MP_OKAY) {
-    return res;
+    goto out;
   }
   if (legendre == -1) {
-    return MP_VAL;
+    res = MP_VAL;
+    goto out;
   }
 
-  if ((res = mp_init_multi(&t1, &C, &Q, &S, &Z, &M)) != MP_OKAY)
-    return res;
+  if ((res = mp_init_multi(t1, C, Q, S, Z, M)) != MP_OKAY)
+    goto out;
 
-  if ((res = mp_init_multi(&T, &R, &two, NULL, NULL, NULL))
-                          != MP_OKAY) {
-    mp_clear(&t1); mp_clear(&C); mp_clear(&Q); mp_clear(&S); mp_clear(&Z);
-    mp_clear(&M);
-    return res;
-  }
+  if ((res = mp_init_multi(T, R, two, NULL, NULL, NULL))
+                          != MP_OKAY)
+    goto out;
 
   /* SPECIAL CASE: if prime mod 4 == 3
    * compute directly: res = n^(prime+1)/4 mod prime
@@ -10803,14 +10837,14 @@ int mp_sqrtmod_prime(mp_int* n, mp_int* prime, mp_int* ret)
    */
   res = mp_mod_d(prime, 4, &i);
   if (res == MP_OKAY && i == 3) {
-    res = mp_add_d(prime, 1, &t1);
+    res = mp_add_d(prime, 1, t1);
 
     if (res == MP_OKAY)
-      res = mp_div_2(&t1, &t1);
+      res = mp_div_2(t1, t1);
     if (res == MP_OKAY)
-      res = mp_div_2(&t1, &t1);
+      res = mp_div_2(t1, t1);
     if (res == MP_OKAY)
-      res = mp_exptmod(n, &t1, prime, ret);
+      res = mp_exptmod(n, t1, prime, ret);
 
     done = 1;
   }
@@ -10821,122 +10855,162 @@ int mp_sqrtmod_prime(mp_int* n, mp_int* prime, mp_int* ret)
     /* factor out powers of 2 from prime-1, defining Q and S
     *                                      as: prime-1 = Q*2^S */
     /* Q = prime - 1 */
-    res = mp_copy(prime, &Q);
+    res = mp_copy(prime, Q);
     if (res == MP_OKAY)
-      res = mp_sub_d(&Q, 1, &Q);
+      res = mp_sub_d(Q, 1, Q);
 
     /* S = 0 */
     if (res == MP_OKAY)
-      mp_zero(&S);
+      mp_zero(S);
 
-    while (res == MP_OKAY && mp_iseven(&Q) == MP_YES) {
+    while (res == MP_OKAY && mp_iseven(Q) == MP_YES) {
       /* Q = Q / 2 */
-      res = mp_div_2(&Q, &Q);
+      res = mp_div_2(Q, Q);
 
       /* S = S + 1 */
       if (res == MP_OKAY)
-        res = mp_add_d(&S, 1, &S);
+        res = mp_add_d(S, 1, S);
     }
 
     /* find a Z such that the Legendre symbol (Z|prime) == -1 */
     /* Z = 2 */
     if (res == MP_OKAY)
-      res = mp_set_int(&Z, 2);
+      res = mp_set_int(Z, 2);
 
     while (res == MP_OKAY) {
-      res = mp_jacobi(&Z, prime, &legendre);
+      res = mp_jacobi(Z, prime, &legendre);
       if (res == MP_OKAY && legendre == -1)
         break;
 
       /* Z = Z + 1 */
       if (res == MP_OKAY)
-        res = mp_add_d(&Z, 1, &Z);
+        res = mp_add_d(Z, 1, Z);
     }
 
     /* C = Z ^ Q mod prime */
     if (res == MP_OKAY)
-      res = mp_exptmod(&Z, &Q, prime, &C);
+      res = mp_exptmod(Z, Q, prime, C);
 
     /* t1 = (Q + 1) / 2 */
     if (res == MP_OKAY)
-      res = mp_add_d(&Q, 1, &t1);
+      res = mp_add_d(Q, 1, t1);
     if (res == MP_OKAY)
-      res = mp_div_2(&t1, &t1);
+      res = mp_div_2(t1, t1);
 
     /* R = n ^ ((Q + 1) / 2) mod prime */
     if (res == MP_OKAY)
-      res = mp_exptmod(n, &t1, prime, &R);
+      res = mp_exptmod(n, t1, prime, R);
 
     /* T = n ^ Q mod prime */
     if (res == MP_OKAY)
-      res = mp_exptmod(n, &Q, prime, &T);
+      res = mp_exptmod(n, Q, prime, T);
 
     /* M = S */
     if (res == MP_OKAY)
-      res = mp_copy(&S, &M);
+      res = mp_copy(S, M);
 
     if (res == MP_OKAY)
-      res = mp_set_int(&two, 2);
+      res = mp_set_int(two, 2);
 
     while (res == MP_OKAY && done == 0) {
-      res = mp_copy(&T, &t1);
+      res = mp_copy(T, t1);
 
       /* reduce to 1 and count */
       i = 0;
       while (res == MP_OKAY) {
-        if (mp_cmp_d(&t1, 1) == MP_EQ)
+        if (mp_cmp_d(t1, 1) == MP_EQ)
             break;
-        res = mp_exptmod(&t1, &two, prime, &t1);
+        res = mp_exptmod(t1, two, prime, t1);
         if (res == MP_OKAY)
           i++;
       }
       if (res == MP_OKAY && i == 0) {
-        res = mp_copy(&R, ret);
+        res = mp_copy(R, ret);
         done = 1;
       }
 
       if (done == 0) {
         /* t1 = 2 ^ (M - i - 1) */
         if (res == MP_OKAY)
-          res = mp_sub_d(&M, i, &t1);
+          res = mp_sub_d(M, i, t1);
         if (res == MP_OKAY)
-          res = mp_sub_d(&t1, 1, &t1);
+          res = mp_sub_d(t1, 1, t1);
         if (res == MP_OKAY)
-          res = mp_exptmod(&two, &t1, prime, &t1);
+          res = mp_exptmod(two, t1, prime, t1);
 
         /* t1 = C ^ (2 ^ (M - i - 1)) mod prime */
         if (res == MP_OKAY)
-          res = mp_exptmod(&C, &t1, prime, &t1);
+          res = mp_exptmod(C, t1, prime, t1);
 
         /* C = (t1 * t1) mod prime */
         if (res == MP_OKAY)
-          res = mp_sqrmod(&t1, prime, &C);
+          res = mp_sqrmod(t1, prime, C);
 
         /* R = (R * t1) mod prime */
         if (res == MP_OKAY)
-          res = mp_mulmod(&R, &t1, prime, &R);
+          res = mp_mulmod(R, t1, prime, R);
 
         /* T = (T * C) mod prime */
         if (res == MP_OKAY)
-          res = mp_mulmod(&T, &C, prime, &T);
+          res = mp_mulmod(T, C, prime, T);
 
         /* M = i */
         if (res == MP_OKAY)
-          res = mp_set(&M, i);
+          res = mp_set(M, i);
       }
     }
   }
 
-  /* done */
-  mp_clear(&t1);
-  mp_clear(&C);
-  mp_clear(&Q);
-  mp_clear(&S);
-  mp_clear(&Z);
-  mp_clear(&M);
-  mp_clear(&T);
-  mp_clear(&R);
-  mp_clear(&two);
+  out:
+
+#ifdef WOLFSSL_SMALL_STACK
+  if (t1) {
+    mp_clear(t1);
+    XFREE(t1, NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  }
+  if (C) {
+    mp_clear(C);
+    XFREE(C, NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  }
+  if (Q) {
+    mp_clear(Q);
+    XFREE(Q, NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  }
+  if (S) {
+    mp_clear(S);
+    XFREE(S, NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  }
+  if (Z) {
+    mp_clear(Z);
+    XFREE(Z, NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  }
+  if (M) {
+    mp_clear(M);
+    XFREE(M, NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  }
+  if (T) {
+    mp_clear(T);
+    XFREE(T, NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  }
+  if (R) {
+    mp_clear(R);
+    XFREE(R, NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  }
+  if (two) {
+    mp_clear(two);
+    XFREE(two, NULL, DYNAMIC_TYPE_ECC_BUFFER);
+  }
+#else
+  mp_clear(t1);
+  mp_clear(C);
+  mp_clear(Q);
+  mp_clear(S);
+  mp_clear(Z);
+  mp_clear(M);
+  mp_clear(T);
+  mp_clear(R);
+  mp_clear(two);
+#endif
 
   return res;
 #endif

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3007,8 +3007,10 @@ exit:
    }
 #ifdef WOLFSSL_SMALL_STACK_CACHE
    if (key) {
-       R->key = NULL;
-       ecc_key_tmp_final(key, heap);
+       if (R)
+           R->key = NULL;
+       if (err == MP_OKAY)
+           ecc_key_tmp_final(key, heap);
        XFREE(key, heap, DYNAMIC_TYPE_ECC);
    }
 #endif /* WOLFSSL_SMALL_STACK_CACHE */

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -24,7 +24,7 @@
     #include <config.h>
 #endif
 
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #ifndef NO_HMAC

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -562,10 +562,10 @@ void mp_rshb (mp_int *c, int x)
     mp_digit r, rr;
     mp_digit D = x;
 
-    /* shifting by a negative number not supported */
-    if (x < 0) return;
-    /* shifting by zero changes nothing */
-    if (x == 0) return;
+    /* shifting by a negative number not supported, and shifting by
+     * zero changes nothing.
+     */
+    if (x <= 0) return;
 
     /* shift digits first if needed */
     if (x >= DIGIT_BIT) {

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -1980,6 +1980,10 @@ static WC_INLINE sp_int_digit sp_div_word(sp_int_digit hi, sp_int_digit lo,
 
 #if defined(WOLFSSL_HAVE_SP_DH) || defined(WOLFSSL_HAVE_SP_RSA)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Modular exponentiation implementations using Single Precision. */
 WOLFSSL_LOCAL int sp_ModExp_1024(sp_int* base, sp_int* exp, sp_int* mod,
     sp_int* res);
@@ -1991,6 +1995,10 @@ WOLFSSL_LOCAL int sp_ModExp_3072(sp_int* base, sp_int* exp, sp_int* mod,
     sp_int* res);
 WOLFSSL_LOCAL int sp_ModExp_4096(sp_int* base, sp_int* exp, sp_int* mod,
     sp_int* res);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif
 
@@ -4994,7 +5002,6 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[5] = l;
             l = h;
             h = o;
-            o = 0;
             SP_ASM_MUL_ADD_NO(l, h, a->dp[3], b->dp[3]);
             t->dp[6] = l;
             t->dp[7] = h;
@@ -5118,7 +5125,6 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[9] = l;
             l = h;
             h = o;
-            o = 0;
             SP_ASM_MUL_ADD_NO(l, h, a->dp[5], b->dp[5]);
             t->dp[10] = l;
             t->dp[11] = h;
@@ -9687,7 +9693,6 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[5] = l;
             l = h;
             h = o;
-            o = 0;
             SP_ASM_SQR_ADD_NO(l, h, a->dp[3]);
             t->dp[6] = l;
             t->dp[7] = h;
@@ -9803,7 +9808,6 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[9] = l;
             l = h;
             h = o;
-            o = 0;
             SP_ASM_SQR_ADD_NO(l, h, a->dp[5]);
             t->dp[10] = l;
             t->dp[11] = h;

--- a/wolfcrypt/src/srp.c
+++ b/wolfcrypt/src/srp.c
@@ -650,7 +650,7 @@ int wc_SrpComputeKey(Srp* srp, byte* clientPubKey, word32 clientPubKeySz,
 
     /* validating params */
 
-    if ((r = mp_init_multi(u, s, temp1, temp2, 0, 0)) != MP_OKAY) {
+    if ((mp_init_multi(u, s, temp1, temp2, 0, 0)) != MP_OKAY) {
         r = MP_INIT_E;
         goto out;
     }

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3903,10 +3903,10 @@ void fp_rshb(fp_int *c, int x)
     fp_digit r, rr;
     fp_digit D = x;
 
-    /* shifting by a negative number not supported */
-    if (x < 0) return;
-    /* shifting by zero changes nothing */
-    if (x == 0) return;
+    /* shifting by a negative number not supported, and shifting by
+     * zero changes nothing.
+     */
+    if (x <= 0) return;
 
     /* shift digits first if needed */
     if (x >= DIGIT_BIT) {

--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -2476,7 +2476,7 @@ static int Pkcs11ECDSA_Verify(Pkcs11Session* session, wc_CryptoInfo* info)
     }
 
     if (ret == 0) {
-        sig = XMALLOC(sz * 2, info->pk.eccverify.key->heap,
+        sig = (unsigned char *)XMALLOC(sz * 2, info->pk.eccverify.key->heap,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
         if (sig == NULL)
             ret = MEMORY_E;

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -700,7 +700,7 @@ XFILE z_fs_open(const char* filename, const char* perm)
 {
     XFILE file;
 
-    file = XMALLOC(sizeof(*file), NULL, DYNAMIC_TYPE_FILE);
+    file = (XFILE)XMALLOC(sizeof(*file), NULL, DYNAMIC_TYPE_FILE);
     if (file != NULL) {
         if (fs_open(file, filename) != 0) {
             XFREE(file, NULL, DYNAMIC_TYPE_FILE);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -15648,12 +15648,14 @@ static int dsa_test(void)
     XMEMCPY(tmp, dsa_key_der_2048, sizeof_dsa_key_der_2048);
     bytes = sizeof_dsa_key_der_2048;
 #else
-    XFILE  file = XFOPEN(dsaKey, "rb");
-    if (!file)
-        ERROR_OUT(-8200, out);
+    {
+        XFILE  file = XFOPEN(dsaKey, "rb");
+        if (!file)
+            ERROR_OUT(-8200, out);
 
-    bytes = (word32) XFREAD(tmp, 1, DSA_TEST_TMP_SIZE, file);
-    XFCLOSE(file);
+        bytes = (word32) XFREAD(tmp, 1, DSA_TEST_TMP_SIZE, file);
+        XFCLOSE(file);
+    }
 #endif /* USE_CERT_BUFFERS */
 
     ret = wc_InitSha_ex(&sha, HEAP_HINT, devId);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -15635,8 +15635,10 @@ static int dsa_test(void)
 #else
     byte   tmp[1024];
     DsaKey key[1];
+#ifdef WOLFSSL_KEY_GEN
     DsaKey derIn[1];
     DsaKey genKey[1];
+#endif
 #endif
 
 #ifdef USE_CERT_BUFFERS_1024

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -3483,7 +3483,7 @@ static int hash_test(void)
         return -3382;
 
 #if !defined(NO_CERTS) && !defined(NO_ASN)
-#if defined(WOLFSSL_MD2) && !defined(HAVE_SELFTEST)
+#if defined(WOLFSSL_MD2) && !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
     ret = wc_GetCTC_HashOID(MD2);
     if (ret == 0)
         return -3383;
@@ -6391,7 +6391,7 @@ EVP_TEST_END:
 
 #ifdef WOLFSSL_AES_128
         /* 128 key size test */
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) && !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
         ret = EVP_test(EVP_aes_128_ofb(), key2, iv2, plain2, sizeof(plain2),
                 cipher2, sizeof(cipher2));
         if (ret != 0) {
@@ -6429,7 +6429,7 @@ EVP_TEST_END:
 
 #ifdef WOLFSSL_AES_192
         /* 192 key size test */
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) && !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
         ret = EVP_test(EVP_aes_192_ofb(), key3, iv3, plain3, sizeof(plain3),
                 cipher3, sizeof(cipher3));
         if (ret != 0) {
@@ -6467,7 +6467,7 @@ EVP_TEST_END:
 
 #ifdef WOLFSSL_AES_256
         /* 256 key size test */
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) && !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
         ret = EVP_test(EVP_aes_256_ofb(), key1, iv1, plain1, sizeof(plain1),
                 cipher1, sizeof(cipher1));
         if (ret != 0) {
@@ -7458,7 +7458,7 @@ static int aes_xts_128_test(void)
         0xff, 0x8d, 0xbc, 0x1d, 0x9f, 0x7f, 0xc8, 0x22
     };
 
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) && !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
     ret = EVP_test(EVP_aes_128_xts(), k2, i2, p2, sizeof(p2), c2, sizeof(c2));
     if (ret != 0) {
         printf("EVP_aes_128_xts failed!\n");
@@ -7639,7 +7639,7 @@ static int aes_xts_256_test(void)
         0xc3, 0xea, 0xd8, 0x10, 0xe9, 0xc0, 0xaf, 0x92
     };
 
-#ifdef OPENSSL_EXTRA
+#if defined(OPENSSL_EXTRA) && !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
     ret = EVP_test(EVP_aes_256_xts(), k2, i2, p2, sizeof(p2), c2, sizeof(c2));
     if (ret != 0) {
         printf("EVP_aes_256_xts failed\n");
@@ -11046,7 +11046,8 @@ byte GetEntropy(ENTROPY_CMD cmd, byte* out)
     !defined(NO_ASN)
     #ifndef NO_DH
         static const char* dhParamsFile = CERT_ROOT "dh2048.der";
-        #ifdef WOLFSSL_DH_EXTRA
+        #if defined(WOLFSSL_DH_EXTRA) && (!defined(HAVE_FIPS) ||                \
+            (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2)))
             static const char* dhKeyFile = CERT_ROOT "statickeys/dh-ffdhe2048.der";
         #endif
     #endif
@@ -12778,7 +12779,6 @@ exit_rsa_pss:
 static int rsa_no_pad_test(void)
 {
     WC_RNG rng;
-    RsaKey key;
     byte*  tmp = NULL;
     size_t bytes;
     int    ret;
@@ -12791,17 +12791,18 @@ static int rsa_no_pad_test(void)
     !defined(NO_FILESYSTEM)
     XFILE  file;
 #endif
+    DECLARE_VAR(key, RsaKey, 1, HEAP_HINT);
     DECLARE_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
     DECLARE_VAR(plain, byte, RSA_TEST_BYTES, HEAP_HINT);
 
 #ifdef DECLARE_VAR_IS_HEAP_ALLOC
-    if ((out == NULL) || (plain == NULL))
+    if ((key == NULL) || (out == NULL) || (plain == NULL))
         ERROR_OUT(MEMORY_E, exit_rsa_nopadding);
 #endif
 
     /* initialize stack structures */
     XMEMSET(&rng, 0, sizeof(rng));
-    XMEMSET(&key, 0, sizeof(key));
+    XMEMSET(key, 0, sizeof(RsaKey));
 #ifdef USE_CERT_BUFFERS_1024
     bytes = (size_t)sizeof_client_key_der_1024;
 	if (bytes < (size_t)sizeof_client_cert_der_1024)
@@ -12846,11 +12847,11 @@ static int rsa_no_pad_test(void)
     ERROR_OUT(-7802, exit_rsa_nopadding);
 #endif /* USE_CERT_BUFFERS */
 
-    ret = wc_InitRsaKey_ex(&key, HEAP_HINT, devId);
+    ret = wc_InitRsaKey_ex(key, HEAP_HINT, devId);
     if (ret != 0) {
         ERROR_OUT(-7803, exit_rsa_nopadding);
     }
-    ret = wc_RsaPrivateKeyDecode(tmp, &idx, &key, (word32)bytes);
+    ret = wc_RsaPrivateKeyDecode(tmp, &idx, key, (word32)bytes);
     if (ret != 0) {
         ERROR_OUT(-7804, exit_rsa_nopadding);
     }
@@ -12867,16 +12868,16 @@ static int rsa_no_pad_test(void)
     }
 
 #ifndef WOLFSSL_RSA_VERIFY_ONLY
-    inLen = wc_RsaEncryptSize(&key);
+    inLen = wc_RsaEncryptSize(key);
     outSz   = inLen;
     plainSz = inLen;
     XMEMSET(tmp, 7, inLen);
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, &key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+        ret = wc_AsyncWait(ret, key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
         if (ret >= 0) {
-            ret = wc_RsaDirect(tmp, inLen, out, &outSz, &key,
+            ret = wc_RsaDirect(tmp, inLen, out, &outSz, key,
                     RSA_PRIVATE_ENCRYPT, &rng);
         }
     } while (ret == WC_PENDING_E);
@@ -12893,10 +12894,10 @@ static int rsa_no_pad_test(void)
     /* decrypt with public key and compare result */
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, &key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+        ret = wc_AsyncWait(ret, key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
         if (ret >= 0) {
-            ret = wc_RsaDirect(out, outSz, plain, &plainSz, &key,
+            ret = wc_RsaDirect(out, outSz, plain, &plainSz, key,
                     RSA_PUBLIC_DECRYPT, &rng);
         }
     } while (ret == WC_PENDING_E);
@@ -12916,7 +12917,7 @@ static int rsa_no_pad_test(void)
         ERROR_OUT(-7810, exit_rsa_nopadding);
     }
 
-    ret = wc_RsaSetRNG(&key, &rng);
+    ret = wc_RsaSetRNG(key, &rng);
     if (ret < 0) {
         ERROR_OUT(-7811, exit_rsa_nopadding);
     }
@@ -12926,10 +12927,10 @@ static int rsa_no_pad_test(void)
 #ifndef WOLFSSL_RSA_VERIFY_ONLY
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, &key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+        ret = wc_AsyncWait(ret, key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
         if (ret >= 0) {
-            ret = wc_RsaPublicEncrypt_ex(tmp, inLen, out, (int)outSz, &key, &rng,
+            ret = wc_RsaPublicEncrypt_ex(tmp, inLen, out, (int)outSz, key, &rng,
                 WC_RSA_NO_PAD, WC_HASH_TYPE_NONE, WC_MGF1NONE, NULL, 0);
         }
     } while (ret == WC_PENDING_E);
@@ -12942,10 +12943,10 @@ static int rsa_no_pad_test(void)
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, &key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+        ret = wc_AsyncWait(ret, key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
         if (ret >= 0) {
-            ret = wc_RsaPrivateDecrypt_ex(out, outSz, plain, (int)plainSz, &key,
+            ret = wc_RsaPrivateDecrypt_ex(out, outSz, plain, (int)plainSz, key,
                 WC_RSA_NO_PAD, WC_HASH_TYPE_NONE, WC_MGF1NONE, NULL, 0);
         }
     } while (ret == WC_PENDING_E);
@@ -12960,7 +12961,7 @@ static int rsa_no_pad_test(void)
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
 
     /* test some bad arguments */
-    ret = wc_RsaDirect(out, outSz, plain, &plainSz, &key, -1,
+    ret = wc_RsaDirect(out, outSz, plain, &plainSz, key, -1,
             &rng);
     if (ret != BAD_FUNC_ARG) {
         ERROR_OUT(-7815, exit_rsa_nopadding);
@@ -12972,13 +12973,13 @@ static int rsa_no_pad_test(void)
         ERROR_OUT(-7816, exit_rsa_nopadding);
     }
 
-    ret = wc_RsaDirect(out, outSz, NULL, &plainSz, &key, RSA_PUBLIC_DECRYPT,
+    ret = wc_RsaDirect(out, outSz, NULL, &plainSz, key, RSA_PUBLIC_DECRYPT,
             &rng);
     if (ret != LENGTH_ONLY_E || plainSz != inLen) {
         ERROR_OUT(-7817, exit_rsa_nopadding);
     }
 
-    ret = wc_RsaDirect(out, outSz - 10, plain, &plainSz, &key,
+    ret = wc_RsaDirect(out, outSz - 10, plain, &plainSz, key,
             RSA_PUBLIC_DECRYPT, &rng);
     if (ret != BAD_FUNC_ARG) {
         ERROR_OUT(-7818, exit_rsa_nopadding);
@@ -12989,10 +12990,11 @@ static int rsa_no_pad_test(void)
     ret = 0;
 
 exit_rsa_nopadding:
+    wc_FreeRsaKey(key);
     XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    FREE_VAR(key, HEAP_HINT);
     FREE_VAR(out, HEAP_HINT);
     FREE_VAR(plain, HEAP_HINT);
-    wc_FreeRsaKey(&key);
     wc_FreeRng(&rng);
 
     return ret;
@@ -15602,15 +15604,40 @@ done:
 
 static int dsa_test(void)
 {
-    int    ret, answer;
+    int    ret = 0, answer;
     word32 bytes;
     word32 idx = 0;
-    byte   tmp[1024];
-    DsaKey key;
     WC_RNG rng;
     wc_Sha sha;
     byte   hash[WC_SHA_DIGEST_SIZE];
     byte   signature[40];
+#ifdef WOLFSSL_KEY_GEN
+    byte*  der = 0;
+#endif
+#define DSA_TEST_TMP_SIZE 1024
+#ifdef WOLFSSL_SMALL_STACK
+    byte   *tmp = (byte *)XMALLOC(DSA_TEST_TMP_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    DsaKey *key = (DsaKey *)XMALLOC(sizeof *key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+#ifdef WOLFSSL_KEY_GEN
+    DsaKey *derIn = (DsaKey *)XMALLOC(sizeof *derIn, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    DsaKey *genKey = (DsaKey *)XMALLOC(sizeof *genKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+    if ((tmp == NULL) ||
+        (key == NULL)
+#ifdef WOLFSSL_KEY_GEN
+        || (derIn == NULL)
+        || (genKey == NULL)
+#endif
+        ) {
+        ret = -8216;
+        goto out;
+    }
+#else
+    byte   tmp[1024];
+    DsaKey key[1];
+    DsaKey derIn[1];
+    DsaKey genKey[1];
+#endif
 
 #ifdef USE_CERT_BUFFERS_1024
     XMEMCPY(tmp, dsa_key_der_1024, sizeof_dsa_key_der_1024);
@@ -15621,110 +15648,150 @@ static int dsa_test(void)
 #else
     XFILE  file = XFOPEN(dsaKey, "rb");
     if (!file)
-        return -8200;
+        ERROR_OUT(-8200, out);
 
-    bytes = (word32) XFREAD(tmp, 1, sizeof(tmp), file);
+    bytes = (word32) XFREAD(tmp, 1, DSA_TEST_TMP_SIZE, file);
     XFCLOSE(file);
 #endif /* USE_CERT_BUFFERS */
 
     ret = wc_InitSha_ex(&sha, HEAP_HINT, devId);
     if (ret != 0)
-        return -8201;
+        ERROR_OUT(-8201, out);
     wc_ShaUpdate(&sha, tmp, bytes);
     wc_ShaFinal(&sha, hash);
     wc_ShaFree(&sha);
 
-    ret = wc_InitDsaKey(&key);
-    if (ret != 0) return -8202;
+    ret = wc_InitDsaKey(key);
+    if (ret != 0)
+        ERROR_OUT(-8202, out);
 
-    ret = wc_DsaPrivateKeyDecode(tmp, &idx, &key, bytes);
-    if (ret != 0) return -8203;
+    ret = wc_DsaPrivateKeyDecode(tmp, &idx, key, bytes);
+    if (ret != 0)
+        ERROR_OUT(-8203, out);
 
 #ifndef HAVE_FIPS
     ret = wc_InitRng_ex(&rng, HEAP_HINT, devId);
 #else
     ret = wc_InitRng(&rng);
 #endif
-    if (ret != 0) return -8204;
+    if (ret != 0)
+        ERROR_OUT(-8204, out);
 
-    ret = wc_DsaSign(hash, signature, &key, &rng);
-    if (ret != 0) return -8205;
+    ret = wc_DsaSign(hash, signature, key, &rng);
+    if (ret != 0)
+        ERROR_OUT(-8205, out);
 
-    ret = wc_DsaVerify(hash, signature, &key, &answer);
-    if (ret != 0) return -8206;
-    if (answer != 1) return -8207;
+    ret = wc_DsaVerify(hash, signature, key, &answer);
+    if (ret != 0)
+        ERROR_OUT(-8206, out);
+    if (answer != 1)
+        ERROR_OUT(-8207, out);
 
-    wc_FreeDsaKey(&key);
+    wc_FreeDsaKey(key);
 
 #ifdef WOLFSSL_KEY_GEN
     {
-    byte*  der;
     int    derSz = 0;
-    DsaKey derIn;
-    DsaKey genKey;
 
-    ret = wc_InitDsaKey(&genKey);
-    if (ret != 0) return -8208;
+    ret = wc_InitDsaKey(genKey);
+    if (ret != 0)
+        ERROR_OUT(-8208, out);
 
-    ret = wc_MakeDsaParameters(&rng, 1024, &genKey);
+    ret = wc_MakeDsaParameters(&rng, 1024, genKey);
     if (ret != 0) {
-        wc_FreeDsaKey(&genKey);
-        return -8209;
+        wc_FreeDsaKey(genKey);
+        ERROR_OUT(-8209, out);
     }
 
-    ret = wc_MakeDsaKey(&rng, &genKey);
+    ret = wc_MakeDsaKey(&rng, genKey);
     if (ret != 0) {
-        wc_FreeDsaKey(&genKey);
-        return -8210;
+        wc_FreeDsaKey(genKey);
+        ERROR_OUT(-8210, out);
     }
 
     der = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (der == NULL) {
-        wc_FreeDsaKey(&genKey);
-        return -8211;
+        wc_FreeDsaKey(genKey);
+        ERROR_OUT(-8211, out);
     }
 
-    derSz = wc_DsaKeyToDer(&genKey, der, FOURK_BUF);
+    derSz = wc_DsaKeyToDer(genKey, der, FOURK_BUF);
     if (derSz < 0) {
         XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        return -8212;
+        ERROR_OUT(-8212, out);
     }
 
     ret = SaveDerAndPem(der, derSz, keyDerFile, keyPemFile,
         DSA_PRIVATEKEY_TYPE, -5814);
     if (ret != 0) {
         XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        wc_FreeDsaKey(&genKey);
-        return ret;
+        wc_FreeDsaKey(genKey);
+        goto out;
     }
 
-    ret = wc_InitDsaKey(&derIn);
+    ret = wc_InitDsaKey(derIn);
     if (ret != 0) {
         XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        wc_FreeDsaKey(&genKey);
-        return -8213;
+        wc_FreeDsaKey(genKey);
+        ERROR_OUT(-8213, out);
     }
 
     idx = 0;
-    ret = wc_DsaPrivateKeyDecode(der, &idx, &derIn, derSz);
+    ret = wc_DsaPrivateKeyDecode(der, &idx, derIn, derSz);
     if (ret != 0) {
         XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-        wc_FreeDsaKey(&derIn);
-        wc_FreeDsaKey(&genKey);
-        return -8214;
+        wc_FreeDsaKey(derIn);
+        wc_FreeDsaKey(genKey);
+        ERROR_OUT(-8214, out);
     }
 
-    wc_FreeDsaKey(&derIn);
-    wc_FreeDsaKey(&genKey);
-    XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     }
 #endif /* WOLFSSL_KEY_GEN */
 
-    if (wc_InitDsaKey_h(&key, NULL) != 0)
-        return -8215;
+  out:
+
+#ifdef WOLFSSL_SMALL_STACK
+    if (key) {
+#endif
+        if (wc_InitDsaKey_h(key, NULL) != 0)
+            ret = -8215;
+#ifdef WOLFSSL_SMALL_STACK
+    }
+#endif
+
+#ifdef WOLFSSL_KEY_GEN
+    if (der)
+        XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+
+#ifdef WOLFSSL_SMALL_STACK
+    if (tmp)
+        XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    if (key)
+        XFREE(key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+#ifdef WOLFSSL_KEY_GEN
+    if (derIn) {
+        wc_FreeDsaKey(derIn);
+        XFREE(derIn, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (genKey) {
+        wc_FreeDsaKey(genKey);
+        XFREE(genKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+#endif
+
+#else /* !WOLFSSL_SMALL_STACK */
+
+#ifdef WOLFSSL_KEY_GEN
+    wc_FreeDsaKey(derIn);
+    wc_FreeDsaKey(genKey);
+#endif
+
+#endif
 
     wc_FreeRng(&rng);
-    return 0;
+
+    return ret;
 }
 
 #endif /* NO_DSA */
@@ -15750,17 +15817,12 @@ static int generate_random_salt(byte *buf, word32 size)
 
 static int srp_test(void)
 {
-    Srp cli, srv;
     int r;
 
     byte clientPubKey[80]; /* A */
     byte serverPubKey[80]; /* B */
     word32 clientPubKeySz = 80;
     word32 serverPubKeySz = 80;
-    byte clientProof[SRP_MAX_DIGEST_SIZE]; /* M1 */
-    byte serverProof[SRP_MAX_DIGEST_SIZE]; /* M2 */
-    word32 clientProofSz = SRP_MAX_DIGEST_SIZE;
-    word32 serverProofSz = SRP_MAX_DIGEST_SIZE;
 
     byte username[] = "user";
     word32 usernameSz = 4;
@@ -15768,7 +15830,7 @@ static int srp_test(void)
     byte password[] = "password";
     word32 passwordSz = 8;
 
-    byte N[] = {
+    static const byte N[] = {
         0xC9, 0x4D, 0x67, 0xEB, 0x5B, 0x1A, 0x23, 0x46, 0xE8, 0xAB, 0x42, 0x2F,
         0xC6, 0xA0, 0xED, 0xAE, 0xDA, 0x8C, 0x7F, 0x89, 0x4C, 0x9E, 0xEE, 0xC4,
         0x2F, 0x9E, 0xD2, 0x50, 0xFD, 0x7F, 0x00, 0x46, 0xE5, 0xAF, 0x2C, 0xF7,
@@ -15778,7 +15840,7 @@ static int srp_test(void)
         0x03, 0x44, 0x60, 0xFA, 0xA7, 0xAD, 0xF4, 0x83
     };
 
-    byte g[] = {
+    static const byte g[] = {
         0x02
     };
 
@@ -15787,10 +15849,32 @@ static int srp_test(void)
     byte verifier[80];
     word32 v_size = sizeof(verifier);
 
+    word32 clientProofSz = SRP_MAX_DIGEST_SIZE;
+    word32 serverProofSz = SRP_MAX_DIGEST_SIZE;
+#ifdef WOLFSSL_SMALL_STACK
+    Srp *cli = (Srp *)XMALLOC(sizeof *cli, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    Srp *srv = (Srp *)XMALLOC(sizeof *srv, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    byte *clientProof = (byte *)XMALLOC(SRP_MAX_DIGEST_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER); /* M1 */
+    byte *serverProof = (byte *)XMALLOC(SRP_MAX_DIGEST_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER); /* M2 */
+
+    if ((cli == NULL) ||
+        (srv == NULL) ||
+        (clientProof == NULL) ||
+        (serverProof == NULL)) {
+        r = -8222;
+        goto out;
+    }
+#else
+    Srp cli[1], srv[1];
+    byte clientProof[SRP_MAX_DIGEST_SIZE]; /* M1 */
+    byte serverProof[SRP_MAX_DIGEST_SIZE]; /* M2 */
+#endif
+
+
     /* set as 0's so if second init on srv not called SrpTerm is not on
      * garbage values */
-    XMEMSET(&srv, 0, sizeof(Srp));
-    XMEMSET(&cli, 0, sizeof(Srp));
+    XMEMSET(srv, 0, sizeof *srv);
+    XMEMSET(cli, 0, sizeof *cli);
 
     /* generating random salt */
 
@@ -15799,47 +15883,60 @@ static int srp_test(void)
     /* client knows username and password.   */
     /* server knows N, g, salt and verifier. */
 
-    if (!r) r = wc_SrpInit(&cli, SRP_TYPE_SHA, SRP_CLIENT_SIDE);
-    if (!r) r = wc_SrpSetUsername(&cli, username, usernameSz);
+    if (!r) r = wc_SrpInit(cli, SRP_TYPE_SHA, SRP_CLIENT_SIDE);
+    if (!r) r = wc_SrpSetUsername(cli, username, usernameSz);
 
     /* loading N, g and salt in advance to generate the verifier. */
 
-    if (!r) r = wc_SrpSetParams(&cli, N,    sizeof(N),
+    if (!r) r = wc_SrpSetParams(cli, N,    sizeof(N),
                                       g,    sizeof(g),
                                       salt, sizeof(salt));
-    if (!r) r = wc_SrpSetPassword(&cli, password, passwordSz);
-    if (!r) r = wc_SrpGetVerifier(&cli, verifier, &v_size);
+    if (!r) r = wc_SrpSetPassword(cli, password, passwordSz);
+    if (!r) r = wc_SrpGetVerifier(cli, verifier, &v_size);
 
     /* client sends username to server */
 
-    if (!r) r = wc_SrpInit(&srv, SRP_TYPE_SHA, SRP_SERVER_SIDE);
-    if (!r) r = wc_SrpSetUsername(&srv, username, usernameSz);
-    if (!r) r = wc_SrpSetParams(&srv, N,    sizeof(N),
+    if (!r) r = wc_SrpInit(srv, SRP_TYPE_SHA, SRP_SERVER_SIDE);
+    if (!r) r = wc_SrpSetUsername(srv, username, usernameSz);
+    if (!r) r = wc_SrpSetParams(srv, N,    sizeof(N),
                                       g,    sizeof(g),
                                       salt, sizeof(salt));
-    if (!r) r = wc_SrpSetVerifier(&srv, verifier, v_size);
-    if (!r) r = wc_SrpGetPublic(&srv, serverPubKey, &serverPubKeySz);
+    if (!r) r = wc_SrpSetVerifier(srv, verifier, v_size);
+    if (!r) r = wc_SrpGetPublic(srv, serverPubKey, &serverPubKeySz);
 
     /* server sends N, g, salt and B to client */
 
-    if (!r) r = wc_SrpGetPublic(&cli, clientPubKey, &clientPubKeySz);
-    if (!r) r = wc_SrpComputeKey(&cli, clientPubKey, clientPubKeySz,
+    if (!r) r = wc_SrpGetPublic(cli, clientPubKey, &clientPubKeySz);
+    if (!r) r = wc_SrpComputeKey(cli, clientPubKey, clientPubKeySz,
                                        serverPubKey, serverPubKeySz);
-    if (!r) r = wc_SrpGetProof(&cli, clientProof, &clientProofSz);
+    if (!r) r = wc_SrpGetProof(cli, clientProof, &clientProofSz);
 
     /* client sends A and M1 to server */
 
-    if (!r) r = wc_SrpComputeKey(&srv, clientPubKey, clientPubKeySz,
+    if (!r) r = wc_SrpComputeKey(srv, clientPubKey, clientPubKeySz,
                                        serverPubKey, serverPubKeySz);
-    if (!r) r = wc_SrpVerifyPeersProof(&srv, clientProof, clientProofSz);
-    if (!r) r = wc_SrpGetProof(&srv, serverProof, &serverProofSz);
+    if (!r) r = wc_SrpVerifyPeersProof(srv, clientProof, clientProofSz);
+    if (!r) r = wc_SrpGetProof(srv, serverProof, &serverProofSz);
 
     /* server sends M2 to client */
 
-    if (!r) r = wc_SrpVerifyPeersProof(&cli, serverProof, serverProofSz);
+    if (!r) r = wc_SrpVerifyPeersProof(cli, serverProof, serverProofSz);
 
-    wc_SrpTerm(&cli);
-    wc_SrpTerm(&srv);
+    wc_SrpTerm(cli);
+    wc_SrpTerm(srv);
+
+#ifdef WOLFSSL_SMALL_STACK
+  out:
+
+    if (cli)
+        XFREE(cli, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    if (srv)
+        XFREE(srv, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    if (clientProof)
+        XFREE(clientProof, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    if (serverProof)
+        XFREE(serverProof, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
 
     return r;
 }
@@ -17976,16 +18073,29 @@ static int openssl_pkey1_test(void)
     EVP_PKEY_CTX* enc = NULL;
     EVP_PKEY* pubKey  = NULL;
     EVP_PKEY* prvKey  = NULL;
-    X509* x509;
+    X509* x509 = NULL;
 
-    const unsigned char msg[] = "sugar slapped";
+    static const unsigned char msg[] = "sugar slapped";
     const unsigned char* clikey;
-    unsigned char tmp[FOURK_BUF];
     long cliKeySz;
-    unsigned char cipher[RSA_TEST_BYTES];
-    unsigned char plain[RSA_TEST_BYTES];
     size_t outlen;
     int keyLenBits = 2048;
+#ifdef WOLFSSL_SMALL_STACK
+    unsigned char *tmp = (unsigned char *)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    unsigned char *cipher = (unsigned char *)XMALLOC(RSA_TEST_BYTES, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    unsigned char *plain = (unsigned char *)XMALLOC(RSA_TEST_BYTES, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+
+    if ((tmp == NULL) ||
+        (cipher == NULL) ||
+        (plain == NULL)) {
+        ret = -9015;
+        goto openssl_pkey1_test_done;
+    }
+#else
+    unsigned char tmp[FOURK_BUF];
+    unsigned char cipher[RSA_TEST_BYTES];
+    unsigned char plain[RSA_TEST_BYTES];
+#endif
 
 #if defined(USE_CERT_BUFFERS_1024)
     XMEMCPY(tmp, client_key_der_1024, sizeof_client_key_der_1024);
@@ -18022,7 +18132,8 @@ static int openssl_pkey1_test(void)
     if (!f) {
         err_sys("can't open ./certs/client-key.der, "
                 "Please run from wolfSSL home dir", -41);
-        return -9000;
+        ret = -9000;
+        goto openssl_pkey1_test_done;
     }
 
     cliKeySz = (long)XFREAD(tmp, 1, FOURK_BUF, f);
@@ -18034,7 +18145,8 @@ static int openssl_pkey1_test(void)
     clikey = tmp;
 
     if ((prvKey = EVP_PKEY_new()) == NULL) {
-        return -9001;
+        ret = -9001;
+        goto openssl_pkey1_test_done;
     }
     EVP_PKEY_free(prvKey);
     prvKey = NULL;
@@ -18101,14 +18213,14 @@ static int openssl_pkey1_test(void)
     }
 #endif
 
-    XMEMSET(cipher, 0, sizeof(cipher));
+    XMEMSET(cipher, 0, RSA_TEST_BYTES);
     outlen = keyLenBits/8;
     if (EVP_PKEY_encrypt(enc, cipher, &outlen, msg, sizeof(msg)) < 0) {
         ret = -9013;
         goto openssl_pkey1_test_done;
     }
 
-    XMEMSET(plain, 0, sizeof(plain));
+    XMEMSET(plain, 0, RSA_TEST_BYTES);
     if (EVP_PKEY_decrypt(dec, plain, &outlen, cipher, outlen) != 1) {
         ret = -9014;
         goto openssl_pkey1_test_done;
@@ -18131,7 +18243,16 @@ openssl_pkey1_test_done:
         X509_free(x509);
     }
 
+#ifdef WOLFSSL_SMALL_STACK
+    if (tmp != NULL)
+        XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    if (cipher != NULL)
+        XFREE(cipher, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    if (plain != NULL)
+        XFREE(plain, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
+#endif
+
     return ret;
 }
 
@@ -18330,6 +18451,9 @@ static int openssl_evpSig_test(void)
 /* Test vectors taken from RFC 7914: scrypt PBKDF - Section 12. */
 static int scrypt_test(void)
 {
+#ifdef HAVE_FIPS
+    /* RFC 7914 test vector keys are too short for FIPS. */
+#else
     int   ret;
     byte  derived[64];
 
@@ -18419,6 +18543,8 @@ static int scrypt_test(void)
         return -9208;
     if (XMEMCMP(derived, verify2, sizeof(verify2)) != 0)
         return -9209;
+
+#endif /* !HAVE_FIPS */
 
     return 0;
 }
@@ -19807,7 +19933,8 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     DECLARE_VAR(sharedB, byte, ECC_SHARED_SIZE, HEAP_HINT);
 #endif
 #ifdef HAVE_ECC_KEY_EXPORT
-    byte    exportBuf[MAX_ECC_BYTES * 2 + 32];
+    static const size_t exportBufSize = MAX_ECC_BYTES * 2 + 32;
+    DECLARE_VAR(exportBuf, byte, exportBufSize, HEAP_HINT);
 #endif
     word32  x = 0;
 #if (defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)) && \
@@ -19839,6 +19966,11 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
     if ((sharedA == NULL) || (sharedB == NULL))
         ERROR_OUT(-9900, done);
+#endif
+
+#ifdef HAVE_ECC_KEY_EXPORT
+    if (exportBuf == NULL)
+        ERROR_OUT(-9913, done);
 #endif
 
 #ifdef HAVE_ECC_SIGN
@@ -20008,7 +20140,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
 #endif /* WOLFSSL_ATECC508A */
 
 #ifdef HAVE_ECC_KEY_EXPORT
-    x = sizeof(exportBuf);
+    x = exportBufSize;
     ret = wc_ecc_export_x963_ex(userA, exportBuf, &x, 0);
     if (ret != 0)
         goto done;
@@ -20044,7 +20176,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
 
     #ifdef HAVE_COMP_KEY
         /* try compressed export / import too */
-        x = sizeof(exportBuf);
+        x = exportBufSize;
         ret = wc_ecc_export_x963_ex(userA, exportBuf, &x, 1);
         if (ret != 0)
             goto done;
@@ -20167,7 +20299,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
 
 #if defined(HAVE_ECC_KEY_EXPORT) && !defined(WOLFSSL_ATECC508) && \
     !defined(WOLFSSL_ATECC608A)
-    x = sizeof(exportBuf);
+    x = exportBufSize;
     ret = wc_ecc_export_private_only(userA, exportBuf, &x);
     if (ret != 0)
         goto done;
@@ -20197,6 +20329,9 @@ done:
 #if defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)
     FREE_VAR(sharedA, HEAP_HINT);
     FREE_VAR(sharedB, HEAP_HINT);
+#endif
+#ifdef HAVE_ECC_KEY_EXPORT
+    FREE_VAR(exportBuf, HEAP_HINT);
 #endif
 #ifdef HAVE_ECC_SIGN
     FREE_VAR(sig, HEAP_HINT);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -19935,8 +19935,8 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     DECLARE_VAR(sharedB, byte, ECC_SHARED_SIZE, HEAP_HINT);
 #endif
 #ifdef HAVE_ECC_KEY_EXPORT
-    static const size_t exportBufSize = MAX_ECC_BYTES * 2 + 32;
-    DECLARE_VAR(exportBuf, byte, exportBufSize, HEAP_HINT);
+    #define ECC_KEY_EXPORT_BUF_SIZE (MAX_ECC_BYTES * 2 + 32)
+    DECLARE_VAR(exportBuf, byte, ECC_KEY_EXPORT_BUF_SIZE, HEAP_HINT);
 #endif
     word32  x = 0;
 #if (defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)) && \
@@ -20142,7 +20142,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
 #endif /* WOLFSSL_ATECC508A */
 
 #ifdef HAVE_ECC_KEY_EXPORT
-    x = exportBufSize;
+    x = ECC_KEY_EXPORT_BUF_SIZE;
     ret = wc_ecc_export_x963_ex(userA, exportBuf, &x, 0);
     if (ret != 0)
         goto done;
@@ -20178,7 +20178,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
 
     #ifdef HAVE_COMP_KEY
         /* try compressed export / import too */
-        x = exportBufSize;
+        x = ECC_KEY_EXPORT_BUF_SIZE;
         ret = wc_ecc_export_x963_ex(userA, exportBuf, &x, 1);
         if (ret != 0)
             goto done;
@@ -20301,7 +20301,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
 
 #if defined(HAVE_ECC_KEY_EXPORT) && !defined(WOLFSSL_ATECC508) && \
     !defined(WOLFSSL_ATECC608A)
-    x = exportBufSize;
+    x = ECC_KEY_EXPORT_BUF_SIZE;
     ret = wc_ecc_export_private_only(userA, exportBuf, &x);
     if (ret != 0)
         goto done;

--- a/wolfssl/openssl/aes.h
+++ b/wolfssl/openssl/aes.h
@@ -42,32 +42,7 @@
  * OpenSSL compatibility layer. This makes code working with an AES structure
  * to need the size of the structure. */
 typedef struct WOLFSSL_AES_KEY {
-    /* aligned and big enough for Aes from wolfssl/wolfcrypt/aes.h */
-    ALIGN16 void* holder[(376 + WC_ASYNC_DEV_SIZE)/ sizeof(void*)];
-    #ifdef GCM_TABLE
-    /* key-based fast multiplication table. */
-    ALIGN16 void* M0[4096 / sizeof(void*)];
-    #elif defined(GCM_TABLE_4BIT)
-    #if !defined(WORD64_AVAILABLE) || defined(BIG_ENDIAN_ORDER)
-    ALIGN16 byte M0[16][AES_BLOCK_SIZE];
-    #else
-    ALIGN16 byte M0[32][AES_BLOCK_SIZE];
-    #endif
-    #endif /* GCM_TABLE */
-    #if defined(WOLFSSL_DEVCRYPTO) && \
-        (defined(WOLFSSL_DEVCRYPTO_AES) || defined(WOLFSSL_DEVCRYPTO_CBC))
-    /* large enough for additional devcrypto information */
-    void* devKey[288 / sizeof(void*)];
-    #endif
-    #ifdef WOLFSSL_AFALG
-    void* afalg_holder[288 / sizeof(void*)];
-    #endif
-    #ifdef HAVE_PKCS11
-    void* pkcs11_holder[(AES_MAX_ID_LEN + sizeof(int)) / sizeof(void*)];
-    #endif
-    #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLF_CRYPTO_CB)
-    void* async_holder[128 / sizeof(void*)];
-    #endif
+    void *buf[(sizeof(Aes) / sizeof(void *)) + 1];
 } WOLFSSL_AES_KEY;
 typedef WOLFSSL_AES_KEY AES_KEY;
 

--- a/wolfssl/openssl/aes.h
+++ b/wolfssl/openssl/aes.h
@@ -42,7 +42,7 @@
  * OpenSSL compatibility layer. This makes code working with an AES structure
  * to need the size of the structure. */
 typedef struct WOLFSSL_AES_KEY {
-    void *buf[(sizeof(Aes) / sizeof(void *)) + 1];
+    ALIGN16 void *buf[(sizeof(Aes) / sizeof(void *)) + 1];
 } WOLFSSL_AES_KEY;
 typedef WOLFSSL_AES_KEY AES_KEY;
 

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -85,7 +85,7 @@ WOLFSSL_API int wolfSSL_BN_is_zero(const WOLFSSL_BIGNUM*);
 WOLFSSL_API int wolfSSL_BN_is_one(const WOLFSSL_BIGNUM*);
 WOLFSSL_API int wolfSSL_BN_is_odd(const WOLFSSL_BIGNUM*);
 WOLFSSL_API int wolfSSL_BN_is_negative(const WOLFSSL_BIGNUM*);
-WOLFSSL_API int wolfSSL_BN_is_word(const WOLFSSL_BIGNUM*, WOLFSSL_BN_ULONG);
+WOLFSSL_API int wolfSSL_BN_is_word(const WOLFSSL_BIGNUM*, unsigned long);
 
 WOLFSSL_API int wolfSSL_BN_cmp(const WOLFSSL_BIGNUM*, const WOLFSSL_BIGNUM*);
 
@@ -109,10 +109,10 @@ WOLFSSL_API int   wolfSSL_BN_dec2bn(WOLFSSL_BIGNUM**, const char* str);
 WOLFSSL_API char* wolfSSL_BN_bn2dec(const WOLFSSL_BIGNUM*);
 
 WOLFSSL_API int wolfSSL_BN_lshift(WOLFSSL_BIGNUM*, const WOLFSSL_BIGNUM*, int);
-WOLFSSL_API int wolfSSL_BN_add_word(WOLFSSL_BIGNUM*, WOLFSSL_BN_ULONG);
+WOLFSSL_API int wolfSSL_BN_add_word(WOLFSSL_BIGNUM*, unsigned long);
 WOLFSSL_API int wolfSSL_BN_set_bit(WOLFSSL_BIGNUM*, int);
 WOLFSSL_API int wolfSSL_BN_clear_bit(WOLFSSL_BIGNUM*, int);
-WOLFSSL_API int wolfSSL_BN_set_word(WOLFSSL_BIGNUM*, WOLFSSL_BN_ULONG);
+WOLFSSL_API int wolfSSL_BN_set_word(WOLFSSL_BIGNUM*, unsigned long);
 WOLFSSL_API unsigned long wolfSSL_BN_get_word(const WOLFSSL_BIGNUM*);
 
 WOLFSSL_API int wolfSSL_BN_add(WOLFSSL_BIGNUM*, WOLFSSL_BIGNUM*,
@@ -123,8 +123,8 @@ WOLFSSL_API int wolfSSL_BN_mod_add(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
 WOLFSSL_API char *wolfSSL_BN_bn2hex(const WOLFSSL_BIGNUM*);
 WOLFSSL_API int wolfSSL_BN_is_prime_ex(const WOLFSSL_BIGNUM*, int,
                                        WOLFSSL_BN_CTX*, WOLFSSL_BN_GENCB*);
-WOLFSSL_API WOLFSSL_BN_ULONG wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM*,
-                                                 WOLFSSL_BN_ULONG);
+WOLFSSL_API unsigned long wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM*,
+                                                 unsigned long);
 #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
     WOLFSSL_API int wolfSSL_BN_print_fp(XFILE, const WOLFSSL_BIGNUM*);
 #endif

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -49,7 +49,7 @@ typedef struct WOLFSSL_BIGNUM {
 
 
 #define BN_ULONG WOLFSSL_BN_ULONG
-#define WOLFSSL_BN_ULONG mp_digit
+#define WOLFSSL_BN_ULONG unsigned long
 
 typedef struct WOLFSSL_BN_CTX WOLFSSL_BN_CTX;
 typedef struct WOLFSSL_BN_GENCB WOLFSSL_BN_GENCB;
@@ -85,7 +85,7 @@ WOLFSSL_API int wolfSSL_BN_is_zero(const WOLFSSL_BIGNUM*);
 WOLFSSL_API int wolfSSL_BN_is_one(const WOLFSSL_BIGNUM*);
 WOLFSSL_API int wolfSSL_BN_is_odd(const WOLFSSL_BIGNUM*);
 WOLFSSL_API int wolfSSL_BN_is_negative(const WOLFSSL_BIGNUM*);
-WOLFSSL_API int wolfSSL_BN_is_word(const WOLFSSL_BIGNUM*, unsigned long);
+WOLFSSL_API int wolfSSL_BN_is_word(const WOLFSSL_BIGNUM*, WOLFSSL_BN_ULONG);
 
 WOLFSSL_API int wolfSSL_BN_cmp(const WOLFSSL_BIGNUM*, const WOLFSSL_BIGNUM*);
 
@@ -109,11 +109,11 @@ WOLFSSL_API int   wolfSSL_BN_dec2bn(WOLFSSL_BIGNUM**, const char* str);
 WOLFSSL_API char* wolfSSL_BN_bn2dec(const WOLFSSL_BIGNUM*);
 
 WOLFSSL_API int wolfSSL_BN_lshift(WOLFSSL_BIGNUM*, const WOLFSSL_BIGNUM*, int);
-WOLFSSL_API int wolfSSL_BN_add_word(WOLFSSL_BIGNUM*, unsigned long);
+WOLFSSL_API int wolfSSL_BN_add_word(WOLFSSL_BIGNUM*, WOLFSSL_BN_ULONG);
 WOLFSSL_API int wolfSSL_BN_set_bit(WOLFSSL_BIGNUM*, int);
 WOLFSSL_API int wolfSSL_BN_clear_bit(WOLFSSL_BIGNUM*, int);
-WOLFSSL_API int wolfSSL_BN_set_word(WOLFSSL_BIGNUM*, unsigned long);
-WOLFSSL_API unsigned long wolfSSL_BN_get_word(const WOLFSSL_BIGNUM*);
+WOLFSSL_API int wolfSSL_BN_set_word(WOLFSSL_BIGNUM*, WOLFSSL_BN_ULONG);
+WOLFSSL_API WOLFSSL_BN_ULONG wolfSSL_BN_get_word(const WOLFSSL_BIGNUM*);
 
 WOLFSSL_API int wolfSSL_BN_add(WOLFSSL_BIGNUM*, WOLFSSL_BIGNUM*,
                                WOLFSSL_BIGNUM*);
@@ -123,8 +123,8 @@ WOLFSSL_API int wolfSSL_BN_mod_add(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
 WOLFSSL_API char *wolfSSL_BN_bn2hex(const WOLFSSL_BIGNUM*);
 WOLFSSL_API int wolfSSL_BN_is_prime_ex(const WOLFSSL_BIGNUM*, int,
                                        WOLFSSL_BN_CTX*, WOLFSSL_BN_GENCB*);
-WOLFSSL_API unsigned long wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM*,
-                                                 unsigned long);
+WOLFSSL_API WOLFSSL_BN_ULONG wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM*,
+                                                 WOLFSSL_BN_ULONG);
 #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
     WOLFSSL_API int wolfSSL_BN_print_fp(XFILE, const WOLFSSL_BIGNUM*);
 #endif

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2052,12 +2052,6 @@ struct stack_size_debug_context {
  * CFLAGS='-g -DHAVE_STACK_SIZE_VERBOSE' ./configure --enable-stacksize [...]
  */
 
-extern THREAD_LS_T unsigned char *StackSizeCheck_myStack;
-extern THREAD_LS_T size_t StackSizeCheck_stackSize;
-extern THREAD_LS_T size_t StackSizeCheck_stackSizeHWM;
-extern THREAD_LS_T size_t *StackSizeCheck_stackSizeHWM_ptr;
-extern THREAD_LS_T void *StackSizeCheck_stackOffsetPointer;
-
 static void *debug_stack_size_verbose_shim(struct stack_size_debug_context *shim_args) {
   StackSizeCheck_myStack = shim_args->myStack;
   StackSizeCheck_stackSize = shim_args->stackSize;

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -191,6 +191,14 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
     #define WOLFSSL_ERROR_MSG(m)
 #endif
 
+#ifdef HAVE_STACK_SIZE_VERBOSE
+    extern WOLFSSL_API THREAD_LS_T unsigned char *StackSizeCheck_myStack;
+    extern WOLFSSL_API THREAD_LS_T size_t StackSizeCheck_stackSize;
+    extern WOLFSSL_API THREAD_LS_T size_t StackSizeCheck_stackSizeHWM;
+    extern WOLFSSL_API THREAD_LS_T size_t *StackSizeCheck_stackSizeHWM_ptr;
+    extern WOLFSSL_API THREAD_LS_T void *StackSizeCheck_stackOffsetPointer;
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2157,12 +2157,6 @@ extern void uITRON4_free(void *p) ;
     #ifndef WOLFSSL_SP_DIV_WORD_HALF
         #define WOLFSSL_SP_DIV_WORD_HALF
     #endif
-    #ifndef SP_HALF_SIZE
-        #define SP_HALF_SIZE        32
-    #endif
-    #ifndef SP_HALF_MAX
-        #define SP_HALF_MAX         4294967295U
-    #endif
 #endif
 
 

--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -90,7 +90,7 @@ enum {
 #else
 
 /* Sha3 digest */
-struct Sha3 {
+struct wc_Sha3 {
     /* State data that is processed for each block. */
     word64 s[25];
     /* Unprocessed message data. */
@@ -109,7 +109,7 @@ struct Sha3 {
 };
 
 #ifndef WC_SHA3_TYPE_DEFINED
-    typedef struct Sha3 wc_Sha3;
+    typedef struct wc_Sha3 wc_Sha3;
     #define WC_SHA3_TYPE_DEFINED
 #endif
 

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -31,6 +31,10 @@ This library provides single precision (SP) integer math functions.
 #include <limits.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Find smallest type for smallest bits. */
 #if UCHAR_MAX == 255
     #define SP_UCHAR_BITS    8
@@ -889,5 +893,8 @@ WOLFSSL_API word32 CheckRunTimeFastMath(void);
 
 #endif
 
-#endif /* WOLF_CRYPT_SP_H */
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
+#endif /* WOLF_CRYPT_SP_H */

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -124,6 +124,27 @@
 
     _Pragma("GCC diagnostic pop");
 
+    /* Linux headers define these using C expressions, but we need
+     * them to be evaluable by the preprocessor, for use in sp_int.h.
+     */
+    _Static_assert(sizeof(ULONG_MAX) == 8, "WOLFSSL_LINUXKM supported only on targets with 64 bit long words.");
+    #undef UCHAR_MAX
+    #define UCHAR_MAX 255
+    #undef USHRT_MAX
+    #define USHRT_MAX 65535
+    #undef UINT_MAX
+    #define UINT_MAX 4294967295U
+    #undef ULONG_MAX
+    #define ULONG_MAX 18446744073709551615UL
+    #undef ULLONG_MAX
+    #define ULLONG_MAX ULONG_MAX
+    #undef INT_MAX
+    #define INT_MAX 2147483647
+    #undef LONG_MAX
+    #define LONG_MAX 9223372036854775807L
+    #undef LLONG_MAX
+    #define LLONG_MAX LONG_MAX
+
     /* remove this multifariously conflicting macro, picked up from
      * Linux arch/<arch>/include/asm/current.h.
      */


### PR DESCRIPTION
Main attractions here are refactoring `_word()` wrapper functions in src/ssl.c to work with `WOLFSSL_BN_ULONG` defined as target-native `unsigned long` (rather than `mp_digit`), and a slew more `_SMALL_STACK` refactors to keep `--enable-all --enable-sp-math-all --enable-smallstack` `wolfcrypt_test()` under 16k of stack.  `--enable-linuxkm[-defaults]` now uses sp-math-all by default, and keeps `wolfcrypt_test()` under 10k of stack.
