### PR TITLE
Fixes for warnings in Windows and failing `wc_BufferKeyEncrypt` test

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -11371,8 +11371,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     if (ssl->options.side == WOLFSSL_CLIENT_END) {
                 #ifdef HAVE_CERTIFICATE_STATUS_REQUEST
                         if (ssl->status_request) {
-                            args->fatal = TLSX_CSR_InitRequest(ssl->extensions,
-                                                    args->dCert, ssl->heap);
+                            args->fatal = (TLSX_CSR_InitRequest(ssl->extensions,
+                                                args->dCert, ssl->heap) != 0);
                             doLookup = 0;
                         #if defined(WOLFSSL_TLS13)
                             if (ssl->options.tls1_3) {
@@ -11399,8 +11399,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 #endif /* HAVE_CERTIFICATE_STATUS_REQUEST */
                 #ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
                         if (ssl->status_request_v2) {
-                            args->fatal = TLSX_CSR2_InitRequests(ssl->extensions,
-                                                    args->dCert, 1, ssl->heap);
+                            args->fatal = (TLSX_CSR2_InitRequests(ssl->extensions,
+                                                 args->dCert, 1, ssl->heap) != 0);
                             doLookup = 0;
                         }
                 #endif /* HAVE_CERTIFICATE_STATUS_REQUEST_V2 */
@@ -19955,6 +19955,7 @@ static byte MinHashAlgo(WOLFSSL* ssl)
         return sha256_mac;
     }
 #endif /* WOLFSSL_NO_TLS12 */
+    (void)ssl;
     return sha_mac;
 }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -27701,8 +27701,7 @@ long wolfSSL_set_tlsext_status_type(WOLFSSL *s, int type)
     }
 
     if (type == TLSEXT_STATUSTYPE_ocsp){
-        int r = 0;
-        r = TLSX_UseCertificateStatusRequest(&s->extensions, type, 0, s,
+        int r = TLSX_UseCertificateStatusRequest(&s->extensions, (byte)type, 0, s,
                                                              s->heap, s->devId);
         return (long)r;
     } else {
@@ -47829,7 +47828,8 @@ int wolfSSL_get_ocsp_producedDate_tm(WOLFSSL *ssl, struct tm *produced_tm) {
     if (produced_tm == NULL)
         return BAD_FUNC_ARG;
 
-    if (ExtractDate(ssl->ocspProducedDate, ssl->ocspProducedDateFormat, produced_tm, &idx))
+    if (ExtractDate(ssl->ocspProducedDate,
+            (unsigned char)ssl->ocspProducedDateFormat, produced_tm, &idx))
         return 0;
     else
         return ASN_PARSE_E;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -6243,12 +6243,14 @@ WOLFSSL_TEST_SUBROUTINE int des_test(void)
         if (ret != BAD_FUNC_ARG)
             return -5008;
 
-        /* Test invalid hash type */
+    #ifndef NO_PWDBASED
+        /* Test invalid hash type - only applies to wc_PBKDF1 call */
         ret = wc_BufferKeyEncrypt(&info, cipher, sizeof(cipher), key,
                 sizeof(key), WC_HASH_TYPE_NONE);
         if (ret == 0)
             return -5009;
     }
+    #endif /* !NO_PWDBASED */
 #endif
 
     return 0;


### PR DESCRIPTION
* Fixes for cast and unused warnings in Windows.
* Fix for failing `wc_BufferKeyEncrypt` with PBKDF disabled.
ZD 11759