### PR TITLE
Make fixes/improvements to TLS PRF code.

### DIFF
--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -130,11 +130,17 @@ int wc_PRF(byte* result, word32 resLen, const byte* secret,
 
     #ifndef NO_SHA
         case sha_mac:
-        default:
             hash = WC_SHA;
             len  = WC_SHA_DIGEST_SIZE;
         break;
     #endif
+        default:
+        #ifdef WOLFSSL_SMALL_STACK
+            if (previous) XFREE(previous, heap, DYNAMIC_TYPE_DIGEST);
+            if (current)  XFREE(current,  heap, DYNAMIC_TYPE_DIGEST);
+            if (hmac)     XFREE(hmac,     heap, DYNAMIC_TYPE_HMAC);
+        #endif
+            return HASH_TYPE_E;
     }
 
     times   = resLen / len;
@@ -321,13 +327,16 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
         FREE_VAR(labelSeed, heap);
     #endif
     }
-#ifndef NO_OLD_TLS
     else {
+#ifndef NO_OLD_TLS
         /* compute TLSv1 PRF (pseudo random function using HMAC) */
         ret = wc_PRF_TLSv1(digest, digLen, secret, secLen, label, labLen, seed,
                           seedLen, heap, devId);
-    }
+#else
+        ret = BAD_FUNC_ARG;
 #endif
+    }
+
 
     return ret;
 }


### PR DESCRIPTION
Make `wc_PRF` return an error if it doesn't find a corresponding hash for the
passed in hash type. Currently, if `wc_PRF_TLS` is called with `NO_OLD_TLS`
defined, it will do nothing but still return success. Make it return an error
instead. These problems were uncovered when running the wolfEngine unit tests
with wolfSSL 5.0.0 FIPS Ready, which defines `NO_MD5` and `NO_OLD_TLS`.