### PR TITLE
SP C: when sp_c32.c ad sp_c64.c are included in build changed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -184,9 +184,9 @@ then
 fi
 
 AC_ARG_ENABLE([64bit],
-    [AS_HELP_STRING([--enable-64bit],[Enables 64-bit support (default: enabled)])],
+    [AS_HELP_STRING([--enable-64bit],[Enables 64-bit support (default: disabled)])],
     [ ENABLED_64BIT=$enableval ],
-    [ ENABLED_64BIT=yes ]
+    [ ENABLED_64BIT=no ]
     )
 
 AC_ARG_ENABLE([kdf],
@@ -5913,6 +5913,9 @@ AS_IF([test "x$ENABLED_INTEL_QA" = "xyes" || test "x$ENABLED_INTEL_QA_SYNC" = "x
      CPPFLAGS="$OLD_CPPFLAGS"
 ])
 
+################################################################################
+# Single Precision option handling                                             #
+################################################################################
 
 ENABLED_SP_RSA=no
 ENABLED_SP_DH=no
@@ -6159,7 +6162,7 @@ fi
 
 if test "$ENABLED_SP_MATH" = "yes"; then
     if test "$ENABLED_SP" = "no"; then
-        AC_MSG_ERROR([Must have SP enabled: --enable-sp])
+        AC_MSG_ERROR([Must have SP enabled with SP math: --enable-sp])
     fi
     if test "$ENABLED_ECCCUSTCURVES" = "yes"; then
         AC_MSG_ERROR([Cannot use single precision math and custom curves])
@@ -6222,8 +6225,6 @@ if test "$ENABLED_SP_MATH_ALL" = "yes"; then
 
   ENABLED_FASTMATH="no"
   ENABLED_SLOWMATH="no"
-  ENABLED_SP="yes"
-  #ENABLED_SP_MATH="yes"
 
   AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_MATH_ALL"
 
@@ -6273,10 +6274,7 @@ if test "$ENABLED_SP_MATH_ALL" = "yes"; then
 fi
 
 
-if test "$ENABLED_SP_ASM" = "yes"; then
-  if test "$ENABLED_SP" = "no"; then
-    AC_MSG_ERROR([Must have SP enabled: --enable-sp])
-  fi
+if test "$ENABLED_SP_ASM" = "yes" && test "$ENABLED_SP" = "yes"; then
   if test "$ENABLED_SP_NONBLOCK" = "yes"; then
     AC_MSG_ERROR([SP non-blocking not supported with sp-asm])
   fi
@@ -6330,6 +6328,9 @@ if test "$ENABLED_SP_MATH" = "yes"; then
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_SP_MATH"
 fi
 
+################################################################################
+# End - Single Precision option handling                                       #
+################################################################################
 
 # Fast RSA using Intel IPP
 ippdir="${srcdir}/IPP"
@@ -7038,6 +7039,22 @@ AS_IF([test "x$ENABLED_ED25519_STREAM" = "xyes" && \
        test "x$ENABLED_ED25519" = "xno"],
       [AC_MSG_ERROR([ED25519 verify streaming enabled but ED25519 is disabled])])
 
+# Ensure only one size is enabled
+AS_IF([test "x$ENABLED_64BIT" = "xyes" && \
+       test "x$ENABLED_32BIT" = "xyes"],
+      [AC_MSG_ERROR([cannot specify 64-bit build and 32-bit build.])])
+AS_IF([test "x$ENABLED_64BIT" = "xyes" && \
+       test "x$ENABLED_16BIT" = "xyes"],
+      [AC_MSG_ERROR([cannot specify 64-bit build and 16-bit build.])])
+AS_IF([test "x$ENABLED_32BIT" = "xyes" && \
+       test "x$ENABLED_16BIT" = "xyes"],
+      [AC_MSG_ERROR([cannot specify 32-bit build and 16-bit build.])])
+
+# 16-bit build not supported with SP
+AS_IF([test "x$ENABLED_16BIT" = "xyes" && \
+       test "x$ENABLED_SP" = "xyes"],
+      [AC_MSG_ERROR([16-bit build not available with SP.])])
+
 ################################################################################
 # Update CFLAGS based on options                                               #
 ################################################################################
@@ -7553,10 +7570,10 @@ AM_CONDITIONAL([BUILD_INTEL_QA_SYNC],[test "x$ENABLED_INTEL_QA_SYNC" = "xyes"])
 AM_CONDITIONAL([BUILD_SP],[test "x$ENABLED_SP" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_SP_C32],[(((test "$ENABLED_SP_RSA" = "yes" || test "$ENABLED_SP_DH" = "yes" \
                                || test "$ENABLED_SP_ECC" = "yes") && test "x$ENABLED_SP_ASM" = "xno") \
-                             || test "x$ENABLED_USERSETTINGS" = "xyes") && test "x$ENABLED_32BIT" = "xyes"])
+                             || test "x$ENABLED_USERSETTINGS" = "xyes") && test "x$ENABLED_64BIT" != "xyes"])
 AM_CONDITIONAL([BUILD_SP_C64],[(((test "$ENABLED_SP_RSA" = "yes" || test "$ENABLED_SP_DH" = "yes" \
                                || test "$ENABLED_SP_ECC" = "yes") && test "x$ENABLED_SP_ASM" = "xno") \
-                             || test "x$ENABLED_USERSETTINGS" = "xyes") && test "x$ENABLED_64BIT" = "xyes"])
+                             || test "x$ENABLED_USERSETTINGS" = "xyes") && test "x$ENABLED_32BIT" != "xyes"])
 AM_CONDITIONAL([BUILD_SP_ARM64],[test "x$ENABLED_SP_ARM64_ASM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_SP_ARM32],[test "x$ENABLED_SP_ARM32_ASM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
 AM_CONDITIONAL([BUILD_SP_ARM_THUMB],[test "x$ENABLED_SP_ARM_THUMB_ASM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])

--- a/src/include.am
+++ b/src/include.am
@@ -435,13 +435,13 @@ if BUILD_SP_ARM64
 src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_arm64.c
 endif
 endif
-if BUILD_SP_INT
-src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_int.c
-endif
 if BUILD_SP_ARM_CORTEX
 src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_cortexm.c
 endif
 endif BUILD_SP
+if BUILD_SP_INT
+src_libwolfssl_la_SOURCES += wolfcrypt/src/sp_int.c
+endif
 
 if !BUILD_FIPS_CURRENT
 if BUILD_AES


### PR DESCRIPTION
# Description

When compiling with the CFLAG -m32, sp_c32.c is used and not sp_c64.c.
The build system cannot detect that this is a 32-bit platform and to use
sp_c32.c.

The SP code detects which implementaiton to use and sets defines that
enable the code in sp_c32.c or sp_c64.c.

ENABLED_64BIT, 64-bit platform, was on by default, which is not always
true.
By making ENABLED_64BIT not default then the decision of which SP C
files to include in the build had to change to not being the other.
That is, sp_c64.c is not included when the configuration line explicitly
enables 32bit and sp_c32.c is not include when the configuration line
explicitly enables 64bit.

F0ixes Issue #4385

# Testing

Tested --enable-sp --enable-sp-math CFLAGS="-m32" with and without --enable-32bit.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
