### PR TITLE
Fix missing NULL check in FreeSuites().  Fixes #3873.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -6361,7 +6361,9 @@ void FreeSuites(WOLFSSL* ssl)
 #endif
     {
     #ifdef OPENSSL_ALL
-        wolfSSL_sk_SSL_CIPHER_free(ssl->suites->stack);
+        if (ssl->suites != NULL) {
+            wolfSSL_sk_SSL_CIPHER_free(ssl->suites->stack);
+        }
     #endif
         XFREE(ssl->suites, ssl->heap, DYNAMIC_TYPE_SUITES);
     }


### PR DESCRIPTION
With OPENSSL_ALL enabled, this was causing a segfault in when freeing a WOLFSSL object created with wolfSSL_write_dup().