### PR TITLE
Rework functions to avoid warning with g++

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4057,14 +4057,22 @@ int wolfSSL_GetHmacSize(WOLFSSL* ssl)
 #ifdef WORD64_AVAILABLE
 int wolfSSL_GetPeerSequenceNumber(WOLFSSL* ssl, word64 *seq)
 {
-    return ssl ? !(*seq = (word64)ssl->keys.peer_sequence_number_hi << 32 |
-                ssl->keys.peer_sequence_number_lo) : BAD_FUNC_ARG;
+    if ((ssl == NULL) || (seq == NULL))
+        return BAD_FUNC_ARG;
+
+    *seq = ((word64)ssl->keys.peer_sequence_number_hi << 32) |
+                    ssl->keys.peer_sequence_number_lo;
+    return !(*seq);
 }
 
 int wolfSSL_GetSequenceNumber(WOLFSSL* ssl, word64 *seq)
 {
-    return ssl ? !(*seq = (word64)ssl->keys.sequence_number_hi << 32 |
-            ssl->keys.sequence_number_lo) : BAD_FUNC_ARG;
+    if ((ssl == NULL) || (seq == NULL))
+        return BAD_FUNC_ARG;
+
+    *seq = ((word64)ssl->keys.sequence_number_hi << 32) |
+                    ssl->keys.sequence_number_lo;
+    return !(*seq);
 }
 #endif
 


### PR DESCRIPTION
# Description

Rework functions to avoid warning with g++.

Fixes Jenikins failure.

# Testing

Built with g++.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
