### PR TITLE
ARMASM, SHA-3: fixup when not using crypto instructions

### DIFF
--- a/wolfcrypt/src/sha3.c
+++ b/wolfcrypt/src/sha3.c
@@ -51,7 +51,7 @@
 #endif
 
 
-#ifndef WOLFSSL_ARMASM
+#if !defined(WOLFSSL_ARMASM) || !defined(WOLFSSL_ARMASM_CRYPTO_SHA3)
 #ifdef WOLFSSL_SHA3_SMALL
 /* Rotate a 64-bit value left.
  *

--- a/wolfssl/wolfcrypt/sha3.h
+++ b/wolfssl/wolfcrypt/sha3.h
@@ -128,7 +128,7 @@ struct wc_Sha3 {
 typedef wc_Sha3 wc_Shake;
 #endif
 
-#ifdef WOLFSSL_ARMASM
+#if defined(WOLFSSL_ARMASM) && defined(WOLFSSL_ARMASM_CRYPTO_SHA3)
 WOLFSSL_LOCAL void BlockSha3(word64 *s);
 #endif
 


### PR DESCRIPTION
# Description

Fixes builds with SHA-3 and ARM assembly but not using crypto instructions.

Fixes Jenkins failure.

# Testing

Tested both with and without the SHA-3 crypto assembly being used.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
