### PR TITLE
--enable-cryptocb CFLAGS='-std=c99 -pedantic'

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -34338,7 +34338,7 @@ static void test_wolfSSL_HMAC(void)
 #endif
 }
 
-static void test_wolfSSL_CMAC()
+static void test_wolfSSL_CMAC(void)
 {
 #if defined(OPENSSL_EXTRA) && defined(WOLFSSL_CMAC)
 
@@ -36727,7 +36727,7 @@ static int check_result(unsigned char *data, int len)
 static int r_offset;
 static int w_offset;
 
-static void init_offset()
+static void init_offset(void)
 {
     r_offset = 0;
     w_offset = 0;
@@ -46558,7 +46558,7 @@ static void test_wolfSSL_ERR_strings(void)
     printf(resultFmt, passed);
 #endif
 }
-static void test_wolfSSL_EVP_shake128()
+static void test_wolfSSL_EVP_shake128(void)
 {
 #if defined(OPENSSL_EXTRA) && defined(WOLFSSL_SHA3) && \
                                             defined(WOLFSSL_SHAKE128)
@@ -46571,7 +46571,7 @@ static void test_wolfSSL_EVP_shake128()
 #endif
 }
 
-static void test_wolfSSL_EVP_shake256()
+static void test_wolfSSL_EVP_shake256(void)
 {
 #if defined(OPENSSL_EXTRA) && defined(WOLFSSL_SHA3) && \
                                             defined(WOLFSSL_SHAKE256)
@@ -46584,7 +46584,7 @@ static void test_wolfSSL_EVP_shake256()
 #endif
 }
 
-static void test_EVP_blake2()
+static void test_EVP_blake2(void)
 {
 #if defined(OPENSSL_EXTRA) && (defined(HAVE_BLAKE2) || defined(HAVE_BLAKE2S))
     printf(testingFmt, "test_EVP_blake2");
@@ -46645,7 +46645,7 @@ static void list_md_fn(const EVP_MD* m, const char* from,
 }
 #endif
 
-static void test_EVP_MD_do_all()
+static void test_EVP_MD_do_all(void)
 {
 #if defined(OPENSSL_EXTRA)
     printf(testingFmt, "test_EVP_MD_do_all");
@@ -46683,7 +46683,7 @@ static void obj_name_t(const OBJ_NAME* nm, void* arg)
 }
 
 #endif
-static void test_OBJ_NAME_do_all()
+static void test_OBJ_NAME_do_all(void)
 {
 #if defined(OPENSSL_EXTRA)
     printf(testingFmt, "test_OBJ_NAME_do_all");

--- a/wolfssl/wolfcrypt/cryptocb.h
+++ b/wolfssl/wolfcrypt/cryptocb.h
@@ -75,10 +75,15 @@
 /* Crypto Information Structure for callbacks */
 typedef struct wc_CryptoInfo {
     int algo_type; /* enum wc_AlgoType */
+#if HAVE_ANONYMOUS_INLINE_AGGREGATES
+    union {
+#endif
 #if !defined(NO_RSA) || defined(HAVE_ECC)
     struct {
         int type; /* enum wc_PkType */
+#if HAVE_ANONYMOUS_INLINE_AGGREGATES
         union {
+#endif
         #ifndef NO_RSA
             struct {
                 const byte* in;
@@ -182,14 +187,18 @@ typedef struct wc_CryptoInfo {
                 byte         contextLen;
             } ed25519verify;
         #endif
+#if HAVE_ANONYMOUS_INLINE_AGGREGATES
         };
+#endif
     } pk;
 #endif /* !NO_RSA || HAVE_ECC */
 #if !defined(NO_AES) || !defined(NO_DES3)
     struct {
         int type; /* enum wc_CipherType */
         int enc;
+#if HAVE_ANONYMOUS_INLINE_AGGREGATES
         union {
+#endif
         #ifdef HAVE_AESGCM
             struct {
                 Aes*        aes;
@@ -232,7 +241,9 @@ typedef struct wc_CryptoInfo {
                 word32      sz;
             } des3;
         #endif
+#if HAVE_ANONYMOUS_INLINE_AGGREGATES
         };
+#endif
     } cipher;
 #endif /* !NO_AES || !NO_DES3 */
 #if !defined(NO_SHA) || !defined(NO_SHA256) || \
@@ -242,7 +253,9 @@ typedef struct wc_CryptoInfo {
         const byte* in;
         word32 inSz;
         byte* digest;
+#if HAVE_ANONYMOUS_INLINE_AGGREGATES
         union {
+#endif
         #ifndef NO_SHA
             wc_Sha* sha1;
         #endif
@@ -255,7 +268,9 @@ typedef struct wc_CryptoInfo {
         #ifdef WOLFSSL_SHA512
             wc_Sha512* sha512;
         #endif
+#if HAVE_ANONYMOUS_INLINE_AGGREGATES
         };
+#endif
     } hash;
 #endif /* !NO_SHA || !NO_SHA256 */
 #ifndef NO_HMAC
@@ -291,6 +306,9 @@ typedef struct wc_CryptoInfo {
         word32  inSz;
         int type;
     } cmac;
+#endif
+#if HAVE_ANONYMOUS_INLINE_AGGREGATES
+    };
 #endif
 } wc_CryptoInfo;
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -95,6 +95,17 @@ decouple library dependencies with standard string, memory and so on.
         typedef const char* const wcchar;
     #endif
 
+    #ifndef HAVE_ANONYMOUS_INLINE_AGGREGATES
+        /* if __STDC__, pivot on the version, otherwise guess it's allowed,
+         * subject to override.
+         */
+        #if !defined(__STDC__) \
+            || (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201101L))
+            #define HAVE_ANONYMOUS_INLINE_AGGREGATES 1
+        #else
+            #define HAVE_ANONYMOUS_INLINE_AGGREGATES 0
+        #endif
+    #endif
 
     /* try to set SIZEOF_LONG or SIZEOF_LONG_LONG if user didn't */
     #if defined(_MSC_VER) || defined(HAVE_LIMITS_H)

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -130,6 +130,11 @@
 
     _Pragma("GCC diagnostic pop");
 
+    /* the kernel uses -std=c89, but not -pedantic, and makes full use of anon
+     * structs/unions, so we should too.
+     */
+    #define HAVE_ANONYMOUS_INLINE_AGGREGATES 1
+
     /* Linux headers define these using C expressions, but we need
      * them to be evaluable by the preprocessor, for use in sp_int.h.
      */


### PR DESCRIPTION
and adds the missing anonymous `union { }` around the top level members `struct pk`, `cipher`, `hash`, `hmac`, `rng`, `seed`, and `cmac`.  only one of them can be in use at a time, as specified by `wc_CryptoInfo.algo_type`.

also fixes missing (void) arg lists in some new api.c tests.
