### PR TITLE
clang-tidy hygiene for fips_test.h

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -13772,9 +13772,18 @@ static int test_wc_Md5HmacSetKey (void)
     for (itr = 0; itr < times; itr++) {
         ret = wc_HmacSetKey(&hmac, WC_MD5, (byte*)keys[itr],
                             (word32)XSTRLEN(keys[itr]));
+#if defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 5)
+        wc_HmacFree(&hmac);
+        if (ret == BAD_FUNC_ARG)
+            return 0;
+        else {
+            return WOLFSSL_FATAL_ERROR;
+        }
+#else
         if (ret != 0) {
             flag = ret;
         }
+#endif
     }
 
     /* Bad args. */
@@ -14166,7 +14175,7 @@ static int test_wc_Sha384HmacSetKey (void)
 static int test_wc_Md5HmacUpdate (void)
 {
     int flag = 0;
-#if !defined(NO_HMAC) && !defined(NO_MD5)
+#if !defined(NO_HMAC) && !defined(NO_MD5) && !(defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 5))
     Hmac hmac;
     testVector a, b;
     int ret;
@@ -14567,7 +14576,7 @@ static int test_wc_Sha384HmacUpdate (void)
 static int test_wc_Md5HmacFinal (void)
 {
     int flag = 0;
-#if !defined(NO_HMAC) && !defined(NO_MD5)
+#if !defined(NO_HMAC) && !defined(NO_MD5) && !(defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 5))
     Hmac hmac;
     byte hash[WC_MD5_DIGEST_SIZE];
     testVector a;

--- a/tests/hash.c
+++ b/tests/hash.c
@@ -130,7 +130,8 @@ int HashTest(void)
 #endif
 
 #ifndef NO_HMAC
-    #ifndef NO_MD5
+    #if !defined(NO_MD5) && !(defined(HAVE_FIPS) && defined(HAVE_FIPS_VERSION) \
+                              && (HAVE_FIPS_VERSION >= 5))
         if ( (ret = hmac_md5_test()) ) {
             printf( "   HMAC-MD5 test failed!\n");
             return ret;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -24642,7 +24642,8 @@ WOLFSSL_TEST_SUBROUTINE int ecc_encrypt_test(void)
         ret = -10412; goto done;
     }
 
-#ifdef HAVE_COMP_KEY
+#if defined(HAVE_COMP_KEY) && \
+    (! defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
     /* Create new client and server contexts. */
     wc_ecc_ctx_free(srvCtx);
     wc_ecc_ctx_free(cliCtx);
@@ -24700,7 +24701,7 @@ WOLFSSL_TEST_SUBROUTINE int ecc_encrypt_test(void)
     if (XMEMCMP(plain, msg, sizeof(msg)) != 0) {
         ret = -10419; goto done;
     }
-#endif /* HAVE_COMP_KEY */
+#endif /* HAVE_COMP_KEY && (!FIPS || FIPS>=5.3) */
 
 #if (!defined(NO_ECC256)  || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 256
     ret = ecc_encrypt_kat(&rng);

--- a/wolfssl/wolfcrypt/fips_test.h
+++ b/wolfssl/wolfcrypt/fips_test.h
@@ -77,16 +77,15 @@ WOLFSSL_API const char* wolfCrypt_GetCoreHash_fips(void);
 
 #ifdef HAVE_FORCE_FIPS_FAILURE
     /* Public function to force failure mode for operational testing */
-    WOLFSSL_API int wolfCrypt_SetStatus_fips(int);
+    WOLFSSL_API int wolfCrypt_SetStatus_fips(int status);
 #endif
 
-WOLFSSL_LOCAL int DoIntegrityTest(char*, int);
-WOLFSSL_LOCAL int DoPOST(char*, int);
-WOLFSSL_LOCAL int DoCAST(int);
-WOLFSSL_LOCAL int DoKnownAnswerTests(char*, int); /* FIPSv1 and FIPSv2 */
+WOLFSSL_LOCAL int DoPOST(char* base16_hash, int base16_hashSz);
+WOLFSSL_LOCAL int DoCAST(int type);
+WOLFSSL_LOCAL int DoKnownAnswerTests(char* base16_hash, int base16_hashSz); /* FIPSv1 and FIPSv2 */
 
-WOLFSSL_API int wc_RunCast_fips(int);
-WOLFSSL_API int wc_GetCastStatus_fips(int);
+WOLFSSL_API int wc_RunCast_fips(int type);
+WOLFSSL_API int wc_GetCastStatus_fips(int type);
 
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
also fixes `make check` for `--enable-fips=dev --enable-md5`.
