### PR TITLE
add dynamic setup of entropy delay on init

### DIFF
--- a/wolfcrypt/src/port/caam/caam_driver.c
+++ b/wolfcrypt/src/port/caam/caam_driver.c
@@ -437,7 +437,7 @@ static void print_jdkek()
 
 /* instantiate RNG and create JDKEK, TDKEK, and TDSK key */
 #define WC_RNG_START_SIZE 6
-static unsigned int wc_rng_start[] = {
+static unsigned int wc_rng_start[WC_RNG_START_SIZE] = {
     CAAM_HEAD | 0x00000006,
     CAAM_OP | CAAM_CLASS1 | CAAM_RNG | 0x00000004, /* Instantiate RNG handle 0
                                                       with TRNG */
@@ -460,7 +460,7 @@ int caamInitRng(struct CAAM_DEVICE* dev)
     /* set up the job description for RNG initialization */
     memset(&desc, 0, sizeof(DESCSTRUCT));
     desc.desc[desc.idx++] = CAAM_HEAD; /* later will put size to header*/
-    for (i = 1; i < WC_RNG_START_SIZE; i = i + 1) {
+    for (i = 1; i < WC_RNG_START_SIZE; i++) {
         desc.desc[desc.idx++] = wc_rng_start[i];
     }
     desc.caam = dev;

--- a/wolfcrypt/src/port/caam/caam_driver.c
+++ b/wolfcrypt/src/port/caam/caam_driver.c
@@ -438,13 +438,13 @@ static void print_jdkek()
 /* instantiate RNG and create JDKEK, TDKEK, and TDSK key */
 static unsigned int wc_rng_start[] = {
     CAAM_HEAD | 0x00000006,
-    CAAM_OP | CAAM_CLASS1 | CAAM_RNG | 0x00000004, /* Instantiate RNG handle 0 with TRNG */
+    CAAM_OP | CAAM_CLASS1 | CAAM_RNG | 0x00000004, /* Instantiate RNG handle 0
+                                                      with TRNG */
     CAAM_JUMP | 0x02000001,  /* wait for Class1 RNG and jump to next cmd */
     CAAM_LOAD | 0x00880004,  /* Load to clear written register */
     0x00000001, /* reset done interrupt */
     CAAM_OP | CAAM_CLASS1 | CAAM_RNG | 0x00001000   /* Generate secure keys */
 };
-
 
 
 /* Initialize CAAM RNG
@@ -453,79 +453,77 @@ int caamInitRng(struct CAAM_DEVICE* dev);
 int caamInitRng(struct CAAM_DEVICE* dev)
 {
     DESCSTRUCT desc;
-    unsigned int reg, status;
-    int ret = 0;
+    unsigned int reg, entropy_delay;
+    int ret = 0, i;
 
+    /* set up the job description for RNG initialization */
     memset(&desc, 0, sizeof(DESCSTRUCT));
-
-    /* Set up use of the TRNG for seeding wolfSSL HASH-DRBG */
-    /* check out the status and see if already setup */
-    CAAM_WRITE(CAAM_RTMCTL, CAAM_PRGM);
-    CAAM_WRITE(CAAM_RTMCTL, CAAM_READ(CAAM_RTMCTL) | 0x40); /* reset */
-
-    /* Set up reading from TRNG */
-    CAAM_WRITE(CAAM_RTMCTL, CAAM_READ(CAAM_RTMCTL) | CAAM_TRNG);
-
-    /* Set up delay for TRNG @TODO Optimizations?
-     * Shift left with RTSDCTL because 0-15 is for sample number
-     * Also setting the max and min frequencies */
-    CAAM_WRITE(CAAM_RTSDCTL, (CAAM_ENT_DLY << 16) | 0x09C4);
-    CAAM_WRITE(CAAM_RTFRQMIN, CAAM_ENT_DLY >> 1); /* 1/2      */
-    CAAM_WRITE(CAAM_RTFRQMAX, CAAM_ENT_DLY << 3); /* up to 8x */
-
-    /* Set back to run mode and clear RTMCL error bit */
-    reg = CAAM_READ(CAAM_RTMCTL) ^ CAAM_PRGM;
-
-    CAAM_WRITE(CAAM_RTMCTL, reg);
-    reg = CAAM_READ(CAAM_RTMCTL);
-    reg |= CAAM_CTLERR;
-    CAAM_WRITE(CAAM_RTMCTL, reg);
-
-    /* check out the status and see if already setup */
-    reg = CAAM_READ(CAAM_RDSTA);
-    if (((reg >> 16) & 0xF) > 0) {
-        WOLFSSL_MSG("RNG is in error state");
-        caamReset();
+    desc.desc[desc.idx++] = CAAM_HEAD; /* later will put size to header*/
+    for (i = 1; i < 6; i = i + 1) {
+        desc.desc[desc.idx++] = wc_rng_start[i];
     }
+    desc.caam = dev;
 
-    if (reg & (1U << 30)) {
-        WOLFSSL_MSG("JKDKEK rng was setup using a non determinstic key");
-        return 0;
-    }
+    /* Attempt to start the RNG, first trying the fastest entropy delay value
+     * and increasing it after each failed attempt until either a success is hit
+     * or the max delay value is.
+     */
+    for (entropy_delay = CAAM_ENT_DLY; entropy_delay <= CAAM_ENT_DLY_MAX;
+            entropy_delay = entropy_delay + CAAM_ENT_DLY_INCREMENT) {
 
-    if (CAAM_READ(0x1014) > 0) {
-        int i;
-    #ifdef CAAM_DEBUG_MODE
-        for (i = 0; i < 6; i = i + 1) {
-            desc.desc[desc.idx++] = wc_rng_start[i];
+        /* Set up use of the TRNG for seeding wolfSSL HASH-DRBG */
+        /* check out the status and see if already setup */
+        CAAM_WRITE(CAAM_RTMCTL, CAAM_PRGM);
+        CAAM_WRITE(CAAM_RTMCTL, CAAM_READ(CAAM_RTMCTL) | 0x40); /* reset */
+
+        /* Set up reading from TRNG */
+        CAAM_WRITE(CAAM_RTMCTL, CAAM_READ(CAAM_RTMCTL) | CAAM_TRNG);
+
+        /* Set up delay for TRNG
+         * Shift left with RTSDCTL because 0-15 is for sample number
+         * Also setting the max and min frequencies */
+        CAAM_WRITE(CAAM_RTSDCTL, (entropy_delay << 16) | CAAM_ENT_SAMPLE);
+        CAAM_WRITE(CAAM_RTFRQMIN, entropy_delay >> CAAM_ENT_MINSHIFT);
+        CAAM_WRITE(CAAM_RTFRQMAX, entropy_delay << CAAM_ENT_MAXSHIFT);
+
+    #ifdef WOLFSSL_CAAM_PRINT
+        printf("Attempt with entropy delay set to %d\n", entropy_delay);
+        printf("Min delay of %d and max of %d\n",
+                entropy_delay >> CAAM_ENT_MINSHIFT,
+                entropy_delay << CAAM_ENT_MAXSHIFT);
+    #endif
+
+        /* Set back to run mode and clear RTMCL error bit */
+        reg = CAAM_READ(CAAM_RTMCTL) ^ CAAM_PRGM;
+        CAAM_WRITE(CAAM_RTMCTL, reg);
+        reg = CAAM_READ(CAAM_RTMCTL);
+        reg |= CAAM_CTLERR;
+        CAAM_WRITE(CAAM_RTMCTL, reg);
+
+        /* check out the status and see if already setup */
+        reg = CAAM_READ(CAAM_RDSTA);
+        if (((reg >> 16) & 0xF) > 0) {
+            WOLFSSL_MSG("RNG is in error state, resetting");
+            caamReset();
         }
 
-        desc.caam = dev;
-        ret = caamDoJob(&desc);
-    #else
-       unsigned int *pt = (unsigned int*)caam.ring.VirtualDesc;
-       for (i = 0; i < 6; i = i + 1) {
-          pt[i] = wc_rng_start[i];
-       }
-       pt    = (unsigned int*)caam.ring.VirtualIn;
-       pt[0] = (unsigned int)caam.ring.Desc;
+        if (reg & (1U << 30)) {
+            WOLFSSL_MSG("JKDKEK rng was setup using a non determinstic key");
+            return 0;
+        }
 
-        /* start process */
-    #if defined(WOLFSSL_CAAM_DEBUG) || defined(WOLFSSL_CAAM_PRINT)
-        printf("incrementing job count\n");
-        fflush(stdout);
-    #endif
-        CAAM_WRITE(CAAM_IRJAR0, 0x00000001);
-    #endif
-    }
-    else {
-        return CAAM_WAITING;
-    }
+        do {
+            ret = caamDoJob(&desc);
+        } while (ret == CAAM_WAITING);
 
-    do {
-        ret = caamGetJob(dev, &status);
-        CAAM_CPU_CHILL();
-    } while (ret == CAAM_WAITING);
+        /* if this entropy delay frequency succeeded then break out, otherwise
+         * try again with increasing the delay value */
+        if (ret == Success) {
+            WOLFSSL_MSG("Init RNG success");
+            break;
+        }
+        WOLFSSL_MSG("Increasing entropy delay");
+    }
 
     if (ret == Success)
         return 0;
@@ -1457,16 +1455,31 @@ int InitCAAM(void)
             CAAM_JOBRING_SIZE * sizeof(unsigned int),
             PROT_READ | PROT_WRITE | PROT_NOCACHE,
             MAP_SHARED | MAP_PHYS, caam.ring.JobIn);
+    if (caam.ring.VirtualIn == MAP_FAILED) {
+        WOLFSSL_MSG("Error mapping virtual in");
+        INTERRUPT_Panic();
+        return -1;
+    }
     memset(caam.ring.VirtualIn, 0, CAAM_JOBRING_SIZE * sizeof(unsigned int));
     caam.ring.VirtualOut  = mmap_device_memory(NULL,
             2 * CAAM_JOBRING_SIZE * sizeof(unsigned int),
             PROT_READ | PROT_WRITE | PROT_NOCACHE,
             MAP_SHARED | MAP_PHYS, caam.ring.JobOut);
+    if (caam.ring.VirtualOut == MAP_FAILED) {
+        WOLFSSL_MSG("Error mapping virtual out");
+        INTERRUPT_Panic();
+        return -1;
+    }
     memset(caam.ring.VirtualOut, 0, 2 * CAAM_JOBRING_SIZE * sizeof(unsigned int));
     caam.ring.VirtualDesc = mmap_device_memory(NULL,
             CAAM_DESC_MAX * CAAM_JOBRING_SIZE,
             PROT_READ | PROT_WRITE | PROT_NOCACHE,
             MAP_SHARED | MAP_PHYS, caam.ring.Desc);
+    if (caam.ring.VirtualDesc == MAP_FAILED) {
+        WOLFSSL_MSG("Error mapping virtual desc");
+        INTERRUPT_Panic();
+        return -1;
+    }
     memset(caam.ring.VirtualDesc, 0, CAAM_DESC_MAX * CAAM_JOBRING_SIZE);
 
     #if defined(WOLFSSL_CAAM_DEBUG) || defined(WOLFSSL_CAAM_PRINT)
@@ -1497,6 +1510,9 @@ int InitCAAM(void)
     printf("RTMCTL = 0x%08X\n", CAAM_READ(0x0600));
     #endif
     WOLFSSL_MSG("Successfully initilazed CAAM driver");
+    #if defined(WOLFSSL_CAAM_DEBUG) || defined(WOLFSSL_CAAM_PRINT)
+    fflush(stdout);
+    #endif
     return 0;
 }
 

--- a/wolfcrypt/src/port/caam/caam_qnx.c
+++ b/wolfcrypt/src/port/caam/caam_qnx.c
@@ -1255,8 +1255,8 @@ int main(int argc, char *argv[])
     if (dpp == NULL) {
         exit (1);
     }
-    memset (&rattr, 0, sizeof (rattr));
-    iofunc_func_init (_RESMGR_CONNECT_NFUNCS, &connect_funcs,
+    memset(&rattr, 0, sizeof(rattr));
+    iofunc_func_init(_RESMGR_CONNECT_NFUNCS, &connect_funcs,
             _RESMGR_IO_NFUNCS, &io_funcs);
 
     connect_funcs.open = io_open;
@@ -1266,7 +1266,7 @@ int main(int argc, char *argv[])
     io_funcs.devctl    = io_devctl;
 
     iofunc_attr_init (&ioattr, S_IFCHR | 0666, NULL, NULL);
-    name = resmgr_attach (dpp, &rattr, "/dev/wolfCrypt",
+    name = resmgr_attach(dpp, &rattr, "/dev/wolfCrypt",
             _FTYPE_ANY, 0, &connect_funcs, &io_funcs, &ioattr);
     if (name == -1) {
         exit (1);
@@ -1279,7 +1279,7 @@ int main(int argc, char *argv[])
             CleanupCAAM();
             exit (1);
         }
-        dispatch_handler (ctp);
+        dispatch_handler(ctp);
     }
 
     pthread_mutex_destroy(&sm_mutex);

--- a/wolfcrypt/src/port/caam/caam_qnx.c
+++ b/wolfcrypt/src/port/caam/caam_qnx.c
@@ -1190,7 +1190,7 @@ static int getSupported(char* in)
 #endif
 
 char cannedResponse[] = {
-        "wolfCrypt QNX CAAM driver\n"
+        "wolfCrypt QNX CAAM driver version 4.7.1 (9)\n"
         "Supports:\n"
         "\tAES-CMAC\n"
         "\tECC (sign, verify, ecdh, keygen)\n"

--- a/wolfssl/wolfcrypt/port/caam/caam_driver.h
+++ b/wolfssl/wolfcrypt/port/caam/caam_driver.h
@@ -182,7 +182,8 @@
 
 /* RNG Masks/Values */
 #ifndef CAAM_ENT_DLY
-    /*less than half the default value to try and increase entropy collection */
+    /* Less than half the default value to try and increase entropy collection.
+     * Value is system clock cycles. */
     #define CAAM_ENT_DLY   1200
 #endif
 #ifndef CAAM_ENT_DLY_INCREMENT
@@ -206,6 +207,7 @@
 
 #define CAAM_PRGM      0x00010000 /* Set RTMCTL to program state */
 #define CAAM_TRNG      0x00000020 /* Set TRNG access */
+#define CAAM_RTMCTL_RESET 0x40    /* TRNG reset to defaults */
 #define CAAM_CTLERR    0x00001000
 #define CAAM_ENTVAL    0x00000400 /* checking RTMCTL for entropy ready */
 

--- a/wolfssl/wolfcrypt/port/caam/caam_driver.h
+++ b/wolfssl/wolfcrypt/port/caam/caam_driver.h
@@ -182,8 +182,28 @@
 
 /* RNG Masks/Values */
 #ifndef CAAM_ENT_DLY
-    #define CAAM_ENT_DLY   1200 /* @TODO lower value may gain performance */
+    /*less than half the default value to try and increase entropy collection */
+    #define CAAM_ENT_DLY   1200
 #endif
+#ifndef CAAM_ENT_DLY_INCREMENT
+    #define CAAM_ENT_DLY_INCREMENT 500
+#endif
+#ifndef CAAM_ENT_SAMPLE
+    /* default sample value from reference manual */
+    #define CAAM_ENT_SAMPLE 0x09C4
+#endif
+#ifndef CAAM_ENT_DLY_MAX
+    #define CAAM_ENT_DLY_MAX 12000
+#endif
+#ifndef CAAM_ENT_MINSHIFT
+    /* default to the minimum entropy delay of 1/4 */
+    #define CAAM_ENT_MINSHIFT 2
+#endif
+#ifndef CAAM_ENT_MAXSHIFT
+    /* default to the maximum entropy delay of 16 times */
+    #define CAAM_ENT_MAXSHIFT 4
+#endif
+
 #define CAAM_PRGM      0x00010000 /* Set RTMCTL to program state */
 #define CAAM_TRNG      0x00000020 /* Set TRNG access */
 #define CAAM_CTLERR    0x00001000

--- a/wolfssl/wolfcrypt/port/caam/caam_qnx.h
+++ b/wolfssl/wolfcrypt/port/caam/caam_qnx.h
@@ -25,7 +25,12 @@
 #ifndef CAAM_QNX_H
 #define CAAM_QNX_H
 
+#ifdef WOLFSSL_CAAM_PRINT
+#include <stdio.h>
+#define WOLFSSL_MSG(in) printf("%s\n", (in))
+#else
 #define WOLFSSL_MSG(in)
+#endif
 
 #include <sys/mman.h>
 #include <hw/inout.h>


### PR DESCRIPTION
On some devices the optimized 1200 system clock cycles for entropy delay was too fast during initialization. This adds dynamically setting the entropy delay by starting at 1200 and increasing by 500 for each failed init until the max value is reached. The change also increases the window of accepted entropy delay from 1/2 to 1/4 of the current attempt as a min value and 16X the current attempt instead of the previous 8X.