### PR TITLE
Old Compiler Warning Cleanup (GCC 4.0.2)

### DIFF
--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -1563,41 +1563,47 @@ static void* server_thread(void* args)
 #endif /* !NO_WOLFSSL_SERVER */
 
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-#endif
 static void print_stats(stats_t* wcStat, const char* desc, const char* cipher, const char *group, int verbose)
 {
-    const char* formatStr;
-
     if (verbose) {
-        formatStr = "wolfSSL %s Benchmark on %s with group %s:\n"
-               "\tTotal       : %9d bytes\n"
-               "\tNum Conns   : %9d\n"
-               "\tRx Total    : %9.3f ms\n"
-               "\tTx Total    : %9.3f ms\n"
-               "\tRx          : %9.3f MB/s\n"
-               "\tTx          : %9.3f MB/s\n"
-               "\tConnect     : %9.3f ms\n"
-               "\tConnect Avg : %9.3f ms\n";
+        fprintf(stderr,
+                "wolfSSL %s Benchmark on %s with group %s:\n"
+                "\tTotal       : %9d bytes\n"
+                "\tNum Conns   : %9d\n"
+                "\tRx Total    : %9.3f ms\n"
+                "\tTx Total    : %9.3f ms\n"
+                "\tRx          : %9.3f MB/s\n"
+                "\tTx          : %9.3f MB/s\n"
+                "\tConnect     : %9.3f ms\n"
+                "\tConnect Avg : %9.3f ms\n",
+                desc,
+                cipher,
+                group,
+                wcStat->txTotal + wcStat->rxTotal,
+                wcStat->connCount,
+                wcStat->rxTime * 1000,
+                wcStat->txTime * 1000,
+                wcStat->rxTotal / wcStat->rxTime / 1024 / 1024,
+                wcStat->txTotal / wcStat->txTime / 1024 / 1024,
+                wcStat->connTime * 1000,
+                wcStat->connTime * 1000 / wcStat->connCount);
     }
     else {
-        formatStr = "%-6s  %-33s  %-25s  %11d  %9d  %9.3f  %9.3f  %9.3f  %9.3f  %17.3f  %15.3f\n";
+        fprintf(stderr,
+                "%-6s  %-33s  %-25s  %11d  %9d  %9.3f  %9.3f  %9.3f  "
+                "%9.3f  %17.3f  %15.3f\n",
+                desc,
+                cipher,
+                group,
+                wcStat->txTotal + wcStat->rxTotal,
+                wcStat->connCount,
+                wcStat->rxTime * 1000,
+                wcStat->txTime * 1000,
+                wcStat->rxTotal / wcStat->rxTime / 1024 / 1024,
+                wcStat->txTotal / wcStat->txTime / 1024 / 1024,
+                wcStat->connTime * 1000,
+                wcStat->connTime * 1000 / wcStat->connCount);
     }
-
-    fprintf(stderr, formatStr,
-            desc,
-            cipher,
-            group,
-            wcStat->txTotal + wcStat->rxTotal,
-            wcStat->connCount,
-            wcStat->rxTime * 1000,
-            wcStat->txTime * 1000,
-            wcStat->rxTotal / wcStat->rxTime / 1024 / 1024,
-            wcStat->txTotal / wcStat->txTime / 1024 / 1024,
-            wcStat->connTime * 1000,
-            wcStat->connTime * 1000 / wcStat->connCount);
 }
 
 static void Usage(void)
@@ -1699,9 +1705,6 @@ static int SetupSupportedGroups(int verbose)
 }
 #endif
 
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
 
 int bench_tls(void* args)
 {

--- a/src/internal.c
+++ b/src/internal.c
@@ -11536,7 +11536,7 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
     char*   filename = NULL;
     const char* post = "";
     byte*   pbuf = NULL;
-    int     len, num, i, index;
+    int     len, num, i, idx;
     byte    suffix = 0;
     int retHash = NOT_COMPILED_IN;
     byte dgt[WC_MAX_DIGEST_SIZE];
@@ -11592,10 +11592,10 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
             }
 
             hash_tmp.hash_value = hash;
-            index = wolfSSL_sk_BY_DIR_HASH_find(entry->hashes, &hash_tmp);
-            if (index >= 0) {
+            idx = wolfSSL_sk_BY_DIR_HASH_find(entry->hashes, &hash_tmp);
+            if (idx >= 0) {
                 WOLFSSL_MSG("find hashed CRL in list");
-                ph = wolfSSL_sk_BY_DIR_HASH_value(entry->hashes, index);
+                ph = wolfSSL_sk_BY_DIR_HASH_value(entry->hashes, idx);
                 suffix = ph->last_suffix;
             } else {
                 ph = NULL;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -41339,7 +41339,7 @@ int wolfSSL_RSA_padding_add_PKCS1_PSS(WOLFSSL_RSA *rsa, unsigned char *EM,
     }
 
     hashType = wolfSSL_EVP_md2macType(hashAlg);
-    if (hashType < WC_HASH_TYPE_NONE || hashType > WC_HASH_TYPE_MAX) {
+    if (hashType > WC_HASH_TYPE_MAX) {
         WOLFSSL_MSG("wolfSSL_EVP_md2macType error");
         goto cleanup;
     }
@@ -41446,7 +41446,7 @@ int wolfSSL_RSA_verify_PKCS1_PSS(WOLFSSL_RSA *rsa, const unsigned char *mHash,
     }
 
     hashType = wolfSSL_EVP_md2macType(hashAlg);
-    if (hashType < WC_HASH_TYPE_NONE || hashType > WC_HASH_TYPE_MAX) {
+    if (hashType > WC_HASH_TYPE_MAX) {
         WOLFSSL_MSG("wolfSSL_EVP_md2macType error");
         return WOLFSSL_FAILURE;
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1439,7 +1439,7 @@ int wolfSSL_set_secret(WOLFSSL* ssl, word16 epoch,
 
 #ifdef WOLFSSL_DTLS
 
-int wolfSSL_mcast_peer_add(WOLFSSL* ssl, word16 peerId, int remove)
+int wolfSSL_mcast_peer_add(WOLFSSL* ssl, word16 peerId, int sub)
 {
     WOLFSSL_DTLS_PEERSEQ* p = NULL;
     int ret = WOLFSSL_SUCCESS;
@@ -1449,7 +1449,7 @@ int wolfSSL_mcast_peer_add(WOLFSSL* ssl, word16 peerId, int remove)
     if (ssl == NULL || peerId > 255)
         return BAD_FUNC_ARG;
 
-    if (!remove) {
+    if (!sub) {
         /* Make sure it isn't already present, while keeping the first
          * open spot. */
         for (i = 0; i < WOLFSSL_DTLS_PEERSEQ_SZ; i++) {
@@ -21427,11 +21427,11 @@ int wolfSSL_sk_X509_CRL_num(WOLF_STACK_OF(WOLFSSL_X509)* sk)
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
 /* return 1 on success 0 on fail */
 int wolfSSL_sk_ACCESS_DESCRIPTION_push(WOLF_STACK_OF(ACCESS_DESCRIPTION)* sk,
-                                              WOLFSSL_ACCESS_DESCRIPTION* access)
+                                              WOLFSSL_ACCESS_DESCRIPTION* a)
 {
     WOLFSSL_ENTER("wolfSSL_sk_ACCESS_DESCRIPTION_push");
 
-    return wolfSSL_sk_push(sk, access);
+    return wolfSSL_sk_push(sk, a);
 }
 
 /* Frees all nodes in ACCESS_DESCRIPTION stack
@@ -21471,19 +21471,19 @@ void wolfSSL_AUTHORITY_INFO_ACCESS_pop_free(
 }
 
 
-void wolfSSL_ACCESS_DESCRIPTION_free(WOLFSSL_ACCESS_DESCRIPTION* access)
+void wolfSSL_ACCESS_DESCRIPTION_free(WOLFSSL_ACCESS_DESCRIPTION* a)
 {
     WOLFSSL_ENTER("wolfSSL_ACCESS_DESCRIPTION_free");
-    if (access == NULL)
+    if (a == NULL)
         return;
 
-    if (access->method)
-        wolfSSL_ASN1_OBJECT_free(access->method);
-    if (access->location)
-        wolfSSL_GENERAL_NAME_free(access->location);
-    XFREE(access, NULL, DYNAMIC_TYPE_X509_EXT);
+    if (a->method)
+        wolfSSL_ASN1_OBJECT_free(a->method);
+    if (a->location)
+        wolfSSL_GENERAL_NAME_free(a->location);
+    XFREE(a, NULL, DYNAMIC_TYPE_X509_EXT);
 
-    /* access = NULL, don't try to access or double free it */
+    /* a = NULL, don't try to a or double free it */
 }
 #endif /* OPENSSL_ALL || WOLFSSL_QT */
 
@@ -22405,7 +22405,7 @@ void wolfSSL_sk_X509_EXTENSION_pop_free(
  */
 WOLFSSL_EC_KEY *wolfSSL_EC_KEY_dup(const WOLFSSL_EC_KEY *src)
 {
-    WOLFSSL_EC_KEY *dup;
+    WOLFSSL_EC_KEY *newKey;
     ecc_key *key, *srcKey;
     int ret;
 
@@ -22418,16 +22418,16 @@ WOLFSSL_EC_KEY *wolfSSL_EC_KEY_dup(const WOLFSSL_EC_KEY *src)
         return NULL;
     }
 
-    dup = wolfSSL_EC_KEY_new();
-    if (dup == NULL) {
+    newKey = wolfSSL_EC_KEY_new();
+    if (newKey == NULL) {
         WOLFSSL_MSG("wolfSSL_EC_KEY_new error");
         return NULL;
     }
 
-    key = (ecc_key*)dup->internal;
+    key = (ecc_key*)newKey->internal;
     if (key == NULL) {
         WOLFSSL_MSG("ecc_key NULL error");
-        wolfSSL_EC_KEY_free(dup);
+        wolfSSL_EC_KEY_free(newKey);
         return NULL;
     }
     srcKey = (ecc_key*)src->internal;
@@ -22437,7 +22437,7 @@ WOLFSSL_EC_KEY *wolfSSL_EC_KEY_dup(const WOLFSSL_EC_KEY *src)
     ret = wc_ecc_copy_point(&srcKey->pubkey, &key->pubkey);
     if (ret != MP_OKAY) {
         WOLFSSL_MSG("wc_ecc_copy_point error");
-        wolfSSL_EC_KEY_free(dup);
+        wolfSSL_EC_KEY_free(newKey);
         return NULL;
     }
 
@@ -22445,7 +22445,7 @@ WOLFSSL_EC_KEY *wolfSSL_EC_KEY_dup(const WOLFSSL_EC_KEY *src)
     ret = mp_copy(&srcKey->k, &key->k);
     if (ret != MP_OKAY) {
         WOLFSSL_MSG("mp_copy error");
-        wolfSSL_EC_KEY_free(dup);
+        wolfSSL_EC_KEY_free(newKey);
         return NULL;
     }
 
@@ -22464,73 +22464,73 @@ WOLFSSL_EC_KEY *wolfSSL_EC_KEY_dup(const WOLFSSL_EC_KEY *src)
     key->flags = srcKey->flags;
 
     /* Copy group */
-    if (dup->group == NULL) {
+    if (newKey->group == NULL) {
         WOLFSSL_MSG("EC_GROUP_new_by_curve_name error");
-        wolfSSL_EC_KEY_free(dup);
+        wolfSSL_EC_KEY_free(newKey);
         return NULL;
     }
 
-    dup->group->curve_idx = src->group->curve_idx;
-    dup->group->curve_nid = src->group->curve_nid;
-    dup->group->curve_oid = src->group->curve_oid;
+    newKey->group->curve_idx = src->group->curve_idx;
+    newKey->group->curve_nid = src->group->curve_nid;
+    newKey->group->curve_oid = src->group->curve_oid;
 
     /* Copy public key */
-    if (src->pub_key->internal == NULL || dup->pub_key->internal == NULL) {
+    if (src->pub_key->internal == NULL || newKey->pub_key->internal == NULL) {
         WOLFSSL_MSG("NULL pub_key error");
-        wolfSSL_EC_KEY_free(dup);
+        wolfSSL_EC_KEY_free(newKey);
         return NULL;
     }
 
     /* Copy public key internal */
     ret = wc_ecc_copy_point((ecc_point*)src->pub_key->internal, \
-                            (ecc_point*)dup->pub_key->internal);
+                            (ecc_point*)newKey->pub_key->internal);
     if (ret != MP_OKAY) {
         WOLFSSL_MSG("ecc_copy_point error");
-        wolfSSL_EC_KEY_free(dup);
+        wolfSSL_EC_KEY_free(newKey);
         return NULL;
     }
 
     /* Copy X, Y, Z */
-    dup->pub_key->X = wolfSSL_BN_dup(src->pub_key->X);
-    if (!dup->pub_key->X && src->pub_key->X) {
+    newKey->pub_key->X = wolfSSL_BN_dup(src->pub_key->X);
+    if (!newKey->pub_key->X && src->pub_key->X) {
         WOLFSSL_MSG("Error copying EC_POINT");
-        wolfSSL_EC_KEY_free(dup);
+        wolfSSL_EC_KEY_free(newKey);
         return NULL;
     }
-    dup->pub_key->Y = wolfSSL_BN_dup(src->pub_key->Y);
-    if (!dup->pub_key->Y && src->pub_key->Y) {
+    newKey->pub_key->Y = wolfSSL_BN_dup(src->pub_key->Y);
+    if (!newKey->pub_key->Y && src->pub_key->Y) {
         WOLFSSL_MSG("Error copying EC_POINT");
-        wolfSSL_EC_KEY_free(dup);
+        wolfSSL_EC_KEY_free(newKey);
         return NULL;
     }
-    dup->pub_key->Z = wolfSSL_BN_dup(src->pub_key->Z);
-    if (!dup->pub_key->Z && src->pub_key->Z) {
+    newKey->pub_key->Z = wolfSSL_BN_dup(src->pub_key->Z);
+    if (!newKey->pub_key->Z && src->pub_key->Z) {
         WOLFSSL_MSG("Error copying EC_POINT");
-        wolfSSL_EC_KEY_free(dup);
+        wolfSSL_EC_KEY_free(newKey);
         return NULL;
     }
 
-    dup->pub_key->inSet = src->pub_key->inSet;
-    dup->pub_key->exSet = src->pub_key->exSet;
-    dup->pkcs8HeaderSz = src->pkcs8HeaderSz;
+    newKey->pub_key->inSet = src->pub_key->inSet;
+    newKey->pub_key->exSet = src->pub_key->exSet;
+    newKey->pkcs8HeaderSz = src->pkcs8HeaderSz;
 
     /* Copy private key */
-    if (src->priv_key->internal == NULL || dup->priv_key->internal == NULL) {
+    if (src->priv_key->internal == NULL || newKey->priv_key->internal == NULL) {
         WOLFSSL_MSG("NULL priv_key error");
-        wolfSSL_EC_KEY_free(dup);
+        wolfSSL_EC_KEY_free(newKey);
         return NULL;
     }
 
-    /* Free priv_key before call to dup function */
-    wolfSSL_BN_free(dup->priv_key);
-    dup->priv_key = wolfSSL_BN_dup(src->priv_key);
-    if (dup->priv_key == NULL) {
-        WOLFSSL_MSG("BN_dup error");
-        wolfSSL_EC_KEY_free(dup);
+    /* Free priv_key before call to newKey function */
+    wolfSSL_BN_free(newKey->priv_key);
+    newKey->priv_key = wolfSSL_BN_dup(src->priv_key);
+    if (newKey->priv_key == NULL) {
+        WOLFSSL_MSG("BN_newKey error");
+        wolfSSL_EC_KEY_free(newKey);
         return NULL;
     }
 
-    return dup;
+    return newKey;
 
 }
 #endif /* HAVE_ECC */
@@ -46359,17 +46359,17 @@ static int get_ex_new_index(int class_index)
     static int ssl_idx = 0;
     static int x509_idx = 0;
 
-    int index = -1;
+    int idx = -1;
 
     switch(class_index) {
         case CRYPTO_EX_INDEX_SSL:
-            index = ssl_idx++;
+            idx = ssl_idx++;
             break;
         case CRYPTO_EX_INDEX_SSL_CTX:
-            index = ctx_idx++;
+            idx = ctx_idx++;
             break;
         case CRYPTO_EX_INDEX_X509:
-            index = x509_idx++;
+            idx = x509_idx++;
             break;
 
         /* following class indexes are not supoprted */
@@ -46389,7 +46389,7 @@ static int get_ex_new_index(int class_index)
         default:
             break;
     }
-    return index;
+    return idx;
 }
 #endif /* HAVE_EX_DATA || WOLFSSL_WPAS_SMALL */
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -18803,7 +18803,7 @@ static int test_wc_RsaPSS_VerifyCheck (void)
     int                 sz = 256; /* 2048/8 */
     byte*               pt;
     byte                digest[32];
-    word32              digestSz;
+    word32              digestSz = sizeof(digest);
     unsigned char       pSignature[2048/8]; /* 2048 is RSA_KEY_SIZE */
     word32              pSignatureSz = sizeof(pSignature);
     unsigned char       pDecrypted[2048/8];
@@ -18898,7 +18898,7 @@ static int test_wc_RsaPSS_VerifyCheckInline (void)
     int                 sz = 256;
     byte*               pt;
     byte                digest[32];
-    word32              digestSz;
+    word32              digestSz = sizeof(digest);
     unsigned char       pSignature[2048/8]; /* 2048 is RSA_KEY_SIZE */
     unsigned char       pDecrypted[2048/8];
     pt = pDecrypted;

--- a/tests/api.c
+++ b/tests/api.c
@@ -9170,12 +9170,12 @@ static int test_wc_InitBlake2b (void)
     int ret = 0;
 #ifdef HAVE_BLAKE2
 
-    Blake2b blake2b;
+    Blake2b blake;
 
     printf(testingFmt, "wc_InitBlake2B()");
 
     /* Test good arg. */
-    ret = wc_InitBlake2b(&blake2b, 64);
+    ret = wc_InitBlake2b(&blake, 64);
     if (ret != 0) {
         ret = WOLFSSL_FATAL_ERROR;
     }
@@ -9200,7 +9200,7 @@ static int test_wc_InitBlake2b (void)
     }
 
     if (!ret) {
-        ret = wc_InitBlake2b(&blake2b, 128);
+        ret = wc_InitBlake2b(&blake, 128);
         if (ret == 0) {
             ret = WOLFSSL_FATAL_ERROR;
         } else {
@@ -9218,7 +9218,7 @@ static int test_wc_InitBlake2b (void)
     }
 
     if (!ret) {
-        ret = wc_InitBlake2b(&blake2b, 0);
+        ret = wc_InitBlake2b(&blake, 0);
         if (ret == 0) {
             ret = WOLFSSL_FATAL_ERROR;
         } else {
@@ -9239,7 +9239,7 @@ static int test_wc_InitBlake2b_WithKey (void)
 {
     int ret = 0;
 #ifdef HAVE_BLAKE2
-    Blake2b     blake2b;
+    Blake2b     blake;
     word32      digestSz = BLAKE2B_KEYBYTES;
     byte        key[BLAKE2B_KEYBYTES];
     word32      keylen = BLAKE2B_KEYBYTES;
@@ -9249,7 +9249,7 @@ static int test_wc_InitBlake2b_WithKey (void)
     printf(testingFmt, "wc_InitBlake2b_WithKey()");
 
     /* Test good arg. */
-    ret = wc_InitBlake2b_WithKey(&blake2b, digestSz, key, keylen);
+    ret = wc_InitBlake2b_WithKey(&blake, digestSz, key, keylen);
     if (ret != 0) {
         ret = WOLFSSL_FATAL_ERROR;
     }
@@ -9261,13 +9261,13 @@ static int test_wc_InitBlake2b_WithKey (void)
         }
     }
     if (ret == 0) {
-        ret = wc_InitBlake2b_WithKey(&blake2b, digestSz, key, 256);
+        ret = wc_InitBlake2b_WithKey(&blake, digestSz, key, 256);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
     }
     if (ret == 0) {
-        ret = wc_InitBlake2b_WithKey(&blake2b, digestSz, NULL, keylen);
+        ret = wc_InitBlake2b_WithKey(&blake, digestSz, NULL, keylen);
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
@@ -9283,7 +9283,7 @@ static int test_wc_InitBlake2s_WithKey (void)
 {
     int ret = 0;
 #ifdef HAVE_BLAKE2S
-    Blake2s     blake2s;
+    Blake2s     blake;
     word32      digestSz = BLAKE2S_KEYBYTES;
     byte        *key = (byte*)"01234567890123456789012345678901";
     word32      keylen = BLAKE2S_KEYBYTES;
@@ -9291,7 +9291,7 @@ static int test_wc_InitBlake2s_WithKey (void)
     printf(testingFmt, "wc_InitBlake2s_WithKey()");
 
     /* Test good arg. */
-    ret = wc_InitBlake2s_WithKey(&blake2s, digestSz, key, keylen);
+    ret = wc_InitBlake2s_WithKey(&blake, digestSz, key, keylen);
     if (ret != 0) {
         ret = WOLFSSL_FATAL_ERROR;
     }
@@ -9303,13 +9303,13 @@ static int test_wc_InitBlake2s_WithKey (void)
         }
     }
     if (ret == 0) {
-        ret = wc_InitBlake2s_WithKey(&blake2s, digestSz, key, 256);
+        ret = wc_InitBlake2s_WithKey(&blake, digestSz, key, 256);
         if (ret == BAD_FUNC_ARG) {
             ret = 0;
         }
     }
     if (ret == 0) {
-        ret = wc_InitBlake2s_WithKey(&blake2s, digestSz, NULL, keylen);
+        ret = wc_InitBlake2s_WithKey(&blake, digestSz, NULL, keylen);
     }
 
     printf(resultFmt, ret == 0 ? passed : failed);
@@ -35140,7 +35140,7 @@ static void test_wolfSSL_sk_SSL_CIPHER(void)
        !defined(NO_FILESYSTEM) && !defined(NO_RSA)
     SSL*     ssl;
     SSL_CTX* ctx;
-    STACK_OF(SSL_CIPHER) *sk, *dup;
+    STACK_OF(SSL_CIPHER) *sk, *dupSk;
 
     printf(testingFmt, "wolfSSL_sk_SSL_CIPHER_*()");
 
@@ -35153,13 +35153,13 @@ static void test_wolfSSL_sk_SSL_CIPHER(void)
     AssertTrue(SSL_CTX_use_PrivateKey_file(ctx, svrKeyFile, SSL_FILETYPE_PEM));
     AssertNotNull(ssl = SSL_new(ctx));
     AssertNotNull(sk = SSL_get_ciphers(ssl));
-    AssertNotNull(dup = sk_SSL_CIPHER_dup(sk));
+    AssertNotNull(dupSk = sk_SSL_CIPHER_dup(sk));
     AssertIntGT(sk_SSL_CIPHER_num(sk), 0);
-    AssertIntEQ(sk_SSL_CIPHER_num(sk), sk_SSL_CIPHER_num(dup));
+    AssertIntEQ(sk_SSL_CIPHER_num(sk), sk_SSL_CIPHER_num(dupSk));
 
     /* error case because connection has not been established yet */
     AssertIntEQ(sk_SSL_CIPHER_find(sk, SSL_get_current_cipher(ssl)), -1);
-    sk_SSL_CIPHER_free(dup);
+    sk_SSL_CIPHER_free(dupSk);
 
     /* sk is pointer to internal struct that should be free'd in SSL_free */
     SSL_free(ssl);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -11924,12 +11924,12 @@ int wc_ecc_encrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
                 word32 msgSz, byte* out, word32* outSz, ecEncCtx* ctx)
 {
     int          ret = 0;
-    word32       blockSz;
+    word32       blockSz = 0;
 #ifndef WOLFSSL_ECIES_OLD
     byte         iv[ECC_MAX_IV_SIZE];
-    word32       pubKeySz;
+    word32       pubKeySz = 0;
 #endif
-    word32       digestSz;
+    word32       digestSz = 0;
     ecEncCtx     localCtx;
 #ifdef WOLFSSL_SMALL_STACK
     byte*        sharedSecret;
@@ -11948,13 +11948,13 @@ int wc_ecc_encrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
     /* 'Uncompressed' byte | public key x | public key y | secret */
     word32       sharedSz = 1 + ECC_MAXSIZE * 3;
 #endif
-    int          keysLen;
-    int          encKeySz;
-    int          ivSz;
+    int          keysLen = 0;
+    int          encKeySz = 0;
+    int          ivSz = 0;
     int          offset = 0;         /* keys offset if doing msg exchange */
-    byte*        encKey;
-    byte*        encIv;
-    byte*        macKey;
+    byte*        encKey = NULL;
+    byte*        encIv = NULL;
+    byte*        macKey = NULL;
 
     if (privKey == NULL || pubKey == NULL || msg == NULL || out == NULL ||
                            outSz  == NULL)
@@ -12191,17 +12191,17 @@ int wc_ecc_decrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
                 word32 msgSz, byte* out, word32* outSz, ecEncCtx* ctx)
 {
     int          ret = 0;
-    word32       blockSz;
+    word32       blockSz = 0;
 #ifndef WOLFSSL_ECIES_OLD
     byte         iv[ECC_MAX_IV_SIZE];
-    word32       pubKeySz;
+    word32       pubKeySz = 0;
 #ifdef WOLFSSL_SMALL_STACK
     ecc_key*     peerKey = NULL;
 #else
     ecc_key      peerKey[1];
 #endif
 #endif
-    word32       digestSz;
+    word32       digestSz = 0;
     ecEncCtx     localCtx;
 #ifdef WOLFSSL_SMALL_STACK
     byte*        sharedSecret;
@@ -12219,13 +12219,13 @@ int wc_ecc_decrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
 #else
     word32       sharedSz = ECC_MAXSIZE * 3 + 1;
 #endif
-    int          keysLen;
-    int          encKeySz;
-    int          ivSz;
+    int          keysLen = 0;
+    int          encKeySz = 0;
+    int          ivSz = 0;
     int          offset = 0;       /* in case using msg exchange */
-    byte*        encKey;
-    byte*        encIv;
-    byte*        macKey;
+    byte*        encKey = NULL;
+    byte*        encIv = NULL;
+    byte*        macKey = NULL;
 
 
     if (privKey == NULL || msg == NULL || out == NULL || outSz  == NULL)

--- a/wolfcrypt/src/eccsi.c
+++ b/wolfcrypt/src/eccsi.c
@@ -1707,17 +1707,17 @@ int wc_SetEccsiPair(EccsiKey* key, const mp_int* ssk, const ecc_point* pvt)
  *
  * @param  [in]   a      MP integer to fix.
  * @param  [in]   order  MP integer representing order of curve.
- * @param  [in]   max    Maximum number of bytes to encode into.
+ * @param  [in]   m      Maximum number of bytes to encode into.
  * @param  [out]  r      MP integer that is the result after fixing.
  * @return  0 on success.
  * @return  MEMORY_E when dynamic memory allocation fails.
  */
-static int eccsi_fit_to_octets(const mp_int* a, mp_int* order, int max,
+static int eccsi_fit_to_octets(const mp_int* a, mp_int* order, int m,
         mp_int* r)
 {
     int err;
 
-    if (mp_count_bits(a) > max * 8) {
+    if (mp_count_bits(a) > m * 8) {
         err = mp_sub(order, (mp_int*)a, r);
     }
     else
@@ -1737,16 +1737,16 @@ static int eccsi_fit_to_octets(const mp_int* a, mp_int* order, int max,
  *
  * @param  [in]   a      MP integer to fix.
  * @param  [in]   order  MP integer representing order of curve.
- * @param  [in]   max    Maximum number of bytes to encode into.
+ * @param  [in]   m      Maximum number of bytes to encode into.
  * @param  [out]  r      MP integer that is the result after fixing.
  * @return  0 on success.
  * @return  MEMORY_E when dynamic memory allocation fails.
  */
-static int eccsi_fit_to_octets(const mp_int* a, const mp_int* order, int max,
+static int eccsi_fit_to_octets(const mp_int* a, const mp_int* order, int m,
         mp_int* r)
 {
     (void)order;
-    (void)max;
+    (void)m;
 
     /* Duplicate line to stop static analyzer complaining. */
     return mp_copy(a, r);

--- a/wolfcrypt/src/ge_operations.c
+++ b/wolfcrypt/src/ge_operations.c
@@ -61,16 +61,16 @@ static void ge_p2_0(ge_p2 *);
 static void ge_precomp_0(ge_precomp *);
 #endif
 static void ge_p3_to_p2(ge_p2 *,const ge_p3 *);
-static void ge_p3_to_cached(ge_cached *,const ge_p3 *);
+static WC_INLINE void ge_p3_to_cached(ge_cached *,const ge_p3 *);
 static void ge_p1p1_to_p2(ge_p2 *,const ge_p1p1 *);
-static void ge_p1p1_to_p3(ge_p3 *,const ge_p1p1 *);
-static void ge_p2_dbl(ge_p1p1 *,const ge_p2 *);
+static WC_INLINE void ge_p1p1_to_p3(ge_p3 *,const ge_p1p1 *);
+static WC_INLINE void ge_p2_dbl(ge_p1p1 *,const ge_p2 *);
 static void ge_p3_dbl(ge_p1p1 *,const ge_p3 *);
 
-static void ge_madd(ge_p1p1 *,const ge_p3 *,const ge_precomp *);
-static void ge_msub(ge_p1p1 *,const ge_p3 *,const ge_precomp *);
-static void ge_add(ge_p1p1 *,const ge_p3 *,const ge_cached *);
-static void ge_sub(ge_p1p1 *,const ge_p3 *,const ge_cached *);
+static WC_INLINE void ge_madd(ge_p1p1 *,const ge_p3 *,const ge_precomp *);
+static WC_INLINE void ge_msub(ge_p1p1 *,const ge_p3 *,const ge_precomp *);
+static WC_INLINE void ge_add(ge_p1p1 *,const ge_p3 *,const ge_cached *);
+static WC_INLINE void ge_sub(ge_p1p1 *,const ge_p3 *,const ge_cached *);
 
 /*
 ge means group element.

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -568,8 +568,6 @@ int wc_PKCS12_PBKDF_ex(byte* output, const byte* passwd, int passLen,
 
 /* (2^32 - 1) */
 #define SCRYPT_WORD32_MAX 4294967295U
-/* (2^32 - 1) * 32, used in a couple of scrypt max calculations. */
-#define SCRYPT_MAX 137438953440UL
 
 /* One round of Salsa20/8.
  * Code taken from RFC 7914: scrypt PBKDF.
@@ -760,7 +758,13 @@ int wc_scrypt(byte* output, const byte* passwd, int passLen,
     if (cost < 1 || cost >= 128 * blockSize / 8 || parallel < 1 || dkLen < 1)
         return BAD_FUNC_ARG;
 
-    if ((word32)parallel > (SCRYPT_MAX / (128 * blockSize)))
+    /* The following comparison used to be:
+     *    ((word32)parallel > (SCRYPT_MAX / (128 * blockSize)))
+     * where SCRYPT_MAX is (2^32 - 1) * 32. For some compilers, the RHS of
+     * the comparison is greater than parallel's type. It wouldn't promote
+     * both sides to word64. What follows is just arithmetic simplification.
+     */
+    if ((word32)parallel > (SCRYPT_WORD32_MAX / (4 * blockSize)))
         return BAD_FUNC_ARG;
 
     bSz = 128 * blockSize;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1769,7 +1769,7 @@ WOLFSSL_LOCAL int  CheckVersion(WOLFSSL *ssl, ProtocolVersion pv);
 WOLFSSL_LOCAL int  PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
                                    word32 hashSigAlgoSz);
 #ifdef WOLF_CRYPTO_CB
-WOLFSSL_LOCAL int  CreateDevPrivateKey(void** pkey, byte* buffer, word32 length,
+WOLFSSL_LOCAL int  CreateDevPrivateKey(void** pkey, byte* data, word32 length,
                                        int hsType, int label, int id,
                                        void* heap, int devId);
 #endif
@@ -2389,8 +2389,8 @@ WOLFSSL_LOCAL word16 TLSX_SNI_GetRequest(TLSX* extensions, byte type,
 #ifndef NO_WOLFSSL_SERVER
 WOLFSSL_LOCAL void   TLSX_SNI_SetOptions(TLSX* extensions, byte type,
                                                                   byte options);
-WOLFSSL_LOCAL int    TLSX_SNI_GetFromBuffer(const byte* buffer, word32 bufferSz,
-                                         byte type, byte* sni, word32* inOutSz);
+WOLFSSL_LOCAL int    TLSX_SNI_GetFromBuffer(const byte* clientHello,
+                         word32 helloSz, byte type, byte* sni, word32* inOutSz);
 #endif
 
 #endif /* HAVE_SNI */
@@ -2489,7 +2489,7 @@ WOLFSSL_LOCAL int   TLSX_CSR2_InitRequests(TLSX* extensions, DecodedCert* cert,
                                                        byte isPeer, void* heap);
 #endif
 WOLFSSL_LOCAL void* TLSX_CSR2_GetRequest(TLSX* extensions, byte status_type,
-                                                                    byte index);
+                                                                    byte idx);
 WOLFSSL_LOCAL int   TLSX_CSR2_ForceRequest(WOLFSSL* ssl);
 
 #endif
@@ -4659,7 +4659,7 @@ WOLFSSL_API   void SSL_ResourceFree(WOLFSSL*);   /* Micrium uses */
     void FreeTimeoutInfo(TimeoutInfo*, void*);
     WOLFSSL_LOCAL
     void AddPacketInfo(WOLFSSL* ssl, const char* name, int type,
-                               const byte* data, int sz, int write, void* heap);
+                             const byte* data, int sz, int written, void* heap);
     WOLFSSL_LOCAL
     void AddLateName(const char*, TimeoutInfo*);
     WOLFSSL_LOCAL

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1339,7 +1339,7 @@ WOLFSSL_API int wolfSSL_sk_push(WOLFSSL_STACK *st, const void *data);
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
 WOLFSSL_API int wolfSSL_sk_ACCESS_DESCRIPTION_push(
                                        WOLF_STACK_OF(ACCESS_DESCRIPTION)* sk,
-                                       WOLFSSL_ACCESS_DESCRIPTION* access);
+                                       WOLFSSL_ACCESS_DESCRIPTION* a);
 #endif /* defined(OPENSSL_ALL) || defined(WOLFSSL_QT) */
 
 typedef WOLF_STACK_OF(WOLFSSL_GENERAL_NAME) WOLFSSL_GENERAL_NAMES;
@@ -1401,7 +1401,7 @@ WOLFSSL_API WOLFSSL_ACCESS_DESCRIPTION* wolfSSL_sk_ACCESS_DESCRIPTION_value(
 WOLFSSL_API void wolfSSL_sk_ACCESS_DESCRIPTION_free(WOLFSSL_STACK* sk);
 WOLFSSL_API void wolfSSL_sk_ACCESS_DESCRIPTION_pop_free(WOLFSSL_STACK* sk,
         void (*f) (WOLFSSL_ACCESS_DESCRIPTION*));
-WOLFSSL_API void wolfSSL_ACCESS_DESCRIPTION_free(WOLFSSL_ACCESS_DESCRIPTION* access);
+WOLFSSL_API void wolfSSL_ACCESS_DESCRIPTION_free(WOLFSSL_ACCESS_DESCRIPTION* a);
 WOLFSSL_API void wolfSSL_sk_X509_EXTENSION_pop_free(
         WOLF_STACK_OF(WOLFSSL_X509_EXTENSION)* sk,
         void (*f) (WOLFSSL_X509_EXTENSION*));

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -530,7 +530,7 @@ WOLFSSL_API int wc_GetDateInfo(const byte* certDate, int certDateSz,
     const byte** date, byte* format, int* length);
 #ifndef NO_ASN_TIME
 WOLFSSL_API int wc_GetDateAsCalendarTime(const byte* date, int length,
-    byte format, struct tm* time);
+    byte format, struct tm* timearg);
 #endif
 
 #if defined(WOLFSSL_PEM_TO_DER) || defined(WOLFSSL_DER_TO_PEM)

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -621,10 +621,10 @@ int wc_ecc_sign_set_k(const byte* k, word32 klen, ecc_key* key);
 #ifdef HAVE_ECC_VERIFY
 WOLFSSL_API
 int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
-                    word32 hashlen, int* stat, ecc_key* key);
+                    word32 hashlen, int* res, ecc_key* key);
 WOLFSSL_API
 int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
-                          word32 hashlen, int* stat, ecc_key* key);
+                          word32 hashlen, int* res, ecc_key* key);
 #endif /* HAVE_ECC_VERIFY */
 
 WOLFSSL_API

--- a/wolfssl/wolfcrypt/ed25519.h
+++ b/wolfssl/wolfcrypt/ed25519.h
@@ -140,18 +140,18 @@ int wc_ed25519_sign_msg_ex(const byte* in, word32 inLen, byte* out,
 #ifdef HAVE_ED25519_VERIFY
 WOLFSSL_API
 int wc_ed25519_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
-                          word32 msgLen, int* stat, ed25519_key* key);
+                          word32 msgLen, int* res, ed25519_key* key);
 WOLFSSL_API
 int wc_ed25519ctx_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
-                             word32 msgLen, int* stat, ed25519_key* key,
+                             word32 msgLen, int* res, ed25519_key* key,
                              const byte* context, byte contextLen);
 WOLFSSL_API
 int wc_ed25519ph_verify_hash(const byte* sig, word32 sigLen, const byte* hash,
-                             word32 hashLen, int* stat, ed25519_key* key,
+                             word32 hashLen, int* res, ed25519_key* key,
                              const byte* context, byte contextLen);
 WOLFSSL_API
 int wc_ed25519ph_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
-                            word32 msgLen, int* stat, ed25519_key* key,
+                            word32 msgLen, int* res, ed25519_key* key,
                             const byte* context, byte contextLen);
 WOLFSSL_API
 int wc_ed25519_verify_msg_ex(const byte* sig, word32 sigLen, const byte* msg,

--- a/wolfssl/wolfcrypt/ed448.h
+++ b/wolfssl/wolfcrypt/ed448.h
@@ -137,19 +137,19 @@ int wc_ed448_verify_msg_update(const byte* msgSegment, word32 msgSegmentLen,
                              ed448_key* key);
 WOLFSSL_API
 int wc_ed448_verify_msg_final(const byte* sig, word32 sigLen,
-                              int* stat, ed448_key* key);
+                              int* res, ed448_key* key);
 #endif /* WOLFSSL_ED448_STREAMING_VERIFY */
 WOLFSSL_API
 int wc_ed448_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
-                        word32 msgLen, int* stat, ed448_key* key,
+                        word32 msgLen, int* res, ed448_key* key,
                         const byte* context, byte contextLen);
 WOLFSSL_API
 int wc_ed448ph_verify_hash(const byte* sig, word32 sigLen, const byte* hash,
-                           word32 hashLen, int* stat, ed448_key* key,
+                           word32 hashLen, int* res, ed448_key* key,
                            const byte* context, byte contextLen);
 WOLFSSL_API
 int wc_ed448ph_verify_msg(const byte* sig, word32 sigLen, const byte* msg,
-                          word32 msgLen, int* stat, ed448_key* key,
+                          word32 msgLen, int* res, ed448_key* key,
                           const byte* context, byte contextLen);
 #endif /* HAVE_ED448_VERIFY */
 WOLFSSL_API

--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -116,9 +116,9 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
     WOLFSSL_LOCAL int wc_LoggingCleanup(void);
     WOLFSSL_LOCAL int wc_AddErrorNode(int error, int line, char* buf,
             char* file);
-    WOLFSSL_LOCAL int wc_PeekErrorNode(int index, const char **file,
+    WOLFSSL_LOCAL int wc_PeekErrorNode(int idx, const char **file,
             const char **reason, int *line);
-    WOLFSSL_LOCAL void wc_RemoveErrorNode(int index);
+    WOLFSSL_LOCAL void wc_RemoveErrorNode(int idx);
     WOLFSSL_LOCAL void wc_ClearErrorNodes(void);
     WOLFSSL_LOCAL int wc_PullErrorNode(const char **file, const char **reason,
                             int *line);


### PR DESCRIPTION
When building the library for someone using GCC v4.0.2 for the PowerPC, the build was throwing a lot of warnings. Most were due to local variables shadowing some global label. A couple pragmas were removed and the reason for them fixed.