### PR TITLE
linuxkm updateFipsHash()

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -29018,7 +29018,7 @@ void wolfSSL_ASN1_TYPE_set(WOLFSSL_ASN1_TYPE *a, int type, void *value)
     }
     switch (type) {
         case V_ASN1_NULL:
-            a->value.ptr = value;
+            a->value.ptr = (char *)value;
             break;
         case V_ASN1_SEQUENCE:
             a->value.asn1_string = (WOLFSSL_ASN1_STRING*)value;
@@ -29276,9 +29276,9 @@ int wolfSSL_X509_PUBKEY_set(WOLFSSL_X509_PUBKEY **x, WOLFSSL_EVP_PKEY *key)
     if (!wolfSSL_X509_ALGOR_set0(pk->algor, wolfSSL_OBJ_nid2obj(key->type), ptype, pval)) {
         WOLFSSL_MSG("Failed to create algorithm object");
         if (ptype == V_ASN1_OBJECT)
-            ASN1_OBJECT_free(pval);
+            ASN1_OBJECT_free((WOLFSSL_ASN1_OBJECT *)pval);
         else
-            ASN1_STRING_free(pval);
+            ASN1_STRING_free((WOLFSSL_ASN1_STRING *)pval);
         goto error;
     }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -55956,7 +55956,7 @@ static int GetStaticEphemeralKey(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
     if (keySz) *keySz = 0;
 
 #ifndef SINGLE_THREADED
-    if (ctx->staticKELockInit && 
+    if (ctx->staticKELockInit &&
         (ret = wc_LockMutex(&ctx->staticKELock)) != 0) {
         return ret;
     }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -13679,7 +13679,7 @@ static int MatchBaseName(int type, const char* name, int nameSz,
     if (base == NULL || baseSz <= 0 || name == NULL || nameSz <= 0 ||
             name[0] == '.' || nameSz < baseSz ||
             (type != ASN_RFC822_TYPE && type != ASN_DNS_TYPE &&
-	     type != ASN_DIR_TYPE)) {
+             type != ASN_DIR_TYPE)) {
         return 0;
     }
 


### PR DESCRIPTION
logic around `WOLFCRYPT_FIPS_CORE_DYNAMIC_HASH_VALUE`.

also a couple fixes around `WOLFSSL_LINUXKM_SIMD_X86_IRQ_ALLOWED`.

also some whitespace cleanup and g++ compilability fixes in ssl.c and asn.c.

companion to a fips PR that will post momentarily.
