### PR TITLE
Refactor wolfSSL_ASN1_TIME_adj to use GetFormattedTimeString (new API)

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -45310,8 +45310,8 @@ WOLFSSL_ASN1_TIME* wolfSSL_ASN1_TIME_adj(WOLFSSL_ASN1_TIME *s, time_t t,
     const time_t sec_per_day = 24*60*60;
     time_t t_adj = 0;
     time_t offset_day_sec = 0;
-    char utc_str_buf[MAX_TIME_STRING_SZ] = {0};
-    char* utc_str = utc_str_buf;
+    char time_str_buf[MAX_TIME_STRING_SZ] = {0};
+    char* time_str = time_str_buf;
     int time_get;
 
     WOLFSSL_ENTER("wolfSSL_ASN1_TIME_adj");
@@ -45328,14 +45328,14 @@ WOLFSSL_ASN1_TIME* wolfSSL_ASN1_TIME_adj(WOLFSSL_ASN1_TIME *s, time_t t,
     t_adj          = t + offset_day_sec + offset_sec;
 
     /* Get UTC Time */
-    time_get = GetUnformattedTimeString(&t_adj, (byte*) utc_str,
-                                        sizeof(utc_str_buf));
+    time_get = GetUnformattedTimeString(&t_adj, (byte*) time_str,
+                                        sizeof(time_str_buf));
     if (time_get <= 0) {
         wolfSSL_ASN1_TIME_free(s);
         return NULL;
     }
 
-    if (wolfSSL_ASN1_TIME_set_string(s, utc_str) != WOLFSSL_SUCCESS) {
+    if (wolfSSL_ASN1_TIME_set_string(s, time_str) != WOLFSSL_SUCCESS) {
         wolfSSL_ASN1_TIME_free(s);
         return NULL;
     }

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -45310,15 +45310,14 @@ WOLFSSL_ASN1_TIME* wolfSSL_ASN1_TIME_adj(WOLFSSL_ASN1_TIME *s, time_t t,
     const time_t sec_per_day = 24*60*60;
     time_t t_adj = 0;
     time_t offset_day_sec = 0;
-    char time_str_buf[MAX_TIME_STRING_SZ] = {0};
-    char* time_str = time_str_buf;
+    char time_str[MAX_TIME_STRING_SZ];
     int time_get;
 
     WOLFSSL_ENTER("wolfSSL_ASN1_TIME_adj");
 
-    if (s == NULL){
+    if (s == NULL) {
         s = wolfSSL_ASN1_TIME_new();
-        if (s == NULL){
+        if (s == NULL) {
             return NULL;
         }
     }
@@ -45327,9 +45326,9 @@ WOLFSSL_ASN1_TIME* wolfSSL_ASN1_TIME_adj(WOLFSSL_ASN1_TIME *s, time_t t,
     offset_day_sec = offset_day * sec_per_day;
     t_adj          = t + offset_day_sec + offset_sec;
 
-    /* Get UTC Time */
-    time_get = GetUnformattedTimeString(&t_adj, (byte*) time_str,
-                                        sizeof(time_str_buf));
+    /* Get time string as either UTC or GeneralizedTime */
+    time_get = GetFormattedTime(&t_adj, (byte*)time_str,
+        (word32)sizeof(time_str));
     if (time_get <= 0) {
         wolfSSL_ASN1_TIME_free(s);
         return NULL;

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -12192,19 +12192,60 @@ int GetTimeString(byte* date, int format, char* buf, int len)
 #endif /* OPENSSL_ALL || WOLFSSL_MYSQL_COMPATIBLE || WOLFSSL_NGINX || WOLFSSL_HAPROXY */
 
 
-#if !defined(NO_ASN_TIME) && defined(HAVE_PKCS7)
-
+#if !defined(NO_ASN_TIME) && !defined(USER_TIME) && \
+    !defined(TIME_OVERRIDES) && (defined(OPENSSL_EXTRA) || defined(HAVE_PKCS7))
 /* Set current time string, either UTC or GeneralizedTime.
  * (void*) tm should be a pointer to time_t, output is placed in buf.
  *
  * Return time string length placed in buf on success, negative on error */
 int GetAsnTimeString(void* currTime, byte* buf, word32 len)
 {
+    byte* data_ptr  = buf;
+    byte  uf_time[ASN_GENERALIZED_TIME_SIZE] = {0};
+    word32 data_len = 0;
+
+    WOLFSSL_ENTER("GetAsnTimeString");
+
+    if (buf == NULL || len == 0)
+        return BAD_FUNC_ARG;
+
+    data_len = GetUnformattedTimeString(currTime, uf_time, len);
+    /* ensure room to add 2 bytes (ASN type and length) before proceeding */
+    if (len < data_len + 2)
+        return BUFFER_E;
+    if(data_len <= 0)
+        return ASN_TIME_E;
+
+    /* Increment by 1 for ASN type */
+    data_len++;
+
+    if (data_len == ASN_UTC_TIME_SIZE) {
+        /* increment data_len for ASN length byte after adding the data_ptr */
+        *data_ptr = (byte) ASN_UTC_TIME; data_ptr++; data_len++;
+        /* -1 below excludes null terminator */
+        *data_ptr = (byte) ASN_UTC_TIME_SIZE - 1; data_ptr++;
+        XMEMCPY(data_ptr,(byte *)uf_time, ASN_UTC_TIME_SIZE - 1);
+    } else if (data_len == ASN_GENERALIZED_TIME_SIZE) {
+        /* increment data_len for ASN length byte after adding the data_ptr */
+        *data_ptr = (byte) ASN_GENERALIZED_TIME; data_ptr++; data_len++;
+        /* -1 below excludes null terminator */
+        *data_ptr = (byte) ASN_GENERALIZED_TIME_SIZE - 1; data_ptr++;
+        XMEMCPY(data_ptr,(byte *)uf_time, ASN_GENERALIZED_TIME_SIZE - 1);
+    } else {
+        WOLFSSL_MSG("Invalid time size returned");
+        return ASN_TIME_E;
+    }
+
+    return data_len;
+}
+
+/* return just the raw time string */
+int GetUnformattedTimeString(void* currTime, byte* buf, word32 len)
+{
     struct tm* ts      = NULL;
     struct tm* tmpTime = NULL;
-    byte* data_ptr  = buf;
-    word32 data_len = 0;
     int year, mon, day, hour, mini, sec;
+    int ret_bytes_len = 0;
 #if defined(NEED_TMP_TIME)
     struct tm tmpTimeStorage;
     tmpTime = &tmpTimeStorage;
@@ -12212,7 +12253,7 @@ int GetAsnTimeString(void* currTime, byte* buf, word32 len)
     (void)tmpTime;
 #endif
 
-    WOLFSSL_ENTER("SetAsnTimeString");
+    WOLFSSL_ENTER("GetTimeString");
 
     if (buf == NULL || len == 0)
         return BAD_FUNC_ARG;
@@ -12228,12 +12269,6 @@ int GetAsnTimeString(void* currTime, byte* buf, word32 len)
 
     if (ts->tm_year >= 50 && ts->tm_year < 150) {
         /* UTC Time */
-        char utc_str[ASN_UTC_TIME_SIZE];
-        data_len = ASN_UTC_TIME_SIZE - 1 + 2;
-
-        if (len < data_len)
-            return BUFFER_E;
-
         if (ts->tm_year >= 50 && ts->tm_year < 100) {
             year = ts->tm_year;
         } else if (ts->tm_year >= 100 && ts->tm_year < 150) {
@@ -12248,40 +12283,27 @@ int GetAsnTimeString(void* currTime, byte* buf, word32 len)
         hour = ts->tm_hour;
         mini = ts->tm_min;
         sec  = ts->tm_sec;
-        XSNPRINTF((char *)utc_str, ASN_UTC_TIME_SIZE,
-                  "%02d%02d%02d%02d%02d%02dZ", year, mon, day, hour, mini, sec);
-        *data_ptr = (byte) ASN_UTC_TIME; data_ptr++;
-        /* -1 below excludes null terminator */
-        *data_ptr = (byte) ASN_UTC_TIME_SIZE - 1; data_ptr++;
-        XMEMCPY(data_ptr,(byte *)utc_str, ASN_UTC_TIME_SIZE - 1);
-
+        ret_bytes_len = XSNPRINTF((char *)buf, len,
+                                  "%02d%02d%02d%02d%02d%02dZ", year, mon, day,
+                                  hour, mini, sec);
     } else {
         /* GeneralizedTime */
-        char gt_str[ASN_GENERALIZED_TIME_SIZE];
-        data_len = ASN_GENERALIZED_TIME_SIZE - 1 + 2;
-
-        if (len < data_len)
-            return BUFFER_E;
-
         year = ts->tm_year + 1900;
         mon  = ts->tm_mon + 1;
         day  = ts->tm_mday;
         hour = ts->tm_hour;
         mini = ts->tm_min;
         sec  = ts->tm_sec;
-        XSNPRINTF((char *)gt_str, ASN_GENERALIZED_TIME_SIZE,
-                  "%4d%02d%02d%02d%02d%02dZ", year, mon, day, hour, mini, sec);
-        *data_ptr = (byte) ASN_GENERALIZED_TIME; data_ptr++;
-        /* -1 below excludes null terminator */
-        *data_ptr = (byte) ASN_GENERALIZED_TIME_SIZE - 1; data_ptr++;
-        XMEMCPY(data_ptr,(byte *)gt_str, ASN_GENERALIZED_TIME_SIZE - 1);
+        ret_bytes_len = XSNPRINTF((char *)buf, len,
+                                  "%4d%02d%02d%02d%02d%02dZ", year, mon, day,
+                                  hour, mini, sec);
     }
 
-    return data_len;
+    return ret_bytes_len;
 }
 
-#endif /* !NO_ASN_TIME && HAVE_PKCS7 */
-
+#endif /* !NO_ASN_TIME && !USER_TIME && !TIME_OVERRIDES &&
+        * (OPENSSL_EXTRA || HAVE_PKCS7) */
 
 #if defined(USE_WOLF_VALIDDATE)
 

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -12211,12 +12211,18 @@ int GetAsnTimeString(void* currTime, byte* buf, word32 len)
 
     data_len = GetUnformattedTimeString(currTime, uf_time, len);
     /* ensure room to add 2 bytes (ASN type and length) before proceeding */
-    if (len < data_len + 2)
-        return BUFFER_E;
-    if(data_len <= 0)
+    if(data_len <= 0) {
         return ASN_TIME_E;
+    } else if (len < data_len + 2) {
+        return BUFFER_E;
+    }
 
-    /* Increment by 1 for ASN type */
+    /* Increment by 1 for ASN type, it is critical that this increment occur
+     * prior to the check on data_len being ASN_UTC_TIME_SIZE or
+     * ASN_GENERALIZED_TIME_SIZE since GetUnformattedTimeString returns the
+     * length without NULL terminator
+     * (IE 13 instead of 14 for ASN_UTC_TIME_SIZE) This logic WILL NEED updated
+     * if ASN_UTC_TIME_SIZE or ASN_GENERALIZED_TIME_SIZE are ever modified */
     data_len++;
 
     if (data_len == ASN_UTC_TIME_SIZE) {

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -156,8 +156,13 @@ enum ASN_Tags {
     ASN_ASYMKEY_PUBKEY    = 0x01,
 };
 
-#define ASN_UTC_TIME_SIZE 14
-#define ASN_GENERALIZED_TIME_SIZE 16
+/* NOTE: If ASN_UTC_TIME_SIZE or ASN_GENERALIZED_TIME_SIZE are ever modified
+ *       one needs to update the logic in asn.c function GetAsnTimeString()
+ *       which depends on the size 14 and/or 16 to determine which format to
+ *       place in the "buf" (output)
+ */
+#define ASN_UTC_TIME_SIZE 14 /* Read note above before modifying */
+#define ASN_GENERALIZED_TIME_SIZE 16 /* Read note above before modifying */
 #define ASN_GENERALIZED_TIME_MAX 68
 
 #ifdef WOLFSSL_ASN_TEMPLATE

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1894,7 +1894,9 @@ typedef struct tm wolfssl_tm;
     defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
 WOLFSSL_LOCAL int GetTimeString(byte* date, int format, char* buf, int len);
 #endif
-#if !defined(NO_ASN_TIME) && defined(HAVE_PKCS7)
+#if !defined(NO_ASN_TIME) && !defined(USER_TIME) && \
+    !defined(TIME_OVERRIDES) && (defined(OPENSSL_EXTRA) || defined(HAVE_PKCS7))
+WOLFSSL_LOCAL int GetUnformattedTimeString(void* currTime, byte* buf, word32 len);
 WOLFSSL_LOCAL int GetAsnTimeString(void* currTime, byte* buf, word32 len);
 #endif
 WOLFSSL_LOCAL int ExtractDate(const unsigned char* date, unsigned char format,

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1901,7 +1901,7 @@ WOLFSSL_LOCAL int GetTimeString(byte* date, int format, char* buf, int len);
 #endif
 #if !defined(NO_ASN_TIME) && !defined(USER_TIME) && \
     !defined(TIME_OVERRIDES) && (defined(OPENSSL_EXTRA) || defined(HAVE_PKCS7))
-WOLFSSL_LOCAL int GetUnformattedTimeString(void* currTime, byte* buf, word32 len);
+WOLFSSL_LOCAL int GetFormattedTime(void* currTime, byte* buf, word32 len);
 WOLFSSL_LOCAL int GetAsnTimeString(void* currTime, byte* buf, word32 len);
 #endif
 WOLFSSL_LOCAL int ExtractDate(const unsigned char* date, unsigned char format,


### PR DESCRIPTION
# Description

After evaluating numerous approaches to resolving the ABI-check-test issues reported by GCC 9 on the cloud slaves @dgarske noticed that the code in wolfSSL_ASN1_TIME_adj in ssl.c was awfully similar (nearly a copy/paste) of some code from the function GetAsnTimeString in asn.c. To that end we decided to kill a few birds with 1 stone. This PR does a few things:

1) Adds a new internal API (not a public API) `GetFormattedTimeString` to return just the time string (not compatible with the existing function `GetAsnTime()`). The new function takes input tm structure, a buffer to hold the output and a length to control the XSNPRINTF number of bytes to be printed into that buffer.
2) Refactors `GetAsnTimeString` to call `GetFormattedTimeString ` (a new API for both use cases) before adding the ASN encoding onto the returned string
3) Refactors `wolfSSL_ASN1_TIME_adj` to use this same new API `GetFormattedTimeString `
4) Resolves the issues reported by the ABI-check-test 
5) Removes stack fluctuations between the UTC and GENERALIZE time cases by using a single buffer `uf_time` to store the formatted time when called from the original function in asn.c `GetAsnTimeString`

Fixes ABI-check-test

# Testing

Tested using the cloud.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
