### PR TITLE
Fix sniffer session free to wait till pending operation is complete

### DIFF
--- a/src/sniffer.c
+++ b/src/sniffer.c
@@ -743,6 +743,14 @@ static void FreePacketList(PacketBuffer* in)
 static void FreeSnifferSession(SnifferSession* session)
 {
     if (session) {
+    #ifdef WOLFSSL_ASYNC_CRYPT
+        /* if session has pending operation then poll till event is done */
+        if (session->sslServer && session->sslServer->error == WC_PENDING_E) {
+            while (wolfSSL_AsyncPoll(session->sslServer,
+                WOLF_POLL_FLAG_CHECK_HW) == 0);
+        }
+    #endif
+
         wolfSSL_free(session->sslClient);
         wolfSSL_free(session->sslServer);
 

--- a/sslSniffer/sslSnifferTest/snifftest.c
+++ b/sslSniffer/sslSnifferTest/snifftest.c
@@ -827,7 +827,7 @@ int main(int argc, char** argv)
             /* grab next pcap packet */
             packetNumber++;
             packet = pcap_next(pcap, &header);
-        #ifdef QAT_DEBUG
+        #ifdef DEBUG_SNIFFER
             printf("Packet Number: %d\n", packetNumber);
         #endif
         }

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -218,7 +218,7 @@ decouple library dependencies with standard string, memory and so on.
                              mp_digit, no 64 bit type so make mp_digit 16 bit */
 #endif
 
-#ifdef WC_PTR_TYPE /* Allow user suppied type */
+#ifdef WC_PTR_TYPE /* Allow user supplied type */
     typedef WC_PTR_TYPE wc_ptr_t;
 #elif defined(HAVE_UINTPTR_T)
     #include <stdint.h>


### PR DESCRIPTION
# Description

Fix sniffer session free to wait till pending operation is complete.
Fixes ZD14054

# Testing

Internal sniffer tests with QAT hardware.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
