### PR TITLE
Fix warnings in VS

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -11499,7 +11499,7 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
     const char* post = "";
     byte*   pbuf = NULL;
     int     len, num, i, idx;
-    byte    suffix = 0;
+    int    suffix = 0;
     int retHash = NOT_COMPILED_IN;
     byte dgt[WC_MAX_DIGEST_SIZE];
 
@@ -19222,7 +19222,7 @@ int SendCertificateRequest(WOLFSSL* ssl)
 
         if (name != NULL) {
             c16toa((word16)name->rawLen +
-                   SetSequence(name->rawLen, seq), &output[i]);
+                   (word16)SetSequence(name->rawLen, seq), &output[i]);
             i += OPAQUE16_LEN;
             i += SetSequence(name->rawLen, output + i);
             XMEMCPY(output + i, name->raw, name->rawLen);
@@ -31159,7 +31159,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
     int ret;
     TicketEncCbCtx* keyCtx = (TicketEncCbCtx*)userCtx;
     WOLFSSL_CTX* ctx = keyCtx->ctx;
-    word16 sLen = XHTONS(inLen);
+    word16 sLen = XHTONS((word16)inLen);
     byte aad[WOLFSSL_TICKET_NAME_SZ + WOLFSSL_TICKET_IV_SZ + sizeof(sLen)];
     int  aadSz = WOLFSSL_TICKET_NAME_SZ + WOLFSSL_TICKET_IV_SZ + sizeof(sLen);
     byte* p = aad;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10177,7 +10177,7 @@ int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext, int lo
             WOLFSSL_MSG("asn1_string_copy_to_buffer error");
             return WOLFSSL_FAILURE;
         }
-        x509->authKeyIdCrit = ext->crit;
+        x509->authKeyIdCrit = (byte)ext->crit;
         break;
     case NID_subject_key_identifier:
         if (asn1_string_copy_to_buffer(&ext->value, &x509->subjKeyId,
@@ -10185,7 +10185,7 @@ int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext, int lo
             WOLFSSL_MSG("asn1_string_copy_to_buffer error");
             return WOLFSSL_FAILURE;
         }
-        x509->subjKeyIdCrit = ext->crit;
+        x509->subjKeyIdCrit = (byte)ext->crit;
         break;
     case NID_subject_alt_name:
     {
@@ -10201,21 +10201,21 @@ int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext, int lo
             gns = gns->next;
         }
         x509->subjAltNameSet = 1;
-        x509->subjAltNameCrit = ext->crit;
+        x509->subjAltNameCrit = (byte)ext->crit;
         break;
     }
     case NID_key_usage:
         if (ext && ext->value.data &&
                 ext->value.length == sizeof(word16)) {
             x509->keyUsage = *(word16*)ext->value.data;
-            x509->keyUsageCrit = ext->crit;
+            x509->keyUsageCrit = (byte)ext->crit;
             x509->keyUsageSet = 1;
         }
         break;
     case NID_basic_constraints:
         if (ext->obj) {
-            x509->isCa = ext->obj->ca;
-            x509->basicConstCrit = ext->crit;
+            x509->isCa = (byte)ext->obj->ca;
+            x509->basicConstCrit = (byte)ext->crit;
             if (ext->obj->pathlen)
                 x509->pathLength = ext->obj->pathlen->length;
             x509->basicConstSet = 1;
@@ -15519,7 +15519,7 @@ int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
                                        ticLenAlloc >= ssl->session.ticketLen) {
         XMEMCPY(ticBuff, session->ticket, ssl->session.ticketLen);
         ssl->session.ticket = ticBuff;
-        ssl->session.ticketLenAlloc = ticLenAlloc;
+        ssl->session.ticketLenAlloc = (word16)ticLenAlloc;
         ticBuff = NULL; /* don't free later after unlock */
     }
     else {
@@ -21039,7 +21039,7 @@ static WOLFSSL_X509* d2i_X509orX509REQ(WOLFSSL_X509** x509,
 
         InitDecodedCert(cert, (byte*)in, len, NULL);
     #ifdef WOLFSSL_CERT_REQ
-        cert->isCSR = req;
+        cert->isCSR = (byte)req;
     #endif
         if (ParseCertRelative(cert, type, 0, NULL) == 0) {
             newX509 = wolfSSL_X509_new();
@@ -26074,39 +26074,39 @@ int wolfSSL_sk_CIPHER_description(WOLFSSL_CIPHER* cipher)
     /* Build up the string by copying onto the end. */
     XSTRNCPY(dp, name, len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (int)strLen; dp += strLen;
+    len -= (unsigned char)strLen; dp += strLen;
 
     XSTRNCPY(dp, " ", len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (int)strLen; dp += strLen;
+    len -= (unsigned char)strLen; dp += strLen;
     XSTRNCPY(dp, protocol, len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (int)strLen; dp += strLen;
+    len -= (unsigned char)strLen; dp += strLen;
 
     XSTRNCPY(dp, " Kx=", len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (int)strLen; dp += strLen;
+    len -= (unsigned char)strLen; dp += strLen;
     XSTRNCPY(dp, keaStr, len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (int)strLen; dp += strLen;
+    len -= (unsigned char)strLen; dp += strLen;
 
     XSTRNCPY(dp, " Au=", len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (int)strLen; dp += strLen;
+    len -= (unsigned char)strLen; dp += strLen;
     XSTRNCPY(dp, authStr, len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (int)strLen; dp += strLen;
+    len -= (unsigned char)strLen; dp += strLen;
 
     XSTRNCPY(dp, " Enc=", len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (int)strLen; dp += strLen;
+    len -= (unsigned char)strLen; dp += strLen;
     XSTRNCPY(dp, encStr, len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (int)strLen; dp += strLen;
+    len -= (unsigned char)strLen; dp += strLen;
 
     XSTRNCPY(dp, " Mac=", len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (int)strLen; dp += strLen;
+    len -= (unsigned char)strLen; dp += strLen;
     XSTRNCPY(dp, macStr, len);
     dp[len-1] = '\0';
 
@@ -43748,7 +43748,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
             else {
                 i->length = cert.serialSz + 2;
                 i->data[0] = ASN_INTEGER;
-                i->data[1] = cert.serialSz;
+                i->data[1] = (unsigned char)cert.serialSz;
                 XMEMCPY(i->data + 2, cert.serial, cert.serialSz);
                 if (wolfSSL_X509_set_serialNumber(x509, i) != WOLFSSL_SUCCESS) {
                     WOLFSSL_MSG("Issue setting generated serial number");
@@ -44078,7 +44078,7 @@ static int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
             /* remove the rest of spaces */
             while (XISSPACE(*++src) && i++ < len);
         } else {
-            *dst = XTOLOWER((unsigned char)*src++);
+            *dst = (char)XTOLOWER((unsigned char)*src++);
         }
     }
     /* put actual length */
@@ -44150,7 +44150,7 @@ int wolfSSL_i2d_X509_NAME_canon(WOLFSSL_X509_NAME* name, unsigned char** out)
             nameStr = (const char*)wolfSSL_ASN1_STRING_data(cano_data);
 
             ret = wc_EncodeNameCanonical(&names[i], nameStr, CTC_UTF8,
-                ConvertNIDToWolfSSL(entry->nid));
+                (byte)ConvertNIDToWolfSSL(entry->nid));
             if (ret < 0) {
             #ifdef WOLFSSL_SMALL_STACK
                 XFREE(names, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -44260,8 +44260,8 @@ int wolfSSL_i2d_X509_NAME(WOLFSSL_X509_NAME* name, unsigned char** out)
                     WOLFSSL_MSG("Unknown encoding type conversion UTF8 by default");
                     type = CTC_UTF8;
             }
-            ret = wc_EncodeName(&names[i], nameStr, type,
-                ConvertNIDToWolfSSL(entry->nid));
+            ret = wc_EncodeName(&names[i], nameStr, (char)type,
+                (byte)ConvertNIDToWolfSSL(entry->nid));
             if (ret < 0) {
             #ifdef WOLFSSL_SMALL_STACK
                 XFREE(names, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -60333,7 +60333,7 @@ void wolfSSL_BIO_set_shutdown(WOLFSSL_BIO* bio, int shut)
 {
     WOLFSSL_ENTER("wolfSSL_BIO_set_shutdown");
     if (bio != NULL)
-        bio->shutdown = shut;
+        bio->shutdown = (byte)shut;
 }
 
 int wolfSSL_BIO_get_shutdown(WOLFSSL_BIO* bio)

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26032,7 +26032,7 @@ int wolfSSL_sk_CIPHER_description(WOLFSSL_CIPHER* cipher)
     const char* name;
     const char *keaStr, *authStr, *encStr, *macStr, *protocol;
     char n[MAX_SEGMENTS][MAX_SEGMENT_SZ] = {{0}};
-    unsigned char len = MAX_DESCRIPTION_SZ-1;
+    int len = MAX_DESCRIPTION_SZ-1;
     const CipherSuiteInfo* cipher_names;
     ProtocolVersion pv;
     WOLFSSL_ENTER("wolfSSL_sk_CIPHER_description");
@@ -26074,39 +26074,39 @@ int wolfSSL_sk_CIPHER_description(WOLFSSL_CIPHER* cipher)
     /* Build up the string by copying onto the end. */
     XSTRNCPY(dp, name, len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (unsigned char)strLen; dp += strLen;
+    len -= strLen; dp += strLen;
 
     XSTRNCPY(dp, " ", len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (unsigned char)strLen; dp += strLen;
+    len -= strLen; dp += strLen;
     XSTRNCPY(dp, protocol, len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (unsigned char)strLen; dp += strLen;
+    len -= strLen; dp += strLen;
 
     XSTRNCPY(dp, " Kx=", len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (unsigned char)strLen; dp += strLen;
+    len -= strLen; dp += strLen;
     XSTRNCPY(dp, keaStr, len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (unsigned char)strLen; dp += strLen;
+    len -= strLen; dp += strLen;
 
     XSTRNCPY(dp, " Au=", len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (unsigned char)strLen; dp += strLen;
+    len -= strLen; dp += strLen;
     XSTRNCPY(dp, authStr, len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (unsigned char)strLen; dp += strLen;
+    len -= strLen; dp += strLen;
 
     XSTRNCPY(dp, " Enc=", len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (unsigned char)strLen; dp += strLen;
+    len -= strLen; dp += strLen;
     XSTRNCPY(dp, encStr, len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (unsigned char)strLen; dp += strLen;
+    len -= strLen; dp += strLen;
 
     XSTRNCPY(dp, " Mac=", len);
     dp[len-1] = '\0'; strLen = (int)XSTRLEN(dp);
-    len -= (unsigned char)strLen; dp += strLen;
+    len -= strLen; dp += strLen;
     XSTRNCPY(dp, macStr, len);
     dp[len-1] = '\0';
 
@@ -26665,9 +26665,6 @@ WOLFSSL_X509_LOOKUP_METHOD* wolfSSL_X509_LOOKUP_file(void)
 /* @return WOLFSSL_SUCCESS on successful, othewise negative or zero         */
 static int x509AddCertDir(WOLFSSL_BY_DIR *ctx, const char *argc, long argl)
 {
-    WOLFSSL_ENTER("x509AddCertDir");
-
-    (void)argl;
 #if defined(OPENSSL_ALL) && !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR)
     WOLFSSL_BY_DIR_entry *entry;
     size_t pathLen;
@@ -26678,6 +26675,8 @@ static int x509AddCertDir(WOLFSSL_BY_DIR *ctx, const char *argc, long argl)
 #else
     char  buf[MAX_FILENAME_SZ];
 #endif
+
+    WOLFSSL_ENTER("x509AddCertDir");
 
     pathLen = 0;
     c = argc;
@@ -26779,6 +26778,7 @@ static int x509AddCertDir(WOLFSSL_BY_DIR *ctx, const char *argc, long argl)
     (void)argc;
     return WOLFSSL_NOT_IMPLEMENTED;
 #endif
+    (void)argl;
 }
 
 /* set additional data to X509_LOOKUP                                   */
@@ -30212,8 +30212,9 @@ int wolfSSL_i2d_ASN1_OBJECT(WOLFSSL_ASN1_OBJECT *a, unsigned char **pp)
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
 WOLFSSL_API size_t wolfSSL_get_finished(const WOLFSSL *ssl, void *buf, size_t count)
 {
-    WOLFSSL_ENTER("SSL_get_finished");
     byte len = 0;
+
+    WOLFSSL_ENTER("SSL_get_finished");
 
     if (!ssl || !buf || count < TLS_FINISHED_SZ) {
         WOLFSSL_MSG("Bad parameter");
@@ -43523,20 +43524,14 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
     static int wolfSSL_sigTypeFromPKEY(WOLFSSL_EVP_MD* md,
             WOLFSSL_EVP_PKEY* pkey)
     {
+    #if !defined(NO_PWDBASED) && defined(OPENSSL_EXTRA)
         int hashType;
         int sigType = WOLFSSL_FAILURE;
 
-    #if !defined(NO_PWDBASED) && defined(OPENSSL_EXTRA)
         /* Convert key type and hash algorithm to a signature algorithm */
         if (wolfSSL_EVP_get_hashinfo(md, &hashType, NULL) == WOLFSSL_FAILURE) {
             return WOLFSSL_FAILURE;
         }
-    #else
-        (void)md;
-        WOLFSSL_MSG("Cannot get hashinfo when NO_PWDBASED is defined");
-        return WOLFSSL_FAILURE;
-    #endif /* !defined(NO_PWDBASED) */
-
 
         if (pkey->type == EVP_PKEY_RSA) {
             switch (hashType) {
@@ -43611,6 +43606,12 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
         else
             return WOLFSSL_FAILURE;
         return sigType;
+#else
+        (void)md;
+        (void)pkey;
+        WOLFSSL_MSG("Cannot get hashinfo when NO_PWDBASED is defined");
+        return WOLFSSL_FAILURE;
+#endif /* !NO_PWDBASED && OPENSSL_EXTRA */
     }
 
 

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -10970,7 +10970,7 @@ static WARN_UNUSED_RESULT int wc_AesFeedbackCFB8(
     #ifdef BIG_ENDIAN_ORDER
         ByteReverseWords(aes->tmp, aes->tmp, AES_BLOCK_SIZE);
     #endif
-        out[0] = aes->tmp[0] ^ in[0];
+        out[0] = (byte)(aes->tmp[0] ^ in[0]);
         if (dir == AES_ENCRYPTION) {
             pt = (byte*)aes->reg;
 

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -728,7 +728,7 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
     #define XINET_PTON(a,b,c)   inet_pton((a),(b),(c))
     #ifdef USE_WINDOWS_API /* Windows-friendly definition */
         #undef  XINET_PTON
-        #define XINET_PTON(a,b,c)   InetPton((a),(b),(c))
+        #define XINET_PTON(a,b,c)   InetPton((a),(PCWSTR)(b),(c))
     #endif
 #endif
 


### PR DESCRIPTION
# Description

Fixes for various VS warnings in `internal.c` and `ssl.c`
> warning C4244: '=': conversion from 'int' to 'byte', possible loss of data
> warning C4702: unreachable code

Fixes zd13613

# Testing
Build with VS with `OPENSSL_ALL` and `OPENSSL_EXTRA` defined
