### PR TITLE
Fix for make distcheck, maintainer-clean, to allow distribution builds.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,7 @@ SUFFIXES =
 TESTS =
 CLEANFILES =
 DISTCLEANFILES =
+MAINTAINERCLEANFILES =
 bin_PROGRAMS =
 noinst_HEADERS =
 lib_LTLIBRARIES =
@@ -237,6 +238,12 @@ scripts/unit.log: testsuite/testsuite.log
 
 DISTCLEANFILES+= cyassl-config
 DISTCLEANFILES+= wolfssl-config
+
+MAINTAINERCLEANFILES+= wolfssl/wolfcrypt/async.h
+MAINTAINERCLEANFILES+= wolfssl/wolfcrypt/fips.h
+MAINTAINERCLEANFILES+= wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h
+MAINTAINERCLEANFILES+= wolfssl/wolfcrypt/port/intel/quickassist.h
+MAINTAINERCLEANFILES+= wolfssl/wolfcrypt/port/intel/quickassist_mem.h
 
 SUBDIRS=$(SUBDIRS_OPT)
 DIST_SUBDIRS=$(DIST_SUBDIRS_OPT)

--- a/configure.ac
+++ b/configure.ac
@@ -6436,6 +6436,17 @@ AC_CONFIG_FILES([scripts/unit.test],[chmod +x scripts/unit.test])
 AX_CREATE_GENERIC_CONFIG
 AX_AM_JOBSERVER([yes])
 
+# See Automake 9.4.1 Built Sources Example
+AC_DEFUN([AX_OUT_OF_TREE_FILE],[
+  AC_CONFIG_COMMANDS([$1], [test ! -f $srcdir/$1 && >> $srcdir/$1])
+])
+
+AX_OUT_OF_TREE_FILE([wolfssl/wolfcrypt/async.h])
+AX_OUT_OF_TREE_FILE([wolfssl/wolfcrypt/fips.h])
+AX_OUT_OF_TREE_FILE([wolfssl/wolfcrypt/port/cavium/cavium_nitrox.h])
+AX_OUT_OF_TREE_FILE([wolfssl/wolfcrypt/port/intel/quickassist.h])
+AX_OUT_OF_TREE_FILE([wolfssl/wolfcrypt/port/intel/quickassist_mem.h])
+
 AC_OUTPUT
 
 

--- a/src/include.am
+++ b/src/include.am
@@ -2,6 +2,48 @@
 # included from Top Level Makefile.am
 # All paths should be given relative to the root
 
+BUILT_SOURCES+= ctaocrypt/src/fips.c
+BUILT_SOURCES+= ctaocrypt/src/fips_test.c
+BUILT_SOURCES+= wolfcrypt/src/async.c
+BUILT_SOURCES+= wolfcrypt/src/fips.c
+BUILT_SOURCES+= wolfcrypt/src/fips_test.c
+BUILT_SOURCES+= wolfcrypt/src/selftest.c
+BUILT_SOURCES+= wolfcrypt/src/wolfcrypt_first.c
+BUILT_SOURCES+= wolfcrypt/src/wolfcrypt_last.c
+
+MAINTAINERCLEANFILES+= ctaocrypt/src/fips.c
+MAINTAINERCLEANFILES+= ctaocrypt/src/fips_test.c
+MAINTAINERCLEANFILES+= wolfcrypt/src/async.c
+MAINTAINERCLEANFILES+= wolfcrypt/src/fips.c
+MAINTAINERCLEANFILES+= wolfcrypt/src/fips_test.c
+MAINTAINERCLEANFILES+= wolfcrypt/src/selftest.c
+MAINTAINERCLEANFILES+= wolfcrypt/src/wolfcrypt_first.c
+MAINTAINERCLEANFILES+= wolfcrypt/src/wolfcrypt_last.c
+
+ctaocrypt/src/fips.c: Makefile
+	touch $(srcdir)/$@
+
+ctaocrypt/src/fips_test.c: Makefile
+	touch $(srcdir)/$@
+
+wolfcrypt/src/async.c: Makefile
+	touch $(srcdir)/$@
+
+wolfcrypt/src/fips.c: Makefile
+	touch $(srcdir)/$@
+
+wolfcrypt/src/fips_test.c: Makefile
+	touch $(srcdir)/$@
+
+wolfcrypt/src/selftest.c: Makefile
+	touch $(srcdir)/$@
+
+wolfcrypt/src/wolfcrypt_first.c: Makefile
+	touch $(srcdir)/$@
+
+wolfcrypt/src/wolfcrypt_last.c: Makefile
+	touch $(srcdir)/$@
+
 if !BUILD_NO_LIBRARY
 lib_LTLIBRARIES+= src/libwolfssl.la
 endif

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -1,6 +1,14 @@
 # vim:ft=automake
 # All paths should be given relative to the root
 
+BUILT_SOURCES+= wolfcrypt/src/port/cavium/cavium_nitrox.c
+BUILT_SOURCES+= wolfcrypt/src/port/intel/quickassist.c
+BUILT_SOURCES+= wolfcrypt/src/port/intel/quickassist_mem.c
+
+MAINTAINERCLEANFILES+= wolfcrypt/src/port/cavium/cavium_nitrox.c
+MAINTAINERCLEANFILES+= wolfcrypt/src/port/intel/quickassist.c
+MAINTAINERCLEANFILES+= wolfcrypt/src/port/intel/quickassist_mem.c
+
 EXTRA_DIST += src/bio.c
 EXTRA_DIST += wolfcrypt/src/misc.c
 EXTRA_DIST += wolfcrypt/src/evp.c
@@ -101,6 +109,14 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/Renesas/README.md \
               wolfcrypt/src/port/cypress/psoc6_crypto.c
 
+wolfcrypt/src/port/cavium/cavium_nitrox.c: Makefile
+	touch $(srcdir)/$@
+
+wolfcrypt/src/port/intel/quickassist.c: Makefile
+	touch $(srcdir)/$@
+
+wolfcrypt/src/port/intel/quickassist_mem.c: Makefile
+	touch $(srcdir)/$@
 
 if BUILD_CRYPTOCB
 src_libwolfssl_la_SOURCES += wolfcrypt/src/cryptocb.c


### PR DESCRIPTION
This the second pass at this after seeing how fips is added to tree in later phases.
This allow autoreconf to be directly called which allows the Makefile to rebuild when seeing that changes have been ( having an autogen.sh is older convention which left to history in the way autotools are invoked )
This fixes "make distcheck" and "make maintainer-clean" which are required by most distributions packaging systems.

The files previously touched by autogen.sh are now properly placed into autoconf.
The include files files are generated by configure. ( There is a note placed in configure.ac as to why and reference to the automake documention for this ). Append to file was done on purpose, touch cannot be in configure safetly. Normally autoheader would be used for this but since the include files are created out of tree, care has to be taken to not overwrite those file.
For the source files, they were moved into the coresponding automake file. It is safe to use touch in automake. Since files can optionally copied from elsewhere, they have to be listed in BUILT_SOURCES. They are written srcdir in order to allow make to do VPATH builds ( which is configure by make distcheck ).
To show fips files are preserved without having the actual fips files, a C style comment can be echoed into the files.
There are a few current, but outstanding issues.
1) config.h needs to be fixed configure.ac to use autoheader in order to allow configure to know to rebuilt depencies on its changes. ( Out of scope for this patch. )
2) verion.h checked into the tree and it is a built file. A make maintainer-clean followed by "git status --ignored" will confirm this. ( Out of scope for this patch )
3) autogen.sh has not been updated to reflect fixes. I believe that for this patch, it should be left alone and checked for regression in Jenkins by itself.
4) There is an out of date .spec file for building RPM which should be updated now that distcheck is working.
5) maintainer-clean should have rule added to remove build-aux testdriver.

This has been tested on current Ubuntu testing, OSX, Fedora 34, and Debian 10.

Additionaly "make distcheck" should be added to regression testing, along with "make maintainer-check".

Other improvement possibilities:
A possible future improvement is to let autoconf handle build with optional out of dist files.
Modify fips configure.ac check to allow for an injection of comments into blank fips files in order to prove distribution of fips/non-fips builds.
Update git rules to use 'make maintainer-clean', 'autoreconf -if', 'make distcheck'.