### PR TITLE
Fixes for TLS v1.3 early data with async

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -583,11 +583,7 @@ then
     test "$enable_truncatedhmac" = "" && enable_truncatedhmac=yes
     test "$enable_trusted_ca" = "" && enable_trusted_ca=yes
     test "$enable_session_ticket" = "" && enable_session_ticket=yes
-
-    # don't add earlydata when assynccrypt, pending fix:
-    if test "$enable_asynccrypt" != "yes"; then
-        test "$enable_earlydata" = "" && enable_earlydata=yes
-    fi
+    test "$enable_earlydata" = "" && enable_earlydata=yes
 
     if test "$ENABLED_32BIT" != "yes"
     then

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -639,6 +639,7 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
                     err = wolfSSL_get_error(ssl, 0);
                 #ifdef WOLFSSL_ASYNC_CRYPT
                     if (err == WC_PENDING_E) {
+                        /* returns the number of polled items or <0 for error */
                         ret = wolfSSL_AsyncPoll(ssl, WOLF_POLL_FLAG_CHECK_HW);
                         if (ret < 0) break;
                     }

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -3017,13 +3017,15 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                         err = SSL_get_error(ssl, 0);
                     #ifdef WOLFSSL_ASYNC_CRYPT
                         if (err == WC_PENDING_E) {
+                            /* returns the number of polled items or <0 for
+                             * error */
                             ret = wolfSSL_AsyncPoll(ssl,
                                                     WOLF_POLL_FLAG_CHECK_HW);
                             if (ret < 0) break;
                         }
                     #endif
                     }
-                    if (ret > 0) {
+                    else if (ret > 0) {
                         input[ret] = 0; /* null terminate message */
                         printf("Early Data Client message: %s\n", input);
                     }

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -9933,7 +9933,8 @@ int wolfSSL_write_early_data(WOLFSSL* ssl, const void* data, int sz, int* outSz)
         return SIDE_ERROR;
 
     if (ssl->options.handShakeState == NULL_STATE) {
-        ssl->earlyData = expecting_early_data;
+        if (ssl->error != WC_PENDING_E)
+            ssl->earlyData = expecting_early_data;
         ret = wolfSSL_connect_TLSv13(ssl);
         if (ret != WOLFSSL_SUCCESS)
             return WOLFSSL_FATAL_ERROR;
@@ -9995,7 +9996,8 @@ int wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz, int* outSz)
         return SIDE_ERROR;
 
     if (ssl->options.handShakeState == NULL_STATE) {
-        ssl->earlyData = expecting_early_data;
+        if (ssl->error != WC_PENDING_E)
+            ssl->earlyData = expecting_early_data;
         ret = wolfSSL_accept_TLSv13(ssl);
         if (ret <= 0)
             return WOLFSSL_FATAL_ERROR;


### PR DESCRIPTION
# Description

Fixes for TLS v1.3 early data with async. Removes workaround in configure.ac.

Found when --enable-earlydata was added to --enable-all.

# Testing

`./configure --enable-all --enable-asynccrypt && make check`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
