### PR TITLE
Fix comment that applies to fp_forcezero

### DIFF
--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -426,7 +426,8 @@ typedef fp_int   mp_int;
 /* initialize [or zero] an fp int */
 void fp_init(fp_int *a);
 MP_API void fp_zero(fp_int *a);
-MP_API void fp_clear(fp_int *a); /* uses ForceZero to clear sensitive memory */
+MP_API void fp_clear(fp_int *a);
+/* uses ForceZero to clear sensitive memory */
 MP_API void fp_forcezero (fp_int * a);
 MP_API void fp_free(fp_int* a);
 


### PR DESCRIPTION
Fix comment mentioning the use of `ForceZero` besides `fp_clear`, which uses `XMEMSET`, and puts it above `fp_forcezero` where it should belong.