### PR TITLE
tls13: fix not including RENEGOTIATION_INFO ext

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4257,8 +4257,10 @@ then
 fi
 
 # Renegotiation Indication - (FAKE Secure Renegotiation)
+# Client will send TLS_EMPTY_RENEGOTIATION_INFO_SCSV, not supported
+# with enabling secure renegotiation
 AC_ARG_ENABLE([renegotiation-indication],
-    [AS_HELP_STRING([--enable-renegotiation-indication],[Enable Renegotiation Indication (default: disabled)])],
+    [AS_HELP_STRING([--enable-renegotiation-indication],[Enable Renegotiation Indication for client via empty cipher  (default: disabled)])],
     [ ENABLED_RENEGOTIATION_INDICATION=$enableval ],
     [ ENABLED_RENEGOTIATION_INDICATION=no ]
     )

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -3125,7 +3125,7 @@ static int _Rehandshake(WOLFSSL* ssl)
                 return WOLFSSL_FATAL_ERROR;
             }
         }
-#endif /* NO_WOLFSSL_SERVER && HAVE_SERVER_RENEGOTIATION_INFO */
+#endif /* !NO_WOLFSSL_SERVER && HAVE_SECURE_RENEGOTIATION */
 
         ret = InitHandshakeHashes(ssl);
         if (ret != 0) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -4997,7 +4997,7 @@ int TLSX_AddEmptyRenegotiationInfo(TLSX** extensions, void* heap)
 #define SCR_WRITE(a, b, c)    0
 #define SCR_PARSE(a, b, c, d) 0
 
-#endif /* HAVE_SECURE_RENEGOTIATION */
+#endif /* HAVE_SECURE_RENEGOTIATION || HAVE_SERVER_RENEGOTIATION_INFO */
 
 /******************************************************************************/
 /* Session Tickets                                                            */
@@ -11107,7 +11107,7 @@ int TLSX_GetResponseSize(WOLFSSL* ssl, byte msgType, word16* pLength)
         #ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_STATUS_REQUEST_V2));
         #endif
-        #if defined(HAVE_SECURE_RENEGOTIATION)
+        #if defined(HAVE_SERVER_RENEGOTIATION_INFO)
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_RENEGOTIATION_INFO));
         #endif
             break;
@@ -11233,7 +11233,7 @@ int TLSX_WriteResponse(WOLFSSL *ssl, byte* output, byte msgType, word16* pOffset
         #ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_STATUS_REQUEST_V2));
         #endif
-        #if defined(HAVE_SECURE_RENEGOTIATION)
+        #if defined(HAVE_SERVER_RENEGOTIATION_INFO)
             TURN_ON(semaphore, TLSX_ToSemaphore(TLSX_RENEGOTIATION_INFO));
         #endif
                 break;
@@ -11561,7 +11561,7 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
                 WOLFSSL_BUFFER(input + offset, size);
             #endif
 
-#if defined(WOLFSSL_TLS13) && defined(HAVE_SECURE_RENEGOTIATION)
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SERVER_RENEGOTIATION_INFO)
                 if (IsAtLeastTLSv1_3(ssl->version))
                     break;
 #endif


### PR DESCRIPTION
# Description

TLS13 was sending the`renegoitation_info` extension in encrypted extensions.

Bug introduced in #4742

# Testing

```
# was failing before
gnutls-cli --debug 1000 -V --port 11111 --x509cafile ../wolfssl/certs/ca-cert.pem --tofu localhost
```
Also used `openssl s_client` and observed in wireshark.

# Checklist

 - [ ] added tests
 - [ ] ~updated/added doxygen~
 - [ ] ~updated appropriate READMEs~
 - [ ] ~Updated manual and documentation~
