### PR TITLE
Add wolfSSL_EVP_PKEY_paramgen to the compatibility layer.

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -43235,12 +43235,27 @@ static void test_wolfSSL_EVP_PKEY_paramgen(void)
 
     printf(testingFmt, "wolfSSL_EVP_PKEY_paramgen");
 
+    /* Test error conditions. */
+    AssertIntEQ(EVP_PKEY_paramgen(NULL, &pkey), WOLFSSL_FAILURE);
     AssertNotNull(ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL));
-    AssertIntEQ(EVP_PKEY_paramgen_init(ctx), 1);
-    AssertIntEQ(EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, NID_X9_62_prime256v1), 1);
-    AssertIntEQ(EVP_PKEY_CTX_set_ec_param_enc(ctx, OPENSSL_EC_NAMED_CURVE), 1);
-    AssertIntEQ(EVP_PKEY_keygen_init(ctx), 1);
-    AssertIntEQ(EVP_PKEY_keygen(ctx, &pkey), 1);
+    AssertIntEQ(EVP_PKEY_paramgen(ctx, NULL), WOLFSSL_FAILURE);
+    EVP_PKEY_CTX_free(ctx);
+#ifndef NO_RSA
+    /* Parameter generation for RSA not supported yet. */
+    AssertNotNull(ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL));
+    AssertIntEQ(EVP_PKEY_paramgen(ctx, &pkey), WOLFSSL_FAILURE);
+    EVP_PKEY_CTX_free(ctx);
+#endif
+
+    AssertNotNull(ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL));
+    AssertIntEQ(EVP_PKEY_paramgen_init(ctx), WOLFSSL_SUCCESS);
+    AssertIntEQ(EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx,
+                    NID_X9_62_prime256v1), WOLFSSL_SUCCESS);
+    AssertIntEQ(EVP_PKEY_paramgen(ctx, &pkey), WOLFSSL_SUCCESS);
+    AssertIntEQ(EVP_PKEY_CTX_set_ec_param_enc(ctx, OPENSSL_EC_NAMED_CURVE),
+                    WOLFSSL_SUCCESS);
+    AssertIntEQ(EVP_PKEY_keygen_init(ctx), WOLFSSL_SUCCESS);
+    AssertIntEQ(EVP_PKEY_keygen(ctx, &pkey), WOLFSSL_SUCCESS);
 
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(pkey);

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -630,6 +630,8 @@ WOLFSSL_API int wolfSSL_EVP_PKEY_sign(WOLFSSL_EVP_PKEY_CTX *ctx,
 WOLFSSL_API int wolfSSL_EVP_PKEY_paramgen_init(WOLFSSL_EVP_PKEY_CTX *ctx);
 WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(WOLFSSL_EVP_PKEY_CTX *ctx,
         int nid);
+WOLFSSL_API int wolfSSL_EVP_PKEY_paramgen(WOLFSSL_EVP_PKEY_CTX* ctx,
+                                          WOLFSSL_EVP_PKEY** pkey);
 WOLFSSL_API int EVP_PKEY_CTX_set_ec_param_enc(WOLFSSL_EVP_PKEY_CTX *ctx,
         int flag);
 WOLFSSL_API int wolfSSL_EVP_PKEY_keygen_init(WOLFSSL_EVP_PKEY_CTX *ctx);
@@ -934,6 +936,7 @@ WOLFSSL_API void wolfSSL_EVP_MD_do_all(void (*fn) (const WOLFSSL_EVP_MD *md,
 #define EVP_PKEY_sign                  wolfSSL_EVP_PKEY_sign
 #define EVP_PKEY_paramgen_init         wolfSSL_EVP_PKEY_paramgen_init
 #define EVP_PKEY_CTX_set_ec_paramgen_curve_nid wolfSSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid
+#define EVP_PKEY_paramgen              wolfSSL_EVP_PKEY_paramgen
 #define EVP_PKEY_keygen                wolfSSL_EVP_PKEY_keygen
 #define EVP_PKEY_keygen_init           wolfSSL_EVP_PKEY_keygen_init
 #define EVP_PKEY_bits                  wolfSSL_EVP_PKEY_bits


### PR DESCRIPTION
# Description

Currently, it only supports ECC, which is all we need it for for the OpenSplice port we're working on. In the ECC case, all it needs to do is set the group appropriately. The logic is very similar to `wolfSSL_EVP_PKEY_keygen`, minus the final step of actually generating the key.

# Testing

I expanded the `test_wolfSSL_EVP_PKEY_paramgen` unit test and I compared the output of a sample program using `EVP_PKEY_paramgen` with both OpenSSL and wolfSSL.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation

OpenSSL documentation is sufficient, I think.