### PR TITLE
Improve `ret` handling in the `ProcessPeerCerts` verify step.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -12589,7 +12589,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 #endif /* HAVE_OCSP */
 
                 #ifdef HAVE_CRL
-                    if (doLookup && SSL_CM(ssl)->crlEnabled) {
+                    if (ret == 0 && doLookup && SSL_CM(ssl)->crlEnabled) {
                         WOLFSSL_MSG("Doing Leaf CRL check");
                         ret = CheckCertCRL(SSL_CM(ssl)->crl, args->dCert);
                     #ifdef WOLFSSL_NONBLOCK_OCSP

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -4567,7 +4567,7 @@ int mp_montgomery_calc_normalization(mp_int *a, mp_int *b)
     return fp_montgomery_calc_normalization(a, b);
 }
 
-#endif /* WOLFSSL_KEYGEN || HAVE_ECC */
+#endif /* WOLFSSL_KEY_GEN || HAVE_ECC */
 
 static int fp_cond_swap_ct (mp_int * a, mp_int * b, int c, int m)
 {


### PR DESCRIPTION
Fix to make sure error from OCSP is not overriden if CRL is enabled. 
ZD13242