### PR TITLE
wolfRand for AMD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1966,6 +1966,18 @@ then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_INTEL_RDRAND"
 fi
 
+# AMD RDSEED
+AC_ARG_ENABLE([amdrand],
+    [AS_HELP_STRING([--enable-amdrand],[Enable AMD rdseed as preferred RNG seeding source (default: disabled)])],
+    [ ENABLED_AMDRDSEED=$enableval ],
+    [ ENABLED_AMDRDSEED=no ]
+    )
+
+if test "$ENABLED_AMDRDSEED" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DHAVE_AMD_RDSEED"
+fi
+
 
 # Linux af_alg
 AC_ARG_ENABLE([afalg],

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -11482,7 +11482,7 @@ WOLFSSL_TEST_SUBROUTINE int random_test(void)
 
         /* Every byte of the entropy scratch is different,
          * entropy is a single byte that shouldn't match. */
-        outputSz = (sizeof(word32) * 2) + 1;
+        outputSz = (sizeof(output) / 2) + 1;
         for (i = 0; i < outputSz; i++)
             output[i] = (byte)i;
         ret = wc_RNG_TestSeed(output, outputSz);


### PR DESCRIPTION
# Description

1. Add seed parameters when building specifically for AMD using RDSEED.
2. Update the wolfCrypt test to play nice with the larger seed size.

# Testing

Verified the seed sizes matched before and after the changes for existing combinations.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
