### PR TITLE
smallstack cleanup for OpenSSL Compatibility Functions

### DIFF
--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -8242,12 +8242,26 @@ static int PrintPubKeyRSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
     int wsz;
     word32 i;
     unsigned long exponent = 0;
-    mp_int a;
+#ifdef WOLFSSL_SMALL_STACK
+    mp_int* a = NULL;
+#else
+    mp_int a[1];
+#endif
     char line[32] = { 0 };
 
     (void)pctx;
 
-    if( mp_init(&a) != 0) {
+#ifdef WOLFSSL_SMALL_STACK
+    a = (mp_int*)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_BIGINT);
+    if (a == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+#endif
+
+    if( mp_init(a) != 0) {
+#ifdef WOLFSSL_SMALL_STACK
+        XFREE(a, NULL, DYNAMIC_TYPE_BIGINT);
+#endif
         return WOLFSSL_FAILURE;
     }
     if (indent < 0) {
@@ -8272,10 +8286,10 @@ static int PrintPubKeyRSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (wolfSSL_BIO_write(out, line, (int)XSTRLEN(line)) <= 0) {
             break;
         }
-        if (mp_set_int(&a, bitlen) != 0) {
+        if (mp_set_int(a, bitlen) != 0) {
             break;
         }
-        if (mp_todecimal(&a, (char*)buff) != 0) {
+        if (mp_todecimal(a, (char*)buff) != 0) {
             break;
         }
         wsz = (int)XSTRLEN((const char*)buff);
@@ -8315,10 +8329,10 @@ static int PrintPubKeyRSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         }
 
         XMEMSET(buff, 0, sizeof(buff));
-        if (mp_set_int(&a, exponent) != 0) {
+        if (mp_set_int(a, exponent) != 0) {
             break;
         }
-        if (mp_todecimal(&a, (char*)buff) != 0) {
+        if (mp_todecimal(a, (char*)buff) != 0) {
             break;
         }
         wsz = (int)XSTRLEN((const char*)buff);
@@ -8331,7 +8345,7 @@ static int PrintPubKeyRSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
             break;
         }
         XMEMSET(buff, 0, sizeof(buff));
-        if (mp_tohex(&a, (char*)buff) != 0) {
+        if (mp_tohex(a, (char*)buff) != 0) {
             break;
         }
         if (wolfSSL_BIO_write(out, buff, (int)XSTRLEN((char*)buff)) <= 0) {
@@ -8345,7 +8359,10 @@ static int PrintPubKeyRSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         res = WOLFSSL_SUCCESS;
     } while (0);
 
-    mp_free(&a);
+    mp_free(a);
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(a, NULL, DYNAMIC_TYPE_BIGINT);
+#endif
     return res;
 }
 #endif /* !NO_RSA */
@@ -8574,11 +8591,26 @@ static int PrintPubKeyDSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
     int     pSz, qSz, gSz, ySz;
     int idx;
     int wsz;
-    mp_int  a;
+#ifdef WOLFSSL_SMALL_STACK
+    mp_int* a = NULL;
+#else
+    mp_int  a[1];
+#endif
     char line[32] = { 0 };
 
-    if( mp_init(&a) != 0)
+#ifdef WOLFSSL_SMALL_STACK
+    a = (mp_int*)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_BIGINT);
+    if (a == NULL) {
         return WOLFSSL_FAILURE;
+    }
+#endif
+
+    if( mp_init(a) != 0) {
+#ifdef WOLFSSL_SMALL_STACK
+        XFREE(a, NULL, DYNAMIC_TYPE_BIGINT);
+#endif
+        return WOLFSSL_FAILURE;
+    }
 
     inOutIdx = 0;
     (void)pctx;
@@ -8684,10 +8716,10 @@ static int PrintPubKeyDSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (wolfSSL_BIO_write(out, line, (int)XSTRLEN(line)) <= 0) {
             break;
         }
-        if (mp_set_int(&a, bitlen) != 0) {
+        if (mp_set_int(a, bitlen) != 0) {
             break;
         }
-        if (mp_todecimal(&a, (char*)buff) != 0) {
+        if (mp_todecimal(a, (char*)buff) != 0) {
             break;
         }
         wsz = (int)XSTRLEN((const char*)buff);
@@ -8738,7 +8770,10 @@ static int PrintPubKeyDSA(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         res = WOLFSSL_SUCCESS;
     } while (0);
 
-    mp_free(&a);
+    mp_free(a);
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(a, NULL, DYNAMIC_TYPE_BIGINT);
+#endif
     return res;
 }
 #endif /* !NO_DSA */
@@ -8774,11 +8809,26 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
     int     wsz;
     word32  outSz;
     byte    outHex[3];
-    mp_int  a;
+#ifdef WOLFSSL_SMALL_STACK
+    mp_int* a = NULL;
+#else
+    mp_int  a[1];
+#endif
     char line[32] = { 0 };
 
-    if( mp_init(&a) != 0)
+#ifdef WOLFSSL_SMALL_STACK
+    a = (mp_int*)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_BIGINT);
+    if (a == NULL) {
         return WOLFSSL_FAILURE;
+    }
+#endif
+
+    if( mp_init(a) != 0) {
+#ifdef WOLFSSL_SMALL_STACK
+        XFREE(a, NULL, DYNAMIC_TYPE_BIGINT);
+#endif
+        return WOLFSSL_FAILURE;
+    }
 
     inOutIdx = 0;
     (void)pctx;
@@ -8872,10 +8922,10 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (wolfSSL_BIO_write(out, line, (int)XSTRLEN(line)) <= 0) {
             break;
         }
-        if (mp_set_int(&a, bitlen) != 0) {
+        if (mp_set_int(a, bitlen) != 0) {
             break;
         }
-        if (mp_todecimal(&a, (char*)buff) != 0) {
+        if (mp_todecimal(a, (char*)buff) != 0) {
             break;
         }
         wsz = (int)XSTRLEN((const char*)buff);
@@ -8911,10 +8961,10 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         if (wolfSSL_BIO_write(out, line, (int)XSTRLEN(line)) <= 0) {
             break;
         }
-        if (mp_set_int(&a, generator) != 0) {
+        if (mp_set_int(a, generator) != 0) {
             break;
         }
-        if (mp_todecimal(&a, (char*)buff) != 0) {
+        if (mp_todecimal(a, (char*)buff) != 0) {
             break;
         }
         wsz = (int)XSTRLEN((const char*)buff);
@@ -8946,7 +8996,10 @@ static int PrintPubKeyDH(WOLFSSL_BIO* out, const byte* pkey, int pkeySz,
         res = WOLFSSL_SUCCESS;
     } while (0);
 
-    mp_free(&a);
+    mp_free(a);
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(a, NULL, DYNAMIC_TYPE_BIGINT);
+#endif
     return res;
 }
 #endif /* WOLFSSL_DH_EXTRA */


### PR DESCRIPTION
# Description

This PR includes some `--enable-smallstack` cleanups.  Numbers below were gathered using:

```
./configure CC="gcc -fstack-usage --enable-smallstack --enable-opensslall --enable-all
```

| Function | From (bytes) | To (bytes) |
|---|---|---|
|`wolfSSL_EC_POINT_invert()`|2160|48|
|`wolfSSL_ASN1_INTEGER_to_BN()`|2192|64|
|`wolfSSL_EC_POINT_get_affine_coordinates_GFp()`|2208|80|
|`wolfSSL_X509_set_ext()`|1984|128|
|`wolfSSL_EC_POINT_mul()`|4352|96|
|`wolfSSL_ECDSA_do_sign()`|4608|96|
|`wolfSSL_X509_REQ_sign()`|2144|80|
|`wc_ecc_import_x963_ex()`|4448|208|
|`mp_jacobi()`|4336|80|
|`wc_ecc_import_point_der_ex()`|4448|208|

# Testing

With our existing unit/API tests, and against OpenSplice test cases.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
