### PR TITLE
Add ESP-IDF WOLFSSL_ESP8266 setting for ESP8266 devices

### DIFF
--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -2455,7 +2455,7 @@ int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
     }
 
 #elif defined(WOLFSSL_ESPIDF)
-    #if defined(WOLFSSL_ESPWROOM32) || defined(WOLFSSL_ESPWROOM32SE)
+    #if defined(WOLFSSL_ESPWROOM32) || defined(WOLFSSL_ESPWROOM32SE) || defined(WOLFSSL_ESP8266)
         #include <esp_system.h>
 
         int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -203,6 +203,9 @@
 /* Uncomment next line if using Espressif ESP32-WROOM-32SE */
 /* #define WOLFSSL_ESPWROOM32SE */
 
+/* Uncomment next line if using Espressif ESP8266 */
+/* #define WOLFSSL_ESP8266 */
+
 /* Uncomment next line if using ARM CRYPTOCELL*/
 /* #define WOLFSSL_CRYPTOCELL */
 


### PR DESCRIPTION
# Description

Adds optional define for `WOLFSSL_ESP8266` in [wolfssl/wolfssl/wolfcrypt/settings.h ESP-IDF section](https://github.com/wolfSSL/wolfssl/blob/70ad19467c4c78e69c74f9969eeba14896dc00bb/wolfssl/wolfcrypt/settings.h#L198) which when `WOLFSSL_ESPIDF` is defined when using the _ESP8266_ ESP-IDF, allows for `wc_GenerateSeed` [code](https://github.com/wolfSSL/wolfssl/blob/70ad19467c4c78e69c74f9969eeba14896dc00bb/wolfcrypt/src/random.c#L2461) to be generated.

# Testing

Without this change, apps configured with `WOLFSSL_ESPIDF` would not compile, due to missing:

```
int wc_GenerateSeed(OS_Seed* os, byte* output, word32 sz)
```

The only current targets for  `WOLFSSL_ESPIDF` are `WOLFSSL_ESPWROOM32` and `WOLFSSL_ESPWROOM32SE`, which, when enabled, do not work for other features in the ESP8266 as the [ESP-IDF toolchain for ESP8266](https://docs.espressif.com/projects/esp8266-rtos-sdk/en/latest/get-started/index.html) is very different from the [ESP-IDF ESP32 toolchain](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html).

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
