### PR TITLE
outbound connection filtering and wolfSentry integration

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1156,7 +1156,8 @@ static const char* client_usage_msg[][68] = {
         "            ln -s ca-cert.pem  `openssl x509 -in ca-cert.pem -hash -noout`.0\n",
                                                                        /* 67 */
 #endif
-#if defined(WOLFSSL_WOLFSENTRY_HOOKS) && !defined(NO_FILESYSTEM) && !defined(WOLFSENTRY_NO_JSON)
+#if defined(WOLFSSL_WOLFSENTRY_HOOKS) && !defined(NO_FILESYSTEM) && \
+    !defined(WOLFSENTRY_NO_JSON)
         "--wolfsentry-config <file>    Path for JSON wolfSentry config\n",
                                                                        /* 68 */
 #endif
@@ -1346,7 +1347,8 @@ static const char* client_usage_msg[][68] = {
         "            ln -s ca-cert.pem  `openssl x509 -in ca-cert.pem -hash -noout`.0\n",
                                                                         /* 67 */
 #endif
-#if defined(WOLFSSL_WOLFSENTRY_HOOKS) && !defined(NO_FILESYSTEM) && !defined(WOLFSENTRY_NO_JSON)
+#if defined(WOLFSSL_WOLFSENTRY_HOOKS) && !defined(NO_FILESYSTEM) && \
+    !defined(WOLFSENTRY_NO_JSON)
         "--wolfsentry-config <file>    wolfSentry コンフィグファイル\n",
                                                                        /* 68 */
 #endif
@@ -1528,7 +1530,8 @@ static void Usage(void)
     !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR)
     printf("%s", msg[++msgid]); /* -9 */
 #endif
-#if defined(WOLFSSL_WOLFSENTRY_HOOKS) && !defined(NO_FILESYSTEM) && !defined(WOLFSENTRY_NO_JSON)
+#if defined(WOLFSSL_WOLFSENTRY_HOOKS) && !defined(NO_FILESYSTEM) && \
+    !defined(WOLFSENTRY_NO_JSON)
     printf("%s", msg[++msgid]); /* --wolfsentry-config */
 #endif
 }
@@ -1563,7 +1566,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #ifndef WOLFSSL_VXWORKS
     int    ch;
     static const struct mygetopt_long_config long_options[] = {
-#if defined(WOLFSSL_WOLFSENTRY_HOOKS) && !defined(NO_FILESYSTEM) && !defined(WOLFSENTRY_NO_JSON)
+#if defined(WOLFSSL_WOLFSENTRY_HOOKS) && !defined(NO_FILESYSTEM) && \
+    !defined(WOLFSENTRY_NO_JSON)
         { "wolfsentry-config", 1, 256 },
 #endif
         { "help", 0, 257 },
@@ -2563,14 +2567,17 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
 
 #ifdef WOLFSSL_WOLFSENTRY_HOOKS
-    if (wolfsentry_setup(&wolfsentry, wolfsentry_config_path, WOLFSENTRY_ROUTE_FLAG_DIRECTION_OUT) < 0)
+    if (wolfsentry_setup(&wolfsentry, wolfsentry_config_path,
+                                     WOLFSENTRY_ROUTE_FLAG_DIRECTION_OUT) < 0) {
         err_sys("unable to initialize wolfSentry");
+    }
 
     if (wolfSSL_CTX_set_ConnectFilter(
             ctx,
             (NetworkFilterCallback_t)wolfSentry_NetworkFilterCallback,
-            wolfsentry) < 0)
+            wolfsentry) < 0) {
         err_sys("unable to install wolfSentry_NetworkFilterCallback");
+    }
 #endif
 
     if (cipherList && !useDefCipherList) {

--- a/examples/client/include.am
+++ b/examples/client/include.am
@@ -5,8 +5,9 @@ if BUILD_EXAMPLE_CLIENTS
 noinst_PROGRAMS += examples/client/client
 noinst_HEADERS += examples/client/client.h
 examples_client_client_SOURCES      = examples/client/client.c
-examples_client_client_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD)
+examples_client_client_LDADD        = src/libwolfssl.la $(LIB_STATIC_ADD) $(WOLFSENTRY_LIB)
 examples_client_client_DEPENDENCIES = src/libwolfssl.la
+examples_client_client_CFLAGS = $(WOLFSENTRY_INCLUDE) $(AM_CFLAGS)
 endif
 EXTRA_DIST += examples/client/client.sln
 EXTRA_DIST += examples/client/client-ntru.vcproj

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1099,7 +1099,8 @@ static void Usage(void)
     !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR)
     printf("%s", msg[++msgId]); /* -9 */
 #endif
-#if defined(WOLFSSL_WOLFSENTRY_HOOKS) && !defined(NO_FILESYSTEM) && !defined(WOLFSENTRY_NO_JSON)
+#if defined(WOLFSSL_WOLFSENTRY_HOOKS) && !defined(NO_FILESYSTEM) && \
+    !defined(WOLFSENTRY_NO_JSON)
     printf("%s", msg[++msgId]); /* --wolfsentry-config */
 #endif
 }
@@ -1123,7 +1124,8 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 #ifndef WOLFSSL_VXWORKS
     int    ch;
     static const struct mygetopt_long_config long_options[] = {
-#if defined(WOLFSSL_WOLFSENTRY_HOOKS) && !defined(NO_FILESYSTEM) && !defined(WOLFSENTRY_NO_JSON)
+#if defined(WOLFSSL_WOLFSENTRY_HOOKS) && !defined(NO_FILESYSTEM) && \
+    !defined(WOLFSENTRY_NO_JSON)
         { "wolfsentry-config", 1, 256 },
 #endif
         { "help", 0, 257 },
@@ -1979,15 +1981,18 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         err_sys_ex(catastrophic, "unable to get ctx");
 
 #ifdef WOLFSSL_WOLFSENTRY_HOOKS
-    if (wolfsentry_setup(&wolfsentry, wolfsentry_config_path, WOLFSENTRY_ROUTE_FLAG_DIRECTION_IN) < 0)
+    if (wolfsentry_setup(&wolfsentry, wolfsentry_config_path,
+                                      WOLFSENTRY_ROUTE_FLAG_DIRECTION_IN) < 0) {
         err_sys("unable to initialize wolfSentry");
+    }
 
     if (wolfSSL_CTX_set_AcceptFilter(
             ctx,
             (NetworkFilterCallback_t)wolfSentry_NetworkFilterCallback,
-            wolfsentry) < 0)
+            wolfsentry) < 0) {
         err_sys_ex(catastrophic,
                    "unable to install wolfSentry_NetworkFilterCallback");
+    }
 #endif
 
     if (simulateWantWrite)

--- a/src/internal.c
+++ b/src/internal.c
@@ -5616,6 +5616,8 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 #ifdef WOLFSSL_WOLFSENTRY_HOOKS
     ssl->AcceptFilter = ctx->AcceptFilter;
     ssl->AcceptFilter_arg = ctx->AcceptFilter_arg;
+    ssl->ConnectFilter = ctx->ConnectFilter;
+    ssl->ConnectFilter_arg = ctx->ConnectFilter_arg;
 #endif
 
     ssl->CBIORecv = ctx->CBIORecv;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -47273,8 +47273,9 @@ void wolfSSL_OPENSSL_config(char *config_name)
 #endif /* !NO_WOLFSSL_STUB */
 #endif /* OPENSSL_ALL || WOLFSSL_NGINX || WOLFSSL_HAPROXY || HAVE_STUNNEL*/
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) \
-    || defined(OPENSSL_EXTRA) || defined(HAVE_LIGHTY)
+#if defined(HAVE_EX_DATA) && (defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) \
+     || defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA)                   \
+     || defined(HAVE_LIGHTY))
 
 int wolfSSL_X509_get_ex_new_index(int idx, void *arg, void *a, void *b, void *c)
 {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1025,7 +1025,7 @@ int wolfSSL_CTX_set_AcceptFilter(
         return BAD_FUNC_ARG;
     ctx->AcceptFilter = AcceptFilter;
     ctx->AcceptFilter_arg = AcceptFilter_arg;
-    return WOLFSSL_SUCCESS;
+    return 0;
 }
 
 int wolfSSL_set_AcceptFilter(
@@ -1037,7 +1037,7 @@ int wolfSSL_set_AcceptFilter(
         return BAD_FUNC_ARG;
     ssl->AcceptFilter = AcceptFilter;
     ssl->AcceptFilter_arg = AcceptFilter_arg;
-    return WOLFSSL_SUCCESS;
+    return 0;
 }
 
 int wolfSSL_CTX_set_ConnectFilter(
@@ -1049,7 +1049,7 @@ int wolfSSL_CTX_set_ConnectFilter(
         return BAD_FUNC_ARG;
     ctx->ConnectFilter = ConnectFilter;
     ctx->ConnectFilter_arg = ConnectFilter_arg;
-    return WOLFSSL_SUCCESS;
+    return 0;
 }
 
 int wolfSSL_set_ConnectFilter(
@@ -1061,7 +1061,7 @@ int wolfSSL_set_ConnectFilter(
         return BAD_FUNC_ARG;
     ssl->ConnectFilter = ConnectFilter;
     ssl->ConnectFilter_arg = ConnectFilter_arg;
-    return WOLFSSL_SUCCESS;
+    return 0;
 }
 
 #endif /* WOLFSSL_WOLFSENTRY_HOOKS */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -48378,6 +48378,7 @@ int wolfSSL_sk_WOLFSSL_STRING_num(WOLF_STACK_OF(WOLFSSL_STRING)* strings)
         return (int)strings->num;
     return 0;
 }
+
 #endif /* WOLFSSL_NGINX || WOLFSSL_HAPROXY || OPENSSL_EXTRA || OPENSSL_ALL */
 
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -53835,6 +53835,30 @@ int wolfSSL_CONF_cmd(WOLFSSL_CONF_CTX* cctx, const char* cmd, const char* value)
     return ret;
 }
 
+/**
+ * Return DH p, q and g parameters
+ * @param dh a pointer to WOLFSSL_DH
+ * @param p  a pointer to WOLFSSL_BIGNUM to be obtained from dh
+ * @param q  a pointer to WOLFSSL_BIGNUM to be obtained from dh
+ * @param q  a pointer to WOLFSSL_BIGNUM to be obtained from dh
+ */
+void wolfSSL_DH_get0_pqg(const WOLFSSL_DH *dh, const WOLFSSL_BIGNUM **p, 
+                    const WOLFSSL_BIGNUM **q, const WOLFSSL_BIGNUM **g)
+{
+    WOLFSSL_ENTER("wolfSSL_DH_get0_pqg");
+    if (dh == NULL)
+        return;
+
+    if (p != NULL)
+        *p = dh->p;
+    if (q != NULL)
+        *q = dh->q;
+    if (g != NULL)
+        *g = dh->g;
+}
+
+#endif /* OPENSSL_EXTRA */
+
 #if defined(HAVE_EX_DATA) || defined(FORTRESS)
 /**
  * Issues unique index for the class specified by class_index.
@@ -53866,30 +53890,6 @@ int wolfSSL_CRYPTO_get_ex_new_index(int class_index, long argl, void *argp,
     return get_ex_new_index(class_index);
 }
 #endif /* HAVE_EX_DATA || FORTRESS */
-
-/**
- * Return DH p, q and g parameters
- * @param dh a pointer to WOLFSSL_DH
- * @param p  a pointer to WOLFSSL_BIGNUM to be obtained from dh
- * @param q  a pointer to WOLFSSL_BIGNUM to be obtained from dh
- * @param q  a pointer to WOLFSSL_BIGNUM to be obtained from dh
- */
-void wolfSSL_DH_get0_pqg(const WOLFSSL_DH *dh, const WOLFSSL_BIGNUM **p, 
-                    const WOLFSSL_BIGNUM **q, const WOLFSSL_BIGNUM **g)
-{
-    WOLFSSL_ENTER("wolfSSL_DH_get0_pqg");
-    if (dh == NULL)
-        return;
-
-    if (p != NULL)
-        *p = dh->p;
-    if (q != NULL)
-        *q = dh->q;
-    if (g != NULL)
-        *g = dh->g;
-}
-
-#endif /* OPENSSL_EXTRA */
 
 #ifndef NO_CERTS
 

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8236,6 +8236,18 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
         return WOLFSSL_FATAL_ERROR;
     }
 
+#ifdef WOLFSSL_WOLFSENTRY_HOOKS
+    if (ssl->ConnectFilter) {
+        wolfSSL_netfilter_decision_t res;
+        if ((ssl->ConnectFilter(ssl, ssl->ConnectFilter_arg, &res) ==
+             WOLFSSL_SUCCESS) &&
+            (res == WOLFSSL_NETFILTER_REJECT)) {
+            WOLFSSL_ERROR(ssl->error = SOCKET_FILTERED_E);
+            return WOLFSSL_FATAL_ERROR;
+        }
+    }
+#endif /* WOLFSSL_WOLFSENTRY_HOOKS */
+
     if (ssl->buffers.outputBuffer.length > 0
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* do not send buffered or advance state if last error was an

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2876,6 +2876,8 @@ struct WOLFSSL_CTX {
 #ifdef WOLFSSL_WOLFSENTRY_HOOKS
     NetworkFilterCallback_t AcceptFilter;
     void *AcceptFilter_arg;
+    NetworkFilterCallback_t ConnectFilter;
+    void *ConnectFilter_arg;
 #endif /* WOLFSSL_WOLFSENTRY_HOOKS */
     CallbackIORecv CBIORecv;
     CallbackIOSend CBIOSend;
@@ -4108,6 +4110,8 @@ struct WOLFSSL {
 #ifdef WOLFSSL_WOLFSENTRY_HOOKS
     NetworkFilterCallback_t AcceptFilter;
     void *AcceptFilter_arg;
+    NetworkFilterCallback_t ConnectFilter;
+    void *ConnectFilter_arg;
 #endif /* WOLFSSL_WOLFSENTRY_HOOKS */
     CallbackIORecv  CBIORecv;
     CallbackIOSend  CBIOSend;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1183,6 +1183,14 @@ WOLFSSL_API int wolfSSL_set_AcceptFilter(
     WOLFSSL *ssl,
     NetworkFilterCallback_t AcceptFilter,
     void *AcceptFilter_arg);
+WOLFSSL_API int wolfSSL_CTX_set_ConnectFilter(
+    WOLFSSL_CTX *ctx,
+    NetworkFilterCallback_t ConnectFilter,
+    void *ConnectFilter_arg);
+WOLFSSL_API int wolfSSL_set_ConnectFilter(
+    WOLFSSL *ssl,
+    NetworkFilterCallback_t ConnectFilter,
+    void *ConnectFilter_arg);
 
 #endif /* WOLFSSL_WOLFSENTRY_HOOKS */
 
@@ -4441,13 +4449,13 @@ WOLFSSL_API int wolfSSL_CONF_CTX_finish(WOLFSSL_CONF_CTX* cctx);
 #define WOLFSSL_CONF_TYPE_FILE          0x2
 
 WOLFSSL_API int wolfSSL_CONF_cmd(WOLFSSL_CONF_CTX* cctx, const char* cmd, const char* value);
-#if defined(HAVE_EX_DATA) || defined(FORTRESS)
+#endif /* OPENSSL_EXTRA */
+#if defined(HAVE_EX_DATA) || defined(FORTRESS) || defined(WOLFSSL_WPAS_SMALL)
 WOLFSSL_API int wolfSSL_CRYPTO_get_ex_new_index(int class_index, long argl, void *argp,
                                            WOLFSSL_CRYPTO_EX_new* new_func,
                                            WOLFSSL_CRYPTO_EX_dup* dup_func,
                                            WOLFSSL_CRYPTO_EX_free* free_func);
 #endif /* HAVE_EX_DATA || FORTRESS */
-#endif /* OPENSSL_EXTRA */
 #ifdef __cplusplus
     }  /* extern "C" */
 #endif

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -16,7 +16,7 @@
     #include <errno.h>
 #endif
 #include <wolfssl/wolfcrypt/types.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/error-ssl.h>
 #include <wolfssl/wolfcrypt/random.h>
 #include <wolfssl/wolfcrypt/mem_track.h>
 #include <wolfssl/wolfio.h>

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -663,7 +663,8 @@ struct mygetopt_long_config {
  *                  present.
  * @return Option letter in argument
  */
-static WC_INLINE int mygetopt_long(int argc, char** argv, const char* optstring, const struct mygetopt_long_config *longopts, int *longindex)
+static WC_INLINE int mygetopt_long(int argc, char** argv, const char* optstring,
+    const struct mygetopt_long_config *longopts, int *longindex)
 {
     static char* next = NULL;
 
@@ -1374,7 +1375,7 @@ static int wolfsentry_setup(
             fprintf(stderr, "wolfsentry_config_json_init() returned "
                     WOLFSENTRY_ERROR_FMT "\n",
                     WOLFSENTRY_ERROR_FMT_ARGS(ret));
-            err_sys("error while initlalizing wolfSentry config parser");
+            err_sys("error while initializing wolfSentry config parser");
         }
 
         for (;;) {
@@ -1400,7 +1401,7 @@ static int wolfsentry_setup(
         }
 
     } else
-#endif /* !defined(NO_FILESYSTEM) && !defined(WOLFSENTRY_NO_JSON) */
+#endif /* !NO_FILESYSTEM && !WOLFSENTRY_NO_JSON */
     {
         struct wolfsentry_route_table *table;
 
@@ -1559,7 +1560,7 @@ static WC_INLINE int tcp_connect_with_wolfSentry(
         &wolfsentry_data->local,
         wolfsentry_data->flags,
         NULL /* event_label */,
-        0 /* event_label_len */,
+        0    /* event_label_len */,
         NULL /* caller_context */,
         NULL /* id */,
         NULL /* inexact_matches */,
@@ -1592,7 +1593,7 @@ static WC_INLINE int tcp_connect_with_wolfSentry(
            decision,
            decision == WOLFSSL_NETFILTER_REJECT ? "REJECT" :
            decision == WOLFSSL_NETFILTER_ACCEPT ? "ACCEPT" :
-           decision == WOLFSSL_NETFILTER_PASS ? "PASS" :
+           decision == WOLFSSL_NETFILTER_PASS ?   "PASS" :
            "???");
 
     if (decision == WOLFSSL_NETFILTER_REJECT)
@@ -1611,7 +1612,8 @@ static WC_INLINE int tcp_connect_with_wolfSentry(
     return WOLFSSL_SUCCESS;
 }
 
-#define tcp_connect(sockfd, ip, port, udp, sctp, ssl) tcp_connect_with_wolfSentry(sockfd, ip, port, udp, sctp, ssl, wolfsentry)
+#define tcp_connect(sockfd, ip, port, udp, sctp, ssl) \
+    tcp_connect_with_wolfSentry(sockfd, ip, port, udp, sctp, ssl, wolfsentry)
 
 #else /* !WOLFSSL_WOLFSENTRY_HOOKS */
 


### PR DESCRIPTION
adds wolfSentry to the test client (defaults to allow-any).

adds wolfSentry JSON config file support to the test client and server using `--wolfsentry-config`.

also, adds `mygetopt_long()` to wolfssl/test.h, and adds `--help` and `--ヘルプ` options to test client and server.
