### PR TITLE
Fix no malloc RSA  test

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -9858,10 +9858,12 @@ void FreeDecodedCert(DecodedCert* cert)
 {
     if (cert == NULL)
         return;
-    if (cert->subjectCNStored == 1)
+    if (cert->subjectCNStored == 1) {
         XFREE(cert->subjectCN, cert->heap, DYNAMIC_TYPE_SUBJECT_CN);
-    if (cert->pubKeyStored == 1)
+    }
+    if (cert->pubKeyStored == 1) {
         XFREE((void*)cert->publicKey, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+    }
     if (cert->weOwnAltNames && cert->altNames)
         FreeAltNames(cert->altNames, cert->heap);
 #ifndef IGNORE_NAME_CONSTRAINTS


### PR DESCRIPTION
# Description

This PR fixes no malloc RSA wolfCrypt test. 

```
./configure --enable-sp=small,nomalloc --enable-sp-math CFLAGS="-DWOLFSSL_NO_MALLOC" --disable-aesgcm && make
./wolfcrypt/test/testwolfcrypt
```
RSA      test failed!
 error = -7900
Exiting main with return code: -1

It also fixes empty-body errors. 

```
wolfcrypt/src/asn.c: In function ‘FreeDecodedCert’:
wolfcrypt/src/asn.c:9862:68: error: suggest braces around empty body in an ‘if’ statement [-Werror=empty-body]
 9862 |         XFREE(cert->subjectCN, cert->heap, DYNAMIC_TYPE_SUBJECT_CN);
      |                                                                    ^
...
wolfcrypt/src/asn.c:9864:75: error: suggest braces around empty body in an ‘if’ statement [-Werror=empty-body]
 9864 |         XFREE((void*)cert->publicKey, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
      |     
 ```                                              


# Testing
./wolfcrypt/test/testwolfcrypt
