### PR TITLE
return value convention on compatibility layer

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -49375,11 +49375,25 @@ int wolfSSL_CTX_set_alpn_protos(WOLFSSL_CTX *ctx, const unsigned char *p,
     ctx->alpn_cli_protos =
         (const unsigned char *)wolfSSL_OPENSSL_memdup(p, p_len, NULL, 0);
     if (ctx->alpn_cli_protos == NULL) {
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+     * the function reverses the return value convention.
+     */
+        return 1;
+#else
         return SSL_FAILURE;
+#endif
     }
     ctx->alpn_cli_protos_len = p_len;
 
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+     * the function reverses the return value convention.
+     */
+    return 0;
+#else
     return WOLFSSL_SUCCESS;
+#endif
 }
 
 
@@ -49405,12 +49419,26 @@ int wolfSSL_set_alpn_protos(WOLFSSL* ssl,
     WOLFSSL_ENTER("wolfSSL_set_alpn_protos");
 
     if (ssl == NULL || p_len <= 1) {
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+     * the function reverses the return value convention.
+     */
+        return 1;
+#else
         return WOLFSSL_FAILURE;
+#endif
     }
 
     bio = wolfSSL_BIO_new(wolfSSL_BIO_s_mem());
     if (bio == NULL) {
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+     * the function reverses the return value convention.
+     */
+        return 1;
+#else
         return WOLFSSL_FAILURE;
+#endif
     }
 
     /* convert into comma separated list */
@@ -49421,7 +49449,14 @@ int wolfSSL_set_alpn_protos(WOLFSSL* ssl,
         if (idx + sz > p_len) {
             WOLFSSL_MSG("Bad list format");
             wolfSSL_BIO_free(bio);
+    #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+        /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+        * the function reverses the return value convention.
+        */
+            return 1;
+    #else
             return WOLFSSL_FAILURE;
+    #endif
         }
         if (sz > 0) {
             for (i = 0; i < sz; i++) {
@@ -49440,7 +49475,14 @@ int wolfSSL_set_alpn_protos(WOLFSSL* ssl,
         wolfSSL_UseALPN(ssl, pt, sz, alpn_opt);
     }
     wolfSSL_BIO_free(bio);
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+     * the function reverses the return value convention.
+     */
+    return 0;
+#else
     return WOLFSSL_SUCCESS;
+#endif
 }
 #endif /* !NO_BIO */
 #endif /* HAVE_ALPN */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -49376,9 +49376,9 @@ int wolfSSL_CTX_set_alpn_protos(WOLFSSL_CTX *ctx, const unsigned char *p,
         (const unsigned char *)wolfSSL_OPENSSL_memdup(p, p_len, NULL, 0);
     if (ctx->alpn_cli_protos == NULL) {
 #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-    /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
-     * the function reverses the return value convention.
-     */
+        /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+         * the function reverses the return value convention.
+        */
         return 1;
 #else
         return SSL_FAILURE;
@@ -49420,9 +49420,9 @@ int wolfSSL_set_alpn_protos(WOLFSSL* ssl,
 
     if (ssl == NULL || p_len <= 1) {
 #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-    /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
-     * the function reverses the return value convention.
-     */
+       /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+        * the function reverses the return value convention.
+        */
         return 1;
 #else
         return WOLFSSL_FAILURE;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -49378,7 +49378,7 @@ int wolfSSL_CTX_set_alpn_protos(WOLFSSL_CTX *ctx, const unsigned char *p,
 #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
         /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
          * the function reverses the return value convention.
-        */
+         */
         return 1;
 #else
         return SSL_FAILURE;
@@ -49420,9 +49420,9 @@ int wolfSSL_set_alpn_protos(WOLFSSL* ssl,
 
     if (ssl == NULL || p_len <= 1) {
 #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-       /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
-        * the function reverses the return value convention.
-        */
+        /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+         * the function reverses the return value convention.
+         */
         return 1;
 #else
         return WOLFSSL_FAILURE;
@@ -49432,9 +49432,9 @@ int wolfSSL_set_alpn_protos(WOLFSSL* ssl,
     bio = wolfSSL_BIO_new(wolfSSL_BIO_s_mem());
     if (bio == NULL) {
 #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-    /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
-     * the function reverses the return value convention.
-     */
+        /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+         * the function reverses the return value convention.
+         */
         return 1;
 #else
         return WOLFSSL_FAILURE;
@@ -49450,9 +49450,9 @@ int wolfSSL_set_alpn_protos(WOLFSSL* ssl,
             WOLFSSL_MSG("Bad list format");
             wolfSSL_BIO_free(bio);
     #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-        /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
-        * the function reverses the return value convention.
-        */
+            /* 0 on success in OpenSSL, non-0 on failure in OpenSSL
+             * the function reverses the return value convention.
+             */
             return 1;
     #else
             return WOLFSSL_FAILURE;

--- a/tests/api.c
+++ b/tests/api.c
@@ -33008,9 +33008,11 @@ static void test_wolfSSL_set_options(void)
 
     AssertTrue(SSL_set_msg_callback(ssl, msg_cb) == SSL_SUCCESS);
     SSL_set_msg_callback_arg(ssl, arg);
-
+#ifdef WOLFSSL_ERROR_CODE_OPENSSL
+    AssertTrue(SSL_CTX_set_alpn_protos(ctx, protos, len) == 0);
+#else
     AssertTrue(SSL_CTX_set_alpn_protos(ctx, protos, len) == SSL_SUCCESS);
-
+#endif
     SSL_free(ssl);
     SSL_CTX_free(ctx);
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -33009,9 +33009,21 @@ static void test_wolfSSL_set_options(void)
     AssertTrue(SSL_set_msg_callback(ssl, msg_cb) == SSL_SUCCESS);
     SSL_set_msg_callback_arg(ssl, arg);
 #ifdef WOLFSSL_ERROR_CODE_OPENSSL
-    AssertTrue(SSL_CTX_set_alpn_protos(ctx, protos, len) == 0);
+    AssertTrue(SSL_CTX_set_alpn_protos(ctx, protos, len) == 0);   
 #else
     AssertTrue(SSL_CTX_set_alpn_protos(ctx, protos, len) == SSL_SUCCESS);
+#endif
+
+#if defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || \
+    defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(OPENSSL_ALL) || \
+    defined(HAVE_LIGHTY) || defined(HAVE_STUNNEL)
+
+#ifdef WOLFSSL_ERROR_CODE_OPENSSL
+    AssertTrue(SSL_set_alpn_protos(ssl, protos, len) == 0);
+#else
+    AssertTrue(SSL_set_alpn_protos(ssl, protos, len) == SSL_SUCCESS);
+#endif
+
 #endif
     SSL_free(ssl);
     SSL_CTX_free(ctx);

--- a/tests/api.c
+++ b/tests/api.c
@@ -33018,13 +33018,17 @@ static void test_wolfSSL_set_options(void)
     defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(OPENSSL_ALL) || \
     defined(HAVE_LIGHTY) || defined(HAVE_STUNNEL)
 
+#if defined(HAVE_ALPN) && !defined(NO_BIO)
+
 #ifdef WOLFSSL_ERROR_CODE_OPENSSL
     AssertTrue(SSL_set_alpn_protos(ssl, protos, len) == 0);
 #else
     AssertTrue(SSL_set_alpn_protos(ssl, protos, len) == SSL_SUCCESS);
 #endif
 
+#endif /* HAVE_ALPN && !NO_BIO */
 #endif
+
     SSL_free(ssl);
     SSL_CTX_free(ctx);
 


### PR DESCRIPTION
SSL_set_alpn_protos and SSL_CTX_set_alpn_protos returns 0 on success, non-0 on failure
