### PR TITLE
cppcheck fixes and a config fix

### DIFF
--- a/tests/suites.c
+++ b/tests/suites.c
@@ -487,7 +487,7 @@ static int execute_test_case(int svr_argc, char** svr_argv,
         if (cliArgs.argc + 2 > MAX_ARGS)
             printf("cannot add the magic port number flag to client\n");
         else {
-            snprintf(portNumber, sizeof(portNumber), "%d", ready.port);
+            snprintf(portNumber, sizeof(portNumber), "%d", (int)ready.port);
             cli_argv[cliArgs.argc++] = portFlag;
             cli_argv[cliArgs.argc++] = portNumber;
         }

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -52,7 +52,7 @@ int unit_test(int argc, char** argv)
 
 #ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
     if (argc > 1) {
-        word32 memFailCount = atoi(argv[1]);
+        int memFailCount = atoi(argv[1]);
         printf("\n--- SET RNG MALLOC FAIL AT %d---\n", memFailCount);
         wolfSSL_SetMemFailCount(memFailCount);
     }

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -378,7 +378,7 @@ static void simple_test(func_args* args)
 #ifndef USE_WINDOWS_API
     cliArgs.argc = NUMARGS;
     strcpy(argvc[1], "-p");
-    snprintf(argvc[2], sizeof(argvc[2]), "%d", svrArgs.signal->port);
+    snprintf(argvc[2], sizeof(argvc[2]), "%d", (int)svrArgs.signal->port);
 #else
     cliArgs.argc = 1;
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -24983,7 +24983,8 @@ static int curve25519_check_public_test(void)
 
 #endif /* HAVE_CURVE25519_SHARED_SECRET && HAVE_CURVE25519_KEY_IMPORT */
 
-#if defined(HAVE_CURVE25519_KEY_EXPORT) && defined(HAVE_CURVE25519_KEY_IMPORT)
+#if !defined(NO_ASN) && defined(HAVE_CURVE25519_KEY_EXPORT) && \
+    defined(HAVE_CURVE25519_KEY_IMPORT)
 static int curve255519_der_test(void)
 {
     int ret = 0;
@@ -25058,7 +25059,7 @@ static int curve255519_der_test(void)
 
     return ret;
 }
-#endif /* HAVE_CURVE25519_KEY_EXPORT && HAVE_CURVE25519_KEY_IMPORT */
+#endif /* !NO_ASN && HAVE_CURVE25519_KEY_EXPORT && HAVE_CURVE25519_KEY_IMPORT */
 
 WOLFSSL_TEST_SUBROUTINE int curve25519_test(void)
 {
@@ -25242,7 +25243,8 @@ WOLFSSL_TEST_SUBROUTINE int curve25519_test(void)
         return ret;
 #endif /* HAVE_CURVE25519_SHARED_SECRET && HAVE_CURVE25519_KEY_IMPORT */
 
-#if defined(HAVE_CURVE25519_KEY_IMPORT) && defined(HAVE_CURVE25519_KEY_IMPORT)
+#if !defined(NO_ASN) && defined(HAVE_CURVE25519_KEY_EXPORT) && \
+    defined(HAVE_CURVE25519_KEY_IMPORT)
     ret = curve255519_der_test();
     if (ret != 0)
         return ret;

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -261,10 +261,18 @@
     #elif defined(WOLFSSL_TIRTOS)
         typedef void          THREAD_RETURN;
         typedef Task_Handle   THREAD_TYPE;
+        #ifdef HAVE_STACK_SIZE
+          #undef EXIT_TEST
+          #define EXIT_TEST(ret)
+        #endif
         #define WOLFSSL_THREAD
     #elif defined(WOLFSSL_ZEPHYR)
         typedef void            THREAD_RETURN;
         typedef struct k_thread THREAD_TYPE;
+        #ifdef HAVE_STACK_SIZE
+          #undef EXIT_TEST
+          #define EXIT_TEST(ret)
+        #endif
         #define WOLFSSL_THREAD
     #else
         typedef unsigned int  THREAD_RETURN;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1080,7 +1080,7 @@ decouple library dependencies with standard string, memory and so on.
 
 
     #if defined(HAVE_STACK_SIZE)
-        #define EXIT_TEST(ret) return (void*)((size_t)(ret))
+        #define EXIT_TEST(ret) return (THREAD_RETURN)((size_t)(ret))
     #else
         #define EXIT_TEST(ret) return ret
     #endif


### PR DESCRIPTION
./configure --disable-rsa --disable-ecc --disable-dsa
--enable-curve25519 --disable-ed25519 --disable-curve448
--disable-ed448 --enable-cryptonly

suites.c, testsuite.c: ensure port is an integer for snprintf.

unit.c: make memFailCount an integer for printf.

aes.c:
  Reduce variable scope.
  Check aes is not NULL before use in GHASH implementations.
XTS check sz is greater than or equal to a AES_BLOCK_SIZE rather than
0 as another block is processed.
  wc_AesXtsEncrypt, wc_AesXtsEncrypt - simplify braces and ifdefs
wc_AesEcbEncrypt - subtracting from sz is unnecessary as is unused
after.

asn.c:
StoreKey, StoreEccKey - compiler doesn't see ret != 0 when publicKey
is NULL.
  DecodeAuthInfo - count is not used when after break.
  DecodeSubtree - don't use min and max as variables (already macros).
SetEccPublicKey - initialize pubSz and set sz regardless for
compiler's sake.
wc_EncodeName_ex - use unique variable 'namesASN'; ret isn't set after
last check.
SetEccPublicKey - simplify code by using else rather than check ret
wasn't set.
  DecodeAsymKey - ret not modified in non-template implementaiton.
  SetAsymKeyDer - ret still at initialized value here.
DecodeResponseData - ensure dataASN is freed when single->next->status
failed to allocate.

test.c:
  curve255519_der_test() can't be compiled when NO_ASN is defined.

types.h:
  cast to the appropriate type in EXIT_TEST
test.h
don't return anything when THREAD_RETURN is void and EXIT_TEST is for
threading with stack size.