### PR TITLE
psoc6_Crypto port: fixes to sha256/sha512 objects

### DIFF
--- a/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
+++ b/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
@@ -23,13 +23,6 @@
 #define _PSOC6_CRYPTO_PORT_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
-#ifdef USE_FAST_MATH
-    #include <wolfssl/wolfcrypt/tfm.h>
-#elif defined WOLFSSL_SP_MATH
-    #include <wolfssl/wolfcrypt/sp_int.h>
-#else
-    #include <wolfssl/wolfcrypt/integer.h>
-#endif
 #include "cy_crypto_core_sha.h"
 #include "cy_device_headers.h"
 #include "psoc6_02_config.h"
@@ -37,24 +30,10 @@
 #include "cy_crypto_core.h"
 
 #ifdef WOLFSSL_SHA512
-typedef struct wc_Sha512 {
-    cy_stc_crypto_sha_state_t hash_state;
-    cy_en_crypto_sha_mode_t sha_mode;
-    cy_stc_crypto_v2_sha512_buffers_t sha_buffers;
-} wc_Sha512;
-
-#define WC_SHA512_TYPE_DEFINED
 #include <wolfssl/wolfcrypt/sha512.h>
 #endif
 
 #ifndef NO_SHA256
-
-typedef struct wc_Sha256 {
-    cy_stc_crypto_sha_state_t hash_state;
-    cy_en_crypto_sha_mode_t sha_mode;
-    cy_stc_crypto_v2_sha256_buffers_t sha_buffers;
-} wc_Sha256;
-
 #include <wolfssl/wolfcrypt/sha.h>
 #include <wolfssl/wolfcrypt/sha256.h>
 #endif /* !def NO_SHA256 */

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -108,8 +108,6 @@ enum {
 #elif defined(WOLFSSL_RENESAS_TSIP_CRYPT) && \
    !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
     #include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
-#elif defined(WOLFSSL_PSOC6_CRYPTO)
-    #include "wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h"
 #else
 
 /* Sha digest */

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -94,6 +94,9 @@
 #if defined(WOLFSSL_SILABS_SE_ACCEL)
     #include <wolfssl/wolfcrypt/port/silabs/silabs_hash.h>
 #endif
+#if defined(WOLFSSL_PSOC6_CRYPTO)
+   #include <wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h>
+#endif
 
 #if defined(_MSC_VER)
     #define SHA256_NOINLINE __declspec(noinline)
@@ -132,8 +135,6 @@ enum {
 #elif defined(WOLFSSL_RENESAS_TSIP_CRYPT) && \
    !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
     #include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
-#elif defined(WOLFSSL_PSOC6_CRYPTO)
-    #include "wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h"
 #else
 
 /* wc_Sha256 digest */
@@ -147,6 +148,10 @@ struct wc_Sha256 {
 #elif defined(WOLFSSL_IMXRT_DCP)
     dcp_handle_t handle;
     dcp_hash_ctx_t ctx;
+#elif defined(WOLFSSL_PSOC6_CRYPTO)
+    cy_stc_crypto_sha_state_t hash_state;
+    cy_en_crypto_sha_mode_t sha_mode;
+    cy_stc_crypto_v2_sha256_buffers_t sha_buffers;
 #else
     /* alignment on digest and buffer speeds up ARMv8 crypto operations */
     ALIGN16 word32  digest[WC_SHA256_DIGEST_SIZE / sizeof(word32)];

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -79,6 +79,9 @@
 #if defined(WOLFSSL_SILABS_SE_ACCEL)
     #include <wolfssl/wolfcrypt/port/silabs/silabs_hash.h>
 #endif
+#if defined(WOLFSSL_PSOC6_CRYPTO)
+   #include <wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h>
+#endif
 
 #if defined(_MSC_VER)
     #define SHA512_NOINLINE __declspec(noinline)
@@ -116,11 +119,14 @@ enum {
 
 #if defined(WOLFSSL_IMX6_CAAM) && !defined(WOLFSSL_QNX_CAAM)
     #include "wolfssl/wolfcrypt/port/caam/wolfcaam_sha.h"
-#elif defined (WOLFSSL_PSOC6_CRYPTO)
-    #include "wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h"
 #else
 /* wc_Sha512 digest */
 struct wc_Sha512 {
+#ifdef WOLFSSL_PSOC6_CRYPTO
+    cy_stc_crypto_sha_state_t hash_state;
+    cy_en_crypto_sha_mode_t sha_mode;
+    cy_stc_crypto_v2_sha512_buffers_t sha_buffers;
+#else
     word64  digest[WC_SHA512_DIGEST_SIZE / sizeof(word64)];
     word64  buffer[WC_SHA512_BLOCK_SIZE  / sizeof(word64)];
     word32  buffLen;   /* in bytes          */
@@ -147,6 +153,7 @@ struct wc_Sha512 {
 #if defined(WOLFSSL_HASH_FLAGS) || defined(WOLF_CRYPTO_CB)
     word32 flags; /* enum wc_HashFlags in hash.h */
 #endif
+#endif /* WOLFSSL_PSOC6_CRYPTO */
 };
 
 #ifndef WC_SHA512_TYPE_DEFINED


### PR DESCRIPTION
Similar refactoring to #4025 on DCP.
ZD12218 reports circular dependencies, due to the (obsolete) wc_Sha256 / wc_Sha512 type declarations in the port header.

Refactored to keep types in wolfcrypt headers. This should prevent circular dependencies in inclusions.

