### PR TITLE
internal.c: fix pad-size when more records are received at once

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -17410,7 +17410,9 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
             }
             else
        #endif
-            if (ssl->buffers.inputBuffer.length -
+                /* TLS13 plaintext limit is checked earlier before decryption */
+                if (!IsAtLeastTLSv1_3(ssl->version)
+                    && ssl->buffers.inputBuffer.length -
                     ssl->keys.padSz -
                     ssl->buffers.inputBuffer.idx > MAX_PLAINTEXT_SZ
 #ifdef WOLFSSL_ASYNC_CRYPT

--- a/src/internal.c
+++ b/src/internal.c
@@ -17398,10 +17398,9 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
 
        #if defined(HAVE_ENCRYPT_THEN_MAC) && !defined(WOLFSSL_AEAD_ONLY)
             if (IsEncryptionOn(ssl, 0) && ssl->options.startedETMRead) {
-                if ((ssl->buffers.inputBuffer.length -
+                if ((ssl->curSize -
                         ssl->keys.padSz -
-                        MacSize(ssl) -
-                        ssl->buffers.inputBuffer.idx > MAX_PLAINTEXT_SZ)
+                        MacSize(ssl) > MAX_PLAINTEXT_SZ)
 #ifdef WOLFSSL_ASYNC_CRYPT
                         && ssl->buffers.inputBuffer.length !=
                                 ssl->buffers.inputBuffer.idx
@@ -17418,9 +17417,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
        #endif
                 /* TLS13 plaintext limit is checked earlier before decryption */
                 if (!IsAtLeastTLSv1_3(ssl->version)
-                    && ssl->buffers.inputBuffer.length -
-                    ssl->keys.padSz -
-                    ssl->buffers.inputBuffer.idx > MAX_PLAINTEXT_SZ
+                        && ssl->curSize - ssl->keys.padSz > MAX_PLAINTEXT_SZ
 #ifdef WOLFSSL_ASYNC_CRYPT
                         && ssl->buffers.inputBuffer.length !=
                                 ssl->buffers.inputBuffer.idx

--- a/src/internal.c
+++ b/src/internal.c
@@ -16278,7 +16278,10 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
             }
             if (!process) {
                 WOLFSSL_MSG("Ignoring EarlyData!");
-                *inOutIdx = ssl->buffers.inputBuffer.length;
+                *inOutIdx += ssl->curSize;
+                if (*inOutIdx > ssl->buffers.inputBuffer.length)
+                    return BUFFER_E;
+
                 return 0;
             }
         }
@@ -17285,8 +17288,11 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                                 if (ssl->keys.peer_sequence_number_lo-- == 0)
                                     ssl->keys.peer_sequence_number_hi--;
                                 ssl->options.processReply = doProcessInit;
-                                ssl->buffers.inputBuffer.idx =
-                                                ssl->buffers.inputBuffer.length;
+                                ssl->buffers.inputBuffer.idx += ssl->curSize;
+                                if (ssl->buffers.inputBuffer.idx >
+                                    ssl->buffers.inputBuffer.length)
+                                    return BUFFER_E;
+
                                 return 0;
                             }
                             WOLFSSL_MSG("Too much EarlyData!");


### PR DESCRIPTION
# Description
don't consider the end of the record the end of received data as more records
may be read at once when DTLS will be supported.

# Testing

`make check`

