### PR TITLE
Fix to free non-custom curve in wc_ecc_curve_free

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -1396,11 +1396,12 @@ static void wc_ecc_curve_free(ecc_curve_spec* curve)
     #ifdef ECC_CACHE_CURVE
         #ifdef WOLFSSL_CUSTOM_CURVES
         /* only free custom curves (rest are globally cached) */
-        if (curve->dp && curve->dp->id == ECC_CURVE_CUSTOM) {
+        if (curve->dp && curve->dp->id == ECC_CURVE_CUSTOM)
+        #endif
+        {
             wc_ecc_curve_cache_free_spec(curve);
             XFREE(curve, NULL, DYNAMIC_TYPE_ECC);
         }
-        #endif
     #else
         wc_ecc_curve_cache_free_spec(curve);
     #endif


### PR DESCRIPTION
# Description

This malloc in `wc_ecc_curve_load` is not freed with `ECC_CACHE_CURVE` (enabled with async):
https://github.com/wolfSSL/wolfssl/blob/master/wolfcrypt/src/ecc.c#L1469

`wc_ecc_curve_load` is being called from `_ecc_make_key_ex` (L5172).
In `_ecc_make_key_ex` the `wc_ecc_curve_free` function is being called (L5193), which you expect to solve this issue.

But in `wc_ecc_curve_free`, `XFREE` is only done for custom curves (L1401, within an if). Since we are not using custom curves, `XFREE` is not being called in this case.

Fixes ZD13974

# Testing

Tested with valgrind

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
