### PR TITLE
[PSOC6_CRYPTO] Do not directly include psoc6 port header to prevent loops

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -33,6 +33,7 @@
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/version.h>
 #include <wolfssl/wolfcrypt/wc_port.h>
+#include <wolfssl/wolfcrypt/ecc.h>
 
 /* Macro to disable benchmark */
 #ifndef NO_CRYPT_BENCHMARK

--- a/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
+++ b/wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h
@@ -29,6 +29,7 @@
 #include "cy_crypto_common.h"
 #include "cy_crypto_core.h"
 
+
 #ifdef WOLFSSL_SHA512
 #include <wolfssl/wolfcrypt/sha512.h>
 #endif

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -65,6 +65,13 @@
 	#include "fsl_dcp.h"
 #endif
 
+#if defined(WOLFSSL_PSOC6_CRYPTO)
+#include "cy_crypto_core_sha.h"
+#include "cy_device_headers.h"
+#include "cy_crypto_common.h"
+#include "cy_crypto_core.h"
+#endif
+
 #ifdef __cplusplus
     extern "C" {
 #endif
@@ -93,9 +100,6 @@
 #endif
 #if defined(WOLFSSL_SILABS_SE_ACCEL)
     #include <wolfssl/wolfcrypt/port/silabs/silabs_hash.h>
-#endif
-#if defined(WOLFSSL_PSOC6_CRYPTO)
-   #include <wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h>
 #endif
 
 #if defined(_MSC_VER)

--- a/wolfssl/wolfcrypt/sha512.h
+++ b/wolfssl/wolfcrypt/sha512.h
@@ -80,7 +80,10 @@
     #include <wolfssl/wolfcrypt/port/silabs/silabs_hash.h>
 #endif
 #if defined(WOLFSSL_PSOC6_CRYPTO)
-   #include <wolfssl/wolfcrypt/port/cypress/psoc6_crypto.h>
+    #include "cy_crypto_core_sha.h"
+    #include "cy_device_headers.h"
+    #include "cy_crypto_common.h"
+    #include "cy_crypto_core.h"
 #endif
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
sha256.h and sha512.h now includes the driver's headers directly instead of the port module header. This avoids conflicts and inclusion loops when compiled with HASHDRBG which includes sha256.h much earlier.

- Fixes a similar problem experienced in NXP DCP driver - see #4025
- should finally fix the issue reported in ZD12218