### PR TITLE
Support psk ciphersuites in benchmarks.

### DIFF
--- a/IDE/STM32Cube/wolfssl_example.c
+++ b/IDE/STM32Cube/wolfssl_example.c
@@ -973,7 +973,7 @@ static void client_thread(const void* args)
 #endif
         }
         info->client.ret = ret;
-        info->server.done = 1;
+        info->client.done = 1;
         osThreadSuspend(info->client.threadId);
 
         if (info->doShutdown)
@@ -1248,7 +1248,7 @@ static void server_thread(const void* args)
 #endif
         }
         info->server.ret = ret;
-        info->client.done = 1;
+        info->server.done = 1;
         osThreadSuspend(info->server.threadId);
 
         if (info->doShutdown)

--- a/IDE/STM32Cube/wolfssl_example.c
+++ b/IDE/STM32Cube/wolfssl_example.c
@@ -973,11 +973,11 @@ static void client_thread(const void* args)
 #endif
         }
         info->client.ret = ret;
-        info->client.done = 1;
+        info->server.done = 1;
         osThreadSuspend(info->client.threadId);
 
         if (info->doShutdown)
-            info->client.done = 1;
+            info->server.done = 1;
     } while (!info->doShutdown);
 
     osThreadTerminate(info->client.threadId);
@@ -1248,11 +1248,11 @@ static void server_thread(const void* args)
 #endif
         }
         info->server.ret = ret;
-        info->server.done = 1;
+        info->client.done = 1;
         osThreadSuspend(info->server.threadId);
 
         if (info->doShutdown)
-            info->server.done = 1;
+            info->client.done = 1;
     } while (!info->doShutdown);
 
     osThreadTerminate(info->server.threadId);

--- a/examples/benchmark/tls_bench.c
+++ b/examples/benchmark/tls_bench.c
@@ -1199,7 +1199,7 @@ static void* client_thread(void* args)
     ret = bench_tls_client(info);
 
     pthread_cond_signal(&info->to_server.cond);
-    info->to_server.done = 1;
+    info->to_client.done = 1;
     info->client.ret = ret;
 
     return NULL;
@@ -1653,7 +1653,7 @@ static void* server_thread(void* args)
     }
 
     pthread_cond_signal(&info->to_client.cond);
-    info->to_client.done = 1;
+    info->to_server.done = 1;
     info->server.ret = ret;
 
     return NULL;

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2473,7 +2473,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 #ifndef NO_PSK
         const char *defaultCipherList = cipherList;
 
-        wolfSSL_CTX_set_psk_server_callback(ctx, my_psk_server_cb);
+        SSL_CTX_set_psk_server_callback(ctx, my_psk_server_cb);
     #ifdef WOLFSSL_TLS13
         wolfSSL_CTX_set_psk_server_tls13_callback(ctx, my_psk_server_tls13_cb);
     #endif

--- a/examples/server/server.c
+++ b/examples/server/server.c
@@ -2473,7 +2473,7 @@ THREAD_RETURN WOLFSSL_THREAD server_test(void* args)
 #ifndef NO_PSK
         const char *defaultCipherList = cipherList;
 
-        SSL_CTX_set_psk_server_callback(ctx, my_psk_server_cb);
+        wolfSSL_CTX_set_psk_server_callback(ctx, my_psk_server_cb);
     #ifdef WOLFSSL_TLS13
         wolfSSL_CTX_set_psk_server_tls13_callback(ctx, my_psk_server_tls13_cb);
     #endif


### PR DESCRIPTION
Also fixed some small errors during shutdown in benchmarks.

Tested with:

./configure --enable-psk CFLAGS=-DWOLFSSL_STATIC_PSK
make all check
./examples/benchmark/tls_bench

