### PR TITLE
tls13.test gcloud grep arg dumbdown

### DIFF
--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -138,9 +138,9 @@ fi
 do_cleanup
 echo ""
 
-cat ./wolfssl/options.h | grep -F -e 'NO_CERTS'
+grep 'NO_CERTS' ./wolfssl/options.h
 NO_CERTS=$?
-cat ./wolfssl/options.h | grep -F -e 'WOLFSSL_NO_CLIENT_AUTH'
+grep 'WOLFSSL_NO_CLIENT_AUTH' ./wolfssl/options.h
 NO_CLIENT_AUTH=$?
 if [ $NO_CERTS -ne 0 -a $NO_CLIENT_AUTH -ne 0 ]; then
     # TLS 1.3 mutual auth required but client doesn't send certificates.
@@ -162,7 +162,7 @@ if [ $NO_CERTS -ne 0 -a $NO_CLIENT_AUTH -ne 0 ]; then
 fi
 
 # Check for TLS 1.2 support
-./examples/client/client -v 3 2>&1 | grep -F -e 'Bad SSL version'
+./examples/client/client -v 3 2>&1 | grep 'Bad SSL version'
 if [ $? -ne 0 ]; then
     # TLS 1.3 server / TLS 1.2 client.
     echo -e "\n\nTLS v1.3 server downgrading to TLS v1.2"
@@ -202,7 +202,7 @@ if [ $? -ne 0 ]; then
     for CS in ECDHE-RSA-AES128-GCM-SHA256 DHE-RSA-AES128-GCM-SHA256
     do
         echo $CS
-        ./examples/client/client -e | grep -F -e "$CS" >/dev/null
+        ./examples/client/client -e | grep "$CS" >/dev/null
         if [ "$?" = "0" ]; then
             TLS12_CS=$CS
             break
@@ -234,11 +234,11 @@ if [ $? -ne 0 ]; then
 fi
 
 # Check for EarlyData support
-./examples/client/client -? 2>&1 | grep -F -e 'Early data'
+./examples/client/client -? 2>&1 | grep 'Early data'
 if [ $? -eq 0 ]; then
     early_data=yes
 fi
-./examples/client/client -? 2>&1 | grep -F -e 'Shared keys'
+./examples/client/client -? 2>&1 | grep 'Shared keys'
 if [ $? -eq 0 ]; then
     psk=yes
 fi
@@ -254,11 +254,11 @@ if [ "$early_data" = "yes" ]; then
     RESULT=$?
     cat "$client_out_file"
     remove_ready_file
-    grep -F -e 'Session Ticket' "$client_out_file"
+    grep 'Session Ticket' "$client_out_file"
     session_ticket=$?
 
-    ed_srv_msg_cnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
-    ed_srv_status_cnt="$(grep -c -F -e 'Early Data was' "$server_out_file")"
+    ed_srv_msg_cnt="$(grep -c 'Early Data Client message' "$server_out_file")"
+    ed_srv_status_cnt="$(grep -c 'Early Data was' "$server_out_file")"
     if [ $session_ticket -eq 0 -a $ed_srv_msg_cnt -ne 2 \
         -a $ed_srv_status_cnt -ne 2 ]; then
         RESULT=1
@@ -286,15 +286,15 @@ if [ "$early_data" = "yes" -a "$psk" = "yes" ]; then
     # wait for the server to quit and write output
     wait $server_pid
 
-    ed_srv_msgcnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
-    ed_srv_status_cnt="$(grep -c -F -e 'Early Data was' "$server_out_file")"
+    ed_srv_msgcnt="$(grep -c 'Early Data Client message' "$server_out_file")"
+    ed_srv_status_cnt="$(grep -c 'Early Data was' "$server_out_file")"
     if [ $ed_srv_msgcnt -ne 2 -a $ed_srv_status_cnt -ne 1 ]; then
         echo
         echo "Server out file"
         cat "$server_out_file"
         echo
         echo "Found lines"
-        grep -F -e 'Early Data' "$server_out_file"
+        grep 'Early Data' "$server_out_file"
         echo -e "\n\nUnexpected 'Early Data' lines - $early_data_cnt"
         RESULT=1
     fi


### PR DESCRIPTION
scripts/tls13.test: don't use -F and -e options to grep -- one or both are causing problems in the gcloud testing image.
