### PR TITLE
Use correct DES IV size when using FIPS v2.

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -306,7 +306,13 @@ int SetCipherSpecs(WOLFSSL* ssl)
         ssl->specs.static_ecdh           = 0;
         ssl->specs.key_size              = DES3_KEY_SIZE;
         ssl->specs.block_size            = DES_BLOCK_SIZE;
+/* DES_IV_SIZE is incorrectly 16 in FIPS v2. It should be 8, same as the
+ * block size. */
+#if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION == 2)
+        ssl->specs.iv_size               = DES_BLOCK_SIZE;
+#else
         ssl->specs.iv_size               = DES_IV_SIZE;
+#endif
 
         break;
 #endif
@@ -468,7 +474,11 @@ int SetCipherSpecs(WOLFSSL* ssl)
         ssl->specs.static_ecdh           = 0;
         ssl->specs.key_size              = DES3_KEY_SIZE;
         ssl->specs.block_size            = DES_BLOCK_SIZE;
+#if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION == 2)
+        ssl->specs.iv_size               = DES_BLOCK_SIZE;
+#else
         ssl->specs.iv_size               = DES_IV_SIZE;
+#endif
 
         break;
 #endif
@@ -732,7 +742,11 @@ int SetCipherSpecs(WOLFSSL* ssl)
         ssl->specs.static_ecdh           = 1;
         ssl->specs.key_size              = DES3_KEY_SIZE;
         ssl->specs.block_size            = DES_BLOCK_SIZE;
+#if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION == 2)
+        ssl->specs.iv_size               = DES_BLOCK_SIZE;
+#else
         ssl->specs.iv_size               = DES_IV_SIZE;
+#endif
 
         break;
 #endif
@@ -766,7 +780,11 @@ int SetCipherSpecs(WOLFSSL* ssl)
         ssl->specs.static_ecdh           = 1;
         ssl->specs.key_size              = DES3_KEY_SIZE;
         ssl->specs.block_size            = DES_BLOCK_SIZE;
+#if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION == 2)
+        ssl->specs.iv_size               = DES_BLOCK_SIZE;
+#else
         ssl->specs.iv_size               = DES_IV_SIZE;
+#endif
 
         break;
 #endif
@@ -1276,7 +1294,11 @@ int SetCipherSpecs(WOLFSSL* ssl)
         ssl->specs.static_ecdh           = 0;
         ssl->specs.key_size              = DES3_KEY_SIZE;
         ssl->specs.block_size            = DES_BLOCK_SIZE;
+#if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION == 2)
+        ssl->specs.iv_size               = DES_BLOCK_SIZE;
+#else
         ssl->specs.iv_size               = DES_IV_SIZE;
+#endif
 
         break;
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -38772,7 +38772,7 @@ static void test_wolfSSL_EVP_CIPHER_CTX_set_iv(void)
 {
 #if defined(OPENSSL_ALL) && defined(HAVE_AESGCM) && !defined(NO_DES3)
     byte key[DES3_KEY_SIZE] = {0};
-    byte iv[DES_IV_SIZE] = {0};
+    byte iv[DES_BLOCK_SIZE] = {0};
     int ivLen, keyLen;
     EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
     const EVP_CIPHER *init = EVP_des_ede3_cbc();

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -10965,12 +10965,22 @@ int wc_EncryptedInfoGet(EncryptedInfo* info, const char* cipherInfo)
     if (XSTRNCMP(cipherInfo, kEncTypeDes, XSTRLEN(kEncTypeDes)) == 0) {
         info->cipherType = WC_CIPHER_DES;
         info->keySz = DES_KEY_SIZE;
+/* DES_IV_SIZE is incorrectly 16 in FIPS v2. It should be 8, same as the
+ * block size. */
+#if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION == 2)
+        if (info->ivSz == 0) info->ivSz  = DES_BLOCK_SIZE;
+#else
         if (info->ivSz == 0) info->ivSz  = DES_IV_SIZE;
+#endif
     }
     else if (XSTRNCMP(cipherInfo, kEncTypeDes3, XSTRLEN(kEncTypeDes3)) == 0) {
         info->cipherType = WC_CIPHER_DES3;
         info->keySz = DES3_KEY_SIZE;
+#if defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION == 2)
+        if (info->ivSz == 0) info->ivSz  = DES_BLOCK_SIZE;
+#else
         if (info->ivSz == 0) info->ivSz  = DES_IV_SIZE;
+#endif
     }
     else
 #endif /* !NO_DES3 */


### PR DESCRIPTION
When using FIPS v2, des3.h will have `DES_IV_SIZE` incorrectly set to 16. This PR makes it so source files using `DES_IV_SIZE` use `DES_BLOCK_SIZE` instead when FIPS v2 is defined. See 5ca2ff187bab9e370ce6c40e2d480e971404d58f.