### PR TITLE
fix to use EXT_KEY_USAGE_OID in object_info

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -32678,7 +32678,7 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
                                                         "X509v3 Key Usage"},
     { NID_inhibit_any_policy, INHIBIT_ANY_OID, oidCertExtType,
                            "inhibitAnyPolicy", "X509v3 Inhibit Any Policy"},
-    { NID_ext_key_usage, KEY_USAGE_OID, oidCertExtType,
+    { NID_ext_key_usage, EXT_KEY_USAGE_OID, oidCertExtType,
                            "extendedKeyUsage", "X509v3 Extended Key Usage"},
     { NID_name_constraints, NAME_CONS_OID, oidCertExtType,
                               "nameConstraints", "X509v3 Name Constraints"},

--- a/tests/api.c
+++ b/tests/api.c
@@ -44589,6 +44589,7 @@ static void test_wolfSSL_X509_get_ext_by_NID(void)
     int rc;
     FILE* f;
     WOLFSSL_X509* x509;
+    ASN1_OBJECT* obj = NULL;
 
     AssertNotNull(f = fopen("./certs/server-cert.pem", "rb"));
     AssertNotNull(x509 = wolfSSL_PEM_read_X509(f, NULL, NULL, NULL));
@@ -44610,6 +44611,13 @@ static void test_wolfSSL_X509_get_ext_by_NID(void)
     rc = wolfSSL_X509_get_ext_by_NID(x509, NID_undef, -1);
     AssertIntEQ(rc, -1);
 
+    /* NID_ext_key_usage, check also its nid and oid */
+    rc = wolfSSL_X509_get_ext_by_NID(x509, NID_ext_key_usage, -1);
+    AssertIntGT(rc, -1);
+    AssertNotNull(obj = wolfSSL_X509_EXTENSION_get_object(wolfSSL_X509_get_ext(x509, rc)));
+    AssertIntEQ(obj->nid, NID_ext_key_usage);
+    AssertIntEQ(obj->type, EXT_KEY_USAGE_OID);
+    
     wolfSSL_X509_free(x509);
 #endif
 }


### PR DESCRIPTION
# Description

fix to use EXT_KEY_USAGE_OID instead of KEY_USAGE_OID for NID_ext_key_usage in wolfssl_object_info array.

# Testing
check NID and OID of ASN1 ext_key_usage object  

# Checklist

 - [x] added tests
