### PR TITLE
Fix PKCS8 build config

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -2773,7 +2773,7 @@ int ToTraditional(byte* input, word32 sz)
 
 #endif /* HAVE_PKCS8 || HAVE_PKCS12 */
 
-#ifdef HAVE_PKCS8
+#if defined(HAVE_PKCS8) && !defined(NO_CERTS)
 
 /* find beginning of traditional key inside PKCS#8 unencrypted buffer
  * return traditional length on success, with inOutIdx at beginning of
@@ -2867,7 +2867,6 @@ int wc_CreatePKCS8Key(byte* out, word32* outSz, byte* key, word32 keySz,
          *  no header information just INTEGER */
         sz = SetMyVersion(PKCS8v0, out + keyIdx, 0);
         tmpSz += sz; keyIdx += sz;
-
         /*  privateKeyAlgorithm PrivateKeyAlgorithmIdentifier */
         sz = 0; /* set sz to 0 and get privateKey oid buffer size needed */
         if (curveOID != NULL && oidSz > 0) {
@@ -2903,7 +2902,7 @@ int wc_CreatePKCS8Key(byte* out, word32* outSz, byte* key, word32 keySz,
         return tmpSz + sz;
 }
 
-#endif /* HAVE_PKCS8 */
+#endif /* HAVE_PKCS8 && !NO_CERTS */
 
 #if defined(HAVE_PKCS12) || !defined(NO_CHECK_PRIVATE_KEY)
 /* check that the private key is a pair for the public key

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11825,10 +11825,11 @@ byte GetEntropy(ENTROPY_CMD cmd, byte* out)
         static const char* eccCaKeyPemFile  = CERT_WRITE_TEMP_DIR "ecc-key.pem";
         static const char* eccPubKeyDerFile = CERT_WRITE_TEMP_DIR "ecc-public-key.der";
         static const char* eccCaKeyTempFile = CERT_WRITE_TEMP_DIR "ecc-key.der";
-    #endif
+
     #ifdef HAVE_PKCS8
         static const char* eccPkcs8KeyDerFile = CERT_WRITE_TEMP_DIR "ecc-key-pkcs8.der";
     #endif
+    #endif /* HAVE_ECC_KEY_EXPORT */
     #if defined(WOLFSSL_CERT_GEN) || \
             (defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_TEST_CERT))
         static const char* certEccDerFile = CERT_WRITE_TEMP_DIR "certecc.der";


### PR DESCRIPTION
This PR fixes a build and linker error for a non-standard configurations:

```
./configure --enable-sp=small,nomalloc,384  --enable-cryptonly --enable-ecc CFLAGS="-DNO_ECC256 -DWOLFSSL_SP_NO_256 -DNO_ECC_KEY_EXPORT -DNO_ASN_TIME -DNO_CERTS"  && make && wolfcrypt/test/testwolfcrypt
```

```
wolfcrypt/test/test.c:11832:28: error: ‘eccPkcs8KeyDerFile’ defined but not used [-Werror=unused-variable]
11832 |         static const char* eccPkcs8KeyDerFile = CERT_WRITE_TEMP_DIR "ecc-key-pkcs8.der";
      |                            ^~~~~~~~~~~~~~~~~~
  CCLD     src/libwolfssl.la

...

/usr/bin/ld: wolfcrypt/src/.libs/src_libwolfssl_la-asn.o: in function `wc_CreatePKCS8Key':
asn.c:(.text+0x1cf2): undefined reference to `SetMyVersion
```