### PR TITLE
TLS minimum downgrade option

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -19,7 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
 #ifdef HAVE_CONFIG_H
         #include <config.h>
 #endif
@@ -1521,6 +1520,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     int    ch;
 #endif
     int    version = CLIENT_INVALID_VERSION;
+    int    minVersion = CLIENT_INVALID_VERSION;
+    int    setMinVersion = 0;
     int    usePsk   = 0;
     int    useAnon  = 0;
     int    sendGET  = 0;
@@ -1719,7 +1720,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     while ((ch = mygetopt(argc, argv, "?:"
             "ab:c:defgh:i;jk:l:mnop:q:rstu;v:wxyz"
             "A:B:CDE:F:GH:IJKL:M:NO:PQRS:TUVW:XYZ:"
-            "01:23:45689"
+            "01:23:4567:89"
             "@#")) != -1) {
         switch (ch) {
             case '?' :
@@ -2186,7 +2187,14 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 nonBlocking = 1;
                 simulateWantWrite = 1;
                 break;
-
+            case '7' :
+                setMinVersion = 1;
+                minVersion = atoi(myoptarg);
+                if (minVersion < 0 || minVersion > 4) {
+                    Usage();
+                    XEXIT_T(MY_EX_USAGE);
+                }
+                break;
             case '8' :
                 #ifdef HAVE_CURVE448
                     useX448 = 1;
@@ -2466,9 +2474,10 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             err_sys("unable to get ctx");
     }
 #endif
-
-    if (simulateWantWrite)
-    {
+    if (setMinVersion) {
+        wolfSSL_CTX_SetMinVersion(ctx, minVersion);
+    }
+    if (simulateWantWrite) {
         wolfSSL_CTX_SetIOSend(ctx, SimulateWantWriteIOSendCb);
     }
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3116,6 +3116,10 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             ssl->version.minor = pv.minor;
         }
 
+        if (foundVersion && ssl->options.downgrade && (pv.minor < ssl->options.minDowngrade)) {
+            return VERSION_ERROR;
+        }
+
         /* Parse and handle extensions. */
         ret = TLSX_Parse(ssl, input + i, totalExtSz, *extMsgType, NULL);
         if (ret != 0)

--- a/tests/include.am
+++ b/tests/include.am
@@ -54,5 +54,6 @@ EXTRA_DIST += tests/test.conf \
               tests/test-p521.conf \
               tests/test-ecc-cust-curves.conf \
               tests/NCONF_test.cnf \
+              tests/test-tls-downgrade.conf \
               tests/TXT_DB.txt
 DISTCLEANFILES+= tests/.libs/unit.test

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -82,6 +82,8 @@ static int GetTlsVersion(const char* line)
 
     if (begin) {
         begin += 3;
+        if (*begin == 'd' || *begin == 'e')
+            begin += 2;
 
         version = atoi(begin);
     }

--- a/tests/test-tls-downgrade.conf
+++ b/tests/test-tls-downgrade.conf
@@ -1,0 +1,30 @@
+# server TLSv1.3
+-v 4
+-l ECDHE-RSA-AES256-GCM-SHA384
+-H exitWithRet
+
+# client TLSv1.2, should fail
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+-H exitWithRet
+
+# server TLSv1.2 
+-v 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+-H exitWithRet
+
+# client TLSv1.3, should fail
+-v 4
+-l ECDHE-RSA-AES256-GCM-SHA384
+-H exitWithRet
+
+# server TLSv1.2 
+-v d 3
+-l ECDHE-RSA-AES256-GCM-SHA384
+-H exitWithRet
+
+# client TLSv1.3 with downgrade option, set downgrade to TLSv1.3, should fail
+-7 4
+-v d 4
+-l ECDHE-RSA-AES256-GCM-SHA384
+-H exitWithRet


### PR DESCRIPTION
This PR addresses a corner case TLS downgrade issue reported on ZD#11999 with the following server/client setup that was connecting instead of failing. 

1. Client configured with TLS1.3 with a downgrade option enabled 
2. Client minimum downgrade version is set as TLS1.3
2. Connect to SSL server configured only for TLS1.2

Previously a client/server would connect with these commands. 

```
./examples/server/server -v d 3
./examples/client/client -7 4 -v d 4
```