### PR TITLE
TLS HMAC: fix number of blocks to not process

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -1055,7 +1055,7 @@ static int Hmac_UpdateFinal(Hmac* hmac, byte* digest, const byte* in,
     blocks     += ((maxSz + padSz) % blockSz) < padSz;
     msgBlocks   = realSz >> blockBits;
     /* #Extra blocks to process. */
-    blocks -= (msgBlocks + (((realSz + padSz) % blockSz) < padSz)) ? 1 : 0;
+    blocks -= msgBlocks + ((((realSz + padSz) % blockSz) < padSz) ? 1 : 0);
     /* Calculate whole blocks. */
     msgBlocks--;
 


### PR DESCRIPTION
# Description

TLS Hmac
Change made to line for static analysis.
Change was made incorrectly due to bracketing.
This fixes it.


Fixes zd#13843

# Testing

Normal configurations.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
