### PR TITLE
sp_copy() pedantic error handling

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -5005,7 +5005,6 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[5] = l;
             l = h;
             h = o;
-            o = 0;
             SP_ASM_MUL_ADD_NO(l, h, a->dp[3], b->dp[3]);
             t->dp[6] = l;
             t->dp[7] = h;
@@ -5130,7 +5129,6 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[9] = l;
             l = h;
             h = o;
-            o = 0;
             SP_ASM_MUL_ADD_NO(l, h, a->dp[5], b->dp[5]);
             t->dp[10] = l;
             t->dp[11] = h;
@@ -9709,7 +9707,6 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[5] = l;
             l = h;
             h = o;
-            o = 0;
             SP_ASM_SQR_ADD_NO(l, h, a->dp[3]);
             t->dp[6] = l;
             t->dp[7] = h;
@@ -9826,7 +9823,6 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[9] = l;
             l = h;
             h = o;
-            o = 0;
             SP_ASM_SQR_ADD_NO(l, h, a->dp[5]);
             t->dp[10] = l;
             t->dp[11] = h;

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -4651,8 +4651,9 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[k+1] = h;
             t->used = k + 2;
 
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -4728,8 +4729,9 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[k+1] = h;
             t->used = k + 2;
 
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -4798,8 +4800,9 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[k+1] = (sp_int_digit)h;
             t->used = k + 2;
 
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -5007,8 +5010,9 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[6] = l;
             t->dp[7] = h;
             t->used = 8;
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -5131,8 +5135,9 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[10] = l;
             t->dp[11] = h;
             t->used = 12;
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -5299,8 +5304,9 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[14] = l;
             t->dp[15] = h;
             t->used = 16;
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -5579,8 +5585,9 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[22] = l;
             t->dp[23] = h;
             t->used = 24;
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -6005,8 +6012,9 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[30] = l;
             t->dp[31] = h;
             t->used = 32;
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -6812,8 +6820,9 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
             t->dp[46] = l;
             t->dp[47] = h;
             t->used = 48;
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -7881,7 +7890,7 @@ int sp_invmod(sp_int* a, sp_int* m, sp_int* r)
             err = MP_VAL;
         }
         else {
-            sp_copy(c, r);
+            err = sp_copy(c, r);
         }
     }
 
@@ -7956,7 +7965,7 @@ int sp_invmod_mont_ct(sp_int* a, sp_int* m, sp_int* r, sp_int_digit mp)
         sp_init(e);
 
         sp_init(&pre[0]);
-        sp_copy(a, &pre[0]);
+        err = sp_copy(a, &pre[0]);
         for (i = 1; (err == MP_OKAY) && (i < CT_INV_MOD_PRE_CNT); i++) {
             sp_init(&pre[i]);
             err = sp_sqr(&pre[i-1], &pre[i]);
@@ -7979,7 +7988,7 @@ int sp_invmod_mont_ct(sp_int* a, sp_int* m, sp_int* r, sp_int_digit mp)
                   break;
               }
         }
-        sp_copy(&pre[j-1], t);
+        err = sp_copy(&pre[j-1], t);
         for (j = 0; (err == MP_OKAY) && (i >= 0); i--) {
             int set = sp_is_bit_set(e, i);
 
@@ -8007,7 +8016,7 @@ int sp_invmod_mont_ct(sp_int* a, sp_int* m, sp_int* r, sp_int_digit mp)
             }
         }
         else {
-            sp_copy(t, r);
+            err = sp_copy(t, r);
         }
     }
 
@@ -8087,13 +8096,13 @@ static int _sp_exptmod_ex(sp_int* b, sp_int* e, int bits, sp_int* m, sp_int* r)
             }
         }
         else {
-            sp_copy(b, &t[0]);
+            err = sp_copy(b, &t[0]);
         }
     }
 
     if ((!done) && (err == MP_OKAY)) {
         /* t[0] is dummy value and t[1] is result */
-        sp_copy(&t[0], &t[1]);
+        err = sp_copy(&t[0], &t[1]);
 
         for (i = bits - 1; (err == MP_OKAY) && (i >= 0); i--) {
 #ifdef WC_NO_CACHE_RESISTANT
@@ -8132,7 +8141,7 @@ static int _sp_exptmod_ex(sp_int* b, sp_int* e, int bits, sp_int* m, sp_int* r)
         }
     }
     if ((!done) && (err == MP_OKAY)) {
-        sp_copy(&t[1], r);
+        err = sp_copy(&t[1], r);
     }
 
 #ifdef WOLFSSL_SMALL_STACK
@@ -8197,7 +8206,7 @@ static int _sp_exptmod_mont_ex(sp_int* b, sp_int* e, int bits, sp_int* m,
             }
         }
         else {
-            sp_copy(b, &t[0]);
+            err = sp_copy(b, &t[0]);
         }
     }
 
@@ -8254,7 +8263,7 @@ static int _sp_exptmod_mont_ex(sp_int* b, sp_int* e, int bits, sp_int* m,
         }
     }
     if ((!done) && (err == MP_OKAY)) {
-        sp_copy(&t[1], r);
+        err = sp_copy(&t[1], r);
     }
 
 #ifdef WOLFSSL_SMALL_STACK
@@ -8340,7 +8349,7 @@ static int _sp_exptmod_mont_ex(sp_int* b, sp_int* e, int bits, sp_int* m,
             }
         }
         else {
-            sp_copy(b, &t[1]);
+            err = sp_copy(b, &t[1]);
         }
     }
 
@@ -8429,7 +8438,7 @@ static int _sp_exptmod_mont_ex(sp_int* b, sp_int* e, int bits, sp_int* m,
         }
     }
     if ((!done) && (err == MP_OKAY)) {
-        sp_copy(tr, r);
+        err = sp_copy(tr, r);
     }
 
     if (t != NULL) {
@@ -8599,7 +8608,7 @@ static int _sp_exptmod_base_2(sp_int* e, int digits, sp_int* m, sp_int* r)
         }
     }
     if (err == MP_OKAY) {
-        sp_copy(tr, r);
+        err = sp_copy(tr, r);
     }
 
 #ifdef WOLFSSL_SMALL_STACK
@@ -8863,7 +8872,7 @@ static int _sp_exptmod_nct(sp_int* b, sp_int* e, sp_int* m, sp_int* r)
             }
         }
         else {
-            sp_copy(b, bm);
+            err = sp_copy(b, bm);
         }
     }
 
@@ -8919,7 +8928,7 @@ static int _sp_exptmod_nct(sp_int* b, sp_int* e, sp_int* m, sp_int* r)
                     n <<= winBits;
                     c -= winBits;
                 }
-                sp_copy(&t[y], tr);
+                err = sp_copy(&t[y], tr);
             }
             else {
                 /* 1 in Montgomery form. */
@@ -9027,7 +9036,7 @@ static int _sp_exptmod_nct(sp_int* b, sp_int* e, sp_int* m, sp_int* r)
         }
     }
     if ((!done) && (err == MP_OKAY)) {
-        sp_copy(tr, r);
+        err = sp_copy(tr, r);
     }
 
     if (t != NULL) {
@@ -9084,7 +9093,7 @@ static int _sp_exptmod_nct(sp_int* b, sp_int* e, sp_int* m, sp_int* r)
             }
         }
         else {
-            sp_copy(b, &t[0]);
+            err = sp_copy(b, &t[0]);
         }
     }
 
@@ -9124,7 +9133,7 @@ static int _sp_exptmod_nct(sp_int* b, sp_int* e, sp_int* m, sp_int* r)
         }
     }
     if ((!done) && (err == MP_OKAY)) {
-        sp_copy(&t[0], r);
+        err = sp_copy(&t[0], r);
     }
 
 #ifdef WOLFSSL_SMALL_STACK
@@ -9233,7 +9242,7 @@ int sp_div_2d(sp_int* a, int e, sp_int* r, sp_int* rem)
         else {
             if (rem != NULL) {
                 /* Copy a in to remainder. */
-                sp_copy(a, rem);
+                err = sp_copy(a, rem);
             }
             /* Shift a down by into result. */
             sp_rshb(a, e, r);
@@ -9318,9 +9327,11 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
     if (err == MP_OKAY) {
         /* Copy a into r as left shift function works on the number. */
         if (a != r) {
-            sp_copy(a, r);
+            err = sp_copy(a, r);
         }
+    }
 
+    if (err == MP_OKAY) {
         if (0) {
             sp_print(a, "a");
             sp_print_int(e, "n");
@@ -9430,8 +9441,9 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[k * 2] = h;
             t->used = a->used * 2;
 
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
         else if (err == MP_OKAY) {
             sp_int_digit l;
@@ -9440,8 +9452,9 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[1] = l;
             t->used = a->used * 2;
 
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -9512,8 +9525,9 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[k+1] = (sp_int_digit)h;
             t->used = k + 2;
 
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
     #ifdef WOLFSSL_SMALL_STACK
         if (t != NULL) {
@@ -9700,8 +9714,9 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[6] = l;
             t->dp[7] = h;
             t->used = 8;
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -9816,8 +9831,9 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[10] = l;
             t->dp[11] = h;
             t->used = 12;
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -9967,8 +9983,9 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[14] = l;
             t->dp[15] = h;
             t->used = 16;
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -10200,8 +10217,9 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[22] = l;
             t->dp[23] = h;
             t->used = 24;
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -10533,8 +10551,9 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[30] = l;
             t->dp[31] = h;
             t->used = 32;
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -11107,8 +11126,9 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
             t->dp[46] = l;
             t->dp[47] = h;
             t->used = 48;
-            sp_copy(t, r);
-            sp_clamp(r);
+            err = sp_copy(t, r);
+            if (err == MP_OKAY)
+                sp_clamp(r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK
@@ -12793,8 +12813,9 @@ int sp_todecimal(sp_int* a, char* str)
             err = MP_MEM;
         }
     #endif /* WOLFSSL_SMALL_STACK */
+        if (err == MP_OKAY)
+            err = sp_copy(a, t);
         if (err == MP_OKAY) {
-            sp_copy(a, t);
 
         #ifdef WOLFSSL_SP_INT_NEGATIVE
             if (a->sign == MP_NEG) {
@@ -12933,8 +12954,10 @@ int sp_radix_size(sp_int* a, int radix, int* size)
                 }
             }
         #endif /* WOLFSSL_SMALL_STACK */
+            if (err == MP_OKAY)
+                err = sp_copy(a, t);
+
             if (err == MP_OKAY) {
-                sp_copy(a, t);
 
                 for (i = 0; !sp_iszero(t); i++) {
                     sp_div_d(t, 10, t, &d);
@@ -13545,11 +13568,11 @@ int sp_gcd(sp_int* a, sp_int* b, sp_int* r)
             err = MP_VAL;
         }
         else {
-            sp_copy(b, r);
+            err = sp_copy(b, r);
         }
     }
     else if (sp_iszero(b)) {
-        sp_copy(a, r);
+        err = sp_copy(a, r);
     }
     else {
     #ifdef WOLFSSL_SMALL_STACK
@@ -13625,7 +13648,8 @@ int sp_gcd(sp_int* a, sp_int* b, sp_int* r)
                 sp_copy(v, u);
                 sp_copy(t, v);
             }
-            sp_copy(u, r);
+            if (err == MP_OKAY)
+                err = sp_copy(u, r);
         }
 
     #ifdef WOLFSSL_SMALL_STACK


### PR DESCRIPTION
@danielinux using gcc10 and `./configure --enable-sp-math-all` reports:
```
In file included from wolfcrypt/src/sp_int.c:82:
wolfcrypt/src/sp_int.c: In function 'sp_todecimal.part.0':
./wolfssl/wolfcrypt/sp_int.h:502:30: error: 't[0].used' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  502 | #define sp_iszero(a)     ((a)->used == 0)
      |    
```
@ejohnstown and I reproduced with gcc10 and gcc11.  @ejohnstown posted a bandaid for this in #3643 so either this or that should be merged but not both.

Additionally I found 4 unused-value whines from scan-build by LLVM9 and LLVM11.  I believe the fix for these may be to code that's autogenerated by scripts, so that needs to be looked at separately.
