### PR TITLE
Don't run test_wolfSSL_DSA_SIG if HAVE_FIPS is defined.

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -39276,7 +39276,8 @@ static void test_wolfSSL_EVP_PKEY_set1_get1_DSA(void)
 
 static void test_wolfSSL_DSA_SIG(void)
 {
-#if !defined (NO_DSA) && !defined(HAVE_SELFTEST) && defined(WOLFSSL_KEY_GEN)
+#if !defined(NO_DSA) && !defined(HAVE_SELFTEST) && defined(WOLFSSL_KEY_GEN) && \
+    !defined(HAVE_FIPS)
     DSA          *dsa  = NULL;
     DSA          *dsa2 = NULL;
     DSA_SIG      *sig  = NULL;


### PR DESCRIPTION
This test calls `wolfSSL_DSA_do_sign_ex` and `wolfSSL_DSA_do_verify_ex`, both
of which don't exist if `HAVE_FIPS` is defined.