### PR TITLE
fixes to mollify cppcheck (sizeofDivisionMemfunc, zerodivcond, shiftTooManyBits, signConversionCond)

### DIFF
--- a/wolfcrypt/src/camellia.c
+++ b/wolfcrypt/src/camellia.c
@@ -1535,7 +1535,7 @@ int wc_CamelliaSetKey(Camellia* cam, const byte* key, word32 len, const byte* iv
 
     if (cam == NULL) return BAD_FUNC_ARG;
 
-    XMEMSET(cam->key, 0, sizeof(KEY_TABLE_TYPE));
+    XMEMSET(cam->key, 0, CAMELLIA_TABLE_BYTE_LEN);
 
     switch (len) {
         case 16:

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -7436,8 +7436,12 @@ static int wc_PKCS7_PwriKek_KeyWrap(PKCS7* pkcs7, const byte* kek, word32 kekSz,
 
     /* get encryption algorithm block size */
     blockSz = wc_PKCS7_GetOIDBlockSize(algID);
-    if (blockSz < 0)
-        return blockSz;
+    if (blockSz <= 0) {
+        if (blockSz < 0)
+            return blockSz;
+        else
+            return ALGO_ID_E;
+    }
 
     /* get pad bytes needed to block boundary */
     padSz = blockSz - ((4 + cekSz) % blockSz);
@@ -7520,9 +7524,12 @@ static int wc_PKCS7_PwriKek_KeyUnWrap(PKCS7* pkcs7, const byte* kek,
 
     /* get encryption algorithm block size */
     blockSz = wc_PKCS7_GetOIDBlockSize(algID);
-    if (blockSz < 0) {
+    if (blockSz <= 0) {
         XFREE(outTmp, pkcs7->heap, DYNAMIC_TYPE_TMP_BUFFER);
-        return blockSz;
+        if (blockSz < 0)
+            return blockSz;
+        else
+            return ALGO_ID_E;
     }
 
     /* input needs to be blockSz multiple and at least 2 * blockSz */

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -981,8 +981,8 @@ int fp_mod(fp_int *a, fp_int *b, fp_int *c)
 /* c = a mod 2**d */
 void fp_mod_2d(fp_int *a, int b, fp_int *c)
 {
-   int x;
-   int bmax;
+   unsigned int x;
+   unsigned int bmax;
 
    /* zero if count less than or equal to zero */
    if (b <= 0) {
@@ -998,16 +998,16 @@ void fp_mod_2d(fp_int *a, int b, fp_int *c)
       return;
    }
 
-  bmax = (b + DIGIT_BIT - 1) / DIGIT_BIT;
+   bmax = ((unsigned int)b + DIGIT_BIT - 1) / DIGIT_BIT;
   /* zero digits above the last digit of the modulus */
-  for (x = bmax; x < c->used; x++) {
+   for (x = bmax; x < (unsigned int)c->used; x++) {
     c->dp[x] = 0;
   }
 
   if (c->sign == FP_NEG) {
      fp_digit carry = 0;
      /* negate value */
-     for (x = 0; x < c->used; x++) {
+     for (x = 0; x < (unsigned int)c->used; x++) {
          fp_digit next = c->dp[x] > 0;
          c->dp[x] = (fp_digit)0 - c->dp[x] - carry;
          carry |= next;
@@ -1015,7 +1015,7 @@ void fp_mod_2d(fp_int *a, int b, fp_int *c)
      for (; x < bmax; x++) {
          c->dp[x] = (fp_digit)0 - carry;
      }
-     c->used = bmax;
+     c->used = (int)bmax;
      c->sign = FP_ZPOS;
   }
 


### PR DESCRIPTION
tested with `wolfssl-multi-test quick-check` updated with cppcheck-2.7.
