### PR TITLE
Add a global variable for heap-hint, mainly in case TSIP can not refer it

### DIFF
--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/common/user_settings.h
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/common/user_settings.h
@@ -124,6 +124,15 @@
  *----------------------------------------------------------------------------*/
   #define SIZEOF_LONG_LONG 8
 
+  /*#define WOLFSSL_STATIC_MEMORY*/
+  
+  #if defined(WOLFSSL_STATIC_MEMORY)
+    #define USE_FAST_MATH
+  #else
+    #define WOLFSSL_SMALL_STACK
+  #endif /* WOLFSSL_STATIC_MEMORY */
+
+
 #if !defined(min)
   #define min(data1, data2)                _builtin_min(data1, data2)
 #endif
@@ -145,7 +154,7 @@
   #define WOLFSSL_LOG_PRINTF
   #define WOLFSSL_HAVE_MIN
   #define WOLFSSL_HAVE_MAX
-  #define WOLFSSL_SMALL_STACK
+  
   #define NO_WRITEV
   #define WOLFSSL_USER_IO
 
@@ -220,3 +229,6 @@
     #define HAVE_HKDF
     #define WC_RSA_PSS
 #endif
+
+
+#define XSTRCASECMP(s1,s2) strcmp((s1),(s2))

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/common/wolfssl_dummy.c
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/common/wolfssl_dummy.c
@@ -22,7 +22,7 @@
 typedef unsigned long time_t;
 
 #define YEAR 2022
-#define MON  3
+#define MON  5
 
 static int tick = 0;
 

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/smc/.cproject
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/smc/.cproject
@@ -23,13 +23,13 @@
 							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.PE" id="com.renesas.cdt.managedbuild.renesas.ccrx.base.targetPlatform.24124316" osList="win32" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.targetPlatform"/>
 							<builder buildPath="${workspace_loc:/smc}/HardwareDebug" id="com.renesas.cdt.managedbuild.renesas.ccrx.base.builder.1276377212" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="CCRX Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.builder"/>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.dsp.1034155595" name="DSP Assembler" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.dsp">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo.1326286577" name="デバッグ情報を出力する (-no_debug_info)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.19247995" name="出力するデータ値のエンディアン (-littleEndianData)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.big" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo.1326286577" name="Output debug information (-no_debug_info)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.19247995" name="Endian of output data value (-littleEndianData)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.big" valueType="enumerated"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.common.1818731181" name="Common" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.common">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.1574659789" name="命令セット・アーキテクチャ (-isa)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.rxv2" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.1574659789" name="Instruction set architecture (-isa)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.rxv2" valueType="enumerated"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.rxArchitecture.7532856" name="RX Architecture" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.rxArchitecture" useByScannerDiscovery="false" value="rxv2" valueType="string"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.841340110" name="浮動小数点演算命令を使用する (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.yes" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.841340110" name="Use floating point arithmetic instructions (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.yes" valueType="enumerated"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.hasFpu.287393662" name="Has FPU" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.hasFpu" useByScannerDiscovery="false" value="TRUE" valueType="string"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceName.646833302" name="Device Name" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceName" useByScannerDiscovery="false" value="R5F565NEHxFP" valueType="string"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceHistory.1966837765" name="Device history" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceHistory" useByScannerDiscovery="false" value="non_init;R5F565NEHxFP" valueType="string"/>
@@ -40,9 +40,10 @@
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceFamily.1674070815" name="Device Family" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceFamily" useByScannerDiscovery="false" value="RX65N" valueType="string"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.compiler.1508700917" name="Compiler" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.compiler">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.4886222" name="浮動小数点演算命令を使用する (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.yes" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include.1248634269" name="インクルード・ファイルを検索するフォルダ (-include)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include" valueType="includePath">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.4886222" name="Use floating point arithmetic instructions (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.yes" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include.1248634269" name="Include file directories (-include)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include" valueType="includePath">
 									<listOptionValue builtIn="false" value="${TCINSTALL}/include"/>
+									<listOptionValue builtIn="false" value="${ProjDirPath}/generate"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/general}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/Config_TMR0}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_pincfg}&quot;"/>
@@ -59,70 +60,70 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_t4_rx/lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_tsip_rx}&quot;"/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore.1431645164" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore.1431645164" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter.148221317" name="追加するオプション（すべての指定オプションの後ろに追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter.148221317" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.10897982" name="Cソース (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.c99" valueType="enumerated"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.2076226696" name="プログラムの文字コード (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.utf8" valueType="enumerated"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.1726073063" name="出力する文字コード (-outcode)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.utf8" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.10897982" name="C source file (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.c99" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.2076226696" name="Character code of an input program (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.utf8" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.1726073063" name="Output character code (-outcode)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.utf8" valueType="enumerated"/>
 								<inputType id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gcc.inputType.680339798" name="Compiler Input C" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gcc.inputType"/>
 								<inputType id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gpp.inputType.1035083979" name="Compiler Input CPP" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gpp.inputType"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.assembler.770500626" name="Assembler" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.assembler">
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore.678526255" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore.678526255" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter.214576131" name="追加するオプション（すべての指定オプションの後ろに追加）&#10;" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter.214576131" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.1261556953" name="プログラムの文字コード (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.utf8" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.1261556953" name="Character code of an input program (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.utf8" valueType="enumerated"/>
 								<inputType id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.inputType.756564181" name="Assembler InputType" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.inputType"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.linker.1339846431" name="Linker" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.linker">
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom.1434821333" name="ROMからRAMへマップするセクション (-rom)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom.1434821333" name="ROM to RAM mapped section (-rom)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value="D=R"/>
 									<listOptionValue builtIn="false" value="D_1=R_1"/>
 									<listOptionValue builtIn="false" value="D_2=R_2"/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection.394830605" name="セクション (-start)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection" useByScannerDiscovery="false" value="SU,SI,B_1,R_1,B_2,R_2,B,R/04,C_1,C_2,C,C$*,D*,W*,L,P*/0FFE00000,EXCEPTVECT/0FFFFFF80,RESETVECT/0FFFFFFFC,B_ETHERNET_BUFFERS_1,B_RX_DESC_1,B_TX_DESC_1/00010000" valueType="string"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore.1196210369" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection.394830605" name="Sections (-start)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection" useByScannerDiscovery="false" value="SU,SI,B_1,R_1,B_2,R_2,B,R/04,C_1,C_2,C,C$*,D*,W*,L,P*/0FFE00000,EXCEPTVECT/0FFFFFF80,RESETVECT/0FFFFFFFC,B_ETHERNET_BUFFERS_1,B_RX_DESC_1,B_TX_DESC_1/00010000" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore.1196210369" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter.41222079" name="追加するオプション（すべての指定オプションの後ろに追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter.41222079" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.vect.1146521938" name="可変ベクタテーブルのアドレス未設定ベクタ番号に指定するアドレス (-vect)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.vect" useByScannerDiscovery="false" value="_undefined_interrupt_source_isr" valueType="string"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection.1165075859" name="セクションの割り付けアドレスをチェックする (-cpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.1456895529" name="アドレス範囲指定方法 (-cpu(アドレス範囲指定方法))" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.autoSpecify" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList.1219751178" name="(リンク順序のリスト) (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList" valueType="stringList">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.vect.1146521938" name="Address setting for unused vector area (-vect)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.vect" useByScannerDiscovery="false" value="_undefined_interrupt_source_isr" valueType="string"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection.1165075859" name="Checks the section larger than the specified range of addresses (-cpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.1456895529" name="Memory address type assignment method (-cpu(Address space of Single-Chip Mode))" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.autoSpecify" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList.1219751178" name="(Linkage order list) (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList" valueType="stringList">
 									<listOptionValue builtIn="false" value="&quot;.\smc.lib&quot;"/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.inputFile.1233488024" name="リンクするリロケータブル・ファイル、ライブラリ・ファイルおよびバイナリ・ファイル (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.inputFile" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.inputFile.1233488024" name="Relocatable files, object files and library files (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.inputFile" valueType="stringList">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_tsip_rx/lib/ccrx/r_tsip_rx65n_little.lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_t4_rx/lib/ccrx/T4_Library_ether_ccrx_rxv1_little.lib}&quot;"/>
 								</option>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.librarian.465470766" name="Library Generator" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.librarian">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.1269590255" name="浮動小数点演算命令を使用する (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.yes" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore.270923116" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.1269590255" name="Use floating point arithmetic instructions (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.yes" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore.270923116" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter.1299397327" name="追加するオプション（すべての指定オプションの後ろに追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter.1299397327" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang.1765409610" name="C言語標準ライブラリ関数の構成 (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang.c99" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang.1765409610" name="Library configuration (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang.c99" valueType="enumerated"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.converter.1302985020" name="Converter" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.converter">
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore.214292277" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore.214292277" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter.291317464" name="追加するオプション（すべての指定オプションの後ろに追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter.291317464" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile.342553276" name="出力ファイル形式 (-form)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile" value="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOFOutputFile.none" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile.342553276" name="Output file type (-form)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile" value="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOFOutputFile.none" valueType="enumerated"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.rtosConfig.287664454" name="RTOS Configurator" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.rtosConfig"/>
 						</toolChain>
@@ -133,6 +134,11 @@
 				</configuration>
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="com.renesas.cdt.managedbuild.core.boardInfo">
+				<option id="board.id" value="gr-rose"/>
+				<option id="board.name" value="gr-rose"/>
+				<option id="board.device" value="R5F565NEHxFP"/>
+			</storageModule>
 		</cconfiguration>
 	</storageModule>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
@@ -143,4 +149,5 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="refreshScope"/>
 </cproject>

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/smc/smc.scfg
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/smc/smc.scfg
@@ -4,13 +4,12 @@
         <configuration active="true" id="com.renesas.smc.toolchain.rxc.configuration.release">
             <property id="com.renesas.smc.service.project.buildArtefactType" values="com.renesas.smc.service.project.buildArtefactType.exe"/>
             <toolchain id="com.renesas.smc.toolchain.rxc.toolchain.rxc">
-                <option id="com.renesas.smc.toolchain.option.language" key="com.renesas.smc.toolchain.option.language.c"/>
                 <option id="com.renesas.smc.toolchain.option.buildArtefactType" key="com.renesas.smc.toolchain.option.buildArtefactType.exe"/>
                 <option id="com.renesas.smc.toolchain.option.rtos" key="com.renesas.smc.toolchain.option.rtos.none"/>
             </toolchain>
         </configuration>
         <platform id="R5F565NEHxFP"/>
-        <option id="board" value="カスタムユーザボード"/>
+        <option id="board" value="gr-rose (v1.01)"/>
     </general>
     <tool id="Clock">
         <option enabled="true" id="vccinput" selection="textinputitem">
@@ -20,14 +19,14 @@
             <item enabled="true" id="check"/>
             <item enabled="true" id="uncheck"/>
         </option>
-        <option enabled="true" id="mainsourcebox" selection="srcR">
+        <option enabled="true" id="mainsourcebox" selection="srcEOI">
             <item enabled="true" id="srcR"/>
             <item enabled="true" id="srcEOI"/>
         </option>
         <option enabled="true" id="mainfrequency" selection="textinputitem">
             <item enabled="true" id="textinputitem" input="12" value="12.000000"/>
         </option>
-        <option enabled="true" id="mainwaittime" selection="textinputitem">
+        <option enabled="false" id="mainwaittime" selection="textinputitem">
             <item enabled="true" id="textinputitem" input="9980" value="9980.000000"/>
         </option>
         <option enabled="true" id="subclockenable" selection="uncheck">
@@ -80,7 +79,7 @@
             <item enabled="false" id="div1-2"/>
             <item enabled="false" id="div1-3"/>
         </option>
-        <option enabled="true" id="pllmul" selection="mul20-1">
+        <option enabled="true" id="pllmul" selection="mul10-1">
             <item enabled="true" id="mul10-1"/>
             <item enabled="true" id="mul10_5-1"/>
             <item enabled="true" id="mul11-1"/>
@@ -124,22 +123,13 @@
             <item enabled="false" id="mul30-1"/>
         </option>
         <option enabled="true" id="sckswitcher" selection="pll">
-            <item enabled="true" id="pll" input="" value="2.4E8"/>
+            <item enabled="true" id="pll" input="" value="1.2E8"/>
             <item enabled="true" id="main" input="" value="1.2E7"/>
             <item enabled="false" id="sub" input="" value="32768.0"/>
             <item enabled="false" id="hoco" input="" value="16000000"/>
             <item enabled="false" id="loco" input="" value="240000"/>
         </option>
         <option enabled="true" id="fclkdivider" selection="comboBox1-4">
-            <item enabled="false" id="comboBox1-1"/>
-            <item enabled="false" id="comboBox1-2"/>
-            <item enabled="true" id="comboBox1-4"/>
-            <item enabled="true" id="comboBox1-8"/>
-            <item enabled="true" id="comboBox1-16"/>
-            <item enabled="true" id="comboBox1-32"/>
-            <item enabled="true" id="comboBox1-64"/>
-        </option>
-        <option enabled="true" id="iclkdivider" selection="comboBox1-2">
             <item enabled="false" id="comboBox1-1"/>
             <item enabled="true" id="comboBox1-2"/>
             <item enabled="true" id="comboBox1-4"/>
@@ -148,8 +138,17 @@
             <item enabled="true" id="comboBox1-32"/>
             <item enabled="true" id="comboBox1-64"/>
         </option>
+        <option enabled="true" id="iclkdivider" selection="comboBox1-1">
+            <item enabled="true" id="comboBox1-1"/>
+            <item enabled="true" id="comboBox1-2"/>
+            <item enabled="true" id="comboBox1-4"/>
+            <item enabled="true" id="comboBox1-8"/>
+            <item enabled="true" id="comboBox1-16"/>
+            <item enabled="true" id="comboBox1-32"/>
+            <item enabled="true" id="comboBox1-64"/>
+        </option>
         <option enabled="true" id="pclkadivider" selection="comboBox1-2">
-            <item enabled="false" id="comboBox1-1"/>
+            <item enabled="true" id="comboBox1-1"/>
             <item enabled="true" id="comboBox1-2"/>
             <item enabled="true" id="comboBox1-4"/>
             <item enabled="true" id="comboBox1-8"/>
@@ -159,7 +158,7 @@
         </option>
         <option enabled="true" id="pclkbdivider" selection="comboBox1-4">
             <item enabled="false" id="comboBox1-1"/>
-            <item enabled="false" id="comboBox1-2"/>
+            <item enabled="true" id="comboBox1-2"/>
             <item enabled="true" id="comboBox1-4"/>
             <item enabled="true" id="comboBox1-8"/>
             <item enabled="true" id="comboBox1-16"/>
@@ -185,7 +184,7 @@
             <item enabled="false" id="comboBox1-64"/>
         </option>
         <option enabled="true" id="bckdivider" selection="comboBox1-2">
-            <item enabled="false" id="comboBox1-1"/>
+            <item enabled="true" id="comboBox1-1"/>
             <item enabled="true" id="comboBox1-2"/>
             <item enabled="true" id="comboBox1-4"/>
             <item enabled="true" id="comboBox1-8"/>
@@ -198,7 +197,7 @@
             <item enabled="true" id="uncheck"/>
         </option>
         <option enabled="false" id="bckselector" selection="comboBox1-2">
-            <item enabled="false" id="comboBox1-1"/>
+            <item enabled="true" id="comboBox1-1"/>
             <item enabled="true" id="comboBox1-2"/>
         </option>
         <option enabled="true" id="uckenable" selection="uncheck">
@@ -207,36 +206,36 @@
         </option>
         <option enabled="false" id="uckdivider" selection="comboBox1-5">
             <item enabled="false" id="comboBox1-2"/>
-            <item enabled="false" id="comboBox1-3"/>
-            <item enabled="false" id="comboBox1-4"/>
+            <item enabled="true" id="comboBox1-3"/>
+            <item enabled="true" id="comboBox1-4"/>
             <item enabled="true" id="comboBox1-5"/>
         </option>
         <option enabled="true" id="fclk" selection="textoutputitem">
-            <item enabled="true" id="textoutputitem" input="" value="60.0"/>
+            <item enabled="true" id="textoutputitem" input="" value="30.0"/>
         </option>
         <option enabled="true" id="iclk" selection="textoutputitem">
             <item enabled="true" id="textoutputitem" input="" value="120.0"/>
         </option>
         <option enabled="true" id="pclka" selection="textoutputitem">
-            <item enabled="true" id="textoutputitem" input="" value="120.0"/>
+            <item enabled="true" id="textoutputitem" input="" value="60.0"/>
         </option>
         <option enabled="true" id="pclkb" selection="textoutputitem">
-            <item enabled="true" id="textoutputitem" input="" value="60.0"/>
+            <item enabled="true" id="textoutputitem" input="" value="30.0"/>
         </option>
         <option enabled="true" id="pclkc" selection="textoutputitem">
-            <item enabled="true" id="textoutputitem" input="" value="60.0"/>
+            <item enabled="true" id="textoutputitem" input="" value="30.0"/>
         </option>
         <option enabled="true" id="pclkd" selection="textoutputitem">
-            <item enabled="true" id="textoutputitem" input="" value="60.0"/>
+            <item enabled="true" id="textoutputitem" input="" value="30.0"/>
         </option>
         <option enabled="true" id="bck" selection="textoutputitem">
-            <item enabled="true" id="textoutputitem" input="" value="120.0"/>
-        </option>
-        <option enabled="false" id="bckpin" selection="textoutputitem">
             <item enabled="true" id="textoutputitem" input="" value="60.0"/>
         </option>
+        <option enabled="false" id="bckpin" selection="textoutputitem">
+            <item enabled="true" id="textoutputitem" input="" value="30.0"/>
+        </option>
         <option enabled="false" id="uclk" selection="textoutputitem">
-            <item enabled="true" id="textoutputitem" input="" value="48.0"/>
+            <item enabled="false" id="textoutputitem" input="" value="24.0"/>
         </option>
         <option enabled="false" id="caclclk" selection="textoutputitem">
             <item enabled="true" id="textoutputitem" input="" value="240"/>
@@ -262,241 +261,265 @@
         </option>
     </tool>
     <tool id="Interrupt">
-        <Item currentVect="16" id="BSC_BUSERR" priority="15" usedState="未使用"/>
-        <Item currentVect="18" id="RAM_RAMERR" priority="15" usedState="未使用"/>
-        <Item currentVect="21" id="FCU_FIFERR" priority="15" usedState="未使用"/>
-        <Item currentVect="23" id="FCU_FRDYI" priority="15" usedState="未使用"/>
-        <Item currentVect="26" id="ICU_SWINT2" priority="1" usedState="使用中"/>
-        <Item currentVect="27" id="ICU_SWINT" priority="1" usedState="使用中"/>
-        <Item currentVect="28" id="CMT0_CMI0" priority="15" usedState="未使用"/>
-        <Item currentVect="29" id="CMT1_CMI1" priority="15" usedState="未使用"/>
-        <Item currentVect="30" id="CMTW0_CMWI0" priority="15" usedState="未使用"/>
-        <Item currentVect="31" id="CMTW1_CMWI1" priority="15" usedState="未使用"/>
-        <Item currentVect="34" id="USB0_D0FIFO0" priority="15" usedState="未使用"/>
-        <Item currentVect="35" id="USB0_D1FIFO0" priority="15" usedState="未使用"/>
-        <Item currentVect="38" id="RSPI0_SPRI0" priority="15" usedState="未使用"/>
-        <Item currentVect="39" id="RSPI0_SPTI0" priority="15" usedState="未使用"/>
-        <Item currentVect="40" id="RSPI1_SPRI1" priority="15" usedState="未使用"/>
-        <Item currentVect="41" id="RSPI1_SPTI1" priority="15" usedState="未使用"/>
-        <Item currentVect="42" id="QSPI_SPRI" priority="15" usedState="未使用"/>
-        <Item currentVect="43" id="QSPI_SPTI" priority="15" usedState="未使用"/>
-        <Item currentVect="44" id="SDHI_SBFAI" priority="15" usedState="未使用"/>
-        <Item currentVect="45" id="MMCIF_MBFAI" priority="15" usedState="未使用"/>
-        <Item currentVect="50" id="RIIC1_RXI1" priority="15" usedState="未使用"/>
-        <Item currentVect="51" id="RIIC1_TXI1" priority="15" usedState="未使用"/>
-        <Item currentVect="52" id="RIIC0_RXI0" priority="15" usedState="未使用"/>
-        <Item currentVect="53" id="RIIC0_TXI0" priority="15" usedState="未使用"/>
-        <Item currentVect="54" id="RIIC2_RXI2" priority="15" usedState="未使用"/>
-        <Item currentVect="55" id="RIIC2_TXI2" priority="15" usedState="未使用"/>
-        <Item currentVect="58" id="SCI0_RXI0" priority="15" usedState="未使用"/>
-        <Item currentVect="59" id="SCI0_TXI0" priority="15" usedState="未使用"/>
-        <Item currentVect="60" id="SCI1_RXI1" priority="15" usedState="未使用"/>
-        <Item currentVect="61" id="SCI1_TXI1" priority="15" usedState="未使用"/>
-        <Item currentVect="62" id="SCI2_RXI2" priority="15" usedState="未使用"/>
-        <Item currentVect="63" id="SCI2_TXI2" priority="15" usedState="未使用"/>
-        <Item currentVect="64" id="ICU_IRQ0" priority="15" usedState="未使用"/>
-        <Item currentVect="65" id="ICU_IRQ1" priority="15" usedState="未使用"/>
-        <Item currentVect="66" id="ICU_IRQ2" priority="15" usedState="未使用"/>
-        <Item currentVect="67" id="ICU_IRQ3" priority="15" usedState="未使用"/>
-        <Item currentVect="68" id="ICU_IRQ4" priority="15" usedState="未使用"/>
-        <Item currentVect="69" id="ICU_IRQ5" priority="15" usedState="未使用"/>
-        <Item currentVect="70" id="ICU_IRQ6" priority="15" usedState="未使用"/>
-        <Item currentVect="71" id="ICU_IRQ7" priority="15" usedState="未使用"/>
-        <Item currentVect="72" id="ICU_IRQ8" priority="15" usedState="未使用"/>
-        <Item currentVect="73" id="ICU_IRQ9" priority="15" usedState="未使用"/>
-        <Item currentVect="74" id="ICU_IRQ10" priority="15" usedState="未使用"/>
-        <Item currentVect="75" id="ICU_IRQ11" priority="15" usedState="未使用"/>
-        <Item currentVect="76" id="ICU_IRQ12" priority="15" usedState="未使用"/>
-        <Item currentVect="77" id="ICU_IRQ13" priority="15" usedState="未使用"/>
-        <Item currentVect="78" id="ICU_IRQ14" priority="15" usedState="未使用"/>
-        <Item currentVect="79" id="ICU_IRQ15" priority="15" usedState="未使用"/>
-        <Item currentVect="80" id="SCI3_RXI3" priority="15" usedState="未使用"/>
-        <Item currentVect="81" id="SCI3_TXI3" priority="15" usedState="未使用"/>
-        <Item currentVect="82" id="SCI4_RXI4" priority="15" usedState="未使用"/>
-        <Item currentVect="83" id="SCI4_TXI4" priority="15" usedState="未使用"/>
-        <Item currentVect="84" id="SCI5_RXI5" priority="15" usedState="未使用"/>
-        <Item currentVect="85" id="SCI5_TXI5" priority="15" usedState="未使用"/>
-        <Item currentVect="86" id="SCI6_RXI6" priority="15" usedState="未使用"/>
-        <Item currentVect="87" id="SCI6_TXI6" priority="15" usedState="未使用"/>
-        <Item currentVect="88" id="LVD1_LVD1" priority="15" usedState="未使用"/>
-        <Item currentVect="89" id="LVD2_LVD2" priority="15" usedState="未使用"/>
-        <Item currentVect="90" id="USB0_USBR0" priority="15" usedState="未使用"/>
-        <Item currentVect="92" id="RTC_ALM" priority="15" usedState="未使用"/>
-        <Item currentVect="93" id="RTC_PRD" priority="15" usedState="未使用"/>
-        <Item currentVect="95" id="IWDT_IWUNI" priority="15" usedState="未使用"/>
-        <Item currentVect="96" id="WDT_WUNI" priority="15" usedState="未使用"/>
-        <Item currentVect="97" id="PDC_PCDFI" priority="15" usedState="未使用"/>
-        <Item currentVect="98" id="SCI7_RXI7" priority="15" usedState="未使用"/>
-        <Item currentVect="99" id="SCI7_TXI7" priority="15" usedState="未使用"/>
-        <Item currentVect="100" id="SCI8_RXI8" priority="15" usedState="未使用"/>
-        <Item currentVect="101" id="SCI8_TXI8" priority="15" usedState="未使用"/>
-        <Item currentVect="102" id="SCI9_RXI9" priority="15" usedState="未使用"/>
-        <Item currentVect="103" id="SCI9_TXI9" priority="15" usedState="未使用"/>
-        <Item currentVect="104" id="SCI10_RXI10" priority="15" usedState="未使用"/>
-        <Item currentVect="105" id="SCI10_TXI10" priority="15" usedState="未使用"/>
-        <Item currentVect="106" groupchild="&lt;br&gt;1-ERS0&lt;br&gt;2-ERS1" id="BE0" priority="15" usedState="未使用"/>
-        <Item currentVect="107" groupchild="&lt;br&gt;1-SDIOI" id="BL2" priority="15" usedState="未使用"/>
-        <Item currentVect="108" id="RSPI2_SPRI2" priority="15" usedState="未使用"/>
-        <Item currentVect="109" id="RSPI2_SPTI2" priority="15" usedState="未使用"/>
-        <Item currentVect="110" groupchild="&lt;br&gt;1-TEI0&lt;br&gt;2-ERI0&lt;br&gt;3-TEI1&lt;br&gt;4-ERI1&lt;br&gt;5-TEI2&lt;br&gt;6-ERI2&lt;br&gt;7-TEI3&lt;br&gt;8-ERI3&lt;br&gt;9-TEI4&lt;br&gt;10-ERI4&lt;br&gt;11-TEI5&lt;br&gt;12-ERI5&lt;br&gt;13-TEI6&lt;br&gt;14-ERI6&lt;br&gt;15-TEI7&lt;br&gt;16-ERI7&lt;br&gt;17-TEI12&lt;br&gt;18-ERI12&lt;br&gt;19-SCIX0&lt;br&gt;20-SCIX1&lt;br&gt;21-SCIX2&lt;br&gt;22-SCIX3&lt;br&gt;23-QSPSSLI&lt;br&gt;24-FERRI&lt;br&gt;25-MENDI&lt;br&gt;26-OVFI&lt;br&gt;27-DOPCI&lt;br&gt;28-PCFEI&lt;br&gt;29-PCERI" id="BL0" priority="15" usedState="未使用"/>
-        <Item currentVect="111" groupchild="&lt;br&gt;1-CDETI&lt;br&gt;2-CACI&lt;br&gt;3-SDACI&lt;br&gt;4-CDETIO&lt;br&gt;5-ERRIO&lt;br&gt;6-ACCIO&lt;br&gt;7-OEI1&lt;br&gt;8-OEI2&lt;br&gt;9-OEI3&lt;br&gt;10-OEI4&lt;br&gt;11-TEI0&lt;br&gt;12-EEI0&lt;br&gt;13-TEI2&lt;br&gt;14-EEI2&lt;br&gt;15-S12CMPAI&lt;br&gt;16-S12CMPBI&lt;br&gt;17-S12CMPAI1&lt;br&gt;18-S12CMPBI1&lt;br&gt;19-TEI8&lt;br&gt;20-ERI8&lt;br&gt;21-TEI9&lt;br&gt;22-ERI9&lt;br&gt;23-TEI1&lt;br&gt;24-EEI1" id="BL1" priority="15" usedState="未使用"/>
-        <Item currentVect="112" groupchild="&lt;br&gt;1-TEI10&lt;br&gt;2-ERI10&lt;br&gt;3-TEI11&lt;br&gt;4-ERI11&lt;br&gt;5-SPII0&lt;br&gt;6-SPEI0&lt;br&gt;7-SPII1&lt;br&gt;8-SPEI1&lt;br&gt;9-SPII2&lt;br&gt;10-SPEI2" id="AL0" priority="15" usedState="未使用"/>
-        <Item currentVect="113" groupchild="&lt;br&gt;1-EINT0&lt;br&gt;2-VPOS&lt;br&gt;3-GR1UF&lt;br&gt;4-GR2UF&lt;br&gt;5-DRW_IRQ" id="AL1" priority="2" usedState="使用中"/>
-        <Item currentVect="114" id="SCI11_RXI11" priority="15" usedState="未使用"/>
-        <Item currentVect="115" id="SCI11_TXI11" priority="15" usedState="未使用"/>
-        <Item currentVect="116" id="SCI12_RXI12" priority="15" usedState="未使用"/>
-        <Item currentVect="117" id="SCI12_TXI12" priority="15" usedState="未使用"/>
-        <Item currentVect="120" id="DMAC_DMAC0I" priority="15" usedState="未使用"/>
-        <Item currentVect="121" id="DMAC_DMAC1I" priority="15" usedState="未使用"/>
-        <Item currentVect="122" id="DMAC_DMAC2I" priority="15" usedState="未使用"/>
-        <Item currentVect="123" id="DMAC_DMAC3I" priority="15" usedState="未使用"/>
-        <Item currentVect="124" id="DMAC_DMAC74I" priority="15" usedState="未使用"/>
-        <Item currentVect="125" id="OST_OSTDI" priority="15" usedState="未使用"/>
-        <Item currentVect="126" id="EXDMAC_EXDMAC0I" priority="15" usedState="未使用"/>
-        <Item currentVect="127" id="EXDMAC_EXDMAC1I" priority="15" usedState="未使用"/>
-        <Item currentVect="128" defaultVect="128" id="CMT2_CMI2" priority="15" usedState="未使用"/>
-        <Item currentVect="129" defaultVect="129" id="CMT3_CMI3" priority="15" usedState="未使用"/>
-        <Item currentVect="130" defaultVect="130" id="TPU0_TGI0A" priority="15" usedState="未使用"/>
-        <Item currentVect="131" defaultVect="131" id="TPU0_TGI0B" priority="15" usedState="未使用"/>
-        <Item currentVect="132" defaultVect="132" id="TPU0_TGI0C" priority="15" usedState="未使用"/>
-        <Item currentVect="133" defaultVect="133" id="TPU0_TGI0D" priority="15" usedState="未使用"/>
-        <Item currentVect="134" defaultVect="134" id="TPU0_TCI0V" priority="15" usedState="未使用"/>
-        <Item currentVect="135" defaultVect="135" id="TPU1_TGI1B" priority="15" usedState="未使用"/>
-        <Item currentVect="136" defaultVect="136" id="TPU1_TCI1V" priority="15" usedState="未使用"/>
-        <Item currentVect="137" defaultVect="137" id="TPU1_TCI1U" priority="15" usedState="未使用"/>
-        <Item currentVect="138" defaultVect="138" id="TPU2_TGI2A" priority="15" usedState="未使用"/>
-        <Item currentVect="139" defaultVect="139" id="TPU2_TGI2B" priority="15" usedState="未使用"/>
-        <Item currentVect="140" defaultVect="140" id="TPU2_TCI2V" priority="15" usedState="未使用"/>
-        <Item currentVect="141" defaultVect="141" id="TPU2_TCI2U" priority="15" usedState="未使用"/>
-        <Item currentVect="142" defaultVect="142" id="TPU3_TGI3A" priority="15" usedState="未使用"/>
-        <Item currentVect="143" defaultVect="143" id="TPU3_TGI3B" priority="15" usedState="未使用"/>
-        <Item currentVect="144" defaultVect="144" id="TPU1_TGI1A" priority="15" usedState="未使用"/>
-        <Item currentVect="145" defaultVect="145" id="TPU3_TGI3C" priority="15" usedState="未使用"/>
-        <Item currentVect="146" defaultVect="146" id="TMR0_CMIA0" priority="15" usedState="未使用"/>
-        <Item currentVect="147" defaultVect="147" id="TMR0_CMIB0" priority="15" usedState="未使用"/>
-        <Item currentVect="148" defaultVect="148" id="TMR0_OVI0" priority="15" usedState="未使用"/>
-        <Item currentVect="149" defaultVect="149" id="TMR1_CMIA1" priority="15" usedState="未使用"/>
-        <Item currentVect="150" defaultVect="150" id="TMR1_CMIB1" priority="15" usedState="未使用"/>
-        <Item currentVect="151" defaultVect="151" id="TMR1_OVI1" priority="15" usedState="未使用"/>
-        <Item currentVect="152" defaultVect="152" id="TMR2_CMIA2" priority="15" usedState="未使用"/>
-        <Item currentVect="153" defaultVect="153" id="TMR2_CMIB2" priority="15" usedState="未使用"/>
-        <Item currentVect="154" defaultVect="154" id="TMR2_OVI2" priority="15" usedState="未使用"/>
-        <Item currentVect="155" defaultVect="155" id="TMR3_CMIA3" priority="15" usedState="未使用"/>
-        <Item currentVect="156" defaultVect="156" id="TMR3_CMIB3" priority="15" usedState="未使用"/>
-        <Item currentVect="157" defaultVect="157" id="TMR3_OVI3" priority="15" usedState="未使用"/>
-        <Item currentVect="158" defaultVect="158" id="TPU3_TGI3D" priority="15" usedState="未使用"/>
-        <Item currentVect="159" defaultVect="159" id="TPU3_TCI3V" priority="15" usedState="未使用"/>
-        <Item currentVect="160" defaultVect="160" id="TPU4_TGI4A" priority="15" usedState="未使用"/>
-        <Item currentVect="161" defaultVect="161" id="TPU4_TGI4B" priority="15" usedState="未使用"/>
-        <Item currentVect="162" defaultVect="162" id="TPU4_TCI4V" priority="15" usedState="未使用"/>
-        <Item currentVect="163" defaultVect="163" id="TPU4_TCI4U" priority="15" usedState="未使用"/>
-        <Item currentVect="164" defaultVect="164" id="TPU5_TGI5A" priority="15" usedState="未使用"/>
-        <Item currentVect="165" defaultVect="165" id="TPU5_TGI5B" priority="15" usedState="未使用"/>
-        <Item currentVect="166" defaultVect="166" id="TPU5_TCI5V" priority="15" usedState="未使用"/>
-        <Item currentVect="167" defaultVect="167" id="TPU5_TCI5U" priority="15" usedState="未使用"/>
-        <Item currentVect="168" defaultVect="168" id="CMTW0_IC0I0" priority="15" usedState="未使用"/>
-        <Item currentVect="169" defaultVect="169" id="CMTW0_IC1I0" priority="15" usedState="未使用"/>
-        <Item currentVect="170" defaultVect="170" id="CMTW0_OC0I0" priority="15" usedState="未使用"/>
-        <Item currentVect="171" defaultVect="171" id="CMTW0_OC1I0" priority="15" usedState="未使用"/>
-        <Item currentVect="172" defaultVect="172" id="CMTW1_IC0I1" priority="15" usedState="未使用"/>
-        <Item currentVect="173" defaultVect="173" id="CMTW1_IC1I1" priority="15" usedState="未使用"/>
-        <Item currentVect="174" defaultVect="174" id="CMTW1_OC0I1" priority="15" usedState="未使用"/>
-        <Item currentVect="175" defaultVect="175" id="CMTW1_OC1I1" priority="15" usedState="未使用"/>
-        <Item currentVect="176" defaultVect="176" id="RTC_CUP" priority="15" usedState="未使用"/>
-        <Item currentVect="177" defaultVect="177" id="CAN0_RXF0" priority="15" usedState="未使用"/>
-        <Item currentVect="178" defaultVect="178" id="CAN0_TXF0" priority="15" usedState="未使用"/>
-        <Item currentVect="179" defaultVect="179" id="CAN0_RXM0" priority="15" usedState="未使用"/>
-        <Item currentVect="180" defaultVect="180" id="CAN0_TXM0" priority="15" usedState="未使用"/>
-        <Item currentVect="181" defaultVect="181" id="CAN1_RXF1" priority="15" usedState="未使用"/>
-        <Item currentVect="182" defaultVect="182" id="CAN1_TXF1" priority="15" usedState="未使用"/>
-        <Item currentVect="183" defaultVect="183" id="CAN1_RXM1" priority="15" usedState="未使用"/>
-        <Item currentVect="184" defaultVect="184" id="CAN1_TXM1" priority="15" usedState="未使用"/>
-        <Item currentVect="185" defaultVect="185" id="USB0_USBI0" priority="15" usedState="未使用"/>
-        <Item currentVect="186" defaultVect="186" id="S12AD_S12ADI" priority="15" usedState="未使用"/>
-        <Item currentVect="187" defaultVect="187" id="S12AD_S12GBADI" priority="15" usedState="未使用"/>
-        <Item currentVect="188" defaultVect="188" id="S12AD_S12GCADI" priority="15" usedState="未使用"/>
-        <Item currentVect="189" defaultVect="189" id="S12AD1_S12ADI1" priority="15" usedState="未使用"/>
-        <Item currentVect="190" defaultVect="190" id="S12AD1_S12GBADI1" priority="15" usedState="未使用"/>
-        <Item currentVect="191" defaultVect="191" id="S12AD1_S12GCADI1" priority="15" usedState="未使用"/>
-        <Item currentVect="192" defaultVect="192" id="RNG_RNGEND" priority="15" usedState="未使用"/>
-        <Item currentVect="193" defaultVect="193" id="ELC_ELSR18I" priority="15" usedState="未使用"/>
-        <Item currentVect="194" defaultVect="194" id="ELC_ELSR19I" priority="15" usedState="未使用"/>
-        <Item currentVect="195" defaultVect="195" id="TSIP_PROC_BUSY" priority="15" usedState="未使用"/>
-        <Item currentVect="196" defaultVect="196" id="TSIP_ROMOK" priority="15" usedState="未使用"/>
-        <Item currentVect="197" defaultVect="197" id="TSIP_LONG_PLG" priority="15" usedState="未使用"/>
-        <Item currentVect="198" defaultVect="198" id="TSIP_TEST_BUSY" priority="15" usedState="未使用"/>
-        <Item currentVect="199" defaultVect="199" id="TSIP_WRRDY0" priority="15" usedState="未使用"/>
-        <Item currentVect="200" defaultVect="200" id="TSIP_WRRDY1" priority="15" usedState="未使用"/>
-        <Item currentVect="201" defaultVect="201" id="TSIP_WRRDY4" priority="15" usedState="未使用"/>
-        <Item currentVect="202" defaultVect="202" id="TSIP_RDRDY0" priority="15" usedState="未使用"/>
-        <Item currentVect="203" defaultVect="203" id="TSIP_RDRDY1" priority="15" usedState="未使用"/>
-        <Item currentVect="204" defaultVect="204" id="TSIP_INTEGRATE_WRRDY" priority="15" usedState="未使用"/>
-        <Item currentVect="205" defaultVect="205" id="TSIP_INTEGRATE_RDRDY" priority="15" usedState="未使用"/>
-        <Item currentVect="206" id="PERIB_INTB206" priority="15" usedState="未使用"/>
-        <Item currentVect="207" id="PERIB_INTB207" priority="15" usedState="未使用"/>
-        <Item currentVect="208" defaultVect="208" id="MTU1_TGIA1" priority="15" usedState="未使用"/>
-        <Item currentVect="209" defaultVect="209" id="MTU0_TGIA0" priority="15" usedState="未使用"/>
-        <Item currentVect="210" defaultVect="210" id="MTU0_TGIB0" priority="15" usedState="未使用"/>
-        <Item currentVect="211" defaultVect="211" id="MTU0_TGIC0" priority="15" usedState="未使用"/>
-        <Item currentVect="212" defaultVect="212" id="MTU0_TGID0" priority="15" usedState="未使用"/>
-        <Item currentVect="213" defaultVect="213" id="MTU0_TCIV0" priority="15" usedState="未使用"/>
-        <Item currentVect="214" defaultVect="214" id="MTU0_TGIE0" priority="15" usedState="未使用"/>
-        <Item currentVect="215" defaultVect="215" id="MTU0_TGIF0" priority="15" usedState="未使用"/>
-        <Item currentVect="216" defaultVect="216" id="MTU1_TGIB1" priority="15" usedState="未使用"/>
-        <Item currentVect="217" defaultVect="217" id="MTU1_TCIV1" priority="15" usedState="未使用"/>
-        <Item currentVect="218" defaultVect="218" id="MTU1_TCIU1" priority="15" usedState="未使用"/>
-        <Item currentVect="219" defaultVect="219" id="MTU2_TGIA2" priority="15" usedState="未使用"/>
-        <Item currentVect="220" defaultVect="220" id="MTU2_TGIB2" priority="15" usedState="未使用"/>
-        <Item currentVect="221" defaultVect="221" id="MTU2_TCIV2" priority="15" usedState="未使用"/>
-        <Item currentVect="222" defaultVect="222" id="MTU2_TCIU2" priority="15" usedState="未使用"/>
-        <Item currentVect="223" defaultVect="223" id="MTU3_TGIA3" priority="15" usedState="未使用"/>
-        <Item currentVect="224" defaultVect="224" id="MTU3_TGIB3" priority="15" usedState="未使用"/>
-        <Item currentVect="225" defaultVect="225" id="MTU3_TGIC3" priority="15" usedState="未使用"/>
-        <Item currentVect="226" defaultVect="226" id="MTU3_TGID3" priority="15" usedState="未使用"/>
-        <Item currentVect="227" defaultVect="227" id="MTU3_TCIV3" priority="15" usedState="未使用"/>
-        <Item currentVect="228" defaultVect="228" id="MTU4_TGIA4" priority="15" usedState="未使用"/>
-        <Item currentVect="229" defaultVect="229" id="MTU4_TGIB4" priority="15" usedState="未使用"/>
-        <Item currentVect="230" defaultVect="230" id="MTU4_TGIC4" priority="15" usedState="未使用"/>
-        <Item currentVect="231" defaultVect="231" id="MTU4_TGID4" priority="15" usedState="未使用"/>
-        <Item currentVect="232" defaultVect="232" id="MTU4_TCIV4" priority="15" usedState="未使用"/>
-        <Item currentVect="233" defaultVect="233" id="MTU5_TGIU5" priority="15" usedState="未使用"/>
-        <Item currentVect="234" defaultVect="234" id="MTU5_TGIV5" priority="15" usedState="未使用"/>
-        <Item currentVect="235" defaultVect="235" id="MTU5_TGIW5" priority="15" usedState="未使用"/>
-        <Item currentVect="236" defaultVect="236" id="MTU6_TGIA6" priority="15" usedState="未使用"/>
-        <Item currentVect="237" defaultVect="237" id="MTU6_TGIB6" priority="15" usedState="未使用"/>
-        <Item currentVect="238" defaultVect="238" id="MTU6_TGIC6" priority="15" usedState="未使用"/>
-        <Item currentVect="239" defaultVect="239" id="MTU6_TGID6" priority="15" usedState="未使用"/>
-        <Item currentVect="240" defaultVect="240" id="MTU6_TCIV6" priority="15" usedState="未使用"/>
-        <Item currentVect="241" defaultVect="241" id="MTU7_TGIA7" priority="15" usedState="未使用"/>
-        <Item currentVect="242" defaultVect="242" id="MTU7_TGIB7" priority="15" usedState="未使用"/>
-        <Item currentVect="243" defaultVect="243" id="MTU7_TGIC7" priority="15" usedState="未使用"/>
-        <Item currentVect="244" defaultVect="244" id="MTU7_TGID7" priority="15" usedState="未使用"/>
-        <Item currentVect="245" defaultVect="245" id="MTU7_TCIV7" priority="15" usedState="未使用"/>
-        <Item currentVect="246" defaultVect="246" id="MTU8_TGIA8" priority="15" usedState="未使用"/>
-        <Item currentVect="247" defaultVect="247" id="MTU8_TGIB8" priority="15" usedState="未使用"/>
-        <Item currentVect="248" defaultVect="248" id="MTU8_TGIC8" priority="15" usedState="未使用"/>
-        <Item currentVect="249" defaultVect="249" id="MTU8_TGID8" priority="15" usedState="未使用"/>
-        <Item currentVect="250" defaultVect="250" id="MTU8_TCIV8" priority="15" usedState="未使用"/>
-        <Item currentVect="251" defaultVect="251" id="AES_AESRDY" priority="15" usedState="未使用"/>
-        <Item currentVect="252" defaultVect="252" id="AES_AESEND" priority="15" usedState="未使用"/>
-        <Item currentVect="253" id="PERIA_INTA253" priority="15" usedState="未使用"/>
-        <Item currentVect="254" id="PERIA_INTA254" priority="15" usedState="未使用"/>
-        <Item currentVect="255" id="PERIA_INTA255" priority="15" usedState="未使用"/>
+        <Item currentVect="16" id="BSC_BUSERR" priority="15" usedState="Not Use"/>
+        <Item currentVect="18" id="RAM_RAMERR" priority="15" usedState="Not Use"/>
+        <Item currentVect="21" id="FCU_FIFERR" priority="15" usedState="Not Use"/>
+        <Item currentVect="23" id="FCU_FRDYI" priority="15" usedState="Not Use"/>
+        <Item currentVect="26" id="ICU_SWINT2" priority="1" usedState="Used"/>
+        <Item currentVect="27" id="ICU_SWINT" priority="1" usedState="Used"/>
+        <Item currentVect="28" id="CMT0_CMI0" priority="15" usedState="Not Use"/>
+        <Item currentVect="29" id="CMT1_CMI1" priority="15" usedState="Not Use"/>
+        <Item currentVect="30" id="CMTW0_CMWI0" priority="15" usedState="Not Use"/>
+        <Item currentVect="31" id="CMTW1_CMWI1" priority="15" usedState="Not Use"/>
+        <Item currentVect="34" id="USB0_D0FIFO0" priority="15" usedState="Not Use"/>
+        <Item currentVect="35" id="USB0_D1FIFO0" priority="15" usedState="Not Use"/>
+        <Item currentVect="38" id="RSPI0_SPRI0" priority="15" usedState="Not Use"/>
+        <Item currentVect="39" id="RSPI0_SPTI0" priority="15" usedState="Not Use"/>
+        <Item currentVect="40" id="RSPI1_SPRI1" priority="15" usedState="Not Use"/>
+        <Item currentVect="41" id="RSPI1_SPTI1" priority="15" usedState="Not Use"/>
+        <Item currentVect="42" id="QSPI_SPRI" priority="15" usedState="Not Use"/>
+        <Item currentVect="43" id="QSPI_SPTI" priority="15" usedState="Not Use"/>
+        <Item currentVect="44" id="SDHI_SBFAI" priority="15" usedState="Not Use"/>
+        <Item currentVect="45" id="MMCIF_MBFAI" priority="15" usedState="Not Use"/>
+        <Item currentVect="50" id="RIIC1_RXI1" priority="15" usedState="Not Use"/>
+        <Item currentVect="51" id="RIIC1_TXI1" priority="15" usedState="Not Use"/>
+        <Item currentVect="52" id="RIIC0_RXI0" priority="15" usedState="Not Use"/>
+        <Item currentVect="53" id="RIIC0_TXI0" priority="15" usedState="Not Use"/>
+        <Item currentVect="54" id="RIIC2_RXI2" priority="15" usedState="Not Use"/>
+        <Item currentVect="55" id="RIIC2_TXI2" priority="15" usedState="Not Use"/>
+        <Item currentVect="58" id="SCI0_RXI0" priority="15" usedState="Not Use"/>
+        <Item currentVect="59" id="SCI0_TXI0" priority="15" usedState="Not Use"/>
+        <Item currentVect="60" id="SCI1_RXI1" priority="15" usedState="Not Use"/>
+        <Item currentVect="61" id="SCI1_TXI1" priority="15" usedState="Not Use"/>
+        <Item currentVect="62" id="SCI2_RXI2" priority="15" usedState="Not Use"/>
+        <Item currentVect="63" id="SCI2_TXI2" priority="15" usedState="Not Use"/>
+        <Item currentVect="64" id="ICU_IRQ0" priority="15" usedState="Not Use"/>
+        <Item currentVect="65" id="ICU_IRQ1" priority="15" usedState="Not Use"/>
+        <Item currentVect="66" id="ICU_IRQ2" priority="15" usedState="Not Use"/>
+        <Item currentVect="67" id="ICU_IRQ3" priority="15" usedState="Not Use"/>
+        <Item currentVect="68" id="ICU_IRQ4" priority="15" usedState="Not Use"/>
+        <Item currentVect="69" id="ICU_IRQ5" priority="15" usedState="Not Use"/>
+        <Item currentVect="70" id="ICU_IRQ6" priority="15" usedState="Not Use"/>
+        <Item currentVect="71" id="ICU_IRQ7" priority="15" usedState="Not Use"/>
+        <Item currentVect="72" id="ICU_IRQ8" priority="15" usedState="Not Use"/>
+        <Item currentVect="73" id="ICU_IRQ9" priority="15" usedState="Not Use"/>
+        <Item currentVect="74" id="ICU_IRQ10" priority="15" usedState="Not Use"/>
+        <Item currentVect="75" id="ICU_IRQ11" priority="15" usedState="Not Use"/>
+        <Item currentVect="76" id="ICU_IRQ12" priority="15" usedState="Not Use"/>
+        <Item currentVect="77" id="ICU_IRQ13" priority="15" usedState="Not Use"/>
+        <Item currentVect="78" id="ICU_IRQ14" priority="15" usedState="Not Use"/>
+        <Item currentVect="79" id="ICU_IRQ15" priority="15" usedState="Not Use"/>
+        <Item currentVect="80" id="SCI3_RXI3" priority="15" usedState="Not Use"/>
+        <Item currentVect="81" id="SCI3_TXI3" priority="15" usedState="Not Use"/>
+        <Item currentVect="82" id="SCI4_RXI4" priority="15" usedState="Not Use"/>
+        <Item currentVect="83" id="SCI4_TXI4" priority="15" usedState="Not Use"/>
+        <Item currentVect="84" id="SCI5_RXI5" priority="15" usedState="Not Use"/>
+        <Item currentVect="85" id="SCI5_TXI5" priority="15" usedState="Not Use"/>
+        <Item currentVect="86" id="SCI6_RXI6" priority="15" usedState="Not Use"/>
+        <Item currentVect="87" id="SCI6_TXI6" priority="15" usedState="Not Use"/>
+        <Item currentVect="88" id="LVD1_LVD1" priority="15" usedState="Not Use"/>
+        <Item currentVect="89" id="LVD2_LVD2" priority="15" usedState="Not Use"/>
+        <Item currentVect="90" id="USB0_USBR0" priority="15" usedState="Not Use"/>
+        <Item currentVect="92" id="RTC_ALM" priority="15" usedState="Not Use"/>
+        <Item currentVect="93" id="RTC_PRD" priority="15" usedState="Not Use"/>
+        <Item currentVect="95" id="IWDT_IWUNI" priority="15" usedState="Not Use"/>
+        <Item currentVect="96" id="WDT_WUNI" priority="15" usedState="Not Use"/>
+        <Item currentVect="97" id="PDC_PCDFI" priority="15" usedState="Not Use"/>
+        <Item currentVect="98" id="SCI7_RXI7" priority="15" usedState="Not Use"/>
+        <Item currentVect="99" id="SCI7_TXI7" priority="15" usedState="Not Use"/>
+        <Item currentVect="100" id="SCI8_RXI8" priority="15" usedState="Not Use"/>
+        <Item currentVect="101" id="SCI8_TXI8" priority="15" usedState="Not Use"/>
+        <Item currentVect="102" id="SCI9_RXI9" priority="15" usedState="Not Use"/>
+        <Item currentVect="103" id="SCI9_TXI9" priority="15" usedState="Not Use"/>
+        <Item currentVect="104" id="SCI10_RXI10" priority="15" usedState="Not Use"/>
+        <Item currentVect="105" id="SCI10_TXI10" priority="15" usedState="Not Use"/>
+        <Item currentVect="106" groupchild="&lt;br&gt;1-ERS0&lt;br&gt;2-ERS1" id="BE0" priority="15" usedState="Not Use"/>
+        <Item currentVect="107" groupchild="&lt;br&gt;1-SDIOI" id="BL2" priority="15" usedState="Not Use"/>
+        <Item currentVect="108" id="RSPI2_SPRI2" priority="15" usedState="Not Use"/>
+        <Item currentVect="109" id="RSPI2_SPTI2" priority="15" usedState="Not Use"/>
+        <Item currentVect="110" groupchild="&lt;br&gt;1-TEI0&lt;br&gt;2-ERI0&lt;br&gt;3-TEI1&lt;br&gt;4-ERI1&lt;br&gt;5-TEI2&lt;br&gt;6-ERI2&lt;br&gt;7-TEI3&lt;br&gt;8-ERI3&lt;br&gt;9-TEI4&lt;br&gt;10-ERI4&lt;br&gt;11-TEI5&lt;br&gt;12-ERI5&lt;br&gt;13-TEI6&lt;br&gt;14-ERI6&lt;br&gt;15-TEI7&lt;br&gt;16-ERI7&lt;br&gt;17-TEI12&lt;br&gt;18-ERI12&lt;br&gt;19-SCIX0&lt;br&gt;20-SCIX1&lt;br&gt;21-SCIX2&lt;br&gt;22-SCIX3&lt;br&gt;23-QSPSSLI&lt;br&gt;24-FERRI&lt;br&gt;25-MENDI&lt;br&gt;26-OVFI&lt;br&gt;27-DOPCI&lt;br&gt;28-PCFEI&lt;br&gt;29-PCERI" id="BL0" priority="15" usedState="Not Use"/>
+        <Item currentVect="111" groupchild="&lt;br&gt;1-CDETI&lt;br&gt;2-CACI&lt;br&gt;3-SDACI&lt;br&gt;4-CDETIO&lt;br&gt;5-ERRIO&lt;br&gt;6-ACCIO&lt;br&gt;7-OEI1&lt;br&gt;8-OEI2&lt;br&gt;9-OEI3&lt;br&gt;10-OEI4&lt;br&gt;11-TEI0&lt;br&gt;12-EEI0&lt;br&gt;13-TEI2&lt;br&gt;14-EEI2&lt;br&gt;15-S12CMPAI&lt;br&gt;16-S12CMPBI&lt;br&gt;17-S12CMPAI1&lt;br&gt;18-S12CMPBI1&lt;br&gt;19-TEI8&lt;br&gt;20-ERI8&lt;br&gt;21-TEI9&lt;br&gt;22-ERI9&lt;br&gt;23-TEI1&lt;br&gt;24-EEI1" id="BL1" priority="15" usedState="Not Use"/>
+        <Item currentVect="112" groupchild="&lt;br&gt;1-TEI10&lt;br&gt;2-ERI10&lt;br&gt;3-TEI11&lt;br&gt;4-ERI11&lt;br&gt;5-SPII0&lt;br&gt;6-SPEI0&lt;br&gt;7-SPII1&lt;br&gt;8-SPEI1&lt;br&gt;9-SPII2&lt;br&gt;10-SPEI2" id="AL0" priority="15" usedState="Not Use"/>
+        <Item currentVect="113" groupchild="&lt;br&gt;1-EINT0&lt;br&gt;2-VPOS&lt;br&gt;3-GR1UF&lt;br&gt;4-GR2UF&lt;br&gt;5-DRW_IRQ" id="AL1" priority="2" usedState="Used"/>
+        <Item currentVect="114" id="SCI11_RXI11" priority="15" usedState="Not Use"/>
+        <Item currentVect="115" id="SCI11_TXI11" priority="15" usedState="Not Use"/>
+        <Item currentVect="116" id="SCI12_RXI12" priority="15" usedState="Not Use"/>
+        <Item currentVect="117" id="SCI12_TXI12" priority="15" usedState="Not Use"/>
+        <Item currentVect="120" id="DMAC_DMAC0I" priority="15" usedState="Not Use"/>
+        <Item currentVect="121" id="DMAC_DMAC1I" priority="15" usedState="Not Use"/>
+        <Item currentVect="122" id="DMAC_DMAC2I" priority="15" usedState="Not Use"/>
+        <Item currentVect="123" id="DMAC_DMAC3I" priority="15" usedState="Not Use"/>
+        <Item currentVect="124" id="DMAC_DMAC74I" priority="15" usedState="Not Use"/>
+        <Item currentVect="125" id="OST_OSTDI" priority="15" usedState="Not Use"/>
+        <Item currentVect="126" id="EXDMAC_EXDMAC0I" priority="15" usedState="Not Use"/>
+        <Item currentVect="127" id="EXDMAC_EXDMAC1I" priority="15" usedState="Not Use"/>
+        <Item currentVect="128" defaultVect="128" id="CMT2_CMI2" priority="15" usedState="Not Use"/>
+        <Item currentVect="129" defaultVect="129" id="CMT3_CMI3" priority="15" usedState="Not Use"/>
+        <Item currentVect="130" defaultVect="130" id="TPU0_TGI0A" priority="15" usedState="Not Use"/>
+        <Item currentVect="131" defaultVect="131" id="TPU0_TGI0B" priority="15" usedState="Not Use"/>
+        <Item currentVect="132" defaultVect="132" id="TPU0_TGI0C" priority="15" usedState="Not Use"/>
+        <Item currentVect="133" defaultVect="133" id="TPU0_TGI0D" priority="15" usedState="Not Use"/>
+        <Item currentVect="134" defaultVect="134" id="TPU0_TCI0V" priority="15" usedState="Not Use"/>
+        <Item currentVect="135" defaultVect="135" id="TPU1_TGI1B" priority="15" usedState="Not Use"/>
+        <Item currentVect="136" defaultVect="136" id="TPU1_TCI1V" priority="15" usedState="Not Use"/>
+        <Item currentVect="137" defaultVect="137" id="TPU1_TCI1U" priority="15" usedState="Not Use"/>
+        <Item currentVect="138" defaultVect="138" id="TPU2_TGI2A" priority="15" usedState="Not Use"/>
+        <Item currentVect="139" defaultVect="139" id="TPU2_TGI2B" priority="15" usedState="Not Use"/>
+        <Item currentVect="140" defaultVect="140" id="TPU2_TCI2V" priority="15" usedState="Not Use"/>
+        <Item currentVect="141" defaultVect="141" id="TPU2_TCI2U" priority="15" usedState="Not Use"/>
+        <Item currentVect="142" defaultVect="142" id="TPU3_TGI3A" priority="15" usedState="Not Use"/>
+        <Item currentVect="143" defaultVect="143" id="TPU3_TGI3B" priority="15" usedState="Not Use"/>
+        <Item currentVect="144" defaultVect="144" id="TPU1_TGI1A" priority="15" usedState="Not Use"/>
+        <Item currentVect="145" defaultVect="145" id="TPU3_TGI3C" priority="15" usedState="Not Use"/>
+        <Item currentVect="146" defaultVect="146" id="TMR0_CMIA0" priority="15" usedState="Not Use"/>
+        <Item currentVect="147" defaultVect="147" id="TMR0_CMIB0" priority="15" usedState="Not Use"/>
+        <Item currentVect="148" defaultVect="148" id="TMR0_OVI0" priority="15" usedState="Not Use"/>
+        <Item currentVect="149" defaultVect="149" id="TMR1_CMIA1" priority="15" usedState="Not Use"/>
+        <Item currentVect="150" defaultVect="150" id="TMR1_CMIB1" priority="15" usedState="Not Use"/>
+        <Item currentVect="151" defaultVect="151" id="TMR1_OVI1" priority="15" usedState="Not Use"/>
+        <Item currentVect="152" defaultVect="152" id="TMR2_CMIA2" priority="15" usedState="Not Use"/>
+        <Item currentVect="153" defaultVect="153" id="TMR2_CMIB2" priority="15" usedState="Not Use"/>
+        <Item currentVect="154" defaultVect="154" id="TMR2_OVI2" priority="15" usedState="Not Use"/>
+        <Item currentVect="155" defaultVect="155" id="TMR3_CMIA3" priority="15" usedState="Not Use"/>
+        <Item currentVect="156" defaultVect="156" id="TMR3_CMIB3" priority="15" usedState="Not Use"/>
+        <Item currentVect="157" defaultVect="157" id="TMR3_OVI3" priority="15" usedState="Not Use"/>
+        <Item currentVect="158" defaultVect="158" id="TPU3_TGI3D" priority="15" usedState="Not Use"/>
+        <Item currentVect="159" defaultVect="159" id="TPU3_TCI3V" priority="15" usedState="Not Use"/>
+        <Item currentVect="160" defaultVect="160" id="TPU4_TGI4A" priority="15" usedState="Not Use"/>
+        <Item currentVect="161" defaultVect="161" id="TPU4_TGI4B" priority="15" usedState="Not Use"/>
+        <Item currentVect="162" defaultVect="162" id="TPU4_TCI4V" priority="15" usedState="Not Use"/>
+        <Item currentVect="163" defaultVect="163" id="TPU4_TCI4U" priority="15" usedState="Not Use"/>
+        <Item currentVect="164" defaultVect="164" id="TPU5_TGI5A" priority="15" usedState="Not Use"/>
+        <Item currentVect="165" defaultVect="165" id="TPU5_TGI5B" priority="15" usedState="Not Use"/>
+        <Item currentVect="166" defaultVect="166" id="TPU5_TCI5V" priority="15" usedState="Not Use"/>
+        <Item currentVect="167" defaultVect="167" id="TPU5_TCI5U" priority="15" usedState="Not Use"/>
+        <Item currentVect="168" defaultVect="168" id="CMTW0_IC0I0" priority="15" usedState="Not Use"/>
+        <Item currentVect="169" defaultVect="169" id="CMTW0_IC1I0" priority="15" usedState="Not Use"/>
+        <Item currentVect="170" defaultVect="170" id="CMTW0_OC0I0" priority="15" usedState="Not Use"/>
+        <Item currentVect="171" defaultVect="171" id="CMTW0_OC1I0" priority="15" usedState="Not Use"/>
+        <Item currentVect="172" defaultVect="172" id="CMTW1_IC0I1" priority="15" usedState="Not Use"/>
+        <Item currentVect="173" defaultVect="173" id="CMTW1_IC1I1" priority="15" usedState="Not Use"/>
+        <Item currentVect="174" defaultVect="174" id="CMTW1_OC0I1" priority="15" usedState="Not Use"/>
+        <Item currentVect="175" defaultVect="175" id="CMTW1_OC1I1" priority="15" usedState="Not Use"/>
+        <Item currentVect="176" defaultVect="176" id="RTC_CUP" priority="15" usedState="Not Use"/>
+        <Item currentVect="177" defaultVect="177" id="CAN0_RXF0" priority="15" usedState="Not Use"/>
+        <Item currentVect="178" defaultVect="178" id="CAN0_TXF0" priority="15" usedState="Not Use"/>
+        <Item currentVect="179" defaultVect="179" id="CAN0_RXM0" priority="15" usedState="Not Use"/>
+        <Item currentVect="180" defaultVect="180" id="CAN0_TXM0" priority="15" usedState="Not Use"/>
+        <Item currentVect="181" defaultVect="181" id="CAN1_RXF1" priority="15" usedState="Not Use"/>
+        <Item currentVect="182" defaultVect="182" id="CAN1_TXF1" priority="15" usedState="Not Use"/>
+        <Item currentVect="183" defaultVect="183" id="CAN1_RXM1" priority="15" usedState="Not Use"/>
+        <Item currentVect="184" defaultVect="184" id="CAN1_TXM1" priority="15" usedState="Not Use"/>
+        <Item currentVect="185" defaultVect="185" id="USB0_USBI0" priority="15" usedState="Not Use"/>
+        <Item currentVect="186" defaultVect="186" id="S12AD_S12ADI" priority="15" usedState="Not Use"/>
+        <Item currentVect="187" defaultVect="187" id="S12AD_S12GBADI" priority="15" usedState="Not Use"/>
+        <Item currentVect="188" defaultVect="188" id="S12AD_S12GCADI" priority="15" usedState="Not Use"/>
+        <Item currentVect="189" defaultVect="189" id="S12AD1_S12ADI1" priority="15" usedState="Not Use"/>
+        <Item currentVect="190" defaultVect="190" id="S12AD1_S12GBADI1" priority="15" usedState="Not Use"/>
+        <Item currentVect="191" defaultVect="191" id="S12AD1_S12GCADI1" priority="15" usedState="Not Use"/>
+        <Item currentVect="192" defaultVect="192" id="RNG_RNGEND" priority="15" usedState="Not Use"/>
+        <Item currentVect="193" defaultVect="193" id="ELC_ELSR18I" priority="15" usedState="Not Use"/>
+        <Item currentVect="194" defaultVect="194" id="ELC_ELSR19I" priority="15" usedState="Not Use"/>
+        <Item currentVect="195" defaultVect="195" id="TSIP_PROC_BUSY" priority="15" usedState="Not Use"/>
+        <Item currentVect="196" defaultVect="196" id="TSIP_ROMOK" priority="15" usedState="Not Use"/>
+        <Item currentVect="197" defaultVect="197" id="TSIP_LONG_PLG" priority="15" usedState="Not Use"/>
+        <Item currentVect="198" defaultVect="198" id="TSIP_TEST_BUSY" priority="15" usedState="Not Use"/>
+        <Item currentVect="199" defaultVect="199" id="TSIP_WRRDY0" priority="15" usedState="Not Use"/>
+        <Item currentVect="200" defaultVect="200" id="TSIP_WRRDY1" priority="15" usedState="Not Use"/>
+        <Item currentVect="201" defaultVect="201" id="TSIP_WRRDY4" priority="15" usedState="Not Use"/>
+        <Item currentVect="202" defaultVect="202" id="TSIP_RDRDY0" priority="15" usedState="Not Use"/>
+        <Item currentVect="203" defaultVect="203" id="TSIP_RDRDY1" priority="15" usedState="Not Use"/>
+        <Item currentVect="204" defaultVect="204" id="TSIP_INTEGRATE_WRRDY" priority="15" usedState="Not Use"/>
+        <Item currentVect="205" defaultVect="205" id="TSIP_INTEGRATE_RDRDY" priority="15" usedState="Not Use"/>
+        <Item currentVect="206" id="PERIB_INTB206" priority="15" usedState="Not Use"/>
+        <Item currentVect="207" id="PERIB_INTB207" priority="15" usedState="Not Use"/>
+        <Item currentVect="208" defaultVect="208" id="MTU1_TGIA1" priority="15" usedState="Not Use"/>
+        <Item currentVect="209" defaultVect="209" id="MTU0_TGIA0" priority="15" usedState="Not Use"/>
+        <Item currentVect="210" defaultVect="210" id="MTU0_TGIB0" priority="15" usedState="Not Use"/>
+        <Item currentVect="211" defaultVect="211" id="MTU0_TGIC0" priority="15" usedState="Not Use"/>
+        <Item currentVect="212" defaultVect="212" id="MTU0_TGID0" priority="15" usedState="Not Use"/>
+        <Item currentVect="213" defaultVect="213" id="MTU0_TCIV0" priority="15" usedState="Not Use"/>
+        <Item currentVect="214" defaultVect="214" id="MTU0_TGIE0" priority="15" usedState="Not Use"/>
+        <Item currentVect="215" defaultVect="215" id="MTU0_TGIF0" priority="15" usedState="Not Use"/>
+        <Item currentVect="216" defaultVect="216" id="MTU1_TGIB1" priority="15" usedState="Not Use"/>
+        <Item currentVect="217" defaultVect="217" id="MTU1_TCIV1" priority="15" usedState="Not Use"/>
+        <Item currentVect="218" defaultVect="218" id="MTU1_TCIU1" priority="15" usedState="Not Use"/>
+        <Item currentVect="219" defaultVect="219" id="MTU2_TGIA2" priority="15" usedState="Not Use"/>
+        <Item currentVect="220" defaultVect="220" id="MTU2_TGIB2" priority="15" usedState="Not Use"/>
+        <Item currentVect="221" defaultVect="221" id="MTU2_TCIV2" priority="15" usedState="Not Use"/>
+        <Item currentVect="222" defaultVect="222" id="MTU2_TCIU2" priority="15" usedState="Not Use"/>
+        <Item currentVect="223" defaultVect="223" id="MTU3_TGIA3" priority="15" usedState="Not Use"/>
+        <Item currentVect="224" defaultVect="224" id="MTU3_TGIB3" priority="15" usedState="Not Use"/>
+        <Item currentVect="225" defaultVect="225" id="MTU3_TGIC3" priority="15" usedState="Not Use"/>
+        <Item currentVect="226" defaultVect="226" id="MTU3_TGID3" priority="15" usedState="Not Use"/>
+        <Item currentVect="227" defaultVect="227" id="MTU3_TCIV3" priority="15" usedState="Not Use"/>
+        <Item currentVect="228" defaultVect="228" id="MTU4_TGIA4" priority="15" usedState="Not Use"/>
+        <Item currentVect="229" defaultVect="229" id="MTU4_TGIB4" priority="15" usedState="Not Use"/>
+        <Item currentVect="230" defaultVect="230" id="MTU4_TGIC4" priority="15" usedState="Not Use"/>
+        <Item currentVect="231" defaultVect="231" id="MTU4_TGID4" priority="15" usedState="Not Use"/>
+        <Item currentVect="232" defaultVect="232" id="MTU4_TCIV4" priority="15" usedState="Not Use"/>
+        <Item currentVect="233" defaultVect="233" id="MTU5_TGIU5" priority="15" usedState="Not Use"/>
+        <Item currentVect="234" defaultVect="234" id="MTU5_TGIV5" priority="15" usedState="Not Use"/>
+        <Item currentVect="235" defaultVect="235" id="MTU5_TGIW5" priority="15" usedState="Not Use"/>
+        <Item currentVect="236" defaultVect="236" id="MTU6_TGIA6" priority="15" usedState="Not Use"/>
+        <Item currentVect="237" defaultVect="237" id="MTU6_TGIB6" priority="15" usedState="Not Use"/>
+        <Item currentVect="238" defaultVect="238" id="MTU6_TGIC6" priority="15" usedState="Not Use"/>
+        <Item currentVect="239" defaultVect="239" id="MTU6_TGID6" priority="15" usedState="Not Use"/>
+        <Item currentVect="240" defaultVect="240" id="MTU6_TCIV6" priority="15" usedState="Not Use"/>
+        <Item currentVect="241" defaultVect="241" id="MTU7_TGIA7" priority="15" usedState="Not Use"/>
+        <Item currentVect="242" defaultVect="242" id="MTU7_TGIB7" priority="15" usedState="Not Use"/>
+        <Item currentVect="243" defaultVect="243" id="MTU7_TGIC7" priority="15" usedState="Not Use"/>
+        <Item currentVect="244" defaultVect="244" id="MTU7_TGID7" priority="15" usedState="Not Use"/>
+        <Item currentVect="245" defaultVect="245" id="MTU7_TCIV7" priority="15" usedState="Not Use"/>
+        <Item currentVect="246" defaultVect="246" id="MTU8_TGIA8" priority="15" usedState="Not Use"/>
+        <Item currentVect="247" defaultVect="247" id="MTU8_TGIB8" priority="15" usedState="Not Use"/>
+        <Item currentVect="248" defaultVect="248" id="MTU8_TGIC8" priority="15" usedState="Not Use"/>
+        <Item currentVect="249" defaultVect="249" id="MTU8_TGID8" priority="15" usedState="Not Use"/>
+        <Item currentVect="250" defaultVect="250" id="MTU8_TCIV8" priority="15" usedState="Not Use"/>
+        <Item currentVect="251" defaultVect="251" id="AES_AESRDY" priority="15" usedState="Not Use"/>
+        <Item currentVect="252" defaultVect="252" id="AES_AESEND" priority="15" usedState="Not Use"/>
+        <Item currentVect="253" id="PERIA_INTA253" priority="15" usedState="Not Use"/>
+        <Item currentVect="254" id="PERIA_INTA254" priority="15" usedState="Not Use"/>
+        <Item currentVect="255" id="PERIA_INTA255" priority="15" usedState="Not Use"/>
     </tool>
     <tool id="Pins" version="1.0.1.0">
         <pinItem allocation="11" comments="" direction="None" id="XTAL" isUsedBySoftware="true" locked="false" status="0"/>
-        <pinItem allocation="56" comments="" direction="None" id="RMII0_TXD_EN" isUsedBySoftware="true" locked="false" status="0"/>
-        <pinItem allocation="65" comments="" direction="None" id="ET0_LINKSTA" isUsedBySoftware="true" locked="false" status="0"/>
-        <pinItem allocation="54" comments="" direction="None" id="RMII0_TXD1" isUsedBySoftware="true" locked="false" status="0"/>
-        <pinItem allocation="67" comments="" direction="None" id="ET0_MDIO" isUsedBySoftware="true" locked="false" status="0"/>
-        <pinItem allocation="55" comments="" direction="None" id="RMII0_TXD0" isUsedBySoftware="true" locked="false" status="0"/>
-        <pinItem allocation="58" comments="" direction="None" id="REF50CK0" isUsedBySoftware="true" locked="false" status="0"/>
-        <pinItem allocation="13" comments="" direction="None" id="EXTAL" isUsedBySoftware="true" locked="false" status="0"/>
-        <pinItem allocation="57" comments="" direction="None" id="RMII0_RX_ER" isUsedBySoftware="true" locked="false" status="0"/>
-        <pinItem allocation="53" comments="" direction="None" id="RMII0_CRS_DV" isUsedBySoftware="true" locked="false" status="0"/>
+        <pinItem allocation="59" comments="" direction="None" id="RMII0_RXD0" isUsedBySoftware="true" locked="false" status="65280"/>
+        <pinItem allocation="61" comments="" direction="None" id="RMII0_RXD1" isUsedBySoftware="true" locked="false" status="65280"/>
+        <pinItem allocation="54" comments="" direction="None" id="RMII0_TXD1" isUsedBySoftware="true" locked="false" status="65280"/>
+        <pinItem allocation="55" comments="" direction="None" id="RMII0_TXD0" isUsedBySoftware="true" locked="false" status="65280"/>
+        <pinItem allocation="58" comments="" direction="None" id="REF50CK0" isUsedBySoftware="true" locked="false" status="65280"/>
         <pinItem allocation="66" comments="" direction="None" id="ET0_MDC" isUsedBySoftware="true" locked="false" status="0"/>
-        <pinItem allocation="59" comments="" direction="None" id="RMII0_RXD0" isUsedBySoftware="true" locked="false" status="0"/>
-        <pinItem allocation="61" comments="" direction="None" id="RMII0_RXD1" isUsedBySoftware="true" locked="false" status="0"/>
+        <pinItem allocation="13" comments="" direction="None" id="EXTAL" isUsedBySoftware="true" locked="false" status="0"/>
+        <pinItem allocation="65" comments="" direction="None" id="ET0_LINKSTA" isUsedBySoftware="true" locked="false" status="0"/>
+        <pinItem allocation="57" comments="" direction="None" id="RMII0_RX_ER" isUsedBySoftware="true" locked="false" status="65280"/>
+        <pinItem allocation="56" comments="" direction="None" id="RMII0_TXD_EN" isUsedBySoftware="true" locked="false" status="65280"/>
+        <pinItem allocation="67" comments="" direction="None" id="ET0_MDIO" isUsedBySoftware="true" locked="false" status="0"/>
+        <pinItem allocation="53" comments="" direction="None" id="RMII0_CRS_DV" isUsedBySoftware="true" locked="false" status="65280"/>
+        <pinnumItem comment="SW2 Reset Switch" id="10"/>
+        <pinnumItem comment="CN10 Serial Servo" id="16"/>
+        <pinnumItem comment="CN10 Serial Servo" id="17"/>
+        <pinnumItem comment="CN10 Serial Servo" id="18"/>
+        <pinnumItem comment="U5 WiFi Module" id="19"/>
+        <pinnumItem comment="N.C." id="4"/>
+        <pinnumItem comment="SW1 Operation Mode Switch" id="7"/>
+        <pinnumItem comment="CN4 PMOD" id="20"/>
+        <pinnumItem comment="U5 WiFi Module" id="21"/>
+        <pinnumItem comment="CN4 PMOD" id="22"/>
+        <pinnumItem comment="U5 WiFi Module" id="23"/>
+        <pinnumItem comment="U5 WiFi Module" id="24"/>
+        <pinnumItem comment="U5 WiFi Module" id="25"/>
+        <pinnumItem comment="CN7 Serial Servo" id="26"/>
+        <pinnumItem comment="CN7 Serial Servo" id="27"/>
+        <pinnumItem comment="CN7 Serial Servo" id="28"/>
+        <pinnumItem comment="U5 WiFi Module" id="29"/>
+        <pinnumItem comment="CN5 USB" id="30"/>
+        <pinnumItem comment="CN8 Serial Servo" id="32"/>
+        <pinnumItem comment="CN8 Serial Servo" id="33"/>
+        <pinnumItem comment="CN8 Serial Servo" id="34"/>
+        <pinnumItem comment="CN5 USB" id="36"/>
+        <pinnumItem comment="CN5 USB" id="37"/>
+        <pinnumItem comment="CN4 PMOD" id="42"/>
         <pinnumItem comment="CN4 PMOD" id="44"/>
         <pinnumItem comment="CN11 Serial Servo I/F" id="45"/>
         <pinnumItem comment="CN11 Serial Servo I/F" id="46"/>
@@ -505,62 +528,174 @@
         <pinnumItem comment="CN9 Serial Servo" id="49"/>
         <pinnumItem comment="CN9 Serial Servo" id="50"/>
         <pinnumItem comment="CN6 Ether" id="53"/>
-        <pinnumItem comment="SW2 Reset Switch" id="10"/>
         <pinnumItem comment="CN6 Ether" id="54"/>
         <pinnumItem comment="CN6 Ether" id="55"/>
         <pinnumItem comment="CN6 Ether" id="56"/>
         <pinnumItem comment="CN6 Ether" id="57"/>
         <pinnumItem comment="CN6 Ether" id="58"/>
         <pinnumItem comment="CN6 Ether" id="59"/>
-        <pinnumItem comment="CN10 Serial Servo" id="16"/>
-        <pinnumItem comment="CN10 Serial Servo" id="17"/>
-        <pinnumItem comment="CN10 Serial Servo" id="18"/>
-        <pinnumItem comment="U5 WiFi Module" id="19"/>
-        <pinnumItem comment="N.C." id="4"/>
-        <pinnumItem comment="SW1 Operation Mode Switch" id="7"/>
         <pinnumItem comment="CN6 Ether" id="61"/>
-        <pinnumItem comment="CN4 PMOD" id="20"/>
         <pinnumItem comment="CN6 Ether" id="64"/>
-        <pinnumItem comment="U5 WiFi Module" id="21"/>
         <pinnumItem comment="CN6 Ether" id="65"/>
-        <pinnumItem comment="CN4 PMOD" id="22"/>
         <pinnumItem comment="CN6 Ether" id="66"/>
-        <pinnumItem comment="U5 WiFi Module" id="23"/>
         <pinnumItem comment="CN6 Ether" id="67"/>
-        <pinnumItem comment="U5 WiFi Module" id="24"/>
-        <pinnumItem comment="U5 WiFi Module" id="25"/>
         <pinnumItem comment="LED2" id="69"/>
-        <pinnumItem comment="CN7 Serial Servo" id="26"/>
-        <pinnumItem comment="CN7 Serial Servo" id="27"/>
-        <pinnumItem comment="CN7 Serial Servo" id="28"/>
-        <pinnumItem comment="U5 WiFi Module" id="29"/>
         <pinnumItem comment="LED1" id="70"/>
         <pinnumItem comment="CN4 PMOD" id="71"/>
         <pinnumItem comment="CN4 PMOD" id="72"/>
         <pinnumItem comment="CN4 PMOD" id="73"/>
-        <pinnumItem comment="CN5 USB" id="30"/>
         <pinnumItem comment="CN4 PMOD" id="74"/>
-        <pinnumItem comment="CN8 Serial Servo" id="32"/>
-        <pinnumItem comment="CN8 Serial Servo" id="33"/>
-        <pinnumItem comment="CN8 Serial Servo" id="34"/>
         <pinnumItem comment="CN12C ADC" id="79"/>
-        <pinnumItem comment="CN5 USB" id="36"/>
-        <pinnumItem comment="CN5 USB" id="37"/>
         <pinnumItem comment="CN13 DAC" id="100"/>
         <pinnumItem comment="CN12C ADC" id="80"/>
         <pinnumItem comment="CN12C ADC" id="81"/>
         <pinnumItem comment="CN12C ADC" id="82"/>
         <pinnumItem comment="CN12C ADC" id="83"/>
         <pinnumItem comment="CN12C ADC" id="84"/>
-        <pinnumItem comment="CN4 PMOD" id="42"/>
     </tool>
     <tool id="Summary" version="1.0.0.0">
         <option id="com.renesas.smc.code.path" value="src\smc_gen"/>
         <option id="com.renesas.smc.code.type" value="Normal Folder"/>
     </tool>
     <tool id="SWComponent" version="1.0.0.0">
+        <configuration id="60957c51-a5e9-46fc-b2c8-a6141e24332c" inuse="true" name="Config_TMR0">
+            <allocatable id="TMR0">
+                <isocket id="CountingClock" selection="Clock.tool_clock_pclkb" value="3.0E7"/>
+                <option enabled="true" id="CountMode" selection="8bitMode">
+                    <item id="8bitMode" input="" vlaue="0"/>
+                    <item id="16bitMode" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="ClockSourceOption" selection="PCLK">
+                    <item id="PCLK" input="" vlaue="0"/>
+                    <item id="PCLK2" input="" vlaue="0"/>
+                    <item id="PCLK8" input="" vlaue="0"/>
+                    <item id="PCLK32" input="" vlaue="0"/>
+                    <item id="PCLK64" input="" vlaue="0"/>
+                    <item id="PCLK1024" input="" vlaue="0"/>
+                    <item id="PCLK8192" input="" vlaue="0"/>
+                    <item id="ExternalClockRising" input="" vlaue="0"/>
+                    <item id="ExternalClockFalling" input="" vlaue="0"/>
+                    <item id="ExternalClockBoth" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="CounterClearOption" selection="Disabled">
+                    <item id="Disabled" input="" vlaue="0"/>
+                    <item id="ClearedMatchA" input="" vlaue="0"/>
+                    <item id="ClearedMatchB" input="" vlaue="0"/>
+                    <item id="ClearedRisingReset" input="" vlaue="0"/>
+                    <item id="ClearedResetHigh" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="CompareMatchAValue" selection="CompareMatchAValue">
+                    <item id="CompareMatchAValue" input="2" vlaue="59"/>
+                </option>
+                <option enabled="true" id="MatchValueOptionA" selection="us">
+                    <item id="ms" input="" vlaue="0"/>
+                    <item id="us" input="" vlaue="0"/>
+                    <item id="ns" input="" vlaue="0"/>
+                    <item id="count" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="S12ADEnable" selection="Disable">
+                    <item id="Disable" input="" vlaue="0"/>
+                    <item id="Enable" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="CompareMatchBValue" selection="CompareMatchBValue">
+                    <item id="CompareMatchBValue" input="2" vlaue="59"/>
+                </option>
+                <option enabled="true" id="TMO0OutputEnable" selection="Disable">
+                    <item id="Disable" input="" vlaue="0"/>
+                    <item id="Enable" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="OutputMatchA" selection="Nochange">
+                    <item id="Nochange" input="" vlaue="0"/>
+                    <item id="Output0" input="" vlaue="0"/>
+                    <item id="Output1" input="" vlaue="0"/>
+                    <item id="ToggleOutput" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="OutputMatchB" selection="Nochange">
+                    <item id="Nochange" input="" vlaue="0"/>
+                    <item id="Output0" input="" vlaue="0"/>
+                    <item id="Output1" input="" vlaue="0"/>
+                    <item id="ToggleOutput" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="TCORAEnable" selection="Disable">
+                    <item id="Disable" input="" vlaue="0"/>
+                    <item id="Enable" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="TCORAOption" selection="Level15">
+                    <item id="Level0" input="" vlaue="0"/>
+                    <item id="Level1" input="" vlaue="0"/>
+                    <item id="Level2" input="" vlaue="0"/>
+                    <item id="Level3" input="" vlaue="0"/>
+                    <item id="Level4" input="" vlaue="0"/>
+                    <item id="Level5" input="" vlaue="0"/>
+                    <item id="Level6" input="" vlaue="0"/>
+                    <item id="Level7" input="" vlaue="0"/>
+                    <item id="Level8" input="" vlaue="0"/>
+                    <item id="Level9" input="" vlaue="0"/>
+                    <item id="Level10" input="" vlaue="0"/>
+                    <item id="Level11" input="" vlaue="0"/>
+                    <item id="Level12" input="" vlaue="0"/>
+                    <item id="Level13" input="" vlaue="0"/>
+                    <item id="Level14" input="" vlaue="0"/>
+                    <item id="Level15" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="TCORBEnable" selection="Disable">
+                    <item id="Disable" input="" vlaue="0"/>
+                    <item id="Enable" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="TCORBOption" selection="Level15">
+                    <item id="Level0" input="" vlaue="0"/>
+                    <item id="Level1" input="" vlaue="0"/>
+                    <item id="Level2" input="" vlaue="0"/>
+                    <item id="Level3" input="" vlaue="0"/>
+                    <item id="Level4" input="" vlaue="0"/>
+                    <item id="Level5" input="" vlaue="0"/>
+                    <item id="Level6" input="" vlaue="0"/>
+                    <item id="Level7" input="" vlaue="0"/>
+                    <item id="Level8" input="" vlaue="0"/>
+                    <item id="Level9" input="" vlaue="0"/>
+                    <item id="Level10" input="" vlaue="0"/>
+                    <item id="Level11" input="" vlaue="0"/>
+                    <item id="Level12" input="" vlaue="0"/>
+                    <item id="Level13" input="" vlaue="0"/>
+                    <item id="Level14" input="" vlaue="0"/>
+                    <item id="Level15" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="TCNTEnable" selection="Disable">
+                    <item id="Disable" input="" vlaue="0"/>
+                    <item id="Enable" input="" vlaue="0"/>
+                </option>
+                <option enabled="true" id="TCNTOption" selection="Level15">
+                    <item id="Level0" input="" vlaue="0"/>
+                    <item id="Level1" input="" vlaue="0"/>
+                    <item id="Level2" input="" vlaue="0"/>
+                    <item id="Level3" input="" vlaue="0"/>
+                    <item id="Level4" input="" vlaue="0"/>
+                    <item id="Level5" input="" vlaue="0"/>
+                    <item id="Level6" input="" vlaue="0"/>
+                    <item id="Level7" input="" vlaue="0"/>
+                    <item id="Level8" input="" vlaue="0"/>
+                    <item id="Level9" input="" vlaue="0"/>
+                    <item id="Level10" input="" vlaue="0"/>
+                    <item id="Level11" input="" vlaue="0"/>
+                    <item id="Level12" input="" vlaue="0"/>
+                    <item id="Level13" input="" vlaue="0"/>
+                    <item id="Level14" input="" vlaue="0"/>
+                    <item id="Level15" input="" vlaue="0"/>
+                </option>
+            </allocatable>
+            <component description="This software component generates two units (unit 0, unit 1) of an on-chip 8-bit timer (TMR) module that comprise two 8-bit counter channels, totaling four channels." detailDescription="" display="8-Bit Timer" id="com.renesas.smc.tools.swcomponent.codegenerator.tmr" version="1.9.0"/>
+            <allocator channelLevel0="0" channelLevel1="" channelLevel2="" channelLevel3="" channelLevel4="" channelLevel5="" description="8-Bit Timer 0" display="TMR0" id="com.renesas.smc.tools.swcomponent.codegenerator.tmr.rx651.tmr0" type="">
+                <context>
+                    <option enabled="true" id="CountMode" selection="8bitMode">
+                        <item enabled="true" id="8bitMode"/>
+                        <item enabled="true" id="16bitMode"/>
+                    </option>
+                </context>
+            </allocator>
+            <source description="Code generator components provide peripheral drivers with customized generated source geared towards small code size" display="Code Generator" id="com.renesas.smc.tools.swcomponent.codegenerator.source"/>
+        </configuration>
         <configuration inuse="true" name="r_bsp">
-            <component description="依存モジュール: なし&#10;The r_bsp package provides a foundation for code to be built on top of. It provides startup code, iodefines, and MCU information for different boards. There are 2 folders that make up the r_bsp package. The 'mcu' folder contains files that are common to a MCU group. These files provide functionality such as easy register access, CPU functions, and a file named 'mcu_info.h' for each MCU group. The 'mcu_info.h' file has information about the MCU on the board and is configured based on the information given in r_bsp_config.h. The information in 'mcu_info.h' is used to help configure Renesas middleware that uses the r_bsp package. The 'board' folder has a folder with startup code for each supported board.  Which MCU and board is chosen is decided by the settings in 'platform.h'. The user can choose which board they are using by uncommenting the include path that applies to their board. For example, if you are using the RSK+RX64M then you would uncomment the #include &quot;./board/generic_rx64m/r_bsp.h&quot; include path. Users are encouraged to add their own boards to the 'board' directory. BSPs are configured by using the r_bsp_config.h file. Each board will have a reference configuration file named r_bsp_config_reference.h. The user should copy this file to their project, rename it to r_bsp_config.h, and use the options inside the file to configure the BSP for their project." detailDescription="Board Support Packages." display="r_bsp" id="r_bsp6.21" version="6.21">
+            <component description="Dependencies : None&#10;The r_bsp package provides a foundation for code to be built on top of. It provides startup code, iodefines, and MCU information for different boards. There are 2 folders that make up the r_bsp package. The 'mcu' folder contains files that are common to a MCU group. These files provide functionality such as easy register access, CPU functions, and a file named 'mcu_info.h' for each MCU group. The 'mcu_info.h' file has information about the MCU on the board and is configured based on the information given in r_bsp_config.h. The information in 'mcu_info.h' is used to help configure Renesas middleware that uses the r_bsp package. The 'board' folder has a folder with startup code for each supported board.  Which MCU and board is chosen is decided by the settings in 'platform.h'. The user can choose which board they are using by uncommenting the include path that applies to their board. For example, if you are using the RSK+RX64M then you would uncomment the #include &quot;./board/generic_rx64m/r_bsp.h&quot; include path. Users are encouraged to add their own boards to the 'board' directory. BSPs are configured by using the r_bsp_config.h file. Each board will have a reference configuration file named r_bsp_config_reference.h. The user should copy this file to their project, rename it to r_bsp_config.h, and use the options inside the file to configure the BSP for their project." detailDescription="Board Support Packages." display="r_bsp" id="r_bsp6.21" version="6.21">
                 <gridItem id="BSP_CFG_USER_STACK_ENABLE" selectedIndex="1"/>
                 <gridItem id="BSP_CFG_USTACK_BYTES" selectedIndex="0x2000"/>
                 <gridItem id="BSP_CFG_ISTACK_BYTES" selectedIndex="0x400"/>
@@ -609,17 +744,16 @@
             </component>
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
-            <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
         </configuration>
         <configuration inuse="true" name="r_cmt_rx">
-            <component description="依存モジュール: r_bsp バージョン 6.20&#10;This module creates a timer tick using a CMT channel based on a frequency input by the user." detailDescription="CMT driver" display="r_cmt_rx" id="r_cmt_rx4.90" version="4.90">
+            <component description="Dependency : r_bsp version(s) 6.20&#10;This module creates a timer tick using a CMT channel based on a frequency input by the user." detailDescription="CMT driver" display="r_cmt_rx" id="r_cmt_rx4.90" version="4.90">
                 <gridItem id="CMT_RX_CFG_IPR" selectedIndex="5"/>
             </component>
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
         </configuration>
         <configuration inuse="true" name="r_ether_rx">
-            <component description="依存モジュール: r_bsp バージョン 5.52&#10;The Ethernet fit module provides a method to send and receive Ethernet / IEEE802.3 frame using Ethernet controller (ETHERC), Ethernet DMA controller (EDMAC)." detailDescription="Ethernet Driver." display="r_ether_rx" id="r_ether_rx1.21" version="1.21">
+            <component description="Dependency : r_bsp version(s) 5.52&#10;The Ethernet fit module provides a method to send and receive Ethernet / IEEE802.3 frame using Ethernet controller (ETHERC), Ethernet DMA controller (EDMAC)." detailDescription="Ethernet Driver." display="r_ether_rx" id="r_ether_rx1.21" version="1.21">
                 <gridItem id="CLKOUT25M" selectedIndex="0"/>
                 <gridItem id="ET0_TX_CLK" selectedIndex="0"/>
                 <gridItem id="ET0_RX_CLK" selectedIndex="1"/>
@@ -729,22 +863,22 @@
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
         </configuration>
         <configuration inuse="true" name="r_sys_time_rx">
-            <component description="依存モジュール: r_bsp バージョン 5.20&#10;依存モジュール: r_cmt_rx バージョン 4.00&#10;Generic system timer for RX MCUs using CMT module." detailDescription="Generic system timer for RX MCUs using CMT module." display="r_sys_time_rx" id="r_sys_time_rx1.01" version="1.01"/>
+            <component description="Dependency : r_bsp version(s) 5.20&#10;Dependency : r_cmt_rx version(s) 4.00&#10;Generic system timer for RX MCUs using CMT module." detailDescription="Generic system timer for RX MCUs using CMT module." display="r_sys_time_rx" id="r_sys_time_rx1.01" version="1.01"/>
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
         </configuration>
         <configuration inuse="true" name="r_t4_driver_rx">
-            <component description="依存モジュール: r_bsp バージョン 5.61&#10;依存モジュール: r_ether_rx バージョン 1.21&#10;依存モジュール: r_sys_time_rx バージョン 1.01&#10;依存モジュール: r_t4_rx バージョン 2.10&#10;Convert the TCP/IP(T4) - RX Ethernet Driver Interface." detailDescription="TCP/IP protocol stack [M3S-T4-Tiny] - RX Ethernet Driver Interface" display="r_t4_driver_rx" id="r_t4_driver_rx1.09" version="1.09"/>
+            <component description="Dependency : r_bsp version(s) 5.61&#10;Dependency : r_ether_rx version(s) 1.21&#10;Dependency : r_sys_time_rx version(s) 1.01&#10;Dependency : r_t4_rx version(s) 2.10&#10;Convert the TCP/IP(T4) - RX Ethernet Driver Interface." detailDescription="TCP/IP protocol stack [M3S-T4-Tiny] - RX Ethernet Driver Interface" display="r_t4_driver_rx" id="r_t4_driver_rx1.09" version="1.09"/>
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
         </configuration>
         <configuration inuse="true" name="r_t4_rx">
-            <component description="依存モジュール: r_t4_driver_rx バージョン 1.09&#10;T4 is TCP/IP protocol stack that has small footprint for Renesas MCUs." detailDescription="TCP/IP protocol stack [M3S-T4-Tiny] for Renesas MCUs" display="r_t4_rx" id="r_t4_rx2.10" version="2.10">
+            <component description="Dependency : r_t4_driver_rx version(s) 1.09&#10;T4 is TCP/IP protocol stack that has small footprint for Renesas MCUs." detailDescription="TCP/IP protocol stack [M3S-T4-Tiny] for Renesas MCUs" display="r_t4_rx" id="r_t4_rx2.10" version="2.10">
                 <gridItem id="T4_CFG_SYSTEM_CHANNEL_NUMBER" selectedIndex="0"/>
                 <gridItem id="T4_CFG_SYSTEM_DHCP" selectedIndex="0"/>
                 <gridItem id="T4_CFG_FIXED_IP_ADDRESS_CH0" selectedIndex="192,168,1,33"/>
                 <gridItem id="T4_CFG_FIXED_SABNET_MASK_CH0" selectedIndex="255,255,255,0"/>
-                <gridItem id="T4_CFG_FIXED_GATEWAY_ADDRESS_CH0" selectedIndex="0,0,0,0"/>
+                <gridItem id="T4_CFG_FIXED_GATEWAY_ADDRESS_CH0" selectedIndex="192,168,1,1"/>
                 <gridItem id="T4_CFG_FIXED_IP_ADDRESS_CH1" selectedIndex="192,168,0,10"/>
                 <gridItem id="T4_CFG_FIXED_SABNET_MASK_CH1" selectedIndex="255,255,255,0"/>
                 <gridItem id="T4_CFG_FIXED_GATEWAY_ADDRESS_CH1" selectedIndex="0,0,0,0"/>
@@ -824,144 +958,8 @@
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
         </configuration>
-        <configuration id="60957c51-a5e9-46fc-b2c8-a6141e24332c" inuse="true" name="Config_TMR0">
-            <allocatable id="TMR0">
-                <isocket id="CountingClock" selection="Clock.tool_clock_pclkb" value="6.0E7"/>
-                <option enabled="true" id="CountMode" selection="8bitMode">
-                    <item id="8bitMode" input="" vlaue="0"/>
-                    <item id="16bitMode" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="ClockSourceOption" selection="PCLK">
-                    <item id="PCLK" input="" vlaue="0"/>
-                    <item id="PCLK2" input="" vlaue="0"/>
-                    <item id="PCLK8" input="" vlaue="0"/>
-                    <item id="PCLK32" input="" vlaue="0"/>
-                    <item id="PCLK64" input="" vlaue="0"/>
-                    <item id="PCLK1024" input="" vlaue="0"/>
-                    <item id="PCLK8192" input="" vlaue="0"/>
-                    <item id="ExternalClockRising" input="" vlaue="0"/>
-                    <item id="ExternalClockFalling" input="" vlaue="0"/>
-                    <item id="ExternalClockBoth" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="CounterClearOption" selection="Disabled">
-                    <item id="Disabled" input="" vlaue="0"/>
-                    <item id="ClearedMatchA" input="" vlaue="0"/>
-                    <item id="ClearedMatchB" input="" vlaue="0"/>
-                    <item id="ClearedRisingReset" input="" vlaue="0"/>
-                    <item id="ClearedResetHigh" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="CompareMatchAValue" selection="CompareMatchAValue">
-                    <item id="CompareMatchAValue" input="2" vlaue="119"/>
-                </option>
-                <option enabled="true" id="MatchValueOptionA" selection="us">
-                    <item id="ms" input="" vlaue="0"/>
-                    <item id="us" input="" vlaue="0"/>
-                    <item id="ns" input="" vlaue="0"/>
-                    <item id="count" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="S12ADEnable" selection="Disable">
-                    <item id="Disable" input="" vlaue="0"/>
-                    <item id="Enable" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="CompareMatchBValue" selection="CompareMatchBValue">
-                    <item id="CompareMatchBValue" input="2" vlaue="119"/>
-                </option>
-                <option enabled="true" id="TMO0OutputEnable" selection="Disable">
-                    <item id="Disable" input="" vlaue="0"/>
-                    <item id="Enable" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="OutputMatchA" selection="Nochange">
-                    <item id="Nochange" input="" vlaue="0"/>
-                    <item id="Output0" input="" vlaue="0"/>
-                    <item id="Output1" input="" vlaue="0"/>
-                    <item id="ToggleOutput" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="OutputMatchB" selection="Nochange">
-                    <item id="Nochange" input="" vlaue="0"/>
-                    <item id="Output0" input="" vlaue="0"/>
-                    <item id="Output1" input="" vlaue="0"/>
-                    <item id="ToggleOutput" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="TCORAEnable" selection="Disable">
-                    <item id="Disable" input="" vlaue="0"/>
-                    <item id="Enable" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="TCORAOption" selection="Level15">
-                    <item id="Level0" input="" vlaue="0"/>
-                    <item id="Level1" input="" vlaue="0"/>
-                    <item id="Level2" input="" vlaue="0"/>
-                    <item id="Level3" input="" vlaue="0"/>
-                    <item id="Level4" input="" vlaue="0"/>
-                    <item id="Level5" input="" vlaue="0"/>
-                    <item id="Level6" input="" vlaue="0"/>
-                    <item id="Level7" input="" vlaue="0"/>
-                    <item id="Level8" input="" vlaue="0"/>
-                    <item id="Level9" input="" vlaue="0"/>
-                    <item id="Level10" input="" vlaue="0"/>
-                    <item id="Level11" input="" vlaue="0"/>
-                    <item id="Level12" input="" vlaue="0"/>
-                    <item id="Level13" input="" vlaue="0"/>
-                    <item id="Level14" input="" vlaue="0"/>
-                    <item id="Level15" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="TCORBEnable" selection="Disable">
-                    <item id="Disable" input="" vlaue="0"/>
-                    <item id="Enable" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="TCORBOption" selection="Level15">
-                    <item id="Level0" input="" vlaue="0"/>
-                    <item id="Level1" input="" vlaue="0"/>
-                    <item id="Level2" input="" vlaue="0"/>
-                    <item id="Level3" input="" vlaue="0"/>
-                    <item id="Level4" input="" vlaue="0"/>
-                    <item id="Level5" input="" vlaue="0"/>
-                    <item id="Level6" input="" vlaue="0"/>
-                    <item id="Level7" input="" vlaue="0"/>
-                    <item id="Level8" input="" vlaue="0"/>
-                    <item id="Level9" input="" vlaue="0"/>
-                    <item id="Level10" input="" vlaue="0"/>
-                    <item id="Level11" input="" vlaue="0"/>
-                    <item id="Level12" input="" vlaue="0"/>
-                    <item id="Level13" input="" vlaue="0"/>
-                    <item id="Level14" input="" vlaue="0"/>
-                    <item id="Level15" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="TCNTEnable" selection="Disable">
-                    <item id="Disable" input="" vlaue="0"/>
-                    <item id="Enable" input="" vlaue="0"/>
-                </option>
-                <option enabled="true" id="TCNTOption" selection="Level15">
-                    <item id="Level0" input="" vlaue="0"/>
-                    <item id="Level1" input="" vlaue="0"/>
-                    <item id="Level2" input="" vlaue="0"/>
-                    <item id="Level3" input="" vlaue="0"/>
-                    <item id="Level4" input="" vlaue="0"/>
-                    <item id="Level5" input="" vlaue="0"/>
-                    <item id="Level6" input="" vlaue="0"/>
-                    <item id="Level7" input="" vlaue="0"/>
-                    <item id="Level8" input="" vlaue="0"/>
-                    <item id="Level9" input="" vlaue="0"/>
-                    <item id="Level10" input="" vlaue="0"/>
-                    <item id="Level11" input="" vlaue="0"/>
-                    <item id="Level12" input="" vlaue="0"/>
-                    <item id="Level13" input="" vlaue="0"/>
-                    <item id="Level14" input="" vlaue="0"/>
-                    <item id="Level15" input="" vlaue="0"/>
-                </option>
-            </allocatable>
-            <component description="本MCU は、8 ビットのカウンタをベースにした2 チャネルの8 ビットタイマ（TMR）を2 ユニット（ユニット0、ユニット1）、合計4 チャネル内蔵しています。" detailDescription="" display="8 ビットタイマ" id="com.renesas.smc.tools.swcomponent.codegenerator.tmr" version="1.9.0"/>
-            <allocator channelLevel0="0" channelLevel1="" channelLevel2="" channelLevel3="" channelLevel4="" channelLevel5="" description="8 ビットタイマ0" display="TMR0" id="com.renesas.smc.tools.swcomponent.codegenerator.tmr.rx651.tmr0" type="">
-                <context>
-                    <option enabled="true" id="CountMode" selection="8bitMode">
-                        <item enabled="true" id="8bitMode"/>
-                        <item enabled="true" id="16bitMode"/>
-                    </option>
-                </context>
-            </allocator>
-            <source description="コード生成に対応したコンポーネントは、設定に応じた周辺ドライバのコードを小さなコードサイズで出力します。" display="コード生成" id="com.renesas.smc.tools.swcomponent.codegenerator.source"/>
-        </configuration>
         <configuration inuse="true" name="r_tsip_rx">
-            <component description="依存モジュール: r_bsp バージョン 7.00&#10;Support functions: AES, GCM, CCM, CMAC, SHA, MD5, Triple-DES, ARC4, RSA, ECC, Random number generate, Key management, secure boot/secure firmware update.&#10;The &quot;.l&quot; in version number means library version." detailDescription="TSIP(Trusted Secure IP) driver." display="r_tsip_rx" id="r_tsip_rx1.15.l" version="1.15.l"/>
+            <component description="Dependency : r_bsp version(s) 7.00&#10;Support functions: AES, GCM, CCM, CMAC, SHA, MD5, Triple-DES, ARC4, RSA, ECC, Random number generate, Key management, secure boot/secure firmware update.&#10;The &quot;.l&quot; in version number means library version." detailDescription="TSIP(Trusted Secure IP) driver." display="r_tsip_rx" id="r_tsip_rx1.15.l" version="1.15.l"/>
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
             <source description="Components supporting Firmware Integration Technology" display="Firmware Integration Technology" id="com.renesas.smc.tools.swcomponent.fit.source"/>
         </configuration>

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/.cproject
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/.cproject
@@ -14,7 +14,7 @@
 			</storageModule>
 			<storageModule moduleId="com.renesas.cdt.managedbuild.core.toolchainInfo">
 				<option id="toolchain.id" value="Renesas_RXC"/>
-				<option id="toolchain.version" value="v3.03.00"/>
+				<option id="toolchain.version" value="v3.04.00"/>
 				<option id="toolchain.enable" value="true"/>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
@@ -24,13 +24,13 @@
 							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.PE" id="com.renesas.cdt.managedbuild.renesas.ccrx.base.targetPlatform.808325012" osList="win32" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.targetPlatform"/>
 							<builder buildPath="${workspace_loc:/test}/HardwareDebug" id="com.renesas.cdt.managedbuild.renesas.ccrx.base.builder.65531188" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="CCRX Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.builder"/>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.dsp.1710373085" name="DSP Assembler" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.dsp">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo.390598726" name="デバッグ情報を出力する (-no_debug_info)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.2145260692" name="出力するデータ値のエンディアン (-littleEndianData)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.big" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo.390598726" name="Output debug information (-no_debug_info)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.2145260692" name="Endian of output data value (-littleEndianData)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.big" valueType="enumerated"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.common.385785132" name="Common" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.common">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.968417281" name="命令セット・アーキテクチャ (-isa)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.rxv2" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.968417281" name="Instruction set architecture (-isa)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.rxv2" valueType="enumerated"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.rxArchitecture.1826562770" name="RX Architecture" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.rxArchitecture" useByScannerDiscovery="false" value="rxv2" valueType="string"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.2015650112" name="浮動小数点演算命令を使用する (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.yes" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.2015650112" name="Use floating point arithmetic instructions (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.yes" valueType="enumerated"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.hasFpu.1065149525" name="Has FPU" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.hasFpu" useByScannerDiscovery="false" value="TRUE" valueType="string"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceName.1439501151" name="Device Name" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceName" useByScannerDiscovery="false" value="R5F565NEHxFP" valueType="string"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceHistory.141103170" name="Device history" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceHistory" useByScannerDiscovery="false" value="non_init;R5F565NEHxFP" valueType="string"/>
@@ -41,8 +41,8 @@
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceFamily.2015079094" name="Device Family" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceFamily" useByScannerDiscovery="false" value="RX65N" valueType="string"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.compiler.220371913" name="Compiler" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.compiler">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.1764475068" name="浮動小数点演算命令を使用する (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.yes" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include.477145288" name="インクルード・ファイルを検索するフォルダ (-include)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include" useByScannerDiscovery="false" valueType="includePath">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.1764475068" name="Use floating point arithmetic instructions (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.yes" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include.477145288" name="Include file directories (-include)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="${TCINSTALL}/include"/>
 									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/../common&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/../../../../../../&quot;"/>
@@ -62,55 +62,56 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/general}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_pincfg}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/Config_TMR0}&quot;"/>
+									<listOptionValue builtIn="false" value="${ProjDirPath}/generate"/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.define.511269805" name="プリプロセッサ・マクロの定義 (-define)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.define" useByScannerDiscovery="false" valueType="definedSymbols">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.define.511269805" name="Macro definition (-define)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.define" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="DEBUG_CONSOLE"/>
 									<listOptionValue builtIn="false" value="WOLFSSL_USER_SETTINGS"/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore.165256012" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore.165256012" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter.850666858" name="追加するオプション（すべての指定オプションの後ろに追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter.850666858" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.897672730" name="Cソース (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.c99" valueType="enumerated"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.862144636" name="プログラムの文字コード (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.utf8" valueType="enumerated"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.48690443" name="出力する文字コード (-outcode)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.utf8" valueType="enumerated"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.optimize.1557621233" name="最適化レベル (-optimize)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.optimize" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.optimize.level0" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.897672730" name="C source file (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.c99" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.862144636" name="Character code of an input program (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.utf8" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.48690443" name="Output character code (-outcode)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.utf8" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.optimize.1557621233" name="Optimization level (-optimize)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.optimize" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.optimize.level0" valueType="enumerated"/>
 								<inputType id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gcc.inputType.1722484558" name="Compiler Input C" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gcc.inputType"/>
 								<inputType id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gpp.inputType.709788007" name="Compiler Input CPP" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gpp.inputType"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.assembler.1564576801" name="Assembler" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.assembler">
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore.1555827005" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore.1555827005" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter.912893655" name="追加するオプション（すべての指定オプションの後ろに追加）&#10;" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter.912893655" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.864537553" name="プログラムの文字コード (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.utf8" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.include.1616986135" name="インクルード・ファイルを検索するフォルダ (-include)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.include" useByScannerDiscovery="false" valueType="includePath">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.864537553" name="Character code of an input program (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.utf8" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.include.1616986135" name="Include file directories (-include)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.include" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/general}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_pincfg}&quot;"/>
 								</option>
 								<inputType id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.inputType.502444415" name="Assembler InputType" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.inputType"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.linker.1333901009" name="Linker" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.linker">
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom.2020069967" name="ROMからRAMへマップするセクション (-rom)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom.2020069967" name="ROM to RAM mapped section (-rom)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value="D=R"/>
 									<listOptionValue builtIn="false" value="D_1=R_1"/>
 									<listOptionValue builtIn="false" value="D_2=R_2"/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection.2043161263" name="セクション (-start)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection" useByScannerDiscovery="false" value="SU,SI,B_1,R_1,B_2,R_2,B,R/04,B_ETHERNET_BUFFERS_1,B_RX_DESC_1,B_TX_DESC_1/020000,C_1,C_2,C,C$*,D*,W*,L,P*/0FFE00000,EXCEPTVECT/0FFFFFF80,RESETVECT/0FFFFFFFC" valueType="string"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore.1452234640" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection.2043161263" name="Sections (-start)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection" useByScannerDiscovery="false" value="SU,SI,B_1,R_1,B_2,R_2,B,R/04,B_ETHERNET_BUFFERS_1,B_RX_DESC_1,B_TX_DESC_1/03C000,C_1,C_2,C,C$*,D*,W*,L,P/0FFE00000,EXCEPTVECT/0FFFFFF80,RESETVECT/0FFFFFFFC" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore.1452234640" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter.1724535779" name="追加するオプション（すべての指定オプションの後ろに追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter.1724535779" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.vect.47410515" name="可変ベクタテーブルのアドレス未設定ベクタ番号に指定するアドレス (-vect)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.vect" useByScannerDiscovery="false" value="_undefined_interrupt_source_isr" valueType="string"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection.239094904" name="セクションの割り付けアドレスをチェックする (-cpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.1942768497" name="アドレス範囲指定方法 (-cpu(アドレス範囲指定方法))" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.autoSpecify" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList.1237940973" name="(リンク順序のリスト) (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList" useByScannerDiscovery="false" valueType="stringList">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.vect.47410515" name="Address setting for unused vector area (-vect)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.vect" useByScannerDiscovery="false" value="_undefined_interrupt_source_isr" valueType="string"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection.239094904" name="Checks the section larger than the specified range of addresses (-cpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.1942768497" name="Memory address type assignment method (-cpu(Address space of Single-Chip Mode))" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.autoSpecify" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList.1237940973" name="(Linkage order list) (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value="&quot;.\src\benchmark.obj&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;.\src\key_data.obj&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;.\src/smc_gen/Config_TMR0\Config_TMR0.obj&quot;"/>
@@ -159,31 +160,31 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_tsip_rx/lib/ccrx/r_tsip_rx65n_little.lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/../wolfssl/Debug/wolfssl.lib&quot;"/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.inputFile.1438206933" name="リンクするリロケータブル・ファイル、ライブラリ・ファイルおよびバイナリ・ファイル (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.inputFile" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.inputFile.1438206933" name="Relocatable files, object files and library files (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.inputFile" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_t4_rx/lib/ccrx/T4_Library_ether_ccrx_rxv1_little_debug.lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_tsip_rx/lib/ccrx/r_tsip_rx65n_little.lib}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/../wolfssl/Debug/wolfssl.lib&quot;"/>
 								</option>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.librarian.1723543812" name="Library Generator" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.librarian">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.1397073307" name="浮動小数点演算命令を使用する (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.yes" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore.1773409552" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.1397073307" name="Use floating point arithmetic instructions (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.yes" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore.1773409552" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter.946493093" name="追加するオプション（すべての指定オプションの後ろに追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter.946493093" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang.338617005" name="C言語標準ライブラリ関数の構成 (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang.c99" valueType="enumerated"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.headCtype.1293885198" name="ctype.h（C89/C99）：文字操作用ライブラリ (-head=ctype)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.headCtype" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang.338617005" name="Library configuration (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang.c99" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.headCtype.1293885198" name="ctype.h (C89/C99): Character classification routines (-head=ctype)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.headCtype" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.converter.1917108303" name="Converter" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.converter">
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore.109845398" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore.109845398" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter.289006348" name="追加するオプション（すべての指定オプションの後ろに追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter.289006348" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile.230415631" name="出力ファイル形式 (-form)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOFOutputFile.none" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile.230415631" name="Output file type (-form)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOFOutputFile.none" valueType="enumerated"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.rtosConfig.318974000" name="RTOS Configurator" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.rtosConfig"/>
 						</toolChain>
@@ -194,7 +195,11 @@
 				</configuration>
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
-			<storageModule moduleId="com.renesas.cdt.managedbuild.core.boardInfo"/>
+			<storageModule moduleId="com.renesas.cdt.managedbuild.core.boardInfo">
+				<option id="board.id" value="gr-rose"/>
+				<option id="board.name" value="gr-rose"/>
+				<option id="board.device" value="R5F565NEHxFP"/>
+			</storageModule>
 		</cconfiguration>
 		<cconfiguration id="com.renesas.cdt.managedbuild.renesas.ccrx.debug.configuration.992474000">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.renesas.cdt.managedbuild.renesas.ccrx.debug.configuration.992474000" moduleId="org.eclipse.cdt.core.settings" name="Debug">
@@ -218,13 +223,13 @@
 							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.PE" id="com.renesas.cdt.managedbuild.renesas.ccrx.base.targetPlatform.617132481" osList="win32" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.targetPlatform"/>
 							<builder buildPath="${workspace_loc:/test}/Debug" id="com.renesas.cdt.managedbuild.renesas.ccrx.base.builder.117543810" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="CCRX Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.builder"/>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.dsp.1744140894" name="DSP Assembler" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.dsp">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo.1464228342" name="デバッグ情報を出力する (-no_debug_info)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.733005442" name="出力するデータ値のエンディアン (-littleEndianData)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.big" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo.1464228342" name="Output debug information (-no_debug_info)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.733005442" name="Endian of output data value (-littleEndianData)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.big" valueType="enumerated"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.common.1294844059" name="Common" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.common">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.644795578" name="命令セット・アーキテクチャ (-isa)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.rxv2" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.644795578" name="Instruction set architecture (-isa)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.rxv2" valueType="enumerated"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.rxArchitecture.1771586719" name="RX Architecture" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.rxArchitecture" useByScannerDiscovery="false" value="rxv2" valueType="string"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.1045346284" name="浮動小数点演算命令を使用する (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.yes" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.1045346284" name="Use floating point arithmetic instructions (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.yes" valueType="enumerated"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.hasFpu.229476184" name="Has FPU" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.hasFpu" useByScannerDiscovery="false" value="TRUE" valueType="string"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceName.748972653" name="Device Name" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceName" useByScannerDiscovery="false" value="R5F565NEHxFP" valueType="string"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceHistory.780008434" name="Device history" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceHistory" useByScannerDiscovery="false" value="non_init;R5F565NEHxFP" valueType="string"/>
@@ -235,8 +240,8 @@
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceFamily.1280023203" name="Device Family" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceFamily" useByScannerDiscovery="false" value="RX65N" valueType="string"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.compiler.278830907" name="Compiler" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.compiler">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.2144484247" name="浮動小数点演算命令を使用する (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.yes" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include.545347560" name="インクルード・ファイルを検索するフォルダ (-include)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include" valueType="includePath">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.2144484247" name="Use floating point arithmetic instructions (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.yes" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include.545347560" name="Include file directories (-include)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include" valueType="includePath">
 									<listOptionValue builtIn="false" value="${TCINSTALL}/include"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_bsp}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_config}&quot;"/>
@@ -255,77 +260,78 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_sys_time_rx/src}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/general}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_pincfg}&quot;"/>
+									<listOptionValue builtIn="false" value="${ProjDirPath}/generate"/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.define.935611572" name="プリプロセッサ・マクロの定義 (-define)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.define" valueType="definedSymbols">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.define.935611572" name="Macro definition (-define)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.define" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="DEBUG_CONSOLE"/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore.878126292" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore.878126292" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter.443993930" name="追加するオプション（すべての指定オプションの後ろに追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter.443993930" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.47850385" name="Cソース (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.c99" valueType="enumerated"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.24533273" name="プログラムの文字コード (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.utf8" valueType="enumerated"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.542364588" name="出力する文字コード (-outcode)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.utf8" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.47850385" name="C source file (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.c99" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.24533273" name="Character code of an input program (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.utf8" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.542364588" name="Output character code (-outcode)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.utf8" valueType="enumerated"/>
 								<inputType id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gcc.inputType.1919404628" name="Compiler Input C" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gcc.inputType"/>
 								<inputType id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gpp.inputType.293530100" name="Compiler Input CPP" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gpp.inputType"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.assembler.607581328" name="Assembler" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.assembler">
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore.622904140" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore.622904140" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter.67379527" name="追加するオプション（すべての指定オプションの後ろに追加）&#10;" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter.67379527" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.1186358257" name="プログラムの文字コード (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.utf8" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.include.1360045103" name="インクルード・ファイルを検索するフォルダ (-include)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.include" valueType="includePath">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.1186358257" name="Character code of an input program (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.utf8" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.include.1360045103" name="Include file directories (-include)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.include" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/general}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_pincfg}&quot;"/>
 								</option>
 								<inputType id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.inputType.1482916460" name="Assembler InputType" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.inputType"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.linker.1516159151" name="Linker" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.linker">
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom.1765662172" name="ROMからRAMへマップするセクション (-rom)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom.1765662172" name="ROM to RAM mapped section (-rom)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value="D=R"/>
 									<listOptionValue builtIn="false" value="D_1=R_1"/>
 									<listOptionValue builtIn="false" value="D_2=R_2"/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection.1046231838" name="セクション (-start)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection" useByScannerDiscovery="false" value="SU,SI,B_1,R_1,B_2,R_2,B,R/04,C_1,C_2,C,C$*,D*,W*,L,P*/0FFE00000,EXCEPTVECT/0FFFFFF80,RESETVECT/0FFFFFFFC,B_ETHERNET_BUFFERS_1,B_RX_DESC_1,B_TX_DESC_1/00010000" valueType="string"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore.1651005552" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection.1046231838" name="Sections (-start)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection" useByScannerDiscovery="false" value="SU,SI,B_1,R_1,B_2,R_2,B,R/04,C_1,C_2,C,C$*,D*,W*,L,P*/0FFE00000,EXCEPTVECT/0FFFFFF80,RESETVECT/0FFFFFFFC,B_ETHERNET_BUFFERS_1,B_RX_DESC_1,B_TX_DESC_1/00010000" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore.1651005552" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter.40118921" name="追加するオプション（すべての指定オプションの後ろに追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter.40118921" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.vect.1524833684" name="可変ベクタテーブルのアドレス未設定ベクタ番号に指定するアドレス (-vect)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.vect" useByScannerDiscovery="false" value="_undefined_interrupt_source_isr" valueType="string"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection.1914971075" name="セクションの割り付けアドレスをチェックする (-cpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.1670384649" name="アドレス範囲指定方法 (-cpu(アドレス範囲指定方法))" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.autoSpecify" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList.1556433699" name="(リンク順序のリスト) (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList" valueType="stringList">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.vect.1524833684" name="Address setting for unused vector area (-vect)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.vect" useByScannerDiscovery="false" value="_undefined_interrupt_source_isr" valueType="string"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection.1914971075" name="Checks the section larger than the specified range of addresses (-cpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.1670384649" name="Memory address type assignment method (-cpu(Address space of Single-Chip Mode))" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.autoSpecify" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList.1556433699" name="(Linkage order list) (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList" valueType="stringList">
 									<listOptionValue builtIn="false" value="&quot;.\test.lib&quot;"/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.inputFile.856176867" name="リンクするリロケータブル・ファイル、ライブラリ・ファイルおよびバイナリ・ファイル (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.inputFile" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.inputFile.856176867" name="Relocatable files, object files and library files (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.inputFile" valueType="stringList">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/smc_gen/r_t4_rx/lib/T4_Library_rxv1_ether_little.lib}&quot;"/>
 								</option>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.librarian.1598250045" name="Library Generator" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.librarian">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.665362864" name="浮動小数点演算命令を使用する (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.yes" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore.413642487" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.665362864" name="Use floating point arithmetic instructions (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.yes" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore.413642487" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter.322853429" name="追加するオプション（すべての指定オプションの後ろに追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter.322853429" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang.1591825359" name="C言語標準ライブラリ関数の構成 (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang.c99" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang.1591825359" name="Library configuration (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.lang.c99" valueType="enumerated"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.converter.175269062" name="Converter" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.converter">
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore.1586351233" name="追加するオプション（すべての指定オプションの前に追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore.1586351233" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter.900284814" name="追加するオプション（すべての指定オプションの後ろに追加）" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter.900284814" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value=""/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile.2141918916" name="出力ファイル形式 (-form)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile" value="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOFOutputFile.none" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile.2141918916" name="Output file type (-form)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile" value="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOFOutputFile.none" valueType="enumerated"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.rtosConfig.1118615463" name="RTOS Configurator" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.rtosConfig"/>
 						</toolChain>
@@ -336,6 +342,11 @@
 				</configuration>
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="com.renesas.cdt.managedbuild.core.boardInfo">
+				<option id="board.id" value="gr-rose"/>
+				<option id="board.name" value="gr-rose"/>
+				<option id="board.device" value="R5F565NEHxFP"/>
+			</storageModule>
 		</cconfiguration>
 	</storageModule>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/.project
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/.project
@@ -32,12 +32,12 @@
 		<link>
 			<name>src/benchmark.c</name>
 			<type>1</type>
-			<locationURI>$%7BPARENT-6-PROJECT_LOC%7D/wolfcrypt/benchmark/benchmark.c</locationURI>
+			<locationURI>PARENT-6-PROJECT_LOC/wolfcrypt/benchmark/benchmark.c</locationURI>
 		</link>
 		<link>
 			<name>src/benchmark.h</name>
 			<type>1</type>
-			<locationURI>$%7BPARENT-6-PROJECT_LOC%7D/wolfcrypt/benchmark/benchmark.h</locationURI>
+			<locationURI>PARENT-6-PROJECT_LOC/wolfcrypt/benchmark/benchmark.h</locationURI>
 		</link>
 		<link>
 			<name>src/test.c</name>

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/test_main.c
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/test_main.c
@@ -52,6 +52,17 @@ extern "C" {
     user_PKCbInfo            guser_PKCbInfo;
 #endif
 
+#if defined(TLS_CLIENT)
+#if defined(WOLFSSL_RENESAS_TSIP_TLS) && defined(WOLFSSL_STATIC_MEMORY)
+    #include <wolfssl/wolfcrypt/memory.h>
+    WOLFSSL_HEAP_HINT*  heapHint = NULL;
+
+    #define  BUFFSIZE_GEN  (110 * 1024)
+    unsigned char heapBufGen[BUFFSIZE_GEN];
+
+#endif /* WOLFSSL_RENESAS_TSIP_TLS && WOLFSSL_STATIC_MEMORY */
+#endif /* TLS_CLIENT */
+
 static long tick;
 static void timeTick(void *pdata)
 {
@@ -242,6 +253,15 @@ void main(void)
 #endif
 #elif defined(TLS_CLIENT)
     #include "r_cmt_rx_if.h"
+
+
+#if defined(WOLFSSL_STATIC_MEMORY)
+    if (wc_LoadStaticMemory(&heapHint, heapBufGen, sizeof(heapBufGen),
+                                            WOLFMEM_GENERAL, 1) !=0) {
+        printf("unable to load static memory.\n");
+        return;
+    }
+#endif /* WOLFSSL_STATIC_MEMORY */
 
     Open_tcp();
 

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/wolf_client.c
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/wolf_client.c
@@ -29,7 +29,7 @@
 #include "wolfssl_demo.h"
 
 
-#define SIMPLE_TLSSEVER_IP       "192.168.11.32"
+#define SIMPLE_TLSSEVER_IP       "192.168.1.12"
 #define SIMPLE_TLSSERVER_PORT    "11111"
 
 ER    t4_tcp_callback(ID cepid, FN fncd , VP p_parblk);
@@ -40,6 +40,17 @@ static WOLFSSL_CTX *client_ctx;
 uint32_t g_encrypted_root_public_key[140];
 static   TsipUserCtx userContext;
 #endif
+
+#if defined(TLS_CLIENT)
+#if defined(WOLFSSL_RENESAS_TSIP_TLS) && defined(WOLFSSL_STATIC_MEMORY)
+
+    extern WOLFSSL_HEAP_HINT*  heapHint;
+
+    #define BUFFSIZE_IO  (16 * 1024)
+    unsigned char heapBufIO[BUFFSIZE_IO];
+
+#endif /* WOLFSSL_RENESAS_TSIP_TLS && WOLFSSL_STATIC_MEMORY */
+#endif /* TLS_CLIENT */
 
 static int my_IORecv(WOLFSSL* ssl, char* buff, int sz, void* ctx)
 {
@@ -115,11 +126,29 @@ void wolfSSL_TLS_client_init(const char* cipherlist)
         wolfSSL_Debugging_ON();
     #endif
 
+#if defined(WOLFSSL_STATIC_MEMORY)
+
+    if ((client_ctx = wolfSSL_CTX_new_ex(wolfTLSv1_2_client_method_ex(heapHint),
+                                                      heapHint)) == NULL) {
+        printf("ERROR: faild to create WOLFSSL_CTX\n");
+        return;                                                
+    }
+
+    if ((wolfSSL_CTX_load_static_memory(&client_ctx, NULL, heapBufIO,
+                sizeof(heapBufIO), WOLFMEM_IO_POOL, 10)) != WOLFSSL_SUCCESS) {
+        printf("ERROR: faild to set static memory for IO\n");
+        return;
+    }
+
+#else
+
     /* Create and initialize WOLFSSL_CTX */
-    if ((client_ctx = wolfSSL_CTX_new(wolfTLSv1_2_client_method_ex((void *)NULL))) == NULL) {
+    if ((client_ctx = 
+        wolfSSL_CTX_new(wolfTLSv1_2_client_method_ex((void *)NULL))) == NULL) {
         printf("ERROR: failed to create WOLFSSL_CTX\n");
         return;
     }
+#endif /* WOLFSSL_STATIC_MEMORY */
 
     #ifdef WOLFSSL_RENESAS_TSIP_TLS
     tsip_set_callbacks(client_ctx);
@@ -128,10 +157,11 @@ void wolfSSL_TLS_client_init(const char* cipherlist)
     #if !defined(NO_FILESYSTEM)
     if (wolfSSL_CTX_load_verify_locations(client_ctx, cert, 0) != SSL_SUCCESS) {
         printf("ERROR: can't load \"%s\"\n", cert);
-        return NULL;
+        return;
     }
     #else
-    if (wolfSSL_CTX_load_verify_buffer(client_ctx, cert, SIZEOF_CERT, SSL_FILETYPE_ASN1) != SSL_SUCCESS){
+    if (wolfSSL_CTX_load_verify_buffer(client_ctx, cert, SIZEOF_CERT, 
+                                            SSL_FILETYPE_ASN1) != SSL_SUCCESS){
            printf("ERROR: can't load certificate data\n");
        return;
     }

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/test.rcpc
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/test.rcpc
@@ -7,6 +7,19 @@
   </Placeholders>
   <Project Name="test" Type="Application">
     <Files>
+      <Category Name="generate">
+        <Path>generate\dbsct.c</Path>
+        <Path>generate\hwsetup.c</Path>
+        <Path>generate\intprg.c</Path>
+        <Path>generate\iodefine.h</Path>
+        <Path>generate\resetprg.c</Path>
+        <Path>generate\sbrk.c</Path>
+        <Path>generate\sbrk.h</Path>
+        <Path>generate\stacksct.h</Path>
+        <Path>generate\typedefine.h</Path>
+        <Path>generate\vect.h</Path>
+        <Path>generate\vecttbl.c</Path>
+      </Category>
       <Category Name="src">
         <Path>..\..\..\..\..\..\wolfcrypt\benchmark\benchmark.c</Path>
         <Path>..\..\..\..\..\..\wolfcrypt\benchmark\benchmark.h</Path>
@@ -243,21 +256,18 @@
             <Path>src\smc_gen\r_tsip_rx\readme.txt</Path>
             <Category Name="doc">
               <Category Name="en">
-                <Path>src\smc_gen\r_tsip_rx\doc\en\r20an0548ej0114-rx-tsip-security.pdf</Path>
+                <Path>src\smc_gen\r_tsip_rx\doc\en\r20an0548ej0115-rx-tsip-security.pdf</Path>
               </Category>
               <Category Name="ja">
-                <Path>src\smc_gen\r_tsip_rx\doc\ja\r20an0548jj0114-rx-tsip-security.pdf</Path>
+                <Path>src\smc_gen\r_tsip_rx\doc\ja\r20an0548jj0115-rx-tsip-security.pdf</Path>
               </Category>
-            </Category>
-            <Category Name="ref">
-              <Path>src\smc_gen\r_tsip_rx\ref\r_tsip_rx_config_reference.h</Path>
             </Category>
           </Category>
         </Category>
       </Category>
     </Files>
     <Device Category="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.cpu.rx600" Series="RX">R5F565NEHxFP</Device>
-    <BuildOptions Name="CC-RX" Version="v3.03.00">
+    <BuildOptions Name="CC-RX" Version="v3.04.00">
       <BuildMode Active="True" Name="HardwareDebug">
         <GeneralOptions/>
         <CompileOptions>
@@ -281,6 +291,7 @@
           <Option>-include="${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\general"</Option>
           <Option>-include="${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\r_pincfg"</Option>
           <Option>-include="${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\Config_TMR0"</Option>
+          <Option>-include="${ProjDirPath}\generate"</Option>
           <Option>-define=DEBUG_CONSOLE,WOLFSSL_USER_SETTINGS</Option>
           <Option>-utf8</Option>
           <Option>-nomessage</Option>
@@ -316,7 +327,7 @@
           <Option>-library="${ProjDirPath}/../../../../../../../${ProjName}/src/smc_gen/r_t4_rx/lib/ccrx/T4_Library_ether_ccrx_rxv1_little_debug.lib"</Option>
           <Option>-library="${ProjDirPath}/../../../../../../../${ProjName}/src/smc_gen/r_tsip_rx/lib/ccrx/r_tsip_rx65n_little.lib"</Option>
           <Option>-library="${ProjDirPath}/../wolfssl/Debug/wolfssl.lib"</Option>
-          <Option>-start=SU,SI,B_1,R_1,B_2,R_2,B,R/04,B_ETHERNET_BUFFERS_1,B_RX_DESC_1,B_TX_DESC_1/020000,C_1,C_2,C,C$*,D*,W*,L,P*/0FFE00000,EXCEPTVECT/0FFFFFF80,RESETVECT/0FFFFFFFC</Option>
+          <Option>-start=SU,SI,B_1,R_1,B_2,R_2,B,R/04,B_ETHERNET_BUFFERS_1,B_RX_DESC_1,B_TX_DESC_1/03C000,C_1,C_2,C,C$*,D*,W*,L,P/0FFE00000,EXCEPTVECT/0FFFFFF80,RESETVECT/0FFFFFFFC</Option>
           <PreLinker>Auto</PreLinker>
         </LinkOptions>
         <LibraryGenerateOptions>
@@ -374,6 +385,12 @@
           <Path>HardwareDebug\wolfssl_dummy.obj</Path>
           <Path>HardwareDebug\test.lib</Path>
         </LinkOrder>
+        <NoTargetFile Target="generate\dbsct.c"/>
+        <NoTargetFile Target="generate\hwsetup.c"/>
+        <NoTargetFile Target="generate\intprg.c"/>
+        <NoTargetFile Target="generate\resetprg.c"/>
+        <NoTargetFile Target="generate\sbrk.c"/>
+        <NoTargetFile Target="generate\vecttbl.c"/>
         <CommonOptions>
           <IncludePathForC>"${ProjDirPath}\..\common"</IncludePathForC>
           <IncludePathForC>"${ProjDirPath}\..\..\..\..\..\..\"</IncludePathForC>
@@ -393,6 +410,7 @@
           <IncludePathForC>"${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\general"</IncludePathForC>
           <IncludePathForC>"${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\r_pincfg"</IncludePathForC>
           <IncludePathForC>"${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\Config_TMR0"</IncludePathForC>
+          <IncludePathForC>"${ProjDirPath}\generate"</IncludePathForC>
           <IncludePathForAsm>"${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\general"</IncludePathForAsm>
           <IncludePathForAsm>"${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\r_pincfg"</IncludePathForAsm>
           <MacroForC>DEBUG_CONSOLE</MacroForC>
@@ -421,6 +439,7 @@
           <Option>-include="${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\r_sys_time_rx\src"</Option>
           <Option>-include="${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\general"</Option>
           <Option>-include="${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\r_pincfg"</Option>
+          <Option>-include="${ProjDirPath}\generate"</Option>
           <Option>-define=DEBUG_CONSOLE</Option>
           <Option>-utf8</Option>
           <Option>-nomessage</Option>
@@ -511,6 +530,12 @@
           <Path>Debug\wolfssl_dummy.obj</Path>
           <Path>Debug\test.lib</Path>
         </LinkOrder>
+        <NoTargetFile Target="generate\dbsct.c"/>
+        <NoTargetFile Target="generate\hwsetup.c"/>
+        <NoTargetFile Target="generate\intprg.c"/>
+        <NoTargetFile Target="generate\resetprg.c"/>
+        <NoTargetFile Target="generate\sbrk.c"/>
+        <NoTargetFile Target="generate\vecttbl.c"/>
         <CommonOptions>
           <IncludePathForC>"${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\r_bsp"</IncludePathForC>
           <IncludePathForC>"${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\r_config"</IncludePathForC>
@@ -529,6 +554,7 @@
           <IncludePathForC>"${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\r_sys_time_rx\src"</IncludePathForC>
           <IncludePathForC>"${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\general"</IncludePathForC>
           <IncludePathForC>"${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\r_pincfg"</IncludePathForC>
+          <IncludePathForC>"${ProjDirPath}\generate"</IncludePathForC>
           <IncludePathForAsm>"${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\general"</IncludePathForAsm>
           <IncludePathForAsm>"${ProjDirPath}\..\..\..\..\..\..\..\${ProjName}\src\smc_gen\r_pincfg"</IncludePathForAsm>
           <MacroForC>DEBUG_CONSOLE</MacroForC>

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/test_HardwareDebug.launch
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/test_HardwareDebug.launch
@@ -20,12 +20,12 @@
     <stringAttribute key="com.renesas.cdt.core.secondGDBExe" value="green_dsp-elf-gdb"/>
     <booleanAttribute key="com.renesas.cdt.core.secondGDBSupport" value="false"/>
     <intAttribute key="com.renesas.cdt.core.secondGdbPortNumber" value="61237"/>
-    <stringAttribute key="com.renesas.cdt.core.serverParam" value="-g E1  -t R5F565NE  -uClockSrcHoco= 0 -uInputClock= 12.0000 -uAllowClockSourceInternal= 1 -uUseFine= 1 -uFineBaudRate= 2.00 -w 1 -z 0 -uRegisterSetting= 0 -uModePin= 0 -uChangeStartupBank= 0 -uStartupBank= 0 -uDebugMode= 0 -uExecuteProgram= 0 -uIdCode= FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -uresetOnReload= 1 -n 0 -uWorkRamAddress= 1000 -uProgReWriteIRom= 0 -uProgReWriteDFlash= 0 -uhookWorkRamAddr= 0x3fdd0 -uhookWorkRamSize= 0x230"/>
+    <stringAttribute key="com.renesas.cdt.core.serverParam" value="-g E1  -t R5F565NE  -uClockSrcHoco= 1 -uAllowClockSourceInternal= 1 -uUseFine= 1 -uFineBaudRate= 2.00 -w 1 -z 0 -uRegisterSetting= 0 -uModePin= 0 -uChangeStartupBank= 0 -uStartupBank= 0 -uDebugMode= 0 -uExecuteProgram= 0 -uIdCode= FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -uresetOnReload= 1 -n 0 -uWorkRamAddress= 1000 -uverifyOnWritingMemory= 0 -uProgReWriteIRom= 0 -uProgReWriteDFlash= 0 -uhookWorkRamAddr= 0x3fdd0 -uhookWorkRamSize= 0x230"/>
     <booleanAttribute key="com.renesas.cdt.core.startServer" value="true"/>
     <stringAttribute key="com.renesas.cdt.core.targetDevice" value="R5F565NE"/>
     <booleanAttribute key="com.renesas.cdt.core.useRemoteTarget" value="true"/>
     <booleanAttribute key="com.renesas.cdt.core.verboseMode" value="false"/>
-    <stringAttribute key="com.renesas.cdt.debug.ioview.dsf.registerSelection0" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;selectedRegisterList ioFilePath=&quot;C:\Users\Taka\.eclipse\com.renesas.platform_1380223289\DebugComp\RX\IoFiles\RX65N.sfrx&quot;/&gt;&#13;&#10;"/>
+    <stringAttribute key="com.renesas.cdt.debug.ioview.dsf.registerSelection0" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;selectedRegisterList ioFilePath=&quot;C:\Users\Taka\.eclipse\com.renesas.platform_923020927\DebugComp\RX\IoFiles\RX65N.sfrx&quot;/&gt;&#13;&#10;"/>
     <stringAttribute key="com.renesas.cdt.launch.dsf.IO_MAP" value="${support_area_loc}"/>
     <booleanAttribute key="com.renesas.cdt.launch.dsf.USE_DEFAULT_IO_MAP" value="true"/>
     <listAttribute key="com.renesas.cdt.launch.dsf.downloadImages">
@@ -36,7 +36,7 @@
     <stringAttribute key="com.renesas.cdt.launch.dsf.serverPath" value="${renesas.support.targetLoc:rx-debug}\e2-server-gdb"/>
     <booleanAttribute key="com.renesas.hardwaredebug.e1.allow.change.startup_bank" value="false"/>
     <booleanAttribute key="com.renesas.hardwaredebug.e1.allow.clock.source.internal" value="true"/>
-    <intAttribute key="com.renesas.hardwaredebug.e1.clock_source" value="0"/>
+    <intAttribute key="com.renesas.hardwaredebug.e1.clock_source" value="1"/>
     <stringAttribute key="com.renesas.hardwaredebug.e1.connection.mode" value="0"/>
     <booleanAttribute key="com.renesas.hardwaredebug.e1.e1_pwr" value="true"/>
     <booleanAttribute key="com.renesas.hardwaredebug.e1.enable.hot.plug" value="false"/>
@@ -51,7 +51,7 @@
     <intAttribute key="com.renesas.hardwaredebug.e1.hook_work_ram_Addr" value="261584"/>
     <intAttribute key="com.renesas.hardwaredebug.e1.hook_work_ram_Size" value="560"/>
     <stringAttribute key="com.renesas.hardwaredebug.e1.id_code" value="FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"/>
-    <stringAttribute key="com.renesas.hardwaredebug.e1.inputclock" value="12.0000"/>
+    <stringAttribute key="com.renesas.hardwaredebug.e1.inputclock" value="27.0"/>
     <stringAttribute key="com.renesas.hardwaredebug.e1.jtag.clock.freq" value="16.5"/>
     <stringAttribute key="com.renesas.hardwaredebug.e1.jtag.or.fine" value="1"/>
     <booleanAttribute key="com.renesas.hardwaredebug.e1.le" value="true"/>
@@ -131,6 +131,6 @@
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
     </listAttribute>
-    <stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&lt;memoryBlockExpressionList context=&quot;reserved-for-future-use&quot;/&gt;"/>
+    <stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&lt;memoryBlockExpressionList context=&quot;reserved-for-future-use&quot;&gt;&lt;gdbmemoryBlockExpression address=&quot;6520&quot; core_thread_id=&quot;1_i1&quot; label=&quot;0x1978&quot;&gt;&lt;memoryRendering id=&quot;org.eclipse.debug.ui.rendering.raw_memory&quot;&gt;&lt;renderingInstance containerId=&quot;org.eclipse.debug.ui.MemoryView.RenderingViewPane.1&quot; viewId=&quot;org.eclipse.debug.ui.MemoryView&quot; viewSecondaryId=&quot;&quot;/&gt;&lt;/memoryRendering&gt;&lt;/gdbmemoryBlockExpression&gt;&lt;gdbmemoryBlockExpression address=&quot;6668&quot; core_thread_id=&quot;1_i1&quot; label=&quot;0x1a0c&quot;&gt;&lt;memoryRendering id=&quot;org.eclipse.debug.ui.rendering.raw_memory&quot;&gt;&lt;renderingInstance containerId=&quot;org.eclipse.debug.ui.MemoryView.RenderingViewPane.1&quot; viewId=&quot;org.eclipse.debug.ui.MemoryView&quot; viewSecondaryId=&quot;&quot;/&gt;&lt;/memoryRendering&gt;&lt;/gdbmemoryBlockExpression&gt;&lt;gdbmemoryBlockExpression address=&quot;6504&quot; core_thread_id=&quot;1_i1&quot; label=&quot;0x1968&quot;&gt;&lt;memoryRendering id=&quot;org.eclipse.debug.ui.rendering.raw_memory&quot;&gt;&lt;renderingInstance containerId=&quot;org.eclipse.debug.ui.MemoryView.RenderingViewPane.1&quot; viewId=&quot;org.eclipse.debug.ui.MemoryView&quot; viewSecondaryId=&quot;&quot;/&gt;&lt;/memoryRendering&gt;&lt;/gdbmemoryBlockExpression&gt;&lt;/memoryBlockExpressionList&gt;"/>
     <stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
 </launchConfiguration>

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/wolfssl/.cproject
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/wolfssl/.cproject
@@ -14,7 +14,7 @@
 			</storageModule>
 			<storageModule moduleId="com.renesas.cdt.managedbuild.core.toolchainInfo">
 				<option id="toolchain.id" value="Renesas_RXC"/>
-				<option id="toolchain.version" value="v3.03.00"/>
+				<option id="toolchain.version" value="v3.04.00"/>
 				<option id="toolchain.enable" value="true"/>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
@@ -24,21 +24,25 @@
 							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.PE" id="com.renesas.cdt.managedbuild.renesas.ccrx.base.targetPlatform.174341512" osList="win32" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.targetPlatform"/>
 							<builder buildPath="${workspace_loc:/wolfssl}/Debug" id="com.renesas.cdt.managedbuild.renesas.ccrx.base.builder.1547537924" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="CCRX Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.builder"/>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.dsp.1555184586" name="DSP Assembler" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.dsp">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo.317830941" name="デバッグ情報を出力する (-no_debug_info)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo.317830941" name="Output debug information (-no_debug_info)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.noDebugInfo" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.1916710340" name="Endian of output data value (-littleEndianData)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian" value="com.renesas.cdt.managedbuild.renesas.ccrx.dsp.option.endian.big" valueType="enumerated"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.common.566285610" name="Common" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.common">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.789156168" name="命令セット・アーキテクチャ (-isa)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.rxv2" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.789156168" name="Instruction set architecture (-isa)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.rxv2" valueType="enumerated"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.hasFpu.1416683217" name="Has FPU" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.hasFpu" useByScannerDiscovery="false" value="TRUE" valueType="string"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceName.738625467" name="Device Name" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceName" useByScannerDiscovery="false" value="R5F571MLCxFC" valueType="string"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceCommand.806008705" name="Device Command" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceCommand" useByScannerDiscovery="false" value="R5F571ML" valueType="string"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceName.738625467" name="Device Name" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceName" useByScannerDiscovery="false" value="R5F565NEHxFP" valueType="string"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceCommand.806008705" name="Device Command" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceCommand" useByScannerDiscovery="false" value="R5F565NE" valueType="string"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.checkRtos.313687436" name="Check RTOS" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.checkRtos" useByScannerDiscovery="false" value="unusedRtos" valueType="string"/>
 								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.hasDsp.963524125" name="Has DSP" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.hasDsp" useByScannerDiscovery="false" value="false" valueType="string"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceFamily.664031971" name="Device Family" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceFamily" useByScannerDiscovery="false" value="RX71M" valueType="string"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceHistory.1128940076" name="Device history" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceHistory" useByScannerDiscovery="false" value="non_init;R5F571MLCxFC" valueType="string"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceFamily.664031971" name="Device Family" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceFamily" useByScannerDiscovery="false" value="RX65N" valueType="string"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceHistory.1128940076" name="Device history" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.deviceHistory" useByScannerDiscovery="false" value="R5F571MLCxFC;R5F565NEHxFP" valueType="string"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.rxArchitecture.2140854078" name="RX Architecture" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.rxArchitecture" useByScannerDiscovery="false" value="rxv2" valueType="string"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.2129136722" name="Use floating point arithmetic instructions (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.floatIns.yes" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isaHistory.855338420" name="ISA history" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isaHistory" useByScannerDiscovery="false" value="non_init;com.renesas.cdt.managedbuild.renesas.ccrx.common.option.isa.rxv2" valueType="string"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.compiler.958103973" name="Compiler" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.compiler">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.1276851320" name="浮動小数点演算命令を使用する (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.yes" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include.1381248206" name="インクルード・ファイルを検索するフォルダ (-include)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include" useByScannerDiscovery="false" valueType="includePath">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.1276851320" name="Use floating point arithmetic instructions (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.fpu.yes" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include.1381248206" name="Include file directories (-include)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.include" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../common"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}//../../../../../../"/>
 									<listOptionValue builtIn="false" value="${TCINSTALL}/include"/>
@@ -47,37 +51,72 @@
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../test/src/smc_gen/r_config"/>
 									<listOptionValue builtIn="false" value="${ProjDirPath}/../test/src/smc_gen/r_tsip_rx"/>
 								</option>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.define.687020263" name="プリプロセッサ・マクロの定義 (-define)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.define" useByScannerDiscovery="false" valueType="definedSymbols">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.define.687020263" name="Macro definition (-define)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.define" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="WOLFSSL_USER_SETTINGS"/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.1494793389" name="Cソース (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.c99" valueType="enumerated"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.optimize.573554071" name="最適化レベル (-optimize)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.optimize" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.optimize.level0" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.1494793389" name="C source file (-lang)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.langFileC.c99" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.optimize.573554071" name="Optimization level (-optimize)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.optimize" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.optimize.level0" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore.478242509" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value=""/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter.1529180842" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value=""/>
+								</option>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.1017624275" name="Character code of an input program (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.inputCharCode.utf8" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.1363723732" name="Output character code (-outcode)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.option.outcode.utf8" valueType="enumerated"/>
 								<inputType id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gcc.inputType.971510512" name="Compiler Input C" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gcc.inputType"/>
 								<inputType id="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gpp.inputType.948214383" name="Compiler Input CPP" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.compiler.gpp.inputType"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.assembler.1769723979" name="Assembler" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore.163658846" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value=""/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter.745123542" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value=""/>
+								</option>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.96349094" name="Character code of an input program (-euc/-sjis/-latin1/-utf8/-big5/-gb2312)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.option.characterCode.utf8" valueType="enumerated"/>
 								<inputType id="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.inputType.328050806" name="Assembler InputType" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.assembler.inputType"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.linker.945835579" name="Linker" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.linker">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.typeOfOutputFileOption.139100472" name="出力ファイル形式 (-form)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.typeOfOutputFileOption" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.typeOfOutputFileOption.userLibrary" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom.177476365" name="ROMからRAMへマップするセクション (-rom)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom" useByScannerDiscovery="false" valueType="stringList">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.typeOfOutputFileOption.139100472" name="Output file type (-form)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.typeOfOutputFileOption" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.typeOfOutputFileOption.userLibrary" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom.177476365" name="ROM to RAM mapped section (-rom)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.rom" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value="D=R"/>
 									<listOptionValue builtIn="false" value="D_1=R_1"/>
 									<listOptionValue builtIn="false" value="D_2=R_2"/>
 								</option>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection.1739258398" name="セクション (-start)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection" useByScannerDiscovery="false" value="SU,SI,B_1,R_1,B_2,R_2,B,R/04,PResetPRG,C_1,C_2,C,C$*,D*,W*,L,PIntPRG,P/0FFC00000,EXCEPTVECT/0FFFFFF80,RESETVECT/0FFFFFFFC" valueType="string"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList.1344120748" name="(リンク順序のリスト) (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList" useByScannerDiscovery="false" valueType="stringList">
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection.1739258398" name="Sections (-start)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.linkerSection" useByScannerDiscovery="false" value="SU,SI,B_1,R_1,B_2,R_2,B,R/04,PResetPRG,C_1,C_2,C,C$*,D*,W*,L,PIntPRG,P/0FFE00000,EXCEPTVECT/0FFFFFF80,RESETVECT/0FFFFFFFC" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList.1344120748" name="(Linkage order list) (-input/-library/-binary)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.noneLinkageOrderList" useByScannerDiscovery="false" valueType="stringList">
 									<listOptionValue builtIn="false" value="&quot;.\src\sample3.obj&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;.\src\sample1.obj&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;.\src\sample2.obj&quot;"/>
 								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore.685139217" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value=""/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter.1997070460" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value=""/>
+								</option>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection.1124913743" name="Checks the section larger than the specified range of addresses (-cpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.checkSection" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.994805952" name="Memory address type assignment method (-cpu(Address space of Single-Chip Mode))" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.linker.option.memoryType.autoSpecify" valueType="enumerated"/>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.librarian.1901868731" name="Library Generator" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.librarian">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.1987941672" name="浮動小数点演算命令を使用する (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.yes" valueType="enumerated"/>
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.mode.820377223" name="標準ライブラリを生成する条件" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.mode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.mode.donotAddLibrary" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.1987941672" name="Use floating point arithmetic instructions (-fpu/-nofpu)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.fpu.yes" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.mode.820377223" name="Generation mode of the standard library" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.mode" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.mode.donotAddLibrary" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore.747426230" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value=""/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter.2138023665" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.librarian.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value=""/>
+								</option>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.converter.620355579" name="Converter" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.converter">
-								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile.1427223323" name="出力ファイル形式 (-form)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOFOutputFile.none" valueType="enumerated"/>
+								<option id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile.1427223323" name="Output file type (-form)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOfOutputFile" useByScannerDiscovery="false" value="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.typeOFOutputFile.none" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore.443186903" name="User-defined options (added before all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userBefore" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value=""/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter.1163725064" name="User-defined options (added after all specified options)" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.converter.option.userAfter" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value=""/>
+								</option>
 							</tool>
 							<tool id="com.renesas.cdt.managedbuild.renesas.ccrx.base.rtosConfig.1798199560" name="RTOS Configurator" superClass="com.renesas.cdt.managedbuild.renesas.ccrx.base.rtosConfig"/>
 						</toolChain>
@@ -88,7 +127,11 @@
 				</configuration>
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
-			<storageModule moduleId="com.renesas.cdt.managedbuild.core.boardInfo"/>
+			<storageModule moduleId="com.renesas.cdt.managedbuild.core.boardInfo">
+				<option id="board.id" value="gr-rose"/>
+				<option id="board.name" value="gr-rose"/>
+				<option id="board.device" value="R5F565NEHxFP"/>
+			</storageModule>
 		</cconfiguration>
 	</storageModule>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/wolfssl/wolfssl.rcpc
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/wolfssl/wolfssl.rcpc
@@ -87,12 +87,13 @@
         </Category>
       </Category>
     </Files>
-    <Device Category="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.cpu.rx600" Series="RX">R5F571MLCxFC</Device>
-    <BuildOptions Name="CC-RX" Version="v3.03.00">
+    <Device Category="com.renesas.cdt.managedbuild.renesas.ccrx.common.option.cpu.rx600" Series="RX">R5F565NEHxFP</Device>
+    <BuildOptions Name="CC-RX" Version="v3.04.00">
       <BuildMode Active="True" Name="Debug">
         <GeneralOptions/>
         <CompileOptions>
           <Option>-isa=rxv2</Option>
+          <Option>-fpu</Option>
           <Option>-include="${ProjDirPath}\..\common"</Option>
           <Option>-include="${ProjDirPath}\\..\..\..\..\..\..\"</Option>
           <Option>-include="${ProjDirPath}\..\test\src\smc_gen\"</Option>
@@ -100,8 +101,10 @@
           <Option>-include="${ProjDirPath}\..\test\src\smc_gen\r_config"</Option>
           <Option>-include="${ProjDirPath}\..\test\src\smc_gen\r_tsip_rx"</Option>
           <Option>-define=WOLFSSL_USER_SETTINGS</Option>
+          <Option>-utf8</Option>
           <Option>-nomessage</Option>
           <Option>-debug</Option>
+          <Option>-outcode=utf8</Option>
           <Option>-optimize=0</Option>
           <Option>-nologo</Option>
           <Option>-lang=c99</Option>
@@ -111,6 +114,8 @@
         </CompileOptions>
         <AssembleOptions>
           <Option>-isa=rxv2</Option>
+          <Option>-fpu</Option>
+          <Option>-utf8</Option>
           <Option>-debug</Option>
           <Option>-nologo</Option>
           <Option>-output=${CONFIGDIR}</Option>

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_sha.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_sha.c
@@ -32,11 +32,15 @@
 
 #if defined(WOLFSSL_RENESAS_TSIP_CRYPT)
 
+#include <wolfssl/wolfcrypt/memory.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h>
 
+
 #if !defined(NO_SHA) && !defined(NO_WOLFSSL_RENESAS_TSIP_CRYPT_HASH)
 #include <wolfssl/wolfcrypt/sha.h>
+
+extern struct WOLFSSL_HEAP_HINT* tsip_heap_hint;
 
 static void TSIPHashFree(wolfssl_TSIP_Hash* hash)
 {
@@ -59,7 +63,13 @@ static int TSIPHashInit(wolfssl_TSIP_Hash* hash, void* heap, int devId,
     (void)devId;
     XMEMSET(hash, 0, sizeof(wolfssl_TSIP_Hash));
 
-    hash->heap = heap;
+    if (heap == NULL && tsip_heap_hint != NULL) {
+        hash->heap = (struct wolfSSL_HEAP_HINT*)tsip_heap_hint;
+    }
+    else {
+        hash->heap = heap;
+    }
+    
     hash->len  = 0;
     hash->used = 0;
     hash->msg  = NULL;

--- a/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
+++ b/wolfcrypt/src/port/Renesas/renesas_tsip_util.c
@@ -52,9 +52,10 @@ extern uint32_t     s_inst1[R_TSIP_SINST_WORD_SIZE];
 
 wolfSSL_Mutex       tsip_mutex;
 static int          tsip_CryptHwMutexInit_ = 0;
-static const byte*  ca_cert_sig;
+static const byte*  ca_cert_sig = NULL;
 static tsip_key_data g_user_key_info;
 
+struct WOLFSSL_HEAP_HINT*  tsip_heap_hint = NULL;
 
 /* tsip only keep one encrypted ca public key */
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
@@ -409,6 +410,12 @@ WOLFSSL_API void tsip_set_callbacks(struct WOLFSSL_CTX* ctx)
     wolfSSL_CTX_SetRsaEncCb(ctx, Renesas_cmn_RsaEnc);
     wolfSSL_CTX_SetVerifyMacCb(ctx, (CallbackVerifyMac)Renesas_cmn_VerifyHmac);
     wolfSSL_CTX_SetEccSharedSecretCb(ctx, NULL);
+
+    /* set heap-hint to tsip_heap_hint so that tsip sha funcs can refer it */
+    if (ctx->heap != NULL) {
+        tsip_heap_hint = ctx->heap;
+    }
+
     WOLFSSL_LEAVE("tsip_set_callbacks", 0);
 }
 


### PR DESCRIPTION
# Description

This PR is intended to address an issue found in ZD13893. If WOLFSSL_STATIC_MEMORY is defined, wc_RNG_HealthTest_ex is called with a null heap hint. Wc_Sha256 on the TSIP port causes a memory error. To handle this situation, a global variable is added to the TSIP port to store the heap hint. It also causes the existing tsip_set_callback to get the heap hint from WOLFSSL_CTX and store it in the variable. 

Also, for the convenience of the user, added the code to use WOLFSSL_STATIC_MEMORY to the sample program.

This PR is a replacement for PR5047.

Fixes ZD13893

# Testing

Build client example code with WOLFSSL_STATIC_MEMORY and run it on Renesas GR-ROSE board.

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
