### PR TITLE
Allow SHA1 with NO_OLD_TLS

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -2124,7 +2124,7 @@ enum KeyStuff {
 
 };
 
-#ifndef NO_OLD_TLS
+#if !defined(NO_OLD_TLS) || defined(WOLFSSL_ALLOW_TLS_SHA1)
 /* true or false, zero for error */
 static int SetPrefix(byte* sha_input, int idx)
 {
@@ -3251,7 +3251,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
     return 0;
 }
 
-#ifndef NO_OLD_TLS
+#if !defined(NO_OLD_TLS) || defined(WOLFSSL_ALLOW_TLS_SHA1)
 int DeriveKeys(WOLFSSL* ssl)
 {
     int    length = 2 * ssl->specs.hash_size +
@@ -3507,14 +3507,14 @@ static int MakeSslMasterSecret(WOLFSSL* ssl)
 
     return ret;
 }
-#endif
+#endif /* #if !NO_OLD_TLS || WOLFSSL_ALLOW_TLS_SHA1 */
 
 
 /* Master wrapper, doesn't use SSL stack space in TLS mode */
 int MakeMasterSecret(WOLFSSL* ssl)
 {
     /* append secret to premaster : premaster | SerSi | CliSi */
-#ifndef NO_OLD_TLS
+#if !defined(NO_OLD_TLS) || defined(WOLFSSL_ALLOW_TLS_SHA1)
     if (ssl->options.tls) return MakeTlsMasterSecret(ssl);
     return MakeSslMasterSecret(ssl);
 #elif !defined(WOLFSSL_NO_TLS12) && !defined(NO_TLS)

--- a/src/tls.c
+++ b/src/tls.c
@@ -148,6 +148,8 @@ int BuildTlsHandshakeHash(WOLFSSL* ssl, byte* hash, word32* hashLen)
     /* for constant timing perform these even if error */
 #ifndef NO_OLD_TLS
     ret |= wc_Md5GetHash(&ssl->hsHashes->hashMd5, hash);
+#endif
+#if !defined(NO_OLD_TLS) || defined(WOLFSSL_ALLOW_TLS_SHA1)
     ret |= wc_ShaGetHash(&ssl->hsHashes->hashSha, &hash[WC_MD5_DIGEST_SIZE]);
 #endif
 


### PR DESCRIPTION
# Description

Add conditional for `WOLFSSL_ALLOW_TLS_SHA1` with `!NO_OLD_TLS`

Fixes #4791 

# Testing

Built with `./configure --disable-oldtls -- CFLAGS="-DWOLFSSL_ALLOW_TLS_SHA1"`