### PR TITLE
Fix to move wolfSSL_ERR_clear_error outside gate for OPENSSL_EXTRA

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -17766,14 +17766,6 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         return ret;
     }
 
-    void wolfSSL_ERR_clear_error(void)
-    {
-        WOLFSSL_ENTER("wolfSSL_ERR_clear_error");
-#if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
-        wc_ClearErrorNodes();
-#endif
-    }
-
 #ifndef NO_DES3
     /* 0 on ok */
     int wolfSSL_DES_key_sched(WOLFSSL_const_DES_cblock* key,
@@ -18027,6 +18019,14 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     }
 
 #endif /* OPENSSL_EXTRA */
+
+#if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE)
+    void wolfSSL_ERR_clear_error(void)
+    {
+        WOLFSSL_ENTER("wolfSSL_ERR_clear_error");
+        wc_ClearErrorNodes();
+    }
+#endif
 
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
     int wolfSSL_clear(WOLFSSL* ssl)

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -4656,7 +4656,7 @@ struct WOLFSSL {
  * to the error queue on file end. This should not be left
  * for the caller to find so we clear the last error.
  */
-#ifdef WOLFSSL_HAVE_ERROR_QUEUE
+#if defined(OPENSSL_EXTRA) && defined(WOLFSSL_HAVE_ERROR_QUEUE)
 #define CLEAR_ASN_NO_PEM_HEADER_ERROR(err)                  \
     (err) = wolfSSL_ERR_peek_last_error();                  \
     if (ERR_GET_LIB(err) == ERR_LIB_PEM &&                  \


### PR DESCRIPTION
# Description

Fix to move `wolfSSL_ERR_clear_error` outside gate for `OPENSSL_EXTRA`.

Fixes zd14227

# Testing

Config with `DEBUG_WOLFSSL_VERBOSE`: `./configure CFLAGS="-DDEBUG_WOLFSSL_VERBOSE" && make`

Call `wolfSSL_ERR_clear_error` in application.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
