### PR TITLE
Add a sanity check in RsaPad_OAEP

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -19192,7 +19192,7 @@ void FreeSigner(Signer* signer, void* heap)
     FreeDer(&signer->derCert);
 #endif
     XFREE(signer, heap, DYNAMIC_TYPE_SIGNER);
-
+    (void)signer;
     (void)heap;
 }
 

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -1167,6 +1167,10 @@ static int RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
             XFREE(seed,  heap, DYNAMIC_TYPE_RSA_BUFFER);
         return MEMORY_E;
     }
+#else
+    if (pkcsBlockLen - hLen - 1 > sizeof(dbMask)) {
+        return MEMORY_E;
+    }
 #endif
     XMEMSET(dbMask, 0, pkcsBlockLen - hLen - 1); /* help static analyzer */
     ret = RsaMGF(mgf, seed, hLen, dbMask, pkcsBlockLen - hLen - 1, heap);
@@ -3117,7 +3121,7 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
         return RSA_BUFFER_E;
     }
 
-    if (sz < RSA_MIN_PAD_SZ) {
+    if (sz < RSA_MIN_PAD_SZ || sz > (int)RSA_MAX_SIZE/8) {
         return WC_KEY_SIZE_E;
     }
 


### PR DESCRIPTION
This PR corrects a possible Out-of-bounds write in RsaPad_OAEP.  Add a check in case of a large RsaKey modulus `key.n` is set by accessing the elements of the RsaKey structure. Since `wc_RsaEncryptSize()` looks at the modules to determine the key size, I believe it's better to fail early.  This PR also corrects a build error for a non-custom config build unrelated to RSA.

Fixes zd#14313
Thanks to Guido Vranken! 

# Testing
Tested locally with -fsanitize=address with oss-fuzz-47811.c

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
