### PR TITLE
Add support for libssh2.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -773,6 +773,7 @@ AC_ARG_ENABLE([mcast],
 
 # List of open source project defines using our openssl compatibility layer:
 # bind dns (--enable-bind) WOLFSSL_BIND
+# libssh2 (--enable-libssh2)
 # openssh (--enable-openssh) WOLFSSL_OPENSSH
 # openvpn (--enable-openvpn) WOLFSSL_OPENVPN
 # nginix (--enable-nginx) WOLFSSL_NGINX
@@ -798,6 +799,11 @@ AC_ARG_ENABLE([bind],
     [AS_HELP_STRING([--enable-bind],[Enable Bind DNS compatibility build (default: disabled)])],
     [ENABLED_BIND=$enableval],
     [ENABLED_BIND=no])
+
+AC_ARG_ENABLE([libssh2],
+    [AS_HELP_STRING([--enable-libssh2],[Enable libssh2 compatibility build (default: disabled)])],
+    [ENABLED_LIBSSH2=$enableval],
+    [ENABLED_LIBSSH2=no])
 
 # OpenSSH compatibility Build
 AC_ARG_ENABLE([openssh],
@@ -959,7 +965,7 @@ AC_ARG_ENABLE([opensslextra],
     [ ENABLED_OPENSSLEXTRA=$enableval ],
     [ ENABLED_OPENSSLEXTRA=no ]
     )
-if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_NGINX" = "yes" || test "$ENABLED_SIGNAL" = "yes" || test "$ENABLED_WPAS" = "yes" || test "$ENABLED_FORTRESS" = "yes" || test "$ENABLED_BUMP" = "yes" || test "$ENABLED_SNIFFER" = "yes" || test "$ENABLED_OPENSSLALL" = "yes" || test "$ENABLED_LIBWEBSOCKETS" = "yes" || test "x$ENABLED_LIGHTY" = "xyes"
+if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_NGINX" = "yes" || test "$ENABLED_SIGNAL" = "yes" || test "$ENABLED_WPAS" = "yes" || test "$ENABLED_FORTRESS" = "yes" || test "$ENABLED_BUMP" = "yes" || test "$ENABLED_SNIFFER" = "yes" || test "$ENABLED_OPENSSLALL" = "yes" || test "$ENABLED_LIBWEBSOCKETS" = "yes" || test "x$ENABLED_LIGHTY" = "xyes" || test "$ENABLED_LIBSSH2" = "yes"
 then
     ENABLED_OPENSSLEXTRA="yes"
 fi
@@ -1364,7 +1370,7 @@ AC_ARG_ENABLE([aesctr],
     [ ENABLED_AESCTR=$enableval ],
     [ ENABLED_AESCTR=no ]
     )
-if test "$ENABLED_OPENVPN" = "yes"
+if test "$ENABLED_OPENVPN" = "yes" || test "$ENABLED_LIBSSH2" = "yes"
 then
     ENABLED_AESCTR=yes
 fi
@@ -1888,7 +1894,7 @@ AC_ARG_ENABLE([keygen],
     [ ENABLED_KEYGEN=no ]
     )
 
-if test "$ENABLED_BIND" = "yes"
+if test "$ENABLED_BIND" = "yes" || test "$ENABLED_LIBSSH2" = "yes"
 then
     ENABLED_KEYGEN=yes
 fi 
@@ -2008,7 +2014,7 @@ AC_ARG_ENABLE([dsa],
     [ ENABLED_DSA=no ]
     )
 
-if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_OPENVPN" = "yes" || test "$ENABLED_NGINX" = "yes" || test "$ENABLED_WPAS" = "yes" || test "$ENABLED_QT" = "yes" || test "$ENABLED_BIND" = "yes"
+if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_OPENVPN" = "yes" || test "$ENABLED_NGINX" = "yes" || test "$ENABLED_WPAS" = "yes" || test "$ENABLED_QT" = "yes" || test "$ENABLED_BIND" = "yes" || test "$ENABLED_LIBSSH2" = "yes"
 then
     ENABLED_DSA="yes"
 fi
@@ -3003,7 +3009,7 @@ AC_ARG_ENABLE([des3],
     [ ENABLED_DES3=no ]
     )
 
-if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_QT" = "yes" || test "$ENABLED_OPENVPN" = "yes" || test "x$ENABLED_WPAS" != "xno"
+if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_QT" = "yes" || test "$ENABLED_OPENVPN" = "yes" || test "x$ENABLED_WPAS" != "xno"  || test "$ENABLED_LIBSSH2" = "yes"
 then
     ENABLED_DES3="yes"
 fi
@@ -6923,6 +6929,7 @@ echo "   * LIGHTY:                     $ENABLED_LIGHTY"
 echo "   * HAPROXY:                    $ENABLED_HAPROXY"
 echo "   * STUNNEL:                    $ENABLED_STUNNEL"
 echo "   * tcpdump:                    $ENABLED_TCPDUMP"
+echo "   * libssh2:                    $ENABLED_LIBSSH2"
 echo "   * Apache httpd:               $ENABLED_APACHE_HTTPD"
 echo "   * NGINX:                      $ENABLED_NGINX"
 echo "   * ASIO:                       $ENABLED_ASIO"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -35133,7 +35133,6 @@ int wolfSSL_ECPoint_i2d(const WOLFSSL_EC_GROUP *group,
     return WOLFSSL_SUCCESS;
 }
 
-#if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION>2))
 /* return code compliant with OpenSSL :
  *   1 if success, 0 if error
  */
@@ -35147,7 +35146,8 @@ int wolfSSL_ECPoint_d2i(unsigned char *in, unsigned int len,
         return WOLFSSL_FAILURE;
     }
 
-#ifndef HAVE_SELFTEST
+#if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
+    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION>2)))
     if (wc_ecc_import_point_der_ex(in, len, group->curve_idx,
                                    (ecc_point*)p->internal, 0) != MP_OKAY) {
         WOLFSSL_MSG("wc_ecc_import_point_der_ex failed");
@@ -35185,7 +35185,8 @@ size_t wolfSSL_EC_POINT_point2oct(const WOLFSSL_EC_GROUP *group,
                                   byte *buf, size_t len, WOLFSSL_BN_CTX *ctx)
 {
     word32 min_len = (word32)len;
-#ifndef HAVE_SELFTEST
+#if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
+    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2)))
     int compressed = form == POINT_CONVERSION_COMPRESSED ? 1 : 0;
 #endif /* !HAVE_SELFTEST */
 
@@ -35220,7 +35221,8 @@ size_t wolfSSL_EC_POINT_point2oct(const WOLFSSL_EC_GROUP *group,
         return WOLFSSL_FAILURE;
     }
 
-#ifndef HAVE_SELFTEST
+#if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
+    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2)))
     if (wc_ecc_export_point_der_ex(group->curve_idx, (ecc_point*)p->internal,
                buf, &min_len, compressed) != (buf ? MP_OKAY : LENGTH_ONLY_E)) {
         return WOLFSSL_FAILURE;
@@ -35467,7 +35469,6 @@ WOLFSSL_BIGNUM *wolfSSL_EC_POINT_point2bn(const WOLFSSL_EC_GROUP *group,
 
     return ret;
 }
-#endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
 
 #ifdef USE_ECC_B_PARAM
 int wolfSSL_EC_POINT_is_on_curve(const WOLFSSL_EC_GROUP *group,


### PR DESCRIPTION
To get libssh2 working with wolfSSL FIPS, some OpenSSL compatibility functions
previously not included with FIPS need to be brought in. These functions should
be fine to use with FIPS.