### PR TITLE
Fix for ZD13795 and also remove all-caps parameter

### DIFF
--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -5005,7 +5005,7 @@ int mp_rand_prime(mp_int* a, int len, WC_RNG* rng, void* heap)
     int   err, res, type;
     byte* buf;
 
-    if (N == NULL || rng == NULL)
+    if (a == NULL || rng == NULL)
         return MP_VAL;
 
     /* get type */

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -5000,7 +5000,7 @@ LBL_B:mp_clear (&b);
 
 static const int USE_BBS = 1;
 
-int mp_rand_prime(mp_int* N, int len, WC_RNG* rng, void* heap)
+int mp_rand_prime(mp_int* a, int len, WC_RNG* rng, void* heap)
 {
     int   err, res, type;
     byte* buf;
@@ -5045,7 +5045,7 @@ int mp_rand_prime(mp_int* N, int len, WC_RNG* rng, void* heap)
         buf[len-1] |= 0x01 | ((type & USE_BBS) ? 0x02 : 0x00);
 
         /* load value */
-        if ((err = mp_read_unsigned_bin(N, buf, len)) != MP_OKAY) {
+        if ((err = mp_read_unsigned_bin(a, buf, len)) != MP_OKAY) {
             XFREE(buf, heap, DYNAMIC_TYPE_RSA);
             return err;
         }
@@ -5055,7 +5055,7 @@ int mp_rand_prime(mp_int* N, int len, WC_RNG* rng, void* heap)
          * of a 1024-bit candidate being a false positive, when it is our
          * prime candidate. (Note 4.49 of Handbook of Applied Cryptography.)
          * Using 8 because we've always used 8. */
-        if ((err = mp_prime_is_prime_ex(N, 8, &res, rng)) != MP_OKAY) {
+        if ((err = mp_prime_is_prime_ex(a, 8, &res, rng)) != MP_OKAY) {
             XFREE(buf, heap, DYNAMIC_TYPE_RSA);
             return err;
         }

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5189,7 +5189,7 @@ int mp_cond_swap_ct(mp_int * a, mp_int * b, int c, int m)
 
 static int  fp_gcd(fp_int *a, fp_int *b, fp_int *c);
 static int  fp_lcm(fp_int *a, fp_int *b, fp_int *c);
-static int  fp_randprime(fp_int* N, int len, WC_RNG* rng, void* heap);
+static int  fp_randprime(fp_int* a, int len, WC_RNG* rng, void* heap);
 
 int mp_gcd(fp_int *a, fp_int *b, fp_int *c)
 {
@@ -5202,11 +5202,11 @@ int mp_lcm(fp_int *a, fp_int *b, fp_int *c)
     return fp_lcm(a, b, c);
 }
 
-int mp_rand_prime(mp_int* N, int len, WC_RNG* rng, void* heap)
+int mp_rand_prime(mp_int* a, int len, WC_RNG* rng, void* heap)
 {
     int err;
 
-    err = fp_randprime(N, len, rng, heap);
+    err = fp_randprime(a, len, rng, heap);
     switch(err) {
         case FP_VAL:
             return MP_VAL;
@@ -5226,7 +5226,7 @@ int mp_exch (mp_int * a, mp_int * b)
 
 
 
-int fp_randprime(fp_int* N, int len, WC_RNG* rng, void* heap)
+int fp_randprime(fp_int* a, int len, WC_RNG* rng, void* heap)
 {
     static const int USE_BBS = 1;
     int   err, type;
@@ -5274,7 +5274,7 @@ int fp_randprime(fp_int* N, int len, WC_RNG* rng, void* heap)
         buf[len-1] |= 0x01 | ((type & USE_BBS) ? 0x02 : 0x00);
 
         /* load value */
-        err = fp_read_unsigned_bin(N, buf, len);
+        err = fp_read_unsigned_bin(a, buf, len);
         if (err != 0) {
             XFREE(buf, heap, DYNAMIC_TYPE_TMP_BUFFER);
             return err;
@@ -5285,7 +5285,7 @@ int fp_randprime(fp_int* N, int len, WC_RNG* rng, void* heap)
          * of a 1024-bit candidate being a false positive, when it is our
          * prime candidate. (Note 4.49 of Handbook of Applied Cryptography.)
          * Using 8 because we've always used 8 */
-        mp_prime_is_prime_ex(N, 8, &isPrime, rng);
+        mp_prime_is_prime_ex(a, 8, &isPrime, rng);
     } while (isPrime == FP_NO);
 
     XMEMSET(buf, 0, len);

--- a/wolfssl/wolfcrypt/integer.h
+++ b/wolfssl/wolfcrypt/integer.h
@@ -398,7 +398,7 @@ MP_API int mp_radix_size (mp_int * a, int radix, int *size);
 #ifdef WOLFSSL_KEY_GEN
     MP_API int mp_gcd (mp_int * a, mp_int * b, mp_int * c);
     MP_API int mp_lcm (mp_int * a, mp_int * b, mp_int * c);
-    MP_API int mp_rand_prime(mp_int* N, int len, WC_RNG* rng, void* heap);
+    MP_API int mp_rand_prime(mp_int* a, int len, WC_RNG* rng, void* heap);
 #endif
 
 MP_API int mp_cnt_lsb(mp_int *a);

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -843,7 +843,7 @@ MP_API int  mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng);
 #ifdef WOLFSSL_KEY_GEN
 MP_API int  mp_gcd(fp_int *a, fp_int *b, fp_int *c);
 MP_API int  mp_lcm(fp_int *a, fp_int *b, fp_int *c);
-MP_API int  mp_rand_prime(mp_int* N, int len, WC_RNG* rng, void* heap);
+MP_API int  mp_rand_prime(mp_int* a, int len, WC_RNG* rng, void* heap);
 MP_API int  mp_exch(mp_int *a, mp_int *b);
 #endif /* WOLFSSL_KEY_GEN */
 MP_API int  mp_cond_swap_ct (mp_int * a, mp_int * b, int c, int m);


### PR DESCRIPTION
# Description

Customer had an environment where `#define N 4096` was changing the value of the all capitol (albeit a single letter) input parameter `N` to `4096` resulting in a build error.

- Change all capitol input parameter to lower-case to be more fitting with expected conventions where all caps should be considered potential for defined variables.
- Changed `N` to `a` to fit the convention used by every other API in tfm.h and integer.h


Fixes zd#13795

# Testing

How did you test? Didn't

# Checklist

 - [N/A ] added tests
 - [ N/A] updated/added doxygen
 - [ N/A] updated appropriate READMEs
 - [ N/A] Updated manual and documentation
