### PR TITLE
Minor documentation cleanup

### DIFF
--- a/doc/dox_comments/header_files/aes.h
+++ b/doc/dox_comments/header_files/aes.h
@@ -29,7 +29,7 @@
     \sa wc_AesSetKeyDirect
     \sa wc_AesSetIV
 */
-WOLFSSL_API int  wc_AesSetKey(Aes* aes, const byte* key, word32 len,
+int  wc_AesSetKey(Aes* aes, const byte* key, word32 len,
                               const byte* iv, int dir);
 
 /*!
@@ -59,7 +59,7 @@ WOLFSSL_API int  wc_AesSetKey(Aes* aes, const byte* key, word32 len,
     \sa wc_AesSetKeyDirect
     \sa wc_AesSetKey
 */
-WOLFSSL_API int  wc_AesSetIV(Aes* aes, const byte* iv);
+int  wc_AesSetIV(Aes* aes, const byte* iv);
 
 /*!
     \ingroup AES
@@ -107,7 +107,7 @@ WOLFSSL_API int  wc_AesSetIV(Aes* aes, const byte* iv);
     \sa wc_AesSetIV
     \sa wc_AesCbcDecrypt
 */
-WOLFSSL_API int  wc_AesCbcEncrypt(Aes* aes, byte* out,
+int  wc_AesCbcEncrypt(Aes* aes, byte* out,
                                   const byte* in, word32 sz);
 
 /*!
@@ -156,7 +156,7 @@ WOLFSSL_API int  wc_AesCbcEncrypt(Aes* aes, byte* out,
     \sa wc_AesSetKey
     \sa wc_AesCbcEncrypt
 */
-WOLFSSL_API int  wc_AesCbcDecrypt(Aes* aes, byte* out,
+int  wc_AesCbcDecrypt(Aes* aes, byte* out,
                                   const byte* in, word32 sz);
 
 /*!
@@ -201,7 +201,7 @@ WOLFSSL_API int  wc_AesCbcDecrypt(Aes* aes, byte* out,
 
     \sa wc_AesSetKey
 */
-WOLFSSL_API int wc_AesCtrEncrypt(Aes* aes, byte* out,
+int wc_AesCtrEncrypt(Aes* aes, byte* out,
                                    const byte* in, word32 sz);
 
 /*!
@@ -235,7 +235,7 @@ WOLFSSL_API int wc_AesCtrEncrypt(Aes* aes, byte* out,
     \sa wc_AesDecryptDirect
     \sa wc_AesSetKeyDirect
 */
-WOLFSSL_API int wc_AesEncryptDirect(Aes* aes, byte* out, const byte* in);
+int wc_AesEncryptDirect(Aes* aes, byte* out, const byte* in);
 
 /*!
     \ingroup AES
@@ -269,7 +269,7 @@ WOLFSSL_API int wc_AesEncryptDirect(Aes* aes, byte* out, const byte* in);
     \sa wc_AesEncryptDirect
     \sa wc_AesSetKeyDirect
  */
-WOLFSSL_API int wc_AesDecryptDirect(Aes* aes, byte* out, const byte* in);
+int wc_AesDecryptDirect(Aes* aes, byte* out, const byte* in);
 
 /*!
     \ingroup AES
@@ -309,7 +309,7 @@ WOLFSSL_API int wc_AesDecryptDirect(Aes* aes, byte* out, const byte* in);
     \sa wc_AesDecryptDirect
     \sa wc_AesSetKey
 */
-WOLFSSL_API int  wc_AesSetKeyDirect(Aes* aes, const byte* key, word32 len,
+int  wc_AesSetKeyDirect(Aes* aes, const byte* key, word32 len,
                                 const byte* iv, int dir);
 
 /*!
@@ -339,7 +339,7 @@ WOLFSSL_API int  wc_AesSetKeyDirect(Aes* aes, const byte* key, word32 len,
     \sa wc_AesGcmEncrypt
     \sa wc_AesGcmDecrypt
 */
-WOLFSSL_API int  wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len);
+int  wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len);
 
 /*!
     \ingroup AES
@@ -384,7 +384,7 @@ WOLFSSL_API int  wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len);
     \sa wc_AesGcmSetKey
     \sa wc_AesGcmDecrypt
 */
-WOLFSSL_API int  wc_AesGcmEncrypt(Aes* aes, byte* out,
+int  wc_AesGcmEncrypt(Aes* aes, byte* out,
                                    const byte* in, word32 sz,
                                    const byte* iv, word32 ivSz,
                                    byte* authTag, word32 authTagSz,
@@ -433,7 +433,7 @@ WOLFSSL_API int  wc_AesGcmEncrypt(Aes* aes, byte* out,
     \sa wc_AesGcmSetKey
     \sa wc_AesGcmEncrypt
 */
-WOLFSSL_API int  wc_AesGcmDecrypt(Aes* aes, byte* out,
+int  wc_AesGcmDecrypt(Aes* aes, byte* out,
                                    const byte* in, word32 sz,
                                    const byte* iv, word32 ivSz,
                                    const byte* authTag, word32 authTagSz,
@@ -460,7 +460,7 @@ WOLFSSL_API int  wc_AesGcmDecrypt(Aes* aes, byte* out,
 
     \sa wc_GmacUpdate
 */
-WOLFSSL_API int wc_GmacSetKey(Gmac* gmac, const byte* key, word32 len);
+int wc_GmacSetKey(Gmac* gmac, const byte* key, word32 len);
 
 /*!
     \ingroup AES
@@ -496,7 +496,7 @@ WOLFSSL_API int wc_GmacSetKey(Gmac* gmac, const byte* key, word32 len);
 
     \sa wc_GmacSetKey
 */
-WOLFSSL_API int wc_GmacUpdate(Gmac* gmac, const byte* iv, word32 ivSz,
+int wc_GmacUpdate(Gmac* gmac, const byte* iv, word32 ivSz,
                                const byte* authIn, word32 authInSz,
                                byte* authTag, word32 authTagSz);
 
@@ -523,7 +523,7 @@ WOLFSSL_API int wc_GmacUpdate(Gmac* gmac, const byte* iv, word32 ivSz,
     \sa wc_AesCcmEncrypt
     \sa wc_AesCcmDecrypt
 */
-WOLFSSL_API int  wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz);
+int  wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz);
 
 /*!
     \ingroup AES
@@ -568,7 +568,7 @@ WOLFSSL_API int  wc_AesCcmSetKey(Aes* aes, const byte* key, word32 keySz);
     \sa wc_AesCcmSetKey
     \sa wc_AesCcmDecrypt
 */
-WOLFSSL_API int  wc_AesCcmEncrypt(Aes* aes, byte* out,
+int  wc_AesCcmEncrypt(Aes* aes, byte* out,
                                    const byte* in, word32 inSz,
                                    const byte* nonce, word32 nonceSz,
                                    byte* authTag, word32 authTagSz,
@@ -623,7 +623,7 @@ WOLFSSL_API int  wc_AesCcmEncrypt(Aes* aes, byte* out,
     \sa wc_AesCcmSetKey
     \sa wc_AesCcmEncrypt
 */
-WOLFSSL_API int  wc_AesCcmDecrypt(Aes* aes, byte* out,
+int  wc_AesCcmDecrypt(Aes* aes, byte* out,
                                    const byte* in, word32 inSz,
                                    const byte* nonce, word32 nonceSz,
                                    const byte* authTag, word32 authTagSz,
@@ -661,7 +661,7 @@ WOLFSSL_API int  wc_AesCcmDecrypt(Aes* aes, byte* out,
     \sa wc_AesXtsDecrypt
     \sa wc_AesXtsFree
 */
-WOLFSSL_API int wc_AesXtsSetKey(XtsAes* aes, const byte* key,
+int wc_AesXtsSetKey(XtsAes* aes, const byte* key,
          word32 len, int dir, void* heap, int devId);
 
 /*!
@@ -700,7 +700,7 @@ WOLFSSL_API int wc_AesXtsSetKey(XtsAes* aes, const byte* key,
     \sa wc_AesXtsSetKey
     \sa wc_AesXtsFree
 */
-WOLFSSL_API int wc_AesXtsEncryptSector(XtsAes* aes, byte* out,
+int wc_AesXtsEncryptSector(XtsAes* aes, byte* out,
          const byte* in, word32 sz, word64 sector);
 
 /*!
@@ -739,7 +739,7 @@ WOLFSSL_API int wc_AesXtsEncryptSector(XtsAes* aes, byte* out,
     \sa wc_AesXtsSetKey
     \sa wc_AesXtsFree
 */
-WOLFSSL_API int wc_AesXtsDecryptSector(XtsAes* aes, byte* out,
+int wc_AesXtsDecryptSector(XtsAes* aes, byte* out,
          const byte* in, word32 sz, word64 sector);
 
 /*!
@@ -779,7 +779,7 @@ WOLFSSL_API int wc_AesXtsDecryptSector(XtsAes* aes, byte* out,
     \sa wc_AesXtsSetKey
     \sa wc_AesXtsFree
 */
-WOLFSSL_API int wc_AesXtsEncrypt(XtsAes* aes, byte* out,
+int wc_AesXtsEncrypt(XtsAes* aes, byte* out,
          const byte* in, word32 sz, const byte* i, word32 iSz);
 
 /*!
@@ -818,7 +818,7 @@ WOLFSSL_API int wc_AesXtsEncrypt(XtsAes* aes, byte* out,
     \sa wc_AesXtsSetKey
     \sa wc_AesXtsFree
 */
-WOLFSSL_API int wc_AesXtsDecrypt(XtsAes* aes, byte* out,
+int wc_AesXtsDecrypt(XtsAes* aes, byte* out,
         const byte* in, word32 sz, const byte* i, word32 iSz);
 
 /*!
@@ -845,7 +845,7 @@ WOLFSSL_API int wc_AesXtsDecrypt(XtsAes* aes, byte* out,
     \sa wc_AesXtsDecrypt
     \sa wc_AesXtsSetKey
 */
-WOLFSSL_API int wc_AesXtsFree(XtsAes* aes);
+int wc_AesXtsFree(XtsAes* aes);
 
 
 /*!
@@ -872,7 +872,7 @@ WOLFSSL_API int wc_AesXtsFree(XtsAes* aes);
     \sa wc_AesSetKey
     \sa wc_AesSetIV
 */
-WOLFSSL_API int  wc_AesInit(Aes*, void*, int);
+int  wc_AesInit(Aes* aes, void* heap, int devId);
 
 /*!
     \ingroup AES
@@ -904,7 +904,7 @@ WOLFSSL_API int  wc_AesInit(Aes*, void*, int);
     \sa wc_AesCfbDecrypt
     \sa wc_AesSetKey
 */
-WOLFSSL_API int wc_AesCfbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+int wc_AesCfbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz);
 
 /*!
     \ingroup AES
@@ -936,7 +936,7 @@ WOLFSSL_API int wc_AesCfbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     \sa wc_AesCfbEncrypt
     \sa wc_AesSetKey
 */
-WOLFSSL_API int wc_AesCfbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz);
+int wc_AesCfbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz);
 
 /*!
     \ingroup AES
@@ -980,7 +980,7 @@ WOLFSSL_API int wc_AesCfbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     \sa wc_AesSivDecrypt
 */
 
-WOLFSSL_API
+
 int wc_AesSivEncrypt(const byte* key, word32 keySz, const byte* assoc,
                      word32 assocSz, const byte* nonce, word32 nonceSz,
                      const byte* in, word32 inSz, byte* siv, byte* out);
@@ -1027,7 +1027,7 @@ int wc_AesSivEncrypt(const byte* key, word32 keySz, const byte* assoc,
 
     \sa wc_AesSivEncrypt
 */
-WOLFSSL_API
+
 int wc_AesSivDecrypt(const byte* key, word32 keySz, const byte* assoc,
                      word32 assocSz, const byte* nonce, word32 nonceSz,
                      const byte* in, word32 inSz, byte* siv, byte* out);

--- a/doc/dox_comments/header_files/arc4.h
+++ b/doc/dox_comments/header_files/arc4.h
@@ -32,7 +32,7 @@
 
     \sa wc_Arc4SetKey
 */
-WOLFSSL_API int wc_Arc4Process(Arc4*, byte*, const byte*, word32);
+int wc_Arc4Process(Arc4* arc4, byte* out, const byte* in, word32 length);
 
 /*!
     \ingroup ARC4
@@ -56,4 +56,4 @@ WOLFSSL_API int wc_Arc4Process(Arc4*, byte*, const byte*, word32);
 
     \sa wc_Arc4Process
 */
-WOLFSSL_API int wc_Arc4SetKey(Arc4*, const byte*, word32);
+int wc_Arc4SetKey(Arc4* arc4, const byte* key, word32 length);

--- a/doc/dox_comments/header_files/asn_public.h
+++ b/doc/dox_comments/header_files/asn_public.h
@@ -19,7 +19,7 @@
     \sa wc_MakeCert
     \sa wc_MakeCertReq
 */
-WOLFSSL_API int wc_InitCert(Cert*);
+int wc_InitCert(Cert*);
 
 /*!
     \ingroup ASN
@@ -64,8 +64,8 @@ WOLFSSL_API int wc_InitCert(Cert*);
     \sa wc_InitCert
     \sa wc_MakeCertReq
 */
-WOLFSSL_API int  wc_MakeCert(Cert*, byte* derBuffer, word32 derSz, RsaKey*,
-                             ecc_key*, WC_RNG*);
+int  wc_MakeCert(Cert* cert, byte* derBuffer, word32 derSz, RsaKey* rsaKey,
+                             ecc_key* eccKey, WC_RNG* rng);
 
 /*!
     \ingroup ASN
@@ -111,8 +111,8 @@ WOLFSSL_API int  wc_MakeCert(Cert*, byte* derBuffer, word32 derSz, RsaKey*,
     \sa wc_InitCert
     \sa wc_MakeCert
 */
-WOLFSSL_API int  wc_MakeCertReq(Cert*, byte* derBuffer, word32 derSz,
-                                    RsaKey*, ecc_key*);
+int  wc_MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
+                                    RsaKey* rsaKey, ecc_key* eccKey);
 
 /*!
     \ingroup ASN
@@ -164,8 +164,8 @@ WOLFSSL_API int  wc_MakeCertReq(Cert*, byte* derBuffer, word32 derSz,
     \sa wc_InitCert
     \sa wc_MakeCert
 */
-WOLFSSL_API int  wc_SignCert(int requestSz, int sigType, byte* derBuffer,
-                             word32 derSz, RsaKey*, ecc_key*, WC_RNG*);
+int  wc_SignCert(int requestSz, int sigType, byte* derBuffer,
+                 word32 derSz, RsaKey* rsaKey, ecc_key* eccKey, WC_RNG* rng);
 
 /*!
     \ingroup ASN
@@ -210,8 +210,8 @@ WOLFSSL_API int  wc_SignCert(int requestSz, int sigType, byte* derBuffer,
     \sa wc_MakeCert
     \sa wc_SignCert
 */
-WOLFSSL_API int  wc_MakeSelfCert(Cert*, byte* derBuffer, word32 derSz, RsaKey*,
-                             WC_RNG*);
+int  wc_MakeSelfCert(Cert* cert, byte* derBuffer, word32 derSz, RsaKey* key,
+                             WC_RNG* rng);
 
 /*!
     \ingroup ASN
@@ -272,7 +272,7 @@ WOLFSSL_API int  wc_MakeSelfCert(Cert*, byte* derBuffer, word32 derSz, RsaKey*,
     \sa wc_SetSubject
     \sa wc_SetIssuerBuffer
 */
-WOLFSSL_API int  wc_SetIssuer(Cert*, const char*);
+int  wc_SetIssuer(Cert* cert, const char* issuerFile);
 
 /*!
     \ingroup ASN
@@ -329,7 +329,7 @@ WOLFSSL_API int  wc_SetIssuer(Cert*, const char*);
     \sa wc_InitCert
     \sa wc_SetIssuer
 */
-WOLFSSL_API int  wc_SetSubject(Cert*, const char*);
+int  wc_SetSubject(Cert* cert, const char* subjectFile);
 
 
 /*!
@@ -394,7 +394,7 @@ WOLFSSL_API int  wc_SetSubject(Cert*, const char*);
     \sa wc_InitCert
     \sa wc_SetSubject
 */
-WOLFSSL_API int  wc_SetSubjectRaw(Cert* cert, const byte* der, int derSz);
+int  wc_SetSubjectRaw(Cert* cert, const byte* der, int derSz);
 
 /*!
     \ingroup ASN
@@ -422,7 +422,7 @@ WOLFSSL_API int  wc_SetSubjectRaw(Cert* cert, const byte* der, int derSz);
     \sa wc_InitCert
     \sa wc_SetSubjectRaw
 */
-WOLFSSL_API int  wc_GetSubjectRaw(byte **subjectRaw, Cert *cert);
+int  wc_GetSubjectRaw(byte **subjectRaw, Cert *cert);
 
 /*!
     \ingroup ASN
@@ -481,7 +481,7 @@ WOLFSSL_API int  wc_GetSubjectRaw(byte **subjectRaw, Cert *cert);
     \sa wc_InitCert
     \sa wc_SetIssuer
 */
-WOLFSSL_API int  wc_SetAltNames(Cert*, const char*);
+int  wc_SetAltNames(Cert* cert, const char* file);
 
 /*!
     \ingroup ASN
@@ -545,7 +545,7 @@ WOLFSSL_API int  wc_SetAltNames(Cert*, const char*);
     \sa wc_InitCert
     \sa wc_SetIssuer
 */
-WOLFSSL_API int  wc_SetIssuerBuffer(Cert*, const byte*, int);
+int  wc_SetIssuerBuffer(Cert* cert, const byte* der, int derSz);
 
 /*!
     \ingroup ASN
@@ -609,7 +609,7 @@ WOLFSSL_API int  wc_SetIssuerBuffer(Cert*, const byte*, int);
     \sa wc_InitCert
     \sa wc_SetIssuer
 */
-WOLFSSL_API int  wc_SetIssuerRaw(Cert* cert, const byte* der, int derSz);
+int  wc_SetIssuerRaw(Cert* cert, const byte* der, int derSz);
 
 /*!
     \ingroup ASN
@@ -672,7 +672,7 @@ WOLFSSL_API int  wc_SetIssuerRaw(Cert* cert, const byte* der, int derSz);
     \sa wc_InitCert
     \sa wc_SetSubject
 */
-WOLFSSL_API int  wc_SetSubjectBuffer(Cert*, const byte*, int);
+int  wc_SetSubjectBuffer(Cert* cert, const byte* der, int derSz);
 
 /*!
     \ingroup ASN
@@ -738,7 +738,7 @@ WOLFSSL_API int  wc_SetSubjectBuffer(Cert*, const byte*, int);
     \sa wc_InitCert
     \sa wc_SetAltNames
 */
-WOLFSSL_API int  wc_SetAltNamesBuffer(Cert*, const byte*, int);
+int  wc_SetAltNamesBuffer(Cert* cert, const byte* der, int derSz);
 
 /*!
     \ingroup ASN
@@ -801,7 +801,7 @@ WOLFSSL_API int  wc_SetAltNamesBuffer(Cert*, const byte*, int);
 
     \sa wc_InitCert
 */
-WOLFSSL_API int  wc_SetDatesBuffer(Cert*, const byte*, int);
+int  wc_SetDatesBuffer(Cert* cert, const byte* der, int derSz);
 
 /*!
     \ingroup ASN
@@ -835,7 +835,7 @@ WOLFSSL_API int  wc_SetDatesBuffer(Cert*, const byte*, int);
     \sa wc_SetAuthKeyId
     \sa wc_SetAuthKeyIdFromCert
 */
-WOLFSSL_API int wc_SetAuthKeyIdFromPublicKey(Cert *cert, RsaKey *rsakey,
+int wc_SetAuthKeyIdFromPublicKey(Cert *cert, RsaKey *rsakey,
                                              ecc_key *eckey);
 
 /*!
@@ -866,7 +866,7 @@ WOLFSSL_API int wc_SetAuthKeyIdFromPublicKey(Cert *cert, RsaKey *rsakey,
     \sa wc_SetAuthKeyIdFromPublicKey
     \sa wc_SetAuthKeyId
 */
-WOLFSSL_API int wc_SetAuthKeyIdFromCert(Cert *cert, const byte *der, int derSz);
+int wc_SetAuthKeyIdFromCert(Cert *cert, const byte *der, int derSz);
 
 /*!
     \ingroup ASN
@@ -895,7 +895,7 @@ WOLFSSL_API int wc_SetAuthKeyIdFromCert(Cert *cert, const byte *der, int derSz);
     \sa wc_SetAuthKeyIdFromPublicKey
     \sa wc_SetAuthKeyIdFromCert
 */
-WOLFSSL_API int wc_SetAuthKeyId(Cert *cert, const char* file);
+int wc_SetAuthKeyId(Cert *cert, const char* file);
 
 /*!
     \ingroup ASN
@@ -926,7 +926,7 @@ WOLFSSL_API int wc_SetAuthKeyId(Cert *cert, const char* file);
 
     \sa wc_SetSubjectKeyId
 */
-WOLFSSL_API int wc_SetSubjectKeyIdFromPublicKey(Cert *cert, RsaKey *rsakey,
+int wc_SetSubjectKeyIdFromPublicKey(Cert *cert, RsaKey *rsakey,
                                                 ecc_key *eckey);
 
 /*!
@@ -957,7 +957,7 @@ WOLFSSL_API int wc_SetSubjectKeyIdFromPublicKey(Cert *cert, RsaKey *rsakey,
 
     \sa wc_SetSubjectKeyIdFromPublicKey
 */
-WOLFSSL_API int wc_SetSubjectKeyId(Cert *cert, const char* file);
+int wc_SetSubjectKeyId(Cert *cert, const char* file);
 
 /*!
     \ingroup RSA
@@ -991,7 +991,7 @@ WOLFSSL_API int wc_SetSubjectKeyId(Cert *cert, const char* file);
     \sa wc_InitCert
     \sa wc_MakeRsaKey
 */
-WOLFSSL_API int wc_SetKeyUsage(Cert *cert, const char *value);
+int wc_SetKeyUsage(Cert *cert, const char *value);
 
 /*!
     \ingroup ASN
@@ -1021,7 +1021,7 @@ WOLFSSL_API int wc_SetKeyUsage(Cert *cert, const char *value);
 
     \sa wc_PubKeyPemToDer
 */
-WOLFSSL_API int wc_PemPubKeyToDer(const char* fileName,
+int wc_PemPubKeyToDer(const char* fileName,
                                        unsigned char* derBuf, int derSz);
 
 /*!
@@ -1053,8 +1053,8 @@ WOLFSSL_API int wc_PemPubKeyToDer(const char* fileName,
 
     \sa wc_PemPubKeyToDer
 */
-WOLFSSL_API int wc_PubKeyPemToDer(const unsigned char*, int,
-                                      unsigned char*, int);
+int wc_PubKeyPemToDer(const unsigned char* pem, int pemSz,
+                                      unsigned char* buff, int buffSz);
 
 /*!
     \ingroup ASN
@@ -1088,7 +1088,7 @@ WOLFSSL_API int wc_PubKeyPemToDer(const unsigned char*, int,
 
     \sa none
 */
-WOLFSSL_API
+
 int wc_PemCertToDer(const char* fileName, unsigned char* derBuf, int derSz);
 
 /*!
@@ -1131,7 +1131,7 @@ int wc_PemCertToDer(const char* fileName, unsigned char* derBuf, int derSz);
 
     \sa wc_PemCertToDer
 */
-WOLFSSL_API int wc_DerToPem(const byte* der, word32 derSz, byte* output,
+int wc_DerToPem(const byte* der, word32 derSz, byte* output,
                                 word32 outputSz, int type);
 
 /*!
@@ -1176,7 +1176,7 @@ WOLFSSL_API int wc_DerToPem(const byte* der, word32 derSz, byte* output,
 
     \sa wc_PemCertToDer
 */
-WOLFSSL_API int wc_DerToPemEx(const byte* der, word32 derSz, byte* output,
+int wc_DerToPemEx(const byte* der, word32 derSz, byte* output,
                                 word32 outputSz, byte *cipherIno, int type);
 
 /*!
@@ -1214,8 +1214,8 @@ WOLFSSL_API int wc_DerToPemEx(const byte* der, word32 derSz, byte* output,
 
     \sa wc_PemToDer
 */
-WOLFSSL_API int wc_KeyPemToDer(const unsigned char*, int,
-                                    unsigned char*, int, const char*);
+int wc_KeyPemToDer(const unsigned char* pem, int pemSz,
+                                    unsigned char* buff, int buffSz, const char* pass);
 
 /*!
     \ingroup CertsKeys
@@ -1246,8 +1246,8 @@ WOLFSSL_API int wc_KeyPemToDer(const unsigned char*, int,
 
     \sa wc_PemToDer
 */
-WOLFSSL_API int wc_CertPemToDer(const unsigned char*, int,
-                                     unsigned char*, int, int);
+int wc_CertPemToDer(const unsigned char* pem, int pemSz,
+                    unsigned char* buff, int buffSz, int type);
 
 /*!
     \ingroup CertsKeys
@@ -1269,7 +1269,7 @@ WOLFSSL_API int wc_CertPemToDer(const unsigned char*, int,
 
     \sa wc_GetPubKeyDerFromCert
 */
-WOLFSSL_API int wc_GetPubKeyDerFromCert(struct DecodedCert* cert,
+int wc_GetPubKeyDerFromCert(struct DecodedCert* cert,
                                         byte* derKey, word32* derKeySz);
 
 /*!
@@ -1329,8 +1329,8 @@ WOLFSSL_API int wc_GetPubKeyDerFromCert(struct DecodedCert* cert,
 
     \sa wc_RSA_PrivateKeyDecode
 */
-WOLFSSL_API int wc_EccPrivateKeyDecode(const byte*, word32*,
-                                           ecc_key*, word32);
+int wc_EccPrivateKeyDecode(const byte* input, word32* inOutIdx,
+                                           ecc_key* key, word32 inSz);
 
 /*!
     \ingroup ASN
@@ -1374,7 +1374,7 @@ WOLFSSL_API int wc_EccPrivateKeyDecode(const byte*, word32*,
 
     \sa wc_RsaKeyToDer
 */
-WOLFSSL_API int wc_EccKeyToDer(ecc_key*, byte* output, word32 inLen);
+int wc_EccKeyToDer(ecc_key* key, byte* output, word32 inLen);
 
 /*!
     \ingroup ASN
@@ -1408,8 +1408,8 @@ WOLFSSL_API int wc_EccKeyToDer(ecc_key*, byte* output, word32 inLen);
 
     \sa wc_ecc_import_x963
 */
-WOLFSSL_API int wc_EccPublicKeyDecode(const byte*, word32*,
-                                              ecc_key*, word32);
+int wc_EccPublicKeyDecode(const byte* input, word32* inOutIdx,
+                          ecc_key* key, word32 inSz);
 
 /*!
     \ingroup ASN
@@ -1449,7 +1449,7 @@ WOLFSSL_API int wc_EccPublicKeyDecode(const byte*, word32*,
     \sa wc_EccKeyToDer
     \sa wc_EccPrivateKeyDecode
 */
-WOLFSSL_API int wc_EccPublicKeyToDer(ecc_key*, byte* output,
+int wc_EccPublicKeyToDer(ecc_key* key, byte* output,
                                          word32 inLen, int with_AlgCurve);
 
 /*!
@@ -1485,7 +1485,7 @@ WOLFSSL_API int wc_EccPublicKeyToDer(ecc_key*, byte* output,
 
     \sa none
 */
-WOLFSSL_API word32 wc_EncodeSignature(byte* out, const byte* digest,
+word32 wc_EncodeSignature(byte* out, const byte* digest,
                                       word32 digSz, int hashOID);
 
 /*!
@@ -1515,7 +1515,7 @@ WOLFSSL_API word32 wc_EncodeSignature(byte* out, const byte* digest,
 
     \sa none
 */
-WOLFSSL_API int wc_GetCTC_HashOID(int type);
+int wc_GetCTC_HashOID(int type);
 
 /*!
     \ingroup ASN
@@ -1546,7 +1546,7 @@ WOLFSSL_API int wc_GetCTC_HashOID(int type);
     \sa wc_SetAltNamesBuffer
     \sa wc_SetDatesBuffer
 */
-WOLFSSL_API void wc_SetCert_Free(Cert* cert);
+void wc_SetCert_Free(Cert* cert);
 
 /*!
     \ingroup ASN
@@ -1578,7 +1578,7 @@ WOLFSSL_API void wc_SetCert_Free(Cert* cert);
     \sa wc_DecryptPKCS8Key
     \sa wc_CreateEncryptedPKCS8Key
 */
-WOLFSSL_API int wc_GetPkcs8TraditionalOffset(byte* input,
+int wc_GetPkcs8TraditionalOffset(byte* input,
                                              word32* inOutIdx, word32 sz);
 
 /*!
@@ -1629,7 +1629,7 @@ WOLFSSL_API int wc_GetPkcs8TraditionalOffset(byte* input,
     \sa wc_DecryptPKCS8Key
     \sa wc_CreateEncryptedPKCS8Key
 */
-WOLFSSL_API int wc_CreatePKCS8Key(byte* out, word32* outSz,
+int wc_CreatePKCS8Key(byte* out, word32* outSz,
         byte* key, word32 keySz, int algoID, const byte* curveOID,
         word32 oidSz);
 
@@ -1690,7 +1690,7 @@ WOLFSSL_API int wc_CreatePKCS8Key(byte* out, word32* outSz,
     \sa wc_DecryptPKCS8Key
     \sa wc_CreateEncryptedPKCS8Key
 */
-WOLFSSL_API int wc_EncryptPKCS8Key(byte* key, word32 keySz, byte* out,
+int wc_EncryptPKCS8Key(byte* key, word32 keySz, byte* out,
         word32* outSz, const char* password, int passwordSz, int vPKCS,
         int pbeOid, int encAlgId, byte* salt, word32 saltSz, int itt,
         WC_RNG* rng, void* heap);
@@ -1727,7 +1727,7 @@ WOLFSSL_API int wc_EncryptPKCS8Key(byte* key, word32 keySz, byte* out,
     \sa wc_EncryptPKCS8Key
     \sa wc_CreateEncryptedPKCS8Key
 */
-WOLFSSL_API int wc_DecryptPKCS8Key(byte* input, word32 sz, const char* password,
+int wc_DecryptPKCS8Key(byte* input, word32 sz, const char* password,
         int passwordSz);
 
 /*!
@@ -1786,7 +1786,7 @@ WOLFSSL_API int wc_DecryptPKCS8Key(byte* input, word32 sz, const char* password,
     \sa wc_EncryptPKCS8Key
     \sa wc_DecryptPKCS8Key
 */
-WOLFSSL_API int wc_CreateEncryptedPKCS8Key(byte* key, word32 keySz, byte* out,
+int wc_CreateEncryptedPKCS8Key(byte* key, word32 keySz, byte* out,
         word32* outSz, const char* password, int passwordSz, int vPKCS,
         int pbeOid, int encAlgId, byte* salt, word32 saltSz, int itt,
         WC_RNG* rng, void* heap);
@@ -1816,7 +1816,7 @@ WOLFSSL_API int wc_CreateEncryptedPKCS8Key(byte* key, word32 keySz, byte* out,
     \sa wc_ParseCert
     \sa wc_FreeDecodedCert
 */
-WOLFSSL_API void wc_InitDecodedCert(struct DecodedCert* cert,
+void wc_InitDecodedCert(struct DecodedCert* cert,
     const byte* source, word32 inSz, void* heap);
 
 /*!
@@ -1855,7 +1855,7 @@ WOLFSSL_API void wc_InitDecodedCert(struct DecodedCert* cert,
     \sa wc_InitDecodedCert
     \sa wc_FreeDecodedCert
 */
-WOLFSSL_API int wc_ParseCert(DecodedCert* cert, int type, int verify, void* cm);
+int wc_ParseCert(DecodedCert* cert, int type, int verify, void* cm);
 
 /*!
     \ingroup ASN
@@ -1883,7 +1883,7 @@ WOLFSSL_API int wc_ParseCert(DecodedCert* cert, int type, int verify, void* cm);
     \sa wc_InitDecodedCert
     \sa wc_ParseCert
 */
-WOLFSSL_API void wc_FreeDecodedCert(struct DecodedCert* cert);
+void wc_FreeDecodedCert(struct DecodedCert* cert);
 
 /*!
     \ingroup ASN
@@ -1914,7 +1914,7 @@ WOLFSSL_API void wc_FreeDecodedCert(struct DecodedCert* cert);
 
     \sa wc_Time
 */
-WOLFSSL_API int wc_SetTimeCb(wc_time_cb f);
+int wc_SetTimeCb(wc_time_cb f);
 
 /*!
     \ingroup ASN
@@ -1936,7 +1936,7 @@ WOLFSSL_API int wc_SetTimeCb(wc_time_cb f);
 
     \sa wc_SetTimeCb
 */
-WOLFSSL_API time_t wc_Time(time_t* t);
+time_t wc_Time(time_t* t);
 
 /*!
     \ingroup ASN
@@ -1981,7 +1981,7 @@ WOLFSSL_API time_t wc_Time(time_t* t);
     \sa wc_InitCert
     \sa wc_SetUnknownExtCallback
 */
-WOLFSSL_API int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
+int wc_SetCustomExtension(Cert *cert, int critical, const char *oid,
                                       const byte *der, word32 derSz);
 
 /*!
@@ -2055,7 +2055,7 @@ WOLFSSL_ASN_API int wc_SetUnknownExtCallback(DecodedCert* cert,
     \param pubKeyOID OID identifying the algorithm of the public key.
     (ie: ECDSAk, DSAk or RSAk)
 
-WOLFSSL_API int wc_CheckCertSigPubKey(const byte* cert, word32 certSz,
+int wc_CheckCertSigPubKey(const byte* cert, word32 certSz,
                                       void* heap, const byte* pubKey,
                                       word32 pubKeySz, int pubKeyOID);
 */

--- a/doc/dox_comments/header_files/blake2.h
+++ b/doc/dox_comments/header_files/blake2.h
@@ -19,7 +19,7 @@
 
     \sa wc_Blake2bUpdate
 */
-WOLFSSL_API int wc_InitBlake2b(Blake2b*, word32);
+int wc_InitBlake2b(Blake2b* b2b, word32 digestSz);
 
 /*!
     \ingroup BLAKE2
@@ -54,7 +54,7 @@ WOLFSSL_API int wc_InitBlake2b(Blake2b*, word32);
     \sa wc_InitBlake2b
     \sa wc_Blake2bFinal
 */
-WOLFSSL_API int wc_Blake2bUpdate(Blake2b*, const byte*, word32);
+int wc_Blake2bUpdate(Blake2b* b2b, const byte* data, word32 sz);
 
 /*!
     \ingroup BLAKE2
@@ -92,4 +92,4 @@ WOLFSSL_API int wc_Blake2bUpdate(Blake2b*, const byte*, word32);
     \sa wc_InitBlake2b
     \sa wc_Blake2bUpdate
 */
-WOLFSSL_API int wc_Blake2bFinal(Blake2b*, byte*, word32);
+int wc_Blake2bFinal(Blake2b* b2b, byte* final, word32 requestSz);

--- a/doc/dox_comments/header_files/bn.h
+++ b/doc/dox_comments/header_files/bn.h
@@ -24,5 +24,5 @@
     \sa wolfSSL_BN_new
     \sa wolfSSL_BN_free
 */
-WOLFSSL_API int wolfSSL_BN_mod_exp(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
+int wolfSSL_BN_mod_exp(WOLFSSL_BIGNUM *r, const WOLFSSL_BIGNUM *a,
         const WOLFSSL_BIGNUM *p, const WOLFSSL_BIGNUM *m, WOLFSSL_BN_CTX *ctx);

--- a/doc/dox_comments/header_files/camellia.h
+++ b/doc/dox_comments/header_files/camellia.h
@@ -35,7 +35,7 @@
     \sa wc_CamelliaCbcEncrypt
     \sa wc_CamelliaCbcDecrypt
 */
-WOLFSSL_API int  wc_CamelliaSetKey(Camellia* cam,
+int  wc_CamelliaSetKey(Camellia* cam,
                                    const byte* key, word32 len, const byte* iv);
 
 /*!
@@ -64,7 +64,7 @@ WOLFSSL_API int  wc_CamelliaSetKey(Camellia* cam,
 
     \sa wc_CamelliaSetKey
 */
-WOLFSSL_API int  wc_CamelliaSetIV(Camellia* cam, const byte* iv);
+int  wc_CamelliaSetIV(Camellia* cam, const byte* iv);
 
 /*!
     \ingroup Camellia
@@ -92,7 +92,7 @@ WOLFSSL_API int  wc_CamelliaSetIV(Camellia* cam, const byte* iv);
 
     \sa wc_CamelliaDecryptDirect
 */
-WOLFSSL_API int  wc_CamelliaEncryptDirect(Camellia* cam, byte* out,
+int  wc_CamelliaEncryptDirect(Camellia* cam, byte* out,
                                                                 const byte* in);
 
 /*!
@@ -122,7 +122,7 @@ WOLFSSL_API int  wc_CamelliaEncryptDirect(Camellia* cam, byte* out,
 
     \sa wc_CamelliaEncryptDirect
 */
-WOLFSSL_API int  wc_CamelliaDecryptDirect(Camellia* cam, byte* out,
+int  wc_CamelliaDecryptDirect(Camellia* cam, byte* out,
                                                                 const byte* in);
 
 /*!
@@ -151,7 +151,7 @@ WOLFSSL_API int  wc_CamelliaDecryptDirect(Camellia* cam, byte* out,
 
     \sa wc_CamelliaCbcDecrypt
 */
-WOLFSSL_API int wc_CamelliaCbcEncrypt(Camellia* cam,
+int wc_CamelliaCbcEncrypt(Camellia* cam,
                                           byte* out, const byte* in, word32 sz);
 
 /*!
@@ -180,5 +180,5 @@ WOLFSSL_API int wc_CamelliaCbcEncrypt(Camellia* cam,
 
     \sa wc_CamelliaCbcEncrypt
 */
-WOLFSSL_API int wc_CamelliaCbcDecrypt(Camellia* cam,
+int wc_CamelliaCbcDecrypt(Camellia* cam,
                                           byte* out, const byte* in, word32 sz);

--- a/doc/dox_comments/header_files/chacha.h
+++ b/doc/dox_comments/header_files/chacha.h
@@ -30,7 +30,7 @@
     \sa wc_Chacha_SetKey
     \sa wc_Chacha_Process
 */
-WOLFSSL_API int wc_Chacha_SetIV(ChaCha* ctx, const byte* inIv, word32 counter);
+int wc_Chacha_SetIV(ChaCha* ctx, const byte* inIv, word32 counter);
 
 /*!
     \ingroup ChaCha
@@ -64,7 +64,7 @@ WOLFSSL_API int wc_Chacha_SetIV(ChaCha* ctx, const byte* inIv, word32 counter);
     \sa wc_Chacha_SetKey
     \sa wc_Chacha_Process
 */
-WOLFSSL_API int wc_Chacha_Process(ChaCha* ctx, byte* cipher, const byte* plain,
+int wc_Chacha_Process(ChaCha* ctx, byte* cipher, const byte* plain,
                               word32 msglen);
 
 /*!
@@ -96,4 +96,4 @@ WOLFSSL_API int wc_Chacha_Process(ChaCha* ctx, byte* cipher, const byte* plain,
     \sa wc_Chacha_SetIV
     \sa wc_Chacha_Process
 */
-WOLFSSL_API int wc_Chacha_SetKey(ChaCha* ctx, const byte* key, word32 keySz);
+int wc_Chacha_SetKey(ChaCha* ctx, const byte* key, word32 keySz);

--- a/doc/dox_comments/header_files/chacha20_poly1305.h
+++ b/doc/dox_comments/header_files/chacha20_poly1305.h
@@ -46,7 +46,7 @@
     \sa wc_ChaCha_*
     \sa wc_Poly1305*
 */
-WOLFSSL_API
+
 int wc_ChaCha20Poly1305_Encrypt(
                 const byte inKey[CHACHA20_POLY1305_AEAD_KEYSIZE],
                 const byte inIV[CHACHA20_POLY1305_AEAD_IV_SIZE],
@@ -110,7 +110,7 @@ int wc_ChaCha20Poly1305_Encrypt(
     \sa wc_ChaCha_*
     \sa wc_Poly1305*
 */
-WOLFSSL_API
+
 int wc_ChaCha20Poly1305_Decrypt(
                 const byte inKey[CHACHA20_POLY1305_AEAD_KEYSIZE],
                 const byte inIV[CHACHA20_POLY1305_AEAD_IV_SIZE],

--- a/doc/dox_comments/header_files/coding.h
+++ b/doc/dox_comments/header_files/coding.h
@@ -35,7 +35,7 @@
     \sa Base64_Encode
     \sa Base16_Decode
 */
-WOLFSSL_API int Base64_Decode(const byte* in, word32 inLen, byte* out,
+int Base64_Decode(const byte* in, word32 inLen, byte* out,
                                word32* outLen);
 
 /*!
@@ -75,7 +75,7 @@ WOLFSSL_API int Base64_Decode(const byte* in, word32 inLen, byte* out,
     \sa Base64_EncodeEsc
     \sa Base64_Decode
 */
-WOLFSSL_API
+
 int Base64_Encode(const byte* in, word32 inLen, byte* out,
                                   word32* outLen);
 
@@ -157,7 +157,7 @@ int Base64_EncodeEsc(const byte* in, word32 inLen, byte* out,
     \sa Base64_Encode
     \sa Base64_Decode
 */
-WOLFSSL_API
+
 int Base64_Encode_NoNl(const byte* in, word32 inLen, byte* out,
                                   word32* outLen);
 
@@ -196,7 +196,7 @@ int Base64_Encode_NoNl(const byte* in, word32 inLen, byte* out,
     \sa Base64_Decode
     \sa Base16_Encode
 */
-WOLFSSL_API
+
 int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen);
 
 /*!
@@ -229,5 +229,5 @@ int Base16_Decode(const byte* in, word32 inLen, byte* out, word32* outLen);
     \sa Base64_Decode
     \sa Base16_Decode
 */
-WOLFSSL_API
+
 int Base16_Encode(const byte* in, word32 inLen, byte* out, word32* outLen);

--- a/doc/dox_comments/header_files/compress.h
+++ b/doc/dox_comments/header_files/compress.h
@@ -36,7 +36,7 @@
 
     \sa wc_DeCompress
 */
-WOLFSSL_API int wc_Compress(byte*, word32, const byte*, word32, word32);
+int wc_Compress(byte* out, word32 outSz, const byte* in, word32 inSz, word32 flags);
 
 /*!
     \ingroup Compression
@@ -69,4 +69,4 @@ WOLFSSL_API int wc_Compress(byte*, word32, const byte*, word32, word32);
 
     \sa wc_Compress
 */
-WOLFSSL_API int wc_DeCompress(byte*, word32, const byte*, word32);
+int wc_DeCompress(byte* out, word32 outSz, const byte* in, word32 inSz);

--- a/doc/dox_comments/header_files/cryptocb.h
+++ b/doc/dox_comments/header_files/cryptocb.h
@@ -85,7 +85,7 @@
     \sa wolfSSL_SetDevId
     \sa wolfSSL_CTX_SetDevId
 */
-WOLFSSL_API int  wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb, void* ctx);
+int  wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb, void* ctx);
 
 /*!
     \ingroup CryptoCb
@@ -108,4 +108,4 @@ WOLFSSL_API int  wc_CryptoCb_RegisterDevice(int devId, CryptoDevCallbackFunc cb,
     \sa wolfSSL_SetDevId
     \sa wolfSSL_CTX_SetDevId
 */
-WOLFSSL_API void wc_CryptoCb_UnRegisterDevice(int devId);
+void wc_CryptoCb_UnRegisterDevice(int devId);

--- a/doc/dox_comments/header_files/curve25519.h
+++ b/doc/dox_comments/header_files/curve25519.h
@@ -38,7 +38,7 @@
 
     \sa wc_curve25519_init
 */
-WOLFSSL_API
+
 int wc_curve25519_make_key(WC_RNG* rng, int keysize, curve25519_key* key);
 
 /*!
@@ -83,7 +83,7 @@ int wc_curve25519_make_key(WC_RNG* rng, int keysize, curve25519_key* key);
     \sa wc_curve25519_make_key
     \sa wc_curve25519_shared_secret_ex
 */
-WOLFSSL_API
+
 int wc_curve25519_shared_secret(curve25519_key* private_key,
                                 curve25519_key* public_key,
                                 byte* out, word32* outlen);
@@ -134,7 +134,7 @@ int wc_curve25519_shared_secret(curve25519_key* private_key,
     \sa wc_curve25519_make_key
     \sa wc_curve25519_shared_secret
 */
-WOLFSSL_API
+
 int wc_curve25519_shared_secret_ex(curve25519_key* private_key,
                                    curve25519_key* public_key,
                                    byte* out, word32* outlen, int endian);
@@ -160,7 +160,7 @@ int wc_curve25519_shared_secret_ex(curve25519_key* private_key,
 
     \sa wc_curve25519_make_key
 */
-WOLFSSL_API
+
 int wc_curve25519_init(curve25519_key* key);
 
 /*!
@@ -180,7 +180,7 @@ int wc_curve25519_init(curve25519_key* key);
     \sa wc_curve25519_init
     \sa wc_curve25519_make_key
 */
-WOLFSSL_API
+
 void wc_curve25519_free(curve25519_key* key);
 
 /*!
@@ -214,7 +214,7 @@ void wc_curve25519_free(curve25519_key* key);
     \sa wc_curve25519_import_private_ex
     \sa wc_curve25519_size
 */
-WOLFSSL_API
+
 int wc_curve25519_import_private(const byte* priv, word32 privSz,
                                  curve25519_key* key);
 
@@ -253,7 +253,7 @@ int wc_curve25519_import_private(const byte* priv, word32 privSz,
     \sa wc_curve25519_import_private
     \sa wc_curve25519_size
 */
-WOLFSSL_API
+
 int wc_curve25519_import_private_ex(const byte* priv, word32 privSz,
                                     curve25519_key* key, int endian);
 
@@ -299,7 +299,7 @@ int wc_curve25519_import_private_ex(const byte* priv, word32 privSz,
     \sa wc_curve25519_import_public
     \sa wc_curve25519_export_private_raw
 */
-WOLFSSL_API
+
 int wc_curve25519_import_private_raw(const byte* priv, word32 privSz,
                             const byte* pub, word32 pubSz, curve25519_key* key);
 
@@ -346,7 +346,7 @@ int wc_curve25519_import_private_raw(const byte* priv, word32 privSz,
     \sa wc_curve25519_export_private_raw
     \sa wc_curve25519_import_private_raw
 */
-WOLFSSL_API
+
 int wc_curve25519_import_private_raw_ex(const byte* priv, word32 privSz,
                                         const byte* pub, word32 pubSz,
                                         curve25519_key* key, int endian);
@@ -388,7 +388,7 @@ int wc_curve25519_import_private_raw_ex(const byte* priv, word32 privSz,
     \sa wc_curve25519_import_private_raw
     \sa wc_curve25519_export_private_raw_ex
 */
-WOLFSSL_API
+
 int wc_curve25519_export_private_raw(curve25519_key* key, byte* out,
                                      word32* outLen);
 
@@ -432,7 +432,7 @@ int wc_curve25519_export_private_raw(curve25519_key* key, byte* out,
     \sa wc_curve25519_export_private_raw
     \sa wc_curve25519_size
 */
-WOLFSSL_API
+
 int wc_curve25519_export_private_raw_ex(curve25519_key* key, byte* out,
                                         word32* outLen, int endian);
 
@@ -476,7 +476,7 @@ int wc_curve25519_export_private_raw_ex(curve25519_key* key, byte* out,
     \sa wc_curve25519_check_public
     \sa wc_curve25519_size
 */
-WOLFSSL_API
+
 int wc_curve25519_import_public(const byte* in, word32 inLen,
                                 curve25519_key* key);
 
@@ -522,7 +522,7 @@ int wc_curve25519_import_public(const byte* in, word32 inLen,
     \sa wc_curve25519_check_public
     \sa wc_curve25519_size
 */
-WOLFSSL_API
+
 int wc_curve25519_import_public_ex(const byte* in, word32 inLen,
                                    curve25519_key* key, int endian);
 
@@ -558,7 +558,7 @@ int wc_curve25519_import_public_ex(const byte* in, word32 inLen,
     \sa wc_curve25519_import_public_ex
     \sa wc_curve25519_size
 */
-WOLFSSL_API
+
 int wc_curve25519_check_public(const byte* pub, word32 pubSz, int endian);
 
 /*!
@@ -598,7 +598,7 @@ int wc_curve25519_check_public(const byte* pub, word32 pubSz, int endian);
     \sa wc_curve25519_export_private_raw
     \sa wc_curve25519_import_public
 */
-WOLFSSL_API
+
 int wc_curve25519_export_public(curve25519_key* key, byte* out, word32* outLen);
 
 /*!
@@ -641,7 +641,7 @@ int wc_curve25519_export_public(curve25519_key* key, byte* out, word32* outLen);
     \sa wc_curve25519_export_private_raw
     \sa wc_curve25519_import_public
 */
-WOLFSSL_API
+
 int wc_curve25519_export_public_ex(curve25519_key* key, byte* out,
                                    word32* outLen, int endian);
 
@@ -686,7 +686,7 @@ int wc_curve25519_export_public_ex(curve25519_key* key, byte* out,
     \sa wc_curve25519_export_key_raw_ex
     \sa wc_curve25519_export_private_raw
 */
-WOLFSSL_API
+
 int wc_curve25519_export_key_raw(curve25519_key* key,
                                  byte* priv, word32 *privSz,
                                  byte* pub, word32 *pubSz);
@@ -736,7 +736,7 @@ int wc_curve25519_export_key_raw(curve25519_key* key,
     \sa wc_curve25519_export_private_raw_ex
     \sa wc_curve25519_export_public_ex
 */
-WOLFSSL_API
+
 int wc_curve25519_export_key_raw_ex(curve25519_key* key,
                                     byte* priv, word32 *privSz,
                                     byte* pub, word32 *pubSz,
@@ -767,5 +767,5 @@ int wc_curve25519_export_key_raw_ex(curve25519_key* key,
     \sa wc_curve25519_init
     \sa wc_curve25519_make_key
 */
-WOLFSSL_API
+
 int wc_curve25519_size(curve25519_key* key);

--- a/doc/dox_comments/header_files/curve448.h
+++ b/doc/dox_comments/header_files/curve448.h
@@ -38,7 +38,7 @@
 
     \sa wc_curve448_init
 */
-WOLFSSL_API
+
 int wc_curve448_make_key(WC_RNG* rng, int keysize, curve448_key* key);
 
 /*!
@@ -81,7 +81,7 @@ int wc_curve448_make_key(WC_RNG* rng, int keysize, curve448_key* key);
     \sa wc_curve448_make_key
     \sa wc_curve448_shared_secret_ex
 */
-WOLFSSL_API
+
 int wc_curve448_shared_secret(curve448_key* private_key,
                                 curve448_key* public_key,
                                 byte* out, word32* outlen);
@@ -130,7 +130,7 @@ int wc_curve448_shared_secret(curve448_key* private_key,
     \sa wc_curve448_make_key
     \sa wc_curve448_shared_secret
 */
-WOLFSSL_API
+
 int wc_curve448_shared_secret_ex(curve448_key* private_key,
                                    curve448_key* public_key,
                                    byte* out, word32* outlen, int endian);
@@ -155,7 +155,7 @@ int wc_curve448_shared_secret_ex(curve448_key* private_key,
 
     \sa wc_curve448_make_key
 */
-WOLFSSL_API
+
 int wc_curve448_init(curve448_key* key);
 
 /*!
@@ -175,7 +175,7 @@ int wc_curve448_init(curve448_key* key);
     \sa wc_curve448_init
     \sa wc_curve448_make_key
 */
-WOLFSSL_API
+
 void wc_curve448_free(curve448_key* key);
 
 /*!
@@ -209,7 +209,7 @@ void wc_curve448_free(curve448_key* key);
     \sa wc_curve448_import_private_ex
     \sa wc_curve448_size
 */
-WOLFSSL_API
+
 int wc_curve448_import_private(const byte* priv, word32 privSz,
                                  curve448_key* key);
 
@@ -248,7 +248,7 @@ int wc_curve448_import_private(const byte* priv, word32 privSz,
     \sa wc_curve448_import_private
     \sa wc_curve448_size
 */
-WOLFSSL_API
+
 int wc_curve448_import_private_ex(const byte* priv, word32 privSz,
                                     curve448_key* key, int endian);
 
@@ -294,7 +294,7 @@ int wc_curve448_import_private_ex(const byte* priv, word32 privSz,
     \sa wc_curve448_import_public
     \sa wc_curve448_export_private_raw
 */
-WOLFSSL_API
+
 int wc_curve448_import_private_raw(const byte* priv, word32 privSz,
                             const byte* pub, word32 pubSz, curve448_key* key);
 
@@ -342,7 +342,7 @@ int wc_curve448_import_private_raw(const byte* priv, word32 privSz,
     \sa wc_curve448_export_private_raw
     \sa wc_curve448_import_private_raw
 */
-WOLFSSL_API
+
 int wc_curve448_import_private_raw_ex(const byte* priv, word32 privSz,
                                         const byte* pub, word32 pubSz,
                                         curve448_key* key, int endian);
@@ -384,7 +384,7 @@ int wc_curve448_import_private_raw_ex(const byte* priv, word32 privSz,
     \sa wc_curve448_import_private_raw
     \sa wc_curve448_export_private_raw_ex
 */
-WOLFSSL_API
+
 int wc_curve448_export_private_raw(curve448_key* key, byte* out,
                                      word32* outLen);
 
@@ -428,7 +428,7 @@ int wc_curve448_export_private_raw(curve448_key* key, byte* out,
     \sa wc_curve448_export_private_raw
     \sa wc_curve448_size
 */
-WOLFSSL_API
+
 int wc_curve448_export_private_raw_ex(curve448_key* key, byte* out,
                                         word32* outLen, int endian);
 
@@ -472,7 +472,7 @@ int wc_curve448_export_private_raw_ex(curve448_key* key, byte* out,
     \sa wc_curve448_check_public
     \sa wc_curve448_size
 */
-WOLFSSL_API
+
 int wc_curve448_import_public(const byte* in, word32 inLen,
                                 curve448_key* key);
 
@@ -518,7 +518,7 @@ int wc_curve448_import_public(const byte* in, word32 inLen,
     \sa wc_curve448_check_public
     \sa wc_curve448_size
 */
-WOLFSSL_API
+
 int wc_curve448_import_public_ex(const byte* in, word32 inLen,
                                    curve448_key* key, int endian);
 
@@ -554,7 +554,7 @@ int wc_curve448_import_public_ex(const byte* in, word32 inLen,
     \sa wc_curve448_import_public_ex
     \sa wc_curve448_size
 */
-WOLFSSL_API
+
 int wc_curve448_check_public(const byte* pub, word32 pubSz, int endian);
 
 /*!
@@ -594,7 +594,7 @@ int wc_curve448_check_public(const byte* pub, word32 pubSz, int endian);
     \sa wc_curve448_export_private_raw
     \sa wc_curve448_import_public
 */
-WOLFSSL_API
+
 int wc_curve448_export_public(curve448_key* key, byte* out, word32* outLen);
 
 /*!
@@ -636,7 +636,7 @@ int wc_curve448_export_public(curve448_key* key, byte* out, word32* outLen);
     \sa wc_curve448_export_private_raw
     \sa wc_curve448_import_public
 */
-WOLFSSL_API
+
 int wc_curve448_export_public_ex(curve448_key* key, byte* out,
                                    word32* outLen, int endian);
 
@@ -682,7 +682,7 @@ int wc_curve448_export_public_ex(curve448_key* key, byte* out,
     \sa wc_curve448_export_key_raw_ex
     \sa wc_curve448_export_private_raw
 */
-WOLFSSL_API
+
 int wc_curve448_export_key_raw(curve448_key* key,
                                  byte* priv, word32 *privSz,
                                  byte* pub, word32 *pubSz);
@@ -733,7 +733,7 @@ int wc_curve448_export_key_raw(curve448_key* key,
     \sa wc_curve448_export_private_raw_ex
     \sa wc_curve448_export_public_ex
 */
-WOLFSSL_API
+
 int wc_curve448_export_key_raw_ex(curve448_key* key,
                                     byte* priv, word32 *privSz,
                                     byte* pub, word32 *pubSz,
@@ -764,5 +764,5 @@ int wc_curve448_export_key_raw_ex(curve448_key* key,
     \sa wc_curve448_init
     \sa wc_curve448_make_key
 */
-WOLFSSL_API
+
 int wc_curve448_size(curve448_key* key);

--- a/doc/dox_comments/header_files/des3.h
+++ b/doc/dox_comments/header_files/des3.h
@@ -34,7 +34,7 @@
     \sa wc_Des_SetIV
     \sa wc_Des3_SetKey
 */
-WOLFSSL_API int  wc_Des_SetKey(Des* des, const byte* key,
+int  wc_Des_SetKey(Des* des, const byte* key,
                                const byte* iv, int dir);
 
 /*!
@@ -61,7 +61,7 @@ WOLFSSL_API int  wc_Des_SetKey(Des* des, const byte* key,
 
     \sa wc_Des_SetKey
 */
-WOLFSSL_API void wc_Des_SetIV(Des* des, const byte* iv);
+void wc_Des_SetIV(Des* des, const byte* iv);
 
 /*!
     \ingroup 3DES
@@ -93,7 +93,7 @@ WOLFSSL_API void wc_Des_SetIV(Des* des, const byte* iv);
     \sa wc_Des_SetKey
     \sa wc_Des_CbcDecrypt
 */
-WOLFSSL_API int  wc_Des_CbcEncrypt(Des* des, byte* out,
+int  wc_Des_CbcEncrypt(Des* des, byte* out,
                                    const byte* in, word32 sz);
 
 /*!
@@ -126,7 +126,7 @@ WOLFSSL_API int  wc_Des_CbcEncrypt(Des* des, byte* out,
     \sa wc_Des_SetKey
     \sa wc_Des_CbcEncrypt
 */
-WOLFSSL_API int  wc_Des_CbcDecrypt(Des* des, byte* out,
+int  wc_Des_CbcDecrypt(Des* des, byte* out,
                                    const byte* in, word32 sz);
 
 /*!
@@ -158,7 +158,7 @@ WOLFSSL_API int  wc_Des_CbcDecrypt(Des* des, byte* out,
 
     \sa wc_Des_SetKe
 */
-WOLFSSL_API int  wc_Des_EcbEncrypt(Des* des, byte* out,
+int  wc_Des_EcbEncrypt(Des* des, byte* out,
                                    const byte* in, word32 sz);
 
 /*!
@@ -192,7 +192,7 @@ WOLFSSL_API int  wc_Des_EcbEncrypt(Des* des, byte* out,
 
     \sa wc_Des3_SetKey
 */
-WOLFSSL_API int wc_Des3_EcbEncrypt(Des3* des, byte* out,
+int wc_Des3_EcbEncrypt(Des3* des, byte* out,
                                    const byte* in, word32 sz);
 
 /*!
@@ -233,7 +233,7 @@ WOLFSSL_API int wc_Des3_EcbEncrypt(Des3* des, byte* out,
     \sa wc_Des3_CbcEncrypt
     \sa wc_Des3_CbcDecrypt
 */
-WOLFSSL_API int  wc_Des3_SetKey(Des3* des, const byte* key,
+int  wc_Des3_SetKey(Des3* des, const byte* key,
                                 const byte* iv,int dir);
 
 /*!
@@ -263,7 +263,7 @@ WOLFSSL_API int  wc_Des3_SetKey(Des3* des, const byte* key,
 
     \sa wc_Des3_SetKey
 */
-WOLFSSL_API int  wc_Des3_SetIV(Des3* des, const byte* iv);
+int  wc_Des3_SetIV(Des3* des, const byte* iv);
 
 /*!
     \ingroup 3DES
@@ -295,7 +295,7 @@ WOLFSSL_API int  wc_Des3_SetIV(Des3* des, const byte* iv);
     \sa wc_Des3_SetKey
     \sa wc_Des3_CbcDecrypt
 */
-WOLFSSL_API int  wc_Des3_CbcEncrypt(Des3* des, byte* out,
+int  wc_Des3_CbcEncrypt(Des3* des, byte* out,
                                     const byte* in,word32 sz);
 
 /*!
@@ -328,5 +328,5 @@ WOLFSSL_API int  wc_Des3_CbcEncrypt(Des3* des, byte* out,
     \sa wc_Des3_SetKey
     \sa wc_Des3_CbcEncrypt
 */
-WOLFSSL_API int  wc_Des3_CbcDecrypt(Des3* des, byte* out,
+int  wc_Des3_CbcDecrypt(Des3* des, byte* out,
                                     const byte* in,word32 sz);

--- a/doc/dox_comments/header_files/dh.h
+++ b/doc/dox_comments/header_files/dh.h
@@ -18,7 +18,7 @@
     \sa wc_FreeDhKey
     \sa wc_DhGenerateKeyPair
 */
-WOLFSSL_API int wc_InitDhKey(DhKey* key);
+int wc_InitDhKey(DhKey* key);
 
 /*!
     \ingroup Diffie-Hellman
@@ -40,7 +40,7 @@ WOLFSSL_API int wc_InitDhKey(DhKey* key);
 
     \sa wc_InitDhKey
 */
-WOLFSSL_API void wc_FreeDhKey(DhKey* key);
+void wc_FreeDhKey(DhKey* key);
 
 /*!
     \ingroup Diffie-Hellman
@@ -91,7 +91,7 @@ WOLFSSL_API void wc_FreeDhKey(DhKey* key);
     \sa wc_DhSetKey
     \sa wc_DhKeyDecode
 */
-WOLFSSL_API int wc_DhGenerateKeyPair(DhKey* key, WC_RNG* rng, byte* priv,
+int wc_DhGenerateKeyPair(DhKey* key, WC_RNG* rng, byte* priv,
                                  word32* privSz, byte* pub, word32* pubSz);
 
 /*!
@@ -142,7 +142,7 @@ WOLFSSL_API int wc_DhGenerateKeyPair(DhKey* key, WC_RNG* rng, byte* priv,
 
     \sa wc_DhGenerateKeyPair
 */
-WOLFSSL_API int wc_DhAgree(DhKey* key, byte* agree, word32* agreeSz,
+int wc_DhAgree(DhKey* key, byte* agree, word32* agreeSz,
                        const byte* priv, word32 privSz, const byte* otherPub,
                        word32 pubSz);
 
@@ -184,7 +184,7 @@ WOLFSSL_API int wc_DhAgree(DhKey* key, byte* agree, word32* agreeSz,
 
     \sa wc_DhSetKey
 */
-WOLFSSL_API int wc_DhKeyDecode(const byte* input, word32* inOutIdx, DhKey* key,
+int wc_DhKeyDecode(const byte* input, word32* inOutIdx, DhKey* key,
                            word32);
 
 /*!
@@ -225,7 +225,7 @@ WOLFSSL_API int wc_DhKeyDecode(const byte* input, word32* inOutIdx, DhKey* key,
 
     \sa wc_DhKeyDecode
 */
-WOLFSSL_API int wc_DhSetKey(DhKey* key, const byte* p, word32 pSz, const byte* g,
+int wc_DhSetKey(DhKey* key, const byte* p, word32 pSz, const byte* g,
                         word32 gSz);
 
 /*!
@@ -269,7 +269,7 @@ WOLFSSL_API int wc_DhSetKey(DhKey* key, const byte* p, word32 pSz, const byte* g
     \sa wc_DhSetKey
     \sa wc_DhKeyDecode
 */
-WOLFSSL_API int wc_DhParamsLoad(const byte* input, word32 inSz, byte* p,
+int wc_DhParamsLoad(const byte* input, word32 inSz, byte* p,
                             word32* pInOutSz, byte* g, word32* gInOutSz);
 
 /*!
@@ -283,7 +283,7 @@ WOLFSSL_API int wc_DhParamsLoad(const byte* input, word32 inSz, byte* p,
     \sa wc_Dh_ffdhe6144_Get
     \sa wc_Dh_ffdhe8192_Get
 */
-WOLFSSL_API const DhParams* wc_Dh_ffdhe2048_Get(void);
+const DhParams* wc_Dh_ffdhe2048_Get(void);
 
 /*!
     \ingroup Diffie-Hellman
@@ -296,7 +296,7 @@ WOLFSSL_API const DhParams* wc_Dh_ffdhe2048_Get(void);
     \sa wc_Dh_ffdhe6144_Get
     \sa wc_Dh_ffdhe8192_Get
 */
-WOLFSSL_API const DhParams* wc_Dh_ffdhe3072_Get(void);
+const DhParams* wc_Dh_ffdhe3072_Get(void);
 
 /*!
     \ingroup Diffie-Hellman
@@ -309,7 +309,7 @@ WOLFSSL_API const DhParams* wc_Dh_ffdhe3072_Get(void);
     \sa wc_Dh_ffdhe6144_Get
     \sa wc_Dh_ffdhe8192_Get
 */
-WOLFSSL_API const DhParams* wc_Dh_ffdhe4096_Get(void);
+const DhParams* wc_Dh_ffdhe4096_Get(void);
 
 /*!
     \ingroup Diffie-Hellman
@@ -322,7 +322,7 @@ WOLFSSL_API const DhParams* wc_Dh_ffdhe4096_Get(void);
     \sa wc_Dh_ffdhe4096_Get
     \sa wc_Dh_ffdhe8192_Get
 */
-WOLFSSL_API const DhParams* wc_Dh_ffdhe6144_Get(void);
+const DhParams* wc_Dh_ffdhe6144_Get(void);
 
 /*!
     \ingroup Diffie-Hellman
@@ -335,7 +335,7 @@ WOLFSSL_API const DhParams* wc_Dh_ffdhe6144_Get(void);
     \sa wc_Dh_ffdhe4096_Get
     \sa wc_Dh_ffdhe6144_Get
 */
-WOLFSSL_API const DhParams* wc_Dh_ffdhe8192_Get(void);
+const DhParams* wc_Dh_ffdhe8192_Get(void);
 
 /*!
     \ingroup Diffie-Hellman
@@ -343,7 +343,7 @@ WOLFSSL_API const DhParams* wc_Dh_ffdhe8192_Get(void);
     \brief Checks DH keys for pair-wise consistency per process in SP 800-56Ar3,
     section 5.6.2.1.4, method (b) for FFC.
 */
-WOLFSSL_API int wc_DhCheckKeyPair(DhKey* key, const byte* pub, word32 pubSz,
+int wc_DhCheckKeyPair(DhKey* key, const byte* pub, word32 pubSz,
                         const byte* priv, word32 privSz);
 
 /*!
@@ -351,50 +351,50 @@ WOLFSSL_API int wc_DhCheckKeyPair(DhKey* key, const byte* pub, word32 pubSz,
 
     \brief Check DH private key for invalid numbers
 */
-WOLFSSL_API int wc_DhCheckPrivKey(DhKey* key, const byte* priv, word32 pubSz);
+int wc_DhCheckPrivKey(DhKey* key, const byte* priv, word32 pubSz);
 
 /*!
     \ingroup Diffie-Hellman
 */
-WOLFSSL_API int wc_DhCheckPrivKey_ex(DhKey* key, const byte* priv, word32 pubSz,
+int wc_DhCheckPrivKey_ex(DhKey* key, const byte* priv, word32 pubSz,
                             const byte* prime, word32 primeSz);
 
 /*!
     \ingroup Diffie-Hellman
 */
-WOLFSSL_API int wc_DhCheckPubKey(DhKey* key, const byte* pub, word32 pubSz);
+int wc_DhCheckPubKey(DhKey* key, const byte* pub, word32 pubSz);
 
 /*!
     \ingroup Diffie-Hellman
 */
-WOLFSSL_API int wc_DhCheckPubKey_ex(DhKey* key, const byte* pub, word32 pubSz,
+int wc_DhCheckPubKey_ex(DhKey* key, const byte* pub, word32 pubSz,
                             const byte* prime, word32 primeSz);
 
 /*!
     \ingroup Diffie-Hellman
 */
-WOLFSSL_API int wc_DhExportParamsRaw(DhKey* dh, byte* p, word32* pSz,
+int wc_DhExportParamsRaw(DhKey* dh, byte* p, word32* pSz,
                        byte* q, word32* qSz, byte* g, word32* gSz);
 
 /*!
     \ingroup Diffie-Hellman
 */
-WOLFSSL_API int wc_DhGenerateParams(WC_RNG *rng, int modSz, DhKey *dh);
+int wc_DhGenerateParams(WC_RNG *rng, int modSz, DhKey *dh);
 
 /*!
     \ingroup Diffie-Hellman
 */
-WOLFSSL_API int wc_DhSetCheckKey(DhKey* key, const byte* p, word32 pSz,
+int wc_DhSetCheckKey(DhKey* key, const byte* p, word32 pSz,
                         const byte* g, word32 gSz, const byte* q, word32 qSz,
                         int trusted, WC_RNG* rng);
 
 /*!
     \ingroup Diffie-Hellman
 */
-WOLFSSL_API int wc_DhSetKey_ex(DhKey* key, const byte* p, word32 pSz,
+int wc_DhSetKey_ex(DhKey* key, const byte* p, word32 pSz,
                         const byte* g, word32 gSz, const byte* q, word32 qSz);
 
 /*!
     \ingroup Diffie-Hellman
 */
-WOLFSSL_API int wc_FreeDhKey(DhKey* key);
+int wc_FreeDhKey(DhKey* key);

--- a/doc/dox_comments/header_files/dsa.h
+++ b/doc/dox_comments/header_files/dsa.h
@@ -18,7 +18,7 @@
 
     \sa wc_FreeDsaKey
 */
-WOLFSSL_API int wc_InitDsaKey(DsaKey* key);
+int wc_InitDsaKey(DsaKey* key);
 
 /*!
     \ingroup DSA
@@ -39,7 +39,7 @@ WOLFSSL_API int wc_InitDsaKey(DsaKey* key);
 
     \sa wc_FreeDsaKey
 */
-WOLFSSL_API void wc_FreeDsaKey(DsaKey* key);
+void wc_FreeDsaKey(DsaKey* key);
 
 /*!
     \ingroup DSA
@@ -96,7 +96,7 @@ WOLFSSL_API void wc_FreeDsaKey(DsaKey* key);
 
     \sa wc_DsaVerify
 */
-WOLFSSL_API int wc_DsaSign(const byte* digest, byte* out,
+int wc_DsaSign(const byte* digest, byte* out,
                            DsaKey* key, WC_RNG* rng);
 
 /*!
@@ -159,7 +159,7 @@ WOLFSSL_API int wc_DsaSign(const byte* digest, byte* out,
 
     \sa wc_DsaSign
 */
-WOLFSSL_API int wc_DsaVerify(const byte* digest, const byte* sig,
+int wc_DsaVerify(const byte* digest, const byte* sig,
                              DsaKey* key, int* answer);
 
 /*!
@@ -199,8 +199,8 @@ WOLFSSL_API int wc_DsaVerify(const byte* digest, const byte* sig,
     \sa wc_InitDsaKey
     \sa wc_DsaPrivateKeyDecode
 */
-WOLFSSL_API int wc_DsaPublicKeyDecode(const byte* input, word32* inOutIdx,
-                                      DsaKey*, word32);
+int wc_DsaPublicKeyDecode(const byte* input, word32* inOutIdx,
+                                      DsaKey* key, word32 inSz);
 
 /*!
     \ingroup DSA
@@ -240,8 +240,8 @@ WOLFSSL_API int wc_DsaPublicKeyDecode(const byte* input, word32* inOutIdx,
     \sa wc_InitDsaKey
     \sa wc_DsaPublicKeyDecode
 */
-WOLFSSL_API int wc_DsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
-                                       DsaKey*, word32);
+int wc_DsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
+                                       DsaKey* key, word32 inSz);
 
 /*!
     \ingroup DSA
@@ -276,7 +276,7 @@ WOLFSSL_API int wc_DsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
     \sa wc_FreeDsaKey
     \sa wc_MakeDsaKey
 */
-WOLFSSL_API int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen);
+int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen);
 
 /*!
     \ingroup DSA
@@ -307,7 +307,7 @@ WOLFSSL_API int wc_DsaKeyToDer(DsaKey* key, byte* output, word32 inLen);
     \sa wc_FreeDsaKey
     \sa wc_DsaSign
 */
-WOLFSSL_API int wc_MakeDsaKey(WC_RNG *rng, DsaKey *dsa);
+int wc_MakeDsaKey(WC_RNG *rng, DsaKey *dsa);
 
 /*!
     \ingroup DSA
@@ -339,4 +339,4 @@ WOLFSSL_API int wc_MakeDsaKey(WC_RNG *rng, DsaKey *dsa);
     \sa wc_DsaKeyToDer
     \sa wc_InitDsaKey
 */
-WOLFSSL_API int wc_MakeDsaParameters(WC_RNG *rng, int modulus_size, DsaKey *dsa);
+int wc_MakeDsaParameters(WC_RNG *rng, int modulus_size, DsaKey *dsa);

--- a/doc/dox_comments/header_files/ecc.h
+++ b/doc/dox_comments/header_files/ecc.h
@@ -49,7 +49,7 @@
     \sa wc_ecc_init
     \sa wc_ecc_shared_secret
 */
-WOLFSSL_API
+
 int wc_ecc_make_key(WC_RNG* rng, int keysize, ecc_key* key);
 
 /*!
@@ -110,7 +110,7 @@ int wc_ecc_make_key(WC_RNG* rng, int keysize, ecc_key* key);
     \sa wc_ecc_make_key
     \sa wc_ecc_get_curve_size_from_id
 */
-WOLFSSL_API
+
 int wc_ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key, int curve_id);
 
 /*!
@@ -146,7 +146,7 @@ int wc_ecc_make_key_ex(WC_RNG* rng, int keysize, ecc_key* key, int curve_id);
 
     \sa wc_ecc_point_is_at_infinity
 */
-WOLFSSL_API
+
 int wc_ecc_check_key(ecc_key* key);
 
 /*!
@@ -167,7 +167,7 @@ int wc_ecc_check_key(ecc_key* key);
     \sa wc_ecc_key_new
     \sa wc_ecc_init_ex
 */
-WOLFSSL_API
+
 void wc_ecc_key_free(ecc_key* key);
 
 /*!
@@ -242,7 +242,7 @@ void wc_ecc_key_free(ecc_key* key);
     \sa wc_ecc_init
     \sa wc_ecc_make_key
 */
-WOLFSSL_API
+
 int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
                       word32* outlen);
 
@@ -288,7 +288,7 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
 
     \sa wc_ecc_verify_hash_ex
 */
-WOLFSSL_API
+
 int wc_ecc_shared_secret_ex(ecc_key* private_key, ecc_point* point,
                              byte* out, word32 *outlen);
 
@@ -357,7 +357,7 @@ int wc_ecc_shared_secret_ex(ecc_key* private_key, ecc_point* point,
 
     \sa wc_ecc_verify_hash
 */
-WOLFSSL_API
+
 int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
                      WC_RNG* rng, ecc_key* key);
 
@@ -428,7 +428,7 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
 
     \sa wc_ecc_verify_hash_ex
 */
-WOLFSSL_API
+
 int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
                         ecc_key* key, mp_int *r, mp_int *s);
 
@@ -496,7 +496,7 @@ int wc_ecc_sign_hash_ex(const byte* in, word32 inlen, WC_RNG* rng,
     \sa wc_ecc_sign_hash
     \sa wc_ecc_verify_hash_ex
 */
-WOLFSSL_API
+
 int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
                     word32 hashlen, int* stat, ecc_key* key);
 
@@ -535,7 +535,7 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
 
     \sa wc_ecc_verify_hash
 */
-WOLFSSL_API
+
 int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
                           word32 hashlen, int* stat, ecc_key* key);
 
@@ -559,7 +559,7 @@ int wc_ecc_verify_hash_ex(mp_int *r, mp_int *s, const byte* hash,
     \sa wc_ecc_make_key
     \sa wc_ecc_free
 */
-WOLFSSL_API
+
 int wc_ecc_init(ecc_key* key);
 
 /*!
@@ -585,7 +585,7 @@ int wc_ecc_init(ecc_key* key);
     \sa wc_ecc_free
     \sa wc_ecc_init
 */
-WOLFSSL_API
+
 int wc_ecc_init_ex(ecc_key* key, void* heap, int devId);
 
 /*!
@@ -607,7 +607,7 @@ int wc_ecc_init_ex(ecc_key* key, void* heap, int devId);
     \sa wc_ecc_key_free
     \sa wc_ecc_init
 */
-WOLFSSL_API
+
 ecc_key* wc_ecc_key_new(void* heap);
 
 /*!
@@ -628,7 +628,7 @@ ecc_key* wc_ecc_key_new(void* heap);
 
     \sa wc_ecc_init
 */
-WOLFSSL_API
+
 int wc_ecc_free(ecc_key* key);
 
 /*!
@@ -653,7 +653,7 @@ int wc_ecc_free(ecc_key* key);
 
     \sa wc_ecc_free
 */
-WOLFSSL_API
+
 void wc_ecc_fp_free(void);
 
 /*!
@@ -687,7 +687,7 @@ void wc_ecc_fp_free(void);
 
     \sa none
 */
-WOLFSSL_API
+
 int wc_ecc_is_valid_idx(int n);
 
 /*!
@@ -715,7 +715,7 @@ int wc_ecc_is_valid_idx(int n);
     \sa wc_ecc_cmp_point
     \sa wc_ecc_copy_point
 */
-WOLFSSL_API
+
 ecc_point* wc_ecc_new_point(void);
 
 /*!
@@ -743,7 +743,7 @@ ecc_point* wc_ecc_new_point(void);
     \sa wc_ecc_cmp_point
     \sa wc_ecc_copy_point
 */
-WOLFSSL_API
+
 void wc_ecc_del_point(ecc_point* p);
 
 /*!
@@ -776,7 +776,7 @@ void wc_ecc_del_point(ecc_point* p);
     \sa wc_ecc_cmp_point
     \sa wc_ecc_del_point
 */
-WOLFSSL_API
+
 int wc_ecc_copy_point(ecc_point* p, ecc_point *r);
 
 /*!
@@ -819,7 +819,7 @@ int wc_ecc_copy_point(ecc_point* p, ecc_point *r);
     \sa wc_ecc_del_point
     \sa wc_ecc_copy_point
 */
-WOLFSSL_API
+
 int wc_ecc_cmp_point(ecc_point* a, ecc_point *b);
 
 /*!
@@ -860,7 +860,7 @@ int wc_ecc_cmp_point(ecc_point* a, ecc_point *b);
     \sa wc_ecc_cmp_point
     \sa wc_ecc_copy_point
 */
-WOLFSSL_API
+
 int wc_ecc_point_is_at_infinity(ecc_point *p);
 
 /*!
@@ -894,7 +894,7 @@ int wc_ecc_point_is_at_infinity(ecc_point *p);
 
     \sa none
 */
-WOLFSSL_API
+
 int wc_ecc_mulmod(mp_int* k, ecc_point *G, ecc_point *R,
                   mp_int* a, mp_int* modulus, int map);
 
@@ -960,8 +960,8 @@ int wc_ecc_mulmod(mp_int* k, ecc_point *G, ecc_point *R,
     \sa wc_ecc_export_x963_ex
     \sa wc_ecc_import_x963
 */
-WOLFSSL_API
-int wc_ecc_export_x963(ecc_key*, byte* out, word32* outLen);
+
+int wc_ecc_export_x963(ecc_key* key, byte* out, word32* outLen);
 
 /*!
     \ingroup ECC
@@ -1031,8 +1031,8 @@ int wc_ecc_export_x963(ecc_key*, byte* out, word32* outLen);
     \sa wc_ecc_export_x963
     \sa wc_ecc_import_x963
 */
-WOLFSSL_API
-int wc_ecc_export_x963_ex(ecc_key*, byte* out, word32* outLen, int compressed);
+
+int wc_ecc_export_x963_ex(ecc_key* key, byte* out, word32* outLen, int compressed);
 
 /*!
     \ingroup ECC
@@ -1094,7 +1094,7 @@ int wc_ecc_export_x963_ex(ecc_key*, byte* out, word32* outLen, int compressed);
     \sa wc_ecc_export_x963
     \sa wc_ecc_import_private_key
 */
-WOLFSSL_API
+
 int wc_ecc_import_x963(const byte* in, word32 inLen, ecc_key* key);
 
 /*!
@@ -1163,7 +1163,7 @@ int wc_ecc_import_x963(const byte* in, word32 inLen, ecc_key* key);
     \sa wc_ecc_export_x963
     \sa wc_ecc_import_private_key
 */
-WOLFSSL_API
+
 int wc_ecc_import_private_key(const byte* priv, word32 privSz, const byte* pub,
                            word32 pubSz, ecc_key* key);
 
@@ -1229,7 +1229,7 @@ int wc_ecc_import_private_key(const byte* priv, word32 privSz, const byte* pub,
     \sa wc_ecc_sign_hash
     \sa wc_ecc_sig_size
 */
-WOLFSSL_API
+
 int wc_ecc_rs_to_sig(const char* r, const char* s, byte* out, word32* outlen);
 
 /*!
@@ -1294,7 +1294,7 @@ int wc_ecc_rs_to_sig(const char* r, const char* s, byte* out, word32* outlen);
 
     \sa wc_ecc_import_private_key
 */
-WOLFSSL_API
+
 int wc_ecc_import_raw(ecc_key* key, const char* qx, const char* qy,
                    const char* d, const char* curveName);
 
@@ -1357,7 +1357,7 @@ int wc_ecc_import_raw(ecc_key* key, const char* qx, const char* qy,
 
     \sa wc_ecc_import_private_key
 */
-WOLFSSL_API
+
 int wc_ecc_export_private_only(ecc_key* key, byte* out, word32* outLen);
 
 /*!
@@ -1389,7 +1389,7 @@ int wc_ecc_export_private_only(ecc_key* key, byte* out, word32* outLen);
 
     \sa wc_ecc_import_point_der
 */
-WOLFSSL_API
+
 int wc_ecc_export_point_der(const int curve_idx, ecc_point* point,
                             byte* out, word32* outLen);
 
@@ -1421,7 +1421,7 @@ int wc_ecc_export_point_der(const int curve_idx, ecc_point* point,
 
     \sa wc_ecc_export_point_der
 */
-WOLFSSL_API
+
 int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
                             ecc_point* point);
 
@@ -1449,7 +1449,7 @@ int wc_ecc_import_point_der(byte* in, word32 inLen, const int curve_idx,
 
     \sa wc_ecc_make_key
 */
-WOLFSSL_API
+
 int wc_ecc_size(ecc_key* key);
 
 /*!
@@ -1475,7 +1475,7 @@ int wc_ecc_size(ecc_key* key);
     \sa wc_ecc_sign_hash
     \sa wc_ecc_sig_size
 */
-WOLFSSL_API
+
 int wc_ecc_sig_size_calc(int sz);
 
 
@@ -1508,7 +1508,7 @@ int wc_ecc_sig_size_calc(int sz);
     \sa wc_ecc_sign_hash
     \sa wc_ecc_sig_size_calc
 */
-WOLFSSL_API
+
 int wc_ecc_sig_size(ecc_key* key);
 
 
@@ -1542,7 +1542,7 @@ int wc_ecc_sig_size(ecc_key* key);
     \sa wc_ecc_encrypt_ex
     \sa wc_ecc_decrypt
 */
-WOLFSSL_API
+
 ecEncCtx* wc_ecc_ctx_new(int flags, WC_RNG* rng);
 
 /*!
@@ -1568,7 +1568,7 @@ ecEncCtx* wc_ecc_ctx_new(int flags, WC_RNG* rng);
 
     \sa wc_ecc_ctx_new
 */
-WOLFSSL_API
+
 void wc_ecc_ctx_free(ecEncCtx*);
 
 /*!
@@ -1599,8 +1599,8 @@ void wc_ecc_ctx_free(ecEncCtx*);
 
     \sa wc_ecc_ctx_new
 */
-WOLFSSL_API
-int wc_ecc_ctx_reset(ecEncCtx*, WC_RNG*);  /* reset for use again w/o alloc/free */
+
+int wc_ecc_ctx_reset(ecEncCtx* ctx, WC_RNG* rng);  /* reset for use again w/o alloc/free */
 
 /*!
     \ingroup ECC
@@ -1630,7 +1630,7 @@ int wc_ecc_ctx_reset(ecEncCtx*, WC_RNG*);  /* reset for use again w/o alloc/free
 
     \sa wc_ecc_ctx_new
 */
-WOLFSSL_API
+
 int wc_ecc_ctx_set_algo(ecEncCtx* ctx, byte encAlgo, byte kdfAlgo,
     byte macAlgo);
 
@@ -1665,7 +1665,7 @@ int wc_ecc_ctx_set_algo(ecEncCtx* ctx, byte encAlgo, byte kdfAlgo,
     \sa wc_ecc_ctx_new
     \sa wc_ecc_ctx_set_peer_salt
 */
-WOLFSSL_API
+
 const byte* wc_ecc_ctx_get_own_salt(ecEncCtx*);
 
 /*!
@@ -1703,8 +1703,8 @@ const byte* wc_ecc_ctx_get_own_salt(ecEncCtx*);
 
     \sa wc_ecc_ctx_get_own_salt
 */
-WOLFSSL_API
-int wc_ecc_ctx_set_peer_salt(ecEncCtx*, const byte* salt);
+
+int wc_ecc_ctx_set_peer_salt(ecEncCtx* ctx, const byte* salt);
 
 /*!
     \ingroup ECC
@@ -1734,8 +1734,8 @@ int wc_ecc_ctx_set_peer_salt(ecEncCtx*, const byte* salt);
 
     \sa wc_ecc_ctx_new
 */
-WOLFSSL_API
-int wc_ecc_ctx_set_info(ecEncCtx*, const byte* info, int sz);
+
+int wc_ecc_ctx_set_info(ecEncCtx* ctx, const byte* info, int sz);
 
 /*!
     \ingroup ECC
@@ -1795,7 +1795,7 @@ int wc_ecc_ctx_set_info(ecEncCtx*, const byte* info, int sz);
     \sa wc_ecc_encrypt_ex
     \sa wc_ecc_decrypt
 */
-WOLFSSL_API
+
 int wc_ecc_encrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
                 word32 msgSz, byte* out, word32* outSz, ecEncCtx* ctx);
 
@@ -1859,7 +1859,7 @@ int wc_ecc_encrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
     \sa wc_ecc_encrypt
     \sa wc_ecc_decrypt
 */
-WOLFSSL_API
+
 int wc_ecc_encrypt_ex(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
     word32 msgSz, byte* out, word32* outSz, ecEncCtx* ctx, int compressed);
 
@@ -1922,7 +1922,7 @@ int wc_ecc_encrypt_ex(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
     \sa wc_ecc_encrypt
     \sa wc_ecc_encrypt_ex
 */
-WOLFSSL_API
+
 int wc_ecc_decrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
                 word32 msgSz, byte* out, word32* outSz, ecEncCtx* ctx);
 
@@ -1967,4 +1967,4 @@ int wc_ecc_decrypt(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
     }
     \endcode
 */
-WOLFSSL_API int wc_ecc_set_nonblock(ecc_key *key, ecc_nb_ctx_t* ctx);
+int wc_ecc_set_nonblock(ecc_key *key, ecc_nb_ctx_t* ctx);

--- a/doc/dox_comments/header_files/eccsi.h
+++ b/doc/dox_comments/header_files/eccsi.h
@@ -2,130 +2,130 @@
 /*!
     \ingroup ECCSI_Setup
 */
-WOLFSSL_API int wc_InitEccsiKey(EccsiKey* key, void* heap, int devId);
+int wc_InitEccsiKey(EccsiKey* key, void* heap, int devId);
 /*!
     \ingroup ECCSI_Setup
 */
-WOLFSSL_API int wc_InitEccsiKey_ex(EccsiKey* key, int keySz, int curveId,
+int wc_InitEccsiKey_ex(EccsiKey* key, int keySz, int curveId,
         void* heap, int devId);
 /*!
     \ingroup ECCSI_Setup
 */
-WOLFSSL_API void wc_FreeEccsiKey(EccsiKey* key);
+void wc_FreeEccsiKey(EccsiKey* key);
 
 /*!
     \ingroup ECCSI_Setup
 */
-WOLFSSL_API int wc_MakeEccsiKey(EccsiKey* key, WC_RNG* rng);
+int wc_MakeEccsiKey(EccsiKey* key, WC_RNG* rng);
 
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_MakeEccsiPair(EccsiKey* key, WC_RNG* rng,
+int wc_MakeEccsiPair(EccsiKey* key, WC_RNG* rng,
         enum wc_HashType hashType, const byte* id, word32 idSz, mp_int* ssk,
         ecc_point* pvt);
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_ValidateEccsiPair(EccsiKey* key, enum wc_HashType hashType,
+int wc_ValidateEccsiPair(EccsiKey* key, enum wc_HashType hashType,
         const byte* id, word32 idSz, const mp_int* ssk, ecc_point* pvt,
         int* valid);
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_ValidateEccsiPvt(EccsiKey* key, const ecc_point* pvt,
+int wc_ValidateEccsiPvt(EccsiKey* key, const ecc_point* pvt,
         int* valid);
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_EncodeEccsiPair(const EccsiKey* key, mp_int* ssk,
+int wc_EncodeEccsiPair(const EccsiKey* key, mp_int* ssk,
         ecc_point* pvt, byte* data, word32* sz);
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_EncodeEccsiSsk(const EccsiKey* key, mp_int* ssk, byte* data,
+int wc_EncodeEccsiSsk(const EccsiKey* key, mp_int* ssk, byte* data,
         word32* sz);
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_EncodeEccsiPvt(const EccsiKey* key, ecc_point* pvt,
+int wc_EncodeEccsiPvt(const EccsiKey* key, ecc_point* pvt,
         byte* data, word32* sz, int raw);
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_DecodeEccsiPair(const EccsiKey* key, const byte* data,
+int wc_DecodeEccsiPair(const EccsiKey* key, const byte* data,
         word32 sz, mp_int* ssk, ecc_point* pvt);
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_DecodeEccsiSsk(const EccsiKey* key, const byte* data,
+int wc_DecodeEccsiSsk(const EccsiKey* key, const byte* data,
         word32 sz, mp_int* ssk);
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_DecodeEccsiPvt(const EccsiKey* key, const byte* data,
+int wc_DecodeEccsiPvt(const EccsiKey* key, const byte* data,
         word32 sz, ecc_point* pvt);
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_DecodeEccsiPvtFromSig(const EccsiKey* key, const byte* sig,
+int wc_DecodeEccsiPvtFromSig(const EccsiKey* key, const byte* sig,
         word32 sz, ecc_point* pvt);
 
 /*!
     \ingroup ECCSI_Setup
 */
-WOLFSSL_API int wc_ExportEccsiKey(EccsiKey* key, byte* data, word32* sz);
+int wc_ExportEccsiKey(EccsiKey* key, byte* data, word32* sz);
 /*!
     \ingroup ECCSI_Setup
 */
-WOLFSSL_API int wc_ImportEccsiKey(EccsiKey* key, const byte* data, word32 sz);
+int wc_ImportEccsiKey(EccsiKey* key, const byte* data, word32 sz);
 
 /*!
     \ingroup ECCSI_Setup
 */
-WOLFSSL_API int wc_ExportEccsiPrivateKey(EccsiKey* key, byte* data, word32* sz);
+int wc_ExportEccsiPrivateKey(EccsiKey* key, byte* data, word32* sz);
 /*!
     \ingroup ECCSI_Setup
 */
-WOLFSSL_API int wc_ImportEccsiPrivateKey(EccsiKey* key, const byte* data,
+int wc_ImportEccsiPrivateKey(EccsiKey* key, const byte* data,
         word32 sz);
 
 /*!
     \ingroup ECCSI_Setup
 */
-WOLFSSL_API int wc_ExportEccsiPublicKey(EccsiKey* key, byte* data, word32* sz,
+int wc_ExportEccsiPublicKey(EccsiKey* key, byte* data, word32* sz,
         int raw);
 /*!
     \ingroup ECCSI_Setup
 */
-WOLFSSL_API int wc_ImportEccsiPublicKey(EccsiKey* key, const byte* data,
+int wc_ImportEccsiPublicKey(EccsiKey* key, const byte* data,
         word32 sz, int trusted);
 
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_HashEccsiId(EccsiKey* key, enum wc_HashType hashType,
+int wc_HashEccsiId(EccsiKey* key, enum wc_HashType hashType,
         const byte* id, word32 idSz, ecc_point* pvt, byte* hash, byte* hashSz);
 /*!
     \ingroup ECCSI_Setup
 */
-WOLFSSL_API int wc_SetEccsiHash(EccsiKey* key, const byte* hash, byte hashSz);
+int wc_SetEccsiHash(EccsiKey* key, const byte* hash, byte hashSz);
 /*!
     \ingroup ECCSI_Setup
 */
-WOLFSSL_API int wc_SetEccsiPair(EccsiKey* key, const mp_int* ssk,
+int wc_SetEccsiPair(EccsiKey* key, const mp_int* ssk,
         const ecc_point* pvt);
 
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_SignEccsiHash(EccsiKey* key, WC_RNG* rng,
+int wc_SignEccsiHash(EccsiKey* key, WC_RNG* rng,
         enum wc_HashType hashType, const byte* msg, word32 msgSz, byte* sig,
         word32* sigSz);
 /*!
     \ingroup ECCSI_Operations
 */
-WOLFSSL_API int wc_VerifyEccsiHash(EccsiKey* key, enum wc_HashType hashType,
+int wc_VerifyEccsiHash(EccsiKey* key, enum wc_HashType hashType,
         const byte* msg, word32 msgSz, const byte* sig, word32 sigSz,
         int* verified);
 

--- a/doc/dox_comments/header_files/ed25519.h
+++ b/doc/dox_comments/header_files/ed25519.h
@@ -38,7 +38,7 @@
     \sa wc_ed25519_import_private_only
     \sa wc_ed25519_make_key
 */
-WOLFSSL_API
+
 int wc_ed25519_make_public(ed25519_key* key, unsigned char* pubKey,
                            word32 pubKeySz);
 
@@ -76,7 +76,7 @@ int wc_ed25519_make_public(ed25519_key* key, unsigned char* pubKey,
 
     \sa wc_ed25519_init
 */
-WOLFSSL_API
+
 int wc_ed25519_make_key(WC_RNG* rng, int keysize, ed25519_key* key);
 
 /*!
@@ -124,7 +124,7 @@ int wc_ed25519_make_key(WC_RNG* rng, int keysize, ed25519_key* key);
     \sa wc_ed25519ph_sign_msg
     \sa wc_ed25519_verify_msg
 */
-WOLFSSL_API
+
 int wc_ed25519_sign_msg(const byte* in, word32 inlen, byte* out,
                         word32 *outlen, ed25519_key* key);
 
@@ -178,7 +178,7 @@ int wc_ed25519_sign_msg(const byte* in, word32 inlen, byte* out,
     \sa wc_ed25519ph_sign_msg
     \sa wc_ed25519_verify_msg
 */
-WOLFSSL_API
+
 int wc_ed25519ctx_sign_msg(const byte* in, word32 inlen, byte* out,
                         word32 *outlen, ed25519_key* key,
                         const byte* context, byte contextLen);
@@ -236,7 +236,7 @@ int wc_ed25519ctx_sign_msg(const byte* in, word32 inlen, byte* out,
     \sa wc_ed25519ph_sign_msg
     \sa wc_ed25519_verify_msg
 */
-WOLFSSL_API
+
 int wc_ed25519ph_sign_hash(const byte* hash, word32 hashLen, byte* out,
                            word32 *outLen, ed25519_key* key,
                            const byte* context, byte contextLen);
@@ -292,7 +292,7 @@ int wc_ed25519ph_sign_hash(const byte* hash, word32 hashLen, byte* out,
     \sa wc_ed25519ph_sign_hash
     \sa wc_ed25519_verify_msg
 */
-WOLFSSL_API
+
 int wc_ed25519ph_sign_msg(const byte* in, word32 inlen, byte* out,
                         word32 *outlen, ed25519_key* key,
                         const byte* context, byte contextLen);
@@ -342,7 +342,7 @@ int wc_ed25519ph_sign_msg(const byte* in, word32 inlen, byte* out,
     \sa wc_ed25519ph_verify_msg
     \sa wc_ed25519_sign_msg
 */
-WOLFSSL_API
+
 int wc_ed25519_verify_msg(const byte* sig, word32 siglen, const byte* msg,
                           word32 msgLen, int* ret, ed25519_key* key);
 
@@ -396,7 +396,7 @@ int wc_ed25519_verify_msg(const byte* sig, word32 siglen, const byte* msg,
     \sa wc_ed25519ph_verify_msg
     \sa wc_ed25519_sign_msg
 */
-WOLFSSL_API
+
 int wc_ed25519ctx_verify_msg(const byte* sig, word32 siglen, const byte* msg,
                              word32 msgLen, int* ret, ed25519_key* key,
                              const byte* context, byte contextLen);
@@ -455,7 +455,7 @@ int wc_ed25519ctx_verify_msg(const byte* sig, word32 siglen, const byte* msg,
     \sa wc_ed25519ph_verify_msg
     \sa wc_ed25519_sign_msg
 */
-WOLFSSL_API
+
 int wc_ed25519ph_verify_hash(const byte* sig, word32 siglen, const byte* hash,
                              word32 hashLen, int* ret, ed25519_key* key,
                              const byte* context, byte contextLen);
@@ -511,7 +511,7 @@ int wc_ed25519ph_verify_hash(const byte* sig, word32 siglen, const byte* hash,
     \sa wc_ed25519ph_verify_msg
     \sa wc_ed25519_sign_msg
 */
-WOLFSSL_API
+
 int wc_ed25519ph_verify_msg(const byte* sig, word32 siglen, const byte* msg,
                             word32 msgLen, int* ret, ed25519_key* key,
                             const byte* context, byte contextLen);
@@ -536,7 +536,7 @@ int wc_ed25519ph_verify_msg(const byte* sig, word32 siglen, const byte* msg,
     \sa wc_ed25519_make_key
     \sa wc_ed25519_free
 */
-WOLFSSL_API
+
 int wc_ed25519_init(ed25519_key* key);
 
 /*!
@@ -556,7 +556,7 @@ int wc_ed25519_init(ed25519_key* key);
 
     \sa wc_ed25519_init
 */
-WOLFSSL_API
+
 void wc_ed25519_free(ed25519_key* key);
 
 /*!
@@ -591,7 +591,7 @@ void wc_ed25519_free(ed25519_key* key);
     \sa wc_ed25519_import_private_key
     \sa wc_ed25519_export_public
 */
-WOLFSSL_API
+
 int wc_ed25519_import_public(const byte* in, word32 inLen, ed25519_key* key);
 
 /*!
@@ -628,7 +628,7 @@ int wc_ed25519_import_public(const byte* in, word32 inLen, ed25519_key* key);
     \sa wc_ed25519_import_private_key
     \sa wc_ed25519_export_private_only
 */
-WOLFSSL_API
+
 int wc_ed25519_import_private_only(const byte* priv, word32 privSz,
                                    ed25519_key* key);
 
@@ -670,7 +670,7 @@ int wc_ed25519_import_private_only(const byte* priv, word32 privSz,
     \sa wc_ed25519_import_private_only
     \sa wc_ed25519_export_private
 */
-WOLFSSL_API
+
 int wc_ed25519_import_private_key(const byte* priv, word32 privSz,
                                const byte* pub, word32 pubSz, ed25519_key* key);
 
@@ -712,8 +712,8 @@ int wc_ed25519_import_private_key(const byte* priv, word32 privSz,
     \sa wc_ed25519_import_public
     \sa wc_ed25519_export_private_only
 */
-WOLFSSL_API
-int wc_ed25519_export_public(ed25519_key*, byte* out, word32* outLen);
+
+int wc_ed25519_export_public(ed25519_key* key, byte* out, word32* outLen);
 
 /*!
     \ingroup ED25519
@@ -751,7 +751,7 @@ int wc_ed25519_export_public(ed25519_key*, byte* out, word32* outLen);
     \sa wc_ed25519_export_public
     \sa wc_ed25519_import_private_key
 */
-WOLFSSL_API
+
 int wc_ed25519_export_private_only(ed25519_key* key, byte* out, word32* outLen);
 
 /*!
@@ -794,7 +794,7 @@ int wc_ed25519_export_private_only(ed25519_key* key, byte* out, word32* outLen);
     \sa wc_ed25519_import_private_key
     \sa wc_ed25519_export_private_only
 */
-WOLFSSL_API
+
 int wc_ed25519_export_private(ed25519_key* key, byte* out, word32* outLen);
 
 /*!
@@ -841,7 +841,7 @@ int wc_ed25519_export_private(ed25519_key* key, byte* out, word32* outLen);
     \sa wc_ed25519_export_private
     \sa wc_ed25519_export_public
 */
-WOLFSSL_API
+
 int wc_ed25519_export_key(ed25519_key* key,
                           byte* priv, word32 *privSz,
                           byte* pub, word32 *pubSz);
@@ -875,7 +875,7 @@ int wc_ed25519_export_key(ed25519_key* key,
 
     \sa wc_ed25519_import_private_key
 */
-WOLFSSL_API
+
 int wc_ed25519_check_key(ed25519_key* key);
 
 /*!
@@ -902,7 +902,7 @@ int wc_ed25519_check_key(ed25519_key* key);
 
     \sa wc_ed25519_make_key
 */
-WOLFSSL_API
+
 int wc_ed25519_size(ed25519_key* key);
 
 /*!
@@ -931,7 +931,7 @@ int wc_ed25519_size(ed25519_key* key);
 
     \sa wc_ed25519_pub_size
 */
-WOLFSSL_API
+
 int wc_ed25519_priv_size(ed25519_key* key);
 
 /*!
@@ -959,7 +959,7 @@ int wc_ed25519_priv_size(ed25519_key* key);
 
     \sa wc_ed25519_priv_size
 */
-WOLFSSL_API
+
 int wc_ed25519_pub_size(ed25519_key* key);
 
 /*!
@@ -987,5 +987,5 @@ int wc_ed25519_pub_size(ed25519_key* key);
 
     \sa wc_ed25519_sign_msg
 */
-WOLFSSL_API
+
 int wc_ed25519_sig_size(ed25519_key* key);

--- a/doc/dox_comments/header_files/ed448.h
+++ b/doc/dox_comments/header_files/ed448.h
@@ -38,7 +38,7 @@
     \sa wc_ed448_import_private_only
     \sa wc_ed448_make_key
 */
-WOLFSSL_API
+
 int wc_ed448_make_public(ed448_key* key, unsigned char* pubKey,
                          word32 pubKeySz);
 
@@ -76,7 +76,7 @@ int wc_ed448_make_public(ed448_key* key, unsigned char* pubKey,
 
     \sa wc_ed448_init
 */
-WOLFSSL_API
+
 int wc_ed448_make_key(WC_RNG* rng, int keysize, ed448_key* key);
 
 /*!
@@ -123,7 +123,7 @@ int wc_ed448_make_key(WC_RNG* rng, int keysize, ed448_key* key);
     \sa wc_ed448ph_sign_msg
     \sa wc_ed448_verify_msg
 */
-WOLFSSL_API
+
 int wc_ed448_sign_msg(const byte* in, word32 inlen, byte* out,
                         word32 *outlen, ed448_key* key);
 
@@ -179,7 +179,7 @@ int wc_ed448_sign_msg(const byte* in, word32 inlen, byte* out,
     \sa wc_ed448ph_sign_msg
     \sa wc_ed448ph_verify_hash
 */
-WOLFSSL_API
+
 int wc_ed448ph_sign_hash(const byte* hash, word32 hashLen, byte* out,
                          word32 *outLen, ed448_key* key,
                          const byte* context, byte contextLen);
@@ -234,7 +234,7 @@ int wc_ed448ph_sign_hash(const byte* hash, word32 hashLen, byte* out,
     \sa wc_ed448ph_sign_hash
     \sa wc_ed448ph_verify_msg
 */
-WOLFSSL_API
+
 int wc_ed448ph_sign_msg(const byte* in, word32 inLen, byte* out,
                         word32 *outLen, ed448_key* key, const byte* context,
                         byte contextLen);
@@ -286,7 +286,7 @@ int wc_ed448ph_sign_msg(const byte* in, word32 inLen, byte* out,
     \sa wc_ed448ph_verify_msg
     \sa wc_ed448_sign_msg
 */
-WOLFSSL_API
+
 int wc_ed448_verify_msg(const byte* sig, word32 siglen, const byte* msg,
                           word32 msgLen, int* res, ed448_key* key,
                           const byte* context, byte contextLen);
@@ -341,7 +341,7 @@ int wc_ed448_verify_msg(const byte* sig, word32 siglen, const byte* msg,
     \sa wc_ed448ph_verify_msg
     \sa wc_ed448ph_sign_hash
 */
-WOLFSSL_API
+
 int wc_ed448ph_verify_hash(const byte* sig, word32 siglen, const byte* hash,
                           word32 hashlen, int* res, ed448_key* key,
                           const byte* context, byte contextLen);
@@ -394,7 +394,7 @@ int wc_ed448ph_verify_hash(const byte* sig, word32 siglen, const byte* hash,
     \sa wc_ed448ph_verify_hash
     \sa wc_ed448ph_sign_msg
 */
-WOLFSSL_API
+
 int wc_ed448ph_verify_msg(const byte* sig, word32 siglen, const byte* msg,
                           word32 msgLen, int* res, ed448_key* key,
                           const byte* context, byte contextLen);
@@ -419,7 +419,7 @@ int wc_ed448ph_verify_msg(const byte* sig, word32 siglen, const byte* msg,
     \sa wc_ed448_make_key
     \sa wc_ed448_free
 */
-WOLFSSL_API
+
 int wc_ed448_init(ed448_key* key);
 
 /*!
@@ -439,7 +439,7 @@ int wc_ed448_init(ed448_key* key);
 
     \sa wc_ed448_init
 */
-WOLFSSL_API
+
 void wc_ed448_free(ed448_key* key);
 
 /*!
@@ -474,7 +474,7 @@ void wc_ed448_free(ed448_key* key);
     \sa wc_ed448_import_private_key
     \sa wc_ed448_export_public
 */
-WOLFSSL_API
+
 int wc_ed448_import_public(const byte* in, word32 inLen, ed448_key* key);
 
 /*!
@@ -509,7 +509,7 @@ int wc_ed448_import_public(const byte* in, word32 inLen, ed448_key* key);
     \sa wc_ed448_import_private_key
     \sa wc_ed448_export_private_only
 */
-WOLFSSL_API
+
 int wc_ed448_import_private_only(const byte* priv, word32 privSz,
                                  ed448_key* key);
 
@@ -551,7 +551,7 @@ int wc_ed448_import_private_only(const byte* priv, word32 privSz,
     \sa wc_ed448_import_private_only
     \sa wc_ed448_export_private
 */
-WOLFSSL_API
+
 int wc_ed448_import_private_key(const byte* priv, word32 privSz,
                                const byte* pub, word32 pubSz, ed448_key* key);
 
@@ -593,8 +593,8 @@ int wc_ed448_import_private_key(const byte* priv, word32 privSz,
     \sa wc_ed448_import_public
     \sa wc_ed448_export_private_only
 */
-WOLFSSL_API
-int wc_ed448_export_public(ed448_key*, byte* out, word32* outLen);
+
+int wc_ed448_export_public(ed448_key* key, byte* out, word32* outLen);
 
 /*!
     \ingroup ED448
@@ -632,7 +632,7 @@ int wc_ed448_export_public(ed448_key*, byte* out, word32* outLen);
     \sa wc_ed448_export_public
     \sa wc_ed448_import_private_key
 */
-WOLFSSL_API
+
 int wc_ed448_export_private_only(ed448_key* key, byte* out, word32* outLen);
 
 /*!
@@ -675,7 +675,7 @@ int wc_ed448_export_private_only(ed448_key* key, byte* out, word32* outLen);
     \sa wc_ed448_import_private
     \sa wc_ed448_export_private_only
 */
-WOLFSSL_API
+
 int wc_ed448_export_private(ed448_key* key, byte* out, word32* outLen);
 
 /*!
@@ -722,7 +722,7 @@ int wc_ed448_export_private(ed448_key* key, byte* out, word32* outLen);
     \sa wc_ed448_export_private
     \sa wc_ed448_export_public
 */
-WOLFSSL_API
+
 int wc_ed448_export_key(ed448_key* key,
                           byte* priv, word32 *privSz,
                           byte* pub, word32 *pubSz);
@@ -756,7 +756,7 @@ int wc_ed448_export_key(ed448_key* key,
 
     \sa wc_ed448_import_private_key
 */
-WOLFSSL_API
+
 int wc_ed448_check_key(ed448_key* key);
 
 
@@ -784,7 +784,7 @@ int wc_ed448_check_key(ed448_key* key);
 
     \sa wc_ed448_make_key
 */
-WOLFSSL_API
+
 int wc_ed448_size(ed448_key* key);
 
 /*!
@@ -813,7 +813,7 @@ int wc_ed448_size(ed448_key* key);
 
     \sa wc_ed448_pub_size
 */
-WOLFSSL_API
+
 int wc_ed448_priv_size(ed448_key* key);
 
 /*!
@@ -840,7 +840,7 @@ int wc_ed448_priv_size(ed448_key* key);
 
     \sa wc_ed448_priv_size
 */
-WOLFSSL_API
+
 int wc_ed448_pub_size(ed448_key* key);
 
 /*!
@@ -868,5 +868,5 @@ int wc_ed448_pub_size(ed448_key* key);
 
     \sa wc_ed448_sign_msg
 */
-WOLFSSL_API
+
 int wc_ed448_sig_size(ed448_key* key);

--- a/doc/dox_comments/header_files/error-crypt.h
+++ b/doc/dox_comments/header_files/error-crypt.h
@@ -22,7 +22,7 @@
 
     \sa wc_GetErrorString
 */
-WOLFSSL_API void wc_ErrorString(int err, char* buff);
+void wc_ErrorString(int err, char* buff);
 
 /*!
     \ingroup Error
@@ -46,4 +46,4 @@ WOLFSSL_API void wc_ErrorString(int err, char* buff);
 
     \sa wc_ErrorString
 */
-WOLFSSL_API const char* wc_GetErrorString(int error);
+const char* wc_GetErrorString(int error);

--- a/doc/dox_comments/header_files/evp.h
+++ b/doc/dox_comments/header_files/evp.h
@@ -20,7 +20,7 @@
 
     \sa wolfSSL_EVP_CIPHER_CTX_init
 */
-WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_ede3_ecb(void);
+const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_ede3_ecb(void);
 
 /*!
     \ingroup openSSL
@@ -43,7 +43,7 @@ WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_ede3_ecb(void);
 
     \sa wolfSSL_EVP_CIPHER_CTX_init
 */
-WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_cbc(void);
+const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_cbc(void);
 
 /*!
     \ingroup openSSL
@@ -77,7 +77,7 @@ WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_cbc(void);
     \sa wolfCrypt_Init
     \sa wolfSSL_EVP_MD_CTX_free
 */
-WOLFSSL_API int wolfSSL_EVP_DigestInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
+int wolfSSL_EVP_DigestInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
                                      const WOLFSSL_EVP_MD* type,
                                      WOLFSSL_ENGINE *impl);
 
@@ -122,7 +122,7 @@ WOLFSSL_API int wolfSSL_EVP_DigestInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
     \sa wolfCrypt_Init
     \sa wolfSSL_EVP_CIPHER_CTX_free
 */
-WOLFSSL_API int  wolfSSL_EVP_CipherInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
+int  wolfSSL_EVP_CipherInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
                                     const WOLFSSL_EVP_CIPHER* type,
                                     WOLFSSL_ENGINE *impl,
                                     const unsigned char* key,
@@ -163,7 +163,7 @@ WOLFSSL_API int  wolfSSL_EVP_CipherInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
     \sa wolfCrypt_Init
     \sa wolfSSL_EVP_CIPHER_CTX_free
 */
-WOLFSSL_API int  wolfSSL_EVP_EncryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
+int  wolfSSL_EVP_EncryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
                                     const WOLFSSL_EVP_CIPHER* type,
                                     WOLFSSL_ENGINE *impl,
                                     const unsigned char* key,
@@ -212,7 +212,7 @@ WOLFSSL_API int  wolfSSL_EVP_EncryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
     \sa wolfCrypt_Init
     \sa wolfSSL_EVP_CIPHER_CTX_free
 */
-WOLFSSL_API int  wolfSSL_EVP_DecryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
+int  wolfSSL_EVP_DecryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
                                     const WOLFSSL_EVP_CIPHER* type,
                                     WOLFSSL_ENGINE *impl,
                                     const unsigned char* key,
@@ -254,7 +254,7 @@ WOLFSSL_API int  wolfSSL_EVP_DecryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
     \sa wolfCrypt_Init
     \sa wolfSSL_EVP_CIPHER_CTX_free
 */
-WOLFSSL_API int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
+int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
                                    unsigned char *out, int *outl,
                                    const unsigned char *in, int inl);
 
@@ -286,7 +286,7 @@ WOLFSSL_API int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
 
     \sa wolfSSL_EVP_CIPHER_CTX_new
 */
-WOLFSSL_API int  wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
+int  wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
                                    unsigned char *out, int *outl);
 
 /*!
@@ -310,7 +310,7 @@ WOLFSSL_API int  wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
 
     \sa wolfSSL_EVP_CIPHER_flags
 */
-WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_set_key_length(WOLFSSL_EVP_CIPHER_CTX* ctx,
+int  wolfSSL_EVP_CIPHER_CTX_set_key_length(WOLFSSL_EVP_CIPHER_CTX* ctx,
                                                      int keylen);
 
 /*!
@@ -331,7 +331,7 @@ WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_set_key_length(WOLFSSL_EVP_CIPHER_CTX* c
 
     \sa wolfSSL_EVP_CIPHER_block_size
 */
-WOLFSSL_API int wolfSSL_EVP_CIPHER_CTX_block_size(const WOLFSSL_EVP_CIPHER_CTX *ctx);
+int wolfSSL_EVP_CIPHER_CTX_block_size(const WOLFSSL_EVP_CIPHER_CTX *ctx);
 
 /*!
     \ingroup openSSL
@@ -350,7 +350,7 @@ WOLFSSL_API int wolfSSL_EVP_CIPHER_CTX_block_size(const WOLFSSL_EVP_CIPHER_CTX *
 
     \sa wolfSSL_EVP_aes_256_ctr
 */
-WOLFSSL_API int wolfSSL_EVP_CIPHER_block_size(const WOLFSSL_EVP_CIPHER *cipher);
+int wolfSSL_EVP_CIPHER_block_size(const WOLFSSL_EVP_CIPHER *cipher);
 
 /*!
     \ingroup openSSL
@@ -373,7 +373,7 @@ WOLFSSL_API int wolfSSL_EVP_CIPHER_block_size(const WOLFSSL_EVP_CIPHER *cipher);
     \sa wolfSSL_EVP_CIPHER_flags
     \sa wolfSSL_EVP_CIPHER_CTX_flags
 */
-WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_set_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags);
+void wolfSSL_EVP_CIPHER_CTX_set_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags);
 
 /*!
     \ingroup openSSL
@@ -396,7 +396,7 @@ WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_set_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, i
     \sa wolfSSL_EVP_CIPHER_flags
     \sa wolfSSL_EVP_CIPHER_CTX_flags
 */
-WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_clear_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags);
+void wolfSSL_EVP_CIPHER_CTX_clear_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags);
 
 /*!
     \ingroup openSSL
@@ -418,7 +418,7 @@ WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_clear_flags(WOLFSSL_EVP_CIPHER_CTX *ctx,
 
     \sa wolfSSL_EVP_CIPHER_CTX_new
 */
-WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_set_padding(WOLFSSL_EVP_CIPHER_CTX *c, int pad);
+int  wolfSSL_EVP_CIPHER_CTX_set_padding(WOLFSSL_EVP_CIPHER_CTX *c, int pad);
 
 
 /*!
@@ -441,4 +441,4 @@ WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_set_padding(WOLFSSL_EVP_CIPHER_CTX *c, i
     \sa wolfSSL_EVP_CIPHER_CTX_new
     \sa wolfSSL_EVP_CIPHER_flags
 */
-WOLFSSL_API unsigned long wolfSSL_EVP_CIPHER_CTX_flags(const WOLFSSL_EVP_CIPHER_CTX *ctx);
+unsigned long wolfSSL_EVP_CIPHER_CTX_flags(const WOLFSSL_EVP_CIPHER_CTX *ctx);

--- a/doc/dox_comments/header_files/hash.h
+++ b/doc/dox_comments/header_files/hash.h
@@ -22,7 +22,7 @@
     \sa wc_HashGetDigestSize
     \sa wc_Hash
 */
-WOLFSSL_API int wc_HashGetOID(enum wc_HashType hash_type);
+int wc_HashGetOID(enum wc_HashType hash_type);
 
 /*!
     \ingroup wolfCrypt
@@ -50,7 +50,7 @@ WOLFSSL_API int wc_HashGetOID(enum wc_HashType hash_type);
 
     \sa wc_Hash
 */
-WOLFSSL_API int wc_HashGetDigestSize(enum wc_HashType hash_type);
+int wc_HashGetDigestSize(enum wc_HashType hash_type);
 
 /*!
     \ingroup wolfCrypt
@@ -81,7 +81,7 @@ WOLFSSL_API int wc_HashGetDigestSize(enum wc_HashType hash_type);
 
     \sa wc_HashGetDigestSize
 */
-WOLFSSL_API int wc_Hash(enum wc_HashType hash_type,
+int wc_Hash(enum wc_HashType hash_type,
     const byte* data, word32 data_len,
     byte* hash, word32 hash_len);
 
@@ -116,7 +116,7 @@ WOLFSSL_API int wc_Hash(enum wc_HashType hash_type,
     \sa wc_Md5Final
     \sa wc_InitMd5
 */
-WOLFSSL_API int wc_Md5Hash(const byte* data, word32 len, byte* hash);
+int wc_Md5Hash(const byte* data, word32 len, byte* hash);
 
 /*!
     \ingroup SHA
@@ -141,7 +141,7 @@ WOLFSSL_API int wc_Md5Hash(const byte* data, word32 len, byte* hash);
     \sa wc_ShaFinal
     \sa wc_InitSha
 */
-WOLFSSL_API int wc_ShaHash(const byte*, word32, byte*);
+int wc_ShaHash(const byte* data, word32 len, byte* hash);
 
 /*!
     \ingroup SHA
@@ -166,7 +166,7 @@ WOLFSSL_API int wc_ShaHash(const byte*, word32, byte*);
     \sa wc_Sha256Final
     \sa wc_InitSha256
 */
-WOLFSSL_API int wc_Sha256Hash(const byte*, word32, byte*);
+int wc_Sha256Hash(const byte* data, word32 len, byte* hash);
 
 /*!
     \ingroup SHA
@@ -190,7 +190,7 @@ WOLFSSL_API int wc_Sha256Hash(const byte*, word32, byte*);
     \sa wc_Sha224Update
     \sa wc_Sha224Final
 */
-WOLFSSL_API int wc_Sha224Hash(const byte*, word32, byte*);
+int wc_Sha224Hash(const byte* data, word32 len, byte* hash);
 
 /*!
     \ingroup SHA
@@ -215,7 +215,7 @@ WOLFSSL_API int wc_Sha224Hash(const byte*, word32, byte*);
     \sa wc_Sha512Final
     \sa wc_InitSha512
 */
-WOLFSSL_API int wc_Sha512Hash(const byte*, word32, byte*);
+int wc_Sha512Hash(const byte* data, word32 len, byte* hash);
 
 /*!
     \ingroup SHA
@@ -240,4 +240,4 @@ WOLFSSL_API int wc_Sha512Hash(const byte*, word32, byte*);
     \sa wc_Sha384Final
     \sa wc_InitSha384
 */
-WOLFSSL_API int wc_Sha384Hash(const byte*, word32, byte*);
+int wc_Sha384Hash(const byte* data, word32 len, byte* hash);

--- a/doc/dox_comments/header_files/hmac.h
+++ b/doc/dox_comments/header_files/hmac.h
@@ -34,7 +34,7 @@
     \sa wc_HmacUpdate
     \sa wc_HmacFinal
 */
-WOLFSSL_API int wc_HmacSetKey(Hmac*, int type, const byte* key, word32 keySz);
+int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 keySz);
 
 /*!
     \ingroup HMAC
@@ -70,7 +70,7 @@ WOLFSSL_API int wc_HmacSetKey(Hmac*, int type, const byte* key, word32 keySz);
     \sa wc_HmacSetKey
     \sa wc_HmacFinal
 */
-WOLFSSL_API int wc_HmacUpdate(Hmac*, const byte*, word32);
+int wc_HmacUpdate(Hmac* hmac, const byte* in, word32 sz);
 
 /*!
     \ingroup HMAC
@@ -101,7 +101,7 @@ WOLFSSL_API int wc_HmacUpdate(Hmac*, const byte*, word32);
     \sa wc_HmacSetKey
     \sa wc_HmacUpdate
 */
-WOLFSSL_API int wc_HmacFinal(Hmac*, byte*);
+int wc_HmacFinal(Hmac* hmac, byte* out);
 
 /*!
     \ingroup HMAC
@@ -121,7 +121,7 @@ WOLFSSL_API int wc_HmacFinal(Hmac*, byte*);
 
     \sa none
 */
-WOLFSSL_API int wolfSSL_GetHmacMaxSize(void);
+int wolfSSL_GetHmacMaxSize(void);
 
 /*!
     \ingroup HMAC
@@ -169,7 +169,7 @@ WOLFSSL_API int wolfSSL_GetHmacMaxSize(void);
 
     \sa wc_HmacSetKey
 */
-WOLFSSL_API int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
+int wc_HKDF(int type, const byte* inKey, word32 inKeySz,
                     const byte* salt, word32 saltSz,
                     const byte* info, word32 infoSz,
                     byte* out, word32 outSz);

--- a/doc/dox_comments/header_files/iotsafe.h
+++ b/doc/dox_comments/header_files/iotsafe.h
@@ -19,7 +19,7 @@
     \sa wolfIoTSafe_SetCSIM_read_cb
     \sa wolfIoTSafe_SetCSIM_write_cb
 */
-WOLFSSL_API int wolfSSL_CTX_iotsafe_enable(WOLFSSL_CTX *ctx);
+int wolfSSL_CTX_iotsafe_enable(WOLFSSL_CTX *ctx);
 
 
 /*!
@@ -61,7 +61,7 @@ WOLFSSL_API int wolfSSL_CTX_iotsafe_enable(WOLFSSL_CTX *ctx);
     \sa wolfSSL_iotsafe_on_ex
     \sa wolfSSL_CTX_iotsafe_enable
 */
-WOLFSSL_API int wolfSSL_iotsafe_on(WOLFSSL *ssl, byte privkey_id,
+int wolfSSL_iotsafe_on(WOLFSSL *ssl, byte privkey_id,
        byte ecdh_keypair_slot, byte peer_pubkey_slot, byte peer_cert_slot);
 
 
@@ -114,7 +114,7 @@ WOLFSSL_API int wolfSSL_iotsafe_on(WOLFSSL *ssl, byte privkey_id,
     \sa wolfSSL_iotsafe_on
     \sa wolfSSL_CTX_iotsafe_enable
 */
-WOLFSSL_API int wolfSSL_iotsafe_on_ex(WOLFSSL *ssl, byte *privkey_id,
+int wolfSSL_iotsafe_on_ex(WOLFSSL *ssl, byte *privkey_id,
        byte *ecdh_keypair_slot, byte *peer_pubkey_slot, byte *peer_cert_slot, word16 id_size);
 
 
@@ -141,7 +141,7 @@ WOLFSSL_API int wolfSSL_iotsafe_on_ex(WOLFSSL *ssl, byte *privkey_id,
 
     \sa wolfIoTSafe_SetCSIM_write_cb
 */
-WOLFSSL_API void wolfIoTSafe_SetCSIM_read_cb(wolfSSL_IOTSafe_CSIM_read_cb rf);
+void wolfIoTSafe_SetCSIM_read_cb(wolfSSL_IOTSafe_CSIM_read_cb rf);
 
 /*!
     \ingroup IoTSafe
@@ -161,7 +161,7 @@ WOLFSSL_API void wolfIoTSafe_SetCSIM_read_cb(wolfSSL_IOTSafe_CSIM_read_cb rf);
 
     \sa wolfIoTSafe_SetCSIM_read_cb
 */
-WOLFSSL_API void wolfIoTSafe_SetCSIM_write_cb(wolfSSL_IOTSafe_CSIM_write_cb wf);
+void wolfIoTSafe_SetCSIM_write_cb(wolfSSL_IOTSafe_CSIM_write_cb wf);
 
 
 
@@ -175,7 +175,7 @@ WOLFSSL_API void wolfIoTSafe_SetCSIM_write_cb(wolfSSL_IOTSafe_CSIM_write_cb wf);
     \return 0 upon success
 
 */
-WOLFSSL_API int wolfIoTSafe_GetRandom(unsigned char* out, word32 sz);
+int wolfIoTSafe_GetRandom(unsigned char* out, word32 sz);
 
 
 /*!
@@ -211,7 +211,7 @@ WOLFSSL_API int wolfIoTSafe_GetRandom(unsigned char* out, word32 sz);
     \endcode
 
 */
-WOLFSSL_API int wolfIoTSafe_GetCert(uint8_t id, unsigned char *output, unsigned long sz);
+int wolfIoTSafe_GetCert(uint8_t id, unsigned char *output, unsigned long sz);
 
 
 /*!
@@ -254,7 +254,7 @@ WOLFSSL_API int wolfIoTSafe_GetCert(uint8_t id, unsigned char *output, unsigned 
     \endcode
 
 */
-WOLFSSL_API int wolfIoTSafe_GetCert_ex(uint8_t *id, uint16_t id_sz, unsigned char *output, unsigned long sz);
+int wolfIoTSafe_GetCert_ex(uint8_t *id, uint16_t id_sz, unsigned char *output, unsigned long sz);
 
 /*!
     \ingroup IoTSafe
@@ -271,7 +271,7 @@ WOLFSSL_API int wolfIoTSafe_GetCert_ex(uint8_t *id, uint16_t id_sz, unsigned cha
     \sa wc_iotsafe_ecc_export_private
 
 */
-WOLFSSL_API int wc_iotsafe_ecc_import_public(ecc_key *key, byte key_id);
+int wc_iotsafe_ecc_import_public(ecc_key *key, byte key_id);
 
 /*!
     \ingroup IoTSafe
@@ -286,7 +286,7 @@ WOLFSSL_API int wc_iotsafe_ecc_import_public(ecc_key *key, byte key_id);
     \sa wc_iotsafe_ecc_export_private
 
 */
-WOLFSSL_API int wc_iotsafe_ecc_export_public(ecc_key *key, byte key_id);
+int wc_iotsafe_ecc_export_public(ecc_key *key, byte key_id);
 
 
 /*!
@@ -306,7 +306,7 @@ WOLFSSL_API int wc_iotsafe_ecc_export_public(ecc_key *key, byte key_id);
     \sa wc_iotsafe_ecc_export_private
 
 */
-WOLFSSL_API int wc_iotsafe_ecc_import_public_ex(ecc_key *key, byte *key_id, word16 id_size);
+int wc_iotsafe_ecc_import_public_ex(ecc_key *key, byte *key_id, word16 id_size);
 
 /*!
     \ingroup IoTSafe
@@ -322,7 +322,7 @@ WOLFSSL_API int wc_iotsafe_ecc_import_public_ex(ecc_key *key, byte *key_id, word
     \sa wc_iotsafe_ecc_export_public
 
 */
-WOLFSSL_API int wc_iotsafe_ecc_export_private(ecc_key *key, byte key_id);
+int wc_iotsafe_ecc_export_private(ecc_key *key, byte key_id);
 
 /*!
     \ingroup IoTSafe
@@ -342,7 +342,7 @@ WOLFSSL_API int wc_iotsafe_ecc_export_private(ecc_key *key, byte key_id);
     \sa wc_iotsafe_ecc_export_public
 
 */
-WOLFSSL_API int wc_iotsafe_ecc_export_private_ex(ecc_key *key, byte *key_id, word16 id_size);
+int wc_iotsafe_ecc_export_private_ex(ecc_key *key, byte *key_id, word16 id_size);
 
 /*!
     \ingroup IoTSafe
@@ -363,7 +363,7 @@ WOLFSSL_API int wc_iotsafe_ecc_export_private_ex(ecc_key *key, byte *key_id, wor
     \sa wc_iotsafe_ecc_gen_k
 
 */
-WOLFSSL_API int wc_iotsafe_ecc_sign_hash(byte *in, word32 inlen, byte *out, word32 *outlen, byte key_id);
+int wc_iotsafe_ecc_sign_hash(byte *in, word32 inlen, byte *out, word32 *outlen, byte key_id);
 
 /*!
     \ingroup IoTSafe
@@ -386,7 +386,7 @@ WOLFSSL_API int wc_iotsafe_ecc_sign_hash(byte *in, word32 inlen, byte *out, word
     \sa wc_iotsafe_ecc_gen_k
 
 */
-WOLFSSL_API int wc_iotsafe_ecc_sign_hash_ex(byte *in, word32 inlen, byte *out, word32 *outlen, byte *key_id, word16 id_size);
+int wc_iotsafe_ecc_sign_hash_ex(byte *in, word32 inlen, byte *out, word32 *outlen, byte *key_id, word16 id_size);
 
 /*!
     \ingroup IoTSafe
@@ -408,7 +408,7 @@ WOLFSSL_API int wc_iotsafe_ecc_sign_hash_ex(byte *in, word32 inlen, byte *out, w
     \sa wc_iotsafe_ecc_gen_k
 
 */
-WOLFSSL_API int wc_iotsafe_ecc_verify_hash(byte *sig, word32 siglen, byte *hash, word32 hashlen, int *res, byte key_id);
+int wc_iotsafe_ecc_verify_hash(byte *sig, word32 siglen, byte *hash, word32 hashlen, int *res, byte key_id);
 
 /*!
     \ingroup IoTSafe
@@ -433,7 +433,7 @@ WOLFSSL_API int wc_iotsafe_ecc_verify_hash(byte *sig, word32 siglen, byte *hash,
     \sa wc_iotsafe_ecc_gen_k
 
 */
-WOLFSSL_API int wc_iotsafe_ecc_verify_hash_ex(byte *sig, word32 siglen, byte *hash, word32 hashlen, int *res, byte *key_id, word16 id_size);
+int wc_iotsafe_ecc_verify_hash_ex(byte *sig, word32 siglen, byte *hash, word32 hashlen, int *res, byte *key_id, word16 id_size);
 
 /*!
     \ingroup IoTSafe
@@ -446,7 +446,7 @@ WOLFSSL_API int wc_iotsafe_ecc_verify_hash_ex(byte *sig, word32 siglen, byte *ha
     \sa wc_iotsafe_ecc_sign_hash
     \sa wc_iotsafe_ecc_verify_hash
 */
-WOLFSSL_API int wc_iotsafe_ecc_gen_k(byte key_id);
+int wc_iotsafe_ecc_gen_k(byte key_id);
 
 /*!
     \ingroup IoTSafe
@@ -462,4 +462,4 @@ WOLFSSL_API int wc_iotsafe_ecc_gen_k(byte key_id);
     \sa wc_iotsafe_ecc_sign_hash_ex
     \sa wc_iotsafe_ecc_verify_hash_ex
 */
-WOLFSSL_API int wc_iotsafe_ecc_gen_k(byte key_id);
+int wc_iotsafe_ecc_gen_k(byte key_id);

--- a/doc/dox_comments/header_files/logging.h
+++ b/doc/dox_comments/header_files/logging.h
@@ -32,7 +32,7 @@
     \sa wolfSSL_Debugging_ON
     \sa wolfSSL_Debugging_OFF
 */
-WOLFSSL_API int wolfSSL_SetLoggingCb(wolfSSL_Logging_cb log_function);
+int wolfSSL_SetLoggingCb(wolfSSL_Logging_cb log_function);
 
 /*!
     \ingroup Debug
@@ -55,7 +55,7 @@ WOLFSSL_API int wolfSSL_SetLoggingCb(wolfSSL_Logging_cb log_function);
     \sa wolfSSL_Debugging_OFF
     \sa wolfSSL_SetLoggingCb
 */
-WOLFSSL_API int  wolfSSL_Debugging_ON(void);
+int  wolfSSL_Debugging_ON(void);
 
 /*!
     \ingroup Debug
@@ -75,4 +75,4 @@ WOLFSSL_API int  wolfSSL_Debugging_ON(void);
     \sa wolfSSL_Debugging_ON
     \sa wolfSSL_SetLoggingCb
 */
-WOLFSSL_API void wolfSSL_Debugging_OFF(void);
+void wolfSSL_Debugging_OFF(void);

--- a/doc/dox_comments/header_files/md2.h
+++ b/doc/dox_comments/header_files/md2.h
@@ -24,7 +24,7 @@
     \sa wc_Md2Update
     \sa wc_Md2Final
 */
-WOLFSSL_API void wc_InitMd2(Md2*);
+void wc_InitMd2(Md2*);
 
 /*!
     \ingroup MD2
@@ -57,7 +57,7 @@ WOLFSSL_API void wc_InitMd2(Md2*);
     \sa wc_Md2Final
     \sa wc_InitMd2
 */
-WOLFSSL_API void wc_Md2Update(Md2*, const byte*, word32);
+void wc_Md2Update(Md2* md2, const byte* data, word32 len);
 
 /*!
     \ingroup MD2
@@ -88,7 +88,7 @@ WOLFSSL_API void wc_Md2Update(Md2*, const byte*, word32);
     \sa wc_Md2Final
     \sa wc_InitMd2
 */
-WOLFSSL_API void wc_Md2Final(Md2*, byte*);
+void wc_Md2Final(Md2* md2, byte* hash);
 
 /*!
     \ingroup MD2
@@ -113,4 +113,4 @@ WOLFSSL_API void wc_Md2Final(Md2*, byte*);
     \sa wc_Md2Final
     \sa wc_InitMd2
 */
-WOLFSSL_API int  wc_Md2Hash(const byte*, word32, byte*);
+int  wc_Md2Hash(const byte* data, word32 len, byte* hash);

--- a/doc/dox_comments/header_files/md4.h
+++ b/doc/dox_comments/header_files/md4.h
@@ -24,7 +24,7 @@
     \sa wc_Md4Update
     \sa wc_Md4Final
 */
-WOLFSSL_API void wc_InitMd4(Md4*);
+void wc_InitMd4(Md4*);
 
 /*!
     \ingroup MD4
@@ -57,7 +57,7 @@ WOLFSSL_API void wc_InitMd4(Md4*);
     \sa wc_Md4Final
     \sa wc_InitMd4
 */
-WOLFSSL_API void wc_Md4Update(Md4*, const byte*, word32);
+void wc_Md4Update(Md4* md4, const byte* data, word32 len);
 
 /*!
     \ingroup MD4
@@ -85,4 +85,4 @@ WOLFSSL_API void wc_Md4Update(Md4*, const byte*, word32);
     \sa wc_Md4Final
     \sa wc_InitMd4
 */
-WOLFSSL_API void wc_Md4Final(Md4*, byte*);
+void wc_Md4Final(Md4* md4, byte* hash);

--- a/doc/dox_comments/header_files/md5.h
+++ b/doc/dox_comments/header_files/md5.h
@@ -33,7 +33,7 @@
     \sa wc_Md5Update
     \sa wc_Md5Final
 */
-WOLFSSL_API int wc_InitMd5(wc_Md5*);
+int wc_InitMd5(wc_Md5*);
 
 /*!
     \ingroup MD5
@@ -75,7 +75,7 @@ WOLFSSL_API int wc_InitMd5(wc_Md5*);
     \sa wc_Md5Final
     \sa wc_InitMd5
 */
-WOLFSSL_API int wc_Md5Update(wc_Md5*, const byte*, word32);
+int wc_Md5Update(wc_Md5* md5, const byte* data, word32 len);
 
 /*!
     \ingroup MD5
@@ -116,7 +116,7 @@ WOLFSSL_API int wc_Md5Update(wc_Md5*, const byte*, word32);
     \sa wc_InitMd5
     \sa wc_Md5GetHash
 */
-WOLFSSL_API int wc_Md5Final(wc_Md5*, byte*);
+int wc_Md5Final(wc_Md5* md5, byte* hash);
 
 /*!
     \ingroup MD5
@@ -148,7 +148,7 @@ WOLFSSL_API int wc_Md5Final(wc_Md5*, byte*);
     \sa wc_Md5Update
     \sa wc_Md5Final
 */
-WOLFSSL_API void wc_Md5Free(wc_Md5*);
+void wc_Md5Free(wc_Md5*);
 
 /*!
     \ingroup MD5
@@ -177,4 +177,4 @@ WOLFSSL_API void wc_Md5Free(wc_Md5*);
     \sa wc_Md5Final
     \sa wc_InitMd5
 */
-WOLFSSL_API int  wc_Md5GetHash(wc_Md5*, byte*);
+int  wc_Md5GetHash(wc_Md5* md5, byte* hash);

--- a/doc/dox_comments/header_files/memory.h
+++ b/doc/dox_comments/header_files/memory.h
@@ -29,7 +29,7 @@
     \sa XFREE
     \sa XREALLOC
 */
-WOLFSSL_API void* wolfSSL_Malloc(size_t size, void* heap, int type);
+void* wolfSSL_Malloc(size_t size, void* heap, int type);
 
 /*!
     \ingroup Memory
@@ -65,7 +65,7 @@ WOLFSSL_API void* wolfSSL_Malloc(size_t size, void* heap, int type);
     \sa XFREE
     \sa XREALLOC
 */
-WOLFSSL_API void  wolfSSL_Free(void *ptr, void* heap, int type);
+void  wolfSSL_Free(void *ptr, void* heap, int type);
 
 /*!
     \ingroup Memory
@@ -101,7 +101,7 @@ WOLFSSL_API void  wolfSSL_Free(void *ptr, void* heap, int type);
     \sa XFREE
     \sa XREALLOC
 */
-WOLFSSL_API void* wolfSSL_Realloc(void *ptr, size_t size, void* heap, int type);
+void* wolfSSL_Realloc(void *ptr, size_t size, void* heap, int type);
 
 /*!
     \ingroup Memory
@@ -148,7 +148,7 @@ WOLFSSL_API void* wolfSSL_Realloc(void *ptr, size_t size, void* heap, int type);
 
     \sa none
 */
-WOLFSSL_API int wolfSSL_SetAllocators(wolfSSL_Malloc_cb,
+int wolfSSL_SetAllocators(wolfSSL_Malloc_cb,
                                       wolfSSL_Free_cb,
                                       wolfSSL_Realloc_cb);
 
@@ -184,7 +184,7 @@ WOLFSSL_API int wolfSSL_SetAllocators(wolfSSL_Malloc_cb,
     \sa wolfSSL_Malloc
     \sa wolfSSL_Free
 */
-WOLFSSL_API int wolfSSL_StaticBufferSz(byte* buffer, word32 sz, int flag);
+int wolfSSL_StaticBufferSz(byte* buffer, word32 sz, int flag);
 
 /*!
     \ingroup Memory
@@ -216,4 +216,4 @@ WOLFSSL_API int wolfSSL_StaticBufferSz(byte* buffer, word32 sz, int flag);
     \sa wolfSSL_Malloc
     \sa wolfSSL_Free
 */
-WOLFSSL_API int wolfSSL_MemoryPaddingSz(void);
+int wolfSSL_MemoryPaddingSz(void);

--- a/doc/dox_comments/header_files/pem.h
+++ b/doc/dox_comments/header_files/pem.h
@@ -27,7 +27,7 @@
 
     \sa wolfSSL_PEM_read_bio_X509_AUX
 */
-WOLFSSL_API
+
 int wolfSSL_PEM_write_bio_PrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key,
                                         const WOLFSSL_EVP_CIPHER* cipher,
                                         unsigned char* passwd, int len,

--- a/doc/dox_comments/header_files/pkcs11.h
+++ b/doc/dox_comments/header_files/pkcs11.h
@@ -1,43 +1,43 @@
 /*!
     \ingroup PKCS11
 */
-WOLFSSL_API int wc_Pkcs11_Initialize(Pkcs11Dev* dev, const char* library,
+int wc_Pkcs11_Initialize(Pkcs11Dev* dev, const char* library,
                                      void* heap);
 
 /*!
     \ingroup PKCS11
 */
-WOLFSSL_API void wc_Pkcs11_Finalize(Pkcs11Dev* dev);
+void wc_Pkcs11_Finalize(Pkcs11Dev* dev);
 
 /*!
     \ingroup PKCS11
 */
-WOLFSSL_API int wc_Pkcs11Token_Init(Pkcs11Token* token, Pkcs11Dev* dev,
+int wc_Pkcs11Token_Init(Pkcs11Token* token, Pkcs11Dev* dev,
     int slotId, const char* tokenName, const unsigned char *userPin,
     int userPinSz);
 
 /*!
     \ingroup PKCS11
 */
-WOLFSSL_API void wc_Pkcs11Token_Final(Pkcs11Token* token);
+void wc_Pkcs11Token_Final(Pkcs11Token* token);
 
 /*!
     \ingroup PKCS11
  */
-WOLFSSL_API int wc_Pkcs11Token_Open(Pkcs11Token* token, int readWrite);
+int wc_Pkcs11Token_Open(Pkcs11Token* token, int readWrite);
 
 /*!
     \ingroup PKCS11
  */
-WOLFSSL_API void wc_Pkcs11Token_Close(Pkcs11Token* token);
+void wc_Pkcs11Token_Close(Pkcs11Token* token);
 
 /*!
     \ingroup PKCS11
  */
-WOLFSSL_API int wc_Pkcs11StoreKey(Pkcs11Token* token, int type, int clear,
+int wc_Pkcs11StoreKey(Pkcs11Token* token, int type, int clear,
 
 /*!
     \ingroup PKCS11
  */
-WOLFSSL_API int wc_Pkcs11_CryptoDevCb(int devId, wc_CryptoInfo* info,
+int wc_Pkcs11_CryptoDevCb(int devId, wc_CryptoInfo* info,
     void* ctx);

--- a/doc/dox_comments/header_files/pkcs7.h
+++ b/doc/dox_comments/header_files/pkcs7.h
@@ -55,7 +55,7 @@
 
     \sa wc_PKCS7_Free
 */
-WOLFSSL_API int  wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* cert, word32 certSz);
+int  wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* cert, word32 certSz);
 
 /*!
     \ingroup PKCS7
@@ -76,7 +76,7 @@ WOLFSSL_API int  wc_PKCS7_InitWithCert(PKCS7* pkcs7, byte* cert, word32 certSz);
 
     \sa wc_PKCS7_InitWithCert
 */
-WOLFSSL_API void wc_PKCS7_Free(PKCS7* pkcs7);
+void wc_PKCS7_Free(PKCS7* pkcs7);
 
 /*!
     \ingroup PKCS7
@@ -119,7 +119,7 @@ WOLFSSL_API void wc_PKCS7_Free(PKCS7* pkcs7);
 
     \sa wc_PKCS7_InitWithCert
 */
-WOLFSSL_API int  wc_PKCS7_EncodeData(PKCS7* pkcs7, byte* output,
+int  wc_PKCS7_EncodeData(PKCS7* pkcs7, byte* output,
                                        word32 outputSz);
 
 /*!
@@ -197,7 +197,7 @@ WOLFSSL_API int  wc_PKCS7_EncodeData(PKCS7* pkcs7, byte* output,
     \sa wc_PKCS7_InitWithCert
     \sa wc_PKCS7_VerifySignedData
 */
-WOLFSSL_API int  wc_PKCS7_EncodeSignedData(PKCS7* pkcs7,
+int  wc_PKCS7_EncodeSignedData(PKCS7* pkcs7,
                                        byte* output, word32 outputSz);
 
 /*!
@@ -297,7 +297,7 @@ WOLFSSL_API int  wc_PKCS7_EncodeSignedData(PKCS7* pkcs7,
     \sa wc_PKCS7_InitWithCert
     \sa wc_PKCS7_VerifySignedData_ex
 */
-WOLFSSL_API int wc_PKCS7_EncodeSignedData_ex(PKCS7* pkcs7, const byte* hashBuf, 
+int wc_PKCS7_EncodeSignedData_ex(PKCS7* pkcs7, const byte* hashBuf, 
     word32 hashSz, byte* outputHead, word32* outputHeadSz, byte* outputFoot, 
     word32* outputFootSz);
 
@@ -375,7 +375,7 @@ WOLFSSL_API int wc_PKCS7_EncodeSignedData_ex(PKCS7* pkcs7, const byte* hashBuf,
     \sa wc_PKCS7_InitWithCert
     \sa wc_PKCS7_EncodeSignedData
 */
-WOLFSSL_API int  wc_PKCS7_VerifySignedData(PKCS7* pkcs7,
+int  wc_PKCS7_VerifySignedData(PKCS7* pkcs7,
                                        byte* pkiMsg, word32 pkiMsgSz);
 
 
@@ -475,7 +475,7 @@ WOLFSSL_API int  wc_PKCS7_VerifySignedData(PKCS7* pkcs7,
     \sa wc_PKCS7_InitWithCert
     \sa wc_PKCS7_EncodeSignedData_ex
 */
-WOLFSSL_API int wc_PKCS7_VerifySignedData_ex(PKCS7* pkcs7, const byte* hashBuf, 
+int wc_PKCS7_VerifySignedData_ex(PKCS7* pkcs7, const byte* hashBuf, 
     word32 hashSz, byte* pkiMsgHead, word32 pkiMsgHeadSz, byte* pkiMsgFoot, 
     word32 pkiMsgFootSz);
 
@@ -530,7 +530,7 @@ WOLFSSL_API int wc_PKCS7_VerifySignedData_ex(PKCS7* pkcs7, const byte* hashBuf,
     \sa wc_PKCS7_InitWithCert
     \sa wc_PKCS7_DecodeEnvelopedData
 */
-WOLFSSL_API int  wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7,
+int  wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7,
                                           byte* output, word32 outputSz);
 
 /*!
@@ -608,6 +608,6 @@ WOLFSSL_API int  wc_PKCS7_EncodeEnvelopedData(PKCS7* pkcs7,
     \sa wc_PKCS7_InitWithCert
     \sa wc_PKCS7_EncodeEnvelopedData
 */
-WOLFSSL_API int  wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
+int  wc_PKCS7_DecodeEnvelopedData(PKCS7* pkcs7, byte* pkiMsg,
                                           word32 pkiMsgSz, byte* output,
                                           word32 outputSz);

--- a/doc/dox_comments/header_files/poly1305.h
+++ b/doc/dox_comments/header_files/poly1305.h
@@ -24,7 +24,7 @@
     \sa wc_Poly1305Update
     \sa wc_Poly1305Final
 */
-WOLFSSL_API int wc_Poly1305SetKey(Poly1305* poly1305, const byte* key,
+int wc_Poly1305SetKey(Poly1305* poly1305, const byte* key,
                                   word32 kySz);
 
 /*!
@@ -58,7 +58,7 @@ WOLFSSL_API int wc_Poly1305SetKey(Poly1305* poly1305, const byte* key,
     \sa wc_Poly1305SetKey
     \sa wc_Poly1305Final
 */
-WOLFSSL_API int wc_Poly1305Update(Poly1305* poly1305, const byte*, word32);
+int wc_Poly1305Update(Poly1305* poly1305, const byte* m, word32 bytes);
 
 /*!
     \ingroup Poly1305
@@ -93,7 +93,7 @@ WOLFSSL_API int wc_Poly1305Update(Poly1305* poly1305, const byte*, word32);
     \sa wc_Poly1305SetKey
     \sa wc_Poly1305Update
 */
-WOLFSSL_API int wc_Poly1305Final(Poly1305* poly1305, byte* tag);
+int wc_Poly1305Final(Poly1305* poly1305, byte* tag);
 
 /*!
     \ingroup Poly1305
@@ -135,5 +135,5 @@ WOLFSSL_API int wc_Poly1305Final(Poly1305* poly1305, byte* tag);
     \sa wc_Poly1305Update
     \sa wcPoly1305Final
 */
-WOLFSSL_API int wc_Poly1305_MAC(Poly1305* ctx, byte* additional, word32 addSz,
+int wc_Poly1305_MAC(Poly1305* ctx, byte* additional, word32 addSz,
                                byte* input, word32 sz, byte* tag, word32 tagSz);

--- a/doc/dox_comments/header_files/psa.h
+++ b/doc/dox_comments/header_files/psa.h
@@ -20,7 +20,7 @@
 
     \sa wolfSSL_set_psa_ctx
 */
-WOLFSSL_API int wolfSSL_CTX_psa_enable(WOLFSSL_CTX *ctx);
+int wolfSSL_CTX_psa_enable(WOLFSSL_CTX *ctx);
 
 /*!
     \ingroup PSA
@@ -52,7 +52,7 @@ WOLFSSL_API int wolfSSL_CTX_psa_enable(WOLFSSL_CTX *ctx);
     \sa wolfSSL_psa_set_private_key_id
     \sa wolfSSL_psa_free_psa_ctx
 */
-WOLFSSL_API int wolfSSL_set_psa_ctx(WOLFSSL *ssl, struct psa_ssl_ctx *ctx);
+int wolfSSL_set_psa_ctx(WOLFSSL *ssl, struct psa_ssl_ctx *ctx);
 
 /*!
     \ingroup PSA
@@ -62,7 +62,7 @@ WOLFSSL_API int wolfSSL_set_psa_ctx(WOLFSSL *ssl, struct psa_ssl_ctx *ctx);
 
     \sa wolfSSL_set_psa_ctx
 */
-WOLFSSL_API void wolfSSL_free_psa_ctx(struct psa_ssl_ctx *ctx);
+void wolfSSL_free_psa_ctx(struct psa_ssl_ctx *ctx);
 
 /*!
     \ingroup PSA
@@ -92,5 +92,5 @@ WOLFSSL_API void wolfSSL_free_psa_ctx(struct psa_ssl_ctx *ctx);
     \sa wolfSSL_set_psa_ctx
 */
 
-WOLFSSL_API int wolfSSL_psa_set_private_key_id(struct psa_ssl_ctx *ctx,
+int wolfSSL_psa_set_private_key_id(struct psa_ssl_ctx *ctx,
                                                psa_key_id_t id);

--- a/doc/dox_comments/header_files/pwdbased.h
+++ b/doc/dox_comments/header_files/pwdbased.h
@@ -43,7 +43,7 @@
     \sa wc_PBKDF2
     \sa wc_PKCS12_PBKDF
 */
-WOLFSSL_API int wc_PBKDF1(byte* output, const byte* passwd, int pLen,
+int wc_PBKDF1(byte* output, const byte* passwd, int pLen,
                       const byte* salt, int sLen, int iterations, int kLen,
                       int typeH);
 
@@ -92,7 +92,7 @@ WOLFSSL_API int wc_PBKDF1(byte* output, const byte* passwd, int pLen,
     \sa wc_PBKDF1
     \sa wc_PKCS12_PBKDF
 */
-WOLFSSL_API int wc_PBKDF2(byte* output, const byte* passwd, int pLen,
+int wc_PBKDF2(byte* output, const byte* passwd, int pLen,
                       const byte* salt, int sLen, int iterations, int kLen,
                       int typeH);
 
@@ -161,6 +161,6 @@ WOLFSSL_API int wc_PBKDF2(byte* output, const byte* passwd, int pLen,
     \sa wc_PBKDF1
     \sa wc_PBKDF2
 */
-WOLFSSL_API int wc_PKCS12_PBKDF(byte* output, const byte* passwd, int pLen,
+int wc_PKCS12_PBKDF(byte* output, const byte* passwd, int pLen,
                             const byte* salt, int sLen, int iterations,
                             int kLen, int typeH, int purpose);

--- a/doc/dox_comments/header_files/random.h
+++ b/doc/dox_comments/header_files/random.h
@@ -24,7 +24,7 @@
 
     \sa wc_FreeNetRandom
 */
-WOLFSSL_API int  wc_InitNetRandom(const char*, wnr_hmac_key, int);
+int  wc_InitNetRandom(const char* configFile, wnr_hmac_key hmac_cb, int timeout);
 
 /*!
     \ingroup Random
@@ -47,7 +47,7 @@ WOLFSSL_API int  wc_InitNetRandom(const char*, wnr_hmac_key, int);
 
     \sa wc_InitNetRandom
 */
-WOLFSSL_API int  wc_FreeNetRandom(void);
+int  wc_FreeNetRandom(void);
 
 /*!
     \ingroup Random
@@ -95,7 +95,7 @@ WOLFSSL_API int  wc_FreeNetRandom(void);
     \sa wc_FreeRng
     \sa wc_RNG_HealthTest
 */
-WOLFSSL_API int  wc_InitRng(WC_RNG*);
+int  wc_InitRng(WC_RNG*);
 
 /*!
     \ingroup Random
@@ -135,7 +135,7 @@ WOLFSSL_API int  wc_InitRng(WC_RNG*);
     \sa wc_FreeRng
     \sa wc_RNG_HealthTest
 */
-WOLFSSL_API int  wc_RNG_GenerateBlock(WC_RNG*, byte*, word32 sz);
+int  wc_RNG_GenerateBlock(WC_RNG* rng, byte* b, word32 sz);
 
 /*!
     \ingroup Random
@@ -167,7 +167,7 @@ WOLFSSL_API int  wc_RNG_GenerateBlock(WC_RNG*, byte*, word32 sz);
     \sa wc_FreeRng
     \sa wc_RNG_HealthTest
 */
-WOLFSSL_API WC_RNG* wc_rng_new(byte* nonce, word32 nonceSz, void* heap)
+WC_RNG* wc_rng_new(byte* nonce, word32 nonceSz, void* heap)
 
 /*!
     \ingroup Random
@@ -207,7 +207,7 @@ WOLFSSL_API WC_RNG* wc_rng_new(byte* nonce, word32 nonceSz, void* heap)
     \sa wc_FreeRng
     \sa wc_RNG_HealthTest
 */
-WOLFSSL_API int  wc_RNG_GenerateByte(WC_RNG*, byte*);
+int  wc_RNG_GenerateByte(WC_RNG* rng, byte* b);
 
 /*!
     \ingroup Random
@@ -241,7 +241,7 @@ WOLFSSL_API int  wc_RNG_GenerateByte(WC_RNG*, byte*);
     \sa wc_RNG_GenerateByte,
     \sa wc_RNG_HealthTest
 */
-WOLFSSL_API int  wc_FreeRng(WC_RNG*);
+int  wc_FreeRng(WC_RNG*);
 
 /*!
     \ingroup Random
@@ -271,7 +271,7 @@ WOLFSSL_API int  wc_FreeRng(WC_RNG*);
     \sa wc_FreeRng
     \sa wc_RNG_HealthTest
 */
-WOLFSSL_API WC_RNG* wc_rng_free(WC_RNG* rng);
+WC_RNG* wc_rng_free(WC_RNG* rng);
 
 /*!
     \ingroup Random
@@ -322,7 +322,7 @@ WOLFSSL_API WC_RNG* wc_rng_free(WC_RNG* rng);
     \sa wc_RNG_GenerateByte
     \sa wc_FreeRng
 */
-WOLFSSL_API int wc_RNG_HealthTest(int reseed,
+int wc_RNG_HealthTest(int reseed,
                                         const byte* entropyA, word32 entropyASz,
                                         const byte* entropyB, word32 entropyBSz,
                                         byte* output, word32 outputSz);

--- a/doc/dox_comments/header_files/ripemd.h
+++ b/doc/dox_comments/header_files/ripemd.h
@@ -23,7 +23,7 @@
     \sa wc_RipeMdUpdate
     \sa wc_RipeMdFinal
 */
-WOLFSSL_API int wc_InitRipeMd(RipeMd*);
+int wc_InitRipeMd(RipeMd*);
 
 /*!
     \ingroup RIPEMD
@@ -59,7 +59,7 @@ WOLFSSL_API int wc_InitRipeMd(RipeMd*);
     \sa wc_InitRipeMd
     \sa wc_RipeMdFinal
 */
-WOLFSSL_API int wc_RipeMdUpdate(RipeMd*, const byte*, word32);
+int wc_RipeMdUpdate(RipeMd* ripemd, const byte* data, word32 len);
 
 /*!
     \ingroup RIPEMD
@@ -100,4 +100,4 @@ WOLFSSL_API int wc_RipeMdUpdate(RipeMd*, const byte*, word32);
 
     \sa none
 */
-WOLFSSL_API int wc_RipeMdFinal(RipeMd*, byte*);
+int wc_RipeMdFinal(RipeMd* ripemd, byte* hash);

--- a/doc/dox_comments/header_files/rsa.h
+++ b/doc/dox_comments/header_files/rsa.h
@@ -31,7 +31,7 @@
     \sa wc_FreeRsaKey
     \sa wc_RsaSetRNG
 */
-WOLFSSL_API int  wc_InitRsaKey(RsaKey* key, void* heap);
+int  wc_InitRsaKey(RsaKey* key, void* heap);
 
 /*!
     \ingroup RSA
@@ -81,7 +81,7 @@ WOLFSSL_API int  wc_InitRsaKey(RsaKey* key, void* heap);
     \sa wc_FreeRsaKey
     \sa wc_RsaSetRNG
 */
-WOLFSSL_API int  wc_InitRsaKey_Id(RsaKey* key, unsigned char* id, int len,
+int  wc_InitRsaKey_Id(RsaKey* key, unsigned char* id, int len,
         void* heap, int devId);
 
 /*!
@@ -109,7 +109,7 @@ WOLFSSL_API int  wc_InitRsaKey_Id(RsaKey* key, unsigned char* id, int len,
     \sa wc_InitRsaKey
     \sa wc_RsaSetRNG
 */
-WOLFSSL_API int wc_RsaSetRNG(RsaKey* key, WC_RNG* rng);
+int wc_RsaSetRNG(RsaKey* key, WC_RNG* rng);
 
 /*!
     \ingroup RSA
@@ -131,7 +131,7 @@ WOLFSSL_API int wc_RsaSetRNG(RsaKey* key, WC_RNG* rng);
 
     \sa wc_InitRsaKey
 */
-WOLFSSL_API int  wc_FreeRsaKey(RsaKey* key);
+int  wc_FreeRsaKey(RsaKey* key);
 
 /*!
     \ingroup RSA
@@ -203,7 +203,7 @@ WOLFSSL_API int  wc_FreeRsaKey(RsaKey* key);
 
     \sa wc_RsaPrivateDecrypt
 */
-WOLFSSL_API int  wc_RsaPublicEncrypt(const byte* in, word32 inLen, byte* out,
+int  wc_RsaPublicEncrypt(const byte* in, word32 inLen, byte* out,
                                  word32 outLen, RsaKey* key, WC_RNG* rng);
 
 /*!
@@ -227,7 +227,7 @@ WOLFSSL_API int  wc_RsaPublicEncrypt(const byte* in, word32 inLen, byte* out,
 
     \sa wc_RsaPrivateDecrypt
 */
-WOLFSSL_API int  wc_RsaPrivateDecryptInline(byte* in, word32 inLen, byte** out,
+int  wc_RsaPrivateDecryptInline(byte* in, word32 inLen, byte** out,
                                         RsaKey* key);
 
 /*!
@@ -261,7 +261,7 @@ WOLFSSL_API int  wc_RsaPrivateDecryptInline(byte* in, word32 inLen, byte** out,
     \sa wc_RsaFunction
     \sa wc_RsaPrivateDecryptInline
 */
-WOLFSSL_API int  wc_RsaPrivateDecrypt(const byte* in, word32 inLen, byte* out,
+int  wc_RsaPrivateDecrypt(const byte* in, word32 inLen, byte* out,
                                   word32 outLen, RsaKey* key);
 
 /*!
@@ -294,7 +294,7 @@ WOLFSSL_API int  wc_RsaPrivateDecrypt(const byte* in, word32 inLen, byte* out,
 
     \sa wc_RsaPad
 */
-WOLFSSL_API int  wc_RsaSSL_Sign(const byte* in, word32 inLen, byte* out,
+int  wc_RsaSSL_Sign(const byte* in, word32 inLen, byte* out,
                             word32 outLen, RsaKey* key, WC_RNG* rng);
 
 /*!
@@ -332,7 +332,7 @@ WOLFSSL_API int  wc_RsaSSL_Sign(const byte* in, word32 inLen, byte* out,
     \sa wc_RsaSSL_Verify
     \sa wc_RsaSSL_Sign
 */
-WOLFSSL_API int  wc_RsaSSL_VerifyInline(byte* in, word32 inLen, byte** out,
+int  wc_RsaSSL_VerifyInline(byte* in, word32 inLen, byte** out,
                                     RsaKey* key);
 
 /*!
@@ -364,7 +364,7 @@ WOLFSSL_API int  wc_RsaSSL_VerifyInline(byte* in, word32 inLen, byte** out,
 
     \sa wc_RsaSSL_Sign
 */
-WOLFSSL_API int  wc_RsaSSL_Verify(const byte* in, word32 inLen, byte* out,
+int  wc_RsaSSL_Verify(const byte* in, word32 inLen, byte* out,
                               word32 outLen, RsaKey* key);
 
 /*!
@@ -414,7 +414,7 @@ WOLFSSL_API int  wc_RsaSSL_Verify(const byte* in, word32 inLen, byte* out,
     \sa wc_RsaPSS_Verify
     \sa wc_RsaSetRNG
 */
-WOLFSSL_API int  wc_RsaPSS_Sign(const byte* in, word32 inLen, byte* out,
+int  wc_RsaPSS_Sign(const byte* in, word32 inLen, byte* out,
                                 word32 outLen, enum wc_HashType hash, int mgf,
                                 RsaKey* key, WC_RNG* rng);
 
@@ -467,7 +467,7 @@ WOLFSSL_API int  wc_RsaPSS_Sign(const byte* in, word32 inLen, byte* out,
     \sa wc_RsaPSS_CheckPadding
     \sa wc_RsaSetRNG
 */
-WOLFSSL_API int  wc_RsaPSS_Verify(byte* in, word32 inLen, byte* out,
+int  wc_RsaPSS_Verify(byte* in, word32 inLen, byte* out,
                                   word32 outLen, enum wc_HashType hash, int mgf,
                                   RsaKey* key);
 
@@ -528,7 +528,7 @@ WOLFSSL_API int  wc_RsaPSS_Verify(byte* in, word32 inLen, byte* out,
 */
 
 
-WOLFSSL_API int  wc_RsaPSS_VerifyInline(byte* in, word32 inLen, byte** out,
+int  wc_RsaPSS_VerifyInline(byte* in, word32 inLen, byte** out,
                                         enum wc_HashType hash, int mgf,
                                         RsaKey* key);
 /*!
@@ -596,7 +596,7 @@ WOLFSSL_API int  wc_RsaPSS_VerifyInline(byte* in, word32 inLen, byte** out,
     \sa wc_RsaSetRNG
 */
 
-WOLFSSL_API int  wc_RsaPSS_VerifyCheck(byte* in, word32 inLen,
+int  wc_RsaPSS_VerifyCheck(byte* in, word32 inLen,
                                byte* out, word32 outLen,
                                const byte* digest, word32 digestLen,
                                enum wc_HashType hash, int mgf,
@@ -668,7 +668,7 @@ WOLFSSL_API int  wc_RsaPSS_VerifyCheck(byte* in, word32 inLen,
     \sa wc_RsaPSS_CheckPadding_ex
     \sa wc_RsaSetRNG
 */
-WOLFSSL_API int  wc_RsaPSS_VerifyCheck_ex(byte* in, word32 inLen,
+int  wc_RsaPSS_VerifyCheck_ex(byte* in, word32 inLen,
                                byte* out, word32 outLen,
                                const byte* digest, word32 digestLen,
                                enum wc_HashType hash, int mgf, int saltLen,
@@ -738,7 +738,7 @@ WOLFSSL_API int  wc_RsaPSS_VerifyCheck_ex(byte* in, word32 inLen,
     \sa wc_RsaPSS_CheckPadding_ex
     \sa wc_RsaSetRNG
 */
-WOLFSSL_API int  wc_RsaPSS_VerifyCheckInline(byte* in, word32 inLen, byte** out,
+int  wc_RsaPSS_VerifyCheckInline(byte* in, word32 inLen, byte** out,
                                const byte* digest, word32 digentLen,
                                enum wc_HashType hash, int mgf,
                                RsaKey* key);
@@ -807,7 +807,7 @@ WOLFSSL_API int  wc_RsaPSS_VerifyCheckInline(byte* in, word32 inLen, byte** out,
     \sa wc_RsaPSS_CheckPadding_ex
     \sa wc_RsaSetRNG
 */
-WOLFSSL_API int  wc_RsaPSS_VerifyCheckInline_ex(byte* in, word32 inLen, byte** out,
+int  wc_RsaPSS_VerifyCheckInline_ex(byte* in, word32 inLen, byte** out,
                                const byte* digest, word32 digentLen,
                                enum wc_HashType hash, int mgf, int saltLen,
                                RsaKey* key);
@@ -872,7 +872,7 @@ WOLFSSL_API int  wc_RsaPSS_VerifyCheckInline_ex(byte* in, word32 inLen, byte** o
     \sa wc_RsaPSS_CheckPadding_ex
     \sa wc_RsaSetRNG
 */
-WOLFSSL_API int  wc_RsaPSS_CheckPadding(const byte* in, word32 inLen, byte* sig,
+int  wc_RsaPSS_CheckPadding(const byte* in, word32 inLen, byte* sig,
                                         word32 sigSz,
                                         enum wc_HashType hashType);
 /*!
@@ -937,7 +937,7 @@ WOLFSSL_API int  wc_RsaPSS_CheckPadding(const byte* in, word32 inLen, byte* sig,
     \sa wc_RsaPSS_VerifyCheckInline_ex
     \sa wc_RsaPSS_CheckPadding
 */
-WOLFSSL_API int  wc_RsaPSS_CheckPadding_ex(const byte* in, word32 inLen, byte* sig,
+int  wc_RsaPSS_CheckPadding_ex(const byte* in, word32 inLen, byte* sig,
                 word32 sigSz, enum wc_HashType hashType, int saltLen, int bits);
 /*!
     \ingroup RSA
@@ -957,7 +957,7 @@ WOLFSSL_API int  wc_RsaPSS_CheckPadding_ex(const byte* in, word32 inLen, byte* s
     \sa wc_InitRsaKey_ex
     \sa wc_MakeRsaKey
 */
-WOLFSSL_API int  wc_RsaEncryptSize(RsaKey* key);
+int  wc_RsaEncryptSize(RsaKey* key);
 
 /*!
     \ingroup RSA
@@ -1000,8 +1000,8 @@ WOLFSSL_API int  wc_RsaEncryptSize(RsaKey* key);
     \sa wc_RsaPublicKeyDecode
     \sa wc_MakeRsaKey
 */
-WOLFSSL_API int  wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
-                                                               RsaKey*, word32);
+int  wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
+                            RsaKey* key, word32 inSz);
 
 /*!
     \ingroup RSA
@@ -1049,8 +1049,8 @@ WOLFSSL_API int  wc_RsaPrivateKeyDecode(const byte* input, word32* inOutIdx,
 
     \sa wc_RsaPublicKeyDecodeRaw
 */
-WOLFSSL_API int  wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx,
-                                                               RsaKey*, word32);
+int  wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx,
+                           RsaKey* key, word32 inSz);
 
 /*!
     \ingroup RSA
@@ -1094,7 +1094,7 @@ WOLFSSL_API int  wc_RsaPublicKeyDecode(const byte* input, word32* inOutIdx,
 
     \sa wc_RsaPublicKeyDecode
 */
-WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
+int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
                                         const byte* e, word32 eSz, RsaKey* key);
 
 /*!
@@ -1135,7 +1135,7 @@ WOLFSSL_API int  wc_RsaPublicKeyDecodeRaw(const byte* n, word32 nSz,
     \sa wc_MakeRsaKey
     \sa wc_InitRng
 */
-WOLFSSL_API int wc_RsaKeyToDer(RsaKey*, byte* output, word32 inLen);
+int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen);
 
 /*!
     \ingroup RSA
@@ -1178,7 +1178,7 @@ WOLFSSL_API int wc_RsaKeyToDer(RsaKey*, byte* output, word32 inLen);
     \sa wc_RsaPublicEncrypt
     \sa wc_RsaPrivateDecrypt_ex
 */
-WOLFSSL_API int  wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
+int  wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
                    word32 outLen, RsaKey* key, WC_RNG* rng, int type,
                    enum wc_HashType hash, int mgf, byte* label, word32 labelSz);
 
@@ -1231,7 +1231,7 @@ WOLFSSL_API int  wc_RsaPublicEncrypt_ex(const byte* in, word32 inLen, byte* out,
 
     \sa none
 */
-WOLFSSL_API int  wc_RsaPrivateDecrypt_ex(const byte* in, word32 inLen,
+int  wc_RsaPrivateDecrypt_ex(const byte* in, word32 inLen,
                    byte* out, word32 outLen, RsaKey* key, int type,
                    enum wc_HashType hash, int mgf, byte* label, word32 labelSz);
 
@@ -1289,7 +1289,7 @@ WOLFSSL_API int  wc_RsaPrivateDecrypt_ex(const byte* in, word32 inLen,
 
     \sa none
 */
-WOLFSSL_API int  wc_RsaPrivateDecryptInline_ex(byte* in, word32 inLen,
+int  wc_RsaPrivateDecryptInline_ex(byte* in, word32 inLen,
                       byte** out, RsaKey* key, int type, enum wc_HashType hash,
                       int mgf, byte* label, word32 labelSz);
 
@@ -1334,8 +1334,8 @@ WOLFSSL_API int  wc_RsaPrivateDecryptInline_ex(byte* in, word32 inLen,
     \sa wc_InitRsaKey_ex
     \sa wc_MakeRsaKey
 */
-WOLFSSL_API int  wc_RsaFlattenPublicKey(RsaKey*, byte*, word32*, byte*,
-                                                                       word32*);
+int  wc_RsaFlattenPublicKey(RsaKey* key, byte* e, word32* eSz, byte* n,
+                            word32* nSz);
 
 /*!
     \ingroup RSA
@@ -1370,7 +1370,7 @@ WOLFSSL_API int  wc_RsaFlattenPublicKey(RsaKey*, byte*, word32*, byte*,
     \sa wc_RsaKeyToPublicDer_ex
     \sa wc_InitRsaKey
 */
-WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen);
+int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen);
 
 /*!
     \ingroup RSA
@@ -1406,7 +1406,7 @@ WOLFSSL_API int wc_RsaKeyToPublicDer(RsaKey* key, byte* output, word32 inLen);
     \sa wc_RsaKeyToPublicDer
     \sa wc_InitRsaKey
 */
-WOLFSSL_API int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
+int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
     int with_header);
 
 /*!
@@ -1478,7 +1478,7 @@ WOLFSSL_API int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
 
     \sa none
 */
-WOLFSSL_API int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng);
+int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng);
 
 /*!
     \ingroup RSA
@@ -1523,7 +1523,7 @@ WOLFSSL_API int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng);
 
     \sa wc_RsaSetNonBlockTime
 */
-WOLFSSL_API int wc_RsaSetNonBlock(RsaKey* key, RsaNb* nb);
+int wc_RsaSetNonBlock(RsaKey* key, RsaNb* nb);
 
 /*!
     \ingroup RSA
@@ -1555,5 +1555,5 @@ WOLFSSL_API int wc_RsaSetNonBlock(RsaKey* key, RsaNb* nb);
 
     \sa wc_RsaSetNonBlock
 */
-WOLFSSL_API int wc_RsaSetNonBlockTime(RsaKey* key, word32 maxBlockUs,
+int wc_RsaSetNonBlockTime(RsaKey* key, word32 maxBlockUs,
     word32 cpuMHz);

--- a/doc/dox_comments/header_files/sakke.h
+++ b/doc/dox_comments/header_files/sakke.h
@@ -2,142 +2,142 @@
 /*!
     \ingroup SAKKE_Setup
 */
-WOLFSSL_API int wc_InitSakkeKey(SakkeKey* key, void* heap, int devId);
+int wc_InitSakkeKey(SakkeKey* key, void* heap, int devId);
 /*!
     \ingroup SAKKE_Setup
 */
-WOLFSSL_API int wc_InitSakkeKey_ex(SakkeKey* key, int keySize, int curveId,
+int wc_InitSakkeKey_ex(SakkeKey* key, int keySize, int curveId,
         void* heap, int devId);
 /*!
     \ingroup SAKKE_Setup
 */
-WOLFSSL_API void wc_FreeSakkeKey(SakkeKey* key);
+void wc_FreeSakkeKey(SakkeKey* key);
 
 /*!
     \ingroup SAKKE_Setup
 */
-WOLFSSL_API int wc_MakeSakkeKey(SakkeKey* key, WC_RNG* rng);
+int wc_MakeSakkeKey(SakkeKey* key, WC_RNG* rng);
 /*!
     \ingroup SAKKE_Setup
 */
-WOLFSSL_API int wc_MakeSakkePublicKey(SakkeKey* key, ecc_point* pub);
+int wc_MakeSakkePublicKey(SakkeKey* key, ecc_point* pub);
 
 /*!
     \ingroup SAKKE_RSK
 */
-WOLFSSL_API int wc_MakeSakkeRsk(SakkeKey* key, const byte* id, word16 idSz,
+int wc_MakeSakkeRsk(SakkeKey* key, const byte* id, word16 idSz,
         ecc_point* rsk);
 /*!
     \ingroup SAKKE_RSK
 */
-WOLFSSL_API int wc_ValidateSakkeRsk(SakkeKey* key, const byte* id, word16 idSz,
+int wc_ValidateSakkeRsk(SakkeKey* key, const byte* id, word16 idSz,
         ecc_point* rsk, int* valid);
 /*!
     \ingroup SAKKE_RSK
 */
-WOLFSSL_API int wc_GenerateSakkeRskTable(const SakkeKey* key,
+int wc_GenerateSakkeRskTable(const SakkeKey* key,
         const ecc_point* rsk, byte* table, word32* len);
 
 
 /*!
     \ingroup SAKKE_Setup
 */
-WOLFSSL_API int wc_ExportSakkeKey(SakkeKey* key, byte* data, word32* sz);
+int wc_ExportSakkeKey(SakkeKey* key, byte* data, word32* sz);
 /*!
     \ingroup SAKKE_Setup
 */
-WOLFSSL_API int wc_ImportSakkeKey(SakkeKey* key, const byte* data, word32 sz);
+int wc_ImportSakkeKey(SakkeKey* key, const byte* data, word32 sz);
 /*!
     \ingroup SAKKE_Setup
 */
-WOLFSSL_API int wc_ExportSakkePrivateKey(SakkeKey* key, byte* data, word32* sz);
+int wc_ExportSakkePrivateKey(SakkeKey* key, byte* data, word32* sz);
 /*!
     \ingroup SAKKE_Setup
 */
-WOLFSSL_API int wc_ImportSakkePrivateKey(SakkeKey* key, const byte* data,
+int wc_ImportSakkePrivateKey(SakkeKey* key, const byte* data,
         word32 sz);
 
 /*!
     \ingroup SAKKE_RSK
 */
-WOLFSSL_API int wc_EncodeSakkeRsk(const SakkeKey* key, ecc_point* rsk,
+int wc_EncodeSakkeRsk(const SakkeKey* key, ecc_point* rsk,
         byte* out, word32* sz, int raw);
 /*!
     \ingroup SAKKE_RSK
 */
-WOLFSSL_API int wc_DecodeSakkeRsk(const SakkeKey* key, const byte* data,
+int wc_DecodeSakkeRsk(const SakkeKey* key, const byte* data,
         word32 sz, ecc_point* rsk);
 
 /*!
     \ingroup SAKKE_RSK
 */
-WOLFSSL_API int wc_ImportSakkeRsk(SakkeKey* key, const byte* data, word32 sz);
+int wc_ImportSakkeRsk(SakkeKey* key, const byte* data, word32 sz);
 
 /*!
     \ingroup SAKKE_Setup
 */
-WOLFSSL_API int wc_ExportSakkePublicKey(SakkeKey* key, byte* data,
+int wc_ExportSakkePublicKey(SakkeKey* key, byte* data,
         word32* sz, int raw);
 /*!
     \ingroup SAKKE_Setup
 */
-WOLFSSL_API int wc_ImportSakkePublicKey(SakkeKey* key, const byte* data,
+int wc_ImportSakkePublicKey(SakkeKey* key, const byte* data,
         word32 sz, int trusted);
 
 /*!
     \ingroup SAKKE_Operations
 */
-WOLFSSL_API int wc_GetSakkeAuthSize(SakkeKey* key, word16* authSz);
+int wc_GetSakkeAuthSize(SakkeKey* key, word16* authSz);
 /*!
     \ingroup SAKKE_Setup
 */
-WOLFSSL_API int wc_SetSakkeIdentity(SakkeKey* key, const byte* id, word16 idSz);
+int wc_SetSakkeIdentity(SakkeKey* key, const byte* id, word16 idSz);
 /*!
     \ingroup SAKKE_Operations
 */
-WOLFSSL_API int wc_MakeSakkePointI(SakkeKey* key, const byte* id, word16 idSz);
+int wc_MakeSakkePointI(SakkeKey* key, const byte* id, word16 idSz);
 /*!
     \ingroup SAKKE_Operations
 */
-WOLFSSL_API int wc_GetSakkePointI(SakkeKey* key, byte* data, word32* sz);
+int wc_GetSakkePointI(SakkeKey* key, byte* data, word32* sz);
 /*!
     \ingroup SAKKE_Operations
 */
-WOLFSSL_API int wc_SetSakkePointI(SakkeKey* key, const byte* id, word16 idSz,
+int wc_SetSakkePointI(SakkeKey* key, const byte* id, word16 idSz,
         const byte* data, word32 sz);
 /*!
     \ingroup SAKKE_Operations
 */
-WOLFSSL_API int wc_GenerateSakkePointITable(SakkeKey* key, byte* table,
+int wc_GenerateSakkePointITable(SakkeKey* key, byte* table,
          word32* len);
 /*!
     \ingroup SAKKE_Operations
 */
-WOLFSSL_API int wc_SetSakkePointITable(SakkeKey* key, byte* table, word32 len);
+int wc_SetSakkePointITable(SakkeKey* key, byte* table, word32 len);
 /*!
     \ingroup SAKKE_Operations
 */
-WOLFSSL_API int wc_ClearSakkePointITable(SakkeKey* key);
+int wc_ClearSakkePointITable(SakkeKey* key);
 /*!
     \ingroup SAKKE_Operations
 */
-WOLFSSL_API int wc_MakeSakkeEncapsulatedSSV(SakkeKey* key,
+int wc_MakeSakkeEncapsulatedSSV(SakkeKey* key,
         enum wc_HashType hashType, byte* ssv, word16 ssvSz, byte* auth,
         word16* authSz);
 /*!
     \ingroup SAKKE_Operations
 */
-WOLFSSL_API int wc_GenerateSakkeSSV(SakkeKey* key, WC_RNG* rng, byte* ssv,
+int wc_GenerateSakkeSSV(SakkeKey* key, WC_RNG* rng, byte* ssv,
         word16* ssvSz);
 /*!
     \ingroup SAKKE_RSK
 */
-WOLFSSL_API int wc_SetSakkeRsk(SakkeKey* key, const ecc_point* rsk, byte* table,
+int wc_SetSakkeRsk(SakkeKey* key, const ecc_point* rsk, byte* table,
         word32 len);
 /*!
     \ingroup SAKKE_Operations
 */
-WOLFSSL_API int wc_DeriveSakkeSSV(SakkeKey* key, enum wc_HashType hashType,
+int wc_DeriveSakkeSSV(SakkeKey* key, enum wc_HashType hashType,
         byte* ssv, word16 ssvSz, const byte* auth,
         word16 authSz);
 

--- a/doc/dox_comments/header_files/sha.h
+++ b/doc/dox_comments/header_files/sha.h
@@ -24,7 +24,7 @@
     \sa wc_ShaUpdate
     \sa wc_ShaFinal
 */
-WOLFSSL_API int wc_InitSha(wc_Sha*);
+int wc_InitSha(wc_Sha*);
 
 /*!
     \ingroup SHA
@@ -57,7 +57,7 @@ WOLFSSL_API int wc_InitSha(wc_Sha*);
     \sa wc_ShaFinal
     \sa wc_InitSha
 */
-WOLFSSL_API int wc_ShaUpdate(wc_Sha*, const byte*, word32);
+int wc_ShaUpdate(wc_Sha* sha, const byte* data, word32 len);
 
 /*!
     \ingroup SHA
@@ -89,7 +89,7 @@ WOLFSSL_API int wc_ShaUpdate(wc_Sha*, const byte*, word32);
     \sa wc_InitSha
     \sa wc_ShaGetHash
 */
-WOLFSSL_API int wc_ShaFinal(wc_Sha*, byte*);
+int wc_ShaFinal(wc_Sha* sha, byte* hash);
 
 /*!
     \ingroup SHA
@@ -113,7 +113,7 @@ WOLFSSL_API int wc_ShaFinal(wc_Sha*, byte*);
     \sa wc_ShaUpdate
     \sa wc_ShaFinal
 */
-WOLFSSL_API void wc_ShaFree(wc_Sha*);
+void wc_ShaFree(wc_Sha*);
 
 /*!
     \ingroup SHA
@@ -142,4 +142,4 @@ WOLFSSL_API void wc_ShaFree(wc_Sha*);
     \sa wc_ShaFinal
     \sa wc_InitSha
 */
-WOLFSSL_API int wc_ShaGetHash(wc_Sha*, byte*);
+int wc_ShaGetHash(wc_Sha* sha, byte* hash);

--- a/doc/dox_comments/header_files/sha256.h
+++ b/doc/dox_comments/header_files/sha256.h
@@ -24,7 +24,7 @@
     \sa wc_Sha256Update
     \sa wc_Sha256Final
 */
-WOLFSSL_API int wc_InitSha256(wc_Sha256*);
+int wc_InitSha256(wc_Sha256*);
 
 /*!
     \ingroup SHA
@@ -57,7 +57,7 @@ WOLFSSL_API int wc_InitSha256(wc_Sha256*);
     \sa wc_Sha256Final
     \sa wc_InitSha256
 */
-WOLFSSL_API int wc_Sha256Update(wc_Sha256*, const byte*, word32);
+int wc_Sha256Update(wc_Sha256* sha, const byte* data, word32 len);
 
 /*!
     \ingroup SHA
@@ -89,7 +89,7 @@ WOLFSSL_API int wc_Sha256Update(wc_Sha256*, const byte*, word32);
     \sa wc_Sha256GetHash
     \sa wc_InitSha256
 */
-WOLFSSL_API int wc_Sha256Final(wc_Sha256*, byte*);
+int wc_Sha256Final(wc_Sha256* sha256, byte* hash);
 
 /*!
     \ingroup SHA
@@ -121,7 +121,7 @@ WOLFSSL_API int wc_Sha256Final(wc_Sha256*, byte*);
     \sa wc_Sha256Update
     \sa wc_Sha256Final
 */
-WOLFSSL_API void wc_Sha256Free(wc_Sha256*);
+void wc_Sha256Free(wc_Sha256*);
 
 /*!
     \ingroup SHA
@@ -150,7 +150,7 @@ WOLFSSL_API void wc_Sha256Free(wc_Sha256*);
     \sa wc_Sha256Final
     \sa wc_InitSha256
 */
-WOLFSSL_API int wc_Sha256GetHash(wc_Sha256*, byte*);
+int wc_Sha256GetHash(wc_Sha256* sha256, byte* hash);
 
 /*!
     \ingroup SHA
@@ -175,7 +175,7 @@ WOLFSSL_API int wc_Sha256GetHash(wc_Sha256*, byte*);
     \sa wc_Sha224Update
     \sa wc_Sha224Final
 */
-WOLFSSL_API int wc_InitSha224(wc_Sha224*);
+int wc_InitSha224(wc_Sha224*);
 
 /*!
     \ingroup SHA
@@ -210,7 +210,7 @@ WOLFSSL_API int wc_InitSha224(wc_Sha224*);
     \sa wc_Sha224Final
     \sa wc_Sha224Hash
 */
-WOLFSSL_API int wc_Sha224Update(wc_Sha224*, const byte*, word32);
+int wc_Sha224Update(wc_Sha224* sha224, const byte* data, word32 len);
 
 /*!
     \ingroup SHA
@@ -243,4 +243,4 @@ WOLFSSL_API int wc_Sha224Update(wc_Sha224*, const byte*, word32);
     \sa wc_Sha224Hash
     \sa wc_Sha224Update
 */
-WOLFSSL_API int wc_Sha224Final(wc_Sha224*, byte*);
+int wc_Sha224Final(wc_Sha224* sha224, byte* hash);

--- a/doc/dox_comments/header_files/sha512.h
+++ b/doc/dox_comments/header_files/sha512.h
@@ -24,7 +24,7 @@
     \sa wc_Sha512Update
     \sa wc_Sha512Final
 */
-WOLFSSL_API int wc_InitSha512(wc_Sha512*);
+int wc_InitSha512(wc_Sha512*);
 
 /*!
     \ingroup SHA
@@ -57,7 +57,7 @@ WOLFSSL_API int wc_InitSha512(wc_Sha512*);
     \sa wc_Sha512Final
     \sa wc_InitSha512
 */
-WOLFSSL_API int wc_Sha512Update(wc_Sha512*, const byte*, word32);
+int wc_Sha512Update(wc_Sha512* sha, const byte* data, word32 len);
 
 /*!
     \ingroup SHA
@@ -88,7 +88,7 @@ WOLFSSL_API int wc_Sha512Update(wc_Sha512*, const byte*, word32);
     \sa wc_Sha512Final
     \sa wc_InitSha512
 */
-WOLFSSL_API int wc_Sha512Final(wc_Sha512*, byte*);
+int wc_Sha512Final(wc_Sha512* sha512, byte* hash);
 
 /*!
     \ingroup SHA
@@ -116,7 +116,7 @@ WOLFSSL_API int wc_Sha512Final(wc_Sha512*, byte*);
     \sa wc_Sha384Update
     \sa wc_Sha384Final
 */
-WOLFSSL_API int wc_InitSha384(wc_Sha384*);
+int wc_InitSha384(wc_Sha384*);
 
 /*!
     \ingroup SHA
@@ -149,7 +149,7 @@ WOLFSSL_API int wc_InitSha384(wc_Sha384*);
     \sa wc_Sha384Final
     \sa wc_InitSha384
 */
-WOLFSSL_API int wc_Sha384Update(wc_Sha384*, const byte*, word32);
+int wc_Sha384Update(wc_Sha384* sha, const byte* data, word32 len);
 
 /*!
     \ingroup SHA
@@ -180,4 +180,4 @@ WOLFSSL_API int wc_Sha384Update(wc_Sha384*, const byte*, word32);
     \sa wc_Sha384Final
     \sa wc_InitSha384
 */
-WOLFSSL_API int wc_Sha384Final(wc_Sha384*, byte*);
+int wc_Sha384Final(wc_Sha384* sha384, byte* hash);

--- a/doc/dox_comments/header_files/signature.h
+++ b/doc/dox_comments/header_files/signature.h
@@ -29,7 +29,7 @@
     \sa wc_SignatureGenerate
     \sa wc_SignatureVerify
 */
-WOLFSSL_API int wc_SignatureGetSize(enum wc_SignatureType sig_type,
+int wc_SignatureGetSize(enum wc_SignatureType sig_type,
     const void* key, word32 key_len);
 
 /*!
@@ -76,7 +76,7 @@ WOLFSSL_API int wc_SignatureGetSize(enum wc_SignatureType sig_type,
     \sa wc_SignatureGetSize
     \sa wc_SignatureGenerate
 */
-WOLFSSL_API int wc_SignatureVerify(
+int wc_SignatureVerify(
     enum wc_HashType hash_type, enum wc_SignatureType sig_type,
     const byte* data, word32 data_len,
     const byte* sig, word32 sig_len,
@@ -139,7 +139,7 @@ WOLFSSL_API int wc_SignatureVerify(
     \sa wc_SignatureGetSize
     \sa wc_SignatureVerify
 */
-WOLFSSL_API int wc_SignatureGenerate(
+int wc_SignatureGenerate(
     enum wc_HashType hash_type, enum wc_SignatureType sig_type,
     const byte* data, word32 data_len,
     byte* sig, word32 *sig_len,

--- a/doc/dox_comments/header_files/siphash.h
+++ b/doc/dox_comments/header_files/siphash.h
@@ -33,7 +33,7 @@
     \sa wc_SipHashUpdate
     \sa wc_SipHashFinal
 */
-WOLFSSL_API int wc_InitSipHash(SipHash* siphash, const unsigned char* key,
+int wc_InitSipHash(SipHash* siphash, const unsigned char* key,
     unsigned char outSz);
 
 /*!
@@ -71,7 +71,7 @@ WOLFSSL_API int wc_InitSipHash(SipHash* siphash, const unsigned char* key,
     \sa wc_InitSipHash
     \sa wc_SipHashFinal
 */
-WOLFSSL_API int wc_SipHashUpdate(SipHash* siphash, const unsigned char* in,
+int wc_SipHashUpdate(SipHash* siphash, const unsigned char* in,
     word32 inSz);
 
 /*!
@@ -109,7 +109,7 @@ WOLFSSL_API int wc_SipHashUpdate(SipHash* siphash, const unsigned char* in,
     \sa wc_InitSipHash
     \sa wc_SipHashUpdate
 */
-WOLFSSL_API int wc_SipHashFinal(SipHash* siphash, unsigned char* out,
+int wc_SipHashFinal(SipHash* siphash, unsigned char* out,
     unsigned char outSz);
 
 /*!
@@ -146,6 +146,6 @@ WOLFSSL_API int wc_SipHashFinal(SipHash* siphash, unsigned char* out,
     \sa wc_SipHashUpdate
     \sa wc_SipHashFinal
 */
-WOLFSSL_API int wc_SipHash(const unsigned char* key, const unsigned char* in,
+int wc_SipHash(const unsigned char* key, const unsigned char* in,
     word32 inSz, unsigned char* out, unsigned char outSz);
 

--- a/doc/dox_comments/header_files/srp.h
+++ b/doc/dox_comments/header_files/srp.h
@@ -30,7 +30,7 @@
     \sa wc_SrpTerm
     \sa wc_SrpSetUsername
 */
-WOLFSSL_API int wc_SrpInit(Srp* srp, SrpType type, SrpSide side);
+int wc_SrpInit(Srp* srp, SrpType type, SrpSide side);
 
 /*!
     \ingroup SRP
@@ -51,7 +51,7 @@ WOLFSSL_API int wc_SrpInit(Srp* srp, SrpType type, SrpSide side);
 
     \sa wc_SrpInit
 */
-WOLFSSL_API void wc_SrpTerm(Srp* srp);
+void wc_SrpTerm(Srp* srp);
 
 /*!
     \ingroup SRP
@@ -86,7 +86,7 @@ WOLFSSL_API void wc_SrpTerm(Srp* srp);
     \sa wc_SrpSetParams
     \sa wc_SrpTerm
 */
-WOLFSSL_API int wc_SrpSetUsername(Srp* srp, const byte* username, word32 size);
+int wc_SrpSetUsername(Srp* srp, const byte* username, word32 size);
 
 /*!
     \ingroup SRP
@@ -133,7 +133,7 @@ WOLFSSL_API int wc_SrpSetUsername(Srp* srp, const byte* username, word32 size);
     \sa wc_SrpSetUsername
     \sa wc_SrpTerm
 */
-WOLFSSL_API int wc_SrpSetParams(Srp* srp, const byte* N,    word32 nSz,
+int wc_SrpSetParams(Srp* srp, const byte* N,    word32 nSz,
                                           const byte* g,    word32 gSz,
                                           const byte* salt, word32 saltSz);
 
@@ -184,7 +184,7 @@ WOLFSSL_API int wc_SrpSetParams(Srp* srp, const byte* N,    word32 nSz,
     \sa wc_SrpSetUsername
     \sa wc_SrpSetParams
 */
-WOLFSSL_API int wc_SrpSetPassword(Srp* srp, const byte* password, word32 size);
+int wc_SrpSetPassword(Srp* srp, const byte* password, word32 size);
 
 /*!
     \ingroup SRP
@@ -227,7 +227,7 @@ WOLFSSL_API int wc_SrpSetPassword(Srp* srp, const byte* password, word32 size);
     \sa wc_SrpSetParams
     \sa wc_SrpGetVerifier
 */
-WOLFSSL_API int wc_SrpSetVerifier(Srp* srp, const byte* verifier, word32 size);
+int wc_SrpSetVerifier(Srp* srp, const byte* verifier, word32 size);
 
 /*!
     \ingroup SRP
@@ -278,7 +278,7 @@ WOLFSSL_API int wc_SrpSetVerifier(Srp* srp, const byte* verifier, word32 size);
     \sa wc_SrpSetVerifier
     \sa wc_SrpSetPassword
 */
-WOLFSSL_API int wc_SrpGetVerifier(Srp* srp, byte* verifier, word32* size);
+int wc_SrpGetVerifier(Srp* srp, byte* verifier, word32* size);
 
 /*!
     \ingroup SRP
@@ -328,7 +328,7 @@ WOLFSSL_API int wc_SrpGetVerifier(Srp* srp, byte* verifier, word32* size);
 
     \sa wc_SrpGetPublic
 */
-WOLFSSL_API int wc_SrpSetPrivate(Srp* srp, const byte* priv, word32 size);
+int wc_SrpSetPrivate(Srp* srp, const byte* priv, word32 size);
 
 /*!
     \ingroup SRP
@@ -383,7 +383,7 @@ WOLFSSL_API int wc_SrpSetPrivate(Srp* srp, const byte* priv, word32 size);
     \sa wc_SrpSetPassword
     \sa wc_SrpSetVerifier
 */
-WOLFSSL_API int wc_SrpGetPublic(Srp* srp, byte* pub, word32* size);
+int wc_SrpGetPublic(Srp* srp, byte* pub, word32* size);
 
 /*!
     \ingroup SRP
@@ -434,7 +434,7 @@ WOLFSSL_API int wc_SrpGetPublic(Srp* srp, byte* pub, word32* size);
 
     \sa wc_SrpGetPublic
 */
-WOLFSSL_API int wc_SrpComputeKey(Srp* srp,
+int wc_SrpComputeKey(Srp* srp,
                                  byte* clientPubKey, word32 clientPubKeySz,
                                  byte* serverPubKey, word32 serverPubKeySz);
 
@@ -468,7 +468,7 @@ WOLFSSL_API int wc_SrpComputeKey(Srp* srp,
 
     \sa wc_SrpComputeKey
 */
-WOLFSSL_API int wc_SrpGetProof(Srp* srp, byte* proof, word32* size);
+int wc_SrpGetProof(Srp* srp, byte* proof, word32* size);
 
 /*!
     \ingroup SRP
@@ -504,4 +504,4 @@ WOLFSSL_API int wc_SrpGetProof(Srp* srp, byte* proof, word32* size);
     \sa wc_SrpGetProof
     \sa wc_SrpTerm
 */
-WOLFSSL_API int wc_SrpVerifyPeersProof(Srp* srp, byte* proof, word32 size);
+int wc_SrpVerifyPeersProof(Srp* srp, byte* proof, word32 size);

--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -18,7 +18,7 @@
     \sa wolfSSL_Init
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfDTLSv1_2_client_method_ex(void* heap);
+WOLFSSL_METHOD *wolfDTLSv1_2_client_method_ex(void* heap);
 
 /*!
     \ingroup Setup
@@ -43,7 +43,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfDTLSv1_2_client_method_ex(void* heap);
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfSSLv23_method(void);
+WOLFSSL_METHOD *wolfSSLv23_method(void);
 
 /*!
     \ingroup Setup
@@ -87,7 +87,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfSSLv23_method(void);
     \sa wolfSSL_CTX_new
 
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfSSLv3_server_method(void);
+WOLFSSL_METHOD *wolfSSLv3_server_method(void);
 
 /*!
     \ingroup Setup
@@ -130,7 +130,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfSSLv3_server_method(void);
     \sa wolfSSLv23_client_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfSSLv3_client_method(void);
+WOLFSSL_METHOD *wolfSSLv3_client_method(void);
 
 /*!
     \ingroup Setup
@@ -173,7 +173,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfSSLv3_client_method(void);
     \sa wolfSSLv23_server_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_server_method(void);
+WOLFSSL_METHOD *wolfTLSv1_server_method(void);
 
 /*!
     \ingroup Setup
@@ -216,7 +216,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_server_method(void);
     \sa wolfSSLv23_client_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_client_method(void);
+WOLFSSL_METHOD *wolfTLSv1_client_method(void);
 
 /*!
     \ingroup Setup
@@ -259,7 +259,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_client_method(void);
     \sa wolfSSLv23_server_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_1_server_method(void);
+WOLFSSL_METHOD *wolfTLSv1_1_server_method(void);
 
 /*!
     \ingroup Setup
@@ -302,7 +302,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_1_server_method(void);
     \sa wolfSSLv23_client_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_1_client_method(void);
+WOLFSSL_METHOD *wolfTLSv1_1_client_method(void);
 
 /*!
     \ingroup Setup
@@ -345,7 +345,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_1_client_method(void);
     \sa wolfSSLv23_server_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_2_server_method(void);
+WOLFSSL_METHOD *wolfTLSv1_2_server_method(void);
 
 /*!
     \ingroup Setup
@@ -388,7 +388,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_2_server_method(void);
     \sa wolfSSLv23_client_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_2_client_method(void);
+WOLFSSL_METHOD *wolfTLSv1_2_client_method(void);
 
 /*!
     \ingroup Setup
@@ -431,7 +431,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_2_client_method(void);
     \sa wolfSSLv23_client_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfDTLSv1_client_method(void);
+WOLFSSL_METHOD *wolfDTLSv1_client_method(void);
 
 /*!
     \ingroup Setup
@@ -474,7 +474,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfDTLSv1_client_method(void);
     \sa wolfSSLv23_server_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfDTLSv1_server_method(void);
+WOLFSSL_METHOD *wolfDTLSv1_server_method(void);
 
 /*!
     \brief This function creates and initializes a WOLFSSL_METHOD for the
@@ -493,7 +493,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfDTLSv1_server_method(void);
 
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfDTLSv1_2_server_method(void);
+WOLFSSL_METHOD *wolfDTLSv1_2_server_method(void);
 
 /*!
     \ingroup Setup
@@ -525,7 +525,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfDTLSv1_2_server_method(void);
 
     \sa none
 */
-WOLFSSL_API int wolfSSL_use_old_poly(WOLFSSL*, int);
+int wolfSSL_use_old_poly(WOLFSSL* ssl, int value);
 
 /*!
     \brief The wolfSSL_dtls_import() function is used to parse in a serialized
@@ -565,7 +565,7 @@ WOLFSSL_API int wolfSSL_use_old_poly(WOLFSSL*, int);
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_dtls_set_export
 */
-WOLFSSL_API int wolfSSL_dtls_import(WOLFSSL* ssl, unsigned char* buf,
+int wolfSSL_dtls_import(WOLFSSL* ssl, unsigned char* buf,
                                                                unsigned int sz);
 
 
@@ -586,7 +586,7 @@ WOLFSSL_API int wolfSSL_dtls_import(WOLFSSL* ssl, unsigned char* buf,
     \sa wolfSSL_dtls_import
     \sa wolfSSL_tls_export
  */
-WOLFSSL_API int wolfSSL_tls_import(WOLFSSL* ssl, const unsigned char* buf,
+int wolfSSL_tls_import(WOLFSSL* ssl, const unsigned char* buf,
         unsigned int sz);
 
 /*!
@@ -625,7 +625,7 @@ WOLFSSL_API int wolfSSL_tls_import(WOLFSSL* ssl, const unsigned char* buf,
     \sa wolfSSL_dtls_set_export
     \sa Static buffer use
 */
-WOLFSSL_API int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx,
+int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx,
                                                            wc_dtls_export func);
 
 /*!
@@ -661,7 +661,7 @@ WOLFSSL_API int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx,
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_dtls_set_export
 */
-WOLFSSL_API int wolfSSL_dtls_set_export(WOLFSSL* ssl, wc_dtls_export func);
+int wolfSSL_dtls_set_export(WOLFSSL* ssl, wc_dtls_export func);
 
 /*!
     \brief The wolfSSL_dtls_export() function is used to serialize a
@@ -698,7 +698,7 @@ WOLFSSL_API int wolfSSL_dtls_set_export(WOLFSSL* ssl, wc_dtls_export func);
     \sa wolfSSL_CTX_dtls_set_export
     \sa wolfSSL_dtls_import
 */
-WOLFSSL_API int wolfSSL_dtls_export(WOLFSSL* ssl, unsigned char* buf,
+int wolfSSL_dtls_export(WOLFSSL* ssl, unsigned char* buf,
                                                               unsigned int* sz);
 
 /*!
@@ -720,7 +720,7 @@ WOLFSSL_API int wolfSSL_dtls_export(WOLFSSL* ssl, unsigned char* buf,
     \sa wolfSSL_dtls_import
     \sa wolfSSL_tls_import
  */
-WOLFSSL_API int wolfSSL_tls_export(WOLFSSL* ssl, unsigned char* buf,
+int wolfSSL_tls_export(WOLFSSL* ssl, unsigned char* buf,
         unsigned int* sz);
 
 /*!
@@ -782,7 +782,7 @@ WOLFSSL_API int wolfSSL_tls_export(WOLFSSL* ssl, unsigned char* buf,
     \sa wolfSSL_CTX_is_static_memory
     \sa wolfSSL_is_static_memory
 */
-WOLFSSL_API int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx,
+int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx,
                                             wolfSSL_method_func method,
                                             unsigned char* buf, unsigned int sz,
                                             int flag, int max);
@@ -820,7 +820,7 @@ WOLFSSL_API int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx,
     \sa wolfSSL_CTX_load_static_memory
     \sa wolfSSL_is_static_memory
 */
-WOLFSSL_API int wolfSSL_CTX_is_static_memory(WOLFSSL_CTX* ctx,
+int wolfSSL_CTX_is_static_memory(WOLFSSL_CTX* ctx,
                                                  WOLFSSL_MEM_STATS* mem_stats);
 
 /*!
@@ -853,7 +853,7 @@ WOLFSSL_API int wolfSSL_CTX_is_static_memory(WOLFSSL_CTX* ctx,
     \sa wolfSSL_new
     \sa wolfSSL_CTX_is_static_memory
 */
-WOLFSSL_API int wolfSSL_is_static_memory(WOLFSSL* ssl,
+int wolfSSL_is_static_memory(WOLFSSL* ssl,
                                             WOLFSSL_MEM_CONN_STATS* mem_stats);
 
 /*!
@@ -896,7 +896,8 @@ WOLFSSL_API int wolfSSL_is_static_memory(WOLFSSL* ssl,
     \sa wolfSSL_use_certificate_file
     \sa wolfSSL_use_certificate_buffer
 */
-WOLFSSL_API int wolfSSL_CTX_use_certificate_file(WOLFSSL_CTX*, const char*, int);
+int wolfSSL_CTX_use_certificate_file(WOLFSSL_CTX* ctx, const char* file,
+                                     int format);
 
 /*!
     \ingroup CertsKeys
@@ -942,7 +943,7 @@ WOLFSSL_API int wolfSSL_CTX_use_certificate_file(WOLFSSL_CTX*, const char*, int)
     \sa wc_CryptoCb_RegisterDevice
     \sa wolfSSL_CTX_SetDevId
 */
-WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_file(WOLFSSL_CTX*, const char*, int);
+int wolfSSL_CTX_use_PrivateKey_file(WOLFSSL_CTX* ctx, const char* file, int format);
 
 /*!
     \ingroup CertsKeys
@@ -1006,8 +1007,8 @@ WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_file(WOLFSSL_CTX*, const char*, int);
     \sa wolfSSL_use_PrivateKey_file
     \sa wolfSSL_use_certificate_chain_file
 */
-WOLFSSL_API int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX*, const char*,
-                                                const char*);
+int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX* ctx, const char* file,
+                                                const char* format);
 
 /*!
     \ingroup CertsKeys
@@ -1071,8 +1072,8 @@ WOLFSSL_API int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX*, const char*,
     \sa wolfSSL_use_PrivateKey_file
     \sa wolfSSL_use_certificate_chain_file
 */
-WOLFSSL_API int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX*, const char*,
-                                                const char*, unsigned int flags);
+int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX* ctx, const char* file,
+                                         const char* path, unsigned int flags);
 
 /*!
     \ingroup Setup
@@ -1122,7 +1123,7 @@ WOLFSSL_API int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX*, const char*,
     \sa wolfSSL_use_PrivateKey_file
     \sa wolfSSL_use_certificate_chain_file
 */
-WOLFSSL_API int wolfSSL_CTX_trust_peer_cert(WOLFSSL_CTX*, const char*, int);
+int wolfSSL_CTX_trust_peer_cert(WOLFSSL_CTX* ctx, const char* file, int type);
 
 /*!
     \ingroup CertsKeys
@@ -1162,7 +1163,7 @@ WOLFSSL_API int wolfSSL_CTX_trust_peer_cert(WOLFSSL_CTX*, const char*, int);
     \sa wolfSSL_use_certificate_file
     \sa wolfSSL_use_certificate_buffer
 */
-WOLFSSL_API int wolfSSL_CTX_use_certificate_chain_file(WOLFSSL_CTX *,
+int wolfSSL_CTX_use_certificate_chain_file(WOLFSSL_CTX *ctx,
                                                      const char *file);
 
 /*!
@@ -1209,7 +1210,7 @@ WOLFSSL_API int wolfSSL_CTX_use_certificate_chain_file(WOLFSSL_CTX *,
     \sa wolfSSL_use_PrivateKey_buffer
     \sa wolfSSL_use_PrivateKey_file
 */
-WOLFSSL_API int wolfSSL_CTX_use_RSAPrivateKey_file(WOLFSSL_CTX*, const char*, int);
+int wolfSSL_CTX_use_RSAPrivateKey_file(WOLFSSL_CTX* ctx, const char* file, int format);
 
 /*!
     \ingroup IO
@@ -1239,7 +1240,7 @@ WOLFSSL_API int wolfSSL_CTX_use_RSAPrivateKey_file(WOLFSSL_CTX*, const char*, in
 
     \sa wolfSSL_CTX_get_verify_depth
 */
-WOLFSSL_API long wolfSSL_get_verify_depth(WOLFSSL* ssl);
+long wolfSSL_get_verify_depth(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -1271,7 +1272,7 @@ WOLFSSL_API long wolfSSL_get_verify_depth(WOLFSSL* ssl);
     \sa wolfSSL_CTX_use_certificate_chain_file
     \sa wolfSSL_get_verify_depth
 */
-WOLFSSL_API long wolfSSL_CTX_get_verify_depth(WOLFSSL_CTX* ctx);
+long wolfSSL_CTX_get_verify_depth(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup openSSL
@@ -1311,7 +1312,7 @@ WOLFSSL_API long wolfSSL_CTX_get_verify_depth(WOLFSSL_CTX* ctx);
     \sa wolfSSL_CTX_use_certificate_file
     \sa wolfSSL_use_certificate_buffer
 */
-WOLFSSL_API int wolfSSL_use_certificate_file(WOLFSSL*, const char*, int);
+int wolfSSL_use_certificate_file(WOLFSSL* ssl, const char* file, int format);
 
 /*!
     \ingroup openSSL
@@ -1361,7 +1362,7 @@ WOLFSSL_API int wolfSSL_use_certificate_file(WOLFSSL*, const char*, int);
     \sa wc_CryptoCb_RegisterDevice
     \sa wolfSSL_SetDevId
 */
-WOLFSSL_API int wolfSSL_use_PrivateKey_file(WOLFSSL*, const char*, int);
+int wolfSSL_use_PrivateKey_file(WOLFSSL* ssl, const char* file, int format);
 
 /*!
     \ingroup openSSL
@@ -1400,7 +1401,7 @@ WOLFSSL_API int wolfSSL_use_PrivateKey_file(WOLFSSL*, const char*, int);
     \sa wolfSSL_CTX_use_certificate_chain_buffer
     \sa wolfSSL_use_certificate_chain_buffer
 */
-WOLFSSL_API int wolfSSL_use_certificate_chain_file(WOLFSSL*, const char *file);
+int wolfSSL_use_certificate_chain_file(WOLFSSL* ssl, const char *file);
 
 /*!
     \ingroup openSSL
@@ -1446,7 +1447,7 @@ WOLFSSL_API int wolfSSL_use_certificate_chain_file(WOLFSSL*, const char *file);
     \sa wolfSSL_use_PrivateKey_buffer
     \sa wolfSSL_use_PrivateKey_file
 */
-WOLFSSL_API int wolfSSL_use_RSAPrivateKey_file(WOLFSSL*, const char*, int);
+int wolfSSL_use_RSAPrivateKey_file(WOLFSSL* ssl, const char* file, int format);
 
 /*!
     \ingroup CertsKeys
@@ -1493,8 +1494,8 @@ WOLFSSL_API int wolfSSL_use_RSAPrivateKey_file(WOLFSSL*, const char*, int);
     \sa wolfSSL_CTX_load_verify_locations
     \sa wolfSSL_CTX_load_verify_buffer
 */
-WOLFSSL_API int wolfSSL_CTX_der_load_verify_locations(WOLFSSL_CTX*,
-                                                    const char*, int);
+int wolfSSL_CTX_der_load_verify_locations(WOLFSSL_CTX* ctx,
+                                          const char* file, int format);
 
 /*!
     \ingroup Setup
@@ -1528,7 +1529,7 @@ WOLFSSL_API int wolfSSL_CTX_der_load_verify_locations(WOLFSSL_CTX*,
 
     \sa wolfSSL_new
 */
-WOLFSSL_API WOLFSSL_CTX* wolfSSL_CTX_new(WOLFSSL_METHOD*);
+WOLFSSL_CTX* wolfSSL_CTX_new(WOLFSSL_METHOD*);
 
 /*!
     \ingroup Setup
@@ -1562,7 +1563,7 @@ WOLFSSL_API WOLFSSL_CTX* wolfSSL_CTX_new(WOLFSSL_METHOD*);
 
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL* wolfSSL_new(WOLFSSL_CTX*);
+WOLFSSL* wolfSSL_new(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
@@ -1594,7 +1595,7 @@ WOLFSSL_API WOLFSSL* wolfSSL_new(WOLFSSL_CTX*);
     \sa wolfSSL_SetIOReadCtx
     \sa wolfSSL_SetIOWriteCtx
 */
-WOLFSSL_API int  wolfSSL_set_fd (WOLFSSL*, int);
+int  wolfSSL_set_fd (WOLFSSL* ssl, int fd);
 
 /*!
     \ingroup IO
@@ -1614,7 +1615,7 @@ WOLFSSL_API int  wolfSSL_set_fd (WOLFSSL*, int);
     \sa wolfSSL_CIPHER_get_name
     \sa wolfSSL_get_current_cipher
 */
-WOLFSSL_API char* wolfSSL_get_cipher_list(int priority);
+char* wolfSSL_get_cipher_list(int priority);
 
 /*!
     \ingroup IO
@@ -1646,7 +1647,7 @@ WOLFSSL_API char* wolfSSL_get_cipher_list(int priority);
     \sa wolfSSL_get_cipher_list
     \sa ShowCiphers
 */
-WOLFSSL_API int  wolfSSL_get_ciphers(char*, int);
+int  wolfSSL_get_ciphers(char* buf, int len);
 
 /*!
     \ingroup IO
@@ -1679,7 +1680,7 @@ WOLFSSL_API int  wolfSSL_get_ciphers(char*, int);
     \sa wolfSSL_get_current_cipher
     \sa wolfSSL_get_cipher_name_internal
 */
-WOLFSSL_API const char* wolfSSL_get_cipher_name(WOLFSSL* ssl);
+const char* wolfSSL_get_cipher_name(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
@@ -1704,7 +1705,7 @@ WOLFSSL_API const char* wolfSSL_get_cipher_name(WOLFSSL* ssl);
 
     \sa wolfSSL_set_fd
 */
-WOLFSSL_API int  wolfSSL_get_fd(const WOLFSSL*);
+int  wolfSSL_get_fd(const WOLFSSL*);
 
 /*!
     \ingroup Setup
@@ -1733,7 +1734,7 @@ WOLFSSL_API int  wolfSSL_get_fd(const WOLFSSL*);
     \sa wolfSSL_dtls_got_timeout
     \sa wolfSSL_dtls_get_current_timeout
 */
-WOLFSSL_API void wolfSSL_set_using_nonblock(WOLFSSL*, int);
+void wolfSSL_set_using_nonblock(WOLFSSL* ssl, int nonblock);
 
 /*!
     \ingroup IO
@@ -1765,7 +1766,7 @@ WOLFSSL_API void wolfSSL_set_using_nonblock(WOLFSSL*, int);
 
     \sa wolfSSL_set_session
 */
-WOLFSSL_API int  wolfSSL_get_using_nonblock(WOLFSSL*);
+int  wolfSSL_get_using_nonblock(WOLFSSL*);
 
 /*!
     \ingroup IO
@@ -1815,7 +1816,7 @@ WOLFSSL_API int  wolfSSL_get_using_nonblock(WOLFSSL*);
     \sa wolfSSL_read
     \sa wolfSSL_recv
 */
-WOLFSSL_API int  wolfSSL_write(WOLFSSL*, const void*, int);
+int  wolfSSL_write(WOLFSSL* ssl, const void* data, int sz);
 
 /*!
     \ingroup IO
@@ -1873,7 +1874,7 @@ WOLFSSL_API int  wolfSSL_write(WOLFSSL*, const void*, int);
     \sa wolfSSL_peek
     \sa wolfSSL_pending
 */
-WOLFSSL_API int  wolfSSL_read(WOLFSSL*, void*, int);
+int  wolfSSL_read(WOLFSSL* ssl, void* data, int sz);
 
 /*!
     \ingroup IO
@@ -1927,7 +1928,7 @@ WOLFSSL_API int  wolfSSL_read(WOLFSSL*, void*, int);
 
     \sa wolfSSL_read
 */
-WOLFSSL_API int  wolfSSL_peek(WOLFSSL*, void*, int);
+int  wolfSSL_peek(WOLFSSL* ssl, void* data, int sz);
 
 /*!
     \ingroup IO
@@ -1971,7 +1972,7 @@ WOLFSSL_API int  wolfSSL_peek(WOLFSSL*, void*, int);
     \sa wolfSSL_get_error
     \sa wolfSSL_connect
 */
-WOLFSSL_API int  wolfSSL_accept(WOLFSSL*);
+int  wolfSSL_accept(WOLFSSL*);
 
 /*!
     \ingroup Setup
@@ -1995,7 +1996,7 @@ WOLFSSL_API int  wolfSSL_accept(WOLFSSL*);
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API void wolfSSL_CTX_free(WOLFSSL_CTX*);
+void wolfSSL_CTX_free(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
@@ -2019,7 +2020,7 @@ WOLFSSL_API void wolfSSL_CTX_free(WOLFSSL_CTX*);
     \sa wolfSSL_new
     \sa wolfSSL_CTX_free
 */
-WOLFSSL_API void wolfSSL_free(WOLFSSL*);
+void wolfSSL_free(WOLFSSL*);
 
 /*!
     \ingroup TLS
@@ -2065,7 +2066,7 @@ WOLFSSL_API void wolfSSL_free(WOLFSSL*);
     \sa wolfSSL_free
     \sa wolfSSL_CTX_free
 */
-WOLFSSL_API int  wolfSSL_shutdown(WOLFSSL*);
+int  wolfSSL_shutdown(WOLFSSL*);
 
 /*!
     \ingroup IO
@@ -2116,7 +2117,7 @@ WOLFSSL_API int  wolfSSL_shutdown(WOLFSSL*);
     \sa wolfSSL_read
     \sa wolfSSL_recv
 */
-WOLFSSL_API int  wolfSSL_send(WOLFSSL*, const void*, int sz, int flags);
+int  wolfSSL_send(WOLFSSL* ssl, const void* data, int sz, int flags);
 
 /*!
     \ingroup IO
@@ -2176,7 +2177,7 @@ WOLFSSL_API int  wolfSSL_send(WOLFSSL*, const void*, int sz, int flags);
     \sa wolfSSL_peek
     \sa wolfSSL_pending
 */
-WOLFSSL_API int  wolfSSL_recv(WOLFSSL*, void*, int sz, int flags);
+int  wolfSSL_recv(WOLFSSL* ssl, void* data, int sz, int flags);
 
 /*!
     \ingroup Debug
@@ -2220,7 +2221,7 @@ WOLFSSL_API int  wolfSSL_recv(WOLFSSL*, void*, int sz, int flags);
     \sa wolfSSL_ERR_print_errors_fp
     \sa wolfSSL_load_error_strings
 */
-WOLFSSL_API int  wolfSSL_get_error(WOLFSSL*, int);
+int  wolfSSL_get_error(WOLFSSL* ssl, int ret);
 
 /*!
     \ingroup IO
@@ -2247,7 +2248,7 @@ WOLFSSL_API int  wolfSSL_get_error(WOLFSSL*, int);
 
     \sa wolfSSL_get_error
 */
-WOLFSSL_API int  wolfSSL_get_alert_history(WOLFSSL*, WOLFSSL_ALERT_HISTORY *);
+int  wolfSSL_get_alert_history(WOLFSSL* ssl, WOLFSSL_ALERT_HISTORY *h);
 
 /*!
     \ingroup Setup
@@ -2296,7 +2297,7 @@ WOLFSSL_API int  wolfSSL_get_alert_history(WOLFSSL*, WOLFSSL_ALERT_HISTORY *);
 
     \sa wolfSSL_get1_session
 */
-WOLFSSL_API int        wolfSSL_set_session(WOLFSSL*, WOLFSSL_SESSION*);
+int        wolfSSL_set_session(WOLFSSL* ssl, WOLFSSL_SESSION* session);
 
 /*!
     \ingroup IO
@@ -2338,7 +2339,7 @@ WOLFSSL_API int        wolfSSL_set_session(WOLFSSL*, WOLFSSL_SESSION*);
     \sa wolfSSL_get1_session
     \sa wolfSSL_set_session
 */
-WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL*);
+WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
@@ -2366,7 +2367,7 @@ WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL*);
     \sa wolfSSL_get1_session
     \sa wolfSSL_set_session
 */
-WOLFSSL_API void       wolfSSL_flush_sessions(WOLFSSL_CTX*, long);
+void       wolfSSL_flush_sessions(WOLFSSL_CTX* ctx, long tm);
 
 /*!
     \ingroup TLS
@@ -2402,8 +2403,8 @@ WOLFSSL_API void       wolfSSL_flush_sessions(WOLFSSL_CTX*, long);
 
     \sa wolfSSL_set_session
 */
-WOLFSSL_API int        wolfSSL_SetServerID(WOLFSSL*, const unsigned char*,
-                                         int, int);
+int        wolfSSL_SetServerID(WOLFSSL* ssl, const unsigned char* id,
+                                         int len, int newSession);
 
 /*!
     \ingroup IO
@@ -2429,7 +2430,7 @@ WOLFSSL_API int        wolfSSL_SetServerID(WOLFSSL*, const unsigned char*,
 
     \sa wolfSSL_GetSessionAtIndex
 */
-WOLFSSL_API int wolfSSL_GetSessionIndex(WOLFSSL* ssl);
+int wolfSSL_GetSessionIndex(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
@@ -2460,7 +2461,7 @@ WOLFSSL_API int wolfSSL_GetSessionIndex(WOLFSSL* ssl);
     \sa LockMutex
     \sa wolfSSL_GetSessionIndex
 */
-WOLFSSL_API int wolfSSL_GetSessionAtIndex(int index, WOLFSSL_SESSION* session);
+int wolfSSL_GetSessionAtIndex(int index, WOLFSSL_SESSION* session);
 
 /*!
     \ingroup IO
@@ -2487,7 +2488,7 @@ WOLFSSL_API int wolfSSL_GetSessionAtIndex(int index, WOLFSSL_SESSION* session);
     \sa wolfSSL_GetSessionIndex
     \sa AddSession
 */
-WOLFSSL_API
+
     WOLFSSL_X509_CHAIN* wolfSSL_SESSION_get_peer_chain(WOLFSSL_SESSION* session);
 
 /*!
@@ -2535,7 +2536,7 @@ WOLFSSL_API
 
     \sa wolfSSL_set_verify
 */
-WOLFSSL_API void wolfSSL_CTX_set_verify(WOLFSSL_CTX*, int,
+void wolfSSL_CTX_set_verify(WOLFSSL_CTX* ctx, int mode,
                                       VerifyCallback verify_callback);
 
 /*!
@@ -2582,7 +2583,7 @@ WOLFSSL_API void wolfSSL_CTX_set_verify(WOLFSSL_CTX*, int,
 
     \sa wolfSSL_CTX_set_verify
 */
-WOLFSSL_API void wolfSSL_set_verify(WOLFSSL*, int, VerifyCallback verify_callback);
+void wolfSSL_set_verify(WOLFSSL* ssl, int mode, VerifyCallback verify_callback);
 
 /*!
     \ingroup CertsKeys
@@ -2612,7 +2613,7 @@ WOLFSSL_API void wolfSSL_set_verify(WOLFSSL*, int, VerifyCallback verify_callbac
     \sa wolfSSL_CTX_restore_cert_cache
     \sa wolfSSL_CTX_set_verify
 */
-WOLFSSL_API void wolfSSL_SetCertCbCtx(WOLFSSL*, void*);
+void wolfSSL_SetCertCbCtx(WOLFSSL* ssl, void* ctx);
 
 /*!
     \ingroup CertsKeys
@@ -2641,7 +2642,7 @@ WOLFSSL_API void wolfSSL_SetCertCbCtx(WOLFSSL*, void*);
     \sa wolfSSL_CTX_restore_cert_cache
     \sa wolfSSL_CTX_set_verify
 */
-WOLFSSL_API void wolfSSL_CTX_SetCertCbCtx(WOLFSSL_CTX*, void*);
+void wolfSSL_CTX_SetCertCbCtx(WOLFSSL_CTX* ctx, void* userCtx);
 
 /*!
     \ingroup IO
@@ -2667,7 +2668,7 @@ WOLFSSL_API void wolfSSL_CTX_SetCertCbCtx(WOLFSSL_CTX*, void*);
     \sa wolfSSL_read
     \sa wolfSSL_peek
 */
-WOLFSSL_API int  wolfSSL_pending(WOLFSSL*);
+int  wolfSSL_pending(WOLFSSL*);
 
 /*!
     \ingroup Debug
@@ -2690,7 +2691,7 @@ WOLFSSL_API int  wolfSSL_pending(WOLFSSL*);
     \sa wolfSSL_ERR_print_errors_fp
     \sa wolfSSL_load_error_strings
 */
-WOLFSSL_API void wolfSSL_load_error_strings(void);
+void wolfSSL_load_error_strings(void);
 
 /*!
     \ingroup TLS
@@ -2719,7 +2720,7 @@ WOLFSSL_API void wolfSSL_load_error_strings(void);
     \sa wolfSSL_Init
     \sa wolfSSL_Cleanup
 */
-WOLFSSL_API int  wolfSSL_library_init(void);
+int  wolfSSL_library_init(void);
 
 /*!
     \brief This function sets the Device Id at the WOLFSSL session level.
@@ -2742,7 +2743,7 @@ WOLFSSL_API int  wolfSSL_library_init(void);
     \sa wolfSSL_CTX_SetDevId
     \sa wolfSSL_CTX_GetDevId
 */
-WOLFSSL_API int wolfSSL_SetDevId(WOLFSSL* ssl, int devId);
+int wolfSSL_SetDevId(WOLFSSL* ssl, int devId);
 
 /*!
     \brief This function sets the Device Id at the WOLFSSL_CTX context level.
@@ -2765,7 +2766,7 @@ WOLFSSL_API int wolfSSL_SetDevId(WOLFSSL* ssl, int devId);
     \sa wolfSSL_SetDevId
     \sa wolfSSL_CTX_GetDevId
 */
-WOLFSSL_API int wolfSSL_CTX_SetDevId(WOLFSSL_CTX* ctx, int devId);
+int wolfSSL_CTX_SetDevId(WOLFSSL_CTX* ctx, int devId);
 
 /*!
     \brief This function retrieves the Device Id.
@@ -2788,7 +2789,7 @@ WOLFSSL_API int wolfSSL_CTX_SetDevId(WOLFSSL_CTX* ctx, int devId);
     \sa wolfSSL_CTX_SetDevId
 
 */
-WOLFSSL_API int wolfSSL_CTX_GetDevId(WOLFSSL_CTX* ctx, WOLFSSL* ssl);
+int wolfSSL_CTX_GetDevId(WOLFSSL_CTX* ctx, WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -2821,7 +2822,7 @@ WOLFSSL_API int wolfSSL_CTX_GetDevId(WOLFSSL_CTX* ctx, WOLFSSL* ssl);
     \sa wolfSSL_get_sessionID
     \sa wolfSSL_CTX_set_timeout
 */
-WOLFSSL_API long wolfSSL_CTX_set_session_cache_mode(WOLFSSL_CTX*, long);
+long wolfSSL_CTX_set_session_cache_mode(WOLFSSL_CTX* ctx, long mode);
 
 /*!
     \brief This function sets the session secret callback function. The
@@ -2852,7 +2853,7 @@ WOLFSSL_API long wolfSSL_CTX_set_session_cache_mode(WOLFSSL_CTX*, long);
 
     \sa SessionSecretCb
 */
-WOLFSSL_API int  wolfSSL_set_session_secret_cb(WOLFSSL*, SessionSecretCb, void*);
+int  wolfSSL_set_session_secret_cb(WOLFSSL* ssl, SessionSecretCb cb, void* ctx);
 
 /*!
     \ingroup IO
@@ -2882,7 +2883,7 @@ WOLFSSL_API int  wolfSSL_set_session_secret_cb(WOLFSSL*, SessionSecretCb, void*)
     \sa wolfSSL_restore_session_cache
     \sa wolfSSL_memrestore_session_cache
 */
-WOLFSSL_API int  wolfSSL_save_session_cache(const char*);
+int  wolfSSL_save_session_cache(const char*);
 
 /*!
     \ingroup IO
@@ -2912,7 +2913,7 @@ WOLFSSL_API int  wolfSSL_save_session_cache(const char*);
     \sa XFREAD
     \sa XFOPEN
 */
-WOLFSSL_API int  wolfSSL_restore_session_cache(const char*);
+int  wolfSSL_restore_session_cache(const char*);
 
 /*!
     \ingroup IO
@@ -2941,7 +2942,7 @@ WOLFSSL_API int  wolfSSL_restore_session_cache(const char*);
     \sa XMEMCPY
     \sa wolfSSL_get_session_cache_memsize
 */
-WOLFSSL_API int  wolfSSL_memsave_session_cache(void*, int);
+int  wolfSSL_memsave_session_cache(void* mem, int sz);
 
 /*!
     \ingroup IO
@@ -2970,7 +2971,7 @@ WOLFSSL_API int  wolfSSL_memsave_session_cache(void*, int);
 
     \sa wolfSSL_save_session_cache
 */
-WOLFSSL_API int  wolfSSL_memrestore_session_cache(const void*, int);
+int  wolfSSL_memrestore_session_cache(const void* mem, int sz);
 
 /*!
     \ingroup IO
@@ -2994,7 +2995,7 @@ WOLFSSL_API int  wolfSSL_memrestore_session_cache(const void*, int);
 
     \sa wolfSSL_memrestore_session_cache
 */
-WOLFSSL_API int  wolfSSL_get_session_cache_memsize(void);
+int  wolfSSL_get_session_cache_memsize(void);
 
 /*!
     \ingroup CertsKeys
@@ -3025,7 +3026,7 @@ WOLFSSL_API int  wolfSSL_get_session_cache_memsize(void);
     \sa CM_SaveCertCache
     \sa DoMemSaveCertCache
 */
-WOLFSSL_API int  wolfSSL_CTX_save_cert_cache(WOLFSSL_CTX*, const char*);
+int  wolfSSL_CTX_save_cert_cache(WOLFSSL_CTX* ctx, const char* fname);
 
 /*!
     \ingroup CertsKeys
@@ -3058,7 +3059,7 @@ WOLFSSL_API int  wolfSSL_CTX_save_cert_cache(WOLFSSL_CTX*, const char*);
     \sa CM_RestoreCertCache
     \sa XFOPEN
 */
-WOLFSSL_API int  wolfSSL_CTX_restore_cert_cache(WOLFSSL_CTX*, const char*);
+int  wolfSSL_CTX_restore_cert_cache(WOLFSSL_CTX* ctx, const char* fname);
 
 /*!
     \ingroup CertsKeys
@@ -3096,7 +3097,7 @@ WOLFSSL_API int  wolfSSL_CTX_restore_cert_cache(WOLFSSL_CTX*, const char*);
     \sa CM_MemRestoreCertCache
     \sa CM_GetCertCacheMemSize
 */
-WOLFSSL_API int  wolfSSL_CTX_memsave_cert_cache(WOLFSSL_CTX*, void*, int, int*);
+int  wolfSSL_CTX_memsave_cert_cache(WOLFSSL_CTX* ctx, void* mem, int sz, int* used);
 
 /*!
     \ingroup Setup
@@ -3132,7 +3133,7 @@ WOLFSSL_API int  wolfSSL_CTX_memsave_cert_cache(WOLFSSL_CTX*, void*, int, int*);
 
     \sa CM_MemRestoreCertCache
 */
-WOLFSSL_API int  wolfSSL_CTX_memrestore_cert_cache(WOLFSSL_CTX*, const void*, int);
+int  wolfSSL_CTX_memrestore_cert_cache(WOLFSSL_CTX* ctx, const void* mem, int sz);
 
 /*!
     \ingroup CertsKeys
@@ -3160,7 +3161,7 @@ WOLFSSL_API int  wolfSSL_CTX_memrestore_cert_cache(WOLFSSL_CTX*, const void*, in
 
     \sa CM_GetCertCacheMemSize
 */
-WOLFSSL_API int  wolfSSL_CTX_get_cert_cache_memsize(WOLFSSL_CTX*);
+int  wolfSSL_CTX_get_cert_cache_memsize(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
@@ -3199,7 +3200,7 @@ WOLFSSL_API int  wolfSSL_CTX_get_cert_cache_memsize(WOLFSSL_CTX*);
     \sa wolfSSL_set_cipher_list
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API int  wolfSSL_CTX_set_cipher_list(WOLFSSL_CTX*, const char*);
+int  wolfSSL_CTX_set_cipher_list(WOLFSSL_CTX* ctx, const char* list);
 
 /*!
     \ingroup Setup
@@ -3238,7 +3239,7 @@ WOLFSSL_API int  wolfSSL_CTX_set_cipher_list(WOLFSSL_CTX*, const char*);
     \sa wolfSSL_CTX_set_cipher_list
     \sa wolfSSL_new
 */
-WOLFSSL_API int  wolfSSL_set_cipher_list(WOLFSSL*, const char*);
+int  wolfSSL_set_cipher_list(WOLFSSL* ssl, const char* list);
 
 /*!
     \brief This function informs the WOLFSSL DTLS object that the underlying
@@ -3265,7 +3266,7 @@ WOLFSSL_API int  wolfSSL_set_cipher_list(WOLFSSL*, const char*);
     \sa wolfSSL_dtls_got_timeout
     \sa wolfSSL_dtls_get_current_timeout
 */
-WOLFSSL_API void wolfSSL_dtls_set_using_nonblock(WOLFSSL*, int);
+void wolfSSL_dtls_set_using_nonblock(WOLFSSL* ssl, int nonblock);
 /*!
     \brief This function allows the application to determine if wolfSSL is
     using non-blocking I/O with UDP. If wolfSSL is using non-blocking I/O, this
@@ -3297,7 +3298,7 @@ WOLFSSL_API void wolfSSL_dtls_set_using_nonblock(WOLFSSL*, int);
     \sa wolfSSL_dtls_got_timeout
     \sa wolfSSL_dtls_set_using_nonblock
 */
-WOLFSSL_API int  wolfSSL_dtls_get_using_nonblock(WOLFSSL*);
+int  wolfSSL_dtls_get_using_nonblock(WOLFSSL*);
 /*!
     \brief This function returns the current timeout value in seconds for
     the WOLFSSL object. When using non-blocking sockets, something in the user
@@ -3324,7 +3325,7 @@ WOLFSSL_API int  wolfSSL_dtls_get_using_nonblock(WOLFSSL*);
     \sa wolfSSL_dtls_got_timeout
     \sa wolfSSL_dtls_set_peer
 */
-WOLFSSL_API int  wolfSSL_dtls_get_current_timeout(WOLFSSL* ssl);
+int  wolfSSL_dtls_get_current_timeout(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -3357,7 +3358,7 @@ WOLFSSL_API int  wolfSSL_dtls_get_current_timeout(WOLFSSL* ssl);
     \sa wolfSSL_dtls_set_timeout_max
     \sa wolfSSL_dtls_got_timeout
 */
-WOLFSSL_API int  wolfSSL_dtls_set_timeout_init(WOLFSSL* ssl, int);
+int  wolfSSL_dtls_set_timeout_init(WOLFSSL* ssl, int);
 
 /*!
     \brief This function sets the maximum dtls timeout.
@@ -3385,7 +3386,7 @@ WOLFSSL_API int  wolfSSL_dtls_set_timeout_init(WOLFSSL* ssl, int);
     \sa wolfSSL_dtls_set_timeout_init
     \sa wolfSSL_dtls_got_timeout
 */
-WOLFSSL_API int  wolfSSL_dtls_set_timeout_max(WOLFSSL* ssl, int);
+int  wolfSSL_dtls_set_timeout_max(WOLFSSL* ssl, int);
 
 /*!
     \brief When using non-blocking sockets with DTLS, this function should
@@ -3414,7 +3415,7 @@ WOLFSSL_API int  wolfSSL_dtls_set_timeout_max(WOLFSSL* ssl, int);
     \sa wolfSSL_dtls_set_peer
     \sa wolfSSL_dtls
 */
-WOLFSSL_API int  wolfSSL_dtls_got_timeout(WOLFSSL* ssl);
+int  wolfSSL_dtls_got_timeout(WOLFSSL* ssl);
 
 /*!
     \brief This function is used to determine if the SSL session has been
@@ -3442,7 +3443,7 @@ WOLFSSL_API int  wolfSSL_dtls_got_timeout(WOLFSSL* ssl);
     \sa wolfSSL_dtls_got_timeout
     \sa wolfSSL_dtls_set_peer
 */
-WOLFSSL_API int  wolfSSL_dtls(WOLFSSL* ssl);
+int  wolfSSL_dtls(WOLFSSL* ssl);
 
 /*!
     \brief This function sets the DTLS peer, peer (sockaddr_in) with size of
@@ -3474,7 +3475,7 @@ WOLFSSL_API int  wolfSSL_dtls(WOLFSSL* ssl);
     \sa wolfSSL_dtls_got_timeout
     \sa wolfSSL_dtls
 */
-WOLFSSL_API int  wolfSSL_dtls_set_peer(WOLFSSL*, void*, unsigned int);
+int  wolfSSL_dtls_set_peer(WOLFSSL* ssl, void* peer, unsigned int peerSz);
 
 /*!
     \brief This function gets the sockaddr_in (of size peerSz) of the current
@@ -3511,7 +3512,7 @@ WOLFSSL_API int  wolfSSL_dtls_set_peer(WOLFSSL*, void*, unsigned int);
     \sa wolfSSL_dtls_set_peer
     \sa wolfSSL_dtls
 */
-WOLFSSL_API int  wolfSSL_dtls_get_peer(WOLFSSL*, void*, unsigned int*);
+int  wolfSSL_dtls_get_peer(WOLFSSL* ssl, void* peer, unsigned int* peerSz);
 
 /*!
     \ingroup Debug
@@ -3548,7 +3549,7 @@ WOLFSSL_API int  wolfSSL_dtls_get_peer(WOLFSSL*, void*, unsigned int*);
     \sa wolfSSL_ERR_print_errors_fp
     \sa wolfSSL_load_error_strings
 */
-WOLFSSL_API char* wolfSSL_ERR_error_string(unsigned long,char*);
+char* wolfSSL_ERR_error_string(unsigned long,char*);
 
 /*!
     \ingroup Debug
@@ -3581,7 +3582,7 @@ WOLFSSL_API char* wolfSSL_ERR_error_string(unsigned long,char*);
     \sa wolfSSL_ERR_print_errors_fp
     \sa wolfSSL_load_error_strings
 */
-WOLFSSL_API void  wolfSSL_ERR_error_string_n(unsigned long e, char* buf,
+void  wolfSSL_ERR_error_string_n(unsigned long e, char* buf,
                                            unsigned long sz);
 
 /*!
@@ -3618,7 +3619,7 @@ WOLFSSL_API void  wolfSSL_ERR_error_string_n(unsigned long e, char* buf,
 
     \sa wolfSSL_SESSION_free
 */
-WOLFSSL_API int  wolfSSL_get_shutdown(const WOLFSSL*);
+int  wolfSSL_get_shutdown(const WOLFSSL*);
 
 /*!
     \ingroup IO
@@ -3645,7 +3646,7 @@ WOLFSSL_API int  wolfSSL_get_shutdown(const WOLFSSL*);
     \sa wolfSSL_GetSessionIndex
     \sa wolfSSL_memsave_session_cache
 */
-WOLFSSL_API int  wolfSSL_session_reused(WOLFSSL*);
+int  wolfSSL_session_reused(WOLFSSL*);
 
 /*!
     \ingroup TLS
@@ -3675,7 +3676,7 @@ WOLFSSL_API int  wolfSSL_session_reused(WOLFSSL*);
     \sa wolfSSL_get_keys
     \sa wolfSSL_set_shutdown
 */
-WOLFSSL_API int  wolfSSL_is_init_finished(WOLFSSL*);
+int  wolfSSL_is_init_finished(WOLFSSL*);
 
 /*!
     \ingroup IO
@@ -3707,7 +3708,7 @@ WOLFSSL_API int  wolfSSL_is_init_finished(WOLFSSL*);
 
     \sa wolfSSL_lib_version
 */
-WOLFSSL_API const char*  wolfSSL_get_version(WOLFSSL*);
+const char*  wolfSSL_get_version(WOLFSSL*);
 
 /*!
     \ingroup IO
@@ -3739,7 +3740,7 @@ WOLFSSL_API const char*  wolfSSL_get_version(WOLFSSL*);
     \sa wolfSSL_get_current_cipher
     \sa wolfSSL_get_cipher_list
 */
-WOLFSSL_API int  wolfSSL_get_current_cipher_suite(WOLFSSL* ssl);
+int  wolfSSL_get_current_cipher_suite(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
@@ -3771,7 +3772,7 @@ WOLFSSL_API int  wolfSSL_get_current_cipher_suite(WOLFSSL* ssl);
     \sa wolfSSL_get_cipher_name_internal
     \sa wolfSSL_get_cipher_name
 */
-WOLFSSL_API WOLFSSL_CIPHER*  wolfSSL_get_current_cipher(WOLFSSL*);
+WOLFSSL_CIPHER*  wolfSSL_get_current_cipher(WOLFSSL*);
 
 /*!
     \ingroup IO
@@ -3805,7 +3806,7 @@ WOLFSSL_API WOLFSSL_CIPHER*  wolfSSL_get_current_cipher(WOLFSSL*);
     \sa wolfSSL_get_cipher_name_internal
     \sa wolfSSL_get_cipher_name
 */
-WOLFSSL_API const char*  wolfSSL_CIPHER_get_name(const WOLFSSL_CIPHER* cipher);
+const char*  wolfSSL_CIPHER_get_name(const WOLFSSL_CIPHER* cipher);
 
 /*!
     \ingroup IO
@@ -3834,7 +3835,7 @@ WOLFSSL_API const char*  wolfSSL_CIPHER_get_name(const WOLFSSL_CIPHER* cipher);
     \sa wolfSSL_CIPHER_get_name
     \sa wolfSSL_get_current_cipher
 */
-WOLFSSL_API const char*  wolfSSL_get_cipher(WOLFSSL*);
+const char*  wolfSSL_get_cipher(WOLFSSL*);
 
 /*!
     \ingroup Setup
@@ -3879,7 +3880,7 @@ WOLFSSL_API const char*  wolfSSL_get_cipher(WOLFSSL*);
     \sa wolfSSL_free
     \sa wolfSSL_SESSION_free
 */
-WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
+WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -3927,7 +3928,7 @@ WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
     \sa wolfDTLSv1_client_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD* wolfSSLv23_client_method(void);
+WOLFSSL_METHOD* wolfSSLv23_client_method(void);
 
 /*!
     \ingroup IO
@@ -3956,7 +3957,7 @@ WOLFSSL_API WOLFSSL_METHOD* wolfSSLv23_client_method(void);
     \sa wolfSSL_BIO_set_fp
     \sa wolfSSL_BIO_free
 */
-WOLFSSL_API int wolfSSL_BIO_get_mem_data(WOLFSSL_BIO* bio,void* p);
+int wolfSSL_BIO_get_mem_data(WOLFSSL_BIO* bio,void* p);
 
 /*!
     \ingroup IO
@@ -3980,7 +3981,7 @@ WOLFSSL_API int wolfSSL_BIO_get_mem_data(WOLFSSL_BIO* bio,void* p);
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_free
 */
-WOLFSSL_API long wolfSSL_BIO_set_fd(WOLFSSL_BIO* b, int fd, int flag);
+long wolfSSL_BIO_set_fd(WOLFSSL_BIO* b, int fd, int flag);
 
 /*!
     \ingroup IO
@@ -4003,7 +4004,7 @@ WOLFSSL_API long wolfSSL_BIO_set_fd(WOLFSSL_BIO* b, int fd, int flag);
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_free
 */
-WOLFSSL_API int wolfSSL_BIO_set_close(WOLFSSL_BIO *b, long flag);
+int wolfSSL_BIO_set_close(WOLFSSL_BIO *b, long flag);
 
 /*!
     \ingroup IO
@@ -4024,7 +4025,7 @@ WOLFSSL_API int wolfSSL_BIO_set_close(WOLFSSL_BIO *b, long flag);
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_s_mem
 */
-WOLFSSL_API WOLFSSL_BIO_METHOD *wolfSSL_BIO_s_socket(void);
+WOLFSSL_BIO_METHOD *wolfSSL_BIO_s_socket(void);
 
 /*!
     \ingroup IO
@@ -4053,7 +4054,7 @@ WOLFSSL_API WOLFSSL_BIO_METHOD *wolfSSL_BIO_s_socket(void);
     \sa wolfSSL_BIO_s_mem
     \sa wolfSSL_BIO_free
 */
-WOLFSSL_API int  wolfSSL_BIO_set_write_buf_size(WOLFSSL_BIO *b, long size);
+int  wolfSSL_BIO_set_write_buf_size(WOLFSSL_BIO *b, long size);
 
 /*!
     \ingroup IO
@@ -4087,7 +4088,7 @@ WOLFSSL_API int  wolfSSL_BIO_set_write_buf_size(WOLFSSL_BIO *b, long size);
     \sa wolfSSL_BIO_s_mem
     \sa wolfSSL_BIO_free
 */
-WOLFSSL_API int  wolfSSL_BIO_make_bio_pair(WOLFSSL_BIO *b1, WOLFSSL_BIO *b2);
+int  wolfSSL_BIO_make_bio_pair(WOLFSSL_BIO *b1, WOLFSSL_BIO *b2);
 
 /*!
     \ingroup IO
@@ -4111,7 +4112,7 @@ WOLFSSL_API int  wolfSSL_BIO_make_bio_pair(WOLFSSL_BIO *b1, WOLFSSL_BIO *b2);
     \sa wolfSSL_BIO_new, wolfSSL_BIO_s_mem
     \sa wolfSSL_BIO_new, wolfSSL_BIO_free
 */
-WOLFSSL_API int  wolfSSL_BIO_ctrl_reset_read_request(WOLFSSL_BIO *b);
+int  wolfSSL_BIO_ctrl_reset_read_request(WOLFSSL_BIO *b);
 
 /*!
     \ingroup IO
@@ -4140,7 +4141,7 @@ WOLFSSL_API int  wolfSSL_BIO_ctrl_reset_read_request(WOLFSSL_BIO *b);
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_nwrite0
 */
-WOLFSSL_API int  wolfSSL_BIO_nread0(WOLFSSL_BIO *bio, char **buf);
+int  wolfSSL_BIO_nread0(WOLFSSL_BIO *bio, char **buf);
 
 /*!
     \ingroup IO
@@ -4174,7 +4175,7 @@ WOLFSSL_API int  wolfSSL_BIO_nread0(WOLFSSL_BIO *bio, char **buf);
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_nwrite
 */
-WOLFSSL_API int  wolfSSL_BIO_nread(WOLFSSL_BIO *bio, char **buf, int num);
+int  wolfSSL_BIO_nread(WOLFSSL_BIO *bio, char **buf, int num);
 
 /*!
     \ingroup IO
@@ -4208,7 +4209,7 @@ WOLFSSL_API int  wolfSSL_BIO_nread(WOLFSSL_BIO *bio, char **buf, int num);
     \sa wolfSSL_BIO_free
     \sa wolfSSL_BIO_nread
 */
-WOLFSSL_API int  wolfSSL_BIO_nwrite(WOLFSSL_BIO *bio, char **buf, int num);
+int  wolfSSL_BIO_nwrite(WOLFSSL_BIO *bio, char **buf, int num);
 
 /*!
     \ingroup IO
@@ -4232,7 +4233,7 @@ WOLFSSL_API int  wolfSSL_BIO_nwrite(WOLFSSL_BIO *bio, char **buf, int num);
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_free
 */
-WOLFSSL_API int  wolfSSL_BIO_reset(WOLFSSL_BIO *bio);
+int  wolfSSL_BIO_reset(WOLFSSL_BIO *bio);
 
 /*!
     \ingroup IO
@@ -4263,7 +4264,7 @@ WOLFSSL_API int  wolfSSL_BIO_reset(WOLFSSL_BIO *bio);
     \sa wolfSSL_BIO_set_fp
     \sa wolfSSL_BIO_free
 */
-WOLFSSL_API int  wolfSSL_BIO_seek(WOLFSSL_BIO *bio, int ofs);
+int  wolfSSL_BIO_seek(WOLFSSL_BIO *bio, int ofs);
 
 /*!
     \ingroup IO
@@ -4291,7 +4292,7 @@ WOLFSSL_API int  wolfSSL_BIO_seek(WOLFSSL_BIO *bio, int ofs);
     \sa wolfSSL_BIO_set_fp
     \sa wolfSSL_BIO_free
 */
-WOLFSSL_API int  wolfSSL_BIO_write_filename(WOLFSSL_BIO *bio, char *name);
+int  wolfSSL_BIO_write_filename(WOLFSSL_BIO *bio, char *name);
 
 /*!
     \ingroup IO
@@ -4318,7 +4319,7 @@ WOLFSSL_API int  wolfSSL_BIO_write_filename(WOLFSSL_BIO *bio, char *name);
     \sa wolfSSL_BIO_set_fp
     \sa wolfSSL_BIO_free
 */
-WOLFSSL_API long wolfSSL_BIO_set_mem_eof_return(WOLFSSL_BIO *bio, int v);
+long wolfSSL_BIO_set_mem_eof_return(WOLFSSL_BIO *bio, int v);
 
 /*!
     \ingroup IO
@@ -4346,7 +4347,7 @@ WOLFSSL_API long wolfSSL_BIO_set_mem_eof_return(WOLFSSL_BIO *bio, int v);
     \sa wolfSSL_BIO_new
     \sa wolfSSL_BIO_s_mem
 */
-WOLFSSL_API long wolfSSL_BIO_get_mem_ptr(WOLFSSL_BIO *bio, WOLFSSL_BUF_MEM **m);
+long wolfSSL_BIO_get_mem_ptr(WOLFSSL_BIO *bio, WOLFSSL_BUF_MEM **m);
 
 /*!
     \ingroup CertsKeys
@@ -4379,7 +4380,7 @@ WOLFSSL_API long wolfSSL_BIO_get_mem_ptr(WOLFSSL_BIO *bio, WOLFSSL_BUF_MEM **m);
     \sa wolfSSL_get_peer_certificate
     \sa wolfSSL_X509_version
 */
-WOLFSSL_API char*       wolfSSL_X509_NAME_oneline(WOLFSSL_X509_NAME*, char*, int);
+char*       wolfSSL_X509_NAME_oneline(WOLFSSL_X509_NAME* name, char* in, int sz);
 
 /*!
     \ingroup CertsKeys
@@ -4411,7 +4412,7 @@ WOLFSSL_API char*       wolfSSL_X509_NAME_oneline(WOLFSSL_X509_NAME*, char*, int
     \sa wolfSSL_get_peer_certificate
     \sa wolfSSL_X509_NAME_oneline
 */
-WOLFSSL_API WOLFSSL_X509_NAME*  wolfSSL_X509_get_issuer_name(WOLFSSL_X509*);
+WOLFSSL_X509_NAME*  wolfSSL_X509_get_issuer_name(WOLFSSL_X509*);
 
 /*!
     \ingroup CertsKeys
@@ -4440,7 +4441,7 @@ WOLFSSL_API WOLFSSL_X509_NAME*  wolfSSL_X509_get_issuer_name(WOLFSSL_X509*);
     \sa wolfSSL_X509_get_isCA
     \sa wolfSSL_get_peer_certificate
 */
-WOLFSSL_API WOLFSSL_X509_NAME*  wolfSSL_X509_get_subject_name(WOLFSSL_X509*);
+WOLFSSL_X509_NAME*  wolfSSL_X509_get_subject_name(WOLFSSL_X509*);
 
 /*!
     \ingroup CertsKeys
@@ -4471,7 +4472,7 @@ WOLFSSL_API WOLFSSL_X509_NAME*  wolfSSL_X509_get_subject_name(WOLFSSL_X509*);
     \sa wolfSSL_X509_get_issuer_name
     \sa wolfSSL_X509_get_isCA
 */
-WOLFSSL_API int  wolfSSL_X509_get_isCA(WOLFSSL_X509*);
+int  wolfSSL_X509_get_isCA(WOLFSSL_X509*);
 
 /*!
     \ingroup CertsKeys
@@ -4500,8 +4501,8 @@ WOLFSSL_API int  wolfSSL_X509_get_isCA(WOLFSSL_X509*);
 
     \sa none
 */
-WOLFSSL_API int wolfSSL_X509_NAME_get_text_by_NID(
-                                            WOLFSSL_X509_NAME*, int, char*, int);
+int wolfSSL_X509_NAME_get_text_by_NID(WOLFSSL_X509_NAME* name, int nid,
+                                      char* buf, int len);
 
 /*!
     \ingroup CertsKeys
@@ -4535,7 +4536,7 @@ WOLFSSL_API int wolfSSL_X509_NAME_get_text_by_NID(
     \sa wolfSSL_X509_notAfter
     \sa wolfSSL_X509_free
 */
-WOLFSSL_API int wolfSSL_X509_get_signature_type(WOLFSSL_X509*);
+int wolfSSL_X509_get_signature_type(WOLFSSL_X509*);
 
 /*!
     \brief This function frees a WOLFSSL_X509 structure.
@@ -4560,7 +4561,7 @@ WOLFSSL_API int wolfSSL_X509_get_signature_type(WOLFSSL_X509*);
     \sa wolfSSL_X509_notAfter
 
 */
-WOLFSSL_API void wolfSSL_X509_free(WOLFSSL_X509* x509);
+void wolfSSL_X509_free(WOLFSSL_X509* x509);
 
 /*!
     \ingroup CertsKeys
@@ -4595,7 +4596,7 @@ WOLFSSL_API void wolfSSL_X509_free(WOLFSSL_X509* x509);
     \sa wolfSSL_X509_get_signature_type
     \sa wolfSSL_X509_get_device_type
 */
-WOLFSSL_API int wolfSSL_X509_get_signature(WOLFSSL_X509*, unsigned char*, int*);
+int wolfSSL_X509_get_signature(WOLFSSL_X509* x509, unsigned char* buf, int* bufSz);
 
 /*!
     \ingroup CertsKeys
@@ -4619,8 +4620,7 @@ WOLFSSL_API int wolfSSL_X509_get_signature(WOLFSSL_X509*, unsigned char*, int*);
 
     \sa wolfSSL_X509_free
 */
-WOLFSSL_API int          wolfSSL_X509_STORE_add_cert(
-                                              WOLFSSL_X509_STORE*, WOLFSSL_X509*);
+int wolfSSL_X509_STORE_add_cert(WOLFSSL_X509_STORE* store, WOLFSSL_X509* x509);
 
 /*!
     \ingroup CertsKeys
@@ -4644,7 +4644,7 @@ WOLFSSL_API int          wolfSSL_X509_STORE_add_cert(
 
     \sa wolfSSL_sk_X509_free
 */
-WOLFSSL_API WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(
+WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(
                                                    WOLFSSL_X509_STORE_CTX* ctx);
 
 /*!
@@ -4674,7 +4674,7 @@ WOLFSSL_API WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(
     \sa wolfSSL_X509_STORE_new
     \sa wolfSSL_X509_STORE_free
 */
-WOLFSSL_API int wolfSSL_X509_STORE_set_flags(WOLFSSL_X509_STORE* store,
+int wolfSSL_X509_STORE_set_flags(WOLFSSL_X509_STORE* store,
                                                             unsigned long flag);
 
 /*!
@@ -4706,7 +4706,7 @@ WOLFSSL_API int wolfSSL_X509_STORE_set_flags(WOLFSSL_X509_STORE* store,
     \sa wolfSSL_X509_notAfter
     \sa wolfSSL_X509_free
 */
-WOLFSSL_API const byte* wolfSSL_X509_notBefore(WOLFSSL_X509* x509);
+const byte* wolfSSL_X509_notBefore(WOLFSSL_X509* x509);
 
 /*!
     \ingroup CertsKeys
@@ -4736,7 +4736,7 @@ WOLFSSL_API const byte* wolfSSL_X509_notBefore(WOLFSSL_X509* x509);
     \sa wolfSSL_X509_notBefore
     \sa wolfSSL_X509_free
 */
-WOLFSSL_API const byte* wolfSSL_X509_notAfter(WOLFSSL_X509* x509);
+const byte* wolfSSL_X509_notAfter(WOLFSSL_X509* x509);
 
 /*!
     \ingroup Setup
@@ -4768,7 +4768,7 @@ WOLFSSL_API const byte* wolfSSL_X509_notAfter(WOLFSSL_X509* x509);
 
     \sa none
 */
-WOLFSSL_API WOLFSSL_BIGNUM *wolfSSL_ASN1_INTEGER_to_BN(const WOLFSSL_ASN1_INTEGER *ai,
+WOLFSSL_BIGNUM *wolfSSL_ASN1_INTEGER_to_BN(const WOLFSSL_ASN1_INTEGER *ai,
                                        WOLFSSL_BIGNUM *bn);
 
 /*!
@@ -4796,7 +4796,7 @@ WOLFSSL_API WOLFSSL_BIGNUM *wolfSSL_ASN1_INTEGER_to_BN(const WOLFSSL_ASN1_INTEGE
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
-WOLFSSL_API long wolfSSL_CTX_add_extra_chain_cert(WOLFSSL_CTX*, WOLFSSL_X509*);
+long wolfSSL_CTX_add_extra_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509);
 
 /*!
     \ingroup Setup
@@ -4822,7 +4822,7 @@ WOLFSSL_API long wolfSSL_CTX_add_extra_chain_cert(WOLFSSL_CTX*, WOLFSSL_X509*);
     \sa wolfSSL_CTX_free
     \sa wolfSSL_CTX_set_read_ahead
 */
-WOLFSSL_API int  wolfSSL_CTX_get_read_ahead(WOLFSSL_CTX*);
+int  wolfSSL_CTX_get_read_ahead(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
@@ -4848,7 +4848,7 @@ WOLFSSL_API int  wolfSSL_CTX_get_read_ahead(WOLFSSL_CTX*);
     \sa wolfSSL_CTX_free
     \sa wolfSSL_CTX_get_read_ahead
 */
-WOLFSSL_API int  wolfSSL_CTX_set_read_ahead(WOLFSSL_CTX*, int v);
+int  wolfSSL_CTX_set_read_ahead(WOLFSSL_CTX* ctx, int v);
 
 /*!
     \ingroup Setup
@@ -4875,7 +4875,7 @@ WOLFSSL_API int  wolfSSL_CTX_set_read_ahead(WOLFSSL_CTX*, int v);
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
-WOLFSSL_API long wolfSSL_CTX_set_tlsext_status_arg(WOLFSSL_CTX*, void* arg);
+long wolfSSL_CTX_set_tlsext_status_arg(WOLFSSL_CTX* ctx, void* arg);
 
 /*!
     \ingroup Setup
@@ -4902,8 +4902,8 @@ WOLFSSL_API long wolfSSL_CTX_set_tlsext_status_arg(WOLFSSL_CTX*, void* arg);
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
-WOLFSSL_API long wolfSSL_CTX_set_tlsext_opaque_prf_input_callback_arg(
-        WOLFSSL_CTX*, void* arg);
+long wolfSSL_CTX_set_tlsext_opaque_prf_input_callback_arg(
+        WOLFSSL_CTX* ctx, void* arg);
 
 /*!
     \ingroup Setup
@@ -4940,7 +4940,7 @@ WOLFSSL_API long wolfSSL_CTX_set_tlsext_opaque_prf_input_callback_arg(
     \sa wolfSSL_free
     \sa wolfSSL_get_options
 */
-WOLFSSL_API long wolfSSL_set_options(WOLFSSL *s, long op);
+long wolfSSL_set_options(WOLFSSL *s, long op);
 
 /*!
     \ingroup Setup
@@ -4963,7 +4963,7 @@ WOLFSSL_API long wolfSSL_set_options(WOLFSSL *s, long op);
     \sa wolfSSL_free
     \sa wolfSSL_set_options
 */
-WOLFSSL_API long wolfSSL_get_options(const WOLFSSL *s);
+long wolfSSL_get_options(const WOLFSSL *s);
 
 /*!
     \ingroup Setup
@@ -4989,7 +4989,7 @@ WOLFSSL_API long wolfSSL_get_options(const WOLFSSL *s);
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API long wolfSSL_set_tlsext_debug_arg(WOLFSSL *s, void *arg);
+long wolfSSL_set_tlsext_debug_arg(WOLFSSL *s, void *arg);
 
 /*!
     \ingroup openSSL
@@ -5023,7 +5023,7 @@ WOLFSSL_API long wolfSSL_set_tlsext_debug_arg(WOLFSSL *s, void *arg);
     \sa wolfSSL_free
     \sa wolfSSL_CTX_free
 */
-WOLFSSL_API long wolfSSL_set_tlsext_status_type(WOLFSSL *s, int type);
+long wolfSSL_set_tlsext_status_type(WOLFSSL *s, int type);
 
 /*!
     \ingroup Setup
@@ -5048,7 +5048,7 @@ WOLFSSL_API long wolfSSL_set_tlsext_status_type(WOLFSSL *s, int type);
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API long wolfSSL_get_verify_result(const WOLFSSL *ssl);
+long wolfSSL_get_verify_result(const WOLFSSL *ssl);
 
 /*!
     \ingroup Debug
@@ -5079,7 +5079,7 @@ WOLFSSL_API long wolfSSL_get_verify_result(const WOLFSSL *ssl);
     \sa wolfSSL_ERR_error_string_n
     \sa wolfSSL_load_error_strings
 */
-WOLFSSL_API void  wolfSSL_ERR_print_errors_fp(FILE*, int err);
+void  wolfSSL_ERR_print_errors_fp(XFILE fp, int err);
 
 /*!
     \ingroup Debug
@@ -5107,7 +5107,7 @@ WOLFSSL_API void  wolfSSL_ERR_print_errors_fp(FILE*, int err);
     \sa wolfSSL_ERR_error_string_n
     \sa wolfSSL_load_error_strings
 */
-WOLFSSL_API void  wolfSSL_ERR_print_errors_cb (
+void  wolfSSL_ERR_print_errors_cb (
         int (*cb)(const char *str, size_t len, void *u), void *u);
 
 /*!
@@ -5147,7 +5147,7 @@ WOLFSSL_API void  wolfSSL_ERR_print_errors_cb (
     \sa wolfSSL_CTX_set_psk_server_callback
     \sa wolfSSL_CTX_set_psk_client_callback
 */
-WOLFSSL_API void wolfSSL_CTX_set_psk_client_callback(WOLFSSL_CTX*,
+void wolfSSL_CTX_set_psk_client_callback(WOLFSSL_CTX* ctx,
                                                     wc_psk_client_callback);
 
 /*!
@@ -5186,7 +5186,7 @@ WOLFSSL_API void wolfSSL_CTX_set_psk_client_callback(WOLFSSL_CTX*,
     \sa wolfSSL_CTX_set_psk_server_callback
     \sa wolfSSL_set_psk_server_callback
 */
-WOLFSSL_API void wolfSSL_set_psk_client_callback(WOLFSSL*,
+void wolfSSL_set_psk_client_callback(WOLFSSL* ssl,
                                                     wc_psk_client_callback);
 
 /*!
@@ -5216,7 +5216,7 @@ WOLFSSL_API void wolfSSL_set_psk_client_callback(WOLFSSL*,
 
     \sa wolfSSL_get_psk_identity
 */
-WOLFSSL_API const char* wolfSSL_get_psk_identity_hint(const WOLFSSL*);
+const char* wolfSSL_get_psk_identity_hint(const WOLFSSL*);
 
 /*!
     \ingroup CertsKeys
@@ -5247,7 +5247,7 @@ WOLFSSL_API const char* wolfSSL_get_psk_identity_hint(const WOLFSSL*);
     \sa wolfSSL_get_psk_identity_hint
     \sa wolfSSL_use_psk_identity_hint
 */
-WOLFSSL_API const char* wolfSSL_get_psk_identity(const WOLFSSL*);
+const char* wolfSSL_get_psk_identity(const WOLFSSL*);
 
 /*!
     \ingroup CertsKeys
@@ -5279,7 +5279,7 @@ WOLFSSL_API const char* wolfSSL_get_psk_identity(const WOLFSSL*);
 
     \sa wolfSSL_use_psk_identity_hint
 */
-WOLFSSL_API int wolfSSL_CTX_use_psk_identity_hint(WOLFSSL_CTX*, const char*);
+int wolfSSL_CTX_use_psk_identity_hint(WOLFSSL_CTX* ctx, const char* hint);
 
 /*!
     \ingroup CertsKeys
@@ -5307,7 +5307,7 @@ WOLFSSL_API int wolfSSL_CTX_use_psk_identity_hint(WOLFSSL_CTX*, const char*);
 
     \sa wolfSSL_CTX_use_psk_identity_hint
 */
-WOLFSSL_API int wolfSSL_use_psk_identity_hint(WOLFSSL*, const char*);
+int wolfSSL_use_psk_identity_hint(WOLFSSL* ssl, const char* hint);
 
 /*!
     \brief This function sets the psk callback for the server side in
@@ -5349,8 +5349,8 @@ WOLFSSL_API int wolfSSL_use_psk_identity_hint(WOLFSSL*, const char*);
     \sa wolfSSL_set_psk_server_callback
     \sa wolfSSL_CTX_set_psk_client_callback
 */
-WOLFSSL_API void wolfSSL_CTX_set_psk_server_callback(WOLFSSL_CTX*,
-                                                    wc_psk_server_callback);
+void wolfSSL_CTX_set_psk_server_callback(WOLFSSL_CTX* ctx,
+                                                    wc_psk_server_callback cb);
 
 /*!
     \brief Sets the psk callback for the server side by setting the
@@ -5393,8 +5393,8 @@ WOLFSSL_API void wolfSSL_CTX_set_psk_server_callback(WOLFSSL_CTX*,
     \sa wc_psk_server_callback
     \sa InitSuites
 */
-WOLFSSL_API void wolfSSL_set_psk_server_callback(WOLFSSL*,
-                                                    wc_psk_server_callback);
+void wolfSSL_set_psk_server_callback(WOLFSSL* ssl,
+                                                    wc_psk_server_callback cb);
 
 
 /*!
@@ -5409,7 +5409,7 @@ WOLFSSL_API void wolfSSL_set_psk_server_callback(WOLFSSL*,
     \sa wolfSSL_CTX_set_psk_callback_ctx
     \sa wolfSSL_CTX_get_psk_callback_ctx
 */
-WOLFSSL_API int wolfSSL_set_psk_callback_ctx(WOLFSSL* ssl, void* psk_ctx);
+int wolfSSL_set_psk_callback_ctx(WOLFSSL* ssl, void* psk_ctx);
 
 /*!
     \brief Sets a PSK user context in the WOLFSSL_CTX structure.
@@ -5423,7 +5423,7 @@ WOLFSSL_API int wolfSSL_set_psk_callback_ctx(WOLFSSL* ssl, void* psk_ctx);
     \sa wolfSSL_get_psk_callback_ctx
     \sa wolfSSL_CTX_get_psk_callback_ctx
 */
-WOLFSSL_API int wolfSSL_CTX_set_psk_callback_ctx(WOLFSSL_CTX* ctx, void* psk_ctx);
+int wolfSSL_CTX_set_psk_callback_ctx(WOLFSSL_CTX* ctx, void* psk_ctx);
 
 /*!
     \brief Get a PSK user context in the WOLFSSL structure options member.
@@ -5436,7 +5436,7 @@ WOLFSSL_API int wolfSSL_CTX_set_psk_callback_ctx(WOLFSSL_CTX* ctx, void* psk_ctx
     \sa wolfSSL_CTX_set_psk_callback_ctx
     \sa wolfSSL_CTX_get_psk_callback_ctx
 */
-WOLFSSL_API void* wolfSSL_get_psk_callback_ctx(WOLFSSL* ssl);
+void* wolfSSL_get_psk_callback_ctx(WOLFSSL* ssl);
 
 /*!
     \brief Get a PSK user context in the WOLFSSL_CTX structure.
@@ -5449,7 +5449,7 @@ WOLFSSL_API void* wolfSSL_get_psk_callback_ctx(WOLFSSL* ssl);
     \sa wolfSSL_set_psk_callback_ctx
     \sa wolfSSL_get_psk_callback_ctx
 */
-WOLFSSL_API void* wolfSSL_CTX_get_psk_callback_ctx(WOLFSSL_CTX* ctx);
+void* wolfSSL_CTX_get_psk_callback_ctx(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup Setup
@@ -5481,7 +5481,7 @@ WOLFSSL_API void* wolfSSL_CTX_get_psk_callback_ctx(WOLFSSL_CTX* ctx);
 
     \sa none
 */
-WOLFSSL_API int wolfSSL_CTX_allow_anon_cipher(WOLFSSL_CTX*);
+int wolfSSL_CTX_allow_anon_cipher(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
@@ -5522,7 +5522,7 @@ WOLFSSL_API int wolfSSL_CTX_allow_anon_cipher(WOLFSSL_CTX*);
     \sa wolfDTLSv1_server_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfSSLv23_server_method(void);
+WOLFSSL_METHOD *wolfSSLv23_server_method(void);
 
 /*!
     \ingroup Setup
@@ -5546,7 +5546,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfSSLv23_server_method(void);
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API int  wolfSSL_state(WOLFSSL* ssl);
+int  wolfSSL_state(WOLFSSL* ssl);
 
 /*!
     \ingroup CertsKeys
@@ -5575,7 +5575,7 @@ WOLFSSL_API int  wolfSSL_state(WOLFSSL* ssl);
     \sa wolfSSL_X509_get_subject_name
     \sa wolfSSL_X509_get_isCA
 */
-WOLFSSL_API WOLFSSL_X509* wolfSSL_get_peer_certificate(WOLFSSL* ssl);
+WOLFSSL_X509* wolfSSL_get_peer_certificate(WOLFSSL* ssl);
 
 /*!
     \ingroup Debug
@@ -5605,7 +5605,7 @@ WOLFSSL_API WOLFSSL_X509* wolfSSL_get_peer_certificate(WOLFSSL* ssl);
     \sa wolfSSL_want_write
     \sa wolfSSL_get_error
 */
-WOLFSSL_API int wolfSSL_want_read(WOLFSSL*);
+int wolfSSL_want_read(WOLFSSL*);
 
 /*!
     \ingroup Debug
@@ -5635,7 +5635,7 @@ WOLFSSL_API int wolfSSL_want_read(WOLFSSL*);
     \sa wolfSSL_want_read
     \sa wolfSSL_get_error
 */
-WOLFSSL_API int wolfSSL_want_write(WOLFSSL*);
+int wolfSSL_want_write(WOLFSSL*);
 
 /*!
     \ingroup Setup
@@ -5667,7 +5667,7 @@ WOLFSSL_API int wolfSSL_want_write(WOLFSSL*);
 
     \sa none
 */
-WOLFSSL_API int wolfSSL_check_domain_name(WOLFSSL* ssl, const char* dn);
+int wolfSSL_check_domain_name(WOLFSSL* ssl, const char* dn);
 
 /*!
     \ingroup TLS
@@ -5691,7 +5691,7 @@ WOLFSSL_API int wolfSSL_check_domain_name(WOLFSSL* ssl, const char* dn);
 
     \sa wolfSSL_Cleanup
 */
-WOLFSSL_API int wolfSSL_Init(void);
+int wolfSSL_Init(void);
 
 /*!
     \ingroup TLS
@@ -5709,7 +5709,7 @@ WOLFSSL_API int wolfSSL_Init(void);
 
     \sa wolfSSL_Init
 */
-WOLFSSL_API int wolfSSL_Cleanup(void);
+int wolfSSL_Cleanup(void);
 
 /*!
     \ingroup IO
@@ -5733,7 +5733,7 @@ WOLFSSL_API int wolfSSL_Cleanup(void);
 
     \sa word32_wolfSSL_lib_version_hex
 */
-WOLFSSL_API const char* wolfSSL_lib_version(void);
+const char* wolfSSL_lib_version(void);
 
 /*!
     \ingroup IO
@@ -5760,7 +5760,7 @@ WOLFSSL_API const char* wolfSSL_lib_version(void);
 
     \sa wolfSSL_lib_version
 */
-WOLFSSL_API word32 wolfSSL_lib_version_hex(void);
+word32 wolfSSL_lib_version_hex(void);
 
 /*!
     \ingroup IO
@@ -5793,7 +5793,7 @@ WOLFSSL_API word32 wolfSSL_lib_version_hex(void);
     \sa SSL_connect
     \sa SSL_accept
 */
-WOLFSSL_API int wolfSSL_negotiate(WOLFSSL* ssl);
+int wolfSSL_negotiate(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -5826,7 +5826,7 @@ WOLFSSL_API int wolfSSL_negotiate(WOLFSSL* ssl);
 
     \sa none
 */
-WOLFSSL_API int wolfSSL_set_compression(WOLFSSL* ssl);
+int wolfSSL_set_compression(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -5855,7 +5855,7 @@ WOLFSSL_API int wolfSSL_set_compression(WOLFSSL* ssl);
     \sa wolfSSL_get1_session
     \sa wolfSSL_set_session
 */
-WOLFSSL_API int wolfSSL_set_timeout(WOLFSSL*, unsigned int);
+int wolfSSL_set_timeout(WOLFSSL* ssl, unsigned int to);
 
 /*!
     \ingroup Setup
@@ -5886,7 +5886,7 @@ WOLFSSL_API int wolfSSL_set_timeout(WOLFSSL*, unsigned int);
     \sa wolfSSL_get_sessionID
     \sa wolfSSL_CTX_set_session_cache_mode
 */
-WOLFSSL_API int wolfSSL_CTX_set_timeout(WOLFSSL_CTX*, unsigned int);
+int wolfSSL_CTX_set_timeout(WOLFSSL_CTX* ctx, unsigned int to);
 
 /*!
     \ingroup openSSL
@@ -5910,7 +5910,7 @@ WOLFSSL_API int wolfSSL_CTX_set_timeout(WOLFSSL_CTX*, unsigned int);
     \sa wolfSSL_get_chain_cert
     \sa wolfSSL_get_chain_cert_pem
 */
-WOLFSSL_API WOLFSSL_X509_CHAIN* wolfSSL_get_peer_chain(WOLFSSL* ssl);
+WOLFSSL_X509_CHAIN* wolfSSL_get_peer_chain(WOLFSSL* ssl);
 
 /*!
     \ingroup openSSL
@@ -5934,7 +5934,7 @@ WOLFSSL_API WOLFSSL_X509_CHAIN* wolfSSL_get_peer_chain(WOLFSSL* ssl);
     \sa wolfSSL_get_chain_cert
     \sa wolfSSL_get_chain_cert_pem
 */
-WOLFSSL_API int  wolfSSL_get_chain_count(WOLFSSL_X509_CHAIN* chain);
+int  wolfSSL_get_chain_count(WOLFSSL_X509_CHAIN* chain);
 
 /*!
     \ingroup openSSL
@@ -5960,7 +5960,7 @@ WOLFSSL_API int  wolfSSL_get_chain_count(WOLFSSL_X509_CHAIN* chain);
     \sa wolfSSL_get_chain_cert
     \sa wolfSSL_get_chain_cert_pem
 */
-WOLFSSL_API int  wolfSSL_get_chain_length(WOLFSSL_X509_CHAIN*, int idx);
+int  wolfSSL_get_chain_length(WOLFSSL_X509_CHAIN* chain, int idx);
 
 /*!
     \ingroup openSSL
@@ -5985,7 +5985,7 @@ WOLFSSL_API int  wolfSSL_get_chain_length(WOLFSSL_X509_CHAIN*, int idx);
     \sa wolfSSL_get_chain_length
     \sa wolfSSL_get_chain_cert_pem
 */
-WOLFSSL_API unsigned char* wolfSSL_get_chain_cert(WOLFSSL_X509_CHAIN*, int idx);
+unsigned char* wolfSSL_get_chain_cert(WOLFSSL_X509_CHAIN* chain, int idx);
 
 /*!
     \ingroup CertsKeys
@@ -6018,7 +6018,7 @@ WOLFSSL_API unsigned char* wolfSSL_get_chain_cert(WOLFSSL_X509_CHAIN*, int idx);
     \sa ParseCertRelative
     \sa CopyDecodedToX509
 */
-WOLFSSL_API WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN*, int idx);
+WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN* chain, int idx);
 
 /*!
     \ingroup openSSL
@@ -6043,7 +6043,7 @@ WOLFSSL_API WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN*, int idx);
     \sa wolfSSL_get_chain_length
     \sa wolfSSL_get_chain_cert
 */
-WOLFSSL_API int  wolfSSL_get_chain_cert_pem(WOLFSSL_X509_CHAIN*, int idx,
+int  wolfSSL_get_chain_cert_pem(WOLFSSL_X509_CHAIN* chain, int idx,
                                 unsigned char* buf, int inLen, int* outLen);
 
 /*!
@@ -6062,7 +6062,7 @@ WOLFSSL_API int  wolfSSL_get_chain_cert_pem(WOLFSSL_X509_CHAIN*, int idx,
 
     \sa SSL_get_session
 */
-WOLFSSL_API const unsigned char* wolfSSL_get_sessionID(const WOLFSSL_SESSION* s);
+const unsigned char* wolfSSL_get_sessionID(const WOLFSSL_SESSION* s);
 
 /*!
     \ingroup openSSL
@@ -6087,7 +6087,8 @@ WOLFSSL_API const unsigned char* wolfSSL_get_sessionID(const WOLFSSL_SESSION* s)
 
     \sa SSL_get_peer_certificate
 */
-WOLFSSL_API int  wolfSSL_X509_get_serial_number(WOLFSSL_X509*,unsigned char*,int*);
+int  wolfSSL_X509_get_serial_number(WOLFSSL_X509* x509, unsigned char* in,
+                                    int* inOutSz);
 
 /*!
     \ingroup CertsKeys
@@ -6120,7 +6121,7 @@ WOLFSSL_API int  wolfSSL_X509_get_serial_number(WOLFSSL_X509*,unsigned char*,int
     \sa wolfSSL_X509_get_subject_name
 
 */
-WOLFSSL_API char*  wolfSSL_X509_get_subjectCN(WOLFSSL_X509*);
+char*  wolfSSL_X509_get_subjectCN(WOLFSSL_X509*);
 
 /*!
     \ingroup CertsKeys
@@ -6154,7 +6155,7 @@ WOLFSSL_API char*  wolfSSL_X509_get_subjectCN(WOLFSSL_X509*);
     \sa wolfSSL_X509_get_issuer_name
     \sa wolfSSL_X509_get_subject_name
 */
-WOLFSSL_API const unsigned char* wolfSSL_X509_get_der(WOLFSSL_X509*, int*);
+const unsigned char* wolfSSL_X509_get_der(WOLFSSL_X509* x509, int* outSz);
 
 /*!
     \ingroup CertsKeys
@@ -6181,7 +6182,7 @@ WOLFSSL_API const unsigned char* wolfSSL_X509_get_der(WOLFSSL_X509*, int*);
 
     \sa wolfSSL_X509_get_notBefore
 */
-WOLFSSL_API WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notAfter(WOLFSSL_X509*);
+WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notAfter(WOLFSSL_X509*);
 
 /*!
     \ingroup CertsKeys
@@ -6209,7 +6210,7 @@ WOLFSSL_API WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notAfter(WOLFSSL_X509*);
     \sa wolfSSL_X509_get_isCA
     \sa wolfSSL_get_peer_certificate
 */
-WOLFSSL_API int wolfSSL_X509_version(WOLFSSL_X509*);
+int wolfSSL_X509_version(WOLFSSL_X509*);
 
 /*!
     \ingroup CertsKeys
@@ -6242,7 +6243,7 @@ WOLFSSL_API int wolfSSL_X509_version(WOLFSSL_X509*);
     \sa XREWIND
     \sa XFSEEK
 */
-WOLFSSL_API WOLFSSL_X509*
+WOLFSSL_X509*
         wolfSSL_X509_d2i_fp(WOLFSSL_X509** x509, FILE* file);
 
 /*!
@@ -6272,7 +6273,7 @@ WOLFSSL_API WOLFSSL_X509*
     \sa wolfSSL_get_certificate
     \sa AssertNotNull
 */
-WOLFSSL_API WOLFSSL_X509*
+WOLFSSL_X509*
     wolfSSL_X509_load_certificate_file(const char* fname, int format);
 
 /*!
@@ -6310,8 +6311,9 @@ WOLFSSL_API WOLFSSL_X509*
     \sa wolfSSL_X509_get_hw_serial_number
     \sa wolfSSL_X509_d2i
 */
-WOLFSSL_API unsigned char*
-           wolfSSL_X509_get_device_type(WOLFSSL_X509*, unsigned char*, int*);
+unsigned char*
+           wolfSSL_X509_get_device_type(WOLFSSL_X509* x509, unsigned char* in,
+                                        int* inOutSz);
 
 /*!
     \ingroup CertsKeys
@@ -6344,8 +6346,9 @@ WOLFSSL_API unsigned char*
     \sa wolfSSL_X509_get_hw_serial_number
     \sa wolfSSL_X509_get_device_type
 */
-WOLFSSL_API unsigned char*
-           wolfSSL_X509_get_hw_type(WOLFSSL_X509*, unsigned char*, int*);
+unsigned char*
+           wolfSSL_X509_get_hw_type(WOLFSSL_X509* x509, unsigned char* in,
+                                    int* inOutSz);
 
 /*!
     \ingroup CertsKeys
@@ -6380,8 +6383,9 @@ WOLFSSL_API unsigned char*
     \sa wolfSSL_get_peer_certificate
     \sa wolfSSL_X509_version
 */
-WOLFSSL_API unsigned char*
-           wolfSSL_X509_get_hw_serial_number(WOLFSSL_X509*, unsigned char*, int*);
+unsigned char*
+           wolfSSL_X509_get_hw_serial_number(WOLFSSL_X509* x509,
+                                             unsigned char* in, int* inOutSz);
 
 /*!
     \ingroup IO
@@ -6427,7 +6431,7 @@ WOLFSSL_API unsigned char*
     \sa wolfSSL_connect
     \sa wolfSSL_accept
 */
-WOLFSSL_API int  wolfSSL_connect_cert(WOLFSSL* ssl);
+int  wolfSSL_connect_cert(WOLFSSL* ssl);
 
 /*!
     \ingroup openSSL
@@ -6463,7 +6467,7 @@ WOLFSSL_API int  wolfSSL_connect_cert(WOLFSSL* ssl);
     \sa wolfSSL_PKCS12_parse
     \sa wc_PKCS12_free
 */
-WOLFSSL_API WC_PKCS12* wolfSSL_d2i_PKCS12_bio(WOLFSSL_BIO* bio,
+WC_PKCS12* wolfSSL_d2i_PKCS12_bio(WOLFSSL_BIO* bio,
                                        WC_PKCS12** pkcs12);
 
 /*!
@@ -6502,7 +6506,7 @@ WOLFSSL_API WC_PKCS12* wolfSSL_d2i_PKCS12_bio(WOLFSSL_BIO* bio,
     \sa wolfSSL_PKCS12_parse
     \sa wc_PKCS12_free
 */
-WOLFSSL_API WC_PKCS12* wolfSSL_i2d_PKCS12_bio(WOLFSSL_BIO* bio,
+WC_PKCS12* wolfSSL_i2d_PKCS12_bio(WOLFSSL_BIO* bio,
                                        WC_PKCS12* pkcs12);
 
 /*!
@@ -6555,7 +6559,7 @@ WOLFSSL_API WC_PKCS12* wolfSSL_i2d_PKCS12_bio(WOLFSSL_BIO* bio,
     \sa wolfSSL_d2i_PKCS12_bio
     \sa wc_PKCS12_free
 */
-WOLFSSL_API int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
+int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
      WOLFSSL_EVP_PKEY** pkey, WOLFSSL_X509** cert, WOLF_STACK_OF(WOLFSSL_X509)** ca);
 
 /*!
@@ -6587,7 +6591,7 @@ WOLFSSL_API int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
 
     \sa SSL_accept
 */
-WOLFSSL_API int  wolfSSL_SetTmpDH(WOLFSSL*, const unsigned char* p, int pSz,
+int  wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
                                 const unsigned char* g, int gSz);
 
 /*!
@@ -6638,7 +6642,7 @@ WOLFSSL_API int  wolfSSL_SetTmpDH(WOLFSSL*, const unsigned char* p, int pSz,
     \sa wolfSSL_CTX_SetTmpDH
     \sa wolfSSL_CTX_SetTmpDH_file
 */
-WOLFSSL_API int  wolfSSL_SetTmpDH_buffer(WOLFSSL*, const unsigned char* b, long sz,
+int  wolfSSL_SetTmpDH_buffer(WOLFSSL* ssl, const unsigned char* b, long sz,
                                        int format);
 
 /*!
@@ -6682,7 +6686,7 @@ WOLFSSL_API int  wolfSSL_SetTmpDH_buffer(WOLFSSL*, const unsigned char* b, long 
     \sa wolfSSL_SetTmpDH
     \sa wolfSSL_CTX_SetTmpDH
 */
-WOLFSSL_API int  wolfSSL_SetTmpDH_file(WOLFSSL*, const char* f, int format);
+int  wolfSSL_SetTmpDH_file(WOLFSSL* ssl, const char* f, int format);
 
 /*!
     \ingroup CertsKeys
@@ -6728,7 +6732,7 @@ WOLFSSL_API int  wolfSSL_SetTmpDH_file(WOLFSSL*, const char* f, int format);
     \sa wolfSSL_SetTmpDH
     \sa wc_DhParamsLoad
 */
-WOLFSSL_API int  wolfSSL_CTX_SetTmpDH(WOLFSSL_CTX*, const unsigned char* p,
+int  wolfSSL_CTX_SetTmpDH(WOLFSSL_CTX* ctx, const unsigned char* p,
                                     int pSz, const unsigned char* g, int gSz);
 
 /*!
@@ -6773,7 +6777,7 @@ WOLFSSL_API int  wolfSSL_CTX_SetTmpDH(WOLFSSL_CTX*, const unsigned char* p,
     \sa wolfSSL_SetTmpDH_file_wrapper
     \sa wolfSSL_CTX_SetTmpDH_file
 */
-WOLFSSL_API int  wolfSSL_CTX_SetTmpDH_buffer(WOLFSSL_CTX*, const unsigned char* b,
+int  wolfSSL_CTX_SetTmpDH_buffer(WOLFSSL_CTX* ctx, const unsigned char* b,
                                            long sz, int format);
 
 /*!
@@ -6831,7 +6835,7 @@ WOLFSSL_API int  wolfSSL_CTX_SetTmpDH_buffer(WOLFSSL_CTX*, const unsigned char* 
     \sa AllocDer
     \sa PemToDer
 */
-WOLFSSL_API int  wolfSSL_CTX_SetTmpDH_file(WOLFSSL_CTX*, const char* f,
+int  wolfSSL_CTX_SetTmpDH_file(WOLFSSL_CTX* ctx, const char* f,
                                              int format);
 
 /*!
@@ -6861,7 +6865,7 @@ WOLFSSL_API int  wolfSSL_CTX_SetTmpDH_file(WOLFSSL_CTX*, const char* f,
     \sa wolfSSL_GetDhKey_Sz
     \sa wolfSSL_CTX_SetTMpDH_file
 */
-WOLFSSL_API int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX* ctx, word16);
+int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX* ctx, word16);
 
 /*!
     \ingroup CertsKeys
@@ -6890,7 +6894,7 @@ WOLFSSL_API int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX* ctx, word16);
     \sa wolfSSL_CTX_SetMinDhKey_Sz
     \sa wolfSSL_GetDhKey_Sz
 */
-WOLFSSL_API int wolfSSL_SetMinDhKey_Sz(WOLFSSL*, word16);
+int wolfSSL_SetMinDhKey_Sz(WOLFSSL* ssl, word16 keySz_bits);
 
 /*!
     \ingroup CertsKeys
@@ -6919,7 +6923,7 @@ WOLFSSL_API int wolfSSL_SetMinDhKey_Sz(WOLFSSL*, word16);
     \sa wolfSSL_GetDhKey_Sz
     \sa wolfSSL_CTX_SetTMpDH_file
 */
-WOLFSSL_API int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX*, word16);
+int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX* ctx, word16 keySz_bits);
 
 /*!
     \ingroup CertsKeys
@@ -6947,7 +6951,7 @@ WOLFSSL_API int wolfSSL_CTX_SetMaxDhKey_Sz(WOLFSSL_CTX*, word16);
     \sa wolfSSL_CTX_SetMaxDhKey_Sz
     \sa wolfSSL_GetDhKey_Sz
 */
-WOLFSSL_API int wolfSSL_SetMaxDhKey_Sz(WOLFSSL*, word16);
+int wolfSSL_SetMaxDhKey_Sz(WOLFSSL* ssl, word16 keySz_bits);
 
 /*!
     \ingroup CertsKeys
@@ -6983,7 +6987,7 @@ WOLFSSL_API int wolfSSL_SetMaxDhKey_Sz(WOLFSSL*, word16);
     \sa wolfSSL_SetTmpDH
     \sa wolfSSL_CTX_SetTmpDH_file
 */
-WOLFSSL_API int wolfSSL_GetDhKey_Sz(WOLFSSL*);
+int wolfSSL_GetDhKey_Sz(WOLFSSL*);
 
 /*!
     \ingroup CertsKeys
@@ -7014,7 +7018,7 @@ WOLFSSL_API int wolfSSL_GetDhKey_Sz(WOLFSSL*);
 
     \sa wolfSSL_SetMinRsaKey_Sz
 */
-WOLFSSL_API int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX*, short);
+int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX* ctx, short keySz);
 
 /*!
     \ingroup CertsKeys
@@ -7043,7 +7047,7 @@ WOLFSSL_API int wolfSSL_CTX_SetMinRsaKey_Sz(WOLFSSL_CTX*, short);
 
     \sa wolfSSL_CTX_SetMinRsaKey_Sz
 */
-WOLFSSL_API int wolfSSL_SetMinRsaKey_Sz(WOLFSSL*, short);
+int wolfSSL_SetMinRsaKey_Sz(WOLFSSL* ssl, short keySz);
 
 /*!
     \ingroup CertsKeys
@@ -7073,7 +7077,7 @@ WOLFSSL_API int wolfSSL_SetMinRsaKey_Sz(WOLFSSL*, short);
 
     \sa wolfSSL_SetMinEccKey_Sz
 */
-WOLFSSL_API int wolfSSL_CTX_SetMinEccKey_Sz(WOLFSSL_CTX*, short);
+int wolfSSL_CTX_SetMinEccKey_Sz(WOLFSSL_CTX* ssl, short keySz);
 
 /*!
     \ingroup CertsKeys
@@ -7105,7 +7109,7 @@ WOLFSSL_API int wolfSSL_CTX_SetMinEccKey_Sz(WOLFSSL_CTX*, short);
     \sa wolfSSL_CTX_SetMinRsaKey_Sz
     \sa wolfSSL_SetMinRsaKey_Sz
 */
-WOLFSSL_API int wolfSSL_SetMinEccKey_Sz(WOLFSSL*, short);
+int wolfSSL_SetMinEccKey_Sz(WOLFSSL* ssl, short keySz);
 
 /*!
     \ingroup CertsKeys
@@ -7138,7 +7142,7 @@ WOLFSSL_API int wolfSSL_SetMinEccKey_Sz(WOLFSSL*, short);
     \sa wc_HmacFinal
     \sa wc_HmacUpdate
 */
-WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL*, void* key, unsigned int len,
+int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
                                                              const char* label);
 
 /*!
@@ -7182,7 +7186,7 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL*, void* key, unsigned int len,
 
     \sa wolfSSL_write
 */
-WOLFSSL_API int wolfSSL_writev(WOLFSSL* ssl, const struct iovec* iov,
+int wolfSSL_writev(WOLFSSL* ssl, const struct iovec* iov,
                                      int iovcnt);
 
 /*!
@@ -7215,7 +7219,7 @@ WOLFSSL_API int wolfSSL_writev(WOLFSSL* ssl, const struct iovec* iov,
     \sa FreeSignerTable
     \sa UnlockMutex
 */
-WOLFSSL_API int wolfSSL_CTX_UnloadCAs(WOLFSSL_CTX*);
+int wolfSSL_CTX_UnloadCAs(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
@@ -7247,7 +7251,7 @@ WOLFSSL_API int wolfSSL_CTX_UnloadCAs(WOLFSSL_CTX*);
     \sa wolfSSL_CTX_trust_peer_buffer
     \sa wolfSSL_CTX_trust_peer_cert
 */
-WOLFSSL_API int wolfSSL_CTX_Unload_trust_peers(WOLFSSL_CTX*);
+int wolfSSL_CTX_Unload_trust_peers(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
@@ -7299,8 +7303,8 @@ WOLFSSL_API int wolfSSL_CTX_Unload_trust_peers(WOLFSSL_CTX*);
     \sa wolfSSL_use_PrivateKey_file
     \sa wolfSSL_use_certificate_chain_file
 */
-WOLFSSL_API int wolfSSL_CTX_trust_peer_buffer(WOLFSSL_CTX*,
-                                               const unsigned char*, long, int);
+int wolfSSL_CTX_trust_peer_buffer(WOLFSSL_CTX* ctx, const unsigned char* in,
+                                  long sz, int format);
 
 /*!
     \ingroup CertsKeys
@@ -7351,8 +7355,8 @@ WOLFSSL_API int wolfSSL_CTX_trust_peer_buffer(WOLFSSL_CTX*,
     \sa wolfSSL_use_PrivateKey_buffer
     \sa wolfSSL_use_certificate_chain_buffer
 */
-WOLFSSL_API int wolfSSL_CTX_load_verify_buffer(WOLFSSL_CTX*,
-                                               const unsigned char*, long, int);
+int wolfSSL_CTX_load_verify_buffer(WOLFSSL_CTX* ctx, const unsigned char* in,
+                                   long sz, int format);
 
 
 /*!
@@ -7411,9 +7415,9 @@ WOLFSSL_API int wolfSSL_CTX_load_verify_buffer(WOLFSSL_CTX*,
     \sa wolfSSL_use_PrivateKey_buffer
     \sa wolfSSL_use_certificate_chain_buffer
 */
-WOLFSSL_API int wolfSSL_CTX_load_verify_buffer_ex(WOLFSSL_CTX*,
-                                               const unsigned char*, long, int,
-                                               int, word32);
+int wolfSSL_CTX_load_verify_buffer_ex(WOLFSSL_CTX* ctx,
+                                      const unsigned char* in, long sz,
+                                      int format, int userChain, word32 flags);
 
 /*!
     \ingroup CertsKeys
@@ -7465,8 +7469,9 @@ WOLFSSL_API int wolfSSL_CTX_load_verify_buffer_ex(WOLFSSL_CTX*,
     \sa wolfSSL_use_PrivateKey_buffer
     \sa wolfSSL_use_certificate_chain_buffer
 */
-WOLFSSL_API int wolfSSL_CTX_load_verify_chain_buffer_format(WOLFSSL_CTX*,
-                                               const unsigned char*, long, int);
+int wolfSSL_CTX_load_verify_chain_buffer_format(WOLFSSL_CTX* ctx,
+                                               const unsigned char* in,
+                                               long sz, int format);
 
 /*!
     \ingroup CertsKeys
@@ -7512,8 +7517,9 @@ WOLFSSL_API int wolfSSL_CTX_load_verify_chain_buffer_format(WOLFSSL_CTX*,
     \sa wolfSSL_use_PrivateKey_buffer
     \sa wolfSSL_use_certificate_chain_buffer
 */
-WOLFSSL_API int wolfSSL_CTX_use_certificate_buffer(WOLFSSL_CTX*,
-                                               const unsigned char*, long, int);
+int wolfSSL_CTX_use_certificate_buffer(WOLFSSL_CTX* ctx,
+                                       const unsigned char* in, long sz,
+                                       int format);
 
 /*!
     \ingroup CertsKeys
@@ -7561,8 +7567,9 @@ WOLFSSL_API int wolfSSL_CTX_use_certificate_buffer(WOLFSSL_CTX*,
     \sa wolfSSL_use_PrivateKey_buffer
     \sa wolfSSL_use_certificate_chain_buffer
 */
-WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_buffer(WOLFSSL_CTX*,
-                                               const unsigned char*, long, int);
+int wolfSSL_CTX_use_PrivateKey_buffer(WOLFSSL_CTX* ctx,
+                                      const unsigned char* in, long sz,
+                                      int format);
 
 /*!
     \ingroup CertsKeys
@@ -7609,8 +7616,8 @@ WOLFSSL_API int wolfSSL_CTX_use_PrivateKey_buffer(WOLFSSL_CTX*,
     \sa wolfSSL_use_PrivateKey_buffer
     \sa wolfSSL_use_certificate_chain_buffer
 */
-WOLFSSL_API int wolfSSL_CTX_use_certificate_chain_buffer(WOLFSSL_CTX*,
-                                                    const unsigned char*, long);
+int wolfSSL_CTX_use_certificate_chain_buffer(WOLFSSL_CTX* ctx,
+                                             const unsigned char* in, long sz);
 
 /*!
     \ingroup CertsKeys
@@ -7656,8 +7663,8 @@ WOLFSSL_API int wolfSSL_CTX_use_certificate_chain_buffer(WOLFSSL_CTX*,
     \sa wolfSSL_use_PrivateKey_buffer
     \sa wolfSSL_use_certificate_chain_buffer
 */
-WOLFSSL_API int wolfSSL_use_certificate_buffer(WOLFSSL*, const unsigned char*,
-                                               long, int);
+int wolfSSL_use_certificate_buffer(WOLFSSL* ssl, const unsigned char* in,
+                                               long sz, int format);
 
 /*!
     \ingroup CertsKeys
@@ -7705,8 +7712,8 @@ WOLFSSL_API int wolfSSL_use_certificate_buffer(WOLFSSL*, const unsigned char*,
     \sa wolfSSL_use_certificate_buffer
     \sa wolfSSL_use_certificate_chain_buffer
 */
-WOLFSSL_API int wolfSSL_use_PrivateKey_buffer(WOLFSSL*, const unsigned char*,
-                                               long, int);
+int wolfSSL_use_PrivateKey_buffer(WOLFSSL* ssl, const unsigned char* in,
+                                               long sz, int format);
 
 /*!
     \ingroup CertsKeys
@@ -7751,8 +7758,8 @@ WOLFSSL_API int wolfSSL_use_PrivateKey_buffer(WOLFSSL*, const unsigned char*,
     \sa wolfSSL_use_certificate_buffer
     \sa wolfSSL_use_PrivateKey_buffer
 */
-WOLFSSL_API int wolfSSL_use_certificate_chain_buffer(WOLFSSL*,
-                                               const unsigned char*, long);
+int wolfSSL_use_certificate_chain_buffer(WOLFSSL* ssl,
+                                         const unsigned char* in, long sz);
 
 /*!
     \ingroup CertsKeys
@@ -7776,7 +7783,7 @@ WOLFSSL_API int wolfSSL_use_certificate_chain_buffer(WOLFSSL*,
 
     \sa wolfSSL_CTX_UnloadCAs
 */
-WOLFSSL_API int wolfSSL_UnloadCertsKeys(WOLFSSL*);
+int wolfSSL_UnloadCertsKeys(WOLFSSL*);
 
 /*!
     \ingroup Setup
@@ -7801,7 +7808,7 @@ WOLFSSL_API int wolfSSL_UnloadCertsKeys(WOLFSSL*);
     \sa wolfSSL_set_group_messages
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API int wolfSSL_CTX_set_group_messages(WOLFSSL_CTX*);
+int wolfSSL_CTX_set_group_messages(WOLFSSL_CTX*);
 
 /*!
     \ingroup Setup
@@ -7826,7 +7833,7 @@ WOLFSSL_API int wolfSSL_CTX_set_group_messages(WOLFSSL_CTX*);
     \sa wolfSSL_CTX_set_group_messages
     \sa wolfSSL_new
 */
-WOLFSSL_API int wolfSSL_set_group_messages(WOLFSSL*);
+int wolfSSL_set_group_messages(WOLFSSL*);
 
 /*!
     \brief This function sets the fuzzer callback.
@@ -7856,7 +7863,7 @@ WOLFSSL_API int wolfSSL_set_group_messages(WOLFSSL*);
 
     \sa CallbackFuzzer
 */
-WOLFSSL_API void wolfSSL_SetFuzzerCb(WOLFSSL* ssl, CallbackFuzzer cbf, void* fCtx);
+void wolfSSL_SetFuzzerCb(WOLFSSL* ssl, CallbackFuzzer cbf, void* fCtx);
 
 /*!
     \brief This function sets a new dtls cookie secret.
@@ -7889,9 +7896,9 @@ WOLFSSL_API void wolfSSL_SetFuzzerCb(WOLFSSL* ssl, CallbackFuzzer cbf, void* fCt
     \sa ForceZero
     \sa wc_RNG_GenerateBlock
 */
-WOLFSSL_API int   wolfSSL_DTLS_SetCookieSecret(WOLFSSL*,
-                                               const unsigned char*,
-                                               unsigned int);
+int   wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
+                                               const unsigned char* secret,
+                                               unsigned int secretSz);
 
 /*!
     \brief This function retrieves the random number.
@@ -7912,7 +7919,7 @@ WOLFSSL_API int   wolfSSL_DTLS_SetCookieSecret(WOLFSSL*,
     \sa  wolfSSL_CTX_new_rng
 
 */
-WOLFSSL_API WC_RNG* wolfSSL_GetRNG(WOLFSSL* ssl);
+WC_RNG* wolfSSL_GetRNG(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -7945,7 +7952,7 @@ WOLFSSL_API WC_RNG* wolfSSL_GetRNG(WOLFSSL* ssl);
 
     \sa SetMinVersionHelper
 */
-WOLFSSL_API int wolfSSL_CTX_SetMinVersion(WOLFSSL_CTX* ctx, int version);
+int wolfSSL_CTX_SetMinVersion(WOLFSSL_CTX* ctx, int version);
 
 /*!
     \ingroup TLS
@@ -7977,7 +7984,7 @@ WOLFSSL_API int wolfSSL_CTX_SetMinVersion(WOLFSSL_CTX* ctx, int version);
 
     \sa SetMinVersionHelper
 */
-WOLFSSL_API int wolfSSL_SetMinVersion(WOLFSSL* ssl, int version);
+int wolfSSL_SetMinVersion(WOLFSSL* ssl, int version);
 
 /*!
     \brief This function returns the size of the WOLFSSL object and will be
@@ -7998,7 +8005,7 @@ WOLFSSL_API int wolfSSL_SetMinVersion(WOLFSSL* ssl, int version);
 
     \sa wolfSSL_new
 */
-WOLFSSL_API int wolfSSL_GetObjectSize(void);  /* object size based on build */
+int wolfSSL_GetObjectSize(void);  /* object size based on build */
 /*!
     \brief Returns the record layer size of the plaintext input. This is helpful
     when an application wants to know how many bytes will be sent across the
@@ -8021,7 +8028,7 @@ WOLFSSL_API int wolfSSL_GetObjectSize(void);  /* object size based on build */
 
     \sa wolfSSL_GetMaxOutputSize
 */
-WOLFSSL_API int wolfSSL_GetOutputSize(WOLFSSL*, int);
+int wolfSSL_GetOutputSize(WOLFSSL* ssl, int inSz);
 
 /*!
     \brief Returns the maximum record layer size for plaintext data.  This
@@ -8045,7 +8052,7 @@ WOLFSSL_API int wolfSSL_GetOutputSize(WOLFSSL*, int);
 
     \sa wolfSSL_GetOutputSize
 */
-WOLFSSL_API int wolfSSL_GetMaxOutputSize(WOLFSSL*);
+int wolfSSL_GetMaxOutputSize(WOLFSSL*);
 
 /*!
     \ingroup Setup
@@ -8078,7 +8085,7 @@ WOLFSSL_API int wolfSSL_GetMaxOutputSize(WOLFSSL*);
 
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API int wolfSSL_SetVersion(WOLFSSL* ssl, int version);
+int wolfSSL_SetVersion(WOLFSSL* ssl, int version);
 
 /*!
     \brief Allows caller to set the Atomic User Record Processing
@@ -8105,7 +8112,7 @@ WOLFSSL_API int wolfSSL_SetVersion(WOLFSSL* ssl, int version);
     \sa wolfSSL_SetMacEncryptCtx
     \sa wolfSSL_GetMacEncryptCtx
 */
-WOLFSSL_API void  wolfSSL_CTX_SetMacEncryptCb(WOLFSSL_CTX*, CallbackMacEncrypt);
+void  wolfSSL_CTX_SetMacEncryptCb(WOLFSSL_CTX* ctx, CallbackMacEncrypti cb);
 
 /*!
     \brief Allows caller to set the Atomic User Record Processing Mac/Encrypt
@@ -8123,7 +8130,7 @@ WOLFSSL_API void  wolfSSL_CTX_SetMacEncryptCb(WOLFSSL_CTX*, CallbackMacEncrypt);
     \sa wolfSSL_CTX_SetMacEncryptCb
     \sa wolfSSL_GetMacEncryptCtx
 */
-WOLFSSL_API void  wolfSSL_SetMacEncryptCtx(WOLFSSL* ssl, void *ctx);
+void  wolfSSL_SetMacEncryptCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
     \brief Allows caller to retrieve the Atomic User Record Processing
@@ -8144,7 +8151,7 @@ WOLFSSL_API void  wolfSSL_SetMacEncryptCtx(WOLFSSL* ssl, void *ctx);
     \sa wolfSSL_CTX_SetMacEncryptCb
     \sa wolfSSL_SetMacEncryptCtx
 */
-WOLFSSL_API void* wolfSSL_GetMacEncryptCtx(WOLFSSL* ssl);
+void* wolfSSL_GetMacEncryptCtx(WOLFSSL* ssl);
 
 /*!
     \brief Allows caller to set the Atomic User Record Processing
@@ -8170,8 +8177,8 @@ WOLFSSL_API void* wolfSSL_GetMacEncryptCtx(WOLFSSL* ssl);
     \sa wolfSSL_SetMacEncryptCtx
     \sa wolfSSL_GetMacEncryptCtx
 */
-WOLFSSL_API void  wolfSSL_CTX_SetDecryptVerifyCb(WOLFSSL_CTX*,
-                                               CallbackDecryptVerify);
+void  wolfSSL_CTX_SetDecryptVerifyCb(WOLFSSL_CTX* ctx,
+                                               CallbackDecryptVerify cb);
 
 /*!
     \brief Allows caller to set the Atomic User Record Processing
@@ -8189,7 +8196,7 @@ WOLFSSL_API void  wolfSSL_CTX_SetDecryptVerifyCb(WOLFSSL_CTX*,
     \sa wolfSSL_CTX_SetDecryptVerifyCb
     \sa wolfSSL_GetDecryptVerifyCtx
 */
-WOLFSSL_API void  wolfSSL_SetDecryptVerifyCtx(WOLFSSL* ssl, void *ctx);
+void  wolfSSL_SetDecryptVerifyCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
     \brief Allows caller to retrieve the Atomic User Record Processing
@@ -8210,7 +8217,7 @@ WOLFSSL_API void  wolfSSL_SetDecryptVerifyCtx(WOLFSSL* ssl, void *ctx);
     \sa wolfSSL_CTX_SetDecryptVerifyCb
     \sa wolfSSL_SetDecryptVerifyCtx
 */
-WOLFSSL_API void* wolfSSL_GetDecryptVerifyCtx(WOLFSSL* ssl);
+void* wolfSSL_GetDecryptVerifyCtx(WOLFSSL* ssl);
 
 /*!
     \brief Allows retrieval of the Hmac/Mac secret from the handshake process.
@@ -8231,7 +8238,7 @@ WOLFSSL_API void* wolfSSL_GetDecryptVerifyCtx(WOLFSSL* ssl);
 
     \sa wolfSSL_GetHmacSize
 */
-WOLFSSL_API const unsigned char* wolfSSL_GetMacSecret(WOLFSSL*, int);
+const unsigned char* wolfSSL_GetMacSecret(WOLFSSL* ssl, int verify);
 
 /*!
     \brief Allows retrieval of the client write key from the handshake process.
@@ -8250,7 +8257,7 @@ WOLFSSL_API const unsigned char* wolfSSL_GetMacSecret(WOLFSSL*, int);
     \sa wolfSSL_GetKeySize
     \sa wolfSSL_GetClientWriteIV
 */
-WOLFSSL_API const unsigned char* wolfSSL_GetClientWriteKey(WOLFSSL*);
+const unsigned char* wolfSSL_GetClientWriteKey(WOLFSSL*);
 
 /*!
     \brief Allows retrieval of the client write IV (initialization vector)
@@ -8270,7 +8277,7 @@ WOLFSSL_API const unsigned char* wolfSSL_GetClientWriteKey(WOLFSSL*);
     \sa wolfSSL_GetCipherBlockSize()
     \sa wolfSSL_GetClientWriteKey()
 */
-WOLFSSL_API const unsigned char* wolfSSL_GetClientWriteIV(WOLFSSL*);
+const unsigned char* wolfSSL_GetClientWriteIV(WOLFSSL*);
 
 /*!
     \brief Allows retrieval of the server write key from the handshake process.
@@ -8289,7 +8296,7 @@ WOLFSSL_API const unsigned char* wolfSSL_GetClientWriteIV(WOLFSSL*);
     \sa wolfSSL_GetKeySize
     \sa wolfSSL_GetServerWriteIV
 */
-WOLFSSL_API const unsigned char* wolfSSL_GetServerWriteKey(WOLFSSL*);
+const unsigned char* wolfSSL_GetServerWriteKey(WOLFSSL*);
 
 /*!
     \brief Allows retrieval of the server write IV (initialization vector)
@@ -8304,7 +8311,7 @@ WOLFSSL_API const unsigned char* wolfSSL_GetServerWriteKey(WOLFSSL*);
     \sa wolfSSL_GetCipherBlockSize
     \sa wolfSSL_GetClientWriteKey
 */
-WOLFSSL_API const unsigned char* wolfSSL_GetServerWriteIV(WOLFSSL*);
+const unsigned char* wolfSSL_GetServerWriteIV(WOLFSSL*);
 
 /*!
     \brief Allows retrieval of the key size from the handshake process.
@@ -8322,7 +8329,7 @@ WOLFSSL_API const unsigned char* wolfSSL_GetServerWriteIV(WOLFSSL*);
     \sa wolfSSL_GetClientWriteKey
     \sa wolfSSL_GetServerWriteKey
 */
-WOLFSSL_API int                  wolfSSL_GetKeySize(WOLFSSL*);
+int                  wolfSSL_GetKeySize(WOLFSSL*);
 
 /*!
     \ingroup CertsKeys
@@ -8352,7 +8359,7 @@ WOLFSSL_API int                  wolfSSL_GetKeySize(WOLFSSL*);
     \sa wolfSSL_GetClientWriteIV
     \sa wolfSSL_GetServerWriteIV
 */
-WOLFSSL_API int                  wolfSSL_GetIVSize(WOLFSSL*);
+int                  wolfSSL_GetIVSize(WOLFSSL*);
 
 /*!
     \brief Allows retrieval of the side of this WOLFSSL connection.
@@ -8372,7 +8379,7 @@ WOLFSSL_API int                  wolfSSL_GetIVSize(WOLFSSL*);
     \sa wolfSSL_GetClientWriteKey
     \sa wolfSSL_GetServerWriteKey
 */
-WOLFSSL_API int                  wolfSSL_GetSide(WOLFSSL*);
+int                  wolfSSL_GetSide(WOLFSSL*);
 
 /*!
     \brief Allows caller to determine if the negotiated protocol version
@@ -8391,7 +8398,7 @@ WOLFSSL_API int                  wolfSSL_GetSide(WOLFSSL*);
 
     \sa wolfSSL_GetSide
 */
-WOLFSSL_API int                  wolfSSL_IsTLSv1_1(WOLFSSL*);
+int                  wolfSSL_IsTLSv1_1(WOLFSSL*);
 
 /*!
     \brief Allows caller to determine the negotiated bulk cipher algorithm
@@ -8412,7 +8419,7 @@ WOLFSSL_API int                  wolfSSL_IsTLSv1_1(WOLFSSL*);
     \sa wolfSSL_GetCipherBlockSize
     \sa wolfSSL_GetKeySize
 */
-WOLFSSL_API int                  wolfSSL_GetBulkCipher(WOLFSSL*);
+int                  wolfSSL_GetBulkCipher(WOLFSSL*);
 
 /*!
     \brief Allows caller to determine the negotiated cipher block size from
@@ -8432,7 +8439,7 @@ WOLFSSL_API int                  wolfSSL_GetBulkCipher(WOLFSSL*);
     \sa wolfSSL_GetBulkCipher
     \sa wolfSSL_GetKeySize
 */
-WOLFSSL_API int                  wolfSSL_GetCipherBlockSize(WOLFSSL*);
+int                  wolfSSL_GetCipherBlockSize(WOLFSSL*);
 
 /*!
     \brief Allows caller to determine the negotiated aead mac size from the
@@ -8452,7 +8459,7 @@ WOLFSSL_API int                  wolfSSL_GetCipherBlockSize(WOLFSSL*);
     \sa wolfSSL_GetBulkCipher
     \sa wolfSSL_GetKeySize
 */
-WOLFSSL_API int                  wolfSSL_GetAeadMacSize(WOLFSSL*);
+int                  wolfSSL_GetAeadMacSize(WOLFSSL*);
 
 /*!
     \brief Allows caller to determine the negotiated (h)mac size from the
@@ -8472,7 +8479,7 @@ WOLFSSL_API int                  wolfSSL_GetAeadMacSize(WOLFSSL*);
     \sa wolfSSL_GetBulkCipher
     \sa wolfSSL_GetHmacType
 */
-WOLFSSL_API int                  wolfSSL_GetHmacSize(WOLFSSL*);
+int                  wolfSSL_GetHmacSize(WOLFSSL*);
 
 /*!
     \brief Allows caller to determine the negotiated (h)mac type from the
@@ -8493,7 +8500,7 @@ WOLFSSL_API int                  wolfSSL_GetHmacSize(WOLFSSL*);
     \sa wolfSSL_GetBulkCipher
     \sa wolfSSL_GetHmacSize
 */
-WOLFSSL_API int                  wolfSSL_GetHmacType(WOLFSSL*);
+int                  wolfSSL_GetHmacType(WOLFSSL*);
 
 /*!
     \brief Allows caller to determine the negotiated cipher type
@@ -8513,7 +8520,7 @@ WOLFSSL_API int                  wolfSSL_GetHmacType(WOLFSSL*);
     \sa wolfSSL_GetBulkCipher
     \sa wolfSSL_GetHmacType
 */
-WOLFSSL_API int                  wolfSSL_GetCipherType(WOLFSSL*);
+int                  wolfSSL_GetCipherType(WOLFSSL*);
 
 /*!
     \brief Allows caller to set the Hmac Inner vector for message
@@ -8536,8 +8543,8 @@ WOLFSSL_API int                  wolfSSL_GetCipherType(WOLFSSL*);
     \sa wolfSSL_GetBulkCipher
     \sa wolfSSL_GetHmacType
 */
-WOLFSSL_API int                  wolfSSL_SetTlsHmacInner(WOLFSSL*, unsigned char*,
-                                                       word32, int, int);
+int wolfSSL_SetTlsHmacInner(WOLFSSL* ssl, byte* inner,
+                            word32 sz, int content, int verify);
 
 /*!
     \brief Allows caller to set the Public Key Callback for ECC Signing.
@@ -8563,7 +8570,7 @@ WOLFSSL_API int                  wolfSSL_SetTlsHmacInner(WOLFSSL*, unsigned char
     \sa wolfSSL_SetEccSignCtx
     \sa wolfSSL_GetEccSignCtx
 */
-WOLFSSL_API void  wolfSSL_CTX_SetEccSignCb(WOLFSSL_CTX*, CallbackEccSign);
+void  wolfSSL_CTX_SetEccSignCb(WOLFSSL_CTX* ctx, CallbackEccSign cb);
 
 /*!
     \brief Allows caller to set the Public Key Ecc Signing Callback
@@ -8581,7 +8588,7 @@ WOLFSSL_API void  wolfSSL_CTX_SetEccSignCb(WOLFSSL_CTX*, CallbackEccSign);
     \sa wolfSSL_CTX_SetEccSignCb
     \sa wolfSSL_GetEccSignCtx
 */
-WOLFSSL_API void  wolfSSL_SetEccSignCtx(WOLFSSL* ssl, void *ctx);
+void  wolfSSL_SetEccSignCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
     \brief Allows caller to retrieve the Public Key Ecc Signing Callback
@@ -8601,7 +8608,7 @@ WOLFSSL_API void  wolfSSL_SetEccSignCtx(WOLFSSL* ssl, void *ctx);
     \sa wolfSSL_CTX_SetEccSignCb
     \sa wolfSSL_SetEccSignCtx
 */
-WOLFSSL_API void* wolfSSL_GetEccSignCtx(WOLFSSL* ssl);
+void* wolfSSL_GetEccSignCtx(WOLFSSL* ssl);
 
 /*!
     \brief Allows caller to set the Public Key Callback for ECC Verification.
@@ -8627,7 +8634,7 @@ WOLFSSL_API void* wolfSSL_GetEccSignCtx(WOLFSSL* ssl);
     \sa wolfSSL_SetEccVerifyCtx
     \sa wolfSSL_GetEccVerifyCtx
 */
-WOLFSSL_API void  wolfSSL_CTX_SetEccVerifyCb(WOLFSSL_CTX*, CallbackEccVerify);
+void  wolfSSL_CTX_SetEccVerifyCb(WOLFSSL_CTX* ctx, CallbackEccVerify cb);
 
 /*!
     \brief Allows caller to set the Public Key Ecc Verification Callback
@@ -8645,7 +8652,7 @@ WOLFSSL_API void  wolfSSL_CTX_SetEccVerifyCb(WOLFSSL_CTX*, CallbackEccVerify);
     \sa wolfSSL_CTX_SetEccVerifyCb
     \sa wolfSSL_GetEccVerifyCtx
 */
-WOLFSSL_API void  wolfSSL_SetEccVerifyCtx(WOLFSSL* ssl, void *ctx);
+void  wolfSSL_SetEccVerifyCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
     \brief Allows caller to retrieve the Public Key Ecc Verification Callback
@@ -8665,7 +8672,7 @@ WOLFSSL_API void  wolfSSL_SetEccVerifyCtx(WOLFSSL* ssl, void *ctx);
     \sa wolfSSL_CTX_SetEccVerifyCb
     \sa wolfSSL_SetEccVerifyCtx
 */
-WOLFSSL_API void* wolfSSL_GetEccVerifyCtx(WOLFSSL* ssl);
+void* wolfSSL_GetEccVerifyCtx(WOLFSSL* ssl);
 
 /*!
     \brief Allows caller to set the Public Key Callback for RSA Signing.
@@ -8691,7 +8698,7 @@ WOLFSSL_API void* wolfSSL_GetEccVerifyCtx(WOLFSSL* ssl);
     \sa wolfSSL_SetRsaSignCtx
     \sa wolfSSL_GetRsaSignCtx
 */
-WOLFSSL_API void  wolfSSL_CTX_SetRsaSignCb(WOLFSSL_CTX*, CallbackRsaSign);
+void  wolfSSL_CTX_SetRsaSignCb(WOLFSSL_CTX* ctx, CallbackRsaSign cb);
 
 /*!
     \brief Allows caller to set the Public Key RSA Signing Callback Context
@@ -8709,7 +8716,7 @@ WOLFSSL_API void  wolfSSL_CTX_SetRsaSignCb(WOLFSSL_CTX*, CallbackRsaSign);
     \sa wolfSSL_CTX_SetRsaSignCb
     \sa wolfSSL_GetRsaSignCtx
 */
-WOLFSSL_API void  wolfSSL_SetRsaSignCtx(WOLFSSL* ssl, void *ctx);
+void  wolfSSL_SetRsaSignCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
     \brief Allows caller to retrieve the Public Key RSA Signing Callback
@@ -8730,7 +8737,7 @@ WOLFSSL_API void  wolfSSL_SetRsaSignCtx(WOLFSSL* ssl, void *ctx);
     \sa wolfSSL_CTX_SetRsaSignCb
     \sa wolfSSL_SetRsaSignCtx
 */
-WOLFSSL_API void* wolfSSL_GetRsaSignCtx(WOLFSSL* ssl);
+void* wolfSSL_GetRsaSignCtx(WOLFSSL* ssl);
 
 /*!
     \brief Allows caller to set the Public Key Callback for RSA Verification.
@@ -8749,7 +8756,7 @@ WOLFSSL_API void* wolfSSL_GetRsaSignCtx(WOLFSSL* ssl);
     \sa wolfSSL_SetRsaVerifyCtx
     \sa wolfSSL_GetRsaVerifyCtx
 */
-WOLFSSL_API void  wolfSSL_CTX_SetRsaVerifyCb(WOLFSSL_CTX*, CallbackRsaVerify);
+void  wolfSSL_CTX_SetRsaVerifyCb(WOLFSSL_CTX* ctx, CallbackRsaVerify cb);
 
 /*!
     \brief Allows caller to set the Public Key RSA Verification Callback
@@ -8767,7 +8774,7 @@ WOLFSSL_API void  wolfSSL_CTX_SetRsaVerifyCb(WOLFSSL_CTX*, CallbackRsaVerify);
     \sa wolfSSL_CTX_SetRsaVerifyCb
     \sa wolfSSL_GetRsaVerifyCtx
 */
-WOLFSSL_API void  wolfSSL_SetRsaVerifyCtx(WOLFSSL* ssl, void *ctx);
+void  wolfSSL_SetRsaVerifyCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
     \brief Allows caller to retrieve the Public Key RSA Verification Callback
@@ -8787,7 +8794,7 @@ WOLFSSL_API void  wolfSSL_SetRsaVerifyCtx(WOLFSSL* ssl, void *ctx);
     \sa wolfSSL_CTX_SetRsaVerifyCb
     \sa wolfSSL_SetRsaVerifyCtx
 */
-WOLFSSL_API void* wolfSSL_GetRsaVerifyCtx(WOLFSSL* ssl);
+void* wolfSSL_GetRsaVerifyCtx(WOLFSSL* ssl);
 
 /*!
     \brief Allows caller to set the Public Key Callback for RSA Public
@@ -8813,7 +8820,7 @@ WOLFSSL_API void* wolfSSL_GetRsaVerifyCtx(WOLFSSL* ssl);
     \sa wolfSSL_SetRsaEncCtx
     \sa wolfSSL_GetRsaEncCtx
 */
-WOLFSSL_API void  wolfSSL_CTX_SetRsaEncCb(WOLFSSL_CTX*, CallbackRsaEnc);
+void  wolfSSL_CTX_SetRsaEncCb(WOLFSSL_CTX* ctx, CallbackRsaEnc cb);
 
 /*!
     \brief Allows caller to set the Public Key RSA Public Encrypt
@@ -8831,7 +8838,7 @@ WOLFSSL_API void  wolfSSL_CTX_SetRsaEncCb(WOLFSSL_CTX*, CallbackRsaEnc);
     \sa wolfSSL_CTX_SetRsaEncCb
     \sa wolfSSL_GetRsaEncCtx
 */
-WOLFSSL_API void  wolfSSL_SetRsaEncCtx(WOLFSSL* ssl, void *ctx);
+void  wolfSSL_SetRsaEncCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
     \brief Allows caller to retrieve the Public Key RSA Public Encrypt
@@ -8851,7 +8858,7 @@ WOLFSSL_API void  wolfSSL_SetRsaEncCtx(WOLFSSL* ssl, void *ctx);
     \sa wolfSSL_CTX_SetRsaEncCb
     \sa wolfSSL_SetRsaEncCtx
 */
-WOLFSSL_API void* wolfSSL_GetRsaEncCtx(WOLFSSL* ssl);
+void* wolfSSL_GetRsaEncCtx(WOLFSSL* ssl);
 
 /*!
     \brief Allows caller to set the Public Key Callback for RSA Private
@@ -8876,7 +8883,7 @@ WOLFSSL_API void* wolfSSL_GetRsaEncCtx(WOLFSSL* ssl);
     \sa wolfSSL_SetRsaDecCtx
     \sa wolfSSL_GetRsaDecCtx
 */
-WOLFSSL_API void  wolfSSL_CTX_SetRsaDecCb(WOLFSSL_CTX*, CallbackRsaDec);
+void  wolfSSL_CTX_SetRsaDecCb(WOLFSSL_CTX* ctx, CallbackRsaDec cb);
 
 /*!
     \brief Allows caller to set the Public Key RSA Private Decrypt
@@ -8894,7 +8901,7 @@ WOLFSSL_API void  wolfSSL_CTX_SetRsaDecCb(WOLFSSL_CTX*, CallbackRsaDec);
     \sa wolfSSL_CTX_SetRsaDecCb
     \sa wolfSSL_GetRsaDecCtx
 */
-WOLFSSL_API void  wolfSSL_SetRsaDecCtx(WOLFSSL* ssl, void *ctx);
+void  wolfSSL_SetRsaDecCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
     \brief Allows caller to retrieve the Public Key RSA Private Decrypt
@@ -8914,7 +8921,7 @@ WOLFSSL_API void  wolfSSL_SetRsaDecCtx(WOLFSSL* ssl, void *ctx);
     \sa wolfSSL_CTX_SetRsaDecCb
     \sa wolfSSL_SetRsaDecCtx
 */
-WOLFSSL_API void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl);
+void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl);
 
 /*!
     \brief This function registers a callback with the SSL context
@@ -8948,7 +8955,7 @@ WOLFSSL_API void* wolfSSL_GetRsaDecCtx(WOLFSSL* ssl);
 
     \sa wolfSSL_CTX_load_verify_locations
 */
-WOLFSSL_API void wolfSSL_CTX_SetCACb(WOLFSSL_CTX*, CallbackCACache);
+void wolfSSL_CTX_SetCACb(WOLFSSL_CTX* ctx, CallbackCACache cb);
 
 /*!
     \ingroup CertManager
@@ -8964,7 +8971,7 @@ WOLFSSL_API void wolfSSL_CTX_SetCACb(WOLFSSL_CTX*, CallbackCACache);
 
     \sa wolfSSL_CertManagerFree
 */
-WOLFSSL_API WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew_ex(void* heap);
+WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew_ex(void* heap);
 
 /*!
     \ingroup CertManager
@@ -8991,7 +8998,7 @@ WOLFSSL_API WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew_ex(void* heap);
 
     \sa wolfSSL_CertManagerFree
 */
-WOLFSSL_API WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew(void);
+WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew(void);
 
 /*!
     \ingroup CertManager
@@ -9014,7 +9021,7 @@ WOLFSSL_API WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew(void);
 
     \sa wolfSSL_CertManagerNew
 */
-WOLFSSL_API void wolfSSL_CertManagerFree(WOLFSSL_CERT_MANAGER*);
+void wolfSSL_CertManagerFree(WOLFSSL_CERT_MANAGER*);
 
 /*!
     \ingroup CertManager
@@ -9056,7 +9063,7 @@ WOLFSSL_API void wolfSSL_CertManagerFree(WOLFSSL_CERT_MANAGER*);
 
     \sa wolfSSL_CertManagerVerify
 */
-WOLFSSL_API int wolfSSL_CertManagerLoadCA(WOLFSSL_CERT_MANAGER*, const char* f,
+int wolfSSL_CertManagerLoadCA(WOLFSSL_CERT_MANAGER* cm, const char* f,
                                                                  const char* d);
 
 /*!
@@ -9093,7 +9100,7 @@ WOLFSSL_API int wolfSSL_CertManagerLoadCA(WOLFSSL_CERT_MANAGER*, const char* f,
     \sa ProcessBuffer
     \sa cm_pick_method
 */
-WOLFSSL_API int wolfSSL_CertManagerLoadCABuffer(WOLFSSL_CERT_MANAGER*,
+int wolfSSL_CertManagerLoadCABuffer(WOLFSSL_CERT_MANAGER* cm,
                                   const unsigned char* in, long sz, int format);
 
 /*!
@@ -9122,7 +9129,7 @@ WOLFSSL_API int wolfSSL_CertManagerLoadCABuffer(WOLFSSL_CERT_MANAGER*,
     \sa FreeSignerTable
     \sa UnlockMutex
 */
-WOLFSSL_API int wolfSSL_CertManagerUnloadCAs(WOLFSSL_CERT_MANAGER* cm);
+int wolfSSL_CertManagerUnloadCAs(WOLFSSL_CERT_MANAGER* cm);
 
 /*!
     \ingroup CertManager
@@ -9151,7 +9158,7 @@ WOLFSSL_API int wolfSSL_CertManagerUnloadCAs(WOLFSSL_CERT_MANAGER* cm);
 
     \sa UnLockMutex
 */
-WOLFSSL_API int wolfSSL_CertManagerUnload_trust_peers(WOLFSSL_CERT_MANAGER* cm);
+int wolfSSL_CertManagerUnload_trust_peers(WOLFSSL_CERT_MANAGER* cm);
 
 /*!
     \ingroup CertManager
@@ -9202,7 +9209,7 @@ WOLFSSL_API int wolfSSL_CertManagerUnload_trust_peers(WOLFSSL_CERT_MANAGER* cm);
     \sa wolfSSL_CertManagerLoadCA
     \sa wolfSSL_CertManagerVerifyBuffer
 */
-WOLFSSL_API int wolfSSL_CertManagerVerify(WOLFSSL_CERT_MANAGER*, const char* f,
+int wolfSSL_CertManagerVerify(WOLFSSL_CERT_MANAGER* cm, const char* f,
                                                                     int format);
 
 /*!
@@ -9258,7 +9265,7 @@ WOLFSSL_API int wolfSSL_CertManagerVerify(WOLFSSL_CERT_MANAGER*, const char* f,
     \sa wolfSSL_CertManagerLoadCA
     \sa wolfSSL_CertManagerVerify
 */
-WOLFSSL_API int wolfSSL_CertManagerVerifyBuffer(WOLFSSL_CERT_MANAGER* cm,
+int wolfSSL_CertManagerVerifyBuffer(WOLFSSL_CERT_MANAGER* cm,
                                 const unsigned char* buff, long sz, int format);
 
 /*!
@@ -9290,7 +9297,7 @@ WOLFSSL_API int wolfSSL_CertManagerVerifyBuffer(WOLFSSL_CERT_MANAGER* cm,
 
     \sa wolfSSL_CertManagerVerify
 */
-WOLFSSL_API void wolfSSL_CertManagerSetVerify(WOLFSSL_CERT_MANAGER* cm,
+void wolfSSL_CertManagerSetVerify(WOLFSSL_CERT_MANAGER* cm,
                                                              VerifyCallback vc);
 
 /*!
@@ -9322,8 +9329,8 @@ WOLFSSL_API void wolfSSL_CertManagerSetVerify(WOLFSSL_CERT_MANAGER* cm,
     \sa wolfSSL_CertManagerSetCRL_CB
     \sa InitDecodedCert
 */
-WOLFSSL_API int wolfSSL_CertManagerCheckCRL(WOLFSSL_CERT_MANAGER*,
-                                                        unsigned char*, int sz);
+int wolfSSL_CertManagerCheckCRL(WOLFSSL_CERT_MANAGER* cm,
+                                unsigned char* der, int sz);
 
 /*!
     \ingroup CertManager
@@ -9364,7 +9371,7 @@ WOLFSSL_API int wolfSSL_CertManagerCheckCRL(WOLFSSL_CERT_MANAGER*,
 
     \sa wolfSSL_CertManagerDisableCRL
 */
-WOLFSSL_API int wolfSSL_CertManagerEnableCRL(WOLFSSL_CERT_MANAGER*,
+int wolfSSL_CertManagerEnableCRL(WOLFSSL_CERT_MANAGER* cm,
                                                                    int options);
 
 /*!
@@ -9398,7 +9405,7 @@ WOLFSSL_API int wolfSSL_CertManagerEnableCRL(WOLFSSL_CERT_MANAGER*,
 
     \sa wolfSSL_CertManagerEnableCRL
 */
-WOLFSSL_API int wolfSSL_CertManagerDisableCRL(WOLFSSL_CERT_MANAGER*);
+int wolfSSL_CertManagerDisableCRL(WOLFSSL_CERT_MANAGER*);
 
 /*!
     \ingroup CertManager
@@ -9432,8 +9439,8 @@ WOLFSSL_API int wolfSSL_CertManagerDisableCRL(WOLFSSL_CERT_MANAGER*);
     \sa wolfSSL_CertManagerEnableCRL
     \sa wolfSSL_LoadCRL
 */
-WOLFSSL_API int wolfSSL_CertManagerLoadCRL(WOLFSSL_CERT_MANAGER*,
-                                                         const char*, int, int);
+int wolfSSL_CertManagerLoadCRL(WOLFSSL_CERT_MANAGER* cm,
+                               const char* path, int type, int monitor);
 
 /*!
     \ingroup CertManager
@@ -9469,8 +9476,9 @@ WOLFSSL_API int wolfSSL_CertManagerLoadCRL(WOLFSSL_CERT_MANAGER*,
     \sa BufferLoadCRL
     \sa wolfSSL_CertManagerEnableCRL
 */
-WOLFSSL_API int wolfSSL_CertManagerLoadCRLBuffer(WOLFSSL_CERT_MANAGER*,
-                                            const unsigned char*, long sz, int);
+int wolfSSL_CertManagerLoadCRLBuffer(WOLFSSL_CERT_MANAGER* cm,
+                                     const unsigned char* buff, long sz,
+                                     int type);
 
 /*!
     \ingroup CertManager
@@ -9509,8 +9517,8 @@ WOLFSSL_API int wolfSSL_CertManagerLoadCRLBuffer(WOLFSSL_CERT_MANAGER*,
     \sa CbMissingCRL
     \sa wolfSSL_SetCRL_Cb
 */
-WOLFSSL_API int wolfSSL_CertManagerSetCRL_Cb(WOLFSSL_CERT_MANAGER*,
-                                                                  CbMissingCRL);
+int wolfSSL_CertManagerSetCRL_Cb(WOLFSSL_CERT_MANAGER* cm,
+                                 CbMissingCRL cb);
 
 /*!
     \ingroup CertManager
@@ -9545,8 +9553,8 @@ WOLFSSL_API int wolfSSL_CertManagerSetCRL_Cb(WOLFSSL_CERT_MANAGER*,
     \sa ParseCertRelative
     \sa CheckCertOCSP
 */
-WOLFSSL_API int wolfSSL_CertManagerCheckOCSP(WOLFSSL_CERT_MANAGER*,
-                                                        unsigned char*, int sz);
+int wolfSSL_CertManagerCheckOCSP(WOLFSSL_CERT_MANAGER* cm,
+                                 unsigned char* der, int sz);
 
 /*!
     \ingroup CertManager
@@ -9580,7 +9588,7 @@ WOLFSSL_API int wolfSSL_CertManagerCheckOCSP(WOLFSSL_CERT_MANAGER*,
 
     \sa wolfSSL_CertManagerNew
 */
-WOLFSSL_API int wolfSSL_CertManagerEnableOCSP(WOLFSSL_CERT_MANAGER*,
+int wolfSSL_CertManagerEnableOCSP(WOLFSSL_CERT_MANAGER* cm,
                                                                    int options);
 
 /*!
@@ -9607,7 +9615,7 @@ WOLFSSL_API int wolfSSL_CertManagerEnableOCSP(WOLFSSL_CERT_MANAGER*,
 
     \sa wolfSSL_DisableCRL
 */
-WOLFSSL_API int wolfSSL_CertManagerDisableOCSP(WOLFSSL_CERT_MANAGER*);
+int wolfSSL_CertManagerDisableOCSP(WOLFSSL_CERT_MANAGER*);
 
 /*!
     \ingroup CertManager
@@ -9637,8 +9645,8 @@ WOLFSSL_API int wolfSSL_CertManagerDisableOCSP(WOLFSSL_CERT_MANAGER*);
     \sa ocspOverrideURL
     \sa wolfSSL_SetOCSP_OverrideURL
 */
-WOLFSSL_API int wolfSSL_CertManagerSetOCSPOverrideURL(WOLFSSL_CERT_MANAGER*,
-                                                                   const char*);
+int wolfSSL_CertManagerSetOCSPOverrideURL(WOLFSSL_CERT_MANAGER* cm,
+                                          const char* url);
 
 /*!
     \ingroup CertManager
@@ -9671,8 +9679,9 @@ WOLFSSL_API int wolfSSL_CertManagerSetOCSPOverrideURL(WOLFSSL_CERT_MANAGER*,
     \sa wolfSSL_DisableOCSP
     \sa wolfSSL_SetOCSP_Cb
 */
-WOLFSSL_API int wolfSSL_CertManagerSetOCSP_Cb(WOLFSSL_CERT_MANAGER*,
-                                               CbOCSPIO, CbOCSPRespFree, void*);
+int wolfSSL_CertManagerSetOCSP_Cb(WOLFSSL_CERT_MANAGER* cm,
+                                  CbOCSPIO ioCb, CbOCSPRespFree respFreeCb,
+                                  void* ioCbCtx);
 
 /*!
     \ingroup CertManager
@@ -9702,7 +9711,7 @@ WOLFSSL_API int wolfSSL_CertManagerSetOCSP_Cb(WOLFSSL_CERT_MANAGER*,
 
     \sa wolfSSL_CTX_EnableOCSPStapling
 */
-WOLFSSL_API int wolfSSL_CertManagerEnableOCSPStapling(
+int wolfSSL_CertManagerEnableOCSPStapling(
                                                       WOLFSSL_CERT_MANAGER* cm);
 
 /*!
@@ -9732,7 +9741,7 @@ WOLFSSL_API int wolfSSL_CertManagerEnableOCSPStapling(
     \sa wolfSSL_CertManagerEnableCRL
     \sa InitCRL
 */
-WOLFSSL_API int wolfSSL_EnableCRL(WOLFSSL* ssl, int options);
+int wolfSSL_EnableCRL(WOLFSSL* ssl, int options);
 
 /*!
     \brief Disables CRL certificate revocation.
@@ -9756,7 +9765,7 @@ WOLFSSL_API int wolfSSL_EnableCRL(WOLFSSL* ssl, int options);
     \sa wolfSSL_CertManagerDisableCRL
     \sa wolfSSL_CertManagerDisableOCSP
 */
-WOLFSSL_API int wolfSSL_DisableCRL(WOLFSSL* ssl);
+int wolfSSL_DisableCRL(WOLFSSL* ssl);
 
 /*!
     \brief A wrapper function that ends up calling LoadCRL to load the
@@ -9790,7 +9799,7 @@ WOLFSSL_API int wolfSSL_DisableCRL(WOLFSSL* ssl);
     \sa wolfSSL_CertManagerEnableCRL
     \sa LoadCRL
 */
-WOLFSSL_API int wolfSSL_LoadCRL(WOLFSSL*, const char*, int, int);
+int wolfSSL_LoadCRL(WOLFSSL* ssl, const char* path, int type, int monitor);
 
 /*!
     \brief Sets the CRL callback in the WOLFSSL_CERT_MANAGER structure.
@@ -9822,7 +9831,7 @@ WOLFSSL_API int wolfSSL_LoadCRL(WOLFSSL*, const char*, int, int);
     \sa CbMissingCRL
     \sa wolfSSL_CertManagerSetCRL_Cb
 */
-WOLFSSL_API int wolfSSL_SetCRL_Cb(WOLFSSL*, CbMissingCRL);
+int wolfSSL_SetCRL_Cb(WOLFSSL* ssl, CbMissingCRL cb);
 
 /*!
     \brief This function enables OCSP certificate verification.
@@ -9854,7 +9863,7 @@ WOLFSSL_API int wolfSSL_SetCRL_Cb(WOLFSSL*, CbMissingCRL);
 
     \sa wolfSSL_CertManagerEnableOCSP
 */
-WOLFSSL_API int wolfSSL_EnableOCSP(WOLFSSL*, int options);
+int wolfSSL_EnableOCSP(WOLFSSL* ssl, int options);
 
 /*!
     \brief Disables the OCSP certificate revocation option.
@@ -9877,7 +9886,7 @@ WOLFSSL_API int wolfSSL_EnableOCSP(WOLFSSL*, int options);
 
     \sa wolfSSL_CertManagerDisableOCSP
 */
-WOLFSSL_API int wolfSSL_DisableOCSP(WOLFSSL*);
+int wolfSSL_DisableOCSP(WOLFSSL*);
 
 /*!
     \brief This function sets the ocspOverrideURL member in the
@@ -9906,7 +9915,7 @@ WOLFSSL_API int wolfSSL_DisableOCSP(WOLFSSL*);
 
     \sa wolfSSL_CertManagerSetOCSPOverrideURL
 */
-WOLFSSL_API int wolfSSL_SetOCSP_OverrideURL(WOLFSSL*, const char*);
+int wolfSSL_SetOCSP_OverrideURL(WOLFSSL* ssl, const char* url);
 
 /*!
     \brief This function sets the OCSP callback in the
@@ -9950,7 +9959,8 @@ WOLFSSL_API int wolfSSL_SetOCSP_OverrideURL(WOLFSSL*, const char*);
     \sa CbOCSPIO
     \sa CbOCSPRespFree
 */
-WOLFSSL_API int wolfSSL_SetOCSP_Cb(WOLFSSL*, CbOCSPIO, CbOCSPRespFree, void*);
+int wolfSSL_SetOCSP_Cb(WOLFSSL* ssl, CbOCSPIO ioCb, CbOCSPRespFree respFreeCb,
+                       void* ioCbCtx);
 
 /*!
     \brief Enables CRL certificate verification through the CTX.
@@ -9981,7 +9991,7 @@ WOLFSSL_API int wolfSSL_SetOCSP_Cb(WOLFSSL*, CbOCSPIO, CbOCSPRespFree, void*);
     \sa InitCRL
     \sa wolfSSL_CTX_DisableCRL
 */
-WOLFSSL_API int wolfSSL_CTX_EnableCRL(WOLFSSL_CTX* ctx, int options);
+int wolfSSL_CTX_EnableCRL(WOLFSSL_CTX* ctx, int options);
 
 /*!
     \brief This function disables CRL verification in the CTX structure.
@@ -10006,7 +10016,7 @@ WOLFSSL_API int wolfSSL_CTX_EnableCRL(WOLFSSL_CTX* ctx, int options);
 
     \sa wolfSSL_CertManagerDisableCRL
 */
-WOLFSSL_API int wolfSSL_CTX_DisableCRL(WOLFSSL_CTX* ctx);
+int wolfSSL_CTX_DisableCRL(WOLFSSL_CTX* ctx);
 
 /*!
     \brief This function loads CRL into the WOLFSSL_CTX structure through
@@ -10037,7 +10047,7 @@ WOLFSSL_API int wolfSSL_CTX_DisableCRL(WOLFSSL_CTX* ctx);
     \sa wolfSSL_CertManagerLoadCRL
     \sa LoadCRL
 */
-WOLFSSL_API int wolfSSL_CTX_LoadCRL(WOLFSSL_CTX*, const char*, int, int);
+int wolfSSL_CTX_LoadCRL(WOLFSSL_CTX* ctx, const char* path, int type, int monitor);
 
 /*!
     \brief This function will set the callback argument to the cbMissingCRL
@@ -10073,7 +10083,7 @@ WOLFSSL_API int wolfSSL_CTX_LoadCRL(WOLFSSL_CTX*, const char*, int, int);
     \sa wolfSSL_CertManagerSetCRL_Cb
     \sa CbMissingCRL
 */
-WOLFSSL_API int wolfSSL_CTX_SetCRL_Cb(WOLFSSL_CTX*, CbMissingCRL);
+int wolfSSL_CTX_SetCRL_Cb(WOLFSSL_CTX* ctx, CbMissingCRL cb);
 
 /*!
     \brief This function sets options to configure behavior of OCSP
@@ -10102,7 +10112,7 @@ WOLFSSL_API int wolfSSL_CTX_SetCRL_Cb(WOLFSSL_CTX*, CbMissingCRL);
 
     \sa wolfSSL_CTX_OCSP_set_override_url
 */
-WOLFSSL_API int wolfSSL_CTX_EnableOCSP(WOLFSSL_CTX*, int options);
+int wolfSSL_CTX_EnableOCSP(WOLFSSL_CTX* ctx, int options);
 
 /*!
     \brief This function disables OCSP certificate revocation checking by
@@ -10128,7 +10138,7 @@ WOLFSSL_API int wolfSSL_CTX_EnableOCSP(WOLFSSL_CTX*, int options);
     \sa wolfSSL_DisableOCSP
     \sa wolfSSL_CertManagerDisableOCSP
 */
-WOLFSSL_API int wolfSSL_CTX_DisableOCSP(WOLFSSL_CTX*);
+int wolfSSL_CTX_DisableOCSP(WOLFSSL_CTX*);
 
 /*!
     \brief This function manually sets the URL for OCSP to use. By default,
@@ -10152,7 +10162,7 @@ WOLFSSL_API int wolfSSL_CTX_DisableOCSP(WOLFSSL_CTX*);
 
     \sa wolfSSL_CTX_OCSP_set_options
 */
-WOLFSSL_API int wolfSSL_CTX_SetOCSP_OverrideURL(WOLFSSL_CTX*, const char*);
+int wolfSSL_CTX_SetOCSP_OverrideURL(WOLFSSL_CTX* ctx, const char* url);
 
 /*!
     \brief Sets the callback for the OCSP in the WOLFSSL_CTX structure.
@@ -10189,8 +10199,9 @@ WOLFSSL_API int wolfSSL_CTX_SetOCSP_OverrideURL(WOLFSSL_CTX*, const char*);
     \sa CbOCSPIO
     \sa CbOCSPRespFree
 */
-WOLFSSL_API int wolfSSL_CTX_SetOCSP_Cb(WOLFSSL_CTX*,
-                                               CbOCSPIO, CbOCSPRespFree, void*);
+int wolfSSL_CTX_SetOCSP_Cb(WOLFSSL_CTX* ctx,
+                           CbOCSPIO ioCb, CbOCSPRespFree respFreeCb,
+                           void* ioCbCtx);
 
 /*!
     \brief This function enables OCSP stapling by calling
@@ -10222,7 +10233,7 @@ WOLFSSL_API int wolfSSL_CTX_SetOCSP_Cb(WOLFSSL_CTX*,
     \sa wolfSSL_CertManagerEnableOCSPStapling
     \sa InitOCSP
 */
-WOLFSSL_API int wolfSSL_CTX_EnableOCSPStapling(WOLFSSL_CTX*);
+int wolfSSL_CTX_EnableOCSPStapling(WOLFSSL_CTX*);
 
 /*!
     \ingroup CertsKeys
@@ -10248,7 +10259,7 @@ WOLFSSL_API int wolfSSL_CTX_EnableOCSPStapling(WOLFSSL_CTX*);
 
     \sa wolfSSL_FreeArrays
 */
-WOLFSSL_API void wolfSSL_KeepArrays(WOLFSSL*);
+void wolfSSL_KeepArrays(WOLFSSL*);
 
 /*!
     \ingroup CertsKeys
@@ -10273,7 +10284,7 @@ WOLFSSL_API void wolfSSL_KeepArrays(WOLFSSL*);
 
     \sa wolfSSL_KeepArrays
 */
-WOLFSSL_API void wolfSSL_FreeArrays(WOLFSSL*);
+void wolfSSL_FreeArrays(WOLFSSL*);
 
 /*!
     \brief This function enables the use of Server Name Indication in the SSL
@@ -10316,7 +10327,7 @@ WOLFSSL_API void wolfSSL_FreeArrays(WOLFSSL*);
     \sa wolfSSL_new
     \sa wolfSSL_CTX_UseSNI
 */
-WOLFSSL_API int wolfSSL_UseSNI(WOLFSSL* ssl, unsigned char type,
+int wolfSSL_UseSNI(WOLFSSL* ssl, unsigned char type,
                                          const void* data, unsigned short size);
 
 /*!
@@ -10355,7 +10366,7 @@ WOLFSSL_API int wolfSSL_UseSNI(WOLFSSL* ssl, unsigned char type,
     \sa wolfSSL_CTX_new
     \sa wolfSSL_UseSNI
 */
-WOLFSSL_API int wolfSSL_CTX_UseSNI(WOLFSSL_CTX* ctx, unsigned char type,
+int wolfSSL_CTX_UseSNI(WOLFSSL_CTX* ctx, unsigned char type,
                                          const void* data, unsigned short size);
 
 /*!
@@ -10404,7 +10415,7 @@ WOLFSSL_API int wolfSSL_CTX_UseSNI(WOLFSSL_CTX* ctx, unsigned char type,
     \sa wolfSSL_UseSNI
     \sa wolfSSL_CTX_SNI_SetOptions
 */
-WOLFSSL_API void wolfSSL_SNI_SetOptions(WOLFSSL* ssl, unsigned char type,
+void wolfSSL_SNI_SetOptions(WOLFSSL* ssl, unsigned char type,
                                                          unsigned char options);
 
 /*!
@@ -10449,7 +10460,7 @@ WOLFSSL_API void wolfSSL_SNI_SetOptions(WOLFSSL* ssl, unsigned char type,
     \sa wolfSSL_CTX_UseSNI
     \sa wolfSSL_SNI_SetOptions
 */
-WOLFSSL_API void wolfSSL_CTX_SNI_SetOptions(WOLFSSL_CTX* ctx,
+void wolfSSL_CTX_SNI_SetOptions(WOLFSSL_CTX* ctx,
                                      unsigned char type, unsigned char options);
 
 /*!
@@ -10490,7 +10501,7 @@ WOLFSSL_API void wolfSSL_CTX_SNI_SetOptions(WOLFSSL_CTX* ctx,
     \sa wolfSSL_CTX_UseSNI
     \sa wolfSSL_SNI_GetRequest
 */
-WOLFSSL_API int wolfSSL_SNI_GetFromBuffer(
+int wolfSSL_SNI_GetFromBuffer(
                  const unsigned char* clientHello, unsigned int helloSz,
                  unsigned char type, unsigned char* sni, unsigned int* inOutSz);
 
@@ -10523,7 +10534,7 @@ WOLFSSL_API int wolfSSL_SNI_GetFromBuffer(
     \sa TLSX_SNI_find
     \sa TLSX_Find
 */
-WOLFSSL_API unsigned char wolfSSL_SNI_Status(WOLFSSL* ssl, unsigned char type);
+unsigned char wolfSSL_SNI_Status(WOLFSSL* ssl, unsigned char type);
 
 /*!
     \brief This function is called on the server side to retrieve the
@@ -10562,7 +10573,7 @@ WOLFSSL_API unsigned char wolfSSL_SNI_Status(WOLFSSL* ssl, unsigned char type);
     \sa wolfSSL_UseSNI
     \sa wolfSSL_CTX_UseSNI
 */
-WOLFSSL_API unsigned short wolfSSL_SNI_GetRequest(WOLFSSL *ssl,
+unsigned short wolfSSL_SNI_GetRequest(WOLFSSL *ssl,
                                                unsigned char type, void** data);
 
 /*!
@@ -10604,7 +10615,7 @@ WOLFSSL_API unsigned short wolfSSL_SNI_GetRequest(WOLFSSL *ssl,
 
     \sa TLSX_UseALPN
 */
-WOLFSSL_API int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
+int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
                                 unsigned int protocol_name_listSz,
                                 unsigned char options);
 
@@ -10646,7 +10657,7 @@ WOLFSSL_API int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
     \sa TLSX_ALPN_GetRequest
     \sa TLSX_Find
 */
-WOLFSSL_API int wolfSSL_ALPN_GetProtocol(WOLFSSL* ssl, char **protocol_name,
+int wolfSSL_ALPN_GetProtocol(WOLFSSL* ssl, char **protocol_name,
                                          unsigned short *size);
 
 /*!
@@ -10689,7 +10700,7 @@ WOLFSSL_API int wolfSSL_ALPN_GetProtocol(WOLFSSL* ssl, char **protocol_name,
 
     \sa wolfSSL_UseALPN
 */
-WOLFSSL_API int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char **list,
+int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char **list,
                                              unsigned short *listSz);
 
 /*!
@@ -10732,7 +10743,7 @@ WOLFSSL_API int wolfSSL_ALPN_GetPeerProtocol(WOLFSSL* ssl, char **list,
     \sa wolfSSL_new
     \sa wolfSSL_CTX_UseMaxFragment
 */
-WOLFSSL_API int wolfSSL_UseMaxFragment(WOLFSSL* ssl, unsigned char mfl);
+int wolfSSL_UseMaxFragment(WOLFSSL* ssl, unsigned char mfl);
 
 /*!
     \brief This function is called on the client side to enable the use
@@ -10771,7 +10782,7 @@ WOLFSSL_API int wolfSSL_UseMaxFragment(WOLFSSL* ssl, unsigned char mfl);
     \sa wolfSSL_CTX_new
     \sa wolfSSL_UseMaxFragment
 */
-WOLFSSL_API int wolfSSL_CTX_UseMaxFragment(WOLFSSL_CTX* ctx, unsigned char mfl);
+int wolfSSL_CTX_UseMaxFragment(WOLFSSL_CTX* ctx, unsigned char mfl);
 
 /*!
     \brief This function is called on the client side to enable the use of
@@ -10808,7 +10819,7 @@ WOLFSSL_API int wolfSSL_CTX_UseMaxFragment(WOLFSSL_CTX* ctx, unsigned char mfl);
     \sa wolfSSL_new
     \sa wolfSSL_CTX_UseMaxFragment
 */
-WOLFSSL_API int wolfSSL_UseTruncatedHMAC(WOLFSSL* ssl);
+int wolfSSL_UseTruncatedHMAC(WOLFSSL* ssl);
 
 /*!
     \brief This function is called on the client side to enable the use of
@@ -10840,7 +10851,7 @@ WOLFSSL_API int wolfSSL_UseTruncatedHMAC(WOLFSSL* ssl);
     \sa wolfSSL_CTX_new
     \sa wolfSSL_UseMaxFragment
 */
-WOLFSSL_API int wolfSSL_CTX_UseTruncatedHMAC(WOLFSSL_CTX* ctx);
+int wolfSSL_CTX_UseTruncatedHMAC(WOLFSSL_CTX* ctx);
 
 /*!
     \brief Stapling eliminates the need to contact the CA. Stapling
@@ -10874,7 +10885,7 @@ WOLFSSL_API int wolfSSL_CTX_UseTruncatedHMAC(WOLFSSL_CTX* ctx);
     \sa TLSX_UseCertificateStatusRequest
     \sa wolfSSL_CTX_UseOCSPStapling
 */
-WOLFSSL_API int wolfSSL_UseOCSPStapling(WOLFSSL* ssl,
+int wolfSSL_UseOCSPStapling(WOLFSSL* ssl,
                               unsigned char status_type, unsigned char options);
 
 /*!
@@ -10915,7 +10926,7 @@ WOLFSSL_API int wolfSSL_UseOCSPStapling(WOLFSSL* ssl,
     \sa wolfSSL_UseOCSPStapling
     \sa TLSX_UseCertificateStatusRequest
 */
-WOLFSSL_API int wolfSSL_CTX_UseOCSPStapling(WOLFSSL_CTX* ctx,
+int wolfSSL_CTX_UseOCSPStapling(WOLFSSL_CTX* ctx,
                               unsigned char status_type, unsigned char options);
 
 /*!
@@ -10945,7 +10956,7 @@ WOLFSSL_API int wolfSSL_CTX_UseOCSPStapling(WOLFSSL_CTX* ctx,
     \sa wolfSSL_SNI_SetOptions
     \sa wolfSSL_CTX_SNI_SetOptions
 */
-WOLFSSL_API int wolfSSL_UseOCSPStaplingV2(WOLFSSL* ssl,
+int wolfSSL_UseOCSPStaplingV2(WOLFSSL* ssl,
                               unsigned char status_type, unsigned char options);
 
 /*!
@@ -10980,7 +10991,7 @@ WOLFSSL_API int wolfSSL_UseOCSPStaplingV2(WOLFSSL* ssl,
     \sa wc_RNG_GenerateBlock
     \sa TLSX_Push
 */
-WOLFSSL_API int wolfSSL_CTX_UseOCSPStaplingV2(WOLFSSL_CTX* ctx,
+int wolfSSL_CTX_UseOCSPStaplingV2(WOLFSSL_CTX* ctx,
                               unsigned char status_type, unsigned char options);
 
 /*!
@@ -11024,7 +11035,7 @@ WOLFSSL_API int wolfSSL_CTX_UseOCSPStaplingV2(WOLFSSL_CTX* ctx,
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_UseSupportedCurve
 */
-WOLFSSL_API int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, word16 name);
+int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, word16 name);
 
 /*!
     \brief This function is called on the client side to enable the use of
@@ -11062,7 +11073,7 @@ WOLFSSL_API int wolfSSL_UseSupportedCurve(WOLFSSL* ssl, word16 name);
     \sa wolfSSL_CTX_new
     \sa wolfSSL_UseSupportedCurve
 */
-WOLFSSL_API int wolfSSL_CTX_UseSupportedCurve(WOLFSSL_CTX* ctx,
+int wolfSSL_CTX_UseSupportedCurve(WOLFSSL_CTX* ctx,
                                                            word16 name);
 
 /*!
@@ -11096,7 +11107,7 @@ WOLFSSL_API int wolfSSL_CTX_UseSupportedCurve(WOLFSSL_CTX* ctx,
     \sa TLSX_Find
     \sa TLSX_UseSecureRenegotiation
 */
-WOLFSSL_API int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl);
+int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
@@ -11131,7 +11142,7 @@ WOLFSSL_API int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl);
     \sa wc_InitSha
     \sa wc_InitMd5
 */
-WOLFSSL_API int wolfSSL_Rehandshake(WOLFSSL* ssl);
+int wolfSSL_Rehandshake(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
@@ -11163,7 +11174,7 @@ WOLFSSL_API int wolfSSL_Rehandshake(WOLFSSL* ssl);
 
     \sa TLSX_UseSessionTicket
 */
-WOLFSSL_API int wolfSSL_UseSessionTicket(WOLFSSL* ssl);
+int wolfSSL_UseSessionTicket(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -11191,7 +11202,7 @@ WOLFSSL_API int wolfSSL_UseSessionTicket(WOLFSSL* ssl);
 
     \sa TLSX_UseSessionTicket
 */
-WOLFSSL_API int wolfSSL_CTX_UseSessionTicket(WOLFSSL_CTX* ctx);
+int wolfSSL_CTX_UseSessionTicket(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup IO
@@ -11224,7 +11235,7 @@ WOLFSSL_API int wolfSSL_CTX_UseSessionTicket(WOLFSSL_CTX* ctx);
     \sa wolfSSL_UseSessionTicket
     \sa wolfSSL_set_SessionTicket
 */
-WOLFSSL_API int wolfSSL_get_SessionTicket(WOLFSSL*, unsigned char*, word32*);
+int wolfSSL_get_SessionTicket(WOLFSSL* ssl, unsigned char* buf, word32* bufSz);
 
 /*!
     \ingroup IO
@@ -11258,7 +11269,8 @@ WOLFSSL_API int wolfSSL_get_SessionTicket(WOLFSSL*, unsigned char*, word32*);
 
     \sa wolfSSL_set_SessionTicket_cb
 */
-WOLFSSL_API int wolfSSL_set_SessionTicket(WOLFSSL*, const unsigned char*, word32);
+int wolfSSL_set_SessionTicket(WOLFSSL* ssl, const unsigned char* buf,
+                              word32 bufSz);
 
 /*!
     \brief This function sets the session ticket callback. The type
@@ -11287,8 +11299,8 @@ WOLFSSL_API int wolfSSL_set_SessionTicket(WOLFSSL*, const unsigned char*, word32
     \sa CallbackSessionTicket
     \sa sessionTicketCB
 */
-WOLFSSL_API int wolfSSL_set_SessionTicket_cb(WOLFSSL*,
-                                                  CallbackSessionTicket, void*);
+int wolfSSL_set_SessionTicket_cb(WOLFSSL* ssl,
+                                 CallbackSessionTicket cb, void* ctx);
 
 /*!
     \brief This function sets the session ticket key encrypt callback function
@@ -11340,7 +11352,7 @@ WOLFSSL_API int wolfSSL_set_SessionTicket_cb(WOLFSSL*,
     \sa wolfSSL_CTX_set_TicketHint
     \sa wolfSSL_CTX_set_TicketEncCtx
 */
-WOLFSSL_API int wolfSSL_CTX_set_TicketEncCb(WOLFSSL_CTX* ctx,
+int wolfSSL_CTX_set_TicketEncCb(WOLFSSL_CTX* ctx,
                                             SessionTicketEncCb);
 
 /*!
@@ -11361,7 +11373,7 @@ WOLFSSL_API int wolfSSL_CTX_set_TicketEncCb(WOLFSSL_CTX* ctx,
 
     \sa wolfSSL_CTX_set_TicketEncCb
 */
-WOLFSSL_API int wolfSSL_CTX_set_TicketHint(WOLFSSL_CTX* ctx, int);
+int wolfSSL_CTX_set_TicketHint(WOLFSSL_CTX* ctx, int);
 
 /*!
     \brief This function sets the session ticket encrypt user context for the
@@ -11382,7 +11394,7 @@ WOLFSSL_API int wolfSSL_CTX_set_TicketHint(WOLFSSL_CTX* ctx, int);
 
     \sa wolfSSL_CTX_set_TicketEncCb
 */
-WOLFSSL_API int wolfSSL_CTX_set_TicketEncCtx(WOLFSSL_CTX* ctx, void*);
+int wolfSSL_CTX_set_TicketEncCtx(WOLFSSL_CTX* ctx, void*);
 
 /*!
     \brief This function gets the session ticket encrypt user context for the
@@ -11403,7 +11415,7 @@ WOLFSSL_API int wolfSSL_CTX_set_TicketEncCtx(WOLFSSL_CTX* ctx, void*);
 
     \sa wolfSSL_CTX_set_TicketEncCtx
 */
-WOLFSSL_API void* wolfSSL_CTX_get_TicketEncCtx(WOLFSSL_CTX* ctx);
+void* wolfSSL_CTX_get_TicketEncCtx(WOLFSSL_CTX* ctx);
 
 /*!
     \brief This function sets the handshake done callback. The hsDoneCb and
@@ -11432,7 +11444,7 @@ WOLFSSL_API void* wolfSSL_CTX_get_TicketEncCtx(WOLFSSL_CTX* ctx);
 
     \sa HandShakeDoneCb
 */
-WOLFSSL_API int wolfSSL_SetHsDoneCb(WOLFSSL*, HandShakeDoneCb, void*);
+int wolfSSL_SetHsDoneCb(WOLFSSL* ssl, HandShakeDoneCb cb, void* user_ctx);
 
 /*!
     \ingroup IO
@@ -11458,7 +11470,7 @@ WOLFSSL_API int wolfSSL_SetHsDoneCb(WOLFSSL*, HandShakeDoneCb, void*);
 
     \sa wolfSSL_get_session_stats
 */
-WOLFSSL_API int wolfSSL_PrintSessionStats(void);
+int wolfSSL_PrintSessionStats(void);
 
 /*!
     \ingroup IO
@@ -11488,7 +11500,7 @@ WOLFSSL_API int wolfSSL_PrintSessionStats(void);
 
     \sa wolfSSL_PrintSessionStats
 */
-WOLFSSL_API int wolfSSL_get_session_stats(unsigned int* active,
+int wolfSSL_get_session_stats(unsigned int* active,
                                           unsigned int* total,
                                           unsigned int* peak,
                                           unsigned int* maxSessions);
@@ -11536,7 +11548,7 @@ WOLFSSL_API int wolfSSL_get_session_stats(unsigned int* active,
     \sa wc_PRF
     \sa MakeTlsMasterSecret
 */
-WOLFSSL_API
+
 int wolfSSL_MakeTlsMasterSecret(unsigned char* ms, word32 msLen,
                                const unsigned char* pms, word32 pmsLen,
                                const unsigned char* cr, const unsigned char* sr,
@@ -11583,7 +11595,7 @@ int wolfSSL_MakeTlsMasterSecret(unsigned char* ms, word32 msLen,
     \sa DeriveTlsKeys
     \sa IsAtLeastTLSv1_2
 */
-WOLFSSL_API
+
 int wolfSSL_DeriveTlsKeys(unsigned char* key_data, word32 keyLen,
                                const unsigned char* ms, word32 msLen,
                                const unsigned char* sr, const unsigned char* cr,
@@ -11620,8 +11632,8 @@ int wolfSSL_DeriveTlsKeys(unsigned char* key_data, word32 keyLen,
 
     \sa wolfSSL_accept_ex
 */
-WOLFSSL_API int wolfSSL_connect_ex(WOLFSSL*, HandShakeCallBack, TimeoutCallBack,
-                                 WOLFSSL_TIMEVAL);
+int wolfSSL_connect_ex(WOLFSSL* ssl, HandShakeCallBack hsCb,
+                       TimeoutCallBack toCb, WOLFSSL_TIMEVAL timeout);
 
 /*!
     \brief wolfSSL_accept_ex() is an extension that allows a HandShake Callback
@@ -11652,8 +11664,8 @@ WOLFSSL_API int wolfSSL_connect_ex(WOLFSSL*, HandShakeCallBack, TimeoutCallBack,
 
     \sa wolfSSL_connect_ex
 */
-WOLFSSL_API int wolfSSL_accept_ex(WOLFSSL*, HandShakeCallBack, TimeoutCallBack,
-                                WOLFSSL_TIMEVAL);
+int wolfSSL_accept_ex(WOLFSSL* ssl, HandShakeCallBacki hsCb,
+                      TimeoutCallBack toCb, WOLFSSL_TIMEVAL timeout);
 
 /*!
     \ingroup IO
@@ -11682,7 +11694,7 @@ WOLFSSL_API int wolfSSL_accept_ex(WOLFSSL*, HandShakeCallBack, TimeoutCallBack,
     \sa wolfSSL_BIO_get_fp
     \sa wolfSSL_BIO_free
 */
-WOLFSSL_API long wolfSSL_BIO_set_fp(WOLFSSL_BIO *bio, XFILE fp, int c);
+long wolfSSL_BIO_set_fp(WOLFSSL_BIO *bio, XFILE fp, int c);
 
 /*!
     \ingroup IO
@@ -11710,7 +11722,7 @@ WOLFSSL_API long wolfSSL_BIO_set_fp(WOLFSSL_BIO *bio, XFILE fp, int c);
     \sa wolfSSL_BIO_set_fp
     \sa wolfSSL_BIO_free
 */
-WOLFSSL_API long wolfSSL_BIO_get_fp(WOLFSSL_BIO *bio, XFILE* fp);
+long wolfSSL_BIO_get_fp(WOLFSSL_BIO *bio, XFILE* fp);
 
 /*!
     \ingroup Setup
@@ -11736,7 +11748,7 @@ WOLFSSL_API long wolfSSL_BIO_get_fp(WOLFSSL_BIO *bio, XFILE* fp);
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API int wolfSSL_check_private_key(const WOLFSSL* ssl);
+int wolfSSL_check_private_key(const WOLFSSL* ssl);
 
 /*!
     \ingroup CertsKeys
@@ -11762,7 +11774,7 @@ WOLFSSL_API int wolfSSL_check_private_key(const WOLFSSL* ssl);
     \endcode
 
 */
-WOLFSSL_API int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509,
+int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509,
                                              int nid, int lastPos);
 
 /*!
@@ -11795,7 +11807,7 @@ WOLFSSL_API int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509,
 
     \sa wolfSSL_sk_ASN1_OBJECT_free
 */
-WOLFSSL_API void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509,
+void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509,
                                                      int nid, int* c, int* idx);
 
 /*!
@@ -11824,7 +11836,7 @@ WOLFSSL_API void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509,
 
     \sa none
 */
-WOLFSSL_API int wolfSSL_X509_digest(const WOLFSSL_X509* x509,
+int wolfSSL_X509_digest(const WOLFSSL_X509* x509,
         const WOLFSSL_EVP_MD* digest, unsigned char* buf, unsigned int* len);
 
 /*!
@@ -11851,7 +11863,7 @@ WOLFSSL_API int wolfSSL_X509_digest(const WOLFSSL_X509* x509,
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API int wolfSSL_use_certificate(WOLFSSL* ssl, WOLFSSL_X509* x509);
+int wolfSSL_use_certificate(WOLFSSL* ssl, WOLFSSL_X509* x509);
 
 /*!
     \ingroup Setup
@@ -11880,7 +11892,7 @@ WOLFSSL_API int wolfSSL_use_certificate(WOLFSSL* ssl, WOLFSSL_X509* x509);
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API int wolfSSL_use_certificate_ASN1(WOLFSSL* ssl, unsigned char* der,
+int wolfSSL_use_certificate_ASN1(WOLFSSL* ssl, unsigned char* der,
                                                                      int derSz);
 
 /*!
@@ -11908,7 +11920,7 @@ WOLFSSL_API int wolfSSL_use_certificate_ASN1(WOLFSSL* ssl, unsigned char* der,
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API int wolfSSL_use_PrivateKey(WOLFSSL* ssl, WOLFSSL_EVP_PKEY* pkey);
+int wolfSSL_use_PrivateKey(WOLFSSL* ssl, WOLFSSL_EVP_PKEY* pkey);
 
 /*!
     \ingroup CertsKeys
@@ -11941,7 +11953,7 @@ WOLFSSL_API int wolfSSL_use_PrivateKey(WOLFSSL* ssl, WOLFSSL_EVP_PKEY* pkey);
     \sa wolfSSL_free
     \sa wolfSSL_use_PrivateKey
 */
-WOLFSSL_API int wolfSSL_use_PrivateKey_ASN1(int pri, WOLFSSL* ssl,
+int wolfSSL_use_PrivateKey_ASN1(int pri, WOLFSSL* ssl,
                                             unsigned char* der, long derSz);
 
 /*!
@@ -11974,7 +11986,7 @@ WOLFSSL_API int wolfSSL_use_PrivateKey_ASN1(int pri, WOLFSSL* ssl,
     \sa wolfSSL_free
     \sa wolfSSL_use_PrivateKey
 */
-WOLFSSL_API int wolfSSL_use_RSAPrivateKey_ASN1(WOLFSSL* ssl, unsigned char* der,
+int wolfSSL_use_RSAPrivateKey_ASN1(WOLFSSL* ssl, unsigned char* der,
                                                                 long derSz);
 
 /*!
@@ -12000,7 +12012,7 @@ WOLFSSL_API int wolfSSL_use_RSAPrivateKey_ASN1(WOLFSSL* ssl, unsigned char* der,
 
     \sa none
 */
-WOLFSSL_API WOLFSSL_DH *wolfSSL_DSA_dup_DH(const WOLFSSL_DSA *r);
+WOLFSSL_DH *wolfSSL_DSA_dup_DH(const WOLFSSL_DSA *r);
 
 /*!
     \ingroup Setup
@@ -12033,7 +12045,7 @@ WOLFSSL_API WOLFSSL_DH *wolfSSL_DSA_dup_DH(const WOLFSSL_DSA *r);
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API int wolfSSL_SESSION_get_master_key(const WOLFSSL_SESSION* ses,
+int wolfSSL_SESSION_get_master_key(const WOLFSSL_SESSION* ses,
         unsigned char* out, int outSz);
 
 /*!
@@ -12060,7 +12072,7 @@ WOLFSSL_API int wolfSSL_SESSION_get_master_key(const WOLFSSL_SESSION* ses,
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API int wolfSSL_SESSION_get_master_key_length(const WOLFSSL_SESSION* ses);
+int wolfSSL_SESSION_get_master_key_length(const WOLFSSL_SESSION* ses);
 
 /*!
     \ingroup Setup
@@ -12086,7 +12098,7 @@ WOLFSSL_API int wolfSSL_SESSION_get_master_key_length(const WOLFSSL_SESSION* ses
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
-WOLFSSL_API void wolfSSL_CTX_set_cert_store(WOLFSSL_CTX* ctx,
+void wolfSSL_CTX_set_cert_store(WOLFSSL_CTX* ctx,
                                                        WOLFSSL_X509_STORE* str);
 
 /*!
@@ -12142,7 +12154,7 @@ WOLFSSL_X509* wolfSSL_d2i_X509_bio(WOLFSSL_BIO* bio, WOLFSSL_X509** x509);
     \sa wolfSSL_CTX_free
     \sa wolfSSL_CTX_set_cert_store
 */
-WOLFSSL_API WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(WOLFSSL_CTX* ctx);
+WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup IO
@@ -12169,7 +12181,7 @@ WOLFSSL_API WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(WOLFSSL_CTX* ctx);
     \sa wolfSSL_BIO_make_bio_pair
     \sa wolfSSL_BIO_new
 */
-WOLFSSL_API size_t wolfSSL_BIO_ctrl_pending(WOLFSSL_BIO *b);
+size_t wolfSSL_BIO_ctrl_pending(WOLFSSL_BIO *b);
 
 /*!
     \ingroup Setup
@@ -12202,7 +12214,7 @@ WOLFSSL_API size_t wolfSSL_BIO_ctrl_pending(WOLFSSL_BIO *b);
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API size_t wolfSSL_get_server_random(const WOLFSSL *ssl,
+size_t wolfSSL_get_server_random(const WOLFSSL *ssl,
                                              unsigned char *out, size_t outlen);
 
 /*!
@@ -12236,7 +12248,7 @@ WOLFSSL_API size_t wolfSSL_get_server_random(const WOLFSSL *ssl,
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API size_t wolfSSL_get_client_random(const WOLFSSL* ssl,
+size_t wolfSSL_get_client_random(const WOLFSSL* ssl,
                                               unsigned char* out, size_t outSz);
 
 /*!
@@ -12261,7 +12273,7 @@ WOLFSSL_API size_t wolfSSL_get_client_random(const WOLFSSL* ssl,
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
-WOLFSSL_API wc_pem_password_cb* wolfSSL_CTX_get_default_passwd_cb(WOLFSSL_CTX*
+wc_pem_password_cb* wolfSSL_CTX_get_default_passwd_cb(WOLFSSL_CTX*
                                                                   ctx);
 
 /*!
@@ -12287,7 +12299,7 @@ WOLFSSL_API wc_pem_password_cb* wolfSSL_CTX_get_default_passwd_cb(WOLFSSL_CTX*
     \sa wolfSSL_CTX_new
     \sa wolfSSL_CTX_free
 */
-WOLFSSL_API void *wolfSSL_CTX_get_default_passwd_cb_userdata(WOLFSSL_CTX *ctx);
+void *wolfSSL_CTX_get_default_passwd_cb_userdata(WOLFSSL_CTX *ctx);
 
 /*!
     \ingroup CertsKeys
@@ -12316,7 +12328,7 @@ WOLFSSL_API void *wolfSSL_CTX_get_default_passwd_cb_userdata(WOLFSSL_CTX *ctx);
 
     \sa wolfSSL_PEM_read_bio_X509
 */
-WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
+WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
         (WOLFSSL_BIO *bp, WOLFSSL_X509 **x, wc_pem_password_cb *cb, void *u);
 
 /*!
@@ -12345,7 +12357,7 @@ WOLFSSL_API WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX
 
     \sa wolfSSL_BN_bn2bin
 */
-WOLFSSL_API long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX*, WOLFSSL_DH*);
+long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL_DH* dh);
 
 /*!
     \ingroup CertsKeys
@@ -12374,7 +12386,7 @@ WOLFSSL_API long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX*, WOLFSSL_DH*);
 
     \sa none
 */
-WOLFSSL_API WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSAparams(WOLFSSL_BIO *bp,
+WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSAparams(WOLFSSL_BIO *bp,
     WOLFSSL_DSA **x, wc_pem_password_cb *cb, void *u);
 
 /*!
@@ -12397,7 +12409,7 @@ WOLFSSL_API WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSAparams(WOLFSSL_BIO *bp,
 
     \sa wolfSSL_ERR_print_errors_fp
 */
-WOLFSSL_API unsigned long wolfSSL_ERR_peek_last_error(void);
+unsigned long wolfSSL_ERR_peek_last_error(void);
 
 /*!
     \ingroup CertsKeys
@@ -12425,7 +12437,7 @@ WOLFSSL_API unsigned long wolfSSL_ERR_peek_last_error(void);
     \sa wolfSSL_X509_get_subject_name
     \sa wolfSSL_X509_get_isCA
 */
-WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_get_peer_cert_chain(const WOLFSSL*);
+WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_get_peer_cert_chain(const WOLFSSL*);
 
 /*!
     \ingroup Setup
@@ -12447,7 +12459,7 @@ WOLFSSL_API WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_get_peer_cert_chain(const WOLFS
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API long wolfSSL_CTX_clear_options(WOLFSSL_CTX*, long);
+long wolfSSL_CTX_clear_options(WOLFSSL_CTX* ctx, long opt);
 
 /*!
     \ingroup IO
@@ -12474,7 +12486,7 @@ WOLFSSL_API long wolfSSL_CTX_clear_options(WOLFSSL_CTX*, long);
 
     \sa wolfSSL_get_jobject
 */
-WOLFSSL_API int wolfSSL_set_jobject(WOLFSSL* ssl, void* objPtr);
+int wolfSSL_set_jobject(WOLFSSL* ssl, void* objPtr);
 
 /*!
     \ingroup IO
@@ -12501,7 +12513,7 @@ WOLFSSL_API int wolfSSL_set_jobject(WOLFSSL* ssl, void* objPtr);
 
     \sa wolfSSL_set_jobject
 */
-WOLFSSL_API void* wolfSSL_get_jobject(WOLFSSL* ssl);
+void* wolfSSL_get_jobject(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -12526,7 +12538,7 @@ WOLFSSL_API void* wolfSSL_get_jobject(WOLFSSL* ssl);
 
     \sa wolfSSL_set_msg_callback_arg
 */
-WOLFSSL_API int wolfSSL_set_msg_callback(WOLFSSL *ssl, SSL_Msg_Cb cb);
+int wolfSSL_set_msg_callback(WOLFSSL *ssl, SSL_Msg_Cb cb);
 
 /*!
     \ingroup Setup
@@ -12551,7 +12563,7 @@ WOLFSSL_API int wolfSSL_set_msg_callback(WOLFSSL *ssl, SSL_Msg_Cb cb);
 
     \sa wolfSSL_set_msg_callback
 */
-WOLFSSL_API int wolfSSL_set_msg_callback_arg(WOLFSSL *ssl, void* arg);
+int wolfSSL_set_msg_callback_arg(WOLFSSL *ssl, void* arg);
 
 /*!
     \ingroup CertsKeys
@@ -12578,7 +12590,7 @@ WOLFSSL_API int wolfSSL_set_msg_callback_arg(WOLFSSL *ssl, void* arg);
     \sa wolfSSL_X509_get_issuer_name
     \sa wolfSSL_X509_get_subject_name
 */
-WOLFSSL_API char* wolfSSL_X509_get_next_altname(WOLFSSL_X509*);
+char* wolfSSL_X509_get_next_altname(WOLFSSL_X509*);
 
 /*!
     \ingroup CertsKeys
@@ -12605,7 +12617,7 @@ WOLFSSL_API char* wolfSSL_X509_get_next_altname(WOLFSSL_X509*);
 
     \sa wolfSSL_X509_get_notAfter
 */
-WOLFSSL_API WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notBefore(WOLFSSL_X509*);
+WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notBefore(WOLFSSL_X509*);
 
 /*!
     \ingroup IO
@@ -12693,7 +12705,7 @@ int  wolfSSL_connect(WOLFSSL* ssl);
 
     \sa wolfSSL_new
 */
-WOLFSSL_API int  wolfSSL_send_hrr_cookie(WOLFSSL* ssl,
+int  wolfSSL_send_hrr_cookie(WOLFSSL* ssl,
     const unsigned char* secret, unsigned int secretSz);
 
 /*!
@@ -12722,7 +12734,7 @@ WOLFSSL_API int  wolfSSL_send_hrr_cookie(WOLFSSL* ssl,
 
     \sa wolfSSL_no_ticket_TLSv13
 */
-WOLFSSL_API int  wolfSSL_CTX_no_ticket_TLSv13(WOLFSSL_CTX* ctx);
+int  wolfSSL_CTX_no_ticket_TLSv13(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup Setup
@@ -12749,7 +12761,7 @@ WOLFSSL_API int  wolfSSL_CTX_no_ticket_TLSv13(WOLFSSL_CTX* ctx);
 
     \sa wolfSSL_CTX_no_ticket_TLSv13
 */
-WOLFSSL_API int  wolfSSL_no_ticket_TLSv13(WOLFSSL* ssl);
+int  wolfSSL_no_ticket_TLSv13(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -12777,7 +12789,7 @@ WOLFSSL_API int  wolfSSL_no_ticket_TLSv13(WOLFSSL* ssl);
 
     \sa wolfSSL_no_dhe_psk
 */
-WOLFSSL_API int  wolfSSL_CTX_no_dhe_psk(WOLFSSL_CTX* ctx);
+int  wolfSSL_CTX_no_dhe_psk(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup Setup
@@ -12804,7 +12816,7 @@ WOLFSSL_API int  wolfSSL_CTX_no_dhe_psk(WOLFSSL_CTX* ctx);
 
     \sa wolfSSL_CTX_no_dhe_psk
 */
-WOLFSSL_API int  wolfSSL_no_dhe_psk(WOLFSSL* ssl);
+int  wolfSSL_no_dhe_psk(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
@@ -12837,7 +12849,7 @@ WOLFSSL_API int  wolfSSL_no_dhe_psk(WOLFSSL* ssl);
 
     \sa wolfSSL_write
 */
-WOLFSSL_API int  wolfSSL_update_keys(WOLFSSL* ssl);
+int  wolfSSL_update_keys(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
@@ -12871,7 +12883,7 @@ WOLFSSL_API int  wolfSSL_update_keys(WOLFSSL* ssl);
 
     \sa wolfSSL_update_keys
 */
-WOLFSSL_API int  wolfSSL_key_update_response(WOLFSSL* ssl, int* required);
+int  wolfSSL_key_update_response(WOLFSSL* ssl, int* required);
 
 /*!
     \ingroup Setup
@@ -12902,7 +12914,7 @@ WOLFSSL_API int  wolfSSL_key_update_response(WOLFSSL* ssl, int* required);
     \sa wolfSSL_allow_post_handshake_auth
     \sa wolfSSL_request_certificate
 */
-WOLFSSL_API int  wolfSSL_CTX_allow_post_handshake_auth(WOLFSSL_CTX* ctx);
+int  wolfSSL_CTX_allow_post_handshake_auth(WOLFSSL_CTX* ctx);
 
 /*!
     \ingroup Setup
@@ -12933,7 +12945,7 @@ WOLFSSL_API int  wolfSSL_CTX_allow_post_handshake_auth(WOLFSSL_CTX* ctx);
     \sa wolfSSL_CTX_allow_post_handshake_auth
     \sa wolfSSL_request_certificate
 */
-WOLFSSL_API int  wolfSSL_allow_post_handshake_auth(WOLFSSL* ssl);
+int  wolfSSL_allow_post_handshake_auth(WOLFSSL* ssl);
 
 /*!
     \ingroup IO
@@ -12970,7 +12982,7 @@ WOLFSSL_API int  wolfSSL_allow_post_handshake_auth(WOLFSSL* ssl);
     \sa wolfSSL_allow_post_handshake_auth
     \sa wolfSSL_write
 */
-WOLFSSL_API int  wolfSSL_request_certificate(WOLFSSL* ssl);
+int  wolfSSL_request_certificate(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -13009,7 +13021,7 @@ WOLFSSL_API int  wolfSSL_request_certificate(WOLFSSL* ssl);
     \sa wolfSSL_UseKeyShare
     \sa wolfSSL_preferred_group
 */
-WOLFSSL_API int  wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, char *list);
+int  wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, char *list);
 
 /*!
     \ingroup Setup
@@ -13047,7 +13059,7 @@ WOLFSSL_API int  wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, char *list);
     \sa wolfSSL_UseKeyShare
     \sa wolfSSL_preferred_group
 */
-WOLFSSL_API int  wolfSSL_set1_groups_list(WOLFSSL *ssl, char *list);
+int  wolfSSL_set1_groups_list(WOLFSSL *ssl, char *list);
 
 /*!
     \ingroup TLS
@@ -13084,7 +13096,7 @@ WOLFSSL_API int  wolfSSL_set1_groups_list(WOLFSSL *ssl, char *list);
     \sa wolfSSL_CTX_set1_groups_list
     \sa wolfSSL_set1_groups_list
 */
-WOLFSSL_API int  wolfSSL_preferred_group(WOLFSSL* ssl);
+int  wolfSSL_preferred_group(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -13126,7 +13138,7 @@ WOLFSSL_API int  wolfSSL_preferred_group(WOLFSSL* ssl);
     \sa wolfSSL_set1_groups_list
     \sa wolfSSL_preferred_group
 */
-WOLFSSL_API int  wolfSSL_CTX_set_groups(WOLFSSL_CTX* ctx, int* groups,
+int  wolfSSL_CTX_set_groups(WOLFSSL_CTX* ctx, int* groups,
     int count);
 
 /*!
@@ -13169,7 +13181,7 @@ WOLFSSL_API int  wolfSSL_CTX_set_groups(WOLFSSL_CTX* ctx, int* groups,
     \sa wolfSSL_set1_groups_list
     \sa wolfSSL_preferred_group
 */
-WOLFSSL_API int  wolfSSL_set_groups(WOLFSSL* ssl, int* groups, int count);
+int  wolfSSL_set_groups(WOLFSSL* ssl, int* groups, int count);
 
 /*!
     \ingroup IO
@@ -13222,7 +13234,7 @@ WOLFSSL_API int  wolfSSL_set_groups(WOLFSSL* ssl, int* groups, int count);
     \sa wolfSSL_accept_TLSv13
     \sa wolfSSL_accept
 */
-WOLFSSL_API int  wolfSSL_connect_TLSv13(WOLFSSL*);
+int  wolfSSL_connect_TLSv13(WOLFSSL*);
 
 /*!
     \ingroup IO
@@ -13271,7 +13283,7 @@ WOLFSSL_API int  wolfSSL_connect_TLSv13(WOLFSSL*);
     \sa wolfSSL_accept_TLSv13
     \sa wolfSSL_accept
 */
-WOLFSSL_API wolfSSL_accept_TLSv13(WOLFSSL* ssl);
+wolfSSL_accept_TLSv13(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -13311,7 +13323,7 @@ WOLFSSL_API wolfSSL_accept_TLSv13(WOLFSSL* ssl);
     \sa wolfSSL_write_early_data
     \sa wolfSSL_read_early_data
 */
-WOLFSSL_API int  wolfSSL_CTX_set_max_early_data(WOLFSSL_CTX* ctx,
+int  wolfSSL_CTX_set_max_early_data(WOLFSSL_CTX* ctx,
     unsigned int sz);
 
 /*!
@@ -13351,7 +13363,7 @@ WOLFSSL_API int  wolfSSL_CTX_set_max_early_data(WOLFSSL_CTX* ctx,
     \sa wolfSSL_write_early_data
     \sa wolfSSL_read_early_data
 */
-WOLFSSL_API int  wolfSSL_set_max_early_data(WOLFSSL* ssl, unsigned int sz);
+int  wolfSSL_set_max_early_data(WOLFSSL* ssl, unsigned int sz);
 
 /*!
     \ingroup IO
@@ -13402,7 +13414,7 @@ WOLFSSL_API int  wolfSSL_set_max_early_data(WOLFSSL* ssl, unsigned int sz);
     \sa wolfSSL_connect
     \sa wolfSSL_connect_TLSv13
 */
-WOLFSSL_API int  wolfSSL_write_early_data(OLFSSL* ssl, const void* data,
+int  wolfSSL_write_early_data(OLFSSL* ssl, const void* data,
     int sz, int* outSz);
 
 /*!
@@ -13454,7 +13466,7 @@ WOLFSSL_API int  wolfSSL_write_early_data(OLFSSL* ssl, const void* data,
     \sa wolfSSL_accept
     \sa wolfSSL_accept_TLSv13
 */
-WOLFSSL_API int  wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz,
+int  wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz,
     int* outSz);
 
 /*!
@@ -13482,7 +13494,7 @@ WOLFSSL_API int  wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz,
     \sa wolfSSL_CTX_set_psk_server_tls13_callback
     \sa wolfSSL_set_psk_server_tls13_callback
 */
-WOLFSSL_API void wolfSSL_CTX_set_psk_client_tls13_callback(WOLFSSL_CTX* ctx,
+void wolfSSL_CTX_set_psk_client_tls13_callback(WOLFSSL_CTX* ctx,
     wc_psk_client_tls13_callback cb);
 
 /*!
@@ -13509,7 +13521,7 @@ WOLFSSL_API void wolfSSL_CTX_set_psk_client_tls13_callback(WOLFSSL_CTX* ctx,
     \sa wolfSSL_CTX_set_psk_server_tls13_callback
     \sa wolfSSL_set_psk_server_tls13_callback
 */
-WOLFSSL_API void wolfSSL_set_psk_client_tls13_callback(WOLFSSL* ssl,
+void wolfSSL_set_psk_client_tls13_callback(WOLFSSL* ssl,
     wc_psk_client_tls13_callback cb);
 
 /*!
@@ -13537,7 +13549,7 @@ WOLFSSL_API void wolfSSL_set_psk_client_tls13_callback(WOLFSSL* ssl,
     \sa wolfSSL_set_psk_client_tls13_callback
     \sa wolfSSL_set_psk_server_tls13_callback
 */
-WOLFSSL_API void wolfSSL_CTX_set_psk_server_tls13_callback(WOLFSSL_CTX* ctx,
+void wolfSSL_CTX_set_psk_server_tls13_callback(WOLFSSL_CTX* ctx,
     wc_psk_server_tls13_callback cb);
 
 /*!
@@ -13564,7 +13576,7 @@ WOLFSSL_API void wolfSSL_CTX_set_psk_server_tls13_callback(WOLFSSL_CTX* ctx,
     \sa wolfSSL_set_psk_client_tls13_callback
     \sa wolfSSL_CTX_set_psk_server_tls13_callback
 */
-WOLFSSL_API void wolfSSL_set_psk_server_tls13_callback(WOLFSSL* ssl,
+void wolfSSL_set_psk_server_tls13_callback(WOLFSSL* ssl,
     wc_psk_server_tls13_callback cb);
 
 /*!
@@ -13603,7 +13615,7 @@ WOLFSSL_API void wolfSSL_set_psk_server_tls13_callback(WOLFSSL* ssl,
     \sa wolfSSL_set_groups
     \sa wolfSSL_NoKeyShares
 */
-WOLFSSL_API int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group);
+int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group);
 
 /*!
     \ingroup Setup
@@ -13635,7 +13647,7 @@ WOLFSSL_API int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group);
 
     \sa wolfSSL_UseKeyShare
 */
-WOLFSSL_API int wolfSSL_NoKeyShares(WOLFSSL* ssl);
+int wolfSSL_NoKeyShares(WOLFSSL* ssl);
 
 /*!
     \ingroup Setup
@@ -13679,7 +13691,7 @@ WOLFSSL_API int wolfSSL_NoKeyShares(WOLFSSL* ssl);
     \sa wolfSSLv23_server_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_server_method_ex(void* heap);
+WOLFSSL_METHOD *wolfTLSv1_3_server_method_ex(void* heap);
 
 /*!
     \ingroup Setup
@@ -13723,7 +13735,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_server_method_ex(void* heap);
     \sa wolfSSLv23_client_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_client_method_ex(void* heap);
+WOLFSSL_METHOD *wolfTLSv1_3_client_method_ex(void* heap);
 
 /*!
     \ingroup Setup
@@ -13765,7 +13777,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_client_method_ex(void* heap);
     \sa wolfSSLv23_server_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_server_method(void);
+WOLFSSL_METHOD *wolfTLSv1_3_server_method(void);
 
 /*!
     \ingroup Setup
@@ -13807,7 +13819,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_server_method(void);
     \sa wolfSSLv23_client_method
     \sa wolfSSL_CTX_new
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_client_method(void);
+WOLFSSL_METHOD *wolfTLSv1_3_client_method(void);
 
 /*!
     \ingroup Setup
@@ -13832,7 +13844,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_client_method(void);
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_method_ex(void* heap);
+WOLFSSL_METHOD *wolfTLSv1_3_method_ex(void* heap);
 
 /*!
     \ingroup Setup
@@ -13855,7 +13867,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_method_ex(void* heap);
     \sa wolfSSL_new
     \sa wolfSSL_free
 */
-WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_method(void);
+WOLFSSL_METHOD *wolfTLSv1_3_method(void);
 
 /*!
  \ingroup SSL
@@ -13868,7 +13880,7 @@ WOLFSSL_API WOLFSSL_METHOD *wolfTLSv1_3_method(void);
  \param format WOLFSSL_FILETYPE_ASN1 or WOLFSSL_FILETYPE_PEM
  \sa wolfSSL_CTX_get_ephemeral_key
  */
-WOLFSSL_API int wolfSSL_CTX_set_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, const char* key, unsigned int keySz, int format);
+int wolfSSL_CTX_set_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, const char* key, unsigned int keySz, int format);
 
 /*!
  \ingroup SSL
@@ -13881,7 +13893,7 @@ WOLFSSL_API int wolfSSL_CTX_set_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, con
  \param format WOLFSSL_FILETYPE_ASN1 or WOLFSSL_FILETYPE_PEM
  \sa wolfSSL_get_ephemeral_key
  */
-WOLFSSL_API int wolfSSL_set_ephemeral_key(WOLFSSL* ssl, int keyAlgo, const char* key, unsigned int keySz, int format);
+int wolfSSL_set_ephemeral_key(WOLFSSL* ssl, int keyAlgo, const char* key, unsigned int keySz, int format);
 
 /*!
  \ingroup SSL
@@ -13893,7 +13905,7 @@ WOLFSSL_API int wolfSSL_set_ephemeral_key(WOLFSSL* ssl, int keyAlgo, const char*
  \param keySz key size pointer
  \sa wolfSSL_CTX_set_ephemeral_key
  */
-WOLFSSL_API int wolfSSL_CTX_get_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, 
+int wolfSSL_CTX_get_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo, 
     const unsigned char** key, unsigned int* keySz);
 
 /*!
@@ -13906,7 +13918,7 @@ WOLFSSL_API int wolfSSL_CTX_get_ephemeral_key(WOLFSSL_CTX* ctx, int keyAlgo,
  \param keySz key size pointer
  \sa wolfSSL_set_ephemeral_key
  */
-WOLFSSL_API int wolfSSL_get_ephemeral_key(WOLFSSL* ssl, int keyAlgo, 
+int wolfSSL_get_ephemeral_key(WOLFSSL* ssl, int keyAlgo, 
     const unsigned char** key, unsigned int* keySz);
 
 /*!
@@ -13929,6 +13941,7 @@ WOLFSSL_API int wolfSSL_get_ephemeral_key(WOLFSSL* ssl, int keyAlgo,
  \param padding   Padding to use. Only RSA_PKCS1_PSS_PADDING and
                   RSA_PKCS1_PADDING are currently supported for signing.
  */
-WOLFSSL_API int wolfSSL_RSA_sign_generic_padding(int type, const unsigned char* m,
+int wolfSSL_RSA_sign_generic_padding(int type, const unsigned char* m,
                                unsigned int mLen, unsigned char* sigRet,
-                               unsigned int* sigLen, WOLFSSL_RSA*, int, int);
+                               unsigned int* sigLen, WOLFSSL_RSA* rsa,
+                               int flag, int padding);

--- a/doc/dox_comments/header_files/tfm.h
+++ b/doc/dox_comments/header_files/tfm.h
@@ -26,4 +26,4 @@
 
     \sa CheckRunTimeSettings
 */
-WOLFSSL_API word32 CheckRunTimeFastMath(void);
+word32 CheckRunTimeFastMath(void);

--- a/doc/dox_comments/header_files/types.h
+++ b/doc/dox_comments/header_files/types.h
@@ -45,7 +45,7 @@
 	\sa wolfSSL_Free
 	\sa wolfSSL_SetAllocators
 */
-WOLFSSL_API void* XMALLOC(size_t n, void* heap, int type);
+void* XMALLOC(size_t n, void* heap, int type);
 
 /*!
     \ingroup Memory
@@ -93,7 +93,7 @@ WOLFSSL_API void* XMALLOC(size_t n, void* heap, int type);
 	\sa wolfSSL_Free
 	\sa wolfSSL_SetAllocators
 */
-WOLFSSL_API void* XREALLOC(void *p, size_t n, void* heap, int type);
+void* XREALLOC(void *p, size_t n, void* heap, int type);
 
 /*!
     \ingroup Memory
@@ -140,7 +140,7 @@ WOLFSSL_API void* XREALLOC(void *p, size_t n, void* heap, int type);
 	\sa wolfSSL_Free
 	\sa wolfSSL_SetAllocators
 */
-WOLFSSL_API void XFREE(void *p, void* heap, int type);
+void XFREE(void *p, void* heap, int type);
 
 /*!
     \ingroup Math
@@ -169,4 +169,4 @@ WOLFSSL_API void XFREE(void *p, void* heap, int type);
 
     \sa CheckRunTimeFastMath
 */
-WOLFSSL_API word32 CheckRunTimeSettings(void);
+word32 CheckRunTimeSettings(void);

--- a/doc/dox_comments/header_files/wc_encrypt.h
+++ b/doc/dox_comments/header_files/wc_encrypt.h
@@ -42,7 +42,7 @@
     \sa wc_AesCbcEncrypt
     \sa wc_AesCbcDecrypt
 */
-WOLFSSL_API int  wc_AesCbcDecryptWithKey(byte* out, const byte* in, word32 inSz,
+int  wc_AesCbcDecryptWithKey(byte* out, const byte* in, word32 inSz,
                                          const byte* key, word32 keySz,
                                          const byte* iv);
 
@@ -84,7 +84,7 @@ WOLFSSL_API int  wc_AesCbcDecryptWithKey(byte* out, const byte* in, word32 inSz,
 
     \sa wc_Des_CbcDecrypt
 */
-WOLFSSL_API int  wc_Des_CbcDecryptWithKey(byte* out,
+int  wc_Des_CbcDecryptWithKey(byte* out,
                                           const byte* in, word32 sz,
                                           const byte* key, const byte* iv);
 
@@ -123,7 +123,7 @@ WOLFSSL_API int  wc_Des_CbcDecryptWithKey(byte* out,
     \sa wc_Des_CbcDecryptWithKey
     \sa wc_Des_CbcEncrypt
 */
-WOLFSSL_API int  wc_Des_CbcEncryptWithKey(byte* out,
+int  wc_Des_CbcEncryptWithKey(byte* out,
                                           const byte* in, word32 sz,
                                           const byte* key, const byte* iv);
 
@@ -165,7 +165,7 @@ WOLFSSL_API int  wc_Des_CbcEncryptWithKey(byte* out,
     \sa wc_Des_CbcEncryptWithKey
     \sa wc_Des_CbcDecryptWithKey
 */
-WOLFSSL_API int  wc_Des3_CbcEncryptWithKey(byte* out,
+int  wc_Des3_CbcEncryptWithKey(byte* out,
                                            const byte* in, word32 sz,
                                            const byte* key, const byte* iv);
 
@@ -207,6 +207,6 @@ WOLFSSL_API int  wc_Des3_CbcEncryptWithKey(byte* out,
 
     \sa wc_Des3_CbcDecrypt
 */
-WOLFSSL_API int  wc_Des3_CbcDecryptWithKey(byte* out,
+int  wc_Des3_CbcDecryptWithKey(byte* out,
                                            const byte* in, word32 sz,
                                            const byte* key, const byte* iv);

--- a/doc/dox_comments/header_files/wc_port.h
+++ b/doc/dox_comments/header_files/wc_port.h
@@ -18,7 +18,7 @@
 
     \sa wolfCrypt_Cleanup
 */
-WOLFSSL_API int wolfCrypt_Init(void);
+int wolfCrypt_Init(void);
 
 /*!
     \ingroup wolfCrypt
@@ -40,4 +40,4 @@ WOLFSSL_API int wolfCrypt_Init(void);
 
     \sa wolfCrypt_Init
 */
-WOLFSSL_API int wolfCrypt_Cleanup(void);
+int wolfCrypt_Cleanup(void);

--- a/doc/dox_comments/header_files/wolfio.h
+++ b/doc/dox_comments/header_files/wolfio.h
@@ -39,7 +39,7 @@
     \sa wolfSSL_CTX_SetIORecv
     \sa wolfSSL_SSLSetIORecv
 */
-WOLFSSL_API int EmbedReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+int EmbedReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 
 /*!
     \brief This function is the send embedded callback.
@@ -77,7 +77,7 @@ WOLFSSL_API int EmbedReceive(WOLFSSL* ssl, char* buf, int sz, void* ctx);
     \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_SSLSetIOSend
 */
-WOLFSSL_API int EmbedSend(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+int EmbedSend(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 
 /*!
     \brief This function is the receive embedded callback.
@@ -115,7 +115,7 @@ WOLFSSL_API int EmbedSend(WOLFSSL* ssl, char* buf, int sz, void* ctx);
     \sa wolfSSL_SSLSetIORecv
     \sa wolfSSL_dtls_get_current_timeout
 */
-WOLFSSL_API int EmbedReceiveFrom(WOLFSSL* ssl, char* buf, int sz, void*);
+int EmbedReceiveFrom(WOLFSSL* ssl, char* buf, int sz, void*);
 
 /*!
     \brief This function is the send embedded callback.
@@ -156,7 +156,7 @@ WOLFSSL_API int EmbedReceiveFrom(WOLFSSL* ssl, char* buf, int sz, void*);
     \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_SSLSetIOSend
 */
-WOLFSSL_API int EmbedSendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
+int EmbedSendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 
 /*!
     \brief This function is the DTLS Generate Cookie callback.
@@ -189,7 +189,7 @@ WOLFSSL_API int EmbedSendTo(WOLFSSL* ssl, char* buf, int sz, void* ctx);
 
     \sa wolfSSL_CTX_SetGenCookie
 */
-WOLFSSL_API int EmbedGenerateCookie(WOLFSSL* ssl, unsigned char* buf,
+int EmbedGenerateCookie(WOLFSSL* ssl, unsigned char* buf,
                                            int sz, void*);
 
 /*!
@@ -212,7 +212,7 @@ WOLFSSL_API int EmbedGenerateCookie(WOLFSSL* ssl, unsigned char* buf,
     \sa wolfSSL_CertManagerEnableOCSPStapling
     \sa wolfSSL_CertManagerEnableOCSP
 */
-WOLFSSL_API void EmbedOcspRespFree(void*, unsigned char*);
+void EmbedOcspRespFree(void* ctx, byte* resp);
 
 /*!
     \brief This function registers a receive callback for wolfSSL to get input
@@ -247,7 +247,7 @@ WOLFSSL_API void EmbedOcspRespFree(void*, unsigned char*);
     \sa wolfSSL_SetIOReadCtx
     \sa wolfSSL_SetIOWriteCtx
 */
-WOLFSSL_API void wolfSSL_CTX_SetIORecv(WOLFSSL_CTX*, CallbackIORecv);
+void wolfSSL_CTX_SetIORecv(WOLFSSL_CTX* ctx, CallbackIORecv CBIORecv);
 
 /*!
     \brief This function registers a context for the SSL session’s receive
@@ -278,7 +278,7 @@ WOLFSSL_API void wolfSSL_CTX_SetIORecv(WOLFSSL_CTX*, CallbackIORecv);
     \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_SetIOWriteCtx
 */
-WOLFSSL_API void wolfSSL_SetIOReadCtx( WOLFSSL* ssl, void *ctx);
+void wolfSSL_SetIOReadCtx( WOLFSSL* ssl, void *ctx);
 
 /*!
     \brief This function registers a context for the SSL session’s send
@@ -309,7 +309,7 @@ WOLFSSL_API void wolfSSL_SetIOReadCtx( WOLFSSL* ssl, void *ctx);
     \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_SetIOReadCtx
 */
-WOLFSSL_API void wolfSSL_SetIOWriteCtx(WOLFSSL* ssl, void *ctx);
+void wolfSSL_SetIOWriteCtx(WOLFSSL* ssl, void *ctx);
 
 /*!
     \ingroup IO
@@ -339,7 +339,7 @@ WOLFSSL_API void wolfSSL_SetIOWriteCtx(WOLFSSL* ssl, void *ctx);
     \sa wolfSSL_SetIOReadCtx
     \sa wolfSSL_CTX_SetIOSend
 */
-WOLFSSL_API void* wolfSSL_GetIOReadCtx( WOLFSSL* ssl);
+void* wolfSSL_GetIOReadCtx( WOLFSSL* ssl);
 
 /*!
     \ingroup IO
@@ -368,7 +368,7 @@ WOLFSSL_API void* wolfSSL_GetIOReadCtx( WOLFSSL* ssl);
     \sa wolfSSL_SetIOReadCtx
     \sa wolfSSL_CTX_SetIOSend
 */
-WOLFSSL_API void* wolfSSL_GetIOWriteCtx(WOLFSSL* ssl);
+void* wolfSSL_GetIOWriteCtx(WOLFSSL* ssl);
 
 /*!
     \brief This function sets the flags for the receive callback to use for
@@ -410,7 +410,7 @@ WOLFSSL_API void* wolfSSL_GetIOWriteCtx(WOLFSSL* ssl);
     \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_SetIOReadCtx
 */
-WOLFSSL_API void wolfSSL_SetIOReadFlags( WOLFSSL* ssl, int flags);
+void wolfSSL_SetIOReadFlags( WOLFSSL* ssl, int flags);
 
 /*!
     \brief This function sets the flags for the send callback to use for the
@@ -445,7 +445,7 @@ WOLFSSL_API void wolfSSL_SetIOReadFlags( WOLFSSL* ssl, int flags);
     \sa wolfSSL_CTX_SetIOSend
     \sa wolfSSL_SetIOReadCtx
 */
-WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
+void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
 
 /*!
     \ingroup IO
@@ -478,7 +478,7 @@ WOLFSSL_API void wolfSSL_SetIOWriteFlags(WOLFSSL* ssl, int flags);
     \sa NetX_Send
     \sa NetX_Receive
 */
-WOLFSSL_API void wolfSSL_SetIO_NetX(WOLFSSL* ssl, NX_TCP_SOCKET* nxsocket,
+void wolfSSL_SetIO_NetX(WOLFSSL* ssl, NX_TCP_SOCKET* nxsocket,
                                       ULONG waitoption);
 
 /*!
@@ -507,7 +507,7 @@ WOLFSSL_API void wolfSSL_SetIO_NetX(WOLFSSL* ssl, NX_TCP_SOCKET* nxsocket,
 
     \sa CallbackGenCookie
 */
-WOLFSSL_API void  wolfSSL_CTX_SetGenCookie(WOLFSSL_CTX*, CallbackGenCookie);
+void  wolfSSL_CTX_SetGenCookie(WOLFSSL_CTX* ctx, CallbackGenCookie cb);
 
 /*!
     \ingroup Setup
@@ -536,7 +536,7 @@ WOLFSSL_API void  wolfSSL_CTX_SetGenCookie(WOLFSSL_CTX*, CallbackGenCookie);
     \sa wolfSSL_SetCookieCtx
     \sa wolfSSL_CTX_SetGenCookie
 */
-WOLFSSL_API void* wolfSSL_GetCookieCtx(WOLFSSL* ssl);
+void* wolfSSL_GetCookieCtx(WOLFSSL* ssl);
 
 
 /*!
@@ -571,7 +571,7 @@ WOLFSSL_API void* wolfSSL_GetCookieCtx(WOLFSSL* ssl);
             receive_buffer, ISOTP_DEFAULT_BUFFER_SIZE, &can_con_info);
     \endcode
  */
-WOLFSSL_API int wolfSSL_SetIO_ISOTP(WOLFSSL *ssl, isotp_wolfssl_ctx *ctx,
+int wolfSSL_SetIO_ISOTP(WOLFSSL *ssl, isotp_wolfssl_ctx *ctx,
         can_recv_fn recv_fn, can_send_fn send_fn, can_delay_fn delay_fn,
         word32 receive_delay, char *receive_buffer, int receive_buffer_size,
         void *arg);


### PR DESCRIPTION
Fixes two things across all the Doxygen:

1. Remove WOLFSSL_API from each definition
2. Add missing parameter names from functions
