### PR TITLE
Show packaging status across Linux distributions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<a href="https://repology.org/project/wolfssl/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/wolfssl.svg" alt="Packaging status" align="right">
+</a>
+
 *** Description ***
 
 The wolfSSL embedded SSL library (formerly CyaSSL) is a lightweight SSL/TLS


### PR DESCRIPTION
Repology offers badges for `wolfSSL`'s packaging status across all known
Linux distributions. [1] In Markdown documents, the HTML version with
a right-hand alignment uses up less space. It is added here.

The badge itself provides a hyperlink to more information [2]
including repositories in which `wolfSSL` is not yet represented.

[1] https://repology.org/project/wolfssl/badges
[2] https://repology.org/project/wolfssl/versions