### PR TITLE
Fixes for PK callbacks with server side and setting a public key

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4877,7 +4877,7 @@ int Ed25519CheckPubKey(WOLFSSL* ssl)
     int ret = 0;
 
     /* Public key required for signing. */
-    if (!key->pubKeySet) {
+    if (key != NULL && !key->pubKeySet) {
         DerBuffer* leaf = ssl->buffers.certificate;
         DecodedCert* cert = (DecodedCert*)XMALLOC(sizeof(*cert),
                                      ssl->heap, DYNAMIC_TYPE_DCERT);
@@ -5211,7 +5211,7 @@ int Ed448CheckPubKey(WOLFSSL* ssl)
     int ret = 0;
 
     /* Public key required for signing. */
-    if (!key->pubKeySet) {
+    if (key != NULL && !key->pubKeySet) {
         DerBuffer* leaf = ssl->buffers.certificate;
         DecodedCert* cert = (DecodedCert*)XMALLOC(sizeof(*cert), ssl->heap,
             DYNAMIC_TYPE_DCERT);
@@ -5786,7 +5786,7 @@ int InitSSL_Suites(WOLFSSL* ssl)
                 WOLFSSL_MSG("Allowing no server private key (external)");
             }
             else
-        #endif 
+        #endif
             {
                 WOLFSSL_MSG("Server missing private key");
                 return NO_PRIVATE_KEY;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -5851,7 +5851,8 @@ static int ProcessBufferTryDecode(WOLFSSL_CTX* ctx, WOLFSSL* ssl, DerBuffer* der
             )) {
                 /* if using crypto or PK callbacks, try public key decode */
                 *idx = 0;
-                ret = wc_Ed25519PublicKeyDecode(der->buffer, idx, key, der->length);
+                ret = wc_Ed25519PublicKeyDecode(der->buffer, idx, key,
+                                                der->length);
             }
         #endif
             if (ret == 0) {
@@ -5925,7 +5926,8 @@ static int ProcessBufferTryDecode(WOLFSSL_CTX* ctx, WOLFSSL* ssl, DerBuffer* der
             )) {
                 /* if using crypto or PK callbacks, try public key decode */
                 *idx = 0;
-                ret = wc_Ed448PublicKeyDecode(der->buffer, idx, key, der->length);
+                ret = wc_Ed448PublicKeyDecode(der->buffer, idx, key,
+                                              der->length);
             }
         #endif
             if (ret == 0) {
@@ -6131,7 +6133,8 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
         #ifdef HAVE_PKCS8
             /* if private key try and remove PKCS8 header */
             if (type == PRIVATEKEY_TYPE) {
-                if ((ret = ToTraditional_ex(der->buffer, der->length, &algId)) > 0) {
+                if ((ret = ToTraditional_ex(der->buffer, der->length,
+                                                                 &algId)) > 0) {
                     /* Found PKCS8 header */
                     /* ToTraditional_ex moves buff and returns adjusted length */
                     der->length = ret;
@@ -14872,7 +14875,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                         || wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)
                     #endif
                     ) {
-                        WOLFSSL_MSG("Allowing no server private key (external)");
+                        WOLFSSL_MSG("Allowing no server private key "
+                                    "(external)");
                     }
                     else
                 #endif

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -9552,7 +9552,7 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
                     WOLFSSL_MSG("Allowing no server private key (external)");
                 }
                 else
-            #endif 
+            #endif
                 {
                     WOLFSSL_MSG("accept error: server key required");
                     WOLFSSL_ERROR(ssl->error = NO_PRIVATE_KEY);

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -9520,7 +9520,6 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
 #endif /* WOLFSSL_WOLFSENTRY_HOOKS */
 
 #ifndef NO_CERTS
-    /* allow no private key if using PK callbacks and CB is set */
 #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
     if (!havePSK)
 #endif
@@ -9542,16 +9541,23 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
                 return WOLFSSL_FATAL_ERROR;
             }
 
-        #ifdef HAVE_PK_CALLBACKS
-            if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)) {
-                WOLFSSL_MSG("Using PK for server private key");
-            }
-            else
-        #endif
             if (!ssl->buffers.key || !ssl->buffers.key->buffer) {
-                WOLFSSL_MSG("accept error: server key required");
-                WOLFSSL_ERROR(ssl->error = NO_PRIVATE_KEY);
-                return WOLFSSL_FATAL_ERROR;
+                /* allow no private key if using existing key */
+            #ifdef WOLF_PRIVATE_KEY_ID
+                if (ssl->devId != INVALID_DEVID
+                #ifdef HAVE_PK_CALLBACKS
+                    || wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)
+                #endif
+                ) {
+                    WOLFSSL_MSG("Allowing no server private key (external)");
+                }
+                else
+            #endif 
+                {
+                    WOLFSSL_MSG("accept error: server key required");
+                    WOLFSSL_ERROR(ssl->error = NO_PRIVATE_KEY);
+                    return WOLFSSL_FATAL_ERROR;
+                }
             }
         }
     }

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -19802,7 +19802,7 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
             }
 #endif
             else {
-            #if defined(WOLF_CRYPTO_CB) || defined(HAVE_PK_CALLBACKS)
+            #ifdef WOLF_PRIVATE_KEY_ID
                 /* allow loading a public key for use with crypto or PK callbacks */
                 type = PUBLICKEY_TYPE;
                 header = BEGIN_PUB_KEY;
@@ -19926,7 +19926,7 @@ int PemToDer(const unsigned char* buff, long longSz, int type,
                 *keyFormat = DSAk;
         #endif
         }
-    #if defined(WOLF_CRYPTO_CB) || defined(HAVE_PK_CALLBACKS)
+    #ifdef WOLF_PRIVATE_KEY_ID
         else if (type == PUBLICKEY_TYPE) {
         #ifndef NO_RSA
             if (header == BEGIN_RSA_PUB)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1735,7 +1735,7 @@ WOLFSSL_LOCAL int  CreateDevPrivateKey(void** pkey, byte* data, word32 length,
                                        void* heap, int devId);
 #endif
 WOLFSSL_LOCAL int  DecodePrivateKey(WOLFSSL *ssl, word16* length);
-#ifdef HAVE_PK_CALLBACKS
+#ifdef WOLF_PRIVATE_KEY_ID
 WOLFSSL_LOCAL int GetPrivateKeySigSize(WOLFSSL* ssl);
 #ifndef NO_ASN
     WOLFSSL_LOCAL int  InitSigPkCb(WOLFSSL* ssl, SignatureCtx* sigCtx);

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -3729,13 +3729,8 @@ typedef struct PkCbInfo {
 #ifdef TEST_PK_PRIVKEY
     union {
     #ifdef HAVE_ECC
+        /* only ECC PK callback with TLS v1.2 needs this */
         ecc_key ecc;
-    #endif
-    #ifdef HAVE_CURVE25519
-        curve25519_key curve;
-    #endif
-    #ifdef HAVE_CURVE448
-        curve448_key curve;
     #endif
     } keyGen;
     int hasKeyGen;

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -4027,8 +4027,13 @@ static WC_INLINE int myEd25519Sign(WOLFSSL* ssl, const byte* in, word32 inSz,
     ret = wc_ed25519_init(&myKey);
     if (ret == 0) {
         ret = wc_Ed25519PrivateKeyDecode(keyBuf, &idx, &myKey, keySz);
-        if (ret == 0)
+        if (ret == 0) {
+            ret = wc_ed25519_make_public(&myKey, myKey.p, ED25519_PUB_KEY_SIZE);
+        }
+        if (ret == 0) {
+            myKey.pubKeySet = 1;
             ret = wc_ed25519_sign_msg(in, inSz, out, outSz, &myKey);
+        }
         wc_ed25519_free(&myKey);
     }
 
@@ -4191,8 +4196,13 @@ static WC_INLINE int myEd448Sign(WOLFSSL* ssl, const byte* in, word32 inSz,
     ret = wc_ed448_init(&myKey);
     if (ret == 0) {
         ret = wc_Ed448PrivateKeyDecode(keyBuf, &idx, &myKey, keySz);
-        if (ret == 0)
+        if (ret == 0) {
+            ret = wc_ed448_make_public(&myKey, myKey.p, ED448_PUB_KEY_SIZE);
+        }
+        if (ret == 0) {
+            myKey.pubKeySet = 1;
             ret = wc_ed448_sign_msg(in, inSz, out, outSz, &myKey, NULL, 0);
+        }
         wc_ed448_free(&myKey);
     }
 


### PR DESCRIPTION
# Description

Fixes for allowing server to have a public key set when using external key with PK callbacks.

Fixes ZD13903

# Testing

```
./configure --enable-pkcallbacks CFLAGS="-DTEST_PK_PRIVKEY" --enable-curve25519 --enable-ed25519 --enable-curve448 --enable-ed448 && make
```

Test code: https://github.com/wolfSSL/wolfssl-examples/pull/306
```
./server-tls-pkcallback
./client-tls-pkcallback 127.0.0.1
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
