### PR TITLE
20220519-multi-test-fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7788,10 +7788,10 @@ AM_CONDITIONAL([BUILD_OCTEON_SYNC],[test "x$ENABLED_OCTEON_SYNC" = "xyes"])
 AM_CONDITIONAL([BUILD_INTEL_QA],[test "x$ENABLED_INTEL_QA" = "xyes"])
 AM_CONDITIONAL([BUILD_INTEL_QA_SYNC],[test "x$ENABLED_INTEL_QA_SYNC" = "xyes"])
 AM_CONDITIONAL([BUILD_SP],[test "x$ENABLED_SP" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])
-AM_CONDITIONAL([BUILD_SP_C32],[(((test "$ENABLED_SP_RSA" = "yes" || test "$ENABLED_SP_DH" = "yes" \
+AM_CONDITIONAL([BUILD_SP_C32],[ ( ( (test "$ENABLED_SP_RSA" = "yes" || test "$ENABLED_SP_DH" = "yes" \
                                || test "$ENABLED_SP_ECC" = "yes") && test "x$ENABLED_SP_ASM" = "xno") \
                              || test "x$ENABLED_USERSETTINGS" = "xyes") && test "x$ENABLED_64BIT" != "xyes"])
-AM_CONDITIONAL([BUILD_SP_C64],[(((test "$ENABLED_SP_RSA" = "yes" || test "$ENABLED_SP_DH" = "yes" \
+AM_CONDITIONAL([BUILD_SP_C64],[ ( ( (test "$ENABLED_SP_RSA" = "yes" || test "$ENABLED_SP_DH" = "yes" \
                                || test "$ENABLED_SP_ECC" = "yes") && test "x$ENABLED_SP_ASM" = "xno") \
                              || test "x$ENABLED_USERSETTINGS" = "xyes") && test "x$ENABLED_32BIT" != "xyes"])
 AM_CONDITIONAL([BUILD_SP_ARM64],[test "x$ENABLED_SP_ARM64_ASM" = "xyes" || test "x$ENABLED_USERSETTINGS" = "xyes"])

--- a/scripts/external.test
+++ b/scripts/external.test
@@ -10,39 +10,39 @@ ca=./certs/wolfssl-website-ca.pem
 [ ! -x ./examples/client/client ] && echo -e "\n\nClient doesn't exist" && exit 1
 
 # www.wolfssl.com isn't using RFC 8446 yet but the draft instead.
-./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
-if [ $? -ne 0 ]; then
+if ! ./examples/client/client -V | grep -q 3; then
+    echo 'skipping external.test because TLS1.2 is not available.' 1>&2
+    exit 0
+fi
 
-    # cloudflare seems to change CAs quickly, disabled by default
-    if test -n "$WOLFSSL_EXTERNAL_TEST"; then
+# cloudflare seems to change CAs quickly, disabled by default
+if test -n "$WOLFSSL_EXTERNAL_TEST"; then
 
-        BUILD_FLAGS="$(./examples/client/client '-#')"
-        if echo "$BUILD_FLAGS" | fgrep -q -e ' -DWOLFSSL_SNIFFER '; then
-            echo 'skipping WOLFSSL_EXTERNAL_TEST because -DWOLFSSL_SNIFFER configuration of build is incompatible.'
-            exit 0
-        fi
-
-        if echo "$BUILD_FLAGS" | fgrep -v -q -e ' -DHAVE_ECC '; then
-            echo 'skipping WOLFSSL_EXTERNAL_TEST because -UHAVE_ECC configuration of build is incompatible.'
-            exit 0
-        fi
-
-        echo "WOLFSSL_EXTERNAL_TEST set, running test..."
-    else
-        echo "WOLFSSL_EXTERNAL_TEST NOT set, won't run"
+    BUILD_FLAGS="$(./examples/client/client '-#')"
+    if echo "$BUILD_FLAGS" | fgrep -q -e ' -DWOLFSSL_SNIFFER '; then
+        echo 'skipping WOLFSSL_EXTERNAL_TEST because -DWOLFSSL_SNIFFER configuration of build is incompatible.'
         exit 0
     fi
 
-    # is our desired server there?
-    "${SCRIPT_DIR}"/ping.test $server 2
-    RESULT=$?
-    [ $RESULT -ne 0 ] && exit 0
+    if echo "$BUILD_FLAGS" | fgrep -v -q -e ' -DHAVE_ECC '; then
+        echo 'skipping WOLFSSL_EXTERNAL_TEST because -UHAVE_ECC configuration of build is incompatible.'
+        exit 0
+    fi
 
-    # client test against the server
-    ./examples/client/client -X -C -h $server -p 443 -g -A $ca
-    RESULT=$?
-    [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
-
+    echo "WOLFSSL_EXTERNAL_TEST set, running test..."
+else
+    echo "WOLFSSL_EXTERNAL_TEST NOT set, won't run"
+    exit 0
 fi
+
+# is our desired server there?
+"${SCRIPT_DIR}"/ping.test $server 2
+RESULT=$?
+[ $RESULT -ne 0 ] && exit 0
+
+# client test against the server
+./examples/client/client -X -C -h $server -p 443 -g -A $ca
+RESULT=$?
+[ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 
 exit 0

--- a/scripts/google.test
+++ b/scripts/google.test
@@ -6,9 +6,8 @@ server=www.google.com
 
 [ ! -x ./examples/client/client ] && echo -e "\n\nClient doesn't exist" && exit 1
 
-./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
-if [ $? -eq 0 ]; then
-    echo -e "\n\nClient doesn't support TLS v1.2"
+if ! ./examples/client/client -V | grep -q 3; then
+    echo 'skipping google.test because TLS1.2 is not available.' 1>&2
     exit 0
 fi
 
@@ -22,8 +21,7 @@ RESULT=$?
 RESULT=$?
 [ $RESULT -ne 0 ] && echo -e "\n\nClient connection failed" && exit 1
 
-./examples/client/client -v 4 2>&1 | grep -- 'Bad SSL version'
-if [ $? -ne 0 ]; then
+if ./examples/client/client -V | grep -q 4; then
     # client test against the server using TLS v1.3
     ./examples/client/client -v 4 -X -C -h $server -p 443 -g -d
     RESULT=$?

--- a/scripts/ocsp-stapling-with-ca-as-responder.test
+++ b/scripts/ocsp-stapling-with-ca-as-responder.test
@@ -23,10 +23,8 @@ if [[ -z "${RETRIES_REMAINING-}" ]]; then
     export RETRIES_REMAINING=2
 fi
 
-./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
-if [ $? -eq 0 ]; then
-    echo "TLS 1.2 or lower required"
-    echo "Skipped"
+if ! ./examples/client/client -V | grep -q 3; then
+    echo 'skipping ocsp-stapling-with-ca-as-responder.test because TLS1.2 is not available.' 1>&2
     exit 0
 fi
 

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -430,13 +430,13 @@ if [ "$openssl_tls13" = "0" -a "$wolfssl_tls13" = "0" ]; then
 else
     echo -n 'skipping TLS1.3 stapling interoperability test:' 1>&2
     if [ "$openssl_tls13" != "0" ]; then
-	echo -n ' OpenSSL' 1>&2
+        echo -n ' OpenSSL' 1>&2
     fi
     if [ "$wolfssl_tls13" != "0" ]; then
-	if [ "$openssl_tls13" != "0" ]; then
-	    echo -n ' and' 1>&2
-	fi
-	echo -n ' wolfSSL' 1>&2
+        if [ "$openssl_tls13" != "0" ]; then
+            echo -n ' and' 1>&2
+        fi
+        echo -n ' wolfSSL' 1>&2
     fi
     echo -n ' missing TLS1.3 support.' 1>&2
 fi

--- a/scripts/ocsp-stapling.test
+++ b/scripts/ocsp-stapling.test
@@ -11,10 +11,8 @@ if [[ -z "${RETRIES_REMAINING-}" ]]; then
     export RETRIES_REMAINING=2
 fi
 
-./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
-if [ $? -eq 0 ]; then
-    echo "TLS 1.2 or lower required"
-    echo "Skipped"
+if ! ./examples/client/client -V | grep -q 3; then
+    echo 'skipping ocsp-stapling.test because TLS1.2 is not available.' 1>&2
     exit 0
 fi
 
@@ -331,8 +329,7 @@ RESULT=$?
 printf '%s\n\n' "Test successfully REVOKED!"
 
 
-./examples/client/client -v 4 2>&1 | grep -- 'Bad SSL version'
-if [ $? -ne 0 ]; then
+if ./examples/client/client -V | grep -q 4; then
     printf '%s\n\n' "------------- TEST CASE 3 SHOULD PASS --------------------"
     # client test against our own server - GOOD CERT
     remove_single_rF "$ready_file2"
@@ -376,6 +373,8 @@ if [ $? -ne 0 ]; then
                       printf '\n\n%s\n' "Client connection 5 succeeded $RESULT" \
                       && exit 1
     printf '%s\n\n' "Test successfully REVOKED!"
+else
+    echo 'skipping TLS1.3 stapling tests.' 1>&2
 fi
 
 # need a unique port since may run the same time as testsuite
@@ -408,9 +407,9 @@ printf '%s\n\n' "Test PASSED!"
 
 openssl ciphers -tls1_3
 openssl_tls13=$?
-./examples/client/client -v 4 2>&1 | grep -- 'Bad SSL version'
-wolfssl_not_tls13=$?
-if [ "$openssl_tls13" = "0" -a "$wolfssl_not_tls13" != "0" ]; then
+./examples/client/client -V | grep -q 4
+wolfssl_tls13=$?
+if [ "$openssl_tls13" = "0" -a "$wolfssl_tls13" = "0" ]; then
     printf '%s\n\n' "------------- TEST CASE 8 SHOULD PASS --------------------"
     # client asks for OCSP staple but doesn't fail when none returned
     ./examples/client/client -p $port -g -v 4 -W 1
@@ -428,6 +427,18 @@ if [ "$openssl_tls13" = "0" -a "$wolfssl_not_tls13" != "0" ]; then
                   && printf '\n\n%s\n' "Client connection 9 succeeded $RESULT" \
                   && exit 1
     printf '%s\n\n' "Test PASSED!"
+else
+    echo -n 'skipping TLS1.3 stapling interoperability test:' 1>&2
+    if [ "$openssl_tls13" != "0" ]; then
+	echo -n ' OpenSSL' 1>&2
+    fi
+    if [ "$wolfssl_tls13" != "0" ]; then
+	if [ "$openssl_tls13" != "0" ]; then
+	    echo -n ' and' 1>&2
+	fi
+	echo -n ' wolfSSL' 1>&2
+    fi
+    echo -n ' missing TLS1.3 support.' 1>&2
 fi
 
 printf '%s\n\n' "------------------- TESTS COMPLETE ---------------------------"

--- a/scripts/ocsp-stapling2.test
+++ b/scripts/ocsp-stapling2.test
@@ -24,10 +24,8 @@ if [[ -z "${RETRIES_REMAINING-}" ]]; then
     export RETRIES_REMAINING=2
 fi
 
-./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
-if [ $? -eq 0 ]; then
-    echo "TLS 1.2 or lower required"
-    echo "Skipped"
+if ! ./examples/client/client -V | grep -q 3; then
+    echo 'skipping ocsp-stapling2.test because TLS1.2 is not available.' 1>&2
     exit 0
 fi
 

--- a/scripts/ocsp.test
+++ b/scripts/ocsp.test
@@ -12,10 +12,8 @@ ca=certs/external/ca-globalsign-root.pem
 [ ! -x ./examples/client/client ] && printf '\n\n%s\n' "Client doesn't exist" \
                                   && exit 1
 
-./examples/client/client -v 3 2>&1 | grep -- 'Bad SSL version'
-if [ $? -eq 0 ]; then
-    echo "TLS 1.2 or lower required"
-    echo "Skipped"
+if ! ./examples/client/client -V | grep -q 3; then
+    echo 'skipping ocsp.test because TLS1.2 is not available.' 1>&2
     exit 0
 fi
 

--- a/src/wolfio.c
+++ b/src/wolfio.c
@@ -317,8 +317,12 @@ int EmbedSend(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 
 #include <wolfssl/wolfcrypt/sha.h>
 
-#define SENDTO_FUNCTION sendto
-#define RECVFROM_FUNCTION recvfrom
+#ifndef DTLS_SENDTO_FUNCTION
+    #define DTLS_SENDTO_FUNCTION sendto
+#endif
+#ifndef DTLS_RECVFROM_FUNCTION
+    #define DTLS_RECVFROM_FUNCTION recvfrom
+#endif
 
 static int sockAddrEqual(
     SOCKADDR_S *a, XSOCKLENT aLen, SOCKADDR_S *b, XSOCKLENT bLen)
@@ -413,7 +417,9 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
     }
 #endif /* !NO_ASN_TIME */
 
-    recvd = (int)RECVFROM_FUNCTION(sd, buf, sz, ssl->rflags,
+    XMEMSET(&peer, 0, sizeof(peer));
+
+    recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, sz, ssl->rflags,
                                   (SOCKADDR*)&peer, &peerSz);
 
     recvd = TranslateReturnCode(recvd, sd);
@@ -455,7 +461,7 @@ int EmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 
     WOLFSSL_ENTER("EmbedSendTo()");
 
-    sent = (int)SENDTO_FUNCTION(sd, buf, sz, ssl->wflags,
+    sent = (int)DTLS_SENDTO_FUNCTION(sd, buf, sz, ssl->wflags,
                                 (const SOCKADDR*)dtlsCtx->peer.sa,
                                 dtlsCtx->peer.sz);
 
@@ -483,7 +489,7 @@ int EmbedReceiveFromMcast(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 
     WOLFSSL_ENTER("EmbedReceiveFromMcast()");
 
-    recvd = (int)RECVFROM_FUNCTION(sd, buf, sz, ssl->rflags, NULL, NULL);
+    recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, sz, ssl->rflags, NULL, NULL);
 
     recvd = TranslateReturnCode(recvd, sd);
 


### PR DESCRIPTION
wolfcrypt/src/asn.c: refactor `DecodeBasicOcspResponse()` to keep `DecodedCert` off the stack in `WOLFSSL_SMALL_STACK` builds.

src/wolfio.c: in `EmbedReceiveFrom()`, clear peer before `recvfrom()` to fix `clang-analyzer-core.UndefinedBinaryOperatorResult`; add `DTLS_` prefix to macros `SENDTO_FUNCTION` and `RECVFROM_FUNCTION`, and gate their definitions on their being undefined to allow overrides.

scripts/: refactor TLS version support tests to use `-V`, rather than `-v` (which makes frivolous connection attempts).


tested with `wolfssl-multi-test.sh ... quick-check all-crypto-linuxkm-defaults-max-func-stack-2k-build commit-test-potpourri clang-tidy-all-async`
