### PR TITLE
Support DTLS bidirectional shutdown in the examples

### DIFF
--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -3356,9 +3356,20 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 
         ret = SSL_shutdown(ssl);
         if (wc_shutdown && ret == WOLFSSL_SHUTDOWN_NOT_DONE) {
-            ret = SSL_shutdown(ssl); /* bidirectional shutdown */
-            if (ret == WOLFSSL_SUCCESS)
-                printf("Bidirectional shutdown complete\n");
+            while (tcp_select(wolfSSL_get_fd(ssl), DEFAULT_TIMEOUT_SEC) ==
+                    TEST_RECV_READY) {
+                ret = wolfSSL_shutdown(ssl); /* bidirectional shutdown */
+                if (ret == WOLFSSL_SUCCESS) {
+                    printf("Bidirectional shutdown complete\n");
+                    break;
+                }
+                else if (ret != WOLFSSL_SHUTDOWN_NOT_DONE) {
+                    printf("Bidirectional shutdown failed\n");
+                    break;
+                }
+            }
+            if (ret != WOLFSSL_SUCCESS)
+                printf("Bidirectional shutdown failed\n");
         }
 
         /* display collected statistics */

--- a/tests/test-dtls-resume.conf
+++ b/tests/test-dtls-resume.conf
@@ -1061,3 +1061,17 @@
 -a
 -v 2
 -l ADH-AES128-SHA
+
+# server DTLSv1.2 DHE-RSA-CHACHA20-POLY1305 bidirectional shutdown
+-u
+-r
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+-w
+
+# client DTLSv1.2 DHE-RSA-CHACHA20-POLY1305 bidirectional shutdown
+-u
+-r
+-v 3
+-l DHE-RSA-CHACHA20-POLY1305
+-w

--- a/tests/test-dtls.conf
+++ b/tests/test-dtls.conf
@@ -907,3 +907,11 @@
 -a
 -v 2
 -l ADH-AES128-SHA
+
+# server with bidirectional shutdown
+-l ECDHE-RSA-AES128-SHA256
+-w
+
+# client with bidirectional shutdown
+-l ECDHE-RSA-AES128-SHA256
+-w


### PR DESCRIPTION
# Description

Due to how the UDP connection is initiated in the examples, we can't do a bidirectional shutdown. Indeed,  when doing resumption, messages can interleave in a way that an alert from the first session can be mistaken for the first message of a second session. 

Enabling bidirectional shutdown will help with testing DTLS retransmission better. 

# Testing

The PR adds configuration to the unit test that will try bidirectional shutdown over DTLS. 
