### PR TITLE
test.c: fix build with -Werror=pedantic

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -90,7 +90,7 @@
 #endif
 
 #ifdef __GNUC__
-_Pragma("GCC diagnostic ignored \"-Wunused-function\"");
+_Pragma("GCC diagnostic ignored \"-Wunused-function\"")
 #endif
 
 #ifdef USE_FLAT_TEST_H


### PR DESCRIPTION
There is a stray `;` in the preprocessor pragma

```
wolfcrypt/test/test.c:93:56: error: ISO C does not allow extra ‘;’ outside of a function [-Werror=pedantic]
   93 | _Pragma("GCC diagnostic ignored \"-Wunused-function\"");
```