### PR TITLE
add write/read_early_data support for compatibility layer

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -489,8 +489,13 @@ static void SetKeyShare(WOLFSSL* ssl, int onlyKeyShare, int useX25519,
 #endif /* WOLFSSL_TLS13 && HAVE_SUPPORTED_CURVES */
 
 #ifdef WOLFSSL_EARLY_DATA
+#if !defined(OPENSSL_EXTRA)
 static void EarlyData(WOLFSSL_CTX* ctx, WOLFSSL* ssl, const char* msg,
                       int msgSz, char* buffer)
+#else
+static void EarlyData(WOLFSSL_CTX* ctx, WOLFSSL* ssl, const char* msg,
+                      size_t msgSz, char* buffer)
+#endif
 {
     int err;
     int ret;
@@ -508,7 +513,7 @@ static void EarlyData(WOLFSSL_CTX* ctx, WOLFSSL* ssl, const char* msg,
         #endif
         }
     } while (err == WC_PENDING_E);
-    if (ret != msgSz) {
+    if (ret != (int)msgSz) {
         printf("SSL_write_early_data msg error %d, %s\n", err,
                                          wolfSSL_ERR_error_string(err, buffer));
         wolfSSL_free(ssl); ssl = NULL;
@@ -528,7 +533,7 @@ static void EarlyData(WOLFSSL_CTX* ctx, WOLFSSL* ssl, const char* msg,
         #endif
         }
     } while (err == WC_PENDING_E);
-    if (ret != msgSz) {
+    if (ret != (int)msgSz) {
         printf("SSL_write_early_data msg error %d, %s\n", err,
                                          wolfSSL_ERR_error_string(err, buffer));
         wolfSSL_free(ssl);

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2891,7 +2891,11 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
     #ifdef WOLFSSL_EARLY_DATA
             if (earlyData) {
                 do {
+                    #if !defined(OPENSSL_EXTRA)
                     int len;
+                    #else
+                    size_t len;
+                    #endif
                     err = 0; /* reset error */
                     ret = wolfSSL_read_early_data(ssl, input, sizeof(input)-1,
                                                                           &len);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -9634,13 +9634,21 @@ int wolfSSL_set_max_early_data(WOLFSSL* ssl, unsigned int sz)
  * or not using TLS v1.3. SIDE ERROR when not a server. Otherwise the number of
  * early data bytes written.
  */
+ #if !defined(OPENSSL_EXTRA)
 int wolfSSL_write_early_data(WOLFSSL* ssl, const void* data, int sz, int* outSz)
+#else
+int wolfSSL_write_early_data(WOLFSSL* ssl, const void* data, size_t sz, 
+                                                                size_t* outSz)
+#endif
 {
     int ret = 0;
 
     WOLFSSL_ENTER("SSL_write_early_data()");
-
+#if !defined(OPENSSL_EXTRA)
     if (ssl == NULL || data == NULL || sz < 0 || outSz == NULL)
+#else
+    if (ssl == NULL || data == NULL || outSz == NULL)
+#endif
         return BAD_FUNC_ARG;
     if (!IsAtLeastTLSv1_3(ssl->version))
         return BAD_FUNC_ARG;
@@ -9695,14 +9703,21 @@ int wolfSSL_write_early_data(WOLFSSL* ssl, const void* data, int sz, int* outSz)
  * or not using TLS v1.3. SIDE ERROR when not a server. Otherwise the number of
  * early data bytes read.
  */
+#if !defined(OPENSSL_EXTRA)
 int wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz, int* outSz)
+#else
+int wolfSSL_read_early_data(WOLFSSL* ssl, void* data, size_t sz, size_t* outSz)
+#endif
 {
     int ret = 0;
 
     WOLFSSL_ENTER("wolfSSL_read_early_data()");
 
-
+#if !defined(OPENSSL_EXTRA)
     if (ssl == NULL || data == NULL || sz < 0 || outSz == NULL)
+#else
+    if (ssl == NULL || data == NULL || outSz == NULL)
+#endif
         return BAD_FUNC_ARG;
     if (!IsAtLeastTLSv1_3(ssl->version))
         return BAD_FUNC_ARG;

--- a/tests/api.c
+++ b/tests/api.c
@@ -45515,7 +45515,11 @@ static int test_tls13_apis(void)
 #endif
     int          required;
 #ifdef WOLFSSL_EARLY_DATA
+    #if !defined(OPENSSL_EXTRA)
     int          outSz;
+    #else
+    size_t       outSz;
+    #endif
 #endif
 #if defined(HAVE_ECC) && defined(HAVE_SUPPORTED_CURVES)
     int          groups[2] = { WOLFSSL_ECC_SECP256R1,
@@ -45916,8 +45920,10 @@ static int test_tls13_apis(void)
 #ifndef NO_WOLFSSL_CLIENT
     AssertIntEQ(wolfSSL_write_early_data(clientSsl, NULL, sizeof(earlyData),
                                          &outSz), BAD_FUNC_ARG);
+#if !defined(OPENSSL_EXTRA)
     AssertIntEQ(wolfSSL_write_early_data(clientSsl, earlyData, -1, &outSz),
                 BAD_FUNC_ARG);
+#endif
     AssertIntEQ(wolfSSL_write_early_data(clientSsl, earlyData,
                                          sizeof(earlyData), NULL),
                 BAD_FUNC_ARG);
@@ -45945,8 +45951,10 @@ static int test_tls13_apis(void)
     AssertIntEQ(wolfSSL_read_early_data(serverSsl, NULL,
                                         sizeof(earlyDataBuffer), &outSz),
                 BAD_FUNC_ARG);
+#if !defined(OPENSSL_EXTRA)
     AssertIntEQ(wolfSSL_read_early_data(serverSsl, earlyDataBuffer, -1, &outSz),
                 BAD_FUNC_ARG);
+#endif
     AssertIntEQ(wolfSSL_read_early_data(serverSsl, earlyDataBuffer,
                                         sizeof(earlyDataBuffer), NULL),
                 BAD_FUNC_ARG);

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1519,6 +1519,12 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 
 #if defined(WOLFSSL_EARLY_DATA)
 #define SSL_get_early_data_status       wolfSSL_get_early_data_status
+#define SSL_write_early_data            wolfSSL_write_early_data
+#define SSL_read_early_data             wolfSSL_read_early_data
+
+#define SSL_EARLY_DATA_NOT_SENT         WOLFSSL_EARLY_DATA_NOT_SENT
+#define SSL_EARLY_DATA_REJECTED         WOLFSSL_EARLY_DATA_REJECTED
+#define SSL_EARLY_DATA_ACCEPTED         WOLFSSL_EARLY_DATA_ACCEPTED
 #endif
 
 #endif  /* OPENSSL_EXTRA */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1086,10 +1086,17 @@ WOLFSSL_API int  wolfSSL_accept_TLSv13(WOLFSSL*);
 WOLFSSL_API int  wolfSSL_CTX_set_max_early_data(WOLFSSL_CTX* ctx,
                                                 unsigned int sz);
 WOLFSSL_API int  wolfSSL_set_max_early_data(WOLFSSL* ssl, unsigned int sz);
+#if !defined(OPENSSL_EXTRA)
 WOLFSSL_API int  wolfSSL_write_early_data(WOLFSSL* ssl, const void* data,
                                           int sz, int* outSz);
 WOLFSSL_API int  wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz,
                                          int* outSz);
+#else
+WOLFSSL_API int  wolfSSL_write_early_data(WOLFSSL* ssl, const void* data,
+                                          size_t sz, size_t* outSz);
+WOLFSSL_API int  wolfSSL_read_early_data(WOLFSSL* ssl, void* data, size_t sz,
+                                         size_t* outSz);
+#endif
 WOLFSSL_API int  wolfSSL_get_early_data_status(const WOLFSSL* ssl);
 #endif /* WOLFSSL_EARLY_DATA */
 #endif /* WOLFSSL_TLS13 */


### PR DESCRIPTION
compliant argument type to Openssl

Seems that there could be different behavior /return value between wolfSSL and OpenSSL implementation. Draft version until those differences are changed.