### PR TITLE
SP dyanmic stack: WOLFSSL_SP_NO_DYN_STACK disable use

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -80,6 +80,8 @@ This library provides single precision (SP) integer math functions.
  * WOLFSSL_SP_INT_NEGATIVE      Enables negative values to be used.
  * WOLFSSL_SP_INT_DIGIT_ALIGN   Enable when unaligned access of sp_int_digit
  *                              pointer is not allowed.
+ * WOLFSSL_SP_NO_DYN_STACK      Disable use of dynamic stack items.
+ *                              Used with small code size and not small stack.
  */
 
 #if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
@@ -94,7 +96,7 @@ This library provides single precision (SP) integer math functions.
         sp_int* n = NULL
 #else
     #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
-        defined(WOLFSSL_SP_SMALL)
+        defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SP_NO_DYN_STACK)
         /* Declare a variable on the stack with the required data size. */
         #define DECL_SP_INT(n, s)               \
             byte    n##d[MP_INT_SIZEOF(s)];     \
@@ -164,7 +166,7 @@ This library provides single precision (SP) integer math functions.
         sp_int* n[c] = { NULL, }
 #else
     #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
-        defined(WOLFSSL_SP_SMALL)
+        defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SP_NO_DYN_STACK)
         /* Declare a variable on the stack with the required data size. */
         #define DECL_SP_INT_ARRAY(n, s, c)          \
             byte    n##d[MP_INT_SIZEOF(s) * (c)];   \
@@ -205,7 +207,7 @@ This library provides single precision (SP) integer math functions.
     while (0)
 #else
     #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
-        defined(WOLFSSL_SP_SMALL)
+        defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SP_NO_DYN_STACK)
         /* Data declared on stack that supports multiple sp_ints of the
          * required size. Use pointers into data to make up array and set sizes.
          */
@@ -4768,7 +4770,8 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
         int k;
     #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         sp_int_digit* t = NULL;
-    #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         defined(WOLFSSL_SP_SMALL)
+    #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
+        defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SP_NO_DYN_STACK)
         sp_int_digit t[a->used * 2];
     #else
         sp_int_digit t[SP_INT_DIGITS];
@@ -4844,7 +4847,8 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
         int k;
     #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         sp_int_digit* t = NULL;
-    #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         defined(WOLFSSL_SP_SMALL)
+    #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
+        defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SP_NO_DYN_STACK)
         sp_int_digit t[a->used + b->used];
     #else
         sp_int_digit t[SP_INT_DIGITS];
@@ -4921,7 +4925,8 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
         int k;
     #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         sp_int_digit* t = NULL;
-    #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         defined(WOLFSSL_SP_SMALL)
+    #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
+        defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SP_NO_DYN_STACK)
         sp_int_digit t[a->used + b->used];
     #else
         sp_int_digit t[SP_INT_DIGITS];
@@ -9300,7 +9305,7 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
     #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         sp_int_digit* t = NULL;
     #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
-        defined(WOLFSSL_SP_SMALL)
+        defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SP_NO_DYN_STACK)
         sp_int_digit t[a->used * 2];
     #else
         sp_int_digit t[SP_INT_DIGITS];
@@ -9409,7 +9414,7 @@ int sp_mul_2d(sp_int* a, int e, sp_int* r)
     #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
         sp_int_digit* t = NULL;
     #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
-        defined(WOLFSSL_SP_SMALL)
+        defined(WOLFSSL_SP_SMALL) && !defined(WOLFSSL_SP_NO_DYN_STACK)
         sp_int_digit t[a->used * 2];
     #else
         sp_int_digit t[SP_INT_DIGITS];


### PR DESCRIPTION
For small code and not small stack, arrays are being defined with a size
dependent on the input parameters, where compiler supports it.
Disable this with: WOLFSSL_SP_NO_DYN_STACK