### PR TITLE
OCSP IPv6 support

### DIFF
--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -280,8 +280,8 @@ static int GetOcspStatus(WOLFSSL_OCSP* ocsp, OcspRequest* request,
  * returns OCSP_LOOKUP_FAIL when the response is bad and 0 otherwise.
  */
 int CheckOcspResponse(WOLFSSL_OCSP *ocsp, byte *response, int responseSz,
-                                    WOLFSSL_BUFFER_INFO *responseBuffer, CertStatus *status,
-                                    OcspEntry *entry, OcspRequest *ocspRequest)
+                      WOLFSSL_BUFFER_INFO *responseBuffer, CertStatus *status,
+                      OcspEntry *entry, OcspRequest *ocspRequest)
 {
 #ifdef WOLFSSL_SMALL_STACK
     CertStatus*   newStatus;
@@ -406,7 +406,7 @@ end:
 }
 
 /* 0 on success */
-/* allow customer to override the maximum request size at build-time */
+/* allow user to override the maximum request size at build-time */
 #ifndef OCSP_MAX_REQUEST_SZ
 #define OCSP_MAX_REQUEST_SZ 2048
 #endif

--- a/src/ocsp.c
+++ b/src/ocsp.c
@@ -279,7 +279,7 @@ static int GetOcspStatus(WOLFSSL_OCSP* ocsp, OcspRequest* request,
  * entry          The OCSP entry for this certificate.
  * returns OCSP_LOOKUP_FAIL when the response is bad and 0 otherwise.
  */
-WOLFSSL_LOCAL int CheckOcspResponse(WOLFSSL_OCSP *ocsp, byte *response, int responseSz,
+int CheckOcspResponse(WOLFSSL_OCSP *ocsp, byte *response, int responseSz,
                                     WOLFSSL_BUFFER_INFO *responseBuffer, CertStatus *status,
                                     OcspEntry *entry, OcspRequest *ocspRequest)
 {
@@ -406,13 +406,17 @@ end:
 }
 
 /* 0 on success */
+/* allow customer to override the maximum request size at build-time */
+#ifndef OCSP_MAX_REQUEST_SZ
+#define OCSP_MAX_REQUEST_SZ 2048
+#endif
 int CheckOcspRequest(WOLFSSL_OCSP* ocsp, OcspRequest* ocspRequest,
                                                       buffer* responseBuffer)
 {
     OcspEntry*  entry          = NULL;
     CertStatus* status         = NULL;
     byte*       request        = NULL;
-    int         requestSz      = 2048;
+    int         requestSz      = OCSP_MAX_REQUEST_SZ;
     int         responseSz     = 0;
     byte*       response       = NULL;
     const char* url            = NULL;
@@ -1113,7 +1117,7 @@ WOLFSSL_OCSP_SINGLERESP* wolfSSL_OCSP_resp_get0(WOLFSSL_OCSP_BASICRESP *bs, int 
     return single;
 }
 
-#endif /* OPENSSL_ALL || APACHE_HTTPD */
+#endif /* OPENSSL_ALL || APACHE_HTTPD || WOLFSSL_HAPROXY */
 
 #ifdef OPENSSL_EXTRA
 #ifndef NO_WOLFSSL_STUB

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -805,13 +805,14 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
 #ifdef HAVE_SOCKADDR
     int ret = 0;
     SOCKADDR_S addr;
-    int sockaddr_len = sizeof(SOCKADDR_IN);
-    /* use gethostbyname for c99 */
-#if defined(HAVE_GETADDRINFO) && !defined(WOLF_C99)
+    int sockaddr_len;
+#if defined(HAVE_GETADDRINFO)
+    /* use getaddrinfo */
     ADDRINFO hints;
     ADDRINFO* answer = NULL;
     char strPort[6];
 #else
+    /* use gethostbyname */
 #if !defined(WOLFSSL_USE_POPEN_HOST)
 #if defined(__GLIBC__) && (__GLIBC__ >= 2) && defined(__USE_MISC) && \
     !defined(SINGLE_THREADED)
@@ -822,13 +823,22 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
     HOSTENT *entry;
 #endif
 #endif
+#ifdef WOLFSSL_IPV6
+    SOCKADDR_IN6 *sin;
+#else
     SOCKADDR_IN *sin;
 #endif
+#endif /* HAVE_SOCKADDR */
 
     if (sockfd == NULL || ip == NULL) {
         return -1;
     }
 
+#ifdef WOLFSSL_IPV6
+    sockaddr_len = sizeof(SOCKADDR_IN6);
+#else
+    sockaddr_len = sizeof(SOCKADDR_IN);
+#endif
     XMEMSET(&addr, 0, sizeof(addr));
 
 #ifdef WOLFIO_DEBUG
@@ -836,9 +846,9 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
 #endif
 
     /* use gethostbyname for c99 */
-#if defined(HAVE_GETADDRINFO) && !defined(WOLF_C99)
+#if defined(HAVE_GETADDRINFO)
     XMEMSET(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;
+    hints.ai_family = AF_UNSPEC; /* detect IPv4 or IPv6 */
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_protocol = IPPROTO_TCP;
 
@@ -855,7 +865,7 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
     sockaddr_len = answer->ai_addrlen;
     XMEMCPY(&addr, answer->ai_addr, sockaddr_len);
     freeaddrinfo(answer);
-#elif defined(WOLFSSL_USE_POPEN_HOST)
+#elif defined(WOLFSSL_USE_POPEN_HOST) && !defined(WOLFSSL_IPV6)
     {
         char host_ipaddr[4] = { 127, 0, 0, 1 };
         int found = 1;
@@ -907,7 +917,6 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
         }
         if (found) {
             sin = (SOCKADDR_IN *)&addr;
-
             sin->sin_family = AF_INET;
             sin->sin_port = XHTONS(port);
             XMEMCPY(&sin->sin_addr.s_addr, host_ipaddr, sizeof(host_ipaddr));
@@ -932,12 +941,19 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
 #else
     entry = gethostbyname(ip);
 #endif
-    sin = (SOCKADDR_IN *)&addr;
 
     if (entry) {
+    #ifdef WOLFSSL_IPV6
+        sin = (SOCKADDR_IN6 *)&addr;
+        sin->sin6_family = AF_INET6;
+        sin->sin6_port = XHTONS(port);
+        XMEMCPY(&sin->sin6_addr, entry->h_addr_list[0], entry->h_length);
+    #else
+        sin = (SOCKADDR_IN *)&addr;
         sin->sin_family = AF_INET;
         sin->sin_port = XHTONS(port);
         XMEMCPY(&sin->sin_addr.s_addr, entry->h_addr_list[0], entry->h_length);
+    #endif
     }
 
 #if defined(__GLIBC__) && (__GLIBC__ >= 2) && defined(__USE_MISC) && \

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1311,7 +1311,7 @@ static WC_INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
         addr->sin6_addr = in6addr_any;
     }
     else {
-        #if defined(HAVE_GETADDRINFO) || defined(WOLF_C99)
+        #if defined(HAVE_GETADDRINFO)
             struct addrinfo  hints;
             struct addrinfo* answer = NULL;
             int    ret;

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -373,8 +373,7 @@
         typedef struct hostent          HOSTENT;
     #endif /* HAVE_SOCKADDR */
 
-    /* use gethostbyname for c99 */
-    #if defined(HAVE_GETADDRINFO) && !defined(WOLF_C99)
+    #if defined(HAVE_GETADDRINFO)
         typedef struct addrinfo         ADDRINFO;
     #endif
 #endif /* WOLFSSL_NO_SOCK */


### PR DESCRIPTION
# Description

Adds IPv6 support to OCSP. Enable with `--enable-ipv6` or `WOLFSSL_IPV6`.  Improve the logic around C99 and getaddrinfo.
Fixes ZD13722

# Testing

```
./configure --enable-ocsp --enable-ipv6
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
