### PR TITLE
Add support for rsyslog.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -785,6 +785,7 @@ AC_ARG_ENABLE([mcast],
 # ssl bump (--enable-bump)
 # signal (--enable-signal)
 # lighty (--enable-lighty) HAVE_LIGHTY
+# rsyslog (--enable-rsyslog)
 # stunnel (--enable-stunnel) HAVE_STUNNEL
 # libest (--enable-libest) HAVE_LIBEST
 # asio (--enable-asio) WOLFSSL_ASIO
@@ -844,6 +845,12 @@ AC_ARG_ENABLE([lighty],
     [AS_HELP_STRING([--enable-lighty],[Enable lighttpd/lighty (default: disabled)])],
     [ ENABLED_LIGHTY=$enableval ],
     [ ENABLED_LIGHTY=no ]
+    )
+# rsyslog Support
+AC_ARG_ENABLE([rsyslog],
+    [AS_HELP_STRING([--enable-rsyslog],[Enable rsyslog (default: disabled)])],
+    [ ENABLED_RSYSLOG=$enableval ],
+    [ ENABLED_RSYSLOG=no ]
     )
 
 # haproxy compatibility build
@@ -978,7 +985,11 @@ AC_ARG_ENABLE([opensslall],
 [ ENABLED_OPENSSLALL=$enableval ],
 [ ENABLED_OPENSSLALL=no ]
 )
-if test "$ENABLED_LIBWEBSOCKETS" = "yes" || test "$ENABLED_OPENVPN" = "yes" || test "$ENABLED_WPAS_DPP" = "yes" || test "$ENABLED_SMIME" = "yes" || test "$ENABLED_HAPROXY" = "yes" || test "$ENABLED_BIND" = "yes" || test "$ENABLED_NTP" == "yes" || test "$ENABLED_NETSNMP" = "yes" || test "$ENABLED_OPENRESTY" = "yes"
+if test "$ENABLED_LIBWEBSOCKETS" = "yes" || test "$ENABLED_OPENVPN" = "yes" || \
+   test "$ENABLED_WPAS_DPP" = "yes" || test "$ENABLED_SMIME" = "yes" || \
+   test "$ENABLED_HAPROXY" = "yes" || test "$ENABLED_BIND" = "yes" || \
+   test "$ENABLED_NTP" == "yes" || test "$ENABLED_NETSNMP" = "yes" || \
+   test "$ENABLED_OPENRESTY" = "yes" || test "$ENABLED_RSYSLOG" == "yes"
 then
     ENABLED_OPENSSLALL="yes"
 fi
@@ -994,7 +1005,13 @@ AC_ARG_ENABLE([opensslextra],
     [ ENABLED_OPENSSLEXTRA=$enableval ],
     [ ENABLED_OPENSSLEXTRA=no ]
     )
-if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_NGINX" = "yes" || test "$ENABLED_SIGNAL" = "yes" || test "$ENABLED_WPAS" = "yes" || test "$ENABLED_FORTRESS" = "yes" || test "$ENABLED_BUMP" = "yes" || test "$ENABLED_SNIFFER" = "yes" || test "$ENABLED_OPENSSLALL" = "yes" || test "$ENABLED_LIBWEBSOCKETS" = "yes" || test "x$ENABLED_LIGHTY" = "xyes" || test "$ENABLED_LIBSSH2" = "yes" || test "x$ENABLED_NTP" = "xyes"
+if test "$ENABLED_OPENSSH" = "yes" || test "$ENABLED_NGINX" = "yes" || \
+   test "$ENABLED_SIGNAL" = "yes" || test "$ENABLED_WPAS" = "yes" || \
+   test "$ENABLED_FORTRESS" = "yes" || test "$ENABLED_BUMP" = "yes" || \
+   test "$ENABLED_SNIFFER" = "yes" || test "$ENABLED_OPENSSLALL" = "yes" || \
+   test "$ENABLED_LIBWEBSOCKETS" = "yes" || \
+   test "x$ENABLED_LIGHTY" = "xyes" || test "$ENABLED_LIBSSH2" = "yes" || \
+   test "x$ENABLED_NTP" = "xyes" || test "$ENABLED_RSYSLOG" == "yes"
 then
     ENABLED_OPENSSLEXTRA="yes"
 fi
@@ -2869,7 +2886,7 @@ AC_ARG_ENABLE([anon],
     [ ENABLED_ANON=no ]
     )
 
-if test "x$ENABLED_WPAS" = "xyes" || test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_HAPROXY" = "xyes"
+if test "x$ENABLED_WPAS" = "xyes" || test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_HAPROXY" = "xyes" || test "$ENABLED_RSYSLOG" == "yes"
 then
     ENABLED_ANON=yes
 fi
@@ -4440,6 +4457,13 @@ then
     ENABLED_SHA224="yes"
     ENABLED_SHA384="yes"
     ENABLED_SHA512="yes"
+fi
+
+if test "$ENABLED_RSYSLOG" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_RSYSLOG -DFP_MAX_BITS=16384"
+    AM_CFLAGS="$AM_CFLAGS -DRSA_MAX_SIZE=8196 -DWOLFSSL_ERROR_CODE_OPENSSL"
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_EX_DATA -DOPENSSL_COMPATIBLE_DEFAULTS"
 fi
 
 if test "$ENABLED_OPENVPN" = "yes"
@@ -7009,6 +7033,7 @@ echo "   * STUNNEL:                    $ENABLED_STUNNEL"
 echo "   * tcpdump:                    $ENABLED_TCPDUMP"
 echo "   * libssh2:                    $ENABLED_LIBSSH2"
 echo "   * ntp:                        $ENABLED_NTP"
+echo "   * rsyslog:                    $ENABLED_RSYSLOG"
 echo "   * Apache httpd:               $ENABLED_APACHE_HTTPD"
 echo "   * NGINX:                      $ENABLED_NGINX"
 echo "   * OpenResty:                  $ENABLED_OPENRESTY"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5733,6 +5733,7 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
             if (info->passwd_cb)
                 EVPerr(0, EVP_R_BAD_DECRYPT);
 #endif
+            WOLFSSL_ERROR(WOLFSSL_BAD_FILE);
             return WOLFSSL_BAD_FILE;
         }
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -11519,8 +11519,10 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
     der = *pDer;
 
     if (Base64_Decode((byte*)headerEnd, (word32)neededSz,
-                      der->buffer, &der->length) < 0)
+                      der->buffer, &der->length) < 0) {
+        WOLFSSL_ERROR(BUFFER_E);
         return BUFFER_E;
+    }
 
     if ((header == BEGIN_PRIV_KEY
 #ifdef OPENSSL_EXTRA

--- a/wolfssl/openssl/opensslv.h
+++ b/wolfssl/openssl/opensslv.h
@@ -30,7 +30,9 @@
     defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x10100000L) ||\
     defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x10001040L)  
      /* valid version */
-#elif defined(WOLFSSL_APACHE_HTTPD) || defined(HAVE_LIBEST) || defined(WOLFSSL_BIND) || defined(WOLFSSL_NGINX)
+#elif defined(WOLFSSL_APACHE_HTTPD) || defined(HAVE_LIBEST) || \
+      defined(WOLFSSL_BIND) || defined(WOLFSSL_NGINX) || \
+      defined(WOLFSSL_RSYSLOG)
     /* For Apache httpd, Use 1.1.0 compatibility */
      #define OPENSSL_VERSION_NUMBER 0x10100000L
 #elif  defined(WOLFSSL_QT)

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2218,7 +2218,20 @@ enum { /* ssl Constants */
     WOLFSSL_ERROR_NONE      =  0,   /* for most functions */
     WOLFSSL_FAILURE         =  0,   /* for some functions */
     WOLFSSL_SUCCESS         =  1,
-    WOLFSSL_SHUTDOWN_NOT_DONE =  2,  /* call wolfSSL_shutdown again to complete */
+
+/* WOLFSSL_SHUTDOWN_NOT_DONE is returned by wolfSSL_shutdown when the other end
+ * of the connection has yet to send its close notify alert as part of the
+ * bidirectional shutdown. To complete the shutdown, either keep calling
+ * wolfSSL_shutdown until it returns WOLFSSL_SUCCESS or call wolfSSL_read until
+ * it returns <= 0 AND SSL_get_error returns SSL_ERROR_ZERO_RETURN. See OpenSSL
+ * docs for more: https://www.openssl.org/docs/man1.1.1/man3/SSL_shutdown.html
+ */
+#ifdef WOLFSSL_ERROR_CODE_OPENSSL
+/* SSL_shutdown returns 0 when not done, per OpenSSL documentation. */
+    WOLFSSL_SHUTDOWN_NOT_DONE = 0,
+#else
+    WOLFSSL_SHUTDOWN_NOT_DONE =  2,
+#endif
 
     WOLFSSL_ALPN_NOT_FOUND  = -9,
     WOLFSSL_BAD_CERTTYPE    = -8,


### PR DESCRIPTION
- Add an --enable-rsyslog option to configure.ac.
- Add a few missing `WOLFSSL_ERROR` calls that were expected by rsyslog unit
  tests.
- Add better documentation around `WOLFSSL_SHUTDOWN_NOT_DONE` and define it to
  be 0 (rather than 2) when `WOLFSSL_ERROR_CODE_OPENSSL` is defined. This is in
  accordance with OpenSSL documentation. Without this change, rsyslog was
  failing to do the bidirectional shutdown properly because it was checking the
  shutdown return value against 0. I'm keeping the old value when
  `WOLFSSL_ERROR_CODE_OPENSSL` isn't defined because it's part of the public
  wolfssl interface (it's in ssl.h).