### PR TITLE
automake: fix fips touch and cleanup

### DIFF
--- a/src/include.am
+++ b/src/include.am
@@ -2,47 +2,22 @@
 # included from Top Level Makefile.am
 # All paths should be given relative to the root
 
-BUILT_SOURCES+= ctaocrypt/src/fips.c
-BUILT_SOURCES+= ctaocrypt/src/fips_test.c
-BUILT_SOURCES+= wolfcrypt/src/async.c
-BUILT_SOURCES+= wolfcrypt/src/fips.c
-BUILT_SOURCES+= wolfcrypt/src/fips_test.c
-BUILT_SOURCES+= wolfcrypt/src/selftest.c
-BUILT_SOURCES+= wolfcrypt/src/wolfcrypt_first.c
-BUILT_SOURCES+= wolfcrypt/src/wolfcrypt_last.c
+FIPS_FILES =					\
+	ctaocrypt/src/fips.c			\
+	ctaocrypt/src/fips_test.c		\
+	wolfcrypt/src/async.c			\
+	wolfcrypt/src/fips.c			\
+	wolfcrypt/src/fips_test.c		\
+	wolfcrypt/src/selftest.c		\
+	wolfcrypt/src/wolfcrypt_first.c		\
+	wolfcrypt/src/wolfcrypt_last.c
 
-MAINTAINERCLEANFILES+= ctaocrypt/src/fips.c
-MAINTAINERCLEANFILES+= ctaocrypt/src/fips_test.c
-MAINTAINERCLEANFILES+= wolfcrypt/src/async.c
-MAINTAINERCLEANFILES+= wolfcrypt/src/fips.c
-MAINTAINERCLEANFILES+= wolfcrypt/src/fips_test.c
-MAINTAINERCLEANFILES+= wolfcrypt/src/selftest.c
-MAINTAINERCLEANFILES+= wolfcrypt/src/wolfcrypt_first.c
-MAINTAINERCLEANFILES+= wolfcrypt/src/wolfcrypt_last.c
+BUILT_SOURCES+= $(FIPS_FILES)
 
-ctaocrypt/src/fips.c: Makefile
-	@test -e $(srcdir)/$@ || touch $(srcdir)/$@
+MAINTAINERCLEANFILES+= $(FIPS_FILES)
 
-ctaocrypt/src/fips_test.c: Makefile
-	@test -e $(srcdir)/$@ || touch $(srcdir)/$@
-
-wolfcrypt/src/async.c: Makefile
-	@test -e $(srcdir)/$@ || touch $(srcdir)/$@
-
-wolfcrypt/src/fips.c: Makefile
-	@test -e $(srcdir)/$@ || touch $(srcdir)/$@
-
-wolfcrypt/src/fips_test.c: Makefile
-	@test -e $(srcdir)/$@ || touch $(srcdir)/$@
-
-wolfcrypt/src/selftest.c: Makefile
-	@test -e $(srcdir)/$@ || touch $(srcdir)/$@
-
-wolfcrypt/src/wolfcrypt_first.c: Makefile
-	@test -e $(srcdir)/$@ || touch $(srcdir)/$@
-
-wolfcrypt/src/wolfcrypt_last.c: Makefile
-	@test -e $(srcdir)/$@ || touch $(srcdir)/$@
+$(FIPS_FILES):
+	$(AM_V_at)touch $(srcdir)/$@
 
 if !BUILD_NO_LIBRARY
 lib_LTLIBRARIES+= src/libwolfssl.la

--- a/wolfcrypt/src/include.am
+++ b/wolfcrypt/src/include.am
@@ -1,13 +1,14 @@
 # vim:ft=automake
 # All paths should be given relative to the root
 
-BUILT_SOURCES+= wolfcrypt/src/port/cavium/cavium_nitrox.c
-BUILT_SOURCES+= wolfcrypt/src/port/intel/quickassist.c
-BUILT_SOURCES+= wolfcrypt/src/port/intel/quickassist_mem.c
+ASYNC_FILES =						\
+	wolfcrypt/src/port/cavium/cavium_nitrox.c	\
+	wolfcrypt/src/port/intel/quickassist.c		\
+	wolfcrypt/src/port/intel/quickassist_mem.c
 
-MAINTAINERCLEANFILES+= wolfcrypt/src/port/cavium/cavium_nitrox.c
-MAINTAINERCLEANFILES+= wolfcrypt/src/port/intel/quickassist.c
-MAINTAINERCLEANFILES+= wolfcrypt/src/port/intel/quickassist_mem.c
+BUILT_SOURCES+= $(ASYNC_FILES)
+
+MAINTAINERCLEANFILES+= $(ASYNC_FILES)
 
 EXTRA_DIST += src/bio.c
 EXTRA_DIST += wolfcrypt/src/misc.c
@@ -118,14 +119,8 @@ EXTRA_DIST += wolfcrypt/src/port/ti/ti-aes.c \
               wolfcrypt/src/port/Renesas/README.md \
               wolfcrypt/src/port/cypress/psoc6_crypto.c
 
-wolfcrypt/src/port/cavium/cavium_nitrox.c: Makefile
-	@test -e $(srcdir)/$@ || touch $(srcdir)/$@
-
-wolfcrypt/src/port/intel/quickassist.c: Makefile
-	@test -e $(srcdir)/$@ || touch $(srcdir)/$@
-
-wolfcrypt/src/port/intel/quickassist_mem.c: Makefile
-	@test -e $(srcdir)/$@ || touch $(srcdir)/$@
+$(ASYNC_FILES):
+	$(AM_V_at)touch $(srcdir)/$@
 
 if BUILD_CRYPTOCB
 src_libwolfssl_la_SOURCES += wolfcrypt/src/cryptocb.c


### PR DESCRIPTION
# Description

This fixes an issue with yocto that only occurs when using `devtool`
which builds out of tree.

Fixes zd13290

# Testing

Tested in yocto
```
devtool modify wolfssl
bitbake -v wolfssl
# for debug cd to build tree
#make -d --trace  install  | less
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
