### PR TITLE
MP Integer: remove unsupported API prototypes

### DIFF
--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -256,9 +256,6 @@ typedef int ltm_prime_callback(unsigned char *dst, int len, void *dat);
 #define mp_prime_random(a, t, size, bbs, cb, dat) \
    mp_prime_random_ex(a, t, ((size) * 8) + 1, (bbs==1)?LTM_PRIME_BBS:0, cb, dat)
 
-#define mp_read_raw(mp, str, len) mp_read_signed_bin((mp), (str), (len))
-#define mp_raw_size(mp)           mp_signed_bin_size(mp)
-#define mp_toraw(mp, str)         mp_to_signed_bin((mp), (str))
 #define mp_read_mag(mp, str, len) mp_read_unsigned_bin((mp), (str), (len))
 #define mp_mag_size(mp)           mp_unsigned_bin_size(mp)
 #define mp_tomag(mp, str)         mp_to_unsigned_bin((mp), (str))

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -660,10 +660,6 @@ int fp_to_unsigned_bin(fp_int *a, unsigned char *b);
 int fp_to_unsigned_bin_len(fp_int *a, unsigned char *b, int c);
 int fp_to_unsigned_bin_at_pos(int x, fp_int *t, unsigned char *b);
 
-/*int fp_signed_bin_size(fp_int *a);*/
-/*void fp_read_signed_bin(fp_int *a, const unsigned char *b, int c);*/
-/*void fp_to_signed_bin(fp_int *a, unsigned char *b);*/
-
 /*int fp_read_radix(fp_int *a, char *str, int radix);*/
 /*int fp_toradix(fp_int *a, char *str, int radix);*/
 /*int fp_toradix_n(fp_int * a, char *str, int radix, int maxlen);*/


### PR DESCRIPTION
mp_read_signed_bin, mp_signed_bin_size, mp_to_signed_bin - not
implemented anywhere. (Removed fp versions that were commented out too.)
mp_read_raw, mp_raw_size, mp_toraw - map to unimplemented mp_*_signed_*
APIs.