### PR TITLE
In d2iGenericKey(), if a falcon key is encountered, make a dummy pkey.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -8534,38 +8534,36 @@ static WOLFSSL_EVP_PKEY* d2iGenericKey(WOLFSSL_EVP_PKEY** out,
     #else
         falcon_key falcon[1];
     #endif
-        XMEMSET(falcon, 0, sizeof(falcon_key));
 
-        /* test if Falcon key */
-        if (priv) {
-            /* Try level 1 */
-            isFalcon = wc_falcon_init(falcon) == 0 &&
-                       wc_falcon_set_level(falcon, 1) == 0 &&
-                       wc_falcon_import_private_only(mem, (word32)memSz,
-                                                     falcon) == 0;
-            if (!isFalcon) {
-                /* Try level 5 */
-                isFalcon = wc_falcon_init(falcon) == 0 &&
-                           wc_falcon_set_level(falcon, 5) == 0 &&
+        if (wc_falcon_init(falcon) == 0) {
+            /* test if Falcon key */
+            if (priv) {
+                /* Try level 1 */
+                isFalcon = wc_falcon_set_level(falcon, 1) == 0 &&
                            wc_falcon_import_private_only(mem, (word32)memSz,
                                                          falcon) == 0;
-            }
-        } else {
-            /* Try level 1 */
-            isFalcon = wc_falcon_init(falcon) == 0 &&
-                       wc_falcon_set_level(falcon, 1) == 0 &&
-                       wc_falcon_import_public(mem, (word32)memSz, falcon) == 0;
+                if (!isFalcon) {
+                    /* Try level 5 */
+                    isFalcon = wc_falcon_set_level(falcon, 5) == 0 &&
+                               wc_falcon_import_private_only(mem, (word32)memSz,
+                                                             falcon) == 0;
+                }
+            } else {
+                /* Try level 1 */
+                isFalcon = wc_falcon_set_level(falcon, 1) == 0 &&
+                           wc_falcon_import_public(mem, (word32)memSz, falcon)
+                           == 0;
 
-            if (!isFalcon) {
-                /* Try level 5 */
-                isFalcon = wc_falcon_init(falcon) == 0 &&
-                           wc_falcon_set_level(falcon, 5) == 0 &&
-                           wc_falcon_import_public(mem, (word32)memSz,
-                                                         falcon) == 0;
+                if (!isFalcon) {
+                    /* Try level 5 */
+                    isFalcon = wc_falcon_set_level(falcon, 5) == 0 &&
+                               wc_falcon_import_public(mem, (word32)memSz,
+                                                       falcon) == 0;
+                }
             }
+            wc_falcon_free(falcon);
         }
 
-        wc_falcon_free(falcon);
     #ifdef WOLFSSL_SMALL_STACK
         XFREE(falcon, NULL, DYNAMIC_TYPE_FALCON);
     #endif

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -247,6 +247,7 @@ enum {
     NID_rc4           = 5,
     EVP_PKEY_DH       = NID_dhKeyAgreement,
     EVP_PKEY_HMAC     = NID_hmac,
+    EVP_PKEY_FALCON = 300,
     AES_128_CFB1_TYPE = 24,
     AES_192_CFB1_TYPE = 25,
     AES_256_CFB1_TYPE = 26,

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -247,7 +247,7 @@ enum {
     NID_rc4           = 5,
     EVP_PKEY_DH       = NID_dhKeyAgreement,
     EVP_PKEY_HMAC     = NID_hmac,
-    EVP_PKEY_FALCON = 300,
+    EVP_PKEY_FALCON   = 300, /* Randomly picked value. */
     AES_128_CFB1_TYPE = 24,
     AES_192_CFB1_TYPE = 25,
     AES_256_CFB1_TYPE = 26,


### PR DESCRIPTION
This allows apache-httpd to work without PQ-specific patch along with a previous
pull request.