### PR TITLE
Fix RX/TX throughput reporting in example server.

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -522,7 +522,7 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
     return EXIT_SUCCESS;
 }
 
-/* Measures throughput in kbps. Throughput = number of bytes */
+/* Measures throughput in mbps. Throughput = number of bytes */
 static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
     int dtlsUDP, int dtlsSCTP, int block, size_t throughput, int useX25519,
     int useX448, int exitWithRet)

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -463,8 +463,8 @@ int ServerEchoData(SSL* ssl, int clientfd, int echoData, int block,
     #else
             (int)throughput,
     #endif
-            tx_time * 1000, throughput / tx_time / 1024 / 1024,
-            rx_time * 1000, throughput / rx_time / 1024 / 1024
+            rx_time * 1000, throughput / rx_time / 1024 / 1024,
+            tx_time * 1000, throughput / tx_time / 1024 / 1024
         );
     }
 

--- a/scripts/benchmark.test
+++ b/scripts/benchmark.test
@@ -67,7 +67,9 @@ then
     server_pid=$!
 fi
 
-
+# NOTE: We sleep for 2 seconds below. If timing the execution of this script
+#       with "time", bear in mind that those 2 seconds will be reflected in
+#       the "real" time.
 echo "Waiting for server_ready file..."
 while [ ! -s /tmp/wolfssl_server_ready -a "$counter" -lt 20 ]; do
     sleep 0.1


### PR DESCRIPTION
- I observed that client TX throughput < client RX throughput, but server TX
  throughput > server RX throughput. Turns out this is just a typo in the
  printing of the stats. The RX stat was being printed as the TX stat and vice-
  versa.
- I added a note to scripts/benchmark.test about a 2 second sleep we do waiting
  for the server to come up. If you were to time this script with the time
  command, you'll see that 2 seconds in the result, which might be confusing
  if you didn't realize the sleep was there.