### PR TITLE
Remove unneeded FIPS guard on wolfSSL_EVP_PKEY_derive.

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -46426,7 +46426,6 @@ static void test_wolfSSL_OCSP_resp_get0(void)
 static void test_wolfSSL_EVP_PKEY_derive(void)
 {
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT) || defined(WOLFSSL_OPENSSH)
-#if !defined(HAVE_FIPS) || FIPS_VERSION_GT(2, 0)
 #if (!defined(NO_DH) && defined(WOLFSSL_DH_EXTRA)) || defined(HAVE_ECC)
 
     EVP_PKEY_CTX *ctx;
@@ -46483,7 +46482,6 @@ static void test_wolfSSL_EVP_PKEY_derive(void)
 
     printf(resultFmt, "passed");
 #endif /* (!NO_DH && WOLFSSL_DH_EXTRA) || HAVE_ECC */
-#endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
 #endif /* OPENSSL_ALL || WOLFSSL_QT || WOLFSSL_OPENSSH */
 }
 
@@ -50505,8 +50503,7 @@ static void test_wolfssl_EVP_chacha20_poly1305(void)
 
 static void test_wolfSSL_EVP_PKEY_hkdf(void)
 {
-#if defined(OPENSSL_EXTRA) && defined(HAVE_HKDF) && (!defined(HAVE_FIPS) || \
-    FIPS_VERSION_GT(2,0))
+#if defined(OPENSSL_EXTRA) && defined(HAVE_HKDF)
     EVP_PKEY_CTX* ctx;
     byte salt[]  = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
                     0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
@@ -50616,7 +50613,7 @@ static void test_wolfSSL_EVP_PKEY_hkdf(void)
     EVP_PKEY_CTX_free(ctx);
 
     printf(resultFmt, passed);
-#endif /* OPENSSL_EXTRA && HAVE_HKDF && (!HAVE_FIPS || HAVE_FIPS_VERSION > 2) */
+#endif /* OPENSSL_EXTRA && HAVE_HKDF */
 }
 
 #ifndef NO_BIO

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1562,7 +1562,6 @@ int wolfSSL_EVP_PKEY_CTX_ctrl_str(WOLFSSL_EVP_PKEY_CTX *ctx,
 
 #if (!defined(NO_DH) && defined(WOLFSSL_DH_EXTRA)) || defined(HAVE_ECC) || \
     defined(HAVE_HKDF)
-#if !defined(HAVE_FIPS) || FIPS_VERSION_GT(2,0)
 int wolfSSL_EVP_PKEY_derive(WOLFSSL_EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen)
 {
     int len;
@@ -1736,7 +1735,6 @@ int wolfSSL_EVP_PKEY_derive(WOLFSSL_EVP_PKEY_CTX *ctx, unsigned char *key, size_
     }
     return WOLFSSL_SUCCESS;
 }
-#endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
 #endif /* (!NO_DH && WOLFSSL_DH_EXTRA) || HAVE_ECC || HAVE_HKDF */
 
 #ifdef HAVE_HKDF


### PR DESCRIPTION
# Description

This FIPS version > 2 guard isn't needed.

# Testing

Tested with a FIPS v2 bundle and all the wolfSSL_EVP_PKEY_derive tests passed.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
