### PR TITLE
adding hkdf-extract callback for iotsafe

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -41644,6 +41644,20 @@ void* wolfSSL_GetEccKeyGenCtx(WOLFSSL* ssl)
 }
 
 WOLFSSL_ABI
+void  wolfSSL_CTX_SetHKDFExtractCb(WOLFSSL_CTX* ctx, CallbackHKDFExtract cb)
+{
+    if (ctx)
+        ctx->HkdfExtractCb = cb;
+}
+void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
+{
+    if (ssl)
+        return ssl->HkdfExtractCtx;
+
+    return NULL;
+}
+
+WOLFSSL_ABI
 void  wolfSSL_CTX_SetEccSignCb(WOLFSSL_CTX* ctx, CallbackEccSign cb)
 {
     if (ctx)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3011,6 +3011,7 @@ struct WOLFSSL_CTX {
         CallbackEccKeyGen EccKeyGenCb;  /* User EccKeyGen Callback Handler */
         CallbackEccSign   EccSignCb;    /* User EccSign   Callback handler */
         CallbackEccVerify EccVerifyCb;  /* User EccVerify Callback handler */
+        CallbackHKDFExtract HkdfExtractCb; /* User hkdf Extract Callback handler */
         CallbackEccSharedSecret EccSharedSecretCb; /* User EccVerify Callback handler */
     #endif /* HAVE_ECC */
     #ifdef HAVE_ED25519
@@ -4437,6 +4438,7 @@ struct WOLFSSL {
     #ifdef HAVE_ECC
         void* EccKeyGenCtx;          /* EccKeyGen  Callback Context */
         void* EccSignCtx;            /* Ecc Sign   Callback Context */
+        void* HkdfExtractCtx;        /* Hkdf Extract Callback Context */
         void* EccVerifyCtx;          /* Ecc Verify Callback Context */
         void* EccSharedSecretCtx;    /* Ecc Pms    Callback Context */
     #endif /* HAVE_ECC */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3021,6 +3021,16 @@ typedef int (*CallbackEccSign)(WOLFSSL* ssl,
        void* ctx);
 WOLFSSL_ABI WOLFSSL_API void  wolfSSL_CTX_SetEccSignCb(WOLFSSL_CTX*,
                                                                CallbackEccSign);
+//hkdf callback
+typedef int (*CallbackHKDFExtract)(WOLFSSL* ssl,
+       byte* prk, const byte* salt, int saltLen,
+       byte* ikm, int ikmLen, int mac,
+       void* ctx);
+WOLFSSL_ABI WOLFSSL_API void  wolfSSL_CTX_SetHKDFExtractCb(WOLFSSL_CTX*,
+                                                               CallbackHKDFExtract);
+WOLFSSL_API void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl);
+
+
 WOLFSSL_API void  wolfSSL_SetEccSignCtx(WOLFSSL* ssl, void *ctx);
 WOLFSSL_API void* wolfSSL_GetEccSignCtx(WOLFSSL* ssl);
 

--- a/wolfssl/wolfcrypt/kdf.h
+++ b/wolfssl/wolfcrypt/kdf.h
@@ -33,6 +33,7 @@
     #include <wolfssl/wolfcrypt/fips.h>
 #endif
 
+#include <wolfssl/internal.h>
 #include <wolfssl/wolfcrypt/hmac.h>
 
 #ifdef __cplusplus
@@ -76,7 +77,7 @@ enum {
     MAX_TLS13_HKDF_LABEL_SZ = 47 + WC_MAX_DIGEST_SIZE
 };
 
-WOLFSSL_API int wc_Tls13_HKDF_Extract(byte* prk, const byte* salt, int saltLen,
+WOLFSSL_API int wc_Tls13_HKDF_Extract(WOLFSSL* ssl, byte* prk, const byte* salt, int saltLen,
                              byte* ikm, int ikmLen, int digest);
 
 WOLFSSL_API int wc_Tls13_HKDF_Expand_Label(byte* okm, word32 okmLen,


### PR DESCRIPTION
Adding callback for HKDF-extract to be used by iot-safe implementation.

as discuss with: @danielinux 

building with:
`./configure CFLAGS="-DHAVE_SECRET_CALLBACK -DDEBUG_WOLFSSL -DWOLFSSL_DEBUG_TLS -DDEBUG_IOTSAFE -w" --enable-tls13 --enable-pkcallbacks --enable-debug --enable-iotsafe
`

the "-w" needs review because the kdf.h need the WOLFSSL context from by including internal.h resulting in:

```
In file included from ./wolfssl/wolfcrypt/kdf.h:36,
                 from wolfcrypt/test/test.c:241:
./wolfssl/internal.h:3195:34: note: shadowed declaration is here
 enum CipherType { stream, block, aead };
                                  ^~~~
wolfcrypt/test/test.c: In function ‘_rng_test’:
wolfcrypt/test/test.c:11620:10: error: declaration of ‘block’ shadows a global declaration [-Werror=shadow]
     byte block[32];
          ^~~~~
In file included from ./wolfssl/wolfcrypt/kdf.h:36,
                 from wolfcrypt/test/test.c:241:
./wolfssl/internal.h:3195:27: note: shadowed declaration is here
 enum CipherType { stream, block, aead };
```
Maybe there is a better way to access the WOLFSSL context.

Thanks for reviewing
Remy

