### PR TITLE
20220601-multi-test-fixes

### DIFF
--- a/tests/api.c
+++ b/tests/api.c
@@ -45202,7 +45202,7 @@ static void test_evp_cipher_aes_gcm(void)
      * wolfSSL OpenSSH clients because there was a bug in this flow that
      * happened to "cancel out" if both sides of the connection had the bug.
      */
-    enum { 
+    enum {
         NUM_ENCRYPTIONS = 3,
         AAD_SIZE = 4
     };
@@ -45278,7 +45278,7 @@ static void test_evp_cipher_aes_gcm(void)
         },
         {
             0x3B, 0xED, 0x18, 0x9C, 0xB3, 0xE3, 0x61, 0x1E, 0x11, 0xEB, 0x13,
-            0x5B, 0xEC, 0x52, 0x49, 0x32, 
+            0x5B, 0xEC, 0x52, 0x49, 0x32,
         }
     };
 
@@ -45294,7 +45294,7 @@ static void test_evp_cipher_aes_gcm(void)
     };
     const byte expCipherText3[] = {
         0xD0, 0x37, 0x59, 0x1C, 0x2F, 0x85, 0x39, 0x4D, 0xED, 0xC2, 0x32, 0x5B,
-        0x80, 0x5E, 0x6B, 
+        0x80, 0x5E, 0x6B,
     };
     const byte* expCipherTexts[NUM_ENCRYPTIONS] = {
         expCipherText1,
@@ -45457,7 +45457,7 @@ static void test_evp_cipher_aes_gcm(void)
         EVP_CIPHER_CTX_free(encCtx);
         EVP_CIPHER_CTX_free(decCtx);
     }
-    
+
     printf(resultFmt, passed);
 #endif
 }

--- a/wolfcrypt/src/evp.c
+++ b/wolfcrypt/src/evp.c
@@ -1012,7 +1012,7 @@ int wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx, unsigned char *out,
     if (ret == WOLFSSL_SUCCESS) {
 #if defined(HAVE_AESGCM) && ((!defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)) \
     || FIPS_VERSION_GE(2,0))
-        /* 
+        /*
          * This flag needs to retain its value between wolfSSL_EVP_CipherFinal
          * calls. wolfSSL_EVP_CipherInit will clear it, so we save and restore
          * it here.
@@ -5444,7 +5444,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
                 }
             #ifdef HAVE_AESGCM
                 if (ret == WOLFSSL_SUCCESS) {
-                    /* 
+                    /*
                      * OpenSSL requires that a EVP_CTRL_AEAD_SET_IV_FIXED
                      * command be issued before a EVP_CTRL_GCM_IV_GEN command.
                      * This flag is used to enforce that.
@@ -5752,7 +5752,7 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
             ret = WOLFSSL_FAILURE;
         }
     #ifdef WOLFSSL_AESGCM_STREAM
-        /* 
+        /*
          * Initialize with key and IV if available. wc_AesGcmInit will fail
          * if called with IV only and no key has been set.
          */
@@ -5864,7 +5864,9 @@ int wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type)
              * Clear any leftover AAD on final (final is when src is
              * NULL).
              */
-            XMEMSET(ctx->gcmAuthIn, 0, ctx->gcmAuthInSz);
+            if (ctx->gcmAuthIn != NULL) {
+                XMEMSET(ctx->gcmAuthIn, 0, ctx->gcmAuthInSz);
+            }
             ctx->gcmAuthInSz = 0;
         }
         if (ret == 0) {


### PR DESCRIPTION
evp.c: in EvpCipherAesGCM(), make sure ctx->gcmAuthIn is non-null before clearing it; fix whitespace.

tested with `wolfssl-multi-test.sh [...] check-source-text sp-asn-template-asm-smallstack-sanitizer all-sp-all-Os-sanitizer sp-all-asm-smallstack-sanitizer intmath-sanitizer`.
