### PR TITLE
OpenSSL compatibility layer cleanups

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -39064,7 +39064,7 @@ int wolfSSL_EC_KEY_set_public_key(WOLFSSL_EC_KEY *key,
 
     if (key == NULL || key->internal == NULL ||
         pub == NULL || pub->internal == NULL) {
-        WOLFSSL_MSG("wolfSSL_EC_GROUP_get_order Bad arguments");
+        WOLFSSL_MSG("wolfSSL_EC_KEY_set_public_key Bad arguments");
         return WOLFSSL_FAILURE;
     }
 
@@ -48261,7 +48261,7 @@ int wolfSSL_PEM_write_bio_X509(WOLFSSL_BIO *bio, WOLFSSL_X509 *cert)
 #endif
     int ret;
 
-    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_X509_AUX()");
+    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_X509()");
 
     if (bio == NULL || cert == NULL) {
         WOLFSSL_MSG("NULL argument passed in");
@@ -57064,14 +57064,14 @@ void wolfSSL_X509V3_set_ctx(WOLFSSL_X509V3_CTX* ctx, WOLFSSL_X509* issuer,
 {
     int ret = WOLFSSL_SUCCESS;
     WOLFSSL_ENTER("wolfSSL_X509V3_set_ctx");
-    if (!ctx || !ctx->x509)
+    if (!ctx)
         return;
 
-    if (!ctx->x509) {
-        ctx->x509 = wolfSSL_X509_new();
-        if (!ctx->x509)
-            return;
-    }
+    /* not checking ctx->x509 for null first since app won't have initalized
+     * this X509V3_CTX before this function call */
+    ctx->x509 = wolfSSL_X509_new();
+    if (!ctx->x509)
+        return;
 
     /* Set parameters in ctx as long as ret == WOLFSSL_SUCCESS */
     if (issuer)
@@ -62043,6 +62043,7 @@ PKCS7* wolfSSL_d2i_PKCS7_ex(PKCS7** p7, const unsigned char** in, int len,
     }
     if (wc_PKCS7_VerifySignedData(&pkcs7->pkcs7, pkcs7->data, pkcs7->len)
                                                                          != 0) {
+        WOLFSSL_MSG("wc_PKCS7_VerifySignedData failed");
         wolfSSL_PKCS7_free((PKCS7*)pkcs7);
         return NULL;
     }
@@ -62176,6 +62177,7 @@ PKCS7* wolfSSL_d2i_PKCS7_bio(WOLFSSL_BIO* bio, PKCS7** p7)
 
     if (wc_PKCS7_VerifySignedData(&pkcs7->pkcs7, pkcs7->data, pkcs7->len)
                                                                          != 0) {
+        WOLFSSL_MSG("wc_PKCS7_VerifySignedData failed");
         wolfSSL_PKCS7_free((PKCS7*)pkcs7);
         return NULL;
     }

--- a/wolfssl/openssl/bio.h
+++ b/wolfssl/openssl/bio.h
@@ -56,6 +56,7 @@
 #define BIO_s_file                      wolfSSL_BIO_s_file
 #define BIO_s_bio                       wolfSSL_BIO_s_bio
 #define BIO_s_socket                    wolfSSL_BIO_s_socket
+#define BIO_s_accept                    wolfSSL_BIO_s_socket
 #define BIO_set_fd                      wolfSSL_BIO_set_fd
 #define BIO_set_close                   wolfSSL_BIO_set_close
 #define BIO_ctrl_reset_read_request     wolfSSL_BIO_ctrl_reset_read_request

--- a/wolfssl/openssl/bio.h
+++ b/wolfssl/openssl/bio.h
@@ -140,6 +140,8 @@
 #define BIO_CTRL_RESET             1
 #define BIO_CTRL_EOF               2
 #define BIO_CTRL_INFO              3
+#define BIO_CTRL_SET               4
+#define BIO_CTRL_GET               5
 #define BIO_CTRL_PUSH              6
 #define BIO_CTRL_POP               7
 #define BIO_CTRL_GET_CLOSE         8

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -2209,9 +2209,6 @@ enum {
                               */
     SSL_MODE_RELEASE_BUFFERS = -1, /* For libwebsockets build. No current use. */
 
-    BIO_CLOSE   = 1,
-    BIO_NOCLOSE = 0,
-
     X509_FILETYPE_PEM = 8,
 
     X509_V_OK                                    = 0,


### PR DESCRIPTION
# Description

This PR includes some OpenSSL compatibility layer and debug message cleanups, including:
- `X509V3_set_ctx()` arg check fix
- Map `BIO_s_accept()` to `BIO_s_socket()`
- Add `BIO_CTRL_SET` and `BIO_CTRL_GET`
- Remove duplicate `BIO_CLOSE`/`BIO_NOCLOSE` definitions

These fixes were made to accommodate the OpenSplice port.

# Testing

Tested with OpenSplice test cases.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
