### PR TITLE
Minor build warning fixes

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -2263,6 +2263,7 @@ exit:
     (void)bench_mac_algs;
     (void)bench_asym_algs;
     (void)bench_other_algs;
+    (void)bench_pq_asym_algs;
 
     return NULL;
 }

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2356,8 +2356,19 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
 
 #if defined(WOLFSSL_SP_MATH)
     (void)rng;
+    #ifndef WOLFSSL_HAVE_SP_RSA
+    (void)in;
+    (void)inLen;
+    (void)out;
+    (void)outLen;
+    (void)type;
+    (void)key;
+    #error RSA SP option invalid (enable WOLFSSL_HAVE_SP_RSA or disable WOLFSSL_SP_MATH)
+    return NOT_COMPILED_IN;
+    #else
     WOLFSSL_MSG("SP Key Size Error");
     return WC_KEY_SIZE_E;
+    #endif
 #else
     (void)rng;
 


### PR DESCRIPTION
* Possible benchmark unused `bench_pq_asym_algs`.
* Fix if RSA enabled and `WOLFSSL_SP_MATH` set and `WOLFSSL_HAVE_SP_RSA` is not.