### PR TITLE
fix unused parameter when using CRYPTO_CB_ONLY_RSA

### DIFF
--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3034,6 +3034,7 @@ static int wc_RsaFunction_ex(const byte* in, word32 inLen, byte* out,
     return ret;
 #else
     (void)rng;
+    (void)checkSmallCt;
 #endif /* WOLF_CRYPTO_CB_ONLY_RSA */
 }
 


### PR DESCRIPTION
# Description

unused parameter causes compiling error with the configuration.

# Testing

compile with `./configure --enable-cryptocb --disable-examples CFLAGS="-DWOLF_CRYPTO_CB_ONLY_RSA -DWOLF_CRYPTO_CB_ONLY_ECC -DUSE_CERT_BUFFERS_256"`


