### PR TITLE
Fix for `set1_curves_list` ignoring last character

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -49183,6 +49183,11 @@ int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, const char* names)
     word16 curve;
     char name[MAX_CURVE_NAME_SZ];
 
+    if (ctx == NULL || names == NULL) {
+        WOLFSSL_MSG("ctx or names was NULL");
+        return WOLFSSL_FAILURE;
+    }
+
     /* Disable all curves so that only the ones the user wants are enabled. */
     ctx->disabledCurves = 0xFFFFFFFFUL;
     for (idx = 1; names[idx-1] != '\0'; idx++) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -49189,7 +49189,7 @@ int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, const char* names)
         if (names[idx] != ':' && names[idx] != '\0')
             continue;
 
-        len = idx - 1 - start;
+        len = idx - start;
         if (len > MAX_CURVE_NAME_SZ - 1)
             return WOLFSSL_FAILURE;
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -33076,8 +33076,8 @@ static void test_wolfSSL_sk_SSL_CIPHER(void)
 static void test_wolfSSL_set1_curves_list(void)
 {
 #if defined(OPENSSL_EXTRA) && defined(HAVE_RSA)
-    SSL*     ssl;
-    SSL_CTX* ctx;
+    SSL*     ssl = NULL;
+    SSL_CTX* ctx = NULL;
 
 #ifndef NO_WOLFSSL_SERVER
     AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_server_method()));

--- a/tests/api.c
+++ b/tests/api.c
@@ -33075,7 +33075,7 @@ static void test_wolfSSL_sk_SSL_CIPHER(void)
 
 static void test_wolfSSL_set1_curves_list(void)
 {
-#if defined(OPENSSL_EXTRA) && defined(HAVE_ECC)
+#if defined(OPENSSL_EXTRA) && defined(HAVE_RSA)
     SSL*     ssl;
     SSL_CTX* ctx;
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -33073,6 +33073,37 @@ static void test_wolfSSL_sk_SSL_CIPHER(void)
              !defined(NO_FILESYSTEM) && !defined(NO_RSA) */
 }
 
+static void test_wolfSSL_set1_curves_list(void)
+{
+#if defined(OPENSSL_EXTRA) && defined(HAVE_ECC)
+    SSL*     ssl;
+    SSL_CTX* ctx;
+
+#ifndef NO_WOLFSSL_SERVER
+    AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_server_method()));
+#else
+    AssertNotNull(ctx = SSL_CTX_new(wolfSSLv23_client_method()));
+#endif
+    AssertTrue(SSL_CTX_use_certificate_file(ctx, svrCertFile,
+               SSL_FILETYPE_PEM));
+    AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
+    AssertNotNull(ssl = SSL_new(ctx));
+
+    AssertIntEQ(SSL_CTX_set1_curves_list(ctx, NULL), WOLFSSL_FAILURE);
+    AssertIntEQ(SSL_CTX_set1_curves_list(ctx, "P-25X"), WOLFSSL_FAILURE);
+    AssertIntEQ(SSL_CTX_set1_curves_list(ctx, "P-256"), WOLFSSL_SUCCESS);
+
+    AssertIntEQ(SSL_set1_curves_list(ssl, NULL), WOLFSSL_FAILURE);
+    AssertIntEQ(SSL_set1_curves_list(ssl, "P-25X"), WOLFSSL_FAILURE);
+    AssertIntEQ(SSL_set1_curves_list(ssl, "P-256"), WOLFSSL_SUCCESS);
+
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+
+    printf(resultFmt, passed);
+#endif
+}
+
 static void test_wolfSSL_set1_sigalgs_list(void)
 {
     #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && !defined(NO_RSA)
@@ -48696,6 +48727,7 @@ void ApiTest(void)
 #endif
     test_wolfSSL_set_options();
     test_wolfSSL_sk_SSL_CIPHER();
+    test_wolfSSL_set1_curves_list();
     test_wolfSSL_set1_sigalgs_list();
     test_wolfSSL_PKCS7_certs();
     test_wolfSSL_X509_STORE_CTX();


### PR DESCRIPTION
Fixes issue with `SSL_CTX_set1_curves_list` and `SSL_set1_curves_list` not checking the last character of the names variable provided.