### PR TITLE
Fix for padding in session tickets

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -44849,7 +44849,7 @@ static void test_wolfSSL_X509_get_ext_by_NID(void)
     AssertNotNull(obj = wolfSSL_X509_EXTENSION_get_object(wolfSSL_X509_get_ext(x509, rc)));
     AssertIntEQ(obj->nid, NID_ext_key_usage);
     AssertIntEQ(obj->type, EXT_KEY_USAGE_OID);
-    
+
     wolfSSL_X509_free(x509);
 #endif
 }


### PR DESCRIPTION
# Description

Adds padding based on `WOLFSSL_GENERAL_ALIGNMENT`. Increases enc_len to 32-bit.

Related to PR #4887

# Testing

```
./configure --enable-session-ticket CFLAGS="-DWOLFSSL_GENERAL_ALIGNMENT=4" && make check
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
