### PR TITLE
Calling wolfSSL_Rehandshake during renegotiation should not be an error

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2671,8 +2671,19 @@ static int _Rehandshake(WOLFSSL* ssl)
         ssl->options.acceptState != ACCEPT_FIRST_REPLY_DONE) {
 
         if (ssl->options.handShakeState != HANDSHAKE_DONE) {
-            WOLFSSL_MSG("Can't renegotiate until previous handshake complete");
-            return SECURE_RENEGOTIATION_E;
+            if (!ssl->options.handShakeDone) {
+                WOLFSSL_MSG("Can't renegotiate until initial "
+                            "handshake complete");
+                return SECURE_RENEGOTIATION_E;
+            }
+            else {
+                WOLFSSL_MSG("Renegotiation already started. "
+                            "Moving it forward.");
+                ret = wolfSSL_negotiate(ssl);
+                if (ret == WOLFSSL_SUCCESS)
+                    ssl->secure_rene_count++;
+                return ret;
+            }
         }
 
 #ifndef NO_FORCE_SCR_SAME_SUITE


### PR DESCRIPTION
If we call wolfSSL_Rehandshake during a renegotiation then it should not result in a SECURE_RENEGOTIATION_E. wolfSSL_Rehandshake might be called when multiple HelloRequest messages are processed or the user could call this API during renegotiation. Either way wolfSSL should not treat this as an error if renegotiation is enabled.