### PR TITLE
SP C RSA: normalize tmpa after conditionally adding p

### DIFF
--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -4067,6 +4067,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         sp_2048_norm_36(tmpa);
         sp_2048_cond_add_36(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[35] >> 31));
         sp_2048_cond_add_36(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[35] >> 31));
+        sp_2048_norm_36(tmpa);
 
         sp_2048_from_mp(qi, 36, qim);
         sp_2048_mul_36(tmpa, tmpa, qi);
@@ -4165,6 +4166,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         sp_2048_norm_36(tmpa);
         sp_2048_cond_add_36(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[35] >> 31));
         sp_2048_cond_add_36(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[35] >> 31));
+        sp_2048_norm_36(tmpa);
         sp_2048_mul_36(tmpa, tmpa, qi);
         err = sp_2048_mod_36(tmpa, tmpa, p);
     }
@@ -7640,6 +7642,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_norm_53(tmpa);
         sp_3072_cond_add_53(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[52] >> 31));
         sp_3072_cond_add_53(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[52] >> 31));
+        sp_3072_norm_53(tmpa);
 
         sp_3072_from_mp(qi, 53, qim);
         sp_3072_mul_53(tmpa, tmpa, qi);
@@ -7738,6 +7741,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_norm_53(tmpa);
         sp_3072_cond_add_53(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[52] >> 31));
         sp_3072_cond_add_53(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[52] >> 31));
+        sp_3072_norm_53(tmpa);
         sp_3072_mul_53(tmpa, tmpa, qi);
         err = sp_3072_mod_53(tmpa, tmpa, p);
     }
@@ -11798,6 +11802,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_norm_55(tmpa);
         sp_3072_cond_add_56(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[54] >> 31));
         sp_3072_cond_add_56(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[54] >> 31));
+        sp_3072_norm_56(tmpa);
 
         sp_3072_from_mp(qi, 56, qim);
         sp_3072_mul_56(tmpa, tmpa, qi);
@@ -11896,6 +11901,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_norm_55(tmpa);
         sp_3072_cond_add_56(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[54] >> 31));
         sp_3072_cond_add_56(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[54] >> 31));
+        sp_3072_norm_56(tmpa);
         sp_3072_mul_56(tmpa, tmpa, qi);
         err = sp_3072_mod_56(tmpa, tmpa, p);
     }
@@ -15453,6 +15459,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_norm_71(tmpa);
         sp_4096_cond_add_71(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[70] >> 31));
         sp_4096_cond_add_71(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[70] >> 31));
+        sp_4096_norm_71(tmpa);
 
         sp_4096_from_mp(qi, 71, qim);
         sp_4096_mul_71(tmpa, tmpa, qi);
@@ -15551,6 +15558,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_norm_71(tmpa);
         sp_4096_cond_add_71(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[70] >> 31));
         sp_4096_cond_add_71(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[70] >> 31));
+        sp_4096_norm_71(tmpa);
         sp_4096_mul_71(tmpa, tmpa, qi);
         err = sp_4096_mod_71(tmpa, tmpa, p);
     }
@@ -19419,6 +19427,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_norm_79(tmpa);
         sp_4096_cond_add_81(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[78] >> 31));
         sp_4096_cond_add_81(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[78] >> 31));
+        sp_4096_norm_81(tmpa);
 
         sp_4096_from_mp(qi, 81, qim);
         sp_4096_mul_81(tmpa, tmpa, qi);
@@ -19517,6 +19526,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_norm_79(tmpa);
         sp_4096_cond_add_81(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[78] >> 31));
         sp_4096_cond_add_81(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[78] >> 31));
+        sp_4096_norm_81(tmpa);
         sp_4096_mul_81(tmpa, tmpa, qi);
         err = sp_4096_mod_81(tmpa, tmpa, p);
     }

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -3019,6 +3019,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         sp_2048_norm_17(tmpa);
         sp_2048_cond_add_17(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[16] >> 63));
         sp_2048_cond_add_17(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[16] >> 63));
+        sp_2048_norm_17(tmpa);
 
         sp_2048_from_mp(qi, 17, qim);
         sp_2048_mul_17(tmpa, tmpa, qi);
@@ -3117,6 +3118,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         sp_2048_norm_17(tmpa);
         sp_2048_cond_add_17(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[16] >> 63));
         sp_2048_cond_add_17(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[16] >> 63));
+        sp_2048_norm_17(tmpa);
         sp_2048_mul_17(tmpa, tmpa, qi);
         err = sp_2048_mod_17(tmpa, tmpa, p);
     }
@@ -6646,6 +6648,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         sp_2048_norm_18(tmpa);
         sp_2048_cond_add_18(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[17] >> 63));
         sp_2048_cond_add_18(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[17] >> 63));
+        sp_2048_norm_18(tmpa);
 
         sp_2048_from_mp(qi, 18, qim);
         sp_2048_mul_18(tmpa, tmpa, qi);
@@ -6744,6 +6747,7 @@ int sp_RsaPrivate_2048(const byte* in, word32 inLen, const mp_int* dm,
         sp_2048_norm_18(tmpa);
         sp_2048_cond_add_18(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[17] >> 63));
         sp_2048_cond_add_18(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[17] >> 63));
+        sp_2048_norm_18(tmpa);
         sp_2048_mul_18(tmpa, tmpa, qi);
         err = sp_2048_mod_18(tmpa, tmpa, p);
     }
@@ -10124,6 +10128,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_norm_26(tmpa);
         sp_3072_cond_add_26(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[25] >> 63));
         sp_3072_cond_add_26(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[25] >> 63));
+        sp_3072_norm_26(tmpa);
 
         sp_3072_from_mp(qi, 26, qim);
         sp_3072_mul_26(tmpa, tmpa, qi);
@@ -10222,6 +10227,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_norm_26(tmpa);
         sp_3072_cond_add_26(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[25] >> 63));
         sp_3072_cond_add_26(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[25] >> 63));
+        sp_3072_norm_26(tmpa);
         sp_3072_mul_26(tmpa, tmpa, qi);
         err = sp_3072_mod_26(tmpa, tmpa, p);
     }
@@ -13900,6 +13906,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_norm_27(tmpa);
         sp_3072_cond_add_27(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[26] >> 63));
         sp_3072_cond_add_27(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[26] >> 63));
+        sp_3072_norm_27(tmpa);
 
         sp_3072_from_mp(qi, 27, qim);
         sp_3072_mul_27(tmpa, tmpa, qi);
@@ -13998,6 +14005,7 @@ int sp_RsaPrivate_3072(const byte* in, word32 inLen, const mp_int* dm,
         sp_3072_norm_27(tmpa);
         sp_3072_cond_add_27(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[26] >> 63));
         sp_3072_cond_add_27(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[26] >> 63));
+        sp_3072_norm_27(tmpa);
         sp_3072_mul_27(tmpa, tmpa, qi);
         err = sp_3072_mod_27(tmpa, tmpa, p);
     }
@@ -17335,6 +17343,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_norm_35(tmpa);
         sp_4096_cond_add_35(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[34] >> 63));
         sp_4096_cond_add_35(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[34] >> 63));
+        sp_4096_norm_35(tmpa);
 
         sp_4096_from_mp(qi, 35, qim);
         sp_4096_mul_35(tmpa, tmpa, qi);
@@ -17433,6 +17442,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_norm_35(tmpa);
         sp_4096_cond_add_35(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[34] >> 63));
         sp_4096_cond_add_35(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[34] >> 63));
+        sp_4096_norm_35(tmpa);
         sp_4096_mul_35(tmpa, tmpa, qi);
         err = sp_4096_mod_35(tmpa, tmpa, p);
     }
@@ -21103,6 +21113,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_norm_39(tmpa);
         sp_4096_cond_add_39(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[38] >> 63));
         sp_4096_cond_add_39(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[38] >> 63));
+        sp_4096_norm_39(tmpa);
 
         sp_4096_from_mp(qi, 39, qim);
         sp_4096_mul_39(tmpa, tmpa, qi);
@@ -21201,6 +21212,7 @@ int sp_RsaPrivate_4096(const byte* in, word32 inLen, const mp_int* dm,
         sp_4096_norm_39(tmpa);
         sp_4096_cond_add_39(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[38] >> 63));
         sp_4096_cond_add_39(tmpa, tmpa, p, 0 - ((sp_int_digit)tmpa[38] >> 63));
+        sp_4096_norm_39(tmpa);
         sp_4096_mul_39(tmpa, tmpa, qi);
         err = sp_4096_mod_39(tmpa, tmpa, p);
     }


### PR DESCRIPTION
Numbers in a word get too big for fast mul implementation when not
normalized.
Only affects RSA keys where p < q.