### PR TITLE
tls13: fix cookie has keyShare information check

### DIFF
--- a/src/tls13.c
+++ b/src/tls13.c
@@ -4437,7 +4437,8 @@ static int RestartHandshakeHashWithCookie(WOLFSSL* ssl, Cookie* cookie)
     length = HRR_BODY_SZ - ID_LEN + ssl->session->sessionIDSz +
              HRR_COOKIE_HDR_SZ + cookie->len;
     length += HRR_VERSIONS_SZ;
-    if (cookieDataSz > hashSz + OPAQUE16_LEN) {
+    /* HashSz (1 byte) + Hash (HashSz bytes) + CipherSuite (2 bytes) */
+    if (cookieDataSz > OPAQUE8_LEN + hashSz + OPAQUE16_LEN) {
         keyShareExt = 1;
         length += HRR_KEY_SHARE_SZ;
     }


### PR DESCRIPTION
# Description

This is part of preliminary PRs to support DTLSv1.3

Fix the check to see if the cookie has key_share information or not (needed to
reconstruct the HelloRetryRequest). At the moment, it looks like we never send a
cookie without KeyShare extension. Indeed the HelloRetryRequest is sent only
because the client didn't provide a good KeyShareEntry in the first
ClientHello. When we will support DTLSv1.3, the HelloRetryRequest will be used
as a return-routability check and it may be sent without the KeyShare extension.

# Testing
`./configure --enable-tls13 --enable-hrrcookie && make check`
`./configure --enable-tls13 && make check`

