### PR TITLE
with WOLFSSL_NO_DH186 restriction allow odd DH param size generations

### DIFF
--- a/wolfcrypt/src/dh.c
+++ b/wolfcrypt/src/dh.c
@@ -2845,7 +2845,16 @@ int wc_DhGenerateParams(WC_RNG *rng, int modSz, DhKey *dh)
                 groupSz = 32;
                 break;
             default:
+        #if !defined(HAVE_FIPS) && defined(WOLFSSL_NO_DH186)
+                /* in non fips mode attempt to match strength of group size with
+                 * mod size */
+                if (modSz < 2048)
+                    groupSz = 20;
+                else
+                    groupSz = 32;
+        #else
                 ret = BAD_FUNC_ARG;
+        #endif
                 break;
         }
     }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -16035,7 +16035,9 @@ static int dh_generate_test(WC_RNG *rng)
     }
 #else
     (void)rng;
+    #if defined(HAVE_FIPS) || !defined(WOLFSSL_NO_DH186)
     ret = 0;
+    #endif
 #endif
 
 #if !defined(HAVE_FIPS) && defined(WOLFSSL_NO_DH186)

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -16038,6 +16038,37 @@ static int dh_generate_test(WC_RNG *rng)
     ret = 0;
 #endif
 
+#if !defined(HAVE_FIPS) && defined(WOLFSSL_NO_DH186)
+    {
+        byte   priv[260];
+        byte   pub[260];
+        word32 privSz = sizeof(priv);
+        word32 pubSz = sizeof(pub);
+
+        /* test odd ball param generation with DH */
+        wc_FreeDhKey(smallKey);
+        ret = wc_InitDhKey_ex(smallKey, HEAP_HINT, devId);
+        if (ret != 0)
+            ERROR_OUT(-8019, exit_gen_test);
+
+        ret = wc_DhGenerateParams(rng, 2056, smallKey);
+        if (ret != 0) {
+            ERROR_OUT(-8020, exit_gen_test);
+        }
+
+        privSz = sizeof(priv);
+        pubSz = sizeof(pub);
+
+        ret = wc_DhGenerateKeyPair(smallKey, rng, priv, &privSz, pub, &pubSz);
+    #if defined(WOLFSSL_ASYNC_CRYPT)
+        ret = wc_AsyncWait(ret, &smallKey->asyncDev, WC_ASYNC_FLAG_NONE);
+    #endif
+        if (ret != 0) {
+            ERROR_OUT(-8021, exit_gen_test);
+        }
+    }
+#endif /* !HAVE_FIPS and WOLFSSL_NO_DH186 */
+
 exit_gen_test:
     if (smallKey_inited)
         wc_FreeDhKey(smallKey);


### PR DESCRIPTION
# Description

When WOLFSSL_NO_DH186 is defined allow odd DH param size generations.

# Testing

Added test case to unit tests

# Checklist

 - [x] added tests
