### PR TITLE
Fixes for for crypto callbacks (SHA1, HMAC and CMAC)

### DIFF
--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -95,16 +95,18 @@ int wc_InitCmac_ex(Cmac* cmac, const byte* key, word32 keySz,
 
     XMEMSET(cmac, 0, sizeof(Cmac));
 
-    #ifdef WOLF_CRYPTO_CB
+#ifdef WOLF_CRYPTO_CB
     if (devId != INVALID_DEVID) {
         cmac->devId = devId;
+        cmac->devCtx = NULL;
+
         ret = wc_CryptoCb_Cmac(cmac, key, keySz, NULL, 0, NULL, NULL,
                 type, unused);
         if (ret != CRYPTOCB_UNAVAILABLE)
             return ret;
         /* fall-through when unavailable */
     }
-    #endif
+#endif
 
     if (key == NULL)
         return BAD_FUNC_ARG;

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -200,62 +200,66 @@ int wc_HmacSizeByType(int type)
 int _InitHmac(Hmac* hmac, int type, void* heap)
 {
     int ret = 0;
-
+#ifdef WOLF_CRYPTO_CB
+    int devId = hmac->devId;
+#else
+    int devId = INVALID_DEVID;
+#endif
     switch (type) {
     #ifndef NO_MD5
         case WC_MD5:
-            ret = wc_InitMd5(&hmac->hash.md5);
+            ret = wc_InitMd5_ex(&hmac->hash.md5, heap, devId);
             break;
     #endif /* !NO_MD5 */
 
     #ifndef NO_SHA
         case WC_SHA:
-            ret = wc_InitSha(&hmac->hash.sha);
+            ret = wc_InitSha_ex(&hmac->hash.sha, heap, devId);
             break;
     #endif /* !NO_SHA */
 
     #ifdef WOLFSSL_SHA224
         case WC_SHA224:
-            ret = wc_InitSha224(&hmac->hash.sha224);
+            ret = wc_InitSha224_ex(&hmac->hash.sha224, heap, devId);
             break;
     #endif /* WOLFSSL_SHA224 */
 
     #ifndef NO_SHA256
         case WC_SHA256:
-            ret = wc_InitSha256(&hmac->hash.sha256);
+            ret = wc_InitSha256_ex(&hmac->hash.sha256, heap, devId);
             break;
     #endif /* !NO_SHA256 */
 
     #ifdef WOLFSSL_SHA384
         case WC_SHA384:
-            ret = wc_InitSha384(&hmac->hash.sha384);
+            ret = wc_InitSha384_ex(&hmac->hash.sha384, heap, devId);
             break;
     #endif /* WOLFSSL_SHA384 */
     #ifdef WOLFSSL_SHA512
         case WC_SHA512:
-            ret = wc_InitSha512(&hmac->hash.sha512);
+            ret = wc_InitSha512_ex(&hmac->hash.sha512, heap, devId);
             break;
     #endif /* WOLFSSL_SHA512 */
 
     #ifdef WOLFSSL_SHA3
     #ifndef WOLFSSL_NOSHA3_224
         case WC_SHA3_224:
-            ret = wc_InitSha3_224(&hmac->hash.sha3, heap, INVALID_DEVID);
+            ret = wc_InitSha3_224(&hmac->hash.sha3, heap, devId);
             break;
     #endif
     #ifndef WOLFSSL_NOSHA3_256
         case WC_SHA3_256:
-            ret = wc_InitSha3_256(&hmac->hash.sha3, heap, INVALID_DEVID);
+            ret = wc_InitSha3_256(&hmac->hash.sha3, heap, devId);
             break;
     #endif
     #ifndef WOLFSSL_NOSHA3_384
         case WC_SHA3_384:
-            ret = wc_InitSha3_384(&hmac->hash.sha3, heap, INVALID_DEVID);
+            ret = wc_InitSha3_384(&hmac->hash.sha3, heap, devId);
             break;
     #endif
     #ifndef WOLFSSL_NOSHA3_512
         case WC_SHA3_512:
-            ret = wc_InitSha3_512(&hmac->hash.sha3, heap, INVALID_DEVID);
+            ret = wc_InitSha3_512(&hmac->hash.sha3, heap, devId);
             break;
     #endif
     #endif

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -495,6 +495,7 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
     sha->heap = heap;
 #ifdef WOLF_CRYPTO_CB
     sha->devId = devId;
+    sha->devCtx = NULL;
 #endif
 
 #if defined(WOLFSSL_ESP32WROOM32_CRYPT) && \

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -396,6 +396,7 @@ static int InitSha256(wc_Sha256* sha256)
         sha256->heap = heap;
     #ifdef WOLF_CRYPTO_CB
         sha256->devId = devId;
+        sha256->devCtx = NULL;
     #endif
     #ifdef WOLFSSL_SMALL_STACK_CACHE
         sha256->W = NULL;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -26766,7 +26766,8 @@ WOLFSSL_TEST_SUBROUTINE int cmac_test(void)
 
         XMEMSET(tag, 0, sizeof(tag));
         tagSz = AES_BLOCK_SIZE;
-        if (wc_InitCmac(cmac, tc->k, tc->kSz, tc->type, NULL) != 0)
+
+        if (wc_InitCmac_ex(cmac, tc->k, tc->kSz, tc->type, NULL, HEAP_HINT, devId) != 0)
             ERROR_OUT(-12000, out);
         if (tc->partial) {
             if (wc_CmacUpdate(cmac, tc->m,
@@ -34568,6 +34569,10 @@ WOLFSSL_TEST_SUBROUTINE int cryptocb_test(void)
     if (ret == 0)
         ret = pbkdf2_test();
     #endif
+#endif
+#if defined(WOLFSSL_CMAC) && !defined(NO_AES)
+    if (ret == 0)
+        ret = cmac_test();
 #endif
 
     /* reset devId */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -26767,8 +26767,15 @@ WOLFSSL_TEST_SUBROUTINE int cmac_test(void)
         XMEMSET(tag, 0, sizeof(tag));
         tagSz = AES_BLOCK_SIZE;
 
+#if !defined(HAVE_FIPS) || \
+    defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 3)    
         if (wc_InitCmac_ex(cmac, tc->k, tc->kSz, tc->type, NULL, HEAP_HINT, devId) != 0)
+#else
+        if (wc_InitCmac(cmac, tc->k, tc->kSz, tc->type, NULL) != 0)
+#endif
+        {
             ERROR_OUT(-12000, out);
+        }
         if (tc->partial) {
             if (wc_CmacUpdate(cmac, tc->m,
                                  tc->mSz/2 - tc->partial) != 0)

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -53,12 +53,15 @@ struct Cmac {
     byte k2[AES_BLOCK_SIZE];
     word32 bufferSz;
     word32 totalSz;
-#if defined(WOLF_CRYPTO_CB)
+#ifdef WOLF_CRYPTO_CB
     int devId;
+    void* devCtx;
+    #ifdef WOLFSSL_QNX_CAAM
     byte ctx[32]; /* hold state for save and return */
     word32 blackKey;
     word32 keylen;
     byte   initialized;
+    #endif
 #endif
 };
 


### PR DESCRIPTION
* Fix for for crypto callback `devCtx` on symmetric algorithms (missing for SHA1 and CMAC).
* Fix for HMAC to use devId for hashing.
* Fixes for CMAC crypto callbacks and testing.