### PR TITLE
Fix for SP ecc_mulmod_fast

### DIFF
--- a/wolfcrypt/src/sp_arm32.c
+++ b/wolfcrypt/src/sp_arm32.c
@@ -32574,7 +32574,7 @@ static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, cons
     sp_point_256* t = NULL;
     sp_digit* tmp = NULL;
 #else
-    sp_point_256 t[16];
+    sp_point_256 t[16 + 1];
     sp_digit tmp[2 * 8 * 5];
 #endif
     sp_point_256* rt = NULL;
@@ -32596,7 +32596,7 @@ static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, cons
     (void)heap;
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 16,
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 16 + 1,
         heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
@@ -41728,7 +41728,7 @@ static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, con
     sp_point_384* t = NULL;
     sp_digit* tmp = NULL;
 #else
-    sp_point_384 t[16];
+    sp_point_384 t[16 + 1];
     sp_digit tmp[2 * 12 * 6];
 #endif
     sp_point_384* rt = NULL;
@@ -41750,7 +41750,7 @@ static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, con
     (void)heap;
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 16,
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 16 + 1,
         heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
@@ -54436,7 +54436,7 @@ static int sp_1024_ecc_mulmod_fast_32(sp_point_1024* r, const sp_point_1024* g, 
     sp_point_1024* t = NULL;
     sp_digit* tmp = NULL;
 #else
-    sp_point_1024 t[16];
+    sp_point_1024 t[16 + 1];
     sp_digit tmp[2 * 32 * 5];
 #endif
     sp_point_1024* rt = NULL;
@@ -54451,7 +54451,7 @@ static int sp_1024_ecc_mulmod_fast_32(sp_point_1024* r, const sp_point_1024* g, 
     (void)heap;
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 16,
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 16 + 1,
         heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;

--- a/wolfcrypt/src/sp_armthumb.c
+++ b/wolfcrypt/src/sp_armthumb.c
@@ -17869,7 +17869,7 @@ static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, cons
     sp_point_256* t = NULL;
     sp_digit* tmp = NULL;
 #else
-    sp_point_256 t[16];
+    sp_point_256 t[16 + 1];
     sp_digit tmp[2 * 8 * 5];
 #endif
     sp_point_256* rt = NULL;
@@ -17891,7 +17891,7 @@ static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, cons
     (void)heap;
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 16,
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 16 + 1,
         heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
@@ -25508,7 +25508,7 @@ static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, con
     sp_point_384* t = NULL;
     sp_digit* tmp = NULL;
 #else
-    sp_point_384 t[16];
+    sp_point_384 t[16 + 1];
     sp_digit tmp[2 * 12 * 6];
 #endif
     sp_point_384* rt = NULL;
@@ -25530,7 +25530,7 @@ static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, con
     (void)heap;
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 16,
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 16 + 1,
         heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
@@ -35999,7 +35999,7 @@ static int sp_1024_ecc_mulmod_fast_32(sp_point_1024* r, const sp_point_1024* g, 
     sp_point_1024* t = NULL;
     sp_digit* tmp = NULL;
 #else
-    sp_point_1024 t[16];
+    sp_point_1024 t[16 + 1];
     sp_digit tmp[2 * 32 * 5];
 #endif
     sp_point_1024* rt = NULL;
@@ -36014,7 +36014,7 @@ static int sp_1024_ecc_mulmod_fast_32(sp_point_1024* r, const sp_point_1024* g, 
     (void)heap;
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 16,
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 16 + 1,
         heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;

--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -17999,7 +17999,7 @@ static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, cons
     sp_point_256* t = NULL;
     sp_digit* tmp = NULL;
 #else
-    sp_point_256 t[16];
+    sp_point_256 t[16 + 1];
     sp_digit tmp[2 * 8 * 5];
 #endif
     sp_point_256* rt = NULL;
@@ -18021,7 +18021,7 @@ static int sp_256_ecc_mulmod_fast_8(sp_point_256* r, const sp_point_256* g, cons
     (void)heap;
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 16,
+    t = (sp_point_256*)XMALLOC(sizeof(sp_point_256) * 16 + 1,
         heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
@@ -25132,7 +25132,7 @@ static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, con
     sp_point_384* t = NULL;
     sp_digit* tmp = NULL;
 #else
-    sp_point_384 t[16];
+    sp_point_384 t[16 + 1];
     sp_digit tmp[2 * 12 * 6];
 #endif
     sp_point_384* rt = NULL;
@@ -25154,7 +25154,7 @@ static int sp_384_ecc_mulmod_fast_12(sp_point_384* r, const sp_point_384* g, con
     (void)heap;
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 16,
+    t = (sp_point_384*)XMALLOC(sizeof(sp_point_384) * 16 + 1,
         heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;
@@ -33838,7 +33838,7 @@ static int sp_1024_ecc_mulmod_fast_32(sp_point_1024* r, const sp_point_1024* g, 
     sp_point_1024* t = NULL;
     sp_digit* tmp = NULL;
 #else
-    sp_point_1024 t[16];
+    sp_point_1024 t[16 + 1];
     sp_digit tmp[2 * 32 * 5];
 #endif
     sp_point_1024* rt = NULL;
@@ -33853,7 +33853,7 @@ static int sp_1024_ecc_mulmod_fast_32(sp_point_1024* r, const sp_point_1024* g, 
     (void)heap;
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_SP_NO_MALLOC)
-    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 16,
+    t = (sp_point_1024*)XMALLOC(sizeof(sp_point_1024) * 16 + 1,
         heap, DYNAMIC_TYPE_ECC);
     if (t == NULL)
         err = MEMORY_E;


### PR DESCRIPTION
Broken in PR #3868. The "t" needs 1 extra point for "rt".