### PR TITLE
Fix SP integer square

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -4798,8 +4798,8 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[k+1] = (sp_int_digit)h;
             t->used = k + 2;
 
-            sp_clamp(t);
             sp_copy(t, r);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -5002,12 +5002,13 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[5] = l;
             l = h;
             h = o;
+            o = 0;
             SP_ASM_MUL_ADD_NO(l, h, a->dp[3], b->dp[3]);
             t->dp[6] = l;
             t->dp[7] = h;
             t->used = 8;
             sp_copy(t, r);
-            sp_clamp(t);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -5125,12 +5126,13 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[9] = l;
             l = h;
             h = o;
+            o = 0;
             SP_ASM_MUL_ADD_NO(l, h, a->dp[5], b->dp[5]);
             t->dp[10] = l;
             t->dp[11] = h;
             t->used = 12;
             sp_copy(t, r);
-            sp_clamp(t);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -5298,7 +5300,7 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[15] = h;
             t->used = 16;
             sp_copy(t, r);
-            sp_clamp(t);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -5578,7 +5580,7 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[23] = h;
             t->used = 24;
             sp_copy(t, r);
-            sp_clamp(t);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -6004,7 +6006,7 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[31] = h;
             t->used = 32;
             sp_copy(t, r);
-            sp_clamp(t);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -6811,7 +6813,7 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[47] = h;
             t->used = 48;
             sp_copy(t, r);
-            sp_clamp(t);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -9693,12 +9695,13 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[5] = l;
             l = h;
             h = o;
+            o = 0;
             SP_ASM_SQR_ADD_NO(l, h, a->dp[3]);
             t->dp[6] = l;
             t->dp[7] = h;
             t->used = 8;
             sp_copy(t, r);
-            sp_clamp(t);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -9808,12 +9811,13 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[9] = l;
             l = h;
             h = o;
+            o = 0;
             SP_ASM_SQR_ADD_NO(l, h, a->dp[5]);
             t->dp[10] = l;
             t->dp[11] = h;
             t->used = 12;
             sp_copy(t, r);
-            sp_clamp(t);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -9964,7 +9968,7 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[15] = h;
             t->used = 16;
             sp_copy(t, r);
-            sp_clamp(t);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -10197,7 +10201,7 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[23] = h;
             t->used = 24;
             sp_copy(t, r);
-            sp_clamp(t);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -10530,7 +10534,7 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[31] = h;
             t->used = 32;
             sp_copy(t, r);
-            sp_clamp(t);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -11104,7 +11108,7 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[47] = h;
             t->used = 48;
             sp_copy(t, r);
-            sp_clamp(t);
+            sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK


### PR DESCRIPTION
This PR corrects an SP math issue found by Guido Vranken. ZD# 11439.

computing `x*x mod m` was producing incorrect results.  

Here's an example. 
x = "d7c134aa264366862a18302575d0fb98d116bc4b6ddebca3a5a7939f"
m = "d3537bed3acf18aba4e6d6f98f049912e6c22bffdd5ea02638da5f617cf03a1f7d5a224c88208d8000000000000000000000000000000003"

`x*x % m` now produces:
 "B5D618463FA8787829E2D8CFE7D83C231C9599B9D50A9B50A1A4859618B4F8FE4076F69A02390444E02F8047403ACD6DED2CF676E491FCC1"

Previously it was producing:

"FFFFFFFFFFFFFFFFE2829C5904D95FCC84FC01D658D3A31035D36DB9F7ABFB2A68CA26349BC4BEDEC31CD44D7A1876C4E02F8047403ACD6DED2CF676E491FCBE"

