### PR TITLE
Fixes for building without hash or rng

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -5611,6 +5611,7 @@ exit:
     (void)times;
     (void)desc;
     (void)start;
+    (void)name;
 }
 
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -7121,8 +7121,6 @@ static int HashForSignature(const byte* buf, word32 bufSz, word32 sigOID,
 {
     int ret = 0;
 
-    (void)verify;
-
     switch (sigOID) {
     #if defined(WOLFSSL_MD2)
         case CTC_MD2wRSA:
@@ -7209,6 +7207,14 @@ static int HashForSignature(const byte* buf, word32 bufSz, word32 sigOID,
             ret = HASH_TYPE_E;
             WOLFSSL_MSG("Hash for Signature has unsupported type");
     }
+
+    (void)buf;
+    (void)bufSz;
+    (void)sigOID;
+    (void)digest;
+    (void)digestSz;
+    (void)typeH;
+    (void)verify;
 
     return ret;
 }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7988,7 +7988,7 @@ int wc_ecc_export_ex(ecc_key* key, byte* qx, word32* qxLen,
         return BAD_FUNC_ARG;
     }
 
-    if (wc_ecc_is_valid_idx(key->idx) == 0) {
+    if (wc_ecc_is_valid_idx(key->idx) == 0 || key->dp == NULL) {
         return ECC_BAD_ARG_E;
     }
     keySz = key->dp->size;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -16538,7 +16538,7 @@ done:
     (void)privSz;
     (void)pubSz;
     (void)pubSz2;
-    (void)pubSz2;
+    (void)privSz2;
 
     return ret;
 #undef DH_TEST_BUF_SIZE

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -16242,7 +16242,6 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
 
 #ifndef WC_NO_RNG
 #ifdef WOLFSSL_SMALL_STACK
-    
     byte *priv = (byte *)XMALLOC(DH_TEST_BUF_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     byte *pub = (byte *)XMALLOC(DH_TEST_BUF_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     byte *priv2 = (byte *)XMALLOC(DH_TEST_BUF_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
@@ -16536,6 +16535,9 @@ done:
     wc_FreeDhKey(key2);
 #endif
 
+    (void)privSz;
+    (void)pubSz;
+    (void)pubSz2;
     (void)pubSz2;
 
     return ret;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14558,22 +14558,12 @@ WOLFSSL_TEST_SUBROUTINE int rsa_test(void)
     RsaKey caKey[1];
 #endif
 #endif
-#if !defined(NO_ASN) || !defined(WOLFSSL_RSA_PUBLIC_ONLY) \
-                     || defined(WOLFSSL_PUBLIC_MP)
     word32 idx = 0;
-#endif
-#if !defined(WC_NO_RNG) && !defined(WC_NO_RSA_OAEP) && \
-    ((!defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
-    defined(WOLFSSL_PUBLIC_MP))
     const char inStr[] = TEST_STRING;
 	const word32 inLen = (word32)TEST_STRING_SZ;
     const word32 outSz   = RSA_TEST_BYTES;
     const word32 plainSz = RSA_TEST_BYTES;
-#endif
-#if (!defined(WOLFSSL_RSA_PUBLIC_ONLY) && !defined(WOLFSSL_RSA_VERIFY_ONLY) && \
-    !defined(WC_NO_RNG)) || defined(WOLFSSL_PUBLIC_MP)
     byte*  res;
-#endif
 #ifndef NO_SIG_WRAPPER
     int modLen;
 #endif
@@ -14591,9 +14581,6 @@ WOLFSSL_TEST_SUBROUTINE int rsa_test(void)
 #endif
 #endif
 
-#if !defined(WC_NO_RNG) && !defined(WC_NO_RSA_OAEP) && \
-    ((!defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
-    defined(WOLFSSL_PUBLIC_MP))
     DECLARE_VAR(in, byte, TEST_STRING_SZ, HEAP_HINT);
     DECLARE_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
     DECLARE_VAR(plain, byte, RSA_TEST_BYTES, HEAP_HINT);
@@ -14604,7 +14591,6 @@ WOLFSSL_TEST_SUBROUTINE int rsa_test(void)
 #endif
 
     XMEMCPY(in, inStr, inLen);
-#endif
 
 #ifdef WOLFSSL_SMALL_STACK
     if (key == NULL)
@@ -14816,9 +14802,6 @@ WOLFSSL_TEST_SUBROUTINE int rsa_test(void)
     TEST_SLEEP();
 
 #elif defined(WOLFSSL_PUBLIC_MP)
-    (void)outSz;
-    (void)inLen;
-    (void)res;
     {
         static byte signature_2048[] = {
             0x07, 0x6f, 0xc9, 0x85, 0x73, 0x9e, 0x21, 0x79,
@@ -15272,8 +15255,6 @@ WOLFSSL_TEST_SUBROUTINE int rsa_test(void)
     }
 
     FreeDecodedCert(cert);
-#else
-    (void)bytes;
 #endif
 
 #ifdef WOLFSSL_CERT_EXT
@@ -15636,50 +15617,52 @@ WOLFSSL_TEST_SUBROUTINE int rsa_test(void)
 exit_rsa:
 
 #ifdef WOLFSSL_SMALL_STACK
-
     if (key != NULL) {
         wc_FreeRsaKey(key);
         XFREE(key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     }
-#if defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_CERT_GEN)
+    #if defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_CERT_GEN)
     if (keypub != NULL) {
         wc_FreeRsaKey(keypub);
         XFREE(keypub, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     }
-#endif
-#if defined(HAVE_NTRU)
+    #endif
+    #if defined(HAVE_NTRU)
     if (caKey != NULL) {
         wc_FreeRsaKey(caKey);
         XFREE(caKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     }
-#endif
-#ifdef WOLFSSL_TEST_CERT
+    #endif
+    #ifdef WOLFSSL_TEST_CERT
     if (cert != NULL)
         XFREE(cert, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-#endif
-
+    #endif
 #else
-
     wc_FreeRsaKey(key);
-#if defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_CERT_GEN)
+    #if defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_CERT_GEN)
     wc_FreeRsaKey(keypub);
-#endif
-#if defined(HAVE_NTRU)
+    #endif
+    #if defined(HAVE_NTRU)
     wc_FreeRsaKey(caKey);
-#endif
-
-#endif
+    #endif
+#endif /* WOLFSSL_SMALL_STACK */
 
     XFREE(der, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     XFREE(tmp, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     wc_FreeRng(&rng);
 
-#if (!defined(WOLFSSL_RSA_VERIFY_ONLY) || defined(WOLFSSL_PUBLIC_MP)) && \
-                                 !defined(WC_NO_RSA_OAEP) && !defined(WC_NO_RNG)
     FREE_VAR(in, HEAP_HINT);
     FREE_VAR(out, HEAP_HINT);
     FREE_VAR(plain, HEAP_HINT);
-#endif
+
+    (void)res;
+    (void)bytes;
+    (void)in;
+    (void)out;
+    (void)plain;
+    (void)inLen;
+    (void)outSz;
+    (void)plainSz;
 
     /* ret can be greater then 0 with certgen but all negative values should
      * be returned and treated as an error */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -16553,6 +16553,8 @@ done:
     wc_FreeDhKey(key2);
 #endif
 
+    (void)pubSz2;
+
     return ret;
 #undef DH_TEST_BUF_SIZE
 #undef DH_TEST_TMP_SIZE

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -849,10 +849,12 @@ initDefaultName();
         test_pass("SHAKE256 test passed!\n");
 #endif
 
+#ifndef NO_HASH_WRAPPER
     if ( (ret = hash_test()) != 0)
         return err_sys("Hash     test failed!\n", ret);
     else
         test_pass("Hash     test passed!\n");
+#endif
 
 #ifdef WOLFSSL_RIPEMD
     if ( (ret = ripemd_test()) != 0)
@@ -3384,7 +3386,7 @@ exit:
 }
 #endif
 
-
+#ifndef NO_HASH_WRAPPER
 WOLFSSL_TEST_SUBROUTINE int hash_test(void)
 {
     wc_HashAlg       hash;
@@ -3689,6 +3691,7 @@ WOLFSSL_TEST_SUBROUTINE int hash_test(void)
 
     return 0;
 }
+#endif /* !NO_HASH_WRAPPER */
 
 #if !defined(NO_HMAC) && !defined(NO_MD5)
 WOLFSSL_TEST_SUBROUTINE int hmac_md5_test(void)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14565,6 +14565,7 @@ WOLFSSL_TEST_SUBROUTINE int rsa_test(void)
 #if !defined(WC_NO_RNG) && !defined(WC_NO_RSA_OAEP) && \
     ((!defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
     defined(WOLFSSL_PUBLIC_MP))
+    const char inStr[] = TEST_STRING;
 	const word32 inLen = (word32)TEST_STRING_SZ;
     const word32 outSz   = RSA_TEST_BYTES;
     const word32 plainSz = RSA_TEST_BYTES;
@@ -22159,7 +22160,9 @@ static int ecc_def_curve_test(WC_RNG *rng)
 #else
     ecc_key key[1];
 #endif
+#ifdef WC_NO_RNG
     word32 idx = 0;
+#endif
 
 #ifdef WOLFSSL_SMALL_STACK
     if (key == NULL)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -290,7 +290,7 @@ _Pragma("GCC diagnostic ignored \"-Wunused-function\"");
     #include <wolfssl/openssl/des.h>
 #endif
 
-#if defined(NO_FILESYSTEM)
+#if defined(NO_FILESYSTEM) || defined(WC_NO_RNG)
     #if !defined(USE_CERT_BUFFERS_1024) && !defined(USE_CERT_BUFFERS_2048) && \
         !defined(USE_CERT_BUFFERS_3072) && !defined(USE_CERT_BUFFERS_4096)
         #define USE_CERT_BUFFERS_2048
@@ -422,7 +422,8 @@ WOLFSSL_TEST_SUBROUTINE int scrypt_test(void);
         WOLFSSL_TEST_SUBROUTINE int  ecc_encrypt_test(void);
     #endif
     #if defined(USE_CERT_BUFFERS_256) && !defined(WOLFSSL_ATECC508A) && \
-        !defined(WOLFSSL_ATECC608A) && !defined(NO_ECC256)
+        !defined(WOLFSSL_ATECC608A) && !defined(NO_ECC256) && \
+        defined(HAVE_ECC_VERIFY) && defined(HAVE_ECC_SIGN)
         /* skip for ATECC508/608A, cannot import private key buffers */
         WOLFSSL_TEST_SUBROUTINE int ecc_test_buffers(void);
     #endif
@@ -1179,7 +1180,8 @@ initDefaultName();
             test_pass("ECC Enc  test passed!\n");
     #endif
     #if defined(USE_CERT_BUFFERS_256) && !defined(WOLFSSL_ATECC508A) && \
-        !defined(WOLFSSL_ATECC608A) && !defined(NO_ECC256)
+        !defined(WOLFSSL_ATECC608A) && !defined(NO_ECC256) && \
+        defined(HAVE_ECC_VERIFY) && defined(HAVE_ECC_SIGN)
         /* skip for ATECC508/608A, cannot import private key buffers */
         if ( (ret = ecc_test_buffers()) != 0)
             return err_sys("ECC buffer test failed!\n", ret);
@@ -11826,12 +11828,11 @@ byte GetEntropy(ENTROPY_CMD cmd, byte* out)
         static const char* certEccRsaPemFile = CERT_WRITE_TEMP_DIR "certeccrsa.pem";
         static const char* certEccRsaDerFile = CERT_WRITE_TEMP_DIR "certeccrsa.der";
     #endif
-    #if defined(HAVE_ECC_KEY_EXPORT)
+    #if defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG)
         static const char* eccCaKeyPemFile  = CERT_WRITE_TEMP_DIR "ecc-key.pem";
         static const char* eccPubKeyDerFile = CERT_WRITE_TEMP_DIR "ecc-public-key.der";
         static const char* eccCaKeyTempFile = CERT_WRITE_TEMP_DIR "ecc-key.der";
-
-    #ifdef HAVE_PKCS8
+    #if defined(HAVE_PKCS8) && !defined(WC_NO_RNG)
         static const char* eccPkcs8KeyDerFile = CERT_WRITE_TEMP_DIR "ecc-key-pkcs8.der";
     #endif
     #endif /* HAVE_ECC_KEY_EXPORT */
@@ -14561,15 +14562,15 @@ WOLFSSL_TEST_SUBROUTINE int rsa_test(void)
                      || defined(WOLFSSL_PUBLIC_MP)
     word32 idx = 0;
 #endif
-#if (!defined(WOLFSSL_RSA_VERIFY_ONLY) || defined(WOLFSSL_PUBLIC_MP)) && \
-                                 !defined(WC_NO_RSA_OAEP) && !defined(WC_NO_RNG)
-    const char inStr[] = TEST_STRING;
+#if !defined(WC_NO_RNG) && !defined(WC_NO_RSA_OAEP) && \
+    ((!defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
+    defined(WOLFSSL_PUBLIC_MP))
 	const word32 inLen = (word32)TEST_STRING_SZ;
     const word32 outSz   = RSA_TEST_BYTES;
     const word32 plainSz = RSA_TEST_BYTES;
 #endif
-#if (!defined(WOLFSSL_RSA_PUBLIC_ONLY) && \
-    !defined(WOLFSSL_RSA_VERIFY_ONLY)) || defined(WOLFSSL_PUBLIC_MP)
+#if (!defined(WOLFSSL_RSA_PUBLIC_ONLY) && !defined(WOLFSSL_RSA_VERIFY_ONLY) && \
+    !defined(WC_NO_RNG)) || defined(WOLFSSL_PUBLIC_MP)
     byte*  res;
 #endif
 #ifndef NO_SIG_WRAPPER
@@ -14589,8 +14590,9 @@ WOLFSSL_TEST_SUBROUTINE int rsa_test(void)
 #endif
 #endif
 
-#if (!defined(WOLFSSL_RSA_VERIFY_ONLY) || defined(WOLFSSL_PUBLIC_MP)) && \
-                                 !defined(WC_NO_RSA_OAEP) && !defined(WC_NO_RNG)
+#if !defined(WC_NO_RNG) && !defined(WC_NO_RSA_OAEP) && \
+    ((!defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
+    defined(WOLFSSL_PUBLIC_MP))
     DECLARE_VAR(in, byte, TEST_STRING_SZ, HEAP_HINT);
     DECLARE_VAR(out, byte, RSA_TEST_BYTES, HEAP_HINT);
     DECLARE_VAR(plain, byte, RSA_TEST_BYTES, HEAP_HINT);
@@ -14736,7 +14738,8 @@ WOLFSSL_TEST_SUBROUTINE int rsa_test(void)
         goto exit_rsa;
 #endif
 
-#if !defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)
+#if !defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_PUBLIC_ONLY) && \
+    !defined(WC_NO_RNG)
     do {
 #if defined(WOLFSSL_ASYNC_CRYPT)
         ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
@@ -14855,8 +14858,9 @@ WOLFSSL_TEST_SUBROUTINE int rsa_test(void)
     }
 #endif
 
-#if (!defined(WOLFSSL_RSA_PUBLIC_ONLY) && \
-    !defined(WOLFSSL_RSA_VERIFY_ONLY)) || defined(WOLFSSL_PUBLIC_MP)
+#if !defined(WC_NO_RNG) && !defined(WC_NO_RSA_OAEP) && \
+    ((!defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
+    defined(WOLFSSL_PUBLIC_MP))
     idx = (word32)ret;
     XMEMSET(plain, 0, plainSz);
     do {
@@ -16059,6 +16063,7 @@ static int dh_test_check_pubvalue(void)
     #define FFDHE_KEY_SIZE      (2048/8)
 #endif
 
+#ifndef WC_NO_RNG
 static int dh_ffdhe_test(WC_RNG *rng, const DhParams* params)
 {
     int    ret;
@@ -16217,7 +16222,7 @@ done:
 
     return ret;
 }
-
+#endif /* !WC_NO_RNG */
 #endif /* HAVE_FFDHE */
 
 WOLFSSL_TEST_SUBROUTINE int dh_test(void)
@@ -16225,7 +16230,9 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
     int    ret;
     word32 bytes;
     word32 idx = 0, privSz, pubSz, privSz2, pubSz2;
+#ifndef WC_NO_RNG
     WC_RNG rng;
+#endif
     int keyInit = 0;
 
 #define DH_TEST_TMP_SIZE 1024
@@ -16234,34 +16241,48 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
 #else
     #define DH_TEST_BUF_SIZE 512
 #endif
+#ifndef WC_NO_RNG
     word32 agreeSz = DH_TEST_BUF_SIZE;
     word32 agreeSz2 = DH_TEST_BUF_SIZE;
+#endif
 
 #ifdef WOLFSSL_SMALL_STACK
-    DhKey  *key = (DhKey *)XMALLOC(sizeof *key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    DhKey  *key2 = (DhKey *)XMALLOC(sizeof *key2, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    byte *tmp = (byte *)XMALLOC(DH_TEST_TMP_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    DhKey *key = (DhKey *)XMALLOC(sizeof *key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    DhKey *key2 = (DhKey *)XMALLOC(sizeof *key2, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    byte  *tmp = (byte *)XMALLOC(DH_TEST_TMP_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+#else
+    DhKey key[1];
+    DhKey key2[1];
+    byte  tmp[DH_TEST_TMP_SIZE];
+#endif
+
+#ifndef WC_NO_RNG
+#ifdef WOLFSSL_SMALL_STACK
+    
     byte *priv = (byte *)XMALLOC(DH_TEST_BUF_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     byte *pub = (byte *)XMALLOC(DH_TEST_BUF_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     byte *priv2 = (byte *)XMALLOC(DH_TEST_BUF_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     byte *pub2 = (byte *)XMALLOC(DH_TEST_BUF_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     byte *agree = (byte *)XMALLOC(DH_TEST_BUF_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     byte *agree2 = (byte *)XMALLOC(DH_TEST_BUF_SIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-
-    if ((tmp == NULL) || (priv == NULL) || (pub == NULL) ||
-	(priv2 == NULL) || (pub2 == NULL) || (agree == NULL) ||
-	(agree2 == NULL))
+    if (priv == NULL || pub == NULL || priv2 == NULL || pub2 == NULL || 
+            agree == NULL || agree2 == NULL) {
         ERROR_OUT(-8100, done);
+    }
 #else
-    DhKey  key[1];
-    DhKey  key2[1];
-    byte tmp[DH_TEST_TMP_SIZE];
     byte priv[DH_TEST_BUF_SIZE];
     byte pub[DH_TEST_BUF_SIZE];
     byte priv2[DH_TEST_BUF_SIZE];
     byte pub2[DH_TEST_BUF_SIZE];
     byte agree[DH_TEST_BUF_SIZE];
     byte agree2[DH_TEST_BUF_SIZE];
+#endif
+#endif /* !WC_NO_RNG */
+
+#ifdef WOLFSSL_SMALL_STACK
+    if (key == NULL || key2 == NULL || tmp == NULL) {
+        ERROR_OUT(-8100, done);
+    }
 #endif
 
 #ifdef USE_CERT_BUFFERS_1024
@@ -16301,7 +16322,10 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
     privSz = DH_TEST_BUF_SIZE;
     privSz2 = DH_TEST_BUF_SIZE;
 
+#ifndef WC_NO_RNG
     XMEMSET(&rng, 0, sizeof(rng));
+#endif
+
     /* Use API for coverage. */
     ret = wc_InitDhKey(key);
     if (ret != 0) {
@@ -16342,6 +16366,7 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
     }
 #endif
 
+#ifndef WC_NO_RNG
 #ifndef HAVE_FIPS
     ret = wc_InitRng_ex(&rng, HEAP_HINT, devId);
 #else
@@ -16386,6 +16411,7 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
     if (agreeSz != agreeSz2 || XMEMCMP(agree, agree2, agreeSz)) {
         ERROR_OUT(-8115, done);
     }
+#endif /* !WC_NO_RNG */
 
 #if defined(WOLFSSL_KEY_GEN) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
     if (wc_DhCheckPrivKey(NULL, NULL, 0) != BAD_FUNC_ARG)
@@ -16447,6 +16473,7 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
     }
 #endif /* WOLFSSL_DH_EXTRA */
 
+#ifndef WC_NO_RNG
     ret = dh_generate_test(&rng);
     if (ret != 0)
         ERROR_OUT(-8126, done);
@@ -16454,6 +16481,7 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
     ret = dh_fips_generate_test(&rng);
     if (ret != 0)
         ERROR_OUT(-8127, done);
+#endif /* !WC_NO_RNG */
 
 #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
     ret = dh_test_check_pubvalue();
@@ -16461,6 +16489,7 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
         ERROR_OUT(-8128, done);
 #endif
 
+#ifndef WC_NO_RNG
     /* Specialized code for key gen when using FFDHE-2048 and FFDHE-3072. */
     #ifdef HAVE_FFDHE_2048
     ret = dh_ffdhe_test(&rng, wc_Dh_ffdhe2048_Get());
@@ -16472,12 +16501,13 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
     if (ret != 0)
         ERROR_OUT(-8130, done);
     #endif
+#endif /* !WC_NO_RNG */
 
     wc_FreeDhKey(key);
     keyInit = 0;
 
 #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && \
-    !defined(WOLFSSL_OLD_PRIME_CHECK)
+    !defined(WOLFSSL_OLD_PRIME_CHECK) && !defined(WC_NO_RNG)
     /* Test Check Key */
     ret = wc_DhSetCheckKey(key, dh_p, sizeof(dh_p), dh_g, sizeof(dh_g),
                            NULL, 0, 0, &rng);
@@ -16488,7 +16518,9 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
 
 done:
 
+#ifndef WC_NO_RNG
     wc_FreeRng(&rng);
+#endif
 
 #ifdef WOLFSSL_SMALL_STACK
     if (key) {
@@ -20649,7 +20681,7 @@ static int ecc_test_make_pub(WC_RNG* rng)
     byte *tmp = (byte *)XMALLOC(ECC_BUFSIZE, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 #else
     ecc_key key[1];
-#if defined(HAVE_ECC_DHE) && defined(HAVE_ECC_KEY_EXPORT)
+#if defined(HAVE_ECC_DHE) && defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG)
     ecc_key pub[1];
 #endif
     byte exportBuf[ECC_BUFSIZE];
@@ -20777,7 +20809,8 @@ static int ecc_test_make_pub(WC_RNG* rng)
     }
 #endif
 
-#ifdef HAVE_ECC_SIGN
+#if defined(HAVE_ECC_SIGN) && (!defined(ECC_TIMING_RESISTANT) || \
+    (defined(ECC_TIMING_RESISTANT) && !defined(WC_NO_RNG)))
     tmpSz = ECC_BUFSIZE;
     ret = 0;
     do {
@@ -20822,7 +20855,7 @@ static int ecc_test_make_pub(WC_RNG* rng)
 
 #endif /* HAVE_ECC_SIGN */
 
-#if defined(HAVE_ECC_DHE) && defined(HAVE_ECC_KEY_EXPORT)
+#if defined(HAVE_ECC_DHE) && defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG)
     /* now test private only key with creating a shared secret */
     x = ECC_BUFSIZE;
     ret = wc_ecc_export_private_only(key, exportBuf, &x);
@@ -20878,7 +20911,7 @@ static int ecc_test_make_pub(WC_RNG* rng)
         ERROR_OUT(-9870, done);
     }
     TEST_SLEEP();
-#endif /* HAVE_ECC_DHE && HAVE_ECC_KEY_EXPORT */
+#endif /* HAVE_ECC_DHE && HAVE_ECC_KEY_EXPORT && !WC_NO_RNG */
 
     ret = 0;
 
@@ -20906,7 +20939,7 @@ done:
     return ret;
 }
 
-#if defined(HAVE_ECC_KEY_EXPORT) && !defined(NO_ASN_CRYPT)
+#if defined(HAVE_ECC_KEY_EXPORT) && !defined(NO_ASN_CRYPT) && !defined(WC_NO_RNG)
 static int ecc_test_key_decode(WC_RNG* rng, int keySize)
 {
     int ret;
@@ -20987,7 +21020,7 @@ static int ecc_test_key_decode(WC_RNG* rng, int keySize)
 #endif /* HAVE_ECC_KEY_EXPORT && !NO_ASN_CRYPT */
 #endif /* HAVE_ECC_KEY_IMPORT */
 
-#if defined(HAVE_ECC_KEY_EXPORT) && !defined(NO_ASN_CRYPT)
+#if defined(HAVE_ECC_KEY_EXPORT) && !defined(NO_ASN_CRYPT) && !defined(WC_NO_RNG)
 static int ecc_test_key_gen(WC_RNG* rng, int keySize)
 {
     int    ret = 0;
@@ -21088,7 +21121,7 @@ done:
 static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     int curve_id, const ecc_set_type* dp)
 {
-#if (defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)) && \
+#if (defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)) && !defined(WC_NO_RNG) && \
     !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
     DECLARE_VAR(sharedA, byte, ECC_SHARED_SIZE, HEAP_HINT);
     DECLARE_VAR(sharedB, byte, ECC_SHARED_SIZE, HEAP_HINT);
@@ -21098,7 +21131,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     DECLARE_VAR(exportBuf, byte, ECC_KEY_EXPORT_BUF_SIZE, HEAP_HINT);
 #endif
     word32  x = 0;
-#if (defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)) && \
+#if (defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)) && !defined(WC_NO_RNG) && \
     !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
     word32  y;
 #endif
@@ -21112,18 +21145,20 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
 #endif /* HAVE_ECC_SIGN */
     int     ret;
 #ifdef WOLFSSL_SMALL_STACK
-    ecc_key *userA = (ecc_key *)XMALLOC(sizeof *userA, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER),
-        *userB = (ecc_key *)XMALLOC(sizeof *userB, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER),
-        *pubKey = (ecc_key *)XMALLOC(sizeof *pubKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    ecc_key *userA = (ecc_key *)XMALLOC(sizeof *userA, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    ecc_key *userB = (ecc_key *)XMALLOC(sizeof *userB, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    ecc_key *pubKey = (ecc_key *)XMALLOC(sizeof *pubKey, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 #else
-    ecc_key userA[1],
-        userB[1],
-        pubKey[1];
+    ecc_key userA[1];
+    ecc_key userB[1];
+    ecc_key pubKey[1];
 #endif
+#ifndef WC_NO_RNG
     int     curveSize;
+#endif
 
 #ifdef DECLARE_VAR_IS_HEAP_ALLOC
-#if (defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)) && \
+#if (defined(HAVE_ECC_DHE) || defined(HAVE_ECC_CDH)) && !defined(WC_NO_RNG) && \
     !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
     if (sharedA == NULL || sharedB == NULL)
         ERROR_OUT(-9900, done);
@@ -21176,6 +21211,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     }
 #endif
 
+#ifndef WC_NO_RNG
     ret = wc_ecc_make_key_ex(rng, keySize, userA, curve_id);
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &userA->asyncDev, WC_ASYNC_FLAG_NONE);
@@ -21293,7 +21329,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     wc_ecc_set_flags(userA, 0);
     wc_ecc_set_flags(userB, 0);
 #endif /* HAVE_ECC_CDH */
-#endif /* WOLFSSL_ATECC508A */
+#endif /* !WOLFSSL_ATECC508A && WOLFSSL_ATECC608A */
 
 #ifdef HAVE_ECC_KEY_EXPORT
     x = ECC_KEY_EXPORT_BUF_SIZE;
@@ -21370,11 +21406,14 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
         TEST_SLEEP();
     #endif /* HAVE_ECC_DHE */
     #endif /* HAVE_COMP_KEY */
-#endif /* WOLFSSL_ATECC508A */
+
+#endif /* !WOLFSSL_ATECC508A && !WOLFSSL_ATECC608A */
+#endif /* !WC_NO_RNG */
 
 #endif /* HAVE_ECC_KEY_IMPORT */
 #endif /* HAVE_ECC_KEY_EXPORT */
 
+#if !defined(ECC_TIMING_RESISTANT) || (defined(ECC_TIMING_RESISTANT) && !defined(WC_NO_RNG))
 #ifdef HAVE_ECC_SIGN
     /* ECC w/out Shamir has issue with all 0 digest */
     /* WC_BIGINT doesn't have 0 len well on hardware */
@@ -21454,13 +21493,16 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     }
 #endif /* HAVE_ECC_VERIFY */
 #endif /* HAVE_ECC_SIGN */
+#endif /* !ECC_TIMING_RESISTANT || (ECC_TIMING_RESISTANT && !WC_NO_RNG) */
 
-#if defined(HAVE_ECC_KEY_EXPORT) && !defined(WOLFSSL_ATECC508) && \
-    !defined(WOLFSSL_ATECC608A)
+#if defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG) && \
+    !defined(WOLFSSL_ATECC508) && !defined(WOLFSSL_ATECC608A)
     x = ECC_KEY_EXPORT_BUF_SIZE;
     ret = wc_ecc_export_private_only(userA, exportBuf, &x);
     if (ret != 0)
         ERROR_OUT(-9942, done);
+#else
+    (void)exportBuf;
 #endif /* HAVE_ECC_KEY_EXPORT */
 
 done:
@@ -21496,6 +21538,10 @@ done:
     FREE_VAR(digest, HEAP_HINT);
 #endif
 
+    (void)keySize;
+    (void)curve_id;
+    (void)rng;
+
     return ret;
 }
 
@@ -21529,7 +21575,7 @@ static int ecc_test_curve(WC_RNG* rng, int keySize)
 #endif
 
 #if defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT) && \
-    !defined(NO_ASN_CRYPT)
+    !defined(NO_ASN_CRYPT) && !defined(WC_NO_RNG)
     ret = ecc_test_key_decode(rng, keySize);
     if (ret < 0) {
         if (ret == ECC_CURVE_OID_E) {
@@ -21542,7 +21588,7 @@ static int ecc_test_curve(WC_RNG* rng, int keySize)
     }
 #endif
 
-#if defined(HAVE_ECC_KEY_EXPORT) && !defined(NO_ASN_CRYPT)
+#if defined(HAVE_ECC_KEY_EXPORT) && !defined(NO_ASN_CRYPT) && !defined(WC_NO_RNG)
     ret = ecc_test_key_gen(rng, keySize);
     if (ret < 0) {
         if (ret == ECC_CURVE_OID_E) {
@@ -22056,7 +22102,7 @@ done:
 }
 #endif
 
-#ifdef HAVE_ECC_DHE
+#if defined(HAVE_ECC_DHE) && !defined(WC_NO_RNG)
 static int ecc_ssh_test(ecc_key* key, WC_RNG* rng)
 {
     int    ret;
@@ -22102,7 +22148,7 @@ static int ecc_ssh_test(ecc_key* key, WC_RNG* rng)
     TEST_SLEEP();
     return 0;
 }
-#endif /* HAVE_ECC_DHE */
+#endif /* HAVE_ECC_DHE && !WC_NO_RNG */
 #endif
 
 static int ecc_def_curve_test(WC_RNG *rng)
@@ -22113,6 +22159,7 @@ static int ecc_def_curve_test(WC_RNG *rng)
 #else
     ecc_key key[1];
 #endif
+    word32 idx = 0;
 
 #ifdef WOLFSSL_SMALL_STACK
     if (key == NULL)
@@ -22133,9 +22180,16 @@ static int ecc_def_curve_test(WC_RNG *rng)
         goto done;
     }
 
+#ifndef WC_NO_RNG
     ret = wc_ecc_make_key(rng, ECC_KEYGEN_SIZE, key);
 #if defined(WOLFSSL_ASYNC_CRYPT)
     ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_NONE);
+#endif
+#else
+    /* use test ECC key */
+    ret = wc_EccPrivateKeyDecode(ecc_key_der_256, &idx, key,
+        (word32)sizeof_ecc_key_der_256);
+    (void)rng;
 #endif
     if (ret != 0) {
         ret = -10092;
@@ -22161,7 +22215,7 @@ static int ecc_def_curve_test(WC_RNG *rng)
     if (ret < 0)
         goto done;
 #endif
-#ifdef HAVE_ECC_DHE
+#if defined(HAVE_ECC_DHE) && !defined(WC_NO_RNG)
     ret = ecc_ssh_test(key, rng);
     if (ret < 0)
         goto done;
@@ -22732,16 +22786,26 @@ static int ecc_test_allocator(WC_RNG* rng)
 {
     int ret = 0;
     ecc_key* key;
+#ifdef WC_NO_RNG
+    word32 idx = 0;
+#endif
 
     key = wc_ecc_key_new(HEAP_HINT);
     if (key == NULL) {
         ERROR_OUT(-10150, exit);
     }
 
+#ifndef WC_NO_RNG
     ret = wc_ecc_make_key(rng, ECC_KEYGEN_SIZE, key);
     if (ret != 0) {
         ERROR_OUT(-10151, exit);
     }
+#else
+    /* use test ECC key */
+    ret = wc_EccPrivateKeyDecode(ecc_key_der_256, &idx, key,
+        (word32)sizeof_ecc_key_der_256);
+    (void)rng;
+#endif
 
 exit:
     wc_ecc_key_free(key);
@@ -23602,6 +23666,7 @@ WOLFSSL_TEST_SUBROUTINE int ecc_test_buffers(void)
     if (ret != 0)
         ERROR_OUT(-10423, done);
 
+#ifndef WC_NO_RNG
 #ifndef HAVE_FIPS
     ret = wc_InitRng_ex(&rng, HEAP_HINT, devId);
 #else
@@ -23618,6 +23683,7 @@ WOLFSSL_TEST_SUBROUTINE int ecc_test_buffers(void)
         ERROR_OUT(-10425, done);
     }
 #endif
+#endif /* !WC_NO_RNG */
 
 #if defined(HAVE_ECC_ENCRYPT) && defined(HAVE_HKDF)
     {

--- a/wolfssl/wolfcrypt/hash.h
+++ b/wolfssl/wolfcrypt/hash.h
@@ -88,7 +88,7 @@ enum wc_HashFlags {
 #endif
 };
 
-
+#ifndef NO_HASH_WRAPPER
 typedef union {
     #ifndef NO_MD5
         wc_Md5 md5;
@@ -112,6 +112,7 @@ typedef union {
         wc_Sha3 sha3;
     #endif
 } wc_HashAlg;
+#endif /* !NO_HASH_WRAPPER */
 
 /* Find largest possible digest size
    Note if this gets up to the size of 80 or over check smallstack build */
@@ -150,6 +151,8 @@ WOLFSSL_API enum wc_HashType wc_OidGetHash(int oid);
 #endif
 
 WOLFSSL_API enum wc_HashType wc_HashTypeConvert(int hashType);
+
+#ifndef NO_HASH_WRAPPER
 
 WOLFSSL_API int wc_HashGetDigestSize(enum wc_HashType hash_type);
 WOLFSSL_API int wc_HashGetBlockSize(enum wc_HashType hash_type);
@@ -214,6 +217,8 @@ WOLFSSL_API int wc_Sha3_512Hash(const byte*, word32, byte*);
 WOLFSSL_API int wc_Shake256Hash(const byte*, word32, byte*, word32);
 #endif
 #endif /* WOLFSSL_SHA3 */
+
+#endif /* !NO_HASH_WRAPPER */
 
 enum max_prf {
 #ifdef HAVE_FFDHE_8192

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1796,7 +1796,9 @@ extern void uITRON4_free(void *p) ;
 /* ECC Configs */
 #ifdef HAVE_ECC
     /* By default enable Sign, Verify, DHE, Key Import and Key Export unless explicitly disabled */
-    #ifndef NO_ECC_SIGN
+    #if !defined(NO_ECC_SIGN) && \
+            (!defined(ECC_TIMING_RESISTANT) || \
+            (defined(ECC_TIMING_RESISTANT) && !defined(WC_NO_RNG)))
         #undef HAVE_ECC_SIGN
         #define HAVE_ECC_SIGN
     #endif
@@ -1808,7 +1810,7 @@ extern void uITRON4_free(void *p) ;
         #undef HAVE_ECC_CHECK_KEY
         #define HAVE_ECC_CHECK_KEY
     #endif
-    #ifndef NO_ECC_DHE
+    #if !defined(NO_ECC_DHE) && !defined(WC_NO_RNG)
         #undef HAVE_ECC_DHE
         #define HAVE_ECC_DHE
     #endif


### PR DESCRIPTION
If all hash algorithms are disabled `wc_HashAlg` could report empty union. ZD 11585.

./configure --enable-cryptonly --disable-sha --disable-sha224 --disable-sha384 --disable-sha512 --disable-shake256 --disable-sha3 --disable-md5 --disable-hashdrbg CFLAGS="-DNO_SHA256 -DNO_HASH_WRAPPER -DWC_NO_RNG -DWC_NO_RSA_OAEP -DNO_HMAC -DNO_SIG_WRAPPER" --disable-tls13 --disable-rsapss && make