### PR TITLE
Fix nonblocking ret value from crlIOCb

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -354,7 +354,7 @@ int CheckCertCRL(WOLFSSL_CRL* crl, DecodedCert* cert)
             ret = crl->crlIOCb(crl, (const char*)cert->extCrlInfo,
                                                         cert->extCrlInfoSz);
             if (ret == WOLFSSL_CBIO_ERR_WANT_READ) {
-                ret = WANT_READ;
+                ret = OCSP_WANT_READ;
             }
             else if (ret >= 0) {
                 /* try again */
@@ -372,7 +372,7 @@ int CheckCertCRL(WOLFSSL_CRL* crl, DecodedCert* cert)
     /* Loading <issuer-hash>.rN form CRL file if find at the folder,        */
     /* and try again checking Cert in the CRL list.                         */
     /* When not set the folder or not use hash_dir, do nothing.             */
-    if (foundEntry == 0) {
+    if ((foundEntry == 0) && (ret != OCSP_WANT_READ)) {
         if (crl->cm->x509_store_p != NULL) {
             ret = LoadCertByIssuer(crl->cm->x509_store_p, 
                           (WOLFSSL_X509_NAME*)cert->issuerName, X509_LU_CRL);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8090,9 +8090,9 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 #endif /* NO_WOLFSSL_SERVER */
     }
 
-#ifdef WOLFSSL_ASYNC_CRYPT
+#if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
     /* if async, offset index so this msg will be processed again */
-    if (ret == WC_PENDING_E && *inOutIdx > 0) {
+    if ((ret == WC_PENDING_E || ret == OCSP_WANT_READ) && *inOutIdx > 0) {
         *inOutIdx -= HANDSHAKE_HEADER_SZ;
     }
 #endif


### PR DESCRIPTION
The nonblocking return code that is checked when `CheckCertCRL` is called is `OCSP_WANT_READ`, but the callback was returning `WANT_READ`, so the error was handled incorrectly. Also adds a check for `OCSP_WANT_READ` in `DoTls13HandShakeMsgType`.

These issues were first reported in ZD12274.