### PR TITLE
TLS/DTLS: size passed to DoAlert to only be current record

### DIFF
--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4228,6 +4228,9 @@ struct WOLFSSL {
     word32          timeout;            /* session timeout */
     word32          fragOffset;         /* fragment offset */
     word16          curSize;
+#ifdef WOLFSSL_DTLS
+    word16          curEnd;
+#endif
     byte            verifyDepth;
     RecordLayerHeader curRL;
     MsgsReceived    msgsReceived;       /* peer messages received */


### PR DESCRIPTION
DTLS can have more bytes in the input buffer than just the current
record. Calculate the endpoint of the record and pass that in.