### PR TITLE
Make several changes to support OpenSSH 8.5p1.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -37816,7 +37816,6 @@ int wolfSSL_EC_POINT_set_affine_coordinates_GFp(const WOLFSSL_EC_GROUP *group,
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
     !defined(HAVE_SELFTEST)
-#if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION>2))
 int wolfSSL_EC_POINT_add(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *r,
                          const WOLFSSL_EC_POINT *p1,
                          const WOLFSSL_EC_POINT *p2, WOLFSSL_BN_CTX *ctx)
@@ -37975,11 +37974,29 @@ int wolfSSL_EC_POINT_mul(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *r,
 
     if (n) {
         /* load generator */
+    #if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION>2))
         if (wc_ecc_get_generator(result, group->curve_idx)
                 != MP_OKAY) {
             WOLFSSL_MSG("wc_ecc_get_generator error");
             goto cleanup;
         }
+    #else
+        /* wc_ecc_get_generator is not defined in the FIPS v2 module. */
+        if (mp_read_radix(result->x, ecc_sets[group->curve_idx].Gx, MP_RADIX_HEX)
+                != MP_OKAY) {
+            WOLFSSL_MSG("mp_read_radix Gx error");
+            goto cleanup;
+        }
+        if (mp_read_radix(result->y, ecc_sets[group->curve_idx].Gy, MP_RADIX_HEX)
+                != MP_OKAY) {
+            WOLFSSL_MSG("mp_read_radix Gy error");
+            goto cleanup;
+        }
+        if (mp_set(result->z, 1) != MP_OKAY) {
+            WOLFSSL_MSG("mp_set Gz error");
+            goto cleanup;
+        }
+    #endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
     }
 
     if (n && q && m) {
@@ -38062,7 +38079,6 @@ cleanup:
     wc_ecc_del_point(tmp);
     return ret;
 }
-#endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
 #endif /* !defined(WOLFSSL_ATECC508A) && defined(ECC_SHAMIR) &&
         * !defined(HAVE_SELFTEST) */
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -22045,7 +22045,8 @@ static int ecc_point_test(void)
                          0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                          0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                          0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
-#ifdef HAVE_COMP_KEY
+#if defined(HAVE_COMP_KEY) && (!defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) || \
+    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2)))
     byte       derComp0[] = { 0x02, /* = Compressed, y even */
                               0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
                               0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
@@ -22215,21 +22216,19 @@ static int ecc_point_test(void)
         goto done;
     }
 
-#ifdef HAVE_COMP_KEY
+#if defined(HAVE_COMP_KEY) && (!defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) || \
+    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2)))
     ret = wc_ecc_import_point_der(derComp0, sizeof(derComp0)*2-1, curve_idx, point3);
     if (ret != 0) {
         ret = -10026;
         goto done;
     }
 
-#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) || \
-    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2))
     ret = wc_ecc_import_point_der_ex(derComp0, sizeof(derComp0), curve_idx, point4, 0);
     if (ret != 0) {
         ret = -10027;
         goto done;
     }
-#endif
 
     ret = wc_ecc_cmp_point(point3, point4);
     if (ret != MP_EQ) {
@@ -22243,14 +22242,11 @@ static int ecc_point_test(void)
         goto done;
     }
 
-#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) || \
-    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2))
     ret = wc_ecc_import_point_der_ex(derComp1, sizeof(derComp1), curve_idx, point4, 0);
     if (ret != 0) {
         ret = -10030;
         goto done;
     }
-#endif
 
     ret = wc_ecc_cmp_point(point3, point4);
     if (ret != MP_EQ) {

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -595,6 +595,8 @@ WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_set_iv_length(WOLFSSL_EVP_CIPHER_CTX* ct
                                                      int ivLen);
 WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_set_iv(WOLFSSL_EVP_CIPHER_CTX* ctx, byte* iv,
                                                      int ivLen);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_get_iv(WOLFSSL_EVP_CIPHER_CTX* ctx, byte* iv,
+                                                     int ivLen);
 WOLFSSL_API int  wolfSSL_EVP_Cipher(WOLFSSL_EVP_CIPHER_CTX* ctx,
                           unsigned char* dst, unsigned char* src,
                           unsigned int len);
@@ -977,6 +979,7 @@ typedef WOLFSSL_ASN1_PCTX      ASN1_PCTX;
 #define EVP_CIPHER_CTX_set_padding wolfSSL_EVP_CIPHER_CTX_set_padding
 #define EVP_CIPHER_CTX_flags       wolfSSL_EVP_CIPHER_CTX_flags
 #define EVP_CIPHER_CTX_set_iv      wolfSSL_EVP_CIPHER_CTX_set_iv
+#define EVP_CIPHER_CTX_get_iv      wolfSSL_EVP_CIPHER_CTX_get_iv
 #define EVP_add_digest             wolfSSL_EVP_add_digest
 #define EVP_add_cipher             wolfSSL_EVP_add_cipher
 #define EVP_cleanup                wolfSSL_EVP_cleanup


### PR DESCRIPTION
- Permit more wolfSSL_EC_POINT_* functions for FIPS builds. This requires one
workaround in wolfSSL_EC_POINT_mul where wc_ecc_get_generator isn't available.
- Permit more AES-GCM code in EVP code for FIPS builds. It's unclear why this
code wasn't already available.
- Add EVP_CIPHER_CTX_get_iv to the compatibility layer.
- Clear any existing AAD in the EVP_CIPHER_CTX for AES-GCM when we receive the
EVP_CTRL_GCM_IV_GEN control command. OpenSSL does this, and OpenSSH is relying
on this behavior to use AES-GCM correctly.
- Modify ecc_point_test in testwolfcrypt so that it doesn't fail when doing a
FIPS build with HAVE_COMP_KEY defined.