### PR TITLE
Fixes for `X509_add_ext`

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -2377,8 +2377,18 @@ static WOLFSSL_X509_EXTENSION* createExtFromStr(int nid, const char *value)
             break;
         case NID_subject_alt_name:
         {
-            WOLFSSL_GENERAL_NAMES* gns = wolfSSL_sk_new_null();
+            WOLFSSL_GENERAL_NAMES* gns;
             WOLFSSL_GENERAL_NAME* gn;
+
+            if (wolfSSL_ASN1_STRING_set(&ext->value, value, -1)
+                    != WOLFSSL_SUCCESS) {
+                WOLFSSL_MSG("wolfSSL_ASN1_STRING_set error");
+                goto err_cleanup;
+            }
+            ext->value.type = ASN_DNS_TYPE;
+
+            /* add stack of general names */
+            gns = wolfSSL_sk_new_null();
             if (gns == NULL) {
                 WOLFSSL_MSG("wolfSSL_sk_new_null error");
                 goto err_cleanup;

--- a/src/x509.c
+++ b/src/x509.c
@@ -1079,14 +1079,17 @@ static int asn1_string_copy_to_buffer(WOLFSSL_ASN1_STRING* str, byte** buf,
 
 int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext, int loc)
 {
+    int nid;
+
     WOLFSSL_ENTER("wolfSSL_X509_add_ext");
 
-    if (!x509 || !ext || !ext->obj || loc >= 0) {
+    if (!x509 || !ext || loc >= 0) {
         WOLFSSL_MSG("Bad parameter");
         return WOLFSSL_FAILURE;
     }
+    nid = (ext->obj != NULL) ? ext->obj->type : ext->value.nid;
 
-    switch (ext->obj->type) {
+    switch (nid) {
     case NID_authority_key_identifier:
         if (x509->authKeyIdSrc != NULL) {
             /* If authKeyId points into authKeyIdSrc then free it and
@@ -2348,16 +2351,19 @@ void wolfSSL_X509V3_set_ctx_nodb(WOLFSSL_X509V3_CTX* ctx)
 #endif /* !NO_WOLFSSL_STUB */
 
 #ifdef OPENSSL_ALL
-static WOLFSSL_X509_EXTENSION* createExtFromStr(int nid, const char *value) {
-    WOLFSSL_X509_EXTENSION* ext = wolfSSL_X509_EXTENSION_new();
+static WOLFSSL_X509_EXTENSION* createExtFromStr(int nid, const char *value)
+{
+    WOLFSSL_X509_EXTENSION* ext;
 
+    if (value == NULL)
+        return NULL;
+
+    ext = wolfSSL_X509_EXTENSION_new();
     if (ext == NULL) {
         WOLFSSL_MSG("memory error");
         return NULL;
     }
-
-    if (value == NULL)
-        return NULL;
+    ext->value.nid = nid;
 
     switch (nid) {
         case NID_subject_key_identifier:

--- a/tests/api.c
+++ b/tests/api.c
@@ -45191,7 +45191,7 @@ static void test_wolfSSL_X509V3_EXT_get(void) {
 
 static void test_wolfSSL_X509V3_EXT_nconf(void)
 {
-#if defined (OPENSSL_ALL)
+#ifdef OPENSSL_ALL
     const char *ext_names[] = {
         "subjectKeyIdentifier",
         "authorityKeyIdentifier",
@@ -45213,22 +45213,30 @@ static void test_wolfSSL_X509V3_EXT_nconf(void)
         "digitalSignature,keyEncipherment,dataEncipherment",
     };
     size_t i;
+    X509_EXTENSION* ext;
+    X509* x509 = X509_new();
 
     printf(testingFmt, "wolfSSL_X509V3_EXT_nconf()");
 
     for (i = 0; i < ext_names_count; i++) {
-        X509_EXTENSION* ext = X509V3_EXT_nconf(NULL, NULL, ext_names[i],
-                ext_values[i]);
+        ext = X509V3_EXT_nconf(NULL, NULL, ext_names[i], ext_values[i]);
         AssertNotNull(ext);
         X509_EXTENSION_free(ext);
     }
 
     for (i = 0; i < ext_nids_count; i++) {
-        X509_EXTENSION* ext = X509V3_EXT_nconf_nid(NULL, NULL, ext_nids[i],
-                ext_values[i]);
+        ext = X509V3_EXT_nconf_nid(NULL, NULL, ext_nids[i], ext_values[i]);
         AssertNotNull(ext);
         X509_EXTENSION_free(ext);
     }
+
+    /* Test adding extension to X509 */
+    for (i = 0; i < ext_nids_count; i++) {
+        ext = X509V3_EXT_nconf(NULL, NULL, ext_names[i], ext_values[i]);
+        AssertIntEQ(X509_add_ext(x509, ext, -1), WOLFSSL_SUCCESS);
+        X509_EXTENSION_free(ext);
+    }
+    X509_free(x509);
 
     printf(resultFmt, "passed");
 #endif

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -251,6 +251,7 @@ struct WOLFSSL_ASN1_STRING {
     char strData[CTC_NAME_SIZE];
     int length;
     int type; /* type of string i.e. CTC_UTF8 */
+    int nid;
     char* data;
     long flags;
     unsigned int   isDynamic:1; /* flag for if data pointer dynamic (1 is yes 0 is no) */
@@ -333,7 +334,7 @@ struct WOLFSSL_ASN1_OBJECT {
     WOLFSSL_GENERAL_NAME* gn;
 #endif
 
-    struct d { /* derefrenced */
+    struct d { /* dereferenced */
         WOLFSSL_ASN1_STRING* dNSName;
         WOLFSSL_ASN1_STRING  ia5_internal;
         WOLFSSL_ASN1_STRING* ia5; /* points to ia5_internal */


### PR DESCRIPTION
# Description

* Fixes for `X509_add_ext`.
* Added test case.

Fixes ZD13538

# Testing

Added test case. Used `./configure --enable-all`.

# Checklist

 - [X] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
