### PR TITLE
fix redefinition of OS_Seed error with FIPS Ready on some compilers

### DIFF
--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -64,9 +64,9 @@ This library defines the interface APIs for X509 certificates.
     #define WC_RSAKEY_TYPE_DEFINED
 #endif
 #ifndef WC_RNG_TYPE_DEFINED
+    typedef struct OS_Seed OS_Seed;
     typedef struct WC_RNG WC_RNG;
     #ifdef WC_RNG_SEED_CB
-    typedef struct OS_Seed OS_Seed;
     typedef int (*wc_RngSeed_Cb)(OS_Seed* os, byte* seed, word32 sz);
     #endif
     #define WC_RNG_TYPE_DEFINED

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -130,9 +130,17 @@
     #endif
 #endif
 
+#ifndef WC_RNG_TYPE_DEFINED /* guard on redeclaration */
+    typedef struct OS_Seed OS_Seed;
+    typedef struct WC_RNG WC_RNG;
+    #ifdef WC_RNG_SEED_CB
+        typedef int (*wc_RngSeed_Cb)(OS_Seed* os, byte* seed, word32 sz);
+    #endif
+    #define WC_RNG_TYPE_DEFINED
+#endif
 
 /* OS specific seeder */
-typedef struct OS_Seed {
+struct OS_Seed {
     #if defined(USE_WINDOWS_API)
         ProviderHandle handle;
     #else
@@ -141,13 +149,7 @@ typedef struct OS_Seed {
     #if defined(WOLF_CRYPTO_CB)
         int devId;
     #endif
-} OS_Seed;
-
-
-#ifndef WC_RNG_TYPE_DEFINED /* guard on redeclaration */
-    typedef struct WC_RNG WC_RNG;
-    #define WC_RNG_TYPE_DEFINED
-#endif
+};
 
 #ifdef HAVE_HASHDRBG
 struct DRBG_internal {
@@ -168,7 +170,7 @@ struct DRBG_internal {
 
 /* RNG context */
 struct WC_RNG {
-    OS_Seed seed;
+    struct OS_Seed seed;
     void* heap;
 #ifdef HAVE_HASHDRBG
     /* Hash-based Deterministic Random Bit Generator */
@@ -234,7 +236,6 @@ WOLFSSL_API int  wc_FreeRng(WC_RNG*);
 #endif
 
 #ifdef WC_RNG_SEED_CB
-    typedef int (*wc_RngSeed_Cb)(OS_Seed* os, byte* seed, word32 sz);
     WOLFSSL_API int wc_SetSeed_Cb(wc_RngSeed_Cb cb);
 #endif
 


### PR DESCRIPTION
This PR fixes compiler errors with latest FIPS Ready bundle seen on CentOS 6:

```
$ cd wolfssl-5.0.0-gplv3-fips-ready
$ ./configure --enable-fips=v5-ready
$ make
...
In file included from ./wolfssl/wolfcrypt/tfm.h:47,
                 from ./wolfssl/wolfcrypt/integer.h:39,
                 from ./wolfssl/wolfcrypt/ecc.h:39,
                 from wolfcrypt/src/ecc.c:124:
./wolfssl/wolfcrypt/random.h:144: error: redefinition of typedef 'OS_Seed'
./wolfssl/wolfcrypt/asn_public.h:69: note: previous declaration of 'OS_Seed' was here
./wolfssl/wolfcrypt/random.h:237: error: redefinition of typedef 'wc_RngSeed_Cb'
./wolfssl/wolfcrypt/asn_public.h:70: note: previous declaration of 'wc_RngSeed_Cb' was here
In file included from wolfcrypt/src/random.c:53:
./wolfssl/wolfcrypt/random.h:144: error: redefinition of typedef 'OS_Seed'
./wolfssl/wolfcrypt/fips.h:58: note: previous declaration of 'OS_Seed' was here
./wolfssl/wolfcrypt/random.h:237: error: redefinition of typedef 'wc_RngSeed_Cb'
./wolfssl/wolfcrypt/fips.h:59: note: previous declaration of 'wc_RngSeed_Cb' was here
```