### PR TITLE
Add api to set heap for TSIP when WOLFSSL_STATIC_MEMORY is defined

### DIFF
--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/test_main.c
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/test_main.c
@@ -52,6 +52,24 @@ extern "C" {
     user_PKCbInfo            guser_PKCbInfo;
 #endif
 
+/*
+ *  buffer for static memory.
+ *  used for TLS_CLIENT demo
+ */
+#if defined(TLS_CLIENT)
+#if defined(WOLFSSL_RENESAS_TSIP_TLS) && defined(WOLFSSL_STATIC_MEMORY)
+    #include <wolfssl/wolfcrypt/memory.h>
+
+    WOLFSSL_HEAP_HINT*  heapHint = NULL;
+
+    #define BUFFSIZE_GEN   (110 * 1024)    
+    unsigned char heapBufGen[BUFFSIZE_GEN];
+ 
+#endif /* WOLFSSL_RENESAS_TSIP_TLS && WOLFSSL_STATIC_MEMORY */
+#endif /* TLS_CLIENT */
+
+
+
 static long tick;
 static void timeTick(void *pdata)
 {
@@ -240,6 +258,15 @@ void main(void)
     const int cipherlist_sz = 0;
 
 #endif
+
+#if defined(WOLFSSL_STATIC_MEMORY)
+    if (wc_LoadStaticMemory(&heapHint, heapBufGen, sizeof(heapBufGen),
+                                                WOLFMEM_GENERAL, 1) != 0) {
+        printf("unable to load static memory.\n");
+        return;
+    }
+#endif /* WOLFSSL_STATIC_MEMORY */
+
     int i = 0;
 
     Open_tcp();

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_sha.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_sha.c
@@ -35,8 +35,14 @@
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
 
+
 #if !defined(NO_SHA)
 #include <wolfssl/wolfcrypt/sha.h>
+
+#if defined(WOLFSSL_STATIC_MEMORY)
+    #include <wolfssl/wolfcrypt/memory.h>
+    extern WOLFSSL_HEAP_HINT*  g_tsip_heap_hint;
+#endif /* WOLFSSL_STATIC_MEMORY */
 
 static void TSIPHashFree(wolfssl_TSIP_Hash* hash)
 {
@@ -64,6 +70,12 @@ static int TSIPHashInit(wolfssl_TSIP_Hash* hash, void* heap, int devId,
     hash->used = 0;
     hash->msg  = NULL;
     hash->sha_type = sha_type;
+
+#if defined(WOLFSSL_STATIC_MEMORY)
+    if (heap == NULL && g_tsip_heap_hint != NULL) {
+        hash->heap = g_tsip_heap_hint;
+    }
+#endif
 
     return 0;
 }

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
@@ -53,6 +53,9 @@ static int          tsip_CryptHwMutexInit_ = 0;
 static const byte*  ca_cert_sig;
 static tsip_key_data g_user_key_info;
 
+#if defined(WOLFSSL_STATIC_MEMORY)
+WOLFSSL_HEAP_HINT*  g_tsip_heap_hint = NULL;
+#endif /* WOLFSSL_STATIC_MEMORY */
 
 /* tsip only keep one encrypted ca public key */
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
@@ -63,7 +66,17 @@ extern uint32_t     g_CAscm_Idx;
 
 #endif /* WOLFSSL_RENESAS_TSIP_TLS */
 
+/* 
+    set heap info. returns 0 on success.
+*/
+#if defined(WOLFSSL_STATIC_MEMORY)
+int  tsip_set_heap(struct WOLFSSL_HEAP_HINT* heap)
+{
+    g_tsip_heap_hint = heap;
 
+    return 0;
+}
+#endif /* WOLFSSL_STATIC_MEMORY */
 
 static int tsip_CryptHwMutexInit(wolfSSL_Mutex* mutex)
 {

--- a/wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h
@@ -197,6 +197,9 @@ WOLFSSL_API void tsip_set_callbacks(struct WOLFSSL_CTX* ctx);
 
 WOLFSSL_API int  tsip_set_callback_ctx(struct WOLFSSL* ssl, void* user_ctx);
 
+#if defined(WOLFSSL_STATIC_MEMORY)
+WOLFSSL_API int  tsip_set_heap(struct WOLFSSL_HEAP_HINT* heap);
+#endif /* WOLFSSL_STATIC_MEMORY */
 
 
 #if (WOLFSSL_RENESAS_TSIP_VER >=109)


### PR DESCRIPTION
# Description

This PR is to address the issue found in ZD13893. When WOLFSSL_STATIC_MEMORY is defined, wc_RNG_HealthTest_ex is called with NULL heap hint. It leads wc_Sha256 of TSIP port to memory error. To handle this situation, a api to set heap hint for TSIP port is added. This api should be called when WOLFSSL_STATIC_MEMORY is defined. Added some code for example-client to work even when WOLFSSL_STATIC_MEMORY is defined.

Fixes  ZD13893

# Testing

Build client example code with WOLFSSL_STATIC_MEMORY and run it on Renesas GR-ROSE board. 

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
