### PR TITLE
include IDE/KDS in make dist archive

### DIFF
--- a/IDE/include.am
+++ b/IDE/include.am
@@ -12,6 +12,7 @@ include IDE/ROWLEY-CROSSWORKS-ARM/include.am
 include IDE/TRUESTUDIO/include.am
 include IDE/ARDUINO/include.am
 include IDE/INTIME-RTOS/include.am
+include IDE/KDS/include.am
 include IDE/STM32Cube/include.am
 include IDE/VS-ARM/include.am
 include IDE/VS-AZURE-SPHERE/include.am


### PR DESCRIPTION
Looks like we forgot to include the ```IDE/KDS``` directory in our ```IDE/include.am```  As such, it was being left out of ```make dist``` archives.