### PR TITLE
fix compilation with define __fallthrough__

### DIFF
--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -315,7 +315,7 @@ decouple library dependencies with standard string, memory and so on.
                 #if defined(WOLFSSL_LINUXKM) && defined(fallthrough)
                     #define FALL_THROUGH fallthrough
                 #else
-                    #define FALL_THROUGH ; __attribute__ ((fallthrough))
+                    #define FALL_THROUGH ; __attribute__ ((__fallthrough__))
                 #endif
             #endif
         #endif


### PR DESCRIPTION
Fix compilation under OE (aarch64 gcc 11.2). The original error:
|/usr/include/optee/export-user_ta/include/compiler.h:259:21: error: expected ')' before '__attribute__'
|   259 | #define fallthrough __attribute__((__fallthrough__))
|       |                     ^~~~~~~~~~~~~
| ./lib/wolf/wolf_symlink/wolfssl/wolfcrypt/types.h:184:50: note: in expansion of macro 'fallthrough'
|   184 |             #define FALL_THROUGH __attribute__ ((fallthrough));
|       |                                                  ^~~~~~~~~~~
| lib/wolf/wolf_symlink/wolfcrypt/src/ecc.c:2980:13: note: in expansion of macro 'FALL_THROUGH'
|  2980 |             FALL_THROUGH;
|       |             ^~~~~~~~~~~~
| In file included from ./lib/wolf/wolf_symlink/wolfssl/wolfcrypt/ecc.h:26,
|                  from lib/wolf/wolf_symlink/wolfcrypt/src/ecc.c:106:
| ./lib/wolf/wolf_symlink/wolfssl/wolfcrypt/types.h:184:62: error: expected identifier or '(' before ')' token
|   184 |             #define FALL_THROUGH __attribute__ ((fallthrough));
|       |                                                              ^
| lib/wolf/wolf_symlink/wolfcrypt/src/ecc.c:2980:13: note: in expansion of macro 'FALL_THROUGH'
|  2980 |             FALL_THROUGH;

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>