### PR TITLE
wc_RsaKeyToPublicDer extension

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -11894,11 +11894,19 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
 #endif
 
 #if (defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA)) && !defined(NO_RSA) && !defined(HAVE_USER_RSA)
+
 /* Convert Rsa Public key to DER format, write to output (inLen), return bytes
    written */
 int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen)
 {
     return SetRsaPublicKey(output, key, inLen, 1);
+}
+
+/* Convert Rsa Public key to DER format, write to output (inLen), return bytes
+   written, choose DER header or not*/
+int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen, int with_header)
+{
+    return SetRsaPublicKey(output, key, inLen, with_header);
 }
 
 #endif /* (WOLFSSL_KEY_GEN || OPENSSL_EXTRA) && !NO_RSA && !HAVE_USER_RSA */

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -506,6 +506,7 @@ WOLFSSL_API void wc_FreeDer(DerBuffer** pDer);
     #if !defined(HAVE_USER_RSA)
     WOLFSSL_API int wc_RsaPublicKeyDecode_ex(const byte* input, word32* inOutIdx,
         word32 inSz, const byte** n, word32* nSz, const byte** e, word32* eSz);
+    WOLFSSL_API int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen, int with_header);
     #endif
     WOLFSSL_API int wc_RsaPublicKeyDerSize(RsaKey* key, int with_header);
 #endif

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -353,7 +353,6 @@ WOLFSSL_API int wc_RsaExportKey(RsaKey* key,
                                 byte* q, word32* qSz);
 
 WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey*, byte* output, word32 inLen);
-WOLFSSL_API int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen, int with_header);
 
 #ifdef WOLFSSL_KEY_GEN
     WOLFSSL_API int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng);

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -353,6 +353,7 @@ WOLFSSL_API int wc_RsaExportKey(RsaKey* key,
                                 byte* q, word32* qSz);
 
 WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey*, byte* output, word32 inLen);
+WOLFSSL_API int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen, int with_header);
 
 #ifdef WOLFSSL_KEY_GEN
     WOLFSSL_API int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng);


### PR DESCRIPTION
Added function wc_RsaKeyToPublicDer_ex, enabling user to chose the DER header or not. This option was offered by static function SetRsaPublicKey but not accessible to the user