### PR TITLE
Fix for issue with `error: format string is not a string literal`

### DIFF
--- a/src/bio.c
+++ b/src/bio.c
@@ -2866,6 +2866,10 @@ void *wolfSSL_BIO_get_ex_data(WOLFSSL_BIO *bio, int idx)
 
 #if defined(OPENSSL_EXTRA)
 /* returns amount printed on success, negative in fail case */
+#ifdef __clang__
+/* tell clang argument 2 is format */
+__attribute__((__format__ (__printf__, 2, 0)))
+#endif
 int wolfSSL_BIO_vprintf(WOLFSSL_BIO* bio, const char* format, va_list args)
 {
     int ret = -1;
@@ -2929,6 +2933,10 @@ int wolfSSL_BIO_vprintf(WOLFSSL_BIO* bio, const char* format, va_list args)
 }
 
 /* returns amount printed on success, negative in fail case */
+#ifdef __clang__
+/* tell clang argument 2 is format */
+__attribute__((__format__ (__printf__, 2, 0)))
+#endif
 int wolfSSL_BIO_printf(WOLFSSL_BIO* bio, const char* format, ...)
 {
     int ret;

--- a/src/x509.c
+++ b/src/x509.c
@@ -4276,7 +4276,7 @@ int wolfSSL_GENERAL_NAME_print(WOLFSSL_BIO* out, WOLFSSL_GENERAL_NAME* gen)
         ret = wolfSSL_BIO_printf(out, "DNS:");
         ret = (ret > 0) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
         if (ret == WOLFSSL_SUCCESS) {
-            ret = wolfSSL_BIO_printf(out, gen->d.dNSName->strData);
+            ret = wolfSSL_BIO_printf(out, "%s", gen->d.dNSName->strData);
             ret = (ret > 0) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
         }
         break;


### PR DESCRIPTION
# Description

Fix for issue with `error: format string is not a string literal`. Found while testing a build on my Mac `Apple clang version 13.0.0 (clang-1300.0.29.30)`.

# Testing

```
./configure --disable-filesystem --enable-all && make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
