### PR TITLE
Fix bad math errors in more cases

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -92,7 +92,7 @@ decouple library dependencies with standard string, memory and so on.
 
     /* try to set SIZEOF_LONG or SIZEOF_LONG_LONG if user didn't */
     #if defined(_MSC_VER) || defined(HAVE_LIMITS_H)
-        #if !defined(SIZEOF_LONG_LONG) && !defined(SIZEOF_LONG)
+        #if !defined(SIZEOF_LONG_LONG) || !defined(SIZEOF_LONG)
             #include <limits.h>
             #if defined(ULONG_MAX) && (ULONG_MAX == 0xffffffffUL)
                 #define SIZEOF_LONG 4


### PR DESCRIPTION
For whatever reason, sometimes only one of the sizeofs isn't defined.

Context: https://github.com/wolfSSL/wolfssl/pull/3283