### PR TITLE
remove dead code, variable gn will currently always be null

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10128,13 +10128,6 @@ void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509, int nid, int* c,
             goto err;
         }
     }
-    else if (gn) {
-        if (wolfSSL_sk_GENERAL_NAME_push(sk, gn) != WOLFSSL_SUCCESS) {
-            WOLFSSL_MSG("Error pushing GENERAL_NAME object onto "
-                        "stack.");
-            goto err;
-        }
-    }
 
     ret = sk;
 


### PR DESCRIPTION
In the function either a goto err will be hit skipping over the push of 'gn' to the wolfssl stack, or gn will be set to null before the end of the switch statement.