### PR TITLE
wolfcrypt: logging: use do{}while(0) to disable WOLFSSL_MSG* macro

### DIFF
--- a/wolfssl/wolfcrypt/logging.h
+++ b/wolfssl/wolfcrypt/logging.h
@@ -177,9 +177,9 @@ WOLFSSL_API void wolfSSL_Debugging_OFF(void);
     #define WOLFSSL_STUB(m)
     #define WOLFSSL_IS_DEBUG_ON() 0
 
-    #define WOLFSSL_MSG_EX(m, ...)
-    #define WOLFSSL_MSG(m)
-    #define WOLFSSL_BUFFER(b, l)
+    #define WOLFSSL_MSG_EX(m, ...)    do{} while(0)
+    #define WOLFSSL_MSG(m)            do{} while(0)
+    #define WOLFSSL_BUFFER(b, l)      do{} while(0)
 
 #endif /* DEBUG_WOLFSSL && !WOLFSSL_DEBUG_ERRORS_ONLY */
 


### PR DESCRIPTION
# Description

otherwise statement of the type:

if (condtion)
    WOLFSSL_MSG("");

after preprocessing will become:

if (condition)
    ;

The empty body emits a warning from the compiler.
