### PR TITLE
Seperate `bio->num` into `len` and `fd` fields

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -58108,7 +58108,7 @@ int wolfSSL_CONF_cmd(WOLFSSL_CONF_CTX* cctx, const char* cmd, const char* value)
             bio->method = method;
 #endif
             bio->shutdown = BIO_CLOSE; /* default to close things */
-            bio->len = WOLFSSL_BIO_ERROR;
+            bio->len = 0;
             bio->fd = WOLFSSL_BIO_ERROR;
             bio->init = 1;
             if (method->type == WOLFSSL_BIO_MEMORY ||

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -529,7 +529,9 @@ struct WOLFSSL_BIO {
     int          wrIdx;         /* current index for write buffer */
     int          rdIdx;         /* current read index */
     int          readRq;        /* read request */
-    int          num;           /* socket num or length */
+    int          len;           /* length of buffered data */
+    int          fd;            /* file descriptor. May be used for a file
+                                 * or a socket. */
     int          eof;           /* eof flag */
     int          flags;
     byte         type;          /* method type */


### PR DESCRIPTION
- This makes interpreting the value easier and safer. No need to worry about which type of value is being stored.
- `bio->num` is removed to catch any configurations where `bio->num` hasn't been updated to the appropriate value