### PR TITLE
Add wolfSSL_CTX_SetCertCbCtx to set user context for CB

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -2615,6 +2615,35 @@ WOLFSSL_API void wolfSSL_set_verify(WOLFSSL*, int, VerifyCallback verify_callbac
 WOLFSSL_API void wolfSSL_SetCertCbCtx(WOLFSSL*, void*);
 
 /*!
+    \ingroup CertsKeys
+
+    \brief This function stores user CTX object information for verify callback.
+
+    \return none No return.
+
+    \param ctx a pointer to a WOLFSSL_CTX structure.
+    \param userCtx a void pointer that is used to set WOLFSSL_CTX structure’s
+    verifyCbCtx member’s value.
+
+    _Example_
+    \code
+    WOLFSSL_CTX* ctx = wolfSSL_CTX_new( method );
+    void* userCtx = NULL; // Assign some user defined context
+    ...
+    if(ctx != NULL){
+        wolfSSL_SetCertCbCtx(ctx, userCtx);
+    } else {
+        // Error case, the SSL is not initialized properly.
+    }
+    \endcode
+
+    \sa wolfSSL_CTX_save_cert_cache
+    \sa wolfSSL_CTX_restore_cert_cache
+    \sa wolfSSL_CTX_set_verify
+*/
+WOLFSSL_API void wolfSSL_CTX_SetCertCbCtx(WOLFSSL_CTX*, void*);
+
+/*!
     \ingroup IO
 
     \brief This function returns the number of bytes which are buffered and

--- a/src/internal.c
+++ b/src/internal.c
@@ -11293,7 +11293,19 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
         store->error_depth = args->certIdx;
         store->discardSessionCerts = 0;
         store->domain = domain;
-        store->userCtx = (ssl != NULL) ? ssl->verifyCbCtx : cm;
+        if (ssl != NULL) {
+            if (ssl->verifyCbCtx != NULL) {
+                /* Use the WOLFSSL user context if set */
+                store->userCtx = ssl->verifyCbCtx;
+            }
+            else {
+                /* Else use the WOLFSSL_CTX user context */
+                store->userCtx = ssl->ctx->verifyCbCtx;
+            }
+        }
+        else {
+            store->userCtx = cm;
+        }
         store->certs = args->certs;
         store->totalCerts = args->totalCerts;
     #if defined(HAVE_EX_DATA) && \

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -12572,6 +12572,15 @@ void wolfSSL_SetCertCbCtx(WOLFSSL* ssl, void* ctx)
 }
 
 
+/* store user ctx for verify callback */
+void wolfSSL_CTX_SetCertCbCtx(WOLFSSL_CTX* ctx, void* userCtx)
+{
+    WOLFSSL_ENTER("wolfSSL_CTX_SetCertCbCtx");
+    if (ctx)
+        ctx->verifyCbCtx = userCtx;
+}
+
+
 /* store context CA Cache addition callback */
 void wolfSSL_CTX_SetCACb(WOLFSSL_CTX* ctx, CallbackCACache cb)
 {

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -2905,6 +2905,7 @@ struct WOLFSSL_CTX {
     CallbackSetPeer CBSetPeer;
 #endif
     VerifyCallback  verifyCallback;     /* cert verification callback */
+    void*           verifyCbCtx;        /* cert verify callback user ctx*/
 #ifdef OPENSSL_ALL
     CertVerifyCallback verifyCertCb;
     void*              verifyCertCbArg;

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -1199,6 +1199,7 @@ WOLFSSL_API int wolfSSL_set_post_handshake_auth(WOLFSSL* ssl, int val);
 #endif
 
 WOLFSSL_API void wolfSSL_SetCertCbCtx(WOLFSSL* ssl, void* ctx);
+WOLFSSL_API void wolfSSL_CTX_SetCertCbCtx(WOLFSSL_CTX* ctx, void* userCtx);
 
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_pending(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_has_pending(const WOLFSSL* ssl);


### PR DESCRIPTION
# Description

Adds `wolfSSL_CTX_SetCertCbCtx` to enable setting a user context that is accessible from the verify callback. If the user context is set with `wolfSSL_SetCertCbCtx`, that will be used instead of the `wolfSSL_CTX_SetCertCbCtx` value.

This was necessary for applications that have access to the `WOLFSSL_CTX` structure, but not the `WOLFSSL` structure. 

Fixes zd13969

# Checklist

 - [ ] added tests
 - [X] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
