### PR TITLE
Fixes for edge case builds with openssl all

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3425,17 +3425,16 @@ fi
 
 
 # OCSP
+if test "x$ENABLED_OPENSSLALL" = "xyes" || test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_LIGHTY" = "xyes"
+then
+    test "$enable_ocsp" = "" && enable_ocsp=yes
+fi
+
 AC_ARG_ENABLE([ocsp],
     [AS_HELP_STRING([--enable-ocsp],[Enable OCSP (default: disabled)])],
     [ ENABLED_OCSP=$enableval ],
-    [ ENABLED_OCSP=no ],
+    [ ENABLED_OCSP=no ]
     )
-
-if test "x$ENABLED_OPENSSLALL" = "xyes" || test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_LIGHTY" = "xyes"
-then
-    ENABLED_OCSP=yes
-fi
-
 if test "$ENABLED_OCSP" = "yes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_OCSP"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -50963,7 +50963,7 @@ int wolfSSL_sk_X509_OBJECT_push(WOLFSSL_STACK* sk, WOLFSSL_X509_OBJECT* obj)
     return wolfSSL_sk_push(sk, obj);
 }
 
-#ifndef NO_BIO
+#if !defined(NO_BIO) && !defined(NO_PWDBASED) && defined(HAVE_PKCS8)
 int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
                                           WOLFSSL_EVP_PKEY* pkey,
                                           const WOLFSSL_EVP_CIPHER* enc,
@@ -51153,8 +51153,6 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PKCS8PrivateKey_bio(WOLFSSL_BIO* bio,
     byte* der;
     int len;
     byte* p;
-    char password[NAME_SZ];
-    int passwordSz;
     word32 algId;
     WOLFSSL_EVP_PKEY* key;
 
@@ -51162,7 +51160,8 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PKCS8PrivateKey_bio(WOLFSSL_BIO* bio,
         return NULL;
 
     if (cb != NULL) {
-        passwordSz = cb(password, sizeof(password), PEM_PASS_READ, ctx);
+        char password[NAME_SZ];
+        int passwordSz = cb(password, sizeof(password), PEM_PASS_READ, ctx);
         if (passwordSz < 0) {
             XFREE(der, bio->heap, DYNAMIC_TYPE_OPENSSL);
             return NULL;
@@ -51174,7 +51173,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PKCS8PrivateKey_bio(WOLFSSL_BIO* bio,
             return NULL;
         }
 
-        XMEMSET(password, 0, passwordSz);
+        ForceZero(password, passwordSz);
     }
 
     p = der;
@@ -51183,7 +51182,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PKCS8PrivateKey_bio(WOLFSSL_BIO* bio,
     return key;
 }
 
-#endif /* !NO_BIO */
+#endif /* !NO_BIO && !NO_PWDBASED && HAVE_PKCS8 */
 
 /* Detect which type of key it is before decoding. */
 WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
@@ -51244,7 +51243,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
 
     return key;
 }
-#endif
+#endif /* OPENSSL_ALL */
 
 #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
     !defined(WOLFCRYPT_ONLY)

--- a/tests/api.c
+++ b/tests/api.c
@@ -22765,7 +22765,7 @@ static int test_wc_ecc_import_raw(void)
 static int test_wc_ecc_import_unsigned(void)
 {
     int         ret = 0;
-#if defined(HAVE_ECC) && !defined(NO_ECC256)  && !defined(HAVE_SELFTEST) && \
+#if defined(HAVE_ECC) && !defined(NO_ECC256) && !defined(HAVE_SELFTEST) && \
     (!defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && HAVE_FIPS_VERSION >= 2))
     ecc_key     key;
     const byte  qx[] = {
@@ -23858,7 +23858,7 @@ static int test_wc_ecc_is_valid_idx (void)
 static int test_wc_ecc_get_curve_id_from_oid (void)
 {
     int ret = 0;
-#if defined(HAVE_ECC) && !defined(NO_ECC256)  && !defined(HAVE_SELFTEST) && \
+#if defined(HAVE_ECC) && !defined(NO_ECC256) && !defined(HAVE_SELFTEST) && \
     !defined(HAVE_FIPS)
     const byte oid[] = {0x2A,0x86,0x48,0xCE,0x3D,0x03,0x01,0x07};
     word32 len = sizeof(oid);
@@ -27770,7 +27770,7 @@ static void test_wolfSSL_certs(void)
                                   sizeof_server_cert_der_2048), WOLFSSL_SUCCESS);
     #endif
 
-    #if !defined(NO_SHA) && !defined(NO_SHA256)
+    #if !defined(NO_SHA) && !defined(NO_SHA256) && !defined(NO_PWDBASED)
     /************* Get Digest of Certificate ******************/
     {
         byte   digest[64]; /* max digest size */
@@ -27785,7 +27785,7 @@ static void test_wolfSSL_certs(void)
         AssertIntEQ(X509_digest(NULL, wolfSSL_EVP_sha1(), digest, &digestSz),
                     WOLFSSL_FAILURE);
     }
-    #endif /* !NO_SHA && !NO_SHA256*/
+    #endif /* !NO_SHA && !NO_SHA256 && !NO_PWDBASED */
 
     /* test and checkout X509 extensions */
     bc = (BASIC_CONSTRAINTS*)X509_get_ext_d2i(x509ext, NID_basic_constraints,
@@ -33611,51 +33611,58 @@ static void test_wolfSSL_PKCS8_Compat(void)
 
 static void test_wolfSSL_PKCS8_d2i(void)
 {
-#ifndef HAVE_FIPS
+#if !defined(HAVE_FIPS) && defined(OPENSSL_EXTRA)
     /* This test ends up using HMAC as a part of PBKDF2, and HMAC
      * requires a 12 byte password in FIPS mode. This test ends up
      * trying to use an 8 byte password. */
-#ifdef OPENSSL_ALL
-    WOLFSSL_EVP_PKEY* pkey = NULL;
+
 #ifndef NO_FILESYSTEM
     unsigned char pkcs8_buffer[2048];
     const unsigned char* p;
     int bytes;
     XFILE file;
+    WOLFSSL_EVP_PKEY* pkey = NULL;
 #ifndef NO_BIO
     BIO* bio;
-    #if defined(HAVE_ECC)
+    #if defined(OPENSSL_ALL) && \
+            ((!defined(NO_RSA) && !defined(NO_DES3)) || \
+               defined(HAVE_ECC)) && \
+        !defined(NO_BIO) && !defined(NO_PWDBASED) && defined(HAVE_PKCS8)
     WOLFSSL_EVP_PKEY* evpPkey = NULL;
     #endif
 #endif
-#endif
-    #ifndef NO_RSA
-        #ifndef NO_FILESYSTEM
+#ifndef NO_RSA
     const char rsaDerPkcs8File[] = "./certs/server-keyPkcs8.der";
     const char rsaPemPkcs8File[] = "./certs/server-keyPkcs8.pem";
-#ifndef NO_DES3
+    #ifndef NO_DES3
     const char rsaDerPkcs8EncFile[] = "./certs/server-keyPkcs8Enc.der";
-#endif
-        #endif
-        #ifdef USE_CERT_BUFFERS_1024
-    const unsigned char* rsa = (unsigned char*)server_key_der_1024;
-    int rsaSz = sizeof_server_key_der_1024;
-        #else
-    const unsigned char* rsa = (unsigned char*)server_key_der_2048;
-    int rsaSz = sizeof_server_key_der_2048;
-        #endif
     #endif
-    #ifdef HAVE_ECC
-    const unsigned char* ec = (unsigned char*)ecc_key_der_256;
-    int ecSz = sizeof_ecc_key_der_256;
-        #ifndef NO_FILESYSTEM
+#endif /* NO_RSA */
+#ifdef HAVE_ECC
     const char ecDerPkcs8File[] = "certs/ecc-keyPkcs8.der";
     const char ecPemPkcs8File[] = "certs/ecc-keyPkcs8.pem";
-#ifndef NO_DES3
+    #ifndef NO_DES3
     const char ecDerPkcs8EncFile[] = "certs/ecc-keyPkcs8Enc.der";
-#endif
-        #endif
     #endif
+#endif /* HAVE_ECC */
+#endif /* !NO_FILESYSTEM */
+
+#if defined(OPENSSL_ALL) && (!defined(NO_RSA) || defined(HAVE_ECC))
+#ifndef NO_RSA
+    #ifdef USE_CERT_BUFFERS_1024
+    const unsigned char* rsa = (unsigned char*)server_key_der_1024;
+    int rsaSz = sizeof_server_key_der_1024;
+    #else
+    const unsigned char* rsa = (unsigned char*)server_key_der_2048;
+    int rsaSz = sizeof_server_key_der_2048;
+    #endif
+#endif
+#ifdef HAVE_ECC
+    const unsigned char* ec = (unsigned char*)ecc_key_der_256;
+    int ecSz = sizeof_ecc_key_der_256;
+#endif
+#endif /* OPENSSL_ALL && (!NO_RSA || HAVE_ECC) */
+
 
 #ifndef NO_FILESYSTEM
    (void)pkcs8_buffer;
@@ -33667,40 +33674,51 @@ static void test_wolfSSL_PKCS8_d2i(void)
 #endif
 #endif
 
-    #ifndef NO_RSA
+#ifdef OPENSSL_ALL
+#ifndef NO_RSA
     /* Try to auto-detect normal RSA private key */
     AssertNotNull(pkey = d2i_AutoPrivateKey(NULL, &rsa, rsaSz));
-    wolfSSL_EVP_PKEY_free(pkey);
-    #endif
-    #ifdef HAVE_ECC
+    EVP_PKEY_free(pkey);
+#endif
+#ifdef HAVE_ECC
     /* Try to auto-detect normal EC private key */
     AssertNotNull(pkey = d2i_AutoPrivateKey(NULL, &ec, ecSz));
-    wolfSSL_EVP_PKEY_free(pkey);
-    #endif
-    #ifndef NO_FILESYSTEM
-        #ifndef NO_RSA
+    EVP_PKEY_free(pkey);
+#endif
+#endif /* OPENSSL_ALL */
+
+#ifndef NO_FILESYSTEM
+#ifndef NO_RSA
     /* Get DER encoded RSA PKCS#8 data. */
     file = XFOPEN(rsaDerPkcs8File, "rb");
     AssertTrue(file != XBADFILE);
+    XMEMSET(pkcs8_buffer, 0, sizeof(pkcs8_buffer));
     AssertIntGT((bytes = (int)XFREAD(pkcs8_buffer, 1, sizeof(pkcs8_buffer),
                                                                      file)), 0);
     XFCLOSE(file);
+
     p = pkcs8_buffer;
+#ifdef OPENSSL_ALL
     /* Try to decode - auto-detect key type. */
     AssertNotNull(pkey = d2i_AutoPrivateKey(NULL, &p, bytes));
+#else
+    AssertNotNull(pkey = d2i_PrivateKey(EVP_PKEY_RSA, NULL, &p, bytes));
+#endif
+
     /* Get PEM encoded RSA PKCS#8 data. */
     file = XFOPEN(rsaPemPkcs8File, "rb");
     AssertTrue(file != XBADFILE);
     AssertIntGT((bytes = (int)XFREAD(pkcs8_buffer, 1, sizeof(pkcs8_buffer),
                                                                      file)), 0);
     XFCLOSE(file);
-#ifndef NO_BIO
+#if defined(OPENSSL_ALL) && \
+    !defined(NO_BIO) && !defined(NO_PWDBASED) && defined(HAVE_PKCS8)
     AssertNotNull(bio = BIO_new(BIO_s_mem()));
     /* Write PKCS#8 PEM to BIO. */
     AssertIntEQ(PEM_write_bio_PKCS8PrivateKey(bio, pkey, NULL, NULL, 0, NULL,
                                                                   NULL), bytes);
     /* Compare file and written data */
-    AssertIntEQ(wolfSSL_BIO_get_mem_data(bio, &p), bytes);
+    AssertIntEQ(BIO_get_mem_data(bio, &p), bytes);
     AssertIntEQ(XMEMCMP(p, pkcs8_buffer, bytes), 0);
     BIO_free(bio);
 #ifndef NO_DES3
@@ -33711,51 +33729,63 @@ static void test_wolfSSL_PKCS8_d2i(void)
                           NULL, 0, PasswordCallBack, (void*)"yassl123"), bytes);
     AssertNotNull(evpPkey = PEM_read_bio_PrivateKey(bio, NULL, PasswordCallBack,
                                                             (void*)"yassl123"));
-    wolfSSL_EVP_PKEY_free(evpPkey);
+    EVP_PKEY_free(evpPkey);
     BIO_free(bio);
-#endif
-#endif /* !NO_BIO */
-    wolfSSL_EVP_PKEY_free(pkey);
+#endif /* !NO_DES3 */
+#endif /* !NO_BIO && !NO_PWDBASED && HAVE_PKCS8 */
+    EVP_PKEY_free(pkey);
 
     /* PKCS#8 encrypted RSA key */
 #ifndef NO_DES3
     file = XFOPEN(rsaDerPkcs8EncFile, "rb");
     AssertTrue(file != XBADFILE);
+    XMEMSET(pkcs8_buffer, 0, sizeof(pkcs8_buffer));
     AssertIntGT((bytes = (int)XFREAD(pkcs8_buffer, 1, sizeof(pkcs8_buffer),
                                                                      file)), 0);
     XFCLOSE(file);
-#ifndef NO_BIO
+#if defined(OPENSSL_ALL) && \
+    !defined(NO_BIO) && !defined(NO_PWDBASED) && defined(HAVE_PKCS8)
     AssertNotNull(bio = BIO_new_mem_buf((void*)pkcs8_buffer, bytes));
     AssertNotNull(pkey = d2i_PKCS8PrivateKey_bio(bio, NULL, PasswordCallBack,
                                                             (void*)"yassl123"));
-    wolfSSL_EVP_PKEY_free(pkey);
+    EVP_PKEY_free(pkey);
     BIO_free(bio);
-#endif
-#endif
-        #endif
-        #ifdef HAVE_ECC
+#endif /* OPENSSL_ALL && !NO_BIO && !NO_PWDBASED && HAVE_PKCS8 */
+#endif /* !NO_DES3 */
+#endif /* NO_RSA */
+
+#ifdef HAVE_ECC
     /* PKCS#8 encode EC key */
     file = XFOPEN(ecDerPkcs8File, "rb");
     AssertTrue(file != XBADFILE);
+    XMEMSET(pkcs8_buffer, 0, sizeof(pkcs8_buffer));
     AssertIntGT((bytes = (int)XFREAD(pkcs8_buffer, 1, sizeof(pkcs8_buffer),
                                                                      file)), 0);
     XFCLOSE(file);
+
     p = pkcs8_buffer;
+#ifdef OPENSSL_ALL
     /* Try to decode - auto-detect key type. */
     AssertNotNull(pkey = d2i_AutoPrivateKey(NULL, &p, bytes));
+#else
+    AssertNotNull(pkey = d2i_PrivateKey(EVP_PKEY_EC, NULL, &p, bytes));
+#endif
+
     /* Get PEM encoded RSA PKCS#8 data. */
     file = XFOPEN(ecPemPkcs8File, "rb");
     AssertTrue(file != XBADFILE);
+    XMEMSET(pkcs8_buffer, 0, sizeof(pkcs8_buffer));
     AssertIntGT((bytes = (int)XFREAD(pkcs8_buffer, 1, sizeof(pkcs8_buffer),
                                                                      file)), 0);
     XFCLOSE(file);
-#ifndef NO_BIO
+#if defined(OPENSSL_ALL) && \
+    !defined(NO_BIO) && !defined(NO_PWDBASED) && defined(HAVE_PKCS8)
     AssertNotNull(bio = BIO_new(BIO_s_mem()));
     /* Write PKCS#8 PEM to BIO. */
     AssertIntEQ(PEM_write_bio_PKCS8PrivateKey(bio, pkey, NULL, NULL, 0, NULL,
                                                                   NULL), bytes);
     /* Compare file and written data */
-    AssertIntEQ(wolfSSL_BIO_get_mem_data(bio, &p), bytes);
+    AssertIntEQ(BIO_get_mem_data(bio, &p), bytes);
     AssertIntEQ(XMEMCMP(p, pkcs8_buffer, bytes), 0);
     BIO_free(bio);
     AssertNotNull(bio = BIO_new(BIO_s_mem()));
@@ -33765,32 +33795,34 @@ static void test_wolfSSL_PKCS8_d2i(void)
                           NULL, 0, PasswordCallBack, (void*)"yassl123"), bytes);
     AssertNotNull(evpPkey = PEM_read_bio_PrivateKey(bio, NULL, PasswordCallBack,
                                                             (void*)"yassl123"));
-    wolfSSL_EVP_PKEY_free(evpPkey);
+    EVP_PKEY_free(evpPkey);
     BIO_free(bio);
-#endif
-    wolfSSL_EVP_PKEY_free(pkey);
+#endif /* OPENSSL_ALL && !NO_BIO && !NO_PWDBASED && HAVE_PKCS8 */
+    EVP_PKEY_free(pkey);
 
     /* PKCS#8 encrypted EC key */
 #ifndef NO_DES3
     file = XFOPEN(ecDerPkcs8EncFile, "rb");
     AssertTrue(file != XBADFILE);
+    XMEMSET(pkcs8_buffer, 0, sizeof(pkcs8_buffer));
     AssertIntGT((bytes = (int)XFREAD(pkcs8_buffer, 1, sizeof(pkcs8_buffer),
                                                                      file)), 0);
     XFCLOSE(file);
-#ifndef NO_BIO
+#if defined(OPENSSL_ALL) && \
+    !defined(NO_BIO) && !defined(NO_PWDBASED) && defined(HAVE_PKCS8)
     AssertNotNull(bio = BIO_new_mem_buf((void*)pkcs8_buffer, bytes));
     AssertNotNull(pkey = d2i_PKCS8PrivateKey_bio(bio, NULL, PasswordCallBack,
                                                             (void*)"yassl123"));
-    wolfSSL_EVP_PKEY_free(pkey);
+    EVP_PKEY_free(pkey);
     BIO_free(bio);
-#endif
-#endif
-        #endif
-    #endif
+#endif /* OPENSSL_ALL && !NO_BIO && !NO_PWDBASED && HAVE_PKCS8 */
+#endif /* !NO_DES3 */
+#endif /* HAVE_ECC */
+
+#endif /* !NO_FILESYSTEM */
 
     printf(resultFmt, passed);
-#endif
-#endif /* HAVE_FIPS */
+#endif /* HAVE_FIPS && OPENSSL_EXTRA */
 }
 
 #if defined(ERROR_QUEUE_PER_THREAD) && !defined(NO_ERROR_QUEUE) && \
@@ -39045,12 +39077,10 @@ static void test_wolfSSL_EVP_PKEY_get0_EC_KEY(void)
 #if defined(HAVE_ECC) && defined(OPENSSL_ALL)
     WOLFSSL_EVP_PKEY*   pkey;
 
-
     printf(testingFmt, "wolfSSL_EVP_PKEY_get0_EC_KEY");
 
-    AssertNotNull(pkey = wolfSSL_EVP_PKEY_new());
-    AssertNull(wolfSSL_EVP_PKEY_get0_EC_KEY(pkey));
-
+    AssertNotNull(pkey = EVP_PKEY_new());
+    AssertNull(EVP_PKEY_get0_EC_KEY(pkey));
     EVP_PKEY_free(pkey);
 
     printf(resultFmt, passed);
@@ -39058,7 +39088,7 @@ static void test_wolfSSL_EVP_PKEY_get0_EC_KEY(void)
 }
 static void test_wolfSSL_EVP_X_STATE(void)
 {
-#if defined(OPENSSL_ALL)  && !defined(NO_DES3)  && !defined(NO_RC4)
+#if defined(OPENSSL_ALL) && !defined(NO_DES3) && !defined(NO_RC4)
 
     byte key[DES3_KEY_SIZE] = {0};
     byte iv[DES_IV_SIZE] = {0};
@@ -39094,7 +39124,7 @@ static void test_wolfSSL_EVP_X_STATE(void)
 }
 static void test_wolfSSL_EVP_X_STATE_LEN(void)
 {
-#if defined(OPENSSL_ALL)  && !defined(NO_DES3)  && !defined(NO_RC4)
+#if defined(OPENSSL_ALL) && !defined(NO_DES3) && !defined(NO_RC4)
 
     byte key[DES3_KEY_SIZE] = {0};
     byte iv[DES_IV_SIZE] = {0};
@@ -39934,7 +39964,11 @@ static void test_wolfSSL_X509V3_EXT(void) {
 #endif
     AssertNotNull(adObj = ad->method);
     /* Make sure nid is OCSP */
+    #ifdef HAVE_OCSP
     AssertIntEQ(wolfSSL_OBJ_obj2nid(adObj), AIA_OCSP_OID);
+    #else
+    AssertIntEQ(wolfSSL_OBJ_obj2nid(adObj), -1);
+    #endif
 
     /* GENERAL_NAME stores URI as an ASN1_STRING */
     AssertNotNull(gn = ad->location);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2245,11 +2245,15 @@ extern void uITRON4_free(void *p) ;
     #ifndef OPENSSL_EXTRA
         #define OPENSSL_EXTRA
     #endif
-    #ifndef HAVE_SESSION_TICKET
+    /* Session Tickets will be enabled when --enable-opensslall is used.
+     * Time is required for ticket expiration checking */
+    #if !defined(HAVE_SESSION_TICKET) && !defined(NO_ASN_TIME)
         #define HAVE_SESSION_TICKET
     #endif
+    /* OCSP will be enabled in configure.ac when --enable-opensslall is used,
+     * but do not force all users to have it enabled. */
     #ifndef HAVE_OCSP
-        #define HAVE_OCSP
+        /*#define HAVE_OCSP*/
     #endif
     #ifndef KEEP_OUR_CERT
         #define KEEP_OUR_CERT
@@ -2266,14 +2270,14 @@ extern void uITRON4_free(void *p) ;
 
 /* both CURVE and ED small math should be enabled */
 #ifdef CURVED25519_SMALL
-        #define CURVE25519_SMALL
-        #define ED25519_SMALL
+    #define CURVE25519_SMALL
+    #define ED25519_SMALL
 #endif
 
 /* both CURVE and ED small math should be enabled */
 #ifdef CURVED448_SMALL
-        #define CURVE448_SMALL
-        #define ED448_SMALL
+    #define CURVE448_SMALL
+    #define ED448_SMALL
 #endif
 
 


### PR DESCRIPTION
* Fixes build issues around PWDBASED, PKCS8 and RSA/ECC enables.
* Do not force OCSP on for `OPENSSL_ALL`, since `ocsp.c` may not be compiled. Instead let configure.ac handle it.
* Improvements to the `test_wolfSSL_PKCS8_d2i`.
Related to #4241