### PR TITLE
ED25119 and SHAKE-256: fixes

### DIFF
--- a/certs/ed25519/gen-ed25519-certs.sh
+++ b/certs/ed25519/gen-ed25519-certs.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+check_result(){
+    if [ $1 -ne 0 ]; then
+        echo "Failed at \"$2\", Abort"
+        exit 1
+    else
+        echo "Step Succeeded!"
+    fi
+}
+
+openssl pkey -in root-ed25519-priv.pem -noout >/dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "OpenSSL does not support Ed25519"
+    echo "Skipping Ed25519 certificate renewal"
+    exit 0
+fi
+
+############################################################
+###### update the self-signed root-ed25519.pem #############
+############################################################
+echo "Updating root-ed25519.pem"
+echo ""
+#pipe the following arguments to openssl req...
+echo -e "US\\nMontana\\nBozeman\\nwolfSSL_Ed25519\\nRoot-Ed25519\\nwww.wolfssl.com\\ninfo@wolfssl.com\\n.\\n.\\n" | \
+openssl req -new -key root-ed25519-priv.pem -config ../renewcerts/wolfssl.cnf -nodes -out root-ed25519.csr
+check_result $? "Generate request"
+
+openssl x509 -req -in root-ed25519.csr -days 1000 -extfile ../renewcerts/wolfssl.cnf -extensions ca_ecc_cert -signkey root-ed25519-priv.pem -out root-ed25519.pem
+check_result $? "Generate certificate"
+rm root-ed25519.csr
+
+openssl x509 -in root-ed25519.pem -outform DER > root-ed25519.der
+check_result $? "Convert to DER"
+openssl x509 -in root-ed25519.pem -text > tmp.pem
+check_result $? "Add text"
+mv tmp.pem root-ed25519.pem
+echo "End of section"
+echo "---------------------------------------------------------------------"
+
+############################################################
+###### update ca-ed25519.pem signed by root ################
+############################################################
+echo "Updating ca-ed25519.pem"
+echo ""
+#pipe the following arguments to openssl req...
+echo -e "US\\nMontana\\nBozeman\\nwolfSSL_ed25519\\nCA-ed25519\\nwww.wolfssl.com\\ninfo@wolfssl.com\\n\\n\\n\\n" | openssl req -new -key ca-ed25519-priv.pem -config ../renewcerts/wolfssl.cnf -nodes -out ca-ed25519.csr
+check_result $? "Generate request"
+
+openssl x509 -req -in ca-ed25519.csr -days 1000 -extfile ../renewcerts/wolfssl.cnf -extensions ca_ecc_cert -CA root-ed25519.pem -CAkey root-ed25519-priv.pem -set_serial 01 -out ca-ed25519.pem
+check_result $? "Generate certificate"
+rm ca-ed25519.csr
+
+openssl x509 -in ca-ed25519.pem -outform DER > ca-ed25519.der
+check_result $? "Convert to DER"
+openssl x509 -in ca-ed25519.pem -text > tmp.pem
+check_result $? "Add text"
+mv tmp.pem ca-ed25519.pem
+echo "End of section"
+echo "---------------------------------------------------------------------"
+
+############################################################
+###### update server-ed25519.pem signed by ca ##############
+############################################################
+echo "Updating server-ed25519.pem"
+echo ""
+#pipe the following arguments to openssl req...
+echo -e "US\\nMontana\\nBozeman\\nwolfSSL_ed25519\\nServer-ed25519\\nwww.wolfssl.com\\ninfo@wolfssl.com\\n\\n\\n\\n" | openssl req -new -key server-ed25519-priv.pem -config ../renewcerts/wolfssl.cnf -nodes -out server-ed25519.csr
+check_result $? "Generate request"
+
+openssl x509 -req -in server-ed25519.csr -days 1000 -extfile ../renewcerts/wolfssl.cnf -extensions server_ecc -CA ca-ed25519.pem -CAkey ca-ed25519-priv.pem -set_serial 01 -out server-ed25519-cert.pem
+check_result $? "Generate certificate"
+rm server-ed25519.csr
+
+openssl x509 -in server-ed25519-cert.pem -outform DER > server-ed25519.der
+check_result $? "Convert to DER"
+openssl x509 -in server-ed25519-cert.pem -text > tmp.pem
+check_result $? "Add text"
+mv tmp.pem server-ed25519-cert.pem
+cat server-ed25519-cert.pem ca-ed25519.pem > server-ed25519.pem
+check_result $? "Add CA into server cert"
+echo "End of section"
+echo "---------------------------------------------------------------------"
+
+############################################################
+###### update the self-signed client-ed25519.pem ###########
+############################################################
+echo "Updating client-ed25519.pem"
+echo ""
+#pipe the following arguments to openssl req...
+echo -e "US\\nMontana\\nBozeman\\nwolfSSL_ed25519\\nClient-ed25519\\nwww.wolfssl.com\\ninfo@wolfssl.com\\n\\n\\n\\n" | openssl req -new -key client-ed25519-priv.pem -config ../renewcerts/wolfssl.cnf -nodes -out client-ed25519.csr
+check_result $? "Generate request"
+
+openssl x509 -req -in client-ed25519.csr -days 1000 -extfile ../renewcerts/wolfssl.cnf -extensions client_ecc -signkey client-ed25519-priv.pem -out client-ed25519.pem
+check_result $? "Generate certificate"
+rm client-ed25519.csr
+
+openssl x509 -in client-ed25519.pem -outform DER > client-ed25519.der
+check_result $? "Convert to DER"
+openssl x509 -in client-ed25519.pem -text > tmp.pem
+check_result $? "Add text"
+mv tmp.pem client-ed25519.pem
+echo "End of section"
+echo "---------------------------------------------------------------------"
+

--- a/certs/ed25519/gen-ed25519-keys.sh
+++ b/certs/ed25519/gen-ed25519-keys.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+for key in root ca server client
+do
+
+  openssl genpkey -algorithm ED25519 > ${key}-ed25519-priv.pem
+
+  openssl pkey -in ${key}-ed25519-priv.pem -outform DER -out ${key}-ed25519-priv.der
+
+  openssl pkey -in ${key}-ed25519-priv.pem -outform PEM -pubout -out ${key}-ed25519-key.pem
+
+  openssl pkey -in ${key}-ed25519-priv.pem -outform DER -pubout -out ${key}-ed25519-key.der
+
+done
+
+

--- a/certs/ed25519/include.am
+++ b/certs/ed25519/include.am
@@ -28,3 +28,8 @@ EXTRA_DIST += \
          certs/ed25519/server-ed25519-key.pem \
          certs/ed25519/server-ed25519-priv.der \
          certs/ed25519/server-ed25519-priv.pem
+
+EXTRA_DIST += \
+         certs/ed25519/gen-ed25519.sh \
+         certs/ed25519/gen-ed25519-certs.sh \
+         certs/ed25519/gen-ed25519-keys.sh

--- a/certs/renewcerts/wolfssl.cnf
+++ b/certs/renewcerts/wolfssl.cnf
@@ -271,6 +271,14 @@ keyUsage=critical, digitalSignature, keyEncipherment, keyAgreement
 extendedKeyUsage=serverAuth
 nsCertType=server
 
+# server-ecc extensions
+[ client_ecc ]
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always
+basicConstraints=critical, CA:FALSE
+keyUsage=critical, digitalSignature, keyEncipherment, keyAgreement
+extendedKeyUsage=clientAuth
+
 # test parsing URI
 [ uri ]
 subjectKeyIdentifier=hash

--- a/configure.ac
+++ b/configure.ac
@@ -1778,6 +1778,7 @@ fi
 AC_ARG_ENABLE([shake256],
     [AS_HELP_STRING([--enable-shake256],[Enable wolfSSL SHAKE256 support (default: disabled)])],
     [ ENABLED_SHAKE256=$enableval ]
+    [ ENABLED_SHAKE256=no ]
     )
 
 # SHA512

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -467,7 +467,7 @@ IFS=$OIFS #restore separator
 #
 
 # Check for cerificate support in wolfSSL
-wolf_certs=`$WOLFSSL_CLIENT -help 2>&1`
+wolf_certs=`$WOLFSSL_CLIENT -? 2>&1`
 case $wolf_certs in
 *"cert"*)
     ;;
@@ -666,7 +666,7 @@ if [ "$wolf_ed25519" != "" ];
 then
     cert_file="${CERT_DIR}/ed25519/server-ed25519.pem"
     key_file="${CERT_DIR}/ed25519/server-ed25519-priv.pem"
-    ca_file="${CERT_DIR}/ed25519/root-ed25519.pem"
+    ca_file="${CERT_DIR}/ed25519/client-ed25519.pem"
 
     openssl_suite="Ed25519"
     start_openssl_server
@@ -974,8 +974,8 @@ do
             fi
             if [ $ed25519_openssl_pid != $no_pid -a "$version" != "0" -a "$version" != "1" -a "$version" != "2" ]
             then
-                cert="${CERT_DIR}/ed25519/server-ed25519.pem"
-                key="${CERT_DIR}/ed25519/server-ed25519-priv.pem"
+                cert="${CERT_DIR}/ed25519/client-ed25519.pem"
+                key="${CERT_DIR}/ed25519/client-ed25519-priv.pem"
                 caCert="${CERT_DIR}/ed25519/server-ed25519.pem"
 
                 wolf_temp_cases_total=$((wolf_temp_cases_total + 1))
@@ -1112,8 +1112,8 @@ do
             # Ed25519
             if [ $ed25519_openssl_pid != $no_pid ]
             then
-                cert="${CERT_DIR}/ed25519/server-ed25519.pem"
-                key="${CERT_DIR}/ed25519/server-ed25519-priv.pem"
+                cert="${CERT_DIR}/ed25519/client-ed25519.pem"
+                key="${CERT_DIR}/ed25519/client-ed25519-priv.pem"
                 caCert="${CERT_DIR}/ed25519/server-ed25519.pem"
 
                 wolf_temp_cases_total=$((wolf_temp_cases_total + 1))

--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -1168,7 +1168,7 @@ int wc_Sha3_GetFlags(wc_Sha3* sha3, word32* flags)
 }
 #endif
 
-#if defined(WOLFSSL_SHAKE256)
+#ifdef WOLFSSL_SHAKE256
 /* Initialize the state for a Shake256 hash operation.
  *
  * shake  wc_Shake object holding state.


### PR DESCRIPTION
SHAKE-256 is off by default now. Make sure WOLFSSL_SHAKE256 doesn't make
it into options.h.
Fix openssl.test usage of ed25519 certificates.
Add scripts that regenerate certificates