### PR TITLE
Correct a build error with a non-standard configurations

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -384,6 +384,7 @@ static int SetASNNull(byte* output)
     return 2;
 }
 
+#ifndef NO_CERTS
 /* Get the DER/BER encoding of an ASN.1 BOOLEAN.
  *
  * input     Buffer holding DER/BER encoded data.
@@ -413,7 +414,7 @@ static int GetBoolean(const byte* input, word32* inOutIdx, word32 maxIdx)
     *inOutIdx = idx;
     return b;
 }
-
+#endif /* !NO_CERTS*/
 #ifdef ASN1_SET_BOOLEAN
 /* Set the DER/BER encoding of the ASN.1 NULL element.
  * Note: Function not required as yet.
@@ -497,6 +498,7 @@ static int GetASNInt(const byte* input, word32* inOutIdx, int* len,
     return 0;
 }
 
+#ifndef NO_CERTS
 /* Get the DER/BER encoding of an ASN.1 INTEGER that has a value of no more than
  * 7 bits.
  *
@@ -526,7 +528,7 @@ static int GetInteger7Bit(const byte* input, word32* inOutIdx, word32 maxIdx)
     *inOutIdx = idx;
     return b;
 }
-
+#endif /* !NO_CERTS */
 
 #if !defined(NO_DSA) && !defined(NO_SHA)
 static const char sigSha1wDsaName[] = "SHAwDSA";
@@ -6792,6 +6794,7 @@ int DecodeToKey(DecodedCert* cert, int verify)
     return ret;
 }
 
+#ifndef NO_CERTS
 static int GetSignature(DecodedCert* cert)
 {
     int length;
@@ -6811,6 +6814,7 @@ static int GetSignature(DecodedCert* cert)
 
     return 0;
 }
+#endif
 
 static word32 SetOctetString8Bit(word32 len, byte* output)
 {

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -2996,8 +2996,8 @@ int sp_cmp_d(sp_int* a, sp_int_digit d)
 #endif
 
 #if defined(WOLFSSL_SP_INT_NEGATIVE) || !defined(NO_PWDBASED) || \
-    defined(WOLFSSL_KEY_GEN) || !defined(NO_DH) || (!defined(NO_RSA) && \
-    !defined(WOLFSSL_RSA_VERIFY_ONLY))
+    defined(WOLFSSL_KEY_GEN) || !defined(NO_DH) || defined(HAVE_ECC) || \
+    (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY))
 /* Add a one digit number to the multi-precision number.
  *
  * @param  [in]   a  SP integer be added to.

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11821,9 +11821,11 @@ byte GetEntropy(ENTROPY_CMD cmd, byte* out)
         static const char* certEccRsaPemFile = CERT_WRITE_TEMP_DIR "certeccrsa.pem";
         static const char* certEccRsaDerFile = CERT_WRITE_TEMP_DIR "certeccrsa.der";
     #endif
+    #if defined(HAVE_ECC_KEY_EXPORT)
         static const char* eccCaKeyPemFile  = CERT_WRITE_TEMP_DIR "ecc-key.pem";
         static const char* eccPubKeyDerFile = CERT_WRITE_TEMP_DIR "ecc-public-key.der";
         static const char* eccCaKeyTempFile = CERT_WRITE_TEMP_DIR "ecc-key.der";
+    #endif
     #ifdef HAVE_PKCS8
         static const char* eccPkcs8KeyDerFile = CERT_WRITE_TEMP_DIR "ecc-key-pkcs8.der";
     #endif
@@ -20648,7 +20650,10 @@ static int ecc_test_make_pub(WC_RNG* rng)
     byte tmp[ECC_BUFSIZE];
 #endif
     const byte* msg = (const byte*)"test wolfSSL ECC public gen";
-    word32 x, tmpSz;
+#if defined(HAVE_ECC_KEY_EXPORT)
+    word32 x;
+#endif
+    word32 tmpSz;
     int ret = 0;
     ecc_point* pubPoint = NULL;
 #ifdef HAVE_ECC_VERIFY


### PR DESCRIPTION
This PR corrects a build error with the following configurations. 

```
./configure --enable-sp=small,nomalloc,384 --enable-sp-math-all  --disable-rsa --disable-dh --enable-cryptonly --enable-ecc CFLAGS="-DNO_ECC256 -DWOLFSSL_SP_NO_256 -DNO_ECC_KEY_EXPORT -DNO_ASN_TIME -DNO_CERTS -DNO_PKCS8"  && make && wolfcrypt/test/testwolfcrypt

...
  CC       wolfcrypt/src/src_libwolfssl_la-sha3.lo
wolfcrypt/src/sp_int.c: In function ‘_sp_read_radix_10’:
wolfcrypt/src/sp_int.c:12388:15: error: implicit declaration of function ‘_sp_add_d’; did you mean ‘sp_add_d’? [-Werror=implicit-function-declaration]
12388 |         (void)_sp_add_d(a, ch, a);
      |               ^~~~~~~~~
      |               sp_add_d
wolfcrypt/src/sp_int.c:12388:15: error: nested extern declaration of ‘_sp_add_d’ [-Werror=nested-externs]
  CC       wolfcrypt/src/src_libwolfssl_la-logging.lo
  CC       wolfcrypt/src/src_libwolfssl_la-wc_port.lo
  CC       wolfcrypt/src/src_libwolfssl_la-error.lo
  CC       wolfcrypt/src/src_libwolfssl_la-wc_encrypt.lo
  CC       wolfcrypt/src/src_libwolfssl_la-signature.lo
  CC       wolfcrypt/src/src_libwolfssl_la-wolfmath.lo
  CC       wolfcrypt/src/src_libwolfssl_la-memory.lo
  CC       wolfcrypt/src/src_libwolfssl_la-asn.lo
  CC       wolfcrypt/src/src_libwolfssl_la-coding.lo
  CC       wolfcrypt/src/src_libwolfssl_la-poly1305.lo
  CC       wolfcrypt/src/src_libwolfssl_la-md5.lo
  CC       wolfcrypt/src/src_libwolfssl_la-chacha.lo
  CC       wolfcrypt/src/src_libwolfssl_la-chacha20_poly1305.lo
  CC       wolfcrypt/src/src_libwolfssl_la-ecc.lo
  CC       wolfcrypt/test/test.o
wolfcrypt/src/asn.c:6795:12: error: ‘GetSignature’ defined but not used [-Werror=unused-function]
 6795 | static int GetSignature(DecodedCert* cert)
      |            ^~~~~~~~~~~~
wolfcrypt/src/asn.c:510:12: error: ‘GetInteger7Bit’ defined but not used [-Werror=unused-function]
  510 | static int GetInteger7Bit(const byte* input, word32* inOutIdx, word32 maxIdx)
      |            ^~~~~~~~~~~~~~
wolfcrypt/src/asn.c:396:12: error: ‘GetBoolean’ defined but not used [-Werror=unused-function]
  396 | static int GetBoolean(const byte* input, word32* inOutIdx, word32 maxIdx)
      |            ^~~~~~~~~~
wolfcrypt/test/test.c: In function ‘ecc_test_make_pub’:
wolfcrypt/test/test.c:20651:12: error: unused variable ‘x’ [-Werror=unused-variable]
20651 |     word32 x, tmpSz;
      |            ^
At top level:
wolfcrypt/test/test.c:11828:28: error: ‘eccPkcs8KeyDerFile’ defined but not used [-Werror=unused-variable]
11828 |         static const char* eccPkcs8KeyDerFile = CERT_WRITE_TEMP_DIR "ecc-key-pkcs8.der";
      |                            ^~~~~~~~~~~~~~~~~~
wolfcrypt/test/test.c:11826:28: error: ‘eccCaKeyTempFile’ defined but not used [-Werror=unused-variable]
11826 |         static const char* eccCaKeyTempFile = CERT_WRITE_TEMP_DIR "ecc-key.der";
      |                            ^~~~~~~~~~~~~~~~
wolfcrypt/test/test.c:11825:28: error: ‘eccPubKeyDerFile’ defined but not used [-Werror=unused-variable]
11825 |         static const char* eccPubKeyDerFile = CERT_WRITE_TEMP_DIR "ecc-public-key.der";
      |                            ^~~~~~~~~~~~~~~~
wolfcrypt/test/test.c:11824:28: error: ‘eccCaKeyPemFile’ defined but not used [-Werror=unused-variable]
11824 |         static const char* eccCaKeyPemFile  = CERT_WRITE_TEMP_DIR "ecc-key.pem";
      |                            ^~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:4912: wolfcrypt/src/src_libwolfssl_la-sp_int.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
cc1: all warnings being treated as errors
make[2]: *** [Makefile:4982: wolfcrypt/src/src_libwolfssl_la-asn.lo] Error 1
cc1: all warnings being treated as errors
make[2]: *** [Makefile:4573: wolfcrypt/test/test.o] Error 1
make[2]: Leaving directory '/home/tesfa/review/wolfssl'
make[1]: *** [Makefile:5736: all-recursive] Error 1

```