### PR TITLE
Reported in ZD13631

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -12340,6 +12340,9 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             }
 
                             ret = 0; /* clear errors and continue */
+                    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+                            ssl->peerVerifyRet = 0;
+                    #endif
                             args->verifyErr = 0;
                         }
 


### PR DESCRIPTION
`ssl->peerVerifyRet` wasn't being cleared when retrying with an alternative cert chain