### PR TITLE
Fix for ATECC on platforms where bool and int have different sizes

### DIFF
--- a/wolfcrypt/src/port/atmel/atmel.c
+++ b/wolfcrypt/src/port/atmel/atmel.c
@@ -453,12 +453,15 @@ int atmel_ecc_sign(int slotId, const byte* message, byte* signature)
 }
 
 int atmel_ecc_verify(const byte* message, const byte* signature,
-    const byte* pubkey, int* verified)
+    const byte* pubkey, int* pVerified)
 {
     int ret;
+    bool verified = false;
 
-    ret = atcab_verify_extern(message, signature, pubkey, (bool*)verified);
+    ret = atcab_verify_extern(message, signature, pubkey, &verified);
     ret = atmel_ecc_translate_err(ret);
+    if (pVerified)
+        *pVerified = (int)verified;
     return ret;
 }
 

--- a/wolfssl/wolfcrypt/port/atmel/atmel.h
+++ b/wolfssl/wolfcrypt/port/atmel/atmel.h
@@ -119,7 +119,7 @@ int  atmel_ecc_create_pms(int slotId, const uint8_t* peerKey, uint8_t* pms);
 int  atmel_ecc_create_key(int slotId, byte* peerKey);
 int  atmel_ecc_sign(int slotId, const byte* message, byte* signature);
 int  atmel_ecc_verify(const byte* message, const byte* signature,
-    const byte* pubkey, int* verified);
+    const byte* pubkey, int* pVerified);
 
 #endif /* WOLFSSL_ATECC508A */
 


### PR DESCRIPTION
Related to issue #3971