### PR TITLE
Release fixes for CAVP selftest builds

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -549,60 +549,60 @@ static RevokedCert *DupRevokedCertList(RevokedCert* in, void* heap)
 /* returns a deep copy of ent on success and null on fail */
 static CRL_Entry* DupCRL_Entry(const CRL_Entry* ent, void* heap)
 {
-    CRL_Entry *dup;
+    CRL_Entry *dupl;
 
-    dup = (CRL_Entry*)XMALLOC(sizeof(CRL_Entry), heap, DYNAMIC_TYPE_CRL_ENTRY);
-    if (dup == NULL) {
+    dupl = (CRL_Entry*)XMALLOC(sizeof(CRL_Entry), heap, DYNAMIC_TYPE_CRL_ENTRY);
+    if (dupl == NULL) {
         WOLFSSL_MSG("alloc CRL Entry failed");
         return NULL;
     }
-    XMEMSET(dup, 0, sizeof(CRL_Entry));
+    XMEMSET(dupl, 0, sizeof(CRL_Entry));
 
-    XMEMCPY(dup->issuerHash, ent->issuerHash, CRL_DIGEST_SIZE);
-    XMEMCPY(dup->lastDate, ent->lastDate, MAX_DATE_SIZE);
-    XMEMCPY(dup->nextDate, ent->nextDate, MAX_DATE_SIZE);
-    dup->lastDateFormat = ent->lastDateFormat;
-    dup->nextDateFormat = ent->nextDateFormat;
-    dup->certs = DupRevokedCertList(ent->certs, heap);
+    XMEMCPY(dupl->issuerHash, ent->issuerHash, CRL_DIGEST_SIZE);
+    XMEMCPY(dupl->lastDate, ent->lastDate, MAX_DATE_SIZE);
+    XMEMCPY(dupl->nextDate, ent->nextDate, MAX_DATE_SIZE);
+    dupl->lastDateFormat = ent->lastDateFormat;
+    dupl->nextDateFormat = ent->nextDateFormat;
+    dupl->certs = DupRevokedCertList(ent->certs, heap);
 
-    dup->totalCerts = ent->totalCerts;
-    dup->verified = ent->verified;
+    dupl->totalCerts = ent->totalCerts;
+    dupl->verified = ent->verified;
 
     if (!ent->verified) {
-        dup->tbsSz = ent->tbsSz;
-        dup->signatureSz = ent->signatureSz;
-        dup->signatureOID = ent->signatureOID;
-        dup->toBeSigned = (byte*)XMALLOC(dup->tbsSz, heap,
+        dupl->tbsSz = ent->tbsSz;
+        dupl->signatureSz = ent->signatureSz;
+        dupl->signatureOID = ent->signatureOID;
+        dupl->toBeSigned = (byte*)XMALLOC(dupl->tbsSz, heap,
                                           DYNAMIC_TYPE_CRL_ENTRY);
-        if (dup->toBeSigned == NULL) {
-            FreeCRL_Entry(dup, heap);
-            XFREE(dup, heap, DYNAMIC_TYPE_CRL_ENTRY);
+        if (dupl->toBeSigned == NULL) {
+            FreeCRL_Entry(dupl, heap);
+            XFREE(dupl, heap, DYNAMIC_TYPE_CRL_ENTRY);
             return NULL;
         }
 
-        dup->signature = (byte*)XMALLOC(dup->signatureSz, heap,
+        dupl->signature = (byte*)XMALLOC(dupl->signatureSz, heap,
                                          DYNAMIC_TYPE_CRL_ENTRY);
-        if (dup->signature == NULL) {
-            FreeCRL_Entry(dup, heap);
-            XFREE(dup, heap, DYNAMIC_TYPE_CRL_ENTRY);
+        if (dupl->signature == NULL) {
+            FreeCRL_Entry(dupl, heap);
+            XFREE(dupl, heap, DYNAMIC_TYPE_CRL_ENTRY);
             return NULL;
         }
-        XMEMCPY(dup->toBeSigned, ent->toBeSigned, dup->tbsSz);
-        XMEMCPY(dup->signature, ent->signature, dup->signatureSz);
+        XMEMCPY(dupl->toBeSigned, ent->toBeSigned, dupl->tbsSz);
+        XMEMCPY(dupl->signature, ent->signature, dupl->signatureSz);
     #ifndef NO_SKID
-        dup->extAuthKeyIdSet = ent->extAuthKeyIdSet;
-        if (dup->extAuthKeyIdSet)
-            XMEMCPY(dup->extAuthKeyId, ent->extAuthKeyId, KEYID_SIZE);
+        dupl->extAuthKeyIdSet = ent->extAuthKeyIdSet;
+        if (dupl->extAuthKeyIdSet)
+            XMEMCPY(dupl->extAuthKeyId, ent->extAuthKeyId, KEYID_SIZE);
     #endif
     }
     else {
-        dup->toBeSigned = NULL;
-        dup->tbsSz = 0;
-        dup->signature = NULL;
-        dup->signatureSz = 0;
+        dupl->toBeSigned = NULL;
+        dupl->tbsSz = 0;
+        dupl->signature = NULL;
+        dupl->signatureSz = 0;
     }
 
-    return dup;
+    return dupl;
 }
 
 
@@ -642,20 +642,20 @@ static CRL_Entry* DupCRL_list(CRL_Entry* crl, void* heap)
 
 
 /* Duplicates everything except the parent cm pointed to.
- * Expects that Init has already been done to 'dup'
+ * Expects that Init has already been done to 'dupl'
  * return 0 on success */
-static int DupX509_CRL(WOLFSSL_X509_CRL *dup, const WOLFSSL_X509_CRL* crl)
+static int DupX509_CRL(WOLFSSL_X509_CRL *dupl, const WOLFSSL_X509_CRL* crl)
 {
-    if (dup == NULL || crl == NULL) {
+    if (dupl == NULL || crl == NULL) {
         return BAD_FUNC_ARG;
     }
 
     if (crl->monitors[0].path) {
         int pathSz = (int)XSTRLEN(crl->monitors[0].path) + 1;
-        dup->monitors[0].path = (char*)XMALLOC(pathSz, dup->heap,
+        dupl->monitors[0].path = (char*)XMALLOC(pathSz, dupl->heap,
                 DYNAMIC_TYPE_CRL_MONITOR);
-        if (dup->monitors[0].path != NULL) {
-            XSTRNCPY(dup->monitors[0].path, crl->monitors[0].path, pathSz);
+        if (dupl->monitors[0].path != NULL) {
+            XSTRNCPY(dupl->monitors[0].path, crl->monitors[0].path, pathSz);
         }
         else {
             return MEMORY_E;
@@ -664,23 +664,23 @@ static int DupX509_CRL(WOLFSSL_X509_CRL *dup, const WOLFSSL_X509_CRL* crl)
 
     if (crl->monitors[1].path) {
         int pathSz = (int)XSTRLEN(crl->monitors[1].path) + 1;
-        dup->monitors[1].path = (char*)XMALLOC(pathSz, dup->heap,
+        dupl->monitors[1].path = (char*)XMALLOC(pathSz, dupl->heap,
                 DYNAMIC_TYPE_CRL_MONITOR);
-        if (dup->monitors[1].path != NULL) {
-            XSTRNCPY(dup->monitors[1].path, crl->monitors[1].path, pathSz);
+        if (dupl->monitors[1].path != NULL) {
+            XSTRNCPY(dupl->monitors[1].path, crl->monitors[1].path, pathSz);
         }
         else {
-            if (dup->monitors[0].path != NULL) {
-                XFREE(dup->monitors[0].path, dup->heap,
+            if (dupl->monitors[0].path != NULL) {
+                XFREE(dupl->monitors[0].path, dupl->heap,
                         DYNAMIC_TYPE_CRL_MONITOR);
             }
             return MEMORY_E;
         }
     }
 
-    dup->crlList = DupCRL_list(crl->crlList, dup->heap);
+    dupl->crlList = DupCRL_list(crl->crlList, dupl->heap);
 #ifdef HAVE_CRL_IO
-    dup->crlIOCb = crl->crlIOCb;
+    dupl->crlIOCb = crl->crlIOCb;
 #endif
 
     return 0;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -18663,7 +18663,7 @@ WOLFSSL_GENERAL_NAME* wolfSSL_GENERAL_NAME_new(void)
 
 static WOLFSSL_GENERAL_NAME* wolfSSL_GENERAL_NAME_dup(WOLFSSL_GENERAL_NAME* gn)
 {
-    WOLFSSL_GENERAL_NAME* dup = NULL;
+    WOLFSSL_GENERAL_NAME* dupl = NULL;
 
     WOLFSSL_ENTER("wolfSSL_GENERAL_NAME_dup");
 
@@ -18672,7 +18672,7 @@ static WOLFSSL_GENERAL_NAME* wolfSSL_GENERAL_NAME_dup(WOLFSSL_GENERAL_NAME* gn)
         return NULL;
     }
 
-    if (!(dup = wolfSSL_GENERAL_NAME_new())) {
+    if (!(dupl = wolfSSL_GENERAL_NAME_new())) {
         WOLFSSL_MSG("wolfSSL_GENERAL_NAME_new error");
         return NULL;
     }
@@ -18680,25 +18680,25 @@ static WOLFSSL_GENERAL_NAME* wolfSSL_GENERAL_NAME_dup(WOLFSSL_GENERAL_NAME* gn)
     switch (gn->type) {
     /* WOLFSSL_ASN1_STRING types */
     case GEN_DNS:
-        if (!(dup->d.dNSName = wolfSSL_ASN1_STRING_dup(gn->d.dNSName))) {
+        if (!(dupl->d.dNSName = wolfSSL_ASN1_STRING_dup(gn->d.dNSName))) {
             WOLFSSL_MSG("wolfSSL_ASN1_STRING_dup error");
             goto error;
         }
         break;
     case GEN_IPADD:
-        if (!(dup->d.iPAddress = wolfSSL_ASN1_STRING_dup(gn->d.iPAddress))) {
+        if (!(dupl->d.iPAddress = wolfSSL_ASN1_STRING_dup(gn->d.iPAddress))) {
             WOLFSSL_MSG("wolfSSL_ASN1_STRING_dup error");
             goto error;
         }
         break;
     case GEN_EMAIL:
-        if (!(dup->d.rfc822Name = wolfSSL_ASN1_STRING_dup(gn->d.rfc822Name))) {
+        if (!(dupl->d.rfc822Name = wolfSSL_ASN1_STRING_dup(gn->d.rfc822Name))) {
             WOLFSSL_MSG("wolfSSL_ASN1_STRING_dup error");
             goto error;
         }
         break;
     case GEN_URI:
-        if (!(dup->d.uniformResourceIdentifier =
+        if (!(dupl->d.uniformResourceIdentifier =
                 wolfSSL_ASN1_STRING_dup(gn->d.uniformResourceIdentifier))) {
             WOLFSSL_MSG("wolfSSL_ASN1_STRING_dup error");
             goto error;
@@ -18714,10 +18714,10 @@ static WOLFSSL_GENERAL_NAME* wolfSSL_GENERAL_NAME_dup(WOLFSSL_GENERAL_NAME* gn)
         goto error;
     }
 
-    return dup;
+    return dupl;
 error:
-    if (dup) {
-        wolfSSL_GENERAL_NAME_free(dup);
+    if (dupl) {
+        wolfSSL_GENERAL_NAME_free(dupl);
     }
     return NULL;
 }
@@ -19589,7 +19589,7 @@ WOLFSSL_ASN1_OBJECT* wolfSSL_ASN1_OBJECT_new(void)
 
 WOLFSSL_ASN1_OBJECT* wolfSSL_ASN1_OBJECT_dup(WOLFSSL_ASN1_OBJECT* obj)
 {
-    WOLFSSL_ASN1_OBJECT* dup = NULL;
+    WOLFSSL_ASN1_OBJECT* dupl = NULL;
 
     WOLFSSL_ENTER("wolfSSL_ASN1_OBJECT_dup");
 
@@ -19597,29 +19597,29 @@ WOLFSSL_ASN1_OBJECT* wolfSSL_ASN1_OBJECT_dup(WOLFSSL_ASN1_OBJECT* obj)
         WOLFSSL_MSG("Bad parameter");
         return NULL;
     }
-    dup = wolfSSL_ASN1_OBJECT_new();
-    if (!dup) {
+    dupl = wolfSSL_ASN1_OBJECT_new();
+    if (!dupl) {
         WOLFSSL_MSG("wolfSSL_ASN1_OBJECT_new error");
         return NULL;
     }
     /* Copy data */
-    XMEMCPY(dup->sName, obj->sName, WOLFSSL_MAX_SNAME);
-    dup->type = obj->type;
-    dup->grp = obj->grp;
-    dup->nid = obj->nid;
-    dup->objSz = obj->objSz;
+    XMEMCPY(dupl->sName, obj->sName, WOLFSSL_MAX_SNAME);
+    dupl->type = obj->type;
+    dupl->grp = obj->grp;
+    dupl->nid = obj->nid;
+    dupl->objSz = obj->objSz;
     if (obj->obj) {
-        dup->obj = (const unsigned char*)XMALLOC(
+        dupl->obj = (const unsigned char*)XMALLOC(
                 obj->objSz, NULL, DYNAMIC_TYPE_ASN1);
-        if (!dup->obj) {
+        if (!dupl->obj) {
             WOLFSSL_MSG("ASN1 obj malloc error");
-            wolfSSL_ASN1_OBJECT_free(dup);
+            wolfSSL_ASN1_OBJECT_free(dupl);
             return NULL;
         }
-        XMEMCPY((byte*)dup->obj, obj->obj, obj->objSz);
-        dup->dynamic |= WOLFSSL_ASN1_DYNAMIC_DATA;
+        XMEMCPY((byte*)dupl->obj, obj->obj, obj->objSz);
+        dupl->dynamic |= WOLFSSL_ASN1_DYNAMIC_DATA;
     }
-    return dup;
+    return dupl;
 }
 #endif /* !NO_ASN && (OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL) */
 
@@ -20982,7 +20982,7 @@ int wolfSSL_X509_cmp(const WOLFSSL_X509 *a, const WOLFSSL_X509 *b)
      */
     WOLFSSL_ASN1_STRING* wolfSSL_ASN1_STRING_dup(WOLFSSL_ASN1_STRING* asn1)
     {
-        WOLFSSL_ASN1_STRING* dup = NULL;
+        WOLFSSL_ASN1_STRING* dupl = NULL;
 
         WOLFSSL_ENTER("wolfSSL_ASN1_STRING_dup");
         if (!asn1) {
@@ -20990,23 +20990,23 @@ int wolfSSL_X509_cmp(const WOLFSSL_X509 *a, const WOLFSSL_X509 *b)
             return NULL;
         }
 
-        dup = wolfSSL_ASN1_STRING_new();
-        if (!dup) {
+        dupl = wolfSSL_ASN1_STRING_new();
+        if (!dupl) {
             WOLFSSL_MSG("wolfSSL_ASN1_STRING_new error");
             return NULL;
         }
 
-        dup->type = asn1->type;
-        dup->flags = asn1->flags;
+        dupl->type = asn1->type;
+        dupl->flags = asn1->flags;
 
-        if (wolfSSL_ASN1_STRING_set(dup, asn1->data, asn1->length)
+        if (wolfSSL_ASN1_STRING_set(dupl, asn1->data, asn1->length)
                 != WOLFSSL_SUCCESS) {
             WOLFSSL_MSG("wolfSSL_ASN1_STRING_set error");
-            wolfSSL_ASN1_STRING_free(dup);
+            wolfSSL_ASN1_STRING_free(dupl);
             return NULL;
         }
 
-        return dup;
+        return dupl;
     }
 
 

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -154,7 +154,8 @@ enum Pkcs7_Misc {
                             MAX_SEQ_SZ + ASN_NAME_MAX + MAX_SN_SZ +
                             MAX_SEQ_SZ + MAX_ALGO_SZ + 1 + MAX_ENCRYPTED_KEY_SZ,
 #if (defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
-     (HAVE_FIPS_VERSION <= 2)) || (defined(HAVE_SELFTEST))
+     (HAVE_FIPS_VERSION <= 2)) || (defined(HAVE_SELFTEST) && \
+     (!defined(HAVE_SELFTEST_VERSION) || (HAVE_SELFTEST_VERSION < 2)))
     /* In the event of fips cert 3389 or CAVP selftest v1 build, these enums are
      * not in aes.h for use with pkcs7 so enumerate it here outside the fips
      * boundary */


### PR DESCRIPTION
This PR fixes:

1. CAVP selftest v2 build, an issue in pkcs7.h
2. CAVP selftest v2 build, rename "dup" variable to "dupl" to fix i386 cross compiler warnings about shadowing a global variable.