### PR TITLE
Fixes for some `-pedantic` errors

### DIFF
--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -127,7 +127,7 @@ bench_tls(args);
 static const char* kShutdown = "shutdown";
 
 #ifndef NO_WOLFSSL_CLIENT
-static const char* kTestStr =
+PEDANTIC_EXTENSION static const char* kTestStr =
 "Biodiesel cupidatat marfa, cliche aute put a bird on it incididunt elit\n"
 "polaroid. Sunt tattooed bespoke reprehenderit. Sint twee organic id\n"
 "marfa. Commodo veniam ad esse gastropub. 3 wolf moon sartorial vero,\n"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -49666,7 +49666,7 @@ static int wolfSSL_TicketKeyCb(WOLFSSL* ssl,
 
     WOLFSSL_ENTER("wolfSSL_TicketKeyCb");
 
-    if (ssl == NULL || ssl->ctx == NULL || ssl->ctx->ticketEncCtx == NULL) {
+    if (ssl == NULL || ssl->ctx == NULL || ssl->ctx->ticketEncWrapCb == NULL) {
         WOLFSSL_MSG("Bad parameter");
         return WOLFSSL_TICKET_RET_FATAL;
     }
@@ -49677,7 +49677,7 @@ static int wolfSSL_TicketKeyCb(WOLFSSL* ssl,
         WOLFSSL_MSG("wolfSSL_HMAC_CTX_Init error");
         return WOLFSSL_TICKET_RET_FATAL;
     }
-    res = ((ticketCompatCb)ssl->ctx->ticketEncCtx)(ssl, keyName,
+    res = ssl->ctx->ticketEncWrapCb(ssl, keyName,
             iv, &evpCtx, &hmacCtx, enc);
     if (res != TICKET_KEY_CB_RET_OK && res != TICKET_KEY_CB_RET_RENEW) {
         WOLFSSL_MSG("Ticket callback error");
@@ -49743,11 +49743,12 @@ end:
  */
 int wolfSSL_CTX_set_tlsext_ticket_key_cb(WOLFSSL_CTX *ctx, ticketCompatCb cb)
 {
+
     /* Set the ticket encryption callback to be a wrapper around OpenSSL
      * callback.
      */
     ctx->ticketEncCb = wolfSSL_TicketKeyCb;
-    ctx->ticketEncCtx = (void*)cb;
+    ctx->ticketEncWrapCb = cb;
 
     return WOLFSSL_SUCCESS;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -23879,9 +23879,9 @@ static void test_wc_PKCS7_EncodeSignedData(void)
     PKCS7*      pkcs7;
     WC_RNG      rng;
     byte        output[FOURK_BUF];
-    byte        badOut[0];
+    byte        badOut[1];
     word32      outputSz = (word32)sizeof(output);
-    word32      badOutSz = (word32)sizeof(badOut);
+    word32      badOutSz = 0;
     byte        data[] = "Test data to encode.";
 
 #ifndef NO_RSA
@@ -24360,8 +24360,8 @@ static void test_wc_PKCS7_VerifySignedData(void)
     byte   output[FOURK_BUF];
     word32 outputSz = sizeof(output);
     byte   data[] = "Test data to encode.";
-    byte   badOut[0];
-    word32 badOutSz = (word32)sizeof(badOut);
+    byte   badOut[1];
+    word32 badOutSz = 0;
     byte   badContent[] = "This is different content than was signed";
 
     AssertIntGT((outputSz = CreatePKCS7SignedData(output, outputSz, data,
@@ -41391,7 +41391,7 @@ static void test_wolfssl_EVP_aes_gcm_zeroLen(void)
     byte iv[]  = {
         0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
     }; /* align */
-    byte plaintxt[0];
+    byte plaintxt[1];
     int ivSz  = 12;
     int plaintxtSz = 0;
     unsigned char tag[16];

--- a/tests/api.c
+++ b/tests/api.c
@@ -3343,7 +3343,7 @@ done:
 
 typedef int (*cbType)(WOLFSSL_CTX *ctx, WOLFSSL *ssl);
 
-static void test_client_nofail(void* args, void *cb)
+static void test_client_nofail(void* args, cbType cb)
 {
     SOCKET_T sockfd = 0;
     callback_functions* cbf;
@@ -3510,7 +3510,7 @@ static void test_client_nofail(void* args, void *cb)
 #endif
 
     if (cb != NULL)
-        ((cbType)cb)(ctx, ssl);
+        (cb)(ctx, ssl);
 
     if (wolfSSL_write(ssl, msg, msgSz) != msgSz) {
         /*err_sys("SSL_write failed");*/
@@ -29826,7 +29826,7 @@ static void test_wolfSSL_msgCb(void)
 #ifndef SINGLE_THREADED
     start_thread(test_server_nofail, &server_args, &serverThread);
     wait_tcp_ready(&server_args);
-    test_client_nofail(&client_args, (void *)msgCb);
+    test_client_nofail(&client_args, msgCb);
     join_thread(serverThread);
 #endif
 
@@ -40261,7 +40261,7 @@ static int my_DhCallback(WOLFSSL* ssl, struct DhKey* key,
     (void)ssl;
     /* return 0 on success */
     return wc_DhAgree(key, out, outlen, priv, privSz, pubKeyDer, pubKeySz);
-};
+}
 
 static void test_dh_ctx_setup(WOLFSSL_CTX* ctx) {
     wolfSSL_CTX_SetDhAgreeCb(ctx, my_DhCallback);
@@ -41764,9 +41764,9 @@ typedef struct {
 ASN1_SEQUENCE(DPP_BOOTSTRAPPING_KEY) = {
     ASN1_SIMPLE(DPP_BOOTSTRAPPING_KEY, alg, X509_ALGOR),
     ASN1_SIMPLE(DPP_BOOTSTRAPPING_KEY, pub_key, ASN1_BIT_STRING)
-} ASN1_SEQUENCE_END(DPP_BOOTSTRAPPING_KEY);
+} ASN1_SEQUENCE_END(DPP_BOOTSTRAPPING_KEY)
 
-IMPLEMENT_ASN1_FUNCTIONS(DPP_BOOTSTRAPPING_KEY);
+IMPLEMENT_ASN1_FUNCTIONS(DPP_BOOTSTRAPPING_KEY)
 #endif
 
 static void test_wolfSSL_IMPLEMENT_ASN1_FUNCTIONS(void)
@@ -42869,7 +42869,7 @@ static void test_export_keying_material(void)
 
     start_thread(test_server_nofail, &server_args, &serverThread);
     wait_tcp_ready(&server_args);
-    test_client_nofail(&client_args, (void*)test_export_keying_material_cb);
+    test_client_nofail(&client_args, test_export_keying_material_cb);
     join_thread(serverThread);
 
     AssertTrue(client_args.return_code);

--- a/tests/unit.h
+++ b/tests/unit.h
@@ -53,10 +53,10 @@
 #define AssertFalse(x)   Assert(!(x), ("%s is false",    #x), (#x " => TRUE"))
 #define AssertNotNull(x) Assert( (x), ("%s is not null", #x), (#x " => NULL"))
 
-#define AssertNull(x) do {                                                     \
-    void* _x = (void *) (x);                                                   \
-                                                                               \
-    Assert(!_x, ("%s is null", #x), (#x " => %p", _x));                        \
+#define AssertNull(x) do {                              \
+    PEDANTIC_EXTENSION void* _x = (void *) (x);         \
+                                                        \
+    Assert(!_x, ("%s is null", #x), (#x " => %p", _x)); \
 } while(0)
 
 #define AssertInt(x, y, op, er) do {                                           \

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -141,7 +141,7 @@ const char *wolfSSL_configure_args(void) {
 #endif
 }
 
-const char *wolfSSL_global_cflags(void) {
+PEDANTIC_EXTENSION const char *wolfSSL_global_cflags(void) {
 #ifdef LIBWOLFSSL_GLOBAL_CFLAGS
   /* the spaces on either side are to make matching simple and efficient. */
   return " " LIBWOLFSSL_GLOBAL_CFLAGS " ";

--- a/wolfcrypt/src/poly1305.c
+++ b/wolfcrypt/src/poly1305.c
@@ -109,7 +109,7 @@ static word32 cpu_flags_set = 0;
 
     #elif defined(__GNUC__)
         #if defined(__SIZEOF_INT128__)
-            typedef unsigned __int128 word128;
+            PEDANTIC_EXTENSION typedef unsigned __int128 word128;
         #else
             typedef unsigned word128 __attribute__((mode(TI)));
         #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -89,7 +89,7 @@
 #endif
 
 #ifdef __GNUC__
-_Pragma("GCC diagnostic ignored \"-Wunused-function\"");
+_Pragma("GCC diagnostic ignored \"-Wunused-function\"")
 #endif
 
 #ifdef USE_FLAT_TEST_H
@@ -36409,9 +36409,9 @@ WOLFSSL_TEST_SUBROUTINE int memcb_test(void)
     b = NULL;
 
     /* Use API. */
-    if (wolfSSL_SetAllocators((wolfSSL_Malloc_cb)(void*)&my_Malloc_cb,
-                              (wolfSSL_Free_cb)(void*)&my_Free_cb,
-                              (wolfSSL_Realloc_cb)(void*)&my_Realloc_cb) != 0) {
+    if (wolfSSL_SetAllocators((wolfSSL_Malloc_cb)my_Malloc_cb,
+                              (wolfSSL_Free_cb)my_Free_cb,
+                              (wolfSSL_Realloc_cb)my_Realloc_cb) != 0) {
         ERROR_OUT(-13802, exit_memcb);
     }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -36345,7 +36345,7 @@ WOLFSSL_TEST_SUBROUTINE int mutex_test(void)
 
 #if defined(USE_WOLFSSL_MEMORY) && !defined(FREERTOS)
 
-#ifndef WOLFSSL_NO_MALLOC
+#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_STATIC_MEMORY)
 static int malloc_cnt = 0;
 static int realloc_cnt = 0;
 static int free_cnt = 0;
@@ -36388,7 +36388,7 @@ static void *my_Realloc_cb(void *ptr, size_t size)
 WOLFSSL_TEST_SUBROUTINE int memcb_test(void)
 {
     int ret = 0;
-#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_LINUXKM)
+#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_STATIC_MEMORY)
     byte* b = NULL;
 #endif
     wolfSSL_Malloc_cb  mc;
@@ -36399,7 +36399,8 @@ WOLFSSL_TEST_SUBROUTINE int memcb_test(void)
     if (wolfSSL_GetAllocators(&mc, &fc, &rc) != 0)
         return -13800;
 
-#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_LINUXKM)
+#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_STATIC_MEMORY)
+
     /* test realloc */
     b = (byte*)XREALLOC(b, 1024, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (b == NULL) {
@@ -36427,7 +36428,7 @@ WOLFSSL_TEST_SUBROUTINE int memcb_test(void)
         ret = -13803;
 #endif /* !WOLFSSL_NO_MALLOC */
 
-#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_LINUXKM)
+#if !defined(WOLFSSL_NO_MALLOC) && !defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_STATIC_MEMORY)
 exit_memcb:
 #endif
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -26445,7 +26445,7 @@ WOLFSSL_TEST_SUBROUTINE int ed448_test(void)
     WOLFSSL_SMALL_STACK_STATIC const byte* sigs[] = {sig1, sig2, sig3, sig4, sig5, sig6};
     #define SIGSZ sizeof(sig1)
 
-    WOLFSSL_SMALL_STACK_STATIC const byte msg1[]  = { };
+    PEDANTIC_EXTENSION WOLFSSL_SMALL_STACK_STATIC const byte msg1[]  = { };
     WOLFSSL_SMALL_STACK_STATIC const byte msg2[]  = { 0x03 };
     WOLFSSL_SMALL_STACK_STATIC const byte msg3[]  = { 0x64, 0xa6, 0x5f, 0x3c, 0xde, 0xdc, 0xdd,
                                   0x66, 0x81, 0x1e, 0x29, 0x15 };

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2955,6 +2955,10 @@ struct WOLFSSL_CTX {
     #if defined(HAVE_SESSION_TICKET) && !defined(NO_WOLFSSL_SERVER)
         SessionTicketEncCb ticketEncCb;   /* enc/dec session ticket Cb */
         void*              ticketEncCtx;  /* session encrypt context */
+        #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) \
+          || defined(OPENSSL_EXTRA) || defined(HAVE_LIGHTY)
+        ticketCompatCb     ticketEncWrapCb; /* callback for OpenSSL ticket key callback */
+        #endif
         int                ticketHint;    /* ticket hint in seconds */
         #ifndef WOLFSSL_NO_DEF_TICKET_ENC_CB
             TicketEncCbCtx ticketKeyCtx;

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -3428,7 +3428,7 @@ static WC_INLINE int myDhCallback(WOLFSSL* ssl, struct DhKey* key,
         ret, privSz, pubKeySz, *outlen);
 
     return ret;
-};
+}
 
 #endif /* !NO_DH */
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1007,6 +1007,14 @@ decouple library dependencies with standard string, memory and so on.
         #endif
     #endif /* WOLFSSL_AESNI || WOLFSSL_ARMASM */
 
+    #if !defined(PEDANTIC_EXTENSION)
+        #if defined(__GNUC__)
+            #define PEDANTIC_EXTENSION __extension__
+        #else
+            #define PEDANTIC_EXTENSION
+        #endif
+    #endif /* !PEDANTIC_EXTENSION */
+
 
     #ifndef TRUE
         #define TRUE  1


### PR DESCRIPTION
It will be a significant effort to have all configurations error free with `-pedantic`. This address some that are easy to address for common configurations.