### PR TITLE
make: fix timing error when switching between revisions

### DIFF
--- a/examples/server/include.am
+++ b/examples/server/include.am
@@ -9,7 +9,7 @@ noinst_HEADERS += examples/server/server.h
 examples_server_server_SOURCES      = examples/server/server.c
 examples_server_server_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD) $(WOLFSENTRY_LIB)
 examples_server_server_DEPENDENCIES = src/libwolfssl.la
-examples_server_server_CFLAGS = $(WOLFSENTRY_INCLUDE)
+examples_server_server_CFLAGS = $(WOLFSENTRY_INCLUDE) $(AM_CFLAGS)
 endif
 EXTRA_DIST += examples/server/server.sln
 EXTRA_DIST += examples/server/server-ntru.vcproj


### PR DESCRIPTION
On switching over revision that added server target specific CFLAGS,
could receive: `error: #warning "For timing resistance / side-channel
attack prevention consider using harden options"`