### PR TITLE
Add support for EVP_PKEY_sign/verify functionality

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -43114,7 +43114,7 @@ int wolfSSL_RSA_public_decrypt(int flen, const unsigned char* from,
 
     if (rsa == NULL || rsa->internal == NULL || from == NULL) {
         WOLFSSL_MSG("Bad function arguments");
-        return WOLFSSL_FAILURE;
+        return WOLFSSL_FATAL_ERROR;
     }
 
 #if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
@@ -43134,7 +43134,7 @@ int wolfSSL_RSA_public_decrypt(int flen, const unsigned char* from,
         break;
     default:
         WOLFSSL_MSG("RSA_public_decrypt unsupported padding");
-        return WOLFSSL_FAILURE;
+        return WOLFSSL_FATAL_ERROR;
     }
 #endif
 
@@ -43143,7 +43143,7 @@ int wolfSSL_RSA_public_decrypt(int flen, const unsigned char* from,
 
         if (SetRsaInternal(rsa) != WOLFSSL_SUCCESS) {
             WOLFSSL_MSG("SetRsaInternal failed");
-            return WOLFSSL_FAILURE;
+            return WOLFSSL_FATAL_ERROR;
         }
     }
 
@@ -43160,14 +43160,14 @@ int wolfSSL_RSA_public_decrypt(int flen, const unsigned char* from,
     }
     else {
         WOLFSSL_MSG("RSA_public_decrypt pad type not supported in FIPS");
-        ret = WOLFSSL_FAILURE;
+        ret = WOLFSSL_FATAL_ERROR;
     }
 #endif
 
     WOLFSSL_LEAVE("RSA_public_decrypt", ret);
 
     if (ret <= 0) {
-        ret = WOLFSSL_FAILURE;
+        ret = WOLFSSL_FATAL_ERROR;
     }
     return ret;
 }

--- a/tests/api.c
+++ b/tests/api.c
@@ -47027,6 +47027,7 @@ static void test_wolfSSL_EVP_PKEY_sign_verify(void)
     byte*  sig = NULL;
     byte*  sigVerify = NULL;
     size_t siglen;
+    size_t siglenOnlyLen;
     size_t keySz = 2048/8;  /* Bytes */
     int encs[3] = {0};
 #if defined(OPENSSL_EXTRA) && !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN) && \
@@ -47116,9 +47117,14 @@ static void test_wolfSSL_EVP_PKEY_sign_verify(void)
 #endif
 #endif
 
+        /* Check returning only length */
+        AssertIntEQ(EVP_PKEY_sign(ctx, NULL, &siglenOnlyLen, hash,
+            SHA256_DIGEST_LENGTH), WOLFSSL_SUCCESS);
+        AssertIntGT(siglenOnlyLen, 0);
         /* Sign data */
         AssertIntEQ(EVP_PKEY_sign(ctx, sig, &siglen, hash,
             SHA256_DIGEST_LENGTH), WOLFSSL_SUCCESS);
+        AssertIntGE(siglenOnlyLen, siglen);
 
         /* Verify signature */
         AssertNotNull(ctx_verify = EVP_PKEY_CTX_new(pkey, NULL));

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3332,13 +3332,17 @@ int wolfSSL_EVP_DigestSignFinal(WOLFSSL_EVP_MD_CTX *ctx, unsigned char *sig,
 
     #ifdef HAVE_ECC
         case EVP_PKEY_EC: {
+            int len;
             WOLFSSL_ECDSA_SIG *ecdsaSig;
             ecdsaSig = wolfSSL_ECDSA_do_sign(digest, hashLen,
                                              ctx->pctx->pkey->ecc);
             if (ecdsaSig == NULL)
                 break;
-            *siglen = wolfSSL_i2d_ECDSA_SIG(ecdsaSig, &sig);
+            len = wolfSSL_i2d_ECDSA_SIG(ecdsaSig, &sig);
             wolfSSL_ECDSA_SIG_free(ecdsaSig);
+            if (len == 0)
+                break;
+            *siglen = len;
             ret = WOLFSSL_SUCCESS;
             break;
         }

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1859,10 +1859,20 @@ int wolfSSL_EVP_PKEY_sign_init(WOLFSSL_EVP_PKEY_CTX *ctx)
         return ret;
 
     switch (ctx->pkey->type) {
+#if !defined(NO_RSA) && !defined(HAVE_USER_RSA)
         case EVP_PKEY_RSA:
             ctx->op = EVP_PKEY_OP_SIGN;
             ret = WOLFSSL_SUCCESS;
             break;
+#endif /* NO_RSA */
+
+#ifndef NO_DSA
+        case EVP_PKEY_DSA:
+            ctx->op = EVP_PKEY_OP_SIGN;
+            ret = WOLFSSL_SUCCESS;
+            break;
+#endif /* NO_DSA */
+
         case EVP_PKEY_EC:
             WOLFSSL_MSG("not implemented");
             FALL_THROUGH;
@@ -1908,6 +1918,22 @@ int wolfSSL_EVP_PKEY_sign(WOLFSSL_EVP_PKEY_CTX *ctx, unsigned char *sig,
     }
 #endif /* NO_RSA */
 
+#ifndef NO_DSA
+    case EVP_PKEY_DSA: {
+        int bytes;
+        /* TODO: Set required siglen when sig is NULL */
+        int ret = wolfSSL_DSA_do_sign(tbs, sig, ctx->pkey->dsa);
+        /* wolfSSL_DSA_do_sign() can return WOLFSSL_FATAL_ERROR */
+        if (ret != WOLFSSL_SUCCESS)
+            return ret;
+        bytes = wolfSSL_BN_num_bytes(ctx->pkey->dsa->q);
+        if (bytes == WOLFSSL_FAILURE || (int)*siglen < bytes * 2)
+            return WOLFSSL_FAILURE;
+        *siglen = bytes * 2;
+        return WOLFSSL_SUCCESS;
+    }
+#endif /* NO_DSA */
+
     case EVP_PKEY_EC:
         WOLFSSL_MSG("not implemented");
         FALL_THROUGH;
@@ -1940,6 +1966,13 @@ int wolfSSL_EVP_PKEY_verify_init(WOLFSSL_EVP_PKEY_CTX *ctx)
             ctx->op = EVP_PKEY_OP_VERIFY;
             return WOLFSSL_SUCCESS;
 #endif /* NO_RSA */
+
+#ifndef NO_DSA
+        case EVP_PKEY_DSA:
+            ctx->op = EVP_PKEY_OP_VERIFY;
+            return WOLFSSL_SUCCESS;
+#endif /* NO_DSA */
+
         default:
             return -2;
     }
@@ -1970,6 +2003,16 @@ int wolfSSL_EVP_PKEY_verify(WOLFSSL_EVP_PKEY_CTX *ctx, const unsigned char *sig,
             (unsigned int)tbslen, sig, (unsigned int)siglen, ctx->pkey->rsa,
             ctx->padding);
 #endif /* NO_RSA */
+
+#ifndef NO_DSA
+     case EVP_PKEY_DSA: {
+        int dsacheck = 0;
+        if (wolfSSL_DSA_do_verify(tbs, (unsigned char *)sig, ctx->pkey->dsa,
+            &dsacheck) != WOLFSSL_SUCCESS || dsacheck != 1)
+            return WOLFSSL_FAILURE;
+        return WOLFSSL_SUCCESS;
+     }
+#endif /* NO_DSA */
 
     default:
         return -2;

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -376,6 +376,7 @@ enum {
 #define NID_dsa                  EVP_PKEY_DSA
 
 #define EVP_PKEY_OP_SIGN    (1 << 3)
+#define EVP_PKEY_OP_VERIFY  (1 << 5)
 #define EVP_PKEY_OP_ENCRYPT (1 << 6)
 #define EVP_PKEY_OP_DECRYPT (1 << 7)
 #define EVP_PKEY_OP_DERIVE  (1 << 8)
@@ -593,6 +594,9 @@ WOLFSSL_API const unsigned char* wolfSSL_EVP_PKEY_get0_hmac(const WOLFSSL_EVP_PK
 WOLFSSL_API int wolfSSL_EVP_PKEY_sign_init(WOLFSSL_EVP_PKEY_CTX *ctx);
 WOLFSSL_API int wolfSSL_EVP_PKEY_sign(WOLFSSL_EVP_PKEY_CTX *ctx,
   unsigned char *sig, size_t *siglen, const unsigned char *tbs, size_t tbslen);
+WOLFSSL_API int wolfSSL_EVP_PKEY_verify_init(WOLFSSL_EVP_PKEY_CTX *ctx);
+WOLFSSL_API int wolfSSL_EVP_PKEY_verify(WOLFSSL_EVP_PKEY_CTX *ctx, const unsigned char *sig,
+  size_t siglen, const unsigned char *tbs, size_t tbslen);
 WOLFSSL_API int wolfSSL_EVP_PKEY_paramgen_init(WOLFSSL_EVP_PKEY_CTX *ctx);
 WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(WOLFSSL_EVP_PKEY_CTX *ctx,
         int nid);
@@ -948,6 +952,8 @@ WOLFSSL_API int wolfSSL_EVP_SignInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
 #define EVP_MD_CTX_copy_ex             wolfSSL_EVP_MD_CTX_copy_ex
 #define EVP_PKEY_sign_init             wolfSSL_EVP_PKEY_sign_init
 #define EVP_PKEY_sign                  wolfSSL_EVP_PKEY_sign
+#define EVP_PKEY_verify_init           wolfSSL_EVP_PKEY_verify_init
+#define EVP_PKEY_verify                wolfSSL_EVP_PKEY_verify
 #define EVP_PKEY_paramgen_init         wolfSSL_EVP_PKEY_paramgen_init
 #define EVP_PKEY_CTX_set_ec_param_enc  wolfSSL_EVP_PKEY_CTX_set_ec_param_enc
 #define EVP_PKEY_CTX_set_ec_paramgen_curve_nid wolfSSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid


### PR DESCRIPTION
# Description

`wpa_supplicant` SAE public key functionality requires `EVP_PKEY_sign/verify` functionality.

# Testing

I build wolfSSL with `./configure --enable-md4 --enable-des3 --enable-pwdbased --enable-wpas --enable-wpas-dpp --enable-opensslall --enable-opensslextra --enable-dsa` and ran `make check` for each commit.

And test SAE public key functionality on `wpa_supplicant` with `sudo ./run-tests.py -f sae_pk` command.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
