### PR TITLE
Fix issues reported in ZD13606

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -134,6 +134,11 @@ static int wolfSSL_BIO_MEMORY_read(WOLFSSL_BIO* bio, void* buf, int len)
     return sz;
 }
 
+int wolfSSL_BIO_method_type(const WOLFSSL_BIO *b)
+{
+    return b != NULL ? b->type : (int)WOLFSSL_BIO_UNDEF;
+}
+
 #ifndef WOLFCRYPT_ONLY
 /* Helper function to read from WOLFSSL_BIO_SSL type
  *
@@ -1738,8 +1743,6 @@ long wolfSSL_BIO_set_nbio(WOLFSSL_BIO* bio, long on)
 
     return WOLFSSL_SUCCESS;
 }
-
-
 
 /* creates a new custom WOLFSSL_BIO_METHOD */
 WOLFSSL_BIO_METHOD *wolfSSL_BIO_meth_new(int type, const char *name)

--- a/src/internal.c
+++ b/src/internal.c
@@ -30759,7 +30759,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
         if (ret == WOLFSSL_TICKET_RET_FATAL)
             ret = WOLFSSL_TICKET_RET_REJECT;
-        if (ret < 0) return ret;
+        if (ret < 0)
+            return ret;
         if (outLen > (int)inLen || outLen < (int)sizeof(InternalTicket)) {
             WOLFSSL_MSG("Bad user ticket decrypt len");
             return BAD_TICKET_KEY_CB_SZ;

--- a/src/internal.c
+++ b/src/internal.c
@@ -30757,7 +30757,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                                     et->enc_ticket, inLen, &outLen,
                                     ssl->ctx->ticketEncCtx);
         }
-        if (ret == WOLFSSL_TICKET_RET_FATAL || ret < 0) return ret;
+        if (ret == WOLFSSL_TICKET_RET_FATAL)
+            ret = WOLFSSL_TICKET_RET_REJECT;
+        if (ret < 0) return ret;
         if (outLen > (int)inLen || outLen < (int)sizeof(InternalTicket)) {
             WOLFSSL_MSG("Bad user ticket decrypt len");
             return BAD_TICKET_KEY_CB_SZ;

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -170,8 +170,8 @@ int BioReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx)
     recvd = wolfSSL_BIO_read(ssl->biord, buf, sz);
     if (recvd <= 0) {
         if (/* ssl->biowr->wrIdx is checked for Bind9 */
-            ssl->biowr != NULL && ssl->biowr->type == WOLFSSL_BIO_BIO &&
-            ssl->biowr->wrIdx != 0 &&
+            wolfSSL_BIO_method_type(ssl->biowr) == WOLFSSL_BIO_BIO &&
+            wolfSSL_BIO_wpending(ssl->biowr) != 0 &&
             /* Not sure this pending check is necessary but let's double
              * check that the read BIO is empty before we signal a write
              * need */

--- a/wolfssl/openssl/ssl.h
+++ b/wolfssl/openssl/ssl.h
@@ -764,6 +764,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define BIO_do_handshake                wolfSSL_BIO_do_handshake
 #define BIO_ssl_shutdown                wolfSSL_BIO_ssl_shutdown
 #define SSL_set_bio                     wolfSSL_set_bio
+#define BIO_method_type                 wolfSSL_BIO_method_type
 #define BIO_set_ssl                     wolfSSL_BIO_set_ssl
 #define BIO_get_ssl                     wolfSSL_BIO_get_ssl
 #define BIO_new_ssl_connect             wolfSSL_BIO_new_ssl_connect

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -446,6 +446,7 @@ struct WOLFSSL_X509_PUBKEY {
 };
 
 enum BIO_TYPE {
+    WOLFSSL_BIO_UNDEF  = 0,
     WOLFSSL_BIO_BUFFER = 1,
     WOLFSSL_BIO_SOCKET = 2,
     WOLFSSL_BIO_SSL    = 3,
@@ -1609,6 +1610,7 @@ WOLFSSL_API long wolfSSL_BIO_set_fd(WOLFSSL_BIO* b, int fd, int flag);
 #endif
 WOLFSSL_API int wolfSSL_BIO_set_close(WOLFSSL_BIO *b, long flag);
 WOLFSSL_API void wolfSSL_set_bio(WOLFSSL* ssl, WOLFSSL_BIO* rd, WOLFSSL_BIO* wr);
+WOLFSSL_API int wolfSSL_BIO_method_type(const WOLFSSL_BIO *b);
 
 #ifndef NO_FILESYSTEM
 WOLFSSL_API WOLFSSL_BIO_METHOD *wolfSSL_BIO_s_file(void);


### PR DESCRIPTION
- Ticket failure should result in a regular handshake
- Fix `BioReceive` for closed connection
  -The pending check was forcing a `WOLFSSL_CBIO_ERR_WANT_WRITE` return even though the underlying socket was closed and `WOLFSSL_BIO_FLAG_READ|WOLFSSL_BIO_FLAG_RETRY` was not set. The `wolfSSL_BIO_ctrl_pending(ssl->biord) == 0` is old and I can't find a reason to keep checking it. I left it just in the case where there is output data pending.

ZD 13606