### PR TITLE
Remove unused warning in ecc.c

### DIFF
--- a/wolfcrypt/src/ecc.c
+++ b/wolfcrypt/src/ecc.c
@@ -12504,6 +12504,8 @@ int wc_ecc_encrypt_ex(ecc_key* privKey, ecc_key* pubKey, const byte* msg,
     else {
         pubKeySz = 1 + wc_ecc_size(privKey);
     }
+#else
+    (void) compressed; /* avoid unused parameter if WOLFSSL_ECIES_OLD is defined */
 #endif
 
     if (ctx->protocol == REQ_RESP_SERVER) {


### PR DESCRIPTION
When WOLFSSL_ECIES_OLD is defined you get an unused warning
in ecc.c / wc_ecc_encrypt_ex().
Just suppress it by "using" the parameter.
