### PR TITLE
TLS 1.3: Don't add a session without a ticket

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -6058,12 +6058,6 @@ static int SendTls13Finished(WOLFSSL* ssl)
     if (sendSz < 0)
         return BUILD_MSG_ERROR;
 
-#ifndef NO_SESSION_CACHE
-    if (!ssl->options.resuming) {
-        AddSession(ssl);    /* just try */
-    }
-#endif
-
     #ifdef WOLFSSL_CALLBACKS
         if (ssl->hsInfoOn) AddPacketName(ssl, "Finished");
         if (ssl->toInfoOn) {


### PR DESCRIPTION
TLS 1.3 doesn't support resumption with PSK (session ticket or with the
PSK callback).