### PR TITLE
autoconf 2.70 / gcc-10 updates

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,7 @@ CFLAGS="$CFLAGS $C_EXTRA_FLAGS $C_FLAGS"
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_CANONICAL_HOST
+AC_CANONICAL_TARGET
 AC_CONFIG_MACRO_DIR([m4])
 
 AM_INIT_AUTOMAKE([1.11 -Wall -Werror -Wno-portability foreign tar-ustar subdir-objects no-define color-tests])
@@ -203,7 +204,7 @@ AS_CASE([$ENABLED_FIPS],
         FIPS_VERSION="v1"
     ],
     [
-        AC_MSG_ERROR([Invalid value for --enable-fips \"$ENABLED_FIPS\" (allowed: ready, rand, v1, v2)])
+        AC_MSG_ERROR([Invalid value for --enable-fips "$ENABLED_FIPS" (allowed: ready, rand, v1, v2)])
     ])
 
 AS_CASE([$FIPS_VERSION],

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #
 #
 AC_COPYRIGHT([Copyright (C) 2006-2020 wolfSSL Inc.])
-AC_PREREQ([2.63])
+AC_PREREQ([2.69])
 AC_INIT([wolfssl],[4.7.1],[https://github.com/wolfssl/wolfssl/issues],[wolfssl],[https://www.wolfssl.com])
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -25,14 +25,14 @@ AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
 AC_CONFIG_MACRO_DIR([m4])
 
-AM_INIT_AUTOMAKE([1.11 -Wall -Werror -Wno-portability foreign tar-ustar subdir-objects no-define color-tests])
+AM_INIT_AUTOMAKE([1.14.1 -Wall -Werror -Wno-portability foreign tar-ustar subdir-objects no-define color-tests])
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
 AC_ARG_PROGRAM
 
 AC_CONFIG_HEADERS([config.h:config.in])
 
-LT_PREREQ([2.2])
+LT_PREREQ([2.4.2])
 LT_INIT([disable-static win32-dll])
 
 #shared library versioning

--- a/m4/ax_linuxkm.m4
+++ b/m4/ax_linuxkm.m4
@@ -140,7 +140,7 @@ AC_DEFUN([AX_SIMD_CC_COMPILER_FLAGS], [
 
         ;;
     *)
-        AC_MSG_ERROR(["Don\'t know how to construct assembler flags for target \"${host_cpu}\"."])
+        AC_MSG_ERROR([Don't know how to construct assembler flags for target "${host_cpu}".])
         ;;
     esac
 

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -14,20 +14,24 @@
 #   flags that are needed. (The user can also force certain compiler
 #   flags/libs to be tested by setting these environment variables.)
 #
-#   Also sets PTHREAD_CC to any special C compiler that is needed for
-#   multi-threaded programs (defaults to the value of CC otherwise). (This
-#   is necessary on AIX to use the special cc_r compiler alias.)
+#   Also sets PTHREAD_CC and PTHREAD_CXX to any special C compiler that is
+#   needed for multi-threaded programs (defaults to the value of CC
+#   respectively CXX otherwise). (This is necessary on e.g. AIX to use the
+#   special cc_r/CC_r compiler alias.)
 #
 #   NOTE: You are assumed to not only compile your program with these flags,
 #   but also to link with them as well. For example, you might link with
 #   $PTHREAD_CC $CFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#   $PTHREAD_CXX $CXXFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
 #
 #   If you are only building threaded programs, you may wish to use these
 #   variables in your default LIBS, CFLAGS, and CC:
 #
 #     LIBS="$PTHREAD_LIBS $LIBS"
 #     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+#     CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
 #     CC="$PTHREAD_CC"
+#     CXX="$PTHREAD_CXX"
 #
 #   In addition, if the PTHREAD_CREATE_JOINABLE thread-attribute constant
 #   has a nonstandard name, this macro defines PTHREAD_CREATE_JOINABLE to
@@ -55,6 +59,7 @@
 #
 #   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
 #   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#   Copyright (c) 2019 Marc Stevens <marc.stevens@cwi.nl>
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -82,11 +87,11 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 24
+#serial 30
 
 AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
 AC_DEFUN([AX_PTHREAD], [
-AC_REQUIRE([AC_CANONICAL_HOST])
+AC_REQUIRE([AC_CANONICAL_TARGET])
 AC_REQUIRE([AC_PROG_CC])
 AC_REQUIRE([AC_PROG_SED])
 AC_LANG_PUSH([C])
@@ -104,6 +109,7 @@ if test "x$PTHREAD_CFLAGS$PTHREAD_LIBS" != "x"; then
         ax_pthread_save_CFLAGS="$CFLAGS"
         ax_pthread_save_LIBS="$LIBS"
         AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
+        AS_IF([test "x$PTHREAD_CXX" != "x"], [CXX="$PTHREAD_CXX"])
         CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
         LIBS="$PTHREAD_LIBS $LIBS"
         AC_MSG_CHECKING([for pthread_join using $CC $PTHREAD_CFLAGS $PTHREAD_LIBS])
@@ -123,10 +129,12 @@ fi
 # (e.g. DEC) have both -lpthread and -lpthreads, where one of the
 # libraries is broken (non-POSIX).
 
-# Create a list of thread flags to try.  Items starting with a "-" are
-# C compiler flags, and other items are library names, except for "none"
-# which indicates that we try without any flags at all, and "pthread-config"
-# which is a program returning the flags for the Pth emulation library.
+# Create a list of thread flags to try. Items with a "," contain both
+# C compiler flags (before ",") and linker flags (after ","). Other items
+# starting with a "-" are C compiler flags, and remaining items are
+# library names, except for "none" which indicates that we try without
+# any flags at all, and "pthread-config" which is a program returning
+# the flags for the Pth emulation library.
 
 ax_pthread_flags="pthreads none -Kthread -pthread -pthreads -mthreads pthread --thread-safe -mt pthread-config"
 
@@ -150,7 +158,7 @@ ax_pthread_flags="pthreads none -Kthread -pthread -pthreads -mthreads pthread --
 # --thread-safe: KAI C++
 # pthread-config: use pthread-config program (for GNU Pth library)
 
-case $host_os in
+case $target_os in
 
         freebsd*)
 
@@ -194,35 +202,9 @@ case $host_os in
         # that too in a future libc.)  So we'll check first for the
         # standard Solaris way of linking pthreads (-mt -lpthread).
 
-        ax_pthread_flags="-mt,pthread pthread $ax_pthread_flags"
+        ax_pthread_flags="-mt,-lpthread pthread $ax_pthread_flags"
         ;;
 esac
-
-# GCC generally uses -pthread, or -pthreads on some platforms (e.g. SPARC)
-
-AS_IF([test "x$GCC" = "xyes"],
-      [ax_pthread_flags="-pthread -pthreads $ax_pthread_flags"])
-
-# The presence of a feature test macro requesting re-entrant function
-# definitions is, on some systems, a strong hint that pthreads support is
-# correctly enabled
-
-case $host_os in
-        darwin* | hpux* | linux* | osf* | solaris*)
-        ax_pthread_check_macro="_REENTRANT"
-        ;;
-
-        aix*)
-        ax_pthread_check_macro="_THREAD_SAFE"
-        ;;
-
-        *)
-        ax_pthread_check_macro="--"
-        ;;
-esac
-AS_IF([test "x$ax_pthread_check_macro" = "x--"],
-      [ax_pthread_check_cond=0],
-      [ax_pthread_check_cond="!defined($ax_pthread_check_macro)"])
 
 # Are we compiling with Clang?
 
@@ -242,83 +224,47 @@ AC_CACHE_CHECK([whether $CC is Clang],
     ])
 ax_pthread_clang="$ax_cv_PTHREAD_CLANG"
 
-ax_pthread_clang_warning=no
 
-# Clang needs special handling, because older versions handle the -pthread
-# option in a rather... idiosyncratic way
+# GCC generally uses -pthread, or -pthreads on some platforms (e.g. SPARC)
 
-if test "x$ax_pthread_clang" = "xyes"; then
+# Note that for GCC and Clang -pthread generally implies -lpthread,
+# except when -nostdlib is passed.
+# This is problematic using libtool to build C++ shared libraries with pthread:
+# [1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25460
+# [2] https://bugzilla.redhat.com/show_bug.cgi?id=661333
+# [3] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=468555
+# To solve this, first try -pthread together with -lpthread for GCC
 
-        # Clang takes -pthread; it has never supported any other flag
+AS_IF([test "x$GCC" = "xyes"],
+      [ax_pthread_flags="-pthread,-lpthread -pthread -pthreads $ax_pthread_flags"])
 
-        # (Note 1: This will need to be revisited if a system that Clang
-        # supports has POSIX threads in a separate library.  This tends not
-        # to be the way of modern systems, but it's conceivable.)
+# Clang takes -pthread (never supported any other flag), but we'll try with -lpthread first
 
-        # (Note 2: On some systems, notably Darwin, -pthread is not needed
-        # to get POSIX threads support; the API is always present and
-        # active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
-        # -pthread does define _REENTRANT, and while the Darwin headers
-        # ignore this macro, third-party headers might not.)
+AS_IF([test "x$ax_pthread_clang" = "xyes"],
+      [ax_pthread_flags="-pthread,-lpthread -pthread"])
 
-        PTHREAD_CFLAGS="-pthread"
-        PTHREAD_LIBS=
 
-        ax_pthread_ok=yes
+# The presence of a feature test macro requesting re-entrant function
+# definitions is, on some systems, a strong hint that pthreads support is
+# correctly enabled
 
-        # However, older versions of Clang make a point of warning the user
-        # that, in an invocation where only linking and no compilation is
-        # taking place, the -pthread option has no effect ("argument unused
-        # during compilation").  They expect -pthread to be passed in only
-        # when source code is being compiled.
-        #
-        # Problem is, this is at odds with the way Automake and most other
-        # C build frameworks function, which is that the same flags used in
-        # compilation (CFLAGS) are also used in linking.  Many systems
-        # supported by AX_PTHREAD require exactly this for POSIX threads
-        # support, and in fact it is often not straightforward to specify a
-        # flag that is used only in the compilation phase and not in
-        # linking.  Such a scenario is extremely rare in practice.
-        #
-        # Even though use of the -pthread flag in linking would only print
-        # a warning, this can be a nuisance for well-run software projects
-        # that build with -Werror.  So if the active version of Clang has
-        # this misfeature, we search for an option to squash it.
+case $target_os in
+        darwin* | hpux* | linux* | osf* | solaris*)
+        ax_pthread_check_macro="_REENTRANT"
+        ;;
 
-        AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
-            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
-            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
-             # Create an alternate version of $ac_link that compiles and
-             # links in two steps (.c -> .o, .o -> exe) instead of one
-             # (.c -> exe), because the warning occurs only in the second
-             # step
-             ax_pthread_save_ac_link="$ac_link"
-             ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
-             ax_pthread_link_step=`$as_echo "$ac_link" | sed "$ax_pthread_sed"`
-             ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
-             ax_pthread_save_CFLAGS="$CFLAGS"
-             for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
-                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
-                CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
-                ac_link="$ax_pthread_save_ac_link"
-                AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
-                    [ac_link="$ax_pthread_2step_ac_link"
-                     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
-                         [break])
-                    ])
-             done
-             ac_link="$ax_pthread_save_ac_link"
-             CFLAGS="$ax_pthread_save_CFLAGS"
-             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
-             ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
-            ])
+        aix*)
+        ax_pthread_check_macro="_THREAD_SAFE"
+        ;;
 
-        case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
-                no | unknown) ;;
-                *) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
-        esac
+        *)
+        ax_pthread_check_macro="--"
+        ;;
+esac
+AS_IF([test "x$ax_pthread_check_macro" = "x--"],
+      [ax_pthread_check_cond=0],
+      [ax_pthread_check_cond="!defined($ax_pthread_check_macro)"])
 
-fi # $ax_pthread_clang = yes
 
 if test "x$ax_pthread_ok" = "xno"; then
 for ax_pthread_try_flag in $ax_pthread_flags; do
@@ -328,10 +274,10 @@ for ax_pthread_try_flag in $ax_pthread_flags; do
                 AC_MSG_CHECKING([whether pthreads work without any flags])
                 ;;
 
-                -mt,pthread)
-                AC_MSG_CHECKING([whether pthreads work with -mt -lpthread])
-                PTHREAD_CFLAGS="-mt"
-                PTHREAD_LIBS="-lpthread"
+                *,*)
+                PTHREAD_CFLAGS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\1/"`
+                PTHREAD_LIBS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\2/"`
+                AC_MSG_CHECKING([whether pthreads work with "$PTHREAD_CFLAGS" and "$PTHREAD_LIBS"])
                 ;;
 
                 -*)
@@ -368,10 +314,16 @@ for ax_pthread_try_flag in $ax_pthread_flags; do
         # We try pthread_create on general principles.
 
         AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>
-dnl#                       if $ax_pthread_check_cond
-dnl#                        error "$ax_pthread_check_macro must be defined"
-dnl#                       endif
-                        static void routine(void *a) { a = 0; }
+#                       if $ax_pthread_check_cond
+#                        error "$ax_pthread_check_macro must be defined"
+#                       endif
+                        static void *some_global = NULL;
+                        static void routine(void *a)
+                          {
+                             /* To avoid any unused-parameter or
+                                unused-but-set-parameter warning.  */
+                             some_global = a;
+                          }
                         static void *start_routine(void *a) { return a; }],
                        [pthread_t th; pthread_attr_t attr;
                         pthread_create(&th, 0, start_routine, 0);
@@ -392,6 +344,80 @@ dnl#                       endif
         PTHREAD_CFLAGS=""
 done
 fi
+
+
+# Clang needs special handling, because older versions handle the -pthread
+# option in a rather... idiosyncratic way
+
+if test "x$ax_pthread_clang" = "xyes"; then
+
+        # Clang takes -pthread; it has never supported any other flag
+
+        # (Note 1: This will need to be revisited if a system that Clang
+        # supports has POSIX threads in a separate library.  This tends not
+        # to be the way of modern systems, but it's conceivable.)
+
+        # (Note 2: On some systems, notably Darwin, -pthread is not needed
+        # to get POSIX threads support; the API is always present and
+        # active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
+        # -pthread does define _REENTRANT, and while the Darwin headers
+        # ignore this macro, third-party headers might not.)
+
+        # However, older versions of Clang make a point of warning the user
+        # that, in an invocation where only linking and no compilation is
+        # taking place, the -pthread option has no effect ("argument unused
+        # during compilation").  They expect -pthread to be passed in only
+        # when source code is being compiled.
+        #
+        # Problem is, this is at odds with the way Automake and most other
+        # C build frameworks function, which is that the same flags used in
+        # compilation (CFLAGS) are also used in linking.  Many systems
+        # supported by AX_PTHREAD require exactly this for POSIX threads
+        # support, and in fact it is often not straightforward to specify a
+        # flag that is used only in the compilation phase and not in
+        # linking.  Such a scenario is extremely rare in practice.
+        #
+        # Even though use of the -pthread flag in linking would only print
+        # a warning, this can be a nuisance for well-run software projects
+        # that build with -Werror.  So if the active version of Clang has
+        # this misfeature, we search for an option to squash it.
+
+        AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
+             # Create an alternate version of $ac_link that compiles and
+             # links in two steps (.c -> .o, .o -> exe) instead of one
+             # (.c -> exe), because the warning occurs only in the second
+             # step
+             ax_pthread_save_ac_link="$ac_link"
+             ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
+             ax_pthread_link_step=`AS_ECHO(["$ac_link"]) | sed "$ax_pthread_sed"`
+             ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
+             ax_pthread_save_CFLAGS="$CFLAGS"
+             for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
+                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
+                CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
+                ac_link="$ax_pthread_save_ac_link"
+                AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                    [ac_link="$ax_pthread_2step_ac_link"
+                     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                         [break])
+                    ])
+             done
+             ac_link="$ax_pthread_save_ac_link"
+             CFLAGS="$ax_pthread_save_CFLAGS"
+             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
+             ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
+            ])
+
+        case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
+                no | unknown) ;;
+                *) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
+        esac
+
+fi # $ax_pthread_clang = yes
+
+
 
 # Various other checks:
 if test "x$ax_pthread_ok" = "xyes"; then
@@ -424,7 +450,7 @@ if test "x$ax_pthread_ok" = "xyes"; then
         AC_CACHE_CHECK([whether more special flags are required for pthreads],
             [ax_cv_PTHREAD_SPECIAL_FLAGS],
             [ax_cv_PTHREAD_SPECIAL_FLAGS=no
-             case $host_os in
+             case $target_os in
              solaris*)
              ax_cv_PTHREAD_SPECIAL_FLAGS="-D_POSIX_PTHREAD_SEMANTICS"
              ;;
@@ -438,7 +464,8 @@ if test "x$ax_pthread_ok" = "xyes"; then
         AC_CACHE_CHECK([for PTHREAD_PRIO_INHERIT],
             [ax_cv_PTHREAD_PRIO_INHERIT],
             [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pthread.h>]],
-                                             [[int i = PTHREAD_PRIO_INHERIT;]])],
+                                             [[int i = PTHREAD_PRIO_INHERIT;
+                                               return i;]])],
                             [ax_cv_PTHREAD_PRIO_INHERIT=yes],
                             [ax_cv_PTHREAD_PRIO_INHERIT=no])
             ])
@@ -453,25 +480,35 @@ if test "x$ax_pthread_ok" = "xyes"; then
 
         # More AIX lossage: compile with *_r variant
         if test "x$GCC" != "xyes"; then
-            case $host_os in
+            case $target_os in
                 aix*)
                 AS_CASE(["x/$CC"],
                     [x*/c89|x*/c89_128|x*/c99|x*/c99_128|x*/cc|x*/cc128|x*/xlc|x*/xlc_v6|x*/xlc128|x*/xlc128_v6],
                     [#handle absolute path differently from PATH based program lookup
                      AS_CASE(["x$CC"],
                          [x/*],
-                         [AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])],
-                         [AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])])])
+                         [
+			   AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])
+			   AS_IF([test "x${CXX}" != "x"], [AS_IF([AS_EXECUTABLE_P([${CXX}_r])],[PTHREAD_CXX="${CXX}_r"])])
+			 ],
+                         [
+			   AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])
+			   AS_IF([test "x${CXX}" != "x"], [AC_CHECK_PROGS([PTHREAD_CXX],[${CXX}_r],[$CXX])])
+			 ]
+                     )
+                    ])
                 ;;
             esac
         fi
 fi
 
 test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
+test -n "$PTHREAD_CXX" || PTHREAD_CXX="$CXX"
 
 AC_SUBST([PTHREAD_LIBS])
 AC_SUBST([PTHREAD_CFLAGS])
 AC_SUBST([PTHREAD_CC])
+AC_SUBST([PTHREAD_CXX])
 
 # Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
 if test "x$ax_pthread_ok" = "xyes"; then

--- a/m4/ax_tls.m4
+++ b/m4/ax_tls.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#          http://www.gnu.org/software/autoconf-archive/ax_tls.html
+#          https://www.gnu.org/software/autoconf-archive/ax_tls.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -9,9 +9,9 @@
 # DESCRIPTION
 #
 #   Provides a test for the compiler support of thread local storage (TLS)
-#   extensions. Defines TLS if it is found. Currently knows about GCC/ICC
-#   and MSVC. I think SunPro uses the same as GCC, and Borland apparently
-#   supports either.
+#   extensions. Defines TLS if it is found. Currently knows about C++11,
+#   GCC/ICC, and MSVC. I think SunPro uses the same as GCC, and Borland
+#   apparently supports either.
 #
 # LICENSE
 #
@@ -29,7 +29,7 @@
 #   Public License for more details.
 #
 #   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 #   As a special exception, the respective Autoconf Macro's copyright owner
 #   gives unlimited permission to copy, distribute and modify the configure
@@ -44,7 +44,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 11
+#serial 15
 
 #   Define m4_ifblank and m4_ifnblank macros from introduced in
 #   autotools 2.64 m4sugar.m4 if using an earlier autotools.
@@ -55,7 +55,6 @@ ifdef([m4_ifblank], [], [
 ]), [], [$2], [$3])])
     ])
 
-
 ifdef([m4_ifnblank], [], [
     m4_define([m4_ifnblank],
     [m4_if(m4_translit([[$1]], [ ][	][
@@ -63,30 +62,25 @@ ifdef([m4_ifnblank], [], [
     ])
 
 AC_DEFUN([AX_TLS], [
-  AC_MSG_CHECKING(for thread local storage (TLS) class)
-  AC_CACHE_VAL(ac_cv_tls, [
-    ax_tls_keywords="__thread __declspec(thread) none"
-    for ax_tls_keyword in $ax_tls_keywords; do
+  AC_MSG_CHECKING([for thread local storage (TLS) class])
+  AC_CACHE_VAL([ac_cv_tls],
+   [for ax_tls_keyword in thread_local _Thread_local __thread '__declspec(thread)' none; do
        AS_CASE([$ax_tls_keyword],
           [none], [ac_cv_tls=none ; break],
-          [AC_TRY_COMPILE(
-              [#include <stdlib.h>
-               static void
-               foo(void) {
-               static ] $ax_tls_keyword [ int bar;
-               exit(1);
-               }],
-               [],
-               [ac_cv_tls=$ax_tls_keyword ; break],
-               ac_cv_tls=none
-           )])
-    done
-  ])
-  AC_MSG_RESULT($ac_cv_tls)
+          [AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+              [#include <stdlib.h>],
+              [static  $ax_tls_keyword  int bar;]
+            )],
+            [ac_cv_tls=$ax_tls_keyword ; break],
+            [ac_cv_tls=none]
+          )]
+        )
+    done ]
+  )
+  AC_MSG_RESULT([$ac_cv_tls])
 
   AS_IF([test "$ac_cv_tls" != "none"],
-    AC_DEFINE_UNQUOTED([TLS], $ac_cv_tls, [If the compiler supports a TLS storage class define it to that here])
-      m4_ifnblank([$1], [$1]),
-    m4_ifnblank([$2], [$2])
-  )
+    [AC_DEFINE_UNQUOTED([TLS],[$ac_cv_tls],[If the compiler supports a TLS storage class, define it to that here])
+     m4_ifnblank([$1],[$1],[[:]])],
+    [m4_ifnblank([$2],[$2],[[:]])])
 ])

--- a/tests/api.c
+++ b/tests/api.c
@@ -476,7 +476,7 @@ static int test_wolfCrypt_Init(void)
 /*----------------------------------------------------------------------------*
  | Platform dependent function test
  *----------------------------------------------------------------------------*/
- static int test_fileAccess()
+ static int test_fileAccess(void)
 {
 #if defined(WOLFSSL_TEST_PLATFORMDEPEND) && !defined(NO_FILESYSTEM)
     const char *fname[] = {
@@ -2503,7 +2503,7 @@ static void test_wolfSSL_EVP_get_cipherbynid(void)
 
 }
 
-static void test_wolfSSL_EVP_CIPHER_CTX()
+static void test_wolfSSL_EVP_CIPHER_CTX(void)
 {
 #if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
@@ -14777,7 +14777,7 @@ static int test_wc_CheckProbablePrime (void)
             ret = 0;
         }
     }
-    
+
     /* Good case */
     if (ret == 0) {
         ret = wc_CheckProbablePrime(p, pSz, q, qSz, e, eSz,
@@ -14920,7 +14920,7 @@ static int test_wc_RsaPSS_VerifyCheck (void)
         ret = wc_Hash(WC_HASH_TYPE_SHA256, pSignature, sz, digest, digestSz);
 
     }
-    
+
     if (ret == 0) {
         ret = wc_RsaPSS_Sign(digest, digestSz, pSignature, pSignatureSz,
                 WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng);
@@ -14957,8 +14957,8 @@ static int test_wc_RsaPSS_VerifyCheck (void)
             if (ret == BAD_FUNC_ARG) {
                 ret = 0;
             }
-    }   
-    
+    }
+
     /* Good case */
     if (ret == 0) {
         ret = wc_RsaPSS_VerifyCheck(pSignature, sz, pt, outLen,
@@ -14990,8 +14990,8 @@ static int test_wc_RsaPSS_VerifyCheckInline (void)
     word32              digestSz;
     unsigned char       pSignature[2048/8]; /* 2048 is RSA_KEY_SIZE */
     unsigned char       pDecrypted[2048/8];
-    pt = pDecrypted; 
-    
+    pt = pDecrypted;
+
 
     printf(testingFmt, "wc_RsaPSS_VerifyCheckInline()");
 
@@ -15014,7 +15014,7 @@ static int test_wc_RsaPSS_VerifyCheckInline (void)
         ret = wc_Hash(WC_HASH_TYPE_SHA256, pSignature, sz, digest, digestSz);
 
     }
-    
+
     if (ret == 0) {
         ret = wc_RsaPSS_Sign(digest, digestSz, pSignature, sizeof(pSignature),
                 WC_HASH_TYPE_SHA256, WC_MGF1SHA256, &key, &rng);
@@ -28062,7 +28062,7 @@ static void test_wolfSSL_CTX_get0_set1_param(void)
     WOLFSSL_X509_VERIFY_PARAM* pvpm;
     char testIPv4[] = "127.0.0.1";
     char testhostName[] = "foo.hoge.com";
-    
+
     printf(testingFmt, "wolfSSL_CTX_get0_set1_param()");
 
     #ifndef NO_WOLFSSL_SERVER
@@ -28085,15 +28085,15 @@ static void test_wolfSSL_CTX_get0_set1_param(void)
 
     ret = SSL_CTX_set1_param(ctx, pvpm);
     AssertIntEQ(1, ret);
-    AssertIntEQ(0, XSTRNCMP(pParam->hostName, testhostName, 
+    AssertIntEQ(0, XSTRNCMP(pParam->hostName, testhostName,
                                          (int)XSTRLEN(testhostName)));
     AssertIntEQ(0x01, pParam->hostFlags);
     AssertIntEQ(0, XSTRNCMP(pParam->ipasc, testIPv4, WOLFSSL_MAX_IPSTR));
-    
+
     SSL_CTX_free(ctx);
 
     XFREE(pvpm, NULL, DYNAMIC_TYPE_OPENSSL);
-    
+
     printf(resultFmt, passed);
 #endif /* OPENSSL_EXTRA && !defined(NO_RSA)*/
 }
@@ -29969,7 +29969,7 @@ static void test_wolfSSL_X509_VERIFY_PARAM(void)
     char testIPv6[] = "0001:0000:0000:0000:0000:0000:0000:0000/32";
     char testhostName1[] = "foo.hoge.com";
     char testhostName2[] = "foobar.hoge.com";
-    
+
     printf(testingFmt, "wolfSSL_X509()");
 
     paramTo = wolfSSL_X509_VERIFY_PARAM_new();
@@ -29983,9 +29983,9 @@ static void test_wolfSSL_X509_VERIFY_PARAM(void)
     ret = wolfSSL_X509_VERIFY_PARAM_set1_host(paramFrom, testhostName1,
                                          (int)XSTRLEN(testhostName1));
     AssertIntEQ(1, ret);
-    AssertIntEQ(0, XSTRNCMP(paramFrom->hostName, testhostName1, 
+    AssertIntEQ(0, XSTRNCMP(paramFrom->hostName, testhostName1,
                                         (int)XSTRLEN(testhostName1)));
-    
+
     wolfSSL_X509_VERIFY_PARAM_set_hostflags(NULL, 0x00);
 
     wolfSSL_X509_VERIFY_PARAM_set_hostflags(paramFrom, 0x01);
@@ -30018,7 +30018,7 @@ static void test_wolfSSL_X509_VERIFY_PARAM(void)
     /* inherit flags test : VPARAM_DEFAULT */
     ret = wolfSSL_X509_VERIFY_PARAM_set1(paramTo, paramFrom);
     AssertIntEQ(1, ret);
-    AssertIntEQ(0, XSTRNCMP(paramTo->hostName, testhostName1, 
+    AssertIntEQ(0, XSTRNCMP(paramTo->hostName, testhostName1,
                                     (int)XSTRLEN(testhostName1)));
     AssertIntEQ(0x01, paramTo->hostFlags);
     AssertIntEQ(0, XSTRNCMP(paramTo->ipasc, testIPv6, WOLFSSL_MAX_IPSTR));
@@ -30028,12 +30028,12 @@ static void test_wolfSSL_X509_VERIFY_PARAM(void)
                                     (int)XSTRLEN(testhostName2));
     wolfSSL_X509_VERIFY_PARAM_set1_ip_asc(paramTo, testIPv4);
     wolfSSL_X509_VERIFY_PARAM_set_hostflags(paramTo, 0x00);
-    
+
     paramTo->inherit_flags = WOLFSSL_VPARAM_OVERWRITE;
 
     ret = wolfSSL_X509_VERIFY_PARAM_set1(paramTo, paramFrom);
     AssertIntEQ(1, ret);
-    AssertIntEQ(0, XSTRNCMP(paramTo->hostName, testhostName1, 
+    AssertIntEQ(0, XSTRNCMP(paramTo->hostName, testhostName1,
                                         (int)XSTRLEN(testhostName1)));
     AssertIntEQ(0x01, paramTo->hostFlags);
     AssertIntEQ(0, XSTRNCMP(paramTo->ipasc, testIPv6, WOLFSSL_MAX_IPSTR));
@@ -30043,12 +30043,12 @@ static void test_wolfSSL_X509_VERIFY_PARAM(void)
                                       (int)XSTRLEN(testhostName2));
     wolfSSL_X509_VERIFY_PARAM_set1_ip_asc(paramTo, testIPv4);
     wolfSSL_X509_VERIFY_PARAM_set_hostflags(paramTo, 0x10);
-    
+
     paramTo->inherit_flags = WOLFSSL_VPARAM_RESET_FLAGS;
 
     ret = wolfSSL_X509_VERIFY_PARAM_set1(paramTo, paramFrom);
     AssertIntEQ(1, ret);
-    AssertIntEQ(0, XSTRNCMP(paramTo->hostName, testhostName1, 
+    AssertIntEQ(0, XSTRNCMP(paramTo->hostName, testhostName1,
                                         (int)XSTRLEN(testhostName1)));
     AssertIntEQ(0x01, paramTo->hostFlags);
     AssertIntEQ(0, XSTRNCMP(paramTo->ipasc, testIPv6, WOLFSSL_MAX_IPSTR));
@@ -30058,12 +30058,12 @@ static void test_wolfSSL_X509_VERIFY_PARAM(void)
                                     (int)XSTRLEN(testhostName2));
     wolfSSL_X509_VERIFY_PARAM_set1_ip_asc(paramTo, testIPv4);
     wolfSSL_X509_VERIFY_PARAM_set_hostflags(paramTo, 0x00);
-    
+
     paramTo->inherit_flags = WOLFSSL_VPARAM_LOCKED;
 
     ret = wolfSSL_X509_VERIFY_PARAM_set1(paramTo, paramFrom);
     AssertIntEQ(1, ret);
-    AssertIntEQ(0, XSTRNCMP(paramTo->hostName, testhostName2, 
+    AssertIntEQ(0, XSTRNCMP(paramTo->hostName, testhostName2,
                                     (int)XSTRLEN(testhostName2)));
     AssertIntEQ(0x00, paramTo->hostFlags);
     AssertIntEQ(0, XSTRNCMP(paramTo->ipasc, testIPv4, WOLFSSL_MAX_IPSTR));
@@ -30188,16 +30188,16 @@ static void test_wolfSSL_RAND_bytes(void)
 {
     #if defined(OPENSSL_EXTRA)
     const int size1 = RNG_MAX_BLOCK_LEN;        /* in bytes */
-    const int size2 = RNG_MAX_BLOCK_LEN + 1;    /* in bytes */ 
+    const int size2 = RNG_MAX_BLOCK_LEN + 1;    /* in bytes */
     const int size3 = RNG_MAX_BLOCK_LEN * 2;    /* in bytes */
     const int size4 = RNG_MAX_BLOCK_LEN * 4;    /* in bytes */
     int  max_bufsize;
     byte *my_buf;
-     
+
     printf(testingFmt, "test_wolfSSL_RAND_bytes()");
 
     max_bufsize = size4;
-    
+
     my_buf = (byte*)XMALLOC(max_bufsize * sizeof(byte), NULL,
                                                      DYNAMIC_TYPE_TMP_BUFFER);
     AssertNotNull(my_buf);
@@ -30206,7 +30206,7 @@ static void test_wolfSSL_RAND_bytes(void)
     AssertIntEQ(wolfSSL_RAND_bytes(my_buf, size2), 1);
     AssertIntEQ(wolfSSL_RAND_bytes(my_buf, size3), 1);
     AssertIntEQ(wolfSSL_RAND_bytes(my_buf, size4), 1);
-    
+
     XFREE(my_buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
     printf(resultFmt, passed);
@@ -32878,7 +32878,7 @@ static void test_wolfSSL_SHA(void)
         XMEMSET(out, 0, WC_SHA_DIGEST_SIZE);
         AssertNotNull(SHA1(in, XSTRLEN((char*)in), out));
         AssertIntEQ(XMEMCMP(out, expected, WC_SHA_DIGEST_SIZE), 0);
-        
+
         /* SHA interface test */
         XMEMSET(out, 0, WC_SHA_DIGEST_SIZE);
         AssertNotNull(SHA(in, XSTRLEN((char*)in), out));
@@ -33098,26 +33098,26 @@ static void test_wolfSSL_MD5(void)
     byte input1[] = "";
     byte input2[] = "message digest";
     byte hash[WC_MD5_DIGEST_SIZE];
-    unsigned char output1[] = 
+    unsigned char output1[] =
         "\xd4\x1d\x8c\xd9\x8f\x00\xb2\x04\xe9\x80\x09\x98\xec\xf8\x42\x7e";
     unsigned char output2[] =
         "\xf9\x6b\x69\x7d\x7c\xb7\x93\x8d\x52\x5a\x2f\x31\xaa\xf1\x61\xd0";
     WOLFSSL_MD5_CTX md5;
-    
+
     printf(testingFmt, "wolfSSL_MD5()");
-    
+
     XMEMSET(&md5, 0, sizeof(md5));
-    
+
     /* Init MD5 CTX */
     AssertIntEQ(wolfSSL_MD5_Init(&md5), 1);
-    AssertIntEQ(wolfSSL_MD5_Update(&md5, input1, 
+    AssertIntEQ(wolfSSL_MD5_Update(&md5, input1,
                                         XSTRLEN((const char*)&input1)), 1);
     AssertIntEQ(wolfSSL_MD5_Final(hash, &md5), 1);
     AssertIntEQ(XMEMCMP(&hash, output1, WC_MD5_DIGEST_SIZE), 0);
-    
+
     /* Init MD5 CTX */
     AssertIntEQ(wolfSSL_MD5_Init(&md5), 1);
-    AssertIntEQ(wolfSSL_MD5_Update(&md5, input2, 
+    AssertIntEQ(wolfSSL_MD5_Update(&md5, input2,
                                     (int)XSTRLEN((const char*)input2)), 1);
     AssertIntEQ(wolfSSL_MD5_Final(hash, &md5), 1);
     AssertIntEQ(XMEMCMP(&hash, output2, WC_MD5_DIGEST_SIZE), 0);
@@ -33141,18 +33141,18 @@ static void test_wolfSSL_MD5_Transform(void)
     byte input2[] = "abc";
     byte local[WC_MD5_BLOCK_SIZE];
     word32 sLen = 0;
-    unsigned char output1[] = 
+    unsigned char output1[] =
         "\xac\x1d\x1f\x03\xd0\x8e\xa5\x6e\xb7\x67\xab\x1f\x91\x77\x31\x74";
     unsigned char output2[] =
         "\x8d\x79\xd3\xef\x90\x25\x17\x67\xc7\x79\x13\xa4\xbc\x7b\xa7\xe3";
 
     WOLFSSL_MD5_CTX md5;
-    
+
     printf(testingFmt, "wolfSSL_MD5_Transform()");
-    
+
     XMEMSET(&md5, 0, sizeof(md5));
     XMEMSET(&local, 0, sizeof(local));
-    
+
     /* sanity check */
     AssertIntEQ(wolfSSL_MD5_Transform(NULL, NULL), 0);
     AssertIntEQ(wolfSSL_MD5_Transform(NULL, (const byte*)&input1), 0);
@@ -33160,24 +33160,24 @@ static void test_wolfSSL_MD5_Transform(void)
     AssertIntEQ(wc_Md5Transform(NULL, NULL), BAD_FUNC_ARG);
     AssertIntEQ(wc_Md5Transform(NULL, (const byte*)&input1), BAD_FUNC_ARG);
     AssertIntEQ(wc_Md5Transform((wc_Md5*)&md5, NULL), BAD_FUNC_ARG);
-    
+
     /* Init MD5 CTX */
     AssertIntEQ(wolfSSL_MD5_Init(&md5), 1);
     /* Do Transform*/
     sLen = (word32)XSTRLEN((char*)input1);
     XMEMCPY(local, input1, sLen);
     AssertIntEQ(wolfSSL_MD5_Transform(&md5, (const byte*)&local[0]), 1);
-    
-    AssertIntEQ(XMEMCMP(&((wc_Md5*)&md5)->digest[0], output1, 
+
+    AssertIntEQ(XMEMCMP(&((wc_Md5*)&md5)->digest[0], output1,
                                                     WC_MD5_DIGEST_SIZE), 0);
-    
+
     /* Init MD5 CTX */
     AssertIntEQ(wolfSSL_MD5_Init(&md5), 1);
     sLen = (word32)XSTRLEN((char*)input2);
     XMEMSET(local, 0, WC_MD5_BLOCK_SIZE);
     XMEMCPY(local, input2, sLen);
     AssertIntEQ(wolfSSL_MD5_Transform(&md5, (const byte*)&local[0]), 1);
-    AssertIntEQ(XMEMCMP(&((wc_Md5*)&md5)->digest[0], output2, 
+    AssertIntEQ(XMEMCMP(&((wc_Md5*)&md5)->digest[0], output2,
                                                     WC_MD5_DIGEST_SIZE), 0);
 
     printf(resultFmt, passed);
@@ -33216,7 +33216,7 @@ static void test_wolfSSL_SHA_Transform(void)
     byte input2[] = "abc";
     byte local[WC_SHA_BLOCK_SIZE];
     word32 sLen = 0;
-    unsigned char output1[] = 
+    unsigned char output1[] =
         "\xe5\x04\xb4\x92\xed\x8c\x58\x56\x4e\xcd\x1a\x6c\x68\x3f\x05\xbf"
         "\x93\x3a\xf7\x09";
     unsigned char output2[] =
@@ -33224,12 +33224,12 @@ static void test_wolfSSL_SHA_Transform(void)
         "\xb8\x08\x6e\x7c";
 
     WOLFSSL_SHA_CTX sha;
-    
+
     printf(testingFmt, "wolfSSL_SHA_Transform()");
-    
+
     XMEMSET(&sha, 0, sizeof(sha));
     XMEMSET(&local, 0, sizeof(local));
-    
+
     /* sanity check */
     AssertIntEQ(wolfSSL_SHA_Transform(NULL, NULL), 0);
     AssertIntEQ(wolfSSL_SHA_Transform(NULL, (const byte*)&input1), 0);
@@ -33237,25 +33237,25 @@ static void test_wolfSSL_SHA_Transform(void)
     AssertIntEQ(wc_ShaTransform(NULL, NULL), BAD_FUNC_ARG);
     AssertIntEQ(wc_ShaTransform(NULL, (const byte*)&input1), BAD_FUNC_ARG);
     AssertIntEQ(wc_ShaTransform((wc_Sha*)&sha, NULL), BAD_FUNC_ARG);
-    
+
     /* Init SHA CTX */
     AssertIntEQ(wolfSSL_SHA_Init(&sha), 1);
     /* Do Transform*/
     sLen = (word32)XSTRLEN((char*)input1);
     XMEMCPY(local, input1, sLen);
     AssertIntEQ(wolfSSL_SHA_Transform(&sha, (const byte*)&local[0]), 1);
-    AssertIntEQ(XMEMCMP(&((wc_Sha*)&sha)->digest[0], output1, 
+    AssertIntEQ(XMEMCMP(&((wc_Sha*)&sha)->digest[0], output1,
                                                         WC_SHA_DIGEST_SIZE), 0);
-    
+
     /* Init SHA256 CTX */
     AssertIntEQ(wolfSSL_SHA_Init(&sha), 1);
     sLen = (word32)XSTRLEN((char*)input2);
     XMEMSET(local, 0, WC_SHA_BLOCK_SIZE);
     XMEMCPY(local, input2, sLen);
     AssertIntEQ(wolfSSL_SHA_Transform(&sha, (const byte*)&local[0]), 1);
-    AssertIntEQ(XMEMCMP(&((wc_Sha*)&sha)->digest[0], output2, 
+    AssertIntEQ(XMEMCMP(&((wc_Sha*)&sha)->digest[0], output2,
                                                         WC_SHA_DIGEST_SIZE), 0);
-    
+
     printf(resultFmt, passed);
 #endif
 #endif
@@ -33270,20 +33270,20 @@ static void test_wolfSSL_SHA256_Transform(void)
     byte input2[] = "abc";
     byte local[WC_SHA256_BLOCK_SIZE];
     word32 sLen = 0;
-    unsigned char output1[] = 
+    unsigned char output1[] =
         "\xbe\x98\x56\xda\x69\xb4\xb9\x17\x99\x57\x33\x62\xca\xbe\x9f\x77"
         "\x91\xd4\xe5\x8c\x43\x62\xd2\xc0\xea\xf9\xfe\xba\xd8\xa9\x37\x18";
     unsigned char output2[] =
         "\x67\xd4\x4e\x1d\x67\x61\x7c\x67\x26\x76\x10\x44\xb8\xff\x10\x78"
         "\x39\x9a\xc8\x40\x8c\x60\x16\x73\x05\xd6\x61\xa6\x35\x8c\xf2\x91";
-    
+
     WOLFSSL_SHA256_CTX sha256;
-    
+
     printf(testingFmt, "wolfSSL_SHA256_Transform()");
-    
+
     XMEMSET(&sha256, 0, sizeof(sha256));
     XMEMSET(&local, 0, sizeof(local));
-    
+
     /* sanity check */
     AssertIntEQ(wolfSSL_SHA256_Transform(NULL, NULL), 0);
     AssertIntEQ(wolfSSL_SHA256_Transform(NULL, (const byte*)&input1), 0);
@@ -33291,25 +33291,25 @@ static void test_wolfSSL_SHA256_Transform(void)
     AssertIntEQ(wc_Sha256Transform(NULL, NULL), BAD_FUNC_ARG);
     AssertIntEQ(wc_Sha256Transform(NULL, (const byte*)&input1), BAD_FUNC_ARG);
     AssertIntEQ(wc_Sha256Transform((wc_Sha256*)&sha256, NULL), BAD_FUNC_ARG);
-    
+
     /* Init SHA256 CTX */
     AssertIntEQ(wolfSSL_SHA256_Init(&sha256), 1);
     /* Do Transform*/
     sLen = (word32)XSTRLEN((char*)input1);
     XMEMCPY(local, input1, sLen);
     AssertIntEQ(wolfSSL_SHA256_Transform(&sha256, (const byte*)&local[0]), 1);
-    AssertIntEQ(XMEMCMP(&((wc_Sha256*)&sha256)->digest[0], output1, 
+    AssertIntEQ(XMEMCMP(&((wc_Sha256*)&sha256)->digest[0], output1,
                                                     WC_SHA256_DIGEST_SIZE), 0);
-    
+
     /* Init SHA256 CTX */
     AssertIntEQ(wolfSSL_SHA256_Init(&sha256), 1);
     sLen = (word32)XSTRLEN((char*)input2);
     XMEMSET(local, 0, WC_SHA256_BLOCK_SIZE);
     XMEMCPY(local, input2, sLen);
     AssertIntEQ(wolfSSL_SHA256_Transform(&sha256, (const byte*)&local[0]), 1);
-    AssertIntEQ(XMEMCMP(&((wc_Sha256*)&sha256)->digest[0], output2, 
+    AssertIntEQ(XMEMCMP(&((wc_Sha256*)&sha256)->digest[0], output2,
                                                     WC_SHA256_DIGEST_SIZE), 0);
-    
+
     printf(resultFmt, passed);
 #endif
 #endif
@@ -33348,7 +33348,7 @@ static void test_wolfSSL_SHA512_Transform(void)
     byte input2[] = "abc";
     byte local[WC_SHA512_BLOCK_SIZE];
     word32 sLen = 0;
-    unsigned char output1[] = 
+    unsigned char output1[] =
         "\xe8\xcb\x4a\x77\xd5\x81\x78\xcf\x70\x80\xc7\xfb\xe0\x62\x33\x53"
         "\xda\x0e\x46\x87\x9d\x63\x67\x02\xb0\x31\x59\xe8\x40\xcb\x86\x30"
         "\xa3\x23\xa0\x88\x52\xc9\x7d\x71\xe0\xb5\xe0\x4c\xc1\xb2\xba\x96"
@@ -33358,14 +33358,14 @@ static void test_wolfSSL_SHA512_Transform(void)
         "\x41\x31\xab\xca\x3d\x26\xb4\xa9\xab\xd7\x67\xe1\xaf\xaa\xc6\xe2"
         "\x83\x4e\xba\x2c\x54\x2e\x8f\x31\x98\x38\x2b\x8f\x9d\xec\x88\xbe"
         "\x4d\x5e\x8b\x53\x9d\x4e\xd2\x14\xf0\x96\x20\xaf\x69\x6c\x68\xde";
-    
+
     WOLFSSL_SHA512_CTX sha512;
-    
+
     printf(testingFmt, "wolfSSL_SHA512_Transform()");
-    
+
     XMEMSET(&sha512, 0, sizeof(sha512));
     XMEMSET(&local, 0, sizeof(local));
-    
+
     /* sanity check */
     AssertIntEQ(wolfSSL_SHA512_Transform(NULL, NULL), 0);
     AssertIntEQ(wolfSSL_SHA512_Transform(NULL, (const byte*)&input1), 0);
@@ -33373,7 +33373,7 @@ static void test_wolfSSL_SHA512_Transform(void)
     AssertIntEQ(wc_Sha512Transform(NULL, NULL), BAD_FUNC_ARG);
     AssertIntEQ(wc_Sha512Transform(NULL, (const byte*)&input1), BAD_FUNC_ARG);
     AssertIntEQ(wc_Sha512Transform((wc_Sha512*)&sha512, NULL), BAD_FUNC_ARG);
-    
+
     /* Init SHA512 CTX */
     AssertIntEQ(wolfSSL_SHA512_Init(&sha512), 1);
 
@@ -33381,16 +33381,16 @@ static void test_wolfSSL_SHA512_Transform(void)
     sLen = (word32)XSTRLEN((char*)input1);
     XMEMCPY(local, input1, sLen);
     AssertIntEQ(wolfSSL_SHA512_Transform(&sha512, (const byte*)&local[0]), 1);
-   AssertIntEQ(XMEMCMP(&((wc_Sha512*)&sha512)->digest[0], output1, 
+   AssertIntEQ(XMEMCMP(&((wc_Sha512*)&sha512)->digest[0], output1,
                                                     WC_SHA512_DIGEST_SIZE), 0);
-    
+
     /* Init SHA512 CTX */
     AssertIntEQ(wolfSSL_SHA512_Init(&sha512), 1);
     sLen = (word32)XSTRLEN((char*)input2);
     XMEMSET(local, 0, WC_SHA512_BLOCK_SIZE);
     XMEMCPY(local, input2, sLen);
     AssertIntEQ(wolfSSL_SHA512_Transform(&sha512, (const byte*)&local[0]), 1);
-    AssertIntEQ(XMEMCMP(&((wc_Sha512*)&sha512)->digest[0], output2, 
+    AssertIntEQ(XMEMCMP(&((wc_Sha512*)&sha512)->digest[0], output2,
                                                     WC_SHA512_DIGEST_SIZE), 0);
     (void)input1;
     printf(resultFmt, passed);
@@ -33913,7 +33913,7 @@ static void test_wolfSSL_DES_ncbc(void){
 #endif
 }
 
-static void test_wolfSSL_AES_cbc_encrypt()
+static void test_wolfSSL_AES_cbc_encrypt(void)
 {
 #if !defined(NO_AES) && defined(HAVE_AES_CBC) && defined(OPENSSL_EXTRA)
     AES_KEY aes;
@@ -34344,7 +34344,7 @@ static void test_wolfSSL_X509_PUBKEY_get(void)
     printf(resultFmt,retEvpPkey == NULL ? passed : failed);
 }
 
-static void test_wolfSSL_d2i_DHparams()
+static void test_wolfSSL_d2i_DHparams(void)
 {
 #if !defined(NO_DH)
 #if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION>2))
@@ -34406,7 +34406,7 @@ static void test_wolfSSL_d2i_DHparams()
 #endif /* !NO_DH */
 }
 
-static void test_wolfSSL_i2d_DHparams()
+static void test_wolfSSL_i2d_DHparams(void)
 {
 #if !defined(NO_DH)
 #if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION>2))
@@ -35597,7 +35597,7 @@ static void test_wolfSSL_EVP_CIPHER_iv_length(void)
          NID_des_ede3_cbc,
     #endif
     #ifdef HAVE_IDEA
-         NID_idea_cbc, 
+         NID_idea_cbc,
     #endif
     };
     int iv_lengths[] = {
@@ -35809,7 +35809,7 @@ static void test_IncCtr(void)
 
     ctx->cipher.aes.keylen = 128;
 
-    AssertIntEQ(wolfSSL_EVP_CIPHER_CTX_ctrl(ctx, type, arg, ptr), 0); 
+    AssertIntEQ(wolfSSL_EVP_CIPHER_CTX_ctrl(ctx, type, arg, ptr), 0);
 
 
     EVP_CIPHER_CTX_free(ctx);
@@ -36429,7 +36429,7 @@ static void test_wolfSSL_X509_cmp(void)
 #endif
 }
 
-static void test_wolfSSL_PKEY_up_ref()
+static void test_wolfSSL_PKEY_up_ref(void)
 {
 #if defined(OPENSSL_ALL)
     EVP_PKEY* pkey;
@@ -36447,7 +36447,7 @@ static void test_wolfSSL_PKEY_up_ref()
 #endif
 }
 
-static void test_wolfSSL_i2d_PrivateKey()
+static void test_wolfSSL_i2d_PrivateKey(void)
 {
 #if (!defined(NO_RSA) || defined(HAVE_ECC)) && defined(OPENSSL_EXTRA) && !defined(NO_ASN) && !defined(NO_PWDBASED)
 
@@ -36494,7 +36494,7 @@ static void test_wolfSSL_i2d_PrivateKey()
 #endif
 }
 
-static void test_wolfSSL_OCSP_id_get0_info()
+static void test_wolfSSL_OCSP_id_get0_info(void)
 {
 #if defined(OPENSSL_ALL) && defined(HAVE_OCSP) && !defined(NO_FILESYSTEM)
     X509* cert;
@@ -36542,7 +36542,7 @@ static void test_wolfSSL_OCSP_id_get0_info()
 #endif
 }
 
-static void test_wolfSSL_i2d_OCSP_CERTID()
+static void test_wolfSSL_i2d_OCSP_CERTID(void)
 {
 #if defined(OPENSSL_ALL) && defined(HAVE_OCSP)
     WOLFSSL_OCSP_CERTID certId;
@@ -36561,7 +36561,7 @@ static void test_wolfSSL_i2d_OCSP_CERTID()
     int ret, i;
 
     printf(testingFmt, "wolfSSL_i2d_OCSP_CERTID()");
-    
+
     XMEMSET(&certId, 0, sizeof(WOLFSSL_OCSP_CERTID));
     certId.rawCertId = rawCertId;
     certId.rawCertIdSize = sizeof(rawCertId);
@@ -36597,7 +36597,7 @@ static void test_wolfSSL_i2d_OCSP_CERTID()
 #endif
 }
 
-static void test_wolfSSL_OCSP_SINGLERESP_get0_id()
+static void test_wolfSSL_OCSP_SINGLERESP_get0_id(void)
 {
 #if defined(OPENSSL_ALL) && defined(HAVE_OCSP)
     WOLFSSL_OCSP_SINGLERESP single;
@@ -36605,7 +36605,7 @@ static void test_wolfSSL_OCSP_SINGLERESP_get0_id()
 
     XMEMSET(&single, 0, sizeof(single));
     certId = wolfSSL_OCSP_SINGLERESP_get0_id(&single);
-    
+
     printf(testingFmt, "wolfSSL_OCSP_SINGLERESP_get0_id()");
 
     AssertPtrEq(&single, certId);
@@ -36614,9 +36614,9 @@ static void test_wolfSSL_OCSP_SINGLERESP_get0_id()
 #endif
 }
 
-static void test_wolfSSL_OCSP_single_get0_status()
+static void test_wolfSSL_OCSP_single_get0_status(void)
 {
-#if defined(OPENSSL_ALL) && defined(HAVE_OCSP) 
+#if defined(OPENSSL_ALL) && defined(HAVE_OCSP)
     WOLFSSL_OCSP_SINGLERESP single;
     CertStatus certStatus;
     WOLFSSL_ASN1_TIME* thisDate;
@@ -36646,7 +36646,7 @@ static void test_wolfSSL_OCSP_single_get0_status()
 #endif
 }
 
-static void test_wolfSSL_OCSP_resp_count()
+static void test_wolfSSL_OCSP_resp_count(void)
 {
 #if defined(OPENSSL_ALL) && defined(HAVE_OCSP)
     WOLFSSL_OCSP_BASICRESP basicResp;
@@ -36675,7 +36675,7 @@ static void test_wolfSSL_OCSP_resp_count()
 #endif
 }
 
-static void test_wolfSSL_OCSP_resp_get0()
+static void test_wolfSSL_OCSP_resp_get0(void)
 {
 #if defined(OPENSSL_ALL) && defined(HAVE_OCSP)
     WOLFSSL_OCSP_BASICRESP basicResp;
@@ -36784,7 +36784,7 @@ static void test_wolfSSL_RSA_padding_add_PKCS1_PSS(void)
 #endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
 #endif /* OPENSSL_ALL && WC_RSA_PSS && !WC_NO_RNG*/
 }
-#endif 
+#endif
 
 static void test_wolfSSL_EC_get_builtin_curves(void)
 {
@@ -39214,7 +39214,7 @@ static void test_wolfSSL_X509_load_crl_file(void)
 
     AssertNotNull(store = wolfSSL_X509_STORE_new());
     AssertNotNull(lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file()));
-    
+
     AssertIntEQ(wolfSSL_X509_LOOKUP_load_file(lookup, "certs/ca-cert.pem",
                                               X509_FILETYPE_PEM), 1);
     AssertIntEQ(wolfSSL_X509_LOOKUP_load_file(lookup, "certs/server-revoked-cert.pem",
@@ -39226,12 +39226,12 @@ static void test_wolfSSL_X509_load_crl_file(void)
         AssertIntEQ(wolfSSL_CertManagerVerify(store->cm, "certs/server-revoked-cert.pem",
                     WOLFSSL_FILETYPE_PEM), 1);
     }
-    
+
     for (i = 0; pem[i][0] != '\0'; i++)
     {
         AssertIntEQ(wolfSSL_X509_load_crl_file(lookup, pem[i], WOLFSSL_FILETYPE_PEM), 1);
     }
-    
+
     if (store) {
         /* since store knows crl list */
         AssertIntEQ(wolfSSL_CertManagerVerify(store->cm, "certs/server-revoked-cert.pem",
@@ -39240,10 +39240,10 @@ static void test_wolfSSL_X509_load_crl_file(void)
     /* once feeing store */
     wolfSSL_X509_STORE_free(store);
     store = NULL;
-    
+
     AssertNotNull(store = wolfSSL_X509_STORE_new());
     AssertNotNull(lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file()));
-    
+
     AssertIntEQ(wolfSSL_X509_LOOKUP_load_file(lookup, "certs/ca-cert.pem",
                                               X509_FILETYPE_PEM), 1);
     AssertIntEQ(wolfSSL_X509_LOOKUP_load_file(lookup, "certs/server-revoked-cert.pem",
@@ -39255,21 +39255,21 @@ static void test_wolfSSL_X509_load_crl_file(void)
         AssertIntEQ(wolfSSL_CertManagerVerify(store->cm, "certs/server-revoked-cert.pem",
                     WOLFSSL_FILETYPE_PEM), 1);
     }
-    
+
     for (i = 0; der[i][0] != '\0'; i++)
     {
         AssertIntEQ(wolfSSL_X509_load_crl_file(lookup, der[i], WOLFSSL_FILETYPE_ASN1), 1);
     }
-    
+
     if (store) {
         /* since store knows crl list */
         AssertIntEQ(wolfSSL_CertManagerVerify(store->cm, "certs/server-revoked-cert.pem",
                    WOLFSSL_FILETYPE_PEM ), CRL_CERT_REVOKED);
     }
-    
+
     wolfSSL_X509_STORE_free(store);
     store = NULL;
-    
+
     printf(resultFmt, passed);
 #endif
 }
@@ -39634,23 +39634,23 @@ static void test_wolfssl_EVP_aes_gcm_AAD_2_parts(void)
 
 #if defined(OPENSSL_EXTRA) && !defined(NO_AES) && defined(HAVE_AESGCM) && \
     !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
-static void test_wolfssl_EVP_aes_gcm_zeroLen()
-{       
+static void test_wolfssl_EVP_aes_gcm_zeroLen(void)
+{
     /* Zero length plain text */
 
-    byte key[] = 
+    byte key[] =
         {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
         0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
         0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
         0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}; /* align */
-    byte iv[]  = 
+    byte iv[]  =
         {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00};
                                                             /* align */
     byte plaintxt[0];
     int ivSz  = 12;
     int plaintxtSz = 0;
     unsigned char tag[16];
-    unsigned char tag_kat[] = 
+    unsigned char tag_kat[] =
         {0x53,0x0f,0x8a,0xfb,0xc7,0x45,0x36,0xb9,
         0xa9,0x63,0xb4,0xf1,0xc4,0xcb,0x73,0x8b};
 
@@ -39673,7 +39673,7 @@ static void test_wolfssl_EVP_aes_gcm_zeroLen()
 
     AssertIntEQ(0, ciphertxtSz);
     AssertIntEQ(0, XMEMCMP(tag, tag_kat, sizeof(tag)));
-    
+
     EVP_CIPHER_CTX_init(de);
     AssertIntEQ(1, EVP_DecryptInit_ex(de, EVP_aes_256_gcm(), NULL, key, iv));
     AssertIntEQ(1, EVP_CIPHER_CTX_ctrl(de, EVP_CTRL_GCM_SET_IVLEN, ivSz, NULL));
@@ -39683,7 +39683,7 @@ static void test_wolfssl_EVP_aes_gcm_zeroLen()
     AssertIntEQ(1, EVP_DecryptFinal_ex(de, decryptedtxt, &len));
     decryptedtxtSz += len;
     AssertIntEQ(0, decryptedtxtSz);
-    
+
     EVP_CIPHER_CTX_free(en);
     EVP_CIPHER_CTX_free(de);
 }
@@ -39795,7 +39795,7 @@ static void test_wolfssl_EVP_aes_gcm(void)
         AssertIntEQ(0, len);
         AssertIntEQ(wolfSSL_EVP_CIPHER_CTX_cleanup(&de[i]), 1);
     }
-    
+
     test_wolfssl_EVP_aes_gcm_zeroLen();
 
     printf(resultFmt, passed);
@@ -39848,7 +39848,7 @@ static void test_wolfSSL_PEM_X509_INFO_read_bio(void)
 }
 #endif /* !NO_BIO */
 
-static void test_wolfSSL_X509_NAME_ENTRY_get_object()
+static void test_wolfSSL_X509_NAME_ENTRY_get_object(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_FILESYSTEM) && !defined(NO_RSA)
     X509 *x509;
@@ -39874,7 +39874,7 @@ static void test_wolfSSL_X509_NAME_ENTRY_get_object()
 #endif
 }
 
-static void test_wolfSSL_ASN1_INTEGER_set()
+static void test_wolfSSL_ASN1_INTEGER_set(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_ASN)
     ASN1_INTEGER *a;
@@ -39972,7 +39972,7 @@ ASN1_SEQUENCE(DPP_BOOTSTRAPPING_KEY) = {
 IMPLEMENT_ASN1_FUNCTIONS(DPP_BOOTSTRAPPING_KEY);
 #endif
 
-static void test_wolfSSL_IMPLEMENT_ASN1_FUNCTIONS()
+static void test_wolfSSL_IMPLEMENT_ASN1_FUNCTIONS(void)
 {
     /* Testing code used in dpp.c in hostap */
 #if defined(OPENSSL_ALL) && defined(HAVE_ECC) && defined(USE_CERT_BUFFERS_256)
@@ -40030,7 +40030,7 @@ static void test_wolfSSL_IMPLEMENT_ASN1_FUNCTIONS()
 #endif /* WOLFSSL_WPAS && HAVE_ECC && USE_CERT_BUFFERS_256 */
 }
 
-static void test_wolfSSL_i2c_ASN1_INTEGER()
+static void test_wolfSSL_i2c_ASN1_INTEGER(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_ASN)
     ASN1_INTEGER *a;
@@ -40166,7 +40166,7 @@ static int test_ForceZero(void)
 
 #ifndef NO_BIO
 
-static void test_wolfSSL_X509_print()
+static void test_wolfSSL_X509_print(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_FILESYSTEM) && \
    !defined(NO_RSA) && !defined(HAVE_FAST_RSA) && defined(XSNPRINTF)
@@ -40210,7 +40210,7 @@ static void test_wolfSSL_X509_print()
 #endif
 }
 
-static void test_wolfSSL_RSA_print()
+static void test_wolfSSL_RSA_print(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_FILESYSTEM) && \
    !defined(NO_RSA) && !defined(HAVE_FAST_RSA) && defined(WOLFSSL_KEY_GEN) && \
@@ -40229,7 +40229,7 @@ static void test_wolfSSL_RSA_print()
 #endif
 }
 
-static void test_wolfSSL_BIO_get_len()
+static void test_wolfSSL_BIO_get_len(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_BIO)
     BIO *bio;
@@ -40362,7 +40362,7 @@ static void test_wolfSSL_ASN1_get_object(void)
 #endif /* OPENSSL_EXTRA && HAVE_ECC && USE_CERT_BUFFERS_256 */
 }
 
-static void test_wolfSSL_RSA_verify()
+static void test_wolfSSL_RSA_verify(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_RSA) && !defined(HAVE_FAST_RSA) && \
     !defined(NO_FILESYSTEM) && defined(HAVE_CRL)
@@ -40547,7 +40547,7 @@ static void test_openssl_generate_key_and_cert(void)
 #endif /* OPENSSL_EXTRA */
 }
 
-static void test_stubs_are_stubs()
+static void test_stubs_are_stubs(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_WOLFSSL_STUB)
     WOLFSSL_CTX* ctx = NULL;
@@ -40586,7 +40586,7 @@ static void test_stubs_are_stubs()
 #endif /* OPENSSL_EXTRA && !NO_WOLFSSL_STUB */
 }
 
-static void test_wolfSSL_CTX_LoadCRL()
+static void test_wolfSSL_CTX_LoadCRL(void)
 {
 #ifdef HAVE_CRL
     WOLFSSL_CTX* ctx = NULL;
@@ -41389,9 +41389,9 @@ void ApiTest(void)
     test_wolfSSL_OCSP_resp_count();
     test_wolfSSL_OCSP_resp_get0();
     test_wolfSSL_EVP_PKEY_derive();
-#ifndef NO_RSA   
+#ifndef NO_RSA
     test_wolfSSL_RSA_padding_add_PKCS1_PSS();
-#endif    
+#endif
 
 #if defined(OPENSSL_ALL)
     test_wolfSSL_X509_PUBKEY_get();


### PR DESCRIPTION
fix numerous warnings from autoconf, and a large batch of warnings on improper function declarations in api.c.
