### PR TITLE
Add test cases for EVP_CIPHER_CTX_cleanup and BIO_free

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26574,9 +26574,14 @@ WOLFSSL_API int wolfSSL_X509_load_crl_file(WOLFSSL_X509_LOOKUP *ctx,
     
     WOLFSSL_ENTER("wolfSSL_X509_load_crl_file");
     
-    bio = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
+    if (ctx == NULL || file == NULL)
+        return ret;
+
+    if ((bio = wolfSSL_BIO_new(wolfSSL_BIO_s_file())) == NULL)
+        return ret;
     
-    if ((bio == NULL) || (wolfSSL_BIO_read_filename(bio, file) <= 0)) {
+    if (wolfSSL_BIO_read_filename(bio, file) <= 0) {
+        wolfSSL_BIO_free(bio);
         return ret;
     }
     
@@ -26940,9 +26945,14 @@ int wolfSSL_X509_VERIFY_PARAM_set1_host(WOLFSSL_X509_VERIFY_PARAM* pParam,
 *
 * RETURNS:
 *   WOLFSSL_SUCCESS on success, otherwise returns WOLFSSL_FAILURE
+*   Note: Returns WOLFSSL_SUCCESS, in case either parameter is NULL,
+*   same as openssl.
 */
 int wolfSSL_CTX_set1_param(WOLFSSL_CTX* ctx, WOLFSSL_X509_VERIFY_PARAM *vpm)
 {
+    if (ctx == NULL || vpm == NULL)
+        return WOLFSSL_SUCCESS;
+
     return wolfSSL_X509_VERIFY_PARAM_set1(ctx->param, vpm);
 }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -39497,7 +39497,7 @@ static int test_tls13_apis(void)
 #endif
 #endif
 
-#ifdef WOLFSSL_EARLY_DATA
+#if defined(OPENSSL_EXTRA) && defined(WOLFSSL_EARLY_DATA)
     AssertIntLT(SSL_get_early_data_status(NULL), 0);
 #endif
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -2523,6 +2523,8 @@ static void test_wolfSSL_EVP_CIPHER_CTX(void)
     AssertIntEQ(EVP_CIPHER_CTX_reset(NULL), WOLFSSL_FAILURE);
 
     EVP_CIPHER_CTX_free(ctx);
+    /* test EVP_CIPHER_CTX_cleanup with NULL */
+    AssertIntEQ(EVP_CIPHER_CTX_cleanup(NULL), WOLFSSL_SUCCESS);
 #endif /* !NO_AES && HAVE_AES_CBC && WOLFSSL_AES_128 */
 }
 #endif /* OPENSSL_EXTRA */
@@ -29190,6 +29192,8 @@ static void test_wolfSSL_BIO(void)
     for (i = 0; i < 20; i++) {
         buff[i] = i;
     }
+    /* test BIO_free with NULL */
+    AssertIntEQ(BIO_free(NULL), WOLFSSL_FAILURE);
 
     /* Creating and testing type BIO_s_bio */
     AssertNotNull(bio1 = BIO_new(BIO_s_bio()));


### PR DESCRIPTION
This PR is to address the issue reported in ZD11934. 
Added unit cases to check if following functions return correct return code when NULL parameter is passed:
- BIO_free
- EVP_CIPHER_CTX_cleanup