### PR TITLE
ssl: check that peer auth succeded in wolfSSL_get_peer_certificate()

### DIFF
--- a/doc/dox_comments/header_files/ssl.h
+++ b/doc/dox_comments/header_files/ssl.h
@@ -5554,8 +5554,9 @@ int  wolfSSL_state(WOLFSSL* ssl);
     \brief This function gets the peer’s certificate.
 
     \return pointer a pointer to the peerCert member of the WOLFSSL_X509
-    structure if it exists.
-    \return 0 returned if the peer certificate issuer size is not defined.
+    structure if it exists and the authentication completed successfully.
+    \return NULL returned if the peer certificate issuer size is not defined or
+    if the authentication did not complete successfully.
 
     \param ssl a pointer to a WOLFSSL structure, created using wolfSSL_new().
 

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -18420,14 +18420,14 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     }
 #endif /* (KEEP_PEER_CERT & SESSION_CERTS) || (OPENSSL_EXTRA & SESSION_CERTS) */
 
-
 #ifdef KEEP_PEER_CERT
     WOLFSSL_ABI
     WOLFSSL_X509* wolfSSL_get_peer_certificate(WOLFSSL* ssl)
     {
         WOLFSSL_X509* ret = NULL;
         WOLFSSL_ENTER("SSL_get_peer_certificate");
-        if (ssl != NULL) {
+        if (ssl != NULL && ssl->options.handShakeState == HANDSHAKE_DONE
+            && ssl->options.peerAuthGood) {
             if (ssl->peerCert.issuer.sz)
                 ret = wolfSSL_X509_dup(&ssl->peerCert);
 #ifdef SESSION_CERTS


### PR DESCRIPTION
# Description

`wolfSSL_get_peer_cerificate()` returns the certificate even if the peer isn't authenticated yet. 

# Testing

`make check`
