### PR TITLE
Fix build error with NO_PKCS12

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -25311,7 +25311,7 @@ WOLFSSL_X509* wolfSSL_d2i_X509_REQ_bio(WOLFSSL_BIO* bio, WOLFSSL_X509** x509)
 #endif
 
 #if !defined(NO_ASN) && !defined(NO_PWDBASED)
-#ifndef NO_BIO
+#if !defined(NO_BIO) && defined(HAVE_PKCS12)
 WC_PKCS12* wolfSSL_d2i_PKCS12_bio(WOLFSSL_BIO* bio, WC_PKCS12** pkcs12)
 {
     WC_PKCS12* localPkcs12    = NULL;
@@ -25391,7 +25391,7 @@ int wolfSSL_i2d_PKCS12_bio(WOLFSSL_BIO *bio, WC_PKCS12 *pkcs12)
 
     return ret;
 }
-#endif /* !NO_BIO */
+#endif /* !NO_BIO && HAVE_PKCS12 */
 
 /* Copies unencrypted DER key buffer into "der". If "der" is null then the size
  * of buffer needed is returned. If *der == NULL then it allocates a buffer.
@@ -25404,6 +25404,7 @@ int wolfSSL_i2d_PrivateKey(const WOLFSSL_EVP_PKEY* key, unsigned char** der)
     return wolfSSL_EVP_PKEY_get_der(key, der);
 }
 
+#ifdef HAVE_PKCS12
 /* Creates a new WC_PKCS12 structure
  *
  * pass  password to use
@@ -25791,6 +25792,7 @@ int wolfSSL_PKCS12_verify_mac(WC_PKCS12 *pkcs12, const char *psw,
     return wc_PKCS12_verify_ex(pkcs12, (const byte*)psw, pswLen) == 0 ?
             WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
 }
+#endif /* HAVE_PKCS12 */
 #endif /* !NO_ASN && !NO_PWDBASED */
 
 
@@ -26377,7 +26379,7 @@ static void *wolfSSL_d2i_X509_fp_ex(XFILE file, void **x509, int type)
             newx509 = (void *)wolfSSL_d2i_X509_CRL(NULL, fileBuffer, (int)sz);
         }
     #endif
-    #if !defined(NO_ASN) && !defined(NO_PWDBASED)
+    #if !defined(NO_ASN) && !defined(NO_PWDBASED) && defined(HAVE_PKCS12)
         else if (type == PKCS12_TYPE) {
             if ((newx509 = wc_PKCS12_new()) == NULL) {
                 goto err_exit;
@@ -26402,7 +26404,7 @@ static void *wolfSSL_d2i_X509_fp_ex(XFILE file, void **x509, int type)
     goto _exit;
 
 err_exit:
-#if !defined(NO_ASN) && !defined(NO_PWDBASED)
+#if !defined(NO_ASN) && !defined(NO_PWDBASED) && defined(HAVE_PKCS12)
     if ((newx509 != NULL) && (type == PKCS12_TYPE)) {
         wc_PKCS12_free((WC_PKCS12*)newx509);
         newx509 = NULL;

--- a/tests/api.c
+++ b/tests/api.c
@@ -5056,7 +5056,7 @@ static void test_wolfSSL_PKCS12(void)
                    */
 #if defined(OPENSSL_EXTRA) && !defined(NO_DES3) && !defined(NO_FILESYSTEM) && \
     !defined(NO_ASN) && !defined(NO_PWDBASED) && !defined(NO_RSA) && \
-    !defined(NO_SHA)
+    !defined(NO_SHA) && defined(HAVE_PKCS12)
     byte buffer[6000];
     char file[] = "./certs/test-servercert.p12";
     char order[] = "./certs/ecc-rsa-server.p12";
@@ -31743,15 +31743,6 @@ static void test_wolfSSL_OBJ(void)
     ASN1_STRING *asn1 = NULL;
     unsigned char *buf_dyn = NULL;
 
-    PKCS12 *p12;
-    int boolRet;
-    EVP_PKEY *pkey = NULL;
-    const char *p12_f[] = {
-        #if !defined(NO_DES3) && !defined(NO_RSA)
-        "./certs/test-servercert.p12",
-        #endif
-        NULL};
-
     printf(testingFmt, "wolfSSL_OBJ()");
 
     AssertIntEQ(OBJ_obj2txt(buf, (int)sizeof(buf), obj, 1), SSL_FAILURE);
@@ -31809,27 +31800,42 @@ static void test_wolfSSL_OBJ(void)
 
     }
 
-    for (i = 0; p12_f[i] != NULL; i++)
+#ifdef HAVE_PKCS12
     {
-        AssertTrue((fp = XFOPEN(p12_f[i], "rb")) != XBADFILE);
-        AssertNotNull(p12 = d2i_PKCS12_fp(fp, NULL));
-        XFCLOSE(fp);
-        AssertTrue((boolRet = PKCS12_parse(p12, "wolfSSL test", &pkey, &x509, NULL)) > 0);
-        wc_PKCS12_free(p12);
-        EVP_PKEY_free(pkey);
-        x509Name = X509_get_issuer_name(x509);
-        AssertNotNull(x509Name);
-        AssertIntNE((numNames = X509_NAME_entry_count(x509Name)), 0);
-        AssertTrue((bio = BIO_new(BIO_s_mem())) != NULL);
-        for (j = 0; j < numNames; j++)
+        PKCS12 *p12;
+        int boolRet;
+        EVP_PKEY *pkey = NULL;
+        const char *p12_f[] = {
+            #if !defined(NO_DES3) && !defined(NO_RSA)
+            "./certs/test-servercert.p12",
+            #endif
+            NULL};
+
+        for (i = 0; p12_f[i] != NULL; i++)
         {
-            AssertNotNull(x509NameEntry = X509_NAME_get_entry(x509Name, j));
-            AssertNotNull(asn1Name = X509_NAME_ENTRY_get_object(x509NameEntry));
-            AssertTrue((nid = OBJ_obj2nid(asn1Name)) > 0);
+            AssertTrue((fp = XFOPEN(p12_f[i], "rb")) != XBADFILE);
+            AssertNotNull(p12 = d2i_PKCS12_fp(fp, NULL));
+            XFCLOSE(fp);
+            AssertTrue((boolRet = PKCS12_parse(p12, "wolfSSL test",
+                                               &pkey, &x509, NULL)) > 0);
+            wc_PKCS12_free(p12);
+            EVP_PKEY_free(pkey);
+            x509Name = X509_get_issuer_name(x509);
+            AssertNotNull(x509Name);
+            AssertIntNE((numNames = X509_NAME_entry_count(x509Name)), 0);
+            AssertTrue((bio = BIO_new(BIO_s_mem())) != NULL);
+            for (j = 0; j < numNames; j++)
+            {
+                AssertNotNull(x509NameEntry = X509_NAME_get_entry(x509Name, j));
+                AssertNotNull(asn1Name =
+                        X509_NAME_ENTRY_get_object(x509NameEntry));
+                AssertTrue((nid = OBJ_obj2nid(asn1Name)) > 0);
+            }
+            BIO_free(bio);
+            X509_free(x509);
         }
-        BIO_free(bio);
-        X509_free(x509);
     }
+#endif /* HAVE_PKCS12 */
 
     printf(resultFmt, passed);
 #endif


### PR DESCRIPTION
Reproduce with `./configure --enable-all --disable-pkcs12`

This fixes an issue first reported in zd11850