### PR TITLE
Add a CMake option to build wolfcrypt test and bench code as libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1234,8 +1234,11 @@ else()
     set(CRYPT_TESTS_DEFAULT "yes")
 endif()
 
-set(WOLFSSL_CRYPT_TESTS_HELP_STRING "Enable Crypt Bench/Test  (default: enabled)")
+set(WOLFSSL_CRYPT_TESTS_HELP_STRING "Enable Crypt Bench/Test (default: enabled)")
 add_option("WOLFSSL_CRYPT_TESTS" ${WOLFSSL_CRYPT_TESTS_HELP_STRING} ${CRYPT_TESTS_DEFAULT} "yes;no")
+
+set(WOLFSSL_CRYPT_TESTS_LIBS_HELP_STRING "Build static libraries from the wolfCrypt test and benchmark sources (default: disabled)")
+add_option("WOLFSSL_CRYPT_TESTS_LIBS" ${WOLFSSL_CRYPT_TESTS_LIBS_HELP_STRING} "no" "yes;no")
 
 # TODO: - LIBZ
 #       - PKCS#11
@@ -1510,7 +1513,27 @@ if(WOLFSSL_EXAMPLES)
 endif()
 
 if(WOLFSSL_CRYPT_TESTS)
-    # Build wolfCrypt test
+    if(WOLFSSL_CRYPT_TESTS_LIBS)
+        # Build wolfCrypt test as a static library. This will compile test.c
+        # and make its functions available as a CMake target that other CMake
+        # targets can pull in, in addition to producing the static library
+        # itself. Note that this feature is not enabled by default, and the API
+        # of this library and wofcryptbench_lib should NOT be treated as stable.
+        add_library(wolfcrypttest_lib
+            ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/test/test.c)
+        set_target_properties(wolfcrypttest_lib PROPERTIES OUTPUT_NAME "wolfcrypttest")
+        target_link_libraries(wolfcrypttest_lib wolfssl)
+        target_compile_options(wolfcrypttest_lib PRIVATE "-DNO_MAIN_DRIVER")
+
+        # Make another static library for the wolfCrypt benchmark code.
+        add_library(wolfcryptbench_lib
+            ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/benchmark/benchmark.c)
+        set_target_properties(wolfcryptbench_lib PROPERTIES OUTPUT_NAME "wolfcryptbench")
+        target_link_libraries(wolfcryptbench_lib wolfssl)
+        target_compile_options(wolfcryptbench_lib PRIVATE "-DNO_MAIN_DRIVER")
+    endif()
+
+    # Build wolfCrypt test executable.
     add_executable(wolfcrypttest
         ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/test/test.c)
     target_link_libraries(wolfcrypttest wolfssl)
@@ -1521,7 +1544,7 @@ if(WOLFSSL_CRYPT_TESTS)
                  PROPERTY RUNTIME_OUTPUT_NAME
                  testwolfcrypt)
 
-    # Build wolfCrypt benchmark
+    # Build wolfCrypt benchmark executable.
     add_executable(wolfcryptbench
         ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/benchmark/benchmark.c)
     target_include_directories(wolfcryptbench PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1514,18 +1514,18 @@ endif()
 
 if(WOLFSSL_CRYPT_TESTS)
     if(WOLFSSL_CRYPT_TESTS_LIBS)
-        # Build wolfCrypt test as a static library. This will compile test.c
-        # and make its functions available as a CMake target that other CMake
-        # targets can pull in, in addition to producing the static library
-        # itself. Note that this feature is not enabled by default, and the API
-        # of this library and wofcryptbench_lib should NOT be treated as stable.
+        # Build wolfCrypt test as a library. This will compile test.c and make
+        # its functions available as a CMake target that other CMake targets can
+        # pull in, in addition to producing the library itself. Note that this
+        # feature is not enabled by default, and the API of this library and
+        # wofcryptbench_lib should NOT be treated as stable.
         add_library(wolfcrypttest_lib
             ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/test/test.c)
         set_target_properties(wolfcrypttest_lib PROPERTIES OUTPUT_NAME "wolfcrypttest")
         target_link_libraries(wolfcrypttest_lib wolfssl)
         target_compile_options(wolfcrypttest_lib PRIVATE "-DNO_MAIN_DRIVER")
 
-        # Make another static library for the wolfCrypt benchmark code.
+        # Make another library for the wolfCrypt benchmark code.
         add_library(wolfcryptbench_lib
             ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/benchmark/benchmark.c)
         set_target_properties(wolfcryptbench_lib PROPERTIES OUTPUT_NAME "wolfcryptbench")

--- a/configure.ac
+++ b/configure.ac
@@ -5072,6 +5072,15 @@ AC_ARG_ENABLE([crypttests],
     )
 AC_SUBST([ENABLED_CRYPT_TESTS])
 
+# Build wolfCrypt test and benchmark as libraries. This will compile test.c and
+# benchmark.c and make their functions available via libraries, libwolfcrypttest
+# and libwolfcryptbench, respectively. Note that this feature is not enabled by
+# default, and the API of these libraries should NOT be treated as stable.
+AC_ARG_ENABLE([crypttests-libs],
+    [AS_HELP_STRING([--enable-crypttests-libs],[Enable wolfcrypt test and benchmark libraries (default: disabled)])],
+    [ ENABLED_CRYPT_TESTS_LIBS=$enableval ],
+    [ ENABLED_CRYPT_TESTS_LIBS=no ]
+    )
 
 # LIBZ
 ENABLED_LIBZ="no"
@@ -6889,6 +6898,7 @@ AM_CONDITIONAL([BUILD_EXAMPLE_CLIENTS],[test "x$ENABLED_EXAMPLES" = "xyes"])
 AM_CONDITIONAL([BUILD_TESTS],[test "x$ENABLED_EXAMPLES" = "xyes"])
 AM_CONDITIONAL([BUILD_THREADED_EXAMPLES],[test "x$ENABLED_SINGLETHREADED" = "xno" && test "x$ENABLED_EXAMPLES" = "xyes" && test "x$ENABLED_LEANTLS" = "xno"])
 AM_CONDITIONAL([BUILD_WOLFCRYPT_TESTS],[test "x$ENABLED_CRYPT_TESTS" = "xyes"])
+AM_CONDITIONAL([BUILD_WOLFCRYPT_TESTS_LIBS],[test "x$ENABLED_CRYPT_TESTS_LIBS" = "xyes"])
 AM_CONDITIONAL([BUILD_LIBZ],[test "x$ENABLED_LIBZ" = "xyes"])
 AM_CONDITIONAL([BUILD_PKCS11],[test "x$ENABLED_PKCS11" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_PKCS12],[test "x$ENABLED_PKCS12" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])

--- a/wolfcrypt/benchmark/include.am
+++ b/wolfcrypt/benchmark/include.am
@@ -13,6 +13,14 @@ noinst_HEADERS += wolfcrypt/benchmark/benchmark.h
 endif
 endif
 
+if BUILD_WOLFCRYPT_TESTS_LIBS
+lib_LTLIBRARIES += wolfcrypt/benchmark/libwolfcryptbench.la
+wolfcrypt_benchmark_libwolfcryptbench_la_SOURCES      = wolfcrypt/benchmark/benchmark.c
+wolfcrypt_benchmark_libwolfcryptbench_la_CPPFLAGS     = -DNO_MAIN_DRIVER
+wolfcrypt_benchmark_libwolfcryptbench_la_LIBADD       = src/libwolfssl.la
+wolfcrypt_benchmark_libwolfcryptbench_la_DEPENDENCIES = src/libwolfssl.la
+endif
+
 EXTRA_DIST += wolfcrypt/benchmark/benchmark.sln
 EXTRA_DIST += wolfcrypt/benchmark/benchmark.vcproj
 EXTRA_DIST += wolfcrypt/benchmark/README.md

--- a/wolfcrypt/test/include.am
+++ b/wolfcrypt/test/include.am
@@ -16,6 +16,14 @@ noinst_HEADERS += wolfcrypt/test/test.h wolfcrypt/test/test_paths.h.in
 endif
 endif
 
+if BUILD_WOLFCRYPT_TESTS_LIBS
+lib_LTLIBRARIES += wolfcrypt/test/libwolfcrypttest.la
+wolfcrypt_test_libwolfcrypttest_la_SOURCES      = wolfcrypt/test/test.c
+wolfcrypt_test_libwolfcrypttest_la_CPPFLAGS     = -DNO_MAIN_DRIVER
+wolfcrypt_test_libwolfcrypttest_la_LIBADD       = src/libwolfssl.la
+wolfcrypt_test_libwolfcrypttest_la_DEPENDENCIES = src/libwolfssl.la
+endif
+
 EXTRA_DIST += wolfcrypt/test/test.sln
 EXTRA_DIST += wolfcrypt/test/test.vcproj
 EXTRA_DIST += wolfcrypt/test/README.md


### PR DESCRIPTION
Application code can use the resulting CMake targets or the static library
artifacts directly (e.g. libwolfcrypttest.a on *nix).