### PR TITLE
Fixes to support building opensslextra with SP math

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6202,9 +6202,6 @@ if test "$ENABLED_SP_MATH" = "yes"; then
     if test "$ENABLED_ECCCUSTCURVES" = "yes"; then
         AC_MSG_ERROR([Cannot use single precision math and custom curves])
     fi
-    if test "$ENABLED_OPENSSLEXTRA" = "yes"; then
-        AC_MSG_ERROR([Cannot use single precision math and OpenSSL extra])
-    fi
     if test "$ENABLED_DSA" = "yes"; then
         AC_MSG_ERROR([Cannot use single precision math and DSA])
     fi

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -40080,6 +40080,7 @@ WOLFSSL_EC_POINT *wolfSSL_EC_POINT_new(const WOLFSSL_EC_GROUP *group)
     return p;
 }
 
+#ifndef WOLFSSL_SP_MATH
 /* return code compliant with OpenSSL :
  *   1 if success, 0 if error
  */
@@ -40140,6 +40141,7 @@ int wolfSSL_EC_POINT_get_affine_coordinates_GFp(const WOLFSSL_EC_GROUP *group,
 
     return WOLFSSL_SUCCESS;
 }
+#endif
 
 int wolfSSL_EC_POINT_set_affine_coordinates_GFp(const WOLFSSL_EC_GROUP *group,
                                                 WOLFSSL_EC_POINT *point,
@@ -40183,7 +40185,7 @@ int wolfSSL_EC_POINT_set_affine_coordinates_GFp(const WOLFSSL_EC_GROUP *group,
 }
 
 #if !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A) && \
-    !defined(HAVE_SELFTEST)
+    !defined(HAVE_SELFTEST) && !defined(WOLFSSL_SP_MATH)
 int wolfSSL_EC_POINT_add(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *r,
                          const WOLFSSL_EC_POINT *p1,
                          const WOLFSSL_EC_POINT *p2, WOLFSSL_BN_CTX *ctx)
@@ -40447,8 +40449,8 @@ cleanup:
     wc_ecc_del_point(tmp);
     return ret;
 }
-#endif /* !defined(WOLFSSL_ATECC508A) && defined(ECC_SHAMIR) &&
-        * !defined(HAVE_SELFTEST) */
+#endif /* !WOLFSSL_ATECC508A && !WOLFSSL_ATECC608A && !HAVE_SELFTEST &&
+        * !WOLFSSL_SP_MATH */
 
 /* (x, y) -> (x, -y) */
 int wolfSSL_EC_POINT_invert(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *a,
@@ -54177,6 +54179,7 @@ WOLFSSL_API int wolfSSL_BN_mul(WOLFSSL_BIGNUM *r, WOLFSSL_BIGNUM *a, WOLFSSL_BIG
     return ret;
 }
 
+#ifndef WOLFSSL_SP_MATH
 int wolfSSL_BN_div(WOLFSSL_BIGNUM* dv, WOLFSSL_BIGNUM* rem,
                    const WOLFSSL_BIGNUM* a, const WOLFSSL_BIGNUM* d,
                    WOLFSSL_BN_CTX* ctx)
@@ -54208,6 +54211,7 @@ int wolfSSL_BN_div(WOLFSSL_BIGNUM* dv, WOLFSSL_BIGNUM* rem,
 
     return ret;
 }
+#endif
 
 #if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN) /* Needed to get mp_gcd. */
 int wolfSSL_BN_gcd(WOLFSSL_BIGNUM* r, WOLFSSL_BIGNUM* a, WOLFSSL_BIGNUM* b,
@@ -55161,6 +55165,7 @@ WOLFSSL_API int wolfSSL_BN_sub_word(WOLFSSL_BIGNUM* bn, WOLFSSL_BN_ULONG w)
     return ret;
 }
 
+#ifndef WOLFSSL_SP_MATH
 /* return code compliant with OpenSSL :
  *   1 if success, 0 else
  */
@@ -55201,6 +55206,7 @@ int wolfSSL_BN_rshift(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *bn, int n)
 
     return WOLFSSL_SUCCESS;
 }
+#endif
 
 /* return code compliant with OpenSSL :
  *   1 if success, 0 else
@@ -55224,6 +55230,7 @@ int wolfSSL_BN_add(WOLFSSL_BIGNUM *r, WOLFSSL_BIGNUM *a, WOLFSSL_BIGNUM *b)
     return WOLFSSL_SUCCESS;
 }
 
+#ifndef WOLFSSL_SP_MATH
 /* r = a + b (mod m) */
 int wolfSSL_BN_mod_add(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
                        const WOLFSSL_BIGNUM *b, const WOLFSSL_BIGNUM *m,
@@ -55248,6 +55255,7 @@ int wolfSSL_BN_mod_add(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
 
     return WOLFSSL_SUCCESS;
 }
+#endif
 
 #if defined(WOLFSSL_KEY_GEN) && (!defined(NO_RSA) || !defined(NO_DH) || !defined(NO_DSA))
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -2979,11 +2979,12 @@ static int test_wolfSSL_SetMinVersion(void)
 /* Test function for EC_POINT_new, EC_POINT_mul, EC_POINT_free,
     EC_GROUP_new_by_curve_name, EC_GROUP_order_bits
  */
-
-# if defined(OPENSSL_EXTRA) && \
-  (!defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION>2)))
+#ifdef OPENSSL_EXTRA
 static void test_wolfSSL_EC(void)
 {
+#if !defined(WOLFSSL_SP_MATH) && \
+  (!defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION>2)))
+
 #if defined(HAVE_ECC)
     BN_CTX *ctx;
     EC_GROUP *group;
@@ -3186,8 +3187,9 @@ static void test_wolfSSL_EC(void)
     EC_GROUP_free(group2);
     BN_CTX_free(ctx);
 #endif /* HAVE_ECC */
+#endif /* OPENSSL_EXTRA && !WOLFSSL_SP_MATH && ( !HAVE_FIPS || HAVE_FIPS_VERSION > 2) */
 }
-#endif /* OPENSSL_EXTRA && ( !HAVE_FIPS || HAVE_FIPS_VERSION > 2) */
+#endif /* OPENSSL_EXTRA */
 
 #ifndef NO_BIO
 static void test_wolfSSL_PEM_read_bio_ECPKParameters(void)
@@ -34336,7 +34338,7 @@ static void test_X509_STORE_get0_objects(void)
 
 static void test_wolfSSL_BN(void)
 {
-#if defined(OPENSSL_EXTRA) && !defined(NO_ASN)
+#if defined(OPENSSL_EXTRA) && !defined(NO_ASN) && !defined(WOLFSSL_SP_MATH)
     BIGNUM* a;
     BIGNUM* b;
     BIGNUM* c;
@@ -53167,9 +53169,7 @@ void ApiTest(void)
     /*wolfSSL_EVP_get_cipherbynid test*/
     test_wolfSSL_EVP_get_cipherbynid();
     test_wolfSSL_EVP_CIPHER_CTX();
-#if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION>2))
     test_wolfSSL_EC();
-#endif
     test_wolfSSL_ECDSA_SIG();
     test_ECDSA_size_sign();
     test_ED25519();


### PR DESCRIPTION
# Description

Disables some of the compatibility layer BN and ECC point handling.

```
--enable-sp (enable the optimized math for common key sizes and curve)
--enable-sp-math (disable multi-precision math)
--enable-sp-asm (enable architecture specific assembly speedups for SP)
--enable-sp-math-all (enable the multi-precision SP math -> sp_int.c)
```

Fixes ZD13759

# Testing

`./configure --enable-sp --enable-sp-math --enable-sp-asm --enable-intelasm --enable-opensslextra && make check`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
