### PR TITLE
Add extended key usage support to wolfSSL_X509_set_ext.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -10069,6 +10069,15 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
             case EXT_KEY_USAGE_OID:
                 if (!isSet)
                     break;
+
+                ret = wolfSSL_ASN1_STRING_set(&ext->value, x509->extKeyUsageSrc,
+                                              x509->extKeyUsageSz);
+                if (ret != WOLFSSL_SUCCESS) {
+                    WOLFSSL_MSG("ASN1_STRING_set() failed");
+                    wolfSSL_X509_EXTENSION_free(ext);
+                    FreeDecodedCert(&cert);
+                    return NULL;
+                }
                 ext->crit = x509->keyUsageCrit;
                 break;
 


### PR DESCRIPTION
# Description

This adds support for the extended key usage extension to `wolfSSL_X509_set_ext`. The lack of support was discovered by a customer using our libspdm port.

Fixes zd#

# Testing

I wrote a test program that read in a certificate with the extended key usage extension using `wolfSSL_PEM_read_X509`. I then pulled out the DER encoding of the extension with `wolfSSL_X509_EXTENSION_get_data` and verified that it was correct. I built the same program with OpenSSL and verified that the results were the same (minus the ASN.1 header, which wolfSSL doesn't store but OpenSSL does).

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
