### PR TITLE
Allow parsing spaces in Base64_SkipNewline

### DIFF
--- a/wolfcrypt/src/coding.c
+++ b/wolfcrypt/src/coding.c
@@ -117,23 +117,31 @@ static WC_INLINE int Base64_SkipNewline(const byte* in, word32 *inLen, word32 *o
 {
     word32 len = *inLen;
     word32 j = *outJ;
-    if (len && (in[j] == ' ' || in[j] == '\r' || in[j] == '\n')) {
-        byte endLine = in[j++];
+    byte curChar = in[j];
+    while (len && curChar == ' ') {
+        /* skip whitespace in the middle or end of line */
+        curChar = in[++j];
         len--;
-        while (len && endLine == ' ') {   /* allow trailing whitespace */
-            endLine = in[j++];
-            len--;
-        }
-        if (endLine == '\r') {
+    }
+    if (len && (curChar == '\r' || curChar == '\n')) {
+        j++;
+        len--;
+        if (curChar == '\r') {
             if (len) {
-                endLine = in[j++];
+                curChar = in[j++];
                 len--;
             }
         }
-        if (endLine != '\n') {
+        if (curChar != '\n') {
             WOLFSSL_MSG("Bad end of line in Base64 Decode");
             return ASN_INPUT_E;
         }
+        curChar = in[j];
+    }
+    while (len && curChar == ' ') {
+        /* skip whitespace at beginning of line */
+        curChar = in[++j];
+        len--;
     }
     if (!len) {
         return BUFFER_E;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -176,10 +176,6 @@ _Pragma("GCC diagnostic ignored \"-Wunused-function\"");
                       __android_log_print(ANDROID_LOG_DEBUG, "TAG", __VA_ARGS__)
     #define fprintf(fp, ...)  \
                       __android_log_print(ANDROID_LOG_DEBUG, "TAG", __VA_ARGS__)
-#elif defined(WOLFSSL_DEOS)
-    #include <printx.h>
-    #undef printf
-    #define printf printx
 #else
     #ifdef XMALLOC_USER
         #include <stdlib.h>  /* we're using malloc / free direct here */
@@ -1652,6 +1648,7 @@ WOLFSSL_TEST_SUBROUTINE int base64_test(void)
     int        ret;
     WOLFSSL_SMALL_STACK_STATIC const byte good[] = "A+Gd\0\0\0";
     WOLFSSL_SMALL_STACK_STATIC const byte goodEnd[] = "A+Gd \r\n";
+    WOLFSSL_SMALL_STACK_STATIC const byte good_spaces[] = " A + G d \0";
     byte       out[128];
     word32     outLen;
 #ifdef WOLFSSL_BASE64_ENCODE
@@ -1660,9 +1657,9 @@ WOLFSSL_TEST_SUBROUTINE int base64_test(void)
     byte       longData[79] = { 0 };
     WOLFSSL_SMALL_STACK_STATIC const byte symbols[] = "+/A=";
 #endif
-    WOLFSSL_SMALL_STACK_STATIC const byte badSmall[] = "AAA Gdj=";
+    WOLFSSL_SMALL_STACK_STATIC const byte badSmall[] = "AAA!Gdj=";
     WOLFSSL_SMALL_STACK_STATIC const byte badLarge[] = "AAA~Gdj=";
-    WOLFSSL_SMALL_STACK_STATIC const byte badEOL[] = "A+Gd AA";
+    WOLFSSL_SMALL_STACK_STATIC const byte badEOL[] = "A+Gd!AA";
     WOLFSSL_SMALL_STACK_STATIC const byte badPadding[] = "AA=A";
     WOLFSSL_SMALL_STACK_STATIC const byte badChar[] = ",-.:;<=>?@[\\]^_`";
     byte goodChar[] =
@@ -1687,6 +1684,10 @@ WOLFSSL_TEST_SUBROUTINE int base64_test(void)
         return -1235;
     if (outLen != 64 / 4 * 3)
         return -1236;
+    outLen = sizeof(out);
+    ret = Base64_Decode(good_spaces, sizeof(good_spaces), out, &outLen);
+    if (ret != 0)
+        return -1201;
 
     /* Bad parameters. */
     outLen = 1;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -176,6 +176,10 @@ _Pragma("GCC diagnostic ignored \"-Wunused-function\"");
                       __android_log_print(ANDROID_LOG_DEBUG, "TAG", __VA_ARGS__)
     #define fprintf(fp, ...)  \
                       __android_log_print(ANDROID_LOG_DEBUG, "TAG", __VA_ARGS__)
+#elif defined(WOLFSSL_DEOS)
+    #include <printx.h>
+    #undef printf
+    #define printf printx
 #else
     #ifdef XMALLOC_USER
         #include <stdlib.h>  /* we're using malloc / free direct here */


### PR DESCRIPTION
Whitespace in the x509 is not strictly forbidden, and we already skipped spaces at the end of lines. This change allows skipping spaces at the beginning and in the middle of lines.

https://stackoverflow.com/questions/26496155/are-spaces-alowed-in-x509-certificates

Thanks to @julek-wolfssl for the patch!

This addresses an issue from ZD12169