### PR TITLE
SP asm: fix map function to use p not point

### DIFF
--- a/wolfcrypt/src/sp_x86_64.c
+++ b/wolfcrypt/src/sp_x86_64.c
@@ -25274,7 +25274,7 @@ int sp_ecc_map_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 
 #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_BMI2(cpuid_flags) && IS_INTEL_ADX(cpuid_flags))
-            sp_256_map_avx2_4(point, point, tmp);
+            sp_256_map_avx2_4(p, p, tmp);
         else
 #endif
             sp_256_map_4(p, p, tmp);
@@ -49875,7 +49875,7 @@ int sp_ecc_map_384(mp_int* pX, mp_int* pY, mp_int* pZ)
 
 #ifdef HAVE_INTEL_AVX2
         if (IS_INTEL_BMI2(cpuid_flags) && IS_INTEL_ADX(cpuid_flags))
-            sp_384_map_avx2_6(point, point, tmp);
+            sp_384_map_avx2_6(p, p, tmp);
         else
 #endif
             sp_384_map_6(p, p, tmp);


### PR DESCRIPTION
# Description

SP asm: fix map function to use p not point

Fixes Issue #4876

# Testing

Specifically the configuration in the issue report.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
