### PR TITLE
Fix `mcapi_test.c` to include the settings.h before crypto.h

### DIFF
--- a/mcapi/mcapi_test.c
+++ b/mcapi/mcapi_test.c
@@ -26,9 +26,9 @@
 
 
 /* mc api header */
-#include "crypto.h"
-
 #include <wolfssl/wolfcrypt/settings.h>
+
+#include "crypto.h"
 
 /* sanity test against our default implementation, wolfssl headers  */
 #include <wolfssl/wolfcrypt/md5.h>


### PR DESCRIPTION
# Description

Fix `mcapi_test.c` to include the settings.h before crypto.h

# Testing

```
./mcapi/test
...
aes-cbc     mcapi test passed
mcapi aes-128 ctr decrypt orig cmp failed
mcapi check_aes ctr failed
```
Was failing because the `CRYPT_AES_CTX` was too small and caused stack corruption.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
