### PR TITLE
add link to new location for old zephyr references

### DIFF
--- a/IDE/include.am
+++ b/IDE/include.am
@@ -46,6 +46,7 @@ include IDE/iotsafe/include.am
 include IDE/Android/include.am
 include IDE/NETOS/include.am
 include IDE/IAR-MSP430/include.am
+include IDE/zephyr/include.am
 
 EXTRA_DIST+= IDE/IAR-EWARM IDE/MDK-ARM IDE/MDK5-ARM IDE/MYSQL IDE/LPCXPRESSO IDE/HEXIWEAR IDE/Espressif
 EXTRA_DIST+= IDE/OPENSTM32/README.md

--- a/IDE/zephyr/README.md
+++ b/IDE/zephyr/README.md
@@ -1,0 +1,1 @@
+Zephyr Project Port has been moved to https://github.com/wolfSSL/wolfssl/tree/master/zephyr

--- a/IDE/zephyr/README.md
+++ b/IDE/zephyr/README.md
@@ -1,1 +1,1 @@
-Zephyr Project Port has been moved to https://github.com/wolfSSL/wolfssl/tree/master/zephyr
+Zephyr Project Port has been moved to [wolfssl/zephyr](../../zephyr/README.md)

--- a/IDE/zephyr/README.md
+++ b/IDE/zephyr/README.md
@@ -1,1 +1,3 @@
+# Zephyr
+
 Zephyr Project Port has been moved to [wolfssl/zephyr](../../zephyr/README.md)

--- a/IDE/zephyr/include.am
+++ b/IDE/zephyr/include.am
@@ -1,0 +1,5 @@
+# vim:ft=automake
+# included from Top Level Makefile.am
+# All paths should be given relative to the root
+
+EXTRA_DIST+= IDE/zephyr/README.md


### PR DESCRIPTION
# Description

This adds a placeholder README file for legacy links such as the one referenced in https://github.com/zephyrproject-rtos/zephyr/issues/36026 that is current 404.

# Testing

Just a new link in the README that points to https://github.com/wolfSSL/wolfssl/tree/master/zephyr

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
