### PR TITLE
Fix compilation with gcc 11

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -27234,7 +27234,7 @@ int wolfSSL_X509_VERIFY_PARAM_set1_host(WOLFSSL_X509_VERIFY_PARAM* pParam,
     if (nameSz > 0)
         XMEMCPY(pParam->hostName, name, nameSz);
 
-        pParam->hostName[nameSz] = '\0';
+    pParam->hostName[nameSz] = '\0';
 
     return WOLFSSL_SUCCESS;
 }
@@ -34093,7 +34093,7 @@ static int wolfSSL_RSA_generate_key_native(WOLFSSL_RSA* rsa, int bits, WOLFSSL_B
             WOLFSSL_MSG("SetRsaExternal failed");
         else {
             rsa->inSet = 1;
-	    ret = WOLFSSL_ERROR_NONE;
+            ret = WOLFSSL_ERROR_NONE;
         }
 
         wc_FreeRng(rng);
@@ -42140,7 +42140,7 @@ cleanup:
         }
 
     out:
-	if (der)
+        if (der)
             XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
         return ret;
@@ -42841,7 +42841,7 @@ err:
         /* unused */
         (void)cb;
         (void)u;
-	    (void)derSz;
+        (void)derSz;
 
         return NULL;
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -14429,7 +14429,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         #ifdef WOLFSSL_SMALL_STACK
             byte   staticBuffer[1]; /* force heap usage */
         #else
-            byte   staticBuffer[FILE_BUFFER_SIZE];
+            byte   staticBuffer[FILE_BUFFER_SIZE] = {0};
         #endif
             byte* myBuffer  = staticBuffer;
             int   dynamic   = 0;

--- a/wolfcrypt/src/hc128.c
+++ b/wolfcrypt/src/hc128.c
@@ -33,7 +33,7 @@
 #include <wolfssl/wolfcrypt/logging.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/hc128.h>
-		#include <wolfssl/wolfcrypt/misc.h>
+    #include <wolfssl/wolfcrypt/misc.h>
 #else
     #define WOLFSSL_MISC_INCLUDED
     #include <wolfcrypt/src/misc.c>
@@ -116,7 +116,7 @@ static void generate_keystream(HC128* ctx, word32* keystream)
    }
    else
    {
-	  ctx->counter1024 = (ctx->counter1024 + 16) & 0x3ff;
+      ctx->counter1024 = (ctx->counter1024 + 16) & 0x3ff;
       step_Q(ctx, 512+cc+0, 512+cc+1, 0, 6, 13,4, keystream[0]);
       step_Q(ctx, 512+cc+1, 512+cc+2, 1, 7, 14,5, keystream[1]);
       step_Q(ctx, 512+cc+2, 512+cc+3, 2, 8, 15,6, keystream[2]);
@@ -241,7 +241,7 @@ static void Hc128_SetIV(HC128* ctx, const byte* inIv)
     else
         XMEMSET(iv,    0, sizeof(iv));
 
-	for (i = 0; i < (128 >> 5); i++)
+    for (i = 0; i < (128 >> 5); i++)
         ctx->iv[i] = LITTLE32(iv[i]);
 
     for (; i < 8; i++) ctx->iv[i] = ctx->iv[i-4];
@@ -249,26 +249,26 @@ static void Hc128_SetIV(HC128* ctx, const byte* inIv)
     /* expand the key and IV into the table T */
     /* (expand the key and IV into the table P and Q) */
 
-	for (i = 0; i < 8;  i++)   ctx->T[i] = ctx->key[i];
-	for (i = 8; i < 16; i++)   ctx->T[i] = ctx->iv[i-8];
+    for (i = 0; i < 8;  i++)   ctx->T[i] = ctx->key[i];
+    for (i = 8; i < 16; i++)   ctx->T[i] = ctx->iv[i-8];
 
     for (i = 16; i < (256+16); i++)
-		ctx->T[i] = f2(ctx->T[i-2]) + ctx->T[i-7] + f1(ctx->T[i-15]) +
+        ctx->T[i] = f2(ctx->T[i-2]) + ctx->T[i-7] + f1(ctx->T[i-15]) +
                                                        ctx->T[i-16]+i;
 
-	for (i = 0; i < 16;  i++)  ctx->T[i] = ctx->T[256+i];
+    for (i = 0; i < 16;  i++)  ctx->T[i] = ctx->T[256+i];
 
-	for (i = 16; i < 1024; i++)
-		ctx->T[i] = f2(ctx->T[i-2]) + ctx->T[i-7] + f1(ctx->T[i-15]) +
+    for (i = 16; i < 1024; i++)
+        ctx->T[i] = f2(ctx->T[i-2]) + ctx->T[i-7] + f1(ctx->T[i-15]) +
                                                        ctx->T[i-16]+256+i;
 
     /* initialize counter1024, X and Y */
-	ctx->counter1024 = 0;
-	for (i = 0; i < 16; i++) ctx->X[i] = ctx->T[512-16+i];
+    ctx->counter1024 = 0;
+    for (i = 0; i < 16; i++) ctx->X[i] = ctx->T[512-16+i];
     for (i = 0; i < 16; i++) ctx->Y[i] = ctx->T[512+512-16+i];
 
     /* run the cipher 1024 steps before generating the output */
-	for (i = 0; i < 64; i++)  setup_update(ctx);
+    for (i = 0; i < 64; i++)  setup_update(ctx);
 }
 
 
@@ -342,25 +342,25 @@ static WC_INLINE int DoProcess(HC128* ctx, byte* output, const byte* input,
 
   for ( ; msglen >= 64; msglen -= 64, input += 64, output += 64)
   {
-	  generate_keystream(ctx, keystream);
+      generate_keystream(ctx, keystream);
 
       /* unroll loop */
-	  ((word32*)output)[0]  = ((word32*)input)[0]  ^ LITTLE32(keystream[0]);
-	  ((word32*)output)[1]  = ((word32*)input)[1]  ^ LITTLE32(keystream[1]);
-	  ((word32*)output)[2]  = ((word32*)input)[2]  ^ LITTLE32(keystream[2]);
-	  ((word32*)output)[3]  = ((word32*)input)[3]  ^ LITTLE32(keystream[3]);
-	  ((word32*)output)[4]  = ((word32*)input)[4]  ^ LITTLE32(keystream[4]);
-	  ((word32*)output)[5]  = ((word32*)input)[5]  ^ LITTLE32(keystream[5]);
-	  ((word32*)output)[6]  = ((word32*)input)[6]  ^ LITTLE32(keystream[6]);
-	  ((word32*)output)[7]  = ((word32*)input)[7]  ^ LITTLE32(keystream[7]);
-	  ((word32*)output)[8]  = ((word32*)input)[8]  ^ LITTLE32(keystream[8]);
-	  ((word32*)output)[9]  = ((word32*)input)[9]  ^ LITTLE32(keystream[9]);
-	  ((word32*)output)[10] = ((word32*)input)[10] ^ LITTLE32(keystream[10]);
-	  ((word32*)output)[11] = ((word32*)input)[11] ^ LITTLE32(keystream[11]);
-	  ((word32*)output)[12] = ((word32*)input)[12] ^ LITTLE32(keystream[12]);
-	  ((word32*)output)[13] = ((word32*)input)[13] ^ LITTLE32(keystream[13]);
-	  ((word32*)output)[14] = ((word32*)input)[14] ^ LITTLE32(keystream[14]);
-	  ((word32*)output)[15] = ((word32*)input)[15] ^ LITTLE32(keystream[15]);
+      ((word32*)output)[0]  = ((word32*)input)[0]  ^ LITTLE32(keystream[0]);
+      ((word32*)output)[1]  = ((word32*)input)[1]  ^ LITTLE32(keystream[1]);
+      ((word32*)output)[2]  = ((word32*)input)[2]  ^ LITTLE32(keystream[2]);
+      ((word32*)output)[3]  = ((word32*)input)[3]  ^ LITTLE32(keystream[3]);
+      ((word32*)output)[4]  = ((word32*)input)[4]  ^ LITTLE32(keystream[4]);
+      ((word32*)output)[5]  = ((word32*)input)[5]  ^ LITTLE32(keystream[5]);
+      ((word32*)output)[6]  = ((word32*)input)[6]  ^ LITTLE32(keystream[6]);
+      ((word32*)output)[7]  = ((word32*)input)[7]  ^ LITTLE32(keystream[7]);
+      ((word32*)output)[8]  = ((word32*)input)[8]  ^ LITTLE32(keystream[8]);
+      ((word32*)output)[9]  = ((word32*)input)[9]  ^ LITTLE32(keystream[9]);
+      ((word32*)output)[10] = ((word32*)input)[10] ^ LITTLE32(keystream[10]);
+      ((word32*)output)[11] = ((word32*)input)[11] ^ LITTLE32(keystream[11]);
+      ((word32*)output)[12] = ((word32*)input)[12] ^ LITTLE32(keystream[12]);
+      ((word32*)output)[13] = ((word32*)input)[13] ^ LITTLE32(keystream[13]);
+      ((word32*)output)[14] = ((word32*)input)[14] ^ LITTLE32(keystream[14]);
+      ((word32*)output)[15] = ((word32*)input)[15] ^ LITTLE32(keystream[15]);
   }
 
   if (msglen > 0)
@@ -378,7 +378,7 @@ static WC_INLINE int DoProcess(HC128* ctx, byte* output, const byte* input,
 #endif
 
       for (i = 0; i < msglen; i++)
-	      output[i] = input[i] ^ ((byte*)keystream)[i];
+          output[i] = input[i] ^ ((byte*)keystream)[i];
   }
 
   return 0;


### PR DESCRIPTION
`-Werror=misleading-indentation` and `-Werror=maybe-uninitialized` have probably been improved since the last working gcc version, and they now prevent wolfssl from building.

I’ve also initialised a `staticBuffer` with zeroes, but I have no idea if this is a correct fix, if the warning should be silenced in another way, or if this is hiding a very real bug.

Note that it would be nice to also remove `-Werror` altogether though, since this obviously can’t be checked for every future compiler.  A random user shouldn’t have to know how to fix your library before they can use it.