### PR TITLE
TLS Session Ticket: Option to disable for TLS 1.2 and below

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -669,31 +669,42 @@ static const char* server_usage_msg[][56] = {
 #ifdef HAVE_CURVE25519
         "-t          Pre-generate Key share using Curve25519 only\n",   /* 43 */
 #endif
+#endif /* WOLFSSL_TLS13 */
 #ifdef HAVE_SESSION_TICKET
+#if defined(WOLFSSL_NO_TLS12) && defined(NO_OLD_TLS)
         "-T          Do not generate session ticket\n",                 /* 44 */
+#else
+        "-T [aon]    Do not generate session ticket\n",                 /* 44 */
+        "            No option affects TLS 1.3 only, 'a' affects all"
+            " protocol versions,\n",                                    /* 45 */
+        "            'o' affects TLS 1.2 and below only\n",             /* 46 */
+        "            'n' affects TLS 1.3 only\n",                       /* 47 */
 #endif
-        "-F          Send alert if no mutual authentication\n",         /* 45 */
+#endif
+#ifdef WOLFSSL_TLS13
+        "-F          Send alert if no mutual authentication\n",         /* 48 */
 #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
-        "-Q          Request certificate from client post-handshake\n", /* 46 */
+        "-Q          Request certificate from client post-handshake\n", /* 49 */
 #endif
 #ifdef WOLFSSL_SEND_HRR_COOKIE
-        "-J          Server sends Cookie Extension containing state\n", /* 47 */
+        "-J          Server sends Cookie Extension containing state\n", /* 50 */
 #endif
 #endif /* WOLFSSL_TLS13 */
 #ifdef WOLFSSL_EARLY_DATA
-        "-0          Early data read from client (0-RTT handshake)\n",  /* 48 */
+        "-0          Early data read from client (0-RTT handshake)\n",  /* 51 */
 #endif
 #ifdef WOLFSSL_MULTICAST
-        "-3 <grpid>  Multicast, grpid < 256\n",                         /* 49 */
+        "-3 <grpid>  Multicast, grpid < 256\n",                         /* 52 */
 #endif
         "-1 <num>    Display a result by specified language."
-                             "\n            0: English, 1: Japanese\n", /* 50 */
+                             "\n            0: English, 1: Japanese\n", /* 53 */
 #ifdef HAVE_TRUSTED_CA
-        "-5          Use Trusted CA Key Indication\n",                  /* 53 */
+        "-5          Use Trusted CA Key Indication\n",                  /* 54 */
 #endif
         "-6          Simulate WANT_WRITE errors on every other IO send\n",
+                                                                        /* 55 */
 #ifdef HAVE_CURVE448
-        "-8          Pre-generate Key share using Curve448 only\n",     /* 55 */
+        "-8          Pre-generate Key share using Curve448 only\n",     /* 56 */
 #endif
         NULL,
     },
@@ -791,32 +802,42 @@ static const char* server_usage_msg[][56] = {
 #ifdef HAVE_CURVE25519
         "-t          Curve25519のみを使用して鍵共有を事前生成する\n",   /* 43 */
 #endif
-#ifdef HAVE_SESSION_TICKET
-        "-T         セッションチケットを生成しない\n",                  /* 44 */
+#endif /* WOLFSSL_TLS13 */
+#if defined(WOLFSSL_NO_TLS12) && defined(NO_OLD_TLS)
+        "-T          セッションチケットを生成しない\n",                 /* 44 */
+#else
+        "-T [aon]    セッションチケットを生成しない\n",                 /* 44 */
+        "            No option affects TLS 1.3 only, 'a' affects all"
+            " protocol versions,\n",                                    /* 45 */
+        "            'o' affects TLS 1.2 and below only\n",             /* 46 */
+        "            'n' affects TLS 1.3 only\n",                       /* 47 */
 #endif
-        "-F          Send alert if no mutual authentication\n",         /* 45 */
+#ifdef WOLFSSL_TLS13
+        "-F          Send alert if no mutual authentication\n",         /* 48 */
 #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
         "-Q          クライアントのポストハンドシェイクから"
-                                              "証明書を要求する\n",     /* 46 */
+                                              "証明書を要求する\n",     /* 49 */
 #endif
 #ifdef WOLFSSL_SEND_HRR_COOKIE
-        "-J          サーバーの状態を含むTLS Cookie 拡張を送信する\n",  /* 47 */
+        "-J          サーバーの状態を含むTLS Cookie 拡張を送信する\n",  /* 50 */
 #endif
 #endif /* WOLFSSL_TLS13 */
 #ifdef WOLFSSL_EARLY_DATA
         "-0          クライアントからの Early Data 読み取り"
-                                      "（0-RTTハンドシェイク）\n",      /* 48 */
+                                      "（0-RTTハンドシェイク）\n",      /* 51 */
 #endif
 #ifdef WOLFSSL_MULTICAST
-        "-3 <grpid>  マルチキャスト, grpid < 256\n",                    /* 49 */
+        "-3 <grpid>  マルチキャスト, grpid < 256\n",                    /* 52 */
 #endif
         "-1 <num>    指定された言語で結果を表示します。"
-                                 "\n            0: 英語、 1: 日本語\n", /* 50 */
+                                 "\n            0: 英語、 1: 日本語\n", /* 53 */
 #ifdef HAVE_TRUSTED_CA
-        "-5          信頼できる認証局の鍵表示を使用する\n",             /* 53 */
+        "-5          信頼できる認証局の鍵表示を使用する\n",             /* 54 */
 #endif
+        "-6          Simulate WANT_WRITE errors on every other IO send\n",
+                                                                        /* 55 */
 #ifdef HAVE_CURVE448
-        "-8          Pre-generate Key share using Curve448 only\n",     /* 55 */
+        "-8          Pre-generate Key share using Curve448 only\n",     /* 56 */
 #endif
         NULL,
     },
@@ -910,9 +931,16 @@ static void Usage(void)
 #ifdef HAVE_CURVE25519
     printf("%s", msg[++msgId]);     /* -t */
 #endif
+#endif /* WOLFSSL_TLS13 */
 #ifdef HAVE_SESSION_TICKET
     printf("%s", msg[++msgId]);     /* -T */
+    #if !defined(WOLFSSL_NO_TLS12) || !defined(NO_OLD_TLS)
+    printf("%s", msg[++msgId]);     /* -T */
+    printf("%s", msg[++msgId]);     /* -T */
+    printf("%s", msg[++msgId]);     /* -T */
+    #endif
 #endif
+#ifdef WOLFSSL_TLS13
     printf("%s", msg[++msgId]);     /* -F */
 #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
     printf("%s", msg[++msgId]);     /* -Q */
@@ -1081,7 +1109,14 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 #endif
 #ifdef WOLFSSL_TLS13
     int onlyKeyShare = 0;
-    int noTicket = 0;
+#endif
+#if defined(HAVE_SESSION_TICKET)
+#ifdef WOLFSSL_TLS13
+    int noTicketTls13 = 0;
+#endif
+#if !defined(WOLFSSL_NO_TLS12) || !defined(NO_OLD_TLS)
+    int noTicketTls12 = 0;
+#endif
 #endif
     int useX25519 = 0;
     int useX448 = 0;
@@ -1152,10 +1187,10 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     /* Reinitialize the global myVerifyAction. */
     myVerifyAction = VERIFY_OVERRIDE_ERROR;
 
-    /* Not Used: h, z, F, T, V, W, X */
+    /* Not Used: h, z, W, X, 7, 9 */
     while ((ch = mygetopt(argc, argv, "?:"
                 "abc:defgijk:l:mnop:q:rstuv:wxy"
-                "A:B:C:D:E:FGH:IJKL:MNO:PQR:S:TUVYZ:"
+                "A:B:C:D:E:FGH:IJKL:MNO:PQR:S:T;UVYZ:"
                 "01:23:4:568"
 		        "@#")) != -1) {
         switch (ch) {
@@ -1464,8 +1499,32 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 break;
 
             case 'T' :
-                #if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)
-                    noTicket = 1;
+                #if defined(HAVE_SESSION_TICKET)
+                    if (XSTRLEN(myoptarg) == 0) {
+                    #if defined(WOLFSSL_TLS13)
+                        noTicketTls13 = 1;
+                    #endif
+                    }
+                #if !defined(WOLFSSL_NO_TLS12) || !defined(NO_OLD_TLS)
+                    else if (XSTRNCMP(myoptarg, "a", 2) == 0) {
+                        noTicketTls12 = 1;
+                    #if defined(WOLFSSL_TLS13)
+                        noTicketTls13 = 1;
+                    #endif
+                    }
+                    else if (XSTRNCMP(myoptarg, "o", 2) == 0) {
+                        noTicketTls12 = 1;
+                    }
+                    else if (XSTRNCMP(myoptarg, "n", 2) == 0) {
+                    #if defined(WOLFSSL_TLS13)
+                        noTicketTls13 = 1;
+                    #endif
+                    }
+                #endif
+                    else {
+                        Usage();
+                        XEXIT_T(MY_EX_USAGE);
+                    }
                 #endif
                 break;
 
@@ -2005,8 +2064,16 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 #ifdef WOLFSSL_TLS13
     if (noPskDheKe)
         wolfSSL_CTX_no_dhe_psk(ctx);
-    if (noTicket)
+#endif
+#ifdef HAVE_SESSION_TICKET
+#ifdef WOLFSSL_TLS13
+    if (noTicketTls13)
         wolfSSL_CTX_no_ticket_TLSv13(ctx);
+#endif
+#if !defined(WOLFSSL_NO_TLS12) || !defined(NO_OLD_TLS)
+    if (noTicketTls12)
+        wolfSSL_CTX_NoTicketTLSv12(ctx);
+#endif
 #endif
 
     while (1) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -904,6 +904,7 @@ static int dtls_export_new(WOLFSSL* ssl, byte* exp, word32 len, byte ver)
 #ifdef HAVE_SESSION_TICKET
     exp[idx++] = options->createTicket;
     exp[idx++] = options->useTicket;
+    exp[idx++] = options->noTicketTls12;
 #ifdef WOLFSSL_TLS13
     if (ver > DTLS_EXPORT_VERSION_3) {
         exp[idx++] = options->noTicketTls13;
@@ -1069,6 +1070,7 @@ static int dtls_export_load(WOLFSSL* ssl, const byte* exp, word32 len, byte ver)
 #ifdef HAVE_SESSION_TICKET
     options->createTicket  = exp[idx++]; /* Server to create new Ticket */
     options->useTicket     = exp[idx++]; /* Use Ticket not session cache */
+    options->noTicketTls12 = exp[idx++]; /* Server won't create new Ticket */
 #ifdef WOLFSSL_TLS13
     if (ver > DTLS_EXPORT_VERSION_3) {
         options->noTicketTls13 = exp[idx++];/* Server won't create new Ticket */
@@ -5946,6 +5948,7 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 #endif
 
 #ifdef HAVE_SESSION_TICKET
+    ssl->options.noTicketTls12 = ctx->noTicketTls12;
     ssl->session.ticket = ssl->session.staticTicket;
 #endif
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -5068,6 +5068,8 @@ static int TLSX_SessionTicket_Parse(WOLFSSL* ssl, byte* input, word16 length,
             WOLFSSL_MSG("Process client ticket rejected, TLS 1.3 no support");
             ssl->options.rejectTicket = 1;
             ret = 0;  /* not fatal */
+        } else if (ssl->options.noTicketTls12) {
+            /* ignore ticket request */
         } else if (length == 0) {
             /* blank ticket */
             ret = TLSX_UseSessionTicket(&ssl->extensions, NULL, ssl->heap);

--- a/tests/test-tls13.conf
+++ b/tests/test-tls13.conf
@@ -186,6 +186,15 @@
 -l TLS13-AES128-GCM-SHA256
 -I
 
+# server TLSv1.3 No session ticket
+-v 4
+-l TLS13-AES128-GCM-SHA256
+-T
+
+# client TLSv1.3  No session ticket
+-v 4
+-l TLS13-AES128-GCM-SHA256
+
 # server TLSv1.3 Post-Handshake Authentication
 -v 4
 -l TLS13-AES128-GCM-SHA256

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -2266,3 +2266,12 @@
 
 # client with bidirectional shutdown
 -w
+
+# server TLSv1.2 No Session ticket
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+-T o
+
+# client TLSv1.2 No Session ticket
+-v 3
+-l ECDHE-RSA-AES128-SHA256

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2719,8 +2719,11 @@ struct WOLFSSL_CTX {
     byte        minDowngrade;     /* minimum downgrade version */
     byte        haveEMS:1;        /* have extended master secret extension */
     byte        useClientOrder:1; /* Use client's cipher preference order */
+#if defined(HAVE_SESSION_TICKET)
+    byte        noTicketTls12:1;  /* TLS 1.2 server won't send ticket */
+#endif
 #ifdef WOLFSSL_TLS13
-    byte        noTicketTls13:1;  /* Server won't create new Ticket */
+    byte        noTicketTls13:1;  /* TLS 1.3 Server won't create new Ticket */
     byte        noPskDheKe:1;     /* Don't use (EC)DHE with PSK */
 #endif
     byte        mutualAuth:1;     /* Mutual authentication required */
@@ -3476,6 +3479,7 @@ typedef struct Options {
     word16            createTicket:1;     /* Server to create new Ticket */
     word16            useTicket:1;        /* Use Ticket not session cache */
     word16            rejectTicket:1;     /* Callback rejected ticket */
+    word16            noTicketTls12:1;    /* TLS 1.2 server won't send ticket */
 #ifdef WOLFSSL_TLS13
     word16            noTicketTls13:1;    /* Server won't create new Ticket */
 #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3201,6 +3201,9 @@ enum TicketEncRet {
 
 #ifndef NO_WOLFSSL_SERVER
 
+WOLFSSL_API int wolfSSL_CTX_NoTicketTLSv12(WOLFSSL_CTX* ctx);
+WOLFSSL_API int wolfSSL_NoTicketTLSv12(WOLFSSL* ssl);
+
 typedef int (*SessionTicketEncCb)(WOLFSSL*,
                                  unsigned char key_name[WOLFSSL_TICKET_NAME_SZ],
                                  unsigned char iv[WOLFSSL_TICKET_IV_SZ],


### PR DESCRIPTION
Customer may want session ticket supported with TLS 1.3 but not TLS 1.2
and below.