### PR TITLE
fix wc_ERR_print_errors_fp() unit test with NO_ERROR_QUEUE

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -36995,9 +36995,16 @@ static int test_wc_ERR_print_errors_fp (void)
 #if defined(DEBUG_WOLFSSL)
     AssertTrue(XFSEEK(fp, 0, XSEEK_END) == 0);
     sz = XFTELL(fp);
+    #ifdef NO_ERROR_QUEUE
+    /* File should be empty when NO_ERROR_QUEUE is defined */
+    if (sz != 0) {
+        ret = BAD_FUNC_ARG;
+    }
+    #else
     if (sz == 0) {
         ret = BAD_FUNC_ARG;
     }
+    #endif
 #endif
     printf(resultFmt, ret == 0 ? passed : failed);
     XFCLOSE(fp);


### PR DESCRIPTION
This fixes the unit test for wc_ERR_print_errors_fp() when ```NO_ERROR_QUEUE``` is defined.

Uncovered using ```./configure --enable-jni --enable-debug```, tested as part of Jenkins **nightly-wolfssljni-jsse-extra**.