### PR TITLE
Support for SEGGER embOS and emNET

### DIFF
--- a/wolfcrypt/src/memory.c
+++ b/wolfcrypt/src/memory.c
@@ -625,6 +625,8 @@ void* wolfSSL_Malloc(size_t size, void* heap, int type)
         #ifndef WOLFSSL_NO_MALLOC
             #ifdef FREERTOS
                 res = pvPortMalloc(size);
+            #elif defined WOLFSSL_EMBOS
+                res = OS_HEAP_malloc(size);
             #else
                 res = malloc(size);
             #endif
@@ -776,6 +778,8 @@ void wolfSSL_Free(void *ptr, void* heap, int type)
         #ifndef WOLFSSL_NO_MALLOC
             #ifdef FREERTOS
                 vPortFree(ptr);
+            #elif defined WOLFSSL_EMBOS
+                OS_HEAP_free(ptr);
             #else
                 free(ptr);
             #endif

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -2187,6 +2187,39 @@ int wolfSSL_CryptHwMutexUnLock(void)
         return 0;
     }
 
+#elif defined(WOLFSSL_EMBOS)
+
+    int wc_InitMutex(wolfSSL_Mutex* m)
+    {
+        int iReturn;
+
+        *m = ( wolfSSL_Mutex ) OS_MUTEX_Create();
+        if( *m != NULL )
+            iReturn = 0;
+        else
+            iReturn = BAD_MUTEX_E;
+
+        return iReturn;
+    }
+
+    int wc_FreeMutex(wolfSSL_Mutex* m)
+    {
+        OS_MUTEX_Delete( *m );
+        return 0;
+    }
+
+    int wc_LockMutex(wolfSSL_Mutex* m)
+    {
+        OS_MUTEX_LockTimed( *m, portMAX_DELAY );
+        return 0;
+    }
+
+    int wc_UnLockMutex(wolfSSL_Mutex* m)
+    {
+        OS_MUTEX_Unlock( *m );
+        return 0;
+    }
+
 #elif defined(WOLFSSL_USER_MUTEX)
 
     /* Use user own mutex */

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -1770,6 +1770,15 @@ extern void uITRON4_free(void *p) ;
     #define USE_WOLFSSL_MEMORY
 #endif
 
+#ifdef WOLFSSL_EMBOS
+    #include "RTOS.h"
+    #if !defined(XMALLOC_USER) && !defined(NO_WOLFSSL_MEMORY) && \
+        !defined(WOLFSSL_STATIC_MEMORY)
+        #define XMALLOC(s, h, type)  OS_HEAP_malloc((s))
+        #define XFREE(p, h, type)    OS_HEAP_free((p))
+        #define XREALLOC(p, n, h, t) OS_HEAP_realloc(((p), (n))
+    #endif
+#endif
 
 #if defined(OPENSSL_EXTRA) && !defined(NO_CERTS)
     #undef  KEEP_PEER_CERT

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -266,6 +266,8 @@
         typedef struct k_mutex wolfSSL_Mutex;
     #elif defined(WOLFSSL_TELIT_M2MB)
         typedef M2MB_OS_MTX_HANDLE wolfSSL_Mutex;
+    #elif defined(WOLFSSL_EMBOS)
+        typedef OS_MUTES wolfSSL_Mutex;
     #elif defined(WOLFSSL_USER_MUTEX)
         /* typedef User_Mutex wolfSSL_Mutex; */
     #elif defined(WOLFSSL_LINUXKM)

--- a/wolfssl/wolfio.h
+++ b/wolfssl/wolfio.h
@@ -174,6 +174,10 @@
         #include <errno.h>
     #endif
 
+    #if defined(WOLFSSL_EMBOS)
+        #include <errno.h>
+    #endif
+
 #endif /* USE_WINDOWS_API */
 
 #ifdef __sun
@@ -287,6 +291,15 @@
     #define SOCKET_EPIPE       ERR_CLSD
     #define SOCKET_ECONNREFUSED ERR_CONN
     #define SOCKET_ECONNABORTED ERR_ABRT
+#elif defined(WOLFSSL_EMNET)
+    #include <IP/IP.h>
+    #define SOCKET_EWOULDBLOCK  IP_ERR_WOULD_BLOCK
+    #define SOCKET_EAGAIN       IP_ERR_WOULD_BLOCK
+    #define SOCKET_ECONNRESET   IP_ERR_CONN_RESET
+    #define SOCKET_EINTR        IP_ERR_FAULT
+    #define SOCKET_EPIPE        IP_ERR_PIPE
+    #define SOCKET_ECONNREFUSED IP_ERR_CONN_REFUSED
+    #define SOCKET_ECONNABORTED IP_ERR_CONN_ABORTED
 #else
     #define SOCKET_EWOULDBLOCK EWOULDBLOCK
     #define SOCKET_EAGAIN      EAGAIN


### PR DESCRIPTION
Adds support for embOS memory and mutex functions. Also adds support for
emNET's error codes, it uses a BSD compatible TCP/IP stack for network
functions.

There is no easy native way to detect that you are compiling with emNET
or embOS so these require the user to define `WOLFSSL_EMBOS` /
`WOLFSSL_EMNET`.

# Testing

Tested on SEGGER embOS / emNET with a S32K146 in SEGGER Embedded Studio.