### PR TITLE
Improve CRL error codes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3577,20 +3577,24 @@ fi
 
 # CRL
 AC_ARG_ENABLE([crl],
-    [AS_HELP_STRING([--enable-crl],[Enable CRL (default: disabled)])],
+    [AS_HELP_STRING([--enable-crl],[Enable CRL (Use =io for inline CRL HTTP GET) (default: disabled)])],
     [ ENABLED_CRL=$enableval ],
     [ ENABLED_CRL=no ],
     )
 
-
-if test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_HAPROXY" = "xyes" || test "x$ENABLED_OPENVPN" = "xyes" || test "x$ENABLED_WPAS" != "xno" || test "x$ENABLED_LIGHTY" = "xyes" || test "x$ENABLED_NETSNMP" = "xyes"
+if test "x$ENABLED_NGINX" = "xyes" || test "x$ENABLED_HAPROXY" = "xyes" || test "x$ENABLED_OPENVPN" = "xyes" || \
+   test "x$ENABLED_WPAS" != "xno" || test "x$ENABLED_LIGHTY" = "xyes" || test "x$ENABLED_NETSNMP" = "xyes"
 then
     ENABLED_CRL=yes
 fi
 
-if test "$ENABLED_CRL" = "yes"
+if test "$ENABLED_CRL" != "no"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_CRL"
+fi
+if test "$ENABLED_CRL" == "io"
+then
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_CRL_IO"
 fi
 
 
@@ -6744,7 +6748,7 @@ AM_CONDITIONAL([BUILD_INLINE],[test "x$ENABLED_INLINE" = "xyes"])
 AM_CONDITIONAL([BUILD_OCSP],[test "x$ENABLED_OCSP" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_OCSP_STAPLING],[test "x$ENABLED_CERTIFICATE_STATUS_REQUEST" = "xyes"])
 AM_CONDITIONAL([BUILD_OCSP_STAPLING_V2],[test "x$ENABLED_CERTIFICATE_STATUS_REQUEST_V2" = "xyes"])
-AM_CONDITIONAL([BUILD_CRL],[test "x$ENABLED_CRL" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
+AM_CONDITIONAL([BUILD_CRL],[test "x$ENABLED_CRL" != "xno" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_CRL_MONITOR],[test "x$ENABLED_CRL_MONITOR" = "xyes"])
 AM_CONDITIONAL([BUILD_USER_RSA],[test "x$ENABLED_USER_RSA" = "xyes"] )
 AM_CONDITIONAL([BUILD_USER_CRYPTO],[test "x$ENABLED_USER_CRYPTO" = "xyes"])

--- a/src/crl.c
+++ b/src/crl.c
@@ -385,7 +385,9 @@ int CheckCertCRL(WOLFSSL_CRL* crl, DecodedCert* cert)
 #endif
     if (foundEntry == 0) {
         WOLFSSL_MSG("Couldn't find CRL for status check");
-        ret = CRL_MISSING;
+        if (ret != CRL_CERT_DATE_ERR) {
+            ret = CRL_MISSING;
+        }
 
         if (crl->cm->cbMissingCRL) {
             char url[256];

--- a/src/internal.c
+++ b/src/internal.c
@@ -11965,7 +11965,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     /* Do verify callback */
                     ret = DoVerifyCallback(SSL_CM(ssl), ssl, ret, args);
                     if (ssl->options.verifyNone &&
-                              (ret == CRL_MISSING || ret == CRL_CERT_REVOKED)) {
+                              (ret == CRL_MISSING || ret == CRL_CERT_REVOKED ||
+                               ret == CRL_CERT_DATE_ERR)) {
                         WOLFSSL_MSG("Ignoring CRL problem based on verify setting");
                         ret = ssl->error = 0;
                     }
@@ -12745,7 +12746,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             ret = DoVerifyCallback(SSL_CM(ssl), ssl, ret, args);
 
             if (ssl->options.verifyNone &&
-                              (ret == CRL_MISSING || ret == CRL_CERT_REVOKED)) {
+                              (ret == CRL_MISSING || ret == CRL_CERT_REVOKED ||
+                               ret == CRL_CERT_DATE_ERR)) {
                 WOLFSSL_MSG("Ignoring CRL problem based on verify setting");
                 ret = ssl->error = 0;
             }
@@ -19805,9 +19807,6 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
     case NOT_CA_ERROR:
         return "Not a CA by basic constraint error";
 
-    case HTTP_TIMEOUT:
-        return "HTTP timeout for OCSP or CRL req";
-
     case BAD_CERT_MANAGER_ERROR:
         return "Bad Cert Manager error";
 
@@ -20059,6 +20058,23 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
 
     case SOCKET_FILTERED_E:
         return "Session stopped by network filter";
+
+#ifdef HAVE_HTTP_CLIENT
+    case HTTP_TIMEOUT:
+        return "HTTP timeout for OCSP or CRL req";
+    case HTTP_RECV_ERR:
+        return "HTTP Receive error";
+    case HTTP_HEADER_ERR:
+        return "HTTP Header error";
+    case HTTP_PROTO_ERR:
+        return "HTTP Protocol error";
+    case HTTP_STATUS_ERR:
+        return "HTTP Status error";
+    case HTTP_VERSION_ERR:
+        return "HTTP Version error";
+    case HTTP_APPSTR_ERR:
+        return "HTTP Application string error";
+#endif
 
     default :
         return "unknown error number";

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -29537,13 +29537,13 @@ static int ParseCRL_CertList(DecodedCRL* dcrl, const byte* buf,
     }
 
 #ifdef WOLFSSL_NO_CRL_NEXT_DATE
-    if (doNextDate)x
+    if (doNextDate)
 #endif
     {
 #ifndef NO_ASN_TIME
         if (!XVALIDATE_DATE(dcrl->nextDate, dcrl->nextDateFormat, AFTER)) {
             WOLFSSL_MSG("CRL after date is no longer valid");
-            return ASN_AFTER_DATE_E;
+            return CRL_CERT_DATE_ERR;
         }
 #endif
     }
@@ -29973,7 +29973,7 @@ end:
             /* Next date was set, so validate it. */
             if (!XVALIDATE_DATE(dcrl->nextDate, dcrl->nextDateFormat, AFTER)) {
                 WOLFSSL_MSG("CRL after date is no longer valid");
-                ret = ASN_AFTER_DATE_E;
+                ret = CRL_CERT_DATE_ERR;
             }
         }
     }

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -260,6 +260,9 @@ const char* wc_GetErrorString(int error)
     case ASN_CRL_NO_SIGNER_E :
         return "ASN CRL no signer error to confirm failure";
 
+    case CRL_CERT_DATE_ERR:
+        return "CRL date error";
+
     case ASN_OCSP_CONFIRM_E :
         return "ASN OCSP sig error, confirm failure";
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1641,7 +1641,7 @@ WOLFSSL_TEST_SUBROUTINE int error_test(void)
     /* Values that are not or no longer error codes. */
     int missing[] = { -122, -123, -124,       -127, -128, -129,
                       -163, -164, -165, -166, -167, -168, -169,
-                      -179,       -233,
+                      -233,
                       0 };
 
     /* Check that all errors have a string and it's the same through the two

--- a/wolfssl/error-ssl.h
+++ b/wolfssl/error-ssl.h
@@ -52,7 +52,6 @@ enum wolfSSL_ErrorCodes {
     RSA_PRIVATE_ERROR            = -318,   /* error during rsa priv op */
     NO_DH_PARAMS                 = -319,   /* server missing DH params */
     BUILD_MSG_ERROR              = -320,   /* build message failure    */
-
     BAD_HELLO                    = -321,   /* client hello malformed   */
     DOMAIN_NAME_MISMATCH         = -322,   /* peer subject name mismatch */
     WANT_READ                    = -323,   /* want read, call again    */
@@ -113,6 +112,7 @@ enum wolfSSL_ErrorCodes {
     UNKNOWN_SNI_HOST_NAME_E      = -381,   /* Unrecognized host name Error */
     UNKNOWN_MAX_FRAG_LEN_E       = -382,   /* Unrecognized max frag len Error */
     KEYUSE_SIGNATURE_E           = -383,   /* KeyUse digSignature error */
+
     KEYUSE_ENCIPHER_E            = -385,   /* KeyUse keyEncipher error */
     EXTKEYUSE_AUTH_E             = -386,   /* ExtKeyUse server|client_auth */
     SEND_OOB_READ_E              = -387,   /* Send Cb out of bounds read */
@@ -171,8 +171,13 @@ enum wolfSSL_ErrorCodes {
     NO_CERT_ERROR                = -440,   /* TLS1.3 - no cert set error */
     APP_DATA_READY               = -441,   /* DTLS1.2 application data ready for read */
     TOO_MUCH_EARLY_DATA          = -442,   /* Too much Early data */
-
     SOCKET_FILTERED_E            = -443,   /* Session stopped by network filter */
+    HTTP_RECV_ERR                = -444,   /* HTTP Receive error */
+    HTTP_HEADER_ERR              = -445,   /* HTTP Header error */
+    HTTP_PROTO_ERR               = -446,   /* HTTP Protocol error */
+    HTTP_STATUS_ERR              = -447,   /* HTTP Status error */
+    HTTP_VERSION_ERR             = -448,   /* HTTP Version error */
+    HTTP_APPSTR_ERR              = -449,   /* HTTP Application string error */
 
     /* add strings to wolfSSL_ERR_reason_error_string in internal.c !!!!! */
 

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -117,6 +117,7 @@ enum {
     NO_PASSWORD        = -176,  /* no password provided by user */
     ALT_NAME_E         = -177,  /* alt name size problem, too big */
     BAD_OCSP_RESPONDER = -178,  /* missing key usage extensions */
+    CRL_CERT_DATE_ERR  = -179,   /* CRL date error */
 
     AES_GCM_AUTH_E     = -180,  /* AES-GCM Authentication check failure */
     AES_CCM_AUTH_E     = -181,  /* AES-CCM Authentication check failure */


### PR DESCRIPTION
* Improve CRL and HTTP error codes. ZD 12791
* Add `--enable-crl=io` option.