### PR TITLE
20220614-multi-test-fixups

### DIFF
--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -61,8 +61,6 @@
 
     #define WOLFSSL_KTHREADS
 
-    typedef struct mutex wolfSSL_Mutex;
-
     #ifdef BUILDING_WOLFSSL
 
     #if defined(CONFIG_MIPS) && defined(HAVE_LINUXKM_PIE_SUPPORT)
@@ -577,6 +575,13 @@
     #define NO_TIMEVAL 1
 
     #endif /* BUILDING_WOLFSSL */
+
+    /* if BUILDING_WOLFSSL, mutex.h will have already been included recursively
+     * above, with the bevy of warnings suppressed, and the below include will
+     * be a redundant no-op.
+     */
+    #include <linux/mutex.h>
+    typedef struct mutex wolfSSL_Mutex;
 
     #define XMALLOC(s, h, t)     ({(void)(h); (void)(t); kmalloc(s, GFP_KERNEL);})
     #define XFREE(p, h, t)       ({void* _xp; (void)(h); _xp = (p); if(_xp) kfree(_xp);})

--- a/linuxkm/linuxkm_wc_port.h
+++ b/linuxkm/linuxkm_wc_port.h
@@ -59,8 +59,6 @@
           (int)_xatoi_res;                              \
         })
 
-    #define WOLFSSL_KTHREADS
-
     #ifdef BUILDING_WOLFSSL
 
     #if defined(CONFIG_MIPS) && defined(HAVE_LINUXKM_PIE_SUPPORT)

--- a/src/internal.c
+++ b/src/internal.c
@@ -17833,7 +17833,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                 /* For TLS v1.1 the block size and explcit IV are added to idx,
                  * so it needs to be included in this limit check */
                 if (!IsAtLeastTLSv1_3(ssl->version)
-                        && ssl->curSize - ssl->keys.padSz - 
+                        && ssl->curSize - ssl->keys.padSz -
                             (ssl->buffers.inputBuffer.idx - startIdx)
                                 > MAX_PLAINTEXT_SZ
 #ifdef WOLFSSL_ASYNC_CRYPT

--- a/wolfcrypt/src/wc_port.c
+++ b/wolfcrypt/src/wc_port.c
@@ -1332,7 +1332,7 @@ int wolfSSL_CryptHwMutexUnLock(void)
             return BAD_MUTEX_E;
     }
 
-#elif defined(WOLFSSL_KTHREADS)
+#elif defined(WOLFSSL_LINUXKM)
 
     /* Linux kernel mutex routines are voids, alas. */
 

--- a/wolfssl/internal.h
+++ b/wolfssl/internal.h
@@ -199,8 +199,7 @@
 #else
     #ifndef SINGLE_THREADED
         #if defined(WOLFSSL_LINUXKM)
-            #define WOLFSSL_KTHREADS
-            #include <linux/kthread.h>
+            /* setup is in linuxkm/linuxkm_wc_port.h */
         #elif defined(WOLFSSL_USER_MUTEX)
             /* do nothing */
         #else

--- a/wolfssl/wolfcrypt/wc_port.h
+++ b/wolfssl/wolfcrypt/wc_port.h
@@ -219,8 +219,6 @@
         typedef CRITICAL_SECTION wolfSSL_Mutex;
     #elif defined(WOLFSSL_PTHREADS)
         typedef pthread_mutex_t wolfSSL_Mutex;
-    #elif defined(WOLFSSL_KTHREADS)
-        typedef struct mutex wolfSSL_Mutex;
     #elif defined(THREADX)
         typedef TX_MUTEX wolfSSL_Mutex;
     #elif defined(WOLFSSL_DEOS)


### PR DESCRIPTION
linuxkm: tweak setup of wolfSSL_Mutex to assure complete type availability in applications (client modules).

also whitespace

tested with `wolfssl-multi-test.sh ... linuxkm-plus-wireguard super-quick-check`
