### PR TITLE
Fixes for SP RSA/DH with `WOLFSSL_SP_NO_MALLOC`

### DIFF
--- a/wolfcrypt/src/sp_arm32.c
+++ b/wolfcrypt/src/sp_arm32.c
@@ -4701,12 +4701,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 64];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -4718,19 +4718,14 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 64), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 64;
-#else
-            t[i] = &td[i * 64];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -4826,9 +4821,8 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -4847,12 +4841,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 64];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -4864,19 +4858,14 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 64), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 64;
-#else
-            t[i] = &td[i * 64];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -4989,9 +4978,8 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -6992,12 +6980,12 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 128];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -7009,19 +6997,14 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 128), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 128;
-#else
-            t[i] = &td[i * 128];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -7117,9 +7100,8 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -7138,12 +7120,12 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 128];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -7155,19 +7137,14 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 128), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 128;
-#else
-            t[i] = &td[i * 128];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -7280,9 +7257,8 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -7306,18 +7282,15 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
 int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[128];
-    sp_digit m[64];
-    sp_digit r[128];
-#else
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[64 * 5];
+#endif    
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-#endif
     sp_digit *ah = NULL;
-    sp_digit e[1];
+    sp_digit e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 256) {
@@ -7331,22 +7304,18 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
-    }
-
-    if (err == MP_OKAY) {
-        a = d;
-        r = a + 64 * 2;
-        m = r + 64 * 2;
     }
 #endif
 
     if (err == MP_OKAY) {
+        r = a + 64 * 2;
+        m = r + 64 * 2;
         ah = a + 64;
 
         sp_2048_from_bin(ah, 64, in, inLen);
@@ -7419,10 +7388,9 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 256;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
 #endif
 
     return err;
@@ -7657,8 +7625,12 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[64 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -7687,13 +7659,15 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 64;
         m = a + 128;
@@ -7704,34 +7678,36 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         sp_2048_from_mp(m, 64, mm);
         err = sp_2048_mod_exp_64(r, a, d, 2048, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_2048_to_bin(r, out);
         *outLen = 256;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 64);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 64);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[64 * 2];
-    sp_digit p[32];
-    sp_digit q[32];
-    sp_digit dp[32];
-    sp_digit tmpa[64];
-    sp_digit tmpb[64];
-#else
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[32 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
     sp_digit* tmpa = NULL;
     sp_digit* tmpb = NULL;
-#endif
     sp_digit* r = NULL;
     sp_digit* qi = NULL;
     sp_digit* dq = NULL;
@@ -7751,31 +7727,23 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
+
     if (err == MP_OKAY) {
-        a = t;
         p = a + 64 * 2;
         q = p + 32;
         qi = dq = dp = q + 32;
         tmpa = qi + 32;
         tmpb = tmpa + 64;
-
-        r = t + 64;
-    }
-#else
-#endif
-
-    if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         r = a;
-        qi = dq = dp;
-#endif
+
         sp_2048_from_bin(a, 64, in, inLen);
         sp_2048_from_mp(p, 32, pm);
         sp_2048_from_mp(q, 32, qm);
@@ -7807,19 +7775,16 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 256;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 32 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
-    }
-#else
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p,    0, sizeof(p));
-    XMEMSET(q,    0, sizeof(q));
-    XMEMSET(dp,   0, sizeof(dp));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
 #endif
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+    {
+        ForceZero(a, sizeof(sp_digit) * 32 * 11);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -8353,12 +8318,12 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
         const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[193];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -8371,18 +8336,13 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 193, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp = td + 128;
-#else
-        tmp = &td[128];
-#endif
 
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_64(norm, m);
@@ -8453,9 +8413,8 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -15331,12 +15290,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 96];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -15348,19 +15307,14 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 96), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 96;
-#else
-            t[i] = &td[i * 96];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -15456,9 +15410,8 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -15477,12 +15430,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 96];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -15494,19 +15447,14 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 96), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 96;
-#else
-            t[i] = &td[i * 96];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -15619,9 +15567,8 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -18422,12 +18369,12 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 192];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -18439,19 +18386,14 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 192), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 192;
-#else
-            t[i] = &td[i * 192];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -18547,9 +18489,8 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -18568,12 +18509,12 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 192];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -18585,19 +18526,14 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 192), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 192;
-#else
-            t[i] = &td[i * 192];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -18710,9 +18646,8 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -18736,18 +18671,15 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
 int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[192];
-    sp_digit m[96];
-    sp_digit r[192];
-#else
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[96 * 5];
+#endif    
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-#endif
     sp_digit *ah = NULL;
-    sp_digit e[1];
+    sp_digit e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 384) {
@@ -18761,22 +18693,18 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 96 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 96 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
-    }
-
-    if (err == MP_OKAY) {
-        a = d;
-        r = a + 96 * 2;
-        m = r + 96 * 2;
     }
 #endif
 
     if (err == MP_OKAY) {
+        r = a + 96 * 2;
+        m = r + 96 * 2;
         ah = a + 96;
 
         sp_3072_from_bin(ah, 96, in, inLen);
@@ -18849,10 +18777,9 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 384;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
 #endif
 
     return err;
@@ -19167,8 +19094,12 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[96 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -19197,13 +19128,15 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 96 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 96;
         m = a + 192;
@@ -19214,34 +19147,36 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_from_mp(m, 96, mm);
         err = sp_3072_mod_exp_96(r, a, d, 3072, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_3072_to_bin(r, out);
         *outLen = 384;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 96);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 96);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[96 * 2];
-    sp_digit p[48];
-    sp_digit q[48];
-    sp_digit dp[48];
-    sp_digit tmpa[96];
-    sp_digit tmpb[96];
-#else
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[48 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
     sp_digit* tmpa = NULL;
     sp_digit* tmpb = NULL;
-#endif
     sp_digit* r = NULL;
     sp_digit* qi = NULL;
     sp_digit* dq = NULL;
@@ -19261,31 +19196,23 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 48 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 48 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
+
     if (err == MP_OKAY) {
-        a = t;
         p = a + 96 * 2;
         q = p + 48;
         qi = dq = dp = q + 48;
         tmpa = qi + 48;
         tmpb = tmpa + 96;
-
-        r = t + 96;
-    }
-#else
-#endif
-
-    if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         r = a;
-        qi = dq = dp;
-#endif
+
         sp_3072_from_bin(a, 96, in, inLen);
         sp_3072_from_mp(p, 48, pm);
         sp_3072_from_mp(q, 48, qm);
@@ -19317,19 +19244,16 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 384;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 48 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
-    }
-#else
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p,    0, sizeof(p));
-    XMEMSET(q,    0, sizeof(q));
-    XMEMSET(dp,   0, sizeof(dp));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
 #endif
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+    {
+        ForceZero(a, sizeof(sp_digit) * 48 * 11);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -20055,12 +19979,12 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
         const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[289];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -20073,18 +19997,13 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 289, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp = td + 192;
-#else
-        tmp = &td[192];
-#endif
 
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_96(norm, m);
@@ -20155,9 +20074,8 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -26354,12 +26272,12 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 256];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -26371,19 +26289,14 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 256), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 256;
-#else
-            t[i] = &td[i * 256];
-#endif
         }
 
         sp_4096_mont_setup(m, &mp);
@@ -26479,9 +26392,8 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -26500,12 +26412,12 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 256];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -26517,19 +26429,14 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 256), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 256;
-#else
-            t[i] = &td[i * 256];
-#endif
         }
 
         sp_4096_mont_setup(m, &mp);
@@ -26642,9 +26549,8 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -26668,18 +26574,15 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
 int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[256];
-    sp_digit m[128];
-    sp_digit r[256];
-#else
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[128 * 5];
+#endif    
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-#endif
     sp_digit *ah = NULL;
-    sp_digit e[1];
+    sp_digit e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 512) {
@@ -26693,22 +26596,18 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 128 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 128 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
-    }
-
-    if (err == MP_OKAY) {
-        a = d;
-        r = a + 128 * 2;
-        m = r + 128 * 2;
     }
 #endif
 
     if (err == MP_OKAY) {
+        r = a + 128 * 2;
+        m = r + 128 * 2;
         ah = a + 128;
 
         sp_4096_from_bin(ah, 128, in, inLen);
@@ -26781,10 +26680,9 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 512;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
 #endif
 
     return err;
@@ -27179,8 +27077,12 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[128 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -27209,13 +27111,15 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 128 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 128;
         m = a + 256;
@@ -27226,34 +27130,36 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_from_mp(m, 128, mm);
         err = sp_4096_mod_exp_128(r, a, d, 4096, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_4096_to_bin(r, out);
         *outLen = 512;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 128);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 128);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[128 * 2];
-    sp_digit p[64];
-    sp_digit q[64];
-    sp_digit dp[64];
-    sp_digit tmpa[128];
-    sp_digit tmpb[128];
-#else
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[64 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
     sp_digit* tmpa = NULL;
     sp_digit* tmpb = NULL;
-#endif
     sp_digit* r = NULL;
     sp_digit* qi = NULL;
     sp_digit* dq = NULL;
@@ -27273,31 +27179,23 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
+
     if (err == MP_OKAY) {
-        a = t;
         p = a + 128 * 2;
         q = p + 64;
         qi = dq = dp = q + 64;
         tmpa = qi + 64;
         tmpb = tmpa + 128;
-
-        r = t + 128;
-    }
-#else
-#endif
-
-    if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         r = a;
-        qi = dq = dp;
-#endif
+
         sp_4096_from_bin(a, 128, in, inLen);
         sp_4096_from_mp(p, 64, pm);
         sp_4096_from_mp(q, 64, qm);
@@ -27329,19 +27227,16 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 512;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 64 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
-    }
-#else
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p,    0, sizeof(p));
-    XMEMSET(q,    0, sizeof(q));
-    XMEMSET(dp,   0, sizeof(dp));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
 #endif
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+    {
+        ForceZero(a, sizeof(sp_digit) * 64 * 11);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -28259,12 +28154,12 @@ static int sp_4096_mod_exp_2_128(sp_digit* r, const sp_digit* e, int bits,
         const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[385];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -28277,18 +28172,13 @@ static int sp_4096_mod_exp_2_128(sp_digit* r, const sp_digit* e, int bits,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 385, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp = td + 256;
-#else
-        tmp = &td[256];
-#endif
 
         sp_4096_mont_setup(m, &mp);
         sp_4096_mont_norm_128(norm, m);
@@ -28359,9 +28249,8 @@ static int sp_4096_mod_exp_2_128(sp_digit* r, const sp_digit* e, int bits,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -29648,64 +29537,6 @@ static sp_digit sp_256_sub_8(sp_digit* r, const sp_digit* a,
 }
 
 #endif /* WOLFSSL_SP_SMALL */
-/* Create a new point.
- *
- * heap  [in]   Buffer to allocate dynamic memory from.
- * sp    [in]   Data for point - only if not allocating.
- * p     [out]  New point.
- * returns MEMORY_E when dynamic memory allocation fails and 0 otherwise.
- */
-static int sp_256_point_new_ex_8(void* heap, sp_point_256* sp,
-    sp_point_256** p)
-{
-    int ret = MP_OKAY;
-    (void)heap;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    (void)sp;
-    *p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap, DYNAMIC_TYPE_ECC);
-#else
-    *p = sp;
-#endif
-    if (*p == NULL) {
-        ret = MEMORY_E;
-    }
-    return ret;
-}
-
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* Allocate memory for point and return error. */
-#define sp_256_point_new_8(heap, sp, p) sp_256_point_new_ex_8((heap), NULL, &(p))
-#else
-/* Set pointer to data and return no error. */
-#define sp_256_point_new_8(heap, sp, p) sp_256_point_new_ex_8((heap), &(sp), &(p))
-#endif
-
-
-/* Free the point.
- *
- * p      [in,out]  Point to free.
- * clear  [in]      Indicates whether to zeroize point.
- * heap   [in]      Buffer from which dynamic memory was allocate from.
- */
-static void sp_256_point_free_8(sp_point_256* p, int clear, void* heap)
-{
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* If valid pointer then clear point data if requested and free data. */
-    if (p != NULL) {
-        if (clear != 0) {
-            XMEMSET(p, 0, sizeof(*p));
-        }
-        XFREE(p, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-/* Clear point data if requested. */
-    if ((p != NULL) && (clear != 0)) {
-        XMEMSET(p, 0, sizeof(*p));
-    }
-#endif
-    (void)heap;
-}
-
 /* Multiply a number by Montogmery normalizer mod modulus (prime).
  *
  * r  The resulting Montgomery form number.
@@ -32739,56 +32570,55 @@ static void sp_256_get_point_16_8(sp_point_256* r, const sp_point_256* table,
 static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, const sp_digit* k,
         int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td[16];
-    sp_point_256 rtd;
-    sp_digit tmpd[2 * 8 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_256 t[16];
+    sp_digit tmp[2 * 8 * 5];
+#endif
+    sp_point_256* rt = NULL;
 #ifndef WC_NO_CACHE_RESISTANT
-    sp_point_256 pd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* p = NULL;
+#else
+    sp_point_256 p[1];
 #endif
-#endif
-    sp_point_256* t;
-    sp_point_256* rt;
-#ifndef WC_NO_CACHE_RESISTANT
-    sp_point_256* p;
-#endif
-    sp_digit* tmp;
+#endif /* !WC_NO_CACHE_RESISTANT */
     sp_digit n;
     int i;
     int c;
     int y;
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_256_point_new_8(heap, rtd, rt);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-#ifndef WC_NO_CACHE_RESISTANT
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 17, heap, DYNAMIC_TYPE_ECC);
-#else
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 16, heap, DYNAMIC_TYPE_ECC);
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 16,
+        heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    #ifndef WC_NO_CACHE_RESISTANT
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256),
+            heap, DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
+    #endif
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
+                                DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
-#ifndef WC_NO_CACHE_RESISTANT
-    #if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        p = t + 16;
-    #else
-        p = &pd;
-    #endif
-#endif
+        rt = t + 16;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -32876,20 +32706,35 @@ static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, cons
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 8 * 5);
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_256) * 16);
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmpd, sizeof(tmpd));
-    ForceZero(td, sizeof(td));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
-    sp_256_point_free_8(rt, 1, heap);
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 8 * 5);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#ifndef WC_NO_CACHE_RESISTANT
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (p != NULL)
+    #endif
+        {
+            ForceZero(p, sizeof(sp_point_256));
+        #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+            XFREE(p, heap, DYNAMIC_TYPE_ECC);
+        #endif
+        }
+#endif /* !WC_NO_CACHE_RESISTANT */
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_256) * 17);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -33113,29 +32958,30 @@ static void sp_256_proj_point_add_qz1_8(sp_point_256* r, const sp_point_256* p,
 static int sp_256_gen_stripe_table_8(const sp_point_256* a,
         sp_table_entry_256* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td;
-    sp_point_256 s1d;
-    sp_point_256 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+#else
+    sp_point_256 t[3];
 #endif
-    sp_point_256* t;
     sp_point_256* s1 = NULL;
     sp_point_256* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_256_point_new_8(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_256_mod_mul_norm_8(t->x, a->x, p256_mod);
     }
     if (err == MP_OKAY) {
@@ -33180,9 +33026,10 @@ static int sp_256_gen_stripe_table_8(const sp_point_256* a,
         }
     }
 
-    sp_256_point_free_8(s2, 0, heap);
-    sp_256_point_free_8(s1, 0, heap);
-    sp_256_point_free_8( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -33258,19 +33105,19 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
         const sp_table_entry_256* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit td[2 * 8 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_256 rt[2];
+    sp_digit t[2 * 8 * 5];
 #endif
-    sp_point_256* rt;
     sp_point_256* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -33278,21 +33125,22 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
     (void)heap;
 
 
-    err = sp_256_point_new_8(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p256_norm_mod, sizeof(p256_norm_mod));
         XMEMCPY(rt->z, p256_norm_mod, sizeof(p256_norm_mod));
 
@@ -33343,13 +33191,12 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p, 0, heap);
-    sp_256_point_free_8(rt, 0, heap);
 
     return err;
 }
@@ -33515,29 +33362,30 @@ static int sp_256_ecc_mulmod_8(sp_point_256* r, const sp_point_256* g, const sp_
 static int sp_256_gen_stripe_table_8(const sp_point_256* a,
         sp_table_entry_256* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td;
-    sp_point_256 s1d;
-    sp_point_256 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+#else
+    sp_point_256 t[3];
 #endif
-    sp_point_256* t;
     sp_point_256* s1 = NULL;
     sp_point_256* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_256_point_new_8(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_256_mod_mul_norm_8(t->x, a->x, p256_mod);
     }
     if (err == MP_OKAY) {
@@ -33582,9 +33430,10 @@ static int sp_256_gen_stripe_table_8(const sp_point_256* a,
         }
     }
 
-    sp_256_point_free_8(s2, 0, heap);
-    sp_256_point_free_8(s1, 0, heap);
-    sp_256_point_free_8( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -33660,19 +33509,19 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
         const sp_table_entry_256* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit td[2 * 8 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_256 rt[2];
+    sp_digit t[2 * 8 * 5];
 #endif
-    sp_point_256* rt;
     sp_point_256* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -33680,21 +33529,22 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
     (void)heap;
 
 
-    err = sp_256_point_new_8(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p256_norm_mod, sizeof(p256_norm_mod));
         XMEMCPY(rt->z, p256_norm_mod, sizeof(p256_norm_mod));
 
@@ -33745,13 +33595,12 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p, 0, heap);
-    sp_256_point_free_8(rt, 0, heap);
 
     return err;
 }
@@ -33915,25 +33764,28 @@ static int sp_256_ecc_mulmod_8(sp_point_256* r, const sp_point_256* g, const sp_
 int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[8];
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[1];
+    sp_digit k[8];
+#endif
     int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(k, 8, km);
         sp_256_point_from_ecc_point_8(point, gm);
@@ -33944,12 +33796,12 @@ int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_256_point_to_ecc_point_8(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -33969,37 +33821,35 @@ int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
 int sp_ecc_mulmod_add_256(const mp_int* km, const ecc_point* gm,
     const ecc_point* am, int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_point_256 a;
-    sp_digit kd[8];
-    sp_digit t[8 * 2 * 5];
-#endif
-    sp_point_256* point;
-    sp_point_256* addP = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;    
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[2];
+    sp_digit k[8 + 8 * 2 * 5];
+#endif
+    sp_point_256* addP = NULL;
     sp_digit* tmp = NULL;
     int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (8 + 8 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (8 + 8 * 2 * 5), heap,
+            DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 8;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 8;
+
         sp_256_from_mp(k, 8, km);
         sp_256_point_from_ecc_point_8(point, gm);
         sp_256_point_from_ecc_point_8(addP, am);
@@ -34026,13 +33876,12 @@ int sp_ecc_mulmod_add_256(const mp_int* km, const ecc_point* gm,
         err = sp_256_point_to_ecc_point_8(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(addP, 0, heap);
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -35466,26 +35315,28 @@ static int sp_256_ecc_mulmod_base_8(sp_point_256* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[8];
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256  point[1];
+    sp_digit k[8];
+#endif
     int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(k, 8, km);
 
@@ -35495,12 +35346,12 @@ int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_256_point_to_ecc_point_8(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -35519,37 +35370,35 @@ int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_point_256 a;
-    sp_digit kd[8];
-    sp_digit t[8 * 2 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_256 point[2];
+    sp_digit k[8 + 8 * 2 * 5];
 #endif
-    sp_point_256* point;
     sp_point_256* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (8 + 8 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (8 + 8 * 2 * 5),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 8;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 8;
+
         sp_256_from_mp(k, 8, km);
         sp_256_point_from_ecc_point_8(addP, am);
     }
@@ -35575,13 +35424,12 @@ int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
         err = sp_256_point_to_ecc_point_8(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(addP, 0, heap);
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -35710,41 +35558,46 @@ static int sp_256_ecc_gen_k_8(WC_RNG* rng, sp_digit* k)
  */
 int sp_ecc_make_key_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[8];
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_point_256 inf;
-#endif
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    sp_point_256 point[2];
+    #else
+    sp_point_256 point[1];
+    #endif
+    sp_digit k[8];
+#endif
 #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
     sp_point_256* infinity = NULL;
 #endif
-    int err;
+    int err = MP_OKAY;
+    
 
     (void)heap;
 
-    err = sp_256_point_new_8(heap, p, point);
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, inf, infinity);
-    }
-#endif
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap, DYNAMIC_TYPE_ECC);
+    #else
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap, DYNAMIC_TYPE_ECC);    
+    #endif
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+        infinity = point + 1;
+    #endif
+
         err = sp_256_ecc_gen_k_8(rng, k);
     }
     if (err == MP_OKAY) {
@@ -35769,15 +35622,14 @@ int sp_ecc_make_key_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
         err = sp_256_point_to_ecc_point_8(point, pub);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL) {
+        /* point is not sensitive, so no need to zeroize */
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
     }
 #endif
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_256_point_free_8(infinity, 1, heap);
-#endif
-    sp_256_point_free_8(point, 1, heap);
 
     return err;
 }
@@ -35838,30 +35690,32 @@ static void sp_256_to_bin(sp_digit* r, byte* a)
 int sp_ecc_secret_gen_256(const mp_int* priv, const ecc_point* pub, byte* out,
                           word32* outLen, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[8];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[1];
+    sp_digit k[8];
+#endif
     int err = MP_OKAY;
 
     if (*outLen < 32U) {
         err = BUFFER_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, p, point);
+        point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
@@ -35874,12 +35728,12 @@ int sp_ecc_secret_gen_256(const mp_int* priv, const ecc_point* pub, byte* out,
         *outLen = 32;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -36656,22 +36510,17 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
 int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
     const mp_int* priv, mp_int* rm, mp_int* sm, mp_int* km, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit ed[2*8];
-    sp_digit xd[2*8];
-    sp_digit kd[2*8];
-    sp_digit rd[2*8];
-    sp_digit td[3 * 2*8];
-    sp_point_256 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* e = NULL;
+    sp_point_256* point = NULL;
+#else
+    sp_digit e[7 * 2 * 8];
+    sp_point_256 point[1];
+#endif
     sp_digit* x = NULL;
     sp_digit* k = NULL;
     sp_digit* r = NULL;
     sp_digit* tmp = NULL;
-    sp_point_256* point = NULL;
     sp_digit* s = NULL;
     int32_t c;
     int err = MP_OKAY;
@@ -36679,31 +36528,26 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
 
     (void)heap;
 
-    err = sp_256_point_new_8(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (point == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        e = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 8, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (e == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        e = d + 0 * 8;
-        x = d + 2 * 8;
-        k = d + 4 * 8;
-        r = d + 6 * 8;
-        tmp = d + 8 * 8;
-#else
-        e = ed;
-        x = xd;
-        k = kd;
-        r = rd;
-        tmp = td;
-#endif
+        x = e + 2 * 8;
+        k = e + 4 * 8;
+        r = e + 6 * 8;
+        tmp = e + 8 * 8;
         s = e;
 
         if (hashLen > 32U) {
@@ -36758,19 +36602,24 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
         err = sp_256_to_mp(s, sm);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 8 * 8);
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 2U * 8U);
-    XMEMSET(x, 0, sizeof(sp_digit) * 2U * 8U);
-    XMEMSET(k, 0, sizeof(sp_digit) * 2U * 8U);
-    XMEMSET(r, 0, sizeof(sp_digit) * 2U * 8U);
-    XMEMSET(tmp, 0, sizeof(sp_digit) * 3U * 2U * 8U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (e != NULL)
 #endif
-    sp_256_point_free_8(point, 1, heap);
+    {
+        ForceZero(e, sizeof(sp_digit) * 7 * 2 * 8);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(e, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (point != NULL)
+#endif
+    {
+        ForceZero(point, sizeof(sp_point_256));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -37350,52 +37199,41 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
     const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
     int* res, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit u1d[2*8];
-    sp_digit u2d[2*8];
-    sp_digit sd[2*8];
-    sp_digit tmpd[2*8 * 5];
-    sp_point_256 p1d;
-    sp_point_256 p2d;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* u1 = NULL;
+    sp_point_256* p1 = NULL;
+#else
+    sp_digit  u1[16 * 8];
+    sp_point_256 p1[2];
+#endif
     sp_digit* u2 = NULL;
     sp_digit* s = NULL;
     sp_digit* tmp = NULL;
-    sp_point_256* p1;
     sp_point_256* p2 = NULL;
     sp_digit carry;
     int32_t c = 0;
-    int err;
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p1d, p1);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, p2d, p2);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        p1 = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (p1 == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        u1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 8, heap,
+                                                              DYNAMIC_TYPE_ECC);
+        if (u1 == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        u1  = d + 0 * 8;
-        u2  = d + 2 * 8;
-        s   = d + 4 * 8;
-        tmp = d + 6 * 8;
-#else
-        u1 = u1d;
-        u2 = u2d;
-        s  = sd;
-        tmp = tmpd;
-#endif
+        u2  = u1 + 2 * 8;
+        s   = u1 + 4 * 8;
+        tmp = u1 + 6 * 8;
+        p2 = p1 + 1;
 
         if (hashLen > 32U) {
             hashLen = 32U;
@@ -37446,12 +37284,12 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL)
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (u1 != NULL)
+        XFREE(u1, heap, DYNAMIC_TYPE_ECC);
+    if (p1 != NULL)
+        XFREE(p1, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p1, 0, heap);
-    sp_256_point_free_8(p2, 0, heap);
 
     return err;
 }
@@ -37468,32 +37306,23 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
 static int sp_256_ecc_is_point_8(const sp_point_256* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*8];
-    sp_digit t2d[2*8];
+    sp_digit t1[8 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 8;
-        t2 = d + 2 * 8;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 8;
 
         sp_256_sqr_8(t1, point->y);
         (void)sp_256_mod_8(t1, t1, p256_mod);
@@ -37513,10 +37342,9 @@ static int sp_256_ecc_is_point_8(const sp_point_256* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -37531,14 +37359,21 @@ static int sp_256_ecc_is_point_8(const sp_point_256* point,
  */
 int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* pub = NULL;
+#else
+    sp_point_256 pub[1];
 #endif
-    sp_point_256* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_8(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(pub->x, 8, pX);
         sp_256_from_mp(pub->y, 8, pY);
@@ -37547,7 +37382,10 @@ int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
         err = sp_256_ecc_is_point_8(pub, NULL);
     }
 
-    sp_256_point_free_8(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -37566,44 +37404,44 @@ int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_256(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[8];
-    sp_point_256 pubd;
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_256* pub;
-    sp_point_256* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_256_point_new_8(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_256* pub = NULL;
+#else
+    sp_digit priv[8];
+    sp_point_256 pub[2];
 #endif
+    sp_point_256* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+    if (((mp_count_bits(pX) > 256) ||
         (mp_count_bits(pY) > 256) ||
         ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_256_from_mp(pub->x, 8, pX);
         sp_256_from_mp(pub->y, 8, pY);
@@ -37653,13 +37491,12 @@ int sp_ecc_check_key_256(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_256_point_free_8(p, 0, heap);
-    sp_256_point_free_8(pub, 0, heap);
 
     return err;
 }
@@ -37683,33 +37520,35 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* qX, mp_int* qY, mp_int* qZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 8 * 5];
-    sp_point_256 pd;
-    sp_point_256 qd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 8 * 5];
+    sp_point_256 p[2];
+#endif
     sp_point_256* q = NULL;
     int err;
 
-    err = sp_256_point_new_8(NULL, pd, p);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(NULL, qd, q);
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, NULL,
-                                                              DYNAMIC_TYPE_ECC);
+                                 DYNAMIC_TYPE_ECC);
         if (tmp == NULL) {
             err = MEMORY_E;
         }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
+        q = p + 1;
+
         sp_256_from_mp(p->x, 8, pX);
         sp_256_from_mp(p->y, 8, pY);
         sp_256_from_mp(p->z, 8, pZ);
@@ -37730,13 +37569,12 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_256_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(q, 0, NULL);
-    sp_256_point_free_8(p, 0, NULL);
 
     return err;
 }
@@ -37755,25 +37593,28 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
 int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 8 * 2];
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
-    int err;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 8 * 2];
+    sp_point_256 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_8(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 2, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
@@ -37794,12 +37635,12 @@ int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_256_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p, 0, NULL);
 
     return err;
 }
@@ -37814,25 +37655,29 @@ int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
  */
 int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 8 * 4];
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
-    int err;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 8 * 4];
+    sp_point_256 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_8(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 4, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
     if (err == MP_OKAY) {
         sp_256_from_mp(p->x, 8, pX);
@@ -37852,12 +37697,12 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
         err = sp_256_to_mp(p->z, pZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p, 0, NULL);
 
     return err;
 }
@@ -37870,31 +37715,23 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
  */
 static int sp_256_mont_sqrt_8(sp_digit* y)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2 * 8];
-    sp_digit t2d[2 * 8];
+    sp_digit t1[4 * 8];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL) {
         err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 8;
-        t2 = d + 2 * 8;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 8;
 
         {
             /* t2 = y ^ 0x2 */
@@ -37929,10 +37766,9 @@ static int sp_256_mont_sqrt_8(sp_digit* y)
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -37948,31 +37784,22 @@ static int sp_256_mont_sqrt_8(sp_digit* y)
  */
 int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
-#else
-    sp_digit xd[2 * 8];
-    sp_digit yd[2 * 8];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* x = NULL;
+#else
+    sp_digit x[4 * 8];
+#endif
     sp_digit* y = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    x = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
+    if (x == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        x = d + 0 * 8;
-        y = d + 2 * 8;
-#else
-        x = xd;
-        y = yd;
-#endif
+        y = x + 2 * 8;
 
         sp_256_from_mp(x, 8, xm);
         err = sp_256_mod_mul_norm_8(x, x, p256_mod);
@@ -38005,10 +37832,9 @@ int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
         err = sp_256_to_mp(y, ym);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (x != NULL)
+        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -40145,64 +39971,6 @@ static sp_digit sp_384_sub_12(sp_digit* r, const sp_digit* a,
 }
 
 #endif /* WOLFSSL_SP_SMALL */
-/* Create a new point.
- *
- * heap  [in]   Buffer to allocate dynamic memory from.
- * sp    [in]   Data for point - only if not allocating.
- * p     [out]  New point.
- * returns MEMORY_E when dynamic memory allocation fails and 0 otherwise.
- */
-static int sp_384_point_new_ex_12(void* heap, sp_point_384* sp,
-    sp_point_384** p)
-{
-    int ret = MP_OKAY;
-    (void)heap;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    (void)sp;
-    *p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap, DYNAMIC_TYPE_ECC);
-#else
-    *p = sp;
-#endif
-    if (*p == NULL) {
-        ret = MEMORY_E;
-    }
-    return ret;
-}
-
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* Allocate memory for point and return error. */
-#define sp_384_point_new_12(heap, sp, p) sp_384_point_new_ex_12((heap), NULL, &(p))
-#else
-/* Set pointer to data and return no error. */
-#define sp_384_point_new_12(heap, sp, p) sp_384_point_new_ex_12((heap), &(sp), &(p))
-#endif
-
-
-/* Free the point.
- *
- * p      [in,out]  Point to free.
- * clear  [in]      Indicates whether to zeroize point.
- * heap   [in]      Buffer from which dynamic memory was allocate from.
- */
-static void sp_384_point_free_12(sp_point_384* p, int clear, void* heap)
-{
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* If valid pointer then clear point data if requested and free data. */
-    if (p != NULL) {
-        if (clear != 0) {
-            XMEMSET(p, 0, sizeof(*p));
-        }
-        XFREE(p, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-/* Clear point data if requested. */
-    if ((p != NULL) && (clear != 0)) {
-        XMEMSET(p, 0, sizeof(*p));
-    }
-#endif
-    (void)heap;
-}
-
 /* Multiply a number by Montogmery normalizer mod modulus (prime).
  *
  * r  The resulting Montgomery form number.
@@ -40212,8 +39980,8 @@ static void sp_384_point_free_12(sp_point_384* p, int clear, void* heap)
  */
 static int sp_384_mod_mul_norm_12(sp_digit* r, const sp_digit* a, const sp_digit* m)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    int64_t* t;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    int64_t* t = NULL;
 #else
     int64_t t[12];
 #endif
@@ -40222,7 +39990,7 @@ static int sp_384_mod_mul_norm_12(sp_digit* r, const sp_digit* a, const sp_digit
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     t = (int64_t*)XMALLOC(sizeof(int64_t) * 12, NULL, DYNAMIC_TYPE_ECC);
     if (t == NULL) {
         err = MEMORY_E;
@@ -40297,7 +40065,7 @@ static int sp_384_mod_mul_norm_12(sp_digit* r, const sp_digit* a, const sp_digit
         r[11] = t[11];
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (t != NULL)
         XFREE(t, NULL, DYNAMIC_TYPE_ECC);
 #endif
@@ -41976,56 +41744,55 @@ static void sp_384_get_point_16_12(sp_point_384* r, const sp_point_384* table,
 static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, const sp_digit* k,
         int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td[16];
-    sp_point_384 rtd;
-    sp_digit tmpd[2 * 12 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_384 t[16];
+    sp_digit tmp[2 * 12 * 6];
+#endif
+    sp_point_384* rt = NULL;
 #ifndef WC_NO_CACHE_RESISTANT
-    sp_point_384 pd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* p = NULL;
+#else
+    sp_point_384 p[1];
 #endif
-#endif
-    sp_point_384* t;
-    sp_point_384* rt;
-#ifndef WC_NO_CACHE_RESISTANT
-    sp_point_384* p;
-#endif
-    sp_digit* tmp;
+#endif /* !WC_NO_CACHE_RESISTANT */
     sp_digit n;
     int i;
     int c;
     int y;
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_384_point_new_12(heap, rtd, rt);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-#ifndef WC_NO_CACHE_RESISTANT
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 17, heap, DYNAMIC_TYPE_ECC);
-#else
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 16, heap, DYNAMIC_TYPE_ECC);
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 16,
+        heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    #ifndef WC_NO_CACHE_RESISTANT
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384),
+            heap, DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
+    #endif
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
+                                DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
-#ifndef WC_NO_CACHE_RESISTANT
-    #if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        p = t + 16;
-    #else
-        p = &pd;
-    #endif
-#endif
+        rt = t + 16;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -42113,20 +41880,35 @@ static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, con
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 12 * 6);
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_384) * 16);
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmpd, sizeof(tmpd));
-    ForceZero(td, sizeof(td));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
-    sp_384_point_free_12(rt, 1, heap);
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 12 * 6);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#ifndef WC_NO_CACHE_RESISTANT
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (p != NULL)
+    #endif
+        {
+            ForceZero(p, sizeof(sp_point_384));
+        #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+            XFREE(p, heap, DYNAMIC_TYPE_ECC);
+        #endif
+        }
+#endif /* !WC_NO_CACHE_RESISTANT */
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_384) * 17);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -42350,29 +42132,30 @@ static void sp_384_proj_point_add_qz1_12(sp_point_384* r, const sp_point_384* p,
 static int sp_384_gen_stripe_table_12(const sp_point_384* a,
         sp_table_entry_384* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td;
-    sp_point_384 s1d;
-    sp_point_384 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+#else
+    sp_point_384 t[3];
 #endif
-    sp_point_384* t;
     sp_point_384* s1 = NULL;
     sp_point_384* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_384_point_new_12(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_384_mod_mul_norm_12(t->x, a->x, p384_mod);
     }
     if (err == MP_OKAY) {
@@ -42417,9 +42200,10 @@ static int sp_384_gen_stripe_table_12(const sp_point_384* a,
         }
     }
 
-    sp_384_point_free_12(s2, 0, heap);
-    sp_384_point_free_12(s1, 0, heap);
-    sp_384_point_free_12( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -42511,19 +42295,19 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
         const sp_table_entry_384* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit td[2 * 12 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_384 rt[2];
+    sp_digit t[2 * 12 * 6];
 #endif
-    sp_point_384* rt;
     sp_point_384* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -42531,21 +42315,22 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
     (void)heap;
 
 
-    err = sp_384_point_new_12(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p384_norm_mod, sizeof(p384_norm_mod));
         XMEMCPY(rt->z, p384_norm_mod, sizeof(p384_norm_mod));
 
@@ -42596,13 +42381,12 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p, 0, heap);
-    sp_384_point_free_12(rt, 0, heap);
 
     return err;
 }
@@ -42768,29 +42552,30 @@ static int sp_384_ecc_mulmod_12(sp_point_384* r, const sp_point_384* g, const sp
 static int sp_384_gen_stripe_table_12(const sp_point_384* a,
         sp_table_entry_384* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td;
-    sp_point_384 s1d;
-    sp_point_384 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+#else
+    sp_point_384 t[3];
 #endif
-    sp_point_384* t;
     sp_point_384* s1 = NULL;
     sp_point_384* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_384_point_new_12(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_384_mod_mul_norm_12(t->x, a->x, p384_mod);
     }
     if (err == MP_OKAY) {
@@ -42835,9 +42620,10 @@ static int sp_384_gen_stripe_table_12(const sp_point_384* a,
         }
     }
 
-    sp_384_point_free_12(s2, 0, heap);
-    sp_384_point_free_12(s1, 0, heap);
-    sp_384_point_free_12( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -42929,19 +42715,19 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
         const sp_table_entry_384* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit td[2 * 12 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_384 rt[2];
+    sp_digit t[2 * 12 * 6];
 #endif
-    sp_point_384* rt;
     sp_point_384* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -42949,21 +42735,22 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
     (void)heap;
 
 
-    err = sp_384_point_new_12(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p384_norm_mod, sizeof(p384_norm_mod));
         XMEMCPY(rt->z, p384_norm_mod, sizeof(p384_norm_mod));
 
@@ -43014,13 +42801,12 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p, 0, heap);
-    sp_384_point_free_12(rt, 0, heap);
 
     return err;
 }
@@ -43184,25 +42970,28 @@ static int sp_384_ecc_mulmod_12(sp_point_384* r, const sp_point_384* g, const sp
 int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[12];
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[1];
+    sp_digit k[12];
+#endif
     int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(k, 12, km);
         sp_384_point_from_ecc_point_12(point, gm);
@@ -43213,12 +43002,12 @@ int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_384_point_to_ecc_point_12(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -43238,37 +43027,35 @@ int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
 int sp_ecc_mulmod_add_384(const mp_int* km, const ecc_point* gm,
     const ecc_point* am, int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_point_384 a;
-    sp_digit kd[12];
-    sp_digit t[12 * 2 * 6];
-#endif
-    sp_point_384* point;
-    sp_point_384* addP = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;    
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[2];
+    sp_digit k[12 + 12 * 2 * 6];
+#endif
+    sp_point_384* addP = NULL;
     sp_digit* tmp = NULL;
     int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (12 + 12 * 2 * 6), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (12 + 12 * 2 * 6), heap,
+            DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 12;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 12;
+
         sp_384_from_mp(k, 12, km);
         sp_384_point_from_ecc_point_12(point, gm);
         sp_384_point_from_ecc_point_12(addP, am);
@@ -43295,13 +43082,12 @@ int sp_ecc_mulmod_add_384(const mp_int* km, const ecc_point* gm,
         err = sp_384_point_to_ecc_point_12(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(addP, 0, heap);
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -44735,26 +44521,28 @@ static int sp_384_ecc_mulmod_base_12(sp_point_384* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[12];
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384  point[1];
+    sp_digit k[12];
+#endif
     int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(k, 12, km);
 
@@ -44764,12 +44552,12 @@ int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_384_point_to_ecc_point_12(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -44788,37 +44576,35 @@ int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_point_384 a;
-    sp_digit kd[12];
-    sp_digit t[12 * 2 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_384 point[2];
+    sp_digit k[12 + 12 * 2 * 6];
 #endif
-    sp_point_384* point;
     sp_point_384* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (12 + 12 * 2 * 6), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (12 + 12 * 2 * 6),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 12;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 12;
+
         sp_384_from_mp(k, 12, km);
         sp_384_point_from_ecc_point_12(addP, am);
     }
@@ -44844,13 +44630,12 @@ int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
         err = sp_384_point_to_ecc_point_12(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(addP, 0, heap);
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -44992,41 +44777,46 @@ static int sp_384_ecc_gen_k_12(WC_RNG* rng, sp_digit* k)
  */
 int sp_ecc_make_key_384(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[12];
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_point_384 inf;
-#endif
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    sp_point_384 point[2];
+    #else
+    sp_point_384 point[1];
+    #endif
+    sp_digit k[12];
+#endif
 #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
     sp_point_384* infinity = NULL;
 #endif
-    int err;
+    int err = MP_OKAY;
+    
 
     (void)heap;
 
-    err = sp_384_point_new_12(heap, p, point);
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, inf, infinity);
-    }
-#endif
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap, DYNAMIC_TYPE_ECC);
+    #else
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap, DYNAMIC_TYPE_ECC);    
+    #endif
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+        infinity = point + 1;
+    #endif
+
         err = sp_384_ecc_gen_k_12(rng, k);
     }
     if (err == MP_OKAY) {
@@ -45051,15 +44841,14 @@ int sp_ecc_make_key_384(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
         err = sp_384_point_to_ecc_point_12(point, pub);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL) {
+        /* point is not sensitive, so no need to zeroize */
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
     }
 #endif
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_384_point_free_12(infinity, 1, heap);
-#endif
-    sp_384_point_free_12(point, 1, heap);
 
     return err;
 }
@@ -45120,30 +44909,32 @@ static void sp_384_to_bin(sp_digit* r, byte* a)
 int sp_ecc_secret_gen_384(const mp_int* priv, const ecc_point* pub, byte* out,
                           word32* outLen, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[12];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[1];
+    sp_digit k[12];
+#endif
     int err = MP_OKAY;
 
     if (*outLen < 48U) {
         err = BUFFER_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, p, point);
+        point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
@@ -45156,12 +44947,12 @@ int sp_ecc_secret_gen_384(const mp_int* priv, const ecc_point* pub, byte* out,
         *outLen = 48;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -45957,22 +45748,17 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
 int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
     const mp_int* priv, mp_int* rm, mp_int* sm, mp_int* km, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit ed[2*12];
-    sp_digit xd[2*12];
-    sp_digit kd[2*12];
-    sp_digit rd[2*12];
-    sp_digit td[3 * 2*12];
-    sp_point_384 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* e = NULL;
+    sp_point_384* point = NULL;
+#else
+    sp_digit e[7 * 2 * 12];
+    sp_point_384 point[1];
+#endif
     sp_digit* x = NULL;
     sp_digit* k = NULL;
     sp_digit* r = NULL;
     sp_digit* tmp = NULL;
-    sp_point_384* point = NULL;
     sp_digit* s = NULL;
     int32_t c;
     int err = MP_OKAY;
@@ -45980,31 +45766,26 @@ int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
 
     (void)heap;
 
-    err = sp_384_point_new_12(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (point == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        e = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 12, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (e == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        e = d + 0 * 12;
-        x = d + 2 * 12;
-        k = d + 4 * 12;
-        r = d + 6 * 12;
-        tmp = d + 8 * 12;
-#else
-        e = ed;
-        x = xd;
-        k = kd;
-        r = rd;
-        tmp = td;
-#endif
+        x = e + 2 * 12;
+        k = e + 4 * 12;
+        r = e + 6 * 12;
+        tmp = e + 8 * 12;
         s = e;
 
         if (hashLen > 48U) {
@@ -46059,19 +45840,24 @@ int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
         err = sp_384_to_mp(s, sm);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 8 * 12);
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 2U * 12U);
-    XMEMSET(x, 0, sizeof(sp_digit) * 2U * 12U);
-    XMEMSET(k, 0, sizeof(sp_digit) * 2U * 12U);
-    XMEMSET(r, 0, sizeof(sp_digit) * 2U * 12U);
-    XMEMSET(tmp, 0, sizeof(sp_digit) * 3U * 2U * 12U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (e != NULL)
 #endif
-    sp_384_point_free_12(point, 1, heap);
+    {
+        ForceZero(e, sizeof(sp_digit) * 7 * 2 * 12);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(e, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (point != NULL)
+#endif
+    {
+        ForceZero(point, sizeof(sp_point_384));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -46698,52 +46484,41 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
     const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
     int* res, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit u1d[2*12];
-    sp_digit u2d[2*12];
-    sp_digit sd[2*12];
-    sp_digit tmpd[2*12 * 5];
-    sp_point_384 p1d;
-    sp_point_384 p2d;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* u1 = NULL;
+    sp_point_384* p1 = NULL;
+#else
+    sp_digit  u1[16 * 12];
+    sp_point_384 p1[2];
+#endif
     sp_digit* u2 = NULL;
     sp_digit* s = NULL;
     sp_digit* tmp = NULL;
-    sp_point_384* p1;
     sp_point_384* p2 = NULL;
     sp_digit carry;
     int32_t c = 0;
-    int err;
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p1d, p1);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, p2d, p2);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        p1 = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (p1 == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        u1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 12, heap,
+                                                              DYNAMIC_TYPE_ECC);
+        if (u1 == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        u1  = d + 0 * 12;
-        u2  = d + 2 * 12;
-        s   = d + 4 * 12;
-        tmp = d + 6 * 12;
-#else
-        u1 = u1d;
-        u2 = u2d;
-        s  = sd;
-        tmp = tmpd;
-#endif
+        u2  = u1 + 2 * 12;
+        s   = u1 + 4 * 12;
+        tmp = u1 + 6 * 12;
+        p2 = p1 + 1;
 
         if (hashLen > 48U) {
             hashLen = 48U;
@@ -46794,12 +46569,12 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL)
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (u1 != NULL)
+        XFREE(u1, heap, DYNAMIC_TYPE_ECC);
+    if (p1 != NULL)
+        XFREE(p1, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p1, 0, heap);
-    sp_384_point_free_12(p2, 0, heap);
 
     return err;
 }
@@ -46816,32 +46591,23 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
 static int sp_384_ecc_is_point_12(const sp_point_384* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*12];
-    sp_digit t2d[2*12];
+    sp_digit t1[12 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 12;
-        t2 = d + 2 * 12;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 12;
 
         sp_384_sqr_12(t1, point->y);
         (void)sp_384_mod_12(t1, t1, p384_mod);
@@ -46861,10 +46627,9 @@ static int sp_384_ecc_is_point_12(const sp_point_384* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -46879,14 +46644,21 @@ static int sp_384_ecc_is_point_12(const sp_point_384* point,
  */
 int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* pub = NULL;
+#else
+    sp_point_384 pub[1];
 #endif
-    sp_point_384* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_12(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(pub->x, 12, pX);
         sp_384_from_mp(pub->y, 12, pY);
@@ -46895,7 +46667,10 @@ int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
         err = sp_384_ecc_is_point_12(pub, NULL);
     }
 
-    sp_384_point_free_12(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -46914,44 +46689,44 @@ int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_384(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[12];
-    sp_point_384 pubd;
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_384* pub;
-    sp_point_384* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_384_point_new_12(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_384* pub = NULL;
+#else
+    sp_digit priv[12];
+    sp_point_384 pub[2];
 #endif
+    sp_point_384* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+    if (((mp_count_bits(pX) > 384) ||
         (mp_count_bits(pY) > 384) ||
         ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_384_from_mp(pub->x, 12, pX);
         sp_384_from_mp(pub->y, 12, pY);
@@ -47001,13 +46776,12 @@ int sp_ecc_check_key_384(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_384_point_free_12(p, 0, heap);
-    sp_384_point_free_12(pub, 0, heap);
 
     return err;
 }
@@ -47031,33 +46805,35 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* qX, mp_int* qY, mp_int* qZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 12 * 5];
-    sp_point_384 pd;
-    sp_point_384 qd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 12 * 5];
+    sp_point_384 p[2];
+#endif
     sp_point_384* q = NULL;
     int err;
 
-    err = sp_384_point_new_12(NULL, pd, p);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(NULL, qd, q);
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 5, NULL,
-                                                              DYNAMIC_TYPE_ECC);
+                                 DYNAMIC_TYPE_ECC);
         if (tmp == NULL) {
             err = MEMORY_E;
         }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
+        q = p + 1;
+
         sp_384_from_mp(p->x, 12, pX);
         sp_384_from_mp(p->y, 12, pY);
         sp_384_from_mp(p->z, 12, pZ);
@@ -47078,13 +46854,12 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_384_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(q, 0, NULL);
-    sp_384_point_free_12(p, 0, NULL);
 
     return err;
 }
@@ -47103,25 +46878,28 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
 int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 12 * 2];
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
-    int err;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 12 * 2];
+    sp_point_384 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_12(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 2, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
@@ -47142,12 +46920,12 @@ int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_384_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p, 0, NULL);
 
     return err;
 }
@@ -47162,25 +46940,29 @@ int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
  */
 int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 12 * 6];
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
-    int err;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 12 * 6];
+    sp_point_384 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_12(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
     if (err == MP_OKAY) {
         sp_384_from_mp(p->x, 12, pX);
@@ -47200,12 +46982,12 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
         err = sp_384_to_mp(p->z, pZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p, 0, NULL);
 
     return err;
 }
@@ -47218,43 +47000,28 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
  */
 static int sp_384_mont_sqrt_12(sp_digit* y)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2 * 12];
-    sp_digit t2d[2 * 12];
-    sp_digit t3d[2 * 12];
-    sp_digit t4d[2 * 12];
-    sp_digit t5d[2 * 12];
+    sp_digit t1[5 * 2 * 12];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* t3;
-    sp_digit* t4;
-    sp_digit* t5;
+    sp_digit* t2 = NULL;
+    sp_digit* t3 = NULL;
+    sp_digit* t4 = NULL;
+    sp_digit* t5 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 12, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 12, NULL, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 12;
-        t2 = d + 2 * 12;
-        t3 = d + 4 * 12;
-        t4 = d + 6 * 12;
-        t5 = d + 8 * 12;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        t3 = t3d;
-        t4 = t4d;
-        t5 = t5d;
-#endif
+        t2 = t1 + 2 * 12;
+        t3 = t1 + 4 * 12;
+        t4 = t1 + 6 * 12;
+        t5 = t1 + 8 * 12;
 
         {
             /* t2 = y ^ 0x2 */
@@ -47314,10 +47081,9 @@ static int sp_384_mont_sqrt_12(sp_digit* y)
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -47333,31 +47099,22 @@ static int sp_384_mont_sqrt_12(sp_digit* y)
  */
 int sp_ecc_uncompress_384(mp_int* xm, int odd, mp_int* ym)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
-#else
-    sp_digit xd[2 * 12];
-    sp_digit yd[2 * 12];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* x = NULL;
+#else
+    sp_digit x[4 * 12];
+#endif
     sp_digit* y = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 12, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    x = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 12, NULL, DYNAMIC_TYPE_ECC);
+    if (x == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        x = d + 0 * 12;
-        y = d + 2 * 12;
-#else
-        x = xd;
-        y = yd;
-#endif
+        y = x + 2 * 12;
 
         sp_384_from_mp(x, 12, xm);
         err = sp_384_mod_mul_norm_12(x, x, p384_mod);
@@ -47390,10 +47147,9 @@ int sp_ecc_uncompress_384(mp_int* xm, int odd, mp_int* ym)
         err = sp_384_to_mp(y, ym);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (x != NULL)
+        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -52123,6 +51879,8 @@ static int sp_1024_mod_mul_norm_32(sp_digit* r, const sp_digit* a,
     return sp_1024_mod_32(r, r, m);
 }
 
+
+#ifdef WOLFCRYPT_HAVE_SAKKE
 /* Create a new point.
  *
  * heap  [in]   Buffer to allocate dynamic memory from.
@@ -52154,8 +51912,8 @@ static int sp_1024_point_new_ex_32(void* heap, sp_point_1024* sp,
 /* Set pointer to data and return no error. */
 #define sp_1024_point_new_32(heap, sp, p) sp_1024_point_new_ex_32((heap), &(sp), &(p))
 #endif
-
-
+#endif /* WOLFCRYPT_HAVE_SAKKE */
+#ifdef WOLFCRYPT_HAVE_SAKKE
 /* Free the point.
  *
  * p      [in,out]  Point to free.
@@ -52180,6 +51938,7 @@ static void sp_1024_point_free_32(sp_point_1024* p, int clear, void* heap)
 #endif
     (void)heap;
 }
+#endif /* WOLFCRYPT_HAVE_SAKKE */
 
 /* Convert an mp_int to an array of sp_digit.
  *
@@ -54713,43 +54472,40 @@ static void sp_1024_proj_point_add_32(sp_point_1024* r,
 static int sp_1024_ecc_mulmod_fast_32(sp_point_1024* r, const sp_point_1024* g, const sp_digit* k,
         int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td[16];
-    sp_point_1024 rtd;
-    sp_digit tmpd[2 * 32 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_1024 t[16];
+    sp_digit tmp[2 * 32 * 5];
 #endif
-    sp_point_1024* t;
-    sp_point_1024* rt;
-    sp_digit* tmp;
+    sp_point_1024* rt = NULL;
     sp_digit n;
     int i;
     int c;
     int y;
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_1024_point_new_32(heap, rtd, rt);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-#ifndef WC_NO_CACHE_RESISTANT
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 17, heap, DYNAMIC_TYPE_ECC);
-#else
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 16, heap, DYNAMIC_TYPE_ECC);
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 16,
+        heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
+                                DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
+        rt = t + 16;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -54817,20 +54573,24 @@ static int sp_1024_ecc_mulmod_fast_32(sp_point_1024* r, const sp_point_1024* g, 
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 32 * 5);
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_1024) * 16);
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmpd, sizeof(tmpd));
-    ForceZero(td, sizeof(td));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
-    sp_1024_point_free_32(rt, 1, heap);
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 32 * 5);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_1024) * 17);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -55054,29 +54814,30 @@ static void sp_1024_proj_point_add_qz1_32(sp_point_1024* r, const sp_point_1024*
 static int sp_1024_gen_stripe_table_32(const sp_point_1024* a,
         sp_table_entry_1024* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td;
-    sp_point_1024 s1d;
-    sp_point_1024 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+#else
+    sp_point_1024 t[3];
 #endif
-    sp_point_1024* t;
     sp_point_1024* s1 = NULL;
     sp_point_1024* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_1024_point_new_32(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_1024_mod_mul_norm_32(t->x, a->x, p1024_mod);
     }
     if (err == MP_OKAY) {
@@ -55121,9 +54882,10 @@ static int sp_1024_gen_stripe_table_32(const sp_point_1024* a,
         }
     }
 
-    sp_1024_point_free_32(s2, 0, heap);
-    sp_1024_point_free_32(s1, 0, heap);
-    sp_1024_point_free_32( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -55149,19 +54911,19 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
         const sp_table_entry_1024* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 rtd;
-    sp_point_1024 pd;
-    sp_digit td[2 * 32 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 rt[2];
+    sp_digit t[2 * 32 * 5];
 #endif
-    sp_point_1024* rt;
     sp_point_1024* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -55169,21 +54931,22 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
     (void)heap;
 
 
-    err = sp_1024_point_new_32(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p1024_norm_mod, sizeof(p1024_norm_mod));
         XMEMCPY(rt->z, p1024_norm_mod, sizeof(p1024_norm_mod));
 
@@ -55219,13 +54982,12 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(p, 0, heap);
-    sp_1024_point_free_32(rt, 0, heap);
 
     return err;
 }
@@ -55391,29 +55153,30 @@ static int sp_1024_ecc_mulmod_32(sp_point_1024* r, const sp_point_1024* g, const
 static int sp_1024_gen_stripe_table_32(const sp_point_1024* a,
         sp_table_entry_1024* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td;
-    sp_point_1024 s1d;
-    sp_point_1024 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+#else
+    sp_point_1024 t[3];
 #endif
-    sp_point_1024* t;
     sp_point_1024* s1 = NULL;
     sp_point_1024* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_1024_point_new_32(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_1024_mod_mul_norm_32(t->x, a->x, p1024_mod);
     }
     if (err == MP_OKAY) {
@@ -55458,9 +55221,10 @@ static int sp_1024_gen_stripe_table_32(const sp_point_1024* a,
         }
     }
 
-    sp_1024_point_free_32(s2, 0, heap);
-    sp_1024_point_free_32(s1, 0, heap);
-    sp_1024_point_free_32( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -55486,19 +55250,19 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
         const sp_table_entry_1024* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 rtd;
-    sp_point_1024 pd;
-    sp_digit td[2 * 32 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 rt[2];
+    sp_digit t[2 * 32 * 5];
 #endif
-    sp_point_1024* rt;
     sp_point_1024* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -55506,21 +55270,22 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
     (void)heap;
 
 
-    err = sp_1024_point_new_32(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p1024_norm_mod, sizeof(p1024_norm_mod));
         XMEMCPY(rt->z, p1024_norm_mod, sizeof(p1024_norm_mod));
 
@@ -55556,13 +55321,12 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(p, 0, heap);
-    sp_1024_point_free_32(rt, 0, heap);
 
     return err;
 }
@@ -55726,25 +55490,28 @@ static int sp_1024_ecc_mulmod_32(sp_point_1024* r, const sp_point_1024* g, const
 int sp_ecc_mulmod_1024(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[32];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024 point[1];
+    sp_digit k[32];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 32, km);
         sp_1024_point_from_ecc_point_32(point, gm);
@@ -55755,12 +55522,12 @@ int sp_ecc_mulmod_1024(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_1024_point_to_ecc_point_32(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(point, 0, heap);
 
     return err;
 }
@@ -59354,26 +59121,28 @@ static int sp_1024_ecc_mulmod_base_32(sp_point_1024* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[32];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024  point[1];
+    sp_digit k[32];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 32, km);
 
@@ -59383,12 +59152,12 @@ int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_1024_point_to_ecc_point_32(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(point, 0, heap);
 
     return err;
 }
@@ -59407,37 +59176,35 @@ int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_point_1024 a;
-    sp_digit kd[32];
-    sp_digit t[32 * 2 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_1024 point[2];
+    sp_digit k[32 + 32 * 2 * 5];
 #endif
-    sp_point_1024* point;
     sp_point_1024* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 + 32 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (32 + 32 * 2 * 5),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 32;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 32;
+
         sp_1024_from_mp(k, 32, km);
         sp_1024_point_from_ecc_point_32(addP, am);
     }
@@ -59463,13 +59230,12 @@ int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
         err = sp_1024_point_to_ecc_point_32(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(addP, 0, heap);
-    sp_1024_point_free_32(point, 0, heap);
 
     return err;
 }
@@ -59487,29 +59253,43 @@ int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
 int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
     void* heap)
 {
-    int err = 0;
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_1024* point = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 point[1];
     sp_digit t[5 * 2 * 32];
+#endif
+    int err = MP_OKAY;
 
     if ((gm == NULL) || (len == NULL)) {
         err = BAD_FUNC_ARG;
     }
 
-    if ((err == 0) && (table == NULL)) {
+    if ((err == MP_OKAY) && (table == NULL)) {
         *len = sizeof(sp_table_entry_1024) * 256;
         err = LENGTH_ONLY_E;
     }
-    if ((err == 0) && (*len < (int)(sizeof(sp_table_entry_1024) * 256))) {
+    if ((err == MP_OKAY) && (*len < (int)(sizeof(sp_table_entry_1024) * 256))) {
         err = BUFFER_E;
     }
 
-    if (err == 0) {
-        err = sp_1024_point_new_32(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+            DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-    if (err == 0) {
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 32, heap,
+            DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
         sp_1024_point_from_ecc_point_32(point, gm);
             err = sp_1024_gen_stripe_table_32(point,
                 (sp_table_entry_1024*)table, t, heap);
@@ -59518,7 +59298,12 @@ int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
         *len = sizeof(sp_table_entry_1024) * 256;
     }
 
-    sp_1024_point_free_32(point, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -59571,24 +59356,28 @@ int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
 int sp_ecc_mulmod_table_1024(const mp_int* km, const ecc_point* gm, byte* table,
         ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[32];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024 point[1];
+    sp_digit k[32];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+        DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap, DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 32, km);
         sp_1024_point_from_ecc_point_32(point, gm);
@@ -59605,12 +59394,12 @@ int sp_ecc_mulmod_table_1024(const mp_int* km, const ecc_point* gm, byte* table,
         err = sp_1024_point_to_ecc_point_32(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(point, 0, heap);
 
     return err;
 }
@@ -63061,33 +62850,24 @@ static void sp_1024_from_bin(sp_digit* r, int size, const byte* a, int n)
 static int sp_1024_ecc_is_point_32(const sp_point_1024* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*32];
-    sp_digit t2d[2*32];
+    sp_digit t1[32 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int32_t n;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 32;
-        t2 = d + 2 * 32;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 32;
 
         sp_1024_sqr_32(t1, point->y);
         (void)sp_1024_mod_32(t1, t1, p1024_mod);
@@ -63111,10 +62891,9 @@ static int sp_1024_ecc_is_point_32(const sp_point_1024* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -63129,14 +62908,21 @@ static int sp_1024_ecc_is_point_32(const sp_point_1024* point,
  */
 int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* pub = NULL;
+#else
+    sp_point_1024 pub[1];
 #endif
-    sp_point_1024* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(pub->x, 32, pX);
         sp_1024_from_mp(pub->y, 32, pY);
@@ -63145,7 +62931,10 @@ int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
         err = sp_1024_ecc_is_point_32(pub, NULL);
     }
 
-    sp_1024_point_free_32(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -63164,44 +62953,44 @@ int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_1024(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[32];
-    sp_point_1024 pubd;
-    sp_point_1024 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_1024* pub;
-    sp_point_1024* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_1024_point_new_32(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_1024* pub = NULL;
+#else
+    sp_digit priv[32];
+    sp_point_1024 pub[2];
 #endif
+    sp_point_1024* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 1024) ||
+    if (((mp_count_bits(pX) > 1024) ||
         (mp_count_bits(pY) > 1024) ||
         ((privm != NULL) && (mp_count_bits(privm) > 1024)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_1024_from_mp(pub->x, 32, pX);
         sp_1024_from_mp(pub->y, 32, pY);
@@ -63251,13 +63040,12 @@ int sp_ecc_check_key_1024(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_1024_point_free_32(p, 0, heap);
-    sp_1024_point_free_32(pub, 0, heap);
 
     return err;
 }

--- a/wolfcrypt/src/sp_arm64.c
+++ b/wolfcrypt/src/sp_arm64.c
@@ -3203,12 +3203,12 @@ static int sp_2048_mod_exp_16(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 32];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -3220,19 +3220,14 @@ static int sp_2048_mod_exp_16(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 32), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 32;
-#else
-            t[i] = &td[i * 32];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -3328,9 +3323,8 @@ static int sp_2048_mod_exp_16(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -3349,12 +3343,12 @@ static int sp_2048_mod_exp_16(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 32];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -3366,19 +3360,14 @@ static int sp_2048_mod_exp_16(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 32), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 32;
-#else
-            t[i] = &td[i * 32];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -3491,9 +3480,8 @@ static int sp_2048_mod_exp_16(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -4779,12 +4767,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 64];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -4796,19 +4784,14 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 64), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 64;
-#else
-            t[i] = &td[i * 64];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -4904,9 +4887,8 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -4925,12 +4907,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 64];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -4942,19 +4924,14 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 64), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 64;
-#else
-            t[i] = &td[i * 64];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -5067,9 +5044,8 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -5093,18 +5069,15 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
 int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[64];
-    sp_digit m[32];
-    sp_digit r[64];
-#else
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[32 * 5];
+#endif    
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-#endif
     sp_digit *ah = NULL;
-    sp_digit e[1];
+    sp_digit e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 256) {
@@ -5118,22 +5091,18 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
-    }
-
-    if (err == MP_OKAY) {
-        a = d;
-        r = a + 32 * 2;
-        m = r + 32 * 2;
     }
 #endif
 
     if (err == MP_OKAY) {
+        r = a + 32 * 2;
+        m = r + 32 * 2;
         ah = a + 32;
 
         sp_2048_from_bin(ah, 32, in, inLen);
@@ -5206,10 +5175,9 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 256;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
 #endif
 
     return err;
@@ -5340,8 +5308,12 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[32 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -5370,13 +5342,15 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 32;
         m = a + 64;
@@ -5387,34 +5361,36 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         sp_2048_from_mp(m, 32, mm);
         err = sp_2048_mod_exp_32(r, a, d, 2048, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_2048_to_bin(r, out);
         *outLen = 256;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 32);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 32);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[32 * 2];
-    sp_digit p[16];
-    sp_digit q[16];
-    sp_digit dp[16];
-    sp_digit tmpa[32];
-    sp_digit tmpb[32];
-#else
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[16 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
     sp_digit* tmpa = NULL;
     sp_digit* tmpb = NULL;
-#endif
     sp_digit* r = NULL;
     sp_digit* qi = NULL;
     sp_digit* dq = NULL;
@@ -5434,31 +5410,23 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
+
     if (err == MP_OKAY) {
-        a = t;
         p = a + 32 * 2;
         q = p + 16;
         qi = dq = dp = q + 16;
         tmpa = qi + 16;
         tmpb = tmpa + 32;
-
-        r = t + 32;
-    }
-#else
-#endif
-
-    if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         r = a;
-        qi = dq = dp;
-#endif
+
         sp_2048_from_bin(a, 32, in, inLen);
         sp_2048_from_mp(p, 16, pm);
         sp_2048_from_mp(q, 16, qm);
@@ -5490,19 +5458,16 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 256;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 16 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
-    }
-#else
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p,    0, sizeof(p));
-    XMEMSET(q,    0, sizeof(q));
-    XMEMSET(dp,   0, sizeof(dp));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
 #endif
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+    {
+        ForceZero(a, sizeof(sp_digit) * 16 * 11);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -5845,12 +5810,12 @@ static int sp_2048_mod_exp_2_32(sp_digit* r, const sp_digit* e, int bits,
         const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[97];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -5863,18 +5828,13 @@ static int sp_2048_mod_exp_2_32(sp_digit* r, const sp_digit* e, int bits,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 97, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp = td + 64;
-#else
-        tmp = &td[64];
-#endif
 
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_32(norm, m);
@@ -5946,9 +5906,8 @@ static int sp_2048_mod_exp_2_32(sp_digit* r, const sp_digit* e, int bits,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -10825,12 +10784,12 @@ static int sp_3072_mod_exp_24(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 48];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -10842,19 +10801,14 @@ static int sp_3072_mod_exp_24(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 48), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 48;
-#else
-            t[i] = &td[i * 48];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -10950,9 +10904,8 @@ static int sp_3072_mod_exp_24(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -10971,12 +10924,12 @@ static int sp_3072_mod_exp_24(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 48];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -10988,19 +10941,14 @@ static int sp_3072_mod_exp_24(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 48), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 48;
-#else
-            t[i] = &td[i * 48];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -11113,9 +11061,8 @@ static int sp_3072_mod_exp_24(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -12825,12 +12772,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 96];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -12842,19 +12789,14 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 96), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 96;
-#else
-            t[i] = &td[i * 96];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -12950,9 +12892,8 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -12971,12 +12912,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 96];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -12988,19 +12929,14 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 96), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 96;
-#else
-            t[i] = &td[i * 96];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -13113,9 +13049,8 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -13139,18 +13074,15 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
 int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[96];
-    sp_digit m[48];
-    sp_digit r[96];
-#else
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[48 * 5];
+#endif    
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-#endif
     sp_digit *ah = NULL;
-    sp_digit e[1];
+    sp_digit e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 384) {
@@ -13164,22 +13096,18 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 48 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 48 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
-    }
-
-    if (err == MP_OKAY) {
-        a = d;
-        r = a + 48 * 2;
-        m = r + 48 * 2;
     }
 #endif
 
     if (err == MP_OKAY) {
+        r = a + 48 * 2;
+        m = r + 48 * 2;
         ah = a + 48;
 
         sp_3072_from_bin(ah, 48, in, inLen);
@@ -13252,10 +13180,9 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 384;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
 #endif
 
     return err;
@@ -13414,8 +13341,12 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[48 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -13444,13 +13375,15 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 48 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 48;
         m = a + 96;
@@ -13461,34 +13394,36 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_from_mp(m, 48, mm);
         err = sp_3072_mod_exp_48(r, a, d, 3072, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_3072_to_bin(r, out);
         *outLen = 384;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 48);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 48);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[48 * 2];
-    sp_digit p[24];
-    sp_digit q[24];
-    sp_digit dp[24];
-    sp_digit tmpa[48];
-    sp_digit tmpb[48];
-#else
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[24 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
     sp_digit* tmpa = NULL;
     sp_digit* tmpb = NULL;
-#endif
     sp_digit* r = NULL;
     sp_digit* qi = NULL;
     sp_digit* dq = NULL;
@@ -13508,31 +13443,23 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 24 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 24 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
+
     if (err == MP_OKAY) {
-        a = t;
         p = a + 48 * 2;
         q = p + 24;
         qi = dq = dp = q + 24;
         tmpa = qi + 24;
         tmpb = tmpa + 48;
-
-        r = t + 48;
-    }
-#else
-#endif
-
-    if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         r = a;
-        qi = dq = dp;
-#endif
+
         sp_3072_from_bin(a, 48, in, inLen);
         sp_3072_from_mp(p, 24, pm);
         sp_3072_from_mp(q, 24, qm);
@@ -13564,19 +13491,16 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 384;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 24 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
-    }
-#else
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p,    0, sizeof(p));
-    XMEMSET(q,    0, sizeof(q));
-    XMEMSET(dp,   0, sizeof(dp));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
 #endif
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+    {
+        ForceZero(a, sizeof(sp_digit) * 24 * 11);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -14015,12 +13939,12 @@ static int sp_3072_mod_exp_2_48(sp_digit* r, const sp_digit* e, int bits,
         const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[145];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -14033,18 +13957,13 @@ static int sp_3072_mod_exp_2_48(sp_digit* r, const sp_digit* e, int bits,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 145, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp = td + 96;
-#else
-        tmp = &td[96];
-#endif
 
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_48(norm, m);
@@ -14116,9 +14035,8 @@ static int sp_3072_mod_exp_2_48(sp_digit* r, const sp_digit* e, int bits,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -18044,12 +17962,12 @@ static int sp_4096_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 128];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -18061,19 +17979,14 @@ static int sp_4096_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 128), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 128;
-#else
-            t[i] = &td[i * 128];
-#endif
         }
 
         sp_4096_mont_setup(m, &mp);
@@ -18169,9 +18082,8 @@ static int sp_4096_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -18190,12 +18102,12 @@ static int sp_4096_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 128];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -18207,19 +18119,14 @@ static int sp_4096_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 128), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 128;
-#else
-            t[i] = &td[i * 128];
-#endif
         }
 
         sp_4096_mont_setup(m, &mp);
@@ -18332,9 +18239,8 @@ static int sp_4096_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -18358,18 +18264,15 @@ static int sp_4096_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
 int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[128];
-    sp_digit m[64];
-    sp_digit r[128];
-#else
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[64 * 5];
+#endif    
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-#endif
     sp_digit *ah = NULL;
-    sp_digit e[1];
+    sp_digit e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 512) {
@@ -18383,22 +18286,18 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
-    }
-
-    if (err == MP_OKAY) {
-        a = d;
-        r = a + 64 * 2;
-        m = r + 64 * 2;
     }
 #endif
 
     if (err == MP_OKAY) {
+        r = a + 64 * 2;
+        m = r + 64 * 2;
         ah = a + 64;
 
         sp_4096_from_bin(ah, 64, in, inLen);
@@ -18471,10 +18370,9 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 512;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
 #endif
 
     return err;
@@ -18661,8 +18559,12 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[64 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -18691,13 +18593,15 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 64;
         m = a + 128;
@@ -18708,34 +18612,36 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_from_mp(m, 64, mm);
         err = sp_4096_mod_exp_64(r, a, d, 4096, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_4096_to_bin(r, out);
         *outLen = 512;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 64);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 64);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[64 * 2];
-    sp_digit p[32];
-    sp_digit q[32];
-    sp_digit dp[32];
-    sp_digit tmpa[64];
-    sp_digit tmpb[64];
-#else
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[32 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
     sp_digit* tmpa = NULL;
     sp_digit* tmpb = NULL;
-#endif
     sp_digit* r = NULL;
     sp_digit* qi = NULL;
     sp_digit* dq = NULL;
@@ -18755,31 +18661,23 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
+
     if (err == MP_OKAY) {
-        a = t;
         p = a + 64 * 2;
         q = p + 32;
         qi = dq = dp = q + 32;
         tmpa = qi + 32;
         tmpb = tmpa + 64;
-
-        r = t + 64;
-    }
-#else
-#endif
-
-    if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         r = a;
-        qi = dq = dp;
-#endif
+
         sp_4096_from_bin(a, 64, in, inLen);
         sp_4096_from_mp(p, 32, pm);
         sp_4096_from_mp(q, 32, qm);
@@ -18811,19 +18709,16 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 512;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 32 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
-    }
-#else
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p,    0, sizeof(p));
-    XMEMSET(q,    0, sizeof(q));
-    XMEMSET(dp,   0, sizeof(dp));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
 #endif
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+    {
+        ForceZero(a, sizeof(sp_digit) * 32 * 11);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -19358,12 +19253,12 @@ static int sp_4096_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
         const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[193];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -19376,18 +19271,13 @@ static int sp_4096_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 193, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp = td + 128;
-#else
-        tmp = &td[128];
-#endif
 
         sp_4096_mont_setup(m, &mp);
         sp_4096_mont_norm_64(norm, m);
@@ -19459,9 +19349,8 @@ static int sp_4096_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -19925,64 +19814,6 @@ static sp_digit sp_256_sub_4(sp_digit* r, const sp_digit* a,
     );
 
     return (sp_digit)r;
-}
-
-/* Create a new point.
- *
- * heap  [in]   Buffer to allocate dynamic memory from.
- * sp    [in]   Data for point - only if not allocating.
- * p     [out]  New point.
- * returns MEMORY_E when dynamic memory allocation fails and 0 otherwise.
- */
-static int sp_256_point_new_ex_4(void* heap, sp_point_256* sp,
-    sp_point_256** p)
-{
-    int ret = MP_OKAY;
-    (void)heap;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    (void)sp;
-    *p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap, DYNAMIC_TYPE_ECC);
-#else
-    *p = sp;
-#endif
-    if (*p == NULL) {
-        ret = MEMORY_E;
-    }
-    return ret;
-}
-
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* Allocate memory for point and return error. */
-#define sp_256_point_new_4(heap, sp, p) sp_256_point_new_ex_4((heap), NULL, &(p))
-#else
-/* Set pointer to data and return no error. */
-#define sp_256_point_new_4(heap, sp, p) sp_256_point_new_ex_4((heap), &(sp), &(p))
-#endif
-
-
-/* Free the point.
- *
- * p      [in,out]  Point to free.
- * clear  [in]      Indicates whether to zeroize point.
- * heap   [in]      Buffer from which dynamic memory was allocate from.
- */
-static void sp_256_point_free_4(sp_point_256* p, int clear, void* heap)
-{
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* If valid pointer then clear point data if requested and free data. */
-    if (p != NULL) {
-        if (clear != 0) {
-            XMEMSET(p, 0, sizeof(*p));
-        }
-        XFREE(p, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-/* Clear point data if requested. */
-    if ((p != NULL) && (clear != 0)) {
-        XMEMSET(p, 0, sizeof(*p));
-    }
-#endif
-    (void)heap;
 }
 
 /* Multiply a number by Montogmery normalizer mod modulus (prime).
@@ -22188,43 +22019,41 @@ static void sp_256_get_point_33_4(sp_point_256* r, const sp_point_256* table,
 static int sp_256_ecc_mulmod_win_add_sub_4(sp_point_256* r, const sp_point_256* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td[33];
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit tmpd[2 * 4 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_256 t[33+2];
+    sp_digit tmp[2 * 4 * 6];
 #endif
-    sp_point_256* t;
-    sp_point_256* rt;
+    sp_point_256* rt = NULL;
     sp_point_256* p = NULL;
-    sp_digit* tmp;
     sp_digit* negy;
     int i;
     ecc_recode_256 v[43];
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_256_point_new_4(heap, rtd, rt);
-    if (err == MP_OKAY)
-        err = sp_256_point_new_4(heap, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 33, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 
+        (33+2), heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 4 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 4 * 6,
+                                 heap, DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
-
     if (err == MP_OKAY) {
+        rt = t + 33;
+        p  = t + 33+1;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -22304,14 +22133,12 @@ static int sp_256_ecc_mulmod_win_add_sub_4(sp_point_256* r, const sp_point_256* 
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
     if (tmp != NULL)
         XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_4(p, 0, heap);
-    sp_256_point_free_4(rt, 0, heap);
 
     return err;
 }
@@ -22444,29 +22271,30 @@ static void sp_256_proj_to_affine_4(sp_point_256* a, sp_digit* t)
 static int sp_256_gen_stripe_table_4(const sp_point_256* a,
         sp_table_entry_256* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td;
-    sp_point_256 s1d;
-    sp_point_256 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+#else
+    sp_point_256 t[3];
 #endif
-    sp_point_256* t;
     sp_point_256* s1 = NULL;
     sp_point_256* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_256_point_new_4(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_4(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_4(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_256_mod_mul_norm_4(t->x, a->x, p256_mod);
     }
     if (err == MP_OKAY) {
@@ -22511,9 +22339,10 @@ static int sp_256_gen_stripe_table_4(const sp_point_256* a,
         }
     }
 
-    sp_256_point_free_4(s2, 0, heap);
-    sp_256_point_free_4(s1, 0, heap);
-    sp_256_point_free_4( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -22574,19 +22403,19 @@ static int sp_256_ecc_mulmod_stripe_4(sp_point_256* r, const sp_point_256* g,
         const sp_table_entry_256* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit td[2 * 4 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_256 rt[2];
+    sp_digit t[2 * 4 * 5];
 #endif
-    sp_point_256* rt;
     sp_point_256* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -22594,21 +22423,22 @@ static int sp_256_ecc_mulmod_stripe_4(sp_point_256* r, const sp_point_256* g,
     (void)heap;
 
 
-    err = sp_256_point_new_4(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_4(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 4 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 4 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p256_norm_mod, sizeof(p256_norm_mod));
         XMEMCPY(rt->z, p256_norm_mod, sizeof(p256_norm_mod));
 
@@ -22659,13 +22489,12 @@ static int sp_256_ecc_mulmod_stripe_4(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_4(p, 0, heap);
-    sp_256_point_free_4(rt, 0, heap);
 
     return err;
 }
@@ -22834,29 +22663,30 @@ static int sp_256_ecc_mulmod_4(sp_point_256* r, const sp_point_256* g, const sp_
 static int sp_256_gen_stripe_table_4(const sp_point_256* a,
         sp_table_entry_256* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td;
-    sp_point_256 s1d;
-    sp_point_256 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+#else
+    sp_point_256 t[3];
 #endif
-    sp_point_256* t;
     sp_point_256* s1 = NULL;
     sp_point_256* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_256_point_new_4(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_4(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_4(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_256_mod_mul_norm_4(t->x, a->x, p256_mod);
     }
     if (err == MP_OKAY) {
@@ -22901,9 +22731,10 @@ static int sp_256_gen_stripe_table_4(const sp_point_256* a,
         }
     }
 
-    sp_256_point_free_4(s2, 0, heap);
-    sp_256_point_free_4(s1, 0, heap);
-    sp_256_point_free_4( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -22964,19 +22795,19 @@ static int sp_256_ecc_mulmod_stripe_4(sp_point_256* r, const sp_point_256* g,
         const sp_table_entry_256* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit td[2 * 4 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_256 rt[2];
+    sp_digit t[2 * 4 * 5];
 #endif
-    sp_point_256* rt;
     sp_point_256* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -22984,21 +22815,22 @@ static int sp_256_ecc_mulmod_stripe_4(sp_point_256* r, const sp_point_256* g,
     (void)heap;
 
 
-    err = sp_256_point_new_4(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_4(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 4 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 4 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p256_norm_mod, sizeof(p256_norm_mod));
         XMEMCPY(rt->z, p256_norm_mod, sizeof(p256_norm_mod));
 
@@ -23049,13 +22881,12 @@ static int sp_256_ecc_mulmod_stripe_4(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_4(p, 0, heap);
-    sp_256_point_free_4(rt, 0, heap);
 
     return err;
 }
@@ -23220,25 +23051,28 @@ static int sp_256_ecc_mulmod_4(sp_point_256* r, const sp_point_256* g, const sp_
 int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[4];
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[1];
+    sp_digit k[4];
+#endif
     int err = MP_OKAY;
 
-    err = sp_256_point_new_4(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(k, 4, km);
         sp_256_point_from_ecc_point_4(point, gm);
@@ -23249,12 +23083,12 @@ int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_256_point_to_ecc_point_4(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_4(point, 0, heap);
 
     return err;
 }
@@ -23274,37 +23108,35 @@ int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
 int sp_ecc_mulmod_add_256(const mp_int* km, const ecc_point* gm,
     const ecc_point* am, int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_point_256 a;
-    sp_digit kd[4];
-    sp_digit t[4 * 2 * 5];
-#endif
-    sp_point_256* point;
-    sp_point_256* addP = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;    
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[2];
+    sp_digit k[4 + 4 * 2 * 5];
+#endif
+    sp_point_256* addP = NULL;
     sp_digit* tmp = NULL;
     int err = MP_OKAY;
 
-    err = sp_256_point_new_4(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_256_point_new_4(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 + 4 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (4 + 4 * 2 * 5), heap,
+            DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 4;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 4;
+
         sp_256_from_mp(k, 4, km);
         sp_256_point_from_ecc_point_4(point, gm);
         sp_256_point_from_ecc_point_4(addP, am);
@@ -23331,13 +23163,12 @@ int sp_ecc_mulmod_add_256(const mp_int* km, const ecc_point* gm,
         err = sp_256_point_to_ecc_point_4(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_4(addP, 0, heap);
-    sp_256_point_free_4(point, 0, heap);
 
     return err;
 }
@@ -37080,35 +36911,41 @@ static int sp_256_ecc_mulmod_add_only_4(sp_point_256* r, const sp_point_256* g,
         const sp_table_entry_256* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit tmpd[2 * 4 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* rt = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_256 rt[2];
+    sp_digit tmp[2 * 4 * 5];
 #endif
-    sp_point_256* rt;
     sp_point_256* p = NULL;
-    sp_digit* tmp;
-    sp_digit* negy;
+    sp_digit* negy = NULL;
     int i;
     ecc_recode_256 v[37];
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     (void)ct;
     (void)heap;
 
-    err = sp_256_point_new_4(heap, rtd, rt);
-    if (err == MP_OKAY)
-        err = sp_256_point_new_4(heap, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 4 * 5, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
-#else
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 4 * 5, heap,
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
-    negy = tmp;
+
+    if (err == MP_OKAY) {
+        negy = tmp;
+        p = rt + 1;
+    }
 
     if (err == MP_OKAY) {
         sp_256_ecc_recode_7_4(k, v);
@@ -37153,16 +36990,19 @@ static int sp_256_ecc_mulmod_add_only_4(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 4 * 5);
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmp, sizeof(sp_digit) * 2 * 4 * 5);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
-    sp_256_point_free_4(p, 0, heap);
-    sp_256_point_free_4(rt, 0, heap);
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 4 * 5);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return MP_OKAY;
 }
@@ -37196,26 +37036,28 @@ static int sp_256_ecc_mulmod_base_4(sp_point_256* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[4];
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256  point[1];
+    sp_digit k[4];
+#endif
     int err = MP_OKAY;
 
-    err = sp_256_point_new_4(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(k, 4, km);
 
@@ -37225,12 +37067,12 @@ int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_256_point_to_ecc_point_4(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_4(point, 0, heap);
 
     return err;
 }
@@ -37249,37 +37091,35 @@ int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_point_256 a;
-    sp_digit kd[4];
-    sp_digit t[4 * 2 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_256 point[2];
+    sp_digit k[4 + 4 * 2 * 5];
 #endif
-    sp_point_256* point;
     sp_point_256* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_256_point_new_4(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_256_point_new_4(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 + 4 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (4 + 4 * 2 * 5),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 4;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 4;
+
         sp_256_from_mp(k, 4, km);
         sp_256_point_from_ecc_point_4(addP, am);
     }
@@ -37305,13 +37145,12 @@ int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
         err = sp_256_point_to_ecc_point_4(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_4(addP, 0, heap);
-    sp_256_point_free_4(point, 0, heap);
 
     return err;
 }
@@ -37436,41 +37275,46 @@ static int sp_256_ecc_gen_k_4(WC_RNG* rng, sp_digit* k)
  */
 int sp_ecc_make_key_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[4];
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_point_256 inf;
-#endif
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    sp_point_256 point[2];
+    #else
+    sp_point_256 point[1];
+    #endif
+    sp_digit k[4];
+#endif
 #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
     sp_point_256* infinity = NULL;
 #endif
-    int err;
+    int err = MP_OKAY;
+    
 
     (void)heap;
 
-    err = sp_256_point_new_4(heap, p, point);
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_4(heap, inf, infinity);
-    }
-#endif
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap, DYNAMIC_TYPE_ECC);
+    #else
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap, DYNAMIC_TYPE_ECC);    
+    #endif
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+        infinity = point + 1;
+    #endif
+
         err = sp_256_ecc_gen_k_4(rng, k);
     }
     if (err == MP_OKAY) {
@@ -37495,15 +37339,14 @@ int sp_ecc_make_key_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
         err = sp_256_point_to_ecc_point_4(point, pub);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL) {
+        /* point is not sensitive, so no need to zeroize */
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
     }
 #endif
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_256_point_free_4(infinity, 1, heap);
-#endif
-    sp_256_point_free_4(point, 1, heap);
 
     return err;
 }
@@ -37547,30 +37390,32 @@ static void sp_256_to_bin(sp_digit* r, byte* a)
 int sp_ecc_secret_gen_256(const mp_int* priv, const ecc_point* pub, byte* out,
                           word32* outLen, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[4];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[1];
+    sp_digit k[4];
+#endif
     int err = MP_OKAY;
 
     if (*outLen < 32U) {
         err = BUFFER_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_4(heap, p, point);
+        point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
@@ -37583,12 +37428,12 @@ int sp_ecc_secret_gen_256(const mp_int* priv, const ecc_point* pub, byte* out,
         *outLen = 32;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_4(point, 0, heap);
 
     return err;
 }
@@ -38227,22 +38072,17 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
 int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
     const mp_int* priv, mp_int* rm, mp_int* sm, mp_int* km, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit ed[2*4];
-    sp_digit xd[2*4];
-    sp_digit kd[2*4];
-    sp_digit rd[2*4];
-    sp_digit td[3 * 2*4];
-    sp_point_256 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* e = NULL;
+    sp_point_256* point = NULL;
+#else
+    sp_digit e[7 * 2 * 4];
+    sp_point_256 point[1];
+#endif
     sp_digit* x = NULL;
     sp_digit* k = NULL;
     sp_digit* r = NULL;
     sp_digit* tmp = NULL;
-    sp_point_256* point = NULL;
     sp_digit* s = NULL;
     int64_t c;
     int err = MP_OKAY;
@@ -38250,31 +38090,26 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
 
     (void)heap;
 
-    err = sp_256_point_new_4(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 4, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (point == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        e = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 4, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (e == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        e = d + 0 * 4;
-        x = d + 2 * 4;
-        k = d + 4 * 4;
-        r = d + 6 * 4;
-        tmp = d + 8 * 4;
-#else
-        e = ed;
-        x = xd;
-        k = kd;
-        r = rd;
-        tmp = td;
-#endif
+        x = e + 2 * 4;
+        k = e + 4 * 4;
+        r = e + 6 * 4;
+        tmp = e + 8 * 4;
         s = e;
 
         if (hashLen > 32U) {
@@ -38329,19 +38164,24 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
         err = sp_256_to_mp(s, sm);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 8 * 4);
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 2U * 4U);
-    XMEMSET(x, 0, sizeof(sp_digit) * 2U * 4U);
-    XMEMSET(k, 0, sizeof(sp_digit) * 2U * 4U);
-    XMEMSET(r, 0, sizeof(sp_digit) * 2U * 4U);
-    XMEMSET(tmp, 0, sizeof(sp_digit) * 3U * 2U * 4U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (e != NULL)
 #endif
-    sp_256_point_free_4(point, 1, heap);
+    {
+        ForceZero(e, sizeof(sp_digit) * 7 * 2 * 4);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(e, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (point != NULL)
+#endif
+    {
+        ForceZero(point, sizeof(sp_point_256));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -38917,52 +38757,41 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
     const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
     int* res, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit u1d[2*4];
-    sp_digit u2d[2*4];
-    sp_digit sd[2*4];
-    sp_digit tmpd[2*4 * 5];
-    sp_point_256 p1d;
-    sp_point_256 p2d;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* u1 = NULL;
+    sp_point_256* p1 = NULL;
+#else
+    sp_digit  u1[16 * 4];
+    sp_point_256 p1[2];
+#endif
     sp_digit* u2 = NULL;
     sp_digit* s = NULL;
     sp_digit* tmp = NULL;
-    sp_point_256* p1;
     sp_point_256* p2 = NULL;
     sp_digit carry;
     int64_t c = 0;
-    int err;
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_4(heap, p1d, p1);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_4(heap, p2d, p2);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 4, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        p1 = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (p1 == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        u1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 4, heap,
+                                                              DYNAMIC_TYPE_ECC);
+        if (u1 == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        u1  = d + 0 * 4;
-        u2  = d + 2 * 4;
-        s   = d + 4 * 4;
-        tmp = d + 6 * 4;
-#else
-        u1 = u1d;
-        u2 = u2d;
-        s  = sd;
-        tmp = tmpd;
-#endif
+        u2  = u1 + 2 * 4;
+        s   = u1 + 4 * 4;
+        tmp = u1 + 6 * 4;
+        p2 = p1 + 1;
 
         if (hashLen > 32U) {
             hashLen = 32U;
@@ -39013,12 +38842,12 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL)
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (u1 != NULL)
+        XFREE(u1, heap, DYNAMIC_TYPE_ECC);
+    if (p1 != NULL)
+        XFREE(p1, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_4(p1, 0, heap);
-    sp_256_point_free_4(p2, 0, heap);
 
     return err;
 }
@@ -39035,32 +38864,23 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
 static int sp_256_ecc_is_point_4(const sp_point_256* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*4];
-    sp_digit t2d[2*4];
+    sp_digit t1[4 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 4;
-        t2 = d + 2 * 4;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 4;
 
         sp_256_sqr_4(t1, point->y);
         (void)sp_256_mod_4(t1, t1, p256_mod);
@@ -39080,10 +38900,9 @@ static int sp_256_ecc_is_point_4(const sp_point_256* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -39098,14 +38917,21 @@ static int sp_256_ecc_is_point_4(const sp_point_256* point,
  */
 int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* pub = NULL;
+#else
+    sp_point_256 pub[1];
 #endif
-    sp_point_256* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_4(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(pub->x, 4, pX);
         sp_256_from_mp(pub->y, 4, pY);
@@ -39114,7 +38940,10 @@ int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
         err = sp_256_ecc_is_point_4(pub, NULL);
     }
 
-    sp_256_point_free_4(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -39133,44 +38962,44 @@ int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_256(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[4];
-    sp_point_256 pubd;
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_256* pub;
-    sp_point_256* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_256_point_new_4(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_4(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_256* pub = NULL;
+#else
+    sp_digit priv[4];
+    sp_point_256 pub[2];
 #endif
+    sp_point_256* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+    if (((mp_count_bits(pX) > 256) ||
         (mp_count_bits(pY) > 256) ||
         ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_256_from_mp(pub->x, 4, pX);
         sp_256_from_mp(pub->y, 4, pY);
@@ -39220,13 +39049,12 @@ int sp_ecc_check_key_256(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_256_point_free_4(p, 0, heap);
-    sp_256_point_free_4(pub, 0, heap);
 
     return err;
 }
@@ -39250,33 +39078,35 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* qX, mp_int* qY, mp_int* qZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 4 * 5];
-    sp_point_256 pd;
-    sp_point_256 qd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 4 * 5];
+    sp_point_256 p[2];
+#endif
     sp_point_256* q = NULL;
     int err;
 
-    err = sp_256_point_new_4(NULL, pd, p);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_4(NULL, qd, q);
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 4 * 5, NULL,
-                                                              DYNAMIC_TYPE_ECC);
+                                 DYNAMIC_TYPE_ECC);
         if (tmp == NULL) {
             err = MEMORY_E;
         }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
+        q = p + 1;
+
         sp_256_from_mp(p->x, 4, pX);
         sp_256_from_mp(p->y, 4, pY);
         sp_256_from_mp(p->z, 4, pZ);
@@ -39297,13 +39127,12 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_256_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_4(q, 0, NULL);
-    sp_256_point_free_4(p, 0, NULL);
 
     return err;
 }
@@ -39322,25 +39151,28 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
 int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 4 * 2];
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
-    int err;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 4 * 2];
+    sp_point_256 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_4(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 4 * 2, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
@@ -39361,12 +39193,12 @@ int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_256_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_4(p, 0, NULL);
 
     return err;
 }
@@ -39381,25 +39213,29 @@ int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
  */
 int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 4 * 4];
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
-    int err;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 4 * 4];
+    sp_point_256 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_4(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 4 * 4, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
     if (err == MP_OKAY) {
         sp_256_from_mp(p->x, 4, pX);
@@ -39419,12 +39255,12 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
         err = sp_256_to_mp(p->z, pZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_4(p, 0, NULL);
 
     return err;
 }
@@ -39437,31 +39273,23 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
  */
 static int sp_256_mont_sqrt_4(sp_digit* y)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2 * 4];
-    sp_digit t2d[2 * 4];
+    sp_digit t1[4 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 4, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 4, NULL, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL) {
         err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 4;
-        t2 = d + 2 * 4;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 4;
 
         {
             /* t2 = y ^ 0x2 */
@@ -39496,10 +39324,9 @@ static int sp_256_mont_sqrt_4(sp_digit* y)
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -39515,31 +39342,22 @@ static int sp_256_mont_sqrt_4(sp_digit* y)
  */
 int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
-#else
-    sp_digit xd[2 * 4];
-    sp_digit yd[2 * 4];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* x = NULL;
+#else
+    sp_digit x[4 * 4];
+#endif
     sp_digit* y = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 4, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    x = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 4, NULL, DYNAMIC_TYPE_ECC);
+    if (x == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        x = d + 0 * 4;
-        y = d + 2 * 4;
-#else
-        x = xd;
-        y = yd;
-#endif
+        y = x + 2 * 4;
 
         sp_256_from_mp(x, 4, xm);
         err = sp_256_mod_mul_norm_4(x, x, p256_mod);
@@ -39572,10 +39390,9 @@ int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
         err = sp_256_to_mp(y, ym);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (x != NULL)
+        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -40250,64 +40067,6 @@ static sp_digit sp_384_sub_6(sp_digit* r, const sp_digit* a,
     return (sp_digit)r;
 }
 
-/* Create a new point.
- *
- * heap  [in]   Buffer to allocate dynamic memory from.
- * sp    [in]   Data for point - only if not allocating.
- * p     [out]  New point.
- * returns MEMORY_E when dynamic memory allocation fails and 0 otherwise.
- */
-static int sp_384_point_new_ex_6(void* heap, sp_point_384* sp,
-    sp_point_384** p)
-{
-    int ret = MP_OKAY;
-    (void)heap;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    (void)sp;
-    *p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap, DYNAMIC_TYPE_ECC);
-#else
-    *p = sp;
-#endif
-    if (*p == NULL) {
-        ret = MEMORY_E;
-    }
-    return ret;
-}
-
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* Allocate memory for point and return error. */
-#define sp_384_point_new_6(heap, sp, p) sp_384_point_new_ex_6((heap), NULL, &(p))
-#else
-/* Set pointer to data and return no error. */
-#define sp_384_point_new_6(heap, sp, p) sp_384_point_new_ex_6((heap), &(sp), &(p))
-#endif
-
-
-/* Free the point.
- *
- * p      [in,out]  Point to free.
- * clear  [in]      Indicates whether to zeroize point.
- * heap   [in]      Buffer from which dynamic memory was allocate from.
- */
-static void sp_384_point_free_6(sp_point_384* p, int clear, void* heap)
-{
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* If valid pointer then clear point data if requested and free data. */
-    if (p != NULL) {
-        if (clear != 0) {
-            XMEMSET(p, 0, sizeof(*p));
-        }
-        XFREE(p, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-/* Clear point data if requested. */
-    if ((p != NULL) && (clear != 0)) {
-        XMEMSET(p, 0, sizeof(*p));
-    }
-#endif
-    (void)heap;
-}
-
 /* Multiply a number by Montogmery normalizer mod modulus (prime).
  *
  * r  The resulting Montgomery form number.
@@ -40317,34 +40076,25 @@ static void sp_384_point_free_6(sp_point_384* p, int clear, void* heap)
  */
 static int sp_384_mod_mul_norm_6(sp_digit* r, const sp_digit* a, const sp_digit* m)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    int64_t* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    int64_t* t = NULL;
 #else
-    int64_t td[12];
-    int64_t a32d[12];
+    int64_t t[2 * 12];
 #endif
-    int64_t* t;
-    int64_t* a32;
+    int64_t* a32 = NULL;
     int64_t o;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 12, NULL, DYNAMIC_TYPE_ECC);
-    if (td == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 12, NULL, DYNAMIC_TYPE_ECC);
+    if (t == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t = td;
-        a32 = td + 12;
-#else
-        t = td;
-        a32 = a32d;
-#endif
+        a32 = t + 12;
 
         a32[0] = a[0] & 0xffffffff;
         a32[1] = a[0] >> 32;
@@ -40420,9 +40170,9 @@ static int sp_384_mod_mul_norm_6(sp_digit* r, const sp_digit* a, const sp_digit*
         r[5] = (t[11] << 32) | t[10];
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL)
-        XFREE(td, NULL, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -42155,43 +41905,41 @@ static void sp_384_get_point_33_6(sp_point_384* r, const sp_point_384* table,
 static int sp_384_ecc_mulmod_win_add_sub_6(sp_point_384* r, const sp_point_384* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td[33];
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit tmpd[2 * 6 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_384 t[33+2];
+    sp_digit tmp[2 * 6 * 6];
 #endif
-    sp_point_384* t;
-    sp_point_384* rt;
+    sp_point_384* rt = NULL;
     sp_point_384* p = NULL;
-    sp_digit* tmp;
     sp_digit* negy;
     int i;
     ecc_recode_384 v[65];
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_384_point_new_6(heap, rtd, rt);
-    if (err == MP_OKAY)
-        err = sp_384_point_new_6(heap, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 33, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 
+        (33+2), heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 6 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 6 * 6,
+                                 heap, DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
-
     if (err == MP_OKAY) {
+        rt = t + 33;
+        p  = t + 33+1;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -42271,14 +42019,12 @@ static int sp_384_ecc_mulmod_win_add_sub_6(sp_point_384* r, const sp_point_384* 
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
     if (tmp != NULL)
         XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_6(p, 0, heap);
-    sp_384_point_free_6(rt, 0, heap);
 
     return err;
 }
@@ -42411,29 +42157,30 @@ static void sp_384_proj_to_affine_6(sp_point_384* a, sp_digit* t)
 static int sp_384_gen_stripe_table_6(const sp_point_384* a,
         sp_table_entry_384* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td;
-    sp_point_384 s1d;
-    sp_point_384 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+#else
+    sp_point_384 t[3];
 #endif
-    sp_point_384* t;
     sp_point_384* s1 = NULL;
     sp_point_384* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_384_point_new_6(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_6(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_6(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_384_mod_mul_norm_6(t->x, a->x, p384_mod);
     }
     if (err == MP_OKAY) {
@@ -42478,9 +42225,10 @@ static int sp_384_gen_stripe_table_6(const sp_point_384* a,
         }
     }
 
-    sp_384_point_free_6(s2, 0, heap);
-    sp_384_point_free_6(s1, 0, heap);
-    sp_384_point_free_6( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -42549,19 +42297,19 @@ static int sp_384_ecc_mulmod_stripe_6(sp_point_384* r, const sp_point_384* g,
         const sp_table_entry_384* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit td[2 * 6 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_384 rt[2];
+    sp_digit t[2 * 6 * 6];
 #endif
-    sp_point_384* rt;
     sp_point_384* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -42569,21 +42317,22 @@ static int sp_384_ecc_mulmod_stripe_6(sp_point_384* r, const sp_point_384* g,
     (void)heap;
 
 
-    err = sp_384_point_new_6(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_6(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 6 * 6, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 6 * 6, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p384_norm_mod, sizeof(p384_norm_mod));
         XMEMCPY(rt->z, p384_norm_mod, sizeof(p384_norm_mod));
 
@@ -42634,13 +42383,12 @@ static int sp_384_ecc_mulmod_stripe_6(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_6(p, 0, heap);
-    sp_384_point_free_6(rt, 0, heap);
 
     return err;
 }
@@ -42809,29 +42557,30 @@ static int sp_384_ecc_mulmod_6(sp_point_384* r, const sp_point_384* g, const sp_
 static int sp_384_gen_stripe_table_6(const sp_point_384* a,
         sp_table_entry_384* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td;
-    sp_point_384 s1d;
-    sp_point_384 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+#else
+    sp_point_384 t[3];
 #endif
-    sp_point_384* t;
     sp_point_384* s1 = NULL;
     sp_point_384* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_384_point_new_6(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_6(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_6(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_384_mod_mul_norm_6(t->x, a->x, p384_mod);
     }
     if (err == MP_OKAY) {
@@ -42876,9 +42625,10 @@ static int sp_384_gen_stripe_table_6(const sp_point_384* a,
         }
     }
 
-    sp_384_point_free_6(s2, 0, heap);
-    sp_384_point_free_6(s1, 0, heap);
-    sp_384_point_free_6( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -42947,19 +42697,19 @@ static int sp_384_ecc_mulmod_stripe_6(sp_point_384* r, const sp_point_384* g,
         const sp_table_entry_384* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit td[2 * 6 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_384 rt[2];
+    sp_digit t[2 * 6 * 6];
 #endif
-    sp_point_384* rt;
     sp_point_384* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -42967,21 +42717,22 @@ static int sp_384_ecc_mulmod_stripe_6(sp_point_384* r, const sp_point_384* g,
     (void)heap;
 
 
-    err = sp_384_point_new_6(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_6(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 6 * 6, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 6 * 6, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p384_norm_mod, sizeof(p384_norm_mod));
         XMEMCPY(rt->z, p384_norm_mod, sizeof(p384_norm_mod));
 
@@ -43032,13 +42783,12 @@ static int sp_384_ecc_mulmod_stripe_6(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_6(p, 0, heap);
-    sp_384_point_free_6(rt, 0, heap);
 
     return err;
 }
@@ -43203,25 +42953,28 @@ static int sp_384_ecc_mulmod_6(sp_point_384* r, const sp_point_384* g, const sp_
 int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[6];
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[1];
+    sp_digit k[6];
+#endif
     int err = MP_OKAY;
 
-    err = sp_384_point_new_6(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 6, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(k, 6, km);
         sp_384_point_from_ecc_point_6(point, gm);
@@ -43232,12 +42985,12 @@ int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_384_point_to_ecc_point_6(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_6(point, 0, heap);
 
     return err;
 }
@@ -43257,37 +43010,35 @@ int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
 int sp_ecc_mulmod_add_384(const mp_int* km, const ecc_point* gm,
     const ecc_point* am, int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_point_384 a;
-    sp_digit kd[6];
-    sp_digit t[6 * 2 * 6];
-#endif
-    sp_point_384* point;
-    sp_point_384* addP = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;    
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[2];
+    sp_digit k[6 + 6 * 2 * 6];
+#endif
+    sp_point_384* addP = NULL;
     sp_digit* tmp = NULL;
     int err = MP_OKAY;
 
-    err = sp_384_point_new_6(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_384_point_new_6(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (6 + 6 * 2 * 6), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (6 + 6 * 2 * 6), heap,
+            DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 6;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 6;
+
         sp_384_from_mp(k, 6, km);
         sp_384_point_from_ecc_point_6(point, gm);
         sp_384_point_from_ecc_point_6(addP, am);
@@ -43314,13 +43065,12 @@ int sp_ecc_mulmod_add_384(const mp_int* km, const ecc_point* gm,
         err = sp_384_point_to_ecc_point_6(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_6(addP, 0, heap);
-    sp_384_point_free_6(point, 0, heap);
 
     return err;
 }
@@ -62885,35 +62635,41 @@ static int sp_384_ecc_mulmod_add_only_6(sp_point_384* r, const sp_point_384* g,
         const sp_table_entry_384* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit tmpd[2 * 6 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* rt = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_384 rt[2];
+    sp_digit tmp[2 * 6 * 6];
 #endif
-    sp_point_384* rt;
     sp_point_384* p = NULL;
-    sp_digit* tmp;
-    sp_digit* negy;
+    sp_digit* negy = NULL;
     int i;
     ecc_recode_384 v[55];
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     (void)ct;
     (void)heap;
 
-    err = sp_384_point_new_6(heap, rtd, rt);
-    if (err == MP_OKAY)
-        err = sp_384_point_new_6(heap, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 6 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
-#else
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 6 * 6, heap,
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
-    negy = tmp;
+
+    if (err == MP_OKAY) {
+        negy = tmp;
+        p = rt + 1;
+    }
 
     if (err == MP_OKAY) {
         sp_384_ecc_recode_7_6(k, v);
@@ -62958,16 +62714,19 @@ static int sp_384_ecc_mulmod_add_only_6(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 6 * 6);
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmp, sizeof(sp_digit) * 2 * 6 * 6);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
-    sp_384_point_free_6(p, 0, heap);
-    sp_384_point_free_6(rt, 0, heap);
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 6 * 6);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return MP_OKAY;
 }
@@ -63001,26 +62760,28 @@ static int sp_384_ecc_mulmod_base_6(sp_point_384* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[6];
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384  point[1];
+    sp_digit k[6];
+#endif
     int err = MP_OKAY;
 
-    err = sp_384_point_new_6(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 6, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(k, 6, km);
 
@@ -63030,12 +62791,12 @@ int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_384_point_to_ecc_point_6(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_6(point, 0, heap);
 
     return err;
 }
@@ -63054,37 +62815,35 @@ int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_point_384 a;
-    sp_digit kd[6];
-    sp_digit t[6 * 2 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_384 point[2];
+    sp_digit k[6 + 6 * 2 * 6];
 #endif
-    sp_point_384* point;
     sp_point_384* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_384_point_new_6(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_384_point_new_6(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (6 + 6 * 2 * 6), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (6 + 6 * 2 * 6),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 6;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 6;
+
         sp_384_from_mp(k, 6, km);
         sp_384_point_from_ecc_point_6(addP, am);
     }
@@ -63110,13 +62869,12 @@ int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
         err = sp_384_point_to_ecc_point_6(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_6(addP, 0, heap);
-    sp_384_point_free_6(point, 0, heap);
 
     return err;
 }
@@ -63245,41 +63003,46 @@ static int sp_384_ecc_gen_k_6(WC_RNG* rng, sp_digit* k)
  */
 int sp_ecc_make_key_384(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[6];
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_point_384 inf;
-#endif
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    sp_point_384 point[2];
+    #else
+    sp_point_384 point[1];
+    #endif
+    sp_digit k[6];
+#endif
 #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
     sp_point_384* infinity = NULL;
 #endif
-    int err;
+    int err = MP_OKAY;
+    
 
     (void)heap;
 
-    err = sp_384_point_new_6(heap, p, point);
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_6(heap, inf, infinity);
-    }
-#endif
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap, DYNAMIC_TYPE_ECC);
+    #else
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap, DYNAMIC_TYPE_ECC);    
+    #endif
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 6, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+        infinity = point + 1;
+    #endif
+
         err = sp_384_ecc_gen_k_6(rng, k);
     }
     if (err == MP_OKAY) {
@@ -63304,15 +63067,14 @@ int sp_ecc_make_key_384(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
         err = sp_384_point_to_ecc_point_6(point, pub);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL) {
+        /* point is not sensitive, so no need to zeroize */
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
     }
 #endif
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_384_point_free_6(infinity, 1, heap);
-#endif
-    sp_384_point_free_6(point, 1, heap);
 
     return err;
 }
@@ -63356,30 +63118,32 @@ static void sp_384_to_bin(sp_digit* r, byte* a)
 int sp_ecc_secret_gen_384(const mp_int* priv, const ecc_point* pub, byte* out,
                           word32* outLen, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[6];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[1];
+    sp_digit k[6];
+#endif
     int err = MP_OKAY;
 
     if (*outLen < 48U) {
         err = BUFFER_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_6(heap, p, point);
+        point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 6, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
@@ -63392,12 +63156,12 @@ int sp_ecc_secret_gen_384(const mp_int* priv, const ecc_point* pub, byte* out,
         *outLen = 48;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_6(point, 0, heap);
 
     return err;
 }
@@ -64071,22 +63835,17 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
 int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
     const mp_int* priv, mp_int* rm, mp_int* sm, mp_int* km, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit ed[2*6];
-    sp_digit xd[2*6];
-    sp_digit kd[2*6];
-    sp_digit rd[2*6];
-    sp_digit td[3 * 2*6];
-    sp_point_384 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* e = NULL;
+    sp_point_384* point = NULL;
+#else
+    sp_digit e[7 * 2 * 6];
+    sp_point_384 point[1];
+#endif
     sp_digit* x = NULL;
     sp_digit* k = NULL;
     sp_digit* r = NULL;
     sp_digit* tmp = NULL;
-    sp_point_384* point = NULL;
     sp_digit* s = NULL;
     int64_t c;
     int err = MP_OKAY;
@@ -64094,31 +63853,26 @@ int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
 
     (void)heap;
 
-    err = sp_384_point_new_6(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 6, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (point == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        e = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 6, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (e == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        e = d + 0 * 6;
-        x = d + 2 * 6;
-        k = d + 4 * 6;
-        r = d + 6 * 6;
-        tmp = d + 8 * 6;
-#else
-        e = ed;
-        x = xd;
-        k = kd;
-        r = rd;
-        tmp = td;
-#endif
+        x = e + 2 * 6;
+        k = e + 4 * 6;
+        r = e + 6 * 6;
+        tmp = e + 8 * 6;
         s = e;
 
         if (hashLen > 48U) {
@@ -64173,19 +63927,24 @@ int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
         err = sp_384_to_mp(s, sm);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 8 * 6);
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 2U * 6U);
-    XMEMSET(x, 0, sizeof(sp_digit) * 2U * 6U);
-    XMEMSET(k, 0, sizeof(sp_digit) * 2U * 6U);
-    XMEMSET(r, 0, sizeof(sp_digit) * 2U * 6U);
-    XMEMSET(tmp, 0, sizeof(sp_digit) * 3U * 2U * 6U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (e != NULL)
 #endif
-    sp_384_point_free_6(point, 1, heap);
+    {
+        ForceZero(e, sizeof(sp_digit) * 7 * 2 * 6);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(e, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (point != NULL)
+#endif
+    {
+        ForceZero(point, sizeof(sp_point_384));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -64646,52 +64405,41 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
     const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
     int* res, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit u1d[2*6];
-    sp_digit u2d[2*6];
-    sp_digit sd[2*6];
-    sp_digit tmpd[2*6 * 5];
-    sp_point_384 p1d;
-    sp_point_384 p2d;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* u1 = NULL;
+    sp_point_384* p1 = NULL;
+#else
+    sp_digit  u1[16 * 6];
+    sp_point_384 p1[2];
+#endif
     sp_digit* u2 = NULL;
     sp_digit* s = NULL;
     sp_digit* tmp = NULL;
-    sp_point_384* p1;
     sp_point_384* p2 = NULL;
     sp_digit carry;
     int64_t c = 0;
-    int err;
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_6(heap, p1d, p1);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_6(heap, p2d, p2);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 6, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        p1 = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (p1 == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        u1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 6, heap,
+                                                              DYNAMIC_TYPE_ECC);
+        if (u1 == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        u1  = d + 0 * 6;
-        u2  = d + 2 * 6;
-        s   = d + 4 * 6;
-        tmp = d + 6 * 6;
-#else
-        u1 = u1d;
-        u2 = u2d;
-        s  = sd;
-        tmp = tmpd;
-#endif
+        u2  = u1 + 2 * 6;
+        s   = u1 + 4 * 6;
+        tmp = u1 + 6 * 6;
+        p2 = p1 + 1;
 
         if (hashLen > 48U) {
             hashLen = 48U;
@@ -64742,12 +64490,12 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL)
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (u1 != NULL)
+        XFREE(u1, heap, DYNAMIC_TYPE_ECC);
+    if (p1 != NULL)
+        XFREE(p1, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_6(p1, 0, heap);
-    sp_384_point_free_6(p2, 0, heap);
 
     return err;
 }
@@ -64764,32 +64512,23 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
 static int sp_384_ecc_is_point_6(const sp_point_384* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*6];
-    sp_digit t2d[2*6];
+    sp_digit t1[6 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 6 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 6 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 6;
-        t2 = d + 2 * 6;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 6;
 
         sp_384_sqr_6(t1, point->y);
         (void)sp_384_mod_6(t1, t1, p384_mod);
@@ -64809,10 +64548,9 @@ static int sp_384_ecc_is_point_6(const sp_point_384* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -64827,14 +64565,21 @@ static int sp_384_ecc_is_point_6(const sp_point_384* point,
  */
 int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* pub = NULL;
+#else
+    sp_point_384 pub[1];
 #endif
-    sp_point_384* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_6(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(pub->x, 6, pX);
         sp_384_from_mp(pub->y, 6, pY);
@@ -64843,7 +64588,10 @@ int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
         err = sp_384_ecc_is_point_6(pub, NULL);
     }
 
-    sp_384_point_free_6(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -64862,44 +64610,44 @@ int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_384(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[6];
-    sp_point_384 pubd;
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_384* pub;
-    sp_point_384* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_384_point_new_6(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_6(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 6, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_384* pub = NULL;
+#else
+    sp_digit priv[6];
+    sp_point_384 pub[2];
 #endif
+    sp_point_384* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+    if (((mp_count_bits(pX) > 384) ||
         (mp_count_bits(pY) > 384) ||
         ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 6, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_384_from_mp(pub->x, 6, pX);
         sp_384_from_mp(pub->y, 6, pY);
@@ -64949,13 +64697,12 @@ int sp_ecc_check_key_384(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_384_point_free_6(p, 0, heap);
-    sp_384_point_free_6(pub, 0, heap);
 
     return err;
 }
@@ -64979,33 +64726,35 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* qX, mp_int* qY, mp_int* qZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 6 * 5];
-    sp_point_384 pd;
-    sp_point_384 qd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 6 * 5];
+    sp_point_384 p[2];
+#endif
     sp_point_384* q = NULL;
     int err;
 
-    err = sp_384_point_new_6(NULL, pd, p);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_6(NULL, qd, q);
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 6 * 5, NULL,
-                                                              DYNAMIC_TYPE_ECC);
+                                 DYNAMIC_TYPE_ECC);
         if (tmp == NULL) {
             err = MEMORY_E;
         }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
+        q = p + 1;
+
         sp_384_from_mp(p->x, 6, pX);
         sp_384_from_mp(p->y, 6, pY);
         sp_384_from_mp(p->z, 6, pZ);
@@ -65026,13 +64775,12 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_384_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_6(q, 0, NULL);
-    sp_384_point_free_6(p, 0, NULL);
 
     return err;
 }
@@ -65051,25 +64799,28 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
 int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 6 * 2];
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
-    int err;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 6 * 2];
+    sp_point_384 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_6(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 6 * 2, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
@@ -65090,12 +64841,12 @@ int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_384_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_6(p, 0, NULL);
 
     return err;
 }
@@ -65110,25 +64861,29 @@ int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
  */
 int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 6 * 6];
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
-    int err;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 6 * 6];
+    sp_point_384 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_6(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 6 * 6, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
     if (err == MP_OKAY) {
         sp_384_from_mp(p->x, 6, pX);
@@ -65148,12 +64903,12 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
         err = sp_384_to_mp(p->z, pZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_6(p, 0, NULL);
 
     return err;
 }
@@ -65166,43 +64921,28 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
  */
 static int sp_384_mont_sqrt_6(sp_digit* y)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2 * 6];
-    sp_digit t2d[2 * 6];
-    sp_digit t3d[2 * 6];
-    sp_digit t4d[2 * 6];
-    sp_digit t5d[2 * 6];
+    sp_digit t1[5 * 2 * 6];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* t3;
-    sp_digit* t4;
-    sp_digit* t5;
+    sp_digit* t2 = NULL;
+    sp_digit* t3 = NULL;
+    sp_digit* t4 = NULL;
+    sp_digit* t5 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 6, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 6, NULL, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 6;
-        t2 = d + 2 * 6;
-        t3 = d + 4 * 6;
-        t4 = d + 6 * 6;
-        t5 = d + 8 * 6;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        t3 = t3d;
-        t4 = t4d;
-        t5 = t5d;
-#endif
+        t2 = t1 + 2 * 6;
+        t3 = t1 + 4 * 6;
+        t4 = t1 + 6 * 6;
+        t5 = t1 + 8 * 6;
 
         {
             /* t2 = y ^ 0x2 */
@@ -65262,10 +65002,9 @@ static int sp_384_mont_sqrt_6(sp_digit* y)
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -65281,31 +65020,22 @@ static int sp_384_mont_sqrt_6(sp_digit* y)
  */
 int sp_ecc_uncompress_384(mp_int* xm, int odd, mp_int* ym)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
-#else
-    sp_digit xd[2 * 6];
-    sp_digit yd[2 * 6];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* x = NULL;
+#else
+    sp_digit x[4 * 6];
+#endif
     sp_digit* y = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 6, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    x = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 6, NULL, DYNAMIC_TYPE_ECC);
+    if (x == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        x = d + 0 * 6;
-        y = d + 2 * 6;
-#else
-        x = xd;
-        y = yd;
-#endif
+        y = x + 2 * 6;
 
         sp_384_from_mp(x, 6, xm);
         err = sp_384_mod_mul_norm_6(x, x, p384_mod);
@@ -65338,10 +65068,9 @@ int sp_ecc_uncompress_384(mp_int* xm, int odd, mp_int* ym)
         err = sp_384_to_mp(y, ym);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (x != NULL)
+        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -67214,6 +66943,8 @@ static int sp_1024_mod_mul_norm_16(sp_digit* r, const sp_digit* a,
     return sp_1024_mod_16(r, r, m);
 }
 
+
+#ifdef WOLFCRYPT_HAVE_SAKKE
 /* Create a new point.
  *
  * heap  [in]   Buffer to allocate dynamic memory from.
@@ -67245,8 +66976,8 @@ static int sp_1024_point_new_ex_16(void* heap, sp_point_1024* sp,
 /* Set pointer to data and return no error. */
 #define sp_1024_point_new_16(heap, sp, p) sp_1024_point_new_ex_16((heap), &(sp), &(p))
 #endif
-
-
+#endif /* WOLFCRYPT_HAVE_SAKKE */
+#ifdef WOLFCRYPT_HAVE_SAKKE
 /* Free the point.
  *
  * p      [in,out]  Point to free.
@@ -67271,6 +67002,7 @@ static void sp_1024_point_free_16(sp_point_1024* p, int clear, void* heap)
 #endif
     (void)heap;
 }
+#endif /* WOLFCRYPT_HAVE_SAKKE */
 
 /* Convert an mp_int to an array of sp_digit.
  *
@@ -69514,43 +69246,41 @@ static void sp_1024_ecc_recode_7_16(const sp_digit* k, ecc_recode_1024* v)
 static int sp_1024_ecc_mulmod_win_add_sub_16(sp_point_1024* r, const sp_point_1024* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td[65];
-    sp_point_1024 rtd;
-    sp_point_1024 pd;
-    sp_digit tmpd[2 * 16 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_1024 t[65+2];
+    sp_digit tmp[2 * 16 * 6];
 #endif
-    sp_point_1024* t;
-    sp_point_1024* rt;
+    sp_point_1024* rt = NULL;
     sp_point_1024* p = NULL;
-    sp_digit* tmp;
     sp_digit* negy;
     int i;
     ecc_recode_1024 v[147];
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_1024_point_new_16(heap, rtd, rt);
-    if (err == MP_OKAY)
-        err = sp_1024_point_new_16(heap, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 65, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 
+        (65+2), heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 16 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 16 * 6,
+                                 heap, DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
-
     if (err == MP_OKAY) {
+        rt = t + 65;
+        p  = t + 65+1;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -69634,14 +69364,12 @@ static int sp_1024_ecc_mulmod_win_add_sub_16(sp_point_1024* r, const sp_point_10
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
     if (tmp != NULL)
         XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_16(p, 0, heap);
-    sp_1024_point_free_16(rt, 0, heap);
 
     return err;
 }
@@ -69773,29 +69501,30 @@ static void sp_1024_proj_to_affine_16(sp_point_1024* a, sp_digit* t)
 static int sp_1024_gen_stripe_table_16(const sp_point_1024* a,
         sp_table_entry_1024* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td;
-    sp_point_1024 s1d;
-    sp_point_1024 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+#else
+    sp_point_1024 t[3];
 #endif
-    sp_point_1024* t;
     sp_point_1024* s1 = NULL;
     sp_point_1024* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_1024_point_new_16(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_16(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_16(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_1024_mod_mul_norm_16(t->x, a->x, p1024_mod);
     }
     if (err == MP_OKAY) {
@@ -69840,9 +69569,10 @@ static int sp_1024_gen_stripe_table_16(const sp_point_1024* a,
         }
     }
 
-    sp_1024_point_free_16(s2, 0, heap);
-    sp_1024_point_free_16(s1, 0, heap);
-    sp_1024_point_free_16( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -69868,19 +69598,19 @@ static int sp_1024_ecc_mulmod_stripe_16(sp_point_1024* r, const sp_point_1024* g
         const sp_table_entry_1024* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 rtd;
-    sp_point_1024 pd;
-    sp_digit td[2 * 16 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 rt[2];
+    sp_digit t[2 * 16 * 5];
 #endif
-    sp_point_1024* rt;
     sp_point_1024* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -69888,21 +69618,22 @@ static int sp_1024_ecc_mulmod_stripe_16(sp_point_1024* r, const sp_point_1024* g
     (void)heap;
 
 
-    err = sp_1024_point_new_16(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_16(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 16 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 16 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p1024_norm_mod, sizeof(p1024_norm_mod));
         XMEMCPY(rt->z, p1024_norm_mod, sizeof(p1024_norm_mod));
 
@@ -69938,13 +69669,12 @@ static int sp_1024_ecc_mulmod_stripe_16(sp_point_1024* r, const sp_point_1024* g
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_16(p, 0, heap);
-    sp_1024_point_free_16(rt, 0, heap);
 
     return err;
 }
@@ -70107,25 +69837,28 @@ static int sp_1024_ecc_mulmod_16(sp_point_1024* r, const sp_point_1024* g, const
 int sp_ecc_mulmod_1024(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[16];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024 point[1];
+    sp_digit k[16];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_16(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 16, km);
         sp_1024_point_from_ecc_point_16(point, gm);
@@ -70136,12 +69869,12 @@ int sp_ecc_mulmod_1024(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_1024_point_to_ecc_point_16(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_16(point, 0, heap);
 
     return err;
 }
@@ -73504,26 +73237,28 @@ static int sp_1024_ecc_mulmod_base_16(sp_point_1024* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[16];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024  point[1];
+    sp_digit k[16];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_16(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 16, km);
 
@@ -73533,12 +73268,12 @@ int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_1024_point_to_ecc_point_16(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_16(point, 0, heap);
 
     return err;
 }
@@ -73557,37 +73292,35 @@ int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_point_1024 a;
-    sp_digit kd[16];
-    sp_digit t[16 * 2 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_1024 point[2];
+    sp_digit k[16 + 16 * 2 * 5];
 #endif
-    sp_point_1024* point;
     sp_point_1024* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_16(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_1024_point_new_16(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 + 16 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (16 + 16 * 2 * 5),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 16;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 16;
+
         sp_1024_from_mp(k, 16, km);
         sp_1024_point_from_ecc_point_16(addP, am);
     }
@@ -73613,13 +73346,12 @@ int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
         err = sp_1024_point_to_ecc_point_16(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_16(addP, 0, heap);
-    sp_1024_point_free_16(point, 0, heap);
 
     return err;
 }
@@ -73637,29 +73369,43 @@ int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
 int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
     void* heap)
 {
-    int err = 0;
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_1024* point = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 point[1];
     sp_digit t[5 * 2 * 16];
+#endif
+    int err = MP_OKAY;
 
     if ((gm == NULL) || (len == NULL)) {
         err = BAD_FUNC_ARG;
     }
 
-    if ((err == 0) && (table == NULL)) {
+    if ((err == MP_OKAY) && (table == NULL)) {
         *len = sizeof(sp_table_entry_1024) * 256;
         err = LENGTH_ONLY_E;
     }
-    if ((err == 0) && (*len < (int)(sizeof(sp_table_entry_1024) * 256))) {
+    if ((err == MP_OKAY) && (*len < (int)(sizeof(sp_table_entry_1024) * 256))) {
         err = BUFFER_E;
     }
 
-    if (err == 0) {
-        err = sp_1024_point_new_16(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+            DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-    if (err == 0) {
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 16, heap,
+            DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
         sp_1024_point_from_ecc_point_16(point, gm);
             err = sp_1024_gen_stripe_table_16(point,
                 (sp_table_entry_1024*)table, t, heap);
@@ -73668,7 +73414,12 @@ int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
         *len = sizeof(sp_table_entry_1024) * 256;
     }
 
-    sp_1024_point_free_16(point, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -73721,24 +73472,28 @@ int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
 int sp_ecc_mulmod_table_1024(const mp_int* km, const ecc_point* gm, byte* table,
         ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[16];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024 point[1];
+    sp_digit k[16];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_16(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+        DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16, heap, DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 16, km);
         sp_1024_point_from_ecc_point_16(point, gm);
@@ -73755,12 +73510,12 @@ int sp_ecc_mulmod_table_1024(const mp_int* km, const ecc_point* gm, byte* table,
         err = sp_1024_point_to_ecc_point_16(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_16(point, 0, heap);
 
     return err;
 }
@@ -76964,33 +76719,24 @@ static void sp_1024_from_bin(sp_digit* r, int size, const byte* a, int n)
 static int sp_1024_ecc_is_point_16(const sp_point_1024* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*16];
-    sp_digit t2d[2*16];
+    sp_digit t1[16 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int64_t n;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 16;
-        t2 = d + 2 * 16;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 16;
 
         sp_1024_sqr_16(t1, point->y);
         (void)sp_1024_mod_16(t1, t1, p1024_mod);
@@ -77014,10 +76760,9 @@ static int sp_1024_ecc_is_point_16(const sp_point_1024* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -77032,14 +76777,21 @@ static int sp_1024_ecc_is_point_16(const sp_point_1024* point,
  */
 int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* pub = NULL;
+#else
+    sp_point_1024 pub[1];
 #endif
-    sp_point_1024* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_1024_point_new_16(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(pub->x, 16, pX);
         sp_1024_from_mp(pub->y, 16, pY);
@@ -77048,7 +76800,10 @@ int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
         err = sp_1024_ecc_is_point_16(pub, NULL);
     }
 
-    sp_1024_point_free_16(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -77067,44 +76822,44 @@ int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_1024(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[16];
-    sp_point_1024 pubd;
-    sp_point_1024 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_1024* pub;
-    sp_point_1024* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_1024_point_new_16(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_16(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_1024* pub = NULL;
+#else
+    sp_digit priv[16];
+    sp_point_1024 pub[2];
 #endif
+    sp_point_1024* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 1024) ||
+    if (((mp_count_bits(pX) > 1024) ||
         (mp_count_bits(pY) > 1024) ||
         ((privm != NULL) && (mp_count_bits(privm) > 1024)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_1024_from_mp(pub->x, 16, pX);
         sp_1024_from_mp(pub->y, 16, pY);
@@ -77154,13 +76909,12 @@ int sp_ecc_check_key_1024(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_1024_point_free_16(p, 0, heap);
-    sp_1024_point_free_16(pub, 0, heap);
 
     return err;
 }

--- a/wolfcrypt/src/sp_armthumb.c
+++ b/wolfcrypt/src/sp_armthumb.c
@@ -3144,12 +3144,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 64];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -3161,19 +3161,14 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 64), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 64;
-#else
-            t[i] = &td[i * 64];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -3269,9 +3264,8 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -3290,12 +3284,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 64];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -3307,19 +3301,14 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 64), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 64;
-#else
-            t[i] = &td[i * 64];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -3432,9 +3421,8 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -4006,12 +3994,12 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 128];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -4023,19 +4011,14 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 128), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 128;
-#else
-            t[i] = &td[i * 128];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -4131,9 +4114,8 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -4152,12 +4134,12 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 128];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -4169,19 +4151,14 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 128), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 128;
-#else
-            t[i] = &td[i * 128];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -4294,9 +4271,8 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -4320,18 +4296,15 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
 int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[128];
-    sp_digit m[64];
-    sp_digit r[128];
-#else
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[64 * 5];
+#endif    
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-#endif
     sp_digit *ah = NULL;
-    sp_digit e[1];
+    sp_digit e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 256) {
@@ -4345,22 +4318,18 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
-    }
-
-    if (err == MP_OKAY) {
-        a = d;
-        r = a + 64 * 2;
-        m = r + 64 * 2;
     }
 #endif
 
     if (err == MP_OKAY) {
+        r = a + 64 * 2;
+        m = r + 64 * 2;
         ah = a + 64;
 
         sp_2048_from_bin(ah, 64, in, inLen);
@@ -4433,10 +4402,9 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 256;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
 #endif
 
     return err;
@@ -4504,8 +4472,12 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[64 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -4534,13 +4506,15 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 64;
         m = a + 128;
@@ -4551,34 +4525,36 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         sp_2048_from_mp(m, 64, mm);
         err = sp_2048_mod_exp_64(r, a, d, 2048, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_2048_to_bin(r, out);
         *outLen = 256;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 64);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 64);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[64 * 2];
-    sp_digit p[32];
-    sp_digit q[32];
-    sp_digit dp[32];
-    sp_digit tmpa[64];
-    sp_digit tmpb[64];
-#else
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[32 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
     sp_digit* tmpa = NULL;
     sp_digit* tmpb = NULL;
-#endif
     sp_digit* r = NULL;
     sp_digit* qi = NULL;
     sp_digit* dq = NULL;
@@ -4598,31 +4574,23 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
+
     if (err == MP_OKAY) {
-        a = t;
         p = a + 64 * 2;
         q = p + 32;
         qi = dq = dp = q + 32;
         tmpa = qi + 32;
         tmpb = tmpa + 64;
-
-        r = t + 64;
-    }
-#else
-#endif
-
-    if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         r = a;
-        qi = dq = dp;
-#endif
+
         sp_2048_from_bin(a, 64, in, inLen);
         sp_2048_from_mp(p, 32, pm);
         sp_2048_from_mp(q, 32, qm);
@@ -4654,19 +4622,16 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 256;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 32 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
-    }
-#else
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p,    0, sizeof(p));
-    XMEMSET(q,    0, sizeof(q));
-    XMEMSET(dp,   0, sizeof(dp));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
 #endif
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+    {
+        ForceZero(a, sizeof(sp_digit) * 32 * 11);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -5208,12 +5173,12 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
         const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[193];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -5226,18 +5191,13 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 193, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp = td + 128;
-#else
-        tmp = &td[128];
-#endif
 
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_64(norm, m);
@@ -5308,9 +5268,8 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -9044,12 +9003,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 96];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -9061,19 +9020,14 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 96), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 96;
-#else
-            t[i] = &td[i * 96];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -9169,9 +9123,8 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -9190,12 +9143,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 96];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -9207,19 +9160,14 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 96), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 96;
-#else
-            t[i] = &td[i * 96];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -9332,9 +9280,8 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -9912,12 +9859,12 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 192];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -9929,19 +9876,14 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 192), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 192;
-#else
-            t[i] = &td[i * 192];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -10037,9 +9979,8 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -10058,12 +9999,12 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 192];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -10075,19 +10016,14 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 192), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 192;
-#else
-            t[i] = &td[i * 192];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -10200,9 +10136,8 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -10226,18 +10161,15 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
 int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[192];
-    sp_digit m[96];
-    sp_digit r[192];
-#else
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[96 * 5];
+#endif    
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-#endif
     sp_digit *ah = NULL;
-    sp_digit e[1];
+    sp_digit e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 384) {
@@ -10251,22 +10183,18 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 96 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 96 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
-    }
-
-    if (err == MP_OKAY) {
-        a = d;
-        r = a + 96 * 2;
-        m = r + 96 * 2;
     }
 #endif
 
     if (err == MP_OKAY) {
+        r = a + 96 * 2;
+        m = r + 96 * 2;
         ah = a + 96;
 
         sp_3072_from_bin(ah, 96, in, inLen);
@@ -10339,10 +10267,9 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 384;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
 #endif
 
     return err;
@@ -10410,8 +10337,12 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[96 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -10440,13 +10371,15 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 96 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 96;
         m = a + 192;
@@ -10457,34 +10390,36 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_from_mp(m, 96, mm);
         err = sp_3072_mod_exp_96(r, a, d, 3072, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_3072_to_bin(r, out);
         *outLen = 384;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 96);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 96);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[96 * 2];
-    sp_digit p[48];
-    sp_digit q[48];
-    sp_digit dp[48];
-    sp_digit tmpa[96];
-    sp_digit tmpb[96];
-#else
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[48 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
     sp_digit* tmpa = NULL;
     sp_digit* tmpb = NULL;
-#endif
     sp_digit* r = NULL;
     sp_digit* qi = NULL;
     sp_digit* dq = NULL;
@@ -10504,31 +10439,23 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 48 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 48 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
+
     if (err == MP_OKAY) {
-        a = t;
         p = a + 96 * 2;
         q = p + 48;
         qi = dq = dp = q + 48;
         tmpa = qi + 48;
         tmpb = tmpa + 96;
-
-        r = t + 96;
-    }
-#else
-#endif
-
-    if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         r = a;
-        qi = dq = dp;
-#endif
+
         sp_3072_from_bin(a, 96, in, inLen);
         sp_3072_from_mp(p, 48, pm);
         sp_3072_from_mp(q, 48, qm);
@@ -10560,19 +10487,16 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 384;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 48 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
-    }
-#else
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p,    0, sizeof(p));
-    XMEMSET(q,    0, sizeof(q));
-    XMEMSET(dp,   0, sizeof(dp));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
 #endif
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+    {
+        ForceZero(a, sizeof(sp_digit) * 48 * 11);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -11312,12 +11236,12 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
         const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[289];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -11330,18 +11254,13 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 289, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp = td + 192;
-#else
-        tmp = &td[192];
-#endif
 
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_96(norm, m);
@@ -11412,9 +11331,8 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -13870,12 +13788,12 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 256];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -13887,19 +13805,14 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 256), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 256;
-#else
-            t[i] = &td[i * 256];
-#endif
         }
 
         sp_4096_mont_setup(m, &mp);
@@ -13995,9 +13908,8 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -14016,12 +13928,12 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 256];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -14033,19 +13945,14 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 256), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 256;
-#else
-            t[i] = &td[i * 256];
-#endif
         }
 
         sp_4096_mont_setup(m, &mp);
@@ -14158,9 +14065,8 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -14184,18 +14090,15 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
 int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[256];
-    sp_digit m[128];
-    sp_digit r[256];
-#else
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[128 * 5];
+#endif    
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-#endif
     sp_digit *ah = NULL;
-    sp_digit e[1];
+    sp_digit e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 512) {
@@ -14209,22 +14112,18 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 128 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 128 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
-    }
-
-    if (err == MP_OKAY) {
-        a = d;
-        r = a + 128 * 2;
-        m = r + 128 * 2;
     }
 #endif
 
     if (err == MP_OKAY) {
+        r = a + 128 * 2;
+        m = r + 128 * 2;
         ah = a + 128;
 
         sp_4096_from_bin(ah, 128, in, inLen);
@@ -14297,10 +14196,9 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 512;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
 #endif
 
     return err;
@@ -14369,8 +14267,12 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[128 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -14399,13 +14301,15 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 128 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 128;
         m = a + 256;
@@ -14416,34 +14320,36 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_from_mp(m, 128, mm);
         err = sp_4096_mod_exp_128(r, a, d, 4096, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_4096_to_bin(r, out);
         *outLen = 512;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 128);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 128);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[128 * 2];
-    sp_digit p[64];
-    sp_digit q[64];
-    sp_digit dp[64];
-    sp_digit tmpa[128];
-    sp_digit tmpb[128];
-#else
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[64 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
     sp_digit* tmpa = NULL;
     sp_digit* tmpb = NULL;
-#endif
     sp_digit* r = NULL;
     sp_digit* qi = NULL;
     sp_digit* dq = NULL;
@@ -14463,31 +14369,23 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
+
     if (err == MP_OKAY) {
-        a = t;
         p = a + 128 * 2;
         q = p + 64;
         qi = dq = dp = q + 64;
         tmpa = qi + 64;
         tmpb = tmpa + 128;
-
-        r = t + 128;
-    }
-#else
-#endif
-
-    if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         r = a;
-        qi = dq = dp;
-#endif
+
         sp_4096_from_bin(a, 128, in, inLen);
         sp_4096_from_mp(p, 64, pm);
         sp_4096_from_mp(q, 64, qm);
@@ -14519,19 +14417,16 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 512;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 64 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
-    }
-#else
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p,    0, sizeof(p));
-    XMEMSET(q,    0, sizeof(q));
-    XMEMSET(dp,   0, sizeof(dp));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
 #endif
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+    {
+        ForceZero(a, sizeof(sp_digit) * 64 * 11);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -15467,12 +15362,12 @@ static int sp_4096_mod_exp_2_128(sp_digit* r, const sp_digit* e, int bits,
         const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[385];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -15485,18 +15380,13 @@ static int sp_4096_mod_exp_2_128(sp_digit* r, const sp_digit* e, int bits,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 385, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp = td + 256;
-#else
-        tmp = &td[256];
-#endif
 
         sp_4096_mont_setup(m, &mp);
         sp_4096_mont_norm_128(norm, m);
@@ -15567,9 +15457,8 @@ static int sp_4096_mod_exp_2_128(sp_digit* r, const sp_digit* e, int bits,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -16161,64 +16050,6 @@ SP_NOINLINE static sp_digit sp_256_sub_8(sp_digit* r, const sp_digit* a,
 }
 
 #endif /* WOLFSSL_SP_SMALL */
-/* Create a new point.
- *
- * heap  [in]   Buffer to allocate dynamic memory from.
- * sp    [in]   Data for point - only if not allocating.
- * p     [out]  New point.
- * returns MEMORY_E when dynamic memory allocation fails and 0 otherwise.
- */
-static int sp_256_point_new_ex_8(void* heap, sp_point_256* sp,
-    sp_point_256** p)
-{
-    int ret = MP_OKAY;
-    (void)heap;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    (void)sp;
-    *p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap, DYNAMIC_TYPE_ECC);
-#else
-    *p = sp;
-#endif
-    if (*p == NULL) {
-        ret = MEMORY_E;
-    }
-    return ret;
-}
-
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* Allocate memory for point and return error. */
-#define sp_256_point_new_8(heap, sp, p) sp_256_point_new_ex_8((heap), NULL, &(p))
-#else
-/* Set pointer to data and return no error. */
-#define sp_256_point_new_8(heap, sp, p) sp_256_point_new_ex_8((heap), &(sp), &(p))
-#endif
-
-
-/* Free the point.
- *
- * p      [in,out]  Point to free.
- * clear  [in]      Indicates whether to zeroize point.
- * heap   [in]      Buffer from which dynamic memory was allocate from.
- */
-static void sp_256_point_free_8(sp_point_256* p, int clear, void* heap)
-{
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* If valid pointer then clear point data if requested and free data. */
-    if (p != NULL) {
-        if (clear != 0) {
-            XMEMSET(p, 0, sizeof(*p));
-        }
-        XFREE(p, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-/* Clear point data if requested. */
-    if ((p != NULL) && (clear != 0)) {
-        XMEMSET(p, 0, sizeof(*p));
-    }
-#endif
-    (void)heap;
-}
-
 /* Multiply a number by Montogmery normalizer mod modulus (prime).
  *
  * r  The resulting Montgomery form number.
@@ -18034,56 +17865,55 @@ static void sp_256_get_point_16_8(sp_point_256* r, const sp_point_256* table,
 static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, const sp_digit* k,
         int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td[16];
-    sp_point_256 rtd;
-    sp_digit tmpd[2 * 8 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_256 t[16];
+    sp_digit tmp[2 * 8 * 5];
+#endif
+    sp_point_256* rt = NULL;
 #ifndef WC_NO_CACHE_RESISTANT
-    sp_point_256 pd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* p = NULL;
+#else
+    sp_point_256 p[1];
 #endif
-#endif
-    sp_point_256* t;
-    sp_point_256* rt;
-#ifndef WC_NO_CACHE_RESISTANT
-    sp_point_256* p;
-#endif
-    sp_digit* tmp;
+#endif /* !WC_NO_CACHE_RESISTANT */
     sp_digit n;
     int i;
     int c;
     int y;
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_256_point_new_8(heap, rtd, rt);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-#ifndef WC_NO_CACHE_RESISTANT
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 17, heap, DYNAMIC_TYPE_ECC);
-#else
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 16, heap, DYNAMIC_TYPE_ECC);
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 16,
+        heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    #ifndef WC_NO_CACHE_RESISTANT
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256),
+            heap, DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
+    #endif
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
+                                DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
-#ifndef WC_NO_CACHE_RESISTANT
-    #if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        p = t + 16;
-    #else
-        p = &pd;
-    #endif
-#endif
+        rt = t + 16;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -18171,20 +18001,35 @@ static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, cons
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 8 * 5);
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_256) * 16);
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmpd, sizeof(tmpd));
-    ForceZero(td, sizeof(td));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
-    sp_256_point_free_8(rt, 1, heap);
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 8 * 5);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#ifndef WC_NO_CACHE_RESISTANT
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (p != NULL)
+    #endif
+        {
+            ForceZero(p, sizeof(sp_point_256));
+        #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+            XFREE(p, heap, DYNAMIC_TYPE_ECC);
+        #endif
+        }
+#endif /* !WC_NO_CACHE_RESISTANT */
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_256) * 17);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -18408,29 +18253,30 @@ static void sp_256_proj_point_add_qz1_8(sp_point_256* r, const sp_point_256* p,
 static int sp_256_gen_stripe_table_8(const sp_point_256* a,
         sp_table_entry_256* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td;
-    sp_point_256 s1d;
-    sp_point_256 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+#else
+    sp_point_256 t[3];
 #endif
-    sp_point_256* t;
     sp_point_256* s1 = NULL;
     sp_point_256* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_256_point_new_8(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_256_mod_mul_norm_8(t->x, a->x, p256_mod);
     }
     if (err == MP_OKAY) {
@@ -18475,9 +18321,10 @@ static int sp_256_gen_stripe_table_8(const sp_point_256* a,
         }
     }
 
-    sp_256_point_free_8(s2, 0, heap);
-    sp_256_point_free_8(s1, 0, heap);
-    sp_256_point_free_8( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -18553,19 +18400,19 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
         const sp_table_entry_256* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit td[2 * 8 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_256 rt[2];
+    sp_digit t[2 * 8 * 5];
 #endif
-    sp_point_256* rt;
     sp_point_256* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -18573,21 +18420,22 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
     (void)heap;
 
 
-    err = sp_256_point_new_8(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p256_norm_mod, sizeof(p256_norm_mod));
         XMEMCPY(rt->z, p256_norm_mod, sizeof(p256_norm_mod));
 
@@ -18638,13 +18486,12 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p, 0, heap);
-    sp_256_point_free_8(rt, 0, heap);
 
     return err;
 }
@@ -18810,29 +18657,30 @@ static int sp_256_ecc_mulmod_8(sp_point_256* r, const sp_point_256* g, const sp_
 static int sp_256_gen_stripe_table_8(const sp_point_256* a,
         sp_table_entry_256* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td;
-    sp_point_256 s1d;
-    sp_point_256 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+#else
+    sp_point_256 t[3];
 #endif
-    sp_point_256* t;
     sp_point_256* s1 = NULL;
     sp_point_256* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_256_point_new_8(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_256_mod_mul_norm_8(t->x, a->x, p256_mod);
     }
     if (err == MP_OKAY) {
@@ -18877,9 +18725,10 @@ static int sp_256_gen_stripe_table_8(const sp_point_256* a,
         }
     }
 
-    sp_256_point_free_8(s2, 0, heap);
-    sp_256_point_free_8(s1, 0, heap);
-    sp_256_point_free_8( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -18955,19 +18804,19 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
         const sp_table_entry_256* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit td[2 * 8 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_256 rt[2];
+    sp_digit t[2 * 8 * 5];
 #endif
-    sp_point_256* rt;
     sp_point_256* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -18975,21 +18824,22 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
     (void)heap;
 
 
-    err = sp_256_point_new_8(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p256_norm_mod, sizeof(p256_norm_mod));
         XMEMCPY(rt->z, p256_norm_mod, sizeof(p256_norm_mod));
 
@@ -19040,13 +18890,12 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p, 0, heap);
-    sp_256_point_free_8(rt, 0, heap);
 
     return err;
 }
@@ -19210,25 +19059,28 @@ static int sp_256_ecc_mulmod_8(sp_point_256* r, const sp_point_256* g, const sp_
 int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[8];
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[1];
+    sp_digit k[8];
+#endif
     int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(k, 8, km);
         sp_256_point_from_ecc_point_8(point, gm);
@@ -19239,12 +19091,12 @@ int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_256_point_to_ecc_point_8(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -19264,37 +19116,35 @@ int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
 int sp_ecc_mulmod_add_256(const mp_int* km, const ecc_point* gm,
     const ecc_point* am, int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_point_256 a;
-    sp_digit kd[8];
-    sp_digit t[8 * 2 * 5];
-#endif
-    sp_point_256* point;
-    sp_point_256* addP = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;    
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[2];
+    sp_digit k[8 + 8 * 2 * 5];
+#endif
+    sp_point_256* addP = NULL;
     sp_digit* tmp = NULL;
     int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (8 + 8 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (8 + 8 * 2 * 5), heap,
+            DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 8;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 8;
+
         sp_256_from_mp(k, 8, km);
         sp_256_point_from_ecc_point_8(point, gm);
         sp_256_point_from_ecc_point_8(addP, am);
@@ -19321,13 +19171,12 @@ int sp_ecc_mulmod_add_256(const mp_int* km, const ecc_point* gm,
         err = sp_256_point_to_ecc_point_8(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(addP, 0, heap);
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -20761,26 +20610,28 @@ static int sp_256_ecc_mulmod_base_8(sp_point_256* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[8];
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256  point[1];
+    sp_digit k[8];
+#endif
     int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(k, 8, km);
 
@@ -20790,12 +20641,12 @@ int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_256_point_to_ecc_point_8(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -20814,37 +20665,35 @@ int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_point_256 a;
-    sp_digit kd[8];
-    sp_digit t[8 * 2 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_256 point[2];
+    sp_digit k[8 + 8 * 2 * 5];
 #endif
-    sp_point_256* point;
     sp_point_256* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (8 + 8 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (8 + 8 * 2 * 5),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 8;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 8;
+
         sp_256_from_mp(k, 8, km);
         sp_256_point_from_ecc_point_8(addP, am);
     }
@@ -20870,13 +20719,12 @@ int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
         err = sp_256_point_to_ecc_point_8(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(addP, 0, heap);
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -21007,41 +20855,46 @@ static int sp_256_ecc_gen_k_8(WC_RNG* rng, sp_digit* k)
  */
 int sp_ecc_make_key_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[8];
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_point_256 inf;
-#endif
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    sp_point_256 point[2];
+    #else
+    sp_point_256 point[1];
+    #endif
+    sp_digit k[8];
+#endif
 #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
     sp_point_256* infinity = NULL;
 #endif
-    int err;
+    int err = MP_OKAY;
+    
 
     (void)heap;
 
-    err = sp_256_point_new_8(heap, p, point);
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, inf, infinity);
-    }
-#endif
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap, DYNAMIC_TYPE_ECC);
+    #else
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap, DYNAMIC_TYPE_ECC);    
+    #endif
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+        infinity = point + 1;
+    #endif
+
         err = sp_256_ecc_gen_k_8(rng, k);
     }
     if (err == MP_OKAY) {
@@ -21066,15 +20919,14 @@ int sp_ecc_make_key_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
         err = sp_256_point_to_ecc_point_8(point, pub);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL) {
+        /* point is not sensitive, so no need to zeroize */
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
     }
 #endif
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_256_point_free_8(infinity, 1, heap);
-#endif
-    sp_256_point_free_8(point, 1, heap);
 
     return err;
 }
@@ -21135,30 +20987,32 @@ static void sp_256_to_bin(sp_digit* r, byte* a)
 int sp_ecc_secret_gen_256(const mp_int* priv, const ecc_point* pub, byte* out,
                           word32* outLen, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[8];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[1];
+    sp_digit k[8];
+#endif
     int err = MP_OKAY;
 
     if (*outLen < 32U) {
         err = BUFFER_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, p, point);
+        point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
@@ -21171,12 +21025,12 @@ int sp_ecc_secret_gen_256(const mp_int* priv, const ecc_point* pub, byte* out,
         *outLen = 32;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -21996,22 +21850,17 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
 int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
     const mp_int* priv, mp_int* rm, mp_int* sm, mp_int* km, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit ed[2*8];
-    sp_digit xd[2*8];
-    sp_digit kd[2*8];
-    sp_digit rd[2*8];
-    sp_digit td[3 * 2*8];
-    sp_point_256 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* e = NULL;
+    sp_point_256* point = NULL;
+#else
+    sp_digit e[7 * 2 * 8];
+    sp_point_256 point[1];
+#endif
     sp_digit* x = NULL;
     sp_digit* k = NULL;
     sp_digit* r = NULL;
     sp_digit* tmp = NULL;
-    sp_point_256* point = NULL;
     sp_digit* s = NULL;
     int32_t c;
     int err = MP_OKAY;
@@ -22019,31 +21868,26 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
 
     (void)heap;
 
-    err = sp_256_point_new_8(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (point == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        e = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 8, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (e == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        e = d + 0 * 8;
-        x = d + 2 * 8;
-        k = d + 4 * 8;
-        r = d + 6 * 8;
-        tmp = d + 8 * 8;
-#else
-        e = ed;
-        x = xd;
-        k = kd;
-        r = rd;
-        tmp = td;
-#endif
+        x = e + 2 * 8;
+        k = e + 4 * 8;
+        r = e + 6 * 8;
+        tmp = e + 8 * 8;
         s = e;
 
         if (hashLen > 32U) {
@@ -22098,19 +21942,24 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
         err = sp_256_to_mp(s, sm);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 8 * 8);
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 2U * 8U);
-    XMEMSET(x, 0, sizeof(sp_digit) * 2U * 8U);
-    XMEMSET(k, 0, sizeof(sp_digit) * 2U * 8U);
-    XMEMSET(r, 0, sizeof(sp_digit) * 2U * 8U);
-    XMEMSET(tmp, 0, sizeof(sp_digit) * 3U * 2U * 8U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (e != NULL)
 #endif
-    sp_256_point_free_8(point, 1, heap);
+    {
+        ForceZero(e, sizeof(sp_digit) * 7 * 2 * 8);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(e, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (point != NULL)
+#endif
+    {
+        ForceZero(point, sizeof(sp_point_256));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -22979,52 +22828,41 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
     const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
     int* res, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit u1d[2*8];
-    sp_digit u2d[2*8];
-    sp_digit sd[2*8];
-    sp_digit tmpd[2*8 * 5];
-    sp_point_256 p1d;
-    sp_point_256 p2d;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* u1 = NULL;
+    sp_point_256* p1 = NULL;
+#else
+    sp_digit  u1[16 * 8];
+    sp_point_256 p1[2];
+#endif
     sp_digit* u2 = NULL;
     sp_digit* s = NULL;
     sp_digit* tmp = NULL;
-    sp_point_256* p1;
     sp_point_256* p2 = NULL;
     sp_digit carry;
     int32_t c = 0;
-    int err;
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p1d, p1);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, p2d, p2);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        p1 = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (p1 == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        u1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 8, heap,
+                                                              DYNAMIC_TYPE_ECC);
+        if (u1 == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        u1  = d + 0 * 8;
-        u2  = d + 2 * 8;
-        s   = d + 4 * 8;
-        tmp = d + 6 * 8;
-#else
-        u1 = u1d;
-        u2 = u2d;
-        s  = sd;
-        tmp = tmpd;
-#endif
+        u2  = u1 + 2 * 8;
+        s   = u1 + 4 * 8;
+        tmp = u1 + 6 * 8;
+        p2 = p1 + 1;
 
         if (hashLen > 32U) {
             hashLen = 32U;
@@ -23075,12 +22913,12 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL)
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (u1 != NULL)
+        XFREE(u1, heap, DYNAMIC_TYPE_ECC);
+    if (p1 != NULL)
+        XFREE(p1, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p1, 0, heap);
-    sp_256_point_free_8(p2, 0, heap);
 
     return err;
 }
@@ -23097,32 +22935,23 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
 static int sp_256_ecc_is_point_8(const sp_point_256* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*8];
-    sp_digit t2d[2*8];
+    sp_digit t1[8 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 8;
-        t2 = d + 2 * 8;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 8;
 
         sp_256_sqr_8(t1, point->y);
         (void)sp_256_mod_8(t1, t1, p256_mod);
@@ -23142,10 +22971,9 @@ static int sp_256_ecc_is_point_8(const sp_point_256* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -23160,14 +22988,21 @@ static int sp_256_ecc_is_point_8(const sp_point_256* point,
  */
 int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* pub = NULL;
+#else
+    sp_point_256 pub[1];
 #endif
-    sp_point_256* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_8(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(pub->x, 8, pX);
         sp_256_from_mp(pub->y, 8, pY);
@@ -23176,7 +23011,10 @@ int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
         err = sp_256_ecc_is_point_8(pub, NULL);
     }
 
-    sp_256_point_free_8(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -23195,44 +23033,44 @@ int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_256(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[8];
-    sp_point_256 pubd;
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_256* pub;
-    sp_point_256* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_256_point_new_8(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_256* pub = NULL;
+#else
+    sp_digit priv[8];
+    sp_point_256 pub[2];
 #endif
+    sp_point_256* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+    if (((mp_count_bits(pX) > 256) ||
         (mp_count_bits(pY) > 256) ||
         ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_256_from_mp(pub->x, 8, pX);
         sp_256_from_mp(pub->y, 8, pY);
@@ -23282,13 +23120,12 @@ int sp_ecc_check_key_256(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_256_point_free_8(p, 0, heap);
-    sp_256_point_free_8(pub, 0, heap);
 
     return err;
 }
@@ -23312,33 +23149,35 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* qX, mp_int* qY, mp_int* qZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 8 * 5];
-    sp_point_256 pd;
-    sp_point_256 qd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 8 * 5];
+    sp_point_256 p[2];
+#endif
     sp_point_256* q = NULL;
     int err;
 
-    err = sp_256_point_new_8(NULL, pd, p);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(NULL, qd, q);
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, NULL,
-                                                              DYNAMIC_TYPE_ECC);
+                                 DYNAMIC_TYPE_ECC);
         if (tmp == NULL) {
             err = MEMORY_E;
         }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
+        q = p + 1;
+
         sp_256_from_mp(p->x, 8, pX);
         sp_256_from_mp(p->y, 8, pY);
         sp_256_from_mp(p->z, 8, pZ);
@@ -23359,13 +23198,12 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_256_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(q, 0, NULL);
-    sp_256_point_free_8(p, 0, NULL);
 
     return err;
 }
@@ -23384,25 +23222,28 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
 int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 8 * 2];
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
-    int err;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 8 * 2];
+    sp_point_256 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_8(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 2, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
@@ -23423,12 +23264,12 @@ int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_256_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p, 0, NULL);
 
     return err;
 }
@@ -23443,25 +23284,29 @@ int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
  */
 int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 8 * 4];
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
-    int err;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 8 * 4];
+    sp_point_256 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_8(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 4, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
     if (err == MP_OKAY) {
         sp_256_from_mp(p->x, 8, pX);
@@ -23481,12 +23326,12 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
         err = sp_256_to_mp(p->z, pZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p, 0, NULL);
 
     return err;
 }
@@ -23499,31 +23344,23 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
  */
 static int sp_256_mont_sqrt_8(sp_digit* y)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2 * 8];
-    sp_digit t2d[2 * 8];
+    sp_digit t1[4 * 8];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL) {
         err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 8;
-        t2 = d + 2 * 8;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 8;
 
         {
             /* t2 = y ^ 0x2 */
@@ -23558,10 +23395,9 @@ static int sp_256_mont_sqrt_8(sp_digit* y)
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -23577,31 +23413,22 @@ static int sp_256_mont_sqrt_8(sp_digit* y)
  */
 int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
-#else
-    sp_digit xd[2 * 8];
-    sp_digit yd[2 * 8];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* x = NULL;
+#else
+    sp_digit x[4 * 8];
+#endif
     sp_digit* y = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    x = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
+    if (x == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        x = d + 0 * 8;
-        y = d + 2 * 8;
-#else
-        x = xd;
-        y = yd;
-#endif
+        y = x + 2 * 8;
 
         sp_256_from_mp(x, 8, xm);
         err = sp_256_mod_mul_norm_8(x, x, p256_mod);
@@ -23634,10 +23461,9 @@ int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
         err = sp_256_to_mp(y, ym);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (x != NULL)
+        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -24189,64 +24015,6 @@ SP_NOINLINE static sp_digit sp_384_sub_12(sp_digit* r, const sp_digit* a,
 }
 
 #endif /* WOLFSSL_SP_SMALL */
-/* Create a new point.
- *
- * heap  [in]   Buffer to allocate dynamic memory from.
- * sp    [in]   Data for point - only if not allocating.
- * p     [out]  New point.
- * returns MEMORY_E when dynamic memory allocation fails and 0 otherwise.
- */
-static int sp_384_point_new_ex_12(void* heap, sp_point_384* sp,
-    sp_point_384** p)
-{
-    int ret = MP_OKAY;
-    (void)heap;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    (void)sp;
-    *p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap, DYNAMIC_TYPE_ECC);
-#else
-    *p = sp;
-#endif
-    if (*p == NULL) {
-        ret = MEMORY_E;
-    }
-    return ret;
-}
-
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* Allocate memory for point and return error. */
-#define sp_384_point_new_12(heap, sp, p) sp_384_point_new_ex_12((heap), NULL, &(p))
-#else
-/* Set pointer to data and return no error. */
-#define sp_384_point_new_12(heap, sp, p) sp_384_point_new_ex_12((heap), &(sp), &(p))
-#endif
-
-
-/* Free the point.
- *
- * p      [in,out]  Point to free.
- * clear  [in]      Indicates whether to zeroize point.
- * heap   [in]      Buffer from which dynamic memory was allocate from.
- */
-static void sp_384_point_free_12(sp_point_384* p, int clear, void* heap)
-{
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* If valid pointer then clear point data if requested and free data. */
-    if (p != NULL) {
-        if (clear != 0) {
-            XMEMSET(p, 0, sizeof(*p));
-        }
-        XFREE(p, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-/* Clear point data if requested. */
-    if ((p != NULL) && (clear != 0)) {
-        XMEMSET(p, 0, sizeof(*p));
-    }
-#endif
-    (void)heap;
-}
-
 /* Multiply a number by Montogmery normalizer mod modulus (prime).
  *
  * r  The resulting Montgomery form number.
@@ -24256,8 +24024,8 @@ static void sp_384_point_free_12(sp_point_384* p, int clear, void* heap)
  */
 static int sp_384_mod_mul_norm_12(sp_digit* r, const sp_digit* a, const sp_digit* m)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    int64_t* t;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    int64_t* t = NULL;
 #else
     int64_t t[12];
 #endif
@@ -24266,7 +24034,7 @@ static int sp_384_mod_mul_norm_12(sp_digit* r, const sp_digit* a, const sp_digit
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     t = (int64_t*)XMALLOC(sizeof(int64_t) * 12, NULL, DYNAMIC_TYPE_ECC);
     if (t == NULL) {
         err = MEMORY_E;
@@ -24341,7 +24109,7 @@ static int sp_384_mod_mul_norm_12(sp_digit* r, const sp_digit* a, const sp_digit
         r[11] = t[11];
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (t != NULL)
         XFREE(t, NULL, DYNAMIC_TYPE_ECC);
 #endif
@@ -25756,56 +25524,55 @@ static void sp_384_get_point_16_12(sp_point_384* r, const sp_point_384* table,
 static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, const sp_digit* k,
         int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td[16];
-    sp_point_384 rtd;
-    sp_digit tmpd[2 * 12 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_384 t[16];
+    sp_digit tmp[2 * 12 * 6];
+#endif
+    sp_point_384* rt = NULL;
 #ifndef WC_NO_CACHE_RESISTANT
-    sp_point_384 pd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* p = NULL;
+#else
+    sp_point_384 p[1];
 #endif
-#endif
-    sp_point_384* t;
-    sp_point_384* rt;
-#ifndef WC_NO_CACHE_RESISTANT
-    sp_point_384* p;
-#endif
-    sp_digit* tmp;
+#endif /* !WC_NO_CACHE_RESISTANT */
     sp_digit n;
     int i;
     int c;
     int y;
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_384_point_new_12(heap, rtd, rt);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-#ifndef WC_NO_CACHE_RESISTANT
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 17, heap, DYNAMIC_TYPE_ECC);
-#else
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 16, heap, DYNAMIC_TYPE_ECC);
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 16,
+        heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    #ifndef WC_NO_CACHE_RESISTANT
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384),
+            heap, DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
+    #endif
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
+                                DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
-#ifndef WC_NO_CACHE_RESISTANT
-    #if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        p = t + 16;
-    #else
-        p = &pd;
-    #endif
-#endif
+        rt = t + 16;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -25893,20 +25660,35 @@ static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, con
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 12 * 6);
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_384) * 16);
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmpd, sizeof(tmpd));
-    ForceZero(td, sizeof(td));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
-    sp_384_point_free_12(rt, 1, heap);
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 12 * 6);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#ifndef WC_NO_CACHE_RESISTANT
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (p != NULL)
+    #endif
+        {
+            ForceZero(p, sizeof(sp_point_384));
+        #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+            XFREE(p, heap, DYNAMIC_TYPE_ECC);
+        #endif
+        }
+#endif /* !WC_NO_CACHE_RESISTANT */
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_384) * 17);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -26130,29 +25912,30 @@ static void sp_384_proj_point_add_qz1_12(sp_point_384* r, const sp_point_384* p,
 static int sp_384_gen_stripe_table_12(const sp_point_384* a,
         sp_table_entry_384* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td;
-    sp_point_384 s1d;
-    sp_point_384 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+#else
+    sp_point_384 t[3];
 #endif
-    sp_point_384* t;
     sp_point_384* s1 = NULL;
     sp_point_384* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_384_point_new_12(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_384_mod_mul_norm_12(t->x, a->x, p384_mod);
     }
     if (err == MP_OKAY) {
@@ -26197,9 +25980,10 @@ static int sp_384_gen_stripe_table_12(const sp_point_384* a,
         }
     }
 
-    sp_384_point_free_12(s2, 0, heap);
-    sp_384_point_free_12(s1, 0, heap);
-    sp_384_point_free_12( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -26291,19 +26075,19 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
         const sp_table_entry_384* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit td[2 * 12 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_384 rt[2];
+    sp_digit t[2 * 12 * 6];
 #endif
-    sp_point_384* rt;
     sp_point_384* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -26311,21 +26095,22 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
     (void)heap;
 
 
-    err = sp_384_point_new_12(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p384_norm_mod, sizeof(p384_norm_mod));
         XMEMCPY(rt->z, p384_norm_mod, sizeof(p384_norm_mod));
 
@@ -26376,13 +26161,12 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p, 0, heap);
-    sp_384_point_free_12(rt, 0, heap);
 
     return err;
 }
@@ -26548,29 +26332,30 @@ static int sp_384_ecc_mulmod_12(sp_point_384* r, const sp_point_384* g, const sp
 static int sp_384_gen_stripe_table_12(const sp_point_384* a,
         sp_table_entry_384* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td;
-    sp_point_384 s1d;
-    sp_point_384 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+#else
+    sp_point_384 t[3];
 #endif
-    sp_point_384* t;
     sp_point_384* s1 = NULL;
     sp_point_384* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_384_point_new_12(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_384_mod_mul_norm_12(t->x, a->x, p384_mod);
     }
     if (err == MP_OKAY) {
@@ -26615,9 +26400,10 @@ static int sp_384_gen_stripe_table_12(const sp_point_384* a,
         }
     }
 
-    sp_384_point_free_12(s2, 0, heap);
-    sp_384_point_free_12(s1, 0, heap);
-    sp_384_point_free_12( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -26709,19 +26495,19 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
         const sp_table_entry_384* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit td[2 * 12 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_384 rt[2];
+    sp_digit t[2 * 12 * 6];
 #endif
-    sp_point_384* rt;
     sp_point_384* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -26729,21 +26515,22 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
     (void)heap;
 
 
-    err = sp_384_point_new_12(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p384_norm_mod, sizeof(p384_norm_mod));
         XMEMCPY(rt->z, p384_norm_mod, sizeof(p384_norm_mod));
 
@@ -26794,13 +26581,12 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p, 0, heap);
-    sp_384_point_free_12(rt, 0, heap);
 
     return err;
 }
@@ -26964,25 +26750,28 @@ static int sp_384_ecc_mulmod_12(sp_point_384* r, const sp_point_384* g, const sp
 int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[12];
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[1];
+    sp_digit k[12];
+#endif
     int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(k, 12, km);
         sp_384_point_from_ecc_point_12(point, gm);
@@ -26993,12 +26782,12 @@ int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_384_point_to_ecc_point_12(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -27018,37 +26807,35 @@ int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
 int sp_ecc_mulmod_add_384(const mp_int* km, const ecc_point* gm,
     const ecc_point* am, int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_point_384 a;
-    sp_digit kd[12];
-    sp_digit t[12 * 2 * 6];
-#endif
-    sp_point_384* point;
-    sp_point_384* addP = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;    
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[2];
+    sp_digit k[12 + 12 * 2 * 6];
+#endif
+    sp_point_384* addP = NULL;
     sp_digit* tmp = NULL;
     int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (12 + 12 * 2 * 6), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (12 + 12 * 2 * 6), heap,
+            DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 12;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 12;
+
         sp_384_from_mp(k, 12, km);
         sp_384_point_from_ecc_point_12(point, gm);
         sp_384_point_from_ecc_point_12(addP, am);
@@ -27075,13 +26862,12 @@ int sp_ecc_mulmod_add_384(const mp_int* km, const ecc_point* gm,
         err = sp_384_point_to_ecc_point_12(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(addP, 0, heap);
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -28515,26 +28301,28 @@ static int sp_384_ecc_mulmod_base_12(sp_point_384* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[12];
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384  point[1];
+    sp_digit k[12];
+#endif
     int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(k, 12, km);
 
@@ -28544,12 +28332,12 @@ int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_384_point_to_ecc_point_12(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -28568,37 +28356,35 @@ int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_point_384 a;
-    sp_digit kd[12];
-    sp_digit t[12 * 2 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_384 point[2];
+    sp_digit k[12 + 12 * 2 * 6];
 #endif
-    sp_point_384* point;
     sp_point_384* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (12 + 12 * 2 * 6), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (12 + 12 * 2 * 6),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 12;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 12;
+
         sp_384_from_mp(k, 12, km);
         sp_384_point_from_ecc_point_12(addP, am);
     }
@@ -28624,13 +28410,12 @@ int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
         err = sp_384_point_to_ecc_point_12(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(addP, 0, heap);
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -28774,41 +28559,46 @@ static int sp_384_ecc_gen_k_12(WC_RNG* rng, sp_digit* k)
  */
 int sp_ecc_make_key_384(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[12];
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_point_384 inf;
-#endif
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    sp_point_384 point[2];
+    #else
+    sp_point_384 point[1];
+    #endif
+    sp_digit k[12];
+#endif
 #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
     sp_point_384* infinity = NULL;
 #endif
-    int err;
+    int err = MP_OKAY;
+    
 
     (void)heap;
 
-    err = sp_384_point_new_12(heap, p, point);
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, inf, infinity);
-    }
-#endif
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap, DYNAMIC_TYPE_ECC);
+    #else
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap, DYNAMIC_TYPE_ECC);    
+    #endif
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+        infinity = point + 1;
+    #endif
+
         err = sp_384_ecc_gen_k_12(rng, k);
     }
     if (err == MP_OKAY) {
@@ -28833,15 +28623,14 @@ int sp_ecc_make_key_384(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
         err = sp_384_point_to_ecc_point_12(point, pub);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL) {
+        /* point is not sensitive, so no need to zeroize */
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
     }
 #endif
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_384_point_free_12(infinity, 1, heap);
-#endif
-    sp_384_point_free_12(point, 1, heap);
 
     return err;
 }
@@ -28902,30 +28691,32 @@ static void sp_384_to_bin(sp_digit* r, byte* a)
 int sp_ecc_secret_gen_384(const mp_int* priv, const ecc_point* pub, byte* out,
                           word32* outLen, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[12];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[1];
+    sp_digit k[12];
+#endif
     int err = MP_OKAY;
 
     if (*outLen < 48U) {
         err = BUFFER_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, p, point);
+        point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
@@ -28938,12 +28729,12 @@ int sp_ecc_secret_gen_384(const mp_int* priv, const ecc_point* pub, byte* out,
         *outLen = 48;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -29754,22 +29545,17 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
 int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
     const mp_int* priv, mp_int* rm, mp_int* sm, mp_int* km, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit ed[2*12];
-    sp_digit xd[2*12];
-    sp_digit kd[2*12];
-    sp_digit rd[2*12];
-    sp_digit td[3 * 2*12];
-    sp_point_384 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* e = NULL;
+    sp_point_384* point = NULL;
+#else
+    sp_digit e[7 * 2 * 12];
+    sp_point_384 point[1];
+#endif
     sp_digit* x = NULL;
     sp_digit* k = NULL;
     sp_digit* r = NULL;
     sp_digit* tmp = NULL;
-    sp_point_384* point = NULL;
     sp_digit* s = NULL;
     int32_t c;
     int err = MP_OKAY;
@@ -29777,31 +29563,26 @@ int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
 
     (void)heap;
 
-    err = sp_384_point_new_12(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (point == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        e = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 12, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (e == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        e = d + 0 * 12;
-        x = d + 2 * 12;
-        k = d + 4 * 12;
-        r = d + 6 * 12;
-        tmp = d + 8 * 12;
-#else
-        e = ed;
-        x = xd;
-        k = kd;
-        r = rd;
-        tmp = td;
-#endif
+        x = e + 2 * 12;
+        k = e + 4 * 12;
+        r = e + 6 * 12;
+        tmp = e + 8 * 12;
         s = e;
 
         if (hashLen > 48U) {
@@ -29856,19 +29637,24 @@ int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
         err = sp_384_to_mp(s, sm);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 8 * 12);
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 2U * 12U);
-    XMEMSET(x, 0, sizeof(sp_digit) * 2U * 12U);
-    XMEMSET(k, 0, sizeof(sp_digit) * 2U * 12U);
-    XMEMSET(r, 0, sizeof(sp_digit) * 2U * 12U);
-    XMEMSET(tmp, 0, sizeof(sp_digit) * 3U * 2U * 12U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (e != NULL)
 #endif
-    sp_384_point_free_12(point, 1, heap);
+    {
+        ForceZero(e, sizeof(sp_digit) * 7 * 2 * 12);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(e, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (point != NULL)
+#endif
+    {
+        ForceZero(point, sizeof(sp_point_384));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -30948,52 +30734,41 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
     const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
     int* res, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit u1d[2*12];
-    sp_digit u2d[2*12];
-    sp_digit sd[2*12];
-    sp_digit tmpd[2*12 * 5];
-    sp_point_384 p1d;
-    sp_point_384 p2d;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* u1 = NULL;
+    sp_point_384* p1 = NULL;
+#else
+    sp_digit  u1[16 * 12];
+    sp_point_384 p1[2];
+#endif
     sp_digit* u2 = NULL;
     sp_digit* s = NULL;
     sp_digit* tmp = NULL;
-    sp_point_384* p1;
     sp_point_384* p2 = NULL;
     sp_digit carry;
     int32_t c = 0;
-    int err;
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p1d, p1);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, p2d, p2);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        p1 = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (p1 == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        u1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 12, heap,
+                                                              DYNAMIC_TYPE_ECC);
+        if (u1 == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        u1  = d + 0 * 12;
-        u2  = d + 2 * 12;
-        s   = d + 4 * 12;
-        tmp = d + 6 * 12;
-#else
-        u1 = u1d;
-        u2 = u2d;
-        s  = sd;
-        tmp = tmpd;
-#endif
+        u2  = u1 + 2 * 12;
+        s   = u1 + 4 * 12;
+        tmp = u1 + 6 * 12;
+        p2 = p1 + 1;
 
         if (hashLen > 48U) {
             hashLen = 48U;
@@ -31044,12 +30819,12 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL)
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (u1 != NULL)
+        XFREE(u1, heap, DYNAMIC_TYPE_ECC);
+    if (p1 != NULL)
+        XFREE(p1, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p1, 0, heap);
-    sp_384_point_free_12(p2, 0, heap);
 
     return err;
 }
@@ -31066,32 +30841,23 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
 static int sp_384_ecc_is_point_12(const sp_point_384* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*12];
-    sp_digit t2d[2*12];
+    sp_digit t1[12 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 12;
-        t2 = d + 2 * 12;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 12;
 
         sp_384_sqr_12(t1, point->y);
         (void)sp_384_mod_12(t1, t1, p384_mod);
@@ -31111,10 +30877,9 @@ static int sp_384_ecc_is_point_12(const sp_point_384* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -31129,14 +30894,21 @@ static int sp_384_ecc_is_point_12(const sp_point_384* point,
  */
 int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* pub = NULL;
+#else
+    sp_point_384 pub[1];
 #endif
-    sp_point_384* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_12(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(pub->x, 12, pX);
         sp_384_from_mp(pub->y, 12, pY);
@@ -31145,7 +30917,10 @@ int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
         err = sp_384_ecc_is_point_12(pub, NULL);
     }
 
-    sp_384_point_free_12(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -31164,44 +30939,44 @@ int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_384(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[12];
-    sp_point_384 pubd;
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_384* pub;
-    sp_point_384* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_384_point_new_12(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_384* pub = NULL;
+#else
+    sp_digit priv[12];
+    sp_point_384 pub[2];
 #endif
+    sp_point_384* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+    if (((mp_count_bits(pX) > 384) ||
         (mp_count_bits(pY) > 384) ||
         ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_384_from_mp(pub->x, 12, pX);
         sp_384_from_mp(pub->y, 12, pY);
@@ -31251,13 +31026,12 @@ int sp_ecc_check_key_384(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_384_point_free_12(p, 0, heap);
-    sp_384_point_free_12(pub, 0, heap);
 
     return err;
 }
@@ -31281,33 +31055,35 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* qX, mp_int* qY, mp_int* qZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 12 * 5];
-    sp_point_384 pd;
-    sp_point_384 qd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 12 * 5];
+    sp_point_384 p[2];
+#endif
     sp_point_384* q = NULL;
     int err;
 
-    err = sp_384_point_new_12(NULL, pd, p);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(NULL, qd, q);
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 5, NULL,
-                                                              DYNAMIC_TYPE_ECC);
+                                 DYNAMIC_TYPE_ECC);
         if (tmp == NULL) {
             err = MEMORY_E;
         }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
+        q = p + 1;
+
         sp_384_from_mp(p->x, 12, pX);
         sp_384_from_mp(p->y, 12, pY);
         sp_384_from_mp(p->z, 12, pZ);
@@ -31328,13 +31104,12 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_384_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(q, 0, NULL);
-    sp_384_point_free_12(p, 0, NULL);
 
     return err;
 }
@@ -31353,25 +31128,28 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
 int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 12 * 2];
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
-    int err;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 12 * 2];
+    sp_point_384 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_12(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 2, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
@@ -31392,12 +31170,12 @@ int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_384_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p, 0, NULL);
 
     return err;
 }
@@ -31412,25 +31190,29 @@ int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
  */
 int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 12 * 6];
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
-    int err;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 12 * 6];
+    sp_point_384 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_12(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
     if (err == MP_OKAY) {
         sp_384_from_mp(p->x, 12, pX);
@@ -31450,12 +31232,12 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
         err = sp_384_to_mp(p->z, pZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p, 0, NULL);
 
     return err;
 }
@@ -31468,43 +31250,28 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
  */
 static int sp_384_mont_sqrt_12(sp_digit* y)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2 * 12];
-    sp_digit t2d[2 * 12];
-    sp_digit t3d[2 * 12];
-    sp_digit t4d[2 * 12];
-    sp_digit t5d[2 * 12];
+    sp_digit t1[5 * 2 * 12];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* t3;
-    sp_digit* t4;
-    sp_digit* t5;
+    sp_digit* t2 = NULL;
+    sp_digit* t3 = NULL;
+    sp_digit* t4 = NULL;
+    sp_digit* t5 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 12, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 12, NULL, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 12;
-        t2 = d + 2 * 12;
-        t3 = d + 4 * 12;
-        t4 = d + 6 * 12;
-        t5 = d + 8 * 12;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        t3 = t3d;
-        t4 = t4d;
-        t5 = t5d;
-#endif
+        t2 = t1 + 2 * 12;
+        t3 = t1 + 4 * 12;
+        t4 = t1 + 6 * 12;
+        t5 = t1 + 8 * 12;
 
         {
             /* t2 = y ^ 0x2 */
@@ -31564,10 +31331,9 @@ static int sp_384_mont_sqrt_12(sp_digit* y)
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -31583,31 +31349,22 @@ static int sp_384_mont_sqrt_12(sp_digit* y)
  */
 int sp_ecc_uncompress_384(mp_int* xm, int odd, mp_int* ym)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
-#else
-    sp_digit xd[2 * 12];
-    sp_digit yd[2 * 12];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* x = NULL;
+#else
+    sp_digit x[4 * 12];
+#endif
     sp_digit* y = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 12, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    x = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 12, NULL, DYNAMIC_TYPE_ECC);
+    if (x == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        x = d + 0 * 12;
-        y = d + 2 * 12;
-#else
-        x = xd;
-        y = yd;
-#endif
+        y = x + 2 * 12;
 
         sp_384_from_mp(x, 12, xm);
         err = sp_384_mod_mul_norm_12(x, x, p384_mod);
@@ -31640,10 +31397,9 @@ int sp_ecc_uncompress_384(mp_int* xm, int odd, mp_int* ym)
         err = sp_384_to_mp(y, ym);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (x != NULL)
+        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -33171,6 +32927,8 @@ static int sp_1024_mod_mul_norm_32(sp_digit* r, const sp_digit* a,
     return sp_1024_mod_32(r, r, m);
 }
 
+
+#ifdef WOLFCRYPT_HAVE_SAKKE
 /* Create a new point.
  *
  * heap  [in]   Buffer to allocate dynamic memory from.
@@ -33202,8 +32960,8 @@ static int sp_1024_point_new_ex_32(void* heap, sp_point_1024* sp,
 /* Set pointer to data and return no error. */
 #define sp_1024_point_new_32(heap, sp, p) sp_1024_point_new_ex_32((heap), &(sp), &(p))
 #endif
-
-
+#endif /* WOLFCRYPT_HAVE_SAKKE */
+#ifdef WOLFCRYPT_HAVE_SAKKE
 /* Free the point.
  *
  * p      [in,out]  Point to free.
@@ -33228,6 +32986,7 @@ static void sp_1024_point_free_32(sp_point_1024* p, int clear, void* heap)
 #endif
     (void)heap;
 }
+#endif /* WOLFCRYPT_HAVE_SAKKE */
 
 /* Convert an mp_int to an array of sp_digit.
  *
@@ -36276,43 +36035,40 @@ static void sp_1024_proj_point_add_32(sp_point_1024* r,
 static int sp_1024_ecc_mulmod_fast_32(sp_point_1024* r, const sp_point_1024* g, const sp_digit* k,
         int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td[16];
-    sp_point_1024 rtd;
-    sp_digit tmpd[2 * 32 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_1024 t[16];
+    sp_digit tmp[2 * 32 * 5];
 #endif
-    sp_point_1024* t;
-    sp_point_1024* rt;
-    sp_digit* tmp;
+    sp_point_1024* rt = NULL;
     sp_digit n;
     int i;
     int c;
     int y;
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_1024_point_new_32(heap, rtd, rt);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-#ifndef WC_NO_CACHE_RESISTANT
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 17, heap, DYNAMIC_TYPE_ECC);
-#else
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 16, heap, DYNAMIC_TYPE_ECC);
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 16,
+        heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
+                                DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
+        rt = t + 16;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -36380,20 +36136,24 @@ static int sp_1024_ecc_mulmod_fast_32(sp_point_1024* r, const sp_point_1024* g, 
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 32 * 5);
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_1024) * 16);
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmpd, sizeof(tmpd));
-    ForceZero(td, sizeof(td));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
-    sp_1024_point_free_32(rt, 1, heap);
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 32 * 5);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_1024) * 17);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -36617,29 +36377,30 @@ static void sp_1024_proj_point_add_qz1_32(sp_point_1024* r, const sp_point_1024*
 static int sp_1024_gen_stripe_table_32(const sp_point_1024* a,
         sp_table_entry_1024* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td;
-    sp_point_1024 s1d;
-    sp_point_1024 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+#else
+    sp_point_1024 t[3];
 #endif
-    sp_point_1024* t;
     sp_point_1024* s1 = NULL;
     sp_point_1024* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_1024_point_new_32(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_1024_mod_mul_norm_32(t->x, a->x, p1024_mod);
     }
     if (err == MP_OKAY) {
@@ -36684,9 +36445,10 @@ static int sp_1024_gen_stripe_table_32(const sp_point_1024* a,
         }
     }
 
-    sp_1024_point_free_32(s2, 0, heap);
-    sp_1024_point_free_32(s1, 0, heap);
-    sp_1024_point_free_32( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -36712,19 +36474,19 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
         const sp_table_entry_1024* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 rtd;
-    sp_point_1024 pd;
-    sp_digit td[2 * 32 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 rt[2];
+    sp_digit t[2 * 32 * 5];
 #endif
-    sp_point_1024* rt;
     sp_point_1024* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -36732,21 +36494,22 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
     (void)heap;
 
 
-    err = sp_1024_point_new_32(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p1024_norm_mod, sizeof(p1024_norm_mod));
         XMEMCPY(rt->z, p1024_norm_mod, sizeof(p1024_norm_mod));
 
@@ -36782,13 +36545,12 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(p, 0, heap);
-    sp_1024_point_free_32(rt, 0, heap);
 
     return err;
 }
@@ -36954,29 +36716,30 @@ static int sp_1024_ecc_mulmod_32(sp_point_1024* r, const sp_point_1024* g, const
 static int sp_1024_gen_stripe_table_32(const sp_point_1024* a,
         sp_table_entry_1024* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td;
-    sp_point_1024 s1d;
-    sp_point_1024 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+#else
+    sp_point_1024 t[3];
 #endif
-    sp_point_1024* t;
     sp_point_1024* s1 = NULL;
     sp_point_1024* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_1024_point_new_32(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_1024_mod_mul_norm_32(t->x, a->x, p1024_mod);
     }
     if (err == MP_OKAY) {
@@ -37021,9 +36784,10 @@ static int sp_1024_gen_stripe_table_32(const sp_point_1024* a,
         }
     }
 
-    sp_1024_point_free_32(s2, 0, heap);
-    sp_1024_point_free_32(s1, 0, heap);
-    sp_1024_point_free_32( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -37049,19 +36813,19 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
         const sp_table_entry_1024* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 rtd;
-    sp_point_1024 pd;
-    sp_digit td[2 * 32 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 rt[2];
+    sp_digit t[2 * 32 * 5];
 #endif
-    sp_point_1024* rt;
     sp_point_1024* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -37069,21 +36833,22 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
     (void)heap;
 
 
-    err = sp_1024_point_new_32(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p1024_norm_mod, sizeof(p1024_norm_mod));
         XMEMCPY(rt->z, p1024_norm_mod, sizeof(p1024_norm_mod));
 
@@ -37119,13 +36884,12 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(p, 0, heap);
-    sp_1024_point_free_32(rt, 0, heap);
 
     return err;
 }
@@ -37289,25 +37053,28 @@ static int sp_1024_ecc_mulmod_32(sp_point_1024* r, const sp_point_1024* g, const
 int sp_ecc_mulmod_1024(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[32];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024 point[1];
+    sp_digit k[32];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 32, km);
         sp_1024_point_from_ecc_point_32(point, gm);
@@ -37318,12 +37085,12 @@ int sp_ecc_mulmod_1024(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_1024_point_to_ecc_point_32(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(point, 0, heap);
 
     return err;
 }
@@ -40917,26 +40684,28 @@ static int sp_1024_ecc_mulmod_base_32(sp_point_1024* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[32];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024  point[1];
+    sp_digit k[32];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 32, km);
 
@@ -40946,12 +40715,12 @@ int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_1024_point_to_ecc_point_32(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(point, 0, heap);
 
     return err;
 }
@@ -40970,37 +40739,35 @@ int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_point_1024 a;
-    sp_digit kd[32];
-    sp_digit t[32 * 2 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_1024 point[2];
+    sp_digit k[32 + 32 * 2 * 5];
 #endif
-    sp_point_1024* point;
     sp_point_1024* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 + 32 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (32 + 32 * 2 * 5),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 32;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 32;
+
         sp_1024_from_mp(k, 32, km);
         sp_1024_point_from_ecc_point_32(addP, am);
     }
@@ -41026,13 +40793,12 @@ int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
         err = sp_1024_point_to_ecc_point_32(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(addP, 0, heap);
-    sp_1024_point_free_32(point, 0, heap);
 
     return err;
 }
@@ -41050,29 +40816,43 @@ int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
 int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
     void* heap)
 {
-    int err = 0;
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_1024* point = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 point[1];
     sp_digit t[5 * 2 * 32];
+#endif
+    int err = MP_OKAY;
 
     if ((gm == NULL) || (len == NULL)) {
         err = BAD_FUNC_ARG;
     }
 
-    if ((err == 0) && (table == NULL)) {
+    if ((err == MP_OKAY) && (table == NULL)) {
         *len = sizeof(sp_table_entry_1024) * 256;
         err = LENGTH_ONLY_E;
     }
-    if ((err == 0) && (*len < (int)(sizeof(sp_table_entry_1024) * 256))) {
+    if ((err == MP_OKAY) && (*len < (int)(sizeof(sp_table_entry_1024) * 256))) {
         err = BUFFER_E;
     }
 
-    if (err == 0) {
-        err = sp_1024_point_new_32(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+            DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-    if (err == 0) {
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 32, heap,
+            DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
         sp_1024_point_from_ecc_point_32(point, gm);
             err = sp_1024_gen_stripe_table_32(point,
                 (sp_table_entry_1024*)table, t, heap);
@@ -41081,7 +40861,12 @@ int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
         *len = sizeof(sp_table_entry_1024) * 256;
     }
 
-    sp_1024_point_free_32(point, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -41134,24 +40919,28 @@ int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
 int sp_ecc_mulmod_table_1024(const mp_int* km, const ecc_point* gm, byte* table,
         ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[32];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024 point[1];
+    sp_digit k[32];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+        DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap, DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 32, km);
         sp_1024_point_from_ecc_point_32(point, gm);
@@ -41168,12 +40957,12 @@ int sp_ecc_mulmod_table_1024(const mp_int* km, const ecc_point* gm, byte* table,
         err = sp_1024_point_to_ecc_point_32(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(point, 0, heap);
 
     return err;
 }
@@ -44624,33 +44413,24 @@ static void sp_1024_from_bin(sp_digit* r, int size, const byte* a, int n)
 static int sp_1024_ecc_is_point_32(const sp_point_1024* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*32];
-    sp_digit t2d[2*32];
+    sp_digit t1[32 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int32_t n;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 32;
-        t2 = d + 2 * 32;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 32;
 
         sp_1024_sqr_32(t1, point->y);
         (void)sp_1024_mod_32(t1, t1, p1024_mod);
@@ -44674,10 +44454,9 @@ static int sp_1024_ecc_is_point_32(const sp_point_1024* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -44692,14 +44471,21 @@ static int sp_1024_ecc_is_point_32(const sp_point_1024* point,
  */
 int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* pub = NULL;
+#else
+    sp_point_1024 pub[1];
 #endif
-    sp_point_1024* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(pub->x, 32, pX);
         sp_1024_from_mp(pub->y, 32, pY);
@@ -44708,7 +44494,10 @@ int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
         err = sp_1024_ecc_is_point_32(pub, NULL);
     }
 
-    sp_1024_point_free_32(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -44727,44 +44516,44 @@ int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_1024(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[32];
-    sp_point_1024 pubd;
-    sp_point_1024 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_1024* pub;
-    sp_point_1024* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_1024_point_new_32(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_1024* pub = NULL;
+#else
+    sp_digit priv[32];
+    sp_point_1024 pub[2];
 #endif
+    sp_point_1024* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 1024) ||
+    if (((mp_count_bits(pX) > 1024) ||
         (mp_count_bits(pY) > 1024) ||
         ((privm != NULL) && (mp_count_bits(privm) > 1024)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_1024_from_mp(pub->x, 32, pX);
         sp_1024_from_mp(pub->y, 32, pY);
@@ -44814,13 +44603,12 @@ int sp_ecc_check_key_1024(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_1024_point_free_32(p, 0, heap);
-    sp_1024_point_free_32(pub, 0, heap);
 
     return err;
 }

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -1797,40 +1797,29 @@ static int sp_2048_div_45(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[90 + 1];
-    sp_digit t2d[45 + 1];
-    sp_digit sdd[45 + 1];
+    sp_digit t1[4 * 45 + 3];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* sd;
+    sp_digit* t2 = NULL;
+    sp_digit* sd = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 45 + 3), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 45 + 3), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     (void)m;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 90 + 1;
+        t2 = t1 + 90 + 1;
         sd = t2 + 45 + 1;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        sd = sdd;
-#endif
 
         sp_2048_mul_d_45(sd, d, 1L << 11);
         sp_2048_mul_d_90(t1, a, 1L << 11);
@@ -1877,10 +1866,9 @@ static int sp_2048_div_45(const sp_digit* a, const sp_digit* d,
         sp_2048_rshift_45(r, r, 11);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -1911,13 +1899,13 @@ static int sp_2048_mod_exp_45(sp_digit* r, const sp_digit* a, const sp_digit* e,
     const sp_digit* m, int reduceA)
 {
 #ifdef WOLFSSL_SP_SMALL
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 90];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -1925,22 +1913,17 @@ static int sp_2048_mod_exp_45(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 45 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 45 * 2);
-#else
-            t[i] = &td[i * 45 * 2];
-#endif
             XMEMSET(t[i], 0, sizeof(sp_digit) * 45U * 2U);
         }
 
@@ -1995,21 +1978,20 @@ static int sp_2048_mod_exp_45(sp_digit* r, const sp_digit* a, const sp_digit* e,
 
     }
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #elif !defined(WC_NO_CACHE_RESISTANT)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 90];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -2017,22 +1999,17 @@ static int sp_2048_mod_exp_45(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 45 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 45 * 2);
-#else
-            t[i] = &td[i * 45 * 2];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -2086,22 +2063,21 @@ static int sp_2048_mod_exp_45(sp_digit* r, const sp_digit* a, const sp_digit* e,
         XMEMCPY(r, t[0], sizeof(*r) * 45 * 2);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #else
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[(32 * 90) + 90];
 #endif
     sp_digit* t[32];
     sp_digit* rt = NULL;
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -2112,22 +2088,15 @@ static int sp_2048_mod_exp_45(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * ((32 * 90) + 90), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         for (i=0; i<32; i++)
             t[i] = td + i * 90;
         rt = td + 2880;
-#else
-        for (i=0; i<32; i++)
-            t[i] = &td[i * 90];
-        rt = &td[2880];
-#endif
 
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_45(norm, m);
@@ -2224,9 +2193,8 @@ static int sp_2048_mod_exp_45(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -2716,40 +2684,29 @@ static int sp_2048_div_90(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[180 + 1];
-    sp_digit t2d[90 + 1];
-    sp_digit sdd[90 + 1];
+    sp_digit t1[4 * 90 + 3];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* sd;
+    sp_digit* t2 = NULL;
+    sp_digit* sd = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 90 + 3), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 90 + 3), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     (void)m;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 180 + 1;
+        t2 = t1 + 180 + 1;
         sd = t2 + 90 + 1;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        sd = sdd;
-#endif
 
         sp_2048_mul_d_90(sd, d, 1L << 22);
         sp_2048_mul_d_180(t1, a, 1L << 22);
@@ -2796,10 +2753,9 @@ static int sp_2048_div_90(const sp_digit* a, const sp_digit* d,
         sp_2048_rshift_90(r, r, 22);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -2832,13 +2788,13 @@ static int sp_2048_mod_exp_90(sp_digit* r, const sp_digit* a, const sp_digit* e,
     const sp_digit* m, int reduceA)
 {
 #ifdef WOLFSSL_SP_SMALL
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 180];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -2846,22 +2802,17 @@ static int sp_2048_mod_exp_90(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 90 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 90 * 2);
-#else
-            t[i] = &td[i * 90 * 2];
-#endif
             XMEMSET(t[i], 0, sizeof(sp_digit) * 90U * 2U);
         }
 
@@ -2916,21 +2867,20 @@ static int sp_2048_mod_exp_90(sp_digit* r, const sp_digit* a, const sp_digit* e,
 
     }
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #elif !defined(WC_NO_CACHE_RESISTANT)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 180];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -2938,22 +2888,17 @@ static int sp_2048_mod_exp_90(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 90 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 90 * 2);
-#else
-            t[i] = &td[i * 90 * 2];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -3007,22 +2952,21 @@ static int sp_2048_mod_exp_90(sp_digit* r, const sp_digit* a, const sp_digit* e,
         XMEMCPY(r, t[0], sizeof(*r) * 90 * 2);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #else
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[(32 * 180) + 180];
 #endif
     sp_digit* t[32];
     sp_digit* rt = NULL;
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -3033,22 +2977,15 @@ static int sp_2048_mod_exp_90(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * ((32 * 180) + 180), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         for (i=0; i<32; i++)
             t[i] = td + i * 180;
         rt = td + 5760;
-#else
-        for (i=0; i<32; i++)
-            t[i] = &td[i * 180];
-        rt = &td[5760];
-#endif
 
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_90(norm, m);
@@ -3145,9 +3082,8 @@ static int sp_2048_mod_exp_90(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -3173,8 +3109,11 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
 #ifdef WOLFSSL_SP_SMALL
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[90 * 5];
+#endif
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
@@ -3202,15 +3141,16 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 90 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 90 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
 
     if (err == MP_OKAY) {
-        a = d;
         r = a + 90 * 2;
         m = r + 90 * 2;
         norm = r;
@@ -3263,18 +3203,17 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 256;
     }
 
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+#endif
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit ad[180];
-    sp_digit md[90];
-    sp_digit rd[180];
-#else
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit d[90 * 5];
 #endif
     sp_digit* a = NULL;
     sp_digit* m = NULL;
@@ -3300,27 +3239,20 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 90 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
         a = d;
         r = a + 90 * 2;
         m = r + 90 * 2;
-    }
-#else
-    a = ad;
-    m = md;
-    r = rd;
-#endif
 
-    if (err == MP_OKAY) {
         sp_2048_from_bin(a, 90, in, inLen);
 #if DIGIT_BIT >= 23
         e[0] = (sp_digit)em->dp[0];
@@ -3384,10 +3316,9 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 256;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
 #endif
 
     return err;
@@ -3419,9 +3350,13 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SP_SMALL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[90 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -3450,13 +3385,15 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 90 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 90;
         m = a + 180;
@@ -3467,22 +3404,34 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         sp_2048_from_mp(m, 90, mm);
         err = sp_2048_mod_exp_90(r, a, d, 2048, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_2048_to_bin(r, out);
         *outLen = 256;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 90);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 90);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-    sp_digit a[180];
-    sp_digit d[90];
-    sp_digit m[90];
-    sp_digit* r = a;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* d = NULL;
+#else
+    sp_digit d[90 * 4];
+#endif
+    sp_digit* a = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
 
     (void)pm;
@@ -3509,7 +3458,20 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 90 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        a = d + 90;
+        m = a + 180;
+        r = a;
+
         sp_2048_from_bin(a, 90, in, inLen);
         sp_2048_from_mp(d, 90, dm);
         sp_2048_from_mp(m, 90, mm);
@@ -3521,14 +3483,27 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 256;
     }
 
-    XMEMSET(d, 0, sizeof(sp_digit) * 90);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 90);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
+    }
 
     return err;
-#endif /* WOLFSSL_SP_SMALL | defined(WOLFSSL_SMALL_STACK) */
+#endif /* WOLFSSL_SP_SMALL */
 #else
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SP_SMALL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[45 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
@@ -3557,22 +3532,21 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 45 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 45 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL) {
+        if (a == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
     if (err == MP_OKAY) {
-        a = t;
         p = a + 90 * 2;
         q = p + 45;
         qi = dq = dp = q + 45;
         tmpa = qi + 45;
         tmpb = tmpa + 90;
-
-        r = t + 90;
+        r = a + 90;
 
         sp_2048_from_bin(a, 90, in, inLen);
         sp_2048_from_mp(p, 45, pm);
@@ -3603,22 +3577,31 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 256;
     }
 
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 45 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+#endif
+    {
+        ForceZero(a, sizeof(sp_digit) * 45 * 11);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-    sp_digit a[90 * 2];
-    sp_digit p[45];
-    sp_digit q[45];
-    sp_digit dp[45];
-    sp_digit dq[45];
-    sp_digit qi[45];
-    sp_digit tmpa[90];
-    sp_digit tmpb[90];
-    sp_digit* r = a;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* a = NULL;
+#else
+    sp_digit a[45 * 13];
+#endif
+    sp_digit* p = NULL;
+    sp_digit* q = NULL;
+    sp_digit* dp = NULL;
+    sp_digit* dq = NULL;
+    sp_digit* qi = NULL;
+    sp_digit* tmpa = NULL;
+    sp_digit* tmpb = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
 
     (void)dm;
@@ -3639,7 +3622,25 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 45 * 13, NULL, 
+                                                              DYNAMIC_TYPE_RSA);
+        if (a == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        p = a + 90 * 2;
+        q = p + 45;
+        dp = q + 45;
+        dq = dp + 45;
+        qi = dq + 45;
+        tmpa = qi + 45;
+        tmpb = tmpa + 90;
+        r = a;
+
         sp_2048_from_bin(a, 90, in, inLen);
         sp_2048_from_mp(p, 45, pm);
         sp_2048_from_mp(q, 45, qm);
@@ -3670,17 +3671,19 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 256;
     }
 
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p, 0, sizeof(p));
-    XMEMSET(q, 0, sizeof(q));
-    XMEMSET(dp, 0, sizeof(dp));
-    XMEMSET(dq, 0, sizeof(dq));
-    XMEMSET(qi, 0, sizeof(qi));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+if (a != NULL)
+#endif
+    {
+        ForceZero(a, sizeof(sp_digit) * 45 * 13);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
 
     return err;
-#endif /* WOLFSSL_SP_SMALL | defined(WOLFSSL_SMALL_STACK) */
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+#endif /* WOLFSSL_SP_SMALL */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 }
 
 #endif /* !WOLFSSL_RSA_PUBLIC_ONLY */
@@ -3769,11 +3772,14 @@ int sp_ModExp_2048(const mp_int* base, const mp_int* exp, const mp_int* mod,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[90 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int expBits = mp_count_bits(exp);
 
     if (mp_count_bits(base) > 2048) {
@@ -3789,16 +3795,16 @@ int sp_ModExp_2048(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 90 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 90 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 90 * 2;
         m = e + 90;
         r = b;
@@ -3814,23 +3820,27 @@ int sp_ModExp_2048(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = sp_2048_to_mp(r, res);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 90U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 90U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[180];
-    sp_digit ed[90];
-    sp_digit md[90];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[90 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
     int expBits = mp_count_bits(exp);
 
@@ -3847,26 +3857,19 @@ int sp_ModExp_2048(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 90 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 90 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 90 * 2;
-        m = e + 90;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 90 * 2;
+        m = e + 90;
+        r = b;
+
         sp_2048_from_mp(b, 90, base);
         sp_2048_from_mp(e, 90, exp);
         sp_2048_from_mp(m, 90, mod);
@@ -3879,14 +3882,17 @@ int sp_ModExp_2048(const mp_int* base, const mp_int* exp, const mp_int* mod,
     }
 
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 90U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 90U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 90U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -4104,12 +4110,12 @@ SP_NOINLINE static void sp_2048_lshift_90(sp_digit* r, const sp_digit* a,
 static int sp_2048_mod_exp_2_90(sp_digit* r, const sp_digit* e, int bits, const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[271];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -4121,20 +4127,14 @@ static int sp_2048_mod_exp_2_90(sp_digit* r, const sp_digit* e, int bits, const 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 271, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp  = td + 180;
         XMEMSET(td, 0, sizeof(sp_digit) * 271);
-#else
-        tmp  = &td[180];
-        XMEMSET(td, 0, sizeof(td));
-#endif
 
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_90(norm, m);
@@ -4192,9 +4192,8 @@ static int sp_2048_mod_exp_2_90(sp_digit* r, const sp_digit* e, int bits, const 
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -4219,11 +4218,14 @@ int sp_DhExp_2048(const mp_int* base, const byte* exp, word32 expLen,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[90 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     word32 i;
 
     if (mp_count_bits(base) > 2048) {
@@ -4239,15 +4241,15 @@ int sp_DhExp_2048(const mp_int* base, const byte* exp, word32 expLen,
         err = MP_VAL;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 90 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 90 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 90 * 2;
         m = e + 90;
         r = b;
@@ -4275,23 +4277,27 @@ int sp_DhExp_2048(const mp_int* base, const byte* exp, word32 expLen,
         XMEMMOVE(out, out + i, *outLen);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 90U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 90U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[180];
-    sp_digit ed[90];
-    sp_digit md[90];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[90 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     word32 i;
     int err = MP_OKAY;
 
@@ -4308,26 +4314,20 @@ int sp_DhExp_2048(const mp_int* base, const byte* exp, word32 expLen,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 90 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 90 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 90 * 2;
-        m = e + 90;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 90 * 2;
+        m = e + 90;
+        r = b;
+
         sp_2048_from_mp(b, 90, base);
         sp_2048_from_bin(e, 90, exp, expLen);
         sp_2048_from_mp(m, 90, mod);
@@ -4355,14 +4355,17 @@ int sp_DhExp_2048(const mp_int* base, const byte* exp, word32 expLen,
         XMEMMOVE(out, out + i, *outLen);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 90U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 90U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 90U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -4383,11 +4386,14 @@ int sp_ModExp_1024(const mp_int* base, const mp_int* exp, const mp_int* mod,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[45 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int expBits = mp_count_bits(exp);
 
     if (mp_count_bits(base) > 1024) {
@@ -4403,16 +4409,16 @@ int sp_ModExp_1024(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 45 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 45 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 45 * 2;
         m = e + 45;
         r = b;
@@ -4429,23 +4435,27 @@ int sp_ModExp_1024(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = sp_2048_to_mp(r, res);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 45U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 90U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[90];
-    sp_digit ed[45];
-    sp_digit md[45];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[45 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
     int expBits = mp_count_bits(exp);
 
@@ -4462,26 +4472,19 @@ int sp_ModExp_1024(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 45 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 45 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 45 * 2;
-        m = e + 45;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 45 * 2;
+        m = e + 45;
+        r = b;
+
         sp_2048_from_mp(b, 45, base);
         sp_2048_from_mp(e, 45, exp);
         sp_2048_from_mp(m, 45, mod);
@@ -4495,14 +4498,17 @@ int sp_ModExp_1024(const mp_int* base, const mp_int* exp, const mp_int* mod,
     }
 
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 45U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 45U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 90U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -5662,34 +5668,25 @@ static int sp_3072_div_67(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[134];
-    sp_digit t2d[67 + 1];
+    sp_digit t1[3 * 67 + 1];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 67 + 1), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 67 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 2 * 67;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 67;
 
         dv = d[66];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 67U);
@@ -5732,10 +5729,9 @@ static int sp_3072_div_67(const sp_digit* a, const sp_digit* d,
                     (sp_digit)1 : (sp_digit)0));
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -5766,13 +5762,13 @@ static int sp_3072_mod_exp_67(sp_digit* r, const sp_digit* a, const sp_digit* e,
     const sp_digit* m, int reduceA)
 {
 #ifdef WOLFSSL_SP_SMALL
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 134];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -5780,22 +5776,17 @@ static int sp_3072_mod_exp_67(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 67 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 67 * 2);
-#else
-            t[i] = &td[i * 67 * 2];
-#endif
             XMEMSET(t[i], 0, sizeof(sp_digit) * 67U * 2U);
         }
 
@@ -5850,21 +5841,20 @@ static int sp_3072_mod_exp_67(sp_digit* r, const sp_digit* a, const sp_digit* e,
 
     }
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #elif !defined(WC_NO_CACHE_RESISTANT)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 134];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -5872,22 +5862,17 @@ static int sp_3072_mod_exp_67(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 67 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 67 * 2);
-#else
-            t[i] = &td[i * 67 * 2];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -5941,22 +5926,21 @@ static int sp_3072_mod_exp_67(sp_digit* r, const sp_digit* a, const sp_digit* e,
         XMEMCPY(r, t[0], sizeof(*r) * 67 * 2);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #else
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[(32 * 134) + 134];
 #endif
     sp_digit* t[32];
     sp_digit* rt = NULL;
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -5967,22 +5951,15 @@ static int sp_3072_mod_exp_67(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * ((32 * 134) + 134), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         for (i=0; i<32; i++)
             t[i] = td + i * 134;
         rt = td + 4288;
-#else
-        for (i=0; i<32; i++)
-            t[i] = &td[i * 134];
-        rt = &td[4288];
-#endif
 
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_67(norm, m);
@@ -6079,9 +6056,8 @@ static int sp_3072_mod_exp_67(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -6603,40 +6579,29 @@ static int sp_3072_div_134(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[268 + 1];
-    sp_digit t2d[134 + 1];
-    sp_digit sdd[134 + 1];
+    sp_digit t1[4 * 134 + 3];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* sd;
+    sp_digit* t2 = NULL;
+    sp_digit* sd = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 134 + 3), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 134 + 3), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     (void)m;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 268 + 1;
+        t2 = t1 + 268 + 1;
         sd = t2 + 134 + 1;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        sd = sdd;
-#endif
 
         sp_3072_mul_d_134(sd, d, 1L << 10);
         sp_3072_mul_d_268(t1, a, 1L << 10);
@@ -6683,10 +6648,9 @@ static int sp_3072_div_134(const sp_digit* a, const sp_digit* d,
         sp_3072_rshift_134(r, r, 10);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -6719,13 +6683,13 @@ static int sp_3072_mod_exp_134(sp_digit* r, const sp_digit* a, const sp_digit* e
     const sp_digit* m, int reduceA)
 {
 #ifdef WOLFSSL_SP_SMALL
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 268];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -6733,22 +6697,17 @@ static int sp_3072_mod_exp_134(sp_digit* r, const sp_digit* a, const sp_digit* e
     byte y;
     int err = MP_OKAY;
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 134 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 134 * 2);
-#else
-            t[i] = &td[i * 134 * 2];
-#endif
             XMEMSET(t[i], 0, sizeof(sp_digit) * 134U * 2U);
         }
 
@@ -6803,21 +6762,20 @@ static int sp_3072_mod_exp_134(sp_digit* r, const sp_digit* a, const sp_digit* e
 
     }
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #elif !defined(WC_NO_CACHE_RESISTANT)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 268];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -6825,22 +6783,17 @@ static int sp_3072_mod_exp_134(sp_digit* r, const sp_digit* a, const sp_digit* e
     byte y;
     int err = MP_OKAY;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 134 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 134 * 2);
-#else
-            t[i] = &td[i * 134 * 2];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -6894,22 +6847,21 @@ static int sp_3072_mod_exp_134(sp_digit* r, const sp_digit* a, const sp_digit* e
         XMEMCPY(r, t[0], sizeof(*r) * 134 * 2);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #else
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[(32 * 268) + 268];
 #endif
     sp_digit* t[32];
     sp_digit* rt = NULL;
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -6920,22 +6872,15 @@ static int sp_3072_mod_exp_134(sp_digit* r, const sp_digit* a, const sp_digit* e
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * ((32 * 268) + 268), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         for (i=0; i<32; i++)
             t[i] = td + i * 268;
         rt = td + 8576;
-#else
-        for (i=0; i<32; i++)
-            t[i] = &td[i * 268];
-        rt = &td[8576];
-#endif
 
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_134(norm, m);
@@ -7032,9 +6977,8 @@ static int sp_3072_mod_exp_134(sp_digit* r, const sp_digit* a, const sp_digit* e
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -7060,8 +7004,11 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
 #ifdef WOLFSSL_SP_SMALL
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[134 * 5];
+#endif
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
@@ -7089,15 +7036,16 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 134 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 134 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
 
     if (err == MP_OKAY) {
-        a = d;
         r = a + 134 * 2;
         m = r + 134 * 2;
         norm = r;
@@ -7150,18 +7098,17 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 384;
     }
 
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+#endif
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit ad[268];
-    sp_digit md[134];
-    sp_digit rd[268];
-#else
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit d[134 * 5];
 #endif
     sp_digit* a = NULL;
     sp_digit* m = NULL;
@@ -7187,27 +7134,20 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 134 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
         a = d;
         r = a + 134 * 2;
         m = r + 134 * 2;
-    }
-#else
-    a = ad;
-    m = md;
-    r = rd;
-#endif
 
-    if (err == MP_OKAY) {
         sp_3072_from_bin(a, 134, in, inLen);
 #if DIGIT_BIT >= 23
         e[0] = (sp_digit)em->dp[0];
@@ -7271,10 +7211,9 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 384;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
 #endif
 
     return err;
@@ -7306,9 +7245,13 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SP_SMALL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[134 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -7337,13 +7280,15 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 134 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 134;
         m = a + 268;
@@ -7354,22 +7299,34 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_from_mp(m, 134, mm);
         err = sp_3072_mod_exp_134(r, a, d, 3072, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_3072_to_bin(r, out);
         *outLen = 384;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 134);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 134);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-    sp_digit a[268];
-    sp_digit d[134];
-    sp_digit m[134];
-    sp_digit* r = a;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* d = NULL;
+#else
+    sp_digit d[134 * 4];
+#endif
+    sp_digit* a = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
 
     (void)pm;
@@ -7396,7 +7353,20 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 134 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        a = d + 134;
+        m = a + 268;
+        r = a;
+
         sp_3072_from_bin(a, 134, in, inLen);
         sp_3072_from_mp(d, 134, dm);
         sp_3072_from_mp(m, 134, mm);
@@ -7408,14 +7378,27 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 384;
     }
 
-    XMEMSET(d, 0, sizeof(sp_digit) * 134);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 134);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
+    }
 
     return err;
-#endif /* WOLFSSL_SP_SMALL | defined(WOLFSSL_SMALL_STACK) */
+#endif /* WOLFSSL_SP_SMALL */
 #else
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SP_SMALL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[67 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
@@ -7444,22 +7427,21 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 67 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 67 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL) {
+        if (a == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
     if (err == MP_OKAY) {
-        a = t;
         p = a + 134 * 2;
         q = p + 67;
         qi = dq = dp = q + 67;
         tmpa = qi + 67;
         tmpb = tmpa + 134;
-
-        r = t + 134;
+        r = a + 134;
 
         sp_3072_from_bin(a, 134, in, inLen);
         sp_3072_from_mp(p, 67, pm);
@@ -7490,22 +7472,31 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 384;
     }
 
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 67 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+#endif
+    {
+        ForceZero(a, sizeof(sp_digit) * 67 * 11);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-    sp_digit a[134 * 2];
-    sp_digit p[67];
-    sp_digit q[67];
-    sp_digit dp[67];
-    sp_digit dq[67];
-    sp_digit qi[67];
-    sp_digit tmpa[134];
-    sp_digit tmpb[134];
-    sp_digit* r = a;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* a = NULL;
+#else
+    sp_digit a[67 * 13];
+#endif
+    sp_digit* p = NULL;
+    sp_digit* q = NULL;
+    sp_digit* dp = NULL;
+    sp_digit* dq = NULL;
+    sp_digit* qi = NULL;
+    sp_digit* tmpa = NULL;
+    sp_digit* tmpb = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
 
     (void)dm;
@@ -7526,7 +7517,25 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 67 * 13, NULL, 
+                                                              DYNAMIC_TYPE_RSA);
+        if (a == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        p = a + 134 * 2;
+        q = p + 67;
+        dp = q + 67;
+        dq = dp + 67;
+        qi = dq + 67;
+        tmpa = qi + 67;
+        tmpb = tmpa + 134;
+        r = a;
+
         sp_3072_from_bin(a, 134, in, inLen);
         sp_3072_from_mp(p, 67, pm);
         sp_3072_from_mp(q, 67, qm);
@@ -7557,17 +7566,19 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 384;
     }
 
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p, 0, sizeof(p));
-    XMEMSET(q, 0, sizeof(q));
-    XMEMSET(dp, 0, sizeof(dp));
-    XMEMSET(dq, 0, sizeof(dq));
-    XMEMSET(qi, 0, sizeof(qi));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+if (a != NULL)
+#endif
+    {
+        ForceZero(a, sizeof(sp_digit) * 67 * 13);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
 
     return err;
-#endif /* WOLFSSL_SP_SMALL | defined(WOLFSSL_SMALL_STACK) */
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+#endif /* WOLFSSL_SP_SMALL */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 }
 
 #endif /* !WOLFSSL_RSA_PUBLIC_ONLY */
@@ -7656,11 +7667,14 @@ int sp_ModExp_3072(const mp_int* base, const mp_int* exp, const mp_int* mod,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[134 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int expBits = mp_count_bits(exp);
 
     if (mp_count_bits(base) > 3072) {
@@ -7676,16 +7690,16 @@ int sp_ModExp_3072(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 134 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 134 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 134 * 2;
         m = e + 134;
         r = b;
@@ -7701,23 +7715,27 @@ int sp_ModExp_3072(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = sp_3072_to_mp(r, res);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 134U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 134U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[268];
-    sp_digit ed[134];
-    sp_digit md[134];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[134 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
     int expBits = mp_count_bits(exp);
 
@@ -7734,26 +7752,19 @@ int sp_ModExp_3072(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 134 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 134 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 134 * 2;
-        m = e + 134;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 134 * 2;
+        m = e + 134;
+        r = b;
+
         sp_3072_from_mp(b, 134, base);
         sp_3072_from_mp(e, 134, exp);
         sp_3072_from_mp(m, 134, mod);
@@ -7766,14 +7777,17 @@ int sp_ModExp_3072(const mp_int* base, const mp_int* exp, const mp_int* mod,
     }
 
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 134U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 134U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 134U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -8079,12 +8093,12 @@ SP_NOINLINE static void sp_3072_lshift_134(sp_digit* r, const sp_digit* a,
 static int sp_3072_mod_exp_2_134(sp_digit* r, const sp_digit* e, int bits, const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[403];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -8096,20 +8110,14 @@ static int sp_3072_mod_exp_2_134(sp_digit* r, const sp_digit* e, int bits, const
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 403, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp  = td + 268;
         XMEMSET(td, 0, sizeof(sp_digit) * 403);
-#else
-        tmp  = &td[268];
-        XMEMSET(td, 0, sizeof(td));
-#endif
 
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_134(norm, m);
@@ -8167,9 +8175,8 @@ static int sp_3072_mod_exp_2_134(sp_digit* r, const sp_digit* e, int bits, const
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -8194,11 +8201,14 @@ int sp_DhExp_3072(const mp_int* base, const byte* exp, word32 expLen,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[134 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     word32 i;
 
     if (mp_count_bits(base) > 3072) {
@@ -8214,15 +8224,15 @@ int sp_DhExp_3072(const mp_int* base, const byte* exp, word32 expLen,
         err = MP_VAL;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 134 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 134 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 134 * 2;
         m = e + 134;
         r = b;
@@ -8250,23 +8260,27 @@ int sp_DhExp_3072(const mp_int* base, const byte* exp, word32 expLen,
         XMEMMOVE(out, out + i, *outLen);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 134U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 134U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[268];
-    sp_digit ed[134];
-    sp_digit md[134];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[134 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     word32 i;
     int err = MP_OKAY;
 
@@ -8283,26 +8297,20 @@ int sp_DhExp_3072(const mp_int* base, const byte* exp, word32 expLen,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 134 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 134 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 134 * 2;
-        m = e + 134;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 134 * 2;
+        m = e + 134;
+        r = b;
+
         sp_3072_from_mp(b, 134, base);
         sp_3072_from_bin(e, 134, exp, expLen);
         sp_3072_from_mp(m, 134, mod);
@@ -8330,14 +8338,17 @@ int sp_DhExp_3072(const mp_int* base, const byte* exp, word32 expLen,
         XMEMMOVE(out, out + i, *outLen);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 134U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 134U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 134U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -8358,11 +8369,14 @@ int sp_ModExp_1536(const mp_int* base, const mp_int* exp, const mp_int* mod,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[67 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int expBits = mp_count_bits(exp);
 
     if (mp_count_bits(base) > 1536) {
@@ -8378,16 +8392,16 @@ int sp_ModExp_1536(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 67 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 67 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 67 * 2;
         m = e + 67;
         r = b;
@@ -8404,23 +8418,27 @@ int sp_ModExp_1536(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = sp_3072_to_mp(r, res);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 67U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 134U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[134];
-    sp_digit ed[67];
-    sp_digit md[67];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[67 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
     int expBits = mp_count_bits(exp);
 
@@ -8437,26 +8455,19 @@ int sp_ModExp_1536(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 67 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 67 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 67 * 2;
-        m = e + 67;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 67 * 2;
+        m = e + 67;
+        r = b;
+
         sp_3072_from_mp(b, 67, base);
         sp_3072_from_mp(e, 67, exp);
         sp_3072_from_mp(m, 67, mod);
@@ -8470,14 +8481,17 @@ int sp_ModExp_1536(const mp_int* base, const mp_int* exp, const mp_int* mod,
     }
 
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 67U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 67U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 134U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -9704,40 +9718,29 @@ static int sp_4096_div_98(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[196 + 1];
-    sp_digit t2d[98 + 1];
-    sp_digit sdd[98 + 1];
+    sp_digit t1[4 * 98 + 3];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* sd;
+    sp_digit* t2 = NULL;
+    sp_digit* sd = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 98 + 3), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 98 + 3), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     (void)m;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 196 + 1;
+        t2 = t1 + 196 + 1;
         sd = t2 + 98 + 1;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        sd = sdd;
-#endif
 
         sp_4096_mul_d_98(sd, d, 1L << 10);
         sp_4096_mul_d_196(t1, a, 1L << 10);
@@ -9784,10 +9787,9 @@ static int sp_4096_div_98(const sp_digit* a, const sp_digit* d,
         sp_4096_rshift_98(r, r, 10);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -9818,13 +9820,13 @@ static int sp_4096_mod_exp_98(sp_digit* r, const sp_digit* a, const sp_digit* e,
     const sp_digit* m, int reduceA)
 {
 #ifdef WOLFSSL_SP_SMALL
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 196];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -9832,22 +9834,17 @@ static int sp_4096_mod_exp_98(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 98 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 98 * 2);
-#else
-            t[i] = &td[i * 98 * 2];
-#endif
             XMEMSET(t[i], 0, sizeof(sp_digit) * 98U * 2U);
         }
 
@@ -9902,21 +9899,20 @@ static int sp_4096_mod_exp_98(sp_digit* r, const sp_digit* a, const sp_digit* e,
 
     }
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #elif !defined(WC_NO_CACHE_RESISTANT)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 196];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -9924,22 +9920,17 @@ static int sp_4096_mod_exp_98(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 98 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 98 * 2);
-#else
-            t[i] = &td[i * 98 * 2];
-#endif
         }
 
         sp_4096_mont_setup(m, &mp);
@@ -9993,22 +9984,21 @@ static int sp_4096_mod_exp_98(sp_digit* r, const sp_digit* a, const sp_digit* e,
         XMEMCPY(r, t[0], sizeof(*r) * 98 * 2);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #else
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[(32 * 196) + 196];
 #endif
     sp_digit* t[32];
     sp_digit* rt = NULL;
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -10019,22 +10009,15 @@ static int sp_4096_mod_exp_98(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * ((32 * 196) + 196), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         for (i=0; i<32; i++)
             t[i] = td + i * 196;
         rt = td + 6272;
-#else
-        for (i=0; i<32; i++)
-            t[i] = &td[i * 196];
-        rt = &td[6272];
-#endif
 
         sp_4096_mont_setup(m, &mp);
         sp_4096_mont_norm_98(norm, m);
@@ -10131,9 +10114,8 @@ static int sp_4096_mod_exp_98(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -10640,40 +10622,29 @@ static int sp_4096_div_196(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[392 + 1];
-    sp_digit t2d[196 + 1];
-    sp_digit sdd[196 + 1];
+    sp_digit t1[4 * 196 + 3];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* sd;
+    sp_digit* t2 = NULL;
+    sp_digit* sd = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 196 + 3), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 196 + 3), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     (void)m;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 392 + 1;
+        t2 = t1 + 392 + 1;
         sd = t2 + 196 + 1;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        sd = sdd;
-#endif
 
         sp_4096_mul_d_196(sd, d, 1L << 20);
         sp_4096_mul_d_392(t1, a, 1L << 20);
@@ -10720,10 +10691,9 @@ static int sp_4096_div_196(const sp_digit* a, const sp_digit* d,
         sp_4096_rshift_196(r, r, 20);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -10756,13 +10726,13 @@ static int sp_4096_mod_exp_196(sp_digit* r, const sp_digit* a, const sp_digit* e
     const sp_digit* m, int reduceA)
 {
 #ifdef WOLFSSL_SP_SMALL
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 392];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -10770,22 +10740,17 @@ static int sp_4096_mod_exp_196(sp_digit* r, const sp_digit* a, const sp_digit* e
     byte y;
     int err = MP_OKAY;
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 196 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 196 * 2);
-#else
-            t[i] = &td[i * 196 * 2];
-#endif
             XMEMSET(t[i], 0, sizeof(sp_digit) * 196U * 2U);
         }
 
@@ -10840,21 +10805,20 @@ static int sp_4096_mod_exp_196(sp_digit* r, const sp_digit* a, const sp_digit* e
 
     }
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #elif !defined(WC_NO_CACHE_RESISTANT)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 392];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -10862,22 +10826,17 @@ static int sp_4096_mod_exp_196(sp_digit* r, const sp_digit* a, const sp_digit* e
     byte y;
     int err = MP_OKAY;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 196 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 196 * 2);
-#else
-            t[i] = &td[i * 196 * 2];
-#endif
         }
 
         sp_4096_mont_setup(m, &mp);
@@ -10931,22 +10890,21 @@ static int sp_4096_mod_exp_196(sp_digit* r, const sp_digit* a, const sp_digit* e
         XMEMCPY(r, t[0], sizeof(*r) * 196 * 2);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #else
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[(32 * 392) + 392];
 #endif
     sp_digit* t[32];
     sp_digit* rt = NULL;
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -10957,22 +10915,15 @@ static int sp_4096_mod_exp_196(sp_digit* r, const sp_digit* a, const sp_digit* e
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * ((32 * 392) + 392), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         for (i=0; i<32; i++)
             t[i] = td + i * 392;
         rt = td + 12544;
-#else
-        for (i=0; i<32; i++)
-            t[i] = &td[i * 392];
-        rt = &td[12544];
-#endif
 
         sp_4096_mont_setup(m, &mp);
         sp_4096_mont_norm_196(norm, m);
@@ -11069,9 +11020,8 @@ static int sp_4096_mod_exp_196(sp_digit* r, const sp_digit* a, const sp_digit* e
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -11097,8 +11047,11 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
 #ifdef WOLFSSL_SP_SMALL
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[196 * 5];
+#endif
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
@@ -11126,15 +11079,16 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 196 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 196 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
 
     if (err == MP_OKAY) {
-        a = d;
         r = a + 196 * 2;
         m = r + 196 * 2;
         norm = r;
@@ -11187,18 +11141,17 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 512;
     }
 
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+#endif
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit ad[392];
-    sp_digit md[196];
-    sp_digit rd[392];
-#else
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit d[196 * 5];
 #endif
     sp_digit* a = NULL;
     sp_digit* m = NULL;
@@ -11224,27 +11177,20 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 196 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
         a = d;
         r = a + 196 * 2;
         m = r + 196 * 2;
-    }
-#else
-    a = ad;
-    m = md;
-    r = rd;
-#endif
 
-    if (err == MP_OKAY) {
         sp_4096_from_bin(a, 196, in, inLen);
 #if DIGIT_BIT >= 21
         e[0] = (sp_digit)em->dp[0];
@@ -11308,10 +11254,9 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 512;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
 #endif
 
     return err;
@@ -11343,9 +11288,13 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SP_SMALL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[196 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -11374,13 +11323,15 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 196 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 196;
         m = a + 392;
@@ -11391,22 +11342,34 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_from_mp(m, 196, mm);
         err = sp_4096_mod_exp_196(r, a, d, 4096, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_4096_to_bin(r, out);
         *outLen = 512;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 196);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 196);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-    sp_digit a[392];
-    sp_digit d[196];
-    sp_digit m[196];
-    sp_digit* r = a;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* d = NULL;
+#else
+    sp_digit d[196 * 4];
+#endif
+    sp_digit* a = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
 
     (void)pm;
@@ -11433,7 +11396,20 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 196 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        a = d + 196;
+        m = a + 392;
+        r = a;
+
         sp_4096_from_bin(a, 196, in, inLen);
         sp_4096_from_mp(d, 196, dm);
         sp_4096_from_mp(m, 196, mm);
@@ -11445,14 +11421,27 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 512;
     }
 
-    XMEMSET(d, 0, sizeof(sp_digit) * 196);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 196);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
+    }
 
     return err;
-#endif /* WOLFSSL_SP_SMALL | defined(WOLFSSL_SMALL_STACK) */
+#endif /* WOLFSSL_SP_SMALL */
 #else
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SP_SMALL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[98 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
@@ -11481,22 +11470,21 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 98 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 98 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL) {
+        if (a == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
     if (err == MP_OKAY) {
-        a = t;
         p = a + 196 * 2;
         q = p + 98;
         qi = dq = dp = q + 98;
         tmpa = qi + 98;
         tmpb = tmpa + 196;
-
-        r = t + 196;
+        r = a + 196;
 
         sp_4096_from_bin(a, 196, in, inLen);
         sp_4096_from_mp(p, 98, pm);
@@ -11527,22 +11515,31 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 512;
     }
 
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 98 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+#endif
+    {
+        ForceZero(a, sizeof(sp_digit) * 98 * 11);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-    sp_digit a[196 * 2];
-    sp_digit p[98];
-    sp_digit q[98];
-    sp_digit dp[98];
-    sp_digit dq[98];
-    sp_digit qi[98];
-    sp_digit tmpa[196];
-    sp_digit tmpb[196];
-    sp_digit* r = a;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* a = NULL;
+#else
+    sp_digit a[98 * 13];
+#endif
+    sp_digit* p = NULL;
+    sp_digit* q = NULL;
+    sp_digit* dp = NULL;
+    sp_digit* dq = NULL;
+    sp_digit* qi = NULL;
+    sp_digit* tmpa = NULL;
+    sp_digit* tmpb = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
 
     (void)dm;
@@ -11563,7 +11560,25 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 98 * 13, NULL, 
+                                                              DYNAMIC_TYPE_RSA);
+        if (a == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        p = a + 196 * 2;
+        q = p + 98;
+        dp = q + 98;
+        dq = dp + 98;
+        qi = dq + 98;
+        tmpa = qi + 98;
+        tmpb = tmpa + 196;
+        r = a;
+
         sp_4096_from_bin(a, 196, in, inLen);
         sp_4096_from_mp(p, 98, pm);
         sp_4096_from_mp(q, 98, qm);
@@ -11594,17 +11609,19 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 512;
     }
 
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p, 0, sizeof(p));
-    XMEMSET(q, 0, sizeof(q));
-    XMEMSET(dp, 0, sizeof(dp));
-    XMEMSET(dq, 0, sizeof(dq));
-    XMEMSET(qi, 0, sizeof(qi));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+if (a != NULL)
+#endif
+    {
+        ForceZero(a, sizeof(sp_digit) * 98 * 13);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
 
     return err;
-#endif /* WOLFSSL_SP_SMALL | defined(WOLFSSL_SMALL_STACK) */
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+#endif /* WOLFSSL_SP_SMALL */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 }
 
 #endif /* !WOLFSSL_RSA_PUBLIC_ONLY */
@@ -11693,11 +11710,14 @@ int sp_ModExp_4096(const mp_int* base, const mp_int* exp, const mp_int* mod,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[196 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int expBits = mp_count_bits(exp);
 
     if (mp_count_bits(base) > 4096) {
@@ -11713,16 +11733,16 @@ int sp_ModExp_4096(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 196 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 196 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 196 * 2;
         m = e + 196;
         r = b;
@@ -11738,23 +11758,27 @@ int sp_ModExp_4096(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = sp_4096_to_mp(r, res);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 196U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 196U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[392];
-    sp_digit ed[196];
-    sp_digit md[196];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[196 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
     int expBits = mp_count_bits(exp);
 
@@ -11771,26 +11795,19 @@ int sp_ModExp_4096(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 196 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 196 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 196 * 2;
-        m = e + 196;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 196 * 2;
+        m = e + 196;
+        r = b;
+
         sp_4096_from_mp(b, 196, base);
         sp_4096_from_mp(e, 196, exp);
         sp_4096_from_mp(m, 196, mod);
@@ -11803,14 +11820,17 @@ int sp_ModExp_4096(const mp_int* base, const mp_int* exp, const mp_int* mod,
     }
 
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 196U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 196U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 196U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -12240,12 +12260,12 @@ SP_NOINLINE static void sp_4096_lshift_196(sp_digit* r, const sp_digit* a,
 static int sp_4096_mod_exp_2_196(sp_digit* r, const sp_digit* e, int bits, const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[589];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -12257,20 +12277,14 @@ static int sp_4096_mod_exp_2_196(sp_digit* r, const sp_digit* e, int bits, const
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 589, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp  = td + 392;
         XMEMSET(td, 0, sizeof(sp_digit) * 589);
-#else
-        tmp  = &td[392];
-        XMEMSET(td, 0, sizeof(td));
-#endif
 
         sp_4096_mont_setup(m, &mp);
         sp_4096_mont_norm_196(norm, m);
@@ -12328,9 +12342,8 @@ static int sp_4096_mod_exp_2_196(sp_digit* r, const sp_digit* e, int bits, const
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -12355,11 +12368,14 @@ int sp_DhExp_4096(const mp_int* base, const byte* exp, word32 expLen,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[196 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     word32 i;
 
     if (mp_count_bits(base) > 4096) {
@@ -12375,15 +12391,15 @@ int sp_DhExp_4096(const mp_int* base, const byte* exp, word32 expLen,
         err = MP_VAL;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 196 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 196 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 196 * 2;
         m = e + 196;
         r = b;
@@ -12411,23 +12427,27 @@ int sp_DhExp_4096(const mp_int* base, const byte* exp, word32 expLen,
         XMEMMOVE(out, out + i, *outLen);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 196U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 196U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[392];
-    sp_digit ed[196];
-    sp_digit md[196];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[196 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     word32 i;
     int err = MP_OKAY;
 
@@ -12444,26 +12464,20 @@ int sp_DhExp_4096(const mp_int* base, const byte* exp, word32 expLen,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 196 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 196 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 196 * 2;
-        m = e + 196;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 196 * 2;
+        m = e + 196;
+        r = b;
+
         sp_4096_from_mp(b, 196, base);
         sp_4096_from_bin(e, 196, exp, expLen);
         sp_4096_from_mp(m, 196, mod);
@@ -12491,14 +12505,17 @@ int sp_DhExp_4096(const mp_int* base, const byte* exp, word32 expLen,
         XMEMMOVE(out, out + i, *outLen);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 196U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 196U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 196U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -12975,64 +12992,6 @@ SP_NOINLINE static int sp_256_sub_10(sp_digit* r, const sp_digit* a,
 }
 
 #endif /* WOLFSSL_SP_SMALL */
-/* Create a new point.
- *
- * heap  [in]   Buffer to allocate dynamic memory from.
- * sp    [in]   Data for point - only if not allocating.
- * p     [out]  New point.
- * returns MEMORY_E when dynamic memory allocation fails and 0 otherwise.
- */
-static int sp_256_point_new_ex_10(void* heap, sp_point_256* sp,
-    sp_point_256** p)
-{
-    int ret = MP_OKAY;
-    (void)heap;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    (void)sp;
-    *p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap, DYNAMIC_TYPE_ECC);
-#else
-    *p = sp;
-#endif
-    if (*p == NULL) {
-        ret = MEMORY_E;
-    }
-    return ret;
-}
-
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* Allocate memory for point and return error. */
-#define sp_256_point_new_10(heap, sp, p) sp_256_point_new_ex_10((heap), NULL, &(p))
-#else
-/* Set pointer to data and return no error. */
-#define sp_256_point_new_10(heap, sp, p) sp_256_point_new_ex_10((heap), &(sp), &(p))
-#endif
-
-
-/* Free the point.
- *
- * p      [in,out]  Point to free.
- * clear  [in]      Indicates whether to zeroize point.
- * heap   [in]      Buffer from which dynamic memory was allocate from.
- */
-static void sp_256_point_free_10(sp_point_256* p, int clear, void* heap)
-{
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* If valid pointer then clear point data if requested and free data. */
-    if (p != NULL) {
-        if (clear != 0) {
-            XMEMSET(p, 0, sizeof(*p));
-        }
-        XFREE(p, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-/* Clear point data if requested. */
-    if ((p != NULL) && (clear != 0)) {
-        XMEMSET(p, 0, sizeof(*p));
-    }
-#endif
-    (void)heap;
-}
-
 /* Convert an mp_int to an array of sp_digit.
  *
  * r  A single precision integer.
@@ -14276,34 +14235,25 @@ static void sp_256_proj_point_add_10(sp_point_256* r,
  */
 static int sp_256_mod_mul_norm_10(sp_digit* r, const sp_digit* a, const sp_digit* m)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    int64_t* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    int64_t* t = NULL;
 #else
-    int64_t td[8];
-    int64_t a32d[8];
+    int64_t t[2 * 8];
 #endif
-    int64_t* t;
-    int64_t* a32;
+    int64_t* a32 = NULL;
     int64_t o;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (td == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 8, NULL, DYNAMIC_TYPE_ECC);
+    if (t == NULL)
         return MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t = td;
-        a32 = td + 8;
-#else
-        t = td;
-        a32 = a32d;
-#endif
+        a32 = t + 8;
 
         a32[0] = a[0];
         a32[0] |= a[1] << 26U;
@@ -14394,10 +14344,9 @@ static int sp_256_mod_mul_norm_10(sp_digit* r, const sp_digit* a, const sp_digit
         r[9] = (sp_digit)(t[7] >> 10U);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -14537,12 +14486,12 @@ static int sp_256_ecc_mulmod_10_nb(sp_ecc_ctx_t* sp_ctx, sp_point_256* r,
 static int sp_256_ecc_mulmod_10(sp_point_256* r, const sp_point_256* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#ifdef WOLFSSL_SP_NO_MALLOC
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+    sp_digit* tmp = NULL;
+#else
     sp_point_256 t[3];
     sp_digit tmp[2 * 10 * 5];
-#else
-    sp_point_256* t;
-    sp_digit* tmp;
 #endif
     sp_digit n;
     int i;
@@ -14554,14 +14503,17 @@ static int sp_256_ecc_mulmod_10(sp_point_256* r, const sp_point_256* g,
     (void)ct;
     (void)heap;
 
-#ifndef WOLFSSL_SP_NO_MALLOC
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 10 * 5, heap,
-                                                              DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 10 * 5, heap,
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
@@ -14612,19 +14564,24 @@ static int sp_256_ecc_mulmod_10(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#ifndef WOLFSSL_SP_NO_MALLOC
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 10 * 5);
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_256) * 3);
-        XFREE(t, NULL, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmp, sizeof(tmp));
-    ForceZero(t, sizeof(t));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 10 * 5);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_256) * 3);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -15090,43 +15047,41 @@ static void sp_256_get_point_33_10(sp_point_256* r, const sp_point_256* table,
 static int sp_256_ecc_mulmod_win_add_sub_10(sp_point_256* r, const sp_point_256* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td[33];
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit tmpd[2 * 10 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_256 t[33+2];
+    sp_digit tmp[2 * 10 * 6];
 #endif
-    sp_point_256* t;
-    sp_point_256* rt;
+    sp_point_256* rt = NULL;
     sp_point_256* p = NULL;
-    sp_digit* tmp;
     sp_digit* negy;
     int i;
     ecc_recode_256 v[43];
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_256_point_new_10(heap, rtd, rt);
-    if (err == MP_OKAY)
-        err = sp_256_point_new_10(heap, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 33, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 
+        (33+2), heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 10 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 10 * 6,
+                                 heap, DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
-
     if (err == MP_OKAY) {
+        rt = t + 33;
+        p  = t + 33+1;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -15206,14 +15161,12 @@ static int sp_256_ecc_mulmod_win_add_sub_10(sp_point_256* r, const sp_point_256*
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
     if (tmp != NULL)
         XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_10(p, 0, heap);
-    sp_256_point_free_10(rt, 0, heap);
 
     return err;
 }
@@ -15339,29 +15292,30 @@ static void sp_256_proj_to_affine_10(sp_point_256* a, sp_digit* t)
 static int sp_256_gen_stripe_table_10(const sp_point_256* a,
         sp_table_entry_256* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td;
-    sp_point_256 s1d;
-    sp_point_256 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+#else
+    sp_point_256 t[3];
 #endif
-    sp_point_256* t;
     sp_point_256* s1 = NULL;
     sp_point_256* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_256_point_new_10(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_10(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_10(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_256_mod_mul_norm_10(t->x, a->x, p256_mod);
     }
     if (err == MP_OKAY) {
@@ -15406,9 +15360,10 @@ static int sp_256_gen_stripe_table_10(const sp_point_256* a,
         }
     }
 
-    sp_256_point_free_10(s2, 0, heap);
-    sp_256_point_free_10(s1, 0, heap);
-    sp_256_point_free_10( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -15492,19 +15447,19 @@ static int sp_256_ecc_mulmod_stripe_10(sp_point_256* r, const sp_point_256* g,
         const sp_table_entry_256* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit td[2 * 10 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_256 rt[2];
+    sp_digit t[2 * 10 * 5];
 #endif
-    sp_point_256* rt;
     sp_point_256* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -15512,21 +15467,22 @@ static int sp_256_ecc_mulmod_stripe_10(sp_point_256* r, const sp_point_256* g,
     (void)heap;
 
 
-    err = sp_256_point_new_10(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_10(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 10 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 10 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p256_norm_mod, sizeof(p256_norm_mod));
         XMEMCPY(rt->z, p256_norm_mod, sizeof(p256_norm_mod));
 
@@ -15577,13 +15533,12 @@ static int sp_256_ecc_mulmod_stripe_10(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_10(p, 0, heap);
-    sp_256_point_free_10(rt, 0, heap);
 
     return err;
 }
@@ -15747,25 +15702,28 @@ static int sp_256_ecc_mulmod_10(sp_point_256* r, const sp_point_256* g, const sp
 int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[10];
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[1];
+    sp_digit k[10];
+#endif
     int err = MP_OKAY;
 
-    err = sp_256_point_new_10(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 10, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(k, 10, km);
         sp_256_point_from_ecc_point_10(point, gm);
@@ -15776,12 +15734,12 @@ int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_256_point_to_ecc_point_10(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_10(point, 0, heap);
 
     return err;
 }
@@ -15801,37 +15759,35 @@ int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
 int sp_ecc_mulmod_add_256(const mp_int* km, const ecc_point* gm,
     const ecc_point* am, int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_point_256 a;
-    sp_digit kd[10];
-    sp_digit t[10 * 2 * 5];
-#endif
-    sp_point_256* point;
-    sp_point_256* addP = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;    
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[2];
+    sp_digit k[10 + 10 * 2 * 5];
+#endif
+    sp_point_256* addP = NULL;
     sp_digit* tmp = NULL;
     int err = MP_OKAY;
 
-    err = sp_256_point_new_10(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_256_point_new_10(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (10 + 10 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (10 + 10 * 2 * 5), heap,
+            DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 10;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 10;
+
         sp_256_from_mp(k, 10, km);
         sp_256_point_from_ecc_point_10(point, gm);
         sp_256_point_from_ecc_point_10(addP, am);
@@ -15858,13 +15814,12 @@ int sp_ecc_mulmod_add_256(const mp_int* km, const ecc_point* gm,
         err = sp_256_point_to_ecc_point_10(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_10(addP, 0, heap);
-    sp_256_point_free_10(point, 0, heap);
 
     return err;
 }
@@ -17207,26 +17162,28 @@ static int sp_256_ecc_mulmod_base_10(sp_point_256* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[10];
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256  point[1];
+    sp_digit k[10];
+#endif
     int err = MP_OKAY;
 
-    err = sp_256_point_new_10(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 10, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(k, 10, km);
 
@@ -17236,12 +17193,12 @@ int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_256_point_to_ecc_point_10(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_10(point, 0, heap);
 
     return err;
 }
@@ -17260,37 +17217,35 @@ int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_point_256 a;
-    sp_digit kd[10];
-    sp_digit t[10 * 2 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_256 point[2];
+    sp_digit k[10 + 10 * 2 * 5];
 #endif
-    sp_point_256* point;
     sp_point_256* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_256_point_new_10(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_256_point_new_10(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (10 + 10 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (10 + 10 * 2 * 5),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 10;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 10;
+
         sp_256_from_mp(k, 10, km);
         sp_256_point_from_ecc_point_10(addP, am);
     }
@@ -17316,13 +17271,12 @@ int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
         err = sp_256_point_to_ecc_point_10(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_10(addP, 0, heap);
-    sp_256_point_free_10(point, 0, heap);
 
     return err;
 }
@@ -17426,41 +17380,46 @@ static int sp_256_ecc_gen_k_10(WC_RNG* rng, sp_digit* k)
  */
 int sp_ecc_make_key_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[10];
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_point_256 inf;
-#endif
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    sp_point_256 point[2];
+    #else
+    sp_point_256 point[1];
+    #endif
+    sp_digit k[10];
+#endif
 #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
     sp_point_256* infinity = NULL;
 #endif
-    int err;
+    int err = MP_OKAY;
+    
 
     (void)heap;
 
-    err = sp_256_point_new_10(heap, p, point);
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_10(heap, inf, infinity);
-    }
-#endif
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap, DYNAMIC_TYPE_ECC);
+    #else
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap, DYNAMIC_TYPE_ECC);    
+    #endif
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 10, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+        infinity = point + 1;
+    #endif
+
         err = sp_256_ecc_gen_k_10(rng, k);
     }
     if (err == MP_OKAY) {
@@ -17485,15 +17444,14 @@ int sp_ecc_make_key_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
         err = sp_256_point_to_ecc_point_10(point, pub);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL) {
+        /* point is not sensitive, so no need to zeroize */
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
     }
 #endif
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_256_point_free_10(infinity, 1, heap);
-#endif
-    sp_256_point_free_10(point, 1, heap);
 
     return err;
 }
@@ -17558,30 +17516,32 @@ static void sp_256_to_bin(sp_digit* r, byte* a)
 int sp_ecc_secret_gen_256(const mp_int* priv, const ecc_point* pub, byte* out,
                           word32* outLen, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[10];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[1];
+    sp_digit k[10];
+#endif
     int err = MP_OKAY;
 
     if (*outLen < 32U) {
         err = BUFFER_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_10(heap, p, point);
+        point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 10, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
@@ -17594,12 +17554,12 @@ int sp_ecc_secret_gen_256(const mp_int* priv, const ecc_point* pub, byte* out,
         *outLen = 32;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_10(point, 0, heap);
 
     return err;
 }
@@ -17732,34 +17692,25 @@ static int sp_256_div_10(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[20];
-    sp_digit t2d[10 + 1];
+    sp_digit t1[3 * 10 + 1];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 10 + 1), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 10 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 2 * 10;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 10;
 
         dv = d[9];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 10U);
@@ -17802,10 +17753,9 @@ static int sp_256_div_10(const sp_digit* a, const sp_digit* d,
                     (sp_digit)1 : (sp_digit)0));
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -18255,22 +18205,17 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
 int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
     const mp_int* priv, mp_int* rm, mp_int* sm, mp_int* km, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit ed[2*10];
-    sp_digit xd[2*10];
-    sp_digit kd[2*10];
-    sp_digit rd[2*10];
-    sp_digit td[3 * 2*10];
-    sp_point_256 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* e = NULL;
+    sp_point_256* point = NULL;
+#else
+    sp_digit e[7 * 2 * 10];
+    sp_point_256 point[1];
+#endif
     sp_digit* x = NULL;
     sp_digit* k = NULL;
     sp_digit* r = NULL;
     sp_digit* tmp = NULL;
-    sp_point_256* point = NULL;
     sp_digit* s = NULL;
     int32_t c;
     int err = MP_OKAY;
@@ -18278,31 +18223,26 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
 
     (void)heap;
 
-    err = sp_256_point_new_10(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 10, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (point == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        e = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 10, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (e == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        e = d + 0 * 10;
-        x = d + 2 * 10;
-        k = d + 4 * 10;
-        r = d + 6 * 10;
-        tmp = d + 8 * 10;
-#else
-        e = ed;
-        x = xd;
-        k = kd;
-        r = rd;
-        tmp = td;
-#endif
+        x = e + 2 * 10;
+        k = e + 4 * 10;
+        r = e + 6 * 10;
+        tmp = e + 8 * 10;
         s = e;
 
         if (hashLen > 32U) {
@@ -18357,19 +18297,24 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
         err = sp_256_to_mp(s, sm);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 8 * 10);
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 2U * 10U);
-    XMEMSET(x, 0, sizeof(sp_digit) * 2U * 10U);
-    XMEMSET(k, 0, sizeof(sp_digit) * 2U * 10U);
-    XMEMSET(r, 0, sizeof(sp_digit) * 2U * 10U);
-    XMEMSET(tmp, 0, sizeof(sp_digit) * 3U * 2U * 10U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (e != NULL)
 #endif
-    sp_256_point_free_10(point, 1, heap);
+    {
+        ForceZero(e, sizeof(sp_digit) * 7 * 2 * 10);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(e, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (point != NULL)
+#endif
+    {
+        ForceZero(point, sizeof(sp_point_256));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -18419,20 +18364,18 @@ static int sp_256_num_bits_10(const sp_digit* a)
 static int sp_256_mod_inv_10(sp_digit* r, const sp_digit* a, const sp_digit* m)
 {
     int err = MP_OKAY;
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
-    sp_digit* u;
-    sp_digit* v;
-    sp_digit* b;
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* u = NULL;
 #else
-    sp_digit u[10];
-    sp_digit v[10];
-    sp_digit b[10];
-    sp_digit d[10];
+    sp_digit u[10 * 4];
 #endif
-    int ut, vt;
+    sp_digit* v = NULL;
+    sp_digit* b = NULL;
+    sp_digit* d = NULL;
+    int ut;
+    int vt;
 
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     u = (sp_digit*)XMALLOC(sizeof(sp_digit) * 10 * 4, NULL,
                                                               DYNAMIC_TYPE_ECC);
     if (u == NULL)
@@ -18440,11 +18383,9 @@ static int sp_256_mod_inv_10(sp_digit* r, const sp_digit* a, const sp_digit* m)
 #endif
 
     if (err == MP_OKAY) {
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
         v = u + 10;
         b = u + 2 * 10;
         d = u + 3 * 10;
-#endif
 
         XMEMCPY(u, m, sizeof(sp_digit) * 10);
         XMEMCPY(v, a, sizeof(sp_digit) * 10);
@@ -18522,7 +18463,7 @@ static int sp_256_mod_inv_10(sp_digit* r, const sp_digit* a, const sp_digit* m)
         else
             XMEMCPY(r, d, sizeof(sp_digit) * 10);
     }
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (u != NULL)
         XFREE(u, NULL, DYNAMIC_TYPE_ECC);
 #endif
@@ -18820,52 +18761,41 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
     const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
     int* res, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit u1d[2*10];
-    sp_digit u2d[2*10];
-    sp_digit sd[2*10];
-    sp_digit tmpd[2*10 * 5];
-    sp_point_256 p1d;
-    sp_point_256 p2d;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* u1 = NULL;
+    sp_point_256* p1 = NULL;
+#else
+    sp_digit  u1[16 * 10];
+    sp_point_256 p1[2];
+#endif
     sp_digit* u2 = NULL;
     sp_digit* s = NULL;
     sp_digit* tmp = NULL;
-    sp_point_256* p1;
     sp_point_256* p2 = NULL;
     sp_digit carry;
     int32_t c = 0;
-    int err;
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_10(heap, p1d, p1);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_10(heap, p2d, p2);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 10, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        p1 = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (p1 == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        u1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 10, heap,
+                                                              DYNAMIC_TYPE_ECC);
+        if (u1 == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        u1  = d + 0 * 10;
-        u2  = d + 2 * 10;
-        s   = d + 4 * 10;
-        tmp = d + 6 * 10;
-#else
-        u1 = u1d;
-        u2 = u2d;
-        s  = sd;
-        tmp = tmpd;
-#endif
+        u2  = u1 + 2 * 10;
+        s   = u1 + 4 * 10;
+        tmp = u1 + 6 * 10;
+        p2 = p1 + 1;
 
         if (hashLen > 32U) {
             hashLen = 32U;
@@ -18916,12 +18846,12 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL)
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (u1 != NULL)
+        XFREE(u1, heap, DYNAMIC_TYPE_ECC);
+    if (p1 != NULL)
+        XFREE(p1, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_10(p1, 0, heap);
-    sp_256_point_free_10(p2, 0, heap);
 
     return err;
 }
@@ -18938,32 +18868,23 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
 static int sp_256_ecc_is_point_10(const sp_point_256* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*10];
-    sp_digit t2d[2*10];
+    sp_digit t1[10 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 10 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 10 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 10;
-        t2 = d + 2 * 10;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 10;
 
         sp_256_sqr_10(t1, point->y);
         (void)sp_256_mod_10(t1, t1, p256_mod);
@@ -18983,10 +18904,9 @@ static int sp_256_ecc_is_point_10(const sp_point_256* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -19001,14 +18921,21 @@ static int sp_256_ecc_is_point_10(const sp_point_256* point,
  */
 int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* pub = NULL;
+#else
+    sp_point_256 pub[1];
 #endif
-    sp_point_256* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_10(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(pub->x, 10, pX);
         sp_256_from_mp(pub->y, 10, pY);
@@ -19017,7 +18944,10 @@ int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
         err = sp_256_ecc_is_point_10(pub, NULL);
     }
 
-    sp_256_point_free_10(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -19036,44 +18966,44 @@ int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_256(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[10];
-    sp_point_256 pubd;
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_256* pub;
-    sp_point_256* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_256_point_new_10(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_10(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 10, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_256* pub = NULL;
+#else
+    sp_digit priv[10];
+    sp_point_256 pub[2];
 #endif
+    sp_point_256* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+    if (((mp_count_bits(pX) > 256) ||
         (mp_count_bits(pY) > 256) ||
         ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 10, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_256_from_mp(pub->x, 10, pX);
         sp_256_from_mp(pub->y, 10, pY);
@@ -19123,13 +19053,12 @@ int sp_ecc_check_key_256(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_256_point_free_10(p, 0, heap);
-    sp_256_point_free_10(pub, 0, heap);
 
     return err;
 }
@@ -19153,33 +19082,35 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* qX, mp_int* qY, mp_int* qZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 10 * 5];
-    sp_point_256 pd;
-    sp_point_256 qd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 10 * 5];
+    sp_point_256 p[2];
+#endif
     sp_point_256* q = NULL;
     int err;
 
-    err = sp_256_point_new_10(NULL, pd, p);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_10(NULL, qd, q);
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 10 * 5, NULL,
-                                                              DYNAMIC_TYPE_ECC);
+                                 DYNAMIC_TYPE_ECC);
         if (tmp == NULL) {
             err = MEMORY_E;
         }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
+        q = p + 1;
+
         sp_256_from_mp(p->x, 10, pX);
         sp_256_from_mp(p->y, 10, pY);
         sp_256_from_mp(p->z, 10, pZ);
@@ -19200,13 +19131,12 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_256_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_10(q, 0, NULL);
-    sp_256_point_free_10(p, 0, NULL);
 
     return err;
 }
@@ -19225,25 +19155,28 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
 int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 10 * 2];
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
-    int err;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 10 * 2];
+    sp_point_256 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_10(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 10 * 2, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
@@ -19264,12 +19197,12 @@ int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_256_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_10(p, 0, NULL);
 
     return err;
 }
@@ -19284,25 +19217,29 @@ int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
  */
 int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 10 * 4];
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
-    int err;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 10 * 4];
+    sp_point_256 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_10(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 10 * 4, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
     if (err == MP_OKAY) {
         sp_256_from_mp(p->x, 10, pX);
@@ -19322,12 +19259,12 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
         err = sp_256_to_mp(p->z, pZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_10(p, 0, NULL);
 
     return err;
 }
@@ -19340,31 +19277,23 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
  */
 static int sp_256_mont_sqrt_10(sp_digit* y)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2 * 10];
-    sp_digit t2d[2 * 10];
+    sp_digit t1[4 * 10];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 10, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 10, NULL, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL) {
         err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 10;
-        t2 = d + 2 * 10;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 10;
 
         {
             /* t2 = y ^ 0x2 */
@@ -19399,10 +19328,9 @@ static int sp_256_mont_sqrt_10(sp_digit* y)
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -19418,31 +19346,22 @@ static int sp_256_mont_sqrt_10(sp_digit* y)
  */
 int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
-#else
-    sp_digit xd[2 * 10];
-    sp_digit yd[2 * 10];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* x = NULL;
+#else
+    sp_digit x[4 * 10];
+#endif
     sp_digit* y = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 10, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    x = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 10, NULL, DYNAMIC_TYPE_ECC);
+    if (x == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        x = d + 0 * 10;
-        y = d + 2 * 10;
-#else
-        x = xd;
-        y = yd;
-#endif
+        y = x + 2 * 10;
 
         sp_256_from_mp(x, 10, xm);
         err = sp_256_mod_mul_norm_10(x, x, p256_mod);
@@ -19475,10 +19394,9 @@ int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
         err = sp_256_to_mp(y, ym);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (x != NULL)
+        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -20178,64 +20096,6 @@ SP_NOINLINE static int sp_384_sub_15(sp_digit* r, const sp_digit* a,
 }
 
 #endif /* WOLFSSL_SP_SMALL */
-/* Create a new point.
- *
- * heap  [in]   Buffer to allocate dynamic memory from.
- * sp    [in]   Data for point - only if not allocating.
- * p     [out]  New point.
- * returns MEMORY_E when dynamic memory allocation fails and 0 otherwise.
- */
-static int sp_384_point_new_ex_15(void* heap, sp_point_384* sp,
-    sp_point_384** p)
-{
-    int ret = MP_OKAY;
-    (void)heap;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    (void)sp;
-    *p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap, DYNAMIC_TYPE_ECC);
-#else
-    *p = sp;
-#endif
-    if (*p == NULL) {
-        ret = MEMORY_E;
-    }
-    return ret;
-}
-
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* Allocate memory for point and return error. */
-#define sp_384_point_new_15(heap, sp, p) sp_384_point_new_ex_15((heap), NULL, &(p))
-#else
-/* Set pointer to data and return no error. */
-#define sp_384_point_new_15(heap, sp, p) sp_384_point_new_ex_15((heap), &(sp), &(p))
-#endif
-
-
-/* Free the point.
- *
- * p      [in,out]  Point to free.
- * clear  [in]      Indicates whether to zeroize point.
- * heap   [in]      Buffer from which dynamic memory was allocate from.
- */
-static void sp_384_point_free_15(sp_point_384* p, int clear, void* heap)
-{
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* If valid pointer then clear point data if requested and free data. */
-    if (p != NULL) {
-        if (clear != 0) {
-            XMEMSET(p, 0, sizeof(*p));
-        }
-        XFREE(p, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-/* Clear point data if requested. */
-    if ((p != NULL) && (clear != 0)) {
-        XMEMSET(p, 0, sizeof(*p));
-    }
-#endif
-    (void)heap;
-}
-
 /* Convert an mp_int to an array of sp_digit.
  *
  * r  A single precision integer.
@@ -21509,34 +21369,25 @@ static void sp_384_proj_point_add_15(sp_point_384* r,
  */
 static int sp_384_mod_mul_norm_15(sp_digit* r, const sp_digit* a, const sp_digit* m)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    int64_t* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    int64_t* t = NULL;
 #else
-    int64_t td[12];
-    int64_t a32d[12];
+    int64_t t[2 * 12];
 #endif
-    int64_t* t;
-    int64_t* a32;
+    int64_t* a32 = NULL;
     int64_t o;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 12, NULL, DYNAMIC_TYPE_ECC);
-    if (td == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 12, NULL, DYNAMIC_TYPE_ECC);
+    if (t == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t = td;
-        a32 = td + 12;
-#else
-        t = td;
-        a32 = a32d;
-#endif
+        a32 = t + 12;
 
         a32[0] = a[0];
         a32[0] |= a[1] << 26U;
@@ -21669,9 +21520,9 @@ static int sp_384_mod_mul_norm_15(sp_digit* r, const sp_digit* a, const sp_digit
         r[14] = (sp_digit)(t[11] >> 12U);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL)
-        XFREE(td, NULL, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -21811,12 +21662,12 @@ static int sp_384_ecc_mulmod_15_nb(sp_ecc_ctx_t* sp_ctx, sp_point_384* r,
 static int sp_384_ecc_mulmod_15(sp_point_384* r, const sp_point_384* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#ifdef WOLFSSL_SP_NO_MALLOC
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+    sp_digit* tmp = NULL;
+#else
     sp_point_384 t[3];
     sp_digit tmp[2 * 15 * 6];
-#else
-    sp_point_384* t;
-    sp_digit* tmp;
 #endif
     sp_digit n;
     int i;
@@ -21828,14 +21679,17 @@ static int sp_384_ecc_mulmod_15(sp_point_384* r, const sp_point_384* g,
     (void)ct;
     (void)heap;
 
-#ifndef WOLFSSL_SP_NO_MALLOC
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 15 * 6, heap,
-                                                              DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 15 * 6, heap,
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
@@ -21886,19 +21740,24 @@ static int sp_384_ecc_mulmod_15(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#ifndef WOLFSSL_SP_NO_MALLOC
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 15 * 6);
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_384) * 3);
-        XFREE(t, NULL, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmp, sizeof(tmp));
-    ForceZero(t, sizeof(t));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 15 * 6);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_384) * 3);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -22404,43 +22263,41 @@ static void sp_384_get_point_33_15(sp_point_384* r, const sp_point_384* table,
 static int sp_384_ecc_mulmod_win_add_sub_15(sp_point_384* r, const sp_point_384* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td[33];
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit tmpd[2 * 15 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_384 t[33+2];
+    sp_digit tmp[2 * 15 * 6];
 #endif
-    sp_point_384* t;
-    sp_point_384* rt;
+    sp_point_384* rt = NULL;
     sp_point_384* p = NULL;
-    sp_digit* tmp;
     sp_digit* negy;
     int i;
     ecc_recode_384 v[65];
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_384_point_new_15(heap, rtd, rt);
-    if (err == MP_OKAY)
-        err = sp_384_point_new_15(heap, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 33, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 
+        (33+2), heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 15 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 15 * 6,
+                                 heap, DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
-
     if (err == MP_OKAY) {
+        rt = t + 33;
+        p  = t + 33+1;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -22520,14 +22377,12 @@ static int sp_384_ecc_mulmod_win_add_sub_15(sp_point_384* r, const sp_point_384*
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
     if (tmp != NULL)
         XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_15(p, 0, heap);
-    sp_384_point_free_15(rt, 0, heap);
 
     return err;
 }
@@ -22653,29 +22508,30 @@ static void sp_384_proj_to_affine_15(sp_point_384* a, sp_digit* t)
 static int sp_384_gen_stripe_table_15(const sp_point_384* a,
         sp_table_entry_384* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td;
-    sp_point_384 s1d;
-    sp_point_384 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+#else
+    sp_point_384 t[3];
 #endif
-    sp_point_384* t;
     sp_point_384* s1 = NULL;
     sp_point_384* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_384_point_new_15(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_15(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_15(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_384_mod_mul_norm_15(t->x, a->x, p384_mod);
     }
     if (err == MP_OKAY) {
@@ -22720,9 +22576,10 @@ static int sp_384_gen_stripe_table_15(const sp_point_384* a,
         }
     }
 
-    sp_384_point_free_15(s2, 0, heap);
-    sp_384_point_free_15(s1, 0, heap);
-    sp_384_point_free_15( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -22826,19 +22683,19 @@ static int sp_384_ecc_mulmod_stripe_15(sp_point_384* r, const sp_point_384* g,
         const sp_table_entry_384* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit td[2 * 15 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_384 rt[2];
+    sp_digit t[2 * 15 * 6];
 #endif
-    sp_point_384* rt;
     sp_point_384* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -22846,21 +22703,22 @@ static int sp_384_ecc_mulmod_stripe_15(sp_point_384* r, const sp_point_384* g,
     (void)heap;
 
 
-    err = sp_384_point_new_15(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_15(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 15 * 6, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 15 * 6, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p384_norm_mod, sizeof(p384_norm_mod));
         XMEMCPY(rt->z, p384_norm_mod, sizeof(p384_norm_mod));
 
@@ -22911,13 +22769,12 @@ static int sp_384_ecc_mulmod_stripe_15(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_15(p, 0, heap);
-    sp_384_point_free_15(rt, 0, heap);
 
     return err;
 }
@@ -23081,25 +22938,28 @@ static int sp_384_ecc_mulmod_15(sp_point_384* r, const sp_point_384* g, const sp
 int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[15];
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[1];
+    sp_digit k[15];
+#endif
     int err = MP_OKAY;
 
-    err = sp_384_point_new_15(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 15, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(k, 15, km);
         sp_384_point_from_ecc_point_15(point, gm);
@@ -23110,12 +22970,12 @@ int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_384_point_to_ecc_point_15(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_15(point, 0, heap);
 
     return err;
 }
@@ -23135,37 +22995,35 @@ int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
 int sp_ecc_mulmod_add_384(const mp_int* km, const ecc_point* gm,
     const ecc_point* am, int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_point_384 a;
-    sp_digit kd[15];
-    sp_digit t[15 * 2 * 6];
-#endif
-    sp_point_384* point;
-    sp_point_384* addP = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;    
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[2];
+    sp_digit k[15 + 15 * 2 * 6];
+#endif
+    sp_point_384* addP = NULL;
     sp_digit* tmp = NULL;
     int err = MP_OKAY;
 
-    err = sp_384_point_new_15(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_384_point_new_15(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (15 + 15 * 2 * 6), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (15 + 15 * 2 * 6), heap,
+            DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 15;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 15;
+
         sp_384_from_mp(k, 15, km);
         sp_384_point_from_ecc_point_15(point, gm);
         sp_384_point_from_ecc_point_15(addP, am);
@@ -23192,13 +23050,12 @@ int sp_ecc_mulmod_add_384(const mp_int* km, const ecc_point* gm,
         err = sp_384_point_to_ecc_point_15(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_15(addP, 0, heap);
-    sp_384_point_free_15(point, 0, heap);
 
     return err;
 }
@@ -25051,26 +24908,28 @@ static int sp_384_ecc_mulmod_base_15(sp_point_384* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[15];
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384  point[1];
+    sp_digit k[15];
+#endif
     int err = MP_OKAY;
 
-    err = sp_384_point_new_15(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 15, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(k, 15, km);
 
@@ -25080,12 +24939,12 @@ int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_384_point_to_ecc_point_15(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_15(point, 0, heap);
 
     return err;
 }
@@ -25104,37 +24963,35 @@ int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_point_384 a;
-    sp_digit kd[15];
-    sp_digit t[15 * 2 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_384 point[2];
+    sp_digit k[15 + 15 * 2 * 6];
 #endif
-    sp_point_384* point;
     sp_point_384* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_384_point_new_15(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_384_point_new_15(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (15 + 15 * 2 * 6), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (15 + 15 * 2 * 6),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 15;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 15;
+
         sp_384_from_mp(k, 15, km);
         sp_384_point_from_ecc_point_15(addP, am);
     }
@@ -25160,13 +25017,12 @@ int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
         err = sp_384_point_to_ecc_point_15(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_15(addP, 0, heap);
-    sp_384_point_free_15(point, 0, heap);
 
     return err;
 }
@@ -25270,41 +25126,46 @@ static int sp_384_ecc_gen_k_15(WC_RNG* rng, sp_digit* k)
  */
 int sp_ecc_make_key_384(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[15];
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_point_384 inf;
-#endif
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    sp_point_384 point[2];
+    #else
+    sp_point_384 point[1];
+    #endif
+    sp_digit k[15];
+#endif
 #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
     sp_point_384* infinity = NULL;
 #endif
-    int err;
+    int err = MP_OKAY;
+    
 
     (void)heap;
 
-    err = sp_384_point_new_15(heap, p, point);
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_15(heap, inf, infinity);
-    }
-#endif
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap, DYNAMIC_TYPE_ECC);
+    #else
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap, DYNAMIC_TYPE_ECC);    
+    #endif
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 15, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+        infinity = point + 1;
+    #endif
+
         err = sp_384_ecc_gen_k_15(rng, k);
     }
     if (err == MP_OKAY) {
@@ -25329,15 +25190,14 @@ int sp_ecc_make_key_384(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
         err = sp_384_point_to_ecc_point_15(point, pub);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL) {
+        /* point is not sensitive, so no need to zeroize */
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
     }
 #endif
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_384_point_free_15(infinity, 1, heap);
-#endif
-    sp_384_point_free_15(point, 1, heap);
 
     return err;
 }
@@ -25402,30 +25262,32 @@ static void sp_384_to_bin(sp_digit* r, byte* a)
 int sp_ecc_secret_gen_384(const mp_int* priv, const ecc_point* pub, byte* out,
                           word32* outLen, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[15];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[1];
+    sp_digit k[15];
+#endif
     int err = MP_OKAY;
 
     if (*outLen < 48U) {
         err = BUFFER_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_15(heap, p, point);
+        point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 15, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
@@ -25438,12 +25300,12 @@ int sp_ecc_secret_gen_384(const mp_int* priv, const ecc_point* pub, byte* out,
         *outLen = 48;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_15(point, 0, heap);
 
     return err;
 }
@@ -25586,34 +25448,25 @@ static int sp_384_div_15(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[30];
-    sp_digit t2d[15 + 1];
+    sp_digit t1[3 * 15 + 1];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 15 + 1), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 15 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 2 * 15;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 15;
 
         dv = d[14];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 15U);
@@ -25656,10 +25509,9 @@ static int sp_384_div_15(const sp_digit* a, const sp_digit* d,
                     (sp_digit)1 : (sp_digit)0));
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -26080,22 +25932,17 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
 int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
     const mp_int* priv, mp_int* rm, mp_int* sm, mp_int* km, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit ed[2*15];
-    sp_digit xd[2*15];
-    sp_digit kd[2*15];
-    sp_digit rd[2*15];
-    sp_digit td[3 * 2*15];
-    sp_point_384 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* e = NULL;
+    sp_point_384* point = NULL;
+#else
+    sp_digit e[7 * 2 * 15];
+    sp_point_384 point[1];
+#endif
     sp_digit* x = NULL;
     sp_digit* k = NULL;
     sp_digit* r = NULL;
     sp_digit* tmp = NULL;
-    sp_point_384* point = NULL;
     sp_digit* s = NULL;
     int32_t c;
     int err = MP_OKAY;
@@ -26103,31 +25950,26 @@ int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
 
     (void)heap;
 
-    err = sp_384_point_new_15(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 15, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (point == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        e = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 15, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (e == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        e = d + 0 * 15;
-        x = d + 2 * 15;
-        k = d + 4 * 15;
-        r = d + 6 * 15;
-        tmp = d + 8 * 15;
-#else
-        e = ed;
-        x = xd;
-        k = kd;
-        r = rd;
-        tmp = td;
-#endif
+        x = e + 2 * 15;
+        k = e + 4 * 15;
+        r = e + 6 * 15;
+        tmp = e + 8 * 15;
         s = e;
 
         if (hashLen > 48U) {
@@ -26182,19 +26024,24 @@ int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
         err = sp_384_to_mp(s, sm);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 8 * 15);
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 2U * 15U);
-    XMEMSET(x, 0, sizeof(sp_digit) * 2U * 15U);
-    XMEMSET(k, 0, sizeof(sp_digit) * 2U * 15U);
-    XMEMSET(r, 0, sizeof(sp_digit) * 2U * 15U);
-    XMEMSET(tmp, 0, sizeof(sp_digit) * 3U * 2U * 15U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (e != NULL)
 #endif
-    sp_384_point_free_15(point, 1, heap);
+    {
+        ForceZero(e, sizeof(sp_digit) * 7 * 2 * 15);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(e, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (point != NULL)
+#endif
+    {
+        ForceZero(point, sizeof(sp_point_384));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -26244,20 +26091,18 @@ static int sp_384_num_bits_15(const sp_digit* a)
 static int sp_384_mod_inv_15(sp_digit* r, const sp_digit* a, const sp_digit* m)
 {
     int err = MP_OKAY;
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
-    sp_digit* u;
-    sp_digit* v;
-    sp_digit* b;
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* u = NULL;
 #else
-    sp_digit u[15];
-    sp_digit v[15];
-    sp_digit b[15];
-    sp_digit d[15];
+    sp_digit u[15 * 4];
 #endif
-    int ut, vt;
+    sp_digit* v = NULL;
+    sp_digit* b = NULL;
+    sp_digit* d = NULL;
+    int ut;
+    int vt;
 
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     u = (sp_digit*)XMALLOC(sizeof(sp_digit) * 15 * 4, NULL,
                                                               DYNAMIC_TYPE_ECC);
     if (u == NULL)
@@ -26265,11 +26110,9 @@ static int sp_384_mod_inv_15(sp_digit* r, const sp_digit* a, const sp_digit* m)
 #endif
 
     if (err == MP_OKAY) {
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
         v = u + 15;
         b = u + 2 * 15;
         d = u + 3 * 15;
-#endif
 
         XMEMCPY(u, m, sizeof(sp_digit) * 15);
         XMEMCPY(v, a, sizeof(sp_digit) * 15);
@@ -26347,7 +26190,7 @@ static int sp_384_mod_inv_15(sp_digit* r, const sp_digit* a, const sp_digit* m)
         else
             XMEMCPY(r, d, sizeof(sp_digit) * 15);
     }
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (u != NULL)
         XFREE(u, NULL, DYNAMIC_TYPE_ECC);
 #endif
@@ -26650,52 +26493,41 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
     const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
     int* res, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit u1d[2*15];
-    sp_digit u2d[2*15];
-    sp_digit sd[2*15];
-    sp_digit tmpd[2*15 * 5];
-    sp_point_384 p1d;
-    sp_point_384 p2d;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* u1 = NULL;
+    sp_point_384* p1 = NULL;
+#else
+    sp_digit  u1[16 * 15];
+    sp_point_384 p1[2];
+#endif
     sp_digit* u2 = NULL;
     sp_digit* s = NULL;
     sp_digit* tmp = NULL;
-    sp_point_384* p1;
     sp_point_384* p2 = NULL;
     sp_digit carry;
     int32_t c = 0;
-    int err;
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_15(heap, p1d, p1);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_15(heap, p2d, p2);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 15, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        p1 = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (p1 == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        u1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 15, heap,
+                                                              DYNAMIC_TYPE_ECC);
+        if (u1 == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        u1  = d + 0 * 15;
-        u2  = d + 2 * 15;
-        s   = d + 4 * 15;
-        tmp = d + 6 * 15;
-#else
-        u1 = u1d;
-        u2 = u2d;
-        s  = sd;
-        tmp = tmpd;
-#endif
+        u2  = u1 + 2 * 15;
+        s   = u1 + 4 * 15;
+        tmp = u1 + 6 * 15;
+        p2 = p1 + 1;
 
         if (hashLen > 48U) {
             hashLen = 48U;
@@ -26746,12 +26578,12 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL)
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (u1 != NULL)
+        XFREE(u1, heap, DYNAMIC_TYPE_ECC);
+    if (p1 != NULL)
+        XFREE(p1, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_15(p1, 0, heap);
-    sp_384_point_free_15(p2, 0, heap);
 
     return err;
 }
@@ -26768,32 +26600,23 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
 static int sp_384_ecc_is_point_15(const sp_point_384* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*15];
-    sp_digit t2d[2*15];
+    sp_digit t1[15 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 15 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 15 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 15;
-        t2 = d + 2 * 15;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 15;
 
         sp_384_sqr_15(t1, point->y);
         (void)sp_384_mod_15(t1, t1, p384_mod);
@@ -26813,10 +26636,9 @@ static int sp_384_ecc_is_point_15(const sp_point_384* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -26831,14 +26653,21 @@ static int sp_384_ecc_is_point_15(const sp_point_384* point,
  */
 int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* pub = NULL;
+#else
+    sp_point_384 pub[1];
 #endif
-    sp_point_384* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_15(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(pub->x, 15, pX);
         sp_384_from_mp(pub->y, 15, pY);
@@ -26847,7 +26676,10 @@ int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
         err = sp_384_ecc_is_point_15(pub, NULL);
     }
 
-    sp_384_point_free_15(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -26866,44 +26698,44 @@ int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_384(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[15];
-    sp_point_384 pubd;
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_384* pub;
-    sp_point_384* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_384_point_new_15(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_15(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 15, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_384* pub = NULL;
+#else
+    sp_digit priv[15];
+    sp_point_384 pub[2];
 #endif
+    sp_point_384* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+    if (((mp_count_bits(pX) > 384) ||
         (mp_count_bits(pY) > 384) ||
         ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 15, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_384_from_mp(pub->x, 15, pX);
         sp_384_from_mp(pub->y, 15, pY);
@@ -26953,13 +26785,12 @@ int sp_ecc_check_key_384(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_384_point_free_15(p, 0, heap);
-    sp_384_point_free_15(pub, 0, heap);
 
     return err;
 }
@@ -26983,33 +26814,35 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* qX, mp_int* qY, mp_int* qZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 15 * 5];
-    sp_point_384 pd;
-    sp_point_384 qd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 15 * 5];
+    sp_point_384 p[2];
+#endif
     sp_point_384* q = NULL;
     int err;
 
-    err = sp_384_point_new_15(NULL, pd, p);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_15(NULL, qd, q);
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 15 * 5, NULL,
-                                                              DYNAMIC_TYPE_ECC);
+                                 DYNAMIC_TYPE_ECC);
         if (tmp == NULL) {
             err = MEMORY_E;
         }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
+        q = p + 1;
+
         sp_384_from_mp(p->x, 15, pX);
         sp_384_from_mp(p->y, 15, pY);
         sp_384_from_mp(p->z, 15, pZ);
@@ -27030,13 +26863,12 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_384_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_15(q, 0, NULL);
-    sp_384_point_free_15(p, 0, NULL);
 
     return err;
 }
@@ -27055,25 +26887,28 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
 int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 15 * 2];
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
-    int err;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 15 * 2];
+    sp_point_384 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_15(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 15 * 2, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
@@ -27094,12 +26929,12 @@ int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_384_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_15(p, 0, NULL);
 
     return err;
 }
@@ -27114,25 +26949,29 @@ int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
  */
 int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 15 * 6];
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
-    int err;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 15 * 6];
+    sp_point_384 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_15(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 15 * 6, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
     if (err == MP_OKAY) {
         sp_384_from_mp(p->x, 15, pX);
@@ -27152,12 +26991,12 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
         err = sp_384_to_mp(p->z, pZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_15(p, 0, NULL);
 
     return err;
 }
@@ -27170,43 +27009,28 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
  */
 static int sp_384_mont_sqrt_15(sp_digit* y)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2 * 15];
-    sp_digit t2d[2 * 15];
-    sp_digit t3d[2 * 15];
-    sp_digit t4d[2 * 15];
-    sp_digit t5d[2 * 15];
+    sp_digit t1[5 * 2 * 15];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* t3;
-    sp_digit* t4;
-    sp_digit* t5;
+    sp_digit* t2 = NULL;
+    sp_digit* t3 = NULL;
+    sp_digit* t4 = NULL;
+    sp_digit* t5 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 15, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 15, NULL, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 15;
-        t2 = d + 2 * 15;
-        t3 = d + 4 * 15;
-        t4 = d + 6 * 15;
-        t5 = d + 8 * 15;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        t3 = t3d;
-        t4 = t4d;
-        t5 = t5d;
-#endif
+        t2 = t1 + 2 * 15;
+        t3 = t1 + 4 * 15;
+        t4 = t1 + 6 * 15;
+        t5 = t1 + 8 * 15;
 
         {
             /* t2 = y ^ 0x2 */
@@ -27266,10 +27090,9 @@ static int sp_384_mont_sqrt_15(sp_digit* y)
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -27285,31 +27108,22 @@ static int sp_384_mont_sqrt_15(sp_digit* y)
  */
 int sp_ecc_uncompress_384(mp_int* xm, int odd, mp_int* ym)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
-#else
-    sp_digit xd[2 * 15];
-    sp_digit yd[2 * 15];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* x = NULL;
+#else
+    sp_digit x[4 * 15];
+#endif
     sp_digit* y = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 15, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    x = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 15, NULL, DYNAMIC_TYPE_ECC);
+    if (x == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        x = d + 0 * 15;
-        y = d + 2 * 15;
-#else
-        x = xd;
-        y = yd;
-#endif
+        y = x + 2 * 15;
 
         sp_384_from_mp(x, 15, xm);
         err = sp_384_mod_mul_norm_15(x, x, p384_mod);
@@ -27342,10 +27156,9 @@ int sp_ecc_uncompress_384(mp_int* xm, int odd, mp_int* ym)
         err = sp_384_to_mp(y, ym);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (x != NULL)
+        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -28132,34 +27945,25 @@ static int sp_1024_div_42(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[84];
-    sp_digit t2d[42 + 1];
+    sp_digit t1[3 * 42 + 1];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 42 + 1), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 42 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 2 * 42;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 42;
 
         dv = d[40];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 42U);
@@ -28203,10 +28007,9 @@ static int sp_1024_div_42(const sp_digit* a, const sp_digit* d,
         r[41] = 0;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -28238,6 +28041,8 @@ static int sp_1024_mod_mul_norm_42(sp_digit* r, const sp_digit* a,
     return sp_1024_mod_42(r, r, m);
 }
 
+
+#ifdef WOLFCRYPT_HAVE_SAKKE
 /* Create a new point.
  *
  * heap  [in]   Buffer to allocate dynamic memory from.
@@ -28269,8 +28074,8 @@ static int sp_1024_point_new_ex_42(void* heap, sp_point_1024* sp,
 /* Set pointer to data and return no error. */
 #define sp_1024_point_new_42(heap, sp, p) sp_1024_point_new_ex_42((heap), &(sp), &(p))
 #endif
-
-
+#endif /* WOLFCRYPT_HAVE_SAKKE */
+#ifdef WOLFCRYPT_HAVE_SAKKE
 /* Free the point.
  *
  * p      [in,out]  Point to free.
@@ -28295,6 +28100,7 @@ static void sp_1024_point_free_42(sp_point_1024* p, int clear, void* heap)
 #endif
     (void)heap;
 }
+#endif /* WOLFCRYPT_HAVE_SAKKE */
 
 /* Convert an mp_int to an array of sp_digit.
  *
@@ -29650,12 +29456,12 @@ static int sp_1024_ecc_mulmod_42_nb(sp_ecc_ctx_t* sp_ctx, sp_point_1024* r,
 static int sp_1024_ecc_mulmod_42(sp_point_1024* r, const sp_point_1024* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#ifdef WOLFSSL_SP_NO_MALLOC
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+    sp_digit* tmp = NULL;
+#else
     sp_point_1024 t[3];
     sp_digit tmp[2 * 42 * 5];
-#else
-    sp_point_1024* t;
-    sp_digit* tmp;
 #endif
     sp_digit n;
     int i;
@@ -29667,14 +29473,17 @@ static int sp_1024_ecc_mulmod_42(sp_point_1024* r, const sp_point_1024* g,
     (void)ct;
     (void)heap;
 
-#ifndef WOLFSSL_SP_NO_MALLOC
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 42 * 5, heap,
-                                                              DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 42 * 5, heap,
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
@@ -29725,19 +29534,24 @@ static int sp_1024_ecc_mulmod_42(sp_point_1024* r, const sp_point_1024* g,
         }
     }
 
-#ifndef WOLFSSL_SP_NO_MALLOC
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 42 * 5);
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_1024) * 3);
-        XFREE(t, NULL, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmp, sizeof(tmp));
-    ForceZero(t, sizeof(t));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 42 * 5);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_1024) * 3);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -30197,43 +30011,41 @@ static void sp_1024_ecc_recode_7_42(const sp_digit* k, ecc_recode_1024* v)
 static int sp_1024_ecc_mulmod_win_add_sub_42(sp_point_1024* r, const sp_point_1024* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td[65];
-    sp_point_1024 rtd;
-    sp_point_1024 pd;
-    sp_digit tmpd[2 * 42 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_1024 t[65+2];
+    sp_digit tmp[2 * 42 * 6];
 #endif
-    sp_point_1024* t;
-    sp_point_1024* rt;
+    sp_point_1024* rt = NULL;
     sp_point_1024* p = NULL;
-    sp_digit* tmp;
     sp_digit* negy;
     int i;
     ecc_recode_1024 v[147];
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_1024_point_new_42(heap, rtd, rt);
-    if (err == MP_OKAY)
-        err = sp_1024_point_new_42(heap, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 65, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 
+        (65+2), heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 42 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 42 * 6,
+                                 heap, DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
-
     if (err == MP_OKAY) {
+        rt = t + 65;
+        p  = t + 65+1;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -30317,14 +30129,12 @@ static int sp_1024_ecc_mulmod_win_add_sub_42(sp_point_1024* r, const sp_point_10
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
     if (tmp != NULL)
         XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_42(p, 0, heap);
-    sp_1024_point_free_42(rt, 0, heap);
 
     return err;
 }
@@ -30450,29 +30260,30 @@ static void sp_1024_proj_to_affine_42(sp_point_1024* a, sp_digit* t)
 static int sp_1024_gen_stripe_table_42(const sp_point_1024* a,
         sp_table_entry_1024* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td;
-    sp_point_1024 s1d;
-    sp_point_1024 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+#else
+    sp_point_1024 t[3];
 #endif
-    sp_point_1024* t;
     sp_point_1024* s1 = NULL;
     sp_point_1024* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_1024_point_new_42(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_42(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_42(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_1024_mod_mul_norm_42(t->x, a->x, p1024_mod);
     }
     if (err == MP_OKAY) {
@@ -30517,9 +30328,10 @@ static int sp_1024_gen_stripe_table_42(const sp_point_1024* a,
         }
     }
 
-    sp_1024_point_free_42(s2, 0, heap);
-    sp_1024_point_free_42(s1, 0, heap);
-    sp_1024_point_free_42( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -30545,19 +30357,19 @@ static int sp_1024_ecc_mulmod_stripe_42(sp_point_1024* r, const sp_point_1024* g
         const sp_table_entry_1024* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 rtd;
-    sp_point_1024 pd;
-    sp_digit td[2 * 42 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 rt[2];
+    sp_digit t[2 * 42 * 5];
 #endif
-    sp_point_1024* rt;
     sp_point_1024* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -30565,21 +30377,22 @@ static int sp_1024_ecc_mulmod_stripe_42(sp_point_1024* r, const sp_point_1024* g
     (void)heap;
 
 
-    err = sp_1024_point_new_42(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_42(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 42 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 42 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p1024_norm_mod, sizeof(p1024_norm_mod));
         XMEMCPY(rt->z, p1024_norm_mod, sizeof(p1024_norm_mod));
 
@@ -30615,13 +30428,12 @@ static int sp_1024_ecc_mulmod_stripe_42(sp_point_1024* r, const sp_point_1024* g
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_42(p, 0, heap);
-    sp_1024_point_free_42(rt, 0, heap);
 
     return err;
 }
@@ -30785,25 +30597,28 @@ static int sp_1024_ecc_mulmod_42(sp_point_1024* r, const sp_point_1024* g, const
 int sp_ecc_mulmod_1024(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[42];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024 point[1];
+    sp_digit k[42];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_42(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 42, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 42, km);
         sp_1024_point_from_ecc_point_42(point, gm);
@@ -30814,12 +30629,12 @@ int sp_ecc_mulmod_1024(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_1024_point_to_ecc_point_42(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_42(point, 0, heap);
 
     return err;
 }
@@ -34712,26 +34527,28 @@ static int sp_1024_ecc_mulmod_base_42(sp_point_1024* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[42];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024  point[1];
+    sp_digit k[42];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_42(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 42, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 42, km);
 
@@ -34741,12 +34558,12 @@ int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_1024_point_to_ecc_point_42(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_42(point, 0, heap);
 
     return err;
 }
@@ -34765,37 +34582,35 @@ int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_point_1024 a;
-    sp_digit kd[42];
-    sp_digit t[42 * 2 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_1024 point[2];
+    sp_digit k[42 + 42 * 2 * 5];
 #endif
-    sp_point_1024* point;
     sp_point_1024* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_42(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_1024_point_new_42(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (42 + 42 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (42 + 42 * 2 * 5),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 42;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 42;
+
         sp_1024_from_mp(k, 42, km);
         sp_1024_point_from_ecc_point_42(addP, am);
     }
@@ -34821,13 +34636,12 @@ int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
         err = sp_1024_point_to_ecc_point_42(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_42(addP, 0, heap);
-    sp_1024_point_free_42(point, 0, heap);
 
     return err;
 }
@@ -34845,29 +34659,43 @@ int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
 int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
     void* heap)
 {
-    int err = 0;
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_1024* point = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 point[1];
     sp_digit t[5 * 2 * 42];
+#endif
+    int err = MP_OKAY;
 
     if ((gm == NULL) || (len == NULL)) {
         err = BAD_FUNC_ARG;
     }
 
-    if ((err == 0) && (table == NULL)) {
+    if ((err == MP_OKAY) && (table == NULL)) {
         *len = sizeof(sp_table_entry_1024) * 256;
         err = LENGTH_ONLY_E;
     }
-    if ((err == 0) && (*len < (int)(sizeof(sp_table_entry_1024) * 256))) {
+    if ((err == MP_OKAY) && (*len < (int)(sizeof(sp_table_entry_1024) * 256))) {
         err = BUFFER_E;
     }
 
-    if (err == 0) {
-        err = sp_1024_point_new_42(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+            DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-    if (err == 0) {
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 42, heap,
+            DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
         sp_1024_point_from_ecc_point_42(point, gm);
             err = sp_1024_gen_stripe_table_42(point,
                 (sp_table_entry_1024*)table, t, heap);
@@ -34876,7 +34704,12 @@ int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
         *len = sizeof(sp_table_entry_1024) * 256;
     }
 
-    sp_1024_point_free_42(point, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -34929,24 +34762,28 @@ int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
 int sp_ecc_mulmod_table_1024(const mp_int* km, const ecc_point* gm, byte* table,
         ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[42];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024 point[1];
+    sp_digit k[42];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_42(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+        DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 42, heap, DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 42, km);
         sp_1024_point_from_ecc_point_42(point, gm);
@@ -34963,12 +34800,12 @@ int sp_ecc_mulmod_table_1024(const mp_int* km, const ecc_point* gm, byte* table,
         err = sp_1024_point_to_ecc_point_42(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_42(point, 0, heap);
 
     return err;
 }
@@ -38421,33 +38258,24 @@ static void sp_1024_from_bin(sp_digit* r, int size, const byte* a, int n)
 static int sp_1024_ecc_is_point_42(const sp_point_1024* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*42];
-    sp_digit t2d[2*42];
+    sp_digit t1[42 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int32_t n;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 42 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 42 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 42;
-        t2 = d + 2 * 42;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 42;
 
         sp_1024_sqr_42(t1, point->y);
         (void)sp_1024_mod_42(t1, t1, p1024_mod);
@@ -38471,10 +38299,9 @@ static int sp_1024_ecc_is_point_42(const sp_point_1024* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -38489,14 +38316,21 @@ static int sp_1024_ecc_is_point_42(const sp_point_1024* point,
  */
 int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* pub = NULL;
+#else
+    sp_point_1024 pub[1];
 #endif
-    sp_point_1024* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_1024_point_new_42(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(pub->x, 42, pX);
         sp_1024_from_mp(pub->y, 42, pY);
@@ -38505,7 +38339,10 @@ int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
         err = sp_1024_ecc_is_point_42(pub, NULL);
     }
 
-    sp_1024_point_free_42(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -38524,44 +38361,44 @@ int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_1024(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[42];
-    sp_point_1024 pubd;
-    sp_point_1024 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_1024* pub;
-    sp_point_1024* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_1024_point_new_42(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_42(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 42, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_1024* pub = NULL;
+#else
+    sp_digit priv[42];
+    sp_point_1024 pub[2];
 #endif
+    sp_point_1024* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 1024) ||
+    if (((mp_count_bits(pX) > 1024) ||
         (mp_count_bits(pY) > 1024) ||
         ((privm != NULL) && (mp_count_bits(privm) > 1024)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 42, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_1024_from_mp(pub->x, 42, pX);
         sp_1024_from_mp(pub->y, 42, pY);
@@ -38611,13 +38448,12 @@ int sp_ecc_check_key_1024(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_1024_point_free_42(p, 0, heap);
-    sp_1024_point_free_42(pub, 0, heap);
 
     return err;
 }

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -1435,34 +1435,25 @@ static int sp_2048_div_18(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[36];
-    sp_digit t2d[18 + 1];
+    sp_digit t1[3 * 18 + 1];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 18 + 1), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 18 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 2 * 18;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 18;
 
         dv = d[17];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 18U);
@@ -1505,10 +1496,9 @@ static int sp_2048_div_18(const sp_digit* a, const sp_digit* d,
                     (sp_digit)1 : (sp_digit)0));
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -1539,13 +1529,13 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a, const sp_digit* e,
     const sp_digit* m, int reduceA)
 {
 #ifdef WOLFSSL_SP_SMALL
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 36];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -1553,22 +1543,17 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 18 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 18 * 2);
-#else
-            t[i] = &td[i * 18 * 2];
-#endif
             XMEMSET(t[i], 0, sizeof(sp_digit) * 18U * 2U);
         }
 
@@ -1623,21 +1608,20 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a, const sp_digit* e,
 
     }
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #elif !defined(WC_NO_CACHE_RESISTANT)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 36];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -1645,22 +1629,17 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 18 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 18 * 2);
-#else
-            t[i] = &td[i * 18 * 2];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -1714,22 +1693,21 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a, const sp_digit* e,
         XMEMCPY(r, t[0], sizeof(*r) * 18 * 2);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #else
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[(32 * 36) + 36];
 #endif
     sp_digit* t[32];
     sp_digit* rt = NULL;
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -1740,22 +1718,15 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * ((32 * 36) + 36), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         for (i=0; i<32; i++)
             t[i] = td + i * 36;
         rt = td + 1152;
-#else
-        for (i=0; i<32; i++)
-            t[i] = &td[i * 36];
-        rt = &td[1152];
-#endif
 
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_18(norm, m);
@@ -1852,9 +1823,8 @@ static int sp_2048_mod_exp_18(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -2345,34 +2315,25 @@ static int sp_2048_div_36(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[72];
-    sp_digit t2d[36 + 1];
+    sp_digit t1[3 * 36 + 1];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 36 + 1), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 36 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 2 * 36;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 36;
 
         dv = d[35];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 36U);
@@ -2415,10 +2376,9 @@ static int sp_2048_div_36(const sp_digit* a, const sp_digit* d,
                     (sp_digit)1 : (sp_digit)0));
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -2451,13 +2411,13 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
     const sp_digit* m, int reduceA)
 {
 #ifdef WOLFSSL_SP_SMALL
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 72];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -2465,22 +2425,17 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 36 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 36 * 2);
-#else
-            t[i] = &td[i * 36 * 2];
-#endif
             XMEMSET(t[i], 0, sizeof(sp_digit) * 36U * 2U);
         }
 
@@ -2535,21 +2490,20 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
 
     }
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #elif !defined(WC_NO_CACHE_RESISTANT)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 72];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -2557,22 +2511,17 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 36 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 36 * 2);
-#else
-            t[i] = &td[i * 36 * 2];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -2626,22 +2575,21 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
         XMEMCPY(r, t[0], sizeof(*r) * 36 * 2);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #else
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[(32 * 72) + 72];
 #endif
     sp_digit* t[32];
     sp_digit* rt = NULL;
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -2652,22 +2600,15 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * ((32 * 72) + 72), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         for (i=0; i<32; i++)
             t[i] = td + i * 72;
         rt = td + 2304;
-#else
-        for (i=0; i<32; i++)
-            t[i] = &td[i * 72];
-        rt = &td[2304];
-#endif
 
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_36(norm, m);
@@ -2764,9 +2705,8 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -2792,8 +2732,11 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
 #ifdef WOLFSSL_SP_SMALL
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[36 * 5];
+#endif
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
@@ -2821,15 +2764,16 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 36 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 36 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
 
     if (err == MP_OKAY) {
-        a = d;
         r = a + 36 * 2;
         m = r + 36 * 2;
         norm = r;
@@ -2882,18 +2826,17 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 256;
     }
 
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+#endif
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit ad[72];
-    sp_digit md[36];
-    sp_digit rd[72];
-#else
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit d[36 * 5];
 #endif
     sp_digit* a = NULL;
     sp_digit* m = NULL;
@@ -2919,27 +2862,20 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 36 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
         a = d;
         r = a + 36 * 2;
         m = r + 36 * 2;
-    }
-#else
-    a = ad;
-    m = md;
-    r = rd;
-#endif
 
-    if (err == MP_OKAY) {
         sp_2048_from_bin(a, 36, in, inLen);
 #if DIGIT_BIT >= 57
         e[0] = (sp_digit)em->dp[0];
@@ -3003,10 +2939,9 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 256;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
 #endif
 
     return err;
@@ -3038,9 +2973,13 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SP_SMALL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[36 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -3069,13 +3008,15 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 36 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 36;
         m = a + 72;
@@ -3086,22 +3027,34 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         sp_2048_from_mp(m, 36, mm);
         err = sp_2048_mod_exp_36(r, a, d, 2048, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_2048_to_bin(r, out);
         *outLen = 256;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 36);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 36);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-    sp_digit a[72];
-    sp_digit d[36];
-    sp_digit m[36];
-    sp_digit* r = a;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* d = NULL;
+#else
+    sp_digit d[36 * 4];
+#endif
+    sp_digit* a = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
 
     (void)pm;
@@ -3128,7 +3081,20 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 36 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        a = d + 36;
+        m = a + 72;
+        r = a;
+
         sp_2048_from_bin(a, 36, in, inLen);
         sp_2048_from_mp(d, 36, dm);
         sp_2048_from_mp(m, 36, mm);
@@ -3140,14 +3106,27 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 256;
     }
 
-    XMEMSET(d, 0, sizeof(sp_digit) * 36);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 36);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
+    }
 
     return err;
-#endif /* WOLFSSL_SP_SMALL | defined(WOLFSSL_SMALL_STACK) */
+#endif /* WOLFSSL_SP_SMALL */
 #else
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SP_SMALL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[18 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
@@ -3176,22 +3155,21 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 18 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 18 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL) {
+        if (a == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
     if (err == MP_OKAY) {
-        a = t;
         p = a + 36 * 2;
         q = p + 18;
         qi = dq = dp = q + 18;
         tmpa = qi + 18;
         tmpb = tmpa + 36;
-
-        r = t + 36;
+        r = a + 36;
 
         sp_2048_from_bin(a, 36, in, inLen);
         sp_2048_from_mp(p, 18, pm);
@@ -3222,22 +3200,31 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 256;
     }
 
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 18 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+#endif
+    {
+        ForceZero(a, sizeof(sp_digit) * 18 * 11);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-    sp_digit a[36 * 2];
-    sp_digit p[18];
-    sp_digit q[18];
-    sp_digit dp[18];
-    sp_digit dq[18];
-    sp_digit qi[18];
-    sp_digit tmpa[36];
-    sp_digit tmpb[36];
-    sp_digit* r = a;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* a = NULL;
+#else
+    sp_digit a[18 * 13];
+#endif
+    sp_digit* p = NULL;
+    sp_digit* q = NULL;
+    sp_digit* dp = NULL;
+    sp_digit* dq = NULL;
+    sp_digit* qi = NULL;
+    sp_digit* tmpa = NULL;
+    sp_digit* tmpb = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
 
     (void)dm;
@@ -3258,7 +3245,25 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 18 * 13, NULL, 
+                                                              DYNAMIC_TYPE_RSA);
+        if (a == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        p = a + 36 * 2;
+        q = p + 18;
+        dp = q + 18;
+        dq = dp + 18;
+        qi = dq + 18;
+        tmpa = qi + 18;
+        tmpb = tmpa + 36;
+        r = a;
+
         sp_2048_from_bin(a, 36, in, inLen);
         sp_2048_from_mp(p, 18, pm);
         sp_2048_from_mp(q, 18, qm);
@@ -3289,17 +3294,19 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 256;
     }
 
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p, 0, sizeof(p));
-    XMEMSET(q, 0, sizeof(q));
-    XMEMSET(dp, 0, sizeof(dp));
-    XMEMSET(dq, 0, sizeof(dq));
-    XMEMSET(qi, 0, sizeof(qi));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+if (a != NULL)
+#endif
+    {
+        ForceZero(a, sizeof(sp_digit) * 18 * 13);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
 
     return err;
-#endif /* WOLFSSL_SP_SMALL | defined(WOLFSSL_SMALL_STACK) */
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+#endif /* WOLFSSL_SP_SMALL */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 }
 
 #endif /* !WOLFSSL_RSA_PUBLIC_ONLY */
@@ -3388,11 +3395,14 @@ int sp_ModExp_2048(const mp_int* base, const mp_int* exp, const mp_int* mod,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[36 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int expBits = mp_count_bits(exp);
 
     if (mp_count_bits(base) > 2048) {
@@ -3408,16 +3418,16 @@ int sp_ModExp_2048(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 36 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 36 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 36 * 2;
         m = e + 36;
         r = b;
@@ -3433,23 +3443,27 @@ int sp_ModExp_2048(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = sp_2048_to_mp(r, res);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 36U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 36U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[72];
-    sp_digit ed[36];
-    sp_digit md[36];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[36 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
     int expBits = mp_count_bits(exp);
 
@@ -3466,26 +3480,19 @@ int sp_ModExp_2048(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 36 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 36 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 36 * 2;
-        m = e + 36;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 36 * 2;
+        m = e + 36;
+        r = b;
+
         sp_2048_from_mp(b, 36, base);
         sp_2048_from_mp(e, 36, exp);
         sp_2048_from_mp(m, 36, mod);
@@ -3498,14 +3505,17 @@ int sp_ModExp_2048(const mp_int* base, const mp_int* exp, const mp_int* mod,
     }
 
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 36U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 36U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 36U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -3615,12 +3625,12 @@ SP_NOINLINE static void sp_2048_lshift_36(sp_digit* r, const sp_digit* a,
 static int sp_2048_mod_exp_2_36(sp_digit* r, const sp_digit* e, int bits, const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[109];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -3632,20 +3642,14 @@ static int sp_2048_mod_exp_2_36(sp_digit* r, const sp_digit* e, int bits, const 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 109, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp  = td + 72;
         XMEMSET(td, 0, sizeof(sp_digit) * 109);
-#else
-        tmp  = &td[72];
-        XMEMSET(td, 0, sizeof(td));
-#endif
 
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_36(norm, m);
@@ -3704,9 +3708,8 @@ static int sp_2048_mod_exp_2_36(sp_digit* r, const sp_digit* e, int bits, const 
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -3731,11 +3734,14 @@ int sp_DhExp_2048(const mp_int* base, const byte* exp, word32 expLen,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[36 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     word32 i;
 
     if (mp_count_bits(base) > 2048) {
@@ -3751,15 +3757,15 @@ int sp_DhExp_2048(const mp_int* base, const byte* exp, word32 expLen,
         err = MP_VAL;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 36 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 36 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 36 * 2;
         m = e + 36;
         r = b;
@@ -3787,23 +3793,27 @@ int sp_DhExp_2048(const mp_int* base, const byte* exp, word32 expLen,
         XMEMMOVE(out, out + i, *outLen);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 36U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 36U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[72];
-    sp_digit ed[36];
-    sp_digit md[36];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[36 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     word32 i;
     int err = MP_OKAY;
 
@@ -3820,26 +3830,20 @@ int sp_DhExp_2048(const mp_int* base, const byte* exp, word32 expLen,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 36 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 36 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 36 * 2;
-        m = e + 36;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 36 * 2;
+        m = e + 36;
+        r = b;
+
         sp_2048_from_mp(b, 36, base);
         sp_2048_from_bin(e, 36, exp, expLen);
         sp_2048_from_mp(m, 36, mod);
@@ -3867,14 +3871,17 @@ int sp_DhExp_2048(const mp_int* base, const byte* exp, word32 expLen,
         XMEMMOVE(out, out + i, *outLen);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 36U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 36U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 36U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -3895,11 +3902,14 @@ int sp_ModExp_1024(const mp_int* base, const mp_int* exp, const mp_int* mod,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[18 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int expBits = mp_count_bits(exp);
 
     if (mp_count_bits(base) > 1024) {
@@ -3915,16 +3925,16 @@ int sp_ModExp_1024(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 18 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 18 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 18 * 2;
         m = e + 18;
         r = b;
@@ -3941,23 +3951,27 @@ int sp_ModExp_1024(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = sp_2048_to_mp(r, res);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 18U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 36U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[36];
-    sp_digit ed[18];
-    sp_digit md[18];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[18 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
     int expBits = mp_count_bits(exp);
 
@@ -3974,26 +3988,19 @@ int sp_ModExp_1024(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 18 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 18 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 18 * 2;
-        m = e + 18;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 18 * 2;
+        m = e + 18;
+        r = b;
+
         sp_2048_from_mp(b, 18, base);
         sp_2048_from_mp(e, 18, exp);
         sp_2048_from_mp(m, 18, mod);
@@ -4007,14 +4014,17 @@ int sp_ModExp_1024(const mp_int* base, const mp_int* exp, const mp_int* mod,
     }
 
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 18U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 18U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 36U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -5648,34 +5658,25 @@ static int sp_3072_div_27(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[54];
-    sp_digit t2d[27 + 1];
+    sp_digit t1[3 * 27 + 1];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 27 + 1), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 27 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 2 * 27;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 27;
 
         dv = d[26];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 27U);
@@ -5718,10 +5719,9 @@ static int sp_3072_div_27(const sp_digit* a, const sp_digit* d,
                     (sp_digit)1 : (sp_digit)0));
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -5752,13 +5752,13 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a, const sp_digit* e,
     const sp_digit* m, int reduceA)
 {
 #ifdef WOLFSSL_SP_SMALL
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 54];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -5766,22 +5766,17 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 27 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 27 * 2);
-#else
-            t[i] = &td[i * 27 * 2];
-#endif
             XMEMSET(t[i], 0, sizeof(sp_digit) * 27U * 2U);
         }
 
@@ -5836,21 +5831,20 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a, const sp_digit* e,
 
     }
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #elif !defined(WC_NO_CACHE_RESISTANT)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 54];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -5858,22 +5852,17 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 27 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 27 * 2);
-#else
-            t[i] = &td[i * 27 * 2];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -5927,22 +5916,21 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a, const sp_digit* e,
         XMEMCPY(r, t[0], sizeof(*r) * 27 * 2);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #else
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[(32 * 54) + 54];
 #endif
     sp_digit* t[32];
     sp_digit* rt = NULL;
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -5953,22 +5941,15 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * ((32 * 54) + 54), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         for (i=0; i<32; i++)
             t[i] = td + i * 54;
         rt = td + 1728;
-#else
-        for (i=0; i<32; i++)
-            t[i] = &td[i * 54];
-        rt = &td[1728];
-#endif
 
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_27(norm, m);
@@ -6065,9 +6046,8 @@ static int sp_3072_mod_exp_27(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -6563,34 +6543,25 @@ static int sp_3072_div_54(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[108];
-    sp_digit t2d[54 + 1];
+    sp_digit t1[3 * 54 + 1];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 54 + 1), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 54 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 2 * 54;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 54;
 
         dv = d[53];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 54U);
@@ -6633,10 +6604,9 @@ static int sp_3072_div_54(const sp_digit* a, const sp_digit* d,
                     (sp_digit)1 : (sp_digit)0));
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -6669,13 +6639,13 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
     const sp_digit* m, int reduceA)
 {
 #ifdef WOLFSSL_SP_SMALL
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 108];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -6683,22 +6653,17 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 54 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 54 * 2);
-#else
-            t[i] = &td[i * 54 * 2];
-#endif
             XMEMSET(t[i], 0, sizeof(sp_digit) * 54U * 2U);
         }
 
@@ -6753,21 +6718,20 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
 
     }
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #elif !defined(WC_NO_CACHE_RESISTANT)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 108];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -6775,22 +6739,17 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 54 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 54 * 2);
-#else
-            t[i] = &td[i * 54 * 2];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -6844,22 +6803,21 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
         XMEMCPY(r, t[0], sizeof(*r) * 54 * 2);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #else
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[(32 * 108) + 108];
 #endif
     sp_digit* t[32];
     sp_digit* rt = NULL;
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -6870,22 +6828,15 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * ((32 * 108) + 108), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         for (i=0; i<32; i++)
             t[i] = td + i * 108;
         rt = td + 3456;
-#else
-        for (i=0; i<32; i++)
-            t[i] = &td[i * 108];
-        rt = &td[3456];
-#endif
 
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_54(norm, m);
@@ -6982,9 +6933,8 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -7010,8 +6960,11 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
 #ifdef WOLFSSL_SP_SMALL
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[54 * 5];
+#endif
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
@@ -7039,15 +6992,16 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 54 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 54 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
 
     if (err == MP_OKAY) {
-        a = d;
         r = a + 54 * 2;
         m = r + 54 * 2;
         norm = r;
@@ -7100,18 +7054,17 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 384;
     }
 
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+#endif
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit ad[108];
-    sp_digit md[54];
-    sp_digit rd[108];
-#else
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit d[54 * 5];
 #endif
     sp_digit* a = NULL;
     sp_digit* m = NULL;
@@ -7137,27 +7090,20 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 54 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
         a = d;
         r = a + 54 * 2;
         m = r + 54 * 2;
-    }
-#else
-    a = ad;
-    m = md;
-    r = rd;
-#endif
 
-    if (err == MP_OKAY) {
         sp_3072_from_bin(a, 54, in, inLen);
 #if DIGIT_BIT >= 57
         e[0] = (sp_digit)em->dp[0];
@@ -7221,10 +7167,9 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 384;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
 #endif
 
     return err;
@@ -7256,9 +7201,13 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SP_SMALL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[54 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -7287,13 +7236,15 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 54 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 54;
         m = a + 108;
@@ -7304,22 +7255,34 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_from_mp(m, 54, mm);
         err = sp_3072_mod_exp_54(r, a, d, 3072, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_3072_to_bin(r, out);
         *outLen = 384;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 54);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 54);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-    sp_digit a[108];
-    sp_digit d[54];
-    sp_digit m[54];
-    sp_digit* r = a;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* d = NULL;
+#else
+    sp_digit d[54 * 4];
+#endif
+    sp_digit* a = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
 
     (void)pm;
@@ -7346,7 +7309,20 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 54 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        a = d + 54;
+        m = a + 108;
+        r = a;
+
         sp_3072_from_bin(a, 54, in, inLen);
         sp_3072_from_mp(d, 54, dm);
         sp_3072_from_mp(m, 54, mm);
@@ -7358,14 +7334,27 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 384;
     }
 
-    XMEMSET(d, 0, sizeof(sp_digit) * 54);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 54);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
+    }
 
     return err;
-#endif /* WOLFSSL_SP_SMALL | defined(WOLFSSL_SMALL_STACK) */
+#endif /* WOLFSSL_SP_SMALL */
 #else
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SP_SMALL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[27 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
@@ -7394,22 +7383,21 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 27 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 27 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL) {
+        if (a == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
     if (err == MP_OKAY) {
-        a = t;
         p = a + 54 * 2;
         q = p + 27;
         qi = dq = dp = q + 27;
         tmpa = qi + 27;
         tmpb = tmpa + 54;
-
-        r = t + 54;
+        r = a + 54;
 
         sp_3072_from_bin(a, 54, in, inLen);
         sp_3072_from_mp(p, 27, pm);
@@ -7440,22 +7428,31 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 384;
     }
 
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 27 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+#endif
+    {
+        ForceZero(a, sizeof(sp_digit) * 27 * 11);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-    sp_digit a[54 * 2];
-    sp_digit p[27];
-    sp_digit q[27];
-    sp_digit dp[27];
-    sp_digit dq[27];
-    sp_digit qi[27];
-    sp_digit tmpa[54];
-    sp_digit tmpb[54];
-    sp_digit* r = a;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* a = NULL;
+#else
+    sp_digit a[27 * 13];
+#endif
+    sp_digit* p = NULL;
+    sp_digit* q = NULL;
+    sp_digit* dp = NULL;
+    sp_digit* dq = NULL;
+    sp_digit* qi = NULL;
+    sp_digit* tmpa = NULL;
+    sp_digit* tmpb = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
 
     (void)dm;
@@ -7476,7 +7473,25 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 27 * 13, NULL, 
+                                                              DYNAMIC_TYPE_RSA);
+        if (a == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        p = a + 54 * 2;
+        q = p + 27;
+        dp = q + 27;
+        dq = dp + 27;
+        qi = dq + 27;
+        tmpa = qi + 27;
+        tmpb = tmpa + 54;
+        r = a;
+
         sp_3072_from_bin(a, 54, in, inLen);
         sp_3072_from_mp(p, 27, pm);
         sp_3072_from_mp(q, 27, qm);
@@ -7507,17 +7522,19 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 384;
     }
 
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p, 0, sizeof(p));
-    XMEMSET(q, 0, sizeof(q));
-    XMEMSET(dp, 0, sizeof(dp));
-    XMEMSET(dq, 0, sizeof(dq));
-    XMEMSET(qi, 0, sizeof(qi));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+if (a != NULL)
+#endif
+    {
+        ForceZero(a, sizeof(sp_digit) * 27 * 13);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
 
     return err;
-#endif /* WOLFSSL_SP_SMALL | defined(WOLFSSL_SMALL_STACK) */
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+#endif /* WOLFSSL_SP_SMALL */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 }
 
 #endif /* !WOLFSSL_RSA_PUBLIC_ONLY */
@@ -7606,11 +7623,14 @@ int sp_ModExp_3072(const mp_int* base, const mp_int* exp, const mp_int* mod,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[54 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int expBits = mp_count_bits(exp);
 
     if (mp_count_bits(base) > 3072) {
@@ -7626,16 +7646,16 @@ int sp_ModExp_3072(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 54 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 54 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 54 * 2;
         m = e + 54;
         r = b;
@@ -7651,23 +7671,27 @@ int sp_ModExp_3072(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = sp_3072_to_mp(r, res);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 54U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 54U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[108];
-    sp_digit ed[54];
-    sp_digit md[54];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[54 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
     int expBits = mp_count_bits(exp);
 
@@ -7684,26 +7708,19 @@ int sp_ModExp_3072(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 54 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 54 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 54 * 2;
-        m = e + 54;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 54 * 2;
+        m = e + 54;
+        r = b;
+
         sp_3072_from_mp(b, 54, base);
         sp_3072_from_mp(e, 54, exp);
         sp_3072_from_mp(m, 54, mod);
@@ -7716,14 +7733,17 @@ int sp_ModExp_3072(const mp_int* base, const mp_int* exp, const mp_int* mod,
     }
 
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 54U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 54U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 54U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -7869,12 +7889,12 @@ SP_NOINLINE static void sp_3072_lshift_54(sp_digit* r, const sp_digit* a,
 static int sp_3072_mod_exp_2_54(sp_digit* r, const sp_digit* e, int bits, const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[163];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -7886,20 +7906,14 @@ static int sp_3072_mod_exp_2_54(sp_digit* r, const sp_digit* e, int bits, const 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 163, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp  = td + 108;
         XMEMSET(td, 0, sizeof(sp_digit) * 163);
-#else
-        tmp  = &td[108];
-        XMEMSET(td, 0, sizeof(td));
-#endif
 
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_54(norm, m);
@@ -7958,9 +7972,8 @@ static int sp_3072_mod_exp_2_54(sp_digit* r, const sp_digit* e, int bits, const 
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -7985,11 +7998,14 @@ int sp_DhExp_3072(const mp_int* base, const byte* exp, word32 expLen,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[54 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     word32 i;
 
     if (mp_count_bits(base) > 3072) {
@@ -8005,15 +8021,15 @@ int sp_DhExp_3072(const mp_int* base, const byte* exp, word32 expLen,
         err = MP_VAL;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 54 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 54 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 54 * 2;
         m = e + 54;
         r = b;
@@ -8041,23 +8057,27 @@ int sp_DhExp_3072(const mp_int* base, const byte* exp, word32 expLen,
         XMEMMOVE(out, out + i, *outLen);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 54U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 54U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[108];
-    sp_digit ed[54];
-    sp_digit md[54];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[54 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     word32 i;
     int err = MP_OKAY;
 
@@ -8074,26 +8094,20 @@ int sp_DhExp_3072(const mp_int* base, const byte* exp, word32 expLen,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 54 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 54 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 54 * 2;
-        m = e + 54;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 54 * 2;
+        m = e + 54;
+        r = b;
+
         sp_3072_from_mp(b, 54, base);
         sp_3072_from_bin(e, 54, exp, expLen);
         sp_3072_from_mp(m, 54, mod);
@@ -8121,14 +8135,17 @@ int sp_DhExp_3072(const mp_int* base, const byte* exp, word32 expLen,
         XMEMMOVE(out, out + i, *outLen);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 54U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 54U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 54U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -8149,11 +8166,14 @@ int sp_ModExp_1536(const mp_int* base, const mp_int* exp, const mp_int* mod,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[27 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int expBits = mp_count_bits(exp);
 
     if (mp_count_bits(base) > 1536) {
@@ -8169,16 +8189,16 @@ int sp_ModExp_1536(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 27 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 27 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 27 * 2;
         m = e + 27;
         r = b;
@@ -8195,23 +8215,27 @@ int sp_ModExp_1536(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = sp_3072_to_mp(r, res);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 27U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 54U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[54];
-    sp_digit ed[27];
-    sp_digit md[27];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[27 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
     int expBits = mp_count_bits(exp);
 
@@ -8228,26 +8252,19 @@ int sp_ModExp_1536(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 27 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 27 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 27 * 2;
-        m = e + 27;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 27 * 2;
+        m = e + 27;
+        r = b;
+
         sp_3072_from_mp(b, 27, base);
         sp_3072_from_mp(e, 27, exp);
         sp_3072_from_mp(m, 27, mod);
@@ -8261,14 +8278,17 @@ int sp_ModExp_1536(const mp_int* base, const mp_int* exp, const mp_int* mod,
     }
 
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 27U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 27U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 54U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -9969,40 +9989,29 @@ static int sp_4096_div_39(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[78 + 1];
-    sp_digit t2d[39 + 1];
-    sp_digit sdd[39 + 1];
+    sp_digit t1[4 * 39 + 3];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* sd;
+    sp_digit* t2 = NULL;
+    sp_digit* sd = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 39 + 3), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 39 + 3), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     (void)m;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 78 + 1;
+        t2 = t1 + 78 + 1;
         sd = t2 + 39 + 1;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        sd = sdd;
-#endif
 
         sp_4096_mul_d_39(sd, d, 1L << 19);
         sp_4096_mul_d_78(t1, a, 1L << 19);
@@ -10049,10 +10058,9 @@ static int sp_4096_div_39(const sp_digit* a, const sp_digit* d,
         sp_4096_rshift_39(r, r, 19);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -10083,13 +10091,13 @@ static int sp_4096_mod_exp_39(sp_digit* r, const sp_digit* a, const sp_digit* e,
     const sp_digit* m, int reduceA)
 {
 #ifdef WOLFSSL_SP_SMALL
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 78];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -10097,22 +10105,17 @@ static int sp_4096_mod_exp_39(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 39 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 39 * 2);
-#else
-            t[i] = &td[i * 39 * 2];
-#endif
             XMEMSET(t[i], 0, sizeof(sp_digit) * 39U * 2U);
         }
 
@@ -10167,21 +10170,20 @@ static int sp_4096_mod_exp_39(sp_digit* r, const sp_digit* a, const sp_digit* e,
 
     }
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #elif !defined(WC_NO_CACHE_RESISTANT)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 78];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -10189,22 +10191,17 @@ static int sp_4096_mod_exp_39(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 39 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 39 * 2);
-#else
-            t[i] = &td[i * 39 * 2];
-#endif
         }
 
         sp_4096_mont_setup(m, &mp);
@@ -10258,22 +10255,21 @@ static int sp_4096_mod_exp_39(sp_digit* r, const sp_digit* a, const sp_digit* e,
         XMEMCPY(r, t[0], sizeof(*r) * 39 * 2);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #else
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[(32 * 78) + 78];
 #endif
     sp_digit* t[32];
     sp_digit* rt = NULL;
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -10284,22 +10280,15 @@ static int sp_4096_mod_exp_39(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * ((32 * 78) + 78), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         for (i=0; i<32; i++)
             t[i] = td + i * 78;
         rt = td + 2496;
-#else
-        for (i=0; i<32; i++)
-            t[i] = &td[i * 78];
-        rt = &td[2496];
-#endif
 
         sp_4096_mont_setup(m, &mp);
         sp_4096_mont_norm_39(norm, m);
@@ -10396,9 +10385,8 @@ static int sp_4096_mod_exp_39(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -10945,40 +10933,29 @@ static int sp_4096_div_78(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[156 + 1];
-    sp_digit t2d[78 + 1];
-    sp_digit sdd[78 + 1];
+    sp_digit t1[4 * 78 + 3];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* sd;
+    sp_digit* t2 = NULL;
+    sp_digit* sd = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 78 + 3), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (4 * 78 + 3), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     (void)m;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 156 + 1;
+        t2 = t1 + 156 + 1;
         sd = t2 + 78 + 1;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        sd = sdd;
-#endif
 
         sp_4096_mul_d_78(sd, d, 1L << 38);
         sp_4096_mul_d_156(t1, a, 1L << 38);
@@ -11025,10 +11002,9 @@ static int sp_4096_div_78(const sp_digit* a, const sp_digit* d,
         sp_4096_rshift_78(r, r, 38);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -11061,13 +11037,13 @@ static int sp_4096_mod_exp_78(sp_digit* r, const sp_digit* a, const sp_digit* e,
     const sp_digit* m, int reduceA)
 {
 #ifdef WOLFSSL_SP_SMALL
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 156];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -11075,22 +11051,17 @@ static int sp_4096_mod_exp_78(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 78 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 78 * 2);
-#else
-            t[i] = &td[i * 78 * 2];
-#endif
             XMEMSET(t[i], 0, sizeof(sp_digit) * 78U * 2U);
         }
 
@@ -11145,21 +11116,20 @@ static int sp_4096_mod_exp_78(sp_digit* r, const sp_digit* a, const sp_digit* e,
 
     }
 
-#if !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #elif !defined(WC_NO_CACHE_RESISTANT)
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[3 * 156];
 #endif
-    sp_digit* t[3];
-    sp_digit* norm;
+    sp_digit* t[3] = {0, 0, 0};
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -11167,22 +11137,17 @@ static int sp_4096_mod_exp_78(sp_digit* r, const sp_digit* a, const sp_digit* e,
     byte y;
     int err = MP_OKAY;
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 3 * 78 * 2, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<3; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + (i * 78 * 2);
-#else
-            t[i] = &td[i * 78 * 2];
-#endif
         }
 
         sp_4096_mont_setup(m, &mp);
@@ -11236,22 +11201,21 @@ static int sp_4096_mod_exp_78(sp_digit* r, const sp_digit* a, const sp_digit* e,
         XMEMCPY(r, t[0], sizeof(*r) * 78 * 2);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (td != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
 #else
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[(32 * 156) + 156];
 #endif
     sp_digit* t[32];
     sp_digit* rt = NULL;
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     int i;
@@ -11262,22 +11226,15 @@ static int sp_4096_mod_exp_78(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * ((32 * 156) + 156), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         for (i=0; i<32; i++)
             t[i] = td + i * 156;
         rt = td + 4992;
-#else
-        for (i=0; i<32; i++)
-            t[i] = &td[i * 156];
-        rt = &td[4992];
-#endif
 
         sp_4096_mont_setup(m, &mp);
         sp_4096_mont_norm_78(norm, m);
@@ -11374,9 +11331,8 @@ static int sp_4096_mod_exp_78(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -11402,8 +11358,11 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
 #ifdef WOLFSSL_SP_SMALL
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[78 * 5];
+#endif
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     sp_digit* norm = NULL;
@@ -11431,15 +11390,16 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 78 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 78 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
 
     if (err == MP_OKAY) {
-        a = d;
         r = a + 78 * 2;
         m = r + 78 * 2;
         norm = r;
@@ -11492,18 +11452,17 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 512;
     }
 
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+#endif
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit ad[156];
-    sp_digit md[78];
-    sp_digit rd[156];
-#else
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit d[78 * 5];
 #endif
     sp_digit* a = NULL;
     sp_digit* m = NULL;
@@ -11529,27 +11488,20 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 78 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
         a = d;
         r = a + 78 * 2;
         m = r + 78 * 2;
-    }
-#else
-    a = ad;
-    m = md;
-    r = rd;
-#endif
 
-    if (err == MP_OKAY) {
         sp_4096_from_bin(a, 78, in, inLen);
 #if DIGIT_BIT >= 53
         e[0] = (sp_digit)em->dp[0];
@@ -11613,10 +11565,9 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 512;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
 #endif
 
     return err;
@@ -11648,9 +11599,13 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SP_SMALL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[78 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -11679,13 +11634,15 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 78 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 78;
         m = a + 156;
@@ -11696,22 +11653,34 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_from_mp(m, 78, mm);
         err = sp_4096_mod_exp_78(r, a, d, 4096, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_4096_to_bin(r, out);
         *outLen = 512;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 78);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 78);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-    sp_digit a[156];
-    sp_digit d[78];
-    sp_digit m[78];
-    sp_digit* r = a;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* d = NULL;
+#else
+    sp_digit d[78 * 4];
+#endif
+    sp_digit* a = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
 
     (void)pm;
@@ -11738,7 +11707,20 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
+        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 78 * 4, NULL,
+                                                              DYNAMIC_TYPE_RSA);
+        if (d == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        a = d + 78;
+        m = a + 156;
+        r = a;
+
         sp_4096_from_bin(a, 78, in, inLen);
         sp_4096_from_mp(d, 78, dm);
         sp_4096_from_mp(m, 78, mm);
@@ -11750,14 +11732,27 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 512;
     }
 
-    XMEMSET(d, 0, sizeof(sp_digit) * 78);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 78);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
+    }
 
     return err;
-#endif /* WOLFSSL_SP_SMALL | defined(WOLFSSL_SMALL_STACK) */
+#endif /* WOLFSSL_SP_SMALL */
 #else
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SP_SMALL)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[39 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
@@ -11786,22 +11781,21 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 39 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 39 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL) {
+        if (a == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
     if (err == MP_OKAY) {
-        a = t;
         p = a + 78 * 2;
         q = p + 39;
         qi = dq = dp = q + 39;
         tmpa = qi + 39;
         tmpb = tmpa + 78;
-
-        r = t + 78;
+        r = a + 78;
 
         sp_4096_from_bin(a, 78, in, inLen);
         sp_4096_from_mp(p, 39, pm);
@@ -11832,22 +11826,31 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 512;
     }
 
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 39 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+#endif
+    {
+        ForceZero(a, sizeof(sp_digit) * 39 * 11);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-    sp_digit a[78 * 2];
-    sp_digit p[39];
-    sp_digit q[39];
-    sp_digit dp[39];
-    sp_digit dq[39];
-    sp_digit qi[39];
-    sp_digit tmpa[78];
-    sp_digit tmpb[78];
-    sp_digit* r = a;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* a = NULL;
+#else
+    sp_digit a[39 * 13];
+#endif
+    sp_digit* p = NULL;
+    sp_digit* q = NULL;
+    sp_digit* dp = NULL;
+    sp_digit* dq = NULL;
+    sp_digit* qi = NULL;
+    sp_digit* tmpa = NULL;
+    sp_digit* tmpb = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
 
     (void)dm;
@@ -11868,7 +11871,25 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 39 * 13, NULL, 
+                                                              DYNAMIC_TYPE_RSA);
+        if (a == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        p = a + 78 * 2;
+        q = p + 39;
+        dp = q + 39;
+        dq = dp + 39;
+        qi = dq + 39;
+        tmpa = qi + 39;
+        tmpb = tmpa + 78;
+        r = a;
+
         sp_4096_from_bin(a, 78, in, inLen);
         sp_4096_from_mp(p, 39, pm);
         sp_4096_from_mp(q, 39, qm);
@@ -11899,17 +11920,19 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 512;
     }
 
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p, 0, sizeof(p));
-    XMEMSET(q, 0, sizeof(q));
-    XMEMSET(dp, 0, sizeof(dp));
-    XMEMSET(dq, 0, sizeof(dq));
-    XMEMSET(qi, 0, sizeof(qi));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+if (a != NULL)
+#endif
+    {
+        ForceZero(a, sizeof(sp_digit) * 39 * 13);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
 
     return err;
-#endif /* WOLFSSL_SP_SMALL | defined(WOLFSSL_SMALL_STACK) */
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+#endif /* WOLFSSL_SP_SMALL */
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
 }
 
 #endif /* !WOLFSSL_RSA_PUBLIC_ONLY */
@@ -11998,11 +12021,14 @@ int sp_ModExp_4096(const mp_int* base, const mp_int* exp, const mp_int* mod,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[78 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int expBits = mp_count_bits(exp);
 
     if (mp_count_bits(base) > 4096) {
@@ -12018,16 +12044,16 @@ int sp_ModExp_4096(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 78 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 78 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 78 * 2;
         m = e + 78;
         r = b;
@@ -12043,23 +12069,27 @@ int sp_ModExp_4096(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = sp_4096_to_mp(r, res);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 78U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 78U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[156];
-    sp_digit ed[78];
-    sp_digit md[78];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[78 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     int err = MP_OKAY;
     int expBits = mp_count_bits(exp);
 
@@ -12076,26 +12106,19 @@ int sp_ModExp_4096(const mp_int* base, const mp_int* exp, const mp_int* mod,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 78 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 78 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 78 * 2;
-        m = e + 78;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 78 * 2;
+        m = e + 78;
+        r = b;
+
         sp_4096_from_mp(b, 78, base);
         sp_4096_from_mp(e, 78, exp);
         sp_4096_from_mp(m, 78, mod);
@@ -12108,14 +12131,17 @@ int sp_ModExp_4096(const mp_int* base, const mp_int* exp, const mp_int* mod,
     }
 
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 78U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 78U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 78U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -12309,12 +12335,12 @@ SP_NOINLINE static void sp_4096_lshift_78(sp_digit* r, const sp_digit* a,
 static int sp_4096_mod_exp_2_78(sp_digit* r, const sp_digit* e, int bits, const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[235];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -12326,20 +12352,14 @@ static int sp_4096_mod_exp_2_78(sp_digit* r, const sp_digit* e, int bits, const 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 235, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp  = td + 156;
         XMEMSET(td, 0, sizeof(sp_digit) * 235);
-#else
-        tmp  = &td[156];
-        XMEMSET(td, 0, sizeof(td));
-#endif
 
         sp_4096_mont_setup(m, &mp);
         sp_4096_mont_norm_78(norm, m);
@@ -12398,9 +12418,8 @@ static int sp_4096_mod_exp_2_78(sp_digit* r, const sp_digit* e, int bits, const 
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -12425,11 +12444,14 @@ int sp_DhExp_4096(const mp_int* base, const byte* exp, word32 expLen,
 {
 #ifdef WOLFSSL_SP_SMALL
     int err = MP_OKAY;
-    sp_digit* d = NULL;
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
+#else
+    sp_digit b[78 * 4];
+#endif
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     word32 i;
 
     if (mp_count_bits(base) > 4096) {
@@ -12445,15 +12467,15 @@ int sp_DhExp_4096(const mp_int* base, const byte* exp, word32 expLen,
         err = MP_VAL;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 78 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL) {
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 78 * 4, NULL, DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
 
     if (err == MP_OKAY) {
-        b = d;
         e = b + 78 * 2;
         m = e + 78;
         r = b;
@@ -12481,23 +12503,27 @@ int sp_DhExp_4096(const mp_int* base, const byte* exp, word32 expLen,
         XMEMMOVE(out, out + i, *outLen);
     }
 
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 78U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
+#endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 78U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
     }
     return err;
 #else
-#ifndef WOLFSSL_SMALL_STACK
-    sp_digit bd[156];
-    sp_digit ed[78];
-    sp_digit md[78];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* b = NULL;
 #else
-    sp_digit* d = NULL;
+    sp_digit b[78 * 4];
 #endif
-    sp_digit* b;
-    sp_digit* e;
-    sp_digit* m;
-    sp_digit* r;
+    sp_digit* e = NULL;
+    sp_digit* m = NULL;
+    sp_digit* r = NULL;
     word32 i;
     int err = MP_OKAY;
 
@@ -12514,26 +12540,20 @@ int sp_DhExp_4096(const mp_int* base, const byte* exp, word32 expLen,
         err = MP_VAL;
     }
 
-#ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(*d) * 78 * 4, NULL, DYNAMIC_TYPE_DH);
-        if (d == NULL)
+        b = (sp_digit*)XMALLOC(sizeof(sp_digit) * 78 * 4, NULL,
+            DYNAMIC_TYPE_DH);
+        if (b == NULL)
             err = MEMORY_E;
     }
-
-    if (err == MP_OKAY) {
-        b = d;
-        e = b + 78 * 2;
-        m = e + 78;
-        r = b;
-    }
-#else
-    r = b = bd;
-    e = ed;
-    m = md;
 #endif
 
     if (err == MP_OKAY) {
+        e = b + 78 * 2;
+        m = e + 78;
+        r = b;
+
         sp_4096_from_mp(b, 78, base);
         sp_4096_from_bin(e, 78, exp, expLen);
         sp_4096_from_mp(m, 78, mod);
@@ -12561,14 +12581,17 @@ int sp_DhExp_4096(const mp_int* base, const byte* exp, word32 expLen,
         XMEMMOVE(out, out + i, *outLen);
     }
 
-#ifdef WOLFSSL_SMALL_STACK
-    if (d != NULL) {
-        XMEMSET(e, 0, sizeof(sp_digit) * 78U);
-        XFREE(d, NULL, DYNAMIC_TYPE_DH);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 78U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (b != NULL)
 #endif
+    {
+        /* only "e" is sensitive and needs zeroized */
+        if (e != NULL)
+            ForceZero(e, sizeof(sp_digit) * 78U);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(b, NULL, DYNAMIC_TYPE_DH);
+    #endif
+    }
 
     return err;
 #endif
@@ -12900,64 +12923,6 @@ SP_NOINLINE static int sp_256_sub_5(sp_digit* r, const sp_digit* a,
 }
 
 #endif /* WOLFSSL_SP_SMALL */
-/* Create a new point.
- *
- * heap  [in]   Buffer to allocate dynamic memory from.
- * sp    [in]   Data for point - only if not allocating.
- * p     [out]  New point.
- * returns MEMORY_E when dynamic memory allocation fails and 0 otherwise.
- */
-static int sp_256_point_new_ex_5(void* heap, sp_point_256* sp,
-    sp_point_256** p)
-{
-    int ret = MP_OKAY;
-    (void)heap;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    (void)sp;
-    *p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap, DYNAMIC_TYPE_ECC);
-#else
-    *p = sp;
-#endif
-    if (*p == NULL) {
-        ret = MEMORY_E;
-    }
-    return ret;
-}
-
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* Allocate memory for point and return error. */
-#define sp_256_point_new_5(heap, sp, p) sp_256_point_new_ex_5((heap), NULL, &(p))
-#else
-/* Set pointer to data and return no error. */
-#define sp_256_point_new_5(heap, sp, p) sp_256_point_new_ex_5((heap), &(sp), &(p))
-#endif
-
-
-/* Free the point.
- *
- * p      [in,out]  Point to free.
- * clear  [in]      Indicates whether to zeroize point.
- * heap   [in]      Buffer from which dynamic memory was allocate from.
- */
-static void sp_256_point_free_5(sp_point_256* p, int clear, void* heap)
-{
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* If valid pointer then clear point data if requested and free data. */
-    if (p != NULL) {
-        if (clear != 0) {
-            XMEMSET(p, 0, sizeof(*p));
-        }
-        XFREE(p, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-/* Clear point data if requested. */
-    if ((p != NULL) && (clear != 0)) {
-        XMEMSET(p, 0, sizeof(*p));
-    }
-#endif
-    (void)heap;
-}
-
 /* Convert an mp_int to an array of sp_digit.
  *
  * r  A single precision integer.
@@ -14147,34 +14112,25 @@ static void sp_256_proj_point_add_5(sp_point_256* r,
  */
 static int sp_256_mod_mul_norm_5(sp_digit* r, const sp_digit* a, const sp_digit* m)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    int64_t* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    int64_t* t = NULL;
 #else
-    int64_t td[8];
-    int64_t a32d[8];
+    int64_t t[2 * 8];
 #endif
-    int64_t* t;
-    int64_t* a32;
+    int64_t* a32 = NULL;
     int64_t o;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (td == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 8, NULL, DYNAMIC_TYPE_ECC);
+    if (t == NULL)
         return MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t = td;
-        a32 = td + 8;
-#else
-        t = td;
-        a32 = a32d;
-#endif
+        a32 = t + 8;
 
         a32[0] = (sp_digit)(a[0]) & 0xffffffffL;
         a32[1] = (sp_digit)(a[0] >> 32U);
@@ -14248,10 +14204,9 @@ static int sp_256_mod_mul_norm_5(sp_digit* r, const sp_digit* a, const sp_digit*
         r[4] |= t[7] << 16U;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -14391,12 +14346,12 @@ static int sp_256_ecc_mulmod_5_nb(sp_ecc_ctx_t* sp_ctx, sp_point_256* r,
 static int sp_256_ecc_mulmod_5(sp_point_256* r, const sp_point_256* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#ifdef WOLFSSL_SP_NO_MALLOC
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+    sp_digit* tmp = NULL;
+#else
     sp_point_256 t[3];
     sp_digit tmp[2 * 5 * 5];
-#else
-    sp_point_256* t;
-    sp_digit* tmp;
 #endif
     sp_digit n;
     int i;
@@ -14408,14 +14363,17 @@ static int sp_256_ecc_mulmod_5(sp_point_256* r, const sp_point_256* g,
     (void)ct;
     (void)heap;
 
-#ifndef WOLFSSL_SP_NO_MALLOC
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 5 * 5, heap,
-                                                              DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 5 * 5, heap,
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
@@ -14466,19 +14424,24 @@ static int sp_256_ecc_mulmod_5(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#ifndef WOLFSSL_SP_NO_MALLOC
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 5 * 5);
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_256) * 3);
-        XFREE(t, NULL, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmp, sizeof(tmp));
-    ForceZero(t, sizeof(t));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 5 * 5);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_256) * 3);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -14904,43 +14867,41 @@ static void sp_256_get_point_33_5(sp_point_256* r, const sp_point_256* table,
 static int sp_256_ecc_mulmod_win_add_sub_5(sp_point_256* r, const sp_point_256* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td[33];
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit tmpd[2 * 5 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_256 t[33+2];
+    sp_digit tmp[2 * 5 * 6];
 #endif
-    sp_point_256* t;
-    sp_point_256* rt;
+    sp_point_256* rt = NULL;
     sp_point_256* p = NULL;
-    sp_digit* tmp;
     sp_digit* negy;
     int i;
     ecc_recode_256 v[43];
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_256_point_new_5(heap, rtd, rt);
-    if (err == MP_OKAY)
-        err = sp_256_point_new_5(heap, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 33, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 
+        (33+2), heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 5 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 5 * 6,
+                                 heap, DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
-
     if (err == MP_OKAY) {
+        rt = t + 33;
+        p  = t + 33+1;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -15020,14 +14981,12 @@ static int sp_256_ecc_mulmod_win_add_sub_5(sp_point_256* r, const sp_point_256* 
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
     if (tmp != NULL)
         XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_5(p, 0, heap);
-    sp_256_point_free_5(rt, 0, heap);
 
     return err;
 }
@@ -15153,29 +15112,30 @@ static void sp_256_proj_to_affine_5(sp_point_256* a, sp_digit* t)
 static int sp_256_gen_stripe_table_5(const sp_point_256* a,
         sp_table_entry_256* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td;
-    sp_point_256 s1d;
-    sp_point_256 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+#else
+    sp_point_256 t[3];
 #endif
-    sp_point_256* t;
     sp_point_256* s1 = NULL;
     sp_point_256* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_256_point_new_5(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_5(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_5(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_256_mod_mul_norm_5(t->x, a->x, p256_mod);
     }
     if (err == MP_OKAY) {
@@ -15220,9 +15180,10 @@ static int sp_256_gen_stripe_table_5(const sp_point_256* a,
         }
     }
 
-    sp_256_point_free_5(s2, 0, heap);
-    sp_256_point_free_5(s1, 0, heap);
-    sp_256_point_free_5( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -15286,19 +15247,19 @@ static int sp_256_ecc_mulmod_stripe_5(sp_point_256* r, const sp_point_256* g,
         const sp_table_entry_256* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit td[2 * 5 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_256 rt[2];
+    sp_digit t[2 * 5 * 5];
 #endif
-    sp_point_256* rt;
     sp_point_256* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -15306,21 +15267,22 @@ static int sp_256_ecc_mulmod_stripe_5(sp_point_256* r, const sp_point_256* g,
     (void)heap;
 
 
-    err = sp_256_point_new_5(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_5(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 5 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 5 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p256_norm_mod, sizeof(p256_norm_mod));
         XMEMCPY(rt->z, p256_norm_mod, sizeof(p256_norm_mod));
 
@@ -15371,13 +15333,12 @@ static int sp_256_ecc_mulmod_stripe_5(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_5(p, 0, heap);
-    sp_256_point_free_5(rt, 0, heap);
 
     return err;
 }
@@ -15541,25 +15502,28 @@ static int sp_256_ecc_mulmod_5(sp_point_256* r, const sp_point_256* g, const sp_
 int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[5];
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[1];
+    sp_digit k[5];
+#endif
     int err = MP_OKAY;
 
-    err = sp_256_point_new_5(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(k, 5, km);
         sp_256_point_from_ecc_point_5(point, gm);
@@ -15570,12 +15534,12 @@ int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_256_point_to_ecc_point_5(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_5(point, 0, heap);
 
     return err;
 }
@@ -15595,37 +15559,35 @@ int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
 int sp_ecc_mulmod_add_256(const mp_int* km, const ecc_point* gm,
     const ecc_point* am, int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_point_256 a;
-    sp_digit kd[5];
-    sp_digit t[5 * 2 * 5];
-#endif
-    sp_point_256* point;
-    sp_point_256* addP = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;    
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[2];
+    sp_digit k[5 + 5 * 2 * 5];
+#endif
+    sp_point_256* addP = NULL;
     sp_digit* tmp = NULL;
     int err = MP_OKAY;
 
-    err = sp_256_point_new_5(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_256_point_new_5(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (5 + 5 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (5 + 5 * 2 * 5), heap,
+            DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 5;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 5;
+
         sp_256_from_mp(k, 5, km);
         sp_256_point_from_ecc_point_5(point, gm);
         sp_256_point_from_ecc_point_5(addP, am);
@@ -15652,13 +15614,12 @@ int sp_ecc_mulmod_add_256(const mp_int* km, const ecc_point* gm,
         err = sp_256_point_to_ecc_point_5(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_5(addP, 0, heap);
-    sp_256_point_free_5(point, 0, heap);
 
     return err;
 }
@@ -17001,26 +16962,28 @@ static int sp_256_ecc_mulmod_base_5(sp_point_256* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[5];
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256  point[1];
+    sp_digit k[5];
+#endif
     int err = MP_OKAY;
 
-    err = sp_256_point_new_5(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(k, 5, km);
 
@@ -17030,12 +16993,12 @@ int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_256_point_to_ecc_point_5(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_5(point, 0, heap);
 
     return err;
 }
@@ -17054,37 +17017,35 @@ int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_point_256 a;
-    sp_digit kd[5];
-    sp_digit t[5 * 2 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_256 point[2];
+    sp_digit k[5 + 5 * 2 * 5];
 #endif
-    sp_point_256* point;
     sp_point_256* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_256_point_new_5(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_256_point_new_5(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (5 + 5 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (5 + 5 * 2 * 5),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 5;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 5;
+
         sp_256_from_mp(k, 5, km);
         sp_256_point_from_ecc_point_5(addP, am);
     }
@@ -17110,13 +17071,12 @@ int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
         err = sp_256_point_to_ecc_point_5(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_5(addP, 0, heap);
-    sp_256_point_free_5(point, 0, heap);
 
     return err;
 }
@@ -17219,41 +17179,46 @@ static int sp_256_ecc_gen_k_5(WC_RNG* rng, sp_digit* k)
  */
 int sp_ecc_make_key_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[5];
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_point_256 inf;
-#endif
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    sp_point_256 point[2];
+    #else
+    sp_point_256 point[1];
+    #endif
+    sp_digit k[5];
+#endif
 #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
     sp_point_256* infinity = NULL;
 #endif
-    int err;
+    int err = MP_OKAY;
+    
 
     (void)heap;
 
-    err = sp_256_point_new_5(heap, p, point);
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_5(heap, inf, infinity);
-    }
-#endif
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap, DYNAMIC_TYPE_ECC);
+    #else
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap, DYNAMIC_TYPE_ECC);    
+    #endif
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+        infinity = point + 1;
+    #endif
+
         err = sp_256_ecc_gen_k_5(rng, k);
     }
     if (err == MP_OKAY) {
@@ -17278,15 +17243,14 @@ int sp_ecc_make_key_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
         err = sp_256_point_to_ecc_point_5(point, pub);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL) {
+        /* point is not sensitive, so no need to zeroize */
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
     }
 #endif
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_256_point_free_5(infinity, 1, heap);
-#endif
-    sp_256_point_free_5(point, 1, heap);
 
     return err;
 }
@@ -17351,30 +17315,32 @@ static void sp_256_to_bin(sp_digit* r, byte* a)
 int sp_ecc_secret_gen_256(const mp_int* priv, const ecc_point* pub, byte* out,
                           word32* outLen, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[5];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[1];
+    sp_digit k[5];
+#endif
     int err = MP_OKAY;
 
     if (*outLen < 32U) {
         err = BUFFER_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_5(heap, p, point);
+        point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
@@ -17387,12 +17353,12 @@ int sp_ecc_secret_gen_256(const mp_int* priv, const ecc_point* pub, byte* out,
         *outLen = 32;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_5(point, 0, heap);
 
     return err;
 }
@@ -17507,34 +17473,25 @@ static int sp_256_div_5(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[10];
-    sp_digit t2d[5 + 1];
+    sp_digit t1[3 * 5 + 1];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 5 + 1), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 5 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 2 * 5;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 5;
 
         dv = d[4];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 5U);
@@ -17577,10 +17534,9 @@ static int sp_256_div_5(const sp_digit* a, const sp_digit* d,
                     (sp_digit)1 : (sp_digit)0));
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -18030,22 +17986,17 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
 int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
     const mp_int* priv, mp_int* rm, mp_int* sm, mp_int* km, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit ed[2*5];
-    sp_digit xd[2*5];
-    sp_digit kd[2*5];
-    sp_digit rd[2*5];
-    sp_digit td[3 * 2*5];
-    sp_point_256 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* e = NULL;
+    sp_point_256* point = NULL;
+#else
+    sp_digit e[7 * 2 * 5];
+    sp_point_256 point[1];
+#endif
     sp_digit* x = NULL;
     sp_digit* k = NULL;
     sp_digit* r = NULL;
     sp_digit* tmp = NULL;
-    sp_point_256* point = NULL;
     sp_digit* s = NULL;
     int64_t c;
     int err = MP_OKAY;
@@ -18053,31 +18004,26 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
 
     (void)heap;
 
-    err = sp_256_point_new_5(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 5, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (point == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        e = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (e == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        e = d + 0 * 5;
-        x = d + 2 * 5;
-        k = d + 4 * 5;
-        r = d + 6 * 5;
-        tmp = d + 8 * 5;
-#else
-        e = ed;
-        x = xd;
-        k = kd;
-        r = rd;
-        tmp = td;
-#endif
+        x = e + 2 * 5;
+        k = e + 4 * 5;
+        r = e + 6 * 5;
+        tmp = e + 8 * 5;
         s = e;
 
         if (hashLen > 32U) {
@@ -18132,19 +18078,24 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
         err = sp_256_to_mp(s, sm);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 8 * 5);
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 2U * 5U);
-    XMEMSET(x, 0, sizeof(sp_digit) * 2U * 5U);
-    XMEMSET(k, 0, sizeof(sp_digit) * 2U * 5U);
-    XMEMSET(r, 0, sizeof(sp_digit) * 2U * 5U);
-    XMEMSET(tmp, 0, sizeof(sp_digit) * 3U * 2U * 5U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (e != NULL)
 #endif
-    sp_256_point_free_5(point, 1, heap);
+    {
+        ForceZero(e, sizeof(sp_digit) * 7 * 2 * 5);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(e, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (point != NULL)
+#endif
+    {
+        ForceZero(point, sizeof(sp_point_256));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -18199,20 +18150,18 @@ static int sp_256_num_bits_5(const sp_digit* a)
 static int sp_256_mod_inv_5(sp_digit* r, const sp_digit* a, const sp_digit* m)
 {
     int err = MP_OKAY;
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
-    sp_digit* u;
-    sp_digit* v;
-    sp_digit* b;
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* u = NULL;
 #else
-    sp_digit u[5];
-    sp_digit v[5];
-    sp_digit b[5];
-    sp_digit d[5];
+    sp_digit u[5 * 4];
 #endif
-    int ut, vt;
+    sp_digit* v = NULL;
+    sp_digit* b = NULL;
+    sp_digit* d = NULL;
+    int ut;
+    int vt;
 
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     u = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 4, NULL,
                                                               DYNAMIC_TYPE_ECC);
     if (u == NULL)
@@ -18220,11 +18169,9 @@ static int sp_256_mod_inv_5(sp_digit* r, const sp_digit* a, const sp_digit* m)
 #endif
 
     if (err == MP_OKAY) {
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
         v = u + 5;
         b = u + 2 * 5;
         d = u + 3 * 5;
-#endif
 
         XMEMCPY(u, m, sizeof(sp_digit) * 5);
         XMEMCPY(v, a, sizeof(sp_digit) * 5);
@@ -18302,7 +18249,7 @@ static int sp_256_mod_inv_5(sp_digit* r, const sp_digit* a, const sp_digit* m)
         else
             XMEMCPY(r, d, sizeof(sp_digit) * 5);
     }
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (u != NULL)
         XFREE(u, NULL, DYNAMIC_TYPE_ECC);
 #endif
@@ -18595,52 +18542,41 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
     const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
     int* res, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit u1d[2*5];
-    sp_digit u2d[2*5];
-    sp_digit sd[2*5];
-    sp_digit tmpd[2*5 * 5];
-    sp_point_256 p1d;
-    sp_point_256 p2d;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* u1 = NULL;
+    sp_point_256* p1 = NULL;
+#else
+    sp_digit  u1[16 * 5];
+    sp_point_256 p1[2];
+#endif
     sp_digit* u2 = NULL;
     sp_digit* s = NULL;
     sp_digit* tmp = NULL;
-    sp_point_256* p1;
     sp_point_256* p2 = NULL;
     sp_digit carry;
     int64_t c = 0;
-    int err;
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_5(heap, p1d, p1);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_5(heap, p2d, p2);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 5, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        p1 = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (p1 == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        u1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 5, heap,
+                                                              DYNAMIC_TYPE_ECC);
+        if (u1 == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        u1  = d + 0 * 5;
-        u2  = d + 2 * 5;
-        s   = d + 4 * 5;
-        tmp = d + 6 * 5;
-#else
-        u1 = u1d;
-        u2 = u2d;
-        s  = sd;
-        tmp = tmpd;
-#endif
+        u2  = u1 + 2 * 5;
+        s   = u1 + 4 * 5;
+        tmp = u1 + 6 * 5;
+        p2 = p1 + 1;
 
         if (hashLen > 32U) {
             hashLen = 32U;
@@ -18691,12 +18627,12 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL)
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (u1 != NULL)
+        XFREE(u1, heap, DYNAMIC_TYPE_ECC);
+    if (p1 != NULL)
+        XFREE(p1, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_5(p1, 0, heap);
-    sp_256_point_free_5(p2, 0, heap);
 
     return err;
 }
@@ -18713,32 +18649,23 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
 static int sp_256_ecc_is_point_5(const sp_point_256* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*5];
-    sp_digit t2d[2*5];
+    sp_digit t1[5 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 5;
-        t2 = d + 2 * 5;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 5;
 
         sp_256_sqr_5(t1, point->y);
         (void)sp_256_mod_5(t1, t1, p256_mod);
@@ -18758,10 +18685,9 @@ static int sp_256_ecc_is_point_5(const sp_point_256* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -18776,14 +18702,21 @@ static int sp_256_ecc_is_point_5(const sp_point_256* point,
  */
 int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* pub = NULL;
+#else
+    sp_point_256 pub[1];
 #endif
-    sp_point_256* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_5(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(pub->x, 5, pX);
         sp_256_from_mp(pub->y, 5, pY);
@@ -18792,7 +18725,10 @@ int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
         err = sp_256_ecc_is_point_5(pub, NULL);
     }
 
-    sp_256_point_free_5(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -18811,44 +18747,44 @@ int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_256(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[5];
-    sp_point_256 pubd;
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_256* pub;
-    sp_point_256* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_256_point_new_5(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_5(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_256* pub = NULL;
+#else
+    sp_digit priv[5];
+    sp_point_256 pub[2];
 #endif
+    sp_point_256* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+    if (((mp_count_bits(pX) > 256) ||
         (mp_count_bits(pY) > 256) ||
         ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_256_from_mp(pub->x, 5, pX);
         sp_256_from_mp(pub->y, 5, pY);
@@ -18898,13 +18834,12 @@ int sp_ecc_check_key_256(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_256_point_free_5(p, 0, heap);
-    sp_256_point_free_5(pub, 0, heap);
 
     return err;
 }
@@ -18928,33 +18863,35 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* qX, mp_int* qY, mp_int* qZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 5 * 5];
-    sp_point_256 pd;
-    sp_point_256 qd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 5 * 5];
+    sp_point_256 p[2];
+#endif
     sp_point_256* q = NULL;
     int err;
 
-    err = sp_256_point_new_5(NULL, pd, p);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_5(NULL, qd, q);
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 5 * 5, NULL,
-                                                              DYNAMIC_TYPE_ECC);
+                                 DYNAMIC_TYPE_ECC);
         if (tmp == NULL) {
             err = MEMORY_E;
         }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
+        q = p + 1;
+
         sp_256_from_mp(p->x, 5, pX);
         sp_256_from_mp(p->y, 5, pY);
         sp_256_from_mp(p->z, 5, pZ);
@@ -18975,13 +18912,12 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_256_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_5(q, 0, NULL);
-    sp_256_point_free_5(p, 0, NULL);
 
     return err;
 }
@@ -19000,25 +18936,28 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
 int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 5 * 2];
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
-    int err;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 5 * 2];
+    sp_point_256 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_5(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 5 * 2, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
@@ -19039,12 +18978,12 @@ int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_256_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_5(p, 0, NULL);
 
     return err;
 }
@@ -19059,25 +18998,29 @@ int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
  */
 int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 5 * 4];
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
-    int err;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 5 * 4];
+    sp_point_256 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_5(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 5 * 4, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
     if (err == MP_OKAY) {
         sp_256_from_mp(p->x, 5, pX);
@@ -19097,12 +19040,12 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
         err = sp_256_to_mp(p->z, pZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_5(p, 0, NULL);
 
     return err;
 }
@@ -19115,31 +19058,23 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
  */
 static int sp_256_mont_sqrt_5(sp_digit* y)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2 * 5];
-    sp_digit t2d[2 * 5];
+    sp_digit t1[4 * 5];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 5, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 5, NULL, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL) {
         err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 5;
-        t2 = d + 2 * 5;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 5;
 
         {
             /* t2 = y ^ 0x2 */
@@ -19174,10 +19109,9 @@ static int sp_256_mont_sqrt_5(sp_digit* y)
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -19193,31 +19127,22 @@ static int sp_256_mont_sqrt_5(sp_digit* y)
  */
 int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
-#else
-    sp_digit xd[2 * 5];
-    sp_digit yd[2 * 5];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* x = NULL;
+#else
+    sp_digit x[4 * 5];
+#endif
     sp_digit* y = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 5, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    x = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 5, NULL, DYNAMIC_TYPE_ECC);
+    if (x == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        x = d + 0 * 5;
-        y = d + 2 * 5;
-#else
-        x = xd;
-        y = yd;
-#endif
+        y = x + 2 * 5;
 
         sp_256_from_mp(x, 5, xm);
         err = sp_256_mod_mul_norm_5(x, x, p256_mod);
@@ -19250,10 +19175,9 @@ int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
         err = sp_256_to_mp(y, ym);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (x != NULL)
+        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -19628,64 +19552,6 @@ SP_NOINLINE static int sp_384_sub_7(sp_digit* r, const sp_digit* a,
 }
 
 #endif /* WOLFSSL_SP_SMALL */
-/* Create a new point.
- *
- * heap  [in]   Buffer to allocate dynamic memory from.
- * sp    [in]   Data for point - only if not allocating.
- * p     [out]  New point.
- * returns MEMORY_E when dynamic memory allocation fails and 0 otherwise.
- */
-static int sp_384_point_new_ex_7(void* heap, sp_point_384* sp,
-    sp_point_384** p)
-{
-    int ret = MP_OKAY;
-    (void)heap;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    (void)sp;
-    *p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap, DYNAMIC_TYPE_ECC);
-#else
-    *p = sp;
-#endif
-    if (*p == NULL) {
-        ret = MEMORY_E;
-    }
-    return ret;
-}
-
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* Allocate memory for point and return error. */
-#define sp_384_point_new_7(heap, sp, p) sp_384_point_new_ex_7((heap), NULL, &(p))
-#else
-/* Set pointer to data and return no error. */
-#define sp_384_point_new_7(heap, sp, p) sp_384_point_new_ex_7((heap), &(sp), &(p))
-#endif
-
-
-/* Free the point.
- *
- * p      [in,out]  Point to free.
- * clear  [in]      Indicates whether to zeroize point.
- * heap   [in]      Buffer from which dynamic memory was allocate from.
- */
-static void sp_384_point_free_7(sp_point_384* p, int clear, void* heap)
-{
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* If valid pointer then clear point data if requested and free data. */
-    if (p != NULL) {
-        if (clear != 0) {
-            XMEMSET(p, 0, sizeof(*p));
-        }
-        XFREE(p, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-/* Clear point data if requested. */
-    if ((p != NULL) && (clear != 0)) {
-        XMEMSET(p, 0, sizeof(*p));
-    }
-#endif
-    (void)heap;
-}
-
 /* Convert an mp_int to an array of sp_digit.
  *
  * r  A single precision integer.
@@ -20895,34 +20761,25 @@ static void sp_384_proj_point_add_7(sp_point_384* r,
  */
 static int sp_384_mod_mul_norm_7(sp_digit* r, const sp_digit* a, const sp_digit* m)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    int64_t* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    int64_t* t = NULL;
 #else
-    int64_t td[12];
-    int64_t a32d[12];
+    int64_t t[2 * 12];
 #endif
-    int64_t* t;
-    int64_t* a32;
+    int64_t* a32 = NULL;
     int64_t o;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 12, NULL, DYNAMIC_TYPE_ECC);
-    if (td == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (int64_t*)XMALLOC(sizeof(int64_t) * 2 * 12, NULL, DYNAMIC_TYPE_ECC);
+    if (t == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t = td;
-        a32 = td + 12;
-#else
-        t = td;
-        a32 = a32d;
-#endif
+        a32 = t + 12;
 
         a32[0] = (sp_digit)(a[0]) & 0xffffffffL;
         a32[1] = (sp_digit)(a[0] >> 32U);
@@ -21028,9 +20885,9 @@ static int sp_384_mod_mul_norm_7(sp_digit* r, const sp_digit* a, const sp_digit*
         r[6] |= t[11] << 22U;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL)
-        XFREE(td, NULL, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -21170,12 +21027,12 @@ static int sp_384_ecc_mulmod_7_nb(sp_ecc_ctx_t* sp_ctx, sp_point_384* r,
 static int sp_384_ecc_mulmod_7(sp_point_384* r, const sp_point_384* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#ifdef WOLFSSL_SP_NO_MALLOC
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+    sp_digit* tmp = NULL;
+#else
     sp_point_384 t[3];
     sp_digit tmp[2 * 7 * 6];
-#else
-    sp_point_384* t;
-    sp_digit* tmp;
 #endif
     sp_digit n;
     int i;
@@ -21187,14 +21044,17 @@ static int sp_384_ecc_mulmod_7(sp_point_384* r, const sp_point_384* g,
     (void)ct;
     (void)heap;
 
-#ifndef WOLFSSL_SP_NO_MALLOC
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 7 * 6, heap,
-                                                              DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 7 * 6, heap,
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
@@ -21245,19 +21105,24 @@ static int sp_384_ecc_mulmod_7(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#ifndef WOLFSSL_SP_NO_MALLOC
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 7 * 6);
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_384) * 3);
-        XFREE(t, NULL, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmp, sizeof(tmp));
-    ForceZero(t, sizeof(t));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 7 * 6);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_384) * 3);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -21699,43 +21564,41 @@ static void sp_384_get_point_33_7(sp_point_384* r, const sp_point_384* table,
 static int sp_384_ecc_mulmod_win_add_sub_7(sp_point_384* r, const sp_point_384* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td[33];
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit tmpd[2 * 7 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_384 t[33+2];
+    sp_digit tmp[2 * 7 * 6];
 #endif
-    sp_point_384* t;
-    sp_point_384* rt;
+    sp_point_384* rt = NULL;
     sp_point_384* p = NULL;
-    sp_digit* tmp;
     sp_digit* negy;
     int i;
     ecc_recode_384 v[65];
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_384_point_new_7(heap, rtd, rt);
-    if (err == MP_OKAY)
-        err = sp_384_point_new_7(heap, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 33, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 
+        (33+2), heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 7 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 7 * 6,
+                                 heap, DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
-
     if (err == MP_OKAY) {
+        rt = t + 33;
+        p  = t + 33+1;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -21815,14 +21678,12 @@ static int sp_384_ecc_mulmod_win_add_sub_7(sp_point_384* r, const sp_point_384* 
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
     if (tmp != NULL)
         XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_7(p, 0, heap);
-    sp_384_point_free_7(rt, 0, heap);
 
     return err;
 }
@@ -21948,29 +21809,30 @@ static void sp_384_proj_to_affine_7(sp_point_384* a, sp_digit* t)
 static int sp_384_gen_stripe_table_7(const sp_point_384* a,
         sp_table_entry_384* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td;
-    sp_point_384 s1d;
-    sp_point_384 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+#else
+    sp_point_384 t[3];
 #endif
-    sp_point_384* t;
     sp_point_384* s1 = NULL;
     sp_point_384* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_384_point_new_7(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_7(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_7(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_384_mod_mul_norm_7(t->x, a->x, p384_mod);
     }
     if (err == MP_OKAY) {
@@ -22015,9 +21877,10 @@ static int sp_384_gen_stripe_table_7(const sp_point_384* a,
         }
     }
 
-    sp_384_point_free_7(s2, 0, heap);
-    sp_384_point_free_7(s1, 0, heap);
-    sp_384_point_free_7( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -22089,19 +21952,19 @@ static int sp_384_ecc_mulmod_stripe_7(sp_point_384* r, const sp_point_384* g,
         const sp_table_entry_384* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit td[2 * 7 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_384 rt[2];
+    sp_digit t[2 * 7 * 6];
 #endif
-    sp_point_384* rt;
     sp_point_384* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -22109,21 +21972,22 @@ static int sp_384_ecc_mulmod_stripe_7(sp_point_384* r, const sp_point_384* g,
     (void)heap;
 
 
-    err = sp_384_point_new_7(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_7(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 7 * 6, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 7 * 6, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p384_norm_mod, sizeof(p384_norm_mod));
         XMEMCPY(rt->z, p384_norm_mod, sizeof(p384_norm_mod));
 
@@ -22174,13 +22038,12 @@ static int sp_384_ecc_mulmod_stripe_7(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_7(p, 0, heap);
-    sp_384_point_free_7(rt, 0, heap);
 
     return err;
 }
@@ -22344,25 +22207,28 @@ static int sp_384_ecc_mulmod_7(sp_point_384* r, const sp_point_384* g, const sp_
 int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[7];
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[1];
+    sp_digit k[7];
+#endif
     int err = MP_OKAY;
 
-    err = sp_384_point_new_7(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(k, 7, km);
         sp_384_point_from_ecc_point_7(point, gm);
@@ -22373,12 +22239,12 @@ int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_384_point_to_ecc_point_7(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_7(point, 0, heap);
 
     return err;
 }
@@ -22398,37 +22264,35 @@ int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
 int sp_ecc_mulmod_add_384(const mp_int* km, const ecc_point* gm,
     const ecc_point* am, int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_point_384 a;
-    sp_digit kd[7];
-    sp_digit t[7 * 2 * 6];
-#endif
-    sp_point_384* point;
-    sp_point_384* addP = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;    
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[2];
+    sp_digit k[7 + 7 * 2 * 6];
+#endif
+    sp_point_384* addP = NULL;
     sp_digit* tmp = NULL;
     int err = MP_OKAY;
 
-    err = sp_384_point_new_7(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_384_point_new_7(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (7 + 7 * 2 * 6), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (7 + 7 * 2 * 6), heap,
+            DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 7;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 7;
+
         sp_384_from_mp(k, 7, km);
         sp_384_point_from_ecc_point_7(point, gm);
         sp_384_point_from_ecc_point_7(addP, am);
@@ -22455,13 +22319,12 @@ int sp_ecc_mulmod_add_384(const mp_int* km, const ecc_point* gm,
         err = sp_384_point_to_ecc_point_7(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_7(addP, 0, heap);
-    sp_384_point_free_7(point, 0, heap);
 
     return err;
 }
@@ -24314,26 +24177,28 @@ static int sp_384_ecc_mulmod_base_7(sp_point_384* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[7];
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384  point[1];
+    sp_digit k[7];
+#endif
     int err = MP_OKAY;
 
-    err = sp_384_point_new_7(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(k, 7, km);
 
@@ -24343,12 +24208,12 @@ int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_384_point_to_ecc_point_7(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_7(point, 0, heap);
 
     return err;
 }
@@ -24367,37 +24232,35 @@ int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_point_384 a;
-    sp_digit kd[7];
-    sp_digit t[7 * 2 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_384 point[2];
+    sp_digit k[7 + 7 * 2 * 6];
 #endif
-    sp_point_384* point;
     sp_point_384* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_384_point_new_7(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_384_point_new_7(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (7 + 7 * 2 * 6), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (7 + 7 * 2 * 6),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 7;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 7;
+
         sp_384_from_mp(k, 7, km);
         sp_384_point_from_ecc_point_7(addP, am);
     }
@@ -24423,13 +24286,12 @@ int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
         err = sp_384_point_to_ecc_point_7(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_7(addP, 0, heap);
-    sp_384_point_free_7(point, 0, heap);
 
     return err;
 }
@@ -24532,41 +24394,46 @@ static int sp_384_ecc_gen_k_7(WC_RNG* rng, sp_digit* k)
  */
 int sp_ecc_make_key_384(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[7];
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_point_384 inf;
-#endif
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    sp_point_384 point[2];
+    #else
+    sp_point_384 point[1];
+    #endif
+    sp_digit k[7];
+#endif
 #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
     sp_point_384* infinity = NULL;
 #endif
-    int err;
+    int err = MP_OKAY;
+    
 
     (void)heap;
 
-    err = sp_384_point_new_7(heap, p, point);
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_7(heap, inf, infinity);
-    }
-#endif
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap, DYNAMIC_TYPE_ECC);
+    #else
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap, DYNAMIC_TYPE_ECC);    
+    #endif
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+        infinity = point + 1;
+    #endif
+
         err = sp_384_ecc_gen_k_7(rng, k);
     }
     if (err == MP_OKAY) {
@@ -24591,15 +24458,14 @@ int sp_ecc_make_key_384(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
         err = sp_384_point_to_ecc_point_7(point, pub);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL) {
+        /* point is not sensitive, so no need to zeroize */
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
     }
 #endif
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_384_point_free_7(infinity, 1, heap);
-#endif
-    sp_384_point_free_7(point, 1, heap);
 
     return err;
 }
@@ -24664,30 +24530,32 @@ static void sp_384_to_bin(sp_digit* r, byte* a)
 int sp_ecc_secret_gen_384(const mp_int* priv, const ecc_point* pub, byte* out,
                           word32* outLen, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[7];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[1];
+    sp_digit k[7];
+#endif
     int err = MP_OKAY;
 
     if (*outLen < 48U) {
         err = BUFFER_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_7(heap, p, point);
+        point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
@@ -24700,12 +24568,12 @@ int sp_ecc_secret_gen_384(const mp_int* priv, const ecc_point* pub, byte* out,
         *outLen = 48;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_7(point, 0, heap);
 
     return err;
 }
@@ -24840,34 +24708,25 @@ static int sp_384_div_7(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[14];
-    sp_digit t2d[7 + 1];
+    sp_digit t1[3 * 7 + 1];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 7 + 1), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 7 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 2 * 7;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 7;
 
         dv = d[6];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 7U);
@@ -24910,10 +24769,9 @@ static int sp_384_div_7(const sp_digit* a, const sp_digit* d,
                     (sp_digit)1 : (sp_digit)0));
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -25334,22 +25192,17 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
 int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
     const mp_int* priv, mp_int* rm, mp_int* sm, mp_int* km, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit ed[2*7];
-    sp_digit xd[2*7];
-    sp_digit kd[2*7];
-    sp_digit rd[2*7];
-    sp_digit td[3 * 2*7];
-    sp_point_384 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* e = NULL;
+    sp_point_384* point = NULL;
+#else
+    sp_digit e[7 * 2 * 7];
+    sp_point_384 point[1];
+#endif
     sp_digit* x = NULL;
     sp_digit* k = NULL;
     sp_digit* r = NULL;
     sp_digit* tmp = NULL;
-    sp_point_384* point = NULL;
     sp_digit* s = NULL;
     int64_t c;
     int err = MP_OKAY;
@@ -25357,31 +25210,26 @@ int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
 
     (void)heap;
 
-    err = sp_384_point_new_7(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 7, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (point == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        e = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 7, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (e == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        e = d + 0 * 7;
-        x = d + 2 * 7;
-        k = d + 4 * 7;
-        r = d + 6 * 7;
-        tmp = d + 8 * 7;
-#else
-        e = ed;
-        x = xd;
-        k = kd;
-        r = rd;
-        tmp = td;
-#endif
+        x = e + 2 * 7;
+        k = e + 4 * 7;
+        r = e + 6 * 7;
+        tmp = e + 8 * 7;
         s = e;
 
         if (hashLen > 48U) {
@@ -25436,19 +25284,24 @@ int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
         err = sp_384_to_mp(s, sm);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 8 * 7);
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 2U * 7U);
-    XMEMSET(x, 0, sizeof(sp_digit) * 2U * 7U);
-    XMEMSET(k, 0, sizeof(sp_digit) * 2U * 7U);
-    XMEMSET(r, 0, sizeof(sp_digit) * 2U * 7U);
-    XMEMSET(tmp, 0, sizeof(sp_digit) * 3U * 2U * 7U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (e != NULL)
 #endif
-    sp_384_point_free_7(point, 1, heap);
+    {
+        ForceZero(e, sizeof(sp_digit) * 7 * 2 * 7);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(e, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (point != NULL)
+#endif
+    {
+        ForceZero(point, sizeof(sp_point_384));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -25503,20 +25356,18 @@ static int sp_384_num_bits_7(const sp_digit* a)
 static int sp_384_mod_inv_7(sp_digit* r, const sp_digit* a, const sp_digit* m)
 {
     int err = MP_OKAY;
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
-    sp_digit* u;
-    sp_digit* v;
-    sp_digit* b;
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* u = NULL;
 #else
-    sp_digit u[7];
-    sp_digit v[7];
-    sp_digit b[7];
-    sp_digit d[7];
+    sp_digit u[7 * 4];
 #endif
-    int ut, vt;
+    sp_digit* v = NULL;
+    sp_digit* b = NULL;
+    sp_digit* d = NULL;
+    int ut;
+    int vt;
 
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     u = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 4, NULL,
                                                               DYNAMIC_TYPE_ECC);
     if (u == NULL)
@@ -25524,11 +25375,9 @@ static int sp_384_mod_inv_7(sp_digit* r, const sp_digit* a, const sp_digit* m)
 #endif
 
     if (err == MP_OKAY) {
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
         v = u + 7;
         b = u + 2 * 7;
         d = u + 3 * 7;
-#endif
 
         XMEMCPY(u, m, sizeof(sp_digit) * 7);
         XMEMCPY(v, a, sizeof(sp_digit) * 7);
@@ -25606,7 +25455,7 @@ static int sp_384_mod_inv_7(sp_digit* r, const sp_digit* a, const sp_digit* m)
         else
             XMEMCPY(r, d, sizeof(sp_digit) * 7);
     }
-#if defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (u != NULL)
         XFREE(u, NULL, DYNAMIC_TYPE_ECC);
 #endif
@@ -25901,52 +25750,41 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
     const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
     int* res, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit u1d[2*7];
-    sp_digit u2d[2*7];
-    sp_digit sd[2*7];
-    sp_digit tmpd[2*7 * 5];
-    sp_point_384 p1d;
-    sp_point_384 p2d;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* u1 = NULL;
+    sp_point_384* p1 = NULL;
+#else
+    sp_digit  u1[16 * 7];
+    sp_point_384 p1[2];
+#endif
     sp_digit* u2 = NULL;
     sp_digit* s = NULL;
     sp_digit* tmp = NULL;
-    sp_point_384* p1;
     sp_point_384* p2 = NULL;
     sp_digit carry;
     int64_t c = 0;
-    int err;
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_7(heap, p1d, p1);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_7(heap, p2d, p2);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 7, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        p1 = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (p1 == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        u1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 7, heap,
+                                                              DYNAMIC_TYPE_ECC);
+        if (u1 == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        u1  = d + 0 * 7;
-        u2  = d + 2 * 7;
-        s   = d + 4 * 7;
-        tmp = d + 6 * 7;
-#else
-        u1 = u1d;
-        u2 = u2d;
-        s  = sd;
-        tmp = tmpd;
-#endif
+        u2  = u1 + 2 * 7;
+        s   = u1 + 4 * 7;
+        tmp = u1 + 6 * 7;
+        p2 = p1 + 1;
 
         if (hashLen > 48U) {
             hashLen = 48U;
@@ -25997,12 +25835,12 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL)
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (u1 != NULL)
+        XFREE(u1, heap, DYNAMIC_TYPE_ECC);
+    if (p1 != NULL)
+        XFREE(p1, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_7(p1, 0, heap);
-    sp_384_point_free_7(p2, 0, heap);
 
     return err;
 }
@@ -26019,32 +25857,23 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
 static int sp_384_ecc_is_point_7(const sp_point_384* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*7];
-    sp_digit t2d[2*7];
+    sp_digit t1[7 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 7;
-        t2 = d + 2 * 7;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 7;
 
         sp_384_sqr_7(t1, point->y);
         (void)sp_384_mod_7(t1, t1, p384_mod);
@@ -26064,10 +25893,9 @@ static int sp_384_ecc_is_point_7(const sp_point_384* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -26082,14 +25910,21 @@ static int sp_384_ecc_is_point_7(const sp_point_384* point,
  */
 int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* pub = NULL;
+#else
+    sp_point_384 pub[1];
 #endif
-    sp_point_384* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_7(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(pub->x, 7, pX);
         sp_384_from_mp(pub->y, 7, pY);
@@ -26098,7 +25933,10 @@ int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
         err = sp_384_ecc_is_point_7(pub, NULL);
     }
 
-    sp_384_point_free_7(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -26117,44 +25955,44 @@ int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_384(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[7];
-    sp_point_384 pubd;
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_384* pub;
-    sp_point_384* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_384_point_new_7(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_7(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_384* pub = NULL;
+#else
+    sp_digit priv[7];
+    sp_point_384 pub[2];
 #endif
+    sp_point_384* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+    if (((mp_count_bits(pX) > 384) ||
         (mp_count_bits(pY) > 384) ||
         ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_384_from_mp(pub->x, 7, pX);
         sp_384_from_mp(pub->y, 7, pY);
@@ -26204,13 +26042,12 @@ int sp_ecc_check_key_384(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_384_point_free_7(p, 0, heap);
-    sp_384_point_free_7(pub, 0, heap);
 
     return err;
 }
@@ -26234,33 +26071,35 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* qX, mp_int* qY, mp_int* qZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 7 * 5];
-    sp_point_384 pd;
-    sp_point_384 qd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 7 * 5];
+    sp_point_384 p[2];
+#endif
     sp_point_384* q = NULL;
     int err;
 
-    err = sp_384_point_new_7(NULL, pd, p);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_7(NULL, qd, q);
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 7 * 5, NULL,
-                                                              DYNAMIC_TYPE_ECC);
+                                 DYNAMIC_TYPE_ECC);
         if (tmp == NULL) {
             err = MEMORY_E;
         }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
+        q = p + 1;
+
         sp_384_from_mp(p->x, 7, pX);
         sp_384_from_mp(p->y, 7, pY);
         sp_384_from_mp(p->z, 7, pZ);
@@ -26281,13 +26120,12 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_384_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_7(q, 0, NULL);
-    sp_384_point_free_7(p, 0, NULL);
 
     return err;
 }
@@ -26306,25 +26144,28 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
 int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 7 * 2];
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
-    int err;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 7 * 2];
+    sp_point_384 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_7(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 7 * 2, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
@@ -26345,12 +26186,12 @@ int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_384_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_7(p, 0, NULL);
 
     return err;
 }
@@ -26365,25 +26206,29 @@ int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
  */
 int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 7 * 6];
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
-    int err;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 7 * 6];
+    sp_point_384 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_7(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 7 * 6, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
     if (err == MP_OKAY) {
         sp_384_from_mp(p->x, 7, pX);
@@ -26403,12 +26248,12 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
         err = sp_384_to_mp(p->z, pZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_7(p, 0, NULL);
 
     return err;
 }
@@ -26421,43 +26266,28 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
  */
 static int sp_384_mont_sqrt_7(sp_digit* y)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2 * 7];
-    sp_digit t2d[2 * 7];
-    sp_digit t3d[2 * 7];
-    sp_digit t4d[2 * 7];
-    sp_digit t5d[2 * 7];
+    sp_digit t1[5 * 2 * 7];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* t3;
-    sp_digit* t4;
-    sp_digit* t5;
+    sp_digit* t2 = NULL;
+    sp_digit* t3 = NULL;
+    sp_digit* t4 = NULL;
+    sp_digit* t5 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 7, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 7, NULL, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 7;
-        t2 = d + 2 * 7;
-        t3 = d + 4 * 7;
-        t4 = d + 6 * 7;
-        t5 = d + 8 * 7;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        t3 = t3d;
-        t4 = t4d;
-        t5 = t5d;
-#endif
+        t2 = t1 + 2 * 7;
+        t3 = t1 + 4 * 7;
+        t4 = t1 + 6 * 7;
+        t5 = t1 + 8 * 7;
 
         {
             /* t2 = y ^ 0x2 */
@@ -26517,10 +26347,9 @@ static int sp_384_mont_sqrt_7(sp_digit* y)
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -26536,31 +26365,22 @@ static int sp_384_mont_sqrt_7(sp_digit* y)
  */
 int sp_ecc_uncompress_384(mp_int* xm, int odd, mp_int* ym)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
-#else
-    sp_digit xd[2 * 7];
-    sp_digit yd[2 * 7];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* x = NULL;
+#else
+    sp_digit x[4 * 7];
+#endif
     sp_digit* y = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 7, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    x = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 7, NULL, DYNAMIC_TYPE_ECC);
+    if (x == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        x = d + 0 * 7;
-        y = d + 2 * 7;
-#else
-        x = xd;
-        y = yd;
-#endif
+        y = x + 2 * 7;
 
         sp_384_from_mp(x, 7, xm);
         err = sp_384_mod_mul_norm_7(x, x, p384_mod);
@@ -26593,10 +26413,9 @@ int sp_ecc_uncompress_384(mp_int* xm, int odd, mp_int* ym)
         err = sp_384_to_mp(y, ym);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (x != NULL)
+        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -27303,34 +27122,25 @@ static int sp_1024_div_18(const sp_digit* a, const sp_digit* d,
 #endif
     sp_digit dv;
     sp_digit r1;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[36];
-    sp_digit t2d[18 + 1];
+    sp_digit t1[3 * 18 + 1];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 18 + 1), NULL,
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * (3 * 18 + 1), NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = td;
-        t2 = td + 2 * 18;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 18;
 
         dv = d[17];
         XMEMCPY(t1, a, sizeof(*t1) * 2U * 18U);
@@ -27373,10 +27183,9 @@ static int sp_1024_div_18(const sp_digit* a, const sp_digit* d,
                     (sp_digit)1 : (sp_digit)0));
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
-        XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -27408,6 +27217,8 @@ static int sp_1024_mod_mul_norm_18(sp_digit* r, const sp_digit* a,
     return sp_1024_mod_18(r, r, m);
 }
 
+
+#ifdef WOLFCRYPT_HAVE_SAKKE
 /* Create a new point.
  *
  * heap  [in]   Buffer to allocate dynamic memory from.
@@ -27439,8 +27250,8 @@ static int sp_1024_point_new_ex_18(void* heap, sp_point_1024* sp,
 /* Set pointer to data and return no error. */
 #define sp_1024_point_new_18(heap, sp, p) sp_1024_point_new_ex_18((heap), &(sp), &(p))
 #endif
-
-
+#endif /* WOLFCRYPT_HAVE_SAKKE */
+#ifdef WOLFCRYPT_HAVE_SAKKE
 /* Free the point.
  *
  * p      [in,out]  Point to free.
@@ -27465,6 +27276,7 @@ static void sp_1024_point_free_18(sp_point_1024* p, int clear, void* heap)
 #endif
     (void)heap;
 }
+#endif /* WOLFCRYPT_HAVE_SAKKE */
 
 /* Convert an mp_int to an array of sp_digit.
  *
@@ -28789,12 +28601,12 @@ static int sp_1024_ecc_mulmod_18_nb(sp_ecc_ctx_t* sp_ctx, sp_point_1024* r,
 static int sp_1024_ecc_mulmod_18(sp_point_1024* r, const sp_point_1024* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#ifdef WOLFSSL_SP_NO_MALLOC
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+    sp_digit* tmp = NULL;
+#else
     sp_point_1024 t[3];
     sp_digit tmp[2 * 18 * 5];
-#else
-    sp_point_1024* t;
-    sp_digit* tmp;
 #endif
     sp_digit n;
     int i;
@@ -28806,14 +28618,17 @@ static int sp_1024_ecc_mulmod_18(sp_point_1024* r, const sp_point_1024* g,
     (void)ct;
     (void)heap;
 
-#ifndef WOLFSSL_SP_NO_MALLOC
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 18 * 5, heap,
-                                                              DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 18 * 5, heap,
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
@@ -28864,19 +28679,24 @@ static int sp_1024_ecc_mulmod_18(sp_point_1024* r, const sp_point_1024* g,
         }
     }
 
-#ifndef WOLFSSL_SP_NO_MALLOC
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 18 * 5);
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_1024) * 3);
-        XFREE(t, NULL, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmp, sizeof(tmp));
-    ForceZero(t, sizeof(t));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 18 * 5);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_1024) * 3);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -29288,43 +29108,41 @@ static void sp_1024_ecc_recode_7_18(const sp_digit* k, ecc_recode_1024* v)
 static int sp_1024_ecc_mulmod_win_add_sub_18(sp_point_1024* r, const sp_point_1024* g,
         const sp_digit* k, int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td[65];
-    sp_point_1024 rtd;
-    sp_point_1024 pd;
-    sp_digit tmpd[2 * 18 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_1024 t[65+2];
+    sp_digit tmp[2 * 18 * 6];
 #endif
-    sp_point_1024* t;
-    sp_point_1024* rt;
+    sp_point_1024* rt = NULL;
     sp_point_1024* p = NULL;
-    sp_digit* tmp;
     sp_digit* negy;
     int i;
     ecc_recode_1024 v[147];
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_1024_point_new_18(heap, rtd, rt);
-    if (err == MP_OKAY)
-        err = sp_1024_point_new_18(heap, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 65, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 
+        (65+2), heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 18 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 18 * 6,
+                                 heap, DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
-
     if (err == MP_OKAY) {
+        rt = t + 65;
+        p  = t + 65+1;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -29408,14 +29226,12 @@ static int sp_1024_ecc_mulmod_win_add_sub_18(sp_point_1024* r, const sp_point_10
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
     if (tmp != NULL)
         XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_18(p, 0, heap);
-    sp_1024_point_free_18(rt, 0, heap);
 
     return err;
 }
@@ -29541,29 +29357,30 @@ static void sp_1024_proj_to_affine_18(sp_point_1024* a, sp_digit* t)
 static int sp_1024_gen_stripe_table_18(const sp_point_1024* a,
         sp_table_entry_1024* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td;
-    sp_point_1024 s1d;
-    sp_point_1024 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+#else
+    sp_point_1024 t[3];
 #endif
-    sp_point_1024* t;
     sp_point_1024* s1 = NULL;
     sp_point_1024* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_1024_point_new_18(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_18(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_18(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_1024_mod_mul_norm_18(t->x, a->x, p1024_mod);
     }
     if (err == MP_OKAY) {
@@ -29608,9 +29425,10 @@ static int sp_1024_gen_stripe_table_18(const sp_point_1024* a,
         }
     }
 
-    sp_1024_point_free_18(s2, 0, heap);
-    sp_1024_point_free_18(s1, 0, heap);
-    sp_1024_point_free_18( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -29636,19 +29454,19 @@ static int sp_1024_ecc_mulmod_stripe_18(sp_point_1024* r, const sp_point_1024* g
         const sp_table_entry_1024* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 rtd;
-    sp_point_1024 pd;
-    sp_digit td[2 * 18 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 rt[2];
+    sp_digit t[2 * 18 * 5];
 #endif
-    sp_point_1024* rt;
     sp_point_1024* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -29656,21 +29474,22 @@ static int sp_1024_ecc_mulmod_stripe_18(sp_point_1024* r, const sp_point_1024* g
     (void)heap;
 
 
-    err = sp_1024_point_new_18(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_18(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 18 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 18 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p1024_norm_mod, sizeof(p1024_norm_mod));
         XMEMCPY(rt->z, p1024_norm_mod, sizeof(p1024_norm_mod));
 
@@ -29706,13 +29525,12 @@ static int sp_1024_ecc_mulmod_stripe_18(sp_point_1024* r, const sp_point_1024* g
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_18(p, 0, heap);
-    sp_1024_point_free_18(rt, 0, heap);
 
     return err;
 }
@@ -29876,25 +29694,28 @@ static int sp_1024_ecc_mulmod_18(sp_point_1024* r, const sp_point_1024* g, const
 int sp_ecc_mulmod_1024(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[18];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024 point[1];
+    sp_digit k[18];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_18(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 18, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 18, km);
         sp_1024_point_from_ecc_point_18(point, gm);
@@ -29905,12 +29726,12 @@ int sp_ecc_mulmod_1024(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_1024_point_to_ecc_point_18(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_18(point, 0, heap);
 
     return err;
 }
@@ -33293,26 +33114,28 @@ static int sp_1024_ecc_mulmod_base_18(sp_point_1024* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[18];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024  point[1];
+    sp_digit k[18];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_18(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 18, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 18, km);
 
@@ -33322,12 +33145,12 @@ int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_1024_point_to_ecc_point_18(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_18(point, 0, heap);
 
     return err;
 }
@@ -33346,37 +33169,35 @@ int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_point_1024 a;
-    sp_digit kd[18];
-    sp_digit t[18 * 2 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_1024 point[2];
+    sp_digit k[18 + 18 * 2 * 5];
 #endif
-    sp_point_1024* point;
     sp_point_1024* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_18(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_1024_point_new_18(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (18 + 18 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (18 + 18 * 2 * 5),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 18;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 18;
+
         sp_1024_from_mp(k, 18, km);
         sp_1024_point_from_ecc_point_18(addP, am);
     }
@@ -33402,13 +33223,12 @@ int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
         err = sp_1024_point_to_ecc_point_18(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_18(addP, 0, heap);
-    sp_1024_point_free_18(point, 0, heap);
 
     return err;
 }
@@ -33426,29 +33246,43 @@ int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
 int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
     void* heap)
 {
-    int err = 0;
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_1024* point = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 point[1];
     sp_digit t[5 * 2 * 18];
+#endif
+    int err = MP_OKAY;
 
     if ((gm == NULL) || (len == NULL)) {
         err = BAD_FUNC_ARG;
     }
 
-    if ((err == 0) && (table == NULL)) {
+    if ((err == MP_OKAY) && (table == NULL)) {
         *len = sizeof(sp_table_entry_1024) * 256;
         err = LENGTH_ONLY_E;
     }
-    if ((err == 0) && (*len < (int)(sizeof(sp_table_entry_1024) * 256))) {
+    if ((err == MP_OKAY) && (*len < (int)(sizeof(sp_table_entry_1024) * 256))) {
         err = BUFFER_E;
     }
 
-    if (err == 0) {
-        err = sp_1024_point_new_18(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+            DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-    if (err == 0) {
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 18, heap,
+            DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
         sp_1024_point_from_ecc_point_18(point, gm);
             err = sp_1024_gen_stripe_table_18(point,
                 (sp_table_entry_1024*)table, t, heap);
@@ -33457,7 +33291,12 @@ int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
         *len = sizeof(sp_table_entry_1024) * 256;
     }
 
-    sp_1024_point_free_18(point, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -33510,24 +33349,28 @@ int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
 int sp_ecc_mulmod_table_1024(const mp_int* km, const ecc_point* gm, byte* table,
         ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[18];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024 point[1];
+    sp_digit k[18];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_18(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+        DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 18, heap, DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 18, km);
         sp_1024_point_from_ecc_point_18(point, gm);
@@ -33544,12 +33387,12 @@ int sp_ecc_mulmod_table_1024(const mp_int* km, const ecc_point* gm, byte* table,
         err = sp_1024_point_to_ecc_point_18(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_18(point, 0, heap);
 
     return err;
 }
@@ -36743,33 +36586,24 @@ static void sp_1024_from_bin(sp_digit* r, int size, const byte* a, int n)
 static int sp_1024_ecc_is_point_18(const sp_point_1024* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*18];
-    sp_digit t2d[2*18];
+    sp_digit t1[18 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int64_t n;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 18 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 18 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 18;
-        t2 = d + 2 * 18;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 18;
 
         sp_1024_sqr_18(t1, point->y);
         (void)sp_1024_mod_18(t1, t1, p1024_mod);
@@ -36793,10 +36627,9 @@ static int sp_1024_ecc_is_point_18(const sp_point_1024* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -36811,14 +36644,21 @@ static int sp_1024_ecc_is_point_18(const sp_point_1024* point,
  */
 int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* pub = NULL;
+#else
+    sp_point_1024 pub[1];
 #endif
-    sp_point_1024* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_1024_point_new_18(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(pub->x, 18, pX);
         sp_1024_from_mp(pub->y, 18, pY);
@@ -36827,7 +36667,10 @@ int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
         err = sp_1024_ecc_is_point_18(pub, NULL);
     }
 
-    sp_1024_point_free_18(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -36846,44 +36689,44 @@ int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_1024(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[18];
-    sp_point_1024 pubd;
-    sp_point_1024 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_1024* pub;
-    sp_point_1024* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_1024_point_new_18(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_18(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 18, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_1024* pub = NULL;
+#else
+    sp_digit priv[18];
+    sp_point_1024 pub[2];
 #endif
+    sp_point_1024* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 1024) ||
+    if (((mp_count_bits(pX) > 1024) ||
         (mp_count_bits(pY) > 1024) ||
         ((privm != NULL) && (mp_count_bits(privm) > 1024)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 18, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_1024_from_mp(pub->x, 18, pX);
         sp_1024_from_mp(pub->y, 18, pY);
@@ -36933,13 +36776,12 @@ int sp_ecc_check_key_1024(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_1024_point_free_18(p, 0, heap);
-    sp_1024_point_free_18(pub, 0, heap);
 
     return err;
 }

--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -3163,12 +3163,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 64];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -3180,19 +3180,14 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 64), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 64;
-#else
-            t[i] = &td[i * 64];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -3288,9 +3283,8 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -3309,12 +3303,12 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 64];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -3326,19 +3320,14 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 64), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 64;
-#else
-            t[i] = &td[i * 64];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -3451,9 +3440,8 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -3900,12 +3888,12 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 128];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -3917,19 +3905,14 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 128), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 128;
-#else
-            t[i] = &td[i * 128];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -4025,9 +4008,8 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -4046,12 +4028,12 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 128];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -4063,19 +4045,14 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 128), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 128;
-#else
-            t[i] = &td[i * 128];
-#endif
         }
 
         sp_2048_mont_setup(m, &mp);
@@ -4188,9 +4165,8 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -4214,18 +4190,15 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
 int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[128];
-    sp_digit m[64];
-    sp_digit r[128];
-#else
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[64 * 5];
+#endif    
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-#endif
     sp_digit *ah = NULL;
-    sp_digit e[1];
+    sp_digit e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 256) {
@@ -4239,22 +4212,18 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
-    }
-
-    if (err == MP_OKAY) {
-        a = d;
-        r = a + 64 * 2;
-        m = r + 64 * 2;
     }
 #endif
 
     if (err == MP_OKAY) {
+        r = a + 64 * 2;
+        m = r + 64 * 2;
         ah = a + 64;
 
         sp_2048_from_bin(ah, 64, in, inLen);
@@ -4327,10 +4296,9 @@ int sp_RsaPublic_2048(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 256;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
 #endif
 
     return err;
@@ -4400,8 +4368,12 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[64 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -4430,13 +4402,15 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 64;
         m = a + 128;
@@ -4447,34 +4421,36 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         sp_2048_from_mp(m, 64, mm);
         err = sp_2048_mod_exp_64(r, a, d, 2048, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_2048_to_bin(r, out);
         *outLen = 256;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 64);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 64);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[64 * 2];
-    sp_digit p[32];
-    sp_digit q[32];
-    sp_digit dp[32];
-    sp_digit tmpa[64];
-    sp_digit tmpb[64];
-#else
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[32 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
     sp_digit* tmpa = NULL;
     sp_digit* tmpb = NULL;
-#endif
     sp_digit* r = NULL;
     sp_digit* qi = NULL;
     sp_digit* dq = NULL;
@@ -4494,31 +4470,23 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
+
     if (err == MP_OKAY) {
-        a = t;
         p = a + 64 * 2;
         q = p + 32;
         qi = dq = dp = q + 32;
         tmpa = qi + 32;
         tmpb = tmpa + 64;
-
-        r = t + 64;
-    }
-#else
-#endif
-
-    if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         r = a;
-        qi = dq = dp;
-#endif
+
         sp_2048_from_bin(a, 64, in, inLen);
         sp_2048_from_mp(p, 32, pm);
         sp_2048_from_mp(q, 32, qm);
@@ -4550,19 +4518,16 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 256;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 32 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
-    }
-#else
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p,    0, sizeof(p));
-    XMEMSET(q,    0, sizeof(q));
-    XMEMSET(dp,   0, sizeof(dp));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
 #endif
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+    {
+        ForceZero(a, sizeof(sp_digit) * 32 * 11);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -5104,12 +5069,12 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
         const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[193];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -5122,18 +5087,13 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 193, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp = td + 128;
-#else
-        tmp = &td[128];
-#endif
 
         sp_2048_mont_setup(m, &mp);
         sp_2048_mont_norm_64(norm, m);
@@ -5204,9 +5164,8 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -8098,12 +8057,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 96];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -8115,19 +8074,14 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 96), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 96;
-#else
-            t[i] = &td[i * 96];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -8223,9 +8177,8 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -8244,12 +8197,12 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 96];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -8261,19 +8214,14 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 96), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 96;
-#else
-            t[i] = &td[i * 96];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -8386,9 +8334,8 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -8838,12 +8785,12 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 192];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -8855,19 +8802,14 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 192), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 192;
-#else
-            t[i] = &td[i * 192];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -8963,9 +8905,8 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -8984,12 +8925,12 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 192];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -9001,19 +8942,14 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 192), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 192;
-#else
-            t[i] = &td[i * 192];
-#endif
         }
 
         sp_3072_mont_setup(m, &mp);
@@ -9126,9 +9062,8 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -9152,18 +9087,15 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
 int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[192];
-    sp_digit m[96];
-    sp_digit r[192];
-#else
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[96 * 5];
+#endif    
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-#endif
     sp_digit *ah = NULL;
-    sp_digit e[1];
+    sp_digit e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 384) {
@@ -9177,22 +9109,18 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 96 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 96 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
-    }
-
-    if (err == MP_OKAY) {
-        a = d;
-        r = a + 96 * 2;
-        m = r + 96 * 2;
     }
 #endif
 
     if (err == MP_OKAY) {
+        r = a + 96 * 2;
+        m = r + 96 * 2;
         ah = a + 96;
 
         sp_3072_from_bin(ah, 96, in, inLen);
@@ -9265,10 +9193,9 @@ int sp_RsaPublic_3072(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 384;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
 #endif
 
     return err;
@@ -9338,8 +9265,12 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[96 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -9368,13 +9299,15 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 96 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 96;
         m = a + 192;
@@ -9385,34 +9318,36 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_from_mp(m, 96, mm);
         err = sp_3072_mod_exp_96(r, a, d, 3072, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_3072_to_bin(r, out);
         *outLen = 384;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 96);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 96);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[96 * 2];
-    sp_digit p[48];
-    sp_digit q[48];
-    sp_digit dp[48];
-    sp_digit tmpa[96];
-    sp_digit tmpb[96];
-#else
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[48 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
     sp_digit* tmpa = NULL;
     sp_digit* tmpb = NULL;
-#endif
     sp_digit* r = NULL;
     sp_digit* qi = NULL;
     sp_digit* dq = NULL;
@@ -9432,31 +9367,23 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 48 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 48 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
+
     if (err == MP_OKAY) {
-        a = t;
         p = a + 96 * 2;
         q = p + 48;
         qi = dq = dp = q + 48;
         tmpa = qi + 48;
         tmpb = tmpa + 96;
-
-        r = t + 96;
-    }
-#else
-#endif
-
-    if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         r = a;
-        qi = dq = dp;
-#endif
+
         sp_3072_from_bin(a, 96, in, inLen);
         sp_3072_from_mp(p, 48, pm);
         sp_3072_from_mp(q, 48, qm);
@@ -9488,19 +9415,16 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 384;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 48 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
-    }
-#else
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p,    0, sizeof(p));
-    XMEMSET(q,    0, sizeof(q));
-    XMEMSET(dp,   0, sizeof(dp));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
 #endif
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+    {
+        ForceZero(a, sizeof(sp_digit) * 48 * 11);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -10238,12 +10162,12 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
         const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[289];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -10256,18 +10180,13 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 289, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp = td + 192;
-#else
-        tmp = &td[192];
-#endif
 
         sp_3072_mont_setup(m, &mp);
         sp_3072_mont_norm_96(norm, m);
@@ -10338,9 +10257,8 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -12189,12 +12107,12 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[16 * 256];
 #endif
     sp_digit* t[16];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -12206,19 +12124,14 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (16 * 256), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<16; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 256;
-#else
-            t[i] = &td[i * 256];
-#endif
         }
 
         sp_4096_mont_setup(m, &mp);
@@ -12314,9 +12227,8 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -12335,12 +12247,12 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
         int bits, const sp_digit* m, int reduceA)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[32 * 256];
 #endif
     sp_digit* t[32];
-    sp_digit* norm;
+    sp_digit* norm = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit mask;
@@ -12352,19 +12264,14 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 * 256), NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
         for (i=0; i<32; i++) {
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
             t[i] = td + i * 256;
-#else
-            t[i] = &td[i * 256];
-#endif
         }
 
         sp_4096_mont_setup(m, &mp);
@@ -12477,9 +12384,8 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -12503,18 +12409,15 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
 int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
     const mp_int* mm, byte* out, word32* outLen)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[256];
-    sp_digit m[128];
-    sp_digit r[256];
-#else
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[128 * 5];
+#endif    
     sp_digit* m = NULL;
     sp_digit* r = NULL;
-#endif
     sp_digit *ah = NULL;
-    sp_digit e[1];
+    sp_digit e[1] = {0};
     int err = MP_OKAY;
 
     if (*outLen < 512) {
@@ -12528,22 +12431,18 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 128 * 5, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 128 * 5, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL)
+        if (a == NULL)
             err = MEMORY_E;
-    }
-
-    if (err == MP_OKAY) {
-        a = d;
-        r = a + 128 * 2;
-        m = r + 128 * 2;
     }
 #endif
 
     if (err == MP_OKAY) {
+        r = a + 128 * 2;
+        m = r + 128 * 2;
         ah = a + 128;
 
         sp_4096_from_bin(ah, 128, in, inLen);
@@ -12616,10 +12515,9 @@ int sp_RsaPublic_4096(const byte* in, word32 inLen, const mp_int* em,
         *outLen = 512;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_RSA);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
 #endif
 
     return err;
@@ -12690,8 +12588,12 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
     const mp_int* qim, const mp_int* mm, byte* out, word32* outLen)
 {
 #if defined(SP_RSA_PRIVATE_EXP_D) || defined(RSA_LOW_MEM)
-    sp_digit* a = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* d = NULL;
+#else
+    sp_digit  d[128 * 4];
+#endif
+    sp_digit* a = NULL;
     sp_digit* m = NULL;
     sp_digit* r = NULL;
     int err = MP_OKAY;
@@ -12720,13 +12622,15 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         }
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 128 * 4, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (d == NULL) {
+        if (d == NULL)
             err = MEMORY_E;
-        }
     }
+#endif
+
     if (err == MP_OKAY) {
         a = d + 128;
         m = a + 256;
@@ -12737,34 +12641,36 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_from_mp(m, 128, mm);
         err = sp_4096_mod_exp_128(r, a, d, 4096, m, 0);
     }
+
     if (err == MP_OKAY) {
         sp_4096_to_bin(r, out);
         *outLen = 512;
     }
 
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 128);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (d != NULL)
+#endif
+    {
+        /* only "a" and "r" are sensitive and need zeroized (same pointer) */
+        if (a != NULL)
+            ForceZero(a, sizeof(sp_digit) * 128);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         XFREE(d, NULL, DYNAMIC_TYPE_RSA);
+#endif
     }
 
     return err;
 #else
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit a[128 * 2];
-    sp_digit p[64];
-    sp_digit q[64];
-    sp_digit dp[64];
-    sp_digit tmpa[128];
-    sp_digit tmpb[128];
-#else
-    sp_digit* t = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* a = NULL;
+#else
+    sp_digit a[64 * 11];
+#endif
     sp_digit* p = NULL;
     sp_digit* q = NULL;
     sp_digit* dp = NULL;
     sp_digit* tmpa = NULL;
     sp_digit* tmpb = NULL;
-#endif
     sp_digit* r = NULL;
     sp_digit* qi = NULL;
     sp_digit* dq = NULL;
@@ -12784,31 +12690,23 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         err = MP_VAL;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 11, NULL,
+        a = (sp_digit*)XMALLOC(sizeof(sp_digit) * 64 * 11, NULL,
                                                               DYNAMIC_TYPE_RSA);
-        if (t == NULL)
+        if (a == NULL)
             err = MEMORY_E;
     }
+#endif
+
     if (err == MP_OKAY) {
-        a = t;
         p = a + 128 * 2;
         q = p + 64;
         qi = dq = dp = q + 64;
         tmpa = qi + 64;
         tmpb = tmpa + 128;
-
-        r = t + 128;
-    }
-#else
-#endif
-
-    if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
         r = a;
-        qi = dq = dp;
-#endif
+
         sp_4096_from_bin(a, 128, in, inLen);
         sp_4096_from_mp(p, 64, pm);
         sp_4096_from_mp(q, 64, qm);
@@ -12840,19 +12738,16 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         *outLen = 512;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_digit) * 64 * 11);
-        XFREE(t, NULL, DYNAMIC_TYPE_RSA);
-    }
-#else
-    XMEMSET(tmpa, 0, sizeof(tmpa));
-    XMEMSET(tmpb, 0, sizeof(tmpb));
-    XMEMSET(p,    0, sizeof(p));
-    XMEMSET(q,    0, sizeof(q));
-    XMEMSET(dp,   0, sizeof(dp));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (a != NULL)
 #endif
-#endif /* SP_RSA_PRIVATE_EXP_D | RSA_LOW_MEM */
+    {
+        ForceZero(a, sizeof(sp_digit) * 64 * 11);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(a, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+    }
+#endif /* SP_RSA_PRIVATE_EXP_D || RSA_LOW_MEM */
     return err;
 }
 #endif /* WOLFSSL_RSA_PUBLIC_ONLY */
@@ -13786,12 +13681,12 @@ static int sp_4096_mod_exp_2_128(sp_digit* r, const sp_digit* e, int bits,
         const sp_digit* m)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* td;
+    sp_digit* td = NULL;
 #else
     sp_digit td[385];
 #endif
-    sp_digit* norm;
-    sp_digit* tmp;
+    sp_digit* norm = NULL;
+    sp_digit* tmp = NULL;
     sp_digit mp = 1;
     sp_digit n;
     sp_digit o;
@@ -13804,18 +13699,13 @@ static int sp_4096_mod_exp_2_128(sp_digit* r, const sp_digit* e, int bits,
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     td = (sp_digit*)XMALLOC(sizeof(sp_digit) * 385, NULL,
                             DYNAMIC_TYPE_TMP_BUFFER);
-    if (td == NULL) {
+    if (td == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
         norm = td;
-#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         tmp = td + 256;
-#else
-        tmp = &td[256];
-#endif
 
         sp_4096_mont_setup(m, &mp);
         sp_4096_mont_norm_128(norm, m);
@@ -13886,9 +13776,8 @@ static int sp_4096_mod_exp_2_128(sp_digit* r, const sp_digit* e, int bits,
     }
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (td != NULL) {
+    if (td != NULL)
         XFREE(td, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
 #endif
 
     return err;
@@ -15088,64 +14977,6 @@ SP_NOINLINE static sp_digit sp_256_sub_8(sp_digit* r, const sp_digit* a,
 }
 
 #endif /* WOLFSSL_SP_SMALL */
-/* Create a new point.
- *
- * heap  [in]   Buffer to allocate dynamic memory from.
- * sp    [in]   Data for point - only if not allocating.
- * p     [out]  New point.
- * returns MEMORY_E when dynamic memory allocation fails and 0 otherwise.
- */
-static int sp_256_point_new_ex_8(void* heap, sp_point_256* sp,
-    sp_point_256** p)
-{
-    int ret = MP_OKAY;
-    (void)heap;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    (void)sp;
-    *p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap, DYNAMIC_TYPE_ECC);
-#else
-    *p = sp;
-#endif
-    if (*p == NULL) {
-        ret = MEMORY_E;
-    }
-    return ret;
-}
-
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* Allocate memory for point and return error. */
-#define sp_256_point_new_8(heap, sp, p) sp_256_point_new_ex_8((heap), NULL, &(p))
-#else
-/* Set pointer to data and return no error. */
-#define sp_256_point_new_8(heap, sp, p) sp_256_point_new_ex_8((heap), &(sp), &(p))
-#endif
-
-
-/* Free the point.
- *
- * p      [in,out]  Point to free.
- * clear  [in]      Indicates whether to zeroize point.
- * heap   [in]      Buffer from which dynamic memory was allocate from.
- */
-static void sp_256_point_free_8(sp_point_256* p, int clear, void* heap)
-{
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* If valid pointer then clear point data if requested and free data. */
-    if (p != NULL) {
-        if (clear != 0) {
-            XMEMSET(p, 0, sizeof(*p));
-        }
-        XFREE(p, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-/* Clear point data if requested. */
-    if ((p != NULL) && (clear != 0)) {
-        XMEMSET(p, 0, sizeof(*p));
-    }
-#endif
-    (void)heap;
-}
-
 /* Multiply a number by Montogmery normalizer mod modulus (prime).
  *
  * r  The resulting Montgomery form number.
@@ -18164,56 +17995,55 @@ static void sp_256_get_point_16_8(sp_point_256* r, const sp_point_256* table,
 static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, const sp_digit* k,
         int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td[16];
-    sp_point_256 rtd;
-    sp_digit tmpd[2 * 8 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_256 t[16];
+    sp_digit tmp[2 * 8 * 5];
+#endif
+    sp_point_256* rt = NULL;
 #ifndef WC_NO_CACHE_RESISTANT
-    sp_point_256 pd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* p = NULL;
+#else
+    sp_point_256 p[1];
 #endif
-#endif
-    sp_point_256* t;
-    sp_point_256* rt;
-#ifndef WC_NO_CACHE_RESISTANT
-    sp_point_256* p;
-#endif
-    sp_digit* tmp;
+#endif /* !WC_NO_CACHE_RESISTANT */
     sp_digit n;
     int i;
     int c;
     int y;
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_256_point_new_8(heap, rtd, rt);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-#ifndef WC_NO_CACHE_RESISTANT
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 17, heap, DYNAMIC_TYPE_ECC);
-#else
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 16, heap, DYNAMIC_TYPE_ECC);
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 16,
+        heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    #ifndef WC_NO_CACHE_RESISTANT
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256),
+            heap, DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
+    #endif
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
+                                DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
-#ifndef WC_NO_CACHE_RESISTANT
-    #if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        p = t + 16;
-    #else
-        p = &pd;
-    #endif
-#endif
+        rt = t + 16;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -18301,20 +18131,35 @@ static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, cons
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 8 * 5);
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_256) * 16);
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmpd, sizeof(tmpd));
-    ForceZero(td, sizeof(td));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
-    sp_256_point_free_8(rt, 1, heap);
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 8 * 5);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#ifndef WC_NO_CACHE_RESISTANT
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (p != NULL)
+    #endif
+        {
+            ForceZero(p, sizeof(sp_point_256));
+        #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+            XFREE(p, heap, DYNAMIC_TYPE_ECC);
+        #endif
+        }
+#endif /* !WC_NO_CACHE_RESISTANT */
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_256) * 17);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -18538,29 +18383,30 @@ static void sp_256_proj_point_add_qz1_8(sp_point_256* r, const sp_point_256* p,
 static int sp_256_gen_stripe_table_8(const sp_point_256* a,
         sp_table_entry_256* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td;
-    sp_point_256 s1d;
-    sp_point_256 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+#else
+    sp_point_256 t[3];
 #endif
-    sp_point_256* t;
     sp_point_256* s1 = NULL;
     sp_point_256* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_256_point_new_8(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_256_mod_mul_norm_8(t->x, a->x, p256_mod);
     }
     if (err == MP_OKAY) {
@@ -18605,9 +18451,10 @@ static int sp_256_gen_stripe_table_8(const sp_point_256* a,
         }
     }
 
-    sp_256_point_free_8(s2, 0, heap);
-    sp_256_point_free_8(s1, 0, heap);
-    sp_256_point_free_8( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -18683,19 +18530,19 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
         const sp_table_entry_256* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit td[2 * 8 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_256 rt[2];
+    sp_digit t[2 * 8 * 5];
 #endif
-    sp_point_256* rt;
     sp_point_256* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -18703,21 +18550,22 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
     (void)heap;
 
 
-    err = sp_256_point_new_8(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p256_norm_mod, sizeof(p256_norm_mod));
         XMEMCPY(rt->z, p256_norm_mod, sizeof(p256_norm_mod));
 
@@ -18768,13 +18616,12 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p, 0, heap);
-    sp_256_point_free_8(rt, 0, heap);
 
     return err;
 }
@@ -18940,29 +18787,30 @@ static int sp_256_ecc_mulmod_8(sp_point_256* r, const sp_point_256* g, const sp_
 static int sp_256_gen_stripe_table_8(const sp_point_256* a,
         sp_table_entry_256* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 td;
-    sp_point_256 s1d;
-    sp_point_256 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* t = NULL;
+#else
+    sp_point_256 t[3];
 #endif
-    sp_point_256* t;
     sp_point_256* s1 = NULL;
     sp_point_256* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_256_point_new_8(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_256_mod_mul_norm_8(t->x, a->x, p256_mod);
     }
     if (err == MP_OKAY) {
@@ -19007,9 +18855,10 @@ static int sp_256_gen_stripe_table_8(const sp_point_256* a,
         }
     }
 
-    sp_256_point_free_8(s2, 0, heap);
-    sp_256_point_free_8(s1, 0, heap);
-    sp_256_point_free_8( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -19085,19 +18934,19 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
         const sp_table_entry_256* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 rtd;
-    sp_point_256 pd;
-    sp_digit td[2 * 8 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_256 rt[2];
+    sp_digit t[2 * 8 * 5];
 #endif
-    sp_point_256* rt;
     sp_point_256* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -19105,21 +18954,22 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
     (void)heap;
 
 
-    err = sp_256_point_new_8(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p256_norm_mod, sizeof(p256_norm_mod));
         XMEMCPY(rt->z, p256_norm_mod, sizeof(p256_norm_mod));
 
@@ -19170,13 +19020,12 @@ static int sp_256_ecc_mulmod_stripe_8(sp_point_256* r, const sp_point_256* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p, 0, heap);
-    sp_256_point_free_8(rt, 0, heap);
 
     return err;
 }
@@ -19340,25 +19189,28 @@ static int sp_256_ecc_mulmod_8(sp_point_256* r, const sp_point_256* g, const sp_
 int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[8];
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[1];
+    sp_digit k[8];
+#endif
     int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(k, 8, km);
         sp_256_point_from_ecc_point_8(point, gm);
@@ -19369,12 +19221,12 @@ int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_256_point_to_ecc_point_8(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -19394,37 +19246,35 @@ int sp_ecc_mulmod_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
 int sp_ecc_mulmod_add_256(const mp_int* km, const ecc_point* gm,
     const ecc_point* am, int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_point_256 a;
-    sp_digit kd[8];
-    sp_digit t[8 * 2 * 5];
-#endif
-    sp_point_256* point;
-    sp_point_256* addP = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;    
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[2];
+    sp_digit k[8 + 8 * 2 * 5];
+#endif
+    sp_point_256* addP = NULL;
     sp_digit* tmp = NULL;
     int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (8 + 8 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (8 + 8 * 2 * 5), heap,
+            DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 8;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 8;
+
         sp_256_from_mp(k, 8, km);
         sp_256_point_from_ecc_point_8(point, gm);
         sp_256_point_from_ecc_point_8(addP, am);
@@ -19451,13 +19301,12 @@ int sp_ecc_mulmod_add_256(const mp_int* km, const ecc_point* gm,
         err = sp_256_point_to_ecc_point_8(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(addP, 0, heap);
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -20891,26 +20740,28 @@ static int sp_256_ecc_mulmod_base_8(sp_point_256* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[8];
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256  point[1];
+    sp_digit k[8];
+#endif
     int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(k, 8, km);
 
@@ -20920,12 +20771,12 @@ int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_256_point_to_ecc_point_8(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -20944,37 +20795,35 @@ int sp_ecc_mulmod_base_256(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_point_256 a;
-    sp_digit kd[8];
-    sp_digit t[8 * 2 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_256 point[2];
+    sp_digit k[8 + 8 * 2 * 5];
 #endif
-    sp_point_256* point;
     sp_point_256* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (8 + 8 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (8 + 8 * 2 * 5),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 8;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 8;
+
         sp_256_from_mp(k, 8, km);
         sp_256_point_from_ecc_point_8(addP, am);
     }
@@ -21000,13 +20849,12 @@ int sp_ecc_mulmod_base_add_256(const mp_int* km, const ecc_point* am,
         err = sp_256_point_to_ecc_point_8(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(addP, 0, heap);
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -21137,41 +20985,46 @@ static int sp_256_ecc_gen_k_8(WC_RNG* rng, sp_digit* k)
  */
 int sp_ecc_make_key_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[8];
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_point_256 inf;
-#endif
-#endif
-    sp_point_256* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    sp_point_256 point[2];
+    #else
+    sp_point_256 point[1];
+    #endif
+    sp_digit k[8];
+#endif
 #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
     sp_point_256* infinity = NULL;
 #endif
-    int err;
+    int err = MP_OKAY;
+    
 
     (void)heap;
 
-    err = sp_256_point_new_8(heap, p, point);
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, inf, infinity);
-    }
-#endif
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap, DYNAMIC_TYPE_ECC);
+    #else
+    point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap, DYNAMIC_TYPE_ECC);    
+    #endif
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+        infinity = point + 1;
+    #endif
+
         err = sp_256_ecc_gen_k_8(rng, k);
     }
     if (err == MP_OKAY) {
@@ -21196,15 +21049,14 @@ int sp_ecc_make_key_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
         err = sp_256_point_to_ecc_point_8(point, pub);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL) {
+        /* point is not sensitive, so no need to zeroize */
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
     }
 #endif
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_256_point_free_8(infinity, 1, heap);
-#endif
-    sp_256_point_free_8(point, 1, heap);
 
     return err;
 }
@@ -21265,30 +21117,32 @@ static void sp_256_to_bin(sp_digit* r, byte* a)
 int sp_ecc_secret_gen_256(const mp_int* priv, const ecc_point* pub, byte* out,
                           word32* outLen, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 p;
-    sp_digit kd[8];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_256* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_256 point[1];
+    sp_digit k[8];
+#endif
     int err = MP_OKAY;
 
     if (*outLen < 32U) {
         err = BUFFER_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, p, point);
+        point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                         DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
@@ -21301,12 +21155,12 @@ int sp_ecc_secret_gen_256(const mp_int* priv, const ecc_point* pub, byte* out,
         *outLen = 32;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(point, 0, heap);
 
     return err;
 }
@@ -22002,22 +21856,17 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
 int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
     const mp_int* priv, mp_int* rm, mp_int* sm, mp_int* km, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit ed[2*8];
-    sp_digit xd[2*8];
-    sp_digit kd[2*8];
-    sp_digit rd[2*8];
-    sp_digit td[3 * 2*8];
-    sp_point_256 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* e = NULL;
+    sp_point_256* point = NULL;
+#else
+    sp_digit e[7 * 2 * 8];
+    sp_point_256 point[1];
+#endif
     sp_digit* x = NULL;
     sp_digit* k = NULL;
     sp_digit* r = NULL;
     sp_digit* tmp = NULL;
-    sp_point_256* point = NULL;
     sp_digit* s = NULL;
     int32_t c;
     int err = MP_OKAY;
@@ -22025,31 +21874,26 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
 
     (void)heap;
 
-    err = sp_256_point_new_8(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        point = (sp_point_256*)XMALLOC(sizeof(sp_point_256), heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (point == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        e = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 8, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (e == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        e = d + 0 * 8;
-        x = d + 2 * 8;
-        k = d + 4 * 8;
-        r = d + 6 * 8;
-        tmp = d + 8 * 8;
-#else
-        e = ed;
-        x = xd;
-        k = kd;
-        r = rd;
-        tmp = td;
-#endif
+        x = e + 2 * 8;
+        k = e + 4 * 8;
+        r = e + 6 * 8;
+        tmp = e + 8 * 8;
         s = e;
 
         if (hashLen > 32U) {
@@ -22104,19 +21948,24 @@ int sp_ecc_sign_256(const byte* hash, word32 hashLen, WC_RNG* rng,
         err = sp_256_to_mp(s, sm);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 8 * 8);
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 2U * 8U);
-    XMEMSET(x, 0, sizeof(sp_digit) * 2U * 8U);
-    XMEMSET(k, 0, sizeof(sp_digit) * 2U * 8U);
-    XMEMSET(r, 0, sizeof(sp_digit) * 2U * 8U);
-    XMEMSET(tmp, 0, sizeof(sp_digit) * 3U * 2U * 8U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (e != NULL)
 #endif
-    sp_256_point_free_8(point, 1, heap);
+    {
+        ForceZero(e, sizeof(sp_digit) * 7 * 2 * 8);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(e, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (point != NULL)
+#endif
+    {
+        ForceZero(point, sizeof(sp_point_256));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -22694,52 +22543,41 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
     const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
     int* res, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit u1d[2*8];
-    sp_digit u2d[2*8];
-    sp_digit sd[2*8];
-    sp_digit tmpd[2*8 * 5];
-    sp_point_256 p1d;
-    sp_point_256 p2d;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* u1 = NULL;
+    sp_point_256* p1 = NULL;
+#else
+    sp_digit  u1[16 * 8];
+    sp_point_256 p1[2];
+#endif
     sp_digit* u2 = NULL;
     sp_digit* s = NULL;
     sp_digit* tmp = NULL;
-    sp_point_256* p1;
     sp_point_256* p2 = NULL;
     sp_digit carry;
     int32_t c = 0;
-    int err;
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_8(heap, p1d, p1);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, p2d, p2);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        p1 = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (p1 == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        u1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 8, heap,
+                                                              DYNAMIC_TYPE_ECC);
+        if (u1 == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        u1  = d + 0 * 8;
-        u2  = d + 2 * 8;
-        s   = d + 4 * 8;
-        tmp = d + 6 * 8;
-#else
-        u1 = u1d;
-        u2 = u2d;
-        s  = sd;
-        tmp = tmpd;
-#endif
+        u2  = u1 + 2 * 8;
+        s   = u1 + 4 * 8;
+        tmp = u1 + 6 * 8;
+        p2 = p1 + 1;
 
         if (hashLen > 32U) {
             hashLen = 32U;
@@ -22790,12 +22628,12 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL)
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (u1 != NULL)
+        XFREE(u1, heap, DYNAMIC_TYPE_ECC);
+    if (p1 != NULL)
+        XFREE(p1, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p1, 0, heap);
-    sp_256_point_free_8(p2, 0, heap);
 
     return err;
 }
@@ -22812,32 +22650,23 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
 static int sp_256_ecc_is_point_8(const sp_point_256* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*8];
-    sp_digit t2d[2*8];
+    sp_digit t1[8 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 8;
-        t2 = d + 2 * 8;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 8;
 
         sp_256_sqr_8(t1, point->y);
         (void)sp_256_mod_8(t1, t1, p256_mod);
@@ -22857,10 +22686,9 @@ static int sp_256_ecc_is_point_8(const sp_point_256* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -22875,14 +22703,21 @@ static int sp_256_ecc_is_point_8(const sp_point_256* point,
  */
 int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_256 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_256* pub = NULL;
+#else
+    sp_point_256 pub[1];
 #endif
-    sp_point_256* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_8(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_256_from_mp(pub->x, 8, pX);
         sp_256_from_mp(pub->y, 8, pY);
@@ -22891,7 +22726,10 @@ int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
         err = sp_256_ecc_is_point_8(pub, NULL);
     }
 
-    sp_256_point_free_8(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -22910,44 +22748,44 @@ int sp_ecc_is_point_256(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_256(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[8];
-    sp_point_256 pubd;
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_256* pub;
-    sp_point_256* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_256_point_new_8(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_256_point_new_8(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_256* pub = NULL;
+#else
+    sp_digit priv[8];
+    sp_point_256 pub[2];
 #endif
+    sp_point_256* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 256) ||
+    if (((mp_count_bits(pX) > 256) ||
         (mp_count_bits(pY) > 256) ||
         ((privm != NULL) && (mp_count_bits(privm) > 256)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 8, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_256_from_mp(pub->x, 8, pX);
         sp_256_from_mp(pub->y, 8, pY);
@@ -22997,13 +22835,12 @@ int sp_ecc_check_key_256(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_256_point_free_8(p, 0, heap);
-    sp_256_point_free_8(pub, 0, heap);
 
     return err;
 }
@@ -23027,33 +22864,35 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* qX, mp_int* qY, mp_int* qZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 8 * 5];
-    sp_point_256 pd;
-    sp_point_256 qd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 8 * 5];
+    sp_point_256 p[2];
+#endif
     sp_point_256* q = NULL;
     int err;
 
-    err = sp_256_point_new_8(NULL, pd, p);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_256_point_new_8(NULL, qd, q);
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 2, NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 5, NULL,
-                                                              DYNAMIC_TYPE_ECC);
+                                 DYNAMIC_TYPE_ECC);
         if (tmp == NULL) {
             err = MEMORY_E;
         }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
+        q = p + 1;
+
         sp_256_from_mp(p->x, 8, pX);
         sp_256_from_mp(p->y, 8, pY);
         sp_256_from_mp(p->z, 8, pZ);
@@ -23074,13 +22913,12 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_256_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(q, 0, NULL);
-    sp_256_point_free_8(p, 0, NULL);
 
     return err;
 }
@@ -23099,25 +22937,28 @@ int sp_ecc_proj_add_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
 int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 8 * 2];
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
-    int err;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 8 * 2];
+    sp_point_256 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_8(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 2, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
@@ -23138,12 +22979,12 @@ int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_256_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p, 0, NULL);
 
     return err;
 }
@@ -23158,25 +22999,29 @@ int sp_ecc_proj_dbl_point_256(mp_int* pX, mp_int* pY, mp_int* pZ,
  */
 int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 8 * 4];
-    sp_point_256 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_256* p;
-    int err;
+    sp_point_256* p = NULL;
+#else
+    sp_digit tmp[2 * 8 * 4];
+    sp_point_256 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_256_point_new_8(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_256*)XMALLOC(sizeof(sp_point_256), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 8 * 4, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
     if (err == MP_OKAY) {
         sp_256_from_mp(p->x, 8, pX);
@@ -23196,12 +23041,12 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
         err = sp_256_to_mp(p->z, pZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_256_point_free_8(p, 0, NULL);
 
     return err;
 }
@@ -23214,31 +23059,23 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
  */
 static int sp_256_mont_sqrt_8(sp_digit* y)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2 * 8];
-    sp_digit t2d[2 * 8];
+    sp_digit t1[4 * 8];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL) {
         err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 8;
-        t2 = d + 2 * 8;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 8;
 
         {
             /* t2 = y ^ 0x2 */
@@ -23273,10 +23110,9 @@ static int sp_256_mont_sqrt_8(sp_digit* y)
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -23292,31 +23128,22 @@ static int sp_256_mont_sqrt_8(sp_digit* y)
  */
 int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
-#else
-    sp_digit xd[2 * 8];
-    sp_digit yd[2 * 8];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* x = NULL;
+#else
+    sp_digit x[4 * 8];
+#endif
     sp_digit* y = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    x = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 8, NULL, DYNAMIC_TYPE_ECC);
+    if (x == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        x = d + 0 * 8;
-        y = d + 2 * 8;
-#else
-        x = xd;
-        y = yd;
-#endif
+        y = x + 2 * 8;
 
         sp_256_from_mp(x, 8, xm);
         err = sp_256_mod_mul_norm_8(x, x, p256_mod);
@@ -23349,10 +23176,9 @@ int sp_ecc_uncompress_256(mp_int* xm, int odd, mp_int* ym)
         err = sp_256_to_mp(y, ym);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (x != NULL)
+        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -23855,64 +23681,6 @@ SP_NOINLINE static sp_digit sp_384_sub_12(sp_digit* r, const sp_digit* a,
 }
 
 #endif /* WOLFSSL_SP_SMALL */
-/* Create a new point.
- *
- * heap  [in]   Buffer to allocate dynamic memory from.
- * sp    [in]   Data for point - only if not allocating.
- * p     [out]  New point.
- * returns MEMORY_E when dynamic memory allocation fails and 0 otherwise.
- */
-static int sp_384_point_new_ex_12(void* heap, sp_point_384* sp,
-    sp_point_384** p)
-{
-    int ret = MP_OKAY;
-    (void)heap;
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    (void)sp;
-    *p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap, DYNAMIC_TYPE_ECC);
-#else
-    *p = sp;
-#endif
-    if (*p == NULL) {
-        ret = MEMORY_E;
-    }
-    return ret;
-}
-
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* Allocate memory for point and return error. */
-#define sp_384_point_new_12(heap, sp, p) sp_384_point_new_ex_12((heap), NULL, &(p))
-#else
-/* Set pointer to data and return no error. */
-#define sp_384_point_new_12(heap, sp, p) sp_384_point_new_ex_12((heap), &(sp), &(p))
-#endif
-
-
-/* Free the point.
- *
- * p      [in,out]  Point to free.
- * clear  [in]      Indicates whether to zeroize point.
- * heap   [in]      Buffer from which dynamic memory was allocate from.
- */
-static void sp_384_point_free_12(sp_point_384* p, int clear, void* heap)
-{
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-/* If valid pointer then clear point data if requested and free data. */
-    if (p != NULL) {
-        if (clear != 0) {
-            XMEMSET(p, 0, sizeof(*p));
-        }
-        XFREE(p, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-/* Clear point data if requested. */
-    if ((p != NULL) && (clear != 0)) {
-        XMEMSET(p, 0, sizeof(*p));
-    }
-#endif
-    (void)heap;
-}
-
 /* Multiply a number by Montogmery normalizer mod modulus (prime).
  *
  * r  The resulting Montgomery form number.
@@ -23922,8 +23690,8 @@ static void sp_384_point_free_12(sp_point_384* p, int clear, void* heap)
  */
 static int sp_384_mod_mul_norm_12(sp_digit* r, const sp_digit* a, const sp_digit* m)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    int64_t* t;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    int64_t* t = NULL;
 #else
     int64_t t[12];
 #endif
@@ -23932,7 +23700,7 @@ static int sp_384_mod_mul_norm_12(sp_digit* r, const sp_digit* a, const sp_digit
 
     (void)m;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     t = (int64_t*)XMALLOC(sizeof(int64_t) * 12, NULL, DYNAMIC_TYPE_ECC);
     if (t == NULL) {
         err = MEMORY_E;
@@ -24007,7 +23775,7 @@ static int sp_384_mod_mul_norm_12(sp_digit* r, const sp_digit* a, const sp_digit
         r[11] = t[11];
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (t != NULL)
         XFREE(t, NULL, DYNAMIC_TYPE_ECC);
 #endif
@@ -25380,56 +25148,55 @@ static void sp_384_get_point_16_12(sp_point_384* r, const sp_point_384* table,
 static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, const sp_digit* k,
         int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td[16];
-    sp_point_384 rtd;
-    sp_digit tmpd[2 * 12 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_384 t[16];
+    sp_digit tmp[2 * 12 * 6];
+#endif
+    sp_point_384* rt = NULL;
 #ifndef WC_NO_CACHE_RESISTANT
-    sp_point_384 pd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* p = NULL;
+#else
+    sp_point_384 p[1];
 #endif
-#endif
-    sp_point_384* t;
-    sp_point_384* rt;
-#ifndef WC_NO_CACHE_RESISTANT
-    sp_point_384* p;
-#endif
-    sp_digit* tmp;
+#endif /* !WC_NO_CACHE_RESISTANT */
     sp_digit n;
     int i;
     int c;
     int y;
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_384_point_new_12(heap, rtd, rt);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-#ifndef WC_NO_CACHE_RESISTANT
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 17, heap, DYNAMIC_TYPE_ECC);
-#else
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 16, heap, DYNAMIC_TYPE_ECC);
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 16,
+        heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    #ifndef WC_NO_CACHE_RESISTANT
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384),
+            heap, DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
+    #endif
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
+                                DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
-#ifndef WC_NO_CACHE_RESISTANT
-    #if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        p = t + 16;
-    #else
-        p = &pd;
-    #endif
-#endif
+        rt = t + 16;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -25517,20 +25284,35 @@ static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, con
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 12 * 6);
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_384) * 16);
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmpd, sizeof(tmpd));
-    ForceZero(td, sizeof(td));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
-    sp_384_point_free_12(rt, 1, heap);
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 12 * 6);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#ifndef WC_NO_CACHE_RESISTANT
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (p != NULL)
+    #endif
+        {
+            ForceZero(p, sizeof(sp_point_384));
+        #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+            XFREE(p, heap, DYNAMIC_TYPE_ECC);
+        #endif
+        }
+#endif /* !WC_NO_CACHE_RESISTANT */
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_384) * 17);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -25754,29 +25536,30 @@ static void sp_384_proj_point_add_qz1_12(sp_point_384* r, const sp_point_384* p,
 static int sp_384_gen_stripe_table_12(const sp_point_384* a,
         sp_table_entry_384* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td;
-    sp_point_384 s1d;
-    sp_point_384 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+#else
+    sp_point_384 t[3];
 #endif
-    sp_point_384* t;
     sp_point_384* s1 = NULL;
     sp_point_384* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_384_point_new_12(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_384_mod_mul_norm_12(t->x, a->x, p384_mod);
     }
     if (err == MP_OKAY) {
@@ -25821,9 +25604,10 @@ static int sp_384_gen_stripe_table_12(const sp_point_384* a,
         }
     }
 
-    sp_384_point_free_12(s2, 0, heap);
-    sp_384_point_free_12(s1, 0, heap);
-    sp_384_point_free_12( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -25915,19 +25699,19 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
         const sp_table_entry_384* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit td[2 * 12 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_384 rt[2];
+    sp_digit t[2 * 12 * 6];
 #endif
-    sp_point_384* rt;
     sp_point_384* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -25935,21 +25719,22 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
     (void)heap;
 
 
-    err = sp_384_point_new_12(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p384_norm_mod, sizeof(p384_norm_mod));
         XMEMCPY(rt->z, p384_norm_mod, sizeof(p384_norm_mod));
 
@@ -26000,13 +25785,12 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p, 0, heap);
-    sp_384_point_free_12(rt, 0, heap);
 
     return err;
 }
@@ -26172,29 +25956,30 @@ static int sp_384_ecc_mulmod_12(sp_point_384* r, const sp_point_384* g, const sp
 static int sp_384_gen_stripe_table_12(const sp_point_384* a,
         sp_table_entry_384* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 td;
-    sp_point_384 s1d;
-    sp_point_384 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* t = NULL;
+#else
+    sp_point_384 t[3];
 #endif
-    sp_point_384* t;
     sp_point_384* s1 = NULL;
     sp_point_384* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_384_point_new_12(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_384_mod_mul_norm_12(t->x, a->x, p384_mod);
     }
     if (err == MP_OKAY) {
@@ -26239,9 +26024,10 @@ static int sp_384_gen_stripe_table_12(const sp_point_384* a,
         }
     }
 
-    sp_384_point_free_12(s2, 0, heap);
-    sp_384_point_free_12(s1, 0, heap);
-    sp_384_point_free_12( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -26333,19 +26119,19 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
         const sp_table_entry_384* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 rtd;
-    sp_point_384 pd;
-    sp_digit td[2 * 12 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_384 rt[2];
+    sp_digit t[2 * 12 * 6];
 #endif
-    sp_point_384* rt;
     sp_point_384* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -26353,21 +26139,22 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
     (void)heap;
 
 
-    err = sp_384_point_new_12(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p384_norm_mod, sizeof(p384_norm_mod));
         XMEMCPY(rt->z, p384_norm_mod, sizeof(p384_norm_mod));
 
@@ -26418,13 +26205,12 @@ static int sp_384_ecc_mulmod_stripe_12(sp_point_384* r, const sp_point_384* g,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p, 0, heap);
-    sp_384_point_free_12(rt, 0, heap);
 
     return err;
 }
@@ -26588,25 +26374,28 @@ static int sp_384_ecc_mulmod_12(sp_point_384* r, const sp_point_384* g, const sp
 int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[12];
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[1];
+    sp_digit k[12];
+#endif
     int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(k, 12, km);
         sp_384_point_from_ecc_point_12(point, gm);
@@ -26617,12 +26406,12 @@ int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_384_point_to_ecc_point_12(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -26642,37 +26431,35 @@ int sp_ecc_mulmod_384(const mp_int* km, const ecc_point* gm, ecc_point* r,
 int sp_ecc_mulmod_add_384(const mp_int* km, const ecc_point* gm,
     const ecc_point* am, int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_point_384 a;
-    sp_digit kd[12];
-    sp_digit t[12 * 2 * 6];
-#endif
-    sp_point_384* point;
-    sp_point_384* addP = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;    
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[2];
+    sp_digit k[12 + 12 * 2 * 6];
+#endif
+    sp_point_384* addP = NULL;
     sp_digit* tmp = NULL;
     int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (12 + 12 * 2 * 6), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (12 + 12 * 2 * 6), heap,
+            DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 12;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 12;
+
         sp_384_from_mp(k, 12, km);
         sp_384_point_from_ecc_point_12(point, gm);
         sp_384_point_from_ecc_point_12(addP, am);
@@ -26699,13 +26486,12 @@ int sp_ecc_mulmod_add_384(const mp_int* km, const ecc_point* gm,
         err = sp_384_point_to_ecc_point_12(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(addP, 0, heap);
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -28139,26 +27925,28 @@ static int sp_384_ecc_mulmod_base_12(sp_point_384* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[12];
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384  point[1];
+    sp_digit k[12];
+#endif
     int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(k, 12, km);
 
@@ -28168,12 +27956,12 @@ int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_384_point_to_ecc_point_12(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -28192,37 +27980,35 @@ int sp_ecc_mulmod_base_384(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_point_384 a;
-    sp_digit kd[12];
-    sp_digit t[12 * 2 * 6];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_384 point[2];
+    sp_digit k[12 + 12 * 2 * 6];
 #endif
-    sp_point_384* point;
     sp_point_384* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (12 + 12 * 2 * 6), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (12 + 12 * 2 * 6),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 12;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 12;
+
         sp_384_from_mp(k, 12, km);
         sp_384_point_from_ecc_point_12(addP, am);
     }
@@ -28248,13 +28034,12 @@ int sp_ecc_mulmod_base_add_384(const mp_int* km, const ecc_point* am,
         err = sp_384_point_to_ecc_point_12(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(addP, 0, heap);
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -28398,41 +28183,46 @@ static int sp_384_ecc_gen_k_12(WC_RNG* rng, sp_digit* k)
  */
 int sp_ecc_make_key_384(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[12];
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_point_384 inf;
-#endif
-#endif
-    sp_point_384* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    sp_point_384 point[2];
+    #else
+    sp_point_384 point[1];
+    #endif
+    sp_digit k[12];
+#endif
 #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
     sp_point_384* infinity = NULL;
 #endif
-    int err;
+    int err = MP_OKAY;
+    
 
     (void)heap;
 
-    err = sp_384_point_new_12(heap, p, point);
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, inf, infinity);
-    }
-#endif
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap, DYNAMIC_TYPE_ECC);
+    #else
+    point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap, DYNAMIC_TYPE_ECC);    
+    #endif
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
+        infinity = point + 1;
+    #endif
+
         err = sp_384_ecc_gen_k_12(rng, k);
     }
     if (err == MP_OKAY) {
@@ -28457,15 +28247,14 @@ int sp_ecc_make_key_384(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* heap)
         err = sp_384_point_to_ecc_point_12(point, pub);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL) {
+        /* point is not sensitive, so no need to zeroize */
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
     }
 #endif
-#ifdef WOLFSSL_VALIDATE_ECC_KEYGEN
-    sp_384_point_free_12(infinity, 1, heap);
-#endif
-    sp_384_point_free_12(point, 1, heap);
 
     return err;
 }
@@ -28526,30 +28315,32 @@ static void sp_384_to_bin(sp_digit* r, byte* a)
 int sp_ecc_secret_gen_384(const mp_int* priv, const ecc_point* pub, byte* out,
                           word32* outLen, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 p;
-    sp_digit kd[12];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_384* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_384 point[1];
+    sp_digit k[12];
+#endif
     int err = MP_OKAY;
 
     if (*outLen < 48U) {
         err = BUFFER_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, p, point);
+        point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                         DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
 
     if (err == MP_OKAY) {
@@ -28562,12 +28353,12 @@ int sp_ecc_secret_gen_384(const mp_int* priv, const ecc_point* pub, byte* out,
         *outLen = 48;
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(point, 0, heap);
 
     return err;
 }
@@ -29248,22 +29039,17 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
 int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
     const mp_int* priv, mp_int* rm, mp_int* sm, mp_int* km, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit ed[2*12];
-    sp_digit xd[2*12];
-    sp_digit kd[2*12];
-    sp_digit rd[2*12];
-    sp_digit td[3 * 2*12];
-    sp_point_384 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* e = NULL;
+    sp_point_384* point = NULL;
+#else
+    sp_digit e[7 * 2 * 12];
+    sp_point_384 point[1];
+#endif
     sp_digit* x = NULL;
     sp_digit* k = NULL;
     sp_digit* r = NULL;
     sp_digit* tmp = NULL;
-    sp_point_384* point = NULL;
     sp_digit* s = NULL;
     int32_t c;
     int err = MP_OKAY;
@@ -29271,31 +29057,26 @@ int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
 
     (void)heap;
 
-    err = sp_384_point_new_12(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        point = (sp_point_384*)XMALLOC(sizeof(sp_point_384), heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (point == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        e = (sp_digit*)XMALLOC(sizeof(sp_digit) * 7 * 2 * 12, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (e == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        e = d + 0 * 12;
-        x = d + 2 * 12;
-        k = d + 4 * 12;
-        r = d + 6 * 12;
-        tmp = d + 8 * 12;
-#else
-        e = ed;
-        x = xd;
-        k = kd;
-        r = rd;
-        tmp = td;
-#endif
+        x = e + 2 * 12;
+        k = e + 4 * 12;
+        r = e + 6 * 12;
+        tmp = e + 8 * 12;
         s = e;
 
         if (hashLen > 48U) {
@@ -29350,19 +29131,24 @@ int sp_ecc_sign_384(const byte* hash, word32 hashLen, WC_RNG* rng,
         err = sp_384_to_mp(s, sm);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XMEMSET(d, 0, sizeof(sp_digit) * 8 * 12);
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    XMEMSET(e, 0, sizeof(sp_digit) * 2U * 12U);
-    XMEMSET(x, 0, sizeof(sp_digit) * 2U * 12U);
-    XMEMSET(k, 0, sizeof(sp_digit) * 2U * 12U);
-    XMEMSET(r, 0, sizeof(sp_digit) * 2U * 12U);
-    XMEMSET(tmp, 0, sizeof(sp_digit) * 3U * 2U * 12U);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (e != NULL)
 #endif
-    sp_384_point_free_12(point, 1, heap);
+    {
+        ForceZero(e, sizeof(sp_digit) * 7 * 2 * 12);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(e, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (point != NULL)
+#endif
+    {
+        ForceZero(point, sizeof(sp_point_384));
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -29988,52 +29774,41 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
     const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
     int* res, void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
-#else
-    sp_digit u1d[2*12];
-    sp_digit u2d[2*12];
-    sp_digit sd[2*12];
-    sp_digit tmpd[2*12 * 5];
-    sp_point_384 p1d;
-    sp_point_384 p2d;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* u1 = NULL;
+    sp_point_384* p1 = NULL;
+#else
+    sp_digit  u1[16 * 12];
+    sp_point_384 p1[2];
+#endif
     sp_digit* u2 = NULL;
     sp_digit* s = NULL;
     sp_digit* tmp = NULL;
-    sp_point_384* p1;
     sp_point_384* p2 = NULL;
     sp_digit carry;
     int32_t c = 0;
-    int err;
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_12(heap, p1d, p1);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, p2d, p2);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (d == NULL) {
+        p1 = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                             DYNAMIC_TYPE_ECC);
+        if (p1 == NULL)
             err = MEMORY_E;
-        }
+    }
+    if (err == MP_OKAY) {
+        u1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 16 * 12, heap,
+                                                              DYNAMIC_TYPE_ECC);
+        if (u1 == NULL)
+            err = MEMORY_E;
     }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        u1  = d + 0 * 12;
-        u2  = d + 2 * 12;
-        s   = d + 4 * 12;
-        tmp = d + 6 * 12;
-#else
-        u1 = u1d;
-        u2 = u2d;
-        s  = sd;
-        tmp = tmpd;
-#endif
+        u2  = u1 + 2 * 12;
+        s   = u1 + 4 * 12;
+        tmp = u1 + 6 * 12;
+        p2 = p1 + 1;
 
         if (hashLen > 48U) {
             hashLen = 48U;
@@ -30084,12 +29859,12 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL)
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (u1 != NULL)
+        XFREE(u1, heap, DYNAMIC_TYPE_ECC);
+    if (p1 != NULL)
+        XFREE(p1, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p1, 0, heap);
-    sp_384_point_free_12(p2, 0, heap);
 
     return err;
 }
@@ -30106,32 +29881,23 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
 static int sp_384_ecc_is_point_12(const sp_point_384* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*12];
-    sp_digit t2d[2*12];
+    sp_digit t1[12 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 12;
-        t2 = d + 2 * 12;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 12;
 
         sp_384_sqr_12(t1, point->y);
         (void)sp_384_mod_12(t1, t1, p384_mod);
@@ -30151,10 +29917,9 @@ static int sp_384_ecc_is_point_12(const sp_point_384* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -30169,14 +29934,21 @@ static int sp_384_ecc_is_point_12(const sp_point_384* point,
  */
 int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_384 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_384* pub = NULL;
+#else
+    sp_point_384 pub[1];
 #endif
-    sp_point_384* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_12(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_384_from_mp(pub->x, 12, pX);
         sp_384_from_mp(pub->y, 12, pY);
@@ -30185,7 +29957,10 @@ int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
         err = sp_384_ecc_is_point_12(pub, NULL);
     }
 
-    sp_384_point_free_12(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -30204,44 +29979,44 @@ int sp_ecc_is_point_384(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_384(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[12];
-    sp_point_384 pubd;
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_384* pub;
-    sp_point_384* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_384_point_new_12(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_384_point_new_12(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_384* pub = NULL;
+#else
+    sp_digit priv[12];
+    sp_point_384 pub[2];
 #endif
+    sp_point_384* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 384) ||
+    if (((mp_count_bits(pX) > 384) ||
         (mp_count_bits(pY) > 384) ||
         ((privm != NULL) && (mp_count_bits(privm) > 384)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 12, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_384_from_mp(pub->x, 12, pX);
         sp_384_from_mp(pub->y, 12, pY);
@@ -30291,13 +30066,12 @@ int sp_ecc_check_key_384(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_384_point_free_12(p, 0, heap);
-    sp_384_point_free_12(pub, 0, heap);
 
     return err;
 }
@@ -30321,33 +30095,35 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* qX, mp_int* qY, mp_int* qZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 12 * 5];
-    sp_point_384 pd;
-    sp_point_384 qd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 12 * 5];
+    sp_point_384 p[2];
+#endif
     sp_point_384* q = NULL;
     int err;
 
-    err = sp_384_point_new_12(NULL, pd, p);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-        err = sp_384_point_new_12(NULL, qd, q);
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 2, NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
     }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 5, NULL,
-                                                              DYNAMIC_TYPE_ECC);
+                                 DYNAMIC_TYPE_ECC);
         if (tmp == NULL) {
             err = MEMORY_E;
         }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
+        q = p + 1;
+
         sp_384_from_mp(p->x, 12, pX);
         sp_384_from_mp(p->y, 12, pY);
         sp_384_from_mp(p->z, 12, pZ);
@@ -30368,13 +30144,12 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_384_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(q, 0, NULL);
-    sp_384_point_free_12(p, 0, NULL);
 
     return err;
 }
@@ -30393,25 +30168,28 @@ int sp_ecc_proj_add_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
 int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
                               mp_int* rX, mp_int* rY, mp_int* rZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 12 * 2];
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
-    int err;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 12 * 2];
+    sp_point_384 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_12(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 2, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
 
     if (err == MP_OKAY) {
@@ -30432,12 +30210,12 @@ int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
         err = sp_384_to_mp(p->z, rZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p, 0, NULL);
 
     return err;
 }
@@ -30452,25 +30230,29 @@ int sp_ecc_proj_dbl_point_384(mp_int* pX, mp_int* pY, mp_int* pZ,
  */
 int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit tmpd[2 * 12 * 6];
-    sp_point_384 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* tmp = NULL;
-    sp_point_384* p;
-    int err;
+    sp_point_384* p = NULL;
+#else
+    sp_digit tmp[2 * 12 * 6];
+    sp_point_384 p[1];
+#endif
+    int err = MP_OKAY;
 
-    err = sp_384_point_new_12(NULL, pd, p);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        p = (sp_point_384*)XMALLOC(sizeof(sp_point_384), NULL,
+                                         DYNAMIC_TYPE_ECC);
+        if (p == NULL)
+            err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 12 * 6, NULL,
-                                                              DYNAMIC_TYPE_ECC);
-        if (tmp == NULL) {
+                                 DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    tmp = tmpd;
 #endif
     if (err == MP_OKAY) {
         sp_384_from_mp(p->x, 12, pX);
@@ -30490,12 +30272,12 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
         err = sp_384_to_mp(p->z, pZ);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
         XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    }
+    if (p != NULL)
+        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
-    sp_384_point_free_12(p, 0, NULL);
 
     return err;
 }
@@ -30508,43 +30290,28 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
  */
 static int sp_384_mont_sqrt_12(sp_digit* y)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2 * 12];
-    sp_digit t2d[2 * 12];
-    sp_digit t3d[2 * 12];
-    sp_digit t4d[2 * 12];
-    sp_digit t5d[2 * 12];
+    sp_digit t1[5 * 2 * 12];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
-    sp_digit* t3;
-    sp_digit* t4;
-    sp_digit* t5;
+    sp_digit* t2 = NULL;
+    sp_digit* t3 = NULL;
+    sp_digit* t4 = NULL;
+    sp_digit* t5 = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 12, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 12, NULL, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 12;
-        t2 = d + 2 * 12;
-        t3 = d + 4 * 12;
-        t4 = d + 6 * 12;
-        t5 = d + 8 * 12;
-#else
-        t1 = t1d;
-        t2 = t2d;
-        t3 = t3d;
-        t4 = t4d;
-        t5 = t5d;
-#endif
+        t2 = t1 + 2 * 12;
+        t3 = t1 + 4 * 12;
+        t4 = t1 + 6 * 12;
+        t5 = t1 + 8 * 12;
 
         {
             /* t2 = y ^ 0x2 */
@@ -30604,10 +30371,9 @@ static int sp_384_mont_sqrt_12(sp_digit* y)
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -30623,31 +30389,22 @@ static int sp_384_mont_sqrt_12(sp_digit* y)
  */
 int sp_ecc_uncompress_384(mp_int* xm, int odd, mp_int* ym)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d;
-#else
-    sp_digit xd[2 * 12];
-    sp_digit yd[2 * 12];
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* x = NULL;
+#else
+    sp_digit x[4 * 12];
+#endif
     sp_digit* y = NULL;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 12, NULL, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    x = (sp_digit*)XMALLOC(sizeof(sp_digit) * 4 * 12, NULL, DYNAMIC_TYPE_ECC);
+    if (x == NULL)
         err = MEMORY_E;
-    }
 #endif
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        x = d + 0 * 12;
-        y = d + 2 * 12;
-#else
-        x = xd;
-        y = yd;
-#endif
+        y = x + 2 * 12;
 
         sp_384_from_mp(x, 12, xm);
         err = sp_384_mod_mul_norm_12(x, x, p384_mod);
@@ -30680,10 +30437,9 @@ int sp_ecc_uncompress_384(mp_int* xm, int odd, mp_int* ym)
         err = sp_384_to_mp(y, ym);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, NULL, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (x != NULL)
+        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -31913,6 +31669,8 @@ static int sp_1024_mod_mul_norm_32(sp_digit* r, const sp_digit* a,
     return sp_1024_mod_32(r, r, m);
 }
 
+
+#ifdef WOLFCRYPT_HAVE_SAKKE
 /* Create a new point.
  *
  * heap  [in]   Buffer to allocate dynamic memory from.
@@ -31944,8 +31702,8 @@ static int sp_1024_point_new_ex_32(void* heap, sp_point_1024* sp,
 /* Set pointer to data and return no error. */
 #define sp_1024_point_new_32(heap, sp, p) sp_1024_point_new_ex_32((heap), &(sp), &(p))
 #endif
-
-
+#endif /* WOLFCRYPT_HAVE_SAKKE */
+#ifdef WOLFCRYPT_HAVE_SAKKE
 /* Free the point.
  *
  * p      [in,out]  Point to free.
@@ -31970,6 +31728,7 @@ static void sp_1024_point_free_32(sp_point_1024* p, int clear, void* heap)
 #endif
     (void)heap;
 }
+#endif /* WOLFCRYPT_HAVE_SAKKE */
 
 /* Convert an mp_int to an array of sp_digit.
  *
@@ -34115,43 +33874,40 @@ static void sp_1024_proj_point_add_32(sp_point_1024* r,
 static int sp_1024_ecc_mulmod_fast_32(sp_point_1024* r, const sp_point_1024* g, const sp_digit* k,
         int map, int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td[16];
-    sp_point_1024 rtd;
-    sp_digit tmpd[2 * 32 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+    sp_digit* tmp = NULL;
+#else
+    sp_point_1024 t[16];
+    sp_digit tmp[2 * 32 * 5];
 #endif
-    sp_point_1024* t;
-    sp_point_1024* rt;
-    sp_digit* tmp;
+    sp_point_1024* rt = NULL;
     sp_digit n;
     int i;
     int c;
     int y;
-    int err;
+    int err = MP_OKAY;
 
     /* Constant time used for cache attack resistance implementation. */
     (void)ct;
     (void)heap;
 
-    err = sp_1024_point_new_32(heap, rtd, rt);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-#ifndef WC_NO_CACHE_RESISTANT
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 17, heap, DYNAMIC_TYPE_ECC);
-#else
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 16, heap, DYNAMIC_TYPE_ECC);
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 16,
+        heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
-    tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
-                             DYNAMIC_TYPE_ECC);
-    if (tmp == NULL)
-        err = MEMORY_E;
-#else
-    t = td;
-    tmp = tmpd;
+    if (err == MP_OKAY) {
+        tmp = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
+                                DYNAMIC_TYPE_ECC);
+        if (tmp == NULL)
+            err = MEMORY_E;
+    }
 #endif
 
     if (err == MP_OKAY) {
+        rt = t + 16;
+
         /* t[0] = {0, 0, 1} * norm */
         XMEMSET(&t[0], 0, sizeof(t[0]));
         t[0].infinity = 1;
@@ -34219,20 +33975,24 @@ static int sp_1024_ecc_mulmod_fast_32(sp_point_1024* r, const sp_point_1024* g, 
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (tmp != NULL) {
-        XMEMSET(tmp, 0, sizeof(sp_digit) * 2 * 32 * 5);
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
-    }
-    if (t != NULL) {
-        XMEMSET(t, 0, sizeof(sp_point_1024) * 16);
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
-#else
-    ForceZero(tmpd, sizeof(tmpd));
-    ForceZero(td, sizeof(td));
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (tmp != NULL)
 #endif
-    sp_1024_point_free_32(rt, 1, heap);
+    {
+        ForceZero(tmp, sizeof(sp_digit) * 2 * 32 * 5);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+#endif
+    {
+        ForceZero(t, sizeof(sp_point_1024) * 17);
+    #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    #endif
+    }
 
     return err;
 }
@@ -34456,29 +34216,30 @@ static void sp_1024_proj_point_add_qz1_32(sp_point_1024* r, const sp_point_1024*
 static int sp_1024_gen_stripe_table_32(const sp_point_1024* a,
         sp_table_entry_1024* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td;
-    sp_point_1024 s1d;
-    sp_point_1024 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+#else
+    sp_point_1024 t[3];
 #endif
-    sp_point_1024* t;
     sp_point_1024* s1 = NULL;
     sp_point_1024* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_1024_point_new_32(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_1024_mod_mul_norm_32(t->x, a->x, p1024_mod);
     }
     if (err == MP_OKAY) {
@@ -34523,9 +34284,10 @@ static int sp_1024_gen_stripe_table_32(const sp_point_1024* a,
         }
     }
 
-    sp_1024_point_free_32(s2, 0, heap);
-    sp_1024_point_free_32(s1, 0, heap);
-    sp_1024_point_free_32( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -34551,19 +34313,19 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
         const sp_table_entry_1024* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 rtd;
-    sp_point_1024 pd;
-    sp_digit td[2 * 32 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 rt[2];
+    sp_digit t[2 * 32 * 5];
 #endif
-    sp_point_1024* rt;
     sp_point_1024* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -34571,21 +34333,22 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
     (void)heap;
 
 
-    err = sp_1024_point_new_32(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p1024_norm_mod, sizeof(p1024_norm_mod));
         XMEMCPY(rt->z, p1024_norm_mod, sizeof(p1024_norm_mod));
 
@@ -34621,13 +34384,12 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(p, 0, heap);
-    sp_1024_point_free_32(rt, 0, heap);
 
     return err;
 }
@@ -34793,29 +34555,30 @@ static int sp_1024_ecc_mulmod_32(sp_point_1024* r, const sp_point_1024* g, const
 static int sp_1024_gen_stripe_table_32(const sp_point_1024* a,
         sp_table_entry_1024* table, sp_digit* tmp, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 td;
-    sp_point_1024 s1d;
-    sp_point_1024 s2d;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* t = NULL;
+#else
+    sp_point_1024 t[3];
 #endif
-    sp_point_1024* t;
     sp_point_1024* s1 = NULL;
     sp_point_1024* s2 = NULL;
     int i;
     int j;
-    int err;
+    int err = MP_OKAY;
 
     (void)heap;
 
-    err = sp_1024_point_new_32(heap, td, t);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, s1d, s1);
-    }
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, s2d, s2);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 3, heap,
+                                     DYNAMIC_TYPE_ECC);
+    if (t == NULL)
+        err = MEMORY_E;
+#endif
 
     if (err == MP_OKAY) {
+        s1 = t + 1;
+        s2 = t + 2;
+
         err = sp_1024_mod_mul_norm_32(t->x, a->x, p1024_mod);
     }
     if (err == MP_OKAY) {
@@ -34860,9 +34623,10 @@ static int sp_1024_gen_stripe_table_32(const sp_point_1024* a,
         }
     }
 
-    sp_1024_point_free_32(s2, 0, heap);
-    sp_1024_point_free_32(s1, 0, heap);
-    sp_1024_point_free_32( t, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -34888,19 +34652,19 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
         const sp_table_entry_1024* table, const sp_digit* k, int map,
         int ct, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 rtd;
-    sp_point_1024 pd;
-    sp_digit td[2 * 32 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* rt = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 rt[2];
+    sp_digit t[2 * 32 * 5];
 #endif
-    sp_point_1024* rt;
     sp_point_1024* p = NULL;
-    sp_digit* t;
     int i;
     int j;
     int y;
     int x;
-    int err;
+    int err = MP_OKAY;
 
     (void)g;
     /* Constant time used for cache attack resistance implementation. */
@@ -34908,21 +34672,22 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
     (void)heap;
 
 
-    err = sp_1024_point_new_32(heap, rtd, rt);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
-                           DYNAMIC_TYPE_ECC);
-    if (t == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    rt = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                      DYNAMIC_TYPE_ECC);
+    if (rt == NULL)
         err = MEMORY_E;
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 2 * 32 * 5, heap,
+                               DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
     }
-#else
-    t = td;
 #endif
 
     if (err == MP_OKAY) {
+        p = rt + 1;
+
         XMEMCPY(p->z, p1024_norm_mod, sizeof(p1024_norm_mod));
         XMEMCPY(rt->z, p1024_norm_mod, sizeof(p1024_norm_mod));
 
@@ -34958,13 +34723,12 @@ static int sp_1024_ecc_mulmod_stripe_32(sp_point_1024* r, const sp_point_1024* g
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (t != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
         XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (rt != NULL)
+        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(p, 0, heap);
-    sp_1024_point_free_32(rt, 0, heap);
 
     return err;
 }
@@ -35128,25 +34892,28 @@ static int sp_1024_ecc_mulmod_32(sp_point_1024* r, const sp_point_1024* g, const
 int sp_ecc_mulmod_1024(const mp_int* km, const ecc_point* gm, ecc_point* r,
         int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[32];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024 point[1];
+    sp_digit k[32];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap,
-                                                              DYNAMIC_TYPE_ECC);
+                               DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 32, km);
         sp_1024_point_from_ecc_point_32(point, gm);
@@ -35157,12 +34924,12 @@ int sp_ecc_mulmod_1024(const mp_int* km, const ecc_point* gm, ecc_point* r,
         err = sp_1024_point_to_ecc_point_32(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(point, 0, heap);
 
     return err;
 }
@@ -38756,26 +38523,28 @@ static int sp_1024_ecc_mulmod_base_32(sp_point_1024* r, const sp_digit* k,
  */
 int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[32];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024  point[1];
+    sp_digit k[32];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+                               DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 32, km);
 
@@ -38785,12 +38554,12 @@ int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
         err = sp_1024_point_to_ecc_point_32(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(point, 0, heap);
 
     return err;
 }
@@ -38809,37 +38578,35 @@ int sp_ecc_mulmod_base_1024(const mp_int* km, ecc_point* r, int map, void* heap)
 int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
         int inMont, ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_point_1024 a;
-    sp_digit kd[32];
-    sp_digit t[32 * 2 * 5];
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
+    sp_digit* k = NULL;
+#else
+    sp_point_1024 point[2];
+    sp_digit k[32 + 32 * 2 * 5];
 #endif
-    sp_point_1024* point;
     sp_point_1024* addP = NULL;
     sp_digit* tmp = NULL;
-    sp_digit* k = NULL;
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap, 
+                                         DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
     if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, a, addP);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY) {
-        k = (sp_digit*)XMALLOC(sizeof(sp_digit) * (32 + 32 * 2 * 5), heap, DYNAMIC_TYPE_ECC);
-        if (k == NULL) {
+        k = (sp_digit*)XMALLOC(
+            sizeof(sp_digit) * (32 + 32 * 2 * 5),
+            heap, DYNAMIC_TYPE_ECC);
+        if (k == NULL)
             err = MEMORY_E;
-        }
-        else {
-            tmp = k + 32;
-        }
     }
-#else
-    k = kd;
-    tmp = t;
 #endif
+
     if (err == MP_OKAY) {
+        addP = point + 1;
+        tmp = k + 32;
+
         sp_1024_from_mp(k, 32, km);
         sp_1024_point_from_ecc_point_32(addP, am);
     }
@@ -38865,13 +38632,12 @@ int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
         err = sp_1024_point_to_ecc_point_32(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(addP, 0, heap);
-    sp_1024_point_free_32(point, 0, heap);
 
     return err;
 }
@@ -38889,29 +38655,43 @@ int sp_ecc_mulmod_base_add_1024(const mp_int* km, const ecc_point* am,
 int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
     void* heap)
 {
-    int err = 0;
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_point_1024* point = NULL;
+    sp_digit* t = NULL;
+#else
+    sp_point_1024 point[1];
     sp_digit t[5 * 2 * 32];
+#endif
+    int err = MP_OKAY;
 
     if ((gm == NULL) || (len == NULL)) {
         err = BAD_FUNC_ARG;
     }
 
-    if ((err == 0) && (table == NULL)) {
+    if ((err == MP_OKAY) && (table == NULL)) {
         *len = sizeof(sp_table_entry_1024) * 256;
         err = LENGTH_ONLY_E;
     }
-    if ((err == 0) && (*len < (int)(sizeof(sp_table_entry_1024) * 256))) {
+    if ((err == MP_OKAY) && (*len < (int)(sizeof(sp_table_entry_1024) * 256))) {
         err = BUFFER_E;
     }
 
-    if (err == 0) {
-        err = sp_1024_point_new_32(heap, p, point);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (err == MP_OKAY) {
+        point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+            DYNAMIC_TYPE_ECC);
+        if (point == NULL)
+            err = MEMORY_E;
     }
-    if (err == 0) {
+    if (err == MP_OKAY) {
+        t = (sp_digit*)XMALLOC(sizeof(sp_digit) * 5 * 2 * 32, heap,
+            DYNAMIC_TYPE_ECC);
+        if (t == NULL)
+            err = MEMORY_E;
+    }
+#endif
+
+    if (err == MP_OKAY) {
         sp_1024_point_from_ecc_point_32(point, gm);
             err = sp_1024_gen_stripe_table_32(point,
                 (sp_table_entry_1024*)table, t, heap);
@@ -38920,7 +38700,12 @@ int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
         *len = sizeof(sp_table_entry_1024) * 256;
     }
 
-    sp_1024_point_free_32(point, 0, heap);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t != NULL)
+        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -38973,24 +38758,28 @@ int sp_ecc_gen_table_1024(const ecc_point* gm, byte* table, word32* len,
 int sp_ecc_mulmod_table_1024(const mp_int* km, const ecc_point* gm, byte* table,
         ecc_point* r, int map, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 p;
-    sp_digit kd[32];
-#endif
-    sp_point_1024* point;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* point = NULL;
     sp_digit* k = NULL;
+#else
+    sp_point_1024 point[1];
+    sp_digit k[32];
+#endif
     int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(heap, p, point);
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    point = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), heap,
+        DYNAMIC_TYPE_ECC);
+    if (point == NULL)
+        err = MEMORY_E;
+    }
     if (err == MP_OKAY) {
         k = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap, DYNAMIC_TYPE_ECC);
         if (k == NULL)
             err = MEMORY_E;
     }
-#else
-    k = kd;
 #endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(k, 32, km);
         sp_1024_point_from_ecc_point_32(point, gm);
@@ -39007,12 +38796,12 @@ int sp_ecc_mulmod_table_1024(const mp_int* km, const ecc_point* gm, byte* table,
         err = sp_1024_point_to_ecc_point_32(point, r);
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (k != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (k != NULL)
         XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    }
+    if (point != NULL)
+        XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
-    sp_1024_point_free_32(point, 0, heap);
 
     return err;
 }
@@ -42463,33 +42252,24 @@ static void sp_1024_from_bin(sp_digit* r, int size, const byte* a, int n)
 static int sp_1024_ecc_is_point_32(const sp_point_1024* point,
     void* heap)
 {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit* d = NULL;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_digit* t1 = NULL;
 #else
-    sp_digit t1d[2*32];
-    sp_digit t2d[2*32];
+    sp_digit t1[32 * 4];
 #endif
-    sp_digit* t1;
-    sp_digit* t2;
+    sp_digit* t2 = NULL;
     int32_t n;
     int err = MP_OKAY;
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    d = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 4, heap, DYNAMIC_TYPE_ECC);
-    if (d == NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    t1 = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32 * 4, heap, DYNAMIC_TYPE_ECC);
+    if (t1 == NULL)
         err = MEMORY_E;
-    }
 #endif
     (void)heap;
 
     if (err == MP_OKAY) {
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-        t1 = d + 0 * 32;
-        t2 = d + 2 * 32;
-#else
-        t1 = t1d;
-        t2 = t2d;
-#endif
+        t2 = t1 + 2 * 32;
 
         sp_1024_sqr_32(t1, point->y);
         (void)sp_1024_mod_32(t1, t1, p1024_mod);
@@ -42513,10 +42293,9 @@ static int sp_1024_ecc_is_point_32(const sp_point_1024* point,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (d != NULL) {
-        XFREE(d, heap, DYNAMIC_TYPE_ECC);
-    }
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (t1 != NULL)
+        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -42531,14 +42310,21 @@ static int sp_1024_ecc_is_point_32(const sp_point_1024* point,
  */
 int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_point_1024 pubd;
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    sp_point_1024* pub = NULL;
+#else
+    sp_point_1024 pub[1];
 #endif
-    sp_point_1024* pub;
-    byte one[1] = { 1 };
-    int err;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
 
-    err = sp_1024_point_new_32(NULL, pubd, pub);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    pub = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024), NULL,
+                                       DYNAMIC_TYPE_ECC);
+    if (pub == NULL)
+        err = MEMORY_E;
+#endif
+
     if (err == MP_OKAY) {
         sp_1024_from_mp(pub->x, 32, pX);
         sp_1024_from_mp(pub->y, 32, pY);
@@ -42547,7 +42333,10 @@ int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
         err = sp_1024_ecc_is_point_32(pub, NULL);
     }
 
-    sp_1024_point_free_32(pub, 0, NULL);
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+#endif
 
     return err;
 }
@@ -42566,44 +42355,44 @@ int sp_ecc_is_point_1024(const mp_int* pX, const mp_int* pY)
 int sp_ecc_check_key_1024(const mp_int* pX, const mp_int* pY,
     const mp_int* privm, void* heap)
 {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-    sp_digit privd[32];
-    sp_point_1024 pubd;
-    sp_point_1024 pd;
-#endif
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     sp_digit* priv = NULL;
-    sp_point_1024* pub;
-    sp_point_1024* p = NULL;
-    byte one[1] = { 1 };
-    int err;
-
-    err = sp_1024_point_new_32(heap, pubd, pub);
-    if (err == MP_OKAY) {
-        err = sp_1024_point_new_32(heap, pd, p);
-    }
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (err == MP_OKAY && privm) {
-        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap,
-                                                              DYNAMIC_TYPE_ECC);
-        if (priv == NULL) {
-            err = MEMORY_E;
-        }
-    }
+    sp_point_1024* pub = NULL;
+#else
+    sp_digit priv[32];
+    sp_point_1024 pub[2];
 #endif
+    sp_point_1024* p = NULL;
+    const byte one[1] = { 1 };
+    int err = MP_OKAY;
+
 
     /* Quick check the lengs of public key ordinates and private key are in
      * range. Proper check later.
      */
-    if ((err == MP_OKAY) && ((mp_count_bits(pX) > 1024) ||
+    if (((mp_count_bits(pX) > 1024) ||
         (mp_count_bits(pY) > 1024) ||
         ((privm != NULL) && (mp_count_bits(privm) > 1024)))) {
         err = ECC_OUT_OF_RANGE_E;
     }
 
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
     if (err == MP_OKAY) {
-#if (!defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SMALL_STACK)) || defined(WOLFSSL_SP_NO_MALLOC)
-        priv = privd;
+        pub = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 2, heap,
+                                           DYNAMIC_TYPE_ECC);
+        if (pub == NULL)
+            err = MEMORY_E;
+    }
+    if (err == MP_OKAY && privm) {
+        priv = (sp_digit*)XMALLOC(sizeof(sp_digit) * 32, heap,
+                                  DYNAMIC_TYPE_ECC);
+        if (priv == NULL)
+            err = MEMORY_E;
+    }
 #endif
+
+    if (err == MP_OKAY) {
+        p = pub + 1;
 
         sp_1024_from_mp(pub->x, 32, pX);
         sp_1024_from_mp(pub->y, 32, pY);
@@ -42653,13 +42442,12 @@ int sp_ecc_check_key_1024(const mp_int* pX, const mp_int* pY,
         }
     }
 
-#if (defined(WOLFSSL_SP_SMALL) || defined(WOLFSSL_SMALL_STACK)) && !defined(WOLFSSL_SP_NO_MALLOC)
-    if (priv != NULL) {
+#if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
+    if (pub != NULL)
+        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    if (priv != NULL)
         XFREE(priv, heap, DYNAMIC_TYPE_ECC);
-    }
 #endif
-    sp_1024_point_free_32(p, 0, heap);
-    sp_1024_point_free_32(pub, 0, heap);
 
     return err;
 }


### PR DESCRIPTION
* Enables the use of `WOLFSSL_SP_NO_MALLOC` with both normal and small versions of code.
* Cleanup of the SP no malloc code for ECC, RSA and DH.

@SparkiDev : I switched the cleanup memset to ForceZero, but please let me know if I should revert that.