### PR TITLE
WOLFSSL_STATIC_MEMORY no longer requires fast math

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -2996,7 +2996,7 @@ int sp_cmp_d(sp_int* a, sp_int_digit d)
 #endif
 
 #if defined(WOLFSSL_SP_INT_NEGATIVE) || !defined(NO_PWDBASED) || \
-    defined(WOLFSSL_KEY_GEN) || !defined(NO_DH) || defined(HAVE_ECC) || \
+    defined(WOLFSSL_KEY_GEN) || !defined(NO_DH) || \
     (!defined(NO_RSA) && !defined(WOLFSSL_RSA_VERIFY_ONLY))
 /* Add a one digit number to the multi-precision number.
  *

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2094,8 +2094,9 @@ extern void uITRON4_free(void *p) ;
     #if defined(HAVE_IO_POOL) || defined(XMALLOC_USER) || defined(NO_WOLFSSL_MEMORY)
          #error static memory cannot be used with HAVE_IO_POOL, XMALLOC_USER or NO_WOLFSSL_MEMORY
     #endif
-    #if !defined(USE_FAST_MATH) && !defined(NO_BIG_INT)
-        #error static memory requires fast math please define USE_FAST_MATH
+    #if !defined(WOLFSSL_SP_NO_MALLOC) && \
+        !defined(USE_FAST_MATH) && !defined(NO_BIG_INT)
+         #error The static memory option is only supported for fast math or SP with no malloc
     #endif
     #ifdef WOLFSSL_SMALL_STACK
         #error static memory does not support small stack please undefine


### PR DESCRIPTION
This PR corrects a couple issues:

```
./wolfssl/wolfcrypt/settings.h:2098:10: error: #error static memory requires fast math please define USE_FAST_MATH
 2098 |         #error static memory requires fast math please define USE_FAST_MATH
      |          ^~~~~
wolfcrypt/src/sp_int.c:3010:12: error: ‘_sp_add_d’ defined but not used [-Werror=unused-function]
 3010 | static int _sp_add_d(sp_int* a, sp_int_digit d, sp_int* r)
      |            ^~~~~~~~~
cc1: all warnings being treated as errors
 ```