### PR TITLE
Fix to allow enabling AES key wrap (direct) with KCAPI

### DIFF
--- a/wolfcrypt/src/aes.c
+++ b/wolfcrypt/src/aes.c
@@ -1069,6 +1069,7 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
     #if defined(WOLFSSL_AES_COUNTER) || defined(HAVE_AESCCM) || \
         defined(WOLFSSL_CMAC) || defined(WOLFSSL_AES_OFB) || \
         defined(WOLFSSL_AES_CFB) || defined(HAVE_AES_ECB) || \
+        defined(WOLFSSL_AES_DIRECT) || \
         (defined(HAVE_AES_CBC) && defined(WOLFSSL_NO_KCAPI_AES_CBC))
 
         #define NEED_AES_TABLES


### PR DESCRIPTION
# Description

Fix to allow enabling AES key wrap (direct) with KCAPI.

Fixes zd14182

# Testing

`./configure --enable-kcapi --enable-aeskeywrap`

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
