### PR TITLE
Fix for c89, use WOLF_C89

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -12389,6 +12389,10 @@ int GetFormattedTime(void* currTime, byte* buf, word32 len)
         mini = ts->tm_min;
         sec  = ts->tm_sec;
         #if defined(WOLF_C89)
+            if (len < 14) {
+                WOLFSSL_MSG("buffer for GetFormattedTime is too short.");
+                return BUFFER_E;
+            }
             ret = XSPRINTF((char*)buf,
         #else
             ret = XSNPRINTF((char*)buf, len,
@@ -12405,6 +12409,10 @@ int GetFormattedTime(void* currTime, byte* buf, word32 len)
         mini = ts->tm_min;
         sec  = ts->tm_sec;
         #if defined(WOLF_C89)
+            if (len < 16) {
+                WOLFSSL_MSG("buffer for GetFormattedTime is too short.");
+                return BUFFER_E;
+            }
             ret = XSPRINTF((char*)buf,
         #else
             ret = XSNPRINTF((char*)buf, len,

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -12388,7 +12388,11 @@ int GetFormattedTime(void* currTime, byte* buf, word32 len)
         hour = ts->tm_hour;
         mini = ts->tm_min;
         sec  = ts->tm_sec;
-        ret = XSNPRINTF((char*)buf, len,
+        #if defined(WOLF_C89)
+            ret = XSPRINTF((char*)buf,
+        #else
+            ret = XSNPRINTF((char*)buf, len,
+        #endif
                         "%02d%02d%02d%02d%02d%02dZ", year, mon, day,
                         hour, mini, sec);
     }
@@ -12400,7 +12404,11 @@ int GetFormattedTime(void* currTime, byte* buf, word32 len)
         hour = ts->tm_hour;
         mini = ts->tm_min;
         sec  = ts->tm_sec;
-        ret = XSNPRINTF((char*)buf, len,
+        #if defined(WOLF_C89)
+            ret = XSPRINTF((char*)buf,
+        #else
+            ret = XSNPRINTF((char*)buf, len,
+        #endif
                         "%4d%02d%02d%02d%02d%02dZ", year, mon, day,
                         hour, mini, sec);
     }

--- a/wolfcrypt/src/integer.c
+++ b/wolfcrypt/src/integer.c
@@ -889,7 +889,7 @@ int mp_lshd (mp_int * a, int b)
 #if defined(FREESCALE_LTC_TFM)
 int wolfcrypt_mp_exptmod (mp_int * G, mp_int * X, mp_int * P, mp_int * Y)
 #else
-    int mp_exptmod (mp_int * G, mp_int * X, mp_int * P, mp_int * Y) // NOLINT(misc-no-recursion)
+    int mp_exptmod (mp_int * G, mp_int * X, mp_int * P, mp_int * Y) /* //NOLINT(misc-no-recursion) */
 #endif
 {
   int dr;
@@ -1996,7 +1996,7 @@ int mp_exptmod_fast (mp_int * G, mp_int * X, mp_int * P, mp_int * Y,
    * one of many reduction algorithms without modding the guts of
    * the code with if statements everywhere.
    */
-  int     (*redux)(mp_int*,mp_int*,mp_digit) = NULL; // cppcheck-suppress nullPointerRedundantCheck // cppcheck 2.6.3 false positive
+  int     (*redux)(mp_int*,mp_int*,mp_digit) = NULL;
 
 #ifdef WOLFSSL_SMALL_STACK
   M = (mp_int*) XMALLOC(sizeof(mp_int) * TAB_SIZE, NULL,
@@ -4335,7 +4335,7 @@ int mp_sqrmod (mp_int * a, mp_int * b, mp_int * c)
     (!defined(NO_RSA) && !defined(NO_RSA_BOUNDS_CHECK))
 
 /* single digit addition */
-int mp_add_d (mp_int* a, mp_digit b, mp_int* c) // NOLINT(misc-no-recursion)
+int mp_add_d (mp_int* a, mp_digit b, mp_int* c) /* //NOLINT(misc-no-recursion) */
 {
   int     res, ix, oldused;
   mp_digit *tmpa, *tmpc, mu;
@@ -4433,7 +4433,7 @@ int mp_add_d (mp_int* a, mp_digit b, mp_int* c) // NOLINT(misc-no-recursion)
 
 
 /* single digit subtraction */
-int mp_sub_d (mp_int * a, mp_digit b, mp_int * c) // NOLINT(misc-no-recursion)
+int mp_sub_d (mp_int * a, mp_digit b, mp_int * c) /* //NOLINT(misc-no-recursion) */
 {
   mp_digit *tmpa, *tmpc, mu;
   int       res, ix, oldused;

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -3586,7 +3586,7 @@ int fp_montgomery_reduce_ex(fp_int *a, fp_int *m, fp_digit mp, int ct)
           ++_c;
        }
        LOOP_END;
-       while (cy) { // NOLINT(bugprone-infinite-loop) /* PROPCARRY is an asm macro */
+       while (cy) { /* //NOLINT(bugprone-infinite-loop) */ /* PROPCARRY is an asm macro */
            PROPCARRY;
            ++_c;
        }

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -34995,7 +34995,11 @@ static int pkcs7signed_run_vectors(
         #endif
 
             for (j = 0, k = 2; j < (int)sizeof(digest); j++, k += 2) {
-                XSNPRINTF((char*)&transId[k], 3, "%02x", digest[j]);
+                #if defined(WOLF_C89)
+                    XSPRINTF((char*)&transId[k], "%02x", digest[j]);
+                #else
+                    XSNPRINTF((char*)&transId[k], 3, "%02x", digest[j]);
+                #endif
             }
         }
 

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -23,21 +23,21 @@
  *   ************************************************************************
  *
  *   ******************************** NOTICE ********************************
- * 
+ *
  *   ************************************************************************
  *
- *   This method of uncommenting a line in settings.h is outdated. 
- * 
- *   Please use user_settings.h / WOLFSSL_USER_SETTINGS 
- * 
- *         or 
- * 
- *   ./configure CFLAGS="-DFLAG" 
- * 
+ *   This method of uncommenting a line in settings.h is outdated.
+ *
+ *   Please use user_settings.h / WOLFSSL_USER_SETTINGS
+ *
+ *         or
+ *
+ *   ./configure CFLAGS="-DFLAG"
+ *
  *   For more information see:
- * 
+ *
  *   https://www.wolfssl.com/how-do-i-manage-the-build-configuration-of-wolfssl/
- * 
+ *
  */
 
 
@@ -216,8 +216,8 @@
 /* #define WOLFSSL_APACHE_MYNEWT */
 
 /* For Espressif chips see example user_settings.h
- * 
- * https://github.com/wolfSSL/wolfssl/blob/master/IDE/Espressif/ESP-IDF/user_settings.h 
+ *
+ * https://github.com/wolfSSL/wolfssl/blob/master/IDE/Espressif/ESP-IDF/user_settings.h
  */
 
 /* Uncomment next line if building for using ESP-IDF */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -651,6 +651,8 @@ decouple library dependencies with standard string, memory and so on.
                 #define XSTRCASECMP(s1,s2) stricmp((s1),(s2))
             #elif defined(WOLFSSL_CMSIS_RTOSv2)
                 #define XSTRCASECMP(s1,s2) strcmp((s1),(s2))
+            #elif defined(WOLF_C89)
+                #define XSTRCASECMP(s1,s2) strcmp((s1),(s2))
             #else
                 #define XSTRCASECMP(s1,s2) strcasecmp((s1),(s2))
             #endif
@@ -677,6 +679,8 @@ decouple library dependencies with standard string, memory and so on.
             #if defined(WOLFSSL_DEOS)
                 #define XSTRNCASECMP(s1,s2,n) strnicmp((s1),(s2),(n))
             #elif defined(WOLFSSL_CMSIS_RTOSv2)
+                #define XSTRNCASECMP(s1,s2,n) strncmp((s1),(s2),(n))
+            #elif defined(WOLF_C89)
                 #define XSTRNCASECMP(s1,s2,n) strncmp((s1),(s2),(n))
             #else
                 #define XSTRNCASECMP(s1,s2,n) strncasecmp((s1),(s2),(n))
@@ -723,6 +727,8 @@ decouple library dependencies with standard string, memory and so on.
                         return ret;
                     }
                 #define XSNPRINTF _xsnprintf_
+            #elif defined(WOLF_C89)
+                #define XSPRINTF sprintf
             #else
                 #define XSNPRINTF snprintf
             #endif


### PR DESCRIPTION
# Description

This PR corrects the following error for c89 build:

```
error: C++ style comments are not allowed in ISO C90
error: implicit declaration of function ‘strncasecmp’; did you mean ‘strncmp’? [-Werror=implicit-function-declaration
error: nested extern declaration of ‘strncasecmp’ [-Werror=nested-externs]
```

# Testing

./configure CC="gcc -std=c89" --enable-cryptonly --disable-inline --disable-benchmark CFLAGS=-DWOLF_C89 && make
./configure CC="gcc -std=c89" --disable-fastmath --enable-cryptonly --disable-inline --disable-benchmark CFLAGS=-DWOLF_C89 && make
./configure CC="gcc -std=c89" --enable-sp --enable-sp-math --enable-cryptonly --disable-inline --disable-benchmark CFLAGS=-DWOLF_C89 && make
./configure CC="gcc -std=c89" --enable-cryptonly --disable-inline --disable-benchmark --enable-all-crypto CFLAGS=-DWOLF_C89 && make
# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
