### PR TITLE
Fix wait-until-done in rsa hw primitive acceleration of ESP-IDF port

### DIFF
--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/wifi_connect.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_client/main/wifi_connect.c
@@ -54,7 +54,7 @@ static void set_time()
     /* please update the time if seeing unknown failure when loading cert.  */
     /* this could cause TLS communication failure due to time expiration    */
     /* incleasing 31536000 seconds is close to spend 356 days.              */
-    utctime.tv_sec = 1619650800; /* dummy time: Wed April 28 23:00:00 2021 */
+    utctime.tv_sec = 1645797600; /* dummy time: Fri 25 Feb 2022 02:00:00 2022 */
     utctime.tv_usec = 0;
     tz.tz_minuteswest = 0;
     tz.tz_dsttime = 0;

--- a/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/wifi_connect.c
+++ b/IDE/Espressif/ESP-IDF/examples/wolfssl_server/main/wifi_connect.c
@@ -51,7 +51,7 @@ static void set_time()
     /* please update the time if seeing unknown failure when loading cert.  */
     /* this could cause TLS communication failure due to time expiration    */
     /* incleasing 31536000 seconds is close to spend 356 days.              */
-    utctime.tv_sec = 1619650800; /* dummy time: Wed April 28 23:00:00 2021 */
+    utctime.tv_sec = 1645797600; /* dummy time: Fri 25 Feb 2022 02:00:00 2022 */
     utctime.tv_usec = 0;
     tz.tz_minuteswest = 0;
     tz.tz_dsttime = 0;

--- a/IDE/Espressif/ESP-IDF/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/user_settings.h
@@ -99,3 +99,6 @@
 /* #define NO_WOLFSSL_ESP32WROOM32_CRYPT_HASH*/
 /* #define NO_WOLFSSL_ESP32WROOM32_CRYPT_AES */
 /* #define NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI */
+
+/* adjust wait-timeout count if you see timeout in  ras hw acceleration */
+#define ESP_RSA_TIMEOUT_CNT    0x249F00

--- a/IDE/Espressif/ESP-IDF/user_settings.h
+++ b/IDE/Espressif/ESP-IDF/user_settings.h
@@ -100,5 +100,5 @@
 /* #define NO_WOLFSSL_ESP32WROOM32_CRYPT_AES */
 /* #define NO_WOLFSSL_ESP32WROOM32_CRYPT_RSA_PRI */
 
-/* adjust wait-timeout count if you see timeout in  ras hw acceleration */
+/* adjust wait-timeout count if you see timeout in rsa hw acceleration */
 #define ESP_RSA_TIMEOUT_CNT    0x249F00

--- a/wolfcrypt/src/port/Espressif/esp32_mp.c
+++ b/wolfcrypt/src/port/Espressif/esp32_mp.c
@@ -66,7 +66,7 @@ static int esp_mp_hw_wait_clean()
                 DPORT_REG_READ(RSA_CLEAN_REG) != 1) { }
 
     if(ESP_TIMEOUT(timeout)) {
-        ESP_LOGE(TAG, "waiting hw ready is time-outed.");
+        ESP_LOGE(TAG, "waiting hw ready is timed out.");
         return MP_NG;
     }
     return MP_OKAY; 
@@ -158,7 +158,7 @@ static int wait_uitil_done(word32 reg)
     DPORT_REG_WRITE(RSA_INTERRUPT_REG, 1);
 
     if(ESP_TIMEOUT(timeout)) {
-        ESP_LOGE(TAG, "rsa operation is time-outed.");
+        ESP_LOGE(TAG, "rsa operation is timed out.");
         return MP_NG;
     }
 

--- a/wolfcrypt/src/port/Espressif/esp32_mp.c
+++ b/wolfcrypt/src/port/Espressif/esp32_mp.c
@@ -51,6 +51,8 @@ static const char* const TAG = "wolfssl_mp";
 
 #define MP_NG   -1
 
+#define ESP_TIMEOUT(cnt)         (cnt >= ESP_RSA_TIMEOUT_CNT)
+
 /* mutex */
 static wolfSSL_Mutex mp_mutex;
 static int espmp_CryptHwMutexInit = 0;
@@ -59,10 +61,11 @@ static int espmp_CryptHwMutexInit = 0;
 */
 static int esp_mp_hw_wait_clean()
 {
-    int timeout = 0;
-    while(++timeout < ESP_RSA_TIMEOUT && DPORT_REG_READ(RSA_CLEAN_REG) != 1){}
+    word32 timeout = 0;
+    while(!ESP_TIMEOUT(++timeout) && 
+                DPORT_REG_READ(RSA_CLEAN_REG) != 1) { }
 
-    if(timeout >= ESP_RSA_TIMEOUT) {
+    if(ESP_TIMEOUT(timeout)) {
         ESP_LOGE(TAG, "waiting hw ready is time-outed.");
         return MP_NG;
     }
@@ -146,18 +149,15 @@ static void process_start(word32 reg)
 /* wait until done */
 static int wait_uitil_done(word32 reg)
 {
-    int timeout = 0;
+    word32 timeout = 0;
     /* wait until done && not timeout */
-    while(1) {
-        if(++timeout < ESP_RSA_TIMEOUT && DPORT_REG_READ(reg) == 1){
-            break;
-        }
-    }
+    while(!ESP_TIMEOUT(++timeout) && 
+                DPORT_REG_READ(reg) != 1) { }
 
     /* clear interrupt */
     DPORT_REG_WRITE(RSA_INTERRUPT_REG, 1);
 
-    if(timeout >= ESP_RSA_TIMEOUT) {
+    if(ESP_TIMEOUT(timeout)) {
         ESP_LOGE(TAG, "rsa operation is time-outed.");
         return MP_NG;
     }

--- a/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
+++ b/wolfssl/wolfcrypt/port/Espressif/esp32-crypt.h
@@ -142,8 +142,8 @@ int esp_sha_process(struct wc_Sha* sha, const byte* data);
 
 #if !defined(NO_RSA) || defined(HAVE_ECC)
 
-#ifndef ESP_RSA_TIMEOUT
-    #define ESP_RSA_TIMEOUT 0xFFFFF
+#if !defined(ESP_RSA_TIMEOUT_CNT)
+    #define ESP_RSA_TIMEOUT_CNT     0x249F00
 #endif
 
 struct fp_int;


### PR DESCRIPTION
# Description

Reported zd#13777. 
Error condition at int wait_uitil_done(word32 reg) in esp32_mp.c causes infinite loop.

# Testing

Verified changes on ESP32-D0WDQ6-V3 chip by using client/server/crypt-test/crypt-benchmark and ESP-IDF unit test

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [x] updated appropriate READMEs
 - [ ] Updated manual and documentation
