### PR TITLE
Don't enable PK Callbacks with JNI FIPS builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4911,7 +4911,8 @@ then
             AM_CFLAGS="$AM_CFLAGS -DECC_SHAMIR"
         fi
     fi
-    if test "x$ENABLED_PKCALLBACKS" = "xno"
+    # Do not enable PK Callbacks in FIPS mode with JNI
+    if test "x$ENABLED_PKCALLBACKS" = "xno" && test "$ENABLED_FIPS" = "no"
     then
         ENABLED_PKCALLBACKS="yes"
         AM_CFLAGS="$AM_CFLAGS -DHAVE_PK_CALLBACKS"


### PR DESCRIPTION
# Description

This PR adjusts the `--enable-jni` build to skip automatically defining `HAVE_PK_CALLBACKS` for FIPS builds.  FIPS users won't be using PK callbacks.

# Testing

Tested with wolfSSL JNI builds on OSX and Ubuntu with `--enable-fips=v2` and `--enable-fips=ready`.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
