### PR TITLE
Fix for SIZEOF detection and issue with CTC_SETTINGS

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -98,12 +98,16 @@ decouple library dependencies with standard string, memory and so on.
 
     /* try to set SIZEOF_LONG or SIZEOF_LONG_LONG if user didn't */
     #if defined(_MSC_VER) || defined(HAVE_LIMITS_H)
-        #if !defined(SIZEOF_LONG_LONG) && !defined(SIZEOF_LONG)
+        /* make sure both SIZEOF_LONG_LONG and SIZEOF_LONG are set, 
+         * otherwise causes issues with CTC_SETTINGS */
+        #if !defined(SIZEOF_LONG_LONG) || !defined(SIZEOF_LONG)
             #include <limits.h>
-            #if defined(ULONG_MAX) && (ULONG_MAX == 0xffffffffUL)
+            #if !defined(SIZEOF_LONG) && defined(ULONG_MAX) && \
+                    (ULONG_MAX == 0xffffffffUL)
                 #define SIZEOF_LONG 4
             #endif
-            #if defined(ULLONG_MAX) && (ULLONG_MAX == 0xffffffffffffffffULL)
+            #if !defined(SIZEOF_LONG_LONG) && defined(ULLONG_MAX) && \
+                    (ULLONG_MAX == 0xffffffffffffffffULL)
                 #define SIZEOF_LONG_LONG 8
             #endif
         #endif


### PR DESCRIPTION
For platforms that support limits.h or windows make sure both `SIZEOF_LONG_LONG` and `SIZEOF_LONG` are set, otherwise causes issues with CTC_SETTINGS.