### PR TITLE
cert subset improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,8 +183,35 @@ then
     AM_CFLAGS="$AM_CFLAGS -DWC_16BIT_CPU"
 fi
 
+AC_ARG_ENABLE([64bit],
+    [AS_HELP_STRING([--enable-64bit],[Enables 64-bit support (default: enabled)])],
+    [ ENABLED_64BIT=$enableval ],
+    [ ENABLED_64BIT=yes ]
+    )
 
+AC_ARG_ENABLE([kdf],
+    [AS_HELP_STRING([--enable-kdf],[Enables kdf support (default: enabled)])],
+    [ ENABLED_KDF=$enableval ],
+    [ ENABLED_KDF=yes ]
+    )
 
+AC_ARG_ENABLE([hmac],
+    [AS_HELP_STRING([--enable-hmac],[Enables HMAC support (default: enabled)])],
+    [ ENABLED_HMAC=$enableval ],
+    [ ENABLED_HMAC=yes ]
+    )
+
+AC_ARG_ENABLE([do178],
+    [AS_HELP_STRING([--enable-do178],[Enable DO-178, Will NOT work w/o DO178 license (default: disabled)])],
+    [ENABLED_DO178=$enableval],
+    [ENABLED_DO178="no"])
+
+if test "$ENABLED_DO178" = "no"
+then
+    AM_CFLAGS="$AM_CFLAGS -DNO_DO178"
+else
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_DO178"
+fi
 # Support for disabling all ASM
 AC_ARG_ENABLE([asm],
     [AS_HELP_STRING([--enable-asm],[Enables option for assembly (default: enabled)])],
@@ -2746,7 +2773,7 @@ fi
 
 # ERROR QUEUE
 AC_ARG_ENABLE([errorqueue],
-    [AS_HELP_STRING([--disable-errorqueue],[Disables adding nodes to error queue when compiled with OPENSSL_EXTRA (default: enabled)])],
+    [AS_HELP_STRING([--enable-errorqueue],[Disables adding nodes to error queue when compiled with OPENSSL_EXTRA (default: enabled)])],
     [ ENABLED_ERROR_QUEUE=$enableval ],
     [ ENABLED_ERROR_QUEUE=yes ]
     )
@@ -6436,10 +6463,7 @@ AC_ARG_ENABLE([staticmemory],
 if test "x$ENABLED_STATICMEMORY" = "xyes"
 then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_STATIC_MEMORY"
-    if test "x$ENABLED_FASTMATH" = "xno"
-    then
-        AC_MSG_ERROR([please use --enable-fastmath if enabling staticmemory.])
-    fi
+
     if test "$ENABLED_LOWRESOURCE" = "yes" && test "$ENABLED_RSA" = "no"
     then
         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_STATIC_MEMORY_SMALL"
@@ -7486,9 +7510,12 @@ AM_CONDITIONAL([BUILD_OCTEON_SYNC],[test "x$ENABLED_OCTEON_SYNC" = "xyes"])
 AM_CONDITIONAL([BUILD_INTEL_QA],[test "x$ENABLED_INTEL_QA" = "xyes"])
 AM_CONDITIONAL([BUILD_INTEL_QA_SYNC],[test "x$ENABLED_INTEL_QA_SYNC" = "xyes"])
 AM_CONDITIONAL([BUILD_SP],[test "x$ENABLED_SP" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
-AM_CONDITIONAL([BUILD_SP_C],[((test "$ENABLED_SP_RSA" = "yes" || test "$ENABLED_SP_DH" = "yes" \
+AM_CONDITIONAL([BUILD_SP_C32],[(((test "$ENABLED_SP_RSA" = "yes" || test "$ENABLED_SP_DH" = "yes" \
                                || test "$ENABLED_SP_ECC" = "yes") && test "x$ENABLED_SP_ASM" = "xno") \
-                             || test "x$ENABLED_USERSETTINGS" = "xyes"])
+                             || test "x$ENABLED_USERSETTINGS" = "xyes") && test "x$ENABLED_32BIT" = "xyes"])
+AM_CONDITIONAL([BUILD_SP_C64],[(((test "$ENABLED_SP_RSA" = "yes" || test "$ENABLED_SP_DH" = "yes" \
+                               || test "$ENABLED_SP_ECC" = "yes") && test "x$ENABLED_SP_ASM" = "xno") \
+                             || test "x$ENABLED_USERSETTINGS" = "xyes") && test "x$ENABLED_64BIT" = "xyes"])
 AM_CONDITIONAL([BUILD_SP_ARM64],[test "x$ENABLED_SP_ARM64_ASM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_SP_ARM32],[test "x$ENABLED_SP_ARM32_ASM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_SP_ARM_THUMB],[test "x$ENABLED_SP_ARM_THUMB_ASM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
@@ -7516,6 +7543,10 @@ AM_CONDITIONAL([BUILD_QNXCAAM],[test "x$ENABLED_CAAM" = "xqnx"])
 AM_CONDITIONAL([BUILD_IOTSAFE],[test "x$ENABLED_IOTSAFE" = "xyes"])
 AM_CONDITIONAL([BUILD_IOTSAFE_HWRNG],[test "x$ENABLED_IOTSAFE_HWRNG" = "xyes"])
 AM_CONDITIONAL([BUILD_SE050],[test "x$ENABLED_SE050" = "xyes"])
+AM_CONDITIONAL([BUILD_KDF],[test "x$ENABLED_KDF" = "xyes"])
+AM_CONDITIONAL([BUILD_HMAC],[test "x$ENABLED_HMAC" = "xyes"])
+AM_CONDITIONAL([BUILD_ERROR_STRINGS],[test "x$ENABLED_ERROR_STRINGS" = "xyes"])
+AM_CONDITIONAL([BUILD_DO178],[test "x$ENABLED_DO178" = "xyes"])
 
 if test "$ENABLED_REPRODUCIBLE_BUILD" != "yes" &&
    (test "$ax_enable_debug" = "yes" ||
@@ -7596,7 +7627,7 @@ rm -f $OPTION_FILE
 echo "/* wolfssl options.h" > $OPTION_FILE
 echo " * generated from configure options" >> $OPTION_FILE
 echo " *" >> $OPTION_FILE
-echo " * Copyright (C) 2006-2020 wolfSSL Inc." >> $OPTION_FILE
+echo " * Copyright (C) 2006-2022 wolfSSL Inc." >> $OPTION_FILE
 echo " *" >> $OPTION_FILE
 echo " * This file is part of wolfSSL. (formerly known as CyaSSL)" >> $OPTION_FILE
 echo " *" >> $OPTION_FILE

--- a/src/include.am
+++ b/src/include.am
@@ -330,7 +330,9 @@ if !BUILD_FIPS_RAND
 # For old FIPS, keep the wolfCrypt versions of the
 # CtaoCrypt files included above.
 if !BUILD_FIPS_CURRENT
+if BUILD_HMAC
 src_libwolfssl_la_SOURCES += wolfcrypt/src/hmac.c
+endif
 endif !BUILD_FIPS_CURRENT
 
 # CAVP self test
@@ -340,14 +342,18 @@ endif
 
 endif !BUILD_FIPS_RAND
 
-src_libwolfssl_la_SOURCES += \
-               wolfcrypt/src/hash.c \
-               wolfcrypt/src/cpuid.c
+src_libwolfssl_la_SOURCES += wolfcrypt/src/hash.c
+
+if !BUILD_DO178
+src_libwolfssl_la_SOURCES += wolfcrypt/src/cpuid.c
+endif !BUILD_DO178
 
 if !BUILD_FIPS_RAND
 
 if !BUILD_FIPS_V5
+if BUILD_KDF
 src_libwolfssl_la_SOURCES += wolfcrypt/src/kdf.c
+endif
 endif !BUILD_FIPS_V5
 
 if !BUILD_FIPS_CURRENT
@@ -405,10 +411,13 @@ src_libwolfssl_la_SOURCES += wolfcrypt/src/rc2.c
 endif
 
 if BUILD_SP
-if BUILD_SP_C
+if BUILD_SP_C32
 src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_c32.c
+endif
+if BUILD_SP_C64
 src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_c64.c
-endif BUILD_SP_C
+endif
+
 if BUILD_SP_X86_64
 src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_x86_64.c
 src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_x86_64_asm.S
@@ -493,14 +502,19 @@ endif
 
 src_libwolfssl_la_SOURCES += \
                wolfcrypt/src/logging.c \
-               wolfcrypt/src/wc_port.c \
-               wolfcrypt/src/error.c
+               wolfcrypt/src/wc_port.c
+
+if BUILD_ERROR_STRINGS
+src_libwolfssl_la_SOURCES += wolfcrypt/src/error.c
+endif
 
 if !BUILD_FIPS_RAND
+if !BUILD_DO178
 src_libwolfssl_la_SOURCES += \
                wolfcrypt/src/wc_encrypt.c \
-               wolfcrypt/src/signature.c \
-               wolfcrypt/src/wolfmath.c
+               wolfcrypt/src/signature.c
+endif !BUILD_DO178
+src_libwolfssl_la_SOURCES += wolfcrypt/src/wolfmath.c
 endif !BUILD_FIPS_RAND
 
 if BUILD_MEMORY

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4599,8 +4599,7 @@ int wc_ecc_point_is_at_infinity(ecc_point* p)
 {
     if (p == NULL)
         return BAD_FUNC_ARG;
-
-    if ((p->x->used == 0) && (p->y->used == 0))
+    if (mp_iszero(p->x) && mp_iszero(p->y))
         return 1;
 
     return 0;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4600,7 +4600,7 @@ int wc_ecc_point_is_at_infinity(ecc_point* p)
     if (p == NULL)
         return BAD_FUNC_ARG;
 
-    if (get_digit_count(p->x) == 0 && get_digit_count(p->y) == 0)
+    if ((p->x->used == 0) && (p->y->used == 0))
         return 1;
 
     return 0;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -23529,7 +23529,7 @@ static int ecc_test_cert_gen(WC_RNG* rng)
     TEST_SLEEP();
 
 #ifdef WOLFSSL_TEST_CERT
-    InitDecodedCert(decode, der, certSz, 0);
+    InitDecodedCert(decode, der, certSz, HEAP_HINT);
     ret = ParseCert(decode, CERT_TYPE, NO_VERIFY, 0);
     if (ret != 0) {
         FreeDecodedCert(decode);


### PR DESCRIPTION
# Description

This PR improves interoperably, decouples build dependencies, and introduces --enable-do178 build option to help speed up DO-178 development. 

- Split SP C 32bit and 64bit configuration
- Introduced a few options to control source files from being built by default
- Update ECC to not use get_digit_count() in wolfmath.c
- Fix test with static configuration
- Update copyright date in options.h