### PR TITLE
SP asm: fix for modexp corner case

### DIFF
--- a/wolfcrypt/src/sp_arm32.c
+++ b/wolfcrypt/src/sp_arm32.c
@@ -4816,6 +4816,10 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 32 - c;
@@ -4982,6 +4986,10 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -7440,6 +7448,10 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 32 - c;
@@ -7589,6 +7601,10 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -8749,6 +8765,10 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -15777,6 +15797,10 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 32 - c;
@@ -15943,6 +15967,10 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -19329,6 +19357,10 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 32 - c;
@@ -19478,6 +19510,10 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -20910,6 +20946,10 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -27838,6 +27878,10 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 32 - c;
@@ -27987,6 +28031,10 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -29691,6 +29739,10 @@ static int sp_4096_mod_exp_2_128(sp_digit* r, const sp_digit* e, int bits,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);

--- a/wolfcrypt/src/sp_arm64.c
+++ b/wolfcrypt/src/sp_arm64.c
@@ -3318,6 +3318,10 @@ static int sp_2048_mod_exp_16(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -3484,6 +3488,10 @@ static int sp_2048_mod_exp_16(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -4897,6 +4905,10 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -5046,6 +5058,10 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -5911,6 +5927,10 @@ static int sp_2048_mod_exp_2_32(sp_digit* r, const sp_digit* e, int bits,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -10941,6 +10961,10 @@ static int sp_3072_mod_exp_24(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -11107,6 +11131,10 @@ static int sp_3072_mod_exp_24(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -12944,6 +12972,10 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -13093,6 +13125,10 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -14082,6 +14118,10 @@ static int sp_3072_mod_exp_2_48(sp_digit* r, const sp_digit* e, int bits,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -18154,6 +18194,10 @@ static int sp_4096_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -18303,6 +18347,10 @@ static int sp_4096_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -19416,6 +19464,10 @@ static int sp_4096_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);

--- a/wolfcrypt/src/sp_cortexm.c
+++ b/wolfcrypt/src/sp_cortexm.c
@@ -3278,6 +3278,10 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 32 - c;
@@ -3444,6 +3448,10 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -4353,6 +4361,10 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 32 - c;
@@ -4502,6 +4514,10 @@ static int sp_2048_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -5505,6 +5521,10 @@ static int sp_2048_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -8549,6 +8569,10 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 32 - c;
@@ -8715,6 +8739,10 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -9762,6 +9790,10 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 32 - c;
@@ -9911,6 +9943,10 @@ static int sp_3072_mod_exp_96(sp_digit* r, const sp_digit* a, const sp_digit* e,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -11110,6 +11146,10 @@ static int sp_3072_mod_exp_2_96(sp_digit* r, const sp_digit* e, int bits,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -13707,6 +13747,10 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 32 - c;
@@ -13856,6 +13900,10 @@ static int sp_4096_mod_exp_128(sp_digit* r, const sp_digit* a, const sp_digit* e
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -15252,6 +15300,10 @@ static int sp_4096_mod_exp_2_128(sp_digit* r, const sp_digit* e, int bits,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);

--- a/wolfcrypt/src/sp_x86_64.c
+++ b/wolfcrypt/src/sp_x86_64.c
@@ -583,6 +583,10 @@ static int sp_2048_mod_exp_16(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -805,6 +809,10 @@ static int sp_2048_mod_exp_avx2_16(sp_digit* r, const sp_digit* a, const sp_digi
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -1268,6 +1276,10 @@ static int sp_2048_mod_exp_32(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -1474,6 +1486,10 @@ static int sp_2048_mod_exp_avx2_32(sp_digit* r, const sp_digit* a, const sp_digi
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -2186,6 +2202,10 @@ static int sp_2048_mod_exp_2_avx2_32(sp_digit* r, const sp_digit* e, int bits,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -2320,6 +2340,10 @@ static int sp_2048_mod_exp_2_32(sp_digit* r, const sp_digit* e, int bits,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -3108,6 +3132,10 @@ static int sp_3072_mod_exp_24(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -3330,6 +3358,10 @@ static int sp_3072_mod_exp_avx2_24(sp_digit* r, const sp_digit* a, const sp_digi
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -3793,6 +3825,10 @@ static int sp_3072_mod_exp_48(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -3999,6 +4035,10 @@ static int sp_3072_mod_exp_avx2_48(sp_digit* r, const sp_digit* a, const sp_digi
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -4711,6 +4751,10 @@ static int sp_3072_mod_exp_2_avx2_48(sp_digit* r, const sp_digit* e, int bits,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -4845,6 +4889,10 @@ static int sp_3072_mod_exp_2_48(sp_digit* r, const sp_digit* e, int bits,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -5683,6 +5731,10 @@ static int sp_4096_mod_exp_64(sp_digit* r, const sp_digit* a, const sp_digit* e,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -5889,6 +5941,10 @@ static int sp_4096_mod_exp_avx2_64(sp_digit* r, const sp_digit* a, const sp_digi
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);
@@ -6601,6 +6657,10 @@ static int sp_4096_mod_exp_2_avx2_64(sp_digit* r, const sp_digit* e, int bits,
             n <<= c;
             c = 64 - c;
         }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
+        }
         else {
             y = (byte)(n >> c);
             n <<= 64 - c;
@@ -6735,6 +6795,10 @@ static int sp_4096_mod_exp_2_64(sp_digit* r, const sp_digit* e, int bits,
             y |= (byte)(n >> (64 - c));
             n <<= c;
             c = 64 - c;
+        }
+        else if (c == 0) {
+            /* All bits in top word used. */
+            y = (byte)n;
         }
         else {
             y = (byte)(n >> c);


### PR DESCRIPTION
# Description

SP ASM
When exponent bit length is a multiple of the window size and the top
word has only window bits in it, then n is shifted down by an undefined
value (size of a word). The n value is not used after this.
Check for this condition and don't attempt to shift n.

Please describe the scope of the fix or feature addition.

Fixes zd#13751

# Testing

Ran POC and make test with reported configuration.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
