### PR TITLE
Rename HAVE_AES_GCM guard to HAVE_AESGCM in the tests.

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -44615,6 +44615,7 @@ static void test_wolfSSL_EVP_CIPHER_block_size(void)
     #endif
 #endif
 
+#ifdef HAVE_AESGCM
     #ifdef WOLFSSL_AES_128
     AssertIntEQ(EVP_CIPHER_block_size(EVP_aes_128_gcm()), 1);
     #endif
@@ -44624,6 +44625,7 @@ static void test_wolfSSL_EVP_CIPHER_block_size(void)
     #ifdef WOLFSSL_AES_256
     AssertIntEQ(EVP_CIPHER_block_size(EVP_aes_256_gcm()), 1);
     #endif
+#endif
 
 #ifdef WOLFSSL_AES_COUNTER
     #ifdef WOLFSSL_AES_128

--- a/tests/api.c
+++ b/tests/api.c
@@ -44615,7 +44615,6 @@ static void test_wolfSSL_EVP_CIPHER_block_size(void)
     #endif
 #endif
 
-#ifdef HAVE_AES_GCM
     #ifdef WOLFSSL_AES_128
     AssertIntEQ(EVP_CIPHER_block_size(EVP_aes_128_gcm()), 1);
     #endif
@@ -44625,7 +44624,6 @@ static void test_wolfSSL_EVP_CIPHER_block_size(void)
     #ifdef WOLFSSL_AES_256
     AssertIntEQ(EVP_CIPHER_block_size(EVP_aes_256_gcm()), 1);
     #endif
-#endif
 
 #ifdef WOLFSSL_AES_COUNTER
     #ifdef WOLFSSL_AES_128


### PR DESCRIPTION

# Testing

`grep -r HAVE_AES_GCM * `
