### PR TITLE
Cleanup the RSA consistency check

### DIFF
--- a/src/pk.c
+++ b/src/pk.c
@@ -2572,18 +2572,7 @@ int wolfSSL_RSA_set_ex_data_with_cleanup(WOLFSSL_RSA *rsa, int idx, void *data,
  * RSA check key APIs
  */
 
-/* If not using old FIPS or CAVP selftest or not using fast or user RSA, able
- * to check RSA key. */
-#if (defined(HAVE_USER_RSA) || defined(HAVE_FAST_RSA) || \
-     defined(WOLFSSL_RSA_PUBLIC_ONLY) || defined(HAVE_INTEL_QA) || \
-     !defined(WOLFSSL_KEY_GEN) || (defined(HAVE_FIPS) && \
-     FIPS_VERSION_LT(2, 0)) || defined(HAVE_SELFTEST)) && \
-     !defined(WOLFSSL_NO_RSA_KEY_CHECK)
-#define WOLFSSL_NO_RSA_KEY_CHECK
-#endif
-
-
-#ifndef WOLFSSL_NO_RSA_KEY_CHECK
+#ifdef WOLFSSL_RSA_KEY_CHECK
 /* Check that the RSA key is valid using wolfCrypt.
  *
  * @param [in] rsa  RSA key.
@@ -2612,7 +2601,7 @@ int wolfSSL_RSA_check_key(const WOLFSSL_RSA* rsa)
 
     return ret;
 }
-#endif /* !WOLFSSL_NO_RSA_KEY_CHECK */
+#endif /* WOLFSSL_RSA_KEY_CHECK */
 
 /*
  * RSA generate APIs

--- a/tests/api.c
+++ b/tests/api.c
@@ -51374,10 +51374,7 @@ static void test_wolfSSL_RSA(void)
     AssertIntEQ(RSA_set0_key(rsa, NULL, NULL, NULL), 0);
     AssertIntEQ(RSA_set0_crt_params(rsa, NULL, NULL, NULL), 0);
     AssertIntEQ(RSA_set0_factors(rsa, NULL, NULL), 0);
-#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) && !defined(HAVE_FAST_RSA) && \
-    (!defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
-    (HAVE_FIPS_VERSION >= 2))) && !defined(HAVE_SELFTEST) && \
-    !defined(HAVE_INTEL_QA) && !defined(WOLFSSL_NO_RSA_KEY_CHECK)
+#ifdef WOLFSSL_RSA_KEY_CHECK
     AssertIntEQ(RSA_check_key(rsa), 0);
 #endif
 
@@ -51385,10 +51382,7 @@ static void test_wolfSSL_RSA(void)
     AssertNotNull(rsa = RSA_generate_key(2048, 3, NULL, NULL));
     AssertIntEQ(RSA_size(rsa), 256);
 
-#if !defined(WOLFSSL_RSA_PUBLIC_ONLY) && !defined(HAVE_FAST_RSA) && \
-    (!defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
-    (HAVE_FIPS_VERSION >= 2))) && !defined(HAVE_SELFTEST) && \
-    !defined(HAVE_INTEL_QA) && !defined(WOLFSSL_NO_RSA_KEY_CHECK)
+#ifdef WOLFSSL_RSA_KEY_CHECK
     AssertIntEQ(RSA_check_key(NULL), 0);
     AssertIntEQ(RSA_check_key(rsa), 1);
 #endif

--- a/wolfcrypt/src/pkcs7.c
+++ b/wolfcrypt/src/pkcs7.c
@@ -1765,19 +1765,13 @@ static int wc_PKCS7_RsaSign(PKCS7* pkcs7, byte* in, word32 inSz, ESD* esd)
             /* If not using old FIPS or CAVP selftest, or not using FAST,
              * or USER RSA, able to check RSA key. */
             if (ret == 0) {
-        #if !defined(WOLFSSL_RSA_PUBLIC_ONLY) && !defined(HAVE_FAST_RSA) && \
-            !defined(HAVE_USER_RSA) && (!defined(HAVE_FIPS) || \
-            (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))) && \
-            !defined(HAVE_SELFTEST) && !defined(HAVE_INTEL_QA)
-
-            #if defined(WOLFSSL_KEY_GEN) && !defined(WOLFSSL_NO_RSA_KEY_CHECK)
+        #ifdef WOLFSSL_RSA_KEY_CHECK
                 /* verify imported private key is a valid key before using it */
                 ret = wc_CheckRsaKey(privKey);
                 if (ret != 0) {
                     WOLFSSL_MSG("Invalid RSA private key, check "
                                 "pkcs7->privateKey");
                 }
-            #endif
         #endif
             }
         #ifdef WOLF_CRYPTO_CB

--- a/wolfcrypt/test/test.c
+++ b/wolfcrypt/test/test.c
@@ -14661,17 +14661,12 @@ static int rsa_keygen_test(WC_RNG* rng)
     }
     TEST_SLEEP();
 
-    /* If not using old FIPS, or not using FAST or USER RSA... */
-    #if !defined(HAVE_FAST_RSA) && !defined(HAVE_USER_RSA) && \
-        (!defined(HAVE_FIPS) || \
-         (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))) && \
-        !defined(HAVE_SELFTEST) && !defined(HAVE_INTEL_QA) \
-        && !defined(WOLFSSL_NO_RSA_KEY_CHECK)
+#ifdef WOLFSSL_RSA_KEY_CHECK
     ret = wc_CheckRsaKey(genKey);
     if (ret != 0) {
         ERROR_OUT(-7872, exit_rsa);
     }
-    #endif
+#endif
     der = (byte*)XMALLOC(FOURK_BUF, HEAP_HINT, DYNAMIC_TYPE_TMP_BUFFER);
     if (der == NULL) {
         ERROR_OUT(-7873, exit_rsa);

--- a/wolfssl/wolfcrypt/settings.h
+++ b/wolfssl/wolfcrypt/settings.h
@@ -2716,6 +2716,22 @@ extern void uITRON4_free(void *p) ;
 #error "DTLS v1.3 requires both WOLFSSL_TLS13 and WOLFSSL_DTLS"
 #endif
 
+/* RSA Key Checking is disabled by default unless WOLFSSL_RSA_KEY_CHECK is
+ *   defined or FIPS v2 3389, FIPS v5 or later.
+ * Not allowed for:
+ *   RSA public only, CAVP selftest, fast RSA, user RSA, QAT or CryptoCell */
+#if (defined(WOLFSSL_RSA_KEY_CHECK) || (defined(HAVE_FIPS) && FIPS_VERSION_GE(2,0))) && \
+    !defined(WOLFSSL_NO_RSA_KEY_CHECK) && !defined(WOLFSSL_RSA_PUBLIC_ONLY) && \
+    !defined(HAVE_USER_RSA) && !defined(HAVE_FAST_RSA) && \
+    !defined(HAVE_INTEL_QA) && !defined(WOLFSSL_CRYPTOCELL) && \
+    !defined(HAVE_SELFTEST)
+
+    #undef  WOLFSSL_RSA_KEY_CHECK
+    #define WOLFSSL_RSA_KEY_CHECK
+#endif
+
+
+
 
 /* ---------------------------------------------------------------------------
  * Depricated Algorithm Handling


### PR DESCRIPTION
# Description

Should only be enabled for FIPS v2 (3389), FIPS v5 or later. Can be forcefully enabled for non-FIPS using `WOLFSSL_RSA_KEY_CHECK`. The existing `WOLFSSL_NO_RSA_KEY_CHECK` macro will also disable it. This change was introduced in PR #4359.

# Testing

```
./configure --enable-keygen && make
./configure --enable-keygen CFLAGS="-DWOLFSSL_RSA_KEY_CHECK" && make
./configure --enable-keygen CFLAGS="-DWOLFSSL_NO_RSA_KEY_CHECK" && make
```

# Checklist

 - [ ] added tests
 - [ ] updated/added doxygen
 - [ ] updated appropriate READMEs
 - [ ] Updated manual and documentation
