### PR TITLE
wolfSSL_X509_get_serialNumber(): Don't leak memory when called more t…

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26431,6 +26431,9 @@ WOLFSSL_ASN1_INTEGER* wolfSSL_X509_get_serialNumber(WOLFSSL_X509* x509)
 
     WOLFSSL_ENTER("wolfSSL_X509_get_serialNumber");
 
+    if (x509->serialNumber != NULL)
+       return x509->serialNumber;
+
     a = wolfSSL_ASN1_INTEGER_new();
     if (a == NULL)
         return NULL;


### PR DESCRIPTION
…han once

Prevents leaks like:
    ==31982== Thread 1:
    ==31982== 144 bytes in 3 blocks are definitely lost in loss record 23 of 30
    ==31982==    at 0x4C26A44: malloc (in /usr/local/lib/valgrind/vgpreload_memcheck-amd64-freebsd.so)
    ==31982==    by 0x5762350: wolfSSL_Malloc (memory.c:140)
    ==31982==    by 0x57F9221: wolfSSL_ASN1_INTEGER_new (ssl.c:26303)
    ==31982==    by 0x5817353: wolfSSL_X509_get_serialNumber (ssl.c:26434)
    ==31982==    by 0x45EDD1: ssl_store_cert (wolfssl.c:363)
    ==31982==    by 0x45E97F: create_server_ssl_connection (wolfssl.c:1234)
    ==31982==    by 0x43AFF5: chat (jcc.c:4471)
    ==31982==    by 0x4398C5: serve (jcc.c:4778)
    ==31982==    by 0x5B5008B: ??? (in /lib/libthr.so.3)