### PR TITLE
20220331-ignore-readability-avoid-const-params-in-decls

### DIFF
--- a/wolfssl/openssl/aes.h
+++ b/wolfssl/openssl/aes.h
@@ -47,17 +47,17 @@ typedef struct WOLFSSL_AES_KEY {
 typedef WOLFSSL_AES_KEY AES_KEY;
 
 WOLFSSL_API int wolfSSL_AES_set_encrypt_key(
-    const unsigned char *key, int bits, AES_KEY *aes);
+    const unsigned char *key, const int bits, AES_KEY *aes);
 WOLFSSL_API int wolfSSL_AES_set_decrypt_key(
-    const unsigned char *key, int bits, AES_KEY *aes);
+    const unsigned char *key, const int bits, AES_KEY *aes);
 WOLFSSL_API void wolfSSL_AES_cbc_encrypt(
     const unsigned char *in, unsigned char* out, size_t len, AES_KEY *key,
-    unsigned char* iv, int enc);
+    unsigned char* iv, const int enc);
 WOLFSSL_API void wolfSSL_AES_ecb_encrypt(
-    const unsigned char *in, unsigned char* out, AES_KEY *key, int enc);
+    const unsigned char *in, unsigned char* out, AES_KEY *key, const int enc);
 WOLFSSL_API void wolfSSL_AES_cfb128_encrypt(
     const unsigned char *in, unsigned char* out, size_t len, AES_KEY *key,
-    unsigned char* iv, int* num, int enc);
+    unsigned char* iv, int* num, const int enc);
 WOLFSSL_API int wolfSSL_AES_wrap_key(
     AES_KEY *key, const unsigned char *iv, unsigned char *out,
     const unsigned char *in, unsigned int inlen);

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -778,13 +778,13 @@ int wc_ecc_export_private_raw(ecc_key* key, byte* qx, word32* qxLen,
 
 #ifdef HAVE_ECC_KEY_EXPORT
 WOLFSSL_API
-int wc_ecc_export_point_der_ex(int curve_idx, ecc_point* point, byte* out,
+int wc_ecc_export_point_der_ex(const int curve_idx, ecc_point* point, byte* out,
                                word32* outLen, int compressed);
 WOLFSSL_API
-int wc_ecc_export_point_der(int curve_idx, ecc_point* point,
+int wc_ecc_export_point_der(const int curve_idx, ecc_point* point,
                             byte* out, word32* outLen);
 WOLFSSL_LOCAL
-int wc_ecc_export_point_der_compressed(int curve_idx, ecc_point* point,
+int wc_ecc_export_point_der_compressed(const int curve_idx, ecc_point* point,
                                        byte* out, word32* outLen);
 #endif /* HAVE_ECC_KEY_EXPORT */
 
@@ -792,10 +792,10 @@ int wc_ecc_export_point_der_compressed(int curve_idx, ecc_point* point,
 #ifdef HAVE_ECC_KEY_IMPORT
 WOLFSSL_API
 int wc_ecc_import_point_der_ex(const byte* in, word32 inLen,
-                               int curve_idx, ecc_point* point,
+                               const int curve_idx, ecc_point* point,
                                int shortKeySize);
 WOLFSSL_API
-int wc_ecc_import_point_der(const byte* in, word32 inLen, int curve_idx,
+int wc_ecc_import_point_der(const byte* in, word32 inLen, const int curve_idx,
                             ecc_point* point);
 #endif /* HAVE_ECC_KEY_IMPORT */
 


### PR DESCRIPTION
undo changes to header files (see b7cecbacb) made to mollify clang-tidy's overly pedantic readability-avoid-const-params-in-decls -- keep declarations and definitions fully aligned, to mollify broken compilers.
