### PR TITLE
SILABS port: fix sizeof

### DIFF
--- a/wolfcrypt/src/port/silabs/silabs_aes.c
+++ b/wolfcrypt/src/port/silabs/silabs_aes.c
@@ -48,7 +48,7 @@ int wc_AesSetKey(Aes* aes, const byte* userKey, word32 keylen,
         return BUFFER_E;
     }
 
-    XMEMSET(aes, 0, sizeof(aes));
+    XMEMSET(aes, 0, sizeof(*aes));
 
     if (keylen > sizeof(aes->key)) {
         return BAD_FUNC_ARG;


### PR DESCRIPTION
# Description

A sizeof wasn't dereferencing a pointer using the sizeof the pointer and not the actual struct. This is limited to setting the key for an AES operation only when using SILABS SE2 acceleration.

# Testing

Visual inspection.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
