### PR TITLE
Store data to send when we don't have async support

### DIFF
--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -301,6 +301,8 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
 {
     int ret = 0;
 
+    WOLFSSL_ENTER("wc_PRF_TLS");
+
     if (useAtLeastSha256) {
     #if defined(WOLFSSL_ASYNC_CRYPT) && !defined(WC_ASYNC_NO_HASH)
         WC_DECLARE_VAR(labelSeed, byte, MAX_PRF_LABSEED, heap);
@@ -338,6 +340,20 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
 #endif
     }
 
+#ifdef WOLFSSL_DEBUG_TLS
+    if (ret == 0) {
+        WOLFSSL_MSG("  digest");
+        WOLFSSL_BUFFER(digest, digLen);
+        WOLFSSL_MSG("  secret");
+        WOLFSSL_BUFFER(secret, secLen);
+        WOLFSSL_MSG("  label");
+        WOLFSSL_BUFFER(label, labLen);
+        WOLFSSL_MSG("  seed");
+        WOLFSSL_BUFFER(seed, seedLen);
+    }
+#endif
+
+    WOLFSSL_LEAVE("wc_PRF_TLS", ret);
 
     return ret;
 }

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4243,6 +4243,20 @@ typedef enum EarlyDataState {
 } EarlyDataState;
 #endif
 
+#if !defined(WOLFSSL_ASYNC_CRYPT) && (!defined(NO_WOLFSSL_SERVER) || \
+    (!defined(NO_WOLFSSL_CLIENT) && !defined(NO_CERTS) && \
+     !defined(WOLFSSL_NO_CLIENT_AUTH)))
+typedef struct ShsArgs {
+    byte* input;
+    const char* packetName;
+    word32 inputSz;
+    byte hsType;
+    byte shsArgsSet:1;
+} ShsArgs;
+
+WOLFSSL_LOCAL void freeShsArgs(ShsArgs* fragArgs, void* heap);
+#endif
+
 /* wolfSSL ssl type */
 struct WOLFSSL {
     WOLFSSL_CTX*    ctx;
@@ -4286,6 +4300,11 @@ struct WOLFSSL {
     struct WOLFSSL_ASYNC async;
 #elif defined(WOLFSSL_NONBLOCK_OCSP)
     void*           nonblockarg;        /* dynamic arg for handling non-block resume */
+#endif
+#if !defined(WOLFSSL_ASYNC_CRYPT) && (!defined(NO_WOLFSSL_SERVER) || \
+    (!defined(NO_WOLFSSL_CLIENT) && !defined(NO_CERTS) && \
+     !defined(WOLFSSL_NO_CLIENT_AUTH)))
+    ShsArgs  fragArgs;
 #endif
     void*           hsKey;              /* Handshake key (RsaKey or ecc_key) allocated from heap */
     word32          hsType;             /* Type of Handshake key (hsKey) */
@@ -4758,6 +4777,8 @@ enum HandShakeType {
                                       conflicts with handshake finished */
     message_hash         = 254,    /* synthetic message type for TLS v1.3 */
     no_shake             = 255     /* used to initialize the DtlsMsg record */
+    /* Make sure to change type of hsType in ShsArgs when adding >255 values
+     * to this enum. */
 };
 
 enum ProvisionSide {


### PR DESCRIPTION
The error can be replicated with:
```
./configure CPPFLAGS='-DWOLFSSL_STATIC_RSA -DWOLFSSL_STATIC_DH'
./examples/server/server -v3 -6
./examples/client/client -v 3 -l TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 -6
```
Cipher selection is important to force a cert verify to be sent.