### PR TITLE
Check return value in BLAKE2 key init functions

### DIFF
--- a/wolfcrypt/src/blake2b.c
+++ b/wolfcrypt/src/blake2b.c
@@ -152,6 +152,7 @@ int blake2b_init( blake2b_state *S, const byte outlen )
 int blake2b_init_key( blake2b_state *S, const byte outlen, const void *key,
                       const byte keylen )
 {
+  int ret = 0;
   blake2b_param P[1];
 
   if ( ( !outlen ) || ( outlen > BLAKE2B_OUTBYTES ) ) return BAD_FUNC_ARG;
@@ -178,10 +179,8 @@ int blake2b_init_key( blake2b_state *S, const byte outlen, const void *key,
   P->depth         = 1;
 #endif
 
-  {
-    int ret = blake2b_init_param( S, P );
-    if ( ret < 0 ) return ret;
-  }
+  ret = blake2b_init_param( S, P );
+  if ( ret < 0 ) return ret;
 
   {
 #ifdef WOLFSSL_SMALL_STACK
@@ -196,7 +195,7 @@ int blake2b_init_key( blake2b_state *S, const byte outlen, const void *key,
 
     XMEMSET( block, 0, BLAKE2B_BLOCKBYTES );
     XMEMCPY( block, key, keylen );
-    blake2b_update( S, block, BLAKE2B_BLOCKBYTES );
+    ret = blake2b_update( S, block, BLAKE2B_BLOCKBYTES );
     secure_zero_memory( block, BLAKE2B_BLOCKBYTES ); /* Burn the key from */
                                                      /* memory */
 
@@ -204,7 +203,7 @@ int blake2b_init_key( blake2b_state *S, const byte outlen, const void *key,
     XFREE(block, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
   }
-  return 0;
+  return ret;
 }
 
 static WC_INLINE int blake2b_compress(

--- a/wolfcrypt/src/blake2s.c
+++ b/wolfcrypt/src/blake2s.c
@@ -148,6 +148,7 @@ int blake2s_init( blake2s_state *S, const byte outlen )
 int blake2s_init_key( blake2s_state *S, const byte outlen, const void *key,
                       const byte keylen )
 {
+  int ret = 0;
   blake2s_param P[1];
 
   if ( ( !outlen ) || ( outlen > BLAKE2S_OUTBYTES ) ) return BAD_FUNC_ARG;
@@ -174,11 +175,9 @@ int blake2s_init_key( blake2s_state *S, const byte outlen, const void *key,
   P->depth         = 1;
 #endif
 
-  {
-      int ret = blake2s_init_param( S, P );
-      if (ret < 0)
-          return ret;
-  }
+  ret = blake2s_init_param( S, P );
+  if (ret < 0)
+      return ret;
 
   {
 #ifdef WOLFSSL_SMALL_STACK
@@ -193,7 +192,7 @@ int blake2s_init_key( blake2s_state *S, const byte outlen, const void *key,
 
     XMEMSET( block, 0, BLAKE2S_BLOCKBYTES );
     XMEMCPY( block, key, keylen );
-    blake2s_update( S, block, BLAKE2S_BLOCKBYTES );
+    ret = blake2s_update( S, block, BLAKE2S_BLOCKBYTES );
     secure_zero_memory( block, BLAKE2S_BLOCKBYTES ); /* Burn the key from */
                                                      /* memory */
 
@@ -201,7 +200,7 @@ int blake2s_init_key( blake2s_state *S, const byte outlen, const void *key,
     XFREE(block, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
   }
-  return 0;
+  return ret;
 }
 
 static WC_INLINE int blake2s_compress(

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -125,6 +125,8 @@ int wc_PBKDF1_ex(byte* key, int keyLen, byte* iv, int ivLen,
             if (err != 0) break;
         }
 
+        if (err != 0) break;
+
         if (keyLeft) {
             store = min(keyLeft, diestLen);
             XMEMCPY(&key[keyLen - keyLeft], digest, store);


### PR DESCRIPTION
If built with smallstack, allocations in `blake2s_update` and `blake2b_update` may fail,
so the error must be propagated.