### PR TITLE
Add wolfSSL_EC_KEY_get_conv_form to compatibility layer.

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -39052,6 +39052,7 @@ static void InitwolfSSL_ECKey(WOLFSSL_EC_KEY* key)
         key->internal = NULL;
         key->inSet    = 0;
         key->exSet    = 0;
+        key->form     = POINT_CONVERSION_UNCOMPRESSED;
     }
 }
 
@@ -40253,6 +40254,14 @@ void wolfSSL_EC_KEY_set_conv_form(WOLFSSL_EC_KEY *eckey, char form)
     }
 }
 
+point_conversion_form_t wolfSSL_EC_KEY_get_conv_form(const WOLFSSL_EC_KEY* key)
+{
+    if (key != NULL) {
+        return key->form;
+    }
+
+    return -1;
+}
 
 /* wolfSSL_EC_POINT_point2bn should return "in" if not null */
 WOLFSSL_BIGNUM *wolfSSL_EC_POINT_point2bn(const WOLFSSL_EC_GROUP *group,

--- a/tests/api.c
+++ b/tests/api.c
@@ -44850,6 +44850,34 @@ static void test_wolfSSL_EC_KEY_set_group(void)
 #endif
 }
 
+static void test_wolfSSL_EC_KEY_set_conv_form(void)
+{
+#if defined(HAVE_ECC) && defined(OPENSSL_EXTRA)
+    BIO* bio;
+    EC_KEY* key;
+
+    printf(testingFmt, "test_wolfSSL_EC_KEY_set_conv_form");
+
+    /* Error condition: NULL key. */
+    AssertIntLT(EC_KEY_get_conv_form(NULL), 0);
+
+    AssertNotNull(bio = BIO_new_file("./certs/ecc-keyPub.pem", "rb"));
+    AssertNotNull(key = PEM_read_bio_EC_PUBKEY(bio, NULL, NULL, NULL));
+    /* Conversion form defaults to uncompressed. */
+    AssertIntEQ(EC_KEY_get_conv_form(key), POINT_CONVERSION_UNCOMPRESSED);
+#ifdef HAVE_COMP_KEY
+    /* Explicitly set to compressed. */
+    EC_KEY_set_conv_form(key, POINT_CONVERSION_COMPRESSED);
+    AssertIntEQ(EC_KEY_get_conv_form(key), POINT_CONVERSION_COMPRESSED);
+#endif
+
+    BIO_free(bio);
+    EC_KEY_free(key);
+
+    printf(resultFmt, passed);
+#endif
+}
+
 static void test_wolfSSL_X509V3_EXT_get(void) {
 #if !defined(NO_FILESYSTEM) && defined(OPENSSL_ALL) && !defined(NO_RSA)
     FILE* f;
@@ -53445,6 +53473,7 @@ void ApiTest(void)
     test_CRYPTO_THREADID_xxx();
     test_ENGINE_cleanup();
     test_wolfSSL_EC_KEY_set_group();
+    test_wolfSSL_EC_KEY_set_conv_form();
 #if defined(OPENSSL_ALL)
     test_wolfSSL_X509_PUBKEY_get();
     test_wolfSSL_sk_CIPHER_description();

--- a/wolfssl/openssl/ec.h
+++ b/wolfssl/openssl/ec.h
@@ -138,6 +138,8 @@ struct WOLFSSL_EC_BUILTIN_CURVE {
 #define WOLFSSL_EC_KEY_LOAD_PRIVATE 1
 #define WOLFSSL_EC_KEY_LOAD_PUBLIC  2
 
+typedef int point_conversion_form_t;
+
 WOLFSSL_API
 size_t wolfSSL_EC_get_builtin_curves(WOLFSSL_EC_BUILTIN_CURVE *r,size_t nitems);
 
@@ -174,6 +176,8 @@ WOLFSSL_API
 int wolfSSL_i2d_ECPrivateKey(const WOLFSSL_EC_KEY *in, unsigned char **out);
 WOLFSSL_API
 void wolfSSL_EC_KEY_set_conv_form(WOLFSSL_EC_KEY *eckey, char form);
+WOLFSSL_API
+point_conversion_form_t wolfSSL_EC_KEY_get_conv_form(const WOLFSSL_EC_KEY* key);
 WOLFSSL_API
 WOLFSSL_BIGNUM *wolfSSL_EC_POINT_point2bn(const WOLFSSL_EC_GROUP *group,
                                           const WOLFSSL_EC_POINT *p,
@@ -374,6 +378,7 @@ typedef WOLFSSL_EC_BUILTIN_CURVE      EC_builtin_curve;
 #define d2i_ECPrivateKey                wolfSSL_d2i_ECPrivateKey
 #define i2d_ECPrivateKey                wolfSSL_i2d_ECPrivateKey
 #define EC_KEY_set_conv_form            wolfSSL_EC_KEY_set_conv_form
+#define EC_KEY_get_conv_form            wolfSSL_EC_KEY_get_conv_form
 
 #ifndef HAVE_SELFTEST
     #define EC_POINT_point2hex          wolfSSL_EC_POINT_point2hex


### PR DESCRIPTION
# Description

See title.

# Testing

Added `test_wolfSSL_EC_KEY_set_conv_form`, which tests the getter and setter.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
