### PR TITLE
Improve ECC with `WOLFSSL_NO_MALLOC`

### DIFF
--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -316,6 +316,9 @@ typedef struct ecc_set_type {
 #ifndef USE_FAST_MATH
     #error USE_FAST_MATH must be defined to use ALT_ECC_SIZE
 #endif
+#ifdef WOLFSSL_NO_MALLOC
+    #error ALT_ECC_SIZE cannot be used with no malloc (WOLFSSL_NO_MALLOC)
+#endif
 
 /* determine max bits required for ECC math */
 #ifndef FP_MAX_BITS_ECC

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2437,6 +2437,12 @@ extern void uITRON4_free(void *p) ;
     #define NO_STRICT_ECDSA_LEN
 #endif
 
+/* Do not allow using small stack with no malloc */
+#if defined(WOLFSSL_NO_MALLOC) && \
+    (defined(WOLFSSL_SMALL_STACK) || defined(WOLFSSL_SMALL_STACK_CACHE))
+    #error Small stack cannot be used with no malloc (WOLFSSL_NO_MALLOC)
+#endif
+
 
 #ifdef __cplusplus
     }   /* extern "C" */


### PR DESCRIPTION
Tested with `./configure --enable-cryptonly --disable-examples --disable-rsa --disable-dh CFLAGS="-DWOLFSSL_NO_MALLOC -DBENCH_EMBEDDED" && make check`.

All ECC operations can work now with `WOLFSSL_NO_MALLOC` and variables will be on stack.
May cleanup this PR further.

ZD 11829