### PR TITLE
Fix OCSP cert status check in internal.c

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -11919,7 +11919,7 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     if ((OcspResponseDecode(response, ssl->ctx->cm, ssl->heap,
                                                                         0) != 0)
                     ||  (response->responseStatus != OCSP_SUCCESSFUL)
-                    ||  (response->single->status != CERT_GOOD))
+                    ||  (response->single->status->status != CERT_GOOD))
                         ret = BAD_CERTIFICATE_STATUS_ERROR;
 
                     while (ret == 0) {


### PR DESCRIPTION
I missed one line in internal.c when I recently modified the OCSP ASN code.