### PR TITLE
Renesas RX: Use intrinsics for rot[rl], revl

### DIFF
--- a/wolfcrypt/src/misc.c
+++ b/wolfcrypt/src/misc.c
@@ -81,6 +81,30 @@ masking and clearing memory logic.
         return y ? _lrotr(x, y) : x;
     }
 
+#elif defined(__CCRX__)
+
+    #include <builtin.h>      /* get intrinsic definitions */
+
+    #if !defined(NO_INLINE)
+
+    #define rotlFixed(x, y) _builtin_rotl(x, y)
+
+    #define rotrFixed(x, y) _builtin_rotr(x, y)
+
+    #else /* create real function */
+
+    WC_STATIC WC_INLINE word32 rotlFixed(word32 x, word32 y)
+    {
+        return _builtin_rotl(x, y);
+    }
+
+    WC_STATIC WC_INLINE word32 rotrFixed(word32 x, word32 y)
+    {
+        return _builtin_rotr(x, y);
+    }
+
+    #endif
+
 #else /* generic */
 /* This routine performs a left circular arithmetic shift of <x> by <y> value. */
 
@@ -115,6 +139,9 @@ WC_STATIC WC_INLINE word16 rotrFixed16(word16 x, word16 y)
 #endif /* WC_RC2 */
 
 /* This routine performs a byte swap of 32-bit word value. */
+#if defined(__CCRX__) && !defined(NO_INLINE) // shortest version for CC-RX
+    #define ByteReverseWord32(value) _builtin_revl(value)
+#else
 WC_STATIC WC_INLINE word32 ByteReverseWord32(word32 value)
 {
 #ifdef PPC_INTRINSICS
@@ -124,6 +151,8 @@ WC_STATIC WC_INLINE word32 ByteReverseWord32(word32 value)
     return (word32)__REV(value);
 #elif defined(KEIL_INTRINSICS)
     return (word32)__rev(value);
+#elif defined(__CCRX__)
+    return (word32)_builtin_revl(value);
 #elif defined(WOLF_ALLOW_BUILTIN) && \
         defined(__GNUC_PREREQ) && __GNUC_PREREQ(4, 3)
     return (word32)__builtin_bswap32(value);
@@ -153,6 +182,7 @@ WC_STATIC WC_INLINE word32 ByteReverseWord32(word32 value)
     return rotlFixed(value, 16U);
 #endif
 }
+#endif /* __CCRX__ */
 /* This routine performs a byte swap of words array of a given count. */
 WC_STATIC WC_INLINE void ByteReverseWords(word32* out, const word32* in,
                                     word32 byteCount)

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -211,6 +211,8 @@ decouple library dependencies with standard string, memory and so on.
             #else
                 #define WC_INLINE inline
             #endif
+        #elif defined(__CCRX__)
+            #define WC_INLINE inline
         #else
             #define WC_INLINE
         #endif
@@ -235,6 +237,8 @@ decouple library dependencies with standard string, memory and so on.
         #define FAST_ROTATE
     #elif defined(__MWERKS__) && TARGET_CPU_PPC
         #define PPC_INTRINSICS
+        #define FAST_ROTATE
+    #elif defined(__CCRX__)
         #define FAST_ROTATE
     #elif defined(__GNUC__)  && (defined(__i386__) || defined(__x86_64__))
         /* GCC does peephole optimizations which should result in using rotate


### PR DESCRIPTION
For byte order reverse and rotation we have builtins
in the CC-RX compiler.
Especially when rotating registers with fixed amounts
this can be compiled efficiently into opcodes with
embedded values for shift (without needing other registers).