### PR TITLE
Fix --enable-openssh FIPS detection syntax in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2758,7 +2758,7 @@ AC_ARG_ENABLE([ed25519-stream],
     )
 
 
-if (test "$ENABLED_OPENSSH" = "yes" && "x$ENABLED_FIPS" = "xno") || \
+if (test "$ENABLED_OPENSSH" = "yes" && test "x$ENABLED_FIPS" = "xno") || \
    test "$ENABLED_CHRONY" = "yes"
 then
     ENABLED_ED25519="yes"


### PR DESCRIPTION
# Description

Fixes typo in `--enabe-openssh` detection of FIPS.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
