### PR TITLE
Sniffer fixes and new sniffer key callback support

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -2797,11 +2797,11 @@ static int DoResume(SnifferSession* session, char* error)
                             session->sslServer->arrays->masterSecret, 0);
     }
     if (resume == NULL) {
-        /* a session id without resume is okay with hello_retry_request */
     #ifdef WOLFSSL_SNIFFER_STATS
-        INC_STAT(SnifferStats.sslStandardConns);
+        INC_STAT(SnifferStats.sslResumeMisses);
     #endif
-        return 0;
+        SetError(BAD_SESSION_RESUME_STR, error, session, FATAL_ERROR_STATE);
+        return -1;
     }
 
     /* make sure client has master secret too */

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -25,6 +25,7 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/wolfcrypt/wc_port.h>
 
 /* xctime */
@@ -2159,10 +2160,13 @@ static int SetupKeys(const byte* input, int* sslBytes, SnifferSession* session,
     DerBuffer* keyBuf;
 #ifdef HAVE_ECC
     int useEccCurveId = ECC_CURVE_DEF;
+#endif
+    int devId = INVALID_DEVID;
+
+#ifdef HAVE_ECC
     if (ksInfo && ksInfo->curve_id != 0)
         useEccCurveId = ksInfo->curve_id;
 #endif
-    int devId = INVALID_DEVID;
 #ifdef WOLF_CRYPTO_CB
     devId = CryptoDeviceId;
 #endif

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -2821,7 +2821,6 @@ static int DoResume(SnifferSession* session, char* error)
     Trace(SERVER_DID_RESUMPTION_STR);
 #ifdef WOLFSSL_SNIFFER_STATS
     INC_STAT(SnifferStats.sslResumedConns);
-    INC_STAT(SnifferStats.sslResumptionValid);
 #endif
     if (SetCipherSpecs(session->sslServer) != 0) {
         SetError(BAD_CIPHER_SPEC_STR, error, session, FATAL_ERROR_STATE);
@@ -3607,9 +3606,9 @@ static int ProcessFinished(const byte* input, int size, int* sslBytes,
             WOLFSSL_SESSION* sess = GetSession(session->sslServer, NULL, 0);
             if (sess == NULL) {
                 AddSession(session->sslServer);  /* don't re add */
-#ifdef WOLFSSL_SNIFFER_STATS
+            #ifdef WOLFSSL_SNIFFER_STATS
                 INC_STAT(SnifferStats.sslResumptionInserts);
-#endif
+            #endif
             }
             session->flags.cached = 1;
          }

--- a/sslSniffer/README.md
+++ b/sslSniffer/README.md
@@ -369,6 +369,32 @@ Return Values:
 * -1 if a problem occurred
 
 
+### ssl_SetKeyCallback
+
+This feature is enabled by default and will be called when a key is required for a session using static ephemeral keys with TLS v1.3.
+
+The public key being used will be provided allowing lookup of the corresponding private key.
+
+The `privKey` buffer is a dynamic buffer assigned via a call to setup a static ephemeral key via `ssl_SetNamedEphemeralKey` or `ssl_SetEphemeralKey`.
+
+```c
+typedef int (*SSLKeyCb)(void* vSniffer, int namedGroup,
+    const unsigned char* srvPub, unsigned int srvPubSz,
+    const unsigned char* cliPub, unsigned int cliPubSz,
+    unsigned char* privKey, unsigned int* privKeySz,
+    void* ctx, char* error);
+
+int ssl_SetKeyCallback(SSLKeyCb cb, void* ctx, char* error);
+```
+
+The parameter `vSniffer` is a typeless pointer to the current sniffer session (`SnifferSession`). The `namedGroup` is the TLS defined named groups like `WOLFSSL_ECC_SECP256R1` or `WOLFSSL_FFDHE_2048`. The server and client public key information are provided to lookup the private key to be used for this session. The loaded private key to be used will be passed in `key`. If a different key should be used it can optionally be returned in `privKey` and `privKeySz`.
+
+Return Values:
+
+* 0 on success
+* -1 if a problem occurred, the string error will hold a message describing the problem
+
+
 ## API Usage: SSL Statistics options
 
 For an example on the use of the sniffer stats option, search the source `snifftest.c` for `WOLFSSL_SNIFFER_STATS`.
@@ -460,7 +486,7 @@ typedef int (*SSLWatchCb)(void* vSniffer,
     void* ctx, char* error);
 ```
 
-The parameter `vSniffer` is a typeless pointer to the current sniffer session and is meant to be passed directly to the function `ssl_SetWatchKey`. `certHash` is a SHA-256 hash of the certificate sent by the server, and its size is `certHashSz`. A pointer to certificate message’s payload is provided in the parameter `certChain`, and the certificate chain’s size in `certChainSz`. This will be a list of pairs of 24-bit certificate sizes and raw DER certificates in network order from the wire. The application space callback context data is provided in parameter ctx and is set by the function `ssl_SetWatchKeyCtx`. Any error string is copied into parameter error. Your callback function can use these values to locate the appropriate private key and load it into the sniffer session with the function `ssl_SetWatchKey`.
+The parameter `vSniffer` is a typeless pointer to the current sniffer session and is meant to be passed directly to the function `ssl_SetWatchKey_file` or `ssl_SetWatchKey_buffer`. The `certHash` is a SHA-256 hash of the certificate sent by the server, and its size is `certHashSz`. A pointer to certificate message’s payload is provided in the parameter `certChain`, and the certificate chain’s size in `certChainSz`. This will be a list of pairs of 24-bit certificate sizes and raw DER certificates in network order from the wire. The application space callback context data is provided in parameter ctx and is set by the function `ssl_SetWatchKeyCtx`. Any error string is copied into parameter error. Your callback function can use these values to locate the appropriate private key and load it into the sniffer session with the function `ssl_SetWatchKey_file` or `ssl_SetWatchKey_buffer`.
 
 Return Values:
 

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -170,6 +170,8 @@ static void DumpStats(void)
             sslStats.sslResumedConns);
     printf("SSL Stats (sslEphemeralMisses):%lu\n",
             sslStats.sslEphemeralMisses);
+    printf("SSL Stats (sslResumptionInserts):%lu\n",
+            sslStats.sslResumptionInserts);
     printf("SSL Stats (sslResumeMisses):%lu\n",
             sslStats.sslResumeMisses);
     printf("SSL Stats (sslCiphersUnsupported):%lu\n",

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -366,6 +366,15 @@ static int load_key(const char* name, const char* server, int port,
     return ret;
 }
 
+static void TrimNewLine(char* str)
+{
+    word32 strSz = 0;
+    if (str)
+        strSz = (word32)XSTRLEN(str);
+    if (strSz > 0 && (str[strSz-1] == '\n' || str[strSz-1] == '\r'))
+        str[strSz-1] = '\0';
+}
+
 int main(int argc, char** argv)
 {
     int          ret = 0;
@@ -504,13 +513,10 @@ int main(int argc, char** argv)
         XMEMSET(keyFilesBuf, 0, sizeof(keyFilesBuf));
         XMEMSET(keyFilesUser, 0, sizeof(keyFilesUser));
         if (XFGETS(keyFilesUser, sizeof(keyFilesUser), stdin)) {
-            word32 strSz;
-            if (keyFilesUser[0] != '\r' && keyFilesUser[0] != '\n') {
+            TrimNewLine(keyFilesUser);
+            if (XSTRLEN(keyFilesUser) > 0) {
                 keyFilesSrc = keyFilesUser;
             }
-            strSz = (word32)XSTRLEN(keyFilesUser);
-            if (keyFilesUser[strSz-1] == '\n')
-                keyFilesUser[strSz-1] = '\0';
         }
         XSTRNCPY(keyFilesBuf, keyFilesSrc, sizeof(keyFilesBuf));
 
@@ -519,6 +525,7 @@ int main(int argc, char** argv)
         printf("Enter alternate SNI [default: none]: ");
         XMEMSET(cmdLineArg, 0, sizeof(cmdLineArg));
         if (XFGETS(cmdLineArg, sizeof(cmdLineArg), stdin)) {
+            TrimNewLine(cmdLineArg);
             if (XSTRLEN(cmdLineArg) > 0) {
                 sniName = cmdLineArg;
             }

--- a/tests/api.c
+++ b/tests/api.c
@@ -42068,17 +42068,14 @@ static int test_get_digit (void)
 /*
  * Testing wc_export_int
  */
-static int test_wc_export_int (void)
+static int test_wc_export_int(void)
 {
     int         ret = 0;
 #if defined(WOLFSSL_PUBLIC_MP)
     mp_int      mp;
-    byte        buf[256];
+    byte        buf[32];
     word32      keySz = (word32)sizeof(buf);
     word32      len = (word32)sizeof(buf);
-
-
-    int encType = WC_TYPE_UNSIGNED_BIN;
 
     printf(testingFmt, "wc_export_int()");
 
@@ -42086,24 +42083,39 @@ static int test_wc_export_int (void)
         ret = -1;
     }
     if (ret == 0) {
-        ret = wc_export_int(NULL, buf, &len, keySz, encType);
+        ret = mp_set_int(&mp, 1234);
+    }
+    if (ret == 0) {
+        ret = wc_export_int(NULL, buf, &len, keySz, WC_TYPE_UNSIGNED_BIN);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
     }
-    len = sizeof(buf)-1;
     if (ret == 0) {
-        ret = wc_export_int(&mp, buf, &len, keySz, encType);
+        len = sizeof(buf)-1;
+        ret = wc_export_int(&mp, buf, &len, keySz, WC_TYPE_UNSIGNED_BIN);
         if (ret == BUFFER_E) {
             ret = 0;
         }
     }
-    len = sizeof(buf);
     if (ret == 0) {
-        ret = wc_export_int(&mp, buf, &len, keySz, WC_TYPE_HEX_STR);
+        len = sizeof(buf);
+        ret = wc_export_int(&mp, buf, &len, keySz, WC_TYPE_UNSIGNED_BIN);
     }
     if (ret == 0) {
-        ret = wc_export_int(&mp, buf, &len, keySz, encType);
+        len = 4; /* test input too small */
+        ret = wc_export_int(&mp, buf, &len, 0, WC_TYPE_HEX_STR);
+        if (ret == BUFFER_E) {
+            ret = 0;
+        }
+    }
+    if (ret == 0) {
+        len = sizeof(buf);
+        ret = wc_export_int(&mp, buf, &len, 0, WC_TYPE_HEX_STR);
+        /* hex version of 1234 is 04D2 and should be 4 digits + 1 null */
+        if (ret == 0 && len != 5) {
+            ret = BAD_FUNC_ARG;
+        }
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1295,7 +1295,7 @@ static void bench_stats_sym_finish(const char* desc, int doAsync, int count,
         }
     }
 
-    /* caclulcate blocks per second */
+    /* calculate blocks per second */
     if (total > 0) {
         persec = (1 / total) * blocks;
     }

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -12722,7 +12722,8 @@ int sp_todecimal(sp_int* a, char* str)
 }
 #endif /* WOLFSSL_SP_MATH_ALL || WOLFSSL_KEY_GEN || HAVE_COMP_KEY */
 
-#if defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)
+#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
+    defined(WC_MP_TO_RADIX)
 /* Put the string version, big-endian, of a in str using the given radix.
  *
  * @param  [in]   a      SP integer to convert.
@@ -12755,9 +12756,10 @@ int sp_toradix(sp_int* a, char* str, int radix)
 
     return err;
 }
-#endif /* WOLFSSL_SP_MATH_ALL */
+#endif /* (WOLFSSL_SP_MATH_ALL && !WOLFSSL_RSA_VERIFY_ONLY) || WC_MP_TO_RADIX */
 
-#if defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)
+#if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
+    defined(WC_MP_TO_RADIX)
 /* Calculate the length of the string version, big-endian, of a using the given
  * radix.
  *
@@ -12848,7 +12850,7 @@ int sp_radix_size(sp_int* a, int radix, int* size)
 
     return err;
 }
-#endif /* WOLFSSL_SP_MATH_ALL && !WOLFSSL_RSA_VERIFY_ONLY */
+#endif /* (WOLFSSL_SP_MATH_ALL && !WOLFSSL_RSA_VERIFY_ONLY) || WC_MP_TO_RADIX */
 
 /***************************************
  * Prime number generation and checking.

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -183,8 +183,6 @@ typedef struct SSLStats
     unsigned long int sslDecryptedPackets;
     unsigned long int sslKeyMatches;
     unsigned long int sslEncryptedConns;
-
-    unsigned long int sslResumptionValid;
     unsigned long int sslResumptionInserts;
 } SSLStats;
 

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -25,6 +25,7 @@
 #define WOLFSSL_SNIFFER_H
 
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/asn_public.h>
 
 #ifdef _WIN32
     #ifdef SSL_SNIFFER_EXPORTS
@@ -199,7 +200,21 @@ SSL_SNIFFER_API int ssl_ReadStatistics(SSLStats* stats);
 WOLFSSL_API
 SSL_SNIFFER_API int ssl_ReadResetStatistics(SSLStats* stats);
 
+typedef int (*SSLKeyCb)(void* vSniffer, int namedGroup,
+    const unsigned char* srvPub, unsigned int srvPubSz,
+    const unsigned char* cliPub, unsigned int cliPubSz,
+    DerBuffer* privKey, void* cbCtx, char* error);
 
+#if defined(WOLFSSL_STATIC_EPHEMERAL) && defined(WOLFSSL_TLS13)
+/* macro indicating support for key callback */
+#undef  WOLFSSL_SNIFFER_KEY_CALLBACK
+#define WOLFSSL_SNIFFER_KEY_CALLBACK
+WOLFSSL_API 
+SSL_SNIFFER_API int ssl_SetKeyCallback(SSLKeyCb cb, void* cbCtx);
+#endif
+
+
+#ifdef WOLFSSL_SNIFFER_WATCH
 typedef int (*SSLWatchCb)(void* vSniffer,
                         const unsigned char* certHash,
                         unsigned int certHashSz,
@@ -226,29 +241,37 @@ WOLFSSL_API
 SSL_SNIFFER_API int ssl_SetWatchKey_file(void* vSniffer,
                         const char* keyFile, int keyType,
                         const char* password, char* error);
+#endif
 
-
+#ifdef WOLFSSL_SNIFFER_STORE_DATA_CB
 typedef int (*SSLStoreDataCb)(const unsigned char* decryptBuf,
         unsigned int decryptBufSz, unsigned int decryptBufOffset, void* ctx);
 
 WOLFSSL_API
 SSL_SNIFFER_API int ssl_SetStoreDataCallback(SSLStoreDataCb cb);
+#endif
 
+#ifdef WOLFSSL_SNIFFER_STORE_DATA_CB
 WOLFSSL_API
 SSL_SNIFFER_API int ssl_DecodePacketWithSessionInfoStoreData(
         const unsigned char* packet, int length, void* ctx,
         SSLInfo* sslInfo, char* error);
+#endif
 
-
+#ifdef WOLFSSL_SNIFFER_CHAIN_INPUT
 WOLFSSL_API
 SSL_SNIFFER_API int ssl_DecodePacketWithChain(void* vChain,
         unsigned int chainSz, unsigned char** data, char* error);
+#endif
 
-
+#if defined(WOLFSSL_SNIFFER_CHAIN_INPUT) && \
+    defined(WOLFSSL_SNIFFER_STORE_DATA_CB)
 WOLFSSL_API
 SSL_SNIFFER_API int ssl_DecodePacketWithChainSessionInfoStoreData(
         void* vChain, unsigned int chainSz, void* ctx, SSLInfo* sslInfo,
         char* error);
+#endif
+
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -881,7 +881,7 @@ MP_API int sp_to_unsigned_bin_at_pos(int o, sp_int* a, unsigned char* out);
 MP_API int sp_read_radix(sp_int* a, const char* in, int radix);
 MP_API int sp_tohex(sp_int* a, char* str);
 MP_API int sp_todecimal(mp_int* a, char* str);
-#ifdef WOLFSSL_SP_MATH_ALL
+#if defined(WOLFSSL_SP_MATH_ALL) || defined(WC_MP_TO_RADIX)
 MP_API int sp_toradix(mp_int* a, char* str, int radix);
 MP_API int sp_radix_size(mp_int* a, int radix, int* size);
 #endif


### PR DESCRIPTION
* Fix for secure renegotiation, which was not keeping handshake resources.
* Fix for sniffer stats on resume miss.
* Added NULL checks for case where handshake resources might be free'd to prevent possible use of NULL.
* Refactor the SNI client hello processing to not assume TLS header is in prior buffer (not there for decrypted handshake packets).
* New API `ssl_SetKeyCallback` with support indicated by `WOLFSSL_SNIFFER_KEY_CALLBACK`. Used with static ephemeral and TLS v1.3.
* Trace cleanup for custom error.
* Cleanup to remove duplicate stat `sslResumptionValid`. Add print of `sslResumptionInserts`.


ZD 12601 and ZD 12593