### PR TITLE
Fix FIPS defines in wolfSSL_RSA_sign_generic_padding() / RSA_verify_ex()

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -36504,7 +36504,8 @@ int wolfSSL_RSA_sign_generic_padding(int type, const unsigned char* m,
                 ret = BAD_FUNC_ARG;
                 break;
 #endif
-#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && defined(WC_RSA_PSS)
+#if defined(WC_RSA_PSS) && !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
+    (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,1)))
             case RSA_PKCS1_PSS_PADDING:
             {
                 enum wc_HashType hType = wc_OidGetHash(type);
@@ -36615,7 +36616,8 @@ int wolfSSL_RSA_verify_ex(int type, const unsigned char* m,
     unsigned char *sigDec = NULL;
     unsigned int   len = 0;
     int verLen;
-#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+#if (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && \
+    FIPS_VERSION_GE(5,1))) && !defined(HAVE_SELFTEST)
     int hSum = nid2HashSum(type);
     enum wc_HashType hType;
 #endif
@@ -36648,7 +36650,8 @@ int wolfSSL_RSA_verify_ex(int type, const unsigned char* m,
         DEBUG_SIGN_msg("Encoded Message", m, mLen);
     }
     /* decrypt signature */
-#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+#if (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && \
+    FIPS_VERSION_GE(5,1))) && !defined(HAVE_SELFTEST)
     hType = wc_OidGetHash(hSum);
     if ((verLen = wc_RsaSSL_Verify_ex2(sig, sigLen, (unsigned char *)sigDec,
             sigLen, (RsaKey*)rsa->internal, padding, hType)) <= 0) {
@@ -36660,7 +36663,8 @@ int wolfSSL_RSA_verify_ex(int type, const unsigned char* m,
         (RsaKey*)rsa->internal);
 #endif
     DEBUG_SIGN_msg("Decrypted Signature", sigDec, ret);
-#if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && defined(WC_RSA_PSS)
+#if defined(WC_RSA_PSS) && !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
+    (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,1)))
     if (padding == RSA_PKCS1_PSS_PADDING) {
         if (wc_RsaPSS_CheckPadding_ex(m, mLen, sigDec, verLen,
                 hType,


### PR DESCRIPTION
# Description

This PR fixes a few FIPS definition checks in ssl.c in `wolfSSL_RSA_sign_generic_padding()` and `wolfSSL_RSA_verify_ex()`. This fix allows these functions to use RSA_PKCS1_PSS_PADDING, which is available in FIPS Ready (140-3).  Changes made as part of the OpenSplice port.

# Testing

Tested using OpenSplice test cases.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
