### PR TITLE
ParseCert: check index in DecodeSubtree before accessing tag

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -15968,6 +15968,12 @@ static int DecodeSubtree(const byte* input, int sz, Base_entry** head,
             WOLFSSL_MSG("\tfail: should be a SEQUENCE");
             return ASN_PARSE_E;
         }
+
+        if (idx >= (word32)sz) {
+            WOLFSSL_MSG("\tfail: expecting tag");
+            return ASN_PARSE_E;
+        }
+
         nameIdx = idx;
         b = input[nameIdx++];
 


### PR DESCRIPTION
# Description

Fuzz testing showed that DecodeSubtree() wasn't checking index before reading tag under sequence.

Fixes zd#13554

# Testing

POC from ZD no longer has error.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
