### PR TITLE
add padding for variable ecc signature size

### DIFF
--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -2624,9 +2624,11 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7, ESD* esd,
 
     if (totalSz > *outputSz) {
         if (*outputSz == 0) {
+        #ifdef HAVE_ECC
             if (pkcs7->publicKeyOID == ECDSAk) {
                 totalSz += ECC_MAX_PAD_SZ; /* signatures size can vary */
             }
+        #endif
             *outputSz = totalSz;
             idx = totalSz;
             goto out;

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -2624,6 +2624,9 @@ static int PKCS7_EncodeSigned(PKCS7* pkcs7, ESD* esd,
 
     if (totalSz > *outputSz) {
         if (*outputSz == 0) {
+            if (pkcs7->publicKeyOID == ECDSAk) {
+                totalSz += ECC_MAX_PAD_SZ; /* signatures size can vary */
+            }
             *outputSz = totalSz;
             idx = totalSz;
             goto out;


### PR DESCRIPTION
# Description

Variable size in ECC signatures could lead to the precalculated value being less than needed size.

Fixes zd#14177


