### PR TITLE
Changed the logic for determining the group used for KeyShare in TLSX_PopulateExtensions.

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -10329,20 +10329,21 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                     int set = 0;
                     int i, j;
 
-                    /* Default to first group in supported list. */
-                    namedGroup = ssl->group[0];
-                    /* Try to find preferred in supported list. */
-                    for (i = 0; i < (int)PREFERRED_GROUP_SZ && !set; i++) {
-                        for (j = 0; j < ssl->numGroups; j++) {
-                            if (preferredGroup[i] == ssl->group[j]) {
-                                /* Most preferred that is supported. */
-                                namedGroup = ssl->group[j];
+                    /* try to find the highest element in ssl->group[]
+                     * that is contained in preferredGroup[].
+                     */
+                    namedGroup = preferredGroup[0];
+                    for (i = 0; i < ssl->numGroups && !set; i++) {
+                        for (j = 0; j < (int)PREFERRED_GROUP_SZ; j++) {
+                            if (preferredGroup[j] == ssl->group[i]) {
+                                namedGroup = ssl->group[i];
                                 set = 1;
                                 break;
                             }
                         }
                     }
                 }
+
                 else {
                     /* Choose the most preferred group. */
                     namedGroup = preferredGroup[0];


### PR DESCRIPTION
This PR is intended to fix an issue reported in ZD11969. The issue is that calling only SSL_CTX_set1_groups_list() does not choose the top ranked group in the list to KeyShare extension. This is a different behavior than OpenSSL. Additional call to wolfSSL_UseKeyShare will solve this difference, but this function is not in OpenSSL compat layer.

This behavior difference comes from the logic to decide group to use for KeyShare in TLSX_PopulateExtensions(). The logic has nested for-loops for the decision. However the loops choose the candidate not from user-specified list but from preferredGroups. To match the behavior to OpenSSL, need to change to pick the candidate from the user-specified list. 