### PR TITLE
Fix early data max size handling in TLS v1.3

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -15838,19 +15838,14 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx)
         int process = 0;
 
         if (ssl->options.side == WOLFSSL_SERVER_END) {
-            ssl->earlyDataSz += ssl->curSize;
             if ((ssl->earlyData != no_early_data) &&
                           (ssl->options.clientState == CLIENT_HELLO_COMPLETE)) {
                 process = 1;
             }
-            if (!process && (ssl->earlyDataSz <= ssl->options.maxEarlyDataSz)) {
+            if (!process) {
                 WOLFSSL_MSG("Ignoring EarlyData!");
                 *inOutIdx = ssl->buffers.inputBuffer.length;
                 return 0;
-            }
-            if (ssl->earlyDataSz > ssl->options.maxEarlyDataSz) {
-                WOLFSSL_MSG("Too much EarlyData!");
-                process = 0;
             }
         }
         if (!process) {


### PR DESCRIPTION
Fixes issue with size checking around `wolfSSL_CTX_set_max_early_data` and `wolfSSL_set_max_early_data`, which was checking against the padded size. Also was adding to the `earlyDataSz` and checking against it with un-padded data size.
ZD 12632.