### PR TITLE
Fixes and refactor for static ephemeral key support

### DIFF
--- a/IDE/GCC-ARM/Source/tls_client.c
+++ b/IDE/GCC-ARM/Source/tls_client.c
@@ -100,7 +100,7 @@ static int tls_client(void)
     /*---------------------*/
     /* for no peer auth:   */
     /*---------------------*/
-    wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, 0);
+    wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, NULL);
     /*---------------------*/
     /* end peer auth option*/
     /*---------------------*/

--- a/IDE/GCC-ARM/Source/tls_server.c
+++ b/IDE/GCC-ARM/Source/tls_server.c
@@ -99,7 +99,7 @@ static int tls_server(void)
     /*---------------------*/
     /* for no peer auth:   */
     /*---------------------*/
-    wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, 0);
+    wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, NULL);
     /*---------------------*/
     /* end peer auth option*/
     /*---------------------*/

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you want to mimic OpenSSL behavior of having `SSL_connect` succeed even if
 verifying the server fails and reducing security you can do this by calling:
 
 ```c
-wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0);
+wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, NULL);
 ```
 
 before calling `wolfSSL_new();`. Though it's not recommended.

--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -1078,10 +1078,10 @@ WOLFSSL_API int wc_PubKeyPemToDer(const unsigned char*, int,
     \code
     char * file = “./certs/client-cert.pem”;
     int derSz;
-    byte * der = (byte*)XMALLOC(EIGHTK_BUF, NULL, DYNAMIC_TYPE_CERT);
+    byte* der = (byte*)XMALLOC((8*1024), NULL, DYNAMIC_TYPE_CERT);
 
-    derSz = wc_PemCertToDer(file, der, EIGHTK_BUF);
-    if(derSz <= 0) {
+    derSz = wc_PemCertToDer(file, der, (8*1024));
+    if (derSz <= 0) {
         //PemCertToDer error
     }
     \endcode

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -2513,8 +2513,8 @@ WOLFSSL_API
     \code
     WOLFSSL_CTX*    ctx    = 0;
     ...
-    wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_PEER |
-                     SSL_VERIFY_FAIL_IF_NO_PEER_CERT, 0);
+    wolfSSL_CTX_set_verify(ctx, (WOLFSSL_VERIFY_PEER |
+                           WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT), NULL);
     \endcode
 
     \sa wolfSSL_set_verify

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -3062,7 +3062,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, myVerify);
     }
     else if (!usePsk && !useAnon && doPeerCheck == 0) {
-        wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, 0);
+        wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, NULL);
     }
     else if (!usePsk && !useAnon && myVerifyAction == VERIFY_OVERRIDE_DATE_ERR) {
         wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_PEER, myVerify);
@@ -3191,7 +3191,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     }
 
     #if defined(WOLFSSL_MDK_ARM)
-    wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, 0);
+    wolfSSL_CTX_set_verify(ctx, WOLFSSL_VERIFY_NONE, NULL);
     #endif
 
     #if defined(OPENSSL_EXTRA)

--- a/src/internal.c
+++ b/src/internal.c
@@ -2408,6 +2408,9 @@ void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
     #ifdef HAVE_CURVE25519
     FreeDer(&ctx->staticKE.x25519Key);
     #endif
+    #ifdef HAVE_CURVE448
+    FreeDer(&ctx->staticKE.x448Key);
+    #endif
     #ifndef SINGLE_THREADED
     if (ctx->staticKELockInit) {
         wc_FreeMutex(&ctx->staticKELock);
@@ -7204,6 +7207,9 @@ void SSL_ResourceFree(WOLFSSL* ssl)
     #endif
     #ifdef HAVE_CURVE25519
     FreeDer(&ssl->staticKE.x25519Key);
+    #endif
+    #ifdef HAVE_CURVE448
+    FreeDer(&ssl->staticKE.x448Key);
     #endif
 #endif
 

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -2595,6 +2595,7 @@ static int SetupKeys(const byte* input, int* sslBytes, SnifferSession* session,
         }
 #endif
 
+        ret = 0;
 #ifdef WOLFSSL_SNIFFER_KEY_CALLBACK
         if (KeyCb != NULL && ksInfo) {
             if (keyBuf == NULL) {
@@ -2701,6 +2702,7 @@ static int SetupKeys(const byte* input, int* sslBytes, SnifferSession* session,
         }
 #endif
 
+        ret = 0;
 #ifdef WOLFSSL_SNIFFER_KEY_CALLBACK
         if (KeyCb != NULL && ksInfo) {
             if (keyBuf == NULL) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17762,6 +17762,11 @@ cleanup:
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || \
     defined(HAVE_SECRET_CALLBACK)
 #if !defined(NO_WOLFSSL_SERVER)
+/* Return the amount of random bytes copied over or error case.
+ * ssl : ssl struct after handshake
+ * out : buffer to hold random bytes
+ * outSz : either 0 (return max buffer sz) or size of out buffer
+ */
 size_t wolfSSL_get_server_random(const WOLFSSL *ssl, unsigned char *out,
                                                                    size_t outSz)
 {
@@ -17776,7 +17781,7 @@ size_t wolfSSL_get_server_random(const WOLFSSL *ssl, unsigned char *out,
         return 0;
     }
 
-    if (ssl->options.saveArrays == 0 || ssl->arrays == NULL) {
+    if (ssl->arrays == NULL) {
         WOLFSSL_MSG("Arrays struct not saved after handshake");
         return 0;
     }
@@ -18497,8 +18502,6 @@ int wolfSSL_CTX_get_max_proto_version(WOLFSSL_CTX* ctx)
  * ssl : ssl struct after handshake
  * out : buffer to hold random bytes
  * outSz : either 0 (return max buffer sz) or size of out buffer
- *
- * NOTE: wolfSSL_KeepArrays(ssl) must be called to retain handshake information.
  */
 size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
                                                                    size_t outSz)
@@ -18514,7 +18517,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         return 0;
     }
 
-    if (ssl->options.saveArrays == 0 || ssl->arrays == NULL) {
+    if (ssl->arrays == NULL) {
         WOLFSSL_MSG("Arrays struct not saved after handshake");
         return 0;
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -55599,7 +55599,7 @@ int wolfSSL_X509_REQ_set_pubkey(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey)
 #ifdef WOLFSSL_STATIC_EPHEMERAL
 int wolfSSL_StaticEphemeralKeyLoad(WOLFSSL* ssl, int keyAlgo, void* keyPtr)
 {
-    int ret = BUFFER_E;
+    int ret;
     word32 idx = 0;
     DerBuffer* der = NULL;
 
@@ -55617,6 +55617,7 @@ int wolfSSL_StaticEphemeralKeyLoad(WOLFSSL* ssl, int keyAlgo, void* keyPtr)
     }
 #endif
 
+    ret = BUFFER_E; /* set default error */
     switch (keyAlgo) {
     #ifndef NO_DH
         case WC_PK_TYPE_DH:

--- a/src/tls.c
+++ b/src/tls.c
@@ -6412,7 +6412,14 @@ static int TLSX_KeyShare_GenX448Key(WOLFSSL *ssl, KeyShareEntry* kse)
         ret = wc_curve448_init((curve448_key*)kse->key);
         if (ret == 0) {
             key = (curve448_key*)kse->key;
-            ret = wc_curve448_make_key(ssl->rng, CURVE448_KEY_SIZE, key);
+
+            #ifdef WOLFSSL_STATIC_EPHEMERAL
+            ret = wolfSSL_StaticEphemeralKeyLoad(ssl, WC_PK_TYPE_CURVE448, kse->key);
+            if (ret != 0)
+        #endif
+            {
+                ret = wc_curve448_make_key(ssl->rng, CURVE448_KEY_SIZE, key);
+            }
         }
     }
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -19721,11 +19721,10 @@ int wc_PubKeyPemToDer(const unsigned char* pem, int pemSz,
 #endif /* WOLFSSL_CERT_EXT || WOLFSSL_PUB_PEM_TO_DER */
 #endif /* WOLFSSL_PEM_TO_DER */
 
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && defined(WOLFSSL_PEM_TO_DER)
 
 #ifdef WOLFSSL_CERT_GEN
-/* load pem cert from file into der buffer, return der size or error */
-int wc_PemCertToDer(const char* fileName, unsigned char* derBuf, int derSz)
+int wc_PemCertToDer_ex(const char* fileName, DerBuffer** der)
 {
 #ifdef WOLFSSL_SMALL_STACK
     byte   staticBuffer[1]; /* force XMALLOC */
@@ -19737,7 +19736,6 @@ int wc_PemCertToDer(const char* fileName, unsigned char* derBuf, int derSz)
     int    ret     = 0;
     long   sz      = 0;
     XFILE  file;
-    DerBuffer* converted = NULL;
 
     WOLFSSL_ENTER("wc_PemCertToDer");
 
@@ -19752,8 +19750,9 @@ int wc_PemCertToDer(const char* fileName, unsigned char* derBuf, int derSz)
     }
 
     if (ret == 0) {
-        if(XFSEEK(file, 0, XSEEK_END) != 0)
+        if (XFSEEK(file, 0, XSEEK_END) != 0) {
             ret = BUFFER_E;
+        }
         sz = XFTELL(file);
         XREWIND(file);
 
@@ -19763,35 +19762,23 @@ int wc_PemCertToDer(const char* fileName, unsigned char* derBuf, int derSz)
         else if (sz > (long)sizeof(staticBuffer)) {
         #ifdef WOLFSSL_STATIC_MEMORY
             WOLFSSL_MSG("File was larger then static buffer");
-            return MEMORY_E;
-        #endif
+            ret = MEMORY_E;
+        #else
             fileBuf = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE);
             if (fileBuf == NULL)
                 ret = MEMORY_E;
             else
                 dynamic = 1;
+        #endif
         }
 
         if (ret == 0) {
             if ((size_t)XFREAD(fileBuf, 1, sz, file) != (size_t)sz) {
                 ret = BUFFER_E;
             }
-        #ifdef WOLFSSL_PEM_TO_DER
             else {
-                ret = PemToDer(fileBuf, sz, CA_TYPE, &converted,  0, NULL,NULL);
+                ret = PemToDer(fileBuf, sz, CA_TYPE, der,  0, NULL,NULL);
             }
-        #endif
-
-            if (ret == 0) {
-                if (converted->length < (word32)derSz) {
-                    XMEMCPY(derBuf, converted->buffer, converted->length);
-                    ret = converted->length;
-                }
-                else
-                    ret = BUFFER_E;
-            }
-
-            FreeDer(&converted);
         }
 
         XFCLOSE(file);
@@ -19801,12 +19788,29 @@ int wc_PemCertToDer(const char* fileName, unsigned char* derBuf, int derSz)
 
     return ret;
 }
+/* load pem cert from file into der buffer, return der size or error */
+int wc_PemCertToDer(const char* fileName, unsigned char* derBuf, int derSz)
+{
+    int ret;
+    DerBuffer* converted = NULL;
+    ret = wc_PemCertToDer_ex(fileName, &converted);
+    if (ret == 0) {
+        if (converted->length < (word32)derSz) {
+            XMEMCPY(derBuf, converted->buffer, converted->length);
+            ret = converted->length;
+        }
+        else
+            ret = BUFFER_E;
+
+        FreeDer(&converted);
+    }
+    return ret;
+}
 #endif /* WOLFSSL_CERT_GEN */
 
 #if defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER)
 /* load pem public key from file into der buffer, return der size or error */
-int wc_PemPubKeyToDer(const char* fileName,
-                           unsigned char* derBuf, int derSz)
+int wc_PemPubKeyToDer_ex(const char* fileName, DerBuffer** der)
 {
 #ifdef WOLFSSL_SMALL_STACK
     byte   staticBuffer[1]; /* force XMALLOC */
@@ -19818,7 +19822,6 @@ int wc_PemPubKeyToDer(const char* fileName,
     int    ret     = 0;
     long   sz      = 0;
     XFILE  file;
-    DerBuffer* converted = NULL;
 
     WOLFSSL_ENTER("wc_PemPubKeyToDer");
 
@@ -19833,8 +19836,9 @@ int wc_PemPubKeyToDer(const char* fileName,
     }
 
     if (ret == 0) {
-        if(XFSEEK(file, 0, XSEEK_END) != 0)
+        if (XFSEEK(file, 0, XSEEK_END) != 0) {
             ret = BUFFER_E;
+        }
         sz = XFTELL(file);
         XREWIND(file);
 
@@ -19844,47 +19848,55 @@ int wc_PemPubKeyToDer(const char* fileName,
         else if (sz > (long)sizeof(staticBuffer)) {
         #ifdef WOLFSSL_STATIC_MEMORY
             WOLFSSL_MSG("File was larger then static buffer");
-            return MEMORY_E;
-        #endif
+            ret = MEMORY_E;
+        #else
             fileBuf = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE);
             if (fileBuf == NULL)
                 ret = MEMORY_E;
             else
                 dynamic = 1;
+        #endif
         }
         if (ret == 0) {
             if ((size_t)XFREAD(fileBuf, 1, sz, file) != (size_t)sz) {
                 ret = BUFFER_E;
             }
-        #ifdef WOLFSSL_PEM_TO_DER
             else {
-                ret = PemToDer(fileBuf, sz, PUBLICKEY_TYPE, &converted,
+                ret = PemToDer(fileBuf, sz, PUBLICKEY_TYPE, der,
                                0, NULL, NULL);
             }
-        #endif
-
-            if (ret == 0) {
-                if (converted->length < (word32)derSz) {
-                    XMEMCPY(derBuf, converted->buffer, converted->length);
-                    ret = converted->length;
-                }
-                else
-                    ret = BUFFER_E;
-            }
-
-            FreeDer(&converted);
         }
 
         XFCLOSE(file);
-        if (dynamic)
+        if (dynamic) {
             XFREE(fileBuf, NULL, DYNAMIC_TYPE_FILE);
+        }
     }
 
     return ret;
 }
+/* load pem public key from file into der buffer, return der size or error */
+int wc_PemPubKeyToDer(const char* fileName,
+                           unsigned char* derBuf, int derSz)
+{
+    int ret;
+    DerBuffer* converted = NULL;
+    ret = wc_PemPubKeyToDer_ex(fileName, &converted);
+    if (ret == 0) {
+        if (converted->length < (word32)derSz) {
+            XMEMCPY(derBuf, converted->buffer, converted->length);
+            ret = converted->length;
+        }
+        else
+            ret = BUFFER_E;
+
+        FreeDer(&converted);
+    }
+    return ret;
+}
 #endif /* WOLFSSL_CERT_EXT || WOLFSSL_PUB_PEM_TO_DER */
 
-#endif /* !NO_FILESYSTEM */
+#endif /* !NO_FILESYSTEM && WOLFSSL_PEM_TO_DER */
 
 
 #if !defined(NO_RSA) && (defined(WOLFSSL_CERT_GEN) || \
@@ -25118,27 +25130,17 @@ int wc_SetAuthKeyIdFromCert(Cert *cert, const byte *der, int derSz)
 int wc_SetAuthKeyId(Cert *cert, const char* file)
 {
     int         ret;
-    int         derSz;
-    byte*       der;
+    DerBuffer*  der = NULL;
 
     if (cert == NULL || file == NULL)
         return BAD_FUNC_ARG;
 
-    der = (byte*)XMALLOC(EIGHTK_BUF, cert->heap, DYNAMIC_TYPE_CERT);
-    if (der == NULL) {
-        WOLFSSL_MSG("wc_SetAuthKeyId OOF Problem");
-        return MEMORY_E;
-    }
-
-    derSz = wc_PemCertToDer(file, der, EIGHTK_BUF);
-    if (derSz <= 0)
+    ret = wc_PemCertToDer_ex(file, &der);
+    if (ret == 0)
     {
-        XFREE(der, cert->heap, DYNAMIC_TYPE_CERT);
-        return derSz;
+        ret = wc_SetAuthKeyIdFromCert(cert, der->buffer, der->length);
+        FreeDer(&der);
     }
-
-    ret = wc_SetAuthKeyIdFromCert(cert, der, derSz);
-    XFREE(der, cert->heap, DYNAMIC_TYPE_CERT);
 
     return ret;
 }
@@ -25516,22 +25518,18 @@ static int SetNameFromCert(CertName* cn, const byte* der, int derSz)
 int wc_SetIssuer(Cert* cert, const char* issuerFile)
 {
     int         ret;
-    int         derSz;
-    byte*       der;
+    DerBuffer*  der = NULL;
 
-    if (cert == NULL) {
+    if (cert == NULL || issuerFile == NULL)
         return BAD_FUNC_ARG;
-    }
 
-    der = (byte*)XMALLOC(EIGHTK_BUF, cert->heap, DYNAMIC_TYPE_CERT);
-    if (der == NULL) {
-        WOLFSSL_MSG("wc_SetIssuer OOF Problem");
-        return MEMORY_E;
+    ret = wc_PemCertToDer_ex(issuerFile, &der);
+    if (ret == 0) {
+        cert->selfSigned = 0;
+        ret = SetNameFromCert(&cert->issuer, der->buffer, der->length);
+
+        FreeDer(&der);
     }
-    derSz = wc_PemCertToDer(issuerFile, der, EIGHTK_BUF);
-    cert->selfSigned = 0;
-    ret = SetNameFromCert(&cert->issuer, der, derSz);
-    XFREE(der, cert->heap, DYNAMIC_TYPE_CERT);
 
     return ret;
 }
@@ -25541,22 +25539,17 @@ int wc_SetIssuer(Cert* cert, const char* issuerFile)
 int wc_SetSubject(Cert* cert, const char* subjectFile)
 {
     int         ret;
-    int         derSz;
-    byte*       der;
+    DerBuffer*  der = NULL;
 
-    if (cert == NULL) {
+    if (cert == NULL || subjectFile == NULL)
         return BAD_FUNC_ARG;
-    }
 
-    der = (byte*)XMALLOC(EIGHTK_BUF, cert->heap, DYNAMIC_TYPE_CERT);
-    if (der == NULL) {
-        WOLFSSL_MSG("wc_SetSubject OOF Problem");
-        return MEMORY_E;
-    }
+    ret = wc_PemCertToDer_ex(subjectFile, &der);
+    if (ret == 0) {
+        ret = SetNameFromCert(&cert->subject, der->buffer, der->length);
 
-    derSz = wc_PemCertToDer(subjectFile, der, EIGHTK_BUF);
-    ret = SetNameFromCert(&cert->subject, der, derSz);
-    XFREE(der, cert->heap, DYNAMIC_TYPE_CERT);
+        FreeDer(&der);
+    }
 
     return ret;
 }
@@ -25567,21 +25560,18 @@ int wc_SetSubject(Cert* cert, const char* subjectFile)
 int wc_SetAltNames(Cert* cert, const char* file)
 {
     int         ret;
-    int         derSz;
-    byte*       der;
+    DerBuffer*  der = NULL;
 
     if (cert == NULL) {
         return BAD_FUNC_ARG;
     }
 
-    der = (byte*)XMALLOC(EIGHTK_BUF, cert->heap, DYNAMIC_TYPE_CERT);
-    if (der == NULL) {
-        WOLFSSL_MSG("wc_SetAltNames OOF Problem");
-        return MEMORY_E;
+    ret = wc_PemCertToDer_ex(file, &der);
+    if (ret == 0) {
+        ret = SetAltNamesFromCert(cert, der->buffer, der->length);
+
+        FreeDer(&der);
     }
-    derSz = wc_PemCertToDer(file, der, EIGHTK_BUF);
-    ret = SetAltNamesFromCert(cert, der, derSz);
-    XFREE(der, cert->heap, DYNAMIC_TYPE_CERT);
 
     return ret;
 }

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -26,6 +26,7 @@
 
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/logging.h>
 
 #ifndef NO_KDF
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2731,6 +2731,9 @@ typedef struct {
 #ifdef HAVE_CURVE25519
     DerBuffer* x25519Key;
 #endif
+#ifdef HAVE_CURVE448
+    DerBuffer* x448Key;
+#endif
 } StaticKeyExchangeInfo_t;
 #endif /* WOLFSSL_STATIC_EPHEMERAL */
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2731,19 +2731,8 @@ typedef struct {
 #ifdef HAVE_CURVE25519
     DerBuffer* x25519Key;
 #endif
-
-    /* bits */
-#ifndef NO_DH
-    byte weOwnDH:1;
-#endif
-#ifdef HAVE_ECC
-    byte weOwnEC:1;
-#endif
-#ifdef HAVE_CURVE25519
-    byte weOwnX25519:1;
-#endif
 } StaticKeyExchangeInfo_t;
-#endif
+#endif /* WOLFSSL_STATIC_EPHEMERAL */
 
 
 /* wolfSSL context type */
@@ -2846,6 +2835,10 @@ struct WOLFSSL_CTX {
 #ifdef WOLFSSL_STATIC_MEMORY
     byte        onHeapHint:1; /* whether the ctx/method is put on heap hint */
 #endif
+#if defined(WOLFSSL_STATIC_EPHEMERAL) && !defined(SINGLE_THREADED)
+    byte        staticKELockInit:1;
+#endif
+
 #ifdef WOLFSSL_MULTICAST
     byte        haveMcast;        /* multicast requested */
     byte        mcastID;          /* multicast group ID */
@@ -3074,6 +3067,9 @@ struct WOLFSSL_CTX {
 #endif /* OPENSSL_EXTRA && HAVE_SECRET_CALLBACK */
 #ifdef WOLFSSL_STATIC_EPHEMERAL
     StaticKeyExchangeInfo_t staticKE;
+    #ifndef SINGLE_THREADED
+    wolfSSL_Mutex staticKELock;
+    #endif
 #endif
 };
 
@@ -5027,6 +5023,10 @@ WOLFSSL_LOCAL int wolfSSL_sk_BY_DIR_entry_push(WOLF_STACK_OF(wolfSSL_BY_DIR_entr
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 WOLFSSL_LOCAL int oid2nid(word32 oid, int grp);
 WOLFSSL_LOCAL word32 nid2oid(int nid, int grp);
+#endif
+
+#ifdef WOLFSSL_STATIC_EPHEMERAL
+WOLFSSL_LOCAL int wolfSSL_StaticEphemeralKeyLoad(WOLFSSL* ssl, int keyAlgo, void* keyPtr);
 #endif
 
 #ifdef __cplusplus

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -894,7 +894,6 @@ enum Misc_ASN {
     OCSP_NONCE_EXT_SZ   = 35,      /* OCSP Nonce Extension size */
     MAX_OCSP_EXT_SZ     = 58,      /* Max OCSP Extension length */
     MAX_OCSP_NONCE_SZ   = 16,      /* OCSP Nonce size           */
-    EIGHTK_BUF          = 8192,    /* Tmp buffer size           */
     MAX_PUBLIC_KEY_SZ   = MAX_DSA_PUBKEY_SZ + MAX_ALGO_SZ + MAX_SEQ_SZ * 2,
 #ifdef WOLFSSL_ENCRYPTED_KEYS
     HEADER_ENCRYPTED_KEY_SIZE = 88,/* Extra header size for encrypted key */

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -535,9 +535,10 @@ WOLFSSL_API void wc_FreeDer(DerBuffer** pDer);
 #endif /* WOLFSSL_PEM_TO_DER */
 
 #if defined(WOLFSSL_CERT_EXT) || defined(WOLFSSL_PUB_PEM_TO_DER)
-    #ifndef NO_FILESYSTEM
+    #if !defined(NO_FILESYSTEM) && defined(WOLFSSL_PEM_TO_DER)
         WOLFSSL_API int wc_PemPubKeyToDer(const char* fileName,
                                           unsigned char* derBuf, int derSz);
+        WOLFSSL_API int wc_PemPubKeyToDer_ex(const char* fileName, DerBuffer** der);
     #endif
 
     WOLFSSL_API int wc_PubKeyPemToDer(const unsigned char*, int,
@@ -545,9 +546,10 @@ WOLFSSL_API void wc_FreeDer(DerBuffer** pDer);
 #endif /* WOLFSSL_CERT_EXT || WOLFSSL_PUB_PEM_TO_DER */
 
 #ifdef WOLFSSL_CERT_GEN
-    #ifndef NO_FILESYSTEM
+    #if !defined(NO_FILESYSTEM) && defined(WOLFSSL_PEM_TO_DER)
         WOLFSSL_API int wc_PemCertToDer(const char* fileName,
                                         unsigned char* derBuf, int derSz);
+        WOLFSSL_API int wc_PemCertToDer_ex(const char* fileName, DerBuffer** der);
     #endif
 #endif /* WOLFSSL_CERT_GEN */
 


### PR DESCRIPTION
* Added x448 static ephemeral support.
* Refactor of the static ephemeral key internals and addition of mutex protection.
* Fix for possible use after free if loaded in CTX and used in SSL then reloaded in CTX.
* Fix to allow calls to get TLS session random even if `wolfSSL_KeepArrays` has not been called.
* Eliminate `EIGHTK_BUF` use in asn.
* Cleanup uses of `0` in set_verify for callback.