### PR TITLE
Release fixes for asynchronous crypto

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17137,7 +17137,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         ssl->options.acceptState  = ACCEPT_BEGIN;
         ssl->options.handShakeState  = NULL_STATE;
         ssl->options.handShakeDone = 0;
-        /* ssl->options.processReply = doProcessInit; */
+        ssl->options.processReply = 0; /* doProcessInit */
 
         ssl->keys.encryptionOn = 0;
         XMEMSET(&ssl->msgsReceived, 0, sizeof(ssl->msgsReceived));

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -7187,7 +7187,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     return ret;
 
                 if ((ret = DeriveTls13Keys(ssl, handshake_key,
-                                           ENCRYPT_AND_DECRYPT_SIDE, 1)) != 0) {
+                                        ENCRYPT_AND_DECRYPT_SIDE, 1)) != 0) {
                     return ret;
                 }
         #ifdef WOLFSSL_EARLY_DATA
@@ -7204,13 +7204,13 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     return ret;
         #ifdef WOLFSSL_EARLY_DATA
                 if ((ret = DeriveTls13Keys(ssl, traffic_key,
-                                       ENCRYPT_AND_DECRYPT_SIDE,
-                                       ssl->earlyData == no_early_data)) != 0) {
+                                    ENCRYPT_AND_DECRYPT_SIDE,
+                                    ssl->earlyData == no_early_data)) != 0) {
                     return ret;
                 }
         #else
                 if ((ret = DeriveTls13Keys(ssl, traffic_key,
-                                           ENCRYPT_AND_DECRYPT_SIDE, 1)) != 0) {
+                                        ENCRYPT_AND_DECRYPT_SIDE, 1)) != 0) {
                     return ret;
                 }
         #endif
@@ -7222,9 +7222,13 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 ssl->options.clientState = CLIENT_HELLO_COMPLETE;
                 ssl->options.connectState  = FIRST_REPLY_DONE;
                 ssl->options.handShakeState = CLIENT_HELLO_COMPLETE;
+                ssl->options.processReply = 0; /* doProcessInit */
 
-                if (wolfSSL_connect_TLSv13(ssl) != SSL_SUCCESS)
-                    ret = POST_HAND_AUTH_ERROR;
+                if (wolfSSL_connect_TLSv13(ssl) != WOLFSSL_SUCCESS) {
+                    ret = ssl->error;
+                    if (ret != WC_PENDING_E)
+                        ret = POST_HAND_AUTH_ERROR;
+                }
             }
         #endif
         }

--- a/sslSniffer/README.md
+++ b/sslSniffer/README.md
@@ -88,7 +88,7 @@ To build with OCTEON III support for a Linux host:
 
 ## Command Line Options
 
-The wolfSSL sniffer includes a test application `snifftest` in the `sslSniffer/sslSnifferTest/ directory`. The command line application has several options that can be passed in at runtime to change the default behavior of the application. To execute a “live” sniff just run the application without any parameters and then pick an interface to sniff on followed by the port.
+The wolfSSL sniffer includes a test application `snifftest` in the `sslSniffer/sslSnifferTest/` directory. The command line application has several options that can be passed in at runtime to change the default behavior of the application. To execute a “live” sniff just run the application without any parameters and then pick an interface to sniff on followed by the port.
 
 An example startup may look like this:
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -34735,8 +34735,11 @@ static void test_wolfSSL_OBJ_ln(void)
         nCurves = EC_get_builtin_curves(r,nCurves);
 
         for (i = 0; i < nCurves; i++) {
-            AssertIntEQ(OBJ_ln2nid(r[i].comment), r[i].nid);
-            AssertStrEQ(OBJ_nid2ln(r[i].nid), r[i].comment);
+            /* skip ECC_CURVE_INVALID */
+            if (r[i].nid != ECC_CURVE_INVALID) {
+                AssertIntEQ(OBJ_ln2nid(r[i].comment), r[i].nid);
+                AssertStrEQ(OBJ_nid2ln(r[i].nid), r[i].comment);
+            }
         }
     }
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -5792,13 +5792,10 @@ static void test_set_x509_badversion(WOLFSSL_CTX* ctx)
     AssertIntGT(derSz, 0);
     AssertIntEQ(wolfSSL_CTX_use_certificate_buffer(ctx, der, derSz,
                                      WOLFSSL_FILETYPE_ASN1), WOLFSSL_SUCCESS);
-    free(der);
-    if (key != NULL)
-        free(key);
-    if (name != NULL)
-        free(name);
-    if (header != NULL)
-        free(header);
+    XFREE(der, HEAP_HINT, DYNAMIC_TYPE_OPENSSL); /* TODO: Replace with API call */
+    XFREE(key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(name, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(header, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     wolfSSL_X509_free(x509);
     wolfSSL_X509_free(x509v2);
     wolfSSL_EVP_PKEY_free(priv);
@@ -29512,7 +29509,7 @@ static void test_wolfSSL_X509_sign(void)
     AssertNotNull(caSubject  = wolfSSL_X509_NAME_oneline(
                                               X509_get_subject_name(ca), 0, 0));
     AssertIntEQ(0, XSTRNCMP(caSubject, dCert.subject, XSTRLEN(caSubject)));
-    free(caSubject);
+    XFREE(caSubject, HEAP_HINT, DYNAMIC_TYPE_OPENSSL);
 
 #ifdef WOLFSSL_MULTI_ATTRIB
     /* test adding multiple OU's to the signer */
@@ -29530,7 +29527,7 @@ static void test_wolfSSL_X509_sign(void)
     AssertIntGT(X509_sign(x509, priv, EVP_sha256()), 0);
     AssertNotNull(caSubject  = wolfSSL_X509_NAME_oneline(
                                              X509_get_issuer_name(x509), 0, 0));
-    free(caSubject);
+    XFREE(caSubject, HEAP_HINT, DYNAMIC_TYPE_OPENSSL);
 
     FreeDecodedCert(&dCert);
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3920,11 +3920,12 @@ static int wc_ecc_shared_secret_gen_async(ecc_key* private_key,
     int err;
 
 #if defined(HAVE_CAVIUM_V) || defined(HAVE_INTEL_QA)
-#ifdef HAVE_CAVIUM_V
-    /* verify the curve is supported by hardware */
-    if (NitroxEccIsCurveSupported(private_key))
-#endif
-    {
+    if (private_key->dp && private_key->dp->id != ECC_CURVE_CUSTOM
+    #ifdef HAVE_CAVIUM_V
+        /* verify the curve is supported by hardware */
+        && NitroxEccIsCurveSupported(private_key)
+    #endif
+    ) {
         word32 keySz = private_key->dp->size;
 
         /* sync public key x/y */

--- a/wolfcrypt/src/hash.c
+++ b/wolfcrypt/src/hash.c
@@ -1027,6 +1027,7 @@ int wc_HashGetFlags(wc_HashAlg* hash, enum wc_HashType type, word32* flags)
     #else
         wc_Sha sha[1];
     #endif
+        int devId = INVALID_DEVID;
 
     #ifdef WOLFSSL_SMALL_STACK
         sha = (wc_Sha*)XMALLOC(sizeof(wc_Sha), NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -1034,8 +1035,13 @@ int wc_HashGetFlags(wc_HashAlg* hash, enum wc_HashType type, word32* flags)
             return MEMORY_E;
     #endif
 
-        if ((ret = wc_InitSha_ex(sha, NULL, 
-                wc_CryptoCb_GetDevIdAtIndex(0))) != 0) {
+    #ifdef WOLF_CRYPTO_CB
+        /* only use devId if its not an empty hash */
+        if (data != NULL && len > 0)
+            devId = wc_CryptoCb_GetDevIdAtIndex(0);
+    #endif
+
+        if ((ret = wc_InitSha_ex(sha, NULL, devId)) != 0) {
             WOLFSSL_MSG("InitSha failed");
         }
         else {
@@ -1103,6 +1109,7 @@ int wc_HashGetFlags(wc_HashAlg* hash, enum wc_HashType type, word32* flags)
     #else
         wc_Sha256 sha256[1];
     #endif
+        int devId = INVALID_DEVID;
 
     #ifdef WOLFSSL_SMALL_STACK
         sha256 = (wc_Sha256*)XMALLOC(sizeof(wc_Sha256), NULL,
@@ -1111,8 +1118,13 @@ int wc_HashGetFlags(wc_HashAlg* hash, enum wc_HashType type, word32* flags)
             return MEMORY_E;
     #endif
 
-        if ((ret = wc_InitSha256_ex(sha256, NULL, 
-                wc_CryptoCb_GetDevIdAtIndex(0))) != 0) {
+    #ifdef WOLF_CRYPTO_CB
+        /* only use devId if its not an empty hash */
+        if (data != NULL && len > 0)
+            devId = wc_CryptoCb_GetDevIdAtIndex(0);
+    #endif
+
+        if ((ret = wc_InitSha256_ex(sha256, NULL, devId)) != 0) {
             WOLFSSL_MSG("InitSha256 failed");
         }
         else {

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3158,7 +3158,8 @@ static int RsaPrivateDecryptEx(byte* in, word32 inLen, byte* out,
             defined(HAVE_CAVIUM)
         if (key->asyncDev.marker == WOLFSSL_ASYNC_MARKER_RSA &&
                                                    pad_type != WC_RSA_PSS_PAD) {
-            if (ret > 0) {
+            ret = key->asyncDev.event.ret;
+            if (ret >= 0) {
                 /* convert result */
                 byte* dataLen = (byte*)&key->dataLen;
                 ret = (dataLen[0] << 8) | (dataLen[1]);

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -526,6 +526,11 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
         return BAD_FUNC_ARG;
     }
 
+    if (data == NULL && len == 0) {
+        /* valid, but do nothing */
+        return 0;
+    }
+
 #ifdef WOLF_CRYPTO_CB
     if (sha->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_ShaHash(sha, data, len, NULL);
@@ -546,11 +551,6 @@ int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len)
     /* check that internal buffLen is valid */
     if (sha->buffLen >= WC_SHA_BLOCK_SIZE)
         return BUFFER_E;
-
-    if (data == NULL && len == 0) {
-        /* valid, but do nothing */
-        return 0;
-    }
 
     /* add length for final */
     AddLength(sha, len);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9196,8 +9196,8 @@ static int aesgcm_test(void)
     #endif
 #endif
 
-#if !defined(BENCH_EMBEDDED)
-    #ifndef BENCH_AESGCM_LARGE
+#if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM)
+    #if !defined(BENCH_AESGCM_LARGE)
         #define BENCH_AESGCM_LARGE 1024
     #endif
     byte *large_input = (byte *)XMALLOC(BENCH_AESGCM_LARGE, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -9561,7 +9561,7 @@ static int aesgcm_test(void)
 
   out:
 
-#if !defined(BENCH_EMBEDDED)
+#if !defined(BENCH_EMBEDDED) && !defined(HAVE_CAVIUM)
     if (large_input)
         XFREE(large_input, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (large_output)
@@ -12142,8 +12142,7 @@ static int rsa_sig_test(RsaKey* key, word32 keyLen, int modLen, WC_RNG* rng)
 #elif defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLF_CRYPTO_CB)
     /* async may not require RNG */
     if (ret != 0 && ret != MISSING_RNG_E)
-#elif defined(HAVE_FIPS) || defined(WOLFSSL_ASYNC_CRYPT) || \
-     !defined(WC_RSA_BLINDING)
+#elif defined(HAVE_FIPS) || !defined(WC_RSA_BLINDING)
     /* FIPS140 implementation does not do blinding */
     if (ret != 0)
 #elif defined(WOLFSSL_RSA_PUBLIC_ONLY)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -8115,7 +8115,7 @@ static int aes_test(void)
     XMEMSET(cipher, 0, AES_BLOCK_SIZE * 4);
     ret = wc_AesCbcEncrypt(enc, cipher, msg, AES_BLOCK_SIZE);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, enc.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &enc->asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(-5904, out);
@@ -8123,7 +8123,7 @@ static int aes_test(void)
     XMEMSET(plain, 0, AES_BLOCK_SIZE * 4);
     ret = wc_AesCbcDecrypt(dec, plain, cipher, AES_BLOCK_SIZE);
 #if defined(WOLFSSL_ASYNC_CRYPT)
-    ret = wc_AsyncWait(ret, dec.asyncDev, WC_ASYNC_FLAG_NONE);
+    ret = wc_AsyncWait(ret, &dec->asyncDev, WC_ASYNC_FLAG_NONE);
 #endif
     if (ret != 0)
         ERROR_OUT(-5905, out);
@@ -8299,7 +8299,7 @@ static int aes_test(void)
         XMEMSET(cipher, 0, AES_BLOCK_SIZE * 2);
         ret = wc_AesCbcEncrypt(enc, cipher, msg2, AES_BLOCK_SIZE);
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, enc.asyncDev, WC_ASYNC_FLAG_NONE);
+        ret = wc_AsyncWait(ret, &enc->asyncDev, WC_ASYNC_FLAG_NONE);
     #endif
         if (ret != 0)
             ERROR_OUT(-5914, out);
@@ -8309,7 +8309,7 @@ static int aes_test(void)
         ret = wc_AesCbcEncrypt(enc, cipher + AES_BLOCK_SIZE,
                 msg2 + AES_BLOCK_SIZE, AES_BLOCK_SIZE);
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, enc.asyncDev, WC_ASYNC_FLAG_NONE);
+        ret = wc_AsyncWait(ret, &enc->asyncDev, WC_ASYNC_FLAG_NONE);
     #endif
         if (ret != 0)
             ERROR_OUT(-5916, out);
@@ -8324,7 +8324,7 @@ static int aes_test(void)
         XMEMSET(plain, 0, AES_BLOCK_SIZE * 2);
         ret = wc_AesCbcDecrypt(dec, plain, verify2, AES_BLOCK_SIZE);
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, dec.asyncDev, WC_ASYNC_FLAG_NONE);
+        ret = wc_AsyncWait(ret, &dec->asyncDev, WC_ASYNC_FLAG_NONE);
     #endif
         if (ret != 0)
             ERROR_OUT(-5919, out);
@@ -8334,7 +8334,7 @@ static int aes_test(void)
         ret = wc_AesCbcDecrypt(dec, plain + AES_BLOCK_SIZE,
                 verify2 + AES_BLOCK_SIZE, AES_BLOCK_SIZE);
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, dec.asyncDev, WC_ASYNC_FLAG_NONE);
+        ret = wc_AsyncWait(ret, &dec->asyncDev, WC_ASYNC_FLAG_NONE);
     #endif
         if (ret != 0)
             ERROR_OUT(-5921, out);
@@ -13036,7 +13036,7 @@ static int rsa_no_pad_test(void)
     XMEMSET(tmp, 7, inLen);
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+        ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
         if (ret >= 0) {
             ret = wc_RsaDirect(tmp, inLen, out, &outSz, key,
@@ -13056,7 +13056,7 @@ static int rsa_no_pad_test(void)
     /* decrypt with public key and compare result */
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+        ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
         if (ret >= 0) {
             ret = wc_RsaDirect(out, outSz, plain, &plainSz, key,
@@ -13089,7 +13089,7 @@ static int rsa_no_pad_test(void)
 #ifndef WOLFSSL_RSA_VERIFY_ONLY
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+        ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
         if (ret >= 0) {
             ret = wc_RsaPublicEncrypt_ex(tmp, inLen, out, (int)outSz, key, &rng,
@@ -13105,7 +13105,7 @@ static int rsa_no_pad_test(void)
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+        ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
         if (ret >= 0) {
             ret = wc_RsaPrivateDecrypt_ex(out, outSz, plain, (int)plainSz, key,
@@ -19784,7 +19784,7 @@ static int ecc_test_cdh_vectors(WC_RNG* rng)
     x = sizeof(sharedA);
     do {
     #if defined(WOLFSSL_ASYNC_CRYPT)
-        ret = wc_AsyncWait(ret, priv_key.asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
+        ret = wc_AsyncWait(ret, &priv_key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
     #endif
         if (ret == 0)
             ret = wc_ecc_shared_secret(priv_key, pub_key, sharedA, &x);

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -306,10 +306,6 @@ WOLFSSL_LOCAL int wc_CryptoCb_RandomBlock(WC_RNG* rng, byte* out, word32 sz);
 WOLFSSL_LOCAL int wc_CryptoCb_RandomSeed(OS_Seed* os, byte* seed, word32 sz);
 #endif
 
-#else
-
-#define wc_CryptoCb_GetDevIdAtIndex(idx) (INVALID_DEVID)
-
 #endif /* WOLF_CRYPTO_CB */
 
 #ifdef __cplusplus


### PR DESCRIPTION
* Fix for async TLS v1.3 post handshake auth. The re-handshake was not resetting the `processReply` state.
* Fix asyncDev usage in test.c
* Fix in `test_wolfSSL_OBJ_ln()` in api.c for handling `ECC_CURVE_INVALID`.
* Fixes for Cavium Nitrox and Intel QuickAssist.
* Fix api.c tests using "free()" instead of "XFREE" causing issues with custom allocators.