### PR TITLE
Fix for stack and heap measurements of a 32-bit build

### DIFF
--- a/testsuite/testsuite.c
+++ b/testsuite/testsuite.c
@@ -630,8 +630,7 @@ int main(int argc, char** argv)
 
     wolfSSL_Cleanup();
     printf("\nAll tests passed!\n");
-
-    EXIT_TEST(EXIT_SUCCESS);
+    return EXIT_SUCCESS;
 }
 
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -70,19 +70,19 @@
 #else
     static ssize_t max_relative_heap_bytes = -1;
 #endif
-#define PRINT_HEAP_CHECKPOINT() {                                        \
+#define PRINT_HEAP_CHECKPOINT() {                                           \
     const ssize_t _rha = wolfCrypt_heap_peakAllocs_checkpoint() - heap_baselineAllocs; \
-    const ssize_t _rhb = wolfCrypt_heap_peakBytes_checkpoint() - heap_baselineBytes; \
-    printf("    relative heap peak usage: %d alloc%s, %d bytes\n",      \
-           (int)_rha,                                                   \
-           _rha == 1 ? "" : "s",                                        \
-           (int)_rhb);                                                  \
+    const ssize_t _rhb = wolfCrypt_heap_peakBytes_checkpoint() - heap_baselineBytes;   \
+    printf("    relative heap peak usage: %ld alloc%s, %ld bytes\n",         \
+           (long int)_rha,                                                   \
+           _rha == 1 ? "" : "s",                                             \
+           (long int)_rhb);                                                  \
     if ((max_relative_heap_allocs > 0) && (_rha > max_relative_heap_allocs)) \
-        return err_sys("heap allocs exceed designated max.", -1);       \
-    if ((max_relative_heap_bytes > 0) && (_rhb > max_relative_heap_bytes)) \
-        return err_sys("heap bytes exceed designated max.", -1);        \
-    heap_baselineAllocs = wolfCrypt_heap_peakAllocs_checkpoint();        \
-    heap_baselineBytes = wolfCrypt_heap_peakBytes_checkpoint();         \
+        return err_sys("heap allocs exceed designated max.", -1);            \
+    if ((max_relative_heap_bytes > 0) && (_rhb > max_relative_heap_bytes))   \
+        return err_sys("heap bytes exceed designated max.", -1);             \
+    heap_baselineAllocs = wolfCrypt_heap_peakAllocs_checkpoint();            \
+    heap_baselineBytes = wolfCrypt_heap_peakBytes_checkpoint();              \
     }
 #else
 #define PRINT_HEAP_CHECKPOINT()

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -73,10 +73,10 @@
 #define PRINT_HEAP_CHECKPOINT() {                                        \
     const ssize_t _rha = wolfCrypt_heap_peakAllocs_checkpoint() - heap_baselineAllocs; \
     const ssize_t _rhb = wolfCrypt_heap_peakBytes_checkpoint() - heap_baselineBytes; \
-    printf("    relative heap peak usage: %ld alloc%s, %ld bytes\n",    \
-           _rha,                                                        \
+    printf("    relative heap peak usage: %d alloc%s, %d bytes\n",      \
+           (int)_rha,                                                   \
            _rha == 1 ? "" : "s",                                        \
-           _rhb);                                                       \
+           (int)_rhb);                                                  \
     if ((max_relative_heap_allocs > 0) && (_rha > max_relative_heap_allocs)) \
         return err_sys("heap allocs exceed designated max.", -1);       \
     if ((max_relative_heap_bytes > 0) && (_rhb > max_relative_heap_bytes)) \

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -250,7 +250,11 @@
 
 
 #ifdef SINGLE_THREADED
-    typedef unsigned int  THREAD_RETURN;
+    #if defined(WC_32BIT_CPU)
+        typedef void*   THREAD_RETURN;
+    #else
+        typedef unsigned int  THREAD_RETURN;
+    #endif
     typedef void*         THREAD_TYPE;
     #define WOLFSSL_THREAD
 #else
@@ -3055,7 +3059,7 @@ int StackSizeHWMReset(void)
 #define STACK_SIZE_CHECKPOINT(...) ({  \
     ssize_t HWM = StackSizeHWM_OffsetCorrected();    \
     __VA_ARGS__;                                     \
-    printf("    relative stack peak usage = %ld bytes\n", HWM);  \
+    printf("    relative stack peak usage = %d bytes\n", (int)HWM);  \
     StackSizeHWMReset();                             \
     })
 
@@ -3063,10 +3067,10 @@ int StackSizeHWMReset(void)
     ssize_t HWM = StackSizeHWM_OffsetCorrected();    \
     int _ret;                                        \
     __VA_ARGS__;                                     \
-    printf("    relative stack peak usage = %ld bytes\n", HWM);  \
+    printf("    relative stack peak usage = %d bytes\n", (int)HWM);  \
     _ret = StackSizeHWMReset();                      \
     if ((max >= 0) && (HWM > (ssize_t)(max))) {      \
-        printf("    relative stack usage at %s L%d exceeds designated max %ld bytes.\n", __FILE__, __LINE__, (ssize_t)(max)); \
+        printf("    relative stack usage at %s L%d exceeds designated max %d bytes.\n", __FILE__, __LINE__, (int)(max)); \
         _ret = -1;                                   \
     }                                                \
     _ret;                                            \

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -3059,7 +3059,7 @@ int StackSizeHWMReset(void)
 #define STACK_SIZE_CHECKPOINT(...) ({  \
     ssize_t HWM = StackSizeHWM_OffsetCorrected();    \
     __VA_ARGS__;                                     \
-    printf("    relative stack peak usage = %d bytes\n", (int)HWM);  \
+    printf("    relative stack peak usage = %ld bytes\n", (long int)HWM);  \
     StackSizeHWMReset();                             \
     })
 
@@ -3067,10 +3067,10 @@ int StackSizeHWMReset(void)
     ssize_t HWM = StackSizeHWM_OffsetCorrected();    \
     int _ret;                                        \
     __VA_ARGS__;                                     \
-    printf("    relative stack peak usage = %d bytes\n", (int)HWM);  \
+    printf("    relative stack peak usage = %ld bytes\n", (long int)HWM);  \
     _ret = StackSizeHWMReset();                      \
     if ((max >= 0) && (HWM > (ssize_t)(max))) {      \
-        printf("    relative stack usage at %s L%d exceeds designated max %d bytes.\n", __FILE__, __LINE__, (int)(max)); \
+        printf("    relative stack usage at %s L%d exceeds designated max %ld bytes.\n", __FILE__, __LINE__, (long int)(max)); \
         _ret = -1;                                   \
     }                                                \
     _ret;                                            \


### PR DESCRIPTION
# Description

Improve stack and heap measurements of a 32-bit build

This PR corrects 32-bit build errors on a 64-bit machine.


`./configure CPPFLAGS=-m32 LDFLAGS=-m32 --enable-singlethreaded --enable-stacksize=verbose --enable-trackmemory=verbose --enable-memory && make`


```
./wolfssl/test.h:3123:46: error: passing argument 3 of ‘pthread_create’ from incompatible pointer type [-Werror=incompatible-pointer-types]
 3123 |     ret = pthread_create(&threadId, &myAttr, (thread_func)debug_stack_size_verbose_shim, (void *)&shim_args);
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                              |
      |                                              THREAD_RETURN (*)(void *) {aka unsigned int (*)(void *)}

...
./wolfssl/test.h:3066:12: error: format ‘%ld’ expects argument of type ‘long int’, but argument 2 has type ‘ssize_t’ {aka ‘int’} [-Werror=format=]
 3066 |     printf("    relative stack peak usage = %ld bytes\n", HWM);  \
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~
      |                                                           |
      |                                                           ssize_t {aka int}


./wolfssl/test.h:3069:16: error: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘int’ [-Werror=format=]
 3069 |         printf("    relative stack usage at %s L%d exceeds designated max %ld bytes.\n", __FILE__, __LINE__, (ssize_t)(max)); \
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                      ~~~~~~~~~~~~~~
      |                                                                                                              |
      |                                                                                                              int

wolfcrypt/test/test.c:76:12: error: format ‘%ld’ expects argument of type ‘long int’, but argument 2 has type ‘ssize_t’ {aka ‘const int’} [-Werror=format=]
   76 |     printf("    relative heap peak usage: %ld alloc%s, %ld bytes\n",    \
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   77 |            _rha,                                                        \
      |            ~~~~
      |            |
      |            ssize_t {aka const int}
```

# Testing
`./configure CPPFLAGS=-m32 LDFLAGS=-m32 --enable-singlethreaded --enable-stacksize=verbose --enable-trackmemory=verbose --enable-memory && make`
`./configure --enable-singlethreaded --enable-stacksize=verbose --enable-trackmemory=verbose --enable-memory && make`
`./configure CC=clang CPPFLAGS=-m32 LDFLAGS=-m32 --enable-singlethreaded --enable-stacksize=verbose --enable-trackmemory=verbose --enable-memory --disable-asm && make`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
