### PR TITLE
Defining RFC2459 size limits in OpenSSL compatibility layer

### DIFF
--- a/wolfssl/openssl/asn1.h
+++ b/wolfssl/openssl/asn1.h
@@ -93,6 +93,16 @@
 #define ASN1_STRING_FLAG_EMBED           0x080
 
 
+/* size limits */
+# define ub_common_name                  CTC_NAME_SIZE
+# define ub_locality_name                CTC_NAME_SIZE
+# define ub_state_name                   CTC_NAME_SIZE
+# define ub_organization_name            CTC_NAME_SIZE
+# define ub_organization_unit_name       CTC_NAME_SIZE
+# define ub_title                        CTC_NAME_SIZE
+# define ub_email_address                CTC_NAME_SIZE
+
+
 WOLFSSL_API WOLFSSL_ASN1_INTEGER *wolfSSL_BN_to_ASN1_INTEGER(
     const WOLFSSL_BIGNUM*, WOLFSSL_ASN1_INTEGER*);
 


### PR DESCRIPTION
ub_* #defines are currently missing in the OpenSSL compatibility layer, and may be required by wolfSSL clients. You can refer to [OpenSSL](https://github.com/openssl/openssl/blob/8c5bff2220c4f39b48660afda40005871f53250d/include/openssl/asn1.h.in#L214-L221) and RFC2459 for reference of their definitions.