### PR TITLE
Confirm ssl->hsHashes is not NULL before attempting to dereference it.

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -14341,7 +14341,7 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         #endif
             {
                 ssl->options.cacheMessages = 0;
-                if (ssl->hsHashes->messages != NULL) {
+                if ((ssl->hsHashes != NULL) && (ssl->hsHashes->messages != NULL)) {
                     XFREE(ssl->hsHashes->messages, ssl->heap,
                         DYNAMIC_TYPE_HASHES);
                     ssl->hsHashes->messages = NULL;
@@ -14427,7 +14427,7 @@ static int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         #endif
             {
                 ssl->options.cacheMessages = 0;
-                if (ssl->hsHashes->messages != NULL) {
+                if ((ssl->hsHashes != NULL) && (ssl->hsHashes->messages != NULL)) {
                     XFREE(ssl->hsHashes->messages, ssl->heap, DYNAMIC_TYPE_HASHES);
                     ssl->hsHashes->messages = NULL;
                 }

--- a/wolfssl/openssl/asn1.h
+++ b/wolfssl/openssl/asn1.h
@@ -164,7 +164,7 @@ WOLFSSL_API int wolfSSL_ASN1_item_i2d(const void *src, byte **dest,
                                       const WOLFSSL_ASN1_ITEM *tpl);
 
 /* Need function declaration otherwise compiler complains */
-/* NOLINTBEGIN(readability-named-parameter) */
+/* // NOLINTBEGIN(readability-named-parameter) */
 #define IMPLEMENT_ASN1_FUNCTIONS(type) \
     type *type##_new(void); \
     type *type##_new(void){ \
@@ -179,7 +179,7 @@ WOLFSSL_API int wolfSSL_ASN1_item_i2d(const void *src, byte **dest,
     { \
         return wolfSSL_ASN1_item_i2d(src, dest, &type##_template_data);\
     }
-/* NOLINTEND(readability-named-parameter) */
+/* // NOLINTEND(readability-named-parameter) */
 
 #endif /* OPENSSL_ALL */
 

--- a/wolfssl/openssl/asn1.h
+++ b/wolfssl/openssl/asn1.h
@@ -164,7 +164,7 @@ WOLFSSL_API int wolfSSL_ASN1_item_i2d(const void *src, byte **dest,
                                       const WOLFSSL_ASN1_ITEM *tpl);
 
 /* Need function declaration otherwise compiler complains */
-// NOLINTBEGIN(readability-named-parameter)
+/* NOLINTBEGIN(readability-named-parameter) */
 #define IMPLEMENT_ASN1_FUNCTIONS(type) \
     type *type##_new(void); \
     type *type##_new(void){ \
@@ -179,7 +179,7 @@ WOLFSSL_API int wolfSSL_ASN1_item_i2d(const void *src, byte **dest,
     { \
         return wolfSSL_ASN1_item_i2d(src, dest, &type##_template_data);\
     }
-// NOLINTEND(readability-named-parameter)
+/* NOLINTEND(readability-named-parameter) */
 
 #endif /* OPENSSL_ALL */
 


### PR DESCRIPTION
# Description

Confirm ssl->hsHashes is not NULL before attempting to dereference it.  Fixes ZD# 14273
Fix comments in asn1.h to use ANSI C style.  Fixes ZD# 14269

# Testing

Confirmed wolfSSL builds.  Confirmed ZD# 14273 issue reproducer no longer fails.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
