### PR TITLE
Check memory is zeroized

### DIFF
--- a/src/keys.c
+++ b/src/keys.c
@@ -2232,11 +2232,21 @@ static int SetKeys(Ciphers* enc, Ciphers* dec, Keys* keys, CipherSpecs* specs,
                     (ChaCha*)XMALLOC(sizeof(ChaCha), heap, DYNAMIC_TYPE_CIPHER);
         if (enc && enc->chacha == NULL)
             return MEMORY_E;
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        if (enc) {
+            wc_MemZero_Add("SSL keys enc chacha", enc->chacha, sizeof(ChaCha));
+        }
+    #endif
         if (dec && dec->chacha == NULL)
             dec->chacha =
                     (ChaCha*)XMALLOC(sizeof(ChaCha), heap, DYNAMIC_TYPE_CIPHER);
         if (dec && dec->chacha == NULL)
             return MEMORY_E;
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        if (dec) {
+            wc_MemZero_Add("SSL keys dec chacha", dec->chacha, sizeof(ChaCha));
+        }
+    #endif
         if (side == WOLFSSL_CLIENT_END) {
             if (enc) {
                 chachaRet = wc_Chacha_SetKey(enc->chacha, keys->client_write_key,
@@ -2822,6 +2832,10 @@ static int SetAuthKeys(OneTimeAuth* authentication, Keys* keys,
                 (Poly1305*)XMALLOC(sizeof(Poly1305), heap, DYNAMIC_TYPE_CIPHER);
         if (authentication && authentication->poly1305 == NULL)
             return MEMORY_E;
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Add("SSL auth keys poly1305", authentication->poly1305,
+            sizeof(Poly1305));
+    #endif
         if (authentication)
             authentication->setup = 1;
 #endif

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -6275,6 +6275,9 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
                 FreeDer(&ssl->buffers.key);
             }
             ssl->buffers.key = der;
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+            wc_MemZero_Add("SSL Buffers key", der->buffer, der->length);
+#endif
             ssl->buffers.weOwnKey = 1;
         }
         else if (ctx != NULL) {
@@ -6283,6 +6286,9 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
             }
             FreeDer(&ctx->privateKey);
             ctx->privateKey = der;
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+            wc_MemZero_Add("CTX private key", der->buffer, der->length);
+#endif
         }
     }
     else {
@@ -6319,6 +6325,9 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
                 info->passwd_userdata);
             if (ret >= 0) {
                 passwordSz = ret;
+            #ifdef WOLFSSL_CHECK_MEM_ZERO
+                wc_MemZero_Add("ProcessBuffer password", password, passwordSz);
+            #endif
 
                 /* PKCS8 decrypt */
                 ret = ToTraditionalEnc(der->buffer, der->length,
@@ -6334,6 +6343,8 @@ int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
 
         #ifdef WOLFSSL_SMALL_STACK
             XFREE(password, heap, DYNAMIC_TYPE_STRING);
+        #elif defined(WOLFSSL_CHECK_MEM_ZERO)
+            wc_MemZero_Check(password, NAME_SZ);
         #endif
             ret = ProcessBufferTryDecode(ctx, ssl, der, &keySz, &idx,
                 &resetSuites, &keyFormat, heap, devId);
@@ -11701,6 +11712,11 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         }
         ssl->buffers.dtlsCookieSecret.buffer = newSecret;
         ssl->buffers.dtlsCookieSecret.length = secretSz;
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Add("wolfSSL_DTLS_SetCookieSecret secret",
+            ssl->buffers.dtlsCookieSecret.buffer,
+            ssl->buffers.dtlsCookieSecret.length);
+    #endif
     }
 
     /* If the supplied secret is NULL, randomly generate a new secret. */
@@ -19469,6 +19485,10 @@ WOLFSSL_SESSION* wolfSSL_NewSession(void* heap)
         ret->type = WOLFSSL_SESSION_TYPE_HEAP;
         ret->heap = heap;
         ret->masterSecret = ret->_masterSecret;
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Add("SESSION master secret", ret->masterSecret, SECRET_LEN);
+        wc_MemZero_Add("SESSION id", ret->sessionID, ID_LEN);
+#endif
     #ifndef NO_CLIENT_CACHE
         ret->serverID = ret->_serverID;
     #endif
@@ -36754,6 +36774,10 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PKCS8PrivateKey_bio(WOLFSSL_BIO* bio,
             XFREE(der, bio->heap, DYNAMIC_TYPE_OPENSSL);
             return NULL;
         }
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Add("wolfSSL_d2i_PKCS8PrivateKey_bio password", password,
+            passwordSz);
+    #endif
 
         ret = ToTraditionalEnc(der, len, password, passwordSz, &algId);
         if (ret < 0) {
@@ -36762,6 +36786,9 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PKCS8PrivateKey_bio(WOLFSSL_BIO* bio,
         }
 
         ForceZero(password, passwordSz);
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Check(password, passwordSz);
+    #endif
     }
 
     p = der;
@@ -37798,6 +37825,10 @@ int wolfSSL_RAND_write_file(const char* fname)
         else {
             XFILE f;
 
+        #ifdef WOLFSSL_CHECK_MEM_ZERO
+            wc_MemZero_Add("wolfSSL_RAND_write_file buf", buf, bytes);
+        #endif
+
             f = XFOPEN(fname, "wb");
             if (f == XBADFILE) {
                 WOLFSSL_MSG("Error opening the file");
@@ -37811,6 +37842,8 @@ int wolfSSL_RAND_write_file(const char* fname)
         ForceZero(buf, bytes);
     #ifdef WOLFSSL_SMALL_STACK
         XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    #elif defined(WOLFSSL_CHECK_MEM_ZERO)
+        wc_MemZero_Check(buf, sizeof(buf));
     #endif
     }
 #endif
@@ -37878,6 +37911,11 @@ int wolfSSL_RAND_egd(const char* nm)
         ret = WOLFSSL_FATAL_ERROR;
     }
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    if (ret == WOLFSSL_SUCCESS) {
+        wc_MemZero_Add("wolfSSL_RAND_egd buf", buf, 256);
+    }
+#endif
     while (ret == WOLFSSL_SUCCESS && bytes < 255 && idx + 2 < 256) {
         buf[idx]     = WOLFSSL_EGD_NBLOCK;
         buf[idx + 1] = 255 - bytes; /* request 255 bytes from server */
@@ -37956,9 +37994,11 @@ int wolfSSL_RAND_egd(const char* nm)
     }
 
     ForceZero(buf, bytes);
-    #ifdef WOLFSSL_SMALL_STACK
+#ifdef WOLFSSL_SMALL_STACK
     XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    #endif
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    wc_MemZero_Check(buf, 256);
+#endif
     close(fd);
 
     if (ret == WOLFSSL_SUCCESS) {

--- a/src/tls.c
+++ b/src/tls.c
@@ -157,6 +157,9 @@ int BuildTlsHandshakeHash(WOLFSSL* ssl, byte* hash, word32* hashLen)
     }
 
     *hashLen = hashSz;
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+     wc_MemZero_Add("TLS hasndshake hash", hash, hashSz);
+#endif
 
     if (ret != 0)
         ret = BUILD_MSG_ERROR;
@@ -226,6 +229,8 @@ int BuildTlsFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
 
 #if defined(WOLFSSL_ASYNC_CRYPT) && !defined(WC_ASYNC_NO_HASH)
     WC_FREE_VAR(handshake_hash, ssl->heap);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    wc_MemZero_Check(handshake_hash, HSHASH_SZ);
 #endif
 
     return ret;
@@ -530,6 +535,8 @@ int MakeTlsMasterSecret(WOLFSSL* ssl)
 
     #ifdef WOLFSSL_SMALL_STACK
         XFREE(handshake_hash, ssl->heap, DYNAMIC_TYPE_DIGEST);
+    #elif defined(WOLFSSL_CHECK_MEM_ZERO)
+        wc_MemZero_Check(handshake_hash, HSHASH_SZ);
     #endif
     }
     else

--- a/tests/api.c
+++ b/tests/api.c
@@ -19107,6 +19107,10 @@ static int test_wc_RsaKeyToDer (void)
                 /* Try Public Key. */
                 genKey.type = 0;
                 ret = wc_RsaKeyToDer(&genKey, der, FOURK_BUF);
+            #ifdef WOLFSSL_CHECK_MEM_ZERO
+                /* Put back to Private Key */
+                genKey.type = 1;
+            #endif
             }
             if (ret == BAD_FUNC_ARG) {
                 ret = 0;
@@ -19126,6 +19130,10 @@ static int test_wc_RsaKeyToDer (void)
                 /* Try Public Key. */
                 genKey.type = 0;
                 ret = wc_RsaKeyToDer(&genKey, der, FOURK_BUF);
+            #ifdef WOLFSSL_CHECK_MEM_ZERO
+                /* Put back to Private Key */
+                genKey.type = 1;
+            #endif
             }
             if (ret == USER_CRYPTO_ERROR) {
                 ret = 0;

--- a/wolfcrypt/src/chacha20_poly1305.c
+++ b/wolfcrypt/src/chacha20_poly1305.c
@@ -383,6 +383,11 @@ static WC_INLINE int wc_XChaCha20Poly1305_crypt_oneshot(
                                          key, (word32)key_len, 1)) < 0)
         goto out;
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Add("wc_XChaCha20Poly1305_crypt_oneshot aead", aead,
+        sizeof(ChaChaPoly_Aead));
+#endif
+
     /* process the input in 16k pieces to accommodate src_lens that don't fit in a word32,
      * and to exploit hot cache for the input data.
      */
@@ -439,6 +444,8 @@ static WC_INLINE int wc_XChaCha20Poly1305_crypt_oneshot(
 
 #if defined(WOLFSSL_SMALL_STACK) && !defined(WOLFSSL_NO_MALLOC)
     XFREE(aead, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    wc_MemZero_Check(aead, sizeof(ChaChaPoly_Aead));
 #endif
 
     return ret;

--- a/wolfcrypt/src/cmac.c
+++ b/wolfcrypt/src/cmac.c
@@ -278,6 +278,11 @@ int wc_AesCmacGenerate(byte* out, word32* outSz,
         return MEMORY_E;
     }
 #endif
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    /* Aes part is checked by wc_AesFree. */
+    wc_MemZero_Add("wc_AesCmacGenerate cmac",
+        ((unsigned char *)cmac) + sizeof(Aes), sizeof(Cmac) - sizeof(Aes));
+#endif
 
     ret = wc_InitCmac(cmac, key, keySz, WC_CMAC_AES, NULL);
     if (ret == 0) {
@@ -291,6 +296,8 @@ int wc_AesCmacGenerate(byte* out, word32* outSz,
     if (cmac) {
         XFREE(cmac, NULL, DYNAMIC_TYPE_CMAC);
     }
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    wc_MemZero_Check(cmac, sizeof(Cmac));
 #endif
 
     return ret;

--- a/wolfcrypt/src/curve25519.c
+++ b/wolfcrypt/src/curve25519.c
@@ -665,6 +665,10 @@ int wc_curve25519_init_ex(curve25519_key* key, void* heap, int devId)
     fe_init();
 #endif
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Add("wc_curve25519_init_ex key->k", key->k, CURVE25519_KEYSIZE);
+#endif
+
     return 0;
 }
 
@@ -688,6 +692,9 @@ void wc_curve25519_free(curve25519_key* key)
     XMEMSET(&key->p, 0, sizeof(key->p));
     key->pubSet = 0;
     key->privSet = 0;
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Check(key, sizeof(curve25519_key));
+#endif
 }
 
 /* get key size */

--- a/wolfcrypt/src/curve448.c
+++ b/wolfcrypt/src/curve448.c
@@ -684,6 +684,10 @@ int wc_curve448_init(curve448_key* key)
         XMEMSET(key, 0, sizeof(*key));
 
         fe448_init();
+
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Add("wc_curve448_init key->k", &key->k, CURVE448_KEY_SIZE);
+    #endif
     }
 
     return ret;
@@ -701,6 +705,9 @@ void wc_curve448_free(curve448_key* key)
         XMEMSET(key->p, 0, sizeof(key->p));
         key->pubSet = 0;
         key->privSet = 0;
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Check(key, sizeof(curve448_key));
+    #endif
     }
 }
 

--- a/wolfcrypt/src/des3.c
+++ b/wolfcrypt/src/des3.c
@@ -1870,6 +1870,10 @@ int wc_Des3Init(Des3* des3, void* heap, int devId)
     ret = wolfAsync_DevCtxInit(&des3->asyncDev, WOLFSSL_ASYNC_MARKER_3DES,
                                                         des3->heap, devId);
 #endif
+#if defined(WOLFSSL_CHECK_MEM_ZERO) && (defined(WOLF_CRYPTO_CB) || \
+        (defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_3DES)))
+    wc_MemZero_Add("DES3 devKey", &des3->devKey, sizeof(des3->devKey));
+#endif
 
     return ret;
 }
@@ -1886,6 +1890,9 @@ void wc_Des3Free(Des3* des3)
 #if defined(WOLF_CRYPTO_CB) || \
         (defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_3DES))
     ForceZero(des3->devKey, sizeof(des3->devKey));
+#endif
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Check(des3, sizeof(Des3));
 #endif
 }
 

--- a/wolfcrypt/src/ed25519.c
+++ b/wolfcrypt/src/ed25519.c
@@ -870,6 +870,10 @@ int wc_ed25519_init_ex(ed25519_key* key, void* heap, int devId)
     fe_init();
 #endif
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Add("wc_ed25519_init_ex key->k", &key->k, sizeof(key->k));
+#endif
+
 #ifdef WOLFSSL_ED25519_PERSISTENT_SHA
     return ed25519_hash_init(key, &key->sha);
 #else /* !WOLFSSL_ED25519_PERSISTENT_SHA */
@@ -897,6 +901,9 @@ void wc_ed25519_free(ed25519_key* key)
 #endif
 
     ForceZero(key, sizeof(ed25519_key));
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Check(key, sizeof(ed25519_key));
+#endif
 }
 
 

--- a/wolfcrypt/src/ed448.c
+++ b/wolfcrypt/src/ed448.c
@@ -814,6 +814,10 @@ int wc_ed448_init_ex(ed448_key* key, void *heap, int devId)
 
     fe448_init();
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Add("wc_ed448_init_ex key->k", &key->k, sizeof(key->k));
+#endif
+
 #ifdef WOLFSSL_ED448_PERSISTENT_SHA
     return ed448_hash_init(key, &key->sha);
 #else /* !WOLFSSL_ED448_PERSISTENT_SHA */
@@ -841,6 +845,9 @@ void wc_ed448_free(ed448_key* key)
         ed448_hash_free(key, &key->sha);
 #endif
         ForceZero(key, sizeof(ed448_key));
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Check(key, sizeof(ed448_key));
+    #endif
     }
 }
 

--- a/wolfcrypt/src/kdf.c
+++ b/wolfcrypt/src/kdf.c
@@ -100,6 +100,12 @@ int wc_PRF(byte* result, word32 resLen, const byte* secret,
     }
 #endif
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Add("wc_PRF previous", previous, P_HASH_MAX_SIZE);
+    wc_MemZero_Add("wc_PRF current", current, P_HASH_MAX_SIZE);
+    wc_MemZero_Add("wc_PRF hmac", hmac, sizeof(Hmac));
+#endif
+
     switch (hash) {
     #ifndef NO_MD5
         case md5_mac:
@@ -197,6 +203,10 @@ int wc_PRF(byte* result, word32 resLen, const byte* secret,
     XFREE(previous, heap, DYNAMIC_TYPE_DIGEST);
     XFREE(current,  heap, DYNAMIC_TYPE_DIGEST);
     XFREE(hmac,     heap, DYNAMIC_TYPE_HMAC);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    wc_MemZero_Check(previous, P_HASH_MAX_SIZE);
+    wc_MemZero_Check(current,  P_HASH_MAX_SIZE);
+    wc_MemZero_Check(hmac,     sizeof(Hmac));
 #endif
 
     return ret;
@@ -258,6 +268,9 @@ int wc_PRF_TLSv1(byte* digest, word32 digLen, const byte* secret,
                                 labLen + seedLen, md5_mac, heap, devId)) == 0) {
         if ((ret = wc_PRF(sha_result, digLen, sha_half, half, labelSeed,
                                 labLen + seedLen, sha_mac, heap, devId)) == 0) {
+        #ifdef WOLFSSL_CHECK_MEM_ZERO
+            wc_MemZero_Add("wc_PRF_TLSv1 sha_result", sha_result, digLen);
+        #endif
             /* calculate XOR for TLSv1 PRF */
             /* md5 result is placed directly in digest */
             xorbuf(digest, sha_result, digLen);
@@ -267,6 +280,8 @@ int wc_PRF_TLSv1(byte* digest, word32 digLen, const byte* secret,
 
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(sha_result, heap, DYNAMIC_TYPE_DIGEST);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    wc_MemZero_Check(sha_result, MAX_PRF_DIG);
 #endif
 
 #if defined(WOLFSSL_ASYNC_CRYPT) && !defined(WC_ASYNC_NO_HASH)
@@ -434,6 +449,10 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
         XMEMCPY(&data[idx], info, infoLen);
         idx += infoLen;
 
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Add("wc_Tls13_HKDF_Expand_Label data", data, idx);
+    #endif
+
 #ifdef WOLFSSL_DEBUG_TLS
         WOLFSSL_MSG("  PRK");
         WOLFSSL_BUFFER(prk, prkLen);
@@ -450,6 +469,9 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
 
         ForceZero(data, idx);
 
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Check(data, MAX_TLS13_HKDF_LABEL_SZ);
+    #endif
         return ret;
     }
 

--- a/wolfcrypt/src/random.c
+++ b/wolfcrypt/src/random.c
@@ -891,6 +891,14 @@ static int _InitRng(WC_RNG* rng, byte* nonce, word32 nonceSz,
         ret = DRBG_CONT_FAILURE;
 
     if (ret == DRBG_SUCCESS) {
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+#ifdef HAVE_HASHDRBG
+        struct DRBG_internal* drbg = (struct DRBG_internal*)rng->drbg;
+        wc_MemZero_Add("DRBG V", &drbg->V, sizeof(drbg->V));
+        wc_MemZero_Add("DRBG C", &drbg->C, sizeof(drbg->C));
+#endif
+#endif
+
         rng->status = DRBG_OK;
         ret = 0;
     }
@@ -1095,6 +1103,8 @@ int wc_FreeRng(WC_RNG* rng)
 
     #if !defined(WOLFSSL_NO_MALLOC) || defined(WOLFSSL_STATIC_MEMORY)
         XFREE(rng->drbg, rng->heap, DYNAMIC_TYPE_RNG);
+    #elif defined(WOLFSSL_CHECK_MEM_ZERO)
+        wc_MemZero_Check(rng->drbg, sizeof(DRBG_internal));
     #endif
         rng->drbg = NULL;
     }

--- a/wolfcrypt/src/rsa.c
+++ b/wolfcrypt/src/rsa.c
@@ -609,6 +609,10 @@ int wc_FreeRsaKey(RsaKey* key)
     KcapiRsa_Free(key);
 #endif
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Check(key, sizeof(RsaKey));
+#endif
+
     return ret;
 }
 
@@ -633,6 +637,9 @@ static int _ifc_pairwise_consistency_test(RsaKey* key, WC_RNG* rng)
         return MEMORY_E;
     }
     XMEMSET(sig, 0, sigLen);
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Add("Pairwise CT sig", sig, sigLen);
+#endif
     plain = sig;
 
 #ifdef WOLFSSL_ASYNC_CRYPT
@@ -735,6 +742,9 @@ int wc_CheckRsaKey(RsaKey* key)
     }
     /* Check p*q = n. */
     if (ret == 0 ) {
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        mp_memzero_add("RSA CheckKey tmp", tmp);
+    #endif
         if (mp_mul(&key->p, &key->q, tmp) != MP_OKAY) {
             ret = MP_EXPTMOD_E;
         }
@@ -834,6 +844,8 @@ int wc_CheckRsaKey(RsaKey* key)
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(tmp, NULL, DYNAMIC_TYPE_RSA);
     XFREE(rng, NULL, DYNAMIC_TYPE_RNG);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    mp_memzero_check(tmp);
 #endif
 
     return ret;
@@ -1213,12 +1225,18 @@ static int RsaPad_OAEP(const byte* input, word32 inputLen, byte* pkcsBlock,
         pkcsBlock[idx] = pkcsBlock[idx] ^ seed[i++];
         idx++;
     }
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    /* Seed must be zeroized now that it has been used. */
+    wc_MemZero_Add("Pad OAEP seed", seed, hLen);
+#endif
 
     /* Zeroize masking bytes so that padding can't be unmasked. */
     ForceZero(seed, hLen);
     #ifdef WOLFSSL_SMALL_STACK
         XFREE(lHash, heap, DYNAMIC_TYPE_RSA_BUFFER);
         XFREE(seed,  heap, DYNAMIC_TYPE_RSA_BUFFER);
+    #elif defined(WOLFSSL_CHECK_MEM_ZERO)
+        wc_MemZero_Check(seed, hLen);
     #endif
     (void)padValue;
 
@@ -1545,6 +1563,7 @@ static int RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
 #else
     byte tmp[RSA_MAX_SIZE/8 + RSA_PSS_PAD_SZ];
 #endif
+
     /* no label is allowed, but catch if no label provided and length > 0 */
     if (optLabel == NULL && labelLen > 0) {
         return BUFFER_E;
@@ -1562,6 +1581,9 @@ static int RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
     }
 #endif
     XMEMSET(tmp, 0, pkcsBlockLen);
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Add("OAEP UnPad temp", tmp, pkcsBlockLen);
+#endif
 
     /* find seedMask value */
     if ((ret = RsaMGF(mgf, (byte*)(pkcsBlock + (hLen + 1)),
@@ -1583,6 +1605,8 @@ static int RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
         ForceZero(tmp, hLen);
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(tmp, NULL, DYNAMIC_TYPE_RSA_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+        wc_MemZero_Check(tmp, hLen);
 #endif
         return ret;
     }
@@ -1596,6 +1620,8 @@ static int RsaUnPad_OAEP(byte *pkcsBlock, unsigned int pkcsBlockLen,
 #ifdef WOLFSSL_SMALL_STACK
     /* done with use of tmp buffer */
     XFREE(tmp, heap, DYNAMIC_TYPE_RSA_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    wc_MemZero_Check(tmp, pkcsBlockLen);
 #endif
 
     /* advance idx to index of PS and msg separator, account for PS size of 0*/
@@ -2200,6 +2226,11 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
                         != MP_OKAY) {
                     ERROR_OUT(MP_TO_E);
                 }
+            #ifdef WOLFSSL_CHECK_MEM_ZERO
+                /* Seed must be zeroized now that it has been used. */
+                wc_MemZero_Add("RSA Sync Priv Enc/Dec keyBuf", keyBuf + keyLen,
+                    keyBufSz);
+            #endif
             }
             break;
 
@@ -2505,6 +2536,12 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
     if (ret == 0 && mp_read_unsigned_bin(tmp, in, inLen) != MP_OKAY)
         ret = MP_READ_E;
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    if (ret == 0) {
+        mp_memzero_add("RSA sync tmp", tmp);
+    }
+#endif
+
     if (ret == 0) {
         switch(type) {
     #if !defined(WOLFSSL_RSA_PUBLIC_ONLY) && !defined(WOLFSSL_RSA_VERIFY_ONLY)
@@ -2521,6 +2558,10 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
                 ret = MP_INVMOD_E;
                 break;
             }
+        #ifdef WOLFSSL_CHECK_MEM_ZERO
+            mp_memzero_add("RSA sync rnd", rnd);
+            mp_memzero_add("RSA sync rndi", rndi);
+        #endif
 
             /* rnd = rnd^e */
         #ifndef WOLFSSL_SP_MATH_ALL
@@ -2580,6 +2621,13 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
                         clearb = 1;
                 }
 
+            #ifdef WOLFSSL_CHECK_MEM_ZERO
+                if (ret == 0) {
+                    mp_memzero_add("RSA Sync tmpa", tmpa);
+                    mp_memzero_add("RSA Sync tmpb", tmpb);
+                }
+            #endif
+
                 /* tmpa = tmp^dP mod p */
                 if (ret == 0 && mp_exptmod(tmp, &key->dP, &key->p,
                                                                tmpa) != MP_OKAY)
@@ -2624,6 +2672,9 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
             #ifdef WOLFSSL_SMALL_STACK
                     /* tmpb is allocated after tmpa. */
                     XFREE(tmpa, key->heap, DYNAMIC_TYPE_RSA);
+            #elif defined(WOLFSSL_CHECK_MEM_ZERO)
+                    mp_memzero_check(tmpb);
+                    mp_memzero_check(tmpa);
             #endif
                 }
             } /* tmpa/b scope */
@@ -2669,6 +2720,8 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
     mp_forcezero(tmp);
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(tmp, key->heap, DYNAMIC_TYPE_RSA);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    mp_memzero_check(tmp);
 #endif
 #ifdef WC_RSA_BLINDING
     if (type == RSA_PRIVATE_DECRYPT || type == RSA_PRIVATE_ENCRYPT) {
@@ -2677,6 +2730,11 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
     }
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(rnd, key->heap, DYNAMIC_TYPE_RSA);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    if (type == RSA_PRIVATE_DECRYPT || type == RSA_PRIVATE_ENCRYPT) {
+        mp_memzero_check(rnd);
+        mp_memzero_check(rndi);
+    }
 #endif
 #endif /* WC_RSA_BLINDING */
     return ret;
@@ -4193,6 +4251,11 @@ static int wc_CompareDiffPQ(mp_int* p, mp_int* q, int size)
     if (ret == 0)
         ret = mp_sub(p, q, d);
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    if (ret == 0)
+        mp_memzero_add("Comare PQ d", d);
+#endif
+
 #if !defined(WOLFSSL_SP_MATH) && (!defined(WOLFSSL_SP_MATH_ALL) || \
                                                defined(WOLFSSL_SP_INT_NEGATIVE))
     if (ret == 0)
@@ -4218,6 +4281,9 @@ static int wc_CompareDiffPQ(mp_int* p, mp_int* q, int size)
 #else
     mp_forcezero(d);
     mp_clear(c);
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    mp_memzero_check(d);
+#endif
 #endif
 
     return ret;
@@ -4342,6 +4408,9 @@ static int _CheckProbablePrime(mp_int* p, mp_int* q, mp_int* e, int nlen,
     /* 4.5,5.6 - Check that GCD(p-1, e) == 1 */
     ret = mp_sub_d(prime, 1, tmp1);  /* tmp1 = prime-1 */
     if (ret != MP_OKAY) goto notOkay;
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    mp_memzero_add("Check Probable Prime tmp1", tmp1);
+#endif
     ret = mp_gcd(tmp1, e, tmp2);  /* tmp2 = gcd(prime-1, e) */
     if (ret != MP_OKAY) goto notOkay;
     ret = mp_cmp_d(tmp2, 1);
@@ -4377,6 +4446,9 @@ notOkay:
 #else
     mp_forcezero(tmp1);
     mp_clear(tmp2);
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    mp_memzero_check(tmp1);
+#endif
 #endif
 
     return ret;
@@ -4422,10 +4494,17 @@ int wc_CheckProbablePrime_ex(const byte* pRaw, word32 pRawSz,
         ret = mp_read_unsigned_bin(p, pRaw, pRawSz);
 
     if (ret == MP_OKAY) {
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        mp_memzero_add("wc_CheckProbablePrime_ex p", p);
+    #endif
         if (qRaw != NULL) {
             ret = mp_read_unsigned_bin(q, qRaw, qRawSz);
-            if (ret == MP_OKAY)
+            if (ret == MP_OKAY) {
+            #ifdef WOLFSSL_CHECK_MEM_ZERO
+                mp_memzero_add("wc_CheckProbablePrime_ex q", q);
+            #endif
                 Q = q;
+            }
         }
     }
 
@@ -4460,6 +4539,10 @@ int wc_CheckProbablePrime_ex(const byte* pRaw, word32 pRawSz,
     mp_forcezero(p);
     mp_forcezero(q);
     mp_clear(e);
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    mp_memzero_check(p);
+    mp_memzero_check(q);
+#endif
 #endif
 
     return ret;
@@ -4600,6 +4683,14 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
 
     /* make p */
     if (err == MP_OKAY) {
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Add("RSA gen buf", buf, primeSz);
+        mp_memzero_add("RSA gen p", p);
+        mp_memzero_add("RSA gen q", q);
+        mp_memzero_add("RSA gen tmp1", tmp1);
+        mp_memzero_add("RSA gen tmp2", tmp2);
+        mp_memzero_add("RSA gen tmp3", tmp3);
+    #endif
         isPrime = 0;
         i = 0;
         do {
@@ -4786,6 +4877,17 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
     if (err == MP_OKAY)
         key->type = RSA_PRIVATE;
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    if (err == MP_OKAY) {
+        mp_memzero_add("Make RSA key d", &key->d);
+        mp_memzero_add("Make RSA key p", &key->p);
+        mp_memzero_add("Make RSA key q", &key->q);
+        mp_memzero_add("Make RSA key dP", &key->dP);
+        mp_memzero_add("Make RSA key dQ", &key->dQ);
+        mp_memzero_add("Make RSA key u", &key->u);
+    }
+#endif
+
     RESTORE_VECTOR_REGISTERS();
 
     /* Last value p - 1. */
@@ -4829,6 +4931,12 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
         XFREE(tmp2, key->heap, DYNAMIC_TYPE_RSA);
     if (tmp3)
         XFREE(tmp3, key->heap, DYNAMIC_TYPE_RSA);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    mp_memzero_check(p);
+    mp_memzero_check(q);
+    mp_memzero_check(tmp1);
+    mp_memzero_check(tmp2);
+    mp_memzero_check(tmp3);
 #endif
 
     return err;

--- a/wolfcrypt/src/sp_int.c
+++ b/wolfcrypt/src/sp_int.c
@@ -15980,4 +15980,26 @@ word32 CheckRunTimeFastMath(void)
     return SP_WORD_SIZE;
 }
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+/* Add an MP to check.
+ *
+ * @param [in] name  Name of address to check.
+ * @param [in] mp    mp_int that needs to be checked.
+ */
+void sp_memzero_add(const char* name, mp_int* mp)
+{
+    wc_MemZero_Add(name, mp->dp, mp->size * sizeof(sp_digit));
+}
+
+/* Check the memory in the data pointer for memory that must be zero.
+ *
+ * @param [in] mp    mp_int that needs to be checked.
+ */
+void sp_memzero_check(mp_int* mp)
+{
+    wc_MemZero_Check(mp->dp, mp->size * sizeof(sp_digit));
+}
+#endif /* WOLFSSL_CHECK_MEM_ZERO */
+
+
 #endif /* WOLFSSL_SP_MATH || WOLFSSL_SP_MATH_ALL */

--- a/wolfcrypt/src/tfm.c
+++ b/wolfcrypt/src/tfm.c
@@ -5895,4 +5895,16 @@ int mp_lshd (mp_int * a, int b)
   return fp_lshd(a, b);
 }
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+void mp_memzero_add(const char* name, mp_int* a)
+{
+    wc_MemZero_Add(name, a->dp, sizeof(a->dp));
+}
+
+void mp_memzero_check(mp_int* a)
+{
+    wc_MemZero_Check(a->dp, sizeof(a->dp));
+}
+#endif /* WOLFSSL_CHECK_MEM_ZERO */
+
 #endif /* USE_FAST_MATH */

--- a/wolfcrypt/src/wc_encrypt.c
+++ b/wolfcrypt/src/wc_encrypt.c
@@ -272,6 +272,9 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
         return MEMORY_E;
     }
 #endif
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Add("wc_BufferKeyDecrypt key", key, WC_MAX_SYM_KEY_SIZE);
+#endif
 
     (void)XMEMSET(key, 0, WC_MAX_SYM_KEY_SIZE);
 
@@ -280,6 +283,8 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
                                         info->keySz, hashType)) != 0) {
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+        wc_MemZero_Check(key, WC_MAX_SYM_KEY_SIZE);
 #endif
         return ret;
     }
@@ -300,6 +305,8 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
     ForceZero(key, WC_MAX_SYM_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    wc_MemZero_Check(key, WC_MAX_SYM_KEY_SIZE);
 #endif
 
     return ret;
@@ -330,6 +337,9 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
         return MEMORY_E;
     }
 #endif /* WOLFSSL_SMALL_STACK */
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Add("wc_BufferKeyDecrypt key", key, WC_MAX_SYM_KEY_SIZE);
+#endif
 
     (void)XMEMSET(key, 0, WC_MAX_SYM_KEY_SIZE);
 
@@ -338,6 +348,8 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
                                         info->keySz, hashType)) != 0) {
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+        wc_MemZero_Check(key, WC_MAX_SYM_KEY_SIZE);
 #endif
         return ret;
     }
@@ -358,6 +370,8 @@ int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
     ForceZero(key, WC_MAX_SYM_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(key, NULL, DYNAMIC_TYPE_SYMMETRIC_KEY);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    wc_MemZero_Check(key, WC_MAX_SYM_KEY_SIZE);
 #endif
 
     return ret;
@@ -475,6 +489,9 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
     if (key == NULL)
         return MEMORY_E;
 #endif
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Add("wc_CryptKey key", key, PKCS_MAX_KEY_SIZE);
+#endif
 
     switch (version) {
 #ifndef NO_HMAC
@@ -499,6 +516,8 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
             ForceZero(key, PKCS_MAX_KEY_SIZE);
         #ifdef WOLFSSL_SMALL_STACK
             XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        #elif defined(WOLFSSL_CHECK_MEM_ZERO)
+            wc_MemZero_Check(key, PKCS_MAX_KEY_SIZE);
         #endif
             return UNICODE_SIZE_E;
         }
@@ -524,6 +543,8 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
         ForceZero(key, PKCS_MAX_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+        wc_MemZero_Check(key, PKCS_MAX_KEY_SIZE);
 #endif
         WOLFSSL_MSG("Unknown/Unsupported PKCS version");
         return ALGO_ID_E;
@@ -533,6 +554,8 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
         ForceZero(key, PKCS_MAX_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+        wc_MemZero_Check(key, PKCS_MAX_KEY_SIZE);
 #endif
         return ret;
     }
@@ -559,6 +582,8 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
                 ForceZero(key, PKCS_MAX_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
                 XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+                wc_MemZero_Check(key, PKCS_MAX_KEY_SIZE);
 #endif
                 return ret;
             }
@@ -587,6 +612,8 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
                 ForceZero(key, PKCS_MAX_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
                 XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+                wc_MemZero_Check(key, PKCS_MAX_KEY_SIZE);
 #endif
                 return ret;
             }
@@ -600,7 +627,10 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
                 ForceZero(key, PKCS_MAX_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
                 XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+                wc_MemZero_Check(key, PKCS_MAX_KEY_SIZE);
 #endif
+                wc_Des3Free(&des);
                 return ret;
             }
             if (enc) {
@@ -609,10 +639,13 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
             else {
                 ret = wc_Des3_CbcDecrypt(&des, input, input, length);
             }
+            wc_Des3Free(&des);
             if (ret != 0) {
                 ForceZero(key, PKCS_MAX_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
                 XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+                wc_MemZero_Check(key, PKCS_MAX_KEY_SIZE);
 #endif
                 return ret;
             }
@@ -674,6 +707,8 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
                 ForceZero(key, PKCS_MAX_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
                 XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+                wc_MemZero_Check(key, PKCS_MAX_KEY_SIZE);
 #endif
                 return ret;
             }
@@ -697,6 +732,8 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
                 ForceZero(key, PKCS_MAX_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
                 XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+                wc_MemZero_Check(key, PKCS_MAX_KEY_SIZE);
 #endif
                 return ret;
             }
@@ -709,6 +746,8 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
             ForceZero(key, PKCS_MAX_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
             XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+            wc_MemZero_Check(key, PKCS_MAX_KEY_SIZE);
 #endif
             WOLFSSL_MSG("Unknown/Unsupported encrypt/decryption algorithm");
             return ALGO_ID_E;
@@ -717,6 +756,8 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
     ForceZero(key, PKCS_MAX_KEY_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    wc_MemZero_Check(key, PKCS_MAX_KEY_SIZE);
 #endif
 
     return ret;

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -132,6 +132,12 @@ int wolfCrypt_Init(void)
     if (initRefCount == 0) {
         WOLFSSL_ENTER("wolfCrypt_Init");
 
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        /* Initialize the mutex for access to the list of memory locations that
+         * must be freed. */
+        wc_MemZero_Init();
+    #endif
+
     #ifdef WOLFSSL_FORCE_MALLOC_FAIL_TEST
         {
             word32 rngMallocFail;
@@ -422,6 +428,12 @@ int wolfCrypt_Cleanup(void)
     #endif
     #if defined(WOLFSSL_LINUXKM_SIMD_X86)
         free_wolfcrypt_linuxkm_fpu_states();
+    #endif
+
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        /* Free the mutex for access to the list of memory locations that
+         * must be freed. */
+        wc_MemZero_Free();
     #endif
     }
 

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -39159,7 +39159,12 @@ WOLFSSL_TEST_SUBROUTINE int memcb_test(void)
     XFREE(b, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
 
 #ifndef WOLFSSL_STATIC_MEMORY
+#ifndef WOLFSSL_CHECK_MEM_ZERO
     if (malloc_cnt != 1 || free_cnt != 1 || realloc_cnt != 1)
+#else
+    /* Checking zeroized memory means realloc is a malloc and free. */
+    if (malloc_cnt != 2 || free_cnt != 2 || realloc_cnt != 0)
+#endif
 #else
     if (malloc_cnt != 0 || free_cnt != 0 || realloc_cnt != 0)
 #endif

--- a/wolfssl/wolfcrypt/memory.h
+++ b/wolfssl/wolfcrypt/memory.h
@@ -238,6 +238,14 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
             __cyg_profile_func_exit(void *func, void *caller);
 #endif /* WOLFSSL_STACK_LOG */
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+WOLFSSL_LOCAL void wc_MemZero_Init(void);
+WOLFSSL_LOCAL void wc_MemZero_Free(void);
+WOLFSSL_LOCAL void wc_MemZero_Add(const char* name, const void* addr,
+    size_t len);
+WOLFSSL_LOCAL void wc_MemZero_Check(void* addr, size_t len);
+#endif
+
 #ifdef __cplusplus
     }  /* extern "C" */
 #endif

--- a/wolfssl/wolfcrypt/sp_int.h
+++ b/wolfssl/wolfcrypt/sp_int.h
@@ -908,6 +908,11 @@ MP_API int sp_lcm(sp_int* a, sp_int* b, sp_int* r);
 
 WOLFSSL_API word32 CheckRunTimeFastMath(void);
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+WOLFSSL_LOCAL void sp_memzero_add(const char* name, mp_int* mp);
+WOLFSSL_LOCAL void sp_memzero_check(mp_int* mp);
+#endif
+
 
 /* Map mp functions to SP math versions. */
 /* Different name or signature. */
@@ -998,6 +1003,9 @@ WOLFSSL_API word32 CheckRunTimeFastMath(void);
 #define mp_prime_is_prime_ex                sp_prime_is_prime_ex
 #define mp_gcd                              sp_gcd
 #define mp_lcm                              sp_lcm
+
+#define mp_memzero_add                      sp_memzero_add
+#define mp_memzero_check                    sp_memzero_check
 
 #ifdef WOLFSSL_DEBUG_MATH
 #define mp_dump(d, a, v)                    sp_print(a, d)

--- a/wolfssl/wolfcrypt/tfm.h
+++ b/wolfssl/wolfcrypt/tfm.h
@@ -856,6 +856,11 @@ MP_API int  mp_abs(mp_int* a, mp_int* b);
 
 WOLFSSL_API word32 CheckRunTimeFastMath(void);
 
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+void mp_memzero_add(const char* name, mp_int* a);
+void mp_memzero_check(mp_int* a);
+#endif
+
 /* If user uses RSA, DH, DSA, or ECC math lib directly then fast math FP_SIZE
    must match, return 1 if a match otherwise 0 */
 #define CheckFastMathSettings() (FP_SIZE == CheckRunTimeFastMath())


### PR DESCRIPTION
# Description

Add a define WOLFSSL_CHECK_MEM_ZERO to turn on code that checks that
memory that must be zeroized before going out of use is zero.
Everytime sensitive data is put into a allocated buffer or stack buffer;
the address, its length and a name is stored to be checked later.
Where the stack buffer is about to go out of use, a call is added to
check that the required parts are zero.

wc_MemZero_Add() adds an address with length and name to a table of
addressed to be checked later.
wc_MemZero_Check() checks that the memory associated with the address is
zeroized where required.
mp_memzero_add() adds mp_int's data pointer with length and name to
table.
mp_memzero_check() checks that the data pointer is zeroized where
required.

Freeing memory will check the address. The length was prepended on
allocation.
Realloction was changed for WOLFSSL_CHECK_MEM_ZERO to perform an
allocate, check, copy, free.

# Testing

1: --disable-shared CFLAGS=-DWOLFSSL_CHECK_MEM_ZERO --enable-sp-math-all
2: --disable-shared CFLAGS=-DWOLFSSL_CHECK_MEM_ZERO --enable-all --enable-sp-math-all
3: --disable-shared CFLAGS=-DWOLFSSL_CHECK_MEM_ZERO --enable-all --enable-sp-math-all --enable-smallstack
4: --disable-shared CFLAGS=-DWOLFSSL_CHECK_MEM_ZERO --enable-all --enable-sp-math-all --enable-fpecc
5: --disable-shared CFLAGS=-DWOLFSSL_CHECK_MEM_ZERO --enable-all --enable-sp-math-all C_EXTRA_FLAGS=-DWOLFSSL_ECDSA_DETERMINISTIC_K_VARIANT

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
