### PR TITLE
Fixes for session resumption edge cases

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -29404,7 +29404,17 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
         #endif
 
-            if (ret == 0) {
+            if (ret == 0 && ssl->options.resuming) {
+                /* for resumption use the cipher suite from session */
+                ssl->options.cipherSuite0 = session->cipherSuite0;
+                ssl->options.cipherSuite =  session->cipherSuite;
+                ret = SetCipherSpecs(ssl);
+                if (ret == 0) {
+                    ret = PickHashSigAlgo(ssl, clSuites->hashSigAlgo,
+                                               clSuites->hashSigAlgoSz);
+                }
+            }
+            else if (ret == 0) {
                 if (MatchSuite(ssl, clSuites) < 0) {
                     WOLFSSL_MSG("Unsupported cipher suite, ClientHello");
                     ret = UNSUPPORTED_SUITE;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -31417,6 +31417,7 @@ void wolfSSL_sk_pop_free(WOLF_STACK_OF(WOLFSSL_ASN1_OBJECT)* sk,
     WOLFSSL_ENTER("wolfSSL_sk_pop_free");
 
     if (sk == NULL) {
+        /* pop_free can be called with NULL, do not print bad argument */
         return;
     }
     #if defined(WOLFSSL_QT)

--- a/src/tls.c
+++ b/src/tls.c
@@ -7492,6 +7492,10 @@ static int TLSX_KeyShare_Process(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
 #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
     ssl->session.namedGroup = (byte)keyShareEntry->group;
 #endif
+    /* reset the pre master secret size */
+    if (ssl->arrays->preMasterSz == 0)
+        ssl->arrays->preMasterSz = ENCRYPT_LEN;
+
     /* Use Key Share Data from server. */
     if (keyShareEntry->group >= MIN_FFHDE_GROUP &&
         keyShareEntry->group <= MAX_FFHDE_GROUP)

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4265,8 +4265,10 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         else
     #endif
         {
-            if ((modes & (1 << PSK_KE)) == 0)
+            if ((modes & (1 << PSK_KE)) == 0) {
+                WOLFSSL_MSG("psk_ke mode does not allow key share");
                 return PSK_KEY_ERROR;
+            }
             ssl->options.noPskDheKe = 1;
             ssl->arrays->preMasterSz = 0;
 


### PR DESCRIPTION
* Fix for session resumption to ensure use of the right cipher suite. ZD13297
* Fix for TLS v1.3 client session ticket resumption where the server opts to do a new handshake. Fix to make sure `preMasterSz` is valid.