### PR TITLE
fix deadstore in ssl.c warned by LLVM11 scan-build.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -41134,7 +41134,7 @@ err:
         }
 
         /* Read the header and footer */
-        while ((l = wolfSSL_BIO_read(bio, &pem[i], 1)) == 1) {
+        while (wolfSSL_BIO_read(bio, &pem[i], 1) == 1) {
             i++;
             if (!header)
                 header = XSTRNSTR(pem, "-----BEGIN ", (unsigned int)i);


### PR DESCRIPTION
```
src/ssl.c:41137:17: warning: Although the value stored to 'l' is used in the enclosing expression, the value is never actually read from 'l' [deadcode.DeadStores]
        while ((l = wolfSSL_BIO_read(bio, &pem[i], 1)) == 1) {
                ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```
