### PR TITLE
wolfcrypt/src/evp.c: fix wolfSSL_EVP_CIPHER_CTX_ctrl() null pointer…

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -4817,7 +4817,8 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
                 /* OpenSSL increments the IV. Not sure why */
                 IncCtr(ctx->iv, ctx->ivSz);
                 /* Clear any leftover AAD. */
-                XMEMSET(ctx->gcmAuthIn, 0, ctx->gcmAuthInSz);
+                if (ctx->gcmAuthIn != NULL)
+                    XMEMSET(ctx->gcmAuthIn, 0, ctx->gcmAuthInSz);
                 ctx->gcmAuthInSz = 0;
                 ret = WOLFSSL_SUCCESS;
                 break;


### PR DESCRIPTION
…passed to XMEMCPY(), found by sanitizers under gcc-11.2.1.