### PR TITLE
Remove WOLFSSL_ALT_NAMES restriction on notBefore/notAfter use in Cert struct

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -8171,7 +8171,6 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
     }
 #endif /* WOLFSSL_CERT_REQ */
 
-#ifdef WOLFSSL_ALT_NAMES
     /* converts WOLFSSL_AN1_TIME to Cert form, returns positive size on
      * success */
     static int CertDateFromX509(byte* out, int outSz, WOLFSSL_ASN1_TIME* t)
@@ -8189,7 +8188,6 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
         }
         return t->length + sz;
     }
-#endif /* WOLFSSL_ALT_NAMES */
 
     /* convert a WOLFSSL_X509 to a Cert structure for writing out */
     static int CertFromX509(Cert* cert, WOLFSSL_X509* x509)
@@ -8209,7 +8207,6 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
 
         cert->version = (int)wolfSSL_X509_get_version(x509);
 
-    #ifdef WOLFSSL_ALT_NAMES
         if (x509->notBefore.length > 0) {
             cert->beforeDateSz = CertDateFromX509(cert->beforeDate,
                         CTC_DATE_SIZE, &x509->notBefore);
@@ -8234,6 +8231,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
             cert->afterDateSz = 0;
         }
 
+    #ifdef WOLFSSL_ALT_NAMES
         cert->altNamesSz = FlattenAltNames(cert->altNames,
                 sizeof(cert->altNames), x509->altNames);
     #endif /* WOLFSSL_ALT_NAMES */

--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -21772,7 +21772,6 @@ static void SetTime(struct tm* date, byte* output)
 }
 #endif
 
-#ifdef WOLFSSL_ALT_NAMES
 #ifndef WOLFSSL_ASN_TEMPLATE
 
 /* Copy Dates from cert, return bytes written */
@@ -21793,7 +21792,6 @@ static int CopyValidity(byte* output, Cert* cert)
 }
 
 #endif /* !WOLFSSL_ASN_TEMPLATE */
-#endif
 
 
 /* Simple name OID size. */
@@ -24017,16 +24015,14 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
         return PUBLIC_KEY_E;
 
     der->validitySz = 0;
-#ifdef WOLFSSL_ALT_NAMES
-    /* date validity copy ? */
+    /* copy date validity if already set in cert struct */
     if (cert->beforeDateSz && cert->afterDateSz) {
         der->validitySz = CopyValidity(der->validity, cert);
         if (der->validitySz <= 0)
             return DATE_E;
     }
-#endif
 
-    /* date validity */
+    /* set date validity using daysValid if not set already */
     if (der->validitySz == 0) {
         der->validitySz = SetValidity(der->validity, cert->daysValid);
         if (der->validitySz <= 0)

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -390,11 +390,11 @@ typedef struct Cert {
 #ifdef WOLFSSL_ALT_NAMES
     byte     altNames[CTC_MAX_ALT_SIZE]; /* altNames copy */
     int      altNamesSz;                 /* altNames size in bytes */
+#endif
     byte     beforeDate[CTC_DATE_SIZE];  /* before date copy */
     int      beforeDateSz;               /* size of copy */
     byte     afterDate[CTC_DATE_SIZE];   /* after date copy */
     int      afterDateSz;                /* size of copy */
-#endif
 #ifdef WOLFSSL_CERT_EXT
     byte    skid[CTC_MAX_SKID_SIZE];     /* Subject Key Identifier */
     int     skidSz;                      /* SKID size in bytes */


### PR DESCRIPTION
# Description

X.509 certificate validity (notBefore/notAfter) use in `CertFromX509()` and `EncodeCert()` were previously protected by `WOLFSSL_ALT_NAMES`.  notBefore/notAfter are not specific to Alt. names.  This PR removes this unnecessary restriction.

Without these changes, importing a certificate with `PEM_read_X509()` then exporting with `PEM_write_bio_X509()` does not maintain the correct certificate validity without `WOLFSSL_ALT_NAMES` defined.

# Testing

Tested with built-in unit tests. Added test to verify notBefore/notAfter are preserved across import/export.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
