### PR TITLE
Uninitialized var. 

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -3781,6 +3781,7 @@ void InitSuites(Suites* suites, ProtocolVersion pv, int keySz, word16 haveRSA,
  */
 static WC_INLINE void DecodeSigAlg(const byte* input, byte* hashAlgo, byte* hsType)
 {
+    *hsType = invalid_sa_algo;
     switch (input[0]) {
         case NEW_SA_MAJOR:
     #ifdef HAVE_ED25519
@@ -3820,7 +3821,8 @@ static WC_INLINE void DecodeSigAlg(const byte* input, byte* hashAlgo, byte* hsTy
                 *hsType = falcon_level1_sa_algo;
                 /* Hash performed as part of sign/verify operation. */
                 *hashAlgo = sha512_mac;
-            } else
+            }
+            else
             if (input[1] == FALCON_LEVEL5_SA_MINOR) {
                 *hsType = falcon_level5_sa_algo;
                 /* Hash performed as part of sign/verify operation. */
@@ -24449,8 +24451,8 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     ERROR_OUT(NOT_COMPILED_IN, exit_dske);
             #else
                     enum wc_HashType hashType;
-                    word16  verifySz;
-                    byte sigAlgo = 0xFF;
+                    word16 verifySz;
+                    byte sigAlgo;
 
                     if (ssl->options.usingAnon_cipher) {
                         break;

--- a/src/internal.c
+++ b/src/internal.c
@@ -3822,8 +3822,7 @@ static WC_INLINE void DecodeSigAlg(const byte* input, byte* hashAlgo, byte* hsTy
                 /* Hash performed as part of sign/verify operation. */
                 *hashAlgo = sha512_mac;
             }
-            else
-            if (input[1] == FALCON_LEVEL5_SA_MINOR) {
+            else if (input[1] == FALCON_LEVEL5_SA_MINOR) {
                 *hsType = falcon_level5_sa_algo;
                 /* Hash performed as part of sign/verify operation. */
                 *hashAlgo = sha512_mac;

--- a/src/internal.c
+++ b/src/internal.c
@@ -24450,7 +24450,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
             #else
                     enum wc_HashType hashType;
                     word16  verifySz;
-                    byte sigAlgo;
+                    byte sigAlgo = 0;
 
                     if (ssl->options.usingAnon_cipher) {
                         break;

--- a/src/internal.c
+++ b/src/internal.c
@@ -24450,7 +24450,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
             #else
                     enum wc_HashType hashType;
                     word16  verifySz;
-                    byte sigAlgo = 0;
+                    byte sigAlgo = 0xFF;
 
                     if (ssl->options.usingAnon_cipher) {
                         break;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -50,6 +50,8 @@
     #include "wolfcrypt/benchmark/benchmark.h"
 #endif
 
+#define BENCH_EMBEDDED
+
 /* printf mappings */
 #ifdef FREESCALE_MQX
     #include <mqx.h>

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -50,8 +50,6 @@
     #include "wolfcrypt/benchmark/benchmark.h"
 #endif
 
-#define BENCH_EMBEDDED
-
 /* printf mappings */
 #ifdef FREESCALE_MQX
     #include <mqx.h>

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3151,7 +3151,8 @@ enum SignatureAlgorithm {
     rsa_pss_pss_algo      = 10,
     ed448_sa_algo         = 11,
     falcon_level1_sa_algo = 12,
-    falcon_level5_sa_algo = 13
+    falcon_level5_sa_algo = 13,
+    invalid_sa_algo       = 255
 };
 
 #define PSS_RSAE_TO_PSS_PSS(macAlgo) \


### PR DESCRIPTION
The following config:

./configure --with-liboqs --enable-all --disable-psk --enable-intelasm --enable-aesni --enable-sp-math-all --enable-sp-asm CFLAGS="-O3"

Yields the following error:

src/internal.c: In function ‘DoServerKeyExchange’:
src/internal.c:24487:28: error: ‘sigAlgo’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
24487 |                         if (sigAlgo == ed448_sa_algo &&
      |                            ^

This fixes it.