### PR TITLE
Removing ghosts and updating defines in openssl/buffer.h

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26895,7 +26895,7 @@ int EncryptDerKey(byte *der, int *derSz, const EVP_CIPHER* cipher,
 #endif
         return WOLFSSL_FAILURE;
     }
-    XSTRNCPY((char*)*cipherInfo, info->name, cipherInfoSz);
+    XSTRCPY((char*)*cipherInfo, info->name);
     XSTRNCAT((char*)*cipherInfo, ",", 2);
 
     idx = (word32)XSTRLEN((char*)*cipherInfo);

--- a/wolfssl/openssl/buffer.h
+++ b/wolfssl/openssl/buffer.h
@@ -37,8 +37,6 @@ WOLFSSL_API int wolfSSL_BUF_MEM_grow_ex(WOLFSSL_BUF_MEM* buf, size_t len,
         char zeroFill);
 WOLFSSL_API int wolfSSL_BUF_MEM_resize(WOLFSSL_BUF_MEM* buf, size_t len);
 WOLFSSL_API void wolfSSL_BUF_MEM_free(WOLFSSL_BUF_MEM* buf);
-WOLFSSL_API size_t wolfSSL_strlcpy(char *dst, const char *src, size_t dstSize);
-WOLFSSL_API size_t wolfSSL_strlcat(char *dst, const char *src, size_t dstSize);
 
 
 #define BUF_MEM_new  wolfSSL_BUF_MEM_new
@@ -46,8 +44,8 @@ WOLFSSL_API size_t wolfSSL_strlcat(char *dst, const char *src, size_t dstSize);
 #define BUF_MEM_free wolfSSL_BUF_MEM_free
 
 #define BUF_strdup strdup
-#define BUF_strlcpy wolfSSL_strlcpy
-#define BUF_strlcat wolfSSL_strlcat
+#define BUF_strlcpy wc_strlcpy
+#define BUF_strlcat wc_strlcat
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -616,6 +616,7 @@ decouple library dependencies with standard string, memory and so on.
 
         #define XSTRLEN(s1)       strlen((s1))
         #define XSTRNCPY(s1,s2,n) strncpy((s1),(s2),(n))
+        #define XSTRCPY(s1,s2)    strcpy((s1),(s2))
         /* strstr, strncmp, strcmp, and strncat only used by wolfSSL proper,
          * not required for wolfCrypt only */
         #define XSTRSTR(s1,s2)    strstr((s1),(s2))


### PR DESCRIPTION
# Description

Define `BUF_strlcpy` and `BUF_strlcat` to `wc_strlcpy` and `wc_strlcpy`. Fix `stringop-overflow` in ssl.c

Fixes zd#

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
