### PR TITLE
handle size greater than RNG_MAX_BLOCK_LEN

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -30973,6 +30973,7 @@ int wolfSSL_RAND_bytes(unsigned char* buf, int num)
     WC_RNG  tmpRNG[1];
 #endif
     int used_global = 0;
+    int blockCount = 0;
 
     WOLFSSL_ENTER("wolfSSL_RAND_bytes");
 
@@ -30996,7 +30997,22 @@ int wolfSSL_RAND_bytes(unsigned char* buf, int num)
         initTmpRng = 1;
     }
     if (rng) {
-        if (wc_RNG_GenerateBlock(rng, buf, num) != 0)
+        /* handles size grater than RNG_MAX_BLOCK_LEN */
+        blockCount = num / RNG_MAX_BLOCK_LEN;
+        
+        while(blockCount--) {
+            if((ret = wc_RNG_GenerateBlock(rng, buf, RNG_MAX_BLOCK_LEN) != 0)){
+                WOLFSSL_MSG("Bad wc_RNG_GenerateBlock");
+                break;
+            }
+            num -= RNG_MAX_BLOCK_LEN;
+            buf += RNG_MAX_BLOCK_LEN;
+        }
+        
+        if (ret == 0 && num)
+            ret = wc_RNG_GenerateBlock(rng, buf, num);
+        
+        if (ret != 0)
             WOLFSSL_MSG("Bad wc_RNG_GenerateBlock");
         else
             ret = WOLFSSL_SUCCESS;

--- a/tests/api.c
+++ b/tests/api.c
@@ -29922,6 +29922,35 @@ static void test_wolfSSL_BUF(void)
     #endif /* OPENSSL_EXTRA */
 }
 
+static void test_wolfSSL_RAND_bytes(void)
+{
+    #if defined(OPENSSL_EXTRA)
+    const int size1 = RNG_MAX_BLOCK_LEN;        /* in bytes */
+    const int size2 = RNG_MAX_BLOCK_LEN + 1;    /* in bytes */ 
+    const int size3 = RNG_MAX_BLOCK_LEN * 2;    /* in bytes */
+    const int size4 = RNG_MAX_BLOCK_LEN * 4;    /* in bytes */
+    int  max_bufsize;
+    byte *buffer;
+     
+    printf(testingFmt, "test_wolfSSL_RAND_bytes()");
+
+    max_bufsize = size4;
+    
+    buffer = (byte*)XMALLOC(max_bufsize * sizeof(byte), NULL, 
+                                                     DYNAMIC_TYPE_TMP_BUFFER);
+    AssertNotNull(buffer);
+    XMEMSET(buffer, 0, max_bufsize);
+    AssertIntEQ(wolfSSL_RAND_bytes(buffer, size1), 1);
+    AssertIntEQ(wolfSSL_RAND_bytes(buffer, size2), 1);
+    AssertIntEQ(wolfSSL_RAND_bytes(buffer, size3), 1);
+    AssertIntEQ(wolfSSL_RAND_bytes(buffer, size4), 1);
+    
+    XFREE(buffer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+
+    printf(resultFmt, passed);
+
+    #endif
+}
 
 static void test_wolfSSL_pseudo_rand(void)
 {
@@ -40129,6 +40158,7 @@ void ApiTest(void)
     test_wolfSSL_CTX_add_client_CA();
     test_wolfSSL_CTX_set_srp_username();
     test_wolfSSL_CTX_set_srp_password();
+    test_wolfSSL_RAND_bytes();
     test_wolfSSL_pseudo_rand();
     test_wolfSSL_PKCS8_Compat();
     test_wolfSSL_PKCS8_d2i();


### PR DESCRIPTION
allows size greater than RNG_MAX_BLOCK_LEN on wolfSSL_RAND_bytes()

Zendesk#11606