### PR TITLE
Timeout Fix

### DIFF
--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -163,7 +163,7 @@
     #define SNPRINTF snprintf
 
     #define XSELECT_WAIT(x,y) do { \
-        struct timeval tv = {(x),(y)}; \
+        struct timeval tv = {((x) + ((y) / 1000000)),((y) % 1000000)}; \
         select(0, NULL, NULL, NULL, &tv); \
     } while (0)
     #define XSLEEP_US(u) XSELECT_WAIT(0,u)


### PR DESCRIPTION
The macros setting up the timeout for the select used to timeout just multiplied the ms by 1000 to make us. The BSD select used on macOS doesn't like the us to be greater than 999999. Modified to carry the excess us over into the seconds.