### PR TITLE
Release fixes for Jenkins tests, example client

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3963,7 +3963,7 @@ fi
 
 if test "$ENABLED_SIGNAL" = "yes"
 then
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SIGNAL"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SIGNAL -DWOLFSSL_AES_COUNTER -DWOLFSSL_AES_DIRECT"
     # Requires opensslextra make sure on
     if test "x$ENABLED_OPENSSLEXTRA" = "xno" && test "x$ENABLED_OPENSSLCOEXIST" = "xno"
     then

--- a/configure.ac
+++ b/configure.ac
@@ -6286,7 +6286,7 @@ fi
 echo "   * Async Crypto:               $ENABLED_ASYNCCRYPT"
 echo "   * PKCS#11:                    $ENABLED_PKCS11"
 echo "   * PKCS#12:                    $ENABLED_PKCS12"
-echo "   * Cavium Nitox:               $ENABLED_CAVIUM"
+echo "   * Cavium Nitrox:              $ENABLED_CAVIUM"
 echo "   * Cavium Octeon (Sync):       $ENABLED_OCTEON_SYNC"
 echo "   * Intel Quick Assist:         $ENABLED_INTEL_QA"
 echo "   * ARM ASM:                    $ENABLED_ARMASM"

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -2898,7 +2898,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif
 
 #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
-    if (!helloRetry) {
+    if (!helloRetry && version >= 4) {
     #if defined(WOLFSSL_TLS13) && (!defined(NO_DH) || defined(HAVE_ECC) || \
                              defined(HAVE_CURVE25519) || defined(HAVE_CURVE448))
         if (onlyKeyShare == 0 || onlyKeyShare == 2) {

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -8588,6 +8588,9 @@ static int wc_AesFeedbackCFB8(Aes* aes, byte* out, const byte* in,
         }
 
         /* MSB + XOR */
+    #ifdef BIG_ENDIAN_ORDER
+        ByteReverseWords(aes->tmp, aes->tmp, AES_BLOCK_SIZE);
+    #endif
         out[0] = aes->tmp[0] ^ in[0];
         if (dir == AES_ENCRYPTION) {
             pt = (byte*)aes->reg;

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -110,6 +110,12 @@ int wc_curve25519_generic(int public_size, byte* pub,
                           int basepoint_size, const byte* basepoint) {
     int ret;
 
+#ifdef FREESCALE_LTC_ECC
+    /* unsupported with NXP LTC, onlly supports single basepoint with
+     * nxp_ltc_curve25519_GetBasePoint() */
+    return WC_HW_E;
+#endif
+
     if ((public_size != CURVE25519_KEYSIZE) ||
         (private_size != CURVE25519_KEYSIZE) ||
         (basepoint_size != CURVE25519_KEYSIZE)) {
@@ -124,14 +130,6 @@ int wc_curve25519_generic(int public_size, byte* pub,
         return ECC_BAD_ARG_E;
     }
 
-#ifdef FREESCALE_LTC_ECC
-    {
-        ECPoint wc_pub;
-        ret = nxp_ltc_curve25519(&wc_pub, priv, basepoint, basepoint);
-        if (ret == 0)
-            XMEMCPY(pub, wc_pub.point, CURVE25519_KEYSIZE);
-    }
-#else
     fe_init();
 
     #if defined(USE_INTEL_SPEEDUP) || defined(WOLFSSL_ARMASM)
@@ -143,7 +141,6 @@ int wc_curve25519_generic(int public_size, byte* pub,
     #if defined(USE_INTEL_SPEEDUP) || defined(WOLFSSL_ARMASM)
         RESTORE_VECTOR_REGISTERS();
     #endif
-#endif
 
     return ret;
 }


### PR DESCRIPTION
This PR includes the following fixes:

1. "--enable-signal" - Fixes nightly libsignal test, which needed AES-CTR to be enabled.
2. Fix for wc_AesFeedbackCFB8() on big endian systems, fixes nightly PowerPC test.
3. Adjust example client to only call wolfSSL_UseKeyShare() when doing TLS 1.3 to prevent unnecessary memory use.
4. Fix NXP LTC build - wc_curve25519_generic()