### PR TITLE
added favourite drink pilot attribute

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -31537,8 +31537,8 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
                       "certificatePolicies", "X509v3 Certificate Policies"},
 
     /* oidCertAuthInfoType */
-    { AIA_OCSP_OID, AIA_OCSP_OID, oidCertAuthInfoType, "authorityInfoAccess",
-                                            "Authority Information Access"},
+    { AIA_OCSP_OID, AIA_OCSP_OID, oidCertAuthInfoType, "OCSP",
+                                            "OCSP"},
     { AIA_CA_ISSUER_OID, AIA_CA_ISSUER_OID, oidCertAuthInfoType,
                                                  "caIssuers", "CA Issuers"},
 
@@ -31576,6 +31576,8 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
                                                             "emailAddress"},
     { NID_domainComponent, NID_domainComponent, oidCertNameType, "DC",
                                                             "domainComponent"},
+    { NID_favouriteDrink, NID_favouriteDrink, oidCertNameType, "favouriteDrink",
+                                                            "favouriteDrink"},
     { NID_businessCategory, NID_businessCategory, oidCertNameType, "businessCategory",
                                                             "businessCategory"},
     { NID_jurisdictionCountryName, NID_jurisdictionCountryName, oidCertNameType, "jurisdictionC",

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -6169,6 +6169,15 @@ int GetName(DecodedCert* cert, int nameType, int maxIdx)
                         nid = NID_domainComponent;
                     #endif /* OPENSSL_EXTRA */
                         break;
+                    case ASN_FAVOURITE_DRINK:
+                        copy = WOLFSSL_FAVOURITE_DRINK;
+                        copyLen = sizeof(WOLFSSL_FAVOURITE_DRINK) - 1;
+                    #if (defined(OPENSSL_EXTRA) || \
+                        defined(OPENSSL_EXTRA_X509_SMALL)) \
+                        && !defined(WOLFCRYPT_ONLY)
+                        nid = NID_favouriteDrink;
+                    #endif /* OPENSSL_EXTRA */
+                        break;
 
                     default:
                         WOLFSSL_MSG("Unknown pilot attribute type");

--- a/wolfssl/openssl/obj_mac.h
+++ b/wolfssl/openssl/obj_mac.h
@@ -42,6 +42,8 @@
 #define NID_sect571k1 733
 #define NID_sect571r1 734
 
+/* the definition is for Qt Unit test */
+#define SN_jurisdictionCountryName "jurisdictionC"
 #ifdef __cplusplus
     } /* extern "C" */
 #endif

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -140,8 +140,8 @@ enum DN_Tags {
     /* pilot attribute types
      * OID values of 0.9.2342.19200300.100.1.* */
     ASN_USER_ID          = 0x01, /* UID */
-    ASN_DOMAIN_COMPONENT = 0x19, /* DC */
-    ASN_FAVOURITE_DRINK  = 0x05  /* favouriteDrink */
+    ASN_FAVOURITE_DRINK  = 0x05, /* favouriteDrink */
+    ASN_DOMAIN_COMPONENT = 0x19  /* DC */
 };
 
 /* This is the size of the smallest possible PEM header and footer */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -140,7 +140,8 @@ enum DN_Tags {
     /* pilot attribute types
      * OID values of 0.9.2342.19200300.100.1.* */
     ASN_USER_ID          = 0x01, /* UID */
-    ASN_DOMAIN_COMPONENT = 0x19  /* DC */
+    ASN_DOMAIN_COMPONENT = 0x19, /* DC */
+    ASN_FAVOURITE_DRINK  = 0x05  /* favouriteDrink */
 };
 
 /* This is the size of the smallest possible PEM header and footer */
@@ -182,6 +183,7 @@ extern const WOLFSSL_ObjectInfo wolfssl_object_info[];
 
 #define WOLFSSL_USER_ID          "/UID="
 #define WOLFSSL_DOMAIN_COMPONENT "/DC="
+#define WOLFSSL_FAVOURITE_DRINK  "/favouriteDrink="
 
 #if defined(WOLFSSL_APACHE_HTTPD)
     /* otherName strings */
@@ -247,6 +249,7 @@ enum
     NID_jurisdictionStateOrProvinceName = 0xd,
     NID_businessCategory = ASN_BUS_CAT,
     NID_domainComponent = ASN_DOMAIN_COMPONENT,
+    NID_favouriteDrink = 462,
     NID_userId = 458,
     NID_emailAddress = 0x30,           /* emailAddress */
     NID_id_on_dnsSRV = 82,             /* 1.3.6.1.5.5.7.8.7 */


### PR DESCRIPTION
fix OCSP authority access info

These changes fix some of Qt 5.15.2 unit test failures at qsslcertificate.
