### PR TITLE
Fix for building SP small math only (no DH) with key generation

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -1624,7 +1624,8 @@ void InitSSL_Method(WOLFSSL_METHOD* method, ProtocolVersion pv)
     method->downgrade  = 0;
 }
 
-#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EITHER_SIDE)
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EITHER_SIDE) || \
+    defined(WOLFSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
 int InitSSL_Side(WOLFSSL* ssl, word16 side)
 {
     if (ssl == NULL)

--- a/tests/api.c
+++ b/tests/api.c
@@ -15493,7 +15493,7 @@ static int test_wc_RsaPSS_Verify (void)
 {
     int ret = 0;
 #if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN) && !defined(HAVE_SELFTEST) && \
- !defined(HAVE_FIPS) && defined(WC_RSA_BLINDING)
+ !defined(HAVE_FIPS) && defined(WC_RSA_BLINDING) && defined(WC_RSA_PSS)
     RsaKey              key;
     WC_RNG              rng;
     int                 sz = 256;
@@ -15578,7 +15578,7 @@ static int test_wc_RsaPSS_VerifyCheck (void)
 {
     int ret = 0;
 #if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN) && !defined(HAVE_SELFTEST) && \
- !defined(HAVE_FIPS) && defined(WC_RSA_BLINDING)
+ !defined(HAVE_FIPS) && defined(WC_RSA_BLINDING) && defined(WC_RSA_PSS)
     RsaKey              key;
     WC_RNG              rng;
     int                 sz = 256; /* 2048/8 */
@@ -15673,7 +15673,7 @@ static int test_wc_RsaPSS_VerifyCheckInline (void)
 {
     int ret = 0;
 #if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN) && !defined(HAVE_SELFTEST) && \
- !defined(HAVE_FIPS) && defined(WC_RSA_BLINDING)
+ !defined(HAVE_FIPS) && defined(WC_RSA_BLINDING) && defined(WC_RSA_PSS)
     RsaKey              key;
     WC_RNG              rng;
     int                 sz = 256;

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -450,8 +450,8 @@ int wc_ed25519_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
    msgLen      length of msg array
    res         will be 1 on successful verify and 0 on unsuccessful
    key         Ed25519 public key
-   context     extra sigining data
-   contextLen  length of extra sigining data
+   context     extra signing data
+   contextLen  length of extra signing data
    return  0 and res of 1 on success
 */
 int wc_ed25519ctx_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
@@ -469,8 +469,8 @@ int wc_ed25519ctx_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
    hashLen     length of hash array
    res         will be 1 on successful verify and 0 on unsuccessful
    key         Ed25519 public key
-   context     extra sigining data
-   contextLen  length of extra sigining data
+   context     extra signing data
+   contextLen  length of extra signing data
    return  0 and res of 1 on success
 */
 int wc_ed25519ph_verify_hash(const byte* sig, word32 sigLen, const byte* hash,
@@ -488,8 +488,8 @@ int wc_ed25519ph_verify_hash(const byte* sig, word32 sigLen, const byte* hash,
    msgLen      length of msg array
    res         will be 1 on successful verify and 0 on unsuccessful
    key         Ed25519 public key
-   context     extra sigining data
-   contextLen  length of extra sigining data
+   context     extra signing data
+   contextLen  length of extra signing data
    return  0 and res of 1 on success
 */
 int wc_ed25519ph_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
@@ -811,4 +811,3 @@ int wc_ed25519_sig_size(ed25519_key* key)
 }
 
 #endif /* HAVE_ED25519 */
-

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -68,8 +68,8 @@ This library provides single precision (SP) integer math functions.
  * WOLFSSL_SP_PPC               Enable PPC assembly speedups
  * WOLFSSL_SP_MIPS64            Enable MIPS64 assembly speedups
  * WOLFSSL_SP_MIPS              Enable MIPS assembly speedups
- * WOLFSSL_SP_RISCV64           Enable RISCV64 assmebly speedups
- * WOLFSSL_SP_RISCV32           Enable RISCV32 assmebly speedups
+ * WOLFSSL_SP_RISCV64           Enable RISCV64 assembly speedups
+ * WOLFSSL_SP_RISCV32           Enable RISCV32 assembly speedups
  * WOLFSSL_SP_S390X             Enable S390X assembly speedups
  * SP_WORD_SIZE                 Force 32 or 64 bit mode
  * WOLFSSL_SP_NONBLOCK          Enables "non blocking" mode for SP math, which
@@ -8621,8 +8621,8 @@ int sp_exptmod_ex(sp_int* b, sp_int* e, int digits, sp_int* m, sp_int* r)
 
     if ((!done) && (err == MP_OKAY)) {
         /* Use code optimized for specific sizes if possible */
-#if defined(WOLFSSL_SP_MATH_ALL) && (defined(WOLFSSL_HAVE_SP_RSA) || \
-        defined(WOLFSSL_HAVE_SP_DH))
+#if (defined(WOLFSSL_SP_MATH) || defined(WOLFSSL_SP_MATH_ALL)) && \
+    (defined(WOLFSSL_HAVE_SP_RSA) || defined(WOLFSSL_HAVE_SP_DH))
     #ifndef WOLFSSL_SP_NO_2048
         if ((mBits == 1024) && sp_isodd(m) && (bBits <= 1024) &&
             (eBits <= 1024)) {

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -2729,7 +2729,8 @@ int sp_count_bits(const sp_int* a)
 
 #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY) && \
     !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH) || \
-    (defined(HAVE_ECC) && defined(FP_ECC))
+    (defined(HAVE_ECC) && defined(FP_ECC)) || \
+    (!defined(NO_RSA) && defined(WOLFSSL_KEY_GEN))
 
 /* Number of entries in array of number of least significant zero bits. */
 #define SP_LNZ_CNT      16
@@ -3460,7 +3461,8 @@ static void _sp_div_10(sp_int* a, sp_int* r, sp_int_digit* rem)
 
 #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
     defined(WOLFSSL_HAVE_SP_DH) || \
-    (defined(HAVE_ECC) && (defined(FP_ECC) || defined(HAVE_COMP_KEY)))
+    (defined(HAVE_ECC) && (defined(FP_ECC) || defined(HAVE_COMP_KEY))) || \
+    (!defined(NO_RSA) && defined(WOLFSSL_KEY_GEN))
 /* Divide by small number: r = a / d and rem = a % d
  *
  * @param  [in]   a    SP integer to be divided.
@@ -3578,7 +3580,8 @@ int sp_div_d(sp_int* a, sp_int_digit d, sp_int* r, sp_int_digit* rem)
 
 #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
     defined(WOLFSSL_HAVE_SP_DH) || \
-    (defined(HAVE_ECC) && (defined(FP_ECC) || defined(HAVE_COMP_KEY)))
+    (defined(HAVE_ECC) && (defined(FP_ECC) || defined(HAVE_COMP_KEY))) || \
+    (!defined(NO_RSA) && defined(WOLFSSL_KEY_GEN))
 /* Calculate a modulo the digit d into r: r = a mod d
  *
  * @param  [in]   a  SP integer to reduce.
@@ -7706,7 +7709,8 @@ int sp_mul(sp_int* a, sp_int* b, sp_int* r)
 /* END SP_MUL implementations. */
 
 #if defined(WOLFSSL_SP_MATH_ALL) || defined(WOLFSSL_HAVE_SP_DH) || \
-    defined(WOLFCRYPT_HAVE_ECCSI)
+    defined(WOLFCRYPT_HAVE_ECCSI) || \
+    (!defined(NO_RSA) && defined(WOLFSSL_KEY_GEN))
 /* Multiply a by b mod m and store in r: r = (a * b) mod m
  *
  * @param  [in]   a  SP integer to multiply.
@@ -8554,7 +8558,8 @@ static int _sp_exptmod_base_2(sp_int* e, int digits, sp_int* m, sp_int* r)
 #endif /* WOLFSSL_SP_MATH_ALL && !WOLFSSL_RSA_VERIFY_ONLY */
 
 #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
-    defined(WOLFSSL_HAVE_SP_DH)
+    defined(WOLFSSL_HAVE_SP_DH) || \
+    (!defined(NO_RSA) && defined(WOLFSSL_KEY_GEN))
 /* Exponentiates b to the power of e modulo m into r: r = b ^ e mod m
  *
  * @param  [in]   b     SP integer that is the base.
@@ -8700,7 +8705,8 @@ int sp_exptmod_ex(sp_int* b, sp_int* e, int digits, sp_int* m, sp_int* r)
 #endif /* WOLFSSL_SP_MATH_ALL || WOLFSSL_HAVE_SP_DH */
 
 #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
-    defined(WOLFSSL_HAVE_SP_DH)
+    defined(WOLFSSL_HAVE_SP_DH) || \
+    (!defined(NO_RSA) && defined(WOLFSSL_KEY_GEN))
 /* Exponentiates b to the power of e modulo m into r: r = b ^ e mod m
  *
  * @param  [in]   b  SP integer that is the base.
@@ -12891,7 +12897,8 @@ int sp_rand_prime(sp_int* r, int len, WC_RNG* rng, void* heap)
 #endif /* WOLFSSL_KEY_GEN && (!NO_DH || !NO_DSA) && !WC_NO_RNG */
 
 #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY) && \
-    !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
+    !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH) || \
+    (!defined(NO_RSA) && defined(WOLFSSL_KEY_GEN))
 /* Miller-Rabin test of "a" to the base of "b" as described in
  * HAC pp. 139 Algorithm 4.24
  *

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -383,7 +383,8 @@ typedef struct sp_ecc_ctx {
             #define SP_INT_DIGITS        (((3072 + SP_WORD_SIZE) / SP_WORD_SIZE) + 1)
         #endif
     #else
-        #if defined(WOLFSSL_HAVE_SP_DH)
+        #if defined(WOLFSSL_HAVE_SP_DH) || \
+                (defined(WOLFSSL_HAVE_SP_RSA) && defined(WOLFSSL_KEY_GEN))
             #define SP_INT_DIGITS        (((4096 + SP_WORD_SIZE) / SP_WORD_SIZE) + 1)
         #else
             #define SP_INT_DIGITS        (((2048 + SP_WORD_SIZE) / SP_WORD_SIZE) + 1)


### PR DESCRIPTION
* Fix for `WOLFSSL_EXTRA`.
* Fix for RSA without PSS.
* Fix ed25519 spelling error.
ZD 12401