### PR TITLE
Encoding the X509 Basic Constraint when CA:FALSE 

### DIFF
--- a/src/x509.c
+++ b/src/x509.c
@@ -8148,6 +8148,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
         if (ret == WOLFSSL_SUCCESS) {
             cert->version = req->version;
             cert->isCA = req->isCa;
+            cert->basicConstSet = req->basicConstSet;
     #ifdef WOLFSSL_CERT_EXT
             if (req->subjKeyIdSz != 0) {
                 XMEMCPY(cert->skid, req->subjKeyId, req->subjKeyIdSz);
@@ -8239,6 +8240,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
         cert->sigType = wolfSSL_X509_get_signature_type(x509);
         cert->keyType = x509->pubKeyOID;
         cert->isCA    = wolfSSL_X509_get_isCA(x509);
+        cert->basicConstSet = x509->basicConstSet;
 
     #ifdef WOLFSSL_CERT_EXT
         if (x509->subjKeyIdSz <= CTC_MAX_SKID_SIZE) {

--- a/tests/api.c
+++ b/tests/api.c
@@ -38593,7 +38593,54 @@ static void test_wolfSSL_PEM_write_bio_X509(void)
     expectedLen = 1688;
     AssertIntEQ(wolfSSL_BIO_get_len(output), expectedLen);
 
+    /* Reset buffers and x509 */
+    BIO_free(input);
+    BIO_free(output);
     X509_free(x509a);
+
+    /* test CA and basicConstSet values are encoded when 
+     * the cert is a CA */ 
+    AssertNotNull(input = BIO_new_file(
+            "certs/server-cert.pem", "rb"));
+
+    /* read PEM into X509 struct */
+    AssertNotNull(PEM_read_bio_X509(input, &x509a, NULL, NULL));
+
+    /* write X509 back to PEM BIO */
+    AssertNotNull(output = BIO_new(wolfSSL_BIO_s_mem()));
+    AssertIntEQ(PEM_write_bio_X509(output, x509a), WOLFSSL_SUCCESS);
+
+    /* read exported X509 PEM back into struct, ensure isCa and
+     * basicConstSet values are maintained */
+    AssertNotNull(PEM_read_bio_X509(output, &x509b, NULL, NULL));
+    AssertIntEQ(x509b->isCa, 1);
+    AssertIntEQ(x509b->basicConstSet, 1);
+    
+    X509_free(x509a);
+    X509_free(x509b);
+    BIO_free(input);
+    BIO_free(output);
+
+    /* test CA and basicConstSet values are encoded when 
+     * the cert is not CA */ 
+    AssertNotNull(input = BIO_new_file(
+            "certs/client-uri-cert.pem", "rb"));
+
+    /* read PEM into X509 struct */
+    AssertNotNull(PEM_read_bio_X509(input, &x509a, NULL, NULL));
+
+    /* write X509 back to PEM BIO */
+    AssertNotNull(output = BIO_new(wolfSSL_BIO_s_mem()));
+    AssertIntEQ(PEM_write_bio_X509(output, x509a), WOLFSSL_SUCCESS);
+
+    /* read exported X509 PEM back into struct, ensure isCa and
+     * basicConstSet values are maintained */
+    AssertNotNull(PEM_read_bio_X509(output, &x509b, NULL, NULL));
+    AssertIntEQ(x509b->isCa, 0);
+    AssertIntEQ(x509b->basicConstSet, 1);
+    
+    X509_free(x509a);
+    X509_free(x509b);
     BIO_free(input);
     BIO_free(output);
 

--- a/wolfssl/wolfcrypt/asn_public.h
+++ b/wolfssl/wolfcrypt/asn_public.h
@@ -443,9 +443,10 @@ typedef struct Cert {
     CertExtension customCertExt[NUM_CUSTOM_EXT];
     int customCertExtCount;
 #endif
-    void*   decodedCert;    /* internal DecodedCert allocated from heap */
-    byte*   der;            /* Pointer to buffer of current DecodedCert cache */
-    void*   heap;           /* heap hint */
+    void*   decodedCert;      /* internal DecodedCert allocated from heap */
+    byte*   der;              /* Pointer to buffer of current DecodedCert cache */
+    void*   heap;             /* heap hint */
+    byte    basicConstSet:1;  /* Indicator for when Basic Constaint is set */
 } Cert;
 
 


### PR DESCRIPTION
# Description

Whenever x509->basicConstSet is 1, this code change will set and encode the Basic Constraints whether or not the Cert is CA

Fixes zd#

# Testing

Tested using wolfCLU command `wolfssl req -new -config test.conf -x509 -days 3650 -key certs/server-key.pem -out x.pem` with both CA:TRUE and CA:FALSE values for basic constraint in the conf file

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
