### PR TITLE
fix nid2oid/oid2nid for oidCertAuthInfoType

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -50716,9 +50716,9 @@ word32 nid2oid(int nid, int grp)
         /* oidCertAuthInfoType */
         case oidCertAuthInfoType:
             switch (nid) {
-                case AIA_OCSP_OID:
+                case NID_ad_OCSP:
                     return AIA_OCSP_OID;
-                case AIA_CA_ISSUER_OID:
+                case NID_ad_ca_issuers:
                     return AIA_CA_ISSUER_OID;
             }
             break;
@@ -51069,9 +51069,9 @@ int oid2nid(word32 oid, int grp)
         case oidCertAuthInfoType:
             switch (oid) {
                 case AIA_OCSP_OID:
-                    return AIA_OCSP_OID;
+                    return NID_ad_OCSP;
                 case AIA_CA_ISSUER_OID:
-                    return AIA_CA_ISSUER_OID;
+                    return NID_ad_ca_issuers;
             }
             break;
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -43795,7 +43795,7 @@ static void test_wolfSSL_X509V3_EXT(void) {
 #endif
     AssertNotNull(adObj = ad->method);
     /* Make sure nid is OCSP */
-    AssertIntEQ(wolfSSL_OBJ_obj2nid(adObj), AIA_OCSP_OID);
+    AssertIntEQ(wolfSSL_OBJ_obj2nid(adObj), NID_ad_OCSP);
 
     /* GENERAL_NAME stores URI as an ASN1_STRING */
     AssertNotNull(gn = ad->location);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -14732,7 +14732,7 @@ static int DecodeAuthInfo(const byte* input, int sz, DecodedCert* cert)
         {
             cert->extAuthInfoSz = length;
             cert->extAuthInfo = input + idx;
-        #if defined(OPENSSL_ALL) && defined(WOLFSSL_QT)
+        #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
             count++;
         #else
             break;


### PR DESCRIPTION
This PR fixes the nid2oid() and oid2nid() conversions for type oidCertAuthInfoType.  Before these changes, we were simply converting from OID to OID, not NID.

It also allows DecodeAuthInfo() to decode certs with Authority Information Access extension that have both OCSP and CA Issuer URI's listed when OPENSSL_ALL or WOLFSSL_QT are defined, not just both.

These were uncovered through Python 3.8.5 test cases.