### PR TITLE
Expand SHA-3 support

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -30741,6 +30741,24 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
         { CTC_SHA512wRSA, CTC_SHA512wRSA, oidSigType, "RSA-SHA512",
                                                      "sha512WithRSAEncryption"},
         #endif
+        #ifdef WOLFSSL_SHA3
+        #ifndef WOLFSSL_NOSHA3_224
+        { CTC_SHA3_224wRSA, CTC_SHA3_224wRSA, oidSigType, "RSA-SHA3-224",
+                                                     "sha3-224WithRSAEncryption"},
+        #endif
+        #ifndef WOLFSSL_NOSHA3_256
+        { CTC_SHA3_256wRSA, CTC_SHA3_256wRSA, oidSigType, "RSA-SHA3-256",
+                                                     "sha3-256WithRSAEncryption"},
+        #endif
+        #ifndef WOLFSSL_NOSHA3_384
+        { CTC_SHA3_384wRSA, CTC_SHA3_384wRSA, oidSigType, "RSA-SHA3-384",
+                                                     "sha3-384WithRSAEncryption"},
+        #endif
+        #ifndef WOLFSSL_NOSHA3_512
+        { CTC_SHA3_512wRSA, CTC_SHA3_512wRSA, oidSigType, "RSA-SHA3-512",
+                                                     "sha3-512WithRSAEncryption"},
+        #endif
+        #endif
     #endif /* NO_RSA */
     #ifdef HAVE_ECC
         #ifndef NO_SHA
@@ -30757,6 +30775,24 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
         #endif
         #ifdef WOLFSSL_SHA512
         { CTC_SHA512wECDSA, CTC_SHA512wECDSA, oidSigType, "ecdsa-with-SHA512","sha512WithECDSA"},
+        #endif
+        #ifdef WOLFSSL_SHA3
+        #ifndef WOLFSSL_NOSHA3_224
+        { CTC_SHA3_224wECDSA, CTC_SHA3_224wECDSA, oidSigType, "ecdsa-with-SHA3-224",
+                "sha3-224WithECDSA"},
+        #endif
+        #ifndef WOLFSSL_NOSHA3_256
+        { CTC_SHA3_256wECDSA, CTC_SHA3_256wECDSA, oidSigType, "ecdsa-with-SHA3-256",
+                "sha3-256WithECDSA"},
+        #endif
+        #ifndef WOLFSSL_NOSHA3_384
+        { CTC_SHA3_384wECDSA, CTC_SHA3_384wECDSA, oidSigType, "ecdsa-with-SHA3-384",
+                "sha3-384WithECDSA"},
+        #endif
+        #ifndef WOLFSSL_NOSHA3_512
+        { CTC_SHA3_512wECDSA, CTC_SHA3_512wECDSA, oidSigType, "ecdsa-with-SHA3-512",
+                "sha3-512WithECDSA"},
+        #endif
         #endif
     #endif /* HAVE_ECC */
 
@@ -40711,6 +40747,20 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
                 case WC_HASH_TYPE_SHA512:
                     sigType = CTC_SHA512wRSA;
                     break;
+            #ifdef WOLFSSL_SHA3
+                case WC_HASH_TYPE_SHA3_224:
+                    sigType = CTC_SHA3_224wRSA;
+                    break;
+                case WC_HASH_TYPE_SHA3_256:
+                    sigType = CTC_SHA3_256wRSA;
+                    break;
+                case WC_HASH_TYPE_SHA3_384:
+                    sigType = CTC_SHA3_384wRSA;
+                    break;
+                case WC_HASH_TYPE_SHA3_512:
+                    sigType = CTC_SHA3_512wRSA;
+                    break;
+            #endif
                 default:
                     return WOLFSSL_FAILURE;
             }
@@ -40732,6 +40782,20 @@ void* wolfSSL_GetDhAgreeCtx(WOLFSSL* ssl)
                 case WC_HASH_TYPE_SHA512:
                     sigType = CTC_SHA512wECDSA;
                     break;
+            #ifdef WOLFSSL_SHA3
+                case WC_HASH_TYPE_SHA3_224:
+                    sigType = CTC_SHA3_224wECDSA;
+                    break;
+                case WC_HASH_TYPE_SHA3_256:
+                    sigType = CTC_SHA3_256wECDSA;
+                    break;
+                case WC_HASH_TYPE_SHA3_384:
+                    sigType = CTC_SHA3_384wECDSA;
+                    break;
+                case WC_HASH_TYPE_SHA3_512:
+                    sigType = CTC_SHA3_512wECDSA;
+                    break;
+            #endif
                 default:
                     return WOLFSSL_FAILURE;
             }
@@ -48824,6 +48888,16 @@ word32 nid2oid(int nid, int grp)
                     return CTC_SHA384wRSA;
                 case CTC_SHA512wRSA:
                     return CTC_SHA512wRSA;
+                #ifdef WOLFSSL_SHA3
+                case CTC_SHA3_224wRSA:
+                    return CTC_SHA3_224wRSA;
+                case CTC_SHA3_256wRSA:
+                    return CTC_SHA3_256wRSA;
+                case CTC_SHA3_384wRSA:
+                    return CTC_SHA3_384wRSA;
+                case CTC_SHA3_512wRSA:
+                    return CTC_SHA3_512wRSA;
+                #endif
             #endif /* NO_RSA */
             #ifdef HAVE_ECC
                 case CTC_SHAwECDSA:
@@ -48836,6 +48910,16 @@ word32 nid2oid(int nid, int grp)
                     return CTC_SHA384wECDSA;
                 case CTC_SHA512wECDSA:
                     return CTC_SHA512wECDSA;
+                #ifdef WOLFSSL_SHA3
+                case CTC_SHA3_224wECDSA:
+                    return CTC_SHA3_224wECDSA;
+                case CTC_SHA3_256wECDSA:
+                    return CTC_SHA3_256wECDSA;
+                case CTC_SHA3_384wECDSA:
+                    return CTC_SHA3_384wECDSA;
+                case CTC_SHA3_512wECDSA:
+                    return CTC_SHA3_512wECDSA;
+                #endif
             #endif /* HAVE_ECC */
             }
             break;
@@ -49160,6 +49244,16 @@ int oid2nid(word32 oid, int grp)
                     return CTC_SHA384wRSA;
                 case CTC_SHA512wRSA:
                     return CTC_SHA512wRSA;
+                #ifdef WOLFSSL_SHA3
+                case CTC_SHA3_224wRSA:
+                    return CTC_SHA3_224wRSA;
+                case CTC_SHA3_256wRSA:
+                    return CTC_SHA3_256wRSA;
+                case CTC_SHA3_384wRSA:
+                    return CTC_SHA3_384wRSA;
+                case CTC_SHA3_512wRSA:
+                    return CTC_SHA3_512wRSA;
+                #endif
             #endif /* NO_RSA */
             #ifdef HAVE_ECC
                 case CTC_SHAwECDSA:
@@ -49172,6 +49266,16 @@ int oid2nid(word32 oid, int grp)
                     return CTC_SHA384wECDSA;
                 case CTC_SHA512wECDSA:
                     return CTC_SHA512wECDSA;
+                #ifdef WOLFSSL_SHA3
+                case CTC_SHA3_224wECDSA:
+                    return CTC_SHA3_224wECDSA;
+                case CTC_SHA3_256wECDSA:
+                    return CTC_SHA3_256wECDSA;
+                case CTC_SHA3_384wECDSA:
+                    return CTC_SHA3_384wECDSA;
+                case CTC_SHA3_512wECDSA:
+                    return CTC_SHA3_512wECDSA;
+                #endif
             #endif /* HAVE_ECC */
             }
             break;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -560,6 +560,20 @@ static const char sigSha256wDsaName[] = "SHA256wDSA";
 #ifdef WOLFSSL_SHA512
     static const char sigSha512wRsaName[] = "sha512WithRSAEncryption";
 #endif
+#ifdef WOLFSSL_SHA3
+#ifndef WOLFSSL_NOSHA3_224
+    static const char sigSha3_224wRsaName[] = "sha3_224WithRSAEncryption";
+#endif
+#ifndef WOLFSSL_NOSHA3_256
+    static const char sigSha3_256wRsaName[] = "sha3_256WithRSAEncryption";
+#endif
+#ifndef WOLFSSL_NOSHA3_384
+    static const char sigSha3_384wRsaName[] = "sha3_384WithRSAEncryption";
+#endif
+#ifndef WOLFSSL_NOSHA3_512
+    static const char sigSha3_512wRsaName[] = "sha3_512WithRSAEncryption";
+#endif
+#endif
 #endif /* NO_RSA */
 #ifdef HAVE_ECC
 #ifndef NO_SHA
@@ -576,6 +590,20 @@ static const char sigSha256wDsaName[] = "SHA256wDSA";
 #endif
 #ifdef WOLFSSL_SHA512
     static const char sigSha512wEcdsaName[] = "SHA512wECDSA";
+#endif
+#ifdef WOLFSSL_SHA3
+#ifndef WOLFSSL_NOSHA3_224
+    static const char sigSha3_224wEcdsaName[] = "SHA3_224wECDSA";
+#endif
+#ifndef WOLFSSL_NOSHA3_256
+    static const char sigSha3_256wEcdsaName[] = "SHA3_256wECDSA";
+#endif
+#ifndef WOLFSSL_NOSHA3_384
+    static const char sigSha3_384wEcdsaName[] = "SHA3_384wECDSA";
+#endif
+#ifndef WOLFSSL_NOSHA3_512
+    static const char sigSha3_512wEcdsaName[] = "SHA3_512wECDSA";
+#endif
 #endif
 #endif /* HAVE_ECC */
 static const char sigUnknownName[] = "Unknown";
@@ -622,6 +650,24 @@ const char* GetSigName(int oid) {
         case CTC_SHA512wRSA:
             return sigSha512wRsaName;
         #endif
+        #ifdef WOLFSSL_SHA3
+        #ifndef WOLFSSL_NOSHA3_224
+        case CTC_SHA3_224wRSA:
+            return sigSha3_224wRsaName;
+        #endif
+        #ifndef WOLFSSL_NOSHA3_256
+        case CTC_SHA3_256wRSA:
+            return sigSha3_256wRsaName;
+        #endif
+        #ifndef WOLFSSL_NOSHA3_384
+        case CTC_SHA3_384wRSA:
+            return sigSha3_384wRsaName;
+        #endif
+        #ifndef WOLFSSL_NOSHA3_512
+        case CTC_SHA3_512wRSA:
+            return sigSha3_512wRsaName;
+        #endif
+        #endif
     #endif /* NO_RSA */
     #ifdef HAVE_ECC
         #ifndef NO_SHA
@@ -643,6 +689,24 @@ const char* GetSigName(int oid) {
         #ifdef WOLFSSL_SHA512
         case CTC_SHA512wECDSA:
             return sigSha512wEcdsaName;
+        #endif
+        #ifdef WOLFSSL_SHA3
+        #ifndef WOLFSSL_NOSHA3_224
+        case CTC_SHA3_224wECDSA:
+            return sigSha3_224wEcdsaName;
+        #endif
+        #ifndef WOLFSSL_NOSHA3_256
+        case CTC_SHA3_256wECDSA:
+            return sigSha3_256wEcdsaName;
+        #endif
+        #ifndef WOLFSSL_NOSHA3_384
+        case CTC_SHA3_384wECDSA:
+            return sigSha3_384wEcdsaName;
+        #endif
+        #ifndef WOLFSSL_NOSHA3_512
+        case CTC_SHA3_512wECDSA:
+            return sigSha3_512wEcdsaName;
+        #endif
         #endif
     #endif /* HAVE_ECC */
         default:
@@ -1465,18 +1529,20 @@ static word32 SetBitString16Bit(word16 val, byte* output)
 #ifdef WOLFSSL_SHA512
     static const byte hashSha512hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 3};
 #endif
-#if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_224)
+#ifdef WOLFSSL_SHA3
+#ifndef WOLFSSL_NOSHA3_224
     static const byte hashSha3_224hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 7};
-#endif
-#if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_256)
+#endif /* WOLFSSL_NOSHA3_224 */
+#ifndef WOLFSSL_NOSHA3_256
     static const byte hashSha3_256hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 8};
-#endif
-#if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_384)
+#endif /* WOLFSSL_NOSHA3_256 */
+#ifndef WOLFSSL_NOSHA3_384
     static const byte hashSha3_384hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 9};
-#endif
-#if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_512)
+#endif /* WOLFSSL_NOSHA3_384 */
+#ifndef WOLFSSL_NOSHA3_512
     static const byte hashSha3_512hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 10};
-#endif
+#endif /* WOLFSSL_NOSHA3_512 */
+#endif /* WOLFSSL_SHA3 */
 
 /* hmacType */
 #ifndef NO_HMAC
@@ -1521,6 +1587,20 @@ static word32 SetBitString16Bit(word16 val, byte* output)
     #ifdef WOLFSSL_SHA512
     static const byte sigSha512wRsaOid[] = {42, 134, 72, 134, 247, 13, 1, 1,13};
     #endif
+    #ifdef WOLFSSL_SHA3
+    #ifndef WOLFSSL_NOSHA3_224
+    static const byte sigSha3_224wRsaOid[] = {96, 134, 72, 1, 101, 3, 4, 3, 13};
+    #endif
+    #ifndef WOLFSSL_NOSHA3_256
+    static const byte sigSha3_256wRsaOid[] = {96, 134, 72, 1, 101, 3, 4, 3, 14};
+    #endif
+    #ifndef WOLFSSL_NOSHA3_384
+    static const byte sigSha3_384wRsaOid[] = {96, 134, 72, 1, 101, 3, 4, 3, 15};
+    #endif
+    #ifndef WOLFSSL_NOSHA3_512
+    static const byte sigSha3_512wRsaOid[] = {96, 134, 72, 1, 101, 3, 4, 3, 16};
+    #endif
+    #endif
 #endif /* NO_RSA */
 #ifdef HAVE_ECC
     #ifndef NO_SHA
@@ -1537,6 +1617,20 @@ static word32 SetBitString16Bit(word16 val, byte* output)
     #endif
     #ifdef WOLFSSL_SHA512
     static const byte sigSha512wEcdsaOid[] = {42, 134, 72, 206, 61, 4, 3, 4};
+    #endif
+    #ifdef WOLFSSL_SHA3
+    #ifndef WOLFSSL_NOSHA3_224
+    static const byte sigSha3_224wEcdsaOid[] = {96, 134, 72, 1, 101, 3, 4, 3, 9};
+    #endif
+    #ifndef WOLFSSL_NOSHA3_256
+    static const byte sigSha3_256wEcdsaOid[] = {96, 134, 72, 1, 101, 3, 4, 3, 10};
+    #endif
+    #ifndef WOLFSSL_NOSHA3_384
+    static const byte sigSha3_384wEcdsaOid[] = {96, 134, 72, 1, 101, 3, 4, 3, 11};
+    #endif
+    #ifndef WOLFSSL_NOSHA3_512
+    static const byte sigSha3_512wEcdsaOid[] = {96, 134, 72, 1, 101, 3, 4, 3, 12};
+    #endif
     #endif
 #endif /* HAVE_ECC */
 #ifdef HAVE_ED25519
@@ -1778,30 +1872,32 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                     *oidSz = sizeof(hashSha512hOid);
                     break;
             #endif
-            #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_224)
+            #ifdef WOLFSSL_SHA3
+            #ifndef WOLFSSL_NOSHA3_224
                 case SHA3_224h:
                     oid = hashSha3_224hOid;
                     *oidSz = sizeof(hashSha3_224hOid);
                     break;
-            #endif
-            #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_256)
+            #endif /* WOLFSSL_NOSHA3_224 */
+            #ifndef WOLFSSL_NOSHA3_256
                 case SHA3_256h:
                     oid = hashSha3_256hOid;
                     *oidSz = sizeof(hashSha3_256hOid);
                     break;
-            #endif
-            #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_384)
+            #endif /* WOLFSSL_NOSHA3_256 */
+            #ifndef WOLFSSL_NOSHA3_384
                 case SHA3_384h:
                     oid = hashSha3_384hOid;
                     *oidSz = sizeof(hashSha3_384hOid);
                     break;
-            #endif
-            #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_512)
+            #endif /* WOLFSSL_NOSHA3_384 */
+            #ifndef WOLFSSL_NOSHA3_512
                 case SHA3_512h:
                     oid = hashSha3_512hOid;
                     *oidSz = sizeof(hashSha3_512hOid);
                     break;
-            #endif
+            #endif /* WOLFSSL_NOSHA3_512 */
+            #endif /* WOLFSSL_SHA3 */
                 default:
                     break;
             }
@@ -1862,6 +1958,32 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                     *oidSz = sizeof(sigSha512wRsaOid);
                     break;
                 #endif /* WOLFSSL_SHA512 */
+                #ifdef WOLFSSL_SHA3
+                #ifndef WOLFSSL_NOSHA3_224
+                case CTC_SHA3_224wRSA:
+                    oid = sigSha3_224wRsaOid;
+                    *oidSz = sizeof(sigSha3_224wRsaOid);
+                    break;
+                #endif
+                #ifndef WOLFSSL_NOSHA3_256
+                case CTC_SHA3_256wRSA:
+                    oid = sigSha3_256wRsaOid;
+                    *oidSz = sizeof(sigSha3_256wRsaOid);
+                    break;
+                #endif
+                #ifndef WOLFSSL_NOSHA3_384
+                case CTC_SHA3_384wRSA:
+                    oid = sigSha3_384wRsaOid;
+                    *oidSz = sizeof(sigSha3_384wRsaOid);
+                    break;
+                #endif
+                #ifndef WOLFSSL_NOSHA3_512
+                case CTC_SHA3_512wRSA:
+                    oid = sigSha3_512wRsaOid;
+                    *oidSz = sizeof(sigSha3_512wRsaOid);
+                    break;
+                #endif
+                #endif
                 #endif /* NO_RSA */
                 #ifdef HAVE_ECC
                 #ifndef NO_SHA
@@ -1893,6 +2015,32 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                     oid = sigSha512wEcdsaOid;
                     *oidSz = sizeof(sigSha512wEcdsaOid);
                     break;
+                #endif
+                #ifdef WOLFSSL_SHA3
+                #ifndef WOLFSSL_NOSHA3_224
+                case CTC_SHA3_224wECDSA:
+                    oid = sigSha3_224wEcdsaOid;
+                    *oidSz = sizeof(sigSha3_224wEcdsaOid);
+                    break;
+                #endif
+                #ifndef WOLFSSL_NOSHA3_256
+                case CTC_SHA3_256wECDSA:
+                    oid = sigSha3_256wEcdsaOid;
+                    *oidSz = sizeof(sigSha3_256wEcdsaOid);
+                    break;
+                #endif
+                #ifndef WOLFSSL_NOSHA3_384
+                case CTC_SHA3_384wECDSA:
+                    oid = sigSha3_384wEcdsaOid;
+                    *oidSz = sizeof(sigSha3_384wEcdsaOid);
+                    break;
+                #endif
+                #ifndef WOLFSSL_NOSHA3_512
+                case CTC_SHA3_512wECDSA:
+                    oid = sigSha3_512wEcdsaOid;
+                    *oidSz = sizeof(sigSha3_512wEcdsaOid);
+                    break;
+                #endif
                 #endif
                 #endif /* HAVE_ECC */
                 #ifdef HAVE_ED25519
@@ -7619,6 +7767,44 @@ static int HashForSignature(const byte* buf, word32 bufSz, word32 sigOID,
                 *digestSz = WC_SHA512_DIGEST_SIZE;
             }
             break;
+    #endif
+    #ifdef WOLFSSL_SHA3
+    #ifndef WOLFSSL_NOSHA3_224
+        case CTC_SHA3_224wRSA:
+        case CTC_SHA3_224wECDSA:
+            if ((ret = wc_Sha3_224Hash(buf, bufSz, digest)) == 0) {
+                *typeH    = SHA3_224h;
+                *digestSz = WC_SHA3_224_DIGEST_SIZE;
+            }
+            break;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_256
+        case CTC_SHA3_256wRSA:
+        case CTC_SHA3_256wECDSA:
+            if ((ret = wc_Sha3_256Hash(buf, bufSz, digest)) == 0) {
+                *typeH    = SHA3_256h;
+                *digestSz = WC_SHA3_256_DIGEST_SIZE;
+            }
+            break;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_384
+        case CTC_SHA3_384wRSA:
+        case CTC_SHA3_384wECDSA:
+            if ((ret = wc_Sha3_384Hash(buf, bufSz, digest)) == 0) {
+                *typeH    = SHA3_384h;
+                *digestSz = WC_SHA3_384_DIGEST_SIZE;
+            }
+            break;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_512
+        case CTC_SHA3_512wRSA:
+        case CTC_SHA3_512wECDSA:
+            if ((ret = wc_Sha3_512Hash(buf, bufSz, digest)) == 0) {
+                *typeH    = SHA3_512h;
+                *digestSz = WC_SHA3_512_DIGEST_SIZE;
+            }
+            break;
+    #endif
     #endif
     #ifdef HAVE_ED25519
         case CTC_ED25519:

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -2582,9 +2582,11 @@ static int wolfSSL_evp_digest_pk_init(WOLFSSL_EVP_MD_CTX *ctx,
             hashType = WC_SHA3_256;
         }
     #endif
+    #ifndef WOLFSSL_NOSHA3_384
         else if (XSTRNCMP(type, "SHA3_384", 8) == 0) {
             hashType = WC_SHA3_384;
         }
+    #endif
     #ifndef WOLFSSL_NOSHA3_512
         else if (XSTRNCMP(type, "SHA3_512", 8) == 0) {
             hashType = WC_SHA3_512;
@@ -3455,7 +3457,6 @@ void wolfSSL_EVP_init(void)
     /* Does nothing. */
 }
 
-#if !defined(NO_PWDBASED)
 /* this function makes the assumption that out buffer is big enough for digest*/
 int wolfSSL_EVP_Digest(const unsigned char* in, int inSz, unsigned char* out,
                               unsigned int* outSz, const WOLFSSL_EVP_MD* evp,
@@ -3485,7 +3486,6 @@ int wolfSSL_EVP_Digest(const unsigned char* in, int inSz, unsigned char* out,
     (void)eng;
     return WOLFSSL_SUCCESS;
 }
-#endif
 
 const WOLFSSL_EVP_MD *wolfSSL_EVP_get_digestbyname(const char *name)
 {
@@ -3642,11 +3642,13 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     }
 #endif /* WOLFSSL_NOSHA3_256 */
 
+#ifndef WOLFSSL_NOSHA3_384
     const WOLFSSL_EVP_MD* wolfSSL_EVP_sha3_384(void)
     {
         WOLFSSL_ENTER("EVP_sha3_384");
         return EVP_get_digestbyname("SHA3_384");
     }
+#endif /* WOLFSSL_NOSHA3_384 */
 
 #ifndef WOLFSSL_NOSHA3_512
     const WOLFSSL_EVP_MD* wolfSSL_EVP_sha3_512(void)
@@ -3793,7 +3795,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             #endif
                     break;
                 case WC_HASH_TYPE_SHA3_384:
-            #if defined(WOLFSSL_SHA3)
+            #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_384)
                     ret = wc_Sha3_384_Copy((wc_Sha3*)&src->hash.digest,
                             (wc_Sha3*)&des->hash.digest);
             #else
@@ -4195,7 +4197,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
             #endif
                     break;
                 case WC_HASH_TYPE_SHA3_384:
-            #if defined(WOLFSSL_SHA3)
+            #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_384)
                     wc_Sha3_384_Free((wc_Sha3*)&ctx->hash.digest);
             #endif
                     break;
@@ -5790,9 +5792,11 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
              ret = wolfSSL_SHA3_256_Init(&(ctx->hash.digest.sha3_256));
         }
     #endif
+    #ifndef WOLFSSL_NOSHA3_384
         else if (XSTRNCMP(md, "SHA3_384", 8) == 0) {
              ret = wolfSSL_SHA3_384_Init(&(ctx->hash.digest.sha3_384));
         }
+    #endif
     #ifndef WOLFSSL_NOSHA3_512
         else if (XSTRNCMP(md, "SHA3_512", 8) == 0) {
              ret = wolfSSL_SHA3_512_Init(&(ctx->hash.digest.sha3_512));
@@ -5880,7 +5884,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         #endif
                 break;
             case WC_HASH_TYPE_SHA3_384:
-        #if defined(WOLFSSL_SHA3)
+        #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_384)
                 ret = wolfSSL_SHA3_384_Update((SHA3_384_CTX*)&ctx->hash, data,
                                      (unsigned long)sz);
         #endif
@@ -5969,7 +5973,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
         #endif
                 break;
             case WC_HASH_TYPE_SHA3_384:
-        #if defined(WOLFSSL_SHA3)
+        #if defined(WOLFSSL_SHA3) && !defined(WOLFSSL_NOSHA3_384)
                 ret = wolfSSL_SHA3_384_Final(md, (SHA3_384_CTX*)&ctx->hash);
                 if (s) *s = WC_SHA3_384_DIGEST_SIZE;
         #endif
@@ -6632,8 +6636,30 @@ int wolfSSL_EVP_MD_block_size(const WOLFSSL_EVP_MD* type)
         return WC_SHA512_BLOCK_SIZE;
     }
 #endif
+#ifdef WOLFSSL_SHA3
+#ifndef WOLFSSL_NOSHA3_224
+    else if (XSTRNCMP(type, "SHA3_224", 8) == 0) {
+        return WC_SHA3_224_BLOCK_SIZE;
+    }
+#endif
+#ifndef WOLFSSL_NOSHA3_256
+    else if (XSTRNCMP(type, "SHA3_256", 8) == 0) {
+        return WC_SHA3_256_BLOCK_SIZE;
+    }
+#endif
+#ifndef WOLFSSL_NOSHA3_384
+    else if (XSTRNCMP(type, "SHA3_384", 8) == 0) {
+        return WC_SHA3_384_BLOCK_SIZE;
+    }
+#endif
+#ifndef WOLFSSL_NOSHA3_512
+    else if (XSTRNCMP(type, "SHA3_512", 8) == 0) {
+        return WC_SHA3_512_BLOCK_SIZE;
+    }
+#endif
+#endif /* WOLFSSL_SHA3 */
 #ifndef NO_SHA
-    /* has to be last since would pick or 256, 384, or 512 too */
+    /* has to be last since would pick or 256, 384, 512, or SHA3 too */
     else if (XSTRNCMP(type, "SHA", 3) == 0) {
         return WC_SHA_BLOCK_SIZE;
     }
@@ -6674,6 +6700,28 @@ int wolfSSL_EVP_MD_size(const WOLFSSL_EVP_MD* type)
         return WC_SHA512_DIGEST_SIZE;
     }
 #endif
+#ifdef WOLFSSL_SHA3
+#ifndef WOLFSSL_NOSHA3_224
+    else if (XSTRNCMP(type, "SHA3_224", 8) == 0) {
+        return WC_SHA3_224_DIGEST_SIZE;
+    }
+#endif
+#ifndef WOLFSSL_NOSHA3_256
+    else if (XSTRNCMP(type, "SHA3_256", 8) == 0) {
+        return WC_SHA3_256_DIGEST_SIZE;
+    }
+#endif
+#ifndef WOLFSSL_NOSHA3_384
+    else if (XSTRNCMP(type, "SHA3_384", 8) == 0) {
+        return WC_SHA3_384_DIGEST_SIZE;
+    }
+#endif
+#ifndef WOLFSSL_NOSHA3_512
+    else if (XSTRNCMP(type, "SHA3_512", 8) == 0) {
+        return WC_SHA3_512_DIGEST_SIZE;
+    }
+#endif
+#endif /* WOLFSSL_SHA3 */
 #ifndef NO_SHA
     /* has to be last since would pick or 256, 384, or 512 too */
     else if (XSTRNCMP(type, "SHA", 3) == 0) {
@@ -8030,7 +8078,6 @@ int wolfSSL_EVP_PKEY_print_public(WOLFSSL_BIO* out,
 }
 #endif /* OPENSSL_EXTRA */
 
-#if !defined(NO_PWDBASED)
 int wolfSSL_EVP_get_hashinfo(const WOLFSSL_EVP_MD* evp,
     int* pHash, int* pHashSz)
 {
@@ -8044,6 +8091,12 @@ int wolfSSL_EVP_get_hashinfo(const WOLFSSL_EVP_MD* evp,
 
     if (XSTRNCMP("SHA", evp, 3) == 0) {
         if (XSTRLEN(evp) > 3) {
+        #ifdef WOLFSSL_SHA224
+            if (XSTRNCMP("SHA224", evp, 6) == 0) {
+                hash = WC_HASH_TYPE_SHA224;
+            }
+            else
+        #endif
         #ifndef NO_SHA256
             if (XSTRNCMP("SHA256", evp, 6) == 0) {
                 hash = WC_HASH_TYPE_SHA256;
@@ -8062,6 +8115,32 @@ int wolfSSL_EVP_get_hashinfo(const WOLFSSL_EVP_MD* evp,
             }
             else
         #endif
+        #ifdef WOLFSSL_SHA3
+        #ifndef WOLFSSL_NOSHA3_224
+            if (XSTRNCMP("SHA3_224", evp, 8) == 0) {
+                hash = WC_HASH_TYPE_SHA3_224;
+            }
+            else
+        #endif
+        #ifndef WOLFSSL_NOSHA3_256
+            if (XSTRNCMP("SHA3_256", evp, 8) == 0) {
+                hash = WC_HASH_TYPE_SHA3_256;
+            }
+            else
+        #endif
+        #ifndef WOLFSSL_NOSHA3_384
+            if (XSTRNCMP("SHA3_384", evp, 8) == 0) {
+                hash = WC_HASH_TYPE_SHA3_384;
+            }
+            else
+        #endif
+        #ifndef WOLFSSL_NOSHA3_512
+            if (XSTRNCMP("SHA3_512", evp, 8) == 0) {
+                hash = WC_HASH_TYPE_SHA3_512;
+            }
+            else
+        #endif
+        #endif /* WOLFSSL_SHA3 */
             if (XSTRNCMP("SHA1", evp, 4) == 0) {
                 hash = WC_HASH_TYPE_SHA;
             }
@@ -8102,7 +8181,6 @@ int wolfSSL_EVP_get_hashinfo(const WOLFSSL_EVP_MD* evp,
 
     return WOLFSSL_SUCCESS;
 }
-#endif /* !defined(NO_PWDBASED) */
 
 /* Base64 encoding APIs */
 #if defined(WOLFSSL_BASE64_ENCODE) || defined(WOLFSSL_BASE64_DECODE)

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -2003,6 +2003,28 @@ static int wc_PKCS7_SignedDataGetEncAlgoId(PKCS7* pkcs7, int* digEncAlgoId,
                 algoId = CTC_SHA512wRSA;
                 break;
         #endif
+        #ifdef WOLFSSL_SHA3
+        #ifndef WOLFSSL_NOSHA3_224
+            case SHA3_224h:
+                algoId = CTC_SHA3_224wRSA;
+                break;
+        #endif
+        #ifndef WOLFSSL_NOSHA3_256
+            case SHA3_256h:
+                algoId = CTC_SHA3_256wRSA;
+                break;
+        #endif
+        #ifndef WOLFSSL_NOSHA3_384
+            case SHA3_384h:
+                algoId = CTC_SHA3_384wRSA;
+                break;
+        #endif
+        #ifndef WOLFSSL_NOSHA3_512
+            case SHA3_512h:
+                algoId = CTC_SHA3_512wRSA;
+                break;
+        #endif
+        #endif
         }
 
     }
@@ -2036,6 +2058,28 @@ static int wc_PKCS7_SignedDataGetEncAlgoId(PKCS7* pkcs7, int* digEncAlgoId,
             case SHA512h:
                 algoId = CTC_SHA512wECDSA;
                 break;
+        #endif
+        #ifdef WOLFSSL_SHA3
+        #ifndef WOLFSSL_NOSHA3_224
+            case SHA3_224h:
+                algoId = CTC_SHA3_224wECDSA;
+                break;
+        #endif
+        #ifndef WOLFSSL_NOSHA3_256
+            case SHA3_256h:
+                algoId = CTC_SHA3_256wECDSA;
+                break;
+        #endif
+        #ifndef WOLFSSL_NOSHA3_384
+            case SHA3_384h:
+                algoId = CTC_SHA3_384wECDSA;
+                break;
+        #endif
+        #ifndef WOLFSSL_NOSHA3_512
+            case SHA3_512h:
+                algoId = CTC_SHA3_512wECDSA;
+                break;
+        #endif
         #endif
         }
     }
@@ -3936,6 +3980,10 @@ static int wc_PKCS7_SetPublicKeyOID(PKCS7* pkcs7, int sigOID)
         case CTC_SHA256wRSA:
         case CTC_SHA384wRSA:
         case CTC_SHA512wRSA:
+        case CTC_SHA3_224wRSA:
+        case CTC_SHA3_256wRSA:
+        case CTC_SHA3_384wRSA:
+        case CTC_SHA3_512wRSA:
             pkcs7->publicKeyOID = RSAk;
             break;
 
@@ -3964,6 +4012,10 @@ static int wc_PKCS7_SetPublicKeyOID(PKCS7* pkcs7, int sigOID)
         case CTC_SHA256wECDSA:
         case CTC_SHA384wECDSA:
         case CTC_SHA512wECDSA:
+        case CTC_SHA3_224wECDSA:
+        case CTC_SHA3_256wECDSA:
+        case CTC_SHA3_384wECDSA:
+        case CTC_SHA3_512wECDSA:
             pkcs7->publicKeyOID = ECDSAk;
             break;
 

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -144,6 +144,17 @@ enum Ctc_SigType {
     CTC_SHA384wECDSA = 525,
     CTC_SHA512wRSA   = 657,
     CTC_SHA512wECDSA = 526,
+
+    /* https://csrc.nist.gov/projects/computer-security-objects-register/algorithm-registration */
+    CTC_SHA3_224wECDSA = 423,
+    CTC_SHA3_256wECDSA = 424,
+    CTC_SHA3_384wECDSA = 425,
+    CTC_SHA3_512wECDSA = 426,
+    CTC_SHA3_224wRSA = 427,
+    CTC_SHA3_256wRSA = 428,
+    CTC_SHA3_384wRSA = 429,
+    CTC_SHA3_512wRSA = 430,
+
     CTC_ED25519      = 256,
     CTC_ED448        = 257
 };


### PR DESCRIPTION
Add more support in the EVP layer as well as add signing support. The SHA-3 OID's were also added for DER algorithm identifier encoding.