### PR TITLE
support TNGTLS certificate loading for Harmony3

### DIFF
--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -921,11 +921,10 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
     #ifndef ATCATLS_TNGTLS_DEVICE_CERT_SIZE
         #define ATCATLS_TNGTLS_DEVICE_CERT_SIZE 0x222
     #endif
-        #ifndef ATCATLS_TNGTLS_CERT_BUFF_SIZE
+    #ifndef ATCATLS_TNGTLS_CERT_BUFF_SIZE
         #define ATCATLS_TNGTLS_CERT_BUFF_SIZE (ATCATLS_TNGTLS_SIGNER_CERT_SIZE +\
-		                                       ATCATLS_TNGTLS_DEVICE_CERT_SIZE)
+                                               ATCATLS_TNGTLS_DEVICE_CERT_SIZE)
     #endif
-	
 
     int ret = 0;
     ATCA_STATUS status;
@@ -935,7 +934,7 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
 
     /*Read signer cert*/
     status = tng_atcacert_read_signer_cert(&certBuffer[ATCATLS_TNGTLS_DEVICE_CERT_SIZE],
-          	 &signerCertSize);
+                                           &signerCertSize);
     if (ATCA_SUCCESS != status) {
         ret = atmel_ecc_translate_err(ret);
         return ret;
@@ -943,14 +942,14 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
     if (signerCertSize != ATCATLS_TNGTLS_SIGNER_CERT_SIZE) {
         #ifdef WOLFSSL_ATECC_DEBUG
         printf("signer cert size != ATCATLS_TNGTLS_SIGNER_CERT_SIZE.(%d)\r\n",
-		        signerCertSize);
+               signerCertSize);
         #endif
         return WOLFSSL_FAILURE;
     }
 
     /*Read device cert signed by the signer above*/
     status = tng_atcacert_read_device_cert(certBuffer, &deviceCertSize,\
-     	     &certBuffer[ATCATLS_TNGTLS_DEVICE_CERT_SIZE]);
+     	                  &certBuffer[ATCATLS_TNGTLS_DEVICE_CERT_SIZE]);
     if (ATCA_SUCCESS != status) {
         ret = atmel_ecc_translate_err(ret);
         return ret;
@@ -958,14 +957,14 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
     if (deviceCertSize != ATCATLS_TNGTLS_DEVICE_CERT_SIZE) {
         #ifdef WOLFSSL_ATECC_DEBUG
         printf("device cert size != ATCATLS_TNGTLS_DEVICE_CERT_SIZE.(%d)\r\n",
-		        deviceCertSize);
+               deviceCertSize);
         #endif
         return WOLFSSL_FAILURE;
     }
 
-    ret = wolfSSL_CTX_use_certificate_chain_buffer_format(ctx, 
-	       (const unsigned char*)certBuffer, ATCATLS_TNGTLS_CERT_BUFF_SIZE,
-		   WOLFSSL_FILETYPE_ASN1);
+    ret = wolfSSL_CTX_use_certificate_chain_buffer_format(ctx,
+          (const unsigned char*)certBuffer, ATCATLS_TNGTLS_CERT_BUFF_SIZE,
+          WOLFSSL_FILETYPE_ASN1);
     if (ret != WOLFSSL_SUCCESS) {
         ret = -1;
     }

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -911,12 +911,16 @@ exit:
 
 static int atcatls_set_certificates(WOLFSSL_CTX *ctx) 
 {
+    #ifndef ATCATLS_MAX_CERT_SIZE
+        #define ATCATLS_MAX_CERT_SIZE 560
+    #endif
+
     int ret = 0;
     ATCA_STATUS status;
-    size_t signerCertSize = 1024;
-    uint8_t signerCert[signerCertSize];
-    size_t deviceCertSize = 1024;
-    uint8_t deviceCert[deviceCertSize];
+    size_t signerCertSize = ATCATLS_MAX_CERT_SIZE;
+    uint8_t signerCert[ATCATLS_MAX_CERT_SIZE];
+    size_t deviceCertSize = ATCATLS_MAX_CERT_SIZE;
+    uint8_t deviceCert[ATCATLS_MAX_CERT_SIZE];
     int devPemSz, signerPemSz;
     char devCertChain[2048];
 
@@ -934,12 +938,14 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
     }
     /*Generate a PEM chain of device certificate.*/
     XMEMSET(devCertChain, 0, sizeof(devCertChain));
-    devPemSz = wc_DerToPem(deviceCert, deviceCertSize, (byte*)&devCertChain[0], sizeof(devCertChain), CERT_TYPE);
-    if((devPemSz <= 0)){
+    devPemSz = wc_DerToPem(deviceCert, deviceCertSize, (byte*)&devCertChain[0],
+                                              sizeof(devCertChain), CERT_TYPE);
+    if(devPemSz <= 0){
         return devPemSz;
     }
-    signerPemSz = wc_DerToPem(signerCert, signerCertSize, (byte*)&devCertChain[devPemSz], sizeof(devCertChain)-devPemSz, CERT_TYPE);
-    if((signerPemSz <= 0)){
+    signerPemSz = wc_DerToPem(signerCert, signerCertSize, (byte*)&devCertChain[devPemSz], 
+                                               sizeof(devCertChain)-devPemSz, CERT_TYPE);
+    if(signerPemSz <= 0){
         return signerPemSz;
     }
     ret = wolfSSL_CTX_use_certificate_chain_buffer(ctx, (const unsigned char*)devCertChain, XSTRLEN(devCertChain));
@@ -967,7 +973,7 @@ int atcatls_set_callbacks(WOLFSSL_CTX* ctx)
         #endif
     }
 #endif
-    return 0;
+    return ret;
 }
 
 int atcatls_set_callback_ctx(WOLFSSL* ssl, void* user_ctx)

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -909,12 +909,13 @@ exit:
     return ret;
 }
 
-static int atcatls_set_certificates(WOLFSSL_CTX *ctx) {
+static int atcatls_set_certificates(WOLFSSL_CTX *ctx) 
+{
     int ret = 0;
     ATCA_STATUS status;
-  
-    /*Read signer cert*/
     size_t signerCertSize = 0;
+	
+    /*Read signer cert*/
     status = tng_atcacert_max_signer_cert_size(&signerCertSize);
     if (ATCA_SUCCESS != status) {
         ret = atmel_ecc_translate_err(ret);
@@ -959,14 +960,16 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx) {
     
     char devCertChain[devPemSz+signerPemSz];
     
-    strncat(devCertChain,(char*)devPem,devPemSz);
-    strncat(devCertChain,(char*)signerPem,signerPemSz);
+    XSTRNCAT(devCertChain,(char*)devPem,devPemSz);
+    XSTRNCAT(devCertChain,(char*)signerPem,signerPemSz);
     
-    ret=wolfSSL_CTX_use_certificate_chain_buffer(ctx,(const unsigned char*)devCertChain,strlen(devCertChain));
-    if (ret != SSL_SUCCESS) {
+    ret=wolfSSL_CTX_use_certificate_chain_buffer(ctx,(const unsigned char*)devCertChain,XSTRLEN(devCertChain));
+    if (ret != WOLFSSL_SUCCESS) {
         ret=-1;
     }
-    else ret=0;
+    else {
+	ret=0;
+    }
     return ret;
 }
 
@@ -979,7 +982,7 @@ int atcatls_set_callbacks(WOLFSSL_CTX* ctx)
     wolfSSL_CTX_SetEccSharedSecretCb(ctx, atcatls_create_pms_cb);
 #ifdef WOLFSSL_ATECC_TNGTLS
     ret=atcatls_set_certificates(ctx);
-    if(0!=ret){
+    if(ret != 0){
         #ifdef WOLFSSL_ATECC_DEBUG
         printf("    atcatls_set_certificates failed. (%d) \r\n",ret);
         #endif


### PR DESCRIPTION
Changes to atmel.c file that lets a user to
1. Use Harmony3 generated configurations to initialize the device in atmel_init().
2. Read the device   certificate chain from ECC608 TNGTLS and initialize the ctx with it to use as device certificate. 
    - This is the true purpose of going with TNGTLS