### PR TITLE
20220208 clang-tidy-15 fixes etc.

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -25347,7 +25347,8 @@ static int test_wc_ecc_pointFns (void)
     if (ret == 0) {
         ret = wc_ecc_import_point_der(der, derSz, idx, point);
         /* Condition double checks wc_ecc_cmp_point().  */
-        if (ret == 0 && XMEMCMP(&key.pubkey, point, sizeof(key.pubkey))) {
+        if (ret == 0 &&
+            XMEMCMP((void *)&key.pubkey, (void *)point, sizeof(key.pubkey))) {
             ret = wc_ecc_cmp_point(&key.pubkey, point);
         }
     }
@@ -52055,7 +52056,6 @@ static void test_openssl_FIPS_drbg(void)
     AssertIntEQ(FIPS_drbg_set_callbacks(dctx, NULL, NULL, 20, NULL, NULL),
         WOLFSSL_SUCCESS);
     AssertIntEQ(FIPS_drbg_instantiate(dctx, NULL, 0), WOLFSSL_SUCCESS);
-    
     AssertIntEQ(FIPS_drbg_generate(dctx, data1, dlen, 0, NULL, 0),
         WOLFSSL_SUCCESS);
     AssertIntNE(XMEMCMP(data1, zeroData, dlen), 0);

--- a/tests/suites.c
+++ b/tests/suites.c
@@ -321,7 +321,7 @@ static int execute_test_case(int svr_argc, char** svr_argv,
     size_t      added;
     static      int tests = 1;
 #if !defined(USE_WINDOWS_API) && !defined(WOLFSSL_TIRTOS)
-    char        portNumber[8];
+    static char portNumber[8];
 #endif
     int         cliTestShouldFail = 0, svrTestShouldFail = 0;
 #ifdef WOLFSSL_NO_CLIENT_AUTH

--- a/wolfssl/openssl/fips_rand.h
+++ b/wolfssl/openssl/fips_rand.h
@@ -54,11 +54,11 @@ typedef struct WOLFSSL_DRBG_CTX {
     void* app_data;
 } WOLFSSL_DRBG_CTX;
 
-#define	DRBG_FLAG_CTR_USE_DF 0x1
-#define	DRBG_FLAG_TEST       0x2
+#define DRBG_FLAG_CTR_USE_DF 0x1
+#define DRBG_FLAG_TEST       0x2
 
-#define	DRBG_FLAG_NOERR      0x1
-#define	DRBG_CUSTOM_RESEED   0x2
+#define DRBG_FLAG_NOERR      0x1
+#define DRBG_CUSTOM_RESEED   0x2
 
 #define DRBG_STATUS_UNINITIALISED 0
 #define DRBG_STATUS_READY         1


### PR DESCRIPTION
fixes for whitespace, C++ warnings, and LLVM 15 clang-tidy defects/carps:

* whitespace in src/ssl.c, tests/api.c, wolfssl/openssl/fips_rand.h.

* "enumerated and non-enumerated type in conditional expression" in src/ssl.c:`wolfSSL_GetPeerSequenceNumber()` and `wolfSSL_GetSequenceNumber()`.

* clang-analyzer-core.StackAddressEscape from llvm-15 clang-tidy, in tests/suites.c:`execute_test_case()`.

* bugprone-suspicious-memory-comparison from llvm-15 clang-tidy, in src/internal.c:`DoSessionTicket()` and src/ssl.c:`wolfSSL_sk_push()`.
