### PR TITLE
Fix multi thread use case with Renesas SCE protected mode and TSIP

### DIFF
--- a/IDE/Renesas/e2studio/RA6M4/README.md
+++ b/IDE/Renesas/e2studio/RA6M4/README.md
@@ -76,7 +76,7 @@ The wolfssl Project Summary is listed below and is relevant for every project.
 |Common General Use Mutexes|Enabled|
 |Common General Enable Backward Compatibility|Enabled|
 |Common Memory Allocation Support Dynamic Allocation|Enabled|
-|Common Memory Allocation Total Heap Size|increase depending on your environment<br> e.g. 0x20000|
+|Common Memory Allocation Total Heap Size|increase depending on your environment<br> e.g. 0x20000, <br>  e.g. 0x30000 when using multi thread example|
 
 + Add `Heap 4` stack to sce_tst_thread from `New Stack` -> `RTOS` -> `FreeRTOS Heap 4`
 + Add `FreeRTOS + TCP` stack to sce_tst_thread from `New Stack` -> `Networking` -> `FreeRTOS+TCP` and set properties
@@ -158,6 +158,7 @@ static const byte ucIPAddress[4]          = { 192, 168, 11, 241 };
 $ autogen.sh
 $ ./configure --enable-extended-master=no CFLAGS="-DWOLFSSL_STATIC_RSA -DHAVE_AES_CBC"
 ```
+
 Run peer wolfSSL server
 
 RSA sign and verify use, launch server with the following option
@@ -165,40 +166,153 @@ RSA sign and verify use, launch server with the following option
 $./examples/server/server -b -d -i
 ```
 
-You will see the following message on J-LinK RTT Viewer
-```
-cipher : AES128-SHA256
-Received: I hear you fa shizzle!
-
-cipher : AES256-SHA256
-Received: I hear you fa shizzle!
-
-cipher : ECDHE-RSA-AES128-SHA256
-Received: I hear you fa shizzle!
-
-cipher : ECDHE-RSA-AES128-GCM-SHA256
-Received: I hear you fa shizzle!
-```
-
 ECDSA sign and verify use, launch server with the following option
 ```
 $./examples/server/server -b -d -c -i ./certs/server-ecc.pem -k ./certs/ecc-key.pem
 ```
 
-You will see the following message on J-LinK RTT Viewer
-```
-cipher : ECDHE-ECDSA-AES128-SHA256
-Received: I hear you fa shizzle!
-
-cipher : ECDHE-ECDSA-AES128-GCM-SHA256
-Received: I hear you fa shizzle!
-```
-
 5.) Run the example Client
+
+You will see the following message on J-LinK RTT Viewer when using RSA sign and verify.
+```
+ Start Client Example, 
+ Connecting to 192.168.11.xx
+
+[wolfSSL_TLS_client_do(00)][00]  Start to connect to the server.
+[wolfSSL_TLS_client_do(00)][00]   Cipher : NULL
+[wolfSSL_TLS_client_do(00)][00]  Received: I hear you fa shizzle!
+
+[wolfSSL_TLS_client_do(01)][01]  Start to connect to the server.
+[wolfSSL_TLS_client_do(01)][01]   Cipher : ECDHE-RSA-AES128-GCM-SHA256
+[wolfSSL_TLS_client_do(01)][01]  Received: I hear you fa shizzle!
+
+[wolfSSL_TLS_client_do(02)][02]  Start to connect to the server.
+[wolfSSL_TLS_client_do(02)][02]   Cipher : ECDHE-RSA-AES256-SHA
+[wolfSSL_TLS_client_do(02)][02]  Received: I hear you fa shizzle!
+
+[wolfSSL_TLS_client_do(03)][03]  Start to connect to the server.
+[wolfSSL_TLS_client_do(03)][03]   Cipher : ECDHE-RSA-AES128-SHA256
+[wolfSSL_TLS_client_do(03)][03]  Received: I hear you fa shizzle!
+
+[wolfSSL_TLS_client_do(04)][04]  Start to connect to the server.
+[wolfSSL_TLS_client_do(04)][04]   Cipher : AES128-SHA256
+[wolfSSL_TLS_client_do(04)][04]  Received: I hear you fa shizzle!
+
+
+ End of Client Example
+```
+
+You will see the following message on J-LinK RTT Viewer when using ECDSA sign and verify.
+```
+ Start Client Example, 
+ Connecting to 192.168.11.xx
+
+[wolfSSL_TLS_client_do(00)][00]  Start to connect to the server.
+[wolfSSL_TLS_client_do(00)][00]   Cipher : NULL
+[wolfSSL_TLS_client_do(00)][00]  Received: I hear you fa shizzle!
+
+[wolfSSL_TLS_client_do(01)][01]  Start to connect to the server.
+[wolfSSL_TLS_client_do(01)][01]   Cipher : ECDHE-ECDSA-AES128-GCM-SHA256
+[wolfSSL_TLS_client_do(01)][01]  Received: I hear you fa shizzle!
+
+[wolfSSL_TLS_client_do(02)][02]  Start to connect to the server.
+[wolfSSL_TLS_client_do(02)][02]   Cipher : ECDHE-ECDSA-AES256-SHA
+[wolfSSL_TLS_client_do(02)][02]  Received: I hear you fa shizzle!
+
+[wolfSSL_TLS_client_do(03)][03]  Start to connect to the server.
+[wolfSSL_TLS_client_do(03)][03]   Cipher : ECDHE-ECDSA-AES128-SHA256
+[wolfSSL_TLS_client_do(03)][03]  Received: I hear you fa shizzle!
+
+
+ End of Client Exampl
+```
 
  **Note**\
    To run "RSA verify" client, enable "#define USE_CERT_BUFFERS_2048" in wolfssl_demo.h\
    To run "ECDSA verify" client, enable "#define USE_CERT_BUFFERS_256" in wolfssl_demo.h
+
+
+### Run Multi Client Session example
+1.) Enable TLS_CLIENT and TLS_MULTITHREAD_TEST definition in wolfssl_demo.h of test_RA6M4 projet
+
+2.) Follow [Run Client](#run-client) instruction 
+
+3.) Prepare peer wolfssl server
+
+RSA sign and verify use, launch server with the following option
+```
+$./examples/server/server -b -d -i -p 11111
+
+Open another terminal and launch another server example
+$./examples/server/server -b -d -i -p 11112
+```
+
+ECDSA sign and verify use, launch server with the following option
+```
+$./examples/server/server -b -d -c -i ./certs/server-ecc.pem -k ./certs/ecc-key.pem -p 11111
+
+Open another terminal and launch another server example
+$./examples/server/server -b -d -c -i ./certs/server-ecc.pem -k ./certs/ecc-key.pem -p 11112
+```
+
+4.) Run Multi Client Session Example
+You will see similar following message on J-LinK RTT Viewer when using ECDSA sign and verify.
+```
+ Start Client Example, 
+ Connecting to 192.168.11.xx
+
+ clt_thd_taskA connecting to 11111 port
+ clt_thd_taskB connecting to 11112 port
+[clt_thd_taskA][00]  Ready to connect.
+[clt_thd_taskA][00]  Start to connect to the server.
+[clt_thd_taskA][00]   Cipher : ECDHE-RSA-AES128-GCM-SHA256
+[clt_thd_taskB][00]  Ready to connect.
+[clt_thd_taskB][00]  Start to connect to the server.
+[clt_thd_taskB][00]   Cipher : ECDHE-RSA-AES128-SHA256
+[clt_thd_taskB][00]  Received: I hear you fa shizzle!
+
+[clt_thd_taskA][00]  Received: I hear you fa shizzle!
+
+ clt_thd_taskA connecting to 11111 port
+ clt_thd_taskB connecting to 11112 port
+[clt_thd_taskA][00]  Ready to connect.
+[clt_thd_taskA][00]  Start to connect to the server.
+[clt_thd_taskA][00]   Cipher : AES128-SHA256
+[clt_thd_taskB][00]  Ready to connect.
+[clt_thd_taskB][00]  Start to connect to the server.
+[clt_thd_taskB][00]   Cipher : AES256-SHA256
+[clt_thd_taskA][00]  Received: I hear you fa shizzle!
+
+[clt_thd_taskB][00]  Received: I hear you fa shizzle!
+
+
+ End of Client Example
+```
+
+You will see similar following message on J-LinK RTT Viewer when using ECDSA sign and verify.
+```
+ Start Client Example, 
+ Connecting to 192.168.11.xx
+
+ clt_thd_taskA connecting to 11111 port
+ clt_thd_taskB connecting to 11112 port
+[clt_thd_taskA][00]  Ready to connect.
+[clt_thd_taskA][00]  Start to connect to the server.
+[clt_thd_taskA][00]   Cipher : ECDHE-ECDSA-AES128-GCM-SHA256
+[clt_thd_taskB][00]  Ready to connect.
+[clt_thd_taskB][00]  Start to connect to the server.
+[clt_thd_taskB][00]   Cipher : ECDHE-ECDSA-AES128-SHA256
+[clt_thd_taskB][00]  Received: I hear you fa shizzle!
+
+[clt_thd_taskA][00]  Received: I hear you fa shizzle!
+
+
+ End of Client Example
+```
+
+**Note**\
+Multi Client session use case is only able to run threads that all use either SCE cipher suite or SW cipher suite.
+The example program runs two threads that use SCE cipher suite.
 
 ## Run Crypt test and Benchmark
 

--- a/IDE/Renesas/e2studio/RA6M4/common/wolfssl_demo.h
+++ b/IDE/Renesas/e2studio/RA6M4/common/wolfssl_demo.h
@@ -41,20 +41,26 @@
 
 /* Enable wolfcrypt test */
 /* can be enabled with benchmark test */
-/* #define CRYPT_TEST */
+/*#define CRYPT_TEST*/
 
 /* Enable benchmark               */
 /* can be enabled with cyrpt test */
-/* #define BENCHMARK */
+/*#define BENCHMARK*/
 
 /* Enable TLS client     */
 /* cannot enable with CRYPT_TEST or BENCHMARK */
 #define TLS_CLIENT
 
+/* use multi-thread example */
+/*#define TLS_MULTITHREAD_TEST*/
+#if defined(TLS_MULTITHREAD_TEST)
+ #define THREAD_STACK_SIZE (5 * 1024)
+#endif
+
 /* Use RSA certificates */
 #define USE_CERT_BUFFERS_2048
 /* Use ECC certificates */
-/*#define USE_CERT_BUFFERS_256 */
+/*#define USE_CERT_BUFFERS_256*/
 
 #if defined(USE_CERT_BUFFERS_2048) && defined(USE_CERT_BUFFERS_256)
     #error please set either macro USE_CERT_BUFFERS_2048 or USE_CERT_BUFFERS_256
@@ -68,6 +74,9 @@ typedef struct tagTestInfo
      const char* cipher;
      WOLFSSL_CTX* ctx;
      wolfSSL_Logging_cb log_f;
+#if defined(TLS_MULTITHREAD_TEST)
+     SemaphoreHandle_t xBinarySemaphore;
+#endif
 } TestInfo;
 
 void sce_test();
@@ -76,6 +85,10 @@ void wolfSSL_TLS_client_init();
 void wolfSSL_TLS_client_do(void *pvParam);
 void wolfSSL_TLS_cleanup();
 extern WOLFSSL_CTX *client_ctx;
+
+#ifdef TLS_MULTITHREAD_TEST
+extern xSemaphoreHandle exit_semaph;
+#endif
 
 static void util_Cleanup(xSocket_t xSock, WOLFSSL_CTX *ctx, WOLFSSL *ssl) {
     printf("Cleaning up socket and wolfSSL objects.\n");

--- a/IDE/Renesas/e2studio/RA6M4/include.am
+++ b/IDE/Renesas/e2studio/RA6M4/include.am
@@ -10,6 +10,7 @@ EXTRA_DIST+= IDE/Renesas/e2studio/RA6M4/test/.project
 EXTRA_DIST+= IDE/Renesas/e2studio/RA6M4/test/test_RA6M4Debug.launch
 EXTRA_DIST+= IDE/Renesas/e2studio/RA6M4/test/src/test_main.c
 EXTRA_DIST+= IDE/Renesas/e2studio/RA6M4/test/src/wolf_client.c
+EXTRA_DIST+= IDE/Renesas/e2studio/RA6M4/test/src/wolfssl_sce_unit_test.c
 EXTRA_DIST+= IDE/Renesas/e2studio/RA6M4/test/src/SEGGER_RTT/myprint.c
 EXTRA_DIST+= IDE/Renesas/e2studio/RA6M4/test/src/common/.gitignore
 EXTRA_DIST+= IDE/Renesas/e2studio/RA6M4/test/key_data/key_data_sce.c

--- a/IDE/Renesas/e2studio/RA6M4/test/src/wolfssl_sce_unit_test.c
+++ b/IDE/Renesas/e2studio/RA6M4/test/src/wolfssl_sce_unit_test.c
@@ -1,0 +1,1052 @@
+/* wolfssl_sce_unit_test.c
+ *
+ * Copyright (C) 2006-2022 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/sha.h>
+#include <wolfssl/wolfcrypt/sha256.h>
+#include <wolfssl/wolfcrypt/aes.h>
+#include <wolfssl/wolfcrypt/port/Renesas/renesas-sce-crypt.h>
+
+#include "FreeRTOS.h"
+
+#ifndef NO_SHA
+ int sha_test();
+#endif
+
+#ifndef NO_SHA256
+ int sha256_test();
+#endif
+
+#define STACK_SIZE (1 * 1024)
+
+#define RESULT_STR(ret)  if (ret == 0)\
+                          printf(" passed \n");\
+                         else \
+                          printf(" failed \n");
+
+static xSemaphoreHandle exit_semaph;
+static byte exit_loop = 0;
+static byte sha256_multTst_rslt1 = 0;
+static byte sha256_multTst_rslt2 = 0;
+static byte Aes128_Cbc_multTst_rslt = 0;
+static byte Aes256_Cbc_multTst_rslt = 0;
+static byte Aes128_Gcm_multTst_rslt = 0;
+static byte Aes256_Gcm_multTst_rslt = 0;
+
+int sce_crypt_AesCbc_multitest();
+int sce_crypt_AesGcm_multitest();
+int sce_crypt_Sha_AesCbcGcm_multitest();
+int sce_crypt_sha_multitest();
+int sce_crypt_test();
+
+#if defined(HAVE_AES_CBC)
+
+#if defined(WOLFSSL_AES_128)
+    sce_aes_wrapped_key_t g_user_aes128_key_index1;
+    sce_aes_wrapped_key_t g_user_aes128_key_index2;
+#endif
+
+#if defined(WOLFSSL_AES_256)
+    sce_aes_wrapped_key_t g_user_aes256_key_index1;
+    sce_aes_wrapped_key_t g_user_aes256_key_index2;
+#endif
+
+#endif
+
+typedef struct tagInfo
+{
+    sce_aes_wrapped_key_t aes_key;
+} Info;
+
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
+
+static int sce_aes_cbc_test(int prnt, sce_aes_wrapped_key_t* aes_key)
+{
+
+    Aes  aes[1];
+
+    byte cipher[AES_BLOCK_SIZE];
+    byte plain[AES_BLOCK_SIZE];
+    int  ret = 0;
+
+    WOLFSSL_SMALL_STACK_STATIC const byte msg[] = { 
+       /* "Now is the time for all " w/o trailing 0 */
+        0x6e,0x6f,0x77,0x20,0x69,0x73,0x20,0x74,
+        0x68,0x65,0x20,0x74,0x69,0x6d,0x65,0x20,
+        0x66,0x6f,0x72,0x20,0x61,0x6c,0x6c,0x20
+    };
+    byte key[] = "0123456789abcdef   ";  /* align */
+    byte iv[]  = "1234567890abcdef   ";  /* align */
+
+    XMEMSET(cipher, 0, AES_BLOCK_SIZE);
+    XMEMSET(plain, 0, AES_BLOCK_SIZE);
+
+    if (prnt) {
+        printf(" sce_aes_cbc_test() ");
+    }
+    
+    ret = wc_AesInit(aes, NULL, INVALID_DEVID);
+    if (ret == 0) {
+        ret = wc_AesSetKey(aes, key, AES_BLOCK_SIZE, iv, AES_ENCRYPTION);
+        XMEMCPY(&aes->ctx.sce_wrapped_key, aes_key,
+                        sizeof(sce_aes_wrapped_key_t));
+
+        aes->ctx.keySize = (word32)aes->keylen;
+        if (ret == 0) {
+            ret = wc_sce_AesCbcEncrypt(aes, cipher, msg, AES_BLOCK_SIZE);
+        }
+
+        wc_AesFree(aes);
+    }
+
+    if (ret != 0)
+        ret = -1;
+
+#ifdef HAVE_AES_DECRYPT
+    ret = wc_AesInit(aes, NULL, INVALID_DEVID);
+    if (ret == 0) {
+        ret = wc_AesSetKey(aes, key, AES_BLOCK_SIZE, iv, AES_DECRYPTION);
+        XMEMCPY(&aes->ctx.sce_wrapped_key, aes_key,
+                sizeof(sce_aes_wrapped_key_t));
+        aes->ctx.keySize = (word32)aes->keylen;
+        if (ret == 0)
+            ret = wc_sce_AesCbcDecrypt(aes, plain, cipher, AES_BLOCK_SIZE);
+
+        wc_AesFree(aes);
+    }
+    if (ret != 0)
+        ret = -2;
+    if (XMEMCMP(plain, msg, AES_BLOCK_SIZE) != 0)
+        ret = -3;
+#endif /* HAVE_AES_DECRYPT */
+
+    (void)plain;
+
+    if (prnt) {
+        RESULT_STR(ret)
+    }
+    
+    return ret;
+}
+
+static void tskAes128_Cbc_Test(void *pvParam)
+{
+    int ret = 0;
+    Info *p = (Info*)pvParam;
+    
+    while (exit_loop == 0) {
+        ret = sce_aes_cbc_test(0, &p->aes_key);
+        vTaskDelay(10/portTICK_PERIOD_MS);
+        if (ret != 0) {
+            printf(" result was not good(%d). sce_aes_cbc_test\n", ret);
+            Aes128_Cbc_multTst_rslt = 1;
+        }
+    }
+
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+}
+
+#endif
+
+#ifdef WOLFSSL_AES_256
+static int sce_aes256_test(int prnt, sce_aes_wrapped_key_t* aes_key)
+{
+    Aes enc[1];
+    byte cipher[AES_BLOCK_SIZE];
+    byte plain[AES_BLOCK_SIZE];
+    Aes dec[1];
+    int  ret = 0;
+
+    /* Test vectors from NIST Special Publication 800-38A, 2001 Edition,
+     * Appendix F.2.5  */
+    WOLFSSL_SMALL_STACK_STATIC const byte msg[] = {
+        0x6b,0xc1,0xbe,0xe2,0x2e,0x40,0x9f,0x96,
+        0xe9,0x3d,0x7e,0x11,0x73,0x93,0x17,0x2a
+    };
+
+
+    WOLFSSL_SMALL_STACK_STATIC byte key[] = {
+        0x60,0x3d,0xeb,0x10,0x15,0xca,0x71,0xbe,
+        0x2b,0x73,0xae,0xf0,0x85,0x7d,0x77,0x81,
+        0x1f,0x35,0x2c,0x07,0x3b,0x61,0x08,0xd7,
+        0x2d,0x98,0x10,0xa3,0x09,0x14,0xdf,0xf4
+    };
+    WOLFSSL_SMALL_STACK_STATIC byte iv[]  = {
+        0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,
+        0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F
+    };
+
+    if (prnt)
+        printf(" sce_aes256_test() ");
+    
+    if (wc_AesInit(enc, NULL, INVALID_DEVID) != 0) {
+        ret = -1;
+        goto out;
+    }
+
+    if (wc_AesInit(dec, NULL, INVALID_DEVID) != 0){
+        ret = -2;
+        goto out;
+    }
+
+    ret = wc_AesSetKey(enc, key, (int) sizeof(key), iv, AES_ENCRYPTION);
+    if (ret != 0){
+        ret = -3;
+        goto out;
+    } else {
+        XMEMCPY(&enc->ctx.sce_wrapped_key, aes_key,
+                                sizeof(sce_aes_wrapped_key_t));
+        enc->ctx.keySize = (word32)enc->keylen;
+    }
+
+    ret = wc_AesSetKey(dec, key, (int) sizeof(key), iv, AES_DECRYPTION);
+    if (ret != 0) {
+        ret = -4;
+        goto out;
+    } else {
+        XMEMCPY(&dec->ctx.sce_wrapped_key, aes_key,
+                                sizeof(sce_aes_wrapped_key_t));
+        dec->ctx.keySize = (word32)dec->keylen;
+    }
+
+    XMEMSET(cipher, 0, AES_BLOCK_SIZE);
+    ret = wc_sce_AesCbcEncrypt(enc, cipher, msg, (int) sizeof(msg));
+
+    if (ret != 0) {
+        ret = -5;
+        goto out;
+    }
+
+    XMEMSET(plain, 0, AES_BLOCK_SIZE);
+    ret = wc_sce_AesCbcDecrypt(dec, plain, cipher, (int) sizeof(cipher));
+
+    if (ret != 0){
+        ret = -6;
+        goto out;
+    }
+    if (XMEMCMP(plain, msg, (int) sizeof(plain))) {
+        ret = -7;
+        goto out;
+    }
+
+out:
+    wc_AesFree(enc);
+    wc_AesFree(dec);
+
+    if (prnt) {
+        RESULT_STR(ret)
+    }
+    
+    return ret;
+}
+
+static void tskAes256_Cbc_Test(void *pvParam)
+{
+    int ret = 0;
+    Info *p = (Info*)pvParam;
+    
+    while (exit_loop == 0) {
+        ret = sce_aes256_test(0, &p->aes_key);
+        vTaskDelay(10/portTICK_PERIOD_MS);
+        if (ret != 0) {
+            printf(" result was not good(%d). sce_aes256_test\n", ret);
+            Aes256_Cbc_multTst_rslt = 1;
+        }
+    }
+
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+}
+
+#endif /* WOLFSSL_AES_256 */
+
+#if defined(WOLFSSL_AES_256)
+static int sce_aesgcm256_test(int prnt, sce_aes_wrapped_key_t* aes256_key)
+{
+    Aes enc[1];
+    Aes dec[1];
+    User_SCEPKCbInfo userContext;
+    
+    
+    /*
+     * This is Test Case 16 from the document Galois/
+     * Counter Mode of Operation (GCM) by McGrew and
+     * Viega.
+     */
+    WOLFSSL_SMALL_STACK_STATIC const byte p[] =
+    {
+        0xd9, 0x31, 0x32, 0x25, 0xf8, 0x84, 0x06, 0xe5,
+        0xa5, 0x59, 0x09, 0xc5, 0xaf, 0xf5, 0x26, 0x9a,
+        0x86, 0xa7, 0xa9, 0x53, 0x15, 0x34, 0xf7, 0xda,
+        0x2e, 0x4c, 0x30, 0x3d, 0x8a, 0x31, 0x8a, 0x72,
+        0x1c, 0x3c, 0x0c, 0x95, 0x95, 0x68, 0x09, 0x53,
+        0x2f, 0xcf, 0x0e, 0x24, 0x49, 0xa6, 0xb5, 0x25,
+        0xb1, 0x6a, 0xed, 0xf5, 0xaa, 0x0d, 0xe6, 0x57,
+        0xba, 0x63, 0x7b, 0x39
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte a[] =
+    {
+        0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+        0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
+        0xab, 0xad, 0xda, 0xd2
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte k1[] =
+    {
+        0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
+        0x6d, 0x6a, 0x8f, 0x94, 0x67, 0x30, 0x83, 0x08,
+        0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
+        0x6d, 0x6a, 0x8f, 0x94, 0x67, 0x30, 0x83, 0x08
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte iv1[] =
+    {
+        0xca, 0xfe, 0xba, 0xbe, 0xfa, 0xce, 0xdb, 0xad,
+        0xde, 0xca, 0xf8, 0x88
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte c1[] =
+    {
+        0x52, 0x2d, 0xc1, 0xf0, 0x99, 0x56, 0x7d, 0x07,
+        0xf4, 0x7f, 0x37, 0xa3, 0x2a, 0x84, 0x42, 0x7d,
+        0x64, 0x3a, 0x8c, 0xdc, 0xbf, 0xe5, 0xc0, 0xc9,
+        0x75, 0x98, 0xa2, 0xbd, 0x25, 0x55, 0xd1, 0xaa,
+        0x8c, 0xb0, 0x8e, 0x48, 0x59, 0x0d, 0xbb, 0x3d,
+        0xa7, 0xb0, 0x8b, 0x10, 0x56, 0x82, 0x88, 0x38,
+        0xc5, 0xf6, 0x1e, 0x63, 0x93, 0xba, 0x7a, 0x0a,
+        0xbc, 0xc9, 0xf6, 0x62
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte t1[] =
+    {
+        0x76, 0xfc, 0x6e, 0xce, 0x0f, 0x4e, 0x17, 0x68,
+        0xcd, 0xdf, 0x88, 0x53, 0xbb, 0x2d, 0x55, 0x1b
+    };
+
+    byte resultT[sizeof(t1)];
+    byte resultP[sizeof(p) + AES_BLOCK_SIZE];
+    byte resultC[sizeof(p) + AES_BLOCK_SIZE];
+    int  result = 0;
+    int  ret;
+
+    (void) result;
+
+    if (prnt) {
+        printf(" sce_aes256_gcm_test() ");
+    }
+    
+    XMEMSET(resultT, 0, sizeof(resultT));
+    XMEMSET(resultC, 0, sizeof(resultC));
+    XMEMSET(resultP, 0, sizeof(resultP));
+    XMEMSET(&userContext, 0, sizeof(User_SCEPKCbInfo));
+
+    if (wc_AesInit(enc, NULL, INVALID_DEVID) != 0) {
+        ret = -1;
+        goto out;
+    }
+    if (wc_AesInit(dec, NULL, INVALID_DEVID) != 0) {
+        ret = -2;
+        goto out;
+    }
+
+    result = wc_AesGcmSetKey(enc, k1, sizeof(k1));
+    if (result != 0) {
+        ret = -3;
+        goto out;
+    } else {
+        XMEMCPY(&userContext.sce_wrapped_key_aes256, aes256_key,
+                                sizeof(sce_aes_wrapped_key_t));
+        userContext.aes256_installedkey_set = 1;
+        enc->ctx.keySize = (word32)enc->keylen;
+    }
+
+    /* AES-GCM encrypt and decrypt both use AES encrypt internally */
+    result = wc_sce_AesGcmEncrypt(enc, resultC, p, sizeof(p),
+                                (byte*)iv1, sizeof(iv1), 
+                                resultT, sizeof(resultT),
+                                 a, sizeof(a), &userContext);
+
+    if (result != 0) {
+        ret = -4;
+        goto out;
+    }
+
+    result = wc_AesGcmSetKey(dec, k1, sizeof(k1));
+    if (result != 0) {
+        ret = -7;
+        goto out;
+    } else {
+        dec->ctx.keySize = (word32)enc->keylen;
+    }
+
+    result = wc_sce_AesGcmDecrypt(dec, resultP, resultC, sizeof(c1),
+                iv1, sizeof(iv1), resultT, sizeof(resultT),
+                 a, sizeof(a), &userContext);
+    if (result != 0){
+        ret = -8;
+        goto out;
+    }
+    if (XMEMCMP(p, resultP, sizeof(p))) {
+        ret = -9;
+        goto out;
+    }
+
+    XMEMSET(resultT, 0, sizeof(resultT));
+    XMEMSET(resultC, 0, sizeof(resultC));
+    XMEMSET(resultP, 0, sizeof(resultP));
+
+    wc_AesGcmSetKey(enc, k1, sizeof(k1));
+    /* AES-GCM encrypt and decrypt both use AES encrypt internally */
+    result = wc_sce_AesGcmEncrypt(enc, resultC, p, sizeof(p),
+                                (byte*)iv1, sizeof(iv1),
+                                resultT + 1, sizeof(resultT) - 1,
+                                a, sizeof(a), &userContext);
+    if (result != 0) {
+        ret = -10;
+        goto out;
+    }
+
+    result = wc_sce_AesGcmDecrypt(enc, resultP, resultC, sizeof(p),
+              iv1, sizeof(iv1), resultT + 1, sizeof(resultT) - 1, 
+              a, sizeof(a), &userContext);
+
+    if (result != 0) {
+        ret = -11;
+        goto out;
+    }
+    if (XMEMCMP(p, resultP, sizeof(p))) {
+        ret = -12;
+        goto out;
+    }
+
+    ret = 0;
+
+  out:
+    wc_AesFree(enc);
+    wc_AesFree(dec);
+    
+    if (prnt) {
+        RESULT_STR(ret)
+    }
+    
+    return ret;
+}
+
+static void tskAes256_Gcm_Test(void *pvParam)
+{
+    int ret = 0;
+    Info *p = (Info*)pvParam;
+    
+    while (exit_loop == 0) {
+        ret = sce_aesgcm256_test(0, &p->aes_key);
+        vTaskDelay(10/portTICK_PERIOD_MS);
+        if (ret != 0) {
+            printf(" result was not good(%d). sce_aesgcm256_test\n", ret);
+            Aes256_Gcm_multTst_rslt = 1;
+        }
+    }
+
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+}
+#endif
+
+#if defined(WOLFSSL_AES_128)
+
+static int sce_aesgcm128_test(int prnt, sce_aes_wrapped_key_t* aes128_key)
+{
+    Aes enc[1];
+    Aes dec[1];
+    User_SCEPKCbInfo userContext;
+    
+    /*
+     * This is Test Case 16 from the document Galois/
+     * Counter Mode of Operation (GCM) by McGrew and
+     * Viega.
+     */
+    WOLFSSL_SMALL_STACK_STATIC const byte p[] =
+    {
+        0xd9, 0x31, 0x32, 0x25, 0xf8, 0x84, 0x06, 0xe5,
+        0xa5, 0x59, 0x09, 0xc5, 0xaf, 0xf5, 0x26, 0x9a,
+        0x86, 0xa7, 0xa9, 0x53, 0x15, 0x34, 0xf7, 0xda,
+        0x2e, 0x4c, 0x30, 0x3d, 0x8a, 0x31, 0x8a, 0x72,
+        0x1c, 0x3c, 0x0c, 0x95, 0x95, 0x68, 0x09, 0x53,
+        0x2f, 0xcf, 0x0e, 0x24, 0x49, 0xa6, 0xb5, 0x25,
+        0xb1, 0x6a, 0xed, 0xf5, 0xaa, 0x0d, 0xe6, 0x57,
+        0xba, 0x63, 0x7b, 0x39
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte t1[] =
+    {
+        0x76, 0xfc, 0x6e, 0xce, 0x0f, 0x4e, 0x17, 0x68,
+        0xcd, 0xdf, 0x88, 0x53, 0xbb, 0x2d, 0x55, 0x1b
+    };
+
+    /* The following is an interesting test case from the example
+     * FIPS test vectors for AES-GCM. IVlen = 1 byte */
+    WOLFSSL_SMALL_STACK_STATIC const byte p3[] =
+    {
+        0x57, 0xce, 0x45, 0x1f, 0xa5, 0xe2, 0x35, 0xa5,
+        0x8e, 0x1a, 0xa2, 0x3b, 0x77, 0xcb, 0xaf, 0xe2
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte k3[] =
+    {
+        0xbb, 0x01, 0xd7, 0x03, 0x81, 0x1c, 0x10, 0x1a,
+        0x35, 0xe0, 0xff, 0xd2, 0x91, 0xba, 0xf2, 0x4b
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte iv3[] =
+    {
+        0xca
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte c3[] =
+    {
+        0x6b, 0x5f, 0xb3, 0x9d, 0xc1, 0xc5, 0x7a, 0x4f,
+        0xf3, 0x51, 0x4d, 0xc2, 0xd5, 0xf0, 0xd0, 0x07
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte a3[] =
+    {
+        0x40, 0xfc, 0xdc, 0xd7, 0x4a, 0xd7, 0x8b, 0xf1,
+        0x3e, 0x7c, 0x60, 0x55, 0x50, 0x51, 0xdd, 0x54
+    };
+
+    WOLFSSL_SMALL_STACK_STATIC const byte t3[] =
+    {
+        0x06, 0x90, 0xed, 0x01, 0x34, 0xdd, 0xc6, 0x95,
+        0x31, 0x2e, 0x2a, 0xf9, 0x57, 0x7a, 0x1e, 0xa6
+    };
+
+    byte resultT[sizeof(t1)];
+    byte resultP[sizeof(p) + AES_BLOCK_SIZE];
+    byte resultC[sizeof(p) + AES_BLOCK_SIZE];
+    int  result = 0;
+    int ret;
+
+    (void) result;
+
+    if (prnt) {
+        printf(" sce_aes128_gcm_test() ");
+    }
+
+    XMEMSET(resultT, 0, sizeof(resultT));
+    XMEMSET(resultC, 0, sizeof(resultC));
+    XMEMSET(resultP, 0, sizeof(resultP));
+    XMEMSET(&userContext, 0, sizeof(User_SCEPKCbInfo));
+
+    if (wc_AesInit(enc, NULL, INVALID_DEVID) != 0) {
+        ret = -1;
+        goto out;
+    }
+
+    if (wc_AesInit(dec, NULL, INVALID_DEVID) != 0) {
+        ret = -2;
+        goto out;
+    }
+
+    wc_AesGcmSetKey(enc, k3, sizeof(k3));
+    if (result != 0) {
+        ret = -3;
+        goto out;
+    } else {
+        XMEMCPY(&userContext.sce_wrapped_key_aes128, aes128_key,
+                                sizeof(sce_aes_wrapped_key_t));
+        userContext.aes128_installedkey_set = 1;
+        enc->ctx.keySize = (word32)enc->keylen;
+    }
+    /* AES-GCM encrypt and decrypt both use AES encrypt internally */
+    result = wc_AesGcmEncrypt(enc, resultC, p3, sizeof(p3), iv3, sizeof(iv3),
+                                        resultT, sizeof(t3), a3, sizeof(a3));
+    if (result != 0) {
+        ret = -4;
+        goto out;
+    }
+    
+
+    result = wc_AesGcmDecrypt(enc, resultP, resultC, sizeof(c3),
+                      iv3, sizeof(iv3), resultT, sizeof(t3), a3, sizeof(a3));
+    if (result != 0) {
+        ret = -5;
+        goto out;
+    }
+    if (XMEMCMP(p3, resultP, sizeof(p3))) {
+        ret = -6;
+        goto out;
+    }
+
+    ret = 0;
+
+  out:
+    wc_AesFree(enc);
+    wc_AesFree(dec);
+    
+    if (prnt) {
+        RESULT_STR(ret)
+    }
+    
+    return ret;
+}
+
+static void tskAes128_Gcm_Test(void *pvParam)
+{
+    int ret = 0;
+    Info *p = (Info*)pvParam;
+    
+    while (exit_loop == 0) {
+        ret = sce_aesgcm128_test(0, &p->aes_key);
+        vTaskDelay(10/portTICK_PERIOD_MS);
+        if (ret != 0) {
+            printf(" result was not good(%d). sce_aesgcm128_test\n", ret);
+            Aes128_Gcm_multTst_rslt = 1;
+        }
+    }
+
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+}
+
+#endif
+
+int sce_crypt_test()
+{
+    int ret = 0;
+    fsp_err_t sce_error_code;
+
+    /* Generate AES sce Key */
+    sce_error_code = R_SCE_AES128_WrappedKeyGenerate(&g_user_aes128_key_index1);
+    
+    if (sce_error_code == FSP_SUCCESS)
+        sce_error_code = R_SCE_AES128_WrappedKeyGenerate(
+                                                &g_user_aes128_key_index2);
+                        
+    if (sce_error_code == FSP_SUCCESS)
+        sce_error_code = R_SCE_AES256_WrappedKeyGenerate(
+                                                &g_user_aes256_key_index1);
+    
+    if (sce_error_code == FSP_SUCCESS)
+        sce_error_code = R_SCE_AES256_WrappedKeyGenerate(
+                                                &g_user_aes256_key_index2);
+                            
+    if (sce_error_code == FSP_SUCCESS) {
+
+   #ifndef NO_SHA256
+        printf(" sha256_test()");
+        ret = sha256_test();
+        RESULT_STR(ret)
+   #endif
+
+        ret = sce_aes_cbc_test(1, &g_user_aes128_key_index1);
+
+        if (ret == 0) {
+
+            ret = sce_aes256_test(1, &g_user_aes256_key_index1);
+
+        }
+
+        if (ret == 0) {
+
+            ret = sce_aesgcm128_test(1, &g_user_aes128_key_index1);
+
+        }
+        
+        if (ret == 0) {
+
+            ret = sce_aesgcm256_test(1, &g_user_aes256_key_index1);
+
+        }
+    }
+    else
+        ret = -1;
+
+    return ret;
+}
+
+#ifndef NO_SHA256
+
+void tskSha256_Test1(void *pvParam)
+{
+    int ret = 0;
+    (void)pvParam;
+
+    while (exit_loop == 0) {
+        ret = sha256_test();
+        vTaskDelay(10/portTICK_PERIOD_MS);
+        if (ret != 0) {
+            printf(" result was not good(%d). sha_test\n", ret);
+            sha256_multTst_rslt1 = 1;
+        }
+    }
+
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+}
+
+static void tskSha256_Test2(void *pvParam)
+{
+    int ret = 0;
+    (void)pvParam;
+
+    while (exit_loop == 0) {
+        ret = sha256_test();
+        vTaskDelay(10/portTICK_PERIOD_MS);
+        if (ret != 0) {
+            printf(" result was not good(%d). sha256_test\n", ret);
+            sha256_multTst_rslt2 = 1;
+        }
+    }
+
+    xSemaphoreGive(exit_semaph);
+    vTaskDelete(NULL);
+}
+#endif
+
+int sce_crypt_sha256_multitest()
+{
+    int ret = 0;
+    int num = 0;
+    int i;
+    BaseType_t xRet;
+    
+#ifndef NO_SHA256
+    num+=2;
+#endif
+    exit_loop = 0;
+    sha256_multTst_rslt1 = 0;
+    sha256_multTst_rslt2 = 0;
+
+    exit_semaph = xSemaphoreCreateCounting(num, 0);
+    xRet = pdPASS;
+    
+#ifndef NO_SHA256
+    xRet = xTaskCreate(tskSha256_Test1, "sha256_test1",
+                                        STACK_SIZE, NULL, 2, NULL);
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskSha256_Test2, "sha256_test2",
+                                        STACK_SIZE, NULL, 3, NULL);
+#endif
+
+    if (xRet == pdPASS) {
+        printf(" Waiting for completing tasks ...");
+        vTaskDelay(10000/portTICK_PERIOD_MS);
+        exit_loop = true;
+
+        for (i = 0; i < num; i++) {
+            if(!xSemaphoreTake(exit_semaph, 2000/portTICK_PERIOD_MS)) {
+                printf("exit semaphore not released by test task");
+                ret = -1;
+                xRet = pdFAIL;
+            }
+        }
+    }
+    
+    vSemaphoreDelete(exit_semaph);
+    
+    if ((xRet == pdPASS) &&
+       (sha256_multTst_rslt1 == 0 && sha256_multTst_rslt2 == 0))
+        ret = 0;
+    else
+        ret = -1;
+    
+    RESULT_STR(ret)
+
+    return ret;
+}
+
+
+int sce_crypt_AesCbc_multitest()
+{
+    int ret = 0;
+    int num = 0;
+    int i;
+    Info info_aes1;
+    Info info_aes2;
+    Info info_aes256_1;
+    Info info_aes256_2;
+    BaseType_t xRet;
+    
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
+    num+=2;
+#endif
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_256)
+    num+=2;
+#endif
+    exit_loop = 0;
+    Aes128_Cbc_multTst_rslt = 0;
+    Aes256_Cbc_multTst_rslt = 0;
+
+    exit_semaph = xSemaphoreCreateCounting(num, 0);
+    xRet = pdPASS;
+    
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
+    XMEMCPY(&info_aes1.aes_key, &g_user_aes128_key_index1,
+                                            sizeof(sce_aes_wrapped_key_t));
+    xRet = xTaskCreate(tskAes128_Cbc_Test, "aes_cbc_tes1t",
+                                    STACK_SIZE, &info_aes1, 3, NULL);
+#endif
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_128)
+    XMEMCPY(&info_aes2.aes_key, &g_user_aes128_key_index2,
+                                            sizeof(sce_aes_wrapped_key_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes128_Cbc_Test, "aes_cbc_test2",
+                                    STACK_SIZE, &info_aes2, 3, NULL);
+#endif
+
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_256)
+    XMEMCPY(&info_aes256_1.aes_key, &g_user_aes256_key_index1,
+                                            sizeof(sce_aes_wrapped_key_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes256_Cbc_Test, "aes256_cbc_test1",
+                                    STACK_SIZE, &info_aes256_1, 3, NULL);
+#endif
+#if defined(HAVE_AES_CBC) && defined(WOLFSSL_AES_256)
+    XMEMCPY(&info_aes256_2.aes_key, &g_user_aes256_key_index2,
+                                            sizeof(sce_aes_wrapped_key_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes256_Cbc_Test, "aes256_cbc_test2",
+                                    STACK_SIZE, &info_aes256_2, 3, NULL);
+#endif
+    
+    if (xRet == pdPASS) {
+    printf(" Waiting for completing tasks ...   ");
+        vTaskDelay(10000/portTICK_PERIOD_MS);
+        exit_loop = 1;
+
+        for (i = 0; i < num; i++) {
+            if(!xSemaphoreTake(exit_semaph, 2000/portTICK_PERIOD_MS)) {
+                printf("exit semaphore not released by test task");
+                ret = -1;
+                xRet = pdFAIL;
+            }
+        }
+    }
+    
+    vSemaphoreDelete(exit_semaph);
+
+    if ((xRet == pdPASS) &&
+       (Aes128_Cbc_multTst_rslt == 0 && Aes256_Cbc_multTst_rslt == 0))
+        ret = 0;
+    else
+        ret = -1;
+
+    RESULT_STR(ret)
+
+    return ret;
+}
+
+
+int sce_crypt_AesGcm_multitest()
+{
+    int ret = 0;
+    int num = 0;
+    int i;
+    Info info_aes1;
+    Info info_aes2;
+    Info info_aes256_1;
+    Info info_aes256_2;
+    BaseType_t xRet;
+    
+#if defined(WOLFSSL_AES_128)
+    num+=2;
+#endif
+#if defined(WOLFSSL_AES_256)
+    num+=2;
+#endif
+
+    exit_loop = 0;
+    Aes128_Gcm_multTst_rslt = 0;
+    Aes256_Gcm_multTst_rslt = 0;
+
+    exit_semaph = xSemaphoreCreateCounting(num, 0);
+    xRet = pdPASS;
+    
+#if defined(WOLFSSL_AES_128)
+    XMEMCPY(&info_aes1.aes_key, &g_user_aes128_key_index1,
+                                    sizeof(sce_aes_wrapped_key_t));
+    xTaskCreate(tskAes128_Gcm_Test, "aes128_gcm_test1",
+                                    STACK_SIZE, &info_aes1, 3, NULL);
+#endif
+
+#if defined(WOLFSSL_AES_128)
+    XMEMCPY(&info_aes2.aes_key, &g_user_aes128_key_index2,
+                                        sizeof(sce_aes_wrapped_key_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes128_Gcm_Test, "aes128_gcm_test2",
+                                        STACK_SIZE, &info_aes2, 3, NULL);
+#endif
+
+#if defined(WOLFSSL_AES_256)
+    XMEMCPY(&info_aes256_1.aes_key, &g_user_aes256_key_index1,
+                                        sizeof(sce_aes_wrapped_key_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes256_Gcm_Test, "aes256_gcm_test1",
+                                    STACK_SIZE, &info_aes256_1, 3, NULL);
+#endif
+
+#if defined(WOLFSSL_AES_256)
+    XMEMCPY(&info_aes256_2.aes_key, &g_user_aes256_key_index2,
+                                        sizeof(sce_aes_wrapped_key_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes256_Gcm_Test, "aes256_gcm_test2",
+                                    STACK_SIZE, &info_aes256_2, 3, NULL);
+#endif
+
+    if (xRet == pdPASS) {
+        printf(" Waiting for completing tasks ...   ");
+        vTaskDelay(10000/portTICK_PERIOD_MS);
+        exit_loop = 1;
+
+        for (i = 0; i < num; i++) {
+            if(!xSemaphoreTake(exit_semaph, 2000/portTICK_PERIOD_MS)) {
+                printf("exit semaphore not released by test task");
+                ret = -1;
+                xRet = pdFAIL;
+            }
+        }
+    }
+    
+    vSemaphoreDelete(exit_semaph);
+
+    if ((xRet == pdPASS) &&
+        (Aes128_Gcm_multTst_rslt == 0 && Aes256_Gcm_multTst_rslt == 0))
+        ret = 0;
+    else
+        ret = -1;
+
+    RESULT_STR(ret)
+
+    return ret;
+}
+
+int sce_crypt_Sha_AesCbcGcm_multitest()
+{
+    int ret = 0;
+    int num = 0;
+    int i;
+    Info info_aes128cbc;
+    Info info_aes128gcm;
+    Info info_aes256cbc;
+    Info info_aes256gcm;
+    BaseType_t xRet;
+    
+#ifndef NO_SHA256
+    num+=2;
+#endif
+
+#if defined(WOLFSSL_AES_128)
+    num+=2;
+#endif
+#if defined(WOLFSSL_AES_256)
+    num+=2;
+#endif
+
+    exit_loop = 0;
+    sha256_multTst_rslt1 = 0;
+    sha256_multTst_rslt2 = 0;
+    Aes128_Cbc_multTst_rslt = 0;
+    Aes256_Cbc_multTst_rslt = 0;
+    Aes128_Gcm_multTst_rslt = 0;
+    Aes256_Gcm_multTst_rslt = 0;
+
+    exit_semaph = xSemaphoreCreateCounting(num, 0);
+    xRet = pdPASS;
+    
+#ifndef NO_SHA256
+    xRet = xTaskCreate(tskSha256_Test1, "sha256_test1", 
+                                            STACK_SIZE, NULL, 3, NULL);
+
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskSha256_Test2, "sha256_test2", 
+                                            STACK_SIZE, NULL, 3, NULL);
+#endif
+
+#if defined(WOLFSSL_AES_128)
+    XMEMCPY(&info_aes128cbc.aes_key, &g_user_aes128_key_index1, 
+                                                sizeof(sce_aes_wrapped_key_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes128_Cbc_Test, "aes128_cbc_test1", 
+                                    STACK_SIZE, &info_aes128cbc, 3, NULL);
+#endif
+
+#if defined(WOLFSSL_AES_128)
+    XMEMCPY(&info_aes128gcm.aes_key, &g_user_aes128_key_index2, 
+                                                sizeof(sce_aes_wrapped_key_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes128_Gcm_Test, "aes128_gcm_test2", 
+                                    STACK_SIZE, &info_aes128gcm, 3, NULL);
+#endif
+
+#if defined(WOLFSSL_AES_256)
+    XMEMCPY(&info_aes256cbc.aes_key, &g_user_aes256_key_index1, 
+                                                sizeof(sce_aes_wrapped_key_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes256_Cbc_Test, "aes256_cbc_test1", 
+                                    STACK_SIZE, &info_aes256cbc, 3, NULL);
+#endif
+
+#if defined(WOLFSSL_AES_256)
+    XMEMCPY(&info_aes256gcm.aes_key, &g_user_aes256_key_index2, 
+                                                sizeof(sce_aes_wrapped_key_t));
+    if (xRet == pdPASS)
+        xRet = xTaskCreate(tskAes256_Gcm_Test, "aes256_gcm_test2", 
+                                    STACK_SIZE, &info_aes256gcm, 3, NULL);
+#endif
+
+    if (xRet == pdPASS) {
+        printf(" Waiting for completing tasks ...   ");
+        vTaskDelay(10000/portTICK_PERIOD_MS);
+        exit_loop = 1;
+
+        for (i = 0; i < num; i++) {
+            if(!xSemaphoreTake(exit_semaph, 2000/portTICK_PERIOD_MS)) {
+                printf("exit semaphore not released by test task");
+                ret = -1;
+                xRet = pdFAIL;
+            }
+        }
+    }
+    
+    vSemaphoreDelete(exit_semaph);
+    
+    if ((xRet == pdPASS) && 
+        (Aes128_Gcm_multTst_rslt == 0 && Aes256_Gcm_multTst_rslt == 0) &&
+        (Aes128_Gcm_multTst_rslt == 0 && Aes256_Gcm_multTst_rslt == 0) &&
+        (sha256_multTst_rslt1 == 0 && sha256_multTst_rslt2 == 0)) {
+        
+        ret = 0;
+    }
+    else {
+        ret = -1;
+    }
+    
+    RESULT_STR(ret)
+
+    return ret;
+}
+

--- a/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/test_main.c
+++ b/IDE/Renesas/e2studio/RX65N/GR-ROSE/test/src/test_main.c
@@ -96,9 +96,6 @@ int SetTsiptlsKey()
             (byte*)&g_key_block_data.encrypted_user_rsa2048_ne_key,
             encrypted_user_key_type);
 
-    #if defined(WOLFSSL_RENESAS_TSIP_TLS) 
-    guser_PKCbInfo.user_key_id = 0;
-    #endif
 
 #elif defined(TLS_SERVER)
 

--- a/IDE/Renesas/e2studio/RX65N/RSK/wolfssl_demo/wolfssl_demo.c
+++ b/IDE/Renesas/e2studio/RX65N/RSK/wolfssl_demo/wolfssl_demo.c
@@ -371,7 +371,6 @@ static void Tls_client_demo(void)
             (byte*)&g_key_block_data.encrypted_user_rsa2048_ne_key,
             encrypted_user_key_type);
 
-    guser_PKCbInfo.user_key_id = 0;
 
 #endif /* WOLFSSL_RENESAS_TSIP_TLS && (WOLFSSL_RENESAS_TSIP_VER >=109) */
 

--- a/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
+++ b/IDE/Renesas/e2studio/RX72N/EnvisionKit/wolfssl_demo/wolfssl_demo.c
@@ -377,8 +377,6 @@ static void Tls_client_demo(void)
             (byte*)&g_key_block_data.encrypted_user_rsa2048_ne_key,
             encrypted_user_key_type);
 
-    guser_PKCbInfo.user_key_id = 0;
-
 #endif /* WOLFSSL_RENESAS_TSIP_TLS && (WOLFSSL_RENESAS_TSIP_VER >=109) */
 
     do {

--- a/wolfcrypt/src/port/Renesas/renesas_common.c
+++ b/wolfcrypt/src/port/Renesas/renesas_common.c
@@ -37,8 +37,8 @@
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/logging.h>
 
-uint32_t     g_CAscm_Idx = (uint32_t)-1; /* index of CM table    */
-static int devId = 7890;                 /* dev Id for Crypt Callback */
+uint32_t   g_CAscm_Idx = (uint32_t)-1; /* index of CM table    */
+static int gdevId = 7890;           /* initial dev Id for Crypt Callback */
 
 #ifdef WOLF_CRYPTO_CB
 
@@ -312,6 +312,8 @@ int Renesas_cmn_usable(const WOLFSSL* ssl, byte session_key_generated)
  * ssl     : a pointer to WOLFSSL object
  * ctx     : callback context
  * return  valid device Id on success, otherwise INVALID_DEVIID
+ *         device Id starts from 7890, and increases + 1 its number 
+ *         when the method is successfully called.
  */
 int wc_CryptoCb_CryptInitRenesasCmn(WOLFSSL* ssl, void* ctx)
 {
@@ -324,14 +326,28 @@ int wc_CryptoCb_CryptInitRenesasCmn(WOLFSSL* ssl, void* ctx)
     User_SCEPKCbInfo* cbInfo = (User_SCEPKCbInfo*)ctx;
  #endif
 
-    if (wc_CryptoCb_RegisterDevice(devId, Renesas_cmn_CryptoDevCb, cbInfo) < 0) {
+    if (cbInfo == NULL || ssl == NULL) {
+        return INVALID_DEVID;
+    }
+
+    cbInfo->devId = gdevId++;
+
+    if (wc_CryptoCb_RegisterDevice(cbInfo->devId, 
+                            Renesas_cmn_CryptoDevCb, cbInfo) < 0) {
+        /* undo devId number */
+        gdevId--;
         return INVALID_DEVID;
     }
 
     if (ssl)
-        wolfSSL_SetDevId(ssl, devId);
+        wolfSSL_SetDevId(ssl, cbInfo->devId);
 
-    return devId;
+    /* sanity check for overflow */
+    if (gdevId < 0) {
+        gdevId = 7890;
+    }
+    
+    return cbInfo->devId;
 }
 
 /* Renesas Security Library Common Method
@@ -594,16 +610,19 @@ static int Renesas_cmn_EncryptKeys(WOLFSSL* ssl, void* ctx)
 WOLFSSL_LOCAL int Renesas_cmn_generateSessionKey(WOLFSSL* ssl, void* ctx)
 {
     int ret = -1;
-
-    (void)ctx;
-
-    WOLFSSL_ENTER("Renesas_cmn_generateSessionKey");
-
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
-    ret = wc_tsip_generateSessionKey(ssl, (TsipUserCtx*)ctx, devId);
+    TsipUserCtx*      cbInfo = (TsipUserCtx*)ctx;
+#elif defined(WOLFSSL_RENESAS_SCEPROTECT)
+    User_SCEPKCbInfo* cbInfo = (User_SCEPKCbInfo*)ctx;
+#endif
+    (void)ctx;
+ 
+    WOLFSSL_ENTER("Renesas_cmn_generateSessionKey");
+#if defined(WOLFSSL_RENESAS_TSIP_TLS)
+        ret = wc_tsip_generateSessionKey(ssl, (TsipUserCtx*)ctx, cbInfo->devId);
 #elif defined(WOLFSSL_RENESAS_SCEPROTECT)
     if (Renesas_cmn_usable(ssl, 0)) {
-         ret = wc_sce_generateSessionKey(ssl, ctx, devId);
+         ret = wc_sce_generateSessionKey(ssl, ctx, cbInfo->devId);
     } else
          ret = PROTOCOLCB_UNAVAILABLE;
 #endif
@@ -901,8 +920,8 @@ WOLFSSL_LOCAL int Renesas_cmn_TLS_hmac(WOLFSSL* ssl, byte* digest,
     if (Renesas_cmn_usable(ssl, 1)) {
         if (ssl->specs.hash_size == WC_SHA256_DIGEST_SIZE) {
             wolfSSL_SetTlsHmacInner(ssl, myInner, sz, content, verify);
-            ret = wc_sce_Sha256GenerateHmac(ssl, myInner, WOLFSSL_TLS_HMAC_INNER_SZ,
-                                                                in, sz, digest);
+            ret = wc_sce_Sha256GenerateHmac(ssl, myInner, 
+                                    WOLFSSL_TLS_HMAC_INNER_SZ, in, sz, digest);
         }
         else
             ret = TSIP_MAC_DIGSZ_E;

--- a/wolfssl/wolfcrypt/port/Renesas/renesas-sce-crypt.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas-sce-crypt.h
@@ -35,7 +35,8 @@ extern "C" {
 #define MAX_SCE_CBINDEX 5
 
 typedef struct tagUser_SCEPKCbInfo {
-    uint32_t user_key_id;
+    /* unique number for each session */
+    int devId;
     
     /* out from R_SCE_TLS_ServerKeyExchangeVerify */
     uint32_t encrypted_ephemeral_ecdh_public_key[SCE_TLS_ENCRYPTED_ECCPUBKEY_SZ];

--- a/wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h
+++ b/wolfssl/wolfcrypt/port/Renesas/renesas-tsip-crypt.h
@@ -120,22 +120,22 @@ typedef wolfssl_TSIP_Hash wc_Sha;
  * structure for ECDH key exchange
  */
 typedef struct TsipUserCtx {
+    /* unique number for each session */
+    int devId;
     
-    uint32_t user_key_id;
-
-#if (WOLFSSL_RENESAS_TSIP_VER >=109)     
+#if (WOLFSSL_RENESAS_TSIP_VER >=109)
     /* out from R_SCE_TLS_ServerKeyExchangeVerify */
     uint32_t encrypted_ephemeral_ecdh_public_key[ENCRYPTED_ECDHE_PUBKEY_SZ];
     
     /* ephemeral ECDH pubkey index 
      * got from R_TSIP_GenerateTlsP256EccKeyIndex.
-     * Input to R_TSIP_TlsGeneratePreMasterSecretWithEccP256Key. 
+     * Input to R_TSIP_TlsGeneratePreMasterSecretWithEccP256Key.
      */
     tsip_tls_p256_ecc_key_index_t ecc_p256_wrapped_key;
 
     /* ephemeral ECDH pub-key Qx(256bit)||Qy(256bit) 
      * got from  R_TSIP_GenerateTlsP256EccKeyIndex.
-     * Should be sent to peer(server) in Client Key Exchange msg. 
+     * Should be sent to peer(server) in Client Key Exchange msg.
      */
     uint8_t ecc_ecdh_public_key[ECCP256_PUBKEY_SZ];
 #endif /* WOLFSSL_RENESAS_TSIP_VER >=109 */


### PR DESCRIPTION
# Description

Fix multi threads use case with Renesas SEC protected mode/TSIP
Add multi Client session use case for RA6M4 board

The PR includes:

-  Fix devId conflict while using multi threads for both SCE and TSIP
-  Add crypt only unit test for RA6M4
-  Update README for RA6M4 because of adding multi client session example
-  Update TSIP examples because of updating user context

# Testing

Multi clients using SCE protected mode communicate servers simultaneously.

# Checklist

 - [x] added tests
 - [ ] updated/added doxygen
 - [x] updated appropriate READMEs
 - [ ] Updated manual and documentation
