### PR TITLE
TLS: add peer authentication failsafe for TLS 1.2 and below

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4470,7 +4470,7 @@ then
 fi
 if test "$ENABLED_TLS13_EARLY_DATA" = "yes"
 then
-    if test "x$ENABLED_TLS13" = "xno"
+    if test "x$ENABLED_TLS13" = "xno" && test "X$ENABLED_ALL" = "xno"
     then
         AC_MSG_ERROR([cannot enable earlydata without enabling tls13.])
     fi
@@ -4478,7 +4478,10 @@ then
     then
         AC_MSG_ERROR([cannot enable earlydata without enabling session tickets and/or PSK.])
     fi
-    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_EARLY_DATA"
+    if test "x$ENABLED_TLS13" = "xyes"
+    then
+        AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_EARLY_DATA"
+    fi
 fi
 
 if test "$ENABLED_TLSV12" = "no" && test "$ENABLED_TLS13" = "yes" && test "x$ENABLED_SESSION_TICKET" = "xno"

--- a/src/keys.c
+++ b/src/keys.c
@@ -2064,6 +2064,11 @@ int SetCipherSpecs(WOLFSSL* ssl)
         #endif
 #endif
 
+    if (ssl->specs.sig_algo == anonymous_sa_algo) {
+        /* CLIENT/SERVER: No peer authentication to be performed. */
+        ssl->options.peerAuthGood = 1;
+    }
+
     return 0;
 }
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -5147,8 +5147,10 @@ static int TLSX_SessionTicket_Parse(WOLFSSL* ssl, const byte* input,
             ret = DoClientTicket(ssl, input, length);
             if (ret == WOLFSSL_TICKET_RET_OK) {    /* use ticket to resume */
                 WOLFSSL_MSG("Using existing client ticket");
-                ssl->options.useTicket = 1;
-                ssl->options.resuming  = 1;
+                ssl->options.useTicket    = 1;
+                ssl->options.resuming     = 1;
+                /* SERVER: ticket is peer auth. */
+                ssl->options.peerAuthGood = 1;
             } else if (ret == WOLFSSL_TICKET_RET_CREATE) {
                 WOLFSSL_MSG("Using existing client ticket, creating new one");
                 ret = TLSX_UseSessionTicket(&ssl->extensions, NULL, ssl->heap);
@@ -5159,6 +5161,8 @@ static int TLSX_SessionTicket_Parse(WOLFSSL* ssl, const byte* input,
                     ssl->options.createTicket = 1;  /* will send ticket msg */
                     ssl->options.useTicket    = 1;
                     ssl->options.resuming     = 1;
+                    /* SERVER: ticket is peer auth. */
+                    ssl->options.peerAuthGood = 1;
                 }
             } else if (ret == WOLFSSL_TICKET_RET_REJECT) {
                 WOLFSSL_MSG("Process client ticket rejected, not using");


### PR DESCRIPTION
# Description

TLS: add peer authentication failsafe for TLS 1.2 and below
Tightened the TLS 1.3 failsafe checks too.

# Testing

Regression tested TLS 1.3 and TLS 1.2 configurations.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
