### PR TITLE
fix for sanity check on PKCS7 indef read

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -4590,8 +4590,13 @@ static int PKCS7_VerifySignedData(PKCS7* pkcs7, const byte* hashBuf,
                     ret = ASN_PARSE_E;
                 }
                 /* if indef, skip EOF */
-                if (isIndef && pkiMsg[idx] == ASN_EOC && pkiMsg[idx+1] == 0) {
-                    idx += 2; /* skip EOF + zero byte */
+                if (isIndef) {
+                    if (idx + 1 >= pkiMsgSz) {
+                        ret = ASN_PARSE_E;
+                    }
+                    else if (pkiMsg[idx] == ASN_EOC && pkiMsg[idx+1] == 0) {
+                        idx += 2; /* skip EOF + zero byte */
+                    }
                 }
             }
 


### PR DESCRIPTION

Fixes zd# 14108
(found in development branch, was not reproduced in v5.2.0-stable)

# Testing

Use the reproducer here (https://github.com/wolfSSL/testing/pull/274) please also merge the reproducer.

