### PR TITLE
Wycheproof fixes/changes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -16259,7 +16259,7 @@ static int test_wc_ChaCha20Poly1305_aead (void)
                     sizeof(plaintext), generatedCiphertext, generatedAuthTag);
     AssertIntEQ(ret,  BAD_FUNC_ARG);
     ret = wc_ChaCha20Poly1305_Encrypt(key, iv, aad, sizeof(aad),
-                    plaintext, 0, generatedCiphertext, generatedAuthTag);
+                NULL, sizeof(plaintext), generatedCiphertext, generatedAuthTag);
     AssertIntEQ(ret,  BAD_FUNC_ARG);
     ret = wc_ChaCha20Poly1305_Encrypt(key, iv, aad, sizeof(aad),
                     plaintext, sizeof(plaintext), NULL, generatedAuthTag);
@@ -16298,8 +16298,8 @@ static int test_wc_ChaCha20Poly1305_aead (void)
     ret = wc_ChaCha20Poly1305_Decrypt(key, iv, aad, sizeof(aad), cipher,
                                                 sizeof(cipher), authTag, NULL);
     AssertIntEQ(ret,  BAD_FUNC_ARG);
-    ret = wc_ChaCha20Poly1305_Decrypt(key, iv, aad, sizeof(aad), cipher,
-                                                0, authTag, generatedPlaintext);
+    ret = wc_ChaCha20Poly1305_Decrypt(key, iv, aad, sizeof(aad), NULL,
+                                   sizeof(cipher), authTag, generatedPlaintext);
     AssertIntEQ(ret,  BAD_FUNC_ARG);
     if (ret == BAD_FUNC_ARG) {
         ret = 0;

--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -11993,12 +11993,15 @@ static WARN_UNUSED_RESULT int S2V(
         }
     }
 
-    if (ret == 0) {
+    if ((ret == 0) && (nonceSz > 0)) {
         ShiftAndXorRb(tmp[0], tmp[1]);
         ret = wc_AesCmacGenerate(tmp[1], &macSz, nonce, nonceSz, key, keySz);
         if (ret == 0) {
             xorbuf(tmp[0], tmp[1], AES_BLOCK_SIZE);
         }
+    }
+    else {
+        XMEMCPY(tmp[0], tmp[1], AES_BLOCK_SIZE);
     }
 
     if (ret == 0) {

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -2089,6 +2089,19 @@ int GetLength_ex(const byte* input, word32* inOutIdx, int* len, word32 maxIdx,
          * Note: 0 indicates indefinte length encoding *not* 0 bytes of length.
          */
         word32 bytes = b & 0x7F;
+        int minLen;
+
+        /* Calculate minimum length to be encoded with bytes. */
+        if (b == 0x80) {
+            /* Indefinite length encoding - no length bytes. */
+            minLen = 0;
+        }
+        else if (bytes == 1) {
+            minLen = 0x80;
+        }
+        else {
+            minLen = 1 << ((bytes - 1) * 8);
+        }
 
         /* Check the number of bytes required are available. */
         if ((idx + bytes) > maxIdx) {
@@ -2107,6 +2120,10 @@ int GetLength_ex(const byte* input, word32* inOutIdx, int* len, word32 maxIdx,
         }
         /* Negative value indicates we overflowed the signed int. */
         if (length < 0) {
+            return ASN_PARSE_E;
+        }
+        /* Don't allow lengths that are longer than strictly required. */
+        if (length < minLen) {
             return ASN_PARSE_E;
         }
     }
@@ -3122,6 +3139,42 @@ int GetInt(mp_int* mpi, const byte* input, word32* inOutIdx, word32 maxIdx)
 #endif
 }
 
+#if (defined(HAVE_ECC) || !defined(NO_DSA)) && !defined(WOLFSSL_ASN_TEMPLATE)
+static int GetIntPositive(mp_int* mpi, const byte* input, word32* inOutIdx,
+    word32 maxIdx)
+{
+    word32 idx = *inOutIdx;
+    int    ret;
+    int    length;
+
+    ret = GetASNInt(input, &idx, &length, maxIdx);
+    if (ret != 0)
+        return ret;
+
+    if (((input[idx] & 0x80) == 0x80) && (input[idx - 1] != 0x00))
+        return MP_INIT_E;
+
+    if (mp_init(mpi) != MP_OKAY)
+        return MP_INIT_E;
+
+    if (mp_read_unsigned_bin(mpi, input + idx, length) != 0) {
+        mp_clear(mpi);
+        return ASN_GETINT_E;
+    }
+
+#ifdef HAVE_WOLF_BIGINT
+    if (wc_bigint_from_unsigned_bin(&mpi->raw, input + idx, length) != 0) {
+        mp_clear(mpi);
+        return ASN_GETINT_E;
+    }
+#endif /* HAVE_WOLF_BIGINT */
+
+    *inOutIdx = idx + length;
+
+    return 0;
+}
+#endif /* (ECC || !NO_DSA) && !WOLFSSL_ASN_TEMPLATE */
+
 #ifndef WOLFSSL_ASN_TEMPLATE
 #if (!defined(WOLFSSL_KEY_GEN) && !defined(OPENSSL_EXTRA) && defined(RSA_LOW_MEM)) \
     || defined(WOLFSSL_RSA_PUBLIC_ONLY) || (!defined(NO_DSA))
@@ -3737,6 +3790,12 @@ static word32 SetBitString16Bit(word16 val, byte* output)
 #endif
 #ifdef WOLFSSL_SHA512
     static const byte hashSha512hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 3};
+    #ifndef WOLFSSL_NOSHA512_224
+    static const byte hashSha512_224hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 5};
+    #endif
+    #ifndef WOLFSSL_NOSHA512_256
+    static const byte hashSha512_256hOid[] = {96, 134, 72, 1, 101, 3, 4, 2, 6};
+    #endif
 #endif
 #ifdef WOLFSSL_SHA3
 #ifndef WOLFSSL_NOSHA3_224
@@ -4130,6 +4189,18 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                     break;
             #endif
             #ifdef WOLFSSL_SHA512
+                #ifndef WOLFSSL_NOSHA512_224
+                case SHA512_224h:
+                    oid = hashSha512_224hOid;
+                    *oidSz = sizeof(hashSha512_224hOid);
+                    break;
+                #endif
+                #ifndef WOLFSSL_NOSHA512_256
+                case SHA512_256h:
+                    oid = hashSha512_256hOid;
+                    *oidSz = sizeof(hashSha512_256hOid);
+                    break;
+                #endif
                 case SHA512h:
                     oid = hashSha512hOid;
                     *oidSz = sizeof(hashSha512hOid);
@@ -27119,11 +27190,11 @@ int DecodeECC_DSA_Sig(const byte* sig, word32 sigLen, mp_int* r, mp_int* s)
     }
 #endif
 
-    if (GetInt(r, sig, &idx, sigLen) < 0) {
+    if (GetIntPositive(r, sig, &idx, sigLen) < 0) {
         return ASN_ECC_KEY_E;
     }
 
-    if (GetInt(s, sig, &idx, sigLen) < 0) {
+    if (GetIntPositive(s, sig, &idx, sigLen) < 0) {
         mp_clear(r);
         return ASN_ECC_KEY_E;
     }
@@ -27142,6 +27213,7 @@ int DecodeECC_DSA_Sig(const byte* sig, word32 sigLen, mp_int* r, mp_int* s)
 #else
     ASNGetData dataASN[dsaSigASN_Length];
     word32 idx = 0;
+    int ret;
 
     /* Clear dynamic data and set mp_ints to put r and s into. */
     XMEMSET(dataASN, 0, sizeof(dataASN));
@@ -27149,8 +27221,19 @@ int DecodeECC_DSA_Sig(const byte* sig, word32 sigLen, mp_int* r, mp_int* s)
     GetASN_MP(&dataASN[DSASIGASN_IDX_S], s);
 
     /* Decode the DSA signature. */
-    return GetASN_Items(dsaSigASN, dataASN, dsaSigASN_Length, 1, sig, &idx,
-                        sigLen);
+    ret = GetASN_Items(dsaSigASN, dataASN, dsaSigASN_Length, 1, sig, &idx,
+                       sigLen);
+#ifndef NO_STRICT_ECDSA_LEN
+    /* sanity check that the index has been advanced all the way to the end of
+     * the buffer */
+    if ((ret == 0) && (idx != sigLen)) {
+        mp_clear(r);
+        mp_clear(s);
+        ret = ASN_ECC_KEY_E;
+    }
+
+    return ret;
+#endif
 #endif /* WOLFSSL_ASN_TEMPLATE */
 }
 #endif

--- a/wolfcrypt/src/chacha20_poly1305.c
+++ b/wolfcrypt/src/chacha20_poly1305.c
@@ -60,7 +60,7 @@ int wc_ChaCha20Poly1305_Encrypt(
 
     /* Validate function arguments */
     if (!inKey || !inIV ||
-        !inPlaintext || !inPlaintextLen ||
+        (inPlaintextLen > 0 && inPlaintext == NULL) ||
         !outCiphertext ||
         !outAuthTag)
     {
@@ -93,7 +93,7 @@ int wc_ChaCha20Poly1305_Decrypt(
 
     /* Validate function arguments */
     if (!inKey || !inIV ||
-        !inCiphertext || !inCiphertextLen ||
+        (inCiphertextLen > 0 && inCiphertext == NULL) ||
         !inAuthTag ||
         !outPlaintext)
     {

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -10011,7 +10011,7 @@ static int wc_ecc_import_raw_private(ecc_key* key, const char* qx,
             err = mp_read_unsigned_bin(key->pubkey.x, (const byte*)qx,
                 key->dp->size);
 
-        if (mp_iszero(key->pubkey.x) || mp_isneg(key->pubkey.x)) {
+        if (mp_isneg(key->pubkey.x)) {
             WOLFSSL_MSG("Invalid Qx");
             err = BAD_FUNC_ARG;
         }
@@ -10025,8 +10025,15 @@ static int wc_ecc_import_raw_private(ecc_key* key, const char* qx,
             err = mp_read_unsigned_bin(key->pubkey.y, (const byte*)qy,
                 key->dp->size);
 
-        if (mp_iszero(key->pubkey.y) || mp_isneg(key->pubkey.y)) {
+        if (mp_isneg(key->pubkey.y)) {
             WOLFSSL_MSG("Invalid Qy");
+            err = BAD_FUNC_ARG;
+        }
+    }
+
+    if (err == MP_OKAY) {
+        if (mp_iszero(key->pubkey.x) && mp_iszero(key->pubkey.y)) {
+            WOLFSSL_MSG("Invalid Qx and Qy");
             err = BAD_FUNC_ARG;
         }
     }

--- a/wolfcrypt/src/ge_operations.c
+++ b/wolfcrypt/src/ge_operations.c
@@ -59,8 +59,8 @@
 static void ge_p2_0(ge_p2 *h);
 #ifndef CURVED25519_ASM
 static void ge_precomp_0(ge_precomp *h);
-#endif
 static void ge_p3_to_p2(ge_p2 *r,const ge_p3 *p);
+#endif
 static WC_INLINE void ge_p3_to_cached(ge_cached *r,const ge_p3 *p);
 static void ge_p1p1_to_p2(ge_p2 *r,const ge_p1p1 *p);
 static WC_INLINE void ge_p1p1_to_p3(ge_p3 *r,const ge_p1p1 *p);
@@ -9725,9 +9725,13 @@ r = 2 * p
 
 static void ge_p3_dbl(ge_p1p1 *r,const ge_p3 *p)
 {
-  ge_p2 q;
-  ge_p3_to_p2(&q,p);
-  ge_p2_dbl(r,&q);
+#ifndef CURVED25519_ASM
+    ge_p2 q;
+    ge_p3_to_p2(&q,p);
+    ge_p2_dbl(r,&q);
+#else
+    fe_ge_dbl(r->X, r->Y, r->Z, r->T, p->X, p->Y, p->Z);
+#endif
 }
 
 
@@ -9772,12 +9776,14 @@ static WC_INLINE void ge_p3_to_cached(ge_cached *r,const ge_p3 *p)
 r = p
 */
 
+#ifndef CURVED25519_ASM
 static void ge_p3_to_p2(ge_p2 *r,const ge_p3 *p)
 {
   fe_copy(r->X,p->X);
   fe_copy(r->Y,p->Y);
   fe_copy(r->Z,p->Z);
 }
+#endif
 
 
 /* ge p3 tobytes */

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5069,6 +5069,8 @@ int mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng)
 
     if (a == NULL || result == NULL || rng == NULL)
         return FP_VAL;
+    if (a->sign == FP_NEG)
+        return FP_VAL;
 
     if (fp_isone(a)) {
         *result = FP_NO;
@@ -5107,12 +5109,14 @@ int mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng)
         byte*  base;
     #endif
         word32 baseSz;
+        word32 bitSz;
         int    err;
 
-        baseSz = fp_count_bits(a);
+        bitSz = fp_count_bits(a);
         /* The base size is the number of bits / 8. One is added if the number
          * of bits isn't an even 8. */
-        baseSz = (baseSz / 8) + ((baseSz % 8) ? 1 : 0);
+        baseSz = (bitSz / 8) + ((bitSz % 8) ? 1 : 0);
+        bitSz %= 8;
 
     #ifndef WOLFSSL_SMALL_STACK
         if (baseSz > sizeof(base))
@@ -5152,6 +5156,9 @@ int mp_prime_is_prime_ex(mp_int* a, int t, int* result, WC_RNG* rng)
             #endif
                return err;
             }
+
+            if (bitSz != 0)
+                base[0] &= (1 << bitSz) - 1;
 
             err = fp_read_unsigned_bin(b, base, baseSz);
             if (err != FP_OKAY) {

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -5860,8 +5860,8 @@ WOLFSSL_TEST_SUBROUTINE int chacha20_poly1305_aead_test(void)
             sizeof(plaintext1), generatedCiphertext, NULL);
     if (err != BAD_FUNC_ARG)
         return -4904;
-    err = wc_ChaCha20Poly1305_Encrypt(key1, iv1, aad1, sizeof(aad1), plaintext1,
-            0, generatedCiphertext, generatedAuthTag);
+    err = wc_ChaCha20Poly1305_Encrypt(key1, iv1, aad1, sizeof(aad1), NULL,
+            sizeof(plaintext1), generatedCiphertext, generatedAuthTag);
     if (err != BAD_FUNC_ARG)
         return -4905;
     /* Decrypt */
@@ -5885,8 +5885,8 @@ WOLFSSL_TEST_SUBROUTINE int chacha20_poly1305_aead_test(void)
             sizeof(cipher2), authTag2, NULL);
     if (err != BAD_FUNC_ARG)
         return -4910;
-    err = wc_ChaCha20Poly1305_Decrypt(key2, iv2, aad2, sizeof(aad2), cipher2,
-            0, authTag2, generatedPlaintext);
+    err = wc_ChaCha20Poly1305_Decrypt(key2, iv2, aad2, sizeof(aad2), NULL,
+            sizeof(cipher2), authTag2, generatedPlaintext);
     if (err != BAD_FUNC_ARG)
         return -4911;
 

--- a/wolfssl/wolfcrypt/rsa.h
+++ b/wolfssl/wolfcrypt/rsa.h
@@ -329,12 +329,14 @@ WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
  */
 
 /* Mask Generation Function Identifiers */
-#define WC_MGF1NONE   0
-#define WC_MGF1SHA1   26
-#define WC_MGF1SHA224 4
-#define WC_MGF1SHA256 1
-#define WC_MGF1SHA384 2
-#define WC_MGF1SHA512 3
+#define WC_MGF1NONE       0
+#define WC_MGF1SHA1       26
+#define WC_MGF1SHA224     4
+#define WC_MGF1SHA256     1
+#define WC_MGF1SHA384     2
+#define WC_MGF1SHA512     3
+#define WC_MGF1SHA512_224 5
+#define WC_MGF1SHA512_256 6
 
 /* Padding types */
 #define WC_RSA_PKCSV15_PAD 0


### PR DESCRIPTION
# Description

Wycheproof fixes/changes

Allow Chachac20-Poly1305 to take an empty msg.
Allow AES-SIV to have an empty nonce.
Don't allow the length to be malleable. Must use the smallest number of
bytes to represent value.
ECDSA and DSA signature values are positive.
Add Sha512-224 and Sha512-256 OIDs.
ASN template - ensure the ECDSA/DSA signature uses all data.
Curve25519/Curve448 - WOLFSSL_ECDHX_SHARED_NOT_ZERO means shared secret
can't be 0.
Curve25519/Curve448 - check public value is less than order.
ECC - x or y may be zero but not both.
Ed25519/Ed448 - check S is less than order.
Ed448 - ge_p3_dbl can be simplified for ASM.
Prime check (integer.c/tfm.c/sp_int.c): Don't allow negative values and
make sure random candidate doesn't have bits higher than those in a set
when bits not a multiple of 8.
RSA: support Sha512-224 and Sha512-256.
RSA: Fix check for invalid in decryption. Affects plaintexts 256 bytes
and longer.
RSA: Don't allow base be larger than modulus.
RSA: Check small ciphertext (1 or 0) on decrypt when not using OAEP.
RSA: WOLFSSL_RSA_DECRYPT_TO_0_LEN allows decrypted value to be 0.
SP math all: fix div to handle large a and d when checking size of
remainder.
SP math all: set sign of result in sp_mod_2d()

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
