### PR TITLE
Refactor DTLS MTU logic

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1529,6 +1529,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     size_t throughput = 0;
     int    doDTLS    = 0;
     int    dtlsUDP   = 0;
+#if (defined(WOLFSSL_SCTP) || defined(WOLFSSL_DTLS_MTU)) && \
+                                                           defined(WOLFSSL_DTLS)
+    int    dtlsMTU = 0;
+#endif
     int    dtlsSCTP  = 0;
     int    doMcast   = 0;
     int    matchName = 0;
@@ -1713,7 +1717,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #ifndef WOLFSSL_VXWORKS
     /* Not used: All used */
     while ((ch = mygetopt(argc, argv, "?:"
-            "ab:c:defgh:i;jk:l:mnop:q:rstuv:wxyz"
+            "ab:c:defgh:i;jk:l:mnop:q:rstu;v:wxyz"
             "A:B:CDE:F:GH:IJKL:M:NO:PQRS:TUVW:XYZ:"
             "01:23:45689"
             "@#")) != -1) {
@@ -1753,6 +1757,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             case 'u' :
                 doDTLS = 1;
                 dtlsUDP = 1;
+            #if (defined(WOLFSSL_SCTP) || defined(WOLFSSL_DTLS_MTU)) && \
+                                                           defined(WOLFSSL_DTLS)
+                dtlsMTU = atoi(myoptarg);
+            #endif
                 break;
 
             case 'G' :
@@ -2493,6 +2501,11 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
     if (fewerPackets)
         wolfSSL_CTX_set_group_messages(ctx);
+#if (defined(WOLFSSL_SCTP) || defined(WOLFSSL_DTLS_MTU)) && \
+                                                           defined(WOLFSSL_DTLS)
+    if (dtlsMTU)
+        wolfSSL_CTX_dtls_set_mtu(ctx, dtlsMTU);
+#endif
 
 #ifndef NO_DH
     if (wolfSSL_CTX_SetMinDhKey_Sz(ctx, (word16)minDhKeyBits)

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1027,6 +1027,10 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     int    useAnon = 0;
     int    doDTLS = 0;
     int    dtlsUDP = 0;
+#if (defined(WOLFSSL_SCTP) || defined(WOLFSSL_DTLS_MTU)) && \
+                                               defined(WOLFSSL_DTLS)
+    int    dtlsMTU = 0;
+#endif
     int    dtlsSCTP = 0;
     int    doMcast = 0;
 #ifdef WOLFSSL_DTLS
@@ -1220,7 +1224,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 
     /* Not Used: h, z, W, X, 7, 9 */
     while ((ch = mygetopt(argc, argv, "?:"
-                "abc:defgijk:l:mnop:q:rstuv:wxy"
+                "abc:defgijk:l:mnop:q:rstu;v:wxy"
                 "A:B:C:D:E:FGH:IJKL:MNO:PQR:S:T;UVYZ:"
                 "01:23:4:5689"
                 "@#")) != -1) {
@@ -1268,6 +1272,10 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             case 'u' :
                 doDTLS  = 1;
                 dtlsUDP = 1;
+            #if (defined(WOLFSSL_SCTP) || defined(WOLFSSL_DTLS_MTU)) && \
+                                                           defined(WOLFSSL_DTLS)
+                dtlsMTU = atoi(myoptarg);
+            #endif
                 break;
 
             case 'G' :
@@ -1884,6 +1892,11 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 
     if (fewerPackets)
         wolfSSL_CTX_set_group_messages(ctx);
+#if (defined(WOLFSSL_SCTP) || defined(WOLFSSL_DTLS_MTU)) && \
+                                                           defined(WOLFSSL_DTLS)
+    if (dtlsMTU)
+        wolfSSL_CTX_dtls_set_mtu(ctx, dtlsMTU);
+#endif
 
 #ifdef WOLFSSL_SCTP
     if (dtlsSCTP)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2043,7 +2043,9 @@ static int wolfSSL_read_internal(WOLFSSL* ssl, void* data, int sz, int peek)
         if (ssl->options.dtlsSctp)
 #endif
 #if defined(WOLFSSL_SCTP) || defined(WOLFSSL_DTLS_MTU)
-            ssl->dtls_expected_rx = max(ssl->dtls_expected_rx, ssl->dtlsMtuSz);
+            /* Add 100 bytes so that we can operate with slight difference
+             * in set MTU size on each peer */
+            ssl->dtls_expected_rx = max(ssl->dtls_expected_rx, ssl->dtlsMtuSz + 100);
 #endif
     }
 #endif

--- a/tests/include.am
+++ b/tests/include.am
@@ -33,6 +33,7 @@ EXTRA_DIST += tests/test.conf \
               tests/test-dtls-fails.conf \
               tests/test-dtls-fails-cipher.conf \
               tests/test-dtls-group.conf \
+              tests/test-dtls-mtu.conf \
               tests/test-dtls-reneg-client.conf \
               tests/test-dtls-reneg-server.conf \
               tests/test-dtls-resume.conf \

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -978,6 +978,19 @@ int SuiteTest(int argc, char** argv)
         goto exit;
     }
 #endif
+#ifdef WOLFSSL_DTLS_MTU
+    /* Add dtls different MTU size tests.
+     * These also use grouping to force wolfSSL to
+     * bounce off the MTU limit more */
+    strcpy(argv0[1], "tests/test-dtls-mtu.conf");
+    printf("starting dtls MTU tests\n");
+    test_harness(&args);
+    if (args.return_code != 0) {
+        printf("error from script %d\n", args.return_code);
+        args.return_code = EXIT_FAILURE;
+        goto exit;
+    }
+#endif
 #ifdef WOLFSSL_OLDTLS_SHA2_CIPHERSUITES
     /* add dtls extra suites */
     strcpy(argv0[1], "tests/test-dtls-sha2.conf");

--- a/tests/test-dtls-mtu.conf
+++ b/tests/test-dtls-mtu.conf
@@ -1,0 +1,2151 @@
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305
+-u 1024
+-f
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305
+-u 1024
+-f
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+
+# server DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305
+
+# client DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305
+
+# server DTLSv1.2 ECDHE-EDCSA-CHACHA20-POLY1305
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-CHACHA20-POLY1305
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 DHE-PSK-CHACHA20-POLY1305
+-u 1024
+-f
+-v 3
+-s
+-l DHE-PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 DHE-PSK-CHACHA20-POLY1305
+-u 1024
+-f
+-v 3
+-s
+-l DHE-PSK-CHACHA20-POLY1305
+
+# server TLSv1.2 ECDHE-PSK-CHACHA20-POLY1305
+-u 1024
+-f
+-v 3
+-s
+-l ECDHE-PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 ECDHE-PSK-CHACHA20-POLY1305
+-u 1024
+-f
+-v 3
+-s
+-l ECDHE-PSK-CHACHA20-POLY1305
+
+# server TLSv1.2 PSK-CHACHA20-POLY1305
+-u 1024
+-f
+-v 3
+-s
+-l PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 PSK-CHACHA20-POLY1305
+-u 1024
+-f
+-v 3
+-s
+-l PSK-CHACHA20-POLY1305
+
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305-OLD
+-u 1024
+-f
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305-OLD
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305-OLD
+-u 1024
+-f
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305-OLD
+
+# server DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305-OLD
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305-OLD
+
+# client DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305-OLD
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305-OLD
+
+# server DTLSv1.2 ECDHE-EDCSA-CHACHA20-POLY1305-OLD
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1 IDEA-CBC-SHA
+-u 1024
+-f
+-v 2
+-l IDEA-CBC-SHA
+
+# client DTLSv1 IDEA-CBC-SHA
+-u 1024
+-f
+-v 2
+-l IDEA-CBC-SHA
+
+# server DTLSv1 DES-CBC3-SHA
+-u 1024
+-f
+-v 2
+-l DES-CBC3-SHA
+
+# client DTLSv1 DES-CBC3-SHA
+-u 1024
+-f
+-v 2
+-l DES-CBC3-SHA
+
+# server DTLSv1.2 DES-CBC3-SHA
+-u 1024
+-f
+-v 3
+-l DES-CBC3-SHA
+
+# client DTLSv1.2 DES-CBC3-SHA
+-u 1024
+-f
+-v 3
+-l DES-CBC3-SHA
+
+# server DTLSv1 AES128-SHA
+-u 1024
+-f
+-v 2
+-l AES128-SHA
+
+# client DTLSv1 AES128-SHA
+-u 1024
+-f
+-v 2
+-l AES128-SHA
+
+# server DTLSv1.2 AES128-SHA
+-u 1024
+-f
+-v 3
+-l AES128-SHA
+
+# client DTLSv1.2 AES128-SHA
+-u 1024
+-f
+-v 3
+-l AES128-SHA
+
+# server DTLSv1 AES256-SHA
+-u 1024
+-f
+-v 2
+-l AES256-SHA
+
+# client DTLSv1 AES256-SHA
+-u 1024
+-f
+-v 2
+-l AES256-SHA
+
+# server DTLSv1.2 AES256-SHA
+-u 1024
+-f
+-v 3
+-l AES256-SHA
+
+# client DTLSv1.2 AES256-SHA
+-u 1024
+-f
+-v 3
+-l AES256-SHA
+
+# server DTLSv1.2 AES128-SHA256
+-u 1024
+-f
+-v 3
+-l AES128-SHA256
+
+# client DTLSv1.2 AES128-SHA256
+-u 1024
+-f
+-v 3
+-l AES128-SHA256
+
+# server DTLSv1.2 AES256-SHA256
+-u 1024
+-f
+-v 3
+-l AES256-SHA256
+
+# client DTLSv1.2 AES256-SHA256
+-u 1024
+-f
+-v 3
+-l AES256-SHA256
+
+# server DTLSv1.1 ECDHE-RSA-DES3
+-u 1024
+-f
+-v 2
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# client DTLSv1.1 ECDHE-RSA-DES3
+-u 1024
+-f
+-v 2
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# server DTLSv1.1 ECDHE-RSA-AES128
+-u 1024
+-f
+-v 2
+-l ECDHE-RSA-AES128-SHA
+
+# client DTLSv1.1 ECDHE-RSA-AES128
+-u 1024
+-f
+-v 2
+-l ECDHE-RSA-AES128-SHA
+
+# server DTLSv1.1 ECDHE-RSA-AES256
+-u 1024
+-f
+-v 2
+-l ECDHE-RSA-AES256-SHA
+
+# client DTLSv1.1 ECDHE-RSA-AES256
+-u 1024
+-f
+-v 2
+-l ECDHE-RSA-AES256-SHA
+
+# server DTLSv1.2 ECDHE-RSA-DES3
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# client DTLSv1.2 ECDHE-RSA-DES3
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# server DTLSv1.2 ECDHE-RSA-AES128
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-AES128-SHA
+
+# client DTLSv1.2 ECDHE-RSA-AES128
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-AES128-SHA
+
+# server DTLSv1.2 ECDHE-RSA-AES128-SHA256
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# client DTLSv1.2 ECDHE-RSA-AES128-SHA256
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# server DTLSv1.2 ECDHE-RSA-AES256
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-AES256-SHA
+
+# client DTLSv1.2 ECDHE-RSA-AES256
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-AES256-SHA
+
+# server TLSv1 ECDHE-ECDSA-NULL-SHA
+-u 1024
+-f
+-v 1
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1 ECDHE-ECDSA-NULL-SHA
+-u 1024
+-f
+-v 1
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.1 ECDHE-ECDSA-NULL-SHA
+-u 1024
+-f
+-v 2
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1 ECDHE-ECDSA-NULL-SHA
+-u 1024
+-f
+-v 2
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-ECDSA-NULL-SHA
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-NULL-SHA
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-DES3
+-u 1024
+-f
+-v 2
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-DES3
+-u 1024
+-f
+-v 2
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-AES128
+-u 1024
+-f
+-v 2
+-l ECDHE-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-AES128
+-u 1024
+-f
+-v 2
+-l ECDHE-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-AES256
+-u 1024
+-f
+-v 2
+-l ECDHE-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-AES256
+-u 1024
+-f
+-v 2
+-l ECDHE-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-DES3
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-DES3
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-SHA256
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-SHA256
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-RSA-DES3
+-u 1024
+-f
+-v 2
+-l ECDH-RSA-DES-CBC3-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-DES3
+-u 1024
+-f
+-v 2
+-l ECDH-RSA-DES-CBC3-SHA
+
+# server DTLSv1.1 ECDH-RSA-AES128
+-u 1024
+-f
+-v 2
+-l ECDH-RSA-AES128-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-AES128
+-u 1024
+-f
+-v 2
+-l ECDH-RSA-AES128-SHA
+
+# server DTLSv1.1 ECDH-RSA-AES256
+-u 1024
+-f
+-v 2
+-l ECDH-RSA-AES256-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-AES256
+-u 1024
+-f
+-v 2
+-l ECDH-RSA-AES256-SHA
+
+# server DTLSv1.2 ECDH-RSA-DES3
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-DES-CBC3-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-DES3
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-DES-CBC3-SHA
+
+# server DTLSv1.2 ECDH-RSA-AES128
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-AES128-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-AES128-SHA
+
+# server DTLSv1.2 ECDH-RSA-AES128-SHA256
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-AES128-SHA256
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128-SHA256
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-AES128-SHA256
+
+# server DTLSv1.2 ECDH-RSA-AES256
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-AES256-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-AES256-SHA
+
+# server DTLSv1.1 ECDH-ECDSA-DES3
+-u 1024
+-f
+-v 2
+-l ECDH-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-DES3
+-u 1024
+-f
+-v 2
+-l ECDH-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-ECDSA-AES128
+-u 1024
+-f
+-v 2
+-l ECDH-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-AES128
+-u 1024
+-f
+-v 2
+-l ECDH-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-ECDSA-AES256
+-u 1024
+-f
+-v 2
+-l ECDH-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-AES256
+-u 1024
+-f
+-v 2
+-l ECDH-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-DES3
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-DES3
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128-SHA256
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128-SHA256
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES256
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-RSA-AES256-SHA384
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-AES256-SHA384
+
+# client DTLSv1.2 ECDHE-RSA-AES256-SHA384
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-AES256-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-SHA384
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-SHA384
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-RSA-AES256-SHA384
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-AES256-SHA384
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256-SHA384
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-AES256-SHA384
+
+# server DTLSv1.2 ECDH-ECDSA-AES256-SHA384
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-AES256-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256-SHA384
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-AES256-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-PSK-AES128-SHA256
+-s
+-u 1024
+-f
+-v 3
+-l ECDHE-PSK-AES128-SHA256
+
+# client TLSv1.2 ECDHE-PSK-AES128-SHA256
+-s
+-u 1024
+-f
+-v 3
+-l ECDHE-PSK-AES128-SHA256
+
+# server TLSv1.2 ECDHE-PSK-NULL-SHA256
+-s
+-u 1024
+-f
+-v 3
+-l ECDHE-PSK-NULL-SHA256
+
+# client TLSv1.2 ECDHE-PSK-NULL-SHA256
+-s
+-u 1024
+-f
+-v 3
+-l ECDHE-PSK-NULL-SHA256
+
+# server DTLSv1 PSK-AES128
+-s
+-u 1024
+-f
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# client DTLSv1 PSK-AES128
+-s
+-u 1024
+-f
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# server DTLSv1 PSK-AES256
+-s
+-u 1024
+-f
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# client DTLSv1 PSK-AES256
+-s
+-u 1024
+-f
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# server DTLSv1.2 PSK-AES128
+-s
+-u 1024
+-f
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# client DTLSv1.2 PSK-AES128
+-s
+-u 1024
+-f
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# server DTLSv1.2 PSK-AES256
+-s
+-u 1024
+-f
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# client DTLSv1.2 PSK-AES256
+-s
+-u 1024
+-f
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# server DTLSv1.2 PSK-AES128-SHA256
+-s
+-u 1024
+-f
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# client DTLSv1.2 PSK-AES128-SHA256
+-s
+-u 1024
+-f
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# server DTLSv1.2 PSK-AES256-SHA384
+-s
+-u 1024
+-f
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# client DTLSv1.2 PSK-AES256-SHA384
+-s
+-u 1024
+-f
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-GCM-SHA256
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-GCM-SHA256
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-GCM-SHA384
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-GCM-SHA384
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128-GCM-SHA256
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128-GCM-SHA256
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES256-GCM-SHA384
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256-GCM-SHA384
+-u 1024
+-f
+-v 3
+-l ECDH-ECDSA-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-RSA-AES128-GCM-SHA256
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+
+# client DTLSv1.2 ECDHE-RSA-AES128-GCM-SHA256
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+
+# server DTLSv1.2 ECDHE-RSA-AES256-GCM-SHA384
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+
+# client DTLSv1.2 ECDHE-RSA-AES256-GCM-SHA384
+-u 1024
+-f
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+
+# server DTLSv1.2 ECDH-RSA-AES128-GCM-SHA256
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-AES128-GCM-SHA256
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128-GCM-SHA256
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-AES128-GCM-SHA256
+
+# server DTLSv1.2 ECDH-RSA-AES256-GCM-SHA384
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-AES256-GCM-SHA384
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256-GCM-SHA384
+-u 1024
+-f
+-v 3
+-l ECDH-RSA-AES256-GCM-SHA384
+
+# server DTLSv1.2 PSK-AES128-GCM-SHA256
+-u 1024
+-f
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# client DTLSv1.2 PSK-AES128-GCM-SHA256
+-u 1024
+-f
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# server DTLSv1.2 PSK-AES256-GCM-SHA384
+-u 1024
+-f
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# client DTLSv1.2 PSK-AES256-GCM-SHA384
+-u 1024
+-f
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM-8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM-8
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-CCM-8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM-8
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-u 1024
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ADH-AES128-SHA
+-u 1024
+-f
+-a
+-v 3
+-l ADH-AES128-SHA
+
+# client DTLSv1.2 ADH-AES128-SHA
+-u 1024
+-f
+-a
+-v 3
+-l ADH-AES128-SHA
+
+# server DTLSv1.0 ADH-AES128-SHA
+-u 1024
+-f
+-a
+-v 2
+-l ADH-AES128-SHA
+
+# client DTLSv1.0 ADH-AES128-SHA
+-u 1024
+-f
+-a
+-v 2
+-l ADH-AES128-SHA
+
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305
+-u 512
+-f
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305
+-u 512
+-f
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+
+# server DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305
+
+# client DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305
+
+# server DTLSv1.2 ECDHE-EDCSA-CHACHA20-POLY1305
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-CHACHA20-POLY1305
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 DHE-PSK-CHACHA20-POLY1305
+-u 512
+-f
+-v 3
+-s
+-l DHE-PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 DHE-PSK-CHACHA20-POLY1305
+-u 512
+-f
+-v 3
+-s
+-l DHE-PSK-CHACHA20-POLY1305
+
+# server TLSv1.2 ECDHE-PSK-CHACHA20-POLY1305
+-u 512
+-f
+-v 3
+-s
+-l ECDHE-PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 ECDHE-PSK-CHACHA20-POLY1305
+-u 512
+-f
+-v 3
+-s
+-l ECDHE-PSK-CHACHA20-POLY1305
+
+# server TLSv1.2 PSK-CHACHA20-POLY1305
+-u 512
+-f
+-v 3
+-s
+-l PSK-CHACHA20-POLY1305
+
+# client TLSv1.2 PSK-CHACHA20-POLY1305
+-u 512
+-f
+-v 3
+-s
+-l PSK-CHACHA20-POLY1305
+
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305-OLD
+-u 512
+-f
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305-OLD
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305-OLD
+-u 512
+-f
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305-OLD
+
+# server DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305-OLD
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305-OLD
+
+# client DTLSv1.2 ECDHE-RSA-CHACHA20-POLY1305-OLD
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-CHACHA20-POLY1305-OLD
+
+# server DTLSv1.2 ECDHE-EDCSA-CHACHA20-POLY1305-OLD
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-CHACHA20-POLY1305-OLD
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1 IDEA-CBC-SHA
+-u 512
+-f
+-v 2
+-l IDEA-CBC-SHA
+
+# client DTLSv1 IDEA-CBC-SHA
+-u 512
+-f
+-v 2
+-l IDEA-CBC-SHA
+
+# server DTLSv1 DES-CBC3-SHA
+-u 512
+-f
+-v 2
+-l DES-CBC3-SHA
+
+# client DTLSv1 DES-CBC3-SHA
+-u 512
+-f
+-v 2
+-l DES-CBC3-SHA
+
+# server DTLSv1.2 DES-CBC3-SHA
+-u 512
+-f
+-v 3
+-l DES-CBC3-SHA
+
+# client DTLSv1.2 DES-CBC3-SHA
+-u 512
+-f
+-v 3
+-l DES-CBC3-SHA
+
+# server DTLSv1 AES128-SHA
+-u 512
+-f
+-v 2
+-l AES128-SHA
+
+# client DTLSv1 AES128-SHA
+-u 512
+-f
+-v 2
+-l AES128-SHA
+
+# server DTLSv1.2 AES128-SHA
+-u 512
+-f
+-v 3
+-l AES128-SHA
+
+# client DTLSv1.2 AES128-SHA
+-u 512
+-f
+-v 3
+-l AES128-SHA
+
+# server DTLSv1 AES256-SHA
+-u 512
+-f
+-v 2
+-l AES256-SHA
+
+# client DTLSv1 AES256-SHA
+-u 512
+-f
+-v 2
+-l AES256-SHA
+
+# server DTLSv1.2 AES256-SHA
+-u 512
+-f
+-v 3
+-l AES256-SHA
+
+# client DTLSv1.2 AES256-SHA
+-u 512
+-f
+-v 3
+-l AES256-SHA
+
+# server DTLSv1.2 AES128-SHA256
+-u 512
+-f
+-v 3
+-l AES128-SHA256
+
+# client DTLSv1.2 AES128-SHA256
+-u 512
+-f
+-v 3
+-l AES128-SHA256
+
+# server DTLSv1.2 AES256-SHA256
+-u 512
+-f
+-v 3
+-l AES256-SHA256
+
+# client DTLSv1.2 AES256-SHA256
+-u 512
+-f
+-v 3
+-l AES256-SHA256
+
+# server DTLSv1.1 ECDHE-RSA-DES3
+-u 512
+-f
+-v 2
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# client DTLSv1.1 ECDHE-RSA-DES3
+-u 512
+-f
+-v 2
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# server DTLSv1.1 ECDHE-RSA-AES128
+-u 512
+-f
+-v 2
+-l ECDHE-RSA-AES128-SHA
+
+# client DTLSv1.1 ECDHE-RSA-AES128
+-u 512
+-f
+-v 2
+-l ECDHE-RSA-AES128-SHA
+
+# server DTLSv1.1 ECDHE-RSA-AES256
+-u 512
+-f
+-v 2
+-l ECDHE-RSA-AES256-SHA
+
+# client DTLSv1.1 ECDHE-RSA-AES256
+-u 512
+-f
+-v 2
+-l ECDHE-RSA-AES256-SHA
+
+# server DTLSv1.2 ECDHE-RSA-DES3
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# client DTLSv1.2 ECDHE-RSA-DES3
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-DES-CBC3-SHA
+
+# server DTLSv1.2 ECDHE-RSA-AES128
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-AES128-SHA
+
+# client DTLSv1.2 ECDHE-RSA-AES128
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-AES128-SHA
+
+# server DTLSv1.2 ECDHE-RSA-AES128-SHA256
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# client DTLSv1.2 ECDHE-RSA-AES128-SHA256
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-AES128-SHA256
+
+# server DTLSv1.2 ECDHE-RSA-AES256
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-AES256-SHA
+
+# client DTLSv1.2 ECDHE-RSA-AES256
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-AES256-SHA
+
+# server TLSv1 ECDHE-ECDSA-NULL-SHA
+-u 512
+-f
+-v 1
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1 ECDHE-ECDSA-NULL-SHA
+-u 512
+-f
+-v 1
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.1 ECDHE-ECDSA-NULL-SHA
+-u 512
+-f
+-v 2
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1 ECDHE-ECDSA-NULL-SHA
+-u 512
+-f
+-v 2
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-ECDSA-NULL-SHA
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-NULL-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client TLSv1.2 ECDHE-ECDSA-NULL-SHA
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-NULL-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-DES3
+-u 512
+-f
+-v 2
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-DES3
+-u 512
+-f
+-v 2
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-AES128
+-u 512
+-f
+-v 2
+-l ECDHE-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-AES128
+-u 512
+-f
+-v 2
+-l ECDHE-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDHE-ECDSA-AES256
+-u 512
+-f
+-v 2
+-l ECDHE-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDHE-ECDSA-AES256
+-u 512
+-f
+-v 2
+-l ECDHE-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-DES3
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-DES3
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-SHA256
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-SHA256
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-RSA-DES3
+-u 512
+-f
+-v 2
+-l ECDH-RSA-DES-CBC3-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-DES3
+-u 512
+-f
+-v 2
+-l ECDH-RSA-DES-CBC3-SHA
+
+# server DTLSv1.1 ECDH-RSA-AES128
+-u 512
+-f
+-v 2
+-l ECDH-RSA-AES128-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-AES128
+-u 512
+-f
+-v 2
+-l ECDH-RSA-AES128-SHA
+
+# server DTLSv1.1 ECDH-RSA-AES256
+-u 512
+-f
+-v 2
+-l ECDH-RSA-AES256-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-RSA-AES256
+-u 512
+-f
+-v 2
+-l ECDH-RSA-AES256-SHA
+
+# server DTLSv1.2 ECDH-RSA-DES3
+-u 512
+-f
+-v 3
+-l ECDH-RSA-DES-CBC3-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-DES3
+-u 512
+-f
+-v 3
+-l ECDH-RSA-DES-CBC3-SHA
+
+# server DTLSv1.2 ECDH-RSA-AES128
+-u 512
+-f
+-v 3
+-l ECDH-RSA-AES128-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128
+-u 512
+-f
+-v 3
+-l ECDH-RSA-AES128-SHA
+
+# server DTLSv1.2 ECDH-RSA-AES128-SHA256
+-u 512
+-f
+-v 3
+-l ECDH-RSA-AES128-SHA256
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128-SHA256
+-u 512
+-f
+-v 3
+-l ECDH-RSA-AES128-SHA256
+
+# server DTLSv1.2 ECDH-RSA-AES256
+-u 512
+-f
+-v 3
+-l ECDH-RSA-AES256-SHA
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256
+-u 512
+-f
+-v 3
+-l ECDH-RSA-AES256-SHA
+
+# server DTLSv1.1 ECDH-ECDSA-DES3
+-u 512
+-f
+-v 2
+-l ECDH-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-DES3
+-u 512
+-f
+-v 2
+-l ECDH-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-ECDSA-AES128
+-u 512
+-f
+-v 2
+-l ECDH-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-AES128
+-u 512
+-f
+-v 2
+-l ECDH-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.1 ECDH-ECDSA-AES256
+-u 512
+-f
+-v 2
+-l ECDH-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.1 ECDH-ECDSA-AES256
+-u 512
+-f
+-v 2
+-l ECDH-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-DES3
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-DES-CBC3-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-DES3
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-DES-CBC3-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-AES128-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-AES128-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128-SHA256
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-AES128-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128-SHA256
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-AES128-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES256
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-AES256-SHA
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-AES256-SHA
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-RSA-AES256-SHA384
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-AES256-SHA384
+
+# client DTLSv1.2 ECDHE-RSA-AES256-SHA384
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-AES256-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-SHA384
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-SHA384
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-RSA-AES256-SHA384
+-u 512
+-f
+-v 3
+-l ECDH-RSA-AES256-SHA384
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256-SHA384
+-u 512
+-f
+-v 3
+-l ECDH-RSA-AES256-SHA384
+
+# server DTLSv1.2 ECDH-ECDSA-AES256-SHA384
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-AES256-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256-SHA384
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-AES256-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server TLSv1.2 ECDHE-PSK-AES128-SHA256
+-s
+-u 512
+-f
+-v 3
+-l ECDHE-PSK-AES128-SHA256
+
+# client TLSv1.2 ECDHE-PSK-AES128-SHA256
+-s
+-u 512
+-f
+-v 3
+-l ECDHE-PSK-AES128-SHA256
+
+# server TLSv1.2 ECDHE-PSK-NULL-SHA256
+-s
+-u 512
+-f
+-v 3
+-l ECDHE-PSK-NULL-SHA256
+
+# client TLSv1.2 ECDHE-PSK-NULL-SHA256
+-s
+-u 512
+-f
+-v 3
+-l ECDHE-PSK-NULL-SHA256
+
+# server DTLSv1 PSK-AES128
+-s
+-u 512
+-f
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# client DTLSv1 PSK-AES128
+-s
+-u 512
+-f
+-v 2
+-l PSK-AES128-CBC-SHA
+
+# server DTLSv1 PSK-AES256
+-s
+-u 512
+-f
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# client DTLSv1 PSK-AES256
+-s
+-u 512
+-f
+-v 2
+-l PSK-AES256-CBC-SHA
+
+# server DTLSv1.2 PSK-AES128
+-s
+-u 512
+-f
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# client DTLSv1.2 PSK-AES128
+-s
+-u 512
+-f
+-v 3
+-l PSK-AES128-CBC-SHA
+
+# server DTLSv1.2 PSK-AES256
+-s
+-u 512
+-f
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# client DTLSv1.2 PSK-AES256
+-s
+-u 512
+-f
+-v 3
+-l PSK-AES256-CBC-SHA
+
+# server DTLSv1.2 PSK-AES128-SHA256
+-s
+-u 512
+-f
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# client DTLSv1.2 PSK-AES128-SHA256
+-s
+-u 512
+-f
+-v 3
+-l PSK-AES128-CBC-SHA256
+
+# server DTLSv1.2 PSK-AES256-SHA384
+-s
+-u 512
+-f
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# client DTLSv1.2 PSK-AES256-SHA384
+-s
+-u 512
+-f
+-v 3
+-l PSK-AES256-CBC-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-GCM-SHA256
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-GCM-SHA256
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-GCM-SHA384
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-GCM-SHA384
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES128-GCM-SHA256
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-AES128-GCM-SHA256
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES128-GCM-SHA256
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-AES128-GCM-SHA256
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDH-ECDSA-AES256-GCM-SHA384
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-AES256-GCM-SHA384
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-ECDSA-AES256-GCM-SHA384
+-u 512
+-f
+-v 3
+-l ECDH-ECDSA-AES256-GCM-SHA384
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-RSA-AES128-GCM-SHA256
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+
+# client DTLSv1.2 ECDHE-RSA-AES128-GCM-SHA256
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-AES128-GCM-SHA256
+
+# server DTLSv1.2 ECDHE-RSA-AES256-GCM-SHA384
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+
+# client DTLSv1.2 ECDHE-RSA-AES256-GCM-SHA384
+-u 512
+-f
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+
+# server DTLSv1.2 ECDH-RSA-AES128-GCM-SHA256
+-u 512
+-f
+-v 3
+-l ECDH-RSA-AES128-GCM-SHA256
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES128-GCM-SHA256
+-u 512
+-f
+-v 3
+-l ECDH-RSA-AES128-GCM-SHA256
+
+# server DTLSv1.2 ECDH-RSA-AES256-GCM-SHA384
+-u 512
+-f
+-v 3
+-l ECDH-RSA-AES256-GCM-SHA384
+-c ./certs/server-ecc-rsa.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDH-RSA-AES256-GCM-SHA384
+-u 512
+-f
+-v 3
+-l ECDH-RSA-AES256-GCM-SHA384
+
+# server DTLSv1.2 PSK-AES128-GCM-SHA256
+-u 512
+-f
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# client DTLSv1.2 PSK-AES128-GCM-SHA256
+-u 512
+-f
+-s
+-v 3
+-l PSK-AES128-GCM-SHA256
+
+# server DTLSv1.2 PSK-AES256-GCM-SHA384
+-u 512
+-f
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# client DTLSv1.2 PSK-AES256-GCM-SHA384
+-u 512
+-f
+-s
+-v 3
+-l PSK-AES256-GCM-SHA384
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM-8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM-8
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM-8
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-CCM-8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM-8
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-CCM-8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES128-CCM8 (OpenSSL-compat alias)
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES128-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-c ./certs/server-ecc.pem
+-k ./certs/ecc-key.pem
+
+# client DTLSv1.2 ECDHE-ECDSA-AES256-CCM8 (OpenSSL-compat alias)
+-u 512
+-f
+-v 3
+-l ECDHE-ECDSA-AES256-CCM8
+-A ./certs/ca-ecc-cert.pem
+
+# server DTLSv1.2 ADH-AES128-SHA
+-u 512
+-f
+-a
+-v 3
+-l ADH-AES128-SHA
+
+# client DTLSv1.2 ADH-AES128-SHA
+-u 512
+-f
+-a
+-v 3
+-l ADH-AES128-SHA
+
+# server DTLSv1.0 ADH-AES128-SHA
+-u 512
+-f
+-a
+-v 2
+-l ADH-AES128-SHA
+
+# client DTLSv1.0 ADH-AES128-SHA
+-u 512
+-f
+-a
+-v 2
+-l ADH-AES128-SHA

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1157,7 +1157,8 @@ enum {
 #endif /* WOLFSSL_MULTICAST */
 
 #ifndef WOLFSSL_MAX_MTU
-    #define WOLFSSL_MAX_MTU 1500
+    /* 1500 - 100 bytes to account for UDP and IP headers */
+    #define WOLFSSL_MAX_MTU 1400
 #endif /* WOLFSSL_MAX_MTU */
 
 

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -565,7 +565,7 @@ static WC_INLINE int mygetopt(int argc, char** argv, const char* optstring)
     char  c;
     char* cp;
 
-    /* Added sanity check becuase scan-build complains argv[myoptind] access 
+    /* Added sanity check because scan-build complains argv[myoptind] access
      * results in a null pointer dereference. */
     if (argv == NULL)  {
         myoptarg = NULL;


### PR DESCRIPTION
- wolfSSL_GetMaxRecordSize will now take additional cipher data into account
- The set MTU size is understood as the maximum size of a DTLS record. The WOLFSSL_MAX_MTU was adjusted to account for UDP/IP headers.