### PR TITLE
Make sure array is initialized to 0s in wolfSSL_EVP_get_digestbyname.

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3288,6 +3288,8 @@ const WOLFSSL_EVP_MD *wolfSSL_EVP_get_digestbyname(const char *name)
     const struct alias  *al;
     const struct s_ent *ent;
 
+    XMEMSET(nameUpper, 0, sizeof(nameUpper));
+
     for (i = 0; i < sizeof(nameUpper) && name[i] != '\0'; i++) {
         nameUpper[i] = (char)XTOUPPER(name[i]);
     }

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -748,9 +748,6 @@ typedef WOLFSSL_EVP_CIPHER_CTX EVP_CIPHER_CTX;
 #define EVP_DigestVerifyFinal  wolfSSL_EVP_DigestVerifyFinal
 #define EVP_BytesToKey         wolfSSL_EVP_BytesToKey
 
-#define EVP_get_cipherbyname wolfSSL_EVP_get_cipherbyname
-#define EVP_get_digestbyname wolfSSL_EVP_get_digestbyname
-
 #define EVP_CIPHER_CTX_init           wolfSSL_EVP_CIPHER_CTX_init
 #define EVP_CIPHER_CTX_cleanup        wolfSSL_EVP_CIPHER_CTX_cleanup
 #define EVP_CIPHER_CTX_iv_length      wolfSSL_EVP_CIPHER_CTX_iv_length


### PR DESCRIPTION
Fixes issue brought to light by ZD 11583.