### PR TITLE
Fix for PKCS11 not properly exporting the public key due to a missing key type field

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7178,7 +7178,7 @@ int wc_ecc_export_x963(ecc_key* key, byte* out, word32* outLen)
    if (key->type == ECC_PRIVATEKEY_ONLY)
        return ECC_PRIVATEONLY_E;
 
-   if (key->type == ECC_STATE_NONE ||
+   if (key->type == 0 ||
        wc_ecc_is_valid_idx(key->idx) == 0 ||
        key->dp == NULL) {
        return ECC_BAD_ARG_E;
@@ -11297,7 +11297,7 @@ static int wc_ecc_export_x963_compressed(ecc_key* key, byte* out, word32* outLen
    if (key->type == ECC_PRIVATEKEY_ONLY)
        return ECC_PRIVATEONLY_E;
 
-   if (key->type == ECC_STATE_NONE ||
+   if (key->type == 0 ||
        wc_ecc_is_valid_idx(key->idx) == 0 ||
        key->dp == NULL) {
        return ECC_BAD_ARG_E;

--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -935,6 +935,8 @@ static int Pkcs11CreateEccPublicKey(CK_OBJECT_HANDLE* publicKey,
         if (len >= ASN_LONG_LENGTH)
             ecPoint[i++] = ASN_LONG_LENGTH | 1;
         ecPoint[i++] = len;
+        if (public_key->type == 0)
+            public_key->type = ECC_PUBLICKEY;
         ret = wc_ecc_export_x963(public_key, ecPoint + i, &len);
     }
     if (ret == 0) {
@@ -1936,6 +1938,8 @@ static int Pkcs11FindEccKey(CK_OBJECT_HANDLE* key, CK_OBJECT_CLASS keyClass,
         if (len >= ASN_LONG_LENGTH)
             ecPoint[i++] = (ASN_LONG_LENGTH | 1);
         ecPoint[i++] = len;
+        if (public_key->type == 0)
+            public_key->type = ECC_PUBLICKEY;
         ret = wc_ecc_export_x963(eccKey, ecPoint + i, &len);
     }
     if (ret == 0 && keyClass == CKO_PUBLIC_KEY) {


### PR DESCRIPTION
This broke due to changes in PR #3687. 
Also resolved mismatch of enum types for the key type check.
ZD 11624