### PR TITLE
Make WOLFSSL_AESNI compatible with clang -fsanitize=memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
      You must delete them, or cmake will refuse to work.")
 endif()
 
-project(wolfssl VERSION 4.5.0 LANGUAGES C)
+project(wolfssl VERSION 4.6.0 LANGUAGES C)
 
 # shared library versioning
 # increment if interfaces have been added, removed or changed


### PR DESCRIPTION
WolfSSL is the `WITH_SSL=bundled` starting with MariaDB Server 10.4. We would like to use the combination of AddressSanitizer and MemorySanitizer as a modern alternative to Valgrind, which is not only faster (thanks to multi-threaded execution) but also compatible with various other debugging tools, such as https://rr-project.org.

MemorySanitizer (MSAN) assumes that any memory that is initialized by code that has not been instrumented by MemorySanitizer is actually not initialized. This would cause false alarms when `WOLFSSL_AESNI` is being used, because the various encryption and decryption functions are actually initializing data in the output buffer.

AddressSanitizer ‘works’ out of the box: it assumes that no uninstrumented code is accessing freed memory or performing other things that would normally be flagged.

This pull request solves the MSAN problem by introducing `static` wrapper functions for the `WOLFSSL_AESNI` functions. The wrappers will try to ensure that all input parameters are initialized and mark the output buffer as initialized. Note: I did this by educated guessing. It seemed to work for my test with a development version of MariaDB 10.5. I hope that you can improve or revise the instrumentation as you see fit.

This pull request is not touching AddressSanitizer (ASAN) at all. It might be useful to add `assert(!__asan_region_is_poisoned(buf,size))` or similar instrumentation for memory regions that are only accessed by the hand-written assembler code and not the code in `aes.c` or its callers.

In MariaDB Server, we combine Valgrind, ASAN and MSAN instrumentation to a single header file [my_valgrind.h](https://github.com/MariaDB/server/blob/mariadb-10.5.8/include/my_valgrind.h) to provide a uniform interface to all three tools. I do not think that Valgrind instrumentation would make much sense in WolfSSL, unless there are known bogus alarms for some code (Valgrind’s V bit tracking does not always work with some bit arithmetics) or you would like to invoke `VALGRIND_MAKE_MEM_UNDEFINED()` a.k.a. `__msan_allocated_memory()` to document that some memory becomes undefined or uninitialized in some operation.