### PR TITLE
Improvements to session locking to allow per-row

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -2452,7 +2452,6 @@ WOLFSSL_API int wolfSSL_GetSessionAtIndex(int index, WOLFSSL_SESSION* session);
     }
     \endcode
 
-    \sa get_locked_session_stats
     \sa wolfSSL_GetSessionAtIndex
     \sa wolfSSL_GetSessionIndex
     \sa AddSession
@@ -11510,7 +11509,6 @@ WOLFSSL_API int wolfSSL_PrintSessionStats(void);
     return ret;
     \endcode
 
-    \sa get_locked_session_stats
     \sa wolfSSL_PrintSessionStats
 */
 WOLFSSL_API int wolfSSL_get_session_stats(unsigned int* active,

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -3654,6 +3654,7 @@ static int ProcessFinished(const byte* input, int size, int* sslBytes,
 
     if (ret == 0 && session->flags.cached == 0) {
         if (session->sslServer->options.haveSessionId) {
+        #ifndef NO_SESSION_CACHE
             WOLFSSL_SESSION* sess = GetSession(session->sslServer, NULL, 0);
             if (sess == NULL) {
                 AddSession(session->sslServer);  /* don't re add */
@@ -3662,6 +3663,7 @@ static int ProcessFinished(const byte* input, int size, int* sslBytes,
             #endif
             }
             session->flags.cached = 1;
+        #endif
          }
     }
 
@@ -5682,7 +5684,7 @@ int ssl_EnableRecovery(int onOff, int maxMemory, char* error)
 
 
 
-#ifdef WOLFSSL_SESSION_STATS
+#if defined(WOLFSSL_SESSION_STATS) && !defined(NO_SESSION_CACHE)
 
 int ssl_GetSessionStats(unsigned int* active,     unsigned int* total,
                         unsigned int* peak,       unsigned int* maxSessions,

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4986,8 +4986,8 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
     #endif
 
     #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-    #define SESSION_ROW_LOCK(row)   wc_LockMutex(&row->row_mutex)
-    #define SESSION_ROW_UNLOCK(row) wc_UnLockMutex(&row->row_mutex);
+    #define SESSION_ROW_LOCK(row)   wc_LockMutex(&(row)->row_mutex)
+    #define SESSION_ROW_UNLOCK(row) wc_UnLockMutex(&(row)->row_mutex);
     #else
     static WOLFSSL_GLOBAL wolfSSL_Mutex session_mutex; /* SessionCache mutex */
     #define SESSION_ROW_LOCK(row)   wc_LockMutex(&session_mutex)
@@ -5067,7 +5067,7 @@ int wolfSSL_Init(void)
 #ifndef NO_SESSION_CACHE
     #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
         for (i = 0; i < SESSION_ROWS; ++i) {
-            if (wc_InitMutex(&&SessionCache[i].row_mutex) != 0) {
+            if (wc_InitMutex(&SessionCache[i].row_mutex) != 0) {
                 WOLFSSL_MSG("Bad Init Mutex session");
                 return BAD_MUTEX_E;
             }
@@ -14061,7 +14061,7 @@ int wolfSSL_Cleanup(void)
 #ifndef NO_SESSION_CACHE
     #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
     for (i = 0; i < SESSION_ROWS; ++i) {
-        if (wc_FreeMutex(&&SessionCache[i].row_mutex) != 0)
+        if (wc_FreeMutex(&SessionCache[i].row_mutex) != 0)
             ret = BAD_MUTEX_E;
     }
     #else

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3333,6 +3333,7 @@ struct WOLFSSL_X509_CHAIN {
 
 /* wolfSSL session type */
 struct WOLFSSL_SESSION {
+    int                cacheRow;                  /* row in session cache     */
     word32             bornOn;                    /* create time in seconds   */
     word32             timeout;                   /* timeout in seconds       */
     byte               sessionID[ID_LEN];         /* id for protocol          */
@@ -3368,7 +3369,7 @@ struct WOLFSSL_SESSION {
     wolfSSL_Mutex      refMutex;                  /* ref count mutex */
 #endif
     int                refCount;                  /* reference count */
-#endif
+#endif /* OPENSSL_EXTRA */
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     byte               peerVerifyRet;             /* cert verify error */
 #endif
@@ -3398,7 +3399,7 @@ struct WOLFSSL_SESSION {
     WOLFSSL_CRYPTO_EX_DATA ex_data;
 #endif
     byte               side;                      /* Either WOLFSSL_CLIENT_END or
-                                                     WOLFSSL_SERVER_END */
+                                                            WOLFSSL_SERVER_END */
 };
 
 


### PR DESCRIPTION
Can manually be enabled with `ENABLE_SESSION_CACHE_ROW_LOCK` or forcefully disabled using `NO_SESSION_CACHE_ROW_LOCK`. Enabled by default for Titan cache.
ZD 12715