### PR TITLE
Fix test build

### DIFF
--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -21689,7 +21689,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     ret = wc_ecc_export_private_only(userA, exportBuf, &x);
     if (ret != 0)
         ERROR_OUT(-9942, done);
-#else
+#elif defined(HAVE_ECC_KEY_EXPORT)
     (void)exportBuf;
 #endif /* HAVE_ECC_KEY_EXPORT */
 


### PR DESCRIPTION
This PR fixes a build error with the following configurations: 

```
./configure  --enable-cryptonly --enable-cryptonly --enable-sp=small,nomalloc,384 CFLAGS="-DNO_ECC256 -DNO_ECC_KEY_EXPORT"  && make
```

```
wolfcrypt/test/test.c: In function ‘ecc_test_curve_size’:
wolfcrypt/test/test.c:21693:11: error: ‘exportBuf’ undeclared (first use in this function)
21693 |     (void)exportBuf;
      |           ^~~~~~~~~
wolfcrypt/test/test.c:21693:11: note: each undeclared identifier is reported only once for each function it appears in

```