### PR TITLE
Configuration: enable all, disable TLS 1.3 - turn off TLS 1.3 only op…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -628,9 +628,11 @@ if test "$ENABLED_TLS13_POST_AUTH" = "yes"
 then
     if test "x$ENABLED_TLS13" = "xno"
     then
-        AC_MSG_ERROR([cannot enable postauth without enabling tls13.])
+        AC_MSG_NOTICE([TLS 1.3 is disabled - disabling Post-handshake Authentication])
+        ENABLED_TLS13_POST_AUTH="no"
+    else
+        AM_CFLAGS="-DWOLFSSL_POST_HANDSHAKE_AUTH $AM_CFLAGS"
     fi
-  AM_CFLAGS="-DWOLFSSL_POST_HANDSHAKE_AUTH $AM_CFLAGS"
 fi
 
 
@@ -644,9 +646,11 @@ if test "$ENABLED_SEND_HRR_COOKIE" = "yes"
 then
     if test "x$ENABLED_TLS13" = "xno"
     then
-        AC_MSG_ERROR([cannot enable hrrcookie without enabling tls13.])
+        AC_MSG_NOTICE([TLS 1.3 is disabled - disabling HRR Cookie])
+        ENABLED_SEND_HRR_COOKIE="no"
+    else
+        AM_CFLAGS="-DWOLFSSL_SEND_HRR_COOKIE $AM_CFLAGS"
     fi
-  AM_CFLAGS="-DWOLFSSL_SEND_HRR_COOKIE $AM_CFLAGS"
 fi
 
 

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -408,7 +408,7 @@ openssl ciphers -tls1_3
 openssl_tls13=$?
 ./examples/client/client -v 4 2>&1 | grep -- 'Bad SSL version'
 wolfssl_not_tls13=$?
-if [ "$openssl_tls13" = "0" -a "wolfssl_not_tls13" != "0" ]; then
+if [ "$openssl_tls13" = "0" -a "$wolfssl_not_tls13" != "0" ]; then
     printf '%s\n\n' "------------- TEST CASE 8 SHOULD PASS --------------------"
     # client asks for OCSP staple but doesn't fail when none returned
     ./examples/client/client -p $port -g -v 4 -W 1

--- a/tests/api.c
+++ b/tests/api.c
@@ -6096,7 +6096,8 @@ static int test_wolfSSL_UseOCSPStaplingV2 (void)
  *----------------------------------------------------------------------------*/
 static void test_wolfSSL_mcast(void)
 {
-#if defined(WOLFSSL_DTLS) && defined(WOLFSSL_MULTICAST)
+#if defined(WOLFSSL_DTLS) && defined(WOLFSSL_MULTICAST) && \
+    (defined(WOLFSSL_TLS13) || defined(WOLFSSL_SNIFFER))
     WOLFSSL_CTX* ctx;
     WOLFSSL* ssl;
     int result;
@@ -6130,7 +6131,7 @@ static void test_wolfSSL_mcast(void)
 
     wolfSSL_free(ssl);
     wolfSSL_CTX_free(ctx);
-#endif /* WOLFSSL_DTLS && WOLFSSL_MULTICAST */
+#endif /* WOLFSSL_DTLS && WOLFSSL_MULTICAST && (WOLFSSL_TLS13 || WOLFSSL_SNIFFER) */
 }
 
 


### PR DESCRIPTION
…tions

configuration: --enable-all --disable-tls13
Post-handshake authentication and HRR cookie are enable with
'--enable-all' but disabling TLS 1.3 caused configure to fail.
Don't enable these TLS 1.3 only options when TLS 1.3 is disabled.

Also fix up tests that don't work without TLS 1.3 enabled.