### PR TITLE
Fix settings and remove warnings in example app for Renesas boards 

### DIFF
--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/common/wolfssl_dummy.c
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/common/wolfssl_dummy.c
@@ -22,7 +22,7 @@
 typedef unsigned long time_t;
 
 #define YEAR 2022
-#define MON  2
+#define MON  3
 
 static int tick = 0;
 

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/wolfssl/.project
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/wolfssl/.project
@@ -72,7 +72,7 @@
 		<link>
 			<name>wolfcrypt/port/renesas_common.c</name>
 			<type>1</type>
-			<location>F:/Work/1_Renesas/tsip113_integrate/wolfssl/wolfcrypt/src/port/Renesas/renesas_common.c</location>
+			<locationURI>PARENT-6-PROJECT_LOC/wolfcrypt/src/port/Renesas/renesas_common.c</locationURI>
 		</link>
 		<link>
 			<name>wolfcrypt/port/renesas_tsip_aes.c</name>

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/wolfssl/wolfssl.rcpc
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/wolfssl/wolfssl.rcpc
@@ -20,7 +20,7 @@
       </Category>
       <Category Name="wolfcrypt">
         <Category Name="port">
-          <Path>..\..\..\..\..\..\..\..\tsip113_integrate\wolfssl\wolfcrypt\src\port\Renesas\renesas_common.c</Path>
+          <Path>..\..\..\..\..\..\wolfcrypt\src\port\Renesas\renesas_common.c</Path>
           <Path>..\..\..\..\..\..\wolfcrypt\src\port\Renesas\renesas_tsip_aes.c</Path>
           <Path>..\..\..\..\..\..\wolfcrypt\src\port\Renesas\renesas_tsip_sha.c</Path>
           <Path>..\..\..\..\..\..\wolfcrypt\src\port\Renesas\renesas_tsip_util.c</Path>

--- a/IDE/Renesas/e2studio/RX65N/RSK/resource/section.esi
+++ b/IDE/Renesas/e2studio/RX65N/RSK/resource/section.esi
@@ -8,9 +8,6 @@
   <sections name="R_2"/>
   <sections name="R"/>
   <sections name="RPFRAM2"/>
-  <sections name="C_BOOTLOADER_KEY_STORAGE*">
-    <sectionAddress xsi:type="com.renesas.linkersection.model:FixedAddress" fixedAddress="1048576"/>
-  </sections>
   <sections name="C_PKCS11_STORAGE*">
     <sectionAddress xsi:type="com.renesas.linkersection.model:FixedAddress" fixedAddress="1050624"/>
   </sections>

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/resource/section.esi
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/resource/section.esi
@@ -16,9 +16,6 @@
   <sections name="RPFRAM2*"/>
   <sections name="SU"/>
   <sections name="SI"/>
-  <sections name="C_BOOTLOADER_KEY_STORAGE*">
-    <sectionAddress xsi:type="com.renesas.linkersection.model:FixedAddress" fixedAddress="1048576"/>
-  </sections>
   <sections name="C_PKCS11_STORAGE*">
     <sectionAddress xsi:type="com.renesas.linkersection.model:FixedAddress" fixedAddress="1050624"/>
   </sections>

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/user_settings.h
@@ -105,7 +105,7 @@
    * - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA256
    * 
    */
-  #define USE_ECC_CERT
+  /*#define USE_ECC_CERT*/
 
   /* In this example application, Root CA cert buffer named 
    * "ca_ecc_cert_der_256" is used under the following macro definition 

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2500,7 +2500,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
                 len = sz;
             }
             /* return 4 words random number*/
-            ret = R_TSIP_GenerateRandomNumber(buffer);
+            ret = R_TSIP_GenerateRandomNumber((uint32_t*)buffer);
             if(ret == TSIP_SUCCESS) {
                 XMEMCPY(output, &buffer, len);
                 output += len;


### PR DESCRIPTION
# Description

This PR addresses following issues in example projects for Renesas boards:
- calendar month settings for cert verification in examples
- a source file path in a project file is not relative path
- unused section is included in section setting file
- remove warnings

Fixes zd#

none

# Testing

build and run examples on the boards with H/W debugger.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
