### PR TITLE
Fix missing include ws2tcpip.h for VS build

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -77,7 +77,7 @@
     #ifndef _WIN32
         #include <arpa/inet.h>
     #else
-        #include <WS2tcpip.h>
+        #include <ws2tcpip.h>
     #endif
 #endif
 

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -618,7 +618,9 @@
                 #include <winsock2.h>
             #endif
             #include <windows.h>
-            #include <ws2tcpip.h>
+            #ifndef WOLFSSL_USER_IO
+                #include <ws2tcpip.h> /* required for InetPton */
+            #endif
         #endif /* WOLFSSL_SGX */
     #endif
 #elif defined(THREADX)

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -618,6 +618,7 @@
                 #include <winsock2.h>
             #endif
             #include <windows.h>
+            #include <ws2tcpip.h>
         #endif /* WOLFSSL_SGX */
     #endif
 #elif defined(THREADX)


### PR DESCRIPTION
This fixes an issue reported in #4684 