### PR TITLE
Fixes in preparation for release

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3920,7 +3920,10 @@ static int wc_ecc_shared_secret_gen_async(ecc_key* private_key,
     int err;
 
 #if defined(HAVE_CAVIUM_V) || defined(HAVE_INTEL_QA)
-    if (private_key->dp && private_key->dp->id != ECC_CURVE_CUSTOM
+    if (private_key->dp 
+    #ifdef WOLFSSL_CUSTOM_CURVES
+        && private_key->dp->id != ECC_CURVE_CUSTOM
+    #endif
     #ifdef HAVE_CAVIUM_V
         /* verify the curve is supported by hardware */
         && NitroxEccIsCurveSupported(private_key)

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5576,31 +5576,31 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
 #ifdef WOLFSSL_ECDSA_SET_K
 int wc_ecc_sign_set_k(const byte* k, word32 klen, ecc_key* key)
 {
-    int ret = 0;
+    int ret;
     DECLARE_CURVE_SPECS(curve, 1);
 
     if (k == NULL || klen == 0 || key == NULL) {
-        ret = BAD_FUNC_ARG;
+        return BAD_FUNC_ARG;
     }
 
-    if (ret == 0) {
-        ALLOC_CURVE_SPECS(1);
-        ret = wc_ecc_curve_load(key->dp, &curve, ECC_CURVE_FIELD_ORDER);
+    ALLOC_CURVE_SPECS(1);
+    ret = wc_ecc_curve_load(key->dp, &curve, ECC_CURVE_FIELD_ORDER);
+    if (ret != 0) {
+        FREE_CURVE_SPECS();
+        return ret;
     }
 
-    if (ret == 0) {
-        if (key->sign_k == NULL) {
-            key->sign_k = (mp_int*)XMALLOC(sizeof(mp_int), key->heap,
-                                                              DYNAMIC_TYPE_ECC);
-            if (key->sign_k == NULL) {
-                ret = MEMORY_E;
-            }
+    if (key->sign_k == NULL) {
+        key->sign_k = (mp_int*)XMALLOC(sizeof(mp_int), key->heap,
+                                                            DYNAMIC_TYPE_ECC);
+        if (key->sign_k) {
+            ret = mp_init(key->sign_k);
+        }
+        else {
+            ret = MEMORY_E;
         }
     }
 
-    if (ret == 0) {
-        ret = mp_init(key->sign_k);
-    }
     if (ret == 0) {
         ret = mp_read_unsigned_bin(key->sign_k, k, klen);
     }
@@ -5608,11 +5608,12 @@ int wc_ecc_sign_set_k(const byte* k, word32 klen, ecc_key* key)
         ret = MP_VAL;
     }
 
+    wc_ecc_curve_free(curve);
     FREE_CURVE_SPECS();
     return ret;
 }
 #endif /* WOLFSSL_ECDSA_SET_K */
-#endif /* WOLFSSL_ATECC508A && WOLFSSL_CRYPTOCELL*/
+#endif /* WOLFSSL_ATECC508A && WOLFSSL_CRYPTOCELL */
 
 #endif /* !HAVE_ECC_SIGN */
 

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -5256,7 +5256,10 @@ int mp_radix_size (mp_int *a, int radix, int *size)
 
     /* special case for binary */
     if (radix == MP_RADIX_BIN) {
-        *size = mp_count_bits (a) + (a->sign == MP_NEG ? 1 : 0) + 1;
+        *size = mp_count_bits(a);
+        if (*size == 0)
+          *size = 1;
+        *size += (a->sign == MP_NEG ? 1 : 0) + 1; /* "-" sign + null term */
         return MP_OKAY;
     }
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1779,6 +1779,8 @@ int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen, byte** out,
 int wc_hash2mgf(enum wc_HashType hType)
 {
     switch (hType) {
+    case WC_HASH_TYPE_NONE:
+        return WC_MGF1NONE;
     case WC_HASH_TYPE_SHA:
 #ifndef NO_SHA
         return WC_MGF1SHA1;
@@ -1809,7 +1811,6 @@ int wc_hash2mgf(enum wc_HashType hType)
 #else
         break;
 #endif
-    case WC_HASH_TYPE_NONE:
     case WC_HASH_TYPE_MD2:
     case WC_HASH_TYPE_MD4:
     case WC_HASH_TYPE_MD5:

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5550,8 +5550,11 @@ int mp_radix_size (mp_int *a, int radix, int *size)
 
     /* special case for binary */
     if (radix == 2) {
-        *size = fp_count_bits (a) + (a->sign == FP_NEG ? 1 : 0) + 1;
-        return FP_YES;
+        *size = fp_count_bits(a);
+        if (*size == 0)
+          *size = 1;
+        *size += (a->sign == FP_NEG ? 1 : 0) + 1; /* "-" sign + null term */
+        return FP_OKAY;
     }
 
     /* make sure the radix is in range */


### PR DESCRIPTION
* Fix for possible leaks with `wc_ecc_sign_set_k` when building with `WOLFSSL_CUSTOM_CURVES` enabled. ZD11416.
* Fix for `mp_radix_size` with radix 2 and mp_int equal to zero. Fix applies to normal and fast math only. ZD11419.
* Fix for building with `--with-intelqa` and custom curves disabled.
* Fix RSA hash warning for operations with no hash specified.