### PR TITLE
Fixes for NXP SE050 ECC create and key store id

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1451,6 +1451,9 @@ AC_ARG_WITH([se050],
             # Requires AES direct
             AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_DIRECT"
 
+            # Does not support SHA2-512 224/256
+            AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_NOSHA512_224 -DWOLFSSL_NOSHA512_256"
+
             AC_MSG_RESULT([yes])
         else
             AC_MSG_RESULT([yes])

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -68,7 +68,7 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
 #ifdef WOLFSSL_IMXRT_DCP
     #include <wolfssl/wolfcrypt/port/nxp/dcp_port.h>
 #endif
-#ifdef WOLFSSL_SE050
+#if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_CRYPT)
     #include <wolfssl/wolfcrypt/port/nxp/se050_port.h>
 #endif
 
@@ -867,7 +867,7 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
 #elif defined(WOLFSSL_DEVCRYPTO_AES)
     /* implemented in wolfcrypt/src/port/devcrypto/devcrypto_aes.c */
 
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_CRYPT)
     static int AES_ECB_encrypt(Aes* aes, const byte* inBlock, byte* outBlock,
         int sz)
     {
@@ -2598,7 +2598,7 @@ static void wc_AesDecrypt(Aes* aes, const byte* inBlock, byte* outBlock)
         return wc_AesSetKey(aes, userKey, keylen, iv, dir);
     }
 
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_CRYPT)
     int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen, const byte* iv,
                   int dir)
     {   
@@ -3876,7 +3876,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 #elif defined(WOLFSSL_DEVCRYPTO_CBC)
     /* implemented in wolfcrypt/src/port/devcrypt/devcrypto_aes.c */
 
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_CRYPT)
     int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     {
         return se050_aes_crypt(aes, in, out, sz, AES_ENCRYPTION,
@@ -10363,7 +10363,7 @@ void wc_AesFree(Aes* aes)
     }
 #endif
 
-#if defined(WOLFSSL_SE050)
+#if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_CRYPT)
     se050_aes_free(aes);
 #endif
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -7094,12 +7094,16 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
     defined(WOLFSSL_CRYPTOCELL) || defined(WOLFSSL_SILABS_SE_ACCEL) || \
     defined(WOLFSSL_KCAPI_ECC) || defined(WOLFSSL_SE050)
-    /* Extract R and S */
-    err = mp_to_unsigned_bin(r, &sigRS[0]);
+
+    /* Extract R and S with front zero padding (if required) */
+    XMEMSET(sigRS, 0, keySz * 2);
+    err = mp_to_unsigned_bin(r, sigRS +
+                                (keySz - mp_unsigned_bin_size(r)));
     if (err != MP_OKAY) {
         return err;
     }
-    err = mp_to_unsigned_bin(s, &sigRS[keySz]);
+    err = mp_to_unsigned_bin(s, sigRS + keySz +
+                                (keySz - mp_unsigned_bin_size(s)));
     if (err != MP_OKAY) {
         return err;
     }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -8513,7 +8513,7 @@ int wc_ecc_get_generator(ecc_point* ecp, int curve_idx)
  * checks on the bounds of the private key. */
 static int _ecc_validate_public_key(ecc_key* key, int partial, int priv)
 {
-    int    err = MP_OKAY;
+    int err = MP_OKAY;
 #ifndef WOLFSSL_SP_MATH
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
     !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
@@ -8680,11 +8680,11 @@ static int _ecc_validate_public_key(ecc_key* key, int partial, int priv)
 
     FREE_CURVE_SPECS();
 #endif /* WOLFSSL_ATECC508A */
+#else
+    err = WC_KEY_SIZE_E;
+#endif /* !WOLFSSL_SP_MATH */
     (void)partial;
     (void)priv;
-#else
-    return WC_KEY_SIZE_E;
-#endif /* !WOLFSSL_SP_MATH */
     return err;
 }
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1218,7 +1218,7 @@ static int wc_ecc_export_x963_compressed(ecc_key*, byte* out, word32* outLen);
 
 #if (defined(WOLFSSL_VALIDATE_ECC_KEYGEN) || !defined(WOLFSSL_SP_MATH)) && \
     !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
-    !defined(WOLFSSL_CRYPTOCELL)
+    !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SE050)
 static int ecc_check_pubkey_order(ecc_key* key, ecc_point* pubkey, mp_int* a,
         mp_int* prime, mp_int* order);
 #endif
@@ -8052,7 +8052,7 @@ int wc_ecc_export_x963_ex(ecc_key* key, byte* out, word32* outLen,
 
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
-    !defined(WOLFSSL_CRYPTOCELL)
+    !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SE050)
 
 /* is ecc point on curve described by dp ? */
 int wc_ecc_is_point(ecc_point* ecp, mp_int* a, mp_int* b, mp_int* prime)
@@ -8516,7 +8516,8 @@ static int _ecc_validate_public_key(ecc_key* key, int partial, int priv)
     int    err = MP_OKAY;
 #ifndef WOLFSSL_SP_MATH
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
-    !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SILABS_SE_ACCEL)
+    !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
+    !defined(WOLFSSL_SE050)
     mp_int* b = NULL;
     #ifdef USE_ECC_B_PARAM
         DECLARE_CURVE_SPECS(curve, 4);
@@ -8527,7 +8528,7 @@ static int _ecc_validate_public_key(ecc_key* key, int partial, int priv)
         DECLARE_CURVE_SPECS(curve, 3);
     #endif /* USE_ECC_B_PARAM */
 #endif /* !WOLFSSL_ATECC508A && !WOLFSSL_ATECC608A && 
-          !WOLFSSL_CRYPTOCELL && !WOLFSSL_SILABS_SE_ACCEL */
+          !WOLFSSL_CRYPTOCELL && !WOLFSSL_SILABS_SE_ACCEL && !WOLFSSL_SE050 */
 #endif /* !WOLFSSL_SP_MATH */
 
     ASSERT_SAVED_VECTOR_REGISTERS();
@@ -8558,7 +8559,8 @@ static int _ecc_validate_public_key(ecc_key* key, int partial, int priv)
 
 #ifndef WOLFSSL_SP_MATH
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A) || \
-    defined(WOLFSSL_CRYPTOCELL) || defined(WOLFSSL_SILABS_SE_ACCEL)
+    defined(WOLFSSL_CRYPTOCELL) || defined(WOLFSSL_SILABS_SE_ACCEL) || \
+    defined(WOLFSSL_SE050)
 
     /* consider key check success on HW crypto 
      * ex: ATECC508/608A, CryptoCell and Silabs */
@@ -8678,9 +8680,9 @@ static int _ecc_validate_public_key(ecc_key* key, int partial, int priv)
 
     FREE_CURVE_SPECS();
 #endif /* WOLFSSL_ATECC508A */
-#else
     (void)partial;
     (void)priv;
+#else
     return WC_KEY_SIZE_E;
 #endif /* !WOLFSSL_SP_MATH */
     return err;

--- a/wolfcrypt/src/port/nxp/README.md
+++ b/wolfcrypt/src/port/nxp/README.md
@@ -42,7 +42,7 @@ make
 ``
 
 Where `PATH` is the directory location of `simw-top`.
-Example: `./configure --enable-debug --disable-shared --with-se050=/home/pi/simw-top CFLAGS="-DWOLFSSL_SE050_INIT"`
+Example: `./configure --with-se050=/home/pi/simw-top CFLAGS="-DWOLFSSL_SE050_INIT"`
 
 To enable AES Cipher support use `WOLFSSL_SE050_CRYPT`
 To enable SHA-1 and SHA-2 support use `WOLFSSL_SE050_HASH`

--- a/wolfcrypt/src/port/nxp/README.md
+++ b/wolfcrypt/src/port/nxp/README.md
@@ -44,6 +44,9 @@ make
 Where `PATH` is the directory location of `simw-top`.
 Example: `./configure --enable-debug --disable-shared --with-se050=/home/pi/simw-top CFLAGS="-DWOLFSSL_SE050_INIT"`
 
+To enable AES Cipher support use `WOLFSSL_SE050_CRYPT`
+To enable SHA-1 and SHA-2 support use `WOLFSSL_SE050_HASH`
+
 ## Building Examples
 
 Confirm that you are able to run the examples from the directory:

--- a/wolfcrypt/src/port/nxp/se050_port.c
+++ b/wolfcrypt/src/port/nxp/se050_port.c
@@ -60,10 +60,6 @@ struct ecc_key;
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
 
-/* AES 55 = keyStoreId - Implementation specific ID */
-/* ECC SIGN 56 = keyStoreId - Implementation specific ID */
-/* ECC VERIFY 57 = keyStoreId - Implementation specific ID */
-/* ED25519 58 = keyStoreId - Implementation specific ID */
 
 /* Global variables */
 static sss_session_t *cfg_se050_i2c_pi;
@@ -116,17 +112,9 @@ int se050_allocate_key(int keyType)
     static int keyId_allocator = 100;
     switch (keyType) {
         case SE050_AES_KEY:
-            keyId = SE050_KEYID_AES;
-            break;
         case SE050_ECC_SIGN:
-            keyId = SE050_KEYID_ECC_SIGN;
-            break;
         case SE050_ECC_VERIFY:
-            keyId = SE050_KEYID_ECC_VERIFY;
-            break;
         case SE050_ED25519:
-            keyId = SE050_KEYID_ED25519;
-            break;
         case SE050_KEYID_ANY:
             keyId = keyId_allocator++;
             break;
@@ -277,7 +265,7 @@ int se050_aes_set_key(Aes* aes, const byte* key, word32 len,
     status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
 
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_allocate(&host_keystore, 55);
+        status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_AES);
     }
 
     if (status == kStatus_SSS_Success) {
@@ -332,7 +320,7 @@ int se050_aes_crypt(Aes* aes, const byte* in, byte* out, word32 sz, int dir,
     status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
 
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_allocate(&host_keystore, 55);
+        status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_AES);
     }
 
     if (status == kStatus_SSS_Success) {
@@ -389,7 +377,7 @@ void se050_aes_free(Aes* aes)
     status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
 
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_allocate(&host_keystore, 55);
+        status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_AES);
     }
 
     if (status == kStatus_SSS_Success) {
@@ -447,7 +435,7 @@ int se050_ecc_sign_hash_ex(const byte* in, word32 inLen, byte* out,
     status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
 
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_allocate(&host_keystore, 70);
+        status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_ECC);
     }
 
     if (status == kStatus_SSS_Success) {
@@ -550,7 +538,7 @@ int se050_ecc_verify_hash_ex(const byte* hash, word32 hashLen, byte* signature,
 
         status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
         if (status == kStatus_SSS_Success) {
-            status = sss_key_store_allocate(&host_keystore, 61);
+            status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_ECC);
         }
         if (status == kStatus_SSS_Success) {
             status = sss_key_object_init(&newKey, &host_keystore);
@@ -586,7 +574,7 @@ int se050_ecc_verify_hash_ex(const byte* hash, word32 hashLen, byte* signature,
         status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
 
         if (status == kStatus_SSS_Success) {
-            status = sss_key_store_allocate(&host_keystore, 60);
+            status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_ECC);
         }
         if (status == kStatus_SSS_Success) {
             status = sss_key_object_init(&newKey, &host_keystore);
@@ -641,7 +629,7 @@ int se050_ecc_free_key(struct ecc_key* key)
     status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
 
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_allocate(&host_keystore, 60);
+        status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_ECC);
     }
     if (status == kStatus_SSS_Success) {
         status = sss_key_object_init(&keyObject, &host_keystore);
@@ -666,7 +654,7 @@ int se050_ecc_create_key(struct ecc_key* key, int curve_id, int keySize)
     sss_object_t    keyPair;
     sss_key_store_t host_keystore;
     int keyId = se050_allocate_key(SE050_KEYID_ANY);
-    uint8_t keyPairExport[MAX_ECC_BYTES];
+    uint8_t keyPairExport[MAX_ECC_BYTES*2];
     size_t keyPairExportLen = sizeof(keyPairExport);
     size_t keyPairExportBitLen = sizeof(keyPairExport) * 8;
     int ret;
@@ -684,19 +672,19 @@ int se050_ecc_create_key(struct ecc_key* key, int curve_id, int keySize)
 
     status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_allocate(&host_keystore, 60);
+        status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_ECC);
     }
     if (status == kStatus_SSS_Success) {
         status = sss_key_object_init(&keyPair, &host_keystore);
     }
     if (status == kStatus_SSS_Success) {
         status = sss_key_object_allocate_handle(&keyPair, keyId,
-            kSSS_KeyPart_Pair, kSSS_CipherType_EC_NIST_P, 256,
+            kSSS_KeyPart_Pair, kSSS_CipherType_EC_NIST_P, keySize*8,
             kKeyObject_Mode_None);
     }
     if (status == kStatus_SSS_Success) {
         status = sss_key_store_generate_key(&host_keystore, &keyPair,
-            256, NULL);
+            keySize*8, NULL);
     }
     if (status == kStatus_SSS_Success) {
         status = sss_key_store_get_key(&host_keystore, &keyPair,
@@ -749,7 +737,7 @@ int se050_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key,
 
     status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_allocate(&host_keystore, 60);
+        status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_ECC);
     }
 
     if (status == kStatus_SSS_Success) {
@@ -765,7 +753,7 @@ int se050_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key,
     }
 
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_allocate(&host_keystore_2, 60);
+        status = sss_key_store_allocate(&host_keystore_2, SE050_KEYSTOREID_ECC);
     }
 
     if (status == kStatus_SSS_Success) {
@@ -844,7 +832,7 @@ int se050_ed25519_create_key(ed25519_key* key)
 
     status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_allocate(&host_keystore, 55);
+        status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_ED25519);
     }
 
     if (status == kStatus_SSS_Success) {
@@ -894,7 +882,7 @@ void se050_ed25519_free_key(ed25519_key* key)
     status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
 
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_allocate(&host_keystore, 55);
+        status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_ED25519);
     }
     if (status == kStatus_SSS_Success) {
         status = sss_key_object_init(&newKey, &host_keystore);
@@ -931,7 +919,7 @@ int se050_ed25519_sign_msg(const byte* in, word32 inLen, byte* out,
     status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
 
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_allocate(&host_keystore, 55);
+        status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_ED25519);
     }
 
     if (status == kStatus_SSS_Success) {
@@ -989,7 +977,7 @@ int se050_ed25519_verify_msg(const byte* signature, word32 signatureLen,
     status = sss_key_store_context_init(&host_keystore, cfg_se050_i2c_pi);
 
     if (status == kStatus_SSS_Success) {
-        status = sss_key_store_allocate(&host_keystore, 61);
+        status = sss_key_store_allocate(&host_keystore, SE050_KEYSTOREID_ED25519);
     }
 
     if (status == kStatus_SSS_Success) {

--- a/wolfcrypt/src/sha.c
+++ b/wolfcrypt/src/sha.c
@@ -336,7 +336,7 @@
 #elif defined(WOLFSSL_SILABS_SE_ACCEL)
 
     /* implemented in wolfcrypt/src/port/silabs/silabs_hash.c */
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
 
     #include <wolfssl/wolfcrypt/port/nxp/se050_port.h>
     int wc_InitSha_ex(wc_Sha* sha, void* heap, int devId)
@@ -846,7 +846,7 @@ void wc_ShaFree(wc_Sha* sha)
 #ifdef WOLFSSL_PIC32MZ_HASH
     wc_ShaPic32Free(sha);
 #endif
-#ifdef WOLFSSL_SE050
+#if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
    se050_hash_free(&sha->se050Ctx);
 #endif
 #if (defined(WOLFSSL_RENESAS_TSIP_CRYPT) && \

--- a/wolfcrypt/src/sha256.c
+++ b/wolfcrypt/src/sha256.c
@@ -184,7 +184,7 @@ where 0 <= L < 2^64.
     (!defined(WOLFSSL_ESP32WROOM32_CRYPT) || defined(NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH)) && \
     (!defined(WOLFSSL_RENESAS_TSIP_CRYPT) || defined(NO_WOLFSSL_RENESAS_TSIP_HASH)) && \
     !defined(WOLFSSL_PSOC6_CRYPTO) && !defined(WOLFSSL_IMXRT_DCP) && !defined(WOLFSSL_SILABS_SE_ACCEL) && \
-    !defined(WOLFSSL_KCAPI_HASH) && !defined(WOLFSSL_SE050)
+    !defined(WOLFSSL_KCAPI_HASH) && !defined(WOLFSSL_SE050_HASH)
 
 
 static int InitSha256(wc_Sha256* sha256)
@@ -585,7 +585,7 @@ static int InitSha256(wc_Sha256* sha256)
     !defined(WOLFSSL_QNX_CAAM)
     /* functions defined in wolfcrypt/src/port/caam/caam_sha256.c */
 
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
 
     #include <wolfssl/wolfcrypt/port/nxp/se050_port.h>
     int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
@@ -1411,7 +1411,7 @@ static int InitSha256(wc_Sha256* sha256)
 
         return ret;
     }
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
 
     #include <wolfssl/wolfcrypt/port/nxp/se050_port.h>
     int wc_InitSha224_ex(wc_Sha224* sha224, void* heap, int devId)

--- a/wolfcrypt/src/sha512.c
+++ b/wolfcrypt/src/sha512.c
@@ -49,7 +49,7 @@
     #include <wolfssl/wolfcrypt/cryptocb.h>
 #endif
 
-#ifdef WOLFSSL_SE050
+#if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
     #include <wolfssl/wolfcrypt/port/nxp/se050_port.h>
 #endif
 
@@ -203,7 +203,7 @@
 #elif defined(WOLFSSL_KCAPI_HASH)
     /* functions defined in wolfcrypt/src/port/kcapi/kcapi_hash.c */
 
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
     int wc_InitSha512(wc_Sha512* sha512)
     {
         if (sha512 == NULL)
@@ -952,7 +952,7 @@ int wc_Sha512Update(wc_Sha512* sha512, const byte* data, word32 len)
 
 #if defined(WOLFSSL_KCAPI_HASH)
     /* functions defined in wolfcrypt/src/port/kcapi/kcapi_hash.c */
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
 
 #else
 
@@ -1063,7 +1063,7 @@ static WC_INLINE int Sha512Final(wc_Sha512* sha512)
 
 #if defined(WOLFSSL_KCAPI_HASH)
     /* functions defined in wolfcrypt/src/port/kcapi/kcapi_hash.c */
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
 
 #else
 
@@ -1135,7 +1135,7 @@ int wc_Sha512Final(wc_Sha512* sha512, byte* hash)
 
 #endif /* WOLFSSL_KCAPI_HASH */
 
-#ifndef WOLFSSL_SE050
+#if !defined(WOLFSSL_SE050) || !defined(WOLFSSL_SE050_HASH)
 int wc_InitSha512(wc_Sha512* sha512)
 {
     return wc_InitSha512_ex(sha512, NULL, INVALID_DEVID);
@@ -1217,7 +1217,7 @@ int wc_Sha512Transform(wc_Sha512* sha, const unsigned char* data)
 }
 #endif /* OPENSSL_EXTRA */
 #endif /* WOLFSSL_SHA512 */
-#endif /* !WOLFSSL_SE050 */
+#endif /* !WOLFSSL_SE050 || !WOLFSSL_SE050_HASH */
 
 
 /* -------------------------------------------------------------------------- */
@@ -1228,7 +1228,7 @@ int wc_Sha512Transform(wc_Sha512* sha, const unsigned char* data)
 #if defined(WOLFSSL_IMX6_CAAM) && !defined(NO_IMX6_CAAM_HASH) && \
     !defined(WOLFSSL_QNX_CAAM)
     /* functions defined in wolfcrypt/src/port/caam/caam_sha.c */
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
     int wc_InitSha384_ex(wc_Sha384* sha384, void* heap, int devId)
     {
         if (sha384 == NULL) {
@@ -1566,7 +1566,7 @@ int wc_Sha512_224Update(wc_Sha512* sha, const byte* data, word32 len)
 
 #if defined(WOLFSSL_KCAPI_HASH)
     /* functions defined in wolfcrypt/src/port/kcapi/kcapi_hash.c */
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
 
 #else
 int wc_Sha512_224FinalRaw(wc_Sha512* sha, byte* hash)
@@ -1585,7 +1585,7 @@ void wc_Sha512_224Free(wc_Sha512* sha)
 }
 #if defined(WOLFSSL_KCAPI_HASH)
     /* functions defined in wolfcrypt/src/port/kcapi/kcapi_hash.c */
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
 
 
 #else
@@ -1630,7 +1630,7 @@ int wc_Sha512_256Update(wc_Sha512* sha, const byte* data, word32 len)
 }
 #if defined(WOLFSSL_KCAPI_HASH)
     /* functions defined in wolfcrypt/src/port/kcapi/kcapi_hash.c */
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
 
 #else
 int wc_Sha512_256FinalRaw(wc_Sha512* sha, byte* hash)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -22692,9 +22692,7 @@ static int ecc_sig_test(WC_RNG* rng, ecc_key* key)
 }
 #endif
 
-#if defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT) && \
-    !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
-    !defined(WOLFSSL_QNX_CAAM)
+#if defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT)
 
 static int ecc_exp_imp_test(ecc_key* key)
 {
@@ -22824,8 +22822,6 @@ done:
 }
 #endif /* HAVE_ECC_KEY_IMPORT && HAVE_ECC_KEY_EXPORT */
 
-#if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
-    !defined(WOLFSSL_CRYPTOCELL) && !defined(WOLFSSL_QNX_CAAM)
 #if defined(HAVE_ECC_KEY_IMPORT) && !defined(WOLFSSL_VALIDATE_ECC_IMPORT)
 static int ecc_mulmod_test(ecc_key* key1)
 {
@@ -22937,7 +22933,6 @@ static int ecc_ssh_test(ecc_key* key, WC_RNG* rng)
     return 0;
 }
 #endif /* HAVE_ECC_DHE && !WC_NO_RNG */
-#endif
 
 static int ecc_def_curve_test(WC_RNG *rng)
 {
@@ -22991,11 +22986,14 @@ static int ecc_def_curve_test(WC_RNG *rng)
     if (ret < 0)
         goto done;
     #endif
+
+    wc_ecc_free(key);
 #else
     (void)rng;
 #endif /* !WC_NO_RNG */
 
-#if defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT)
+#if (defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT)) || \
+    (defined(HAVE_ECC_KEY_IMPORT) && !defined(WOLFSSL_VALIDATE_ECC_IMPORT))
     /* Use test ECC key - ensure real private "d" exists */
     #ifdef USE_CERT_BUFFERS_256
     ret = wc_EccPrivateKeyDecode(ecc_key_der_256, &idx, key,
@@ -23017,24 +23015,27 @@ static int ecc_def_curve_test(WC_RNG *rng)
         goto done;
     }
 
+#if defined(HAVE_ECC_KEY_IMPORT) && defined(HAVE_ECC_KEY_EXPORT)
     ret = ecc_exp_imp_test(key);
     if (ret < 0)
         goto done;
+#endif
+#if defined(HAVE_ECC_KEY_IMPORT) && !defined(WOLFSSL_VALIDATE_ECC_IMPORT)
     ret = ecc_mulmod_test(key);
     if (ret < 0)
         goto done;
 #endif
+#endif
 
 done:
 
+    wc_ecc_free(key);
 #ifdef WOLFSSL_SMALL_STACK
-    if (key != NULL) {
-        wc_ecc_free(key);
+    if (key != NULL) {    
         XFREE(key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     }
-#else
-    wc_ecc_free(key);
 #endif
+
     return ret;
 }
 #endif /* !NO_ECC256 || HAVE_ALL_CURVES */

--- a/wolfssl/wolfcrypt/port/nxp/se050_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/se050_port.h
@@ -65,15 +65,16 @@
 #endif
 
 enum {
-    SSS_BLOCK_SIZE = 512
+    SSS_BLOCK_SIZE = 512,
+
+    SSS_MAX_ECC_BITS = 521
 };
 
 enum SE050KeyType {
-    SE050_KEYID_ANY,
+    SE050_ANY_KEY,
     SE050_AES_KEY,
-    SE050_ECC_SIGN,
-    SE050_ECC_VERIFY,
-    SE050_ED25519,
+    SE050_ECC_KEY,
+    SE050_ED25519_KEY
 };
 
 
@@ -132,7 +133,7 @@ WOLFSSL_LOCAL int se050_ecc_verify_hash_ex(const byte* hash, word32 hashlen,
 WOLFSSL_LOCAL int se050_ecc_create_key(struct ecc_key* key, int curve_id, int keySize);
 WOLFSSL_LOCAL int se050_ecc_shared_secret(struct ecc_key* private_key,
     struct ecc_key* public_key, byte* out, word32* outlen);
-WOLFSSL_LOCAL int se050_ecc_free_key(struct ecc_key* key);
+WOLFSSL_LOCAL void se050_ecc_free_key(struct ecc_key* key);
 
 struct ed25519_key;
 WOLFSSL_LOCAL int se050_ed25519_create_key(struct ed25519_key* key);

--- a/wolfssl/wolfcrypt/port/nxp/se050_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/se050_port.h
@@ -128,7 +128,7 @@ WOLFSSL_LOCAL int se050_ecc_sign_hash_ex(const byte* in, word32 inLen,
     byte* out, word32 *outLen, struct ecc_key* key);
 
 WOLFSSL_LOCAL int se050_ecc_verify_hash_ex(const byte* hash, word32 hashlen,
-    byte* signature, word32 signatureLen, struct ecc_key* key, int* res);
+    byte* sigRS, word32 sigRSLen, struct ecc_key* key, int* res);
 
 WOLFSSL_LOCAL int se050_ecc_create_key(struct ecc_key* key, int curve_id, int keySize);
 WOLFSSL_LOCAL int se050_ecc_shared_secret(struct ecc_key* private_key,

--- a/wolfssl/wolfcrypt/port/nxp/se050_port.h
+++ b/wolfssl/wolfcrypt/port/nxp/se050_port.h
@@ -54,19 +54,15 @@
 
 
 /* Default key ID's */
-#ifndef SE050_KEYID_AES
-#define SE050_KEYID_AES        55
+#ifndef SE050_KEYSTOREID_AES
+#define SE050_KEYSTOREID_AES     55
 #endif
-#ifndef SE050_KEYID_ECC_SIGN
-#define SE050_KEYID_ECC_SIGN   56
+#ifndef SE050_KEYSTOREID_ED25519
+#define SE050_KEYSTOREID_ED25519 58
 #endif
-#ifndef SE050_KEYID_ECC_VERIFY 
-#define SE050_KEYID_ECC_VERIFY 57
+#ifndef SE050_KEYSTOREID_ECC
+#define SE050_KEYSTOREID_ECC     60
 #endif
-#ifndef SE050_KEYID_ED25519
-#define SE050_KEYID_ED25519    58
-#endif
-
 
 enum {
     SSS_BLOCK_SIZE = 512

--- a/wolfssl/wolfcrypt/sha.h
+++ b/wolfssl/wolfcrypt/sha.h
@@ -110,7 +110,7 @@ enum {
     #include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
 #else
 
-#if defined(WOLFSSL_SE050)
+#if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
     #include "wolfssl/wolfcrypt/port/nxp/se050_port.h"
 #endif
 
@@ -118,7 +118,7 @@ enum {
 struct wc_Sha {
 #ifdef FREESCALE_LTC_SHA
         ltc_hash_ctx_t ctx;
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
         SE050_HASH_Context se050Ctx;
 #elif defined(STM32_HASH)
         STM32_HASH_Context stmCtx;

--- a/wolfssl/wolfcrypt/sha256.h
+++ b/wolfssl/wolfcrypt/sha256.h
@@ -144,7 +144,7 @@ enum {
     #include "wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h"
 #else
 
-#if defined(WOLFSSL_SE050)
+#if defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
     #include "wolfssl/wolfcrypt/port/nxp/se050_port.h"
 #endif
 
@@ -152,7 +152,7 @@ enum {
 struct wc_Sha256 {
 #ifdef FREESCALE_LTC_SHA
     ltc_hash_ctx_t ctx;
-#elif defined(WOLFSSL_SE050)
+#elif defined(WOLFSSL_SE050) && defined(WOLFSSL_SE050_HASH)
     SE050_HASH_Context se050Ctx;
 #elif defined(STM32_HASH_SHA2)
     STM32_HASH_Context stmCtx;


### PR DESCRIPTION
Fix for ECC create key public export size and key size bits. Fix for key store ID vs key ID.