### PR TITLE
Fixes for async ECC

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4429,7 +4429,7 @@ static int wc_ecc_shared_secret_gen_sync(ecc_key* private_key, ecc_point* point,
 static int wc_ecc_shared_secret_gen_async(ecc_key* private_key,
             ecc_point* point, byte* out, word32 *outlen)
 {
-    int err;
+    int err = 0;
     DECLARE_CURVE_SPECS(3);
 
     /* load curve info */
@@ -4503,7 +4503,7 @@ static int wc_ecc_shared_secret_gen_async(ecc_key* private_key,
 #endif
 
     /* use sync in other cases */
-    err = wc_ecc_shared_secret_gen_sync(private_key, point, out, outlen, curve);
+    err = wc_ecc_shared_secret_gen_sync(private_key, point, out, outlen);
 
     wc_ecc_curve_free(curve);
     FREE_CURVE_SPECS();


### PR DESCRIPTION
# Description

Minor fixes for ECC with async broke in PR #4982.

```
wolfcrypt/src/ecc.c:4506:11: error: too many arguments to function ‘wc_ecc_shared_secret_gen_sync’
 4506 |     err = wc_ecc_shared_secret_gen_sync(private_key, point, out, outlen, curve);
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

wolfcrypt/src/ecc.c:4437:8: error: ‘err’ is used uninitialized in this function [-Werror=uninitialized]
 4437 |     if (err == MP_OKAY) {
      |        ^
```

# Testing

Multi-test `all-asynccrypt`.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
