### PR TITLE
print errors to stderr, not stdout

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -491,7 +491,7 @@ static void EarlyData(WOLFSSL_CTX* ctx, WOLFSSL* ssl, const char* msg,
         }
     } while (err == WC_PENDING_E);
     if (ret != msgSz) {
-        printf("SSL_write_early_data msg error %d, %s\n", err,
+        fprintf(stderr, "SSL_write_early_data msg error %d, %s\n", err,
                                          wolfSSL_ERR_error_string(err, buffer));
         wolfSSL_free(ssl); ssl = NULL;
         wolfSSL_CTX_free(ctx); ctx = NULL;
@@ -511,7 +511,7 @@ static void EarlyData(WOLFSSL_CTX* ctx, WOLFSSL* ssl, const char* msg,
         }
     } while (err == WC_PENDING_E);
     if (ret != msgSz) {
-        printf("SSL_write_early_data msg error %d, %s\n", err,
+        fprintf(stderr, "SSL_write_early_data msg error %d, %s\n", err,
                                          wolfSSL_ERR_error_string(err, buffer));
         wolfSSL_free(ssl);
         wolfSSL_CTX_free(ctx);
@@ -779,7 +779,7 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
                         }
                     } while (err == WC_PENDING_E);
                     if (ret != len) {
-                        printf("SSL_write bench error %d!\n", err);
+                        fprintf(stderr, "SSL_write bench error %d!\n", err);
                         if (!exitWithRet)
                             err_sys("SSL_write failed");
                         goto doExit;
@@ -804,7 +804,7 @@ static int ClientBenchmarkThroughput(WOLFSSL_CTX* ctx, char* host, word16 port,
                                 else
                             #endif
                                 if (err != WOLFSSL_ERROR_WANT_READ) {
-                                    printf("SSL_read bench error %d\n", err);
+                                    fprintf(stderr, "SSL_read bench error %d\n", err);
                                     err_sys("SSL_read failed");
                                 }
                             }
@@ -995,7 +995,7 @@ static int SMTP_Shutdown(WOLFSSL* ssl, int wc_shutdown)
                 printf("Bidirectional shutdown complete\n");
         }
         if (ret != WOLFSSL_SUCCESS)
-            printf("Bidirectional shutdown failed\n");
+            fprintf(stderr, "Bidirectional shutdown failed\n");
     }
 
     return WOLFSSL_SUCCESS;
@@ -1026,7 +1026,7 @@ static int ClientWrite(WOLFSSL* ssl, const char* msg, int msgSz, const char* str
     #endif
     );
     if (ret != msgSz) {
-        printf("SSL_write%s msg error %d, %s\n", str, err,
+        fprintf(stderr, "SSL_write%s msg error %d, %s\n", str, err,
                                         wolfSSL_ERR_error_string(err, buffer));
         if (!exitWithRet) {
             err_sys("SSL_write failed");
@@ -1056,7 +1056,7 @@ static int ClientRead(WOLFSSL* ssl, char* reply, int replyLen, int mustRead,
             else
         #endif
             if (err != WOLFSSL_ERROR_WANT_READ && err != APP_DATA_READY) {
-                printf("SSL_read reply error %d, %s\n", err,
+                fprintf(stderr, "SSL_read reply error %d, %s\n", err,
                                          wolfSSL_ERR_error_string(err, buffer));
                 if (!exitWithRet) {
                     err_sys("SSL_read failed");
@@ -1070,7 +1070,7 @@ static int ClientRead(WOLFSSL* ssl, char* reply, int replyLen, int mustRead,
         if (mustRead && err == WOLFSSL_ERROR_WANT_READ) {
             elapsed = current_time(0) - start;
             if (elapsed > MAX_NON_BLOCK_SEC) {
-                printf("Nonblocking read timeout\n");
+                fprintf(stderr, "Nonblocking read timeout\n");
                 ret = WOLFSSL_FATAL_ERROR;
                 break;
             }
@@ -1534,12 +1534,12 @@ static void showPeerPEM(WOLFSSL* ssl)
     if (peer) {
         WOLFSSL_BIO* bioOut = wolfSSL_BIO_new(wolfSSL_BIO_s_file());
         if (bioOut == NULL) {
-            printf("failed to get bio on stdout\n");
+            fprintf(stderr, "failed to get bio on stdout\n");
         }
         else {
             if (wolfSSL_BIO_set_fp(bioOut, stdout, BIO_NOCLOSE)
                 != WOLFSSL_SUCCESS) {
-                printf("failed to set stdout to bio output\n");
+                fprintf(stderr, "failed to set stdout to bio output\n");
                 wolfSSL_BIO_free(bioOut);
                 bioOut = NULL;
             }
@@ -1774,7 +1774,7 @@ static int client_srtp_test(WOLFSSL *ssl, func_args *args)
     ret = wolfSSL_export_dtls_srtp_keying_material(ssl, NULL,
                                                    &srtp_secret_length);
     if (ret != LENGTH_ONLY_E) {
-        printf("DTLS SRTP: Error getting keying material length\n");
+        fprintf(stderr, "DTLS SRTP: Error getting keying material length\n");
         return ret;
     }
 
@@ -1788,7 +1788,7 @@ static int client_srtp_test(WOLFSSL *ssl, func_args *args)
                                                    &srtp_secret_length);
     if (ret != WOLFSSL_SUCCESS) {
         XFREE(srtp_secret, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        printf("DTLS SRTP: Error getting keying material\n");
+        fprintf(stderr, "DTLS SRTP: Error getting keying material\n");
         return ret;
     }
 
@@ -2726,7 +2726,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         #endif
 
         if (done) {
-            printf("external test can't be run in this mode\n");
+            fprintf(stderr, "external test can't be run in this mode\n");
 
             ((func_args*)args)->return_code = 0;
             XEXIT_T(EXIT_SUCCESS);
@@ -2762,7 +2762,8 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
     if (usePqc) {
         if (version == CLIENT_DOWNGRADE_VERSION ||
             version == EITHER_DOWNGRADE_VERSION)
-            printf("WARNING: If a TLS 1.3 connection is not negotiated, you "
+            fprintf(stderr,
+                   "WARNING: If a TLS 1.3 connection is not negotiated, you "
                    "will not be using a post-quantum group.\n");
         else if (version != 4)
             err_sys("can only use post-quantum groups with TLS 1.3");
@@ -3209,7 +3210,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfAsync_DevOpen(&devId);
     if (ret < 0) {
-        printf("Async device open failed\nRunning without async\n");
+        fprintf(stderr, "Async device open failed\nRunning without async\n");
     }
     wolfSSL_CTX_SetDevId(ctx, devId);
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -3658,7 +3659,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
 #endif
     if (ret != WOLFSSL_SUCCESS) {
         err = wolfSSL_get_error(ssl, 0);
-        printf("wolfSSL_connect error %d, %s\n", err,
+        fprintf(stderr, "wolfSSL_connect error %d, %s\n", err,
             wolfSSL_ERR_error_string(err, buffer));
 
         /* cleanup */
@@ -3888,7 +3889,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                     }
                     if (ret != WOLFSSL_SUCCESS) {
                         err = wolfSSL_get_error(ssl, 0);
-                        printf("wolfSSL_Rehandshake error %d, %s\n", err,
+                        fprintf(stderr, "wolfSSL_Rehandshake error %d, %s\n", err,
                             wolfSSL_ERR_error_string(err, buffer));
                         wolfSSL_free(ssl); ssl = NULL;
                         wolfSSL_CTX_free(ctx); ctx = NULL;
@@ -3897,7 +3898,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 }
             }
             else {
-                printf("not doing secure resumption with non-blocking");
+                fprintf(stderr, "not doing secure resumption with non-blocking");
             }
         } else {
             if (!resumeScr) {
@@ -4056,12 +4057,12 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 break;
             }
             else if (ret != WOLFSSL_SHUTDOWN_NOT_DONE) {
-                printf("Bidirectional shutdown failed\n");
+                fprintf(stderr, "Bidirectional shutdown failed\n");
                 break;
             }
         }
         if (ret != WOLFSSL_SUCCESS)
-            printf("Bidirectional shutdown failed\n");
+            fprintf(stderr, "Bidirectional shutdown failed\n");
     }
 #if defined(ATOMIC_USER) && !defined(WOLFSSL_AEAD_ONLY)
     if (atomicUser)
@@ -4197,7 +4198,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         ret = NonBlockingSSL_Connect(sslResume);  /* will keep retrying on timeout */
 #endif
         if (ret != WOLFSSL_SUCCESS) {
-            printf("wolfSSL_connect resume error %d, %s\n", err,
+            fprintf(stderr, "wolfSSL_connect resume error %d, %s\n", err,
                 wolfSSL_ERR_error_string(err, buffer));
             wolfSSL_free(sslResume); sslResume = NULL;
             wolfSSL_CTX_free(ctx); ctx = NULL;
@@ -4210,7 +4211,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
         if (wolfSSL_session_reused(sslResume))
             printf("reused session id\n");
         else
-            printf("didn't reuse session id!!!\n");
+            fprintf(stderr, "didn't reuse session id!!!\n");
 
 #ifdef HAVE_ALPN
         if (alpnList != NULL) {
@@ -4245,7 +4246,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 printf("Beginning secure renegotiation.\n");
                 if (wolfSSL_Rehandshake(sslResume) != WOLFSSL_SUCCESS) {
                     err = wolfSSL_get_error(sslResume, 0);
-                    printf("err = %d, %s\n", err,
+                    fprintf(stderr, "err = %d, %s\n", err,
                                     wolfSSL_ERR_error_string(err, buffer));
                     wolfSSL_free(sslResume); sslResume = NULL;
                     wolfSSL_CTX_free(ctx); ctx = NULL;
@@ -4259,7 +4260,7 @@ THREAD_RETURN WOLFSSL_THREAD client_test(void* args)
                 printf("Beginning secure resumption.\n");
                 if (wolfSSL_SecureResume(sslResume) != WOLFSSL_SUCCESS) {
                     err = wolfSSL_get_error(sslResume, 0);
-                    printf("err = %d, %s\n", err,
+                    fprintf(stderr, "err = %d, %s\n", err,
                                     wolfSSL_ERR_error_string(err, buffer));
                     wolfSSL_free(sslResume); sslResume = NULL;
                     wolfSSL_CTX_free(ctx); ctx = NULL;
@@ -4378,7 +4379,7 @@ exit:
         client_test(&args);
 #endif
 #else
-        printf("Client not compiled in!\n");
+        fprintf(stderr, "Client not compiled in!\n");
 #endif
         wolfSSL_Cleanup();
 

--- a/examples/echoclient/echoclient.c
+++ b/examples/echoclient/echoclient.c
@@ -224,7 +224,7 @@ void echoclient_test(void* args)
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfAsync_DevOpen(&devId);
     if (ret < 0) {
-        printf("Async device open failed\nRunning without async\n");
+        fprintf(stderr, "Async device open failed\nRunning without async\n");
     }
     wolfSSL_CTX_SetDevId(ctx, devId);
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -252,7 +252,7 @@ void echoclient_test(void* args)
         }
     } while (err == WC_PENDING_E);
     if (ret != WOLFSSL_SUCCESS) {
-        printf("SSL_connect error %d, %s\n", err,
+        fprintf(stderr, "SSL_connect error %d, %s\n", err,
             ERR_error_string(err, buffer));
         err_sys("SSL_connect failed");
     }
@@ -275,7 +275,7 @@ void echoclient_test(void* args)
             }
         } while (err == WC_PENDING_E);
         if (ret != sendSz) {
-            printf("SSL_write msg error %d, %s\n", err,
+            fprintf(stderr, "SSL_write msg error %d, %s\n", err,
                 ERR_error_string(err, buffer));
             err_sys("SSL_write failed");
         }
@@ -322,7 +322,7 @@ void echoclient_test(void* args)
             }
 #endif
             else {
-                printf("SSL_read msg error %d, %s\n", err,
+                fprintf(stderr, "SSL_read msg error %d, %s\n", err,
                     ERR_error_string(err, buffer));
                 err_sys("SSL_read failed");
             }

--- a/examples/echoserver/echoserver.c
+++ b/examples/echoserver/echoserver.c
@@ -279,7 +279,7 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfAsync_DevOpen(&devId);
     if (ret < 0) {
-        printf("Async device open failed\nRunning without async\n");
+        fprintf(stderr, "Async device open failed\nRunning without async\n");
     }
     wolfSSL_CTX_SetDevId(ctx, devId);
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -342,9 +342,9 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
             }
         } while (err == WC_PENDING_E);
         if (ret != WOLFSSL_SUCCESS) {
-            printf("SSL_accept error = %d, %s\n", err,
+            fprintf(stderr, "SSL_accept error = %d, %s\n", err,
                 CyaSSL_ERR_error_string(err, buffer));
-            printf("SSL_accept failed\n");
+            fprintf(stderr, "SSL_accept failed\n");
             CyaSSL_free(ssl);
             CloseSocket(clientfd);
             continue;
@@ -356,7 +356,7 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
 #ifdef HAVE_WRITE_DUP
         write_ssl = wolfSSL_write_dup(ssl);
         if (write_ssl == NULL) {
-            printf("wolfSSL_write_dup failed\n");
+            fprintf(stderr, "wolfSSL_write_dup failed\n");
             CyaSSL_free(ssl);
             CloseSocket(clientfd);
             continue;
@@ -381,7 +381,7 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
             } while (err == WC_PENDING_E);
             if (ret <= 0) {
                 if (err != WOLFSSL_ERROR_WANT_READ && err != WOLFSSL_ERROR_ZERO_RETURN){
-                    printf("SSL_read echo error %d, %s!\n", err,
+                    fprintf(stderr, "SSL_read echo error %d, %s!\n", err,
                         CyaSSL_ERR_error_string(err, buffer));
                 }
                 break;
@@ -443,7 +443,7 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
                     }
                 } while (err == WC_PENDING_E);
                 if (ret != echoSz) {
-                    printf("SSL_write get error = %d, %s\n", err,
+                    fprintf(stderr, "SSL_write get error = %d, %s\n", err,
                         CyaSSL_ERR_error_string(err, buffer));
                     err_sys("SSL_write get failed");
                 }
@@ -470,7 +470,7 @@ THREAD_RETURN CYASSL_THREAD echoserver_test(void* args)
             } while (err == WC_PENDING_E);
 
             if (ret != echoSz) {
-                printf("SSL_write echo error = %d, %s\n", err,
+                fprintf(stderr, "SSL_write echo error = %d, %s\n", err,
                         CyaSSL_ERR_error_string(err, buffer));
                 err_sys("SSL_write echo failed");
             }

--- a/examples/sctp/sctp-client-dtls.c
+++ b/examples/sctp/sctp-client-dtls.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
     wolfSSL_read(ssl, bigBuf, sizeof(bigBuf));
     for (i = 0; i < sizeof(bigBuf); i++) {
         if (bigBuf[i] != (unsigned char)(i & 0xFF)) {
-            printf("big message check fail\n");
+            fprintf(stderr, "big message check fail\n");
             break;
         }
     }

--- a/src/internal.c
+++ b/src/internal.c
@@ -12370,7 +12370,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         skipAddCA = 1;
                     }
                 #endif /* WOLFSSL_ALT_CERT_CHAINS */
-                
+
                     /* Do verify callback */
                     ret = DoVerifyCallback(SSL_CM(ssl), ssl, ret, args);
                     if (ssl->options.verifyNone &&

--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -646,19 +646,19 @@ void ssl_InitSniffer(void)
     #ifdef HAVE_INTEL_QA_SYNC
     devId = wc_CryptoCb_InitIntelQa();
     if (devId == INVALID_DEVID) {
-        printf("Couldn't init the Intel QA\n");
+        fprintf(stderr, "Couldn't init the Intel QA\n");
     }
     #endif
     #ifdef HAVE_CAVIUM_OCTEON_SYNC
     devId = wc_CryptoCb_InitOcteon();
     if (devId == INVALID_DEVID) {
-        printf("Couldn't init the Octeon\n");
+        fprintf(stderr, "Couldn't init the Octeon\n");
     }
     #endif
 #endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     if (wolfAsync_DevOpen(&devId) < 0) {
-        printf("Async device open failed\nRunning without async\n");
+        fprintf(stderr, "Async device open failed\nRunning without async\n");
         devId = INVALID_DEVID;
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -6710,7 +6710,7 @@ int ssl_SetWatchKey_buffer(void* vSniffer, const byte* key, word32 keySz,
     if (ret != 0) {
     #ifdef DEBUG_SNIFFER
         /* print warnings */
-        printf("key watch set ephemeral failed %d\n", ret);
+        fprintf(stderr, "key watch set ephemeral failed %d\n", ret);
     #endif
     }
 #endif
@@ -6815,7 +6815,7 @@ int ssl_PollSniffer(WOLF_EVENT** events, int maxEvents, WOLF_EVENT_FLAG flags,
         }
         else {
         #ifdef DEBUG_SNIFFER
-            printf("Sniffer Server %p: Poll error: %d\n", srv, ret);
+            fprintf(stderr, "Sniffer Server %p: Poll error: %d\n", srv, ret);
         #endif
             break;
         }

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -758,7 +758,7 @@ int wolfIO_Send(SOCKET_T sd, char *buf, int sz, int wrFlags)
         ret = select(nfds, &rfds, &wfds, NULL, &timeout);
         if (ret == 0) {
         #ifdef DEBUG_HTTP
-            printf("Timeout: %d\n", ret);
+            fprintf(stderr, "Timeout: %d\n", ret);
         #endif
             return HTTP_TIMEOUT;
         }
@@ -2445,11 +2445,11 @@ int uIPSend(WOLFSSL* ssl, char* buf, int sz, void* _ctx)
         unsigned int bytes_left = sz - total_written;
         max_sendlen = tcp_socket_max_sendlen(&ctx->conn.tcp);
         if (bytes_left > max_sendlen) {
-            printf("Send limited by buffer\r\n");
+            fprintf(stderr, "uIPSend: Send limited by buffer\r\n");
             bytes_left = max_sendlen;
         }
         if (bytes_left == 0) {
-            printf("Buffer full!\r\n");
+            fprintf(stderr, "uIPSend: Buffer full!\r\n");
             break;
         }
         ret = tcp_socket_send(&ctx->conn.tcp, (unsigned char *)buf + total_written, bytes_left);

--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -5343,7 +5343,7 @@ static void wc_ecc_dump_oids(void)
 
         /* validate sum */
         if (ecc_sets[x].oidSum != sum) {
-            printf("  Sum %u Not Valid!\n", ecc_sets[x].oidSum);
+            fprintf(stderr, "  Sum %u Not Valid!\n", ecc_sets[x].oidSum);
         }
     }
     mOidDumpDone = 1;

--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -152,7 +152,7 @@ void* wolfSSL_Malloc(size_t size)
 
 #ifdef WOLFSSL_DEBUG_MEMORY
 #if defined(WOLFSSL_DEBUG_MEMORY_PRINT) && !defined(WOLFSSL_TRACK_MEMORY)
-    printf("Alloc: %p -> %u at %s:%u\n", res, (word32)size, func, line);
+    fprintf(stderr, "Alloc: %p -> %u at %s:%u\n", res, (word32)size, func, line);
 #else
     (void)func;
     (void)line;
@@ -166,7 +166,7 @@ void* wolfSSL_Malloc(size_t size)
 
 #ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
     if (res && --gMemFailCount == 0) {
-        printf("\n---FORCED MEM FAIL TEST---\n");
+        fprintf(stderr, "\n---FORCED MEM FAIL TEST---\n");
         if (free_function) {
         #ifdef WOLFSSL_DEBUG_MEMORY
             free_function(res, func, line);
@@ -193,7 +193,7 @@ void wolfSSL_Free(void *ptr)
 {
 #ifdef WOLFSSL_DEBUG_MEMORY
 #if defined(WOLFSSL_DEBUG_MEMORY_PRINT) && !defined(WOLFSSL_TRACK_MEMORY)
-    printf("Free: %p at %s:%u\n", ptr, func, line);
+    fprintf(stderr, "Free: %p at %s:%u\n", ptr, func, line);
 #else
     (void)func;
     (void)line;
@@ -406,7 +406,7 @@ int wolfSSL_load_static_memory(byte* buffer, word32 sz, int flag,
     }
 
 #ifdef WOLFSSL_DEBUG_MEMORY
-    printf("Allocated %d bytes for static memory @ %p\n", ava, pt);
+    fprintf(stderr, "Allocated %d bytes for static memory @ %p\n", ava, pt);
 #endif
 
     /* divide into chunks of memory and add them to available list */
@@ -630,12 +630,12 @@ void* wolfSSL_Malloc(size_t size, void* heap, int type)
             #endif
 
             #ifdef WOLFSSL_DEBUG_MEMORY
-                printf("Alloc: %p -> %u at %s:%d\n", res, (word32)size, func, line);
+                fprintf(stderr, "Alloc: %p -> %u at %s:%d\n", res, (word32)size, func, line);
             #endif
         #else
             WOLFSSL_MSG("No heap hint found to use and no malloc");
             #ifdef WOLFSSL_DEBUG_MEMORY
-            printf("ERROR: at %s:%d\n", func, line);
+            fprintf(stderr, "ERROR: at %s:%d\n", func, line);
             #endif
         #endif /* WOLFSSL_NO_MALLOC */
         #endif /* WOLFSSL_HEAP_TEST */
@@ -682,7 +682,7 @@ void* wolfSSL_Malloc(size_t size, void* heap, int type)
                         }
                     #ifdef WOLFSSL_DEBUG_STATIC_MEMORY
                         else {
-                            printf("Size: %ld, Empty: %d\n", size,
+                            fprintf(stderr, "Size: %ld, Empty: %d\n", size,
                                                               mem->sizeList[i]);
                         }
                     #endif
@@ -697,7 +697,7 @@ void* wolfSSL_Malloc(size_t size, void* heap, int type)
             res = pt->buffer;
 
         #ifdef WOLFSSL_DEBUG_MEMORY
-            printf("Alloc: %p -> %u at %s:%d\n", pt->buffer, pt->sz, func, line);
+            fprintf(stderr, "Alloc: %p -> %u at %s:%d\n", pt->buffer, pt->sz, func, line);
         #endif
 
             /* keep track of connection statistics if flag is set */
@@ -719,7 +719,7 @@ void* wolfSSL_Malloc(size_t size, void* heap, int type)
         else {
             WOLFSSL_MSG("ERROR ran out of static memory");
             #ifdef WOLFSSL_DEBUG_MEMORY
-            printf("Looking for %lu bytes at %s:%d\n", size, func, line);
+            fprintf(stderr, "Looking for %lu bytes at %s:%d\n", size, func, line);
             #endif
         }
 
@@ -756,7 +756,7 @@ void wolfSSL_Free(void *ptr, void* heap, int type)
     #ifdef WOLFSSL_HEAP_TEST
         if (heap == (void*)WOLFSSL_HEAP_TEST) {
         #ifdef WOLFSSL_DEBUG_MEMORY
-            printf("Free: %p at %s:%d\n", pt, func, line);
+            fprintf(stderr, "Free: %p at %s:%d\n", pt, func, line);
         #endif
             return free(ptr);
         }
@@ -821,7 +821,7 @@ void wolfSSL_Free(void *ptr, void* heap, int type)
             mem->frAlc += 1;
 
         #ifdef WOLFSSL_DEBUG_MEMORY
-            printf("Free: %p -> %u at %s:%d\n", pt->buffer, pt->sz, func, line);
+            fprintf(stderr, "Free: %p -> %u at %s:%d\n", pt->buffer, pt->sz, func, line);
         #endif
 
             /* keep track of connection statistics if flag is set */

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -1404,7 +1404,7 @@ int wc_InitNetRandom(const char* configFile, wnr_hmac_key hmac_cb, int timeout)
 
     /* create/init polling mechanism */
     if (wnr_poll_create() != WNR_ERROR_NONE) {
-        printf("ERROR: wnr_poll_create() failed\n");
+        fprintf(stderr, "ERROR: wnr_poll_create() failed\n");
         WOLFSSL_MSG("Error initializing netRandom polling mechanism");
         wnr_destroy(wnr_ctx);
         wnr_ctx = NULL;

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -138,7 +138,7 @@ int wolfCrypt_Init(void)
             time_t seed = time(NULL);
             srand((word32)seed);
             rngMallocFail = rand() % 2000; /* max 2000 */
-            printf("\n--- RNG MALLOC FAIL AT %u ---\n", rngMallocFail);
+            fprintf(stderr, "\n--- RNG MALLOC FAIL AT %u ---\n", rngMallocFail);
             wolfSSL_SetMemFailCount(rngMallocFail);
         }
     #endif

--- a/wolfssl/test.h
+++ b/wolfssl/test.h
@@ -1019,7 +1019,7 @@ static WC_INLINE void ShowX509Ex(WOLFSSL_X509* x509, const char* hdr,
     const char** words = client_showx509_msg[lng_index];
 
     if (x509 == NULL) {
-        printf("%s No Cert\n", hdr);
+        fprintf(stderr, "%s No Cert\n", hdr);
         return;
     }
 
@@ -1100,7 +1100,7 @@ static WC_INLINE void ShowX509Chain(WOLFSSL_X509_CHAIN* chain, int count,
         if (chainX509)
             ShowX509(chainX509, hdr);
         else
-            printf("get_chain_X509 failed\n");
+            fprintf(stderr, "get_chain_X509 failed\n");
         wolfSSL_FreeX509(chainX509);
     }
 }
@@ -1128,7 +1128,7 @@ static WC_INLINE void showPeerEx(WOLFSSL* ssl, int lng_index)
     if (peer)
         ShowX509Ex(peer, words[6], lng_index);
     else
-        printf("peer has no cert!\n");
+        fprintf(stderr, "peer has no cert!\n");
     wolfSSL_FreeX509(peer);
 #endif
 #if defined(SHOW_CERTS) && defined(KEEP_OUR_CERT) && \
@@ -1536,7 +1536,7 @@ static int wolfSentry_NetworkFilterCallback(
         else
             *decision = WOLFSSL_NETFILTER_PASS;
     } else {
-        printf("wolfsentry_route_event_dispatch error "
+        fprintf(stderr, "wolfsentry_route_event_dispatch error "
                WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
         *decision = WOLFSSL_NETFILTER_PASS;
     }
@@ -1787,7 +1787,7 @@ static WC_INLINE int tcp_connect_with_wolfSentry(
         &action_results);
 
     if (ret < 0) {
-        printf("wolfsentry_route_event_dispatch error "
+        fprintf(stderr, "wolfsentry_route_event_dispatch error "
                WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
         decision = WOLFSSL_NETFILTER_PASS;
     } else {
@@ -2549,7 +2549,7 @@ static WC_INLINE void OCSPRespFreeCb(void* ioCtx, unsigned char* response)
         /* open file (read-only binary) */
         lFile = XFOPEN(fname, "rb");
         if (!lFile) {
-            printf("Error loading %s\n", fname);
+            fprintf(stderr, "Error loading %s\n", fname);
             return BAD_PATH_ERROR;
         }
 
@@ -2561,7 +2561,8 @@ static WC_INLINE void OCSPRespFreeCb(void* ioCtx, unsigned char* response)
             *buf = (byte*)malloc(*bufLen);
             if (*buf == NULL) {
                 ret = MEMORY_E;
-                printf("Error allocating %lu bytes\n", (unsigned long)*bufLen);
+                fprintf(stderr,
+                        "Error allocating %lu bytes\n", (unsigned long)*bufLen);
             }
             else {
                 size_t readLen = fread(*buf, *bufLen, 1, lFile);
@@ -2744,7 +2745,7 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
         will be discarded (only with SESSION_CERTS)
      */
 
-    printf("In verification callback, error = %d, %s\n", store->error,
+    fprintf(stderr, "In verification callback, error = %d, %s\n", store->error,
                                  wolfSSL_ERR_error_string(store->error, buffer));
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     peer = store->current_cert;
@@ -2777,7 +2778,7 @@ static WC_INLINE int myVerify(int preverify, WOLFSSL_X509_STORE_CTX* store)
 #endif
     }
     else
-        printf("\tPeer has no cert!\n");
+        fprintf(stderr, "\tPeer has no cert!\n");
 #else
     printf("\tPeer certs: %d\n", store->totalCerts);
     #ifdef SHOW_CERTS
@@ -3072,7 +3073,9 @@ int StackSizeHWMReset(void)
     printf("    relative stack peak usage = %ld bytes\n", (long int)HWM);  \
     _ret = StackSizeHWMReset();                      \
     if ((max >= 0) && (HWM > (ssize_t)(max))) {      \
-        printf("    relative stack usage at %s L%d exceeds designated max %ld bytes.\n", __FILE__, __LINE__, (long int)(max)); \
+        fprintf(stderr,                              \
+            "    relative stack usage at %s L%d exceeds designated max %ld bytes.\n", \
+            __FILE__, __LINE__, (long int)(max));    \
         _ret = -1;                                   \
     }                                                \
     _ret;                                            \
@@ -3367,7 +3370,7 @@ static WC_INLINE int myMacEncryptCb(WOLFSSL* ssl, unsigned char* macOut,
 
         ret = wc_AesSetKey(&encCtx->aes, key, keyLen, iv, AES_ENCRYPTION);
         if (ret != 0) {
-            printf("AesSetKey failed in myMacEncryptCb\n");
+            fprintf(stderr, "AesSetKey failed in myMacEncryptCb\n");
             return ret;
         }
         encCtx->keySetup = 1;
@@ -3423,7 +3426,7 @@ static WC_INLINE int myDecryptVerifyCb(WOLFSSL* ssl,
 
         ret = wc_AesSetKey(&decCtx->aes, key, keyLen, iv, AES_DECRYPTION);
         if (ret != 0) {
-            printf("AesSetKey failed in myDecryptVerifyCb\n");
+            fprintf(stderr, "AesSetKey failed in myDecryptVerifyCb\n");
             return ret;
         }
         decCtx->keySetup = 1;
@@ -3517,7 +3520,7 @@ static WC_INLINE int myEncryptMacCb(WOLFSSL* ssl, unsigned char* macOut,
 
         ret = wc_AesSetKey(&encCtx->aes, key, keyLen, iv, AES_ENCRYPTION);
         if (ret != 0) {
-            printf("AesSetKey failed in myMacEncryptCb\n");
+            fprintf(stderr, "AesSetKey failed in myMacEncryptCb\n");
             return ret;
         }
         encCtx->keySetup = 1;
@@ -3615,7 +3618,7 @@ static WC_INLINE int myVerifyDecryptCb(WOLFSSL* ssl,
 
         ret = wc_AesSetKey(&decCtx->aes, key, keyLen, iv, AES_DECRYPTION);
         if (ret != 0) {
-            printf("AesSetKey failed in myDecryptVerifyCb\n");
+            fprintf(stderr, "AesSetKey failed in myDecryptVerifyCb\n");
             return ret;
         }
         decCtx->keySetup = 1;
@@ -5077,20 +5080,20 @@ static WC_INLINE const char* mymktemp(char *tempfn, int len, int num)
     byte   out = 0;
 
     if (tempfn == NULL || len < 1 || num < 1 || len <= num) {
-        printf("Bad input\n");
+        fprintf(stderr, "Bad input\n");
         return NULL;
     }
 
     size = len - 1;
 
     if (wc_InitRng(&rng) != 0) {
-        printf("InitRng failed\n");
+        fprintf(stderr, "InitRng failed\n");
         return NULL;
     }
 
     for (x = size; x > size - num; x--) {
         if (wc_RNG_GenerateBlock(&rng,(byte*)&out, sizeof(out)) != 0) {
-            printf("RNG_GenerateBlock failed\n");
+            fprintf(stderr, "RNG_GenerateBlock failed\n");
             return NULL;
         }
         tempfn[x] = alphanum[out % (sizeof(alphanum) - 1)];

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -434,7 +434,7 @@ decouple library dependencies with standard string, memory and so on.
             #ifdef WOLFSSL_MALLOC_CHECK
                 #include <stdio.h>
                 static inline void* malloc_check(size_t sz) {
-                    printf("wolfSSL_malloc failed");
+                    fprintf(stderr, "wolfSSL_malloc failed");
                     return NULL;
                 };
                 #define XMALLOC(s, h, t)     malloc_check((s))


### PR DESCRIPTION
also,

fix whitespace in internal.c;

add missing error handling in examples/server/server.c around recvfrom().

tested with `wolfssl-multi-test ... quick-check`
