### PR TITLE
extend set_cipher_list() compatibility layer API

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12005,6 +12005,15 @@ static char* buildEnabledCipherList(WOLFSSL_CTX* ctx, Suites* suites,
         
         head = locallist;
         
+        if (!onlytlsv13suites)
+        {
+            /* always tls13 suites in the head position */
+            XSTRNCPY(locallist, list, len);
+            locallist += listsz;
+            *locallist = 0;
+            len -= listsz;
+        }
+        
         for(idx = 0; idx < suites->suiteSz; idx++) {
             cipherSuite0 = suites->suites[idx];
             cipherSuite  = suites->suites[++idx];
@@ -12030,9 +12039,12 @@ static char* buildEnabledCipherList(WOLFSSL_CTX* ctx, Suites* suites,
                 return NULL;
             }
         }
-        XSTRNCPY(locallist, list, len);
-        locallist += listsz;
-        *locallist = 0;
+        
+        if (onlytlsv13suites) {
+            XSTRNCPY(locallist, list, len);
+            locallist += listsz;
+            *locallist = 0;
+        }
         
         return head;
     } else 
@@ -12079,8 +12091,8 @@ static int CheckcipherList(const char* list)
         }
         
         if (findTLSv13Suites == 1 && findbeforeSuites == 1)
-         /* list has mixed suites */
-         return 0;
+            /* list has mixed suites */
+            return 0;
     }  while (next++); /* ++ needed to skip ':' */
     
     if (findTLSv13Suites == 0 && findbeforeSuites == 1)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11954,10 +11954,10 @@ static int wolfSSL_remove_ciphers(char* list, int sz, const char* toRemove)
 static char* buildEnabledCipherList(WOLFSSL_CTX* ctx, Suites* suites,
            int onlytlsv13suites, const char* list)
 {
-    int idx = 0;
-    int listsz = 0;
-    int len = 0;
-    int ianasz = 0;
+    word32 idx = 0;
+    word32 listsz = 0;
+    word32 len = 0;
+    word32 ianasz = 0;
     const char* enabledcs = NULL;
     char* locallist = NULL;
     char* head = NULL;
@@ -11971,7 +11971,7 @@ static char* buildEnabledCipherList(WOLFSSL_CTX* ctx, Suites* suites,
     if (!suites->setSuites)
         return NULL;
     
-    listsz = XSTRLEN(list);
+    listsz = (word32)XSTRLEN(list);
     
     /* calculate necessary buffer length */
     for(idx = 0; idx < suites->suiteSz; idx++) {
@@ -11987,7 +11987,7 @@ static char* buildEnabledCipherList(WOLFSSL_CTX* ctx, Suites* suites,
             continue;
         
         if (XSTRNCMP(enabledcs, "None", XSTRLEN(enabledcs)) != 0) {
-            len += XSTRLEN(enabledcs) + 2;
+            len += (word32)XSTRLEN(enabledcs) + 2;
         }
     }
     
@@ -12035,7 +12035,7 @@ static char* buildEnabledCipherList(WOLFSSL_CTX* ctx, Suites* suites,
                 len -= ianasz + 1;
             }
             else{
-                XFREE(locallist, ctx-heap, DYNAMIC_TYPE_TMP_BUFFER);
+                XFREE(locallist, ctx->heap, DYNAMIC_TYPE_TMP_BUFFER);
                 return NULL;
             }
         }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11991,7 +11991,7 @@ static char* buildEnabledCipherList(WOLFSSL_CTX* ctx, Suites* suites,
         }
     }
     
-    len += listsz + 1;
+    len += listsz + 2;
     
     /* build string */
     if (len > 0) {
@@ -12010,8 +12010,9 @@ static char* buildEnabledCipherList(WOLFSSL_CTX* ctx, Suites* suites,
             /* always tls13 suites in the head position */
             XSTRNCPY(locallist, list, len);
             locallist += listsz;
+            *locallist++ = ':';
             *locallist = 0;
-            len -= listsz;
+            len -= listsz + 1;
         }
         
         for(idx = 0; idx < suites->suiteSz; idx++) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12076,13 +12076,19 @@ static int CheckcipherList(const char* list)
     do {
         char*  current = next;
         char   name[MAX_SUITE_NAME + 1];
-        word32 length;
-        
+        word32 length = MAX_SUITE_NAME;
+        word32 current_length;
+
         next   = XSTRSTR(next, ":");
-        length = min(sizeof(name), !next ? (word32)XSTRLEN(current) /* last */
-                                         : (word32)(next - current));
+        
+        current_length = (!next) ? (word32)XSTRLEN(current)
+                                 : (word32)(next - current);
+        
+        if (current_length < length) {
+            length = current_length;
+        }
         XSTRNCPY(name, current, length);
-        name[(length == sizeof(name)) ? length - 1 : length] = 0;
+        name[length] = 0;
         
         ret = wolfSSL_get_cipher_suite_from_name(name, &cipherSuite0, 
                                                         &cipherSuite1, &flags);
@@ -12142,14 +12148,19 @@ static int wolfSSL_parse_cipher_list(WOLFSSL_CTX* ctx, Suites* suites,
             char*  current = next;
             char   name[MAX_SUITE_NAME + 1];
             int    i;
-            word32 length;
+            word32 length = MAX_SUITE_NAME;
+            word32 current_length;
 
             next   = XSTRSTR(next, ":");
-            length = min(sizeof(name), !next ? (word32)XSTRLEN(current) /*last*/
-                                             : (word32)(next - current));
-
+            
+            current_length = (!next) ? (word32)XSTRLEN(current)
+                                     : (word32)(next - current);
+            
+            if (current_length < length) {
+                length = current_length;
+            }
             XSTRNCPY(name, current, length);
-            name[(length == sizeof(name)) ? length - 1 : length] = 0;
+            name[length] = 0;
 
             /* check for "not" case */
             if (name[0] == '!' && suiteSz > 0) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12097,17 +12097,21 @@ static int CheckcipherList(const char* list)
                 break;
             }
         } 
-        if (findTLSv13Suites == 1 && findbeforeSuites == 1)
+        if (findTLSv13Suites == 1 && findbeforeSuites == 1) {
             /* list has mixed suites */
             return 0;
+        }
     }  while (next++); /* ++ needed to skip ':' */
     
-    if (findTLSv13Suites == 0 && findbeforeSuites == 1)
+    if (findTLSv13Suites == 0 && findbeforeSuites == 1) {
         return 1;/* only before TLSv13 sutes */
-    else if (findTLSv13Suites == 1 && findbeforeSuites == 0)
+    }
+    else if (findTLSv13Suites == 1 && findbeforeSuites == 0) {
         return 2;/* only TLSv13 suties */
-    else 
+    }
+    else { 
         return 0;/* handle as mixed */
+    }
 }
 
 /* parse some bulk lists like !eNULL / !aNULL
@@ -12179,22 +12183,22 @@ static int wolfSSL_parse_cipher_list(WOLFSSL_CTX* ctx, Suites* suites,
         listattribute = CheckcipherList(list);
         
         if (listattribute == 0) {
-            /* list has mixed(pre-TLSv13 and TLSv13) suites
-             * update cipher suites the same as before
-             */
+           /* list has mixed(pre-TLSv13 and TLSv13) suites
+            * update cipher suites the same as before
+            */
             return (SetCipherList(ctx, suites, list)) ? WOLFSSL_SUCCESS :
             WOLFSSL_FAILURE;
         } 
         else if (listattribute == 1) {
-            /* list has only pre-TLSv13 suites. 
-             * Only update before TLSv13 suites.
-             */
+           /* list has only pre-TLSv13 suites. 
+            * Only update before TLSv13 suites.
+            */
             tls13Only = 1;
         } 
         else if (listattribute == 2) {
-        /* list has only TLSv13 suites. Only update TLv13 suites
-         * simulate set_ciphersuites() comatibility layer API
-         */
+           /* list has only TLSv13 suites. Only update TLv13 suites
+            * simulate set_ciphersuites() comatibility layer API
+            */
             tls13Only = 0;
         }
         
@@ -12202,13 +12206,13 @@ static int wolfSSL_parse_cipher_list(WOLFSSL_CTX* ctx, Suites* suites,
                                                 tls13Only, list);
         
         if (buildcipherList) {
-            
             ret = SetCipherList(ctx, suites, buildcipherList);
             XFREE(buildcipherList, ctx->heap, DYNAMIC_TYPE_TMP_BUFFER);
         }
-        else
+        else {
             ret = SetCipherList(ctx, suites, list);
-        
+        }
+
         return ret;
     }
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -756,6 +756,14 @@ static void test_for_double_Free(void)
         AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, testCertFile, WOLFSSL_FILETYPE_PEM));
         AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, testKeyFile, WOLFSSL_FILETYPE_PEM));
         AssertTrue(wolfSSL_CTX_set_cipher_list(ctx, optionsCiphers));
+#ifdef WOLFSSL_TLS13
+        /* only update TLSv13 suites */
+        AssertTrue(wolfSSL_CTX_set_cipher_list(ctx, "TLS13-AES256-GCM-SHA384"));
+#endif
+#ifndef WOLFSSL_NO_TLS12
+        /* only update pre-TLSv13 suites */
+        AssertTrue(wolfSSL_CTX_set_cipher_list(ctx, "ECDHE-RSA-AES128-GCM-SHA256"));
+#endif
         AssertNotNull(ssl = wolfSSL_new(ctx));
         wolfSSL_CTX_free(ctx);
         wolfSSL_free(ssl);
@@ -773,6 +781,14 @@ static void test_for_double_Free(void)
         AssertNotNull(ssl);
         /* test setting ciphers at SSL level */
         AssertTrue(wolfSSL_set_cipher_list(ssl, optionsCiphers));
+#ifdef WOLFSSL_TLS13
+        /* only update TLSv13 suites */
+        AssertTrue(wolfSSL_set_cipher_list(ssl, "TLS13-AES256-GCM-SHA384"));
+#endif
+#ifndef WOLFSSL_NO_TLS12
+        /* only update pre-TLSv13 suites */
+        AssertTrue(wolfSSL_set_cipher_list(ssl, "ECDHE-RSA-AES128-GCM-SHA256"));
+#endif
         wolfSSL_CTX_free(ctx);
         wolfSSL_free(ssl);
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -756,11 +756,14 @@ static void test_for_double_Free(void)
         AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, testCertFile, WOLFSSL_FILETYPE_PEM));
         AssertTrue(wolfSSL_CTX_use_PrivateKey_file(ctx, testKeyFile, WOLFSSL_FILETYPE_PEM));
         AssertTrue(wolfSSL_CTX_set_cipher_list(ctx, optionsCiphers));
-#ifdef WOLFSSL_TLS13
+#if defined(OPENSSL_EXTRA) && defined(WOLFSSL_TLS13) && defined(HAVE_AESGCM) && \
+        defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256)
         /* only update TLSv13 suites */
         AssertTrue(wolfSSL_CTX_set_cipher_list(ctx, "TLS13-AES256-GCM-SHA384"));
 #endif
-#ifndef WOLFSSL_NO_TLS12
+#if defined(OPENSSL_EXTRA) && defined(HAVE_ECC) && defined(HAVE_AESGCM) && \
+    !defined(NO_SHA256) && !defined(WOLFSSL_NO_TLS12) && \
+    defined(WOLFSSL_AES_128) && !defined(NO_RSA)
         /* only update pre-TLSv13 suites */
         AssertTrue(wolfSSL_CTX_set_cipher_list(ctx, "ECDHE-RSA-AES128-GCM-SHA256"));
 #endif
@@ -781,11 +784,14 @@ static void test_for_double_Free(void)
         AssertNotNull(ssl);
         /* test setting ciphers at SSL level */
         AssertTrue(wolfSSL_set_cipher_list(ssl, optionsCiphers));
-#ifdef WOLFSSL_TLS13
+#if defined(OPENSSL_EXTRA) && defined(WOLFSSL_TLS13) && defined(HAVE_AESGCM) && \
+        defined(WOLFSSL_SHA384) && defined(WOLFSSL_AES_256)
         /* only update TLSv13 suites */
         AssertTrue(wolfSSL_set_cipher_list(ssl, "TLS13-AES256-GCM-SHA384"));
 #endif
-#ifndef WOLFSSL_NO_TLS12
+#if defined(OPENSSL_EXTRA) && defined(HAVE_ECC) && defined(HAVE_AESGCM) && \
+    !defined(NO_SHA256) && !defined(WOLFSSL_NO_TLS12) && \
+    defined(WOLFSSL_AES_128) && !defined(NO_RSA)
         /* only update pre-TLSv13 suites */
         AssertTrue(wolfSSL_set_cipher_list(ssl, "ECDHE-RSA-AES128-GCM-SHA256"));
 #endif


### PR DESCRIPTION
Changes to extend set_cipher_list() compatibility layer API to have set_ciphersuites compatibility layer API capability.
 
 1. the same behavior when list has mixed, pre-TLS13 suites and TLS13 suites
 2. only update pre-TLS13 suites when list has only pre-TLS13 suites
 3. only update TLS13 suites when list has only TLS13 suites

Currently, both set_cipher_list() and set_ciphersuites() are mapped to wolfSSL_set_cipher_list. Therefore, suites are overwritten even if cipher list has only pre-TLSv13 or TLS13.