### PR TITLE
configure: When enabling --enable-sp-asm, accept host_cpu amd64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5242,7 +5242,7 @@ if test "$ENABLED_SP_ASM" = "yes"; then
       fi
     fi
     ;;
-  *x86_64*)
+  *x86_64*|*amd64*)
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_X86_64_ASM"
     AM_CCASFLAGS="$AM_CCASFLAGS -DWOLFSSL_SP_X86_64_ASM"
     ENABLED_SP_X86_64_ASM=yes


### PR DESCRIPTION
… as alternative to x86_64

Allows to use --enable-sp-asm on ElectroBSD amd64.

Previously configure failed with:
 configure: error: ASM not available for CPU. Supported CPUs: x86_64, aarch64, arm