### PR TITLE
add WOLF_CRYPTO_CB_ONLY_RSA and WOLF_CRYPTO_CB_ONLY_ECC

### DIFF
--- a/tests/suites.c
+++ b/tests/suites.c
@@ -778,7 +778,8 @@ static void test_harness(void* vargs)
 
 int SuiteTest(int argc, char** argv)
 {
-#if !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT)
+#if !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT) && \
+    !defined(WOLF_CRYPTO_CB_ONLY_RSA) && !defined(WOLF_CRYPTO_CB_ONLY_ECC)
     func_args args;
     char argv0[3][80];
     char* myArgv[3];

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -97,7 +97,8 @@ static void *echoclient_test_wrapper(void* args) {
 
 int testsuite_test(int argc, char** argv)
 {
-#if !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT)
+#if !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT) && \
+    (!defined(WOLF_CRYPTO_CB_ONLY_RSA) && !defined(WOLF_CRYPTO_CB_ONLY_ECC))
     func_args server_args;
 
     tcp_ready ready;
@@ -242,7 +243,8 @@ int testsuite_test(int argc, char** argv)
     return EXIT_SUCCESS;
 }
 
-#if !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT)
+#if !defined(NO_WOLFSSL_SERVER) && !defined(NO_WOLFSSL_CLIENT) && \
+   (!defined(WOLF_CRYPTO_CB_ONLY_RSA) && !defined(WOLF_CRYPTO_CB_ONLY_ECC))
 /* Perform a basic TLS handshake.
  *
  * First connection to echo a file.

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -9160,8 +9160,8 @@ static int _ecc_validate_public_key(ecc_key* key, int partial, int priv)
     defined(WOLFSSL_SE050) || defined(WOLF_CRYPTO_CB_ONLY_ECC)
 
     /* consider key check success on HW crypto
-     * ex: ATECC508/608A, CryptoCell and Silabs 
-     * 
+     * ex: ATECC508/608A, CryptoCell and Silabs
+     *
      * consider key check success on Crypt Cb
      */
     err = MP_OKAY;

--- a/wolfcrypt/src/error.c
+++ b/wolfcrypt/src/error.c
@@ -563,6 +563,10 @@ const char* wc_GetErrorString(int error)
 
     case PROTOCOLCB_UNAVAILABLE:
         return "Protocol callback unavailable";
+
+    case NO_VALID_DEVID:
+        return "No valid device ID set";
+
     default:
         return "unknown error number";
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1585,7 +1585,7 @@ options: [-s max_relative_stack_bytes] [-m max_relative_heap_memory_bytes]\n\
 #if !defined(NO_ASN) && (defined(HAVE_ECC) || !defined(NO_DSA) || \
 (!defined(NO_RSA) && (defined(WOLFSSL_KEY_GEN) || defined(WOLFSSL_CERT_GEN)))) \
      && !defined(WOLF_CRYPTO_CB_ONLY_ECC)
-    
+
 #if !defined(NO_FILESYSTEM) && !defined(NO_WRITE_TEMP_FILES)
 #define SaveDerAndPem(d, dSz, fD, fP, pT, eB) _SaveDerAndPem(d, dSz, fD, fP, pT, eB)
 #else
@@ -38377,11 +38377,11 @@ typedef struct {
 #ifdef WOLF_CRYPTO_CB_ONLY_RSA
 /* Testing rsa cb when CB_ONLY_RSA is enabled
  * When CB_ONLY_RSA is enabled, software imple. is not available.
- * 
+ *
  * ctx callback ctx
  * returen 0 on success, otherwise return -8000 - -8007
  */
-static int rsa_onlycb_test(myCryptoDevCtx *ctx) 
+static int rsa_onlycb_test(myCryptoDevCtx *ctx)
 {
     int     ret = 0;
 #if !defined(NO_RSA)
@@ -38503,7 +38503,7 @@ static int rsa_onlycb_test(myCryptoDevCtx *ctx)
     if (ret == 0) {
        /* wc_SignatureGenerate() -> rsa cb ->
         *                    myCryptoDevCb -> wc_RsaFunction(INVALID_DEVID)
-        * wc_SignatureGenerate(INVALID_DEVID) expects to 
+        * wc_SignatureGenerate(INVALID_DEVID) expects to
         *                               return NO_VALID_DEVID(failure)
         */
         ctx->exampleVar = 1;
@@ -38536,7 +38536,7 @@ exit_onlycb:
 #ifdef WOLF_CRYPTO_CB_ONLY_ECC
 /* Testing rsa cb when CB_ONLY_ECC is enabled
  * When CB_ONLY_ECC is enabled, software imple. is not available.
- * 
+ *
  * ctx callback ctx
  * returen 0 on success, otherwise return -8008 - -8018
  */
@@ -38615,7 +38615,7 @@ static int ecc_onlycb_test(myCryptoDevCtx *ctx)
     }
     else
         ret = 0;
-    
+
     /* wc_CryptoCb_EccVerify cb test, no actual testing */
     ctx->exampleVar = 99;
     if (ret == 0) {
@@ -38624,7 +38624,7 @@ static int ecc_onlycb_test(myCryptoDevCtx *ctx)
     if (ret != 0) {
         ERROR_OUT(-8015, exit_onlycb);
     }
-    
+
     ctx->exampleVar = 1;
     if (ret == 0) {
         ret = wc_ecc_verify_hash(in, inLen, out, outLen, &verify, key);
@@ -38634,12 +38634,12 @@ static int ecc_onlycb_test(myCryptoDevCtx *ctx)
     }
     else
         ret = 0;
-    
+
     /* wc_CryptoCb_Ecdh cb test, no actual testing */
-    
+
     /* make public key for shared secret */
     wc_ecc_init_ex(pub, HEAP_HINT, devId);
-    
+
     ctx->exampleVar = 99;
     if (ret == 0) {
         ret = wc_ecc_shared_secret(key, pub, out, &outLen);

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -38387,9 +38387,12 @@ static int rsa_onlycb_test(myCryptoDevCtx *ctx)
 #if !defined(NO_RSA)
 
 #ifdef WOLFSSL_SMALL_STACK
-    RsaKey *key = (RsaKey *)XMALLOC(sizeof *key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    RsaKey *key = (RsaKey *)XMALLOC(sizeof *key, 
+                                            HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    byte*  tmp = NULL;
 #else
     RsaKey key[1];
+    byte tmp[FOURK_BUF];
 #endif
     size_t bytes;
     const word32 inLen = (word32)TEST_STRING_SZ;
@@ -38403,6 +38406,10 @@ static int rsa_onlycb_test(myCryptoDevCtx *ctx)
     !defined(USE_CERT_BUFFERS_3072) && !defined(USE_CERT_BUFFERS_4096) && \
     !defined(NO_FILESYSTEM)
     XFILE   file;
+#endif
+
+#ifdef WOLFSSL_KEY_GEN
+    WC_RNG rng;
 #endif
 
 #ifdef USE_CERT_BUFFERS_1024
@@ -38426,11 +38433,9 @@ static int rsa_onlycb_test(myCryptoDevCtx *ctx)
 #endif
 
 #ifdef WOLFSSL_SMALL_STACK
-    byte*  tmp = (byte*)XMALLOC(bytes, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    tmp = (byte*)XMALLOC(bytes, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (tmp == NULL)
         ERROR_OUT(-8000, exit_onlycb);
-#else
-    byte tmp[bytes];
 #endif
 
 #ifdef USE_CERT_BUFFERS_1024
@@ -38453,7 +38458,6 @@ static int rsa_onlycb_test(myCryptoDevCtx *ctx)
 #endif
 
 #ifdef WOLFSSL_KEY_GEN
-   WC_RNG rng;
    /* wc_CryptoCb_MakeRsaKey cb test, no actual making key
     * wc_MakeRsaKey() -> rsa cb ->
     *        myCryptoDevCb -> wc_MakeRsaKey(CBONLY_TEST_DEVID)
@@ -38494,8 +38498,8 @@ static int rsa_onlycb_test(myCryptoDevCtx *ctx)
         * wc_RsaFunction(CBONLY_TEST_DEVID) expects to return 0(success)
         */
         ctx->exampleVar = 99;
-        ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
-                               inLen, out, &sigSz, key, sizeof(*key), NULL);
+        ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, 
+                               in, inLen, out, &sigSz, key, sizeof(*key), NULL);
         if (ret != 0) {
             ERROR_OUT(-8006, exit_onlycb);
         }
@@ -38507,8 +38511,8 @@ static int rsa_onlycb_test(myCryptoDevCtx *ctx)
         *                               return NO_VALID_DEVID(failure)
         */
         ctx->exampleVar = 1;
-        ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, in,
-                               inLen, out, &sigSz, key, sizeof(*key), NULL);
+        ret = wc_SignatureGenerate(WC_HASH_TYPE_SHA256, WC_SIGNATURE_TYPE_RSA, 
+                            in, inLen, out, &sigSz, key, sizeof(*key), NULL);
         if (ret != NO_VALID_DEVID) {
             ERROR_OUT(-8007, exit_onlycb);
         } else
@@ -38546,9 +38550,12 @@ static int ecc_onlycb_test(myCryptoDevCtx *ctx)
 #if defined(HAVE_ECC)
 
 #ifdef WOLFSSL_SMALL_STACK
-    ecc_key* key = (ecc_key *)XMALLOC(sizeof *key, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    ecc_key* pub = (ecc_key *)XMALLOC(sizeof *pub, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
-    byte* out = (byte*)XMALLOC(sizeof(byte), HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    ecc_key* key = (ecc_key *)XMALLOC(sizeof *key, 
+                                            HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    ecc_key* pub = (ecc_key *)XMALLOC(sizeof *pub, 
+                                            HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
+    byte* out = (byte*)XMALLOC(sizeof(byte), 
+                                            HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 #else
     ecc_key key[1];
     ecc_key pub[1];

--- a/wolfssl/wolfcrypt/error-crypt.h
+++ b/wolfssl/wolfcrypt/error-crypt.h
@@ -248,8 +248,9 @@ enum {
     FIPS_PRIVATE_KEY_LOCKED_E = -287, /* Cannot export private key. */
     PROTOCOLCB_UNAVAILABLE  = -288, /* Protocol callback unavailable */
     AES_SIV_AUTH_E = -289, /* AES-SIV authentication failed */
+    NO_VALID_DEVID = -290, /* no valid device ID */
 
-    WC_LAST_E           = -289,  /* Update this to indicate last error */
+    WC_LAST_E           = -290,  /* Update this to indicate last error */
     MIN_CODE_E          = -300   /* errors -101 - -299 */
 
     /* add new companion error id strings for any new error codes

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -1080,7 +1080,6 @@ decouple library dependencies with standard string, memory and so on.
     /* invalid device id */
     #define INVALID_DEVID    (-2)
 
-
     /* AESNI requires alignment and ARMASM gains some performance from it
      * Xilinx RSA operations require alignment */
     #if defined(WOLFSSL_AESNI) || defined(WOLFSSL_ARMASM) || \


### PR DESCRIPTION
# Description
To reduce code size, adding WOLF_CRYPTO_CB_ONLY_RSA and WOLF_CRYPTO_CB_ONLY_ECC to compile out the software implementation

Assume the following configuration use:
 1). `configure --enable-cryptocb --disable-examples CFLAGS="-DWOLF_CRYPTO_CB_ONLY_RSA -DWOLF_CRYPTO_CB_ONLY_ECC -DUSE_CERT_BUFFERS_256"`

`libwolfssl.a: 5% reduction(ecc.o: 42% , rsa:13%)`

# Testing

Added test case into crypto test

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
