### PR TITLE
EVP AES-GCM Streaming: must free Aes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -12275,6 +12275,10 @@ static int test_wc_AesGcmStream (void)
         AES_IV_SIZE, tag, AES_BLOCK_SIZE, aad, sizeof(aad)), 0);
     AssertIntEQ(XMEMCMP(plain, in, sizeof(in)), 0);
 
+    wc_AesFree(aesEnc);
+    wc_AesFree(aesDec);
+    wc_FreeRng(rng);
+
 #endif
     return ret;
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -8044,7 +8044,7 @@ static void AesGcmFinal_C(Aes* aes, byte* authTag, word32 authTagSz)
     aes->aadLen = aes->aSz;
 #endif
     /* Zeroize last block to protect sensitive data. */
-    ForceZero(AES_LASTBLOCK(aes), sizeof(AES_LASTBLOCK(aes)));
+    ForceZero(AES_LASTBLOCK(aes), AES_BLOCK_SIZE);
 }
 
 #ifdef WOLFSSL_AESNI

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -4365,6 +4365,16 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD *md)
     {
         WOLFSSL_ENTER("EVP_CIPHER_CTX_cleanup");
         if (ctx) {
+#if (!defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)) || \
+    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2))
+    #if defined(HAVE_AESGCM) && defined(WOLFSSL_AESGCM_STREAM)
+            if ((ctx->cipherType == AES_128_GCM_TYPE) ||
+                (ctx->cipherType == AES_192_GCM_TYPE) ||
+                (ctx->cipherType == AES_256_GCM_TYPE)) {
+               wc_AesFree(&ctx->cipher.aes);
+            }
+    #endif /* HAVE_AESGCM && WOLFSSL_AESGCM_STREAM */
+#endif /* not FIPS or new FIPS */
             ctx->cipherType = WOLFSSL_EVP_CIPH_TYPE_INIT;  /* not yet initialized  */
             ctx->keyLen     = 0;
 #ifdef HAVE_AESGCM


### PR DESCRIPTION
AES streaming implementation allocates data in Aes objects, when small
stack, that needs to be freed.
Fix memory leaks in streaming test case too.