### PR TITLE
Fix main signature in benchmark.c.

### DIFF
--- a/wolfcrypt/benchmark/benchmark.c
+++ b/wolfcrypt/benchmark/benchmark.c
@@ -7827,6 +7827,6 @@ int main(int argc, char** argv)
 
 #else
     #ifndef NO_MAIN_DRIVER
-        int main() { return 0; }
+        int main(void) { return 0; }
     #endif
 #endif /* !NO_CRYPT_BENCHMARK */


### PR DESCRIPTION
# Description

If `NO_CRYPT_BENCHMARK` is defined, the main function is `int main()`, but it should be `int main(void)`.

# Testing

Compiled with this PRB config:

```
./configure --enable-linuxkm-defaults --enable-all --enable-crypttests --disable-examples --enable-asm --enable-aesni CFLAGS="-Wframe-larger-than=4096 -DNO_CRYPT_BENCHMARK -g3"
```

Compilation failed on my machine before this fix with:

```
wolfcrypt/benchmark/benchmark.c:7830:13: error: function declaration isn’t a prototype [-Werror=strict-prototypes]
 7830 |         int main() { return 0; }
      |           
```

It succeeds after the fix.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
