### PR TITLE
TLS: fix build with no TLSv12 but PK callbacks

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -3692,7 +3692,8 @@ static word32 MacSize(WOLFSSL* ssl)
 #endif /* HAVE_ENCRYPT_THEN_MAC && !WOLFSSL_AEAD_ONLY */
 
 #ifndef NO_RSA
-#ifndef WOLFSSL_NO_TLS12
+#if !defined(WOLFSSL_NO_TLS12) || \
+    (defined(WC_RSA_PSS) && defined(HAVE_PK_CALLBACKS))
 #if !defined(NO_WOLFSSL_SERVER) || !defined(NO_WOLFSSL_CLIENT)
 static int TypeHash(int hashAlgo)
 {

--- a/tests/api.c
+++ b/tests/api.c
@@ -40238,7 +40238,8 @@ static int test_tls13_apis(void)
 
 #endif
 
-#ifdef HAVE_PK_CALLBACKS
+#if defined(HAVE_PK_CALLBACKS) && (!defined(WOLFSSL_NO_TLS12) || \
+    !defined(NO_OLD_TLS))
 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS) && !defined(NO_RSA) && \
         !defined(NO_WOLFSSL_CLIENT) && !defined(NO_DH) && !defined(NO_AES) && \
          defined(HAVE_IO_TESTS_DEPENDENCIES) && !defined(SINGLE_THREADED)
@@ -43750,7 +43751,8 @@ void ApiTest(void)
     AssertIntEQ(test_RsaSigFailure_cm(), ASN_SIG_CONFIRM_E);
 #endif /* NO_CERTS */
 
-#ifdef HAVE_PK_CALLBACKS
+#if defined(HAVE_PK_CALLBACKS) && (!defined(WOLFSSL_NO_TLS12) || \
+    !defined(NO_OLD_TLS))
     /* public key callback tests */
     test_DhCallbacks();
 #endif


### PR DESCRIPTION
./configure '--disable-tlsv12' '-enable-pkcallbacks'
Disable non-TLS13 cipher suite test as well.