### PR TITLE
OE10 and OE13 ACVP updates for armv8 PAA

### DIFF
--- a/src/include.am
+++ b/src/include.am
@@ -247,8 +247,10 @@ endif
 if BUILD_SP_ARM_THUMB
 src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_armthumb.c
 endif
+if !BUILD_FIPS_V2
 if BUILD_SP_ARM64
 src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_arm64.c
+endif
 endif
 if BUILD_SP_INT
 src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_int.c


### PR DESCRIPTION
Supports OE10_ACVP and OE13_ACVP with wolfCrypt v4.5.4 FIPS module. Assembly is in-line in the FIPS sources so excludes the original source file.