### PR TITLE
use XSTRLCPY() and XSTRLCAT() in EncryptDerKey()

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -26895,8 +26895,8 @@ int EncryptDerKey(byte *der, int *derSz, const EVP_CIPHER* cipher,
 #endif
         return WOLFSSL_FAILURE;
     }
-    XSTRCPY((char*)*cipherInfo, info->name);
-    XSTRNCAT((char*)*cipherInfo, ",", 2);
+    XSTRLCPY((char*)*cipherInfo, info->name, cipherInfoSz);
+    XSTRLCAT((char*)*cipherInfo, ",", cipherInfoSz);
 
     idx = (word32)XSTRLEN((char*)*cipherInfo);
     cipherInfoSz -= idx;

--- a/wolfssl/wolfcrypt/types.h
+++ b/wolfssl/wolfcrypt/types.h
@@ -616,7 +616,6 @@ decouple library dependencies with standard string, memory and so on.
 
         #define XSTRLEN(s1)       strlen((s1))
         #define XSTRNCPY(s1,s2,n) strncpy((s1),(s2),(n))
-        #define XSTRCPY(s1,s2)    strcpy((s1),(s2))
         /* strstr, strncmp, strcmp, and strncat only used by wolfSSL proper,
          * not required for wolfCrypt only */
         #define XSTRSTR(s1,s2)    strstr((s1),(s2))


### PR DESCRIPTION
use `XSTRLCPY()` and `XSTRLCAT()` to build up `cipherInfo`, and remove `XSTRCPY()` macro from wolfssl/wolfcrypt/types.h (clang-tidy hates on it, albeit frivolously).

tested with `wolfssl-multi-test.sh ... super-quick-check` with `sp-asn-template-asm-smallstack-sanitizer` and `clang-tidy-asn-template-sp-all-small-stack` added.

@lealem47 sorry for the wrong advice on using `strcpy()` in #5214 !    :facepalm: 
