### PR TITLE
20220524-shellcheck-warnings

### DIFF
--- a/certs/intermediate/genintcerts.sh
+++ b/certs/intermediate/genintcerts.sh
@@ -189,11 +189,11 @@ create_cert() {
     mv ./certs/intermediate/tmp.pem ./certs/intermediate/$4.pem
 }
 
-if [ "$1" == "clean" ]; then
+if [ "$1" = "clean" ]; then
     echo "Cleaning temp files"
     cleanup_files
 fi
-if [ "$1" == "cleanall" ]; then
+if [ "$1" = "cleanall" ]; then
     echo "Cleaning all files"
     rm -f ./certs/intermediate/*.pem
     rm -f ./certs/intermediate/*.der

--- a/scripts/ocsp.test
+++ b/scripts/ocsp.test
@@ -37,7 +37,7 @@ if [ "$OUTPUT" = "SNI is: ON" ]; then
 
     if [ $RESULT -eq 0 ]; then
         # client test against the server
-        echo "./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N -v d -S $server"
+        echo "./examples/client/client -X -C -h $server -p 443 -A \"$ca\" -g -o -N -v d -S $server"
         ./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N -v d -S $server
         GL_RESULT=$?
         [ $GL_RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection failed"
@@ -62,7 +62,7 @@ fi
 
 if [ $RESULT -eq 0 ]; then
     # client test against the server
-    echo "./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N"
+    echo "./examples/client/client -X -C -h $server -p 443 -A \"$ca\" -g -o -N"
     ./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N
     GR_RESULT=$?
     [ $GR_RESULT -ne 0 ] && printf '\n\n%s\n' "Client connection failed"

--- a/scripts/openssl.test
+++ b/scripts/openssl.test
@@ -321,11 +321,11 @@ do_wolfssl_client() {
     if [ "$version" != "5" -a "$version" != "" ]
     then
         echo "#"
-        echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite -v $version $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl"
+        echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite -v $version $psk $adh \"$wolfssl_cert\" \"$wolfssl_key\" \"$wolfssl_caCert\" $crl"
         $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite -v $version $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
     else
         echo "#"
-        echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl"
+        echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite $psk $adh \"$wolfssl_cert\" \"$wolfssl_key\" \"$wolfssl_caCert\" $crl"
         # do all versions
         $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl
     fi
@@ -451,10 +451,10 @@ esac
 wolf_ciphers=`$WOLFSSL_CLIENT -e`
 # get wolfssl supported versions
 wolf_versions=`$WOLFSSL_CLIENT -V`
-wolf_versions="$wolf_versions:5" #5 will test without -v flag
+wolf_versions="${wolf_versions}:5" #5 will test without -v flag
 
-OIFS=$IFS # store old separator to reset
-IFS=$'\:' # set delimiter
+OIFS="$IFS" # store old separator to reset
+IFS=: # set delimiter
 for version in $wolf_versions
 do
     case $version in
@@ -466,7 +466,7 @@ do
         ;;
     esac
 done
-IFS=$OIFS #restore separator
+IFS="$OIFS" #restore separator
 
 #
 # Start OpenSSL servers
@@ -552,8 +552,8 @@ case $openssl_nodhe in
 esac
 
 # Check suites to determine support in wolfSSL
-OIFS=$IFS # store old separator to reset
-IFS=$'\:' # set delimiter
+OIFS="$IFS" # store old separator to reset
+IFS=: # set delimiter
 for wolfSuite in $wolf_ciphers; do
     case $wolfSuite in
     *ECDHE-RSA-*)
@@ -589,7 +589,7 @@ for wolfSuite in $wolf_ciphers; do
         wolf_rsa=yes
     esac
 done
-IFS=$OIFS #restore separator
+IFS="$OIFS" #restore separator
 
 openssl_ciphers=`$OPENSSL ciphers ALL 2>&1`
 case $openssl_ciphers in
@@ -744,8 +744,8 @@ do
     check_server_ready
 done
 
-OIFS=$IFS # store old separator to reset
-IFS=$'\:' # set delimiter
+OIFS="$IFS" # store old separator to reset
+IFS=: # set delimiter
 set -f # no globbing
 
 wolf_temp_cases_total=0
@@ -1173,7 +1173,7 @@ do
     open_temp_cases_tested=0
     wolfdowngrade="$version"
 done
-IFS=$OIFS #restore separator
+IFS="$OIFS" #restore separator
 
 do_cleanup
 

--- a/scripts/openssl_srtp.test
+++ b/scripts/openssl_srtp.test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Test WolfSSL/OpenSSL srtp interoperability
 #
 # TODO: add OpenSSL client with WolfSSL server
@@ -59,7 +59,7 @@ start_openssl_server() {
 
     server_output_file=/tmp/openssl_srtp_out
 
-    # hackish but OpenSSL doesn't work if input is feeded before handshaking and
+    # hackish but OpenSSL doesn't work if input is fed before handshaking and
     # the wolfSSL client needs a reply to stop
     (sleep 1;echo -n "I hear you fa shizzle...") | \
         ${OPENSSL} s_server \

--- a/scripts/resume.test
+++ b/scripts/resume.test
@@ -74,7 +74,7 @@ do_test() {
     esac
 
     remove_ready_file
-    echo "./examples/server/server -r -R "$ready_file" -p $resume_port"
+    echo "./examples/server/server -r -R \"$ready_file\" -p $resume_port"
     ./examples/server/server -r -R "$ready_file" -p $resume_port &
     server_pid=$!
 

--- a/scripts/sniffer-testsuite.test
+++ b/scripts/sniffer-testsuite.test
@@ -102,7 +102,7 @@ then
 fi
 
 # TLS v1.3 sniffer test X25519
-if test $RESULT -eq 0 && test $has_tlsv13 == yes && test $has_x22519 == yes
+if test $RESULT -eq 0 && test $has_tlsv13 == yes && test $has_x25519 == yes
 then
     ./sslSniffer/sslSnifferTest/snifftest ./scripts/sniffer-tls13-x25519.pcap ./certs/statickeys/x25519.pem 127.0.0.1 11111
 

--- a/scripts/tls13.test
+++ b/scripts/tls13.test
@@ -38,7 +38,7 @@ server_out_file="$(pwd)/wolfssl_tls13_server_out$$"
 # Client output
 client_out_file="$(pwd)/wolfssl_tls13_client_out$$"
 
-echo "ready file "$ready_file""
+echo "ready file \"$ready_file\""
 
 create_port() {
     while [ ! -s "$ready_file" ]; do
@@ -262,7 +262,7 @@ if [ "$early_data" = "yes" ]; then
              tee "$server_out_file") &
         server_pid=$!
         create_port
-        ./examples/client/client -v 4 -r -0 -p $port 2>&1 >"$client_out_file"
+        ./examples/client/client -v 4 -r -0 -p $port >"$client_out_file" 2>&1
         RESULT=$?
         cat "$client_out_file"
         remove_ready_file

--- a/scripts/unit.test.in
+++ b/scripts/unit.test.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then
+if [ -n "$NETWORK_UNSHARE_HELPER" ]; then
     exec "${NETWORK_UNSHARE_HELPER}" "@builddir@/tests/unit.test" "$@" || exit $?
 elif [ "${AM_BWRAPPED-}" != "yes" ]; then
     bwrap_path="$(command -v bwrap)"

--- a/src/pk.c
+++ b/src/pk.c
@@ -9306,7 +9306,7 @@ int wolfSSL_ECDSA_do_verify(const unsigned char *d, int dlen,
     r = wolfSSL_BN_bn2hex(sig->r);
     s = wolfSSL_BN_bn2hex(sig->s);
     /* get DER-encoded ECDSA signature */
-    ret = wc_ecc_rs_to_sig((const char*)r, (const char*)s, 
+    ret = wc_ecc_rs_to_sig((const char*)r, (const char*)s,
                                         signature, &signaturelen);
     /* free r and s */
     if (r)
@@ -9318,10 +9318,10 @@ int wolfSSL_ECDSA_do_verify(const unsigned char *d, int dlen,
         WOLFSSL_MSG("wc_ecc_verify_hash failed");
         return WOLFSSL_FATAL_ERROR;
     }
-    /* verify hash. expects to call wc_CryptoCb_EccVerify internally */ 
+    /* verify hash. expects to call wc_CryptoCb_EccVerify internally */
     ret = wc_ecc_verify_hash(signature, signaturelen, d, dlen, &check_sign,
                         (ecc_key*)key->internal);
-    
+
     if (ret != MP_OKAY) {
         WOLFSSL_MSG("wc_ecc_verify_hash failed");
         return WOLFSSL_FATAL_ERROR;

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -39428,7 +39428,7 @@ static int ecc_onlycb_test(myCryptoDevCtx *ctx)
     byte* out = (byte*)XMALLOC(sizeof(byte),
                                             HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     #ifdef OPENSSL_EXTRA
-    byte* check = (byte*)XMALLOC(sizeof(byte)*(256), HEAP_HINT, 
+    byte* check = (byte*)XMALLOC(sizeof(byte)*(256), HEAP_HINT,
                                             DYNAMIC_TYPE_TMP_BUFFER);
 
     #endif
@@ -39581,10 +39581,10 @@ static int ecc_onlycb_test(myCryptoDevCtx *ctx)
     }
     else
         ret = 0;
-    
- 
+
+
     #ifdef OPENSSL_EXTRA
-    
+
     (void)pkey;
     cp = ecc_clikey_der_256;
     privKey = d2i_PrivateKey(EVP_PKEY_EC, NULL, &cp,
@@ -39594,7 +39594,7 @@ static int ecc_onlycb_test(myCryptoDevCtx *ctx)
     }
     pkey = (ecc_key*)privKey->ecc->internal;
     pkey->devId = devId;
-   
+
     p = ecc_clikeypub_der_256;
     pubKey = d2i_PUBKEY(NULL, &p, sizeof_ecc_clikeypub_der_256);
     if (pubKey == NULL) {
@@ -39605,7 +39605,7 @@ static int ecc_onlycb_test(myCryptoDevCtx *ctx)
 
     /* sign */
     EVP_MD_CTX_init(&mdCtx);
-    
+
     ret = EVP_DigestSignInit(&mdCtx, NULL, EVP_sha256(), NULL, privKey);
     if (ret != WOLFSSL_SUCCESS) {
         ERROR_OUT(-8021, exit_onlycb);
@@ -39647,7 +39647,7 @@ static int ecc_onlycb_test(myCryptoDevCtx *ctx)
     }
 
     /* verify */
-    
+
     EVP_MD_CTX_init(&mdCtx);
 
     if (ret == SSL_SUCCESS) {


### PR DESCRIPTION
global fixes for shellcheck warnings SC2027, SC2069, SC2154, SC2141, SC3014, SC3037 (all true positives).  note, does not fix SC2057 in ocsp-stapling.test, which is addressed by PR #5174 .

tested with `wolfssl-multi-test ... super-quick-check`

```
[check-shell-scripts] [1 of 1] [52af2f7457]
    autoreconf 52af2f7457...   real 0m14.684s  user 0m12.993s  sys 0m0.828s
    bash -n... done.
    shellcheck scripts...
4d4145e6a0 (<douzzer@wolfssl.com> 2022-05-05 15:59:11 -0500 3) if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then
In ./scripts/unit.test.in line 3:
if [[ -n "$NETWORK_UNSHARE_HELPER" ]]; then
   ^-- SC3010 (warning): In POSIX sh, [[ ]] is undefined.


21db484f50 (<jeff@wolfssl.com> 2021-06-08 18:42:30 -0700 41) echo "ready file "$ready_file""
In ./scripts/tls13.test line 41:
echo "ready file "$ready_file""
                  ^---------^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.


830431ccdf (<douzzer@wolfssl.com> 2022-03-11 13:54:50 -0600 265)         ./examples/client/client -v 4 -r -0 -p $port 2>&1 >"$client_out_file"
In ./scripts/tls13.test line 265:
        ./examples/client/client -v 4 -r -0 -p $port 2>&1 >"$client_out_file"
                                                     ^--^ SC2069 (warning): To redirect stdout+stderr, 2>&1 must be last (or use '{ cmd > file; } 2>&1' to clarify).


659d33fdaf (<david@wolfssl.com> 2022-04-08 15:22:16 -0700 105) if test $RESULT -eq 0 && test $has_tlsv13 == yes && test $has_x22519 == yes
In ./scripts/sniffer-testsuite.test line 105:
if test $RESULT -eq 0 && test $has_tlsv13 == yes && test $has_x22519 == yes
                                                         ^---------^ SC2154 (warning): has_x22519 is referenced but not assigned (did you mean 'has_x25519'?).


d8b58b8b05 (<david@wolfssl.com> 2021-12-20 11:47:34 -0800 77)     echo "./examples/server/server -r -R "$ready_file" -p $resume_port"
In ./scripts/resume.test line 77:
    echo "./examples/server/server -r -R "$ready_file" -p $resume_port"
                                          ^---------^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.


46c0809f5a (<marco@wolfssl.com> 2022-01-20 16:11:15 +0100 64)     (sleep 1;echo -n "I hear you fa shizzle...") | \
In ./scripts/openssl_srtp.test line 64:
    (sleep 1;echo -n "I hear you fa shizzle...") | \
                  ^-- SC3037 (warning): In POSIX sh, echo flags are undefined.


46c0809f5a (<marco@wolfssl.com> 2022-01-20 16:11:15 +0100 120)     echo -n "check dtls $1 $2... "
In ./scripts/openssl_srtp.test line 120:
    echo -n "check dtls $1 $2... "
         ^-- SC3037 (warning): In POSIX sh, echo flags are undefined.


21db484f50 (<jeff@wolfssl.com> 2021-06-08 18:42:30 -0700 324)         echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite -v $version $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl"
In ./scripts/openssl.test line 324:
        echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite -v $version $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl"
                                                                                                 ^-----------^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.
                                                                                                                 ^----------^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.
                                                                                                                                ^-------------^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.


21db484f50 (<jeff@wolfssl.com> 2021-06-08 18:42:30 -0700 328)         echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl"
In ./scripts/openssl.test line 328:
        echo "# $WOLFSSL_CLIENT -p $port -g $wolfssl_resume -l $wolfSuite $psk $adh "$wolfssl_cert" "$wolfssl_key" "$wolfssl_caCert" $crl"
                                                                                     ^-----------^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.
                                                                                                     ^----------^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.
                                                                                                                    ^-------------^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.


93cdfd7132 (<sean@wolfssl.com> 2020-07-07 22:47:28 +1000 457) IFS=$'\:' # set delimiter
In ./scripts/openssl.test line 457:
IFS=$'\:' # set delimiter
    ^---^ SC2141 (warning): This IFS value contains a literal backslash. For tabs/linefeeds/escapes, use $'..', literal, or printf.


93cdfd7132 (<sean@wolfssl.com> 2020-07-07 22:47:28 +1000 556) IFS=$'\:' # set delimiter
In ./scripts/openssl.test line 556:
IFS=$'\:' # set delimiter
    ^---^ SC2141 (warning): This IFS value contains a literal backslash. For tabs/linefeeds/escapes, use $'..', literal, or printf.


fbd4f8a6ed (<todd@wolfssl.com> 2015-11-02 13:26:46 -0800 748) IFS=$'\:' # set delimiter
In ./scripts/openssl.test line 748:
IFS=$'\:' # set delimiter
    ^---^ SC2141 (warning): This IFS value contains a literal backslash. For tabs/linefeeds/escapes, use $'..', literal, or printf.


d8b58b8b05 (<david@wolfssl.com> 2021-12-20 11:47:34 -0800 40)         echo "./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N -v d -S $server"
In ./scripts/ocsp.test line 40:
        echo "./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N -v d -S $server"
                                                                   ^-^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.


d8b58b8b05 (<david@wolfssl.com> 2021-12-20 11:47:34 -0800 65)     echo "./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N"
In ./scripts/ocsp.test line 65:
    echo "./examples/client/client -X -C -h $server -p 443 -A "$ca" -g -o -N"
                                                               ^-^ SC2027 (warning): The surrounding quotes actually unquote this. Remove or escape them.


139b0431cb (<douzzer@wolfssl.com> 2020-10-27 14:23:55 -0500 238)     if [ $? -neq 0 ]; then
In ./scripts/ocsp-stapling.test line 238:
    if [ $? -neq 0 ]; then
            ^--^ SC2057 (warning): Unknown binary operator.


59a3b4a110 (<david@wolfssl.com> 2018-12-21 09:33:54 -0800 192) if [ "$1" == "clean" ]; then
In ./certs/intermediate/genintcerts.sh line 192:
if [ "$1" == "clean" ]; then
          ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.


59a3b4a110 (<david@wolfssl.com> 2018-12-21 09:33:54 -0800 196) if [ "$1" == "cleanall" ]; then
In ./certs/intermediate/genintcerts.sh line 196:
if [ "$1" == "cleanall" ]; then
          ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.


For more information:
  https://www.shellcheck.net/wiki/SC2027 -- The surrounding quotes actually u...
  https://www.shellcheck.net/wiki/SC2057 -- Unknown binary operator.
  https://www.shellcheck.net/wiki/SC2069 -- To redirect stdout+stderr, 2>&1 m...
```

also fixes whitespace in test/test.c and src/pk.c
