### PR TITLE
Example client fix for SMTP temp buffer size

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -895,7 +895,7 @@ const char* starttlsCmd[6] = {
 /* Initiates the STARTTLS command sequence over TCP */
 static int StartTLS_Init(SOCKET_T* sockfd)
 {
-    char tmpBuf[256];
+    char tmpBuf[512];
 
     if (sockfd == NULL)
         return BAD_FUNC_ARG;


### PR DESCRIPTION
Increase the size of the temp buffer for SMTP in example client. Some SMTP servers send larger messages.

Example: `./examples/client/client -v 4 -M smtp -h smtp.gmail.com -p 587 -x -d`