### PR TITLE
--enable-trackmemory=verbose

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2228,7 +2228,6 @@ then
         AC_MSG_ERROR(stacksize-verbose needs thread-local storage.)
     fi
     AM_CFLAGS="$AM_CFLAGS -DHAVE_STACK_SIZE_VERBOSE"
-    ENABLED_STACKSIZE=yes
 fi
 
 
@@ -2259,13 +2258,17 @@ AC_ARG_ENABLE([trackmemory],
     [ ENABLED_TRACKMEMORY=no ]
     )
 
-if test "$ENABLED_TRACKMEMORY" = "yes"
+if test "$ENABLED_TRACKMEMORY" != "no"
 then
     if test "$ENABLED_MEMORY" = "yes"
     then
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_TRACK_MEMORY"
     else
         AC_MSG_ERROR([trackmemory requires using wolfSSL memory (--enable-memory).])
+    fi
+    if test "$ENABLED_TRACKMEMORY" = "verbose"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_TRACK_MEMORY_VERBOSE"
     fi
 fi
 
@@ -5927,7 +5930,7 @@ if test "x$ENABLED_LINUXKM" = "xyes"; then
     if test "$ENABLED_SP_MATH" = "no" && test "$ENABLED_SP_MATH_ALL" = "no"; then
         AC_MSG_ERROR([--enable-sp-math or --enable-sp-math-all is required for --enable-linuxkm.])
     fi
-    if test "$ENABLED_STACKSIZE" = "yes"; then
+    if test "$ENABLED_STACKSIZE" != "no"; then
         AC_MSG_ERROR([--enable-stacksize is incompatible with --enable-linuxkm.])
     fi
     if test "$ENABLED_STACKLOG" = "yes"; then
@@ -6062,7 +6065,7 @@ AM_CONDITIONAL([BUILD_NO_LIBRARY],[test "$ENABLED_NO_LIBRARY" = "yes"])
 AM_CONDITIONAL([BUILD_RC2],[test "x$ENABLED_RC2" = "xyes"])
 
 if test "$ax_enable_debug" = "yes" ||
-        test "$ENABLED_STACKSIZE" = "yes" ||
+        test "$ENABLED_STACKSIZE" != "no" ||
         (test "$ENABLED_LEANTLS" = "no" &&
              test "$ENABLED_LEANPSK" = "no" &&
              test "$ENABLED_LOWRESOURCE" = "no")
@@ -6360,6 +6363,7 @@ echo "   * LIBZ:                       $ENABLED_LIBZ"
 echo "   * Examples:                   $ENABLED_EXAMPLES"
 echo "   * Crypt tests:                $ENABLED_CRYPT_TESTS"
 echo "   * Stack sizes in tests:       $ENABLED_STACKSIZE"
+echo "   * Heap stats in tests:        $ENABLED_TRACKMEMORY"
 echo "   * User Crypto:                $ENABLED_USER_CRYPTO"
 echo "   * Fast RSA:                   $ENABLED_FAST_RSA"
 echo "   * Single Precision:           $ENABLED_SP"

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -290,6 +290,19 @@ int wolfCrypt_Init(void)
     return ret;
 }
 
+#ifdef WOLFSSL_TRACK_MEMORY_VERBOSE
+long wolfCrypt_heap_peakAllocs_checkpoint(void) {
+    long ret = ourMemStats.peakAllocsTripOdometer;
+    ourMemStats.peakAllocsTripOdometer = ourMemStats.totalAllocs -
+        ourMemStats.totalDeallocs;
+    return ret;
+}
+long wolfCrypt_heap_peakBytes_checkpoint(void) {
+    long ret = ourMemStats.peakBytesTripOdometer;
+    ourMemStats.peakBytesTripOdometer = ourMemStats.currentBytes;
+    return ret;
+}
+#endif
 
 /* return success value is the same as wolfCrypt_Init */
 int wolfCrypt_Cleanup(void)

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2126,7 +2126,7 @@ int StackSizeHWMReset(void)
 #define STACK_SIZE_CHECKPOINT(...) ({  \
     ssize_t HWM = StackSizeHWM_OffsetCorrected();    \
     __VA_ARGS__;                                     \
-    printf("relative stack used = %ld\n", HWM);      \
+    printf("    relative stack peak usage = %ld bytes\n", HWM);  \
     StackSizeHWMReset();                             \
     })
 
@@ -2134,10 +2134,10 @@ int StackSizeHWMReset(void)
     ssize_t HWM = StackSizeHWM_OffsetCorrected();    \
     int _ret;                                        \
     __VA_ARGS__;                                     \
-    printf("relative stack used = %ld\n", HWM);      \
+    printf("    relative stack peak usage = %ld bytes\n", HWM);  \
     _ret = StackSizeHWMReset();                      \
     if ((max >= 0) && (HWM > (ssize_t)(max))) {      \
-        printf("relative stack usage at %s L%d exceeds designated max %ld.\n", __FILE__, __LINE__, (ssize_t)(max)); \
+        printf("    relative stack usage at %s L%d exceeds designated max %ld bytes.\n", __FILE__, __LINE__, (ssize_t)(max)); \
         _ret = -1;                                   \
     }                                                \
     _ret;                                            \

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -449,6 +449,11 @@ WOLFSSL_API int wc_SetMutexCb(mutex_cb* cb);
 WOLFSSL_API int wolfCrypt_Init(void);
 WOLFSSL_API int wolfCrypt_Cleanup(void);
 
+#ifdef WOLFSSL_TRACK_MEMORY_VERBOSE
+    WOLFSSL_API long wolfCrypt_heap_peakAllocs_checkpoint(void);
+    WOLFSSL_API long wolfCrypt_heap_peakBytes_checkpoint(void);
+#endif
+
 
 /* FILESYSTEM SECTION */
 /* filesystem abstraction layer, used by ssl.c */


### PR DESCRIPTION
add verbose heap instrumentation to `wolfcrypt_test()`, analogous to `--enable-stacksize=verbose`.

`--enable-stacksize=verbose --enable-trackmemory=verbose` gives a full measure of stack and heap high water marks for each subtest in `wolfcrypt_test()`.

Three arguments to `wolfcrypt_test()` (or, from the command line, `testwolfcrypt`) are now recognized:

```
[-s max_relative_stack_bytes]
[-m max_relative_heap_memory_bytes]
[-a max_relative_heap_allocs]
```

plus `-h` to list options.
