### PR TITLE
DH SP math: return key size error with DH Agree

### DIFF
--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -1998,6 +1998,8 @@ static int wc_DhAgree_Sync(DhKey* key, byte* agree, word32* agreeSz,
     mp_clear(z);
     mp_clear(y);
     mp_forcezero(x);
+#else
+    ret = WC_KEY_SIZE_E;
 #endif
 
 #ifdef WOLFSSL_SMALL_STACK


### PR DESCRIPTION
SP math requires SP to support DH operations.
When SP doesn't support bit size, WC_KEY_SIZE_E must be returned.