### PR TITLE
print out PEM of peer cert with example client

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1533,7 +1533,7 @@ static const char* client_usage_msg[][70] = {
 
 static void showPeerPEM(WOLFSSL* ssl)
 {
-#if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)) && !defined(NO_BIO)
+#if defined(OPENSSL_ALL) && !defined(NO_BIO) && defined(WOLFSSL_CERT_GEN)
     WOLFSSL_X509* peer = wolfSSL_get_peer_certificate(ssl);
     if (peer) {
         WOLFSSL_BIO* bioOut = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
@@ -1557,7 +1557,7 @@ static void showPeerPEM(WOLFSSL* ssl)
         wolfSSL_BIO_free(bioOut);
     }
     wolfSSL_FreeX509(peer);
-#endif /* (OPENSSL_ALL || OPENSSL_EXTRA) && !NO_BIO */
+#endif /* OPENSSL_ALL && WOLFSSL_CERT_GEN && !NO_BIO */
     (void)ssl;
 }
 

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -1531,6 +1531,37 @@ static const char* client_usage_msg[][70] = {
 
 };
 
+static void showPeerPEM(WOLFSSL* ssl)
+{
+#if (defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)) && !defined(NO_BIO)
+    WOLFSSL_X509* peer = wolfSSL_get_peer_certificate(ssl);
+    if (peer) {
+        WOLFSSL_BIO* bioOut = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
+        if (bioOut == NULL) {
+            printf("failed to get bio on stdout\n");
+        }
+        else {
+            if (wolfSSL_BIO_set_fp(bioOut, stdout, BIO_NOCLOSE)
+                != WOLFSSL_SUCCESS) {
+                printf("failed to set stdout to bio output\n");
+                wolfSSL_BIO_free(bioOut);
+                bioOut = NULL;
+            }
+        }
+
+        if (bioOut) {
+            wolfSSL_BIO_write(bioOut, "---\nServer certificate\n",
+                    XSTRLEN("---\nServer certificate\n"));
+            wolfSSL_PEM_write_bio_X509(bioOut, peer);
+        }
+        wolfSSL_BIO_free(bioOut);
+    }
+    wolfSSL_FreeX509(peer);
+#endif /* (OPENSSL_ALL || OPENSSL_EXTRA) && !NO_BIO */
+    (void)ssl;
+}
+
+
 static void Usage(void)
 {
     int msgid = 0;
@@ -3535,6 +3566,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     }
 
     showPeerEx(ssl, lng_index);
+    showPeerPEM(ssl);
 
     /* if the caller requested a particular cipher, check here that either
      * a canonical name of the established cipher matches the requested
@@ -4032,6 +4064,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         }
 
         showPeerEx(sslResume, lng_index);
+        showPeerPEM(sslResume);
 
         if (wolfSSL_session_reused(sslResume))
             printf("reused session id\n");


### PR DESCRIPTION
alter example client to print out the peers certificate in PEM format for OpenSSL compatibility builds