### PR TITLE
Check ssl->arrays in SendClientHello to avoid null dereference.  Allow building with fallthrough defined.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -22666,6 +22666,10 @@ exit_dpk:
         WOLFSSL_START(WC_FUNC_CLIENT_HELLO_SEND);
         WOLFSSL_ENTER("SendClientHello");
 
+        if (ssl == NULL || ssl->arrays == NULL) {
+            return BAD_FUNC_ARG;
+        }
+
         if (ssl->suites == NULL) {
             WOLFSSL_MSG("Bad suites pointer in SendClientHello");
             return SUITES_ERROR;

--- a/src/internal.c
+++ b/src/internal.c
@@ -22658,6 +22658,10 @@ exit_dpk:
         int                ret;
         word16             extSz = 0;
 
+        if (ssl == NULL) {
+            return BAD_FUNC_ARG;
+        }
+
 #ifdef WOLFSSL_TLS13
         if (IsAtLeastTLSv1_3(ssl->version))
             return SendTls13ClientHello(ssl);
@@ -22665,10 +22669,6 @@ exit_dpk:
 
         WOLFSSL_START(WC_FUNC_CLIENT_HELLO_SEND);
         WOLFSSL_ENTER("SendClientHello");
-
-        if (ssl == NULL || ssl->arrays == NULL) {
-            return BAD_FUNC_ARG;
-        }
 
         if (ssl->suites == NULL) {
             WOLFSSL_MSG("Bad suites pointer in SendClientHello");
@@ -22718,6 +22718,10 @@ exit_dpk:
             length += extSz + HELLO_EXT_SZ_SZ;
 #endif
         sendSz = length + HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ;
+
+        if (ssl->arrays == NULL) {
+            return BAD_FUNC_ARG;
+        }
 
 #ifdef WOLFSSL_DTLS
         if (ssl->options.dtls) {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -9676,7 +9676,7 @@ int wolfSSL_CTX_get_max_early_data(WOLFSSL_CTX* ctx)
  *
  * ssl  The SSL/TLS object.
  * returns BAD_FUNC_ARG when ssl is NULL, or not using TLS v1.3,
- * SIDE_ERROR when not a server and 
+ * SIDE_ERROR when not a server and
  * returns the maximum amount of early data to be set
  */
 int wolfSSL_get_max_early_data(WOLFSSL* ssl)

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3014,6 +3014,10 @@ int SendTls13ClientHello(WOLFSSL* ssl)
     WOLFSSL_START(WC_FUNC_CLIENT_HELLO_SEND);
     WOLFSSL_ENTER("SendTls13ClientHello");
 
+    if (ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
 #ifdef HAVE_SESSION_TICKET
     if (ssl->options.resuming &&
             (ssl->session.version.major != ssl->version.major ||
@@ -3130,6 +3134,9 @@ int SendTls13ClientHello(WOLFSSL* ssl)
     /* Keep for downgrade. */
     ssl->chVersion = ssl->version;
 
+    if (ssl->arrays == NULL) {
+        return BAD_FUNC_ARG;
+    }
     /* Client Random */
     if (ssl->options.connectState == CONNECT_BEGIN) {
         ret = wc_RNG_GenerateBlock(ssl->rng, args->output + args->idx, RAN_LEN);

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1964,6 +1964,7 @@ int wolfSSL_EVP_PKEY_keygen(WOLFSSL_EVP_PKEY_CTX *ctx,
                     pkey->ownEcc = 1;
                 }
             }
+            break;
 #endif
         default:
             break;

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -11682,8 +11682,8 @@ WOLFSSL_API int wc_PKCS7_DecodeAuthEnvelopedData(PKCS7* pkcs7, byte* in,
             wc_PKCS7_ChangeState(pkcs7, WC_PKCS7_AUTHENV_ATRBEND);
             FALL_THROUGH;
 
-authenv_atrbend:
         case WC_PKCS7_AUTHENV_ATRBEND:
+authenv_atrbend:
         #ifndef NO_PKCS7_STREAM
             if ((ret = wc_PKCS7_AddDataToStream(pkcs7, in, inSz, MAX_LENGTH_SZ +
                             ASN_TAG_SZ, &pkiMsg, &idx)) != 0) {

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -315,7 +315,8 @@ decouple library dependencies with standard string, memory and so on.
                 #if defined(WOLFSSL_LINUXKM) && defined(fallthrough)
                     #define FALL_THROUGH fallthrough
                 #else
-                    #define FALL_THROUGH ; __attribute__ ((fallthrough))
+                    /* Use __ notation to avoid conflicts */
+                    #define FALL_THROUGH ; __attribute__ ((__fallthrough__))
                 #endif
             #endif
         #endif

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -311,13 +311,13 @@ decouple library dependencies with standard string, memory and so on.
     #ifndef FALL_THROUGH
         /* GCC 7 has new switch() fall-through detection */
         #if defined(__GNUC__)
-            #if ((__GNUC__ > 7) || ((__GNUC__ == 7) && (__GNUC_MINOR__ >= 1)))
-                #if defined(WOLFSSL_LINUXKM) && defined(fallthrough)
-                    #define FALL_THROUGH fallthrough
-                #else
-                    /* Use __ notation to avoid conflicts */
-                    #define FALL_THROUGH ; __attribute__ ((__fallthrough__))
-                #endif
+            #if defined(fallthrough)
+                #define FALL_THROUGH fallthrough
+            #elif ((__GNUC__ > 7) || ((__GNUC__ == 7) && (__GNUC_MINOR__ >= 1)))
+                #define FALL_THROUGH ; __attribute__ ((fallthrough))
+            #elif defined(__clang__) && defined(__clang_major__) &&
+                    (__clang_major__ >= 4)
+                #define FALL_THROUGH ; __attribute__ ((fallthrough))
             #endif
         #endif
     #endif /* FALL_THROUGH */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -316,7 +316,7 @@ decouple library dependencies with standard string, memory and so on.
             #elif ((__GNUC__ > 7) || ((__GNUC__ == 7) && (__GNUC_MINOR__ >= 1)))
                 #define FALL_THROUGH ; __attribute__ ((fallthrough))
             #elif defined(__clang__) && defined(__clang_major__) && \
-                    (__clang_major__ >= 4)
+                    (__clang_major__ >= 11)
                 #define FALL_THROUGH ; __attribute__ ((fallthrough))
             #endif
         #endif

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -315,7 +315,7 @@ decouple library dependencies with standard string, memory and so on.
                 #define FALL_THROUGH fallthrough
             #elif ((__GNUC__ > 7) || ((__GNUC__ == 7) && (__GNUC_MINOR__ >= 1)))
                 #define FALL_THROUGH ; __attribute__ ((fallthrough))
-            #elif defined(__clang__) && defined(__clang_major__) &&
+            #elif defined(__clang__) && defined(__clang_major__) && \
                     (__clang_major__ >= 4)
                 #define FALL_THROUGH ; __attribute__ ((fallthrough))
             #endif


### PR DESCRIPTION
GH #4568
ZD 13238