### PR TITLE
Fix configure.ac to generate empty files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6436,6 +6436,22 @@ AC_CONFIG_FILES([scripts/unit.test],[chmod +x scripts/unit.test])
 AX_CREATE_GENERIC_CONFIG
 AX_AM_JOBSERVER([yes])
 
+AC_CONFIG_FILES([wolfssl/wolfcrypt/async.h:])
+AC_CONFIG_FILES([wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h:])
+AC_CONFIG_FILES([wolfssl/wolfcrypt/port/intel/quickassist.h:])
+AC_CONFIG_FILES([wolfssl/wolfcrypt/port/intel/quickassist_mem.h:])
+AC_CONFIG_FILES([wolfssl/wolfcrypt/fips.h:])
+AC_CONFIG_FILES([ctaocrypt/src/fips.c:])
+AC_CONFIG_FILES([ctaocrypt/src/fips_test.c:])
+AC_CONFIG_FILES([wolfcrypt/src/wolfcrypt_first.c:])
+AC_CONFIG_FILES([wolfcrypt/src/fips.c:])
+AC_CONFIG_FILES([wolfcrypt/src/fips_test.c:])
+AC_CONFIG_FILES([wolfcrypt/src/wolfcrypt_last.c:])
+AC_CONFIG_FILES([wolfcrypt/src/selftest.c:])
+AC_CONFIG_FILES([wolfcrypt/src/async.c:])
+AC_CONFIG_FILES([wolfcrypt/src/port/cavium/cavium_nitrox.c:])
+AC_CONFIG_FILES([wolfcrypt/src/port/intel/quickassist.c:])
+AC_CONFIG_FILES([wolfcrypt/src/port/intel/quickassist_mem.c:])
 AC_OUTPUT
 
 


### PR DESCRIPTION
The fixes 'make dist' which is currently broken. To confirm error that this fixes:
autoreconf -if
./configure
make dist

FWIW normally repositories would use *.in to generate the above named files in an empty manner instead of using a blank ":" operator. I don't know how you use these files so I am unsure if you want that since the *.in would need to have rules around it being shipped as well.
All rules right now that would force autoreconf will also fail.
The usage of a "autogen.sh" was discontinued by autoconf a number of years ago in favor of just using autoreconf.