### PR TITLE
Catch allocation failure in DecodeResponseData

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -17480,7 +17480,7 @@ static int DecodeResponseData(byte* source,
 
             single->next->status = (CertStatus*)XMALLOC(sizeof(CertStatus),
                 resp->heap, DYNAMIC_TYPE_OCSP_STATUS);
-            if ( single->next->status == NULL ) {
+            if (single->next->status == NULL) {
                 XFREE(single->next, resp->heap, DYNAMIC_TYPE_OCSP_ENTRY);
                 single->next = NULL;
                 return MEMORY_E;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -17472,12 +17472,20 @@ static int DecodeResponseData(byte* source,
             if (single->next == NULL) {
                 return MEMORY_E;
             }
-            single = single->next;
-            XMEMSET(single, 0, sizeof(OcspEntry));
-            single->status = (CertStatus*)XMALLOC(sizeof(CertStatus),
+            XMEMSET(single->next, 0, sizeof(OcspEntry));
+
+            single->next->status = (CertStatus*)XMALLOC(sizeof(CertStatus),
                 resp->heap, DYNAMIC_TYPE_OCSP_STATUS);
-            XMEMSET(single->status, 0, sizeof(CertStatus));
-            single->isDynamic = 1;
+            if ( single->next->status == NULL ) {
+                XFREE(single->next, resp->heap, DYNAMIC_TYPE_OCSP_ENTRY);
+                single->next = NULL;
+                return MEMORY_E;
+            }
+            XMEMSET(single->next->status, 0, sizeof(CertStatus));
+
+            single->next->isDynamic = 1;
+
+            single = single->next;
         }
     }
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -16166,6 +16166,10 @@ static int ASNToHexString(const byte* input, word32* inOutIdx, char** out,
     }
 
     str = (char*)XMALLOC(len * 2 + 1, heap, heapType);
+    if (str == NULL) {
+        return MEMORY_E;
+    }
+
     for (i=0; i<len; i++)
         ByteToHex(input[*inOutIdx + i], str + i*2);
     str[len*2] = '\0';


### PR DESCRIPTION
The order of the operations was changed slightly such that member variables (`status` and `isDynamic`) are initialized first, and, if no error occurred, the chain is advanced (`single = single->next`). This makes it easier to deal with the potential failure to allocate a `CertStatus`.