### PR TITLE
Linux kernel module port update

### DIFF
--- a/linuxkm/Makefile
+++ b/linuxkm/Makefile
@@ -33,7 +33,7 @@ ifndef SRC_TOP
     SRC_TOP=$(shell dirname $(MODULE_TOP))
 endif
 
-WOLFSSL_CFLAGS=-DHAVE_CONFIG_H -I$(SRC_TOP) -DBUILDING_WOLFSSL $(AM_CFLAGS) $(CFLAGS) -Wno-declaration-after-statement -Wno-redundant-decls
+WOLFSSL_CFLAGS=-DHAVE_CONFIG_H -I$(SRC_TOP) -DBUILDING_WOLFSSL $(AM_CFLAGS) $(CFLAGS) -Wno-declaration-after-statement -Wno-redundant-decls -ffreestanding
 ifdef KERNEL_EXTRA_CFLAGS
     WOLFSSL_CFLAGS += $(KERNEL_EXTRA_CFLAGS)
 endif

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -82,6 +82,10 @@
     _Pragma("GCC diagnostic ignored \"-Wpointer-sign\"");
     _Pragma("GCC diagnostic ignored \"-Wbad-function-cast\"");
     _Pragma("GCC diagnostic ignored \"-Wdiscarded-qualifiers\"");
+    _Pragma("GCC diagnostic ignored \"-Wtype-limits\"");
+
+    /* suppress inclusion of stdint-gcc.h to avoid conflicts with Linux native include/linux/types.h: */
+    #define _GCC_STDINT_H
 
     #include <linux/kconfig.h>
     #include <linux/kernel.h>


### PR DESCRIPTION
add an explicit -ffreestanding to CFLAGS in linuxkm/Makefile, and in wc_port.h ifdef WOLFSSL_LINUXKM, ignore -Wtype-limits in Linux kernel header files (needed for kernel v5.13), and suppress inclusion of stdint-gcc.h.