### PR TITLE
OpenSSL considers PSK resuming

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -3958,6 +3958,10 @@ static int FindPsk(WOLFSSL* ssl, PreSharedKey* psk, byte* suite, int* err)
             /* Derive the early secret using the PSK. */
             ret = DeriveEarlySecret(ssl);
         }
+        if ((ret == 0) && found) {
+            /* PSK negotiation has succeeded */
+            ssl->options.isPSK = 1;
+        }
     }
 
     *err = ret;
@@ -6912,6 +6916,13 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     /* verify the client sent certificate if required */
     if (ssl->options.side == WOLFSSL_SERVER_END && !ssl->options.resuming &&
             (ssl->options.mutualAuth || ssl->options.failNoCert)) {
+#ifdef OPENSSL_COMPATIBLE_DEFAULTS
+        if (ssl->options.isPSK) {
+            WOLFSSL_MSG("TLS v1.3 client used PSK but cert required. Allowing "
+                        "for OpenSSL compatibility");
+        }
+        else
+#endif
         if (!ssl->options.havePeerCert || !ssl->options.havePeerVerify) {
             ret = NO_PEER_CERT; /* NO_PEER_VERIFY */
             WOLFSSL_MSG("TLS v1.3 client did not present peer cert");

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -3633,6 +3633,7 @@ typedef struct Options {
     word16            failNoCertxPSK:1;   /* fail for no cert except with PSK */
     word16            downgrade:1;        /* allow downgrade of versions */
     word16            resuming:1;
+    word16            isPSK:1;
     word16            haveSessionId:1;    /* server may not send */
     word16            tls:1;              /* using TLS ? */
     word16            tls1_1:1;           /* using TLSv1.1+ ? */


### PR DESCRIPTION
- `SSL_VERIFY_FAIL_IF_NO_PEER_CERT` check passes on a TLS 1.3 PSK connection that isn't a ticket