### PR TITLE
Session doc and naming cleanups

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -2384,7 +2384,7 @@ WOLFSSL_API void       wolfSSL_flush_sessions(WOLFSSL_CTX*, long);
     }
     \endcode
 
-    \sa GetSessionClient
+    \sa wolfSSL_set_session
 */
 WOLFSSL_API int        wolfSSL_SetServerID(WOLFSSL*, const unsigned char*,
                                          int, int);
@@ -3794,7 +3794,10 @@ WOLFSSL_API const char*  wolfSSL_get_cipher(WOLFSSL*);
 /*!
     \ingroup Setup
 
-    \brief This function returns the WOLFSSL_SESSION from the WOLFSSL structure.
+    \brief This function returns the WOLFSSL_SESSION from the WOLFSSL structure
+    as a reference type. This requires calling wolfSSL_SESSION_free to release
+    the session reference. If the referred to session expires from the cache an
+    error will occur when trying to set the session.
 
     \return WOLFSSL_SESSION On success return session pointer.
     \return NULL on failure returns NULL.
@@ -3806,12 +3809,18 @@ WOLFSSL_API const char*  wolfSSL_get_cipher(WOLFSSL*);
     WOLFSSL* ssl;
     WOLFSSL_SESSION* ses;
     // attempt/complete handshake
+    wolfSSL_connect(ssl);
     ses  = wolfSSL_get1_session(ssl);
     // check ses information
+    // disconnect / setup new SSL instance
+    wolfSSL_set_session(ssl, ses);
+    // attempt/resume handshake
+    wolfSSL_SESSION_free(ses);
     \endcode
 
     \sa wolfSSL_new
     \sa wolfSSL_free
+    \sa wolfSSL_SESSION_free
 */
 WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -29276,7 +29276,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ssl->options.haveSessionId = 1;
         /* DoClientHello uses same resume code */
         if (ssl->options.resuming) {  /* let's try */
-            WOLFSSL_SESSION* session = GetSession(ssl,
+            WOLFSSL_SESSION* session = wolfSSL_GetSession(ssl,
                                                   ssl->arrays->masterSecret, 1);
             #ifdef HAVE_SESSION_TICKET
                 if (ssl->options.useTicket == 1) {
@@ -29351,7 +29351,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         } else
     #endif
         {
-            session = GetSession(ssl, ssl->arrays->masterSecret, 1);
+            session = wolfSSL_GetSession(ssl, ssl->arrays->masterSecret, 1);
         #ifdef HAVE_EXT_CACHE
             gotSess = 1;
         #endif

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -3084,7 +3084,8 @@ static int ProcessSessionTicket(const byte* input, int* sslBytes,
 
         /* Use the wolf Session cache to retain resumption secret */
         if (session->flags.cached == 0) {
-            WOLFSSL_SESSION* sess = GetSession(session->sslServer, NULL, 0);
+            WOLFSSL_SESSION* sess = wolfSSL_GetSession(session->sslServer,
+                NULL, 0);
             if (sess == NULL) {
                 AddSession(session->sslServer); /* don't re add */
             #ifdef WOLFSSL_SNIFFER_STATS
@@ -3121,8 +3122,8 @@ static int DoResume(SnifferSession* session, char* error)
 
 #ifdef WOLFSSL_TLS13
     if (IsAtLeastTLSv1_3(session->sslServer->version)) {
-        resume = GetSession(session->sslServer,
-                            session->sslServer->session.masterSecret, 0);
+        resume = wolfSSL_GetSession(session->sslServer,
+                                    session->sslServer->session.masterSecret, 0);
         if (resume == NULL) {
             /* TLS v1.3 with hello_retry uses session_id even for new session,
                 so ignore error here */
@@ -3132,8 +3133,8 @@ static int DoResume(SnifferSession* session, char* error)
     else
 #endif
     {
-        resume = GetSession(session->sslServer,
-                            session->sslServer->arrays->masterSecret, 0);
+        resume = wolfSSL_GetSession(session->sslServer,
+                                    session->sslServer->arrays->masterSecret, 0);
         if (resume == NULL) {
         #ifdef WOLFSSL_SNIFFER_STATS
             INC_STAT(SnifferStats.sslResumeMisses);
@@ -3967,7 +3968,7 @@ static int ProcessFinished(const byte* input, int size, int* sslBytes,
     if (ret == 0 && session->flags.cached == 0) {
         if (session->sslServer->options.haveSessionId) {
         #ifndef NO_SESSION_CACHE
-            WOLFSSL_SESSION* sess = GetSession(session->sslServer, NULL, 0);
+            WOLFSSL_SESSION* sess = wolfSSL_GetSession(session->sslServer, NULL, 0);
             if (sess == NULL) {
                 AddSession(session->sslServer); /* don't re add */
             #ifdef WOLFSSL_SNIFFER_STATS

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3452,17 +3452,17 @@ struct WOLFSSL_SESSION {
 };
 
 
-WOLFSSL_LOCAL WOLFSSL_SESSION* NewSession(void* heap);
-WOLFSSL_LOCAL WOLFSSL_SESSION* GetSession(WOLFSSL*, byte*, byte);
-WOLFSSL_LOCAL WOLFSSL_SESSION* GetSessionRef(WOLFSSL*);
-WOLFSSL_LOCAL int              SetSession(WOLFSSL*, WOLFSSL_SESSION*);
-WOLFSSL_LOCAL void             FreeSession(WOLFSSL_SESSION*);
+WOLFSSL_LOCAL WOLFSSL_SESSION* wolfSSL_NewSession(void* heap);
+WOLFSSL_LOCAL WOLFSSL_SESSION* wolfSSL_GetSession(WOLFSSL*, byte*, byte);
+WOLFSSL_LOCAL WOLFSSL_SESSION* wolfSSL_GetSessionRef(WOLFSSL*);
+WOLFSSL_LOCAL int              wolfSSL_SetSession(WOLFSSL*, WOLFSSL_SESSION*);
+WOLFSSL_LOCAL void             wolfSSL_FreeSession(WOLFSSL_SESSION*);
 
 typedef int (*hmacfp) (WOLFSSL*, byte*, const byte*, word32, int, int, int, int);
 
 #ifndef NO_CLIENT_CACHE
     WOLFSSL_LOCAL
-    WOLFSSL_SESSION* GetSessionClient(WOLFSSL*, const byte*, int);
+    WOLFSSL_SESSION* wolfSSL_GetSessionClient(WOLFSSL*, const byte*, int);
 #endif
 
 /* client connect state for nonblocking restart */


### PR DESCRIPTION
Improve documentation for `wolfSSL_get1_session`. ZD13363 
Add wolfSSL specific naming on the internal session functions to avoid possible user conflicts. ZD13487.