### PR TITLE
TLS 1.3: don't group and wait on send session ticket

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -6696,8 +6696,10 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
 
     ssl->buffers.outputBuffer.length += sendSz;
 
-    if (!ssl->options.groupMessages)
-        ret = SendBuffered(ssl);
+    /* Always send as this is either directly after server's Finished or only
+     * message after client's Finished.
+     */
+    ret = SendBuffered(ssl);
 
     WOLFSSL_LEAVE("SendTls13NewSessionTicket", 0);
     WOLFSSL_END(WC_FUNC_NEW_SESSION_TICKET_SEND);


### PR DESCRIPTION
The state machine goes on and frees the handshake resources which frees
the digest for the client Finished message.

ZD 11356