### PR TITLE
SP C: multiplication of two signed types with overflow is undefined in C

### DIFF
--- a/wolfcrypt/src/sp_c32.c
+++ b/wolfcrypt/src/sp_c32.c
@@ -1724,11 +1724,11 @@ static void sp_2048_mont_reduce_36(sp_digit* a, const sp_digit* m, sp_digit mp)
     sp_2048_norm_36(a + 36);
 
     for (i=0; i<35; i++) {
-        mu = (a[i] * mp) & 0x1fffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1fffffff;
         sp_2048_mul_add_36(a+i, m, mu);
         a[i+1] += a[i] >> 29;
     }
-    mu = (a[i] * mp) & 0x1ffL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1ffL;
     sp_2048_mul_add_36(a+i, m, mu);
     a[i+1] += a[i] >> 29;
     a[i] &= 0x1fffffff;
@@ -2782,11 +2782,11 @@ static void sp_2048_mont_reduce_72(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<70; i++) {
-            mu = (a[i] * mp) & 0x1fffffff;
+            mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1fffffff;
             sp_2048_mul_add_72(a+i, m, mu);
             a[i+1] += a[i] >> 29;
         }
-        mu = (a[i] * mp) & 0x3ffffL;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x3ffffL;
         sp_2048_mul_add_72(a+i, m, mu);
         a[i+1] += a[i] >> 29;
         a[i] &= 0x1fffffff;
@@ -2804,11 +2804,11 @@ static void sp_2048_mont_reduce_72(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<70; i++) {
-        mu = (a[i] * mp) & 0x1fffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1fffffff;
         sp_2048_mul_add_72(a+i, m, mu);
         a[i+1] += a[i] >> 29;
     }
-    mu = (a[i] * mp) & 0x3ffffL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x3ffffL;
     sp_2048_mul_add_72(a+i, m, mu);
     a[i+1] += a[i] >> 29;
     a[i] &= 0x1fffffff;
@@ -5451,11 +5451,11 @@ static void sp_3072_mont_reduce_53(sp_digit* a, const sp_digit* m, sp_digit mp)
     sp_3072_norm_53(a + 53);
 
     for (i=0; i<52; i++) {
-        mu = (a[i] * mp) & 0x1fffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1fffffff;
         sp_3072_mul_add_53(a+i, m, mu);
         a[i+1] += a[i] >> 29;
     }
-    mu = (a[i] * mp) & 0xfffffffL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0xfffffffL;
     sp_3072_mul_add_53(a+i, m, mu);
     a[i+1] += a[i] >> 29;
     a[i] &= 0x1fffffff;
@@ -6450,11 +6450,11 @@ static void sp_3072_mont_reduce_106(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<105; i++) {
-            mu = (a[i] * mp) & 0x1fffffff;
+            mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1fffffff;
             sp_3072_mul_add_106(a+i, m, mu);
             a[i+1] += a[i] >> 29;
         }
-        mu = (a[i] * mp) & 0x7ffffffL;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x7ffffffL;
         sp_3072_mul_add_106(a+i, m, mu);
         a[i+1] += a[i] >> 29;
         a[i] &= 0x1fffffff;
@@ -6472,11 +6472,11 @@ static void sp_3072_mont_reduce_106(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<105; i++) {
-        mu = (a[i] * mp) & 0x1fffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1fffffff;
         sp_3072_mul_add_106(a+i, m, mu);
         a[i+1] += a[i] >> 29;
     }
-    mu = (a[i] * mp) & 0x7ffffffL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x7ffffffL;
     sp_3072_mul_add_106(a+i, m, mu);
     a[i+1] += a[i] >> 29;
     a[i] &= 0x1fffffff;
@@ -9691,11 +9691,11 @@ static void sp_3072_mont_reduce_56(sp_digit* a, const sp_digit* m, sp_digit mp)
     sp_3072_norm_56(a + 55);
 
     for (i=0; i<54; i++) {
-        mu = (a[i] * mp) & 0xfffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0xfffffff;
         sp_3072_mul_add_56(a+i, m, mu);
         a[i+1] += a[i] >> 28;
     }
-    mu = (a[i] * mp) & 0xffffffL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0xffffffL;
     sp_3072_mul_add_56(a+i, m, mu);
     a[i+1] += a[i] >> 28;
     a[i] &= 0xfffffff;
@@ -10617,11 +10617,11 @@ static void sp_3072_mont_reduce_112(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<109; i++) {
-            mu = (a[i] * mp) & 0xfffffff;
+            mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0xfffffff;
             sp_3072_mul_add_112(a+i, m, mu);
             a[i+1] += a[i] >> 28;
         }
-        mu = (a[i] * mp) & 0xfffffL;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0xfffffL;
         sp_3072_mul_add_112(a+i, m, mu);
         a[i+1] += a[i] >> 28;
         a[i] &= 0xfffffff;
@@ -10639,11 +10639,11 @@ static void sp_3072_mont_reduce_112(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<109; i++) {
-        mu = (a[i] * mp) & 0xfffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0xfffffff;
         sp_3072_mul_add_112(a+i, m, mu);
         a[i+1] += a[i] >> 28;
     }
-    mu = (a[i] * mp) & 0xfffffL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0xfffffL;
     sp_3072_mul_add_112(a+i, m, mu);
     a[i+1] += a[i] >> 28;
     a[i] &= 0xfffffff;
@@ -13267,11 +13267,11 @@ static void sp_4096_mont_reduce_71(sp_digit* a, const sp_digit* m, sp_digit mp)
     sp_4096_norm_71(a + 71);
 
     for (i=0; i<70; i++) {
-        mu = (a[i] * mp) & 0x1fffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1fffffff;
         sp_4096_mul_add_71(a+i, m, mu);
         a[i+1] += a[i] >> 29;
     }
-    mu = (a[i] * mp) & 0x3ffffL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x3ffffL;
     sp_4096_mul_add_71(a+i, m, mu);
     a[i+1] += a[i] >> 29;
     a[i] &= 0x1fffffff;
@@ -14267,11 +14267,11 @@ static void sp_4096_mont_reduce_142(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<141; i++) {
-            mu = (a[i] * mp) & 0x1fffffff;
+            mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1fffffff;
             sp_4096_mul_add_142(a+i, m, mu);
             a[i+1] += a[i] >> 29;
         }
-        mu = (a[i] * mp) & 0x7fL;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x7fL;
         sp_4096_mul_add_142(a+i, m, mu);
         a[i+1] += a[i] >> 29;
         a[i] &= 0x1fffffff;
@@ -14289,11 +14289,11 @@ static void sp_4096_mont_reduce_142(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<141; i++) {
-        mu = (a[i] * mp) & 0x1fffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1fffffff;
         sp_4096_mul_add_142(a+i, m, mu);
         a[i+1] += a[i] >> 29;
     }
-    mu = (a[i] * mp) & 0x7fL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x7fL;
     sp_4096_mul_add_142(a+i, m, mu);
     a[i+1] += a[i] >> 29;
     a[i] &= 0x1fffffff;
@@ -17390,11 +17390,11 @@ static void sp_4096_mont_reduce_81(sp_digit* a, const sp_digit* m, sp_digit mp)
     sp_4096_norm_81(a + 79);
 
     for (i=0; i<78; i++) {
-        mu = (a[i] * mp) & 0x3ffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x3ffffff;
         sp_4096_mul_add_81(a+i, m, mu);
         a[i+1] += a[i] >> 26;
     }
-    mu = (a[i] * mp) & 0xfffffL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0xfffffL;
     sp_4096_mul_add_81(a+i, m, mu);
     a[i+1] += a[i] >> 26;
     a[i] &= 0x3ffffff;
@@ -18278,11 +18278,11 @@ static void sp_4096_mont_reduce_162(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<157; i++) {
-            mu = (a[i] * mp) & 0x3ffffff;
+            mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x3ffffff;
             sp_4096_mul_add_162(a+i, m, mu);
             a[i+1] += a[i] >> 26;
         }
-        mu = (a[i] * mp) & 0x3fffL;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x3fffL;
         sp_4096_mul_add_162(a+i, m, mu);
         a[i+1] += a[i] >> 26;
         a[i] &= 0x3ffffff;
@@ -18300,11 +18300,11 @@ static void sp_4096_mont_reduce_162(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<157; i++) {
-        mu = (a[i] * mp) & 0x3ffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x3ffffff;
         sp_4096_mul_add_162(a+i, m, mu);
         a[i+1] += a[i] >> 26;
     }
-    mu = (a[i] * mp) & 0x3fffL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x3fffL;
     sp_4096_mul_add_162(a+i, m, mu);
     a[i+1] += a[i] >> 26;
     a[i] &= 0x3ffffff;
@@ -21175,11 +21175,11 @@ static void sp_256_mont_reduce_order_9(sp_digit* a, const sp_digit* m, sp_digit 
     sp_256_norm_9(a + 9);
 
     for (i=0; i<8; i++) {
-        mu = (a[i] * mp) & 0x1fffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1fffffff;
         sp_256_mul_add_9(a+i, m, mu);
         a[i+1] += a[i] >> 29;
     }
-    mu = (a[i] * mp) & 0xffffffL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0xffffffL;
     sp_256_mul_add_9(a+i, m, mu);
     a[i+1] += a[i] >> 29;
     a[i] &= 0x1fffffff;
@@ -28373,11 +28373,11 @@ static void sp_384_mont_reduce_order_15(sp_digit* a, const sp_digit* m, sp_digit
     sp_384_norm_15(a + 15);
 
     for (i=0; i<14; i++) {
-        mu = (a[i] * mp) & 0x3ffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x3ffffff;
         sp_384_mul_add_15(a+i, m, mu);
         a[i+1] += a[i] >> 26;
     }
-    mu = (a[i] * mp) & 0xfffffL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0xfffffL;
     sp_384_mul_add_15(a+i, m, mu);
     a[i+1] += a[i] >> 26;
     a[i] &= 0x3ffffff;
@@ -36669,11 +36669,11 @@ static void sp_1024_mont_reduce_42(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<40; i++) {
-            mu = (a[i] * mp) & 0x1ffffff;
+            mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1ffffff;
             sp_1024_mul_add_42(a+i, m, mu);
             a[i+1] += a[i] >> 25;
         }
-        mu = (a[i] * mp) & 0xffffffL;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0xffffffL;
         sp_1024_mul_add_42(a+i, m, mu);
         a[i+1] += a[i] >> 25;
         a[i] &= 0x1ffffff;
@@ -36691,11 +36691,11 @@ static void sp_1024_mont_reduce_42(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<40; i++) {
-        mu = (a[i] * mp) & 0x1ffffff;
+        mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0x1ffffff;
         sp_1024_mul_add_42(a+i, m, mu);
         a[i+1] += a[i] >> 25;
     }
-    mu = (a[i] * mp) & 0xffffffL;
+    mu = ((sp_uint32)a[i] * (sp_uint32)mp) & 0xffffffL;
     sp_1024_mul_add_42(a+i, m, mu);
     a[i+1] += a[i] >> 25;
     a[i] &= 0x1ffffff;

--- a/wolfcrypt/src/sp_c64.c
+++ b/wolfcrypt/src/sp_c64.c
@@ -586,11 +586,11 @@ static void sp_2048_mont_reduce_17(sp_digit* a, const sp_digit* m, sp_digit mp)
     sp_2048_norm_17(a + 17);
 
     for (i=0; i<16; i++) {
-        mu = (a[i] * mp) & 0x1fffffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1fffffffffffffffL;
         sp_2048_mul_add_17(a+i, m, mu);
         a[i+1] += a[i] >> 61;
     }
-    mu = (a[i] * mp) & 0xffffffffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0xffffffffffffL;
     sp_2048_mul_add_17(a+i, m, mu);
     a[i+1] += a[i] >> 61;
     a[i] &= 0x1fffffffffffffffL;
@@ -1699,11 +1699,11 @@ static void sp_2048_mont_reduce_34(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<33; i++) {
-            mu = (a[i] * mp) & 0x1fffffffffffffffL;
+            mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1fffffffffffffffL;
             sp_2048_mul_add_34(a+i, m, mu);
             a[i+1] += a[i] >> 61;
         }
-        mu = (a[i] * mp) & 0x7ffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7ffffffffL;
         sp_2048_mul_add_34(a+i, m, mu);
         a[i+1] += a[i] >> 61;
         a[i] &= 0x1fffffffffffffffL;
@@ -1721,11 +1721,11 @@ static void sp_2048_mont_reduce_34(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<33; i++) {
-        mu = (a[i] * mp) & 0x1fffffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1fffffffffffffffL;
         sp_2048_mul_add_34(a+i, m, mu);
         a[i+1] += a[i] >> 61;
     }
-    mu = (a[i] * mp) & 0x7ffffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7ffffffffL;
     sp_2048_mul_add_34(a+i, m, mu);
     a[i+1] += a[i] >> 61;
     a[i] &= 0x1fffffffffffffffL;
@@ -4581,11 +4581,11 @@ static void sp_2048_mont_reduce_18(sp_digit* a, const sp_digit* m, sp_digit mp)
     sp_2048_norm_18(a + 18);
 
     for (i=0; i<17; i++) {
-        mu = (a[i] * mp) & 0x1ffffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1ffffffffffffffL;
         sp_2048_mul_add_18(a+i, m, mu);
         a[i+1] += a[i] >> 57;
     }
-    mu = (a[i] * mp) & 0x7fffffffffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7fffffffffffffL;
     sp_2048_mul_add_18(a+i, m, mu);
     a[i+1] += a[i] >> 57;
     a[i] &= 0x1ffffffffffffffL;
@@ -5470,11 +5470,11 @@ static void sp_2048_mont_reduce_36(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<35; i++) {
-            mu = (a[i] * mp) & 0x1ffffffffffffffL;
+            mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1ffffffffffffffL;
             sp_2048_mul_add_36(a+i, m, mu);
             a[i+1] += a[i] >> 57;
         }
-        mu = (a[i] * mp) & 0x1fffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1fffffffffffffL;
         sp_2048_mul_add_36(a+i, m, mu);
         a[i+1] += a[i] >> 57;
         a[i] &= 0x1ffffffffffffffL;
@@ -5492,11 +5492,11 @@ static void sp_2048_mont_reduce_36(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<35; i++) {
-        mu = (a[i] * mp) & 0x1ffffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1ffffffffffffffL;
         sp_2048_mul_add_36(a+i, m, mu);
         a[i+1] += a[i] >> 57;
     }
-    mu = (a[i] * mp) & 0x1fffffffffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1fffffffffffffL;
     sp_2048_mul_add_36(a+i, m, mu);
     a[i+1] += a[i] >> 57;
     a[i] &= 0x1ffffffffffffffL;
@@ -7904,11 +7904,11 @@ static void sp_3072_mont_reduce_26(sp_digit* a, const sp_digit* m, sp_digit mp)
     sp_3072_norm_26(a + 26);
 
     for (i=0; i<25; i++) {
-        mu = (a[i] * mp) & 0xfffffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0xfffffffffffffffL;
         sp_3072_mul_add_26(a+i, m, mu);
         a[i+1] += a[i] >> 60;
     }
-    mu = (a[i] * mp) & 0xfffffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0xfffffffffL;
     sp_3072_mul_add_26(a+i, m, mu);
     a[i+1] += a[i] >> 60;
     a[i] &= 0xfffffffffffffffL;
@@ -8896,11 +8896,11 @@ static void sp_3072_mont_reduce_52(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<51; i++) {
-            mu = (a[i] * mp) & 0xfffffffffffffffL;
+            mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0xfffffffffffffffL;
             sp_3072_mul_add_52(a+i, m, mu);
             a[i+1] += a[i] >> 60;
         }
-        mu = (a[i] * mp) & 0xfffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0xfffL;
         sp_3072_mul_add_52(a+i, m, mu);
         a[i+1] += a[i] >> 60;
         a[i] &= 0xfffffffffffffffL;
@@ -8918,11 +8918,11 @@ static void sp_3072_mont_reduce_52(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<51; i++) {
-        mu = (a[i] * mp) & 0xfffffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0xfffffffffffffffL;
         sp_3072_mul_add_52(a+i, m, mu);
         a[i+1] += a[i] >> 60;
     }
-    mu = (a[i] * mp) & 0xfffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0xfffL;
     sp_3072_mul_add_52(a+i, m, mu);
     a[i+1] += a[i] >> 60;
     a[i] &= 0xfffffffffffffffL;
@@ -11823,11 +11823,11 @@ static void sp_3072_mont_reduce_27(sp_digit* a, const sp_digit* m, sp_digit mp)
     sp_3072_norm_27(a + 27);
 
     for (i=0; i<26; i++) {
-        mu = (a[i] * mp) & 0x1ffffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1ffffffffffffffL;
         sp_3072_mul_add_27(a+i, m, mu);
         a[i+1] += a[i] >> 57;
     }
-    mu = (a[i] * mp) & 0x3fffffffffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x3fffffffffffffL;
     sp_3072_mul_add_27(a+i, m, mu);
     a[i+1] += a[i] >> 57;
     a[i] &= 0x1ffffffffffffffL;
@@ -12724,11 +12724,11 @@ static void sp_3072_mont_reduce_54(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<53; i++) {
-            mu = (a[i] * mp) & 0x1ffffffffffffffL;
+            mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1ffffffffffffffL;
             sp_3072_mul_add_54(a+i, m, mu);
             a[i+1] += a[i] >> 57;
         }
-        mu = (a[i] * mp) & 0x7ffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7ffffffffffffL;
         sp_3072_mul_add_54(a+i, m, mu);
         a[i+1] += a[i] >> 57;
         a[i] &= 0x1ffffffffffffffL;
@@ -12746,11 +12746,11 @@ static void sp_3072_mont_reduce_54(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<53; i++) {
-        mu = (a[i] * mp) & 0x1ffffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1ffffffffffffffL;
         sp_3072_mul_add_54(a+i, m, mu);
         a[i+1] += a[i] >> 57;
     }
-    mu = (a[i] * mp) & 0x7ffffffffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7ffffffffffffL;
     sp_3072_mul_add_54(a+i, m, mu);
     a[i+1] += a[i] >> 57;
     a[i] &= 0x1ffffffffffffffL;
@@ -15204,11 +15204,11 @@ static void sp_4096_mont_reduce_35(sp_digit* a, const sp_digit* m, sp_digit mp)
     sp_4096_norm_35(a + 35);
 
     for (i=0; i<34; i++) {
-        mu = (a[i] * mp) & 0x7ffffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7ffffffffffffffL;
         sp_4096_mul_add_35(a+i, m, mu);
         a[i+1] += a[i] >> 59;
     }
-    mu = (a[i] * mp) & 0x3ffffffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x3ffffffffffL;
     sp_4096_mul_add_35(a+i, m, mu);
     a[i+1] += a[i] >> 59;
     a[i] &= 0x7ffffffffffffffL;
@@ -16151,11 +16151,11 @@ static void sp_4096_mont_reduce_70(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<69; i++) {
-            mu = (a[i] * mp) & 0x7ffffffffffffffL;
+            mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7ffffffffffffffL;
             sp_4096_mul_add_70(a+i, m, mu);
             a[i+1] += a[i] >> 59;
         }
-        mu = (a[i] * mp) & 0x1ffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1ffffffL;
         sp_4096_mul_add_70(a+i, m, mu);
         a[i+1] += a[i] >> 59;
         a[i] &= 0x7ffffffffffffffL;
@@ -16173,11 +16173,11 @@ static void sp_4096_mont_reduce_70(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<69; i++) {
-        mu = (a[i] * mp) & 0x7ffffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7ffffffffffffffL;
         sp_4096_mul_add_70(a+i, m, mu);
         a[i+1] += a[i] >> 59;
     }
-    mu = (a[i] * mp) & 0x1ffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1ffffffL;
     sp_4096_mul_add_70(a+i, m, mu);
     a[i+1] += a[i] >> 59;
     a[i] &= 0x7ffffffffffffffL;
@@ -19085,11 +19085,11 @@ static void sp_4096_mont_reduce_39(sp_digit* a, const sp_digit* m, sp_digit mp)
     sp_4096_norm_39(a + 39);
 
     for (i=0; i<38; i++) {
-        mu = (a[i] * mp) & 0x1fffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1fffffffffffffL;
         sp_4096_mul_add_39(a+i, m, mu);
         a[i+1] += a[i] >> 53;
     }
-    mu = (a[i] * mp) & 0x3ffffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x3ffffffffL;
     sp_4096_mul_add_39(a+i, m, mu);
     a[i+1] += a[i] >> 53;
     a[i] &= 0x1fffffffffffffL;
@@ -19963,11 +19963,11 @@ static void sp_4096_mont_reduce_78(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<77; i++) {
-            mu = (a[i] * mp) & 0x1fffffffffffffL;
+            mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1fffffffffffffL;
             sp_4096_mul_add_78(a+i, m, mu);
             a[i+1] += a[i] >> 53;
         }
-        mu = (a[i] * mp) & 0x7fffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7fffL;
         sp_4096_mul_add_78(a+i, m, mu);
         a[i+1] += a[i] >> 53;
         a[i] &= 0x1fffffffffffffL;
@@ -19985,11 +19985,11 @@ static void sp_4096_mont_reduce_78(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<77; i++) {
-        mu = (a[i] * mp) & 0x1fffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1fffffffffffffL;
         sp_4096_mul_add_78(a+i, m, mu);
         a[i+1] += a[i] >> 53;
     }
-    mu = (a[i] * mp) & 0x7fffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7fffL;
     sp_4096_mul_add_78(a+i, m, mu);
     a[i+1] += a[i] >> 53;
     a[i] &= 0x1fffffffffffffL;
@@ -22533,11 +22533,11 @@ static void sp_256_mont_reduce_order_5(sp_digit* a, const sp_digit* m, sp_digit 
     sp_256_norm_5(a + 5);
 
     for (i=0; i<4; i++) {
-        mu = (a[i] * mp) & 0xfffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0xfffffffffffffL;
         sp_256_mul_add_5(a+i, m, mu);
         a[i+1] += a[i] >> 52;
     }
-    mu = (a[i] * mp) & 0xffffffffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0xffffffffffffL;
     sp_256_mul_add_5(a+i, m, mu);
     a[i+1] += a[i] >> 52;
     a[i] &= 0xfffffffffffffL;
@@ -29252,11 +29252,11 @@ static void sp_384_mont_reduce_order_7(sp_digit* a, const sp_digit* m, sp_digit 
     sp_384_norm_7(a + 7);
 
     for (i=0; i<6; i++) {
-        mu = (a[i] * mp) & 0x7fffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7fffffffffffffL;
         sp_384_mul_add_7(a+i, m, mu);
         a[i+1] += a[i] >> 55;
     }
-    mu = (a[i] * mp) & 0x3fffffffffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x3fffffffffffffL;
     sp_384_mul_add_7(a+i, m, mu);
     a[i+1] += a[i] >> 55;
     a[i] &= 0x7fffffffffffffL;
@@ -37196,11 +37196,11 @@ static void sp_1024_mont_reduce_18(sp_digit* a, const sp_digit* m, sp_digit mp)
 #ifdef WOLFSSL_SP_DH
     if (mp != 1) {
         for (i=0; i<17; i++) {
-            mu = (a[i] * mp) & 0x1ffffffffffffffL;
+            mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1ffffffffffffffL;
             sp_1024_mul_add_18(a+i, m, mu);
             a[i+1] += a[i] >> 57;
         }
-        mu = (a[i] * mp) & 0x7fffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7fffffffffffffL;
         sp_1024_mul_add_18(a+i, m, mu);
         a[i+1] += a[i] >> 57;
         a[i] &= 0x1ffffffffffffffL;
@@ -37218,11 +37218,11 @@ static void sp_1024_mont_reduce_18(sp_digit* a, const sp_digit* m, sp_digit mp)
     }
 #else
     for (i=0; i<17; i++) {
-        mu = (a[i] * mp) & 0x1ffffffffffffffL;
+        mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x1ffffffffffffffL;
         sp_1024_mul_add_18(a+i, m, mu);
         a[i+1] += a[i] >> 57;
     }
-    mu = (a[i] * mp) & 0x7fffffffffffffL;
+    mu = ((sp_uint64)a[i] * (sp_uint64)mp) & 0x7fffffffffffffL;
     sp_1024_mul_add_18(a+i, m, mu);
     a[i+1] += a[i] >> 57;
     a[i] &= 0x1ffffffffffffffL;


### PR DESCRIPTION
# Description

Montgomery Reduction: cast variables to be unsigned where signed
multiplication with overflow is performed.

Fixes issue: #4786

# Testing

Tested SP C code 64/32 on Linux.
