### PR TITLE
Refactor SSL types to be defined in ssl_types.h

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -94,6 +94,7 @@
     #include <wolfssl/openssl/err.h>
     #include <wolfssl/openssl/opensslv.h>
     #include <wolfssl/openssl/rc4.h>
+    #include <wolfssl/openssl/ssl.h>
     #include <wolfssl/openssl/stack.h>
     #include <wolfssl/openssl/x509_vfy.h>
     /* openssl headers end, wolfssl internal headers next */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -136,7 +136,7 @@ extern int wc_InitRsaHw(RsaKey* key);
 #endif
 
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-    #include <wolfssl/openssl/objects.h>
+    #include <wolfssl/openssl/ssl.h>
 #endif
 
 #ifdef _MSC_VER

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -302,6 +302,7 @@ _Pragma("GCC diagnostic ignored \"-Wunused-function\"");
 #ifdef OPENSSL_EXTRA
   #ifndef WOLFCRYPT_ONLY
     #include <wolfssl/openssl/evp.h>
+    #include <wolfssl/openssl/ssl.h>
   #endif
     #include <wolfssl/openssl/rand.h>
     #include <wolfssl/openssl/hmac.h>

--- a/wolfssl/crl.h
+++ b/wolfssl/crl.h
@@ -27,7 +27,7 @@
 
 #ifdef HAVE_CRL
 
-#include <wolfssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 #include <wolfssl/wolfcrypt/asn.h>
 
 #ifdef __cplusplus

--- a/wolfssl/include.am
+++ b/wolfssl/include.am
@@ -9,6 +9,7 @@ EXTRA_DIST+= wolfssl/sniffer_error.rc
 
 nobase_include_HEADERS+= \
                          wolfssl/error-ssl.h \
+                         wolfssl/ssl_types.h \
                          wolfssl/ssl.h \
                          wolfssl/sniffer_error.h \
                          wolfssl/sniffer.h \

--- a/wolfssl/ocsp.h
+++ b/wolfssl/ocsp.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_OCSP
 
-#include <wolfssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 #include <wolfssl/wolfcrypt/asn.h>
 
 #ifdef __cplusplus

--- a/wolfssl/openssl/aes.h
+++ b/wolfssl/openssl/aes.h
@@ -32,7 +32,8 @@
 #include <wolfssl/wolfcrypt/settings.h>
 
 #ifndef NO_AES
-#include <wolfssl/openssl/ssl.h> /* for size_t */
+#include <wolfssl/ssl_types.h>
+#include <wolfssl/wolfcrypt/aes.h>
 
 #ifdef __cplusplus
     extern "C" {

--- a/wolfssl/openssl/asn1.h
+++ b/wolfssl/openssl/asn1.h
@@ -24,7 +24,7 @@
 #ifndef WOLFSSL_ASN1_H_
 #define WOLFSSL_ASN1_H_
 
-#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 
 #define ASN1_STRING_new      wolfSSL_ASN1_STRING_new
 #define ASN1_STRING_type_new wolfSSL_ASN1_STRING_type_new

--- a/wolfssl/openssl/bio.h
+++ b/wolfssl/openssl/bio.h
@@ -25,7 +25,7 @@
 #ifndef WOLFSSL_BIO_H_
 #define WOLFSSL_BIO_H_
 
-#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 
 
 #ifdef __cplusplus

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -31,22 +31,11 @@
 #define WOLFSSL_BN_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/ssl_types.h>
 
 #ifdef __cplusplus
     extern "C" {
 #endif
-
-typedef struct WOLFSSL_BIGNUM {
-    int neg;        /* openssh deference */
-    void *internal; /* our big num */
-#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
-    sp_int fp;
-#elif defined(USE_FAST_MATH) && !defined(HAVE_WOLF_BIGINT)
-    fp_int fp;
-#endif
-} WOLFSSL_BIGNUM;
-
 
 #define BN_ULONG WOLFSSL_BN_ULONG
 #define WOLFSSL_BN_ULONG unsigned long

--- a/wolfssl/openssl/buffer.h
+++ b/wolfssl/openssl/buffer.h
@@ -24,7 +24,7 @@
 #define WOLFSSL_BUFFER_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 
 #ifdef __cplusplus
     extern "C" {

--- a/wolfssl/openssl/conf.h
+++ b/wolfssl/openssl/conf.h
@@ -30,15 +30,13 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/version.h>
+#include <wolfssl/ssl_types.h>
 
 typedef struct WOLFSSL_CONF_VALUE {
     char *section;
     char *name;
     char *value;
 } WOLFSSL_CONF_VALUE;
-
-/* ssl.h requires WOLFSSL_CONF_VALUE */
-#include <wolfssl/ssl.h>
 
 typedef struct WOLFSSL_CONF {
     void *meth_data;

--- a/wolfssl/openssl/ecdh.h
+++ b/wolfssl/openssl/ecdh.h
@@ -24,7 +24,7 @@
 #ifndef WOLFSSL_ECDH_H_
 #define WOLFSSL_ECDH_H_
 
-#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 #include <wolfssl/openssl/bn.h>
 
 #ifdef __cplusplus

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -36,6 +36,7 @@
 #include "prefix_evp.h"
 #endif
 
+#include <wolfssl/ssl_types.h>
 #ifndef NO_MD4
     #include <wolfssl/openssl/md4.h>
 #endif
@@ -62,18 +63,6 @@
 #ifdef __cplusplus
     extern "C" {
 #endif
-
-
-typedef char WOLFSSL_EVP_CIPHER;
-#ifndef WOLFSSL_EVP_TYPE_DEFINED /* guard on redeclaration */
-typedef char   WOLFSSL_EVP_MD;
-typedef struct WOLFSSL_EVP_PKEY     WOLFSSL_EVP_PKEY;
-typedef struct WOLFSSL_EVP_MD_CTX   WOLFSSL_EVP_MD_CTX;
-#define WOLFSSL_EVP_TYPE_DEFINED
-#endif
-
-typedef WOLFSSL_EVP_PKEY       EVP_PKEY;
-typedef WOLFSSL_EVP_PKEY       PKCS8_PRIV_KEY_INFO;
 
 #ifndef NO_MD4
     WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_md4(void);
@@ -140,79 +129,6 @@ WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_rc4(void);
 WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_idea_cbc(void);
 WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_enc_null(void);
 WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_rc2_cbc(void);
-
-
-typedef union {
-    #ifndef NO_MD4
-        WOLFSSL_MD4_CTX    md4;
-    #endif
-    #ifndef NO_MD5
-        WOLFSSL_MD5_CTX    md5;
-    #endif
-    WOLFSSL_SHA_CTX    sha;
-    #ifdef WOLFSSL_SHA224
-        WOLFSSL_SHA224_CTX sha224;
-    #endif
-    WOLFSSL_SHA256_CTX sha256;
-    #ifdef WOLFSSL_SHA384
-        WOLFSSL_SHA384_CTX sha384;
-    #endif
-    #ifdef WOLFSSL_SHA512
-        WOLFSSL_SHA512_CTX sha512;
-    #endif
-    #ifdef WOLFSSL_RIPEMD
-        WOLFSSL_RIPEMD_CTX ripemd;
-    #endif
-    #ifndef WOLFSSL_NOSHA3_224
-        WOLFSSL_SHA3_224_CTX sha3_224;
-    #endif
-    #ifndef WOLFSSL_NOSHA3_256
-        WOLFSSL_SHA3_256_CTX sha3_256;
-    #endif
-        WOLFSSL_SHA3_384_CTX sha3_384;
-    #ifndef WOLFSSL_NOSHA3_512
-        WOLFSSL_SHA3_512_CTX sha3_512;
-    #endif
-} WOLFSSL_Hasher;
-
-typedef struct WOLFSSL_EVP_PKEY_CTX WOLFSSL_EVP_PKEY_CTX;
-typedef struct WOLFSSL_EVP_CIPHER_CTX WOLFSSL_EVP_CIPHER_CTX;
-
-struct WOLFSSL_EVP_MD_CTX {
-    union {
-        WOLFSSL_Hasher digest;
-    #ifndef NO_HMAC
-        Hmac hmac;
-    #endif
-    } hash;
-    enum wc_HashType macType;
-    WOLFSSL_EVP_PKEY_CTX *pctx;
-#ifndef NO_HMAC
-    unsigned int isHMAC;
-#endif
-};
-
-
-typedef union {
-#ifndef NO_AES
-    Aes  aes;
-#ifdef WOLFSSL_AES_XTS
-    XtsAes xts;
-#endif
-#endif
-#ifndef NO_DES3
-    Des  des;
-    Des3 des3;
-#endif
-    Arc4 arc4;
-#ifdef HAVE_IDEA
-    Idea idea;
-#endif
-#ifdef WOLFSSL_QT
-    int (*ctrl) (WOLFSSL_EVP_CIPHER_CTX *, int type, int arg, void *ptr);
-#endif
-} WOLFSSL_Cipher;
-
 
 enum {
     AES_128_CBC_TYPE  = 1,
@@ -664,11 +580,6 @@ WOLFSSL_LOCAL int wolfSSL_EVP_get_hashinfo(const WOLFSSL_EVP_MD* evp,
 
 /* end OpenSSH compat */
 
-typedef WOLFSSL_EVP_MD         EVP_MD;
-typedef WOLFSSL_EVP_CIPHER     EVP_CIPHER;
-typedef WOLFSSL_EVP_MD_CTX     EVP_MD_CTX;
-typedef WOLFSSL_EVP_CIPHER_CTX EVP_CIPHER_CTX;
-
 #ifndef NO_MD4
     #define EVP_md4       wolfSSL_EVP_md4
 #endif
@@ -939,6 +850,13 @@ typedef WOLFSSL_EVP_CIPHER_CTX EVP_CIPHER_CTX;
 
 
 WOLFSSL_API void printPKEY(WOLFSSL_EVP_PKEY *k);
+
+/*
+ * This include is placed at the end because evp.h does not depend on ssl.h
+ * but ssl.h depends on evp.h. ssl.h is included because user projects
+ * including evp.h expect functionality that is provided by ssl.h in wolfSSL.
+ */
+#include <wolfssl/openssl/ssl.h>
 
 #ifdef __cplusplus
     } /* extern "C" */

--- a/wolfssl/openssl/lhash.h
+++ b/wolfssl/openssl/lhash.h
@@ -28,7 +28,7 @@
     extern "C" {
 #endif
 
-#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 
 #ifdef OPENSSL_ALL
 #define IMPLEMENT_LHASH_HASH_FN(name, type) \

--- a/wolfssl/openssl/md4.h
+++ b/wolfssl/openssl/md4.h
@@ -24,6 +24,7 @@
 #define WOLFSSL_MD4_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/ssl_types.h>
 
 #ifndef NO_MD4
 
@@ -36,17 +37,10 @@
 #endif
 
 
-typedef struct WOLFSSL_MD4_CTX {
-    int buffer[32];      /* big enough to hold, check size in Init */
-} WOLFSSL_MD4_CTX;
-
-
 WOLFSSL_API void wolfSSL_MD4_Init(WOLFSSL_MD4_CTX*);
 WOLFSSL_API void wolfSSL_MD4_Update(WOLFSSL_MD4_CTX*, const void*, unsigned long);
 WOLFSSL_API void wolfSSL_MD4_Final(unsigned char*, WOLFSSL_MD4_CTX*);
 
-
-typedef WOLFSSL_MD4_CTX MD4_CTX;
 
 #define MD4_Init   wolfSSL_MD4_Init
 #define MD4_Update wolfSSL_MD4_Update

--- a/wolfssl/openssl/md5.h
+++ b/wolfssl/openssl/md5.h
@@ -30,6 +30,7 @@
 #ifndef NO_MD5
 
 #include <wolfssl/wolfcrypt/hash.h>
+#include <wolfssl/ssl_types.h>
 
 #ifdef WOLFSSL_PREFIX
 #include "prefix_md5.h"
@@ -40,21 +41,11 @@
 #endif
 
 
-typedef struct WOLFSSL_MD5_CTX {
-    /* big enough to hold wolfcrypt md5, but check on init */
-#ifdef STM32_HASH
-    void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(STM32_HASH_Context)) / sizeof(void*)];
-#else
-    void* holder[(112 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
-#endif
-} WOLFSSL_MD5_CTX;
-
 WOLFSSL_API int wolfSSL_MD5_Init(WOLFSSL_MD5_CTX*);
 WOLFSSL_API int wolfSSL_MD5_Update(WOLFSSL_MD5_CTX*, const void*, unsigned long);
 WOLFSSL_API int wolfSSL_MD5_Final(unsigned char*, WOLFSSL_MD5_CTX*);
 WOLFSSL_API int wolfSSL_MD5_Transform(WOLFSSL_MD5_CTX*, const unsigned char*);
 
-typedef WOLFSSL_MD5_CTX MD5_CTX;
 
 #define MD5_Init wolfSSL_MD5_Init
 #define MD5_Update wolfSSL_MD5_Update

--- a/wolfssl/openssl/objects.h
+++ b/wolfssl/openssl/objects.h
@@ -24,11 +24,7 @@
 #define WOLFSSL_OBJECTS_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
-//#include <wolfssl/openssl/ssl.h>
-#ifndef OPENSSL_EXTRA_SSL_GUARD
-#define OPENSSL_EXTRA_SSL_GUARD
-#include <wolfssl/ssl.h>
-#endif /* OPENSSL_EXTRA_SSL_GUARD */
+#include <wolfssl/ssl_types.h>
 
 #ifdef __cplusplus
     extern "C" {

--- a/wolfssl/openssl/ossl_typ.h
+++ b/wolfssl/openssl/ossl_typ.h
@@ -27,6 +27,6 @@
 #ifndef WOLFSSL_OSSL_TYP_H_
 #define WOLFSSL_OSSL_TYP_H_
 
-#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 
 #endif /* !WOLFSSL_OSSL_TYP_H_ */

--- a/wolfssl/openssl/pem.h
+++ b/wolfssl/openssl/pem.h
@@ -33,7 +33,7 @@
 #include <wolfssl/openssl/bio.h>
 #include <wolfssl/openssl/rsa.h>
 #include <wolfssl/openssl/dsa.h>
-#include <wolfssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 
 #ifdef __cplusplus
     extern "C" {

--- a/wolfssl/openssl/pkcs12.h
+++ b/wolfssl/openssl/pkcs12.h
@@ -22,7 +22,7 @@
 /* pkcs12.h for openssl */
 
 
-#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 #include <wolfssl/wolfcrypt/pkcs12.h>
 
 #ifndef WOLFSSL_PKCS12_COMPAT_H_

--- a/wolfssl/openssl/pkcs7.h
+++ b/wolfssl/openssl/pkcs7.h
@@ -25,7 +25,7 @@
 #ifndef WOLFSSL_PKCS7_H_
 #define WOLFSSL_PKCS7_H_
 
-#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 #include <wolfssl/wolfcrypt/pkcs7.h>
 
 #ifdef __cplusplus

--- a/wolfssl/openssl/rc4.h
+++ b/wolfssl/openssl/rc4.h
@@ -29,7 +29,7 @@
 #define WOLFSSL_RC4_COMPAT_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/openssl/ssl.h> /* included for size_t */
+#include <wolfssl/ssl_types.h> /* included for size_t */
 
 #ifdef __cplusplus
     extern "C" {

--- a/wolfssl/openssl/ripemd.h
+++ b/wolfssl/openssl/ripemd.h
@@ -32,17 +32,11 @@
 #endif
 
 
-typedef struct WOLFSSL_RIPEMD_CTX {
-    int holder[32];   /* big enough to hold wolfcrypt, but check on init */
-} WOLFSSL_RIPEMD_CTX;
-
 WOLFSSL_API void wolfSSL_RIPEMD_Init(WOLFSSL_RIPEMD_CTX*);
 WOLFSSL_API void wolfSSL_RIPEMD_Update(WOLFSSL_RIPEMD_CTX*, const void*,
                                      unsigned long);
 WOLFSSL_API void wolfSSL_RIPEMD_Final(unsigned char*, WOLFSSL_RIPEMD_CTX*);
 
-
-typedef WOLFSSL_RIPEMD_CTX RIPEMD_CTX;
 
 #define RIPEMD_Init   wolfSSL_RIPEMD_Init
 #define RIPEMD_Update wolfSSL_RIPEMD_Update

--- a/wolfssl/openssl/rsa.h
+++ b/wolfssl/openssl/rsa.h
@@ -25,6 +25,7 @@
 #ifndef WOLFSSL_RSA_H_
 #define WOLFSSL_RSA_H_
 
+#include <wolfssl/ssl_types.h>
 #include <wolfssl/openssl/bn.h>
 #include <wolfssl/openssl/err.h>
 #include <wolfssl/wolfcrypt/types.h>
@@ -56,45 +57,6 @@
 /* Max salt length */
 #define RSA_PSS_SALTLEN_MAX      -3
 
-typedef struct WOLFSSL_RSA_METHOD {
-    int flags;
-    char *name;
-} WOLFSSL_RSA_METHOD;
-
-#ifndef WOLFSSL_RSA_TYPE_DEFINED /* guard on redeclaration */
-#define WOLFSSL_RSA_TYPE_DEFINED
-typedef struct WOLFSSL_RSA {
-#ifdef WC_RSA_BLINDING
-    WC_RNG* rng;              /* for PrivateDecrypt blinding */
-#endif
-    WOLFSSL_BIGNUM* n;
-    WOLFSSL_BIGNUM* e;
-    WOLFSSL_BIGNUM* d;
-    WOLFSSL_BIGNUM* p;
-    WOLFSSL_BIGNUM* q;
-    WOLFSSL_BIGNUM* dmp1;      /* dP */
-    WOLFSSL_BIGNUM* dmq1;      /* dQ */
-    WOLFSSL_BIGNUM* iqmp;      /* u */
-    void*          heap;
-    void*          internal;  /* our RSA */
-    char           inSet;     /* internal set from external ? */
-    char           exSet;     /* external set from internal ? */
-    char           ownRng;    /* flag for if the rng should be free'd */
-#if defined(OPENSSL_EXTRA)
-    WOLFSSL_RSA_METHOD* meth;
-#endif
-#if defined(HAVE_EX_DATA)
-    WOLFSSL_CRYPTO_EX_DATA ex_data;  /* external data */
-#endif
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
-    wolfSSL_Mutex    refMutex;                       /* ref count mutex */
-    int              refCount;                       /* reference count */
-#endif
-} WOLFSSL_RSA;
-#endif
-
-typedef WOLFSSL_RSA                   RSA;
-typedef WOLFSSL_RSA_METHOD            RSA_METHOD;
 
 WOLFSSL_API WOLFSSL_RSA* wolfSSL_RSA_new(void);
 WOLFSSL_API void        wolfSSL_RSA_free(WOLFSSL_RSA*);

--- a/wolfssl/openssl/sha.h
+++ b/wolfssl/openssl/sha.h
@@ -37,18 +37,6 @@
 #endif
 
 
-typedef struct WOLFSSL_SHA_CTX {
-    /* big enough to hold wolfcrypt Sha, but check on init */
-#if defined(STM32_HASH)
-    void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(STM32_HASH_Context)) / sizeof(void*)];
-#else
-    void* holder[(112 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
-#endif
-    #ifdef WOLF_CRYPTO_CB
-    void* cryptocb_holder[(sizeof(int) + sizeof(void*) + 4) / sizeof(void*)];
-    #endif
-} WOLFSSL_SHA_CTX;
-
 WOLFSSL_API int wolfSSL_SHA_Init(WOLFSSL_SHA_CTX*);
 WOLFSSL_API int wolfSSL_SHA_Update(WOLFSSL_SHA_CTX*, const void*, unsigned long);
 WOLFSSL_API int wolfSSL_SHA_Final(unsigned char*, WOLFSSL_SHA_CTX*);
@@ -60,12 +48,7 @@ WOLFSSL_API int wolfSSL_SHA1_Update(WOLFSSL_SHA_CTX*, const void*, unsigned long
 WOLFSSL_API int wolfSSL_SHA1_Final(unsigned char*, WOLFSSL_SHA_CTX*);
 WOLFSSL_API int wolfSSL_SHA1_Transform(WOLFSSL_SHA_CTX*, 
                                           const unsigned char *data);
-enum {
-    SHA_DIGEST_LENGTH = 20
-};
 
-
-typedef WOLFSSL_SHA_CTX SHA_CTX;
 
 #define SHA_Init wolfSSL_SHA_Init
 #define SHA_Update wolfSSL_SHA_Update
@@ -85,25 +68,11 @@ typedef WOLFSSL_SHA_CTX SHA_CTX;
 
 #ifdef WOLFSSL_SHA224
 
-/* Using ALIGN16 because when AES-NI is enabled digest and buffer in Sha256
- * struct are 16 byte aligned. Any dereference to those elements after casting
- * to Sha224, is expected to also be 16 byte aligned addresses.  */
-typedef struct WOLFSSL_SHA224_CTX {
-    /* big enough to hold wolfcrypt Sha224, but check on init */
-    ALIGN16 void* holder[(272 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
-} WOLFSSL_SHA224_CTX;
-
 WOLFSSL_API int wolfSSL_SHA224_Init(WOLFSSL_SHA224_CTX*);
 WOLFSSL_API int wolfSSL_SHA224_Update(WOLFSSL_SHA224_CTX*, const void*,
 	                                 unsigned long);
 WOLFSSL_API int wolfSSL_SHA224_Final(unsigned char*, WOLFSSL_SHA224_CTX*);
 
-enum {
-    SHA224_DIGEST_LENGTH = 28
-};
-
-
-typedef WOLFSSL_SHA224_CTX SHA224_CTX;
 
 #define SHA224_Init   wolfSSL_SHA224_Init
 #define SHA224_Update wolfSSL_SHA224_Update
@@ -115,17 +84,8 @@ typedef WOLFSSL_SHA224_CTX SHA224_CTX;
      * because of SHA224 enum in FIPS build. */
     #define SHA224 wolfSSL_SHA224
 #endif
-
 #endif /* WOLFSSL_SHA224 */
 
-
-/* Using ALIGN16 because when AES-NI is enabled digest and buffer in Sha256
- * struct are 16 byte aligned. Any dereference to those elements after casting
- * to Sha256, is expected to also be 16 byte aligned addresses.  */
-typedef struct WOLFSSL_SHA256_CTX {
-    /* big enough to hold wolfcrypt Sha256, but check on init */
-    ALIGN16 void* holder[(272 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
-} WOLFSSL_SHA256_CTX;
 
 WOLFSSL_API int wolfSSL_SHA256_Init(WOLFSSL_SHA256_CTX*);
 WOLFSSL_API int wolfSSL_SHA256_Update(WOLFSSL_SHA256_CTX*, const void*,
@@ -133,12 +93,6 @@ WOLFSSL_API int wolfSSL_SHA256_Update(WOLFSSL_SHA256_CTX*, const void*,
 WOLFSSL_API int wolfSSL_SHA256_Final(unsigned char*, WOLFSSL_SHA256_CTX*);
 WOLFSSL_API int wolfSSL_SHA256_Transform(WOLFSSL_SHA256_CTX*, 
                                                 const unsigned char *data);
-enum {
-    SHA256_DIGEST_LENGTH = 32
-};
-
-
-typedef WOLFSSL_SHA256_CTX SHA256_CTX;
 
 #define SHA256_Init   wolfSSL_SHA256_Init
 #define SHA256_Update wolfSSL_SHA256_Update
@@ -153,23 +107,10 @@ typedef WOLFSSL_SHA256_CTX SHA256_CTX;
 
 
 #ifdef WOLFSSL_SHA384
-
-typedef struct WOLFSSL_SHA384_CTX {
-    /* big enough to hold wolfCrypt Sha384, but check on init */
-    void* holder[(256 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
-} WOLFSSL_SHA384_CTX;
-
 WOLFSSL_API int wolfSSL_SHA384_Init(WOLFSSL_SHA384_CTX*);
 WOLFSSL_API int wolfSSL_SHA384_Update(WOLFSSL_SHA384_CTX*, const void*,
 	                                 unsigned long);
 WOLFSSL_API int wolfSSL_SHA384_Final(unsigned char*, WOLFSSL_SHA384_CTX*);
-
-enum {
-    SHA384_DIGEST_LENGTH = 48
-};
-
-
-typedef WOLFSSL_SHA384_CTX SHA384_CTX;
 
 #define SHA384_Init   wolfSSL_SHA384_Init
 #define SHA384_Update wolfSSL_SHA384_Update
@@ -182,24 +123,12 @@ typedef WOLFSSL_SHA384_CTX SHA384_CTX;
 #endif /* WOLFSSL_SHA384 */
 
 #ifdef WOLFSSL_SHA512
-
-typedef struct WOLFSSL_SHA512_CTX {
-    /* big enough to hold wolfCrypt Sha384, but check on init */
-    void* holder[(288 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
-} WOLFSSL_SHA512_CTX;
-
 WOLFSSL_API int wolfSSL_SHA512_Init(WOLFSSL_SHA512_CTX*);
 WOLFSSL_API int wolfSSL_SHA512_Update(WOLFSSL_SHA512_CTX*, const void*,
                                      unsigned long);
 WOLFSSL_API int wolfSSL_SHA512_Final(unsigned char*, WOLFSSL_SHA512_CTX*);
 WOLFSSL_API int wolfSSL_SHA512_Transform(WOLFSSL_SHA512_CTX*, 
                                         const unsigned char*);
-enum {
-    SHA512_DIGEST_LENGTH = 64
-};
-
-
-typedef WOLFSSL_SHA512_CTX SHA512_CTX;
 
 #define SHA512_Init   wolfSSL_SHA512_Init
 #define SHA512_Update wolfSSL_SHA512_Update

--- a/wolfssl/openssl/sha3.h
+++ b/wolfssl/openssl/sha3.h
@@ -37,27 +37,13 @@
 #endif
 
 
-/* Using ALIGN16 because when AES-NI is enabled digest and buffer in Sha3
- * struct are 16 byte aligned. Any dereference to those elements after casting
- * to Sha3 is expected to also be 16 byte aligned addresses.  */
-struct WOLFSSL_SHA3_CTX {
-    /* big enough to hold wolfcrypt Sha3, but check on init */
-    ALIGN16 void* holder[(424 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
-};
 
 #ifndef WOLFSSL_NOSHA3_224
-typedef struct WOLFSSL_SHA3_CTX WOLFSSL_SHA3_224_CTX;
 
 WOLFSSL_API int wolfSSL_SHA3_224_Init(WOLFSSL_SHA3_224_CTX*);
 WOLFSSL_API int wolfSSL_SHA3_224_Update(WOLFSSL_SHA3_224_CTX*, const void*,
                                      unsigned long);
 WOLFSSL_API int wolfSSL_SHA3_224_Final(unsigned char*, WOLFSSL_SHA3_224_CTX*);
-
-enum {
-    SHA3_224_DIGEST_LENGTH = 28
-};
-
-typedef WOLFSSL_SHA3_224_CTX SHA3_224_CTX;
 
 #define SHA3_224_Init   wolfSSL_SHA3_224_Init
 #define SHA3_224_Update wolfSSL_SHA3_224_Update
@@ -69,20 +55,11 @@ typedef WOLFSSL_SHA3_224_CTX SHA3_224_CTX;
 
 
 #ifndef WOLFSSL_NOSHA3_256
-typedef struct WOLFSSL_SHA3_CTX WOLFSSL_SHA3_256_CTX;
-
 
 WOLFSSL_API int wolfSSL_SHA3_256_Init(WOLFSSL_SHA3_256_CTX*);
 WOLFSSL_API int wolfSSL_SHA3_256_Update(WOLFSSL_SHA3_256_CTX*, const void*,
                                      unsigned long);
 WOLFSSL_API int wolfSSL_SHA3_256_Final(unsigned char*, WOLFSSL_SHA3_256_CTX*);
-
-enum {
-    SHA3_256_DIGEST_LENGTH = 32
-};
-
-
-typedef WOLFSSL_SHA3_256_CTX SHA3_256_CTX;
 
 #define SHA3_256_Init   wolfSSL_SHA3_256_Init
 #define SHA3_256_Update wolfSSL_SHA3_256_Update
@@ -93,18 +70,11 @@ typedef WOLFSSL_SHA3_256_CTX SHA3_256_CTX;
 #endif /* WOLFSSL_NOSHA3_256 */
 
 
-typedef struct WOLFSSL_SHA3_CTX WOLFSSL_SHA3_384_CTX;
-
 WOLFSSL_API int wolfSSL_SHA3_384_Init(WOLFSSL_SHA3_384_CTX*);
 WOLFSSL_API int wolfSSL_SHA3_384_Update(WOLFSSL_SHA3_384_CTX*, const void*,
 	                                 unsigned long);
 WOLFSSL_API int wolfSSL_SHA3_384_Final(unsigned char*, WOLFSSL_SHA3_384_CTX*);
 
-enum {
-    SHA3_384_DIGEST_LENGTH = 48
-};
-
-typedef WOLFSSL_SHA3_384_CTX SHA3_384_CTX;
 
 #define SHA3_384_Init   wolfSSL_SHA3_384_Init
 #define SHA3_384_Update wolfSSL_SHA3_384_Update
@@ -115,20 +85,10 @@ typedef WOLFSSL_SHA3_384_CTX SHA3_384_CTX;
 
 
 #ifndef WOLFSSL_NOSHA3_512
-
-typedef struct WOLFSSL_SHA3_CTX WOLFSSL_SHA3_512_CTX;
-
 WOLFSSL_API int wolfSSL_SHA3_512_Init(WOLFSSL_SHA3_512_CTX*);
 WOLFSSL_API int wolfSSL_SHA3_512_Update(WOLFSSL_SHA3_512_CTX*, const void*,
 	                                 unsigned long);
 WOLFSSL_API int wolfSSL_SHA3_512_Final(unsigned char*, WOLFSSL_SHA3_512_CTX*);
-
-enum {
-    SHA3_512_DIGEST_LENGTH = 64
-};
-
-
-typedef WOLFSSL_SHA3_512_CTX SHA3_512_CTX;
 
 #define SHA3_512_Init   wolfSSL_SHA3_512_Init
 #define SHA3_512_Update wolfSSL_SHA3_512_Update

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -130,10 +130,6 @@ typedef WOLFSSL_X509_VERIFY_PARAM X509_VERIFY_PARAM;
 
 #define EVP_CIPHER_INFO        EncryptedInfo
 
-#define STACK_OF(x) WOLFSSL_STACK
-#define OPENSSL_STACK WOLFSSL_STACK
-#define _STACK OPENSSL_STACK
-
 #define CONF_get1_default_config_file   wolfSSL_CONF_get1_default_config_file
 typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 

--- a/wolfssl/openssl/txt_db.h
+++ b/wolfssl/openssl/txt_db.h
@@ -22,7 +22,7 @@
 #ifndef WOLFSSL_TXT_DB_H_
 #define WOLFSSL_TXT_DB_H_
 
-#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 
 #define WOLFSSL_TXT_DB_MAX_FIELDS 10
 

--- a/wolfssl/openssl/x509.h
+++ b/wolfssl/openssl/x509.h
@@ -1,6 +1,6 @@
 /* x509.h for openssl */
 
-#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl_types.h>
 #include <wolfssl/openssl/crypto.h>
 #include <wolfssl/openssl/dh.h>
 #include <wolfssl/openssl/ec.h>

--- a/wolfssl/openssl/x509v3.h
+++ b/wolfssl/openssl/x509v3.h
@@ -46,7 +46,7 @@ typedef STACK_OF(CONF_VALUE) *(*X509V3_EXT_I2V) (
                                 void *ext, STACK_OF(CONF_VALUE) *extlist);
 typedef char *(*X509V3_EXT_I2S)(struct WOLFSSL_v3_ext_method *method, void *ext);
 typedef int (*X509V3_EXT_I2R) (struct WOLFSSL_v3_ext_method *method,
-                               void *ext, BIO *out, int indent);
+                               void *ext, WOLFSSL_BIO *out, int indent);
 typedef struct WOLFSSL_v3_ext_method X509V3_EXT_METHOD;
 
 struct WOLFSSL_v3_ext_method {

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -102,627 +102,18 @@
     extern "C" {
 #endif
 
-/* LHASH is implemented as a stack */
-typedef struct WOLFSSL_STACK WOLFSSL_LHASH;
-#ifndef WOLF_LHASH_OF
-    #define WOLF_LHASH_OF(x) WOLFSSL_LHASH
-#endif
-
-#ifndef WOLF_STACK_OF
-    #define WOLF_STACK_OF(x) WOLFSSL_STACK
-#endif
-#ifndef DECLARE_STACK_OF
-    #define DECLARE_STACK_OF(x) WOLF_STACK_OF(x);
-#endif
-
-#ifndef WOLFSSL_WOLFSSL_TYPE_DEFINED
-#define WOLFSSL_WOLFSSL_TYPE_DEFINED
-typedef struct WOLFSSL          WOLFSSL;
-#endif
-typedef struct WOLFSSL_SESSION  WOLFSSL_SESSION;
-typedef struct WOLFSSL_METHOD   WOLFSSL_METHOD;
-#ifndef WOLFSSL_WOLFSSL_CTX_TYPE_DEFINED
-#define WOLFSSL_WOLFSSL_CTX_TYPE_DEFINED
-typedef struct WOLFSSL_CTX      WOLFSSL_CTX;
-#endif
-
-typedef struct WOLFSSL_STACK      WOLFSSL_STACK;
-typedef struct WOLFSSL_X509       WOLFSSL_X509;
-typedef struct WOLFSSL_X509_NAME  WOLFSSL_X509_NAME;
-typedef struct WOLFSSL_X509_NAME_ENTRY  WOLFSSL_X509_NAME_ENTRY;
-typedef struct WOLFSSL_X509_PUBKEY WOLFSSL_X509_PUBKEY;
-typedef struct WOLFSSL_X509_ALGOR WOLFSSL_X509_ALGOR;
-typedef struct WOLFSSL_X509_CHAIN WOLFSSL_X509_CHAIN;
-typedef struct WC_PKCS12          WOLFSSL_X509_PKCS12;
-typedef struct WOLFSSL_X509_INFO  WOLFSSL_X509_INFO;
-
-typedef struct WOLFSSL_CERT_MANAGER WOLFSSL_CERT_MANAGER;
-typedef struct WOLFSSL_SOCKADDR     WOLFSSL_SOCKADDR;
-typedef struct WOLFSSL_CRL          WOLFSSL_CRL;
-typedef struct WOLFSSL_X509_STORE_CTX WOLFSSL_X509_STORE_CTX;
-
-typedef int (*WOLFSSL_X509_STORE_CTX_verify_cb)(int, WOLFSSL_X509_STORE_CTX *);
-
-/* redeclare guard */
-#define WOLFSSL_TYPES_DEFINED
+#include <wolfssl/ssl_types.h>
 
 #include <wolfssl/wolfio.h>
-
-
-#ifndef WOLFSSL_RSA_TYPE_DEFINED /* guard on redeclaration */
-typedef struct WOLFSSL_RSA            WOLFSSL_RSA;
-#define WOLFSSL_RSA_TYPE_DEFINED
-#endif
-
-#ifndef WC_RNG_TYPE_DEFINED /* guard on redeclaration */
-    typedef struct WC_RNG WC_RNG;
-    #define WC_RNG_TYPE_DEFINED
-#endif
-
-#ifndef WOLFSSL_DSA_TYPE_DEFINED /* guard on redeclaration */
-typedef struct WOLFSSL_DSA            WOLFSSL_DSA;
-#define WOLFSSL_DSA_TYPE_DEFINED
-#endif
-
-#ifndef WOLFSSL_EC_TYPE_DEFINED /* guard on redeclaration */
-typedef struct WOLFSSL_EC_KEY         WOLFSSL_EC_KEY;
-typedef struct WOLFSSL_EC_POINT       WOLFSSL_EC_POINT;
-typedef struct WOLFSSL_EC_GROUP       WOLFSSL_EC_GROUP;
-typedef struct WOLFSSL_EC_BUILTIN_CURVE WOLFSSL_EC_BUILTIN_CURVE;
-/* WOLFSSL_EC_METHOD is just an alias of WOLFSSL_EC_GROUP for now */
-typedef struct WOLFSSL_EC_GROUP       WOLFSSL_EC_METHOD;
-#define WOLFSSL_EC_TYPE_DEFINED
-#endif
-
-#ifndef WOLFSSL_ECDSA_TYPE_DEFINED /* guard on redeclaration */
-typedef struct WOLFSSL_ECDSA_SIG      WOLFSSL_ECDSA_SIG;
-#define WOLFSSL_ECDSA_TYPE_DEFINED
-#endif
-
-typedef struct WOLFSSL_CIPHER         WOLFSSL_CIPHER;
-typedef struct WOLFSSL_X509_LOOKUP    WOLFSSL_X509_LOOKUP;
-typedef struct WOLFSSL_X509_LOOKUP_METHOD WOLFSSL_X509_LOOKUP_METHOD;
-typedef struct WOLFSSL_CRL            WOLFSSL_X509_CRL;
-typedef struct WOLFSSL_X509_STORE     WOLFSSL_X509_STORE;
-typedef struct WOLFSSL_X509_VERIFY_PARAM WOLFSSL_X509_VERIFY_PARAM;
-typedef struct WOLFSSL_BIO            WOLFSSL_BIO;
-typedef struct WOLFSSL_BIO_METHOD     WOLFSSL_BIO_METHOD;
-typedef struct WOLFSSL_X509_EXTENSION WOLFSSL_X509_EXTENSION;
-typedef struct WOLFSSL_ASN1_OBJECT    WOLFSSL_ASN1_OBJECT;
-typedef struct WOLFSSL_ASN1_OTHERNAME WOLFSSL_ASN1_OTHERNAME;
-typedef struct WOLFSSL_X509V3_CTX     WOLFSSL_X509V3_CTX;
-typedef struct WOLFSSL_v3_ext_method  WOLFSSL_v3_ext_method;
-
-typedef struct WOLFSSL_ASN1_STRING      WOLFSSL_ASN1_STRING;
-typedef struct WOLFSSL_dynlock_value    WOLFSSL_dynlock_value;
-#ifndef WOLFSSL_DH_TYPE_DEFINED /* guard on redeclaration */
-typedef struct WOLFSSL_DH               WOLFSSL_DH;
-#define WOLFSSL_DH_TYPE_DEFINED /* guard on redeclaration */
-#endif
-typedef struct WOLFSSL_ASN1_BIT_STRING  WOLFSSL_ASN1_BIT_STRING;
-typedef struct WOLFSSL_ASN1_TYPE        WOLFSSL_ASN1_TYPE;
-typedef struct WOLFSSL_X509_ATTRIBUTE   WOLFSSL_X509_ATTRIBUTE;
-
-typedef struct WOLFSSL_GENERAL_NAME WOLFSSL_GENERAL_NAME;
-typedef struct WOLFSSL_AUTHORITY_KEYID  WOLFSSL_AUTHORITY_KEYID;
-typedef struct WOLFSSL_BASIC_CONSTRAINTS WOLFSSL_BASIC_CONSTRAINTS;
-typedef struct WOLFSSL_ACCESS_DESCRIPTION WOLFSSL_ACCESS_DESCRIPTION;
-
-#if defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
-
-struct WOLFSSL_AUTHORITY_KEYID {
-    WOLFSSL_ASN1_STRING *keyid;
-    WOLFSSL_ASN1_OBJECT *issuer;
-    WOLFSSL_ASN1_INTEGER *serial;
-};
-
-struct WOLFSSL_BASIC_CONSTRAINTS {
-    int ca;
-    WOLFSSL_ASN1_INTEGER *pathlen;
-};
-
-#endif /* OPENSSL_ALL || OPENSSL_EXTRA*/
-
-#define WOLFSSL_ASN1_UTCTIME          WOLFSSL_ASN1_TIME
-#define WOLFSSL_ASN1_GENERALIZEDTIME  WOLFSSL_ASN1_TIME
-
-struct WOLFSSL_ASN1_STRING {
-    char strData[CTC_NAME_SIZE];
-    int length;
-    int type; /* type of string i.e. CTC_UTF8 */
-    char* data;
-    long flags;
-    unsigned int   isDynamic:1; /* flag for if data pointer dynamic (1 is yes 0 is no) */
-};
-
-#define WOLFSSL_MAX_SNAME 40
-
-
-#define WOLFSSL_ASN1_DYNAMIC 0x1
-#define WOLFSSL_ASN1_DYNAMIC_DATA 0x2
-
-struct WOLFSSL_ASN1_OTHERNAME {
-    WOLFSSL_ASN1_OBJECT* type_id;
-    WOLFSSL_ASN1_TYPE*   value;
-};
-
-struct WOLFSSL_GENERAL_NAME {
-    int type;
-    union {
-        char* ptr;
-        WOLFSSL_ASN1_OTHERNAME* otherName;
-        WOLFSSL_ASN1_STRING* rfc822Name;
-        WOLFSSL_ASN1_STRING* dNSName;
-        WOLFSSL_ASN1_TYPE* x400Address;
-        WOLFSSL_X509_NAME* directoryName;
-        WOLFSSL_ASN1_STRING* uniformResourceIdentifier;
-        WOLFSSL_ASN1_STRING* iPAddress;
-        WOLFSSL_ASN1_OBJECT* registeredID;
-
-        WOLFSSL_ASN1_STRING* ip;
-        WOLFSSL_X509_NAME* dirn;
-        WOLFSSL_ASN1_STRING* ia5;
-        WOLFSSL_ASN1_OBJECT* rid;
-        WOLFSSL_ASN1_TYPE* other;
-    } d; /* dereference */
-};
-
-struct WOLFSSL_ACCESS_DESCRIPTION {
-    WOLFSSL_ASN1_OBJECT*  method;
-    WOLFSSL_GENERAL_NAME* location;
-};
-
-struct WOLFSSL_X509V3_CTX {
-    WOLFSSL_X509* x509;
-};
-
-
-
-struct WOLFSSL_ASN1_OBJECT {
-    void*  heap;
-    const unsigned char* obj;
-    /* sName is short name i.e sha256 rather than oid (null terminated) */
-    char   sName[WOLFSSL_MAX_SNAME];
-    int    type; /* oid */
-    int    grp;  /* type of OID, i.e. oidCertPolicyType */
-    int    nid;
-    unsigned int  objSz;
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_QT) || defined(WOLFSSL_APACHE_HTTPD)
-    int ca;
-    WOLFSSL_ASN1_INTEGER *pathlen;
-#endif
-    unsigned char dynamic; /* Use WOLFSSL_ASN1_DYNAMIC and WOLFSSL_ASN1_DYNAMIC_DATA
-                            * to determine what needs to be freed. */
-
-#if defined(WOLFSSL_APACHE_HTTPD)
-    WOLFSSL_GENERAL_NAME* gn;
-#endif
-
-    struct d { /* derefrenced */
-        WOLFSSL_ASN1_STRING* dNSName;
-        WOLFSSL_ASN1_STRING  ia5_internal;
-        WOLFSSL_ASN1_STRING* ia5; /* points to ia5_internal */
-#if defined(WOLFSSL_QT) || defined(OPENSSL_ALL)
-        WOLFSSL_ASN1_STRING* uniformResourceIdentifier;
-        WOLFSSL_ASN1_STRING  iPAddress_internal;
-        WOLFSSL_ASN1_OTHERNAME* otherName; /* added for Apache httpd */
-#endif
-        WOLFSSL_ASN1_STRING* iPAddress; /* points to iPAddress_internal */
-    } d;
-};
-
-/* wrap ASN1 types */
-struct WOLFSSL_ASN1_TYPE {
-    int type;
-    union {
-        char *ptr;
-        WOLFSSL_ASN1_STRING*     asn1_string;
-        WOLFSSL_ASN1_OBJECT*     object;
-        WOLFSSL_ASN1_INTEGER*    integer;
-        WOLFSSL_ASN1_BIT_STRING* bit_string;
-        WOLFSSL_ASN1_STRING*     octet_string;
-        WOLFSSL_ASN1_STRING*     printablestring;
-        WOLFSSL_ASN1_STRING*     ia5string;
-        WOLFSSL_ASN1_UTCTIME*    utctime;
-        WOLFSSL_ASN1_GENERALIZEDTIME* generalizedtime;
-        WOLFSSL_ASN1_STRING*     utf8string;
-        WOLFSSL_ASN1_STRING*     set;
-        WOLFSSL_ASN1_STRING*     sequence;
-    } value;
-};
-
-struct WOLFSSL_X509_ATTRIBUTE {
-    WOLFSSL_ASN1_OBJECT *object;
-    WOLFSSL_ASN1_TYPE *value;
-    WOLF_STACK_OF(WOLFSSL_ASN1_TYPE) *set;
-};
-
-struct WOLFSSL_EVP_PKEY {
-    void* heap;
-    int type;         /* openssh dereference */
-    int save_type;    /* openssh dereference */
-    int pkey_sz;
-    int references;  /*number of times free should be called for complete free*/
-    wolfSSL_Mutex    refMutex; /* ref count mutex */
-
-    union {
-        char* ptr; /* der format of key / or raw for NTRU */
-    } pkey;
-    #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
-    #ifndef NO_RSA
-        WOLFSSL_RSA* rsa;
-        byte      ownRsa; /* if struct owns RSA and should free it */
-    #endif
-    #ifndef NO_DSA
-        WOLFSSL_DSA* dsa;
-        byte      ownDsa; /* if struct owns DSA and should free it */
-    #endif
-    #ifdef HAVE_ECC
-        WOLFSSL_EC_KEY* ecc;
-        byte      ownEcc; /* if struct owns ECC and should free it */
-    #endif
-    #ifndef NO_DH
-        WOLFSSL_DH* dh;
-        byte      ownDh; /* if struct owns DH and should free it */
-    #endif
-    WC_RNG rng;
-    #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
-    #ifdef HAVE_ECC
-        int pkey_curve;
-    #endif
-};
-typedef struct WOLFSSL_EVP_PKEY WOLFSSL_PKCS8_PRIV_KEY_INFO;
-#ifndef WOLFSSL_EVP_TYPE_DEFINED /* guard on redeclaration */
-typedef struct WOLFSSL_EVP_PKEY     WOLFSSL_EVP_PKEY;
-typedef struct WOLFSSL_EVP_MD_CTX   WOLFSSL_EVP_MD_CTX;
-typedef char   WOLFSSL_EVP_MD;
-#define WOLFSSL_EVP_TYPE_DEFINED
-#endif
-
-struct WOLFSSL_X509_PKEY {
-    WOLFSSL_EVP_PKEY* dec_pkey; /* dereferenced by Apache */
-    void* heap;
-};
-typedef struct WOLFSSL_X509_PKEY WOLFSSL_X509_PKEY;
-
-struct WOLFSSL_X509_INFO {
-    WOLFSSL_X509      *x509;
-    WOLFSSL_X509_CRL  *crl;
-    WOLFSSL_X509_PKEY  *x_pkey; /* dereferenced by Apache */
-    EncryptedInfo     enc_cipher;
-    int               enc_len;
-    char              *enc_data;
-    int               num;
-};
-
-#define WOLFSSL_EVP_PKEY_DEFAULT EVP_PKEY_RSA /* default key type */
-
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
-    #define wolfSSL_SSL_MODE_RELEASE_BUFFERS    0x00000010U
-    #define wolfSSL_SSL_CTRL_SET_TMP_ECDH       4
-#endif
-
-struct WOLFSSL_X509_ALGOR {
-    WOLFSSL_ASN1_OBJECT* algorithm;
-    WOLFSSL_ASN1_TYPE* parameter;
-};
-
-struct WOLFSSL_X509_PUBKEY {
-    WOLFSSL_X509_ALGOR* algor;
-    WOLFSSL_EVP_PKEY* pkey;
-    int pubKeyOID;
-};
-
-
-enum BIO_TYPE {
-    WOLFSSL_BIO_BUFFER = 1,
-    WOLFSSL_BIO_SOCKET = 2,
-    WOLFSSL_BIO_SSL    = 3,
-    WOLFSSL_BIO_MEMORY = 4,
-    WOLFSSL_BIO_BIO    = 5,
-    WOLFSSL_BIO_FILE   = 6,
-    WOLFSSL_BIO_BASE64 = 7,
-    WOLFSSL_BIO_MD     = 8
-};
-
-enum BIO_FLAGS {
-    WOLFSSL_BIO_FLAG_BASE64_NO_NL = 0x01,
-    WOLFSSL_BIO_FLAG_READ         = 0x02,
-    WOLFSSL_BIO_FLAG_WRITE        = 0x04,
-    WOLFSSL_BIO_FLAG_IO_SPECIAL   = 0x08,
-    WOLFSSL_BIO_FLAG_RETRY        = 0x10
-};
-
-enum BIO_CB_OPS {
-    WOLFSSL_BIO_CB_FREE   = 0x01,
-    WOLFSSL_BIO_CB_READ   = 0x02,
-    WOLFSSL_BIO_CB_WRITE  = 0x03,
-    WOLFSSL_BIO_CB_PUTS   = 0x04,
-    WOLFSSL_BIO_CB_GETS   = 0x05,
-    WOLFSSL_BIO_CB_CTRL   = 0x06,
-    WOLFSSL_BIO_CB_RETURN = 0x80
-};
-
-typedef struct WOLFSSL_BUF_MEM {
-    char*  data;   /* dereferenced */
-    size_t length; /* current length */
-    size_t max;    /* maximum length */
-} WOLFSSL_BUF_MEM;
-
-/* custom method with user set callbacks */
-typedef int  (*wolfSSL_BIO_meth_write_cb)(WOLFSSL_BIO*, const char*, int);
-typedef int  (*wolfSSL_BIO_meth_read_cb)(WOLFSSL_BIO *, char *, int);
-typedef int  (*wolfSSL_BIO_meth_puts_cb)(WOLFSSL_BIO*, const char*);
-typedef int  (*wolfSSL_BIO_meth_gets_cb)(WOLFSSL_BIO*, char*, int);
-typedef long (*wolfSSL_BIO_meth_ctrl_get_cb)(WOLFSSL_BIO*, int, long, void*);
-typedef int  (*wolfSSL_BIO_meth_create_cb)(WOLFSSL_BIO*);
-typedef int  (*wolfSSL_BIO_meth_destroy_cb)(WOLFSSL_BIO*);
-
-typedef int wolfSSL_BIO_info_cb(WOLFSSL_BIO *, int, int);
-typedef long (*wolfssl_BIO_meth_ctrl_info_cb)(WOLFSSL_BIO*, int, wolfSSL_BIO_info_cb*);
-
-/* wolfSSL BIO_METHOD type */
-#ifndef MAX_BIO_METHOD_NAME
-#define MAX_BIO_METHOD_NAME 256
-#endif
-struct WOLFSSL_BIO_METHOD {
-    byte type;               /* method type */
-    char name[MAX_BIO_METHOD_NAME];
-    wolfSSL_BIO_meth_write_cb writeCb;
-    wolfSSL_BIO_meth_read_cb readCb;
-    wolfSSL_BIO_meth_puts_cb putsCb;
-    wolfSSL_BIO_meth_gets_cb getsCb;
-    wolfSSL_BIO_meth_ctrl_get_cb ctrlCb;
-    wolfSSL_BIO_meth_create_cb createCb;
-    wolfSSL_BIO_meth_destroy_cb freeCb;
-    wolfssl_BIO_meth_ctrl_info_cb ctrlInfoCb;
-};
-
-/* wolfSSL BIO type */
-typedef long (*wolf_bio_info_cb)(WOLFSSL_BIO *bio, int event, const char *parg,
-                                 int iarg, long larg, long return_value);
-
-struct WOLFSSL_BIO {
-    WOLFSSL_BUF_MEM* mem_buf;
-    WOLFSSL_BIO_METHOD* method;
-    WOLFSSL_BIO* prev;          /* previous in chain */
-    WOLFSSL_BIO* next;          /* next in chain */
-    WOLFSSL_BIO* pair;          /* BIO paired with */
-    void*        heap;          /* user heap hint */
-    void*        ptr;           /* WOLFSSL, file descriptor, MD, or mem buf */
-    void*        usrCtx;        /* user set pointer */
-    const char*  ip;            /* IP address for wolfIO_TcpConnect */
-    word16       port;          /* Port for wolfIO_TcpConnect */
-    char*        infoArg;       /* BIO callback argument */
-    wolf_bio_info_cb infoCb;    /* BIO callback */
-    int          wrSz;          /* write buffer size (mem) */
-    int          wrIdx;         /* current index for write buffer */
-    int          rdIdx;         /* current read index */
-    int          readRq;        /* read request */
-    int          num;           /* socket num or length */
-    int          eof;           /* eof flag */
-    int          flags;
-    byte         type;          /* method type */
-    byte         init:1;        /* bio has been initialized */
-    byte         shutdown:1;    /* close flag */
-#ifdef HAVE_EX_DATA
-    WOLFSSL_CRYPTO_EX_DATA ex_data;
-#endif
-};
-
-typedef struct WOLFSSL_COMP_METHOD {
-    int type;            /* stunnel dereference */
-} WOLFSSL_COMP_METHOD;
-
-typedef struct WOLFSSL_COMP {
-    int id;
-    const char *name;
-    WOLFSSL_COMP_METHOD *method;
-} WOLFSSL_COMP;
 
 #define WOLFSSL_X509_L_FILE_LOAD  0x1
 #define WOLFSSL_X509_L_ADD_DIR    0x2
 #define WOLFSSL_X509_L_ADD_STORE  0x3
 #define WOLFSSL_X509_L_LOAD_STORE 0x4
 
-struct WOLFSSL_X509_LOOKUP_METHOD {
-    int type;
-};
-
-struct WOLFSSL_X509_LOOKUP {
-    WOLFSSL_X509_STORE *store;
-};
-
-struct WOLFSSL_X509_STORE {
-    int                   cache;          /* stunnel dereference */
-    WOLFSSL_CERT_MANAGER* cm;
-    WOLFSSL_X509_LOOKUP   lookup;
-#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
-    int                   isDynamic;
-    WOLFSSL_X509_VERIFY_PARAM* param;    /* certificate validation parameter */
-#endif
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
-    WOLFSSL_X509_STORE_CTX_verify_cb verify_cb;
-#endif
-#ifdef HAVE_EX_DATA
-    WOLFSSL_CRYPTO_EX_DATA ex_data;
-#endif
-#if (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)) && defined(HAVE_CRL)
-    WOLFSSL_X509_CRL *crl; /* points to cm->crl */
-#endif
-};
-
 #define WOLFSSL_NO_WILDCARDS   0x4
 
-#if defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA) || \
-    defined(WOLFSSL_WPAS_SMALL) || defined(WOLFSSL_IP_ALT_NAME)
-    #define WOLFSSL_MAX_IPSTR 46 /* max ip size IPv4 mapped IPv6 */
-#endif /* OPENSSL_ALL || WOLFSSL_IP_ALT_NAME */
-
-#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
-#define WOLFSSL_USE_CHECK_TIME 0x2
-#define WOLFSSL_NO_CHECK_TIME  0x200000
-#define WOLFSSL_HOST_NAME_MAX  256
-
-#define WOLFSSL_VPARAM_DEFAULT          0x1
-#define WOLFSSL_VPARAM_OVERWRITE        0x2
-#define WOLFSSL_VPARAM_RESET_FLAGS      0x4
-#define WOLFSSL_VPARAM_LOCKED           0x8
-#define WOLFSSL_VPARAM_ONCE             0x10
-
-struct WOLFSSL_X509_VERIFY_PARAM {
-    time_t         check_time;
-    unsigned int   inherit_flags;
-    unsigned long  flags;
-    char           hostName[WOLFSSL_HOST_NAME_MAX];
-    unsigned int  hostFlags;
-    char ipasc[WOLFSSL_MAX_IPSTR];
-};
-#endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
-
-typedef struct WOLFSSL_ALERT {
-    int code;
-    int level;
-} WOLFSSL_ALERT;
-
-typedef struct WOLFSSL_ALERT_HISTORY {
-    WOLFSSL_ALERT last_rx;
-    WOLFSSL_ALERT last_tx;
-} WOLFSSL_ALERT_HISTORY;
-
-typedef struct WOLFSSL_X509_REVOKED {
-    WOLFSSL_ASN1_INTEGER* serialNumber;          /* stunnel dereference */
-} WOLFSSL_X509_REVOKED;
-
-
-typedef struct WOLFSSL_X509_OBJECT {
-    union {
-        char* ptr;
-        WOLFSSL_X509 *x509;
-        WOLFSSL_X509_CRL* crl;           /* stunnel dereference */
-    } data;
-} WOLFSSL_X509_OBJECT;
-
 #define WOLFSSL_ASN1_BOOLEAN                int
-
-typedef struct WOLFSSL_BUFFER_INFO {
-    unsigned char* buffer;
-    unsigned int length;
-} WOLFSSL_BUFFER_INFO;
-
-struct WOLFSSL_X509_STORE_CTX {
-    WOLFSSL_X509_STORE* store;    /* Store full of a CA cert chain */
-    WOLFSSL_X509* current_cert;   /* current X509 (OPENSSL_EXTRA) */
-#ifdef WOLFSSL_ASIO
-    WOLFSSL_X509* current_issuer; /* asio dereference */
-#endif
-    WOLFSSL_X509_CHAIN* sesChain; /* pointer to WOLFSSL_SESSION peer chain */
-    WOLFSSL_STACK* chain;
-#ifdef OPENSSL_EXTRA
-    WOLFSSL_X509_VERIFY_PARAM* param; /* certificate validation parameter */
-#endif
-    char* domain;                /* subject CN domain name */
-#if defined(HAVE_EX_DATA) || defined(FORTRESS)
-    WOLFSSL_CRYPTO_EX_DATA ex_data;  /* external data */
-#endif
-#if defined(WOLFSSL_APACHE_HTTPD) || defined(OPENSSL_EXTRA)
-    int depth;                   /* used in X509_STORE_CTX_*_depth */
-#endif
-    void* userCtx;               /* user ctx */
-    int   error;                 /* current error */
-    int   error_depth;           /* index of cert depth for this error */
-    int   discardSessionCerts;   /* so verify callback can flag for discard */
-    int   totalCerts;            /* number of peer cert buffers */
-    WOLFSSL_BUFFER_INFO* certs;  /* peer certs */
-    WOLFSSL_X509_STORE_CTX_verify_cb verify_cb; /* verify callback */
-};
-
-typedef char* WOLFSSL_STRING;
-
-/* Valid Alert types from page 16/17
- * Add alert string to the function wolfSSL_alert_type_string_long in src/ssl.c
- */
-enum AlertDescription {
-    close_notify                    =   0,
-    unexpected_message              =  10,
-    bad_record_mac                  =  20,
-    record_overflow                 =  22,
-    decompression_failure           =  30,
-    handshake_failure               =  40,
-    no_certificate                  =  41,
-    bad_certificate                 =  42,
-    unsupported_certificate         =  43,
-    certificate_revoked             =  44,
-    certificate_expired             =  45,
-    certificate_unknown             =  46,
-    illegal_parameter               =  47,
-    unknown_ca                      =  48,
-    decode_error                    =  50,
-    decrypt_error                   =  51,
-    #ifdef WOLFSSL_MYSQL_COMPATIBLE
-    /* catch name conflict for enum protocol with MYSQL build */
-    wc_protocol_version             =  70,
-    #else
-    protocol_version                =  70,
-    #endif
-    inappropriate_fallback          =  86,
-    no_renegotiation                = 100,
-    missing_extension               = 109,
-    unsupported_extension           = 110, /**< RFC 5246, section 7.2.2 */
-    unrecognized_name               = 112, /**< RFC 6066, section 3 */
-    bad_certificate_status_response = 113, /**< RFC 6066, section 8 */
-    unknown_psk_identity            = 115, /**< RFC 4279, section 2 */
-    certificate_required            = 116, /**< RFC 8446, section 8.2 */
-    no_application_protocol         = 120
-};
-
-
-enum AlertLevel {
-    alert_warning = 1,
-    alert_fatal   = 2
-};
-
-/* WS_RETURN_CODE macro
- * Some OpenSSL APIs specify "0" as the return value when an error occurs.
- * However, some corresponding wolfSSL APIs　return negative values. Such
- * functions should use this macro to fill this gap. Users who want them
- * to return the same return value as OpenSSL can define
- * WOLFSSL_ERR_CODE_OPENSSL.
- * Give item1 a variable that contains the potentially negative
- * wolfSSL-defined return value or the return value itself, and
- * give item2 the openSSL-defined return value.
- * Note that this macro replaces only negative return values with the
- * specified value.
- * Since wolfSSL 4.7.0, the following functions use this macro:
- * - wolfSSL_CTX_load_verify_locations
- * - wolfSSL_X509_LOOKUP_load_file
- */
-#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-    #define WS_RETURN_CODE(item1,item2) \
-      ((item1 < 0) ? item2 : item1)
-#else
-    #define WS_RETURN_CODE(item1,item2)  (item1)
-#endif
-
-/* Maximum master key length (SECRET_LEN) */
-#define WOLFSSL_MAX_MASTER_KEY_LENGTH 48
-/* Maximum number of groups that can be set */
-#define WOLFSSL_MAX_GROUP_COUNT       10
-
-#if defined(HAVE_SECRET_CALLBACK) && defined(WOLFSSL_TLS13)
-enum Tls13Secret {
-    CLIENT_EARLY_TRAFFIC_SECRET,
-    CLIENT_HANDSHAKE_TRAFFIC_SECRET,
-    SERVER_HANDSHAKE_TRAFFIC_SECRET,
-    CLIENT_TRAFFIC_SECRET,
-    SERVER_TRAFFIC_SECRET,
-    EARLY_EXPORTER_SECRET,
-    EXPORTER_SECRET
-};
-#endif
-
-
-typedef WOLFSSL_METHOD* (*wolfSSL_method_func)(void* heap);
 
 /* CTX Method EX Constructor Functions */
 WOLFSSL_API WOLFSSL_METHOD *wolfTLS_client_method_ex(void* heap);
@@ -1192,8 +583,6 @@ WOLFSSL_API int wolfSSL_sk_ACCESS_DESCRIPTION_push(
                                        WOLF_STACK_OF(ACCESS_DESCRIPTION)* sk,
                                        WOLFSSL_ACCESS_DESCRIPTION* access);
 #endif /* defined(OPENSSL_ALL) || defined(WOLFSSL_QT) */
-
-typedef WOLF_STACK_OF(WOLFSSL_GENERAL_NAME) WOLFSSL_GENERAL_NAMES;
 
 WOLFSSL_API int wolfSSL_sk_X509_push(WOLF_STACK_OF(WOLFSSL_X509_NAME)* sk,
                                                             WOLFSSL_X509* x509);
@@ -1735,195 +1124,6 @@ WOLFSSL_API long wolfSSL_get_verify_result(const WOLFSSL *ssl);
 
 #define WOLFSSL_DEFAULT_CIPHER_LIST ""   /* default all */
 
-/* These are bit-masks */
-enum {
-    WOLFSSL_OCSP_URL_OVERRIDE = 1,
-    WOLFSSL_OCSP_NO_NONCE     = 2,
-    WOLFSSL_OCSP_CHECKALL     = 4,
-
-    WOLFSSL_CRL_CHECKALL = 1,
-    WOLFSSL_CRL_CHECK    = 2,
-};
-
-/* Separated out from other enums because of size */
-enum {
-    SSL_OP_MICROSOFT_SESS_ID_BUG                  = 0x00000001,
-    SSL_OP_NETSCAPE_CHALLENGE_BUG                 = 0x00000002,
-    SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG       = 0x00000004,
-    SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG            = 0x00000008,
-    SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER             = 0x00000010,
-    SSL_OP_MSIE_SSLV2_RSA_PADDING                 = 0x00000020,
-    SSL_OP_SSLEAY_080_CLIENT_DH_BUG               = 0x00000040,
-    SSL_OP_TLS_D5_BUG                             = 0x00000080,
-    SSL_OP_TLS_BLOCK_PADDING_BUG                  = 0x00000100,
-    SSL_OP_TLS_ROLLBACK_BUG                       = 0x00000200,
-    SSL_OP_EPHEMERAL_RSA                          = 0x00000800,
-    WOLFSSL_OP_NO_SSLv3                           = 0x00001000,
-    WOLFSSL_OP_NO_TLSv1                           = 0x00002000,
-    SSL_OP_PKCS1_CHECK_1                          = 0x00004000,
-    SSL_OP_PKCS1_CHECK_2                          = 0x00008000,
-    SSL_OP_NETSCAPE_CA_DN_BUG                     = 0x00010000,
-    SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG        = 0x00020000,
-    SSL_OP_SINGLE_DH_USE                          = 0x00040000,
-    SSL_OP_NO_TICKET                              = 0x00080000,
-    SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS            = 0x00100000,
-    SSL_OP_NO_QUERY_MTU                           = 0x00200000,
-    SSL_OP_COOKIE_EXCHANGE                        = 0x00400000,
-    SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION = 0x00800000,
-    SSL_OP_SINGLE_ECDH_USE                        = 0x01000000,
-    SSL_OP_CIPHER_SERVER_PREFERENCE               = 0x02000000,
-    WOLFSSL_OP_NO_TLSv1_1                         = 0x04000000,
-    WOLFSSL_OP_NO_TLSv1_2                         = 0x08000000,
-    SSL_OP_NO_COMPRESSION                         = 0x10000000,
-    WOLFSSL_OP_NO_TLSv1_3                         = 0x20000000,
-    WOLFSSL_OP_NO_SSLv2                           = 0x40000000,
-    SSL_OP_ALL   =
-                    (SSL_OP_MICROSOFT_SESS_ID_BUG
-                  | SSL_OP_NETSCAPE_CHALLENGE_BUG
-                  | SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG
-                  | SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG
-                  | SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER
-                  | SSL_OP_MSIE_SSLV2_RSA_PADDING
-                  | SSL_OP_SSLEAY_080_CLIENT_DH_BUG
-                  | SSL_OP_TLS_D5_BUG
-                  | SSL_OP_TLS_BLOCK_PADDING_BUG
-                  | SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS
-                  | SSL_OP_TLS_ROLLBACK_BUG),
-};
-
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
-    defined(HAVE_WEBSERVER)
-/* for compatibility these must be macros */
-#define SSL_OP_NO_SSLv2   WOLFSSL_OP_NO_SSLv2
-#define SSL_OP_NO_SSLv3   WOLFSSL_OP_NO_SSLv3
-#define SSL_OP_NO_TLSv1   WOLFSSL_OP_NO_TLSv1
-#define SSL_OP_NO_TLSv1_1 WOLFSSL_OP_NO_TLSv1_1
-#define SSL_OP_NO_TLSv1_2 WOLFSSL_OP_NO_TLSv1_2
-#if !(!defined(WOLFSSL_TLS13) && defined(WOLFSSL_APACHE_HTTPD)) /* apache uses this to determine if TLS 1.3 is enabled */
-#define SSL_OP_NO_TLSv1_3 WOLFSSL_OP_NO_TLSv1_3
-#endif
-
-#define SSL_OP_NO_SSL_MASK (SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | \
-    SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3)
-
-#define SSL_NOTHING 1
-#define SSL_WRITING 2
-#define SSL_READING 3
-
-enum {
-#ifdef HAVE_OCSP
-    /* OCSP Flags */
-    OCSP_NOCERTS     = 1,
-    OCSP_NOINTERN    = 2,
-    OCSP_NOSIGS      = 4,
-    OCSP_NOCHAIN     = 8,
-    OCSP_NOVERIFY    = 16,
-    OCSP_NOEXPLICIT  = 32,
-    OCSP_NOCASIGN    = 64,
-    OCSP_NODELEGATED = 128,
-    OCSP_NOCHECKS    = 256,
-    OCSP_TRUSTOTHER  = 512,
-    OCSP_RESPID_KEY  = 1024,
-    OCSP_NOTIME      = 2048,
-
-    /* OCSP Types */
-    OCSP_CERTID   = 2,
-    OCSP_REQUEST  = 4,
-    OCSP_RESPONSE = 8,
-    OCSP_BASICRESP = 16,
-#endif
-
-    ASN1_GENERALIZEDTIME = 4,
-    SSL_MAX_SSL_SESSION_ID_LENGTH = 32,
-
-    SSL_ST_CONNECT = 0x1000,
-    SSL_ST_ACCEPT  = 0x2000,
-    SSL_ST_MASK    = 0x0FFF,
-
-    SSL_CB_LOOP = 0x01,
-    SSL_CB_EXIT = 0x02,
-    SSL_CB_READ = 0x04,
-    SSL_CB_WRITE = 0x08,
-    SSL_CB_HANDSHAKE_START = 0x10,
-    SSL_CB_HANDSHAKE_DONE = 0x20,
-    SSL_CB_ALERT = 0x4000,
-    SSL_CB_READ_ALERT = (SSL_CB_ALERT | SSL_CB_READ),
-    SSL_CB_WRITE_ALERT = (SSL_CB_ALERT | SSL_CB_WRITE),
-    SSL_CB_ACCEPT_LOOP = (SSL_ST_ACCEPT | SSL_CB_LOOP),
-    SSL_CB_ACCEPT_EXIT = (SSL_ST_ACCEPT | SSL_CB_EXIT),
-    SSL_CB_CONNECT_LOOP = (SSL_ST_CONNECT | SSL_CB_LOOP),
-    SSL_CB_CONNECT_EXIT = (SSL_ST_CONNECT | SSL_CB_EXIT),
-    SSL_CB_MODE_READ = 1,
-    SSL_CB_MODE_WRITE = 2,
-
-    SSL_MODE_ENABLE_PARTIAL_WRITE = 2,
-    SSL_MODE_AUTO_RETRY = 3, /* wolfSSL default is to block with blocking io
-                              * and auto retry */
-    SSL_MODE_RELEASE_BUFFERS = -1, /* For libwebsockets build. No current use. */
-
-    BIO_CLOSE   = 1,
-    BIO_NOCLOSE = 0,
-
-    X509_FILETYPE_PEM = 8,
-    X509_LU_X509      = 9,
-    X509_LU_CRL       = 12,
-
-    X509_V_OK                                    = 0,
-    X509_V_ERR_CRL_SIGNATURE_FAILURE             = 13,
-    X509_V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD    = 14,
-    X509_V_ERR_CRL_HAS_EXPIRED                   = 15,
-    X509_V_ERR_CERT_REVOKED                      = 16,
-    X509_V_ERR_CERT_CHAIN_TOO_LONG               = 17,
-    X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT         = 18,
-    X509_V_ERR_CERT_NOT_YET_VALID                = 19,
-    X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD    = 20,
-    X509_V_ERR_CERT_HAS_EXPIRED                  = 21,
-    X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD     = 22,
-    X509_V_ERR_CERT_REJECTED                     = 23,
-    /* Required for Nginx  */
-    X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT       = 24,
-    X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN         = 25,
-    X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY = 26,
-    X509_V_ERR_CERT_UNTRUSTED                    = 27,
-    X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE   = 28,
-    X509_V_ERR_SUBJECT_ISSUER_MISMATCH           = 29,
-    /* additional X509_V_ERR_* enums not used in wolfSSL */
-    X509_V_ERR_UNABLE_TO_GET_CRL,
-    X509_V_ERR_UNABLE_TO_DECRYPT_CERT_SIGNATURE,
-    X509_V_ERR_UNABLE_TO_DECRYPT_CRL_SIGNATURE,
-    X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY,
-    X509_V_ERR_CERT_SIGNATURE_FAILURE,
-    X509_V_ERR_CRL_NOT_YET_VALID,
-    X509_V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD,
-    X509_V_ERR_OUT_OF_MEM,
-    X509_V_ERR_INVALID_CA,
-    X509_V_ERR_PATH_LENGTH_EXCEEDED,
-    X509_V_ERR_INVALID_PURPOSE,
-    X509_V_ERR_AKID_SKID_MISMATCH,
-    X509_V_ERR_AKID_ISSUER_SERIAL_MISMATCH,
-    X509_V_ERR_KEYUSAGE_NO_CERTSIGN,
-    X509_V_ERR_UNABLE_TO_GET_CRL_ISSUER,
-    X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION,
-    X509_V_ERR_KEYUSAGE_NO_CRL_SIGN,
-    X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION,
-    X509_V_ERR_INVALID_NON_CA,
-    X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED,
-    X509_V_ERR_KEYUSAGE_NO_DIGITAL_SIGNATURE,
-    X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED,
-    X509_V_ERR_INVALID_EXTENSION,
-    X509_V_ERR_INVALID_POLICY_EXTENSION,
-    X509_V_ERR_NO_EXPLICIT_POLICY,
-    X509_V_ERR_UNNESTED_RESOURCE,
-    X509_V_ERR_APPLICATION_VERIFICATION,
-
-    X509_R_CERT_ALREADY_IN_HASH_TABLE,
-
-    CRYPTO_LOCK = 1,
-    CRYPTO_NUM_LOCKS = 10,
-
-    ASN1_STRFLGS_ESC_MSB = 4
-};
-#endif
 
 /* extras end */
 
@@ -2002,63 +1202,6 @@ WOLFSSL_API void wolfSSL_ERR_print_errors(WOLFSSL_BIO *bio);
     #define PEM_BUFSIZE WOLF_PEM_BUFSIZE
 #endif
 
-enum { /* ssl Constants */
-    WOLFSSL_ERROR_NONE      =  0,   /* for most functions */
-    WOLFSSL_FAILURE         =  0,   /* for some functions */
-    WOLFSSL_SUCCESS         =  1,
-    WOLFSSL_SHUTDOWN_NOT_DONE =  2,  /* call wolfSSL_shutdown again to complete */
-
-    WOLFSSL_ALPN_NOT_FOUND  = -9,
-    WOLFSSL_BAD_CERTTYPE    = -8,
-    WOLFSSL_BAD_STAT        = -7,
-    WOLFSSL_BAD_PATH        = -6,
-    WOLFSSL_BAD_FILETYPE    = -5,
-    WOLFSSL_BAD_FILE        = -4,
-    WOLFSSL_NOT_IMPLEMENTED = -3,
-    WOLFSSL_UNKNOWN         = -2,
-    WOLFSSL_FATAL_ERROR     = -1,
-
-    WOLFSSL_FILETYPE_ASN1    = 2,
-    WOLFSSL_FILETYPE_PEM     = 1,
-    WOLFSSL_FILETYPE_DEFAULT = 2, /* ASN1 */
-    WOLFSSL_FILETYPE_RAW     = 3, /* NTRU raw key blob */
-
-    WOLFSSL_VERIFY_NONE                 = 0,
-    WOLFSSL_VERIFY_PEER                 = 1,
-    WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT = 2,
-    WOLFSSL_VERIFY_CLIENT_ONCE          = 4,
-    WOLFSSL_VERIFY_FAIL_EXCEPT_PSK      = 8,
-
-    WOLFSSL_SESS_CACHE_OFF                = 0x0000,
-    WOLFSSL_SESS_CACHE_CLIENT             = 0x0001,
-    WOLFSSL_SESS_CACHE_SERVER             = 0x0002,
-    WOLFSSL_SESS_CACHE_BOTH               = 0x0003,
-    WOLFSSL_SESS_CACHE_NO_AUTO_CLEAR      = 0x0008,
-    WOLFSSL_SESS_CACHE_NO_INTERNAL_LOOKUP = 0x0100,
-    WOLFSSL_SESS_CACHE_NO_INTERNAL_STORE  = 0x0200,
-    WOLFSSL_SESS_CACHE_NO_INTERNAL        = 0x0300,
-
-    WOLFSSL_ERROR_WANT_READ        =  2,
-    WOLFSSL_ERROR_WANT_WRITE       =  3,
-    WOLFSSL_ERROR_WANT_CONNECT     =  7,
-    WOLFSSL_ERROR_WANT_ACCEPT      =  8,
-    WOLFSSL_ERROR_SYSCALL          =  5,
-    WOLFSSL_ERROR_WANT_X509_LOOKUP = 83,
-    WOLFSSL_ERROR_ZERO_RETURN      =  6,
-    WOLFSSL_ERROR_SSL              = 85,
-
-    WOLFSSL_SENT_SHUTDOWN     = 1,
-    WOLFSSL_RECEIVED_SHUTDOWN = 2,
-    WOLFSSL_MODE_ACCEPT_MOVING_WRITE_BUFFER = 4,
-
-    WOLFSSL_R_SSL_HANDSHAKE_FAILURE           = 101,
-    WOLFSSL_R_TLSV1_ALERT_UNKNOWN_CA          = 102,
-    WOLFSSL_R_SSLV3_ALERT_CERTIFICATE_UNKNOWN = 103,
-    WOLFSSL_R_SSLV3_ALERT_BAD_CERTIFICATE     = 104,
-
-    WOLF_PEM_BUFSIZE = 1024
-};
-
 #ifndef NO_PSK
     typedef unsigned int (*wc_psk_client_callback)(WOLFSSL*, const char*, char*,
                                     unsigned int, unsigned char*, unsigned int);
@@ -2109,20 +1252,6 @@ enum { /* ssl Constants */
     WOLFSSL_API int wolfSSL_CTX_allow_anon_cipher(WOLFSSL_CTX*);
 #endif /* HAVE_ANON */
 
-
-/* extra begins */
-#ifdef OPENSSL_EXTRA
-enum {  /* ERR Constants */
-    ERR_TXT_STRING = 1
-};
-
-/* bio misc */
-enum {
-    WOLFSSL_BIO_ERROR = -1,
-    WOLFSSL_BIO_UNSET = -2,
-    WOLFSSL_BIO_SIZE  = 17000 /* default BIO write size if not set */
-};
-#endif
 
 WOLFSSL_API void wolfSSL_ERR_put_error(int lib, int fun, int err,
                                        const char* file, int line);
@@ -2491,48 +1620,7 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL*, void* key, unsigned int len,
 WOLFSSL_API int wolfSSL_CTX_set_group_messages(WOLFSSL_CTX*);
 WOLFSSL_API int wolfSSL_set_group_messages(WOLFSSL*);
 
-
-#ifdef HAVE_FUZZER
-enum fuzzer_type {
-    FUZZ_HMAC      = 0,
-    FUZZ_ENCRYPT   = 1,
-    FUZZ_SIGNATURE = 2,
-    FUZZ_HASH      = 3,
-    FUZZ_HEAD      = 4
-};
-
-typedef int (*CallbackFuzzer)(WOLFSSL* ssl, const unsigned char* buf, int sz,
-        int type, void* fuzzCtx);
-
-WOLFSSL_API void wolfSSL_SetFuzzerCb(WOLFSSL* ssl, CallbackFuzzer cbf, void* fCtx);
-#endif
-
-
 WOLFSSL_API int   wolfSSL_DTLS_SetCookieSecret(WOLFSSL*, const byte*, word32);
-
-
-/* I/O Callback default errors */
-enum IOerrors {
-    WOLFSSL_CBIO_ERR_GENERAL    = -1,     /* general unexpected err */
-    WOLFSSL_CBIO_ERR_WANT_READ  = -2,     /* need to call read  again */
-    WOLFSSL_CBIO_ERR_WANT_WRITE = -2,     /* need to call write again */
-    WOLFSSL_CBIO_ERR_CONN_RST   = -3,     /* connection reset */
-    WOLFSSL_CBIO_ERR_ISR        = -4,     /* interrupt */
-    WOLFSSL_CBIO_ERR_CONN_CLOSE = -5,     /* connection closed or epipe */
-    WOLFSSL_CBIO_ERR_TIMEOUT    = -6      /* socket timeout */
-};
-
-
-/* CA cache callbacks */
-enum {
-    WOLFSSL_SSLV3    = 0,
-    WOLFSSL_TLSV1    = 1,
-    WOLFSSL_TLSV1_1  = 2,
-    WOLFSSL_TLSV1_2  = 3,
-    WOLFSSL_TLSV1_3  = 4,
-    WOLFSSL_USER_CA  = 1,          /* user added as trusted */
-    WOLFSSL_CHAIN_CA = 2           /* added to cache from trusted chain */
-};
 
 WOLFSSL_ABI WOLFSSL_API WC_RNG* wolfSSL_GetRNG(WOLFSSL*);
 
@@ -2553,46 +1641,20 @@ WOLFSSL_API int wolfSSL_SetVersion(WOLFSSL* ssl, int version);
 #define wolfSSL_PubKeyPemToDer wc_PubKeyPemToDer
 #define wolfSSL_PemCertToDer   wc_PemCertToDer
 
-
-typedef void (*CallbackCACache)(unsigned char* der, int sz, int type);
-typedef void (*CbMissingCRL)(const char* url);
-typedef int  (*CbOCSPIO)(void*, const char*, int,
-                                         unsigned char*, int, unsigned char**);
-typedef void (*CbOCSPRespFree)(void*,unsigned char*);
-
-#ifdef HAVE_CRL_IO
-typedef int  (*CbCrlIO)(WOLFSSL_CRL* crl, const char* url, int urlSz);
-#endif
-
 /* User Atomic Record Layer CallBacks */
-typedef int (*CallbackMacEncrypt)(WOLFSSL* ssl, unsigned char* macOut,
-       const unsigned char* macIn, unsigned int macInSz, int macContent,
-       int macVerify, unsigned char* encOut, const unsigned char* encIn,
-       unsigned int encSz, void* ctx);
 WOLFSSL_API void  wolfSSL_CTX_SetMacEncryptCb(WOLFSSL_CTX*, CallbackMacEncrypt);
 WOLFSSL_API void  wolfSSL_SetMacEncryptCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetMacEncryptCtx(WOLFSSL* ssl);
 
-typedef int (*CallbackDecryptVerify)(WOLFSSL* ssl,
-       unsigned char* decOut, const unsigned char* decIn,
-       unsigned int decSz, int content, int verify, unsigned int* padSz,
-       void* ctx);
 WOLFSSL_API void  wolfSSL_CTX_SetDecryptVerifyCb(WOLFSSL_CTX*,
                                                  CallbackDecryptVerify);
 WOLFSSL_API void  wolfSSL_SetDecryptVerifyCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetDecryptVerifyCtx(WOLFSSL* ssl);
 
-typedef int (*CallbackEncryptMac)(WOLFSSL* ssl, unsigned char* macOut,
-       int content, int macVerify, unsigned char* encOut,
-       const unsigned char* encIn, unsigned int encSz, void* ctx);
 WOLFSSL_API void  wolfSSL_CTX_SetEncryptMacCb(WOLFSSL_CTX*, CallbackEncryptMac);
 WOLFSSL_API void  wolfSSL_SetEncryptMacCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetEncryptMacCtx(WOLFSSL* ssl);
 
-typedef int (*CallbackVerifyDecrypt)(WOLFSSL* ssl,
-       unsigned char* decOut, const unsigned char* decIn,
-       unsigned int decSz, int content, int verify, unsigned int* padSz,
-       void* ctx);
 WOLFSSL_API void  wolfSSL_CTX_SetVerifyDecryptCb(WOLFSSL_CTX*,
                                                  CallbackVerifyDecrypt);
 WOLFSSL_API void  wolfSSL_SetVerifyDecryptCtx(WOLFSSL* ssl, void *ctx);
@@ -2616,46 +1678,6 @@ WOLFSSL_API int                  wolfSSL_GetHmacType(WOLFSSL*);
 WOLFSSL_API int                  wolfSSL_GetCipherType(WOLFSSL*);
 WOLFSSL_API int                  wolfSSL_SetTlsHmacInner(WOLFSSL*, unsigned char*,
                                                        word32, int, int);
-
-/* Atomic User Needs */
-enum {
-    WOLFSSL_SERVER_END = 0,
-    WOLFSSL_CLIENT_END = 1,
-    WOLFSSL_NEITHER_END = 3,
-    WOLFSSL_BLOCK_TYPE = 2,
-    WOLFSSL_STREAM_TYPE = 3,
-    WOLFSSL_AEAD_TYPE = 4,
-    WOLFSSL_TLS_HMAC_INNER_SZ = 13      /* SEQ_SZ + ENUM + VERSION_SZ + LEN_SZ */
-};
-
-/* for GetBulkCipher and internal use */
-enum BulkCipherAlgorithm {
-    wolfssl_cipher_null,
-    wolfssl_rc4,
-    wolfssl_rc2,
-    wolfssl_des,
-    wolfssl_triple_des,             /* leading 3 (3des) not valid identifier */
-    wolfssl_des40,
-#ifdef HAVE_IDEA
-    wolfssl_idea,
-#endif
-    wolfssl_aes,
-    wolfssl_aes_gcm,
-    wolfssl_aes_ccm,
-    wolfssl_chacha,
-    wolfssl_camellia,
-    wolfssl_hc128,                  /* wolfSSL extensions */
-    wolfssl_rabbit
-};
-
-
-/* for KDF TLS 1.2 mac types */
-enum KDF_MacAlgorithm {
-    wolfssl_sha256 = 4,     /* needs to match hash.h wc_MACAlgorithm */
-    wolfssl_sha384,
-    wolfssl_sha512
-};
-
 
 /* Public Key Callback support */
 #ifdef HAVE_PK_CALLBACKS
@@ -3000,30 +2022,12 @@ WOLFSSL_API void* wolfSSL_CTX_GetHeap(WOLFSSL_CTX* ctx, WOLFSSL* ssl);
 /* Server Name Indication */
 #ifdef HAVE_SNI
 
-/* SNI types */
-enum {
-    WOLFSSL_SNI_HOST_NAME = 0
-};
-
 WOLFSSL_ABI WOLFSSL_API int wolfSSL_UseSNI(WOLFSSL*, unsigned char,
                                                    const void*, unsigned short);
 WOLFSSL_ABI WOLFSSL_API int wolfSSL_CTX_UseSNI(WOLFSSL_CTX*, unsigned char,
                                                    const void*, unsigned short);
 
 #ifndef NO_WOLFSSL_SERVER
-
-/* SNI options */
-enum {
-    /* Do not abort the handshake if the requested SNI didn't match. */
-    WOLFSSL_SNI_CONTINUE_ON_MISMATCH = 0x01,
-
-    /* Behave as if the requested SNI matched in a case of mismatch.  */
-    /* In this case, the status will be set to WOLFSSL_SNI_FAKE_MATCH. */
-    WOLFSSL_SNI_ANSWER_ON_MISMATCH   = 0x02,
-
-    /* Abort the handshake if the client didn't send a SNI request. */
-    WOLFSSL_SNI_ABORT_ON_ABSENCE     = 0x04,
-};
 
 WOLFSSL_API void wolfSSL_SNI_SetOptions(WOLFSSL* ssl, unsigned char type,
                                                          unsigned char options);
@@ -3035,14 +2039,6 @@ WOLFSSL_API int wolfSSL_SNI_GetFromBuffer(
 
 #endif /* NO_WOLFSSL_SERVER */
 
-/* SNI status */
-enum {
-    WOLFSSL_SNI_NO_MATCH   = 0,
-    WOLFSSL_SNI_FAKE_MATCH = 1, /**< @see WOLFSSL_SNI_ANSWER_ON_MISMATCH */
-    WOLFSSL_SNI_REAL_MATCH = 2,
-    WOLFSSL_SNI_FORCE_KEEP = 3  /** Used with -DWOLFSSL_ALWAYS_KEEP_SNI */
-};
-
 WOLFSSL_API unsigned char wolfSSL_SNI_Status(WOLFSSL* ssl, unsigned char type);
 
 WOLFSSL_API unsigned short wolfSSL_SNI_GetRequest(WOLFSSL *ssl,
@@ -3052,41 +2048,12 @@ WOLFSSL_API unsigned short wolfSSL_SNI_GetRequest(WOLFSSL *ssl,
 
 /* Trusted CA Key Indication - RFC 6066 (Section 6) */
 #ifdef HAVE_TRUSTED_CA
-
-/* TCA Identifier Type */
-enum {
-    WOLFSSL_TRUSTED_CA_PRE_AGREED = 0,
-    WOLFSSL_TRUSTED_CA_KEY_SHA1 = 1,
-    WOLFSSL_TRUSTED_CA_X509_NAME = 2,
-    WOLFSSL_TRUSTED_CA_CERT_SHA1 = 3
-};
-
 WOLFSSL_API int wolfSSL_UseTrustedCA(WOLFSSL* ssl, unsigned char type,
             const unsigned char* certId, unsigned int certIdSz);
 #endif /* HAVE_TRUSTED_CA */
 
 /* Application-Layer Protocol Negotiation */
 #ifdef HAVE_ALPN
-
-/* ALPN status code */
-enum {
-    WOLFSSL_ALPN_NO_MATCH = 0,
-    WOLFSSL_ALPN_MATCH    = 1,
-    WOLFSSL_ALPN_CONTINUE_ON_MISMATCH = 2,
-    WOLFSSL_ALPN_FAILED_ON_MISMATCH = 4,
-};
-
-enum {
-    WOLFSSL_MAX_ALPN_PROTO_NAME_LEN = 255,
-    WOLFSSL_MAX_ALPN_NUMBER = 257
-};
-
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || defined(HAVE_LIGHTY)
-typedef int (*CallbackALPNSelect)(WOLFSSL* ssl, const unsigned char** out,
-    unsigned char* outLen, const unsigned char* in, unsigned int inLen,
-    void *arg);
-#endif
-
 WOLFSSL_ABI WOLFSSL_API int wolfSSL_UseALPN(WOLFSSL* ssl,
                                 char *protocol_name_list,
                                 unsigned int protocol_name_listSz,
@@ -3102,19 +2069,6 @@ WOLFSSL_API int wolfSSL_ALPN_FreePeerProtocol(WOLFSSL* ssl, char **list);
 
 /* Maximum Fragment Length */
 #ifdef HAVE_MAX_FRAGMENT
-
-/* Fragment lengths */
-enum {
-    WOLFSSL_MFL_2_9  = 1, /*  512 bytes */
-    WOLFSSL_MFL_2_10 = 2, /* 1024 bytes */
-    WOLFSSL_MFL_2_11 = 3, /* 2048 bytes */
-    WOLFSSL_MFL_2_12 = 4, /* 4096 bytes */
-    WOLFSSL_MFL_2_13 = 5, /* 8192 bytes *//* wolfSSL ONLY!!! */
-    WOLFSSL_MFL_2_8  = 6, /*  256 bytes *//* wolfSSL ONLY!!! */
-    WOLFSSL_MFL_MIN  = WOLFSSL_MFL_2_9,
-    WOLFSSL_MFL_MAX  = WOLFSSL_MFL_2_8,
-};
-
 #ifndef NO_WOLFSSL_CLIENT
 
 WOLFSSL_API int wolfSSL_UseMaxFragment(WOLFSSL* ssl, unsigned char mfl);
@@ -3133,17 +2087,6 @@ WOLFSSL_API int wolfSSL_CTX_UseTruncatedHMAC(WOLFSSL_CTX* ctx);
 #endif
 #endif
 
-/* Certificate Status Request */
-/* Certificate Status Type */
-enum {
-    WOLFSSL_CSR_OCSP = 1
-};
-
-/* Certificate Status Options (flags) */
-enum {
-    WOLFSSL_CSR_OCSP_USE_NONCE = 0x01
-};
-
 #ifdef HAVE_CERTIFICATE_STATUS_REQUEST
 #ifndef NO_WOLFSSL_CLIENT
 
@@ -3156,18 +2099,6 @@ WOLFSSL_API int wolfSSL_CTX_UseOCSPStapling(WOLFSSL_CTX* ctx,
 #endif
 #endif
 
-/* Certificate Status Request v2 */
-/* Certificate Status Type */
-enum {
-    WOLFSSL_CSR2_OCSP = 1,
-    WOLFSSL_CSR2_OCSP_MULTI = 2
-};
-
-/* Certificate Status v2 Options (flags) */
-enum {
-    WOLFSSL_CSR2_OCSP_USE_NONCE = 0x01
-};
-
 #ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
 #ifndef NO_WOLFSSL_CLIENT
 
@@ -3179,57 +2110,6 @@ WOLFSSL_API int wolfSSL_CTX_UseOCSPStaplingV2(WOLFSSL_CTX* ctx,
 
 #endif
 #endif
-
-/* Named Groups */
-enum {
-#if 0 /* Not Supported */
-    WOLFSSL_ECC_SECT163K1 = 1,
-    WOLFSSL_ECC_SECT163R1 = 2,
-    WOLFSSL_ECC_SECT163R2 = 3,
-    WOLFSSL_ECC_SECT193R1 = 4,
-    WOLFSSL_ECC_SECT193R2 = 5,
-    WOLFSSL_ECC_SECT233K1 = 6,
-    WOLFSSL_ECC_SECT233R1 = 7,
-    WOLFSSL_ECC_SECT239K1 = 8,
-    WOLFSSL_ECC_SECT283K1 = 9,
-    WOLFSSL_ECC_SECT283R1 = 10,
-    WOLFSSL_ECC_SECT409K1 = 11,
-    WOLFSSL_ECC_SECT409R1 = 12,
-    WOLFSSL_ECC_SECT571K1 = 13,
-    WOLFSSL_ECC_SECT571R1 = 14,
-#endif
-    WOLFSSL_ECC_SECP160K1 = 15,
-    WOLFSSL_ECC_SECP160R1 = 16,
-    WOLFSSL_ECC_SECP160R2 = 17,
-    WOLFSSL_ECC_SECP192K1 = 18,
-    WOLFSSL_ECC_SECP192R1 = 19,
-    WOLFSSL_ECC_SECP224K1 = 20,
-    WOLFSSL_ECC_SECP224R1 = 21,
-    WOLFSSL_ECC_SECP256K1 = 22,
-    WOLFSSL_ECC_SECP256R1 = 23,
-    WOLFSSL_ECC_SECP384R1 = 24,
-    WOLFSSL_ECC_SECP521R1 = 25,
-    WOLFSSL_ECC_BRAINPOOLP256R1 = 26,
-    WOLFSSL_ECC_BRAINPOOLP384R1 = 27,
-    WOLFSSL_ECC_BRAINPOOLP512R1 = 28,
-    WOLFSSL_ECC_X25519    = 29,
-    WOLFSSL_ECC_X448      = 30,
-    WOLFSSL_ECC_MAX       = 30,
-
-    WOLFSSL_FFDHE_2048    = 256,
-    WOLFSSL_FFDHE_3072    = 257,
-    WOLFSSL_FFDHE_4096    = 258,
-    WOLFSSL_FFDHE_6144    = 259,
-    WOLFSSL_FFDHE_8192    = 260,
-};
-
-enum {
-    WOLFSSL_EC_PF_UNCOMPRESSED = 0,
-#if 0 /* Not Supported */
-    WOLFSSL_EC_PF_X962_COMP_PRIME = 1,
-    WOLFSSL_EC_PF_X962_COMP_CHAR2 = 2,
-#endif
-};
 
 #ifdef HAVE_SUPPORTED_CURVES
 WOLFSSL_API int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, word16 name);
@@ -3258,54 +2138,20 @@ WOLFSSL_API long wolfSSL_SSL_get_secure_renegotiation_support(WOLFSSL* ssl);
 /* Session Ticket */
 #ifdef HAVE_SESSION_TICKET
 
-#if !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && !defined(WOLFSSL_NO_SERVER)
-    #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305) && \
-        !defined(WOLFSSL_TICKET_ENC_AES128_GCM) && \
-        !defined(WOLFSSL_TICKET_ENC_AES256_GCM)
-        #define WOLFSSL_TICKET_KEY_SZ       CHACHA20_POLY1305_AEAD_KEYSIZE
-    #elif defined(WOLFSSL_TICKET_ENC_AES256_GCM)
-        #define WOLFSSL_TICKET_KEY_SZ       AES_256_KEY_SIZE
-    #else
-        #define WOLFSSL_TICKET_KEY_SZ       AES_128_KEY_SIZE
-    #endif
-
-    #define WOLFSSL_TICKET_KEYS_SZ     (WOLFSSL_TICKET_NAME_SZ +    \
-                                        2 * WOLFSSL_TICKET_KEY_SZ + \
-                                        sizeof(word32) * 2)
-#endif
-
 #ifndef NO_WOLFSSL_CLIENT
 WOLFSSL_API int wolfSSL_UseSessionTicket(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_CTX_UseSessionTicket(WOLFSSL_CTX* ctx);
 WOLFSSL_API int wolfSSL_get_SessionTicket(WOLFSSL*, unsigned char*, word32*);
 WOLFSSL_API int wolfSSL_set_SessionTicket(WOLFSSL*, const unsigned char*, word32);
-typedef int (*CallbackSessionTicket)(WOLFSSL*, const unsigned char*, int, void*);
 WOLFSSL_API int wolfSSL_set_SessionTicket_cb(WOLFSSL*,
                                                   CallbackSessionTicket, void*);
 #endif /* NO_WOLFSSL_CLIENT */
-
-
-#define WOLFSSL_TICKET_NAME_SZ 16
-#define WOLFSSL_TICKET_IV_SZ   16
-#define WOLFSSL_TICKET_MAC_SZ  32
-
-enum TicketEncRet {
-    WOLFSSL_TICKET_RET_FATAL  = -1,  /* fatal error, don't use ticket */
-    WOLFSSL_TICKET_RET_OK     =  0,  /* ok, use ticket */
-    WOLFSSL_TICKET_RET_REJECT,       /* don't use ticket, but not fatal */
-    WOLFSSL_TICKET_RET_CREATE        /* existing ticket ok and create new one */
-};
 
 #ifndef NO_WOLFSSL_SERVER
 
 WOLFSSL_API int wolfSSL_CTX_NoTicketTLSv12(WOLFSSL_CTX* ctx);
 WOLFSSL_API int wolfSSL_NoTicketTLSv12(WOLFSSL* ssl);
 
-typedef int (*SessionTicketEncCb)(WOLFSSL*,
-                                 unsigned char key_name[WOLFSSL_TICKET_NAME_SZ],
-                                 unsigned char iv[WOLFSSL_TICKET_IV_SZ],
-                                 unsigned char mac[WOLFSSL_TICKET_MAC_SZ],
-                                 int enc, unsigned char*, int, int*, void*);
 WOLFSSL_API int wolfSSL_CTX_set_TicketEncCb(WOLFSSL_CTX* ctx,
                                             SessionTicketEncCb);
 WOLFSSL_API int wolfSSL_CTX_set_TicketHint(WOLFSSL_CTX* ctx, int);
@@ -3317,17 +2163,6 @@ WOLFSSL_API void* wolfSSL_CTX_get_TicketEncCtx(WOLFSSL_CTX* ctx);
 #endif /* HAVE_SESSION_TICKET */
 
 #ifdef HAVE_QSH
-/* Quantum-safe Crypto Schemes */
-enum {
-    WOLFSSL_NTRU_EESS439 = 0x0101, /* max plaintext length of 65  */
-    WOLFSSL_NTRU_EESS593 = 0x0102, /* max plaintext length of 86  */
-    WOLFSSL_NTRU_EESS743 = 0x0103, /* max plaintext length of 106 */
-    WOLFSSL_LWE_XXX  = 0x0201,     /* Learning With Error encryption scheme */
-    WOLFSSL_HFE_XXX  = 0x0301,     /* Hidden Field Equation scheme */
-    WOLFSSL_NULL_QSH = 0xFFFF      /* QSHScheme is not used */
-};
-
-
 /* test if the connection is using a QSH secure connection return 1 if so */
 WOLFSSL_API int wolfSSL_isQSH(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_UseSupportedQSH(WOLFSSL* ssl, unsigned short name);
@@ -3337,7 +2172,6 @@ WOLFSSL_API int wolfSSL_UseSupportedQSH(WOLFSSL* ssl, unsigned short name);
        then will not send keys in the hello extension */
     WOLFSSL_API int wolfSSL_UseClientQSHKeys(WOLFSSL* ssl, unsigned char flag);
 #endif
-
 #endif /* QSH */
 
 /* TLS Extended Master Secret Extension */
@@ -3350,7 +2184,6 @@ WOLFSSL_API int wolfSSL_CTX_DisableExtendedMasterSecret(WOLFSSL_CTX* ctx);
 
 
 /* notify user the handshake is done */
-typedef int (*HandShakeDoneCb)(WOLFSSL*, void*);
 WOLFSSL_API int wolfSSL_SetHsDoneCb(WOLFSSL*, HandShakeDoneCb, void*);
 
 
@@ -3379,17 +2212,12 @@ int wolfSSL_DeriveTlsKeys(unsigned char* key_data, word32 keyLen,
                                int tls1_2, int hash_type);
 
 #ifdef WOLFSSL_CALLBACKS
-
-typedef int (*HandShakeCallBack)(HandShakeInfo*);
-typedef int (*TimeoutCallBack)(TimeoutInfo*);
-
 /* wolfSSL connect extension allowing HandShakeCallBack and/or TimeoutCallBack
    for diagnostics */
 WOLFSSL_API int wolfSSL_connect_ex(WOLFSSL*, HandShakeCallBack, TimeoutCallBack,
                                  WOLFSSL_TIMEVAL);
 WOLFSSL_API int wolfSSL_accept_ex(WOLFSSL*, HandShakeCallBack, TimeoutCallBack,
                                 WOLFSSL_TIMEVAL);
-
 #endif /* WOLFSSL_CALLBACKS */
 
 
@@ -3404,40 +2232,11 @@ WOLFSSL_API int wolfSSL_accept_ex(WOLFSSL*, HandShakeCallBack, TimeoutCallBack,
 #if defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 /* Smaller subset of X509 compatibility functions. Avoid increasing the size of
  * this subset and its memory usage */
-
 #include <wolfssl/openssl/asn1.h>
-struct WOLFSSL_X509_NAME_ENTRY {
-    WOLFSSL_ASN1_OBJECT* object;  /* static object just for keeping grp, type */
-    WOLFSSL_ASN1_STRING* value;  /* points to data, for lighttpd port */
-    int nid; /* i.e. ASN_COMMON_NAME */
-    int set;
-    int size;
-};
 
 WOLFSSL_API int wolfSSL_X509_NAME_get_index_by_OBJ(WOLFSSL_X509_NAME *name,
                                                    const WOLFSSL_ASN1_OBJECT *obj,
                                                    int idx);
-
-
-
-enum {
-    WOLFSSL_SYS_ACCEPT = 0,
-    WOLFSSL_SYS_BIND,
-    WOLFSSL_SYS_CONNECT,
-    WOLFSSL_SYS_FOPEN,
-    WOLFSSL_SYS_FREAD,
-    WOLFSSL_SYS_GETADDRINFO,
-    WOLFSSL_SYS_GETSOCKOPT,
-    WOLFSSL_SYS_GETSOCKNAME,
-    WOLFSSL_SYS_GETHOSTBYNAME,
-    WOLFSSL_SYS_GETNAMEINFO,
-    WOLFSSL_SYS_GETSERVBYNAME,
-    WOLFSSL_SYS_IOCTLSOCKET,
-    WOLFSSL_SYS_LISTEN,
-    WOLFSSL_SYS_OPENDIR,
-    WOLFSSL_SYS_SETSOCKOPT,
-    WOLFSSL_SYS_SOCKET
-};
 
 /* Object functions */
 WOLFSSL_API const char* wolfSSL_OBJ_nid2sn(int n);
@@ -3628,15 +2427,9 @@ WOLFSSL_API int wolfSSL_PEM_do_header(EncryptedInfo* cipher,
 
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || \
     defined(OPENSSL_EXTRA_X509_SMALL)
-struct WOLFSSL_ASN1_BIT_STRING {
-    int length;
-    int type;
-    byte* data;
-    long flags;
-};
 
 WOLFSSL_API WOLFSSL_X509_NAME_ENTRY *wolfSSL_X509_NAME_get_entry(WOLFSSL_X509_NAME *name, int loc);
-#endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
+#endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL || OPENSSL_EXTRA_X509_SMALL */
 
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)|| \
     defined(OPENSSL_EXTRA_X509_SMALL)
@@ -3790,9 +2583,6 @@ WOLFSSL_API void wolfSSL_sk_X509_INFO_pop_free(WOLF_STACK_OF(WOLFSSL_X509_INFO)*
     void (*f) (WOLFSSL_X509_INFO*));
 WOLFSSL_API void wolfSSL_sk_X509_INFO_free(WOLF_STACK_OF(WOLFSSL_X509_INFO)*);
 
-typedef int (*wolf_sk_compare_cb)(const void* a,
-                                  const void* b);
-typedef unsigned long (*wolf_sk_hash_cb) (const void *v);
 WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_sk_X509_NAME_new(
     wolf_sk_compare_cb);
 WOLFSSL_API int wolfSSL_sk_X509_NAME_push(WOLF_STACK_OF(WOLFSSL_X509_NAME)*,
@@ -3885,9 +2675,6 @@ WOLFSSL_API VerifyCallback wolfSSL_get_verify_callback(WOLFSSL*);
 #endif /* OPENSSL_ALL || HAVE_STUNNEL || WOLFSSL_NGINX || WOLFSSL_HAPROXY || HAVE_LIGHTY */
 
 #ifdef HAVE_SNI
-/* SNI received callback type */
-typedef int (*CallbackSniRecv)(WOLFSSL *ssl, int *ret, void* exArg);
-
 WOLFSSL_API void wolfSSL_CTX_set_servername_callback(WOLFSSL_CTX *,
         CallbackSniRecv);
 WOLFSSL_API int wolfSSL_CTX_set_tlsext_servername_callback(WOLFSSL_CTX *,
@@ -3956,9 +2743,6 @@ WOLFSSL_API int wolfSSL_CTX_AsyncPoll(WOLFSSL_CTX* ctx, WOLF_EVENT** events, int
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
 #ifdef OPENSSL_EXTRA
-typedef void (*SSL_Msg_Cb)(int write_p, int version, int content_type,
-    const void *buf, size_t len, WOLFSSL *ssl, void *arg);
-
 WOLFSSL_API int wolfSSL_CTX_set_msg_callback(WOLFSSL_CTX *ctx, SSL_Msg_Cb cb);
 WOLFSSL_API int wolfSSL_set_msg_callback(WOLFSSL *ssl, SSL_Msg_Cb cb);
 WOLFSSL_API int wolfSSL_CTX_set_msg_callback_arg(WOLFSSL_CTX *ctx, void* arg);

--- a/wolfssl/ssl_types.h
+++ b/wolfssl/ssl_types.h
@@ -1,0 +1,1606 @@
+/* ssl_types.h
+ *
+ * Copyright (C) 2006-2021 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/*
+ * This file defines types that were previously found in wolfssl/ssl.h. Other
+ * ssl header files should include this header instead of wolfssl/ssl.h to
+ * prevent circular dependencies of header includes.
+ */
+
+#ifndef WOLFSSL_SSL_TYPES_H_
+#define WOLFSSL_SSL_TYPES_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+/* *NEVER* include any other ssl headers. Only wolfcrypt headers
+ * may be included from this file. */
+#include <wolfssl/wolfcrypt/aes.h>
+#include <wolfssl/wolfcrypt/arc4.h>
+#include <wolfssl/wolfcrypt/asn_public.h>
+#include <wolfssl/wolfcrypt/des3.h>
+#include <wolfssl/wolfcrypt/hmac.h>
+#include <wolfssl/wolfcrypt/idea.h>
+#include <wolfssl/wolfcrypt/integer.h>
+#include <wolfssl/wolfcrypt/random.h>
+
+/* LHASH is implemented as a stack */
+typedef struct WOLFSSL_STACK WOLFSSL_LHASH;
+#ifndef WOLF_LHASH_OF
+    #define WOLF_LHASH_OF(x) WOLFSSL_LHASH
+#endif
+
+#ifndef WOLF_STACK_OF
+    #define WOLF_STACK_OF(x) WOLFSSL_STACK
+#endif
+#ifndef DECLARE_STACK_OF
+    #define DECLARE_STACK_OF(x) WOLF_STACK_OF(x);
+#endif
+
+#define STACK_OF(x) WOLFSSL_STACK
+#define OPENSSL_STACK WOLFSSL_STACK
+#define _STACK OPENSSL_STACK
+
+#ifndef WOLFSSL_WOLFSSL_TYPE_DEFINED
+#define WOLFSSL_WOLFSSL_TYPE_DEFINED
+typedef struct WOLFSSL          WOLFSSL;
+#endif
+typedef struct WOLFSSL_SESSION  WOLFSSL_SESSION;
+typedef struct WOLFSSL_METHOD   WOLFSSL_METHOD;
+#ifndef WOLFSSL_WOLFSSL_CTX_TYPE_DEFINED
+#define WOLFSSL_WOLFSSL_CTX_TYPE_DEFINED
+typedef struct WOLFSSL_CTX      WOLFSSL_CTX;
+#endif
+
+typedef struct WOLFSSL_STACK      WOLFSSL_STACK;
+typedef struct WOLFSSL_X509       WOLFSSL_X509;
+typedef struct WOLFSSL_X509_NAME  WOLFSSL_X509_NAME;
+typedef struct WOLFSSL_X509_NAME_ENTRY  WOLFSSL_X509_NAME_ENTRY;
+typedef struct WOLFSSL_X509_PUBKEY WOLFSSL_X509_PUBKEY;
+typedef struct WOLFSSL_X509_ALGOR WOLFSSL_X509_ALGOR;
+typedef struct WOLFSSL_X509_CHAIN WOLFSSL_X509_CHAIN;
+typedef struct WC_PKCS12          WOLFSSL_X509_PKCS12;
+typedef struct WOLFSSL_X509_INFO  WOLFSSL_X509_INFO;
+
+typedef struct WOLFSSL_CERT_MANAGER WOLFSSL_CERT_MANAGER;
+typedef struct WOLFSSL_SOCKADDR     WOLFSSL_SOCKADDR;
+typedef struct WOLFSSL_CRL          WOLFSSL_CRL;
+typedef struct WOLFSSL_X509_STORE_CTX WOLFSSL_X509_STORE_CTX;
+
+typedef int (*WOLFSSL_X509_STORE_CTX_verify_cb)(int, WOLFSSL_X509_STORE_CTX *);
+
+typedef struct WOLFSSL_RSA                  WOLFSSL_RSA;
+typedef struct WOLFSSL_RSA_METHOD           WOLFSSL_RSA_METHOD;
+
+typedef struct WOLFSSL_BIGNUM               WOLFSSL_BIGNUM;
+
+
+#ifndef NO_MD4
+typedef struct WOLFSSL_MD4_CTX              WOLFSSL_MD4_CTX;
+typedef WOLFSSL_MD4_CTX                     MD4_CTX;
+#endif
+#ifndef NO_MD5
+typedef struct WOLFSSL_MD5_CTX              WOLFSSL_MD5_CTX;
+typedef WOLFSSL_MD5_CTX                     MD5_CTX;
+#endif
+
+typedef struct WOLFSSL_SHA_CTX              WOLFSSL_SHA_CTX;
+typedef WOLFSSL_SHA_CTX                     SHA_CTX;
+#ifdef WOLFSSL_SHA224
+typedef struct WOLFSSL_SHA224_CTX           WOLFSSL_SHA224_CTX;
+typedef WOLFSSL_SHA224_CTX                  SHA224_CTX;
+#endif /* WOLFSSL_SHA224 */
+typedef struct WOLFSSL_SHA256_CTX           WOLFSSL_SHA256_CTX;
+typedef WOLFSSL_SHA256_CTX                  SHA256_CTX;
+#ifdef WOLFSSL_SHA384
+typedef struct WOLFSSL_SHA384_CTX           WOLFSSL_SHA384_CTX;
+typedef WOLFSSL_SHA384_CTX SHA384_CTX;
+#endif /* WOLFSSL_SHA384 */
+#ifdef WOLFSSL_SHA512
+typedef struct WOLFSSL_SHA512_CTX           WOLFSSL_SHA512_CTX;
+typedef WOLFSSL_SHA512_CTX                  SHA512_CTX;
+#endif /* WOLFSSL_SHA512 */
+
+typedef struct WOLFSSL_RIPEMD_CTX           WOLFSSL_RIPEMD_CTX;
+typedef WOLFSSL_RIPEMD_CTX                  RIPEMD_CTX;
+
+#ifndef WOLFSSL_NOSHA3_224
+typedef struct WOLFSSL_SHA3_CTX             WOLFSSL_SHA3_224_CTX;
+typedef WOLFSSL_SHA3_224_CTX                SHA3_224_CTX;
+#endif /* WOLFSSL_NOSHA3_224 */
+#ifndef WOLFSSL_NOSHA3_256
+typedef struct WOLFSSL_SHA3_CTX             WOLFSSL_SHA3_256_CTX;
+typedef WOLFSSL_SHA3_256_CTX                SHA3_256_CTX;
+#endif /* WOLFSSL_NOSHA3_256 */
+typedef struct WOLFSSL_SHA3_CTX             WOLFSSL_SHA3_384_CTX;
+typedef WOLFSSL_SHA3_384_CTX                SHA3_384_CTX;
+#ifndef WOLFSSL_NOSHA3_512
+typedef struct WOLFSSL_SHA3_CTX             WOLFSSL_SHA3_512_CTX;
+typedef WOLFSSL_SHA3_512_CTX                SHA3_512_CTX;
+#endif /* WOLFSSL_NOSHA3_512 */
+
+
+/* redeclare guard */
+#define WOLFSSL_TYPES_DEFINED
+
+#ifndef WC_RNG_TYPE_DEFINED /* guard on redeclaration */
+    typedef struct WC_RNG WC_RNG;
+    #define WC_RNG_TYPE_DEFINED
+#endif
+
+#ifndef WOLFSSL_DSA_TYPE_DEFINED /* guard on redeclaration */
+typedef struct WOLFSSL_DSA            WOLFSSL_DSA;
+#define WOLFSSL_DSA_TYPE_DEFINED
+#endif
+
+#ifndef WOLFSSL_EC_TYPE_DEFINED /* guard on redeclaration */
+typedef struct WOLFSSL_EC_KEY         WOLFSSL_EC_KEY;
+typedef struct WOLFSSL_EC_POINT       WOLFSSL_EC_POINT;
+typedef struct WOLFSSL_EC_GROUP       WOLFSSL_EC_GROUP;
+typedef struct WOLFSSL_EC_BUILTIN_CURVE WOLFSSL_EC_BUILTIN_CURVE;
+/* WOLFSSL_EC_METHOD is just an alias of WOLFSSL_EC_GROUP for now */
+typedef struct WOLFSSL_EC_GROUP       WOLFSSL_EC_METHOD;
+#define WOLFSSL_EC_TYPE_DEFINED
+#endif
+
+#ifndef WOLFSSL_ECDSA_TYPE_DEFINED /* guard on redeclaration */
+typedef struct WOLFSSL_ECDSA_SIG      WOLFSSL_ECDSA_SIG;
+#define WOLFSSL_ECDSA_TYPE_DEFINED
+#endif
+
+typedef struct WOLFSSL_CIPHER         WOLFSSL_CIPHER;
+typedef struct WOLFSSL_X509_LOOKUP    WOLFSSL_X509_LOOKUP;
+typedef struct WOLFSSL_X509_LOOKUP_METHOD WOLFSSL_X509_LOOKUP_METHOD;
+typedef struct WOLFSSL_CRL            WOLFSSL_X509_CRL;
+typedef struct WOLFSSL_X509_STORE     WOLFSSL_X509_STORE;
+typedef struct WOLFSSL_X509_VERIFY_PARAM WOLFSSL_X509_VERIFY_PARAM;
+typedef struct WOLFSSL_BIO            WOLFSSL_BIO;
+typedef struct WOLFSSL_BIO_METHOD     WOLFSSL_BIO_METHOD;
+typedef struct WOLFSSL_X509_EXTENSION WOLFSSL_X509_EXTENSION;
+typedef struct WOLFSSL_ASN1_OBJECT    WOLFSSL_ASN1_OBJECT;
+typedef struct WOLFSSL_ASN1_OTHERNAME WOLFSSL_ASN1_OTHERNAME;
+typedef struct WOLFSSL_X509V3_CTX     WOLFSSL_X509V3_CTX;
+typedef struct WOLFSSL_v3_ext_method  WOLFSSL_v3_ext_method;
+
+typedef struct WOLFSSL_ASN1_STRING      WOLFSSL_ASN1_STRING;
+typedef struct WOLFSSL_dynlock_value    WOLFSSL_dynlock_value;
+#ifndef WOLFSSL_DH_TYPE_DEFINED /* guard on redeclaration */
+typedef struct WOLFSSL_DH               WOLFSSL_DH;
+#define WOLFSSL_DH_TYPE_DEFINED /* guard on redeclaration */
+#endif
+typedef struct WOLFSSL_ASN1_BIT_STRING  WOLFSSL_ASN1_BIT_STRING;
+typedef struct WOLFSSL_ASN1_TYPE        WOLFSSL_ASN1_TYPE;
+typedef struct WOLFSSL_X509_ATTRIBUTE   WOLFSSL_X509_ATTRIBUTE;
+
+typedef struct WOLFSSL_GENERAL_NAME WOLFSSL_GENERAL_NAME;
+typedef struct WOLFSSL_AUTHORITY_KEYID  WOLFSSL_AUTHORITY_KEYID;
+typedef struct WOLFSSL_BASIC_CONSTRAINTS WOLFSSL_BASIC_CONSTRAINTS;
+typedef struct WOLFSSL_ACCESS_DESCRIPTION WOLFSSL_ACCESS_DESCRIPTION;
+
+#if defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
+
+struct WOLFSSL_AUTHORITY_KEYID {
+    WOLFSSL_ASN1_STRING *keyid;
+    WOLFSSL_ASN1_OBJECT *issuer;
+    WOLFSSL_ASN1_INTEGER *serial;
+};
+
+struct WOLFSSL_BASIC_CONSTRAINTS {
+    int ca;
+    WOLFSSL_ASN1_INTEGER *pathlen;
+};
+
+#endif /* OPENSSL_ALL || OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
+
+
+#define WOLFSSL_ASN1_UTCTIME          WOLFSSL_ASN1_TIME
+#define WOLFSSL_ASN1_GENERALIZEDTIME  WOLFSSL_ASN1_TIME
+
+struct WOLFSSL_ASN1_STRING {
+    char strData[CTC_NAME_SIZE];
+    int length;
+    int type; /* type of string i.e. CTC_UTF8 */
+    char* data;
+    long flags;
+    unsigned int   isDynamic:1; /* flag for if data pointer dynamic (1 is yes 0 is no) */
+};
+
+#define WOLFSSL_MAX_SNAME 40
+
+
+#define WOLFSSL_ASN1_DYNAMIC 0x1
+#define WOLFSSL_ASN1_DYNAMIC_DATA 0x2
+
+struct WOLFSSL_ASN1_OTHERNAME {
+    WOLFSSL_ASN1_OBJECT* type_id;
+    WOLFSSL_ASN1_TYPE*   value;
+};
+
+struct WOLFSSL_GENERAL_NAME {
+    int type;
+    union {
+        char* ptr;
+        WOLFSSL_ASN1_OTHERNAME* otherName;
+        WOLFSSL_ASN1_STRING* rfc822Name;
+        WOLFSSL_ASN1_STRING* dNSName;
+        WOLFSSL_ASN1_TYPE* x400Address;
+        WOLFSSL_X509_NAME* directoryName;
+        WOLFSSL_ASN1_STRING* uniformResourceIdentifier;
+        WOLFSSL_ASN1_STRING* iPAddress;
+        WOLFSSL_ASN1_OBJECT* registeredID;
+
+        WOLFSSL_ASN1_STRING* ip;
+        WOLFSSL_X509_NAME* dirn;
+        WOLFSSL_ASN1_STRING* ia5;
+        WOLFSSL_ASN1_OBJECT* rid;
+        WOLFSSL_ASN1_TYPE* other;
+    } d; /* dereference */
+};
+
+typedef WOLF_STACK_OF(WOLFSSL_GENERAL_NAME) WOLFSSL_GENERAL_NAMES;
+
+struct WOLFSSL_ACCESS_DESCRIPTION {
+    WOLFSSL_ASN1_OBJECT*  method;
+    WOLFSSL_GENERAL_NAME* location;
+};
+
+struct WOLFSSL_X509V3_CTX {
+    WOLFSSL_X509* x509;
+};
+
+
+
+struct WOLFSSL_ASN1_OBJECT {
+    void*  heap;
+    const unsigned char* obj;
+    /* sName is short name i.e sha256 rather than oid (null terminated) */
+    char   sName[WOLFSSL_MAX_SNAME];
+    int    type; /* oid */
+    int    grp;  /* type of OID, i.e. oidCertPolicyType */
+    int    nid;
+    unsigned int  objSz;
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_QT) || defined(WOLFSSL_APACHE_HTTPD)
+    int ca;
+    WOLFSSL_ASN1_INTEGER *pathlen;
+#endif
+    unsigned char dynamic; /* Use WOLFSSL_ASN1_DYNAMIC and WOLFSSL_ASN1_DYNAMIC_DATA
+                            * to determine what needs to be freed. */
+
+#if defined(WOLFSSL_APACHE_HTTPD)
+    WOLFSSL_GENERAL_NAME* gn;
+#endif
+
+    struct d { /* derefrenced */
+        WOLFSSL_ASN1_STRING* dNSName;
+        WOLFSSL_ASN1_STRING  ia5_internal;
+        WOLFSSL_ASN1_STRING* ia5; /* points to ia5_internal */
+#if defined(WOLFSSL_QT) || defined(OPENSSL_ALL)
+        WOLFSSL_ASN1_STRING* uniformResourceIdentifier;
+        WOLFSSL_ASN1_STRING  iPAddress_internal;
+        WOLFSSL_ASN1_OTHERNAME* otherName; /* added for Apache httpd */
+#endif
+        WOLFSSL_ASN1_STRING* iPAddress; /* points to iPAddress_internal */
+    } d;
+};
+
+/* wrap ASN1 types */
+struct WOLFSSL_ASN1_TYPE {
+    int type;
+    union {
+        char *ptr;
+        WOLFSSL_ASN1_STRING*     asn1_string;
+        WOLFSSL_ASN1_OBJECT*     object;
+        WOLFSSL_ASN1_INTEGER*    integer;
+        WOLFSSL_ASN1_BIT_STRING* bit_string;
+        WOLFSSL_ASN1_STRING*     octet_string;
+        WOLFSSL_ASN1_STRING*     printablestring;
+        WOLFSSL_ASN1_STRING*     ia5string;
+        WOLFSSL_ASN1_UTCTIME*    utctime;
+        WOLFSSL_ASN1_GENERALIZEDTIME* generalizedtime;
+        WOLFSSL_ASN1_STRING*     utf8string;
+        WOLFSSL_ASN1_STRING*     set;
+        WOLFSSL_ASN1_STRING*     sequence;
+    } value;
+};
+
+struct WOLFSSL_X509_ATTRIBUTE {
+    WOLFSSL_ASN1_OBJECT *object;
+    WOLFSSL_ASN1_TYPE *value;
+    WOLF_STACK_OF(WOLFSSL_ASN1_TYPE) *set;
+};
+
+struct WOLFSSL_EVP_PKEY {
+    void* heap;
+    int type;         /* openssh dereference */
+    int save_type;    /* openssh dereference */
+    int pkey_sz;
+    int references;  /*number of times free should be called for complete free*/
+    wolfSSL_Mutex    refMutex; /* ref count mutex */
+
+    union {
+        char* ptr; /* der format of key / or raw for NTRU */
+    } pkey;
+    #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
+    #ifndef NO_RSA
+        WOLFSSL_RSA* rsa;
+        byte      ownRsa; /* if struct owns RSA and should free it */
+    #endif
+    #ifndef NO_DSA
+        WOLFSSL_DSA* dsa;
+        byte      ownDsa; /* if struct owns DSA and should free it */
+    #endif
+    #ifdef HAVE_ECC
+        WOLFSSL_EC_KEY* ecc;
+        byte      ownEcc; /* if struct owns ECC and should free it */
+    #endif
+    #ifndef NO_DH
+        WOLFSSL_DH* dh;
+        byte      ownDh; /* if struct owns DH and should free it */
+    #endif
+    WC_RNG rng;
+    #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+    #ifdef HAVE_ECC
+        int pkey_curve;
+    #endif
+};
+
+/* Digest types */
+
+#ifndef NO_MD4
+struct WOLFSSL_MD4_CTX {
+    int buffer[32];      /* big enough to hold, check size in Init */
+};
+#endif
+
+#ifndef NO_MD5
+struct WOLFSSL_MD5_CTX {
+    /* big enough to hold wolfcrypt md5, but check on init */
+#ifdef STM32_HASH
+    void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(STM32_HASH_Context)) / sizeof(void*)];
+#else
+    void* holder[(112 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+#endif
+};
+#endif
+
+struct WOLFSSL_SHA_CTX {
+    /* big enough to hold wolfcrypt Sha, but check on init */
+#if defined(STM32_HASH)
+    void* holder[(112 + WC_ASYNC_DEV_SIZE + sizeof(STM32_HASH_Context)) / sizeof(void*)];
+#else
+    void* holder[(112 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+#endif
+    #ifdef WOLF_CRYPTO_CB
+    void* cryptocb_holder[(sizeof(int) + sizeof(void*) + 4) / sizeof(void*)];
+    #endif
+};
+enum {
+    SHA_DIGEST_LENGTH = 20
+};
+
+#ifdef WOLFSSL_SHA224
+/* Using ALIGN16 because when AES-NI is enabled digest and buffer in Sha256
+ * struct are 16 byte aligned. Any dereference to those elements after casting
+ * to Sha224, is expected to also be 16 byte aligned addresses.  */
+struct WOLFSSL_SHA224_CTX {
+    /* big enough to hold wolfcrypt Sha224, but check on init */
+    ALIGN16 void* holder[(272 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+};
+enum {
+    SHA224_DIGEST_LENGTH = 28
+};
+#endif /* WOLFSSL_SHA224 */
+/* Using ALIGN16 because when AES-NI is enabled digest and buffer in Sha256
+ * struct are 16 byte aligned. Any dereference to those elements after casting
+ * to Sha256, is expected to also be 16 byte aligned addresses.  */
+struct WOLFSSL_SHA256_CTX {
+    /* big enough to hold wolfcrypt Sha256, but check on init */
+    ALIGN16 void* holder[(272 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+};
+enum {
+    SHA256_DIGEST_LENGTH = 32
+};
+#ifdef WOLFSSL_SHA384
+struct WOLFSSL_SHA384_CTX {
+    /* big enough to hold wolfCrypt Sha384, but check on init */
+    void* holder[(256 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+};
+enum {
+    SHA384_DIGEST_LENGTH = 48
+};
+#endif /* WOLFSSL_SHA384 */
+#ifdef WOLFSSL_SHA512
+struct WOLFSSL_SHA512_CTX {
+    /* big enough to hold wolfCrypt Sha384, but check on init */
+    void* holder[(288 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+};
+enum {
+    SHA512_DIGEST_LENGTH = 64
+};
+#endif /* WOLFSSL_SHA512 */
+
+struct WOLFSSL_RIPEMD_CTX {
+    int holder[32];   /* big enough to hold wolfcrypt, but check on init */
+};
+
+/* Using ALIGN16 because when AES-NI is enabled digest and buffer in Sha3
+ * struct are 16 byte aligned. Any dereference to those elements after casting
+ * to Sha3 is expected to also be 16 byte aligned addresses.  */
+struct WOLFSSL_SHA3_CTX {
+    /* big enough to hold wolfcrypt Sha3, but check on init */
+    ALIGN16 void* holder[(424 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+};
+
+#ifndef WOLFSSL_NOSHA3_224
+enum {
+    SHA3_224_DIGEST_LENGTH = 28
+};
+#endif /* WOLFSSL_NOSHA3_224 */
+
+#ifndef WOLFSSL_NOSHA3_256
+enum {
+    SHA3_256_DIGEST_LENGTH = 32
+};
+#endif /* WOLFSSL_NOSHA3_256 */
+
+enum {
+    SHA3_384_DIGEST_LENGTH = 48
+};
+#ifndef WOLFSSL_NOSHA3_512
+enum {
+    SHA3_512_DIGEST_LENGTH = 64
+};
+#endif /* WOLFSSL_NOSHA3_512 */
+
+typedef union {
+    #ifndef NO_MD4
+        WOLFSSL_MD4_CTX    md4;
+    #endif
+    #ifndef NO_MD5
+        WOLFSSL_MD5_CTX    md5;
+    #endif
+    WOLFSSL_SHA_CTX    sha;
+    #ifdef WOLFSSL_SHA224
+        WOLFSSL_SHA224_CTX sha224;
+    #endif
+    WOLFSSL_SHA256_CTX sha256;
+    #ifdef WOLFSSL_SHA384
+        WOLFSSL_SHA384_CTX sha384;
+    #endif
+    #ifdef WOLFSSL_SHA512
+        WOLFSSL_SHA512_CTX sha512;
+    #endif
+    #ifdef WOLFSSL_RIPEMD
+        WOLFSSL_RIPEMD_CTX ripemd;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_224
+        WOLFSSL_SHA3_224_CTX sha3_224;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_256
+        WOLFSSL_SHA3_256_CTX sha3_256;
+    #endif
+        WOLFSSL_SHA3_384_CTX sha3_384;
+    #ifndef WOLFSSL_NOSHA3_512
+        WOLFSSL_SHA3_512_CTX sha3_512;
+    #endif
+} WOLFSSL_Hasher;
+
+typedef struct WOLFSSL_EVP_PKEY_CTX WOLFSSL_EVP_PKEY_CTX;
+typedef struct WOLFSSL_EVP_CIPHER_CTX WOLFSSL_EVP_CIPHER_CTX;
+
+struct WOLFSSL_EVP_MD_CTX {
+    union {
+        WOLFSSL_Hasher digest;
+    #ifndef NO_HMAC
+        Hmac hmac;
+    #endif
+    } hash;
+    enum wc_HashType macType;
+    WOLFSSL_EVP_PKEY_CTX *pctx;
+#ifndef NO_HMAC
+    unsigned int isHMAC;
+#endif
+};
+
+
+typedef union {
+#ifndef NO_AES
+    Aes  aes;
+#ifdef WOLFSSL_AES_XTS
+    XtsAes xts;
+#endif
+#endif
+#ifndef NO_DES3
+    Des  des;
+    Des3 des3;
+#endif
+    Arc4 arc4;
+#ifdef HAVE_IDEA
+    Idea idea;
+#endif
+#ifdef WOLFSSL_QT
+    int (*ctrl) (WOLFSSL_EVP_CIPHER_CTX *, int type, int arg, void *ptr);
+#endif
+} WOLFSSL_Cipher;
+
+typedef struct WOLFSSL_EVP_PKEY WOLFSSL_PKCS8_PRIV_KEY_INFO;
+#ifndef WOLFSSL_EVP_TYPE_DEFINED /* guard on redeclaration */
+typedef char WOLFSSL_EVP_CIPHER;
+typedef struct WOLFSSL_EVP_PKEY     WOLFSSL_EVP_PKEY;
+typedef struct WOLFSSL_EVP_MD_CTX   WOLFSSL_EVP_MD_CTX;
+typedef char   WOLFSSL_EVP_MD;
+
+typedef WOLFSSL_EVP_MD         EVP_MD;
+typedef WOLFSSL_EVP_CIPHER     EVP_CIPHER;
+typedef WOLFSSL_EVP_MD_CTX     EVP_MD_CTX;
+typedef WOLFSSL_EVP_CIPHER_CTX EVP_CIPHER_CTX;
+
+typedef WOLFSSL_EVP_PKEY       EVP_PKEY;
+typedef WOLFSSL_EVP_PKEY       PKCS8_PRIV_KEY_INFO;
+#define WOLFSSL_EVP_TYPE_DEFINED
+#endif
+
+struct WOLFSSL_X509_PKEY {
+    WOLFSSL_EVP_PKEY* dec_pkey; /* dereferenced by Apache */
+    void* heap;
+};
+typedef struct WOLFSSL_X509_PKEY WOLFSSL_X509_PKEY;
+
+struct WOLFSSL_X509_INFO {
+    WOLFSSL_X509      *x509;
+    WOLFSSL_X509_CRL  *crl;
+    WOLFSSL_X509_PKEY  *x_pkey; /* dereferenced by Apache */
+    EncryptedInfo     enc_cipher;
+    int               enc_len;
+    char              *enc_data;
+    int               num;
+};
+
+#define WOLFSSL_EVP_PKEY_DEFAULT EVP_PKEY_RSA /* default key type */
+
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+    #define wolfSSL_SSL_MODE_RELEASE_BUFFERS    0x00000010U
+    #define wolfSSL_SSL_CTRL_SET_TMP_ECDH       4
+#endif
+
+struct WOLFSSL_X509_ALGOR {
+    WOLFSSL_ASN1_OBJECT* algorithm;
+    WOLFSSL_ASN1_TYPE* parameter;
+};
+
+struct WOLFSSL_X509_PUBKEY {
+    WOLFSSL_X509_ALGOR* algor;
+    WOLFSSL_EVP_PKEY* pkey;
+    int pubKeyOID;
+};
+
+struct WOLFSSL_BIGNUM {
+    int neg;        /* openssh deference */
+    void *internal; /* our big num */
+#if defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)
+    sp_int fp;
+#elif defined(USE_FAST_MATH) && !defined(HAVE_WOLF_BIGINT)
+    fp_int fp;
+#endif
+};
+
+struct WOLFSSL_RSA_METHOD {
+    int flags;
+    char *name;
+};
+typedef WOLFSSL_RSA_METHOD                   RSA_METHOD;
+
+#ifndef WOLFSSL_RSA_TYPE_DEFINED /* guard on redeclaration */
+#define WOLFSSL_RSA_TYPE_DEFINED
+struct WOLFSSL_RSA {
+#ifdef WC_RSA_BLINDING
+    WC_RNG* rng;              /* for PrivateDecrypt blinding */
+#endif
+    WOLFSSL_BIGNUM* n;
+    WOLFSSL_BIGNUM* e;
+    WOLFSSL_BIGNUM* d;
+    WOLFSSL_BIGNUM* p;
+    WOLFSSL_BIGNUM* q;
+    WOLFSSL_BIGNUM* dmp1;      /* dP */
+    WOLFSSL_BIGNUM* dmq1;      /* dQ */
+    WOLFSSL_BIGNUM* iqmp;      /* u */
+    void*          heap;
+    void*          internal;  /* our RSA */
+    char           inSet;     /* internal set from external ? */
+    char           exSet;     /* external set from internal ? */
+    char           ownRng;    /* flag for if the rng should be free'd */
+#if defined(OPENSSL_EXTRA)
+    WOLFSSL_RSA_METHOD* meth;
+#endif
+#if defined(HAVE_EX_DATA)
+    WOLFSSL_CRYPTO_EX_DATA ex_data;  /* external data */
+#endif
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
+    wolfSSL_Mutex    refMutex;                       /* ref count mutex */
+    int              refCount;                       /* reference count */
+#endif
+};
+#endif
+typedef WOLFSSL_RSA                          RSA;
+
+enum BIO_TYPE {
+    WOLFSSL_BIO_BUFFER = 1,
+    WOLFSSL_BIO_SOCKET = 2,
+    WOLFSSL_BIO_SSL    = 3,
+    WOLFSSL_BIO_MEMORY = 4,
+    WOLFSSL_BIO_BIO    = 5,
+    WOLFSSL_BIO_FILE   = 6,
+    WOLFSSL_BIO_BASE64 = 7,
+    WOLFSSL_BIO_MD     = 8
+};
+
+enum BIO_FLAGS {
+    WOLFSSL_BIO_FLAG_BASE64_NO_NL = 0x01,
+    WOLFSSL_BIO_FLAG_READ         = 0x02,
+    WOLFSSL_BIO_FLAG_WRITE        = 0x04,
+    WOLFSSL_BIO_FLAG_IO_SPECIAL   = 0x08,
+    WOLFSSL_BIO_FLAG_RETRY        = 0x10
+};
+
+enum BIO_CB_OPS {
+    WOLFSSL_BIO_CB_FREE   = 0x01,
+    WOLFSSL_BIO_CB_READ   = 0x02,
+    WOLFSSL_BIO_CB_WRITE  = 0x03,
+    WOLFSSL_BIO_CB_PUTS   = 0x04,
+    WOLFSSL_BIO_CB_GETS   = 0x05,
+    WOLFSSL_BIO_CB_CTRL   = 0x06,
+    WOLFSSL_BIO_CB_RETURN = 0x80
+};
+
+typedef struct WOLFSSL_BUF_MEM {
+    char*  data;   /* dereferenced */
+    size_t length; /* current length */
+    size_t max;    /* maximum length */
+} WOLFSSL_BUF_MEM;
+
+/* custom method with user set callbacks */
+typedef int  (*wolfSSL_BIO_meth_write_cb)(WOLFSSL_BIO*, const char*, int);
+typedef int  (*wolfSSL_BIO_meth_read_cb)(WOLFSSL_BIO *, char *, int);
+typedef int  (*wolfSSL_BIO_meth_puts_cb)(WOLFSSL_BIO*, const char*);
+typedef int  (*wolfSSL_BIO_meth_gets_cb)(WOLFSSL_BIO*, char*, int);
+typedef long (*wolfSSL_BIO_meth_ctrl_get_cb)(WOLFSSL_BIO*, int, long, void*);
+typedef int  (*wolfSSL_BIO_meth_create_cb)(WOLFSSL_BIO*);
+typedef int  (*wolfSSL_BIO_meth_destroy_cb)(WOLFSSL_BIO*);
+
+typedef int wolfSSL_BIO_info_cb(WOLFSSL_BIO *, int, int);
+typedef long (*wolfssl_BIO_meth_ctrl_info_cb)(WOLFSSL_BIO*, int, wolfSSL_BIO_info_cb*);
+
+/* wolfSSL BIO_METHOD type */
+#ifndef MAX_BIO_METHOD_NAME
+#define MAX_BIO_METHOD_NAME 256
+#endif
+struct WOLFSSL_BIO_METHOD {
+    byte type;               /* method type */
+    char name[MAX_BIO_METHOD_NAME];
+    wolfSSL_BIO_meth_write_cb writeCb;
+    wolfSSL_BIO_meth_read_cb readCb;
+    wolfSSL_BIO_meth_puts_cb putsCb;
+    wolfSSL_BIO_meth_gets_cb getsCb;
+    wolfSSL_BIO_meth_ctrl_get_cb ctrlCb;
+    wolfSSL_BIO_meth_create_cb createCb;
+    wolfSSL_BIO_meth_destroy_cb freeCb;
+    wolfssl_BIO_meth_ctrl_info_cb ctrlInfoCb;
+};
+
+/* wolfSSL BIO type */
+typedef long (*wolf_bio_info_cb)(WOLFSSL_BIO *bio, int event, const char *parg,
+                                 int iarg, long larg, long return_value);
+
+struct WOLFSSL_BIO {
+    WOLFSSL_BUF_MEM* mem_buf;
+    WOLFSSL_BIO_METHOD* method;
+    WOLFSSL_BIO* prev;          /* previous in chain */
+    WOLFSSL_BIO* next;          /* next in chain */
+    WOLFSSL_BIO* pair;          /* BIO paired with */
+    void*        heap;          /* user heap hint */
+    void*        ptr;           /* WOLFSSL, file descriptor, MD, or mem buf */
+    void*        usrCtx;        /* user set pointer */
+    const char*  ip;            /* IP address for wolfIO_TcpConnect */
+    word16       port;          /* Port for wolfIO_TcpConnect */
+    char*        infoArg;       /* BIO callback argument */
+    wolf_bio_info_cb infoCb;    /* BIO callback */
+    int          wrSz;          /* write buffer size (mem) */
+    int          wrIdx;         /* current index for write buffer */
+    int          rdIdx;         /* current read index */
+    int          readRq;        /* read request */
+    int          num;           /* socket num or length */
+    int          eof;           /* eof flag */
+    int          flags;
+    byte         type;          /* method type */
+    byte         init:1;        /* bio has been initialized */
+    byte         shutdown:1;    /* close flag */
+#ifdef HAVE_EX_DATA
+    WOLFSSL_CRYPTO_EX_DATA ex_data;
+#endif
+};
+
+typedef struct WOLFSSL_COMP_METHOD {
+    int type;            /* stunnel dereference */
+} WOLFSSL_COMP_METHOD;
+
+typedef struct WOLFSSL_COMP {
+    int id;
+    const char *name;
+    WOLFSSL_COMP_METHOD *method;
+} WOLFSSL_COMP;
+
+
+struct WOLFSSL_X509_LOOKUP_METHOD {
+    int type;
+};
+
+struct WOLFSSL_X509_LOOKUP {
+    WOLFSSL_X509_STORE *store;
+};
+
+struct WOLFSSL_X509_STORE {
+    int                   cache;          /* stunnel dereference */
+    WOLFSSL_CERT_MANAGER* cm;
+    WOLFSSL_X509_LOOKUP   lookup;
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
+    int                   isDynamic;
+    WOLFSSL_X509_VERIFY_PARAM* param;    /* certificate validation parameter */
+#endif
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
+    WOLFSSL_X509_STORE_CTX_verify_cb verify_cb;
+#endif
+#ifdef HAVE_EX_DATA
+    WOLFSSL_CRYPTO_EX_DATA ex_data;
+#endif
+#if (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)) && defined(HAVE_CRL)
+    WOLFSSL_X509_CRL *crl; /* points to cm->crl */
+#endif
+};
+
+#if defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA) || \
+    defined(WOLFSSL_WPAS_SMALL) || defined(WOLFSSL_IP_ALT_NAME)
+    #define WOLFSSL_MAX_IPSTR 46 /* max ip size IPv4 mapped IPv6 */
+#endif /* OPENSSL_ALL || WOLFSSL_IP_ALT_NAME */
+
+
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
+#define WOLFSSL_USE_CHECK_TIME 0x2
+#define WOLFSSL_NO_CHECK_TIME  0x200000
+#define WOLFSSL_HOST_NAME_MAX  256
+
+#define WOLFSSL_VPARAM_DEFAULT          0x1
+#define WOLFSSL_VPARAM_OVERWRITE        0x2
+#define WOLFSSL_VPARAM_RESET_FLAGS      0x4
+#define WOLFSSL_VPARAM_LOCKED           0x8
+#define WOLFSSL_VPARAM_ONCE             0x10
+
+struct WOLFSSL_X509_VERIFY_PARAM {
+    time_t         check_time;
+    unsigned int   inherit_flags;
+    unsigned long  flags;
+    char           hostName[WOLFSSL_HOST_NAME_MAX];
+    unsigned int  hostFlags;
+    char ipasc[WOLFSSL_MAX_IPSTR];
+};
+#endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
+
+
+typedef struct WOLFSSL_ALERT {
+    int code;
+    int level;
+} WOLFSSL_ALERT;
+
+typedef struct WOLFSSL_ALERT_HISTORY {
+    WOLFSSL_ALERT last_rx;
+    WOLFSSL_ALERT last_tx;
+} WOLFSSL_ALERT_HISTORY;
+
+typedef struct WOLFSSL_X509_REVOKED {
+    WOLFSSL_ASN1_INTEGER* serialNumber;          /* stunnel dereference */
+} WOLFSSL_X509_REVOKED;
+
+
+typedef struct WOLFSSL_X509_OBJECT {
+    union {
+        char* ptr;
+        WOLFSSL_X509 *x509;
+        WOLFSSL_X509_CRL* crl;           /* stunnel dereference */
+    } data;
+} WOLFSSL_X509_OBJECT;
+
+
+typedef struct WOLFSSL_BUFFER_INFO {
+    unsigned char* buffer;
+    unsigned int length;
+} WOLFSSL_BUFFER_INFO;
+
+struct WOLFSSL_X509_STORE_CTX {
+    WOLFSSL_X509_STORE* store;    /* Store full of a CA cert chain */
+    WOLFSSL_X509* current_cert;   /* current X509 (OPENSSL_EXTRA) */
+#ifdef WOLFSSL_ASIO
+    WOLFSSL_X509* current_issuer; /* asio dereference */
+#endif
+    WOLFSSL_X509_CHAIN* sesChain; /* pointer to WOLFSSL_SESSION peer chain */
+    WOLFSSL_STACK* chain;
+#ifdef OPENSSL_EXTRA
+    WOLFSSL_X509_VERIFY_PARAM* param; /* certificate validation parameter */
+#endif
+    char* domain;                /* subject CN domain name */
+#if defined(HAVE_EX_DATA) || defined(FORTRESS)
+    WOLFSSL_CRYPTO_EX_DATA ex_data;  /* external data */
+#endif
+#if defined(WOLFSSL_APACHE_HTTPD) || defined(OPENSSL_EXTRA)
+    int depth;                   /* used in X509_STORE_CTX_*_depth */
+#endif
+    void* userCtx;               /* user ctx */
+    int   error;                 /* current error */
+    int   error_depth;           /* index of cert depth for this error */
+    int   discardSessionCerts;   /* so verify callback can flag for discard */
+    int   totalCerts;            /* number of peer cert buffers */
+    WOLFSSL_BUFFER_INFO* certs;  /* peer certs */
+    WOLFSSL_X509_STORE_CTX_verify_cb verify_cb; /* verify callback */
+};
+
+typedef char* WOLFSSL_STRING;
+
+/* Valid Alert types from page 16/17
+ * Add alert string to the function wolfSSL_alert_type_string_long in src/ssl.c
+ */
+enum AlertDescription {
+    close_notify                    =   0,
+    unexpected_message              =  10,
+    bad_record_mac                  =  20,
+    record_overflow                 =  22,
+    decompression_failure           =  30,
+    handshake_failure               =  40,
+    no_certificate                  =  41,
+    bad_certificate                 =  42,
+    unsupported_certificate         =  43,
+    certificate_revoked             =  44,
+    certificate_expired             =  45,
+    certificate_unknown             =  46,
+    illegal_parameter               =  47,
+    unknown_ca                      =  48,
+    decode_error                    =  50,
+    decrypt_error                   =  51,
+    #ifdef WOLFSSL_MYSQL_COMPATIBLE
+    /* catch name conflict for enum protocol with MYSQL build */
+    wc_protocol_version             =  70,
+    #else
+    protocol_version                =  70,
+    #endif
+    inappropriate_fallback          =  86,
+    no_renegotiation                = 100,
+    missing_extension               = 109,
+    unsupported_extension           = 110, /**< RFC 5246, section 7.2.2 */
+    unrecognized_name               = 112, /**< RFC 6066, section 3 */
+    bad_certificate_status_response = 113, /**< RFC 6066, section 8 */
+    unknown_psk_identity            = 115, /**< RFC 4279, section 2 */
+    certificate_required            = 116, /**< RFC 8446, section 8.2 */
+    no_application_protocol         = 120
+};
+
+
+enum AlertLevel {
+    alert_warning = 1,
+    alert_fatal   = 2
+};
+
+/* WS_RETURN_CODE macro
+ * Some OpenSSL APIs specify "0" as the return value when an error occurs.
+ * However, some corresponding wolfSSL APIs　return negative values. Such
+ * functions should use this macro to fill this gap. Users who want them
+ * to return the same return value as OpenSSL can define
+ * WOLFSSL_ERR_CODE_OPENSSL.
+ * Give item1 a variable that contains the potentially negative
+ * wolfSSL-defined return value or the return value itself, and
+ * give item2 the openSSL-defined return value.
+ * Note that this macro replaces only negative return values with the
+ * specified value.
+ * Since wolfSSL 4.7.0, the following functions use this macro:
+ * - wolfSSL_CTX_load_verify_locations
+ * - wolfSSL_X509_LOOKUP_load_file
+ */
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    #define WS_RETURN_CODE(item1,item2) \
+      ((item1 < 0) ? item2 : item1)
+#else
+    #define WS_RETURN_CODE(item1,item2)  (item1)
+#endif
+
+/* Maximum master key length (SECRET_LEN) */
+#define WOLFSSL_MAX_MASTER_KEY_LENGTH 48
+/* Maximum number of groups that can be set */
+#define WOLFSSL_MAX_GROUP_COUNT       10
+
+#if defined(HAVE_SECRET_CALLBACK) && defined(WOLFSSL_TLS13)
+enum Tls13Secret {
+    CLIENT_EARLY_TRAFFIC_SECRET,
+    CLIENT_HANDSHAKE_TRAFFIC_SECRET,
+    SERVER_HANDSHAKE_TRAFFIC_SECRET,
+    CLIENT_TRAFFIC_SECRET,
+    SERVER_TRAFFIC_SECRET,
+    EARLY_EXPORTER_SECRET,
+    EXPORTER_SECRET
+};
+#endif
+
+typedef WOLFSSL_METHOD* (*wolfSSL_method_func)(void* heap);
+
+
+#if defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+/* Smaller subset of X509 compatibility functions. Avoid increasing the size of
+ * this subset and its memory usage */
+
+struct WOLFSSL_X509_NAME_ENTRY {
+    WOLFSSL_ASN1_OBJECT* object;  /* static object just for keeping grp, type */
+    WOLFSSL_ASN1_STRING* value;  /* points to data, for lighttpd port */
+    int nid; /* i.e. ASN_COMMON_NAME */
+    int set;
+    int size;
+};
+
+enum {
+    WOLFSSL_SYS_ACCEPT = 0,
+    WOLFSSL_SYS_BIND,
+    WOLFSSL_SYS_CONNECT,
+    WOLFSSL_SYS_FOPEN,
+    WOLFSSL_SYS_FREAD,
+    WOLFSSL_SYS_GETADDRINFO,
+    WOLFSSL_SYS_GETSOCKOPT,
+    WOLFSSL_SYS_GETSOCKNAME,
+    WOLFSSL_SYS_GETHOSTBYNAME,
+    WOLFSSL_SYS_GETNAMEINFO,
+    WOLFSSL_SYS_GETSERVBYNAME,
+    WOLFSSL_SYS_IOCTLSOCKET,
+    WOLFSSL_SYS_LISTEN,
+    WOLFSSL_SYS_OPENDIR,
+    WOLFSSL_SYS_SETSOCKOPT,
+    WOLFSSL_SYS_SOCKET
+};
+#endif /* OPENSSL_ALL || OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || \
+    defined(OPENSSL_EXTRA_X509_SMALL)
+struct WOLFSSL_ASN1_BIT_STRING {
+    int length;
+    int type;
+    byte* data;
+    long flags;
+};
+#endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL || OPENSSL_EXTRA_X509_SMALL */
+
+
+/* These are bit-masks */
+enum {
+    WOLFSSL_OCSP_URL_OVERRIDE = 1,
+    WOLFSSL_OCSP_NO_NONCE     = 2,
+    WOLFSSL_OCSP_CHECKALL     = 4,
+
+    WOLFSSL_CRL_CHECKALL = 1,
+    WOLFSSL_CRL_CHECK    = 2,
+};
+
+/* Separated out from other enums because of size */
+enum {
+    SSL_OP_MICROSOFT_SESS_ID_BUG                  = 0x00000001,
+    SSL_OP_NETSCAPE_CHALLENGE_BUG                 = 0x00000002,
+    SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG       = 0x00000004,
+    SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG            = 0x00000008,
+    SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER             = 0x00000010,
+    SSL_OP_MSIE_SSLV2_RSA_PADDING                 = 0x00000020,
+    SSL_OP_SSLEAY_080_CLIENT_DH_BUG               = 0x00000040,
+    SSL_OP_TLS_D5_BUG                             = 0x00000080,
+    SSL_OP_TLS_BLOCK_PADDING_BUG                  = 0x00000100,
+    SSL_OP_TLS_ROLLBACK_BUG                       = 0x00000200,
+    SSL_OP_EPHEMERAL_RSA                          = 0x00000800,
+    WOLFSSL_OP_NO_SSLv3                           = 0x00001000,
+    WOLFSSL_OP_NO_TLSv1                           = 0x00002000,
+    SSL_OP_PKCS1_CHECK_1                          = 0x00004000,
+    SSL_OP_PKCS1_CHECK_2                          = 0x00008000,
+    SSL_OP_NETSCAPE_CA_DN_BUG                     = 0x00010000,
+    SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG        = 0x00020000,
+    SSL_OP_SINGLE_DH_USE                          = 0x00040000,
+    SSL_OP_NO_TICKET                              = 0x00080000,
+    SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS            = 0x00100000,
+    SSL_OP_NO_QUERY_MTU                           = 0x00200000,
+    SSL_OP_COOKIE_EXCHANGE                        = 0x00400000,
+    SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION = 0x00800000,
+    SSL_OP_SINGLE_ECDH_USE                        = 0x01000000,
+    SSL_OP_CIPHER_SERVER_PREFERENCE               = 0x02000000,
+    WOLFSSL_OP_NO_TLSv1_1                         = 0x04000000,
+    WOLFSSL_OP_NO_TLSv1_2                         = 0x08000000,
+    SSL_OP_NO_COMPRESSION                         = 0x10000000,
+    WOLFSSL_OP_NO_TLSv1_3                         = 0x20000000,
+    WOLFSSL_OP_NO_SSLv2                           = 0x40000000,
+    SSL_OP_ALL   =
+                    (SSL_OP_MICROSOFT_SESS_ID_BUG
+                  | SSL_OP_NETSCAPE_CHALLENGE_BUG
+                  | SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG
+                  | SSL_OP_SSLREF2_REUSE_CERT_TYPE_BUG
+                  | SSL_OP_MICROSOFT_BIG_SSLV3_BUFFER
+                  | SSL_OP_MSIE_SSLV2_RSA_PADDING
+                  | SSL_OP_SSLEAY_080_CLIENT_DH_BUG
+                  | SSL_OP_TLS_D5_BUG
+                  | SSL_OP_TLS_BLOCK_PADDING_BUG
+                  | SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS
+                  | SSL_OP_TLS_ROLLBACK_BUG),
+};
+
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+    defined(HAVE_WEBSERVER)
+/* for compatibility these must be macros */
+#define SSL_OP_NO_SSLv2   WOLFSSL_OP_NO_SSLv2
+#define SSL_OP_NO_SSLv3   WOLFSSL_OP_NO_SSLv3
+#define SSL_OP_NO_TLSv1   WOLFSSL_OP_NO_TLSv1
+#define SSL_OP_NO_TLSv1_1 WOLFSSL_OP_NO_TLSv1_1
+#define SSL_OP_NO_TLSv1_2 WOLFSSL_OP_NO_TLSv1_2
+#if !(!defined(WOLFSSL_TLS13) && defined(WOLFSSL_APACHE_HTTPD)) /* apache uses this to determine if TLS 1.3 is enabled */
+#define SSL_OP_NO_TLSv1_3 WOLFSSL_OP_NO_TLSv1_3
+#endif
+
+#define SSL_OP_NO_SSL_MASK (SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | \
+    SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3)
+
+#define SSL_NOTHING 1
+#define SSL_WRITING 2
+#define SSL_READING 3
+
+enum {
+#ifdef HAVE_OCSP
+    /* OCSP Flags */
+    OCSP_NOCERTS     = 1,
+    OCSP_NOINTERN    = 2,
+    OCSP_NOSIGS      = 4,
+    OCSP_NOCHAIN     = 8,
+    OCSP_NOVERIFY    = 16,
+    OCSP_NOEXPLICIT  = 32,
+    OCSP_NOCASIGN    = 64,
+    OCSP_NODELEGATED = 128,
+    OCSP_NOCHECKS    = 256,
+    OCSP_TRUSTOTHER  = 512,
+    OCSP_RESPID_KEY  = 1024,
+    OCSP_NOTIME      = 2048,
+
+    /* OCSP Types */
+    OCSP_CERTID   = 2,
+    OCSP_REQUEST  = 4,
+    OCSP_RESPONSE = 8,
+    OCSP_BASICRESP = 16,
+#endif
+
+    ASN1_GENERALIZEDTIME = 4,
+    SSL_MAX_SSL_SESSION_ID_LENGTH = 32,
+
+    SSL_ST_CONNECT = 0x1000,
+    SSL_ST_ACCEPT  = 0x2000,
+    SSL_ST_MASK    = 0x0FFF,
+
+    SSL_CB_LOOP = 0x01,
+    SSL_CB_EXIT = 0x02,
+    SSL_CB_READ = 0x04,
+    SSL_CB_WRITE = 0x08,
+    SSL_CB_HANDSHAKE_START = 0x10,
+    SSL_CB_HANDSHAKE_DONE = 0x20,
+    SSL_CB_ALERT = 0x4000,
+    SSL_CB_READ_ALERT = (SSL_CB_ALERT | SSL_CB_READ),
+    SSL_CB_WRITE_ALERT = (SSL_CB_ALERT | SSL_CB_WRITE),
+    SSL_CB_ACCEPT_LOOP = (SSL_ST_ACCEPT | SSL_CB_LOOP),
+    SSL_CB_ACCEPT_EXIT = (SSL_ST_ACCEPT | SSL_CB_EXIT),
+    SSL_CB_CONNECT_LOOP = (SSL_ST_CONNECT | SSL_CB_LOOP),
+    SSL_CB_CONNECT_EXIT = (SSL_ST_CONNECT | SSL_CB_EXIT),
+    SSL_CB_MODE_READ = 1,
+    SSL_CB_MODE_WRITE = 2,
+
+    SSL_MODE_ENABLE_PARTIAL_WRITE = 2,
+    SSL_MODE_AUTO_RETRY = 3, /* wolfSSL default is to block with blocking io
+                              * and auto retry */
+    SSL_MODE_RELEASE_BUFFERS = -1, /* For libwebsockets build. No current use. */
+
+    BIO_CLOSE   = 1,
+    BIO_NOCLOSE = 0,
+
+    X509_FILETYPE_PEM = 8,
+    X509_LU_X509      = 9,
+    X509_LU_CRL       = 12,
+
+    X509_V_OK                                    = 0,
+    X509_V_ERR_CRL_SIGNATURE_FAILURE             = 13,
+    X509_V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD    = 14,
+    X509_V_ERR_CRL_HAS_EXPIRED                   = 15,
+    X509_V_ERR_CERT_REVOKED                      = 16,
+    X509_V_ERR_CERT_CHAIN_TOO_LONG               = 17,
+    X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT         = 18,
+    X509_V_ERR_CERT_NOT_YET_VALID                = 19,
+    X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD    = 20,
+    X509_V_ERR_CERT_HAS_EXPIRED                  = 21,
+    X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD     = 22,
+    X509_V_ERR_CERT_REJECTED                     = 23,
+    /* Required for Nginx  */
+    X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT       = 24,
+    X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN         = 25,
+    X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY = 26,
+    X509_V_ERR_CERT_UNTRUSTED                    = 27,
+    X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE   = 28,
+    X509_V_ERR_SUBJECT_ISSUER_MISMATCH           = 29,
+    /* additional X509_V_ERR_* enums not used in wolfSSL */
+    X509_V_ERR_UNABLE_TO_GET_CRL,
+    X509_V_ERR_UNABLE_TO_DECRYPT_CERT_SIGNATURE,
+    X509_V_ERR_UNABLE_TO_DECRYPT_CRL_SIGNATURE,
+    X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY,
+    X509_V_ERR_CERT_SIGNATURE_FAILURE,
+    X509_V_ERR_CRL_NOT_YET_VALID,
+    X509_V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD,
+    X509_V_ERR_OUT_OF_MEM,
+    X509_V_ERR_INVALID_CA,
+    X509_V_ERR_PATH_LENGTH_EXCEEDED,
+    X509_V_ERR_INVALID_PURPOSE,
+    X509_V_ERR_AKID_SKID_MISMATCH,
+    X509_V_ERR_AKID_ISSUER_SERIAL_MISMATCH,
+    X509_V_ERR_KEYUSAGE_NO_CERTSIGN,
+    X509_V_ERR_UNABLE_TO_GET_CRL_ISSUER,
+    X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION,
+    X509_V_ERR_KEYUSAGE_NO_CRL_SIGN,
+    X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION,
+    X509_V_ERR_INVALID_NON_CA,
+    X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED,
+    X509_V_ERR_KEYUSAGE_NO_DIGITAL_SIGNATURE,
+    X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED,
+    X509_V_ERR_INVALID_EXTENSION,
+    X509_V_ERR_INVALID_POLICY_EXTENSION,
+    X509_V_ERR_NO_EXPLICIT_POLICY,
+    X509_V_ERR_UNNESTED_RESOURCE,
+    X509_V_ERR_APPLICATION_VERIFICATION,
+
+    X509_R_CERT_ALREADY_IN_HASH_TABLE,
+
+    CRYPTO_LOCK = 1,
+    CRYPTO_NUM_LOCKS = 10,
+
+    ASN1_STRFLGS_ESC_MSB = 4
+};
+#endif
+
+enum { /* ssl Constants */
+    WOLFSSL_ERROR_NONE      =  0,   /* for most functions */
+    WOLFSSL_FAILURE         =  0,   /* for some functions */
+    WOLFSSL_SUCCESS         =  1,
+    WOLFSSL_SHUTDOWN_NOT_DONE =  2,  /* call wolfSSL_shutdown again to complete */
+
+    WOLFSSL_ALPN_NOT_FOUND  = -9,
+    WOLFSSL_BAD_CERTTYPE    = -8,
+    WOLFSSL_BAD_STAT        = -7,
+    WOLFSSL_BAD_PATH        = -6,
+    WOLFSSL_BAD_FILETYPE    = -5,
+    WOLFSSL_BAD_FILE        = -4,
+    WOLFSSL_NOT_IMPLEMENTED = -3,
+    WOLFSSL_UNKNOWN         = -2,
+    WOLFSSL_FATAL_ERROR     = -1,
+
+    WOLFSSL_FILETYPE_ASN1    = 2,
+    WOLFSSL_FILETYPE_PEM     = 1,
+    WOLFSSL_FILETYPE_DEFAULT = 2, /* ASN1 */
+    WOLFSSL_FILETYPE_RAW     = 3, /* NTRU raw key blob */
+
+    WOLFSSL_VERIFY_NONE                 = 0,
+    WOLFSSL_VERIFY_PEER                 = 1,
+    WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT = 2,
+    WOLFSSL_VERIFY_CLIENT_ONCE          = 4,
+    WOLFSSL_VERIFY_FAIL_EXCEPT_PSK      = 8,
+
+    WOLFSSL_SESS_CACHE_OFF                = 0x0000,
+    WOLFSSL_SESS_CACHE_CLIENT             = 0x0001,
+    WOLFSSL_SESS_CACHE_SERVER             = 0x0002,
+    WOLFSSL_SESS_CACHE_BOTH               = 0x0003,
+    WOLFSSL_SESS_CACHE_NO_AUTO_CLEAR      = 0x0008,
+    WOLFSSL_SESS_CACHE_NO_INTERNAL_LOOKUP = 0x0100,
+    WOLFSSL_SESS_CACHE_NO_INTERNAL_STORE  = 0x0200,
+    WOLFSSL_SESS_CACHE_NO_INTERNAL        = 0x0300,
+
+    WOLFSSL_ERROR_WANT_READ        =  2,
+    WOLFSSL_ERROR_WANT_WRITE       =  3,
+    WOLFSSL_ERROR_WANT_CONNECT     =  7,
+    WOLFSSL_ERROR_WANT_ACCEPT      =  8,
+    WOLFSSL_ERROR_SYSCALL          =  5,
+    WOLFSSL_ERROR_WANT_X509_LOOKUP = 83,
+    WOLFSSL_ERROR_ZERO_RETURN      =  6,
+    WOLFSSL_ERROR_SSL              = 85,
+
+    WOLFSSL_SENT_SHUTDOWN     = 1,
+    WOLFSSL_RECEIVED_SHUTDOWN = 2,
+    WOLFSSL_MODE_ACCEPT_MOVING_WRITE_BUFFER = 4,
+
+    WOLFSSL_R_SSL_HANDSHAKE_FAILURE           = 101,
+    WOLFSSL_R_TLSV1_ALERT_UNKNOWN_CA          = 102,
+    WOLFSSL_R_SSLV3_ALERT_CERTIFICATE_UNKNOWN = 103,
+    WOLFSSL_R_SSLV3_ALERT_BAD_CERTIFICATE     = 104,
+
+    WOLF_PEM_BUFSIZE = 1024
+};
+
+
+/* extra begins */
+#ifdef OPENSSL_EXTRA
+enum {  /* ERR Constants */
+    ERR_TXT_STRING = 1
+};
+
+/* bio misc */
+enum {
+    WOLFSSL_BIO_ERROR = -1,
+    WOLFSSL_BIO_UNSET = -2,
+    WOLFSSL_BIO_SIZE  = 17000 /* default BIO write size if not set */
+};
+#endif
+
+
+#ifdef HAVE_FUZZER
+enum fuzzer_type {
+    FUZZ_HMAC      = 0,
+    FUZZ_ENCRYPT   = 1,
+    FUZZ_SIGNATURE = 2,
+    FUZZ_HASH      = 3,
+    FUZZ_HEAD      = 4
+};
+
+typedef int (*CallbackFuzzer)(WOLFSSL* ssl, const unsigned char* buf, int sz,
+        int type, void* fuzzCtx);
+
+WOLFSSL_API void wolfSSL_SetFuzzerCb(WOLFSSL* ssl, CallbackFuzzer cbf, void* fCtx);
+#endif
+
+/* I/O Callback default errors */
+enum IOerrors {
+    WOLFSSL_CBIO_ERR_GENERAL    = -1,     /* general unexpected err */
+    WOLFSSL_CBIO_ERR_WANT_READ  = -2,     /* need to call read  again */
+    WOLFSSL_CBIO_ERR_WANT_WRITE = -2,     /* need to call write again */
+    WOLFSSL_CBIO_ERR_CONN_RST   = -3,     /* connection reset */
+    WOLFSSL_CBIO_ERR_ISR        = -4,     /* interrupt */
+    WOLFSSL_CBIO_ERR_CONN_CLOSE = -5,     /* connection closed or epipe */
+    WOLFSSL_CBIO_ERR_TIMEOUT    = -6      /* socket timeout */
+};
+
+
+/* CA cache callbacks */
+enum {
+    WOLFSSL_SSLV3    = 0,
+    WOLFSSL_TLSV1    = 1,
+    WOLFSSL_TLSV1_1  = 2,
+    WOLFSSL_TLSV1_2  = 3,
+    WOLFSSL_TLSV1_3  = 4,
+    WOLFSSL_USER_CA  = 1,          /* user added as trusted */
+    WOLFSSL_CHAIN_CA = 2           /* added to cache from trusted chain */
+};
+
+typedef void (*CallbackCACache)(unsigned char* der, int sz, int type);
+typedef void (*CbMissingCRL)(const char* url);
+typedef int  (*CbOCSPIO)(void*, const char*, int,
+                                         unsigned char*, int, unsigned char**);
+typedef void (*CbOCSPRespFree)(void*,unsigned char*);
+
+#ifdef HAVE_CRL_IO
+typedef int  (*CbCrlIO)(WOLFSSL_CRL* crl, const char* url, int urlSz);
+#endif
+
+typedef int (*CallbackMacEncrypt)(WOLFSSL* ssl, unsigned char* macOut,
+       const unsigned char* macIn, unsigned int macInSz, int macContent,
+       int macVerify, unsigned char* encOut, const unsigned char* encIn,
+       unsigned int encSz, void* ctx);
+typedef int (*CallbackDecryptVerify)(WOLFSSL* ssl,
+       unsigned char* decOut, const unsigned char* decIn,
+       unsigned int decSz, int content, int verify, unsigned int* padSz,
+       void* ctx);
+typedef int (*CallbackEncryptMac)(WOLFSSL* ssl, unsigned char* macOut,
+       int content, int macVerify, unsigned char* encOut,
+       const unsigned char* encIn, unsigned int encSz, void* ctx);
+typedef int (*CallbackVerifyDecrypt)(WOLFSSL* ssl,
+       unsigned char* decOut, const unsigned char* decIn,
+       unsigned int decSz, int content, int verify, unsigned int* padSz,
+       void* ctx);
+
+
+/* Atomic User Needs */
+enum {
+    WOLFSSL_SERVER_END = 0,
+    WOLFSSL_CLIENT_END = 1,
+    WOLFSSL_NEITHER_END = 3,
+    WOLFSSL_BLOCK_TYPE = 2,
+    WOLFSSL_STREAM_TYPE = 3,
+    WOLFSSL_AEAD_TYPE = 4,
+    WOLFSSL_TLS_HMAC_INNER_SZ = 13      /* SEQ_SZ + ENUM + VERSION_SZ + LEN_SZ */
+};
+
+/* for GetBulkCipher and internal use */
+enum BulkCipherAlgorithm {
+    wolfssl_cipher_null,
+    wolfssl_rc4,
+    wolfssl_rc2,
+    wolfssl_des,
+    wolfssl_triple_des,             /* leading 3 (3des) not valid identifier */
+    wolfssl_des40,
+#ifdef HAVE_IDEA
+    wolfssl_idea,
+#endif
+    wolfssl_aes,
+    wolfssl_aes_gcm,
+    wolfssl_aes_ccm,
+    wolfssl_chacha,
+    wolfssl_camellia,
+    wolfssl_hc128,                  /* wolfSSL extensions */
+    wolfssl_rabbit
+};
+
+
+/* for KDF TLS 1.2 mac types */
+enum KDF_MacAlgorithm {
+    wolfssl_sha256 = 4,     /* needs to match hash.h wc_MACAlgorithm */
+    wolfssl_sha384,
+    wolfssl_sha512
+};
+
+
+/* Server Name Indication */
+#ifdef HAVE_SNI
+
+/* SNI types */
+enum {
+    WOLFSSL_SNI_HOST_NAME = 0
+};
+
+#ifndef NO_WOLFSSL_SERVER
+/* SNI options */
+enum {
+    /* Do not abort the handshake if the requested SNI didn't match. */
+    WOLFSSL_SNI_CONTINUE_ON_MISMATCH = 0x01,
+
+    /* Behave as if the requested SNI matched in a case of mismatch.  */
+    /* In this case, the status will be set to WOLFSSL_SNI_FAKE_MATCH. */
+    WOLFSSL_SNI_ANSWER_ON_MISMATCH   = 0x02,
+
+    /* Abort the handshake if the client didn't send a SNI request. */
+    WOLFSSL_SNI_ABORT_ON_ABSENCE     = 0x04,
+};
+#endif /* NO_WOLFSSL_SERVER */
+
+/* SNI status */
+enum {
+    WOLFSSL_SNI_NO_MATCH   = 0,
+    WOLFSSL_SNI_FAKE_MATCH = 1, /**< @see WOLFSSL_SNI_ANSWER_ON_MISMATCH */
+    WOLFSSL_SNI_REAL_MATCH = 2,
+    WOLFSSL_SNI_FORCE_KEEP = 3  /** Used with -DWOLFSSL_ALWAYS_KEEP_SNI */
+};
+
+/* SNI received callback type */
+typedef int (*CallbackSniRecv)(WOLFSSL *ssl, int *ret, void* exArg);
+
+#endif /* HAVE_SNI */
+
+/* Trusted CA Key Indication - RFC 6066 (Section 6) */
+#ifdef HAVE_TRUSTED_CA
+/* TCA Identifier Type */
+enum {
+    WOLFSSL_TRUSTED_CA_PRE_AGREED = 0,
+    WOLFSSL_TRUSTED_CA_KEY_SHA1 = 1,
+    WOLFSSL_TRUSTED_CA_X509_NAME = 2,
+    WOLFSSL_TRUSTED_CA_CERT_SHA1 = 3
+};
+#endif /* HAVE_TRUSTED_CA */
+
+
+/* Application-Layer Protocol Negotiation */
+#ifdef HAVE_ALPN
+/* ALPN status code */
+enum {
+    WOLFSSL_ALPN_NO_MATCH = 0,
+    WOLFSSL_ALPN_MATCH    = 1,
+    WOLFSSL_ALPN_CONTINUE_ON_MISMATCH = 2,
+    WOLFSSL_ALPN_FAILED_ON_MISMATCH = 4,
+};
+
+enum {
+    WOLFSSL_MAX_ALPN_PROTO_NAME_LEN = 255,
+    WOLFSSL_MAX_ALPN_NUMBER = 257
+};
+
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || defined(HAVE_LIGHTY)
+typedef int (*CallbackALPNSelect)(WOLFSSL* ssl, const unsigned char** out,
+    unsigned char* outLen, const unsigned char* in, unsigned int inLen,
+    void *arg);
+#endif
+#endif /* HAVE_ALPN */
+
+
+/* Maximum Fragment Length */
+#ifdef HAVE_MAX_FRAGMENT
+
+/* Fragment lengths */
+enum {
+    WOLFSSL_MFL_2_9  = 1, /*  512 bytes */
+    WOLFSSL_MFL_2_10 = 2, /* 1024 bytes */
+    WOLFSSL_MFL_2_11 = 3, /* 2048 bytes */
+    WOLFSSL_MFL_2_12 = 4, /* 4096 bytes */
+    WOLFSSL_MFL_2_13 = 5, /* 8192 bytes *//* wolfSSL ONLY!!! */
+    WOLFSSL_MFL_2_8  = 6, /*  256 bytes *//* wolfSSL ONLY!!! */
+    WOLFSSL_MFL_MIN  = WOLFSSL_MFL_2_9,
+    WOLFSSL_MFL_MAX  = WOLFSSL_MFL_2_8,
+};
+#endif /* HAVE_MAX_FRAGMENT */
+
+/* Certificate Status Request */
+/* Certificate Status Type */
+enum {
+    WOLFSSL_CSR_OCSP = 1
+};
+
+/* Certificate Status Options (flags) */
+enum {
+    WOLFSSL_CSR_OCSP_USE_NONCE = 0x01
+};
+
+/* Certificate Status Request v2 */
+/* Certificate Status Type */
+enum {
+    WOLFSSL_CSR2_OCSP = 1,
+    WOLFSSL_CSR2_OCSP_MULTI = 2
+};
+
+/* Certificate Status v2 Options (flags) */
+enum {
+    WOLFSSL_CSR2_OCSP_USE_NONCE = 0x01
+};
+
+/* Named Groups */
+enum {
+#if 0 /* Not Supported */
+    WOLFSSL_ECC_SECT163K1 = 1,
+    WOLFSSL_ECC_SECT163R1 = 2,
+    WOLFSSL_ECC_SECT163R2 = 3,
+    WOLFSSL_ECC_SECT193R1 = 4,
+    WOLFSSL_ECC_SECT193R2 = 5,
+    WOLFSSL_ECC_SECT233K1 = 6,
+    WOLFSSL_ECC_SECT233R1 = 7,
+    WOLFSSL_ECC_SECT239K1 = 8,
+    WOLFSSL_ECC_SECT283K1 = 9,
+    WOLFSSL_ECC_SECT283R1 = 10,
+    WOLFSSL_ECC_SECT409K1 = 11,
+    WOLFSSL_ECC_SECT409R1 = 12,
+    WOLFSSL_ECC_SECT571K1 = 13,
+    WOLFSSL_ECC_SECT571R1 = 14,
+#endif
+    WOLFSSL_ECC_SECP160K1 = 15,
+    WOLFSSL_ECC_SECP160R1 = 16,
+    WOLFSSL_ECC_SECP160R2 = 17,
+    WOLFSSL_ECC_SECP192K1 = 18,
+    WOLFSSL_ECC_SECP192R1 = 19,
+    WOLFSSL_ECC_SECP224K1 = 20,
+    WOLFSSL_ECC_SECP224R1 = 21,
+    WOLFSSL_ECC_SECP256K1 = 22,
+    WOLFSSL_ECC_SECP256R1 = 23,
+    WOLFSSL_ECC_SECP384R1 = 24,
+    WOLFSSL_ECC_SECP521R1 = 25,
+    WOLFSSL_ECC_BRAINPOOLP256R1 = 26,
+    WOLFSSL_ECC_BRAINPOOLP384R1 = 27,
+    WOLFSSL_ECC_BRAINPOOLP512R1 = 28,
+    WOLFSSL_ECC_X25519    = 29,
+    WOLFSSL_ECC_X448      = 30,
+    WOLFSSL_ECC_MAX       = 30,
+
+    WOLFSSL_FFDHE_2048    = 256,
+    WOLFSSL_FFDHE_3072    = 257,
+    WOLFSSL_FFDHE_4096    = 258,
+    WOLFSSL_FFDHE_6144    = 259,
+    WOLFSSL_FFDHE_8192    = 260,
+};
+
+enum {
+    WOLFSSL_EC_PF_UNCOMPRESSED = 0,
+#if 0 /* Not Supported */
+    WOLFSSL_EC_PF_X962_COMP_PRIME = 1,
+    WOLFSSL_EC_PF_X962_COMP_CHAR2 = 2,
+#endif
+};
+
+/* Session Ticket */
+#ifdef HAVE_SESSION_TICKET
+
+#if !defined(WOLFSSL_NO_DEF_TICKET_ENC_CB) && !defined(WOLFSSL_NO_SERVER)
+    #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305) && \
+        !defined(WOLFSSL_TICKET_ENC_AES128_GCM) && \
+        !defined(WOLFSSL_TICKET_ENC_AES256_GCM)
+        #define WOLFSSL_TICKET_KEY_SZ       CHACHA20_POLY1305_AEAD_KEYSIZE
+    #elif defined(WOLFSSL_TICKET_ENC_AES256_GCM)
+        #define WOLFSSL_TICKET_KEY_SZ       AES_256_KEY_SIZE
+    #else
+        #define WOLFSSL_TICKET_KEY_SZ       AES_128_KEY_SIZE
+    #endif
+
+    #define WOLFSSL_TICKET_KEYS_SZ     (WOLFSSL_TICKET_NAME_SZ +    \
+                                        2 * WOLFSSL_TICKET_KEY_SZ + \
+                                        sizeof(word32) * 2)
+#endif
+
+#ifndef NO_WOLFSSL_CLIENT
+typedef int (*CallbackSessionTicket)(WOLFSSL*, const unsigned char*, int, void*);
+#endif /* NO_WOLFSSL_CLIENT */
+
+#define WOLFSSL_TICKET_NAME_SZ 16
+#define WOLFSSL_TICKET_IV_SZ   16
+#define WOLFSSL_TICKET_MAC_SZ  32
+
+enum TicketEncRet {
+    WOLFSSL_TICKET_RET_FATAL  = -1,  /* fatal error, don't use ticket */
+    WOLFSSL_TICKET_RET_OK     =  0,  /* ok, use ticket */
+    WOLFSSL_TICKET_RET_REJECT,       /* don't use ticket, but not fatal */
+    WOLFSSL_TICKET_RET_CREATE        /* existing ticket ok and create new one */
+};
+
+#ifndef NO_WOLFSSL_SERVER
+typedef int (*SessionTicketEncCb)(WOLFSSL*,
+                                 unsigned char key_name[WOLFSSL_TICKET_NAME_SZ],
+                                 unsigned char iv[WOLFSSL_TICKET_IV_SZ],
+                                 unsigned char mac[WOLFSSL_TICKET_MAC_SZ],
+                                 int enc, unsigned char*, int, int*, void*);
+#endif /* NO_WOLFSSL_SERVER */
+
+#endif /* HAVE_SESSION_TICKET */
+
+
+#ifdef HAVE_QSH
+/* Quantum-safe Crypto Schemes */
+enum {
+    WOLFSSL_NTRU_EESS439 = 0x0101, /* max plaintext length of 65  */
+    WOLFSSL_NTRU_EESS593 = 0x0102, /* max plaintext length of 86  */
+    WOLFSSL_NTRU_EESS743 = 0x0103, /* max plaintext length of 106 */
+    WOLFSSL_LWE_XXX  = 0x0201,     /* Learning With Error encryption scheme */
+    WOLFSSL_HFE_XXX  = 0x0301,     /* Hidden Field Equation scheme */
+    WOLFSSL_NULL_QSH = 0xFFFF      /* QSHScheme is not used */
+};
+#endif /* QSH */
+
+typedef int (*HandShakeDoneCb)(WOLFSSL*, void*);
+
+#ifdef WOLFSSL_CALLBACKS
+typedef int (*HandShakeCallBack)(HandShakeInfo*);
+typedef int (*TimeoutCallBack)(TimeoutInfo*);
+#endif /* WOLFSSL_CALLBACKS */
+
+#if defined(OPENSSL_ALL) || defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) \
+    || defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA) || defined(HAVE_LIGHTY)
+typedef int (*wolf_sk_compare_cb)(const void* a,
+                                  const void* b);
+typedef unsigned long (*wolf_sk_hash_cb) (const void *v);
+#endif /* OPENSSL_ALL || HAVE_STUNNEL || WOLFSSL_NGINX || WOLFSSL_HAPROXY || OPENSSL_EXTRA || HAVE_LIGHTY */
+
+
+#ifdef OPENSSL_EXTRA
+typedef void (*SSL_Msg_Cb)(int write_p, int version, int content_type,
+    const void *buf, size_t len, WOLFSSL *ssl, void *arg);
+#endif
+
+
+
+#ifdef __cplusplus
+    }   /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_SSL_TYPES_H_ */

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -48,6 +48,7 @@
     #endif
 #endif
 
+#include <wolfssl/ssl_types.h>
 
 #if defined(USE_WOLFSSL_IO) || defined(HAVE_HTTP_CLIENT)
 


### PR DESCRIPTION
Moving SSL type definitions to ssl_types.h aims to eliminate circular dependencies when including some OpenSSL compatibility headers. One example is crypto.h, which when included alone or first errors out during compilation due to undefined types.