### PR TITLE
Fix for `wolfSSL_set_secret` with DTLS where TLS v1.3 is not defined

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -3504,6 +3504,10 @@ static int MakeSslMasterSecret(WOLFSSL* ssl)
     wc_Sha sha[1];
 #endif
 
+    if (ssl->arrays->preMasterSecret == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
 #ifdef SHOW_SECRETS
     {
         word32 j;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1360,8 +1360,18 @@ int wolfSSL_set_secret(WOLFSSL* ssl, word16 epoch,
         ret = BAD_FUNC_ARG;
     }
 
+    if (ret == 0 && ssl->arrays->preMasterSecret == NULL) {
+        ssl->arrays->preMasterSz = ENCRYPT_LEN;
+        ssl->arrays->preMasterSecret = (byte*)XMALLOC(ENCRYPT_LEN, ssl->heap,
+            DYNAMIC_TYPE_SECRET);
+        if (ssl->arrays->preMasterSecret == NULL) {
+            ret = MEMORY_E;
+        }
+    }
+
     if (ret == 0) {
         XMEMCPY(ssl->arrays->preMasterSecret, preMasterSecret, preMasterSz);
+        XMEMSET(ssl->arrays->preMasterSecret + preMasterSz, 0, ENCRYPT_LEN - preMasterSz);
         ssl->arrays->preMasterSz = preMasterSz;
         XMEMCPY(ssl->arrays->clientRandom, clientRandom, RAN_LEN);
         XMEMCPY(ssl->arrays->serverRandom, serverRandom, RAN_LEN);


### PR DESCRIPTION
Function assumed `ssl->arrays->preMasterSecret` was allocated.