### PR TITLE
initialized XFILE file

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -20654,7 +20654,7 @@ int wc_PemPubKeyToDer_ex(const char* fileName, DerBuffer** der)
     int    dynamic = 0;
     int    ret     = 0;
     long   sz      = 0;
-    XFILE  file;
+    XFILE  file    = NULL;
 
     WOLFSSL_ENTER("wc_PemPubKeyToDer");
 


### PR DESCRIPTION
# Description

Initialized XFILE file to NULL to fix VisualStudio error. (C4703 "potentially uninitialized local pointer variable 'file' used")

Fixes zd#14294
https://wolfssl.zendesk.com/hc/en-us/requests/14294

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
