### PR TITLE
Implement FIPS_mode and FIPS_mode_set in the compat layer.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -48636,26 +48636,31 @@ void wolfSSL_ERR_load_crypto_strings(void)
     return;
 }
 
-#ifndef NO_WOLFSSL_STUB
 int wolfSSL_FIPS_mode(void)
 {
-    WOLFSSL_ENTER("wolfSSL_FIPS_mode");
-    WOLFSSL_STUB("FIPS_mode");
-
-    return WOLFSSL_FAILURE;
-}
+#ifdef HAVE_FIPS
+    return 1;
+#else
+    return 0;
 #endif
+}
 
-#ifndef NO_WOLFSSL_STUB
 int wolfSSL_FIPS_mode_set(int r)
 {
-    (void)r;
-    WOLFSSL_ENTER("wolfSSL_FIPS_mode_set");
-    WOLFSSL_STUB("FIPS_mode_set");
-
+#ifdef HAVE_FIPS
+    if (r == 0) {
+        WOLFSSL_MSG("Cannot disable FIPS at runtime.");
+        return WOLFSSL_FAILURE;
+    }
+    return WOLFSSL_SUCCESS;
+#else
+    if (r == 0) {
+        return WOLFSSL_SUCCESS;
+    }
+    WOLFSSL_MSG("Cannot enable FIPS. This isn't the wolfSSL FIPS code.");
     return WOLFSSL_FAILURE;
-}
 #endif
+}
 
 int wolfSSL_CIPHER_get_bits(const WOLFSSL_CIPHER *c, int *alg_bits)
 {

--- a/tests/api.c
+++ b/tests/api.c
@@ -52071,7 +52071,24 @@ static void test_openssl_FIPS_drbg(void)
 #endif
 }
 
+static void test_wolfSSL_FIPS_mode(void)
+{
+#if defined(OPENSSL_ALL)
+    printf(testingFmt, "test_wolfSSL_FIPS_mode()");
 
+#ifdef HAVE_FIPS
+    AssertIntEQ(wolfSSL_FIPS_mode(), 1);
+    AssertIntEQ(wolfSSL_FIPS_mode_set(0), WOLFSSL_FAILURE);
+    AssertIntEQ(wolfSSL_FIPS_mode_set(1), WOLFSSL_SUCCESS);
+#else
+    AssertIntEQ(wolfSSL_FIPS_mode(), 0);
+    AssertIntEQ(wolfSSL_FIPS_mode_set(0), WOLFSSL_SUCCESS);
+    AssertIntEQ(wolfSSL_FIPS_mode_set(1), WOLFSSL_FAILURE);
+#endif
+
+    printf(resultFmt, passed);
+#endif
+}
 
 /*----------------------------------------------------------------------------*
  | Main
@@ -52933,6 +52950,7 @@ void ApiTest(void)
     test_openssl_FIPS_drbg();
     test_wc_CryptoCb();
     test_wolfSSL_CTX_StaticMemory();
+    test_wolfSSL_FIPS_mode();
 
     AssertIntEQ(test_ForceZero(), 0);
 


### PR DESCRIPTION
# Description

This adds compatibility layer functions for `FIPS_mode` and `FIPS_mode_set`. Because wolfSSL FIPS is purely a compile-time thing (i.e. there is no runtime mechanism for enabling/disabling a FIPS "mode"), `wolfSSL_FIPS_mode` simply returns 1 if using the FIPS code and 0 otherwise. Calling `wolfSSL_FIPS_mode_set` to enable FIPS returns success if it's the FIPS code and failure otherwise. Likewise, calling `wolfSSL_FIPS_mode_set` to _disable_ FIPS returns success if it's NOT the FIPS code and failure otherwise.

ZD 13538

# Testing

I added a unit test.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
