### PR TITLE
Added private key id/label support - improve PK callback public key use

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -10459,7 +10459,7 @@ int wc_AesInit(Aes* aes, void* heap, int devId)
     return ret;
 }
 
-#ifdef HAVE_PKCS11
+#ifdef WOLF_PRIVATE_KEY_ID
 int  wc_AesInit_Id(Aes* aes, unsigned char* id, int len, void* heap, int devId)
 {
     int ret = 0;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -10567,7 +10567,7 @@ typedef struct CertNameData {
     const char* str;
     /* Length of type string of name component. */
     byte        strLen;
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
     /* Offset of data in subject name component. */
     size_t      data;
     /* Offset of length in subject name component. */
@@ -10586,7 +10586,7 @@ static const CertNameData certNameSubject[] = {
     /* Common Name */
     {
         "/CN=", 4,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         OFFSETOF(DecodedCert, subjectCN),
         OFFSETOF(DecodedCert, subjectCNLen),
         OFFSETOF(DecodedCert, subjectCNEnc),
@@ -10598,7 +10598,7 @@ static const CertNameData certNameSubject[] = {
     /* Surname */
     {
         "/SN=", 4,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         OFFSETOF(DecodedCert, subjectSN),
         OFFSETOF(DecodedCert, subjectSNLen),
         OFFSETOF(DecodedCert, subjectSNEnc),
@@ -10610,7 +10610,7 @@ static const CertNameData certNameSubject[] = {
     /* Serial Number */
     {
         "/serialNumber=", 14,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         OFFSETOF(DecodedCert, subjectSND),
         OFFSETOF(DecodedCert, subjectSNDLen),
         OFFSETOF(DecodedCert, subjectSNDEnc),
@@ -10622,7 +10622,7 @@ static const CertNameData certNameSubject[] = {
     /* Country Name */
     {
         "/C=", 3,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         OFFSETOF(DecodedCert, subjectC),
         OFFSETOF(DecodedCert, subjectCLen),
         OFFSETOF(DecodedCert, subjectCEnc),
@@ -10634,7 +10634,7 @@ static const CertNameData certNameSubject[] = {
     /* Locality Name */
     {
         "/L=", 3,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         OFFSETOF(DecodedCert, subjectL),
         OFFSETOF(DecodedCert, subjectLLen),
         OFFSETOF(DecodedCert, subjectLEnc),
@@ -10646,7 +10646,7 @@ static const CertNameData certNameSubject[] = {
     /* State Name */
     {
         "/ST=", 4,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         OFFSETOF(DecodedCert, subjectST),
         OFFSETOF(DecodedCert, subjectSTLen),
         OFFSETOF(DecodedCert, subjectSTEnc),
@@ -10670,7 +10670,7 @@ static const CertNameData certNameSubject[] = {
     /* Organization Name */
     {
         "/O=", 3,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         OFFSETOF(DecodedCert, subjectO),
         OFFSETOF(DecodedCert, subjectOLen),
         OFFSETOF(DecodedCert, subjectOEnc),
@@ -10682,7 +10682,7 @@ static const CertNameData certNameSubject[] = {
     /* Organization Unit Name */
     {
         "/OU=", 4,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         OFFSETOF(DecodedCert, subjectOU),
         OFFSETOF(DecodedCert, subjectOULen),
         OFFSETOF(DecodedCert, subjectOUEnc),
@@ -10694,7 +10694,7 @@ static const CertNameData certNameSubject[] = {
     /* Title */
     {
         NULL, 0,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         0,
         0,
         0,
@@ -10706,7 +10706,7 @@ static const CertNameData certNameSubject[] = {
     /* Undefined */
     {
         NULL, 0,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         0,
         0,
         0,
@@ -10718,7 +10718,7 @@ static const CertNameData certNameSubject[] = {
     /* Undefined */
     {
         NULL, 0,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         0,
         0,
         0,
@@ -10730,16 +10730,10 @@ static const CertNameData certNameSubject[] = {
     /* Business Category */
     {
         "/businessCategory=", 18,
-#ifdef WOLFSSL_CERT_GEN
-#ifdef WOLFSSL_CERT_EXT
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         OFFSETOF(DecodedCert, subjectBC),
         OFFSETOF(DecodedCert, subjectBCLen),
         OFFSETOF(DecodedCert, subjectBCEnc),
-#else
-        0,
-        0,
-        0,
-#endif
 #endif
 #ifdef WOLFSSL_X509_NAME_AVAILABLE
         NID_businessCategory
@@ -10748,7 +10742,7 @@ static const CertNameData certNameSubject[] = {
     /* Undefined */
     {
         NULL, 0,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         0,
         0,
         0,
@@ -10760,16 +10754,10 @@ static const CertNameData certNameSubject[] = {
     /* Postal Code */
     {
         "/postalCode=", 12,
-#ifdef WOLFSSL_CERT_GEN
-#ifdef WOLFSSL_CERT_EXT
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         OFFSETOF(DecodedCert, subjectPC),
         OFFSETOF(DecodedCert, subjectPCLen),
         OFFSETOF(DecodedCert, subjectPCEnc),
-#else
-        0,
-        0,
-        0,
-#endif
 #endif
 #ifdef WOLFSSL_X509_NAME_AVAILABLE
         NID_postalCode
@@ -10778,14 +10766,13 @@ static const CertNameData certNameSubject[] = {
     /* User Id */
     {
         "/userid=", 8,
-#ifdef WOLFSSL_CERT_GEN
+#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
         OFFSETOF(DecodedCert, subjectUID),
         OFFSETOF(DecodedCert, subjectUIDLen),
         OFFSETOF(DecodedCert, subjectUIDEnc),
 #endif
 #ifdef WOLFSSL_X509_NAME_AVAILABLE
         NID_userId
-
 #endif
     },
 };
@@ -20713,8 +20700,8 @@ int wc_RsaPublicKeyDerSize(RsaKey* key, int with_header)
 
 #endif /* !NO_RSA && WOLFSSL_CERT_GEN */
 
-#if ((defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA)) && \
-    !defined(NO_RSA) && !defined(HAVE_USER_RSA)) || defined(WOLFSSL_KCAPI_RSA)
+#if (defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA) || \
+     defined(WOLFSSL_KCAPI_RSA)) && !defined(NO_RSA) && !defined(HAVE_USER_RSA)
 
 /* Encode private RSA key in DER format.
  *

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5404,7 +5404,7 @@ int wc_ecc_init(ecc_key* key)
 #endif
 }
 
-#ifdef WOLF_CRYPTO_CB
+#ifdef WOLF_PRIVATE_KEY_ID
 int wc_ecc_init_id(ecc_key* key, unsigned char* id, int len, void* heap,
                    int devId)
 {
@@ -5447,7 +5447,7 @@ int wc_ecc_init_label(ecc_key* key, const char* label, void* heap, int devId)
 
     return ret;
 }
-#endif
+#endif /* WOLF_PRIVATE_KEY_ID */
 
 int wc_ecc_set_flags(ecc_key* key, word32 flags)
 {
@@ -8732,7 +8732,7 @@ static int ecc_check_privkey_gen(ecc_key* key, mp_int* a, mp_int* prime)
 
     return err;
 }
-#endif /* WOLFSSL_VALIDATE_ECC_KEYGEN ||
+#endif /* FIPS_VERSION_GE(5,0) || WOLFSSL_VALIDATE_ECC_KEYGEN ||
         * (!WOLFSSL_SP_MATH && WOLFSSL_VALIDATE_ECC_IMPORT) */
 
 #if FIPS_VERSION_GE(5,0) || defined(WOLFSSL_VALIDATE_ECC_KEYGEN)

--- a/wolfcrypt/src/hmac.c
+++ b/wolfcrypt/src/hmac.c
@@ -1021,7 +1021,7 @@ int wc_HmacInit(Hmac* hmac, void* heap, int devId)
     return ret;
 }
 
-#ifdef HAVE_PKCS11
+#ifdef WOLF_PRIVATE_KEY_ID
 int  wc_HmacInit_Id(Hmac* hmac, unsigned char* id, int len, void* heap,
                     int devId)
 {
@@ -1064,7 +1064,7 @@ int wc_HmacInit_Label(Hmac* hmac, const char* label, void* heap, int devId)
 
     return ret;
 }
-#endif
+#endif /* WOLF_PRIVATE_KEY_ID */
 
 /* Free Hmac from use with async device */
 void wc_HmacFree(Hmac* hmac)

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -345,7 +345,7 @@ int wc_InitRsaKey(RsaKey* key, void* heap)
     return wc_InitRsaKey_ex(key, heap, INVALID_DEVID);
 }
 
-#ifdef WOLF_CRYPTO_CB
+#ifdef WOLF_PRIVATE_KEY_ID
 int wc_InitRsaKey_Id(RsaKey* key, unsigned char* id, int len, void* heap,
                      int devId)
 {
@@ -388,7 +388,7 @@ int wc_InitRsaKey_Label(RsaKey* key, const char* label, void* heap, int devId)
 
     return ret;
 }
-#endif
+#endif /* WOLF_PRIVATE_KEY_ID */
 
 
 #ifdef WOLFSSL_XILINX_CRYPT

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1729,7 +1729,7 @@ WOLFSSL_LOCAL int  CompleteServerHello(WOLFSSL *ssl);
 WOLFSSL_LOCAL int  CheckVersion(WOLFSSL *ssl, ProtocolVersion pv);
 WOLFSSL_LOCAL int  PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
                                    word32 hashSigAlgoSz);
-#ifdef WOLF_CRYPTO_CB
+#if defined(WOLF_PRIVATE_KEY_ID) && !defined(NO_CHECK_PRIVATE_KEY)
 WOLFSSL_LOCAL int  CreateDevPrivateKey(void** pkey, byte* data, word32 length,
                                        int hsType, int label, int id,
                                        void* heap, int devId);

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1843,7 +1843,7 @@ WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_PublicKey(int type, WOLFSSL_EVP_PKEY**
         const unsigned char ** in, long inSz);
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey(int type,
         WOLFSSL_EVP_PKEY** out, const unsigned char **in, long inSz);
-#ifdef WOLF_CRYPTO_CB
+#ifdef WOLF_PRIVATE_KEY_ID
 WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_id(int type,
     WOLFSSL_EVP_PKEY** out, void* heap, int devId);
 #endif

--- a/wolfssl/wolfcrypt/aes.h
+++ b/wolfssl/wolfcrypt/aes.h
@@ -159,7 +159,7 @@ enum {
     AES_XTS_MODE = 3,
 #endif
 
-#ifdef HAVE_PKCS11
+#ifdef WOLF_PRIVATE_KEY_ID
     AES_MAX_ID_LEN      = 32,
     AES_MAX_LABEL_LEN   = 32,
 #endif
@@ -213,7 +213,7 @@ struct Aes {
     int    devId;
     void*  devCtx;
 #endif
-#ifdef HAVE_PKCS11
+#ifdef WOLF_PRIVATE_KEY_ID
     byte id[AES_MAX_ID_LEN];
     int  idLen;
     char label[AES_MAX_LABEL_LEN];
@@ -537,7 +537,7 @@ WOLFSSL_API int wc_AesXtsFree(XtsAes* aes);
 WOLFSSL_API int wc_AesGetKeySize(Aes* aes, word32* keySize);
 
 WOLFSSL_API int  wc_AesInit(Aes* aes, void* heap, int devId);
-#ifdef HAVE_PKCS11
+#ifdef WOLF_PRIVATE_KEY_ID
 WOLFSSL_API int  wc_AesInit_Id(Aes* aes, unsigned char* id, int len, void* heap,
         int devId);
 WOLFSSL_API int  wc_AesInit_Label(Aes* aes, const char* label, void* heap,

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1585,7 +1585,6 @@ struct DecodedCert {
     char*   subjectUID;
     int     subjectUIDLen;
     char    subjectUIDEnc;
-#if defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT)
     char*   subjectStreet;
     int     subjectStreetLen;
     char    subjectStreetEnc;
@@ -1601,7 +1600,6 @@ struct DecodedCert {
     char*   subjectPC;
     int     subjectPCLen;
     char    subjectPCEnc;
-#endif
     char*   subjectEmail;
     int     subjectEmailLen;
 #endif /* defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT) */
@@ -1766,7 +1764,7 @@ struct TrustedPeerCert {
 
 /* for testing or custom openssl wrappers */
 #if defined(WOLFSSL_TEST_CERT) || defined(OPENSSL_EXTRA) || \
-    defined(OPENSSL_EXTRA_X509_SMALL)
+    defined(OPENSSL_EXTRA_X509_SMALL) || defined(WOLFSSL_PUBLIC_ASN)
     #define WOLFSSL_ASN_API WOLFSSL_API
 #else
     #define WOLFSSL_ASN_API WOLFSSL_LOCAL

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -186,7 +186,7 @@ enum {
     /* Shamir's dual add constants */
     SHAMIR_PRECOMP_SZ = 16,
 
-#ifdef WOLF_CRYPTO_CB
+#ifdef WOLF_PRIVATE_KEY_ID
     ECC_MAX_ID_LEN    = 32,
     ECC_MAX_LABEL_LEN = 32,
 #endif
@@ -481,7 +481,7 @@ struct ecc_key {
         CertSignCtx certSignCtx; /* context info for cert sign (MakeSignature) */
     #endif
 #endif /* WOLFSSL_ASYNC_CRYPT */
-#ifdef WOLF_CRYPTO_CB
+#ifdef WOLF_PRIVATE_KEY_ID
     byte id[ECC_MAX_ID_LEN];
     int  idLen;
     char label[ECC_MAX_LABEL_LEN];
@@ -631,7 +631,7 @@ WOLFSSL_API
 int wc_ecc_init(ecc_key* key);
 WOLFSSL_ABI WOLFSSL_API
 int wc_ecc_init_ex(ecc_key* key, void* heap, int devId);
-#ifdef WOLF_CRYPTO_CB
+#ifdef WOLF_PRIVATE_KEY_ID
 WOLFSSL_API
 int wc_ecc_init_id(ecc_key* key, unsigned char* id, int len, void* heap,
                    int devId);

--- a/wolfssl/wolfcrypt/hmac.h
+++ b/wolfssl/wolfcrypt/hmac.h
@@ -99,7 +99,7 @@ enum {
     WC_SHA3_384 = WC_HASH_TYPE_SHA3_384,
     WC_SHA3_512 = WC_HASH_TYPE_SHA3_512,
 #endif
-#ifdef HAVE_PKCS11
+#ifdef WOLF_PRIVATE_KEY_ID
     HMAC_MAX_ID_LEN    = 32,
     HMAC_MAX_LABEL_LEN = 32,
 #endif
@@ -160,7 +160,7 @@ struct Hmac {
     void*   devCtx;
     const byte* keyRaw;
 #endif
-#ifdef HAVE_PKCS11
+#ifdef WOLF_PRIVATE_KEY_ID
     byte    id[HMAC_MAX_ID_LEN];
     int     idLen;
     char    label[HMAC_MAX_LABEL_LEN];
@@ -192,7 +192,7 @@ WOLFSSL_API int wc_HmacFinal_Software(Hmac* hmac, byte* out);
 WOLFSSL_API int wc_HmacSizeByType(int type);
 
 WOLFSSL_API int wc_HmacInit(Hmac* hmac, void* heap, int devId);
-#ifdef HAVE_PKCS11
+#ifdef WOLF_PRIVATE_KEY_ID
 WOLFSSL_API int wc_HmacInit_Id(Hmac* hmac, byte* id, int len, void* heap,
                                int devId);
 WOLFSSL_API int wc_HmacInit_Label(Hmac* hmac, const char* label, void* heap,

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -148,7 +148,7 @@ enum {
     RSA_PSS_SALT_LEN_DISCOVER = -2,
 #endif
 
-#ifdef WOLF_CRYPTO_CB
+#ifdef WOLF_PRIVATE_KEY_ID
     RSA_MAX_ID_LEN      = 32,
     RSA_MAX_LABEL_LEN   = 32,
 #endif
@@ -195,7 +195,7 @@ struct RsaKey {
 #if defined(WOLFSSL_KCAPI_RSA)
     struct kcapi_handle* handle;
 #endif
-#ifdef WOLF_CRYPTO_CB
+#ifdef WOLF_PRIVATE_KEY_ID
     byte id[RSA_MAX_ID_LEN];
     int  idLen;
     char label[RSA_MAX_LABEL_LEN];
@@ -226,7 +226,7 @@ struct RsaKey {
 WOLFSSL_API int  wc_InitRsaKey(RsaKey* key, void* heap);
 WOLFSSL_API int  wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId);
 WOLFSSL_API int  wc_FreeRsaKey(RsaKey* key);
-#ifdef WOLF_CRYPTO_CB
+#ifdef WOLF_PRIVATE_KEY_ID
 WOLFSSL_API int wc_InitRsaKey_Id(RsaKey* key, unsigned char* id, int len,
                                  void* heap, int devId);
 WOLFSSL_API int wc_InitRsaKey_Label(RsaKey* key, const char* label, void* heap,

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2614,6 +2614,16 @@ extern void uITRON4_free(void *p) ;
     #error The SRTP extension requires DTLS
 #endif
 
+/* Are we using an external private key store like:
+ *     PKCS11 / HSM / crypto callback / PK callback */
+#if !defined(WOLF_PRIVATE_KEY_ID) && \
+    (defined(HAVE_PKCS11) || defined(HAVE_PK_CALLBACKS) || \
+     defined(WOLF_CRYPTO_CB) || defined(WOLFSSL_KCAPI))
+     /* Enables support for using wolfSSL_CTX_use_PrivateKey_Id and
+      *   wolfSSL_CTX_use_PrivateKey_Label */
+    #define WOLF_PRIVATE_KEY_ID
+#endif
+
 
 
 /* ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description

* Improve logic around private key id/label.
* Adds `WOLF_PRIVATE_KEY_ID`.
* Improve PK callbacks to allow using a public key with `wolfSSL_CTX_use_PrivateKey_*` and `wolfSSL_use_PrivateKey_*` API's.

ZD13791

# Testing

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
