### PR TITLE
cmake: Increase minimum version to 3.16 and fix HomeBrew build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 # Project
 ####################################################
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.16)
 
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(FATAL_ERROR "In-source builds are not allowed.\
@@ -56,7 +56,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/functions.cmake)
 #       the same checks.
 # TODO: Turn on warnings.
 
-if(APPLE)
+if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
     # Silence ranlib warning "has no symbols"
     set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
     set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")


### PR DESCRIPTION
Increasing cmake version required to allow use of more recent
additions in the future.

Reported issue is that Homebrew use different compiler than AppleClang
(from XCode). Correctly test for AppleClang to set xcode specific `ar`
and `ranlib` flags. It may also be appropraite to use for ANDROID as
well see
https://github.com/Kitware/CMake/commit/7d057b2738e229192ae5afe71d50354681813235#diff-6f7a068f87ca22bd0105fef2143b0960e4993854863fd20c9416c677ee33a737R61-R67