### PR TITLE
Fix double include of sha256.h causing a build error

### DIFF
--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -35,6 +35,8 @@
 #include <wolfssl/wolfcrypt/sha.h>
 #include <wolfssl/wolfcrypt/sha256.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
+#include "fsl_device_registers.h"
+#include "fsl_debug_console.h"
 
 #ifdef WOLFSSL_IMXRT_DCP
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U) && defined(DCP_USE_DCACHE) && (DCP_USE_DCACHE == 1U)
@@ -48,6 +50,15 @@
 #include "fsl_device_registers.h"
 #include "fsl_debug_console.h"
 #include "fsl_dcp.h"
+
+#ifdef USE_FAST_MATH
+    #include <wolfssl/wolfcrypt/tfm.h>
+#elif defined WOLFSSL_SP_MATH
+    #include <wolfssl/wolfcrypt/sp_int.h>
+#else
+    #include <wolfssl/wolfcrypt/integer.h>
+#endif
+
 
 #ifndef SINGLE_THREADED
 #define dcp_lock_init() wolfSSL_CryptHwMutexInit()
@@ -446,11 +457,6 @@ int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
         ret = WC_HW_E;
     dcp_unlock();
     return ret;
-}
-
-int wc_InitSha(wc_Sha* sha)
-{
-    return wc_InitSha_ex(sha, NULL, INVALID_DEVID);
 }
 
 void DCPShaFree(wc_Sha* sha)

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -19,11 +19,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+
 #ifdef HAVE_CONFIG_H
     #include <config.h>
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_IMXRT_DCP
+
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
 #else
@@ -38,10 +42,10 @@
 #include "fsl_device_registers.h"
 #include "fsl_debug_console.h"
 
-#ifdef WOLFSSL_IMXRT_DCP
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U) && defined(DCP_USE_DCACHE) && (DCP_USE_DCACHE == 1U)
 #error "DCACHE not supported by this driver. Please undefine DCP_USE_DCACHE."
 #endif
+
 
 #ifndef DCP_USE_OTP_KEY
 #define DCP_USE_OTP_KEY 0 /* Set to 1 to select OTP key for AES encryption/decryption. */
@@ -58,7 +62,6 @@
 #else
     #include <wolfssl/wolfcrypt/integer.h>
 #endif
-
 
 #ifndef SINGLE_THREADED
 #define dcp_lock_init() wolfSSL_CryptHwMutexInit()

--- a/wolfcrypt/src/port/nxp/dcp_port.c
+++ b/wolfcrypt/src/port/nxp/dcp_port.c
@@ -27,41 +27,20 @@
 #include <wolfssl/wolfcrypt/settings.h>
 
 #ifdef WOLFSSL_IMXRT_DCP
-
-#ifdef NO_INLINE
-    #include <wolfssl/wolfcrypt/misc.h>
-#else
-    #define WOLFSSL_MISC_INCLUDED
-    #include <wolfcrypt/src/misc.c>
-#endif
-
 #include <wolfssl/wolfcrypt/aes.h>
 #include <wolfssl/wolfcrypt/sha.h>
 #include <wolfssl/wolfcrypt/sha256.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
-#include "fsl_device_registers.h"
-#include "fsl_debug_console.h"
 
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U) && defined(DCP_USE_DCACHE) && (DCP_USE_DCACHE == 1U)
 #error "DCACHE not supported by this driver. Please undefine DCP_USE_DCACHE."
 #endif
 
-
 #ifndef DCP_USE_OTP_KEY
 #define DCP_USE_OTP_KEY 0 /* Set to 1 to select OTP key for AES encryption/decryption. */
 #endif
 
-#include "fsl_device_registers.h"
-#include "fsl_debug_console.h"
 #include "fsl_dcp.h"
-
-#ifdef USE_FAST_MATH
-    #include <wolfssl/wolfcrypt/tfm.h>
-#elif defined WOLFSSL_SP_MATH
-    #include <wolfssl/wolfcrypt/sp_int.h>
-#else
-    #include <wolfssl/wolfcrypt/integer.h>
-#endif
 
 #ifndef SINGLE_THREADED
 #define dcp_lock_init() wolfSSL_CryptHwMutexInit()

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -330,6 +330,7 @@
     /* implemented in wolfcrypt/src/port/Renesas/renesas_tsip_sha.c */
 
 #elif defined(WOLFSSL_IMXRT_DCP)
+    #include <wolfssl/wolfcrypt/port/nxp/dcp_port.h>
     /* implemented in wolfcrypt/src/port/nxp/dcp_port.c */
 
 #elif defined(WOLFSSL_SILABS_SE_ACCEL)
@@ -793,13 +794,10 @@ int wc_ShaTransform(wc_Sha* sha, const unsigned char* data)
 #endif /* USE_SHA_SOFTWARE_IMPL */
 
 
-
-#if !defined(WOLFSSL_IMXRT_DCP)
 int wc_InitSha(wc_Sha* sha)
 {
     return wc_InitSha_ex(sha, NULL, INVALID_DEVID);
 }
-#endif /* !defined(WOLFSSL_IMXRT_DCP) */
 
 void wc_ShaFree(wc_Sha* sha)
 {

--- a/wolfssl/wolfcrypt/port/nxp/dcp_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/dcp_port.h
@@ -22,23 +22,22 @@
 #define _DCP_PORT_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
-#ifdef USE_FAST_MATH
-    #include <wolfssl/wolfcrypt/tfm.h>
-#elif defined WOLFSSL_SP_MATH
-    #include <wolfssl/wolfcrypt/sp_int.h>
-#else
-    #include <wolfssl/wolfcrypt/integer.h>
+#include "fsl_dcp.h"
+
+#ifndef NO_SHA256
+#include <wolfssl/wolfcrypt/sha256.h>
+void DCPSha256Free(wc_Sha256 *sha256);
 #endif
 
-#include <wolfssl/wolfcrypt/aes.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
-#include "fsl_device_registers.h"
-#include "fsl_debug_console.h"
-#include "fsl_dcp.h"
+#ifndef NO_SHA
+#include <wolfssl/wolfcrypt/sha.h>
+void DCPShaFree(wc_Sha *sha);
+#endif
 
 int wc_dcp_init(void);
 
 #ifndef NO_AES
+#include <wolfssl/wolfcrypt/aes.h>
 int  DCPAesInit(Aes* aes);
 void DCPAesFree(Aes *aes);
 
@@ -53,25 +52,5 @@ int  DCPAesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
 int  DCPAesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz);
 #endif
 
-#ifndef NO_SHA256
-typedef struct wc_Sha256_DCP {
-    dcp_handle_t handle;
-    dcp_hash_ctx_t ctx;
-} wc_Sha256;
-#define WC_SHA256_TYPE_DEFINED
-
-void DCPSha256Free(wc_Sha256 *sha256);
-
-#endif
-
-#ifndef NO_SHA
-typedef struct wc_Sha_DCP {
-    dcp_handle_t handle;
-    dcp_hash_ctx_t ctx;
-} wc_Sha;
-#define WC_SHA_TYPE_DEFINED
-
-void DCPShaFree(wc_Sha *sha);
-#endif
 
 #endif

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -103,9 +103,7 @@
     #ifdef NO_SHA256
         #error "Hash DRBG requires SHA-256."
     #endif /* NO_SHA256 */
-    #ifdef WOLFSSL_SMALL_STACK_CACHE
-        #include <wolfssl/wolfcrypt/sha256.h>
-    #endif
+    #include <wolfssl/wolfcrypt/sha256.h>
 #elif defined(HAVE_WNR)
      /* allow whitewood as direct RNG source using wc_GenerateSeed directly */
 #elif defined(HAVE_INTEL_RDRAND)

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -103,6 +103,9 @@
     #ifdef NO_SHA256
         #error "Hash DRBG requires SHA-256."
     #endif /* NO_SHA256 */
+    #ifdef WOLFSSL_SMALL_STACK_CACHE
+        #include <wolfssl/wolfcrypt/sha256.h>
+    #endif
 #elif defined(HAVE_WNR)
      /* allow whitewood as direct RNG source using wc_GenerateSeed directly */
 #elif defined(HAVE_INTEL_RDRAND)

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -103,7 +103,6 @@
     #ifdef NO_SHA256
         #error "Hash DRBG requires SHA-256."
     #endif /* NO_SHA256 */
-    #include <wolfssl/wolfcrypt/sha256.h>
 #elif defined(HAVE_WNR)
      /* allow whitewood as direct RNG source using wc_GenerateSeed directly */
 #elif defined(HAVE_INTEL_RDRAND)

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -52,6 +52,10 @@
     #include "fsl_ltc.h"
 #endif
 
+#ifdef WOLFSSL_IMXRT_DCP
+	#include "fsl_dcp.h"
+#endif
+
 #ifdef __cplusplus
     extern "C" {
 #endif
@@ -71,9 +75,6 @@
 #endif
 #ifdef WOLFSSL_ESP32WROOM32_CRYPT
     #include <wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h>
-#endif
-#ifdef WOLFSSL_IMXRT_DCP
-    #include <wolfssl/wolfcrypt/port/nxp/dcp_port.h>
 #endif
 #if defined(WOLFSSL_SILABS_SE_ACCEL)
     #include <wolfssl/wolfcrypt/port/silabs/silabs_hash.h>
@@ -119,6 +120,9 @@ struct wc_Sha {
         STM32_HASH_Context stmCtx;
 #elif defined(WOLFSSL_SILABS_SE_ACCEL)
         wc_silabs_sha_t silabsCtx;
+#elif defined(WOLFSSL_IMXRT_DCP)
+        dcp_handle_t handle;
+        dcp_hash_ctx_t ctx;
 #else
         word32  buffLen;   /* in bytes          */
         word32  loLen;     /* length in bytes   */

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -61,6 +61,9 @@
     #include "fsl_ltc.h"
 #endif
 
+#ifdef WOLFSSL_IMXRT_DCP
+	#include "fsl_dcp.h"
+#endif
 
 #ifdef __cplusplus
     extern "C" {
@@ -131,8 +134,6 @@ enum {
     #include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
 #elif defined(WOLFSSL_PSOC6_CRYPTO)
     #include "wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h"
-#elif defined(WOLFSSL_IMXRT_DCP)
-    #include <wolfssl/wolfcrypt/port/nxp/dcp_port.h>
 #else
 
 /* wc_Sha256 digest */
@@ -143,6 +144,9 @@ struct wc_Sha256 {
     STM32_HASH_Context stmCtx;
 #elif defined(WOLFSSL_SILABS_SE_ACCEL)
   wc_silabs_sha_t silabsCtx;
+#elif defined(WOLFSSL_IMXRT_DCP)
+    dcp_handle_t handle;
+    dcp_hash_ctx_t ctx;
 #else
     /* alignment on digest and buffer speeds up ARMv8 crypto operations */
     ALIGN16 word32  digest[WC_SHA256_DIGEST_SIZE / sizeof(word32)];


### PR DESCRIPTION
Per ZD 12243: When compiling a HW driver with sha256 support (e.g. DCP) with `HAVE_HASHDRBG` and without `NO_RNG` or `CUSTOM_RAND_GENERATE_BLOCK`, a build error occurs:

```
In file included from ./wolfssl/wolfcrypt/port/nxp/dcp_port.h:26:0,
                 from ./wolfssl/wolfcrypt/sha256.h:135,
                 from ./wolfssl/wolfcrypt/random.h:106,
                 from wolfcrypt/src/random.c:53:
./wolfssl/wolfcrypt/tfm.h:835:65: error: unknown type name ‘WC_RNG’; did you mean ‘DT_REG’?
 MP_API int  mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng);
                                                                 ^~~~~~
                                                                 DT_REG
```

Fixed by removing explicit include of sha256.h in HASHDBRG case.

Edit: except when required by `--enable-smallstackcache` as Jenkins pointed out.
