### PR TITLE
Expose Sequence Numbers so that Linux TLS (kTLS) can be configured

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4053,6 +4053,20 @@ int wolfSSL_GetHmacSize(WOLFSSL* ssl)
     return BAD_FUNC_ARG;
 }
 
+#ifdef WORD64_AVAILABLE
+int wolfSSL_GetPeerSequenceNumber(WOLFSSL* ssl, word64 *seq)
+{
+    return ssl ? !(*seq = (word64)ssl->keys.peer_sequence_number_hi << 32 |
+                ssl->keys.peer_sequence_number_lo) : BAD_FUNC_ARG;
+}
+
+int wolfSSL_GetSequenceNumber(WOLFSSL* ssl, word64 *seq)
+{
+    return ssl ? !(*seq = (word64)ssl->keys.sequence_number_hi << 32 |
+            ssl->keys.sequence_number_lo) : BAD_FUNC_ARG;
+}
+#endif
+
 #endif /* ATOMIC_USER */
 
 #ifndef NO_CERTS

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -3013,6 +3013,10 @@ WOLFSSL_API int                  wolfSSL_GetCipherBlockSize(WOLFSSL* ssl);
 WOLFSSL_API int                  wolfSSL_GetAeadMacSize(WOLFSSL* ssl);
 WOLFSSL_API int                  wolfSSL_GetHmacSize(WOLFSSL* ssl);
 WOLFSSL_API int                  wolfSSL_GetHmacType(WOLFSSL* ssl);
+#ifdef WORD64_AVAILABLE
+WOLFSSL_API int                  wolfSSL_GetPeerSequenceNumber(WOLFSSL* ssl, word64* seq);
+WOLFSSL_API int                  wolfSSL_GetSequenceNumber(WOLFSSL* ssl, word64* seq);
+#endif
 WOLFSSL_API int                  wolfSSL_GetCipherType(WOLFSSL* ssl);
 WOLFSSL_API int                  wolfSSL_SetTlsHmacInner(WOLFSSL* ssl,
                                byte* inner, word32 sz, int content, int verify);


### PR DESCRIPTION
# Description

Expose Sequence Numbers so that Linux Kernel TLS offload can be configured. The TLS handshake must be done with wolfSSL as currently only the symmetric encryption can be handled in the kernel.  After the TLS handshake is complete, we have all the parameters required to move the data-path to the kernel however the Sequence Numbers were not exposed by wolfSSL. This is what this patch fixes.

# Testing

Tested in our server application by using this patch and the following function after the TLS establishment. Traffic flows fine as expected. The function can be used as an example if someone wants to use Linux Kernel TLS offload with wolfSSL (at the handshake part).
```
bool vpn_server_setup_ktls(int sockfd, WOLFSSL *ssl)
{
    if (wolfSSL_GetCipherType(ssl) != WOLFSSL_AEAD_TYPE || wolfSSL_GetBulkCipher(ssl) != wolfssl_aes_gcm)
    {
        czlog_error("Cipher type is not AES-GCM");
        return false;
    }

    int key_size = wolfSSL_GetKeySize(ssl);
    int iv_size = wolfSSL_GetIVSize(ssl);

    if (key_size != TLS_CIPHER_AES_GCM_256_KEY_SIZE)
    {
        czlog_error("Invalid AES key size %d", key_size);
        return false;
    }

    if (setsockopt(sockfd, SOL_TCP, TCP_ULP, "tls", sizeof("tls")) < 0)
    {
        czlog_error("Failed to set TCP_ULP");
        return false;
    }

    RNG rng;
    if (wc_InitRng(&rng))
    {
        czlog_error("Failed to setup RNG");
        return false;
    }

    struct tls12_crypto_info_aes_gcm_256 crypto_256 = {};
    crypto_256.info.version = TLS_1_2_VERSION;
    crypto_256.info.cipher_type = TLS_CIPHER_AES_GCM_256;
    if (wc_RNG_GenerateBlock(&rng, crypto_256.iv, sizeof(crypto_256.iv)))
    {
        czlog_error("Failed to generate the IV");
        wc_FreeRng(&rng);
        return false;
    }

    // TX
    memcpy(crypto_256.key, wolfSSL_GetServerWriteKey(ssl), key_size);
    memcpy(crypto_256.salt, wolfSSL_GetServerWriteIV(ssl), iv_size);
    uint64_t tx_seq;
    wolfSSL_GetSequenceNumber(ssl, &tx_seq);
    tx_seq = htobe64(tx_seq);
    memcpy(crypto_256.rec_seq, &tx_seq, sizeof(tx_seq));

    if (setsockopt(sockfd, SOL_TLS, TLS_TX, &crypto_256, sizeof(crypto_256)) < 0)
    {
        czlog_error("setsockopt(TLS_TX) failed: %s", g_strerror(errno));
        wc_FreeRng(&rng);
        return false;
    }

    // RX
    memcpy(crypto_256.key, wolfSSL_GetClientWriteKey(ssl), key_size);
    memcpy(crypto_256.salt, wolfSSL_GetClientWriteIV(ssl), iv_size);
    uint64_t rx_seq;
    wolfSSL_GetPeerSequenceNumber(ssl, &rx_seq);
    rx_seq = htobe64(rx_seq);
    memcpy(crypto_256.rec_seq, &rx_seq, sizeof(rx_seq));

    if (setsockopt(sockfd, SOL_TLS, TLS_RX, &crypto_256, sizeof(crypto_256)) < 0)
    {
        czlog_error("setsockopt(TLS_RX) failed: %s", g_strerror(errno));
        wc_FreeRng(&rng);
        return false;
    }

    wc_FreeRng(&rng);
    return true;
}
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
