### PR TITLE
Clean up CMake option strings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ find_package(Threads)
 
 # Support for disabling all ASM
 set(WOLFSSL_ASM_HELP_STRING "Enables option for assembly (default: enabled)")
-option(WOLFSSL_ASM ${WOLFSSL_ASM_HELP_STRING} "yes")
+add_option("WOLFSSL_ASM" ${WOLFSSL_ASM_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_ASM)
     list(APPEND WOLFSSL_DEFINITIONS
@@ -192,7 +192,7 @@ endif()
 
 # Single threaded
 set(WOLFSSL_SINGLE_THREADED_HELP_STRING "Enable wolfSSL single threaded (default: disabled)")
-option(WOLFSSL_SINGLE_THREADED ${WOLFSSL_SINGLE_THREADED_HELP_STRING} "no")
+add_option("WOLFSSL_SINGLE_THREADED" ${WOLFSSL_SINGLE_THREADED_HELP_STRING} "no" "yes;no")
 
 # TODO: Logic here isn't complete, yet (see AX_PTHREAD)
 if(NOT WOLFSSL_SINGLE_THREADED)
@@ -209,7 +209,7 @@ endif()
 
 # TLS v1.3
 set(WOLFSSL_TLS13_HELP_STRING "Enable wolfSSL TLS v1.3 (default: enabled)")
-option(WOLFSSL_TLS13 ${WOLFSSL_TLS13_HELP_STRING} "yes")
+add_option("WOLFSSL_TLS13" ${WOLFSSL_TLS13_HELP_STRING} "yes" "yes;no")
 
 if("${FIPS_VERSION}" STREQUAL "v1")
     override_cache(WOLFSSL_TLS13 "no")
@@ -220,7 +220,7 @@ endif()
 
 # RNG
 set(WOLFSSL_RNG_HELP_STRING "Enable compiling and using RNG (default: enabled)")
-option(WOLFSSL_RNG ${WOLFSSL_RNG_HELP_STRING} "yes")
+add_option("WOLFSSL_RNG" ${WOLFSSL_RNG_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_RNG)
     list(APPEND WOLFSSL_DEFINITIONS "-DWC_NO_RNG")
@@ -247,7 +247,7 @@ endif()
 
 # Harden, enable Timing Resistance and Blinding by default
 set(WOLFSSL_HARDEN_HELP_STRING "Enable Hardened build, Enables Timing Resistance and Blinding (default: enabled)")
-option(WOLFSSL_HARDEN ${WOLFSSL_HARDEN_HELP_STRING} "yes")
+add_option("WOLFSSL_HARDEN" ${WOLFSSL_HARDEN_HELP_STRING} "yes" "yes;no")
 
 if(WOLFSSL_HARDEN)
     list(APPEND WOLFSSL_DEFINITIONS "-DTFM_TIMING_RESISTANT" "-DECC_TIMING_RESISTANT")
@@ -279,7 +279,7 @@ set(WOLFSSL_SLOW_MATH "yes")
 
 # AES-CBC
 set(WOLFSSL_AESCBC_HELP_STRING "Enable wolfSSL AES-CBC support (default: enabled)")
-option(WOLFSSL_AESCBC ${WOLFSSL_AESCBC_HELP_STRING} "yes")
+add_option("WOLFSSL_AESCBC" ${WOLFSSL_AESCBC_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_AESCBC)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_AES_CBC")
@@ -287,8 +287,7 @@ endif()
 
 # AES-GCM
 set(WOLFSSL_AESGCM_HELP_STRING "Enable wolfSSL AES-GCM support (default: enabled)")
-set(WOLFSSL_AESGCM "yes" CACHE STRING ${WOLFSSL_AESGCM_HELP_STRING})
-set_property(CACHE WOLFSSL_AESGCM PROPERTY STRINGS "yes" "no" "table" "small" "word32")
+add_option("WOLFSSL_AESGCM" ${WOLFSSL_AESGCM_HELP_STRING} "yes" "yes;no;table;small;word32")
 
 # leanpsk and leantls don't need gcm
 if(WOLFSSL_LEAN_PSK OR (WOLFSSL_LEAN_TLS AND NOT WOLFSSL_TLS13))
@@ -342,7 +341,7 @@ if(("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64") OR
     endif()
 endif()
 set(WOLFSSL_SHA224_HELP_STRING "Enable wolfSSL SHA-224 support (default: enabled on x86_64/aarch64)")
-option(WOLFSSL_SHA224 ${WOLFSSL_SHA224_HELP_STRING} ${SHA224_DEFAULT})
+add_option("WOLFSSL_SHA224" ${WOLFSSL_SHA224_HELP_STRING} ${SHA224_DEFAULT} "yes;no")
 
 # SHA3
 set(SHA3_DEFAULT "no")
@@ -353,17 +352,15 @@ if(("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64") OR
     endif()
 endif()
 set(WOLFSSL_SHA3_HELP_STRING "Enable wolfSSL SHA-3 support (default: enabled on x86_64/aarch64)")
-set(WOLFSSL_SHA3 ${SHA3_DEFAULT} CACHE STRING ${WOLFSSL_SHA3_HELP_STRING})
-set_property(CACHE WOLFSSL_SHA3 PROPERTY STRINGS "yes" "no" "small")
+add_option("WOLFSSL_SHA3" ${WOLFSSL_SHA3_HELP_STRING} ${SHA3_DEFAULT} "yes;no;small")
 
 # SHAKE256
 set(WOLFSSL_SHAKE256_HELP_STRING "Enable wolfSSL SHAKE256 support (default: enabled on x86_64/aarch64)")
-set(WOLFSSL_SHAKE256 "no" CACHE STRING ${WOLFSSL_SHAKE256_HELP_STRING})
-set_property(CACHE WOLFSSL_SHAKE256 PROPERTY STRINGS "yes" "no" "small")
+add_option("WOLFSSL_SHAKE256" ${WOLFSSL_SHAKE256_HELP_STRING} "no" "yes;no;small")
 
 # SHA512
 set(WOLFSSL_SHA512_HELP_STRING "Enable wolfSSL SHA-512 support (default: enabled)")
-option(WOLFSSL_SHA512 ${WOLFSSL_SHA512_HELP_STRING} "yes")
+add_option("WOLFSSL_SHA512" ${WOLFSSL_SHA512_HELP_STRING} "yes" "yes;no")
 
 # options that don't require sha512
 if(WOLFSSL_LEAN_PSK OR
@@ -386,7 +383,7 @@ endif()
 
 # SHA384
 set(WOLFSSL_SHA384_HELP_STRING "Enable wolfSSL SHA-384 support (default: enabled)")
-option(WOLFSSL_SHA384 ${WOLFSSL_SHA384_HELP_STRING} "yes")
+add_option("WOLFSSL_SHA384" ${WOLFSSL_SHA384_HELP_STRING} "yes" "yes;no")
 
 # options that don't require sha384
 if(WOLFSSL_LEAN_PSK OR
@@ -417,7 +414,7 @@ endif()
 
 # HKDF
 set(WOLFSSL_HKDF_HELP_STRING "Enable HKDF (HMAC-KDF) support (default: disabled)")
-option(WOLFSSL_HKDF ${WOLFSSL_HKDF_HELP_STRING} "no")
+add_option("WOLFSSL_HKDF" ${WOLFSSL_HKDF_HELP_STRING} "no" "yes;no")
 
 if(WOLFSSL_TLS13)
     override_cache(WOLFSSL_HKDF "yes")
@@ -431,7 +428,7 @@ endif()
 
 # DSA
 set(WOLFSSL_DSA_HELP_STRING "Enable DSA (default: disabled)")
-option(WOLFSSL_DSA ${WOLFSSL_DSA_HELP_STRING} "no")
+add_option("WOLFSSL_DSA" ${WOLFSSL_DSA_HELP_STRING} "no" "yes;no")
 
 if(NOT WOLFSSL_DSA AND NOT WOLFSSL_OPENSSH)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_DSA")
@@ -439,12 +436,11 @@ endif()
 
 # ECC Shamir
 set(WOLFSSL_ECCSHAMIR_HELP_STRING "Enable ECC Shamir (default: enabled)")
-option(WOLFSSL_ECCSHAMIR ${WOLFSSL_ECCSHAMIR_HELP_STRING} "yes")
+add_option("WOLFSSL_ECCSHAMIR" ${WOLFSSL_ECCSHAMIR_HELP_STRING} "yes" "yes;no")
 
 # ECC
 set(WOLFSSL_ECC_HELP_STRING "Enable ECC (default: enabled)")
-set(WOLFSSL_ECC "yes" CACHE STRING ${WOLFSSL_ECC_HELP_STRING})
-set_property(CACHE WOLFSSL_ECC PROPERTY STRINGS "yes" "no" "nonblock")
+add_option("WOLFSSL_ECC" ${WOLFSSL_ECC_HELP_STRING} "yes" "yes;no;nonblock")
 
 # lean psk doesn't need ecc
 if(WOLFSSL_LEAN_PSK)
@@ -479,8 +475,7 @@ endif()
 # CURVE25519
 set(WOLFSSL_CURVE25519_SMALL "no")
 set(WOLFSSL_CURVE25519_HELP_STRING "Enable Curve25519 (default: disabled)")
-set(WOLFSSL_CURVE25519 "no" CACHE STRING ${WOLFSSL_CURVE25519_HELP_STRING})
-set_property(CACHE WOLFSSL_CURVE25519 PROPERTY STRINGS "yes" "no" "small" "no128bit")
+add_option("WOLFSSL_CURVE25519" ${WOLFSSL_CURVE25519_HELP_STRING} "no" "yes;no;small;no128bit")
 
 if(WOLFSSL_OPENSSH)
     override_cache(WOLFSSL_CURVE25519 "yes")
@@ -503,8 +498,7 @@ endif()
 # ED25519
 set(WOLFSSL_ED25519_SMALL "no")
 set(WOLFSSL_ED25519_HELP_STRING "Enable ED25519 (default: disabled)")
-set(WOLFSSL_ED25519 "no" CACHE STRING ${WOLFSSL_ED25519_HELP_STRING})
-set_property(CACHE WOLFSSL_ED25519 PROPERTY STRINGS "yes" "no" "small")
+add_option("WOLFSSL_ED25519" ${WOLFSSL_ED25519_HELP_STRING} "no" "yes;no")
 
 if(WOLFSSL_OPENSSH)
     override_cache(WOLFSSL_ED25519 "yes")
@@ -529,8 +523,7 @@ endif()
 # CURVE448
 set(WOLFSSL_CURVE448_SMALL "no")
 set(WOLFSSL_CURVE448_HELP_STRING "Enable Curve448 (default: disabled)")
-set(WOLFSSL_CURVE448 "no" CACHE STRING ${WOLFSSL_CURVE448_HELP_STRING})
-set_property(CACHE WOLFSSL_CURVE448 PROPERTY STRINGS "yes" "no" "small")
+add_option("WOLFSSL_CURVE448" ${WOLFSSL_CURVE448_HELP_STRING} "no" "yes;no;small")
 
 if(WOLFSSL_CURVE448)
     if("${WOLFSSL_CURVE448}" STREQUAL "small" OR WOLFSSL_LOW_RESOURCE)
@@ -549,8 +542,7 @@ endif()
 # ED448
 set(WOLFSSL_ED448_SMALL "no")
 set(WOLFSSL_ED448_HELP_STRING "Enable ED448 (default: disabled)")
-set(WOLFSSL_ED448 "no" CACHE STRING ${WOLFSSL_ED448_HELP_STRING})
-set_property(CACHE WOLFSSL_ED448 PROPERTY STRINGS "yes" "no" "small")
+add_option("WOLFSSL_ED448" ${WOLFSSL_ED448_HELP_STRING} "no" "yes;no;small")
 
 if(WOLFSSL_ED448 AND NOT WOLFSSL_32BIT)
     if("${WOLFSSL_ED448}" STREQUAL "small" OR WOLFSSL_LOW_RESOURCE)
@@ -573,7 +565,7 @@ endif()
 
 # Error strings
 set(WOLFSSL_ERROR_STRINGS_HELP_STRING "Enable error strings table (default: enabled)")
-option(WOLFSSL_ERROR_STRINGS ${WOLFSSL_ERROR_STRINGS_HELP_STRING} "yes")
+add_option("WOLFSSL_ERROR_STRINGS" ${WOLFSSL_ERROR_STRINGS_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_ERROR_STRINGS)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_ERROR_STRINGS")
@@ -587,7 +579,7 @@ endif()
 
 # Error queue
 set(WOLFSSL_ERROR_QUEUE_HELP_STRING "Enables adding nodes to error queue when compiled with OPENSSL_EXTRA (default: enabled)")
-option(WOLFSSL_ERROR_QUEUE ${WOLFSSL_DISABLE_ERROR_QUEUE_HELP_STRING} "yes")
+add_option("WOLFSSL_ERROR_QUEUE" ${WOLFSSL_ERROR_QUEUE_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_ERROR_QUEUE)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_ERROR_QUEUE")
@@ -595,7 +587,7 @@ endif()
 
 # Old TLS
 set(WOLFSSL_OLD_TLS_HELP_STRING "Enable old TLS versions < 1.2 (default: enabled)")
-option(WOLFSSL_OLD_TLS ${WOLFSSL_OLD_TLS_HELP_STRING} "yes")
+add_option("WOLFSSL_OLD_TLS" ${WOLFSSL_OLD_TLS_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_OLD_TLS)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_OLD_TLS")
@@ -609,7 +601,7 @@ endif()
 
 # TLSv1.2
 set(WOLFSSL_TLSV12_HELP_STRING "Enable TLS versions 1.2 (default: enabled)")
-option(WOLFSSL_TLSV12 ${WOLFSSL_TLSV12_HELP_STRING} "yes")
+add_option("WOLFSSL_TLSV12" ${WOLFSSL_TLSV12_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_TLSV12)
     list(APPEND WOLFSSL_DEFINITIONS
@@ -624,7 +616,7 @@ endif()
 
 # Memory
 set(WOLFSSL_MEMORY_HELP_STRING "Enable memory callbacks (default: enabled)")
-option(WOLFSSL_MEMORY ${WOLFSSL_MEMORY_HELP_STRING} "yes")
+add_option("WOLFSSL_MEMORY" ${WOLFSSL_MEMORY_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_MEMORY)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_WOLFSSL_MEMORY")
@@ -642,7 +634,7 @@ endif()
 
 # RSA
 set(WOLFSSL_RSA_HELP_STRING "Enable RSA (default: enabled)")
-option(WOLFSSL_RSA ${WOLFSSL_RSA_HELP_STRING} "yes")
+add_option("WOLFSSL_RSA" ${WOLFSSL_RSA_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_RSA)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_RSA")
@@ -655,7 +647,7 @@ endif()
 
 # OAEP
 set(WOLFSSL_OAEP_HELP_STRING "Enable RSA OAEP (default: enabled)")
-option(WOLFSSL_OAEP ${WOLFSSL_OAEP_HELP_STRING} "yes")
+add_option("WOLFSSL_OAEP" ${WOLFSSL_OAEP_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_OAEP)
     list(APPEND WOLFSSL_DEFINITIONS "-DWC_NO_RSA_OAEP")
@@ -666,7 +658,7 @@ endif()
 
 # RSA-PSS
 set(WOLFSSL_RSA_PSS_HELP_STRING "Enable RSA-PSS (default: disabled)")
-option(WOLFSSL_RSA_PSS ${WOLFSSL_RSA_PSS_HELP_STRING} "no")
+add_option("WOLFSSL_RSA_PSS" ${WOLFSSL_RSA_PSS_HELP_STRING} "no" "yes;no")
 
 if(NOT WOLFSSL_RSA)
     override_cache(WOLFSSL_RSA_PSS "no")
@@ -681,7 +673,7 @@ endif()
 
 # DH
 set(WOLFSSL_DH_HELP_STRING "Enable DH (default: enabled)")
-option(WOLFSSL_DH ${WOLFSSL_DH_HELP_STRING} "yes")
+add_option("WOLFSSL_DH" ${WOLFSSL_DH_HELP_STRING} "yes" "yes;no")
 
 if(WOLFSSL_OPENSSH)
     override_cache(WOLFSSL_DH "yes")
@@ -702,7 +694,7 @@ endif()
 # turn off asn, which means no certs, no rsa, no dsa, no ecc,
 # and no big int (unless dh is on)
 set(WOLFSSL_ASN_HELP_STRING "Enable ASN (default: enabled)")
-option(WOLFSSL_ASN ${WOLFSSL_ASN_HELP_STRING} "yes")
+add_option("WOLFSSL_ASN" ${WOLFSSL_ASN_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_ASN)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_ASN" "-DNO_CERTS")
@@ -747,7 +739,7 @@ endif()
 
 # AES
 set(WOLFSSL_AES_HELP_STRING "Enable AES (default: enabled)")
-option(WOLFSSL_AES ${WOLFSSL_AES_HELP_STRING} "yes")
+add_option("WOLFSSL_AES" ${WOLFSSL_AES_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_AES)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_AES")
@@ -776,7 +768,7 @@ endif()
 
 # Coding
 set(WOLFSSL_CODING_HELP_STRING "Enable coding base 16/64 (default: enabled)")
-option(WOLFSSL_CODING ${WOLFSSL_CODING_HELP_STRING} "yes")
+add_option("WOLFSSL_CODING" ${WOLFSSL_CODING_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_CODING)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_CODING")
@@ -795,7 +787,7 @@ if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
 endif()
 
 set(WOLFSSL_BASE64_ENCODE_HELP_STRING "Enable Base64 encoding (default: enabled on x86_64)")
-option(WOLFSSL_BASE64_ENCODE ${WOLFSSL_BASE64_ENCODE_HELP_STRING} ${BASE64_ENCODE_DEFAULT})
+add_option("WOLFSSL_BASE64_ENCODE" ${WOLFSSL_BASE64_ENCODE_HELP_STRING} ${BASE64_ENCODE_DEFAULT} "yes;no")
 
 if(WOLFSSL_BASE64_ENCODE)
     list(APPEND WOLFSSL_DEFINITIONS "-DWOLFSSL_BASE64_ENCODE")  
@@ -805,7 +797,7 @@ endif()
 
 # DES3
 set(WOLFSSL_DES3_HELP_STRING "Enable DES3 (default: disabled)")
-option(WOLFSSL_DES3 ${WOLFSSL_DES3_HELP_STRING} "no")
+add_option("WOLFSSL_DES3" ${WOLFSSL_DES3_HELP_STRING} "no" "yes;no")
 
 if(WOLFSSL_OPENSSH OR
    WOLFSSL_QT OR
@@ -818,7 +810,7 @@ endif()
 
 # ARC4
 set(WOLFSSL_ARC4_HELP_STRING "Enable ARC4 (default: disabled)")
-option(WOLFSSL_ARC4 ${WOLFSSL_ARC4_HELP_STRING} "no")
+add_option("WOLFSSL_ARC4" ${WOLFSSL_ARC4_HELP_STRING} "no" "yes;no")
 
 if(WOLFSSL_OPENSSH OR WOLFSSL_WPAS)
     override_cache(WOLFSSL_ARC4 "yes")
@@ -836,7 +828,7 @@ endif()
 
 # MD5
 set(WOLFSSL_MD5_HELP_STRING "Enable MD5 (default: enabled)")
-option(WOLFSSL_MD5 ${WOLFSSL_MD5_HELP_STRING} "yes")
+add_option("WOLFSSL_MD5" ${WOLFSSL_MD5_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_MD5)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_MD5" "-DNO_OLD_TLS")
@@ -850,7 +842,7 @@ endif()
 
 # SHA
 set(WOLFSSL_SHA_HELP_STRING "Enable SHA (default: enabled)")
-option(WOLFSSL_SHA ${WOLFSSL_SHA_HELP_STRING} "yes")
+add_option("WOLFSSL_SHA" ${WOLFSSL_SHA_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_SHA)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_SHA" "-DNO_OLD_TLS")
@@ -869,7 +861,7 @@ endif()
 
 # HC128
 set(WOLFSSL_HC128_HELP_STRING "Enable HC-128 (default: disabled)")
-option(WOLFSSL_HC128 ${WOLFSSL_HC128_HELP_STRING} "no")
+add_option("WOLFSSL_HC128" ${WOLFSSL_HC128_HELP_STRING} "no" "yes;no")
 
 if(NOT WOLFSSL_HC128)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_HC128")
@@ -925,7 +917,7 @@ if(WOLFSSL_FIPS)
 endif()
 
 set(WOLFSSL_POLY1305_HELP_STRING "Enable wolfSSL POLY1305 support (default: enabled)")
-option(WOLFSSL_POLY1305 ${WOLFSSL_POLY1305_HELP_STRING} ${POLY1305_DEFAULT})
+add_option("WOLFSSL_POLY1305" ${WOLFSSL_POLY1305_HELP_STRING} ${POLY1305_DEFAULT} "yes;no")
 
 # leanpsk and leantls don't need poly1305
 if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
@@ -945,8 +937,7 @@ if(WOLFSSL_FIPS)
 endif()
 
 set(WOLFSSL_CHACHA_HELP_STRING "Enable CHACHA (default: enabled). Use `=noasm` to disable ASM AVX/AVX2 speedups")
-set(WOLFSSL_CHACHA ${CHACHA_DEFAULT} CACHE STRING ${WOLFSSL_CHACHA_HELP_STRING})
-set_property(CACHE WOLFSSL_CHACHA PROPERTY STRINGS "yes" "no" "noasm")
+add_option("WOLFSSL_CHACHA" ${WOLFSSL_CHACHA_HELP_STRING} ${CHACHA_DEFAULT} "yes;no;noasm")
 
 # leanpsk and leantls don't need chacha
 if(WOLFSSL_LEAN_PSK OR WOLFSSL_LEAN_TLS)
@@ -965,7 +956,7 @@ endif()
 
 # Hash DRBG
 set(WOLFSSL_HASH_DRBG_HELP_STRING "Enable Hash DRBG support (default: enabled)")
-option(WOLFSSL_HASH_DRBG ${WOLFSSL_HASH_DRBG_HELP_STRING} "yes")
+add_option("WOLFSSL_HASH_DRBG" ${WOLFSSL_HASH_DRBG_HELP_STRING} "yes" "yes;no")
 
 if(WOLFSSL_HASH_DRBG)
     list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_HASHDRBG")
@@ -987,7 +978,7 @@ else()
 endif()
 
 set(WOLFSSL_FILESYSTEM_HELP_STRING "Enable Filesystem support (default: enabled)")
-option(WOLFSSL_FILESYSTEM ${WOLFSSL_FILESYSTEM_HELP_STRING} ${FILESYSTEM_DEFAULT})
+add_option("WOLFSSL_FILESYSTEM" ${WOLFSSL_FILESYSTEM_HELP_STRING} ${FILESYSTEM_DEFAULT} "yes;no")
 
 if(NOT WOLFSSL_FILESYSTEM)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_FILESYSTEM")
@@ -1000,7 +991,7 @@ endif()
 
 # Inline function support
 set(WOLFSSL_INLINE_HELP_STRING "Enable inline functions (default: enabled)")
-option(WOLFSSL_INLINE ${WOLFSSL_INLINE_HELP_STRING} "yes")
+add_option("WOLFSSL_INLINE" ${WOLFSSL_INLINE_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_INLINE)
     list(APPEND WOLFSSL_DEFINITIONS "-DNO_INLINE")
@@ -1026,7 +1017,7 @@ endif()
 
 # Supported elliptic curves extensions
 set(WOLFSSL_SUPPORTED_CURVES_HELP_STRING "Enable Supported Elliptic Curves (default: enabled)")
-option(WOLFSSL_SUPPORTED_CURVES ${WOLFSSL_SUPPORTED_CURVES_HELP_STRING} "yes")
+add_option("WOLFSSL_SUPPORTED_CURVES" ${WOLFSSL_SUPPORTED_CURVES_HELP_STRING} "yes" "yes;no")
 
 if(WOLFSSL_SUPPORTED_CURVES)
     if(NOT WOLFSSL_ECC AND NOT WOLFSSL_CURVE25519 AND NOT WOLFSSL_CURVE448)
@@ -1065,7 +1056,7 @@ endif()
 
 # Extended master secret extension
 set(WOLFSSL_EXTENDED_MASTER_HELP_STRING "Enable Extended Master Secret (default: enabled)")
-option(WOLFSSL_EXTENDED_MASTER ${WOLFSSL_EXTENDED_MASTER_HELP_STRING} "yes")
+add_option("WOLFSSL_EXTENDED_MASTER" ${WOLFSSL_EXTENDED_MASTER_HELP_STRING} "yes" "yes;no")
 
 if(WOLFSSL_EXTENDED_MASTER)
     list(APPEND WOLFSSL_DEFINITIONS "-DHAVE_EXTENDED_MASTER")
@@ -1091,7 +1082,7 @@ endif()
 
 # Encrypt-then-mac
 set(WOLFSSL_ENC_THEN_MAC_HELP_STRING "Enable Encryptr-Then-Mac extension (default: enabled)")
-option(WOLFSSL_ENC_THEN_MAC ${WOLFSSL_ENC_THEN_MAC_HELP_STRING} "yes")
+add_option("WOLFSSL_ENC_THEN_MAC" ${WOLFSSL_ENC_THEN_MAC_HELP_STRING} "yes" "yes;no")
 
 if(WOLFSSL_APACHE_HTTPD)
     override_cache(WOLFSSL_ENC_THEN_MAC "no")
@@ -1108,7 +1099,7 @@ endif()
 # stunnel Support
 # TODO: rest of stunnel support
 set(WOLFSSL_STUNNEL_HELP_STRING "Enable stunnel (default: disabled)")
-option(WOLFSSL_STUNNEL ${WOLFSSL_STUNNEL_HELP_STRING} "no")
+add_option("WOLFSSL_STUNNEL" ${WOLFSSL_STUNNEL_HELP_STRING} "no" "yes;no")
 
 if(NOT WOLFSSL_PSK AND
    NOT WOLFSSL_LEAN_PSK AND
@@ -1122,7 +1113,7 @@ endif()
 
 # MD4
 set(WOLFSSL_MD4_HELP_STRING "Enable MD4 (default: disabled)")
-option(WOLFSSL_MD4 ${WOLFSSL_MD4_HELP_STRING} "no")
+add_option("WOLFSSL_MD4" ${WOLFSSL_MD4_HELP_STRING} "no" "yes;no")
 
 if(NOT WOLFSSL_MD4)
     # turn on MD4 if using stunnel
@@ -1138,7 +1129,7 @@ endif()
 # PWDBASED has to come after certservice since we want it on w/o explicit on
 # PWDBASED
 set(WOLFSSL_PWDBASED_HELP_STRING "Enable PWDBASED (default: disabled)")
-option(WOLFSSL_PWDBASED ${WOLFSSL_PWDBASED_HELP_STRING} "no")
+add_option("WOLFSSL_PWDBASED" ${WOLFSSL_PWDBASED_HELP_STRING} "no" "yes;no")
 
 if(NOT WOLFSSL_PWDBASED)
     if(WOLFSSL_OPENSSLEXTRA OR
@@ -1172,7 +1163,7 @@ if(WOLFSSL_SP_MATH)
 endif()
 
 set(WOLFSSL_FAST_MATH_HELP_STRING "Enable fast math ops (default: enabled on x86_64/aarch64)")
-option(WOLFSSL_FAST_MATH ${WOLFSSL_FAST_MATH_HELP_STRING} ${FASTMATH_DEFAULT})
+add_option("WOLFSSL_FAST_MATH" ${WOLFSSL_FAST_MATH_HELP_STRING} ${FASTMATH_DEFAULT} "yes;no")
 
 if(WOLFSSL_FAST_MATH)
     # turn off fastmath if leanpsk on or asn off (w/o DH and ECC)
@@ -1206,7 +1197,7 @@ else()
 endif()
 
 set(WOLFSSL_EXAMPLES_HELP_STRING "Enable examples (default: enabled)")
-option(WOLFSSL_EXAMPLES ${WOLFSSL_EXAMPLES_HELP_STRING} ${EXAMPLES_DEFAULT})
+add_option("WOLFSSL_EXAMPLES" ${WOLFSSL_EXAMPLES_HELP_STRING} ${EXAMPLES_DEFAULT} "yes;no")
 
 if(NOT WOLFSSL_FILESYSTEM OR
    NOT WOLFSSL_INLINE OR
@@ -1222,7 +1213,7 @@ else()
 endif()
 
 set(WOLFSSL_CRYPT_TESTS_HELP_STRING "Enable Crypt Bench/Test  (default: enabled)")
-option(WOLFSSL_CRYPT_TESTS ${WOLFSSL_CRYPT_TESTS_HELP_STRING} ${CRYPT_TESTS_DEFAULT})
+add_option("WOLFSSL_CRYPT_TESTS" ${WOLFSSL_CRYPT_TESTS_HELP_STRING} ${CRYPT_TESTS_DEFAULT} "yes;no")
 
 # TODO: - LIBZ
 #       - PKCS#11
@@ -1239,7 +1230,7 @@ option(WOLFSSL_CRYPT_TESTS ${WOLFSSL_CRYPT_TESTS_HELP_STRING} ${CRYPT_TESTS_DEFA
 
 # Asynchronous threading
 set(WOLFSSL_ASYNC_THREADS_HELP_STRING "Enable Asynchronous Threading (default: enabled)")
-option(WOLFSSL_ASYNC_THREADS ${WOLFSSL_ASYNC_THREADS_HELP_STRING} "yes")
+add_option("WOLFSSL_ASYNC_THREADS" ${WOLFSSL_ASYNC_THREADS_HELP_STRING} "yes" "yes;no")
 
 if(WOLFSSL_ASYNC_CRYPT AND WOLFSSL_ASYNC_THREADS)
     if(CMAKE_USE_PTHREADS_INIT)
@@ -1264,7 +1255,7 @@ endif()
 #       - AES key wrap
 
 set(WOLFSSL_OLD_NAMES_HELP_STRING "Keep backwards compat with old names (default: enabled)")
-option(WOLFSSL_OLD_NAMES ${WOLFSSL_OLD_NAMES_HELP_STRING} "yes")
+add_option("WOLFSSL_OLD_NAMES" ${WOLFSSL_OLD_NAMES_HELP_STRING} "yes" "yes;no")
 
 if(NOT WOLFSSL_OLD_NAMES AND NOT WOLFSSL_OPENSSL_COEXIST)
     list(APPEND WOLFSSL_DEFINITIONS
@@ -1279,7 +1270,7 @@ endif()
 
 # Support for enabling setting default DH parameters
 set(WOLFSSL_DH_DEFAULT_PARAMS_HELP_STRING "Enables option for default dh parameters (default: disabled)")
-option(WOLFSSL_DH_DEFAULT_PARAMS ${WOLFSSL_DH_DEFAULT_PARAMS_HELP_STRING} "no")
+add_option("WOLFSSL_DH_DEFAULT_PARAMS" ${WOLFSSL_DH_DEFAULT_PARAMS_HELP_STRING} "no" "yes;no")
 
 if(WOLFSSL_DH_DEFAULT_PARAMS OR NOT WOLFSSL_QT)
     override_cache(WOLFSSL_DH_DEFAULT_PARAMS "yes")
@@ -1297,10 +1288,10 @@ else()
 endif()
 
 set(WOLFSSL_USER_SETTINGS_HELP_STRING "Use your own user_settings.h and do not add Makefile CFLAGS (default: disabled)")
-option(WOLFSSL_USER_SETTINGS ${WOLFSSL_USER_SETTINGS_HELP_STRING} "no")
+add_option("WOLFSSL_USER_SETTINGS" ${WOLFSSL_USER_SETTINGS_HELP_STRING} "no" "yes;no")
 
 set(WOLFSSL_OPTFLAGS_HELP_STRING "Enable default optimization CFLAGS for the compiler (default: enabled)")
-option(WOLFSSL_OPTFLAGS ${WOLFSSL_OPTFLAGS_HELP_STRING} "yes")
+add_option("WOLFSSL_OPTFLAGS" ${WOLFSSL_OPTFLAGS_HELP_STRING} "yes" "yes;no")
 
 # Generates the BUILD_* flags. These control what source files are included in
 # the library. A series of AM_CONDITIONALs handle this in configure.ac.
@@ -1320,7 +1311,7 @@ endif()
 add_definitions(${WOLFSSL_DEFINITIONS})
 
 set(WOLFSSL_CONFIG_H_HELP_STRING "Enable generation of config.h and define HAVE_CONFIG_H (default: enabled)")
-option(WOLFSSL_CONFIG_H ${WOLFSSL_CONFIG_H_HELP_STRING} "yes")
+add_option("WOLFSSL_CONFIG_H" ${WOLFSSL_CONFIG_H_HELP_STRING} "yes" "yes;no")
 
 if(WOLFSSL_CONFIG_H)
     add_definitions("-DHAVE_CONFIG_H")

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -1,3 +1,22 @@
+function(add_option NAME HELP_STRING DEFAULT VALUES)
+    list(FIND VALUES ${DEFAULT} IDX)
+    if (${IDX} EQUAL -1)
+        message(FATAL_ERROR "Failed to add option ${NAME}. Default value "
+            "${DEFAULT} is not in list of possible values: ${VALUES}.")
+    endif()
+
+    if(DEFINED ${NAME})
+        list(FIND VALUES ${${NAME}} IDX)
+        if (${IDX} EQUAL -1)
+            message(FATAL_ERROR "Failed to set option ${NAME}. Value "
+                "${${NAME}} is not in list of possible values: ${VALUES}.")
+        endif()
+    endif()
+
+    set(${NAME} ${DEFAULT} CACHE STRING ${HELP_STRING})
+    set_property(CACHE ${NAME} PROPERTY STRINGS ${VALUES})
+endfunction()
+
 function(override_cache VAR VAL)
     get_property(VAR_TYPE CACHE ${VAR} PROPERTY TYPE)
     set(${VAR} ${VAL} CACHE ${VAR_TYPE} ${${VAR}_HELP_STRING} FORCE)


### PR DESCRIPTION
This commit makes all the binary CMake options (i.e. yes/no) conform to one
string convention: "yes/no." Previously, we had a mixture of yes/no and ON/OFF.