### PR TITLE
cmake: out of source support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1767,7 +1767,7 @@ endif()
 
 target_include_directories(wolfssl
     PUBLIC
-        $<INSTALL_INTERFACE:wolfssl>
+        $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
@@ -2048,9 +2048,11 @@ set(INSTALLED_EXAMPLES
 
 # Install the library
 install(TARGETS wolfssl
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}
         EXPORT wolfssl-targets
-        LIBRARY)
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin
+        )
 # Install the headers
 install(DIRECTORY ${WOLFSSL_OUTPUT_BASE}/wolfssl/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/wolfssl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1683,7 +1683,22 @@ add_definitions("-DWOLFSSL_IGNORE_FILE_WARN")
 
 # Generate user options header
 message("Generating user options header...")
-set(OPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/wolfssl/options.h")
+if (${CMAKE_DISABLE_SOURCE_CHANGES})
+    set(WOLFSSL_BUILD_OUT_OF_TREE_DEFAULT "${CMAKE_DISABLE_SOURCE_CHANGES}")
+else()
+    set(WOLFSSL_BUILD_OUT_OF_TREE_DEFAULT "no")
+endif()
+add_option("WOLFSSL_BUILD_OUT_OF_TREE"
+    "Don't generate files in the source tree (default: ${WOLFSSL_BUILD_OUT_OF_TREE_DEFAULT})"
+    "${WOLFSSL_BUILD_OUT_OF_TREE_DEFAULT}" "yes;no")
+if (${WOLFSSL_BUILD_OUT_OF_TREE})
+   set(WOLFSSL_OUTPUT_BASE ${CMAKE_CURRENT_BINARY_DIR})
+else()
+   set(WOLFSSL_OUTPUT_BASE ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+set(OPTION_FILE "${WOLFSSL_OUTPUT_BASE}/wolfssl/options.h")
+set(CYASSL_OPTION_FILE "${WOLFSSL_OUTPUT_BASE}/cyassl/options.h")
+
 file(REMOVE ${OPTION_FILE})
 
 file(APPEND ${OPTION_FILE} "/* wolfssl options.h\n")
@@ -1713,7 +1728,6 @@ file(APPEND ${OPTION_FILE} "#endif\n\n\n")
 file(APPEND ${OPTION_FILE} "#endif /* WOLFSSL_OPTIONS_H */\n\n")
 
 # backwards compatibility for those who have included options or version
-set(CYASSL_OPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cyassl/options.h")
 file(REMOVE ${CYASSL_OPTION_FILE})
 file(APPEND ${CYASSL_OPTION_FILE} "/* cyassl options.h\n")
 file(APPEND ${CYASSL_OPTION_FILE} " * generated from wolfssl/options.h\n")
@@ -1786,7 +1800,7 @@ if(WOLFSSL_EXAMPLES)
     target_link_libraries(client wolfssl)
     set_property(TARGET client
                  PROPERTY RUNTIME_OUTPUT_DIRECTORY
-                 ${CMAKE_CURRENT_SOURCE_DIR}/examples/client)
+                 ${WOLFSSL_OUTPUT_BASE}/examples/client)
 
     # Build wolfSSL server example
     add_executable(server
@@ -1794,7 +1808,7 @@ if(WOLFSSL_EXAMPLES)
     target_link_libraries(server wolfssl)
     set_property(TARGET server
                  PROPERTY RUNTIME_OUTPUT_DIRECTORY
-                 ${CMAKE_CURRENT_SOURCE_DIR}/examples/server)
+                 ${WOLFSSL_OUTPUT_BASE}/examples/server)
 
     # Build echo client example
     add_executable(echoclient
@@ -1804,7 +1818,7 @@ if(WOLFSSL_EXAMPLES)
     target_link_libraries(echoclient wolfssl)
     set_property(TARGET echoclient
                  PROPERTY RUNTIME_OUTPUT_DIRECTORY
-                 ${CMAKE_CURRENT_SOURCE_DIR}/examples/echoclient)
+                 ${WOLFSSL_OUTPUT_BASE}/examples/echoclient)
 
     # Build echo server example
     add_executable(echoserver
@@ -1814,7 +1828,7 @@ if(WOLFSSL_EXAMPLES)
     target_link_libraries(echoserver wolfssl)
     set_property(TARGET echoserver
                  PROPERTY RUNTIME_OUTPUT_DIRECTORY
-                 ${CMAKE_CURRENT_SOURCE_DIR}/examples/echoserver)
+                 ${WOLFSSL_OUTPUT_BASE}/examples/echoserver)
 
     if(NOT WIN32)
         # Build TLS benchmark example
@@ -1824,7 +1838,7 @@ if(WOLFSSL_EXAMPLES)
         target_link_libraries(tls_bench Threads::Threads)
         set_property(TARGET tls_bench
                  PROPERTY RUNTIME_OUTPUT_DIRECTORY
-                 ${CMAKE_CURRENT_SOURCE_DIR}/examples/benchmark)
+                 ${WOLFSSL_OUTPUT_BASE}/examples/benchmark)
     endif()
 
     # Build unit tests
@@ -1843,7 +1857,7 @@ if(WOLFSSL_EXAMPLES)
     target_link_libraries(unit_test Threads::Threads)
     set_property(TARGET unit_test
                  PROPERTY RUNTIME_OUTPUT_DIRECTORY
-                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/)
+                 ${WOLFSSL_OUTPUT_BASE}/tests/)
     set_property(TARGET unit_test
                  PROPERTY RUNTIME_OUTPUT_NAME
                  unit.test)
@@ -1876,7 +1890,7 @@ if(WOLFSSL_CRYPT_TESTS)
     target_link_libraries(wolfcrypttest wolfssl)
     set_property(TARGET wolfcrypttest
                  PROPERTY RUNTIME_OUTPUT_DIRECTORY
-                 ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/test)
+                 ${WOLFSSL_OUTPUT_BASE}/wolfcrypt/test)
     set_property(TARGET wolfcrypttest
                  PROPERTY RUNTIME_OUTPUT_NAME
                  testwolfcrypt)
@@ -1889,7 +1903,7 @@ if(WOLFSSL_CRYPT_TESTS)
     target_link_libraries(wolfcryptbench wolfssl)
     set_property(TARGET wolfcryptbench
                  PROPERTY RUNTIME_OUTPUT_DIRECTORY
-                 ${CMAKE_CURRENT_SOURCE_DIR}/wolfcrypt/benchmark)
+                 ${WOLFSSL_OUTPUT_BASE}/wolfcrypt/benchmark)
     set_property(TARGET wolfcryptbench
                  PROPERTY RUNTIME_OUTPUT_NAME
                  benchmark)
@@ -2038,6 +2052,14 @@ install(TARGETS wolfssl
         EXPORT wolfssl-targets
         LIBRARY)
 # Install the headers
+install(DIRECTORY ${WOLFSSL_OUTPUT_BASE}/wolfssl/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/wolfssl
+        FILES_MATCHING PATTERN "*.h"
+        REGEX ${EXCLUDED_HEADERS_REGEX} EXCLUDE)
+install(DIRECTORY ${WOLFSSL_OUTPUT_BASE}/cyassl/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cyassl
+        FILES_MATCHING PATTERN "*.h"
+        REGEX ${EXCLUDED_HEADERS_REGEX} EXCLUDE)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/wolfssl/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/wolfssl
         FILES_MATCHING PATTERN "*.h"

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2835,7 +2835,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 wolfSSL_CTX_EnableOCSP(ctx, WOLFSSL_OCSP_NO_NONCE);
         }
 #ifndef NO_RSA
-    /* All the OSCP Stapling test certs are RSA. */
+    /* All the OCSP Stapling test certs are RSA. */
 #if defined(HAVE_CERTIFICATE_STATUS_REQUEST) \
     || defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
         { /* scope start */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -31065,10 +31065,10 @@ int InitOcspRequest(OcspRequest* req, DecodedCert* cert, byte useNonce,
         ret = wc_InitRng(&rng);
     #endif
         if (ret != 0) {
-            WOLFSSL_MSG("\tCannot initialize RNG. Skipping the OSCP Nonce.");
+            WOLFSSL_MSG("\tCannot initialize RNG. Skipping the OCSP Nonce.");
         } else {
             if (wc_RNG_GenerateBlock(&rng, req->nonce, MAX_OCSP_NONCE_SZ) != 0)
-                WOLFSSL_MSG("\tCannot run RNG. Skipping the OSCP Nonce.");
+                WOLFSSL_MSG("\tCannot run RNG. Skipping the OCSP Nonce.");
             else
                 req->nonceSz = MAX_OCSP_NONCE_SZ;
 


### PR DESCRIPTION
# Description

Add option (`WOLFSSL_BUILD_OUT_OF_TREE`) to make avoid making changes to the source tree. Defaults to value of `CMAKE_DISABLE_SOURCE_CHANGES` if is set.

# Testing

Out of tree builds with options enabled.
Also tested with `vcpkg` configuration which enables `CMAKE_DISABLE_SOURCE_CHANGES`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
