### PR TITLE
Allow 'WOLFSSL_HAVE_ERROR_QUEUE' to be enabled for Windows as well.

### DIFF
--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -106,8 +106,8 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
 #endif
 
 
-#if (defined(OPENSSL_EXTRA) && !defined(_WIN32) && \
-        !defined(NO_ERROR_QUEUE)) || defined(DEBUG_WOLFSSL_VERBOSE)
+#if (defined(OPENSSL_EXTRA) && !defined(NO_ERROR_QUEUE)) || \
+        defined(DEBUG_WOLFSSL_VERBOSE)
 #define WOLFSSL_HAVE_ERROR_QUEUE
 #endif
 


### PR DESCRIPTION
# Description

Fixes zd# 13761
Did not see any justification in original commit for excluding this functionality from Windows, also didn't see anything in the code which would not work on Windows.

# Testing

Built & ran test suite on Windows 10 with VS 2022, confirmed all tests pass.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
