### PR TITLE
Return code compliant with OpenSSL

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -38287,7 +38287,16 @@ static void test_EVP_PKEY_cmp(void)
         &in, (long)sizeof_client_key_der_2048));
 
     /* Test success case RSA */
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    /* return compliant with OpneSSL */
+    /* 1 : match                     */
+    /* 0 : dont match                */
+    /* -1 : different type           */
+    /* -2 : not support              */
+    AssertIntEQ(EVP_PKEY_cmp(a, b), 1);
+#else
     AssertIntEQ(EVP_PKEY_cmp(a, b), 0);
+#endif
 
     EVP_PKEY_free(b);
     EVP_PKEY_free(a);
@@ -38302,7 +38311,11 @@ static void test_EVP_PKEY_cmp(void)
         &in, (long)sizeof_ecc_clikey_der_256));
 
     /* Test success case ECC */
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    AssertIntEQ(EVP_PKEY_cmp(a, b), 1);
+#else
     AssertIntEQ(EVP_PKEY_cmp(a, b), 0);
+#endif
 
     EVP_PKEY_free(b);
     EVP_PKEY_free(a);
@@ -38318,8 +38331,11 @@ static void test_EVP_PKEY_cmp(void)
     in = ecc_clikey_der_256;
     AssertNotNull(b = wolfSSL_d2i_PrivateKey(EVP_PKEY_EC, NULL,
         &in, (long)sizeof_ecc_clikey_der_256));
-
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    AssertIntEQ(EVP_PKEY_cmp(a, b), -1);
+#else
     AssertIntNE(EVP_PKEY_cmp(a, b), 0);
+#endif
 
     EVP_PKEY_free(b);
     EVP_PKEY_free(a);
@@ -38328,10 +38344,20 @@ static void test_EVP_PKEY_cmp(void)
     /* invalid or empty failure cases */
     a = EVP_PKEY_new();
     b = EVP_PKEY_new();
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    AssertIntEQ(EVP_PKEY_cmp(NULL, NULL), 0);
+    AssertIntEQ(EVP_PKEY_cmp(a, NULL), 0);
+    AssertIntEQ(EVP_PKEY_cmp(NULL, b), 0);
+    AssertIntEQ(EVP_PKEY_cmp(a, b), 0);
+    /* not support type */
+    a->type = b->type = EVP_PKEY_DSA;
+    AssertIntEQ(EVP_PKEY_cmp(a, b), -2);
+#else
     AssertIntNE(EVP_PKEY_cmp(NULL, NULL), 0);
     AssertIntNE(EVP_PKEY_cmp(a, NULL), 0);
     AssertIntNE(EVP_PKEY_cmp(NULL, b), 0);
     AssertIntNE(EVP_PKEY_cmp(a, b), 0);
+#endif
     EVP_PKEY_free(b);
     EVP_PKEY_free(a);
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -2033,16 +2033,31 @@ WOLFSSL_API int wolfSSL_EVP_PKEY_missing_parameters(WOLFSSL_EVP_PKEY *pkey)
 
 WOLFSSL_API int wolfSSL_EVP_PKEY_cmp(const WOLFSSL_EVP_PKEY *a, const WOLFSSL_EVP_PKEY *b)
 {
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    /* return compliant with OpneSSL */
+    /* 1 : match                     */
+    /* 0 : dont match                */
+    /* -1 : different type           */
+    /* -2 : not support              */
+    int ret = 0;  /* dont match */
+#else
     int ret = -1; /* failure */
+#endif
+
     int a_sz = 0, b_sz = 0;
 
     if (a == NULL || b == NULL)
         return ret;
 
     /* check its the same type of key */
-    if (a->type != b->type)
+    if (a->type != b->type) {
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+        return -1;
+#else
         return ret;
-
+#endif
+    }
+    
     /* get size based on key type */
     switch (a->type) {
 #ifndef NO_RSA
@@ -2062,7 +2077,11 @@ WOLFSSL_API int wolfSSL_EVP_PKEY_cmp(const WOLFSSL_EVP_PKEY *a, const WOLFSSL_EV
         break;
 #endif /* HAVE_ECC */
     default:
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+        return -2;
+#else
         return ret;
+#endif
     } /* switch (a->type) */
 
     /* check size */
@@ -2081,8 +2100,11 @@ WOLFSSL_API int wolfSSL_EVP_PKEY_cmp(const WOLFSSL_EVP_PKEY *a, const WOLFSSL_EV
             return ret;
         }
     }
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    ret = 1; /* 1 : match */
+#else
     ret = 0; /* success */
-
+#endif
     return ret;
 }
 


### PR DESCRIPTION
Return code compliant with OpenSSL EVP_PKEY_cmp(). This resolves some Qt unit test.  
To maintain backward compatibility, this is only enabled when WOLFSSL_ERROR_CODE_OPENSSL is defined.