### PR TITLE
zd14249

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -10500,6 +10500,7 @@ int CheckHostName(DecodedCert* dCert, const char *domainName, size_t domainNameL
         ret = 0;
     }
 
+#ifndef ONLY_ALT_NAME_VERIFICATION
     if (checkCN == 1) {
         if (MatchDomainName(dCert->subjectCN, dCert->subjectCNLen,
                             domainName) == 1) {
@@ -10509,6 +10510,7 @@ int CheckHostName(DecodedCert* dCert, const char *domainName, size_t domainNameL
             WOLFSSL_MSG("DomainName match on common name failed");
         }
     }
+#endif /* #ifndef ONLY_ALT_NAME_VERIFICATION */
 
     return ret;
 }
@@ -11333,6 +11335,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
                     }
                 }
             }
+        #ifndef ONLY_ALT_NAME_VERIFICATION
             else {
                 if (args->dCert->subjectCN) {
                     if (MatchDomainName(args->dCert->subjectCN,
@@ -11344,6 +11347,13 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
                     }
                 }
             }
+        #else /* #ifndef ONLY_ALT_NAME_VERIFICATION */
+            else {
+                if (ret == 0) {
+                    ret = DOMAIN_NAME_MISMATCH;
+                }
+            }
+        #endif /* #ifndef ONLY_ALT_NAME_VERIFICATION */
         }
 
         /* perform IP address check on the peer certificate */

--- a/src/internal.c
+++ b/src/internal.c
@@ -73,8 +73,9 @@
  *     clientHello messages will consume resources on the server.
  *     This define is turned off by default.
  * WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY
- *     Certificates without SAN will get rejected during handshake instead of
- *     trying to match hostname or IP address with subject common name.
+ *     Verify hostname/ip address using alternate name (SAN) only and do not
+ *     use the common name. Forces use of the alternate name, so certificates
+ *     missing SAN will be rejected during the handshake
  */
 
 
@@ -10513,7 +10514,7 @@ int CheckHostName(DecodedCert* dCert, const char *domainName, size_t domainNameL
             WOLFSSL_MSG("DomainName match on common name failed");
         }
     }
-#endif /* # !WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY */
+#endif /* !WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY */
 
     return ret;
 }
@@ -11350,7 +11351,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
                     }
                 }
             }
-        #else /* #ifndef ONLY_ALT_NAME_VERIFICATION */
+        #else
             else {
                 if (ret == 0) {
                     ret = DOMAIN_NAME_MISMATCH;

--- a/src/internal.c
+++ b/src/internal.c
@@ -72,6 +72,9 @@
  *     less). On the other hand, if a valid SessionID is collected, forged
  *     clientHello messages will consume resources on the server.
  *     This define is turned off by default.
+ * WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY
+ *     Certificates without SAN will get rejected during handshake instead of
+ *     trying to match hostname or IP address with subject common name.
  */
 
 
@@ -10500,7 +10503,7 @@ int CheckHostName(DecodedCert* dCert, const char *domainName, size_t domainNameL
         ret = 0;
     }
 
-#ifndef ONLY_ALT_NAME_VERIFICATION
+#ifndef WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY
     if (checkCN == 1) {
         if (MatchDomainName(dCert->subjectCN, dCert->subjectCNLen,
                             domainName) == 1) {
@@ -10510,7 +10513,7 @@ int CheckHostName(DecodedCert* dCert, const char *domainName, size_t domainNameL
             WOLFSSL_MSG("DomainName match on common name failed");
         }
     }
-#endif /* #ifndef ONLY_ALT_NAME_VERIFICATION */
+#endif /* # !WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY */
 
     return ret;
 }
@@ -11335,7 +11338,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
                     }
                 }
             }
-        #ifndef ONLY_ALT_NAME_VERIFICATION
+        #ifndef WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY
             else {
                 if (args->dCert->subjectCN) {
                     if (MatchDomainName(args->dCert->subjectCN,
@@ -11353,7 +11356,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
                     ret = DOMAIN_NAME_MISMATCH;
                 }
             }
-        #endif /* #ifndef ONLY_ALT_NAME_VERIFICATION */
+        #endif /* !WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY */
         }
 
         /* perform IP address check on the peer certificate */


### PR DESCRIPTION
# Description

Added build flag to make DoVerifyCallback verify hostname or ip addr only against altnames instead of altnames and common name.

Fixes zd#14249

# Testing

How did you test?

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
