### PR TITLE
Add ability to store issuer name components when parsing a certificate.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -709,6 +709,9 @@ then
 
     # Enable deterministic ECC signing API with variant
     AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_ECDSA_DETERMINISTIC_K_VARIANT"
+
+    # Store issuer name components when parsing certificates.
+    AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_HAVE_ISSUER_NAMES"
 fi
 
 

--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -7827,6 +7827,6 @@ int main(int argc, char** argv)
 
 #else
     #ifndef NO_MAIN_DRIVER
-        int main() { return 0; }
+        int main(void) { return 0; }
     #endif
 #endif /* !NO_CRYPT_BENCHMARK */

--- a/wolfssl/wolfcrypt/asn.h
+++ b/wolfssl/wolfcrypt/asn.h
@@ -1607,6 +1607,34 @@ struct DecodedCert {
     char    subjectPCEnc;
     char*   subjectEmail;
     int     subjectEmailLen;
+#if defined(WOLFSSL_HAVE_ISSUER_NAMES)
+    char*   issuerCN;
+    int     issuerCNLen;
+    char    issuerCNEnc;
+    char*   issuerSN;
+    int     issuerSNLen;
+    char    issuerSNEnc;
+    char*   issuerC;
+    int     issuerCLen;
+    char    issuerCEnc;
+    char*   issuerL;
+    int     issuerLLen;
+    char    issuerLEnc;
+    char*   issuerST;
+    int     issuerSTLen;
+    char    issuerSTEnc;
+    char*   issuerO;
+    int     issuerOLen;
+    char    issuerOEnc;
+    char*   issuerOU;
+    int     issuerOULen;
+    char    issuerOUEnc;
+    char*   issuerSND;
+    int     issuerSNDLen;
+    char    issuerSNDEnc;
+    char*   issuerEmail;
+    int     issuerEmailLen;
+#endif /* WOLFSSL_HAVE_ISSUER_NAMES */
 #endif /* defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_CERT_EXT) */
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     /* WOLFSSL_X509_NAME structures (used void* to avoid including ssl.h) */


### PR DESCRIPTION
# Description

This is turned on when `WOLFSSL_HAVE_ISSUER_NAMES` is defined. This allows the user to inspect various issuer name components (e.g. locality, organization, etc.) by using these new fields in a `DecodedCert`.

Fixes ZD #14192.

# Testing

I used gdb to step through `test_wc_GetPubKeyDerFromCert` and verified that these new fields were set when the test cert was parsed.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
