### PR TITLE
Extend ed25519 support

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -7541,6 +7541,15 @@ void wolfSSL_EVP_PKEY_free(WOLFSSL_EVP_PKEY* key)
                     break;
                 #endif /* ! NO_DH ... */
 
+                #if defined(HAVE_ED25519)
+                case EVP_PKEY_ED25519:
+                    if (key->ed25519 != NULL && key->ownEd25519 == 1) {
+                        wolfSSL_ED25519_free(key->ed25519);
+                        key->ed25519 = NULL;
+                    }
+                    break;
+                #endif /* ! HAVE_ED25519 */
+
                 default:
                 break;
             }

--- a/wolfssl/openssl/ed25519.h
+++ b/wolfssl/openssl/ed25519.h
@@ -28,6 +28,26 @@
 extern "C" {
 #endif
 
+#ifndef WOLFSSL_ED25519_TYPE_DEFINED /* guard on redeclaration */
+typedef struct WOLFSSL_ED25519   WOLFSSL_ED25519;
+#define WOLFSSL_ED25519_TYPE_DEFINED
+#endif
+
+typedef struct WOLFSSL_ED25519 {
+    WOLFSSL_BIGNUM* p; /* public key */
+    WOLFSSL_BIGNUM* k; /* private key */
+    void* internal;
+    /* bits */
+    byte inSet:1;     /* internal set from external ? */
+    byte exSet:1;     /* external set from internal ? */
+} WOLFSSL_ED25519;
+
+WOLFSSL_API
+WOLFSSL_ED25519* wolfSSL_ED25519_new(void);
+
+WOLFSSL_API
+void wolfSSL_ED25519_free(WOLFSSL_ED25519 *key);
+
 WOLFSSL_API
 int wolfSSL_ED25519_generate_key(unsigned char *priv, unsigned int *privSz,
                                  unsigned char *pub, unsigned int *pubSz);

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -240,6 +240,7 @@ enum {
     EVP_PKEY_RSA      = 16,
     EVP_PKEY_DSA      = 17,
     EVP_PKEY_EC       = 18,
+    EVP_PKEY_ED25519  = NID_ED25519,
 #ifdef HAVE_IDEA
     IDEA_CBC_TYPE     = 19,
 #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -184,6 +184,11 @@ typedef struct WOLFSSL_ECDSA_SIG      WOLFSSL_ECDSA_SIG;
 #define WOLFSSL_ECDSA_TYPE_DEFINED
 #endif
 
+#ifndef WOLFSSL_ED25519_TYPE_DEFINED /* guard on redeclaration */
+typedef struct WOLFSSL_ED25519        WOLFSSL_ED25519;
+#define WOLFSSL_ED25519_TYPE_DEFINED
+#endif
+
 typedef struct WOLFSSL_CIPHER         WOLFSSL_CIPHER;
 typedef struct WOLFSSL_X509_LOOKUP    WOLFSSL_X509_LOOKUP;
 typedef struct WOLFSSL_X509_LOOKUP_METHOD WOLFSSL_X509_LOOKUP_METHOD;
@@ -371,6 +376,9 @@ struct WOLFSSL_EVP_PKEY {
     #ifndef NO_DH
     WOLFSSL_DH* dh;
     #endif
+    #ifdef HAVE_ED25519
+    WOLFSSL_ED25519* ed25519;
+    #endif
     WC_RNG rng;
 #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 #ifdef HAVE_ECC
@@ -383,6 +391,7 @@ struct WOLFSSL_EVP_PKEY {
     byte ownEcc:1; /* if struct owns ECC and should free it */
     byte ownDsa:1; /* if struct owns DSA and should free it */
     byte ownRsa:1; /* if struct owns RSA and should free it */
+    byte ownEd25519:1; /* if struct owns ED25519 and should free it */
 };
 typedef struct WOLFSSL_EVP_PKEY WOLFSSL_PKCS8_PRIV_KEY_INFO;
 #ifndef WOLFSSL_EVP_TYPE_DEFINED /* guard on redeclaration */

--- a/wolfssl/wolfcrypt/ed25519.h
+++ b/wolfssl/wolfcrypt/ed25519.h
@@ -47,6 +47,7 @@
     extern "C" {
 #endif
 
+#define FreeEd25519Key wc_ed25519_free
 
 /* info about EdDSA curve specifically ed25519, defined as an elliptic curve
    over GF(p) */


### PR DESCRIPTION
This PR adds ed25519 support in wolfSSL_X509_get_pubkey.

I am testing using this test application https://gist.github.com/tomoveu/d9215530927b156dcf3c60d028ae1d3d

My wolfSSL configuration

`./configure --enable-ed25519 --enable-opensslextra --enable-debug --disable-shared`

I need help confirming the correct extraction of the public key.