### PR TITLE
Make sure CMAKE_C_FLAGS gets parsed for defines to add to options.h.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1369,35 +1369,12 @@ file(APPEND ${OPTION_FILE} "#ifdef __cplusplus\n")
 file(APPEND ${OPTION_FILE} "extern \"C\" {\n")
 file(APPEND ${OPTION_FILE} "#endif\n\n")
 
-list(REMOVE_DUPLICATES WOLFSSL_DEFINITIONS)
-
-foreach(DEF IN LISTS WOLFSSL_DEFINITIONS)
-    if(DEF MATCHES "^-D")
-        if(DEF MATCHES "^-D(N)?DEBUG(=.+)?")
-            message("not outputting (N)DEBUG to ${OPTION_FILE}")
-        endif()
-
-        # allow user to ignore system options
-        if(DEF MATCHES "^-D_.*")
-            file(APPEND ${OPTION_FILE} "#ifndef WOLFSSL_OPTIONS_IGNORE_SYS\n")
-        endif()
-
-        string(REGEX REPLACE "^-D" "" DEF_NO_PREFIX ${DEF})
-        string(REGEX REPLACE "=.*$" "" DEF_NO_EQUAL_NO_VAL ${DEF_NO_PREFIX})
-        string(REPLACE "=" " " DEF_NO_EQUAL ${DEF_NO_PREFIX})
-
-        file(APPEND ${OPTION_FILE} "#undef  ${DEF_NO_EQUAL_NO_VAL}\n")
-        file(APPEND ${OPTION_FILE} "#define ${DEF_NO_EQUAL}\n")
-
-        if(DEF MATCHES "^-D_.*")
-            file(APPEND ${OPTION_FILE} "#endif\n")
-        endif()
-
-        file(APPEND ${OPTION_FILE} "\n")
-    else()
-        message("option w/o begin -D is ${DEF}, not saving to ${OPTION_FILE}")
-    endif()
-endforeach()
+add_to_options_file("${WOLFSSL_DEFINITIONS}" "${OPTION_FILE}")
+# CMAKE_C_FLAGS is just a string of space-separated flags to pass to the C
+# compiler. We need to replace those spaces with semicolons in order to treat it
+# as a CMake list.
+string(REPLACE " " ";" CMAKE_C_FLAGS_LIST ${CMAKE_C_FLAGS})
+add_to_options_file("${CMAKE_C_FLAGS_LIST}" "${OPTION_FILE}")
 
 file(APPEND ${OPTION_FILE} "\n#ifdef __cplusplus\n")
 file(APPEND ${OPTION_FILE} "}\n")

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -860,3 +860,34 @@ function(generate_lib_src_list LIB_SOURCES)
 
     set(LIB_SOURCES ${LIB_SOURCES} PARENT_SCOPE)
 endfunction()
+
+function(add_to_options_file DEFINITIONS OPTION_FILE)
+    list(REMOVE_DUPLICATES DEFINITIONS)
+    foreach(DEF IN LISTS DEFINITIONS)
+        if(DEF MATCHES "^-D")
+            if(DEF MATCHES "^-D(N)?DEBUG(=.+)?")
+                message("not outputting (N)DEBUG to ${OPTION_FILE}")
+            endif()
+
+            # allow user to ignore system options
+            if(DEF MATCHES "^-D_.*")
+                file(APPEND ${OPTION_FILE} "#ifndef WOLFSSL_OPTIONS_IGNORE_SYS\n")
+            endif()
+
+            string(REGEX REPLACE "^-D" "" DEF_NO_PREFIX ${DEF})
+            string(REGEX REPLACE "=.*$" "" DEF_NO_EQUAL_NO_VAL ${DEF_NO_PREFIX})
+            string(REPLACE "=" " " DEF_NO_EQUAL ${DEF_NO_PREFIX})
+
+            file(APPEND ${OPTION_FILE} "#undef  ${DEF_NO_EQUAL_NO_VAL}\n")
+            file(APPEND ${OPTION_FILE} "#define ${DEF_NO_EQUAL}\n")
+
+            if(DEF MATCHES "^-D_.*")
+                file(APPEND ${OPTION_FILE} "#endif\n")
+            endif()
+
+            file(APPEND ${OPTION_FILE} "\n")
+        else()
+            message("option w/o begin -D is ${DEF}, not saving to ${OPTION_FILE}")
+        endif()
+    endforeach()
+endfunction()


### PR DESCRIPTION
For example, if a user does

```
cmake -DCMAKE_C_FLAGS="-DWOLFSSL_AESGCM_STREAM -DFP_MAX_BITS=16384" ..
```

definitions for `WOLFSSL_AESGCM_STREAM` and `FP_MAX_BITS 16384` should wind up
in options.h (same as the autotools build).