### PR TITLE
Add support for OpenSSL compatibility function SSL_CTX_get_min_proto_…

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16663,6 +16663,62 @@ int wolfSSL_CTX_set_max_proto_version(WOLFSSL_CTX* ctx, int ver)
     return sanityCheckProtoVersion(ctx);
 }
 
+static int GetMinProtoVersion(int minDowngrade)
+{
+    int ret;
+
+    switch (minDowngrade) {
+#ifndef NO_OLD_TLS
+    #ifdef WOLFSSL_ALLOW_SSLV3
+        case SSLv3_MINOR:
+            ret = SSL3_VERSION;
+            break;
+    #endif
+    #ifdef WOLFSSL_ALLOW_TLSV10
+        case TLSv1_MINOR:
+            ret = TLS1_VERSION;
+            break;
+    #endif
+        case TLSv1_1_MINOR:
+            ret = TLS1_1_VERSION;
+            break;
+#endif
+#ifndef WOLFSSL_NO_TLS12
+        case TLSv1_2_MINOR:
+            ret = TLS1_2_VERSION;
+            break;
+#endif
+#ifdef WOLFSSL_TLS13
+        case TLSv1_3_MINOR:
+            ret = TLS1_3_VERSION;
+            break;
+#endif
+        default:
+            ret = 0;
+            break;
+    }
+
+    return ret;
+}
+
+WOLFSSL_API int wolfSSL_CTX_get_min_proto_version(WOLFSSL_CTX* ctx)
+{
+    int ret = 0;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_get_min_proto_version");
+
+    if (ctx != NULL) {
+        ret = GetMinProtoVersion(ctx->minDowngrade);
+    }
+    if (ret == 0) {
+        ret = GetMinProtoVersion(WOLFSSL_MIN_DOWNGRADE);
+    }
+
+    WOLFSSL_LEAVE("wolfSSL_CTX_get_min_proto_version", ret);
+
+    return ret;
+}
+
 #endif /* OPENSSL_EXTRA */
 
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)

--- a/tests/api.c
+++ b/tests/api.c
@@ -40412,6 +40412,71 @@ static void test_export_keying_material(void)
 }
 #endif /* HAVE_KEYING_MATERIAL */
 
+static void test_wolfSSL_CTX_get_min_proto_version(void)
+{
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
+    WOLFSSL_CTX *ctx;
+
+    printf(testingFmt, "wolfSSL_CTX_get_min_proto_version()");
+
+    #ifndef NO_OLD_TLS
+        #ifdef WOLFSSL_ALLOW_SSLV3
+            #ifdef NO_WOLFSSL_SERVER
+                AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
+            #else
+                AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
+            #endif
+            AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, SSL3_VERSION), WOLFSSL_SUCCESS);
+            AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), SSL3_VERSION);
+            wolfSSL_CTX_free(ctx);
+        #endif
+        #ifdef WOLFSSL_ALLOW_TLSV10
+            #ifdef NO_WOLFSSL_SERVER
+                AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_client_method()));
+            #else
+                AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_server_method()));
+            #endif
+            AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, TLS1_VERSION), WOLFSSL_SUCCESS);
+            AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), TLS1_VERSION);
+            wolfSSL_CTX_free(ctx);
+        #endif
+
+        #ifdef NO_WOLFSSL_SERVER
+            AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_1_client_method()));
+        #else
+            AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_1_server_method()));
+        #endif
+        AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, TLS1_1_VERSION), WOLFSSL_SUCCESS);
+        AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), TLS1_1_VERSION);
+        wolfSSL_CTX_free(ctx);
+    #endif
+
+    #ifndef WOLFSSL_NO_TLS12
+        #ifdef NO_WOLFSSL_SERVER
+            AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method()));
+        #else
+            AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_server_method()));
+        #endif
+        AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION), WOLFSSL_SUCCESS);
+        AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), TLS1_2_VERSION);
+        wolfSSL_CTX_free(ctx);
+    #endif
+
+    #ifdef WOLFSSL_TLS13
+        #ifdef NO_WOLFSSL_SERVER
+            AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
+        #else
+            AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
+        #endif
+        AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION), WOLFSSL_SUCCESS);
+        AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), TLS1_3_VERSION);
+        wolfSSL_CTX_free(ctx);
+    #endif
+
+    printf(resultFmt, passed);
+#endif /* defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL) */
+}
+
 /*----------------------------------------------------------------------------*
  | Main
  *----------------------------------------------------------------------------*/
@@ -40829,6 +40894,8 @@ void ApiTest(void)
 #ifdef HAVE_KEYING_MATERIAL
     test_export_keying_material();
 #endif /* HAVE_KEYING_MATERIAL */
+
+    test_wolfSSL_CTX_get_min_proto_version();
 
     /*wolfcrypt */
     printf("\n-----------------wolfcrypt unit tests------------------\n");

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1071,6 +1071,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 
 #define SSL_CTX_set_min_proto_version   wolfSSL_CTX_set_min_proto_version
 #define SSL_CTX_set_max_proto_version   wolfSSL_CTX_set_max_proto_version
+#define SSL_CTX_get_min_proto_version   wolfSSL_CTX_get_min_proto_version
 
 #define SSL_get_tlsext_status_exts      wolfSSL_get_tlsext_status_exts
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3555,6 +3555,7 @@ WOLFSSL_API int wolfSSL_get_server_tmp_key(const WOLFSSL*, WOLFSSL_EVP_PKEY**);
 
 WOLFSSL_API int wolfSSL_CTX_set_min_proto_version(WOLFSSL_CTX*, int);
 WOLFSSL_API int wolfSSL_CTX_set_max_proto_version(WOLFSSL_CTX*, int);
+WOLFSSL_API int wolfSSL_CTX_get_min_proto_version(WOLFSSL_CTX*);
 
 WOLFSSL_API int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *pkey);
 WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 **x, pem_password_cb *cb, void *u);


### PR DESCRIPTION
…version.

This is needed by socat-1.7.4.1.