### PR TITLE
ECDSA FP ECC: fix corner case

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5942,7 +5942,18 @@ int ecc_projective_add_point_safe(ecc_point* A, ecc_point* B, ecc_point* R,
         if ((err == MP_OKAY) && mp_iszero(R->z)) {
             /* When all zero then should have done a double */
             if (mp_iszero(R->x) && mp_iszero(R->y)) {
-                err = ecc_projective_dbl_point(B, R, a, modulus, mp);
+                if (mp_iszero(B->z)) {
+                    err = wc_ecc_copy_point(B, R);
+                    if (err == MP_OKAY) {
+                        err = mp_montgomery_calc_normalization(R->z, modulus);
+                    }
+                    if (err == MP_OKAY) {
+                        err = ecc_projective_dbl_point(R, R, a, modulus, mp);
+                    }
+                }
+                else {
+                    err = ecc_projective_dbl_point(B, R, a, modulus, mp);
+                }
             }
             /* When only Z zero then result is infinity */
             else {


### PR DESCRIPTION
When the same table is used for both base point and public point (which
is not a valid thing to do) then a corner case occurs when the table
point can be added to the same point. This has to be a double operation
instead.
The table point isn't able to be doubled as it has a z-ordinate of 0 and
the original point is overwritten with the invalid add result.
Fix this case by:
 - copying the table point into the result,
 - setting z-ordinate to Montgomery form of 1,
 - double the result point in place.