### PR TITLE
fix version error when minimum downgrade is set to TLSv1.3

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -6224,6 +6224,10 @@ static int TLSX_SupportedVersions_Parse(WOLFSSL* ssl, const byte* input,
             /* Downgrade the version. */
             ssl->version.minor = minor;
         }
+
+        if (ssl->options.downgrade && (minor < ssl->options.minDowngrade)) {
+            return VERSION_ERROR;
+        }
     }
     else
         return SANITY_MSG_E;

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3450,10 +3450,6 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 return VERSION_ERROR;
             ssl->version.minor = args->pv.minor;
         }
-        if (foundVersion && ssl->options.downgrade && 
-                                 (args->pv.minor < ssl->options.minDowngrade)) {
-            return VERSION_ERROR;
-        }
     }
     
     /* Advance state and proceed */


### PR DESCRIPTION
fix version error when minDowngrade is set to TLSv1.3