### PR TITLE
Consistent return value from SSL_CTX_load_verify_locations{,_ex}

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -977,7 +977,8 @@ WOLFSSL_API int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX*, const char*,
 
     \return SSL_SUCCESS up success.
     \return SSL_FAILURE will be returned if ctx is NULL, or if both file and
-    path are NULL.
+    path are NULL. This will also be returned if at least one cert is loaded
+    successfully but there is one or more that failed. Check error stack for reason.
     \return SSL_BAD_FILETYPE will be returned if the file is the wrong format.
     \return SSL_BAD_FILE will be returned if the file doesn’t exist, can’t be
     read, or is corrupted.

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7030,7 +7030,9 @@ int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX* ctx, const char* file,
                        (ret == ASN_NO_PEM_HEADER))) {
                     /* Do not fail here if a certificate fails to load,
                        continue to next file */
+    #if defined(WOLFSSL_QT)
                     ret = WOLFSSL_SUCCESS;
+    #endif
                 }
                 else {
                     WOLFSSL_ERROR(ret);
@@ -7068,13 +7070,11 @@ int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX* ctx, const char* file,
             /* use existing error code if exists */
     #if defined(WOLFSSL_QT)
             /* compliant with OpenSSL when flag sets*/
-            if (!(flags & WOLFSSL_LOAD_FLAG_IGNORE_ZEROFILE)) {
+            if (!(flags & WOLFSSL_LOAD_FLAG_IGNORE_ZEROFILE))
     #endif
-            if (ret == WOLFSSL_SUCCESS)
+            {
                 ret = WOLFSSL_FAILURE;
-    #if defined(WOLFSSL_QT)
             }
-    #endif
         }
         else {
             ret = WOLFSSL_SUCCESS;


### PR DESCRIPTION
On any failure, return `WOLFSSL_FAILURE`

If there was a failure and a successful processing of certs from the
same directory, the return value depended on the last cert processed
which not guarenteed to be the same order. If the last cert load
failed, it would return the specific wolfSSL error code. If it
succeeded, then WOLFSSL_FAILURE would be returned as a generic failure
due to a previous cert error.