### PR TITLE
Return code differences in wolfSSL_EVP_PKEY_cmp et al.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16286,8 +16286,9 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             }
 
             XFREE(bio, 0, DYNAMIC_TYPE_OPENSSL);
+            return WOLFSSL_SUCCESS;
         }
-        return 1;
+        return WOLFSSL_FAILURE;
     }
 
     /* like BIO_free, but no return value */

--- a/tests/api.c
+++ b/tests/api.c
@@ -37690,6 +37690,7 @@ static void test_EVP_PKEY_cmp(void)
     EVP_PKEY *a, *b;
     const unsigned char *in;
 
+    printf(testingFmt, "wolfSSL_EVP_PKEY_cmp()");
 #if !defined(NO_RSA) && defined(USE_CERT_BUFFERS_2048)
     in = client_key_der_2048;
     AssertNotNull(a = wolfSSL_d2i_PrivateKey(EVP_PKEY_RSA, NULL,
@@ -37699,7 +37700,11 @@ static void test_EVP_PKEY_cmp(void)
         &in, (long)sizeof_client_key_der_2048));
 
     /* Test success case RSA */
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    AssertIntEQ(EVP_PKEY_cmp(a, b), 1);
+#else
     AssertIntEQ(EVP_PKEY_cmp(a, b), 0);
+#endif /* WOLFSSL_ERROR_CODE_OPENSSL */
 
     EVP_PKEY_free(b);
     EVP_PKEY_free(a);
@@ -37714,7 +37719,11 @@ static void test_EVP_PKEY_cmp(void)
         &in, (long)sizeof_ecc_clikey_der_256));
 
     /* Test success case ECC */
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    AssertIntEQ(EVP_PKEY_cmp(a, b), 1);
+#else
     AssertIntEQ(EVP_PKEY_cmp(a, b), 0);
+#endif /* WOLFSSL_ERROR_CODE_OPENSSL */
 
     EVP_PKEY_free(b);
     EVP_PKEY_free(a);
@@ -37731,8 +37740,11 @@ static void test_EVP_PKEY_cmp(void)
     AssertNotNull(b = wolfSSL_d2i_PrivateKey(EVP_PKEY_EC, NULL,
         &in, (long)sizeof_ecc_clikey_der_256));
 
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    AssertIntEQ(EVP_PKEY_cmp(a, b), -1);
+#else
     AssertIntNE(EVP_PKEY_cmp(a, b), 0);
-
+#endif /* WOLFSSL_ERROR_CODE_OPENSSL */
     EVP_PKEY_free(b);
     EVP_PKEY_free(a);
 #endif
@@ -37740,10 +37752,17 @@ static void test_EVP_PKEY_cmp(void)
     /* invalid or empty failure cases */
     a = EVP_PKEY_new();
     b = EVP_PKEY_new();
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    AssertIntEQ(EVP_PKEY_cmp(NULL, NULL), 0);
+    AssertIntEQ(EVP_PKEY_cmp(a, NULL), 0);
+    AssertIntEQ(EVP_PKEY_cmp(NULL, b), 0);
+    AssertIntEQ(EVP_PKEY_cmp(a, b), 0);
+#else
     AssertIntNE(EVP_PKEY_cmp(NULL, NULL), 0);
     AssertIntNE(EVP_PKEY_cmp(a, NULL), 0);
     AssertIntNE(EVP_PKEY_cmp(NULL, b), 0);
     AssertIntNE(EVP_PKEY_cmp(a, b), 0);
+#endif
     EVP_PKEY_free(b);
     EVP_PKEY_free(a);
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1984,8 +1984,9 @@ WOLFSSL_API int wolfSSL_EVP_PKEY_missing_parameters(WOLFSSL_EVP_PKEY *pkey)
  *    0 : do not match
  *    -1: key types are different
  *    -2: the operation is not supported
- * If you mant this function behave the same as openSSL,
- * define WOLFSSL_ERROR_CODE_OPENSSL so that WS_RETURN_CODE fills the gap.
+ * If you want this function behave the same as openSSL,
+ * define WOLFSSL_ERROR_CODE_OPENSSL so that WS_RETURN_CODE translates return
+ * codes to match OpenSSL equivalent behavior.
  */
 WOLFSSL_API int wolfSSL_EVP_PKEY_cmp(const WOLFSSL_EVP_PKEY *a, const WOLFSSL_EVP_PKEY *b)
 {
@@ -4139,10 +4140,9 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             }
             ctx->gcmAuthInSz = 0;
 #endif
-            return WOLFSSL_SUCCESS;
         }
 
-        return WOLFSSL_FAILURE;
+        return WOLFSSL_SUCCESS;
     }
 
     /* Permanent stub for Qt compilation. */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -696,6 +696,7 @@ enum AlertLevel {
  * Since wolfSSL 4.7.0, the following functions use this macro:
  * - wolfSSL_CTX_load_verify_locations
  * - wolfSSL_X509_LOOKUP_load_file
+ * - wolfSSL_EVP_PKEY_cmp
  */
 #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
     #define WS_RETURN_CODE(item1,item2) \


### PR DESCRIPTION
This PR is to fix issues reported in  ZD11899.
Return code differences in the following functions are addressed:
- EVP_CIPHER_CTX_cleanup
- BIO_free
- EVP_PKEY_cmp

