### PR TITLE
Fix ATECC608A TNGTLS certificate size issue

### DIFF
--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -190,7 +190,11 @@ int wolfCrypt_ATECC_SetConfig(ATCAIfaceCfg* cfg)
     XMEMSET(&cfg_ateccx08a_i2c_pi, 0, sizeof(cfg_ateccx08a_i2c_pi));
     cfg_ateccx08a_i2c_pi.iface_type            = cfg->iface_type;
     cfg_ateccx08a_i2c_pi.devtype               = cfg->devtype;
+#ifdef ATCA_ENABLE_DEPRECATED
+    cfg_ateccx08a_i2c_pi.atcai2c.slave_address       = cfg->atcai2c.slave_address;
+#else
     cfg_ateccx08a_i2c_pi.atcai2c.address       = cfg->atcai2c.address;
+#endif
     cfg_ateccx08a_i2c_pi.atcai2c.bus           = cfg->atcai2c.bus;
     cfg_ateccx08a_i2c_pi.atcai2c.baud          = cfg->atcai2c.baud;
     cfg_ateccx08a_i2c_pi.wake_delay            = cfg->wake_delay;
@@ -389,7 +393,7 @@ void atmel_show_rev_info(void)
 #ifdef WOLFSSL_ATECC_DEBUG
     word32 revision = 0;
     atmel_get_rev_info(&revision);
-    printf("ATECC508A Revision: %x\r\n", (word32)revision);
+    printf("ATECC608 Revision: %x\n", (word32)revision);
 #endif
 }
 
@@ -513,7 +517,12 @@ int atmel_init(void)
             XMEMSET(&cfg_ateccx08a_i2c_pi, 0, sizeof(cfg_ateccx08a_i2c_pi));
             cfg_ateccx08a_i2c_pi.iface_type             = ATCA_I2C_IFACE;
             cfg_ateccx08a_i2c_pi.devtype                = ATECC_DEV_TYPE;
+#ifdef ATCA_ENABLE_DEPRECATED
+            cfg_ateccx08a_i2c_pi.atcai2c.slave_address        = ATECC_I2C_ADDR;
+#else
             cfg_ateccx08a_i2c_pi.atcai2c.address        = ATECC_I2C_ADDR;
+#endif
+	    cfg_ateccx08a_i2c_pi.atcai2c.address        = ATECC_I2C_ADDR;
             cfg_ateccx08a_i2c_pi.atcai2c.bus            = ATECC_I2C_BUS;
             cfg_ateccx08a_i2c_pi.atcai2c.baud           = 400000;
             cfg_ateccx08a_i2c_pi.wake_delay             = 1500;
@@ -921,7 +930,7 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
     size_t deviceCertSize=0;
     uint8_t *certBuffer;
 
-    /*fetch signer cert size*/
+    /* fetch signer cert size */
     status=tng_atcacert_read_signer_cert(NULL, &signerCertSize);
     if (ATCA_SUCCESS != status) {
         #ifdef WOLFSSL_ATECC_DEBUG
@@ -930,7 +939,7 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
         return WOLFSSL_FAILURE;
     }
 
-    /*fetch device cert size*/
+    /* fetch device cert size */
     status=tng_atcacert_read_device_cert(NULL, &deviceCertSize, NULL);
     if (ATCA_SUCCESS != status) {
         #ifdef WOLFSSL_ATECC_DEBUG
@@ -938,7 +947,7 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
         #endif
         return WOLFSSL_FAILURE;
     }    
-    certBuffer=XMALLOC(signerCertSize+deviceCertSize, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    certBuffer=(uint8_t*)XMALLOC(signerCertSize+deviceCertSize, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if(NULL == certBuffer){
         #ifdef WOLFSSL_ATECC_DEBUG
         printf("Failed allocating space for certBuffer\r\n");
@@ -946,8 +955,8 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
         return WOLFSSL_FAILURE;
     }
     
-    /*Read signer cert*/
-    status = tng_atcacert_read_signer_cert(&certBuffer[deviceCertSize],\
+    /* Read signer cert */
+    status = tng_atcacert_read_signer_cert(&certBuffer[deviceCertSize],
                                            &signerCertSize);
     if (ATCA_SUCCESS != status) {
         #ifdef WOLFSSL_ATECC_DEBUG
@@ -958,7 +967,7 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
         return ret;
     }
 
-    /*Read device cert signed by the signer above*/
+    /* Read device cert signed by the signer above */
     status = tng_atcacert_read_device_cert(certBuffer, &deviceCertSize,\
      	                                   &certBuffer[deviceCertSize]);
     if (ATCA_SUCCESS != status) {

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -523,11 +523,10 @@ int atmel_init(void)
             cfg_ateccx08a_i2c_pi.iface_type             = ATCA_I2C_IFACE;
             cfg_ateccx08a_i2c_pi.devtype                = ATECC_DEV_TYPE;
 #ifdef ATCA_ENABLE_DEPRECATED
-            cfg_ateccx08a_i2c_pi.atcai2c.slave_address        = ATECC_I2C_ADDR;
+            cfg_ateccx08a_i2c_pi.atcai2c.slave_address  = ATECC_I2C_ADDR;
 #else
             cfg_ateccx08a_i2c_pi.atcai2c.address        = ATECC_I2C_ADDR;
 #endif
-	    cfg_ateccx08a_i2c_pi.atcai2c.address        = ATECC_I2C_ADDR;
             cfg_ateccx08a_i2c_pi.atcai2c.bus            = ATECC_I2C_BUS;
             cfg_ateccx08a_i2c_pi.atcai2c.baud           = 400000;
             cfg_ateccx08a_i2c_pi.wake_delay             = 1500;
@@ -973,7 +972,7 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
     }
 
     /* Read device cert signed by the signer above */
-    status = tng_atcacert_read_device_cert(certBuffer, &deviceCertSize,\
+    status = tng_atcacert_read_device_cert(certBuffer, &deviceCertSize,
      	                                   &certBuffer[deviceCertSize]);
     if (ATCA_SUCCESS != status) {
         #ifdef WOLFSSL_ATECC_DEBUG
@@ -984,8 +983,8 @@ static int atcatls_set_certificates(WOLFSSL_CTX *ctx)
         return ret;
     }
 
-    ret = wolfSSL_CTX_use_certificate_chain_buffer_format(ctx,\
-          (const unsigned char*)certBuffer, signerCertSize+deviceCertSize,\
+    ret = wolfSSL_CTX_use_certificate_chain_buffer_format(ctx,
+          (const unsigned char*)certBuffer, signerCertSize+deviceCertSize,
           WOLFSSL_FILETYPE_ASN1);
     if (ret != WOLFSSL_SUCCESS) {
         printf("Error registering certificate chain\r\n");

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -263,7 +263,12 @@ int atmel_ecc_alloc(int slotType)
                 goto exit;
             case ATMEL_SLOT_ECDHE:
                 slotId = ATECC_SLOT_ECDHE_PRIV;
+            #ifdef WOLFSSL_ATECC_TNGTLS
+                /* not reserved in mSlotList, so return */
+                goto exit;
+            #else
                 break;
+            #endif
             case ATMEL_SLOT_ECDHE_ENC:
                 slotId = ATECC_SLOT_ENC_PARENT;
             #ifdef WOLFSSL_ATECC_TNGTLS

--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -190,9 +190,9 @@ int wolfCrypt_ATECC_SetConfig(ATCAIfaceCfg* cfg)
     XMEMSET(&cfg_ateccx08a_i2c_pi, 0, sizeof(cfg_ateccx08a_i2c_pi));
     cfg_ateccx08a_i2c_pi.iface_type            = cfg->iface_type;
     cfg_ateccx08a_i2c_pi.devtype               = cfg->devtype;
-    cfg_ateccx08a_i2c_pi.atcai2c.slave_address = cfg->atcai2c.slave_address;
+    cfg_ateccx08a_i2c_pi.atcai2c.address       = cfg->atcai2c.address;
     cfg_ateccx08a_i2c_pi.atcai2c.bus           = cfg->atcai2c.bus;
-    cfg_ateccx08a_i2c_pi.atcai2c.baud          = 400000;//cfg->atcai2c.baud;
+    cfg_ateccx08a_i2c_pi.atcai2c.baud          = cfg->atcai2c.baud;
     cfg_ateccx08a_i2c_pi.wake_delay            = cfg->wake_delay;
     cfg_ateccx08a_i2c_pi.rx_retries            = cfg->rx_retries;
     cfg_ateccx08a_i2c_pi.cfg_data              = cfg->cfg_data;
@@ -513,7 +513,7 @@ int atmel_init(void)
             XMEMSET(&cfg_ateccx08a_i2c_pi, 0, sizeof(cfg_ateccx08a_i2c_pi));
             cfg_ateccx08a_i2c_pi.iface_type             = ATCA_I2C_IFACE;
             cfg_ateccx08a_i2c_pi.devtype                = ATECC_DEV_TYPE;
-            cfg_ateccx08a_i2c_pi.atcai2c.slave_address  = ATECC_I2C_ADDR;
+            cfg_ateccx08a_i2c_pi.atcai2c.address        = ATECC_I2C_ADDR;
             cfg_ateccx08a_i2c_pi.atcai2c.bus            = ATECC_I2C_BUS;
             cfg_ateccx08a_i2c_pi.atcai2c.baud           = 400000;
             cfg_ateccx08a_i2c_pi.wake_delay             = 1500;


### PR DESCRIPTION
TNGTLS devices has shown variations in the device and signer certificate sizes causing failure.
This fix makes the size query dynamic.

I have also updated the I2C address variable name to match the latest release of cryptoauth lib.

@dgarske This is a continuation of the work we did in #3531