### PR TITLE
Get host name: add code to use popen and the command 'host'

### DIFF
--- a/scripts/google.test
+++ b/scripts/google.test
@@ -6,7 +6,6 @@ server=www.google.com
 
 [ ! -x ./examples/client/client ] && echo -e "\n\nClient doesn't exist" && exit 1
 
-# TODO: [TLS13] Remove this when google supports final version of TLS 1.3
 ./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
 if [ $? -eq 0 ]; then
     echo -e "\n\nClient doesn't support TLS v1.2"
@@ -22,5 +21,13 @@ RESULT=$?
 ./examples/client/client -X -C -h $server -p 443 -g -d
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
+
+./examples/client/client -v 4 2>&1 | grep -- 'Bad SSL version'
+if [ $? -ne 0 ]; then
+    # client test against the server using TLS v1.3
+    ./examples/client/client -v 4 -X -C -h $server -p 443 -g -d
+    RESULT=$?
+    [ $RESULT -ne 0 ] && echo -e "\n\nTLSv1.3 Client connection failed" && exit 1
+fi
 
 exit 0

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -12952,6 +12952,15 @@ int sp_rand_prime(sp_int* r, int len, WC_RNG* rng, void* heap)
             err = MP_VAL;
             break;
         }
+
+        /* munge bits */
+#ifndef LITTLE_ENDIAN_ORDER
+        ((byte*)(r->dp + r->used - 1))[0] |= 0x80 | 0x40;
+#else
+        ((byte*)r->dp)[len-1] |= 0x80 | 0x40;
+#endif /* LITTLE_ENDIAN_ORDER */
+        r->dp[0]              |= 0x01 | ((type & USE_BBS) ? 0x02 : 0x00);
+
 #ifndef LITTLE_ENDIAN_ORDER
         if (((len * 8) & SP_WORD_MASK) != 0) {
             r->dp[r->used-1] >>= SP_WORD_SIZE - ((len * 8) & SP_WORD_MASK);
@@ -12962,14 +12971,6 @@ int sp_rand_prime(sp_int* r, int len, WC_RNG* rng, void* heap)
             r->dp[r->used - 1] &= ((sp_digit)1 << bits) - 1;
         }
 #endif /* WOLFSSL_SP_MATH_ALL */
-
-        /* munge bits */
-#ifndef LITTLE_ENDIAN_ORDER
-        ((byte*)(r->dp + r->used - 1))[0] |= 0x80 | 0x40;
-#else
-        ((byte*)r->dp)[len-1] |= 0x80 | 0x40;
-#endif /* LITTLE_ENDIAN_ORDER */
-        r->dp[0]              |= 0x01 | ((type & USE_BBS) ? 0x02 : 0x00);
 
         /* test */
         /* Running Miller-Rabin up to 3 times gives us a 2^{-80} chance

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2437,11 +2437,9 @@ WOLFSSL_API int wolfSSL_want(WOLFSSL*);
 WOLFSSL_API int wolfSSL_want_read(WOLFSSL*);
 WOLFSSL_API int wolfSSL_want_write(WOLFSSL*);
 
-#if !defined(NO_FILESYSTEM) && defined (OPENSSL_EXTRA)
 #include <stdarg.h> /* var_arg */
 WOLFSSL_API int wolfSSL_BIO_vprintf(WOLFSSL_BIO* bio, const char* format,
                                                             va_list args);
-#endif
 WOLFSSL_API int wolfSSL_BIO_printf(WOLFSSL_BIO*, const char*, ...);
 WOLFSSL_API int wolfSSL_BIO_dump(WOLFSSL_BIO *bio, const char*, int);
 WOLFSSL_API int wolfSSL_ASN1_UTCTIME_print(WOLFSSL_BIO*,

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -1012,22 +1012,6 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
     #endif
 #endif
 
-/* Defaults, user may over-ride with user_settings.h or in a porting section
- * above
- */
-#ifndef XVFPRINTF
-    #define XVFPRINTF  vfprintf
-#endif
-#ifndef XVSNPRINTF
-    #define XVSNPRINTF vsnprintf
-#endif
-#ifndef XFPUTS
-    #define XFPUTS     fputs
-#endif
-#ifndef XSPRINTF
-    #define XSPRINTF   sprintf
-#endif
-
     #ifndef MAX_FILENAME_SZ
         #define MAX_FILENAME_SZ  256 /* max file name length */
     #endif
@@ -1081,6 +1065,22 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
     WOLFSSL_API int wc_FileExists(const char* fname);
 
 #endif /* !NO_FILESYSTEM */
+
+/* Defaults, user may over-ride with user_settings.h or in a porting section
+ * above
+ */
+#ifndef XVFPRINTF
+    #define XVFPRINTF  vfprintf
+#endif
+#ifndef XVSNPRINTF
+    #define XVSNPRINTF vsnprintf
+#endif
+#ifndef XFPUTS
+    #define XFPUTS     fputs
+#endif
+#ifndef XSPRINTF
+    #define XSPRINTF   sprintf
+#endif
 
 
 /* MIN/MAX MACRO SECTION */


### PR DESCRIPTION
When compiling for QEMU, the gethostbyname call doesn't have access to
the OS DNS.
Implemented a lookup of hostname that uses the system command host.

Fix for QEMU Aarch64 where 'char' is unsigned and the -1 return is being
converted to 255 in wolfSSL_OPENSSL_hexchar2int().

Test TLSv1.3 with www.google.com if wolfSSL supports it.