### PR TITLE
Fixes for various nightly scan-build errors and warnings

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -2069,7 +2069,6 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     (void)resumeScr;
     (void)ourKey;
     (void)ourCert;
-    (void)customVerifyCert;
     (void)verifyCert;
     (void)useClientCert;
     (void)disableCRL;
@@ -3898,7 +3897,6 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 
                         if (ret == WOLFSSL_SUCCESS) {
                             printf("NON-BLOCKING RENEGOTIATION SUCCESSFUL\n");
-                            err = 0;
                         }
                     }
                     if (ret != WOLFSSL_SUCCESS) {
@@ -4342,6 +4340,7 @@ exit:
     (void) ourCert;
     (void) ourKey;
     (void) useVerifyCb;
+    (void) customVerifyCert;
 
 #if !defined(WOLFSSL_TIRTOS)
     return 0;

--- a/mcapi/crypto.h
+++ b/mcapi/crypto.h
@@ -173,7 +173,7 @@ enum {
 typedef struct CRYPT_AES_CTX {
     /* big enough to hold internal, but check on init */
     #ifdef WOLF_PRIVATE_KEY_ID
-    int holder[104];
+    int holder[108];
     #else
     int holder[90];
     #endif

--- a/mcapi/mcapi_test.c
+++ b/mcapi/mcapi_test.c
@@ -562,13 +562,12 @@ static int check_compress(void)
         printf("compress dynamic ret failed\n");
         return -1;
     }
+    outSz = ret1;
 
-    if (memcmp(cBuffer, dBuffer, ret1) != 0) {
+    if (memcmp(cBuffer, dBuffer, outSz) != 0) {
         printf("compress dynamic cmp failed\n");
         return -1;
     }
-
-    outSz = ret1;
 
     ret1 = CRYPT_HUFFMAN_DeCompress(dBuffer, sizeof(dBuffer), cBuffer, outSz);
 
@@ -578,9 +577,11 @@ static int check_compress(void)
     }
 
     memset(dBuffer, 0, sizeof(dBuffer));
+    ret2 = wc_DeCompress(dBuffer, sizeof(dBuffer), cBuffer, outSz);
 
-    ret1 = wc_DeCompress(dBuffer, sizeof(dBuffer), cBuffer, outSz);
-
+    if (ret1 != ret2 || ret2 < 0) {
+        printf("decompress dynamic ret failed\n");
+    }
     if (memcmp(dBuffer, text, inSz) != 0) {
         printf("decompress dynamic cmp failed\n");
         return -1;
@@ -597,13 +598,13 @@ static int check_compress(void)
         printf("compress static ret failed\n");
         return -1;
     }
+    outSz = ret1;
 
-    if (memcmp(cBuffer, dBuffer, ret1) != 0) {
+    if (memcmp(cBuffer, dBuffer, outSz) != 0) {
         printf("compress static cmp failed\n");
         return -1;
     }
 
-    outSz = ret1;
 
     ret1 = CRYPT_HUFFMAN_DeCompress(dBuffer, sizeof(dBuffer), cBuffer, outSz);
 
@@ -613,9 +614,10 @@ static int check_compress(void)
     }
 
     memset(dBuffer, 0, sizeof(dBuffer));
-
-    ret1 = wc_DeCompress(dBuffer, sizeof(dBuffer), cBuffer, outSz);
-
+    ret2 = wc_DeCompress(dBuffer, sizeof(dBuffer), cBuffer, outSz);
+    if (ret1 != ret2 || ret2 < 0) {
+        printf("decompress static ret failed\n");
+    }
     if (memcmp(dBuffer, text, inSz) != 0) {
         printf("decompress static cmp failed\n");
         return -1;

--- a/src/internal.c
+++ b/src/internal.c
@@ -11700,8 +11700,13 @@ static int ProcessPeerCertParse(WOLFSSL* ssl, ProcPeerCertArgs* args,
     int sigRet = 0;
 #endif
 
-    if (ssl == NULL || args == NULL || args->dCert == NULL)
+    if (ssl == NULL || args == NULL
+    #ifndef WOLFSSL_SMALL_CERT_VERIFY
+        || args->dCert == NULL
+    #endif
+    ) {
         return BAD_FUNC_ARG;
+    }
 
     /* check to make sure certificate index is valid */
     if (args->certIdx > args->count)

--- a/src/internal.c
+++ b/src/internal.c
@@ -10741,12 +10741,16 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
 #endif
     }
 
-    /* store cert for potential retrieval */
-    if (AllocDer(&x509->derCert, dCert->maxIdx, CERT_TYPE, x509->heap) == 0) {
-        XMEMCPY(x509->derCert->buffer, dCert->source, dCert->maxIdx);
-    }
-    else {
-        ret = MEMORY_E;
+    /* if der contains original source buffer then store for potential
+     * retrieval */
+    if (dCert->source != NULL && dCert->maxIdx > 0) {
+        if (AllocDer(&x509->derCert, dCert->maxIdx, CERT_TYPE, x509->heap)
+                                                                         == 0) {
+            XMEMCPY(x509->derCert->buffer, dCert->source, dCert->maxIdx);
+        }
+        else {
+            ret = MEMORY_E;
+        }
     }
 
     x509->altNames       = dCert->altNames;

--- a/src/internal.c
+++ b/src/internal.c
@@ -11696,7 +11696,7 @@ static int ProcessPeerCertParse(WOLFSSL* ssl, ProcPeerCertArgs* args,
     int sigRet = 0;
 #endif
 
-    if (ssl == NULL || args == NULL)
+    if (ssl == NULL || args == NULL || args->dCert == NULL)
         return BAD_FUNC_ARG;
 
     /* check to make sure certificate index is valid */

--- a/src/internal.c
+++ b/src/internal.c
@@ -3871,11 +3871,13 @@ static enum wc_HashType HashAlgoToType(int hashAlgo)
 
 void InitX509Name(WOLFSSL_X509_NAME* name, int dynamicFlag, void* heap)
 {
+    (void)dynamicFlag;
+
     if (name != NULL) {
         XMEMSET(name, 0, sizeof(WOLFSSL_X509_NAME));
         name->name        = name->staticName;
         name->heap = heap;
-        name->dynamicName = dynamicFlag;
+        name->dynamicName = 0;
     }
 }
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -3871,13 +3871,11 @@ static enum wc_HashType HashAlgoToType(int hashAlgo)
 
 void InitX509Name(WOLFSSL_X509_NAME* name, int dynamicFlag, void* heap)
 {
-    (void)dynamicFlag;
-    (void)heap;
-
     if (name != NULL) {
         XMEMSET(name, 0, sizeof(WOLFSSL_X509_NAME));
         name->name        = name->staticName;
         name->heap = heap;
+        name->dynamicName = dynamicFlag;
     }
 }
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -21462,6 +21462,7 @@ WOLFSSL_ASN1_INTEGER* wolfSSL_ASN1_INTEGER_new(void)
 
     XMEMSET(a, 0, sizeof(WOLFSSL_ASN1_INTEGER));
     a->data    = a->intData;
+    a->isDynamic = 0;
     a->dataMax = WOLFSSL_ASN1_INTEGER_MAX;
     a->length  = 0;
     return a;
@@ -24866,9 +24867,7 @@ void wolfSSL_sk_pop_free(WOLF_STACK_OF(WOLFSSL_ASN1_OBJECT)* sk,
         WOLFSSL_STACK* next = sk->next;
 
         if (func != NULL) {
-            if (sk->type == STACK_TYPE_CIPHER)
-                func(&sk->data.cipher);
-            else
+            if (sk->type != STACK_TYPE_CIPHER)
                 func(sk->data.generic);
         }
         XFREE(sk, NULL, DYNAMIC_TYPE_OPENSSL);
@@ -25982,6 +25981,7 @@ WOLFSSL_ASN1_INTEGER* wolfSSL_BN_to_ASN1_INTEGER(const WOLFSSL_BIGNUM *bn, WOLFS
         else {
             XMEMSET(a->intData, 0, sizeof(a->intData));
             a->data = a->intData;
+            a->isDynamic = 0;
         }
 
         /* populate data */
@@ -40941,10 +40941,10 @@ int wolfSSL_a2i_ASN1_INTEGER(WOLFSSL_BIO *bio, WOLFSSL_ASN1_INTEGER *asn1,
     /* Reset asn1 */
     if (asn1->isDynamic && asn1->data) {
         XFREE(asn1->data, NULL, DYNAMIC_TYPE_OPENSSL);
-        asn1->isDynamic = 0;
     }
     XMEMSET(asn1->intData, 0, WOLFSSL_ASN1_INTEGER_MAX);
     asn1->data = asn1->intData;
+    asn1->isDynamic = 0;
     asn1->length = 0;
     asn1->negative = 0;
     asn1->type = V_ASN1_INTEGER;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -7600,7 +7600,6 @@ int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX* ctx, const char* file,
                 if (ret != WOLFSSL_SUCCESS) {
                     WOLFSSL_MSG("wolfSSL_CTX_trust_peer_cert error. Ignoring"
                             "this error.");
-                    ret = WOLFSSL_SUCCESS;
                 }
     #endif
                 successCount++;

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -511,7 +511,7 @@ void mp_zero (mp_int * a)
   a->used = 0;
 
   tmp = a->dp;
-  for (n = 0; n < a->alloc; n++) {
+  for (n = 0; tmp != NULL && n < a->alloc; n++) {
      *tmp++ = 0;
   }
 }
@@ -2962,7 +2962,7 @@ int mp_mul_d (mp_int * a, mp_digit b, mp_int * c)
   int      ix, res, olduse;
 
   /* make sure c is big enough to hold a*b */
-  if (c->alloc < a->used + 1) {
+  if (c->dp == NULL || c->alloc < a->used + 1) {
     if ((res = mp_grow (c, a->used + 1)) != MP_OKAY) {
       return res;
     }

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -4378,6 +4378,10 @@ int mp_add_d (mp_int* a, mp_digit b, mp_int* c) // NOLINT(misc-no-recursion)
   /* destination alias */
   tmpc    = c->dp;
 
+  if (tmpa == NULL || tmpc == NULL) {
+    return MP_MEM;
+  }
+
   /* if a is positive */
   if (a->sign == MP_ZPOS) {
      /* add digit, after this we're propagating
@@ -4461,6 +4465,10 @@ int mp_sub_d (mp_int * a, mp_digit b, mp_int * c) // NOLINT(misc-no-recursion)
   oldused = c->used;
   tmpa    = a->dp;
   tmpc    = c->dp;
+
+  if (tmpa == NULL || tmpc == NULL) {
+    return MP_MEM;
+  }
 
   /* if a <= b simply fix the single digit */
   if ((a->used == 1 && a->dp[0] <= b) || a->used == 0) {

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -1713,7 +1713,7 @@ int s_mp_add (mp_int * a, mp_int * b, mp_int * c)
   }
 
   /* init result */
-  if (c->alloc < max_ab + 1) {
+  if (c->dp == NULL || c->alloc < max_ab + 1) {
     if ((res = mp_grow (c, max_ab + 1)) != MP_OKAY) {
       return res;
     }
@@ -1757,7 +1757,7 @@ int s_mp_add (mp_int * a, mp_int * b, mp_int * c)
     if (min_ab != max_ab) {
       for (; i < max_ab; i++) {
         /* T[i] = X[i] + U */
-          *tmpc = x->dp[i] + u; // NOLINT(clang-analyzer-core.NullDereference) /* clang-tidy 13 false positive */
+          *tmpc = x->dp[i] + u;
 
         /* U = carry bit of T[i] */
         u = *tmpc >> ((mp_digit)DIGIT_BIT);

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -3278,6 +3278,7 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
             XMEMCPY(key->data, in, inLen);
         }
         else {
+            key->dataIsAlloc = 0;
             key->data = out;
         }
 #endif

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -16674,11 +16674,11 @@ WOLFSSL_TEST_SUBROUTINE int dh_test(void)
     #ifdef HAVE_FFDHE_4096
     #ifdef HAVE_PUBLIC_FFDHE
     ret = dh_ffdhe_test(&rng, wc_Dh_ffdhe4096_Get());
-    if (ret != 0)
-        ERROR_OUT(-8128, done);
     #else
     ret = dh_ffdhe_test(&rng, WC_FFDHE_4096);
     #endif
+    if (ret != 0)
+        ERROR_OUT(-8128, done);
     #endif
 #endif /* !WC_NO_RNG */
 #endif /* HAVE_FIPS_VERSION == 2 && !WOLFSSL_SP_ARM64_ASM */

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -31862,6 +31862,7 @@ WOLFSSL_TEST_SUBROUTINE int compress_test(void)
     if ((ret = wc_DeCompress(d, dSz, c, cSz)) != (int)dSz) {
         ERROR_OUT(-12102, exit);
     }
+    dSz = (word32)ret;
 
     if (XMEMCMP(d, sample_text, dSz) != 0) {
         ERROR_OUT(-12103, exit);


### PR DESCRIPTION
# Description

* Fix for report of `Use of memory after it is freed`. Force the `dataIsAlloc` set to 0.
* Fix for MCAPI `CRYPT_AES_CTX` size with `./configure --enable-pkcallbacks --enable-mcapi --enable-ecc --enable-sha512 --with-libz --enable-opensslextra`.
* Fix for integer.c `s_mp_add` output to make sure it grows if not set.
* Fix for integer.c possible uses of mp_int input with DP NULL.
* Fix to ensure args->dCert is set for `ProcessPeerCertParse`.
* Fix `InitX509Name` to set `dynamicName` on init.
* Fixes for warnings is MCAPI `check_compress` test.
* Make sure ASN1 isDynamic is always set to 0. SK Cipher doesn't have free (data is contained in the SK).
* Various other scan-build warning fixes.


# Testing

nightly-CDT-scan-build-known-configs

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
