### PR TITLE
In wc_ecc_verify_hash_ex, return if ALLOC_CURVE_SPECS() fails

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7131,8 +7131,10 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 #endif /* WOLFSSL_ASYNC_CRYPT && HAVE_CAVIUM_V */
 
    err = mp_init(e);
-   if (err != MP_OKAY)
+   if (err != MP_OKAY) {
+      FREE_CURVE_SPECS();
       return MEMORY_E;
+   }
 
    /* read in the specs for this curve */
    err = wc_ecc_curve_load(key->dp, &curve, ECC_CURVE_FIELD_ALL);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7108,6 +7108,9 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 
 #if !defined(WOLFSSL_SP_MATH) || defined(FREESCALE_LTC_ECC)
    ALLOC_CURVE_SPECS(ECC_CURVE_FIELD_COUNT, err);
+   if (err != 0) {
+      return err;
+   }
 
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_CAVIUM_V)
    err = wc_ecc_alloc_mpint(key, &key->e);


### PR DESCRIPTION
This prevents a NULL pointer dereference later in the function.