### PR TITLE
Fix bug in wolfSSL_ASN1_TIME_diff.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -32084,7 +32084,7 @@ int wolfSSL_ASN1_TIME_diff(int *days, int *secs, const WOLFSSL_ASN1_TIME *from,
     }
 
     fromSecs = XMKTIME(fromTm);
-    if (fromSecs <= 0) {
+    if (fromSecs < 0) {
         WOLFSSL_MSG("XMKTIME for from time failed.");
         return WOLFSSL_FAILURE;
     }
@@ -32103,7 +32103,7 @@ int wolfSSL_ASN1_TIME_diff(int *days, int *secs, const WOLFSSL_ASN1_TIME *from,
     }
 
     toSecs = XMKTIME(toTm);
-    if (toSecs <= 0) {
+    if (toSecs < 0) {
         WOLFSSL_MSG("XMKTIME for to time failed.");
         return WOLFSSL_FAILURE;
     }

--- a/tests/api.c
+++ b/tests/api.c
@@ -30618,14 +30618,22 @@ static void test_wolfSSL_ASN1_TIME_diff(void)
 
     AssertNotNull((fromTime = ASN1_TIME_new()));
     /* Feb 22, 2003, 21:15:15 */
-    AssertIntEQ(ASN1_TIME_set_string(fromTime, "030222211515Z"), 1);
+    AssertIntEQ(ASN1_TIME_set_string(fromTime, "030222211515Z"), WOLFSSL_SUCCESS);
     AssertNotNull((toTime = ASN1_TIME_new()));
     /* Dec 19, 2010, 18:10:11 */
-    AssertIntEQ(ASN1_TIME_set_string(toTime, "101219181011Z"), 1);
-    AssertIntEQ(ASN1_TIME_diff(&daysDiff, &secsDiff, fromTime, toTime), 1);
+    AssertIntEQ(ASN1_TIME_set_string(toTime, "101219181011Z"), WOLFSSL_SUCCESS);
+    AssertIntEQ(ASN1_TIME_diff(&daysDiff, &secsDiff, fromTime, toTime), WOLFSSL_SUCCESS);
 
     AssertIntEQ(daysDiff, 2856);
     AssertIntEQ(secsDiff, 75296);
+
+    /* Edge case with Unix epoch. */
+    AssertNotNull(ASN1_TIME_set_string(fromTime, "19700101000000Z"));
+    AssertNotNull(ASN1_TIME_set_string(toTime, "19800101000000Z"));
+    AssertIntEQ(ASN1_TIME_diff(&daysDiff, &secsDiff, fromTime, toTime), WOLFSSL_SUCCESS);
+
+    AssertIntEQ(daysDiff, 3652);
+    AssertIntEQ(secsDiff, 0);
 
     ASN1_TIME_free(fromTime);
     ASN1_TIME_free(toTime);


### PR DESCRIPTION
# Description

This function should not error out if one of the passed in times is the Unix epoch. This amounts to erroring out when the XMKTIME returns < 0, rather than <= 0.

# Testing

I actually couldn't get this to fail on my dev machine, but I could get it to fail in the customer's environment (they discovered this bug).

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
