### PR TITLE
For `0` OpenSSL prints "ok"

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -20170,7 +20170,7 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
 
     switch (error) {
 
-#ifdef WOLFSSL_WPAS
+#ifdef OPENSSL_EXTRA
     case 0 :
         return "ok";
 #endif


### PR DESCRIPTION
Reported in https://github.com/wolfSSL/wolfssl/issues/4773