### PR TITLE
Add support for Nginx 1.21.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2188,7 +2188,7 @@ AC_ARG_ENABLE([keygen],
     [ ENABLED_KEYGEN=no ]
     )
 
-if test "$ENABLED_BIND" = "yes" || test "$ENABLED_NTP" = "yes" || test "$ENABLED_LIBSSH2" = "yes" || test "$ENABLED_OPENRESTY" = "yes"
+if test "$ENABLED_BIND" = "yes" || test "$ENABLED_NTP" = "yes" || test "$ENABLED_LIBSSH2" = "yes" || test "$ENABLED_OPENRESTY" = "yes" || test "$ENABLED_NGINX" = "yes"
 then
     ENABLED_KEYGEN=yes
 fi

--- a/src/internal.c
+++ b/src/internal.c
@@ -5929,7 +5929,11 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 #endif
     ssl->timeout = ctx->timeout;
     ssl->verifyCallback    = ctx->verifyCallback;
-    ssl->options.side      = ctx->method->side;
+    /* If we are setting the ctx on an already initialized SSL object
+     * then we possibly already have a side defined. Don't overwrite unless
+     * the context has a well defined role. */
+    if (newSSL || ctx->method->side != WOLFSSL_NEITHER_END)
+        ssl->options.side      = ctx->method->side;
     ssl->options.downgrade    = ctx->method->downgrade;
     ssl->options.minDowngrade = ctx->minDowngrade;
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -23527,7 +23527,7 @@ WOLFSSL_ABI
 WOLFSSL_X509_NAME* wolfSSL_X509_get_subject_name(WOLFSSL_X509* cert)
 {
     WOLFSSL_ENTER("wolfSSL_X509_get_subject_name");
-    if (cert)
+    if (cert && cert->subject.sz > 0)
         return &cert->subject;
     return NULL;
 }
@@ -23603,7 +23603,7 @@ WOLFSSL_ABI
 WOLFSSL_X509_NAME* wolfSSL_X509_get_issuer_name(WOLFSSL_X509* cert)
 {
     WOLFSSL_ENTER("X509_get_issuer_name");
-    if (cert && cert->issuer.sz != 0)
+    if (cert && cert->issuer.sz > 0)
         return &cert->issuer;
     return NULL;
 }
@@ -57761,6 +57761,43 @@ static const conf_cmd_tbl conf_cmds_tbl[] = {
 static const size_t size_of_cmd_tbls = sizeof(conf_cmds_tbl)
                                                     / sizeof(conf_cmd_tbl);
 
+static const conf_cmd_tbl* wolfssl_conf_find_cmd(WOLFSSL_CONF_CTX* cctx,
+                                         const char* cmd)
+{
+    size_t i = 0;
+    size_t cmdlen = 0;
+
+    if (cctx->flags & WOLFSSL_CONF_FLAG_CMDLINE) {
+        cmdlen = XSTRLEN(cmd);
+
+        if (cmdlen < 2) {
+            WOLFSSL_MSG("bad cmdline command");
+            return NULL;
+        }
+        /* skip "-" prefix */
+        ++cmd;
+    }
+
+    for (i = 0; i < size_of_cmd_tbls; i++) {
+        /* check if the cmd is valid */
+        if (cctx->flags & WOLFSSL_CONF_FLAG_CMDLINE) {
+            if (conf_cmds_tbl[i].cmdline_cmd != NULL &&
+                XSTRCMP(cmd, conf_cmds_tbl[i].cmdline_cmd) == 0) {
+                return &conf_cmds_tbl[i];
+            }
+        }
+
+        if (cctx->flags & WOLFSSL_CONF_FLAG_FILE) {
+            if (conf_cmds_tbl[i].file_cmd != NULL &&
+                XSTRCMP(cmd, conf_cmds_tbl[i].file_cmd) == 0) {
+                return &conf_cmds_tbl[i];
+            }
+        }
+    }
+
+    return NULL;
+}
+
 /**
  * send configuration command
  * @param cctx  a pointer to WOLFSSL_CONF_CTX structure
@@ -57775,14 +57812,8 @@ static const size_t size_of_cmd_tbls = sizeof(conf_cmds_tbl)
 int wolfSSL_CONF_cmd(WOLFSSL_CONF_CTX* cctx, const char* cmd, const char* value)
 {
     int ret = WOLFSSL_FAILURE;
-    size_t i = 0;
-    size_t cmdlen = 0;
-    const char* c = NULL;
+    const conf_cmd_tbl* confcmd = NULL;
     WOLFSSL_ENTER("wolfSSL_CONF_cmd");
-
-    (void)cctx;
-    (void)cmd;
-    (void)value;
 
     /* sanity check */
     if (cctx == NULL || cmd == NULL) {
@@ -57790,50 +57821,16 @@ int wolfSSL_CONF_cmd(WOLFSSL_CONF_CTX* cctx, const char* cmd, const char* value)
         return ret;
     }
 
-    if (cctx->flags & WOLFSSL_CONF_FLAG_CMDLINE) {
-        cmdlen = XSTRLEN(cmd);
+    confcmd = wolfssl_conf_find_cmd(cctx, cmd);
+    if (confcmd == NULL)
+        return -2;
 
-        if (cmdlen < 2) {
-            WOLFSSL_MSG("bad cmdline command");
-            return -2;
-        }
-        /* skip "-" prefix */
-        c = ++cmd;
+    if (confcmd->cmdfunc == NULL) {
+        WOLFSSL_MSG("cmd not yet implemented");
+        return -2;
     }
 
-    for (i = 0; i < size_of_cmd_tbls; i++) {
-        /* check if the cmd is valid */
-        if (cctx->flags & WOLFSSL_CONF_FLAG_CMDLINE) {
-            if (c != NULL && conf_cmds_tbl[i].cmdline_cmd != NULL &&
-                XSTRCMP(c, conf_cmds_tbl[i].cmdline_cmd) == 0) {
-                if (conf_cmds_tbl[i].cmdfunc != NULL) {
-                    ret = conf_cmds_tbl[i].cmdfunc(cctx, value);
-                    break;
-                } else {
-                    WOLFSSL_MSG("cmd not yet implemented");
-                    return -2;
-                }
-            }
-        }
-
-        if (cctx->flags & WOLFSSL_CONF_FLAG_FILE) {
-            if (conf_cmds_tbl[i].file_cmd != NULL &&
-                XSTRCMP(cmd, conf_cmds_tbl[i].file_cmd) == 0) {
-                if (conf_cmds_tbl[i].cmdfunc != NULL) {
-                    ret = conf_cmds_tbl[i].cmdfunc(cctx, value);
-                    break;
-                } else {
-                    WOLFSSL_MSG("cmd not yet implemented");
-                    return -2;
-                }
-            }
-        }
-    }
-
-    if (i == size_of_cmd_tbls) {
-        WOLFSSL_MSG("invalid command");
-        ret = -2;
-    }
+    ret = confcmd->cmdfunc(cctx, value);
 
     /* return code compliant with OpenSSL */
     if (ret < -3)
@@ -57841,6 +57838,24 @@ int wolfSSL_CONF_cmd(WOLFSSL_CONF_CTX* cctx, const char* cmd, const char* value)
 
     WOLFSSL_LEAVE("wolfSSL_CONF_cmd", ret);
     return ret;
+}
+
+/**
+ *
+ * @param cctx a pointer to WOLFSSL_CONF_CTX structure
+ * @param cmd  configuration command
+ * @return The SSL_CONF_TYPE_* type or SSL_CONF_TYPE_UNKNOWN if an
+ *         unvalid command
+ */
+int wolfSSL_CONF_cmd_value_type(WOLFSSL_CONF_CTX *cctx, const char *cmd)
+{
+    const conf_cmd_tbl* confcmd = NULL;
+    WOLFSSL_ENTER("wolfSSL_CONF_cmd_value_type");
+
+    confcmd = wolfssl_conf_find_cmd(cctx, cmd);
+    if (confcmd == NULL)
+        return SSL_CONF_TYPE_UNKNOWN;
+    return (int)confcmd->data_type;
 }
 
 #endif /* OPENSSL_EXTRA */

--- a/tests/api.c
+++ b/tests/api.c
@@ -32747,7 +32747,7 @@ static void test_wolfSSL_X509_STORE_CTX_get0_current_issuer(void)
         cmp = X509_NAME_cmp(caName, issuerName);
         AssertIntEQ(cmp, 0);
     #else
-        AssertNotNull(issuerName);
+        AssertNull(issuerName);
     #endif
 
     X509_free(issuer);

--- a/wolfssl/openssl/opensslv.h
+++ b/wolfssl/openssl/opensslv.h
@@ -34,7 +34,7 @@
       defined(WOLFSSL_BIND) || defined(WOLFSSL_NGINX) || \
       defined(WOLFSSL_RSYSLOG)
     /* For Apache httpd, Use 1.1.0 compatibility */
-     #define OPENSSL_VERSION_NUMBER 0x10100000L
+     #define OPENSSL_VERSION_NUMBER 0x10100003L
 #elif defined(WOLFSSL_QT) || defined(WOLFSSL_PYTHON)
     /* For Qt and Python 3.8.5 compatibility */
      #define OPENSSL_VERSION_NUMBER 0x10101000L

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -1262,13 +1262,16 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define DTLS_MAX_VERSION                 DTLS1_2_VERSION
 
 /* apache and lighty use SSL_CONF_FLAG_FILE to enable conf support */
-#if !defined(WOLFSSL_APACHE_HTTPD) && !defined(HAVE_LIGHTY)
 #define SSL_CONF_FLAG_CMDLINE            WOLFSSL_CONF_FLAG_CMDLINE
 #define SSL_CONF_FLAG_FILE               WOLFSSL_CONF_FLAG_FILE
 #define SSL_CONF_FLAG_CERTIFICATE        WOLFSSL_CONF_FLAG_CERTIFICATE
+#define SSL_CONF_FLAG_SERVER             WOLFSSL_CONF_FLAG_SERVER
+#define SSL_CONF_FLAG_CLIENT             WOLFSSL_CONF_FLAG_CLIENT
+#define SSL_CONF_FLAG_SHOW_ERRORS        WOLFSSL_CONF_FLAG_SHOW_ERRORS
+#define SSL_CONF_TYPE_UNKNOWN            WOLFSSL_CONF_TYPE_UNKNOWN
 #define SSL_CONF_TYPE_STRING             WOLFSSL_CONF_TYPE_STRING
 #define SSL_CONF_TYPE_FILE               WOLFSSL_CONF_TYPE_FILE
-#endif
+#define SSL_CONF_TYPE_DIR                WOLFSSL_CONF_TYPE_DIR
 
 #if defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || defined(OPENSSL_EXTRA) \
                                                          || defined(OPENSSL_ALL)
@@ -1595,6 +1598,7 @@ typedef WOLFSSL_CONF_CTX SSL_CONF_CTX;
 #define SSL_CONF_CTX_set_flags          wolfSSL_CONF_CTX_set_flags
 #define SSL_CONF_CTX_finish             wolfSSL_CONF_CTX_finish
 #define SSL_CONF_cmd                    wolfSSL_CONF_cmd
+#define SSL_CONF_cmd_value_type         wolfSSL_CONF_cmd_value_type
 
 #ifdef __cplusplus
     } /* extern "C" */

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4750,12 +4750,18 @@ WOLFSSL_API int wolfSSL_CONF_CTX_finish(WOLFSSL_CONF_CTX* cctx);
 
 #define WOLFSSL_CONF_FLAG_CMDLINE       0x1
 #define WOLFSSL_CONF_FLAG_FILE          0x2
+#define WOLFSSL_CONF_FLAG_CLIENT        0x4
+#define WOLFSSL_CONF_FLAG_SERVER        0x8
+#define WOLFSSL_CONF_FLAG_SHOW_ERRORS   0x10
 #define WOLFSSL_CONF_FLAG_CERTIFICATE   0x20
 
+#define WOLFSSL_CONF_TYPE_UNKNOWN       0x0
 #define WOLFSSL_CONF_TYPE_STRING        0x1
 #define WOLFSSL_CONF_TYPE_FILE          0x2
+#define WOLFSSL_CONF_TYPE_DIR           0x3
 
 WOLFSSL_API int wolfSSL_CONF_cmd(WOLFSSL_CONF_CTX* cctx, const char* cmd, const char* value);
+WOLFSSL_API int wolfSSL_CONF_cmd_value_type(WOLFSSL_CONF_CTX *cctx, const char *cmd);
 #endif /* OPENSSL_EXTRA */
 #if defined(HAVE_EX_DATA) || defined(WOLFSSL_WPAS_SMALL)
 WOLFSSL_API int wolfSSL_CRYPTO_get_ex_new_index(int class_index, long argl, void *argp,


### PR DESCRIPTION
- Add KEYGEN to Nginx config
- Check for name length in `wolfSSL_X509_get_subject_name`
- Refactor `wolfSSL_CONF_cmd`
- Implement `wolfSSL_CONF_cmd_value_type`
- Don't forecfully overwrite side