### PR TITLE
Skip CRL verification in case no CDP in peer cert

### DIFF
--- a/src/crl.c
+++ b/src/crl.c
@@ -345,6 +345,13 @@ int CheckCertCRL(WOLFSSL_CRL* crl, DecodedCert* cert)
 
     WOLFSSL_ENTER("CheckCertCRL");
 
+#ifdef WOLFSSL_CRL_ALLOW_MISSING_CDP
+    /* Skip CRL verification in case no CDP in peer cert */
+    if (!cert->extCrlInfo) {
+        return ret;
+    }
+#endif
+
     ret = CheckCertCRLList(crl, cert, &foundEntry);
 
 #ifdef HAVE_CRL_IO


### PR DESCRIPTION
WolfSSL sets `CRL_MISSING` in case CRL is enabled and the received certificate has no CDP. Added an optional parameter to make wolfSSL behave like browsers, nginx etc. where CRL verification proceeds if and only if the certificate at hand has any CDP.

At the moment the only way to achieve this behavior is by setting a custom verification callback  with `*_set_verify()` in which you have to see if there is any CDP with `X509_get_ext_d2i(cert, NID_crl_distribution_points, NULL, NULL);` and override the error (By the way we found there was bug there https://github.com/wolfSSL/wolfssl/pull/4456).

With this simple patch there is no need for the caller application to re-extract and check if there is any CDP in the certificate using custom callback. The information is already in `cert->extCrlInfo`