### PR TITLE
SP int negative: check size of a in mp_mod

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -4722,6 +4722,11 @@ int sp_mod(sp_int* a, sp_int* m, sp_int* r)
     if ((a == NULL) || (m == NULL) || (r == NULL)) {
         err = MP_VAL;
     }
+#ifdef WOLFSSL_SP_INT_NEGATIVE
+    if ((err == MP_OKAY) && (a->used >= SP_INT_DIGITS)) {
+        err = MP_VAL;
+    }
+#endif
 
 #ifndef WOLFSSL_SP_INT_NEGATIVE
     if (err == MP_OKAY) {


### PR DESCRIPTION
When using negative numbers, t is allocated to be one digit longer than
a->used. Fail when a->used is SP_DIGIT_MAX.