### PR TITLE
TLS: Default secure renegotiation compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4171,6 +4171,14 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_TLS_EXTENSIONS -DHAVE_SECURE_RENEGOTIATION -DHAVE_SERVER_RENEGOTIATION_INFO"
 fi
 
+# Secure Renegotiation Info
+AC_ARG_ENABLE([secure-renegotiation-info],
+    [AS_HELP_STRING([--enable-secure-renegotiation-info],[Enable Secure Renegotiation info extension (default: enabled)])],
+    [ ENABLED_SECURE_RENEGOTIATION_INFO=$enableval ],
+    [ ENABLED_SECURE_RENEGOTIATION_INFO=yes ]
+    )
+
+
 # Fallback SCSV
 AC_ARG_ENABLE([fallback-scsv],
     [AS_HELP_STRING([--enable-fallback-scsv],[Enable Fallback SCSV (default: disabled)])],
@@ -7153,7 +7161,20 @@ AS_IF([test "x$ENABLED_WOLFSSH" = "xyes"],[AM_CPPFLAGS="$AM_CPPFLAGS -DWOLFSSL_W
 
 if test "x$ENABLED_CERTS" = "xno" || test "x$ENABLED_LEANPSK" = "xyes" || test "x$ENABLED_ASN" = "xno"; then
    AM_CFLAGS="$AM_CFLAGS -DNO_ASN -DNO_CERTS"
+   ENABLED_ASN=no
 fi
+
+# only allow secure renegotiation info with TLSV12 and ASN
+if test "x$ENABLED_ASN" = "xno" || \
+    test "x$ENABLED_TLSV12" = "xno" || \
+    test "x$ENABLED_RENEGOTIATION_INDICATION" = "xyes"; then
+    ENABLED_SECURE_RENEGOTIATION_INFO="no"
+fi
+
+if test "x$ENABLED_SECURE_RENEGOTIATION_INFO" = "xyes"; then
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_TLS_EXTENSIONS -DHAVE_SERVER_RENEGOTIATION_INFO"
+fi
+
 
 
 # Depricated Algorithm Handling

--- a/src/internal.c
+++ b/src/internal.c
@@ -31371,7 +31371,6 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
 #ifndef WOLFSSL_NO_TLS12
 
 #if defined(HAVE_SECURE_RENEGOTIATION) && \
-    defined(HAVE_SERVER_RENEGOTIATION_INFO) && \
     !defined(WOLFSSL_NO_SERVER)
 
     /* handle generation of server's hello_request (0) */
@@ -31440,7 +31439,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
         return ret;
     }
 
-#endif /* HAVE_SECURE_RENEGOTIATION && HAVE_SERVER_RENEGOTIATION_INFO */
+#endif /* HAVE_SECURE_RENEGOTIATION && !WOLFSSL_NO_SERVER */
 
 #ifdef WOLFSSL_DTLS
     /* handle generation of DTLS hello_verify_request (3) */

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3024,7 +3024,7 @@ int wolfSSL_SecureResume(WOLFSSL* ssl)
 
     if (ssl->options.side == WOLFSSL_SERVER_END) {
         ssl->error = SIDE_ERROR;
-        return SSL_FATAL_ERROR;
+        return WOLFSSL_FATAL_ERROR;
     }
 
     return _Rehandshake(ssl);
@@ -41263,7 +41263,7 @@ int wolfSSL_RSA_LoadDer_ex(WOLFSSL_RSA* rsa, const unsigned char* derBuf,
         else {
              WOLFSSL_MSG("RsaPublicKeyDecode failed");
         }
-        return SSL_FATAL_ERROR;
+        return WOLFSSL_FATAL_ERROR;
     }
 
     if (SetRsaExternal(rsa) != WOLFSSL_SUCCESS) {
@@ -52746,7 +52746,7 @@ int wolfSSL_RSA_private_encrypt(int len, const unsigned char* in,
     #endif
     {
         WOLFSSL_MSG("Error with random number");
-        return SSL_FATAL_ERROR;
+        return WOLFSSL_FATAL_ERROR;
     }
 #endif
 
@@ -52781,7 +52781,7 @@ int wolfSSL_RSA_private_encrypt(int len, const unsigned char* in,
     #if !defined(WC_RSA_BLINDING) || defined(HAVE_USER_RSA)
     if (wc_FreeRng(rng) != 0) {
         WOLFSSL_MSG("Error freeing random number generator");
-        return SSL_FATAL_ERROR;
+        return WOLFSSL_FATAL_ERROR;
     }
     #endif
     if (sz <= 0) {

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -2863,7 +2863,7 @@ int wolfSSL_ALPN_FreePeerProtocol(WOLFSSL* ssl, char **list)
 #endif /* HAVE_ALPN */
 
 /* Secure Renegotiation */
-#ifdef HAVE_SECURE_RENEGOTIATION
+#ifdef HAVE_SERVER_RENEGOTIATION_INFO
 
 /* user is forcing ability to use secure renegotiation, we discourage it */
 int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl)
@@ -2954,7 +2954,7 @@ static int _Rehandshake(WOLFSSL* ssl)
 
         ssl->secure_renegotiation->cache_status = SCR_CACHE_NEEDED;
 
-#if !defined(NO_WOLFSSL_SERVER) && defined(HAVE_SERVER_RENEGOTIATION_INFO)
+#if !defined(NO_WOLFSSL_SERVER) && defined(HAVE_SECURE_RENEGOTIATION)
         if (ssl->options.side == WOLFSSL_SERVER_END) {
             ret = SendHelloRequest(ssl);
             if (ret != 0) {
@@ -3041,7 +3041,7 @@ long wolfSSL_SSL_get_secure_renegotiation_support(WOLFSSL* ssl)
     return ssl->secure_renegotiation->enabled;
 }
 
-#endif /* HAVE_SECURE_RENEGOTIATION */
+#endif /* HAVE_SECURE_RENEGOTIATION_INFO */
 
 #if defined(HAVE_SESSION_TICKET)
 /* Session Ticket */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2839,7 +2839,7 @@ struct WOLFSSL_CTX {
     byte        dhKeyTested:1;   /* Set when key has been tested. */
     #endif
 #endif
-#ifdef HAVE_SECURE_RENEGOTIATION
+#if defined(HAVE_SECURE_RENEGOTIATION) || defined(HAVE_SERVER_RENEGOTIATION_INFO)
     byte        useSecureReneg:1; /* when set will set WOLFSSL objects generated to enable */
 #endif
 #ifdef HAVE_ENCRYPT_THEN_MAC
@@ -4760,7 +4760,7 @@ WOLFSSL_LOCAL int SendCertificateRequest(WOLFSSL*);
 WOLFSSL_LOCAL int CreateOcspResponse(WOLFSSL*, OcspRequest**, buffer*);
 #endif
 #if defined(HAVE_SECURE_RENEGOTIATION) && \
-    defined(HAVE_SERVER_RENEGOTIATION_INFO)
+    !defined(WOLFSSL_NO_SERVER)
 WOLFSSL_LOCAL int SendHelloRequest(WOLFSSL*);
 #endif
 WOLFSSL_LOCAL int SendCertificateStatus(WOLFSSL*);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3710,7 +3710,7 @@ WOLFSSL_API int wolfSSL_NoKeyShares(WOLFSSL* ssl);
 
 
 /* Secure Renegotiation */
-#ifdef HAVE_SECURE_RENEGOTIATION
+#if defined(HAVE_SECURE_RENEGOTIATION) || defined(HAVE_SERVER_RENEGOTIATION_INFO)
 
 WOLFSSL_API int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_CTX_UseSecureRenegotiation(WOLFSSL_CTX* ctx);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2579,6 +2579,14 @@ extern void uITRON4_free(void *p) ;
      */
 #endif
 
+/* if secure renegotiation is enabled, make sure server info is enabled */
+#if !defined(HAVE_RENEGOTIATION_INDICATION) &&                               \
+  !defined(HAVE_SERVER_RENEGOTIATION_INFO) &&   \
+  defined(HAVE_SECURE_RENEGOTIATION) &&         \
+  !defined(NO_WOLFSSL_SERVER)
+    #define HAVE_SERVER_RENEGOTIATION_INFO
+#endif
+
 /* Crypto callbacks should enable hash flag support */
 #if defined(WOLF_CRYPTO_CB) && !defined(WOLFSSL_HASH_FLAGS)
     /* FIPS v1 and v2 do not support hash flags, so do not allow it with


### PR DESCRIPTION
By default this change will have servers send the renegotiation info
extension, but not allow renegotiation. This is accordance with RFC 5746

From to RFC 5746:
> In order to enable clients to probe, even servers that do not support
> renegotiation MUST implement the minimal version of the extension
> described in this document for initial handshakes, thus signaling
> that they have been upgraded.

With openSSL 3.0 the default it not allow connections to servers
without secure renegotiation extension. See
https://github.com/openssl/openssl/pull/15127