### PR TITLE
Fix Small Memory Leaks

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -34947,6 +34947,12 @@ int wolfSSL_DSA_generate_key(WOLFSSL_DSA* dsa)
         }
 
         if (rng) {
+            /* These were allocated above by SetDsaInternal(). They should
+             * be cleared before wc_MakeDsaKey() which reinitializes
+             * x and y. */
+            mp_clear(&((DsaKey*)dsa->internal)->x);
+            mp_clear(&((DsaKey*)dsa->internal)->y);
+
             if (wc_MakeDsaKey(rng, (DsaKey*)dsa->internal) != MP_OKAY)
                 WOLFSSL_MSG("wc_MakeDsaKey failed");
             else if (SetDsaExternal(dsa) != WOLFSSL_SUCCESS)


### PR DESCRIPTION
# Description

1. ssl.c: In wolfSSL_DSA_generate_key(), we initialize (and allocate) all the parameters in the key (p, q, g, x, y), and then we generate a key, initializes (and allocates) x and y, again. mp_clear them first.
2. evp.c: When printing public keys, the temporary mp_int wasn't getting correctly freed.
3. evp.c: When printing public keys, modified the utility functions to return once with a do-while-0 loop.

# Testing

Found with the configuration running the unit test through valgrind.

    % ./configure CFLAGS=-DNO_WOLFSSL_CIPHER_SUITE_TEST \
      --enable-all --disable-fastmath --enable-debug --disable-shared

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
