### PR TITLE
Properly declare htons() and friends

### DIFF
--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -48,6 +48,9 @@
     #endif
 #endif
 
+#ifndef USE_WINDOWS_API
+    #include <arpa/inet.h>
+#endif
 
 #if defined(USE_WOLFSSL_IO) || defined(HAVE_HTTP_CLIENT)
 
@@ -155,7 +158,6 @@
                 && !defined(WOLFSSL_CONTIKI) && !defined(WOLFSSL_WICED) \
                 && !defined(WOLFSSL_GNRC) && !defined(WOLFSSL_RIOT_OS)
             #include <sys/socket.h>
-            #include <arpa/inet.h>
             #include <netinet/in.h>
             #include <netdb.h>
             #ifdef __PPU


### PR DESCRIPTION
Since 794cb5c7a9ec9495d9751a0397b4cf681909e5a5 both GCC and Clang issue `-Wimplicit-function-declaration` about `XHTONS()` a.k.a. `htons()` in `wolfssl/src/internal.c`:
```
In file included from /mariadb/10.6-merge/extra/wolfssl/wolfssl/wolfssl/ssl.h:153,
                 from /mariadb/10.6-merge/extra/wolfssl/wolfssl/wolfssl/internal.h:29,
                 from /mariadb/10.6-merge/extra/wolfssl/wolfssl/src/internal.c:73:
/mariadb/10.6-merge/extra/wolfssl/wolfssl/src/internal.c: In function ‘DefTicketEncCb’:
/mariadb/10.6-merge/extra/wolfssl/wolfssl/wolfssl/wolfio.h:620:23: warning: implicit declaration of function ‘htons’ [-Wimplicit-function-declaration]
  620 |     #define XHTONS(a) htons((a))
      |                       ^~~~~
/mariadb/10.6-merge/extra/wolfssl/wolfssl/src/internal.c:30263:19: note: in expansion of macro ‘XHTONS’
30263 |     word16 sLen = XHTONS(inLen);
      |                   ^~~~~~
```
I am not sure where this would best be fixed; I saw quite a few `#include <arpa/inet.h>` in other files. In my opinion, header files should `#include` what they build upon. If some header file includes many mutually ‘unrelated’ things, then maybe the header file should be split, if you think that having every compilation unit depend on `<arpa/inet.h>` is a bad idea.