### PR TITLE
Adds CSR userId support in subject name

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -33287,6 +33287,7 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
     { NID_surname, NID_surname, oidCertNameType, "SN", "surname"},
     { NID_serialNumber, NID_serialNumber, oidCertNameType, "serialNumber",
                                                             "serialNumber"},
+    { NID_userId, NID_userId, oidCertNameType, "UID", "userid"},
     { NID_countryName, NID_countryName, oidCertNameType, "C", "countryName"},
     { NID_localityName, NID_localityName, oidCertNameType, "L", "localityName"},
     { NID_stateOrProvinceName, NID_stateOrProvinceName, oidCertNameType, "ST",
@@ -44658,6 +44659,7 @@ static int ConvertNIDToWolfSSL(int nid)
         case NID_organizationalUnitName: return ASN_ORGUNIT_NAME;
         case NID_emailAddress: return ASN_EMAIL_NAME;
         case NID_serialNumber: return ASN_SERIAL_NUMBER;
+        case NID_userId: return ASN_USER_ID;
         case NID_businessCategory: return ASN_BUS_CAT;
         case NID_domainComponent: return ASN_DOMAIN_COMPONENT;
         case NID_postalCode: return ASN_POSTAL_CODE;
@@ -53470,6 +53472,8 @@ int oid2nid(word32 oid, int grp)
                     return NID_pkcs9_challengePassword;
                 case SERIAL_NUMBER_OID:
                     return NID_serialNumber;
+                case USER_ID_OID:
+                    return NID_userId;
             }
             break;
 #endif

--- a/tests/api.c
+++ b/tests/api.c
@@ -33957,7 +33957,7 @@ static void test_wolfSSL_Tls13_postauth(void)
 
 static void test_wolfSSL_X509_NID(void)
 {
-    #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
+#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
     !defined(NO_RSA) && defined(USE_CERT_BUFFERS_2048) && !defined(NO_ASN)
     int   sigType;
     int   nameSz;
@@ -34027,7 +34027,7 @@ static void test_wolfSSL_X509_NID(void)
     X509_free(cert);
 
     printf(resultFmt, passed);
-    #endif
+#endif
 }
 
 static void test_wolfSSL_CTX_set_srp_username(void)
@@ -41921,7 +41921,7 @@ static void test_wolfSSL_X509_check_ip_asc(void){
 #endif
 }
 
-static void test_wolfSSL_DC_cert(void)
+static void test_wolfSSL_make_cert(void)
 {
 #if !defined(NO_RSA) && defined(WOLFSSL_CERT_GEN) && defined(WOLFSSL_CERT_EXT)
     int      ret;
@@ -41942,7 +41942,7 @@ static void test_wolfSSL_DC_cert(void)
     ASN1_STRING*         entryValue;
 #endif
 
-    printf(testingFmt, "wolfSSL Certs with DC");
+    printf(testingFmt, "wolfSSL Make Certs");
 
     XMEMSET(&name, 0, sizeof(CertName));
 
@@ -41963,6 +41963,8 @@ static void test_wolfSSL_DC_cert(void)
     name.commonNameEnc = CTC_UTF8;
     XMEMCPY(name.serialDev, "wolfSSL12345", sizeof("wolfSSL12345"));
     name.serialDevEnc = CTC_PRINTABLE;
+    XMEMCPY(name.userId, "TestUserID", sizeof("TestUserID"));
+    name.userIdEnc = CTC_PRINTABLE;
 #ifdef WOLFSSL_MULTI_ATTRIB
     #if CTC_MAX_ATTRIB > 2
     {
@@ -52695,7 +52697,7 @@ void ApiTest(void)
     test_wolfSSL_i2c_ASN1_INTEGER();
     test_wolfSSL_X509_check_ca();
     test_wolfSSL_X509_check_ip_asc();
-    test_wolfSSL_DC_cert();
+    test_wolfSSL_make_cert();
     test_wolfSSL_DES_ncbc();
     test_wolfSSL_AES_cbc_encrypt();
     test_wolfSSL_CRYPTO_cts128();

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -11127,7 +11127,7 @@ static int GetRDN(DecodedCert* cert, char* full, word32* idx, int* nid,
         if (ret == 0) {
             /* Check there is space for this in the full name string and
              * terminating NUL character. */
-            if ((typeStrLen + strLen) < (word32)(ASN_NAME_MAX - *idx))
+            if ((typeStrLen + strLen) < (word32)(WC_ASN_NAME_MAX - *idx))
             {
                 /* Add RDN to full string. */
                 XMEMCPY(&full[*idx], typeStr, typeStrLen);
@@ -11525,7 +11525,7 @@ static int GetCertName(DecodedCert* cert, char* full, byte* hash, int nameType,
                 #endif /* OPENSSL_EXTRA */
             }
 
-            if ((strLen + copyLen) > (int)(ASN_NAME_MAX - idx)) {
+            if ((strLen + copyLen) > (int)(WC_ASN_NAME_MAX - idx)) {
                 WOLFSSL_MSG("ASN Name too big, skipping");
                 tooBig = TRUE;
             }
@@ -11559,14 +11559,14 @@ static int GetCertName(DecodedCert* cert, char* full, byte* hash, int nameType,
                 return ASN_PARSE_E;
             }
 
-            if (strLen > (int)(ASN_NAME_MAX - idx)) {
+            if (strLen > (int)(WC_ASN_NAME_MAX - idx)) {
                 WOLFSSL_MSG("ASN name too big, skipping");
                 tooBig = TRUE;
             }
 
             if (email) {
                 copyLen = sizeof(WOLFSSL_EMAIL_ADDR) - 1;
-                if ((copyLen + strLen) > (int)(ASN_NAME_MAX - idx)) {
+                if ((copyLen + strLen) > (int)(WC_ASN_NAME_MAX - idx)) {
                     WOLFSSL_MSG("ASN name too big, skipping");
                     tooBig = TRUE;
                 }
@@ -11664,7 +11664,7 @@ static int GetCertName(DecodedCert* cert, char* full, byte* hash, int nameType,
                 }
             }
         }
-        if ((copyLen + strLen) > (int)(ASN_NAME_MAX - idx))
+        if ((copyLen + strLen) > (int)(WC_ASN_NAME_MAX - idx))
         {
             WOLFSSL_MSG("ASN Name too big, skipping");
             tooBig = TRUE;
@@ -11707,14 +11707,14 @@ static int GetCertName(DecodedCert* cert, char* full, byte* hash, int nameType,
     if (nameType == ISSUER) {
 #if (defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY)) && \
     (defined(HAVE_PKCS7) || defined(WOLFSSL_CERT_EXT))
-        dName->rawLen = min(cert->issuerRawLen, ASN_NAME_MAX);
+        dName->rawLen = min(cert->issuerRawLen, WC_ASN_NAME_MAX);
         XMEMCPY(dName->raw, cert->issuerRaw, dName->rawLen);
 #endif
         cert->issuerName = dName;
     }
     else {
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX)
-        dName->rawLen = min(cert->subjectRawLen, ASN_NAME_MAX);
+        dName->rawLen = min(cert->subjectRawLen, WC_ASN_NAME_MAX);
         XMEMCPY(dName->raw, cert->subjectRaw, dName->rawLen);
 #endif
         cert->subjectName = dName;
@@ -11838,14 +11838,14 @@ static int GetCertName(DecodedCert* cert, char* full, byte* hash, int nameType,
         #if (defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || \
              defined(HAVE_LIGHTY)) && \
             (defined(HAVE_PKCS7) || defined(WOLFSSL_CERT_EXT))
-            dName->rawLen = min(cert->issuerRawLen, ASN_NAME_MAX);
+            dName->rawLen = min(cert->issuerRawLen, WC_ASN_NAME_MAX);
             XMEMCPY(dName->raw, cert->issuerRaw, dName->rawLen);
         #endif
             cert->issuerName = dName;
         }
         else {
         #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX)
-            dName->rawLen = min(cert->subjectRawLen, ASN_NAME_MAX);
+            dName->rawLen = min(cert->subjectRawLen, WC_ASN_NAME_MAX);
             XMEMCPY(dName->raw, cert->subjectRaw, dName->rawLen);
         #endif
             cert->subjectName = dName;
@@ -20880,8 +20880,8 @@ typedef struct DerCert {
     byte version[MAX_VERSION_SZ];      /* version encoded */
     byte serial[(int)CTC_SERIAL_SIZE + (int)MAX_LENGTH_SZ]; /* serial number encoded */
     byte sigAlgo[MAX_ALGO_SZ];         /* signature algo encoded */
-    byte issuer[ASN_NAME_MAX];         /* issuer  encoded */
-    byte subject[ASN_NAME_MAX];        /* subject encoded */
+    byte issuer[WC_ASN_NAME_MAX];         /* issuer  encoded */
+    byte subject[WC_ASN_NAME_MAX];        /* subject encoded */
     byte validity[MAX_DATE_SIZE*2 + MAX_SEQ_SZ*2];  /* before and after dates */
     byte publicKey[MAX_PUBLIC_KEY_SZ]; /* rsa public key encoded */
     byte ca[MAX_CA_SZ];                /* basic constraint CA true size */
@@ -23017,11 +23017,11 @@ int SetNameEx(byte* output, word32 outputSz, CertName* name, void* heap)
     /* header */
     idx = SetSequence(totalBytes, output);
     totalBytes += idx;
-    if (totalBytes > ASN_NAME_MAX) {
+    if (totalBytes > WC_ASN_NAME_MAX) {
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(names, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
-        WOLFSSL_MSG("Total Bytes is greater than ASN_NAME_MAX");
+        WOLFSSL_MSG("Total Bytes is greater than WC_ASN_NAME_MAX");
         return BUFFER_E;
     }
 
@@ -24549,7 +24549,7 @@ static int MakeAnyCert(Cert* cert, byte* derBuffer, word32 derSz,
     #endif
         {
             /* Calcuate issuer name encoding size. */
-            issuerSz = SetNameEx(NULL, ASN_NAME_MAX, &cert->issuer, cert->heap);
+            issuerSz = SetNameEx(NULL, WC_ASN_NAME_MAX, &cert->issuer, cert->heap);
             ret = issuerSz;
         }
     }
@@ -24565,7 +24565,7 @@ static int MakeAnyCert(Cert* cert, byte* derBuffer, word32 derSz,
     #endif
         {
             /* Calcuate subject name encoding size. */
-            subjectSz = SetNameEx(NULL, ASN_NAME_MAX, &cert->subject, cert->heap);
+            subjectSz = SetNameEx(NULL, WC_ASN_NAME_MAX, &cert->subject, cert->heap);
             ret = subjectSz;
         }
     }
@@ -25385,7 +25385,7 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
         else
     #endif
         {
-            subjectSz = SetNameEx(NULL, ASN_NAME_MAX, &cert->subject, cert->heap);
+            subjectSz = SetNameEx(NULL, WC_ASN_NAME_MAX, &cert->subject, cert->heap);
             ret = subjectSz;
         }
     }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -4061,13 +4061,12 @@ static const byte dnsSRVOid[] = {43, 6, 1, 5, 5, 7, 8, 7};
 #endif
 
 #if defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_GEN) || \
-    defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+    defined(WOLFSSL_ASN_TEMPLATE)
 /* Pilot attribute types (0.9.2342.19200300.100.1.*) */
 static const byte uidOid[] = {9, 146, 38, 137, 147, 242, 44, 100, 1, 1}; /* user id */
-#if !defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_GEN) || \
-    defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+
 static const byte dcOid[] = {9, 146, 38, 137, 147, 242, 44, 100, 1, 25}; /* domain component */
-#endif
 #endif
 
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11904,6 +11904,8 @@ static void initDefaultName(void)
     certDefaultName.joiCEnc = CTC_PRINTABLE;
 #endif
     XMEMCPY(certDefaultName.email, "info@wolfssl.com", sizeof("info@wolfssl.com"));
+    XMEMCPY(certDefaultName.userId, "TestUserID", sizeof("TestUserID"));
+    certDefaultName.userIdEnc = CTC_PRINTABLE;
 
 #if defined(WOLFSSL_MULTI_ATTRIB) && defined(WOLFSSL_TEST_CERT)
     /* test having additional OUs and setting DC */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3812,7 +3812,18 @@ typedef struct Arrays {
 } Arrays;
 
 #ifndef ASN_NAME_MAX
-#define ASN_NAME_MAX 256
+    #ifndef NO_ASN
+        /* use value from asn.h */
+        #define ASN_NAME_MAX WC_ASN_NAME_MAX
+    #else
+        /* calculate for WOLFSSL_X509 */
+        #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+            defined(WOLFSSL_CERT_EXT)
+            #define ASN_NAME_MAX 330
+        #else
+            #define ASN_NAME_MAX 256
+        #endif
+    #endif
 #endif
 
 #ifndef MAX_DATE_SZ

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -20,10 +20,7 @@
 #include <wolfssl/wolfcrypt/random.h>
 #include <wolfssl/wolfcrypt/mem_track.h>
 #include <wolfssl/wolfio.h>
-#if defined(SHOW_CERTS) && \
-    (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
-    #include <wolfssl/wolfcrypt/asn.h> /* for domain component NID value */
-#endif
+#include <wolfssl/wolfcrypt/asn.h>
 
 #ifdef ATOMIC_USER
     #include <wolfssl/wolfcrypt/aes.h>
@@ -31,7 +28,6 @@
     #include <wolfssl/wolfcrypt/hmac.h>
 #endif
 #ifdef HAVE_PK_CALLBACKS
-    #include <wolfssl/wolfcrypt/asn.h>
     #ifndef NO_RSA
         #include <wolfssl/wolfcrypt/rsa.h>
     #endif
@@ -1053,7 +1049,7 @@ static WC_INLINE void ShowX509Ex(WOLFSSL_X509* x509, const char* hdr,
 #if defined(SHOW_CERTS) && defined(OPENSSL_EXTRA)
     {
         WOLFSSL_BIO* bio;
-        char buf[256]; /* should be size of ASN_NAME_MAX */
+        char buf[WC_ASN_NAME_MAX];
         int  textSz;
 
         /* print out domain component if certificate has it */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -668,12 +668,13 @@ enum DN_Tags {
     ASN_ORGUNIT_NAME  = 0x0b,   /* OU */
     ASN_BUS_CAT       = 0x0f,   /* businessCategory */
     ASN_POSTAL_CODE   = 0x11,   /* postalCode */
+    ASN_USER_ID       = 0x12,   /* UserID */
+
     ASN_EMAIL_NAME    = 0x98,   /* not actual OID (see attrEmailOid) */
     ASN_CUSTOM_NAME   = 0x99,   /* not actual OID (see CertOidField) */
 
     /* pilot attribute types
      * OID values of 0.9.2342.19200300.100.1.* */
-    ASN_USER_ID          = 0x01, /* UID */
     ASN_FAVOURITE_DRINK  = 0x05, /* favouriteDrink */
     ASN_DOMAIN_COMPONENT = 0x19  /* DC */
 };
@@ -839,7 +840,7 @@ enum ECC_TYPES
 #define ASN_JOI_ST              0x2
 
 #ifndef WC_ASN_NAME_MAX
-    #ifdef OPENSSL_EXTRA
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
         #define WC_ASN_NAME_MAX 330
     #else
         #define WC_ASN_NAME_MAX 256
@@ -973,9 +974,9 @@ enum Misc_ASN {
 #ifndef WC_MAX_NAME_ENTRIES
     /* entries added to x509 name struct */
     #ifdef OPENSSL_EXTRA
-    #define WC_MAX_NAME_ENTRIES 15
+    #define WC_MAX_NAME_ENTRIES 16
     #else
-    #define WC_MAX_NAME_ENTRIES 13
+    #define WC_MAX_NAME_ENTRIES 14
     #endif
 #endif
 #define MAX_NAME_ENTRIES WC_MAX_NAME_ENTRIES
@@ -1188,6 +1189,7 @@ enum CsrAttrType {
     CHALLENGE_PASSWORD_OID = 659,
     SERIAL_NUMBER_OID = 94,
     EXTENSION_REQUEST_OID = 666,
+    USER_ID_OID = 865,
 };
 #endif
 
@@ -1575,6 +1577,9 @@ struct DecodedCert {
     char*   subjectSND;
     int     subjectSNDLen;
     char    subjectSNDEnc;
+    char*   subjectUID;
+    int     subjectUIDLen;
+    char    subjectUIDEnc;
 #if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
     char*   subjectStreet;
     int     subjectStreetLen;

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -840,13 +840,13 @@ enum ECC_TYPES
 #define ASN_JOI_ST              0x2
 
 #ifndef WC_ASN_NAME_MAX
-    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
+        defined(WOLFSSL_CERT_EXT)
         #define WC_ASN_NAME_MAX 330
     #else
         #define WC_ASN_NAME_MAX 256
     #endif
 #endif
-#define ASN_NAME_MAX WC_ASN_NAME_MAX
 
 enum Misc_ASN {
     MAX_SALT_SIZE       =  64,     /* MAX PKCS Salt length */
@@ -1487,8 +1487,8 @@ struct DecodedCert {
     char*   subjectCN;               /* CommonName                       */
     int     subjectCNLen;            /* CommonName Length                */
     char    subjectCNEnc;            /* CommonName Encoding              */
-    char    issuer[ASN_NAME_MAX];    /* full name including common name  */
-    char    subject[ASN_NAME_MAX];   /* full name including common name  */
+    char    issuer[WC_ASN_NAME_MAX]; /* full name including common name  */
+    char    subject[WC_ASN_NAME_MAX];/* full name including common name  */
     int     verify;                  /* Default to yes, but could be off */
     const byte* source;              /* byte buffer holder cert, NOT owner */
     word32  srcIdx;                  /* current offset into buffer       */

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -345,6 +345,8 @@ typedef struct CertName {
     char commonNameEnc;
     char serialDev[CTC_NAME_SIZE];
     char serialDevEnc;
+    char userId[CTC_NAME_SIZE];
+    char userIdEnc;
     char postalCode[CTC_NAME_SIZE];
     char postalCodeEnc;
 #ifdef WOLFSSL_CERT_EXT

--- a/wolfssl/wolfcrypt/pkcs7.h
+++ b/wolfssl/wolfcrypt/pkcs7.h
@@ -156,7 +156,7 @@ enum Pkcs7_Misc {
     MAX_CONTENT_BLOCK_LEN = DES_BLOCK_SIZE,
 #endif
     MAX_RECIP_SZ          = MAX_VERSION_SZ +
-                            MAX_SEQ_SZ + ASN_NAME_MAX + MAX_SN_SZ +
+                            MAX_SEQ_SZ + WC_ASN_NAME_MAX + MAX_SN_SZ +
                             MAX_SEQ_SZ + MAX_ALGO_SZ + 1 + MAX_ENCRYPTED_KEY_SZ,
 };
 


### PR DESCRIPTION
# Description

* Adds CSR userId support in subject name.
* Minor build fixes for ASN template code.

Fixes ZD13745

# Testing

Tested X509 CSR generation, CSR parsing and certificate parsing. wolfCryptTest outputs a `cert.pem` in root, that includes the UserID field.

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
