### PR TITLE
Add support for tcpdump with wolfSSL.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4557,6 +4557,27 @@ then
     ENABLED_PSK=yes
 fi
 
+# tcpdump support
+AC_ARG_ENABLE([tcpdump],
+    [AS_HELP_STRING([--enable-tcpdump],[Enable tcpdump (default: disabled)])],
+    [ ENABLED_TCPDUMP=$enableval ],
+    [ ENABLED_TCPDUMP=no ]
+    )
+# tcpdump support requires all the features enabled within this conditional.
+if test "$ENABLED_TCPDUMP" = "yes"
+then
+    if test "x$ENABLED_OPENSSLEXTRA" = "xno" && test "x$ENABLED_OPENSSLCOEXIST" = "xno"
+    then
+        ENABLED_OPENSSLEXTRA="yes"
+        AM_CFLAGS="-DOPENSSL_EXTRA $AM_CFLAGS"
+    fi
+
+    if test "x$ENABLED_DES3" = "xno"
+    then
+        ENABLED_DES3="yes"
+    fi
+fi
+
 # libest Support
 AC_ARG_ENABLE([libest],
     [AS_HELP_STRING([--enable-libest],[Enable libest (default: disabled)])],
@@ -6684,6 +6705,7 @@ echo "   * wolfSentry:                 $ENABLED_WOLFSENTRY"
 echo "   * LIGHTY:                     $ENABLED_LIGHTY"
 echo "   * HAPROXY:                    $ENABLED_HAPROXY"
 echo "   * STUNNEL:                    $ENABLED_STUNNEL"
+echo "   * tcpdump:                    $ENABLED_TCPDUMP"
 echo "   * Apache httpd:               $ENABLED_APACHE_HTTPD"
 echo "   * NGINX:                      $ENABLED_NGINX"
 echo "   * ASIO:                       $ENABLED_ASIO"

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3279,6 +3279,7 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbyname(const char *name)
         {EVP_DES_ECB, "des-ecb"},
         {EVP_DES_EDE3_CBC, "DES3"},
         {EVP_DES_EDE3_CBC, "des3"},
+        {EVP_DES_EDE3_CBC, "3des"},
         {EVP_DES_EDE3_ECB, "DES-EDE3"},
         {EVP_DES_EDE3_ECB, "des-ede3"},
         {EVP_DES_EDE3_ECB, "des-ede3-ecb"},
@@ -3292,6 +3293,7 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbyname(const char *name)
         #ifdef WOLFSSL_AES_128
             {EVP_AES_128_CBC, "AES128-CBC"},
             {EVP_AES_128_CBC, "aes128-cbc"},
+            {EVP_AES_128_CBC, "aes128"},
         #endif
         #ifdef WOLFSSL_AES_192
             {EVP_AES_192_CBC, "AES192-CBC"},
@@ -3300,6 +3302,7 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbyname(const char *name)
         #ifdef WOLFSSL_AES_256
             {EVP_AES_256_CBC, "AES256-CBC"},
             {EVP_AES_256_CBC, "aes256-cbc"},
+            {EVP_AES_256_CBC, "aes256"},
         #endif
     #endif
     #ifdef HAVE_AES_ECB


### PR DESCRIPTION
See tcpdump port up for review here: https://github.com/wolfSSL/osp/pull/59.