### PR TITLE
Fixes for wolfSSL Async v5.1.0

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -20621,6 +20621,7 @@ static int test_wc_DsaKeyToPublicDer(void)
     }
     if (ret == 0) {
         word32 idx = 0;
+        wc_FreeDsaKey(&genKey);
         ret = wc_DsaPublicKeyDecode(der, &idx, &genKey, sz);
     }
     /* Test without the SubjectPublicKeyInfo header */
@@ -20635,6 +20636,7 @@ static int test_wc_DsaKeyToPublicDer(void)
     }
     if (ret == 0) {
         word32 idx = 0;
+        wc_FreeDsaKey(&genKey);
         ret = wc_DsaPublicKeyDecode(der, &idx, &genKey, sz);
     }
 


### PR DESCRIPTION
* Fix to resolve possible memory leak with DSA `wc_DsaPublicKeyDecode` in API unit test when used with `HAVE_WOLF_BIGINT`.