### PR TITLE
Add parameter check in sp_rand_prime()

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -914,7 +914,7 @@ int wc_RNG_GenerateBlock(WC_RNG* rng, byte* output, word32 sz)
 {
     int ret;
 
-    if (rng == NULL || output == NULL)
+    if (rng == NULL || output == NULL || sz == 0 )
         return BAD_FUNC_ARG;
 
 #ifdef WOLF_CRYPTO_CB

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -914,8 +914,11 @@ int wc_RNG_GenerateBlock(WC_RNG* rng, byte* output, word32 sz)
 {
     int ret;
 
-    if (rng == NULL || output == NULL || sz == 0 )
+    if (rng == NULL || output == NULL)
         return BAD_FUNC_ARG;
+
+    if (sz == 0)
+        return 0; 
 
 #ifdef WOLF_CRYPTO_CB
     if (rng->devId != INVALID_DEVID) {

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -9240,7 +9240,7 @@ int sp_div_2d(sp_int* a, int e, sp_int* r, sp_int* rem)
                 rem->used = (e + SP_WORD_SIZE - 1) >> SP_WORD_SHIFT;
                 e &= SP_WORD_MASK;
                 if (e > 0) {
-                    rem->dp[rem->used - 1] &= (1 << e) - 1;
+                    rem->dp[rem->used - 1] &= ((sp_int_digit)1 << e) - 1;
                 }
                 sp_clamp(rem);
             }
@@ -12979,9 +12979,12 @@ int sp_rand_prime(sp_int* r, int len, WC_RNG* rng, void* heap)
 
     (void)heap;
 
-    if ((r == NULL) || (rng == NULL) || len <= 0 ) {
+    if ((r == NULL) || (rng == NULL) || len < 0 ) {
         err = MP_VAL;
     }
+
+    if (len == 0)
+        return MP_OKAY;
 
     if (err == MP_OKAY) {
         /* get type */

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -12979,7 +12979,7 @@ int sp_rand_prime(sp_int* r, int len, WC_RNG* rng, void* heap)
 
     (void)heap;
 
-    if ((r == NULL) || (rng == NULL)) {
+    if ((r == NULL) || (rng == NULL) || len <= 0 ) {
         err = MP_VAL;
     }
 


### PR DESCRIPTION
This PR adds the following check:
- `len` parameter check in sp_rand_prime()
- `sz` parameter check in wc_RNG_GenerateBlock()

Otherwise,  a user could experience an unknown behavior including an endless loop when specifying a wrong len or sz. 
ZD#11436

Additionally, this PR fixes `wolfcrypt/src/sp_int.c:9243:50: runtime error: shift exponent 32 is too large for 32-bit type 'int'` reported in ZD#11440