### PR TITLE
TLS EncryptThenMac; fix when extension response sent

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -5282,7 +5282,6 @@ static int TLSX_EncryptThenMac_Parse(WOLFSSL* ssl, const byte* input,
             ret = TLSX_EncryptThenMac_Use(ssl);
             if (ret != 0)
                 return ret;
-            TLSX_SetResponse(ssl, TLSX_ENCRYPT_THEN_MAC);
         }
         return 0;
     }
@@ -5316,6 +5315,24 @@ static int TLSX_EncryptThenMac_Use(WOLFSSL* ssl)
         if (ret != 0)
             return ret;
     }
+
+    return 0;
+}
+
+/**
+ * Set the Encrypt-Then-MAC extension as one to respond too.
+ *
+ * ssl      SSL object
+ * return EXT_MISSING when EncryptThenMac extension not in list.
+ */
+int TLSX_EncryptThenMac_Respond(WOLFSSL* ssl)
+{
+    TLSX* extension;
+
+    extension = TLSX_Find(ssl->extensions, TLSX_ENCRYPT_THEN_MAC);
+    if (extension == NULL)
+        return EXT_MISSING;
+    extension->resp = 1;
 
     return 0;
 }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2600,6 +2600,10 @@ WOLFSSL_LOCAL void TLSX_SessionTicket_Free(SessionTicket* ticket, void* heap);
 
 #endif /* HAVE_SESSION_TICKET */
 
+#if defined(HAVE_ENCRYPT_THEN_MAC) && !defined(WOLFSSL_AEAD_ONLY)
+int TLSX_EncryptThenMac_Respond(WOLFSSL* ssl);
+#endif
+
 #ifdef WOLFSSL_TLS13
 /* Cookie extension information - cookie data. */
 typedef struct Cookie {


### PR DESCRIPTION
Only respond with the extension when negotiated a block cipher.