### PR TITLE
fix wrong prototype definition in SCE protected support

### DIFF
--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -37,8 +37,8 @@
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
 
-extern uint32_t     g_CAscm_Idx = (uint32_t)-1; /* index of CM table    */
-static int devId = 7890;                        /* dev Id for Crypt Callback */
+uint32_t     g_CAscm_Idx = (uint32_t)-1; /* index of CM table    */
+static int devId = 7890;                 /* dev Id for Crypt Callback */
 
 #ifdef WOLF_CRYPTO_CB
 

--- a/wolfcrypt/src/port/Renesas/renesas_sce_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_sce_util.c
@@ -53,7 +53,7 @@ static const byte*  ca_cert_sig;
 static sce_key_data g_user_key_info;
 
 static uint32_t     g_encrypted_publicCA_key[HW_SCE_SINST_WORD_SIZE];
-uint32_t            g_CAscm_Idx;          /* index of CM table    */
+extern uint32_t     g_CAscm_Idx;          /* index of CM table    */
 wolfSSL_Mutex       sce_mutex;
 static int          sce_CryptHwMutexInit_ = 0;
 static uint32_t     sce_sess_idx = 0;

--- a/wolfssl/wolfcrypt/port/Renesas/renesas_cmn.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas_cmn.h
@@ -32,7 +32,7 @@ WOLFSSL_LOCAL int Renesas_cmn_RsaEnc(WOLFSSL* ssl, const unsigned char* in,
        unsigned int inSz, unsigned char* out, word32* outSz,
        const unsigned char* keyDer, unsigned int keySz, void* ctx);
 WOLFSSL_LOCAL int Renesas_cmn_VerifyHmac(WOLFSSL *ssl, const byte* message, 
-                    word32 messageSz, word32 macSz, word32 content);
+                    word32 messageSz, word32 macSz, word32 content, void* ctx);
 WOLFSSL_LOCAL int Renesas_cmn_EccVerify(WOLFSSL* ssl, const uint8_t* sig, 
         uint32_t sigSz, const uint8_t* hash, uint32_t hashSz, 
         const uint8_t* key, uint32_t keySz, int* result, void* ctx);


### PR DESCRIPTION
fix function prototype definition. This causes compile error while using IAR compiler
better handling of global index