### PR TITLE
Injection and parsing of custom extensions in X.509 certificates.

### DIFF
--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -1937,3 +1937,55 @@ WOLFSSL_API int wc_SetTimeCb(wc_time_cb f);
     \sa wc_SetTimeCb
 */
 WOLFSSL_API time_t wc_Time(time_t* t);
+
+/*!
+    \ingroup ASN
+
+    \brief This function registers a callback that will be used anytime
+    wolfSSL encounters an unknown X.509 extension in a certificate while parsing
+    a certificate. The prototype of the callback should be:
+
+    \return 0 Returned on success.
+
+    \param cert the DecodedCert struct that is to be associated with this
+    callback.
+    \param cb function to register as the time callback.
+
+    _Example_
+    \code
+    int ret = 0;
+    // Unkown extension callback prototype
+    int myUnknownExtCallback(const word16* oid, word32 oidSz, int crit,
+                             const unsigned char* der, word32 derSz);
+
+    // Register it
+    ret = wc_SetUnknownExtCallback(cert, myUnknownExtCallback);
+    if (ret != 0) {
+        // failed to set the callback
+    }
+
+    // oid: Array of integers that are the dot separated values in an oid.
+    // oidSz: Number of values in oid.
+    // crit: Whether the extension was mark critical.
+    // der: The der encoding of the content of the extension.
+    // derSz: The size in bytes of the der encoding.
+    int myCustomExtCallback(const word16* oid, word32 oidSz, int crit,
+                            const unsigned char* der, word32 derSz) {
+
+        // Logic to parse extension goes here.
+
+        // NOTE: by returning zero, we are accepting this extension and
+        // informing wolfSSL that it is acceptable. If you find an extension
+        // that you do not find acceptable, you should return an error. The
+        // standard behavior upon encountering an unknown extension with the
+        // critical flag set is to return ASN_CRIT_EXT_E. For the sake of
+        // brevity, this example is always accepting every extension; you
+        // should use different logic.
+        return 0;
+    }
+    \endcode
+
+    \sa ParseCert
+*/
+WOLFSSL_ASN_API int wc_SetUnknownExtCallback(DecodedCert* cert,
+                                             wc_UnknownExtCallback cb);

--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -1941,11 +1941,58 @@ WOLFSSL_API time_t wc_Time(time_t* t);
 /*!
     \ingroup ASN
 
+    \brief This function injects a custom extension in to an X.509 certificate.
+
+    \return 0 Returned on success.
+    \return Other negative values on failure.
+
+    \param cert Pointer to an initialized DecodedCert object.
+    \param critical If 0, the extension will not be marked critical, otherwise
+     it will be marked critical.
+    \param oid Dot separted oid as a string. For example "1.2.840.10045.3.1.7"
+    \param der The der encoding of the content of the extension.
+    \param derSz The size in bytes of the der encoding.
+
+
+    _Example_
+    \code
+    int ret = 0;
+    Cert newCert;
+    wc_InitCert(&newCert);
+
+    // Code to setup subject, public key, issuer, and other things goes here.
+
+    ret = wc_SetCustomExtension(&newCert, 1, "1.2.3.4.5",
+              (const byte *)"This is a critical extension", 28);
+    if (ret < 0) {
+        // Failed to set the extension.
+    }
+
+    ret = wc_SetCustomExtension(&newCert, 0, "1.2.3.4.6",
+              (const byte *)"This is NOT a critical extension", 32)
+    if (ret < 0) {
+        // Failed to set the extension.
+    }
+
+    // Code to sign the certificate and then write it out goes here.
+
+    \endcode
+
+    \sa wc_InitCert
+    \sa wc_SetUnknownExtCallback
+*/
+WOLFSSL_API int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
+                                      const byte *der, word32 derSz);
+
+/*!
+    \ingroup ASN
+
     \brief This function registers a callback that will be used anytime
     wolfSSL encounters an unknown X.509 extension in a certificate while parsing
     a certificate. The prototype of the callback should be:
 
     \return 0 Returned on success.
+    \return Other negative values on failure.
 
     \param cert the DecodedCert struct that is to be associated with this
     callback.
@@ -1986,6 +2033,7 @@ WOLFSSL_API time_t wc_Time(time_t* t);
     \endcode
 
     \sa ParseCert
+    \sa wc_SetCustomExtension
 */
 WOLFSSL_ASN_API int wc_SetUnknownExtCallback(DecodedCert* cert,
                                              wc_UnknownExtCallback cb);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5119,7 +5119,7 @@ static int DumpOID(const byte* oidData, word32 oidSz, word32 oid,
 
     #ifdef HAVE_OID_DECODING
     {
-        word16 decOid[16];
+        word16 decOid[MAX_OID_SZ];
         word32 decOidSz = sizeof(decOid);
         /* Decode the OID into dotted form. */
         ret = DecodeObjectId(oidData, oidSz, decOid, &decOidSz);
@@ -16978,7 +16978,7 @@ end:
                                       &isUnknownExt);
 #if defined(WOLFSSL_CUSTOM_OID) && defined(HAVE_OID_DECODING)
             if (isUnknownExt && (cert->unknownExtCallback != NULL)) {
-                word16 decOid[16];
+                word16 decOid[MAX_OID_SZ];
                 word32 decOidSz = sizeof(decOid);
                 ret = DecodeObjectId(
                           dataASN[CERTEXTASN_IDX_OID].data.oid.data,

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -23259,7 +23259,6 @@ static const ASNItem static_certExtsASN[] = {
 /* SAN_SEQ       */    { 0, ASN_SEQUENCE, 1, 1, 0 },
 /* SAN_OID       */       { 1, ASN_OBJECT_ID, 0, 0, 0 },
 /* SAN_STR       */       { 1, ASN_OCTET_STRING, 0, 0, 0 },
-#ifdef WOLFSSL_CERT_EXT
             /* Subject Key Identifier - 4.2.1.2 */
 /* SKID_SEQ      */    { 0, ASN_SEQUENCE, 1, 1, 0 },
 /* SKID_OID      */        { 1, ASN_OBJECT_ID, 0, 0, 0 },
@@ -23294,12 +23293,9 @@ static const ASNItem static_certExtsASN[] = {
 /* CRLINFO_SEQ   */    { 0, ASN_SEQUENCE, 1, 1, 0 },
 /* CRLINFO_OID   */        { 1, ASN_OBJECT_ID, 0, 0, 0 },
 /* CRLINFO_STR   */        { 1, ASN_OCTET_STRING, 0, 0, 0 },
-#endif /* WOLFSSL_CERT_EXT */
-#ifdef WOLFSSL_CUSTOM_OID
 /* CUSTOM_SEQ    */    { 0, ASN_SEQUENCE, 1, 1, 0 },
 /* CUSTOM_OID    */        { 1, ASN_OBJECT_ID, 0, 0, 0 },
 /* CUSTOM_STR    */        { 1, ASN_OCTET_STRING, 0, 0, 0 },
-#endif
 };
 enum {
     CERTEXTSASN_IDX_BC_SEQ = 0,
@@ -23343,6 +23339,7 @@ enum {
     CERTEXTSASN_IDX_CUSTOM_OID,
     CERTEXTSASN_IDX_CUSTOM_STR,
     CERTEXTSASN_IDX_START_CUSTOM,
+
 };
 
 /* Number of items in ASN.1 template for certificate extensions. We multiply
@@ -23402,7 +23399,7 @@ static int EncodeExtensions(Cert* cert, byte* output, word32 maxSz,
     /* Clone static_certExtsASN into a certExtsASN and then fill the rest of it
      * with (NUM_CUSTOM_EXT*4) more ASNItems specifying extensions. See comment
      * above definition of certExtsASN_Length. */
-    XMEMCPY(certExtsASN, static_certExtsASN, sizeof(*static_certExtsASN));
+    XMEMCPY(certExtsASN, static_certExtsASN, sizeof(static_certExtsASN));
     for (i = sizeof(static_certExtsASN) / sizeof(ASNItem);
          i < (int)(sizeof(certExtsASN) / sizeof(ASNItem)); i += 4) {
         /* CUSTOM_SEQ */
@@ -23581,8 +23578,9 @@ static int EncodeExtensions(Cert* cert, byte* output, word32 maxSz,
                     CERTEXTSASN_IDX_CUSTOM_STR);
         }
 
+        i = 0;
     #ifdef WOLFSSL_CUSTOM_OID
-        for (i = 0; i < cert->customCertExtCount; i++) {
+        for (; i < cert->customCertExtCount; i++) {
              int idx = CERTEXTSASN_IDX_START_CUSTOM + (i * 4);
              word32 encodedOidSz = MAX_OID_SZ;
              idx ++; /* Skip one for for SEQ. */
@@ -23600,7 +23598,6 @@ static int EncodeExtensions(Cert* cert, byte* output, word32 maxSz,
         }
     #endif
 
-        /* Note: i initialized to 0 at top. */
         while (i < NUM_CUSTOM_EXT) {
             SetASNItem_NoOut(dataASN, CERTEXTSASN_IDX_START_CUSTOM + (i * 4),
                              CERTEXTSASN_IDX_START_CUSTOM + (i * 4) + 3);

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -23374,7 +23374,9 @@ static int EncodeExtensions(Cert* cert, byte* output, word32 maxSz,
 #endif
 
 #ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_CERT_EXT)
     byte *encodedOids;
+#endif
     ASNItem *certExtsASN = (ASNItem *)XMALLOC(certExtsASN_Length *
                                               sizeof(ASNItem), cert->heap,
                                               DYNAMIC_TYPE_TMP_BUFFER);
@@ -23382,16 +23384,19 @@ static int EncodeExtensions(Cert* cert, byte* output, word32 maxSz,
         return MEMORY_E;
     }
 
+#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_CERT_EXT)
     encodedOids = (byte *)XMALLOC(NUM_CUSTOM_EXT * MAX_OID_SZ, cert->heap,
                                   DYNAMIC_TYPE_TMP_BUFFER);
     if (encodedOids == NULL) {
         XFREE(certExtsASN, cert->heap, DYNAMIC_TYPE_TMP_BUFFER);
         return MEMORY_E;
     }
-
+#endif
 #else
     ASNItem certExtsASN[certExtsASN_Length];
+#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_CERT_EXT)
     byte encodedOids[NUM_CUSTOM_EXT * MAX_OID_SZ];
+#endif
 #endif
 
     /* Clone static_certExtsASN into a certExtsASN and then fill the rest of it
@@ -23651,7 +23656,9 @@ static int EncodeExtensions(Cert* cert, byte* output, word32 maxSz,
 
     FREE_ASNSETDATA(dataASN, cert->heap);
 #ifdef WOLFSSL_SMALL_STACK
+#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_CERT_EXT)
     XFREE(encodedOids, cert->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
     XFREE(certExtsASN, cert->heap, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -23284,7 +23284,7 @@ static const ASNItem static_certExtsASN[] = {
 /* POLICIES_SEQ, */    { 0, ASN_SEQUENCE, 1, 1, 0 },
 /* POLICIES_OID, */        { 1, ASN_OBJECT_ID, 0, 0, 0 },
 /* POLICIES_STR, */        { 1, ASN_OCTET_STRING, 0, 1, 0 },
-/* POLICIES_INFO */            { 2, ASN_SEQUENCE, 0, 0, 0 },
+/* POLICIES_INFO */            { 2, ASN_SEQUENCE, 1, 0, 0 },
                                        /* Netscape Certificate Type */
 /* NSTYPE_SEQ    */    { 0, ASN_SEQUENCE, 1, 1, 0 },
 /* NSTYPE_OID    */        { 1, ASN_OBJECT_ID, 0, 0, 0 },

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -5119,16 +5119,14 @@ static int DumpOID(const byte* oidData, word32 oidSz, word32 oid,
 
     #ifdef HAVE_OID_DECODING
     {
-        byte decOid[MAX_OID_SZ];
-        word16 *out = decOid;
-        word32 decOidSz = sizeof(decOid) / 2;
+        word16 decOid[16];
+        word32 decOidSz = sizeof(decOid);
         /* Decode the OID into dotted form. */
-        ret = DecodeObjectId(oidData, oidSz, (word16*)decOid, &decOidSz);
+        ret = DecodeObjectId(oidData, oidSz, decOid, &decOidSz);
         if (ret == 0) {
             printf("  Decoded (Sz %d): ", decOidSz);
-            for (i=0; i<decOidSz; i += 2) {
-                printf("%d.", *out);
-                out ++;
+            for (i=0; i<decOidSz; i++) {
+                printf("%d.", decOid[i]);
             }
             printf("\n");
         }
@@ -16981,12 +16979,12 @@ end:
 #if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
     && defined(HAVE_OID_DECODING)
             if (isUnknownExt && (cert->unknownExtCallback != NULL)) {
-                byte decOid[MAX_OID_SZ];
-                word32 decOidSz = sizeof(decOid) / 2;
+                word16 decOid[16];
+                word32 decOidSz = sizeof(decOid);
                 ret = DecodeObjectId(
                           dataASN[CERTEXTASN_IDX_OID].data.oid.data,
                           dataASN[CERTEXTASN_IDX_OID].data.oid.length,
-                          (word16*)decOid, &decOidSz);
+                          decOid, &decOidSz);
                 if (ret != 0) {
                     /* Should never get here as the extension was successfully
                      * decoded earlier. Something might be corrupted. */
@@ -16994,7 +16992,7 @@ end:
                     WOLFSSL_ERROR(ret);
                 }
 
-                ret = cert->unknownExtCallback(decOid, decOidSz * 2, critical,
+                ret = cert->unknownExtCallback(decOid, decOidSz, critical,
                           dataASN[CERTEXTASN_IDX_VAL].data.buffer.data,
                           dataASN[CERTEXTASN_IDX_VAL].length);
             }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4049,7 +4049,7 @@ int wc_ecc_get_curve_id_from_oid(const byte* oid, word32 len)
     int curve_idx;
 #ifdef HAVE_OID_DECODING
     int ret;
-    word16 decOid[16];
+    word16 decOid[MAX_OID_SZ];
     word32 decOidSz = sizeof(decOid);
 #endif
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4047,17 +4047,37 @@ int wc_ecc_get_curve_id_from_dp_params(const ecc_set_type* dp)
 int wc_ecc_get_curve_id_from_oid(const byte* oid, word32 len)
 {
     int curve_idx;
+#ifdef HAVE_OID_DECODING
+    int ret;
+    word16 decOid[16];
+    word32 decOidSz = sizeof(decOid);
+#endif
 
     if (oid == NULL)
         return BAD_FUNC_ARG;
+
+#ifdef HAVE_OID_DECODING
+    ret = DecodeObjectId(oid, len, decOid, &decOidSz);
+    if (ret != 0) {
+        return ret;
+    }
+#endif
 
     for (curve_idx = 0; ecc_sets[curve_idx].size != 0; curve_idx++) {
         if (
         #ifndef WOLFSSL_ECC_CURVE_STATIC
             ecc_sets[curve_idx].oid &&
         #endif
+        #ifdef HAVE_OID_DECODING
+            /* We double because decOidSz is a count of word16 elements. */
+            ecc_sets[curve_idx].oidSz == decOidSz &&
+                              XMEMCMP(ecc_sets[curve_idx].oid, decOid,
+                                      decOidSz * 2) == 0
+        #else
             ecc_sets[curve_idx].oidSz == len &&
-                              XMEMCMP(ecc_sets[curve_idx].oid, oid, len) == 0) {
+                              XMEMCMP(ecc_sets[curve_idx].oid, oid, len) == 0
+        #endif
+        ) {
             break;
         }
     }

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -513,7 +513,7 @@ WOLFSSL_LOCAL void SetASN_OID(ASNSetData *dataASN, int oid, int oidType);
  */
 #define SetASN_Buffer(dataASN, d, l)                                   \
     do {                                                               \
-        (dataASN)->data.buffer.data   = (const byte *) d;              \
+        (dataASN)->data.buffer.data   = d;                             \
         (dataASN)->data.buffer.length = l;                             \
     } while (0)
 

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -513,7 +513,7 @@ WOLFSSL_LOCAL void SetASN_OID(ASNSetData *dataASN, int oid, int oidType);
  */
 #define SetASN_Buffer(dataASN, d, l)                                   \
     do {                                                               \
-        (dataASN)->data.buffer.data   = d;                             \
+        (dataASN)->data.buffer.data   = (const byte *) d;              \
         (dataASN)->data.buffer.length = l;                             \
     } while (0)
 
@@ -1459,6 +1459,11 @@ typedef struct TrustedPeerCert TrustedPeerCert;
 typedef struct SignatureCtx SignatureCtx;
 typedef struct CertSignCtx  CertSignCtx;
 
+#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
+    && defined(HAVE_OID_DECODING)
+typedef int (*wc_UnknownExtCallback)(const word16* oid, word32 oidSz, int crit,
+                                     const unsigned char* der, word32 derSz);
+#endif
 
 struct DecodedCert {
     const byte* publicKey;
@@ -1689,6 +1694,10 @@ struct DecodedCert {
 #ifdef WOLFSSL_CERT_REQ
     byte isCSR : 1;                /* Do we intend on parsing a CSR? */
 #endif
+#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
+    && defined(HAVE_OID_DECODING)
+    wc_UnknownExtCallback unknownExtCallback;
+#endif
 };
 
 #ifdef NO_SHA
@@ -1815,6 +1824,12 @@ WOLFSSL_ASN_API void InitDecodedCert(DecodedCert* cert, const byte* source,
 WOLFSSL_ASN_API void FreeDecodedCert(DecodedCert* cert);
 WOLFSSL_ASN_API int  ParseCert(DecodedCert* cert, int type, int verify,
                                void* cm);
+
+#if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
+    && defined(HAVE_OID_DECODING)
+WOLFSSL_ASN_API void SetUnknownExtCallback(DecodedCert* cert,
+                                           wc_UnknownExtCallback cb);
+#endif
 
 WOLFSSL_LOCAL int DecodePolicyOID(char *out, word32 outSz, const byte *in,
                                   word32 inSz);

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1461,7 +1461,7 @@ typedef struct CertSignCtx  CertSignCtx;
 
 #if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
     && defined(HAVE_OID_DECODING)
-typedef int (*wc_UnknownExtCallback)(const byte* oid, word32 oidSz, int crit,
+typedef int (*wc_UnknownExtCallback)(const word16* oid, word32 oidSz, int crit,
                                      const unsigned char* der, word32 derSz);
 #endif
 

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1461,7 +1461,7 @@ typedef struct CertSignCtx  CertSignCtx;
 
 #if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
     && defined(HAVE_OID_DECODING)
-typedef int (*wc_UnknownExtCallback)(const word16* oid, word32 oidSz, int crit,
+typedef int (*wc_UnknownExtCallback)(const byte* oid, word32 oidSz, int crit,
                                      const unsigned char* der, word32 derSz);
 #endif
 
@@ -1827,8 +1827,8 @@ WOLFSSL_ASN_API int  ParseCert(DecodedCert* cert, int type, int verify,
 
 #if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
     && defined(HAVE_OID_DECODING)
-WOLFSSL_ASN_API void SetUnknownExtCallback(DecodedCert* cert,
-                                           wc_UnknownExtCallback cb);
+WOLFSSL_ASN_API int wc_SetUnknownExtCallback(DecodedCert* cert,
+                                             wc_UnknownExtCallback cb);
 #endif
 
 WOLFSSL_LOCAL int DecodePolicyOID(char *out, word32 outSz, const byte *in,

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -322,6 +322,13 @@ typedef struct CertOidField {
     int    valSz;
     char   enc;
 } CertOidField;
+
+typedef struct CertExtension {
+    const char* oid;
+    byte        crit;
+    const byte* val;
+    int         valSz;
+} CertExtension;
 #endif
 #endif /* WOLFSSL_CERT_GEN */
 
@@ -368,6 +375,10 @@ typedef struct CertName {
 #endif /* WOLFSSL_CERT_GEN || OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL*/
 
 #ifdef WOLFSSL_CERT_GEN
+
+#ifndef NUM_CUSTOM_EXT
+#define NUM_CUSTOM_EXT 16
+#endif
 
 /* for user to fill for certificate generation */
 typedef struct Cert {
@@ -432,9 +443,13 @@ typedef struct Cert {
     int      challengePwPrintableString; /* encode as PrintableString */
 #endif
 #ifdef WOLFSSL_CUSTOM_OID
-    CertOidField extCustom; /* user oid and value to go in req extensions */
-#endif
+    /* user oid and value to go in req extensions */
+    CertOidField extCustom;
 
+    /* Extensions to go into X.509 certificates */
+    CertExtension customCertExt[NUM_CUSTOM_EXT];
+    int customCertExtCount;
+#endif
     void*   decodedCert;    /* internal DecodedCert allocated from heap */
     byte*   der;            /* Pointer to buffer of current DecodedCert cache */
     void*   heap;           /* heap hint */
@@ -530,6 +545,13 @@ WOLFSSL_API int wc_SetExtKeyUsage(Cert *cert, const char *value);
 WOLFSSL_API int wc_SetExtKeyUsageOID(Cert *cert, const char *oid, word32 sz,
                                      byte idx, void* heap);
 #endif /* WOLFSSL_EKU_OID */
+
+#if defined(WOLFSSL_ASN_TEMPLATE) && defined(WOLFSSL_CUSTOM_OID) && \
+    defined(HAVE_OID_ENCODING)
+WOLFSSL_API int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
+                                      const byte *der, word32 derSz);
+#endif
+
 #endif /* WOLFSSL_CERT_EXT */
 #endif /* WOLFSSL_CERT_GEN */
 


### PR DESCRIPTION
# Testing

Wrote and example and ran it against customer certificate. 
https://github.com/wolfSSL/wolfssl-examples/pull/299

For parsing:
```
./configure --enable-asn=template --enable-certreq --enable-certgen CFLAGS="-DWOLFSSL_TEST_CERT -DHAVE_OID_DECODING -DWOLFSSL_CUSTOM_OID -DWOLFSSL_CERT_EXT"
```
For injecting: 
```
./configure --enable-asn=template --enable-certgen --enable-keygen CFLAGS="-DWOLFSSL_CUSTOM_OID -DHAVE_OID_ENCODING -DWOLFSSL_CERT_EXT"
```

# Checklist

 - [ ] added tests
 - [X] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
