### PR TITLE
Add support for value zero as version parameter for SSL_CTX_set_min/max_proto_version

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -5720,6 +5720,8 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     ssl->version = ctx->method->version;
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
     ssl->options.mask = ctx->mask;
+    ssl->options.minProto = ctx->minProto;
+    ssl->options.maxProto = ctx->maxProto;
 #endif
 #ifdef OPENSSL_EXTRA
     #ifdef WOLFSSL_TLS13

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16968,7 +16968,7 @@ int wolfSSL_CTX_set_min_proto_version(WOLFSSL_CTX* ctx, int version)
     }
     if (version != 0) {
         proto = version;
-        wolfSSL_CTX_clear_options(ctx, WOLFSSL_OP_MIN_PROTO);
+        ctx->minProto = 0; /* turn min proto flag off */
         for (i = 0; i < tblSz; i++) {
             if (verTbl[i] == version) {
                 break;
@@ -16981,7 +16981,7 @@ int wolfSSL_CTX_set_min_proto_version(WOLFSSL_CTX* ctx, int version)
             ret = Set_CTX_min_proto_version(ctx, verTbl[i]);
             if (ret == WOLFSSL_SUCCESS) {
                 proto = verTbl[i];
-                wolfSSL_CTX_set_options(ctx, WOLFSSL_OP_MIN_PROTO);
+                ctx->minProto = 1; /* turn min proto flag on */
                 break;
             }
         }
@@ -17097,7 +17097,7 @@ int wolfSSL_CTX_set_max_proto_version(WOLFSSL_CTX* ctx, int version)
             WOLFSSL_OP_NO_TLSv1_2 | WOLFSSL_OP_NO_TLSv1_3);
     wolfSSL_CTX_set_min_proto_version(ctx, minProto);
     if (version != 0) {
-        wolfSSL_CTX_clear_options(ctx, WOLFSSL_OP_MAX_PROTO);
+        ctx->maxProto = 0; /* turn max proto flag off */
         return Set_CTX_max_proto_version(ctx, version);
     }
 
@@ -17105,7 +17105,7 @@ int wolfSSL_CTX_set_max_proto_version(WOLFSSL_CTX* ctx, int version)
     for (i= 0; i < tblSz; i++) {
         ret = Set_CTX_max_proto_version(ctx, verTbl[i]);
         if (ret == WOLFSSL_SUCCESS) {
-            wolfSSL_CTX_set_options(ctx, WOLFSSL_OP_MAX_PROTO);
+            ctx->maxProto = 1; /* turn max proto flag on */
             break;
         }
     }
@@ -17342,7 +17342,7 @@ WOLFSSL_API int wolfSSL_CTX_get_min_proto_version(WOLFSSL_CTX* ctx)
     WOLFSSL_ENTER("wolfSSL_CTX_get_min_proto_version");
 
     if (ctx != NULL) {
-        if (wolfSSL_CTX_get_options(ctx) & WOLFSSL_OP_MIN_PROTO) {
+        if (ctx->minProto) {
             ret = 0;
         }
         else {
@@ -17400,7 +17400,7 @@ int wolfSSL_CTX_get_max_proto_version(WOLFSSL_CTX* ctx)
         options = wolfSSL_CTX_get_options(ctx);
     }
 
-    if (options & WOLFSSL_OP_MAX_PROTO) {
+    if (ctx->maxProto) {
         ret = 0;
     }
     else {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17209,7 +17209,7 @@ static int Set_SSL_min_proto_version(WOLFSSL* ssl, int ver)
 int wolfSSL_set_min_proto_version(WOLFSSL* ssl, int version)
 {
     int i;
-    int ret;
+    int ret = WOLFSSL_FAILURE;;
 
     WOLFSSL_ENTER("wolfSSL_set_min_proto_version");
 
@@ -17277,7 +17277,7 @@ static int Set_SSL_max_proto_version(WOLFSSL* ssl, int ver)
 int wolfSSL_set_max_proto_version(WOLFSSL* ssl, int version)
 {
     int i;
-    int ret;
+    int ret = WOLFSSL_FAILURE;;
 
     WOLFSSL_ENTER("wolfSSL_set_max_proto_version");
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16840,14 +16840,17 @@ static int CheckSslMethodVersion(byte major, unsigned long options)
 }
 
 /**
- * This function attempts to set the minimum protocol version to use by SSL
- * objects created from this WOLFSSL_CTX. This API guarantees that a version
- * of SSL/TLS lower than specified here will not be allowed. If the version
- * specified is not compiled in then this API sets the lowest compiled in
- * protocol version. CheckSslMethodVersion() is called to check if any
- * remaining protocol versions are enabled.
+ * wolfSSL_CTX_set_min_proto_version attempts to set the minimum protocol
+ * version to use by SSL objects created from this WOLFSSL_CTX.
+ * This API guarantees that a version of SSL/TLS lower than specified
+ * here will not be allowed. If the version specified is not compiled in 
+ * then this API sets the lowest compiled in protocol version. 
+ * This API also accept 0 as version, to set the minimum version automatically.
+ * CheckSslMethodVersion() is called to check if any remaining protocol versions
+ * are enabled.
  * @param ctx
  * @param version Any of the following
+ *          * 0
  *          * SSL3_VERSION
  *          * TLS1_VERSION
  *          * TLS1_1_VERSION
@@ -16858,9 +16861,9 @@ static int CheckSslMethodVersion(byte major, unsigned long options)
  * @return WOLFSSL_SUCCESS on valid settings and WOLFSSL_FAILURE when no
  *         protocol versions are left enabled.
  */
-int wolfSSL_CTX_set_min_proto_version(WOLFSSL_CTX* ctx, int version)
+static int Set_CTX_min_proto_version(WOLFSSL_CTX* ctx, int version)
 {
-    WOLFSSL_ENTER("wolfSSL_CTX_set_min_proto_version");
+    WOLFSSL_ENTER("wolfSSL_CTX_set_min_proto_version_ex");
 
     if (ctx == NULL) {
         return WOLFSSL_FAILURE;
@@ -16941,15 +16944,51 @@ int wolfSSL_CTX_set_min_proto_version(WOLFSSL_CTX* ctx, int version)
     return CheckSslMethodVersion(ctx->method->version.major, ctx->mask);
 }
 
+int wolfSSL_CTX_set_min_proto_version(WOLFSSL_CTX* ctx, int version)
+{
+    const int verTbl[] = {SSL3_VERSION, TLS1_VERSION, TLS1_1_VERSION, 
+                          TLS1_2_VERSION, TLS1_3_VERSION,DTLS1_VERSION,
+                          DTLS1_2_VERSION};
+    int tblSz = sizeof(verTbl);
+    int i;
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_set_min_proto_version");
+
+    (void)verTbl;
+    (void)tblSz;
+    (void)i;
+    (void)ret;
+
+    if (ctx == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+    if (version != 0) {
+        return Set_CTX_min_proto_version(ctx, version);
+    }
+
+    /* when 0 is specified as version, try to find out the min version */
+    for (i= 0; i < tblSz; i++) {
+        ret = Set_CTX_min_proto_version(ctx, verTbl[i]);
+        if (ret == WOLFSSL_SUCCESS)
+            break;
+    }
+
+    return ret;
+}
+
 /**
- * This function attempts to set the maximum protocol version to use by SSL
- * objects created from this WOLFSSL_CTX. This API guarantees that a version
- * of SSL/TLS higher than specified here will not be allowed. If the version
- * specified is not compiled in then this API sets the highest compiled in
- * protocol version. CheckSslMethodVersion() is called to check if any
- * remaining protocol versions are enabled.
+ * wolfSSL_CTX_set_max_proto_version attempts to set the maximum protocol
+ * version to use by SSL objects created from this WOLFSSL_CTX.
+ * This API guarantees that a version of SSL/TLS higher than specified
+ * here will not be allowed. If the version specified is not compiled in 
+ * then this API sets the highest compiled in protocol version. 
+ * This API also accept 0 as version, to set the maximum version automatically.
+ * CheckSslMethodVersion() is called to check if any remaining protocol versions
+ * are enabled.
  * @param ctx
  * @param version Any of the following
+ *          * 0
  *          * SSL3_VERSION
  *          * TLS1_VERSION
  *          * TLS1_1_VERSION
@@ -16960,9 +16999,9 @@ int wolfSSL_CTX_set_min_proto_version(WOLFSSL_CTX* ctx, int version)
  * @return WOLFSSL_SUCCESS on valid settings and WOLFSSL_FAILURE when no
  *         protocol versions are left enabled.
  */
-int wolfSSL_CTX_set_max_proto_version(WOLFSSL_CTX* ctx, int ver)
+static int Set_CTX_max_proto_version(WOLFSSL_CTX* ctx, int ver)
 {
-    WOLFSSL_ENTER("wolfSSL_CTX_set_max_proto_version");
+    WOLFSSL_ENTER("Set_CTX_max_proto_version");
 
     if (!ctx || !ctx->method) {
         WOLFSSL_MSG("Bad parameter");
@@ -17003,9 +17042,44 @@ int wolfSSL_CTX_set_max_proto_version(WOLFSSL_CTX* ctx, int ver)
     return CheckSslMethodVersion(ctx->method->version.major, ctx->mask);
 }
 
-int wolfSSL_set_min_proto_version(WOLFSSL* ssl, int ver)
+int wolfSSL_CTX_set_max_proto_version(WOLFSSL_CTX* ctx, int version)
 {
-    WOLFSSL_ENTER("wolfSSL_set_min_proto_version");
+    const int verTbl[] = {DTLS1_2_VERSION, DTLS1_VERSION, TLS1_3_VERSION, 
+                          TLS1_2_VERSION, TLS1_1_VERSION, TLS1_VERSION, 
+                          SSL3_VERSION};
+    int tblSz = sizeof(verTbl);
+    int i;
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_set_max_proto_version");
+
+    (void)verTbl;
+    (void)tblSz;
+    (void)i;
+    (void)ret;
+
+    if (ctx == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+    if (version != 0) {
+        return Set_CTX_max_proto_version(ctx, version);
+    }
+
+    /* when 0 is specified as version, try to find out the min version */
+    for (i= 0; i < tblSz; i++) {
+        ret = Set_CTX_max_proto_version(ctx, verTbl[i]);
+        if (ret == WOLFSSL_SUCCESS) {      
+            break;
+        }
+    }
+
+    return ret;
+}
+
+
+static int Set_SSL_min_proto_version(WOLFSSL* ssl, int ver)
+{
+    WOLFSSL_ENTER("Set_SSL_min_proto_version");
 
     if (ssl == NULL) {
         return WOLFSSL_FAILURE;
@@ -17086,10 +17160,43 @@ int wolfSSL_set_min_proto_version(WOLFSSL* ssl, int ver)
     return CheckSslMethodVersion(ssl->version.major, ssl->options.mask);
 }
 
-int wolfSSL_set_max_proto_version(WOLFSSL* ssl, int ver)
+int wolfSSL_set_min_proto_version(WOLFSSL* ssl, int version)
+{
+    const int verTbl[] = {SSL3_VERSION, TLS1_VERSION, TLS1_1_VERSION, 
+                          TLS1_2_VERSION, TLS1_3_VERSION,DTLS1_VERSION,
+                          DTLS1_2_VERSION};
+    int tblSz = sizeof(verTbl);
+    int i;
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_set_min_proto_version");
+
+    (void)verTbl;
+    (void)tblSz;
+    (void)i;
+    (void)ret;
+
+    if (ssl == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+    if (version != 0) {
+        return Set_SSL_min_proto_version(ssl, version);
+    }
+
+    /* when 0 is specified as version, try to find out the min version */
+    for (i= 0; i < tblSz; i++) {
+        ret = Set_SSL_min_proto_version(ssl, verTbl[i]);
+        if (ret == WOLFSSL_SUCCESS)
+            break;
+    }
+
+    return ret;
+}
+
+static int Set_SSL_max_proto_version(WOLFSSL* ssl, int ver)
 {
 
-    WOLFSSL_ENTER("wolfSSL_set_max_proto_version");
+    WOLFSSL_ENTER("Set_SSL_max_proto_version");
 
     if (!ssl) {
         WOLFSSL_MSG("Bad parameter");
@@ -17128,6 +17235,39 @@ int wolfSSL_set_max_proto_version(WOLFSSL* ssl, int ver)
     }
 
     return CheckSslMethodVersion(ssl->version.major, ssl->options.mask);
+}
+
+int wolfSSL_set_max_proto_version(WOLFSSL* ssl, int version)
+{
+    const int verTbl[] = {DTLS1_2_VERSION, DTLS1_VERSION, TLS1_3_VERSION, 
+                          TLS1_2_VERSION, TLS1_1_VERSION, TLS1_VERSION, 
+                          SSL3_VERSION};
+    int tblSz = sizeof(verTbl);
+    int i;
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_set_max_proto_version");
+
+    (void)verTbl;
+    (void)tblSz;
+    (void)i;
+    (void)ret;
+
+    if (ssl == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+    if (version != 0) {
+        return Set_SSL_max_proto_version(ssl, version);
+    }
+
+    /* when 0 is specified as version, try to find out the max version */
+    for (i= 0; i < tblSz; i++) {
+        ret = Set_SSL_max_proto_version(ssl, verTbl[i]);
+        if (ret == WOLFSSL_SUCCESS)
+            break;
+    }
+
+    return ret;
 }
 
 static int GetMinProtoVersion(int minDowngrade)
@@ -43865,17 +44005,9 @@ long wolfSSL_CTX_ctrl(WOLFSSL_CTX* ctx, int cmd, long opt, void* pt)
         break;
     case SSL_CTRL_SET_MIN_PROTO_VERSION:
         WOLFSSL_MSG("set min proto version");
-        if (opt == 0) {
-            /* do nothing */
-            return WOLFSSL_SUCCESS;
-        }
         return wolfSSL_CTX_set_min_proto_version(ctx, (int)opt);
     case SSL_CTRL_SET_MAX_PROTO_VERSION:
         WOLFSSL_MSG("set max proto version");
-        if (opt == 0) {
-            /* do nothing */
-            return WOLFSSL_SUCCESS;
-        }
         return wolfSSL_CTX_set_max_proto_version(ctx, (int)opt);
     default:
         WOLFSSL_MSG("CTX_ctrl cmd not implemented");

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16944,15 +16944,20 @@ static int Set_CTX_min_proto_version(WOLFSSL_CTX* ctx, int version)
     return CheckSslMethodVersion(ctx->method->version.major, ctx->mask);
 }
 
+/* number of protocol versions listed in table */
+#define NUMBER_OF_PROTOCOLS 7
+
+/* Sets the min protocol version allowed with WOLFSSL_CTX
+ * returns WOLFSSL_SUCCESS on success */
 int wolfSSL_CTX_set_min_proto_version(WOLFSSL_CTX* ctx, int version)
 {
     const int verTbl[] = {SSL3_VERSION, TLS1_VERSION, TLS1_1_VERSION,
                           TLS1_2_VERSION, TLS1_3_VERSION, DTLS1_VERSION,
                           DTLS1_2_VERSION};
-    int tblSz = sizeof(verTbl);
+    int tblSz = NUMBER_OF_PROTOCOLS;
     int ret;
-    int proto;
-    int maxProto;
+    int proto    = 0;
+    int maxProto = 0;
     int i;
     int idx = 0;
 
@@ -17066,12 +17071,15 @@ static int Set_CTX_max_proto_version(WOLFSSL_CTX* ctx, int ver)
     return CheckSslMethodVersion(ctx->method->version.major, ctx->mask);
 }
 
+
+/* Sets the max protocol version allowed with WOLFSSL_CTX
+ * returns WOLFSSL_SUCCESS on success */
 int wolfSSL_CTX_set_max_proto_version(WOLFSSL_CTX* ctx, int version)
 {
     const int verTbl[] = {DTLS1_2_VERSION, DTLS1_VERSION, TLS1_3_VERSION,
                           TLS1_2_VERSION, TLS1_1_VERSION, TLS1_VERSION,
                           SSL3_VERSION};
-    int tblSz = sizeof(verTbl);
+    int tblSz = NUMBER_OF_PROTOCOLS;
     int i;
     int ret;
     int minProto;

--- a/tests/api.c
+++ b/tests/api.c
@@ -2035,6 +2035,47 @@ static void test_wolfSSL_CTX_ticket_API(void)
 #endif /* HAVE_SESSION_TICKET && !NO_WOLFSSL_SERVER */
 }
 
+static void test_wolfSSL_set_minmax_proto_version(void)
+{
+#ifdef OPENSSL_EXTRA
+WOLFSSL_CTX *ctx;
+WOLFSSL *ssl;
+int ret;
+(void)ret;
+(void)ssl;
+printf(testingFmt, "test_wolfSSL_set_minmax_proto_version");
+
+#ifndef NO_WOLFSSL_CLIENT
+    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
+    AssertNotNull(ssl = wolfSSL_new(ctx));
+
+    AssertIntEQ(wolfSSL_CTX_set_min_proto_version(NULL, 0), SSL_FAILURE);
+    AssertIntEQ(wolfSSL_CTX_set_max_proto_version(NULL, 0), SSL_FAILURE);
+    AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, 0), SSL_SUCCESS);
+    AssertIntEQ(wolfSSL_CTX_set_max_proto_version(ctx, 0), SSL_SUCCESS);
+
+    AssertIntEQ(wolfSSL_set_min_proto_version(NULL, 0), SSL_FAILURE);
+    AssertIntEQ(wolfSSL_set_min_proto_version(ssl, 0), SSL_SUCCESS);
+    AssertIntEQ(wolfSSL_set_max_proto_version(NULL, 0), SSL_FAILURE);
+    AssertIntEQ(wolfSSL_set_max_proto_version(ssl, 0), SSL_SUCCESS);
+
+    wolfSSL_free(ssl);
+    wolfSSL_CTX_free(ctx);
+
+#else
+    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_server_method()));
+
+    AssertIntEQ(wolfSSL_CTX_set_min_proto_version(NULL, 0), SSL_FAILURE);
+    AssertIntEQ(wolfSSL_CTX_set_max_proto_version(NULL, 0), SSL_FAILURE);
+    AssertIntEQ(wolfSSL_CTX_set_min_proto_version(ctx, 0), SSL_SUCCESS);
+    AssertIntEQ(wolfSSL_CTX_set_max_proto_version(ctx, 0), SSL_SUCCESS);
+
+    wolfSSL_CTX_free(ctx);
+#endif
+
+    printf(resultFmt, passed);
+#endif
+}
 
 /*----------------------------------------------------------------------------*
  | SSL
@@ -16929,7 +16970,7 @@ static int test_wc_RsaPublicEncryptDecrypt (void)
     if (in == NULL || plain == NULL || cipher == NULL) {
         printf("test_wc_RsaPublicEncryptDecrypt malloc failed\n");
         return MEMORY_E;
-    }
+}
 #endif
     XMEMCPY(in, inStr, inLen);
 
@@ -46936,6 +46977,7 @@ void ApiTest(void)
     test_wolfSSL_Tls12_Key_Logging_test();
     test_wolfSSL_Tls13_Key_Logging_test();
     test_wolfSSL_CTX_set_ecdh_auto();
+    test_wolfSSL_set_minmax_proto_version();
     test_wolfSSL_THREADID_hash();
     test_wolfSSL_RAND_set_rand_method();
     test_wolfSSL_RAND_bytes();

--- a/tests/api.c
+++ b/tests/api.c
@@ -38962,6 +38962,12 @@ static void test_wolfSSL_CTX_ctrl(void)
     
      AssertIntEQ((int)wolfSSL_CTX_ctrl(ctx, SSL_CTRL_SET_MAX_PROTO_VERSION,
                                            TLS1_3_VERSION, NULL), SSL_SUCCESS);
+     AssertIntEQ(wolfSSL_CTX_get_max_proto_version(ctx), TLS1_3_VERSION);
+     #ifndef WOLFSSL_NO_TLS12
+     AssertIntEQ((int)wolfSSL_CTX_ctrl(ctx, SSL_CTRL_SET_MAX_PROTO_VERSION,
+                                           TLS1_2_VERSION, NULL), SSL_SUCCESS);
+     AssertIntEQ(wolfSSL_CTX_get_max_proto_version(ctx), TLS1_2_VERSION);
+     #endif
      #endif
     /* Cleanup and Pass */
 #if !defined(NO_DH) && !defined(NO_DSA)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2885,6 +2885,8 @@ struct WOLFSSL_CTX {
     short       minEccKeySz;      /* minimum ECC key size */
 #endif
     unsigned long     mask;             /* store SSL_OP_ flags */
+    word16            minProto:1; /* sets min to min available */
+    word16            maxProto:1; /* sets max to max available */
 #ifdef OPENSSL_EXTRA
     byte              sessionCtx[ID_LEN]; /* app session context ID */
     word32            disabledCurves;   /* curves disabled by user */
@@ -3566,6 +3568,8 @@ typedef struct Options {
 #endif /* NO_PSK */
 #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(WOLFSSL_WPAS_SMALL)
     unsigned long     mask; /* store SSL_OP_ flags */
+    word16            minProto:1; /* sets min to min available */
+    word16            maxProto:1; /* sets max to max available */
 #endif
 
     /* on/off or small bit flags, optimize layout */

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1128,6 +1128,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define SSL_set_min_proto_version       wolfSSL_set_min_proto_version
 #define SSL_set_max_proto_version       wolfSSL_set_max_proto_version
 #define SSL_CTX_get_min_proto_version   wolfSSL_CTX_get_min_proto_version
+#define SSL_CTX_get_max_proto_version   wolfSSL_CTX_get_max_proto_version
 
 #define SSL_get_tlsext_status_exts      wolfSSL_get_tlsext_status_exts
 
@@ -1154,6 +1155,8 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define SSL_CTRL_GET_SERVER_TMP_KEY               SSL_CTRL_GET_PEER_TMP_KEY
 #define SSL_CTRL_SET_MIN_PROTO_VERSION            123
 #define SSL_CTRL_SET_MAX_PROTO_VERSION            124
+#define SSL_CTRL_GET_MIN_PROTO_VERSION            125
+#define SSL_CTRL_GET_MAX_PROTO_VERSION            126
 #define SSL_CTRL_SET_CURVES                       SSL_CTRL_SET_GROUPS
 
 #define SSL_CTRL_EXTRA_CHAIN_CERT               14

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1955,6 +1955,8 @@ enum {
     SSL_OP_NO_COMPRESSION                         = 0x10000000,
     WOLFSSL_OP_NO_TLSv1_3                         = 0x20000000,
     WOLFSSL_OP_NO_SSLv2                           = 0x40000000,
+    WOLFSSL_OP_MAX_PROTO                          = 0x80000000,
+    WOLFSSL_OP_MIN_PROTO                         = 0x100000000,
     SSL_OP_ALL   =
                     (SSL_OP_MICROSOFT_SESS_ID_BUG
                   | SSL_OP_NETSCAPE_CHALLENGE_BUG
@@ -3854,6 +3856,7 @@ WOLFSSL_API int wolfSSL_CTX_set_max_proto_version(WOLFSSL_CTX*, int);
 WOLFSSL_API int wolfSSL_set_min_proto_version(WOLFSSL*, int);
 WOLFSSL_API int wolfSSL_set_max_proto_version(WOLFSSL*, int);
 WOLFSSL_API int wolfSSL_CTX_get_min_proto_version(WOLFSSL_CTX*);
+WOLFSSL_API int wolfSSL_CTX_get_max_proto_version(WOLFSSL_CTX*);
 
 WOLFSSL_API int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *pkey);
 WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 **x, pem_password_cb *cb, void *u);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1955,8 +1955,6 @@ enum {
     SSL_OP_NO_COMPRESSION                         = 0x10000000,
     WOLFSSL_OP_NO_TLSv1_3                         = 0x20000000,
     WOLFSSL_OP_NO_SSLv2                           = 0x40000000,
-    WOLFSSL_OP_MAX_PROTO                          = 0x80000000,
-    WOLFSSL_OP_MIN_PROTO                         = 0x100000000,
     SSL_OP_ALL   =
                     (SSL_OP_MICROSOFT_SESS_ID_BUG
                   | SSL_OP_NETSCAPE_CHALLENGE_BUG


### PR DESCRIPTION
This PR is to address the issue reported in ZD12625. Following APIs are changed to accept value zero as version parameter. 

- wolfSSL_CTX_set_min_proto_version
- wolfSSL_CTX_set_max_proto_version
- wolfSSL_set_min_proto_version
- wolfSSL_set_max_proto_version
- wolfSSL_CTX_ctrl