### PR TITLE
Fix RSA PSS padding check

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3478,7 +3478,11 @@ int wc_RsaPSS_Verify_ex(byte* in, word32 inLen, byte* out, word32 outLen,
 int wc_RsaPSS_CheckPadding(const byte* in, word32 inSz, byte* sig,
                            word32 sigSz, enum wc_HashType hashType)
 {
-    return wc_RsaPSS_CheckPadding_ex(in, inSz, sig, sigSz, hashType, inSz, 0);
+#ifndef WOLFSSL_PSS_SALT_LEN_DISCOVER
+    return wc_RsaPSS_CheckPadding_ex(in, inSz, sig, sigSz, hashType, RSA_PSS_SALT_LEN_DEFAULT, 0);
+#else
+    return wc_RsaPSS_CheckPadding_ex(in, inSz, sig, sigSz, hashType, RSA_PSS_SALT_LEN_DISCOVER, 0);
+#endif
 }
 
 /* Checks the PSS data to ensure that the signature matches.
@@ -3524,7 +3528,7 @@ int wc_RsaPSS_CheckPadding_ex(const byte* in, word32 inSz, byte* sig,
             #endif
         }
 #ifndef WOLFSSL_PSS_LONG_SALT
-        else if ((word32)saltLen > inSz) {
+        else if (saltLen > (int)inSz) {
             ret = PSS_SALTLEN_E;
         }
 #endif


### PR DESCRIPTION
This PR corrects the detection of a salt length from an RSA signature (ZD# 12073). 
It improves interop with OpenSSL default behavior. 

Signatures created with something like the following command can now be verified in wolfSSL. 
```
openssl dgst -sha256 -sign priv_key.pem -out open_signFile.bin -sigopt rsa_padding_mode:pss dataFile.txt
```

```
./configure --enable-rsapss C_EXTRA_FLAGS="-DWOLFSSL_PSS_SALT_LEN_DISCOVER -DWOLFSSL_PSS_LONG_SALT"
wc_RsaPSS_Verify()
wc_RsaPSS_CheckPadding()
```