### PR TITLE
Call wc_SetSeed_Cb and wolfCrypt_SetPrivateKeyReadEnable_fips in wolfSSL_Init.

### DIFF
--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -1754,9 +1754,6 @@ int bench_tls(void* args)
 
     /* Initialize wolfSSL */
     wolfSSL_Init();
-#ifdef WC_RNG_SEED_CB
-    wc_SetSeed_Cb(wc_GenerateSeed);
-#endif
 
     /* Parse command line arguments */
     while ((ch = mygetopt(argc, argv, "?" "udeil:p:t:vT:sch:P:mS:g")) != -1) {

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -4224,9 +4224,6 @@ exit:
         wolfSSL_Debugging_ON();
 #endif
         wolfSSL_Init();
-#ifdef WC_RNG_SEED_CB
-        wc_SetSeed_Cb(wc_GenerateSeed);
-#endif
         ChangeToWolfRoot();
 
 #ifndef NO_WOLFSSL_CLIENT

--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -385,9 +385,6 @@ void echoclient_test(void* args)
 #if defined(DEBUG_CYASSL) && !defined(WOLFSSL_MDK_SHELL)
         CyaSSL_Debugging_ON();
 #endif
-#ifdef WC_RNG_SEED_CB
-        wc_SetSeed_Cb(wc_GenerateSeed);
-#endif
 #ifndef CYASSL_TIRTOS
         ChangeToWolfRoot();
 #endif

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -547,9 +547,6 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
 #if defined(DEBUG_CYASSL) && !defined(CYASSL_MDK_SHELL)
         CyaSSL_Debugging_ON();
 #endif
-#ifdef WC_RNG_SEED_CB
-        wc_SetSeed_Cb(wc_GenerateSeed);
-#endif
         ChangeToWolfRoot();
 #ifndef NO_WOLFSSL_SERVER
         echoserver_test(&args);

--- a/examples/sctp/sctp-client-dtls.c
+++ b/examples/sctp/sctp-client-dtls.c
@@ -70,9 +70,6 @@ int main()
     const char* response = "hello there";
     char buffer[80];
 
-#ifdef WC_RNG_SEED_CB
-    wc_SetSeed_Cb(wc_GenerateSeed);
-#endif
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new(wolfDTLSv1_2_client_method());
     if (ctx == NULL)
         err_sys("ctx new dtls client failed");

--- a/examples/sctp/sctp-server-dtls.c
+++ b/examples/sctp/sctp-server-dtls.c
@@ -76,9 +76,6 @@ int main()
     const char* response = "well hello to you";
     char buffer[80];
 
-#ifdef WC_RNG_SEED_CB
-    wc_SetSeed_Cb(wc_GenerateSeed);
-#endif
     WOLFSSL_CTX* ctx = wolfSSL_CTX_new(wolfDTLSv1_2_server_method());
     if (ctx == NULL)
         err_sys("ctx new dtls server failed");

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5194,6 +5194,14 @@ int wolfSSL_Init(void)
         }
 #endif
 
+    #ifdef WC_RNG_SEED_CB
+        wc_SetSeed_Cb(wc_GenerateSeed);
+    #endif
+
+    #if defined(HAVE_FIPS_VERSION) && HAVE_FIPS_VERSION == 5
+        wolfCrypt_SetPrivateKeyReadEnable_fips(1, WC_KEYTYPE_ALL);
+    #endif
+
 #ifdef OPENSSL_EXTRA
     #ifndef WOLFSSL_NO_OPENSSL_RAND_CB
         if ((ret == WOLFSSL_SUCCESS) && (wolfSSL_RAND_InitMutex() != 0)) {

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -133,9 +133,6 @@ int testsuite_test(int argc, char** argv)
 #if defined(DEBUG_WOLFSSL) && !defined(HAVE_VALGRIND)
     wolfSSL_Debugging_ON();
 #endif
-#ifdef WC_RNG_SEED_CB
-    wc_SetSeed_Cb(wc_GenerateSeed);
-#endif
 
 #if !defined(WOLFSSL_TIRTOS)
     ChangeToWolfRoot();
@@ -602,10 +599,6 @@ int main(int argc, char** argv)
 
     wolfcrypt_test_args.argc = argc;
     wolfcrypt_test_args.argv = argv;
-
-#ifdef WC_RNG_SEED_CB
-    wc_SetSeed_Cb(wc_GenerateSeed);
-#endif
 
     wolfSSL_Init();
     ChangeToWolfRoot();


### PR DESCRIPTION
Additionally, remove wc_SetSeed_Cb calls in applications (e.g. example client and
server), since they are now redundant.