### PR TITLE
Add get_default_cert_file/env() stubs, SSL_get/set_read_ahead(), SSL_SESSION_has_ticket/lifetime_hint()

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -30030,7 +30030,7 @@ end:
  * Returns 1 if has session ticket, otherwise 0 */
 int wolfSSL_SESSION_has_ticket(const WOLFSSL_SESSION* sess)
 {
-    WOLFSSL_ENTER("wolfSSL_SESSION_get_timeout");
+    WOLFSSL_ENTER("wolfSSL_SESSION_has_ticket");
 #ifdef HAVE_SESSION_TICKET
     if (sess) {
         if ((sess->ticketLen > 0) && (sess->ticket != NULL)) {
@@ -30040,6 +30040,16 @@ int wolfSSL_SESSION_has_ticket(const WOLFSSL_SESSION* sess)
 #else
     (void)sess;
 #endif
+    return 0;
+}
+
+unsigned long wolfSSL_SESSION_get_ticket_lifetime_hint(
+                  const WOLFSSL_SESSION* sess)
+{
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_ticket_lifetime_hint");
+    if (sess) {
+        return sess->timeout;
+    }
     return 0;
 }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -30023,6 +30023,26 @@ end:
     return s;
 }
 
+/* Returns 1 if there is a session ticket associated with this WOLFSSL_SESSION.
+ *
+ * sess - pointer to WOLFSSL_SESSION struct
+ *
+ * Returns 1 if has session ticket, otherwise 0 */
+int wolfSSL_SESSION_has_ticket(const WOLFSSL_SESSION* sess)
+{
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_timeout");
+#ifdef HAVE_SESSION_TICKET
+    if (sess) {
+        if ((sess->ticketLen > 0) && (sess->ticket != NULL)) {
+            return 1;
+        }
+    }
+#else
+    (void)sess;
+#endif
+    return 0;
+}
+
 long wolfSSL_SESSION_get_timeout(const WOLFSSL_SESSION* sess)
 {
     long timeout = 0;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -16384,6 +16384,30 @@ cleanup:
         WOLFSSL_STUB("SSL_CTX_set_default_verify_paths");
         return SSL_NOT_IMPLEMENTED;
     }
+
+    const char* wolfSSL_X509_get_default_cert_file_env(void)
+    {
+        WOLFSSL_STUB("X509_get_default_cert_file_env");
+        return NULL;
+    }
+
+    const char* wolfSSL_X509_get_default_cert_file(void)
+    {
+        WOLFSSL_STUB("X509_get_default_cert_file");
+        return NULL;
+    }
+
+    const char* wolfSSL_X509_get_default_cert_dir_env(void)
+    {
+        WOLFSSL_STUB("X509_get_default_cert_dir_env");
+        return NULL;
+    }
+
+    const char* wolfSSL_X509_get_default_cert_dir(void)
+    {
+        WOLFSSL_STUB("X509_get_default_cert_dir");
+        return NULL;
+    }
     #endif
 
     #if defined(WOLFCRYPT_HAVE_SRP) && !defined(NO_SHA256) \

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28432,6 +28432,28 @@ WOLFSSL_API long wolfSSL_CTX_get_session_cache_mode(WOLFSSL_CTX* ctx)
 }
 
 
+int wolfSSL_get_read_ahead(WOLFSSL* ssl)
+{
+    if (ssl == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    return ssl->readAhead;
+}
+
+
+int wolfSSL_set_read_ahead(WOLFSSL* ssl, int v)
+{
+    if (ssl == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    ssl->readAhead = (byte)v;
+
+    return WOLFSSL_SUCCESS;
+}
+
+
 int wolfSSL_CTX_get_read_ahead(WOLFSSL_CTX* ctx)
 {
     if (ctx == NULL) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28432,7 +28432,7 @@ WOLFSSL_API long wolfSSL_CTX_get_session_cache_mode(WOLFSSL_CTX* ctx)
 }
 
 
-int wolfSSL_get_read_ahead(WOLFSSL* ssl)
+int wolfSSL_get_read_ahead(const WOLFSSL* ssl)
 {
     if (ssl == NULL) {
         return WOLFSSL_FAILURE;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -30023,7 +30023,7 @@ end:
     return s;
 }
 
-/* Returns 1 if there is a session ticket associated with this WOLFSSL_SESSION.
+/* Check if there is a session ticket associated with this WOLFSSL_SESSION.
  *
  * sess - pointer to WOLFSSL_SESSION struct
  *
@@ -30034,13 +30034,13 @@ int wolfSSL_SESSION_has_ticket(const WOLFSSL_SESSION* sess)
 #ifdef HAVE_SESSION_TICKET
     if (sess) {
         if ((sess->ticketLen > 0) && (sess->ticket != NULL)) {
-            return 1;
+            return WOLFSSL_SUCCESS;
         }
     }
 #else
     (void)sess;
 #endif
-    return 0;
+    return WOLFSSL_FAILURE;
 }
 
 unsigned long wolfSSL_SESSION_get_ticket_lifetime_hint(

--- a/tests/api.c
+++ b/tests/api.c
@@ -343,8 +343,10 @@
         #include <wolfssl/wolfcrypt/srp.h>
 #endif
 
-#if defined(SESSION_CERTS) && defined(TEST_PEER_CERT_CHAIN)
-#include "wolfssl/internal.h" /* for testing SSL_get_peer_cert_chain */
+#if (defined(SESSION_CERTS) && defined(TEST_PEER_CERT_CHAIN)) || \
+    defined(HAVE_SESSION_TICKET)
+    /* for testing SSL_get_peer_cert_chain, or SESSION_TICKET_HINT_DEFAULT */
+#include "wolfssl/internal.h"
 #endif
 
 /* force enable test buffers */
@@ -36052,9 +36054,10 @@ static void test_wolfSSL_SESSION(void)
 
     AssertIntEQ(wolfSSL_SESSION_has_ticket(NULL), 0);
     AssertIntEQ(wolfSSL_SESSION_get_ticket_lifetime_hint(NULL), 0);
-    AssertIntGT(wolfSSL_SESSION_get_ticket_lifetime_hint(sess), 0);
     #ifdef HAVE_SESSION_TICKET
     AssertIntEQ(wolfSSL_SESSION_has_ticket(sess), 1);
+    AssertIntEQ(wolfSSL_SESSION_get_ticket_lifetime_hint(sess),
+                SESSION_TICKET_HINT_DEFAULT);
     #else
     AssertIntEQ(wolfSSL_SESSION_has_ticket(sess), 0);
     #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -35993,6 +35993,10 @@ static void test_wolfSSL_SESSION(void)
 #ifdef WOLFSSL_ENCRYPTED_KEYS
     wolfSSL_CTX_set_default_passwd_cb(ctx, PasswordCallBack);
 #endif
+#ifdef HAVE_SESSION_TICKET
+    /* Use session tickets, for ticket tests below */
+    AssertIntEQ(wolfSSL_CTX_UseSessionTicket(ctx), WOLFSSL_SUCCESS);
+#endif
 
     XMEMSET(&server_args, 0, sizeof(func_args));
 #ifdef WOLFSSL_TIRTOS
@@ -36044,6 +36048,15 @@ static void test_wolfSSL_SESSION(void)
     #else
     AssertIntEQ(wolfSSL_SESSION_is_resumable(NULL), 0);
     AssertIntEQ(wolfSSL_SESSION_is_resumable(sess), 1);
+    #endif
+
+    AssertIntEQ(wolfSSL_SESSION_has_ticket(NULL), 0);
+    AssertIntEQ(wolfSSL_SESSION_get_ticket_lifetime_hint(NULL), 0);
+    AssertIntGT(wolfSSL_SESSION_get_ticket_lifetime_hint(sess), 0);
+    #ifdef HAVE_SESSION_TICKET
+    AssertIntEQ(wolfSSL_SESSION_has_ticket(sess), 1);
+    #else
+    AssertIntEQ(wolfSSL_SESSION_has_ticket(sess), 0);
     #endif
     
     wolfSSL_shutdown(ssl);

--- a/tests/api.c
+++ b/tests/api.c
@@ -6373,7 +6373,7 @@ static void test_wolfSSL_PKCS12(void)
 #if defined(OPENSSL_EXTRA) && !defined(NO_DES3) && !defined(NO_FILESYSTEM) && \
     !defined(NO_ASN) && !defined(NO_PWDBASED) && !defined(NO_RSA) && \
     !defined(NO_SHA) && defined(HAVE_PKCS12)
-    byte buffer[6000];
+    byte buf[6000];
     char file[] = "./certs/test-servercert.p12";
     char order[] = "./certs/ecc-rsa-server.p12";
 #ifdef WC_RC2
@@ -6406,13 +6406,13 @@ static void test_wolfSSL_PKCS12(void)
 
     f = XFOPEN(file, "rb");
     AssertTrue((f != XBADFILE));
-    bytes = (int)XFREAD(buffer, 1, sizeof(buffer), f);
+    bytes = (int)XFREAD(buf, 1, sizeof(buf), f);
     XFCLOSE(f);
 
     goodPswLen = (int)XSTRLEN(goodPsw);
     badPswLen = (int)XSTRLEN(badPsw);
 
-    bio = BIO_new_mem_buf((void*)buffer, bytes);
+    bio = BIO_new_mem_buf((void*)buf, bytes);
     AssertNotNull(bio);
 
     pkcs12 = d2i_PKCS12_bio(bio, NULL);
@@ -6557,10 +6557,10 @@ static void test_wolfSSL_PKCS12(void)
     /* test order of parsing */
     f = XFOPEN(order, "rb");
     AssertTrue(f != XBADFILE);
-    bytes = (int)XFREAD(buffer, 1, sizeof(buffer), f);
+    bytes = (int)XFREAD(buf, 1, sizeof(buf), f);
     XFCLOSE(f);
 
-    AssertNotNull(bio = BIO_new_mem_buf((void*)buffer, bytes));
+    AssertNotNull(bio = BIO_new_mem_buf((void*)buf, bytes));
     AssertNotNull(pkcs12 = d2i_PKCS12_bio(bio, NULL));
     AssertIntEQ((ret = PKCS12_parse(pkcs12, "", &pkey, &cert, &ca)),
             WOLFSSL_SUCCESS);
@@ -6640,10 +6640,10 @@ static void test_wolfSSL_PKCS12(void)
     /* test PKCS#12 with RC2 encryption */
     f = XFOPEN(rc2p12, "rb");
     AssertTrue(f != XBADFILE);
-    bytes = (int)XFREAD(buffer, 1, sizeof(buffer), f);
+    bytes = (int)XFREAD(buf, 1, sizeof(buf), f);
     XFCLOSE(f);
 
-    AssertNotNull(bio = BIO_new_mem_buf((void*)buffer, bytes));
+    AssertNotNull(bio = BIO_new_mem_buf((void*)buf, bytes));
     AssertNotNull(pkcs12 = d2i_PKCS12_bio(bio, NULL));
 
     /* check verify MAC fail case */

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1009,6 +1009,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 
 #define i2d_SSL_SESSION                 wolfSSL_i2d_SSL_SESSION
 #define d2i_SSL_SESSION                 wolfSSL_d2i_SSL_SESSION
+#define SSL_SESSION_has_ticket          wolfSSL_SESSION_has_ticket
 #define SSL_SESSION_set_timeout         wolfSSL_SSL_SESSION_set_timeout
 #define SSL_SESSION_get_timeout         wolfSSL_SESSION_get_timeout
 #define SSL_SESSION_get_time            wolfSSL_SESSION_get_time

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -970,6 +970,10 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 
 #define SSL_CTX_sess_set_cache_size     wolfSSL_CTX_sess_set_cache_size
 #define SSL_CTX_set_default_verify_paths wolfSSL_CTX_set_default_verify_paths
+#define X509_get_default_cert_file_env  wolfSSL_X509_get_default_cert_file_env
+#define X509_get_default_cert_file      wolfSSL_X509_get_default_cert_file
+#define X509_get_default_cert_dir_env   wolfSSL_X509_get_default_cert_dir_env
+#define X509_get_default_cert_dir       wolfSSL_X509_get_default_cert_dir
 
 #define SSL_CTX_set_session_id_context  wolfSSL_CTX_set_session_id_context
 #define SSL_get_peer_certificate        wolfSSL_get_peer_certificate

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1010,6 +1010,8 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define i2d_SSL_SESSION                 wolfSSL_i2d_SSL_SESSION
 #define d2i_SSL_SESSION                 wolfSSL_d2i_SSL_SESSION
 #define SSL_SESSION_has_ticket          wolfSSL_SESSION_has_ticket
+#define SSL_SESSION_get_ticket_lifetime_hint \
+                                        wolfSSL_SESSION_get_ticket_lifetime_hint
 #define SSL_SESSION_set_timeout         wolfSSL_SSL_SESSION_set_timeout
 #define SSL_SESSION_get_timeout         wolfSSL_SESSION_get_timeout
 #define SSL_SESSION_get_time            wolfSSL_SESSION_get_time

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1136,6 +1136,8 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define SSL_get_tlsext_status_ocsp_resp  wolfSSL_get_tlsext_status_ocsp_resp
 
 #define SSL_CTX_add_extra_chain_cert    wolfSSL_CTX_add_extra_chain_cert
+#define SSL_get_read_ahead              wolfSSL_get_read_ahead
+#define SSL_set_read_ahead              wolfSSL_set_read_ahead
 #define SSL_CTX_get_read_ahead          wolfSSL_CTX_get_read_ahead
 #define SSL_CTX_set_read_ahead          wolfSSL_CTX_set_read_ahead
 #define SSL_CTX_set_tlsext_status_arg   wolfSSL_CTX_set_tlsext_status_arg

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2488,6 +2488,7 @@ WOLFSSL_API int          wolfSSL_i2d_SSL_SESSION(WOLFSSL_SESSION*,unsigned char*
 WOLFSSL_API WOLFSSL_SESSION* wolfSSL_d2i_SSL_SESSION(WOLFSSL_SESSION**,
                                                    const unsigned char**, long);
 
+WOLFSSL_API int wolfSSL_SESSION_has_ticket(const WOLFSSL_SESSION*);
 WOLFSSL_API long wolfSSL_SESSION_get_timeout(const WOLFSSL_SESSION*);
 WOLFSSL_API long wolfSSL_SESSION_get_time(const WOLFSSL_SESSION*);
 WOLFSSL_API int  wolfSSL_CTX_get_ex_new_index(long, void*, void*, void*, void*);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1914,6 +1914,8 @@ WOLFSSL_API long wolfSSL_CTX_sess_set_cache_size(WOLFSSL_CTX*, long);
 WOLFSSL_API long wolfSSL_CTX_sess_get_cache_size(WOLFSSL_CTX*);
 
 WOLFSSL_API long wolfSSL_CTX_get_session_cache_mode(WOLFSSL_CTX*);
+WOLFSSL_API int  wolfSSL_get_read_ahead(WOLFSSL*);
+WOLFSSL_API int  wolfSSL_set_read_ahead(WOLFSSL*, int v);
 WOLFSSL_API int  wolfSSL_CTX_get_read_ahead(WOLFSSL_CTX*);
 WOLFSSL_API int  wolfSSL_CTX_set_read_ahead(WOLFSSL_CTX*, int v);
 WOLFSSL_API long wolfSSL_CTX_set_tlsext_status_arg(WOLFSSL_CTX*, void* arg);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2409,6 +2409,10 @@ WOLFSSL_API long wolfSSL_SSL_get_mode(WOLFSSL* ssl);
 
 
 WOLFSSL_API int  wolfSSL_CTX_set_default_verify_paths(WOLFSSL_CTX*);
+WOLFSSL_API const char* wolfSSL_X509_get_default_cert_file_env(void);
+WOLFSSL_API const char* wolfSSL_X509_get_default_cert_file(void);
+WOLFSSL_API const char* wolfSSL_X509_get_default_cert_dir_env(void);
+WOLFSSL_API const char* wolfSSL_X509_get_default_cert_dir(void);
 WOLFSSL_API int  wolfSSL_CTX_set_session_id_context(WOLFSSL_CTX*,
                                             const unsigned char*, unsigned int);
 WOLFSSL_ABI WOLFSSL_API WOLFSSL_X509* wolfSSL_get_peer_certificate(WOLFSSL*);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2489,6 +2489,8 @@ WOLFSSL_API WOLFSSL_SESSION* wolfSSL_d2i_SSL_SESSION(WOLFSSL_SESSION**,
                                                    const unsigned char**, long);
 
 WOLFSSL_API int wolfSSL_SESSION_has_ticket(const WOLFSSL_SESSION*);
+WOLFSSL_API unsigned long wolfSSL_SESSION_get_ticket_lifetime_hint(
+                              const WOLFSSL_SESSION* sess);
 WOLFSSL_API long wolfSSL_SESSION_get_timeout(const WOLFSSL_SESSION*);
 WOLFSSL_API long wolfSSL_SESSION_get_time(const WOLFSSL_SESSION*);
 WOLFSSL_API int  wolfSSL_CTX_get_ex_new_index(long, void*, void*, void*, void*);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1914,7 +1914,7 @@ WOLFSSL_API long wolfSSL_CTX_sess_set_cache_size(WOLFSSL_CTX*, long);
 WOLFSSL_API long wolfSSL_CTX_sess_get_cache_size(WOLFSSL_CTX*);
 
 WOLFSSL_API long wolfSSL_CTX_get_session_cache_mode(WOLFSSL_CTX*);
-WOLFSSL_API int  wolfSSL_get_read_ahead(WOLFSSL*);
+WOLFSSL_API int  wolfSSL_get_read_ahead(const WOLFSSL*);
 WOLFSSL_API int  wolfSSL_set_read_ahead(WOLFSSL*, int v);
 WOLFSSL_API int  wolfSSL_CTX_get_read_ahead(WOLFSSL_CTX*);
 WOLFSSL_API int  wolfSSL_CTX_set_read_ahead(WOLFSSL_CTX*, int v);


### PR DESCRIPTION
This PR expands OpenSSL compatibility for Python 3.8.5 with the following functions:

- wolfSSL_X509_get_default_cert_file/file_env/dir/dir_env() stubs
- SSL_get_read_ahead/SSL_set_read_ahead()
- SSL_SESSION_has_ticket()
- SSL_SESSION_get_ticket_lifetime_hint()