### PR TITLE
Turn on AES-OFB mode in windows for FIPS=v5

### DIFF
--- a/IDE/WIN10/user_settings.h
+++ b/IDE/WIN10/user_settings.h
@@ -99,6 +99,7 @@
         #define HAVE_FFDHE_6144
         #define HAVE_FFDHE_8192
         #define FP_MAX_BITS 16384
+        #define WOLFSSL_AES_OFB
     #endif /* FIPS v5 */
 #else
     /* Enables blinding mode, to prevent timing attacks */

--- a/IDE/WIN10/user_settings.h
+++ b/IDE/WIN10/user_settings.h
@@ -98,8 +98,8 @@
         #define HAVE_FFDHE_4096
         #define HAVE_FFDHE_6144
         #define HAVE_FFDHE_8192
-        #define FP_MAX_BITS 16384
         #define WOLFSSL_AES_OFB
+        #define FP_MAX_BITS 16384
     #endif /* FIPS v5 */
 #else
     /* Enables blinding mode, to prevent timing attacks */

--- a/IDE/WIN10/user_settings.h
+++ b/IDE/WIN10/user_settings.h
@@ -15,7 +15,7 @@
     #undef HAVE_FIPS_VERSION
     #define HAVE_FIPS_VERSION 5
     #undef HAVE_FIPS_VERSION_MINOR
-    #define HAVE_FIPS_VERSION_MINOR 1
+    #define HAVE_FIPS_VERSION_MINOR 2
 #endif
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -269,7 +269,7 @@ AS_CASE([$ENABLED_FIPS],
     [ready|v5-ready],[
         FIPS_VERSION="v5-ready"
         HAVE_FIPS_VERSION=5
-        HAVE_FIPS_VERSION_MINOR=1
+        HAVE_FIPS_VERSION_MINOR=2
         ENABLED_FIPS="yes"
     ],
     [

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -1825,7 +1825,7 @@ static void* benchmarks_do(void* args)
     #ifdef WOLFSSL_KEY_GEN
         if (bench_all || (bench_asym_algs & BENCH_RSA_KEYGEN)) {
         #ifndef NO_SW_BENCH
-            if (((word32)bench_asym_algs == 0xFFFFFFFFU) || 
+            if (((word32)bench_asym_algs == 0xFFFFFFFFU) ||
                         (bench_asym_algs & BENCH_RSA_SZ) == 0) {
                 bench_rsaKeyGen(0);
             }


### PR DESCRIPTION
https://github.com/wolfSSL/wolfssl/pull/4551 - enabled AES_OFB in master
https://github.com/wolfSSL/fips/pull/165 - Turned on the AES_OFB testing in the harness

The tests passed on wolfssl PR and it was merged before the harness was updated. The harness depended on configure.ac enabling AES_OFB by default to pass the linux tests performed by the harness PRB tests.

The harness PRB tests do not yet run windows tests so we didn't catch that once the harness started processing the AES_OFB responses the windows tests would also be missing that setting just like Linux was. This PR addresses the windows side-harness tests. 