### PR TITLE
Fix for session ticket handling with error cases

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -3589,7 +3589,7 @@ static int ProcessClientHello(const byte* input, int* sslBytes,
                 inputHelloSz - bindersLen + HANDSHAKE_HEADER_SZ);
 
             /* call to decrypt session ticket */
-            if (DoClientTicket(ssl, identity, idLen) != 0) {
+            if (DoClientTicket(ssl, identity, idLen) != WOLFSSL_TICKET_RET_OK) {
                 /* we aren't decrypting the resumption, since we know the master secret */
                 /* ignore errors */
             }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4202,12 +4202,12 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
     RefineSuites(ssl, clSuites);
 
 #ifndef WOLFSSL_PSK_ONE_ID
-    if (!usingPSK)
+    if (usingPSK == NULL)
         return BAD_FUNC_ARG;
 
     if (!ssl->options.useClientOrder) {
         /* Server order - server list has only common suites from refining. */
-        for (i = 0; !*usingPSK && i < ssl->suites->suiteSz; i += 2) {
+        for (i = 0; !(*usingPSK) && i < ssl->suites->suiteSz; i += 2) {
             ret = DoPreSharedKeys(ssl, ssl->suites->suites + i, usingPSK,
                                                                         &first);
             if (ret != 0) {
@@ -4217,8 +4217,8 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
     }
     else {
         /* Client order */
-        for (j = 0; !*usingPSK && j < clSuites->suiteSz; j += 2) {
-            for (i = 0; !*usingPSK && i < ssl->suites->suiteSz; i += 2) {
+        for (j = 0; !(*usingPSK) && j < clSuites->suiteSz; j += 2) {
+            for (i = 0; !(*usingPSK) && i < ssl->suites->suiteSz; i += 2) {
             ret = DoPreSharedKeys(ssl, ssl->suites->suites + i, usingPSK,
                                                                         &first);
                 if (ret != 0)
@@ -4237,7 +4237,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
     if (ret != 0)
         return ret;
 
-    if (usingPSK) {
+    if (*usingPSK != 0) {
         word16 modes;
     #ifdef WOLFSSL_EARLY_DATA
         TLSX*  extEarlyData;


### PR DESCRIPTION
Session ticket callback return code failures were still trying to do resumption. Behavior broken in PR #3827.

To reproduce build with `WOLFSSL_NO_DEF_TICKET_ENC_CB` and modify the `myTicketEncCb` to return `WOLFSSL_TICKET_RET_REJECT`, which should not use ticket and treat as new connection. Instead it will cause TLS handshake to fail because it attempts to use resumption and will affect additional connections to server instance.

Reported: https://www.wolfssl.com/forums/topic1821-wolfssl-481-invalid-client-ticket-handshake-failure.html