### PR TITLE
Fix for ASN template parsing of extended key usage

### DIFF
--- a/wolfcrypt/src/asn.c
+++ b/wolfcrypt/src/asn.c
@@ -16034,7 +16034,7 @@ static int DecodeExtKeyUsage(const byte* input, int sz, DecodedCert* cert)
 
         /* Clear dynamic data items and set OID type expected. */
         XMEMSET(dataASN, 0, sizeof(dataASN));
-        GetASN_OID(&dataASN[KEYPURPOSEIDASN_IDX_OID], oidCertKeyUseType);
+        GetASN_OID(&dataASN[KEYPURPOSEIDASN_IDX_OID], oidIgnoreType);
         /* Decode KeyPurposeId. */
         ret = GetASN_Items(keyPurposeIdASN, dataASN, keyPurposeIdASN_Length, 0,
                            input, &idx, sz);


### PR DESCRIPTION
# Description

Fix for ASN template parsing of `DecodeExtKeyUsage` to parse any OID.

Fixes ZD 14344

# Testing

Certificate with "Extended Key Usage" containing `EKU_SERVER_AUTH_OID` and `EKU_CLIENT_AUTH_OID`.

```
 ./configure --enable-all --enable-asn=template && make
./examples/server/server -A test_cert.pem
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
