### PR TITLE
IoT-SAFE module: improvements and bug fixes

### DIFF
--- a/IDE/iotsafe/Makefile
+++ b/IDE/iotsafe/Makefile
@@ -62,6 +62,7 @@ WOLFSSL_OBJS += 	\
 	$(WOLFSSL_BUILD)/wolfcrypt/poly1305.o  \
 	$(WOLFSSL_BUILD)/wolfcrypt/pwdbased.o  \
 	$(WOLFSSL_BUILD)/wolfcrypt/random.o  \
+	$(WOLFSSL_BUILD)/wolfcrypt/kdf.o  \
 	$(WOLFSSL_BUILD)/wolfcrypt/sha.o  \
 	$(WOLFSSL_BUILD)/wolfcrypt/sha256.o  \
 	$(WOLFSSL_BUILD)/wolfcrypt/sha512.o  \

--- a/IDE/iotsafe/Makefile
+++ b/IDE/iotsafe/Makefile
@@ -28,7 +28,6 @@ LDFLAGS+=-mcpu=cortex-m3
 LDFLAGS+=-lc -lg -lm
 LDFLAGS+=--specs=nosys.specs
 
-
 OBJS:=main.o startup.o devices.o memory-tls.o
 
 WOLFSSL_OBJS += 	\
@@ -80,8 +79,8 @@ OBJS+=$(WOLFSSL_OBJS) $(OBJS_SPMATH)
 vpath %.c $(dir $(WOLFSSL_ROOT)/src)
 vpath %.c $(dir $(WOLFSSL_ROOT)/wolfcrypt/src)
 
-CFLAGS+=-g -ggdb3
-#CFLAGS+=-O2
+#CFLAGS+=-g -ggdb3
+CFLAGS+=-Os
 
 #all: image.bin
 

--- a/IDE/iotsafe/main.c
+++ b/IDE/iotsafe/main.c
@@ -79,7 +79,7 @@ void main(void)
 {
     uint32_t last_mark = 0;
     int i;
-    char randombytes[16];
+    uint8_t randombytes[16];
     int ret;
     char c;
     WC_RNG rng;

--- a/IDE/iotsafe/memory-tls.c
+++ b/IDE/iotsafe/memory-tls.c
@@ -35,43 +35,8 @@
 
 #include <stdio.h>
 #include <string.h>
-
 #include "ca-cert.c"
 
-/* IoTSAFE Certificate slots */
-
-/* File Slot '03' is pre-provisioned with
- * local certificate.
- */
-#define CRT_CLIENT_FILE_ID 0x03     /* pre-provisioned */
-
-/* File Slot '04' is pre-provisioned with the
- * server's EC public key certificate
- */
-#define CRT_SERVER_FILE_ID 0x04
-
-/* IoTSAFE Key slots */
-
-/* Key slot '02' is pre-provisioned with
- * the client private key.
- */
-#define PRIVKEY_ID      0x02 /* pre-provisioned */
-
-/* Key slot '03' is used by wolfSSL to generate
- * the ECDH key that will be used during the TLS
- * session.
- */
-#define ECDH_KEYPAIR_ID 0x03
-
-/* Key slot '04' is used to store the public key
- * received from the peer.
- */
-#define PEER_PUBKEY_ID  0x04
-
-/* Key slot '05' is used to store a public key
- * used for ecc verification
- */
-#define PEER_CERT_ID    0x05
 
 /* The following define
  * activates mutual authentication */
@@ -178,6 +143,20 @@ static int client_loop(void)
     /* set up client */
     int ret;
     const char* helloStr = "hello iot-safe wolfSSL";
+    #if (IOTSAFE_ID_SIZE == 1)
+    byte cert_file_id, privkey_id, keypair_id, peer_pubkey_id, peer_cert_id;
+    byte ca_cert_id;
+    #else
+    word16 cert_file_id, privkey_id, keypair_id, peer_pubkey_id, peer_cert_id;
+    word16 ca_cert_id;
+    #endif
+    cert_file_id = CRT_CLIENT_FILE_ID;
+    privkey_id = PRIVKEY_ID;
+    keypair_id = ECDH_KEYPAIR_ID;
+    peer_pubkey_id = PEER_PUBKEY_ID;
+    peer_cert_id = PEER_CERT_ID;
+    ca_cert_id = CRT_SERVER_FILE_ID;
+
 
     printf("=== CLIENT step %d ===\n", client_state);
     if (client_state == 0) {
@@ -202,7 +181,8 @@ static int client_loop(void)
             return -1;
         }
 
-        cert_buffer_size = wolfIoTSafe_GetCert(CRT_SERVER_FILE_ID, cert_buffer,
+        cert_buffer_size = wolfIoTSafe_GetCert_ex(&ca_cert_id,IOTSAFE_ID_SIZE, 
+                cert_buffer, 
             sizeof(cert_buffer));
         if (cert_buffer_size < 1) {
             printf("Bad server cert\n");
@@ -219,7 +199,8 @@ static int client_loop(void)
         wolfSSL_CTX_set_verify(cli_ctx, WOLFSSL_VERIFY_PEER, NULL);
 
 #ifdef CLIENT_AUTH
-        cert_buffer_size = wolfIoTSafe_GetCert(CRT_CLIENT_FILE_ID, cert_buffer,
+        cert_buffer_size = wolfIoTSafe_GetCert_ex(&cert_file_id, IOTSAFE_ID_SIZE,
+                cert_buffer,
             sizeof(cert_buffer));
         if (cert_buffer_size < 1) {
             printf("Bad client cert\n");
@@ -248,8 +229,9 @@ static int client_loop(void)
         }
 
         printf("Setting TLS options: turn on IoT-safe for this socket\n");
-        wolfSSL_iotsafe_on(cli_ssl, PRIVKEY_ID, ECDH_KEYPAIR_ID,
-            PEER_PUBKEY_ID, PEER_CERT_ID);
+
+        wolfSSL_iotsafe_on_ex(cli_ssl, &privkey_id, &keypair_id,
+            &peer_pubkey_id, &peer_cert_id, IOTSAFE_ID_SIZE);
 
     #ifdef WOLFSSL_TLS13
         printf("Setting TLSv1.3 for SECP256R1 key share\n");
@@ -407,6 +389,7 @@ int memory_tls_test(void)
     wolfSSL_CTX_free(cli_ctx);
     wolfSSL_free(srv_ssl);
     wolfSSL_CTX_free(srv_ctx);
+
 
     return 0;
 }

--- a/IDE/iotsafe/memory-tls.c
+++ b/IDE/iotsafe/memory-tls.c
@@ -192,6 +192,8 @@ static int client_loop(void)
         }
         printf("Loaded Server CA from IoT-Safe, size = %lu\n",
                 cert_buffer_size);
+        ret = wolfSSL_CTX_load_verify_buffer(cli_ctx, cert_buffer,
+                cert_buffer_size, WOLFSSL_FILETYPE_ASN1);
 #endif
 
 

--- a/IDE/iotsafe/user_settings.h
+++ b/IDE/iotsafe/user_settings.h
@@ -40,7 +40,7 @@
     #define CRT_SERVER_FILE_ID  0x3330
     #define PRIVKEY_ID          0x3230     /* pre-provisioned */
     #define ECDH_KEYPAIR_ID     0x3330
-    #define PEER_PUBKEY_ID      0x3530
+    #define PEER_PUBKEY_ID      0x3730
     #define PEER_CERT_ID        0x3430
 
     /* In this version of the demo, the server certificate is
@@ -75,7 +75,9 @@
 
 /* Debugging */
 #define WOLFSSL_LOG_PRINTF
-#if 1
+
+/* Change to "if 1" to enable debug */
+#if 0
     #define DEBUG_WOLFSSL
     #define WOLFSSL_DEBUG_TLS
     #define DEBUG_IOTSAFE

--- a/IDE/iotsafe/user_settings.h
+++ b/IDE/iotsafe/user_settings.h
@@ -26,20 +26,31 @@
 #include <stdint.h>
 
 /* Uncomment next line to enable 2-bytes ID demo */
-//#define TWO_BYTES_ID_DEMO
+/* #define TWO_BYTES_ID_DEMO */
 
 
-/* IOT-Safe slot configuration for this example
+/* IOT-Safe slot configurations for this example:
+ *   - TWO_BYTES_ID_DEMO: two-bytes ID sim, with hardcoded CA
+ *   - Default: one-byte ID sim, with hardcoded server certificate
  */
 
 #ifdef TWO_BYTES_ID_DEMO
     #define IOTSAFE_ID_SIZE 2
     #define CRT_CLIENT_FILE_ID  0x3430     /* pre-provisioned */
     #define CRT_SERVER_FILE_ID  0x3330
-    #define PRIVKEY_ID          0x3230 /* pre-provisioned */
+    #define PRIVKEY_ID          0x3230     /* pre-provisioned */
     #define ECDH_KEYPAIR_ID     0x3330
     #define PEER_PUBKEY_ID      0x3430
     #define PEER_CERT_ID        0x3530
+
+    /* In this version of the demo, the server certificate is
+     * stored in a buffer, while the CA is read from a file slot in IoT-SAFE
+     */
+    #define SOFT_SERVER_CERT
+
+    /* DELME */
+    #define SOFT_SERVER_CA
+
 #else
     #define IOTSAFE_ID_SIZE     1
     #define CRT_CLIENT_FILE_ID  0x03     /* pre-provisioned */
@@ -48,6 +59,11 @@
     #define ECDH_KEYPAIR_ID     0x03
     #define PEER_PUBKEY_ID      0x04
     #define PEER_CERT_ID        0x05
+
+    /* In this version of the demo, the server certificate is
+     * read from a file slot in IoT-SAFE, while the CA is stored in buffer in memory
+     */
+    #define SOFT_SERVER_CA
 #endif
 
 

--- a/IDE/iotsafe/user_settings.h
+++ b/IDE/iotsafe/user_settings.h
@@ -23,8 +23,35 @@
 
 #ifndef IOTSAFE_EXAMPLE_USER_SETTINGS_H
 #define IOTSAFE_EXAMPLE_USER_SETTINGS_H
-
 #include <stdint.h>
+
+/* Uncomment next line to enable 2-bytes ID demo */
+//#define TWO_BYTES_ID_DEMO
+
+
+/* IOT-Safe slot configuration for this example
+ */
+
+#ifdef TWO_BYTES_ID_DEMO
+    #define IOTSAFE_ID_SIZE 2
+    #define CRT_CLIENT_FILE_ID  0x3430     /* pre-provisioned */
+    #define CRT_SERVER_FILE_ID  0x3330
+    #define PRIVKEY_ID          0x3230 /* pre-provisioned */
+    #define ECDH_KEYPAIR_ID     0x3330
+    #define PEER_PUBKEY_ID      0x3430
+    #define PEER_CERT_ID        0x3530
+#else
+    #define IOTSAFE_ID_SIZE     1
+    #define CRT_CLIENT_FILE_ID  0x03     /* pre-provisioned */
+    #define CRT_SERVER_FILE_ID  0x04
+    #define PRIVKEY_ID          0x02 /* pre-provisioned */
+    #define ECDH_KEYPAIR_ID     0x03
+    #define PEER_PUBKEY_ID      0x04
+    #define PEER_CERT_ID        0x05
+#endif
+
+
+
 
 /* Platform */
 #define WOLFSSL_IOTSAFE
@@ -33,9 +60,10 @@
 #define SINGLE_THREADED
 #define WOLFSSL_USER_IO
 
+
 /* Debugging */
 #define WOLFSSL_LOG_PRINTF
-#if 0
+#if 1
     #define DEBUG_WOLFSSL
     #define WOLFSSL_DEBUG_TLS
     #define DEBUG_IOTSAFE
@@ -50,6 +78,8 @@
 #define HAVE_IOTSAFE_HWRNG
 #define HAVE_HASHDRBG
 #define NO_OLD_RNGNAME
+
+//#define USE_GENSEED_FORTEST
 
 /* Time porting */
 #define TIME_OVERRIDES

--- a/IDE/iotsafe/user_settings.h
+++ b/IDE/iotsafe/user_settings.h
@@ -26,7 +26,7 @@
 #include <stdint.h>
 
 /* Uncomment next line to enable 2-bytes ID demo */
-#define TWO_BYTES_ID_DEMO
+/* #define TWO_BYTES_ID_DEMO */
 
 
 /* IOT-Safe slot configurations for this example:

--- a/IDE/iotsafe/user_settings.h
+++ b/IDE/iotsafe/user_settings.h
@@ -26,7 +26,7 @@
 #include <stdint.h>
 
 /* Uncomment next line to enable 2-bytes ID demo */
-/* #define TWO_BYTES_ID_DEMO */
+#define TWO_BYTES_ID_DEMO
 
 
 /* IOT-Safe slot configurations for this example:

--- a/IDE/iotsafe/user_settings.h
+++ b/IDE/iotsafe/user_settings.h
@@ -40,17 +40,13 @@
     #define CRT_SERVER_FILE_ID  0x3330
     #define PRIVKEY_ID          0x3230     /* pre-provisioned */
     #define ECDH_KEYPAIR_ID     0x3330
-    #define PEER_PUBKEY_ID      0x3430
-    #define PEER_CERT_ID        0x3530
+    #define PEER_PUBKEY_ID      0x3530
+    #define PEER_CERT_ID        0x3430
 
     /* In this version of the demo, the server certificate is
      * stored in a buffer, while the CA is read from a file slot in IoT-SAFE
      */
     #define SOFT_SERVER_CERT
-
-    /* DELME */
-    #define SOFT_SERVER_CA
-
 #else
     #define IOTSAFE_ID_SIZE     1
     #define CRT_CLIENT_FILE_ID  0x03     /* pre-provisioned */

--- a/doc/dox_comments/header_files/iotsafe.h
+++ b/doc/dox_comments/header_files/iotsafe.h
@@ -25,6 +25,10 @@ WOLFSSL_API int wolfSSL_CTX_iotsafe_enable(WOLFSSL_CTX *ctx);
 /*!
     \ingroup IoTSafe
     \brief This function connects the IoT-Safe TLS callbacks to the given SSL session.
+    \brief This should be called to connect a SSL session to IoT-Safe applet when the
+           ID of the slots are one-byte long.
+           If IoT-SAFE slots have an ID of two or more bytes, \ref wolfSSL_iotsafe_on_ex "wolfSSL_iotsafe_on_ex()"
+           should be used instead.
 
     \param ssl pointer to the WOLFSSL object where the callbacks will be enabled
     \param privkey_id id of the iot-safe applet slot containing the private key for the host
@@ -48,13 +52,70 @@ WOLFSSL_API int wolfSSL_CTX_iotsafe_enable(WOLFSSL_CTX *ctx);
     if (!ssl)
         return NULL;
     // Enable IoT-Safe and associate key slots
-    ret = wolfSSL_CTX_iotsafe_on(ssl, PRIVKEY_ID, ECDH_KEYPAIR_ID, PEER_PUBKEY_ID, PEER_CERT_ID);
+    ret = wolfSSL_CTX_iotsafe_enable(ctx);
+    if (ret == 0) {
+        ret = wolfSSL_iotsafe_on(ssl, PRIVKEY_ID, ECDH_KEYPAIR_ID, PEER_PUBKEY_ID, PEER_CERT_ID);
+    }
     \endcode
 
+    \sa wolfSSL_iotsafe_on_ex
     \sa wolfSSL_CTX_iotsafe_enable
 */
 WOLFSSL_API int wolfSSL_iotsafe_on(WOLFSSL *ssl, byte privkey_id,
        byte ecdh_keypair_slot, byte peer_pubkey_slot, byte peer_cert_slot);
+
+
+/*!
+    \ingroup IoTSafe
+    \brief This function connects the IoT-Safe TLS callbacks to the given SSL session.
+           This is equivalent to \ref wolfSSL_iotsafe_on "wolfSSL_iotsafe_on" except that the IDs for the IoT-SAFE
+           slots can be passed by reference, and the length of the ID fields can be specified via
+           the parameter "id_size".
+
+
+    \param ssl pointer to the WOLFSSL object where the callbacks will be enabled
+    \param privkey_id pointer to the id of the iot-safe applet slot containing the private key for the host
+    \param ecdh_keypair_slot pointer to the id of the iot-safe applet slot to store the ECDH keypair
+    \param peer_pubkey_slot pointer to the of id the iot-safe applet slot to store the other endpoint's public key for ECDH
+    \param peer_cert_slot pointer to the id of the iot-safe applet slot to store the other endpoint's public key for verification
+    \param id_size size of each slot ID
+    \return 0 upon success
+    \return NOT_COMPILED_IN if HAVE_PK_CALLBACKS is disabled
+    \return BAD_FUNC_ARG if the ssl pointer is invalid
+
+    _Example_
+    \code
+    // Define key ids for IoT-Safe (16 bit, little endian)
+    #define PRIVKEY_ID 0x0201
+    #define ECDH_KEYPAIR_ID 0x0301
+    #define PEER_PUBKEY_ID 0x0401
+    #define PEER_CERT_ID 0x0501
+    #define ID_SIZE (sizeof(word16))
+
+    word16 privkey = PRIVKEY_ID,
+             ecdh_keypair = ECDH_KEYPAIR_ID,
+             peer_pubkey = PEER_PUBKEY_ID,
+             peer_cert = PEER_CERT_ID;
+
+
+
+    // Create new ssl session
+    WOLFSSL *ssl;
+    ssl = wolfSSL_new(ctx);
+    if (!ssl)
+        return NULL;
+    // Enable IoT-Safe and associate key slots
+    ret = wolfSSL_CTX_iotsafe_enable(ctx);
+    if (ret == 0) {
+        ret = wolfSSL_CTX_iotsafe_on_ex(ssl, &privkey, &ecdh_keypair, &peer_pubkey, &peer_cert, ID_SIZE);
+    }
+    \endcode
+
+    \sa wolfSSL_iotsafe_on
+    \sa wolfSSL_CTX_iotsafe_enable
+*/
+WOLFSSL_API int wolfSSL_iotsafe_on_ex(WOLFSSL *ssl, byte *privkey_id,
+       byte *ecdh_keypair_slot, byte *peer_pubkey_slot, byte *peer_cert_slot, word16 id_size);
 
 
 /*!
@@ -120,14 +181,14 @@ WOLFSSL_API int wolfIoTSafe_GetRandom(unsigned char* out, word32 sz);
 /*!
     \ingroup IoTSafe
     \brief Import a certificate stored in a file on IoT-Safe applet, and
-    store it locally in memory.
+    store it locally in memory. Works with one-byte file ID field.
 
     \param id The file id in the IoT-Safe applet where the certificate is stored
     \param output the buffer where the certificate will be imported
     \param sz the maximum size available in the buffer output
     \return the length of the certificate imported
     \return < 0 in case of failure
-    
+
     _Example_
     \code
     #define CRT_CLIENT_FILE_ID 0x03
@@ -139,7 +200,7 @@ WOLFSSL_API int wolfIoTSafe_GetRandom(unsigned char* out, word32 sz);
         return -1;
     }
     printf("Loaded Client certificate from IoT-Safe, size = %lu\n", cert_buffer_size);
-    
+
     // Use the certificate buffer as identity for the TLS client context
     if (wolfSSL_CTX_use_certificate_buffer(cli_ctx, cert_buffer,
                 cert_buffer_size, SSL_FILETYPE_ASN1) != SSL_SUCCESS) {
@@ -153,6 +214,47 @@ WOLFSSL_API int wolfIoTSafe_GetRandom(unsigned char* out, word32 sz);
 WOLFSSL_API int wolfIoTSafe_GetCert(uint8_t id, unsigned char *output, unsigned long sz);
 
 
+/*!
+    \ingroup IoTSafe
+    \brief Import a certificate stored in a file on IoT-Safe applet, and
+    store it locally in memory. Equivalent to \ref wolfIoTSafe_GetCert "wolfIoTSafe_GetCert",
+    except that it can be invoked with a file ID of two or more bytes.
+
+    \param id Pointer to the file id in the IoT-Safe applet where the certificate is stored
+    \param id_sz Size of the file id in bytes
+    \param output the buffer where the certificate will be imported
+    \param sz the maximum size available in the buffer output
+    \return the length of the certificate imported
+    \return < 0 in case of failure
+
+    _Example_
+    \code
+    #define CRT_CLIENT_FILE_ID 0x0302
+    #define ID_SIZE (sizeof(word16))
+    unsigned char cert_buffer[2048];
+    word16 client_file_id = CRT_CLIENT_FILE_ID;
+
+
+
+    // Get the certificate into the buffer
+    cert_buffer_size = wolfIoTSafe_GetCert_ex(&client_file_id, ID_SIZE, cert_buffer, 2048);
+    if (cert_buffer_size < 1) {
+        printf("Bad cli cert\n");
+        return -1;
+    }
+    printf("Loaded Client certificate from IoT-Safe, size = %lu\n", cert_buffer_size);
+
+    // Use the certificate buffer as identity for the TLS client context
+    if (wolfSSL_CTX_use_certificate_buffer(cli_ctx, cert_buffer,
+                cert_buffer_size, SSL_FILETYPE_ASN1) != SSL_SUCCESS) {
+        printf("Cannot load client cert\n");
+        return -1;
+    }
+    printf("Client certificate successfully imported.\n");
+    \endcode
+
+*/
+WOLFSSL_API int wolfIoTSafe_GetCert_ex(uint8_t *id, uint16_t id_sz, unsigned char *output, unsigned long sz);
 
 /*!
     \ingroup IoTSafe
@@ -163,7 +265,7 @@ WOLFSSL_API int wolfIoTSafe_GetCert(uint8_t id, unsigned char *output, unsigned 
     \param id The key id in the IoT-Safe applet where the public key is stored
     \return 0 upon success
     \return < 0 in case of failure
-    
+
 
     \sa wc_iotsafe_ecc_export_public
     \sa wc_iotsafe_ecc_export_private
@@ -178,13 +280,33 @@ WOLFSSL_API int wc_iotsafe_ecc_import_public(ecc_key *key, byte key_id);
     \param id The key id in the IoT-Safe applet where the public key will be stored
     \return 0 upon success
     \return < 0 in case of failure
-    
+
+
+    \sa wc_iotsafe_ecc_import_public_ex
+    \sa wc_iotsafe_ecc_export_private
+
+*/
+WOLFSSL_API int wc_iotsafe_ecc_export_public(ecc_key *key, byte key_id);
+
+
+/*!
+    \ingroup IoTSafe
+    \brief Export an ECC 256-bit public key, from ecc_key object to a writable public-key slot into the IoT-Safe applet.
+           Equivalent to \ref wc_iotsafe_ecc_import_public "wc_iotsafe_ecc_import_public",
+           except that it can be invoked with a key ID of two or more bytes.
+    \param key the ecc_key object containing the key to be exported
+    \param id The pointer to the key id in the IoT-Safe applet where the public key will be stored
+    \param id_size The key id size
+
+    \return 0 upon success
+    \return < 0 in case of failure
+
 
     \sa wc_iotsafe_ecc_import_public
     \sa wc_iotsafe_ecc_export_private
 
 */
-WOLFSSL_API int wc_iotsafe_ecc_export_public(ecc_key *key, byte key_id);
+WOLFSSL_API int wc_iotsafe_ecc_import_public_ex(ecc_key *key, byte *key_id, word16 id_size);
 
 /*!
     \ingroup IoTSafe
@@ -193,13 +315,34 @@ WOLFSSL_API int wc_iotsafe_ecc_export_public(ecc_key *key, byte key_id);
     \param id The key id in the IoT-Safe applet where the private key will be stored
     \return 0 upon success
     \return < 0 in case of failure
-    
 
+
+    \sa wc_iotsafe_ecc_export_private_ex
     \sa wc_iotsafe_ecc_import_public
     \sa wc_iotsafe_ecc_export_public
 
 */
 WOLFSSL_API int wc_iotsafe_ecc_export_private(ecc_key *key, byte key_id);
+
+/*!
+    \ingroup IoTSafe
+    \brief Export an ECC 256-bit key, from ecc_key object to a writable private-key slot into the IoT-Safe applet.
+           Equivalent to \ref wc_iotsafe_ecc_export_private "wc_iotsafe_ecc_export_private",
+           except that it can be invoked with a key ID of two or more bytes.
+
+    \param key the ecc_key object containing the key to be exported
+    \param id The pointer to the key id in the IoT-Safe applet where the private key will be stored
+    \param id_size The key id size
+    \return 0 upon success
+    \return < 0 in case of failure
+
+
+    \sa wc_iotsafe_ecc_export_private
+    \sa wc_iotsafe_ecc_import_public
+    \sa wc_iotsafe_ecc_export_public
+
+*/
+WOLFSSL_API int wc_iotsafe_ecc_export_private_ex(ecc_key *key, byte *key_id, word16 id_size);
 
 /*!
     \ingroup IoTSafe
@@ -214,12 +357,36 @@ WOLFSSL_API int wc_iotsafe_ecc_export_private(ecc_key *key, byte key_id);
     written to out upon successfully generating a message signature
     \return 0 upon success
     \return < 0 in case of failure
-    
+
+    \sa wc_iotsafe_ecc_sign_hash_ex
     \sa wc_iotsafe_ecc_verify_hash
     \sa wc_iotsafe_ecc_gen_k
 
 */
 WOLFSSL_API int wc_iotsafe_ecc_sign_hash(byte *in, word32 inlen, byte *out, word32 *outlen, byte key_id);
+
+/*!
+    \ingroup IoTSafe
+    \brief Sign a pre-computed 256-bit HASH, using a private key previously stored, or pre-provisioned,
+           in the IoT-Safe applet. Equivalent to \ref wc_iotsafe_ecc_sign_hash "wc_iotsafe_ecc_sign_hash",
+           except that it can be invoked with a key ID of two or more bytes.
+
+    \param in pointer to the buffer containing the message hash to sign
+    \param inlen length of the message hash to sign
+    \param out buffer in which to store the generated signature
+    \param outlen max length of the output buffer. Will store the bytes
+    \param id pointer to a key id in the IoT-Safe applet for the slot containing the private key to sign the payload
+        written to out upon successfully generating a message signature
+    \param id_size The key id size
+    \return 0 upon success
+    \return < 0 in case of failure
+
+    \sa wc_iotsafe_ecc_sign_hash
+    \sa wc_iotsafe_ecc_verify_hash
+    \sa wc_iotsafe_ecc_gen_k
+
+*/
+WOLFSSL_API int wc_iotsafe_ecc_sign_hash_ex(byte *in, word32 inlen, byte *out, word32 *outlen, byte *key_id, word16 id_size);
 
 /*!
     \ingroup IoTSafe
@@ -236,6 +403,7 @@ WOLFSSL_API int wc_iotsafe_ecc_sign_hash(byte *in, word32 inlen, byte *out, word
     \param res Result of signature, 1==valid, 0==invalid
     \param key_id The id of the slot where the public ECC key is stored in the IoT-Safe applet
 
+    \sa wc_iotsafe_ecc_verify_hash_ex
     \sa wc_iotsafe_ecc_sign_hash
     \sa wc_iotsafe_ecc_gen_k
 
@@ -244,13 +412,54 @@ WOLFSSL_API int wc_iotsafe_ecc_verify_hash(byte *sig, word32 siglen, byte *hash,
 
 /*!
     \ingroup IoTSafe
+    \brief Verify an ECC signature against a pre-computed 256-bit HASH, using a public key previously stored, or pre-provisioned,
+    in the IoT-Safe applet. Result is written to res. 1 is valid, 0 is invalid.
+    Note: Do not use the return value to test for valid. Only use res.
+    Equivalent to \ref wc_iotsafe_ecc_verify_hash "wc_iotsafe_ecc_verify_hash",
+    except that it can be invoked with a key ID of two or more bytes.
+
+    \return 0 upon success (even if the signature is not valid)
+    \return < 0 in case of failure.
+
+    \param sig  buffer containing the signature to verify
+    \param hash The hash (message digest) that was signed
+    \param hashlen The length of the hash (octets)
+    \param res Result of signature, 1==valid, 0==invalid
+    \param key_id The id of the slot where the public ECC key is stored in the IoT-Safe applet
+    \param id_size The key id size
+
+    \sa wc_iotsafe_ecc_verify_hash
+    \sa wc_iotsafe_ecc_sign_hash
+    \sa wc_iotsafe_ecc_gen_k
+
+*/
+WOLFSSL_API int wc_iotsafe_ecc_verify_hash_ex(byte *sig, word32 siglen, byte *hash, word32 hashlen, int *res, byte *key_id, word16 id_size);
+
+/*!
+    \ingroup IoTSafe
     \brief Generate an ECC 256-bit keypair and store it in a (writable) slot into the IoT-Safe applet.
     \param key_id The id of the slot where the ECC key pair is stored in the IoT-Safe applet.
     \return 0 upon success
     \return < 0 in case of failure.
 
+    \sa wc_iotsafe_ecc_gen_k_ex
     \sa wc_iotsafe_ecc_sign_hash
     \sa wc_iotsafe_ecc_verify_hash
 */
 WOLFSSL_API int wc_iotsafe_ecc_gen_k(byte key_id);
 
+/*!
+    \ingroup IoTSafe
+    \brief Generate an ECC 256-bit keypair and store it in a (writable) slot into the IoT-Safe applet.
+           Equivalent to \ref wc_iotsafe_ecc_gen_k "wc_iotsafe_ecc_gen_k",
+           except that it can be invoked with a key ID of two or more bytes.
+    \param key_id The id of the slot where the ECC key pair is stored in the IoT-Safe applet.
+    \param id_size The key id size
+    \return 0 upon success
+    \return < 0 in case of failure.
+
+    \sa wc_iotsafe_ecc_gen_k
+    \sa wc_iotsafe_ecc_sign_hash_ex
+    \sa wc_iotsafe_ecc_verify_hash_ex
+*/
+WOLFSSL_API int wc_iotsafe_ecc_gen_k(byte key_id);

--- a/wolfcrypt/src/port/iotsafe/iotsafe.c
+++ b/wolfcrypt/src/port/iotsafe/iotsafe.c
@@ -387,8 +387,9 @@ static int expect_csim_response(const char *cmd, word32 size, char **reply)
     ret -= 2;
     if (ret >= 4) {
         endstr = XSTRSTR(payload, "9000\"");
-        if (endstr == NULL)
+        if (endstr == NULL) {
             endstr = XSTRSTR(payload, "\"");
+        }
         if (endstr) {
             *endstr = 0;
             ret = (int)XSTRLEN(payload);
@@ -420,7 +421,7 @@ static int iotsafe_init(void)
 
     WOLFSSL_MSG("ATE0 OK!");
     if (expect_csim_response(atcmd_load_applet_str,
-                (word32)XSTRLEN(atcmd_load_applet_str), &reply) < 1) {
+                (word32)XSTRLEN(atcmd_load_applet_str), &reply) < 0) {
         WOLFSSL_MSG("FAIL: no Applet code response from iot-safe init");
     } else {
         WOLFSSL_MSG("IoT Safe Applet INIT OK");

--- a/wolfcrypt/src/port/iotsafe/iotsafe.c
+++ b/wolfcrypt/src/port/iotsafe/iotsafe.c
@@ -423,6 +423,7 @@ static int iotsafe_init(void)
     if (expect_csim_response(atcmd_load_applet_str,
                 (word32)XSTRLEN(atcmd_load_applet_str), &reply) < 0) {
         WOLFSSL_MSG("FAIL: no Applet code response from iot-safe init");
+        expect_ok("AT", 2);
     } else {
         WOLFSSL_MSG("IoT Safe Applet INIT OK");
     }

--- a/wolfcrypt/src/port/iotsafe/iotsafe.c
+++ b/wolfcrypt/src/port/iotsafe/iotsafe.c
@@ -627,8 +627,8 @@ static int iotsafe_put_public_key(byte *pubkey_id, unsigned long id_size,
 
     /* Export raw Qx, Qy values */
     ret = wc_ecc_export_public_raw(key,
-        ecc_pub_raw + 4 + id_size, &qxlen,
-        ecc_pub_raw + 4 + id_size + IOTSAFE_ECC_KSIZE, &qylen);
+        ecc_pub_raw + 5, &qxlen,
+        ecc_pub_raw + 5 + IOTSAFE_ECC_KSIZE, &qylen);
     if (ret != 0) {
         WOLFSSL_MSG("IoT Safe: Could not export public key: Error");
         return ret;

--- a/wolfcrypt/src/port/iotsafe/iotsafe.c
+++ b/wolfcrypt/src/port/iotsafe/iotsafe.c
@@ -1420,17 +1420,17 @@ int wolfSSL_iotsafe_on_ex(WOLFSSL *ssl, byte *privkey_id,
 #if defined(HAVE_PK_CALLBACKS)
     int ret;
     IOTSAFE iotsafe;
-    if (id_size == 1) {
-        iotsafe.privkey_id = *privkey_id;
-        iotsafe.ecdh_keypair_slot = *ecdh_keypair_slot;
-        iotsafe.peer_pubkey_slot = *peer_pubkey_slot;
-        iotsafe.peer_cert_slot = *peer_cert_slot;
-    } else if (id_size == 2) {
-        XMEMCPY(&iotsafe.privkey_id, privkey_id, id_size);
-        XMEMCPY(&iotsafe.ecdh_keypair_slot, ecdh_keypair_slot, id_size);
-        XMEMCPY(&iotsafe.peer_pubkey_slot, peer_pubkey_slot, id_size);
-        XMEMCPY(&iotsafe.peer_cert_slot, peer_cert_slot, id_size);
-    }
+#ifdef TWO_BYTES_ID_DEMO
+    iotsafe.privkey_id = *privkey_id;
+    iotsafe.ecdh_keypair_slot = *ecdh_keypair_slot;
+    iotsafe.peer_pubkey_slot = *peer_pubkey_slot;
+    iotsafe.peer_cert_slot = *peer_cert_slot;
+#else
+    XMEMCPY(&iotsafe.privkey_id, privkey_id, id_size);
+    XMEMCPY(&iotsafe.ecdh_keypair_slot, ecdh_keypair_slot, id_size);
+    XMEMCPY(&iotsafe.peer_pubkey_slot, peer_pubkey_slot, id_size);
+    XMEMCPY(&iotsafe.peer_cert_slot, peer_cert_slot, id_size);
+#endif
     iotsafe.enabled = 1;
     ret = wolfSSL_set_iotsafe_ctx(ssl, &iotsafe);
     if (ret == 0) {

--- a/wolfcrypt/src/port/iotsafe/iotsafe.c
+++ b/wolfcrypt/src/port/iotsafe/iotsafe.c
@@ -354,8 +354,6 @@ static int expect_csim_response(const char *cmd, word32 size, char **reply)
     payload++;
     if (XSTRNCMP(payload, "61", 2) == 0) {
         if (hex_to_bytes(payload + 2, &len, 1) == 1) {
-            if (len == 0)
-                len = 256;
             iotsafe_cmd_start(csim_cmd,1,IOTSAFE_INS_GETRESPONSE, 0, 0);
             bytes_to_hex(&len, csim_cmd + AT_CSIM_CMD_SIZE + AT_CMD_LC_POS, 1);
             csim_cmd[AT_CSIM_CMD_SIZE + AT_CMD_HDR_SIZE] = 0;

--- a/wolfcrypt/src/port/iotsafe/iotsafe.c
+++ b/wolfcrypt/src/port/iotsafe/iotsafe.c
@@ -140,8 +140,6 @@ static int expect_tok(const char *cmd, int size, const char *tok, char **repl)
 #ifdef DEBUG_IOTSAFE
         if (ret > 0)
             printf("<<< %s\n", csim_read_buf);
-        else
-            printf("<<< csim_read returned %d\n", ret);
 #endif
         if (tok && (ret > 0) && !r_found) {
             /* Mark the beginning of the match in the reply. */
@@ -462,7 +460,9 @@ static int iotsafe_readfile(uint8_t *file_id, uint16_t file_id_sz,
             return -1;
         file_sz = (fs_msb << 8) + fs_lsb;
         WOLFSSL_MSG("Stat successful on file");
-        printf("File size: %d (%04x)", file_sz, file_sz);
+        #ifdef DEBUG_IOTSAFE
+            printf("File size: %d (%04x)", file_sz, file_sz);
+        #endif
     }
 
     if (file_sz > max_size) {
@@ -1056,7 +1056,9 @@ static int wolfIoT_ecc_verify(WOLFSSL *ssl,
             /* Store public key in IoT-safe slot */
             ret = iotsafe_put_public_key(pubkey_slot, id_size, key);
             if (ret < 0) {
+            #ifdef DEBUG_IOTSAFE
                 printf("IOTSAFE: put public key failed\n");
+            #endif
             }
         }
         if (ret == 0) {

--- a/wolfcrypt/src/port/iotsafe/iotsafe.c
+++ b/wolfcrypt/src/port/iotsafe/iotsafe.c
@@ -909,6 +909,9 @@ static int wolfIoT_ecc_keygen(WOLFSSL* ssl, struct ecc_key* key,
         if (ret == 0) {
             ret = iotsafe_get_public_key((byte *)&iotsafe->ecdh_keypair_slot,
                     IOTSAFE_ID_SIZE, key);
+        } else if (ret > 0) {
+            /* Key has been stored during generation */
+            ret = 0;
         }
     } else {
         WC_RNG *rng = wolfSSL_GetRNG(ssl);

--- a/wolfssl/wolfcrypt/port/iotsafe/iotsafe.h
+++ b/wolfssl/wolfcrypt/port/iotsafe/iotsafe.h
@@ -34,6 +34,9 @@ WOLFSSL_API int wolfSSL_CTX_iotsafe_enable(WOLFSSL_CTX *ctx);
 WOLFSSL_API int wolfSSL_iotsafe_on(WOLFSSL *ssl, byte privkey_id,
        byte ecdh_keypair_slot, byte peer_pubkey_slot, byte peer_cert_slot);
 
+WOLFSSL_API int wolfSSL_iotsafe_on_ex(WOLFSSL *ssl, byte *privkey_id,
+       byte *ecdh_keypair_slot, byte *peer_pubkey_slot, byte *peer_cert_slot, word16 id_size);
+
 
 typedef int  (*wolfSSL_IOTSafe_CSIM_write_cb)(const char*, int);
 typedef int  (*wolfSSL_IOTSafe_CSIM_read_cb)(char *, int);
@@ -54,6 +57,13 @@ WOLFSSL_API int wc_iotsafe_ecc_export_private(ecc_key *key, byte key_id);
 WOLFSSL_API int wc_iotsafe_ecc_sign_hash(byte *in, word32 inlen, byte *out, word32 *outlen, byte key_id);
 WOLFSSL_API int wc_iotsafe_ecc_verify_hash(byte *sig, word32 siglen, byte *hash, word32 hashlen, int *res, byte key_id);
 WOLFSSL_API int wc_iotsafe_ecc_gen_k(byte key_id);
+
+WOLFSSL_API int wc_iotsafe_ecc_import_public_ex(ecc_key *key, byte *key_id, word16 id_size);
+WOLFSSL_API int wc_iotsafe_ecc_export_public_ex(ecc_key *key, byte *key_id, word16 id_size);
+WOLFSSL_API int wc_iotsafe_ecc_export_private_ex(ecc_key *key, byte *key_id, word16 id_size);
+WOLFSSL_API int wc_iotsafe_ecc_sign_hash_ex(byte *in, word32 inlen, byte *out, word32 *outlen, byte *key_id, word16 id_size);
+WOLFSSL_API int wc_iotsafe_ecc_verify_hash_ex(byte *sig, word32 siglen, byte *hash, word32 hashlen, int *res, byte *key_id, word16 id_size);
+WOLFSSL_API int wc_iotsafe_ecc_gen_k_ex(byte *key_id, word16 id_size);
 #endif
 
 
@@ -65,12 +75,26 @@ WOLFSSL_API int wc_iotsafe_ecc_gen_k(byte key_id);
     #endif
 #endif
 
+#ifndef IOTSAFE_ID_SIZE
+#   define IOTSAFE_ID_SIZE 1
+#endif
+
 struct wc_IOTSAFE {
     int enabled;
+
+#if (IOTSAFE_ID_SIZE == 1)
     byte privkey_id;
     byte ecdh_keypair_slot;
     byte peer_pubkey_slot;
     byte peer_cert_slot;
+#elif (IOTSAFE_ID_SIZE == 2)
+    word16 privkey_id;
+    word16 ecdh_keypair_slot;
+    word16 peer_pubkey_slot;
+    word16 peer_cert_slot;
+#else
+#error "IOTSAFE: ID_SIZE not supported"
+#endif
 };
 typedef struct wc_IOTSAFE IOTSAFE;
 

--- a/wolfssl/wolfcrypt/port/iotsafe/iotsafe.h
+++ b/wolfssl/wolfcrypt/port/iotsafe/iotsafe.h
@@ -46,6 +46,7 @@ WOLFSSL_API void wolfIoTSafe_SetCSIM_write_cb(wolfSSL_IOTSafe_CSIM_write_cb wf);
 
 WOLFSSL_API int wolfIoTSafe_GetRandom(unsigned char* out, word32 sz);
 WOLFSSL_API int wolfIoTSafe_GetCert(uint8_t id, unsigned char *output, unsigned long sz);
+WOLFSSL_API int wolfIoTSafe_GetCert_ex(uint8_t *id, uint16_t id_sz, unsigned char *output, unsigned long sz);
 
 #ifdef HAVE_ECC
 #include <wolfssl/wolfcrypt/ecc.h>


### PR DESCRIPTION
- Added support for Key/File slot IDs larger than one byte
    - new API functions passing Key/File IDs via ptr + len
    - new demo case with `TWO_BYTES_ID` compile time option
- Fixes retrieving the public key after key generation
    - now supports both cases (implicit key returned from `generate key` command or explicit `get public` called afterwards)
- Fixes in the reply parser
- Fixes in the API logic

Tested with two SIM card applets with different configurations