### PR TITLE
KCAPI ECC/AES optimizations to further reduce page memory use

### DIFF
--- a/wolfcrypt/src/port/kcapi/kcapi_ecc.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_ecc.c
@@ -293,8 +293,18 @@ static int KcapiEcc_SetPrivKey(ecc_key* key)
     if (ret == 0) {
         priv[0] = ECDSA_KEY_VERSION;
         priv[1] = kcapiCurveId;
-        ret = wc_export_int(&key->k, priv + KCAPI_PARAM_SZ, &keySz, keySz,
-                            WC_TYPE_UNSIGNED_BIN);
+    #ifdef WOLF_PRIVATE_KEY_ID
+        if (key->idLen > 0) {
+            WOLFSSL_MSG("Using ID based private key");
+            keySz = key->idLen;
+            XMEMCPY(priv + KCAPI_PARAM_SZ, key->id, keySz);
+        }
+        else
+    #endif
+        {
+            ret = wc_export_int(&key->k, priv + KCAPI_PARAM_SZ, &keySz, keySz,
+                                WC_TYPE_UNSIGNED_BIN);
+        }
     }
     if (ret == 0) {
         /* call with NULL to so KCAPI treats incoming data as hash */


### PR DESCRIPTION
# Description

* KCAPI ECC optimization to further reduce page memory use
* Adds `KCAPI_USE_XMALLOC` option for AES and ECC to reduce page memory use in certain KCAPI cases that allow it.
* Add KCAPI ECC support for using a private key id.

# Testing

Tested on customer hardware.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
