### PR TITLE
WolfSSL support for OQS's implementation of NIST Round 3 KEMs as TLS 1.3 groups

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -136,3 +136,50 @@
     2) Run the Visual Studio batch to setup command line variables, e.g. C:\Program Files (x86)\Microsoft Visual   
        Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat
     3) Follow steps in "Unix-based Platforms" above.
+
+15. Building with liboqs for TLS 1.3 KEM Groups [EXPERIMENTAL]
+    In order be able to use liboqs, you must have it built and installed on your
+    system. For example, on linux, this would be sufficient:
+
+    $ cd liboqs
+    $ mkdir build
+    $ cd build
+    $ cmake -DOQS_USE_OPENSSL=0 ..
+    $ make all
+    $ sudo make install
+
+    And then for building wolfssl, the following is sufficient:
+
+    $ cd wolfssl
+    $ ./autogen.sh (Might not be necessary)
+    $ ./configure --with-liboqs
+    $ make all
+
+    Execute the following to see the liboqs-related options near the end of the
+    output of these commands:
+
+    $ ./examples/server/server -?
+    $ ./examples/client/client -?
+
+    For a quick start, you can run the client and server like this:
+
+    $ ./examples/server/server -v 4 --oqs KYBER512
+    $ ./examples/client/client -v 4 --oqs KYBER512
+
+    Look for the following line in the output of the server and client:
+
+    ```
+    Using OQS KEM: KYBER512
+    ```
+
+    The following NIST Competition Round 3 Finalist KEMs are supported:
+    - CRYSTALS-KYBER
+    - SABER
+    - NTRU
+
+    Links to more information about these algorithms can be found here:
+    https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions
+
+    NOTE: The quantum-safe algorithms provided by LIBOQS are unstandardized and
+          experimental. It is highly advised that they NOT be used in production
+          environments.

--- a/configure.ac
+++ b/configure.ac
@@ -3736,6 +3736,52 @@ then
 fi
 
 
+# liboqs
+ENABLED_LIBOQS="no"
+tryliboqsdir=""
+AC_ARG_WITH([liboqs],
+    [AS_HELP_STRING([--with-liboqs=PATH],[Path to liboqs install (default /usr/local) EXPERIMENTAL!])],
+    [
+        AC_MSG_CHECKING([for liboqs])
+        CPPFLAGS="$CPPFLAGS -DHAVE_LIBOQS -DHAVE_TLS_EXTENSIONS"
+        LIBS="$LIBS -loqs"
+
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <oqs/common.h>]], [[ OQS_init(); ]])], [ liboqs_linked=yes ],[ liboqs_linked=no ])
+
+        if test "x$liboqs_linked" = "xno" ; then
+            if test "x$withval" != "xno" ; then
+                tryliboqsdir=$withval
+            fi
+            if test "x$withval" = "xyes" ; then
+                tryliboqsdir="/usr/local"
+            fi
+
+            LDFLAGS="$AM_LDFLAGS $LDFLAGS -L$tryliboqsdir/lib"
+            CPPFLAGS="$CPPFLAGS -I$tryliboqsdir/include"
+
+            AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <oqs/common.h>]], [[ OQS_init(); ]])], [ liboqs_linked=yes ],[ liboqs_linked=no ])
+
+            if test "x$liboqs_linked" = "xno" ; then
+                AC_MSG_ERROR([liboqs isn't found.
+                If it's already installed, specify its path using --with-liboqs=/dir/])
+            fi
+            AC_MSG_RESULT([yes])
+            AM_LDFLAGS="$AM_LDFLAGS -L$tryliboqsdir/lib"
+        else
+            AC_MSG_RESULT([yes])
+        fi
+
+        if test "x$ENABLED_OPENSSLEXTRA" = "xno" && test "x$ENABLED_OPENSSLCOEXIST" = "xno"
+        then
+            ENABLED_OPENSSLEXTRA="yes"
+            AM_CFLAGS="-DOPENSSL_EXTRA $AM_CFLAGS"
+        fi
+
+        AM_CFLAGS="$AM_CFLAGS -DHAVE_LIBOQS -DHAVE_TLS_EXTENSIONS"
+        ENABLED_LIBOQS="yes"
+    ]
+)
+
 # Whitewood netRandom client library
 ENABLED_WNR="no"
 trywnrdir=""
@@ -3937,11 +3983,12 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_REQUIRE_FFDHE"
 fi
 
-# TLS 1.3 Requires either ECC or (RSA/DH), or CURVE25519/ED25519 or CURVE448/ED448
+# TLS 1.3 Requires either ECC or (RSA/DH), or CURVE25519/ED25519 or CURVE448/ED448 or libOQS
 if test "x$ENABLED_PSK" = "xno" && test "x$ENABLED_ECC" = "xno" && \
     (test "x$ENABLED_RSA" = "xno" || test "x$ENABLED_DH" = "xno") && \
     (test "x$ENABLED_CURVE25519" = "xno" || test "x$ENABLED_ED25519" = "xno") && \
-    (test "x$ENABLED_CURVE448" = "xno" || test "x$ENABLED_ED448" = "xno")
+    (test "x$ENABLED_CURVE448" = "xno" || test "x$ENABLED_ED448" = "xno") && \
+    test "x$ENABLED_LIBOQS" = "xno"
 then
     # disable TLS 1.3
     ENABLED_TLS13=no
@@ -6749,6 +6796,7 @@ AM_CONDITIONAL([BUILD_CRL_MONITOR],[test "x$ENABLED_CRL_MONITOR" = "xyes"])
 AM_CONDITIONAL([BUILD_USER_RSA],[test "x$ENABLED_USER_RSA" = "xyes"] )
 AM_CONDITIONAL([BUILD_USER_CRYPTO],[test "x$ENABLED_USER_CRYPTO" = "xyes"])
 AM_CONDITIONAL([BUILD_NTRU],[test "x$ENABLED_NTRU" = "xyes"])
+AM_CONDITIONAL([BUILD_LIBOQS],[test "x$ENABLED_LIBOQS" = "xyes"])
 AM_CONDITIONAL([BUILD_WNR],[test "x$ENABLED_WNR" = "xyes"])
 AM_CONDITIONAL([BUILD_SRP],[test "x$ENABLED_SRP" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([USE_VALGRIND],[test "x$ENABLED_VALGRIND" = "xyes"])
@@ -7109,6 +7157,7 @@ echo "   * Atomic User Record Layer:   $ENABLED_ATOMICUSER"
 echo "   * Public Key Callbacks:       $ENABLED_PKCALLBACKS"
 echo "   * NTRU:                       $ENABLED_NTRU"
 echo "   * QSH:                        $ENABLED_QSH"
+echo "   * liboqs:                     $ENABLED_LIBOQS"
 echo "   * Whitewood netRandom:        $ENABLED_WNR"
 echo "   * Server Name Indication:     $ENABLED_SNI"
 echo "   * ALPN:                       $ENABLED_ALPN"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2527,6 +2527,22 @@ static int isValidCurveGroup(word16 name)
         case WOLFSSL_FFDHE_4096:
         case WOLFSSL_FFDHE_6144:
         case WOLFSSL_FFDHE_8192:
+
+#ifdef HAVE_LIBOQS
+        case WOLFSSL_KYBER512:
+        case WOLFSSL_KYBER768:
+        case WOLFSSL_KYBER1024:
+        case WOLFSSL_NTRU_HPS2048509:
+        case WOLFSSL_NTRU_HPS2048677:
+        case WOLFSSL_NTRU_HPS4096821:
+        case WOLFSSL_NTRU_HRSS701:
+        case WOLFSSL_LIGHTSABER:
+        case WOLFSSL_SABER:
+        case WOLFSSL_FIRESABER:
+        case WOLFSSL_KYBER90S512:
+        case WOLFSSL_KYBER90S768:
+        case WOLFSSL_KYBER90S1024:
+#endif
             return 1;
 
         default:
@@ -22682,7 +22698,6 @@ int wolfSSL_X509_cmp(const WOLFSSL_X509 *a, const WOLFSSL_X509 *b)
 
         return id;
     }
-
 
     byte* wolfSSL_X509_get_subjectKeyID(WOLFSSL_X509* x509,
                                         byte* dst, int* dstLen)

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -8667,6 +8667,19 @@ int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group)
     }
 #endif
 
+#ifdef HAVE_LIBOQS
+    if (group >= WOLFSSL_OQS_MIN &&
+        group <= WOLFSSL_OQS_MAX &&
+        ssl->options.side == WOLFSSL_SERVER_END) {
+        /* If I am the server of a KEM connection, do not do keygen because I'm
+         * going to encapsulate with the client's public key. Note that I might
+         * be the client and ssl->option.side has not been properly set yet. In
+         * that case the KeyGen operation will be deferred to connection time.
+         */
+        return WOLFSSL_SUCCESS;
+    }
+#endif
+
     ret = TLSX_KeyShare_Use(ssl, group, 0, NULL, NULL);
     if (ret != 0)
         return ret;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -24,7 +24,6 @@
 #ifndef WOLFSSL_INT_H
 #define WOLFSSL_INT_H
 
-
 #include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/ssl.h>
 #ifdef HAVE_CRL

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -775,7 +775,11 @@ enum SNICbReturn {
 /* Maximum master key length (SECRET_LEN) */
 #define WOLFSSL_MAX_MASTER_KEY_LENGTH 48
 /* Maximum number of groups that can be set */
+#ifdef HAVE_LIBOQS
+#define WOLFSSL_MAX_GROUP_COUNT       23
+#else
 #define WOLFSSL_MAX_GROUP_COUNT       10
+#endif
 
 #if defined(HAVE_SECRET_CALLBACK) && defined(WOLFSSL_TLS13)
 enum Tls13Secret {
@@ -3493,6 +3497,27 @@ enum {
     WOLFSSL_FFDHE_4096    = 258,
     WOLFSSL_FFDHE_6144    = 259,
     WOLFSSL_FFDHE_8192    = 260,
+
+#ifdef HAVE_LIBOQS
+    /* These group numbers were taken from liboqs' openssl fork, see:
+    https://github.com/open-quantum-safe/openssl/blob/OQS-OpenSSL_1_1_1-stable/
+    oqs-template/oqs-kem-info.md */
+    WOLFSSL_OQS_MIN         = 532,
+    WOLFSSL_NTRU_HPS2048509 = 532,
+    WOLFSSL_NTRU_HPS2048677 = 533,
+    WOLFSSL_NTRU_HPS4096821 = 534,
+    WOLFSSL_NTRU_HRSS701    = 535,
+    WOLFSSL_LIGHTSABER      = 536,
+    WOLFSSL_SABER           = 537,
+    WOLFSSL_FIRESABER       = 538,
+    WOLFSSL_KYBER512        = 570,
+    WOLFSSL_KYBER768        = 572,
+    WOLFSSL_KYBER1024       = 573,
+    WOLFSSL_KYBER90S512     = 574,
+    WOLFSSL_KYBER90S768     = 575,
+    WOLFSSL_KYBER90S1024    = 576,
+    WOLFSSL_OQS_MAX         = 576,
+#endif
 };
 
 enum {


### PR DESCRIPTION
```
LIBOQS:
git clone git@github.com:open-quantum-safe/liboqs.git
cd liboqs && mkdir build && cd build
cmake -DOQS_USE_OPENSSL=0  ..
make all
sudo make install

WOLFSSL:
./configure --with-liboqs && make
```