### PR TITLE
ST Cube Pack Fixes

### DIFF
--- a/IDE/STM32Cube/README.md
+++ b/IDE/STM32Cube/README.md
@@ -50,10 +50,10 @@ The TLS client/server benchmark example requires about 76 KB for allocated tasks
 
 ### STM32 Cube Pack Installation
 
-1. Download [wolfSSL Cube Pack](https://www.wolfssl.com/files/ide/I-CUBE-WOLFSSL-WOLFSSL.pack)
+1. Download [wolfSSL Cube Pack](https://www.wolfssl.com/files/ide/I-CUBE-wolfSSL.pack)
 2. Run the “STM32CubeMX” tool.
 3. Under “Manage software installations” click “INSTALL/REMOVE” button.
-4. From Local and choose “I-CUBE-WOLFSSL-WOLFSSL.pack”.
+4. From Local and choose “I-CUBE-wolfSSL.pack”.
 5. Accept the GPLv2 license. Contact wolfSSL at sales@wolfssl.com for a commercial license and support/maintenance.
 
 ### STM32 Cube Pack Usage
@@ -69,7 +69,7 @@ The TLS client/server benchmark example requires about 76 KB for allocated tasks
 
 ### STM32 Cube Pack Examples
 
-In the `I-CUBE-WOLFSSL-WOLFSSL.pack` pack there are pre-assembled example projects available.
+In the `I-CUBE-wolfSSL.pack` pack there are pre-assembled example projects available.
 After installing the pack you can find these example projects in `STM32Cube/Repository/Packs/wolfSSL/wolfSSL/[Version]/Projects`.
 To use an example:
 

--- a/IDE/STM32Cube/default_conf.ftl
+++ b/IDE/STM32Cube/default_conf.ftl
@@ -121,9 +121,23 @@ extern ${variable.value} ${variable.name};
     #define NO_STM32_RNG
     #define WOLFSSL_GENSEED_FORTEST
 #else
-	#warning Please define a hardware platform!
-    #define WOLFSSL_STM32F4 /* default */
+    #warning Please define a hardware platform!
+    /* This means there is not a pre-defined platform for your board/CPU */
+    /* You need to define a CPU type, HW crypto and debug UART */
+    /* CPU Type: WOLFSSL_STM32F1, WOLFSSL_STM32F2, WOLFSSL_STM32F4, 
+        WOLFSSL_STM32F7, WOLFSSL_STM32H7, WOLFSSL_STM32L4 and WOLFSSL_STM32L5 */
+    #define WOLFSSL_STM32F4
+
+    /* Debug UART */
     #define HAL_CONSOLE_UART huart4
+
+    /* Hardware Crypto - uncomment as available on hardware */
+    //#define WOLFSSL_STM32_PKA
+    //#define NO_STM32_RNG
+    //#undef  NO_STM32_HASH
+    //#undef  NO_STM32_CRYPTO
+    //#define WOLFSSL_GENSEED_FORTEST
+    //#define STM32_HAL_V2
 #endif
 
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -4331,7 +4331,7 @@ int wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len)
     }
 #endif
     XMEMSET(iv, 0, AES_BLOCK_SIZE);
-    ret = wc_AesSetKeyLocal(aes, key, len, iv, AES_ENCRYPTION, 0);
+    ret = wc_AesSetKey(aes, key, len, iv, AES_ENCRYPTION);
 
     #ifdef WOLFSSL_AESNI
         /* AES-NI code generates its own H value. */


### PR DESCRIPTION
* Fix for AES GCM with hardware crypto (others besides ST also broken). With HW crypto the API `wc_AesSetKeyLocal` is not available. Broken in PR #3388.
* Updates to v4.5.1 cube pack.