### PR TITLE
WOLFSSL_ECC_NO_SMALL_STACK etc

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -31085,9 +31085,9 @@ void wolfSSL_sk_pop_free(WOLF_STACK_OF(WOLFSSL_ASN1_OBJECT)* sk,
         return;
     }
     #if defined(WOLFSSL_QT)
-    /* In Qt v15.5, it calls OPENSSL_sk_free(xxx, OPENSSL_sk_free). 
-    *  By using OPENSSL_sk_free for free causes access violation. 
-    *  Therefore, switching free func to wolfSSL_ACCESS_DESCRIPTION_free 
+    /* In Qt v15.5, it calls OPENSSL_sk_free(xxx, OPENSSL_sk_free).
+    *  By using OPENSSL_sk_free for free causes access violation.
+    *  Therefore, switching free func to wolfSSL_ACCESS_DESCRIPTION_free
     *  is needed even the func isn't NULL.
     */
     if (sk->type == STACK_TYPE_ACCESS_DESCRIPTION) {
@@ -52578,7 +52578,7 @@ int wolfSSL_BN_div(WOLFSSL_BIGNUM* dv, WOLFSSL_BIGNUM* rem,
     return ret;
 }
 
-#ifdef WOLFSSL_KEY_GEN /* Needed to get mp_gcd. */
+#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN) /* Needed to get mp_gcd. */
 int wolfSSL_BN_gcd(WOLFSSL_BIGNUM* r, WOLFSSL_BIGNUM* a, WOLFSSL_BIGNUM* b,
                    WOLFSSL_BN_CTX* ctx)
 {
@@ -52608,7 +52608,7 @@ int wolfSSL_BN_gcd(WOLFSSL_BIGNUM* r, WOLFSSL_BIGNUM* a, WOLFSSL_BIGNUM* b,
 
     return ret;
 }
-#endif /* WOLFSSL_KEY_GEN */
+#endif /* !NO_RSA && WOLFSSL_KEY_GEN */
 
 /* WOLFSSL_SUCCESS on ok */
 int wolfSSL_BN_mod(WOLFSSL_BIGNUM* r, const WOLFSSL_BIGNUM* a,
@@ -53618,7 +53618,7 @@ int wolfSSL_BN_mod_add(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
     return WOLFSSL_SUCCESS;
 }
 
-#ifdef WOLFSSL_KEY_GEN
+#if defined(WOLFSSL_KEY_GEN) && (!defined(NO_RSA) || !defined(NO_DH) || !defined(NO_DSA))
 
 int wolfSSL_BN_generate_prime_ex(WOLFSSL_BIGNUM* prime, int bits,
     int safe, const WOLFSSL_BIGNUM* add, const WOLFSSL_BIGNUM* rem,
@@ -53785,7 +53785,7 @@ WOLFSSL_BN_ULONG wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM *bn,
 
     return ret;
 }
-#endif /* #ifdef WOLFSSL_KEY_GEN */
+#endif /* WOLFSSL_KEY_GEN && (!NO_RSA || !NO_DH || !NO_DSA) */
 
 char *wolfSSL_BN_bn2hex(const WOLFSSL_BIGNUM *bn)
 {

--- a/tests/api.c
+++ b/tests/api.c
@@ -6171,7 +6171,7 @@ done:
 
 static void test_wolfSSL_get_finished(void)
 {
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+#if !defined(NO_RSA) && defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
 
     tcp_ready ready;
     func_args client_args;
@@ -26397,6 +26397,7 @@ static int test_wc_EccPrivateKeyToDer (void)
 static int test_wc_DhPublicKeyDecode(void)
 {
     int ret = 0;
+#ifndef NO_DH
     word32 inOutIdx;
 
 #if defined(WOLFSSL_DH_EXTRA) && defined(USE_CERT_BUFFERS_2048)
@@ -26427,6 +26428,7 @@ static int test_wc_DhPublicKeyDecode(void)
 
 #endif
     (void)inOutIdx;
+#endif /* !NO_DH */
     return ret;
 }
 
@@ -33759,7 +33761,8 @@ static void test_wolfSSL_Tls13_Key_Logging_test(void)
 #endif /* OPENSSL_EXTRA && HAVE_SECRET_CALLBACK && WOLFSSL_TLS13 */
 }
 
-#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
+#if defined(HAVE_IO_TESTS_DEPENDENCIES) && \
+defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
     defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
 static void post_auth_version_cb(WOLFSSL* ssl)
 {
@@ -33799,7 +33802,8 @@ static void set_post_auth_cb(WOLFSSL* ssl)
 
 static void test_wolfSSL_Tls13_postauth(void)
 {
-#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
+#if defined(HAVE_IO_TESTS_DEPENDENCIES) && \
+    defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && \
     defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
     tcp_ready ready;
     func_args client_args;
@@ -34304,14 +34308,14 @@ static void test_wolfSSL_BN(void)
     AssertIntEQ(BN_set_word(a, 16), SSL_SUCCESS);
     AssertIntEQ(BN_set_word(b, 24), SSL_SUCCESS);
 
-#ifdef WOLFSSL_KEY_GEN
+#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
     /* gcd of a and b */
     AssertIntEQ(BN_gcd(d, NULL, b, NULL), SSL_FAILURE);
     AssertIntEQ(BN_gcd(d, a, b, NULL), SSL_SUCCESS);
 
     /* check result gcd(16, 24) */
     AssertIntEQ(BN_get_word(d), 8);
-#endif /* WOLFSSL_KEY_GEN */
+#endif /* !NO_RSA && WOLFSSL_KEY_GEN */
 
     AssertIntEQ(BN_set_word(a, 1 << 6), SSL_SUCCESS);
     AssertIntEQ(BN_rshift(b, a, 6), SSL_SUCCESS);
@@ -34417,7 +34421,7 @@ static void test_wolfSSL_BN(void)
     }
     #endif
 
-#ifdef WOLFSSL_KEY_GEN
+#if defined(WOLFSSL_KEY_GEN) && (!defined(NO_RSA) || !defined(NO_DH) || !defined(NO_DSA))
     AssertNotNull(a = BN_new());
     AssertIntEQ(BN_generate_prime_ex(a, 512, 0, NULL, NULL, NULL),
         SSL_SUCCESS);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -28,6 +28,11 @@
 /* in case user set HAVE_ECC there */
 #include <wolfssl/wolfcrypt/settings.h>
 
+#ifdef WOLFSSL_ECC_NO_SMALL_STACK
+#undef WOLFSSL_SMALL_STACK
+#undef WOLFSSL_SMALL_STACK_CACHE
+#endif
+
 /*
 Possible ECC enable options:
  * HAVE_ECC:            Overall control of ECC                  default: on

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -2254,7 +2254,7 @@ static int DH_param_check(WOLFSSL_DH* dh_key)
                 WOLFSSL_MSG("dh_key->g is not suitable generator");
                 ret = WOLFSSL_FAILURE;
             }
-#ifdef WOLFSSL_KEY_GEN
+#if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
         /* test if the number q is prime. */
         if (ret == WOLFSSL_SUCCESS &&
             (wolfSSL_BN_is_prime_ex(dh_key->q, 64, ctx, NULL) <= 0)) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -34440,7 +34440,7 @@ WOLFSSL_TEST_SUBROUTINE int pkcs7signed_test(void)
                             eccClientCertBuf, (word32)eccClientCertBufSz,
                             eccClientPrivKeyBuf, (word32)eccClientPrivKeyBufSz);
 
-#if !defined(NO_AES) && defined(HAVE_AES_CBC)
+#if !defined(NO_RSA) && !defined(NO_AES) && defined(HAVE_AES_CBC)
     if (ret >= 0)
         ret = pkcs7callback_test(
                             rsaClientCertBuf, (word32)rsaClientCertBufSz,

--- a/wolfssl/openssl/bn.h
+++ b/wolfssl/openssl/bn.h
@@ -72,8 +72,10 @@ WOLFSSL_API int wolfSSL_BN_mul(WOLFSSL_BIGNUM*, WOLFSSL_BIGNUM*,
         WOLFSSL_BIGNUM*, WOLFSSL_BN_CTX*);
 WOLFSSL_API int wolfSSL_BN_div(WOLFSSL_BIGNUM*, WOLFSSL_BIGNUM*,
         const WOLFSSL_BIGNUM*, const WOLFSSL_BIGNUM*, WOLFSSL_BN_CTX*);
+#if defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)
 WOLFSSL_API int wolfSSL_BN_gcd(WOLFSSL_BIGNUM*, WOLFSSL_BIGNUM*,
                                WOLFSSL_BIGNUM*, WOLFSSL_BN_CTX*);
+#endif
 WOLFSSL_API int wolfSSL_BN_mod(WOLFSSL_BIGNUM*, const WOLFSSL_BIGNUM*,
                              const WOLFSSL_BIGNUM*, const WOLFSSL_BN_CTX*);
 WOLFSSL_API int wolfSSL_BN_mod_exp(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
@@ -130,12 +132,14 @@ WOLFSSL_API int wolfSSL_BN_mod_add(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
                                    const WOLFSSL_BIGNUM *b, const WOLFSSL_BIGNUM *m,
                                    WOLFSSL_BN_CTX *ctx);
 WOLFSSL_API char *wolfSSL_BN_bn2hex(const WOLFSSL_BIGNUM*);
+#if defined(WOLFSSL_KEY_GEN) && (!defined(NO_RSA) || !defined(NO_DH) || !defined(NO_DSA))
 WOLFSSL_API int wolfSSL_BN_generate_prime_ex(WOLFSSL_BIGNUM*, int, int,
     const WOLFSSL_BIGNUM*, const WOLFSSL_BIGNUM*, WOLFSSL_BN_GENCB*);
 WOLFSSL_API int wolfSSL_BN_is_prime_ex(const WOLFSSL_BIGNUM*, int,
                                        WOLFSSL_BN_CTX*, WOLFSSL_BN_GENCB*);
 WOLFSSL_API WOLFSSL_BN_ULONG wolfSSL_BN_mod_word(const WOLFSSL_BIGNUM*,
                                                  WOLFSSL_BN_ULONG);
+#endif
 #if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
     WOLFSSL_API int wolfSSL_BN_print_fp(XFILE, const WOLFSSL_BIGNUM*);
 #endif

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -395,7 +395,7 @@ typedef struct {
     mp_int* z;        /* The z coordinate */
     alt_fp_int xyz[3];
 #endif
-#ifdef WOLFSSL_SMALL_STACK_CACHE
+#if defined(WOLFSSL_SMALL_STACK_CACHE) && !defined(WOLFSSL_ECC_NO_SMALL_STACK)
     ecc_key* key;
 #endif
 } ecc_point;
@@ -496,7 +496,7 @@ struct ecc_key {
     byte deterministic:1;
 #endif
 
-#ifdef WOLFSSL_SMALL_STACK_CACHE
+#if defined(WOLFSSL_SMALL_STACK_CACHE) && !defined(WOLFSSL_ECC_NO_SMALL_STACK)
     mp_int* t1;
     mp_int* t2;
 #ifdef ALT_ECC_SIZE


### PR DESCRIPTION
adds gate `WOLFSSL_ECC_NO_SMALL_STACK`.

also adds feature gating tweaks to better support `--enable-all --disable-rsa --disable-dh --disable-dsa`.  also a whitespace fix in ssl.c.

with these tweaks, the following can build, and passes make check except for unit.test:
```
./configure --quiet --disable-jobserver --enable-all --enable-smallstack --enable-sp-math-all CFLAGS=-DWOLFSSL_ECC_NO_SMALL_STACK --disable-rsa --disable-dh --disable-anon --disable-dsa --disable-openssh --disable-nginx --disable-qt --disable-openvpn --disable-opensslall --disable-opensslextra --disable-libwebsockets --disable-asio --with-max-ecc-bits=1024 --enable-stacksize=verbose --enable-debug --disable-smime
```

ZD 13366