### PR TITLE
Testing: fix OCSP stapling2 with openSSL 3

### DIFF
--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -416,7 +416,10 @@ remove_single_rF $ready_file5
                          -p $port5 -H loadSSL &
 server_pid5=$!
 wait_for_readyFile $ready_file5 $server_pid5 $port5
-echo "test connection" | openssl s_client -status -connect ${LOCALHOST}:$port5 -cert ./certs/client-cert.pem -key ./certs/client-key.pem -CAfile ./certs/ocsp/root-ca-cert.pem
+# with openSSL 3.0 the default it not allow connections to servers
+# without secure renegotiation extension. See
+# https://github.com/openssl/openssl/pull/15127
+echo "test connection" | openssl s_client -status -legacy_server_connect -connect ${LOCALHOST}:$port5 -cert ./certs/client-cert.pem -key ./certs/client-key.pem -CAfile ./certs/ocsp/root-ca-cert.pem
 RESULT=$?
 [ $RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection failed $RESULT" && exit 1
 wait $server_pid5


### PR DESCRIPTION
openSSL 3 appears to have changed use of legacy renegotiation from a
warning to an error resulting in this test failing.

Tested with `OpenSSL 3.0.1 14 Dec 2021`