### PR TITLE
Fix for mingw builds

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -39694,7 +39694,8 @@ static void test_wolfSSL_SESSION(void)
     unsigned int contextSz = (unsigned int)sizeof(context);
     int sz;
 #endif
-    int ret, err, sockfd;
+    int ret, err;
+    SOCKET_T sockfd;
     tcp_ready ready;
     func_args server_args;
     THREAD_TYPE serverThread;

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -35,6 +35,10 @@
 #include <wolfssl/wolfcrypt/wc_port.h>
 #include <wolfssl/wolfcrypt/ecc.h>
 
+#ifdef HAVE_PTHREAD
+    #include <pthread.h>
+#endif
+
 /* Macro to disable benchmark */
 #ifndef NO_CRYPT_BENCHMARK
 
@@ -53,12 +57,14 @@
        defined(HAVE_PTHREAD) && !defined(HAVE_RENESAS_SYNC)
 
     #define WC_ENABLE_BENCH_THREADING
-    #if defined(_POSIX_THREADS) && !defined(__MINGW32__)
+    #if defined(_POSIX_THREADS)
         typedef void*         THREAD_RETURN;
         typedef pthread_t     THREAD_TYPE;
         #define WOLFSSL_THREAD
+        #if !defined(__MINGW32__)
         #define INFINITE (-1)
         #define WAIT_OBJECT_0 0L
+        #endif
     #elif defined(WOLFSSL_MDK_ARM)|| defined(WOLFSSL_KEIL_TCP_NET) || defined(FREESCALE_MQX)
         typedef unsigned int  THREAD_RETURN;
         typedef int           THREAD_TYPE;


### PR DESCRIPTION
# Description

Fix for build errors when using mingw

Fixes zd14105

# Testing

```
./configure --enable-static --enable-tls13 --enable-keygen --enable-psk --enable-certgen --enable-certgen --enable-certext --enable-hkdf --enable-eccencrypt --enable-eccencrypt --enable-harden --enable-debug --enable-dsa C_EXTRA_FLAGS="-DKEEP_PEER_CERT" --host=x86_64-w64-mingw32

make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
