### PR TITLE
casting fix for clang-12

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -2338,7 +2338,7 @@ int sp_cond_swap_ct(sp_int * a, sp_int * b, int c, int m)
        return MP_MEM;
 #endif
 
-    t->used = (a->used ^ b->used) & mask;
+    t->used = (int)((a->used ^ b->used) & mask);
     for (i = 0; i < c; i++) {
         t->dp[i] = (a->dp[i] ^ b->dp[i]) & mask;
     }


### PR DESCRIPTION
Fix #3589
Corrects the error below generated with `clang version 12.0.0` with `./configure --enable-sp --enable-sp-math && make`.

```
wolfcrypt/src/sp_int.c:2341:35: error: implicit conversion loses integer precision: 'long' to 'int' [-Werror,-Wshorten-64-to-32]
    t->used = (a->used ^ b->used) & mask;
            ~ ~~~~~~~~~~~~~~~~~~~~^~~~~~
```