### PR TITLE
Jenkins nighlty fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6415,6 +6415,11 @@ fi
 
 if test "$ENABLED_AESGCM" != "no"
 then
+    if test "$ENABLED_AESGCM" = "word"
+    then
+        ENABLED_AESGCM=yes
+    fi
+
     if test "$ENABLED_AESGCM" = "word32"
     then
         AM_CFLAGS="$AM_CFLAGS -DGCM_WORD32"

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2912,7 +2912,9 @@ int wolfSSL_Rehandshake(WOLFSSL* ssl)
     if (ssl == NULL)
         return WOLFSSL_FAILURE;
 
+#ifdef HAVE_SESSION_TICKET
     ret = WOLFSSL_SUCCESS;
+#endif
 
     if (ssl->options.side == WOLFSSL_SERVER_END) {
         /* Reset option to send certificate verify. */


### PR DESCRIPTION
wolfSSL_Rehandshake(): don't set 'ret' unless HAVE_SESSION_TICKET
defined (otherwise compiler will complain:  warning: Value stored to
'ret' is never read)

AES GCM streaming: fix 64-bit word version to compile and pass testing