### PR TITLE
Zephyr: Rename leftover CONFIG_WOLFSSL_OPTIONS_FILE

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -3,7 +3,7 @@ if(CONFIG_WOLFSSL)
   
   if(CONFIG_WOLFSSL_BUILTIN)
     target_compile_definitions(wolfSSL INTERFACE
-  	WOLFSSL_OPTIONS_FILE="${CONFIG_WOLFSSL_OPTIONS_FILE}"
+  	WOLFSSL_SETTINGS_FILE="${CONFIG_WOLFSSL_SETTINGS_FILE}"
   	)
   
     target_include_directories(wolfSSL INTERFACE


### PR DESCRIPTION
**Zephyr support:**

Rename leftover `CONFIG_WOLFSSL_OPTIONS_FILE` to `CONFIG_WOLFSSL_SETTINGS_FILE`
This now allows to properly override `user_settings.h` from your Zephyr application.

Signed-off-by: Maxime Vincent <maxime@veemax.be>