### PR TITLE
Fix failure of make distclean when linuxkm is enabled

### DIFF
--- a/linuxkm/Makefile
+++ b/linuxkm/Makefile
@@ -112,6 +112,9 @@ clean:
 .PHONY: check
 check:
 
+.PHONY: distclean
+distclean: clean
+
 .PHONY: dist
 dist:
 

--- a/linuxkm/Makefile
+++ b/linuxkm/Makefile
@@ -109,6 +109,9 @@ install modules_install:
 clean:
 	+$(MAKE) -C $(KERNEL_ROOT) M=$(MODULE_TOP) src=$(MODULE_TOP) clean
 
+.PHONY: check
+check:
+
 .PHONY: dist
 dist:
 


### PR DESCRIPTION
```
$ make distclean
Making distclean in linuxkm
make[1]: Entering directory '/home/honma/git/wolfssl/linuxkm'
make[1]: *** No rule to make target 'distclean'.  Stop.
make[1]: Leaving directory '/home/honma/git/wolfssl/linuxkm'
make: *** [Makefile:6431: distclean-recursive] Error 1
```
And also fixed failure of check at commiting.

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>