### PR TITLE
Fix for certreq and certgen options with openssl compatability

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -56320,7 +56320,7 @@ int wolfSSL_X509_REQ_set_pubkey(WOLFSSL_X509 *req, WOLFSSL_EVP_PKEY *pkey)
 #endif /* OPENSSL_ALL && !NO_CERTS && WOLFSSL_CERT_GEN && WOLFSSL_CERT_REQ */
 
 #if defined(OPENSSL_ALL) && !defined(NO_CERTS) && \
-    defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_REQ)
+    (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_REQ))
 
 WOLFSSL_ASN1_TYPE *wolfSSL_X509_ATTRIBUTE_get0_type(
         WOLFSSL_X509_ATTRIBUTE *attr, int idx)

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4009,7 +4009,9 @@ static const byte extExtKeyUsageOcspSignOid[]     = {43, 6, 1, 5, 5, 7, 3, 9};
     defined(WOLFSSL_ASN_TEMPLATE)
 /* csrAttrType */
 #define CSR_ATTR_TYPE_OID_BASE(num) {42, 134, 72, 134, 247, 13, 1, 9, num}
+#if !defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_GEN)
 static const byte attrEmailOid[] =             CSR_ATTR_TYPE_OID_BASE(1);
+#endif
 #ifdef WOLFSSL_CERT_REQ
 static const byte attrUnstructuredNameOid[] =  CSR_ATTR_TYPE_OID_BASE(2);
 static const byte attrPkcs9ContentTypeOid[] =  CSR_ATTR_TYPE_OID_BASE(3);
@@ -4056,7 +4058,9 @@ static const byte dnsSRVOid[] = {43, 6, 1, 5, 5, 7, 8, 7};
 #ifdef WOLFSSL_ASN_TEMPLATE
 static const byte uidOid[] = {9, 146, 38, 137, 147, 242, 44, 100, 1, 1}; /* user id */
 #endif
+#if !defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_GEN)
 static const byte dcOid[] = {9, 146, 38, 137, 147, 242, 44, 100, 1, 25}; /* domain component */
+#endif
 #endif
 
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4022,13 +4022,15 @@ struct WOLFSSL_X509 {
 #endif
     byte             serial[EXTERNAL_SERIAL_SIZE];
     char             subjectCN[ASN_NAME_MAX];        /* common name short cut */
-#ifdef WOLFSSL_CERT_REQ
-#ifdef OPENSSL_ALL
+#if defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_GEN)
+#if defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA)
     WOLFSSL_X509_ATTRIBUTE* challengePwAttr;
 #endif
+    #if defined(WOLFSSL_CERT_REQ)
     char             challengePw[CTC_NAME_SIZE]; /* for REQ certs */
     char             contentType[CTC_NAME_SIZE];
-#endif /* WOLFSSL_CERT_REQ */
+    #endif
+#endif /* WOLFSSL_CERT_REQ || WOLFSSL_CERT_GEN */
     WOLFSSL_X509_NAME issuer;
     WOLFSSL_X509_NAME subject;
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4282,21 +4282,24 @@ WOLFSSL_API int wolfSSL_X509_REQ_add1_attr_by_NID(WOLFSSL_X509 *req,
                                                   int nid, int type,
                                                   const unsigned char *bytes,
                                                   int len);
-WOLFSSL_API int wolfSSL_X509_REQ_get_attr_by_NID(const WOLFSSL_X509 *req,
-        int nid, int lastpos);
 WOLFSSL_API int wolfSSL_X509_REQ_add1_attr_by_txt(WOLFSSL_X509 *req,
                               const char *attrname, int type,
                               const unsigned char *bytes, int len);
-WOLFSSL_API WOLFSSL_X509_ATTRIBUTE *wolfSSL_X509_REQ_get_attr(
-        const WOLFSSL_X509 *req, int loc);
-WOLFSSL_API WOLFSSL_X509_ATTRIBUTE* wolfSSL_X509_ATTRIBUTE_new(void);
-WOLFSSL_API void wolfSSL_X509_ATTRIBUTE_free(WOLFSSL_X509_ATTRIBUTE* attr);
-WOLFSSL_API WOLFSSL_ASN1_TYPE *wolfSSL_X509_ATTRIBUTE_get0_type(
-        WOLFSSL_X509_ATTRIBUTE *attr, int idx);
 WOLFSSL_API WOLFSSL_X509 *wolfSSL_X509_to_X509_REQ(WOLFSSL_X509 *x,
         WOLFSSL_EVP_PKEY *pkey, const WOLFSSL_EVP_MD *md);
 #endif
 
+#if defined(OPENSSL_EXTRA) && !defined(NO_CERTS) && defined(WOLFSSL_CERT_GEN) || \
+                                                       defined(WOLFSSL_CERT_REQ)
+WOLFSSL_API WOLFSSL_X509_ATTRIBUTE *wolfSSL_X509_REQ_get_attr(
+        const WOLFSSL_X509 *req, int loc);
+WOLFSSL_API int wolfSSL_X509_REQ_get_attr_by_NID(const WOLFSSL_X509 *req,
+        int nid, int lastpos);
+WOLFSSL_API WOLFSSL_X509_ATTRIBUTE* wolfSSL_X509_ATTRIBUTE_new(void);
+WOLFSSL_API void wolfSSL_X509_ATTRIBUTE_free(WOLFSSL_X509_ATTRIBUTE* attr);
+WOLFSSL_API WOLFSSL_ASN1_TYPE *wolfSSL_X509_ATTRIBUTE_get0_type(
+        WOLFSSL_X509_ATTRIBUTE *attr, int idx);
+#endif
 
 #if defined(OPENSSL_ALL) || defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) \
     || defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA) || defined(HAVE_LIGHTY)


### PR DESCRIPTION
# Description

Changes so that the following configs work :
- `--enable-opensslall --enable-opensslextra --enable-certgen`
- `--enable-opensslall --enable-opensslextra --enable-certreq`

Fixes zd#  none

# Testing

Make check for configs and commit tests.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
