### PR TITLE
Fix `test_wolfSSL_BIO_should_retry` test

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -38659,6 +38659,9 @@ static void test_wolfSSL_BIO_should_retry(void)
 
 
     AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
+#ifdef OPENSSL_COMPATIBLE_DEFAULTS
+    AssertIntEQ(wolfSSL_CTX_clear_mode(ctx, SSL_MODE_AUTO_RETRY), 0);
+#endif
     AssertIntEQ(WOLFSSL_SUCCESS,
             wolfSSL_CTX_load_verify_locations(ctx, caCertFile, 0));
     AssertIntEQ(WOLFSSL_SUCCESS,


### PR DESCRIPTION
When `OPENSSL_COMPATIBLE_DEFAULTS` is defined then `SSL_MODE_AUTO_RETRY` is set on context creation. For this test we need to clear this mode so that the `WOLFSSL_CBIO_ERR_WANT_READ` can propagate up to the user.