### PR TITLE
Added support for AES GCM session ticket encryption

### DIFF
--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -165,8 +165,9 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
     CyaSSL_CTX_set_default_passwd_cb(ctx, PasswordCallBack);
 #endif
 
-#if defined(HAVE_SESSION_TICKET) && defined(HAVE_CHACHA) && \
-                                    defined(HAVE_POLY1305)
+#if defined(HAVE_SESSION_TICKET) && \
+    ((defined(HAVE_CHACHA) && defined(HAVE_POLY1305)) || \
+      defined(HAVE_AESGCM))
     if (TicketInit() != 0)
         err_sys("unable to setup Session Ticket Key context");
     wolfSSL_CTX_set_TicketEncCb(ctx, myTicketEncCb);

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1739,8 +1739,9 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         wolfSSL_CTX_SetIOSend(ctx, SimulateWantWriteIOSendCb);
     }
 
-#if defined(HAVE_SESSION_TICKET) && defined(HAVE_CHACHA) && \
-                                    defined(HAVE_POLY1305)
+#if defined(HAVE_SESSION_TICKET) && \
+    ((defined(HAVE_CHACHA) && defined(HAVE_POLY1305)) || \
+      defined(HAVE_AESGCM))
     if (TicketInit() != 0)
         err_sys_ex(catastrophic, "unable to setup Session Ticket Key context");
     wolfSSL_CTX_set_TicketEncCb(ctx, myTicketEncCb);

--- a/tests/api.c
+++ b/tests/api.c
@@ -2636,8 +2636,9 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
         ctx = wolfSSL_CTX_new(method);
     }
 
-#if defined(HAVE_SESSION_TICKET) && defined(HAVE_CHACHA) && \
-                                    defined(HAVE_POLY1305)
+#if defined(HAVE_SESSION_TICKET) && \
+    ((defined(HAVE_CHACHA) && defined(HAVE_POLY1305)) || \
+      defined(HAVE_AESGCM))
     TicketInit();
     wolfSSL_CTX_set_TicketEncCb(ctx, myTicketEncCb);
 #endif
@@ -31466,7 +31467,7 @@ static void test_wolfSSL_SESSION(void)
     /* CHACHA and POLY1305 required for myTicketEncCb */
 #if defined(WOLFSSL_TLS13) && (!defined(HAVE_SESSION_TICKET) && \
     !defined(WOLFSSL_NO_TLS12) || !(defined(HAVE_CHACHA) && \
-            defined(HAVE_POLY1305)))
+            defined(HAVE_POLY1305) && !defined(HAVE_AESGCM)))
     AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method()));
 #else
     AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -3935,6 +3935,7 @@ static WC_INLINE const char* mymktemp(char *tempfn, int len, int num)
     #define WOLFSSL_TICKET_KEY_SZ CHACHA20_POLY1305_AEAD_KEYSIZE
 #elif defined(HAVE_AESGCM)
     #include <wolfssl/wolfcrypt/aes.h>
+    #include <wolfssl/wolfcrypt/wc_encrypt.h> /* AES IV sizes in FIPS mode */
     #define WOLFSSL_TICKET_KEY_SZ AES_256_KEY_SIZE
 #endif
 

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -41,6 +41,7 @@
 #ifndef NO_DES3
     #include <wolfssl/wolfcrypt/des3.h>
 #endif
+#include <wolfssl/wolfcrypt/wc_encrypt.h>
 
 #ifdef __cplusplus
     extern "C" {
@@ -157,15 +158,6 @@ enum Pkcs7_Misc {
     MAX_RECIP_SZ          = MAX_VERSION_SZ +
                             MAX_SEQ_SZ + ASN_NAME_MAX + MAX_SN_SZ +
                             MAX_SEQ_SZ + MAX_ALGO_SZ + 1 + MAX_ENCRYPTED_KEY_SZ,
-#if (defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
-     (HAVE_FIPS_VERSION <= 2)) || (defined(HAVE_SELFTEST) && \
-     (!defined(HAVE_SELFTEST_VERSION) || (HAVE_SELFTEST_VERSION < 2)))
-    /* In the event of fips cert 3389 or CAVP selftest v1 build, these enums are
-     * not in aes.h for use with pkcs7 so enumerate it here outside the fips
-     * boundary */
-    GCM_NONCE_MID_SZ = 12, /* The usual default nonce size for AES-GCM. */
-    CCM_NONCE_MIN_SZ = 7,
-#endif
 };
 
 enum Cms_Options {

--- a/wolfssl/wolfcrypt/wc_encrypt.h
+++ b/wolfssl/wolfcrypt/wc_encrypt.h
@@ -60,6 +60,22 @@
 #endif
 
 
+#if (defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && \
+     (HAVE_FIPS_VERSION <= 2)) || (defined(HAVE_SELFTEST) && \
+     (!defined(HAVE_SELFTEST_VERSION) || (HAVE_SELFTEST_VERSION < 2)))
+    /* In FIPS cert 3389 and CAVP selftest v1 build, these enums are
+     * not in aes.h. Define them here outside the fips boundary. 
+     */
+    #ifndef GCM_NONCE_MID_SZ
+        /* The usual default nonce size for AES-GCM. */
+        #define GCM_NONCE_MID_SZ 12
+    #endif
+    #ifndef CCM_NONCE_MIN_SZ
+        #define CCM_NONCE_MIN_SZ 7
+    #endif
+#endif
+
+
 #if !defined(NO_AES) && defined(HAVE_AES_CBC)
 WOLFSSL_API int wc_AesCbcEncryptWithKey(byte* out, const byte* in, word32 inSz,
                                         const byte* key, word32 keySz,


### PR DESCRIPTION
 If ChaCha/Poly is disabled it will use AES GCM (`./configure --enable-session-ticket --disable-chacha && make check`).
@SparkiDev is the author of this AES GCM code. Thanks Sean!
ZD 11511.