### PR TITLE
Improve the client certificate checking logic

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -11101,7 +11101,7 @@ int InitSigPkCb(WOLFSSL* ssl, SignatureCtx* sigCtx)
 
 
 #if !defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)
-static void DoCertFatalAlert(WOLFSSL* ssl, int ret)
+void DoCertFatalAlert(WOLFSSL* ssl, int ret)
 {
     int alertWhy;
     if (ssl == NULL || ret == 0) {
@@ -31519,7 +31519,8 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                 }
 
             #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_CLIENT_AUTH)
-                if (ssl->options.verifyPeer && ssl->options.failNoCert) {
+                if (ssl->options.verifyPeer &&
+                         (ssl->options.mutualAuth || ssl->options.failNoCert)) {
                     if (!ssl->options.havePeerCert) {
                         WOLFSSL_MSG("client didn't present peer cert");
                         ERROR_OUT(NO_PEER_CERT, exit_dcke);
@@ -31530,7 +31531,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                     if (!ssl->options.havePeerCert &&
                                              !ssl->options.usingPSK_cipher) {
                         WOLFSSL_MSG("client didn't present peer cert");
-                        return NO_PEER_CERT;
+                        ERROR_OUT(NO_PEER_CERT, exit_dcke);
                     }
                 }
             #endif /* !NO_CERTS && !WOLFSSL_NO_CLIENT_AUTH */

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -71,6 +71,8 @@
  *    You cannot use wc_psk_client_cs_callback type callback on client.
  * WOLFSSL_CHECK_ALERT_ON_ERR
  *    Check for alerts during the handshake in the event of an error.
+ * WOLFSSL_NO_CLIENT_CERT_ERROR
+ *    Requires client to set a client certificate
  */
 
 #ifdef HAVE_CONFIG_H
@@ -6892,10 +6894,11 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_CLIENT_AUTH)
     /* verify the client sent certificate if required */
-    if (ssl->options.side == WOLFSSL_SERVER_END &&
+    if (ssl->options.side == WOLFSSL_SERVER_END && !ssl->options.resuming &&
             (ssl->options.mutualAuth || ssl->options.failNoCert)) {
-        if (!ssl->options.havePeerVerify && !ssl->options.resuming) {
-            ret = NO_PEER_CERT;
+        if (!ssl->options.havePeerCert || !ssl->options.havePeerVerify) {
+            ret = NO_PEER_CERT; /* NO_PEER_VERIFY */
+            WOLFSSL_MSG("TLS v1.3 client did not present peer cert");
             DoCertFatalAlert(ssl, ret);
             return ret;
         }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -6890,6 +6890,18 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     WOLFSSL_START(WC_FUNC_FINISHED_DO);
     WOLFSSL_ENTER("DoTls13Finished");
 
+#if !defined(NO_CERTS) && !defined(WOLFSSL_NO_CLIENT_AUTH)
+    /* verify the client sent certificate if required */
+    if (ssl->options.side == WOLFSSL_SERVER_END &&
+            (ssl->options.mutualAuth || ssl->options.failNoCert)) {
+        if (!ssl->options.havePeerVerify && !ssl->options.resuming) {
+            ret = NO_PEER_CERT;
+            DoCertFatalAlert(ssl, ret);
+            return ret;
+        }
+    }
+#endif
+
     /* check against totalSz */
     if (*inOutIdx + size + ssl->keys.padSz > totalSz)
         return BUFFER_E;

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4839,7 +4839,9 @@ WOLFSSL_LOCAL int  BuildTlsFinished(WOLFSSL* ssl, Hashes* hashes,
 WOLFSSL_LOCAL void FreeArrays(WOLFSSL* ssl, int keep);
 WOLFSSL_LOCAL  int CheckAvailableSize(WOLFSSL *ssl, int size);
 WOLFSSL_LOCAL  int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength);
-
+#if !defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH)
+WOLFSSL_LOCAL void DoCertFatalAlert(WOLFSSL* ssl, int ret);
+#endif
 #ifndef NO_TLS
     WOLFSSL_LOCAL int  MakeTlsMasterSecret(WOLFSSL* ssl);
 #ifndef WOLFSSL_AEAD_ONLY


### PR DESCRIPTION
# Description

Improve client certificate checking. Make sure wolfSSL_CTX_mutual_auth` is also checked.

Fixes zd13571

# Testing

New test cases to come later.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
