### PR TITLE
SP int: Rework allocation of temporaries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5099,6 +5099,10 @@ do
     AM_CFLAGS="$AM_CFLAGS -DSP_INT_BITS=$v"
     ENABLED_SP_MATH_ALL="yes"
     ;;
+  nomalloc)
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_NO_MALLOC"
+    ENABLED_SP_MATH_ALL="yes"
+    ;;
   *)
     AC_MSG_ERROR([Support SP int bit sizes: 256, 384, 521, 1024, 2048, 3072, 4096. $ENABLED_SP_MATH_ALL not supported])
     ;;

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -629,23 +629,12 @@ typedef struct sp_ecc_ctx {
 #define CheckFastMathSettings()   (SP_WORD_SIZE == CheckRunTimeFastMath())
 
 
-#ifdef WOLFSSL_SP_INT_NEGATIVE
-    #ifdef HAVE_WOLF_BIGINT
-        #define SP_INT_EXTRA_OVERHEAD    sizeof(int) + sizeof(struct WC_BIGINT)
-    #else
-        #define SP_INT_EXTRA_OVERHEAD    sizeof(int)
-    #endif
-#elif defined(HAVE_WOLF_BIGINT)
-    #define SP_INT_EXTRA_OVERHEAD    sizeof(struct WC_BIGINT)
-#else
-    #define SP_INT_EXTRA_OVERHEAD    0
-#endif
-#define WOLFSSL_SP_INT_OVERHEAD \
-    (sizeof(int) + sizeof(int) + SP_INT_EXTRA_OVERHEAD)
-
+/* The number of bytes to a sp_int with 'cnt' digits. */
 #define MP_INT_SIZEOF(cnt) \
-    (WOLFSSL_SP_INT_OVERHEAD + ((cnt) * SP_WORD_SIZEOF))
-
+    (sizeof(sp_int) - (SP_INT_DIGITS - (cnt)) * sizeof(sp_int_digit))
+/* The address of the next sp_int after one with 'cnt' digits. */
+#define MP_INT_NEXT(t, cnt) \
+        (sp_int*)(((byte*)(t)) + MP_INT_SIZEOF(cnt))
 
 /**
  * A reuslt of NO.


### PR DESCRIPTION
Allocate only as much is as needed.
Use macros to simplify code.
Don't use an sp_int if you can use an array of 'sp_int_digit's.