### PR TITLE
Fix for InTime RTOS v5 random

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2237,16 +2237,27 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
         uint32_t randval;
-        word32 len = sizeof(randval);
+        word32 len;
 
         if (output == NULL) {
             return BUFFER_E;
         }
 
+    #ifdef INTIMEVER
+        /* If INTIMEVER exists then it is INTIME RTOS v6 or later */
+        #define INTIME_RAND_FUNC arc4random
+        len = 4;
+    #else
+        /* v5 and older */
+        #define INTIME_RAND_FUNC rand
+        srand(time(0));
+        len = 2; /* don't use all 31 returned bits */
+    #endif
+
         while (sz > 0) {
             if (sz < len)
                 len = sz;
-            randval = rand(); /* returns 32-bits of random */
+            randval = INTIME_RAND_FUNC();
             XMEMCPY(output, &randval, len);
             output += len;
             sz -= len;

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2236,8 +2236,8 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 #elif defined(INTIME_RTOS)
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
-        uint32_t rand;
-        word32 len = sizeof(rand);
+        uint32_t randval;
+        word32 len = sizeof(randval);
 
         if (output == NULL) {
             return BUFFER_E;
@@ -2246,8 +2246,8 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         while (sz > 0) {
             if (sz < len)
                 len = sz;
-            rand = arc4random(); /* returns 32-bits of random */
-            XMEMCPY(output, &rand, len);
+            randval = rand(); /* returns 32-bits of random */
+            XMEMCPY(output, &randval, len);
             output += len;
             sz -= len;
         }

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2236,19 +2236,24 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 #elif defined(INTIME_RTOS)
     int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     {
-        int ret = 0;
-
-        (void)os;
+        uint32_t rand;
+        word32 len = sizeof(rand);
 
         if (output == NULL) {
             return BUFFER_E;
         }
 
-        /* Note: Investigate better solution */
-        /* no return to check */
-        arc4random_buf(output, sz);
+        while (sz > 0) {
+            if (sz < len)
+                len = sz;
+            rand = arc4random(); /* returns 32-bits of random */
+            XMEMCPY(output, &rand, len);
+            output += len;
+            sz -= len;
+        }
+        (void)os;
 
-        return ret;
+        return 0;
     }
 
 #elif defined(WOLFSSL_WICED)


### PR DESCRIPTION
The `arc4random_buf` wasn't added until v6, so opting to use `arc4random`.
ZD 11760