### PR TITLE
Add Cryptocell wc_ecc_import_x963_ex

### DIFF
--- a/IDE/CRYPTOCELL/user_settings.h
+++ b/IDE/CRYPTOCELL/user_settings.h
@@ -41,6 +41,7 @@ extern "C" {
 #endif
 
 #if defined(WOLFSSL_CRYPTOCELL)
+    /* see SASI_AES_KEY_MAX_SIZE_IN_BYTES in the nRF5 SDK */
     #define AES_MAX_KEY_SIZE    128
 #endif /* WOLFSSL_CRYPTOCELL*/
 

--- a/IDE/CRYPTOCELL/user_settings.h
+++ b/IDE/CRYPTOCELL/user_settings.h
@@ -138,6 +138,9 @@ extern "C" {
 #if 1
     #define HAVE_ECC
 
+    #include <strings.h>
+    /* strings.h required for strncasecmp */
+
     /* Manually define enabled curves */
     #undef  ECC_USER_CURVES
     #define ECC_USER_CURVES

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7770,7 +7770,10 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
 #endif
     int keysize = 0;
     byte pointType;
-
+#ifdef WOLFSSL_CRYPTOCELL
+    const CRYS_ECPKI_Domain_t* pDomain;
+    CRYS_ECPKI_BUILD_TempData_t tempBuff;
+#endif
     if (in == NULL || key == NULL)
         return BAD_FUNC_ARG;
 
@@ -7951,9 +7954,6 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
     err = silabs_ecc_import(key, keysize);
 #endif
 #ifdef WOLFSSL_CRYPTOCELL
-    const CRYS_ECPKI_Domain_t* pDomain;
-    CRYS_ECPKI_BUILD_TempData_t tempBuff;
-
     pDomain = CRYS_ECPKI_GetEcDomain(cc310_mapCurve(key->dp->id));
 
     /* create public key from external key buffer */

--- a/wolfcrypt/src/signature.c
+++ b/wolfcrypt/src/signature.c
@@ -48,6 +48,13 @@
 /* Signature wrapper disabled check */
 #ifndef NO_SIG_WRAPPER
 
+#ifdef WOLFSSL_CRYPTOCELL
+extern int cc310_RsaSSL_Verify(const byte* in, word32 inLen, byte* sig,
+                            RsaKey* key, CRYS_RSA_HASH_OpMode_t mode);
+extern int cc310_RsaSSL_Sign(const byte* in, word32 inLen, byte* out,
+                word32 outLen, RsaKey* key, CRYS_RSA_HASH_OpMode_t mode);
+#endif
+
 #if !defined(NO_RSA) && !defined(NO_ASN)
 static int wc_SignatureDerEncode(enum wc_HashType hash_type, byte* hash_data,
     word32 hash_len, word32* hash_enc_len)
@@ -178,12 +185,12 @@ int wc_SignatureVerifyHash(
 #ifndef NO_RSA
     #ifdef WOLFSSL_CRYPTOCELL
         if (sig_type == WC_SIGNATURE_TYPE_RSA_W_ENC) {
-            ret = cc310_RsaSSL_Verify(hash_data, hash_len, (byte*)sig, key,
-                                              cc310_hashModeRSA(hash_type, 0));
+            ret = cc310_RsaSSL_Verify(hash_data, hash_len, (byte*)sig,
+                (RsaKey*)key, cc310_hashModeRSA(hash_type, 0));
         }
         else {
-            ret = cc310_RsaSSL_Verify(hash_data, hash_len, (byte*)sig, key,
-                                              cc310_hashModeRSA(hash_type, 1));
+            ret = cc310_RsaSSL_Verify(hash_data, hash_len, (byte*)sig,
+                (RsaKey*)key, cc310_hashModeRSA(hash_type, 1));
         }
     #else
 
@@ -400,12 +407,12 @@ int wc_SignatureGenerateHash_ex(
             /* use expected signature size (incoming sig_len could be larger buffer */
             *sig_len = wc_SignatureGetSize(sig_type, key, key_len);
             if (sig_type == WC_SIGNATURE_TYPE_RSA_W_ENC) {
-                ret = cc310_RsaSSL_Sign(hash_data, hash_len, sig, *sig_len, key,
-                                        cc310_hashModeRSA(hash_type, 0));
+                ret = cc310_RsaSSL_Sign(hash_data, hash_len, sig, *sig_len,
+                    (RsaKey*)key, cc310_hashModeRSA(hash_type, 0));
             }
             else {
-                ret = cc310_RsaSSL_Sign(hash_data, hash_len, sig, *sig_len, key,
-                                        cc310_hashModeRSA(hash_type, 1));
+                ret = cc310_RsaSSL_Sign(hash_data, hash_len, sig, *sig_len,
+                    (RsaKey*)key, cc310_hashModeRSA(hash_type, 1));
            }
     #else
             /* Create signature using provided RSA key */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -7621,9 +7621,11 @@ static int aes_key_size_test(void)
 #endif
     byte   key16[] = { 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
                        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66 };
+#ifndef WOLFSSL_CRYPTOCELL
     byte   key24[] = { 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
                        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
                        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37 };
+#endif
     byte   key32[] = { 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
                        0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
                        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
@@ -7700,7 +7702,7 @@ static int aes_key_size_test(void)
     if (ret != 0 || keySize != sizeof(key16))
         ERROR_OUT(-5310, out);
 #endif
-#if !defined(WOLFSSL_CRYPTOCELL)
+#ifndef WOLFSSL_CRYPTOCELL
 /* Cryptocell only supports AES-128 key size */
     ret = wc_AesSetKey(aes, key24, sizeof(key24), iv, AES_ENCRYPTION);
 #ifdef WOLFSSL_AES_192
@@ -14435,7 +14437,9 @@ static int rsa_keygen_test(WC_RNG* rng)
 #endif
     int    ret;
     byte*  der = NULL;
+#ifndef WOLFSSL_CRYPTOCELL
     word32 idx = 0;
+#endif
     int    derSz = 0;
 #if !defined(WOLFSSL_SP_MATH) && !defined(HAVE_FIPS)
     int    keySz = 1024;
@@ -14495,8 +14499,9 @@ static int rsa_keygen_test(WC_RNG* rng)
     if (ret != 0) {
         ERROR_OUT(-7875, exit_rsa);
     }
+
+#ifndef WOLFSSL_CRYPTOCELL
     idx = 0;
-#if !defined(WOLFSSL_CRYPTOCELL)
     /* The private key part of the key gen pairs from cryptocell can't be exported */
     ret = wc_RsaPrivateKeyDecode(der, &idx, genKey, derSz);
     if (ret != 0) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -7700,7 +7700,8 @@ static int aes_key_size_test(void)
     if (ret != 0 || keySize != sizeof(key16))
         ERROR_OUT(-5310, out);
 #endif
-
+#if !defined(WOLFSSL_CRYPTOCELL)
+/* Cryptocell only supports AES-128 key size */
     ret = wc_AesSetKey(aes, key24, sizeof(key24), iv, AES_ENCRYPTION);
 #ifdef WOLFSSL_AES_192
     if (ret != 0)
@@ -7726,7 +7727,7 @@ static int aes_key_size_test(void)
     if (ret != 0 || keySize != sizeof(key32))
         ERROR_OUT(-5314, out);
 #endif
-
+#endif /* !WOLFSSL_CRYPTOCELL */
   out:
 
 #ifdef WOLFSSL_SMALL_STACK
@@ -21367,7 +21368,9 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
 #ifdef HAVE_ECC_SIGN
     /* ECC w/out Shamir has issue with all 0 digest */
     /* WC_BIGINT doesn't have 0 len well on hardware */
-#if defined(ECC_SHAMIR) && !defined(WOLFSSL_ASYNC_CRYPT)
+    /* Cryptocell has issues with all 0 digest */
+#if defined(ECC_SHAMIR) && !defined(WOLFSSL_ASYNC_CRYPT) && \
+    !defined(WOLFSSL_CRYPTOCELL)
     /* test DSA sign hash with zeros */
     for (i = 0; i < (int)ECC_DIGEST_SIZE; i++) {
         digest[i] = 0;
@@ -21404,7 +21407,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
         TEST_SLEEP();
     }
 #endif /* HAVE_ECC_VERIFY */
-#endif /* ECC_SHAMIR && !WOLFSSL_ASYNC_CRYPT */
+#endif /* ECC_SHAMIR && !WOLFSSL_ASYNC_CRYPT && !WOLFSSL_CRYPTOCELL */
 
     /* test DSA sign hash with sequence (0,1,2,3,4,...) */
     for (i = 0; i < (int)ECC_DIGEST_SIZE; i++) {


### PR DESCRIPTION
This PR addresses some issues with Cryptocell. 

- Add support for importing public key with _wc_ecc_import_x963_ex()_
- Test for curves other than the default secp256r1
- Limit AES tests since Cryptocell only supports AES-128 key size
- Fixes for build warnings for CryptoCell with ECC and RSA.