### PR TITLE
Fix bug where OCSP stapling wasn't happening even when requested by client

### DIFF
--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -311,7 +311,7 @@ wolf_pid3=$!
 wait_for_readyFile $ready_file2 $wolf_pid3 $port3
 ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p $port3
 RESULT=$?
-[ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 2 failed" && exit 1
+[ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 1 failed" && exit 1
 printf '%s\n\n' "Test PASSED!"
 
 printf '%s\n\n' "------------- TEST CASE 2 SHOULD REVOKE ----------------------"
@@ -324,7 +324,7 @@ wait_for_readyFile $ready_file2 $wolf_pid3 $port3
 sleep 0.1
 ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1 -p $port3
 RESULT=$?
-[ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection succeeded $RESULT" \
+[ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection 2 succeeded $RESULT" \
                   && exit 1
 printf '%s\n\n' "Test successfully REVOKED!"
 
@@ -345,7 +345,21 @@ if [ $? -ne 0 ]; then
     [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 3 failed" && exit 1
     printf '%s\n\n' "Test PASSED!"
 
-    printf '%s\n\n' "------------- TEST CASE 4 SHOULD REVOKE ------------------"
+    printf '%s\n\n' "------------- TEST CASE 4 SHOULD PASS --------------------"
+    # client test against our own server, must staple - GOOD CERT
+    remove_single_rF $ready_file2
+    ./examples/server/server -c certs/ocsp/server1-cert.pem -R $ready_file2 \
+                             -k certs/ocsp/server1-key.pem -v 4 \
+                             -p $port3 &
+    wolf_pid3=$!
+    wait_for_readyFile $ready_file2 $wolf_pid3 $port3
+    ./examples/client/client -C -A certs/ocsp/root-ca-cert.pem -W 1m -v 4 -F 1 \
+                             -p $port3
+    RESULT=$?
+    [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 4 failed" && exit 1
+    printf '%s\n\n' "Test PASSED!"
+
+    printf '%s\n\n' "------------- TEST CASE 5 SHOULD REVOKE ------------------"
     # client test against our own server - REVOKED CERT
     remove_single_rF $ready_file2
     ./examples/server/server -c certs/ocsp/server2-cert.pem -R $ready_file2 \
@@ -357,7 +371,7 @@ if [ $? -ne 0 ]; then
                              -p $port3
     RESULT=$?
     [ $RESULT -ne 1 ] && \
-                      printf '\n\n%s\n' "Client connection succeeded $RESULT" \
+                      printf '\n\n%s\n' "Client connection 5 succeeded $RESULT" \
                       && exit 1
     printf '%s\n\n' "Test successfully REVOKED!"
 fi
@@ -373,20 +387,20 @@ openssl s_server $V4V6_FLAG -cert ./certs/server-cert.pem -key certs/server-key.
 openssl_pid=$!
 sleep 0.1
 
-printf '%s\n\n' "------------- TEST CASE 5 SHOULD PASS ----------------------"
+printf '%s\n\n' "------------- TEST CASE 6 SHOULD PASS ----------------------"
 # client asks for OCSP staple but doesn't fail when none returned
 ./examples/client/client -p $port -g -v 3 -W 1
 
 RESULT=$?
-[ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 5 failed" && exit 1
+[ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 6 failed" && exit 1
 printf '%s\n\n' "Test PASSED!"
 
-printf '%s\n\n' "------------- TEST CASE 6 SHOULD UNKNOWN -------------------"
+printf '%s\n\n' "------------- TEST CASE 7 SHOULD UNKNOWN -------------------"
 # client asks for OCSP staple but doesn't fail when none returned
 ./examples/client/client -p $port -g -v 3 -W 1m
 
 RESULT=$?
-[ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection 6 succeeded $RESULT" \
+[ $RESULT -ne 1 ] && printf '\n\n%s\n' "Client connection 7 succeeded $RESULT" \
                   && exit 1
 printf '%s\n\n' "Test PASSED!"
 
@@ -395,21 +409,21 @@ openssl_tls13=$?
 ./examples/client/client -v 4 2>&1 | grep -- 'Bad SSL version'
 wolfssl_not_tls13=$?
 if [ "$openssl_tls13" = "0" -a "wolfssl_not_tls13" != "0" ]; then
-    printf '%s\n\n' "------------- TEST CASE 7 SHOULD PASS --------------------"
+    printf '%s\n\n' "------------- TEST CASE 8 SHOULD PASS --------------------"
     # client asks for OCSP staple but doesn't fail when none returned
     ./examples/client/client -p $port -g -v 4 -W 1
 
     RESULT=$?
-    [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 7 failed" && exit 1
+    [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection 8 failed" && exit 1
     printf '%s\n\n' "Test PASSED!"
 
-    printf '%s\n\n' "------------- TEST CASE 8 SHOULD UNKNOWN -----------------"
+    printf '%s\n\n' "------------- TEST CASE 9 SHOULD UNKNOWN -----------------"
     # client asks for OCSP staple but doesn't fail when none returned
     ./examples/client/client -p $port -g -v 4 -W 1m
 
     RESULT=$?
     [ $RESULT -ne 1 ] \
-                  && printf '\n\n%s\n' "Client connection 8 succeeded $RESULT" \
+                  && printf '\n\n%s\n' "Client connection 9 succeeded $RESULT" \
                   && exit 1
     printf '%s\n\n' "Test PASSED!"
 fi

--- a/src/internal.c
+++ b/src/internal.c
@@ -9825,6 +9825,7 @@ static int ProcessCSR(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 {
     int ret = 0;
     OcspRequest* request;
+    WOLFSSL_ENTER("ProcessCSR");
 
     #ifdef WOLFSSL_SMALL_STACK
         CertStatus* status;
@@ -9906,6 +9907,7 @@ static int ProcessCSR(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         XFREE(response, ssl->heap, DYNAMIC_TYPE_OCSP_REQUEST);
     #endif
 
+    WOLFSSL_LEAVE("ProcessCSR", ret);
     return ret;
 }
 #endif
@@ -11196,7 +11198,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             args->fatal = TLSX_CSR_InitRequest(ssl->extensions,
                                                     args->dCert, ssl->heap);
                             doLookup = 0;
-                        #if defined(WOLFSSL_TLS13) && !defined(NO_WOLFSSL_CLIENT)
+                        #if defined(WOLFSSL_TLS13)
                             if (ssl->options.tls1_3) {
                                 TLSX* ext = TLSX_Find(ssl->extensions,
                                                            TLSX_STATUS_REQUEST);

--- a/src/tls.c
+++ b/src/tls.c
@@ -3061,12 +3061,10 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, byte* input, word16 length,
                 if (offset + resp_length != length)
                     ret = BUFFER_ERROR;
             }
-        #if !defined(NO_WOLFSSL_SERVER)
             if (ret == 0) {
                 csr->response.buffer = input + offset;
                 csr->response.length = resp_length;
             }
-        #endif
 
             return ret;
         }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2352,7 +2352,7 @@ typedef struct {
     union {
         OcspRequest ocsp;
     } request;
-#if defined(WOLFSSL_TLS13) && !defined(NO_WOLFSSL_SERVER)
+#if defined(WOLFSSL_TLS13)
     buffer response;
 #endif
 } CertificateStatusRequest;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2018,8 +2018,8 @@ struct WOLFSSL_CERT_MANAGER {
     byte            ocspSendNonce:1;       /* send the OCSP nonce ? */
     byte            ocspUseOverrideURL:1;  /* ignore cert responder, override */
     byte            ocspStaplingEnabled:1; /* is OCSP Stapling on ? */
-#if !defined(NO_WOLFSSL_CLIENT) && (defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
-                               ||  defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2))
+#if defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
+||  defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
     byte            ocspMustStaple:1;      /* server must respond with staple */
 #endif
 


### PR DESCRIPTION
The OCSP request that we created didn't have a URL for the OCSP responder, so the server couldn't reach out to the responder for its cert status.