### PR TITLE
Enable Base64 as part of --enable-all.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -385,6 +385,7 @@ then
     test "$enable_enckeys" = "" && enable_enckeys=yes
     test "$enable_hashflags" = "" && enable_hashflags=yes
     test "$enable_defaultdhparams" = "" && enable_defaultdhparams=yes
+    test "$enable_base64encode" = "" && enable_base64encode=yes
     test "$enable_arc4" = "" && enable_arc4=yes
     test "$enable_des3" = "" && enable_des3=yes
     test "$enable_nullcipher" = "" && enable_nullcipher=yes


### PR DESCRIPTION
Part of an effort to standardize build options across distributions.

When building with all options, this includes `Base64`, a feature that
was requested in the past.

This commit passed Debian's Salsa CI pipeline [1] as part of a larger
commit streamlining the build options for distributions. [2]

A related pull request by @douzzer activated reproducible builds for
distributions by default. [3]

Thanks to @dgarske for his generous contributions to this commit!

[1] https://salsa.debian.org/lechner/wolfssl/-/pipelines/233601
[2] https://salsa.debian.org/lechner/wolfssl/-/blob/debian/master/debian/patches/standardize-distro-options.patch
[3] https://github.com/wolfSSL/wolfssl/commit/e30b3d35549ed4ec07cd63bfffc9ae80bf2a3b16