### PR TITLE
Regression test fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3260,10 +3260,10 @@ fi
 
 if test "$ENABLED_CHACHA" = "noasm" || test "$ENABLED_ASM" = "no"
 then
-    AM_CFLAGS="$AM_CFLAGS -DHAVE_CHACHA -DNO_CHACHA_ASM"
+    AM_CFLAGS="$AM_CFLAGS -DNO_CHACHA_ASM"
 fi
 
-if test "$ENABLED_CHACHA" = "yes"
+if test "$ENABLED_CHACHA" != "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_CHACHA"
 fi

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -1259,7 +1259,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
         WOLFSSL_MEM_STATS mem_stats;
     #endif
 #endif
-#if defined(WOLFSSL_TLS13)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
     int onlyKeyShare = 0;
 #endif
 #if defined(HAVE_SESSION_TICKET)
@@ -1643,13 +1643,15 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 break;
 
             case 'y' :
-                #if defined(WOLFSSL_TLS13) && !defined(NO_DH)
+                #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES) \
+                    && !defined(NO_DH)
                     onlyKeyShare = 1;
                 #endif
                 break;
 
             case 'Y' :
-                #if defined(WOLFSSL_TLS13) && defined(HAVE_ECC)
+                #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES) \
+                    && defined(HAVE_ECC)
                     onlyKeyShare = 2;
                 #endif
                 break;
@@ -1657,7 +1659,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             case 't' :
                 #ifdef HAVE_CURVE25519
                     useX25519 = 1;
-                    #if defined(WOLFSSL_TLS13) && defined(HAVE_ECC)
+                    #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
                         onlyKeyShare = 2;
                     #endif
                 #endif
@@ -1786,7 +1788,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             case '8' :
                 #ifdef HAVE_CURVE448
                     useX448 = 1;
-                    #if defined(WOLFSSL_TLS13) && defined(HAVE_ECC)
+                    #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
                         onlyKeyShare = 2;
                     #endif
                 #endif
@@ -2558,7 +2560,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
             SetupPkCallbackContexts(ssl, &pkCbInfo);
 #endif
 
-    #ifdef WOLFSSL_TLS13
+    #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
         if (version >= 4) {
             SetKeyShare(ssl, onlyKeyShare, useX25519, useX448);   
         }

--- a/src/keys.c
+++ b/src/keys.c
@@ -2273,7 +2273,7 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
 #endif /* BUILD_ARC4 */
 
 
-#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305) && !defined(NO_CHAPOL_AEAD)
     /* Check that the max implicit iv size is suffecient */
     #if (AEAD_MAX_IMP_SZ < 12) /* CHACHA20_IMP_IV_SZ */
         #error AEAD_MAX_IMP_SZ is too small for ChaCha20

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6762,8 +6762,10 @@ int ProcessFile(WOLFSSL_CTX* ctx, const char* fname, int format, int type,
     long   sz = 0;
     XFILE  file;
     void*  heapHint = wolfSSL_CTX_GetHeap(ctx, ssl);
+#ifndef NO_CODING
     const char* header = NULL;
     const char* footer = NULL;
+#endif
 
     (void)crl;
     (void)heapHint;
@@ -6800,6 +6802,7 @@ int ProcessFile(WOLFSSL_CTX* ctx, const char* fname, int format, int type,
     else {
         /* Try to detect type by parsing cert header and footer */
         if (type == DETECT_CERT_TYPE) {
+#ifndef NO_CODING
             if (wc_PemGetHeaderFooter(CA_TYPE, &header, &footer) == 0 &&
                (XSTRNSTR((char*)myBuffer, header, (int)sz) != NULL)) {
                 type = CA_TYPE;
@@ -6814,7 +6817,9 @@ int ProcessFile(WOLFSSL_CTX* ctx, const char* fname, int format, int type,
                     (XSTRNSTR((char*)myBuffer, header, (int)sz) != NULL)) {
                 type = CERT_TYPE;
             }
-            else {
+            else
+#endif
+            {
                 WOLFSSL_MSG("Failed to detect certificate type");
                 if (dynamic)
                     XFREE(myBuffer, heapHint, DYNAMIC_TYPE_FILE);

--- a/src/tls.c
+++ b/src/tls.c
@@ -10244,10 +10244,11 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
 #if defined(WOLFSSL_TLS13) && (defined(HAVE_SESSION_TICKET) || !defined(NO_PSK))
     int usingPSK = 0;
 #endif
-#if defined(HAVE_SUPPORTED_CURVES) || defined(HAVE_QSH)
+#if (defined(HAVE_SUPPORTED_CURVES) && defined(WOLFSSL_TLS13)) || \
+                                                               defined(HAVE_QSH)
     TLSX* extension = NULL;
 #endif
-#if defined(HAVE_SUPPORTED_CURVES)
+#if defined(HAVE_SUPPORTED_CURVES) && defined(WOLFSSL_TLS13)
     word16 namedGroup = 0;
 #endif
 #ifdef HAVE_QSH
@@ -10623,8 +10624,6 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
     (void)public_key;
     (void)public_key_len;
     (void)ssl;
-    (void)extension;
-    (void)namedGroup;
 
     return ret;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -6708,7 +6708,7 @@ static void test_wolfSSL_PKCS8(void)
     XFILE f;
     int bytes;
     WOLFSSL_CTX* ctx;
-#ifdef HAVE_ECC
+#if defined(HAVE_ECC) && !defined(NO_CODING)
     int ret;
     ecc_key key;
     word32 x = 0;
@@ -6724,6 +6724,8 @@ static void test_wolfSSL_PKCS8(void)
     #endif
     int flag;
 #endif
+
+    (void)der;
 
     printf(testingFmt, "wolfSSL_PKCS8()");
 
@@ -6854,6 +6856,7 @@ static void test_wolfSSL_PKCS8(void)
     AssertIntEQ(wolfSSL_CTX_use_PrivateKey_buffer(ctx, buff, bytes,
                 WOLFSSL_FILETYPE_PEM), WOLFSSL_SUCCESS);
 
+#ifndef NO_CODING
     /* decrypt PKCS8 PEM to key in DER format */
     AssertIntGT((bytes = wc_KeyPemToDer(buff, bytes, der,
         (word32)sizeof(der), NULL)), 0);
@@ -6863,6 +6866,7 @@ static void test_wolfSSL_PKCS8(void)
         wc_ecc_free(&key);
     }
     AssertIntEQ(ret, 0);
+#endif
 
     /* Test PKCS8 DER ECC key no crypt */
     f = XFOPEN(eccPkcs8PrivKeyDerFile, "rb");

--- a/tests/api.c
+++ b/tests/api.c
@@ -1131,7 +1131,7 @@ static int test_cm_load_ca_file(const char* ca_cert_file)
 
 static void test_wolfSSL_CertManagerCheckOCSPResponse(void)
 {
-#ifdef HAVE_OCSP
+#if defined(HAVE_OCSP) && !defined(NO_RSA)
 /* Need one of these for wolfSSL_OCSP_REQUEST_new. */
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || \
     defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_APACHE_HTTPD) || \
@@ -5728,7 +5728,8 @@ static void test_wolfSSL_UseSNI(void)
 
 static void test_wolfSSL_UseTrustedCA(void)
 {
-#if defined(HAVE_TRUSTED_CA) && !defined(NO_CERTS) && !defined(NO_FILESYSTEM)
+#if defined(HAVE_TRUSTED_CA) && !defined(NO_CERTS) && !defined(NO_FILESYSTEM) \
+    && !defined(NO_RSA)
     WOLFSSL_CTX *ctx;
     WOLFSSL     *ssl;
     byte        id[20];
@@ -5775,7 +5776,8 @@ static void test_wolfSSL_UseTrustedCA(void)
 
 static void test_wolfSSL_UseMaxFragment(void)
 {
-#if defined(HAVE_MAX_FRAGMENT) && !defined(NO_CERTS) && !defined(NO_FILESYSTEM)
+#if defined(HAVE_MAX_FRAGMENT) && !defined(NO_CERTS) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_RSA)
   #ifndef NO_WOLFSSL_SERVER
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new(wolfSSLv23_server_method());
     AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile, WOLFSSL_FILETYPE_PEM));
@@ -5817,7 +5819,8 @@ static void test_wolfSSL_UseMaxFragment(void)
 
 static void test_wolfSSL_UseTruncatedHMAC(void)
 {
-#if defined(HAVE_TRUNCATED_HMAC) && !defined(NO_CERTS) && !defined(NO_FILESYSTEM)
+#if defined(HAVE_TRUNCATED_HMAC) && !defined(NO_CERTS) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_RSA)
   #ifndef NO_WOLFSSL_SERVER
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new(wolfSSLv23_server_method());
     AssertTrue(wolfSSL_CTX_use_certificate_file(ctx, svrCertFile, WOLFSSL_FILETYPE_PEM));
@@ -27166,7 +27169,7 @@ static void test_wolfSSL_X509_NAME(void)
 #ifndef NO_BIO
 static void test_wolfSSL_X509_INFO(void)
 {
-#if defined(OPENSSL_ALL)
+#if defined(OPENSSL_ALL) && !defined(NO_RSA)
     STACK_OF(X509_INFO) *info_stack;
     X509_INFO *info;
     BIO *cert;
@@ -27273,7 +27276,7 @@ static void test_wolfSSL_X509_check_host(void)
 
 static void test_wolfSSL_X509_check_email(void)
 {
-#if defined(OPENSSL_EXTRA) && defined(WOLFSSL_CERT_GEN)
+#if defined(OPENSSL_EXTRA) && defined(WOLFSSL_CERT_GEN) && !defined(NO_RSA)
     X509* x509;
     const char goodEmail[] = "info@wolfssl.com";
     const char badEmail[] = "disinfo@wolfssl.com";
@@ -29445,7 +29448,7 @@ static void test_wolfSSL_X509_Name_canon(void)
 #if defined(OPENSSL_ALL) && !defined(NO_CERTS) && \
     !defined(NO_FILESYSTEM) && !defined(NO_SHA) && \
      defined(WOLFSSL_CERT_GEN) && \
-    (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT))
+    (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT)) && !defined(NO_RSA)
     
     const long ex_hash1 = 0x0fdb2da4;
     const long ex_hash2 = 0x9f3e8c9e;
@@ -30443,8 +30446,8 @@ static void test_wolfSSL_X509_STORE(void)
 
 static void test_wolfSSL_X509_STORE_load_locations(void)
 {
-#if (defined(OPENSSL_ALL) || defined(WOLFSSL_APACHE_HTTPD)) && !defined(NO_FILESYSTEM)\
-    && !defined(NO_WOLFSSL_DIR)
+#if (defined(OPENSSL_ALL) || defined(WOLFSSL_APACHE_HTTPD)) && \
+    !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR) && !defined(NO_RSA)
     SSL_CTX *ctx;
     X509_STORE *store;
 
@@ -31848,7 +31851,8 @@ static void test_wolfSSL_X509(void)
 
 static void test_wolfSSL_X509_get_ext_count(void)
 {
-#if defined(OPENSSL_ALL) && !defined(NO_CERTS) && !defined(NO_FILESYSTEM)
+#if defined(OPENSSL_ALL) && !defined(NO_CERTS) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_RSA)
     int ret = 0;
     WOLFSSL_X509* x509;
     const char ocspRootCaFile[] = "./certs/ocsp/root-ca-cert.pem";
@@ -31889,7 +31893,7 @@ static void test_wolfSSL_X509_get_ext_count(void)
 
 static void test_wolfSSL_X509_sign2(void)
 {
-#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
+#if defined(OPENSSL_EXTRA) && !defined(NO_RSA) && !defined(NO_CERTS) && \
     defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_ALT_NAMES) && \
     defined(WOLFSSL_CERT_EXT) && \
     (defined(WOLFSSL_QT) || defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME))
@@ -32086,7 +32090,7 @@ static void test_wolfSSL_X509_sign2(void)
 static void test_wolfSSL_X509_sign(void)
 {
 #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
-    defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_REQ)
+    defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_REQ) && !defined(NO_RSA)
     int ret;
     char *caSubject;
     X509_NAME *name;
@@ -32279,7 +32283,8 @@ static void test_wolfSSL_X509_get0_tbs_sigalg(void)
 
 static void test_wolfSSL_X509_ALGOR_get0(void)
 {
-#if (defined(OPENSSL_ALL) || defined(WOLFSSL_APACHE_HTTPD)) && !defined(NO_SHA256)
+#if (defined(OPENSSL_ALL) || defined(WOLFSSL_APACHE_HTTPD)) && \
+    !defined(NO_SHA256) && !defined(NO_RSA)
     X509* x509 = NULL;
     const ASN1_OBJECT* obj = NULL;
     const X509_ALGOR* alg;
@@ -32468,7 +32473,8 @@ static void test_wolfSSL_X509_get_X509_PUBKEY(void)
 
 static void test_wolfSSL_X509_PUBKEY(void)
 {
-#if (defined(OPENSSL_ALL) || defined(WOLFSSL_APACHE_HTTPD)) && !defined(NO_SHA256)
+#if (defined(OPENSSL_ALL) || defined(WOLFSSL_APACHE_HTTPD)) && \
+    !defined(NO_SHA256) && !defined(NO_RSA)
     X509* x509 = NULL;
     ASN1_OBJECT* obj = NULL;
     X509_PUBKEY* pubKey;
@@ -35112,7 +35118,7 @@ static void test_wolfSSL_RSA_meth(void)
 
 static void test_wolfSSL_verify_mode(void)
 {
-#if defined(OPENSSL_ALL)
+#if defined(OPENSSL_ALL) && !defined(NO_RSA)
     WOLFSSL*     ssl;
     WOLFSSL_CTX* ctx;
 
@@ -36791,6 +36797,7 @@ static void test_wolfSSL_AES_cbc_encrypt(void)
 #if !defined(NO_ASN)
 static void test_wolfSSL_ASN1_STRING_to_UTF8(void)
 {
+#if !defined(NO_RSA)
     WOLFSSL_X509* x509;
     WOLFSSL_X509_NAME* subject;
     WOLFSSL_X509_NAME_ENTRY* e;
@@ -36834,6 +36841,7 @@ static void test_wolfSSL_ASN1_STRING_to_UTF8(void)
 
     wolfSSL_X509_free(x509);
     XFREE(actual_output, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
 }
 
 static void test_wolfSSL_ASN1_UNIVERSALSTRING_to_string(void)
@@ -36869,6 +36877,7 @@ static void test_wolfSSL_ASN1_UNIVERSALSTRING_to_string(void)
 
 static void test_wolfSSL_sk_CIPHER_description(void)
 {
+#if !defined(NO_RSA)
     const long flags = SSL_OP_NO_SSLv2 | SSL_OP_NO_COMPRESSION;
     int i,j,k;
     int numCiphers = 0;
@@ -36930,10 +36939,12 @@ static void test_wolfSSL_sk_CIPHER_description(void)
     SSL_CTX_free(ctx);
 
     printf(resultFmt, passed);
+#endif
 }
 
 static void test_wolfSSL_get_ciphers_compat(void)
 {
+#if !defined(NO_RSA)
     const SSL_METHOD *method = NULL;
     const char certPath[] = "./certs/client-cert.pem";
     STACK_OF(SSL_CIPHER) *supportedCiphers = NULL;
@@ -36967,6 +36978,7 @@ static void test_wolfSSL_get_ciphers_compat(void)
     SSL_CTX_free(ctx);
 
     printf(resultFmt, passed);
+#endif
 }
 
 static void test_wolfSSL_X509_PUBKEY_get(void)
@@ -38767,7 +38779,7 @@ static void test_wolfSSL_EC_KEY_set_group(void)
 }
 
 static void test_wolfSSL_X509V3_EXT_get(void) {
-#if !defined(NO_FILESYSTEM) && defined (OPENSSL_ALL)
+#if !defined(NO_FILESYSTEM) && defined(OPENSSL_ALL) && !defined(NO_RSA)
     FILE* f;
     int numOfExt =0;
     int extNid = 0;
@@ -38799,7 +38811,7 @@ static void test_wolfSSL_X509V3_EXT_get(void) {
 }
 
 static void test_wolfSSL_X509V3_EXT(void) {
-#if !defined(NO_FILESYSTEM) && defined (OPENSSL_ALL)
+#if !defined(NO_FILESYSTEM) && defined(OPENSSL_ALL) && !defined(NO_RSA)
     FILE* f;
     int numOfExt = 0, nid = 0, i = 0, expected, actual;
     char* str;
@@ -38943,7 +38955,7 @@ static void test_wolfSSL_X509V3_EXT(void) {
 }
 
 static void test_wolfSSL_X509_get_ext(void){
-#if !defined(NO_FILESYSTEM) && defined (OPENSSL_ALL)
+#if !defined(NO_FILESYSTEM) && defined(OPENSSL_ALL) && !defined(NO_RSA)
     int ret = 0;
     FILE* f;
     WOLFSSL_X509* x509;
@@ -38978,7 +38990,7 @@ static void test_wolfSSL_X509_get_ext(void){
 
 static void test_wolfSSL_X509_get_ext_by_NID(void)
 {
-#if defined(OPENSSL_ALL)
+#if defined(OPENSSL_ALL) && !defined(NO_RSA)
     int rc;
     FILE* f;
     WOLFSSL_X509* x509;
@@ -39024,7 +39036,7 @@ static void test_wolfSSL_X509_EXTENSION_new(void)
 
 static void test_wolfSSL_X509_EXTENSION_get_object(void)
 {
-#if !defined(NO_FILESYSTEM) && defined (OPENSSL_ALL)
+#if !defined(NO_FILESYSTEM) && defined(OPENSSL_ALL) && !defined(NO_RSA)
     WOLFSSL_X509* x509;
     WOLFSSL_X509_EXTENSION* ext;
     WOLFSSL_ASN1_OBJECT* o;
@@ -39052,7 +39064,7 @@ static void test_wolfSSL_X509_EXTENSION_get_object(void)
 
 static void test_wolfSSL_X509_EXTENSION_get_data(void)
 {
-#if !defined(NO_FILESYSTEM) && defined (OPENSSL_ALL)
+#if !defined(NO_FILESYSTEM) && defined(OPENSSL_ALL) && !defined(NO_RSA)
     WOLFSSL_X509* x509;
     WOLFSSL_X509_EXTENSION* ext;
     WOLFSSL_ASN1_STRING* str;
@@ -39074,7 +39086,7 @@ static void test_wolfSSL_X509_EXTENSION_get_data(void)
 
 static void test_wolfSSL_X509_EXTENSION_get_critical(void)
 {
-#if !defined(NO_FILESYSTEM) && defined (OPENSSL_ALL)
+#if !defined(NO_FILESYSTEM) && defined(OPENSSL_ALL) && !defined(NO_RSA)
     WOLFSSL_X509* x509;
     WOLFSSL_X509_EXTENSION* ext;
     FILE* file;
@@ -39097,7 +39109,8 @@ static void test_wolfSSL_X509_EXTENSION_get_critical(void)
 
 static void test_wolfSSL_X509V3_EXT_print(void)
 {
-#if !defined(NO_FILESYSTEM) && defined (OPENSSL_ALL) && !defined(NO_BIO)
+#if !defined(NO_FILESYSTEM) && defined(OPENSSL_ALL) && !defined(NO_BIO) && \
+    !defined(NO_RSA)
     printf(testingFmt, "wolfSSL_X509V3_EXT_print");
 
     {
@@ -39172,7 +39185,7 @@ static void test_wolfSSL_X509V3_EXT_print(void)
 
 static void test_wolfSSL_X509_cmp(void)
 {
-#if defined(OPENSSL_ALL)
+#if defined(OPENSSL_ALL) && !defined(NO_RSA)
     FILE* file1;
     FILE* file2;
     WOLFSSL_X509* cert1;
@@ -39284,7 +39297,8 @@ static void test_wolfSSL_i2d_PrivateKey(void)
 
 static void test_wolfSSL_OCSP_id_get0_info(void)
 {
-#if defined(OPENSSL_ALL) && defined(HAVE_OCSP) && !defined(NO_FILESYSTEM)
+#if defined(OPENSSL_ALL) && defined(HAVE_OCSP) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_RSA)
     X509* cert;
     X509* issuer;
     OCSP_CERTID* id;
@@ -40714,7 +40728,8 @@ static void test_wolfSSL_PEM_write_bio_PKCS7(void)
 #ifdef HAVE_SMIME
 static void test_wolfSSL_SMIME_read_PKCS7(void)
 {
-#if defined(OPENSSL_ALL) && defined(HAVE_PKCS7) && !defined(NO_FILESYSTEM)
+#if defined(OPENSSL_ALL) && defined(HAVE_PKCS7) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_RSA)
     PKCS7* pkcs7 = NULL;
     BIO* bio = NULL;
     BIO* bcont = NULL;
@@ -42018,7 +42033,8 @@ static void test_wolfSSL_X509_CRL(void)
 
 static void test_wolfSSL_X509_load_crl_file(void)
 {
-#if defined(OPENSSL_EXTRA) && defined(HAVE_CRL) && !defined(NO_FILESYSTEM)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_CRL) && !defined(NO_FILESYSTEM) && \
+    !defined(NO_RSA)
     int i;
     char pem[][100] = {
         "./certs/crl/crl.pem",
@@ -42107,7 +42123,8 @@ static void test_wolfSSL_X509_load_crl_file(void)
 
 static void test_wolfSSL_d2i_X509_REQ(void)
 {
-#if defined(WOLFSSL_CERT_REQ) && (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA))
+#if defined(WOLFSSL_CERT_REQ) && !defined(NO_RSA) && \
+    (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA))
     /* ./certs/csr.signed.der, ./certs/csr.ext.der, and ./certs/csr.attr.der were
      * generated by libest
      * ./certs/csr.attr.der contains sample attributes
@@ -42669,7 +42686,7 @@ static void test_wolfssl_EVP_aes_gcm(void)
 #ifndef NO_BIO
 static void test_wolfSSL_PEM_X509_INFO_read_bio(void)
 {
-#if defined(OPENSSL_ALL) && !defined(NO_FILESYSTEM)
+#if defined(OPENSSL_ALL) && !defined(NO_FILESYSTEM) && !defined(NO_RSA)
     BIO* bio;
     X509_INFO* info;
     STACK_OF(X509_INFO)* sk;
@@ -42820,7 +42837,7 @@ static void test_wolfSSL_ASN1_INTEGER_set(void)
 static void test_wolfSSL_X509_STORE_get1_certs(void)
 {
 #if defined(OPENSSL_EXTRA) && defined(WOLFSSL_SIGNER_DER_CERT) && \
-    !defined(NO_FILESYSTEM)
+    !defined(NO_FILESYSTEM) && !defined(NO_RSA)
     X509_STORE_CTX *storeCtx;
     X509_STORE *store;
     X509 *caX509;
@@ -43923,7 +43940,7 @@ static int test_various_pathlen_chains(void)
 }
 #endif /* !NO_RSA && !NO_SHA && !NO_FILESYSTEM && !NO_CERTS */
 
-#ifdef HAVE_KEYING_MATERIAL
+#if defined(HAVE_KEYING_MATERIAL) && defined(HAVE_IO_TESTS_DEPENDENCIES)
 static int test_export_keying_material_cb(WOLFSSL_CTX *ctx, WOLFSSL *ssl)
 {
     byte ekm[100] = {0};
@@ -44490,7 +44507,7 @@ static void test_CONF_CTX_CMDLINE(void)
     
     /* cmd Certificate and Private Key*/
     {
-    #ifndef NO_CERTS
+    #if !defined(NO_CERTS) && !defined(NO_RSA)
         const char*  ourCert = svrCertFile;
         const char*  ourKey  = svrKeyFile;
         
@@ -44526,7 +44543,7 @@ static void test_CONF_CTX_CMDLINE(void)
     /* cmd DH parameter */
     {
     #if !defined(NO_DH) && !defined(NO_BIO)
-        const char* ourdhcert = "./certs/dh4096.pem";
+        const char* ourdhcert = "./certs/dh2048.pem";
         
         AssertIntEQ(SSL_CONF_cmd(cctx, "-dhparam", NULL), 
                                                         -3);
@@ -44570,7 +44587,7 @@ static void test_CONF_CTX_FILE(void)
     
     /* cmd Certificate and Private Key*/
     {
-    #ifndef NO_CERTS
+    #if !defined(NO_CERTS) && !defined(NO_RSA)
         const char*  ourCert = svrCertFile;
         const char*  ourKey  = svrKeyFile;
         
@@ -45271,7 +45288,7 @@ void ApiTest(void)
 #endif
 
 
-#ifdef HAVE_KEYING_MATERIAL
+#if defined(HAVE_KEYING_MATERIAL) && defined(HAVE_IO_TESTS_DEPENDENCIES)
     test_export_keying_material();
 #endif /* HAVE_KEYING_MATERIAL */
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -783,7 +783,9 @@ static const char* bench_desc_words[][14] = {
 #endif
 
 #if defined(BENCH_ASYM)
-#if defined(HAVE_ECC) || !defined(NO_RSA) || !defined(NO_DH)
+#if defined(HAVE_ECC) || !defined(NO_RSA) || !defined(NO_DH) || \
+    defined(HAVE_CURVE25519) || defined(HAVE_ED25519) || \
+    defined(HAVE_CURVE448) || defined(HAVE_ED448)
 static const char* bench_result_words2[][5] = {
     { "ops took", "sec"     , "avg" , "ops/sec", NULL },            /* 0 English  */
 #ifndef NO_MULTIBYTE_PRINT
@@ -1325,7 +1327,9 @@ static void bench_stats_sym_finish(const char* desc, int doAsync, int count,
 }
 
 #ifdef BENCH_ASYM
-#if defined(HAVE_ECC) || !defined(NO_RSA) || !defined(NO_DH)
+#if defined(HAVE_ECC) || !defined(NO_RSA) || !defined(NO_DH) || \
+    defined(HAVE_CURVE25519) || defined(HAVE_ED25519) || \
+    defined(HAVE_CURVE448) || defined(HAVE_ED448)
 static void bench_stats_asym_finish(const char* algo, int strength,
     const char* desc, int doAsync, int count, double start, int ret)
 {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -861,6 +861,13 @@
     #endif
 #endif
 
+#if !defined(WOLFCRYPT_ONLY) && defined(NO_PSK) && \
+    (defined(NO_DH) || !defined(HAVE_ANON)) && \
+    defined(NO_RSA) && !defined(HAVE_ECC) && \
+    !defined(HAVE_ED25519) && !defined(HAVE_ED448)
+   #error "No cipher suites avaialble with this build"
+#endif
+
 #ifdef WOLFSSL_MULTICAST
     #if defined(HAVE_NULL_CIPHER) && !defined(NO_SHA256)
         #define BUILD_WDM_WITH_NULL_SHA256

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2322,7 +2322,7 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 /* support for disabling PEM to DER */
-#if !defined(WOLFSSL_NO_PEM)
+#if !defined(WOLFSSL_NO_PEM) && !defined(NO_CODING)
     #undef  WOLFSSL_PEM_TO_DER
     #define WOLFSSL_PEM_TO_DER
 #endif

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -802,7 +802,10 @@ MP_API int sp_cmp_d(sp_int* a, sp_int_digit d);
 MP_API int sp_add_d(sp_int* a, sp_int_digit d, sp_int* r);
 MP_API int sp_sub_d(sp_int* a, sp_int_digit d, sp_int* r);
 MP_API int sp_mul_d(sp_int* a, sp_int_digit d, sp_int* r);
+#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
+    defined(WOLFSSL_KEY_GEN) || defined(HAVE_COMP_KEY)
 MP_API int sp_div_d(sp_int* a, sp_int_digit d, sp_int* r, sp_int_digit* rem);
+#endif
 #if defined(WOLFSSL_SP_MATH_ALL) || (defined(HAVE_ECC) && \
     defined(HAVE_COMP_KEY))
 MP_API int sp_mod_d(sp_int* a, const sp_int_digit d, sp_int_digit* r);
@@ -883,8 +886,12 @@ MP_API int sp_radix_size(mp_int* a, int radix, int* size);
 MP_API int sp_rand_prime(sp_int* r, int len, WC_RNG* rng, void* heap);
 MP_API int sp_prime_is_prime(mp_int* a, int t, int* result);
 MP_API int sp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng);
+#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
 MP_API int sp_gcd(sp_int* a, sp_int* b, sp_int* r);
+#endif
+#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN) && !defined(WC_RSA_BLINDING)
 MP_API int sp_lcm(sp_int* a, sp_int* b, sp_int* r);
+#endif
 
 WOLFSSL_API word32 CheckRunTimeFastMath(void);
 


### PR DESCRIPTION
./configure --enable-all --disable-rsa
./configure --disable-chacha --disable-asm
./configure --disable-rsa --disable-ecc --disable-dh --enable-curve25519
./configure --enable-cryptonly (and ed25519, curve448, ed448)
./configure --disable-tls13 --enable-psk --disable-rsa --disable-ecc
./configure --disable-dh C_EXTRA_FLAGS=-DWOLFSSL_STATIC_PSK
./configure --disable-oldtls --enable-psk -disable-rsa --disable-dh
./configure --disable-ecc --disable-asn C_EXTRA_FLAGS=-DWOLFSSL_STATIC_PSK
./configure --enable-lowresource --enable-singlethreaded --disable-asm
./configure --disable-errorstrings --disable-pkcs12 --disable-sha3 --disable-sha224
./configure --disable-sha384 --disable-sha512 --disable-sha --disable-md5
./configure --disable-aescbc --disable-chacha --disable-poly1305 --disable-coding
Various build combinations with WOLFSSL_SP_MATH and WOLFSSL_SP_MATH_ALL