### PR TITLE
Improved sniffer statistics and documentation

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -30735,7 +30735,7 @@ static int TicketEncCbCtx_Init(WOLFSSL_CTX* ctx, TicketEncCbCtx* keyCtx)
 
 /* Setup the session ticket encryption context for this.
  *
- * Initialize RNG, generate name, generate primeary key and set primary key
+ * Initialize RNG, generate name, generate primary key and set primary key
  * expirary.
  *
  * @param [in]  keyCtx  Context for session ticket encryption.

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -2189,6 +2189,9 @@ static int SetupKeys(const byte* input, int* sslBytes, SnifferSession* session,
             ret = wc_RsaPrivateKeyDecode(keyBuf->buffer, &idx, &key, keyBuf->length);
             if (ret != 0) {
             #ifndef HAVE_ECC
+                #ifdef WOLFSSL_SNIFFER_STATS
+                INC_STAT(SnifferStats.sslKeyFails);
+                #endif
                 SetError(RSA_DECODE_STR, error, session, FATAL_ERROR_STATE);
             #else
                 /* If we can do ECC, this isn't fatal. Not loading an ECC
@@ -2342,6 +2345,11 @@ static int SetupKeys(const byte* input, int* sslBytes, SnifferSession* session,
 
             wc_FreeDhKey(&dhKey);
         
+
+        #ifdef WOLFSSL_SNIFFER_STATS
+            if (ret != 0)
+                INC_STAT(SnifferStats.sslKeyFails);
+        #endif
             /* left-padded with zeros up to the size of the prime */
             if (params->p_len > session->sslServer->arrays->preMasterSz) {
                 word32 diff = params->p_len - session->sslServer->arrays->preMasterSz;

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -2344,14 +2344,14 @@ static int SetupKeys(const byte* input, int* sslBytes, SnifferSession* session,
             } while (ret == WC_PENDING_E);
 
             wc_FreeDhKey(&dhKey);
-        
 
         #ifdef WOLFSSL_SNIFFER_STATS
             if (ret != 0)
                 INC_STAT(SnifferStats.sslKeyFails);
         #endif
+
             /* left-padded with zeros up to the size of the prime */
-            if (params->p_len > session->sslServer->arrays->preMasterSz) {
+            if (ret == 0 && params->p_len > session->sslServer->arrays->preMasterSz) {
                 word32 diff = params->p_len - session->sslServer->arrays->preMasterSz;
                 XMEMMOVE(session->sslServer->arrays->preMasterSecret + diff,
                         session->sslServer->arrays->preMasterSecret, 

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -2195,7 +2195,7 @@ static int SetupKeys(const byte* input, int* sslBytes, SnifferSession* session,
                 SetError(RSA_DECODE_STR, error, session, FATAL_ERROR_STATE);
             #else
                 /* If we can do ECC, this isn't fatal. Not loading an ECC
-                    * key will be fatal, though. */
+                 * key will be fatal, though. */
                 SetError(RSA_DECODE_STR, error, session, 0);
                 if (keys->ecKey == NULL)
                     keys->ecKey = session->sslServer->buffers.key; /* try ECC */

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -9577,7 +9577,7 @@ int wolfSSL_set_max_early_data(WOLFSSL* ssl, unsigned int sz)
  *
  * ssl    The SSL/TLS object.
  * data   Early data to write
- * sz     The size of the eary data in bytes.
+ * sz     The size of the early data in bytes.
  * outSz  The number of early data bytes written.
  * returns BAD_FUNC_ARG when: ssl, data or outSz is NULL; sz is negative;
  * or not using TLS v1.3. SIDE ERROR when not a server. Otherwise the number of

--- a/sslSniffer/README.md
+++ b/sslSniffer/README.md
@@ -404,25 +404,23 @@ See the header file `sniffer.h` for the structure `SSLStats` for the list of sta
 ```c
 typedef struct SSLStats
 {
-    unsigned long int sslStandardConns;
-    unsigned long int sslClientAuthConns;
-    unsigned long int sslResumedConns;
-    unsigned long int sslEphemeralMisses;
-    unsigned long int sslResumeMisses;
-    unsigned long int sslCiphersUnsupported;
-    unsigned long int sslKeysUnmatched;
-    unsigned long int sslKeyFails;
-    unsigned long int sslDecodeFails;
-    unsigned long int sslAlerts;
-    unsigned long int sslDecryptedBytes;
-    unsigned long int sslEncryptedBytes;
-    unsigned long int sslEncryptedPackets;
-    unsigned long int sslDecryptedPackets;
-    unsigned long int sslKeyMatches;
-    unsigned long int sslEncryptedConns;
-
-    unsigned long int sslResumptionValid;
-    unsigned long int sslResumptionInserts;
+    unsigned long int sslStandardConns;      /* server_hello count not including resumed sessions */
+    unsigned long int sslClientAuthConns;    /* client's who have presented certificates (mutual authentication) */
+    unsigned long int sslResumedConns;       /* resumed connections */
+    unsigned long int sslEphemeralMisses;    /* TLS v1.2 and older PFS / ephemeral connections missed (not able to decrypt) */
+    unsigned long int sslResumeMisses;       /* Resumption sessions not found */
+    unsigned long int sslCiphersUnsupported; /* No cipher suite match found when compared to supported */
+    unsigned long int sslKeysUnmatched;      /* Key callback failures (not found). Applies to WOLFSSL_SNIFFER_WATCH only */
+    unsigned long int sslKeyFails;           /* Failures loading or using keys */
+    unsigned long int sslDecodeFails;        /* Dropped packets (not application_data or match protocol version) */
+    unsigned long int sslAlerts;             /* Number of decoded alert messages */
+    unsigned long int sslDecryptedBytes;     /* Number of decrypted bytes */
+    unsigned long int sslEncryptedBytes;     /* Number of encrypted bytes */
+    unsigned long int sslEncryptedPackets;   /* Number of encrypted packets */
+    unsigned long int sslDecryptedPackets;   /* Number of decrypted packets */
+    unsigned long int sslKeyMatches;         /* Key callback successes (failures tracked in sslKeysUnmatched). Applies to WOLFSSL_SNIFFER_WATCH only. */
+    unsigned long int sslEncryptedConns;     /* Number of created sniffer sessions */
+    unsigned long int sslResumptionInserts;  /* Number of sessions reused with resumption */
 } SSLStats;
 ```
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -17262,9 +17262,7 @@ int wc_Ed25519KeyToDer(ed25519_key* key, byte* output, word32 inLen)
     return wc_BuildEd25519KeyDer(key, output, inLen, 1);
 }
 
-
-
-/* Write only private ecc key to DER format,
+/* Write only private Ed25519 key to DER format,
  * length on success else < 0 */
 int wc_Ed25519PrivateKeyToDer(ed25519_key* key, byte* output, word32 inLen)
 {

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -132,7 +132,7 @@ int wc_RNG_GenerateByte(WC_RNG* rng, byte* b)
     #include <wnr.h>
     #include <wolfssl/wolfcrypt/logging.h>
     wolfSSL_Mutex wnr_mutex;    /* global netRandom mutex */
-    int wnr_timeout     = 0;    /* entropy timeout, mililseconds */
+    int wnr_timeout     = 0;    /* entropy timeout, milliseconds */
     int wnr_mutex_init  = 0;    /* flag for mutex init */
     wnr_context*  wnr_ctx;      /* global netRandom context */
 #elif defined(FREESCALE_KSDK_2_0_TRNG)

--- a/wolfssl/sniffer.h
+++ b/wolfssl/sniffer.h
@@ -167,46 +167,45 @@ SSL_SNIFFER_API int ssl_SetConnectionCtx(void* ctx);
 
 typedef struct SSLStats
 {
-    unsigned long int sslStandardConns;
-    unsigned long int sslClientAuthConns;
-    unsigned long int sslResumedConns;
-    unsigned long int sslEphemeralMisses;
-    unsigned long int sslResumeMisses;
-    unsigned long int sslCiphersUnsupported;
-    unsigned long int sslKeysUnmatched;
-    unsigned long int sslKeyFails;
-    unsigned long int sslDecodeFails;
-    unsigned long int sslAlerts;
-    unsigned long int sslDecryptedBytes;
-    unsigned long int sslEncryptedBytes;
-    unsigned long int sslEncryptedPackets;
-    unsigned long int sslDecryptedPackets;
-    unsigned long int sslKeyMatches;
-    unsigned long int sslEncryptedConns;
-    unsigned long int sslResumptionInserts;
+    unsigned long int sslStandardConns;      /* server_hello count not including resumed sessions */
+    unsigned long int sslClientAuthConns;    /* client's who have presented certificates (mutual authentication) */
+    unsigned long int sslResumedConns;       /* resumed connections */
+    unsigned long int sslEphemeralMisses;    /* TLS v1.2 and older PFS / ephemeral connections missed (not able to decrypt) */
+    unsigned long int sslResumeMisses;       /* Resumption sessions not found */
+    unsigned long int sslCiphersUnsupported; /* No cipher suite match found when compared to supported */
+    unsigned long int sslKeysUnmatched;      /* Key callback failures (not found). Applies to WOLFSSL_SNIFFER_WATCH only */
+    unsigned long int sslKeyFails;           /* Failures loading or using keys */
+    unsigned long int sslDecodeFails;        /* Dropped packets (not application_data or match protocol version) */
+    unsigned long int sslAlerts;             /* Number of decoded alert messages */
+    unsigned long int sslDecryptedBytes;     /* Number of decrypted bytes */
+    unsigned long int sslEncryptedBytes;     /* Number of encrypted bytes */
+    unsigned long int sslEncryptedPackets;   /* Number of encrypted packets */
+    unsigned long int sslDecryptedPackets;   /* Number of decrypted packets */
+    unsigned long int sslKeyMatches;         /* Key callback successes (failures tracked in sslKeysUnmatched). Applies to WOLFSSL_SNIFFER_WATCH only. */
+    unsigned long int sslEncryptedConns;     /* Number of created sniffer sessions */
+    unsigned long int sslResumptionInserts;  /* Number of sessions reused with resumption */
 } SSLStats;
-
 
 WOLFSSL_API
 SSL_SNIFFER_API int ssl_ResetStatistics(void);
 
-
 WOLFSSL_API
 SSL_SNIFFER_API int ssl_ReadStatistics(SSLStats* stats);
 
-
 WOLFSSL_API
 SSL_SNIFFER_API int ssl_ReadResetStatistics(SSLStats* stats);
+
+
+#if defined(WOLFSSL_STATIC_EPHEMERAL) && defined(WOLFSSL_TLS13)
+/* macro indicating support for key callback */
+#undef  WOLFSSL_SNIFFER_KEY_CALLBACK
+#define WOLFSSL_SNIFFER_KEY_CALLBACK
 
 typedef int (*SSLKeyCb)(void* vSniffer, int namedGroup,
     const unsigned char* srvPub, unsigned int srvPubSz,
     const unsigned char* cliPub, unsigned int cliPubSz,
     DerBuffer* privKey, void* cbCtx, char* error);
 
-#if defined(WOLFSSL_STATIC_EPHEMERAL) && defined(WOLFSSL_TLS13)
-/* macro indicating support for key callback */
-#undef  WOLFSSL_SNIFFER_KEY_CALLBACK
-#define WOLFSSL_SNIFFER_KEY_CALLBACK
 WOLFSSL_API 
 SSL_SNIFFER_API int ssl_SetKeyCallback(SSLKeyCb cb, void* cbCtx);
 #endif


### PR DESCRIPTION
* Improved documentation for sniffer statistics (ZD 12731).
* TLS v1.3 DH KeyShare - Do not add DH padding on failure.
* Various spelling fixes.