### PR TITLE
SP math all: div handling of length of dividend

### DIFF
--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -4614,6 +4614,10 @@ int sp_div(sp_int* a, sp_int* d, sp_int* r, sp_int* rem)
     if ((err == MP_OKAY) && (rem != NULL) && (rem->size < a->used + 1)) {
         err = MP_VAL;
     }
+    /* May need to shift number being divided left into a new word. */
+    if ((err == MP_OKAY) && (a->used == SP_INT_DIGITS)) {
+        err = MP_VAL;
+    }
 
     #if 0
     if (err == MP_OKAY) {


### PR DESCRIPTION
Fail when dividend is maximum size as we may be shifting left and
overflow when divisor is not on a word boundary.