### PR TITLE
Fixes for building wolfSSL with Android WPA Supplicant and KeyStore

### DIFF
--- a/IDE/Android/Android.bp
+++ b/IDE/Android/Android.bp
@@ -17,6 +17,11 @@ cc_library_shared {
         "-DWOLFSSL_USER_SETTINGS",
         "-Os",
         "-fomit-frame-pointer",
+
+        /* If using WOLFSSL_ARMASM then add these cflags for ARM crypto extensions */
+        /* "-mcpu=cortex-a73+crypto", */
+        /* "-march=armv8-a", */
+        /* "-mstrict-align", */
     ],
     include_dirs: [
         "external/wolfssl/wolfssl",
@@ -72,6 +77,7 @@ cc_library_shared {
         "./wolfcrypt/src/hmac.c",
         "./wolfcrypt/src/idea.c",
         "./wolfcrypt/src/integer.c",
+        "./wolfcrypt/src/kdf.c",
         "./wolfcrypt/src/logging.c",
         "./wolfcrypt/src/md2.c",
         "./wolfcrypt/src/md4.c",

--- a/IDE/Android/user_settings.h
+++ b/IDE/Android/user_settings.h
@@ -8,12 +8,32 @@
     #define HAVE_FIPS
 #endif
 
+#ifdef __aarch64__
+    #if !defined(__clang__) || \
+        (defined(__clang__) && defined(__clang_major__) && __clang_major__ >= 5)
+        /* older clang v4 has issue with inline assembly contraints */
+        #define WOLFSSL_ARMASM
+    #endif
+#endif
+
+#if 1 /* SP Assembly Speedups (wPAA) */
+    #define WOLFSSL_SP
+    #define WOLFSSL_SP_SMALL      /* use smaller version of code */
+    #define WOLFSSL_HAVE_SP_RSA
+    #define WOLFSSL_HAVE_SP_DH
+    #define WOLFSSL_HAVE_SP_ECC
+    #ifdef WOLFSSL_ARMASM
+        #define WOLFSSL_SP_ARM64_ASM
+    #endif
+#endif
+
 /* WPA Supplicant Support */
 #define WOLFSSL_WPAS_SMALL
 #define OPENSSL_ALL
 #define HAVE_THREAD_LS
 
 #define USE_FAST_MATH
+#define FP_MAX_BITS (4096*2) /* Maximum math bits (Max RSA key bits * 2) */
 #define TFM_TIMING_RESISTANT
 #define ECC_TIMING_RESISTANT
 #define WC_RSA_BLINDING
@@ -22,8 +42,8 @@
 
 #if 1
     #define WOLFSSL_TLS13
-    #define WC_RSA_PSS
 #endif
+#define WC_RSA_PSS
 #define HAVE_SESSION_TICKET
 #define HAVE_TLS_EXTENSIONS
 #define HAVE_SUPPORTED_CURVES
@@ -58,7 +78,10 @@
 #define WOLFSSL_KEY_GEN
 #define WC_RSA_NO_PADDING
 
+#define WOLFSSL_DH_CONST
 #define HAVE_FFDHE_2048
+#define HAVE_FFDHE_3072
+#define HAVE_FFDHE_4096
 #define HAVE_DH_DEFAULT_PARAMS
 #ifdef HAVE_FIPS
     #define WOLFSSL_VALIDATE_FFC_IMPORT
@@ -68,6 +91,9 @@
 #define WOLFSSL_SHA224
 #define WOLFSSL_SHA512
 #define WOLFSSL_SHA384
+#define WOLFSSL_NOSHA512_256
+#define WOLFSSL_NOSHA512_224
+#define WOLFSSL_SHA3
 
 #define HAVE_HKDF
 #define HAVE_PKCS8
@@ -79,6 +105,9 @@
 #ifdef HAVE_FIPS
     #define HAVE_ECC_CDH
     #define WOLFSSL_VALIDATE_ECC_IMPORT
+#endif
+#ifdef __i386
+    #define TFM_NO_ASM
 #endif
 
 #define HAVE_AESGCM

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -833,7 +833,10 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define ASN1_STRING_set_default_mask_asc(...) 1
 #endif
 
+#define ASN1_OCTET_STRING               WOLFSSL_ASN1_STRING
+#define ASN1_OCTET_STRING_new           wolfSSL_ASN1_STRING_new
 #define ASN1_OCTET_STRING_free          wolfSSL_ASN1_STRING_free
+#define ASN1_OCTET_STRING_set           wolfSSL_ASN1_STRING_set
 
 #define ASN1_PRINTABLE_type(...)        V_ASN1_PRINTABLESTRING
 
@@ -841,7 +844,6 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 
 #define ASN1_IA5STRING                  WOLFSSL_ASN1_STRING
 
-#define ASN1_OCTET_STRING               WOLFSSL_ASN1_STRING
 #define ASN1_BOOLEAN                    WOLFSSL_ASN1_BOOLEAN
 
 #define SSL_load_client_CA_file         wolfSSL_load_client_CA_file
@@ -1109,10 +1111,6 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #include <wolfssl/openssl/pem.h>
 
 #define SSL_CTRL_CHAIN       88
-#define ERR_LIB_RSA          4
-#define ERR_LIB_EC           16
-#define ERR_LIB_SSL          20
-#define ERR_LIB_PKCS12       35
 #define SSL_R_SHORT_READ     10
 #define ERR_R_PEM_LIB        9
 #define SSL_CTRL_MODE        33
@@ -1412,10 +1410,17 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define PEM_R_BAD_DECRYPT               (-MIN_CODE_E + 4)
 #define ASN1_R_HEADER_TOO_LONG          (-MIN_CODE_E + 5)
 
+#define ERR_LIB_RSA             4
+#define ERR_LIB_EC              16
+#define ERR_LIB_SSL             20
+#define ERR_LIB_PKCS12          35
 #define ERR_LIB_PEM             9
 #define ERR_LIB_X509            10
 #define ERR_LIB_EVP             11
 #define ERR_LIB_ASN1            12
+#define ERR_LIB_DIGEST          13
+#define ERR_LIB_CIPHER          14
+#define ERR_LIB_USER            15
 
 #if defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || \
     defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(OPENSSL_ALL) || \


### PR DESCRIPTION
Cleanup on some compatibility. Adds `ERR_LIB_DIGEST`, `ERR_LIB_CIPHER` and `ERR_LIB_USER`.