### PR TITLE
Fix usage of SSL_OP_NO_COMPRESSION that was breaking wolfEngine.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28767,7 +28767,7 @@ static long wolf_set_options(long old_op, long op)
         WOLFSSL_MSG("\tWOLFSSL_OP_CIPHER_SERVER_PREFERENCE");
     }
 
-    if ((op & SSL_OP_NO_COMPRESSION) == SSL_OP_NO_COMPRESSION) {
+    if ((op & WOLFSSL_OP_NO_COMPRESSION) == WOLFSSL_OP_NO_COMPRESSION) {
     #ifdef HAVE_LIBZ
         WOLFSSL_MSG("SSL_OP_NO_COMPRESSION");
     #else
@@ -28815,7 +28815,7 @@ long wolfSSL_set_options(WOLFSSL* ssl, long op)
             ssl->version.minor = SSLv3_MINOR;
     }
 
-    if ((ssl->options.mask & SSL_OP_NO_COMPRESSION) == SSL_OP_NO_COMPRESSION) {
+    if ((ssl->options.mask & WOLFSSL_OP_NO_COMPRESSION) == WOLFSSL_OP_NO_COMPRESSION) {
     #ifdef HAVE_LIBZ
         ssl->options.usingCompression = 0;
     #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2083,11 +2083,12 @@ enum {
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
     defined(HAVE_WEBSERVER)
 /* for compatibility these must be macros */
-#define SSL_OP_NO_SSLv2   WOLFSSL_OP_NO_SSLv2
-#define SSL_OP_NO_SSLv3   WOLFSSL_OP_NO_SSLv3
-#define SSL_OP_NO_TLSv1   WOLFSSL_OP_NO_TLSv1
-#define SSL_OP_NO_TLSv1_1 WOLFSSL_OP_NO_TLSv1_1
-#define SSL_OP_NO_TLSv1_2 WOLFSSL_OP_NO_TLSv1_2
+#define SSL_OP_NO_SSLv2       WOLFSSL_OP_NO_SSLv2
+#define SSL_OP_NO_SSLv3       WOLFSSL_OP_NO_SSLv3
+#define SSL_OP_NO_TLSv1       WOLFSSL_OP_NO_TLSv1
+#define SSL_OP_NO_TLSv1_1     WOLFSSL_OP_NO_TLSv1_1
+#define SSL_OP_NO_TLSv1_2     WOLFSSL_OP_NO_TLSv1_2
+#define SSL_OP_NO_COMPRESSION WOLFSSL_OP_NO_COMPRESSION
 #if !(!defined(WOLFSSL_TLS13) && defined(WOLFSSL_APACHE_HTTPD)) /* apache uses this to determine if TLS 1.3 is enabled */
 #define SSL_OP_NO_TLSv1_3 WOLFSSL_OP_NO_TLSv1_3
 #endif

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2297,7 +2297,6 @@ extern void uITRON4_free(void *p) ;
     #undef HAVE_GMTIME_R /* don't trust macro with windows */
 #endif /* WOLFSSL_MYSQL_COMPATIBLE */
 
-#define SSL_OP_NO_COMPRESSION    WOLFSSL_OP_NO_COMPRESSION
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) \
  || defined(HAVE_LIGHTY)
     #define OPENSSL_NO_ENGINE


### PR DESCRIPTION
Replace instances of SSL_OP_NO_COMPRESSION with WOLFSSL_OP_NO_COMPRESSION in
ssl.c. Only define SSL_OP_NO_COMPRESSION when using the compatibility layer.
Before these changes, wolfEngine builds were failing due to
SSL_OP_NO_COMPRESSION being defined in both wolfSSL and OpenSSL headers.