### PR TITLE
add option to use an engine with openssl test script

### DIFF
--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -2,6 +2,10 @@
 
 #openssl.test
 
+# Enviornment variables used:
+# OPENSSL            (openssl app to use)
+# OPENSSL_ENGINE_ID  (engine id if any i.e. -engine wolfengine)
+
 CERT_DIR="$PWD/$(dirname "$0")/../certs"
 
 if ! test -n "$WOLFSSL_OPENSSL_TEST"; then
@@ -135,11 +139,11 @@ start_openssl_server() {
 
         if [ "$cert_file" != "" ]
         then
-            echo "# " $OPENSSL s_server -accept $server_port -cert $cert_file -key $key_file  -quiet -CAfile $ca_file -www -dhparam ${CERT_DIR}/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" $openssl_nodhe
-            $OPENSSL s_server -accept $server_port -cert $cert_file -key $key_file  -quiet -CAfile $ca_file -www -dhparam ${CERT_DIR}/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" $openssl_nodhe &
+            echo "# " $OPENSSL s_server -accept $server_port $OPENSSL_ENGINE_ID -cert $cert_file -key $key_file  -quiet -CAfile $ca_file -www -dhparam ${CERT_DIR}/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" $openssl_nodhe
+            $OPENSSL s_server -accept $server_port $OPENSSL_ENGINE_ID -cert $cert_file -key $key_file  -quiet -CAfile $ca_file -www -dhparam ${CERT_DIR}/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" $openssl_nodhe &
         else
-            echo "# " $OPENSSL s_server -accept $server_port -quiet -nocert -www -dhparam ${CERT_DIR}/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" $openssl_nodhe
-            $OPENSSL s_server -accept $server_port -quiet -nocert -www -dhparam ${CERT_DIR}/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" $openssl_nodhe &
+            echo "# " $OPENSSL s_server -accept $server_port $OPENSSL_ENGINE_ID -quiet -nocert -www -dhparam ${CERT_DIR}/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" $openssl_nodhe
+            $OPENSSL s_server -accept $server_port $OPENSSL_ENGINE_ID -quiet -nocert -www -dhparam ${CERT_DIR}/dh2048.pem -verify 10 -verify_return_error -psk $psk_hex -cipher "ALL:eNULL" $openssl_nodhe &
         fi
         server_pid=$!
         # wait to see if s_server successfully starts before continuing

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -152,8 +152,8 @@ start_openssl_server() {
                 exit 1
             fi
         fi
+        OPENSSL_ENGINE_ID="-engine ${OPENSSL_ENGINE_ID}"
     fi
-    OPENSSL_ENGINE_ID="-engine ${OPENSSL_ENGINE_ID}"
 
     while [ "$counter" -lt 20 ]; do
         echo -e "\n# Trying to start $openssl_suite OpenSSL server on port $server_port..."

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -4,7 +4,7 @@
 
 # Enviornment variables used:
 # OPENSSL            (openssl app to use)
-# OPENSSL_ENGINE_ID  (engine id if any i.e. -engine wolfengine)
+# OPENSSL_ENGINE_ID  (engine id if any i.e. "wolfengine")
 
 CERT_DIR="$PWD/$(dirname "$0")/../certs"
 
@@ -133,6 +133,28 @@ start_openssl_server() {
     server_port=$port
     found_free_port=0
     counter=0
+
+    # If OPENSSL_ENGINE_ID has been set then check that the desired engine can
+    # be loaded successfully and error out if not. Otherwise the OpenSSL app
+    # will fall back to default engine.
+    if [ ! -z "${OPENSSL_ENGINE_ID}" ]; then
+        OUTPUT=`$OPENSSL engine -tt $OPENSSL_ENGINE_ID`
+        if [ $? != 0 ]; then
+            printf "not able to load engine\n"
+            printf "$OPENSSL engine -tt $OPENSSL_ENGINE_ID\n"
+            do_cleanup
+            exit 1
+        else
+            echo $OUTPUT | grep "available"
+            if [ $? != 0 ]; then
+                printf "engine not available\n"
+                do_cleanup
+                exit 1
+            fi
+        fi
+    fi
+    OPENSSL_ENGINE_ID="-engine ${OPENSSL_ENGINE_ID}"
+
     while [ "$counter" -lt 20 ]; do
         echo -e "\n# Trying to start $openssl_suite OpenSSL server on port $server_port..."
         echo "#"


### PR DESCRIPTION
Use the env variable OPENSSL_ENGINE_ID to set an engine to be used for the server during interop testing