### PR TITLE
fixups for warnings from gcc-12

### DIFF
--- a/scripts/sniffer-tls13-gen.sh
+++ b/scripts/sniffer-tls13-gen.sh
@@ -70,7 +70,7 @@ fi
 # Run this script from the wolfSSL root
 if [ ! -f wolfssl/ssl.h ]; then
     echo "Run from the wolfssl root"
-    exit -1
+    exit 1
 fi
 
 run_sequence() {

--- a/src/internal.c
+++ b/src/internal.c
@@ -30632,7 +30632,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         byte            haveEMS;               /* have extended master secret */
 #ifdef WOLFSSL_TLS13
         byte            ageAdd[AGEADD_LEN];    /* Obfuscation of age */
-        byte            namedGroup[NAMEDGREOUP_LEN]; /* Named group used */
+        byte            namedGroup[NAMEDGROUP_LEN]; /* Named group used */
         TicketNonce     ticketNonce;           /* Ticket nonce */
     #ifdef WOLFSSL_EARLY_DATA
         byte            maxEarlyDataSz[MAXEARLYDATASZ_LEN]; /* Max size of
@@ -30652,17 +30652,23 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             (a->pv.minor == b->pv.minor) &&
             (XMEMCMP(a->suite,b->suite,sizeof a->suite) == 0) &&
             (XMEMCMP(a->msecret,b->msecret,sizeof a->msecret) == 0) &&
-            (a->timestamp == b->timestamp) &&
+            (XMEMCMP(a->timestamp, b->timestamp, sizeof a->timestamp) == 0) &&
             (a->haveEMS == b->haveEMS)
 #ifdef WOLFSSL_TLS13
             &&
-            (a->ageAdd == b->ageAdd) &&
-            (a->namedGroup == b->namedGroup) &&
+            (XMEMCMP(a->ageAdd, b->ageAdd, sizeof a->ageAdd) == 0) &&
+            (XMEMCMP(a->namedGroup, b->namedGroup, sizeof a->namedGroup)
+             == 0) &&
             (a->ticketNonce.len == b->ticketNonce.len) &&
-            (XMEMCMP(a->ticketNonce.data, b->ticketNonce.data,
-                     a->ticketNonce.len) == 0)
+            (XMEMCMP(
+                a->ticketNonce.data,
+                b->ticketNonce.data,
+                a->ticketNonce.len) == 0)
 #ifdef WOLFSSL_EARLY_DATA
-            && (a->maxEarlyDataSz == b->maxEarlyDataSz)
+            && (XMEMCMP(
+                    a->maxEarlyDataSz,
+                    b->maxEarlyDataSz,
+                    sizeof a->maxEarlyDataSz) == 0)
 #endif
 #endif
             )

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -13720,7 +13720,7 @@ static int CheckcipherList(const char* list)
         if (current_length < length) {
             length = current_length;
         }
-        XSTRNCPY(name, current, length);
+        XMEMCPY(name, current, length);
         name[length] = 0;
 
         ret = wolfSSL_get_cipher_suite_from_name(name, &cipherSuite0,
@@ -13792,7 +13792,7 @@ static int wolfSSL_parse_cipher_list(WOLFSSL_CTX* ctx, Suites* suites,
             if (current_length < length) {
                 length = current_length;
             }
-            XSTRNCPY(name, current, length);
+            XMEMCPY(name, current, length);
             name[length] = 0;
 
             /* check for "not" case */

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -1188,7 +1188,7 @@ enum Misc {
     TIMESTAMP_LEN   = 4,        /* timestamp size in ticket */
 #ifdef WOLFSSL_TLS13
     AGEADD_LEN      = 4,        /* ageAdd size in ticket */
-    NAMEDGREOUP_LEN = 2,        /* namedGroup size in ticket */
+    NAMEDGROUP_LEN  = 2,        /* namedGroup size in ticket */
 #ifdef WOLFSSL_EARLY_DATA
     MAXEARLYDATASZ_LEN = 4,     /* maxEarlyDataSz size in ticket */
 #endif


### PR DESCRIPTION
src/internal.c: use XMEMCMP(), not ==, to compare array elements (fixes conflict of 74408e3ee3 vs 617eda9d44);

fix spelling of NAMEDGROUP_LEN (was NAMEDGREOUP_LEN);

src/ssl.c: in CheckcipherList() and wolfSSL_parse_cipher_list(), use XMEMCPY(), not XSTRNCPY(), to avoid (benign) -Wstringop-truncation;

scripts/sniffer-tls13-gen.sh: fix for shellcheck SC2242 (exit 1, not -1).
