### PR TITLE
Fix compiler warnings

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -6817,7 +6817,7 @@ int DecryptContent(byte* input, word32 sz, const char* password, int passwordSz)
 {
 #ifndef WOLFSSL_ASN_TEMPLATE
     word32 inOutIdx = 0, seqEnd, oid, shaOid = 0;
-    int    ret = 0, first, second, length = 0, version, saltSz, id;
+    int    ret = 0, first, second, length = 0, version, saltSz, id = 0;
     int    iterations = 0, keySz = 0;
 #ifdef WOLFSSL_SMALL_STACK
     byte*  salt = NULL;

--- a/wolfcrypt/src/port/iotsafe/iotsafe.c
+++ b/wolfcrypt/src/port/iotsafe/iotsafe.c
@@ -93,14 +93,14 @@ static int hex_to_bytes(const char *hex, unsigned char *output, unsigned long sz
 {
     word32 i;
     for (i = 0; i < sz; i++) {
-        char ch1, ch2;
+        signed char ch1, ch2;
         ch1 = HexCharToByte(hex[i * 2]);
         ch2 = HexCharToByte(hex[i * 2 + 1]);
-        if (ch1 < 0 || ch2 < 0) {
+        if ((ch1 < 0) || (ch2 < 0)) {
             WOLFSSL_MSG("hex_to_bytes: syntax error");
             return -1;
         }
-        output[i] = (ch1 << 4) + ch2;
+        output[i] = (unsigned char)((ch1 << 4) + ch2);
     }
     return (int)sz;
 }
@@ -157,7 +157,6 @@ static int expect_ok(const char *cmd, int size)
 /* Conversion utility from hex string format to bytes */
 static int hexbuffer_conv(char *hex_str, unsigned char *output, unsigned long sz)
 {
-    int ret;
     if (XSTRLEN(hex_str) != (2 * sz)) {
         return -1;
     }


### PR DESCRIPTION
FIxed compiler warnings:

- ZD12802 : unused 'ret' + warn on unsigned char
- Another one found during pre-commit tests:

```
wolfcrypt/src/asn.c: In function 'DecryptContent':
wolfcrypt/src/asn.c:6957:11: error: 'id' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 6957 |     ret = wc_CryptKey(password, passwordSz, salt, saltSz, iterations, id,
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 6958 |                    input + inOutIdx, length, version, cbcIv, 0, shaOid);
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
