### PR TITLE
Fix for sniffer TCP sequence rollover

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -4645,7 +4645,7 @@ static int AdjustSequence(TcpInfo* tcpInfo, SnifferSession* session,
 
     /* handle rollover of sequence */
     if (tcpInfo->sequence < seqStart)
-        real = 0xffffffffU - seqStart + tcpInfo->sequence;
+        real = 0xffffffffU - seqStart + tcpInfo->sequence + 1;
 
     TraceRelativeSequence(*expected, real);
 


### PR DESCRIPTION
The math to detect and compute the rollover was off by one. ZD 12801.