### PR TITLE
M1 Support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4530,6 +4530,7 @@ then
         # Have settings.h set FP_MAX_BITS higher if user didn't set directly
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_X86_64_BUILD"
     fi
+    AS_IF([test "x$host_cpu" = "xaarch64"],[AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AARCH64_BUILD"])
 fi
 
 

--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -273,7 +273,8 @@ WC_STATIC WC_INLINE void ForceZero(const void* mem, word32 len)
 {
     volatile byte* z = (volatile byte*)mem;
 
-#if defined(WOLFSSL_X86_64_BUILD) && defined(WORD64_AVAILABLE)
+#if (defined(WOLFSSL_X86_64_BUILD) || defined(WOLFSSL_AARCH64_BUILD)) \
+            && defined(WORD64_AVAILABLE)
     volatile word64* w;
     #ifndef WOLFSSL_UNALIGNED_64BIT_ACCESS
         word32 l = (sizeof(word64) - ((size_t)z & (sizeof(word64)-1))) &

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -72,7 +72,7 @@ extern "C" {
 
 
 /* detect 64-bit mode if possible */
-#if defined(__x86_64__) && !(defined (_MSC_VER) && defined(__clang__))
+#if (defined(__x86_64__) || defined(__aarch64__)) && !(defined (_MSC_VER) && defined(__clang__))
    #if !(defined(MP_64BIT) && defined(MP_16BIT) && defined(MP_8BIT))
       #define MP_64BIT
    #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1979,7 +1979,7 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 /* if desktop type system and fastmath increase default max bits */
-#ifdef WOLFSSL_X86_64_BUILD
+#if defined(WOLFSSL_X86_64_BUILD) || defined(WOLFSSL_AARCH64_BUILD)
     #if defined(USE_FAST_MATH) && !defined(FP_MAX_BITS)
         #if MIN_FFDHE_FP_MAX_BITS <= 8192
             #define FP_MAX_BITS 8192

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -70,7 +70,12 @@
       #define TFM_X86_64
    #endif
 #endif
-#if defined(TFM_X86_64)
+#if defined(__aarch64__)
+    #if !defined(TFM_AARCH_64) && !defined(TFM_NO_ASM)
+        #define TFM_AARCH_64
+    #endif
+#endif
+#if defined(TFM_X86_64) || defined(TFM_AARCH_64)
     #if !defined(FP_64BIT)
        #define FP_64BIT
     #endif


### PR DESCRIPTION
We separate out 64-bit desktop support based on the Intel check. With the advent of the new Apple chip, ARM can also be a desktop processor. Detect it like we do the Intel 64-bit, and treat it similarly with respect to fast and normal math.