### PR TITLE
Fix AESNI enabled aesgcm cann't decrypt block that big than 256M in V…

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -4431,21 +4431,21 @@ void AES_GCM_encrypt_avx2(const unsigned char *in, unsigned char *out,
 #ifdef HAVE_AES_DECRYPT
 void AES_GCM_decrypt(const unsigned char *in, unsigned char *out,
                      const unsigned char* addt, const unsigned char* ivec,
-                     const unsigned char *tag, int nbytes, int abytes,
+                     const unsigned char *tag, unsigned int nbytes, int abytes,
                      int ibytes, int tbytes, const unsigned char* key, int nr,
                      int* res)
                      XASM_LINK("AES_GCM_decrypt");
 #ifdef HAVE_INTEL_AVX1
 void AES_GCM_decrypt_avx1(const unsigned char *in, unsigned char *out,
                           const unsigned char* addt, const unsigned char* ivec,
-                          const unsigned char *tag, int nbytes, int abytes,
+                          const unsigned char *tag, unsigned int nbytes, int abytes,
                           int ibytes, int tbytes, const unsigned char* key,
                           int nr, int* res)
                           XASM_LINK("AES_GCM_decrypt_avx1");
 #ifdef HAVE_INTEL_AVX2
 void AES_GCM_decrypt_avx2(const unsigned char *in, unsigned char *out,
                           const unsigned char* addt, const unsigned char* ivec,
-                          const unsigned char *tag, int nbytes, int abytes,
+                          const unsigned char *tag, unsigned int nbytes, int abytes,
                           int ibytes, int tbytes, const unsigned char* key,
                           int nr, int* res)
                           XASM_LINK("AES_GCM_decrypt_avx2");
@@ -5222,7 +5222,7 @@ static void AES_GCM_encrypt(const unsigned char *in,
         X =_mm_xor_si128(X, tmp1);
         X = gfmul_shifted(X, H);
     }
-    tmp1 = _mm_insert_epi64(tmp1, nbytes*8, 0);
+    tmp1 = _mm_insert_epi64(tmp1, ((__int64)nbytes)*8, 0);
     tmp1 = _mm_insert_epi64(tmp1, abytes*8, 1);
     X = _mm_xor_si128(X, tmp1);
     X = gfmul_shifted(X, H);
@@ -5239,7 +5239,7 @@ static void AES_GCM_decrypt(const unsigned char *in,
                            unsigned char *out,
                            const unsigned char* addt,
                            const unsigned char* ivec,
-                           const unsigned char *tag, int nbytes, int abytes,
+                           const unsigned char *tag, unsigned int nbytes, int abytes,
                            int ibytes, word32 tbytes, const unsigned char* key,
                            int nr, int* res)
 {
@@ -5547,7 +5547,7 @@ static void AES_GCM_decrypt(const unsigned char *in,
         X = gfmul_shifted(XV, H);
     }
 
-    tmp1 = _mm_insert_epi64(tmp1, nbytes*8, 0);
+    tmp1 = _mm_insert_epi64(tmp1, ((__int64)nbytes)*8, 0);
     tmp1 = _mm_insert_epi64(tmp1, abytes*8, 1);
     /* 128 x 128 Carryless Multiply */
     X = _mm_xor_si128(X, tmp1);


### PR DESCRIPTION
AESNI enabled aesgcm cann't decrypt block that big than 256M in Visual Studio 2017(Win10)

256M*8 = 2G, which is the max +1 of int