### PR TITLE
SP RSA verify only: fix to compile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2911,7 +2911,8 @@ AC_ARG_ENABLE([asn],
 
 if test "$ENABLED_ASN" = "no"
 then
-    AM_CFLAGS="$AM_CFLAGS -DNO_ASN"
+    AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_ASN_CRYPT"
+    enable_pwdbased=no
     if test "$ENABLED_DH" = "no" && test "$ENABLED_ECC" = "no"
     then
         # DH and ECC need bigint

--- a/tests/api.c
+++ b/tests/api.c
@@ -16865,7 +16865,7 @@ static int test_wc_RsaKeyToPublicDer (void)
     word32      derLen = 162;
     #else
     int         bits = 2048;
-    word32      derLen = 290;
+    word32      derLen = 294;
     #endif
 
     XMEMSET(&rng, 0, sizeof(rng));

--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -249,6 +249,7 @@ static void sp_2048_to_bin_72(sp_digit* r, byte* a)
     }
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && (!defined(WOLFSSL_RSA_PUBLIC_ONLY) || !defined(WOLFSSL_SP_SMALL))) || defined(WOLFSSL_HAVE_SP_DH)
 /* Normalize the values in each word to 29 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -279,6 +280,7 @@ static void sp_2048_norm_36(sp_digit* a)
 #endif /* WOLFSSL_SP_SMALL */
 }
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && (!WOLFSSL_RSA_PUBLIC_ONLY || !WOLFSSL_SP_SMALL)) || WOLFSSL_HAVE_SP_DH */
 /* Normalize the values in each word to 29 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -3221,6 +3223,7 @@ static int sp_2048_mod_72(sp_digit* r, const sp_digit* a, const sp_digit* m)
     return sp_2048_div_72(a, m, NULL, r);
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 #if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
                                                      defined(WOLFSSL_HAVE_SP_DH)
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
@@ -3535,6 +3538,7 @@ static int sp_2048_mod_exp_72(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #endif /* (WOLFSSL_HAVE_SP_RSA & !WOLFSSL_RSA_PUBLIC_ONLY) || */
        /* WOLFSSL_HAVE_SP_DH */
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.
  *
@@ -5030,6 +5034,7 @@ static void sp_3072_to_bin_106(sp_digit* r, byte* a)
     }
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 /* Normalize the values in each word to 29 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -5043,6 +5048,7 @@ static void sp_3072_norm_53(sp_digit* a)
     }
 }
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 /* Normalize the values in each word to 29 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -6728,6 +6734,7 @@ static int sp_3072_mod_106(sp_digit* r, const sp_digit* a, const sp_digit* m)
     return sp_3072_div_106(a, m, NULL, r);
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
  *
  * r     A single precision number that is the result of the operation.
@@ -7038,6 +7045,7 @@ static int sp_3072_mod_exp_106(sp_digit* r, const sp_digit* a, const sp_digit* e
 #endif
 }
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.
  *
@@ -8380,6 +8388,7 @@ static void sp_3072_to_bin_112(sp_digit* r, byte* a)
     }
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 /* Normalize the values in each word to 28 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -8406,6 +8415,7 @@ static void sp_3072_norm_56(sp_digit* a)
     a[55] += a[54] >> 28; a[54] &= 0xfffffff;
 }
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 /* Normalize the values in each word to 28 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -10812,6 +10822,7 @@ static int sp_3072_mod_112(sp_digit* r, const sp_digit* a, const sp_digit* m)
     return sp_3072_div_112(a, m, NULL, r);
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 #if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
                                                      defined(WOLFSSL_HAVE_SP_DH)
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
@@ -11126,6 +11137,7 @@ static int sp_3072_mod_exp_112(sp_digit* r, const sp_digit* a, const sp_digit* e
 #endif /* (WOLFSSL_HAVE_SP_RSA & !WOLFSSL_RSA_PUBLIC_ONLY) || */
        /* WOLFSSL_HAVE_SP_DH */
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.
  *
@@ -12693,6 +12705,7 @@ static void sp_4096_to_bin_142(sp_digit* r, byte* a)
     }
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 #if defined(WOLFSSL_HAVE_SP_RSA) && !defined(SP_RSA_PRIVATE_EXP_D)
 /* Normalize the values in each word to 29 bits.
  *
@@ -12708,6 +12721,7 @@ static void sp_4096_norm_71(sp_digit* a)
 }
 
 #endif /* WOLFSSL_HAVE_SP_RSA & !SP_RSA_PRIVATE_EXP_D */
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 /* Normalize the values in each word to 29 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -14401,6 +14415,7 @@ static int sp_4096_mod_142(sp_digit* r, const sp_digit* a, const sp_digit* m)
     return sp_4096_div_142(a, m, NULL, r);
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
  *
  * r     A single precision number that is the result of the operation.
@@ -14711,6 +14726,7 @@ static int sp_4096_mod_exp_142(sp_digit* r, const sp_digit* a, const sp_digit* e
 #endif
 }
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.
  *
@@ -15911,6 +15927,7 @@ static void sp_4096_to_bin_162(sp_digit* r, byte* a)
     }
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 #if defined(WOLFSSL_HAVE_SP_RSA) && !defined(SP_RSA_PRIVATE_EXP_D)
 /* Normalize the values in each word to 26 bits.
  *
@@ -15932,6 +15949,7 @@ static void sp_4096_norm_81(sp_digit* a)
 }
 
 #endif /* WOLFSSL_HAVE_SP_RSA & !SP_RSA_PRIVATE_EXP_D */
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 /* Normalize the values in each word to 26 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -18293,6 +18311,7 @@ static int sp_4096_mod_162(sp_digit* r, const sp_digit* a, const sp_digit* m)
     return sp_4096_div_162(a, m, NULL, r);
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 #if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
                                                      defined(WOLFSSL_HAVE_SP_DH)
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
@@ -18607,6 +18626,7 @@ static int sp_4096_mod_exp_162(sp_digit* r, const sp_digit* a, const sp_digit* e
 #endif /* (WOLFSSL_HAVE_SP_RSA & !WOLFSSL_RSA_PUBLIC_ONLY) || */
        /* WOLFSSL_HAVE_SP_DH */
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.
  *

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -250,6 +250,7 @@ static void sp_2048_to_bin_34(sp_digit* r, byte* a)
     }
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 /* Normalize the values in each word to 61 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -263,6 +264,7 @@ static void sp_2048_norm_17(sp_digit* a)
     }
 }
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 /* Normalize the values in each word to 61 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -2177,6 +2179,7 @@ static int sp_2048_mod_34(sp_digit* r, const sp_digit* a, const sp_digit* m)
     return sp_2048_div_34(a, m, NULL, r);
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
  *
  * r     A single precision number that is the result of the operation.
@@ -2487,6 +2490,7 @@ static int sp_2048_mod_exp_34(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #endif
 }
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.
  *
@@ -3830,6 +3834,7 @@ static void sp_2048_to_bin_36(sp_digit* r, byte* a)
     }
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 /* Normalize the values in each word to 57 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -3850,6 +3855,7 @@ static void sp_2048_norm_18(sp_digit* a)
     a[17] += a[16] >> 57; a[16] &= 0x1ffffffffffffffL;
 }
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 /* Normalize the values in each word to 57 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -5730,6 +5736,7 @@ static int sp_2048_mod_36(sp_digit* r, const sp_digit* a, const sp_digit* m)
     return sp_2048_div_36(a, m, NULL, r);
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 #if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
                                                      defined(WOLFSSL_HAVE_SP_DH)
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
@@ -6044,6 +6051,7 @@ static int sp_2048_mod_exp_36(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #endif /* (WOLFSSL_HAVE_SP_RSA & !WOLFSSL_RSA_PUBLIC_ONLY) || */
        /* WOLFSSL_HAVE_SP_DH */
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.
  *
@@ -7460,6 +7468,7 @@ static void sp_3072_to_bin_52(sp_digit* r, byte* a)
     }
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 /* Normalize the values in each word to 60 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -7473,6 +7482,7 @@ static void sp_3072_norm_26(sp_digit* a)
     }
 }
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 /* Normalize the values in each word to 60 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -9142,6 +9152,7 @@ static int sp_3072_mod_52(sp_digit* r, const sp_digit* a, const sp_digit* m)
     return sp_3072_div_52(a, m, NULL, r);
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
  *
  * r     A single precision number that is the result of the operation.
@@ -9452,6 +9463,7 @@ static int sp_3072_mod_exp_52(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #endif
 }
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.
  *
@@ -10795,6 +10807,7 @@ static void sp_3072_to_bin_54(sp_digit* r, byte* a)
     }
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 /* Normalize the values in each word to 57 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -10816,6 +10829,7 @@ static void sp_3072_norm_27(sp_digit* a)
     a[26] += a[25] >> 57; a[25] &= 0x1ffffffffffffffL;
 }
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 /* Normalize the values in each word to 57 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -12844,6 +12858,7 @@ static int sp_3072_mod_54(sp_digit* r, const sp_digit* a, const sp_digit* m)
     return sp_3072_div_54(a, m, NULL, r);
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 #if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
                                                      defined(WOLFSSL_HAVE_SP_DH)
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
@@ -13158,6 +13173,7 @@ static int sp_3072_mod_exp_54(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #endif /* (WOLFSSL_HAVE_SP_RSA & !WOLFSSL_RSA_PUBLIC_ONLY) || */
        /* WOLFSSL_HAVE_SP_DH */
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.
  *
@@ -14610,6 +14626,7 @@ static void sp_4096_to_bin_70(sp_digit* r, byte* a)
     }
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 #if defined(WOLFSSL_HAVE_SP_RSA) && !defined(SP_RSA_PRIVATE_EXP_D)
 /* Normalize the values in each word to 59 bits.
  *
@@ -14625,6 +14642,7 @@ static void sp_4096_norm_35(sp_digit* a)
 }
 
 #endif /* WOLFSSL_HAVE_SP_RSA & !SP_RSA_PRIVATE_EXP_D */
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 /* Normalize the values in each word to 59 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -16213,6 +16231,7 @@ static int sp_4096_mod_70(sp_digit* r, const sp_digit* a, const sp_digit* m)
     return sp_4096_div_70(a, m, NULL, r);
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
  *
  * r     A single precision number that is the result of the operation.
@@ -16523,6 +16542,7 @@ static int sp_4096_mod_exp_70(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #endif
 }
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.
  *
@@ -17724,6 +17744,7 @@ static void sp_4096_to_bin_78(sp_digit* r, byte* a)
     }
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 #if defined(WOLFSSL_HAVE_SP_RSA) && !defined(SP_RSA_PRIVATE_EXP_D)
 /* Normalize the values in each word to 53 bits.
  *
@@ -17751,6 +17772,7 @@ static void sp_4096_norm_39(sp_digit* a)
 }
 
 #endif /* WOLFSSL_HAVE_SP_RSA & !SP_RSA_PRIVATE_EXP_D */
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 /* Normalize the values in each word to 53 bits.
  *
  * a  Array of sp_digit to normalize.
@@ -19907,6 +19929,7 @@ static int sp_4096_mod_78(sp_digit* r, const sp_digit* a, const sp_digit* m)
     return sp_4096_div_78(a, m, NULL, r);
 }
 
+#if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || defined(WOLFSSL_HAVE_SP_DH)
 #if (defined(WOLFSSL_HAVE_SP_RSA) && !defined(WOLFSSL_RSA_PUBLIC_ONLY)) || \
                                                      defined(WOLFSSL_HAVE_SP_DH)
 /* Modular exponentiate a to the e mod m. (r = a^e mod m)
@@ -20221,6 +20244,7 @@ static int sp_4096_mod_exp_78(sp_digit* r, const sp_digit* a, const sp_digit* e,
 #endif /* (WOLFSSL_HAVE_SP_RSA & !WOLFSSL_RSA_PUBLIC_ONLY) || */
        /* WOLFSSL_HAVE_SP_DH */
 
+#endif /* (WOLFSSL_HAVE_SP_RSA && !WOLFSSL_RSA_PUBLIC_ONLY) || WOLFSSL_HAVE_SP_DH */
 #ifdef WOLFSSL_HAVE_SP_RSA
 /* RSA public key operation.
  *

--- a/wolfcrypt/src/sp_x86_64_asm.S
+++ b/wolfcrypt/src/sp_x86_64_asm.S
@@ -11067,194 +11067,126 @@ L_2048_mont_loop_32:
 #ifndef __APPLE__
 .size	sp_2048_mont_reduce_32,.-sp_2048_mont_reduce_32
 #endif /* __APPLE__ */
-#ifdef HAVE_INTEL_AVX2
-/* Conditionally subtract b from a using the mask m.
- * m is -1 to subtract and 0 when not copying.
+/* Sub b from a into r. (r = a - b)
  *
- * r  A single precision number representing condition subtract result.
- * a  A single precision number to subtract from.
- * b  A single precision number to subtract.
- * m  Mask value to apply.
+ * r  A single precision integer.
+ * a  A single precision integer.
+ * b  A single precision integer.
  */
 #ifndef __APPLE__
 .text
-.globl	sp_2048_cond_sub_avx2_32
-.type	sp_2048_cond_sub_avx2_32,@function
+.globl	sp_2048_sub_32
+.type	sp_2048_sub_32,@function
 .align	16
-sp_2048_cond_sub_avx2_32:
+sp_2048_sub_32:
 #else
 .section	__TEXT,__text
-.globl	_sp_2048_cond_sub_avx2_32
+.globl	_sp_2048_sub_32
 .p2align	4
-_sp_2048_cond_sub_avx2_32:
+_sp_2048_sub_32:
 #endif /* __APPLE__ */
-        movq	$0x00, %rax
-        movq	(%rdx), %r10
-        movq	(%rsi), %r8
-        pextq	%rcx, %r10, %r10
-        subq	%r10, %r8
-        movq	8(%rdx), %r10
-        movq	8(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, (%rdi)
-        sbbq	%r10, %r9
-        movq	16(%rdx), %r8
-        movq	16(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 8(%rdi)
-        sbbq	%r8, %r10
-        movq	24(%rdx), %r9
+        movq	(%rsi), %rcx
+        xorq	%rax, %rax
+        subq	(%rdx), %rcx
+        movq	8(%rsi), %r8
+        movq	%rcx, (%rdi)
+        sbbq	8(%rdx), %r8
+        movq	16(%rsi), %rcx
+        movq	%r8, 8(%rdi)
+        sbbq	16(%rdx), %rcx
         movq	24(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 16(%rdi)
-        sbbq	%r9, %r8
-        movq	32(%rdx), %r10
-        movq	32(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 16(%rdi)
+        sbbq	24(%rdx), %r8
+        movq	32(%rsi), %rcx
         movq	%r8, 24(%rdi)
-        sbbq	%r10, %r9
-        movq	40(%rdx), %r8
-        movq	40(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 32(%rdi)
-        sbbq	%r8, %r10
-        movq	48(%rdx), %r9
-        movq	48(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 40(%rdi)
-        sbbq	%r9, %r8
-        movq	56(%rdx), %r10
-        movq	56(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 48(%rdi)
-        sbbq	%r10, %r9
-        movq	64(%rdx), %r8
-        movq	64(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 56(%rdi)
-        sbbq	%r8, %r10
-        movq	72(%rdx), %r9
+        sbbq	32(%rdx), %rcx
+        movq	40(%rsi), %r8
+        movq	%rcx, 32(%rdi)
+        sbbq	40(%rdx), %r8
+        movq	48(%rsi), %rcx
+        movq	%r8, 40(%rdi)
+        sbbq	48(%rdx), %rcx
+        movq	56(%rsi), %r8
+        movq	%rcx, 48(%rdi)
+        sbbq	56(%rdx), %r8
+        movq	64(%rsi), %rcx
+        movq	%r8, 56(%rdi)
+        sbbq	64(%rdx), %rcx
         movq	72(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 64(%rdi)
-        sbbq	%r9, %r8
-        movq	80(%rdx), %r10
-        movq	80(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 64(%rdi)
+        sbbq	72(%rdx), %r8
+        movq	80(%rsi), %rcx
         movq	%r8, 72(%rdi)
-        sbbq	%r10, %r9
-        movq	88(%rdx), %r8
-        movq	88(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 80(%rdi)
-        sbbq	%r8, %r10
-        movq	96(%rdx), %r9
-        movq	96(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 88(%rdi)
-        sbbq	%r9, %r8
-        movq	104(%rdx), %r10
-        movq	104(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 96(%rdi)
-        sbbq	%r10, %r9
-        movq	112(%rdx), %r8
-        movq	112(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 104(%rdi)
-        sbbq	%r8, %r10
-        movq	120(%rdx), %r9
+        sbbq	80(%rdx), %rcx
+        movq	88(%rsi), %r8
+        movq	%rcx, 80(%rdi)
+        sbbq	88(%rdx), %r8
+        movq	96(%rsi), %rcx
+        movq	%r8, 88(%rdi)
+        sbbq	96(%rdx), %rcx
+        movq	104(%rsi), %r8
+        movq	%rcx, 96(%rdi)
+        sbbq	104(%rdx), %r8
+        movq	112(%rsi), %rcx
+        movq	%r8, 104(%rdi)
+        sbbq	112(%rdx), %rcx
         movq	120(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 112(%rdi)
-        sbbq	%r9, %r8
-        movq	128(%rdx), %r10
-        movq	128(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 112(%rdi)
+        sbbq	120(%rdx), %r8
+        movq	128(%rsi), %rcx
         movq	%r8, 120(%rdi)
-        sbbq	%r10, %r9
-        movq	136(%rdx), %r8
-        movq	136(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 128(%rdi)
-        sbbq	%r8, %r10
-        movq	144(%rdx), %r9
-        movq	144(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 136(%rdi)
-        sbbq	%r9, %r8
-        movq	152(%rdx), %r10
-        movq	152(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 144(%rdi)
-        sbbq	%r10, %r9
-        movq	160(%rdx), %r8
-        movq	160(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 152(%rdi)
-        sbbq	%r8, %r10
-        movq	168(%rdx), %r9
+        sbbq	128(%rdx), %rcx
+        movq	136(%rsi), %r8
+        movq	%rcx, 128(%rdi)
+        sbbq	136(%rdx), %r8
+        movq	144(%rsi), %rcx
+        movq	%r8, 136(%rdi)
+        sbbq	144(%rdx), %rcx
+        movq	152(%rsi), %r8
+        movq	%rcx, 144(%rdi)
+        sbbq	152(%rdx), %r8
+        movq	160(%rsi), %rcx
+        movq	%r8, 152(%rdi)
+        sbbq	160(%rdx), %rcx
         movq	168(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 160(%rdi)
-        sbbq	%r9, %r8
-        movq	176(%rdx), %r10
-        movq	176(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 160(%rdi)
+        sbbq	168(%rdx), %r8
+        movq	176(%rsi), %rcx
         movq	%r8, 168(%rdi)
-        sbbq	%r10, %r9
-        movq	184(%rdx), %r8
-        movq	184(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 176(%rdi)
-        sbbq	%r8, %r10
-        movq	192(%rdx), %r9
-        movq	192(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 184(%rdi)
-        sbbq	%r9, %r8
-        movq	200(%rdx), %r10
-        movq	200(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 192(%rdi)
-        sbbq	%r10, %r9
-        movq	208(%rdx), %r8
-        movq	208(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 200(%rdi)
-        sbbq	%r8, %r10
-        movq	216(%rdx), %r9
+        sbbq	176(%rdx), %rcx
+        movq	184(%rsi), %r8
+        movq	%rcx, 176(%rdi)
+        sbbq	184(%rdx), %r8
+        movq	192(%rsi), %rcx
+        movq	%r8, 184(%rdi)
+        sbbq	192(%rdx), %rcx
+        movq	200(%rsi), %r8
+        movq	%rcx, 192(%rdi)
+        sbbq	200(%rdx), %r8
+        movq	208(%rsi), %rcx
+        movq	%r8, 200(%rdi)
+        sbbq	208(%rdx), %rcx
         movq	216(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 208(%rdi)
-        sbbq	%r9, %r8
-        movq	224(%rdx), %r10
-        movq	224(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 208(%rdi)
+        sbbq	216(%rdx), %r8
+        movq	224(%rsi), %rcx
         movq	%r8, 216(%rdi)
-        sbbq	%r10, %r9
-        movq	232(%rdx), %r8
-        movq	232(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 224(%rdi)
-        sbbq	%r8, %r10
-        movq	240(%rdx), %r9
-        movq	240(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 232(%rdi)
-        sbbq	%r9, %r8
-        movq	248(%rdx), %r10
-        movq	248(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 240(%rdi)
-        sbbq	%r10, %r9
-        movq	%r9, 248(%rdi)
+        sbbq	224(%rdx), %rcx
+        movq	232(%rsi), %r8
+        movq	%rcx, 224(%rdi)
+        sbbq	232(%rdx), %r8
+        movq	240(%rsi), %rcx
+        movq	%r8, 232(%rdi)
+        sbbq	240(%rdx), %rcx
+        movq	248(%rsi), %r8
+        movq	%rcx, 240(%rdi)
+        sbbq	248(%rdx), %r8
+        movq	%r8, 248(%rdi)
         sbbq	$0x00, %rax
         repz retq
 #ifndef __APPLE__
-.size	sp_2048_cond_sub_avx2_32,.-sp_2048_cond_sub_avx2_32
+.size	sp_2048_sub_32,.-sp_2048_sub_32
 #endif /* __APPLE__ */
-#endif /* HAVE_INTEL_AVX2 */
 #ifdef HAVE_INTEL_AVX2
 /* Mul a by digit b into r. (r = a * b)
  *
@@ -11502,6 +11434,194 @@ _div_2048_word_asm_32:
 .size	div_2048_word_asm_32,.-div_2048_word_asm_32
 #endif /* __APPLE__ */
 #endif /* _WIN64 */
+#ifdef HAVE_INTEL_AVX2
+/* Conditionally subtract b from a using the mask m.
+ * m is -1 to subtract and 0 when not copying.
+ *
+ * r  A single precision number representing condition subtract result.
+ * a  A single precision number to subtract from.
+ * b  A single precision number to subtract.
+ * m  Mask value to apply.
+ */
+#ifndef __APPLE__
+.text
+.globl	sp_2048_cond_sub_avx2_32
+.type	sp_2048_cond_sub_avx2_32,@function
+.align	16
+sp_2048_cond_sub_avx2_32:
+#else
+.section	__TEXT,__text
+.globl	_sp_2048_cond_sub_avx2_32
+.p2align	4
+_sp_2048_cond_sub_avx2_32:
+#endif /* __APPLE__ */
+        movq	$0x00, %rax
+        movq	(%rdx), %r10
+        movq	(%rsi), %r8
+        pextq	%rcx, %r10, %r10
+        subq	%r10, %r8
+        movq	8(%rdx), %r10
+        movq	8(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, (%rdi)
+        sbbq	%r10, %r9
+        movq	16(%rdx), %r8
+        movq	16(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 8(%rdi)
+        sbbq	%r8, %r10
+        movq	24(%rdx), %r9
+        movq	24(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 16(%rdi)
+        sbbq	%r9, %r8
+        movq	32(%rdx), %r10
+        movq	32(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 24(%rdi)
+        sbbq	%r10, %r9
+        movq	40(%rdx), %r8
+        movq	40(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 32(%rdi)
+        sbbq	%r8, %r10
+        movq	48(%rdx), %r9
+        movq	48(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 40(%rdi)
+        sbbq	%r9, %r8
+        movq	56(%rdx), %r10
+        movq	56(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 48(%rdi)
+        sbbq	%r10, %r9
+        movq	64(%rdx), %r8
+        movq	64(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 56(%rdi)
+        sbbq	%r8, %r10
+        movq	72(%rdx), %r9
+        movq	72(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 64(%rdi)
+        sbbq	%r9, %r8
+        movq	80(%rdx), %r10
+        movq	80(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 72(%rdi)
+        sbbq	%r10, %r9
+        movq	88(%rdx), %r8
+        movq	88(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 80(%rdi)
+        sbbq	%r8, %r10
+        movq	96(%rdx), %r9
+        movq	96(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 88(%rdi)
+        sbbq	%r9, %r8
+        movq	104(%rdx), %r10
+        movq	104(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 96(%rdi)
+        sbbq	%r10, %r9
+        movq	112(%rdx), %r8
+        movq	112(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 104(%rdi)
+        sbbq	%r8, %r10
+        movq	120(%rdx), %r9
+        movq	120(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 112(%rdi)
+        sbbq	%r9, %r8
+        movq	128(%rdx), %r10
+        movq	128(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 120(%rdi)
+        sbbq	%r10, %r9
+        movq	136(%rdx), %r8
+        movq	136(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 128(%rdi)
+        sbbq	%r8, %r10
+        movq	144(%rdx), %r9
+        movq	144(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 136(%rdi)
+        sbbq	%r9, %r8
+        movq	152(%rdx), %r10
+        movq	152(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 144(%rdi)
+        sbbq	%r10, %r9
+        movq	160(%rdx), %r8
+        movq	160(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 152(%rdi)
+        sbbq	%r8, %r10
+        movq	168(%rdx), %r9
+        movq	168(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 160(%rdi)
+        sbbq	%r9, %r8
+        movq	176(%rdx), %r10
+        movq	176(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 168(%rdi)
+        sbbq	%r10, %r9
+        movq	184(%rdx), %r8
+        movq	184(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 176(%rdi)
+        sbbq	%r8, %r10
+        movq	192(%rdx), %r9
+        movq	192(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 184(%rdi)
+        sbbq	%r9, %r8
+        movq	200(%rdx), %r10
+        movq	200(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 192(%rdi)
+        sbbq	%r10, %r9
+        movq	208(%rdx), %r8
+        movq	208(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 200(%rdi)
+        sbbq	%r8, %r10
+        movq	216(%rdx), %r9
+        movq	216(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 208(%rdi)
+        sbbq	%r9, %r8
+        movq	224(%rdx), %r10
+        movq	224(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 216(%rdi)
+        sbbq	%r10, %r9
+        movq	232(%rdx), %r8
+        movq	232(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 224(%rdi)
+        sbbq	%r8, %r10
+        movq	240(%rdx), %r9
+        movq	240(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 232(%rdi)
+        sbbq	%r9, %r8
+        movq	248(%rdx), %r10
+        movq	248(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 240(%rdi)
+        sbbq	%r10, %r9
+        movq	%r9, 248(%rdi)
+        sbbq	$0x00, %rax
+        repz retq
+#ifndef __APPLE__
+.size	sp_2048_cond_sub_avx2_32,.-sp_2048_cond_sub_avx2_32
+#endif /* __APPLE__ */
+#endif /* HAVE_INTEL_AVX2 */
 /* Compare a with b in constant time.
  *
  * a  A single precision integer.
@@ -11785,126 +11905,6 @@ _sp_2048_cmp_32:
         repz retq
 #ifndef __APPLE__
 .size	sp_2048_cmp_32,.-sp_2048_cmp_32
-#endif /* __APPLE__ */
-/* Sub b from a into r. (r = a - b)
- *
- * r  A single precision integer.
- * a  A single precision integer.
- * b  A single precision integer.
- */
-#ifndef __APPLE__
-.text
-.globl	sp_2048_sub_32
-.type	sp_2048_sub_32,@function
-.align	16
-sp_2048_sub_32:
-#else
-.section	__TEXT,__text
-.globl	_sp_2048_sub_32
-.p2align	4
-_sp_2048_sub_32:
-#endif /* __APPLE__ */
-        movq	(%rsi), %rcx
-        xorq	%rax, %rax
-        subq	(%rdx), %rcx
-        movq	8(%rsi), %r8
-        movq	%rcx, (%rdi)
-        sbbq	8(%rdx), %r8
-        movq	16(%rsi), %rcx
-        movq	%r8, 8(%rdi)
-        sbbq	16(%rdx), %rcx
-        movq	24(%rsi), %r8
-        movq	%rcx, 16(%rdi)
-        sbbq	24(%rdx), %r8
-        movq	32(%rsi), %rcx
-        movq	%r8, 24(%rdi)
-        sbbq	32(%rdx), %rcx
-        movq	40(%rsi), %r8
-        movq	%rcx, 32(%rdi)
-        sbbq	40(%rdx), %r8
-        movq	48(%rsi), %rcx
-        movq	%r8, 40(%rdi)
-        sbbq	48(%rdx), %rcx
-        movq	56(%rsi), %r8
-        movq	%rcx, 48(%rdi)
-        sbbq	56(%rdx), %r8
-        movq	64(%rsi), %rcx
-        movq	%r8, 56(%rdi)
-        sbbq	64(%rdx), %rcx
-        movq	72(%rsi), %r8
-        movq	%rcx, 64(%rdi)
-        sbbq	72(%rdx), %r8
-        movq	80(%rsi), %rcx
-        movq	%r8, 72(%rdi)
-        sbbq	80(%rdx), %rcx
-        movq	88(%rsi), %r8
-        movq	%rcx, 80(%rdi)
-        sbbq	88(%rdx), %r8
-        movq	96(%rsi), %rcx
-        movq	%r8, 88(%rdi)
-        sbbq	96(%rdx), %rcx
-        movq	104(%rsi), %r8
-        movq	%rcx, 96(%rdi)
-        sbbq	104(%rdx), %r8
-        movq	112(%rsi), %rcx
-        movq	%r8, 104(%rdi)
-        sbbq	112(%rdx), %rcx
-        movq	120(%rsi), %r8
-        movq	%rcx, 112(%rdi)
-        sbbq	120(%rdx), %r8
-        movq	128(%rsi), %rcx
-        movq	%r8, 120(%rdi)
-        sbbq	128(%rdx), %rcx
-        movq	136(%rsi), %r8
-        movq	%rcx, 128(%rdi)
-        sbbq	136(%rdx), %r8
-        movq	144(%rsi), %rcx
-        movq	%r8, 136(%rdi)
-        sbbq	144(%rdx), %rcx
-        movq	152(%rsi), %r8
-        movq	%rcx, 144(%rdi)
-        sbbq	152(%rdx), %r8
-        movq	160(%rsi), %rcx
-        movq	%r8, 152(%rdi)
-        sbbq	160(%rdx), %rcx
-        movq	168(%rsi), %r8
-        movq	%rcx, 160(%rdi)
-        sbbq	168(%rdx), %r8
-        movq	176(%rsi), %rcx
-        movq	%r8, 168(%rdi)
-        sbbq	176(%rdx), %rcx
-        movq	184(%rsi), %r8
-        movq	%rcx, 176(%rdi)
-        sbbq	184(%rdx), %r8
-        movq	192(%rsi), %rcx
-        movq	%r8, 184(%rdi)
-        sbbq	192(%rdx), %rcx
-        movq	200(%rsi), %r8
-        movq	%rcx, 192(%rdi)
-        sbbq	200(%rdx), %r8
-        movq	208(%rsi), %rcx
-        movq	%r8, 200(%rdi)
-        sbbq	208(%rdx), %rcx
-        movq	216(%rsi), %r8
-        movq	%rcx, 208(%rdi)
-        sbbq	216(%rdx), %r8
-        movq	224(%rsi), %rcx
-        movq	%r8, 216(%rdi)
-        sbbq	224(%rdx), %rcx
-        movq	232(%rsi), %r8
-        movq	%rcx, 224(%rdi)
-        sbbq	232(%rdx), %r8
-        movq	240(%rsi), %rcx
-        movq	%r8, 232(%rdi)
-        sbbq	240(%rdx), %rcx
-        movq	248(%rsi), %r8
-        movq	%rcx, 240(%rdi)
-        sbbq	248(%rdx), %r8
-        movq	%r8, 248(%rdi)
-        sbbq	$0x00, %rax
-        repz retq
-#ifndef __APPLE__
-.size	sp_2048_sub_32,.-sp_2048_sub_32
 #endif /* __APPLE__ */
 #ifdef HAVE_INTEL_AVX2
 /* Reduce the number back to 2048 bits using Montgomery reduction.
@@ -25764,274 +25764,174 @@ L_3072_mont_loop_48:
 #ifndef __APPLE__
 .size	sp_3072_mont_reduce_48,.-sp_3072_mont_reduce_48
 #endif /* __APPLE__ */
-#ifdef HAVE_INTEL_AVX2
-/* Conditionally subtract b from a using the mask m.
- * m is -1 to subtract and 0 when not copying.
+/* Sub b from a into r. (r = a - b)
  *
- * r  A single precision number representing condition subtract result.
- * a  A single precision number to subtract from.
- * b  A single precision number to subtract.
- * m  Mask value to apply.
+ * r  A single precision integer.
+ * a  A single precision integer.
+ * b  A single precision integer.
  */
 #ifndef __APPLE__
 .text
-.globl	sp_3072_cond_sub_avx2_48
-.type	sp_3072_cond_sub_avx2_48,@function
+.globl	sp_3072_sub_48
+.type	sp_3072_sub_48,@function
 .align	16
-sp_3072_cond_sub_avx2_48:
+sp_3072_sub_48:
 #else
 .section	__TEXT,__text
-.globl	_sp_3072_cond_sub_avx2_48
+.globl	_sp_3072_sub_48
 .p2align	4
-_sp_3072_cond_sub_avx2_48:
+_sp_3072_sub_48:
 #endif /* __APPLE__ */
-        movq	$0x00, %rax
-        movq	(%rdx), %r10
-        movq	(%rsi), %r8
-        pextq	%rcx, %r10, %r10
-        subq	%r10, %r8
-        movq	8(%rdx), %r10
-        movq	8(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, (%rdi)
-        sbbq	%r10, %r9
-        movq	16(%rdx), %r8
-        movq	16(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 8(%rdi)
-        sbbq	%r8, %r10
-        movq	24(%rdx), %r9
+        movq	(%rsi), %rcx
+        xorq	%rax, %rax
+        subq	(%rdx), %rcx
+        movq	8(%rsi), %r8
+        movq	%rcx, (%rdi)
+        sbbq	8(%rdx), %r8
+        movq	16(%rsi), %rcx
+        movq	%r8, 8(%rdi)
+        sbbq	16(%rdx), %rcx
         movq	24(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 16(%rdi)
-        sbbq	%r9, %r8
-        movq	32(%rdx), %r10
-        movq	32(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 16(%rdi)
+        sbbq	24(%rdx), %r8
+        movq	32(%rsi), %rcx
         movq	%r8, 24(%rdi)
-        sbbq	%r10, %r9
-        movq	40(%rdx), %r8
-        movq	40(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 32(%rdi)
-        sbbq	%r8, %r10
-        movq	48(%rdx), %r9
-        movq	48(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 40(%rdi)
-        sbbq	%r9, %r8
-        movq	56(%rdx), %r10
-        movq	56(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 48(%rdi)
-        sbbq	%r10, %r9
-        movq	64(%rdx), %r8
-        movq	64(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 56(%rdi)
-        sbbq	%r8, %r10
-        movq	72(%rdx), %r9
+        sbbq	32(%rdx), %rcx
+        movq	40(%rsi), %r8
+        movq	%rcx, 32(%rdi)
+        sbbq	40(%rdx), %r8
+        movq	48(%rsi), %rcx
+        movq	%r8, 40(%rdi)
+        sbbq	48(%rdx), %rcx
+        movq	56(%rsi), %r8
+        movq	%rcx, 48(%rdi)
+        sbbq	56(%rdx), %r8
+        movq	64(%rsi), %rcx
+        movq	%r8, 56(%rdi)
+        sbbq	64(%rdx), %rcx
         movq	72(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 64(%rdi)
-        sbbq	%r9, %r8
-        movq	80(%rdx), %r10
-        movq	80(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 64(%rdi)
+        sbbq	72(%rdx), %r8
+        movq	80(%rsi), %rcx
         movq	%r8, 72(%rdi)
-        sbbq	%r10, %r9
-        movq	88(%rdx), %r8
-        movq	88(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 80(%rdi)
-        sbbq	%r8, %r10
-        movq	96(%rdx), %r9
-        movq	96(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 88(%rdi)
-        sbbq	%r9, %r8
-        movq	104(%rdx), %r10
-        movq	104(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 96(%rdi)
-        sbbq	%r10, %r9
-        movq	112(%rdx), %r8
-        movq	112(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 104(%rdi)
-        sbbq	%r8, %r10
-        movq	120(%rdx), %r9
+        sbbq	80(%rdx), %rcx
+        movq	88(%rsi), %r8
+        movq	%rcx, 80(%rdi)
+        sbbq	88(%rdx), %r8
+        movq	96(%rsi), %rcx
+        movq	%r8, 88(%rdi)
+        sbbq	96(%rdx), %rcx
+        movq	104(%rsi), %r8
+        movq	%rcx, 96(%rdi)
+        sbbq	104(%rdx), %r8
+        movq	112(%rsi), %rcx
+        movq	%r8, 104(%rdi)
+        sbbq	112(%rdx), %rcx
         movq	120(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 112(%rdi)
-        sbbq	%r9, %r8
-        movq	128(%rdx), %r10
-        movq	128(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 112(%rdi)
+        sbbq	120(%rdx), %r8
+        movq	128(%rsi), %rcx
         movq	%r8, 120(%rdi)
-        sbbq	%r10, %r9
-        movq	136(%rdx), %r8
-        movq	136(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 128(%rdi)
-        sbbq	%r8, %r10
-        movq	144(%rdx), %r9
-        movq	144(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 136(%rdi)
-        sbbq	%r9, %r8
-        movq	152(%rdx), %r10
-        movq	152(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 144(%rdi)
-        sbbq	%r10, %r9
-        movq	160(%rdx), %r8
-        movq	160(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 152(%rdi)
-        sbbq	%r8, %r10
-        movq	168(%rdx), %r9
+        sbbq	128(%rdx), %rcx
+        movq	136(%rsi), %r8
+        movq	%rcx, 128(%rdi)
+        sbbq	136(%rdx), %r8
+        movq	144(%rsi), %rcx
+        movq	%r8, 136(%rdi)
+        sbbq	144(%rdx), %rcx
+        movq	152(%rsi), %r8
+        movq	%rcx, 144(%rdi)
+        sbbq	152(%rdx), %r8
+        movq	160(%rsi), %rcx
+        movq	%r8, 152(%rdi)
+        sbbq	160(%rdx), %rcx
         movq	168(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 160(%rdi)
-        sbbq	%r9, %r8
-        movq	176(%rdx), %r10
-        movq	176(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 160(%rdi)
+        sbbq	168(%rdx), %r8
+        movq	176(%rsi), %rcx
         movq	%r8, 168(%rdi)
-        sbbq	%r10, %r9
-        movq	184(%rdx), %r8
-        movq	184(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 176(%rdi)
-        sbbq	%r8, %r10
-        movq	192(%rdx), %r9
-        movq	192(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 184(%rdi)
-        sbbq	%r9, %r8
-        movq	200(%rdx), %r10
-        movq	200(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 192(%rdi)
-        sbbq	%r10, %r9
-        movq	208(%rdx), %r8
-        movq	208(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 200(%rdi)
-        sbbq	%r8, %r10
-        movq	216(%rdx), %r9
+        sbbq	176(%rdx), %rcx
+        movq	184(%rsi), %r8
+        movq	%rcx, 176(%rdi)
+        sbbq	184(%rdx), %r8
+        movq	192(%rsi), %rcx
+        movq	%r8, 184(%rdi)
+        sbbq	192(%rdx), %rcx
+        movq	200(%rsi), %r8
+        movq	%rcx, 192(%rdi)
+        sbbq	200(%rdx), %r8
+        movq	208(%rsi), %rcx
+        movq	%r8, 200(%rdi)
+        sbbq	208(%rdx), %rcx
         movq	216(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 208(%rdi)
-        sbbq	%r9, %r8
-        movq	224(%rdx), %r10
-        movq	224(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 208(%rdi)
+        sbbq	216(%rdx), %r8
+        movq	224(%rsi), %rcx
         movq	%r8, 216(%rdi)
-        sbbq	%r10, %r9
-        movq	232(%rdx), %r8
-        movq	232(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 224(%rdi)
-        sbbq	%r8, %r10
-        movq	240(%rdx), %r9
-        movq	240(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 232(%rdi)
-        sbbq	%r9, %r8
-        movq	248(%rdx), %r10
-        movq	248(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 240(%rdi)
-        sbbq	%r10, %r9
-        movq	256(%rdx), %r8
-        movq	256(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 248(%rdi)
-        sbbq	%r8, %r10
-        movq	264(%rdx), %r9
+        sbbq	224(%rdx), %rcx
+        movq	232(%rsi), %r8
+        movq	%rcx, 224(%rdi)
+        sbbq	232(%rdx), %r8
+        movq	240(%rsi), %rcx
+        movq	%r8, 232(%rdi)
+        sbbq	240(%rdx), %rcx
+        movq	248(%rsi), %r8
+        movq	%rcx, 240(%rdi)
+        sbbq	248(%rdx), %r8
+        movq	256(%rsi), %rcx
+        movq	%r8, 248(%rdi)
+        sbbq	256(%rdx), %rcx
         movq	264(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 256(%rdi)
-        sbbq	%r9, %r8
-        movq	272(%rdx), %r10
-        movq	272(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 256(%rdi)
+        sbbq	264(%rdx), %r8
+        movq	272(%rsi), %rcx
         movq	%r8, 264(%rdi)
-        sbbq	%r10, %r9
-        movq	280(%rdx), %r8
-        movq	280(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 272(%rdi)
-        sbbq	%r8, %r10
-        movq	288(%rdx), %r9
-        movq	288(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 280(%rdi)
-        sbbq	%r9, %r8
-        movq	296(%rdx), %r10
-        movq	296(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 288(%rdi)
-        sbbq	%r10, %r9
-        movq	304(%rdx), %r8
-        movq	304(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 296(%rdi)
-        sbbq	%r8, %r10
-        movq	312(%rdx), %r9
+        sbbq	272(%rdx), %rcx
+        movq	280(%rsi), %r8
+        movq	%rcx, 272(%rdi)
+        sbbq	280(%rdx), %r8
+        movq	288(%rsi), %rcx
+        movq	%r8, 280(%rdi)
+        sbbq	288(%rdx), %rcx
+        movq	296(%rsi), %r8
+        movq	%rcx, 288(%rdi)
+        sbbq	296(%rdx), %r8
+        movq	304(%rsi), %rcx
+        movq	%r8, 296(%rdi)
+        sbbq	304(%rdx), %rcx
         movq	312(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 304(%rdi)
-        sbbq	%r9, %r8
-        movq	320(%rdx), %r10
-        movq	320(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 304(%rdi)
+        sbbq	312(%rdx), %r8
+        movq	320(%rsi), %rcx
         movq	%r8, 312(%rdi)
-        sbbq	%r10, %r9
-        movq	328(%rdx), %r8
-        movq	328(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 320(%rdi)
-        sbbq	%r8, %r10
-        movq	336(%rdx), %r9
-        movq	336(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 328(%rdi)
-        sbbq	%r9, %r8
-        movq	344(%rdx), %r10
-        movq	344(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 336(%rdi)
-        sbbq	%r10, %r9
-        movq	352(%rdx), %r8
-        movq	352(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 344(%rdi)
-        sbbq	%r8, %r10
-        movq	360(%rdx), %r9
+        sbbq	320(%rdx), %rcx
+        movq	328(%rsi), %r8
+        movq	%rcx, 320(%rdi)
+        sbbq	328(%rdx), %r8
+        movq	336(%rsi), %rcx
+        movq	%r8, 328(%rdi)
+        sbbq	336(%rdx), %rcx
+        movq	344(%rsi), %r8
+        movq	%rcx, 336(%rdi)
+        sbbq	344(%rdx), %r8
+        movq	352(%rsi), %rcx
+        movq	%r8, 344(%rdi)
+        sbbq	352(%rdx), %rcx
         movq	360(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 352(%rdi)
-        sbbq	%r9, %r8
-        movq	368(%rdx), %r10
-        movq	368(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 352(%rdi)
+        sbbq	360(%rdx), %r8
+        movq	368(%rsi), %rcx
         movq	%r8, 360(%rdi)
-        sbbq	%r10, %r9
-        movq	376(%rdx), %r8
-        movq	376(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 368(%rdi)
-        sbbq	%r8, %r10
-        movq	%r10, 376(%rdi)
+        sbbq	368(%rdx), %rcx
+        movq	376(%rsi), %r8
+        movq	%rcx, 368(%rdi)
+        sbbq	376(%rdx), %r8
+        movq	%r8, 376(%rdi)
         sbbq	$0x00, %rax
         repz retq
 #ifndef __APPLE__
-.size	sp_3072_cond_sub_avx2_48,.-sp_3072_cond_sub_avx2_48
+.size	sp_3072_sub_48,.-sp_3072_sub_48
 #endif /* __APPLE__ */
-#endif /* HAVE_INTEL_AVX2 */
 #ifdef HAVE_INTEL_AVX2
 /* Mul a by digit b into r. (r = a * b)
  *
@@ -26375,6 +26275,274 @@ _div_3072_word_asm_48:
 .size	div_3072_word_asm_48,.-div_3072_word_asm_48
 #endif /* __APPLE__ */
 #endif /* _WIN64 */
+#ifdef HAVE_INTEL_AVX2
+/* Conditionally subtract b from a using the mask m.
+ * m is -1 to subtract and 0 when not copying.
+ *
+ * r  A single precision number representing condition subtract result.
+ * a  A single precision number to subtract from.
+ * b  A single precision number to subtract.
+ * m  Mask value to apply.
+ */
+#ifndef __APPLE__
+.text
+.globl	sp_3072_cond_sub_avx2_48
+.type	sp_3072_cond_sub_avx2_48,@function
+.align	16
+sp_3072_cond_sub_avx2_48:
+#else
+.section	__TEXT,__text
+.globl	_sp_3072_cond_sub_avx2_48
+.p2align	4
+_sp_3072_cond_sub_avx2_48:
+#endif /* __APPLE__ */
+        movq	$0x00, %rax
+        movq	(%rdx), %r10
+        movq	(%rsi), %r8
+        pextq	%rcx, %r10, %r10
+        subq	%r10, %r8
+        movq	8(%rdx), %r10
+        movq	8(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, (%rdi)
+        sbbq	%r10, %r9
+        movq	16(%rdx), %r8
+        movq	16(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 8(%rdi)
+        sbbq	%r8, %r10
+        movq	24(%rdx), %r9
+        movq	24(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 16(%rdi)
+        sbbq	%r9, %r8
+        movq	32(%rdx), %r10
+        movq	32(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 24(%rdi)
+        sbbq	%r10, %r9
+        movq	40(%rdx), %r8
+        movq	40(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 32(%rdi)
+        sbbq	%r8, %r10
+        movq	48(%rdx), %r9
+        movq	48(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 40(%rdi)
+        sbbq	%r9, %r8
+        movq	56(%rdx), %r10
+        movq	56(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 48(%rdi)
+        sbbq	%r10, %r9
+        movq	64(%rdx), %r8
+        movq	64(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 56(%rdi)
+        sbbq	%r8, %r10
+        movq	72(%rdx), %r9
+        movq	72(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 64(%rdi)
+        sbbq	%r9, %r8
+        movq	80(%rdx), %r10
+        movq	80(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 72(%rdi)
+        sbbq	%r10, %r9
+        movq	88(%rdx), %r8
+        movq	88(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 80(%rdi)
+        sbbq	%r8, %r10
+        movq	96(%rdx), %r9
+        movq	96(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 88(%rdi)
+        sbbq	%r9, %r8
+        movq	104(%rdx), %r10
+        movq	104(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 96(%rdi)
+        sbbq	%r10, %r9
+        movq	112(%rdx), %r8
+        movq	112(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 104(%rdi)
+        sbbq	%r8, %r10
+        movq	120(%rdx), %r9
+        movq	120(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 112(%rdi)
+        sbbq	%r9, %r8
+        movq	128(%rdx), %r10
+        movq	128(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 120(%rdi)
+        sbbq	%r10, %r9
+        movq	136(%rdx), %r8
+        movq	136(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 128(%rdi)
+        sbbq	%r8, %r10
+        movq	144(%rdx), %r9
+        movq	144(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 136(%rdi)
+        sbbq	%r9, %r8
+        movq	152(%rdx), %r10
+        movq	152(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 144(%rdi)
+        sbbq	%r10, %r9
+        movq	160(%rdx), %r8
+        movq	160(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 152(%rdi)
+        sbbq	%r8, %r10
+        movq	168(%rdx), %r9
+        movq	168(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 160(%rdi)
+        sbbq	%r9, %r8
+        movq	176(%rdx), %r10
+        movq	176(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 168(%rdi)
+        sbbq	%r10, %r9
+        movq	184(%rdx), %r8
+        movq	184(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 176(%rdi)
+        sbbq	%r8, %r10
+        movq	192(%rdx), %r9
+        movq	192(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 184(%rdi)
+        sbbq	%r9, %r8
+        movq	200(%rdx), %r10
+        movq	200(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 192(%rdi)
+        sbbq	%r10, %r9
+        movq	208(%rdx), %r8
+        movq	208(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 200(%rdi)
+        sbbq	%r8, %r10
+        movq	216(%rdx), %r9
+        movq	216(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 208(%rdi)
+        sbbq	%r9, %r8
+        movq	224(%rdx), %r10
+        movq	224(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 216(%rdi)
+        sbbq	%r10, %r9
+        movq	232(%rdx), %r8
+        movq	232(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 224(%rdi)
+        sbbq	%r8, %r10
+        movq	240(%rdx), %r9
+        movq	240(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 232(%rdi)
+        sbbq	%r9, %r8
+        movq	248(%rdx), %r10
+        movq	248(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 240(%rdi)
+        sbbq	%r10, %r9
+        movq	256(%rdx), %r8
+        movq	256(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 248(%rdi)
+        sbbq	%r8, %r10
+        movq	264(%rdx), %r9
+        movq	264(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 256(%rdi)
+        sbbq	%r9, %r8
+        movq	272(%rdx), %r10
+        movq	272(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 264(%rdi)
+        sbbq	%r10, %r9
+        movq	280(%rdx), %r8
+        movq	280(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 272(%rdi)
+        sbbq	%r8, %r10
+        movq	288(%rdx), %r9
+        movq	288(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 280(%rdi)
+        sbbq	%r9, %r8
+        movq	296(%rdx), %r10
+        movq	296(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 288(%rdi)
+        sbbq	%r10, %r9
+        movq	304(%rdx), %r8
+        movq	304(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 296(%rdi)
+        sbbq	%r8, %r10
+        movq	312(%rdx), %r9
+        movq	312(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 304(%rdi)
+        sbbq	%r9, %r8
+        movq	320(%rdx), %r10
+        movq	320(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 312(%rdi)
+        sbbq	%r10, %r9
+        movq	328(%rdx), %r8
+        movq	328(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 320(%rdi)
+        sbbq	%r8, %r10
+        movq	336(%rdx), %r9
+        movq	336(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 328(%rdi)
+        sbbq	%r9, %r8
+        movq	344(%rdx), %r10
+        movq	344(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 336(%rdi)
+        sbbq	%r10, %r9
+        movq	352(%rdx), %r8
+        movq	352(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 344(%rdi)
+        sbbq	%r8, %r10
+        movq	360(%rdx), %r9
+        movq	360(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 352(%rdi)
+        sbbq	%r9, %r8
+        movq	368(%rdx), %r10
+        movq	368(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 360(%rdi)
+        sbbq	%r10, %r9
+        movq	376(%rdx), %r8
+        movq	376(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 368(%rdi)
+        sbbq	%r8, %r10
+        movq	%r10, 376(%rdi)
+        sbbq	$0x00, %rax
+        repz retq
+#ifndef __APPLE__
+.size	sp_3072_cond_sub_avx2_48,.-sp_3072_cond_sub_avx2_48
+#endif /* __APPLE__ */
+#endif /* HAVE_INTEL_AVX2 */
 /* Compare a with b in constant time.
  *
  * a  A single precision integer.
@@ -26786,174 +26954,6 @@ _sp_3072_cmp_48:
         repz retq
 #ifndef __APPLE__
 .size	sp_3072_cmp_48,.-sp_3072_cmp_48
-#endif /* __APPLE__ */
-/* Sub b from a into r. (r = a - b)
- *
- * r  A single precision integer.
- * a  A single precision integer.
- * b  A single precision integer.
- */
-#ifndef __APPLE__
-.text
-.globl	sp_3072_sub_48
-.type	sp_3072_sub_48,@function
-.align	16
-sp_3072_sub_48:
-#else
-.section	__TEXT,__text
-.globl	_sp_3072_sub_48
-.p2align	4
-_sp_3072_sub_48:
-#endif /* __APPLE__ */
-        movq	(%rsi), %rcx
-        xorq	%rax, %rax
-        subq	(%rdx), %rcx
-        movq	8(%rsi), %r8
-        movq	%rcx, (%rdi)
-        sbbq	8(%rdx), %r8
-        movq	16(%rsi), %rcx
-        movq	%r8, 8(%rdi)
-        sbbq	16(%rdx), %rcx
-        movq	24(%rsi), %r8
-        movq	%rcx, 16(%rdi)
-        sbbq	24(%rdx), %r8
-        movq	32(%rsi), %rcx
-        movq	%r8, 24(%rdi)
-        sbbq	32(%rdx), %rcx
-        movq	40(%rsi), %r8
-        movq	%rcx, 32(%rdi)
-        sbbq	40(%rdx), %r8
-        movq	48(%rsi), %rcx
-        movq	%r8, 40(%rdi)
-        sbbq	48(%rdx), %rcx
-        movq	56(%rsi), %r8
-        movq	%rcx, 48(%rdi)
-        sbbq	56(%rdx), %r8
-        movq	64(%rsi), %rcx
-        movq	%r8, 56(%rdi)
-        sbbq	64(%rdx), %rcx
-        movq	72(%rsi), %r8
-        movq	%rcx, 64(%rdi)
-        sbbq	72(%rdx), %r8
-        movq	80(%rsi), %rcx
-        movq	%r8, 72(%rdi)
-        sbbq	80(%rdx), %rcx
-        movq	88(%rsi), %r8
-        movq	%rcx, 80(%rdi)
-        sbbq	88(%rdx), %r8
-        movq	96(%rsi), %rcx
-        movq	%r8, 88(%rdi)
-        sbbq	96(%rdx), %rcx
-        movq	104(%rsi), %r8
-        movq	%rcx, 96(%rdi)
-        sbbq	104(%rdx), %r8
-        movq	112(%rsi), %rcx
-        movq	%r8, 104(%rdi)
-        sbbq	112(%rdx), %rcx
-        movq	120(%rsi), %r8
-        movq	%rcx, 112(%rdi)
-        sbbq	120(%rdx), %r8
-        movq	128(%rsi), %rcx
-        movq	%r8, 120(%rdi)
-        sbbq	128(%rdx), %rcx
-        movq	136(%rsi), %r8
-        movq	%rcx, 128(%rdi)
-        sbbq	136(%rdx), %r8
-        movq	144(%rsi), %rcx
-        movq	%r8, 136(%rdi)
-        sbbq	144(%rdx), %rcx
-        movq	152(%rsi), %r8
-        movq	%rcx, 144(%rdi)
-        sbbq	152(%rdx), %r8
-        movq	160(%rsi), %rcx
-        movq	%r8, 152(%rdi)
-        sbbq	160(%rdx), %rcx
-        movq	168(%rsi), %r8
-        movq	%rcx, 160(%rdi)
-        sbbq	168(%rdx), %r8
-        movq	176(%rsi), %rcx
-        movq	%r8, 168(%rdi)
-        sbbq	176(%rdx), %rcx
-        movq	184(%rsi), %r8
-        movq	%rcx, 176(%rdi)
-        sbbq	184(%rdx), %r8
-        movq	192(%rsi), %rcx
-        movq	%r8, 184(%rdi)
-        sbbq	192(%rdx), %rcx
-        movq	200(%rsi), %r8
-        movq	%rcx, 192(%rdi)
-        sbbq	200(%rdx), %r8
-        movq	208(%rsi), %rcx
-        movq	%r8, 200(%rdi)
-        sbbq	208(%rdx), %rcx
-        movq	216(%rsi), %r8
-        movq	%rcx, 208(%rdi)
-        sbbq	216(%rdx), %r8
-        movq	224(%rsi), %rcx
-        movq	%r8, 216(%rdi)
-        sbbq	224(%rdx), %rcx
-        movq	232(%rsi), %r8
-        movq	%rcx, 224(%rdi)
-        sbbq	232(%rdx), %r8
-        movq	240(%rsi), %rcx
-        movq	%r8, 232(%rdi)
-        sbbq	240(%rdx), %rcx
-        movq	248(%rsi), %r8
-        movq	%rcx, 240(%rdi)
-        sbbq	248(%rdx), %r8
-        movq	256(%rsi), %rcx
-        movq	%r8, 248(%rdi)
-        sbbq	256(%rdx), %rcx
-        movq	264(%rsi), %r8
-        movq	%rcx, 256(%rdi)
-        sbbq	264(%rdx), %r8
-        movq	272(%rsi), %rcx
-        movq	%r8, 264(%rdi)
-        sbbq	272(%rdx), %rcx
-        movq	280(%rsi), %r8
-        movq	%rcx, 272(%rdi)
-        sbbq	280(%rdx), %r8
-        movq	288(%rsi), %rcx
-        movq	%r8, 280(%rdi)
-        sbbq	288(%rdx), %rcx
-        movq	296(%rsi), %r8
-        movq	%rcx, 288(%rdi)
-        sbbq	296(%rdx), %r8
-        movq	304(%rsi), %rcx
-        movq	%r8, 296(%rdi)
-        sbbq	304(%rdx), %rcx
-        movq	312(%rsi), %r8
-        movq	%rcx, 304(%rdi)
-        sbbq	312(%rdx), %r8
-        movq	320(%rsi), %rcx
-        movq	%r8, 312(%rdi)
-        sbbq	320(%rdx), %rcx
-        movq	328(%rsi), %r8
-        movq	%rcx, 320(%rdi)
-        sbbq	328(%rdx), %r8
-        movq	336(%rsi), %rcx
-        movq	%r8, 328(%rdi)
-        sbbq	336(%rdx), %rcx
-        movq	344(%rsi), %r8
-        movq	%rcx, 336(%rdi)
-        sbbq	344(%rdx), %r8
-        movq	352(%rsi), %rcx
-        movq	%r8, 344(%rdi)
-        sbbq	352(%rdx), %rcx
-        movq	360(%rsi), %r8
-        movq	%rcx, 352(%rdi)
-        sbbq	360(%rdx), %r8
-        movq	368(%rsi), %rcx
-        movq	%r8, 360(%rdi)
-        sbbq	368(%rdx), %rcx
-        movq	376(%rsi), %r8
-        movq	%rcx, 368(%rdi)
-        sbbq	376(%rdx), %r8
-        movq	%r8, 376(%rdi)
-        sbbq	$0x00, %rax
-        repz retq
-#ifndef __APPLE__
-.size	sp_3072_sub_48,.-sp_3072_sub_48
 #endif /* __APPLE__ */
 #ifdef HAVE_INTEL_AVX2
 /* Reduce the number back to 3072 bits using Montgomery reduction.
@@ -35677,354 +35677,222 @@ L_4096_mont_loop_64:
 #ifndef __APPLE__
 .size	sp_4096_mont_reduce_64,.-sp_4096_mont_reduce_64
 #endif /* __APPLE__ */
-#ifdef HAVE_INTEL_AVX2
-/* Conditionally subtract b from a using the mask m.
- * m is -1 to subtract and 0 when not copying.
+/* Sub b from a into r. (r = a - b)
  *
- * r  A single precision number representing condition subtract result.
- * a  A single precision number to subtract from.
- * b  A single precision number to subtract.
- * m  Mask value to apply.
+ * r  A single precision integer.
+ * a  A single precision integer.
+ * b  A single precision integer.
  */
 #ifndef __APPLE__
 .text
-.globl	sp_4096_cond_sub_avx2_64
-.type	sp_4096_cond_sub_avx2_64,@function
+.globl	sp_4096_sub_64
+.type	sp_4096_sub_64,@function
 .align	16
-sp_4096_cond_sub_avx2_64:
+sp_4096_sub_64:
 #else
 .section	__TEXT,__text
-.globl	_sp_4096_cond_sub_avx2_64
+.globl	_sp_4096_sub_64
 .p2align	4
-_sp_4096_cond_sub_avx2_64:
+_sp_4096_sub_64:
 #endif /* __APPLE__ */
-        movq	$0x00, %rax
-        movq	(%rdx), %r10
-        movq	(%rsi), %r8
-        pextq	%rcx, %r10, %r10
-        subq	%r10, %r8
-        movq	8(%rdx), %r10
-        movq	8(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, (%rdi)
-        sbbq	%r10, %r9
-        movq	16(%rdx), %r8
-        movq	16(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 8(%rdi)
-        sbbq	%r8, %r10
-        movq	24(%rdx), %r9
+        movq	(%rsi), %rcx
+        xorq	%rax, %rax
+        subq	(%rdx), %rcx
+        movq	8(%rsi), %r8
+        movq	%rcx, (%rdi)
+        sbbq	8(%rdx), %r8
+        movq	16(%rsi), %rcx
+        movq	%r8, 8(%rdi)
+        sbbq	16(%rdx), %rcx
         movq	24(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 16(%rdi)
-        sbbq	%r9, %r8
-        movq	32(%rdx), %r10
-        movq	32(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 16(%rdi)
+        sbbq	24(%rdx), %r8
+        movq	32(%rsi), %rcx
         movq	%r8, 24(%rdi)
-        sbbq	%r10, %r9
-        movq	40(%rdx), %r8
-        movq	40(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 32(%rdi)
-        sbbq	%r8, %r10
-        movq	48(%rdx), %r9
-        movq	48(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 40(%rdi)
-        sbbq	%r9, %r8
-        movq	56(%rdx), %r10
-        movq	56(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 48(%rdi)
-        sbbq	%r10, %r9
-        movq	64(%rdx), %r8
-        movq	64(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 56(%rdi)
-        sbbq	%r8, %r10
-        movq	72(%rdx), %r9
+        sbbq	32(%rdx), %rcx
+        movq	40(%rsi), %r8
+        movq	%rcx, 32(%rdi)
+        sbbq	40(%rdx), %r8
+        movq	48(%rsi), %rcx
+        movq	%r8, 40(%rdi)
+        sbbq	48(%rdx), %rcx
+        movq	56(%rsi), %r8
+        movq	%rcx, 48(%rdi)
+        sbbq	56(%rdx), %r8
+        movq	64(%rsi), %rcx
+        movq	%r8, 56(%rdi)
+        sbbq	64(%rdx), %rcx
         movq	72(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 64(%rdi)
-        sbbq	%r9, %r8
-        movq	80(%rdx), %r10
-        movq	80(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 64(%rdi)
+        sbbq	72(%rdx), %r8
+        movq	80(%rsi), %rcx
         movq	%r8, 72(%rdi)
-        sbbq	%r10, %r9
-        movq	88(%rdx), %r8
-        movq	88(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 80(%rdi)
-        sbbq	%r8, %r10
-        movq	96(%rdx), %r9
-        movq	96(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 88(%rdi)
-        sbbq	%r9, %r8
-        movq	104(%rdx), %r10
-        movq	104(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 96(%rdi)
-        sbbq	%r10, %r9
-        movq	112(%rdx), %r8
-        movq	112(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 104(%rdi)
-        sbbq	%r8, %r10
-        movq	120(%rdx), %r9
+        sbbq	80(%rdx), %rcx
+        movq	88(%rsi), %r8
+        movq	%rcx, 80(%rdi)
+        sbbq	88(%rdx), %r8
+        movq	96(%rsi), %rcx
+        movq	%r8, 88(%rdi)
+        sbbq	96(%rdx), %rcx
+        movq	104(%rsi), %r8
+        movq	%rcx, 96(%rdi)
+        sbbq	104(%rdx), %r8
+        movq	112(%rsi), %rcx
+        movq	%r8, 104(%rdi)
+        sbbq	112(%rdx), %rcx
         movq	120(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 112(%rdi)
-        sbbq	%r9, %r8
-        movq	128(%rdx), %r10
-        movq	128(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 112(%rdi)
+        sbbq	120(%rdx), %r8
+        movq	128(%rsi), %rcx
         movq	%r8, 120(%rdi)
-        sbbq	%r10, %r9
-        movq	136(%rdx), %r8
-        movq	136(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 128(%rdi)
-        sbbq	%r8, %r10
-        movq	144(%rdx), %r9
-        movq	144(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 136(%rdi)
-        sbbq	%r9, %r8
-        movq	152(%rdx), %r10
-        movq	152(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 144(%rdi)
-        sbbq	%r10, %r9
-        movq	160(%rdx), %r8
-        movq	160(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 152(%rdi)
-        sbbq	%r8, %r10
-        movq	168(%rdx), %r9
+        sbbq	128(%rdx), %rcx
+        movq	136(%rsi), %r8
+        movq	%rcx, 128(%rdi)
+        sbbq	136(%rdx), %r8
+        movq	144(%rsi), %rcx
+        movq	%r8, 136(%rdi)
+        sbbq	144(%rdx), %rcx
+        movq	152(%rsi), %r8
+        movq	%rcx, 144(%rdi)
+        sbbq	152(%rdx), %r8
+        movq	160(%rsi), %rcx
+        movq	%r8, 152(%rdi)
+        sbbq	160(%rdx), %rcx
         movq	168(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 160(%rdi)
-        sbbq	%r9, %r8
-        movq	176(%rdx), %r10
-        movq	176(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 160(%rdi)
+        sbbq	168(%rdx), %r8
+        movq	176(%rsi), %rcx
         movq	%r8, 168(%rdi)
-        sbbq	%r10, %r9
-        movq	184(%rdx), %r8
-        movq	184(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 176(%rdi)
-        sbbq	%r8, %r10
-        movq	192(%rdx), %r9
-        movq	192(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 184(%rdi)
-        sbbq	%r9, %r8
-        movq	200(%rdx), %r10
-        movq	200(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 192(%rdi)
-        sbbq	%r10, %r9
-        movq	208(%rdx), %r8
-        movq	208(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 200(%rdi)
-        sbbq	%r8, %r10
-        movq	216(%rdx), %r9
+        sbbq	176(%rdx), %rcx
+        movq	184(%rsi), %r8
+        movq	%rcx, 176(%rdi)
+        sbbq	184(%rdx), %r8
+        movq	192(%rsi), %rcx
+        movq	%r8, 184(%rdi)
+        sbbq	192(%rdx), %rcx
+        movq	200(%rsi), %r8
+        movq	%rcx, 192(%rdi)
+        sbbq	200(%rdx), %r8
+        movq	208(%rsi), %rcx
+        movq	%r8, 200(%rdi)
+        sbbq	208(%rdx), %rcx
         movq	216(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 208(%rdi)
-        sbbq	%r9, %r8
-        movq	224(%rdx), %r10
-        movq	224(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 208(%rdi)
+        sbbq	216(%rdx), %r8
+        movq	224(%rsi), %rcx
         movq	%r8, 216(%rdi)
-        sbbq	%r10, %r9
-        movq	232(%rdx), %r8
-        movq	232(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 224(%rdi)
-        sbbq	%r8, %r10
-        movq	240(%rdx), %r9
-        movq	240(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 232(%rdi)
-        sbbq	%r9, %r8
-        movq	248(%rdx), %r10
-        movq	248(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 240(%rdi)
-        sbbq	%r10, %r9
-        movq	256(%rdx), %r8
-        movq	256(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 248(%rdi)
-        sbbq	%r8, %r10
-        movq	264(%rdx), %r9
+        sbbq	224(%rdx), %rcx
+        movq	232(%rsi), %r8
+        movq	%rcx, 224(%rdi)
+        sbbq	232(%rdx), %r8
+        movq	240(%rsi), %rcx
+        movq	%r8, 232(%rdi)
+        sbbq	240(%rdx), %rcx
+        movq	248(%rsi), %r8
+        movq	%rcx, 240(%rdi)
+        sbbq	248(%rdx), %r8
+        movq	256(%rsi), %rcx
+        movq	%r8, 248(%rdi)
+        sbbq	256(%rdx), %rcx
         movq	264(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 256(%rdi)
-        sbbq	%r9, %r8
-        movq	272(%rdx), %r10
-        movq	272(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 256(%rdi)
+        sbbq	264(%rdx), %r8
+        movq	272(%rsi), %rcx
         movq	%r8, 264(%rdi)
-        sbbq	%r10, %r9
-        movq	280(%rdx), %r8
-        movq	280(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 272(%rdi)
-        sbbq	%r8, %r10
-        movq	288(%rdx), %r9
-        movq	288(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 280(%rdi)
-        sbbq	%r9, %r8
-        movq	296(%rdx), %r10
-        movq	296(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 288(%rdi)
-        sbbq	%r10, %r9
-        movq	304(%rdx), %r8
-        movq	304(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 296(%rdi)
-        sbbq	%r8, %r10
-        movq	312(%rdx), %r9
+        sbbq	272(%rdx), %rcx
+        movq	280(%rsi), %r8
+        movq	%rcx, 272(%rdi)
+        sbbq	280(%rdx), %r8
+        movq	288(%rsi), %rcx
+        movq	%r8, 280(%rdi)
+        sbbq	288(%rdx), %rcx
+        movq	296(%rsi), %r8
+        movq	%rcx, 288(%rdi)
+        sbbq	296(%rdx), %r8
+        movq	304(%rsi), %rcx
+        movq	%r8, 296(%rdi)
+        sbbq	304(%rdx), %rcx
         movq	312(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 304(%rdi)
-        sbbq	%r9, %r8
-        movq	320(%rdx), %r10
-        movq	320(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 304(%rdi)
+        sbbq	312(%rdx), %r8
+        movq	320(%rsi), %rcx
         movq	%r8, 312(%rdi)
-        sbbq	%r10, %r9
-        movq	328(%rdx), %r8
-        movq	328(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 320(%rdi)
-        sbbq	%r8, %r10
-        movq	336(%rdx), %r9
-        movq	336(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 328(%rdi)
-        sbbq	%r9, %r8
-        movq	344(%rdx), %r10
-        movq	344(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 336(%rdi)
-        sbbq	%r10, %r9
-        movq	352(%rdx), %r8
-        movq	352(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 344(%rdi)
-        sbbq	%r8, %r10
-        movq	360(%rdx), %r9
+        sbbq	320(%rdx), %rcx
+        movq	328(%rsi), %r8
+        movq	%rcx, 320(%rdi)
+        sbbq	328(%rdx), %r8
+        movq	336(%rsi), %rcx
+        movq	%r8, 328(%rdi)
+        sbbq	336(%rdx), %rcx
+        movq	344(%rsi), %r8
+        movq	%rcx, 336(%rdi)
+        sbbq	344(%rdx), %r8
+        movq	352(%rsi), %rcx
+        movq	%r8, 344(%rdi)
+        sbbq	352(%rdx), %rcx
         movq	360(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 352(%rdi)
-        sbbq	%r9, %r8
-        movq	368(%rdx), %r10
-        movq	368(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 352(%rdi)
+        sbbq	360(%rdx), %r8
+        movq	368(%rsi), %rcx
         movq	%r8, 360(%rdi)
-        sbbq	%r10, %r9
-        movq	376(%rdx), %r8
-        movq	376(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 368(%rdi)
-        sbbq	%r8, %r10
-        movq	384(%rdx), %r9
-        movq	384(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 376(%rdi)
-        sbbq	%r9, %r8
-        movq	392(%rdx), %r10
-        movq	392(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 384(%rdi)
-        sbbq	%r10, %r9
-        movq	400(%rdx), %r8
-        movq	400(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 392(%rdi)
-        sbbq	%r8, %r10
-        movq	408(%rdx), %r9
+        sbbq	368(%rdx), %rcx
+        movq	376(%rsi), %r8
+        movq	%rcx, 368(%rdi)
+        sbbq	376(%rdx), %r8
+        movq	384(%rsi), %rcx
+        movq	%r8, 376(%rdi)
+        sbbq	384(%rdx), %rcx
+        movq	392(%rsi), %r8
+        movq	%rcx, 384(%rdi)
+        sbbq	392(%rdx), %r8
+        movq	400(%rsi), %rcx
+        movq	%r8, 392(%rdi)
+        sbbq	400(%rdx), %rcx
         movq	408(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 400(%rdi)
-        sbbq	%r9, %r8
-        movq	416(%rdx), %r10
-        movq	416(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 400(%rdi)
+        sbbq	408(%rdx), %r8
+        movq	416(%rsi), %rcx
         movq	%r8, 408(%rdi)
-        sbbq	%r10, %r9
-        movq	424(%rdx), %r8
-        movq	424(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 416(%rdi)
-        sbbq	%r8, %r10
-        movq	432(%rdx), %r9
-        movq	432(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 424(%rdi)
-        sbbq	%r9, %r8
-        movq	440(%rdx), %r10
-        movq	440(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 432(%rdi)
-        sbbq	%r10, %r9
-        movq	448(%rdx), %r8
-        movq	448(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 440(%rdi)
-        sbbq	%r8, %r10
-        movq	456(%rdx), %r9
+        sbbq	416(%rdx), %rcx
+        movq	424(%rsi), %r8
+        movq	%rcx, 416(%rdi)
+        sbbq	424(%rdx), %r8
+        movq	432(%rsi), %rcx
+        movq	%r8, 424(%rdi)
+        sbbq	432(%rdx), %rcx
+        movq	440(%rsi), %r8
+        movq	%rcx, 432(%rdi)
+        sbbq	440(%rdx), %r8
+        movq	448(%rsi), %rcx
+        movq	%r8, 440(%rdi)
+        sbbq	448(%rdx), %rcx
         movq	456(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 448(%rdi)
-        sbbq	%r9, %r8
-        movq	464(%rdx), %r10
-        movq	464(%rsi), %r9
-        pextq	%rcx, %r10, %r10
+        movq	%rcx, 448(%rdi)
+        sbbq	456(%rdx), %r8
+        movq	464(%rsi), %rcx
         movq	%r8, 456(%rdi)
-        sbbq	%r10, %r9
-        movq	472(%rdx), %r8
-        movq	472(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 464(%rdi)
-        sbbq	%r8, %r10
-        movq	480(%rdx), %r9
-        movq	480(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 472(%rdi)
-        sbbq	%r9, %r8
-        movq	488(%rdx), %r10
-        movq	488(%rsi), %r9
-        pextq	%rcx, %r10, %r10
-        movq	%r8, 480(%rdi)
-        sbbq	%r10, %r9
-        movq	496(%rdx), %r8
-        movq	496(%rsi), %r10
-        pextq	%rcx, %r8, %r8
-        movq	%r9, 488(%rdi)
-        sbbq	%r8, %r10
-        movq	504(%rdx), %r9
+        sbbq	464(%rdx), %rcx
+        movq	472(%rsi), %r8
+        movq	%rcx, 464(%rdi)
+        sbbq	472(%rdx), %r8
+        movq	480(%rsi), %rcx
+        movq	%r8, 472(%rdi)
+        sbbq	480(%rdx), %rcx
+        movq	488(%rsi), %r8
+        movq	%rcx, 480(%rdi)
+        sbbq	488(%rdx), %r8
+        movq	496(%rsi), %rcx
+        movq	%r8, 488(%rdi)
+        sbbq	496(%rdx), %rcx
         movq	504(%rsi), %r8
-        pextq	%rcx, %r9, %r9
-        movq	%r10, 496(%rdi)
-        sbbq	%r9, %r8
+        movq	%rcx, 496(%rdi)
+        sbbq	504(%rdx), %r8
         movq	%r8, 504(%rdi)
         sbbq	$0x00, %rax
         repz retq
 #ifndef __APPLE__
-.size	sp_4096_cond_sub_avx2_64,.-sp_4096_cond_sub_avx2_64
+.size	sp_4096_sub_64,.-sp_4096_sub_64
 #endif /* __APPLE__ */
-#endif /* HAVE_INTEL_AVX2 */
 #ifdef HAVE_INTEL_AVX2
 /* Mul a by digit b into r. (r = a * b)
  *
@@ -36464,6 +36332,354 @@ _div_4096_word_asm_64:
 .size	div_4096_word_asm_64,.-div_4096_word_asm_64
 #endif /* __APPLE__ */
 #endif /* _WIN64 */
+#ifdef HAVE_INTEL_AVX2
+/* Conditionally subtract b from a using the mask m.
+ * m is -1 to subtract and 0 when not copying.
+ *
+ * r  A single precision number representing condition subtract result.
+ * a  A single precision number to subtract from.
+ * b  A single precision number to subtract.
+ * m  Mask value to apply.
+ */
+#ifndef __APPLE__
+.text
+.globl	sp_4096_cond_sub_avx2_64
+.type	sp_4096_cond_sub_avx2_64,@function
+.align	16
+sp_4096_cond_sub_avx2_64:
+#else
+.section	__TEXT,__text
+.globl	_sp_4096_cond_sub_avx2_64
+.p2align	4
+_sp_4096_cond_sub_avx2_64:
+#endif /* __APPLE__ */
+        movq	$0x00, %rax
+        movq	(%rdx), %r10
+        movq	(%rsi), %r8
+        pextq	%rcx, %r10, %r10
+        subq	%r10, %r8
+        movq	8(%rdx), %r10
+        movq	8(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, (%rdi)
+        sbbq	%r10, %r9
+        movq	16(%rdx), %r8
+        movq	16(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 8(%rdi)
+        sbbq	%r8, %r10
+        movq	24(%rdx), %r9
+        movq	24(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 16(%rdi)
+        sbbq	%r9, %r8
+        movq	32(%rdx), %r10
+        movq	32(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 24(%rdi)
+        sbbq	%r10, %r9
+        movq	40(%rdx), %r8
+        movq	40(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 32(%rdi)
+        sbbq	%r8, %r10
+        movq	48(%rdx), %r9
+        movq	48(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 40(%rdi)
+        sbbq	%r9, %r8
+        movq	56(%rdx), %r10
+        movq	56(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 48(%rdi)
+        sbbq	%r10, %r9
+        movq	64(%rdx), %r8
+        movq	64(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 56(%rdi)
+        sbbq	%r8, %r10
+        movq	72(%rdx), %r9
+        movq	72(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 64(%rdi)
+        sbbq	%r9, %r8
+        movq	80(%rdx), %r10
+        movq	80(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 72(%rdi)
+        sbbq	%r10, %r9
+        movq	88(%rdx), %r8
+        movq	88(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 80(%rdi)
+        sbbq	%r8, %r10
+        movq	96(%rdx), %r9
+        movq	96(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 88(%rdi)
+        sbbq	%r9, %r8
+        movq	104(%rdx), %r10
+        movq	104(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 96(%rdi)
+        sbbq	%r10, %r9
+        movq	112(%rdx), %r8
+        movq	112(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 104(%rdi)
+        sbbq	%r8, %r10
+        movq	120(%rdx), %r9
+        movq	120(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 112(%rdi)
+        sbbq	%r9, %r8
+        movq	128(%rdx), %r10
+        movq	128(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 120(%rdi)
+        sbbq	%r10, %r9
+        movq	136(%rdx), %r8
+        movq	136(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 128(%rdi)
+        sbbq	%r8, %r10
+        movq	144(%rdx), %r9
+        movq	144(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 136(%rdi)
+        sbbq	%r9, %r8
+        movq	152(%rdx), %r10
+        movq	152(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 144(%rdi)
+        sbbq	%r10, %r9
+        movq	160(%rdx), %r8
+        movq	160(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 152(%rdi)
+        sbbq	%r8, %r10
+        movq	168(%rdx), %r9
+        movq	168(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 160(%rdi)
+        sbbq	%r9, %r8
+        movq	176(%rdx), %r10
+        movq	176(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 168(%rdi)
+        sbbq	%r10, %r9
+        movq	184(%rdx), %r8
+        movq	184(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 176(%rdi)
+        sbbq	%r8, %r10
+        movq	192(%rdx), %r9
+        movq	192(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 184(%rdi)
+        sbbq	%r9, %r8
+        movq	200(%rdx), %r10
+        movq	200(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 192(%rdi)
+        sbbq	%r10, %r9
+        movq	208(%rdx), %r8
+        movq	208(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 200(%rdi)
+        sbbq	%r8, %r10
+        movq	216(%rdx), %r9
+        movq	216(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 208(%rdi)
+        sbbq	%r9, %r8
+        movq	224(%rdx), %r10
+        movq	224(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 216(%rdi)
+        sbbq	%r10, %r9
+        movq	232(%rdx), %r8
+        movq	232(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 224(%rdi)
+        sbbq	%r8, %r10
+        movq	240(%rdx), %r9
+        movq	240(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 232(%rdi)
+        sbbq	%r9, %r8
+        movq	248(%rdx), %r10
+        movq	248(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 240(%rdi)
+        sbbq	%r10, %r9
+        movq	256(%rdx), %r8
+        movq	256(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 248(%rdi)
+        sbbq	%r8, %r10
+        movq	264(%rdx), %r9
+        movq	264(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 256(%rdi)
+        sbbq	%r9, %r8
+        movq	272(%rdx), %r10
+        movq	272(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 264(%rdi)
+        sbbq	%r10, %r9
+        movq	280(%rdx), %r8
+        movq	280(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 272(%rdi)
+        sbbq	%r8, %r10
+        movq	288(%rdx), %r9
+        movq	288(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 280(%rdi)
+        sbbq	%r9, %r8
+        movq	296(%rdx), %r10
+        movq	296(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 288(%rdi)
+        sbbq	%r10, %r9
+        movq	304(%rdx), %r8
+        movq	304(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 296(%rdi)
+        sbbq	%r8, %r10
+        movq	312(%rdx), %r9
+        movq	312(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 304(%rdi)
+        sbbq	%r9, %r8
+        movq	320(%rdx), %r10
+        movq	320(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 312(%rdi)
+        sbbq	%r10, %r9
+        movq	328(%rdx), %r8
+        movq	328(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 320(%rdi)
+        sbbq	%r8, %r10
+        movq	336(%rdx), %r9
+        movq	336(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 328(%rdi)
+        sbbq	%r9, %r8
+        movq	344(%rdx), %r10
+        movq	344(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 336(%rdi)
+        sbbq	%r10, %r9
+        movq	352(%rdx), %r8
+        movq	352(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 344(%rdi)
+        sbbq	%r8, %r10
+        movq	360(%rdx), %r9
+        movq	360(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 352(%rdi)
+        sbbq	%r9, %r8
+        movq	368(%rdx), %r10
+        movq	368(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 360(%rdi)
+        sbbq	%r10, %r9
+        movq	376(%rdx), %r8
+        movq	376(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 368(%rdi)
+        sbbq	%r8, %r10
+        movq	384(%rdx), %r9
+        movq	384(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 376(%rdi)
+        sbbq	%r9, %r8
+        movq	392(%rdx), %r10
+        movq	392(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 384(%rdi)
+        sbbq	%r10, %r9
+        movq	400(%rdx), %r8
+        movq	400(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 392(%rdi)
+        sbbq	%r8, %r10
+        movq	408(%rdx), %r9
+        movq	408(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 400(%rdi)
+        sbbq	%r9, %r8
+        movq	416(%rdx), %r10
+        movq	416(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 408(%rdi)
+        sbbq	%r10, %r9
+        movq	424(%rdx), %r8
+        movq	424(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 416(%rdi)
+        sbbq	%r8, %r10
+        movq	432(%rdx), %r9
+        movq	432(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 424(%rdi)
+        sbbq	%r9, %r8
+        movq	440(%rdx), %r10
+        movq	440(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 432(%rdi)
+        sbbq	%r10, %r9
+        movq	448(%rdx), %r8
+        movq	448(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 440(%rdi)
+        sbbq	%r8, %r10
+        movq	456(%rdx), %r9
+        movq	456(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 448(%rdi)
+        sbbq	%r9, %r8
+        movq	464(%rdx), %r10
+        movq	464(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 456(%rdi)
+        sbbq	%r10, %r9
+        movq	472(%rdx), %r8
+        movq	472(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 464(%rdi)
+        sbbq	%r8, %r10
+        movq	480(%rdx), %r9
+        movq	480(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 472(%rdi)
+        sbbq	%r9, %r8
+        movq	488(%rdx), %r10
+        movq	488(%rsi), %r9
+        pextq	%rcx, %r10, %r10
+        movq	%r8, 480(%rdi)
+        sbbq	%r10, %r9
+        movq	496(%rdx), %r8
+        movq	496(%rsi), %r10
+        pextq	%rcx, %r8, %r8
+        movq	%r9, 488(%rdi)
+        sbbq	%r8, %r10
+        movq	504(%rdx), %r9
+        movq	504(%rsi), %r8
+        pextq	%rcx, %r9, %r9
+        movq	%r10, 496(%rdi)
+        sbbq	%r9, %r8
+        movq	%r8, 504(%rdi)
+        sbbq	$0x00, %rax
+        repz retq
+#ifndef __APPLE__
+.size	sp_4096_cond_sub_avx2_64,.-sp_4096_cond_sub_avx2_64
+#endif /* __APPLE__ */
+#endif /* HAVE_INTEL_AVX2 */
 /* Compare a with b in constant time.
  *
  * a  A single precision integer.
@@ -37003,222 +37219,6 @@ _sp_4096_cmp_64:
         repz retq
 #ifndef __APPLE__
 .size	sp_4096_cmp_64,.-sp_4096_cmp_64
-#endif /* __APPLE__ */
-/* Sub b from a into r. (r = a - b)
- *
- * r  A single precision integer.
- * a  A single precision integer.
- * b  A single precision integer.
- */
-#ifndef __APPLE__
-.text
-.globl	sp_4096_sub_64
-.type	sp_4096_sub_64,@function
-.align	16
-sp_4096_sub_64:
-#else
-.section	__TEXT,__text
-.globl	_sp_4096_sub_64
-.p2align	4
-_sp_4096_sub_64:
-#endif /* __APPLE__ */
-        movq	(%rsi), %rcx
-        xorq	%rax, %rax
-        subq	(%rdx), %rcx
-        movq	8(%rsi), %r8
-        movq	%rcx, (%rdi)
-        sbbq	8(%rdx), %r8
-        movq	16(%rsi), %rcx
-        movq	%r8, 8(%rdi)
-        sbbq	16(%rdx), %rcx
-        movq	24(%rsi), %r8
-        movq	%rcx, 16(%rdi)
-        sbbq	24(%rdx), %r8
-        movq	32(%rsi), %rcx
-        movq	%r8, 24(%rdi)
-        sbbq	32(%rdx), %rcx
-        movq	40(%rsi), %r8
-        movq	%rcx, 32(%rdi)
-        sbbq	40(%rdx), %r8
-        movq	48(%rsi), %rcx
-        movq	%r8, 40(%rdi)
-        sbbq	48(%rdx), %rcx
-        movq	56(%rsi), %r8
-        movq	%rcx, 48(%rdi)
-        sbbq	56(%rdx), %r8
-        movq	64(%rsi), %rcx
-        movq	%r8, 56(%rdi)
-        sbbq	64(%rdx), %rcx
-        movq	72(%rsi), %r8
-        movq	%rcx, 64(%rdi)
-        sbbq	72(%rdx), %r8
-        movq	80(%rsi), %rcx
-        movq	%r8, 72(%rdi)
-        sbbq	80(%rdx), %rcx
-        movq	88(%rsi), %r8
-        movq	%rcx, 80(%rdi)
-        sbbq	88(%rdx), %r8
-        movq	96(%rsi), %rcx
-        movq	%r8, 88(%rdi)
-        sbbq	96(%rdx), %rcx
-        movq	104(%rsi), %r8
-        movq	%rcx, 96(%rdi)
-        sbbq	104(%rdx), %r8
-        movq	112(%rsi), %rcx
-        movq	%r8, 104(%rdi)
-        sbbq	112(%rdx), %rcx
-        movq	120(%rsi), %r8
-        movq	%rcx, 112(%rdi)
-        sbbq	120(%rdx), %r8
-        movq	128(%rsi), %rcx
-        movq	%r8, 120(%rdi)
-        sbbq	128(%rdx), %rcx
-        movq	136(%rsi), %r8
-        movq	%rcx, 128(%rdi)
-        sbbq	136(%rdx), %r8
-        movq	144(%rsi), %rcx
-        movq	%r8, 136(%rdi)
-        sbbq	144(%rdx), %rcx
-        movq	152(%rsi), %r8
-        movq	%rcx, 144(%rdi)
-        sbbq	152(%rdx), %r8
-        movq	160(%rsi), %rcx
-        movq	%r8, 152(%rdi)
-        sbbq	160(%rdx), %rcx
-        movq	168(%rsi), %r8
-        movq	%rcx, 160(%rdi)
-        sbbq	168(%rdx), %r8
-        movq	176(%rsi), %rcx
-        movq	%r8, 168(%rdi)
-        sbbq	176(%rdx), %rcx
-        movq	184(%rsi), %r8
-        movq	%rcx, 176(%rdi)
-        sbbq	184(%rdx), %r8
-        movq	192(%rsi), %rcx
-        movq	%r8, 184(%rdi)
-        sbbq	192(%rdx), %rcx
-        movq	200(%rsi), %r8
-        movq	%rcx, 192(%rdi)
-        sbbq	200(%rdx), %r8
-        movq	208(%rsi), %rcx
-        movq	%r8, 200(%rdi)
-        sbbq	208(%rdx), %rcx
-        movq	216(%rsi), %r8
-        movq	%rcx, 208(%rdi)
-        sbbq	216(%rdx), %r8
-        movq	224(%rsi), %rcx
-        movq	%r8, 216(%rdi)
-        sbbq	224(%rdx), %rcx
-        movq	232(%rsi), %r8
-        movq	%rcx, 224(%rdi)
-        sbbq	232(%rdx), %r8
-        movq	240(%rsi), %rcx
-        movq	%r8, 232(%rdi)
-        sbbq	240(%rdx), %rcx
-        movq	248(%rsi), %r8
-        movq	%rcx, 240(%rdi)
-        sbbq	248(%rdx), %r8
-        movq	256(%rsi), %rcx
-        movq	%r8, 248(%rdi)
-        sbbq	256(%rdx), %rcx
-        movq	264(%rsi), %r8
-        movq	%rcx, 256(%rdi)
-        sbbq	264(%rdx), %r8
-        movq	272(%rsi), %rcx
-        movq	%r8, 264(%rdi)
-        sbbq	272(%rdx), %rcx
-        movq	280(%rsi), %r8
-        movq	%rcx, 272(%rdi)
-        sbbq	280(%rdx), %r8
-        movq	288(%rsi), %rcx
-        movq	%r8, 280(%rdi)
-        sbbq	288(%rdx), %rcx
-        movq	296(%rsi), %r8
-        movq	%rcx, 288(%rdi)
-        sbbq	296(%rdx), %r8
-        movq	304(%rsi), %rcx
-        movq	%r8, 296(%rdi)
-        sbbq	304(%rdx), %rcx
-        movq	312(%rsi), %r8
-        movq	%rcx, 304(%rdi)
-        sbbq	312(%rdx), %r8
-        movq	320(%rsi), %rcx
-        movq	%r8, 312(%rdi)
-        sbbq	320(%rdx), %rcx
-        movq	328(%rsi), %r8
-        movq	%rcx, 320(%rdi)
-        sbbq	328(%rdx), %r8
-        movq	336(%rsi), %rcx
-        movq	%r8, 328(%rdi)
-        sbbq	336(%rdx), %rcx
-        movq	344(%rsi), %r8
-        movq	%rcx, 336(%rdi)
-        sbbq	344(%rdx), %r8
-        movq	352(%rsi), %rcx
-        movq	%r8, 344(%rdi)
-        sbbq	352(%rdx), %rcx
-        movq	360(%rsi), %r8
-        movq	%rcx, 352(%rdi)
-        sbbq	360(%rdx), %r8
-        movq	368(%rsi), %rcx
-        movq	%r8, 360(%rdi)
-        sbbq	368(%rdx), %rcx
-        movq	376(%rsi), %r8
-        movq	%rcx, 368(%rdi)
-        sbbq	376(%rdx), %r8
-        movq	384(%rsi), %rcx
-        movq	%r8, 376(%rdi)
-        sbbq	384(%rdx), %rcx
-        movq	392(%rsi), %r8
-        movq	%rcx, 384(%rdi)
-        sbbq	392(%rdx), %r8
-        movq	400(%rsi), %rcx
-        movq	%r8, 392(%rdi)
-        sbbq	400(%rdx), %rcx
-        movq	408(%rsi), %r8
-        movq	%rcx, 400(%rdi)
-        sbbq	408(%rdx), %r8
-        movq	416(%rsi), %rcx
-        movq	%r8, 408(%rdi)
-        sbbq	416(%rdx), %rcx
-        movq	424(%rsi), %r8
-        movq	%rcx, 416(%rdi)
-        sbbq	424(%rdx), %r8
-        movq	432(%rsi), %rcx
-        movq	%r8, 424(%rdi)
-        sbbq	432(%rdx), %rcx
-        movq	440(%rsi), %r8
-        movq	%rcx, 432(%rdi)
-        sbbq	440(%rdx), %r8
-        movq	448(%rsi), %rcx
-        movq	%r8, 440(%rdi)
-        sbbq	448(%rdx), %rcx
-        movq	456(%rsi), %r8
-        movq	%rcx, 448(%rdi)
-        sbbq	456(%rdx), %r8
-        movq	464(%rsi), %rcx
-        movq	%r8, 456(%rdi)
-        sbbq	464(%rdx), %rcx
-        movq	472(%rsi), %r8
-        movq	%rcx, 464(%rdi)
-        sbbq	472(%rdx), %r8
-        movq	480(%rsi), %rcx
-        movq	%r8, 472(%rdi)
-        sbbq	480(%rdx), %rcx
-        movq	488(%rsi), %r8
-        movq	%rcx, 480(%rdi)
-        sbbq	488(%rdx), %r8
-        movq	496(%rsi), %rcx
-        movq	%r8, 488(%rdi)
-        sbbq	496(%rdx), %rcx
-        movq	504(%rsi), %r8
-        movq	%rcx, 496(%rdi)
-        sbbq	504(%rdx), %r8
-        movq	%r8, 504(%rdi)
-        sbbq	$0x00, %rax
-        repz retq
-#ifndef __APPLE__
-.size	sp_4096_sub_64,.-sp_4096_sub_64
 #endif /* __APPLE__ */
 #ifdef HAVE_INTEL_AVX2
 /* Reduce the number back to 4096 bits using Montgomery reduction.

--- a/wolfcrypt/src/sp_x86_64_asm.asm
+++ b/wolfcrypt/src/sp_x86_64_asm.asm
@@ -10780,185 +10780,115 @@ ENDIF
         ret
 sp_2048_mont_reduce_32 ENDP
 _text ENDS
-IFDEF HAVE_INTEL_AVX2
-; /* Conditionally subtract b from a using the mask m.
-;  * m is -1 to subtract and 0 when not copying.
+; /* Sub b from a into r. (r = a - b)
 ;  *
-;  * r  A single precision number representing condition subtract result.
-;  * a  A single precision number to subtract from.
-;  * b  A single precision number to subtract.
-;  * m  Mask value to apply.
+;  * r  A single precision integer.
+;  * a  A single precision integer.
+;  * b  A single precision integer.
 ;  */
 _text SEGMENT READONLY PARA
-sp_2048_cond_sub_avx2_32 PROC
-        push	r12
-        mov	rax, 0
-        mov	r12, QWORD PTR [r8]
-        mov	r10, QWORD PTR [rdx]
-        pext	r12, r12, r9
-        sub	r10, r12
-        mov	r12, QWORD PTR [r8+8]
-        mov	r11, QWORD PTR [rdx+8]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+16]
-        mov	r12, QWORD PTR [rdx+16]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+8], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+24]
+sp_2048_sub_32 PROC
+        mov	r9, QWORD PTR [rdx]
+        xor	rax, rax
+        sub	r9, QWORD PTR [r8]
+        mov	r10, QWORD PTR [rdx+8]
+        mov	QWORD PTR [rcx], r9
+        sbb	r10, QWORD PTR [r8+8]
+        mov	r9, QWORD PTR [rdx+16]
+        mov	QWORD PTR [rcx+8], r10
+        sbb	r9, QWORD PTR [r8+16]
         mov	r10, QWORD PTR [rdx+24]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+16], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+32]
-        mov	r11, QWORD PTR [rdx+32]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+16], r9
+        sbb	r10, QWORD PTR [r8+24]
+        mov	r9, QWORD PTR [rdx+32]
         mov	QWORD PTR [rcx+24], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+40]
-        mov	r12, QWORD PTR [rdx+40]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+32], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+48]
-        mov	r10, QWORD PTR [rdx+48]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+40], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+56]
-        mov	r11, QWORD PTR [rdx+56]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+48], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+64]
-        mov	r12, QWORD PTR [rdx+64]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+56], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+72]
+        sbb	r9, QWORD PTR [r8+32]
+        mov	r10, QWORD PTR [rdx+40]
+        mov	QWORD PTR [rcx+32], r9
+        sbb	r10, QWORD PTR [r8+40]
+        mov	r9, QWORD PTR [rdx+48]
+        mov	QWORD PTR [rcx+40], r10
+        sbb	r9, QWORD PTR [r8+48]
+        mov	r10, QWORD PTR [rdx+56]
+        mov	QWORD PTR [rcx+48], r9
+        sbb	r10, QWORD PTR [r8+56]
+        mov	r9, QWORD PTR [rdx+64]
+        mov	QWORD PTR [rcx+56], r10
+        sbb	r9, QWORD PTR [r8+64]
         mov	r10, QWORD PTR [rdx+72]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+64], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+80]
-        mov	r11, QWORD PTR [rdx+80]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+64], r9
+        sbb	r10, QWORD PTR [r8+72]
+        mov	r9, QWORD PTR [rdx+80]
         mov	QWORD PTR [rcx+72], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+88]
-        mov	r12, QWORD PTR [rdx+88]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+80], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+96]
-        mov	r10, QWORD PTR [rdx+96]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+88], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+104]
-        mov	r11, QWORD PTR [rdx+104]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+96], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+112]
-        mov	r12, QWORD PTR [rdx+112]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+104], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+120]
+        sbb	r9, QWORD PTR [r8+80]
+        mov	r10, QWORD PTR [rdx+88]
+        mov	QWORD PTR [rcx+80], r9
+        sbb	r10, QWORD PTR [r8+88]
+        mov	r9, QWORD PTR [rdx+96]
+        mov	QWORD PTR [rcx+88], r10
+        sbb	r9, QWORD PTR [r8+96]
+        mov	r10, QWORD PTR [rdx+104]
+        mov	QWORD PTR [rcx+96], r9
+        sbb	r10, QWORD PTR [r8+104]
+        mov	r9, QWORD PTR [rdx+112]
+        mov	QWORD PTR [rcx+104], r10
+        sbb	r9, QWORD PTR [r8+112]
         mov	r10, QWORD PTR [rdx+120]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+112], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+128]
-        mov	r11, QWORD PTR [rdx+128]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+112], r9
+        sbb	r10, QWORD PTR [r8+120]
+        mov	r9, QWORD PTR [rdx+128]
         mov	QWORD PTR [rcx+120], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+136]
-        mov	r12, QWORD PTR [rdx+136]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+128], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+144]
-        mov	r10, QWORD PTR [rdx+144]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+136], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+152]
-        mov	r11, QWORD PTR [rdx+152]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+144], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+160]
-        mov	r12, QWORD PTR [rdx+160]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+152], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+168]
+        sbb	r9, QWORD PTR [r8+128]
+        mov	r10, QWORD PTR [rdx+136]
+        mov	QWORD PTR [rcx+128], r9
+        sbb	r10, QWORD PTR [r8+136]
+        mov	r9, QWORD PTR [rdx+144]
+        mov	QWORD PTR [rcx+136], r10
+        sbb	r9, QWORD PTR [r8+144]
+        mov	r10, QWORD PTR [rdx+152]
+        mov	QWORD PTR [rcx+144], r9
+        sbb	r10, QWORD PTR [r8+152]
+        mov	r9, QWORD PTR [rdx+160]
+        mov	QWORD PTR [rcx+152], r10
+        sbb	r9, QWORD PTR [r8+160]
         mov	r10, QWORD PTR [rdx+168]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+160], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+176]
-        mov	r11, QWORD PTR [rdx+176]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+160], r9
+        sbb	r10, QWORD PTR [r8+168]
+        mov	r9, QWORD PTR [rdx+176]
         mov	QWORD PTR [rcx+168], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+184]
-        mov	r12, QWORD PTR [rdx+184]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+176], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+192]
-        mov	r10, QWORD PTR [rdx+192]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+184], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+200]
-        mov	r11, QWORD PTR [rdx+200]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+192], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+208]
-        mov	r12, QWORD PTR [rdx+208]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+200], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+216]
+        sbb	r9, QWORD PTR [r8+176]
+        mov	r10, QWORD PTR [rdx+184]
+        mov	QWORD PTR [rcx+176], r9
+        sbb	r10, QWORD PTR [r8+184]
+        mov	r9, QWORD PTR [rdx+192]
+        mov	QWORD PTR [rcx+184], r10
+        sbb	r9, QWORD PTR [r8+192]
+        mov	r10, QWORD PTR [rdx+200]
+        mov	QWORD PTR [rcx+192], r9
+        sbb	r10, QWORD PTR [r8+200]
+        mov	r9, QWORD PTR [rdx+208]
+        mov	QWORD PTR [rcx+200], r10
+        sbb	r9, QWORD PTR [r8+208]
         mov	r10, QWORD PTR [rdx+216]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+208], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+224]
-        mov	r11, QWORD PTR [rdx+224]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+208], r9
+        sbb	r10, QWORD PTR [r8+216]
+        mov	r9, QWORD PTR [rdx+224]
         mov	QWORD PTR [rcx+216], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+232]
-        mov	r12, QWORD PTR [rdx+232]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+224], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+240]
-        mov	r10, QWORD PTR [rdx+240]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+232], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+248]
-        mov	r11, QWORD PTR [rdx+248]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+240], r10
-        sbb	r11, r12
-        mov	QWORD PTR [rcx+248], r11
+        sbb	r9, QWORD PTR [r8+224]
+        mov	r10, QWORD PTR [rdx+232]
+        mov	QWORD PTR [rcx+224], r9
+        sbb	r10, QWORD PTR [r8+232]
+        mov	r9, QWORD PTR [rdx+240]
+        mov	QWORD PTR [rcx+232], r10
+        sbb	r9, QWORD PTR [r8+240]
+        mov	r10, QWORD PTR [rdx+248]
+        mov	QWORD PTR [rcx+240], r9
+        sbb	r10, QWORD PTR [r8+248]
+        mov	QWORD PTR [rcx+248], r10
         sbb	rax, 0
-        pop	r12
         ret
-sp_2048_cond_sub_avx2_32 ENDP
+sp_2048_sub_32 ENDP
 _text ENDS
-ENDIF
 IFDEF HAVE_INTEL_AVX2
 ; /* Mul a by digit b into r. (r = a * b)
 ;  *
@@ -11186,6 +11116,185 @@ div_2048_word_asm_32 PROC
         div	r8
         ret
 div_2048_word_asm_32 ENDP
+_text ENDS
+ENDIF
+IFDEF HAVE_INTEL_AVX2
+; /* Conditionally subtract b from a using the mask m.
+;  * m is -1 to subtract and 0 when not copying.
+;  *
+;  * r  A single precision number representing condition subtract result.
+;  * a  A single precision number to subtract from.
+;  * b  A single precision number to subtract.
+;  * m  Mask value to apply.
+;  */
+_text SEGMENT READONLY PARA
+sp_2048_cond_sub_avx2_32 PROC
+        push	r12
+        mov	rax, 0
+        mov	r12, QWORD PTR [r8]
+        mov	r10, QWORD PTR [rdx]
+        pext	r12, r12, r9
+        sub	r10, r12
+        mov	r12, QWORD PTR [r8+8]
+        mov	r11, QWORD PTR [rdx+8]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+16]
+        mov	r12, QWORD PTR [rdx+16]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+8], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+24]
+        mov	r10, QWORD PTR [rdx+24]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+16], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+32]
+        mov	r11, QWORD PTR [rdx+32]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+24], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+40]
+        mov	r12, QWORD PTR [rdx+40]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+32], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+48]
+        mov	r10, QWORD PTR [rdx+48]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+40], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+56]
+        mov	r11, QWORD PTR [rdx+56]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+48], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+64]
+        mov	r12, QWORD PTR [rdx+64]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+56], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+72]
+        mov	r10, QWORD PTR [rdx+72]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+64], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+80]
+        mov	r11, QWORD PTR [rdx+80]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+72], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+88]
+        mov	r12, QWORD PTR [rdx+88]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+80], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+96]
+        mov	r10, QWORD PTR [rdx+96]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+88], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+104]
+        mov	r11, QWORD PTR [rdx+104]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+96], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+112]
+        mov	r12, QWORD PTR [rdx+112]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+104], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+120]
+        mov	r10, QWORD PTR [rdx+120]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+112], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+128]
+        mov	r11, QWORD PTR [rdx+128]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+120], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+136]
+        mov	r12, QWORD PTR [rdx+136]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+128], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+144]
+        mov	r10, QWORD PTR [rdx+144]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+136], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+152]
+        mov	r11, QWORD PTR [rdx+152]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+144], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+160]
+        mov	r12, QWORD PTR [rdx+160]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+152], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+168]
+        mov	r10, QWORD PTR [rdx+168]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+160], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+176]
+        mov	r11, QWORD PTR [rdx+176]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+168], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+184]
+        mov	r12, QWORD PTR [rdx+184]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+176], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+192]
+        mov	r10, QWORD PTR [rdx+192]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+184], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+200]
+        mov	r11, QWORD PTR [rdx+200]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+192], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+208]
+        mov	r12, QWORD PTR [rdx+208]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+200], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+216]
+        mov	r10, QWORD PTR [rdx+216]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+208], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+224]
+        mov	r11, QWORD PTR [rdx+224]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+216], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+232]
+        mov	r12, QWORD PTR [rdx+232]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+224], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+240]
+        mov	r10, QWORD PTR [rdx+240]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+232], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+248]
+        mov	r11, QWORD PTR [rdx+248]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+240], r10
+        sbb	r11, r12
+        mov	QWORD PTR [rcx+248], r11
+        sbb	rax, 0
+        pop	r12
+        ret
+sp_2048_cond_sub_avx2_32 ENDP
 _text ENDS
 ENDIF
 ; /* Compare a with b in constant time.
@@ -11462,115 +11571,6 @@ sp_2048_cmp_32 PROC
         pop	r12
         ret
 sp_2048_cmp_32 ENDP
-_text ENDS
-; /* Sub b from a into r. (r = a - b)
-;  *
-;  * r  A single precision integer.
-;  * a  A single precision integer.
-;  * b  A single precision integer.
-;  */
-_text SEGMENT READONLY PARA
-sp_2048_sub_32 PROC
-        mov	r9, QWORD PTR [rdx]
-        xor	rax, rax
-        sub	r9, QWORD PTR [r8]
-        mov	r10, QWORD PTR [rdx+8]
-        mov	QWORD PTR [rcx], r9
-        sbb	r10, QWORD PTR [r8+8]
-        mov	r9, QWORD PTR [rdx+16]
-        mov	QWORD PTR [rcx+8], r10
-        sbb	r9, QWORD PTR [r8+16]
-        mov	r10, QWORD PTR [rdx+24]
-        mov	QWORD PTR [rcx+16], r9
-        sbb	r10, QWORD PTR [r8+24]
-        mov	r9, QWORD PTR [rdx+32]
-        mov	QWORD PTR [rcx+24], r10
-        sbb	r9, QWORD PTR [r8+32]
-        mov	r10, QWORD PTR [rdx+40]
-        mov	QWORD PTR [rcx+32], r9
-        sbb	r10, QWORD PTR [r8+40]
-        mov	r9, QWORD PTR [rdx+48]
-        mov	QWORD PTR [rcx+40], r10
-        sbb	r9, QWORD PTR [r8+48]
-        mov	r10, QWORD PTR [rdx+56]
-        mov	QWORD PTR [rcx+48], r9
-        sbb	r10, QWORD PTR [r8+56]
-        mov	r9, QWORD PTR [rdx+64]
-        mov	QWORD PTR [rcx+56], r10
-        sbb	r9, QWORD PTR [r8+64]
-        mov	r10, QWORD PTR [rdx+72]
-        mov	QWORD PTR [rcx+64], r9
-        sbb	r10, QWORD PTR [r8+72]
-        mov	r9, QWORD PTR [rdx+80]
-        mov	QWORD PTR [rcx+72], r10
-        sbb	r9, QWORD PTR [r8+80]
-        mov	r10, QWORD PTR [rdx+88]
-        mov	QWORD PTR [rcx+80], r9
-        sbb	r10, QWORD PTR [r8+88]
-        mov	r9, QWORD PTR [rdx+96]
-        mov	QWORD PTR [rcx+88], r10
-        sbb	r9, QWORD PTR [r8+96]
-        mov	r10, QWORD PTR [rdx+104]
-        mov	QWORD PTR [rcx+96], r9
-        sbb	r10, QWORD PTR [r8+104]
-        mov	r9, QWORD PTR [rdx+112]
-        mov	QWORD PTR [rcx+104], r10
-        sbb	r9, QWORD PTR [r8+112]
-        mov	r10, QWORD PTR [rdx+120]
-        mov	QWORD PTR [rcx+112], r9
-        sbb	r10, QWORD PTR [r8+120]
-        mov	r9, QWORD PTR [rdx+128]
-        mov	QWORD PTR [rcx+120], r10
-        sbb	r9, QWORD PTR [r8+128]
-        mov	r10, QWORD PTR [rdx+136]
-        mov	QWORD PTR [rcx+128], r9
-        sbb	r10, QWORD PTR [r8+136]
-        mov	r9, QWORD PTR [rdx+144]
-        mov	QWORD PTR [rcx+136], r10
-        sbb	r9, QWORD PTR [r8+144]
-        mov	r10, QWORD PTR [rdx+152]
-        mov	QWORD PTR [rcx+144], r9
-        sbb	r10, QWORD PTR [r8+152]
-        mov	r9, QWORD PTR [rdx+160]
-        mov	QWORD PTR [rcx+152], r10
-        sbb	r9, QWORD PTR [r8+160]
-        mov	r10, QWORD PTR [rdx+168]
-        mov	QWORD PTR [rcx+160], r9
-        sbb	r10, QWORD PTR [r8+168]
-        mov	r9, QWORD PTR [rdx+176]
-        mov	QWORD PTR [rcx+168], r10
-        sbb	r9, QWORD PTR [r8+176]
-        mov	r10, QWORD PTR [rdx+184]
-        mov	QWORD PTR [rcx+176], r9
-        sbb	r10, QWORD PTR [r8+184]
-        mov	r9, QWORD PTR [rdx+192]
-        mov	QWORD PTR [rcx+184], r10
-        sbb	r9, QWORD PTR [r8+192]
-        mov	r10, QWORD PTR [rdx+200]
-        mov	QWORD PTR [rcx+192], r9
-        sbb	r10, QWORD PTR [r8+200]
-        mov	r9, QWORD PTR [rdx+208]
-        mov	QWORD PTR [rcx+200], r10
-        sbb	r9, QWORD PTR [r8+208]
-        mov	r10, QWORD PTR [rdx+216]
-        mov	QWORD PTR [rcx+208], r9
-        sbb	r10, QWORD PTR [r8+216]
-        mov	r9, QWORD PTR [rdx+224]
-        mov	QWORD PTR [rcx+216], r10
-        sbb	r9, QWORD PTR [r8+224]
-        mov	r10, QWORD PTR [rdx+232]
-        mov	QWORD PTR [rcx+224], r9
-        sbb	r10, QWORD PTR [r8+232]
-        mov	r9, QWORD PTR [rdx+240]
-        mov	QWORD PTR [rcx+232], r10
-        sbb	r9, QWORD PTR [r8+240]
-        mov	r10, QWORD PTR [rdx+248]
-        mov	QWORD PTR [rcx+240], r9
-        sbb	r10, QWORD PTR [r8+248]
-        mov	QWORD PTR [rcx+248], r10
-        sbb	rax, 0
-        ret
-sp_2048_sub_32 ENDP
 _text ENDS
 IFDEF HAVE_INTEL_AVX2
 ; /* Reduce the number back to 2048 bits using Montgomery reduction.
@@ -24990,265 +24990,163 @@ ENDIF
         ret
 sp_3072_mont_reduce_48 ENDP
 _text ENDS
-IFDEF HAVE_INTEL_AVX2
-; /* Conditionally subtract b from a using the mask m.
-;  * m is -1 to subtract and 0 when not copying.
+; /* Sub b from a into r. (r = a - b)
 ;  *
-;  * r  A single precision number representing condition subtract result.
-;  * a  A single precision number to subtract from.
-;  * b  A single precision number to subtract.
-;  * m  Mask value to apply.
+;  * r  A single precision integer.
+;  * a  A single precision integer.
+;  * b  A single precision integer.
 ;  */
 _text SEGMENT READONLY PARA
-sp_3072_cond_sub_avx2_48 PROC
-        push	r12
-        mov	rax, 0
-        mov	r12, QWORD PTR [r8]
-        mov	r10, QWORD PTR [rdx]
-        pext	r12, r12, r9
-        sub	r10, r12
-        mov	r12, QWORD PTR [r8+8]
-        mov	r11, QWORD PTR [rdx+8]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+16]
-        mov	r12, QWORD PTR [rdx+16]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+8], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+24]
+sp_3072_sub_48 PROC
+        mov	r9, QWORD PTR [rdx]
+        xor	rax, rax
+        sub	r9, QWORD PTR [r8]
+        mov	r10, QWORD PTR [rdx+8]
+        mov	QWORD PTR [rcx], r9
+        sbb	r10, QWORD PTR [r8+8]
+        mov	r9, QWORD PTR [rdx+16]
+        mov	QWORD PTR [rcx+8], r10
+        sbb	r9, QWORD PTR [r8+16]
         mov	r10, QWORD PTR [rdx+24]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+16], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+32]
-        mov	r11, QWORD PTR [rdx+32]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+16], r9
+        sbb	r10, QWORD PTR [r8+24]
+        mov	r9, QWORD PTR [rdx+32]
         mov	QWORD PTR [rcx+24], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+40]
-        mov	r12, QWORD PTR [rdx+40]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+32], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+48]
-        mov	r10, QWORD PTR [rdx+48]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+40], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+56]
-        mov	r11, QWORD PTR [rdx+56]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+48], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+64]
-        mov	r12, QWORD PTR [rdx+64]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+56], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+72]
+        sbb	r9, QWORD PTR [r8+32]
+        mov	r10, QWORD PTR [rdx+40]
+        mov	QWORD PTR [rcx+32], r9
+        sbb	r10, QWORD PTR [r8+40]
+        mov	r9, QWORD PTR [rdx+48]
+        mov	QWORD PTR [rcx+40], r10
+        sbb	r9, QWORD PTR [r8+48]
+        mov	r10, QWORD PTR [rdx+56]
+        mov	QWORD PTR [rcx+48], r9
+        sbb	r10, QWORD PTR [r8+56]
+        mov	r9, QWORD PTR [rdx+64]
+        mov	QWORD PTR [rcx+56], r10
+        sbb	r9, QWORD PTR [r8+64]
         mov	r10, QWORD PTR [rdx+72]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+64], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+80]
-        mov	r11, QWORD PTR [rdx+80]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+64], r9
+        sbb	r10, QWORD PTR [r8+72]
+        mov	r9, QWORD PTR [rdx+80]
         mov	QWORD PTR [rcx+72], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+88]
-        mov	r12, QWORD PTR [rdx+88]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+80], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+96]
-        mov	r10, QWORD PTR [rdx+96]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+88], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+104]
-        mov	r11, QWORD PTR [rdx+104]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+96], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+112]
-        mov	r12, QWORD PTR [rdx+112]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+104], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+120]
+        sbb	r9, QWORD PTR [r8+80]
+        mov	r10, QWORD PTR [rdx+88]
+        mov	QWORD PTR [rcx+80], r9
+        sbb	r10, QWORD PTR [r8+88]
+        mov	r9, QWORD PTR [rdx+96]
+        mov	QWORD PTR [rcx+88], r10
+        sbb	r9, QWORD PTR [r8+96]
+        mov	r10, QWORD PTR [rdx+104]
+        mov	QWORD PTR [rcx+96], r9
+        sbb	r10, QWORD PTR [r8+104]
+        mov	r9, QWORD PTR [rdx+112]
+        mov	QWORD PTR [rcx+104], r10
+        sbb	r9, QWORD PTR [r8+112]
         mov	r10, QWORD PTR [rdx+120]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+112], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+128]
-        mov	r11, QWORD PTR [rdx+128]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+112], r9
+        sbb	r10, QWORD PTR [r8+120]
+        mov	r9, QWORD PTR [rdx+128]
         mov	QWORD PTR [rcx+120], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+136]
-        mov	r12, QWORD PTR [rdx+136]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+128], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+144]
-        mov	r10, QWORD PTR [rdx+144]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+136], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+152]
-        mov	r11, QWORD PTR [rdx+152]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+144], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+160]
-        mov	r12, QWORD PTR [rdx+160]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+152], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+168]
+        sbb	r9, QWORD PTR [r8+128]
+        mov	r10, QWORD PTR [rdx+136]
+        mov	QWORD PTR [rcx+128], r9
+        sbb	r10, QWORD PTR [r8+136]
+        mov	r9, QWORD PTR [rdx+144]
+        mov	QWORD PTR [rcx+136], r10
+        sbb	r9, QWORD PTR [r8+144]
+        mov	r10, QWORD PTR [rdx+152]
+        mov	QWORD PTR [rcx+144], r9
+        sbb	r10, QWORD PTR [r8+152]
+        mov	r9, QWORD PTR [rdx+160]
+        mov	QWORD PTR [rcx+152], r10
+        sbb	r9, QWORD PTR [r8+160]
         mov	r10, QWORD PTR [rdx+168]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+160], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+176]
-        mov	r11, QWORD PTR [rdx+176]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+160], r9
+        sbb	r10, QWORD PTR [r8+168]
+        mov	r9, QWORD PTR [rdx+176]
         mov	QWORD PTR [rcx+168], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+184]
-        mov	r12, QWORD PTR [rdx+184]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+176], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+192]
-        mov	r10, QWORD PTR [rdx+192]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+184], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+200]
-        mov	r11, QWORD PTR [rdx+200]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+192], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+208]
-        mov	r12, QWORD PTR [rdx+208]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+200], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+216]
+        sbb	r9, QWORD PTR [r8+176]
+        mov	r10, QWORD PTR [rdx+184]
+        mov	QWORD PTR [rcx+176], r9
+        sbb	r10, QWORD PTR [r8+184]
+        mov	r9, QWORD PTR [rdx+192]
+        mov	QWORD PTR [rcx+184], r10
+        sbb	r9, QWORD PTR [r8+192]
+        mov	r10, QWORD PTR [rdx+200]
+        mov	QWORD PTR [rcx+192], r9
+        sbb	r10, QWORD PTR [r8+200]
+        mov	r9, QWORD PTR [rdx+208]
+        mov	QWORD PTR [rcx+200], r10
+        sbb	r9, QWORD PTR [r8+208]
         mov	r10, QWORD PTR [rdx+216]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+208], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+224]
-        mov	r11, QWORD PTR [rdx+224]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+208], r9
+        sbb	r10, QWORD PTR [r8+216]
+        mov	r9, QWORD PTR [rdx+224]
         mov	QWORD PTR [rcx+216], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+232]
-        mov	r12, QWORD PTR [rdx+232]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+224], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+240]
-        mov	r10, QWORD PTR [rdx+240]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+232], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+248]
-        mov	r11, QWORD PTR [rdx+248]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+240], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+256]
-        mov	r12, QWORD PTR [rdx+256]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+248], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+264]
+        sbb	r9, QWORD PTR [r8+224]
+        mov	r10, QWORD PTR [rdx+232]
+        mov	QWORD PTR [rcx+224], r9
+        sbb	r10, QWORD PTR [r8+232]
+        mov	r9, QWORD PTR [rdx+240]
+        mov	QWORD PTR [rcx+232], r10
+        sbb	r9, QWORD PTR [r8+240]
+        mov	r10, QWORD PTR [rdx+248]
+        mov	QWORD PTR [rcx+240], r9
+        sbb	r10, QWORD PTR [r8+248]
+        mov	r9, QWORD PTR [rdx+256]
+        mov	QWORD PTR [rcx+248], r10
+        sbb	r9, QWORD PTR [r8+256]
         mov	r10, QWORD PTR [rdx+264]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+256], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+272]
-        mov	r11, QWORD PTR [rdx+272]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+256], r9
+        sbb	r10, QWORD PTR [r8+264]
+        mov	r9, QWORD PTR [rdx+272]
         mov	QWORD PTR [rcx+264], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+280]
-        mov	r12, QWORD PTR [rdx+280]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+272], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+288]
-        mov	r10, QWORD PTR [rdx+288]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+280], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+296]
-        mov	r11, QWORD PTR [rdx+296]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+288], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+304]
-        mov	r12, QWORD PTR [rdx+304]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+296], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+312]
+        sbb	r9, QWORD PTR [r8+272]
+        mov	r10, QWORD PTR [rdx+280]
+        mov	QWORD PTR [rcx+272], r9
+        sbb	r10, QWORD PTR [r8+280]
+        mov	r9, QWORD PTR [rdx+288]
+        mov	QWORD PTR [rcx+280], r10
+        sbb	r9, QWORD PTR [r8+288]
+        mov	r10, QWORD PTR [rdx+296]
+        mov	QWORD PTR [rcx+288], r9
+        sbb	r10, QWORD PTR [r8+296]
+        mov	r9, QWORD PTR [rdx+304]
+        mov	QWORD PTR [rcx+296], r10
+        sbb	r9, QWORD PTR [r8+304]
         mov	r10, QWORD PTR [rdx+312]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+304], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+320]
-        mov	r11, QWORD PTR [rdx+320]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+304], r9
+        sbb	r10, QWORD PTR [r8+312]
+        mov	r9, QWORD PTR [rdx+320]
         mov	QWORD PTR [rcx+312], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+328]
-        mov	r12, QWORD PTR [rdx+328]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+320], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+336]
-        mov	r10, QWORD PTR [rdx+336]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+328], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+344]
-        mov	r11, QWORD PTR [rdx+344]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+336], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+352]
-        mov	r12, QWORD PTR [rdx+352]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+344], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+360]
+        sbb	r9, QWORD PTR [r8+320]
+        mov	r10, QWORD PTR [rdx+328]
+        mov	QWORD PTR [rcx+320], r9
+        sbb	r10, QWORD PTR [r8+328]
+        mov	r9, QWORD PTR [rdx+336]
+        mov	QWORD PTR [rcx+328], r10
+        sbb	r9, QWORD PTR [r8+336]
+        mov	r10, QWORD PTR [rdx+344]
+        mov	QWORD PTR [rcx+336], r9
+        sbb	r10, QWORD PTR [r8+344]
+        mov	r9, QWORD PTR [rdx+352]
+        mov	QWORD PTR [rcx+344], r10
+        sbb	r9, QWORD PTR [r8+352]
         mov	r10, QWORD PTR [rdx+360]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+352], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+368]
-        mov	r11, QWORD PTR [rdx+368]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+352], r9
+        sbb	r10, QWORD PTR [r8+360]
+        mov	r9, QWORD PTR [rdx+368]
         mov	QWORD PTR [rcx+360], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+376]
-        mov	r12, QWORD PTR [rdx+376]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+368], r11
-        sbb	r12, r10
-        mov	QWORD PTR [rcx+376], r12
+        sbb	r9, QWORD PTR [r8+368]
+        mov	r10, QWORD PTR [rdx+376]
+        mov	QWORD PTR [rcx+368], r9
+        sbb	r10, QWORD PTR [r8+376]
+        mov	QWORD PTR [rcx+376], r10
         sbb	rax, 0
-        pop	r12
         ret
-sp_3072_cond_sub_avx2_48 ENDP
+sp_3072_sub_48 ENDP
 _text ENDS
-ENDIF
 IFDEF HAVE_INTEL_AVX2
 ; /* Mul a by digit b into r. (r = a * b)
 ;  *
@@ -25572,6 +25470,265 @@ div_3072_word_asm_48 PROC
         div	r8
         ret
 div_3072_word_asm_48 ENDP
+_text ENDS
+ENDIF
+IFDEF HAVE_INTEL_AVX2
+; /* Conditionally subtract b from a using the mask m.
+;  * m is -1 to subtract and 0 when not copying.
+;  *
+;  * r  A single precision number representing condition subtract result.
+;  * a  A single precision number to subtract from.
+;  * b  A single precision number to subtract.
+;  * m  Mask value to apply.
+;  */
+_text SEGMENT READONLY PARA
+sp_3072_cond_sub_avx2_48 PROC
+        push	r12
+        mov	rax, 0
+        mov	r12, QWORD PTR [r8]
+        mov	r10, QWORD PTR [rdx]
+        pext	r12, r12, r9
+        sub	r10, r12
+        mov	r12, QWORD PTR [r8+8]
+        mov	r11, QWORD PTR [rdx+8]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+16]
+        mov	r12, QWORD PTR [rdx+16]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+8], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+24]
+        mov	r10, QWORD PTR [rdx+24]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+16], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+32]
+        mov	r11, QWORD PTR [rdx+32]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+24], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+40]
+        mov	r12, QWORD PTR [rdx+40]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+32], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+48]
+        mov	r10, QWORD PTR [rdx+48]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+40], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+56]
+        mov	r11, QWORD PTR [rdx+56]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+48], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+64]
+        mov	r12, QWORD PTR [rdx+64]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+56], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+72]
+        mov	r10, QWORD PTR [rdx+72]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+64], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+80]
+        mov	r11, QWORD PTR [rdx+80]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+72], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+88]
+        mov	r12, QWORD PTR [rdx+88]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+80], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+96]
+        mov	r10, QWORD PTR [rdx+96]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+88], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+104]
+        mov	r11, QWORD PTR [rdx+104]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+96], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+112]
+        mov	r12, QWORD PTR [rdx+112]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+104], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+120]
+        mov	r10, QWORD PTR [rdx+120]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+112], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+128]
+        mov	r11, QWORD PTR [rdx+128]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+120], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+136]
+        mov	r12, QWORD PTR [rdx+136]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+128], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+144]
+        mov	r10, QWORD PTR [rdx+144]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+136], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+152]
+        mov	r11, QWORD PTR [rdx+152]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+144], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+160]
+        mov	r12, QWORD PTR [rdx+160]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+152], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+168]
+        mov	r10, QWORD PTR [rdx+168]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+160], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+176]
+        mov	r11, QWORD PTR [rdx+176]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+168], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+184]
+        mov	r12, QWORD PTR [rdx+184]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+176], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+192]
+        mov	r10, QWORD PTR [rdx+192]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+184], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+200]
+        mov	r11, QWORD PTR [rdx+200]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+192], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+208]
+        mov	r12, QWORD PTR [rdx+208]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+200], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+216]
+        mov	r10, QWORD PTR [rdx+216]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+208], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+224]
+        mov	r11, QWORD PTR [rdx+224]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+216], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+232]
+        mov	r12, QWORD PTR [rdx+232]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+224], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+240]
+        mov	r10, QWORD PTR [rdx+240]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+232], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+248]
+        mov	r11, QWORD PTR [rdx+248]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+240], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+256]
+        mov	r12, QWORD PTR [rdx+256]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+248], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+264]
+        mov	r10, QWORD PTR [rdx+264]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+256], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+272]
+        mov	r11, QWORD PTR [rdx+272]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+264], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+280]
+        mov	r12, QWORD PTR [rdx+280]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+272], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+288]
+        mov	r10, QWORD PTR [rdx+288]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+280], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+296]
+        mov	r11, QWORD PTR [rdx+296]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+288], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+304]
+        mov	r12, QWORD PTR [rdx+304]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+296], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+312]
+        mov	r10, QWORD PTR [rdx+312]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+304], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+320]
+        mov	r11, QWORD PTR [rdx+320]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+312], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+328]
+        mov	r12, QWORD PTR [rdx+328]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+320], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+336]
+        mov	r10, QWORD PTR [rdx+336]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+328], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+344]
+        mov	r11, QWORD PTR [rdx+344]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+336], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+352]
+        mov	r12, QWORD PTR [rdx+352]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+344], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+360]
+        mov	r10, QWORD PTR [rdx+360]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+352], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+368]
+        mov	r11, QWORD PTR [rdx+368]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+360], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+376]
+        mov	r12, QWORD PTR [rdx+376]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+368], r11
+        sbb	r12, r10
+        mov	QWORD PTR [rcx+376], r12
+        sbb	rax, 0
+        pop	r12
+        ret
+sp_3072_cond_sub_avx2_48 ENDP
 _text ENDS
 ENDIF
 ; /* Compare a with b in constant time.
@@ -25976,163 +26133,6 @@ sp_3072_cmp_48 PROC
         pop	r12
         ret
 sp_3072_cmp_48 ENDP
-_text ENDS
-; /* Sub b from a into r. (r = a - b)
-;  *
-;  * r  A single precision integer.
-;  * a  A single precision integer.
-;  * b  A single precision integer.
-;  */
-_text SEGMENT READONLY PARA
-sp_3072_sub_48 PROC
-        mov	r9, QWORD PTR [rdx]
-        xor	rax, rax
-        sub	r9, QWORD PTR [r8]
-        mov	r10, QWORD PTR [rdx+8]
-        mov	QWORD PTR [rcx], r9
-        sbb	r10, QWORD PTR [r8+8]
-        mov	r9, QWORD PTR [rdx+16]
-        mov	QWORD PTR [rcx+8], r10
-        sbb	r9, QWORD PTR [r8+16]
-        mov	r10, QWORD PTR [rdx+24]
-        mov	QWORD PTR [rcx+16], r9
-        sbb	r10, QWORD PTR [r8+24]
-        mov	r9, QWORD PTR [rdx+32]
-        mov	QWORD PTR [rcx+24], r10
-        sbb	r9, QWORD PTR [r8+32]
-        mov	r10, QWORD PTR [rdx+40]
-        mov	QWORD PTR [rcx+32], r9
-        sbb	r10, QWORD PTR [r8+40]
-        mov	r9, QWORD PTR [rdx+48]
-        mov	QWORD PTR [rcx+40], r10
-        sbb	r9, QWORD PTR [r8+48]
-        mov	r10, QWORD PTR [rdx+56]
-        mov	QWORD PTR [rcx+48], r9
-        sbb	r10, QWORD PTR [r8+56]
-        mov	r9, QWORD PTR [rdx+64]
-        mov	QWORD PTR [rcx+56], r10
-        sbb	r9, QWORD PTR [r8+64]
-        mov	r10, QWORD PTR [rdx+72]
-        mov	QWORD PTR [rcx+64], r9
-        sbb	r10, QWORD PTR [r8+72]
-        mov	r9, QWORD PTR [rdx+80]
-        mov	QWORD PTR [rcx+72], r10
-        sbb	r9, QWORD PTR [r8+80]
-        mov	r10, QWORD PTR [rdx+88]
-        mov	QWORD PTR [rcx+80], r9
-        sbb	r10, QWORD PTR [r8+88]
-        mov	r9, QWORD PTR [rdx+96]
-        mov	QWORD PTR [rcx+88], r10
-        sbb	r9, QWORD PTR [r8+96]
-        mov	r10, QWORD PTR [rdx+104]
-        mov	QWORD PTR [rcx+96], r9
-        sbb	r10, QWORD PTR [r8+104]
-        mov	r9, QWORD PTR [rdx+112]
-        mov	QWORD PTR [rcx+104], r10
-        sbb	r9, QWORD PTR [r8+112]
-        mov	r10, QWORD PTR [rdx+120]
-        mov	QWORD PTR [rcx+112], r9
-        sbb	r10, QWORD PTR [r8+120]
-        mov	r9, QWORD PTR [rdx+128]
-        mov	QWORD PTR [rcx+120], r10
-        sbb	r9, QWORD PTR [r8+128]
-        mov	r10, QWORD PTR [rdx+136]
-        mov	QWORD PTR [rcx+128], r9
-        sbb	r10, QWORD PTR [r8+136]
-        mov	r9, QWORD PTR [rdx+144]
-        mov	QWORD PTR [rcx+136], r10
-        sbb	r9, QWORD PTR [r8+144]
-        mov	r10, QWORD PTR [rdx+152]
-        mov	QWORD PTR [rcx+144], r9
-        sbb	r10, QWORD PTR [r8+152]
-        mov	r9, QWORD PTR [rdx+160]
-        mov	QWORD PTR [rcx+152], r10
-        sbb	r9, QWORD PTR [r8+160]
-        mov	r10, QWORD PTR [rdx+168]
-        mov	QWORD PTR [rcx+160], r9
-        sbb	r10, QWORD PTR [r8+168]
-        mov	r9, QWORD PTR [rdx+176]
-        mov	QWORD PTR [rcx+168], r10
-        sbb	r9, QWORD PTR [r8+176]
-        mov	r10, QWORD PTR [rdx+184]
-        mov	QWORD PTR [rcx+176], r9
-        sbb	r10, QWORD PTR [r8+184]
-        mov	r9, QWORD PTR [rdx+192]
-        mov	QWORD PTR [rcx+184], r10
-        sbb	r9, QWORD PTR [r8+192]
-        mov	r10, QWORD PTR [rdx+200]
-        mov	QWORD PTR [rcx+192], r9
-        sbb	r10, QWORD PTR [r8+200]
-        mov	r9, QWORD PTR [rdx+208]
-        mov	QWORD PTR [rcx+200], r10
-        sbb	r9, QWORD PTR [r8+208]
-        mov	r10, QWORD PTR [rdx+216]
-        mov	QWORD PTR [rcx+208], r9
-        sbb	r10, QWORD PTR [r8+216]
-        mov	r9, QWORD PTR [rdx+224]
-        mov	QWORD PTR [rcx+216], r10
-        sbb	r9, QWORD PTR [r8+224]
-        mov	r10, QWORD PTR [rdx+232]
-        mov	QWORD PTR [rcx+224], r9
-        sbb	r10, QWORD PTR [r8+232]
-        mov	r9, QWORD PTR [rdx+240]
-        mov	QWORD PTR [rcx+232], r10
-        sbb	r9, QWORD PTR [r8+240]
-        mov	r10, QWORD PTR [rdx+248]
-        mov	QWORD PTR [rcx+240], r9
-        sbb	r10, QWORD PTR [r8+248]
-        mov	r9, QWORD PTR [rdx+256]
-        mov	QWORD PTR [rcx+248], r10
-        sbb	r9, QWORD PTR [r8+256]
-        mov	r10, QWORD PTR [rdx+264]
-        mov	QWORD PTR [rcx+256], r9
-        sbb	r10, QWORD PTR [r8+264]
-        mov	r9, QWORD PTR [rdx+272]
-        mov	QWORD PTR [rcx+264], r10
-        sbb	r9, QWORD PTR [r8+272]
-        mov	r10, QWORD PTR [rdx+280]
-        mov	QWORD PTR [rcx+272], r9
-        sbb	r10, QWORD PTR [r8+280]
-        mov	r9, QWORD PTR [rdx+288]
-        mov	QWORD PTR [rcx+280], r10
-        sbb	r9, QWORD PTR [r8+288]
-        mov	r10, QWORD PTR [rdx+296]
-        mov	QWORD PTR [rcx+288], r9
-        sbb	r10, QWORD PTR [r8+296]
-        mov	r9, QWORD PTR [rdx+304]
-        mov	QWORD PTR [rcx+296], r10
-        sbb	r9, QWORD PTR [r8+304]
-        mov	r10, QWORD PTR [rdx+312]
-        mov	QWORD PTR [rcx+304], r9
-        sbb	r10, QWORD PTR [r8+312]
-        mov	r9, QWORD PTR [rdx+320]
-        mov	QWORD PTR [rcx+312], r10
-        sbb	r9, QWORD PTR [r8+320]
-        mov	r10, QWORD PTR [rdx+328]
-        mov	QWORD PTR [rcx+320], r9
-        sbb	r10, QWORD PTR [r8+328]
-        mov	r9, QWORD PTR [rdx+336]
-        mov	QWORD PTR [rcx+328], r10
-        sbb	r9, QWORD PTR [r8+336]
-        mov	r10, QWORD PTR [rdx+344]
-        mov	QWORD PTR [rcx+336], r9
-        sbb	r10, QWORD PTR [r8+344]
-        mov	r9, QWORD PTR [rdx+352]
-        mov	QWORD PTR [rcx+344], r10
-        sbb	r9, QWORD PTR [r8+352]
-        mov	r10, QWORD PTR [rdx+360]
-        mov	QWORD PTR [rcx+352], r9
-        sbb	r10, QWORD PTR [r8+360]
-        mov	r9, QWORD PTR [rdx+368]
-        mov	QWORD PTR [rcx+360], r10
-        sbb	r9, QWORD PTR [r8+368]
-        mov	r10, QWORD PTR [rdx+376]
-        mov	QWORD PTR [rcx+368], r9
-        sbb	r10, QWORD PTR [r8+376]
-        mov	QWORD PTR [rcx+376], r10
-        sbb	rax, 0
-        ret
-sp_3072_sub_48 ENDP
 _text ENDS
 IFDEF HAVE_INTEL_AVX2
 ; /* Reduce the number back to 3072 bits using Montgomery reduction.
@@ -34638,345 +34638,211 @@ ENDIF
         ret
 sp_4096_mont_reduce_64 ENDP
 _text ENDS
-IFDEF HAVE_INTEL_AVX2
-; /* Conditionally subtract b from a using the mask m.
-;  * m is -1 to subtract and 0 when not copying.
+; /* Sub b from a into r. (r = a - b)
 ;  *
-;  * r  A single precision number representing condition subtract result.
-;  * a  A single precision number to subtract from.
-;  * b  A single precision number to subtract.
-;  * m  Mask value to apply.
+;  * r  A single precision integer.
+;  * a  A single precision integer.
+;  * b  A single precision integer.
 ;  */
 _text SEGMENT READONLY PARA
-sp_4096_cond_sub_avx2_64 PROC
-        push	r12
-        mov	rax, 0
-        mov	r12, QWORD PTR [r8]
-        mov	r10, QWORD PTR [rdx]
-        pext	r12, r12, r9
-        sub	r10, r12
-        mov	r12, QWORD PTR [r8+8]
-        mov	r11, QWORD PTR [rdx+8]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+16]
-        mov	r12, QWORD PTR [rdx+16]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+8], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+24]
+sp_4096_sub_64 PROC
+        mov	r9, QWORD PTR [rdx]
+        xor	rax, rax
+        sub	r9, QWORD PTR [r8]
+        mov	r10, QWORD PTR [rdx+8]
+        mov	QWORD PTR [rcx], r9
+        sbb	r10, QWORD PTR [r8+8]
+        mov	r9, QWORD PTR [rdx+16]
+        mov	QWORD PTR [rcx+8], r10
+        sbb	r9, QWORD PTR [r8+16]
         mov	r10, QWORD PTR [rdx+24]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+16], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+32]
-        mov	r11, QWORD PTR [rdx+32]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+16], r9
+        sbb	r10, QWORD PTR [r8+24]
+        mov	r9, QWORD PTR [rdx+32]
         mov	QWORD PTR [rcx+24], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+40]
-        mov	r12, QWORD PTR [rdx+40]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+32], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+48]
-        mov	r10, QWORD PTR [rdx+48]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+40], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+56]
-        mov	r11, QWORD PTR [rdx+56]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+48], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+64]
-        mov	r12, QWORD PTR [rdx+64]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+56], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+72]
+        sbb	r9, QWORD PTR [r8+32]
+        mov	r10, QWORD PTR [rdx+40]
+        mov	QWORD PTR [rcx+32], r9
+        sbb	r10, QWORD PTR [r8+40]
+        mov	r9, QWORD PTR [rdx+48]
+        mov	QWORD PTR [rcx+40], r10
+        sbb	r9, QWORD PTR [r8+48]
+        mov	r10, QWORD PTR [rdx+56]
+        mov	QWORD PTR [rcx+48], r9
+        sbb	r10, QWORD PTR [r8+56]
+        mov	r9, QWORD PTR [rdx+64]
+        mov	QWORD PTR [rcx+56], r10
+        sbb	r9, QWORD PTR [r8+64]
         mov	r10, QWORD PTR [rdx+72]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+64], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+80]
-        mov	r11, QWORD PTR [rdx+80]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+64], r9
+        sbb	r10, QWORD PTR [r8+72]
+        mov	r9, QWORD PTR [rdx+80]
         mov	QWORD PTR [rcx+72], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+88]
-        mov	r12, QWORD PTR [rdx+88]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+80], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+96]
-        mov	r10, QWORD PTR [rdx+96]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+88], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+104]
-        mov	r11, QWORD PTR [rdx+104]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+96], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+112]
-        mov	r12, QWORD PTR [rdx+112]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+104], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+120]
+        sbb	r9, QWORD PTR [r8+80]
+        mov	r10, QWORD PTR [rdx+88]
+        mov	QWORD PTR [rcx+80], r9
+        sbb	r10, QWORD PTR [r8+88]
+        mov	r9, QWORD PTR [rdx+96]
+        mov	QWORD PTR [rcx+88], r10
+        sbb	r9, QWORD PTR [r8+96]
+        mov	r10, QWORD PTR [rdx+104]
+        mov	QWORD PTR [rcx+96], r9
+        sbb	r10, QWORD PTR [r8+104]
+        mov	r9, QWORD PTR [rdx+112]
+        mov	QWORD PTR [rcx+104], r10
+        sbb	r9, QWORD PTR [r8+112]
         mov	r10, QWORD PTR [rdx+120]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+112], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+128]
-        mov	r11, QWORD PTR [rdx+128]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+112], r9
+        sbb	r10, QWORD PTR [r8+120]
+        mov	r9, QWORD PTR [rdx+128]
         mov	QWORD PTR [rcx+120], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+136]
-        mov	r12, QWORD PTR [rdx+136]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+128], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+144]
-        mov	r10, QWORD PTR [rdx+144]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+136], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+152]
-        mov	r11, QWORD PTR [rdx+152]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+144], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+160]
-        mov	r12, QWORD PTR [rdx+160]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+152], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+168]
+        sbb	r9, QWORD PTR [r8+128]
+        mov	r10, QWORD PTR [rdx+136]
+        mov	QWORD PTR [rcx+128], r9
+        sbb	r10, QWORD PTR [r8+136]
+        mov	r9, QWORD PTR [rdx+144]
+        mov	QWORD PTR [rcx+136], r10
+        sbb	r9, QWORD PTR [r8+144]
+        mov	r10, QWORD PTR [rdx+152]
+        mov	QWORD PTR [rcx+144], r9
+        sbb	r10, QWORD PTR [r8+152]
+        mov	r9, QWORD PTR [rdx+160]
+        mov	QWORD PTR [rcx+152], r10
+        sbb	r9, QWORD PTR [r8+160]
         mov	r10, QWORD PTR [rdx+168]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+160], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+176]
-        mov	r11, QWORD PTR [rdx+176]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+160], r9
+        sbb	r10, QWORD PTR [r8+168]
+        mov	r9, QWORD PTR [rdx+176]
         mov	QWORD PTR [rcx+168], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+184]
-        mov	r12, QWORD PTR [rdx+184]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+176], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+192]
-        mov	r10, QWORD PTR [rdx+192]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+184], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+200]
-        mov	r11, QWORD PTR [rdx+200]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+192], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+208]
-        mov	r12, QWORD PTR [rdx+208]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+200], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+216]
+        sbb	r9, QWORD PTR [r8+176]
+        mov	r10, QWORD PTR [rdx+184]
+        mov	QWORD PTR [rcx+176], r9
+        sbb	r10, QWORD PTR [r8+184]
+        mov	r9, QWORD PTR [rdx+192]
+        mov	QWORD PTR [rcx+184], r10
+        sbb	r9, QWORD PTR [r8+192]
+        mov	r10, QWORD PTR [rdx+200]
+        mov	QWORD PTR [rcx+192], r9
+        sbb	r10, QWORD PTR [r8+200]
+        mov	r9, QWORD PTR [rdx+208]
+        mov	QWORD PTR [rcx+200], r10
+        sbb	r9, QWORD PTR [r8+208]
         mov	r10, QWORD PTR [rdx+216]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+208], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+224]
-        mov	r11, QWORD PTR [rdx+224]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+208], r9
+        sbb	r10, QWORD PTR [r8+216]
+        mov	r9, QWORD PTR [rdx+224]
         mov	QWORD PTR [rcx+216], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+232]
-        mov	r12, QWORD PTR [rdx+232]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+224], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+240]
-        mov	r10, QWORD PTR [rdx+240]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+232], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+248]
-        mov	r11, QWORD PTR [rdx+248]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+240], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+256]
-        mov	r12, QWORD PTR [rdx+256]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+248], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+264]
+        sbb	r9, QWORD PTR [r8+224]
+        mov	r10, QWORD PTR [rdx+232]
+        mov	QWORD PTR [rcx+224], r9
+        sbb	r10, QWORD PTR [r8+232]
+        mov	r9, QWORD PTR [rdx+240]
+        mov	QWORD PTR [rcx+232], r10
+        sbb	r9, QWORD PTR [r8+240]
+        mov	r10, QWORD PTR [rdx+248]
+        mov	QWORD PTR [rcx+240], r9
+        sbb	r10, QWORD PTR [r8+248]
+        mov	r9, QWORD PTR [rdx+256]
+        mov	QWORD PTR [rcx+248], r10
+        sbb	r9, QWORD PTR [r8+256]
         mov	r10, QWORD PTR [rdx+264]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+256], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+272]
-        mov	r11, QWORD PTR [rdx+272]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+256], r9
+        sbb	r10, QWORD PTR [r8+264]
+        mov	r9, QWORD PTR [rdx+272]
         mov	QWORD PTR [rcx+264], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+280]
-        mov	r12, QWORD PTR [rdx+280]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+272], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+288]
-        mov	r10, QWORD PTR [rdx+288]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+280], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+296]
-        mov	r11, QWORD PTR [rdx+296]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+288], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+304]
-        mov	r12, QWORD PTR [rdx+304]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+296], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+312]
+        sbb	r9, QWORD PTR [r8+272]
+        mov	r10, QWORD PTR [rdx+280]
+        mov	QWORD PTR [rcx+272], r9
+        sbb	r10, QWORD PTR [r8+280]
+        mov	r9, QWORD PTR [rdx+288]
+        mov	QWORD PTR [rcx+280], r10
+        sbb	r9, QWORD PTR [r8+288]
+        mov	r10, QWORD PTR [rdx+296]
+        mov	QWORD PTR [rcx+288], r9
+        sbb	r10, QWORD PTR [r8+296]
+        mov	r9, QWORD PTR [rdx+304]
+        mov	QWORD PTR [rcx+296], r10
+        sbb	r9, QWORD PTR [r8+304]
         mov	r10, QWORD PTR [rdx+312]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+304], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+320]
-        mov	r11, QWORD PTR [rdx+320]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+304], r9
+        sbb	r10, QWORD PTR [r8+312]
+        mov	r9, QWORD PTR [rdx+320]
         mov	QWORD PTR [rcx+312], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+328]
-        mov	r12, QWORD PTR [rdx+328]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+320], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+336]
-        mov	r10, QWORD PTR [rdx+336]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+328], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+344]
-        mov	r11, QWORD PTR [rdx+344]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+336], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+352]
-        mov	r12, QWORD PTR [rdx+352]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+344], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+360]
+        sbb	r9, QWORD PTR [r8+320]
+        mov	r10, QWORD PTR [rdx+328]
+        mov	QWORD PTR [rcx+320], r9
+        sbb	r10, QWORD PTR [r8+328]
+        mov	r9, QWORD PTR [rdx+336]
+        mov	QWORD PTR [rcx+328], r10
+        sbb	r9, QWORD PTR [r8+336]
+        mov	r10, QWORD PTR [rdx+344]
+        mov	QWORD PTR [rcx+336], r9
+        sbb	r10, QWORD PTR [r8+344]
+        mov	r9, QWORD PTR [rdx+352]
+        mov	QWORD PTR [rcx+344], r10
+        sbb	r9, QWORD PTR [r8+352]
         mov	r10, QWORD PTR [rdx+360]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+352], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+368]
-        mov	r11, QWORD PTR [rdx+368]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+352], r9
+        sbb	r10, QWORD PTR [r8+360]
+        mov	r9, QWORD PTR [rdx+368]
         mov	QWORD PTR [rcx+360], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+376]
-        mov	r12, QWORD PTR [rdx+376]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+368], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+384]
-        mov	r10, QWORD PTR [rdx+384]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+376], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+392]
-        mov	r11, QWORD PTR [rdx+392]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+384], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+400]
-        mov	r12, QWORD PTR [rdx+400]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+392], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+408]
+        sbb	r9, QWORD PTR [r8+368]
+        mov	r10, QWORD PTR [rdx+376]
+        mov	QWORD PTR [rcx+368], r9
+        sbb	r10, QWORD PTR [r8+376]
+        mov	r9, QWORD PTR [rdx+384]
+        mov	QWORD PTR [rcx+376], r10
+        sbb	r9, QWORD PTR [r8+384]
+        mov	r10, QWORD PTR [rdx+392]
+        mov	QWORD PTR [rcx+384], r9
+        sbb	r10, QWORD PTR [r8+392]
+        mov	r9, QWORD PTR [rdx+400]
+        mov	QWORD PTR [rcx+392], r10
+        sbb	r9, QWORD PTR [r8+400]
         mov	r10, QWORD PTR [rdx+408]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+400], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+416]
-        mov	r11, QWORD PTR [rdx+416]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+400], r9
+        sbb	r10, QWORD PTR [r8+408]
+        mov	r9, QWORD PTR [rdx+416]
         mov	QWORD PTR [rcx+408], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+424]
-        mov	r12, QWORD PTR [rdx+424]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+416], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+432]
-        mov	r10, QWORD PTR [rdx+432]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+424], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+440]
-        mov	r11, QWORD PTR [rdx+440]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+432], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+448]
-        mov	r12, QWORD PTR [rdx+448]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+440], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+456]
+        sbb	r9, QWORD PTR [r8+416]
+        mov	r10, QWORD PTR [rdx+424]
+        mov	QWORD PTR [rcx+416], r9
+        sbb	r10, QWORD PTR [r8+424]
+        mov	r9, QWORD PTR [rdx+432]
+        mov	QWORD PTR [rcx+424], r10
+        sbb	r9, QWORD PTR [r8+432]
+        mov	r10, QWORD PTR [rdx+440]
+        mov	QWORD PTR [rcx+432], r9
+        sbb	r10, QWORD PTR [r8+440]
+        mov	r9, QWORD PTR [rdx+448]
+        mov	QWORD PTR [rcx+440], r10
+        sbb	r9, QWORD PTR [r8+448]
         mov	r10, QWORD PTR [rdx+456]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+448], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+464]
-        mov	r11, QWORD PTR [rdx+464]
-        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+448], r9
+        sbb	r10, QWORD PTR [r8+456]
+        mov	r9, QWORD PTR [rdx+464]
         mov	QWORD PTR [rcx+456], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+472]
-        mov	r12, QWORD PTR [rdx+472]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+464], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+480]
-        mov	r10, QWORD PTR [rdx+480]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+472], r12
-        sbb	r10, r11
-        mov	r12, QWORD PTR [r8+488]
-        mov	r11, QWORD PTR [rdx+488]
-        pext	r12, r12, r9
-        mov	QWORD PTR [rcx+480], r10
-        sbb	r11, r12
-        mov	r10, QWORD PTR [r8+496]
-        mov	r12, QWORD PTR [rdx+496]
-        pext	r10, r10, r9
-        mov	QWORD PTR [rcx+488], r11
-        sbb	r12, r10
-        mov	r11, QWORD PTR [r8+504]
+        sbb	r9, QWORD PTR [r8+464]
+        mov	r10, QWORD PTR [rdx+472]
+        mov	QWORD PTR [rcx+464], r9
+        sbb	r10, QWORD PTR [r8+472]
+        mov	r9, QWORD PTR [rdx+480]
+        mov	QWORD PTR [rcx+472], r10
+        sbb	r9, QWORD PTR [r8+480]
+        mov	r10, QWORD PTR [rdx+488]
+        mov	QWORD PTR [rcx+480], r9
+        sbb	r10, QWORD PTR [r8+488]
+        mov	r9, QWORD PTR [rdx+496]
+        mov	QWORD PTR [rcx+488], r10
+        sbb	r9, QWORD PTR [r8+496]
         mov	r10, QWORD PTR [rdx+504]
-        pext	r11, r11, r9
-        mov	QWORD PTR [rcx+496], r12
-        sbb	r10, r11
+        mov	QWORD PTR [rcx+496], r9
+        sbb	r10, QWORD PTR [r8+504]
         mov	QWORD PTR [rcx+504], r10
         sbb	rax, 0
-        pop	r12
         ret
-sp_4096_cond_sub_avx2_64 ENDP
+sp_4096_sub_64 ENDP
 _text ENDS
-ENDIF
 IFDEF HAVE_INTEL_AVX2
 ; /* Mul a by digit b into r. (r = a * b)
 ;  *
@@ -35396,6 +35262,345 @@ div_4096_word_asm_64 PROC
         div	r8
         ret
 div_4096_word_asm_64 ENDP
+_text ENDS
+ENDIF
+IFDEF HAVE_INTEL_AVX2
+; /* Conditionally subtract b from a using the mask m.
+;  * m is -1 to subtract and 0 when not copying.
+;  *
+;  * r  A single precision number representing condition subtract result.
+;  * a  A single precision number to subtract from.
+;  * b  A single precision number to subtract.
+;  * m  Mask value to apply.
+;  */
+_text SEGMENT READONLY PARA
+sp_4096_cond_sub_avx2_64 PROC
+        push	r12
+        mov	rax, 0
+        mov	r12, QWORD PTR [r8]
+        mov	r10, QWORD PTR [rdx]
+        pext	r12, r12, r9
+        sub	r10, r12
+        mov	r12, QWORD PTR [r8+8]
+        mov	r11, QWORD PTR [rdx+8]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+16]
+        mov	r12, QWORD PTR [rdx+16]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+8], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+24]
+        mov	r10, QWORD PTR [rdx+24]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+16], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+32]
+        mov	r11, QWORD PTR [rdx+32]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+24], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+40]
+        mov	r12, QWORD PTR [rdx+40]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+32], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+48]
+        mov	r10, QWORD PTR [rdx+48]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+40], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+56]
+        mov	r11, QWORD PTR [rdx+56]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+48], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+64]
+        mov	r12, QWORD PTR [rdx+64]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+56], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+72]
+        mov	r10, QWORD PTR [rdx+72]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+64], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+80]
+        mov	r11, QWORD PTR [rdx+80]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+72], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+88]
+        mov	r12, QWORD PTR [rdx+88]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+80], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+96]
+        mov	r10, QWORD PTR [rdx+96]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+88], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+104]
+        mov	r11, QWORD PTR [rdx+104]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+96], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+112]
+        mov	r12, QWORD PTR [rdx+112]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+104], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+120]
+        mov	r10, QWORD PTR [rdx+120]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+112], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+128]
+        mov	r11, QWORD PTR [rdx+128]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+120], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+136]
+        mov	r12, QWORD PTR [rdx+136]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+128], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+144]
+        mov	r10, QWORD PTR [rdx+144]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+136], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+152]
+        mov	r11, QWORD PTR [rdx+152]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+144], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+160]
+        mov	r12, QWORD PTR [rdx+160]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+152], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+168]
+        mov	r10, QWORD PTR [rdx+168]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+160], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+176]
+        mov	r11, QWORD PTR [rdx+176]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+168], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+184]
+        mov	r12, QWORD PTR [rdx+184]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+176], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+192]
+        mov	r10, QWORD PTR [rdx+192]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+184], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+200]
+        mov	r11, QWORD PTR [rdx+200]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+192], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+208]
+        mov	r12, QWORD PTR [rdx+208]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+200], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+216]
+        mov	r10, QWORD PTR [rdx+216]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+208], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+224]
+        mov	r11, QWORD PTR [rdx+224]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+216], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+232]
+        mov	r12, QWORD PTR [rdx+232]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+224], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+240]
+        mov	r10, QWORD PTR [rdx+240]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+232], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+248]
+        mov	r11, QWORD PTR [rdx+248]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+240], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+256]
+        mov	r12, QWORD PTR [rdx+256]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+248], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+264]
+        mov	r10, QWORD PTR [rdx+264]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+256], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+272]
+        mov	r11, QWORD PTR [rdx+272]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+264], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+280]
+        mov	r12, QWORD PTR [rdx+280]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+272], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+288]
+        mov	r10, QWORD PTR [rdx+288]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+280], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+296]
+        mov	r11, QWORD PTR [rdx+296]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+288], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+304]
+        mov	r12, QWORD PTR [rdx+304]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+296], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+312]
+        mov	r10, QWORD PTR [rdx+312]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+304], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+320]
+        mov	r11, QWORD PTR [rdx+320]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+312], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+328]
+        mov	r12, QWORD PTR [rdx+328]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+320], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+336]
+        mov	r10, QWORD PTR [rdx+336]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+328], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+344]
+        mov	r11, QWORD PTR [rdx+344]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+336], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+352]
+        mov	r12, QWORD PTR [rdx+352]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+344], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+360]
+        mov	r10, QWORD PTR [rdx+360]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+352], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+368]
+        mov	r11, QWORD PTR [rdx+368]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+360], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+376]
+        mov	r12, QWORD PTR [rdx+376]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+368], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+384]
+        mov	r10, QWORD PTR [rdx+384]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+376], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+392]
+        mov	r11, QWORD PTR [rdx+392]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+384], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+400]
+        mov	r12, QWORD PTR [rdx+400]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+392], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+408]
+        mov	r10, QWORD PTR [rdx+408]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+400], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+416]
+        mov	r11, QWORD PTR [rdx+416]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+408], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+424]
+        mov	r12, QWORD PTR [rdx+424]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+416], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+432]
+        mov	r10, QWORD PTR [rdx+432]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+424], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+440]
+        mov	r11, QWORD PTR [rdx+440]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+432], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+448]
+        mov	r12, QWORD PTR [rdx+448]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+440], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+456]
+        mov	r10, QWORD PTR [rdx+456]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+448], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+464]
+        mov	r11, QWORD PTR [rdx+464]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+456], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+472]
+        mov	r12, QWORD PTR [rdx+472]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+464], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+480]
+        mov	r10, QWORD PTR [rdx+480]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+472], r12
+        sbb	r10, r11
+        mov	r12, QWORD PTR [r8+488]
+        mov	r11, QWORD PTR [rdx+488]
+        pext	r12, r12, r9
+        mov	QWORD PTR [rcx+480], r10
+        sbb	r11, r12
+        mov	r10, QWORD PTR [r8+496]
+        mov	r12, QWORD PTR [rdx+496]
+        pext	r10, r10, r9
+        mov	QWORD PTR [rcx+488], r11
+        sbb	r12, r10
+        mov	r11, QWORD PTR [r8+504]
+        mov	r10, QWORD PTR [rdx+504]
+        pext	r11, r11, r9
+        mov	QWORD PTR [rcx+496], r12
+        sbb	r10, r11
+        mov	QWORD PTR [rcx+504], r10
+        sbb	rax, 0
+        pop	r12
+        ret
+sp_4096_cond_sub_avx2_64 ENDP
 _text ENDS
 ENDIF
 ; /* Compare a with b in constant time.
@@ -35928,211 +36133,6 @@ sp_4096_cmp_64 PROC
         pop	r12
         ret
 sp_4096_cmp_64 ENDP
-_text ENDS
-; /* Sub b from a into r. (r = a - b)
-;  *
-;  * r  A single precision integer.
-;  * a  A single precision integer.
-;  * b  A single precision integer.
-;  */
-_text SEGMENT READONLY PARA
-sp_4096_sub_64 PROC
-        mov	r9, QWORD PTR [rdx]
-        xor	rax, rax
-        sub	r9, QWORD PTR [r8]
-        mov	r10, QWORD PTR [rdx+8]
-        mov	QWORD PTR [rcx], r9
-        sbb	r10, QWORD PTR [r8+8]
-        mov	r9, QWORD PTR [rdx+16]
-        mov	QWORD PTR [rcx+8], r10
-        sbb	r9, QWORD PTR [r8+16]
-        mov	r10, QWORD PTR [rdx+24]
-        mov	QWORD PTR [rcx+16], r9
-        sbb	r10, QWORD PTR [r8+24]
-        mov	r9, QWORD PTR [rdx+32]
-        mov	QWORD PTR [rcx+24], r10
-        sbb	r9, QWORD PTR [r8+32]
-        mov	r10, QWORD PTR [rdx+40]
-        mov	QWORD PTR [rcx+32], r9
-        sbb	r10, QWORD PTR [r8+40]
-        mov	r9, QWORD PTR [rdx+48]
-        mov	QWORD PTR [rcx+40], r10
-        sbb	r9, QWORD PTR [r8+48]
-        mov	r10, QWORD PTR [rdx+56]
-        mov	QWORD PTR [rcx+48], r9
-        sbb	r10, QWORD PTR [r8+56]
-        mov	r9, QWORD PTR [rdx+64]
-        mov	QWORD PTR [rcx+56], r10
-        sbb	r9, QWORD PTR [r8+64]
-        mov	r10, QWORD PTR [rdx+72]
-        mov	QWORD PTR [rcx+64], r9
-        sbb	r10, QWORD PTR [r8+72]
-        mov	r9, QWORD PTR [rdx+80]
-        mov	QWORD PTR [rcx+72], r10
-        sbb	r9, QWORD PTR [r8+80]
-        mov	r10, QWORD PTR [rdx+88]
-        mov	QWORD PTR [rcx+80], r9
-        sbb	r10, QWORD PTR [r8+88]
-        mov	r9, QWORD PTR [rdx+96]
-        mov	QWORD PTR [rcx+88], r10
-        sbb	r9, QWORD PTR [r8+96]
-        mov	r10, QWORD PTR [rdx+104]
-        mov	QWORD PTR [rcx+96], r9
-        sbb	r10, QWORD PTR [r8+104]
-        mov	r9, QWORD PTR [rdx+112]
-        mov	QWORD PTR [rcx+104], r10
-        sbb	r9, QWORD PTR [r8+112]
-        mov	r10, QWORD PTR [rdx+120]
-        mov	QWORD PTR [rcx+112], r9
-        sbb	r10, QWORD PTR [r8+120]
-        mov	r9, QWORD PTR [rdx+128]
-        mov	QWORD PTR [rcx+120], r10
-        sbb	r9, QWORD PTR [r8+128]
-        mov	r10, QWORD PTR [rdx+136]
-        mov	QWORD PTR [rcx+128], r9
-        sbb	r10, QWORD PTR [r8+136]
-        mov	r9, QWORD PTR [rdx+144]
-        mov	QWORD PTR [rcx+136], r10
-        sbb	r9, QWORD PTR [r8+144]
-        mov	r10, QWORD PTR [rdx+152]
-        mov	QWORD PTR [rcx+144], r9
-        sbb	r10, QWORD PTR [r8+152]
-        mov	r9, QWORD PTR [rdx+160]
-        mov	QWORD PTR [rcx+152], r10
-        sbb	r9, QWORD PTR [r8+160]
-        mov	r10, QWORD PTR [rdx+168]
-        mov	QWORD PTR [rcx+160], r9
-        sbb	r10, QWORD PTR [r8+168]
-        mov	r9, QWORD PTR [rdx+176]
-        mov	QWORD PTR [rcx+168], r10
-        sbb	r9, QWORD PTR [r8+176]
-        mov	r10, QWORD PTR [rdx+184]
-        mov	QWORD PTR [rcx+176], r9
-        sbb	r10, QWORD PTR [r8+184]
-        mov	r9, QWORD PTR [rdx+192]
-        mov	QWORD PTR [rcx+184], r10
-        sbb	r9, QWORD PTR [r8+192]
-        mov	r10, QWORD PTR [rdx+200]
-        mov	QWORD PTR [rcx+192], r9
-        sbb	r10, QWORD PTR [r8+200]
-        mov	r9, QWORD PTR [rdx+208]
-        mov	QWORD PTR [rcx+200], r10
-        sbb	r9, QWORD PTR [r8+208]
-        mov	r10, QWORD PTR [rdx+216]
-        mov	QWORD PTR [rcx+208], r9
-        sbb	r10, QWORD PTR [r8+216]
-        mov	r9, QWORD PTR [rdx+224]
-        mov	QWORD PTR [rcx+216], r10
-        sbb	r9, QWORD PTR [r8+224]
-        mov	r10, QWORD PTR [rdx+232]
-        mov	QWORD PTR [rcx+224], r9
-        sbb	r10, QWORD PTR [r8+232]
-        mov	r9, QWORD PTR [rdx+240]
-        mov	QWORD PTR [rcx+232], r10
-        sbb	r9, QWORD PTR [r8+240]
-        mov	r10, QWORD PTR [rdx+248]
-        mov	QWORD PTR [rcx+240], r9
-        sbb	r10, QWORD PTR [r8+248]
-        mov	r9, QWORD PTR [rdx+256]
-        mov	QWORD PTR [rcx+248], r10
-        sbb	r9, QWORD PTR [r8+256]
-        mov	r10, QWORD PTR [rdx+264]
-        mov	QWORD PTR [rcx+256], r9
-        sbb	r10, QWORD PTR [r8+264]
-        mov	r9, QWORD PTR [rdx+272]
-        mov	QWORD PTR [rcx+264], r10
-        sbb	r9, QWORD PTR [r8+272]
-        mov	r10, QWORD PTR [rdx+280]
-        mov	QWORD PTR [rcx+272], r9
-        sbb	r10, QWORD PTR [r8+280]
-        mov	r9, QWORD PTR [rdx+288]
-        mov	QWORD PTR [rcx+280], r10
-        sbb	r9, QWORD PTR [r8+288]
-        mov	r10, QWORD PTR [rdx+296]
-        mov	QWORD PTR [rcx+288], r9
-        sbb	r10, QWORD PTR [r8+296]
-        mov	r9, QWORD PTR [rdx+304]
-        mov	QWORD PTR [rcx+296], r10
-        sbb	r9, QWORD PTR [r8+304]
-        mov	r10, QWORD PTR [rdx+312]
-        mov	QWORD PTR [rcx+304], r9
-        sbb	r10, QWORD PTR [r8+312]
-        mov	r9, QWORD PTR [rdx+320]
-        mov	QWORD PTR [rcx+312], r10
-        sbb	r9, QWORD PTR [r8+320]
-        mov	r10, QWORD PTR [rdx+328]
-        mov	QWORD PTR [rcx+320], r9
-        sbb	r10, QWORD PTR [r8+328]
-        mov	r9, QWORD PTR [rdx+336]
-        mov	QWORD PTR [rcx+328], r10
-        sbb	r9, QWORD PTR [r8+336]
-        mov	r10, QWORD PTR [rdx+344]
-        mov	QWORD PTR [rcx+336], r9
-        sbb	r10, QWORD PTR [r8+344]
-        mov	r9, QWORD PTR [rdx+352]
-        mov	QWORD PTR [rcx+344], r10
-        sbb	r9, QWORD PTR [r8+352]
-        mov	r10, QWORD PTR [rdx+360]
-        mov	QWORD PTR [rcx+352], r9
-        sbb	r10, QWORD PTR [r8+360]
-        mov	r9, QWORD PTR [rdx+368]
-        mov	QWORD PTR [rcx+360], r10
-        sbb	r9, QWORD PTR [r8+368]
-        mov	r10, QWORD PTR [rdx+376]
-        mov	QWORD PTR [rcx+368], r9
-        sbb	r10, QWORD PTR [r8+376]
-        mov	r9, QWORD PTR [rdx+384]
-        mov	QWORD PTR [rcx+376], r10
-        sbb	r9, QWORD PTR [r8+384]
-        mov	r10, QWORD PTR [rdx+392]
-        mov	QWORD PTR [rcx+384], r9
-        sbb	r10, QWORD PTR [r8+392]
-        mov	r9, QWORD PTR [rdx+400]
-        mov	QWORD PTR [rcx+392], r10
-        sbb	r9, QWORD PTR [r8+400]
-        mov	r10, QWORD PTR [rdx+408]
-        mov	QWORD PTR [rcx+400], r9
-        sbb	r10, QWORD PTR [r8+408]
-        mov	r9, QWORD PTR [rdx+416]
-        mov	QWORD PTR [rcx+408], r10
-        sbb	r9, QWORD PTR [r8+416]
-        mov	r10, QWORD PTR [rdx+424]
-        mov	QWORD PTR [rcx+416], r9
-        sbb	r10, QWORD PTR [r8+424]
-        mov	r9, QWORD PTR [rdx+432]
-        mov	QWORD PTR [rcx+424], r10
-        sbb	r9, QWORD PTR [r8+432]
-        mov	r10, QWORD PTR [rdx+440]
-        mov	QWORD PTR [rcx+432], r9
-        sbb	r10, QWORD PTR [r8+440]
-        mov	r9, QWORD PTR [rdx+448]
-        mov	QWORD PTR [rcx+440], r10
-        sbb	r9, QWORD PTR [r8+448]
-        mov	r10, QWORD PTR [rdx+456]
-        mov	QWORD PTR [rcx+448], r9
-        sbb	r10, QWORD PTR [r8+456]
-        mov	r9, QWORD PTR [rdx+464]
-        mov	QWORD PTR [rcx+456], r10
-        sbb	r9, QWORD PTR [r8+464]
-        mov	r10, QWORD PTR [rdx+472]
-        mov	QWORD PTR [rcx+464], r9
-        sbb	r10, QWORD PTR [r8+472]
-        mov	r9, QWORD PTR [rdx+480]
-        mov	QWORD PTR [rcx+472], r10
-        sbb	r9, QWORD PTR [r8+480]
-        mov	r10, QWORD PTR [rdx+488]
-        mov	QWORD PTR [rcx+480], r9
-        sbb	r10, QWORD PTR [r8+488]
-        mov	r9, QWORD PTR [rdx+496]
-        mov	QWORD PTR [rcx+488], r10
-        sbb	r9, QWORD PTR [r8+496]
-        mov	r10, QWORD PTR [rdx+504]
-        mov	QWORD PTR [rcx+496], r9
-        sbb	r10, QWORD PTR [r8+504]
-        mov	QWORD PTR [rcx+504], r10
-        sbb	rax, 0
-        ret
-sp_4096_sub_64 ENDP
 _text ENDS
 IFDEF HAVE_INTEL_AVX2
 ; /* Reduce the number back to 4096 bits using Montgomery reduction.

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14122,8 +14122,10 @@ exit_rsa_even_mod:
 
     (void)out;
     (void)outSz;
+#ifndef WOLFSSL_RSA_PUBLIC_ONLY
     (void)plain;
     (void)plainSz;
+#endif
     (void)inLen;
     (void)rng;
 

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -806,7 +806,8 @@ MP_API int sp_add_d(sp_int* a, sp_int_digit d, sp_int* r);
 MP_API int sp_sub_d(sp_int* a, sp_int_digit d, sp_int* r);
 MP_API int sp_mul_d(sp_int* a, sp_int_digit d, sp_int* r);
 #if (defined(WOLFSSL_SP_MATH_ALL) && !defined(WOLFSSL_RSA_VERIFY_ONLY)) || \
-    defined(WOLFSSL_KEY_GEN) || defined(HAVE_COMP_KEY)
+    defined(WOLFSSL_KEY_GEN) || defined(HAVE_COMP_KEY) || \
+    defined(WC_MP_TO_RADIX)
 MP_API int sp_div_d(sp_int* a, sp_int_digit d, sp_int* r, sp_int_digit* rem);
 #endif
 #if defined(WOLFSSL_SP_MATH_ALL) || (defined(HAVE_ECC) && \


### PR DESCRIPTION
Configurations:
./configure --disable-asn --disable-filesystem --enable-cryptonly
--disable-dh --disable-sha224 --disable-ecc CFLAGS=-DWOLFSSL_PUBLIC_MP
--enable-rsavfy --enable-sp=small2048 --enable-sp-math

./configure --disable-asn --disable-filesystem --enable-cryptonly
--disable-dh --disable-sha224 --disable-ecc CFLAGS=-DWOLFSSL_PUBLIC_MP
--enable-rsavfy --enable-sp=2048 --enable-sp-math

./configure --disable-asn --disable-filesystem --enable-cryptonly
--disable-dh --disable-sha224 --disable-ecc CFLAGS=-DWOLFSSL_PUBLIC_MP
--enable-rsavfy --enable-sp=small2048 --enable-sp-math-all

./configure --disable-asn --disable-filesystem --enable-cryptonly
--disable-dh --disable-sha224 --disable-ecc CFLAGS=-DWOLFSSL_PUBLIC_MP
--enable-rsavfy --enable-sp=small2048 --enable-sp-math --enable-sp-asm

./configure --disable-asn --disable-filesystem --enable-cryptonly
--disable-dh --disable-sha224 --disable-ecc CFLAGS=-DWOLFSSL_PUBLIC_MP
--enable-rsavfy --enable-sp=2048 --enable-sp-math --enable-sp-asm