### PR TITLE
test: fix `--enable-opensslall --enable-debug` build

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -28698,7 +28698,7 @@ static int msgCb(SSL_CTX *ctx, SSL *ssl)
 {
     (void) ctx;
     (void) ssl;
-    #ifdef OPENSSL_ALL
+    #if defined(OPENSSL_ALL) && defined(SESSION_CERTS)
         STACK_OF(X509)* sk;
         X509* x509;
         int i, num;
@@ -28710,7 +28710,7 @@ static int msgCb(SSL_CTX *ctx, SSL *ssl)
     AssertIntEQ(((WOLFSSL_X509_CHAIN *)SSL_get_peer_cert_chain(ssl))->count, 2);
     #endif
 
-    #ifdef OPENSSL_ALL
+    #if defined(OPENSSL_ALL) && defined(SESSION_CERTS)
     bio = BIO_new(BIO_s_file());
     BIO_set_fp(bio, stdout, BIO_NOCLOSE);
     sk = SSL_get_peer_cert_chain(ssl);


### PR DESCRIPTION
Gate `SSL_get_peer_cert_chain` calls in api.c with same flags as
`wolfSSL_get_peer_cert_chain` definition.