### PR TITLE
Fixes for building without HMAC

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28267,7 +28267,7 @@ WOLFSSL_ASN1_INTEGER* wolfSSL_d2i_ASN1_INTEGER(WOLFSSL_ASN1_INTEGER** a,
             }
         }
     }
-    
+
     if (err != 0) {
         wolfSSL_ASN1_INTEGER_free(ret);
         ret = NULL;
@@ -34392,7 +34392,7 @@ WOLFSSL_DH* wolfSSL_DH_get_2048_256(void)
             WOLFSSL_MSG("Error converting q hex to WOLFSSL_BIGNUM.");
             err = 1;
         }
-    }   
+    }
     if (err == 0) {
     #if defined(OPENSSL_ALL) || \
         defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
@@ -45826,7 +45826,7 @@ err:
         current = &name->entry[i];
         if (current->set == 0)
             name->entrySz++;
-        
+
         if (wolfSSL_X509_NAME_ENTRY_create_by_NID(&current,
                             entry->nid,
                             wolfSSL_ASN1_STRING_type(entry->value),
@@ -45847,7 +45847,7 @@ err:
         else {
             ret = WOLFSSL_FAILURE;
         }
-        
+
         if (ret != WOLFSSL_SUCCESS) {
             WOLFSSL_MSG("Error adding the name entry");
             if (current->set == 0)

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -344,7 +344,7 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
 #endif /* WOLFSSL_HAVE_PRF */
 
 
-#if defined(HAVE_HKDF)
+#if defined(HAVE_HKDF) && !defined(NO_HMAC)
 
     /* Extract data using HMAC, salt and input.
      * RFC 5869 - HMAC-based Extract-and-Expand Key Derivation Function (HKDF)
@@ -470,7 +470,7 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
         return ret;
     }
 
-#endif /* HAVE_HKDF */
+#endif /* HAVE_HKDF && !NO_HMAC */
 
 
 #ifdef WOLFSSL_WOLFSSH

--- a/wolfcrypt/src/pkcs12.c
+++ b/wolfcrypt/src/pkcs12.c
@@ -27,7 +27,8 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#if !defined(NO_ASN) && !defined(NO_PWDBASED) && defined(HAVE_PKCS12)
+#if defined(HAVE_PKCS12) && \
+    !defined(NO_ASN) && !defined(NO_PWDBASED) && !defined(NO_HMAC)
 
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
@@ -2491,4 +2492,4 @@ void* wc_PKCS12_GetHeap(WC_PKCS12* pkcs12)
 
 #undef ERROR_OUT
 
-#endif /* !NO_ASN && !NO_PWDBASED && HAVE_PKCS12 */
+#endif /* HAVE_PKCS12 && !NO_ASN && !NO_PWDBASED && !NO_HMAC */

--- a/wolfcrypt/src/pwdbased.c
+++ b/wolfcrypt/src/pwdbased.c
@@ -171,7 +171,7 @@ int wc_PBKDF1(byte* output, const byte* passwd, int pLen, const byte* salt,
 
 #endif /* HAVE_PKCS5 */
 
-#ifdef HAVE_PBKDF2
+#if defined(HAVE_PBKDF2) && !defined(NO_HMAC)
 
 int wc_PBKDF2_ex(byte* output, const byte* passwd, int pLen, const byte* salt,
            int sLen, int iterations, int kLen, int hashType, void* heap, int devId)
@@ -279,7 +279,7 @@ int wc_PBKDF2(byte* output, const byte* passwd, int pLen, const byte* salt,
         hashType, NULL, INVALID_DEVID);
 }
 
-#endif /* HAVE_PBKDF2 */
+#endif /* HAVE_PBKDF2 && !NO_HMAC */
 
 #ifdef HAVE_PKCS12
 

--- a/wolfssl/openssl/compat_types.h
+++ b/wolfssl/openssl/compat_types.h
@@ -30,12 +30,14 @@
 #include <wolfssl/wolfcrypt/types.h>
 #include <wolfssl/wolfcrypt/hmac.h>
 
+#ifndef NO_HMAC
 typedef struct WOLFSSL_HMAC_CTX {
     Hmac hmac;
     int  type;
     word32  save_ipad[WC_HMAC_BLOCK_SIZE  / sizeof(word32)];  /* same block size all*/
     word32  save_opad[WC_HMAC_BLOCK_SIZE  / sizeof(word32)];
 } WOLFSSL_HMAC_CTX;
+#endif
 
 typedef char   WOLFSSL_EVP_MD;
 typedef struct WOLFSSL_EVP_PKEY     WOLFSSL_EVP_PKEY;

--- a/wolfssl/openssl/hmac.h
+++ b/wolfssl/openssl/hmac.h
@@ -21,7 +21,7 @@
 
 
 
-/*  hmac.h defines mini hamc openssl compatibility layer
+/*  hmac.h defines mini hmac openssl compatibility layer
  *
  */
 

--- a/wolfssl/wolfcrypt/hmac.h
+++ b/wolfssl/wolfcrypt/hmac.h
@@ -23,12 +23,12 @@
     \file wolfssl/wolfcrypt/hmac.h
 */
 
-#ifndef NO_HMAC
-
 #ifndef WOLF_CRYPT_HMAC_H
 #define WOLF_CRYPT_HMAC_H
 
 #include <wolfssl/wolfcrypt/hash.h>
+
+#ifndef NO_HMAC
 
 #if defined(HAVE_FIPS) && \
         (!defined(HAVE_FIPS_VERSION) || (HAVE_FIPS_VERSION < 2))
@@ -223,7 +223,5 @@ WOLFSSL_API int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
     } /* extern "C" */
 #endif
 
-#endif /* WOLF_CRYPT_HMAC_H */
-
 #endif /* NO_HMAC */
-
+#endif /* WOLF_CRYPT_HMAC_H */


### PR DESCRIPTION
# Description

Fixes for building with without HMAC support in wolfCrypt only. Also fixes some trailing whitespace.

Fixes ZD 13477

# Testing

`./configure --enable-opensslextra --enable-cryptonly CFLAGS="-DNO_HMAC" && make`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
