### PR TITLE
Added API's for getting pointer to loaded static ephemeral key

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -13769,6 +13769,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_method(void);
  \param key key file path (if keySz == 0) or actual key buffer (PEM or ASN.1)
  \param keySz key size (should be 0 for "key" arg is file path)
  \param format WOLFSSL_FILETYPE_ASN1 or WOLFSSL_FILETYPE_PEM
+ \sa wolfSSL_CTX_get_ephemeral_key
  */
 WOLFSSL_API int wolfSSL_CTX_set_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, const char* key, unsigned int keySz, int format);
 
@@ -13781,8 +13782,35 @@ WOLFSSL_API int wolfSSL_CTX_set_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, con
  \param key key file path (if keySz == 0) or actual key buffer (PEM or ASN.1)
  \param keySz key size (should be 0 for "key" arg is file path)
  \param format WOLFSSL_FILETYPE_ASN1 or WOLFSSL_FILETYPE_PEM
+ \sa wolfSSL_get_ephemeral_key
  */
 WOLFSSL_API int wolfSSL_set_ephemeral_key(WOLFSSL* ssl, int keyAlgo, const char* key, unsigned int keySz, int format);
+
+/*!
+ \ingroup SSL
+ \brief This function returns pointer to loaded key as ASN.1/DER
+ \return 0 Key returned successfully
+ \param ctx A WOLFSSL_CTX context pointer
+ \param keyAlgo enum wc_PkType like WC_PK_TYPE_DH and WC_PK_TYPE_ECDH
+ \param key key buffer pointer
+ \param keySz key size pointer
+ \sa wolfSSL_CTX_set_ephemeral_key
+ */
+WOLFSSL_API int wolfSSL_CTX_get_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, 
+    const unsigned char** key, unsigned int* keySz);
+
+/*!
+ \ingroup SSL
+ \brief This function returns pointer to loaded key as ASN.1/DER
+ \return 0 Key returned successfully
+ \param ssl A WOLFSSL object pointer
+ \param keyAlgo enum wc_PkType like WC_PK_TYPE_DH and WC_PK_TYPE_ECDH
+ \param key key buffer pointer
+ \param keySz key size pointer
+ \sa wolfSSL_set_ephemeral_key
+ */
+WOLFSSL_API int wolfSSL_get_ephemeral_key(WOLFSSL* ssl, int keyAlgo, 
+    const unsigned char** key, unsigned int* keySz);
 
 /*!
  \ingroup SSL

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1854,6 +1854,14 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     if (ret != 0) {
         err_sys_ex(runWithErrors, "error loading static ECDH key");
     }
+    {
+        const byte* key = NULL;
+        word32 keySz = 0;
+        /* example for getting pointer to loaded static ephemeral key */
+        wolfSSL_CTX_get_ephemeral_key(ctx, WC_PK_TYPE_ECDH, &key, &keySz);
+        (void)key;
+        (void)keySz;
+    }
 #endif
 #ifndef NO_DH
     ret = wolfSSL_CTX_set_ephemeral_key(ctx, WC_PK_TYPE_DH,

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4234,6 +4234,12 @@ WOLFSSL_API int wolfSSL_CTX_set_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo,
     const char* key, unsigned int keySz, int format);
 WOLFSSL_API int wolfSSL_set_ephemeral_key(WOLFSSL* ssl, int keyAlgo,
     const char* key, unsigned int keySz, int format);
+
+/* returns pointer to loaded key as ASN.1/DER */
+WOLFSSL_API int wolfSSL_CTX_get_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, 
+    const unsigned char** key, unsigned int* keySz);
+WOLFSSL_API int wolfSSL_get_ephemeral_key(WOLFSSL* ssl, int keyAlgo, 
+    const unsigned char** key, unsigned int* keySz);
 #endif
 
 


### PR DESCRIPTION
Open to feedback on API arguments (returning pointer to loaded memory vs. allocating a copy, etc...).

https://www.wolfssl.com/forums/topic1724-where-to-get-the-private-keys-from-dh-in-the-clientserver-example.html