### PR TITLE
s/strncmp/strcmp/g

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -367,107 +367,82 @@ static void SetKeyShare(WOLFSSL* ssl, int onlyKeyShare, int useX25519,
         if (usePqc) {
             int group = 0;
 
-            if (XSTRNCMP(pqcAlg, "KYBER_LEVEL1", XSTRLEN("KYBER_LEVEL1")) == 0) {
+            if (XSTRCMP(pqcAlg, "KYBER_LEVEL1") == 0) {
                 group = WOLFSSL_KYBER_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "KYBER_LEVEL3",
-                                XSTRLEN("KYBER_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "KYBER_LEVEL3") == 0) {
                 group = WOLFSSL_KYBER_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "KYBER_LEVEL5",
-                                XSTRLEN("KYBER_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "KYBER_LEVEL5") == 0) {
                 group = WOLFSSL_KYBER_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "NTRU_HPS_LEVEL1",
-                                XSTRLEN("NTRU_HPS_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "NTRU_HPS_LEVEL1") == 0) {
                 group = WOLFSSL_NTRU_HPS_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "NTRU_HPS_LEVEL3",
-                                XSTRLEN("NTRU_HPS_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "NTRU_HPS_LEVEL3") == 0) {
                 group = WOLFSSL_NTRU_HPS_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "NTRU_HPS_LEVEL5",
-                                XSTRLEN("NTRU_HPS_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "NTRU_HPS_LEVEL5") == 0) {
                 group = WOLFSSL_NTRU_HPS_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "NTRU_HRSS_LEVEL3",
-                                XSTRLEN("NTRU_HRSS_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "NTRU_HRSS_LEVEL3") == 0) {
                 group = WOLFSSL_NTRU_HRSS_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "SABER_LEVEL1",
-                                XSTRLEN("SABER_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "SABER_LEVEL1") == 0) {
                 group = WOLFSSL_SABER_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "SABER_LEVEL3",
-                                XSTRLEN("SABER_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "SABER_LEVEL3") == 0) {
                 group = WOLFSSL_SABER_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "SABER_LEVEL5",
-                                XSTRLEN("SABER_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "SABER_LEVEL5") == 0) {
                 group = WOLFSSL_SABER_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "KYBER_90S_LEVEL1",
-                                XSTRLEN("KYBER_90S_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "KYBER_90S_LEVEL1") == 0) {
                 group = WOLFSSL_KYBER_90S_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "KYBER_90S_LEVEL3",
-                                XSTRLEN("KYBER_90S_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "KYBER_90S_LEVEL3") == 0) {
                 group = WOLFSSL_KYBER_90S_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "KYBER_90S_LEVEL5",
-                                XSTRLEN("KYBER_90S_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "KYBER_90S_LEVEL5") == 0) {
                 group = WOLFSSL_KYBER_90S_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "P256_NTRU_HPS_LEVEL1",
-                                XSTRLEN("P256_NTRU_HPS_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P256_NTRU_HPS_LEVEL1") == 0) {
                 group = WOLFSSL_P256_NTRU_HPS_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "P384_NTRU_HPS_LEVEL3",
-                                XSTRLEN("P384_NTRU_HPS_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P384_NTRU_HPS_LEVEL3") == 0) {
                 group = WOLFSSL_P384_NTRU_HPS_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "P521_NTRU_HPS_LEVEL5",
-                                XSTRLEN("P521_NTRU_HPS_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P521_NTRU_HPS_LEVEL5") == 0) {
                 group = WOLFSSL_P521_NTRU_HPS_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "P384_NTRU_HRSS_LEVEL3",
-                                XSTRLEN("P384_NTRU_HRSS_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P384_NTRU_HRSS_LEVEL3") == 0) {
                 group = WOLFSSL_P384_NTRU_HRSS_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "P256_SABER_LEVEL1",
-                                XSTRLEN("P256_SABER_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P256_SABER_LEVEL1") == 0) {
                 group = WOLFSSL_P256_SABER_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "P384_SABER_LEVEL3",
-                                XSTRLEN("P384_SABER_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P384_SABER_LEVEL3") == 0) {
                 group = WOLFSSL_P384_SABER_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "P521_SABER_LEVEL5",
-                                XSTRLEN("P521_SABER_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P521_SABER_LEVEL5") == 0) {
                 group = WOLFSSL_P521_SABER_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "P256_KYBER_LEVEL1",
-                                XSTRLEN("P256_KYBER_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P256_KYBER_LEVEL1") == 0) {
                 group = WOLFSSL_P256_KYBER_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "P384_KYBER_LEVEL3",
-                                XSTRLEN("P384_KYBER_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P384_KYBER_LEVEL3") == 0) {
                 group = WOLFSSL_P384_KYBER_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "P521_KYBER_LEVEL5",
-                                XSTRLEN("P521_KYBER_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P521_KYBER_LEVEL5") == 0) {
                 group = WOLFSSL_P521_KYBER_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "P256_KYBER_90S_LEVEL1",
-                                XSTRLEN("P256_KYBER_90S_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P256_KYBER_90S_LEVEL1") == 0) {
                 group = WOLFSSL_P256_KYBER_90S_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "P384_KYBER_90S_LEVEL3",
-                                XSTRLEN("P384_KYBER_90S_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P384_KYBER_90S_LEVEL3") == 0) {
                 group = WOLFSSL_P384_KYBER_90S_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "P521_KYBER_90S_LEVEL5",
-                                XSTRLEN("P521_KYBER_90S_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P521_KYBER_90S_LEVEL5") == 0) {
                 group = WOLFSSL_P521_KYBER_90S_LEVEL5;
             } else {
                 err_sys("invalid post-quantum KEM specified");
@@ -915,7 +890,7 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     if (recv(*sockfd, tmpBuf, sizeof(tmpBuf)-1, 0) < 0)
         err_sys("failed to read STARTTLS command\n");
 
-    if (!XSTRNCMP(tmpBuf, starttlsCmd[0], XSTRLEN(starttlsCmd[0]))) {
+    if (!XSTRCMP(tmpBuf, starttlsCmd[0])) {
         printf("%s\n", tmpBuf);
     } else {
         err_sys("incorrect STARTTLS command received");
@@ -931,7 +906,7 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     if (recv(*sockfd, tmpBuf, sizeof(tmpBuf)-1, 0) < 0)
         err_sys("failed to read STARTTLS command\n");
 
-    if (!XSTRNCMP(tmpBuf, starttlsCmd[2], XSTRLEN(starttlsCmd[2]))) {
+    if (!XSTRCMP(tmpBuf, starttlsCmd[2])) {
         printf("%s\n", tmpBuf);
     } else {
         err_sys("incorrect STARTTLS command received");
@@ -948,7 +923,7 @@ static int StartTLS_Init(SOCKET_T* sockfd)
     if (recv(*sockfd, tmpBuf, sizeof(tmpBuf)-1, 0) < 0)
         err_sys("failed to read STARTTLS command\n");
     tmpBuf[sizeof(tmpBuf)-1] = '\0';
-    if (!XSTRNCMP(tmpBuf, starttlsCmd[4], XSTRLEN(starttlsCmd[4]))) {
+    if (!XSTRCMP(tmpBuf, starttlsCmd[4])) {
         printf("%s\n", tmpBuf);
     } else {
         err_sys("incorrect STARTTLS command received, expected 220");
@@ -2248,23 +2223,23 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 break;
 
             case 'H' :
-                if (XSTRNCMP(myoptarg, "defCipherList", 13) == 0) {
+                if (XSTRCMP(myoptarg, "defCipherList") == 0) {
                     printf("Using default cipher list for testing\n");
                     useDefCipherList = 1;
                 }
-                else if (XSTRNCMP(myoptarg, "exitWithRet", 11) == 0) {
+                else if (XSTRCMP(myoptarg, "exitWithRet") == 0) {
                     printf("Skip exit() for testing\n");
                     exitWithRet = 1;
                 }
-                else if (XSTRNCMP(myoptarg, "verifyFail", 10) == 0) {
+                else if (XSTRCMP(myoptarg, "verifyFail") == 0) {
                     printf("Verify should fail\n");
                     myVerifyAction = VERIFY_FORCE_FAIL;
                 }
-                else if (XSTRNCMP(myoptarg, "verifyInfo", 10) == 0) {
+                else if (XSTRCMP(myoptarg, "verifyInfo") == 0) {
                     printf("Verify should not override error\n");
                     myVerifyAction = VERIFY_USE_PREVERFIY;
                 }
-                else if (XSTRNCMP(myoptarg, "useSupCurve", 11) == 0) {
+                else if (XSTRCMP(myoptarg, "useSupCurve") == 0) {
                     printf("Attempting to test use supported curve\n");
                 #if defined(HAVE_ECC) && defined(HAVE_SUPPORTED_CURVES)
                     useSupCurve = 1;
@@ -2272,7 +2247,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                     printf("Supported curves not compiled in!\n");
                 #endif
                 }
-                else if (XSTRNCMP(myoptarg, "loadSSL", 7) == 0) {
+                else if (XSTRCMP(myoptarg, "loadSSL") == 0) {
                     printf("Load cert/key into wolfSSL object\n");
                 #ifndef NO_CERTS
                     loadCertKeyIntoSSLObj = 1;
@@ -2280,7 +2255,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                     printf("Certs turned off with NO_CERTS!\n");
                 #endif
                 }
-                else if (XSTRNCMP(myoptarg, "disallowETM", 7) == 0) {
+                else if (XSTRCMP(myoptarg, "disallowETM") == 0) {
                     printf("Disallow Encrypt-Then-MAC\n");
                 #ifdef HAVE_ENCRYPT_THEN_MAC
                     disallowETM = 1;
@@ -2359,7 +2334,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 #ifdef HAVE_SECURE_RENEGOTIATION
                     scr      = 1;
                     forceScr = 1;
-                    if (XSTRNCMP(myoptarg, "scr-app-data", 12) == 0) {
+                    if (XSTRCMP(myoptarg, "scr-app-data") == 0) {
                         scrAppData = 1;
                     }
                 #endif
@@ -2372,7 +2347,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 break;
 
             case 'S' :
-                if (XSTRNCMP(myoptarg, "check", 5) == 0) {
+                if (XSTRCMP(myoptarg, "check") == 0) {
                 #ifdef HAVE_SNI
                     printf("SNI is: ON\n");
                 #else
@@ -2470,7 +2445,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 doSTARTTLS = 1;
                 starttlsProt = myoptarg;
 
-                if (XSTRNCMP(starttlsProt, "smtp", 4) != 0) {
+                if (XSTRCMP(starttlsProt, "smtp") != 0) {
                     Usage();
                     XEXIT_T(MY_EX_USAGE);
                 }
@@ -2679,7 +2654,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             done += 1; /* require RSA for external tests */
         #endif
 
-        if (!XSTRNCMP(domain, "www.globalsign.com", 14)) {
+        if (!XSTRCMP(domain, "www.globalsign.com")) {
         /* www.globalsign.com does not respond to ipv6 ocsp requests */
         #if defined(TEST_IPV6) && defined(HAVE_OCSP)
             done += 1;
@@ -2713,18 +2688,18 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
             || ( defined(HAVE_ECC) && !defined(HAVE_SUPPORTED_CURVES) \
                   && !defined(WOLFSSL_STATIC_RSA) )
             /* google needs ECDHE+Supported Curves or static RSA */
-            if (!XSTRNCMP(domain, "www.google.com", 14))
+            if (!XSTRCASECMP(domain, "www.google.com"))
                 done += 1;
         #endif
 
         #if !defined(HAVE_ECC) && !defined(WOLFSSL_STATIC_RSA)
             /* wolfssl needs ECDHE or static RSA */
-            if (!XSTRNCMP(domain, "www.wolfssl.com", 15))
+            if (!XSTRCASECMP(domain, "www.wolfssl.com"))
                 done += 1;
         #endif
 
         #if !defined(WOLFSSL_SHA384)
-            if (!XSTRNCMP(domain, "www.wolfssl.com", 15)) {
+            if (!XSTRCASECMP(domain, "www.wolfssl.com")) {
                 /* wolfssl need sha384 for cert chain verify */
                 done += 1;
             }
@@ -2740,7 +2715,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
          * connection. They only currently support AES suites, RC4 and 3DES
          * suites. With AES disabled we only offer PolyChacha suites. */
         #if defined(NO_AES) && !defined(HAVE_AESGCM)
-            if (!XSTRNCMP(domain, "www.wolfssl.com", 15)) {
+            if (!XSTRCASECMP(domain, "www.wolfssl.com")) {
                 done += 1;
             }
         #endif
@@ -3813,7 +3788,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif
 
     if (doSTARTTLS && starttlsProt != NULL) {
-        if (XSTRNCMP(starttlsProt, "smtp", 4) == 0) {
+        if (XSTRCMP(starttlsProt, "smtp") == 0) {
             if (SMTP_Shutdown(ssl, wc_shutdown) != WOLFSSL_SUCCESS) {
                 wolfSSL_free(ssl); ssl = NULL;
                 wolfSSL_CTX_free(ctx); ctx = NULL;

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -638,107 +638,82 @@ static void SetKeyShare(WOLFSSL* ssl, int onlyKeyShare, int useX25519,
         else if (usePqc == 1) {
     #ifdef HAVE_PQC
             groups[count] = 0;
-            if (XSTRNCMP(pqcAlg, "KYBER_LEVEL1", XSTRLEN("KYBER_LEVEL1")) == 0) {
+            if (XSTRCMP(pqcAlg, "KYBER_LEVEL1") == 0) {
                 groups[count] = WOLFSSL_KYBER_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "KYBER_LEVEL3",
-                                XSTRLEN("KYBER_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "KYBER_LEVEL3") == 0) {
                 groups[count] = WOLFSSL_KYBER_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "KYBER_LEVEL5",
-                                XSTRLEN("KYBER_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "KYBER_LEVEL5") == 0) {
                 groups[count] = WOLFSSL_KYBER_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "NTRU_HPS_LEVEL1",
-                                XSTRLEN("NTRU_HPS_LEVEL1")) == 0)  {
+            else if (XSTRCMP(pqcAlg, "NTRU_HPS_LEVEL1") == 0)  {
                 groups[count] = WOLFSSL_NTRU_HPS_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "NTRU_HPS_LEVEL3",
-                                XSTRLEN("NTRU_HPS_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "NTRU_HPS_LEVEL3") == 0) {
                 groups[count] = WOLFSSL_NTRU_HPS_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "NTRU_HPS_LEVEL5",
-                                XSTRLEN("NTRU_HPS_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "NTRU_HPS_LEVEL5") == 0) {
                 groups[count] = WOLFSSL_NTRU_HPS_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "NTRU_HRSS_LEVEL3",
-                                XSTRLEN("NTRU_HRSS_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "NTRU_HRSS_LEVEL3") == 0) {
                 groups[count] = WOLFSSL_NTRU_HRSS_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "SABER_LEVEL1",
-                                XSTRLEN("SABER_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "SABER_LEVEL1") == 0) {
                 groups[count] = WOLFSSL_SABER_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "SABER_LEVEL3",
-                                XSTRLEN("SABER_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "SABER_LEVEL3") == 0) {
                 groups[count] = WOLFSSL_SABER_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "SABER_LEVEL5",
-                                XSTRLEN("SABER_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "SABER_LEVEL5") == 0) {
                 groups[count] = WOLFSSL_SABER_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "KYBER_90S_LEVEL1",
-                                XSTRLEN("KYBER_90S_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "KYBER_90S_LEVEL1") == 0) {
                 groups[count] = WOLFSSL_KYBER_90S_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "KYBER_90S_LEVEL3",
-                                XSTRLEN("KYBER_90S_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "KYBER_90S_LEVEL3") == 0) {
                 groups[count] = WOLFSSL_KYBER_90S_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "KYBER_90S_LEVEL5",
-                                XSTRLEN("KYBER_90S_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "KYBER_90S_LEVEL5") == 0) {
                 groups[count] = WOLFSSL_KYBER_90S_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "P256_NTRU_HPS_LEVEL1",
-                                XSTRLEN("P256_NTRU_HPS_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P256_NTRU_HPS_LEVEL1") == 0) {
                 groups[count] = WOLFSSL_P256_NTRU_HPS_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "P384_NTRU_HPS_LEVEL3",
-                                XSTRLEN("P384_NTRU_HPS_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P384_NTRU_HPS_LEVEL3") == 0) {
                 groups[count] = WOLFSSL_P384_NTRU_HPS_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "P521_NTRU_HPS_LEVEL5",
-                                XSTRLEN("P521_NTRU_HPS_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P521_NTRU_HPS_LEVEL5") == 0) {
                 groups[count] = WOLFSSL_P521_NTRU_HPS_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "P384_NTRU_HRSS_LEVEL3",
-                                XSTRLEN("P384_NTRU_HRSS_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P384_NTRU_HRSS_LEVEL3") == 0) {
                 groups[count] = WOLFSSL_P384_NTRU_HRSS_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "P256_SABER_LEVEL1",
-                                XSTRLEN("P256_SABER_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P256_SABER_LEVEL1") == 0) {
                 groups[count] = WOLFSSL_P256_SABER_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "P384_SABER_LEVEL3",
-                                XSTRLEN("P384_SABER_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P384_SABER_LEVEL3") == 0) {
                 groups[count] = WOLFSSL_P384_SABER_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "P521_SABER_LEVEL5",
-                                XSTRLEN("P521_SABER_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P521_SABER_LEVEL5") == 0) {
                 groups[count] = WOLFSSL_P521_SABER_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "P256_KYBER_LEVEL1",
-                                XSTRLEN("P256_KYBER_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P256_KYBER_LEVEL1") == 0) {
                 groups[count] = WOLFSSL_P256_KYBER_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "P384_KYBER_LEVEL3",
-                                XSTRLEN("P384_KYBER_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P384_KYBER_LEVEL3") == 0) {
                 groups[count] = WOLFSSL_P384_KYBER_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "P521_KYBER_LEVEL5",
-                                XSTRLEN("P521_KYBER_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P521_KYBER_LEVEL5") == 0) {
                 groups[count] = WOLFSSL_P521_KYBER_LEVEL5;
             }
-            else if (XSTRNCMP(pqcAlg, "P256_KYBER_90S_LEVEL1",
-                                XSTRLEN("P256_KYBER_90S_LEVEL1")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P256_KYBER_90S_LEVEL1") == 0) {
                 groups[count] = WOLFSSL_P256_KYBER_90S_LEVEL1;
             }
-            else if (XSTRNCMP(pqcAlg, "P384_KYBER_90S_LEVEL3",
-                                XSTRLEN("P384_KYBER_90S_LEVEL3")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P384_KYBER_90S_LEVEL3") == 0) {
                 groups[count] = WOLFSSL_P384_KYBER_90S_LEVEL3;
             }
-            else if (XSTRNCMP(pqcAlg, "P521_KYBER_90S_LEVEL5",
-                                XSTRLEN("P521_KYBER_90S_LEVEL5")) == 0) {
+            else if (XSTRCMP(pqcAlg, "P521_KYBER_90S_LEVEL5") == 0) {
                 groups[count] = WOLFSSL_P521_KYBER_90S_LEVEL5;
             }
 
@@ -1743,41 +1718,41 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                 break;
 
             case 'H' :
-                if (XSTRNCMP(myoptarg, "defCipherList", 13) == 0) {
+                if (XSTRCMP(myoptarg, "defCipherList") == 0) {
                     printf("Using default cipher list for testing\n");
                     useDefCipherList = 1;
                 }
-                else if (XSTRNCMP(myoptarg, "exitWithRet", 11) == 0) {
+                else if (XSTRCMP(myoptarg, "exitWithRet") == 0) {
                     printf("Skip exit() for testing\n");
                     exitWithRet = 1;
                 }
-                else if (XSTRNCMP(myoptarg, "verifyFail", 10) == 0) {
+                else if (XSTRCMP(myoptarg, "verifyFail") == 0) {
                     printf("Verify should fail\n");
                     myVerifyAction = VERIFY_FORCE_FAIL;
                 }
-                else if (XSTRNCMP(myoptarg, "verifyInfo", 10) == 0) {
+                else if (XSTRCMP(myoptarg, "verifyInfo") == 0) {
                     printf("Verify should use preverify (just show info)\n");
                     myVerifyAction = VERIFY_USE_PREVERFIY;
                 }
-                else if (XSTRNCMP(myoptarg, "loadSSL", 7) == 0) {
+                else if (XSTRCMP(myoptarg, "loadSSL") == 0) {
                     printf("Also load cert/key into wolfSSL object\n");
                 #ifndef NO_CERTS
                     loadCertKeyIntoSSLObj = 2;
                 #endif
                 }
-                else if (XSTRNCMP(myoptarg, "loadSSLOnly", 11) == 0) {
+                else if (XSTRCMP(myoptarg, "loadSSLOnly") == 0) {
                     printf("Only load cert/key into wolfSSL object\n");
                 #ifndef NO_CERTS
                     loadCertKeyIntoSSLObj = 1;
                 #endif
                 }
-                else if (XSTRNCMP(myoptarg, "disallowETM", 11) == 0) {
+                else if (XSTRCMP(myoptarg, "disallowETM") == 0) {
                     printf("Disallow Encrypt-Then-MAC\n");
                 #ifdef HAVE_ENCRYPT_THEN_MAC
                     disallowETM = 1;
                 #endif
                 }
-                else if (XSTRNCMP(myoptarg, "overrideDateErr", 15) == 0) {
+                else if (XSTRCMP(myoptarg, "overrideDateErr") == 0) {
                 #if !defined(NO_FILESYSTEM) && !defined(NO_CERTS)
                     myVerifyAction = VERIFY_OVERRIDE_DATE_ERR;
                 #endif
@@ -1951,16 +1926,16 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
                     #endif
                     }
                 #if !defined(WOLFSSL_NO_TLS12) || !defined(NO_OLD_TLS)
-                    else if (XSTRNCMP(myoptarg, "a", 2) == 0) {
+                    else if (XSTRCMP(myoptarg, "a") == 0) {
                         noTicketTls12 = 1;
                     #if defined(WOLFSSL_TLS13)
                         noTicketTls13 = 1;
                     #endif
                     }
-                    else if (XSTRNCMP(myoptarg, "o", 2) == 0) {
+                    else if (XSTRCMP(myoptarg, "o") == 0) {
                         noTicketTls12 = 1;
                     }
-                    else if (XSTRNCMP(myoptarg, "n", 2) == 0) {
+                    else if (XSTRCMP(myoptarg, "n") == 0) {
                     #if defined(WOLFSSL_TLS13)
                         noTicketTls13 = 1;
                     #endif

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -227,8 +227,17 @@
     #ifndef __ARCH_MEMMOVE_NO_REDIRECT
         typeof(memmove) *memmove;
     #endif
+    #ifndef __ARCH_STRCMP_NO_REDIRECT
+        typeof(strcmp) *strcmp;
+    #endif
     #ifndef __ARCH_STRNCMP_NO_REDIRECT
         typeof(strncmp) *strncmp;
+    #endif
+    #ifndef __ARCH_STRCASECMP_NO_REDIRECT
+        typeof(strcasecmp) *strcasecmp;
+    #endif
+    #ifndef __ARCH_STRNCASECMP_NO_REDIRECT
+        typeof(strncasecmp) *strncasecmp;
     #endif
     #ifndef __ARCH_STRLEN_NO_REDIRECT
         typeof(strlen) *strlen;
@@ -241,9 +250,6 @@
     #endif
     #ifndef __ARCH_STRNCAT_NO_REDIRECT
         typeof(strncat) *strncat;
-    #endif
-    #ifndef __ARCH_STRNCASECMP_NO_REDIRECT
-        typeof(strncasecmp) *strncasecmp;
     #endif
         typeof(kstrtoll) *kstrtoll;
 
@@ -355,8 +361,17 @@
     #ifndef __ARCH_MEMMOVE_NO_REDIRECT
         #define memmove (wolfssl_linuxkm_get_pie_redirect_table()->memmove)
     #endif
+    #ifndef __ARCH_STRCMP_NO_REDIRECT
+        #define strcmp (wolfssl_linuxkm_get_pie_redirect_table()->strcmp)
+    #endif
     #ifndef __ARCH_STRNCMP_NO_REDIRECT
         #define strncmp (wolfssl_linuxkm_get_pie_redirect_table()->strncmp)
+    #endif
+    #ifndef __ARCH_STRCASECMP_NO_REDIRECT
+        #define strcasecmp (wolfssl_linuxkm_get_pie_redirect_table()->strcasecmp)
+    #endif
+    #ifndef __ARCH_STRNCASECMP_NO_REDIRECT
+        #define strncasecmp (wolfssl_linuxkm_get_pie_redirect_table()->strncasecmp)
     #endif
     #ifndef __ARCH_STRLEN_NO_REDIRECT
         #define strlen (wolfssl_linuxkm_get_pie_redirect_table()->strlen)
@@ -369,9 +384,6 @@
     #endif
     #ifndef __ARCH_STRNCAT_NO_REDIRECT
         #define strncat (wolfssl_linuxkm_get_pie_redirect_table()->strncat)
-    #endif
-    #ifndef __ARCH_STRNCASECMP_NO_REDIRECT
-        #define strncasecmp (wolfssl_linuxkm_get_pie_redirect_table()->strncasecmp)
     #endif
     #define kstrtoll (wolfssl_linuxkm_get_pie_redirect_table()->kstrtoll)
 

--- a/linuxkm/module_hooks.c
+++ b/linuxkm/module_hooks.c
@@ -350,8 +350,17 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
 #ifndef __ARCH_MEMMOVE_NO_REDIRECT
     wolfssl_linuxkm_pie_redirect_table.memmove = memmove;
 #endif
+#ifndef __ARCH_STRCMP_NO_REDIRECT
+    wolfssl_linuxkm_pie_redirect_table.strcmp = strcmp;
+#endif
 #ifndef __ARCH_STRNCMP_NO_REDIRECT
     wolfssl_linuxkm_pie_redirect_table.strncmp = strncmp;
+#endif
+#ifndef __ARCH_STRCASECMP_NO_REDIRECT
+    wolfssl_linuxkm_pie_redirect_table.strcasecmp = strcasecmp;
+#endif
+#ifndef __ARCH_STRNCASECMP_NO_REDIRECT
+    wolfssl_linuxkm_pie_redirect_table.strncasecmp = strncasecmp;
 #endif
 #ifndef __ARCH_STRLEN_NO_REDIRECT
     wolfssl_linuxkm_pie_redirect_table.strlen = strlen;
@@ -364,9 +373,6 @@ static int set_up_wolfssl_linuxkm_pie_redirect_table(void) {
 #endif
 #ifndef __ARCH_STRNCAT_NO_REDIRECT
     wolfssl_linuxkm_pie_redirect_table.strncat = strncat;
-#endif
-#ifndef __ARCH_STRNCASECMP_NO_REDIRECT
-    wolfssl_linuxkm_pie_redirect_table.strncasecmp = strncasecmp;
 #endif
     wolfssl_linuxkm_pie_redirect_table.kstrtoll = kstrtoll;
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -21344,7 +21344,7 @@ const char* GetCipherKeaStr(char n[][MAX_SEGMENT_SZ]) {
 
     if (XSTRCMP(n[0],"ECDHE") == 0 && XSTRCMP(n[1],"PSK") == 0)
         keaStr = "ECDHEPSK";
-    else if (XSTRCMP(n[0],"ECDHE") == 0)
+    else if ((XSTRCMP(n[0],"ECDH") == 0) || (XSTRCMP(n[0],"ECDHE") == 0))
         keaStr = "ECDH";
     else if (XSTRCMP(n[0],"DHE") == 0 && XSTRCMP(n[1],"PSK") == 0)
         keaStr = "DHEPSK";

--- a/src/internal.c
+++ b/src/internal.c
@@ -21341,33 +21341,27 @@ const char* GetCipherSegment(const WOLFSSL_CIPHER* cipher, char n[][MAX_SEGMENT_
 
 const char* GetCipherKeaStr(char n[][MAX_SEGMENT_SZ]) {
     const char* keaStr = NULL;
-    const char *n0,*n1,*n2,*n3,*n4;
-    n0 = n[0];
-    n1 = n[1];
-    n2 = n[2];
-    n3 = n[3];
-    n4 = n[4];
 
-    if (XSTRNCMP(n0,"ECDHE",5) == 0 && XSTRNCMP(n1,"PSK",3) == 0)
+    if (XSTRCMP(n[0],"ECDHE") == 0 && XSTRCMP(n[1],"PSK") == 0)
         keaStr = "ECDHEPSK";
-    else if (XSTRNCMP(n0,"ECDH",4) == 0)
+    else if (XSTRCMP(n[0],"ECDHE") == 0)
         keaStr = "ECDH";
-    else if (XSTRNCMP(n0,"DHE",3) == 0 && XSTRNCMP(n1,"PSK",3) == 0)
+    else if (XSTRCMP(n[0],"DHE") == 0 && XSTRCMP(n[1],"PSK") == 0)
         keaStr = "DHEPSK";
-    else if (XSTRNCMP(n0,"DHE",3) == 0)
+    else if (XSTRCMP(n[0],"DHE") == 0)
         keaStr = "DH";
-   else if (XSTRNCMP(n0,"RSA",3) == 0 && XSTRNCMP(n1,"PSK",3) == 0)
+    else if (XSTRCMP(n[0],"RSA") == 0 && XSTRCMP(n[1],"PSK") == 0)
         keaStr = "RSAPSK";
-    else if (XSTRNCMP(n0,"SRP",3) == 0)
+    else if (XSTRCMP(n[0],"SRP") == 0)
         keaStr = "SRP";
-    else if (XSTRNCMP(n0,"PSK",3) == 0)
+    else if (XSTRCMP(n[0],"PSK") == 0)
         keaStr = "PSK";
-    else if (XSTRNCMP(n0,"EDH",3) == 0)
+    else if (XSTRCMP(n[0],"EDH") == 0)
         keaStr = "EDH";
-    else if ((XSTRNCMP(n1,"SHA",3) == 0) || (XSTRNCMP(n2,"SHA",3) == 0) ||
-             (XSTRNCMP(n3,"SHA",3) == 0) || (XSTRNCMP(n4,"SHA",3) == 0) ||
-             (XSTRNCMP(n2,"RSA",3) == 0) || (XSTRNCMP(n0,"AES128",6) == 0) ||
-             (XSTRNCMP(n0,"AES256",6) == 0) || (XSTRNCMP(n1,"MD5",3) == 0))
+    else if ((XSTRCMP(n[1],"SHA") == 0) || (XSTRCMP(n[2],"SHA") == 0) ||
+             (XSTRCMP(n[3],"SHA") == 0) || (XSTRCMP(n[4],"SHA") == 0) ||
+             (XSTRCMP(n[2],"RSA") == 0) || (XSTRCMP(n[0],"AES128") == 0) ||
+             (XSTRCMP(n[0],"AES256") == 0) || (XSTRCMP(n[1],"MD5") == 0))
         keaStr = "RSA";
     else
         keaStr = "unknown";
@@ -21375,28 +21369,25 @@ const char* GetCipherKeaStr(char n[][MAX_SEGMENT_SZ]) {
     return keaStr;
 }
 
+
 const char* GetCipherAuthStr(char n[][MAX_SEGMENT_SZ]) {
 
     const char* authStr = NULL;
-    const char *n0,*n1,*n2;
-    n0 = n[0];
-    n1 = n[1];
-    n2 = n[2];
 
-    if ((XSTRNCMP(n0,"AES128",6) == 0) || (XSTRNCMP(n0,"AES256",6) == 0)  ||
-        ((XSTRNCMP(n0,"TLS13",5) == 0) && ((XSTRNCMP(n1,"AES128",6) == 0) ||
-         (XSTRNCMP(n1,"AES256",6) == 0) || (XSTRNCMP(n1,"CHACHA20",8) == 0))) ||
-        (XSTRNCMP(n0,"RSA",3) == 0) || (XSTRNCMP(n1,"RSA",3) == 0) ||
-        (XSTRNCMP(n1,"SHA",3) == 0) || (XSTRNCMP(n2,"SHA",3) == 0) ||
-        (XSTRNCMP(n1,"MD5",3) == 0))
+    if ((XSTRCMP(n[0],"AES128") == 0) || (XSTRCMP(n[0],"AES256") == 0)  ||
+        ((XSTRCMP(n[0],"TLS13") == 0) && ((XSTRCMP(n[1],"AES128") == 0) ||
+         (XSTRCMP(n[1],"AES256") == 0) || (XSTRCMP(n[1],"CHACHA20") == 0))) ||
+        (XSTRCMP(n[0],"RSA") == 0) || (XSTRCMP(n[1],"RSA") == 0) ||
+        (XSTRCMP(n[1],"SHA") == 0) || (XSTRCMP(n[2],"SHA") == 0) ||
+        (XSTRCMP(n[1],"MD5") == 0))
         authStr = "RSA";
-    else if (XSTRNCMP(n0,"PSK",3) == 0 || XSTRNCMP(n1,"PSK",3) == 0)
+    else if (XSTRCMP(n[0],"PSK") == 0 || XSTRCMP(n[1],"PSK") == 0)
         authStr = "PSK";
-    else if (XSTRNCMP(n0,"SRP",3) == 0 && XSTRNCMP(n1,"AES",3) == 0)
+    else if (XSTRCMP(n[0],"SRP") == 0 && XSTRCMP(n[1],"AES") == 0)
         authStr = "SRP";
-    else if (XSTRNCMP(n1,"ECDSA",5) == 0)
+    else if (XSTRCMP(n[1],"ECDSA") == 0)
         authStr = "ECDSA";
-    else if (XSTRNCMP(n0,"ADH",3) == 0)
+    else if (XSTRCMP(n[0],"ADH") == 0)
         authStr = "None";
     else
         authStr = "unknown";
@@ -21406,75 +21397,69 @@ const char* GetCipherAuthStr(char n[][MAX_SEGMENT_SZ]) {
 
 const char* GetCipherEncStr(char n[][MAX_SEGMENT_SZ]) {
     const char* encStr = NULL;
-    const char *n0,*n1,*n2,*n3;
-    n0 = n[0];
-    n1 = n[1];
-    n2 = n[2];
-    n3 = n[3];
 
-    if ((XSTRNCMP(n0,"AES256",6) == 0 && XSTRNCMP(n1,"GCM",3) == 0) ||
-        (XSTRNCMP(n1,"AES256",6) == 0 && XSTRNCMP(n2,"GCM",3) == 0) ||
-        (XSTRNCMP(n2,"AES256",6) == 0 && XSTRNCMP(n3,"GCM",3) == 0))
+    if ((XSTRCMP(n[0],"AES256") == 0 && XSTRCMP(n[1],"GCM") == 0) ||
+        (XSTRCMP(n[1],"AES256") == 0 && XSTRCMP(n[2],"GCM") == 0) ||
+        (XSTRCMP(n[2],"AES256") == 0 && XSTRCMP(n[3],"GCM") == 0))
         encStr = "AESGCM(256)";
 
-    else if ((XSTRNCMP(n0,"AES128",6) == 0 && XSTRNCMP(n1,"GCM",3) == 0) ||
-             (XSTRNCMP(n1,"AES128",6) == 0 && XSTRNCMP(n2,"GCM",3) == 0) ||
-             (XSTRNCMP(n2,"AES128",6) == 0 && XSTRNCMP(n3,"GCM",3) == 0))
+    else if ((XSTRCMP(n[0],"AES128") == 0 && XSTRCMP(n[1],"GCM") == 0) ||
+             (XSTRCMP(n[1],"AES128") == 0 && XSTRCMP(n[2],"GCM") == 0) ||
+             (XSTRCMP(n[2],"AES128") == 0 && XSTRCMP(n[3],"GCM") == 0))
         encStr = "AESGCM(128)";
 
-    else if ((XSTRNCMP(n0,"AES128",6) == 0 && XSTRNCMP(n1,"CCM",3) == 0) ||
-             (XSTRNCMP(n1,"AES128",6) == 0 && XSTRNCMP(n2,"CCM",3) == 0) ||
-             (XSTRNCMP(n2,"AES128",6) == 0 && XSTRNCMP(n3,"CCM",3) == 0))
+    else if ((XSTRCMP(n[0],"AES128") == 0 && XSTRCMP(n[1],"CCM") == 0) ||
+             (XSTRCMP(n[1],"AES128") == 0 && XSTRCMP(n[2],"CCM") == 0) ||
+             (XSTRCMP(n[2],"AES128") == 0 && XSTRCMP(n[3],"CCM") == 0))
         encStr = "AESCCM(128)";
 
-    else if ((XSTRNCMP(n0,"AES128",6) == 0) ||
-             (XSTRNCMP(n1,"AES128",6) == 0) ||
-             (XSTRNCMP(n2,"AES128",6) == 0) ||
-             (XSTRNCMP(n1,"AES",3) == 0 && XSTRNCMP(n2,"128",3) == 0) ||
-             (XSTRNCMP(n2,"AES",3) == 0 && XSTRNCMP(n3,"128",3) == 0))
+    else if ((XSTRCMP(n[0],"AES128") == 0) ||
+             (XSTRCMP(n[1],"AES128") == 0) ||
+             (XSTRCMP(n[2],"AES128") == 0) ||
+             (XSTRCMP(n[1],"AES") == 0 && XSTRCMP(n[2],"128") == 0) ||
+             (XSTRCMP(n[2],"AES") == 0 && XSTRCMP(n[3],"128") == 0))
         encStr = "AES(128)";
 
-    else if ((XSTRNCMP(n0,"AES256",6) == 0) ||
-             (XSTRNCMP(n1,"AES256",6) == 0) ||
-             (XSTRNCMP(n2,"AES256",6) == 0) ||
-             (XSTRNCMP(n1,"AES",3) == 0 && XSTRNCMP(n2,"256",3) == 0) ||
-             (XSTRNCMP(n2,"AES",3) == 0 && XSTRNCMP(n3,"256",3) == 0))
+    else if ((XSTRCMP(n[0],"AES256") == 0) ||
+             (XSTRCMP(n[1],"AES256") == 0) ||
+             (XSTRCMP(n[2],"AES256") == 0) ||
+             (XSTRCMP(n[1],"AES") == 0 && XSTRCMP(n[2],"256") == 0) ||
+             (XSTRCMP(n[2],"AES") == 0 && XSTRCMP(n[3],"256") == 0))
         encStr = "AES(256)";
 
-    else if ((XSTRNCMP(n0,"CAMELLIA256",11) == 0) ||
-             (XSTRNCMP(n2,"CAMELLIA256",11) == 0))
+    else if ((XSTRCMP(n[0],"CAMELLIA256") == 0) ||
+             (XSTRCMP(n[2],"CAMELLIA256") == 0))
         encStr = "CAMELLIA(256)";
-    else if ((XSTRNCMP(n0,"CAMELLIA128",11) == 0) ||
-             (XSTRNCMP(n2,"CAMELLIA128",11) == 0))
+    else if ((XSTRCMP(n[0],"CAMELLIA128") == 0) ||
+             (XSTRCMP(n[2],"CAMELLIA128") == 0))
         encStr = "CAMELLIA(128)";
-    else if ((XSTRNCMP(n0,"RC4",3) == 0) || (XSTRNCMP(n1,"RC4",3) == 0) ||
-            (XSTRNCMP(n2,"RC4",3) == 0))
+    else if ((XSTRCMP(n[0],"RC4") == 0) || (XSTRCMP(n[1],"RC4") == 0) ||
+            (XSTRCMP(n[2],"RC4") == 0))
         encStr = "RC4";
-    else if (((XSTRNCMP(n0,"DES",3) == 0)  || (XSTRNCMP(n1,"DES",3) == 0) ||
-              (XSTRNCMP(n2,"DES",3) == 0)) &&
-             ((XSTRNCMP(n1,"CBC3",4) == 0) || (XSTRNCMP(n2,"CBC3",4) == 0) ||
-              (XSTRNCMP(n3,"CBC3",4) == 0)))
+    else if (((XSTRCMP(n[0],"DES") == 0)  || (XSTRCMP(n[1],"DES") == 0) ||
+              (XSTRCMP(n[2],"DES") == 0)) &&
+             ((XSTRCMP(n[1],"CBC3") == 0) || (XSTRCMP(n[2],"CBC3") == 0) ||
+              (XSTRCMP(n[3],"CBC3") == 0)))
         encStr = "3DES";
-    else if ((XSTRNCMP(n1,"CHACHA20",8) == 0 && XSTRNCMP(n2,"POLY1305",8) == 0) ||
-             (XSTRNCMP(n2,"CHACHA20",8) == 0 && XSTRNCMP(n3,"POLY1305",8) == 0))
+    else if ((XSTRCMP(n[1],"CHACHA20") == 0 && XSTRCMP(n[2],"POLY1305") == 0) ||
+             (XSTRCMP(n[2],"CHACHA20") == 0 && XSTRCMP(n[3],"POLY1305") == 0))
         encStr = "CHACHA20/POLY1305(256)";
-    else if ((XSTRNCMP(n0,"NULL",4) == 0) || (XSTRNCMP(n1,"NULL",4) == 0) ||
-             (XSTRNCMP(n2,"NULL",4) == 0) ||
-             ((XSTRNCMP(n0,"TLS13",5) == 0) && (XSTRNCMP(n3,"",0) == 0)))
+    else if ((XSTRCMP(n[0],"NULL") == 0) || (XSTRCMP(n[1],"NULL") == 0) ||
+             (XSTRCMP(n[2],"NULL") == 0) ||
+             ((XSTRCMP(n[0],"TLS13") == 0) && (XSTRCMP(n[3],"") == 0)))
         encStr = "None";
     else
         encStr = "unknown";
 
     return encStr;
 }
+
 /* Check if a cipher is AEAD
  * @param n return segment cipher name
  * return 1 if the cipher is AEAD, otherwise 0
  */
 int IsCipherAEAD(char n[][MAX_SEGMENT_SZ])
 {
-    const char *n1,*n2,*n3;
-
     WOLFSSL_ENTER("IsCipherAEAD");
 
     if (n == NULL) {
@@ -21482,45 +21467,37 @@ int IsCipherAEAD(char n[][MAX_SEGMENT_SZ])
         return 0;
     }
 
-    n1 = n[1];
-    n2 = n[2];
-    n3 = n[3];
-
-    if ((XSTRNCMP(n2,"GCM",3) == 0) || (XSTRNCMP(n3,"GCM",3) == 0) ||
-        (XSTRNCMP(n1,"CCM",3) == 0) ||
-        (XSTRNCMP(n2,"CCM",3) == 0) || (XSTRNCMP(n3,"CCM",3) == 0) ||
-        (XSTRNCMP(n1,"CHACHA20",8) == 0 && XSTRNCMP(n2,"POLY1305",8) == 0) ||
-        (XSTRNCMP(n2,"CHACHA20",8) == 0 && XSTRNCMP(n3,"POLY1305",8) == 0))
+    if ((XSTRCMP(n[2],"GCM") == 0) || (XSTRCMP(n[3],"GCM") == 0) ||
+        (XSTRCMP(n[1],"CCM") == 0) ||
+        (XSTRCMP(n[2],"CCM") == 0) || (XSTRCMP(n[3],"CCM") == 0) ||
+        (XSTRCMP(n[1],"CHACHA20") == 0 && XSTRCMP(n[2],"POLY1305") == 0) ||
+        (XSTRCMP(n[2],"CHACHA20") == 0 && XSTRCMP(n[3],"POLY1305") == 0))
         return 1;
     return 0;
 }
+
 /* Returns the MAC string of a cipher or "unknown" on failure */
 const char* GetCipherMacStr(char n[][MAX_SEGMENT_SZ]) {
 
     const char* macStr = NULL;
-    const char *n1,*n2,*n3,*n4;
-    n1 = n[1];
-    n2 = n[2];
-    n3 = n[3];
-    n4 = n[4];
 
-    if ((XSTRNCMP(n4,"SHA256",6) == 0) || (XSTRNCMP(n3,"SHA256",6) == 0) ||
-        (XSTRNCMP(n2,"SHA256",6) == 0) || (XSTRNCMP(n1,"SHA256",6) == 0))
+    if ((XSTRCMP(n[4],"SHA256") == 0) || (XSTRCMP(n[3],"SHA256") == 0) ||
+        (XSTRCMP(n[2],"SHA256") == 0) || (XSTRCMP(n[1],"SHA256") == 0))
         macStr = "SHA256";
-    else if ((XSTRNCMP(n4,"SHA384",6) == 0) ||
-             (XSTRNCMP(n3,"SHA384",6) == 0) ||
-             (XSTRNCMP(n2,"SHA384",6) == 0) ||
-             (XSTRNCMP(n1,"SHA384",6) == 0))
+    else if ((XSTRCMP(n[4],"SHA384") == 0) ||
+             (XSTRCMP(n[3],"SHA384") == 0) ||
+             (XSTRCMP(n[2],"SHA384") == 0) ||
+             (XSTRCMP(n[1],"SHA384") == 0))
         macStr = "SHA384";
-    else if ((XSTRNCMP(n4,"SHA",3) == 0) || (XSTRNCMP(n3,"SHA",3) == 0) ||
-             (XSTRNCMP(n2,"SHA",3) == 0) || (XSTRNCMP(n1,"SHA",3) == 0) ||
-             (XSTRNCMP(n1,"MD5",3) == 0))
+    else if ((XSTRCMP(n[4],"SHA") == 0) || (XSTRCMP(n[3],"SHA") == 0) ||
+             (XSTRCMP(n[2],"SHA") == 0) || (XSTRCMP(n[1],"SHA") == 0) ||
+             (XSTRCMP(n[1],"MD5") == 0))
         macStr = "SHA1";
-    else if ((XSTRNCMP(n3,"GCM",3) == 0) ||
-             (XSTRNCMP(n1,"CCM",3) == 0) ||
-             (XSTRNCMP(n2,"CCM",3) == 0) || (XSTRNCMP(n3,"CCM",3) == 0) ||
-             (XSTRNCMP(n1,"CHACHA20",8) == 0 && XSTRNCMP(n2,"POLY1305",8) == 0) ||
-             (XSTRNCMP(n2,"CHACHA20",8) == 0 && XSTRNCMP(n3,"POLY1305",8) == 0))
+    else if ((XSTRCMP(n[3],"GCM") == 0) ||
+             (XSTRCMP(n[1],"CCM") == 0) ||
+             (XSTRCMP(n[2],"CCM") == 0) || (XSTRCMP(n[3],"CCM") == 0) ||
+             (XSTRCMP(n[1],"CHACHA20") == 0 && XSTRCMP(n[2],"POLY1305") == 0) ||
+             (XSTRCMP(n[2],"CHACHA20") == 0 && XSTRCMP(n[3],"POLY1305") == 0))
         macStr = "AEAD";
     else
         macStr = "unknown";
@@ -21532,22 +21509,22 @@ const char* GetCipherMacStr(char n[][MAX_SEGMENT_SZ]) {
 int SetCipherBits(const char* enc) {
     int ret = WOLFSSL_FAILURE;
 
-    if ((XSTRNCMP(enc,"AESGCM(256)",11) == 0) ||
-        (XSTRNCMP(enc,"AES(256)",8) == 0) ||
-        (XSTRNCMP(enc,"CAMELLIA(256)",13) == 0) ||
-        (XSTRNCMP(enc,"CHACHA20/POLY1305(256)",22) == 0))
+    if ((XSTRCMP(enc,"AESGCM(256)") == 0) ||
+        (XSTRCMP(enc,"AES(256)") == 0) ||
+        (XSTRCMP(enc,"CAMELLIA(256)") == 0) ||
+        (XSTRCMP(enc,"CHACHA20/POLY1305(256)") == 0))
             ret = 256;
     else if
-        ((XSTRNCMP(enc,"3DES",4) == 0))
+        ((XSTRCMP(enc,"3DES") == 0))
             ret = 168;
     else if
-        ((XSTRNCMP(enc,"AESGCM(128)",11) == 0) ||
-         (XSTRNCMP(enc,"AES(128)",8) == 0) ||
-         (XSTRNCMP(enc,"CAMELLIA(128)",13) == 0) ||
-         (XSTRNCMP(enc,"RC4",3) == 0))
+        ((XSTRCMP(enc,"AESGCM(128)") == 0) ||
+         (XSTRCMP(enc,"AES(128)") == 0) ||
+         (XSTRCMP(enc,"CAMELLIA(128)") == 0) ||
+         (XSTRCMP(enc,"RC4") == 0))
             ret = 128;
    else if
-        ((XSTRNCMP(enc,"DES",3) == 0))
+        ((XSTRCMP(enc,"DES") == 0))
             ret = 56;
 
     return ret;
@@ -21644,19 +21621,19 @@ int SetCipherList(WOLFSSL_CTX* ctx, Suites* suites, const char* list)
     int       haveFalconSig = 0;
     int       haveAnon      = 0;
     const int suiteSz       = GetCipherNamesSize();
-    char*     next          = (char*)list;
+    const char* next        = list;
 
     if (suites == NULL || list == NULL) {
         WOLFSSL_MSG("SetCipherList parameter error");
         return 0;
     }
 
-    if (next[0] == 0 || XSTRNCMP(next, "ALL", 3) == 0 ||
-        XSTRNCMP(next, "DEFAULT", 7) == 0 || XSTRNCMP(next, "HIGH", 4) == 0)
+    if (next[0] == 0 || XSTRCMP(next, "ALL") == 0 ||
+        XSTRCMP(next, "DEFAULT") == 0 || XSTRCMP(next, "HIGH") == 0)
         return 1; /* wolfSSL default */
 
     do {
-        char*  current = next;
+        const char* current = next;
         char   name[MAX_SUITE_NAME + 1];
         int    i;
         word32 length;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -11005,7 +11005,7 @@ static char* buildEnabledCipherList(WOLFSSL_CTX* ctx, Suites* suites,
         else
             continue;
 
-        if (XSTRNCMP(enabledcs, "None", XSTRLEN(enabledcs)) != 0) {
+        if (XSTRCMP(enabledcs, "None") != 0) {
             len += (word32)XSTRLEN(enabledcs) + 2;
         }
     }
@@ -17619,61 +17619,61 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         }
 
 #ifndef NO_MD5
-        if (XSTRNCMP(evp_md, "MD5", 3) == 0) {
+        if (XSTRCMP(evp_md, "MD5") == 0) {
             type = WC_MD5;
             mdlen = WC_MD5_DIGEST_SIZE;
         } else
 #endif
 #ifdef WOLFSSL_SHA224
-        if (XSTRNCMP(evp_md, "SHA224", 6) == 0) {
+        if (XSTRCMP(evp_md, "SHA224") == 0) {
             type = WC_SHA224;
             mdlen = WC_SHA224_DIGEST_SIZE;
         } else
 #endif
 #ifndef NO_SHA256
-        if (XSTRNCMP(evp_md, "SHA256", 6) == 0) {
+        if (XSTRCMP(evp_md, "SHA256") == 0) {
             type = WC_SHA256;
             mdlen = WC_SHA256_DIGEST_SIZE;
         } else
 #endif
 #ifdef WOLFSSL_SHA384
-        if (XSTRNCMP(evp_md, "SHA384", 6) == 0) {
+        if (XSTRCMP(evp_md, "SHA384") == 0) {
             type = WC_SHA384;
             mdlen = WC_SHA384_DIGEST_SIZE;
         } else
 #endif
 #ifdef WOLFSSL_SHA512
-        if (XSTRNCMP(evp_md, "SHA512", 6) == 0) {
+        if (XSTRCMP(evp_md, "SHA512") == 0) {
             type = WC_SHA512;
             mdlen = WC_SHA512_DIGEST_SIZE;
         } else
 #endif
 #ifdef WOLFSSL_SHA3
     #ifndef WOLFSSL_NOSHA3_224
-        if (XSTRNCMP(evp_md, "SHA3_224", 8) == 0) {
+        if (XSTRCMP(evp_md, "SHA3_224") == 0) {
             type = WC_SHA3_224;
             mdlen = WC_SHA3_224_DIGEST_SIZE;
         } else
     #endif
     #ifndef WOLFSSL_NOSHA3_256
-        if (XSTRNCMP(evp_md, "SHA3_256", 8) == 0) {
+        if (XSTRCMP(evp_md, "SHA3_256") == 0) {
             type = WC_SHA3_256;
             mdlen = WC_SHA3_256_DIGEST_SIZE;
         } else
     #endif
-        if (XSTRNCMP(evp_md, "SHA3_384", 8) == 0) {
+        if (XSTRCMP(evp_md, "SHA3_384") == 0) {
             type = WC_SHA3_384;
             mdlen = WC_SHA3_384_DIGEST_SIZE;
         } else
     #ifndef WOLFSSL_NOSHA3_512
-        if (XSTRNCMP(evp_md, "SHA3_512", 8) == 0) {
+        if (XSTRCMP(evp_md, "SHA3_512") == 0) {
             type = WC_SHA3_512;
             mdlen = WC_SHA3_512_DIGEST_SIZE;
         } else
     #endif
 #endif
 #ifndef NO_SHA
-        if (XSTRNCMP(evp_md, "SHA", 3) == 0) {
+        if (XSTRCMP(evp_md, "SHA") == 0) {
             type = WC_SHA;
             mdlen = WC_SHA_DIGEST_SIZE;
         } else
@@ -20717,7 +20717,7 @@ int wolfSSL_CIPHER_get_auth_nid(const WOLFSSL_CIPHER* cipher)
 
     if (authStr != NULL) {
         for(sa = authnid_tbl; sa->alg_name != NULL; sa++) {
-            if (XSTRNCMP(sa->alg_name, authStr, XSTRLEN(sa->alg_name)) == 0) {
+            if (XSTRCMP(sa->alg_name, authStr) == 0) {
                 return sa->nid;
             }
         }
@@ -20764,7 +20764,7 @@ int wolfSSL_CIPHER_get_cipher_nid(const WOLFSSL_CIPHER* cipher)
 
     if (encStr != NULL) {
         for(c = ciphernid_tbl; c->alg_name != NULL; c++) {
-            if (XSTRNCMP(c->alg_name, encStr, XSTRLEN(c->alg_name)) == 0) {
+            if (XSTRCMP(c->alg_name, encStr) == 0) {
                 return c->nid;
             }
         }
@@ -20810,7 +20810,7 @@ int wolfSSL_CIPHER_get_digest_nid(const WOLFSSL_CIPHER* cipher)
 
     if (macStr != NULL) {
         for(mc = macnid_tbl; mc->alg_name != NULL; mc++) {
-            if (XSTRNCMP(mc->alg_name, macStr, XSTRLEN(mc->alg_name)) == 0) {
+            if (XSTRCMP(mc->alg_name, macStr) == 0) {
                 return mc->nid;
             }
         }
@@ -20824,7 +20824,7 @@ int wolfSSL_CIPHER_get_digest_nid(const WOLFSSL_CIPHER* cipher)
  */
 int wolfSSL_CIPHER_get_kx_nid(const WOLFSSL_CIPHER* cipher)
 {
-static const struct kxnid {
+    static const struct kxnid {
         const char* name;
         const int  nid;
     } kxnid_table[] = {
@@ -20840,20 +20840,18 @@ static const struct kxnid {
     };
 
     const struct kxnid* k;
-    const char* name;
     const char* keaStr;
     char n[MAX_SEGMENTS][MAX_SEGMENT_SZ] = {{0}};
-    (void)name;
 
     WOLFSSL_ENTER("wolfSSL_CIPHER_get_kx_nid");
 
-    if ((name = GetCipherSegment(cipher, n)) == NULL) {
+    if (GetCipherSegment(cipher, n) == NULL) {
         WOLFSSL_MSG("no suitable cipher name found");
         return NID_undef;
     }
 
     /* in TLS 1.3 case, NID will be NID_kx_any */
-    if (XSTRNCMP(name, "TLS13", 5) == 0) {
+    if (XSTRCMP(n[0], "TLS13") == 0) {
         return NID_kx_any;
     }
 
@@ -20861,8 +20859,7 @@ static const struct kxnid {
 
     if (keaStr != NULL) {
         for(k = kxnid_table; k->name != NULL; k++) {
-            if (XSTRNCMP(k->name, keaStr, XSTRLEN(k->name)) == 0) {
-                printf("k->name %s k->nid %d\n", k->name, k->nid);
+            if (XSTRCMP(k->name, keaStr) == 0) {
                 return k->nid;
             }
         }
@@ -29641,35 +29638,42 @@ int wolfSSL_HMAC_Init(WOLFSSL_HMAC_CTX* ctx, const void* key, int keylen,
         WOLFSSL_MSG("init has type");
 
 #ifndef NO_MD5
-        if (XSTRNCMP(type, "MD5", 3) == 0) {
+        if (XSTRCMP(type, "MD5") == 0) {
             WOLFSSL_MSG("md5 hmac");
             ctx->type = WC_MD5;
         }
         else
 #endif
+#ifndef NO_SHA
+        if ((XSTRCMP(type, "SHA") == 0) || (XSTRCMP(type, "SHA1") == 0)) {
+            WOLFSSL_MSG("sha hmac");
+            ctx->type = WC_SHA;
+        }
+        else
+#endif
 #ifdef WOLFSSL_SHA224
-        if (XSTRNCMP(type, "SHA224", 6) == 0) {
+        if (XSTRCMP(type, "SHA224") == 0) {
             WOLFSSL_MSG("sha224 hmac");
             ctx->type = WC_SHA224;
         }
         else
 #endif
 #ifndef NO_SHA256
-        if (XSTRNCMP(type, "SHA256", 6) == 0) {
+        if (XSTRCMP(type, "SHA256") == 0) {
             WOLFSSL_MSG("sha256 hmac");
             ctx->type = WC_SHA256;
         }
         else
 #endif
 #ifdef WOLFSSL_SHA384
-        if (XSTRNCMP(type, "SHA384", 6) == 0) {
+        if (XSTRCMP(type, "SHA384") == 0) {
             WOLFSSL_MSG("sha384 hmac");
             ctx->type = WC_SHA384;
         }
         else
 #endif
 #ifdef WOLFSSL_SHA512
-        if (XSTRNCMP(type, "SHA512", 6) == 0) {
+        if (XSTRCMP(type, "SHA512") == 0) {
             WOLFSSL_MSG("sha512 hmac");
             ctx->type = WC_SHA512;
         }
@@ -29677,40 +29681,31 @@ int wolfSSL_HMAC_Init(WOLFSSL_HMAC_CTX* ctx, const void* key, int keylen,
 #endif
 #ifdef WOLFSSL_SHA3
     #ifndef WOLFSSL_NOSHA3_224
-        if (XSTRNCMP(type, "SHA3_224", 8) == 0) {
+        if (XSTRCMP(type, "SHA3_224") == 0) {
             WOLFSSL_MSG("sha3_224 hmac");
             ctx->type = WC_SHA3_224;
         }
         else
     #endif
     #ifndef WOLFSSL_NOSHA3_256
-        if (XSTRNCMP(type, "SHA3_256", 8) == 0) {
+        if (XSTRCMP(type, "SHA3_256") == 0) {
             WOLFSSL_MSG("sha3_256 hmac");
             ctx->type = WC_SHA3_256;
         }
         else
     #endif
-        if (XSTRNCMP(type, "SHA3_384", 8) == 0) {
+        if (XSTRCMP(type, "SHA3_384") == 0) {
             WOLFSSL_MSG("sha3_384 hmac");
             ctx->type = WC_SHA3_384;
         }
         else
     #ifndef WOLFSSL_NOSHA3_512
-        if (XSTRNCMP(type, "SHA3_512", 8) == 0) {
+        if (XSTRCMP(type, "SHA3_512") == 0) {
             WOLFSSL_MSG("sha3_512 hmac");
             ctx->type = WC_SHA3_512;
         }
         else
     #endif
-#endif
-
-#ifndef NO_SHA
-        /* has to be last since would pick or 256, 384, or 512 too */
-        if (XSTRNCMP(type, "SHA", 3) == 0) {
-            WOLFSSL_MSG("sha hmac");
-            ctx->type = WC_SHA;
-        }
-        else
 #endif
         {
             WOLFSSL_MSG("bad init type");
@@ -37380,7 +37375,7 @@ int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
         const struct oid_dict* idx;
 
         for (idx = oid_dict; idx->num != NULL; idx++) {
-            if (!XSTRNCMP(oid, idx->num, XSTRLEN(idx->num))) {
+            if (!XSTRCMP(oid, idx->num)) {
                 return idx->desc;
             }
         }
@@ -38016,7 +38011,7 @@ int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
 #if defined(WOLFSSL_CERT_EXT) && defined(WOLFSSL_CERT_GEN)
     WOLFSSL_ASN1_OBJECT* wolfSSL_OBJ_txt2obj(const char* s, int no_name)
     {
-        int len, i, ret;
+        int i, ret;
         int nid = NID_undef;
         unsigned int outSz = MAX_OID_SZ;
         unsigned char out[MAX_OID_SZ];
@@ -38052,15 +38047,16 @@ int wolfSSL_ASN1_STRING_canon(WOLFSSL_ASN1_STRING* asn_out,
             return obj;
         }
 
-        len = (int)XSTRLEN(s);
-
         /* TODO: update short names in wolfssl_object_info and check OID sums
            are correct */
         for (i = 0; i < (int)WOLFSSL_OBJECT_INFO_SZ; i++) {
             /* Short name, long name, and numerical value are interpreted */
-            if (no_name == 0 && ((XSTRNCMP(s, wolfssl_object_info[i].sName, len) == 0) ||
-                                 (XSTRNCMP(s, wolfssl_object_info[i].lName, len) == 0)))
+            if (no_name == 0 &&
+                ((XSTRCMP(s, wolfssl_object_info[i].sName) == 0) ||
+                 (XSTRCMP(s, wolfssl_object_info[i].lName) == 0)))
+            {
                     nid = wolfssl_object_info[i].nid;
+            }
         }
 
         if (nid != NID_undef)
@@ -42013,23 +42009,28 @@ int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, const char* names)
         XMEMCPY(name, names + start, len);
         name[len] = 0;
 
-        if ((XSTRNCMP(name, "prime256v1", len) == 0) ||
-                                      (XSTRNCMP(name, "secp256r1", len) == 0) ||
-                                      (XSTRNCMP(name, "P-256", len) == 0)) {
+        if ((XSTRCMP(name, "prime256v1") == 0) ||
+            (XSTRCMP(name, "secp256r1") == 0) ||
+            (XSTRCMP(name, "P-256") == 0))
+        {
             curve = WOLFSSL_ECC_SECP256R1;
         }
-        else if ((XSTRNCMP(name, "secp384r1", len) == 0) ||
-                                          (XSTRNCMP(name, "P-384", len) == 0)) {
+        else if ((XSTRCMP(name, "secp384r1") == 0) ||
+                 (XSTRCMP(name, "P-384") == 0))
+        {
             curve = WOLFSSL_ECC_SECP384R1;
         }
-        else if ((XSTRNCMP(name, "secp521r1", len) == 0) ||
-                                          (XSTRNCMP(name, "P-521", len) == 0)) {
+        else if ((XSTRCMP(name, "secp521r1") == 0) ||
+                 (XSTRCMP(name, "P-521") == 0))
+        {
             curve = WOLFSSL_ECC_SECP521R1;
         }
-        else if (XSTRNCMP(name, "X25519", len) == 0) {
+        else if (XSTRCMP(name, "X25519") == 0)
+        {
             curve = WOLFSSL_ECC_X25519;
         }
-        else if (XSTRNCMP(name, "X448", len) == 0) {
+        else if (XSTRCMP(name, "X448") == 0)
+        {
             curve = WOLFSSL_ECC_X448;
         }
         else {

--- a/src/tls.c
+++ b/src/tls.c
@@ -168,7 +168,7 @@ int BuildTlsHandshakeHash(WOLFSSL* ssl, byte* hash, word32* hashLen)
 int BuildTlsFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
 {
     int ret;
-    const byte* side;
+    const byte* side = NULL;
     word32 hashSz = HSHASH_SZ;
 #if defined(WOLFSSL_ASYNC_CRYPT) && !defined(WC_ASYNC_NO_HASH)
     WC_DECLARE_VAR(handshake_hash, byte, HSHASH_SZ, ssl->heap);

--- a/src/tls.c
+++ b/src/tls.c
@@ -182,9 +182,16 @@ int BuildTlsFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
     if (ret == 0) {
         if (XSTRNCMP((const char*)sender, (const char*)client, SIZEOF_SENDER) == 0)
             side = tls_client;
-        else
+        else if (XSTRNCMP((const char*)sender, (const char*)server, SIZEOF_SENDER)
+                 == 0)
             side = tls_server;
+        else {
+            ret = BAD_FUNC_ARG;
+            WOLFSSL_MSG("Unexpected sender value");
+        }
+    }
 
+    if (ret == 0) {
 #ifdef WOLFSSL_HAVE_PRF
 #if !defined(NO_CERTS) && defined(HAVE_PK_CALLBACKS)
         if (ssl->ctx->TlsFinishedCb) {

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -9472,10 +9472,10 @@ const char* wolfSSL_get_cipher_name_by_hash(WOLFSSL* ssl, const char* hash)
     byte mac = no_mac;
     int i;
 
-    if (XSTRNCMP(hash, "SHA256", 6) == 0) {
+    if (XSTRCMP(hash, "SHA256") == 0) {
         mac = sha256_mac;
     }
-    else if (XSTRNCMP(hash, "SHA384", 6) == 0) {
+    else if (XSTRCMP(hash, "SHA384") == 0) {
         mac = sha384_mac;
     }
     if (mac != no_mac) {

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -3840,19 +3840,16 @@ int wc_ecc_get_curve_size_from_id(int curve_id)
 int wc_ecc_get_curve_idx_from_name(const char* curveName)
 {
     int curve_idx;
-    word32 len;
 
     if (curveName == NULL)
         return BAD_FUNC_ARG;
-
-    len = (word32)XSTRLEN(curveName);
 
     for (curve_idx = 0; ecc_sets[curve_idx].size != 0; curve_idx++) {
         if (
         #ifndef WOLFSSL_ECC_CURVE_STATIC
             ecc_sets[curve_idx].name &&
         #endif
-                XSTRNCASECMP(ecc_sets[curve_idx].name, curveName, len) == 0) {
+                XSTRCASECMP(ecc_sets[curve_idx].name, curveName) == 0) {
             break;
         }
     }

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -3083,7 +3083,7 @@ static enum wc_HashType EvpMd2MacType(const WOLFSSL_EVP_MD *md)
 
     if (md != NULL) {
         for (ent = md_tbl; ent->name != NULL; ent++) {
-            if (XSTRNCMP((const char *)md, ent->name, XSTRLEN(ent->name)+1) == 0) {
+            if (XSTRCMP((const char *)md, ent->name) == 0) {
                 return ent->macType;
             }
         }
@@ -3323,58 +3323,58 @@ static int wolfSSL_evp_digest_pk_init(WOLFSSL_EVP_MD_CTX *ctx,
         int                  hashType;
         const unsigned char* key;
 
-        if (XSTRNCMP(type, "SHA256", 6) == 0) {
+    #ifndef NO_SHA256
+        if (XSTRCMP(type, "SHA256") == 0) {
             hashType = WC_SHA256;
-        }
+        } else
+    #endif
+    #ifndef NO_SHA
+        if ((XSTRCMP(type, "SHA") == 0) || (XSTRCMP(type, "SHA1") == 0)) {
+            hashType = WC_SHA;
+        } else
+    #endif /* NO_SHA */
     #ifdef WOLFSSL_SHA224
-        else if (XSTRNCMP(type, "SHA224", 6) == 0) {
+        if (XSTRCMP(type, "SHA224") == 0) {
             hashType = WC_SHA224;
-        }
+        } else
     #endif
     #ifdef WOLFSSL_SHA384
-        else if (XSTRNCMP(type, "SHA384", 6) == 0) {
+        if (XSTRCMP(type, "SHA384") == 0) {
             hashType = WC_SHA384;
-        }
+        } else
     #endif
     #ifdef WOLFSSL_SHA512
-        else if (XSTRNCMP(type, "SHA512", 6) == 0) {
+        if (XSTRCMP(type, "SHA512") == 0) {
             hashType = WC_SHA512;
-        }
+        } else
     #endif
 #ifdef WOLFSSL_SHA3
     #ifndef WOLFSSL_NOSHA3_224
-        else if (XSTRNCMP(type, "SHA3_224", 8) == 0) {
+        if (XSTRCMP(type, "SHA3_224") == 0) {
             hashType = WC_SHA3_224;
-        }
+        } else
     #endif
     #ifndef WOLFSSL_NOSHA3_256
-        else if (XSTRNCMP(type, "SHA3_256", 8) == 0) {
+        if (XSTRCMP(type, "SHA3_256") == 0) {
             hashType = WC_SHA3_256;
-        }
+        } else
     #endif
     #ifndef WOLFSSL_NOSHA3_384
-        else if (XSTRNCMP(type, "SHA3_384", 8) == 0) {
+        if (XSTRCMP(type, "SHA3_384") == 0) {
             hashType = WC_SHA3_384;
-        }
+        } else
     #endif
     #ifndef WOLFSSL_NOSHA3_512
-        else if (XSTRNCMP(type, "SHA3_512", 8) == 0) {
+        if (XSTRCMP(type, "SHA3_512") == 0) {
             hashType = WC_SHA3_512;
-        }
+        } else
     #endif
 #endif
     #ifndef NO_MD5
-        else if (XSTRNCMP(type, "MD5", 3) == 0) {
+        if (XSTRCMP(type, "MD5") == 0) {
             hashType = WC_MD5;
-        }
+        } else
     #endif
-    #ifndef NO_SHA
-        /* has to be last since would pick or 224, 256, 384, or 512 too */
-        else if (XSTRNCMP(type, "SHA", 3) == 0) {
-            hashType = WC_SHA;
-        }
-    #endif /* NO_SHA */
-        else
              return BAD_FUNC_ARG;
 
         {
@@ -4091,7 +4091,7 @@ int wolfSSL_EVP_CIPHER_nid(const WOLFSSL_EVP_CIPHER *cipher)
     }
 
     for (c = cipher_tbl; c->type != 0; c++) {
-        if (XSTRNCMP(cipher, c->name, XSTRLEN(c->name)+1) == 0) {
+        if (XSTRCMP(cipher, c->name) == 0) {
             return c->nid;
         }
     }
@@ -4167,7 +4167,7 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbyname(const char *name)
 
     for (al = cipher_alias_tbl; al->name != NULL; al++) {
         /* Accept any case alternative version of an alias. */
-        if (XSTRNCASECMP(name, al->alias, XSTRLEN(al->alias)+1) == 0) {
+        if (XSTRCASECMP(name, al->alias) == 0) {
             name = al->name;
             break;
         }
@@ -4175,7 +4175,7 @@ const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbyname(const char *name)
 
     for (ent = cipher_tbl; ent->name != NULL; ent++) {
         /* Accept any case alternative version of name. */
-        if (XSTRNCASECMP(name, ent->name, XSTRLEN(ent->name)+1) == 0) {
+        if (XSTRCASECMP(name, ent->name) == 0) {
             return (WOLFSSL_EVP_CIPHER *)ent->name;
         }
     }
@@ -4342,13 +4342,13 @@ const WOLFSSL_EVP_MD *wolfSSL_EVP_get_digestbyname(const char *name)
 
     name = nameUpper;
     for (al = digest_alias_tbl; al->name != NULL; al++)
-        if(XSTRNCMP(name, al->alias, XSTRLEN(al->alias)+1) == 0) {
+        if(XSTRCMP(name, al->alias) == 0) {
             name = al->name;
             break;
         }
 
     for (ent = md_tbl; ent->name != NULL; ent++)
-        if(XSTRNCMP(name, ent->name, XSTRLEN(ent->name)+1) == 0) {
+        if(XSTRCMP(name, ent->name) == 0) {
             return (EVP_MD *)ent->name;
         }
     return NULL;
@@ -4371,7 +4371,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
     }
 
     for( ent = md_tbl; ent->name != NULL; ent++){
-        if(XSTRNCMP((const char *)type, ent->name, XSTRLEN(ent->name)+1) == 0) {
+        if(XSTRCMP((const char *)type, ent->name) == 0) {
             return ent->nid;
         }
     }
@@ -4802,7 +4802,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
         const struct alias  *al;
 
         for (al = digest_alias_tbl; al->name != NULL; al++)
-            if(XSTRNCMP(n, al->name, XSTRLEN(al->name)+1) == 0) {
+            if(XSTRCMP(n, al->name) == 0) {
                 aliasnm = al->alias;
                 break;
             }
@@ -6897,76 +6897,77 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
         ctx->macType = EvpMd2MacType(md);
         if (md == NULL) {
              XMEMSET(&ctx->hash.digest, 0, sizeof(WOLFSSL_Hasher));
-        }
-        else if (XSTRNCMP(md, "SHA256", 6) == 0) {
+        } else
+    #ifndef NO_SHA
+        if ((XSTRCMP(md, "SHA") == 0) || (XSTRCMP(md, "SHA1") == 0)) {
+             ret = wolfSSL_SHA_Init(&(ctx->hash.digest.sha));
+        } else
+    #endif
+    #ifndef NO_SHA256
+        if (XSTRCMP(md, "SHA256") == 0) {
              ret = wolfSSL_SHA256_Init(&(ctx->hash.digest.sha256));
-        }
+        } else
+    #endif
     #ifdef WOLFSSL_SHA224
-        else if (XSTRNCMP(md, "SHA224", 6) == 0) {
+        if (XSTRCMP(md, "SHA224") == 0) {
              ret = wolfSSL_SHA224_Init(&(ctx->hash.digest.sha224));
-        }
+        } else
     #endif
     #ifdef WOLFSSL_SHA384
-        else if (XSTRNCMP(md, "SHA384", 6) == 0) {
+        if (XSTRCMP(md, "SHA384") == 0) {
              ret = wolfSSL_SHA384_Init(&(ctx->hash.digest.sha384));
-        }
+        } else
     #endif
     #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && \
         defined(WOLFSSL_SHA512) && !defined(WOLFSSL_NOSHA512_224)
-        else if (XSTRNCMP(md, "SHA512_224", 10) == 0) {
+        if (XSTRCMP(md, "SHA512_224") == 0) {
              ret = wolfSSL_SHA512_224_Init(&(ctx->hash.digest.sha512));
-        }
+        } else
     #endif
     #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && \
         defined(WOLFSSL_SHA512) && !defined(WOLFSSL_NOSHA512_256)
-        else if (XSTRNCMP(md, "SHA512_256", 10) == 0) {
+        if (XSTRCMP(md, "SHA512_256") == 0) {
              ret = wolfSSL_SHA512_256_Init(&(ctx->hash.digest.sha512));
-        }
+        } else
     #endif
     #ifdef WOLFSSL_SHA512
-        else if (XSTRNCMP(md, "SHA512", 6) == 0) {
+        if (XSTRCMP(md, "SHA512") == 0) {
              ret = wolfSSL_SHA512_Init(&(ctx->hash.digest.sha512));
-        }
+        } else
     #endif
     #ifndef NO_MD4
-        else if (XSTRNCMP(md, "MD4", 3) == 0) {
+        if (XSTRCMP(md, "MD4") == 0) {
             wolfSSL_MD4_Init(&(ctx->hash.digest.md4));
-        }
+        } else
     #endif
     #ifndef NO_MD5
-        else if (XSTRNCMP(md, "MD5", 3) == 0) {
+        if (XSTRCMP(md, "MD5") == 0) {
             ret = wolfSSL_MD5_Init(&(ctx->hash.digest.md5));
-        }
+        } else
     #endif
 #ifdef WOLFSSL_SHA3
     #ifndef WOLFSSL_NOSHA3_224
-        else if (XSTRNCMP(md, "SHA3_224", 8) == 0) {
+        if (XSTRCMP(md, "SHA3_224") == 0) {
              ret = wolfSSL_SHA3_224_Init(&(ctx->hash.digest.sha3_224));
-        }
+        } else
     #endif
     #ifndef WOLFSSL_NOSHA3_256
-        else if (XSTRNCMP(md, "SHA3_256", 8) == 0) {
+        if (XSTRCMP(md, "SHA3_256") == 0) {
              ret = wolfSSL_SHA3_256_Init(&(ctx->hash.digest.sha3_256));
-        }
+        } else
     #endif
     #ifndef WOLFSSL_NOSHA3_384
-        else if (XSTRNCMP(md, "SHA3_384", 8) == 0) {
+        if (XSTRCMP(md, "SHA3_384") == 0) {
              ret = wolfSSL_SHA3_384_Init(&(ctx->hash.digest.sha3_384));
-        }
+        } else
     #endif
     #ifndef WOLFSSL_NOSHA3_512
-        else if (XSTRNCMP(md, "SHA3_512", 8) == 0) {
+        if (XSTRCMP(md, "SHA3_512") == 0) {
              ret = wolfSSL_SHA3_512_Init(&(ctx->hash.digest.sha3_512));
-        }
+        } else
     #endif
 #endif
-    #ifndef NO_SHA
-        /* has to be last since would pick or 224, 256, 384, or 512 too */
-        else if (XSTRNCMP(md, "SHA", 3) == 0) {
-             ret = wolfSSL_SHA_Init(&(ctx->hash.digest.sha));
-        }
-    #endif /* NO_SHA */
-        else {
+        {
              ctx->macType = WC_HASH_TYPE_NONE;
              return BAD_FUNC_ARG;
         }
@@ -7952,62 +7953,63 @@ int wolfSSL_EVP_MD_block_size(const WOLFSSL_EVP_MD* type)
         return BAD_FUNC_ARG;
     }
 
-    if (XSTRNCMP(type, "SHA256", 6) == 0) {
+#ifndef NO_SHA
+    if ((XSTRCMP(type, "SHA") == 0) || (XSTRCMP(type, "SHA1") == 0)) {
+        return WC_SHA_BLOCK_SIZE;
+    } else
+#endif
+#ifndef NO_SHA256
+    if (XSTRCMP(type, "SHA256") == 0) {
         return WC_SHA256_BLOCK_SIZE;
-    }
+    } else
+#endif
 #ifndef NO_MD4
-    else if (XSTRNCMP(type, "MD4", 3) == 0) {
+    if (XSTRCMP(type, "MD4") == 0) {
         return MD4_BLOCK_SIZE;
-    }
+    } else
 #endif
 #ifndef NO_MD5
-    else if (XSTRNCMP(type, "MD5", 3) == 0) {
+    if (XSTRCMP(type, "MD5") == 0) {
         return WC_MD5_BLOCK_SIZE;
-    }
+    } else
 #endif
 #ifdef WOLFSSL_SHA224
-    else if (XSTRNCMP(type, "SHA224", 6) == 0) {
+    if (XSTRCMP(type, "SHA224") == 0) {
         return WC_SHA224_BLOCK_SIZE;
-    }
+    } else
 #endif
 #ifdef WOLFSSL_SHA384
-    else if (XSTRNCMP(type, "SHA384", 6) == 0) {
+    if (XSTRCMP(type, "SHA384") == 0) {
         return WC_SHA384_BLOCK_SIZE;
-    }
+    } else
 #endif
 #ifdef WOLFSSL_SHA512
-    else if (XSTRNCMP(type, "SHA512", 6) == 0) {
+    if (XSTRCMP(type, "SHA512") == 0) {
         return WC_SHA512_BLOCK_SIZE;
-    }
+    } else
 #endif
 #ifdef WOLFSSL_SHA3
 #ifndef WOLFSSL_NOSHA3_224
-    else if (XSTRNCMP(type, "SHA3_224", 8) == 0) {
+    if (XSTRCMP(type, "SHA3_224") == 0) {
         return WC_SHA3_224_BLOCK_SIZE;
-    }
+    } else
 #endif
 #ifndef WOLFSSL_NOSHA3_256
-    else if (XSTRNCMP(type, "SHA3_256", 8) == 0) {
+    if (XSTRCMP(type, "SHA3_256") == 0) {
         return WC_SHA3_256_BLOCK_SIZE;
-    }
+    } else
 #endif
 #ifndef WOLFSSL_NOSHA3_384
-    else if (XSTRNCMP(type, "SHA3_384", 8) == 0) {
+    if (XSTRCMP(type, "SHA3_384") == 0) {
         return WC_SHA3_384_BLOCK_SIZE;
-    }
+    } else
 #endif
 #ifndef WOLFSSL_NOSHA3_512
-    else if (XSTRNCMP(type, "SHA3_512", 8) == 0) {
+    if (XSTRCMP(type, "SHA3_512") == 0) {
         return WC_SHA3_512_BLOCK_SIZE;
     }
 #endif
 #endif /* WOLFSSL_SHA3 */
-#ifndef NO_SHA
-    /* has to be last since would pick or 256, 384, 512, or SHA3 too */
-    else if (XSTRNCMP(type, "SHA", 3) == 0) {
-        return WC_SHA_BLOCK_SIZE;
-    }
-#endif
 
     return BAD_FUNC_ARG;
 }
@@ -8021,62 +8023,73 @@ int wolfSSL_EVP_MD_size(const WOLFSSL_EVP_MD* type)
         return BAD_FUNC_ARG;
     }
 
-    if (XSTRNCMP(type, "SHA256", 6) == 0) {
+#ifndef NO_SHA
+    if ((XSTRCMP(type, "SHA") == 0) || (XSTRCMP(type, "SHA1") == 0)) {
+        return WC_SHA_DIGEST_SIZE;
+    } else
+#endif
+#ifndef NO_SHA256
+    if (XSTRCMP(type, "SHA256") == 0) {
         return WC_SHA256_DIGEST_SIZE;
-    }
+    } else
+#endif
 #ifndef NO_MD4
-    else if (XSTRNCMP(type, "MD4", 3) == 0) {
+    if (XSTRCMP(type, "MD4") == 0) {
         return MD4_DIGEST_SIZE;
-    }
+    } else
 #endif
 #ifndef NO_MD5
-    else if (XSTRNCMP(type, "MD5", 3) == 0) {
+    if (XSTRCMP(type, "MD5") == 0) {
         return WC_MD5_DIGEST_SIZE;
-    }
+    } else
 #endif
 #ifdef WOLFSSL_SHA224
-    else if (XSTRNCMP(type, "SHA224", 6) == 0) {
+    if (XSTRCMP(type, "SHA224") == 0) {
         return WC_SHA224_DIGEST_SIZE;
-    }
+    } else
 #endif
 #ifdef WOLFSSL_SHA384
-    else if (XSTRNCMP(type, "SHA384", 6) == 0) {
+    if (XSTRCMP(type, "SHA384") == 0) {
         return WC_SHA384_DIGEST_SIZE;
-    }
+    } else
 #endif
 #ifdef WOLFSSL_SHA512
-    else if (XSTRNCMP(type, "SHA512", 6) == 0) {
+    if (XSTRCMP(type, "SHA512") == 0) {
         return WC_SHA512_DIGEST_SIZE;
-    }
+    } else
+#ifndef WOLFSSL_NOSHA512_224
+    if (XSTRCMP(type, "SHA512_224") == 0) {
+        return WC_SHA512_224_DIGEST_SIZE;
+    } else
+#endif
+#ifndef WOLFSSL_NOSHA512_256
+    if (XSTRCMP(type, "SHA512_256") == 0) {
+        return WC_SHA512_256_DIGEST_SIZE;
+    } else
+#endif
 #endif
 #ifdef WOLFSSL_SHA3
 #ifndef WOLFSSL_NOSHA3_224
-    else if (XSTRNCMP(type, "SHA3_224", 8) == 0) {
+    if (XSTRCMP(type, "SHA3_224") == 0) {
         return WC_SHA3_224_DIGEST_SIZE;
-    }
+    } else
 #endif
 #ifndef WOLFSSL_NOSHA3_256
-    else if (XSTRNCMP(type, "SHA3_256", 8) == 0) {
+    if (XSTRCMP(type, "SHA3_256") == 0) {
         return WC_SHA3_256_DIGEST_SIZE;
-    }
+    } else
 #endif
 #ifndef WOLFSSL_NOSHA3_384
-    else if (XSTRNCMP(type, "SHA3_384", 8) == 0) {
+    if (XSTRCMP(type, "SHA3_384") == 0) {
         return WC_SHA3_384_DIGEST_SIZE;
-    }
+    } else
 #endif
 #ifndef WOLFSSL_NOSHA3_512
-    else if (XSTRNCMP(type, "SHA3_512", 8) == 0) {
+    if (XSTRCMP(type, "SHA3_512") == 0) {
         return WC_SHA3_512_DIGEST_SIZE;
     }
 #endif
 #endif /* WOLFSSL_SHA3 */
-#ifndef NO_SHA
-    /* has to be last since would pick or 256, 384, or 512 too */
-    else if (XSTRNCMP(type, "SHA", 3) == 0) {
-        return WC_SHA_DIGEST_SIZE;
-    }
-#endif
 
     return BAD_FUNC_ARG;
 }
@@ -8088,22 +8101,22 @@ int wolfSSL_EVP_MD_pkey_type(const WOLFSSL_EVP_MD* type)
     WOLFSSL_ENTER("wolfSSL_EVP_MD_pkey_type");
 
     if (type != NULL) {
-        if (XSTRNCMP(type, "MD5", 3) == 0) {
+        if (XSTRCMP(type, "MD5") == 0) {
             ret = NID_md5WithRSAEncryption;
         }
-        else if (XSTRNCMP(type, "SHA1", 4) == 0) {
+        else if (XSTRCMP(type, "SHA1") == 0) {
             ret = NID_sha1WithRSAEncryption;
         }
-        else if (XSTRNCMP(type, "SHA224", 6) == 0) {
+        else if (XSTRCMP(type, "SHA224") == 0) {
             ret = NID_sha224WithRSAEncryption;
         }
-        else if (XSTRNCMP(type, "SHA256", 6) == 0) {
+        else if (XSTRCMP(type, "SHA256") == 0) {
             ret = NID_sha256WithRSAEncryption;
         }
-        else if (XSTRNCMP(type, "SHA384", 6) == 0) {
+        else if (XSTRCMP(type, "SHA384") == 0) {
             ret = NID_sha384WithRSAEncryption;
         }
-        else if (XSTRNCMP(type, "SHA512", 6) == 0) {
+        else if (XSTRCMP(type, "SHA512") == 0) {
             ret = NID_sha512WithRSAEncryption;
         }
     }
@@ -8214,15 +8227,15 @@ int wolfSSL_EVP_CIPHER_iv_length(const WOLFSSL_EVP_CIPHER* cipher)
 #ifndef NO_AES
 #if defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_DIRECT)
     #ifdef WOLFSSL_AES_128
-    if (XSTRNCMP(name, EVP_AES_128_CBC, XSTRLEN(EVP_AES_128_CBC)) == 0)
+    if (XSTRCMP(name, EVP_AES_128_CBC) == 0)
         return AES_BLOCK_SIZE;
     #endif
     #ifdef WOLFSSL_AES_192
-    if (XSTRNCMP(name, EVP_AES_192_CBC, XSTRLEN(EVP_AES_192_CBC)) == 0)
+    if (XSTRCMP(name, EVP_AES_192_CBC) == 0)
         return AES_BLOCK_SIZE;
     #endif
     #ifdef WOLFSSL_AES_256
-    if (XSTRNCMP(name, EVP_AES_256_CBC, XSTRLEN(EVP_AES_256_CBC)) == 0)
+    if (XSTRCMP(name, EVP_AES_256_CBC) == 0)
         return AES_BLOCK_SIZE;
     #endif
 #endif /* HAVE_AES_CBC || WOLFSSL_AES_DIRECT */
@@ -8230,41 +8243,41 @@ int wolfSSL_EVP_CIPHER_iv_length(const WOLFSSL_EVP_CIPHER* cipher)
     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))
 #ifdef HAVE_AESGCM
     #ifdef WOLFSSL_AES_128
-    if (XSTRNCMP(name, EVP_AES_128_GCM, XSTRLEN(EVP_AES_128_GCM)) == 0)
+    if (XSTRCMP(name, EVP_AES_128_GCM) == 0)
         return GCM_NONCE_MID_SZ;
     #endif
     #ifdef WOLFSSL_AES_192
-    if (XSTRNCMP(name, EVP_AES_192_GCM, XSTRLEN(EVP_AES_192_GCM)) == 0)
+    if (XSTRCMP(name, EVP_AES_192_GCM) == 0)
         return GCM_NONCE_MID_SZ;
     #endif
     #ifdef WOLFSSL_AES_256
-    if (XSTRNCMP(name, EVP_AES_256_GCM, XSTRLEN(EVP_AES_256_GCM)) == 0)
+    if (XSTRCMP(name, EVP_AES_256_GCM) == 0)
         return GCM_NONCE_MID_SZ;
     #endif
 #endif /* HAVE_AESGCM */
 #endif /* (HAVE_FIPS && !HAVE_SELFTEST) || HAVE_FIPS_VERSION >= 2 */
 #ifdef WOLFSSL_AES_COUNTER
     #ifdef WOLFSSL_AES_128
-    if (XSTRNCMP(name, EVP_AES_128_CTR, XSTRLEN(EVP_AES_128_CTR)) == 0)
+    if (XSTRCMP(name, EVP_AES_128_CTR) == 0)
         return AES_BLOCK_SIZE;
     #endif
     #ifdef WOLFSSL_AES_192
-    if (XSTRNCMP(name, EVP_AES_192_CTR, XSTRLEN(EVP_AES_192_CTR)) == 0)
+    if (XSTRCMP(name, EVP_AES_192_CTR) == 0)
         return AES_BLOCK_SIZE;
     #endif
     #ifdef WOLFSSL_AES_256
-    if (XSTRNCMP(name, EVP_AES_256_CTR, XSTRLEN(EVP_AES_256_CTR)) == 0)
+    if (XSTRCMP(name, EVP_AES_256_CTR) == 0)
         return AES_BLOCK_SIZE;
     #endif
 #endif
 #ifdef WOLFSSL_AES_XTS
     #ifdef WOLFSSL_AES_128
-    if (XSTRNCMP(name, EVP_AES_128_XTS, XSTRLEN(EVP_AES_128_XTS)) == 0)
+    if (XSTRCMP(name, EVP_AES_128_XTS) == 0)
         return AES_BLOCK_SIZE;
     #endif /* WOLFSSL_AES_128 */
 
     #ifdef WOLFSSL_AES_256
-    if (XSTRNCMP(name, EVP_AES_256_XTS, XSTRLEN(EVP_AES_256_XTS)) == 0)
+    if (XSTRCMP(name, EVP_AES_256_XTS) == 0)
         return AES_BLOCK_SIZE;
     #endif /* WOLFSSL_AES_256 */
 #endif /* WOLFSSL_AES_XTS */
@@ -8272,8 +8285,8 @@ int wolfSSL_EVP_CIPHER_iv_length(const WOLFSSL_EVP_CIPHER* cipher)
 #endif
 
 #ifndef NO_DES3
-    if ((XSTRNCMP(name, EVP_DES_CBC, XSTRLEN(EVP_DES_CBC)) == 0) ||
-           (XSTRNCMP(name, EVP_DES_EDE3_CBC, XSTRLEN(EVP_DES_EDE3_CBC)) == 0)) {
+    if ((XSTRCMP(name, EVP_DES_CBC) == 0) ||
+           (XSTRCMP(name, EVP_DES_EDE3_CBC) == 0)) {
         return DES_BLOCK_SIZE;
     }
 #endif
@@ -9646,84 +9659,84 @@ int wolfSSL_EVP_get_hashinfo(const WOLFSSL_EVP_MD* evp,
         return WOLFSSL_FAILURE;
     }
 
-    if (XSTRNCMP("SHA", evp, 3) == 0) {
-        if (XSTRLEN(evp) > 3) {
-        #ifdef WOLFSSL_SHA224
-            if (XSTRNCMP("SHA224", evp, 6) == 0) {
-                hash = WC_HASH_TYPE_SHA224;
-            }
-            else
-        #endif
-        #ifndef NO_SHA256
-            if (XSTRNCMP("SHA256", evp, 6) == 0) {
-                hash = WC_HASH_TYPE_SHA256;
-            }
-            else
-        #endif
-        #ifdef WOLFSSL_SHA384
-            if (XSTRNCMP("SHA384", evp, 6) == 0) {
-                hash = WC_HASH_TYPE_SHA384;
-            }
-            else
-        #endif
-        #ifdef WOLFSSL_SHA512
-            if (XSTRNCMP("SHA512", evp, 6) == 0) {
-                hash = WC_HASH_TYPE_SHA512;
-            }
-            else
-        #endif
-        #ifdef WOLFSSL_SHA3
-        #ifndef WOLFSSL_NOSHA3_224
-            if (XSTRNCMP("SHA3_224", evp, 8) == 0) {
-                hash = WC_HASH_TYPE_SHA3_224;
-            }
-            else
-        #endif
-        #ifndef WOLFSSL_NOSHA3_256
-            if (XSTRNCMP("SHA3_256", evp, 8) == 0) {
-                hash = WC_HASH_TYPE_SHA3_256;
-            }
-            else
-        #endif
-        #ifndef WOLFSSL_NOSHA3_384
-            if (XSTRNCMP("SHA3_384", evp, 8) == 0) {
-                hash = WC_HASH_TYPE_SHA3_384;
-            }
-            else
-        #endif
-        #ifndef WOLFSSL_NOSHA3_512
-            if (XSTRNCMP("SHA3_512", evp, 8) == 0) {
-                hash = WC_HASH_TYPE_SHA3_512;
-            }
-            else
-        #endif
-        #endif /* WOLFSSL_SHA3 */
-            if (XSTRNCMP("SHA1", evp, 4) == 0) {
-                hash = WC_HASH_TYPE_SHA;
-            }
-            else {
-                WOLFSSL_MSG("Unknown SHA hash");
-            }
-        }
-        else {
-            hash = WC_HASH_TYPE_SHA;
-        }
-    }
+#ifndef NO_SHA
+    if ((XSTRCMP("SHA", evp) == 0) || (XSTRCMP("SHA1", evp) == 0)) {
+        hash = WC_HASH_TYPE_SHA;
+    } else
+#endif
+#ifdef WOLFSSL_SHA224
+    if (XSTRCMP("SHA224", evp) == 0) {
+        hash = WC_HASH_TYPE_SHA224;
+    } else
+#endif
+#ifndef NO_SHA256
+    if (XSTRCMP("SHA256", evp) == 0) {
+        hash = WC_HASH_TYPE_SHA256;
+    } else
+#endif
+#ifdef WOLFSSL_SHA384
+    if (XSTRCMP("SHA384", evp) == 0) {
+        hash = WC_HASH_TYPE_SHA384;
+    } else
+#endif
+#ifdef WOLFSSL_SHA512
+    if (XSTRCMP("SHA512", evp) == 0) {
+        hash = WC_HASH_TYPE_SHA512;
+    } else
+#ifndef WOLFSSL_NOSHA512_224
+    if (XSTRCMP("SHA512_224", evp) == 0) {
+        hash = WC_HASH_TYPE_SHA512_224;
+    } else
+#endif
+#ifndef WOLFSSL_NOSHA512_256
+    if (XSTRCMP("SHA512_256", evp) == 0) {
+        hash = WC_HASH_TYPE_SHA512_256;
+    } else
+#endif
+#endif
+#ifdef WOLFSSL_SHA3
+#ifndef WOLFSSL_NOSHA3_224
+    if (XSTRCMP("SHA3_224", evp) == 0) {
+        hash = WC_HASH_TYPE_SHA3_224;
+    } else
+#endif
+#ifndef WOLFSSL_NOSHA3_256
+    if (XSTRCMP("SHA3_256", evp) == 0) {
+        hash = WC_HASH_TYPE_SHA3_256;
+    } else
+#endif
+#ifndef WOLFSSL_NOSHA3_384
+    if (XSTRCMP("SHA3_384", evp) == 0) {
+        hash = WC_HASH_TYPE_SHA3_384;
+    } else
+#endif
+#ifndef WOLFSSL_NOSHA3_512
+    if (XSTRCMP("SHA3_512", evp) == 0) {
+        hash = WC_HASH_TYPE_SHA3_512;
+    } else
+#endif
+#endif /* WOLFSSL_SHA3 */
 #ifdef WOLFSSL_MD2
-    else if (XSTRNCMP("MD2", evp, 3) == 0) {
+    if (XSTRCMP("MD2", evp) == 0) {
         hash = WC_HASH_TYPE_MD2;
-    }
+    } else
 #endif
 #ifndef NO_MD4
-    else if (XSTRNCMP("MD4", evp, 3) == 0) {
+    if (XSTRCMP("MD4", evp) == 0) {
         hash = WC_HASH_TYPE_MD4;
-    }
+    } else
 #endif
 #ifndef NO_MD5
-    else if (XSTRNCMP("MD5", evp, 3) == 0) {
+    if (XSTRCMP("MD5", evp) == 0) {
         hash = WC_HASH_TYPE_MD5;
-    }
+    } else
 #endif
+    {
+        if (XSTRNCMP("SHA", evp, 3) == 0) {
+            WOLFSSL_MSG("Unknown SHA hash");
+        }
+        return WOLFSSL_FAILURE;
+    }
 
     if (pHash)
         *pHash = hash;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -1689,9 +1689,9 @@ WOLFSSL_TEST_SUBROUTINE int error_test(void)
      */
     errStr = wc_GetErrorString(OPEN_RAN_E);
     wc_ErrorString(OPEN_RAN_E, out);
-    if (XSTRNCMP(errStr, unknownStr, XSTRLEN(unknownStr)) != 0)
+    if (XSTRCMP(errStr, unknownStr) != 0)
         return -1100;
-    if (XSTRNCMP(out, unknownStr, XSTRLEN(unknownStr)) != 0)
+    if (XSTRCMP(out, unknownStr) != 0)
         return -1101;
 #else
     int i;
@@ -1710,20 +1710,20 @@ WOLFSSL_TEST_SUBROUTINE int error_test(void)
         wc_ErrorString(i, out);
 
         if (i != missing[j]) {
-            if (XSTRNCMP(errStr, unknownStr, XSTRLEN(unknownStr)) == 0)
+            if (XSTRCMP(errStr, unknownStr) == 0)
                 return -1102;
-            if (XSTRNCMP(out, unknownStr, XSTRLEN(unknownStr)) == 0)
+            if (XSTRCMP(out, unknownStr) == 0)
                 return -1103;
-            if (XSTRNCMP(errStr, out, XSTRLEN(errStr)) != 0)
+            if (XSTRCMP(errStr, out) != 0)
                 return -1104;
             if (XSTRLEN(errStr) >= WOLFSSL_MAX_ERROR_SZ)
                 return -1105;
         }
         else {
             j++;
-            if (XSTRNCMP(errStr, unknownStr, XSTRLEN(unknownStr)) != 0)
+            if (XSTRCMP(errStr, unknownStr) != 0)
                 return -1106;
-            if (XSTRNCMP(out, unknownStr, XSTRLEN(unknownStr)) != 0)
+            if (XSTRCMP(out, unknownStr) != 0)
                 return -1107;
         }
     }
@@ -1731,9 +1731,9 @@ WOLFSSL_TEST_SUBROUTINE int error_test(void)
     /* Check if the next possible value has been given a string. */
     errStr = wc_GetErrorString(i);
     wc_ErrorString(i, out);
-    if (XSTRNCMP(errStr, unknownStr, XSTRLEN(unknownStr)) != 0)
+    if (XSTRCMP(errStr, unknownStr) != 0)
         return -1108;
-    if (XSTRNCMP(out, unknownStr, XSTRLEN(unknownStr)) != 0)
+    if (XSTRCMP(out, unknownStr) != 0)
         return -1109;
 #endif
 

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1207,8 +1207,8 @@ static WC_INLINE void build_addr(SOCKADDR_IN_T* addr, const char* peer,
         char host_ipaddr[4] = { 127, 0, 0, 1 };
         int found = 1;
 
-        if ((XSTRNCMP(peer, "localhost", 10) != 0) &&
-            (XSTRNCMP(peer, "127.0.0.1", 10) != 0)) {
+        if ((XSTRCMP(peer, "localhost") != 0) &&
+            (XSTRCMP(peer, "127.0.0.1") != 0)) {
             FILE* fp;
             char host_out[100];
             char cmd[100];
@@ -2245,7 +2245,7 @@ static WC_INLINE unsigned int my_psk_server_cb(WOLFSSL* ssl, const char* identit
     (void)key_max_len;
 
     /* see internal.h MAX_PSK_ID_LEN for PSK identity limit */
-    if (XSTRNCMP(identity, kIdentityStr, XSTRLEN(kIdentityStr)) != 0)
+    if (XSTRCMP(identity, kIdentityStr) != 0)
         return 0;
 
     if (wolfSSL_GetVersion(ssl) < WOLFSSL_TLSV1_3) {

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -2521,7 +2521,7 @@ static WC_INLINE int OCSPIOCb(void* ioCtx, const char* url, int urlSz,
 
 static WC_INLINE void OCSPRespFreeCb(void* ioCtx, unsigned char* response)
 {
-    return EmbedOcspRespFree(ioCtx, response);
+    EmbedOcspRespFree(ioCtx, response);
 }
 #endif
 

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -630,10 +630,42 @@ decouple library dependencies with standard string, memory and so on.
             #define XSTRSEP(s1,d) strsep((s1),(d))
         #endif
 
-        #ifndef XSTRNCASECMP
-        #if defined(MICROCHIP_PIC32) || defined(WOLFSSL_TIRTOS) || \
+        #ifndef XSTRCASECMP
+        #if defined(MICROCHIP_PIC32) && (__XC32_VERSION >= 1000)
+            /* XC32 supports str[n]casecmp in version >= 1.0. */
+            #define XSTRCASECMP(s1,s2) strcasecmp((s1),(s2))
+        #elif defined(MICROCHIP_PIC32) || defined(WOLFSSL_TIRTOS) || \
                 defined(WOLFSSL_ZEPHYR)
-            /* XC32 does not support strncasecmp, so use case sensitive one */
+            /* XC32 version < 1.0 does not support strcasecmp, so use
+             * case sensitive one.
+             */
+            #define XSTRCASECMP(s1,s2) strcmp((s1),(s2))
+        #elif defined(USE_WINDOWS_API) || defined(FREERTOS_TCP_WINSIM)
+            #define XSTRCASECMP(s1,s2) _stricmp((s1),(s2))
+        #else
+            #if defined(HAVE_STRINGS_H) && defined(WOLF_C99) && \
+                !defined(WOLFSSL_SGX)
+                #include <strings.h>
+            #endif
+            #if defined(WOLFSSL_DEOS)
+                #define XSTRCASECMP(s1,s2) stricmp((s1),(s2))
+            #elif defined(WOLFSSL_CMSIS_RTOSv2)
+                #define XSTRCASECMP(s1,s2) strcmp((s1),(s2))
+            #else
+                #define XSTRCASECMP(s1,s2) strcasecmp((s1),(s2))
+            #endif
+        #endif
+        #endif /* !XSTRCASECMP */
+
+        #ifndef XSTRNCASECMP
+        #if defined(MICROCHIP_PIC32) && (__XC32_VERSION >= 1000)
+            /* XC32 supports str[n]casecmp in version >= 1.0. */
+            #define XSTRNCASECMP(s1,s2,n) strncasecmp((s1),(s2),(n))
+        #elif defined(MICROCHIP_PIC32) || defined(WOLFSSL_TIRTOS) || \
+                defined(WOLFSSL_ZEPHYR)
+            /* XC32 version < 1.0 does not support strncasecmp, so use case
+             * sensitive one.
+             */
             #define XSTRNCASECMP(s1,s2,n) strncmp((s1),(s2),(n))
         #elif defined(USE_WINDOWS_API) || defined(FREERTOS_TCP_WINSIM)
             #define XSTRNCASECMP(s1,s2,n) _strnicmp((s1),(s2),(n))


### PR DESCRIPTION
where appropriate, use `strcmp()`/`strcasecmp()`, not `strncmp()`/`strncasecmp()`;

add macro `XSTRCASECMP()`;

update `XSTRNCASECMP()` for XC32 >= 1.00 to use `strncasecmp()`.

tested with `wolfssl-multi-test ... quick-check '.*gcc-13.*'`
