### PR TITLE
Create a new function, ParseCertLockOptional, that's equivalent to Parse…

### DIFF
--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4556,6 +4556,7 @@ WOLFSSL_LOCAL WC_RNG* WOLFSSL_RSA_GetRNG(WOLFSSL_RSA *rsa, WC_RNG **tmpRNG,
                                                              DecodedCert* cert);
     #endif
 
+    WOLFSSL_LOCAL Signer* GetCALockOptional(void* cm, byte* hash, int locked);
     WOLFSSL_LOCAL Signer* GetCA(void* cm, byte* hash);
     #ifndef NO_SKID
         WOLFSSL_LOCAL Signer* GetCAByName(void* cm, byte* hash);

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1061,6 +1061,8 @@ WOLFSSL_ASN_API void FreeAltNames(DNS_entry*, void*);
 #endif /* IGNORE_NAME_CONSTRAINTS */
 WOLFSSL_ASN_API void InitDecodedCert(DecodedCert*, const byte*, word32, void*);
 WOLFSSL_ASN_API void FreeDecodedCert(DecodedCert*);
+WOLFSSL_LOCAL int ParseCertLockOptional(DecodedCert*, int type, int verify,
+                                        void* cm, int locked);
 WOLFSSL_ASN_API int  ParseCert(DecodedCert*, int type, int verify, void* cm);
 
 WOLFSSL_LOCAL int DecodePolicyOID(char *o, word32 oSz,
@@ -1076,7 +1078,10 @@ WOLFSSL_LOCAL int CheckCSRSignaturePubKey(const byte* cert, word32 certSz, void*
 #endif /* WOLFSSL_CERT_REQ */
 WOLFSSL_LOCAL int AddSignature(byte* buf, int bodySz, const byte* sig, int sigSz,
                         int sigAlgoType);
-WOLFSSL_LOCAL int ParseCertRelative(DecodedCert*,int type,int verify,void* cm);
+WOLFSSL_LOCAL int ParseCertRelative(DecodedCert*, int type, int verify,
+                                    void* cm);
+WOLFSSL_LOCAL int ParseCertRelativeLockOptional(DecodedCert*, int type, int
+                                                verify, void* cm, int locked);
 WOLFSSL_LOCAL int DecodeToKey(DecodedCert*, int verify);
 WOLFSSL_LOCAL int wc_GetPubX509(DecodedCert* cert, int verify, int* badDate);
 


### PR DESCRIPTION
…Cert, but

knows if the CA table lock is held.

This resolves an issue where ParseCert was called by the function
wolfSSL_CertManagerGetCerts after that function acquired the lock in question.
Ultimately, ParseCert calls GetCA, which attempts to acquire the same lock.
Deadlock ensues. By passing a parameter down that indicates the lock is already
held by the calling function, GetCA knows whether or not it needs to acquire the
lock itself.