### PR TITLE
internal.c:reset input/processReply state if exiting after DoAlert()

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -17708,8 +17708,12 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                         return ret;
 
                     /* catch warnings that are handled as errors */
-                    if (type == close_notify)
+                    if (type == close_notify) {
+                        ssl->buffers.inputBuffer.idx =
+                            ssl->buffers.inputBuffer.length;
+                        ssl->options.processReply = doProcessInit;
                         return ssl->error = ZERO_RETURN;
+                    }
 
                     if (type == decrypt_error)
                         return FATAL_ERROR;

--- a/src/internal.c
+++ b/src/internal.c
@@ -17396,6 +17396,10 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
 
         /* the record layer is here */
         case runProcessingOneMessage:
+            /* can't process a message if we have no data.  */
+            if (ssl->buffers.inputBuffer.idx
+                >= ssl->buffers.inputBuffer.length)
+                return BUFFER_ERROR;
 
        #if defined(HAVE_ENCRYPT_THEN_MAC) && !defined(WOLFSSL_AEAD_ONLY)
             if (IsEncryptionOn(ssl, 0) && ssl->options.startedETMRead) {


### PR DESCRIPTION
# Description

The checks refactored in f06ac9965c5105b9b767b4e894b52a816ec1a2f6 were avoiding memory corruption when when the state of the `processReplyEx` was left incoherent. This fixes that, but it's unclear if those checks were catching something else. 



# Testing

found used fuzzer seed 1674065818


