### PR TITLE
INTIME: add support for directory file search

### DIFF
--- a/IDE/INTIME-RTOS/user_settings.h
+++ b/IDE/INTIME-RTOS/user_settings.h
@@ -14,7 +14,7 @@ extern "C" {
 #define INTIME_RTOS
 
 #undef  WOLF_EXAMPLES_STACK
-#define WOLF_EXAMPLES_STACK         65536
+#define WOLF_EXAMPLES_STACK         (1<<17)
 
 #undef  WOLFSSL_GENERAL_ALIGNMENT
 #define WOLFSSL_GENERAL_ALIGNMENT   4
@@ -27,7 +27,7 @@ extern "C" {
 
 /* disable directory support */
 #undef  NO_WOLFSSL_DIR
-#define NO_WOLFSSL_DIR
+//#define NO_WOLFSSL_DIR
 
 /* disable writev */
 #undef  NO_WRITEV

--- a/IDE/INTIME-RTOS/wolfExamples.vcxproj
+++ b/IDE/INTIME-RTOS/wolfExamples.vcxproj
@@ -66,7 +66,7 @@
     </Link>
     <ClCompile>
       <ExceptionHandling>Async</ExceptionHandling>
-      <PreprocessorDefinitions>WOLFSSL_USER_SETTINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WOLFSSL_USER_SETTINGS;_USE_64BIT_TIME_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -431,7 +431,7 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
         return BAD_FUNC_ARG;
     }
 
-    XMEMSET(ctx->name, 0, MAX_FILENAME_SZ);
+    XMEMSET(ctx, 0, sizeof(ReadDirCtx));
     pathLen = (int)XSTRLEN(path);
 
 #ifdef USE_WINDOWS_API
@@ -466,34 +466,34 @@ int wc_ReadDirFirst(ReadDirCtx* ctx, const char* path, char** name)
     } while (FindNextFileA(ctx->hFind, &ctx->FindFileData));
 
 #elif defined(INTIME_RTOS)
-	if (pathLen > MAX_FILENAME_SZ - 3)
-		return BAD_PATH_ERROR;
+    if (pathLen > MAX_FILENAME_SZ - 3)
+        return BAD_PATH_ERROR;
 
-	XSTRNCPY(ctx->name, path, MAX_FILENAME_SZ - 3);
-	XSTRNCPY(ctx->name + pathLen, "\\*", MAX_FILENAME_SZ - pathLen);
+    XSTRNCPY(ctx->name, path, MAX_FILENAME_SZ - 3);
+    XSTRNCPY(ctx->name + pathLen, "\\*", MAX_FILENAME_SZ - pathLen);
 
-	if (!FindFirstRtFile(ctx->name, &ctx->FindFileData, 0)) {
-		WOLFSSL_MSG("FindFirstFile for path verify locations failed");
-		return BAD_PATH_ERROR;
-	}
+    if (!FindFirstRtFile(ctx->name, &ctx->FindFileData, 0)) {
+        WOLFSSL_MSG("FindFirstFile for path verify locations failed");
+        return BAD_PATH_ERROR;
+    }
 
-	do {
-		if (!(ctx->FindFileData.dwFileAttributes & FILE_ATTR_DIRECTORY)) {
-			dnameLen = (int)XSTRLEN(ctx->FindFileData.cFileName);
+    do {
+        if (!(ctx->FindFileData.dwFileAttributes & FILE_ATTR_DIRECTORY)) {
+            dnameLen = (int)XSTRLEN(ctx->FindFileData.cFileName);
 
-			if (pathLen + dnameLen + 2 > MAX_FILENAME_SZ) {
-				return BAD_PATH_ERROR;
-			}
-			XSTRNCPY(ctx->name, path, pathLen + 1);
-			ctx->name[pathLen] = '\\';
-			XSTRNCPY(ctx->name + pathLen + 1,
-				ctx->FindFileData.cFileName,
-				MAX_FILENAME_SZ - pathLen - 1);
-			if (name)
-				*name = ctx->name;
-			return 0;
-		}
-	} while (FindNextRtFile(&ctx->FindFileData));
+            if (pathLen + dnameLen + 2 > MAX_FILENAME_SZ) {
+                return BAD_PATH_ERROR;
+            }
+            XSTRNCPY(ctx->name, path, pathLen + 1);
+            ctx->name[pathLen] = '\\';
+            XSTRNCPY(ctx->name + pathLen + 1,
+                     ctx->FindFileData.cFileName,
+                     MAX_FILENAME_SZ - pathLen - 1);
+            if (name)
+                *name = ctx->name;
+            return 0;
+        }
+    } while (FindNextRtFile(&ctx->FindFileData));
 
 #elif defined(WOLFSSL_ZEPHYR)
     if (fs_opendir(&ctx->dir, path) != 0) {
@@ -633,23 +633,23 @@ int wc_ReadDirNext(ReadDirCtx* ctx, const char* path, char** name)
     }
 
 #elif defined(INTIME_RTOS)
-while (FindNextRtFile(&ctx->FindFileData)) {
-	if (!(ctx->FindFileData.dwFileAttributes & FILE_ATTR_DIRECTORY)) {
-		dnameLen = (int)XSTRLEN(ctx->FindFileData.cFileName);
+    while (FindNextRtFile(&ctx->FindFileData)) {
+        if (!(ctx->FindFileData.dwFileAttributes & FILE_ATTR_DIRECTORY)) {
+            dnameLen = (int)XSTRLEN(ctx->FindFileData.cFileName);
 
-		if (pathLen + dnameLen + 2 > MAX_FILENAME_SZ) {
-			return BAD_PATH_ERROR;
-		}
-		XSTRNCPY(ctx->name, path, pathLen + 1);
-		ctx->name[pathLen] = '\\';
-		XSTRNCPY(ctx->name + pathLen + 1,
-			ctx->FindFileData.cFileName,
-			MAX_FILENAME_SZ - pathLen - 1);
-		if (name)
-			*name = ctx->name;
-		return 0;
-	}
-}
+            if (pathLen + dnameLen + 2 > MAX_FILENAME_SZ) {
+                return BAD_PATH_ERROR;
+            }
+            XSTRNCPY(ctx->name, path, pathLen + 1);
+            ctx->name[pathLen] = '\\';
+            XSTRNCPY(ctx->name + pathLen + 1,
+                     ctx->FindFileData.cFileName,
+                     MAX_FILENAME_SZ - pathLen - 1);
+            if (name)
+                *name = ctx->name;
+            return 0;
+        }
+    }
 
 #elif defined(WOLFSSL_ZEPHYR)
     while ((fs_readdir(&ctx->dir, &ctx->entry)) != 0) {
@@ -748,7 +748,7 @@ void wc_ReadDirClose(ReadDirCtx* ctx)
     }
 
 #elif defined(INTIME_RTOS)
-	FindRtFileClose(&ctx->FindFileData);
+    FindRtFileClose(&ctx->FindFileData);
 
 #elif defined(WOLFSSL_ZEPHYR)
     if (ctx->dirp) {

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -730,7 +730,7 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
         struct M2MB_DIRENT* entry;
         struct M2MB_STAT s;
     #elif defined(INTIME_RTOS)
-		FIND_FILE_DATA FindFileData;
+        FIND_FILE_DATA FindFileData;
     #else
         struct dirent* entry;
         DIR*   dir;

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -729,6 +729,8 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
         M2MB_DIR_T* dir;
         struct M2MB_DIRENT* entry;
         struct M2MB_STAT s;
+    #elif defined(INTIME_RTOS)
+		FIND_FILE_DATA FindFileData;
     #else
         struct dirent* entry;
         DIR*   dir;


### PR DESCRIPTION
Directory support allows CRL use with undefining `NO_WOLFSSL_DIR`

Also increase stack size to avoid page fault and add
`_USE_64BIT_TIME_T` to example project to pass ASN test

ZD 11798