### PR TITLE
Causes SSL_CTX_load_verify_locations and X509_LOOKUP_load_file to return zero on failure if WOLFSSL_ERR_CODE_OPENSSL is defined

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6916,7 +6916,7 @@ int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX* ctx, const char* file,
     int ret = wolfSSL_CTX_load_verify_locations_ex(ctx, file, path,
         WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS);
 
-    return RETURN_CODE(ret,WOLFSSL_FAILURE);
+    return WS_RETURN_CODE(ret,WOLFSSL_FAILURE);
 }
 
 
@@ -24409,15 +24409,15 @@ int wolfSSL_X509_LOOKUP_load_file(WOLFSSL_X509_LOOKUP* lookup,
     const char* footer = NULL;
 
     if (type != X509_FILETYPE_PEM)
-        return RETURN_CODE(BAD_FUNC_ARG,WOLFSSL_FAILURE);
+        return WS_RETURN_CODE(BAD_FUNC_ARG,WOLFSSL_FAILURE);
 
     fp = XFOPEN(file, "rb");
     if (fp == XBADFILE)
-        return RETURN_CODE(BAD_FUNC_ARG,WOLFSSL_FAILURE);
+        return WS_RETURN_CODE(BAD_FUNC_ARG,WOLFSSL_FAILURE);
 
     if(XFSEEK(fp, 0, XSEEK_END) != 0) {
         XFCLOSE(fp);
-        return RETURN_CODE(WOLFSSL_BAD_FILE,WOLFSSL_FAILURE);
+        return WS_RETURN_CODE(WOLFSSL_BAD_FILE,WOLFSSL_FAILURE);
     }
     sz = XFTELL(fp);
     XREWIND(fp);
@@ -24487,12 +24487,12 @@ end:
     if (pem != NULL)
         XFREE(pem, 0, DYNAMIC_TYPE_PEM);
     XFCLOSE(fp);
-    return RETURN_CODE(ret,WOLFSSL_FAILURE);
+    return WS_RETURN_CODE(ret,WOLFSSL_FAILURE);
 #else
     (void)lookup;
     (void)file;
     (void)type;
-    return RETURN_CODE(WOLFSSL_FAILURE,WOLFSSL_FAILURE);
+    return WS_RETURN_CODE(WOLFSSL_FAILURE,WOLFSSL_FAILURE);
 #endif
 }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6913,8 +6913,10 @@ WOLFSSL_ABI
 int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX* ctx, const char* file,
                                      const char* path)
 {
-    return wolfSSL_CTX_load_verify_locations_ex(ctx, file, path,
+    int ret = wolfSSL_CTX_load_verify_locations_ex(ctx, file, path,
         WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS);
+
+    return RETURN_CODE(ret,0);
 }
 
 
@@ -24407,15 +24409,15 @@ int wolfSSL_X509_LOOKUP_load_file(WOLFSSL_X509_LOOKUP* lookup,
     const char* footer = NULL;
 
     if (type != X509_FILETYPE_PEM)
-        return BAD_FUNC_ARG;
+        return RETURN_CODE(BAD_FUNC_ARG,0);
 
     fp = XFOPEN(file, "rb");
     if (fp == XBADFILE)
-        return BAD_FUNC_ARG;
+        return RETURN_CODE(BAD_FUNC_ARG,0);
 
     if(XFSEEK(fp, 0, XSEEK_END) != 0) {
         XFCLOSE(fp);
-        return WOLFSSL_BAD_FILE;
+        return RETURN_CODE(WOLFSSL_BAD_FILE,0);
     }
     sz = XFTELL(fp);
     XREWIND(fp);
@@ -24485,12 +24487,12 @@ end:
     if (pem != NULL)
         XFREE(pem, 0, DYNAMIC_TYPE_PEM);
     XFCLOSE(fp);
-    return ret;
+    return RETURN_CODE(ret,0);
 #else
     (void)lookup;
     (void)file;
     (void)type;
-    return WOLFSSL_FAILURE;
+    return RETURN_CODE(WOLFSSL_FAILURE,0);
 #endif
 }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6916,7 +6916,7 @@ int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX* ctx, const char* file,
     int ret = wolfSSL_CTX_load_verify_locations_ex(ctx, file, path,
         WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS);
 
-    return RETURN_CODE(ret,0);
+    return RETURN_CODE(ret,WOLFSSL_FAILURE);
 }
 
 
@@ -24409,15 +24409,15 @@ int wolfSSL_X509_LOOKUP_load_file(WOLFSSL_X509_LOOKUP* lookup,
     const char* footer = NULL;
 
     if (type != X509_FILETYPE_PEM)
-        return RETURN_CODE(BAD_FUNC_ARG,0);
+        return RETURN_CODE(BAD_FUNC_ARG,WOLFSSL_FAILURE);
 
     fp = XFOPEN(file, "rb");
     if (fp == XBADFILE)
-        return RETURN_CODE(BAD_FUNC_ARG,0);
+        return RETURN_CODE(BAD_FUNC_ARG,WOLFSSL_FAILURE);
 
     if(XFSEEK(fp, 0, XSEEK_END) != 0) {
         XFCLOSE(fp);
-        return RETURN_CODE(WOLFSSL_BAD_FILE,0);
+        return RETURN_CODE(WOLFSSL_BAD_FILE,WOLFSSL_FAILURE);
     }
     sz = XFTELL(fp);
     XREWIND(fp);
@@ -24487,12 +24487,12 @@ end:
     if (pem != NULL)
         XFREE(pem, 0, DYNAMIC_TYPE_PEM);
     XFCLOSE(fp);
-    return RETURN_CODE(ret,0);
+    return RETURN_CODE(ret,WOLFSSL_FAILURE);
 #else
     (void)lookup;
     (void)file;
     (void)type;
-    return RETURN_CODE(WOLFSSL_FAILURE,0);
+    return RETURN_CODE(WOLFSSL_FAILURE,WOLFSSL_FAILURE);
 #endif
 }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -954,19 +954,19 @@ static void test_wolfSSL_CTX_load_verify_locations(void)
 
     /* invalid ca file */
     AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, bogusFile, NULL),
-     RETURN_CODE(WOLFSSL_BAD_FILE,WOLFSSL_FAILURE));
+     WS_RETURN_CODE(WOLFSSL_BAD_FILE,WOLFSSL_FAILURE));
 
 
 #if !defined(NO_WOLFSSL_DIR) && !defined(WOLFSSL_TIRTOS)
     /* invalid path */
     AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, NULL, bogusFile),
-     RETURN_CODE(BAD_PATH_ERROR,WOLFSSL_FAILURE));
+     WS_RETURN_CODE(BAD_PATH_ERROR,WOLFSSL_FAILURE));
 #endif
 
     /* load ca cert */
 #ifdef NO_RSA
     AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, NULL),
-     RETURN_CODE(ASN_UNKNOWN_OID_E,WOLFSSL_FAILURE));
+     WS_RETURN_CODE(ASN_UNKNOWN_OID_E,WOLFSSL_FAILURE));
 #else /* Skip the following test without RSA certs. */
     AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, NULL), WOLFSSL_SUCCESS);
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -954,19 +954,19 @@ static void test_wolfSSL_CTX_load_verify_locations(void)
 
     /* invalid ca file */
     AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, bogusFile, NULL),
-     RETURN_CODE(WOLFSSL_BAD_FILE,0));
+     RETURN_CODE(WOLFSSL_BAD_FILE,WOLFSSL_FAILURE));
 
 
 #if !defined(NO_WOLFSSL_DIR) && !defined(WOLFSSL_TIRTOS)
     /* invalid path */
     AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, NULL, bogusFile),
-     RETURN_CODE(BAD_PATH_ERROR,0));
+     RETURN_CODE(BAD_PATH_ERROR,WOLFSSL_FAILURE));
 #endif
 
     /* load ca cert */
 #ifdef NO_RSA
     AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, NULL),
-     RETURN_CODE(ASN_UNKNOWN_OID_E,0));
+     RETURN_CODE(ASN_UNKNOWN_OID_E,WOLFSSL_FAILURE));
 #else /* Skip the following test without RSA certs. */
     AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, NULL), WOLFSSL_SUCCESS);
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -953,17 +953,20 @@ static void test_wolfSSL_CTX_load_verify_locations(void)
     AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, NULL, NULL), WOLFSSL_FAILURE);
 
     /* invalid ca file */
-    AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, bogusFile, NULL), WOLFSSL_BAD_FILE);
+    AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, bogusFile, NULL),
+     RETURN_CODE(WOLFSSL_BAD_FILE,0));
 
 
 #if !defined(NO_WOLFSSL_DIR) && !defined(WOLFSSL_TIRTOS)
     /* invalid path */
-    AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, NULL, bogusFile), BAD_PATH_ERROR);
+    AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, NULL, bogusFile),
+     RETURN_CODE(BAD_PATH_ERROR,0));
 #endif
 
     /* load ca cert */
 #ifdef NO_RSA
-    AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, NULL), ASN_UNKNOWN_OID_E);
+    AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, NULL),
+     RETURN_CODE(ASN_UNKNOWN_OID_E,0));
 #else /* Skip the following test without RSA certs. */
     AssertIntEQ(wolfSSL_CTX_load_verify_locations(ctx, caCertFile, NULL), WOLFSSL_SUCCESS);
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -674,6 +674,12 @@ enum AlertLevel {
     alert_fatal   = 2
 };
 
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    #define RETURN_CODE(w,o)  ((w < 0)?o:w)
+#else
+    #define RETURN_CODE(w,o) (w)
+#endif
+
 /* Maximum master key length (SECRET_LEN) */
 #define WOLFSSL_MAX_MASTER_KEY_LENGTH 48
 /* Maximum number of groups that can be set */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -674,19 +674,26 @@ enum AlertLevel {
     alert_fatal   = 2
 };
 
-/* RETURN_CODE macro
+/* WS_RETURN_CODE macro
  * Some OpenSSL APIs specify "0" as the return value when an error occurs.
- * However, some corresponding wolfSSL APIs(eg.
- * wolfSSL_CTX_load_verify_locations) return negative values. Such functions
- * should use this macro to fill this gap. Users who want them to return
- * the same return value as OpenSSL can define WOLFSSL_ERR_CODE_OPENSSL.
+ * However, some corresponding wolfSSL APIs　return negative values. Such
+ * functions should use this macro to fill this gap. Users who want them
+ * to return the same return value as OpenSSL can define
+ * WOLFSSL_ERR_CODE_OPENSSL.
+ * Give item1 a variable that contains the potentially negative
+ * wolfSSL-defined return value or the return value itself, and
+ * give item2 the openSSL-defined return value.
  * Note that this macro replaces only negative return values with the
  * specified value.
+ * Since wolfSSL 4.7.0, the following functions use this macro:
+ * - wolfSSL_CTX_load_verify_locations
+ * - wolfSSL_X509_LOOKUP_load_file
  */
 #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-    #define RETURN_CODE(w,o)  ((w < 0)?o:w)
+    #define WS_RETURN_CODE(item1,item2) \
+      ((item1 < 0) ? item2 : item1)
 #else
-    #define RETURN_CODE(w,o) (w)
+    #define WS_RETURN_CODE(item1,item2)  (item1)
 #endif
 
 /* Maximum master key length (SECRET_LEN) */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -674,6 +674,15 @@ enum AlertLevel {
     alert_fatal   = 2
 };
 
+/* RETURN_CODE macro
+ * Some OpenSSL APIs specify "0" as the return value when an error occurs.
+ * However, some corresponding wolfSSL APIs(eg.
+ * wolfSSL_CTX_load_verify_locations) return negative values. Such functions
+ * should use this macro to fill this gap. Users who want them to return
+ * the same return value as OpenSSL can define WOLFSSL_ERR_CODE_OPENSSL.
+ * Note that this macro replaces only negative return values with the
+ * specified value.
+ */
 #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
     #define RETURN_CODE(w,o)  ((w < 0)?o:w)
 #else


### PR DESCRIPTION
To fix issue reported in ZD11641, RETURN_CODE macro were introduced to those two functions. By defining WOLFSSL_ERR_CODE_OPENSSL, RETURN_CODE macro returns openssl error code instead of negative values defined in wolfSSL.