### PR TITLE
wolfcrypt/src/asn.c: fix buffer underrun in EncodeExtensions() and leak in ParseCRL_Extensions()

### DIFF
--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -259,6 +259,9 @@ if [ "$early_data" = "yes" ]; then
 
     ed_srv_msg_cnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
     ed_srv_status_cnt="$(grep -c -F -e 'Early Data was' "$server_out_file")"
+
+    echo "earlydata: session_ticket=${session_ticket} ed_srv_msg_cnt=${ed_srv_msg_cnt} ed_srv_status_cnt=${ed_srv_status_cnt}"
+
     if [ $session_ticket -eq 0 -a $ed_srv_msg_cnt -ne 2 \
         -a $ed_srv_status_cnt -ne 2 ]; then
         RESULT=1
@@ -286,16 +289,19 @@ if [ "$early_data" = "yes" -a "$psk" = "yes" ]; then
     # wait for the server to quit and write output
     wait $server_pid
 
-    ed_srv_msgcnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
+    ed_srv_msg_cnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
     ed_srv_status_cnt="$(grep -c -F -e 'Early Data was' "$server_out_file")"
-    if [ $ed_srv_msgcnt -ne 2 -a $ed_srv_status_cnt -ne 1 ]; then
+
+    echo "PSK earlydata: ed_srv_msg_cnt=${ed_srv_msg_cnt} ed_srv_status_cnt=${ed_srv_status_cnt}"
+
+    if [ $ed_srv_msg_cnt -ne 2 -a $ed_srv_status_cnt -ne 1 ]; then
         echo
         echo "Server out file"
         cat "$server_out_file"
         echo
         echo "Found lines"
         grep -F -e 'Early Data' "$server_out_file"
-        echo -e "\n\nUnexpected 'Early Data' lines - $early_data_cnt"
+        echo -e "\n\nUnexpected 'Early Data' lines."
         RESULT=1
     fi
     if [ $RESULT -ne 0 ]; then

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -13,6 +13,9 @@ if [ "${AM_BWRAPPED-}" != "yes" ]; then
     unset AM_BWRAPPED
 fi
 
+# retries to mitigate race on early data:
+early_data_try_max=10
+
 # getting unique port is modeled after resume.test script
 # need a unique port since may run the same time as testsuite
 # use server port zero hack to get one
@@ -244,71 +247,98 @@ if [ $? -eq 0 ]; then
 fi
 
 if [ "$early_data" = "yes" ]; then
-    echo -e "\n\nTLS v1.3 Early Data - session ticket"
-    port=0
-    (./examples/server/server -v 4 -r -0 -R "$ready_file" -p $port 2>&1 | \
-            tee "$server_out_file") &
-    server_pid=$!
-    create_port
-    ./examples/client/client -v 4 -r -0 -p $port 2>&1 >"$client_out_file"
-    RESULT=$?
-    cat "$client_out_file"
-    remove_ready_file
-    grep -F -e 'Session Ticket' "$client_out_file"
-    session_ticket=$?
 
-    ed_srv_msg_cnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
-    ed_srv_status_cnt="$(grep -c -F -e 'Early Data was' "$server_out_file")"
+    early_data_try_num=1
+    while :; do
 
-    echo "earlydata: session_ticket=${session_ticket} ed_srv_msg_cnt=${ed_srv_msg_cnt} ed_srv_status_cnt=${ed_srv_status_cnt}"
+	echo -e "\n\nTLS v1.3 Early Data - session ticket"
+	port=0
+	(./examples/server/server -v 4 -r -0 -R "$ready_file" -p $port 2>&1 | \
+             tee "$server_out_file") &
+	server_pid=$!
+	create_port
+	./examples/client/client -v 4 -r -0 -p $port 2>&1 >"$client_out_file"
+	RESULT=$?
+	cat "$client_out_file"
+	remove_ready_file
+	grep -F -e 'Session Ticket' "$client_out_file"
+	session_ticket=$?
 
-    if [ $session_ticket -eq 0 -a $ed_srv_msg_cnt -ne 2 \
-        -a $ed_srv_status_cnt -ne 2 ]; then
-        RESULT=1
-    fi
-    if [ $RESULT -ne 0 ]; then
-        echo -e "\n\nIssue with TLS v1.3 Early Data - session ticket"
-        do_cleanup
-        exit 1
-    fi
-    do_cleanup
+	ed_srv_msg_cnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
+	ed_srv_status_cnt="$(grep -c -F -e 'Early Data was' "$server_out_file")"
+
+	echo "earlydata: session_ticket=${session_ticket} ed_srv_msg_cnt=${ed_srv_msg_cnt} ed_srv_status_cnt=${ed_srv_status_cnt}"
+
+	if [ $session_ticket -eq 0 -a $ed_srv_msg_cnt -ne 2 \
+			     -a $ed_srv_status_cnt -ne 2 ]; then
+            RESULT=1
+	fi
+	if [ $RESULT -ne 0 ]; then
+            echo -e "\n\nIssue with TLS v1.3 Early Data - session ticket"
+	    if [ $early_data_try_num -lt $early_data_try_max ]; then
+		echo -e "retry #${early_data_try_num}...\n"
+		: $((++early_data_try_num))
+		continue
+	    fi
+            do_cleanup
+            exit 1
+	fi
+	do_cleanup
+	break
+
+    done
+
     echo ""
 fi
 
 if [ "$early_data" = "yes" -a "$psk" = "yes" ]; then
     echo -e "\n\nTLS v1.3 Early Data - PSK"
     port=0
-    (./examples/server/server -v 4 -s -0 -R "$ready_file" -p $port 2>&1 | \
-            tee "$server_out_file") &
-    server_pid=$!
-    create_port
-    ./examples/client/client -v 4 -s -0 -p $port
-    RESULT=$?
-    remove_ready_file
 
-    # wait for the server to quit and write output
-    wait $server_pid
+    early_data_try_num=1
+    while :; do
 
-    ed_srv_msg_cnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
-    ed_srv_status_cnt="$(grep -c -F -e 'Early Data was' "$server_out_file")"
+	(./examples/server/server -v 4 -s -0 -R "$ready_file" -p $port 2>&1 | \
+             tee "$server_out_file") &
+	server_pid=$!
+	create_port
+	./examples/client/client -v 4 -s -0 -p $port
+	RESULT=$?
+	remove_ready_file
 
-    echo "PSK earlydata: ed_srv_msg_cnt=${ed_srv_msg_cnt} ed_srv_status_cnt=${ed_srv_status_cnt}"
+	# wait for the server to quit and write output
+	wait $server_pid
 
-    if [ $ed_srv_msg_cnt -ne 2 -a $ed_srv_status_cnt -ne 1 ]; then
-        echo
-        echo "Server out file"
-        cat "$server_out_file"
-        echo
-        echo "Found lines"
-        grep -F -e 'Early Data' "$server_out_file"
-        echo -e "\n\nUnexpected 'Early Data' lines."
-        RESULT=1
-    fi
-    if [ $RESULT -ne 0 ]; then
-        echo -e "\n\nIssue with TLS v1.3 Early Data - PSK"
-        do_cleanup
-        exit 1
-    fi
+	ed_srv_msg_cnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
+	ed_srv_status_cnt="$(grep -c -F -e 'Early Data was' "$server_out_file")"
+
+	echo "PSK earlydata: ed_srv_msg_cnt=${ed_srv_msg_cnt} ed_srv_status_cnt=${ed_srv_status_cnt}"
+
+	if [ $ed_srv_msg_cnt -ne 2 -a $ed_srv_status_cnt -ne 1 ]; then
+            echo
+            echo "Server out file"
+            cat "$server_out_file"
+            echo
+            echo "Found lines"
+            grep -F -e 'Early Data' "$server_out_file"
+            echo -e "\n\nUnexpected 'Early Data' lines."
+            RESULT=1
+	fi
+	if [ $RESULT -ne 0 ]; then
+            echo -e "\n\nIssue with TLS v1.3 Early Data - PSK"
+	    if [ $early_data_try_num -lt $early_data_try_max ]; then
+		echo -e "retry #${early_data_try_num}...\n"
+		: $((++early_data_try_num))
+		continue
+	    fi
+            do_cleanup
+            exit 1
+	fi
+
+	break
+
+    done
+
 else
     echo "Early Data not available"
 fi

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -251,40 +251,40 @@ if [ "$early_data" = "yes" ]; then
     early_data_try_num=1
     while :; do
 
-	echo -e "\n\nTLS v1.3 Early Data - session ticket"
-	port=0
-	(./examples/server/server -v 4 -r -0 -R "$ready_file" -p $port 2>&1 | \
+        echo -e "\n\nTLS v1.3 Early Data - session ticket"
+        port=0
+        (./examples/server/server -v 4 -r -0 -R "$ready_file" -p $port 2>&1 | \
              tee "$server_out_file") &
-	server_pid=$!
-	create_port
-	./examples/client/client -v 4 -r -0 -p $port 2>&1 >"$client_out_file"
-	RESULT=$?
-	cat "$client_out_file"
-	remove_ready_file
-	grep -F -e 'Session Ticket' "$client_out_file"
-	session_ticket=$?
+        server_pid=$!
+        create_port
+        ./examples/client/client -v 4 -r -0 -p $port 2>&1 >"$client_out_file"
+        RESULT=$?
+        cat "$client_out_file"
+        remove_ready_file
+        grep -F -e 'Session Ticket' "$client_out_file"
+        session_ticket=$?
 
-	ed_srv_msg_cnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
-	ed_srv_status_cnt="$(grep -c -F -e 'Early Data was' "$server_out_file")"
+        ed_srv_msg_cnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
+        ed_srv_status_cnt="$(grep -c -F -e 'Early Data was' "$server_out_file")"
 
-	echo "earlydata: session_ticket=${session_ticket} ed_srv_msg_cnt=${ed_srv_msg_cnt} ed_srv_status_cnt=${ed_srv_status_cnt}"
+        echo "earlydata: session_ticket=${session_ticket} ed_srv_msg_cnt=${ed_srv_msg_cnt} ed_srv_status_cnt=${ed_srv_status_cnt}"
 
-	if [ $session_ticket -eq 0 -a $ed_srv_msg_cnt -ne 2 \
-			     -a $ed_srv_status_cnt -ne 2 ]; then
+        if [ $session_ticket -eq 0 -a $ed_srv_msg_cnt -ne 2 \
+                             -a $ed_srv_status_cnt -ne 2 ]; then
             RESULT=1
-	fi
-	if [ $RESULT -ne 0 ]; then
+        fi
+        if [ $RESULT -ne 0 ]; then
             echo -e "\n\nIssue with TLS v1.3 Early Data - session ticket"
-	    if [ $early_data_try_num -lt $early_data_try_max ]; then
-		echo -e "retry #${early_data_try_num}...\n"
-		: $((++early_data_try_num))
-		continue
-	    fi
+            if [ $early_data_try_num -lt $early_data_try_max ]; then
+                echo -e "retry #${early_data_try_num}...\n"
+                : $((++early_data_try_num))
+                continue
+            fi
             do_cleanup
             exit 1
-	fi
-	do_cleanup
-	break
+        fi
+        do_cleanup
+        break
 
     done
 
@@ -298,23 +298,23 @@ if [ "$early_data" = "yes" -a "$psk" = "yes" ]; then
     early_data_try_num=1
     while :; do
 
-	(./examples/server/server -v 4 -s -0 -R "$ready_file" -p $port 2>&1 | \
+        (./examples/server/server -v 4 -s -0 -R "$ready_file" -p $port 2>&1 | \
              tee "$server_out_file") &
-	server_pid=$!
-	create_port
-	./examples/client/client -v 4 -s -0 -p $port
-	RESULT=$?
-	remove_ready_file
+        server_pid=$!
+        create_port
+        ./examples/client/client -v 4 -s -0 -p $port
+        RESULT=$?
+        remove_ready_file
 
-	# wait for the server to quit and write output
-	wait $server_pid
+        # wait for the server to quit and write output
+        wait $server_pid
 
-	ed_srv_msg_cnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
-	ed_srv_status_cnt="$(grep -c -F -e 'Early Data was' "$server_out_file")"
+        ed_srv_msg_cnt="$(grep -c -F -e 'Early Data Client message' "$server_out_file")"
+        ed_srv_status_cnt="$(grep -c -F -e 'Early Data was' "$server_out_file")"
 
-	echo "PSK earlydata: ed_srv_msg_cnt=${ed_srv_msg_cnt} ed_srv_status_cnt=${ed_srv_status_cnt}"
+        echo "PSK earlydata: ed_srv_msg_cnt=${ed_srv_msg_cnt} ed_srv_status_cnt=${ed_srv_status_cnt}"
 
-	if [ $ed_srv_msg_cnt -ne 2 -a $ed_srv_status_cnt -ne 1 ]; then
+        if [ $ed_srv_msg_cnt -ne 2 -a $ed_srv_status_cnt -ne 1 ]; then
             echo
             echo "Server out file"
             cat "$server_out_file"
@@ -323,19 +323,19 @@ if [ "$early_data" = "yes" -a "$psk" = "yes" ]; then
             grep -F -e 'Early Data' "$server_out_file"
             echo -e "\n\nUnexpected 'Early Data' lines."
             RESULT=1
-	fi
-	if [ $RESULT -ne 0 ]; then
+        fi
+        if [ $RESULT -ne 0 ]; then
             echo -e "\n\nIssue with TLS v1.3 Early Data - PSK"
-	    if [ $early_data_try_num -lt $early_data_try_max ]; then
-		echo -e "retry #${early_data_try_num}...\n"
-		: $((++early_data_try_num))
-		continue
-	    fi
+            if [ $early_data_try_num -lt $early_data_try_max ]; then
+                echo -e "retry #${early_data_try_num}...\n"
+                : $((++early_data_try_num))
+                continue
+            fi
             do_cleanup
             exit 1
-	fi
+        fi
 
-	break
+        break
 
     done
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20576,7 +20576,8 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         ssl->keys.encryptionOn = 0;
         XMEMSET(&ssl->msgsReceived, 0, sizeof(ssl->msgsReceived));
 
-        FreeHandshakeHashes(ssl);
+        if (ssl->hsHashes)
+            (void)InitHandshakeHashes(ssl);
 
 #ifdef SESSION_CERTS
         ssl->session->chain.count = 0;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28418,7 +28418,7 @@ int wolfSSL_X509_VERIFY_PARAM_set1_ip_asc(WOLFSSL_X509_VERIFY_PARAM *param,
             param->ipasc[0] = '\0';
         }
         else {
-            XSTRNCPY(param->ipasc, ipasc, WOLFSSL_MAX_IPSTR);
+            XSTRLCPY(param->ipasc, ipasc, WOLFSSL_MAX_IPSTR);
             param->ipasc[WOLFSSL_MAX_IPSTR-1] = '\0';
         }
         ret = WOLFSSL_SUCCESS;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -28418,7 +28418,7 @@ int wolfSSL_X509_VERIFY_PARAM_set1_ip_asc(WOLFSSL_X509_VERIFY_PARAM *param,
             param->ipasc[0] = '\0';
         }
         else {
-            XSTRNCPY(param->ipasc, ipasc, WOLFSSL_MAX_IPSTR - 1);
+            XSTRNCPY(param->ipasc, ipasc, WOLFSSL_MAX_IPSTR);
             param->ipasc[WOLFSSL_MAX_IPSTR-1] = '\0';
         }
         ret = WOLFSSL_SUCCESS;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -20576,55 +20576,8 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         ssl->keys.encryptionOn = 0;
         XMEMSET(&ssl->msgsReceived, 0, sizeof(ssl->msgsReceived));
 
-        if (ssl->hsHashes != NULL) {
-#ifndef NO_OLD_TLS
-#ifndef NO_MD5
-            if (wc_InitMd5_ex(&ssl->hsHashes->hashMd5, ssl->heap,
-                    ssl->devId) != 0) {
-                return WOLFSSL_FAILURE;
-            }
-        #ifdef WOLFSSL_HASH_FLAGS
-            wc_Md5SetFlags(&ssl->hsHashes->hashMd5, WC_HASH_FLAG_WILLCOPY);
-        #endif
-#endif
-#ifndef NO_SHA
-            if (wc_InitSha_ex(&ssl->hsHashes->hashSha, ssl->heap,
-                    ssl->devId) != 0) {
-                return WOLFSSL_FAILURE;
-            }
-        #ifdef WOLFSSL_HASH_FLAGS
-            wc_ShaSetFlags(&ssl->hsHashes->hashSha, WC_HASH_FLAG_WILLCOPY);
-        #endif
-#endif
-#endif
-#ifndef NO_SHA256
-            if (wc_InitSha256_ex(&ssl->hsHashes->hashSha256, ssl->heap,
-                    ssl->devId) != 0) {
-                return WOLFSSL_FAILURE;
-            }
-        #ifdef WOLFSSL_HASH_FLAGS
-            wc_Sha256SetFlags(&ssl->hsHashes->hashSha256, WC_HASH_FLAG_WILLCOPY);
-        #endif
-#endif
-#ifdef WOLFSSL_SHA384
-            if (wc_InitSha384_ex(&ssl->hsHashes->hashSha384, ssl->heap,
-                    ssl->devId) != 0) {
-                return WOLFSSL_FAILURE;
-            }
-        #ifdef WOLFSSL_HASH_FLAGS
-            wc_Sha384SetFlags(&ssl->hsHashes->hashSha384, WC_HASH_FLAG_WILLCOPY);
-        #endif
-#endif
-#ifdef WOLFSSL_SHA512
-            if (wc_InitSha512_ex(&ssl->hsHashes->hashSha512, ssl->heap,
-                    ssl->devId) != 0) {
-                return WOLFSSL_FAILURE;
-            }
-        #ifdef WOLFSSL_HASH_FLAGS
-            wc_Sha512SetFlags(&ssl->hsHashes->hashSha512, WC_HASH_FLAG_WILLCOPY);
-        #endif
-#endif
-        }
+        FreeHandshakeHashes(ssl);
+
 #ifdef SESSION_CERTS
         ssl->session->chain.count = 0;
 #endif
@@ -51807,7 +51760,8 @@ static int wolfSSL_TicketKeyCb(WOLFSSL* ssl,
             iv, &evpCtx, &hmacCtx, enc);
     if (res != TICKET_KEY_CB_RET_OK && res != TICKET_KEY_CB_RET_RENEW) {
         WOLFSSL_MSG("Ticket callback error");
-        return WOLFSSL_TICKET_RET_FATAL;
+        ret = WOLFSSL_TICKET_RET_FATAL;
+        goto end;
     }
 
     if (enc)
@@ -51861,6 +51815,9 @@ static int wolfSSL_TicketKeyCb(WOLFSSL* ssl,
     else
         ret = WOLFSSL_TICKET_RET_OK;
 end:
+
+    (void)wc_HmacFree(&hmacCtx.hmac);
+
     return ret;
 }
 

--- a/tests/api.c
+++ b/tests/api.c
@@ -38690,6 +38690,14 @@ static void test_wolfSSL_BIO_connect(void)
 
     printf(testingFmt, "wolfSSL_BIO_new_connect()");
 
+    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
+    AssertIntEQ(WOLFSSL_SUCCESS,
+            wolfSSL_CTX_load_verify_locations(ctx, caCertFile, 0));
+    AssertIntEQ(WOLFSSL_SUCCESS,
+          wolfSSL_CTX_use_certificate_file(ctx, cliCertFile, SSL_FILETYPE_PEM));
+    AssertIntEQ(WOLFSSL_SUCCESS,
+            wolfSSL_CTX_use_PrivateKey_file(ctx, cliKeyFile, SSL_FILETYPE_PEM));
+
     /* Setup server */
     XMEMSET(&server_args, 0, sizeof(func_args));
     StartTCP();
@@ -38708,13 +38716,6 @@ static void test_wolfSSL_BIO_connect(void)
     AssertNotNull(tcpBio = BIO_new_connect(wolfSSLIP));
     AssertIntEQ(BIO_set_conn_port(tcpBio, buff), 1);
     /* Setup the SSL object */
-    AssertNotNull(ctx = wolfSSL_CTX_new(wolfSSLv23_client_method()));
-    AssertIntEQ(WOLFSSL_SUCCESS,
-            wolfSSL_CTX_load_verify_locations(ctx, caCertFile, 0));
-    AssertIntEQ(WOLFSSL_SUCCESS,
-          wolfSSL_CTX_use_certificate_file(ctx, cliCertFile, SSL_FILETYPE_PEM));
-    AssertIntEQ(WOLFSSL_SUCCESS,
-            wolfSSL_CTX_use_PrivateKey_file(ctx, cliKeyFile, SSL_FILETYPE_PEM));
     AssertNotNull(ssl = SSL_new(ctx));
     SSL_set_connect_state(ssl);
     /* Setup the SSL BIO */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -22994,7 +22994,7 @@ static int SetNameRdnItems(ASNSetData* dataASN, ASNItem* namesASN,
                     break;
                 }
                 /* Copy data into dynamic vars. */
-                SetRdnItems(namesASN + idx, dataASN + idx, nameOid[type],
+                SetRdnItems(namesASN + idx, dataASN + idx, nameOid[i],
                     NAME_OID_SZ, name->name[j].type,
                     (byte*)name->name[j].value, name->name[j].sz);
             }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -16198,8 +16198,8 @@ static int DecodeNameConstraints(const byte* input, int sz, DecodedCert* cert)
 
     if (ret == 0) {
         /* Parse NameConstraints. */
-        ret = GetASN_Items(nameConstraintsASN, dataASN, nameConstraintsASN_Length,
-                           1, input, &idx, sz);
+        ret = GetASN_Items(nameConstraintsASN, dataASN,
+                           nameConstraintsASN_Length, 1, input, &idx, sz);
     }
     if (ret == 0) {
         /* If there was a permittedSubtrees then parse it. */
@@ -16219,6 +16219,8 @@ static int DecodeNameConstraints(const byte* input, int sz, DecodedCert* cert)
                     &cert->excludedNames, cert->heap);
         }
     }
+
+    FREE_ASNGETDATA(dataASN, cert->heap);
 
     return ret;
 #endif /* WOLFSSL_ASN_TEMPLATE */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -23423,7 +23423,7 @@ static int EncodeExtensions(Cert* cert, byte* output, word32 maxSz,
      * above definition of certExtsASN_Length. */
     XMEMCPY(certExtsASN, static_certExtsASN, sizeof(static_certExtsASN));
     for (i = sizeof(static_certExtsASN) / sizeof(ASNItem);
-         i < (int)(sizeof(certExtsASN) / sizeof(ASNItem)); i += 4) {
+         i < (int)certExtsASN_Length; i += 4) {
         XMEMCPY(&certExtsASN[i], customExtASN, sizeof(customExtASN));
     }
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -31831,6 +31831,9 @@ static int ParseCRL_Extensions(DecodedCRL* dcrl, const byte* buf, word32 idx,
     if (ret < 0) {
         ret = ASN_PARSE_E;
     }
+
+    FREE_ASNGETDATA(dataASN, dcrl->heap);
+
     return ret;
 }
 #endif /* !WOLFSSL_ASN_TEMPLATE */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -28910,6 +28910,7 @@ int eccsi_test(void)
 {
     int ret = 0;
     WC_RNG rng;
+    int rng_inited = 0;
     EccsiKey* priv = NULL;
     EccsiKey* pub  = NULL;
     mp_int* ssk    = NULL;
@@ -28917,24 +28918,27 @@ int eccsi_test(void)
 
     priv = (EccsiKey*)XMALLOC(sizeof(EccsiKey), HEAP_HINT,
             DYNAMIC_TYPE_TMP_BUFFER);
-    if (priv == NULL) {
+    if (priv == NULL)
         ret = -10205;
-    }
+    else
+        XMEMSET(priv, 0, sizeof(*priv));
 
     if (ret == 0) {
         pub = (EccsiKey*)XMALLOC(sizeof(EccsiKey), HEAP_HINT,
             DYNAMIC_TYPE_TMP_BUFFER);
-        if (pub == NULL) {
-        ret = -10206;
-        }
+        if (pub == NULL)
+            ret = -10206;
+        else
+            XMEMSET(pub, 0, sizeof(*pub));
     }
 
     if (ret == 0) {
         ssk = (mp_int*)XMALLOC(sizeof(mp_int), HEAP_HINT,
                 DYNAMIC_TYPE_TMP_BUFFER);
-        if (ssk == NULL) {
+        if (ssk == NULL)
             ret = -10207;
-        }
+        else
+            XMEMSET(ssk, 0, sizeof(*ssk));
     }
 
     if (ret == 0) {
@@ -28945,6 +28949,8 @@ int eccsi_test(void)
     #endif
         if (ret != 0)
             ret = -10200;
+        else
+            rng_inited = 1;
     }
 
     if (ret == 0) {
@@ -28987,19 +28993,22 @@ int eccsi_test(void)
         ret = eccsi_sign_verify_test(priv, pub, &rng, ssk, pvt);
     }
 
-    wc_FreeEccsiKey(priv);
-    wc_FreeEccsiKey(pub);
-    mp_free(ssk);
-    wc_ecc_del_point(pvt);
-
-    if (ret != -10200)
+    if (pvt != NULL)
+        wc_ecc_del_point(pvt);
+    if (rng_inited)
         wc_FreeRng(&rng);
-    if (ssk != NULL)
+    if (ssk != NULL) {
+        mp_free(ssk);
         XFREE(ssk, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (pub != NULL)
+    }
+    if (pub != NULL) {
+        wc_FreeEccsiKey(pub);
         XFREE(pub, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (priv != NULL)
+    }
+    if (priv != NULL) {
+        wc_FreeEccsiKey(priv);
         XFREE(priv, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    }
 
     return ret;
 }
@@ -30056,6 +30065,7 @@ int sakke_test(void)
 {
     int ret = 0;
     WC_RNG rng;
+    int rng_inited = 0;
     SakkeKey* priv = NULL;
     SakkeKey* pub  = NULL;
     SakkeKey* key  = NULL;
@@ -30063,24 +30073,27 @@ int sakke_test(void)
 
     priv = (SakkeKey*)XMALLOC(sizeof(SakkeKey), HEAP_HINT,
             DYNAMIC_TYPE_TMP_BUFFER);
-    if (priv == NULL) {
+    if (priv == NULL)
         ret = -10404;
-    }
+    else
+        XMEMSET(priv, 0, sizeof(*priv));
 
     if (ret == 0) {
         pub = (SakkeKey*)XMALLOC(sizeof(SakkeKey), HEAP_HINT,
             DYNAMIC_TYPE_TMP_BUFFER);
-        if (pub == NULL) {
+        if (pub == NULL)
             ret = -10405;
-        }
+        else
+            XMEMSET(pub, 0, sizeof(*pub));
     }
 
     if (ret == 0) {
         key = (SakkeKey*)XMALLOC(sizeof(SakkeKey), HEAP_HINT,
             DYNAMIC_TYPE_TMP_BUFFER);
-        if (key == NULL) {
+        if (key == NULL)
             ret = -10406;
-        }
+        else
+            XMEMSET(key, 0, sizeof(*key));
     }
 
     if (ret == 0) {
@@ -30089,7 +30102,9 @@ int sakke_test(void)
     #else
         ret = wc_InitRng(&rng);
     #endif
-        if (ret != 0)
+        if (ret == 0)
+            rng_inited = 1;
+        else
             ret = -10400;
     }
 
@@ -30131,20 +30146,22 @@ int sakke_test(void)
         ret = sakke_op_test(priv, pub, &rng, rsk);
     }
 
-    wc_FreeSakkeKey(priv);
-    wc_FreeSakkeKey(pub);
-    wc_ecc_forcezero_point(rsk);
-    wc_ecc_del_point(rsk);
-
-    if (ret != -10400)
+    if (rsk != NULL) {
+        wc_ecc_forcezero_point(rsk);
+        wc_ecc_del_point(rsk);
+    }
+    if (rng_inited)
         wc_FreeRng(&rng);
-
     if (key != NULL)
         XFREE(key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (pub != NULL)
+    if (pub != NULL) {
+        wc_FreeSakkeKey(pub);
         XFREE(pub, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    if (priv != NULL)
+    }
+    if (priv != NULL) {
+        wc_FreeSakkeKey(priv);
         XFREE(priv, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    }
 
     return ret;
 }

--- a/wolfssl/openssl/asn1.h
+++ b/wolfssl/openssl/asn1.h
@@ -146,7 +146,8 @@ typedef enum {
     static const WOLFSSL_ASN1_TEMPLATE type##_member_data[]
 
 #define ASN1_SIMPLE(type, member, member_type) \
-    { (char*)&__##type##_dummy_struct.member - (char*)&__##type##_dummy_struct, \
+    { ((size_t)&__##type##_dummy_struct.member - \
+       (size_t)&__##type##_dummy_struct), \
         WOLFSSL_##member_type##_ASN1 }
 
 #define ASN1_SEQUENCE_END(type) \

--- a/wolfssl/openssl/asn1.h
+++ b/wolfssl/openssl/asn1.h
@@ -142,12 +142,10 @@ typedef enum {
 } WOLFSSL_ASN1_TYPES;
 
 #define ASN1_SEQUENCE(type) \
-    static type __##type##_dummy_struct;\
     static const WOLFSSL_ASN1_TEMPLATE type##_member_data[]
 
 #define ASN1_SIMPLE(type, member, member_type) \
-    { ((size_t)&__##type##_dummy_struct.member - \
-       (size_t)&__##type##_dummy_struct), \
+    { OFFSETOF(type, member), \
         WOLFSSL_##member_type##_ASN1 }
 
 #define ASN1_SEQUENCE_END(type) \


### PR DESCRIPTION
wolfcrypt/src/asn.c: fix buffer underrun in EncodeExtensions(), due to faulty iteration limit calculation, when smallstack build.

fixes these:
```
[all-sp-small-stack-asn-template] [5 of 76] [6b7f0d4ee7]
    configure...   real 0m6.724s  user 0m3.743s  sys 0m3.653s
    build...wolfcrypt/src/asn.c: In function ‘EncodeExtensions’:
0053bd3af1 (<anthony@wolfssl.com> 2022-03-02 15:16:39 -0500 23426)          i < (int)(sizeof(certExtsASN) / sizeof(ASNItem)); i += 4) {
wolfcrypt/src/asn.c:23426:40: error: division ‘sizeof (ASNItem *) / sizeof (ASNItem)’ does not compute the number of array elements [-Werror=sizeof-pointer-div]
23426 |          i < (int)(sizeof(certExtsASN) / sizeof(ASNItem)); i += 4) {
      |                                        ^
0053bd3af1 (<anthony@wolfssl.com> 2022-03-02 15:16:39 -0500 23399)     ASNItem *certExtsASN = (ASNItem *)XMALLOC(certExtsASN_Length *
wolfcrypt/src/asn.c:23399:14: note: first ‘sizeof’ operand was declared here
23399 |     ASNItem *certExtsASN = (ASNItem *)XMALLOC(certExtsASN_Length *
      |              ^~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:5691: wolfcrypt/src/src_libwolfssl_la-asn.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:6576: all-recursive] Error 1
make: *** [Makefile:3943: all] Error 2
   real 0m17.880s  user 1m11.021s  sys 0m3.116s
    all-sp-small-stack-asn-template fail_build
```

```[clang-tidy-asn-template-sp-all-small-stack] [12 of 76] [6b7f0d4ee7]
    configure...   real 0m10.556s  user 0m5.072s  sys 0m6.262s
    build...0053bd3af1 (<anthony@wolfssl.com> 2022-03-02 15:16:39 -0500 23426)          i < (int)(sizeof(certExtsASN) / sizeof(ASNItem)); i += 4) {
/home/wolfbot/tmp/wolfssl_test_workdir.20197/wolfssl/wolfcrypt/src/asn.c:23426:20: warning: suspicious usage of 'sizeof(A*)'; pointer to aggregate [bugprone-sizeof-expression]
i < (int)(sizeof(certExtsASN) / sizeof(ASNItem)); i += 4) {
                   ^
0053bd3af1 (<anthony@wolfssl.com> 2022-03-02 15:16:39 -0500 23426)          i < (int)(sizeof(certExtsASN) / sizeof(ASNItem)); i += 4) {
/home/wolfbot/tmp/wolfssl_test_workdir.20197/wolfssl/wolfcrypt/src/asn.c:23426:20: warning: suspicious usage of sizeof pointer 'sizeof(T*)/sizeof(T)' [bugprone-sizeof-expression]
/home/wolfbot/tmp/wolfssl_test_workdir.20197/wolfssl/wolfcrypt/src/asn.c:23426:40: warning: 'sizeof (certExtsASN)' will return the size of the pointer, not the array itself [clang-diagnostic-sizeof-pointer-div]
i < (int)(sizeof(certExtsASN) / sizeof(ASNItem)); i += 4) {
                   ~~~~~~~~~~~~~~~~~~~ ^
0053bd3af1 (<anthony@wolfssl.com> 2022-03-02 15:16:39 -0500 23399)     ASNItem *certExtsASN = (ASNItem *)XMALLOC(certExtsASN_Length *
/home/wolfbot/tmp/wolfssl_test_workdir.20197/wolfssl/wolfcrypt/src/asn.c:23399:14: note: pointer 'certExtsASN' declared here
ASNItem *certExtsASN = (ASNItem *)XMALLOC(certExtsASN_Length *
             ^
make[2]: *** [Makefile:5691: wolfcrypt/src/src_libwolfssl_la-asn.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:6576: all-recursive] Error 1
make: *** [Makefile:3943: all] Error 2
   real 5m15.488s  user 10m14.623s  sys 0m11.961s
    clang-tidy-asn-template-sp-all-small-stack fail_build
```
