### PR TITLE
cppcheck: fixes

### DIFF
--- a/IDE/IAR-MSP430/main.c
+++ b/IDE/IAR-MSP430/main.c
@@ -304,7 +304,7 @@ only_rng:
 
     printf(
         "ChaCha20/Poly1305 Encryption Start, 1000 itterations, %d bytes\r\n",
-        strlen((const char*)plaintext));
+        (int)strlen((const char*)plaintext));
     start = seconds;
     for (int i=0; i <= 1000; i++) {
         ret = wc_ChaCha20Poly1305_Encrypt(key, iv, aad, sizeof(aad), plaintext,

--- a/src/internal.c
+++ b/src/internal.c
@@ -2112,7 +2112,22 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
     ctx->cbioFlag = WOLFSSL_CBIO_NONE;
 #endif
 
-#ifndef WOLFSSL_USER_IO
+#ifdef HAVE_NETX
+    ctx->CBIORecv = NetX_Receive;
+    ctx->CBIOSend = NetX_Send;
+#elif defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP)
+    ctx->CBIORecv = Mynewt_Receive;
+    ctx->CBIOSend = Mynewt_Send;
+#elif defined WOLFSSL_LWIP_NATIVE
+    ctx->CBIORecv = LwIPNativeReceive;
+    ctx->CBIOSend = LwIPNativeSend;
+#elif defined(WOLFSSL_GNRC)
+    ctx->CBIORecv = GNRC_ReceiveFrom;
+    ctx->CBIOSend = GNRC_SendTo;
+#elif defined WOLFSSL_ISOTP
+    ctx->CBIORecv = ISOTP_Receive;
+    ctx->CBIOSend = ISOTP_Send;
+#elif !defined(WOLFSSL_USER_IO)
     #ifdef MICRIUM
         ctx->CBIORecv = MicriumReceive;
         ctx->CBIOSend = MicriumSend;
@@ -2149,23 +2164,6 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
         #endif
     #endif /* MICRIUM */
 #endif /* WOLFSSL_USER_IO */
-
-#ifdef HAVE_NETX
-    ctx->CBIORecv = NetX_Receive;
-    ctx->CBIOSend = NetX_Send;
-#elif defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP)
-    ctx->CBIORecv = Mynewt_Receive;
-    ctx->CBIOSend = Mynewt_Send;
-#elif defined WOLFSSL_LWIP_NATIVE
-    ctx->CBIORecv = LwIPNativeReceive;
-    ctx->CBIOSend = LwIPNativeSend;
-#elif defined(WOLFSSL_GNRC)
-    ctx->CBIORecv = GNRC_ReceiveFrom;
-    ctx->CBIOSend = GNRC_SendTo;
-#elif defined WOLFSSL_ISOTP
-    ctx->CBIORecv = ISOTP_Receive;
-    ctx->CBIOSend = ISOTP_Send;
-#endif
 
 #ifdef HAVE_PQC
     if (method->side == WOLFSSL_CLIENT_END)
@@ -6341,24 +6339,6 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     ssl->wfd = -1;
     ssl->devId = ctx->devId; /* device for async HW (from wolfAsync_DevOpen) */
 
-#ifdef HAVE_NETX
-    ssl->IOCB_ReadCtx  = &ssl->nxCtx;  /* default NetX IO ctx, same for read */
-    ssl->IOCB_WriteCtx = &ssl->nxCtx;  /* and write */
-#elif defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP)
-    ssl->mnCtx = mynewt_ctx_new();
-    if(!ssl->mnCtx) {
-        return MEMORY_E;
-    }
-    ssl->IOCB_ReadCtx  = ssl->mnCtx;  /* default Mynewt IO ctx, same for read */
-    ssl->IOCB_WriteCtx = ssl->mnCtx;  /* and write */
-#elif defined (WOLFSSL_GNRC)
-    ssl->IOCB_ReadCtx = ssl->gnrcCtx;
-    ssl->IOCB_WriteCtx = ssl->gnrcCtx;
-#else
-    ssl->IOCB_ReadCtx  = &ssl->rfd;  /* prevent invalid pointer access if not */
-    ssl->IOCB_WriteCtx = &ssl->wfd;  /* correctly set */
-#endif
-
     /* initialize states */
     ssl->options.serverState = NULL_STATE;
     ssl->options.clientState = NULL_STATE;
@@ -6402,8 +6382,26 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 
     ssl->IOCB_ReadCtx  = &ssl->buffers.dtlsCtx;  /* prevent invalid pointer access if not */
     ssl->IOCB_WriteCtx = &ssl->buffers.dtlsCtx;  /* correctly set */
-
+#else
+#ifdef HAVE_NETX
+    ssl->IOCB_ReadCtx  = &ssl->nxCtx;  /* default NetX IO ctx, same for read */
+    ssl->IOCB_WriteCtx = &ssl->nxCtx;  /* and write */
+#elif defined(WOLFSSL_APACHE_MYNEWT) && !defined(WOLFSSL_LWIP)
+    ssl->mnCtx = mynewt_ctx_new();
+    if(!ssl->mnCtx) {
+        return MEMORY_E;
+    }
+    ssl->IOCB_ReadCtx  = ssl->mnCtx;  /* default Mynewt IO ctx, same for read */
+    ssl->IOCB_WriteCtx = ssl->mnCtx;  /* and write */
+#elif defined (WOLFSSL_GNRC)
+    ssl->IOCB_ReadCtx = ssl->gnrcCtx;
+    ssl->IOCB_WriteCtx = ssl->gnrcCtx;
+#else
+    ssl->IOCB_ReadCtx  = &ssl->rfd;  /* prevent invalid pointer access if not */
+    ssl->IOCB_WriteCtx = &ssl->wfd;  /* correctly set */
 #endif
+#endif
+
 
 #ifndef WOLFSSL_AEAD_ONLY
     #ifndef NO_OLD_TLS
@@ -18169,6 +18167,13 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
     if (ssl == NULL) {
         return BAD_FUNC_ARG;
     }
+    /* catch mistaken sizeOnly parameter */
+    if (!sizeOnly && (output == NULL || input == NULL) ) {
+        return BAD_FUNC_ARG;
+    }
+    if (sizeOnly && (output || input) ) {
+        return BAD_FUNC_ARG;
+    }
 
     (void)epochOrder;
 
@@ -18216,14 +18221,6 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
     switch (ssl->options.buildMsgState) {
         case BUILD_MSG_BEGIN:
         {
-            /* catch mistaken sizeOnly parameter */
-            if (!sizeOnly && (output == NULL || input == NULL) ) {
-                ERROR_OUT(BAD_FUNC_ARG, exit_buildmsg);
-            }
-            if (sizeOnly && (output || input) ) {
-                WOLFSSL_MSG("BuildMessage w/sizeOnly doesn't need input/output");
-                ERROR_OUT(BAD_FUNC_ARG, exit_buildmsg);
-            }
         #if defined(WOLFSSL_DTLS) && defined(HAVE_SECURE_RENEGOTIATION)
             if (ssl->options.dtls && DtlsSCRKeysSet(ssl)) {
                 /* For epochs >1 the current cipher parameters are located in

--- a/tests/api.c
+++ b/tests/api.c
@@ -7302,7 +7302,7 @@ static void test_wolfSSL_UseSNI_connection(void)
     XMEMSET(&server_cb, 0, sizeof(callback_functions));
     client_cb.method = wolfSSLv23_client_method;
     server_cb.method = wolfSSLv23_server_method;
-    server_cb.devId = devId;
+    client_cb.devId = devId;
     server_cb.devId = devId;
 
     /* success case at ctx */
@@ -7338,6 +7338,7 @@ static void test_wolfSSL_UseSNI_connection(void)
     /* sni abort - abort when absent (ctx) */
     client_cb.ctx_ready = NULL;                     client_cb.ssl_ready = NULL; client_cb.on_result = verify_FATAL_ERROR_on_client;
     server_cb.ctx_ready = use_MANDATORY_SNI_at_ctx; server_cb.ssl_ready = NULL; server_cb.on_result = verify_SNI_ABSENT_on_server;
+    test_wolfSSL_client_server(&client_cb, &server_cb);
 
     /* sni abort - abort when absent (ssl) */
     client_cb.ctx_ready = NULL; client_cb.ssl_ready = NULL;                     client_cb.on_result = verify_FATAL_ERROR_on_client;
@@ -7831,7 +7832,7 @@ static void test_wolfSSL_UseALPN_connection(void)
     XMEMSET(&server_cb, 0, sizeof(callback_functions));
     client_cb.method = wolfSSLv23_client_method;
     server_cb.method = wolfSSLv23_server_method;
-    server_cb.devId = devId;
+    client_cb.devId = devId;
     server_cb.devId = devId;
 
     /* success case same list */
@@ -8031,7 +8032,7 @@ static void test_wolfSSL_set_alpn_protos(void)
     XMEMSET(&server_cb, 0, sizeof(callback_functions));
     client_cb.method = wolfSSLv23_client_method;
     server_cb.method = wolfSSLv23_server_method;
-    server_cb.devId = devId;
+    client_cb.devId = devId;
     server_cb.devId = devId;
 
     /* use CTX_alpn_protos */
@@ -30365,8 +30366,8 @@ static void test_wc_GetPubKeyDerFromCert(void)
     byte certBuf[6000]; /* for PEM and CSR, client-cert.pem is 5-6kB */
     word32 certBufSz = sizeof(certBuf);
 #endif
-#if (!defined(USE_CERT_BUFFERS_2048) && !defined(USE_CERT_BUFFERS_1024)) || \
-    defined(WOLFSSL_CERT_REQ)
+#if ((!defined(USE_CERT_BUFFERS_2048) && !defined(USE_CERT_BUFFERS_1024)) || \
+     defined(WOLFSSL_CERT_REQ)) && !defined(NO_RSA)
     XFILE fp;
 #endif
 #ifndef NO_RSA

--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -102,7 +102,11 @@ int testsuite_test(int argc, char** argv)
     func_args server_args;
 
     tcp_ready ready;
+#if !defined(NETOS)
     THREAD_TYPE serverThread;
+
+    int ret;
+#endif
 
 #ifndef USE_WINDOWS_API
     const char *tempDir = NULL;
@@ -117,7 +121,6 @@ int testsuite_test(int argc, char** argv)
 #ifdef HAVE_STACK_SIZE
     void *serverThreadStackContext = NULL;
 #endif
-    int ret;
 
 #ifndef USE_WINDOWS_API
 #ifdef XGETENV

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -25447,7 +25447,9 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
     return ret;
 #else
     DECL_ASNSETDATA(dataASN, certReqBodyASN_Length);
-    word32 publicKeySz, subjectSz, extSz;
+    word32 publicKeySz;
+    word32 subjectSz = 0;
+    word32 extSz;
     int sz = 0;
     int ret = 0;
 #if defined(WOLFSSL_CERT_EXT) || defined(OPENSSL_EXTRA)

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -4198,6 +4198,9 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
    !defined(WOLFSSL_ATECC608A)
    CRYS_ECDH_TempData_t tempBuff;
 #endif
+
+   (void)err;
+
    if (private_key == NULL || public_key == NULL || out == NULL ||
                                                             outlen == NULL) {
        return BAD_FUNC_ARG;
@@ -4210,13 +4213,11 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
         if (err != CRYPTOCB_UNAVAILABLE)
             return err;
         /* fall-through when unavailable */
-    #else
-        return err;
     #endif
     }
     #ifdef WOLF_CRYPTO_CB_ONLY_ECC
     else {
-        return NO_VALID_DEVID;
+        err = NO_VALID_DEVID;
     }
     #endif
 #endif
@@ -4262,17 +4263,17 @@ int wc_ecc_shared_secret(ecc_key* private_key, ecc_key* public_key, byte* out,
         return err;
     }
 #elif defined(WOLFSSL_SILABS_SE_ACCEL)
-    err = silabs_ecc_shared_secret(private_key, public_key, out, outlen);
+   err = silabs_ecc_shared_secret(private_key, public_key, out, outlen);
 #elif defined(WOLFSSL_KCAPI_ECC)
    err = KcapiEcc_SharedSecret(private_key, public_key, out, outlen);
 #elif defined(WOLFSSL_SE050)
-    err = se050_ecc_shared_secret(private_key, public_key, out, outlen);
+   err = se050_ecc_shared_secret(private_key, public_key, out, outlen);
 #else
    err = wc_ecc_shared_secret_ex(private_key, &public_key->pubkey, out, outlen);
 #endif /* WOLFSSL_ATECC508A */
+#endif /* WOLF_CRYPTO_CB_ONLY_ECC */
 
    return err;
-#endif /* WOLF_CRYPTO_CB_ONLY_ECC */
 }
 
 
@@ -5798,13 +5799,11 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
         if (err != CRYPTOCB_UNAVAILABLE)
             return err;
         /* fall-through when unavailable */
-    #else
-        return err;
     #endif
     }
     #ifdef WOLF_CRYPTO_CB_ONLY_ECC
     else {
-        return NO_VALID_DEVID;
+        err = NO_VALID_DEVID;
     }
     #endif
 #endif
@@ -5872,15 +5871,15 @@ int wc_ecc_sign_hash(const byte* in, word32 inlen, byte* out, word32 *outlen,
     XFREE(r, key->heap, DYNAMIC_TYPE_ECC);
 #endif
 #endif /* WOLFSSL_ASYNC_CRYPT */
-
-    return err;
 #else
     (void)rng;
     (void)inlen;
     (void)s;
     (void)r;
+    (void)err;
 #endif /* WOLF_CRYPTO_CB_ONLY_ECC */
 
+    return err;
 }
 #endif /* !NO_ASN */
 
@@ -7388,13 +7387,11 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
         if (err != CRYPTOCB_UNAVAILABLE)
             return err;
         /* fall-through when unavailable */
-    #else
-        return err;
     #endif
     }
     #ifdef WOLF_CRYPTO_CB_ONLY_ECC
     else {
-        return NO_VALID_DEVID;
+        err = NO_VALID_DEVID;
     }
     #endif
 #endif
@@ -7500,8 +7497,6 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
 
     /* make sure required variables are reset */
     wc_ecc_reset(key);
-
-    return err;
 #else
     (void)siglen;
     (void)hashlen;
@@ -7511,8 +7506,10 @@ int wc_ecc_verify_hash(const byte* sig, word32 siglen, const byte* hash,
     #endif
     (void)s;
     (void)r;
+    (void)err;
 #endif /* WOLF_CRYPTO_CB_ONLY_ECC */
 
+    return err;
 }
 #endif /* !NO_ASN */
 

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3660,7 +3660,7 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbyname(const char *name)
     const struct alias {
         const char *name;
         const char *alias;
-    } alias_tbl[] = {
+    } cipher_alias_tbl[] = {
 #ifndef NO_DES3
         {EVP_DES_CBC, "des"},
         {EVP_DES_ECB, "des-ecb"},
@@ -3721,7 +3721,7 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbyname(const char *name)
 
     WOLFSSL_ENTER("EVP_get_cipherbyname");
 
-    for (al = alias_tbl; al->name != NULL; al++) {
+    for (al = cipher_alias_tbl; al->name != NULL; al++) {
         /* Accept any case alternative version of an alias. */
         if (XSTRNCASECMP(name, al->alias, XSTRLEN(al->alias)+1) == 0) {
             name = al->name;
@@ -3871,7 +3871,7 @@ int wolfSSL_EVP_Digest(const unsigned char* in, int inSz, unsigned char* out,
 static const struct alias {
             const char *name;
             const char *alias;
-} alias_tbl[] =
+} digest_alias_tbl[] =
 {
     {"MD4", "ssl3-md4"},
     {"MD5", "ssl3-md5"},
@@ -3897,7 +3897,7 @@ const WOLFSSL_EVP_MD *wolfSSL_EVP_get_digestbyname(const char *name)
         return NULL;
 
     name = nameUpper;
-    for (al = alias_tbl; al->name != NULL; al++)
+    for (al = digest_alias_tbl; al->name != NULL; al++)
         if(XSTRNCMP(name, al->alias, XSTRLEN(al->alias)+1) == 0) {
             name = al->name;
             break;
@@ -4357,7 +4357,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
         const char* aliasnm = NULL;
         const struct alias  *al;
 
-        for (al = alias_tbl; al->name != NULL; al++)
+        for (al = digest_alias_tbl; al->name != NULL; al++)
             if(XSTRNCMP(n, al->name, XSTRLEN(al->name)+1) == 0) {
                 aliasnm = al->alias;
                 break;
@@ -9005,19 +9005,26 @@ int wolfSSL_EVP_PKEY_print_public(WOLFSSL_BIO* out,
     const WOLFSSL_EVP_PKEY* pkey, int indent, ASN1_PCTX* pctx)
 {
     int res;
+#if !defined(NO_RSA) || defined(HAVE_ECC) || !defined(NO_DSA) || \
+    defined(WOLFSSL_DH_EXTRA)
     int keybits;    /* bit length of the key */
+#endif
 
     WOLFSSL_ENTER("wolfSSL_EVP_PKEY_print_public");
 
     if (pkey == NULL || out == NULL) {
         return 0;
     }
+#if !defined(NO_RSA) || defined(HAVE_ECC) || !defined(NO_DSA) || \
+    defined(WOLFSSL_DH_EXTRA)
     if (indent < 0) {
         indent = 0;
     }
     if (indent > EVP_PKEY_PRINT_INDENT_MAX) {
         indent = EVP_PKEY_PRINT_INDENT_MAX;
     }
+#endif
+
     switch (pkey->type) {
         case EVP_PKEY_RSA:
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3071,7 +3071,9 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
                             byte* label, word32 labelSz, int saltLen,
                             WC_RNG* rng)
 {
-    int ret, sz, state;
+    int ret = 0;
+    int sz;
+    int state;
 
     if (in == NULL || inLen == 0 || out == NULL || key == NULL) {
         return BAD_FUNC_ARG;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -16668,11 +16668,11 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
     #ifdef HAVE_FFDHE_4096
     #ifdef HAVE_PUBLIC_FFDHE
     ret = dh_ffdhe_test(&rng, wc_Dh_ffdhe4096_Get());
-    if (ret != 0)
-        ERROR_OUT(-8128, done);
     #else
     ret = dh_ffdhe_test(&rng, WC_FFDHE_4096);
     #endif
+    if (ret != 0)
+        ERROR_OUT(-8128, done);
     #endif
 #endif /* !WC_NO_RNG */
 #endif /* HAVE_FIPS_VERSION == 2 && !WOLFSSL_SP_ARM64_ASM */


### PR DESCRIPTION
# Description

cppcheck: fixes

CBIORecv/Send are only assigned once.
IOCB_ReadCtx/WriteCtx only assigned once.
BuildMessage checks output and input wiht sizeOnly every call - state
machine doesn't cache these.
Renamed alias_tbl variables to something unique.
Other cppcheck fixes.
Also reworked pem_read_bio_key().

# Testing

cppcheck

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
