### PR TITLE
wolSSL_DH_new_by_nid() redux

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26454,7 +26454,7 @@ WOLFSSL_DH* wolfSSL_DH_new(void)
 
 WOLFSSL_DH* wolSSL_DH_new_by_nid(int nid)
 {
-    WOLFSSL_DH* dh = NULL;
+    WOLFSSL_DH* dh;
     int err = 0;
 #if defined(HAVE_PUBLIC_FFDHE) || (defined(HAVE_FIPS) && FIPS_VERSION_EQ(2,0))
     const DhParams* params = NULL;
@@ -26473,38 +26473,39 @@ WOLFSSL_DH* wolSSL_DH_new_by_nid(int nid)
 
     WOLFSSL_ENTER("wolfSSL_DH_new_by_nid");
 
+    dh = wolfSSL_DH_new();
+    if (dh == NULL) {
+        WOLFSSL_MSG("Failed to create WOLFSSL_DH.");
+        err = 1;
+    }
+
 /* HAVE_PUBLIC_FFDHE not required to expose wc_Dh_ffdhe* functions in FIPS v2
  * module */
 #if defined(HAVE_PUBLIC_FFDHE) || (defined(HAVE_FIPS) && FIPS_VERSION_EQ(2,0))
-    switch (nid) {
+    if (err == 0) {
+        switch (nid) {
 #ifdef HAVE_FFDHE_2048
-    case NID_ffdhe2048:
-        params = wc_Dh_ffdhe2048_Get();
-        break;
+            case NID_ffdhe2048:
+                params = wc_Dh_ffdhe2048_Get();
+                break;
 #endif /* HAVE_FFDHE_2048 */
 #ifdef HAVE_FFDHE_3072
-    case NID_ffdhe3072:
-        params = wc_Dh_ffdhe3072_Get();
-        break;
+            case NID_ffdhe3072:
+                params = wc_Dh_ffdhe3072_Get();
+                break;
 #endif /* HAVE_FFDHE_3072 */
 #ifdef HAVE_FFDHE_4096
-    case NID_ffdhe4096:
-        params = wc_Dh_ffdhe4096_Get();
-        break;
+            case NID_ffdhe4096:
+                params = wc_Dh_ffdhe4096_Get();
+                break;
 #endif /* HAVE_FFDHE_4096 */
-    default:
-        break;
+            default:
+                break;
+        }
     }
-    if (params == NULL) {
+    if (err == 0 && params == NULL) {
         WOLFSSL_MSG("Unable to find DH params for nid.");
         err = 1;
-    }
-    if (err == 0) {
-        dh = wolfSSL_DH_new();
-        if (dh == NULL) {
-            WOLFSSL_MSG("Failed to create WOLFSSL_DH.");
-            err = 1;
-        }
     }
     if (err == 0) {
         pBn = wolfSSL_BN_bin2bn(params->p, params->p_len, NULL);
@@ -26536,14 +26537,12 @@ WOLFSSL_DH* wolSSL_DH_new_by_nid(int nid)
         err = 1;
     }
 #else
-    if (err == 0) {
-        dh->p = pBn;
-        dh->q = qBn;
-        dh->g = gBn;
-        if (SetDhInternal(dh) != WOLFSSL_SUCCESS) {
-            WOLFSSL_MSG("Failed to set internal DH params.");
-            err = 1;
-        }
+    dh->p = pBn;
+    dh->q = qBn;
+    dh->g = gBn;
+    if (err == 0 && SetDhInternal(dh) != WOLFSSL_SUCCESS) {
+        WOLFSSL_MSG("Failed to set internal DH params.");
+        err = 1;
     }
 #endif /* OPENSSL_ALL || OPENSSL_VERSION_NUMBER >= 0x10100000L */
 
@@ -26555,32 +26554,27 @@ WOLFSSL_DH* wolSSL_DH_new_by_nid(int nid)
 /* FIPS v2 and lower doesn't support wc_DhSetNamedKey. */
 #elif !defined(HAVE_PUBLIC_FFDHE) && (!defined(HAVE_FIPS) || \
       FIPS_VERSION_GT(2,0))
-    switch (nid) {
+    if (err == 0) {
+        switch (nid) {
 #ifdef HAVE_FFDHE_2048
-    case NID_ffdhe2048:
-        name = WC_FFDHE_2048;
-        break;
+            case NID_ffdhe2048:
+                name = WC_FFDHE_2048;
+                break;
 #endif /* HAVE_FFDHE_2048 */
 #ifdef HAVE_FFDHE_3072
-    case NID_ffdhe3072:
-        name = WC_FFDHE_3072;
-        break;
+            case NID_ffdhe3072:
+                name = WC_FFDHE_3072;
+                break;
 #endif /* HAVE_FFDHE_3072 */
 #ifdef HAVE_FFDHE_4096
-    case NID_ffdhe4096:
-        name = WC_FFDHE_4096;
-        break;
+            case NID_ffdhe4096:
+                name = WC_FFDHE_4096;
+                break;
 #endif /* HAVE_FFDHE_4096 */
-    default:
-        err = 1;
-        WOLFSSL_MSG("Unable to find DH params for nid.");
-        break;
-    }
-    if (err == 0) {
-        dh = wolfSSL_DH_new();
-        if (dh == NULL) {
-            WOLFSSL_MSG("Failed to create WOLFSSL_DH.");
-            err = 1;
+            default:
+                err = 1;
+                WOLFSSL_MSG("Unable to find DH params for nid.");
+                break;
         }
     }
     if (err == 0 && wc_DhSetNamedKey((DhKey*)dh->internal, name) != 0) {
@@ -26600,8 +26594,6 @@ WOLFSSL_DH* wolSSL_DH_new_by_nid(int nid)
         wolfSSL_DH_free(dh);
         dh = NULL;
     }
-
-    WOLFSSL_LEAVE("wolfSSL_DH_new_by_nid", err);
 
     return dh;
 }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26503,7 +26503,7 @@ WOLFSSL_DH* wolSSL_DH_new_by_nid(int nid)
                 break;
         }
     }
-    if (err == 0 && params == NULL) {
+    if (params == NULL) {
         WOLFSSL_MSG("Unable to find DH params for nid.");
         err = 1;
     }
@@ -26513,6 +26513,10 @@ WOLFSSL_DH* wolSSL_DH_new_by_nid(int nid)
             WOLFSSL_MSG("Error converting p hex to WOLFSSL_BIGNUM.");
             err = 1;
         }
+    }
+    if (params == NULL) {
+        /* work around cppcheck false positive. */
+        err = 1;
     }
     if (err == 0) {
         gBn = wolfSSL_BN_bin2bn(params->g, params->g_len, NULL);
@@ -26537,9 +26541,11 @@ WOLFSSL_DH* wolSSL_DH_new_by_nid(int nid)
         err = 1;
     }
 #else
-    dh->p = pBn;
-    dh->q = qBn;
-    dh->g = gBn;
+    if (err == 0) {
+        dh->p = pBn;
+        dh->q = qBn;
+        dh->g = gBn;
+    }
     if (err == 0 && SetDhInternal(dh) != WOLFSSL_SUCCESS) {
         WOLFSSL_MSG("Failed to set internal DH params.");
         err = 1;


### PR DESCRIPTION
revert previous refactor of `wolSSL_DH_new_by_nid()`, and add uglier changes to mollify `cppcheck` re null pointer deref false positives.  also, still fix the true positive at L26545-26547 in the patched file.
