### PR TITLE
Aarch64 SHA512: fixup to work on Apple M1

### DIFF
--- a/wolfcrypt/src/port/arm/armv8-sha512-asm.S
+++ b/wolfcrypt/src/port/arm/armv8-sha512-asm.S
@@ -1215,6 +1215,9 @@ _Transform_Sha512_Len_crypto:
 	stp	d26, d27, [x29, #160]
 	stp	d28, d29, [x29, #176]
 	stp	d30, d31, [x29, #192]
+#ifdef __APPLE__
+.arch_extension sha3
+#endif /* __APPLE__ */
 #ifndef __APPLE__
 	adrp x4, L_SHA512_transform_crypto_len_k
 	add  x4, x4, :lo12:L_SHA512_transform_crypto_len_k

--- a/wolfcrypt/src/port/arm/armv8-sha512-asm.c
+++ b/wolfcrypt/src/port/arm/armv8-sha512-asm.c
@@ -1135,9 +1135,13 @@ static const uint64_t L_SHA512_transform_crypto_len_k[] = {
     0x6c44198c4a475817UL,
 };
 
+void Transform_Sha512_Len_crypto(wc_Sha512* sha512, const byte* data, word32 len);
 void Transform_Sha512_Len_crypto(wc_Sha512* sha512, const byte* data, word32 len)
 {
     __asm__ __volatile__ (
+#ifdef __APPLE__
+    ".arch_extension sha3\n\t"
+#endif /* __APPLE__ */
 #ifndef __APPLE__
         "adrp x4, %[L_SHA512_transform_crypto_len_k]\n\t"
         "add  x4, x4, :lo12:%[L_SHA512_transform_crypto_len_k]\n\t"
@@ -1652,7 +1656,7 @@ void Transform_Sha512_Len_crypto(wc_Sha512* sha512, const byte* data, word32 len
         /* Store digest back */
         "st1	{v24.2d, v25.2d, v26.2d, v27.2d}, [%x[sha512]]\n\t"
         : [sha512] "+r" (sha512), [data] "+r" (data), [len] "+r" (len)
-        : [L_SHA512_transform_neon_len_k] "S" (L_SHA512_transform_neon_len_k), [L_SHA512_transform_neon_len_ror8] "S" (L_SHA512_transform_neon_len_ror8), [L_SHA512_transform_crypto_len_k] "S" (L_SHA512_transform_crypto_len_k)
+        : [L_SHA512_transform_crypto_len_k] "S" (L_SHA512_transform_crypto_len_k)
         : "memory", "x3", "x4", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31"
     );
 }


### PR DESCRIPTION
Directive needed on Apple to indicate SHA3 extensions available.
Fixup C file as well - remove unused constants not avaiable and
prototype function that is extern elsewhere.