### PR TITLE
Fix for AES GCM with STM32H7

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -7021,13 +7021,33 @@ static int wc_AesGcmEncrypt_STM32(Aes* aes, byte* out, const byte* in, word32 sz
     #ifdef STM32_AESGCM_PARTIAL
     hcryp.Init.HeaderPadSize = authPadSz - authInSz;
     #endif
-    ByteReverseWords(partialBlock, ctr, AES_BLOCK_SIZE);
-    hcryp.Init.pInitVect = (STM_CRYPT_TYPE*)partialBlock;
+    #ifdef CRYP_KEYIVCONFIG_ONCE
+    /* allows repeated calls to HAL_CRYP_Encrypt */
+    hcryp.Init.KeyIVConfigSkip = CRYP_KEYIVCONFIG_ONCE;
+    #endif
+    ByteReverseWords(ctr, ctr, AES_BLOCK_SIZE);
+    hcryp.Init.pInitVect = (STM_CRYPT_TYPE*)ctr;
     HAL_CRYP_Init(&hcryp);
 
+    #ifndef CRYP_KEYIVCONFIG_ONCE
     /* GCM payload phase - can handle partial blocks */
     status = HAL_CRYP_Encrypt(&hcryp, (uint32_t*)in,
         (blocks * AES_BLOCK_SIZE) + partial, (uint32_t*)out, STM32_HAL_TIMEOUT);
+    #else
+    /* GCM payload phase - blocks */
+    if (blocks) {
+        status = HAL_CRYP_Encrypt(&hcryp, (uint32_t*)in,
+            (blocks * AES_BLOCK_SIZE), (uint32_t*)out, STM32_HAL_TIMEOUT);
+    }
+    /* GCM payload phase - partial remainder */
+    if (status == HAL_OK && (partial != 0 || blocks == 0)) {
+        XMEMSET(partialBlock, 0, sizeof(partialBlock));
+        XMEMCPY(partialBlock, in + (blocks * AES_BLOCK_SIZE), partial);
+        status = HAL_CRYP_Encrypt(&hcryp, (uint32_t*)partialBlock, partial,
+            (uint32_t*)partialBlock, STM32_HAL_TIMEOUT);
+        XMEMCPY(out + (blocks * AES_BLOCK_SIZE), partialBlock, partial);
+    }
+    #endif
     if (status == HAL_OK && !useSwGhash) {
         /* Compute the authTag */
         status = HAL_CRYPEx_AESGCM_GenerateAuthTAG(&hcryp, (uint32_t*)tag,
@@ -7466,10 +7486,10 @@ static int wc_AesGcmDecrypt_STM32(Aes* aes, byte* out,
         || authPadSz != authInSz
     #endif
     ) {
-		GHASH(aes, authIn, authInSz, in, sz, (byte*)tag, sizeof(tag));
-		wc_AesEncrypt(aes, (byte*)ctr, (byte*)partialBlock);
-		xorbuf(tag, partialBlock, sizeof(tag));
-		tagComputed = 1;
+        GHASH(aes, authIn, authInSz, in, sz, (byte*)tag, sizeof(tag));
+        wc_AesEncrypt(aes, (byte*)ctr, (byte*)partialBlock);
+        xorbuf(tag, partialBlock, sizeof(tag));
+        tagComputed = 1;
     }
 
     /* if using hardware for authentication tag make sure its aligned and zero padded */
@@ -7514,25 +7534,32 @@ static int wc_AesGcmDecrypt_STM32(Aes* aes, byte* out,
     #ifdef STM32_AESGCM_PARTIAL
     hcryp.Init.HeaderPadSize = authPadSz - authInSz;
     #endif
-    ByteReverseWords(partialBlock, ctr, AES_BLOCK_SIZE);
-    hcryp.Init.pInitVect = (STM_CRYPT_TYPE*)partialBlock;
+    #ifdef CRYP_KEYIVCONFIG_ONCE
+    /* allows repeated calls to HAL_CRYP_Decrypt */
+    hcryp.Init.KeyIVConfigSkip = CRYP_KEYIVCONFIG_ONCE;
+    #endif
+    ByteReverseWords(ctr, ctr, AES_BLOCK_SIZE);
+    hcryp.Init.pInitVect = (STM_CRYPT_TYPE*)ctr;
     HAL_CRYP_Init(&hcryp);
 
-    /* GCM payload phase - can handle partial blocks */
-    #ifdef CRYP_HEADERWIDTHUNIT_BYTE
-    {
-        /* clear remainder of partial input (for 32-bit uint) */
-        word32 remain = (partial & 3);
-        if (remain > 0)
-            remain = 4 - remain;
-        while (sz > 0 && remain > 0) {
-            ((byte*)in)[sz + remain - 1] = 0;
-            remain--;
-        }
-    }
-    #endif
+    #ifndef CRYP_KEYIVCONFIG_ONCE
     status = HAL_CRYP_Decrypt(&hcryp, (uint32_t*)in,
         (blocks * AES_BLOCK_SIZE) + partial, (uint32_t*)out, STM32_HAL_TIMEOUT);
+    #else
+    /* GCM payload phase - blocks */
+    if (blocks) {
+        status = HAL_CRYP_Decrypt(&hcryp, (uint32_t*)in,
+            (blocks * AES_BLOCK_SIZE), (uint32_t*)out, STM32_HAL_TIMEOUT);
+    }
+    /* GCM payload phase - partial remainder */
+    if (status == HAL_OK && (partial != 0 || blocks == 0)) {
+        XMEMSET(partialBlock, 0, sizeof(partialBlock));
+        XMEMCPY(partialBlock, in + (blocks * AES_BLOCK_SIZE), partial);
+        status = HAL_CRYP_Decrypt(&hcryp, (uint32_t*)partialBlock, partial,
+(           uint32_t*)partialBlock, STM32_HAL_TIMEOUT);
+        XMEMCPY(out + (blocks * AES_BLOCK_SIZE), partialBlock, partial);
+    }
+    #endif
     if (status == HAL_OK && !tagComputed) {
         /* Compute the authTag */
         status = HAL_CRYPEx_AESGCM_GenerateAuthTAG(&hcryp, (uint32_t*)tag,
@@ -7618,7 +7645,7 @@ static int wc_AesGcmDecrypt_STM32(Aes* aes, byte* out,
     if (status != SUCCESS)
         ret = AES_GCM_AUTH_E;
     if (tagComputed == 0)
-    	XMEMCPY(tag, partialBlock, authTagSz);
+        XMEMCPY(tag, partialBlock, authTagSz);
 #endif /* WOLFSSL_STM32_CUBEMX */
     wolfSSL_CryptHwMutexUnLock();
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -7013,7 +7013,7 @@ static int wc_AesGcmEncrypt_STM32(Aes* aes, byte* out, const byte* in, word32 sz
 #if defined(STM32_HAL_V2)
     hcryp.Init.Algorithm = CRYP_AES_GCM;
     #ifdef CRYP_HEADERWIDTHUNIT_BYTE
-    /* V2 with CRYP_DATAWIDTHUNIT_BYTE uses byte size for header */
+    /* V2 with CRYP_HEADERWIDTHUNIT_BYTE uses byte size for header */
     hcryp.Init.HeaderSize = authPadSz;
     #else
     hcryp.Init.HeaderSize = authPadSz/sizeof(word32);
@@ -7506,7 +7506,7 @@ static int wc_AesGcmDecrypt_STM32(Aes* aes, byte* out,
 #if defined(STM32_HAL_V2)
     hcryp.Init.Algorithm = CRYP_AES_GCM;
     #ifdef CRYP_HEADERWIDTHUNIT_BYTE
-    /* V2 with CRYP_DATAWIDTHUNIT_BYTE uses byte size for header */
+    /* V2 with CRYP_HEADERWIDTHUNIT_BYTE uses byte size for header */
     hcryp.Init.HeaderSize = authPadSz;
     #else
     hcryp.Init.HeaderSize = authPadSz/sizeof(word32);

--- a/wolfcrypt/src/port/st/stm32.c
+++ b/wolfcrypt/src/port/st/stm32.c
@@ -294,6 +294,9 @@ int wc_Stm32_Aes_Init(Aes* aes, CRYP_HandleTypeDef* hcryp)
     hcryp->Init.pKey = (STM_CRYPT_TYPE*)aes->key;
 #ifdef STM32_HAL_V2
     hcryp->Init.DataWidthUnit = CRYP_DATAWIDTHUNIT_BYTE;
+    #ifdef CRYP_HEADERWIDTHUNIT_BYTE
+    hcryp->Init.HeaderWidthUnit = CRYP_HEADERWIDTHUNIT_BYTE;
+    #endif
 #endif
 
     return 0;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9895,7 +9895,7 @@ WOLFSSL_TEST_SUBROUTINE int aesgcm_test(void)
     /* Variable plain text length test */
     for (plen=1; plen<(int)sizeof(p); plen++) {
          /* AES-GCM encrypt and decrypt both use AES encrypt internally */
-        result = wc_AesGcmEncrypt(enc, resultC, resultP, (word32)plen, iv1,
+         result = wc_AesGcmEncrypt(enc, resultC, p, (word32)plen, iv1,
                            sizeof(iv1), resultT, sizeof(resultT), a, sizeof(a));
 #if defined(WOLFSSL_ASYNC_CRYPT)
         result = wc_AsyncWait(result, &enc->asyncDev, WC_ASYNC_FLAG_NONE);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -9895,7 +9895,7 @@ WOLFSSL_TEST_SUBROUTINE int aesgcm_test(void)
     /* Variable plain text length test */
     for (plen=1; plen<(int)sizeof(p); plen++) {
          /* AES-GCM encrypt and decrypt both use AES encrypt internally */
-         result = wc_AesGcmEncrypt(enc, resultC, p, (word32)plen, iv1,
+        result = wc_AesGcmEncrypt(enc, resultC, resultP, (word32)plen, iv1,
                            sizeof(iv1), resultT, sizeof(resultT), a, sizeof(a));
 #if defined(WOLFSSL_ASYNC_CRYPT)
         result = wc_AsyncWait(result, &enc->asyncDev, WC_ASYNC_FLAG_NONE);


### PR DESCRIPTION
Fixes to allow use of AES GCM authentication tag calculation more often.
Fix to improve STM32 AES GCM with partial blocks. Use a local buffer for partial remainder and make sure remainder is zero'd.

ZD 11928