### PR TITLE
Fixes for NXP LTC ECC/RSA

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -2278,7 +2278,7 @@ int ecc_projective_dbl_point(ecc_point *P, ecc_point *R, mp_int* a,
 #endif
 }
 
-
+#if !defined(FREESCALE_LTC_ECC) && !defined(WOLFSSL_STM32_PKA)
 /**
   Map a projective Jacobian point back to affine space
   P        [in/out] The point to map
@@ -2497,6 +2497,7 @@ done:
     return ECC_BAD_ARG_E;
 #endif
 }
+#endif /* !FREESCALE_LTC_ECC && !WOLFSSL_STM32_PKA */
 
 int ecc_map(ecc_point* P, mp_int* modulus, mp_digit mp)
 {
@@ -4463,14 +4464,10 @@ static int ecc_make_pub_ex(ecc_key* key, ecc_curve_spec* curveIn,
                err = MEMORY_E;
             }
         }
-#ifndef FREESCALE_LTC_ECC /* this is done in hardware */
         if (err == MP_OKAY) {
             /* Use constant time map if compiled in */
             err = ecc_map_ex(pub, curve->prime, mp, 1);
         }
-#else
-        (void)mp;
-#endif
 
         wc_ecc_del_point_ex(base, key->heap);
     }

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -1450,7 +1450,7 @@ int mp_is_bit_set (mp_int *a, mp_digit b)
     mp_digit s = b % DIGIT_BIT;  /* bit index */
 
     if ((mp_digit)a->used <= i) {
-        /* no words avaialable at that bit count */
+        /* no words available at that bit count */
         return 0;
     }
 

--- a/wolfcrypt/src/md5.c
+++ b/wolfcrypt/src/md5.c
@@ -127,7 +127,7 @@ static int Transform(wc_Md5* md5, const byte* data)
 #ifdef FREESCALE_MMCAU_CLASSIC_SHA
         cau_md5_hash_n((byte*)data, 1, (unsigned char*)md5->digest);
 #else
-        MMCAU_MD5_HashN((byte*)data, 1, (word32*)md5->digest);
+        MMCAU_MD5_HashN((byte*)data, 1, (uint32_t*)md5->digest);
 #endif
         wolfSSL_CryptHwMutexUnLock();
     }
@@ -148,7 +148,7 @@ static int Transform_Len(wc_Md5* md5, const byte* data, word32 len)
             #ifdef FREESCALE_MMCAU_CLASSIC_SHA
                 cau_md5_hash_n(local, 1, (unsigned char*)md5->digest);
             #else
-                MMCAU_MD5_HashN(local, 1, (word32*)md5->digest);
+                MMCAU_MD5_HashN(local, 1, (uint32_t*)md5->digest);
             #endif
                 data += WC_MD5_BLOCK_SIZE;
                 len  -= WC_MD5_BLOCK_SIZE;
@@ -162,7 +162,7 @@ static int Transform_Len(wc_Md5* md5, const byte* data, word32 len)
             (unsigned char*)md5->digest);
 #else
         MMCAU_MD5_HashN((byte*)data, len / WC_MD5_BLOCK_SIZE,
-            (word32*)md5->digest);
+            (uint32_t*)md5->digest);
 #endif
         }
         wolfSSL_CryptHwMutexUnLock();

--- a/wolfcrypt/src/port/nxp/ksdk_port.c
+++ b/wolfcrypt/src/port/nxp/ksdk_port.c
@@ -560,20 +560,21 @@ int mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng)
         /* The base size is the number of bits / 8. One is added if the number
          * of bits isn't an even 8. */
         sizeB = (sizeB / 8) + ((sizeB % 8) ? 1 : 0);
-        
+
         ptrA = (uint8_t*)XMALLOC(LTC_MAX_INT_BYTES, NULL, DYNAMIC_TYPE_BIGINT);
         ptrB = (uint8_t*)XMALLOC(sizeB, NULL, DYNAMIC_TYPE_BIGINT);
         if (ptrA == NULL || ptrB == NULL) {
             res = MEMORY_E;
         }
 
-    #ifndef WC_NO_RNG
-        if (res == MP_OKAY && rng != NULL) {
+        if (res == MP_OKAY) {
+        #ifndef WC_NO_RNG
+            /* A NULL rng will return as bad function arg */
             res = wc_RNG_GenerateBlock(rng, ptrB, sizeB);
+        #else
+            res = NOT_COMPILED_IN;
+        #endif
         }
-    #else
-        res = NOT_COMPILED_IN;
-    #endif
 
         if (res == MP_OKAY) {
             res = ltc_get_lsb_bin_from_mp_int(ptrA, a, &sizeA);

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -397,7 +397,7 @@ int wc_InitRsaKey_Label(RsaKey* key, const char* label, void* heap, int devId)
  */
 int wc_InitRsaHw(RsaKey* key)
 {
-    unsigned char* m; /* RSA modulous */
+    unsigned char* m; /* RSA modulus */
     word32 e = 0;     /* RSA public exponent */
     int mSz;
     int eSz;
@@ -673,7 +673,7 @@ int wc_CheckRsaKey(RsaKey* key)
                 break;
     #endif /* WOLFSSL_SP_4096 */
                 default:
-                /* If using only single precsision math then issue key size
+                /* If using only single precision math then issue key size
                  * error, otherwise fall-back to multi-precision math
                  * calculation */
                 #if defined(WOLFSSL_SP_MATH)

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -4275,7 +4275,11 @@ int mp_exptmod_ex (mp_int * G, mp_int * X, int digits, mp_int * P, mp_int * Y)
   return fp_exptmod_ex(G, X, digits, P, Y);
 }
 
+#if defined(FREESCALE_LTC_TFM)
+int wolfcrypt_mp_exptmod_nct (mp_int * G, mp_int * X, mp_int * P, mp_int * Y)
+#else
 int mp_exptmod_nct (mp_int * G, mp_int * X, mp_int * P, mp_int * Y)
+#endif
 {
   return fp_exptmod_nct(G, X, P, Y);
 }
@@ -4724,8 +4728,11 @@ int mp_mod_d(fp_int *a, fp_digit b, fp_digit *c)
 
 static int  fp_isprime_ex(fp_int *a, int t, int* result);
 
-
+#if defined(FREESCALE_LTC_TFM)
+int wolfcrypt_mp_prime_is_prime(mp_int* a, int t, int* result)
+#else
 int mp_prime_is_prime(mp_int* a, int t, int* result)
+#endif
 {
     return fp_isprime_ex(a, t, result);
 }
@@ -4960,7 +4967,11 @@ int fp_isprime_ex(fp_int *a, int t, int* result)
 }
 
 
+#if defined(FREESCALE_LTC_TFM)
+int wolfcrypt_mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng)
+#else
 int mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng)
+#endif
 {
     int ret = FP_YES;
     fp_digit d;
@@ -5370,7 +5381,7 @@ int mp_add_d(fp_int *a, fp_digit b, fp_int *c)
 
 /* chars used in radix conversions */
 static wcchar fp_s_rmap = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                     "abcdefghijklmnopqrstuvwxyz+/";
+                                    "abcdefghijklmnopqrstuvwxyz+/";
 #endif
 
 #if !defined(NO_DSA) || defined(HAVE_ECC)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14705,7 +14705,8 @@ static int rsa_keygen_test(WC_RNG* rng)
     #if !defined(HAVE_FAST_RSA) && !defined(HAVE_USER_RSA) && \
         (!defined(HAVE_FIPS) || \
          (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))) && \
-        !defined(HAVE_SELFTEST) && !defined(HAVE_INTEL_QA)
+        !defined(HAVE_SELFTEST) && !defined(HAVE_INTEL_QA) \
+        && !defined(WOLFSSL_NO_RSA_KEY_CHECK)
     ret = wc_CheckRsaKey(genKey);
     if (ret != 0) {
         ERROR_OUT(-7872, exit_rsa);


### PR DESCRIPTION
Fixes for NXP LTC with ECC and RSA:
* The invmod function must reduce if A > B. 
* Fix for `mp_mulmod` to use mul then mod.
* Fix for `ecc_map` and `ecc_map_ex`, which are handled in hardware.
* Fix for NXP LTC `mp_mul` N value.
* Added error response checking for NXP LTC `LTC_PKHA_ModMul` and isolated the result C to its own variable.
* Fix for MMCAU cast warnings.
* Added RSA Key Generation acceleration.

ZD 12096