### PR TITLE
Change default DTLS future packet behaviour

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -13546,7 +13546,7 @@ static WC_INLINE int DtlsCheckWindow(WOLFSSL* ssl)
         WOLFSSL_MSG("Current record sequence number from the past.");
         return 0;
     }
-#ifndef WOLFSSL_DTLS_ALLOW_FUTURE
+#ifdef WOLFSSL_DTLS_DISALLOW_FUTURE
     else if (!curLT && (diff > DTLS_SEQ_BITS)) {
         WOLFSSL_MSG("Rejecting message too far into the future.");
         return 0;


### PR DESCRIPTION
This is a better default for most users. Most users who make use of DTLS, allow messages from "too far into the future". It makes sense that DTLS may lose connection for a period of time and will lose all messages from this period. Losing connection effectively stalls the wolfSSL DTLS connection.