### PR TITLE
Add wolfSSL_CRYPTO_get_ex_new_index

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -44947,6 +44947,69 @@ int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *pkey)
 #endif /* !NO_CERTS */
 
 #endif /* OPENSSL_EXTRA */
+#if defined(HAVE_EX_DATA) || defined(FORTRESS)
+static int get_ex_new_index(int class_index)
+{
+    /* index counter for each class index*/
+    static int ctx_idx = 0;
+    static int ssl_idx = 0;
+    static int x509_idx = 0;
+
+    int index = -1;
+
+    switch(class_index) {
+        case CRYPTO_EX_INDEX_SSL:
+            index = ssl_idx++;
+            break;
+        case CRYPTO_EX_INDEX_SSL_CTX:
+            index = ctx_idx++;
+            break;
+        case CRYPTO_EX_INDEX_X509:
+            index = x509_idx++;
+            break;
+
+        /* following class indexes are not supoprted */
+        case CRYPTO_EX_INDEX_SSL_SESSION:
+        case CRYPTO_EX_INDEX_X509_STORE:
+        case CRYPTO_EX_INDEX_X509_STORE_CTX:
+        case CRYPTO_EX_INDEX_DH:
+        case CRYPTO_EX_INDEX_DSA:
+        case CRYPTO_EX_INDEX_EC_KEY:
+        case CRYPTO_EX_INDEX_RSA:
+        case CRYPTO_EX_INDEX_ENGINE:
+        case CRYPTO_EX_INDEX_UI:
+        case CRYPTO_EX_INDEX_BIO:
+        case CRYPTO_EX_INDEX_APP:
+        case CRYPTO_EX_INDEX_UI_METHOD:
+        case CRYPTO_EX_INDEX_DRBG:
+        default:
+            break;
+    }
+    return index;
+}
+/*  wolfSSL_CRYPTO_get_ex_new_index issues unique index for the class
+ *  specified by class_index. Other parameter except class_index are
+ *  ignored. Currentry, following class_index are accepted:
+ *  - CRYPTO_EX_INDEX_SSL
+ *  - CRYPTO_EX_INDEX_SSL_CTX
+ *  - CRYPTO_EX_INDEX_X509
+ *  Returns index value grater or equal to zero on success, -1 on failure.
+ */
+WOLFSSL_API int wolfSSL_CRYPTO_get_ex_new_index(int class_index,
+                                                long argl, void* argp,
+                                        WOLFSSL_CRYPTO_EX_new* new_func,
+                                        WOLFSSL_CRYPTO_EX_dup* dup_func,
+                                        WOLFSSL_CRYPTO_EX_free* free_func)
+{
+    (void)argl;
+    (void)argp;
+    (void)new_func;
+    (void)dup_func;
+    (void)free_func;
+
+    return get_ex_new_index(class_index);
+}
+#endif /* HAVE_EX_DATA || FORTRESS */
 
 #if defined(HAVE_EX_DATA) || defined(FORTRESS) || defined(WOLFSSL_WPAS_SMALL)
 void* wolfSSL_CTX_get_ex_data(const WOLFSSL_CTX* ctx, int idx)
@@ -44966,7 +45029,6 @@ void* wolfSSL_CTX_get_ex_data(const WOLFSSL_CTX* ctx, int idx)
 int wolfSSL_CTX_get_ex_new_index(long idx, void* arg, void* a, void* b,
                                 void* c)
 {
-    static int ctx_idx = 0;
 
     WOLFSSL_ENTER("wolfSSL_CTX_get_ex_new_index");
     (void)idx;
@@ -44975,7 +45037,7 @@ int wolfSSL_CTX_get_ex_new_index(long idx, void* arg, void* a, void* b,
     (void)b;
     (void)c;
 
-    return ctx_idx++;
+    return get_ex_new_index(CRYPTO_EX_INDEX_SSL_CTX);
 }
 
 /* Return the index that can be used for the WOLFSSL structure to store
@@ -44986,7 +45048,6 @@ int wolfSSL_get_ex_new_index(long argValue, void* arg,
         WOLFSSL_CRYPTO_EX_new* cb1, WOLFSSL_CRYPTO_EX_dup* cb2,
         WOLFSSL_CRYPTO_EX_free* cb3)
 {
-    static int ssl_idx = 0;
 
     WOLFSSL_ENTER("wolfSSL_get_ex_new_index");
 
@@ -44996,7 +45057,7 @@ int wolfSSL_get_ex_new_index(long argValue, void* arg,
     (void)cb2;
     (void)cb3;
 
-    return ssl_idx++;
+    return get_ex_new_index(CRYPTO_EX_INDEX_SSL);
 }
 
 
@@ -48960,7 +49021,6 @@ void wolfSSL_OPENSSL_config(char *config_name)
 
 int wolfSSL_X509_get_ex_new_index(int idx, void *arg, void *a, void *b, void *c)
 {
-    static int x509_idx = 0;
 
     WOLFSSL_ENTER("wolfSSL_X509_get_ex_new_index");
     (void)idx;
@@ -48969,7 +49029,7 @@ int wolfSSL_X509_get_ex_new_index(int idx, void *arg, void *a, void *b, void *c)
     (void)b;
     (void)c;
 
-    return x509_idx++;
+    return get_ex_new_index(CRYPTO_EX_INDEX_X509);
 }
 #endif
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -44947,7 +44947,21 @@ int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *pkey)
 #endif /* !NO_CERTS */
 
 #endif /* OPENSSL_EXTRA */
-#if defined(HAVE_EX_DATA) || defined(FORTRESS)
+
+#if ((defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && defined(HAVE_EX_DATA) || \
+      defined(FORTRESS) || defined(WOLFSSL_WPAS_SMALL) || defined(OPENSSL_EXTRA) || \
+      defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || \
+      defined(WOLFSSL_HAPROXY) || defined(HAVE_LIGHTY))
+/**
+ * get_ex_new_index is a helper function for the following
+ * xx_get_ex_new_index functions:
+ *  - wolfSSL_CRYPTO_get_ex_new_index
+ *  - wolfSSL_CTX_get_ex_new_index
+ *  - wolfSSL_get_ex_new_index
+ * Issues a unique index number for the specified class-index.
+ * Returns an index number greater or equal to zero on success,
+ * -1 on failure.
+ */
 static int get_ex_new_index(int class_index)
 {
     /* index counter for each class index*/
@@ -56081,35 +56095,40 @@ int wolfSSL_CONF_cmd(WOLFSSL_CONF_CTX* cctx, const char* cmd, const char* value)
     (void)value;
     return WOLFSSL_FAILURE;
 }
+#endif /* !NO_WOLFSSL_STUB */
 
+#if defined(HAVE_EX_DATA) || defined(FORTRESS)
 /**
- * returns a new index or -1 on failure
+ * Issues unique index for the class specified by class_index.
+ * Other parameter except class_index are ignored.
+ * Currentry, following class_index are accepted:
+ *  - CRYPTO_EX_INDEX_SSL
+ *  - CRYPTO_EX_INDEX_SSL_CTX
+ *  - CRYPTO_EX_INDEX_X509
  * @param class index one of CRYPTO_EX_INDEX_xxx
  * @param argp  parameters to be saved
  * @param argl  parameters to be saved
  * @param new_func a pointer to WOLFSSL_CRYPTO_EX_new
  * @param dup_func a pointer to WOLFSSL_CRYPTO_EX_dup
  * @param free_func a pointer to WOLFSSL_CRYPTO_EX_free
- * @return WOLFSSL_SUCCESS on success, 
- *     otherwise WOLFSSL_FAILURE (stub currently returns WOLFSSL_FAILURE always)
+ * @return index value grater or equal to zero on success, -1 on failure.
  */
-#ifdef HAVE_EX_DATA
 int wolfSSL_CRYPTO_get_ex_new_index(int class_index, long argl, void *argp,
                                            WOLFSSL_CRYPTO_EX_new* new_func,
                                            WOLFSSL_CRYPTO_EX_dup* dup_func,
                                            WOLFSSL_CRYPTO_EX_free* free_func)
 {
-    WOLFSSL_STUB("wolfSSL_CRYPTO_get_ex_new_index");
-    (void)class_index;
+    WOLFSSL_ENTER("wolfSSL_CRYPTO_get_ex_new_index");
     (void)argl;
     (void)argp;
     (void)new_func;
     (void)dup_func;
     (void)free_func;
-    return WOLFSSL_FAILURE;
+
+    return get_ex_new_index(class_index);
 }
-#endif
-#endif /* NO_WOLFSSL_STUB */
+#endif /* HAVE_EX_DATA || FORTRESS */
+#ifndef NO_WOLFSSL_STUB
 /**
  * Return DH p, q and g parameters
  * @param dh a pointer to WOLFSSL_DH

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -45001,28 +45001,6 @@ static int get_ex_new_index(int class_index)
     }
     return index;
 }
-/*  wolfSSL_CRYPTO_get_ex_new_index issues unique index for the class
- *  specified by class_index. Other parameter except class_index are
- *  ignored. Currentry, following class_index are accepted:
- *  - CRYPTO_EX_INDEX_SSL
- *  - CRYPTO_EX_INDEX_SSL_CTX
- *  - CRYPTO_EX_INDEX_X509
- *  Returns index value grater or equal to zero on success, -1 on failure.
- */
-WOLFSSL_API int wolfSSL_CRYPTO_get_ex_new_index(int class_index,
-                                                long argl, void* argp,
-                                        WOLFSSL_CRYPTO_EX_new* new_func,
-                                        WOLFSSL_CRYPTO_EX_dup* dup_func,
-                                        WOLFSSL_CRYPTO_EX_free* free_func)
-{
-    (void)argl;
-    (void)argp;
-    (void)new_func;
-    (void)dup_func;
-    (void)free_func;
-
-    return get_ex_new_index(class_index);
-}
 #endif /* HAVE_EX_DATA || FORTRESS */
 
 #if defined(HAVE_EX_DATA) || defined(FORTRESS) || defined(WOLFSSL_WPAS_SMALL)
@@ -56101,7 +56079,7 @@ int wolfSSL_CONF_cmd(WOLFSSL_CONF_CTX* cctx, const char* cmd, const char* value)
 /**
  * Issues unique index for the class specified by class_index.
  * Other parameter except class_index are ignored.
- * Currentry, following class_index are accepted:
+ * Currently, following class_index are accepted:
  *  - CRYPTO_EX_INDEX_SSL
  *  - CRYPTO_EX_INDEX_SSL_CTX
  *  - CRYPTO_EX_INDEX_X509

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -56106,7 +56106,7 @@ int wolfSSL_CRYPTO_get_ex_new_index(int class_index, long argl, void *argp,
     return get_ex_new_index(class_index);
 }
 #endif /* HAVE_EX_DATA || FORTRESS */
-#ifndef NO_WOLFSSL_STUB
+
 /**
  * Return DH p, q and g parameters
  * @param dh a pointer to WOLFSSL_DH

--- a/tests/api.c
+++ b/tests/api.c
@@ -37873,6 +37873,71 @@ static void test_wolfSSL_i2d_PrivateKey(void)
 #endif
 }
 
+static void test_wolfSSL_CRYPTO_get_ex_new_index(void)
+{
+#if defined(HAVE_EX_DATA) || defined(FORTRESS)
+    int idx1,idx2;
+
+    printf(testingFmt, "test_wolfSSL_CRYPTO_get_ex_new_index()");
+
+    /* test for unsupported flass index */
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_SESSION,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE_CTX,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_DH,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_DSA,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_EC_KEY,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_RSA,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_ENGINE,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_UI,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_BIO,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_APP,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_UI_METHOD,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_DRBG,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(20, 0,NULL, NULL, NULL, NULL ), -1);
+
+    /* test for supported class index */
+    idx1 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL,
+                                         0,NULL, NULL, NULL, NULL );
+    idx2 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL,
+                                         0,NULL, NULL, NULL, NULL );
+    AssertIntNE(idx1, -1);
+    AssertIntNE(idx2, -1);
+    AssertIntNE(idx1, idx2);
+
+    idx1 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_CTX,
+                                         0,NULL, NULL, NULL, NULL );
+    idx2 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_CTX,
+                                         0,NULL, NULL, NULL, NULL );
+    AssertIntNE(idx1, -1);
+    AssertIntNE(idx2, -1);
+    AssertIntNE(idx1, idx2);
+
+    idx1 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509,
+                                         0,NULL, NULL, NULL, NULL );
+    idx2 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509,
+                                         0,NULL, NULL, NULL, NULL );
+    AssertIntNE(idx1, -1);
+    AssertIntNE(idx2, -1);
+    AssertIntNE(idx1, idx2);
+
+    printf(resultFmt, "passed");
+#endif /* HAVE_EX_DATA || FORTRESS */
+}
+
 static void test_wolfSSL_OCSP_id_get0_info(void)
 {
 #if defined(OPENSSL_ALL) && defined(HAVE_OCSP) && !defined(NO_FILESYSTEM)
@@ -43259,7 +43324,7 @@ void ApiTest(void)
     test_CRYPTO_set_dynlock_xxx();
     test_CRYPTO_THREADID_xxx();
     test_ENGINE_cleanup();
-
+    test_wolfSSL_CRYPTO_get_ex_new_index();
     test_wolfSSL_EC_KEY_set_group();
 #if defined(OPENSSL_ALL)
     test_wolfSSL_X509_PUBKEY_get();

--- a/tests/api.c
+++ b/tests/api.c
@@ -37873,71 +37873,6 @@ static void test_wolfSSL_i2d_PrivateKey(void)
 #endif
 }
 
-static void test_wolfSSL_CRYPTO_get_ex_new_index(void)
-{
-#if defined(HAVE_EX_DATA) || defined(FORTRESS)
-    int idx1,idx2;
-
-    printf(testingFmt, "test_wolfSSL_CRYPTO_get_ex_new_index()");
-
-    /* test for unsupported flass index */
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_SESSION,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE_CTX,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_DH,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_DSA,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_EC_KEY,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_RSA,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_ENGINE,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_UI,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_BIO,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_APP,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_UI_METHOD,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_DRBG,
-                                         0,NULL, NULL, NULL, NULL ), -1);
-    AssertIntEQ(CRYPTO_get_ex_new_index(20, 0,NULL, NULL, NULL, NULL ), -1);
-
-    /* test for supported class index */
-    idx1 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL,
-                                         0,NULL, NULL, NULL, NULL );
-    idx2 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL,
-                                         0,NULL, NULL, NULL, NULL );
-    AssertIntNE(idx1, -1);
-    AssertIntNE(idx2, -1);
-    AssertIntNE(idx1, idx2);
-
-    idx1 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_CTX,
-                                         0,NULL, NULL, NULL, NULL );
-    idx2 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_CTX,
-                                         0,NULL, NULL, NULL, NULL );
-    AssertIntNE(idx1, -1);
-    AssertIntNE(idx2, -1);
-    AssertIntNE(idx1, idx2);
-
-    idx1 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509,
-                                         0,NULL, NULL, NULL, NULL );
-    idx2 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509,
-                                         0,NULL, NULL, NULL, NULL );
-    AssertIntNE(idx1, -1);
-    AssertIntNE(idx2, -1);
-    AssertIntNE(idx1, idx2);
-
-    printf(resultFmt, "passed");
-#endif /* HAVE_EX_DATA || FORTRESS */
-}
-
 static void test_wolfSSL_OCSP_id_get0_info(void)
 {
 #if defined(OPENSSL_ALL) && defined(HAVE_OCSP) && !defined(NO_FILESYSTEM)
@@ -42888,22 +42823,67 @@ static void test_CONF_CTX(void)
 
 static void test_wolfSSL_CRYPTO_get_ex_new_index(void)
 {
-#if defined(OPENSSL_ALL) && !defined(NO_WOLFSSL_STUB) && defined(HAVE_EX_DATA)
-    printf(testingFmt, "test_wolfSSL_CRYPTO_get_ex_new_index");
-    
-    int class_index = 0;
-    long argl = 0;
-    void* argp = NULL;
-    CRYPTO_EX_new* nfunc = NULL;
-    CRYPTO_EX_dup* dfunc = NULL;
-    CRYPTO_EX_free* ffunc = NULL;
-    
-    AssertIntEQ(CRYPTO_get_ex_new_index(class_index,
-                                        argl, argp,
-                                        nfunc, dfunc, ffunc),
-                                        WOLFSSL_FAILURE);
-    printf(resultFmt, passed);
-#endif
+#if defined(HAVE_EX_DATA) || defined(FORTRESS)
+    int idx1,idx2;
+
+    printf(testingFmt, "test_wolfSSL_CRYPTO_get_ex_new_index()");
+
+    /* test for unsupported flass index */
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_SESSION,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE_CTX,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_DH,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_DSA,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_EC_KEY,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_RSA,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_ENGINE,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_UI,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_BIO,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_APP,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_UI_METHOD,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_DRBG,
+                                         0,NULL, NULL, NULL, NULL ), -1);
+    AssertIntEQ(CRYPTO_get_ex_new_index(20, 0,NULL, NULL, NULL, NULL ), -1);
+
+    /* test for supported class index */
+    idx1 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL,
+                                         0,NULL, NULL, NULL, NULL );
+    idx2 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL,
+                                         0,NULL, NULL, NULL, NULL );
+    AssertIntNE(idx1, -1);
+    AssertIntNE(idx2, -1);
+    AssertIntNE(idx1, idx2);
+
+    idx1 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_CTX,
+                                         0,NULL, NULL, NULL, NULL );
+    idx2 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL_CTX,
+                                         0,NULL, NULL, NULL, NULL );
+    AssertIntNE(idx1, -1);
+    AssertIntNE(idx2, -1);
+    AssertIntNE(idx1, idx2);
+
+    idx1 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509,
+                                         0,NULL, NULL, NULL, NULL );
+    idx2 = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509,
+                                         0,NULL, NULL, NULL, NULL );
+    AssertIntNE(idx1, -1);
+    AssertIntNE(idx2, -1);
+    AssertIntNE(idx1, idx2);
+
+    printf(resultFmt, "passed");
+#endif /* HAVE_EX_DATA || FORTRESS */
 }
 
 static void test_wolfSSL_set_psk_use_session_callback(void)
@@ -43324,7 +43304,6 @@ void ApiTest(void)
     test_CRYPTO_set_dynlock_xxx();
     test_CRYPTO_THREADID_xxx();
     test_ENGINE_cleanup();
-    test_wolfSSL_CRYPTO_get_ex_new_index();
     test_wolfSSL_EC_KEY_set_group();
 #if defined(OPENSSL_ALL)
     test_wolfSSL_X509_PUBKEY_get();

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -166,6 +166,8 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define CRYPTO_memcmp                   wolfSSL_CRYPTO_memcmp
 #define CRYPTO_get_ex_new_index         wolfSSL_CRYPTO_get_ex_new_index
 
+#define CRYPTO_get_ex_new_index         wolfSSL_CRYPTO_get_ex_new_index
+
 /* this function was used to set the default malloc, free, and realloc */
 #define CRYPTO_malloc_init() 0 /* CRYPTO_malloc_init is not needed */
 #define OPENSSL_malloc_init() 0 /* OPENSSL_malloc_init is not needed */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1063,17 +1063,6 @@ WOLFSSL_API WOLFSSL_X509* wolfSSL_SESSION_get0_peer(WOLFSSL_SESSION* session);
 typedef int (*VerifyCallback)(int, WOLFSSL_X509_STORE_CTX*);
 typedef void (CallbackInfoState)(const WOLFSSL*, int, int);
 
-#if defined(HAVE_EX_DATA) || defined(FORTRESS)
-typedef int  (WOLFSSL_CRYPTO_EX_new)(void* p, void* ptr,
-        WOLFSSL_CRYPTO_EX_DATA* a, int idx, long argValue, void* arg);
-typedef int  (WOLFSSL_CRYPTO_EX_dup)(WOLFSSL_CRYPTO_EX_DATA* out,
-        WOLFSSL_CRYPTO_EX_DATA* in, void* inPtr, int idx, long argV, void* arg);
-typedef void (WOLFSSL_CRYPTO_EX_free)(void* p, void* ptr,
-        WOLFSSL_CRYPTO_EX_DATA* a, int idx, long argValue, void* arg);
-
-WOLFSSL_API int  wolfSSL_get_ex_new_index(long argValue, void* arg,
-        WOLFSSL_CRYPTO_EX_new* a, WOLFSSL_CRYPTO_EX_dup* b,
-        WOLFSSL_CRYPTO_EX_free* c);
 /* class index for wolfSSL_CRYPTO_get_ex_new_index */
 #define CRYPTO_EX_INDEX_SSL             0
 #define CRYPTO_EX_INDEX_SSL_CTX         1
@@ -1093,12 +1082,18 @@ WOLFSSL_API int  wolfSSL_get_ex_new_index(long argValue, void* arg,
 #define CRYPTO_EX_INDEX_DRBG            15
 #define CRYPTO_EX_INDEX__COUNT          16
 
+#if defined(HAVE_EX_DATA) || defined(FORTRESS)
+typedef int  (WOLFSSL_CRYPTO_EX_new)(void* p, void* ptr,
+        WOLFSSL_CRYPTO_EX_DATA* a, int idx, long argValue, void* arg);
+typedef int  (WOLFSSL_CRYPTO_EX_dup)(WOLFSSL_CRYPTO_EX_DATA* out,
+        WOLFSSL_CRYPTO_EX_DATA* in, void* inPtr, int idx, long argV, void* arg);
+typedef void (WOLFSSL_CRYPTO_EX_free)(void* p, void* ptr,
+        WOLFSSL_CRYPTO_EX_DATA* a, int idx, long argValue, void* arg);
 
-WOLFSSL_API int wolfSSL_CRYPTO_get_ex_new_index(int class_index,
-                                                long argl, void* argp,
-                                        WOLFSSL_CRYPTO_EX_new* new_func,
-                                        WOLFSSL_CRYPTO_EX_dup* dup_func,
-                                        WOLFSSL_CRYPTO_EX_free* free_func);
+WOLFSSL_API int  wolfSSL_get_ex_new_index(long argValue, void* arg,
+        WOLFSSL_CRYPTO_EX_new* a, WOLFSSL_CRYPTO_EX_dup* b,
+        WOLFSSL_CRYPTO_EX_free* c);
+
 #endif
 
 WOLFSSL_API void wolfSSL_CTX_set_verify(WOLFSSL_CTX*, int,
@@ -4419,12 +4414,12 @@ WOLFSSL_API void wolfSSL_CONF_CTX_set_ssl_ctx(WOLFSSL_CONF_CTX* cctx, WOLFSSL_CT
 WOLFSSL_API unsigned int wolfSSL_CONF_CTX_set_flags(WOLFSSL_CONF_CTX* cctx, unsigned int flags);
 WOLFSSL_API int wolfSSL_CONF_CTX_finish(WOLFSSL_CONF_CTX* cctx);
 WOLFSSL_API int wolfSSL_CONF_cmd(WOLFSSL_CONF_CTX* cctx, const char* cmd, const char* value);
-#ifdef HAVE_EX_DATA
+#if defined(HAVE_EX_DATA) || defined(FORTRESS)
 WOLFSSL_API int wolfSSL_CRYPTO_get_ex_new_index(int class_index, long argl, void *argp,
                                            WOLFSSL_CRYPTO_EX_new* new_func,
                                            WOLFSSL_CRYPTO_EX_dup* dup_func,
                                            WOLFSSL_CRYPTO_EX_free* free_func);
-#endif
+#endif /* HAVE_EX_DATA || FORTRESS */
 #endif /* OPENSSL_EXTRA */
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1074,6 +1074,31 @@ typedef void (WOLFSSL_CRYPTO_EX_free)(void* p, void* ptr,
 WOLFSSL_API int  wolfSSL_get_ex_new_index(long argValue, void* arg,
         WOLFSSL_CRYPTO_EX_new* a, WOLFSSL_CRYPTO_EX_dup* b,
         WOLFSSL_CRYPTO_EX_free* c);
+/* class index for wolfSSL_CRYPTO_get_ex_new_index */
+#define CRYPTO_EX_INDEX_SSL             0
+#define CRYPTO_EX_INDEX_SSL_CTX         1
+#define CRYPTO_EX_INDEX_SSL_SESSION     2
+#define CRYPTO_EX_INDEX_X509            3
+#define CRYPTO_EX_INDEX_X509_STORE      4
+#define CRYPTO_EX_INDEX_X509_STORE_CTX  5
+#define CRYPTO_EX_INDEX_DH              6
+#define CRYPTO_EX_INDEX_DSA             7
+#define CRYPTO_EX_INDEX_EC_KEY          8
+#define CRYPTO_EX_INDEX_RSA             9
+#define CRYPTO_EX_INDEX_ENGINE          10
+#define CRYPTO_EX_INDEX_UI              11
+#define CRYPTO_EX_INDEX_BIO             12
+#define CRYPTO_EX_INDEX_APP             13
+#define CRYPTO_EX_INDEX_UI_METHOD       14
+#define CRYPTO_EX_INDEX_DRBG            15
+#define CRYPTO_EX_INDEX__COUNT          16
+
+
+WOLFSSL_API int wolfSSL_CRYPTO_get_ex_new_index(int class_index,
+                                                long argl, void* argp,
+                                        WOLFSSL_CRYPTO_EX_new* new_func,
+                                        WOLFSSL_CRYPTO_EX_dup* dup_func,
+                                        WOLFSSL_CRYPTO_EX_free* free_func);
 #endif
 
 WOLFSSL_API void wolfSSL_CTX_set_verify(WOLFSSL_CTX*, int,


### PR DESCRIPTION
Add wolfSSL_CRYPTO_get_ex_new_index for OpenSSL compat layer.

wolfSSL_CRYPTO_get_ex_new_index issues unique index value for the class  specified by class_index.
Other parameter except class_index are  ignored. 
Currentry, following class_index are accepted:
 - CRYPTO_EX_INDEX_SSL
 - CRYPTO_EX_INDEX_SSL_CTX
 - CRYPTO_EX_INDEX_X509