### PR TITLE
Fixes for CAAM build macros and spelling

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -8789,7 +8789,7 @@ int wc_ecc_import_private_key_ex(const byte* priv, word32 privSz,
     }
 #elif defined(WOLFSSL_QNX_CAAM)
     if ((wc_ecc_size(key) + WC_CAAM_MAC_SZ) == (int)privSz) {
-        int part = caamFindUnusuedPartition();
+        int part = caamFindUnusedPartition();
         if (part >= 0) {
             CAAM_ADDRESS vaddr = caamGetPartition(part, privSz*3);
             if (vaddr == 0) {

--- a/wolfcrypt/src/port/caam/caam_aes.c
+++ b/wolfcrypt/src/port/caam/caam_aes.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolfssl/wolfcrypt/settings.h>
 

--- a/wolfcrypt/src/port/caam/caam_driver.c
+++ b/wolfcrypt/src/port/caam/caam_driver.c
@@ -19,7 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-
 #if (defined(__INTEGRITY) || defined(INTEGRITY)) || \
     (defined(__QNX__) || defined(__QNXNTO__))
 
@@ -29,11 +28,11 @@
     #include <sys/iofunc.h>
     #include <sys/neutrino.h>
 
-    #include "caam_qnx.h"
+    #include <wolfssl/wolfcrypt/port/caam/caam_qnx.h>
 #endif
 
-#include "caam_driver.h"
-#include "caam_error.h"
+#include <wolfssl/wolfcrypt/port/caam/caam_driver.h>
+#include <wolfssl/wolfcrypt/port/caam/caam_error.h>
 
 #include <string.h> /* for memcpy / memset */
 
@@ -265,7 +264,7 @@ static Error caamFreeAllPart()
 /* search through the partitions to find an unused one
  * returns negative value on failure, on success returns 0 or greater
  */
-int caamFindUnusuedPartition()
+int caamFindUnusedPartition()
 {
     unsigned int SMPO;
     unsigned int i;
@@ -870,7 +869,7 @@ int caamECDSAMake(DESCSTRUCT* desc, CAAM_BUFFER* buf, unsigned int args[4])
     desc->desc[desc->idx++] = pdECDSEL;
     if (isBlackKey == 1) {
         /* create secure partition for private key out */
-        part = caamFindUnusuedPartition();
+        part = caamFindUnusedPartition();
         if (part < 0) {
             WOLFSSL_MSG("error finding an unused partition for new key");
             return -1;
@@ -1527,4 +1526,5 @@ int CleanupCAAM()
     caamFreeAllPart();
     return 0;
 }
-#endif
+
+#endif /* __INTEGRITY || INTEGRITY || __QNX__ || __QNXNTO__ */

--- a/wolfcrypt/src/port/caam/caam_error.c
+++ b/wolfcrypt/src/port/caam/caam_error.c
@@ -19,8 +19,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include "caam_driver.h"
-#include "caam_error.h"
+#if (defined(__INTEGRITY) || defined(INTEGRITY)) || \
+    (defined(__QNX__) || defined(__QNXNTO__))
+
+#include <wolfssl/wolfcrypt/port/caam/caam_driver.h>
+#include <wolfssl/wolfcrypt/port/caam/caam_error.h>
 
 /* return a negative value if CAAM reset needed */
 int caamParseCCBError(unsigned int error)
@@ -205,3 +208,4 @@ unsigned int caamParseJRError(unsigned int error)
     return err;
 }
 
+#endif

--- a/wolfcrypt/src/port/caam/caam_integrity.c
+++ b/wolfcrypt/src/port/caam/caam_integrity.c
@@ -19,11 +19,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
 #if defined(__INTEGRITY) || defined(INTEGRITY)
 
 /* build into Integrity kernel */
 #include <bsp.h>
-#include "wolfssl/wolfcrypt/port/caam/caam_driver.h"
+#include <wolfssl/wolfcrypt/port/caam/caam_driver.h>
 
 #define CAAM_READ(reg) *(volatile unsigned int*)(reg)
 #define CAAM_WRITE(reg, in) *(volatile unsigned int*)(reg) = (in);

--- a/wolfcrypt/src/port/caam/caam_qnx.c
+++ b/wolfcrypt/src/port/caam/caam_qnx.c
@@ -19,8 +19,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
-#include "caam_driver.h"
-#include "wolfssl/version.h"
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#if defined(__QNX__) || defined(__QNXNTO__)
+
+#include <wolfssl/wolfcrypt/port/caam/caam_driver.h>
+#include <wolfssl/version.h>
 
 #include <errno.h>
 #include <stdio.h>
@@ -193,7 +201,7 @@ void CAAM_ADR_UNMAP(void* vaddr, unsigned int out, int outSz,
 }
 
 
-/* syncoronize virtual buffer with physical
+/* synchronize virtual buffer with physical
  * return 0 on success */
 int CAAM_ADR_SYNC(void* vaddr, int sz)
 {
@@ -1115,7 +1123,7 @@ int io_devctl (resmgr_context_t *ctp, io_devctl_t *msg, iofunc_ocb_t *ocb)
             break;
 
         case WC_CAAM_FIND_PART:
-            ret = caamFindUnusuedPartition();
+            ret = caamFindUnusedPartition();
             if (ret < 0) {
                 /* none found, try again later */
                 return EAGAIN;
@@ -1289,3 +1297,4 @@ int main(int argc, char *argv[])
     return 0;
 }
 
+#endif /* __QNX__ || __QNXNTO__ */

--- a/wolfcrypt/src/port/caam/caam_sha.c
+++ b/wolfcrypt/src/port/caam/caam_sha.c
@@ -19,6 +19,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
 
 #include <wolfssl/wolfcrypt/settings.h>
 
@@ -35,7 +38,9 @@
 #endif
 
 
+#if defined(__INTEGRITY) || defined(INTEGRITY)
 #include <INTEGRITY.h>
+#endif
 #include <wolfssl/wolfcrypt/port/caam/caam_driver.h>
 #include <wolfssl/wolfcrypt/port/caam/wolfcaam.h>
 
@@ -393,5 +398,4 @@ int wc_Sha512Final(wc_Sha512* sha, byte* out)
 }
 #endif /* WOLFSSL_SHA512 */
 
-#endif /* WOLFSSL_IMX6_CAAM */
-
+#endif /* WOLFSSL_IMX6_CAAM && !NO_IMX6_CAAM_HASH */

--- a/wolfcrypt/src/port/caam/wolfcaam_cmac.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_cmac.c
@@ -25,7 +25,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#if defined(WOLFSSL_CMAC) && defined(WOLFSSL_QNX_CAAM)
+#if defined(WOLFSSL_QNX_CAAM) && defined(WOLFSSL_CMAC)
 
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
@@ -169,4 +169,4 @@ int wc_CAAM_Cmac(Cmac* cmac, const byte* key, word32 keySz, const byte* in,
     return 0;
 }
 
-#endif
+#endif /* WOLFSSL_QNX_CAAM && WOLFSSL_CMAC */

--- a/wolfcrypt/src/port/caam/wolfcaam_ecdsa.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_ecdsa.c
@@ -25,7 +25,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#if defined(HAVE_ECC) && defined(WOLFSSL_QNX_CAAM)
+#if defined(WOLFSSL_QNX_CAAM) && defined(HAVE_ECC)
 
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
@@ -466,4 +466,4 @@ int wc_CAAM_EccCheckPrivKey(ecc_key* key, const byte* pubKey, word32 pubKeySz) {
     return CRYPTOCB_UNAVAILABLE;
 }
 
-#endif /* HAVE_ECC && WOLFSSL_QNX_CAAM */
+#endif /* WOLFSSL_QNX_CAAM && HAVE_ECC */

--- a/wolfcrypt/src/port/caam/wolfcaam_init.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_init.c
@@ -500,7 +500,7 @@ int wc_caamCoverKey(byte* in, word32 inSz, byte* out, word32* outSz, int flag)
 /* return 0 or greater on success for the partition number available
  * returns a negative value on failure
  */
-int caamFindUnusuedPartition()
+int caamFindUnusedPartition()
 {
     CAAM_BUFFER buf[1];
     word32 arg[4];
@@ -604,5 +604,5 @@ int caamReadPartition(CAAM_ADDRESS addr, unsigned char* out, int outSz)
     return 0;
 }
 
-#endif /* WOLFSSL_IMX6_CAAM */
-
+#endif /* WOLFSSL_IMX6_CAAM || WOLFSSL_IMX6_CAAM_RNG || 
+          WOLFSSL_IMX6UL_CAAM || WOLFSSL_IMX6_CAAM_BLOB */

--- a/wolfcrypt/src/port/caam/wolfcaam_qnx.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_qnx.c
@@ -25,7 +25,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#if defined(WOLFSSL_QNX_CAAM)
+#if defined(WOLFSSL_QNX_CAAM) && (defined(__QNX__) || defined(__QNXNTO__))
 
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
@@ -349,4 +349,4 @@ int SynchronousSendRequest(int type, unsigned int args[4], CAAM_BUFFER *buf,
     return Success;
 }
 
-#endif
+#endif /* WOLFSSL_QNX_CAAM && (__QNX__ || __QNXNTO__) */

--- a/wolfssl/wolfcrypt/port/caam/caam_driver.h
+++ b/wolfssl/wolfcrypt/port/caam/caam_driver.h
@@ -332,7 +332,7 @@ int caamBlob(DESCSTRUCT *desc);
 
 CAAM_ADDRESS caamGetPartition(unsigned int part, int partSz, unsigned int flag);
 int caamFreePart(unsigned int part);
-int caamFindUnusuedPartition(void);
+int caamFindUnusedPartition(void);
 
 
 

--- a/wolfssl/wolfcrypt/port/caam/caam_error.h
+++ b/wolfssl/wolfcrypt/port/caam/caam_error.h
@@ -26,4 +26,5 @@ int caamParseError(unsigned int error);
 int caamParseDECOError(unsigned int error);
 int caamParseCCBError(unsigned int error);
 unsigned int caamParseJRError(unsigned int error);
+
 #endif /* CAAM_ERROR_H */

--- a/wolfssl/wolfcrypt/port/caam/wolfcaam.h
+++ b/wolfssl/wolfcrypt/port/caam/wolfcaam.h
@@ -49,7 +49,7 @@ WOLFSSL_LOCAL void wc_caamWriteRegister(word32 reg, word32 value);
 WOLFSSL_LOCAL int  wc_caamAddAndWait(CAAM_BUFFER* buf, int sz, word32 arg[4],
         word32 type);
 
-WOLFSSL_LOCAL int caamFindUnusuedPartition(void);
+WOLFSSL_LOCAL int caamFindUnusedPartition(void);
 WOLFSSL_LOCAL CAAM_ADDRESS caamGetPartition(int part, int sz);
 WOLFSSL_LOCAL int caamFreePart(int partNum);
 WOLFSSL_LOCAL int caamWriteToPartition(CAAM_ADDRESS addr, const unsigned char* in, int inSz);


### PR DESCRIPTION
Encountered this with Keil CMSIS pack v4.8.0.