### PR TITLE
Add implementation to make wolfSSL_BIO_flush work for WOLFSSL_BIO_FILE

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -1842,9 +1842,18 @@ int wolfSSL_BIO_pending(WOLFSSL_BIO* bio)
 
 int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
 {
-    /* for wolfSSL no flushing needed */
     WOLFSSL_ENTER("BIO_flush");
-    (void)bio;
-    return 1;
+
+    if (bio == NULL)
+        return WOLFSSL_FAILURE;
+
+    if (bio->type == WOLFSSL_BIO_FILE) {
+#if !defined(NO_FILESYSTEM) && defined(XFFLUSH)
+        if (XFFLUSH((FILE *)bio->ptr) != 0)
+            return WOLFSSL_FAILURE;
+
+#endif /* !NO_FILESYSTEM && XFFLUSH */
+    }
+    return WOLFSSL_SUCCESS;
 }
 #endif /* WOLFSSL_BIO_INCLUDED */

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -972,6 +972,7 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XBADFILE   NULL
     #define XFGETS     fgets
     #define XFPRINTF   fprintf
+    #define XFFLUSH    fflush
 
     #if !defined(NO_WOLFSSL_DIR)\
         && !defined(WOLFSSL_NUCLEUS) && !defined(WOLFSSL_NUCLEUS_1_2)


### PR DESCRIPTION
This PR is for Python project.
Currently wolfSSL_BIO_flush is implemented but does nothing for any BIO type. Added implementation for BIO_FILE type.
