### PR TITLE
Add support for more extensions to wolfSSL_X509_print_ex.

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -51464,10 +51464,11 @@ static void test_wolfSSL_X509_print(void)
     AssertNotNull(bio = BIO_new(BIO_s_mem()));
     AssertIntEQ(X509_print(bio, x509), SSL_SUCCESS);
 
-#if defined(WOLFSSL_QT)
-    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3113);
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+    /* Will print IP address subject alt name. */
+    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3329);
 #else
-    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3103);
+    AssertIntEQ(BIO_get_mem_data(bio, NULL), 3307);
 #endif
     BIO_free(bio);
 


### PR DESCRIPTION
# Description

This function did not print these extensions prior to this commit. Requested by a customer.

- Key usage
- Extended key usage
- Subject alt name
    
Additionally, print out the criticality of the extensions.

# Testing

wolfCLU uses this function for its `x509` subcommand. I did before-and-after testing with wolfCLU and this commit to verify that the extensions print correctly. I also needed to update `test_wolfSSL_X509_print`, since the certificate it uses has these new extensions, and we verify the exact number of bytes printed.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
