### PR TITLE
OpenVPN additions and fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -42653,55 +42653,46 @@ static void test_wolfSSL_CTX_get_min_proto_version(void)
 
     printf(testingFmt, "wolfSSL_CTX_get_min_proto_version()");
 
-    #ifndef NO_OLD_TLS
-        #ifdef WOLFSSL_ALLOW_SSLV3
-            #ifdef NO_WOLFSSL_SERVER
-                AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
-            #else
-                AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
-            #endif
-            AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, SSL3_VERSION), WOLFSSL_SUCCESS);
-            AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), SSL3_VERSION);
-            wolfSSL_CTX_free(ctx);
-        #endif
-        #ifdef WOLFSSL_ALLOW_TLSV10
-            #ifdef NO_WOLFSSL_SERVER
-                AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_client_method()));
-            #else
-                AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_server_method()));
-            #endif
-            AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, TLS1_VERSION), WOLFSSL_SUCCESS);
-            AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), TLS1_VERSION);
-            wolfSSL_CTX_free(ctx);
-        #endif
-
-        #ifdef NO_WOLFSSL_SERVER
-            AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_1_client_method()));
-        #else
-            AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_1_server_method()));
-        #endif
-        AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, TLS1_1_VERSION), WOLFSSL_SUCCESS);
-        AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), TLS1_1_VERSION);
-        wolfSSL_CTX_free(ctx);
+    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_method()));
+    AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, SSL3_VERSION), WOLFSSL_SUCCESS);
+    #ifdef WOLFSSL_ALLOW_SSLV3
+        AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), SSL3_VERSION);
+    #else
+        AssertIntGT(wolfSSL_CTX_get_min_proto_version(ctx), SSL3_VERSION);
     #endif
+    wolfSSL_CTX_free(ctx);
+
+    #ifdef WOLFSSL_ALLOW_TLSV10
+        AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_method()));
+    #else
+        AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_method()));
+    #endif
+    AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, TLS1_VERSION), WOLFSSL_SUCCESS);
+    #ifdef WOLFSSL_ALLOW_TLSV10
+        AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), TLS1_VERSION);
+    #else
+        AssertIntGT(wolfSSL_CTX_get_min_proto_version(ctx), TLS1_VERSION);
+    #endif
+    wolfSSL_CTX_free(ctx);
+
+    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_method()));
+    AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, TLS1_1_VERSION), WOLFSSL_SUCCESS);
+    #ifndef NO_OLD_TLS
+        AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), TLS1_1_VERSION);
+    #else
+        AssertIntGT(wolfSSL_CTX_get_min_proto_version(ctx), TLS1_1_VERSION);
+    #endif
+    wolfSSL_CTX_free(ctx);
 
     #ifndef WOLFSSL_NO_TLS12
-        #ifdef NO_WOLFSSL_SERVER
-            AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method()));
-        #else
-            AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_server_method()));
-        #endif
+        AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_2_method()));
         AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION), WOLFSSL_SUCCESS);
         AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), TLS1_2_VERSION);
         wolfSSL_CTX_free(ctx);
     #endif
 
     #ifdef WOLFSSL_TLS13
-        #ifdef NO_WOLFSSL_SERVER
-            AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_client_method()));
-        #else
-            AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_server_method()));
-        #endif
+        AssertNotNull(ctx = wolfSSL_CTX_new(wolfTLSv1_3_method()));
         AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION), WOLFSSL_SUCCESS);
         AssertIntEQ(wolfSSL_CTX_get_min_proto_version(ctx), TLS1_3_VERSION);
         wolfSSL_CTX_free(ctx);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -10974,6 +10974,7 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
                         XSTR_SIZEOF(BEGIN_PRIV_KEY_PREFIX)) != 0 ||
                         beginEnd - headerEnd > PEM_LINE_LEN) {
                     WOLFSSL_MSG("Couldn't find PEM header");
+                    WOLFSSL_ERROR(ASN_NO_PEM_HEADER);
                     return ASN_NO_PEM_HEADER;
                 }
 
@@ -10986,6 +10987,7 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
                                 (unsigned int)((char*)buff + sz - beginEnd));
                 if (!footer) {
                     WOLFSSL_MSG("Couldn't find PEM footer");
+                    WOLFSSL_ERROR(ASN_NO_PEM_HEADER);
                     return ASN_NO_PEM_HEADER;
                 }
 
@@ -11011,6 +11013,7 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
 
         if (!headerEnd) {
             WOLFSSL_MSG("Couldn't find PEM header");
+            WOLFSSL_ERROR(ASN_NO_PEM_HEADER);
             return ASN_NO_PEM_HEADER;
         }
 #else

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3724,7 +3724,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     {
         int ret;
         if (src->isHMAC) {
-            ret = wolfSSL_HmacCopy(&des->hash.hmac, (Hmac*)&src->hash.hmac);
+            return wolfSSL_HmacCopy(&des->hash.hmac, (Hmac*)&src->hash.hmac);
         }
         else {
             switch (src->macType) {
@@ -3818,8 +3818,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
                     ret = BAD_FUNC_ARG;
                     break;
             }
+            return ret == 0 ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
         }
-        return ret == 0 ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
     }
 
     /* copies structure in to the structure out

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1262,7 +1262,7 @@ unsigned long WOLFSSL_CIPHER_mode(const WOLFSSL_EVP_CIPHER *cipher)
         case AES_128_GCM_TYPE:
         case AES_192_GCM_TYPE:
         case AES_256_GCM_TYPE:
-            return WOLFSSL_EVP_CIPH_GCM_MODE &
+            return WOLFSSL_EVP_CIPH_GCM_MODE |
                     WOLFSSL_EVP_CIPH_FLAG_AEAD_CIPHER;
     #endif
     #if defined(WOLFSSL_AES_COUNTER)
@@ -1319,7 +1319,7 @@ unsigned long WOLFSSL_CIPHER_mode(const WOLFSSL_EVP_CIPHER *cipher)
 unsigned long WOLFSSL_EVP_CIPHER_mode(const WOLFSSL_EVP_CIPHER *cipher)
 {
   if (cipher == NULL) return 0;
-  return WOLFSSL_CIPHER_mode(cipher);
+  return WOLFSSL_CIPHER_mode(cipher) & WOLFSSL_EVP_CIPH_MODE;
 }
 
 void wolfSSL_EVP_CIPHER_CTX_set_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags)

--- a/wolfssl/openssl/crypto.h
+++ b/wolfssl/openssl/crypto.h
@@ -87,6 +87,15 @@ typedef struct crypto_threadid_st   CRYPTO_THREADID;
 
 #define OPENSSL_init_crypto wolfSSL_OPENSSL_init_crypto
 
+#ifdef WOLFSSL_OPENVPN
+# define OPENSSL_assert(e) \
+    if (!(e)) { \
+        fprintf(stderr, "%s:%d wolfSSL internal error: assertion failed: " #e, \
+                __FILE__, __LINE__); \
+        raise(SIGABRT); \
+        _exit(3); \
+    }
+#endif
 
 #if defined(OPENSSL_ALL) || defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
     defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA) || defined(HAVE_EX_DATA)

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -938,7 +938,7 @@ typedef WOLFSSL_EVP_CIPHER_CTX EVP_CIPHER_CTX;
 
 #define EVP_PKEY_NONE                   NID_undef
 #define EVP_PKEY_DH                     28
-#define EVP_CIPHER_mode                 WOLFSSL_CIPHER_mode
+#define EVP_CIPHER_mode                 WOLFSSL_EVP_CIPHER_mode
 /* WOLFSSL_EVP_CIPHER is just the string name of the cipher */
 #define EVP_CIPHER_name(x)              x
 #define EVP_MD_CTX_reset                wolfSSL_EVP_MD_CTX_cleanup

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -742,6 +742,9 @@ typedef WOLFSSL_EVP_CIPHER_CTX EVP_CIPHER_CTX;
 #define EVP_MD_CTX_size         wolfSSL_EVP_MD_CTX_size
 #define EVP_MD_CTX_block_size   wolfSSL_EVP_MD_CTX_block_size
 #define EVP_MD_type             wolfSSL_EVP_MD_type
+#ifndef NO_WOLFSSL_STUB
+#define EVP_MD_CTX_set_flags(...)
+#endif
 
 #define EVP_Digest             wolfSSL_EVP_Digest
 #define EVP_DigestInit         wolfSSL_EVP_DigestInit


### PR DESCRIPTION
- OpenVPN requires all TLS versions to be enabled because it uses `SSL_CTX_set_min_proto_version` to set the min version without checking if support for that version is compiled in
- wolfSSL_HmacCopy return already returns `WOLFSSL_SUCCESS` or `WOLFSSL_FAILURE`
