### PR TITLE
Free mutex and fix tls13.test script

### DIFF
--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -261,7 +261,7 @@ if [ "$early_data" = "yes" ]; then
         RESULT=1
     fi
     if [ $RESULT -ne 0 ]; then
-        echo -e "\n\nIssue with TLS v1.3 Early DAta - session ticket"
+        echo -e "\n\nIssue with TLS v1.3 Early Data - session ticket"
         do_cleanup
         exit 1
     fi
@@ -280,16 +280,16 @@ if [ "$early_data" = "yes" -a "$psk" = "yes" ]; then
     RESULT=$?
     remove_ready_file
     early_data_cnt=`grep 'Early Data' $server_out_file | wc -l`
-    if [ $early_data_cnt -ne 2 ]; then
+    if [ $early_data_cnt -ne 2 -a $early_data_cnt -ne 4 ]; then
         RESULT=1
     fi
     if [ $RESULT -ne 0 ]; then
-        echo -e "\n\nIssue with TLS v1.3 Early DAta - session ticket"
+        echo -e "\n\nIssue with TLS v1.3 Early Data - session ticket"
         do_cleanup
         exit 1
     fi
 else
-    echo "Early data not available"
+    echo "Early Data not available"
 fi
 
 do_cleanup

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3663,7 +3663,9 @@ void wolfSSL_CertManagerFree(WOLFSSL_CERT_MANAGER* cm)
             FreeTrustedPeerTable(cm->tpTable, TP_TABLE_SIZE, cm->heap);
             wc_FreeMutex(&cm->tpLock);
             #endif
-
+            if (wc_FreeMutex(&cm->refMutex) != 0) {
+                WOLFSSL_MSG("Couldn't free refMutex mutex");
+            }
             XFREE(cm, cm->heap, DYNAMIC_TYPE_CERT_MANAGER);
         }
     }


### PR DESCRIPTION
This PR adds a missing wc_FreeMutex() in wolfSSL_CertManagerFree() and it also address issue #3597 
ZD#11448