### PR TITLE
Correctly move the Tx sequence number forward

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -29785,13 +29785,8 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
         /* are we in scr */
         if (IsEncryptionOn(ssl, 1)) {
             byte* input;
-            int   inputSz = HANDSHAKE_HEADER_SZ + length; /* build msg adds rec hdr */
-            int   recordHeaderSz = RECORD_HEADER_SZ;
-
-            if (ssl->options.dtls) {
-                recordHeaderSz += DTLS_RECORD_EXTRA;
-                inputSz += DTLS_HANDSHAKE_EXTRA;
-            }
+            int   inputSz = DTLS_HANDSHAKE_HEADER_SZ + length; /* build msg adds rec hdr */
+            int   recordHeaderSz = DTLS_RECORD_HEADER_SZ;
 
             input = (byte*)XMALLOC(inputSz, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
             if (input == NULL)
@@ -29807,6 +29802,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
         }
 
         ssl->buffers.outputBuffer.length += sendSz;
+        DtlsSEQIncrement(ssl, CUR_ORDER);
 
         return SendBuffered(ssl);
     }

--- a/tests/include.am
+++ b/tests/include.am
@@ -31,6 +31,7 @@ EXTRA_DIST += tests/test.conf \
               tests/test-psk-no-id-sha2.conf \
               tests/test-dtls.conf \
               tests/test-dtls-fails.conf \
+              tests/test-dtls-fails-cipher.conf \
               tests/test-dtls-group.conf \
               tests/test-dtls-reneg-client.conf \
               tests/test-dtls-reneg-server.conf \

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -1003,6 +1003,20 @@ int SuiteTest(int argc, char** argv)
     }
     strcpy(argv0[2], "");
 #endif
+#ifdef WOLFSSL_EXTRA_ALERTS
+    /* failure tests */
+    args.argc = 3;
+    strcpy(argv0[1], "tests/test-dtls-fails-cipher.conf");
+    strcpy(argv0[2], "expFail"); /* tests are expected to fail */
+    printf("starting dtls cipher mismatch tests that expect failure\n");
+    test_harness(&args);
+    if (args.return_code != 0) {
+        printf("error from script %d\n", args.return_code);
+        args.return_code = EXIT_FAILURE;
+        goto exit;
+    }
+    strcpy(argv0[2], "");
+#endif
 #endif
 #ifdef WOLFSSL_SCTP
     /* add dtls-sctp extra suites */

--- a/tests/test-dtls-fails-cipher.conf
+++ b/tests/test-dtls-fails-cipher.conf
@@ -1,0 +1,9 @@
+# server DTLSv1.2 cipher mismatch
+-v 3
+-u
+-l DHE-RSA-AES128-SHA256
+
+# client DTLSv1.2 cipher mismatch
+-v 3
+-u
+-l DHE-RSA-AES256-SHA256


### PR DESCRIPTION
All DTLS records after the ClientHello should try to start from the sequence number of the ClientHello if it is available.
Related ticket: 11803