### PR TITLE
fix mp_read_unsigned_bin() calculation of mp_int.used_bits

### DIFF
--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -697,10 +697,18 @@ int mp_mod_2d (mp_int * a, int b, mp_int * c)
 int mp_read_unsigned_bin (mp_int * a, const unsigned char *b, int c)
 {
   int     res;
+  int     digits_needed;
 
-  /* make sure there are at least two digits */
-  if (a->alloc < 2) {
-     if ((res = mp_grow(a, 2)) != MP_OKAY) {
+  while (c > 0 && b[0] == 0) {
+      c--;
+      b++;
+  }
+
+  digits_needed = ((c * CHAR_BIT) + DIGIT_BIT - 1) / DIGIT_BIT;
+
+  /* make sure there are enough digits available */
+  if (a->alloc < digits_needed) {
+     if ((res = mp_grow(a, digits_needed)) != MP_OKAY) {
         return res;
      }
   }
@@ -716,11 +724,13 @@ int mp_read_unsigned_bin (mp_int * a, const unsigned char *b, int c)
 
 #ifndef MP_8BIT
       a->dp[0] |= *b++;
-      a->used += 1;
+      if (a->used == 0)
+          a->used = 1;
 #else
       a->dp[0] = (*b & MP_MASK);
       a->dp[1] |= ((*b++ >> 7U) & 1);
-      a->used += 2;
+      if (a->used == 0)
+          a->used = 2;
 #endif
   }
   mp_clamp (a);


### PR DESCRIPTION
Fixes #3539.

In the final iteration of the loop in `mp_read_unsigned_bin()`, the pessimistic full-digit increment of `a->used` could overshoot `a->alloc`, and since `mp_mul_2d()` wasn't called again, `mp_clamp()` could be entered with that in place, resulting in an out-of-bounds read of `a->dp`.

The fix is to initialize `a->used` in the first iteration to the count of digits used at that point, and let `mp_mul_2d()` increase `->used` thereafter in each iteration with correct bit-granularity logic.

As an optimization, the output buffer is enlarged at entry to be able to hold the supplied input.  This avoid calls to `realloc()` inside the loop.
