### PR TITLE
SP rand_prime: fix length check

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -12989,12 +12989,10 @@ int sp_rand_prime(sp_int* r, int len, WC_RNG* rng, void* heap)
 
     (void)heap;
 
-    if ((r == NULL) || (rng == NULL) || len < 0 ) {
+    /* Check NULL parameters and 0 is not prime so 0 bytes is invalid. */
+    if ((r == NULL) || (rng == NULL) || (len == 0)) {
         err = MP_VAL;
     }
-
-    if (len == 0)
-        return MP_OKAY;
 
     if (err == MP_OKAY) {
         /* get type */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -30786,6 +30786,9 @@ static int mp_test_param(mp_int* a, mp_int* b, mp_int* r, WC_RNG* rng)
     ret = mp_rand_prime(NULL, 32, rng, NULL);
     if (ret != MP_VAL)
         return -12789;
+    ret = mp_rand_prime(a, 0, rng, NULL);
+    if (ret != MP_VAL)
+        return -9969;
 #endif
 
 #if defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)


### PR DESCRIPTION
-ve length indicates to use a BBS prime (last two bits set)