### PR TITLE
KCAPI ECC/AES fixes for private key checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3633,7 +3633,6 @@ AS_CASE([$FIPS_VERSION],
             -DHAVE_FIPS_VERSION_MINOR=$HAVE_FIPS_VERSION_MINOR \
             -DHAVE_ECC_CDH \
             -DWC_RSA_NO_PADDING \
-            -DWOLFSSL_VALIDATE_ECC_IMPORT \
             -DECC_USER_CURVES \
             -DHAVE_ECC384 \
             -DHAVE_ECC521 \
@@ -3649,6 +3648,8 @@ AS_CASE([$FIPS_VERSION],
             [AM_CFLAGS="$AM_CFLAGS \
                 -DWC_RNG_SEED_CB \
                 -DWOLFSSL_ECDSA_SET_K \
+                -DWOLFSSL_VALIDATE_ECC_IMPORT \
+                -DWOLFSSL_VALIDATE_ECC_KEYGEN \
                 -DHAVE_ECC192 \
                 -DHAVE_ECC224 \
                 -DHAVE_ECC256"])
@@ -3682,8 +3683,7 @@ AS_CASE([$FIPS_VERSION],
         AS_IF([test "$ENABLED_ECC" != "yes" && (test "$FIPS_VERSION" != "v5-dev" || test "$enable_ecc" != "no")],
             [ENABLED_ECC="yes"; AM_CFLAGS="$AM_CFLAGS -DHAVE_ECC -DTFM_ECC256"
              AS_IF([test "$ENABLED_ECC_SHAMIR" = "yes" && (test "$FIPS_VERSION" != "v5-dev" || test "$enable_eccshamir" != "no")],
-                 [AM_CFLAGS="$AM_CFLAGS -DECC_SHAMIR"])],
-                 [AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_VALIDATE_ECC_IMPORT -DWOLFSSL_VALIDATE_ECC_KEYGEN"])
+                 [AM_CFLAGS="$AM_CFLAGS -DECC_SHAMIR"])])
 
         AS_IF([test "$ENABLED_AESCTR" != "yes" && (test "$FIPS_VERSION" != "v5-dev" || test "$enable_aesctr" != "no")],
             [ENABLED_AESCTR="yes"; AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AES_COUNTER"])

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -8691,8 +8691,9 @@ int wc_ecc_is_point(ecc_point* ecp, mp_int* a, mp_int* b, mp_int* prime)
 #endif
 }
 
-#if FIPS_VERSION_GE(5,0) || defined(WOLFSSL_VALIDATE_ECC_KEYGEN) || \
-    (defined(WOLFSSL_VALIDATE_ECC_IMPORT) && !defined(WOLFSSL_SP_MATH))
+#if (FIPS_VERSION_GE(5,0) || defined(WOLFSSL_VALIDATE_ECC_KEYGEN) || \
+    (defined(WOLFSSL_VALIDATE_ECC_IMPORT) && !defined(WOLFSSL_SP_MATH))) && \
+    !defined(WOLFSSL_KCAPI_ECC)
 /* validate privkey * generator == pubkey, 0 on success */
 static int ecc_check_privkey_gen(ecc_key* key, mp_int* a, mp_int* prime)
 {
@@ -9746,7 +9747,7 @@ int wc_ecc_import_private_key_ex(const byte* priv, word32 privSz,
 
 #endif /* WOLFSSL_CRYPTOCELL */
 
-#ifdef WOLFSSL_VALIDATE_ECC_IMPORT
+#if defined(WOLFSSL_VALIDATE_ECC_IMPORT) && !defined(WOLFSSL_KCAPI_ECC)
     if ((pub != NULL) && (ret == MP_OKAY))
         /* public key needed to perform key validation */
         ret = _ecc_validate_public_key(key, 1, 1);

--- a/wolfcrypt/src/port/kcapi/kcapi_aes.c
+++ b/wolfcrypt/src/port/kcapi/kcapi_aes.c
@@ -84,8 +84,8 @@
             }
         }
         if (ret == 0 && aes->init == 0) {
-            ret = kcapi_cipher_stream_init_enc(aes->handle, (byte*)aes->reg,
-                                               NULL, 0);
+            ret = (int)kcapi_cipher_stream_init_enc(aes->handle, (byte*)aes->reg,
+                                                    NULL, 0);
             if (ret != 0) {
                 WOLFSSL_MSG("Error initializing IV through KCAPI");
             }
@@ -95,7 +95,7 @@
             aes->init = 1;
             iov.iov_base = (byte*)in;
             iov.iov_len = sz;
-            ret = kcapi_cipher_stream_update(aes->handle, &iov, 1);
+            ret = (int)kcapi_cipher_stream_update(aes->handle, &iov, 1);
             if (ret < 0) {
                 WOLFSSL_MSG("CbcEncrypt error updateing through KCAPI");
             }
@@ -103,7 +103,7 @@
         if (ret >= 0) {
             iov.iov_base = out;
             iov.iov_len = sz;
-            ret = kcapi_cipher_stream_op(aes->handle, &iov, 1);
+            ret = (int)kcapi_cipher_stream_op(aes->handle, &iov, 1);
             if (ret < 0) {
                 WOLFSSL_MSG("CbcEncrypt error with op in KCAPI");
             }
@@ -142,8 +142,8 @@
             }
         }
         if (ret == 0 && aes->init == 0) {
-            ret = kcapi_cipher_stream_init_dec(aes->handle, (byte*)aes->reg,
-                                               NULL, 0);
+            ret = (int)kcapi_cipher_stream_init_dec(aes->handle, (byte*)aes->reg,
+                                                    NULL, 0);
             if (ret != 0) {
                 WOLFSSL_MSG("Error initializing IV through KCAPI");
             }
@@ -153,7 +153,7 @@
             aes->init = 1;
             iov.iov_base = (byte*)in;
             iov.iov_len = sz;
-            ret = kcapi_cipher_stream_update(aes->handle, &iov, 1);
+            ret = (int)kcapi_cipher_stream_update(aes->handle, &iov, 1);
             if (ret < 0) {
                 WOLFSSL_MSG("CbcDecrypt error updateing through KCAPI");
             }
@@ -161,7 +161,7 @@
         if (ret >= 0) {
             iov.iov_base = out;
             iov.iov_len = sz;
-            ret = kcapi_cipher_stream_op(aes->handle, &iov, 1);
+            ret = (int)kcapi_cipher_stream_op(aes->handle, &iov, 1);
             if (ret < 0) {
                 WOLFSSL_MSG("CbcDecrypt error with op in KCAPI");
             }


### PR DESCRIPTION
# Description

* Disable the public key check in import private key for KCAPI.
* Cleanup the FIPS 140-3 (v5-*) configure.ac for ECC checks.
* Fix type warning in KCAPI AES.

# Testing

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
