### PR TITLE
Fix EVP_CTRL_GCM_IV_GEN with AES-GCM.

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -45178,27 +45178,279 @@ static void test_wolfSSL_EVP_BytesToKey(void)
     printf(resultFmt, passed);
 #endif
 }
-static void test_IncCtr(void)
+static void test_evp_cipher_aes_gcm(void)
 {
-#if defined(HAVE_AESGCM) && !defined(HAVE_FIPS)
-    byte key[AES_128_KEY_SIZE] = {0};
-    byte iv[GCM_NONCE_MID_SZ] = {0};
-    int type = EVP_CTRL_GCM_IV_GEN;
-    int arg = 0;
-    void *ptr = NULL;
+#if defined(HAVE_AESGCM) && ((!defined(HAVE_FIPS) && \
+    !defined(HAVE_SELFTEST)) || (defined(HAVE_FIPS_VERSION) && \
+    (HAVE_FIPS_VERSION >= 2)))
+    /*
+     * This test checks data at various points in the encrypt/decrypt process
+     * against known values produced using the same test with OpenSSL. This
+     * interop testing is critical for verifying the correctness of our
+     * EVP_Cipher implementation with AES-GCM. Specifically, this test exercises
+     * a flow supported by OpenSSL that uses the control command
+     * EVP_CTRL_GCM_IV_GEN to increment the IV between cipher operations without
+     * the need to call EVP_CipherInit. OpenSSH uses this flow, for example. We
+     * had a bug with OpenSSH where wolfSSL OpenSSH servers could only talk to
+     * wolfSSL OpenSSH clients because there was a bug in this flow that
+     * happened to "cancel out" if both sides of the connection had the bug.
+     */
+    enum { 
+        NUM_ENCRYPTIONS = 3,
+        AAD_SIZE = 4
+    };
+    byte plainText1[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+        0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+        0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23
+    };
+    byte plainText2[] = {
+        0x42, 0x49, 0x3b, 0x27, 0x03, 0x35, 0x59, 0x14, 0x41, 0x47, 0x37, 0x14,
+        0x0e, 0x34, 0x0d, 0x28, 0x63, 0x09, 0x0a, 0x5b, 0x22, 0x57, 0x42, 0x22,
+        0x0f, 0x5c, 0x1e, 0x53, 0x45, 0x15, 0x62, 0x08, 0x60, 0x43, 0x50, 0x2c
+    };
+    byte plainText3[] = {
+        0x36, 0x0d, 0x2b, 0x09, 0x4a, 0x56, 0x3b, 0x4c, 0x21, 0x22, 0x58, 0x0e,
+        0x5b, 0x57, 0x10
+    };
+    byte* plainTexts[NUM_ENCRYPTIONS] = {
+        plainText1,
+        plainText2,
+        plainText3
+    };
+    const int plainTextSzs[NUM_ENCRYPTIONS] = {
+        sizeof(plainText1),
+        sizeof(plainText2),
+        sizeof(plainText3)
+    };
+    byte aad1[AAD_SIZE] = {
+        0x00, 0x00, 0x00, 0x01
+    };
+    byte aad2[AAD_SIZE] = {
+        0x00, 0x00, 0x00, 0x10
+    };
+    byte aad3[AAD_SIZE] = {
+        0x00, 0x00, 0x01, 0x00
+    };
+    byte* aads[NUM_ENCRYPTIONS] = {
+        aad1,
+        aad2,
+        aad3
+    };
+    const byte iv[GCM_NONCE_MID_SZ] = {
+        0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF
+    };
+    byte currentIv[GCM_NONCE_MID_SZ];
+    const byte key[] = {
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+        0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
+        0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f
+    };
+    const byte expIvs[NUM_ENCRYPTIONS][GCM_NONCE_MID_SZ] = {
+        {
+            0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE,
+            0xEF
+        },
+        {
+            0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE,
+            0xF0
+        },
+        {
+            0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE,
+            0xF1
+        }
+    };
+    const byte expTags[NUM_ENCRYPTIONS][AES_BLOCK_SIZE] = {
+        {
+            0x65, 0x4F, 0xF7, 0xA0, 0xBB, 0x7B, 0x90, 0xB7, 0x9C, 0xC8, 0x14,
+            0x3D, 0x32, 0x18, 0x34, 0xA9
+        },
+        {
+            0x50, 0x3A, 0x13, 0x8D, 0x91, 0x1D, 0xEC, 0xBB, 0xBA, 0x5B, 0x57,
+            0xA2, 0xFD, 0x2D, 0x6B, 0x7F
+        },
+        {
+            0x3B, 0xED, 0x18, 0x9C, 0xB3, 0xE3, 0x61, 0x1E, 0x11, 0xEB, 0x13,
+            0x5B, 0xEC, 0x52, 0x49, 0x32, 
+        }
+    };
 
-    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
-    const EVP_CIPHER *init = EVP_aes_128_gcm();
+    const byte expCipherText1[] = {
+        0xCB, 0x93, 0x4F, 0xC8, 0x22, 0xE2, 0xC0, 0x35, 0xAA, 0x6B, 0x41, 0x15,
+        0x17, 0x30, 0x2F, 0x97, 0x20, 0x74, 0x39, 0x28, 0xF8, 0xEB, 0xC5, 0x51,
+        0x7B, 0xD9, 0x8A, 0x36, 0xB8, 0xDA, 0x24, 0x80, 0xE7, 0x9E, 0x09, 0xDE
+    };
+    const byte expCipherText2[] = {
+        0xF9, 0x32, 0xE1, 0x87, 0x37, 0x0F, 0x04, 0xC1, 0xB5, 0x59, 0xF0, 0x45,
+        0x3A, 0x0D, 0xA0, 0x26, 0xFF, 0xA6, 0x8D, 0x38, 0xFE, 0xB8, 0xE5, 0xC2,
+        0x2A, 0x98, 0x4A, 0x54, 0x8F, 0x1F, 0xD6, 0x13, 0x03, 0xB2, 0x1B, 0xC0
+    };
+    const byte expCipherText3[] = {
+        0xD0, 0x37, 0x59, 0x1C, 0x2F, 0x85, 0x39, 0x4D, 0xED, 0xC2, 0x32, 0x5B,
+        0x80, 0x5E, 0x6B, 
+    };
+    const byte* expCipherTexts[NUM_ENCRYPTIONS] = {
+        expCipherText1,
+        expCipherText2,
+        expCipherText3
+    };
+    byte* cipherText;
+    byte* calcPlainText;
+    byte tag[AES_BLOCK_SIZE];
+    EVP_CIPHER_CTX* encCtx = NULL;
+    EVP_CIPHER_CTX* decCtx = NULL;
+    int i, j, outl;
 
-    printf(testingFmt, "IncCtr");
+    printf(testingFmt, "test_evp_cipher_aes_gcm");
 
-    AssertNotNull(ctx);
-    wolfSSL_EVP_CIPHER_CTX_init(ctx);
-    AssertIntEQ(EVP_CipherInit(ctx, init, key, iv, 1), WOLFSSL_SUCCESS);
+    /****************************************************/
+    for (i = 0; i < 3; ++i) {
+        AssertNotNull(encCtx = EVP_CIPHER_CTX_new());
+        AssertNotNull(decCtx = EVP_CIPHER_CTX_new());
 
-    AssertIntEQ(wolfSSL_EVP_CIPHER_CTX_ctrl(ctx, type, arg, ptr), WOLFSSL_SUCCESS);
+        /* First iteration, set key before IV. */
+        if (i == 0) {
+            AssertIntEQ(EVP_CipherInit(encCtx, EVP_aes_256_gcm(), key, NULL, 1),
+                        SSL_SUCCESS);
+            AssertIntEQ(EVP_CipherInit(encCtx, NULL, NULL, iv, 1),
+                        SSL_SUCCESS);
+            AssertIntEQ(EVP_CipherInit(decCtx, EVP_aes_256_gcm(), key, NULL, 0),
+                        SSL_SUCCESS);
+            AssertIntEQ(EVP_CipherInit(decCtx, NULL, NULL, iv, 0),
+                        SSL_SUCCESS);
+        }
+        /* Second iteration, IV before key. */
+        else {
+            AssertIntEQ(EVP_CipherInit(encCtx, EVP_aes_256_gcm(), NULL, iv, 1),
+                        SSL_SUCCESS);
+            AssertIntEQ(EVP_CipherInit(encCtx, NULL, key, NULL, 1),
+                        SSL_SUCCESS);
+            AssertIntEQ(EVP_CipherInit(decCtx, EVP_aes_256_gcm(), NULL, iv, 0),
+                        SSL_SUCCESS);
+            AssertIntEQ(EVP_CipherInit(decCtx, NULL, key, NULL, 0),
+                        SSL_SUCCESS);
+        }
 
-    EVP_CIPHER_CTX_free(ctx);
+        /*
+         * EVP_CTRL_GCM_IV_GEN should fail if EVP_CTRL_GCM_SET_IV_FIXED hasn't
+         * been issued first.
+         */
+        AssertIntEQ(EVP_CIPHER_CTX_ctrl(encCtx, EVP_CTRL_GCM_IV_GEN, -1,
+                        currentIv), SSL_FAILURE);
+
+        AssertIntEQ(EVP_CIPHER_CTX_ctrl(encCtx, EVP_CTRL_GCM_SET_IV_FIXED, -1,
+                    (void*)iv), SSL_SUCCESS);
+        AssertIntEQ(EVP_CIPHER_CTX_ctrl(decCtx, EVP_CTRL_GCM_SET_IV_FIXED, -1,
+                    (void*)iv), SSL_SUCCESS);
+
+        for (j = 0; j < NUM_ENCRYPTIONS; ++j) {
+            /*************** Encrypt ***************/
+            AssertIntEQ(EVP_CIPHER_CTX_ctrl(encCtx, EVP_CTRL_GCM_IV_GEN, -1,
+                        currentIv), SSL_SUCCESS);
+            /* Check current IV against expected. */
+            AssertIntEQ(XMEMCMP(currentIv, expIvs[j], GCM_NONCE_MID_SZ), 0);
+
+            /* Add AAD. */
+            if (i == 2) {
+                /* Test streaming API. */
+                AssertIntEQ(EVP_CipherUpdate(encCtx, NULL, &outl, aads[j],
+                                             AAD_SIZE), SSL_SUCCESS);
+            }
+            else {
+                AssertIntEQ(EVP_Cipher(encCtx, NULL, aads[j], AAD_SIZE),
+                                       AAD_SIZE);
+            }
+
+            AssertNotNull(cipherText = (byte*)XMALLOC(plainTextSzs[j], NULL,
+                          DYNAMIC_TYPE_TMP_BUFFER));
+
+            /* Encrypt plaintext. */
+            if (i == 2){
+                AssertIntEQ(EVP_CipherUpdate(encCtx, cipherText, &outl,
+                                             plainTexts[j], plainTextSzs[j]),
+                            SSL_SUCCESS);
+            }
+            else {
+                AssertIntEQ(EVP_Cipher(encCtx, cipherText, plainTexts[j],
+                            plainTextSzs[j]), plainTextSzs[j]);
+            }
+
+            if (i == 2) {
+                AssertIntEQ(EVP_CipherFinal(encCtx, cipherText, &outl),
+                            SSL_SUCCESS);
+            }
+            else {
+                /*
+                 * Calling EVP_Cipher with NULL input and output for AES-GCM is
+                 * akin to calling EVP_CipherFinal.
+                 */
+                AssertIntGE(EVP_Cipher(encCtx, NULL, NULL, 0), 0);
+            }
+
+            /* Check ciphertext against expected. */
+            AssertIntEQ(XMEMCMP(cipherText, expCipherTexts[j], plainTextSzs[j]),
+                        0);
+
+            /* Get and check tag against expected. */
+            AssertIntEQ(EVP_CIPHER_CTX_ctrl(encCtx, EVP_CTRL_GCM_GET_TAG,
+                        sizeof(tag), tag), SSL_SUCCESS);
+            AssertIntEQ(XMEMCMP(tag, expTags[j], sizeof(tag)), 0);
+
+            /*************** Decrypt ***************/
+            AssertIntEQ(EVP_CIPHER_CTX_ctrl(decCtx, EVP_CTRL_GCM_IV_GEN, -1,
+                        currentIv), SSL_SUCCESS);
+            /* Check current IV against expected. */
+            AssertIntEQ(XMEMCMP(currentIv, expIvs[j], GCM_NONCE_MID_SZ), 0);
+
+            /* Add AAD. */
+            if (i == 2) {
+                /* Test streaming API. */
+                AssertIntEQ(EVP_CipherUpdate(decCtx, NULL, &outl, aads[j],
+                                             AAD_SIZE), SSL_SUCCESS);
+            }
+            else {
+                AssertIntEQ(EVP_Cipher(decCtx, NULL, aads[j], AAD_SIZE),
+                            AAD_SIZE);
+            }
+
+            /* Set expected tag. */
+            AssertIntEQ(EVP_CIPHER_CTX_ctrl(decCtx, EVP_CTRL_GCM_SET_TAG,
+                        sizeof(tag), tag), SSL_SUCCESS);
+
+            /* Decrypt ciphertext. */
+            AssertNotNull(calcPlainText = (byte*)XMALLOC(plainTextSzs[j], NULL,
+                          DYNAMIC_TYPE_TMP_BUFFER));
+            if (i == 2){
+                AssertIntEQ(EVP_CipherUpdate(decCtx, calcPlainText, &outl,
+                                             cipherText, plainTextSzs[j]),
+                            SSL_SUCCESS);
+            }
+            else {
+                /* This first EVP_Cipher call will check the tag, too. */
+                AssertIntEQ(EVP_Cipher(decCtx, calcPlainText, cipherText,
+                        plainTextSzs[j]), plainTextSzs[j]);
+            }
+
+            if (i == 2) {
+                AssertIntEQ(EVP_CipherFinal(decCtx, calcPlainText, &outl),
+                            SSL_SUCCESS);
+            }
+            else {
+                AssertIntGE(EVP_Cipher(decCtx, NULL, NULL, 0), 0);
+            }
+
+            /* Check plaintext against expected. */
+            AssertIntEQ(XMEMCMP(calcPlainText, plainTexts[j], plainTextSzs[j]),
+                        0);
+
+            XFREE(cipherText, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            XFREE(calcPlainText, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        }
+
+        EVP_CIPHER_CTX_free(encCtx);
+        EVP_CIPHER_CTX_free(decCtx);
+    }
+    
     printf(resultFmt, passed);
 #endif
 }
@@ -54478,7 +54730,7 @@ void ApiTest(void)
     test_wolfSSL_EVP_BytesToKey();
     test_wolfSSL_EVP_PKEY_param_check();
     test_wolfSSL_QT_EVP_PKEY_CTX_free();
-    test_IncCtr();
+    test_evp_cipher_aes_gcm();
     test_wolfSSL_OBJ_ln();
     test_wolfSSL_OBJ_sn();
     test_wolfSSL_TXT_DB();

--- a/wolfssl/openssl/evp.h
+++ b/wolfssl/openssl/evp.h
@@ -438,6 +438,10 @@ struct WOLFSSL_EVP_CIPHER_CTX {
 #endif
     int     authTagSz;
 #endif
+#ifdef HAVE_AESGCM
+    byte    gcmIvGenEnable:1;
+    byte    gcmIncIv:1;
+#endif
 #endif
 };
 


### PR DESCRIPTION
# Description

Discovered the AES-GCM flow using this command didn't work in our OpenSSH port. This commit makes the behavior match OpenSSL and adds testing using known OpenSSL-generated test vectors to prevent regressions. This was one of those problems where two ends of a connection would work fine if they were both using wolfSSL but not if one was using OpenSSL (i.e. OpenSSH interop with AES-GCM was broken).

# Testing

Added a unit test and verified this fixed AES-GCM-based connections in our OpenSSH port.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
