### PR TITLE
RSA/DH: check for even modulus

### DIFF
--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -1208,6 +1208,10 @@ static int GeneratePrivateDh(DhKey* key, WC_RNG* rng, byte* priv,
     int ret = 0;
     word32 sz = 0;
 
+    if (mp_iseven(&key->p) == MP_YES) {
+        ret = MP_VAL;
+    }
+    else
 #ifndef WOLFSSL_NO_DH186
     if (mp_iszero(&key->q) == MP_NO) {
 
@@ -1215,7 +1219,8 @@ static int GeneratePrivateDh(DhKey* key, WC_RNG* rng, byte* priv,
          * Generation Using Extra Random Bits" */
         ret = GeneratePrivateDh186(key, rng, priv, privSz);
 
-    } else
+    }
+    else
 #endif
     {
 
@@ -1793,6 +1798,8 @@ static int _ffc_pairwise_consistency_test(DhKey* key,
 
     if (key == NULL || pub == NULL || priv == NULL)
         return BAD_FUNC_ARG;
+    if (mp_iseven(&key->p) == MP_YES)
+        return MP_VAL;
 
 #ifdef WOLFSSL_SMALL_STACK
     publicKey = (mp_int*)XMALLOC(sizeof(mp_int), key->heap, DYNAMIC_TYPE_DH);
@@ -1957,6 +1964,9 @@ static int wc_DhAgree_Sync(DhKey* key, byte* agree, word32* agreeSz,
 #endif
 #endif
 
+    if (mp_iseven(&key->p) == MP_YES) {
+        return MP_VAL;
+    }
 #ifdef WOLFSSL_VALIDATE_FFC_IMPORT
     if (wc_DhCheckPrivKey(key, priv, privSz) != 0) {
         WOLFSSL_MSG("wc_DhAgree wc_DhCheckPrivKey failed");

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -2258,6 +2258,9 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
     word32 keyLen = 0;
 #endif
 
+    if (mp_iseven(&key->n)) {
+        return MP_VAL;
+    }
 #ifdef WOLFSSL_HAVE_SP_RSA
 #ifndef WOLFSSL_SP_NO_2048
     if (mp_count_bits(&key->n) == 2048) {


### PR DESCRIPTION
# Description

RSA/DH: check for even modulus as this is a bad value.

# Testing

Normal testing.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
