### PR TITLE
Fix BIO_free_all return type

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16601,7 +16601,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
     }
 
 
-    int wolfSSL_BIO_free_all(WOLFSSL_BIO* bio)
+    void wolfSSL_BIO_free_all(WOLFSSL_BIO* bio)
     {
         WOLFSSL_ENTER("BIO_free_all");
         while (bio) {
@@ -16609,7 +16609,6 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             wolfSSL_BIO_free(bio);
             bio = next;
         }
-        return 0;
     }
 
 

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1371,7 +1371,7 @@ WOLFSSL_API WOLFSSL_BIO* wolfSSL_BIO_new(WOLFSSL_BIO_METHOD*);
 #endif
 WOLFSSL_API int  wolfSSL_BIO_free(WOLFSSL_BIO*);
 WOLFSSL_API void wolfSSL_BIO_vfree(WOLFSSL_BIO*);
-WOLFSSL_API int  wolfSSL_BIO_free_all(WOLFSSL_BIO*);
+WOLFSSL_API void wolfSSL_BIO_free_all(WOLFSSL_BIO*);
 WOLFSSL_API int wolfSSL_BIO_gets(WOLFSSL_BIO* bio, char* buf, int sz);
 WOLFSSL_API int wolfSSL_BIO_puts(WOLFSSL_BIO* bio, const char* buf);
 WOLFSSL_API WOLFSSL_BIO* wolfSSL_BIO_next(WOLFSSL_BIO* bio);


### PR DESCRIPTION
The API signature for the openSSL function `BIO_free_all` is a void return type.
https://www.openssl.org/docs/man1.1.0/man3/BIO_free_all.html

This addresses an issue first reported in ZD12463.