### PR TITLE
DTLS secure renegotiation fixes

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7328,7 +7328,7 @@ int VerifyForDtlsMsgPoolSend(WOLFSSL* ssl, byte type, word32 fragOffset)
              ((ssl->options.verifyPeer) && (type == certificate)) ||
              ((!ssl->options.verifyPeer) && (type == client_key_exchange)))) ||
             ((ssl->options.side == WOLFSSL_CLIENT_END) &&
-             (type == server_hello))));
+             (type == hello_request || type == server_hello))));
 }
 
 

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -354,6 +354,7 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     else if(IsSCR(ssl)) {
         if (ssl->dtls_start_timeout &&
                 LowResTimer() - ssl->dtls_start_timeout > (word32)dtls_timeout) {
+            ssl->dtls_start_timeout = 0;
             return WOLFSSL_CBIO_ERR_TIMEOUT;
         }
         else if (!ssl->dtls_start_timeout) {


### PR DESCRIPTION
- clear TX queue only on APP DATA received outside of a renegotiation
- client should re-transmit on duplicate HelloRequest
- reset dtls_start_timeout on a timeout