### PR TITLE
Add support for VxWorks 6.x

### DIFF
--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -104,7 +104,11 @@
     #include <sys/types.h>
     #include <netinet/in.h>
     #include <fcntl.h>
-    #include <sys/time.h>
+    #ifdef WOLFSSL_VXWORKS_6_x
+        #include <time.h>
+    #else
+        #include <sys/time.h>
+    #endif
     #include <netdb.h>
     #include <pthread.h>
     #define SOCKET_T int

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -565,8 +565,6 @@
     /* #define WOLFSSL_PTHREADS */
     #define WOLFSSL_HAVE_MIN
     #define WOLFSSL_HAVE_MAX
-    #define USE_FAST_MATH
-    #define TFM_TIMING_RESISTANT
     #define NO_MAIN_DRIVER
     #define NO_DEV_RANDOM
     #define NO_WRITEV

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -100,6 +100,11 @@
     #include "fsl_os_abstraction.h"
 #elif defined(WOLFSSL_VXWORKS)
     #include <semLib.h>
+    #ifdef WOLFSSL_VXWORKS_6_x
+        #ifndef SEM_ID_NULL
+            #define SEM_ID_NULL ((SEM_ID)NULL)
+        #endif
+    #endif
 #elif defined(WOLFSSL_uITRON4)
     #include "stddef.h"
     #include "kernel.h"

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -312,6 +312,9 @@
     #define RECV_FUNCTION(a,b,c,d)  FreeRTOS_recv((Socket_t)(a),(void*)(b), (size_t)(c), (BaseType_t)(d))
     #define SEND_FUNCTION(a,b,c,d)  FreeRTOS_send((Socket_t)(a),(void*)(b), (size_t)(c), (BaseType_t)(d))
 #elif defined(WOLFSSL_VXWORKS)
+    /*socket.h already has "typedef struct sockaddr SOCKADDR;"
+      so don't redefine it in wolfSSL */
+    #define HAVE_SOCKADDR_DEFINED
     #define SEND_FUNCTION send
     #define RECV_FUNCTION recv
 #elif defined(WOLFSSL_NUCLEUS_1_2)
@@ -364,7 +367,9 @@
 
     /* Socket Addr Support */
     #ifdef HAVE_SOCKADDR
+    #ifndef HAVE_SOCKADDR_DEFINED
         typedef struct sockaddr         SOCKADDR;
+    #endif
         typedef struct sockaddr_storage SOCKADDR_S;
         typedef struct sockaddr_in      SOCKADDR_IN;
         #ifdef WOLFSSL_IPV6


### PR DESCRIPTION
# Description

This PR introduces WOLFSSL_VXWORKS_6_x to add support for VxWorks 6.x. wolfSSL currently supports the recent VxWorks 7 by default.

VxWorks 6.x does not include support for randomNumGen.h and randBytes(). Instead, use srand()/rand() that are available in VxWorks 6.x.

Additionally, `sys/time.h` appears to be only available in recent toolchains for VxWorks 7. 

Fixes zd#13707

# Testing
The customer is testing this.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
