### PR TITLE
Fix authTagSz error in AES-GCM (AF_ALG)

### DIFF
--- a/wolfcrypt/src/port/af_alg/afalg_aes.c
+++ b/wolfcrypt/src/port/af_alg/afalg_aes.c
@@ -539,7 +539,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     if (ivSz != WC_SYSTEM_AESGCM_IV || authTagSz > WOLFSSL_MAX_AUTH_TAG_SZ) {
-        WOLFSSL_MSG("IV/AAD size not supported on system");
+        WOLFSSL_MSG("IV / auth tag size not supported on system");
         return BAD_FUNC_ARG;
     }
 
@@ -724,7 +724,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     }
 
     if (ivSz != WC_SYSTEM_AESGCM_IV || authTagSz > WOLFSSL_MAX_AUTH_TAG_SZ) {
-        WOLFSSL_MSG("IV/AAD size not supported on system");
+        WOLFSSL_MSG("IV / auth tag size not supported on system");
         return BAD_FUNC_ARG;
     }
 


### PR DESCRIPTION
These conditions ensure that the `ivSz` and `authTagSz` parameters are valid w.r.t. the `AF_ALG` implementation of the kernel. However, the error refers to the `authInSz` parameter.

The next condition, `authTagSz < WOLFSSL_MIN_AUTH_TAG_SZ`, does not depend on support from the kernel, and it makes sense to separate them (as it is).