### PR TITLE
Fix for SP ECC non-blocking test and synchronization of changes

### DIFF
--- a/wolfcrypt/src/sp_arm32.c
+++ b/wolfcrypt/src/sp_arm32.c
@@ -36385,13 +36385,10 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
             hashLen = 32U;
         }
 
-        sp_256_from_bin(ctx->e, 8, hash, (int)hashLen);
-
         ctx->i = SP_ECC_MAX_SIG_GEN;
         ctx->state = 1;
         break;
     case 1: /* GEN */
-        sp_256_from_mp(ctx->x, 8, priv);
         /* New random point. */
         if (km == NULL || mp_iszero(km)) {
             err = sp_256_ecc_gen_k_8(rng, ctx->k);
@@ -36419,6 +36416,9 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
         c = sp_256_cmp_8(ctx->r, p256_order);
         sp_256_cond_sub_8(ctx->r, ctx->r, p256_order, 0L - (sp_digit)(c >= 0));
         sp_256_norm_8(ctx->r);
+
+        sp_256_from_mp(ctx->x, 8, priv);
+        sp_256_from_bin(ctx->e, 8, hash, (int)hashLen);
         ctx->state = 4;
         break;
     }
@@ -36475,6 +36475,9 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
             ctx->state = 10;
             break;
         }
+    #ifdef WOLFSSL_ECDSA_SET_K_ONE_LOOP
+        ctx->i = 1;
+    #endif
 
         /* not usable gen, try again */
         ctx->i--;
@@ -37041,7 +37044,7 @@ typedef struct sp_ecc_verify_256_ctx {
 
 int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
     word32 hashLen, const mp_int* pX, const mp_int* pY, const mp_int* pZ,
-    const mp_int* r, const mp_int* sm, int* res, void* heap)
+    const mp_int* rm, const mp_int* sm, int* res, void* heap)
 {
     int err = FP_WOULDBLOCK;
     sp_ecc_verify_256_ctx* ctx = (sp_ecc_verify_256_ctx*)sp_ctx->data;
@@ -37056,7 +37059,7 @@ int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
         }
 
         sp_256_from_bin(ctx->u1, 8, hash, (int)hashLen);
-        sp_256_from_mp(ctx->u2, 8, r);
+        sp_256_from_mp(ctx->u2, 8, rm);
         sp_256_from_mp(ctx->s, 8, sm);
         sp_256_from_mp(ctx->p2.x, 8, pX);
         sp_256_from_mp(ctx->p2.y, 8, pY);
@@ -37114,57 +37117,33 @@ int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
         if (err == MP_OKAY)
             ctx->state = 9;
         break;
-    case 9: /* DBLPREP */
-        if (sp_256_iszero_8(ctx->p1.z)) {
-            if (sp_256_iszero_8(ctx->p1.x) && sp_256_iszero_8(ctx->p1.y)) {
-                XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
-                ctx->state = 10;
-                break;
-            }
-            else {
-                /* Y ordinate is not used from here - don't set. */
-                int i;
-                for (i=0; i<8; i++) {
-                    ctx->p1.x[i] = 0;
-                }
-                XMEMCPY(ctx->p1.z, p256_norm_mod, sizeof(p256_norm_mod));
-            }
-        }
-        ctx->state = 11;
-        break;
-    case 10: /* DBL */
-        err = sp_256_proj_point_dbl_8_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->p1,
-            &ctx->p2, ctx->tmp);
-        if (err == MP_OKAY) {
-            ctx->state = 11;
-        }
-        break;
-    case 11: /* MONT */
+    case 9: /* MONT */
         /* (r + n*order).z'.z' mod prime == (u1.G + u2.Q)->x' */
         /* Reload r and convert to Montgomery form. */
-        sp_256_from_mp(ctx->u2, 8, r);
+        sp_256_from_mp(ctx->u2, 8, rm);
         err = sp_256_mod_mul_norm_8(ctx->u2, ctx->u2, p256_mod);
         if (err == MP_OKAY)
-            ctx->state = 12;
+            ctx->state = 10;
         break;
-    case 12: /* SQR */
+    case 10: /* SQR */
         /* u1 = r.z'.z' mod prime */
         sp_256_mont_sqr_8(ctx->p1.z, ctx->p1.z, p256_mod, p256_mp_mod);
-        ctx->state = 13;
+        ctx->state = 11;
         break;
-    case 13: /* MUL */
+    case 11: /* MUL */
         sp_256_mont_mul_8(ctx->u1, ctx->u2, ctx->p1.z, p256_mod, p256_mp_mod);
-        ctx->state = 14;
+        ctx->state = 12;
         break;
-    case 14: /* RES */
+    case 12: /* RES */
+    {
+        int32_t c = 0;
         err = MP_OKAY; /* math okay, now check result */
         *res = (int)(sp_256_cmp_8(ctx->p1.x, ctx->u1) == 0);
         if (*res == 0) {
             sp_digit carry;
-            int32_t c;
 
             /* Reload r and add order. */
-            sp_256_from_mp(ctx->u2, 8, r);
+            sp_256_from_mp(ctx->u2, 8, rm);
             carry = sp_256_add_8(ctx->u2, ctx->u2, p256_order);
             /* Carry means result is greater than mod and is not valid. */
             if (carry == 0) {
@@ -37172,22 +37151,23 @@ int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
 
                 /* Compare with mod and if greater or equal then not valid. */
                 c = sp_256_cmp_8(ctx->u2, p256_mod);
-                if (c < 0) {
-                    /* Convert to Montogomery form */
-                    err = sp_256_mod_mul_norm_8(ctx->u2, ctx->u2, p256_mod);
-                    if (err == MP_OKAY) {
-                        /* u1 = (r + 1*order).z'.z' mod prime */
-                        sp_256_mont_mul_8(ctx->u1, ctx->u2, ctx->p1.z, p256_mod,
-                                                                  p256_mp_mod);
-                        *res = (int)(sp_256_cmp_8(ctx->p1.x, ctx->u1) == 0);
-                    }
-                }
+            }
+        }
+        if ((*res == 0) && (c < 0)) {
+            /* Convert to Montogomery form */
+            err = sp_256_mod_mul_norm_8(ctx->u2, ctx->u2, p256_mod);
+            if (err == MP_OKAY) {
+                /* u1 = (r + 1*order).z'.z' mod prime */
+                sp_256_mont_mul_8(ctx->u1, ctx->u2, ctx->p1.z, p256_mod,
+                                                            p256_mp_mod);
+                *res = (int)(sp_256_cmp_8(ctx->p1.x, ctx->u1) == 0);
             }
         }
         break;
     }
+    } /* switch */
 
-    if (err == MP_OKAY && ctx->state != 14) {
+    if (err == MP_OKAY && ctx->state != 12) {
         err = FP_WOULDBLOCK;
     }
 
@@ -37196,7 +37176,7 @@ int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
 #endif /* WOLFSSL_SP_NONBLOCK */
 
 int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
-    const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
+    const mp_int* pY, const mp_int* pZ, const mp_int* rm, const mp_int* sm,
     int* res, void* heap)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
@@ -37240,7 +37220,7 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
         }
 
         sp_256_from_bin(u1, 8, hash, (int)hashLen);
-        sp_256_from_mp(u2, 8, r);
+        sp_256_from_mp(u2, 8, rm);
         sp_256_from_mp(s, 8, sm);
         sp_256_from_mp(p2->x, 8, pX);
         sp_256_from_mp(p2->y, 8, pY);
@@ -37251,7 +37231,7 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
     if (err == MP_OKAY) {
         /* (r + n*order).z'.z' mod prime == (u1.G + u2.Q)->x' */
         /* Reload r and convert to Montgomery form. */
-        sp_256_from_mp(u2, 8, r);
+        sp_256_from_mp(u2, 8, rm);
         err = sp_256_mod_mul_norm_8(u2, u2, p256_mod);
     }
 
@@ -37262,7 +37242,7 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
         *res = (int)(sp_256_cmp_8(p1->x, u1) == 0);
         if (*res == 0) {
             /* Reload r and add order. */
-            sp_256_from_mp(u2, 8, r);
+            sp_256_from_mp(u2, 8, rm);
             carry = sp_256_add_8(u2, u2, p256_order);
             /* Carry means result is greater than mod and is not valid. */
             if (carry == 0) {
@@ -37271,8 +37251,8 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
                 /* Compare with mod and if greater or equal then not valid. */
                 c = sp_256_cmp_8(u2, p256_mod);
             }
-         }
-         if ((*res == 0) && (c < 0)) {
+        }
+        if ((*res == 0) && (c < 0)) {
             /* Convert to Montogomery form */
             err = sp_256_mod_mul_norm_8(u2, u2, p256_mod);
             if (err == MP_OKAY) {
@@ -45623,13 +45603,10 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
             hashLen = 48U;
         }
 
-        sp_384_from_bin(ctx->e, 12, hash, (int)hashLen);
-
         ctx->i = SP_ECC_MAX_SIG_GEN;
         ctx->state = 1;
         break;
     case 1: /* GEN */
-        sp_384_from_mp(ctx->x, 12, priv);
         /* New random point. */
         if (km == NULL || mp_iszero(km)) {
             err = sp_384_ecc_gen_k_12(rng, ctx->k);
@@ -45657,6 +45634,9 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
         c = sp_384_cmp_12(ctx->r, p384_order);
         sp_384_cond_sub_12(ctx->r, ctx->r, p384_order, 0L - (sp_digit)(c >= 0));
         sp_384_norm_12(ctx->r);
+
+        sp_384_from_mp(ctx->x, 12, priv);
+        sp_384_from_bin(ctx->e, 12, hash, (int)hashLen);
         ctx->state = 4;
         break;
     }
@@ -45713,6 +45693,9 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
             ctx->state = 10;
             break;
         }
+    #ifdef WOLFSSL_ECDSA_SET_K_ONE_LOOP
+        ctx->i = 1;
+    #endif
 
         /* not usable gen, try again */
         ctx->i--;
@@ -46326,7 +46309,7 @@ typedef struct sp_ecc_verify_384_ctx {
 
 int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
     word32 hashLen, const mp_int* pX, const mp_int* pY, const mp_int* pZ,
-    const mp_int* r, const mp_int* sm, int* res, void* heap)
+    const mp_int* rm, const mp_int* sm, int* res, void* heap)
 {
     int err = FP_WOULDBLOCK;
     sp_ecc_verify_384_ctx* ctx = (sp_ecc_verify_384_ctx*)sp_ctx->data;
@@ -46341,7 +46324,7 @@ int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
         }
 
         sp_384_from_bin(ctx->u1, 12, hash, (int)hashLen);
-        sp_384_from_mp(ctx->u2, 12, r);
+        sp_384_from_mp(ctx->u2, 12, rm);
         sp_384_from_mp(ctx->s, 12, sm);
         sp_384_from_mp(ctx->p2.x, 12, pX);
         sp_384_from_mp(ctx->p2.y, 12, pY);
@@ -46399,57 +46382,33 @@ int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
         if (err == MP_OKAY)
             ctx->state = 9;
         break;
-    case 9: /* DBLPREP */
-        if (sp_384_iszero_12(ctx->p1.z)) {
-            if (sp_384_iszero_12(ctx->p1.x) && sp_384_iszero_12(ctx->p1.y)) {
-                XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
-                ctx->state = 10;
-                break;
-            }
-            else {
-                /* Y ordinate is not used from here - don't set. */
-                int i;
-                for (i=0; i<12; i++) {
-                    ctx->p1.x[i] = 0;
-                }
-                XMEMCPY(ctx->p1.z, p384_norm_mod, sizeof(p384_norm_mod));
-            }
-        }
-        ctx->state = 11;
-        break;
-    case 10: /* DBL */
-        err = sp_384_proj_point_dbl_12_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->p1,
-            &ctx->p2, ctx->tmp);
-        if (err == MP_OKAY) {
-            ctx->state = 11;
-        }
-        break;
-    case 11: /* MONT */
+    case 9: /* MONT */
         /* (r + n*order).z'.z' mod prime == (u1.G + u2.Q)->x' */
         /* Reload r and convert to Montgomery form. */
-        sp_384_from_mp(ctx->u2, 12, r);
+        sp_384_from_mp(ctx->u2, 12, rm);
         err = sp_384_mod_mul_norm_12(ctx->u2, ctx->u2, p384_mod);
         if (err == MP_OKAY)
-            ctx->state = 12;
+            ctx->state = 10;
         break;
-    case 12: /* SQR */
+    case 10: /* SQR */
         /* u1 = r.z'.z' mod prime */
         sp_384_mont_sqr_12(ctx->p1.z, ctx->p1.z, p384_mod, p384_mp_mod);
-        ctx->state = 13;
+        ctx->state = 11;
         break;
-    case 13: /* MUL */
+    case 11: /* MUL */
         sp_384_mont_mul_12(ctx->u1, ctx->u2, ctx->p1.z, p384_mod, p384_mp_mod);
-        ctx->state = 14;
+        ctx->state = 12;
         break;
-    case 14: /* RES */
+    case 12: /* RES */
+    {
+        int32_t c = 0;
         err = MP_OKAY; /* math okay, now check result */
         *res = (int)(sp_384_cmp_12(ctx->p1.x, ctx->u1) == 0);
         if (*res == 0) {
             sp_digit carry;
-            int32_t c;
 
             /* Reload r and add order. */
-            sp_384_from_mp(ctx->u2, 12, r);
+            sp_384_from_mp(ctx->u2, 12, rm);
             carry = sp_384_add_12(ctx->u2, ctx->u2, p384_order);
             /* Carry means result is greater than mod and is not valid. */
             if (carry == 0) {
@@ -46457,22 +46416,23 @@ int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
 
                 /* Compare with mod and if greater or equal then not valid. */
                 c = sp_384_cmp_12(ctx->u2, p384_mod);
-                if (c < 0) {
-                    /* Convert to Montogomery form */
-                    err = sp_384_mod_mul_norm_12(ctx->u2, ctx->u2, p384_mod);
-                    if (err == MP_OKAY) {
-                        /* u1 = (r + 1*order).z'.z' mod prime */
-                        sp_384_mont_mul_12(ctx->u1, ctx->u2, ctx->p1.z, p384_mod,
-                                                                  p384_mp_mod);
-                        *res = (int)(sp_384_cmp_12(ctx->p1.x, ctx->u1) == 0);
-                    }
-                }
+            }
+        }
+        if ((*res == 0) && (c < 0)) {
+            /* Convert to Montogomery form */
+            err = sp_384_mod_mul_norm_12(ctx->u2, ctx->u2, p384_mod);
+            if (err == MP_OKAY) {
+                /* u1 = (r + 1*order).z'.z' mod prime */
+                sp_384_mont_mul_12(ctx->u1, ctx->u2, ctx->p1.z, p384_mod,
+                                                            p384_mp_mod);
+                *res = (int)(sp_384_cmp_12(ctx->p1.x, ctx->u1) == 0);
             }
         }
         break;
     }
+    } /* switch */
 
-    if (err == MP_OKAY && ctx->state != 14) {
+    if (err == MP_OKAY && ctx->state != 12) {
         err = FP_WOULDBLOCK;
     }
 
@@ -46481,7 +46441,7 @@ int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
 #endif /* WOLFSSL_SP_NONBLOCK */
 
 int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
-    const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
+    const mp_int* pY, const mp_int* pZ, const mp_int* rm, const mp_int* sm,
     int* res, void* heap)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
@@ -46525,7 +46485,7 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
         }
 
         sp_384_from_bin(u1, 12, hash, (int)hashLen);
-        sp_384_from_mp(u2, 12, r);
+        sp_384_from_mp(u2, 12, rm);
         sp_384_from_mp(s, 12, sm);
         sp_384_from_mp(p2->x, 12, pX);
         sp_384_from_mp(p2->y, 12, pY);
@@ -46536,7 +46496,7 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
     if (err == MP_OKAY) {
         /* (r + n*order).z'.z' mod prime == (u1.G + u2.Q)->x' */
         /* Reload r and convert to Montgomery form. */
-        sp_384_from_mp(u2, 12, r);
+        sp_384_from_mp(u2, 12, rm);
         err = sp_384_mod_mul_norm_12(u2, u2, p384_mod);
     }
 
@@ -46547,7 +46507,7 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
         *res = (int)(sp_384_cmp_12(p1->x, u1) == 0);
         if (*res == 0) {
             /* Reload r and add order. */
-            sp_384_from_mp(u2, 12, r);
+            sp_384_from_mp(u2, 12, rm);
             carry = sp_384_add_12(u2, u2, p384_order);
             /* Carry means result is greater than mod and is not valid. */
             if (carry == 0) {
@@ -46556,8 +46516,8 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
                 /* Compare with mod and if greater or equal then not valid. */
                 c = sp_384_cmp_12(u2, p384_mod);
             }
-         }
-         if ((*res == 0) && (c < 0)) {
+        }
+        if ((*res == 0) && (c < 0)) {
             /* Convert to Montogomery form */
             err = sp_384_mod_mul_norm_12(u2, u2, p384_mod);
             if (err == MP_OKAY) {

--- a/wolfcrypt/src/sp_arm64.c
+++ b/wolfcrypt/src/sp_arm64.c
@@ -37947,13 +37947,10 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
             hashLen = 32U;
         }
 
-        sp_256_from_bin(ctx->e, 4, hash, (int)hashLen);
-
         ctx->i = SP_ECC_MAX_SIG_GEN;
         ctx->state = 1;
         break;
     case 1: /* GEN */
-        sp_256_from_mp(ctx->x, 4, priv);
         /* New random point. */
         if (km == NULL || mp_iszero(km)) {
             err = sp_256_ecc_gen_k_4(rng, ctx->k);
@@ -37981,6 +37978,9 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
         c = sp_256_cmp_4(ctx->r, p256_order);
         sp_256_cond_sub_4(ctx->r, ctx->r, p256_order, 0L - (sp_digit)(c >= 0));
         sp_256_norm_4(ctx->r);
+
+        sp_256_from_mp(ctx->x, 4, priv);
+        sp_256_from_bin(ctx->e, 4, hash, (int)hashLen);
         ctx->state = 4;
         break;
     }
@@ -38037,6 +38037,9 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
             ctx->state = 10;
             break;
         }
+    #ifdef WOLFSSL_ECDSA_SET_K_ONE_LOOP
+        ctx->i = 1;
+    #endif
 
         /* not usable gen, try again */
         ctx->i--;
@@ -38599,7 +38602,7 @@ typedef struct sp_ecc_verify_256_ctx {
 
 int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
     word32 hashLen, const mp_int* pX, const mp_int* pY, const mp_int* pZ,
-    const mp_int* r, const mp_int* sm, int* res, void* heap)
+    const mp_int* rm, const mp_int* sm, int* res, void* heap)
 {
     int err = FP_WOULDBLOCK;
     sp_ecc_verify_256_ctx* ctx = (sp_ecc_verify_256_ctx*)sp_ctx->data;
@@ -38614,7 +38617,7 @@ int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
         }
 
         sp_256_from_bin(ctx->u1, 4, hash, (int)hashLen);
-        sp_256_from_mp(ctx->u2, 4, r);
+        sp_256_from_mp(ctx->u2, 4, rm);
         sp_256_from_mp(ctx->s, 4, sm);
         sp_256_from_mp(ctx->p2.x, 4, pX);
         sp_256_from_mp(ctx->p2.y, 4, pY);
@@ -38672,57 +38675,33 @@ int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
         if (err == MP_OKAY)
             ctx->state = 9;
         break;
-    case 9: /* DBLPREP */
-        if (sp_256_iszero_4(ctx->p1.z)) {
-            if (sp_256_iszero_4(ctx->p1.x) && sp_256_iszero_4(ctx->p1.y)) {
-                XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
-                ctx->state = 10;
-                break;
-            }
-            else {
-                /* Y ordinate is not used from here - don't set. */
-                int i;
-                for (i=0; i<4; i++) {
-                    ctx->p1.x[i] = 0;
-                }
-                XMEMCPY(ctx->p1.z, p256_norm_mod, sizeof(p256_norm_mod));
-            }
-        }
-        ctx->state = 11;
-        break;
-    case 10: /* DBL */
-        err = sp_256_proj_point_dbl_4_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->p1,
-            &ctx->p2, ctx->tmp);
-        if (err == MP_OKAY) {
-            ctx->state = 11;
-        }
-        break;
-    case 11: /* MONT */
+    case 9: /* MONT */
         /* (r + n*order).z'.z' mod prime == (u1.G + u2.Q)->x' */
         /* Reload r and convert to Montgomery form. */
-        sp_256_from_mp(ctx->u2, 4, r);
+        sp_256_from_mp(ctx->u2, 4, rm);
         err = sp_256_mod_mul_norm_4(ctx->u2, ctx->u2, p256_mod);
         if (err == MP_OKAY)
-            ctx->state = 12;
+            ctx->state = 10;
         break;
-    case 12: /* SQR */
+    case 10: /* SQR */
         /* u1 = r.z'.z' mod prime */
         sp_256_mont_sqr_4(ctx->p1.z, ctx->p1.z, p256_mod, p256_mp_mod);
-        ctx->state = 13;
+        ctx->state = 11;
         break;
-    case 13: /* MUL */
+    case 11: /* MUL */
         sp_256_mont_mul_4(ctx->u1, ctx->u2, ctx->p1.z, p256_mod, p256_mp_mod);
-        ctx->state = 14;
+        ctx->state = 12;
         break;
-    case 14: /* RES */
+    case 12: /* RES */
+    {
+        int64_t c = 0;
         err = MP_OKAY; /* math okay, now check result */
         *res = (int)(sp_256_cmp_4(ctx->p1.x, ctx->u1) == 0);
         if (*res == 0) {
             sp_digit carry;
-            int64_t c;
 
             /* Reload r and add order. */
-            sp_256_from_mp(ctx->u2, 4, r);
+            sp_256_from_mp(ctx->u2, 4, rm);
             carry = sp_256_add_4(ctx->u2, ctx->u2, p256_order);
             /* Carry means result is greater than mod and is not valid. */
             if (carry == 0) {
@@ -38730,22 +38709,23 @@ int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
 
                 /* Compare with mod and if greater or equal then not valid. */
                 c = sp_256_cmp_4(ctx->u2, p256_mod);
-                if (c < 0) {
-                    /* Convert to Montogomery form */
-                    err = sp_256_mod_mul_norm_4(ctx->u2, ctx->u2, p256_mod);
-                    if (err == MP_OKAY) {
-                        /* u1 = (r + 1*order).z'.z' mod prime */
-                        sp_256_mont_mul_4(ctx->u1, ctx->u2, ctx->p1.z, p256_mod,
-                                                                  p256_mp_mod);
-                        *res = (int)(sp_256_cmp_4(ctx->p1.x, ctx->u1) == 0);
-                    }
-                }
+            }
+        }
+        if ((*res == 0) && (c < 0)) {
+            /* Convert to Montogomery form */
+            err = sp_256_mod_mul_norm_4(ctx->u2, ctx->u2, p256_mod);
+            if (err == MP_OKAY) {
+                /* u1 = (r + 1*order).z'.z' mod prime */
+                sp_256_mont_mul_4(ctx->u1, ctx->u2, ctx->p1.z, p256_mod,
+                                                            p256_mp_mod);
+                *res = (int)(sp_256_cmp_4(ctx->p1.x, ctx->u1) == 0);
             }
         }
         break;
     }
+    } /* switch */
 
-    if (err == MP_OKAY && ctx->state != 14) {
+    if (err == MP_OKAY && ctx->state != 12) {
         err = FP_WOULDBLOCK;
     }
 
@@ -38754,7 +38734,7 @@ int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
 #endif /* WOLFSSL_SP_NONBLOCK */
 
 int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
-    const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
+    const mp_int* pY, const mp_int* pZ, const mp_int* rm, const mp_int* sm,
     int* res, void* heap)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
@@ -38798,7 +38778,7 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
         }
 
         sp_256_from_bin(u1, 4, hash, (int)hashLen);
-        sp_256_from_mp(u2, 4, r);
+        sp_256_from_mp(u2, 4, rm);
         sp_256_from_mp(s, 4, sm);
         sp_256_from_mp(p2->x, 4, pX);
         sp_256_from_mp(p2->y, 4, pY);
@@ -38809,7 +38789,7 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
     if (err == MP_OKAY) {
         /* (r + n*order).z'.z' mod prime == (u1.G + u2.Q)->x' */
         /* Reload r and convert to Montgomery form. */
-        sp_256_from_mp(u2, 4, r);
+        sp_256_from_mp(u2, 4, rm);
         err = sp_256_mod_mul_norm_4(u2, u2, p256_mod);
     }
 
@@ -38820,7 +38800,7 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
         *res = (int)(sp_256_cmp_4(p1->x, u1) == 0);
         if (*res == 0) {
             /* Reload r and add order. */
-            sp_256_from_mp(u2, 4, r);
+            sp_256_from_mp(u2, 4, rm);
             carry = sp_256_add_4(u2, u2, p256_order);
             /* Carry means result is greater than mod and is not valid. */
             if (carry == 0) {
@@ -38829,8 +38809,8 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
                 /* Compare with mod and if greater or equal then not valid. */
                 c = sp_256_cmp_4(u2, p256_mod);
             }
-         }
-         if ((*res == 0) && (c < 0)) {
+        }
+        if ((*res == 0) && (c < 0)) {
             /* Convert to Montogomery form */
             err = sp_256_mod_mul_norm_4(u2, u2, p256_mod);
             if (err == MP_OKAY) {
@@ -63710,13 +63690,10 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
             hashLen = 48U;
         }
 
-        sp_384_from_bin(ctx->e, 6, hash, (int)hashLen);
-
         ctx->i = SP_ECC_MAX_SIG_GEN;
         ctx->state = 1;
         break;
     case 1: /* GEN */
-        sp_384_from_mp(ctx->x, 6, priv);
         /* New random point. */
         if (km == NULL || mp_iszero(km)) {
             err = sp_384_ecc_gen_k_6(rng, ctx->k);
@@ -63744,6 +63721,9 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
         c = sp_384_cmp_6(ctx->r, p384_order);
         sp_384_cond_sub_6(ctx->r, ctx->r, p384_order, 0L - (sp_digit)(c >= 0));
         sp_384_norm_6(ctx->r);
+
+        sp_384_from_mp(ctx->x, 6, priv);
+        sp_384_from_bin(ctx->e, 6, hash, (int)hashLen);
         ctx->state = 4;
         break;
     }
@@ -63800,6 +63780,9 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
             ctx->state = 10;
             break;
         }
+    #ifdef WOLFSSL_ECDSA_SET_K_ONE_LOOP
+        ctx->i = 1;
+    #endif
 
         /* not usable gen, try again */
         ctx->i--;
@@ -64247,7 +64230,7 @@ typedef struct sp_ecc_verify_384_ctx {
 
 int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
     word32 hashLen, const mp_int* pX, const mp_int* pY, const mp_int* pZ,
-    const mp_int* r, const mp_int* sm, int* res, void* heap)
+    const mp_int* rm, const mp_int* sm, int* res, void* heap)
 {
     int err = FP_WOULDBLOCK;
     sp_ecc_verify_384_ctx* ctx = (sp_ecc_verify_384_ctx*)sp_ctx->data;
@@ -64262,7 +64245,7 @@ int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
         }
 
         sp_384_from_bin(ctx->u1, 6, hash, (int)hashLen);
-        sp_384_from_mp(ctx->u2, 6, r);
+        sp_384_from_mp(ctx->u2, 6, rm);
         sp_384_from_mp(ctx->s, 6, sm);
         sp_384_from_mp(ctx->p2.x, 6, pX);
         sp_384_from_mp(ctx->p2.y, 6, pY);
@@ -64320,57 +64303,33 @@ int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
         if (err == MP_OKAY)
             ctx->state = 9;
         break;
-    case 9: /* DBLPREP */
-        if (sp_384_iszero_6(ctx->p1.z)) {
-            if (sp_384_iszero_6(ctx->p1.x) && sp_384_iszero_6(ctx->p1.y)) {
-                XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
-                ctx->state = 10;
-                break;
-            }
-            else {
-                /* Y ordinate is not used from here - don't set. */
-                int i;
-                for (i=0; i<6; i++) {
-                    ctx->p1.x[i] = 0;
-                }
-                XMEMCPY(ctx->p1.z, p384_norm_mod, sizeof(p384_norm_mod));
-            }
-        }
-        ctx->state = 11;
-        break;
-    case 10: /* DBL */
-        err = sp_384_proj_point_dbl_6_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->p1,
-            &ctx->p2, ctx->tmp);
-        if (err == MP_OKAY) {
-            ctx->state = 11;
-        }
-        break;
-    case 11: /* MONT */
+    case 9: /* MONT */
         /* (r + n*order).z'.z' mod prime == (u1.G + u2.Q)->x' */
         /* Reload r and convert to Montgomery form. */
-        sp_384_from_mp(ctx->u2, 6, r);
+        sp_384_from_mp(ctx->u2, 6, rm);
         err = sp_384_mod_mul_norm_6(ctx->u2, ctx->u2, p384_mod);
         if (err == MP_OKAY)
-            ctx->state = 12;
+            ctx->state = 10;
         break;
-    case 12: /* SQR */
+    case 10: /* SQR */
         /* u1 = r.z'.z' mod prime */
         sp_384_mont_sqr_6(ctx->p1.z, ctx->p1.z, p384_mod, p384_mp_mod);
-        ctx->state = 13;
+        ctx->state = 11;
         break;
-    case 13: /* MUL */
+    case 11: /* MUL */
         sp_384_mont_mul_6(ctx->u1, ctx->u2, ctx->p1.z, p384_mod, p384_mp_mod);
-        ctx->state = 14;
+        ctx->state = 12;
         break;
-    case 14: /* RES */
+    case 12: /* RES */
+    {
+        int64_t c = 0;
         err = MP_OKAY; /* math okay, now check result */
         *res = (int)(sp_384_cmp_6(ctx->p1.x, ctx->u1) == 0);
         if (*res == 0) {
             sp_digit carry;
-            int64_t c;
 
             /* Reload r and add order. */
-            sp_384_from_mp(ctx->u2, 6, r);
+            sp_384_from_mp(ctx->u2, 6, rm);
             carry = sp_384_add_6(ctx->u2, ctx->u2, p384_order);
             /* Carry means result is greater than mod and is not valid. */
             if (carry == 0) {
@@ -64378,22 +64337,23 @@ int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
 
                 /* Compare with mod and if greater or equal then not valid. */
                 c = sp_384_cmp_6(ctx->u2, p384_mod);
-                if (c < 0) {
-                    /* Convert to Montogomery form */
-                    err = sp_384_mod_mul_norm_6(ctx->u2, ctx->u2, p384_mod);
-                    if (err == MP_OKAY) {
-                        /* u1 = (r + 1*order).z'.z' mod prime */
-                        sp_384_mont_mul_6(ctx->u1, ctx->u2, ctx->p1.z, p384_mod,
-                                                                  p384_mp_mod);
-                        *res = (int)(sp_384_cmp_6(ctx->p1.x, ctx->u1) == 0);
-                    }
-                }
+            }
+        }
+        if ((*res == 0) && (c < 0)) {
+            /* Convert to Montogomery form */
+            err = sp_384_mod_mul_norm_6(ctx->u2, ctx->u2, p384_mod);
+            if (err == MP_OKAY) {
+                /* u1 = (r + 1*order).z'.z' mod prime */
+                sp_384_mont_mul_6(ctx->u1, ctx->u2, ctx->p1.z, p384_mod,
+                                                            p384_mp_mod);
+                *res = (int)(sp_384_cmp_6(ctx->p1.x, ctx->u1) == 0);
             }
         }
         break;
     }
+    } /* switch */
 
-    if (err == MP_OKAY && ctx->state != 14) {
+    if (err == MP_OKAY && ctx->state != 12) {
         err = FP_WOULDBLOCK;
     }
 
@@ -64402,7 +64362,7 @@ int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
 #endif /* WOLFSSL_SP_NONBLOCK */
 
 int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
-    const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
+    const mp_int* pY, const mp_int* pZ, const mp_int* rm, const mp_int* sm,
     int* res, void* heap)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
@@ -64446,7 +64406,7 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
         }
 
         sp_384_from_bin(u1, 6, hash, (int)hashLen);
-        sp_384_from_mp(u2, 6, r);
+        sp_384_from_mp(u2, 6, rm);
         sp_384_from_mp(s, 6, sm);
         sp_384_from_mp(p2->x, 6, pX);
         sp_384_from_mp(p2->y, 6, pY);
@@ -64457,7 +64417,7 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
     if (err == MP_OKAY) {
         /* (r + n*order).z'.z' mod prime == (u1.G + u2.Q)->x' */
         /* Reload r and convert to Montgomery form. */
-        sp_384_from_mp(u2, 6, r);
+        sp_384_from_mp(u2, 6, rm);
         err = sp_384_mod_mul_norm_6(u2, u2, p384_mod);
     }
 
@@ -64468,7 +64428,7 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
         *res = (int)(sp_384_cmp_6(p1->x, u1) == 0);
         if (*res == 0) {
             /* Reload r and add order. */
-            sp_384_from_mp(u2, 6, r);
+            sp_384_from_mp(u2, 6, rm);
             carry = sp_384_add_6(u2, u2, p384_order);
             /* Carry means result is greater than mod and is not valid. */
             if (carry == 0) {
@@ -64477,8 +64437,8 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
                 /* Compare with mod and if greater or equal then not valid. */
                 c = sp_384_cmp_6(u2, p384_mod);
             }
-         }
-         if ((*res == 0) && (c < 0)) {
+        }
+        if ((*res == 0) && (c < 0)) {
             /* Convert to Montogomery form */
             err = sp_384_mod_mul_norm_6(u2, u2, p384_mod);
             if (err == MP_OKAY) {

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -14499,7 +14499,7 @@ static int sp_256_ecc_mulmod_10(sp_point_256* r, const sp_point_256* g,
     int y;
     int err = MP_OKAY;
 
-    /* Implementatio is constant time. */
+    /* Implementation is constant time. */
     (void)ct;
     (void)heap;
 
@@ -18080,13 +18080,10 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
             hashLen = 32U;
         }
 
-        sp_256_from_bin(ctx->e, 10, hash, (int)hashLen);
-
         ctx->i = SP_ECC_MAX_SIG_GEN;
         ctx->state = 1;
         break;
     case 1: /* GEN */
-        sp_256_from_mp(ctx->x, 10, priv);
         /* New random point. */
         if (km == NULL || mp_iszero(km)) {
             err = sp_256_ecc_gen_k_10(rng, ctx->k);
@@ -18114,6 +18111,9 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
         c = sp_256_cmp_10(ctx->r, p256_order);
         sp_256_cond_sub_10(ctx->r, ctx->r, p256_order, 0L - (sp_digit)(c >= 0));
         sp_256_norm_10(ctx->r);
+
+        sp_256_from_mp(ctx->x, 10, priv);
+        sp_256_from_bin(ctx->e, 10, hash, (int)hashLen);
         ctx->state = 4;
         break;
     }
@@ -18170,6 +18170,9 @@ int sp_ecc_sign_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
             ctx->state = 10;
             break;
         }
+    #ifdef WOLFSSL_ECDSA_SET_K_ONE_LOOP
+        ctx->i = 1;
+    #endif
 
         /* not usable gen, try again */
         ctx->i--;
@@ -18603,7 +18606,7 @@ typedef struct sp_ecc_verify_256_ctx {
 
 int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
     word32 hashLen, const mp_int* pX, const mp_int* pY, const mp_int* pZ,
-    const mp_int* r, const mp_int* sm, int* res, void* heap)
+    const mp_int* rm, const mp_int* sm, int* res, void* heap)
 {
     int err = FP_WOULDBLOCK;
     sp_ecc_verify_256_ctx* ctx = (sp_ecc_verify_256_ctx*)sp_ctx->data;
@@ -18618,7 +18621,7 @@ int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
         }
 
         sp_256_from_bin(ctx->u1, 10, hash, (int)hashLen);
-        sp_256_from_mp(ctx->u2, 10, r);
+        sp_256_from_mp(ctx->u2, 10, rm);
         sp_256_from_mp(ctx->s, 10, sm);
         sp_256_from_mp(ctx->p2.x, 10, pX);
         sp_256_from_mp(ctx->p2.y, 10, pY);
@@ -18676,57 +18679,33 @@ int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
         if (err == MP_OKAY)
             ctx->state = 9;
         break;
-    case 9: /* DBLPREP */
-        if (sp_256_iszero_10(ctx->p1.z)) {
-            if (sp_256_iszero_10(ctx->p1.x) && sp_256_iszero_10(ctx->p1.y)) {
-                XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
-                ctx->state = 10;
-                break;
-            }
-            else {
-                /* Y ordinate is not used from here - don't set. */
-                int i;
-                for (i=0; i<10; i++) {
-                    ctx->p1.x[i] = 0;
-                }
-                XMEMCPY(ctx->p1.z, p256_norm_mod, sizeof(p256_norm_mod));
-            }
-        }
-        ctx->state = 11;
-        break;
-    case 10: /* DBL */
-        err = sp_256_proj_point_dbl_10_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->p1,
-            &ctx->p2, ctx->tmp);
-        if (err == MP_OKAY) {
-            ctx->state = 11;
-        }
-        break;
-    case 11: /* MONT */
+    case 9: /* MONT */
         /* (r + n*order).z'.z' mod prime == (u1.G + u2.Q)->x' */
         /* Reload r and convert to Montgomery form. */
-        sp_256_from_mp(ctx->u2, 10, r);
+        sp_256_from_mp(ctx->u2, 10, rm);
         err = sp_256_mod_mul_norm_10(ctx->u2, ctx->u2, p256_mod);
         if (err == MP_OKAY)
-            ctx->state = 12;
+            ctx->state = 10;
         break;
-    case 12: /* SQR */
+    case 10: /* SQR */
         /* u1 = r.z'.z' mod prime */
         sp_256_mont_sqr_10(ctx->p1.z, ctx->p1.z, p256_mod, p256_mp_mod);
-        ctx->state = 13;
+        ctx->state = 11;
         break;
-    case 13: /* MUL */
+    case 11: /* MUL */
         sp_256_mont_mul_10(ctx->u1, ctx->u2, ctx->p1.z, p256_mod, p256_mp_mod);
-        ctx->state = 14;
+        ctx->state = 12;
         break;
-    case 14: /* RES */
+    case 12: /* RES */
+    {
+        int32_t c = 0;
         err = MP_OKAY; /* math okay, now check result */
         *res = (int)(sp_256_cmp_10(ctx->p1.x, ctx->u1) == 0);
         if (*res == 0) {
             sp_digit carry;
-            int32_t c;
 
             /* Reload r and add order. */
-            sp_256_from_mp(ctx->u2, 10, r);
+            sp_256_from_mp(ctx->u2, 10, rm);
             carry = sp_256_add_10(ctx->u2, ctx->u2, p256_order);
             /* Carry means result is greater than mod and is not valid. */
             if (carry == 0) {
@@ -18734,22 +18713,23 @@ int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
 
                 /* Compare with mod and if greater or equal then not valid. */
                 c = sp_256_cmp_10(ctx->u2, p256_mod);
-                if (c < 0) {
-                    /* Convert to Montogomery form */
-                    err = sp_256_mod_mul_norm_10(ctx->u2, ctx->u2, p256_mod);
-                    if (err == MP_OKAY) {
-                        /* u1 = (r + 1*order).z'.z' mod prime */
-                        sp_256_mont_mul_10(ctx->u1, ctx->u2, ctx->p1.z, p256_mod,
-                                                                  p256_mp_mod);
-                        *res = (int)(sp_256_cmp_10(ctx->p1.x, ctx->u1) == 0);
-                    }
-                }
+            }
+        }
+        if ((*res == 0) && (c < 0)) {
+            /* Convert to Montogomery form */
+            err = sp_256_mod_mul_norm_10(ctx->u2, ctx->u2, p256_mod);
+            if (err == MP_OKAY) {
+                /* u1 = (r + 1*order).z'.z' mod prime */
+                sp_256_mont_mul_10(ctx->u1, ctx->u2, ctx->p1.z, p256_mod,
+                                                            p256_mp_mod);
+                *res = (int)(sp_256_cmp_10(ctx->p1.x, ctx->u1) == 0);
             }
         }
         break;
     }
+    } /* switch */
 
-    if (err == MP_OKAY && ctx->state != 14) {
+    if (err == MP_OKAY && ctx->state != 12) {
         err = FP_WOULDBLOCK;
     }
 
@@ -18758,7 +18738,7 @@ int sp_ecc_verify_256_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
 #endif /* WOLFSSL_SP_NONBLOCK */
 
 int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
-    const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
+    const mp_int* pY, const mp_int* pZ, const mp_int* rm, const mp_int* sm,
     int* res, void* heap)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
@@ -18802,7 +18782,7 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
         }
 
         sp_256_from_bin(u1, 10, hash, (int)hashLen);
-        sp_256_from_mp(u2, 10, r);
+        sp_256_from_mp(u2, 10, rm);
         sp_256_from_mp(s, 10, sm);
         sp_256_from_mp(p2->x, 10, pX);
         sp_256_from_mp(p2->y, 10, pY);
@@ -18813,7 +18793,7 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
     if (err == MP_OKAY) {
         /* (r + n*order).z'.z' mod prime == (u1.G + u2.Q)->x' */
         /* Reload r and convert to Montgomery form. */
-        sp_256_from_mp(u2, 10, r);
+        sp_256_from_mp(u2, 10, rm);
         err = sp_256_mod_mul_norm_10(u2, u2, p256_mod);
     }
 
@@ -18824,7 +18804,7 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
         *res = (int)(sp_256_cmp_10(p1->x, u1) == 0);
         if (*res == 0) {
             /* Reload r and add order. */
-            sp_256_from_mp(u2, 10, r);
+            sp_256_from_mp(u2, 10, rm);
             carry = sp_256_add_10(u2, u2, p256_order);
             /* Carry means result is greater than mod and is not valid. */
             if (carry == 0) {
@@ -18833,8 +18813,8 @@ int sp_ecc_verify_256(const byte* hash, word32 hashLen, const mp_int* pX,
                 /* Compare with mod and if greater or equal then not valid. */
                 c = sp_256_cmp_10(u2, p256_mod);
             }
-         }
-         if ((*res == 0) && (c < 0)) {
+        }
+        if ((*res == 0) && (c < 0)) {
             /* Convert to Montogomery form */
             err = sp_256_mod_mul_norm_10(u2, u2, p256_mod);
             if (err == MP_OKAY) {
@@ -21675,7 +21655,7 @@ static int sp_384_ecc_mulmod_15(sp_point_384* r, const sp_point_384* g,
     int y;
     int err = MP_OKAY;
 
-    /* Implementatio is constant time. */
+    /* Implementation is constant time. */
     (void)ct;
     (void)heap;
 
@@ -25807,13 +25787,10 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
             hashLen = 48U;
         }
 
-        sp_384_from_bin(ctx->e, 15, hash, (int)hashLen);
-
         ctx->i = SP_ECC_MAX_SIG_GEN;
         ctx->state = 1;
         break;
     case 1: /* GEN */
-        sp_384_from_mp(ctx->x, 15, priv);
         /* New random point. */
         if (km == NULL || mp_iszero(km)) {
             err = sp_384_ecc_gen_k_15(rng, ctx->k);
@@ -25841,6 +25818,9 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
         c = sp_384_cmp_15(ctx->r, p384_order);
         sp_384_cond_sub_15(ctx->r, ctx->r, p384_order, 0L - (sp_digit)(c >= 0));
         sp_384_norm_15(ctx->r);
+
+        sp_384_from_mp(ctx->x, 15, priv);
+        sp_384_from_bin(ctx->e, 15, hash, (int)hashLen);
         ctx->state = 4;
         break;
     }
@@ -25897,6 +25877,9 @@ int sp_ecc_sign_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash, word32 hashLen, W
             ctx->state = 10;
             break;
         }
+    #ifdef WOLFSSL_ECDSA_SET_K_ONE_LOOP
+        ctx->i = 1;
+    #endif
 
         /* not usable gen, try again */
         ctx->i--;
@@ -26335,7 +26318,7 @@ typedef struct sp_ecc_verify_384_ctx {
 
 int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
     word32 hashLen, const mp_int* pX, const mp_int* pY, const mp_int* pZ,
-    const mp_int* r, const mp_int* sm, int* res, void* heap)
+    const mp_int* rm, const mp_int* sm, int* res, void* heap)
 {
     int err = FP_WOULDBLOCK;
     sp_ecc_verify_384_ctx* ctx = (sp_ecc_verify_384_ctx*)sp_ctx->data;
@@ -26350,7 +26333,7 @@ int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
         }
 
         sp_384_from_bin(ctx->u1, 15, hash, (int)hashLen);
-        sp_384_from_mp(ctx->u2, 15, r);
+        sp_384_from_mp(ctx->u2, 15, rm);
         sp_384_from_mp(ctx->s, 15, sm);
         sp_384_from_mp(ctx->p2.x, 15, pX);
         sp_384_from_mp(ctx->p2.y, 15, pY);
@@ -26408,57 +26391,33 @@ int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
         if (err == MP_OKAY)
             ctx->state = 9;
         break;
-    case 9: /* DBLPREP */
-        if (sp_384_iszero_15(ctx->p1.z)) {
-            if (sp_384_iszero_15(ctx->p1.x) && sp_384_iszero_15(ctx->p1.y)) {
-                XMEMSET(&ctx->dbl_ctx, 0, sizeof(ctx->dbl_ctx));
-                ctx->state = 10;
-                break;
-            }
-            else {
-                /* Y ordinate is not used from here - don't set. */
-                int i;
-                for (i=0; i<15; i++) {
-                    ctx->p1.x[i] = 0;
-                }
-                XMEMCPY(ctx->p1.z, p384_norm_mod, sizeof(p384_norm_mod));
-            }
-        }
-        ctx->state = 11;
-        break;
-    case 10: /* DBL */
-        err = sp_384_proj_point_dbl_15_nb((sp_ecc_ctx_t*)&ctx->dbl_ctx, &ctx->p1,
-            &ctx->p2, ctx->tmp);
-        if (err == MP_OKAY) {
-            ctx->state = 11;
-        }
-        break;
-    case 11: /* MONT */
+    case 9: /* MONT */
         /* (r + n*order).z'.z' mod prime == (u1.G + u2.Q)->x' */
         /* Reload r and convert to Montgomery form. */
-        sp_384_from_mp(ctx->u2, 15, r);
+        sp_384_from_mp(ctx->u2, 15, rm);
         err = sp_384_mod_mul_norm_15(ctx->u2, ctx->u2, p384_mod);
         if (err == MP_OKAY)
-            ctx->state = 12;
+            ctx->state = 10;
         break;
-    case 12: /* SQR */
+    case 10: /* SQR */
         /* u1 = r.z'.z' mod prime */
         sp_384_mont_sqr_15(ctx->p1.z, ctx->p1.z, p384_mod, p384_mp_mod);
-        ctx->state = 13;
+        ctx->state = 11;
         break;
-    case 13: /* MUL */
+    case 11: /* MUL */
         sp_384_mont_mul_15(ctx->u1, ctx->u2, ctx->p1.z, p384_mod, p384_mp_mod);
-        ctx->state = 14;
+        ctx->state = 12;
         break;
-    case 14: /* RES */
+    case 12: /* RES */
+    {
+        int32_t c = 0;
         err = MP_OKAY; /* math okay, now check result */
         *res = (int)(sp_384_cmp_15(ctx->p1.x, ctx->u1) == 0);
         if (*res == 0) {
             sp_digit carry;
-            int32_t c;
 
             /* Reload r and add order. */
-            sp_384_from_mp(ctx->u2, 15, r);
+            sp_384_from_mp(ctx->u2, 15, rm);
             carry = sp_384_add_15(ctx->u2, ctx->u2, p384_order);
             /* Carry means result is greater than mod and is not valid. */
             if (carry == 0) {
@@ -26466,22 +26425,23 @@ int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
 
                 /* Compare with mod and if greater or equal then not valid. */
                 c = sp_384_cmp_15(ctx->u2, p384_mod);
-                if (c < 0) {
-                    /* Convert to Montogomery form */
-                    err = sp_384_mod_mul_norm_15(ctx->u2, ctx->u2, p384_mod);
-                    if (err == MP_OKAY) {
-                        /* u1 = (r + 1*order).z'.z' mod prime */
-                        sp_384_mont_mul_15(ctx->u1, ctx->u2, ctx->p1.z, p384_mod,
-                                                                  p384_mp_mod);
-                        *res = (int)(sp_384_cmp_15(ctx->p1.x, ctx->u1) == 0);
-                    }
-                }
+            }
+        }
+        if ((*res == 0) && (c < 0)) {
+            /* Convert to Montogomery form */
+            err = sp_384_mod_mul_norm_15(ctx->u2, ctx->u2, p384_mod);
+            if (err == MP_OKAY) {
+                /* u1 = (r + 1*order).z'.z' mod prime */
+                sp_384_mont_mul_15(ctx->u1, ctx->u2, ctx->p1.z, p384_mod,
+                                                            p384_mp_mod);
+                *res = (int)(sp_384_cmp_15(ctx->p1.x, ctx->u1) == 0);
             }
         }
         break;
     }
+    } /* switch */
 
-    if (err == MP_OKAY && ctx->state != 14) {
+    if (err == MP_OKAY && ctx->state != 12) {
         err = FP_WOULDBLOCK;
     }
 
@@ -26490,7 +26450,7 @@ int sp_ecc_verify_384_nb(sp_ecc_ctx_t* sp_ctx, const byte* hash,
 #endif /* WOLFSSL_SP_NONBLOCK */
 
 int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
-    const mp_int* pY, const mp_int* pZ, const mp_int* r, const mp_int* sm,
+    const mp_int* pY, const mp_int* pZ, const mp_int* rm, const mp_int* sm,
     int* res, void* heap)
 {
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
@@ -26534,7 +26494,7 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
         }
 
         sp_384_from_bin(u1, 15, hash, (int)hashLen);
-        sp_384_from_mp(u2, 15, r);
+        sp_384_from_mp(u2, 15, rm);
         sp_384_from_mp(s, 15, sm);
         sp_384_from_mp(p2->x, 15, pX);
         sp_384_from_mp(p2->y, 15, pY);
@@ -26545,7 +26505,7 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
     if (err == MP_OKAY) {
         /* (r + n*order).z'.z' mod prime == (u1.G + u2.Q)->x' */
         /* Reload r and convert to Montgomery form. */
-        sp_384_from_mp(u2, 15, r);
+        sp_384_from_mp(u2, 15, rm);
         err = sp_384_mod_mul_norm_15(u2, u2, p384_mod);
     }
 
@@ -26556,7 +26516,7 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
         *res = (int)(sp_384_cmp_15(p1->x, u1) == 0);
         if (*res == 0) {
             /* Reload r and add order. */
-            sp_384_from_mp(u2, 15, r);
+            sp_384_from_mp(u2, 15, rm);
             carry = sp_384_add_15(u2, u2, p384_order);
             /* Carry means result is greater than mod and is not valid. */
             if (carry == 0) {
@@ -26565,8 +26525,8 @@ int sp_ecc_verify_384(const byte* hash, word32 hashLen, const mp_int* pX,
                 /* Compare with mod and if greater or equal then not valid. */
                 c = sp_384_cmp_15(u2, p384_mod);
             }
-         }
-         if ((*res == 0) && (c < 0)) {
+        }
+        if ((*res == 0) && (c < 0)) {
             /* Convert to Montogomery form */
             err = sp_384_mod_mul_norm_15(u2, u2, p384_mod);
             if (err == MP_OKAY) {
@@ -29469,7 +29429,7 @@ static int sp_1024_ecc_mulmod_42(sp_point_1024* r, const sp_point_1024* g,
     int y;
     int err = MP_OKAY;
 
-    /* Implementatio is constant time. */
+    /* Implementation is constant time. */
     (void)ct;
     (void)heap;
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -23248,7 +23248,7 @@ static int crypto_ecc_verify(const uint8_t *key, uint32_t keySz,
             );
             count++;
 
-            /* TODO: Real-time work can be called here */
+            /* This is where real-time work could be called */
         } while (ret == FP_WOULDBLOCK);
     #ifdef DEBUG_WOLFSSL
         printf("ECC non-block verify: %d times\n", count);
@@ -23332,7 +23332,7 @@ static int crypto_ecc_sign(const uint8_t *key, uint32_t keySz,
             );
             count++;
 
-            /* TODO: Real-time work can be called here */
+            /* This is where real-time work could be called */
         } while (ret == FP_WOULDBLOCK);
 
     #ifdef DEBUG_WOLFSSL
@@ -23342,8 +23342,8 @@ static int crypto_ecc_sign(const uint8_t *key, uint32_t keySz,
 
     if (ret == 0) {
         /* export r/s */
-        mp_to_unsigned_bin(&r, sig);
-        mp_to_unsigned_bin(&s, sig + curveSz);
+        mp_to_unsigned_bin_len(&r, sig, curveSz);
+        mp_to_unsigned_bin_len(&s, sig + curveSz, curveSz);
     }
 
     mp_clear(&r);


### PR DESCRIPTION
* Fix for ECC non-blocking test R/S values not zero padded causing occasstional wolfCrypt test failures with `./configure --enable-ecc=nonblock --enable-sp=yes,nonblock CFLAGS="-DWOLFSSL_PUBLIC_MP"`.
* Synchronization of SP ECC non-blocking code. Adds `WOLFSSL_ECDSA_SET_K_ONE_LOOP` support to SP ECC non-block. Removes double code in verify steps. Fixes verify result logic. Spelling error.
