### PR TITLE
Modify ParseCertRelative to ensure issuerKeyHash gets parsed and copi…

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9903,18 +9903,18 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
                     }
                 }
             }
-            #ifdef HAVE_OCSP
-            if (verify != NO_VERIFY && type != CA_TYPE &&
-                                                    type != TRUSTED_PEER_TYPE) {
-                if (cert->ca) {
-                    /* Need the CA's public key hash for OCSP */
-                    XMEMCPY(cert->issuerKeyHash, cert->ca->subjectKeyHash,
-                                                                    KEYID_SIZE);
-                }
-
-            }
-            #endif /* HAVE_OCSP */
         }
+
+        #ifdef HAVE_OCSP
+        if (verify != NO_VERIFY && type != CA_TYPE &&
+                                                type != TRUSTED_PEER_TYPE) {
+            if (cert->ca) {
+                /* Need the CA's public key hash for OCSP */
+                XMEMCPY(cert->issuerKeyHash, cert->ca->subjectKeyHash,
+                                                                KEYID_SIZE);
+            }
+        }
+        #endif /* HAVE_OCSP */
     }
 #if defined(WOLFSSL_RENESAS_TSIP)
     /* prepare for TSIP TLS cert verification API use */


### PR DESCRIPTION
…ed into the

decoded cert for self-signed CA certs.

The bit of code that does this copy was previously inside a conditional that's
only entered if the certificate is not self-signed. The primary purpose of this
conditional is to set the maxPathLen field. It's possible that the copying of
the issuerKeyHash was mistakenly included in the "else" block here, when it
should be outside.

See: https://www.wolfssl.com/forums/post5675.html#p5675