### PR TITLE
support creating new mem bio of length 0

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -2537,7 +2537,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
             len = (int)XSTRLEN((const char*)buf) + 1;
         }
 
-        if (wolfSSL_BUF_MEM_resize(bio->mem_buf, len) == 0) {
+        if (len > 0 && wolfSSL_BUF_MEM_resize(bio->mem_buf, len) == 0) {
             wolfSSL_BIO_free(bio);
             return NULL;
         }

--- a/tests/api.c
+++ b/tests/api.c
@@ -39123,6 +39123,9 @@ static void test_wolfSSL_BIO_write(void)
     BIO_set_retry_read(bio);
     BIO_free_all(bio); /* frees bio64s also */
 
+    AssertNotNull(bio = BIO_new_mem_buf(out, 0));
+    AssertIntEQ(BIO_write(bio, msg, sizeof(msg)), sizeof(msg));
+    BIO_free(bio);
     printf(resultFmt, passed);
     #endif
 }


### PR DESCRIPTION
# Description

fix for 0 length when creating mem bio

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
