### PR TITLE
Rename pem_password_cb to wc_pem_password_cb.

### DIFF
--- a/doc/dox_comments/header_files/pem.h
+++ b/doc/dox_comments/header_files/pem.h
@@ -31,4 +31,4 @@ WOLFSSL_API
 int wolfSSL_PEM_write_bio_PrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key,
                                         const WOLFSSL_EVP_CIPHER* cipher,
                                         unsigned char* passwd, int len,
-                                        pem_password_cb* cb, void* arg);
+                                        wc_pem_password_cb* cb, void* arg);

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -12187,7 +12187,7 @@ WOLFSSL_API size_t wolfSSL_get_client_random(const WOLFSSL* ssl,
     _Example_
     \code
     WOLFSSL_CTX* ctx;
-    pem_password_cb cb;
+    wc_pem_password_cb cb;
     // setup ctx
     cb = wolfSSL_CTX_get_default_passwd_cb(ctx);
     //use cb
@@ -12196,7 +12196,8 @@ WOLFSSL_API size_t wolfSSL_get_client_random(const WOLFSSL* ssl,
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
-WOLFSSL_API pem_password_cb* wolfSSL_CTX_get_default_passwd_cb(WOLFSSL_CTX *ctx);
+WOLFSSL_API wc_pem_password_cb* wolfSSL_CTX_get_default_passwd_cb(WOLFSSL_CTX*
+                                                                  ctx);
 
 /*!
     \ingroup Setup
@@ -12251,7 +12252,7 @@ WOLFSSL_API void *wolfSSL_CTX_get_default_passwd_cb_userdata(WOLFSSL_CTX *ctx);
     \sa wolfSSL_PEM_read_bio_X509
 */
 WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
-        (WOLFSSL_BIO *bp, WOLFSSL_X509 **x, pem_password_cb *cb, void *u);
+        (WOLFSSL_BIO *bp, WOLFSSL_X509 **x, wc_pem_password_cb *cb, void *u);
 
 /*!
     \ingroup CertsKeys
@@ -12309,7 +12310,7 @@ WOLFSSL_API long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX*, WOLFSSL_DH*);
     \sa none
 */
 WOLFSSL_API WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSAparams(WOLFSSL_BIO *bp,
-    WOLFSSL_DSA **x, pem_password_cb *cb, void *u);
+    WOLFSSL_DSA **x, wc_pem_password_cb *cb, void *u);
 
 /*!
     \ingroup Debug

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17423,14 +17423,15 @@ cleanup:
     }
 
 
-    void wolfSSL_CTX_set_default_passwd_cb(WOLFSSL_CTX* ctx,pem_password_cb* cb)
+    void wolfSSL_CTX_set_default_passwd_cb(WOLFSSL_CTX* ctx, wc_pem_password_cb*
+                                           cb)
     {
         WOLFSSL_ENTER("SSL_CTX_set_default_passwd_cb");
         if (ctx)
             ctx->passwd_cb = cb;
     }
 
-    pem_password_cb* wolfSSL_CTX_get_default_passwd_cb(WOLFSSL_CTX *ctx)
+    wc_pem_password_cb* wolfSSL_CTX_get_default_passwd_cb(WOLFSSL_CTX *ctx)
     {
         if (ctx == NULL || ctx->passwd_cb == NULL) {
             return NULL;
@@ -35480,7 +35481,7 @@ static int wolfSSL_RSA_To_Der(WOLFSSL_RSA* rsa, byte** outBuf, int publicKey, vo
 int wolfSSL_PEM_write_bio_RSAPrivateKey(WOLFSSL_BIO* bio, WOLFSSL_RSA* key,
                                         const WOLFSSL_EVP_CIPHER* cipher,
                                         unsigned char* passwd, int len,
-                                        pem_password_cb* cb, void* arg)
+                                        wc_pem_password_cb* cb, void* arg)
 {
     int ret;
     WOLFSSL_EVP_PKEY* pkey;
@@ -35581,7 +35582,8 @@ int wolfSSL_PEM_write_bio_RSA_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa)
  * Returns WOLFSSL_SUCCESS or WOLFSSL_FAILURE
  */
 WOLFSSL_RSA *wolfSSL_PEM_read_bio_RSA_PUBKEY(WOLFSSL_BIO* bio,WOLFSSL_RSA** rsa,
-                                                pem_password_cb* cb, void *pass)
+                                             wc_pem_password_cb* cb,
+                                             void *pass)
 {
     WOLFSSL_EVP_PKEY* pkey;
     WOLFSSL_RSA* local;
@@ -35741,9 +35743,9 @@ int wolfSSL_PEM_write_bio_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key)
  * Returns WOLFSSL_SUCCESS or WOLFSSL_FAILURE
  */
 int wolfSSL_PEM_write_bio_PrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key,
-                                        const WOLFSSL_EVP_CIPHER* cipher,
-                                        unsigned char* passwd, int len,
-                                        pem_password_cb* cb, void* arg)
+                                     const WOLFSSL_EVP_CIPHER* cipher,
+                                     unsigned char* passwd, int len,
+                                     wc_pem_password_cb* cb, void* arg)
 {
     byte* keyDer;
     int pemSz;
@@ -35947,7 +35949,7 @@ int wolfSSL_PEM_write_mem_RSAPrivateKey(RSA* rsa, const EVP_CIPHER* cipher,
 int wolfSSL_PEM_write_RSAPrivateKey(XFILE fp, WOLFSSL_RSA *rsa,
                                     const EVP_CIPHER *enc,
                                     unsigned char *kstr, int klen,
-                                    pem_password_cb *cb, void *u)
+                                    wc_pem_password_cb *cb, void *u)
 {
     byte *pem;
     int  plen, ret;
@@ -38716,7 +38718,8 @@ int wolfSSL_PEM_write_EC_PUBKEY(XFILE fp, WOLFSSL_EC_KEY *x)
 
 WOLFSSL_EC_KEY* wolfSSL_PEM_read_bio_EC_PUBKEY(WOLFSSL_BIO* bio,
                                                WOLFSSL_EC_KEY** ec,
-                                               pem_password_cb* cb, void *pass)
+                                               wc_pem_password_cb* cb,
+                                               void *pass)
 {
     WOLFSSL_EVP_PKEY* pkey;
     WOLFSSL_EC_KEY* local;
@@ -38746,7 +38749,7 @@ WOLFSSL_EC_KEY* wolfSSL_PEM_read_bio_EC_PUBKEY(WOLFSSL_BIO* bio,
  */
 WOLFSSL_EC_KEY* wolfSSL_PEM_read_bio_ECPrivateKey(WOLFSSL_BIO* bio,
                                                   WOLFSSL_EC_KEY** ec,
-                                                  pem_password_cb* cb,
+                                                  wc_pem_password_cb* cb,
                                                   void *pass)
 {
     WOLFSSL_EVP_PKEY* pkey;
@@ -38817,7 +38820,7 @@ int wolfSSL_PEM_write_bio_EC_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_EC_KEY* ec)
 int wolfSSL_PEM_write_bio_ECPrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EC_KEY* ec,
                                        const EVP_CIPHER* cipher,
                                        unsigned char* passwd, int len,
-                                       pem_password_cb* cb, void* arg)
+                                       wc_pem_password_cb* cb, void* arg)
 {
     int ret = 0, der_max_len = 0, derSz = 0;
     byte *derBuf;
@@ -39013,7 +39016,7 @@ int wolfSSL_PEM_write_mem_ECPrivateKey(WOLFSSL_EC_KEY* ecc,
 int wolfSSL_PEM_write_ECPrivateKey(XFILE fp, WOLFSSL_EC_KEY *ecc,
                                    const EVP_CIPHER *enc,
                                    unsigned char *kstr, int klen,
-                                   pem_password_cb *cb, void *u)
+                                   wc_pem_password_cb *cb, void *u)
 {
     byte *pem;
     int  plen, ret;
@@ -39061,7 +39064,7 @@ int wolfSSL_PEM_write_ECPrivateKey(XFILE fp, WOLFSSL_EC_KEY *ecc,
 int wolfSSL_PEM_write_bio_DSAPrivateKey(WOLFSSL_BIO* bio, WOLFSSL_DSA* dsa,
                                        const EVP_CIPHER* cipher,
                                        unsigned char* passwd, int len,
-                                       pem_password_cb* cb, void* arg)
+                                       wc_pem_password_cb* cb, void* arg)
 {
     int ret = 0, der_max_len = 0, derSz = 0;
     byte *derBuf;
@@ -39285,7 +39288,7 @@ int wolfSSL_PEM_write_mem_DSAPrivateKey(WOLFSSL_DSA* dsa,
 int wolfSSL_PEM_write_DSAPrivateKey(XFILE fp, WOLFSSL_DSA *dsa,
                                     const EVP_CIPHER *enc,
                                     unsigned char *kstr, int klen,
-                                    pem_password_cb *cb, void *u)
+                                    wc_pem_password_cb *cb, void *u)
 {
     byte *pem;
     int  plen, ret;
@@ -39340,15 +39343,16 @@ int wolfSSL_PEM_write_DSA_PUBKEY(XFILE fp, WOLFSSL_DSA *x)
 
 #ifndef NO_BIO
 
-static int pem_read_bio_key(WOLFSSL_BIO* bio, pem_password_cb* cb, void* pass,
-                            int keyType, int* eccFlag, DerBuffer** der)
+static int pem_read_bio_key(WOLFSSL_BIO* bio, wc_pem_password_cb* cb,
+                            void* pass, int keyType, int* eccFlag,
+                            DerBuffer** der)
 {
 #ifdef WOLFSSL_SMALL_STACK
     EncryptedInfo* info = NULL;
 #else
     EncryptedInfo info[1];
 #endif /* WOLFSSL_SMALL_STACK */
-    pem_password_cb* localCb = NULL;
+    wc_pem_password_cb* localCb = NULL;
     char* mem = NULL;
     int memSz = 0;
     int ret;
@@ -39472,7 +39476,7 @@ static int pem_read_bio_key(WOLFSSL_BIO* bio, pem_password_cb* cb, void* pass,
 
 WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PrivateKey(WOLFSSL_BIO* bio,
                                                   WOLFSSL_EVP_PKEY** key,
-                                                  pem_password_cb* cb,
+                                                  wc_pem_password_cb* cb,
                                                   void* pass)
 {
     WOLFSSL_EVP_PKEY* pkey = NULL;
@@ -39527,7 +39531,8 @@ WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PrivateKey(WOLFSSL_BIO* bio,
 
 WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_bio_PUBKEY(WOLFSSL_BIO* bio,
                                               WOLFSSL_EVP_PKEY **key,
-                                              pem_password_cb *cb, void *pass)
+                                              wc_pem_password_cb *cb,
+                                              void *pass)
 {
     WOLFSSL_EVP_PKEY* pkey = NULL;
     DerBuffer*        der = NULL;
@@ -39574,7 +39579,7 @@ WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_bio_PUBKEY(WOLFSSL_BIO* bio,
  * returns a pointer to a new WOLFSSL_RSA structure on success and NULL on fail
  */
 WOLFSSL_RSA* wolfSSL_PEM_read_bio_RSAPrivateKey(WOLFSSL_BIO* bio,
-        WOLFSSL_RSA** rsa, pem_password_cb* cb, void* pass)
+        WOLFSSL_RSA** rsa, wc_pem_password_cb* cb, void* pass)
 {
     WOLFSSL_EVP_PKEY* pkey;
     WOLFSSL_RSA* local;
@@ -39614,7 +39619,8 @@ WOLFSSL_RSA* wolfSSL_PEM_read_bio_RSAPrivateKey(WOLFSSL_BIO* bio,
  */
 WOLFSSL_DSA* wolfSSL_PEM_read_bio_DSAPrivateKey(WOLFSSL_BIO* bio,
                                                 WOLFSSL_DSA** dsa,
-                                                pem_password_cb* cb,void *pass)
+                                                wc_pem_password_cb* cb,
+                                                void* pass)
 {
     WOLFSSL_EVP_PKEY* pkey = NULL;
     WOLFSSL_DSA* local;
@@ -39642,7 +39648,7 @@ WOLFSSL_DSA* wolfSSL_PEM_read_bio_DSAPrivateKey(WOLFSSL_BIO* bio,
  * Returns WOLFSSL_SUCCESS or WOLFSSL_FAILURE
  */
 WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSA_PUBKEY(WOLFSSL_BIO* bio,WOLFSSL_DSA** dsa,
-                                                pem_password_cb* cb, void *pass)
+                                             wc_pem_password_cb* cb, void* pass)
 {
     WOLFSSL_EVP_PKEY* pkey;
     WOLFSSL_DSA* local;
@@ -39672,7 +39678,7 @@ WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSA_PUBKEY(WOLFSSL_BIO* bio,WOLFSSL_DSA** dsa,
 #ifdef HAVE_ECC
 /* returns a new WOLFSSL_EC_GROUP structure on success and NULL on fail */
 WOLFSSL_EC_GROUP* wolfSSL_PEM_read_bio_ECPKParameters(WOLFSSL_BIO* bio,
-        WOLFSSL_EC_GROUP** group, pem_password_cb* cb, void* pass)
+        WOLFSSL_EC_GROUP** group, wc_pem_password_cb* cb, void* pass)
 {
     WOLFSSL_EVP_PKEY* pkey;
     WOLFSSL_EC_GROUP* ret = NULL;
@@ -39701,7 +39707,7 @@ WOLFSSL_EC_GROUP* wolfSSL_PEM_read_bio_ECPKParameters(WOLFSSL_BIO* bio,
 
 #if !defined(NO_FILESYSTEM)
 WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_PUBKEY(XFILE fp, EVP_PKEY **x,
-                                          pem_password_cb *cb, void *u)
+                                          wc_pem_password_cb *cb, void *u)
 {
     (void)fp;
     (void)x;
@@ -39947,7 +39953,7 @@ int wolfSSL_RSA_print(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa, int offset)
 #if !defined(NO_FILESYSTEM)
 #ifndef NO_WOLFSSL_STUB
 WOLFSSL_RSA *wolfSSL_PEM_read_RSAPublicKey(XFILE fp, WOLFSSL_RSA **x,
-                                           pem_password_cb *cb, void *u)
+                                           wc_pem_password_cb *cb, void *u)
 {
     (void)fp;
     (void)x;
@@ -42631,7 +42637,7 @@ cleanup:
 #ifndef NO_BIO
 
     static WOLFSSL_X509 *loadX509orX509REQFromPemBio(WOLFSSL_BIO *bp,
-            WOLFSSL_X509 **x, pem_password_cb *cb, void *u, int type)
+            WOLFSSL_X509 **x, wc_pem_password_cb *cb, void *u, int type)
     {
         WOLFSSL_X509* x509 = NULL;
 #if defined(WOLFSSL_PEM_TO_DER) || defined(WOLFSSL_DER_TO_PEM)
@@ -42717,21 +42723,21 @@ cleanup:
 
 
     WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 **x,
-                                            pem_password_cb *cb, void *u)
+                                            wc_pem_password_cb *cb, void *u)
     {
         return loadX509orX509REQFromPemBio(bp, x, cb, u, CERT_TYPE);
     }
 
 #ifdef WOLFSSL_CERT_REQ
     WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_REQ(WOLFSSL_BIO *bp, WOLFSSL_X509 **x,
-                                                pem_password_cb *cb, void *u)
+                                                wc_pem_password_cb *cb, void *u)
     {
         return loadX509orX509REQFromPemBio(bp, x, cb, u, CERTREQ_TYPE);
     }
 
 #ifndef NO_FILESYSTEM
     WOLFSSL_X509* wolfSSL_PEM_read_X509_REQ(XFILE fp, WOLFSSL_X509** x,
-                                            pem_password_cb* cb, void* u)
+                                            wc_pem_password_cb* cb, void* u)
     {
         int err = 0;
         WOLFSSL_X509* ret = NULL;
@@ -42770,7 +42776,7 @@ cleanup:
 #endif /* WOLFSSL_CERT_REQ */
 
     WOLFSSL_X509_CRL *wolfSSL_PEM_read_bio_X509_CRL(WOLFSSL_BIO *bp,
-            WOLFSSL_X509_CRL **x, pem_password_cb *cb, void *u)
+            WOLFSSL_X509_CRL **x, wc_pem_password_cb *cb, void *u)
     {
 #if defined(WOLFSSL_PEM_TO_DER) && defined(HAVE_CRL)
         unsigned char* pem = NULL;
@@ -42826,7 +42832,7 @@ err:
 
 #if !defined(NO_FILESYSTEM)
     static void* wolfSSL_PEM_read_X509_ex(XFILE fp, void **x,
-        pem_password_cb *cb, void *u, int type)
+        wc_pem_password_cb *cb, void *u, int type)
     {
         unsigned char* pem = NULL;
         int pemSz;
@@ -42914,14 +42920,15 @@ err:
     }
 
     WOLFSSL_API WOLFSSL_X509* wolfSSL_PEM_read_X509(XFILE fp, WOLFSSL_X509 **x,
-                                                    pem_password_cb *cb, void *u)
+                                                    wc_pem_password_cb *cb,
+                                                    void *u)
     {
         return (WOLFSSL_X509* )wolfSSL_PEM_read_X509_ex(fp, (void **)x, cb, u, CERT_TYPE);
     }
 
 #ifndef NO_BIO
     WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_PrivateKey(XFILE fp,
-        WOLFSSL_EVP_PKEY **x, pem_password_cb *cb, void *u)
+        WOLFSSL_EVP_PKEY **x, wc_pem_password_cb *cb, void *u)
     {
         int err = 0;
         WOLFSSL_EVP_PKEY* ret = NULL;
@@ -42953,7 +42960,7 @@ err:
 
 #if defined(HAVE_CRL)
     WOLFSSL_API WOLFSSL_X509_CRL* wolfSSL_PEM_read_X509_CRL(XFILE fp, WOLFSSL_X509_CRL **crl,
-                                                    pem_password_cb *cb, void *u)
+                                                    wc_pem_password_cb *cb, void *u)
     {
         return (WOLFSSL_X509_CRL* )wolfSSL_PEM_read_X509_ex(fp, (void **)crl, cb, u, CRL_TYPE);
     }
@@ -43304,7 +43311,8 @@ err:
     }
 
     int wolfSSL_PEM_do_header(EncryptedInfo* cipher, unsigned char* data,
-                              long* len, pem_password_cb* callback, void* ctx)
+                              long* len, wc_pem_password_cb* callback,
+                              void* ctx)
     {
         int ret = WOLFSSL_SUCCESS;
         char password[NAME_SZ];
@@ -43339,7 +43347,9 @@ err:
      * _AUX is for working with a trusted X509 certificate
      */
     WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX(WOLFSSL_BIO *bp,
-                               WOLFSSL_X509 **x, pem_password_cb *cb, void *u) {
+                               WOLFSSL_X509 **x, wc_pem_password_cb *cb,
+                               void *u)
+    {
         WOLFSSL_ENTER("wolfSSL_PEM_read_bio_X509");
 
         /* AUX info is; trusted/rejected uses, friendly name, private key id,
@@ -43455,8 +43465,8 @@ err:
      * @return WOLFSSL_SUCCESSS on success and WOLFSSL_FAILURE otherwise
      */
     static int wolfSSL_PEM_X509_X509_CRL_X509_PKEY_read_bio(
-            WOLFSSL_BIO* bio, pem_password_cb* cb,
-            WOLFSSL_X509** x509, WOLFSSL_X509_CRL** crl, WOLFSSL_X509_PKEY** x_pkey)
+            WOLFSSL_BIO* bio, wc_pem_password_cb* cb, WOLFSSL_X509** x509,
+            WOLFSSL_X509_CRL** crl, WOLFSSL_X509_PKEY** x_pkey)
     {
 
 #if defined(WOLFSSL_PEM_TO_DER) || defined(WOLFSSL_DER_TO_PEM)
@@ -43618,7 +43628,7 @@ err:
      */
     WOLF_STACK_OF(WOLFSSL_X509_INFO)* wolfSSL_PEM_X509_INFO_read_bio(
         WOLFSSL_BIO* bio, WOLF_STACK_OF(WOLFSSL_X509_INFO)* sk,
-        pem_password_cb* cb, void* u)
+        wc_pem_password_cb* cb, void* u)
     {
         WOLF_STACK_OF(WOLFSSL_X509_INFO)* localSk = NULL;
         int ret = WOLFSSL_SUCCESS;
@@ -45248,7 +45258,7 @@ void* wolfSSL_get_ex_data(const WOLFSSL* ssl, int idx)
 #ifndef NO_DSA
 #ifndef NO_BIO
 WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSAparams(WOLFSSL_BIO *bp, WOLFSSL_DSA **x,
-        pem_password_cb *cb, void *u)
+        wc_pem_password_cb *cb, void *u)
 {
     WOLFSSL_DSA* dsa;
     DsaKey* key;
@@ -45352,7 +45362,7 @@ WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSAparams(WOLFSSL_BIO *bp, WOLFSSL_DSA **x,
 #ifndef NO_DH
 #ifndef NO_BIO
 WOLFSSL_DH *wolfSSL_PEM_read_bio_DHparams(WOLFSSL_BIO *bio, WOLFSSL_DH **x,
-        pem_password_cb *cb, void *u)
+        wc_pem_password_cb *cb, void *u)
 {
 #ifndef NO_FILESYSTEM
     WOLFSSL_DH* localDh = NULL;
@@ -45495,7 +45505,7 @@ end:
  *
  * Returns new WOLFSSL_DH structure pointer on success, NULL on failure. */
 WOLFSSL_DH *wolfSSL_PEM_read_DHparams(XFILE fp, WOLFSSL_DH **x,
-        pem_password_cb *cb, void *u)
+        wc_pem_password_cb *cb, void *u)
 {
     WOLFSSL_BIO* fbio = NULL;
     WOLFSSL_DH* dh = NULL;
@@ -54092,7 +54102,7 @@ int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
                                           WOLFSSL_EVP_PKEY* pkey,
                                           const WOLFSSL_EVP_CIPHER* enc,
                                           char* passwd, int passwdSz,
-                                          pem_password_cb* cb, void* ctx)
+                                          wc_pem_password_cb* cb, void* ctx)
 {
     int ret = 0;
     char password[NAME_SZ];
@@ -54211,7 +54221,7 @@ int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
 #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
 int wolfSSL_PEM_write_PKCS8PrivateKey(XFILE f, WOLFSSL_EVP_PKEY* pkey,
     const WOLFSSL_EVP_CIPHER* enc, char* passwd, int passwdSz,
-    pem_password_cb* cb, void* ctx)
+    wc_pem_password_cb* cb, void* ctx)
 {
     int ret = WOLFSSL_SUCCESS;
     BIO *b;
@@ -54295,7 +54305,7 @@ static int bio_get_data(WOLFSSL_BIO* bio, byte** data)
 /* DER data is PKCS#8 encrypted. */
 WOLFSSL_EVP_PKEY* wolfSSL_d2i_PKCS8PrivateKey_bio(WOLFSSL_BIO* bio,
                                                   WOLFSSL_EVP_PKEY** pkey,
-                                                  pem_password_cb* cb,
+                                                  wc_pem_password_cb* cb,
                                                   void* ctx)
 {
     int ret;

--- a/tests/api.c
+++ b/tests/api.c
@@ -30298,7 +30298,7 @@ static void test_wolfSSL_PEM_PrivateKey(void)
     defined(WOLFSSL_KEY_GEN) && !defined(HAVE_USER_RSA) && !defined(NO_RSA)
     {
         XFILE f;
-        pem_password_cb* passwd_cb;
+        wc_pem_password_cb* passwd_cb;
         void* passwd_cb_userdata;
         SSL_CTX* ctx;
         char passwd[] = "bad password";

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2905,8 +2905,8 @@ struct WOLFSSL_CTX {
     byte        haveAnon;               /* User wants to allow Anon suites */
 #endif /* HAVE_ANON */
 #ifdef WOLFSSL_ENCRYPTED_KEYS
-    pem_password_cb* passwd_cb;
-    void*            passwd_userdata;
+    wc_pem_password_cb* passwd_cb;
+    void*               passwd_userdata;
 #endif
 #ifdef WOLFSSL_LOCAL_X509_STORE
     WOLFSSL_X509_STORE x509_store; /* points to ctx->cm */

--- a/wolfssl/openssl/pem.h
+++ b/wolfssl/openssl/pem.h
@@ -44,11 +44,11 @@ WOLFSSL_API
 int wolfSSL_PEM_write_bio_RSAPrivateKey(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa,
                                         const EVP_CIPHER* cipher,
                                         unsigned char* passwd, int len,
-                                        pem_password_cb* cb, void* arg);
+                                        wc_pem_password_cb* cb, void* arg);
 WOLFSSL_API
 WOLFSSL_RSA* wolfSSL_PEM_read_bio_RSAPrivateKey(WOLFSSL_BIO* bio,
                                                   WOLFSSL_RSA**,
-                                                  pem_password_cb* cb,
+                                                  wc_pem_password_cb* cb,
                                                   void* arg);
 
 WOLFSSL_API
@@ -57,12 +57,12 @@ int wolfSSL_PEM_write_bio_RSA_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa);
 WOLFSSL_API
 WOLFSSL_RSA *wolfSSL_PEM_read_bio_RSA_PUBKEY(WOLFSSL_BIO* bio,
                                              WOLFSSL_RSA** rsa,
-                                             pem_password_cb* cb, void *u);
+                                             wc_pem_password_cb* cb, void *u);
 
 WOLFSSL_API
 WOLFSSL_EC_GROUP* wolfSSL_PEM_read_bio_ECPKParameters(WOLFSSL_BIO* bio,
                                                       WOLFSSL_EC_GROUP** group,
-                                                      pem_password_cb* cb,
+                                                      wc_pem_password_cb* cb,
                                                       void* pass);
 WOLFSSL_API
 int wolfSSL_PEM_write_mem_RSAPrivateKey(RSA* rsa, const EVP_CIPHER* cipher,
@@ -73,10 +73,10 @@ WOLFSSL_API
 int wolfSSL_PEM_write_RSAPrivateKey(XFILE fp, WOLFSSL_RSA *rsa,
                                     const EVP_CIPHER *enc,
                                     unsigned char *kstr, int klen,
-                                    pem_password_cb *cb, void *u);
+                                    wc_pem_password_cb *cb, void *u);
 WOLFSSL_API
 WOLFSSL_RSA *wolfSSL_PEM_read_RSAPublicKey(XFILE fp, WOLFSSL_RSA **x,
-                                           pem_password_cb *cb, void *u);
+                                           wc_pem_password_cb *cb, void *u);
 WOLFSSL_API
 int wolfSSL_PEM_write_RSAPublicKey(XFILE fp, WOLFSSL_RSA *x);
 
@@ -90,16 +90,19 @@ int wolfSSL_PEM_write_bio_DSAPrivateKey(WOLFSSL_BIO* bio,
                                         WOLFSSL_DSA* dsa,
                                         const EVP_CIPHER* cipher,
                                         unsigned char* passwd, int len,
-                                        pem_password_cb* cb, void* arg);
+                                        wc_pem_password_cb* cb, void* arg);
 
 WOLFSSL_API
 WOLFSSL_DSA* wolfSSL_PEM_read_bio_DSAPrivateKey(WOLFSSL_BIO* bio,
                                                 WOLFSSL_DSA** dsa,
-                                                pem_password_cb* cb,void *pass);
+                                                wc_pem_password_cb* cb,
+                                                void *pass);
 
 WOLFSSL_API
-WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSA_PUBKEY(WOLFSSL_BIO* bio,WOLFSSL_DSA** dsa,
-                                               pem_password_cb* cb, void *pass);
+WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSA_PUBKEY(WOLFSSL_BIO* bio,
+                                             WOLFSSL_DSA** dsa,
+                                             wc_pem_password_cb* cb,
+                                             void *pass);
 
 WOLFSSL_API
 int wolfSSL_PEM_write_bio_DSA_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_DSA* dsa);
@@ -114,7 +117,7 @@ WOLFSSL_API
 int wolfSSL_PEM_write_DSAPrivateKey(XFILE fp, WOLFSSL_DSA *dsa,
                                     const EVP_CIPHER *enc,
                                     unsigned char *kstr, int klen,
-                                    pem_password_cb *cb, void *u);
+                                    wc_pem_password_cb *cb, void *u);
 WOLFSSL_API
 int wolfSSL_PEM_write_DSA_PUBKEY(XFILE fp, WOLFSSL_DSA *x);
 #endif /* NO_FILESYSTEM */
@@ -124,11 +127,11 @@ WOLFSSL_API
 int wolfSSL_PEM_write_bio_ECPrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EC_KEY* ec,
                                        const EVP_CIPHER* cipher,
                                        unsigned char* passwd, int len,
-                                       pem_password_cb* cb, void* arg);
+                                       wc_pem_password_cb* cb, void* arg);
 WOLFSSL_API
 WOLFSSL_EC_KEY* wolfSSL_PEM_read_bio_ECPrivateKey(WOLFSSL_BIO* bio,
                                                   WOLFSSL_EC_KEY** ec,
-                                                  pem_password_cb* cb,
+                                                  wc_pem_password_cb* cb,
                                                   void *pass);
 WOLFSSL_API
 int wolfSSL_PEM_write_bio_EC_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_EC_KEY* ec);
@@ -143,31 +146,33 @@ WOLFSSL_API
 int wolfSSL_PEM_write_ECPrivateKey(XFILE fp, WOLFSSL_EC_KEY *key,
                                    const EVP_CIPHER *enc,
                                    unsigned char *kstr, int klen,
-                                   pem_password_cb *cb, void *u);
+                                   wc_pem_password_cb *cb, void *u);
 WOLFSSL_API
 int wolfSSL_PEM_write_EC_PUBKEY(XFILE fp, WOLFSSL_EC_KEY *key);
 
 WOLFSSL_API
 WOLFSSL_EC_KEY* wolfSSL_PEM_read_bio_EC_PUBKEY(WOLFSSL_BIO* bio,
                                                WOLFSSL_EC_KEY** ec,
-                                               pem_password_cb* cb, void *pass);
+                                               wc_pem_password_cb* cb,
+                                               void *pass);
 #endif /* NO_FILESYSTEM */
 
 /* EVP_KEY */
 WOLFSSL_API
 WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PrivateKey(WOLFSSL_BIO* bio,
                                                   WOLFSSL_EVP_PKEY**,
-                                                  pem_password_cb* cb,
+                                                  wc_pem_password_cb* cb,
                                                   void* arg);
 WOLFSSL_API
 WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_bio_PUBKEY(WOLFSSL_BIO* bio,
                                               WOLFSSL_EVP_PKEY **key,
-                                              pem_password_cb *cb, void *pass);
+                                              wc_pem_password_cb *cb,
+                                              void *pass);
 WOLFSSL_API
 int wolfSSL_PEM_write_bio_PrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key,
                                         const WOLFSSL_EVP_CIPHER* cipher,
                                         unsigned char* passwd, int len,
-                                        pem_password_cb* cb, void* arg);
+                                        wc_pem_password_cb* cb, void* arg);
 WOLFSSL_API
 int wolfSSL_PEM_write_bio_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key);
 
@@ -191,13 +196,13 @@ int wolfSSL_PEM_write(XFILE fp, const char *name, const char *header,
 #if !defined(NO_FILESYSTEM)
 WOLFSSL_API
 WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_PUBKEY(XFILE fp, EVP_PKEY **x,
-                                          pem_password_cb *cb, void *u);
+                                          wc_pem_password_cb *cb, void *u);
 WOLFSSL_API
 WOLFSSL_X509 *wolfSSL_PEM_read_X509(XFILE fp, WOLFSSL_X509 **x,
-                                          pem_password_cb *cb, void *u);
+                                          wc_pem_password_cb *cb, void *u);
 WOLFSSL_API
 WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_PrivateKey(XFILE fp, WOLFSSL_EVP_PKEY **x,
-                                          pem_password_cb *cb, void *u);
+                                          wc_pem_password_cb *cb, void *u);
 
 WOLFSSL_API
 int wolfSSL_PEM_write_X509(XFILE fp, WOLFSSL_X509 *x);

--- a/wolfssl/openssl/sha3.h
+++ b/wolfssl/openssl/sha3.h
@@ -36,7 +36,6 @@
     extern "C" {
 #endif
 
-
 /* Using ALIGN16 because when AES-NI is enabled digest and buffer in Sha3
  * struct are 16 byte aligned. Any dereference to those elements after casting
  * to Sha3 is expected to also be 16 byte aligned addresses.  */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -78,14 +78,6 @@
         #include <openssl/bn.h>
     #endif
 
-    /* make sure old names are disabled */
-    #ifndef NO_OLD_SSL_NAMES
-        #define NO_OLD_SSL_NAMES
-    #endif
-    #ifndef NO_OLD_WC_NAMES
-        #define NO_OLD_WC_NAMES
-    #endif
-
 #elif (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
     #include <wolfssl/openssl/compat_types.h>
     #include <wolfssl/openssl/bn.h>
@@ -1931,8 +1923,8 @@ WOLFSSL_API void* wolfSSL_get_ex_data(const WOLFSSL*, int);
 WOLFSSL_API void wolfSSL_CTX_set_default_passwd_cb_userdata(WOLFSSL_CTX*,
                                                           void* userdata);
 WOLFSSL_API void wolfSSL_CTX_set_default_passwd_cb(WOLFSSL_CTX*,
-                                                   pem_password_cb*);
-WOLFSSL_API pem_password_cb* wolfSSL_CTX_get_default_passwd_cb(WOLFSSL_CTX *ctx);
+                                                   wc_pem_password_cb*);
+WOLFSSL_API wc_pem_password_cb* wolfSSL_CTX_get_default_passwd_cb(WOLFSSL_CTX*);
 WOLFSSL_API void *wolfSSL_CTX_get_default_passwd_cb_userdata(WOLFSSL_CTX *ctx);
 
 WOLFSSL_API void wolfSSL_CTX_set_info_callback(WOLFSSL_CTX*,
@@ -4036,31 +4028,31 @@ WOLFSSL_API int wolfSSL_CTX_get_min_proto_version(WOLFSSL_CTX*);
 WOLFSSL_API int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx,
     WOLFSSL_EVP_PKEY *pkey);
 WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509(WOLFSSL_BIO *bp,
-    WOLFSSL_X509 **x, pem_password_cb *cb, void *u);
+    WOLFSSL_X509 **x, wc_pem_password_cb *cb, void *u);
 #ifdef WOLFSSL_CERT_REQ
 WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_REQ(WOLFSSL_BIO *bp,
-    WOLFSSL_X509 **x, pem_password_cb *cb, void *u);
+    WOLFSSL_X509 **x, wc_pem_password_cb *cb, void *u);
 #ifndef NO_FILESYSTEM
 WOLFSSL_API WOLFSSL_X509* wolfSSL_PEM_read_X509_REQ(XFILE, WOLFSSL_X509**,
-    pem_password_cb*, void*);
+    wc_pem_password_cb*, void*);
 #endif
 #endif
 WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_PEM_read_bio_X509_CRL(WOLFSSL_BIO *bp,
-        WOLFSSL_X509_CRL **x, pem_password_cb *cb, void *u);
+        WOLFSSL_X509_CRL **x, wc_pem_password_cb *cb, void *u);
 WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
-        (WOLFSSL_BIO *bp, WOLFSSL_X509 **x, pem_password_cb *cb, void *u);
+        (WOLFSSL_BIO *bp, WOLFSSL_X509 **x, wc_pem_password_cb *cb, void *u);
 WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509_INFO)* wolfSSL_PEM_X509_INFO_read_bio(
         WOLFSSL_BIO* bio, WOLF_STACK_OF(WOLFSSL_X509_INFO)* sk,
-        pem_password_cb* cb, void* u);
+        wc_pem_password_cb* cb, void* u);
 #ifndef NO_FILESYSTEM
 WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_PEM_read_X509_CRL(XFILE fp,
-        WOLFSSL_X509_CRL **x, pem_password_cb *cb, void *u);
+        WOLFSSL_X509_CRL **x, wc_pem_password_cb *cb, void *u);
 #endif
 WOLFSSL_API int wolfSSL_PEM_get_EVP_CIPHER_INFO(const char* header,
                                                 EncryptedInfo* cipher);
 WOLFSSL_API int wolfSSL_PEM_do_header(EncryptedInfo* cipher,
                                       unsigned char* data, long* len,
-                                      pem_password_cb* callback, void* ctx);
+                                      wc_pem_password_cb* callback, void* ctx);
 #endif /* OPENSSL_EXTRA || OPENSSL_ALL */
 
 /*lighttp compatibility */
@@ -4147,13 +4139,13 @@ WOLFSSL_API WOLFSSL_BIO* wolfSSL_BIO_new_fp(XFILE fp, int c);
 
 WOLFSSL_API long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX*, WOLFSSL_DH*);
 WOLFSSL_API WOLFSSL_DH *wolfSSL_PEM_read_bio_DHparams(WOLFSSL_BIO *bp,
-    WOLFSSL_DH **x, pem_password_cb *cb, void *u);
+    WOLFSSL_DH **x, wc_pem_password_cb *cb, void *u);
 #ifndef NO_FILESYSTEM
 WOLFSSL_API WOLFSSL_DH *wolfSSL_PEM_read_DHparams(XFILE fp, WOLFSSL_DH **x,
-        pem_password_cb *cb, void *u);
+        wc_pem_password_cb *cb, void *u);
 #endif
 WOLFSSL_API WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSAparams(WOLFSSL_BIO *bp,
-    WOLFSSL_DSA **x, pem_password_cb *cb, void *u);
+    WOLFSSL_DSA **x, wc_pem_password_cb *cb, void *u);
 WOLFSSL_API int wolfSSL_PEM_write_bio_X509_REQ(WOLFSSL_BIO *bp,WOLFSSL_X509 *x);
 WOLFSSL_API int wolfSSL_PEM_write_bio_X509_AUX(WOLFSSL_BIO *bp,WOLFSSL_X509 *x);
 WOLFSSL_API int wolfSSL_PEM_write_bio_X509(WOLFSSL_BIO *bp, WOLFSSL_X509 *x);
@@ -4692,13 +4684,13 @@ WOLFSSL_API int wolfSSL_X509_get_signature_nid(const WOLFSSL_X509* x);
 
 WOLFSSL_API int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
     WOLFSSL_EVP_PKEY* pkey, const WOLFSSL_EVP_CIPHER* enc, char* passwd,
-    int passwdSz, pem_password_cb* cb, void* ctx);
+    int passwdSz, wc_pem_password_cb* cb, void* ctx);
 #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
 WOLFSSL_API int wolfSSL_PEM_write_PKCS8PrivateKey(XFILE, WOLFSSL_EVP_PKEY*,
-    const WOLFSSL_EVP_CIPHER*, char*, int, pem_password_cb*, void*);
+    const WOLFSSL_EVP_CIPHER*, char*, int, wc_pem_password_cb*, void*);
 #endif /* !NO_FILESYSTEM && !NO_STDIO_FILESYSTEM */
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_PKCS8PrivateKey_bio(WOLFSSL_BIO* bio,
-    WOLFSSL_EVP_PKEY** pkey, pem_password_cb* cb, void* u);
+    WOLFSSL_EVP_PKEY** pkey, wc_pem_password_cb* cb, void* u);
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(
     WOLFSSL_EVP_PKEY** pkey, const unsigned char** data, long length);
 

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -220,11 +220,19 @@ enum {
     PEM_PASS_WRITE = 1,
 };
 
-
-typedef int (pem_password_cb)(char* passwd, int sz, int rw, void* userdata);
+typedef int (wc_pem_password_cb)(char* passwd, int sz, int rw, void* userdata);
+#ifndef OPENSSL_COEXIST
+/* In the past, wc_pem_password_cb was called pem_password_cb, which is the same
+ * name as an identical typedef in OpenSSL. We don't want to break existing code
+ * that uses the name pem_password_cb, so we define it here as a macro alias for
+ * wc_pem_password_cb. In cases where a user needs to use both OpenSSL and
+ * wolfSSL headers in the same code, they should define OPENSSL_COEXIST to
+ * avoid errors stemming from the typedef being declared twice. */
+#define pem_password_cb wc_pem_password_cb
+#endif
 
 typedef struct EncryptedInfo {
-    pem_password_cb* passwd_cb;
+    wc_pem_password_cb* passwd_cb;
     void*            passwd_userdata;
 
     long     consumed;         /* tracks PEM bytes consumed */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2310,6 +2310,16 @@ extern void uITRON4_free(void *p) ;
     #endif
 #endif
 
+#ifdef OPENSSL_COEXIST
+    /* make sure old names are disabled */
+    #ifndef NO_OLD_SSL_NAMES
+        #define NO_OLD_SSL_NAMES
+    #endif
+    #ifndef NO_OLD_WC_NAMES
+        #define NO_OLD_WC_NAMES
+    #endif
+#endif
+
 #if defined(NO_OLD_WC_NAMES) || defined(OPENSSL_EXTRA)
     /* added to have compatibility with SHA256() */
     #if !defined(NO_OLD_SHA_NAMES) && (!defined(HAVE_FIPS) || \


### PR DESCRIPTION
Recently, we had a wolfEngine customer report a compilation error because
wolfSSL and OpenSSL both define the typedef pem_password_cb. The solution is to
namespace our typedef with the wc_ prefix. In order to not break existing code
that relies on wolfSSL providing pem_password_cb, if OPENSSL_COEXIST is not
defined, we define pem_password_cb as a macro that maps to wc_pem_password_cb.