### PR TITLE
WOLFSSL_BIO_SSL BIO should use remaining chain for IO

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -202,8 +202,9 @@ int wolfSSL_BIO_read(WOLFSSL_BIO* bio, void* buf, int len)
         }
     }
 
-    /* start at end of list and work backwards */
-    while ((bio != NULL) && (bio->next != NULL)) {
+    /* start at end of list (or a WOLFSSL_BIO_SSL object since it takes care of
+     * the rest of the chain) and work backwards */
+    while (bio != NULL && bio->next != NULL && bio->type != WOLFSSL_BIO_SSL) {
         bio = bio->next;
     }
 
@@ -249,6 +250,10 @@ int wolfSSL_BIO_read(WOLFSSL_BIO* bio, void* buf, int len)
             ret = wolfSSL_BIO_MD_read(bio, buf, ret);
         }
     #endif
+
+        if (bio->type == WOLFSSL_BIO_SOCKET) {
+            ret = wolfIO_Recv(bio->num, (char*)buf, len, 0);
+        }
 
         /* case where front of list is done */
         if (bio == front) {
@@ -606,6 +611,8 @@ int wolfSSL_BIO_write(WOLFSSL_BIO* bio, const void* data, int len)
             else {
                 ret = wolfSSL_BIO_SSL_write(bio, data, len, front);
             }
+            /* Rest of chain is taken care of inside call */
+            break;
         }
 
         if (bio->type == WOLFSSL_BIO_MD) {
@@ -614,6 +621,10 @@ int wolfSSL_BIO_write(WOLFSSL_BIO* bio, const void* data, int len)
             }
         }
     #endif /* WOLFCRYPT_ONLY */
+
+        if (bio->type == WOLFSSL_BIO_SOCKET) {
+            ret = wolfIO_Send(bio->num, (char*)data, len, 0);
+        }
 
         /* advance to the next bio in list */
         bio = bio->next;
@@ -941,6 +952,21 @@ size_t wolfSSL_BIO_wpending(const WOLFSSL_BIO *bio)
         return pair->wrIdx;
     }
 
+    return 0;
+}
+
+/* Custom wolfSSL API to check if current bio object supports checking
+ * pending state.
+ */
+int wolfSSL_BIO_supports_pending(const WOLFSSL_BIO *bio)
+{
+    while (bio) {
+        if (bio->type == WOLFSSL_BIO_SSL ||
+                bio->type == WOLFSSL_BIO_MEMORY ||
+                bio->type == WOLFSSL_BIO_BIO)
+            return 1;
+        bio = bio->next;
+    }
     return 0;
 }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -6426,9 +6426,14 @@ void SSL_ResourceFree(WOLFSSL* ssl)
 #endif /* WOLFSSL_DTLS */
 #ifdef OPENSSL_EXTRA
 #ifndef NO_BIO
+    /* Don't free if there was/is a previous element in the chain.
+     * This means that this BIO was part of a chain that will be
+     * free'd separately. */
     if (ssl->biord != ssl->biowr)        /* only free write if different */
-        wolfSSL_BIO_free(ssl->biowr);
-    wolfSSL_BIO_free(ssl->biord);        /* always free read bio */
+        if (ssl->biowr != NULL && ssl->biowr->prev == NULL)
+            wolfSSL_BIO_free(ssl->biowr);
+    if (ssl->biord != NULL && ssl->biord->prev == NULL)
+        wolfSSL_BIO_free(ssl->biord);
     ssl->biowr = NULL;
     ssl->biord = NULL;
 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -15136,37 +15136,27 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             return;
         }
 
-        /* if WOLFSSL_BIO is socket type then set WOLFSSL socket to use */
-        if (rd != NULL && rd->type == WOLFSSL_BIO_SOCKET) {
-            wolfSSL_set_rfd(ssl, rd->num);
-        }
-        if (wr != NULL && wr->type == WOLFSSL_BIO_SOCKET) {
-            wolfSSL_set_wfd(ssl, wr->num);
-        }
-
-        /* free any existing WOLFSSL_BIOs in use */
+        /* free any existing WOLFSSL_BIOs in use but don't free those in
+         * a chain */
         if (ssl->biord != NULL) {
             if (ssl->biord != ssl->biowr) {
-                if (ssl->biowr != NULL) {
+                if (ssl->biowr != NULL && ssl->biowr->prev != NULL)
                     wolfSSL_BIO_free(ssl->biowr);
-                    ssl->biowr = NULL;
-                }
+                ssl->biowr = NULL;
             }
-            wolfSSL_BIO_free(ssl->biord);
+            if (ssl->biord->prev != NULL)
+                wolfSSL_BIO_free(ssl->biord);
             ssl->biord = NULL;
         }
-
 
         ssl->biord = rd;
         ssl->biowr = wr;
 
         /* set SSL to use BIO callbacks instead */
-        if (((ssl->cbioFlag & WOLFSSL_CBIO_RECV) == 0) &&
-            (rd != NULL && rd->type != WOLFSSL_BIO_SOCKET)) {
+        if (((ssl->cbioFlag & WOLFSSL_CBIO_RECV) == 0)) {
             ssl->CBIORecv = BioReceive;
         }
-        if (((ssl->cbioFlag & WOLFSSL_CBIO_SEND) == 0) &&
-            (wr != NULL && wr->type != WOLFSSL_BIO_SOCKET)) {
+        if (((ssl->cbioFlag & WOLFSSL_CBIO_SEND) == 0)) {
             ssl->CBIOSend = BioSend;
         }
 
@@ -16049,6 +16039,21 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         return 0;
     }
 
+    long wolfSSL_BIO_do_handshake(WOLFSSL_BIO *b)
+    {
+        WOLFSSL_ENTER("wolfSSL_BIO_do_handshake");
+        if (b == NULL) {
+            WOLFSSL_MSG("Bad parameter");
+            return WOLFSSL_FAILURE;
+        }
+        if (b->type == WOLFSSL_BIO_SSL && b->ptr != NULL) {
+            return wolfSSL_negotiate((WOLFSSL*)b->ptr);
+        }
+        else {
+            WOLFSSL_MSG("Not SSL BIO or no SSL object set");
+            return WOLFSSL_FAILURE;
+        }
+    }
 
     long wolfSSL_BIO_set_ssl(WOLFSSL_BIO* b, WOLFSSL* ssl, int closeF)
     {
@@ -16059,6 +16064,8 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         if (b != NULL) {
             b->ptr   = ssl;
             b->shutdown = (byte)closeF;
+            if (b->next != NULL)
+                wolfSSL_set_bio(ssl, b->next, b->next);
     /* add to ssl for bio free if SSL_free called before/instead of free_all? */
             ret = WOLFSSL_SUCCESS;
         }
@@ -16279,6 +16286,10 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         WOLFSSL_ENTER("BIO_push");
         top->next    = append;
         append->prev = top;
+
+        /* SSL BIO's should use the next object in the chain for IO */
+        if (top->type == WOLFSSL_BIO_SSL && top->ptr)
+            wolfSSL_set_bio((WOLFSSL*)top->ptr, append, append);
 
         return top;
     }

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -672,11 +672,10 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define BIO_set_write_buffer_size       wolfSSL_BIO_set_write_buffer_size
 #define BIO_f_ssl                       wolfSSL_BIO_f_ssl
 #define BIO_new_socket                  wolfSSL_BIO_new_socket
-#ifndef NO_WOLFSSL_STUB
 #define BIO_new_connect                 wolfSSL_BIO_new_connect
 #define BIO_set_conn_port               wolfSSL_BIO_set_conn_port
 #define BIO_do_connect                  wolfSSL_BIO_do_connect
-#endif
+#define BIO_do_handshake                wolfSSL_BIO_do_handshake
 #define SSL_set_bio                     wolfSSL_set_bio
 #define BIO_set_ssl                     wolfSSL_BIO_set_ssl
 #define BIO_eof                         wolfSSL_BIO_eof

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1325,6 +1325,8 @@ WOLFSSL_API WOLFSSL_BIO *wolfSSL_BIO_new_connect(const char *str);
 WOLFSSL_API long wolfSSL_BIO_set_conn_port(WOLFSSL_BIO *b, char* port);
 WOLFSSL_API long wolfSSL_BIO_do_connect(WOLFSSL_BIO *b);
 
+WOLFSSL_API long wolfSSL_BIO_do_handshake(WOLFSSL_BIO *b);
+
 WOLFSSL_API long wolfSSL_BIO_ctrl(WOLFSSL_BIO *bp, int cmd, long larg, void *parg);
 WOLFSSL_API long wolfSSL_BIO_int_ctrl(WOLFSSL_BIO *bp, int cmd, long larg, int iarg);
 
@@ -3549,6 +3551,7 @@ WOLFSSL_API size_t wolfSSL_get_client_random(const WOLFSSL* ssl,
 
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
 WOLFSSL_API size_t wolfSSL_BIO_wpending(const WOLFSSL_BIO *bio);
+WOLFSSL_API int wolfSSL_BIO_supports_pending(const WOLFSSL_BIO *bio);
 WOLFSSL_API size_t wolfSSL_BIO_ctrl_pending(WOLFSSL_BIO *b);
 
 WOLFSSL_API int wolfSSL_get_server_tmp_key(const WOLFSSL*, WOLFSSL_EVP_PKEY**);


### PR DESCRIPTION
This is accomplished by passing the next BIO in the chain in to the `wolfSSL_set_bio` API.