### PR TITLE
Fix for `wc_ecc_ctx_free` and heap hint

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -11171,8 +11171,10 @@ ecEncCtx* wc_ecc_ctx_new(int flags, WC_RNG* rng)
 void wc_ecc_ctx_free(ecEncCtx* ctx)
 {
     if (ctx) {
+        void* heap = ctx->heap;
         ForceZero(ctx, sizeof(ecEncCtx));
-        XFREE(ctx, ctx->heap, DYNAMIC_TYPE_ECC);
+        XFREE(ctx, heap, DYNAMIC_TYPE_ECC);
+        (void)heap;
     }
 }
 


### PR DESCRIPTION
Fixes #4246