### PR TITLE
Fixed unused variable in asn.c

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -22090,7 +22090,7 @@ static int SetExtKeyUsage(Cert* cert, byte* output, word32 outSz, byte input)
     int cnt = 1 + EKU_OID_HI;
     int i;
     int ret = 0;
-    int sz;
+    int sz = 0;
 
 #ifdef WOLFSSL_EKU_OID
     cnt += CTC_MAX_EKU_NB;


### PR DESCRIPTION
# Description

Fixed potential unused variable 'sz' in asn.c

# Testing

tested via `cppcheck -UDEBUG_VECTOR_REGISTER_ACCESS -DWOLFSSL_SP_MATH --force --enable=warning,performance,portability wolfcrypt/src/asn.c`


