### PR TITLE
Remove unnecessary FIPS guards in CMAC code.

### DIFF
--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -57,12 +57,7 @@
 #endif
 
 
-#ifdef HAVE_FIPS
-static void ShiftAndXorRb(byte* out, byte* in)
-#else
-/* Used by AES-SIV. See aes.c. */
 void ShiftAndXorRb(byte* out, byte* in)
-#endif
 {
     int i, j, xorRb;
     int mask = 0, last = 0;

--- a/wolfssl/wolfcrypt/cmac.h
+++ b/wolfssl/wolfcrypt/cmac.h
@@ -103,10 +103,8 @@ int wc_AesCmacVerify(const byte* check, word32 checkSz,
                      const byte* in, word32 inSz,
                      const byte* key, word32 keySz);
 
-#ifndef HAVE_FIPS
 WOLFSSL_LOCAL
 void ShiftAndXorRb(byte* out, byte* in);
-#endif
 
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
Thanks to @douzzer for pointing out that these guards aren't needed.