### PR TITLE
Fixes for SE050 Ed25519/Curve25519

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1471,6 +1471,7 @@ AC_ARG_WITH([se050],
             CPPFLAGS="$CPPFLAGS -I$trylibse050dir/sss/ex/inc"
             CPPFLAGS="$CPPFLAGS -I$trylibse050dir/sss/port/default"
             CPPFLAGS="$CPPFLAGS -I$trylibse050dir/hostlib/hostLib/inc"
+            CPPFLAGS="$CPPFLAGS -I$trylibse050dir/hostlib/hostLib/libCommon/log/"
             CPPFLAGS="$CPPFLAGS -I$trylibse050dir/hostlib/hostLib/libCommon/infra"
 
             if test -e "$trylibse050dir/build/sss/libSSS_APIs.a"; then
@@ -1483,6 +1484,7 @@ AC_ARG_WITH([se050],
                                 $trylibse050dir/build/sss/libSSS_APIs.a \
                                 $trylibse050dir/build/hostlib/hostLib/se05x/libse05x.a \
                                 $trylibse050dir/build/hostlib/hostLib/liba7x_utils.a \
+                                $trylibse050dir/build/hostlib/hostLib/libCommon/log/libmwlog.a \
                                 $trylibse050dir/build/hostlib/hostLib/libCommon/libsmCom.a $LIB_STATIC_ADD"
             else
                 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <fsl_sss_api.h>]], [[ sss_mac_init(0); ]])],[ libse050_linked=yes ],[ libse050_linked=no ])

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -300,7 +300,7 @@ int wc_curve25519_shared_secret_ex(curve25519_key* private_key,
 #else
     #ifdef WOLFSSL_SE050
     if (!private_key->privSet) {
-        /* use NXP SE050 is private key is not set */
+        /* use NXP SE050: "privSet" is not set */
         ret = se050_curve25519_shared_secret(private_key, public_key, &o);
     }
     else

--- a/wolfssl/wolfcrypt/curve25519.h
+++ b/wolfssl/wolfcrypt/curve25519.h
@@ -43,6 +43,7 @@
 #endif
 
 #define CURVE25519_KEYSIZE 32
+#define CURVE25519_PUB_KEY_SIZE 32
 
 #ifdef WOLFSSL_NAMES_STATIC
 typedef char curve25519_str[12];
@@ -193,4 +194,3 @@ int wc_curve25519_size(curve25519_key* key);
 
 #endif /* HAVE_CURVE25519 */
 #endif /* WOLF_CRYPT_CURVE25519_H */
-

--- a/wolfssl/wolfcrypt/ed25519.h
+++ b/wolfssl/wolfcrypt/ed25519.h
@@ -77,6 +77,12 @@ enum {
     #define WC_ED25519KEY_TYPE_DEFINED
 #endif
 
+/* ED25519 Flags */
+enum {
+    WC_ED25519_FLAG_NONE     = 0x00,
+    WC_ED25519_FLAG_DEC_SIGN = 0x01,
+};
+
 /* An ED25519 Key */
 struct ed25519_key {
     byte    p[ED25519_PUB_KEY_SIZE]; /* compressed public key */
@@ -88,6 +94,7 @@ struct ed25519_key {
 #endif
 #ifdef WOLFSSL_SE050
     int keyId;
+    word32 flags;
 #endif
     word16 pubKeySet:1;
 #ifdef WOLFSSL_ASYNC_CRYPT


### PR DESCRIPTION
Still debugging issue with TLS side shared secret computation. Confirmed key inputs match, but result of computation does not.

server:

```
./configure CFLAGS="-DECC_USER_CURVES -DSHOW_SECRETS -DWOLFSSL_DEBUG_TLS" --disable-ecc --disable-rsa --disable-dh --enable-ed25519 --enable-curve25519 --disable-shared --enable-debug && make
./examples/server/server -b -d -i -x
```

client:

```
./configure --with-se050=/home/pi/se050_middleware/simw-top CFLAGS="-DWOLFSSL_SE050_INIT -DSE050_DEBUG -DECC_USER_CURVES -DWOLFSSL_SE050_FACTORY_RESET -DSHOW_SECRETS -DWOLFSSL_DEBUG_TLS" --disable-ecc --disable-rsa --disable-dh --enable-ed25519 --enable-curve25519 --disable-shared --enable-debug  && make
./examples/client/client -h [ip]
```