### PR TITLE
Provide access to "Finished" messages outside the compat layer.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -7054,7 +7054,7 @@ void SSL_ResourceFree(WOLFSSL* ssl)
         ForceZero(&ssl->serverSecret, sizeof(ssl->serverSecret));
     }
 #endif
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+#ifdef WOLFSSL_HAVE_TLS_UNIQUE
     ForceZero(&ssl->clientFinished, TLS_FINISHED_SZ_MAX);
     ForceZero(&ssl->serverFinished, TLS_FINISHED_SZ_MAX);
     ssl->serverFinished_len = 0;
@@ -13613,7 +13613,7 @@ int DoFinished(WOLFSSL* ssl, const byte* input, word32* inOutIdx, word32 size,
         ssl->secure_renegotiation->verifySet = 1;
     }
 #endif
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+#ifdef WOLFSSL_HAVE_TLS_UNIQUE
     if (ssl->options.side == WOLFSSL_CLIENT_END) {
         XMEMCPY(ssl->serverFinished,
                 input + *inOutIdx, TLS_FINISHED_SZ);
@@ -18716,7 +18716,7 @@ int SendFinished(WOLFSSL* ssl)
                     TLS_FINISHED_SZ);
     }
 #endif
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+#ifdef WOLFSSL_HAVE_TLS_UNIQUE
     if (ssl->options.side == WOLFSSL_CLIENT_END) {
         XMEMCPY(ssl->clientFinished,
                 hashes, TLS_FINISHED_SZ);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -22897,52 +22897,6 @@ int wolfSSL_i2d_ASN1_OBJECT(WOLFSSL_ASN1_OBJECT *a, unsigned char **pp)
     return a->objSz;
 }
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
-WOLFSSL_API size_t wolfSSL_get_finished(const WOLFSSL *ssl, void *buf, size_t count)
-{
-    byte len = 0;
-
-    WOLFSSL_ENTER("SSL_get_finished");
-
-    if (!ssl || !buf || count < TLS_FINISHED_SZ) {
-        WOLFSSL_MSG("Bad parameter");
-        return WOLFSSL_FAILURE;
-    }
-
-    if (ssl->options.side == WOLFSSL_SERVER_END) {
-        len = ssl->serverFinished_len;
-        XMEMCPY(buf, ssl->serverFinished, len);
-    }
-    else {
-        len = ssl->clientFinished_len;
-        XMEMCPY(buf, ssl->clientFinished, len);
-    }
-    return len;
-}
-
-WOLFSSL_API size_t wolfSSL_get_peer_finished(const WOLFSSL *ssl, void *buf, size_t count)
-{
-    byte len = 0;
-    WOLFSSL_ENTER("SSL_get_peer_finished");
-
-    if (!ssl || !buf || count < TLS_FINISHED_SZ) {
-        WOLFSSL_MSG("Bad parameter");
-        return WOLFSSL_FAILURE;
-    }
-
-    if (ssl->options.side == WOLFSSL_CLIENT_END) {
-        len = ssl->serverFinished_len;
-        XMEMCPY(buf, ssl->serverFinished, len);
-    }
-    else {
-        len = ssl->clientFinished_len;
-        XMEMCPY(buf, ssl->clientFinished, len);
-    }
-
-    return len;
-}
-#endif /* WOLFSSL_HAPROXY */
-
 #ifndef NO_WOLFSSL_STUB
 /*** TBD ***/
 WOLFSSL_API void SSL_CTX_set_tmp_dh_callback(WOLFSSL_CTX *ctx, WOLFSSL_DH *(*dh) (WOLFSSL *ssl, int is_export, int keylength))
@@ -23041,6 +22995,52 @@ WOLFSSL_API int wolfSSL_set_tlsext_max_fragment_length(WOLFSSL *s,
 #endif /* HAVE_MAX_FRAGMENT */
 
 #endif /* OPENSSL_EXTRA */
+
+#ifdef WOLFSSL_HAVE_TLS_UNIQUE
+WOLFSSL_API size_t wolfSSL_get_finished(const WOLFSSL *ssl, void *buf, size_t count)
+{
+    byte len = 0;
+
+    WOLFSSL_ENTER("SSL_get_finished");
+
+    if (!ssl || !buf || count < TLS_FINISHED_SZ) {
+        WOLFSSL_MSG("Bad parameter");
+        return WOLFSSL_FAILURE;
+    }
+
+    if (ssl->options.side == WOLFSSL_SERVER_END) {
+        len = ssl->serverFinished_len;
+        XMEMCPY(buf, ssl->serverFinished, len);
+    }
+    else {
+        len = ssl->clientFinished_len;
+        XMEMCPY(buf, ssl->clientFinished, len);
+    }
+    return len;
+}
+
+WOLFSSL_API size_t wolfSSL_get_peer_finished(const WOLFSSL *ssl, void *buf, size_t count)
+{
+    byte len = 0;
+    WOLFSSL_ENTER("SSL_get_peer_finished");
+
+    if (!ssl || !buf || count < TLS_FINISHED_SZ) {
+        WOLFSSL_MSG("Bad parameter");
+        return WOLFSSL_FAILURE;
+    }
+
+    if (ssl->options.side == WOLFSSL_CLIENT_END) {
+        len = ssl->serverFinished_len;
+        XMEMCPY(buf, ssl->serverFinished, len);
+    }
+    else {
+        len = ssl->clientFinished_len;
+        XMEMCPY(buf, ssl->clientFinished, len);
+    }
+
+    return len;
+}
+#endif /* WOLFSSL_HAVE_TLS_UNIQUE */
 
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 long wolfSSL_get_verify_result(const WOLFSSL *ssl)

--- a/src/tls13.c
+++ b/src/tls13.c
@@ -7008,7 +7008,7 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     if (sniff == NO_SNIFF) {
         ret = BuildTls13HandshakeHmac(ssl, secret, mac, &finishedSz);
-    #if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+    #ifdef WOLFSSL_HAVE_TLS_UNIQUE
         if (ssl->options.side == WOLFSSL_CLIENT_END) {
             XMEMCPY(ssl->serverFinished, mac, finishedSz);
             ssl->serverFinished_len = finishedSz;
@@ -7017,7 +7017,7 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             XMEMCPY(ssl->clientFinished, mac, finishedSz);
             ssl->clientFinished_len = finishedSz;
         }
-    #endif
+    #endif /* WOLFSSL_HAVE_TLS_UNIQUE */
         if (ret != 0)
             return ret;
         if (size != finishedSz)
@@ -7134,7 +7134,7 @@ static int SendTls13Finished(WOLFSSL* ssl)
     ret = BuildTls13HandshakeHmac(ssl, secret, &input[headerSz], NULL);
     if (ret != 0)
         return ret;
-    #if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+    #ifdef WOLFSSL_HAVE_TLS_UNIQUE
         if (ssl->options.side == WOLFSSL_CLIENT_END) {
             XMEMCPY(ssl->clientFinished, &input[headerSz], finishedSz);
             ssl->clientFinished_len = finishedSz;
@@ -7143,7 +7143,7 @@ static int SendTls13Finished(WOLFSSL* ssl)
             XMEMCPY(ssl->serverFinished, &input[headerSz], finishedSz);
             ssl->serverFinished_len = finishedSz;
         }
-    #endif
+    #endif /* WOLFSSL_HAVE_TLS_UNIQUE */
     /* This message is always encrypted. */
     sendSz = BuildTls13Message(ssl, output, outputSz, input,
                                headerSz + finishedSz, handshake, 1, 0, 0);

--- a/tests/api.c
+++ b/tests/api.c
@@ -4487,7 +4487,7 @@ static int nonblocking_accept_read(void* args, WOLFSSL* ssl, SOCKET_T* sockfd)
     }
 #endif
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+#ifdef WOLFSSL_HAVE_TLS_UNIQUE
     #ifdef WC_SHA512_DIGEST_SIZE
         #define MD_MAX_SIZE WC_SHA512_DIGEST_SIZE
     #else
@@ -4497,7 +4497,7 @@ static int nonblocking_accept_read(void* args, WOLFSSL* ssl, SOCKET_T* sockfd)
     byte server_side_msg2[MD_MAX_SIZE] = {0};/* msg received from client */
     byte client_side_msg1[MD_MAX_SIZE] = {0};/* msg sent by client */
     byte client_side_msg2[MD_MAX_SIZE] = {0};/* msg received from server */
-#endif
+#endif /* WOLFSSL_HAVE_TLS_UNIQUE */
 static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
 {
     SOCKET_T sockfd = 0;
@@ -4518,7 +4518,7 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
     SOCKADDR_IN_T cliAddr;
     socklen_t     cliLen;
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+#ifdef WOLFSSL_HAVE_TLS_UNIQUE
     size_t msg_len = 0;
 #endif
 
@@ -4726,7 +4726,7 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
         goto done;
     }
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+#ifdef WOLFSSL_HAVE_TLS_UNIQUE
     XMEMSET(server_side_msg2, 0, MD_MAX_SIZE);
     msg_len = wolfSSL_get_peer_finished(ssl, server_side_msg2, MD_MAX_SIZE);
     AssertIntGE(msg_len, 0);
@@ -4734,7 +4734,7 @@ static THREAD_RETURN WOLFSSL_THREAD test_server_nofail(void* args)
     XMEMSET(server_side_msg1, 0, MD_MAX_SIZE);
     msg_len = wolfSSL_get_finished(ssl, server_side_msg1, MD_MAX_SIZE);
     AssertIntGE(msg_len, 0);
-#endif
+#endif /* WOLFSSL_HAVE_TLS_UNIQUE */
 
     idx = wolfSSL_read(ssl, input, sizeof(input)-1);
     if (idx > 0) {
@@ -6111,7 +6111,7 @@ static void test_wolfSSL_CTX_verifyDepth_ServerClient(void)
 
 static void test_client_get_finished(void* args, cbType cb)
 {
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+#ifdef WOLFSSL_HAVE_TLS_UNIQUE
     SOCKET_T sockfd = 0;
     callback_functions* cbf;
 
@@ -6256,12 +6256,12 @@ done:
 #else
     (void)args;
     (void)cb;
-#endif
+#endif /* WOLFSSL_HAVE_TLS_UNIQUE */
 }
 
 static void test_wolfSSL_get_finished(void)
 {
-#if !defined(NO_RSA) && defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+#if !defined(NO_RSA) && defined(WOLFSSL_HAVE_TLS_UNIQUE)
 
     tcp_ready ready;
     func_args client_args;
@@ -6297,7 +6297,7 @@ static void test_wolfSSL_get_finished(void)
     FreeTcpReady(&ready);
 #else
     (void)test_client_get_finished;
-#endif
+#endif /* !NO_RSA && WOLFSSL_HAVE_TLS_UNIQUE */
 }
 
 #if defined(HAVE_IO_TESTS_DEPENDENCIES) && defined(HAVE_EXT_CACHE) && \

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4627,7 +4627,7 @@ struct WOLFSSL {
 #ifdef WOLFSSL_STATIC_EPHEMERAL
     StaticKeyExchangeInfo_t staticKE;
 #endif
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+#ifdef WOLFSSL_HAVE_TLS_UNIQUE
     /* Added in libest port: allow applications to get the 'tls-unique' Channel
      * Binding Type (https://tools.ietf.org/html/rfc5929#section-3). This is
      * used in the EST protocol to bind an enrollment to a TLS session through

--- a/wolfssl/ssl.h
+++ b/wolfssl/ssl.h
@@ -4838,10 +4838,10 @@ WOLFSSL_API int wolfSSL_X509_check_email(WOLFSSL_X509 *x, const char *chk,
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
 WOLFSSL_API const unsigned char *SSL_SESSION_get0_id_context(
         const WOLFSSL_SESSION *sess, unsigned int *sid_ctx_length);
-WOLFSSL_API size_t wolfSSL_get_finished(const WOLFSSL *ssl, void *buf, size_t count);
-WOLFSSL_API size_t wolfSSL_get_peer_finished(const WOLFSSL *ssl, void *buf, size_t count);
+#endif
 #endif
 
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 WOLFSSL_API int SSL_SESSION_set1_id(WOLFSSL_SESSION *s, const unsigned char *sid, unsigned int sid_len);
 WOLFSSL_API int SSL_SESSION_set1_id_context(WOLFSSL_SESSION *s, const unsigned char *sid_ctx, unsigned int sid_ctx_len);
 WOLFSSL_API WOLFSSL_X509_ALGOR* wolfSSL_X509_ALGOR_new(void);
@@ -4907,6 +4907,11 @@ WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(
 #endif /* !WOLFCRYPT_ONLY */
 
 #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+#ifdef WOLFSSL_HAVE_TLS_UNIQUE
+WOLFSSL_API size_t wolfSSL_get_finished(const WOLFSSL *ssl, void *buf, size_t count);
+WOLFSSL_API size_t wolfSSL_get_peer_finished(const WOLFSSL *ssl, void *buf, size_t count);
+#endif /* WOLFSSL_HAVE_TLS_UNIQUE */
 
 #ifdef HAVE_PK_CALLBACKS
 WOLFSSL_API int wolfSSL_IsPrivatePkSet(WOLFSSL* ssl);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2430,6 +2430,16 @@ extern void uITRON4_free(void *p) ;
     #define KEEP_PEER_CERT
 #endif
 
+/*
+ * Keeps the "Finished" messages after a TLS handshake for use as the so-called
+ * "tls-unique" channel binding. See comment in internal.h around clientFinished
+ * and serverFinished for more information.
+ */
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_WPAS)
+    #undef  WOLFSSL_HAVE_TLS_UNIQUE
+    #define WOLFSSL_HAVE_TLS_UNIQUE
+#endif
+
 /* RAW hash function APIs are not implemented */
 #if defined(WOLFSSL_ARMASM) || defined(WOLFSSL_AFALG_HASH)
     #undef  WOLFSSL_NO_HASH_RAW


### PR DESCRIPTION
# Description

Prior to this commit, if you wanted access to the Finished messages from a handshake, you needed to turn on the compatibility layer, via one of OPENSSL_ALL, WOLFSSL_HAPROXY, or WOLFSSL_WPAS. With this commit, defining any of these causes WOLFSSL_HAVE_TLS_UNIQUE to be defined (a reference to the tls-unique channel binding which these messages are used for) in settings.h. This allows a user to define WOLFSSL_HAVE_TLS_UNIQUE to access the Finished messages without bringing in the whole compat layer.

Fixes ZD 14192.

# Testing

There are already tests exercising wolfSSL_get_finished and wolfSSL_get_peer_finished; those are still passing after this change. I also verified with gdb and the example server/client that the client/serverFinished fields of a WOLFSSL object do get populated if you configure with just `./configure CFLAGS="-g3 -O0" CPPFLAGS="-DWOLFSSL_HAVE_TLS_UNIQUE"`.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
