### PR TITLE
Improvements to KCAPI support

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -25788,8 +25788,8 @@ static int test_wc_ecc_verify_hash_ex (void)
     int             ret = 0;
 
 #if defined(HAVE_ECC) && defined(HAVE_ECC_SIGN) && defined(WOLFSSL_PUBLIC_MP) \
-     && !defined(WC_NO_RNG) && !defined(WOLFSSL_ATECC508A) && \
-    !defined(WOLFSSL_ATECC608A)
+    && !defined(WC_NO_RNG) && !defined(WOLFSSL_ATECC508A) && \
+       !defined(WOLFSSL_ATECC608A) && !defined(WOLFSSL_KCAPI_ECC)
     ecc_key         key;
     WC_RNG          rng;
     mp_int          r;

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -6604,7 +6604,7 @@ int wc_ecc_set_deterministic(ecc_key* key, byte flag)
     key->deterministic = flag;
     return 0;
 }
-#endif
+#endif /* end sign_ex and deterministic sign */
 
 
 #if defined(WOLFSSL_ECDSA_SET_K) || defined(WOLFSSL_ECDSA_SET_K_ONE_LOOP)

--- a/wolfcrypt/src/port/kcapi/README.md
+++ b/wolfcrypt/src/port/kcapi/README.md
@@ -17,7 +17,34 @@ wolfSSL can be configured to use libkcapi for the following operations:
 Note: Linux kernel does not support public key operations without patching.
 
 
-## Build
+## Building libkcapi
+
+Based on README from https://github.com/smuellerDD/libkcapi
+
+```sh
+git clone https://github.com/smuellerDD/libkcapi
+cd libkcapi
+
+autoreconf -i
+
+./configure	--enable-kcapi-test \
+    --enable-kcapi-speed \
+    --enable-kcapi-hasher \
+    --enable-kcapi-rngapp \
+    --enable-kcapi-encapp \
+    --enable-kcapi-dgstapp \
+    --enable-lib-asym \
+    --enable-lib-kpp \
+    --prefix=/usr/
+make
+sudo make install
+
+# Optional testing
+cd test
+./test.sh
+```
+
+## Building wolfSSL
 
 #### Basic configuration
 
@@ -38,7 +65,10 @@ If AES-CCM is enabled then the following define is also added:
 
 #### Other defines
 
-If hash operations need to be copied or have an intermediate hash result returned then add 'WOLFSSL_KCAPI_HASH_KEEP' to the compile line. For example:
+If hash operations need to be copied or have an intermediate hash result
+returned then add 'WOLFSSL_KCAPI_HASH_KEEP' to the compile line.
+
+For example:
 
 ```
 ./configure --enable-kcapi C_EXTRA_FLAGS=-DWOLFSSL_KCAPI_HASH_KEEP
@@ -73,7 +103,7 @@ To enable libkcapi support in wolfSSL for ECC:
 ./configure --enable-kcapi --enable-kcapi-ecc
 ```
 
-This enanbles support for ECDH and ECDSA.
+This enables support for ECDH and ECDSA.
 
 #### Make
 
@@ -114,7 +144,8 @@ Cipher Name: "sha224", "sha256", "sha384", "sha512"
 When partial results are needed from a hash then define: WOLFSSL_KCAPI_HASH_KEEP
 
 This will keep a copy of all the message data. When a hash result is required,
-the data is passed to libkcapi to perform the operation. When the final hash is requested (eg wc_Sha256Final) then the message data is disposed of. (Required for TLS)
+the data is passed to libkcapi to perform the operation. When the final hash is
+requested (eg wc_Sha256Final) then the message data is disposed of. (Required for TLS)
 
 #### HMAC
 
@@ -143,7 +174,7 @@ Cipher Name: "rsa"
 RSA operations are supported by using the raw RSA encrypt/decrypt operations
 through libkcapi.
 This means that wolfSSL performs the padding. Therefore the following padding schemes are supported:
-* PKCS 1.5 for sign/verify and encrypt/decrypt
+* PKCS v1.5 for sign/verify and encrypt/decrypt
 * PSS for sign/verify
 * OAEP for encrypt/decrypt
 
@@ -163,7 +194,7 @@ The curve is set using kcapi_kpp_ecdh_setcurve().
 
 The Linux kernel does not support ECDSA operations.
 
-Support for specific harware has been added with the following details.
+Support for specific hardware has been added with the following details.
 
 Cipher Name: "ecdsa"
 
@@ -175,4 +206,3 @@ curve-id - one byte and has the same value as used by ECDH.
 private-key - big-endian encoded number the length of the curve.
 x-ord - big-endian encoded number the length of the curve in bytes.
 y-ord - big-endian encoded number the length of the curve in bytes.
-

--- a/wolfcrypt/src/port/kcapi/kcapi_ecc.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_ecc.c
@@ -117,7 +117,7 @@ int KcapiEcc_MakeKey(ecc_key* key, int keysize, int curve_id)
         ret = kcapi_kpp_ecdh_setcurve(key->handle, kcapiCurveId);
     }
     if (ret == 0) {
-        ret = kcapi_kpp_keygen(key->handle, key->pubkey_raw,
+        ret = (int)kcapi_kpp_keygen(key->handle, key->pubkey_raw,
                                sizeof(key->pubkey_raw), KCAPI_ACCESS_HEURISTIC);
     }
     if (ret >= 0) {
@@ -141,9 +141,9 @@ int KcapiEcc_SharedSecret(ecc_key* private_key, ecc_key* public_key, byte* out,
 {
     int ret;
 
-    ret = kcapi_kpp_ssgen(private_key->handle, public_key->pubkey_raw,
-                          public_key->dp->size * 2, out, *outlen,
-                          KCAPI_ACCESS_HEURISTIC);
+    ret = (int)kcapi_kpp_ssgen(private_key->handle, public_key->pubkey_raw,
+                               public_key->dp->size * 2, out, *outlen,
+                               KCAPI_ACCESS_HEURISTIC);
     if (ret >= 0) {
         *outlen = ret;
         ret = 0;
@@ -210,9 +210,9 @@ int KcapiEcc_Sign(ecc_key* key, const byte* hash, word32 hashLen, byte* sig,
             hash_aligned = buf_aligned + pageSz;
             XMEMCPY(hash_aligned, hash, hashLen);
         }
-        ret = kcapi_akcipher_sign(key->handle, hash_aligned, hashLen,
-                                  sig_aligned, *sigLen,
-                                  KCAPI_ACCESS_HEURISTIC);
+        ret = (int)kcapi_akcipher_sign(key->handle, hash_aligned, hashLen,
+                                       sig_aligned, *sigLen,
+                                       KCAPI_ACCESS_HEURISTIC);
         if (ret >= 0) {
             *sigLen = ret;
             ret = 0;
@@ -277,7 +277,7 @@ int KcapiEcc_Verify(ecc_key* key, const byte* hash, word32 hashLen, byte* sig,
         XMEMCPY(sigHash_aligned, sig, sigLen);
         XMEMCPY(sigHash_aligned + sigLen, hash, hashLen);
 
-        ret = kcapi_akcipher_verify(key->handle, sigHash_aligned,
+        ret = (int)kcapi_akcipher_verify(key->handle, sigHash_aligned,
                 sigLen + hashLen, NULL, hashLen, KCAPI_ACCESS_HEURISTIC);
         if (ret >= 0) {
             ret = 0;
@@ -294,4 +294,3 @@ int KcapiEcc_Verify(ecc_key* key, const byte* hash, word32 hashLen, byte* sig,
 #endif
 
 #endif /* WOLFSSL_KCAPI_ECC */
-

--- a/wolfcrypt/src/port/kcapi/kcapi_hash.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_hash.c
@@ -164,13 +164,13 @@ static int KcapiHashFinal(wolfssl_KCAPI_Hash* hash, byte* out, word32 outSz,
         heap = hash->heap; /* keep because KcapiHashInit clears the pointer */
     #ifdef WOLFSSL_KCAPI_HASH_KEEP
         /* keep full message to out at end instead of incremental updates */
-        ret = kcapi_md_update(hash->handle, hash->msg, hash->used);
+        ret = (int)kcapi_md_update(hash->handle, hash->msg, hash->used);
         XFREE(hash->msg, heap, DYNAMIC_TYPE_TMP_BUFFER);
         hash->msg = NULL;
     #endif
 
         if (ret == 0) {
-            ret = kcapi_md_final(hash->handle, out, outSz);
+            ret = (int)kcapi_md_final(hash->handle, out, outSz);
         }
 
         KcapiHashFree(hash);
@@ -198,9 +198,9 @@ static int KcapiHashGet(wolfssl_KCAPI_Hash* hash, byte* out, word32 outSz)
         ret = kcapi_md_init(&hash->handle, hash->type, 0);
     }
     if (ret == 0) {
-        ret = kcapi_md_update(hash->handle, hash->msg, hash->used);
+        ret = (int)kcapi_md_update(hash->handle, hash->msg, hash->used);
         if (ret >= 0) {
-            ret = kcapi_md_final(hash->handle, out, outSz);
+            ret = (int)kcapi_md_final(hash->handle, out, outSz);
             if (ret >= 0) {
                 ret = 0;
             }

--- a/wolfcrypt/src/port/kcapi/kcapi_hmac.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_hmac.c
@@ -234,7 +234,7 @@ int wc_HmacUpdate(Hmac* hmac, const byte* msg, word32 length)
             ret = wc_HmacUpdate_Software(hmac, msg, length);
             break;
         default:
-            ret = kcapi_md_update(hmac->handle, msg, length);
+            ret = (int)kcapi_md_update(hmac->handle, msg, length);
             if (ret >= 0) {
                 ret = 0;
             }
@@ -325,7 +325,7 @@ int wc_HmacFinal(Hmac* hmac, byte* hash)
                 return wc_HmacFinal_Software(hmac, hash);
         #endif
         }
-        ret = kcapi_md_final(hmac->handle, hash, len);
+        ret = (int)kcapi_md_final(hmac->handle, hash, len);
     }
     if (ret >= 0) {
         ret = 0;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -23268,7 +23268,7 @@ exit:
 /* ./configure --enable-ecc=nonblock --enable-sp=yes,nonblock CFLAGS="-DWOLFSSL_PUBLIC_MP" */
 #if defined(WC_ECC_NONBLOCK) && defined(WOLFSSL_PUBLIC_MP) && \
     defined(HAVE_ECC_SIGN) && defined(HAVE_ECC_VERIFY) && \
-    !defined(WOLFSSL_KCAPI_ECC)
+    defined(WOLFSSL_HAVE_SP_ECC)
 /* Test Data - Random */
 static const uint8_t kMsg[] = {
     0x69, 0xbc, 0x9f, 0xce, 0x68, 0x17, 0xc2, 0x10, 0xea, 0xfc, 0x10, 0x65, 0x67, 0x52, 0xed, 0x78,

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -22678,7 +22678,8 @@ done:
 }
 #endif /* !NO_ECC256 || HAVE_ALL_CURVES */
 
-#ifdef WOLFSSL_CERT_EXT
+#if defined(WOLFSSL_CERT_EXT) && \
+    (!defined(NO_ECC256) || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 256
 static int ecc_decode_test(void)
 {
     int        ret;
@@ -23266,7 +23267,8 @@ exit:
 /* Requires SP math and supports P384 or P256 */
 /* ./configure --enable-ecc=nonblock --enable-sp=yes,nonblock CFLAGS="-DWOLFSSL_PUBLIC_MP" */
 #if defined(WC_ECC_NONBLOCK) && defined(WOLFSSL_PUBLIC_MP) && \
-    defined(HAVE_ECC_SIGN) && defined(HAVE_ECC_VERIFY)
+    defined(HAVE_ECC_SIGN) && defined(HAVE_ECC_VERIFY) && \
+    !defined(WOLFSSL_KCAPI_ECC)
 /* Test Data - Random */
 static const uint8_t kMsg[] = {
     0x69, 0xbc, 0x9f, 0xce, 0x68, 0x17, 0xc2, 0x10, 0xea, 0xfc, 0x10, 0x65, 0x67, 0x52, 0xed, 0x78,
@@ -23829,7 +23831,8 @@ WOLFSSL_TEST_SUBROUTINE int ecc_test(void)
     int ret;
     WC_RNG rng;
 
-#ifdef WOLFSSL_CERT_EXT
+#if defined(WOLFSSL_CERT_EXT) && \
+    (!defined(NO_ECC256) || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 256
     ret = ecc_decode_test();
     if (ret < 0)
         return ret;


### PR DESCRIPTION
# Description

Fixes for minor build warnings / error with libkcapi.

Fixes ZD12663

# Testing

Tested on RedHat kernel 4.18 using `./configure --enable-ssh --enable-kcapi --enable-kcapi-hmac --enable-kcapi-ecc`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
