### PR TITLE
Fixes for sniffer and static ephemeral keys

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -2016,11 +2016,11 @@ void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
 #endif
 #ifdef WOLFSSL_STATIC_EPHEMERAL
     #ifndef NO_DH
-    if (ctx->staticKE.dhKey)
+    if (ctx->staticKE.dhKey && ctx->staticKE.weOwnDH)
         FreeDer(&ctx->staticKE.dhKey);
     #endif
     #ifdef HAVE_ECC
-    if (ctx->staticKE.ecKey)
+    if (ctx->staticKE.ecKey && ctx->staticKE.weOwnEC)
         FreeDer(&ctx->staticKE.ecKey);
     #endif
 #endif
@@ -5925,7 +5925,13 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     ssl->options.mutualAuth = ctx->mutualAuth;
 
 #ifdef WOLFSSL_STATIC_EPHEMERAL
-    ssl->staticKE = ctx->staticKE;
+    XMEMCPY(&ssl->staticKE, &ctx->staticKE, sizeof(StaticKeyExchangeInfo_t));
+    #ifdef HAVE_ECC
+    ssl->staticKE.weOwnEC = 0;
+    #endif
+    #ifndef NO_DH
+    ssl->staticKE.weOwnDH = 0;
+    #endif
 #endif
 
 #ifdef WOLFSSL_TLS13
@@ -6669,11 +6675,11 @@ void SSL_ResourceFree(WOLFSSL* ssl)
 #endif
 #ifdef WOLFSSL_STATIC_EPHEMERAL
     #ifndef NO_DH
-    if (ssl->staticKE.dhKey && ssl->staticKE.dhKey != ssl->ctx->staticKE.dhKey)
+    if (ssl->staticKE.dhKey && ssl->staticKE.weOwnDH)
         FreeDer(&ssl->staticKE.dhKey);
     #endif
     #ifdef HAVE_ECC
-    if (ssl->staticKE.ecKey && ssl->staticKE.ecKey != ssl->ctx->staticKE.ecKey)
+    if (ssl->staticKE.ecKey && ssl->staticKE.weOwnEC)
         FreeDer(&ssl->staticKE.ecKey);
     #endif
 #endif

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -10729,7 +10729,7 @@ void FreeDer(DerBuffer** pDer)
         DerBuffer* der = (DerBuffer*)*pDer;
 
         /* ForceZero private keys */
-        if (der->type == PRIVATEKEY_TYPE) {
+        if (der->type == PRIVATEKEY_TYPE && der->buffer != NULL) {
             ForceZero(der->buffer, der->length);
         }
         der->buffer = NULL;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2746,6 +2746,13 @@ typedef struct {
 #ifdef HAVE_ECC
     DerBuffer* ecKey;
 #endif
+    /* bits */
+#ifndef NO_DH
+    byte weOwnDH:1;
+#endif
+#ifdef HAVE_ECC
+    byte weOwnEC:1;
+#endif
 } StaticKeyExchangeInfo_t;
 #endif
 


### PR DESCRIPTION
* Fix to prevent static ephemeral memory leak if `WC_PK_TYPE_NONE` is used for auto-detect.
* Add DER PK auto detect support.
* Add sniffer `ssl_SetWatchKey_buffer` support for static ephemeral.