### PR TITLE
Added RSA Public DER export without header (plus doc / code cleanups)

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -7818,7 +7818,6 @@ WOLFSSL_API void wolfSSL_SetFuzzerCb(WOLFSSL* ssl, CallbackFuzzer cbf, void* fCt
 
     \sa ForceZero
     \sa wc_RNG_GenerateBlock
-    \sa XMEMCPY
 */
 WOLFSSL_API int   wolfSSL_DTLS_SetCookieSecret(WOLFSSL*,
                                                const unsigned char*,

--- a/doc/dox_comments/header_files/wolfio.h
+++ b/doc/dox_comments/header_files/wolfio.h
@@ -35,9 +35,9 @@
     }
     \endcode
 
-    \sa wolfSSL_dtls_get_current_timeout
-    \sa TranslateReturnCode
-    \sa RECV_FUNCTION
+    \sa EmbedSend
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_SSLSetIORecv
 */
 WOLFSSL_API int EmbedReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 
@@ -73,11 +73,9 @@ WOLFSSL_API int EmbedReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
     }
     \endcode
 
-    \sa TranslateReturnCode
-    \sa SEND_FUNCTION
-    \sa LastError
-    \sa InitSSL_Ctx
-    \sa LastError
+    \sa EmbedReceive
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_SSLSetIOSend
 */
 WOLFSSL_API int EmbedSend(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 
@@ -112,9 +110,10 @@ WOLFSSL_API int EmbedSend(WOLFSSL* ssl, char* buf, int sz, void* ctx);
     }
     \endcode
 
-    \sa TranslateReturnCode
-    \sa RECVFROM_FUNCTION
-    \sa Setsockopt
+    \sa EmbedSendTo
+    \sa wolfSSL_CTX_SetIORecv
+    \sa wolfSSL_SSLSetIORecv
+    \sa wolfSSL_dtls_get_current_timeout
 */
 WOLFSSL_API int EmbedReceiveFrom(WOLFSSL* ssl, char* buf, int sz, void*);
 
@@ -153,9 +152,9 @@ WOLFSSL_API int EmbedReceiveFrom(WOLFSSL* ssl, char* buf, int sz, void*);
     }
     \endcode
 
-    \sa LastError
-    \sa EmbedSend
-    \sa EmbedReceive
+    \sa EmbedReceiveFrom
+    \sa wolfSSL_CTX_SetIOSend
+    \sa wolfSSL_SSLSetIOSend
 */
 WOLFSSL_API int EmbedSendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 
@@ -188,10 +187,7 @@ WOLFSSL_API int EmbedSendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
     }
     \endcode
 
-    \sa wc_ShaHash
-    \sa EmbedGenerateCookie
-    \sa XMEMCPY
-    \sa XMEMSET
+    \sa wolfSSL_CTX_SetGenCookie
 */
 WOLFSSL_API int EmbedGenerateCookie(WOLFSSL* ssl, unsigned char* buf,
                                            int sz, void*);
@@ -212,7 +208,9 @@ WOLFSSL_API int EmbedGenerateCookie(WOLFSSL* ssl, unsigned char* buf,
     EmbedOcspRespFree(ctx, resp);
     \endcode
 
-    \sa XFREE
+    \sa wolfSSL_CertManagerSetOCSP_Cb
+    \sa wolfSSL_CertManagerEnableOCSPStapling
+    \sa wolfSSL_CertManagerEnableOCSP
 */
 WOLFSSL_API void EmbedOcspRespFree(void*, unsigned char*);
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -16859,8 +16859,6 @@ static int test_wc_RsaKeyToPublicDer (void)
         }
     }
 
-    #if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
-        (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION != 2)))
     if (ret == 0) {
         /* test getting size only */
         ret = wc_RsaKeyToPublicDer_ex(&key, NULL, derLen, 0);
@@ -16875,7 +16873,6 @@ static int test_wc_RsaKeyToPublicDer (void)
             ret = WOLFSSL_FATAL_ERROR;
         }
     }
-    #endif
 
     #ifndef HAVE_USER_RSA
         /* Pass in bad args. */

--- a/tests/api.c
+++ b/tests/api.c
@@ -16859,6 +16859,24 @@ static int test_wc_RsaKeyToPublicDer (void)
         }
     }
 
+    #if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
+        (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION != 2)))
+    if (ret == 0) {
+        /* test getting size only */
+        ret = wc_RsaKeyToPublicDer_ex(&key, NULL, derLen, 0);
+        if (ret >= 0)
+            ret = 0;
+    }
+    if (ret == 0) {
+        ret = wc_RsaKeyToPublicDer_ex(&key, der, derLen, 0);
+        if (ret >= 0) {
+            ret = 0;
+        } else {
+            ret = WOLFSSL_FATAL_ERROR;
+        }
+    }
+    #endif
+
     #ifndef HAVE_USER_RSA
         /* Pass in bad args. */
         if (ret == 0) {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -12065,55 +12065,7 @@ static int SetRsaPublicKey(byte* output, RsaKey* key,
 #if !defined(NO_RSA) && (defined(WOLFSSL_CERT_GEN) || defined(OPENSSL_EXTRA))
 int wc_RsaPublicKeyDerSize(RsaKey* key, int with_header)
 {
-    int  idx = 0;
-    int  nSz, eSz, seqSz, bitStringSz, algoSz;
-
-    if (key == NULL)
-        return BAD_FUNC_ARG;
-
-    /* n */
-#ifdef HAVE_USER_RSA
-    nSz = SetASNIntRSA(key->n, NULL);
-#else
-    nSz = SetASNIntMP(&key->n, MAX_RSA_INT_SZ, NULL);
-#endif
-    if (nSz < 0) {
-        return nSz;
-    }
-
-    /* e */
-#ifdef HAVE_USER_RSA
-    eSz = SetASNIntRSA(key->e, NULL);
-#else
-    eSz = SetASNIntMP(&key->e, MAX_RSA_INT_SZ, NULL);
-#endif
-    if (eSz < 0) {
-        return eSz;
-    }
-
-    seqSz  = SetSequence(nSz + eSz, NULL);
-
-    /* headers */
-    if (with_header) {
-        algoSz = SetAlgoID(RSAk, NULL, oidKeyType, 0);
-        bitStringSz = SetBitString(seqSz + nSz + eSz, 0, NULL);
-
-        idx += SetSequence(nSz + eSz + seqSz + bitStringSz + algoSz, NULL);
-
-        /* algo */
-        idx += algoSz;
-        /* bit string */
-        idx += bitStringSz;
-    }
-
-    /* seq */
-    idx += seqSz;
-    /* n */
-    idx += nSz;
-    /* e */
-    idx += eSz;
-
-    return idx;
+    return SetRsaPublicKey(NULL, key, 0, with_header);
 }
 
 #endif /* !NO_RSA && WOLFSSL_CERT_GEN */
@@ -12225,6 +12177,13 @@ int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen)
     return SetRsaPublicKey(output, key, inLen, 1);
 }
 
+/* Returns public DER version of the RSA key. If with_header is 0 then only a 
+ * seq + n + e is returned in ASN.1 DER format */
+int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
+    int with_header)
+{
+    return SetRsaPublicKey(output, key, inLen, with_header);
+}
 #endif /* (WOLFSSL_KEY_GEN || OPENSSL_EXTRA) && !NO_RSA && !HAVE_USER_RSA */
 
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3542,6 +3542,7 @@ int wc_RsaPSS_CheckPadding(const byte* in, word32 inSz, byte* sig,
  * saltLen   Length of salt used. RSA_PSS_SALT_LEN_DEFAULT (-1) indicates salt
  *           length is the same as the hash length. RSA_PSS_SALT_LEN_DISCOVER
  *           indicates salt length is determined from the data.
+ * bits      Can be used to calculate salt size in FIPS case
  * returns BAD_PADDING_E when the PSS data is invalid, BAD_FUNC_ARG when
  * NULL is passed in to in or sig or inSz is not the same as the hash
  * algorithm length and 0 on success.

--- a/wolfcrypt/user-crypto/src/rsa.c
+++ b/wolfcrypt/user-crypto/src/rsa.c
@@ -2769,6 +2769,13 @@ int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen)
     return SetRsaPublicKey(output, key, inLen, 1);
 }
 
+/* Returns public DER version of the RSA key. If with_header is 0 then only a 
+ * seq + n + e is returned in ASN.1 DER format */
+int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
+    int with_header)
+{
+    return SetRsaPublicKey(output, key, inLen, with_header);
+}
 
 #endif /* WOLFSSL_KEY_GEN || OPENSSL_EXTRA */
 

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -521,8 +521,15 @@ WOLFSSL_API void wc_FreeDer(DerBuffer** pDer);
     #if !defined(HAVE_USER_RSA)
     WOLFSSL_API int wc_RsaPublicKeyDecode_ex(const byte* input, word32* inOutIdx,
         word32 inSz, const byte** n, word32* nSz, const byte** e, word32* eSz);
+    /* For FIPS v1/v2 and selftest this is in rsa.h */
+    #if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
+        (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION > 2)))
+    WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen);
+    #endif
     #endif
     WOLFSSL_API int wc_RsaPublicKeyDerSize(RsaKey* key, int with_header);
+    WOLFSSL_API int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
+        int with_header);
 #endif
 
 #ifndef NO_DSA

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -214,7 +214,7 @@ struct RsaKey {
     #define WC_RSAKEY_TYPE_DEFINED
 #endif
 
-#endif /*HAVE_FIPS */
+#endif /* HAVE_FIPS */
 
 WOLFSSL_API int  wc_InitRsaKey(RsaKey* key, void* heap);
 WOLFSSL_API int  wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId);
@@ -354,10 +354,6 @@ WOLFSSL_API int wc_RsaExportKey(RsaKey* key,
                                 byte* d, word32* dSz,
                                 byte* p, word32* pSz,
                                 byte* q, word32* qSz);
-
-WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen);
-WOLFSSL_API int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
-    int with_header);
 
 #ifdef WOLFSSL_KEY_GEN
     WOLFSSL_API int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng);

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -332,13 +332,13 @@ WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
 
 WOLFSSL_API int  wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
                    word32 outLen, RsaKey* key, WC_RNG* rng, int type,
-                   enum wc_HashType hash, int mgf, byte* label, word32 lableSz);
+                   enum wc_HashType hash, int mgf, byte* label, word32 labelSz);
 WOLFSSL_API int  wc_RsaPrivateDecrypt_ex(const byte* in, word32 inLen,
                    byte* out, word32 outLen, RsaKey* key, int type,
-                   enum wc_HashType hash, int mgf, byte* label, word32 lableSz);
+                   enum wc_HashType hash, int mgf, byte* label, word32 labelSz);
 WOLFSSL_API int  wc_RsaPrivateDecryptInline_ex(byte* in, word32 inLen,
                       byte** out, RsaKey* key, int type, enum wc_HashType hash,
-                      int mgf, byte* label, word32 lableSz);
+                      int mgf, byte* label, word32 labelSz);
 #if defined(WC_RSA_DIRECT) || defined(WC_RSA_NO_PADDING)
 WOLFSSL_API int wc_RsaDirect(byte* in, word32 inLen, byte* out, word32* outSz,
                    RsaKey* key, int type, WC_RNG* rng);
@@ -355,7 +355,9 @@ WOLFSSL_API int wc_RsaExportKey(RsaKey* key,
                                 byte* p, word32* pSz,
                                 byte* q, word32* qSz);
 
-WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey*, byte* output, word32 inLen);
+WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen);
+WOLFSSL_API int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
+    int with_header);
 
 #ifdef WOLFSSL_KEY_GEN
     WOLFSSL_API int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng);


### PR DESCRIPTION
* Added public API `wc_RsaKeyToPublicDer_ex` to allow getting RSA public key without ASN.1 header (can return only seq + n + e). Related to PR #4068.
* Consolidate duplicate code in `wc_RsaPublicKeyDerSize`.
* Cleanup documentation for RSA and wolfIO.