### PR TITLE
Fix for ASN `SignatureCtx.verify` build option

### DIFF
--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -682,7 +682,7 @@ struct SignatureCtx {
 #if !(defined(NO_RSA) && defined(NO_DSA))
     byte* sigCpy;
 #endif
-#if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
+#if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448) || !defined(NO_DSA)
     int verify;
 #endif
     union {


### PR DESCRIPTION
Fix for build without asymmetric algorithms causing error with missing `verify` in `SignatureCtx` structure.
ZD 11365