### PR TITLE
User settings template for FIPS v5 ready

### DIFF
--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -9,6 +9,7 @@ Example wolfSSL configuration file templates for use when autoconf is not availa
 * `user_settings_min_ecc.h`: This is ECC and SHA-256 only. For ECC verify only add `BUILD_VERIFY_ONLY`.
 * `user_settings_wolfboot_keytools.h`: This from wolfBoot tools/keytools and is ECC, RSA, ED25519 and ChaCha20.
 * `user_settings_fipsv2.h`: The FIPS v2 (3389) 140-2 certificate build options.
+* `user_settings_fipsv5.h`: The FIPS v5 (ready) 140-3 build options. Equivalent to `./configure --enable-fips=v5-dev`.
 * `user_settings_stm32.h`: Example configuration file generated from the wolfSSL STM32 Cube pack.
 
 ## Usage

--- a/examples/configs/include.am
+++ b/examples/configs/include.am
@@ -7,4 +7,5 @@ EXTRA_DIST += examples/configs/user_settings_min_ecc.h
 EXTRA_DIST += examples/configs/user_settings_wolfboot_keytools.h
 EXTRA_DIST += examples/configs/user_settings_template.h
 EXTRA_DIST += examples/configs/user_settings_fipsv2.h
+EXTRA_DIST += examples/configs/user_settings_fipsv5.h
 EXTRA_DIST += examples/configs/user_settings_stm32.h

--- a/examples/configs/user_settings_fipsv2.h
+++ b/examples/configs/user_settings_fipsv2.h
@@ -105,7 +105,8 @@ extern "C" {
 #define NO_PWDBASED
 #define NO_RC4
 #define WOLFSSL_NO_SHAKE256
-
+#define NO_RABBIT
+#define NO_HC128
 
 #ifdef __cplusplus
 }

--- a/examples/configs/user_settings_fipsv5.h
+++ b/examples/configs/user_settings_fipsv5.h
@@ -1,0 +1,145 @@
+/* user_settings_fipsv5.h
+ *
+ * Copyright (C) 2006-2022 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* should be renamed to user_settings.h for customer use
+ * generated from configure options:
+ * ./fips-check.sh linuxv5-dev keep
+ * XXX-fips-test\wolfssl\options.h
+ * ./configure --enable-fips=v5-dev
+ *
+ * Cleaned up by David Garske
+ */
+
+
+#ifndef WOLFSSL_USER_SETTINGS_H
+#define WOLFSSL_USER_SETTINGS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* FIPS Version 5.3 */
+#define HAVE_FIPS
+#define HAVE_FIPS_VERSION 5
+#define HAVE_FIPS_VERSION_MINOR 3
+
+#define HAVE_HASHDRBG /* NIST Certified DRBG - SHA256 based */
+#define HAVE_THREAD_LS
+
+/* Math */
+#define USE_FAST_MATH
+#define FP_MAX_BITS 16384
+#define SP_INT_BITS 8192
+
+/* Timing Resistance */
+#define TFM_TIMING_RESISTANT
+#define ECC_TIMING_RESISTANT
+#define WC_RSA_BLINDING
+
+/* FIPS Features */
+#define WC_RNG_SEED_CB
+#define WOLFSSL_VALIDATE_ECC_IMPORT
+#define WOLFSSL_VALIDATE_ECC_KEYGEN
+#define WOLFSSL_VALIDATE_FFC_IMPORT
+
+/* TLS Features */
+#define WOLFSSL_TLS13
+#define WOLFSSL_BASE64_ENCODE
+#define WOLFSSL_USE_ALIGN
+#define WOLFSSL_PUBLIC_MP
+#define HAVE_ENCRYPT_THEN_MAC
+#define HAVE_TLS_EXTENSIONS
+#define HAVE_SUPPORTED_CURVES
+#define HAVE_EXTENDED_MASTER
+//#define HAVE_SERVER_RENEGOTIATION_INFO
+
+#undef  WOLFSSL_WOLFSSH
+#define WOLFSSL_WOLFSSH
+
+/* DH */
+#undef  NO_DH
+#define HAVE_FFDHE_Q
+#define HAVE_FFDHE_2048
+#define HAVE_FFDHE_3072
+#define HAVE_FFDHE_4096
+#define HAVE_FFDHE_6144
+#define HAVE_FFDHE_8192
+#define HAVE_DH_DEFAULT_PARAMS
+#define HAVE_PUBLIC_FFDHE
+
+/* ECC */
+#define HAVE_ECC
+#define TFM_ECC256
+#define ECC_SHAMIR
+#define HAVE_ECC_CDH
+#define ECC_USER_CURVES
+#define HAVE_ECC192
+#define HAVE_ECC224
+#define HAVE_ECC256
+#define HAVE_ECC384
+#define HAVE_ECC521
+#define WOLFSSL_ECDSA_SET_K
+
+/* RSA */
+#undef  NO_RSA
+#define WC_RSA_PSS
+#define WOLFSSL_KEY_GEN
+#define WC_RSA_NO_PADDING
+
+/* AES */
+#define WOLFSSL_AES_COUNTER
+#define HAVE_AESCCM
+#define HAVE_AES_ECB
+#define WOLFSSL_AES_COUNTER
+#define WOLFSSL_AES_DIRECT
+#define WOLFSSL_AES_OFB
+#define HAVE_AESGCM
+#define GCM_TABLE_4BIT
+#define WOLFSSL_CMAC
+
+/* Hashing */
+#undef  NO_SHA
+#undef  NO_SHA256
+#define WOLFSSL_SHA224
+#define WOLFSSL_SHA512
+#define WOLFSSL_SHA384
+#define WOLFSSL_NO_SHAKE256
+#define WOLFSSL_NOSHA512_224
+#define WOLFSSL_NOSHA512_256
+#define WOLFSSL_SHA3
+#define HAVE_HKDF
+
+/* Disabled Algorithms */
+#define NO_OLD_TLS
+#define NO_RC4
+#define NO_MD4
+#define NO_MD5
+#define NO_DES3
+#define NO_PSK
+#define NO_DSA
+#define NO_PWDBASED
+#define WOLFSSL_NO_SHAKE256
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WOLFSSL_USER_SETTINGS_H */

--- a/examples/configs/user_settings_fipsv5.h
+++ b/examples/configs/user_settings_fipsv5.h
@@ -48,6 +48,7 @@ extern "C" {
 #define USE_FAST_MATH
 #define FP_MAX_BITS 16384
 #define SP_INT_BITS 8192
+#define WOLFSSL_PUBLIC_MP /* expose the mp_ math API's */
 
 /* Timing Resistance */
 #define TFM_TIMING_RESISTANT
@@ -64,12 +65,16 @@ extern "C" {
 #define WOLFSSL_TLS13
 #define WOLFSSL_BASE64_ENCODE
 #define WOLFSSL_USE_ALIGN
-#define WOLFSSL_PUBLIC_MP
 #define HAVE_ENCRYPT_THEN_MAC
 #define HAVE_TLS_EXTENSIONS
 #define HAVE_SUPPORTED_CURVES
 #define HAVE_EXTENDED_MASTER
+#define HAVE_ONE_TIME_AUTH /* TLS extension used with Poly1305 */
 #define HAVE_CRL
+#define HAVE_EXT_CACHE
+#define WOLFSSL_VERIFY_CB_ALL_CERTS
+#define WOLFSSL_ALWAYS_VERIFY_CB
+#define WOLFSSL_DH_EXTRA /* DHE ASN.1 key import/export support */
 
 #if 0
     #define HAVE_SECURE_RENEGOTIATION
@@ -80,6 +85,10 @@ extern "C" {
 #define WOLFSSL_WOLFSSH
 #endif
 
+/* Compatibility Layer */
+#if 0
+    #define OPENSSL_ALL
+#endif
 
 /* DH */
 #undef  NO_DH
@@ -122,6 +131,10 @@ extern "C" {
 #define GCM_TABLE_4BIT
 #define WOLFSSL_CMAC
 
+/* ChaCha/Poly */
+#define HAVE_CHACHA
+#define HAVE_POLY1305
+
 /* Hashing */
 #undef  NO_SHA
 #undef  NO_SHA256
@@ -145,6 +158,7 @@ extern "C" {
 #define WOLFSSL_NO_SHAKE256
 #define NO_RABBIT
 #define NO_HC128
+
 
 #ifdef __cplusplus
 }

--- a/examples/configs/user_settings_fipsv5.h
+++ b/examples/configs/user_settings_fipsv5.h
@@ -69,10 +69,17 @@ extern "C" {
 #define HAVE_TLS_EXTENSIONS
 #define HAVE_SUPPORTED_CURVES
 #define HAVE_EXTENDED_MASTER
-//#define HAVE_SERVER_RENEGOTIATION_INFO
+#define HAVE_CRL
 
-#undef  WOLFSSL_WOLFSSH
+#if 0
+    #define HAVE_SECURE_RENEGOTIATION
+    #define HAVE_SERVER_RENEGOTIATION_INFO
+#endif
+
+#ifndef WOLFSSL_WOLFSSH  /* ifndef check required due to configure already generating flag */
 #define WOLFSSL_WOLFSSH
+#endif
+
 
 /* DH */
 #undef  NO_DH
@@ -135,7 +142,6 @@ extern "C" {
 #define NO_DES3
 #define NO_PSK
 #define NO_DSA
-#define NO_PWDBASED
 #define WOLFSSL_NO_SHAKE256
 #define NO_RABBIT
 #define NO_HC128

--- a/examples/configs/user_settings_fipsv5.h
+++ b/examples/configs/user_settings_fipsv5.h
@@ -137,6 +137,8 @@ extern "C" {
 #define NO_DSA
 #define NO_PWDBASED
 #define WOLFSSL_NO_SHAKE256
+#define NO_RABBIT
+#define NO_HC128
 
 #ifdef __cplusplus
 }

--- a/examples/configs/user_settings_fipsv5.h
+++ b/examples/configs/user_settings_fipsv5.h
@@ -77,7 +77,9 @@ extern "C" {
 /* Other Features */
 #define WOLFSSL_USE_ALIGN
 #define WOLFSSL_BASE64_ENCODE
-//#define HAVE_CRL
+#if 0 /* optionally enable CRL (Certificate Revocation List) */
+    #define HAVE_CRL
+#endif
 #define HAVE_EXT_CACHE
 #define WOLFSSL_VERIFY_CB_ALL_CERTS
 #define WOLFSSL_ALWAYS_VERIFY_CB
@@ -89,7 +91,7 @@ extern "C" {
 
 /* Compatibility Layer */
 #define OPENSSL_EXTRA
-#if 0
+#if 0 /* if full suite of compatibility API's are needed */
     #define OPENSSL_ALL
 #endif
 
@@ -124,6 +126,7 @@ extern "C" {
 #define WC_RSA_NO_PADDING
 
 /* AES */
+#undef  NO_AES
 #define WOLFSSL_AES_COUNTER
 #define HAVE_AESCCM
 #define HAVE_AES_ECB
@@ -164,8 +167,11 @@ extern "C" {
 #define NO_HC128
 #define WOLFSSL_NO_SHAKE256
 
+/* Debugging */
 #if 0
     #define DEBUG_WOLFSSL
+#else
+    /* #define NO_ERROR_STRINGS */
 #endif
 
 #ifdef __cplusplus

--- a/examples/configs/user_settings_fipsv5.h
+++ b/examples/configs/user_settings_fipsv5.h
@@ -63,29 +63,32 @@ extern "C" {
 
 /* TLS Features */
 #define WOLFSSL_TLS13
-#define WOLFSSL_BASE64_ENCODE
-#define WOLFSSL_USE_ALIGN
-#define HAVE_ENCRYPT_THEN_MAC
 #define HAVE_TLS_EXTENSIONS
+#define HAVE_ENCRYPT_THEN_MAC
 #define HAVE_SUPPORTED_CURVES
 #define HAVE_EXTENDED_MASTER
 #define HAVE_ONE_TIME_AUTH /* TLS extension used with Poly1305 */
-#define HAVE_CRL
+
+/* TLS Resumption */
+#define HAVE_SECURE_RENEGOTIATION
+#define HAVE_SERVER_RENEGOTIATION_INFO
+#define HAVE_SESSION_TICKET
+
+/* Other Features */
+#define WOLFSSL_USE_ALIGN
+#define WOLFSSL_BASE64_ENCODE
+//#define HAVE_CRL
 #define HAVE_EXT_CACHE
 #define WOLFSSL_VERIFY_CB_ALL_CERTS
 #define WOLFSSL_ALWAYS_VERIFY_CB
 #define WOLFSSL_DH_EXTRA /* DHE ASN.1 key import/export support */
 
-#if 0
-    #define HAVE_SECURE_RENEGOTIATION
-    #define HAVE_SERVER_RENEGOTIATION_INFO
-#endif
-
-#ifndef WOLFSSL_WOLFSSH  /* ifndef check required due to configure already generating flag */
+#ifndef WOLFSSL_WOLFSSH /* ifndef check required due to configure already generating flag */
 #define WOLFSSL_WOLFSSH
 #endif
 
 /* Compatibility Layer */
+#define OPENSSL_EXTRA
 #if 0
     #define OPENSSL_ALL
 #endif
@@ -147,18 +150,23 @@ extern "C" {
 #define WOLFSSL_SHA3
 #define HAVE_HKDF
 
-/* Disabled Algorithms */
+/* Disabled Features */
 #define NO_OLD_TLS
+#define NO_PSK
+
+/* Disabled Algorithms */
 #define NO_RC4
 #define NO_MD4
 #define NO_MD5
 #define NO_DES3
-#define NO_PSK
 #define NO_DSA
-#define WOLFSSL_NO_SHAKE256
 #define NO_RABBIT
 #define NO_HC128
+#define WOLFSSL_NO_SHAKE256
 
+#if 0
+    #define DEBUG_WOLFSSL
+#endif
 
 #ifdef __cplusplus
 }

--- a/examples/sctp/sctp-client-dtls.c
+++ b/examples/sctp/sctp-client-dtls.c
@@ -49,8 +49,10 @@ static int err_sys(const char* msg)
 }
 #endif /* WOLFSSL_SCTP && WOLFSSL_DTLS */
 
-int main()
+int main(int argc, char **argv)
 {
+    (void)argc;
+    (void)argv;
 #if defined(WOLFSSL_SCTP) && defined(WOLFSSL_DTLS)
     int sd = socket(PF_INET, SOCK_STREAM, IPPROTO_SCTP);
 

--- a/examples/sctp/sctp-client.c
+++ b/examples/sctp/sctp-client.c
@@ -38,8 +38,10 @@
 #include <unistd.h>
 #endif /* WOLFSSL_SCTP */
 
-int main()
+int main(int argc, char **argv)
 {
+    (void)argc;
+    (void)argv;
 #ifdef WOLFSSL_SCTP
     int sd = socket(PF_INET, SOCK_STREAM, IPPROTO_SCTP);
 

--- a/examples/sctp/sctp-server-dtls.c
+++ b/examples/sctp/sctp-server-dtls.c
@@ -49,8 +49,10 @@ static int err_sys(const char* msg)
 }
 #endif /* WOLFSSL_SCTP && WOLFSSL_DTLS */
 
-int main()
+int main(int argc, char **argv)
 {
+    (void)argc;
+    (void)argv;
 #if defined(WOLFSSL_SCTP) && defined(WOLFSSL_DTLS)
     int sd = socket(PF_INET, SOCK_STREAM, IPPROTO_SCTP);
 

--- a/examples/sctp/sctp-server.c
+++ b/examples/sctp/sctp-server.c
@@ -36,8 +36,10 @@
 #include <unistd.h>
 #endif /* WOLFSSL_SCTP */
 
-int main()
+int main(int argc, char **argv)
 {
+    (void)argc;
+    (void)argv;
 #ifdef WOLFSSL_SCTP
     int sd = socket(PF_INET, SOCK_STREAM, IPPROTO_SCTP);
 


### PR DESCRIPTION
# Description

Template for building FIPS v5 ready with `user_settings.h`.
Fixes ZD 13538

# Testing

```sh
./fips-check.sh linuxv5-dev keep
cd XXX-fips-test
cp ../examples/configs/user_settings_fipsv5.h user_settings.h
./configure --enable-fips=v5-dev --enable-usersettings
make
./fips-hash.sh
make
make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [X] updated appropriate READMEs
 - [ ] Updated manual and documentation
