### PR TITLE
Fix for DH public FFDHE incorrectly getting enabled

### DIFF
--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2027,7 +2027,9 @@ extern void uITRON4_free(void *p) ;
 
 #if !defined(HAVE_PUBLIC_FFDHE) && !defined(NO_DH) && \
     !defined(WOLFSSL_NO_PUBLIC_FFDHE) && \
-    (defined(HAVE_SELFTEST) || FIPS_VERSION_GE(2,0))
+    (defined(HAVE_SELFTEST) || FIPS_VERSION_LE(2,0))
+    /* This should only be enabled for FIPS v2 or older. It enables use of the
+     * older wc_Dh_ffdhe####_Get() API's */
     #define HAVE_PUBLIC_FFDHE
 #endif
 


### PR DESCRIPTION
# Description

Fix to make sure the old public DH API's are not enabled with `HAVE_PUBLIC_FFDHE` unless FIPS v2 or older.

Broken in PR #5018.

# Testing

wolfACVP test FIPS hash instability.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
