### PR TITLE
Update `wolfSSL_get_session` docs

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -670,7 +670,9 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
             wolfSSL_shutdown(ssl);
     #ifndef NO_SESSION_CACHE
             if (i == (times-1) && resumeSession) {
-                benchSession = wolfSSL_get_session(ssl);
+                if (benchSession != NULL)
+                    wolfSSL_SESSION_free(benchSession);
+                benchSession = wolfSSL_get1_session(ssl);
             }
     #endif
             wolfSSL_free(ssl); ssl = NULL;
@@ -688,6 +690,11 @@ static int ClientBenchmarkConnections(WOLFSSL_CTX* ctx, char* host, word16 port,
 
         WOLFSSL_TIME(times);
     }
+
+#ifndef NO_SESSION_CACHE
+    if (benchSession != NULL)
+        wolfSSL_SESSION_free(benchSession);
+#endif
 
     return EXIT_SUCCESS;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -5272,12 +5272,14 @@ static void test_client_reuse_WOLFSSLobj(void* args, void *cb, void* server_args
         /* err_sys ("SSL shutdown failed"); */
         goto done;
     }
-    session = wolfSSL_get_session(ssl);
+    session = wolfSSL_get1_session(ssl);
     if (wolfSSL_clear(ssl) != WOLFSSL_SUCCESS) {
         /* err_sys ("SSL_clear failed"); */
         goto done;
     }
     wolfSSL_set_session(ssl, session);
+    wolfSSL_SESSION_free(session);
+    session = NULL;
     /* close socket once */
     CloseSocket(sockfd);
     sockfd = 0;


### PR DESCRIPTION
Recommend using `wolfSSL_get1_session` and `NO_SESSION_CACHE_REF` for session resumption purposes. `wolfSSL_get_session` should not be used unless to inspect the current session object.