### PR TITLE
Delete extra newlines '\n' in WOLFSSL_MSG logging messages

### DIFF
--- a/IDE/MDK-ARM/MDK-ARM/wolfSSL/main.c
+++ b/IDE/MDK-ARM/MDK-ARM/wolfSSL/main.c
@@ -74,7 +74,7 @@ __task void tcp_tick (void)
 
 __task void tcp_poll (void)
 {
-    WOLFSSL_MSG("TCP polling started.\n") ;
+    WOLFSSL_MSG("TCP polling started.") ;
     while (1) {
         main_TcpNet ();
         #if defined (HAVE_KEIL_RTX)
@@ -128,7 +128,7 @@ void main_task (void)
     #endif
 
     #ifdef   HAVE_KEIL_RTX
-    WOLFSSL_MSG("Terminating tcp_main\n") ;
+    WOLFSSL_MSG("Terminating tcp_main") ;
     os_tsk_delete_self ();
     #endif
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -636,7 +636,7 @@ static int ExportCipherSpecState(WOLFSSL* ssl, byte* exp, word32 len, byte ver,
         byte *pt = (byte*)ssl->encrypt.aes->reg;
 
         if ((idx + 2*AES_BLOCK_SIZE) > len) {
-            WOLFSSL_MSG("Can not fit AES state into buffer\n");
+            WOLFSSL_MSG("Can not fit AES state into buffer");
             return BUFFER_E;
         }
         XMEMCPY(exp + idx, pt, AES_BLOCK_SIZE);
@@ -1533,7 +1533,7 @@ int wolfSSL_dtls_export_state_internal(WOLFSSL* ssl, byte* buf, word32 sz)
     {
         char debug[256];
         XSNPRINTF(debug, sizeof(debug), "Exporting DTLS session state\n"
-                   "\tVersion  : %d\n\tProtocol : %02X%01X\n\tLength of: %d\n\n"
+                   "\tVersion  : %d\n\tProtocol : %02X%01X\n\tLength of: %d"
                , (int)WOLFSSL_EXPORT_VERSION, buf[0], (buf[1] >> 4), idx - 2);
         WOLFSSL_MSG(debug);
     }
@@ -1577,7 +1577,7 @@ int wolfSSL_dtls_import_state_internal(WOLFSSL* ssl, const byte* buf, word32 sz)
     {
         char debug[256];
         XSNPRINTF(debug, sizeof(debug), "Importing DTLS session state\n"
-                   "\tVersion  : %d\n\tProtocol : %02X%01X\n\tLength of: %d\n\n"
+                   "\tVersion  : %d\n\tProtocol : %02X%01X\n\tLength of: %d"
                , (int)version, buf[0], (buf[1] >> 4), length);
         WOLFSSL_MSG(debug);
     }
@@ -1683,7 +1683,7 @@ int wolfSSL_session_import_internal(WOLFSSL* ssl, const unsigned char* buf,
     {
         char debug[256];
         XSNPRINTF(debug, sizeof(debug), "Importing DTLS session\n"
-                   "\tVersion  : %d\n\tProtocol : %02X%01X\n\tLength of: %d\n\n"
+                   "\tVersion  : %d\n\tProtocol : %02X%01X\n\tLength of: %d"
                , (int)version, buf[0], (buf[1] >> 4), length);
         WOLFSSL_MSG(debug);
     }
@@ -1965,7 +1965,7 @@ int wolfSSL_session_export_internal(WOLFSSL* ssl, byte* buf, word32* sz,
         {
             char debug[256];
             XSNPRINTF(debug, sizeof(debug), "Exporting TLS session\n"
-                   "\tVersion  : %d\n\tProtocol : %02X%01X\n\tLength of: %d\n\n"
+                   "\tVersion  : %d\n\tProtocol : %02X%01X\n\tLength of: %d"
                   ,(int)WOLFSSL_EXPORT_VERSION, buf[0], (buf[1] >> 4), idx - 2);
             WOLFSSL_MSG(debug);
         }
@@ -9028,7 +9028,7 @@ retry:
 /* Switch dynamic output buffer back to static, buffer is assumed clear */
 void ShrinkOutputBuffer(WOLFSSL* ssl)
 {
-    WOLFSSL_MSG("Shrinking output buffer\n");
+    WOLFSSL_MSG("Shrinking output buffer");
     XFREE(ssl->buffers.outputBuffer.buffer - ssl->buffers.outputBuffer.offset,
           ssl->heap, DYNAMIC_TYPE_OUT_BUFFER);
     ssl->buffers.outputBuffer.buffer = ssl->buffers.outputBuffer.staticBuffer;
@@ -9047,7 +9047,7 @@ void ShrinkInputBuffer(WOLFSSL* ssl, int forcedFree)
     if (!forcedFree && usedLength > STATIC_BUFFER_LEN)
         return;
 
-    WOLFSSL_MSG("Shrinking input buffer\n");
+    WOLFSSL_MSG("Shrinking input buffer");
 
     if (!forcedFree && usedLength > 0)
         XMEMCPY(ssl->buffers.inputBuffer.staticBuffer,
@@ -9167,7 +9167,7 @@ static WC_INLINE int GrowOutputBuffer(WOLFSSL* ssl, int size)
 
     tmp = (byte*)XMALLOC(size + ssl->buffers.outputBuffer.length + align,
                              ssl->heap, DYNAMIC_TYPE_OUT_BUFFER);
-    WOLFSSL_MSG("growing output buffer\n");
+    WOLFSSL_MSG("growing output buffer");
 
     if (tmp == NULL)
         return MEMORY_E;
@@ -9241,7 +9241,7 @@ int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength)
 
     tmp = (byte*)XMALLOC(size + usedLength + align,
                              ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
-    WOLFSSL_MSG("growing input buffer\n");
+    WOLFSSL_MSG("growing input buffer");
 
     if (tmp == NULL)
         return MEMORY_E;
@@ -11605,7 +11605,7 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
                        ret = wolfSSL_X509_STORE_add_cert(store, x509);
                        wolfSSL_X509_free(x509);
                     } else {
-                       WOLFSSL_MSG("failed to load certificate\n");
+                       WOLFSSL_MSG("failed to load certificate");
                        ret = WOLFSSL_FAILURE;
                        break;
                     }
@@ -11615,7 +11615,7 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
                     ret = wolfSSL_X509_load_crl_file(&store->lookup, filename,
                                                     WOLFSSL_FILETYPE_PEM);
                     if (ret != WOLFSSL_SUCCESS) {
-                        WOLFSSL_MSG("failed to load CRL\n");
+                        WOLFSSL_MSG("failed to load CRL");
                         break;
                     }
                 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -22281,7 +22281,7 @@ int wolfSSL_DH_check(const WOLFSSL_DH *dh, int *codes)
             mp_prime_is_prime_ex((mp_int*)dh->p->internal,8,&isPrime,&rng);
         }
         else {
-            WOLFSSL_MSG("Error initializing rng\n");
+            WOLFSSL_MSG("Error initializing rng");
             return WOLFSSL_FAILURE;
         }
         wc_FreeRng(&rng);
@@ -27335,7 +27335,7 @@ int wolfSSL_X509_VERIFY_PARAM_set1_ip(WOLFSSL_X509_VERIFY_PARAM* param,
            }
            /* sanity check */
            if (XSTRLEN(buf) > max_ipv6_len) {
-               WOLFSSL_MSG("The target ip adress exceeds buffer length(40)\n");
+               WOLFSSL_MSG("The target ip adress exceeds buffer length(40)");
                XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                buf = NULL;
                break;
@@ -62250,7 +62250,7 @@ WOLFSSL_API PKCS7* wolfSSL_SMIME_read_PKCS7(WOLFSSL_BIO* in,
     section[sectionLen] = '\0';
     ret = wc_MIME_parse_headers(section, sectionLen, &allHdrs);
     if (ret < 0) {
-        WOLFSSL_MSG("Parsing MIME headers failed.\n");
+        WOLFSSL_MSG("Parsing MIME headers failed.");
         goto error;
     }
     isEnd = 0;
@@ -62397,7 +62397,7 @@ WOLFSSL_API PKCS7* wolfSSL_SMIME_read_PKCS7(WOLFSSL_BIO* in,
             section[sectionLen] = '\0';
             ret = wc_MIME_parse_headers(section, sectionLen, &allHdrs);
             if (ret < 0) {
-                WOLFSSL_MSG("Parsing MIME headers failed.\n");
+                WOLFSSL_MSG("Parsing MIME headers failed.");
                 goto error;
             }
             curHdr = wc_MIME_find_header_name(kContType, allHdrs);
@@ -62406,7 +62406,7 @@ WOLFSSL_API PKCS7* wolfSSL_SMIME_read_PKCS7(WOLFSSL_BIO* in,
                                    XSTRNCMP(curHdr->body, kAppXPkcsSign,
                                    XSTR_SIZEOF(kAppXPkcsSign)))) {
                 WOLFSSL_MSG("S/MIME headers not found inside "
-                            "multipart message.\n");
+                            "multipart message.");
                 goto error;
             }
 
@@ -62438,12 +62438,12 @@ WOLFSSL_API PKCS7* wolfSSL_SMIME_read_PKCS7(WOLFSSL_BIO* in,
         }
         ret = wolfSSL_BIO_read(in, section, sectionLen);
         if (ret < 0 || ret != sectionLen) {
-            WOLFSSL_MSG("Error reading input BIO.\n");
+            WOLFSSL_MSG("Error reading input BIO.");
             goto error;
         }
     }
     else {
-        WOLFSSL_MSG("S/MIME headers not found.\n");
+        WOLFSSL_MSG("S/MIME headers not found.");
         goto error;
     }
 
@@ -62454,7 +62454,7 @@ WOLFSSL_API PKCS7* wolfSSL_SMIME_read_PKCS7(WOLFSSL_BIO* in,
     }
     else if (XSTRNCMP(curHdr->body, "base64", XSTRLEN("base64"))) {
         WOLFSSL_MSG("S/MIME encodings other than base64 are not "
-                    "currently supported.\n");
+                    "currently supported.");
         goto error;
     }
 
@@ -62475,7 +62475,7 @@ WOLFSSL_API PKCS7* wolfSSL_SMIME_read_PKCS7(WOLFSSL_BIO* in,
     section[sectionLen] = '\0';
     ret = Base64_Decode((const byte*)section, sectionLen, out, &outLen);
     if (ret < 0) {
-        WOLFSSL_MSG("Error base64 decoding S/MIME message.\n");
+        WOLFSSL_MSG("Error base64 decoding S/MIME message.");
         goto error;
     }
     pkcs7 = wolfSSL_d2i_PKCS7_ex(NULL, (const unsigned char**)&out, outLen,

--- a/src/tls.c
+++ b/src/tls.c
@@ -7539,7 +7539,7 @@ static int TLSX_KeyShare_ProcessOqs(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
     }
 
     if (sharedSecretLen > ENCRYPT_LEN) {
-        WOLFSSL_MSG("shared secret is too long.\n");
+        WOLFSSL_MSG("shared secret is too long.");
         ret = LENGTH_ERROR;
     }
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -15139,7 +15139,7 @@ static int DecodeAuthKeyId(const byte* input, int sz, DecodedCert* cert)
     WOLFSSL_ENTER("DecodeAuthKeyId");
 
     if (GetSequence(input, &idx, &length, sz) < 0) {
-        WOLFSSL_MSG("\tfail: should be a SEQUENCE\n");
+        WOLFSSL_MSG("\tfail: should be a SEQUENCE");
         return ASN_PARSE_E;
     }
 
@@ -15148,7 +15148,7 @@ static int DecodeAuthKeyId(const byte* input, int sz, DecodedCert* cert)
     }
 
     if (tag != (ASN_CONTEXT_SPECIFIC | 0)) {
-        WOLFSSL_MSG("\tinfo: OPTIONAL item 0, not available\n");
+        WOLFSSL_MSG("\tinfo: OPTIONAL item 0, not available");
         cert->extAuthKeyIdSet = 0;
         return 0;
     }
@@ -22261,7 +22261,7 @@ int SetNameEx(byte* output, word32 outputSz, CertName* name, void* heap)
             #ifdef WOLFSSL_SMALL_STACK
                 XFREE(names, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             #endif
-                WOLFSSL_MSG("EncodeName on multiple attributes failed\n");
+                WOLFSSL_MSG("EncodeName on multiple attributes failed");
                 return BUFFER_E;
             }
             totalBytes += ret;
@@ -30341,7 +30341,7 @@ static int ParseCRL_AuthKeyIdExt(const byte* input, int sz, DecodedCRL* dcrl)
     WOLFSSL_ENTER("ParseCRL_AuthKeyIdExt");
 
     if (GetSequence(input, &idx, &length, sz) < 0) {
-        WOLFSSL_MSG("\tfail: should be a SEQUENCE\n");
+        WOLFSSL_MSG("\tfail: should be a SEQUENCE");
         return ASN_PARSE_E;
     }
 
@@ -30350,7 +30350,7 @@ static int ParseCRL_AuthKeyIdExt(const byte* input, int sz, DecodedCRL* dcrl)
     }
 
     if (tag != (ASN_CONTEXT_SPECIFIC | 0)) {
-        WOLFSSL_MSG("\tinfo: OPTIONAL item 0, not available\n");
+        WOLFSSL_MSG("\tinfo: OPTIONAL item 0, not available");
         return 0;
     }
 

--- a/wolfcrypt/src/logging.c
+++ b/wolfcrypt/src/logging.c
@@ -731,7 +731,7 @@ int wc_AddErrorNode(int error, int line, char* buf, char* file)
             /* case of first node added to queue */
             if (wc_errors != NULL) {
                 /* check for unexpected case before over writing wc_errors */
-                WOLFSSL_MSG("ERROR in adding new node to logging queue!!\n");
+                WOLFSSL_MSG("ERROR in adding new node to logging queue!!");
                 /* In the event both wc_last_node and wc_errors are NULL, err
                  * goes unassigned to external wc_errors, wc_last_node. Free
                  * err in this instance since wc_ClearErrorNodes will not

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -614,11 +614,11 @@ void* wolfSSL_Malloc(size_t size, void* heap, int type)
             /* allow using malloc for creating ctx and method */
             if (type == DYNAMIC_TYPE_CTX || type == DYNAMIC_TYPE_METHOD ||
                                             type == DYNAMIC_TYPE_CERT_MANAGER) {
-                WOLFSSL_MSG("ERROR allowing null heap hint for ctx/method\n");
+                WOLFSSL_MSG("ERROR allowing null heap hint for ctx/method");
                 res = malloc(size);
             }
             else {
-                WOLFSSL_MSG("ERROR null heap hint passed into XMALLOC\n");
+                WOLFSSL_MSG("ERROR null heap hint passed into XMALLOC");
                 res = NULL;
             }
         #else
@@ -767,10 +767,10 @@ void wolfSSL_Free(void *ptr, void* heap, int type)
             /* allow using malloc for creating ctx and method */
             if (type == DYNAMIC_TYPE_CTX || type == DYNAMIC_TYPE_METHOD ||
                                             type == DYNAMIC_TYPE_CERT_MANAGER) {
-                WOLFSSL_MSG("ERROR allowing null heap hint for ctx/method\n");
+                WOLFSSL_MSG("ERROR allowing null heap hint for ctx/method");
             }
             else {
-                WOLFSSL_MSG("ERROR null heap hint passed into XFREE\n");
+                WOLFSSL_MSG("ERROR null heap hint passed into XFREE");
             }
         #endif
         #ifndef WOLFSSL_NO_MALLOC
@@ -871,7 +871,7 @@ void* wolfSSL_Realloc(void *ptr, size_t size, void* heap, int type)
 
     if (heap == NULL) {
         #ifdef WOLFSSL_HEAP_TEST
-            WOLFSSL_MSG("ERROR null heap hint passed in to XREALLOC\n");
+            WOLFSSL_MSG("ERROR null heap hint passed in to XREALLOC");
         #endif
         #ifndef WOLFSSL_NO_MALLOC
             res = realloc(ptr, size);

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -236,7 +236,7 @@ static int GetSafeContent(WC_PKCS12* pkcs12, const byte* input,
 
     switch (oid) {
         case WC_PKCS12_ENCRYPTED_DATA:
-            WOLFSSL_MSG("Found PKCS12 OBJECT: ENCRYPTED DATA\n");
+            WOLFSSL_MSG("Found PKCS12 OBJECT: ENCRYPTED DATA");
             break;
 
         case WC_PKCS12_DATA:

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1118,7 +1118,7 @@ int wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* derCert, word32 derCertSz)
         ret = wc_PKCS7_CheckPublicKeyDer(pkcs7, dCert->keyOID,
                                          dCert->publicKey, dCert->pubKeySize);
         if (ret != 0) {
-            WOLFSSL_MSG("Invalid public key, check pkcs7->cert\n");
+            WOLFSSL_MSG("Invalid public key, check pkcs7->cert");
             FreeDecodedCert(dCert);
 #ifdef WOLFSSL_SMALL_STACK
             XFREE(dCert, pkcs7->heap, DYNAMIC_TYPE_DCERT);
@@ -1128,7 +1128,7 @@ int wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* derCert, word32 derCertSz)
 
         if (dCert->pubKeySize > (MAX_RSA_INT_SZ + MAX_RSA_E_SZ) ||
             dCert->serialSz > MAX_SN_SZ) {
-            WOLFSSL_MSG("Invalid size in certificate\n");
+            WOLFSSL_MSG("Invalid size in certificate");
             FreeDecodedCert(dCert);
 #ifdef WOLFSSL_SMALL_STACK
             XFREE(dCert, pkcs7->heap, DYNAMIC_TYPE_DCERT);

--- a/wolfcrypt/src/port/Renesas/renesas_sce_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_sce_util.c
@@ -133,7 +133,7 @@ WOLFSSL_LOCAL int wc_sce_Open()
              g_CAscm_Idx = (uint32_t)-1;
             
         } else {
-            WOLFSSL_MSG("Failed to lock sce hw \n");
+            WOLFSSL_MSG("Failed to lock sce hw");
         }
 
     }
@@ -161,7 +161,7 @@ WOLFSSL_LOCAL void wc_sce_Close()
             WOLFSSL_MSG("RENESAS SCE Close failed");
         }
     } else {
-        WOLFSSL_MSG("Failed to unlock sce hw \n");
+        WOLFSSL_MSG("Failed to unlock sce hw");
     }
 }
 
@@ -512,7 +512,7 @@ WOLFSSL_LOCAL int wc_sce_Sha256GenerateHmac(const struct WOLFSSL *ssl,const uint
     wrapped_key = ssl->keys.sce_client_write_MAC_secret;
     
     if ((ret = wc_sce_hw_lock()) != 0) {
-        WOLFSSL_MSG("hw lock failed\n");
+        WOLFSSL_MSG("hw lock failed");
         return ret;
     }
     
@@ -564,7 +564,7 @@ WOLFSSL_LOCAL int wc_sce_Sha256VerifyHmac(const struct WOLFSSL *ssl,
     wrapped_key = ssl->keys.sce_server_write_MAC_secret;
 
     if ((ret = wc_sce_hw_lock()) != 0) {
-        WOLFSSL_MSG("hw lock failed\n");
+        WOLFSSL_MSG("hw lock failed");
         return ret;
     }
     
@@ -626,7 +626,7 @@ WOLFSSL_LOCAL int wc_sce_generateVerifyData(const uint8_t *ms, /* master secret 
         ret = R_SCE_TLS_VerifyDataGenerate(l_side, (uint32_t*)ms,
                        (uint8_t*)handshake_hash, hashes/* out */);
         if (ret != FSP_SUCCESS) {
-            WOLFSSL_MSG("R_SCE_TLS_VerifyDataGenerate failed\n");
+            WOLFSSL_MSG("R_SCE_TLS_VerifyDataGenerate failed");
         }
     }
     /* unlock hw */
@@ -680,7 +680,7 @@ WOLFSSL_LOCAL int wc_sce_generateSeesionKey(struct WOLFSSL *ssl,
         }
         
         if (ret != FSP_SUCCESS) {
-            WOLFSSL_MSG("R_SCE_TLS_SessionKeyGenerate failed\n");
+            WOLFSSL_MSG("R_SCE_TLS_SessionKeyGenerate failed");
         } else {
             /* succeeded creating session keys */
             /* alloc aes instance for both enc and dec */
@@ -756,7 +756,7 @@ WOLFSSL_LOCAL int wc_sce_generateSeesionKey(struct WOLFSSL *ssl,
         /* unlock hw */
         wc_sce_hw_unlock();
     } else 
-        WOLFSSL_LEAVE("hw lock failed\n", ret);
+        WOLFSSL_MSG("hw lock failed", ret);
     
     WOLFSSL_LEAVE("sce_generateSeesionKey", ret);
     return ret;
@@ -788,7 +788,7 @@ WOLFSSL_LOCAL int wc_sce_generateMasterSecret(
             (uint32_t*)pr,
             (uint8_t*)cr, (uint8_t*)sr, (uint32_t*)ms);
         if (ret != FSP_SUCCESS) {
-            WOLFSSL_MSG("R_SCE_TLS_MasterSecretGenerate failed\n");
+            WOLFSSL_MSG("R_SCE_TLS_MasterSecretGenerate failed");
         } 
         /* unlock hw */
         wc_sce_hw_unlock();
@@ -814,7 +814,7 @@ WOLFSSL_LOCAL int wc_sce_generatePremasterSecret(uint8_t *premaster,
             /* generate pre-master, 80 bytes */
             ret = R_SCE_TLS_PreMasterSecretGenerateForRSA2048((uint32_t*)premaster);
             if (ret != FSP_SUCCESS) {
-                WOLFSSL_MSG(" R_SCE_TLS_GeneratePreMasterSecret failed\n");
+                WOLFSSL_MSG(" R_SCE_TLS_GeneratePreMasterSecret failed");
             }
         /* unlock hw */
         wc_sce_hw_unlock();
@@ -851,7 +851,7 @@ WOLFSSL_LOCAL int wc_sce_generateEncryptPreMasterSecret(
             ret = -1;
             
         if (ret != FSP_SUCCESS) {
-            WOLFSSL_MSG("R_SCE_TLS_PreMasterSecretEncryptWithRSA2048 failed\n");
+            WOLFSSL_MSG("R_SCE_TLS_PreMasterSecretEncryptWithRSA2048 failed");
         } else {
             *outSz = 256; /* SCE can only handles 2048 RSA */
             /* set GenMaster Callback for Master secret generation */
@@ -893,11 +893,11 @@ WOLFSSL_LOCAL int wc_sce_tls_CertVerify(
       return BAD_FUNC_ARG;
     
     if (!signature) {
-        WOLFSSL_MSG(" signature for ca verification is not set\n");
+        WOLFSSL_MSG(" signature for ca verification is not set");
         return -1;
     }
     if (!sce_encPublickey) {
-        WOLFSSL_MSG(" sce_encPublickey is NULL.\n");
+        WOLFSSL_MSG(" sce_encPublickey is NULL.");
         return -1;
     }
     
@@ -981,7 +981,7 @@ WOLFSSL_LOCAL int wc_sce_tls_RootCertVerify(
       return BAD_FUNC_ARG;
       
     if (!signature) {
-        WOLFSSL_MSG(" signature for ca verification is not set\n");
+        WOLFSSL_MSG(" signature for ca verification is not set");
         return -1;
     }
    

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
@@ -329,7 +329,7 @@ int tsip_Open()
         /* unlock hw */
         tsip_hw_unlock();
     } else 
-        WOLFSSL_MSG("Failed to lock tsip hw \n");
+        WOLFSSL_MSG("Failed to lock tsip hw");
     
     WOLFSSL_MSG( "<< tsip_Open");
     return ret;
@@ -353,7 +353,7 @@ void tsip_Close()
             WOLFSSL_MSG("RENESAS TSIP Close failed");
         }
     } else
-        WOLFSSL_MSG("Failed to unlock tsip hw \n");
+        WOLFSSL_MSG("Failed to unlock tsip hw");
     WOLFSSL_MSG("<< tsip_Close");    
 }
 
@@ -441,7 +441,7 @@ int tsip_Sha1Hmac(
       return BAD_FUNC_ARG;
     
     if ((ret = tsip_hw_lock()) != 0) {
-        WOLFSSL_MSG("hw lock failed\n");
+        WOLFSSL_MSG("hw lock failed");
         return ret;
     }
     
@@ -507,7 +507,7 @@ int tsip_Sha256Hmac(
         key_index = ssl->keys.tsip_server_write_MAC_secret;
 
     if ((ret = tsip_hw_lock()) != 0) {
-        WOLFSSL_MSG("hw lock failed\n");
+        WOLFSSL_MSG("hw lock failed");
         return ret;
     }
     
@@ -561,7 +561,7 @@ int tsip_generateVerifyData(const byte *ms, /* master secret */
         ret = R_TSIP_TlsGenerateVerifyData(l_side, (uint32_t*)ms,
                        (uint8_t*)handshake_hash, hashes/* out */);
         if (ret != TSIP_SUCCESS) {
-            WOLFSSL_MSG("R_TSIP_TlsGenerateSessionKey failed\n");
+            WOLFSSL_MSG("R_TSIP_TlsGenerateSessionKey failed");
         }
     }
     /* unlock hw */
@@ -620,7 +620,7 @@ int tsip_generateSeesionKey(struct WOLFSSL *ssl)
                     NULL, NULL);
 #endif                
         if (ret != TSIP_SUCCESS) {
-            WOLFSSL_MSG("R_TSIP_TlsGenerateSessionKey failed\n");
+            WOLFSSL_MSG("R_TSIP_TlsGenerateSessionKey failed");
         } else {
             /* succeeded creating session keys */
             /* alloc aes instance for both enc and dec */
@@ -685,7 +685,7 @@ int tsip_generateSeesionKey(struct WOLFSSL *ssl)
         /* unlock hw */
         tsip_hw_unlock();
     } else 
-        WOLFSSL_MSG("hw lock failed\n");
+        WOLFSSL_MSG("hw lock failed");
     
     WOLFSSL_MSG("<< tsip_generateSeesionKey");
     return ret;
@@ -718,7 +718,7 @@ int tsip_generateMasterSecretEx(
             (uint32_t*)pr,
             (uint8_t*)cr, (uint8_t*)sr, (uint32_t*)ms);
         if (ret != TSIP_SUCCESS) {
-            WOLFSSL_MSG("R_TSIP_TlsGenerateMasterSecret failed\n");
+            WOLFSSL_MSG("R_TSIP_TlsGenerateMasterSecret failed");
         }
         /* unlock hw */
         tsip_hw_unlock();
@@ -751,7 +751,7 @@ int tsip_generateMasterSecret(
                 (uint32_t*)ms);
 
         if (ret != TSIP_SUCCESS) {
-            WOLFSSL_MSG("R_TSIP_TlsGenerateMasterSecret failed\n");
+            WOLFSSL_MSG("R_TSIP_TlsGenerateMasterSecret failed");
         }
         /* unlock hw */
         tsip_hw_unlock();
@@ -776,7 +776,7 @@ int tsip_generatePremasterSecret(byte *premaster, word32 preSz )
         /* generate pre-master, 80 bytes */
         ret = R_TSIP_TlsGeneratePreMasterSecret( (uint32_t*)premaster );
         if (ret != TSIP_SUCCESS) {
-            WOLFSSL_MSG(" R_TSIP_TlsGeneratePreMasterSecret failed\n");
+            WOLFSSL_MSG(" R_TSIP_TlsGeneratePreMasterSecret failed");
         }
         
         /* unlock hw */
@@ -824,7 +824,7 @@ int tsip_generateEncryptPreMasterSecret(
             ret = -1;
             
         if (ret != TSIP_SUCCESS) {
-            WOLFSSL_MSG(" R_TSIP_TlsEncryptPreMasterSecret failed\n");
+            WOLFSSL_MSG(" R_TSIP_TlsEncryptPreMasterSecret failed");
         } else {
             *outSz = 256; /* TSIP can only handles 2048 RSA */
         }
@@ -854,11 +854,11 @@ int tsip_tls_CertVerify(
       return BAD_FUNC_ARG;
     
     if (!signature) {
-        WOLFSSL_MSG(" signature for ca verification is not set\n");
+        WOLFSSL_MSG(" signature for ca verification is not set");
         return -1;
     }
     if (!tsip_encRsaKeyIndex) {
-        WOLFSSL_MSG(" tsip_encRsaKeyIndex is NULL.\n");
+        WOLFSSL_MSG(" tsip_encRsaKeyIndex is NULL.");
         return -1;
     }
     
@@ -920,7 +920,7 @@ int tsip_tls_RootCertVerify(
       return BAD_FUNC_ARG;
       
     if (!signature) {
-        WOLFSSL_MSG(" signature for ca verification is not set\n");
+        WOLFSSL_MSG(" signature for ca verification is not set");
         return -1;
     }
     

--- a/wolfcrypt/src/port/caam/wolfcaam_ecdsa.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_ecdsa.c
@@ -117,7 +117,7 @@ int wc_CAAM_EccSign(const byte* in, int inlen, byte* out, word32* outlen,
     /* check for known predetermined parameters */
     ecdsel = GetECDSEL(dp->id, CAAM_ECDSA_PD);
     if (ecdsel == 0) {
-        WOLFSSL_MSG("Unsupported curve type\n");
+        WOLFSSL_MSG("Unsupported curve type");
         return BAD_FUNC_ARG;
     }
 
@@ -175,7 +175,7 @@ int wc_CAAM_EccSign(const byte* in, int inlen, byte* out, word32* outlen,
         mp_free(&mpr);
         mp_free(&mps);
         if (ret != 0) {
-            WOLFSSL_MSG("Issue converting to signature\n");
+            WOLFSSL_MSG("Issue converting to signature");
             return -1;
         }
     }

--- a/wolfcrypt/src/port/caam/wolfcaam_init.c
+++ b/wolfcrypt/src/port/caam/wolfcaam_init.c
@@ -218,7 +218,7 @@ word32 wc_caamReadRegister(word32 reg)
     }
 
     if (ReadIODeviceRegister(caam, reg, &out) != Success) {
-         WOLFSSL_MSG("Error reading register\n");
+         WOLFSSL_MSG("Error reading register");
     }
 
     return (word32)out;
@@ -234,7 +234,7 @@ int wc_caamWriteRegister(word32 reg, word32 value)
     }
 
     if (WriteIODeviceRegister(caam, reg, value) != Success) {
-         WOLFSSL_MSG("Error writing to register\n");
+         WOLFSSL_MSG("Error writing to register");
     }
     return 0;
 }

--- a/wolfcrypt/src/port/iotsafe/iotsafe.c
+++ b/wolfcrypt/src/port/iotsafe/iotsafe.c
@@ -843,7 +843,7 @@ static int wolfIoT_ecc_sign(WOLFSSL* ssl,
     if (iotsafe == NULL) {
         return BAD_FUNC_ARG;
     }
-    WOLFSSL_MSG("IOTSAFE: Called wolfIoT_ecc_sign\n");
+    WOLFSSL_MSG("IOTSAFE: Called wolfIoT_ecc_sign");
 
 #ifdef DEBUG_IOTSAFE
     printf("IOTSAFE PK ECC Sign: InSz %d, KeySz %d\n", inSz, keySz);
@@ -995,7 +995,7 @@ static int wolfIoT_ecc_shared_secret(WOLFSSL* ssl, struct ecc_key* otherKey,
         return BAD_FUNC_ARG;
     }
 
-    WOLFSSL_MSG("IOTSAFE: Called wolfIoT_ecc_shared_secret\n");
+    WOLFSSL_MSG("IOTSAFE: Called wolfIoT_ecc_shared_secret");
 
 #ifdef DEBUG_IOTSAFE
     printf("IOTSAFE PK ECC PMS: Side %s, Peer Curve %d\n",
@@ -1119,7 +1119,7 @@ static int wolfIoT_dh_agree(WOLFSSL* ssl, struct DhKey* key,
         void* ctx)
 {
 
-    WOLFSSL_MSG("IOTSAFE: Called wolfIoT_ecc_dh_agree\n");
+    WOLFSSL_MSG("IOTSAFE: Called wolfIoT_ecc_dh_agree");
     (void)ctx;
     (void)ssl;
     (void)key;

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2258,7 +2258,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         }
 
         if (wc_LockMutex(&wnr_mutex) != 0) {
-            WOLFSSL_MSG("Bad Lock Mutex wnr_mutex\n");
+            WOLFSSL_MSG("Bad Lock Mutex wnr_mutex");
             return BAD_MUTEX_E;
         }
 


### PR DESCRIPTION
Extra newlines `\n` in `WOLFSSL_MSG` logging messages were deleted, since the newline symbols are added in `wolfssl_log()` function. Otherwise the logging adds extra empty lines.