### PR TITLE
Misc. fixes

### DIFF
--- a/mcapi/README
+++ b/mcapi/README
@@ -54,10 +54,10 @@ Included Project Files
 
     This project builds the zlib library for use in the wolfcrypt_test.X
     and wolfcrypt_mcapi.X projects. This project expects the zlib sources
-    to be located under the wolfSSL root directory. Currently it is set up
-    to work with zlib 1.2.8, and looks for sources under:
+    to be located under the wolfSSL root directory. It is set up to work
+    with the latest zlib, and looks for sources under:
 
-    <wolfssl_root>/zlib-1.2.8
+    <wolfssl_root>/zlib
 
 PIC32MX/PIC32MZ
 ---------------

--- a/mcapi/zlib.X/nbproject/configurations.xml
+++ b/mcapi/zlib.X/nbproject/configurations.xml
@@ -12,21 +12,21 @@
     <logicalFolder name="SourceFiles"
                    displayName="Source Files"
                    projectFiles="true">
-      <itemPath>../../zlib-1.2.8/adler32.c</itemPath>
-      <itemPath>../../zlib-1.2.8/compress.c</itemPath>
-      <itemPath>../../zlib-1.2.8/crc32.c</itemPath>
-      <itemPath>../../zlib-1.2.8/deflate.c</itemPath>
-      <itemPath>../../zlib-1.2.8/gzclose.c</itemPath>
-      <itemPath>../../zlib-1.2.8/gzlib.c</itemPath>
-      <itemPath>../../zlib-1.2.8/gzread.c</itemPath>
-      <itemPath>../../zlib-1.2.8/gzwrite.c</itemPath>
-      <itemPath>../../zlib-1.2.8/infback.c</itemPath>
-      <itemPath>../../zlib-1.2.8/inffast.c</itemPath>
-      <itemPath>../../zlib-1.2.8/inflate.c</itemPath>
-      <itemPath>../../zlib-1.2.8/inftrees.c</itemPath>
-      <itemPath>../../zlib-1.2.8/trees.c</itemPath>
-      <itemPath>../../zlib-1.2.8/uncompr.c</itemPath>
-      <itemPath>../../zlib-1.2.8/zutil.c</itemPath>
+      <itemPath>../../zlib/adler32.c</itemPath>
+      <itemPath>../../zlib/compress.c</itemPath>
+      <itemPath>../../zlib/crc32.c</itemPath>
+      <itemPath>../../zlib/deflate.c</itemPath>
+      <itemPath>../../zlib/gzclose.c</itemPath>
+      <itemPath>../../zlib/gzlib.c</itemPath>
+      <itemPath>../../zlib/gzread.c</itemPath>
+      <itemPath>../../zlib/gzwrite.c</itemPath>
+      <itemPath>../../zlib/infback.c</itemPath>
+      <itemPath>../../zlib/inffast.c</itemPath>
+      <itemPath>../../zlib/inflate.c</itemPath>
+      <itemPath>../../zlib/inftrees.c</itemPath>
+      <itemPath>../../zlib/trees.c</itemPath>
+      <itemPath>../../zlib/uncompr.c</itemPath>
+      <itemPath>../../zlib/zutil.c</itemPath>
     </logicalFolder>
     <logicalFolder name="ExternalFiles"
                    displayName="Important Files"
@@ -76,7 +76,7 @@
         <property key="enable-symbols" value="true"/>
         <property key="enable-unroll-loops" value="false"/>
         <property key="exclude-floating-point" value="false"/>
-        <property key="extra-include-directories" value="../../zlib-1.2.8"/>
+        <property key="extra-include-directories" value="../../zlib"/>
         <property key="generate-16-bit-code" value="false"/>
         <property key="generate-micro-compressed-code" value="false"/>
         <property key="isolate-each-function" value="false"/>

--- a/wolfssl/wolfcrypt/ecc.h
+++ b/wolfssl/wolfcrypt/ecc.h
@@ -293,7 +293,7 @@ typedef struct ecc_set_type {
 } ecc_set_type;
 #else
 #define MAX_ECC_NAME 16
-#define MAX_ECC_STRING ((MAX_ECC_BYTES * 2) + 1)
+#define MAX_ECC_STRING ((MAX_ECC_BYTES * 2) + 2)
     /* The values are stored as text strings. */
 
 typedef struct ecc_set_type {

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -828,7 +828,7 @@ decouple library dependencies with standard string, memory and so on.
     #endif
 
     #ifndef OFFSETOF
-        #if defined(__clang__) || (__GNUC__ >= 4)
+        #if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >= 4))
             #define OFFSETOF(type, field) __builtin_offsetof(type, field)
         #else
             #define OFFSETOF(type, field) ((size_t)&(((type *)0)->field))

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -828,7 +828,7 @@ decouple library dependencies with standard string, memory and so on.
     #endif
 
     #ifndef OFFSETOF
-        #if defined(__clang__) || defined(__GNUC__)
+        #if defined(__clang__) || (__GNUC__ >= 4)
             #define OFFSETOF(type, field) __builtin_offsetof(type, field)
         #else
             #define OFFSETOF(type, field) ((size_t)&(((type *)0)->field))

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -417,7 +417,7 @@ WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFGETS(b,s,f) -2 /* Not ported yet */
 
 #elif defined(WOLFSSL_ZEPHYR)
-    #include <fs.h>
+    #include <fs/fs.h>
 
     #define XFILE      struct fs_file_t*
     #define STAT       struct fs_dirent


### PR DESCRIPTION
# Description

Update Zephyr fs.h path.  Fixes #5135
Remove MCAPI project's depency on zlib version.  Fixes #5017
Only use __builtin_offset on supported GCC versions (4+).  Fixes ZD 14195
Increase MAX_ECC_STRING to fix off-by-one error.  Fixes #5173

# Testing

Confirmed wolfSSL builds successfully.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [X] Updated manual and documentation
