### PR TITLE
Add support for reproducible builds with CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,18 @@ find_package(Threads)
 #       - 32-bit mode
 #       - 16-bit mode
 
+# For reproducible build, gate out from the build anything that might
+# introduce semantically frivolous jitter, maximizing chance of
+# identical object files.
+set(WOLFSSL_REPRODUCIBLE_BUILD_HELP_STRING "Enable maximally reproducible build (default: disabled)")
+add_option("WOLFSSL_REPRODUCIBLE_BUILD" ${WOLFSSL_REPRODUCIBLE_BUILD_HELP_STRING} "no" "yes;no")
+
+if(WOLFSSL_REPRODUCIBLE_BUILD)
+    set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> Dqc <TARGET> <LINK_FLAGS> <OBJECTS>")
+    set(CMAKE_C_ARCHIVE_APPEND "<CMAKE_AR> Dq  <TARGET> <LINK_FLAGS> <OBJECTS>")
+    set(CMAKE_C_ARCHIVE_FINISH "<CMAKE_RANLIB> -D <TARGET>")
+endif()
+
 # Support for disabling all ASM
 set(WOLFSSL_ASM_HELP_STRING "Enables option for assembly (default: enabled)")
 add_option("WOLFSSL_ASM" ${WOLFSSL_ASM_HELP_STRING} "yes" "yes;no")


### PR DESCRIPTION
Unlike the autotools build, I've chosen NOT to make the build un-deterministic
if WOLFSSL_REPRODUCIBLE_BUILD is set to no (the default). Instead, I just use
whatever CMake's default is. On my system, ar and ranlib run in deterministic
mode by default, and the CMake defaults for the relevant ar and ranlib variables
are:

CMAKE_C_ARCHIVE_CREATE = <CMAKE_AR> qc <TARGET> <LINK_FLAGS> <OBJECTS>
CMAKE_C_ARCHIVE_APPEND = <CMAKE_AR> q  <TARGET> <LINK_FLAGS> <OBJECTS>
CMAKE_C_ARCHIVE_FINISH = <CMAKE_RANLIB> <TARGET>

So my builds are automatically deterministic. This is normal on my system so I
wouldn't want to make them not deterministic by default, hence the decision.

I validated with md5sum on libwolfssl.a that explicitly making the build not
deterministic indeed results in different checksums across multiple runs. The
checksums are the same when flipping back to deterministic mode.

Addresses feature request from https://github.com/wolfSSL/wolfssl/issues/3887.