### PR TITLE
ZD13495

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -18916,9 +18916,12 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
 
     const char* wolfSSLeay_version(int type)
     {
-        static const char* version = "SSLeay wolfSSL compatibility";
         (void)type;
-        return version;
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
+        return wolfSSL_OpenSSL_version(type);
+#else
+        return wolfSSL_OpenSSL_version();
+#endif
     }
 
 

--- a/wolfssl/openssl/crypto.h
+++ b/wolfssl/openssl/crypto.h
@@ -47,6 +47,10 @@ typedef void (CRYPTO_free_func)(void* parent, void* ptr, CRYPTO_EX_DATA* ad, int
 #include "prefix_crypto.h"
 #endif
 
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
 WOLFSSL_API const char*   wolfSSLeay_version(int type);
 WOLFSSL_API unsigned long wolfSSLeay(void);
 WOLFSSL_API unsigned long wolfSSL_OpenSSL_version_num(void);
@@ -125,5 +129,9 @@ WOLFSSL_API int wolfSSL_OPENSSL_init_crypto(word64 opts, const OPENSSL_INIT_SETT
 #define CRYPTO_set_ex_data wolfSSL_CRYPTO_set_ex_data
 
 #endif /* OPENSSL_ALL || HAVE_STUNNEL || WOLFSSL_NGINX || WOLFSSL_HAPROXY || HAVE_EX_DATA */
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
 
 #endif /* header */


### PR DESCRIPTION
- `wolfSSLeay_version` now returns the version of wolfSSL
- `wolfssl/openssl/crypto.h` was not enveloped in a `extern "C"` wrapper