### PR TITLE
Fixes for NXP LTC with RSA and Blinding

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2434,7 +2434,7 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
             /* unblind */
             if (ret == 0 && mp_mulmod(tmp, rndi, &key->n, tmp) != MP_OKAY)
                 ret = MP_MULMOD_E;
-        #endif   /* WC_RSA_BLINDING */
+        #endif /* WC_RSA_BLINDING */
 
             break;
         }

--- a/wolfssl/wolfcrypt/port/nxp/ksdk_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/ksdk_port.h
@@ -46,6 +46,7 @@ int ksdk_port_init(void);
 	int wolfcrypt_mp_mod(mp_int *a, mp_int *b, mp_int *c);
 	int wolfcrypt_mp_invmod(mp_int *a, mp_int *b, mp_int *c);
 	int wolfcrypt_mp_exptmod(mp_int *G, mp_int *X, mp_int *P, mp_int *Y);
+	int wolfcrypt_mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng);
 
     /* Exported mp_mulmod function */
     int mp_mulmod(mp_int *a, mp_int *b, mp_int *c, mp_int *d);


### PR DESCRIPTION
* Fix limit check for `mp_mulmod` using hardware vs software. Resolves issue when using `WC_RSA_BLINDING`.
* Fix for `int neg` being defined mid code in `mp_mulmod`.
* Fix for missing `wolfcrypt_mp_prime_is_prime_ex` def.
ZD 12096