### PR TITLE
Add calling wc_FreeMutex for globalRNGMutex

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -13389,6 +13389,11 @@ int wolfSSL_Cleanup(void)
         ret = WC_CLEANUP_E;
     }
 
+#ifdef HAVE_GLOBAL_RNG
+    if (wc_FreeMutex(&globalRNGMutex) != 0) {
+        ret = BAD_MUTEX_E;
+    }
+#endif
     return ret;
 }
 


### PR DESCRIPTION
This PR addresses an issue reported in ZD12138 that the globalRNGMutext was not released. Since the mutex is a static variable, no leaks have been detected in the pthread environment. In VxWorks, even static mutexes allocate memory internally at initialization, so finalizing the mutex is essential. 