### PR TITLE
Add `wc_ecc_gen_k` arg checking. Fix SP math debug support (mp_dump)

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3222,13 +3222,13 @@ int wc_ecc_mulmod_ex2(const mp_int* k, ecc_point *G, ecc_point *R, mp_int* a,
    if (err == MP_OKAY) {
       int kIsMinusOne = (mp_cmp((mp_int*)k, &t) == MP_EQ);
       err = mp_cond_copy(tG->x, kIsMinusOne, R->x);
-      if (err == 0) {
+      if (err == MP_OKAY) {
           err = mp_sub(modulus, tG->y, &t);
       }
-      if (err == 0) {
+      if (err == MP_OKAY) {
           err = mp_cond_copy(&t, kIsMinusOne, R->y);
       }
-      if (err == 0) {
+      if (err == MP_OKAY) {
           err = mp_cond_copy(tG->z, kIsMinusOne, R->z);
       }
    }
@@ -4291,8 +4291,12 @@ int wc_ecc_gen_k(WC_RNG* rng, int size, mp_int* k, mp_int* order)
     int err;
     byte buf[ECC_MAXSIZE_GEN];
 
-    /*generate 8 extra bytes to mitigate bias from the modulo operation below*/
-    /*see section A.1.2 in 'Suite B Implementor's Guide to FIPS 186-3 (ECDSA)'*/
+    if (rng == NULL || size > ECC_MAXSIZE_GEN || k == NULL || order == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* generate 8 extra bytes to mitigate bias from the modulo operation below */
+    /* see section A.1.2 in 'Suite B Implementor's Guide to FIPS 186-3 (ECDSA)' */
     size += 8;
 
     /* make up random string */

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -156,7 +156,7 @@ extern "C" {
 #endif
 
 
-/* Detemine the number of bits to use in each word. */
+/* Determine the number of bits to use in each word. */
 #ifdef SP_WORD_SIZE
 #elif defined(WOLFSSL_DSP_BUILD)
     #define SP_WORD_SIZE 32
@@ -510,7 +510,7 @@ typedef struct sp_ecc_ctx {
     #define sp_print_digit(a, s)
     #define sp_print_int(a, s)
 
-#endif
+#endif /* !NO_FILESYSTEM */
 
 /* Returns whether multi-precision number is odd
  *
@@ -978,7 +978,15 @@ WOLFSSL_API word32 CheckRunTimeFastMath(void);
 #define mp_gcd                              sp_gcd
 #define mp_lcm                              sp_lcm
 
+#ifdef WOLFSSL_DEBUG_MATH
+static inline void mp_dump(const char* desc, mp_int* a, byte verbose)
+{
+    sp_print(a, desc);
+    (void)verbose;
+}
 #endif
+
+#endif /* WOLFSSL_SP_MATH || WOLFSSL_SP_MATH_ALL */
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -979,11 +979,7 @@ WOLFSSL_API word32 CheckRunTimeFastMath(void);
 #define mp_lcm                              sp_lcm
 
 #ifdef WOLFSSL_DEBUG_MATH
-static inline void mp_dump(const char* desc, mp_int* a, byte verbose)
-{
-    sp_print(a, desc);
-    (void)verbose;
-}
+#define mp_dump(d, a, v)                    sp_print(a, d)
 #endif
 
 #endif /* WOLFSSL_SP_MATH || WOLFSSL_SP_MATH_ALL */


### PR DESCRIPTION
* Add argument checking to `wc_ecc_gen_k` (since it is a public API now).
* Cleanup return codes for `wc_ecc_mulmod_ex2`.
* Support for `mp_dump` with SP Math ALL.

Old work I forgot to put up as PR...