### PR TITLE
Fixes for KCAPI AES GCM and ECC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3888,8 +3888,8 @@ if test "x$ENABLED_HASHDRBG" = "xyes"
 then
     AM_CFLAGS="$AM_CFLAGS -DHAVE_HASHDRBG"
 else
-    # turn on Hash DRBG if FIPS is on
-    if test "x$ENABLED_FIPS" = "xyes"
+    # turn on Hash DRBG if FIPS is on (don't force on for KCAPI)
+    if test "x$ENABLED_FIPS" = "xyes" && test "x$ENABLED_KCAPI" = "xno"
     then
         AM_CFLAGS="$AM_CFLAGS -DHAVE_HASHDRBG"
         ENABLED_HASHDRBG=yes

--- a/configure.ac
+++ b/configure.ac
@@ -2075,19 +2075,21 @@ then
     AS_IF([test "$enable_kcapi_hash" != "no"], [ENABLED_KCAPI_HASH=yes])
     AS_IF([test "$enable_kcapi_hmac" != "no"], [ENABLED_KCAPI_HMAC=yes])
     AS_IF([test "$enable_kcapi_aes" != "no"], [ENABLED_KCAPI_AES=yes])
-# currently the PK alg KCAPI options run into build failures, so disabling here for now.
-#    AS_IF([test "$enable_kcapi_rsa" != "no"], [ENABLED_KCAPI_RSA=yes])
-#    AS_IF([test "$enable_kcapi_dh" != "no"], [ENABLED_KCAPI_DH=yes])
-#    AS_IF([test "$enable_kcapi_ecc" != "no"], [ENABLED_KCAPI_ECC=yes])
+    AS_IF([test "$enable_kcapi_rsa" != "no"], [ENABLED_KCAPI_RSA=yes])
+    AS_IF([test "$enable_kcapi_dh" != "no"], [ENABLED_KCAPI_DH=yes])
+    AS_IF([test "$enable_kcapi_ecc" != "no"], [ENABLED_KCAPI_ECC=yes])
 fi
 
-AS_IF([test "$ENABLED_KCAPI_HASH" != "no" ||
-       test "$ENABLED_KCAPI_HMAC" != "no" ||
-       test "$ENABLED_KCAPI_AES" != "no" ||
-       test "$ENABLED_KCAPI_RSA" != "no" ||
-       test "$ENABLED_KCAPI_DH" != "no" ||
-       test "$ENABLED_KCAPI_ECC" != "no"],
-    [LIBS="$LIBS -lkcapi"])
+if  test "$ENABLED_KCAPI_HASH" != "no" ||
+    test "$ENABLED_KCAPI_HMAC" != "no" ||
+    test "$ENABLED_KCAPI_AES" != "no" ||
+    test "$ENABLED_KCAPI_RSA" != "no" ||
+    test "$ENABLED_KCAPI_DH" != "no" ||
+    test "$ENABLED_KCAPI_ECC" != "no"
+then
+    LIBS="$LIBS -lkcapi"
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_KCAPI"
+fi
 
 if test "$ENABLED_KCAPI_HASH" = "yes"
 then
@@ -3594,22 +3596,25 @@ AS_CASE([$FIPS_VERSION],
             -DHAVE_FIPS_VERSION_MINOR=$HAVE_FIPS_VERSION_MINOR \
             -DHAVE_ECC_CDH \
             -DWC_RSA_NO_PADDING \
-            -DWOLFSSL_ECDSA_SET_K \
             -DWOLFSSL_VALIDATE_ECC_IMPORT \
             -DECC_USER_CURVES \
-            -DHAVE_ECC192 \
-            -DHAVE_ECC224 \
-            -DHAVE_ECC256 \
             -DHAVE_ECC384 \
             -DHAVE_ECC521 \
-            -DWOLFSSL_ECDSA_SET_K \
-            -DWC_RNG_SEED_CB \
             -DWOLFSSL_VALIDATE_FFC_IMPORT \
             -DHAVE_FFDHE_Q \
             -DHAVE_FFDHE_3072 \
             -DHAVE_FFDHE_4096 \
             -DHAVE_FFDHE_6144 \
             -DHAVE_FFDHE_8192"
+
+        # KCAPI API does not support custom k for sign, don't force enable ECC key sizes and do not use seed callback
+        AS_IF([test "x$ENABLED_KCAPI_ECC" = "xno"],
+            [AM_CFLAGS="$AM_CFLAGS \
+                -DWC_RNG_SEED_CB \
+                -DWOLFSSL_ECDSA_SET_K \
+                -DHAVE_ECC192 \
+                -DHAVE_ECC224 \
+                -DHAVE_ECC256"])
 
         DEFAULT_MAX_CLASSIC_ASYM_KEY_BITS=8192
 

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -8670,16 +8670,16 @@ static int ecc_check_privkey_gen(ecc_key* key, mp_int* a, mp_int* prime)
 
 #ifdef WOLFSSL_KCAPI_ECC
         if (err == MP_OKAY) {
-            byte   pubkey_raw[MAX_ECC_BYTES * 2];
-            word32 pubkey_sz = (word32)sizeof(pubkey_raw);
+            word32 pubkey_sz = (word32)sizeof(key->pubkey_raw);
 
-            err = KcapiEcc_LoadKey(key, pubkey_raw, &pubkey_sz, 1);
+            err = KcapiEcc_LoadKey(key, key->pubkey_raw, &pubkey_sz, 1);
             if (err == 0) {
-                err = mp_read_unsigned_bin(res->x, pubkey_raw,
+                err = mp_read_unsigned_bin(res->x, key->pubkey_raw,
                                            pubkey_sz/2);
             }
             if (err == MP_OKAY) {
-                err = mp_read_unsigned_bin(res->y, pubkey_raw + pubkey_sz/2,
+                err = mp_read_unsigned_bin(res->y,
+                                           key->pubkey_raw + pubkey_sz/2,
                                            pubkey_sz/2);
             }
             if (err == MP_OKAY) {
@@ -9190,14 +9190,14 @@ int wc_ecc_import_x963_ex(const byte* in, word32 inLen, ecc_key* key,
 
 #if defined(WOLFSSL_ATECC508A) || defined(WOLFSSL_ATECC608A)
     /* For SECP256R1 only save raw public key for hardware */
-    if (curve_id == ECC_SECP256R1 && inLen <= sizeof(key->pubkey_raw)) {
+    if (curve_id == ECC_SECP256R1 && inLen <= (word32)sizeof(key->pubkey_raw)) {
     #ifdef HAVE_COMP_KEY
         if (!compressed)
     #endif
             XMEMCPY(key->pubkey_raw, (byte*)in, inLen);
     }
 #elif defined(WOLFSSL_KCAPI_ECC)
-    XMEMCPY(key->pubkey_raw + KCAPI_PARAM_SZ, (byte*)in, inLen);
+    XMEMCPY(key->pubkey_raw, (byte*)in, inLen);
 #endif
 
     if (err == MP_OKAY) {
@@ -9870,11 +9870,11 @@ static int wc_ecc_import_raw_private(ecc_key* key, const char* qx,
 #elif defined(WOLFSSL_KCAPI_ECC)
     if (err == MP_OKAY) {
         word32 keySz = key->dp->size;
-        err = wc_export_int(key->pubkey.x, key->pubkey_raw + KCAPI_PARAM_SZ,
+        err = wc_export_int(key->pubkey.x, key->pubkey_raw,
             &keySz, keySz, WC_TYPE_UNSIGNED_BIN);
         if (err == MP_OKAY) {
             err = wc_export_int(key->pubkey.y,
-                &key->pubkey_raw[KCAPI_PARAM_SZ + keySz], &keySz, keySz,
+                &key->pubkey_raw[keySz], &keySz, keySz,
                 WC_TYPE_UNSIGNED_BIN);
         }
     }

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5572,7 +5572,7 @@ static int wc_ecc_sign_hash_hw(const byte* in, word32 inlen,
             return err;
         }
     #elif defined(WOLFSSL_KCAPI_ECC)
-        err = KcapiEcc_Sign(key, in, inlen, out, outlen);
+        err = KcapiEcc_Sign(key, in, inlen, out, *outlen);
         if (err != MP_OKAY) {
             return err;
         }
@@ -8673,7 +8673,7 @@ static int ecc_check_privkey_gen(ecc_key* key, mp_int* a, mp_int* prime)
             byte   pubkey_raw[MAX_ECC_BYTES * 2];
             word32 pubkey_sz = (word32)sizeof(pubkey_raw);
 
-            err = KcapiEcc_LoadKey(key, pubkey_raw, &pubkey_sz);
+            err = KcapiEcc_LoadKey(key, pubkey_raw, &pubkey_sz, 1);
             if (err == 0) {
                 err = mp_read_unsigned_bin(res->x, pubkey_raw,
                                            pubkey_sz/2);

--- a/wolfcrypt/src/port/kcapi/kcapi_aes.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_aes.c
@@ -235,7 +235,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     int     ret = 0;
     byte*   data = NULL;
     word32  dataSz;
-    int     inbuflen, outbuflen;
+    int     inbuflen = 0, outbuflen = 0;
     size_t  pageSz = (size_t)sysconf(_SC_PAGESIZE);
 
     /* argument checks */
@@ -336,7 +336,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
     int     ret = 0;
     byte*   data = NULL;
     word32  dataSz;
-    int     inbuflen, outbuflen;
+    int     inbuflen = 0, outbuflen = 0;
     size_t  pageSz = (size_t)sysconf(_SC_PAGESIZE);
 
     /* argument checks */

--- a/wolfcrypt/src/port/kcapi/kcapi_dh.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_dh.c
@@ -26,7 +26,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#if defined(WOLFSSL_KCAPI_DH)
+#if defined(WOLFSSL_KCAPI_DH) && !defined(NO_DH)
 
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
@@ -232,4 +232,4 @@ int KcapiDh_SharedSecret(DhKey* private_key, const byte* pub, word32 pubSz,
     return ret;
 }
 
-#endif /* WOLFSSL_KCAPI_DH */
+#endif /* WOLFSSL_KCAPI_DH && !NO_DH */

--- a/wolfcrypt/src/port/kcapi/kcapi_ecc.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_ecc.c
@@ -26,7 +26,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#if defined(WOLFSSL_KCAPI_ECC)
+#if defined(WOLFSSL_KCAPI_ECC) && defined(HAVE_ECC)
 
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
@@ -367,4 +367,4 @@ int KcapiEcc_Verify(ecc_key* key, const byte* hash, word32 hashLen, byte* sig,
 }
 #endif
 
-#endif /* WOLFSSL_KCAPI_ECC */
+#endif /* WOLFSSL_KCAPI_ECC && HAVE_ECC */

--- a/wolfcrypt/src/port/kcapi/kcapi_ecc.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_ecc.c
@@ -290,7 +290,7 @@ static int KcapiEcc_SetPrivKey(ecc_key* key)
     if (ret == 0) {
         priv[0] = ECDSA_KEY_VERSION;
         priv[1] = kcapiCurveId;
-        ret = wc_export_int(&key->k, priv + 2, &keySz, keySz,
+        ret = wc_export_int(&key->k, priv + KCAPI_PARAM_SZ, &keySz, keySz,
                             WC_TYPE_UNSIGNED_BIN);
     }
     if (ret == 0) {
@@ -359,10 +359,10 @@ int KcapiEcc_Sign(ecc_key* key, const byte* hash, word32 hashLen, byte* sig,
         ret = (int)kcapi_akcipher_sign(key->handle, hash_aligned, hashLen,
             sig_aligned, keySz*2, KCAPI_ACCESS_HEURISTIC);
         if (ret >= 0) {
-            ret = 0;
             if (sig_aligned != sig) {
                 XMEMCPY(sig, sig_aligned, ret);
             }
+            ret = 0; /* mark success */
         }
     }
 

--- a/wolfcrypt/src/port/kcapi/kcapi_hash.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_hash.c
@@ -642,4 +642,3 @@ int wc_Sha512_256Copy(wc_Sha512* src, wc_Sha512* dst)
 #endif /* WOLFSSL_SHA512 */
 
 #endif /* WOLFSSL_KCAPI_HASH */
-

--- a/wolfcrypt/src/port/kcapi/kcapi_hmac.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_hmac.c
@@ -26,7 +26,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#if defined(WOLFSSL_KCAPI_HMAC)
+#if defined(WOLFSSL_KCAPI_HMAC) && !defined(NO_HMAC)
 
 #define FIPS_NO_WRAPPERS
 
@@ -334,5 +334,4 @@ int wc_HmacFinal(Hmac* hmac, byte* hash)
     return ret;
 }
 
-#endif /* WOLFSSL_KCAPI_HMAC */
-
+#endif /* WOLFSSL_KCAPI_HMAC && !NO_HMAC */

--- a/wolfcrypt/src/port/kcapi/kcapi_rsa.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_rsa.c
@@ -26,7 +26,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#if defined(WOLFSSL_KCAPI_RSA)
+#if defined(WOLFSSL_KCAPI_RSA) && !defined(NO_RSA)
 
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
@@ -356,5 +356,4 @@ int KcapiRsa_Encrypt(RsaKey* key, const byte* in, word32 inLen, byte* out,
     return ret;
 }
 
-#endif /* WOLFSSL_KCAPI_RSA */
-
+#endif /* WOLFSSL_KCAPI_RSA && !NO_RSA */

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2786,8 +2786,33 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
         return 0;
     }
 #endif
-
-
 /* End wc_GenerateSeed */
+
+#if defined(CUSTOM_RAND_GENERATE_BLOCK) && defined(WOLFSSL_KCAPI)
+#include <fcntl.h>
+int wc_hwrng_generate_block(byte *output, word32 sz)
+{
+    int fd;
+    int len; 
+    int ret = 0; 
+    fd = open("/dev/hwrng", O_RDONLY);
+    if (fd == -1)
+        return OPEN_RAN_E;
+    while(sz)
+    {    
+        len = (int)read(fd, output, sz); 
+        if (len == -1)
+        {
+            ret = READ_RAN_E;
+            break;
+        }
+        sz -= len;
+        output += len;
+    }
+    close(fd);
+    return ret;
+}
+#endif
+
 #endif /* WC_NO_RNG */
 #endif /* HAVE_FIPS */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -21717,7 +21717,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     !defined(WOLFSSL_ATECC508A) && !defined(WOLFSSL_ATECC608A)
     word32  y;
 #endif
-#ifdef HAVE_ECC_SIGN
+#if defined(HAVE_ECC_SIGN) && !defined(WOLFSSL_KCAPI_ECC)
     WC_DECLARE_VAR(sig, byte, ECC_SIG_SIZE, HEAP_HINT);
     WC_DECLARE_VAR(digest, byte, ECC_DIGEST_SIZE, HEAP_HINT);
     int     i;
@@ -21751,7 +21751,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
         ERROR_OUT(-9901, done);
 #endif
 
-#ifdef HAVE_ECC_SIGN
+#if defined(HAVE_ECC_SIGN) && !defined(WOLFSSL_KCAPI_ECC)
     if (sig == NULL || digest == NULL)
         ERROR_OUT(-9902, done);
 #endif
@@ -21997,7 +21997,9 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
 #endif /* HAVE_ECC_KEY_IMPORT */
 #endif /* HAVE_ECC_KEY_EXPORT */
 
-#if !defined(ECC_TIMING_RESISTANT) || (defined(ECC_TIMING_RESISTANT) && !defined(WC_NO_RNG))
+    /* For KCAPI cannot sign using generated ECDH key */
+#if !defined(ECC_TIMING_RESISTANT) || (defined(ECC_TIMING_RESISTANT) && \
+    !defined(WC_NO_RNG) && !defined(WOLFSSL_KCAPI_ECC))
 #ifdef HAVE_ECC_SIGN
     /* ECC w/out Shamir has issue with all 0 digest */
     /* WC_BIGINT doesn't have 0 len well on hardware */
@@ -22079,10 +22081,12 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     }
 #endif /* HAVE_ECC_VERIFY */
 #endif /* HAVE_ECC_SIGN */
-#endif /* !ECC_TIMING_RESISTANT || (ECC_TIMING_RESISTANT && !WC_NO_RNG) */
+#endif /* !ECC_TIMING_RESISTANT || (ECC_TIMING_RESISTANT && 
+        * !WC_NO_RNG && !WOLFSSL_KCAPI_ECC) */
 
 #if defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG) && \
-    !defined(WOLFSSL_ATECC508) && !defined(WOLFSSL_ATECC608A)
+    !defined(WOLFSSL_ATECC508) && !defined(WOLFSSL_ATECC608A) && \
+    !defined(WOLFSSL_KCAPI_ECC)
     x = ECC_KEY_EXPORT_BUF_SIZE;
     ret = wc_ecc_export_private_only(userA, exportBuf, &x);
     if (ret != 0)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1120,13 +1120,15 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
         return err_sys("AES-GCM  test failed!\n", ret);
     #endif
     #if !defined(WOLFSSL_AFALG_XILINX_AES) && !defined(WOLFSSL_XILINX_CRYPT) && \
-        !(defined(WOLF_CRYPTO_CB) && \
+        !defined(WOLFSSL_KCAPI_AES) && !(defined(WOLF_CRYPTO_CB) && \
             (defined(HAVE_INTEL_QA_SYNC) || defined(HAVE_CAVIUM_OCTEON_SYNC)))
     if ((ret = aesgcm_default_test()) != 0) {
         return err_sys("AES-GCM  test failed!\n", ret);
     }
     #endif
-    TEST_PASS("AES-GCM  test passed!\n");
+    if (ret == 0) {
+        TEST_PASS("AES-GCM  test passed!\n");
+    }
 #endif
 
 #if defined(HAVE_AESCCM) && defined(WOLFSSL_AES_128)
@@ -21039,7 +21041,8 @@ done:
 #endif
 
 
-#if defined(HAVE_ECC_SIGN) && defined(WOLFSSL_ECDSA_SET_K)
+#if defined(HAVE_ECC_SIGN) && defined(WOLFSSL_ECDSA_SET_K) && \
+    !defined(WOLFSSL_KCAPI_ECC)
 static int ecc_test_sign_vectors(WC_RNG* rng)
 {
     int ret;
@@ -24118,7 +24121,8 @@ WOLFSSL_TEST_SUBROUTINE int ecc_test(void)
     #endif
 #endif
 
-#if defined(HAVE_ECC_SIGN) && defined(WOLFSSL_ECDSA_SET_K)
+#if defined(HAVE_ECC_SIGN) && defined(WOLFSSL_ECDSA_SET_K) && \
+    !defined(WOLFSSL_KCAPI_ECC)
     ret = ecc_test_sign_vectors(&rng);
     if (ret != 0) {
         printf("ecc_test_sign_vectors failed! %d\n", ret);

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1840,7 +1840,7 @@ WOLFSSL_LOCAL int CheckCertSignaturePubKey(const byte* cert, word32 certSz,
 WOLFSSL_LOCAL int CheckCSRSignaturePubKey(const byte* cert, word32 certSz,
         void* heap, const byte* pubKey, word32 pubKeySz, int pubKeyOID);
 #endif /* WOLFSSL_CERT_REQ */
-WOLFSSL_LOCAL int AddSignature(byte* buf, int bodySz, const byte* sig, int sigSz,
+WOLFSSL_ASN_API int AddSignature(byte* buf, int bodySz, const byte* sig, int sigSz,
                         int sigAlgoType);
 WOLFSSL_LOCAL int ParseCertRelative(DecodedCert* cert, int type, int verify,
                                     void* cm);

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -466,7 +466,7 @@ struct ecc_key {
 #endif
 #ifdef WOLFSSL_KCAPI_ECC
     struct kcapi_handle* handle;
-    byte pubkey_raw[KCAPI_PARAM_SZ + MAX_ECC_BYTES * 2];
+    byte pubkey_raw[MAX_ECC_BYTES * 2];
 #endif
 
 #ifdef WOLFSSL_ASYNC_CRYPT

--- a/wolfssl/wolfcrypt/port/kcapi/kcapi_ecc.h
+++ b/wolfssl/wolfcrypt/port/kcapi/kcapi_ecc.h
@@ -36,16 +36,18 @@
     #define WC_ECCKEY_TYPE_DEFINED
 #endif
 
-int KcapiEcc_SetPubKey(ecc_key* key);
+WOLFSSL_LOCAL int KcapiEcc_SetPubKey(ecc_key* key);
 
-void KcapiEcc_Free(ecc_key* key);
-int KcapiEcc_MakeKey(ecc_key* key, int keysize, int curve_id);
-int KcapiEcc_SharedSecret(ecc_key* private_key, ecc_key* public_key, byte* out,
-                          word32* outlen);
-int KcapiEcc_Sign(ecc_key* key, const byte* hash, word32 hashLen, byte* sig,
-                  word32* sigLen);
-int KcapiEcc_Verify(ecc_key* key, const byte* hash, word32 hashLen, byte* sig,
-                  word32 sigLen);
+WOLFSSL_LOCAL void KcapiEcc_Free(ecc_key* key);
+WOLFSSL_LOCAL int KcapiEcc_MakeKey(ecc_key* key, int keysize, int curve_id);
+WOLFSSL_LOCAL int KcapiEcc_LoadKey(ecc_key* key, byte* pubkey_raw,
+                  word32* pubkey_sz);
+WOLFSSL_LOCAL int KcapiEcc_SharedSecret(ecc_key* private_key,
+                  ecc_key* public_key, byte* out, word32* outlen);
+WOLFSSL_LOCAL int KcapiEcc_Sign(ecc_key* key, const byte* hash, word32 hashLen,
+                  byte* sig, word32* sigLen);
+WOLFSSL_LOCAL int KcapiEcc_Verify(ecc_key* key, const byte* hash, word32 hashLen,
+                  byte* sig, word32 sigLen);
 
 #endif /* WOLF_CRYPT_KCAPI_ECC_H  */
 

--- a/wolfssl/wolfcrypt/port/kcapi/kcapi_ecc.h
+++ b/wolfssl/wolfcrypt/port/kcapi/kcapi_ecc.h
@@ -36,8 +36,6 @@
     #define WC_ECCKEY_TYPE_DEFINED
 #endif
 
-WOLFSSL_LOCAL int KcapiEcc_SetPubKey(ecc_key* key);
-
 WOLFSSL_LOCAL void KcapiEcc_Free(ecc_key* key);
 WOLFSSL_LOCAL int KcapiEcc_MakeKey(ecc_key* key, int keysize, int curve_id);
 WOLFSSL_LOCAL int KcapiEcc_LoadKey(ecc_key* key, byte* pubkey_raw,

--- a/wolfssl/wolfcrypt/port/kcapi/kcapi_ecc.h
+++ b/wolfssl/wolfcrypt/port/kcapi/kcapi_ecc.h
@@ -41,11 +41,11 @@ WOLFSSL_LOCAL int KcapiEcc_SetPubKey(ecc_key* key);
 WOLFSSL_LOCAL void KcapiEcc_Free(ecc_key* key);
 WOLFSSL_LOCAL int KcapiEcc_MakeKey(ecc_key* key, int keysize, int curve_id);
 WOLFSSL_LOCAL int KcapiEcc_LoadKey(ecc_key* key, byte* pubkey_raw,
-                  word32* pubkey_sz);
+                  word32* pubkey_sz, int release_handle);
 WOLFSSL_LOCAL int KcapiEcc_SharedSecret(ecc_key* private_key,
                   ecc_key* public_key, byte* out, word32* outlen);
 WOLFSSL_LOCAL int KcapiEcc_Sign(ecc_key* key, const byte* hash, word32 hashLen,
-                  byte* sig, word32* sigLen);
+                  byte* sig, word32 sigLen);
 WOLFSSL_LOCAL int KcapiEcc_Verify(ecc_key* key, const byte* hash, word32 hashLen,
                   byte* sig, word32 sigLen);
 

--- a/wolfssl/wolfcrypt/random.h
+++ b/wolfssl/wolfcrypt/random.h
@@ -99,6 +99,11 @@
      * #define CUSTOM_RAND_GENERATE_BLOCK myRngFunc
      * extern int myRngFunc(byte* output, word32 sz);
      */
+    #if defined(CUSTOM_RAND_GENERATE_BLOCK) && defined(WOLFSSL_KCAPI)
+        #undef  CUSTOM_RAND_GENERATE_BLOCK
+        #define CUSTOM_RAND_GENERATE_BLOCK wc_hwrng_generate_block
+        WOLFSSL_LOCAL int wc_hwrng_generate_block(byte *output, word32 sz);
+    #endif
 #elif defined(HAVE_HASHDRBG)
     #ifdef NO_SHA256
         #error "Hash DRBG requires SHA-256."

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1627,9 +1627,12 @@ extern void uITRON4_free(void *p) ;
     #define WOLFSSL_AES_GCM_FIXED_IV_AAD
 #endif
 #ifdef WOLFSSL_KCAPI_ECC
+    #undef  ECC_USER_CURVES
     #define ECC_USER_CURVES
     #undef  NO_ECC256
+    #undef  HAVE_ECC384
     #define HAVE_ECC384
+    #undef  HAVE_ECC521
     #define HAVE_ECC521
 #endif
 


### PR DESCRIPTION
# Description

* For KCAPI do not force enable ECC curves, set K or seed callback, disable AES GCM tests with non standard IV.
* Allow disabling DRBG with KCAPI.
* Add KCAPI `/dev/hwrng` support.
* Fixes for KCAPI AES GCM. Add guards for algorithm macros on KCAPI.
* Fix for `ecc_check_privkey_gen` with KCAPI.
* Fix KCAPI ECDSA to ensure we don't leak handle for multiple sign/verify calls.
* Fix for KCAPI `KcapiEcc_LoadKey` parameter to `kcapi_kpp_keygen`.
* Added KcapiEcc_LoadKey option to release handle on load.
* Fixes for KCAPI sign output length.

ZD 13791

# Testing

On customer hardware

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
