### PR TITLE
20220325 multi-test fixes

### DIFF
--- a/mcapi/crypto.c
+++ b/mcapi/crypto.c
@@ -24,14 +24,14 @@
 #ifdef HAVE_CONFIG_H
     #include "config.h"
 #endif
+#include <wolfssl/wolfcrypt/settings.h>
+
 #ifdef MICROCHIP_MPLAB_HARMONY
     #include "system_config.h"
     #include "crypto/crypto.h"
 #else
     #include "crypto.h"
 #endif
-
-#include <wolfssl/wolfcrypt/settings.h>
 
 #include <wolfssl/wolfcrypt/md5.h>
 #include <wolfssl/wolfcrypt/sha.h>

--- a/mcapi/crypto.h
+++ b/mcapi/crypto.h
@@ -27,7 +27,6 @@
 #ifndef MC_CRYPTO_API_H
 #define MC_CRYPTO_API_H
 
-
 #ifdef __cplusplus
     extern "C" {
 #endif
@@ -107,7 +106,12 @@ enum {
 
 /* HMAC */
 typedef struct CRYPT_HMAC_CTX {
-    long long holder[98];   /* big enough to hold internal, but check on init */
+    /* big enough to hold internal, but check on init */
+    #ifdef WOLF_PRIVATE_KEY_ID
+    long long holder[108];
+    #else
+    long long holder[98];
+    #endif
 } CRYPT_HMAC_CTX;
 
 int CRYPT_HMAC_SetKey(CRYPT_HMAC_CTX*, int, const unsigned char*, unsigned int);
@@ -167,7 +171,12 @@ enum {
 
 /* AES */
 typedef struct CRYPT_AES_CTX {
-    int holder[90];   /* big enough to hold internal, but check on init */
+    /* big enough to hold internal, but check on init */
+    #ifdef WOLF_PRIVATE_KEY_ID
+    int holder[104];
+    #else
+    int holder[90];
+    #endif
 } CRYPT_AES_CTX;
 
 /* key */

--- a/tests/api.c
+++ b/tests/api.c
@@ -51361,7 +51361,7 @@ static THREAD_RETURN WOLFSSL_THREAD SSL_read_test_server_thread(void* args)
     }
 
     /* bidirectional shutdown */
-    while ((ret = wolfSSL_shutdown(ssl)) != WOLFSSL_SUCCESS) {
+    while (wolfSSL_shutdown(ssl) != WOLFSSL_SUCCESS) {
         continue;
     }
 
@@ -51433,7 +51433,7 @@ static THREAD_RETURN WOLFSSL_THREAD SSL_read_test_client_thread(void* args)
         }
     } while (ret != WOLFSSL_SUCCESS && err == WC_PENDING_E);
 
-    ret = wolfSSL_write(ssl, msg, len);
+    AssertIntGE(wolfSSL_write(ssl, msg, len), 0);
 
     if (0 < (idx = wolfSSL_read(ssl, input, sizeof(input)-1))) {
         input[idx] = 0;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -43,8 +43,10 @@
     #include <wolfssl/ssl.h>
     #include <wolfssl/test.h>
 
-#elif defined(WOLFSSL_ASYNC_CRYPT) && !defined(WC_NO_ASYNC_THREADING)
-    #define WC_ENABLE_BENCH_THREADING
+#elif defined(WOLFSSL_ASYNC_CRYPT)
+    #ifndef WC_NO_ASYNC_THREADING
+        #define WC_ENABLE_BENCH_THREADING
+    #endif
 
 /* benchmark multi-threading - disable for FIPS self test */
 #elif !defined(SINGLE_THREADED) && !defined(WC_NO_BENCH_THREADING) && \

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2793,14 +2793,14 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
 int wc_hwrng_generate_block(byte *output, word32 sz)
 {
     int fd;
-    int len; 
-    int ret = 0; 
+    int len;
+    int ret = 0;
     fd = open("/dev/hwrng", O_RDONLY);
     if (fd == -1)
         return OPEN_RAN_E;
     while(sz)
-    {    
-        len = (int)read(fd, output, sz); 
+    {
+        len = (int)read(fd, output, sz);
         if (len == -1)
         {
             ret = READ_RAN_E;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -22081,7 +22081,7 @@ static int ecc_test_curve_size(WC_RNG* rng, int keySize, int testVerifyCount,
     }
 #endif /* HAVE_ECC_VERIFY */
 #endif /* HAVE_ECC_SIGN */
-#endif /* !ECC_TIMING_RESISTANT || (ECC_TIMING_RESISTANT && 
+#endif /* !ECC_TIMING_RESISTANT || (ECC_TIMING_RESISTANT &&
         * !WC_NO_RNG && !WOLFSSL_KCAPI_ECC) */
 
 #if defined(HAVE_ECC_KEY_EXPORT) && !defined(WC_NO_RNG) && \

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -786,7 +786,7 @@ enum SNICbReturn {
  */
 #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
     #define WS_RETURN_CODE(item1,item2) \
-      ((item1 < 0) ? item2 : item1)
+      (((item1) < 0) ? (int)(item2) : (int)(item1))
 #else
     #define WS_RETURN_CODE(item1,item2)  (item1)
 #endif


### PR DESCRIPTION
* whitespace in wolfcrypt/src/random.c and wolfcrypt/test/test.c
* bugprone-macro-parentheses and -Wenum-compare in WS_RETURN_CODE() (wolfssl/ssl.h)
* clang-analyzer-deadcode.DeadStores in api.c.
* Fix for increased mcapi (used by Microchip) ctx sizes if PK callbacks is enabled due to key id/label.
* Fix for async without threading. `./configure --enable-asynccrypt --enable-all CFLAGS="-DWC_NO_ASYNC_THREADING"`. 